### PR TITLE
Update LLVM to match xla

### DIFF
--- a/env/CMakeLists.txt
+++ b/env/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.20.0)
 project(ttmlir-toolchain LANGUAGES CXX C)
 
 set(FLATBUFFERS_VERSION "fb9afbafc7dfe226b9db54d4923bfb8839635274")
-set(LLVM_PROJECT_VERSION "llvmorg-18.1.0")
+set(LLVM_PROJECT_VERSION "9ddfe62f5c11e3f65f444209f514029ded2d58b9")
 
 include(ExternalProject)
 

--- a/lib/CAPI/CMakeLists.txt
+++ b/lib/CAPI/CMakeLists.txt
@@ -11,6 +11,7 @@ add_mlir_public_c_api_library(TTMLIRCAPI
 
   LINK_LIBS PUBLIC
   MLIRIR
+  MLIRCAPITransforms
   MLIRSupport
   MLIRTTDialect
   MLIRTTIRDialect

--- a/lib/CAPI/TTAttrs.cpp
+++ b/lib/CAPI/TTAttrs.cpp
@@ -35,7 +35,7 @@ MlirAttribute ttmlirTTChipDescAttrGet(MlirContext ctx, MlirAttribute arch,
                                       unsigned nocDRAMAddressAlignBytes) {
   std::vector<int64_t> gridVec(grid, grid + gridSize);
   return wrap(ChipDescAttr::get(
-      unwrap(ctx), unwrap(arch).dyn_cast<ArchAttr>(), gridVec, l1Size,
+      unwrap(ctx), mlir::dyn_cast<ArchAttr>(unwrap(arch)), gridVec, l1Size,
       numDramChannels, dramChannelSize, nocL1AddressAlignBytes,
       pcieAddressAlignBytes, nocDRAMAddressAlignBytes));
 }
@@ -66,24 +66,24 @@ MlirAttribute ttmlirTTSystemDescAttrGet(
   // Unwrap all of the MlirAttributes
   std::vector<tt::ChipDescAttr> chipDescsUnwrapped;
   for (auto chipDesc : chipDescsRef) {
-    chipDescsUnwrapped.push_back(unwrap(chipDesc).cast<ChipDescAttr>());
+    chipDescsUnwrapped.push_back(mlir::cast<ChipDescAttr>(unwrap(chipDesc)));
   }
 
   std::vector<tt::ChipCapabilityAttr> chipCapabilitiesUnwrapped;
   for (auto chipCapability : chipCapabilitiesRef) {
     chipCapabilitiesUnwrapped.push_back(
-        unwrap(chipCapability).cast<ChipCapabilityAttr>());
+        mlir::cast<ChipCapabilityAttr>(unwrap(chipCapability)));
   }
 
   std::vector<tt::ChipCoordAttr> chipCoordsUnwrapped;
   for (auto chipCoord : chipCoordsRef) {
-    chipCoordsUnwrapped.push_back(unwrap(chipCoord).cast<ChipCoordAttr>());
+    chipCoordsUnwrapped.push_back(mlir::cast<ChipCoordAttr>(unwrap(chipCoord)));
   }
 
   std::vector<tt::ChipChannelAttr> chipChannelsUnwrapped;
   for (auto chipChannel : chipChannelsRef) {
     chipChannelsUnwrapped.push_back(
-        unwrap(chipChannel).cast<ChipChannelAttr>());
+        mlir::cast<ChipChannelAttr>(unwrap(chipChannel)));
   }
 
   return wrap(SystemDescAttr::get(unwrap(ctx), chipDescsUnwrapped,
@@ -95,9 +95,10 @@ MlirAttribute ttmlirTTLayoutAttrGet(MlirContext ctx, MlirAffineMap linear,
                                     unsigned oobVal, MlirAttribute grid,
                                     MlirType memref) {
   mlir::AffineMap affineMap = mlir::AffineMap::getFromOpaquePointer(linear.ptr);
-  return wrap(LayoutAttr::get(
-      unwrap(ctx), affineMap, static_cast<OOBVal>(oobVal),
-      unwrap(grid).cast<GridAttr>(), unwrap(memref).cast<MemRefType>()));
+  return wrap(LayoutAttr::get(unwrap(ctx), affineMap,
+                              static_cast<OOBVal>(oobVal),
+                              mlir::cast<GridAttr>(unwrap(grid)),
+                              mlir::cast<MemRefType>(unwrap(memref))));
 }
 
 MlirAttribute ttmlirTTMemorySpaceAttrGet(MlirContext ctx,

--- a/lib/CAPI/TTKernelTypes.cpp
+++ b/lib/CAPI/TTKernelTypes.cpp
@@ -13,5 +13,5 @@ using namespace mlir::tt::ttkernel;
 MlirType ttmlirTTKernelCBTypeGet(MlirContext ctx, uint64_t address,
                                  uint64_t port, MlirType memrefType) {
   return wrap(CBType::get(unwrap(ctx), address, port,
-                          unwrap(memrefType).cast<mlir::MemRefType>()));
+                          mlir::cast<mlir::MemRefType>(unwrap(memrefType))));
 }

--- a/lib/CAPI/TTTypes.cpp
+++ b/lib/CAPI/TTTypes.cpp
@@ -17,8 +17,8 @@ MlirType ttmlirTTTileTypeGet(MlirContext ctx, unsigned height, unsigned width,
 }
 
 MlirType ttmlirTTDeviceTypeGet(MlirContext ctx, MlirAttribute deviceAttr) {
-  return wrap(
-      DeviceType::get(unwrap(ctx), unwrap(deviceAttr).cast<tt::DeviceAttr>()));
+  return wrap(DeviceType::get(unwrap(ctx),
+                              mlir::cast<tt::DeviceAttr>(unwrap(deviceAttr))));
 }
 
 } // namespace mlir::tt

--- a/lib/Conversion/TosaToTTIR/TosaToTTIR.cpp
+++ b/lib/Conversion/TosaToTTIR/TosaToTTIR.cpp
@@ -47,8 +47,7 @@ public:
       assert(srcOp.getShift() == 0);
     }
 
-    auto outputType =
-        srcOp.getResult().getType().template cast<RankedTensorType>();
+    auto outputType = mlir::cast<RankedTensorType>(srcOp.getResult().getType());
     auto outputTensor = rewriter.create<tensor::EmptyOp>(
         srcOp.getLoc(), outputType.getShape(), outputType.getElementType());
     rewriter.replaceOpWithNewOp<DestOp>(
@@ -78,7 +77,7 @@ struct ConvertTosaToTTIRPass
     // For now keep the same type assuming tosa ops operate on builtin tensor.
     TypeConverter typeConverter;
     typeConverter.addConversion([](Type type) {
-      assert(type.isa<RankedTensorType>() &&
+      assert(isa<RankedTensorType>(type) &&
              "only ranked tensor type supported");
       return type;
     });

--- a/lib/Dialect/TT/IR/TTDialect.cpp
+++ b/lib/Dialect/TT/IR/TTDialect.cpp
@@ -24,15 +24,15 @@ struct TTOpAsmDialectInterface : public OpAsmDialectInterface {
       return AliasResult::OverridableAlias;
     }
     if (llvm::isa<MemorySpaceAttr>(attr)) {
-      os << attr.template cast<MemorySpaceAttr>().getValue();
+      os << mlir::cast<MemorySpaceAttr>(attr).getValue();
       return AliasResult::OverridableAlias;
     }
     if (llvm::isa<IteratorTypeAttr>(attr)) {
-      os << attr.template cast<IteratorTypeAttr>().getValue();
+      os << mlir::cast<IteratorTypeAttr>(attr).getValue();
       return AliasResult::OverridableAlias;
     }
     if (llvm::isa<OperandConstraintAttr>(attr)) {
-      auto value = attr.template cast<OperandConstraintAttr>().getValue();
+      auto value = mlir::cast<OperandConstraintAttr>(attr).getValue();
       if (value == OperandConstraint::Any) {
         os << "any";
       } else if (value == OperandConstraint::AnyDevice) {

--- a/lib/Dialect/TT/IR/TTOpsTypes.cpp
+++ b/lib/Dialect/TT/IR/TTOpsTypes.cpp
@@ -53,9 +53,9 @@ static mlir::MemRefType buildMemRef(::mlir::MLIRContext *context,
                                     ::llvm::ArrayRef<int64_t> shardShape,
                                     ::mlir::Type elementType,
                                     MemorySpace memorySpace) {
-  if (elementType.isa<TileType>()) {
-    shardShape = elementType.cast<TileType>().getTiledShape(
-        ::llvm::SmallVector<int64_t>(shardShape));
+  if (mlir::isa<TileType>(elementType)) {
+    shardShape = mlir::cast<TileType>(elementType)
+                     .getTiledShape(::llvm::SmallVector<int64_t>(shardShape));
   }
   return mlir::MemRefType::get(
       shardShape, elementType,
@@ -246,8 +246,8 @@ LayoutAttr::getStride(ArrayRef<int64_t> logicalShape) const {
 llvm::SmallVector<int64_t> LayoutAttr::getShardShape() const {
   SmallVector<int64_t> shardShape(getMemref().getShape());
   auto elementType = getElementType();
-  if (elementType.isa<TileType>()) {
-    return elementType.cast<TileType>().getScalarShape(shardShape);
+  if (mlir::isa<TileType>(elementType)) {
+    return mlir::cast<TileType>(elementType).getScalarShape(shardShape);
   }
   return shardShape;
 }
@@ -278,9 +278,7 @@ LayoutAttr LayoutAttr::withElementType(::mlir::MLIRContext *context,
 }
 
 MemorySpace LayoutAttr::getMemorySpace() const {
-  return getMemref()
-      .getMemorySpace()
-      .template cast<mlir::tt::MemorySpaceAttr>()
+  return mlir::cast<mlir::tt::MemorySpaceAttr>(getMemref().getMemorySpace())
       .getValue();
 }
 

--- a/lib/Dialect/TTIR/Analysis/LegalGridAnalysis.cpp
+++ b/lib/Dialect/TTIR/Analysis/LegalGridAnalysis.cpp
@@ -10,8 +10,8 @@ bool LegalGridAnalysis::applyOverrides() {
   // Lookup grid size overrides based on location information for current
   // operation.
   //
-  if (analysisInput.gridSizeOverrides && op->getLoc().isa<NameLoc>()) {
-    StringRef loc_str_op_name = op->getLoc().cast<NameLoc>().getName();
+  if (analysisInput.gridSizeOverrides && isa<NameLoc>(op->getLoc())) {
+    StringRef loc_str_op_name = mlir::cast<NameLoc>(op->getLoc()).getName();
     auto gridOverride = analysisInput.gridSizeOverrides->find(loc_str_op_name);
     if (gridOverride != analysisInput.gridSizeOverrides->end()) {
       analysisResult.push_back(GridAttr::get(

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -14,9 +14,9 @@
   ::mlir::RankedTensorType inputTy = getInput().getType();
   ::mlir::RankedTensorType outputTy = getOutput().getType();
   auto inputLayout =
-      inputTy.getEncoding().template dyn_cast_or_null<mlir::tt::LayoutAttr>();
+      mlir::dyn_cast_or_null<mlir::tt::LayoutAttr>(inputTy.getEncoding());
   auto outputLayout =
-      outputTy.getEncoding().template dyn_cast_or_null<mlir::tt::LayoutAttr>();
+      mlir::dyn_cast_or_null<mlir::tt::LayoutAttr>(outputTy.getEncoding());
   if (not inputLayout) {
     return emitOpError("Input tensor type missing layout attribute");
   }
@@ -84,10 +84,8 @@
 // ANCHOR_END: adding_an_op_matmul_ttir_verify
 
 ::mlir::LogicalResult mlir::tt::ttir::AllocOp::verify() {
-  auto layout = getResult()
-                    .getType()
-                    .getEncoding()
-                    .template dyn_cast_or_null<mlir::tt::LayoutAttr>();
+  auto layout = mlir::dyn_cast_or_null<mlir::tt::LayoutAttr>(
+      getResult().getType().getEncoding());
   if (not layout) {
     return emitOpError("Result type missing layout attribute");
   }
@@ -97,9 +95,8 @@
   }
 
   auto memref = layout.getMemref();
-  auto memspace = memref.getMemorySpace()
-                      .template cast<mlir::tt::MemorySpaceAttr>()
-                      .getValue();
+  auto memspace =
+      mlir::cast<mlir::tt::MemorySpaceAttr>(memref.getMemorySpace()).getValue();
   if (memspace != getMemorySpace()) {
     return emitOpError(
         "Input tensor layout memory space must match alloc memory space");

--- a/lib/Dialect/TTIR/Transforms/Passes.cpp
+++ b/lib/Dialect/TTIR/Transforms/Passes.cpp
@@ -45,7 +45,7 @@ public:
       module->setAttr(
           tt::DeviceAttr::name,
           tt::DeviceAttr::get(&getContext(),
-                              systemDesc.cast<tt::SystemDescAttr>()));
+                              mlir::cast<tt::SystemDescAttr>(systemDesc)));
     }
   }
 
@@ -112,9 +112,9 @@ public:
     if (operands.empty()) {
       return false;
     }
-    auto rank = operands[0].getType().cast<RankedTensorType>().getRank();
+    auto rank = mlir::cast<RankedTensorType>(operands[0].getType()).getRank();
     for (auto operand : operands) {
-      if (operand.getType().cast<RankedTensorType>().getRank() != rank) {
+      if (mlir::cast<RankedTensorType>(operand.getType()).getRank() != rank) {
         return false;
       }
     }
@@ -126,7 +126,7 @@ public:
                             mlir::OperandRange operands) {
     assert(sameRank(operands) &&
            "For now all operands must have the same rank");
-    auto rank = operands[0].getType().cast<RankedTensorType>().getRank();
+    auto rank = mlir::cast<RankedTensorType>(operands[0].getType()).getRank();
     SmallVector<AffineMap> indexingMaps(operands.size(),
                                         rewriter.getMultiDimIdentityMap(rank));
     SmallVector<Attribute> iteratorTypes(
@@ -140,7 +140,7 @@ public:
                            mlir::OperandRange operands) {
     assert(sameRank(operands) &&
            "For now all operands must have the same rank");
-    auto rank = operands[0].getType().cast<RankedTensorType>().getRank();
+    auto rank = mlir::cast<RankedTensorType>(operands[0].getType()).getRank();
     assert(rank >= 2 && "Matmul requires rank >= 2");
     auto rank_plus_inner_dim = rank + 1;
 
@@ -263,26 +263,22 @@ public:
                                 PatternRewriter &rewriter) const final {
     auto dpsInterface = cast<DestinationStyleOpInterface>(op.getOperation());
     for (auto &operand : op->getOpOperands()) {
-      auto encoding = operand.get()
-                          .getType()
-                          .template cast<RankedTensorType>()
-                          .getEncoding();
+      auto encoding =
+          mlir::cast<RankedTensorType>(operand.get().getType()).getEncoding();
       if (not encoding) {
         return failure(); // Hasn't been type converted yet
       }
 
       auto blockArg = op.getRegion().getArgument(operand.getOperandNumber());
-      if (blockArg.getType().isa<MemRefType>()) {
+      if (mlir::isa<MemRefType>(blockArg.getType())) {
         return failure(); // Already lowered
       }
 
       // Rewire the operand to the layout op
       rewriter.modifyOpInPlace(op, [&]() {
-        auto layout = operand.get()
-                          .getType()
-                          .template cast<RankedTensorType>()
-                          .getEncoding()
-                          .template cast<LayoutAttr>();
+        auto layout = mlir::cast<LayoutAttr>(
+            mlir::cast<RankedTensorType>(operand.get().getType())
+                .getEncoding());
 
         blockArg.setType(layout.getMemref());
 
@@ -320,7 +316,7 @@ public:
 };
 
 inline MemorySpace getMemorySpace(MemRefType memref) {
-  return memref.getMemorySpace().template cast<MemorySpaceAttr>().getValue();
+  return mlir::cast<MemorySpaceAttr>(memref.getMemorySpace()).getValue();
 }
 
 inline MemorySpace getMemorySpace(LayoutAttr layout) {
@@ -329,7 +325,7 @@ inline MemorySpace getMemorySpace(LayoutAttr layout) {
 
 inline MemorySpace getMemorySpace(RankedTensorType ty) {
   assert(ty.getEncoding());
-  auto layout = ty.getEncoding().template cast<LayoutAttr>();
+  auto layout = mlir::cast<LayoutAttr>(ty.getEncoding());
   return getMemorySpace(layout);
 }
 
@@ -420,8 +416,8 @@ public:
 static std::optional<Value>
 createToLayoutOp(PatternRewriter &rewriter, Location loc, Value input,
                  OperandConstraint operandConstraint) {
-  auto ty = input.getType().cast<RankedTensorType>();
-  auto currLayout = ty.getEncoding().cast<LayoutAttr>();
+  auto ty = mlir::cast<RankedTensorType>(input.getType());
+  auto currLayout = mlir::cast<LayoutAttr>(ty.getEncoding());
   auto currMemorySpace = currLayout.getMemorySpace();
   auto desiredMemorySpace = uppermostMemorySpace(operandConstraint);
   if (currMemorySpace == desiredMemorySpace) {
@@ -454,17 +450,15 @@ public:
     bool modified = false;
     for (auto &operand : op->getOpOperands()) {
       bool isResult = dpsInterface.isDpsInit(&operand);
-      auto encoding = operand.get()
-                          .getType()
-                          .template cast<RankedTensorType>()
-                          .getEncoding();
+      auto encoding =
+          mlir::cast<RankedTensorType>(operand.get().getType()).getEncoding();
       if (not encoding) {
         return failure(); // Hasn't been type converted yet
       }
 
       auto operandConstraint =
-          op.getOperandConstraints()[operand.getOperandNumber()]
-              .template cast<OperandConstraintAttr>()
+          mlir::cast<OperandConstraintAttr>(
+              op.getOperandConstraints()[operand.getOperandNumber()])
               .getValue();
       auto desiredLayout = createToLayoutOp(rewriter, op.getLoc(),
                                             operand.get(), operandConstraint);
@@ -578,7 +572,7 @@ inline uint64_t getLayoutMemrefSizeBytes(LayoutAttr layout) {
 
 inline uint64_t getTensorMemrefSizeBytes(RankedTensorType ty) {
   assert(ty.getEncoding());
-  auto layout = ty.getEncoding().template cast<LayoutAttr>();
+  auto layout = mlir::cast<LayoutAttr>(ty.getEncoding());
   return getLayoutMemrefSizeBytes(layout);
 }
 
@@ -648,7 +642,7 @@ public:
           liveness.getLiveness(&func.getBody().front());
       func->walk([&](tensor::EmptyOp empty) {
         auto resultTy =
-            empty.getResult().getType().template cast<RankedTensorType>();
+            mlir::cast<RankedTensorType>(empty.getResult().getType());
         assert(resultTy.getEncoding());
 
         auto [startOp, endOp] =
@@ -689,12 +683,12 @@ public:
     // Get the max grid size from the system description.
     //
     assert(moduleOp->hasAttr(tt::DeviceAttr::name));
-    GridAttr max_grid = moduleOp->getAttr(tt::DeviceAttr::name)
-                            .cast<tt::DeviceAttr>()
-                            .getGrid();
+    GridAttr max_grid =
+        mlir::cast<tt::DeviceAttr>(moduleOp->getAttr(tt::DeviceAttr::name))
+            .getGrid();
 
-    SystemDescAttr systemDesc =
-        moduleOp->getAttr(tt::SystemDescAttr::name).cast<tt::SystemDescAttr>();
+    SystemDescAttr systemDesc = mlir::cast<tt::SystemDescAttr>(
+        moduleOp->getAttr(tt::SystemDescAttr::name));
     ChipDescAttr chipDesc = systemDesc.getChipDescs()[0];
     llvm::DenseMap<Operation *, std::vector<GridAttr>> legalGrids;
 
@@ -704,7 +698,7 @@ public:
       }
 
       RankedTensorType tensorType =
-          op->getResult(0).getType().template cast<RankedTensorType>();
+          mlir::cast<RankedTensorType>(op->getResult(0).getType());
       LegalGridAnalysis legalGridAnalysis =
           getChildAnalysis<LegalGridAnalysis>(op);
       legalGridAnalysis.init(LegalGridAnalysisInput(
@@ -733,9 +727,8 @@ public:
         }
 
         RankedTensorType tensorType =
-            op->getResult(0).getType().template cast<RankedTensorType>();
-        LayoutAttr layout =
-            tensorType.getEncoding().template cast<LayoutAttr>();
+            mlir::cast<RankedTensorType>(op->getResult(0).getType());
+        LayoutAttr layout = mlir::cast<LayoutAttr>(tensorType.getEncoding());
         llvm::ArrayRef<int64_t> tensorShape = tensorType.getShape();
 
         // Update the output layout attribute with the new grid size.

--- a/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
@@ -46,7 +46,7 @@ static ttkernel::ThreadType getRegionThreadType(mlir::Region *region) {
   } else {
     assert(false && "Unexpected parent op in getRegionThreadType");
   }
-  return threadType.cast<ttkernel::ThreadTypeAttr>().getValue();
+  return mlir::cast<ttkernel::ThreadTypeAttr>(threadType).getValue();
 }
 
 static bool insideThread(mlir::Operation *op, ttkernel::ThreadType threadType) {

--- a/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
+++ b/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
@@ -18,12 +18,12 @@ namespace mlir::tt::ttmetal {
   ::mlir::RankedTensorType inputTy = getInput().getType();
   ::mlir::RankedTensorType outputTy = getOutput().getType();
   auto inputLayout =
-      inputTy.getEncoding().template dyn_cast_or_null<mlir::tt::LayoutAttr>();
+      mlir::dyn_cast_or_null<mlir::tt::LayoutAttr>(inputTy.getEncoding());
   if (not inputLayout) {
     return emitOpError("Input tensor missing layout attribute");
   }
   auto outputLayout =
-      outputTy.getEncoding().template dyn_cast_or_null<mlir::tt::LayoutAttr>();
+      mlir::dyn_cast_or_null<mlir::tt::LayoutAttr>(outputTy.getEncoding());
   if (not outputLayout) {
     return emitOpError("Input tensor missing layout attribute");
   }
@@ -40,12 +40,12 @@ namespace mlir::tt::ttmetal {
   ::mlir::RankedTensorType inputTy = getInput().getType();
   ::mlir::RankedTensorType outputTy = getOutput().getType();
   auto inputLayout =
-      inputTy.getEncoding().template dyn_cast_or_null<mlir::tt::LayoutAttr>();
+      mlir::dyn_cast_or_null<mlir::tt::LayoutAttr>(inputTy.getEncoding());
   if (not inputLayout) {
     return emitOpError("Input tensor missing layout attribute");
   }
   auto outputLayout =
-      outputTy.getEncoding().template dyn_cast_or_null<mlir::tt::LayoutAttr>();
+      mlir::dyn_cast_or_null<mlir::tt::LayoutAttr>(outputTy.getEncoding());
   if (not outputLayout) {
     return emitOpError("Input tensor missing layout attribute");
   }
@@ -59,10 +59,8 @@ namespace mlir::tt::ttmetal {
 }
 
 ::mlir::LogicalResult AllocOp::verify() {
-  auto layout = getResult()
-                    .getType()
-                    .getEncoding()
-                    .template dyn_cast_or_null<mlir::tt::LayoutAttr>();
+  auto layout = mlir::dyn_cast_or_null<mlir::tt::LayoutAttr>(
+      getResult().getType().getEncoding());
   if (not layout) {
     return emitOpError("Result type missing layout attribute");
   }
@@ -72,9 +70,8 @@ namespace mlir::tt::ttmetal {
   }
 
   auto memref = layout.getMemref();
-  auto memspace = memref.getMemorySpace()
-                      .template cast<mlir::tt::MemorySpaceAttr>()
-                      .getValue();
+  auto memspace =
+      mlir::cast<mlir::tt::MemorySpaceAttr>(memref.getMemorySpace()).getValue();
   if (memspace != getMemorySpace()) {
     return emitOpError(
         "Input tensor layout memory space must match alloc memory space");
@@ -97,10 +94,8 @@ namespace mlir::tt::ttmetal {
 ::mlir::LogicalResult DispatchOp::verify() {
   // Assert inputs/outputs device memspace
   for (auto operand : getOperands()) {
-    auto layout = operand.getType()
-                      .cast<mlir::RankedTensorType>()
-                      .getEncoding()
-                      .template dyn_cast_or_null<mlir::tt::LayoutAttr>();
+    auto layout = mlir::dyn_cast_or_null<mlir::tt::LayoutAttr>(
+        mlir::cast<mlir::RankedTensorType>(operand.getType()).getEncoding());
     if (not layout) {
       return emitOpError("Input tensor missing layout attribute");
     }
@@ -112,7 +107,7 @@ namespace mlir::tt::ttmetal {
   // Assert block inputs are CBs
   for (auto &region : getRegions()) {
     for (auto arg : region.getArguments()) {
-      if (not arg.getType().isa<ttkernel::CBType>()) {
+      if (not mlir::isa<ttkernel::CBType>(arg.getType())) {
         return emitOpError("Block inputs must be CBType");
       }
     }

--- a/lib/Dialect/TTMetal/Transforms/KernelsToCpp.cpp
+++ b/lib/Dialect/TTMetal/Transforms/KernelsToCpp.cpp
@@ -98,7 +98,7 @@ LogicalResult emitDispatchOpRegionAsCpp(DispatchOp origOp,
   OpBuilder builder(op.getOperation());
 
   auto threadTypeAttr =
-      op.getThreadTypes()[regionNumber].cast<ttkernel::ThreadTypeAttr>();
+      mlir::cast<ttkernel::ThreadTypeAttr>(op.getThreadTypes()[regionNumber]);
 
   // Replace the original block with a the new block containing a module op
   auto module = builder.create<mlir::ModuleOp>(

--- a/lib/Dialect/TTMetal/Transforms/Passes.cpp
+++ b/lib/Dialect/TTMetal/Transforms/Passes.cpp
@@ -36,15 +36,15 @@ public:
 
   LogicalResult matchAndRewrite(ttir::ToLayoutOp op,
                                 PatternRewriter &rewriter) const final {
-    auto inputTy = op.getInput().getType().template cast<RankedTensorType>();
-    auto outputTy = op.getType().template cast<RankedTensorType>();
+    auto inputTy = mlir::cast<RankedTensorType>(op.getInput().getType());
+    auto outputTy = mlir::cast<RankedTensorType>(op.getType());
     if (not inputTy.getEncoding() || not outputTy.getEncoding()) {
       return failure();
     }
-    assert(inputTy.getEncoding().isa<tt::LayoutAttr>());
-    assert(outputTy.getEncoding().isa<tt::LayoutAttr>());
-    auto inputLayout = inputTy.getEncoding().template cast<tt::LayoutAttr>();
-    auto outputLayout = outputTy.getEncoding().template cast<tt::LayoutAttr>();
+    assert(mlir::isa<tt::LayoutAttr>(inputTy.getEncoding()));
+    assert(mlir::isa<tt::LayoutAttr>(outputTy.getEncoding()));
+    auto inputLayout = mlir::cast<tt::LayoutAttr>(inputTy.getEncoding());
+    auto outputLayout = mlir::cast<tt::LayoutAttr>(outputTy.getEncoding());
     if (inputLayout.isSystemMemorySpace()) {
       assert(outputLayout.isDeviceMemorySpace());
       rewriter.replaceOpWithNewOp<ttmetal::HostWriteOp>(
@@ -121,10 +121,10 @@ public:
     SmallVector<Type> rewrittenBlockArgumentTypes;
     for (auto arg : blockArguments) {
       auto address = lookupAddress(arg);
-      auto port = operand_cb_port_mapping[arg.getArgNumber()]
-                      .cast<IntegerAttr>()
-                      .getInt();
-      auto memref = arg.getType().cast<MemRefType>();
+      auto port =
+          mlir::cast<IntegerAttr>(operand_cb_port_mapping[arg.getArgNumber()])
+              .getInt();
+      auto memref = mlir::cast<MemRefType>(arg.getType());
       rewrittenBlockArgumentTypes.push_back(
           rewriter.getType<ttkernel::CBType>(address, port, memref));
     }

--- a/lib/Dialect/TTMetal/Transforms/SerializeToBinary.cpp
+++ b/lib/Dialect/TTMetal/Transforms/SerializeToBinary.cpp
@@ -111,8 +111,8 @@ public:
     CQBuilder cqBuilder(&fbb);
 
     ModuleOp module = getOperation();
-    auto systemDesc =
-        module->getAttr(tt::SystemDescAttr::name).cast<tt::SystemDescAttr>();
+    auto systemDesc = mlir::cast<tt::SystemDescAttr>(
+        module->getAttr(tt::SystemDescAttr::name));
     func::FuncOp entry = dyn_cast<func::FuncOp>(*module.getRegion().op_begin());
     assert(entry && "expected an entry function");
     cqBuilder.name = entry.getSymName().data();
@@ -142,12 +142,12 @@ public:
           assert(succeeded(result) &&
                  "failed to emit dispatch op region as cpp");
           auto threadType =
-              dispatchOp.getThreadTypes()[region.getRegionNumber()]
-                  .cast<ttkernel::ThreadTypeAttr>()
+              mlir::cast<ttkernel::ThreadTypeAttr>(
+                  dispatchOp.getThreadTypes()[region.getRegionNumber()])
                   .getValue();
           ::tt::target::Dim2dRange core_range =
-              toFlatbuffer(dispatchOp.getCoreRanges()[region.getRegionNumber()]
-                               .cast<CoreRangeAttr>());
+              toFlatbuffer(mlir::cast<CoreRangeAttr>(
+                  dispatchOp.getCoreRanges()[region.getRegionNumber()]));
           ::tt::target::Dim2dRange(::tt::target::Dim2d(0, 0),
                                    ::tt::target::Dim2d(0, 0));
           std::vector<::flatbuffers::Offset<::tt::target::CBRef>> cbs;

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -18,9 +18,9 @@ namespace mlir::tt::ttnn {
   ::mlir::RankedTensorType inputTy = getInput().getType();
   ::mlir::RankedTensorType outputTy = getOutput().getType();
   auto inputLayout =
-      inputTy.getEncoding().template dyn_cast_or_null<mlir::tt::LayoutAttr>();
+      mlir::dyn_cast_or_null<mlir::tt::LayoutAttr>(inputTy.getEncoding());
   auto outputLayout =
-      outputTy.getEncoding().template dyn_cast_or_null<mlir::tt::LayoutAttr>();
+      mlir::dyn_cast_or_null<mlir::tt::LayoutAttr>(outputTy.getEncoding());
   if (not inputLayout) {
     return emitOpError("Input tensor type missing layout attribute");
   }
@@ -88,10 +88,8 @@ namespace mlir::tt::ttnn {
 // ANCHOR_END: adding_an_op_matmul_ttnn_verify
 
 ::mlir::LogicalResult AllocOp::verify() {
-  auto layout = getResult()
-                    .getType()
-                    .getEncoding()
-                    .template dyn_cast_or_null<mlir::tt::LayoutAttr>();
+  auto layout = mlir::dyn_cast_or_null<mlir::tt::LayoutAttr>(
+      getResult().getType().getEncoding());
   if (not layout) {
     return emitOpError("Result type missing layout attribute");
   }
@@ -101,9 +99,8 @@ namespace mlir::tt::ttnn {
   }
 
   auto memref = layout.getMemref();
-  auto memspace = memref.getMemorySpace()
-                      .template cast<mlir::tt::MemorySpaceAttr>()
-                      .getValue();
+  auto memspace =
+      mlir::cast<mlir::tt::MemorySpaceAttr>(memref.getMemorySpace()).getValue();
   if (memspace != getMemorySpace()) {
     return emitOpError(
         "Input tensor layout memory space must match alloc memory space");

--- a/lib/Dialect/TTNN/Transforms/Passes.cpp
+++ b/lib/Dialect/TTNN/Transforms/Passes.cpp
@@ -32,8 +32,8 @@ public:
   void runOnOperation() final {
     ModuleOp module = getOperation();
     OpBuilder builder(module);
-    auto systemDesc =
-        module->getAttr(tt::SystemDescAttr::name).cast<tt::SystemDescAttr>();
+    auto systemDesc = llvm::cast<tt::SystemDescAttr>(
+        module->getAttr(tt::SystemDescAttr::name));
     auto chipDescIndices = systemDesc.getChipDescIndices();
     assert(chipDescIndices.size() == 1 && "Multiple chips not supported yet");
 

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -56,7 +56,7 @@ createOperation(FlatbufferObjectCache &cache, ::flatbuffers::Offset<OpT> op,
 ::flatbuffers::Offset<::tt::target::ttnn::OpenDeviceOp>
 createOp(FlatbufferObjectCache &cache, OpenDeviceOp op) {
   auto result = op.getResult();
-  auto resultType = result.getType().cast<DeviceType>();
+  auto resultType = mlir::cast<DeviceType>(result.getType());
   ::tt::target::Dim2d grid =
       toFlatbuffer(cache, resultType.getDesc().getGrid());
   auto chipIds = toFlatbuffer(cache, resultType.getDesc().getChipIds());
@@ -228,10 +228,9 @@ std::shared_ptr<void> ttnnToFlatbuffer(Operation *op) {
   ::tt::target::Version binaryVersion(ttmlirVersion.major, ttmlirVersion.minor,
                                       ttmlirVersion.patch);
 
-  auto systemDesc = toFlatbuffer(
-      cache,
-      module->getAttr(tt::SystemDescAttr::name).cast<tt::SystemDescAttr>());
-
+  auto systemDesc =
+      toFlatbuffer(cache, mlir::cast<tt::SystemDescAttr>(
+                              module->getAttr(tt::SystemDescAttr::name)));
   func::FuncOp entry = dyn_cast<func::FuncOp>(*module.getRegion().op_begin());
   assert(entry && "Expected an entry function");
   Program<::tt::target::ttnn::Operation> program =

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -49,6 +49,7 @@ declare_mlir_python_extension(TTMLIRPythonExtensions.Main
     TTKernelModule.cpp
     Overrides.cpp
   EMBED_CAPI_LINK_LIBS
+    MLIRCAPITransforms
     TTMLIRCAPI
   PRIVATE_LINK_LIBS
     LLVMSupport

--- a/python/TTKernelModule.cpp
+++ b/python/TTKernelModule.cpp
@@ -20,9 +20,10 @@ void populateTTKernelModule(py::module &m) {
                     return ttmlirTTKernelCBTypeGet(ctx, address, port,
                                                    memrefType);
                   })
-      .def_static(
-          "cast",
-          [](MlirType &ty) { return unwrap(ty).cast<tt::ttkernel::CBType>(); })
+      .def_static("cast",
+                  [](MlirType &ty) {
+                    return mlir::cast<tt::ttkernel::CBType>(unwrap(ty));
+                  })
       .def_property_readonly("shape",
                              [](tt::ttkernel::CBType &cb) {
                                return std::vector<int64_t>(cb.getShape());

--- a/python/TTModule.cpp
+++ b/python/TTModule.cpp
@@ -22,9 +22,10 @@ void populateTTModule(py::module &m) {
                      uint32_t oobValValue) {
                     return wrap(tt::LayoutAttr::get(
                         unwrap(ctx),
-                        unwrap(rankedTensorType).cast<RankedTensorType>(),
+                        mlir::cast<RankedTensorType>(unwrap(rankedTensorType)),
                         static_cast<tt::MemorySpace>(memorySpaceValue),
-                        unwrap(grid).cast<tt::GridAttr>(), collapseIntervals,
+                        mlir::cast<tt::GridAttr>(unwrap(grid)),
+                        collapseIntervals,
                         static_cast<tt::OOBVal>(oobValValue)));
                   })
       .def_static("with_grid",
@@ -32,41 +33,45 @@ void populateTTModule(py::module &m) {
                      std::vector<std::int64_t> tensorShape, MlirAttribute grid,
                      std::vector<std::pair<std::int64_t, std::int64_t>>
                          collapseIntervals) {
-                    return wrap(unwrap(self).cast<tt::LayoutAttr>().withGrid(
-                        unwrap(ctx), tensorShape,
-                        unwrap(grid).cast<tt::GridAttr>(), collapseIntervals));
+                    return wrap(
+                        mlir::cast<tt::LayoutAttr>(unwrap(self))
+                            .withGrid(unwrap(ctx), tensorShape,
+                                      mlir::cast<tt::GridAttr>(unwrap(grid)),
+                                      collapseIntervals));
                   })
       .def_static("with_grid_",
                   [](MlirContext ctx, MlirAttribute self,
                      std::vector<std::int64_t> tensorShape, MlirAttribute grid,
                      std::vector<std::pair<std::int64_t, std::int64_t>>
                          collapseIntervals) {
-                    return unwrap(self).cast<tt::LayoutAttr>().withGrid(
-                        unwrap(ctx), tensorShape,
-                        unwrap(grid).cast<tt::GridAttr>(), collapseIntervals);
+                    return mlir::cast<tt::LayoutAttr>(unwrap(self))
+                        .withGrid(unwrap(ctx), tensorShape,
+                                  mlir::cast<tt::GridAttr>(unwrap(grid)),
+                                  collapseIntervals);
                   })
       .def_static(
           "with_element_type",
           [](MlirContext ctx, MlirAttribute self, MlirType elementType) {
-            return wrap(unwrap(self).cast<tt::LayoutAttr>().withElementType(
-                unwrap(ctx), unwrap(elementType)));
+            return wrap(mlir::cast<tt::LayoutAttr>(unwrap(self))
+                            .withElementType(unwrap(ctx), unwrap(elementType)));
           })
       .def_static(
           "with_element_type_",
           [](MlirContext ctx, MlirAttribute self, MlirType elementType) {
-            return unwrap(self).cast<tt::LayoutAttr>().withElementType(
-                unwrap(ctx), unwrap(elementType));
+            return mlir::cast<tt::LayoutAttr>(unwrap(self))
+                .withElementType(unwrap(ctx), unwrap(elementType));
           })
       .def("getLayout",
            [](MlirType &type) {
              assert(isa<RankedTensorType>(
                  unwrap(type))); // Make sure that this is operating on a
                                  // RankedTensorType object
-             RankedTensorType tensor = unwrap(type).cast<RankedTensorType>();
+             RankedTensorType tensor =
+                 mlir::cast<RankedTensorType>(unwrap(type));
              assert(tensor.getEncoding()); // Make sure that this Tensor has an
                                            // encoding value
              tt::LayoutAttr layout =
-                 tensor.getEncoding().template cast<tt::LayoutAttr>();
+                 mlir::cast<tt::LayoutAttr>(tensor.getEncoding());
              return layout;
            })
       .def("wrapped", [](tt::LayoutAttr const &self) { return wrap(self); })
@@ -111,7 +116,7 @@ void populateTTModule(py::module &m) {
                             unsigned pcieAddressAlignBytes,
                             unsigned nocDRAMAddressAlignBytes) {
         return wrap(tt::ChipDescAttr::get(
-            unwrap(ctx), unwrap(arch).cast<tt::ArchAttr>(), grid, l1Size,
+            unwrap(ctx), mlir::cast<tt::ArchAttr>(unwrap(arch)), grid, l1Size,
             numDramChannels, dramChannelSize, nocL1AddressAlignBytes,
             pcieAddressAlignBytes, nocDRAMAddressAlignBytes));
       });
@@ -139,22 +144,22 @@ void populateTTModule(py::module &m) {
         std::vector<tt::ChipDescAttr> chipDescsUnwrapped;
         for (auto chipDesc : chipDescs) {
           chipDescsUnwrapped.push_back(
-              unwrap(chipDesc).cast<tt::ChipDescAttr>());
+              mlir::cast<tt::ChipDescAttr>(unwrap(chipDesc)));
         }
         std::vector<tt::ChipCapabilityAttr> chipCapabilitiesUnwrapped;
         for (auto chipCapability : chipCapabilities) {
           chipCapabilitiesUnwrapped.push_back(
-              unwrap(chipCapability).cast<tt::ChipCapabilityAttr>());
+              mlir::cast<tt::ChipCapabilityAttr>(unwrap(chipCapability)));
         }
         std::vector<tt::ChipCoordAttr> chipCoordsUnwrapped;
         for (auto chipCoord : chipCoords) {
           chipCoordsUnwrapped.push_back(
-              unwrap(chipCoord).cast<tt::ChipCoordAttr>());
+              mlir::cast<tt::ChipCoordAttr>(unwrap(chipCoord)));
         }
         std::vector<tt::ChipChannelAttr> chipChannelsUnwrapped;
         for (auto chipChannel : chipChannels) {
           chipChannelsUnwrapped.push_back(
-              unwrap(chipChannel).cast<tt::ChipChannelAttr>());
+              mlir::cast<tt::ChipChannelAttr>(unwrap(chipChannel)));
         }
         return wrap(tt::SystemDescAttr::get(
             unwrap(ctx), chipDescsUnwrapped, chipDescIndices,
@@ -190,7 +195,7 @@ void populateTTModule(py::module &m) {
   py::class_<tt::DeviceType>(m, "DeviceType")
       .def_static("get", [](MlirContext ctx, MlirAttribute deviceAttr) {
         return wrap(tt::DeviceType::get(
-            unwrap(ctx), unwrap(deviceAttr).cast<tt::DeviceAttr>()));
+            unwrap(ctx), mlir::cast<tt::DeviceAttr>(unwrap(deviceAttr))));
       });
 
   py::class_<tt::DeviceAttr>(m, "DeviceAttr")
@@ -202,7 +207,7 @@ void populateTTModule(py::module &m) {
                 unwrap(ctx), shape, unwrap(physicalGridMapping), chipIds));
           })
       .def("unwrap", [](MlirAttribute const &self) {
-        return unwrap(self).cast<tt::DeviceAttr>();
+        return mlir::cast<tt::DeviceAttr>(unwrap(self));
       });
 
   py::class_<tt::TileType>(m, "TileType")


### PR DESCRIPTION
1. Update LLVM version to match xla
2. Add required patches for xla
3. Modify the deprecated calls