### PR TITLE
Workarounding flatbuffer generation API

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Transforms/TTNNToSerializedBinary.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/TTNNToSerializedBinary.h
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_TRANSFORMS_TTNNTOSERIALIZEDBINARY_H
+#define TTMLIR_DIALECT_TTNN_TRANSFORMS_TTNNTOSERIALIZEDBINARY_H
+
+#include <memory>
+
+#include "mlir/IR/BuiltinOps.h"
+
+namespace mlir::tt::ttnn {
+std::shared_ptr<void> emitTTNNAsFlatbuffer(OwningOpRef<ModuleOp> &moduleOp);
+} // namespace mlir::tt::ttnn
+#endif

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_mlir_dialect_library(MLIRTTNNTransforms
         Passes.cpp
         TTNNToCpp.cpp
-        SerializeToBinary.cpp
+        TTNNToSerializedBinary.cpp
 
         ADDITIONAL_HEADER_DIRS
         ${PROJECT_SOURCE_DIR}/include/ttmlir


### PR DESCRIPTION
Exposing flatbuffer generation API from tt-mlir lib. Aligning things with how we plan to generate plain C++, TTNNToCpp, hence this change consists of:

- Renaming SerialzedBinary.cpp -> TTNNToSerializedBinary.cpp
- Creating API function in a new header file: TTNNToSerializedBinary.h(`std::shared_ptr<void> emitTTNNAsFlatbuffer(...)`)
- Implementing API function at the end of  TTNNToSerializedBinary.cpp:
```
std::shared_ptr<void> emitTTNNAsFlatbuffer(OwningOpRef<ModuleOp> &moduleOp) {
  auto pm = PassManager::on<ModuleOp>(moduleOp.get().getContext());
  auto pass = createTTNNSerializeToBinary();
  Pass* basePass = pass.get();
  pm.addPass(std::move(pass));

  // Run the pass manager.
  if (failed(pm.run(moduleOp.get())))
  {
    return nullptr;
  }

  auto *derivedPass= llvm::dyn_cast<TTNNSerializeToBinary>(basePass);
  if (!derivedPass) {
    return nullptr;
  }

  return derivedPass->getBinary();
}
```

This is a workaround solution to enable e2e demo, and I plan to address the follow-up issue to align emitting the flatbuffer binary with the MLIR translation framework: https://github.com/tenstorrent/tt-mlir/issues/120