### PR TITLE
Runtime gtest infrastructure

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -3,8 +3,6 @@ option(TTMLIR_ENABLE_RUNTIME_TESTS "Enable runtime tests" OFF)
 
 add_subdirectory(lib)
 add_subdirectory(tools)
-
 if (TTMLIR_ENABLE_RUNTIME_TESTS)
-    enable_testing()
     add_subdirectory(test)
 endif()

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -1,2 +1,10 @@
+# Options
+option(TTMLIR_ENABLE_RUNTIME_TESTS "Enable runtime tests" OFF)
+
 add_subdirectory(lib)
 add_subdirectory(tools)
+
+if (TTMLIR_ENABLE_RUNTIME_TESTS)
+    enable_testing()
+    add_subdirectory(test)
+endif()

--- a/runtime/test/CMakeLists.txt
+++ b/runtime/test/CMakeLists.txt
@@ -1,7 +1,4 @@
-# GoogleTest requires at least C++14
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
+enable_testing()
 include(FetchContent)
 FetchContent_Declare(
   googletest
@@ -16,12 +13,40 @@ endif()
 
 include(GoogleTest)
 
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+if (NOT Python3_LIBRARIES)
+  message(FATAL_ERROR "python libraries not found")
+endif()
+
+find_library(FLATBUFFERS_LIB flatbuffers PATHS ${TTMLIR_TOOLCHAIN_DIR}/lib)
+if (NOT FLATBUFFERS_LIB)
+  message(FATAL_ERROR "flatbuffers library not found")
+endif()
+
+add_library(TTRuntimeTEST INTERFACE)
+add_dependencies(TTRuntimeTEST TTRuntimeTTNN TTRuntimeTTMetal TTRuntime)
+target_include_directories(TTRuntimeTEST INTERFACE
+    ${PROJECT_SOURCE_DIR}/runtime/include
+    ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common
+    ${TTMLIR_TOOLCHAIN}/include
+)
+target_link_libraries(TTRuntimeTEST INTERFACE
+    tt_eager
+    tt_metal
+    TTRuntime
+    TTRuntimeTTNN
+    TTRuntimeTTMetal
+    ${Python3_LIBRARIES}
+    ${FLATBUFFERS_LIB}
+    GTest::gtest_main
+)
+
 function(add_runtime_gtest test_name)
   add_executable(${test_name} ${ARGN})
-  target_link_libraries(${test_name} PRIVATE GTest::gtest_main)
+  add_dependencies(${test_name} TTRuntimeTEST)
+  target_link_libraries(${test_name} PRIVATE TTRuntimeTEST)
   gtest_discover_tests(${test_name})
 endfunction()
 
 add_subdirectory(ttnn)
 add_subdirectory(ttmetal)
-

--- a/runtime/test/CMakeLists.txt
+++ b/runtime/test/CMakeLists.txt
@@ -1,0 +1,27 @@
+# GoogleTest requires at least C++14
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip
+  DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+)
+FetchContent_MakeAvailable(googletest)
+
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+  target_compile_options(gtest PRIVATE -Wno-covered-switch-default)
+endif()
+
+include(GoogleTest)
+
+function(add_runtime_gtest test_name)
+  add_executable(${test_name} ${ARGN})
+  target_link_libraries(${test_name} PRIVATE GTest::gtest_main)
+  gtest_discover_tests(${test_name})
+endfunction()
+
+add_subdirectory(ttnn)
+add_subdirectory(ttmetal)
+

--- a/runtime/test/ttnn/CMakeLists.txt
+++ b/runtime/test/ttnn/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_runtime_gtest(hello_test hello_test.cc)
+add_runtime_gtest(subtract_test test_subtract.cpp)

--- a/runtime/test/ttnn/CMakeLists.txt
+++ b/runtime/test/ttnn/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_runtime_gtest(hello_test hello_test.cc)

--- a/runtime/test/ttnn/hello_test.cc
+++ b/runtime/test/ttnn/hello_test.cc
@@ -1,9 +1,0 @@
-#include <gtest/gtest.h>
-
-// Demonstrate some basic assertions.
-TEST(HelloTest, BasicAssertions) {
-  // Expect two strings not to be equal.
-  EXPECT_STRNE("hello", "world");
-  // Expect equality.
-  EXPECT_EQ(7 * 6, 42);
-}

--- a/runtime/test/ttnn/hello_test.cc
+++ b/runtime/test/ttnn/hello_test.cc
@@ -1,0 +1,9 @@
+#include <gtest/gtest.h>
+
+// Demonstrate some basic assertions.
+TEST(HelloTest, BasicAssertions) {
+  // Expect two strings not to be equal.
+  EXPECT_STRNE("hello", "world");
+  // Expect equality.
+  EXPECT_EQ(7 * 6, 42);
+}

--- a/runtime/test/ttnn/test_subtract.cpp
+++ b/runtime/test/ttnn/test_subtract.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+#include "tt/runtime/detail/ttnn.h"
+#include "tt/runtime/runtime.h"
+#include "tt/runtime/utils.h"
+#include <cstring>
+#include <filesystem>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+TEST(TTNNSubtract, Equal) {
+  const char *fbPath = std::getenv("TTMLIR_SUBTRACT_FB_PATH");
+  assert(fbPath && "Path to subtract flatbuffer must be provided");
+  ::tt::runtime::Binary fbb = ::tt::runtime::Binary::loadFromPath(fbPath);
+  EXPECT_EQ(fbb.getFileIdentifier(), "TTNN");
+  std::vector<::tt::runtime::TensorDesc> inputDescs = fbb.getProgramInputs(0);
+  std::vector<::tt::runtime::TensorDesc> outputDescs = fbb.getProgramOutputs(0);
+  std::vector<::tt::runtime::Tensor> inputTensors, outputTensors;
+
+  std::uint32_t tensorSize = inputDescs[0].itemsize;
+  for (const int dim : inputDescs[0].shape) {
+    tensorSize *= dim;
+  }
+
+  for (const auto &desc : inputDescs) {
+    std::shared_ptr<void> data =
+        ::tt::runtime::utils::malloc_shared(tensorSize);
+    std::memset(data.get(), 1, tensorSize);
+    inputTensors.emplace_back(::tt::runtime::createTensor(data, desc));
+  }
+  for (const auto &desc : outputDescs) {
+    std::shared_ptr<void> data =
+        ::tt::runtime::utils::malloc_shared(tensorSize);
+    // Set to wrong value on purpose here
+    std::memset(data.get(), 1, tensorSize);
+    outputTensors.emplace_back(::tt::runtime::createTensor(data, desc));
+  }
+
+  auto device = ::tt::runtime::openDevice();
+  auto ev = ::tt::runtime::submit(device, fbb, 0, inputTensors, outputTensors);
+  ::tt::runtime::closeDevice(device);
+
+  std::shared_ptr<void> expected =
+      ::tt::runtime::utils::malloc_shared(tensorSize);
+  std::memset(expected.get(), 0, tensorSize);
+  for (const auto &outputTensor : outputTensors) {
+    EXPECT_EQ(std::memcmp(outputTensor.data.get(), expected.get(), tensorSize),
+              0);
+  }
+}

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -27,7 +27,11 @@ set(TTMETAL_INCLUDE_DIRS
   PARENT_SCOPE
 )
 set(TTMETAL_LIBRARY_DIR ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal-build/lib PARENT_SCOPE)
+set(TTMETAL_LIBRARY_DIR ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal-build/lib)
+
 set(TTNN_LIBRARY ${TTMETAL_LIBRARY_DIR}/_ttnn.so PARENT_SCOPE)
+set(TTNN_LIBRARY ${TTMETAL_LIBRARY_DIR}/_ttnn.so)
+
 set(TTMETAL_LIBRARY -ltt_metal PARENT_SCOPE)
 
 if(EXISTS ${TTNN_LIBRARY})
@@ -48,5 +52,4 @@ ExternalProject_Add(
     GIT_PROGRESS ON
 )
 endif()
-
 set_target_properties(tt-metal PROPERTIES EXCLUDE_FROM_ALL TRUE)


### PR DESCRIPTION
#102 
Added a prototype of runtime gtest infra. Parent `CMakeLists.txt` under `runtime/test` defines a function that can be used to add tests. Subdirectories include `runtime/test/ttmetal` and `runtime/test/ttnn`. `runtime/test` is guarded by a cmake flag `-DTTMLIR_ENABLE_RUNTIME_TESTS`, and will only be built if `-DTTMLIR_ENABLE_RUNTIME_TESTS=ON`.

Added an example test `test_subtract.cpp` under `runtime/test/ttnn`. Currently using an environment variable to receive the flatbuffer path which isn't the most ideal, any suggestions are appreciated to improve the flow. Presumably we could have some directory that contains flatbuffers for these tests, and update/regenerate these flatbuffers once the compiler version is newer.

To run all tests:
```
cd build/runtime/test
TTMLIR_SUBTRACT_FB_PATH=/localdev/jnie/tt-mlir/out.ttnn ctest
```

To test a specific backend (for example ttnn):
```
cd build/runtime/test/ttnn
TTMLIR_SUBTRACT_FB_PATH=/localdev/jnie/tt-mlir/out.ttnn ctest
```
OR (assuming all ttnn tests are prefixed with TTNN):
```
cd build/runtime/test
TTMLIR_SUBTRACT_FB_PATH=/localdev/jnie/tt-mlir/out.ttnn ctest -R ^TTNN
```

To run a specific test suite (for example TTNNSubtract):
```
cd build/runtime/test
TTMLIR_SUBTRACT_FB_PATH=/localdev/jnie/tt-mlir/out.ttnn ctest -R TTNNSubtract
```
