### PR TITLE
Create tt-mlir-toolchain directory during the environment setup

### DIFF
--- a/docs/src/build.md
+++ b/docs/src/build.md
@@ -20,7 +20,7 @@ cmake --build env/build
 >   The commands create it and assign the proper ownership are:
 >     ```bash
 >     sudo mkdir -p /opt/ttmlir-toolchain
->     sudo chown -R rjakovljevic /opt/ttmlir-toolchain
+>     sudo chown -R $USER /opt/ttmlir-toolchain
 >     ```
 
 


### PR DESCRIPTION
Without this change, the command `cmake -B env/build env` requires the directory `/opt/tt-mlir-toolchain` to exist and to have the current user as the owner.

This change automates the creation of the directory and setting ownership to the current user.