### PR TITLE
Adding a support for ttnn::add op in a runtime

### DIFF
--- a/runtime/lib/ttnn/program.cpp
+++ b/runtime/lib/ttnn/program.cpp
@@ -68,6 +68,14 @@ run(::tt::target::ttnn::EltwiseOp const *op, ::ttnn::Device &device,
     std::unordered_map<std::uint32_t, ::ttnn::Tensor *> &liveTensors,
     std::list<::ttnn::Tensor> &tensorPool) {
   switch (op->type()) {
+  case ::tt::target::ttnn::EltwiseOpType::Add: {
+    assert(op->ins()->size() == 2 && "Unsupported number of inputs");
+    auto &lhs = *liveTensors.at(op->ins()->Get(0)->global_id());
+    auto &rhs = *liveTensors.at(op->ins()->Get(1)->global_id());
+    tensorPool.push_back(::ttnn::add(lhs, rhs));
+    liveTensors.try_emplace(op->out()->global_id(), &tensorPool.back());
+    break;
+  }
   case ::tt::target::ttnn::EltwiseOpType::Multiply: {
     assert(op->ins()->size() == 2 && "Unsupported number of inputs");
     auto &lhs = *liveTensors.at(op->ins()->Get(0)->global_id());


### PR DESCRIPTION
This code change introduces a TTNN::Add operation switch within the TTNN program handling. It appears this functionality was missed during the initial project setup. This will enable us to execute the end-to-end demo for add op.

Solves https://github.com/tenstorrent/tt-mlir/issues/126