### PR TITLE
Feed HW alignment requirements from system desc into allocator

### DIFF
--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.h
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.h
@@ -29,6 +29,7 @@ inline bool isDeviceMemorySpace(MemorySpace memorySpace) {
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h.inc"
 
 namespace mlir::tt {
+SystemDescAttr getCurrentScopeSystemDesc(Operation *op);
 DeviceAttr getCurrentScopeDevice(Operation *op);
 } // namespace mlir::tt
 

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -101,6 +101,10 @@ def TT_SystemDescAttr : TT_Attr<"SystemDesc", "system_desc"> {
   let extraClassDeclaration = [{
     static tt::SystemDescAttr getDefault(MLIRContext *context);
     static tt::SystemDescAttr getFromPath(MLIRContext *context, std::string& path);
+    unsigned getAddressAlignBytes(unsigned chipIndex = 0) const;
+    unsigned getNocL1AddressAlignBytes(unsigned chipIndex = 0) const;
+    unsigned getNocDRAMAddressAlignBytes(unsigned chipIndex = 0) const;
+    unsigned getPcieAddressAlignBytes(unsigned chipIndex = 0) const;
   }];
 }
 
@@ -186,6 +190,12 @@ def TT_LayoutAttr : TT_Attr<"Layout", "layout"> {
                             GridAttr grid = {},
                             ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}},
                             OOBVal oobVal = OOBVal::Undef);
+      LayoutAttr withGrid(::mlir::MLIRContext *context, ArrayRef<int64_t> tensorShape, GridAttr grid, ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}});
+      LayoutAttr withGrid(::mlir::MLIRContext *context,
+                          RankedTensorType ty,
+                          GridAttr grid,
+                          ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}});
+
       MemorySpace getMemorySpace() const;
       bool isSystemMemorySpace() const { return ::mlir::tt::isSystemMemorySpace(getMemorySpace()); }
       bool isDeviceMemorySpace() const { return ::mlir::tt::isDeviceMemorySpace(getMemorySpace()); }
@@ -193,11 +203,6 @@ def TT_LayoutAttr : TT_Attr<"Layout", "layout"> {
       llvm::SmallVector<int64_t> getStride(ArrayRef<int64_t> logicalShape) const;
       llvm::SmallVector<int64_t> getPhysicalShape(ArrayRef<int64_t> logicalShape) const;
       llvm::SmallVector<int64_t> getShardShape() const;
-      LayoutAttr withGrid(::mlir::MLIRContext *context, ArrayRef<int64_t> tensorShape, GridAttr grid, ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}});
-      LayoutAttr withGrid(::mlir::MLIRContext *context,
-                          RankedTensorType ty,
-                          GridAttr grid,
-                          ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}});
       LayoutAttr withElementType(::mlir::MLIRContext *context, Type elementType);
   }];
 }
@@ -239,6 +244,15 @@ def TT_OperandConstraintAttr : EnumAttr<TT_Dialect, TT_OperandConstraint, "opera
 }
 
 def TT_OperandConstraintArrayAttr : TypedArrayAttrBase<TT_OperandConstraintAttr, "">;
+
+def TT_ArgumentAllocationAttr : TT_Attr<"ArgumentAllocation", "arg_alloc", []> {
+  let summary = "Argument allocation attribute in TT dialect";
+  let description = [{
+    Holds the metadata for the allocation of an function argument i.e. for graph inputs.
+  }];
+  let parameters = (ins "uint64_t":$address, "uint64_t":$size, "MemorySpace":$memorySpace);
+  let assemblyFormat = "`<` $address `,` $size `,` $memorySpace `>`";
+}
 
 //===----------------------------------------------------------------------===//
 // TT type definitions

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -60,8 +60,8 @@ def TTIR_GenericOp : TTIR_DPSOp<"generic", [AttrSizedOperandSegments]> {
     let regions = (region AnyRegion:$region);
 }
 
-def TTIR_ToLayoutOp : TTIR_Op<"to_layout", [DestinationStyleOpInterface]> {
-    let summary = "ToLayout op.";
+def TTIR_ToLayoutOp : TTIR_Op<"to_layout", [DestinationStyleOpInterface, TTIROpInterface]> {
+    let summary = "Layout op.";
     let description = [{
       ToLayout operation, transition tensors from one layout to another.  Some examples include:
         - Transitioning between different memory spaces, e.g. DRAM to L1.
@@ -83,6 +83,11 @@ def TTIR_ToLayoutOp : TTIR_Op<"to_layout", [DestinationStyleOpInterface]> {
 
     let extraClassDeclaration = [{
       MutableOperandRange getDpsInitsMutable() { return getOutputMutable(); }
+      ArrayAttr getOperandConstraints() {
+        return nullptr;
+        // TODO return below, but we need a way to properly create an ArrayAttr:
+        // return {OperandConstraint::Any, OperandConstraint::Any};
+      }
     }];
 
     let hasVerifier = 1;

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROpsInterfaces.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROpsInterfaces.td
@@ -25,6 +25,16 @@ def TTIROpInterface : OpInterface<"TTIROp"> {
       /*desc=*/[{
         Get the device of the current scope.
       }],
+      /*retTy=*/"::mlir::tt::SystemDescAttr",
+      /*methodName=*/"getSystemDesc",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/"return ::mlir::tt::getCurrentScopeSystemDesc($_op);"
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Get the device of the current scope.
+      }],
       /*retTy=*/"::mlir::tt::DeviceAttr",
       /*methodName=*/"getDevice",
       /*args=*/(ins),

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -218,7 +218,7 @@ toFlatbuffer(FlatbufferObjectCache &cache, GridAttr tensorGrid,
   SmallVector<std::int64_t> tensorGridShape(tensorGrid.getShape());
   AffineMap mapping = deviceGrid.getMapping();
   ::ttmlir::utils::sample(
-      tensorGridShape, [&](SmallVector<std::int64_t> const &virtualCoreCoord) {
+      tensorGridShape, [&](ArrayRef<std::int64_t> virtualCoreCoord) {
         SmallVector<std::int64_t> coreCoord = mapping.compose(virtualCoreCoord);
         assert(coreCoord.size() == 3 && "expected a 2D core");
         assert(coreCoord[0] == 0 && "expected single device");

--- a/include/ttmlir/Utils.h
+++ b/include/ttmlir/Utils.h
@@ -7,18 +7,23 @@
 
 #include <cstdint>
 
+#include "llvm/ADT/SmallVector.h"
+
 namespace ttmlir::utils {
+template <typename T> T alignUp(T ptr, T alignment) {
+  return (ptr + alignment - 1) & ~(alignment - 1);
+}
 
 template <typename Vector, typename Fn>
 inline void sample(Vector const &shape, Fn fn) {
-  Vector strides(shape.size());
+  llvm::SmallVector<std::int64_t, 8> strides(shape.size());
   std::int64_t stride = 1;
   for (std::int64_t i = shape.size() - 1; i >= 0; --i) {
     strides[i] = stride;
     stride *= shape[i];
   }
 
-  Vector index(shape.size());
+  llvm::SmallVector<std::int64_t, 8> index(shape.size());
   int64_t volume = stride;
   for (int64_t i = 0; i < volume; ++i) {
     for (unsigned j = 0; j < shape.size(); ++j) {

--- a/lib/Dialect/TT/IR/TTOpsTypes.cpp
+++ b/lib/Dialect/TT/IR/TTOpsTypes.cpp
@@ -503,13 +503,17 @@ uint64_t TileType::getSizeBytes() const {
 }
 
 SystemDescAttr mlir::tt::getCurrentScopeSystemDesc(mlir::Operation *op) {
+  // Walk up scope levels until we find the top level ModuleOp which carries the
+  // system desc
   while (op) {
-    if (auto systemDesc =
-            op->getAttrOfType<SystemDescAttr>(SystemDescAttr::name)) {
+    if (mlir::isa<mlir::ModuleOp>(op)) {
+      auto systemDesc = op->getAttrOfType<SystemDescAttr>(SystemDescAttr::name);
+      assert(systemDesc && "expected system desc to be present on the module");
       return systemDesc;
     }
     op = op->getParentOp();
   }
+  assert(false && "expected system desc to be present in the scope");
   return nullptr;
 }
 

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -23,6 +23,9 @@
   if (not outputLayout) {
     return emitOpError("Output tensor type missing layout attribute");
   }
+  if (inputTy.getShape() != outputTy.getShape()) {
+    return emitOpError("Input and output shapes must be the same");
+  }
   return success();
 }
 

--- a/lib/Dialect/TTIR/Transforms/Passes.cpp
+++ b/lib/Dialect/TTIR/Transforms/Passes.cpp
@@ -657,7 +657,7 @@ public:
         argumentAllocations.push_back(rewriter.getAttr<ArgumentAllocationAttr>(
             address, sizeBytes, memorySpace));
       }
-      func->setDiscardableAttr("argument_allocations",
+      func->setDiscardableAttr(ArgumentAllocationAttr::name,
                                rewriter.getArrayAttr(argumentAllocations));
 
       func->walk([&](tensor::EmptyOp empty) {

--- a/lib/Dialect/TTMetal/Transforms/Passes.cpp
+++ b/lib/Dialect/TTMetal/Transforms/Passes.cpp
@@ -250,6 +250,8 @@ public:
 };
 
 void createTTIRToTTMetalBackendPipeline(OpPassManager &pm) {
+  pm.addPass(mlir::tt::ttir::createTTIRLoadSystemDesc());
+  pm.addPass(mlir::tt::ttir::createTTIRImplicitDevice());
   pm.addPass(mlir::tt::ttir::createTTIRGeneric());
   pm.addPass(mlir::tt::ttir::createTTIRLayout());
   pm.addPass(mlir::tt::ttir::createTTIRGenericRegionOperandsToMemref());

--- a/lib/Dialect/TTMetal/Transforms/SerializeToBinary.cpp
+++ b/lib/Dialect/TTMetal/Transforms/SerializeToBinary.cpp
@@ -115,8 +115,8 @@ public:
     cqBuilder.name = entry.getSymName().data();
 
     auto argumentAllocations = mlir::cast<ArrayAttr>(
-        entry->getDiscardableAttr("argument_allocations"));
-    assert(argumentAllocations && "expected argument_allocations attribute");
+        entry->getDiscardableAttr(ArgumentAllocationAttr::name));
+    assert(argumentAllocations && "expected tt.argument_allocations attribute");
     for (auto &input : entry.getBody().getArguments()) {
       auto argAlloc = mlir::cast<tt::ArgumentAllocationAttr>(
           argumentAllocations[input.getArgNumber()]);

--- a/lib/Dialect/TTMetal/Transforms/SerializeToBinary.cpp
+++ b/lib/Dialect/TTMetal/Transforms/SerializeToBinary.cpp
@@ -103,9 +103,6 @@ public:
   }
 
   void runOnOperation() final {
-    constexpr uint64_t kHostAllocatedAddress = 0;
-    constexpr uint64_t kHostAllocatedSize = 0;
-
     ::flatbuffers::FlatBufferBuilder fbb;
     FlatbufferObjectCache cache(&fbb);
     CQBuilder cqBuilder(&fbb);
@@ -117,10 +114,22 @@ public:
     assert(entry && "expected an entry function");
     cqBuilder.name = entry.getSymName().data();
 
+    auto argumentAllocations = mlir::cast<ArrayAttr>(
+        entry->getDiscardableAttr("argument_allocations"));
+    assert(argumentAllocations && "expected argument_allocations attribute");
     for (auto &input : entry.getBody().getArguments()) {
+      auto argAlloc = mlir::cast<tt::ArgumentAllocationAttr>(
+          argumentAllocations[input.getArgNumber()]);
+      assert(
+          argAlloc.getMemorySpace() ==
+              mlir::cast<tt::LayoutAttr>(
+                  mlir::cast<RankedTensorType>(input.getType()).getEncoding())
+                  .getMemorySpace() &&
+          "argument allocation memory space does not match tensor type memory "
+          "space");
       cqBuilder.inputs.push_back(
           cache.getOrCreate(input, tensorValueToFlatbuffer,
-                            kHostAllocatedAddress, kHostAllocatedSize));
+                            argAlloc.getAddress(), argAlloc.getSize()));
     }
 
     module->walk([&](mlir::Operation *op) {
@@ -145,17 +154,16 @@ public:
               mlir::cast<ttkernel::ThreadTypeAttr>(
                   dispatchOp.getThreadTypes()[region.getRegionNumber()])
                   .getValue();
-          std::vector<::tt::target::Dim2dRange> core_range = {
+          std::vector<::tt::target::Dim2dRange> coreRangeSet = {
               toFlatbuffer(mlir::cast<CoreRangeAttr>(
-                  dispatchOp.getCoreRanges()[region.getRegionNumber()])),
-          };
+                  dispatchOp.getCoreRanges()[region.getRegionNumber()]))};
           std::vector<::flatbuffers::Offset<::tt::target::CBRef>> cbs;
           kernels.push_back(::tt::target::metal::CreateKernelDescDirect(
               fbb, ::tt::target::metal::Kernel::KernelSource,
               ::tt::target::metal::CreateKernelSourceDirect(
                   fbb, toFlatbuffer(threadType), source.c_str())
                   .Union(),
-              &core_range, &cbs, nullptr /*TODO debug info*/));
+              &coreRangeSet, &cbs, nullptr /*TODO debug info*/));
         }
         ::flatbuffers::Offset<::tt::target::metal::ProgramDesc> program =
             ::tt::target::metal::CreateProgramDescDirect(fbb, &kernels);

--- a/test/ttmlir/Dialect/TTIR/test_allocate.mlir
+++ b/test/ttmlir/Dialect/TTIR/test_allocate.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttir-layout --ttir-allocate %s | FileCheck %s
+// RUN: ttmlir-opt --ttir-load-system-desc --ttir-implicit-device --ttir-layout --ttir-allocate %s | FileCheck %s
 #any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/Dialect/TTMetal/simple_multiply.mlir
+++ b/test/ttmlir/Dialect/TTMetal/simple_multiply.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttir-generic --ttir-layout --ttir-generic-region-operands-to-memref --ttir-allocate --convert-ttir-to-ttmetal %s | FileCheck %s
+// RUN: ttmlir-opt --ttir-load-system-desc --ttir-implicit-device --ttir-generic --ttir-layout --ttir-generic-region-operands-to-memref --ttir-allocate --convert-ttir-to-ttmetal %s | FileCheck %s
 #any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/Dialect/TTMetal/to_layout.mlir
+++ b/test/ttmlir/Dialect/TTMetal/to_layout.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttir-allocate --convert-ttir-to-ttmetal %s | FileCheck %s
+// RUN: ttmlir-opt --ttir-load-system-desc --ttir-implicit-device --ttir-allocate --convert-ttir-to-ttmetal %s | FileCheck %s
 #l1_ = #tt.memory_space<l1>
 #layout = #tt.layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<64x128xf32, #l1_>>
 #layout1 = #tt.layout<(d0, d1) -> (d0, d1), undef, <1x4>, memref<64x32xf32, #l1_>>


### PR DESCRIPTION
- Enforce the Noc/DRAM/PCIE alignment requirements taken from the system
      descriptor on the allocator.
- Annotate function arguments with new attribute "argument_allocations"
      with info about where inputs are allocated.