### PR TITLE
[tensor-layout] implements LayoutAttr::getStride()

### DIFF
--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -189,7 +189,8 @@ def TT_LayoutAttr : TT_Attr<"Layout", "layout"> {
       bool isSystemMemorySpace() const { return ::mlir::tt::isSystemMemorySpace(getMemorySpace()); }
       bool isDeviceMemorySpace() const { return ::mlir::tt::isDeviceMemorySpace(getMemorySpace()); }
       Type getElementType() const;
-      llvm::SmallVector<int64_t> getStride() const;
+      llvm::SmallVector<int64_t> getStride(ArrayRef<int64_t> logicalShape) const;
+      llvm::SmallVector<int64_t> getPhysicalShape(ArrayRef<int64_t> logicalShape) const;
       llvm::SmallVector<int64_t> getShardShape() const;
       LayoutAttr withGrid(::mlir::MLIRContext *context, ArrayRef<int64_t> tensorShape, GridAttr grid, ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}});
       LayoutAttr withGrid(::mlir::MLIRContext *context,

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -271,10 +271,11 @@ memrefAttrToFlatbuffer(FlatbufferObjectCache &cache, MemRefType memref) {
 }
 
 inline flatbuffers::Offset<::tt::target::LayoutDesc>
-layoutAttrToFlatbuffer(FlatbufferObjectCache &cache, Attribute attr) {
+layoutAttrToFlatbuffer(FlatbufferObjectCache &cache, Attribute attr,
+                       ArrayRef<int64_t> logicalShape) {
   assert(attr.isa<LayoutAttr>() && "expected a tensor type");
   auto layoutAttr = attr.cast<LayoutAttr>();
-  auto strideInt64 = layoutAttr.getStride();
+  auto strideInt64 = layoutAttr.getStride(logicalShape);
   std::vector<int32_t> stride(strideInt64.begin(), strideInt64.end());
   auto gridAttr = layoutAttr.getGrid();
   auto gridShape = gridAttr.getShape();
@@ -294,7 +295,8 @@ tensorTypeToFlatbuffer(FlatbufferObjectCache &cache, Type type) {
   std::vector<int32_t> shape(shapeInt64.begin(), shapeInt64.end());
   return ::tt::target::CreateTensorDescDirect(
       *cache.fbb, &shape,
-      cache.getOrCreate(tensorType.getEncoding(), layoutAttrToFlatbuffer));
+      cache.getOrCreate(tensorType.getEncoding(), layoutAttrToFlatbuffer,
+                        shapeInt64));
 }
 
 inline flatbuffers::Offset<::tt::target::TensorRef>

--- a/lib/Dialect/TT/IR/TTOpsTypes.cpp
+++ b/lib/Dialect/TT/IR/TTOpsTypes.cpp
@@ -170,8 +170,75 @@ LayoutAttr LayoutAttr::get(
              collapseIntervals, oobVal);
 }
 
-llvm::SmallVector<int64_t> LayoutAttr::getStride() const {
-  return llvm::SmallVector<int64_t>();
+// From the logical shape of the tensor and the affine map of the layout,
+// compute the physical shape of the tensor, i.e the shape of the tensor
+// after the dimensions have been collapsed onto a grid.
+llvm::SmallVector<int64_t>
+LayoutAttr::getPhysicalShape(ArrayRef<int64_t> logicalShape) const {
+  llvm::SmallVector<int64_t> physicalShape(getGrid().getShape().size());
+  SmallVector<AffineExpr> logicalShapeExprs(
+      llvm::map_range(logicalShape, [context = getContext()](std::int64_t e) {
+        return getAffineConstantExpr(e - 1, context);
+      }));
+
+  for (size_t i = 0; i < physicalShape.size(); i++) {
+    AffineExpr expr = getLinear().getResult(i);
+    AffineExpr constantExpr = expr.replaceDims(logicalShapeExprs);
+    std::int64_t constant =
+        llvm::cast<AffineConstantExpr>(constantExpr).getValue() + 1;
+    physicalShape[i] = constant;
+  }
+
+  return physicalShape;
+}
+
+llvm::SmallVector<int64_t>
+LayoutAttr::getStride(ArrayRef<int64_t> logicalShape) const {
+
+  llvm::SmallVector<int64_t> stride(logicalShape.size());
+
+  auto physicalShape = getPhysicalShape(logicalShape);
+
+  // Origin point in the logical space (0, 0, ...)
+  SmallVector<AffineExpr> originPoint(logicalShape.size(),
+                                      getAffineConstantExpr(0, getContext()));
+
+  auto linearMap = getLinear();
+  size_t prevDimElems = 1;
+
+  // Iterates through physical dimensions (starting from the inner one).
+  for (int i = linearMap.getNumResults() - 1; i >= 0; i--) {
+    AffineExpr expr = linearMap.getResult(i);
+
+    // Get coordinate of the i-th dimension (in physical space) of the origin
+    // (in logical space).
+    AffineExpr constantExpr = expr.replaceDims(originPoint);
+    std::int64_t valueAtZero =
+        llvm::cast<AffineConstantExpr>(constantExpr).getValue();
+
+    for (size_t j = 0; j < logicalShape.size(); j++) {
+      if (!expr.isFunctionOfDim(j)) {
+        continue;
+      }
+
+      // Move from the origin point by one in the j-th dimension,
+      // and get the coordinate of the i-th dimension (in physical space).
+      auto newPoint = originPoint;
+      newPoint[j] = getAffineConstantExpr(1, getContext());
+      constantExpr = expr.replaceDims(newPoint);
+      std::int64_t valueAtOne =
+          llvm::cast<AffineConstantExpr>(constantExpr).getValue();
+
+      // One step in the j-th dimension, jumps delta * prevDimElems elements in
+      // the physical space.
+      int64_t delta = valueAtOne - valueAtZero;
+      stride[j] = prevDimElems * delta;
+    }
+
+    prevDimElems *= physicalShape[i];
+  }
+
+  return stride;
 }
 
 llvm::SmallVector<int64_t> LayoutAttr::getShardShape() const {

--- a/python/TTModule.cpp
+++ b/python/TTModule.cpp
@@ -137,12 +137,12 @@ void populateTTModule(py::module &m) {
              return layout;
            })
       .def("wrapped", [](tt::LayoutAttr const &self) { return wrap(self); })
-      .def_property_readonly("stride",
-                             [](tt::LayoutAttr const &self) {
-                               auto stride = self.getStride();
-                               return std::vector<std::int64_t>(stride.begin(),
-                                                                stride.end());
-                             })
+      .def_property_readonly(
+          "stride",
+          [](tt::LayoutAttr const &self, std::vector<int64_t> logicalShape) {
+            auto stride = self.getStride(logicalShape);
+            return std::vector<std::int64_t>(stride.begin(), stride.end());
+          })
       .def_property_readonly("oobval", &tt::LayoutAttr::getOobVal)
       .def_property_readonly("grid_attr", &tt::LayoutAttr::getGrid)
       .def_property_readonly("memref", &tt::LayoutAttr::getMemref)


### PR DESCRIPTION
Initial implementation of stride calculation from the logical shape and the `LayoutAttr`. The strides of the tensors are stored in the Flatbuffer and are used by FE to allocate the tensors.

Needed for E2E scenario (issues: #19 #68)