### PR TITLE
embed sdk in ccache

### DIFF
--- a/.github/actions/build-toolchain/action.yml
+++ b/.github/actions/build-toolchain/action.yml
@@ -4,6 +4,10 @@ inputs:
   os:
     description: 'Operating System'
     required: true
+  sdk:
+    description: 'MacOS SDK, if applicable'
+    required: true
+    default: '0'
 runs:
   using: 'composite'
   steps:
@@ -18,7 +22,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: /opt/ttmlir-toolchain
-        key: ${{ inputs.os }}-ttmlir-toolchain-${{ hashFiles('env/**') }}
+        key: ${{ inputs.os }}-ttmlir-toolchain-${{ hashFiles('env/**') }}-${{ inputs.sdk }}
 
     - name: 'Build ttmlir-toolchain'
       if: steps.cache-toolchain.outputs.cache-hit != 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+env:
+  SDK_VERSION: "0"
+
 jobs:
   build:
     strategy:
@@ -24,16 +27,23 @@ jobs:
       with:
         os: ${{ matrix.build.runs-on }}
 
+    - name: Get macos sdk version
+      if: startsWith(matrix.build.runs-on, 'macos')
+      shell: bash
+      run: |
+        echo "SDK_VERSION=$(xcrun --show-sdk-version)" >> $GITHUB_ENV
+
     - name: Build and cache ttmlir-toolchain
       uses: ./.github/actions/build-toolchain
       with:
         os: ${{ matrix.build.runs-on }}
+        sdk: ${{ env.SDK_VERSION }}
 
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1.2
       with:
         create-symlink: true
-        key: ${{ matrix.build.runs-on }}-runtime-${{ matrix.build.enable_runtime }}
+        key: ${{ matrix.build.runs-on }}-runtime-${{ matrix.build.enable_runtime }}-${{ env.SDK_VERSION }}
 
     - name: Set reusable strings
       id: strings


### PR DESCRIPTION
Fixes CI build errors to do with stale ccache files against mismatched macOS SDK 

e.g. error:
```
/Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__memory/unique_ptr.h:191:3: error: non-static data member cannot be constexpr; did you intend to make it const?
  _LIBCPP_CONSTEXPR unique_ptr(nullptr_t) _NOEXCEPT : __ptr_(__value_init_tag(), __value_init_tag()) {}
  ^
/Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__config:612:31: note: expanded from macro '_LIBCPP_CONSTEXPR'
#    define _LIBCPP_CONSTEXPR constexpr
```