### PR TITLE
fix parsing of `ChipPhysicalCoresAttr`

### DIFF
--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -69,7 +69,7 @@ def TT_ChipPhysicalCoresAttr : TT_Attr<"ChipPhysicalCores", "chip_physical_cores
   }];
 
   let parameters = (ins ArrayRefParameter<"CoreCoordAttr">:$worker, ArrayRefParameter<"CoreCoordAttr">:$dram, OptionalArrayRefParameter<"CoreCoordAttr">:$eth, OptionalArrayRefParameter<"CoreCoordAttr">:$eth_inactive);
-  let assemblyFormat = "`{` `worker` `=` `[` $worker `]` `,` `dram` `=` `[` $dram `]` (`,` `eth` `=` `[` $eth^ `]`)? (`,` `eth_inactive` `=` `[` $eth_inactive^ `]`)? `}`";
+  let assemblyFormat = "`{` `worker` `=` `[` $worker `]` `dram` `=` `[` $dram `]` (`eth` `=` `[` $eth^ `]`)? (`eth_inactive` `=` `[` $eth_inactive^ `]`)? `}`";
 }
 
 def TT_ChipDescAttr : TT_Attr<"ChipDesc", "chip_desc"> {


### PR DESCRIPTION
Removing commas from `assemblyFormat` so that the parsing of multiple optional groups works.

It seems that there isn't great support for this kind of parsing in mlir...