### PR TITLE
Workaround multi-device system descs by only observing the first device

### DIFF
--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -228,7 +228,7 @@ def TT_DeviceAttr : TT_Attr<"Device", "device", []> {
         return DeviceAttr::get(context, GridAttr::get(context, shape, physicalGridMapping), chipIds);
       }
       static DeviceAttr get(::mlir::MLIRContext *context, SystemDescAttr systemDesc, ArrayRef<unsigned> chipIds);
-      static DeviceAttr get(::mlir::MLIRContext *context, SystemDescAttr systemDesc);
+      static DeviceAttr get(::mlir::MLIRContext *context, SystemDescAttr systemDesc, bool enableMultichip = false);
   }];
 
   let genVerifyDecl = 1;

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
@@ -31,8 +31,8 @@ def TTKernel_CB : TTKernel_Type<"CB", "cb"> {
         static CBType get(::mlir::MLIRContext *context,
                               uint64_t address,
                               uint64_t port,
-                              MemRefType memref,
-                              uint64_t numBuffers = 1) {
+                              MemRefType memref) {
+          uint64_t numBuffers = 1;
           uint64_t pageSize = 0;
           if (::mlir::isa<::mlir::tt::TileType>(memref.getElementType())) {
             pageSize = ::mlir::cast<::mlir::tt::TileType>(memref.getElementType()).getSizeBytes();

--- a/lib/Dialect/TT/IR/TTOpsTypes.cpp
+++ b/lib/Dialect/TT/IR/TTOpsTypes.cpp
@@ -407,7 +407,6 @@ DeviceAttr DeviceAttr::get(::mlir::MLIRContext *context,
                            SystemDescAttr systemDesc,
                            ArrayRef<unsigned> chipIds) {
   assert(not chipIds.empty() && "expected at least one chip");
-  assert(chipIds.size() == 1 && "only single chip supported for now");
   ChipDescAttr chipDesc = systemDesc.getChipDescs()[chipIds.front()];
   ArrayRef<int64_t> physicalGrid(chipDesc.getGrid());
   assert(physicalGrid.size() == 2 && "expected 2D grid");
@@ -437,8 +436,11 @@ DeviceAttr DeviceAttr::get(::mlir::MLIRContext *context,
 }
 
 DeviceAttr DeviceAttr::get(::mlir::MLIRContext *context,
-                           SystemDescAttr systemDesc) {
-  SmallVector<unsigned> chipIds(systemDesc.getChipDescIndices().size());
+                           SystemDescAttr systemDesc, bool enableMultichip) {
+  assert(systemDesc.getChipDescIndices().size() > 0 &&
+         "expected at least one chip");
+  SmallVector<unsigned> chipIds(
+      enableMultichip ? systemDesc.getChipDescIndices().size() : 1);
   std::iota(chipIds.begin(), chipIds.end(), 0);
   return get(context, systemDesc, chipIds);
 }


### PR DESCRIPTION
Until we have system desc slicing #113, by default the compiler will only construct a `DeviceAttr` that observes the first chip on the system to enable running on n300.

Once we have system desc slicing, we can change it back, and the user will have to explicitly generate a system desc that partitions out a single device.