### PR TITLE
Additional fixes to metal runtime bootstrap #290

### DIFF
--- a/include/ttmlir/Target/TTMetal/binary.fbs
+++ b/include/ttmlir/Target/TTMetal/binary.fbs
@@ -5,6 +5,8 @@ include "command.fbs";
 namespace tt.target.metal;
 
 table DeviceProgram {
+  inputs: [TensorRef];
+  outputs: [TensorRef];
   command_queues: [CommandQueue];
 }
 

--- a/lib/Dialect/TTMetal/Transforms/SerializeToBinary.cpp
+++ b/lib/Dialect/TTMetal/Transforms/SerializeToBinary.cpp
@@ -222,7 +222,8 @@ public:
 
     std::vector<::flatbuffers::Offset<::tt::target::metal::DeviceProgram>>
         devicePrograms = {
-            ::tt::target::metal::CreateDeviceProgramDirect(fbb, &commandQueues),
+            ::tt::target::metal::CreateDeviceProgramDirect(
+                fbb, &cqBuilder.inputs, &cqBuilder.outputs, &commandQueues),
         };
 
     std::vector<::flatbuffers::Offset<::tt::target::metal::Program>> programs =

--- a/runtime/include/tt/runtime/detail/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal.h
@@ -64,15 +64,97 @@ Event submit(Device device, Binary executable, std::uint32_t programIndex,
 
 void wait(Event event);
 
-std::shared_ptr<::tt::tt_metal::Event> executeCommandQueue(
-    ::tt::tt_metal::Device *device, ::tt::target::metal::CommandQueue const *cq,
-    std::size_t cq_id,
-    std::vector<
-        std::pair<std::uint32_t, std::shared_ptr<::tt::tt_metal::Buffer>>> const
-        &inputs,
-    std::vector<
-        std::pair<std::uint32_t, std::shared_ptr<::tt::tt_metal::Buffer>>> const
-        &outputs);
+using InputBuffer =
+    std::tuple<std::uint32_t, std::shared_ptr<::tt::tt_metal::Buffer>,
+               std::shared_ptr<::tt::tt_metal::Event>>;
+
+using OutputBuffer =
+    std::tuple<std::uint32_t, std::shared_ptr<::tt::tt_metal::Buffer>>;
+
+std::shared_ptr<::tt::tt_metal::Event>
+executeCommandQueue(::tt::tt_metal::Device *device,
+                    ::tt::target::metal::CommandQueue const *cq,
+                    std::size_t cq_id, std::vector<InputBuffer> const &inputs,
+                    std::vector<OutputBuffer> const &outputs);
+
+// Utils
+
+inline CoreRangeSet toCoreRangeSet(
+    ::flatbuffers::Vector<tt::target::Dim2dRange const *> const *coreRangeSet) {
+  std::set<CoreRange> coreRanges;
+  for (::tt::target::Dim2dRange const *coreRange : *coreRangeSet) {
+    CoreCoord start(coreRange->loc().x(), coreRange->loc().y());
+    // End is inclusive
+    CoreCoord end(coreRange->loc().x() + coreRange->size().x() - 1,
+                  coreRange->loc().y() + coreRange->size().y() - 1);
+    coreRanges.emplace(start, end);
+  }
+  return CoreRangeSet(coreRanges);
+}
+
+#pragma clang diagnostic push
+// Needed to construct ShardedBufferConfig
+#pragma clang diagnostic ignored "-Wc++20-designator"
+
+inline std::shared_ptr<::tt::tt_metal::Buffer>
+createBufferFromTensorRef(::tt::tt_metal::Device *device,
+                          ::tt::target::TensorRef const *tensorRef) {
+  ::tt::target::TensorDesc const *tensorDesc = tensorRef->desc();
+  ::tt::target::LayoutDesc const *layout = tensorDesc->layout();
+  CoreRangeSet coreRangeSet = toCoreRangeSet(layout->core_range_set());
+  auto shardRank = layout->memory_desc()->shape()->size();
+  ::tt::target::Dim2d const *tile_shape = layout->memory_desc()->tile_shape();
+  std::array<uint32_t, 2> shardShape;
+  shardShape[1] =
+      layout->memory_desc()->shape()->Get(shardRank - 1) * tile_shape->x();
+  shardShape[0] = tile_shape->y();
+  for (unsigned i = 0; i < shardRank - 1; ++i) {
+    shardShape[0] *= layout->memory_desc()->shape()->Get(i);
+  }
+  ShardSpec shardSpec(coreRangeSet, shardShape);
+  std::array<uint32_t, 2> pageShape = {static_cast<uint32_t>(tile_shape->y()),
+                                       shardShape[1]};
+
+  auto tensorRank = layout->stride()->size();
+  auto innerDim = layout->stride()->Get(tensorRank - 2);
+  assert(layout->stride()->size() >= 2);
+  assert((layout->stride()->Get(0) * tensorDesc->shape()->Get(0)) %
+             (pageShape[0] * innerDim) ==
+         0);
+  assert(innerDim % pageShape[1] == 0);
+  std::array<uint32_t, 2> tensorShape = {
+      (layout->stride()->Get(0) * tensorDesc->shape()->Get(0)) /
+          (pageShape[0] * innerDim),
+      innerDim / pageShape[1],
+  };
+
+  ShardSpecBuffer shardSpecBuffer(shardSpec, pageShape, tensorShape);
+  assert(layout->memory_desc()->memory_space() ==
+             ::tt::target::MemorySpace::DeviceDRAM ||
+         layout->memory_desc()->memory_space() ==
+             ::tt::target::MemorySpace::DeviceL1);
+  BufferType bufferType = layout->memory_desc()->memory_space() ==
+                                  ::tt::target::MemorySpace::DeviceDRAM
+                              ? BufferType::DRAM
+                              : BufferType::L1;
+  uint64_t pageSize =
+      pageShape[0] * pageShape[1] * 4; // FIXME: Hardcoded data type size
+  uint64_t size = tensorShape[0] * tensorShape[1] * pageSize;
+  auto shardedBufferConfig = ShardedBufferConfig{
+      .device = device,
+      .size = size,
+      .page_size = pageSize,
+      .buffer_type = bufferType,
+      .buffer_layout = TensorMemoryLayout::BLOCK_SHARDED,
+      .shard_parameters = shardSpecBuffer,
+  };
+  std::shared_ptr<::tt::tt_metal::Buffer> buffer =
+      ::tt::tt_metal::CreateBuffer(shardedBufferConfig);
+  assert(tensorRef->address());
+  buffer->set_address(tensorRef->address());
+  return buffer;
+}
+#pragma clang diagnostic pop
 
 } // namespace tt::runtime::ttmetal
 

--- a/runtime/lib/binary.cpp
+++ b/runtime/lib/binary.cpp
@@ -138,7 +138,8 @@ std::vector<TensorDesc> getProgramInputs(Flatbuffer binary,
                                          std::uint32_t programIndex) {
   std::vector<TensorDesc> inputs;
   auto const *program = getBinary(binary)->programs()->Get(programIndex);
-  for (auto const *input : *program->inputs()) {
+  assert(program->device_programs()->size() == 1);
+  for (auto const *input : *program->device_programs()->Get(0)->inputs()) {
     TensorDesc desc;
     desc.shape = {input->desc()->shape()->begin(),
                   input->desc()->shape()->end()};
@@ -156,7 +157,8 @@ std::vector<TensorDesc> getProgramOutputs(Flatbuffer binary,
                                           std::uint32_t programIndex) {
   std::vector<TensorDesc> outputs;
   auto const *program = getBinary(binary)->programs()->Get(programIndex);
-  for (auto const *output : *program->outputs()) {
+  assert(program->device_programs()->size() == 1);
+  for (auto const *output : *program->device_programs()->Get(0)->outputs()) {
     TensorDesc desc;
     desc.shape = {output->desc()->shape()->begin(),
                   output->desc()->shape()->end()};

--- a/runtime/lib/binary.cpp
+++ b/runtime/lib/binary.cpp
@@ -138,7 +138,8 @@ std::vector<TensorDesc> getProgramInputs(Flatbuffer binary,
                                          std::uint32_t programIndex) {
   std::vector<TensorDesc> inputs;
   auto const *program = getBinary(binary)->programs()->Get(programIndex);
-  assert(program->device_programs()->size() == 1);
+  assert(program->device_programs()->size() == 1 &&
+         "Currently only one device is supported");
   for (auto const *input : *program->device_programs()->Get(0)->inputs()) {
     TensorDesc desc;
     desc.shape = {input->desc()->shape()->begin(),

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -83,6 +83,14 @@ Event submit(Device deviceHandle, Binary executableHandle,
 #endif
 }
 
-void wait(Event) { throw std::runtime_error("Not implemented"); }
+void wait(Event event) {
+#if defined(TT_RUNTIME_ENABLE_TTNN)
+  return ::tt::runtime::ttnn::wait(event);
+#elif defined(TT_RUNTIME_ENABLE_TTMETAL)
+  return ::tt::runtime::ttmetal::wait(event);
+#else
+  throw std::runtime_error("runtime is not enabled");
+#endif
+}
 
 } // namespace tt::runtime

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -134,8 +134,7 @@ static std::pair<std::shared_ptr<::tt::tt_metal::Buffer>,
                  std::shared_ptr<::tt::tt_metal::Event>>
 prepareInput(::tt::tt_metal::Device *device, MetalTensor const &metalTensor,
              void *data, ::tt::target::TensorRef const *tensorRef) {
-  if (TensorDesc const *hostTensorDesc = std::get_if<TensorDesc>(&metalTensor);
-      hostTensorDesc) {
+  if (std::holds_alternative<TensorDesc>(metalTensor)) {
     // todo assert that tensorDesc matches hostTensorDesc
     std::shared_ptr<::tt::tt_metal::Buffer> buffer =
         createBufferFromTensorRef(device, tensorRef);
@@ -146,10 +145,10 @@ prepareInput(::tt::tt_metal::Device *device, MetalTensor const &metalTensor,
     ::tt::tt_metal::EnqueueWriteBuffer(cq, buffer, data, blocking);
     ::tt::tt_metal::EnqueueRecordEvent(cq, event);
     return std::make_pair(buffer, event);
-  } else if (std::shared_ptr<::tt::tt_metal::Buffer> const *buffer =
-                 std::get_if<std::shared_ptr<::tt::tt_metal::Buffer>>(
-                     &metalTensor);
-             buffer) {
+  } else if (std::holds_alternative<std::shared_ptr<::tt::tt_metal::Buffer>>(
+                 metalTensor)) {
+    std::shared_ptr<::tt::tt_metal::Buffer> buffer =
+        std::get<std::shared_ptr<::tt::tt_metal::Buffer>>(metalTensor);
     throw std::runtime_error("Input from buffer not supported yet");
   }
   assert(false && "Unsupported tensor type");

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -212,7 +212,6 @@ Event submit(Device deviceHandle, Binary executableHandle,
   DeviceMesh &deviceMesh = deviceHandle.as<DeviceMesh>();
   assert(deviceMesh.size() == 1 && "Only one device is supported for now");
   std::shared_ptr<Events> events = std::make_shared<Events>();
-  std::size_t cq_id = 0;
   assert(program->device_programs()->size() == deviceMesh.size() &&
          "Device programs size mismatch");
   for (std::size_t i = 0; i < program->device_programs()->size(); ++i) {
@@ -248,6 +247,7 @@ Event submit(Device deviceHandle, Binary executableHandle,
                            buffer);
     }
 
+    std::size_t cq_id = 0;
     for (::tt::target::metal::CommandQueue const *cq :
          *deviceProgram->command_queues()) {
       deviceEvents.push_back(

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -39,7 +39,8 @@ std::pair<SystemDesc, DeviceIds> getCurrentSystemDesc() {
   ::ttmlir::Version ttmlirVersion = ::ttmlir::getVersion();
   ::tt::target::Version version(ttmlirVersion.major, ttmlirVersion.minor,
                                 ttmlirVersion.patch);
-  ::tt::target::Dim2d deviceGrid = toFlatbuffer(device.logical_grid_size());
+  ::tt::target::Dim2d deviceGrid =
+      toFlatbuffer(device.compute_with_storage_grid_size());
   std::vector<::flatbuffers::Offset<tt::target::ChipDesc>> chipDescs = {
       ::tt::target::CreateChipDesc(
           fbb, toFlatbuffer(device.arch()), &deviceGrid, (1 << 20), 12,

--- a/runtime/tools/python/ttrt/common/api.py
+++ b/runtime/tools/python/ttrt/common/api.py
@@ -182,7 +182,6 @@ def run(args):
 
             print("inputs:\n", torch_inputs)
 
-<<<<<<< HEAD
             total_inputs = []
             total_outputs = []
             for loop in range(arg_loops):

--- a/runtime/tools/python/ttrt/common/api.py
+++ b/runtime/tools/python/ttrt/common/api.py
@@ -182,6 +182,7 @@ def run(args):
 
             print("inputs:\n", torch_inputs)
 
+<<<<<<< HEAD
             total_inputs = []
             total_outputs = []
             for loop in range(arg_loops):
@@ -212,11 +213,13 @@ def run(args):
                 total_inputs.append(inputs)
                 total_outputs.append(outputs)
 
+            event = None
             for loop in range(arg_loops):
-                ttrt.runtime.submit(
+                event = ttrt.runtime.submit(
                     device, fbb, program_index, total_inputs[loop], total_outputs[loop]
                 )
                 print(f"finished loop={loop}")
+            ttrt.runtime.wait(event)
             print("outputs:\n", torch_outputs)
 
     # save artifacts

--- a/runtime/tools/python/ttrt/runtime/__init__.py
+++ b/runtime/tools/python/ttrt/runtime/__init__.py
@@ -13,6 +13,7 @@ try:
         close_device,
         submit,
         create_tensor,
+        wait,
     )
 except ModuleNotFoundError:
     raise ImportError(

--- a/runtime/tools/python/ttrt/runtime/module.cpp
+++ b/runtime/tools/python/ttrt/runtime/module.cpp
@@ -51,4 +51,5 @@ PYBIND11_MODULE(_C, m) {
   m.def("submit", &tt::runtime::submit, py::arg("device"),
         py::arg("executable"), py::arg("program_index"), py::arg("inputs"),
         py::arg("outputs"), "Submit a binary for execution");
+  m.def("wait", &tt::runtime::wait, py::arg("event"));
 }


### PR DESCRIPTION
- Make inputs per-device (multi-device inputs still need to be worked out)
- Create common functions for creating metal Buffers and CoreRange from flatbuffer types
- Implement wait API + events, update ttrt to use it
- Bug fix logical_grid_size -> compute_with_storage_grid_size, the latter accurately gives post-harvested shape
- Automatically move inputs / outputs during submit