### PR TITLE
Split compound layout pass #356

### DIFF
--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -198,17 +198,19 @@ def TT_LayoutAttr : TT_Attr<"Layout", "layout"> {
                           RankedTensorType ty,
                           GridAttr grid,
                           ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}});
+      LayoutAttr withElementType(::mlir::MLIRContext *context, Type elementType);
+      LayoutAttr withMemorySpace(::mlir::MLIRContext *context, MemorySpace memorySpace);
 
       MemorySpace getMemorySpace() const;
       bool isSystemMemorySpace() const { return ::mlir::tt::isSystemMemorySpace(getMemorySpace()); }
       bool isDeviceMemorySpace() const { return ::mlir::tt::isDeviceMemorySpace(getMemorySpace()); }
       bool isTiled() const;
       Type getElementType() const;
+      Type getScalarElementType() const;
       uint64_t getElementSizeBytes() const;
       llvm::SmallVector<int64_t> getStride(ArrayRef<int64_t> logicalShape) const;
       llvm::SmallVector<int64_t> getPhysicalShape(ArrayRef<int64_t> logicalShape) const;
       llvm::SmallVector<int64_t> getShardShape() const;
-      LayoutAttr withElementType(::mlir::MLIRContext *context, Type elementType);
   }];
 }
 
@@ -280,6 +282,9 @@ def TT_Tile : TT_Type<"Tile", "tile", [MemRefElementTypeInterface]> {
       uint64_t getSizeBytes() const;
       int64_t getHeight() const { return getShape()[0]; }
       int64_t getWidth() const { return getShape()[1]; }
+      // Returns the scalar element type of the tile, if compressed it returns
+      // the corresponding uncompressed element type, i.e. bfp_bf8 -> bf16
+      Type getElementType() const;
     }];
 
     let genVerifyDecl = 1;

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -88,6 +88,8 @@ def TTIR_ToLayoutOp : TTIR_Op<"to_layout", [DestinationStyleOpInterface, TTIROpI
         // TODO return below, but we need a way to properly create an ArrayAttr:
         // return {OperandConstraint::Any, OperandConstraint::Any};
       }
+      // Returns a tuple of booleans indicating if the op changes layout, grid, format, or memory space.
+      std::tuple<bool, bool, bool, bool> compoundComponents();
     }];
 
     let hasVerifier = 1;

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -43,6 +43,15 @@ def TTIRLayout: Pass<"ttir-layout", "::mlir::ModuleOp"> {
   ];
 }
 
+def TTIRSplitCompoundLayout: Pass<"ttir-split-compound-layout", "::mlir::ModuleOp"> {
+  let summary = "Split compound layouts.";
+  let description = [{
+    A single to_layout op in ttir can simultaneously perform multiple layout transformations
+    at once, including changing layout, format, or memory space. This pass splits each of
+    these transformation categories into separate to_layout ops.
+  }];
+}
+
 def TTIRAllocate: Pass<"ttir-allocate", "::mlir::ModuleOp"> {
   let summary = "Allocate tensors.";
   let description = [{

--- a/lib/Dialect/TT/IR/TTOpsTypes.cpp
+++ b/lib/Dialect/TT/IR/TTOpsTypes.cpp
@@ -357,6 +357,14 @@ mlir::Type LayoutAttr::getElementType() const {
   return getMemref().getElementType();
 }
 
+mlir::Type LayoutAttr::getScalarElementType() const {
+  auto elementType = getElementType();
+  if (mlir::isa<TileType>(elementType)) {
+    return mlir::cast<TileType>(elementType).getElementType();
+  }
+  return elementType;
+}
+
 bool LayoutAttr::isTiled() const {
   return ::mlir::isa<::mlir::tt::TileType>(getElementType());
 }
@@ -389,6 +397,13 @@ LayoutAttr LayoutAttr::withElementType(::mlir::MLIRContext *context,
   return LayoutAttr::get(
       context, getLinear(), getOobVal(), getGrid(),
       buildMemRef(context, getShardShape(), elementType, getMemorySpace()));
+}
+
+LayoutAttr LayoutAttr::withMemorySpace(::mlir::MLIRContext *context,
+                                       MemorySpace memorySpace) {
+  return LayoutAttr::get(
+      context, getLinear(), getOobVal(), getGrid(),
+      buildMemRef(context, getShardShape(), getElementType(), memorySpace));
 }
 
 MemorySpace LayoutAttr::getMemorySpace() const {
@@ -522,6 +537,35 @@ uint64_t TileType::getSizeBytes() const {
     return getHeight() * getWidth() * 2;
   case DataType::UInt8:
     return getHeight() * getWidth();
+  }
+}
+
+mlir::Type TileType::getElementType() const {
+  switch (getDataType()) {
+  case DataType::Float32:
+    return FloatType::getF32(getContext());
+  case DataType::Float16:
+    return FloatType::getF16(getContext());
+  case DataType::BFloat16:
+    return FloatType::getBF16(getContext());
+  case DataType::BFP_Float8:
+    return FloatType::getF16(getContext());
+  case DataType::BFP_BFloat8:
+    return FloatType::getBF16(getContext());
+  case DataType::BFP_Float4:
+    return FloatType::getF16(getContext());
+  case DataType::BFP_BFloat4:
+    return FloatType::getBF16(getContext());
+  case DataType::BFP_Float2:
+    return FloatType::getF16(getContext());
+  case DataType::BFP_BFloat2:
+    return FloatType::getBF16(getContext());
+  case DataType::UInt32:
+    return IntegerType::get(getContext(), 32);
+  case DataType::UInt16:
+    return IntegerType::get(getContext(), 16);
+  case DataType::UInt8:
+    return IntegerType::get(getContext(), 8);
   }
 }
 

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -29,6 +29,25 @@
   return success();
 }
 
+std::tuple<bool, bool, bool, bool>
+mlir::tt::ttir::ToLayoutOp::compoundComponents() {
+  auto inputLayout =
+      mlir::cast<tt::LayoutAttr>(getInput().getType().getEncoding());
+  auto outputLayout =
+      mlir::cast<tt::LayoutAttr>(getOutput().getType().getEncoding());
+  bool isLayoutChange = inputLayout.getLinear() != outputLayout.getLinear();
+  bool isGridChange = inputLayout.getGrid() != outputLayout.getGrid();
+  bool isShardChange =
+      inputLayout.getShardShape() != outputLayout.getShardShape();
+  assert(isGridChange == isShardChange);
+  bool isFormatChange =
+      inputLayout.getElementType() != outputLayout.getElementType();
+  bool isMemorySpaceChange =
+      inputLayout.getMemorySpace() != outputLayout.getMemorySpace();
+  return std::make_tuple(isLayoutChange, isGridChange, isFormatChange,
+                         isMemorySpaceChange);
+}
+
 ::mlir::LogicalResult mlir::tt::ttir::SoftmaxOp::verify() {
   ::mlir::RankedTensorType inputType = getInput().getType();
   ::mlir::RankedTensorType outputType = getOutput().getType();

--- a/test/ttmlir/Dialect/TTIR/split_compound_layout.mlir
+++ b/test/ttmlir/Dialect/TTIR/split_compound_layout.mlir
@@ -1,0 +1,80 @@
+// RUN: ttmlir-opt --ttir-split-compound-layout %s | FileCheck %s
+
+#dram = #tt.memory_space<dram>
+#l1_ = #tt.memory_space<l1>
+
+// CHECK-DAG: #[[row_major1x1:.*]] = #tt.layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<64x128xf32, #l1_>>
+// CHECK-DAG: #[[row_major1x1_T:.*]] = #tt.layout<(d0, d1) -> (d1, d0), undef, <1x1>, memref<64x128xf32, #l1_>>
+// CHECK-DAG: #[[row_major2x2:.*]] = #tt.layout<(d0, d1) -> (d0, d1), undef, <2x2>, memref<32x64xf32, #l1_>>
+// CHECK-DAG: #[[tile1x1_f32:.*]] = #tt.layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<2x4x!tt.tile<32x32, f32>, #l1_>>
+// CHECK-DAG: #[[tile1x1_bf16:.*]] = #tt.layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<2x4x!tt.tile<32x32, bf16>, #l1_>>
+// CHECK-DAG: #[[tile1x1_f32_dram:.*]] = #tt.layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<2x4x!tt.tile<32x32, f32>, #dram>>
+// CHECK-DAG: #[[tile2x2_f32:.*]] = #tt.layout<(d0, d1) -> (d0, d1), undef, <2x2>, memref<1x2x!tt.tile<32x32, f32>, #l1_>>
+
+#row_major1x1 = #tt.layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<64x128xf32, #l1_>>
+#row_major1x1_T = #tt.layout<(d0, d1) -> (d1, d0), undef, <1x1>, memref<64x128xf32, #l1_>>
+#row_major2x2 = #tt.layout<(d0, d1) -> (d0, d1), undef, <2x2>, memref<32x64xf32, #l1_>>
+#tile1x1_f32 = #tt.layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<2x4x!tt.tile<32x32, f32>, #l1_>>
+#tile1x1_bf16 = #tt.layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<2x4x!tt.tile<32x32, bf16>, #l1_>>
+#tile1x1_f32_dram = #tt.layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<2x4x!tt.tile<32x32, f32>, #dram>>
+#tile2x2_f32 = #tt.layout<(d0, d1) -> (d0, d1), undef, <2x2>, memref<1x2x!tt.tile<32x32, f32>, #l1_>>
+
+func.func @noncompound_linear(%in: tensor<64x128xf32, #row_major1x1>) -> tensor<64x128xf32, #row_major1x1_T> {
+    %out = tensor.empty() : tensor<64x128xf32, #row_major1x1_T>
+    // CHECK-COUNT-1: %[[C:.*]] = "ttir.to_layout"(%[[IN:.*]], %[[OUT:.*]]) : (tensor<64x128xf32, #[[row_major1x1]]>, tensor<64x128xf32, #[[row_major1x1_T]]>) -> tensor<64x128xf32, #[[row_major1x1_T]]>
+    // CHECK-NOT: %[[C:.*]] = "ttir.to_layout"[[LAYOUT:.*]]
+    %0 = "ttir.to_layout"(%in, %out) : (tensor<64x128xf32, #row_major1x1>, tensor<64x128xf32, #row_major1x1_T>) -> tensor<64x128xf32, #row_major1x1_T>
+    return %0 : tensor<64x128xf32, #row_major1x1_T>
+}
+
+func.func @noncompound_grid(%in: tensor<64x128xf32, #row_major1x1>) -> tensor<64x128xf32, #row_major2x2> {
+    %out = tensor.empty() : tensor<64x128xf32, #row_major2x2>
+    // CHECK-COUNT-1: %[[C:.*]] = "ttir.to_layout"(%[[IN:.*]], %[[OUT:.*]]) : (tensor<64x128xf32, #[[row_major1x1]]>, tensor<64x128xf32, #[[row_major2x2]]>) -> tensor<64x128xf32, #[[row_major2x2]]>
+    // CHECK-NOT: %[[C:.*]] = "ttir.to_layout"[[LAYOUT:.*]]
+    %0 = "ttir.to_layout"(%in, %out) : (tensor<64x128xf32, #row_major1x1>, tensor<64x128xf32, #row_major2x2>) -> tensor<64x128xf32, #row_major2x2>
+    return %0 : tensor<64x128xf32, #row_major2x2>
+}
+
+func.func @noncompound_format(%in: tensor<64x128xf32, #tile1x1_f32>) -> tensor<64x128xf32, #tile1x1_bf16> {
+    %out = tensor.empty() : tensor<64x128xf32, #tile1x1_bf16>
+    // CHECK-COUNT-1: %[[C:.*]] = "ttir.to_layout"(%[[IN:.*]], %[[OUT:.*]]) : (tensor<64x128xf32, #[[tile1x1_f32]]>, tensor<64x128xf32, #[[tile1x1_bf16]]>) -> tensor<64x128xf32, #[[tile1x1_bf16]]>
+    // CHECK-NOT: %[[C:.*]] = "ttir.to_layout"[[LAYOUT:.*]]
+    %0 = "ttir.to_layout"(%in, %out) : (tensor<64x128xf32, #tile1x1_f32>, tensor<64x128xf32, #tile1x1_bf16>) -> tensor<64x128xf32, #tile1x1_bf16>
+    return %0 : tensor<64x128xf32, #tile1x1_bf16>
+}
+
+func.func @noncompound_memspace(%in: tensor<64x128xf32, #tile1x1_f32>) -> tensor<64x128xf32, #tile1x1_f32_dram> {
+    %out = tensor.empty() : tensor<64x128xf32, #tile1x1_f32_dram>
+    // CHECK-COUNT-1: %[[C:.*]] = "ttir.to_layout"(%[[IN:.*]], %[[OUT:.*]]) : (tensor<64x128xf32, #[[tile1x1_f32]]>, tensor<64x128xf32, #[[tile1x1_f32_dram]]>) -> tensor<64x128xf32, #[[tile1x1_f32_dram]]>
+    // CHECK-NOT: %[[C:.*]] = "ttir.to_layout"[[LAYOUT:.*]]
+    %0 = "ttir.to_layout"(%in, %out) : (tensor<64x128xf32, #tile1x1_f32>, tensor<64x128xf32, #tile1x1_f32_dram>) -> tensor<64x128xf32, #tile1x1_f32_dram>
+    return %0 : tensor<64x128xf32, #tile1x1_f32_dram>
+}
+
+func.func @compound_gridformat(%in: tensor<64x128xf32, #row_major1x1>) -> tensor<64x128xf32, #tile2x2_f32> {
+    %out = tensor.empty() : tensor<64x128xf32, #tile2x2_f32>
+    // CHECK-COUNT-1: %[[C:.*]] = "ttir.to_layout"(%[[IN:.*]], %[[OUT:.*]]) : (tensor<64x128xf32, #[[row_major1x1]]>, tensor<64x128xf32, #[[tile1x1_f32]]>) -> tensor<64x128xf32, #[[tile1x1_f32]]>
+    // CHECK-COUNT-1: %[[C:.*]] = "ttir.to_layout"(%[[IN:.*]], %[[OUT:.*]]) : (tensor<64x128xf32, #[[tile1x1_f32]]>, tensor<64x128xf32, #[[tile2x2_f32]]>) -> tensor<64x128xf32, #[[tile2x2_f32]]>
+    // CHECK-NOT: %[[C:.*]] = "ttir.to_layout"[[LAYOUT:.*]]
+    %0 = "ttir.to_layout"(%in, %out) : (tensor<64x128xf32, #row_major1x1>, tensor<64x128xf32, #tile2x2_f32>) -> tensor<64x128xf32, #tile2x2_f32>
+    return %0 : tensor<64x128xf32, #tile2x2_f32>
+}
+
+func.func @compound_gridmemspace(%in: tensor<64x128xf32, #tile1x1_f32_dram>) -> tensor<64x128xf32, #tile2x2_f32> {
+    %out = tensor.empty() : tensor<64x128xf32, #tile2x2_f32>
+    // CHECK-COUNT-1: %[[C:.*]] = "ttir.to_layout"(%[[IN:.*]], %[[OUT:.*]]) : (tensor<64x128xf32, #[[tile1x1_f32_dram]]>, tensor<64x128xf32, #[[tile1x1_f32]]>) -> tensor<64x128xf32, #[[tile1x1_f32]]>
+    // CHECK-COUNT-1: %[[C:.*]] = "ttir.to_layout"(%[[IN:.*]], %[[OUT:.*]]) : (tensor<64x128xf32, #[[tile1x1_f32]]>, tensor<64x128xf32, #[[tile2x2_f32]]>) -> tensor<64x128xf32, #[[tile2x2_f32]]>
+    // CHECK-NOT: %[[C:.*]] = "ttir.to_layout"[[LAYOUT:.*]]
+    %0 = "ttir.to_layout"(%in, %out) : (tensor<64x128xf32, #tile1x1_f32_dram>, tensor<64x128xf32, #tile2x2_f32>) -> tensor<64x128xf32, #tile2x2_f32>
+    return %0 : tensor<64x128xf32, #tile2x2_f32>
+}
+
+func.func @compound_gridmemspaceformat(%in: tensor<64x128xf32, #tile1x1_f32_dram>) -> tensor<64x128xf32, #row_major2x2> {
+    %out = tensor.empty() : tensor<64x128xf32, #row_major2x2>
+    // CHECK-COUNT-1: %[[C:.*]] = "ttir.to_layout"(%[[IN:.*]], %[[OUT:.*]]) : (tensor<64x128xf32, #[[tile1x1_f32_dram]]>, tensor<64x128xf32, #[[tile1x1_f32]]>) -> tensor<64x128xf32, #[[tile1x1_f32]]>
+    // CHECK-COUNT-1: %[[C:.*]] = "ttir.to_layout"(%[[IN:.*]], %[[OUT:.*]]) : (tensor<64x128xf32, #[[tile1x1_f32]]>, tensor<64x128xf32, #[[tile2x2_f32]]>) -> tensor<64x128xf32, #[[tile2x2_f32]]>
+    // CHECK-COUNT-1: %[[C:.*]] = "ttir.to_layout"(%[[IN:.*]], %[[OUT:.*]]) : (tensor<64x128xf32, #[[tile2x2_f32]]>, tensor<64x128xf32, #[[row_major2x2]]>) -> tensor<64x128xf32, #[[row_major2x2]]>
+    // CHECK-NOT: %[[C:.*]] = "ttir.to_layout"[[LAYOUT:.*]]
+    %0 = "ttir.to_layout"(%in, %out) : (tensor<64x128xf32, #tile1x1_f32_dram>, tensor<64x128xf32, #row_major2x2>) -> tensor<64x128xf32, #row_major2x2>
+    return %0 : tensor<64x128xf32, #row_major2x2>
+}


### PR DESCRIPTION
This graph pass breaks up compound to_layout ops into constituent pieces. In TTIR, to_layout can do any of the following all at once:

- Change dataformat (including to/from tile or different tile types)
- Change memory space
- Change linear affine map
- Change grid shape

Going to TTMetal dialect, we need a pass that breaks these compound to_layout ops into successive to_layout ops such that each one only does a single task. There will be opportunity in the future to merge back particular patterns, but that's an optimization for a follow on change.