### PR TITLE
Patched CMake Doxygen Target to work on GH Action runners

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -39,7 +39,7 @@ if (DOXYGEN_FOUND)
       doxygen ${DOXYGEN_DIR}/doxygen.cfg
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
     DEPENDS
-      docs mlir-doc copy-docs-dir
+      mlir-headers docs mlir-doc copy-docs-dir
   )
 else()
   message("Doxygen is required to build documentation")


### PR DESCRIPTION
**Implemented**:
- Added a quick patch for `doxygen` CMake target to run on GH Action runners.