### PR TITLE
Fixing flatbuffer store calculation to include prefix size

### DIFF
--- a/runtime/lib/binary.cpp
+++ b/runtime/lib/binary.cpp
@@ -147,7 +147,7 @@ Flatbuffer Flatbuffer::loadFromPath(char const *path) {
 void Flatbuffer::store(char const *path) const {
   // store a flatbuffer to path
   std::ofstream fbb(path, std::ios::binary);
-  auto size = ::flatbuffers::GetPrefixedSize(
+  auto size = ::flatbuffers::GetSizePrefixedBufferLength(
       static_cast<const uint8_t *>(handle.get()));
   fbb.write(reinterpret_cast<char const *>(handle.get()), size);
 }


### PR DESCRIPTION
We encountered an issue when storing the FlatBuffer to disk and rereading it from the saved file. The problem arose because we didn’t include the size of the prefix. The GetPrefixedSize function returns the size of the FlatBuffer, excluding the prefix size. To resolve this, I am updating the code to use GetSizePrefixedBufferLength instead. This function includes both the size of the prefix and the size of the FlatBuffer, ensuring accurate storage and retrieval.
  
  [size prefix][flatbuffer]
  |---------length--------|

Solves https://github.com/tenstorrent/tt-mlir/issues/43