### PR TITLE
Update SystemDesc's ChipDesc to have Worker, Dram, Eth physical core list

### DIFF
--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -55,14 +55,35 @@ def TT_ArchAttr : EnumAttr<TT_Dialect, TT_Arch, "arch"> {
   let assemblyFormat = "`<` $value `>`";
 }
 
+def TT_CoreCoordAttr : TT_Attr<"CoreCoord", "core_coord"> {
+  let summary = "TT core_coord attribute";
+  let description = [{
+    TT core_coord attribute containing a single physical core coordinate.
+  }];
+
+  let parameters = (ins "int64_t":$y, "int64_t":$x);
+  let assemblyFormat = "`(` $y `,` $x `)`";
+}
+
+
+def TT_ChipPhysicalCoresAttr : TT_Attr<"ChipPhysicalCores", "chip_physical_cores"> {
+  let summary = "TT chip_physical_cores attribute";
+  let description = [{
+    TT chip_physical_cores attribute containing arrays of physical cores by core type in order of logical cores.
+  }];
+
+  let parameters = (ins ArrayRefParameter<"CoreCoordAttr">:$worker, ArrayRefParameter<"CoreCoordAttr">:$dram, ArrayRefParameter<"CoreCoordAttr">:$eth, ArrayRefParameter<"CoreCoordAttr">:$eth_inactive);
+  let assemblyFormat = "`{` `worker` `=` `[` $worker `]` `,` `dram` `=` `[` $dram `]` `,` `eth` `=` `[` $eth `]` `,` `eth_inactive` `=` `[` $eth_inactive `]` `}`";
+}
+
 def TT_ChipDescAttr : TT_Attr<"ChipDesc", "chip_desc"> {
   let summary = "TT chip_desc attribute";
   let description = [{
     TT chip_desc attribute
   }];
 
-  let parameters = (ins "ArchAttr":$arch, ArrayRefParameter<"int64_t">:$grid, "unsigned":$l1Size, "unsigned":$numDramChannels, "unsigned":$dramChannelSize, "unsigned":$nocL1AddressAlignBytes, "unsigned":$pcieAddressAlignBytes, "unsigned":$nocDRAMAddressAlignBytes);
-  let assemblyFormat = "`{` `arch` `=` $arch `,` `grid` `=` custom<DimensionList>($grid) `,` `l1_size` `=` $l1Size `,` `num_dram_channels` `=` $numDramChannels `,` `dram_channel_size` `=` $dramChannelSize `,` `noc_l1_address_align_bytes` `=` $nocL1AddressAlignBytes `,` `pcie_address_align_bytes` `=` $pcieAddressAlignBytes `,` `noc_dram_address_align_bytes` `=` $nocDRAMAddressAlignBytes `}`";
+  let parameters = (ins "ArchAttr":$arch, ArrayRefParameter<"int64_t">:$grid, "unsigned":$l1Size, "unsigned":$numDramChannels, "unsigned":$dramChannelSize, "unsigned":$nocL1AddressAlignBytes, "unsigned":$pcieAddressAlignBytes, "unsigned":$nocDRAMAddressAlignBytes, "ChipPhysicalCoresAttr":$chipPhysicalCores);
+  let assemblyFormat = "`{` `arch` `=` $arch `,` `grid` `=` custom<DimensionList>($grid) `,` `l1_size` `=` $l1Size `,` `num_dram_channels` `=` $numDramChannels `,` `dram_channel_size` `=` $dramChannelSize `,` `noc_l1_address_align_bytes` `=` $nocL1AddressAlignBytes `,` `pcie_address_align_bytes` `=` $pcieAddressAlignBytes `,` `noc_dram_address_align_bytes` `=` $nocDRAMAddressAlignBytes  `,` `physical_cores` `=` $chipPhysicalCores  `}`";
 }
 
 def TT_ChipCoordAttr : TT_Attr<"ChipCoord", "chip_coord"> {

--- a/include/ttmlir/Target/Common/types.fbs
+++ b/include/ttmlir/Target/Common/types.fbs
@@ -102,6 +102,7 @@ table ChipDesc {
   noc_l1_address_align_bytes: uint32;
   pcie_address_align_bytes: uint32;
   noc_dram_address_align_bytes: uint32;
+  physical_cores: ChipPhysicalCores;
 }
 
 struct ChipCoord {
@@ -116,6 +117,13 @@ struct ChipChannel {
   ethernet_core_coord0: Dim2d;
   device_id1: uint32;
   ethernet_core_coord1: Dim2d;
+}
+
+table ChipPhysicalCores {
+  worker: [Dim2d];
+  dram: [Dim2d];
+  eth: [Dim2d];
+  eth_inactive: [Dim2d];
 }
 
 table SystemDesc {

--- a/lib/CAPI/TTAttrs.cpp
+++ b/lib/CAPI/TTAttrs.cpp
@@ -26,18 +26,17 @@ MlirAttribute ttmlirTTArchAttrGet(MlirContext ctx, uint32_t arch) {
   return wrap(ArchAttr::get(unwrap(ctx), static_cast<Arch>(arch)));
 }
 
-MlirAttribute ttmlirTTChipDescAttrGet(MlirContext ctx, MlirAttribute arch,
-                                      int64_t *grid, size_t gridSize,
-                                      unsigned l1Size, unsigned numDramChannels,
-                                      unsigned dramChannelSize,
-                                      unsigned nocL1AddressAlignBytes,
-                                      unsigned pcieAddressAlignBytes,
-                                      unsigned nocDRAMAddressAlignBytes) {
+MlirAttribute ttmlirTTChipDescAttrGet(
+    MlirContext ctx, MlirAttribute arch, int64_t *grid, size_t gridSize,
+    unsigned l1Size, unsigned numDramChannels, unsigned dramChannelSize,
+    unsigned nocL1AddressAlignBytes, unsigned pcieAddressAlignBytes,
+    unsigned nocDRAMAddressAlignBytes, MlirAttribute chipPhysicalCores) {
   std::vector<int64_t> gridVec(grid, grid + gridSize);
   return wrap(ChipDescAttr::get(
       unwrap(ctx), mlir::dyn_cast<ArchAttr>(unwrap(arch)), gridVec, l1Size,
       numDramChannels, dramChannelSize, nocL1AddressAlignBytes,
-      pcieAddressAlignBytes, nocDRAMAddressAlignBytes));
+      pcieAddressAlignBytes, nocDRAMAddressAlignBytes,
+      mlir::dyn_cast<ChipPhysicalCoresAttr>(unwrap(chipPhysicalCores))));
 }
 
 MlirAttribute ttmlirTTChipCoordAttrGet(MlirContext ctx, unsigned rack,

--- a/python/TTModule.cpp
+++ b/python/TTModule.cpp
@@ -114,11 +114,14 @@ void populateTTModule(py::module &m) {
                             unsigned numDramChannels, unsigned dramChannelSize,
                             unsigned nocL1AddressAlignBytes,
                             unsigned pcieAddressAlignBytes,
-                            unsigned nocDRAMAddressAlignBytes) {
+                            unsigned nocDRAMAddressAlignBytes,
+                            MlirAttribute chipPhysicalCores) {
         return wrap(tt::ChipDescAttr::get(
             unwrap(ctx), mlir::cast<tt::ArchAttr>(unwrap(arch)), grid, l1Size,
             numDramChannels, dramChannelSize, nocL1AddressAlignBytes,
-            pcieAddressAlignBytes, nocDRAMAddressAlignBytes));
+            pcieAddressAlignBytes, nocDRAMAddressAlignBytes,
+            mlir::dyn_cast<tt::ChipPhysicalCoresAttr>(
+                unwrap(chipPhysicalCores))));
       });
 
   py::class_<tt::ChipCoordAttr>(m, "ChipCoordAttr")

--- a/test/ttmlir/Dialect/TTIR/test_allocate.mlir
+++ b/test/ttmlir/Dialect/TTIR/test_allocate.mlir
@@ -2,7 +2,7 @@
 #any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 #l1_ = #tt.memory_space<l1>
 #layout = #tt.layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<64x128xf32, #l1_>>
-module attributes {tt.device = #tt.device<#tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, [0]>, tt.system_desc = #tt.system_desc<[{arch = <wormhole_b0>, grid = 8x8, l1_size = 1499136, num_dram_channels = 12, dram_channel_size = 1073741824, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32}], [0], [<pcie|host_mmio>], [<0, 0, 0, 0>]>} {
+module attributes {} {
   func.func @forward(%arg0: tensor<64x128xf32, #layout>, %arg1: tensor<64x128xf32, #layout>) -> tensor<64x128xf32, #layout> {
     // CHECK: %[[C:.*]] = "ttir.alloc"[[C:.*]]
     // CHECK-NOT: %[[C:.*]] = tensor.empty() : tensor<64x128xf32>

--- a/test/ttmlir/Dialect/TTNN/simple_mean.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_mean.mlir
@@ -1,6 +1,6 @@
-// RUN: ttmlir-opt --ttir-layout --ttnn-open-device --convert-ttir-to-ttnn %s | FileCheck %s
+// RUN: ttmlir-opt --ttir-load-system-desc --ttir-layout --ttnn-open-device --convert-ttir-to-ttnn %s | FileCheck %s
 #any_device = #tt.operand_constraint<dram|l1|tile|any_device|any_device_tile>
-module attributes {tt.system_desc = #tt.system_desc<[{arch = <wormhole_b0>, grid = 8x8, l1_size = 1048576, num_dram_channels = 12, dram_channel_size = 1048576, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32}], [0], [<pcie|host_mmio>], [<0, 0, 0, 0>]>} {
+module attributes {} {
   func.func @forward(%arg0: tensor<512x1024xbf16>) -> tensor<512x32xbf16> {
     // CHECK: %[[C:.*]] = "ttnn.open_device"[[C:.*]]
     // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]


### PR DESCRIPTION
Closes #264

First TTMLIR PR finally, hooray.

from commit desc:

 - Originally was going to have logical to phyical cores by type, but after some discussion, storing physical cores only, by type under ChipDesc
 - Create TT_CoreCoordAttr layer w/ Y,X members to make printing nicer and in the format [(1, 2), (2, 3)] for 2 core coordinates.
 
 
 Tested with below commands:
 
 
 ```
 
% ttrt query --save-artifacts --system-desc // Looked at system desc, looks good
%  ./build/bin/ttmlir-opt --ttir-to-ttnn-backend-pipeline --ttir-load-system-desc="path=./ttrt-artifacts/system_desc.ttsys" test/ttmlir/Dialect/TTNN/simple_subtract.mlir

#l1_ = #tt.memory_space<l1>
#system = #tt.memory_space<system>
#layout = #tt.layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<64x128xf32, #system>>
#layout1 = #tt.layout<(d0, d1) -> (d0, d1), undef, <8x8>, memref<8x16xf32, #system>>
#layout2 = #tt.layout<(d0, d1) -> (d0, d1), undef, <8x8>, memref<8x16xf32, #l1_>>
module attributes {tt.device = #tt.device<#tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, [0]>, tt.system_desc = #tt.system_desc<[{arch = <wormhole_b0>, grid = 7x8, l1_size = 1499136, num_dram_channels = 12, dram_channel_size = 1073741824, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32, physical_cores = {worker = [(2, 1), (2, 2), (2, 3), (2, 4), (2, 6), (2, 7), (2, 8), (2, 9), (3, 1), (3, 2), (3, 3), (3, 4), (3, 6), (3, 7), (3, 8), (3, 9), (4, 1), (4, 2), (4, 3), (4, 4), (4, 6), (4, 7), (4, 8), (4, 9), (5, 1), (5, 2), (5, 3), (5, 4), (5, 6), (5, 7), (5, 8), (5, 9), (7, 1), (7, 2), (7, 3), (7, 4), (7, 6), (7, 7), (7, 8), (7, 9), (8, 1), (8, 2), (8, 3), (8, 4), (8, 6), (8, 7), (8, 8), (8, 9), (9, 1), (9, 2), (9, 3), (9, 4), (9, 6), (9, 7), (9, 8), (9, 9), (10, 1), (10, 2), (10, 3), (10, 4), (10, 6), (10, 7), (10, 8), (10, 9)], dram = [(11, 0), (1, 0), (5, 0), (7, 0), (1, 5), (11, 5), (2, 5), (9, 5), (8, 5), (3, 5), (5, 5), (7, 5)], eth = [(6, 9), (6, 1)], eth_inactive = [(6, 7), (6, 2), (6, 8), (0, 4), (0, 6), (0, 3), (0, 7), (0, 2), (0, 8), (6, 6), (0, 1), (6, 3), (0, 9)]}}, {arch = <wormhole_b0>, grid = 7x8, l1_size = 1499136, num_dram_channels = 12, dram_channel_size = 1073741824, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32, physical_cores = {worker = [(2, 1), (2, 2), (2, 3), (2, 4), (2, 6), (2, 7), (2, 8), (2, 9), (3, 1), (3, 2), (3, 3), (3, 4), (3, 6), (3, 7), (3, 8), (3, 9), (4, 1), (4, 2), (4, 3), (4, 4), (4, 6), (4, 7), (4, 8), (4, 9), (5, 1), (5, 2), (5, 3), (5, 4), (5, 6), (5, 7), (5, 8), (5, 9), (7, 1), (7, 2), (7, 3), (7, 4), (7, 6), (7, 7), (7, 8), (7, 9), (8, 1), (8, 2), (8, 3), (8, 4), (8, 6), (8, 7), (8, 8), (8, 9), (9, 1), (9, 2), (9, 3), (9, 4), (9, 6), (9, 7), (9, 8), (9, 9), (10, 1), (10, 2), (10, 3), (10, 4), (10, 6), (10, 7), (10, 8), (10, 9)], dram = [(11, 0), (1, 0), (5, 0), (7, 0), (1, 5), (11, 5), (2, 5), (9, 5), (8, 5), (3, 5), (5, 5), (7, 5)], eth = [(0, 9), (0, 1)], eth_inactive = [(6, 4), (0, 8), (0, 2), (0, 7), (0, 3), (0, 6), (0, 4), (6, 9), (6, 1), (6, 8), (6, 2), (6, 7), (6, 3), (6, 6)]}}], [0, 1], [<pcie|host_mmio>, <pcie>], [<0, 0, 0, 0>]>} {
```

and a test:

```
./build/bin/ttmlir-opt --ttir-to-ttnn-backend-pipeline --ttir-load-system-desc="path=./ttrt-artifacts/system_desc.ttsys" test/ttmlir/Dialect/TTNN/simple_subtract.mlir | ./build/bin/ttmlir-translate  --ttnn-to-flatbuffer -o out.ttnn
TTMLIR_SUBTRACT_FB_PATH=/localdev/kmabee/mlir2/out.ttnn ctest --test-dir ./build/runtime/test -R TTNNSubtract --verbose |& tee run_test.log
<passes>
```
 
 Wanted to run thse, but I only have N300 for now and they fai with "only single chip supported for now" assert.
 
```
export SYSTEM_DESC_PATH=/some/path
llvm-lit -v test/ttmlir/Silicon
ttrt run build/test/ttmlir/Silicon
```