### PR TITLE
Change ttnn->emitc transform to use dialect conversion API

### DIFF
--- a/docs/src/adding-an-op.md
+++ b/docs/src/adding-an-op.md
@@ -140,8 +140,8 @@ TTIRToTTNNBinaryOpRewriter<ttir::MatmulOp, MatmulOp>
 ```
 
 We also need to add this op to the C++ emitter,
-`lib/Dialect/TTNN/Transforms/TTNNToCpp.cpp` see
-`TTNNToEmitCOpaqueRewriter<MatmulOp>`.
+`lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp` see
+`populateTTNNToEmitCPatterns(...)`.
 
 ## 4. Add a unit test for the Op
 

--- a/include/ttmlir/CMakeLists.txt
+++ b/include/ttmlir/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(Conversion)
 add_subdirectory(Dialect)
 add_subdirectory(Target)
 add_dependencies(mlir-headers FBS_GENERATION)

--- a/include/ttmlir/Conversion/CMakeLists.txt
+++ b/include/ttmlir/Conversion/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls -name TTMLIRConversion)
+add_public_tablegen_target(TTMLIRConversionPassIncGen)

--- a/include/ttmlir/Conversion/Passes.h
+++ b/include/ttmlir/Conversion/Passes.h
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_CONVERSION_PASSES_H
+#define TTMLIR_CONVERSION_PASSES_H
+
+#include "ttmlir/Conversion/TTNNToEmitC/TTNNToEmitC.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNN.h"
+
+#include "mlir/Dialect/EmitC/IR/EmitC.h"
+
+namespace mlir::tt {
+
+#define GEN_PASS_REGISTRATION
+#include "ttmlir/Conversion/Passes.h.inc"
+
+} // namespace mlir::tt
+
+#endif // TTMLIR_CONVERSION_PASSES_H

--- a/include/ttmlir/Conversion/Passes.td
+++ b/include/ttmlir/Conversion/Passes.td
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_CONVERSION_PASSES
+#define TTMLIR_CONVERSION_PASSES
+
+include "mlir/Pass/PassBase.td"
+
+def ConvertTTNNToEmitC : Pass<"convert-ttnn-to-emitc", "::mlir::func::FuncOp"> {
+  let summary = "Convert TTNN dialect to EmitC dialect.";
+  let constructor = "createConvertTTNNToEmitCPass()";
+  let dependentDialects = ["mlir::emitc::EmitCDialect", "mlir::tt::ttnn::TTNNDialect"];
+}
+
+#endif // TTMLIR_CONVERSION_PASSES

--- a/include/ttmlir/Conversion/TTNNToEmitC/TTNNToEmitC.h
+++ b/include/ttmlir/Conversion/TTNNToEmitC/TTNNToEmitC.h
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_CONVERSION_TTNNTOEMITC_TTNNTOEMITC_H
+#define TTMLIR_CONVERSION_TTNNTOEMITC_TTNNTOEMITC_H
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir::tt {
+
+std::unique_ptr<OperationPass<func::FuncOp>> createConvertTTNNToEmitCPass();
+
+} // namespace mlir::tt
+
+#endif // TTMLIR_CONVERSION_TTNNTOEMITC_TTNNTOEMITC_H

--- a/include/ttmlir/Dialect/TTNN/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Passes.td
@@ -21,13 +21,6 @@ def ConvertTTIRToTTNN: Pass<"convert-ttir-to-ttnn", "::mlir::ModuleOp"> {
   }];
 }
 
-def ConvertTTNNToEmitC: Pass<"convert-ttnn-to-emitc", "::mlir::ModuleOp"> {
-  let summary = "";
-  let description = [{
-    todo
-  }];
-}
-
 def TTNNSerializeToBinary: Pass<"ttnn-serialize-to-binary", "::mlir::ModuleOp"> {
   let summary = "";
   let description = [{

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(CAPI)
+add_subdirectory(Conversion)
 add_subdirectory(Dialect)
 
 add_mlir_library(TTMLIR STATIC RegisterAll.cpp

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(TTNNToEmitC)

--- a/lib/Conversion/PassDetail.h
+++ b/lib/Conversion/PassDetail.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_LIB_CONVERSION_PASSDETAIL_H
+#define TTMLIR_LIB_CONVERSION_PASSDETAIL_H
+
+#include "ttmlir/Dialect/TTNN/IR/TTNN.h"
+
+#include "mlir/Dialect/EmitC/IR/EmitC.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir::emitc {
+class EmitCDialect;
+}
+
+namespace mlir::tt::ttnn {
+
+#define GEN_PASS_CLASSES
+#include "ttmlir/Conversion/Passes.h.inc"
+
+} // namespace mlir::tt::ttnn
+
+#endif // TTMLIR_LIB_CONVERSION_PASSDETAIL_H

--- a/lib/Conversion/TTNNToEmitC/CMakeLists.txt
+++ b/lib/Conversion/TTNNToEmitC/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_mlir_library(TTMLIRTTNNToEmitC
+  TTNNToEmitC.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${PROJECT_SOURCE_DIR}/include/ttmlir/Conversion/TTNNToEmitC
+
+  DEPENDS
+  TTMLIRConversionPassIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRPass
+  MLIRTransformUtils
+)

--- a/lib/Conversion/TTNNToEmitC/PopulatePatterns.h
+++ b/lib/Conversion/TTNNToEmitC/PopulatePatterns.h
@@ -26,22 +26,21 @@ public:
                              MLIRContext *context, PatternBenefit benefit = 1)
       : OpConversionPattern<SrcOp>(typeConverter, context, benefit) {}
 
-  // Coverts op name by removing the dialect prefix ("ttnn.") and replacing with
-  // namespace prefix ("ttnn::")
+  // Converts op name by removing the dialect prefix ("ttnn.") and replacing
+  // with namespace prefix ("ttnn::")
   //
   std::string convertOpName(SrcOp op) const {
     auto name = op.getOperationName();
-    if (name.starts_with("ttnn.")) {
-      return "ttnn::" + name.drop_front(5).str();
-    }
-    return "ttnn::" + name.str();
+    assert(
+        name.starts_with("ttnn.") &&
+        "DefaultOpConversionPattern only supports ops from the TTNN dialect");
+
+    return name.str().replace(0, 5, "ttnn::");
   }
 
   LogicalResult
   matchAndRewrite(SrcOp srcOp, Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    SmallVector<Attribute, 4> templateArguments;
-
     int numReturnTypes = srcOp->getResultTypes().size();
     assert(numReturnTypes <= 1 &&
            "DefaultOpConversionPattern does not support multiple return types");

--- a/lib/Conversion/TTNNToEmitC/PopulatePatterns.h
+++ b/lib/Conversion/TTNNToEmitC/PopulatePatterns.h
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_LIB_CONVERSION_TTNNTOEMITC_POPULATEPATTERNS_H
+#define TTMLIR_LIB_CONVERSION_TTNNTOEMITC_POPULATEPATTERNS_H
+
+#include "mlir/Dialect/EmitC/IR/EmitC.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+using namespace mlir;
+
+namespace {
+
+template <typename SrcOp, typename Adaptor = typename SrcOp::Adaptor>
+class DefaultOpConversionPattern : public OpConversionPattern<SrcOp> {
+  using OpConversionPattern<SrcOp>::OpConversionPattern;
+
+public:
+  // Default op conversion pattern, used to convert most ops
+  //
+  DefaultOpConversionPattern(MLIRContext *ctx)
+      : OpConversionPattern<SrcOp>(ctx) {}
+
+  DefaultOpConversionPattern(const TypeConverter &typeConverter,
+                             MLIRContext *context, PatternBenefit benefit = 1)
+      : OpConversionPattern<SrcOp>(typeConverter, context, benefit) {}
+
+  // Coverts op name by removing the dialect prefix ("ttnn.") and replacing with
+  // namespace prefix ("ttnn::")
+  //
+  std::string convertOpName(SrcOp op) const {
+    auto name = op.getOperationName();
+    if (name.starts_with("ttnn.")) {
+      return "ttnn::" + name.drop_front(5).str();
+    }
+    return "ttnn::" + name.str();
+  }
+
+  LogicalResult
+  matchAndRewrite(SrcOp srcOp, Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    SmallVector<Attribute, 4> templateArguments;
+
+    int numReturnTypes = srcOp->getResultTypes().size();
+    assert(numReturnTypes <= 1 &&
+           "DefaultOpConversionPattern does not support multiple return types");
+
+    // If srcOp has a return type, cast it before converting
+    //
+    if (numReturnTypes == 1) {
+      auto resultTy = cast<emitc::OpaqueType>(
+          this->getTypeConverter()->convertType(srcOp->getResult(0).getType()));
+      rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
+          srcOp, resultTy, convertOpName(srcOp), nullptr, nullptr,
+          adaptor.getOperands());
+    } else {
+      // No return type, only convert the op
+      //
+      rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
+          srcOp, srcOp->getResultTypes(), convertOpName(srcOp), nullptr,
+          nullptr, adaptor.getOperands());
+    }
+
+    return success();
+  }
+};
+
+} // namespace
+
+#endif // TTMLIR_LIB_CONVERSION_TTNNTOEMITC_POPULATEPATTERNS_H

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Conversion/TTNNToEmitC/TTNNToEmitC.h"
+
+#include "../PassDetail.h"
+#include "PopulatePatterns.h"
+#include "TypeConverter.h"
+
+#include "ttmlir/Dialect/TT/IR/TTOpsDialect.h.inc"
+#include "ttmlir/Dialect/TTNN/IR/TTNN.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+
+#include "mlir/Dialect/EmitC/IR/EmitC.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Func/Transforms/FuncConversions.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+using namespace mlir;
+using namespace mlir::tt;
+
+namespace {
+
+void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
+                                 mlir::RewritePatternSet &patterns,
+                                 TypeConverter &typeConverter) {
+  // Device ops
+  //
+  patterns.add<DefaultOpConversionPattern<ttnn::OpenDeviceOp>>(typeConverter,
+                                                               ctx, true);
+  patterns.add<DefaultOpConversionPattern<ttnn::CloseDeviceOp>>(typeConverter,
+                                                                ctx);
+
+  // Memory ops
+  //
+  patterns.add<DefaultOpConversionPattern<ttnn::ToMemoryConfigOp>>(
+      typeConverter, ctx);
+
+  // Tensor ops
+  //
+  patterns.add<DefaultOpConversionPattern<ttnn::FullOp>>(typeConverter, ctx);
+
+  // Math ops
+  //
+  patterns.add<DefaultOpConversionPattern<ttnn::AddOp>>(typeConverter, ctx);
+  patterns.add<DefaultOpConversionPattern<ttnn::SubtractOp>>(typeConverter,
+                                                             ctx);
+  patterns.add<DefaultOpConversionPattern<ttnn::SumOp>>(typeConverter, ctx);
+  patterns.add<DefaultOpConversionPattern<ttnn::MultiplyOp>>(typeConverter,
+                                                             ctx);
+  patterns.add<DefaultOpConversionPattern<ttnn::MatmulOp>>(typeConverter, ctx);
+  patterns.add<DefaultOpConversionPattern<ttnn::ReluOp>>(typeConverter, ctx);
+}
+
+struct ConvertTTNNToEmitCPass
+    : public ttnn::ConvertTTNNToEmitCBase<ConvertTTNNToEmitCPass> {
+  void runOnOperation() override {
+    mlir::ConversionTarget target(getContext());
+
+    target.addLegalDialect<func::FuncDialect>();
+    target.addLegalDialect<emitc::EmitCDialect>();
+    target.addIllegalDialect<ttnn::TTNNDialect>();
+
+    // Add header imports to front of module
+    //
+    {
+      auto module = getOperation();
+      OpBuilder builder(module);
+
+      builder.create<emitc::IncludeOp>(module.getLoc(), "ttnn/device.h",
+                                       /*isStandard=*/false);
+      builder.create<emitc::IncludeOp>(
+          module.getLoc(), "ttnn/operations/eltwise/binary/binary.hpp",
+          /*isStandard=*/false);
+      builder.create<emitc::IncludeOp>(
+          module.getLoc(), "ttnn/operations/core.hpp", /*isStandard=*/false);
+      builder.create<emitc::IncludeOp>(module.getLoc(),
+                                       "ttnn/operations/creation.hpp",
+                                       /*isStandard=*/false);
+      builder.create<emitc::IncludeOp>(
+          module.getLoc(),
+          "ttnn/operations/reduction/generic/generic_reductions.hpp",
+          /*isStandard=*/false);
+    }
+
+    // TTNN -> EmitC
+    //
+    {
+      TTNNToEmitCTypeConverter typeConverter(&getContext());
+      RewritePatternSet patterns(&getContext());
+
+      // Func dialect handling
+      //
+      populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(
+          patterns, typeConverter);
+      target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp op) {
+        return typeConverter.isSignatureLegal(op.getFunctionType()) &&
+               typeConverter.isLegal(&op.getBody());
+      });
+      populateReturnOpTypeConversionPattern(patterns, typeConverter);
+      target.addDynamicallyLegalOp<func::ReturnOp>(
+          [&](func::ReturnOp op) { return typeConverter.isLegal(op); });
+      populateCallOpTypeConversionPattern(patterns, typeConverter);
+      target.addDynamicallyLegalOp<func::CallOp>(
+          [&](func::CallOp op) { return typeConverter.isLegal(op); });
+
+      // TTNN -> EmitC patterns
+      //
+      populateTTNNToEmitCPatterns(&getContext(), patterns, typeConverter);
+
+      // Apply conversion
+      //
+      if (failed(applyFullConversion(getOperation(), target,
+                                     std::move(patterns)))) {
+        signalPassFailure();
+        return;
+      }
+    }
+  };
+};
+
+} // namespace
+
+namespace mlir::tt {
+
+std::unique_ptr<OperationPass<func::FuncOp>> createConvertTTNNToEmitCPass() {
+  return std::make_unique<ConvertTTNNToEmitCPass>();
+}
+
+} // namespace mlir::tt

--- a/lib/Conversion/TTNNToEmitC/TypeConverter.h
+++ b/lib/Conversion/TTNNToEmitC/TypeConverter.h
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_LIB_CONVERSION_TTNNTOEMITC_TYPECONVERTER_H
+#define TTMLIR_LIB_CONVERSION_TTNNTOEMITC_TYPECONVERTER_H
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+
+#include "mlir/Dialect/EmitC/IR/EmitC.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+using namespace mlir;
+
+namespace {
+
+class TTNNToEmitCTypeConverter : public TypeConverter {
+public:
+  TTNNToEmitCTypeConverter(MLIRContext *ctx) {
+    addConversion([](Type type) { return type; });
+    addConversion([ctx](mlir::tt::DeviceType type) -> Type {
+      return emitc::OpaqueType::get(ctx, "ttnn::Device");
+    });
+    addConversion([ctx](TensorType type) -> Type {
+      return emitc::OpaqueType::get(ctx, "ttnn::Tensor");
+    });
+  }
+};
+
+} // namespace
+
+#endif // TTMLIR_LIB_CONVERSION_TTNNTOEMITC_TYPECONVERTER_H

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -13,3 +13,4 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         )
 
 target_include_directories(MLIRTTNNTransforms PUBLIC ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common)
+target_link_libraries(MLIRTTNNTransforms PRIVATE TTMLIRTTNNToEmitC)

--- a/lib/Dialect/TTNN/Transforms/TTNNToCpp.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNToCpp.cpp
@@ -2,189 +2,25 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "llvm/ADT/ScopeExit.h"
+#include "ttmlir/Conversion/TTNNToEmitC/TTNNToEmitC.h"
+#include "ttmlir/Dialect/TTNN/Passes.h"
 
 #include "mlir/Dialect/EmitC/IR/EmitC.h"
-#include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/IR/PatternMatch.h"
-#include "mlir/Rewrite/FrozenRewritePatternSet.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Target/Cpp/CppEmitter.h"
-#include "mlir/Transforms/DialectConversion.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
-#include "ttmlir/Dialect/TT/IR/TT.h"
-#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
 
-#include "ttmlir/Dialect/TTKernel/IR/TTKernel.h"
-#include "ttmlir/Dialect/TTKernel/IR/TTKernelOps.h"
-#include "ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.h"
-#include "ttmlir/Dialect/TTNN/IR/TTNNOpsTypes.h"
-#include "ttmlir/Dialect/TTNN/Passes.h"
+#include "llvm/ADT/ScopeExit.h"
 
 namespace mlir::tt::ttnn {
 #define GEN_PASS_DEF_CONVERTTTNNTOEMITC
-#include "ttmlir/Dialect/TTNN/Passes.h.inc"
-
-class TTNNToEmitCTypeConverter : public TypeConverter {
-public:
-  TTNNToEmitCTypeConverter(MLIRContext *ctx) {
-    addConversion([](Type type) { return type; });
-    addConversion([ctx](DeviceType type) -> Type {
-      return emitc::OpaqueType::get(ctx, "ttnn::Device");
-    });
-    addConversion([ctx](TensorType type) -> Type {
-      return emitc::OpaqueType::get(ctx, "ttnn::Tensor");
-    });
-  }
-};
-
-class TTNNToEmitCTypeRewriter : public RewritePattern {
-public:
-  TTNNToEmitCTypeRewriter(const TypeConverter &converter, MLIRContext *ctx)
-      : RewritePattern(MatchAnyOpTypeTag(), /*benefit=*/1, ctx),
-        converter(&converter) {}
-
-  template <typename ValueRange>
-  bool convertTypes(ValueRange valueRange, SmallVector<Type> &newTypes) const {
-    bool updated = false;
-    auto result = converter->convertTypes(valueRange.getTypes(), newTypes);
-    if (result.failed()) {
-      return false;
-    }
-    for (auto [operand, newType] : llvm::zip(valueRange, newTypes)) {
-      if (operand.getType() == newType) {
-        continue;
-      }
-      operand.setType(newType);
-      updated = true;
-    }
-    return updated;
-  }
-
-  bool convertFuncType(Operation *op, PatternRewriter &rewriter) const {
-    auto funcOp = dyn_cast<func::FuncOp>(op);
-    if (not funcOp) {
-      return false;
-    }
-    SmallVector<Type> inputTypes(funcOp.getArgumentTypes());
-    SmallVector<Type> outputTypes(funcOp.getResultTypes());
-    for (Type &ty : inputTypes) {
-      ty = converter->convertType(ty);
-    }
-    for (Type &ty : outputTypes) {
-      ty = converter->convertType(ty);
-    }
-    auto newType = rewriter.getType<FunctionType>(inputTypes, outputTypes);
-    if (funcOp.getFunctionType() == newType) {
-      return false;
-    }
-    funcOp.setFunctionType(newType);
-    return true;
-  }
-
-  LogicalResult matchAndRewrite(Operation *op,
-                                PatternRewriter &rewriter) const override {
-    bool updated = false;
-    SmallVector<Type> operands;
-    SmallVector<Type> results;
-    updated |= convertTypes(op->getOperands(), operands);
-    updated |= convertTypes(op->getResults(), results);
-    updated |= convertFuncType(op, rewriter);
-    return updated ? success() : failure();
-  }
-
-  const TypeConverter *converter;
-};
-
-template <typename OpTy>
-class TTNNToEmitCOpaqueRewriter : public OpRewritePattern<OpTy> {
-public:
-  using OpRewritePattern<OpTy>::OpRewritePattern;
-
-  std::string getOpName(OpTy op) const {
-    auto name = op.getOperation()->getName().getStringRef();
-    if (name.starts_with("ttnn.")) {
-      name = name.drop_front(5);
-    }
-    return "ttnn::" + name.str();
-  }
-
-  LogicalResult matchAndRewrite(OpTy op,
-                                PatternRewriter &rewriter) const final {
-    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
-        op, op->getResultTypes(), getOpName(op), nullptr, nullptr,
-        op->getOperands());
-    return success();
-  }
-};
-
-class ConvertTTNNToEmitC
-    : public impl::ConvertTTNNToEmitCBase<ConvertTTNNToEmitC> {
-public:
-  using impl::ConvertTTNNToEmitCBase<
-      ConvertTTNNToEmitC>::ConvertTTNNToEmitCBase;
-
-  void runOnOperation() final {
-    {
-      TTNNToEmitCTypeConverter typeConverter(&getContext());
-      RewritePatternSet patterns(&getContext());
-      patterns.add<TTNNToEmitCTypeRewriter>(typeConverter, &getContext());
-      FrozenRewritePatternSet patternSet(std::move(patterns));
-      if (failed(applyPatternsAndFoldGreedily(getOperation(), patternSet))) {
-        signalPassFailure();
-        return;
-      }
-    }
-
-    {
-      RewritePatternSet patterns(&getContext());
-      patterns.add<TTNNToEmitCOpaqueRewriter<OpenDeviceOp>,
-                   TTNNToEmitCOpaqueRewriter<FullOp>,
-                   TTNNToEmitCOpaqueRewriter<ToMemoryConfigOp>,
-                   TTNNToEmitCOpaqueRewriter<MultiplyOp>,
-                   TTNNToEmitCOpaqueRewriter<SubtractOp>,
-                   TTNNToEmitCOpaqueRewriter<ReluOp>,
-                   TTNNToEmitCOpaqueRewriter<MatmulOp>,
-                   TTNNToEmitCOpaqueRewriter<SumOp>,
-                   TTNNToEmitCOpaqueRewriter<CloseDeviceOp>>(&getContext());
-      FrozenRewritePatternSet patternSet(std::move(patterns));
-      if (failed(applyPatternsAndFoldGreedily(getOperation(), patternSet))) {
-        signalPassFailure();
-      }
-    }
-
-    {
-      auto module = getOperation();
-      OpBuilder builder(module);
-      module.getBody()->push_front(builder.create<emitc::IncludeOp>(
-          module.getLoc(), "ttnn/device.h", /*isStandard=*/false));
-      module.getBody()->push_front(builder.create<emitc::IncludeOp>(
-          module.getLoc(), "ttnn/operations/eltwise/binary/binary.hpp",
-          /*isStandard=*/false));
-      module.getBody()->push_front(builder.create<emitc::IncludeOp>(
-          module.getLoc(), "ttnn/operations/core.hpp", /*isStandard=*/false));
-      module.getBody()->push_front(builder.create<emitc::IncludeOp>(
-          module.getLoc(), "ttnn/operations/creation.hpp",
-          /*isStandard=*/false));
-      module.getBody()->push_front(builder.create<emitc::IncludeOp>(
-          module.getLoc(),
-          "ttnn/operations/reduction/generic/generic_reductions.hpp",
-          /*isStandard=*/false));
-    }
-  }
-
-  void getDependentDialects(mlir::DialectRegistry &registry) const override {
-    registry.insert<mlir::tt::ttnn::TTNNDialect>();
-    registry.insert<emitc::EmitCDialect>();
-  }
-};
+#include "ttmlir/Conversion/Passes.h.inc"
 
 LogicalResult emitTTNNAsCpp(ModuleOp origOp, llvm::raw_ostream &os) {
   ModuleOp op = cast<ModuleOp>(origOp->clone());
   auto cleanupDispatchClone = llvm::make_scope_exit([&op] { op->erase(); });
 
   auto pm = PassManager::on<ModuleOp>(op.getContext());
-  pm.addPass(createConvertTTNNToEmitC());
+  pm.addPass(createConvertTTNNToEmitCPass());
 
   if (pm.run(op).failed()) {
     return failure();

--- a/lib/Dialect/TTNN/Transforms/TTNNToSerializedBinary.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNToSerializedBinary.cpp
@@ -220,7 +220,7 @@ public:
     auto mlir = toDebugInfo(fbb, "ttnn", module);
     std::string cpp;
     llvm::raw_string_ostream os(cpp);
-    auto result = emitTTNNAsCpp(module, os);
+    auto result = mlir::tt::ttnn::emitTTNNAsCpp(module, os);
     (void)result;
 
     auto debugInfo =

--- a/lib/RegisterAll.cpp
+++ b/lib/RegisterAll.cpp
@@ -8,6 +8,7 @@
 #include "mlir/InitAllDialects.h"
 #include "mlir/InitAllPasses.h"
 
+#include "ttmlir/Conversion/Passes.h"
 #include "ttmlir/Dialect/TT/IR/TT.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIR.h"
 #include "ttmlir/Dialect/TTIR/Passes.h"
@@ -29,6 +30,10 @@ void mlir::tt::registerAllDialects(mlir::DialectRegistry &registry) {
 }
 
 void mlir::tt::registerAllPasses() {
+  // Register all dialect conversion passes
+  //
+  mlir::tt::registerTTMLIRConversionPasses();
+
   mlir::tt::ttir::registerPasses();
   mlir::tt::ttnn::registerPasses();
   mlir::tt::ttmetal::registerPasses();

--- a/tools/ttmlir-opt/CMakeLists.txt
+++ b/tools/ttmlir-opt/CMakeLists.txt
@@ -1,6 +1,6 @@
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
-set(LIBS ${dialect_libs} ${conversion_libs} MLIROptLib MLIRTargetCpp TTMLIR)
+set(LIBS ${dialect_libs} ${conversion_libs} TTMLIRTTNNToEmitC MLIROptLib MLIRTargetCpp TTMLIR)
 add_llvm_executable(ttmlir-opt ttmlir-opt.cpp)
 
 llvm_update_compile_flags(ttmlir-opt)


### PR DESCRIPTION
Details:
- Convert TTNN to EmitC dialect via dialect conversion API (#94)
- Structure set following [torch-mlir](https://github.com/llvm/torch-mlir/tree/main) approach
- `TTNNToCpp.cpp` stills exists as I didn't want to break existing tests/pipelines (used to embed cpp into flatbuffer), but it should be removed in the near future

To run, we first generate an IR in EmitC dialect, dump it to disk, and read back with `ttmlir-translate` tool to covert to actual cpp code:
```bash
./build/bin/ttmlir-opt --ttir-layout --ttnn-open-device --convert-ttir-to-ttnn --convert-ttnn-to-emitc test/ttmlir/Dialect/TTNN/simple_multiply.mlir -o c.mlir
./build/bin/ttmlir-translate -mlir-to-cpp c.mlir -allow-unregistered-dialect
```

TODO: Add these commands to docs (#147)