### PR TITLE
Implemented basic Override feature with a serializeable override descriptor

### DIFF
--- a/include/ttmlir-c/TTTypes.h
+++ b/include/ttmlir-c/TTTypes.h
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_C_TTTYPES_H
+#define TTMLIR_C_TTTYPES_H
+
+#include "ttmlir-c/Dialects.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+MLIR_CAPI_EXPORTED MlirAttribute
+ttmlirTTOperandConstraintAttrGet(MlirContext ctx, uint32_t OperandConstraint);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TTMLIR_C_TTKERNELTYPES_H

--- a/include/ttmlir/Bindings/Python/Overrides.h
+++ b/include/ttmlir/Bindings/Python/Overrides.h
@@ -5,7 +5,9 @@
 #ifndef TTMLIR_BINDINGS_PYTHON_OVERRIDES_H
 #define TTMLIR_BINDINGS_PYTHON_OVERRIDES_H
 
+#include "mlir-c/Bindings/Python/Interop.h"
 #include "mlir/Bindings/Python/PybindAdaptors.h"
+#include "mlir/CAPI/IR.h"
 #include "mlir/InitAllDialects.h"
 #include "mlir/InitAllPasses.h"
 #include "mlir/Parser/Parser.h"

--- a/include/ttmlir/Dialect/TTIR/Analysis/GridAnalysis.h
+++ b/include/ttmlir/Dialect/TTIR/Analysis/GridAnalysis.h
@@ -41,6 +41,7 @@ class GridAnalysis
 
 private:
   void analysisImplementation() override;
+  void handleOverride(llvm::json::Object *override) override;
 
 public:
   GridAnalysis(Operation *op) : TTIRAnalysis(op) {}

--- a/include/ttmlir/Dialect/TTIR/Analysis/OverrideMap.h
+++ b/include/ttmlir/Dialect/TTIR/Analysis/OverrideMap.h
@@ -1,0 +1,25 @@
+#include "llvm/Support/JSON.h"
+
+#ifndef TTMLIR_DIALECT_TTIR_ANALYSIS_OVERRIDEMAP_H
+#define TTMLIR_DIAlECT_TTIR_ANALYSIS_OVERRIDEMAP_H
+
+namespace mlir::tt {
+
+class OverrideMap {
+private:
+  static OverrideMap *instance;
+  OverrideMap() {}
+  llvm::json::Object *overrideMap;
+
+public:
+  static OverrideMap *getInstance();
+  void fromJSON(llvm::StringRef jsonString);
+  bool containsOverride(llvm::StringRef attrName);
+  llvm::json::Object *getOverride(llvm::StringRef attrName);
+};
+
+OverrideMap *OverrideMap::instance = nullptr;
+
+} // namespace mlir::tt
+
+#endif

--- a/include/ttmlir/Dialect/TTIR/Analysis/TTIRAnalysis.h
+++ b/include/ttmlir/Dialect/TTIR/Analysis/TTIRAnalysis.h
@@ -6,6 +6,7 @@
 #define TTMLIR_DIALECT_TTIR_ANALYSIS_TTIRANALYSIS_H
 
 #include "mlir/IR/Operation.h"
+#include "ttmlir/Dialect/TTIR/Analysis/OverrideMap.h"
 
 namespace mlir::tt::ttir {
 // Base class for all TTIR analyses.
@@ -14,6 +15,7 @@ template <class I, class R> class TTIRAnalysis {
 protected:
   Operation *op;
   bool is_valid = false;
+  std::string attributeName;
   R analysis_result;
   I analysis_input;
 
@@ -23,6 +25,7 @@ protected:
   // Must be implemented by every analysis type.
   //
   virtual void analysisImplementation() = 0;
+  virtual void handleOverride(llvm::json::Object *override) = 0;
 
 public:
   virtual ~TTIRAnalysis() {};
@@ -41,7 +44,11 @@ public:
   // Get the analysis result.
   //
   const R &getResult() {
-    runAnalysis();
+    auto overrideMap = tt::OverrideMap::getInstance();
+    if (overrideMap->containsOverride(attributeName))
+      handleOverride(overrideMap->getOverride(attributeName));
+    else
+      runAnalysis();
     return analysis_result;
   }
 

--- a/lib/CAPI/CMakeLists.txt
+++ b/lib/CAPI/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mlir_public_c_api_library(TTMLIRCAPI
   Dialects.cpp
   TTKernelTypes.cpp
+  TTTypes.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${PROJECT_SOURCE_DIR}/include/ttmlir-c/

--- a/lib/CAPI/TTTypes.cpp
+++ b/lib/CAPI/TTTypes.cpp
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir-c/TTTypes.h"
+#include "mlir/CAPI/IR.h"
+#include "mlir/CAPI/Support.h"
+
+#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
+
+namespace mlir::tt {
+
+MlirAttribute ttmlirTTOperandConstraintAttrGet(MlirContext ctx,
+                                               uint32_t operandConstraint) {
+  return wrap(OperandConstraintAttr::get(
+      unwrap(ctx), static_cast<OperandConstraint>(operandConstraint)));
+}
+
+} // namespace mlir::tt

--- a/lib/Dialect/TTIR/Analysis/CMakeLists.txt
+++ b/lib/Dialect/TTIR/Analysis/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_mlir_dialect_library(MLIRTTIRAnalysis
         GridAnalysis.cpp
+        OverrideMap.cpp
 
         ADDITIONAL_HEADER_DIRS
         ${PROJECT_SOURCE_DIR}/include/ttmlir

--- a/lib/Dialect/TTIR/Analysis/GridAnalysis.cpp
+++ b/lib/Dialect/TTIR/Analysis/GridAnalysis.cpp
@@ -11,4 +11,14 @@ void GridAnalysis::analysisImplementation() {
   analysis_result.target_rows = analysis_input.max_supported_rows;
   analysis_result.target_columns = analysis_input.max_supported_columns;
 }
+
+void GridAnalysis::handleOverride(llvm::json::Object *override) {
+  // Need to now collect the grid parameter from the override:
+  // Grid Override Syntax: [rows, cols]
+  llvm::json::Array newGrid = *(override->getArray("grid"));
+
+  analysis_result.target_rows = newGrid[0].getAsInteger().value();
+  analysis_result.target_columns = newGrid[1].getAsInteger().value();
+}
+
 } // namespace mlir::tt::ttir

--- a/lib/Dialect/TTIR/Analysis/OverrideMap.cpp
+++ b/lib/Dialect/TTIR/Analysis/OverrideMap.cpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTIR/Analysis/OverrideMap.h"
+
+namespace mlir::tt {
+
+OverrideMap *OverrideMap::getInstance() {
+  if (instance == nullptr) {
+    instance = new OverrideMap();
+  }
+  return instance;
+}
+
+void OverrideMap::fromJSON(llvm::StringRef jsonString) {
+  llvm::Expected<llvm::json::Value> json = llvm::json::parse(jsonString);
+  if (!json) {
+    llvm::errs() << "Error parsing JSON: " << json.takeError() << "\n";
+    return;
+  }
+  overrideMap = json->getAsObject();
+}
+
+bool OverrideMap::containsOverride(llvm::StringRef attrName) {
+  return overrideMap->find(attrName) != overrideMap->end();
+}
+
+llvm::json::Object *OverrideMap::getOverride(llvm::StringRef attrName) {
+  return overrideMap->get(attrName)->getAsObject();
+}
+
+} // namespace mlir::tt

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -38,6 +38,12 @@ declare_mlir_dialect_python_bindings(
   DIALECT_NAME ttkernel
 )
 
+declare_mlir_python_sources(TTMLIRPythonSources.Overrides
+  ROOT_DIR "${TTMLIR_PYTHON_ROOT_DIR}"
+  ADD_TO_PARENT TTMLIRPythonSources
+  SOURCES overrides.py
+)
+
 declare_mlir_python_extension(TTMLIRPythonExtensions.Main
   MODULE_NAME _ttmlir
   ADD_TO_PARENT TTMLIRPythonExtensions

--- a/python/Overrides.cpp
+++ b/python/Overrides.cpp
@@ -6,11 +6,107 @@
 
 namespace mlir::ttmlir::python {
 
+std::unordered_map<std::string,
+                   std::function<MlirAttribute(py::dict, MlirOperation)>>
+    overrideHandlers;
+
+void registerHandlers() {
+  // Make these handlers accessible for further override purposes
+
+  overrideHandlers["operandSegmentSizes"] =
+      [](py::dict attributeParams, MlirOperation op) -> MlirAttribute {
+    // We know that this is built with only an array that represents the
+    // segmentSizes
+    std::vector<int32_t> arr = py::cast<std::vector<int32_t>>(
+        attributeParams["array"].cast<py::list>());
+    return wrap(mlir::DenseI32ArrayAttr::get(
+        unwrap(mlirOperationGetContext(op)), llvm::ArrayRef(arr)));
+  };
+
+  overrideHandlers["operand_constraints"] =
+      [](py::dict attributeParams, MlirOperation op) -> MlirAttribute {
+    std::vector<mlir::Attribute> Array;
+    mlir::MLIRContext *ctx = unwrap(mlirOperationGetContext(op));
+    std::vector<uint32_t> operandConstraints = py::cast<std::vector<uint32_t>>(
+        attributeParams["constraintEnums"].cast<py::list>());
+    for (auto operandConstraint : operandConstraints)
+      Array.push_back(tt::OperandConstraintAttr::get(
+          ctx, static_cast<tt::OperandConstraint>(operandConstraint)));
+    return wrap(mlir::ArrayAttr::get(ctx, llvm::ArrayRef(Array)));
+  };
+}
+
+void parseOverride(py::dict override, MlirOperation op) {
+  // This dictionary will now be used to determine the override itself, it's
+  // easier to manipulate py::dict than a JSON object
+  /*
+    {
+      "attribute_name": {...<named_attribute_parameters>}
+    }
+  */
+
+  if (overrideHandlers.size() == 0)
+    registerHandlers();
+
+  // Apply Override to the MlirOperation object
+  for (auto &attr : override) {
+    std::string attrName = py::str(attr.first);
+    py::dict attrOverride = py::cast<py::dict>(attr.second);
+
+    if (overrideHandlers.find(attrName) != overrideHandlers.end()) {
+      MlirAttribute attr_ = overrideHandlers[attrName](attrOverride, op);
+      mlirOperationSetInherentAttributeByName(
+          op, mlirStringRefCreateFromCString(attrName.c_str()), attr_);
+    }
+  }
+}
+
 void populateOverridesModule(py::module &m) {
 
   m.def(
-      "get_ptr", [](void *op) { return reinterpret_cast<uintptr_t>(op); },
+      "get_op_ptr",
+      [](MlirOperation op) { return reinterpret_cast<uintptr_t>(unwrap(op)); },
       py::arg("op").noconvert());
+
+  m.def("parse_override", [](py::dict overrides) {
+    for (auto overrideToApply : overrides) {
+      uintptr_t opPtr = py::cast<uintptr_t>(overrideToApply.first);
+      py::dict attrOverrides = py::cast<py::dict>(overrideToApply.second);
+      mlir::Operation *op_ = (reinterpret_cast<mlir::Operation *>(opPtr));
+      MlirOperation op = wrap(op_);
+      llvm::outs() << op_->getName().getStringRef() << '\n';
+      parseOverride(attrOverrides, op);
+    }
+  });
+
+  m.def(
+      "override_dict",
+      [](py::dict opDict) {
+        // Iterate through all the ops
+
+        for (auto item : opDict) {
+          // Now transform the object into an operation
+          py::object pyOp =
+              pybind11::detail::mlirApiObjectToCapsule(item.first);
+          MlirOperation op = mlirPythonCapsuleToOperation(pyOp.ptr());
+          // Loop through to modify the attributes, a py::handle of item.second
+          // contains a dict
+          py::dict attrs = py::cast<py::dict>(item.second);
+          for (auto attr : attrs) {
+            std::string name = py::str(attr.first);
+
+            py::object pyAttr =
+                pybind11::detail::mlirApiObjectToCapsule(attr.second);
+            MlirAttribute attr_ = mlirPythonCapsuleToAttribute(pyAttr.ptr());
+            // This defines the new attribute!
+
+            // Set the new value for the attribute, hope we don't seg-fault
+            MlirStringRef name_ = mlirStringRefCreateFromCString(name.c_str());
+            mlirOperationSetInherentAttributeByName(op, name_, attr_);
+          }
+        }
+      },
+      py::arg("op_dict"));
 }
 
 } // namespace mlir::ttmlir::python

--- a/python/ttmlir/dialects/ttir.py
+++ b/python/ttmlir/dialects/ttir.py
@@ -4,4 +4,3 @@
 
 from ._ttir_ops_gen import *
 from .._mlir_libs._ttmlir import register_dialect
-from .._mlir_libs._ttmlir import overrides

--- a/python/ttmlir/overrides.py
+++ b/python/ttmlir/overrides.py
@@ -1,0 +1,1 @@
+from ._mlir_libs._ttmlir import overrides

--- a/python/ttmlir/overrides.py
+++ b/python/ttmlir/overrides.py
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from ._mlir_libs._ttmlir import overrides


### PR DESCRIPTION
**Implemented**
- `ttmlir.overrides` python module, instead of `ttmlir.ttir.overrides`, finally figured out the CMake.
- `overrides.get_op_ptr` to fetch the pointer address (used as UID in visualizer tool)
- `overrides.override_dict`, *non*-serializeable method using Python objects in a Python dictionary
- `overrides.parse_override` & `overrideHandlers` to handle different sorts of override commands, serializeable into JSON.

**Known Issues**
- Very rudimentary, needs some work to support different types of overrides in `parse_override`.
- An attempt to solve the problem, would love some feedback and review as to what the appropriate method to approach this problem would be.