### PR TITLE
Update Softmax op to use signed version of I32 attribute for dimension

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -225,7 +225,7 @@ def TTIR_SoftmaxOp : TTIR_DPSOp<"softmax"> {
 
     let arguments = (ins AnyRankedTensor:$input,
                          AnyRankedTensor:$output,
-                         I32Attr:$dimension,
+                         SI32Attr:$dimension,
                          TT_OperandConstraintArrayAttr:$operand_constraints);
 
     let results = (outs AnyRankedTensor:$result);

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -139,7 +139,7 @@ def TTNN_SoftmaxOp : TTNN_NamedDPSOp<"softmax"> {
 
     let arguments = (ins AnyRankedTensor:$input,
                          AnyRankedTensor:$output,
-                         I32Attr: $dimension);
+                         SI32Attr: $dimension);
 
     let results = (outs AnyRankedTensor:$result);
 

--- a/test/ttmlir/Dialect/TTNN/softmax/simple_softmax.mlir
+++ b/test/ttmlir/Dialect/TTNN/softmax/simple_softmax.mlir
@@ -8,13 +8,13 @@ module attributes {tt.system_desc = #tt.system_desc<[{arch = <wormhole_b0>, grid
     // CHECK: %[[C:.*]] = "ttnn.to_memory_config"[[C:.*]]
     // CHECK: %[[C:.*]] = "ttnn.softmax"[[C:.*]]
     // Check for positive dimension attribute
-    %1 = "ttir.softmax"(%arg0, %0) <{dimension = 1 : i32, operand_constraints = [#any_device, #any_device]}> : (tensor<512x1024xbf16>, tensor<512x1024xbf16>) -> tensor<512x1024xbf16>
+    %1 = "ttir.softmax"(%arg0, %0) <{dimension = 1 : si32, operand_constraints = [#any_device, #any_device]}> : (tensor<512x1024xbf16>, tensor<512x1024xbf16>) -> tensor<512x1024xbf16>
     // CHECK: %[[C:.*]] = "ttnn.full"[[C:.*]]
     %2 = tensor.empty() : tensor<512x1024xbf16>
     // CHECK: %[[C:.*]] = "ttnn.to_memory_config"[[C:.*]]
     // CHECK: %[[C:.*]] = "ttnn.softmax"[[C:.*]]
     // Check for negative dimension attribute
-    %3 = "ttir.softmax"(%1, %2) <{dimension = -1 : i32, operand_constraints = [#any_device, #any_device]}> : (tensor<512x1024xbf16>, tensor<512x1024xbf16>) -> tensor<512x1024xbf16>
+    %3 = "ttir.softmax"(%1, %2) <{dimension = -1 : si32, operand_constraints = [#any_device, #any_device]}> : (tensor<512x1024xbf16>, tensor<512x1024xbf16>) -> tensor<512x1024xbf16>
     // CHECK: %[[C:.*]] = "ttnn.to_memory_config"[[C:.*]]
     // CHECK: "ttnn.close_device"[[C:.*]]
     return %3 : tensor<512x1024xbf16>

--- a/test/ttmlir/Dialect/TTNN/softmax/softmax_negative_1.mlir
+++ b/test/ttmlir/Dialect/TTNN/softmax/softmax_negative_1.mlir
@@ -4,7 +4,7 @@
 module attributes {tt.system_desc = #tt.system_desc<[{arch = <wormhole_b0>, grid = 8x8, l1_size = 1048576, num_dram_channels = 12, dram_channel_size = 1048576, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32}], [0], [<pcie|host_mmio>], [<0, 0, 0, 0>]>} {
   func.func @forward(%arg0: tensor<512x1024xbf16>) -> tensor<512x1024xbf16> {
     %0 = tensor.empty() : tensor<512x1024xbf16>
-    %1 = "ttir.softmax"(%arg0, %0) <{dimension = 2 : i32, operand_constraints = [#any_device, #any_device]}> : (tensor<512x1024xbf16>, tensor<512x1024xbf16>) -> tensor<512x1024xbf16>
+    %1 = "ttir.softmax"(%arg0, %0) <{dimension = 2 : si32, operand_constraints = [#any_device, #any_device]}> : (tensor<512x1024xbf16>, tensor<512x1024xbf16>) -> tensor<512x1024xbf16>
     return %1 : tensor<512x1024xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/softmax/softmax_negative_2.mlir
+++ b/test/ttmlir/Dialect/TTNN/softmax/softmax_negative_2.mlir
@@ -4,7 +4,7 @@
 module attributes {tt.system_desc = #tt.system_desc<[{arch = <wormhole_b0>, grid = 8x8, l1_size = 1048576, num_dram_channels = 12, dram_channel_size = 1048576, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32}], [0], [<pcie|host_mmio>], [<0, 0, 0, 0>]>} {
   func.func @forward(%arg0: tensor<512x1024xbf16>) -> tensor<512x1024xbf16> {
     %0 = tensor.empty() : tensor<512x1024xbf16>
-    %1 = "ttir.softmax"(%arg0, %0) <{dimension = -3 : i32, operand_constraints = [#any_device, #any_device]}> : (tensor<512x1024xbf16>, tensor<512x1024xbf16>) -> tensor<512x1024xbf16>
+    %1 = "ttir.softmax"(%arg0, %0) <{dimension = -3 : si32, operand_constraints = [#any_device, #any_device]}> : (tensor<512x1024xbf16>, tensor<512x1024xbf16>) -> tensor<512x1024xbf16>
     return %1 : tensor<512x1024xbf16>
   }
 }


### PR DESCRIPTION
Softmax op is updated to use a signed version of the I32 attribute to support positive and negative dimension attributes.

Solves: https://github.com/tenstorrent/tt-mlir/issues/240