### PR TITLE
Improve CI build time

### DIFF
--- a/.github/actions/build_toolchain/action.yml
+++ b/.github/actions/build_toolchain/action.yml
@@ -1,0 +1,25 @@
+name: 'Build ttmlir-toolchain'
+description: 'Creates directory, caches, and builds the ttmlir-toolchain'
+inputs:
+  os:
+    description: 'Operating System'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - run: |
+        sudo mkdir -p /opt/ttmlir-toolchain
+        sudo chown -R ${USER} /opt/ttmlir-toolchain
+      shell: bash
+      name: 'mkdir /opt/ttmlir-toolchain'
+    - uses: actions/cache@v3
+      with:
+        path: /opt/ttmlir-toolchain
+        key: ${{ inputs.os }}-ttmlir-toolchain-${{ hashFiles('env/**') }}
+      name: 'Cache ttmlir-toolchain'
+    - run: |
+        source env/activate
+        cmake -B env/build env
+        cmake --build env/build
+      shell: bash
+      name: 'Build ttmlir-toolchain'

--- a/.github/actions/build_toolchain/action.yml
+++ b/.github/actions/build_toolchain/action.yml
@@ -7,18 +7,22 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Mkdir /opt/ttmlir-toolchain
+      shell: bash
+      run: |
+        sudo mkdir -p /opt/ttmlir-toolchain
+        sudo chown -R ${USER} /opt/ttmlir-toolchain
+
     - name: 'Cache ttmlir-toolchain'
       uses: actions/cache@v3
       with:
         path: /opt/ttmlir-toolchain
-        key: ${{ inputs.os }}-ttmlir-toolchain-${{ hashFiles('env/**') }}      
+        key: ${{ inputs.os }}-ttmlir-toolchain-${{ hashFiles('env/**') }}
 
     - name: 'Build ttmlir-toolchain'
       if: steps.cache-toolchain.outputs.cache-hit != 'true'
+      shell: bash
       run: |
-        sudo mkdir -p /opt/ttmlir-toolchain
-        sudo chown -R ${USER} /opt/ttmlir-toolchain
         source env/activate
         cmake -B env/build env
         cmake --build env/build
-      shell: bash

--- a/.github/actions/build_toolchain/action.yml
+++ b/.github/actions/build_toolchain/action.yml
@@ -14,6 +14,7 @@ runs:
         sudo chown -R ${USER} /opt/ttmlir-toolchain
 
     - name: 'Cache ttmlir-toolchain'
+      id: cache-toolchain
       uses: actions/cache@v3
       with:
         path: /opt/ttmlir-toolchain

--- a/.github/actions/build_toolchain/action.yml
+++ b/.github/actions/build_toolchain/action.yml
@@ -1,5 +1,5 @@
 name: 'Build ttmlir-toolchain'
-description: 'Creates directory, caches, and builds the ttmlir-toolchain'
+description: 'Loads the ttmlir-toolchain from cache or builds it if there is no cache hit'
 inputs:
   os:
     description: 'Operating System'
@@ -7,19 +7,18 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - run: |
-        sudo mkdir -p /opt/ttmlir-toolchain
-        sudo chown -R ${USER} /opt/ttmlir-toolchain
-      shell: bash
-      name: 'mkdir /opt/ttmlir-toolchain'
-    - uses: actions/cache@v3
+    - name: 'Cache ttmlir-toolchain'
+      uses: actions/cache@v3
       with:
         path: /opt/ttmlir-toolchain
-        key: ${{ inputs.os }}-ttmlir-toolchain-${{ hashFiles('env/**') }}
-      name: 'Cache ttmlir-toolchain'
-    - run: |
+        key: ${{ inputs.os }}-ttmlir-toolchain-${{ hashFiles('env/**') }}      
+
+    - name: 'Build ttmlir-toolchain'
+      if: steps.cache-toolchain.outputs.cache-hit != 'true'
+      run: |
+        sudo mkdir -p /opt/ttmlir-toolchain
+        sudo chown -R ${USER} /opt/ttmlir-toolchain
         source env/activate
         cmake -B env/build env
         cmake --build env/build
       shell: bash
-      name: 'Build ttmlir-toolchain'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,12 @@ jobs:
       with:
         os: ${{ matrix.os }}
 
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        create-symlink: true
+        key: ${{ matrix.os }} 
+
     - name: Set reusable strings
       id: strings
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,26 +31,10 @@ jobs:
       with:
           fetch-depth: 0 # Fetch all history and tags
 
-    - name: mkdir /opt/ttmlir-toolchain
-      shell: bash
-      run: |
-        sudo mkdir -p /opt/ttmlir-toolchain
-        sudo chown -R ${USER} /opt/ttmlir-toolchain
-
-    - name: Cache ttmlir-toolchain
-      uses: actions/cache@v3
+    - name: Build and cache ttmlir-toolchain
+      uses: ./.github/actions/build_toolchain
       with:
-        path: /opt/ttmlir-toolchain
-        key: ${{ runner.OS }}-ttmlir-toolchain-cache-${{ hashFiles('env/**') }}
-        restore-keys: |
-          ${{ runner.OS }}-ttmlir-toolchain-cache-
-
-    - name: Build ttmlir-toolchain
-      shell: bash
-      run: |
-        source env/activate
-        cmake -B env/build env
-        cmake --build env/build
+        os: ${{ matrix.os }}
 
     - name: Set reusable strings
       id: strings

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       uses: hendrikmuhs/ccache-action@v1.2
       with:
         create-symlink: true
-        key: ${{ matrix.os }} 
+        key: ${{ matrix.os }}
 
     - name: Set reusable strings
       id: strings

--- a/env/CMakeLists.txt
+++ b/env/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.20.0)
 project(ttmlir-toolchain LANGUAGES CXX C)
+
+set(FLATBUFFERS_VERSION "v24.3.7")
+set(LLVM_PROJECT_VERSION "llvmorg-18.1.0")
+
 include(ExternalProject)
 
 if (NOT DEFINED ENV{TTMLIR_TOOLCHAIN_DIR})
@@ -25,7 +29,7 @@ ExternalProject_Add(
     -DFLATBUFFERS_BUILD_TESTS=OFF
     -DCMAKE_POSITION_INDEPENDENT_CODE=ON # Required for linking into shared libraries (python bindings)
     GIT_REPOSITORY https://github.com/google/flatbuffers.git
-    GIT_TAG v24.3.7
+    GIT_TAG ${FLATBUFFERS_VERSION}
     DEPENDS python-venv
 )
 
@@ -58,7 +62,7 @@ ExternalProject_Add(
     SOURCE_SUBDIR llvm
     LIST_SEPARATOR ","
     GIT_REPOSITORY https://github.com/llvm/llvm-project.git
-    GIT_TAG llvmorg-18.1.0
+    GIT_TAG ${LLVM_PROJECT_VERSION}
     GIT_PROGRESS ON
     DEPENDS python-venv
 )


### PR DESCRIPTION
# Improve CI build time

## Cache /opt/ttmlir-toolchain

- moved ttmlir-toolchain build to separate action
- build ttmlir-toolchain only if files in env/ are changed or there is no cache

## Use ccache for builds

- Add ccache to build
- Ccache folder will be cached between pipeline runs

## env/CMakeLists.txt

- Moved dependency versions to variables

Note:
Github can access the cache from "parent" branches, but not the other way around. This means that we will sometimes get one more full build, for example if we make a change in a branch to update the flatbuffer version we will have full build for branch, and again full build for main after merging. This is just how Github works

# Build time with toolchain caching and cache added:

<img width="1211" alt="image" src="https://github.com/user-attachments/assets/7d09ed87-61cc-40a3-a14e-6604ddef51bc">

Closes: #36
Closes: #51
