### PR TITLE
Fix mac build; link against MLIR dylib

### DIFF
--- a/lib/Conversion/TTIRToTTNN/CMakeLists.txt
+++ b/lib/Conversion/TTIRToTTNN/CMakeLists.txt
@@ -9,7 +9,5 @@ add_mlir_library(TTMLIRTTIRToTTNN
   TTMLIRConversionPassIncGen
 
   LINK_LIBS PUBLIC
-  MLIRIR
-  MLIRPass
-  MLIRTransformUtils
+  MLIR
 )

--- a/lib/Conversion/TTNNToEmitC/CMakeLists.txt
+++ b/lib/Conversion/TTNNToEmitC/CMakeLists.txt
@@ -8,7 +8,5 @@ add_mlir_library(TTMLIRTTNNToEmitC
   TTMLIRConversionPassIncGen
 
   LINK_LIBS PUBLIC
-  MLIRIR
-  MLIRPass
-  MLIRTransformUtils
+  MLIR
 )

--- a/lib/Conversion/TosaToTTIR/CMakeLists.txt
+++ b/lib/Conversion/TosaToTTIR/CMakeLists.txt
@@ -8,7 +8,5 @@ add_mlir_library(TTMLIRTosaToTTIR
   TTMLIRConversionPassIncGen
 
   LINK_LIBS PUBLIC
-  MLIRIR
-  MLIRPass
-  MLIRTransformUtils
+  MLIR
 )


### PR DESCRIPTION
We should only ever link against `MLIR`, `LLVM`, or `MLIR-C`, any other libs with a suffix will match against a static MLIR library and can lead to weird linker errors like the Mac build was seeing.

FYI @mmanzoorTT, audit your branch for places where we might be accidentally linking against a static library, because the error message looked nearly identical to the one you're seeing on your llvm upgrade branch:
```
LLVM ERROR: can't create Attribute 'mlir::DenseArrayAttr' because storage uniquer isn't initialized: the dialect was likely not loaded, or the attribute wasn't added with addAttributes<...>() in the Dialect::initialize() method.          
```