### PR TITLE
Add ttmlir-translate to check-ttmlir target

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,7 @@ configure_lit_site_cfg(
 set(TTMLIR_TEST_DEPENDS
         FileCheck count not
         ttmlir-opt
+        ttmlir-translate
         )
 if(MLIR_ENABLE_BINDINGS_PYTHON AND TTMLIR_ENABLE_BINDINGS_PYTHON)
   list(APPEND TTMLIR_TEST_DEPENDS TTMLIRPythonModules)


### PR DESCRIPTION
- Fixes issue where `cmake --build build -- check-ttmlir` would fail on a clean build, as `ttmlir-translate` wouldn't be compiled