### PR TITLE
Change ttir -> ttnn to use dialect conversion API

### DIFF
--- a/include/ttmlir/Conversion/Passes.h
+++ b/include/ttmlir/Conversion/Passes.h
@@ -5,7 +5,9 @@
 #ifndef TTMLIR_CONVERSION_PASSES_H
 #define TTMLIR_CONVERSION_PASSES_H
 
+#include "ttmlir/Conversion/TTIRToTTNN/TTIRToTTNN.h"
 #include "ttmlir/Conversion/TTNNToEmitC/TTNNToEmitC.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIR.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNN.h"
 
 #include "mlir/Dialect/EmitC/IR/EmitC.h"

--- a/include/ttmlir/Conversion/Passes.td
+++ b/include/ttmlir/Conversion/Passes.td
@@ -13,4 +13,10 @@ def ConvertTTNNToEmitC : Pass<"convert-ttnn-to-emitc", "::mlir::func::FuncOp"> {
   let dependentDialects = ["mlir::emitc::EmitCDialect", "mlir::tt::ttnn::TTNNDialect"];
 }
 
+def ConvertTTIRToTTNN: Pass<"convert-ttir-to-ttnn", "::mlir::ModuleOp"> {
+  let summary = "Convert TTIR dialect to TTNN dialect.";
+  let constructor = "createConvertTTIRToTTNNPass()";
+  let dependentDialects = ["mlir::tt::ttir::TTIRDialect", "mlir::tt::ttnn::TTNNDialect"];
+}
+
 #endif // TTMLIR_CONVERSION_PASSES

--- a/include/ttmlir/Conversion/TTIRToTTNN/TTIRToTTNN.h
+++ b/include/ttmlir/Conversion/TTIRToTTNN/TTIRToTTNN.h
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_CONVERSION_TTIRTOTTNN_TTIRTOTTNN_H
+#define TTMLIR_CONVERSION_TTIRTOTTNN_TTIRTOTTNN_H
+
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir::tt {
+
+void populateTTIRToTTNNPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
+                                TypeConverter &typeConverter);
+
+std::unique_ptr<OperationPass<ModuleOp>> createConvertTTIRToTTNNPass();
+
+} // namespace mlir::tt
+
+#endif // TTMLIR_CONVERSION_TTIRTOTTNN_TTIRTOTTNN_H

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -14,11 +14,4 @@ def TTNNOpenDevice: Pass<"ttnn-open-device", "::mlir::ModuleOp"> {
   }];
 }
 
-def ConvertTTIRToTTNN: Pass<"convert-ttir-to-ttnn", "::mlir::ModuleOp"> {
-  let summary = "";
-  let description = [{
-    todo
-  }];
-}
-
 #endif

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(TTNNToEmitC)
+add_subdirectory(TTIRToTTNN)

--- a/lib/Conversion/PassDetail.h
+++ b/lib/Conversion/PassDetail.h
@@ -5,6 +5,7 @@
 #ifndef TTMLIR_LIB_CONVERSION_PASSDETAIL_H
 #define TTMLIR_LIB_CONVERSION_PASSDETAIL_H
 
+#include "ttmlir/Dialect/TTIR/IR/TTIR.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNN.h"
 
 #include "mlir/Dialect/EmitC/IR/EmitC.h"

--- a/lib/Conversion/TTIRToTTNN/CMakeLists.txt
+++ b/lib/Conversion/TTIRToTTNN/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_mlir_library(TTMLIRTTIRToTTNN
+  TTIRToTTNN.cpp
+  TTIRToTTNNPass.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${PROJECT_SOURCE_DIR}/include/ttmlir/Conversion/TTIRToTTNN
+
+  DEPENDS
+  TTMLIRConversionPassIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRPass
+  MLIRTransformUtils
+)

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Conversion/TTIRToTTNN/TTIRToTTNN.h"
+
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+using namespace mlir;
+using namespace mlir::tt;
+
+namespace {
+
+static Value findDevice(Operation *op) {
+  Block *block = op->getBlock();
+  for (auto &op : block->getOperations()) {
+    if (auto deviceOp = dyn_cast<ttnn::OpenDeviceOp>(op)) {
+      return deviceOp.getResult();
+    }
+  }
+  assert(false && "No device found");
+  return nullptr;
+}
+
+class TensorEmptyToFullConversionPattern
+    : public OpConversionPattern<tensor::EmptyOp> {
+public:
+  using OpConversionPattern<tensor::EmptyOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(tensor::EmptyOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto device = findDevice(op);
+    rewriter.replaceOpWithNewOp<ttnn::FullOp>(
+        op, this->getTypeConverter()->convertType(op.getType()), device,
+        rewriter.getF32FloatAttr(0.0));
+    return success();
+  }
+};
+
+class LayoutOpConversionPattern : public OpConversionPattern<ttir::LayoutOp> {
+public:
+  using OpConversionPattern<ttir::LayoutOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttir::LayoutOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<ttnn::ToMemoryConfigOp>(
+        op, this->getTypeConverter()->convertType(op.getType()),
+        adaptor.getInput(), adaptor.getOutput());
+    return success();
+  }
+};
+
+template <typename TTIROp, typename TTNNOp,
+          typename OpAdaptor = typename TTIROp::Adaptor>
+class ElementwiseBinaryOpConversionPattern
+    : public OpConversionPattern<TTIROp> {
+public:
+  using OpConversionPattern<TTIROp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(TTIROp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    SmallVector<Type> resultTypes;
+    if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(),
+                                                      resultTypes))) {
+      return failure();
+    }
+
+    rewriter.replaceOpWithNewOp<TTNNOp>(op, resultTypes, adaptor.getInputs(),
+                                        adaptor.getOutputs());
+    return success();
+  }
+};
+
+template <typename TTIROp, typename TTNNOp,
+          typename OpAdaptor = typename TTIROp::Adaptor>
+class ReductionOpConversionPattern : public OpConversionPattern<TTIROp> {
+public:
+  using OpConversionPattern<TTIROp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(TTIROp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<TTNNOp>(
+        op, this->getTypeConverter()->convertType(op.getType()),
+        adaptor.getInput(), adaptor.getOutput(), adaptor.getKeepDim(),
+        adaptor.getDimArg().value_or(nullptr));
+    return success();
+  }
+};
+
+class SoftmaxOpConversionPattern : public OpConversionPattern<ttir::SoftmaxOp> {
+public:
+  using OpConversionPattern<ttir::SoftmaxOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttir::SoftmaxOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<ttnn::SoftmaxOp>(
+        op, this->getTypeConverter()->convertType(op.getType()),
+        adaptor.getInput(), adaptor.getOutput(), adaptor.getDimension());
+    return success();
+  }
+};
+
+} // namespace
+
+// ANCHOR: adding_an_op_matmul_op_rewriter
+class MatmulOpConversionPattern : public OpConversionPattern<ttir::MatmulOp> {
+public:
+  using OpConversionPattern<ttir::MatmulOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttir::MatmulOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<ttnn::MatmulOp>(
+        op, this->getTypeConverter()->convertType(op.getType()), adaptor.getA(),
+        adaptor.getB(), adaptor.getOutput());
+    return success();
+  }
+};
+// ANCHOR_END: adding_an_op_matmul_op_rewriter
+
+namespace mlir::tt {
+
+void populateTTIRToTTNNPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
+                                TypeConverter &typeConverter) {
+  // clang-format off
+  // ANCHOR: adding_an_op_matmul_rewrite_pattern_set
+  patterns
+      .add<TensorEmptyToFullConversionPattern,
+           LayoutOpConversionPattern,
+           ElementwiseBinaryOpConversionPattern<ttir::AddOp, ttnn::AddOp>,
+           ElementwiseBinaryOpConversionPattern<ttir::SubtractOp, ttnn::SubtractOp>,
+           ElementwiseBinaryOpConversionPattern<ttir::MultiplyOp, ttnn::MultiplyOp>,
+           ElementwiseBinaryOpConversionPattern<ttir::GreaterEqualOp, ttnn::GreaterEqualOp>,
+           ElementwiseBinaryOpConversionPattern<ttir::ReluOp, ttnn::ReluOp>,
+           ReductionOpConversionPattern<ttir::SumOp, ttnn::SumOp>,
+           SoftmaxOpConversionPattern,
+           MatmulOpConversionPattern
+           >(typeConverter, ctx);
+  // ANCHOR_END: adding_an_op_matmul_rewrite_pattern_set
+  // clang-format on
+}
+
+} // namespace mlir::tt

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNNPass.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNNPass.cpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Conversion/TTIRToTTNN/TTIRToTTNN.h"
+
+#include "../PassDetail.h"
+
+#include "mlir/Dialect/Func/Transforms/FuncConversions.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIR.h"
+
+using namespace mlir;
+using namespace mlir::tt;
+
+namespace {
+
+struct ConvertTTIRToTTNNPass
+    : public ttnn::ConvertTTIRToTTNNBase<ConvertTTIRToTTNNPass> {
+  void runOnOperation() final {
+    mlir::ConversionTarget target(getContext());
+    target.addLegalDialect<ttnn::TTNNDialect>();
+    target.addIllegalDialect<ttir::TTIRDialect>();
+
+    TypeConverter typeConverter;
+    // All types map 1:1.
+    typeConverter.addConversion([](Type type) { return type; });
+
+    RewritePatternSet patterns(&getContext());
+    populateTTIRToTTNNPatterns(&getContext(), patterns, typeConverter);
+
+    // Full conversion requires explicit handling of FuncOp and ModuleOp, which
+    // should be passed down unmodified so partial conversion is used.
+    if (failed(applyPartialConversion(getOperation(), target,
+                                      std::move(patterns)))) {
+      signalPassFailure();
+      return;
+    }
+  }
+};
+
+} // namespace
+
+namespace mlir::tt {
+
+std::unique_ptr<OperationPass<ModuleOp>> createConvertTTIRToTTNNPass() {
+  return std::make_unique<ConvertTTIRToTTNNPass>();
+}
+
+} // namespace mlir::tt

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "mlir/Pass/PassManager.h"
+#include "ttmlir/Conversion/Passes.h"
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTNN/Pipelines/Passes.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
@@ -24,7 +25,7 @@ void createTTIRToTTNNBackendPipeline(
   }
 
   pm.addPass(createTTNNOpenDevice());
-  pm.addPass(createConvertTTIRToTTNN());
+  pm.addPass(createConvertTTIRToTTNNPass());
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -13,3 +13,4 @@ add_mlir_dialect_library(MLIRTTNNTransforms
 
 target_include_directories(MLIRTTNNTransforms PUBLIC ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common)
 target_link_libraries(MLIRTTNNTransforms PRIVATE TTMLIRTTNNToEmitC)
+target_link_libraries(MLIRTTNNTransforms PRIVATE TTMLIRTTIRToTTNN)

--- a/lib/Dialect/TTNN/Transforms/Passes.cpp
+++ b/lib/Dialect/TTNN/Transforms/Passes.cpp
@@ -11,6 +11,7 @@
 #include "mlir/Rewrite/FrozenRewritePatternSet.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "ttmlir/Conversion/TTIRToTTNN/TTIRToTTNN.h"
 #include "ttmlir/Dialect/TT/IR/TT.h"
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIR.h"
@@ -23,17 +24,6 @@ namespace mlir::tt::ttnn {
 #define GEN_PASS_DEF_TTNNOPENDEVICE
 #define GEN_PASS_DEF_CONVERTTTIRTOTTNN
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h.inc"
-
-static Value findDevice(Operation *op) {
-  Block *block = op->getBlock();
-  for (auto &op : block->getOperations()) {
-    if (auto deviceOp = dyn_cast<OpenDeviceOp>(op)) {
-      return deviceOp.getResult();
-    }
-  }
-  assert(false && "No device found");
-  return nullptr;
-}
 
 class TTNNOpenDevice : public impl::TTNNOpenDeviceBase<TTNNOpenDevice> {
 public:
@@ -65,115 +55,6 @@ public:
   }
 
   void getDependentDialects(mlir::DialectRegistry &registry) const override {
-    registry.insert<mlir::tt::ttnn::TTNNDialect>();
-  }
-};
-
-class TTIRToTTNNLayoutRewriter : public OpRewritePattern<ttir::LayoutOp> {
-public:
-  using OpRewritePattern<ttir::LayoutOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(ttir::LayoutOp op,
-                                PatternRewriter &rewriter) const final {
-    rewriter.replaceOpWithNewOp<ToMemoryConfigOp>(
-        op, op->getResultTypes(), op.getInput(), op.getOutput());
-    return success();
-  }
-};
-
-template <typename TTIROp, typename TTNNOp>
-class TTIRToTTNNOpRewriter : public OpRewritePattern<TTIROp> {
-public:
-  using OpRewritePattern<TTIROp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(TTIROp op,
-                                PatternRewriter &rewriter) const final {
-    rewriter.replaceOpWithNewOp<TTNNOp>(op, op.getResultTypes(), op.getInputs(),
-                                        op.getOutputs());
-    return success();
-  }
-};
-
-template <typename TTIROp, typename TTNNOp>
-class TTIRToTTNNReductionOpRewriter : public OpRewritePattern<TTIROp> {
-  using OpRewritePattern<TTIROp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(TTIROp op,
-                                PatternRewriter &rewriter) const final {
-    rewriter.replaceOpWithNewOp<TTNNOp>(
-        op, op.getResult().getType(), op.getInput(), op.getOutput(),
-        op.getKeepDim(), op.getDimArg().value_or(nullptr));
-    return success();
-  }
-};
-
-class TTIRToTTNNSoftmaxOpRewriter : public OpRewritePattern<ttir::SoftmaxOp> {
-  using OpRewritePattern<ttir::SoftmaxOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(ttir::SoftmaxOp op,
-                                PatternRewriter &rewriter) const final {
-    rewriter.replaceOpWithNewOp<SoftmaxOp>(op, op.getResult().getType(),
-                                           op.getInput(), op.getOutput(),
-                                           op.getDimension());
-    return success();
-  }
-};
-
-// ANCHOR: adding_an_op_matmul_op_rewriter
-template <typename TTIROp, typename TTNNOp>
-class TTIRToTTNNBinaryOpRewriter : public OpRewritePattern<TTIROp> {
-public:
-  using OpRewritePattern<TTIROp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(TTIROp op,
-                                PatternRewriter &rewriter) const final {
-    rewriter.replaceOpWithNewOp<TTNNOp>(op, op.getResult().getType(), op.getA(),
-                                        op.getB(), op.getOutput());
-    return success();
-  }
-};
-// ANCHOR_END: adding_an_op_matmul_op_rewriter
-
-class TensorEmptyToFullRewriter : public OpRewritePattern<tensor::EmptyOp> {
-public:
-  using OpRewritePattern<tensor::EmptyOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(tensor::EmptyOp op,
-                                PatternRewriter &rewriter) const final {
-    auto device = findDevice(op);
-    rewriter.replaceOpWithNewOp<FullOp>(op, op.getType(), device,
-                                        rewriter.getF32FloatAttr(0.0));
-    return success();
-  }
-};
-
-class ConvertTTIRToTTNN
-    : public impl::ConvertTTIRToTTNNBase<ConvertTTIRToTTNN> {
-public:
-  using impl::ConvertTTIRToTTNNBase<ConvertTTIRToTTNN>::ConvertTTIRToTTNNBase;
-
-  void runOnOperation() final {
-    // ANCHOR: adding_an_op_matmul_rewrite_pattern_set
-    RewritePatternSet patterns(&getContext());
-    patterns
-        .add<TTIRToTTNNLayoutRewriter, TTIRToTTNNOpRewriter<ttir::AddOp, AddOp>,
-             TTIRToTTNNOpRewriter<ttir::MultiplyOp, MultiplyOp>,
-             TTIRToTTNNOpRewriter<ttir::SubtractOp, SubtractOp>,
-             TTIRToTTNNOpRewriter<ttir::GreaterEqualOp, GreaterEqualOp>,
-             TTIRToTTNNOpRewriter<ttir::ReluOp, ReluOp>,
-             TTIRToTTNNBinaryOpRewriter<ttir::MatmulOp, MatmulOp>,
-             TTIRToTTNNReductionOpRewriter<ttir::SumOp, SumOp>,
-             TTIRToTTNNSoftmaxOpRewriter, TensorEmptyToFullRewriter>(
-            &getContext());
-    // ANCHOR_END: adding_an_op_matmul_rewrite_pattern_set
-    FrozenRewritePatternSet patternSet(std::move(patterns));
-    if (failed(applyPatternsAndFoldGreedily(getOperation(), patternSet))) {
-      signalPassFailure();
-    }
-  }
-
-  void getDependentDialects(mlir::DialectRegistry &registry) const override {
-    registry.insert<mlir::tt::ttir::TTIRDialect>();
     registry.insert<mlir::tt::ttnn::TTNNDialect>();
   }
 };


### PR DESCRIPTION
Details:
* Refactor ttir -> ttnn pass to use the dialect conversion API (#177)
* Structure following [llvm conversion passes](https://github.com/llvm/llvm-project/tree/main/mlir/lib/Conversion)

This leaves the repo in an inconsistent state since the current ttnn->emitc conversion pass follows torch-mlir structure.

Next steps:
* Refactor common conversion pass files from torch approach to llvm
* Refactor ttnn -> emitc to llvm approach
* Add tests
