### PR TITLE
[docs] fix build on linux

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_target(copy-docs-dir
   COMMAND
-    cp -r ${CMAKE_CURRENT_SOURCE_DIR}/ ${CMAKE_CURRENT_BINARY_DIR}
+    cp -r ${CMAKE_CURRENT_SOURCE_DIR}/* ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 add_custom_target(autogen-summary

--- a/docs/src/build.md
+++ b/docs/src/build.md
@@ -104,10 +104,11 @@ For more information visit [pre-commit](https://pre-commit.com/)
 ```bash
 source env/activate
 cmake --build build -- docs
-mdbook serve build/docs/book
+mdbook serve build/docs
 ```
 
 > - `mdbook` can be installed with the system's package manager.
+> - `mdbook serve` will by default create a local server at `http://localhost:3000`.
 
 ## Dependencies
 


### PR DESCRIPTION
It looks like the `cp -r` command behaves differently on linux vs macOS.

`cp -r dir/ new_dir/` will copy contents of the `dir/` into `new_dir/` on macOS, but on Linux, it will copy the directory, so you would end up with `new_dir/dir/`.

Hence, changing the command to be:
`cp -r dir/* new_dir/` which works the same on both platforms.

Updating the docs for building docs as well.