### PR TITLE
Patch applied to ignore pessimizing-move and build runtime successfully

### DIFF
--- a/runtime/include/tt/runtime/detail/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn.h
@@ -30,6 +30,7 @@
 #pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wpessimizing-move"
 #define FMT_HEADER_ONLY
 #include "ttnn//operations/reduction/generic/generic_reductions.hpp"
 #include "ttnn/device.hpp"


### PR DESCRIPTION
**Implemented**
- Simple patch to build runtime and avoid errors building with clang-17