### PR TITLE
Make SystemDesc's eth and eth_inactive core list optional (solves N150 MLIR parsing fail introduced today)

### DIFF
--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -68,8 +68,8 @@ def TT_ChipPhysicalCoresAttr : TT_Attr<"ChipPhysicalCores", "chip_physical_cores
     TT chip_physical_cores attribute containing arrays of physical cores by core type in order of logical cores.
   }];
 
-  let parameters = (ins ArrayRefParameter<"CoreCoordAttr">:$worker, ArrayRefParameter<"CoreCoordAttr">:$dram, ArrayRefParameter<"CoreCoordAttr">:$eth, ArrayRefParameter<"CoreCoordAttr">:$eth_inactive);
-  let assemblyFormat = "`{` `worker` `=` `[` $worker `]` `,` `dram` `=` `[` $dram `]` `,` `eth` `=` `[` $eth `]` `,` `eth_inactive` `=` `[` $eth_inactive `]` `}`";
+  let parameters = (ins ArrayRefParameter<"CoreCoordAttr">:$worker, ArrayRefParameter<"CoreCoordAttr">:$dram, OptionalArrayRefParameter<"CoreCoordAttr">:$eth, OptionalArrayRefParameter<"CoreCoordAttr">:$eth_inactive);
+  let assemblyFormat = "`{` `worker` `=` `[` $worker `]` `,` `dram` `=` `[` $dram `]` (`,` `eth` `=` `[` $eth^ `]`)? (`,` `eth_inactive` `=` `[` $eth_inactive^ `]`)? `}`";
 }
 
 def TT_ChipDescAttr : TT_Attr<"ChipDesc", "chip_desc"> {


### PR DESCRIPTION
Closes #411 - sorry for (not so obvious) breakage that would affect users on N150 machines.

Make SystemDesc's eth and eth_inactive core list optional
 - Empty eth core list happens on N150, this solves MLIR parser issue introduced on 8/15 commit d187e56
 - Removes ", eth = []" entirely from MLIR when list is empty, took inspiration from chipChannels existing optional param.
 
 
 ==
 
Testing:
 
-  Solved issue for me locally on N300 (when I hacked eth and eth_inactive to become empty).  I left worker and dram cores as not optional.

Folks who are blocked by this plz cherry-pick b7c920d562 and recompile and regenerate systemdesc for your N150 (`ttrt query --save-artifacts`)