### PR TITLE
Add ttnn.emptyOp

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -192,6 +192,16 @@ def TTNN_MatmulOp : TTNN_NamedDPSOp<"matmul"> {
 }
 // ANCHOR_END: adding_an_op_matmul_ttnn
 
+def TTNN_EmptyOp : TTNN_Op<"empty"> {
+    let summary = "Empty op.";
+    let description = [{
+      Tensor empty operation
+    }];
+
+    let arguments = (ins TT_Device:$device);
+    let results = (outs AnyRankedTensor:$result);
+}
+
 def TTNN_FullOp : TTNN_Op<"full"> {
     let summary = "Full op.";
     let description = [{

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -18,6 +18,11 @@ table ToMemoryConfigOp {
   out: tt.target.TensorRef;
 }
 
+table EmptyOp {
+  device: tt.target.DeviceRef;
+  out: tt.target.TensorRef;
+}
+
 table FullOp {
   device: tt.target.DeviceRef;
   fill_value: float;
@@ -76,6 +81,7 @@ union OpType {
   OpenDeviceOp,
   CloseDeviceOp,
   ToMemoryConfigOp,
+  EmptyOp,
   FullOp,
   EltwiseOp,
   MatmulOp,

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -27,7 +27,7 @@ static Value findDevice(Operation *op) {
   return nullptr;
 }
 
-class TensorEmptyToFullConversionPattern
+class TensorEmptyConversionPattern
     : public OpConversionPattern<tensor::EmptyOp> {
 public:
   using OpConversionPattern<tensor::EmptyOp>::OpConversionPattern;
@@ -36,9 +36,8 @@ public:
   matchAndRewrite(tensor::EmptyOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto device = findDevice(op);
-    rewriter.replaceOpWithNewOp<ttnn::FullOp>(
-        op, this->getTypeConverter()->convertType(op.getType()), device,
-        rewriter.getF32FloatAttr(0.0));
+    rewriter.replaceOpWithNewOp<ttnn::EmptyOp>(
+        op, this->getTypeConverter()->convertType(op.getType()), device);
     return success();
   }
 };
@@ -152,7 +151,7 @@ void populateTTIRToTTNNPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
   // clang-format off
   // ANCHOR: adding_an_op_matmul_rewrite_pattern_set
   patterns
-      .add<TensorEmptyToFullConversionPattern,
+      .add<TensorEmptyConversionPattern,
            ToLayoutOpConversionPattern,
            ElementwiseBinaryOpConversionPattern<ttir::AddOp, ttnn::AddOp>,
            ElementwiseBinaryOpConversionPattern<ttir::SubtractOp, ttnn::SubtractOp>,

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -172,6 +172,7 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
 
   // Tensor ops
   //
+  patterns.add<DefaultOpConversionPattern<ttnn::EmptyOp>>(typeConverter, ctx);
   patterns.add<DefaultOpConversionPattern<ttnn::FullOp>>(typeConverter, ctx);
 
   // Eltwise unary ops

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -81,6 +81,18 @@ createOp(FlatbufferObjectCache &cache, ToMemoryConfigOp op) {
       cache.at<::tt::target::TensorRef>(output));
 }
 
+::flatbuffers::Offset<::tt::target::ttnn::EmptyOp>
+createOp(FlatbufferObjectCache &cache, EmptyOp op) {
+  constexpr uint64_t kHostAllocatedAddress = 0;
+  constexpr uint64_t kHostAllocatedSize = 0;
+  auto device = getOperandThroughDPSOps(op.getDevice());
+  auto output = getOperandThroughDPSOps(op.getResult());
+  return ::tt::target::ttnn::CreateEmptyOp(
+      *cache.fbb, cache.at<::tt::target::DeviceRef>(device),
+      cache.getOrCreate(output, tensorValueToFlatbuffer, kHostAllocatedAddress,
+                        kHostAllocatedSize));
+}
+
 ::flatbuffers::Offset<::tt::target::ttnn::FullOp>
 createOp(FlatbufferObjectCache &cache, FullOp op) {
   constexpr uint64_t kHostAllocatedAddress = 0;
@@ -198,6 +210,9 @@ emitTTNNOperation(FlatbufferObjectCache &cache, Operation *op,
       toMemoryConfigOp) {
     return createOperation(cache, createOp(cache, toMemoryConfigOp),
                            debugString);
+  }
+  if (auto emptyOp = dyn_cast<EmptyOp>(op); emptyOp) {
+    return createOperation(cache, createOp(cache, emptyOp), debugString);
   }
   if (auto fullOp = dyn_cast<FullOp>(op); fullOp) {
     return createOperation(cache, createOp(cache, fullOp), debugString);

--- a/runtime/lib/ttnn/program.cpp
+++ b/runtime/lib/ttnn/program.cpp
@@ -178,7 +178,7 @@ run(::tt::target::ttnn::ToMemoryConfigOp const *op, ::ttnn::Device &device,
 }
 
 static void
-run(::tt::target::ttnn::EmptyOp const *op, ::ttnn::device::Device &device,
+run(::tt::target::ttnn::EmptyOp const *op, ::ttnn::Device &device,
     std::unordered_map<std::uint32_t, ::ttnn::Tensor *> &liveTensors,
     std::list<::ttnn::Tensor> &tensorPool) {
 

--- a/runtime/lib/ttnn/program.cpp
+++ b/runtime/lib/ttnn/program.cpp
@@ -320,6 +320,9 @@ run(::tt::target::ttnn::Operation const *op, ::ttnn::Device &device,
   case ::tt::target::ttnn::OpType::ToMemoryConfigOp: {
     return run(op->type_as_ToMemoryConfigOp(), device, liveTensors, tensorPool);
   }
+  case ::tt::target::ttnn::OpType::EmptyOp: {
+    return run(op->type_as_EmptyOp(), device, liveTensors, tensorPool);
+  }
   case ::tt::target::ttnn::OpType::FullOp: {
     // Skip for now, we need an empty op
     break;

--- a/runtime/lib/ttnn/program.cpp
+++ b/runtime/lib/ttnn/program.cpp
@@ -186,9 +186,8 @@ run(::tt::target::ttnn::EmptyOp const *op, ::ttnn::device::Device &device,
       op->out()->desc()->layout()->memory_desc()->data_type());
   // TODO: determine layout, hardcoding tile_layout for now
   auto desiredLayout = ::ttnn::Layout::TILE;
-  // TODO: how do we determine shape from an int* and no known rank?
-  // op->out()->desc()->shape()
-  auto shape = ::ttnn::Shape(::tt::tt_metal::Shape({1, 1, 32, 32}));
+  auto shape = ::ttnn::Shape(::tt::tt_metal::Shape(
+      utils::toShapeFromFBShape(*op->out()->desc()->shape())));
   tensorPool.push_back(
       ::ttnn::empty(shape, targetDataTypeTTNN, desiredLayout, device));
   liveTensors.try_emplace(op->out()->global_id(), &tensorPool.back());

--- a/runtime/lib/ttnn/utils.h
+++ b/runtime/lib/ttnn/utils.h
@@ -5,6 +5,7 @@
 #ifndef TTNN_RUNTIME_UTILS_H
 #define TTNN_RUNTIME_UTILS_H
 
+#include "flatbuffers/vector.h"
 #include "ttmlir/Target/TTNN/Target.h"
 #include "ttnn/types.hpp"
 
@@ -34,6 +35,11 @@ inline ::ttnn::DataType toTTNNDataType(::tt::target::DataType dataType) {
   default:
     throw std::runtime_error("Unsupported data type");
   }
+}
+
+inline std::vector<uint32_t>
+toShapeFromFBShape(const flatbuffers::Vector<int32_t> &vec) {
+  return std::vector<uint32_t>(vec.begin(), vec.end());
 }
 
 } // namespace tt::runtime::ttnn::utils

--- a/test/ttmlir/Dialect/TTNN/simple_ge.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_ge.mlir
@@ -3,7 +3,7 @@
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
     // CHECK: %[[C:.*]] = "ttnn.open_device"[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttnn.full"[[C:.*]]
+    // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
     %0 = tensor.empty() : tensor<64x128xf32>
     // CHECK: %[[C:.*]] = "ttnn.ge"[[C:.*]]
     %1 = "ttir.ge"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>

--- a/test/ttmlir/Dialect/TTNN/simple_mean.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_mean.mlir
@@ -3,7 +3,7 @@
 module attributes {tt.system_desc = #tt.system_desc<[{arch = <wormhole_b0>, grid = 8x8, l1_size = 1048576, num_dram_channels = 12, dram_channel_size = 1048576, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32}], [0], [<pcie|host_mmio>], [<0, 0, 0, 0>]>} {
   func.func @forward(%arg0: tensor<512x1024xbf16>) -> tensor<512x32xbf16> {
     // CHECK: %[[C:.*]] = "ttnn.open_device"[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttnn.full"[[C:.*]]
+    // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
     %0 = tensor.empty() : tensor<512x32xbf16>
     // CHECK: %[[C:.*]] = "ttnn.mean"[[C:.*]]
     %1 = "ttir.mean"(%arg0, %0) <{dim_arg = [-1: i32], keep_dim = true, operand_constraints = [#any_device, #any_device]}> : (tensor<512x1024xbf16>, tensor<512x32xbf16>) -> tensor<512x32xbf16>

--- a/test/ttmlir/Dialect/TTNN/simple_multiply.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_multiply.mlir
@@ -3,7 +3,7 @@
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
     // CHECK: %[[C:.*]] = "ttnn.open_device"[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttnn.full"[[C:.*]]
+    // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
     %0 = tensor.empty() : tensor<64x128xf32>
     // CHECK: %[[C:.*]] = "ttnn.multiply"[[C:.*]]
     %1 = "ttir.multiply"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>

--- a/test/ttmlir/Dialect/TTNN/simple_relu.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_relu.mlir
@@ -3,7 +3,7 @@
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
     // CHECK: %[[C:.*]] = "ttnn.open_device"[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttnn.full"[[C:.*]]
+    // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
     %0 = tensor.empty() : tensor<64x128xf32>
     // CHECK: %[[C:.*]] = "ttnn.relu"[[C:.*]]
     %1 = "ttir.relu"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>, operand_constraints = [#any_device, #any_device]}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>

--- a/test/ttmlir/Dialect/TTNN/simple_subtract.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_subtract.mlir
@@ -3,7 +3,7 @@
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
     // CHECK: %[[C:.*]] = "ttnn.open_device"[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttnn.full"[[C:.*]]
+    // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
     %0 = tensor.empty() : tensor<64x128xf32>
     // CHECK: %[[C:.*]] = "ttnn.subtract"[[C:.*]]
     %1 = "ttir.subtract"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>

--- a/test/ttmlir/Dialect/TTNN/simple_sum.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_sum.mlir
@@ -3,7 +3,7 @@
 module attributes {} {
   func.func @forward(%arg0: tensor<512x1024xbf16>) -> tensor<512x32xbf16> {
     // CHECK: %[[C:.*]] = "ttnn.open_device"[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttnn.full"[[C:.*]]
+    // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
     %0 = tensor.empty() : tensor<512x32xbf16>
     // CHECK: %[[C:.*]] = "ttnn.sum"[[C:.*]]
     %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [-1: i32], keep_dim = true, operand_constraints = [#any_device, #any_device]}> : (tensor<512x1024xbf16>, tensor<512x32xbf16>) -> tensor<512x32xbf16>

--- a/test/ttmlir/Dialect/TTNN/softmax/simple_softmax.mlir
+++ b/test/ttmlir/Dialect/TTNN/softmax/simple_softmax.mlir
@@ -3,12 +3,12 @@
 module attributes {} {
   func.func @forward(%arg0: tensor<512x1024xbf16>) -> tensor<512x1024xbf16> {
     // CHECK: %[[C:.*]] = "ttnn.open_device"[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttnn.full"[[C:.*]]
+    // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
     %0 = tensor.empty() : tensor<512x1024xbf16>
     // CHECK: %[[C:.*]] = "ttnn.softmax"[[C:.*]]
     // Check for positive dimension attribute
     %1 = "ttir.softmax"(%arg0, %0) <{dimension = 1 : si32, operand_constraints = [#any_device, #any_device]}> : (tensor<512x1024xbf16>, tensor<512x1024xbf16>) -> tensor<512x1024xbf16>
-    // CHECK: %[[C:.*]] = "ttnn.full"[[C:.*]]
+    // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
     %2 = tensor.empty() : tensor<512x1024xbf16>
     // CHECK: %[[C:.*]] = "ttnn.softmax"[[C:.*]]
     // Check for negative dimension attribute

--- a/test/ttmlir/Dialect/TTNN/ttir_to_ttnn_pipeline.mlir
+++ b/test/ttmlir/Dialect/TTNN/ttir_to_ttnn_pipeline.mlir
@@ -4,7 +4,7 @@ module attributes {} {
   func.func @forward(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
     // CHECK: #[[LAYOUT_1:.*]] = #tt.layout<(d0, d1) -> (d0, d1), undef, <8x8>, memref<8x16xf32, #l1_>>
     // CHECK: %[[C:.*]] = "ttnn.open_device"[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttnn.full"[[C:.*]]
+    // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
     %0 = tensor.empty() : tensor<64x128xf32>
     // CHECK: %[[C:.*]] = "ttnn.multiply"[[C:.*]] -> tensor<64x128xf32, #[[LAYOUT_1]]>
     %1 = "ttir.multiply"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>

--- a/test/ttmlir/Dialect/TTNN/ttir_to_ttnn_pipeline_custom_opt.mlir
+++ b/test/ttmlir/Dialect/TTNN/ttir_to_ttnn_pipeline_custom_opt.mlir
@@ -4,7 +4,7 @@ module attributes {} {
   func.func @forward(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
     // CHECK: #[[LAYOUT_1:.*]] = #tt.layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<64x128xf32, #l1_>>
     // CHECK: %[[C:.*]] = "ttnn.open_device"[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttnn.full"[[C:.*]]
+    // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
     %0 = tensor.empty() : tensor<64x128xf32>
     // CHECK: %[[C:.*]] = "ttnn.multiply"[[C:.*]] -> tensor<64x128xf32, #[[LAYOUT_1:.*]]>
     %1 = "ttir.multiply"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>

--- a/test/ttmlir/Silicon/TTNN/simple_eltwise.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_eltwise.mlir
@@ -6,7 +6,7 @@
 
 func.func @subtract(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
   // CHECK: %[[C:.*]] = "ttnn.open_device"[[C:.*]]
-  // CHECK: %[[C:.*]] = "ttnn.full"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
   %0 = tensor.empty() : tensor<64x128xf32>
   // CHECK: %[[C:.*]] = "ttnn.subtract"[[C:.*]]
   %1 = "ttir.subtract"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
@@ -16,7 +16,7 @@ func.func @subtract(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> ten
 
 func.func @multiply(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
   // CHECK: %[[C:.*]] = "ttnn.open_device"[[C:.*]]
-  // CHECK: %[[C:.*]] = "ttnn.full"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
   %0 = tensor.empty() : tensor<64x128xf32>
   // CHECK: %[[C:.*]] = "ttnn.multiply"[[C:.*]]
   %1 = "ttir.multiply"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
@@ -26,7 +26,7 @@ func.func @multiply(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> ten
 
 func.func @relu(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
   // CHECK: %[[C:.*]] = "ttnn.open_device"[[C:.*]]
-  // CHECK: %[[C:.*]] = "ttnn.full"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
   %0 = tensor.empty() : tensor<64x128xf32>
   // CHECK: %[[C:.*]] = "ttnn.relu"[[C:.*]]
   %1 = "ttir.relu"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>, operand_constraints = [#any_device, #any_device]}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
@@ -36,7 +36,7 @@ func.func @relu(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
 
 func.func @ge(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
   // CHECK: %[[C:.*]] = "ttnn.open_device"[[C:.*]]
-  // CHECK: %[[C:.*]] = "ttnn.full"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
   %0 = tensor.empty() : tensor<64x128xf32>
   // CHECK: %[[C:.*]] = "ttnn.ge"[[C:.*]]
   %1 = "ttir.ge"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>

--- a/test/ttmlir/Silicon/TTNN/simple_ge.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_ge.mlir
@@ -6,7 +6,7 @@
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
     // CHECK: %[[C:.*]] = "ttnn.open_device"[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttnn.full"[[C:.*]]
+    // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
     %0 = tensor.empty() : tensor<64x128xf32>
     // CHECK: %[[C:.*]] = "ttnn.ge"[[C:.*]]
     %1 = "ttir.ge"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>

--- a/test/ttmlir/Silicon/TTNN/simple_multiply.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_multiply.mlir
@@ -6,7 +6,7 @@
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
     // CHECK: %[[C:.*]] = "ttnn.open_device"[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttnn.full"[[C:.*]]
+    // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
     %0 = tensor.empty() : tensor<64x128xf32>
     // CHECK: %[[C:.*]] = "ttnn.multiply"[[C:.*]]
     %1 = "ttir.multiply"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>

--- a/test/ttmlir/Silicon/TTNN/simple_relu.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_relu.mlir
@@ -6,7 +6,7 @@
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
     // CHECK: %[[C:.*]] = "ttnn.open_device"[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttnn.full"[[C:.*]]
+    // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
     %0 = tensor.empty() : tensor<64x128xf32>
     // CHECK: %[[C:.*]] = "ttnn.relu"[[C:.*]]
     %1 = "ttir.relu"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>, operand_constraints = [#any_device, #any_device]}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>

--- a/test/ttmlir/Silicon/TTNN/simple_subtract.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_subtract.mlir
@@ -6,7 +6,7 @@
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
     // CHECK: %[[C:.*]] = "ttnn.open_device"[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttnn.full"[[C:.*]]
+    // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
     %0 = tensor.empty() : tensor<64x128xf32>
     // CHECK: %[[C:.*]] = "ttnn.subtract"[[C:.*]]
     %1 = "ttir.subtract"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>

--- a/test/ttmlir/Silicon/TTNN/simple_sum.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_sum.mlir
@@ -6,7 +6,7 @@
 module attributes {} {
   func.func @forward(%arg0: tensor<512x1024xbf16>) -> tensor<512x32xbf16> {
     // CHECK: %[[C:.*]] = "ttnn.open_device"[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttnn.full"[[C:.*]]
+    // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
     %0 = tensor.empty() : tensor<512x32xbf16>
     // CHECK: %[[C:.*]] = "ttnn.sum"[[C:.*]]
     %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [-1: i32], keep_dim = true, operand_constraints = [#any_device, #any_device]}> : (tensor<512x1024xbf16>, tensor<512x32xbf16>) -> tensor<512x32xbf16>


### PR DESCRIPTION
- Add `ttnn.emptyOp` to match TTNN lib API
- Update tests to expect `ttnn.empty()` instead of `ttnn.full()` when converting from `tensor.empty()`

Resolves #373 