### PR TITLE
Added pre-commit hook to check for SPDX, applies if missing

### DIFF
--- a/.github/check-spdx.yaml
+++ b/.github/check-spdx.yaml
@@ -1,0 +1,14 @@
+DEFAULT:
+  perform_check: yes  # Perform check for all files
+  allowed_licenses:
+    - Apache-2.0
+  license_for_new_files: Apache-2.0  # license to be used when inserting a new copyright notice
+  new_notice_c: |  # notice for new C, CPP, H, HPP and LD files
+    // SPDX-FileCopyrightText: (c) {years} Tenstorrent AI ULC
+    //
+    // SPDX-License-Identifier: {license}
+
+  new_notice_python: |  # notice for new python files
+    # SPDX-FileCopyrightText: (c) {years} Tenstorrent AI ULC
+    #
+    # SPDX-License-Identifier: {license}

--- a/.github/check-spdx.yaml
+++ b/.github/check-spdx.yaml
@@ -3,12 +3,12 @@ DEFAULT:
   allowed_licenses:
     - Apache-2.0
   license_for_new_files: Apache-2.0  # license to be used when inserting a new copyright notice
-  new_notice_c: |  # notice for new C, CPP, H, HPP and LD files
+  new_notice_c: |+  # notice for new C, CPP, H, HPP and LD files
     // SPDX-FileCopyrightText: (c) {years} Tenstorrent AI ULC
     //
     // SPDX-License-Identifier: {license}
 
-  new_notice_python: |  # notice for new python files
+  new_notice_python: |+  # notice for new python files
     # SPDX-FileCopyrightText: (c) {years} Tenstorrent AI ULC
     #
     # SPDX-License-Identifier: {license}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,11 @@ repos:
     - id: clang-format
       types_or: [c++, c]
       args: [-style=file, -i]
+  - repo: https://github.com/espressif/check-copyright/
+    rev: v1.0.3
+    hooks:
+      - id: check-copyright
+        args: ['--config', '.github/check-spdx.yaml']
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
     hooks:

--- a/include/ttmlir-c/Dialects.h
+++ b/include/ttmlir-c/Dialects.h
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
-
 #ifndef TTMLIR_C_DIALECTS_H
 #define TTMLIR_C_DIALECTS_H
 

--- a/include/ttmlir-c/Dialects.h
+++ b/include/ttmlir-c/Dialects.h
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
+
 #ifndef TTMLIR_C_DIALECTS_H
 #define TTMLIR_C_DIALECTS_H
 


### PR DESCRIPTION
**Implemented**:
- Added SPDX config to `pre-commit`. No more failed builds with a small incremental update! 
- License configuration file stored in `.github/check-spdx.yaml`