### PR TITLE
Updating TT-Metal external project dependency to be HTTPS instead of SSH

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -43,7 +43,7 @@ ExternalProject_Add(
       -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
       -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
       -DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}
-    GIT_REPOSITORY git@github.com:tenstorrent/tt-metal.git
+    GIT_REPOSITORY https://github.com/tenstorrent/tt-metal.git
     GIT_TAG v0.49.0
     GIT_PROGRESS ON
 )


### PR DESCRIPTION
TT-Metal is a public project, so we're updating the external GitHub reference to HTTPS instead of SSH. Using SSH requires you to have a personal generated token uploaded to your GitHub account, and if this requirement is not met, it can lead to the build hanging without any clear guidance on what might have gone wrong.