### PR TITLE
Change TOSA->TTIR to use dialect conversion API

### DIFF
--- a/include/ttmlir/Conversion/Passes.h
+++ b/include/ttmlir/Conversion/Passes.h
@@ -7,6 +7,7 @@
 
 #include "ttmlir/Conversion/TTIRToTTNN/TTIRToTTNN.h"
 #include "ttmlir/Conversion/TTNNToEmitC/TTNNToEmitC.h"
+#include "ttmlir/Conversion/TosaToTTIR/TosaToTTIR.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIR.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNN.h"
 

--- a/include/ttmlir/Conversion/Passes.td
+++ b/include/ttmlir/Conversion/Passes.td
@@ -19,4 +19,10 @@ def ConvertTTIRToTTNN: Pass<"convert-ttir-to-ttnn", "::mlir::ModuleOp"> {
   let dependentDialects = ["mlir::tt::ttir::TTIRDialect", "mlir::tt::ttnn::TTNNDialect"];
 }
 
+def ConvertTosaToTTIR : Pass<"convert-tosa-to-ttir", "::mlir::ModuleOp"> {
+  let summary = "Convert TOSA dialect to TTIR dialect.";
+  let constructor = "createConvertTosaToTTIRPass()";
+  let dependentDialects = ["mlir::tt::ttir::TTIRDialect"];
+}
+
 #endif // TTMLIR_CONVERSION_PASSES

--- a/include/ttmlir/Conversion/TosaToTTIR/TosaToTTIR.h
+++ b/include/ttmlir/Conversion/TosaToTTIR/TosaToTTIR.h
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_CONVERSION_TOSATOTTIR_TOSATOTTIR_H
+#define TTMLIR_CONVERSION_TOSATOTTIR_TOSATOTTIR_H
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir::tt {
+
+std::unique_ptr<OperationPass<ModuleOp>> createConvertTosaToTTIRPass();
+
+} // namespace mlir::tt
+
+#endif

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -15,13 +15,6 @@ def TTIRImplicitDevice: Pass<"ttir-implicit-device", "::mlir::ModuleOp"> {
   }];
 }
 
-def ConvertTosaToTTIR: Pass<"convert-tosa-to-ttir", "::mlir::ModuleOp"> {
-  let summary = "";
-  let description = [{
-    Convert TOSA ops to TTIR ops.
-  }];
-}
-
 def TTIRGeneric: Pass<"ttir-generic", "::mlir::ModuleOp"> {
   let summary = "";
   let description = [{

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -9,6 +9,7 @@ add_mlir_library(TTMLIR STATIC RegisterAll.cpp
     MLIRTTDialect
     MLIRTTIRDialect
     MLIRTTIRTransforms
+    TTMLIRConversions
     MLIRTTIRAnalysis
     MLIRTTNNDialect
     MLIRTTNNTransforms

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -1,2 +1,11 @@
+add_subdirectory(TosaToTTIR)
 add_subdirectory(TTNNToEmitC)
 add_subdirectory(TTIRToTTNN)
+
+add_library(TTMLIRConversions INTERFACE)
+
+target_link_libraries(TTMLIRConversions INTERFACE
+  TTMLIRTosaToTTIR
+  TTMLIRTTNNToEmitC
+  TTMLIRTTIRToTTNN
+)

--- a/lib/Conversion/PassDetail.h
+++ b/lib/Conversion/PassDetail.h
@@ -18,7 +18,7 @@ class EmitCDialect;
 
 namespace mlir::tt::ttnn {
 
-#define GEN_PASS_CLASSES
+#define GEN_PASS_DEF_CONVERTTTNNTOEMITC
 #include "ttmlir/Conversion/Passes.h.inc"
 
 } // namespace mlir::tt::ttnn

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNNPass.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNNPass.cpp
@@ -16,10 +16,17 @@
 using namespace mlir;
 using namespace mlir::tt;
 
+namespace mlir::tt::ttir {
+
+#define GEN_PASS_DEF_CONVERTTTIRTOTTNN
+#include "ttmlir/Conversion/Passes.h.inc"
+
+} // namespace mlir::tt::ttir
+
 namespace {
 
 struct ConvertTTIRToTTNNPass
-    : public ttnn::ConvertTTIRToTTNNBase<ConvertTTIRToTTNNPass> {
+    : public ttir::impl::ConvertTTIRToTTNNBase<ConvertTTIRToTTNNPass> {
   void runOnOperation() final {
     mlir::ConversionTarget target(getContext());
     target.addLegalDialect<ttnn::TTNNDialect>();

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -63,7 +63,7 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
 }
 
 struct ConvertTTNNToEmitCPass
-    : public ttnn::ConvertTTNNToEmitCBase<ConvertTTNNToEmitCPass> {
+    : public ttnn::impl::ConvertTTNNToEmitCBase<ConvertTTNNToEmitCPass> {
   void runOnOperation() override {
     mlir::ConversionTarget target(getContext());
 

--- a/lib/Conversion/TosaToTTIR/CMakeLists.txt
+++ b/lib/Conversion/TosaToTTIR/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_mlir_library(TTMLIRTosaToTTIR
+  TosaToTTIR.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${PROJECT_SOURCE_DIR}/include/ttmlir/Conversion/TosaToTTIR
+
+  DEPENDS
+  TTMLIRConversionPassIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRPass
+  MLIRTransformUtils
+)

--- a/lib/Conversion/TosaToTTIR/TosaToTTIR.cpp
+++ b/lib/Conversion/TosaToTTIR/TosaToTTIR.cpp
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Conversion/TosaToTTIR/TosaToTTIR.h"
+#include "ttmlir/Dialect/TT/IR/TT.h"
+#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIR.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+
+#include "mlir/Dialect/Func/Transforms/FuncConversions.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Tosa/IR/TosaOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/Tensor/IR/Tensor.h>
+#include <mlir/IR/BuiltinAttributes.h>
+#include <mlir/IR/BuiltinOps.h>
+#include <mlir/IR/Dialect.h>
+#include <mlir/IR/PatternMatch.h>
+#include <mlir/IR/ValueRange.h>
+#include <mlir/Support/LogicalResult.h>
+
+using namespace mlir;
+using namespace tt;
+
+namespace mlir::tt::ttir {
+
+#define GEN_PASS_DEF_CONVERTTOSATOTTIR
+#include "ttmlir/Conversion/Passes.h.inc"
+
+} // namespace mlir::tt::ttir
+
+namespace {
+
+template <typename SrcOp, typename DestOp,
+          typename Adaptor = typename SrcOp::Adaptor>
+class TosaToTTIROpConversionPattern : public OpConversionPattern<SrcOp> {
+  using OpConversionPattern<SrcOp>::OpConversionPattern;
+
+public:
+  LogicalResult
+  matchAndRewrite(SrcOp srcOp, Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if constexpr (std::is_same<SrcOp, tosa::MulOp>::value) {
+      assert(srcOp.getShift() == 0);
+    }
+
+    auto outputType =
+        srcOp.getResult().getType().template cast<RankedTensorType>();
+    auto outputTensor = rewriter.create<tensor::EmptyOp>(
+        srcOp.getLoc(), outputType.getShape(), outputType.getElementType());
+    rewriter.replaceOpWithNewOp<DestOp>(
+        srcOp, TypeRange(outputTensor.getType()), adaptor.getOperands(),
+        ValueRange(outputTensor),
+        rewriter.getArrayAttr(
+            SmallVector<Attribute>(adaptor.getOperands().size() + 1,
+                                   rewriter.getAttr<OperandConstraintAttr>(
+                                       OperandConstraint::AnyDeviceTile))));
+    return success();
+  }
+};
+
+struct ConvertTosaToTTIRPass
+    : public ttir::impl::ConvertTosaToTTIRBase<ConvertTosaToTTIRPass> {
+  void runOnOperation() override {
+    mlir::ConversionTarget target(getContext());
+
+    target.addIllegalDialect<tosa::TosaDialect>();
+
+    target.addLegalDialect<ttir::TTIRDialect>();
+    target.addLegalOp<mlir::tensor::EmptyOp>();
+    target.addLegalOp<mlir::ModuleOp>();
+    target.addLegalOp<mlir::func::FuncOp>();
+    target.addLegalOp<mlir::func::ReturnOp>();
+
+    // For now keep the same type assuming tosa ops operate on builtin tensor.
+    TypeConverter typeConverter;
+    typeConverter.addConversion([](Type type) {
+      assert(type.isa<RankedTensorType>() &&
+             "only ranked tensor type supported");
+      return type;
+    });
+    RewritePatternSet patterns(&getContext());
+
+    // Add conversion patterns.
+    patterns
+        .add<TosaToTTIROpConversionPattern<tosa::AddOp, mlir::tt::ttir::AddOp>>(
+            typeConverter, &getContext());
+    patterns.add<
+        TosaToTTIROpConversionPattern<tosa::MulOp, mlir::tt::ttir::MultiplyOp>>(
+        typeConverter, &getContext());
+    patterns.add<
+        TosaToTTIROpConversionPattern<tosa::SubOp, mlir::tt::ttir::SubtractOp>>(
+        typeConverter, &getContext());
+    patterns.add<TosaToTTIROpConversionPattern<tosa::GreaterEqualOp,
+                                               mlir::tt::ttir::GreaterEqualOp>>(
+        typeConverter, &getContext());
+
+    // Apply conversion.
+    if (failed(
+            applyFullConversion(getOperation(), target, std::move(patterns)))) {
+      signalPassFailure();
+      return;
+    }
+  }
+};
+
+} // namespace
+
+namespace mlir::tt {
+
+std::unique_ptr<OperationPass<ModuleOp>> createConvertTosaToTTIRPass() {
+  return std::make_unique<ConvertTosaToTTIRPass>();
+}
+
+} // namespace mlir::tt

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -12,5 +12,3 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         )
 
 target_include_directories(MLIRTTNNTransforms PUBLIC ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common)
-target_link_libraries(MLIRTTNNTransforms PRIVATE TTMLIRTTNNToEmitC)
-target_link_libraries(MLIRTTNNTransforms PRIVATE TTMLIRTTIRToTTNN)

--- a/test/ttmlir/Dialect/TTIR/tosa_to_ttir_multiply.mlir
+++ b/test/ttmlir/Dialect/TTIR/tosa_to_ttir_multiply.mlir
@@ -1,0 +1,10 @@
+// RUN: ttmlir-opt --convert-tosa-to-ttir %s | FileCheck %s
+#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
+module attributes {tt.system_desc = #tt.system_desc<[{arch = <wormhole_b0>, grid = 8x8, l1_size = 1048576, num_dram_channels = 12, dram_channel_size = 1048576, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32}], [0], [<pcie|host_mmio>], [<0, 0, 0, 0>]>} {
+  func.func @test_mul(%arg0: tensor<13x21x3xf32>, %arg1: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
+    %0 = tosa.mul %arg0, %arg1 {shift = 0 : i8} : (tensor<13x21x3xf32>, tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+    // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
+    // CHECK: %[[C:.*]] = "ttir.multiply"[[C:.*]]
+    return %0 : tensor<13x21x3xf32>
+  }
+}

--- a/tools/ttmlir-opt/CMakeLists.txt
+++ b/tools/ttmlir-opt/CMakeLists.txt
@@ -1,6 +1,6 @@
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
-set(LIBS ${dialect_libs} ${conversion_libs} TTMLIRTTNNToEmitC MLIROptLib MLIRTargetCpp TTMLIR)
+set(LIBS ${dialect_libs} ${conversion_libs} MLIROptLib MLIRTargetCpp TTMLIR)
 add_llvm_executable(ttmlir-opt ttmlir-opt.cpp)
 
 llvm_update_compile_flags(ttmlir-opt)


### PR DESCRIPTION
Fixes #178

Added conversion lib that implements conversion from TOSA to TTIR. Did not add new coverage of TOSA ops, it still supports only add, mul, sub, geq ops. Type conversion is still a no-op.

Removed old conversion.

Added MLIRTTConversions lib that links all conversion libs and is linked against TTMLIR.