### PR TITLE
[TTNN Dialect] Convert ttnn.to_memory_config from DPS to non-DPS op

### DIFF
--- a/docs/src/ttmlir-translate.md
+++ b/docs/src/ttmlir-translate.md
@@ -5,7 +5,7 @@ The `ttmlir-translate` translation utility. Unlike `ttmlir-opt` tool which is us
 
 ```bash
 # First, let's run `ttmlir-opt` to convert to proper dialect
-./build/bin/ttmlir-opt --ttir-layout --ttnn-open-device --convert-ttir-to-ttnn --convert-ttnn-to-emitc test/ttmlir/Dialect/TTNN/simple_multiply.mlir -o c.mlir
+./build/bin/ttmlir-opt --ttir-load-system-desc --ttir-layout --ttnn-open-device --convert-ttir-to-ttnn --convert-ttnn-to-emitc test/ttmlir/Dialect/TTNN/simple_multiply.mlir -o c.mlir
 
 # Now run `ttmlir-translate` to produce C++ code
 ./build/bin/ttmlir-translate -mlir-to-cpp c.mlir -allow-unregistered-dialect
@@ -13,7 +13,7 @@ The `ttmlir-translate` translation utility. Unlike `ttmlir-opt` tool which is us
 
 Bonus: These two commands can be piped, to avoid writing a `mlir` file to disk, like so:
 ```bash
-./build/bin/ttmlir-opt --ttir-layout --ttnn-open-device --convert-ttir-to-ttnn --convert-ttnn-to-emitc test/ttmlir/Dialect/TTNN/simple_multiply.mlir | ./build/bin/ttmlir-translate -mlir-to-cpp -allow-unregistered-dialect
+./build/bin/ttmlir-opt --ttir-load-system-desc --ttir-layout --ttnn-open-device --convert-ttir-to-ttnn --convert-ttnn-to-emitc test/ttmlir/Dialect/TTNN/simple_multiply.mlir | ./build/bin/ttmlir-translate -mlir-to-cpp -allow-unregistered-dialect
 ```
 
 ## Generate flatbuffer file from MLIR

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -32,18 +32,13 @@ def TTNN_CloseDeviceOp : TTNN_Op<"close_device"> {
     let arguments = (ins TT_Device:$device);
 }
 
-def TTNN_ToMemoryConfigOp : TTNN_Op<"to_memory_config", [DestinationStyleOpInterface]> {
+def TTNN_ToMemoryConfigOp : TTNN_Op<"to_memory_config"> {
     let summary = "ToMemoryConfig op.";
     let description = [{
     }];
 
-    let arguments = (ins AnyRankedTensor:$input,
-                         AnyRankedTensor:$output);
+    let arguments = (ins AnyRankedTensor:$input);
     let results = (outs AnyRankedTensor:$result);
-
-    let extraClassDeclaration = [{
-      MutableOperandRange getDpsInitsMutable() { return getOutputMutable(); }
-    }];
 
     let hasVerifier = 1;
 }

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -8,8 +8,10 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/ValueRange.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "llvm/Support/Casting.h"
 
 using namespace mlir;
 using namespace mlir::tt;
@@ -50,9 +52,22 @@ public:
   LogicalResult
   matchAndRewrite(ttir::ToLayoutOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+
+    // Get the DPS operand and delete it's creator op, if it's tensor::emptyOp
+    //
+    Value dpsOperand = adaptor.getOperands().back();
+    ttnn::EmptyOp emptyOp = dpsOperand.getDefiningOp<ttnn::EmptyOp>();
+    if (emptyOp) {
+      rewriter.eraseOp(emptyOp);
+    }
+
+    // Drop the last operand which is the DPS operand.
+    //
+    ValueRange nonDPSOperands = adaptor.getOperands().drop_back();
+
     rewriter.replaceOpWithNewOp<ttnn::ToMemoryConfigOp>(
         op, this->getTypeConverter()->convertType(op.getType()),
-        adaptor.getInput(), adaptor.getOutput());
+        nonDPSOperands);
     return success();
   }
 };

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -105,10 +105,6 @@ public:
       : TTNNToEmitCBaseOpConversionPattern<ttnn::OpenDeviceOp>(
             typeConverter, context, benefit) {}
 
-private:
-  std::string getPrefixSearchPattern() const override { return "ttnn."; }
-  std::string getPrefixSwapPattern() const override { return "ttnn::device::"; }
-
 public:
   LogicalResult
   matchAndRewrite(ttnn::OpenDeviceOp srcOp, OpAdaptor adaptor,
@@ -135,10 +131,6 @@ public:
                                  PatternBenefit benefit = 1)
       : TTNNToEmitCBaseOpConversionPattern<ttnn::CloseDeviceOp>(
             typeConverter, context, benefit) {}
-
-private:
-  std::string getPrefixSearchPattern() const override { return "ttnn."; }
-  std::string getPrefixSwapPattern() const override { return "ttnn::device::"; }
 
 public:
   LogicalResult

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitCPass.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitCPass.cpp
@@ -32,7 +32,7 @@ public:
   TTNNToEmitCTypeConverter(MLIRContext *ctx) {
     addConversion([](Type type) { return type; });
     addConversion([ctx](tt::DeviceType type) -> emitc::OpaqueType {
-      return emitc::OpaqueType::get(ctx, "ttnn::device::Device&");
+      return emitc::OpaqueType::get(ctx, "ttnn::Device&");
     });
     addConversion([ctx](mlir::TensorType type) -> emitc::OpaqueType {
       return emitc::OpaqueType::get(ctx, "ttnn::Tensor");
@@ -67,7 +67,7 @@ struct ConvertTTNNToEmitCPass
 
       // Include headers
       //
-      builder.create<emitc::IncludeOp>(module.getLoc(), "pch.hpp",
+      builder.create<emitc::IncludeOp>(module.getLoc(), "ttnn-precompiled.hpp",
                                        /*isStandard=*/false);
     }
 

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -16,7 +16,7 @@ namespace mlir::tt::ttnn {
 
 ::mlir::LogicalResult mlir::tt::ttnn::ToMemoryConfigOp::verify() {
   ::mlir::RankedTensorType inputTy = getInput().getType();
-  ::mlir::RankedTensorType outputTy = getOutput().getType();
+  ::mlir::RankedTensorType outputTy = getResult().getType();
   auto inputLayout =
       mlir::dyn_cast_or_null<mlir::tt::LayoutAttr>(inputTy.getEncoding());
   auto outputLayout =

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -74,11 +74,18 @@ createOp(FlatbufferObjectCache &cache, CloseDeviceOp op) {
 
 ::flatbuffers::Offset<::tt::target::ttnn::ToMemoryConfigOp>
 createOp(FlatbufferObjectCache &cache, ToMemoryConfigOp op) {
-  auto input = getOperandThroughDPSOps(op.getInput());
-  auto output = getOperandThroughDPSOps(op.getOutput());
-  return ::tt::target::ttnn::CreateToMemoryConfigOp(
-      *cache.fbb, cache.at<::tt::target::TensorRef>(input),
-      cache.at<::tt::target::TensorRef>(output));
+  constexpr uint64_t kHostAllocatedAddress = 0;
+  constexpr uint64_t kHostAllocatedSize = 0;
+  auto input = cache.getOrCreate(
+      op.getInput(), tensorValueToFlatbuffer, kHostAllocatedAddress,
+      kHostAllocatedSize); // TODO: Fix this so it reads an existing value - one
+                           // should always exist in cache. This is a temporary
+                           // workaround until
+                           // https://github.com/tenstorrent/tt-mlir/issues/435
+                           // is resolved.
+  auto output = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
+                                  kHostAllocatedAddress, kHostAllocatedSize);
+  return ::tt::target::ttnn::CreateToMemoryConfigOp(*cache.fbb, input, output);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::EmptyOp>

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -76,13 +76,8 @@ createOp(FlatbufferObjectCache &cache, CloseDeviceOp op) {
 createOp(FlatbufferObjectCache &cache, ToMemoryConfigOp op) {
   constexpr uint64_t kHostAllocatedAddress = 0;
   constexpr uint64_t kHostAllocatedSize = 0;
-  auto input = cache.getOrCreate(
-      op.getInput(), tensorValueToFlatbuffer, kHostAllocatedAddress,
-      kHostAllocatedSize); // TODO: Fix this so it reads an existing value - one
-                           // should always exist in cache. This is a temporary
-                           // workaround until
-                           // https://github.com/tenstorrent/tt-mlir/issues/435
-                           // is resolved.
+  auto input = cache.getOrCreate(op.getInput(), tensorValueToFlatbuffer,
+                                 kHostAllocatedAddress, kHostAllocatedSize);
   auto output = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
                                   kHostAllocatedAddress, kHostAllocatedSize);
   return ::tt::target::ttnn::CreateToMemoryConfigOp(*cache.fbb, input, output);

--- a/test/ttmlir/Dialect/TTNN/eltwise/operand_broadcasts.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/operand_broadcasts.mlir
@@ -5,10 +5,8 @@ module attributes {} {
     // CHECK: %[[C:.*]] = "ttnn.open_device"[[C:.*]]
     // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
     %0 = tensor.empty() : tensor<2x64x128xf32>
-    // CHECK: %[[C:.*]] = "ttnn.to_memory_config"[[C:.*]]
     // CHECK: %[[C:.*]] = "ttnn.multiply"[[C:.*]]
     %1 = "ttir.multiply"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<2x64x128xf32>, tensor<64x128xf32>, tensor<2x64x128xf32>) -> tensor<2x64x128xf32>
-    // CHECK: %[[C:.*]] = "ttnn.to_memory_config"[[C:.*]]
     // CHECK: "ttnn.close_device"[[C:.*]]
     return %1 : tensor<2x64x128xf32>
   }
@@ -17,10 +15,8 @@ module attributes {} {
     // CHECK: %[[C:.*]] = "ttnn.open_device"[[C:.*]]
     // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
     %0 = tensor.empty() : tensor<17x16x15x14xf32>
-    // CHECK: %[[C:.*]] = "ttnn.to_memory_config"[[C:.*]]
     // CHECK: %[[C:.*]] = "ttnn.multiply"[[C:.*]]
     %1 = "ttir.multiply"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<17x16x15x14xf32>, tensor<15x1xf32>, tensor<17x16x15x14xf32>) -> tensor<17x16x15x14xf32>
-    // CHECK: %[[C:.*]] = "ttnn.to_memory_config"[[C:.*]]
     // CHECK: "ttnn.close_device"[[C:.*]]
     return %1 : tensor<17x16x15x14xf32>
   }

--- a/tools/ttnn-standalone/ttnn-standalone.cpp
+++ b/tools/ttnn-standalone/ttnn-standalone.cpp
@@ -26,18 +26,18 @@
 // }
 
 ttnn::Tensor forward(ttnn::Tensor v1, ttnn::Tensor v2) {
-  ttnn::device::Device &v3 = ttnn::device::open_device(0);
+  ttnn::Device &v3 = ttnn::open_device(0);
 
-  ttnn::Tensor v4 = ttnn::full(v1.shape(), 4.0f, v1.tensor_attributes->dtype,
-                               v1.tensor_attributes->layout, std::ref(v3));
+  ttnn::Tensor v4 = ttnn::empty(v1.shape(), v1.tensor_attributes->dtype,
+                                v1.tensor_attributes->layout, v3);
   //   ttnn::Tensor v5 = ttnn::to_memory_config(v1, v4);
 
-  ttnn::Tensor v6 = ttnn::full(v2.shape(), 6.0f, v2.tensor_attributes->dtype,
-                               v2.tensor_attributes->layout, std::ref(v3));
+  ttnn::Tensor v6 = ttnn::empty(v2.shape(), v2.tensor_attributes->dtype,
+                                v2.tensor_attributes->layout, v3);
   //   ttnn::Tensor v7 = ttnn::to_memory_config(v2, v6);
 
-  ttnn::Tensor v9 = ttnn::full(v2.shape(), 2.0f, v2.tensor_attributes->dtype,
-                               v2.tensor_attributes->layout, std::ref(v3));
+  ttnn::Tensor v9 = ttnn::empty(v2.shape(), v2.tensor_attributes->dtype,
+                                v2.tensor_attributes->layout, v3);
   ttnn::multiply(v4, v6, std::nullopt, std::nullopt, v9, std::nullopt,
                  std::nullopt);
   v9 = v9.cpu(); // move to CPU


### PR DESCRIPTION
- `ttnn.to_memory_config` was implemented as a DPS op in TTNN dialect. However, actual `ttnn` implementation doesn't support this type of signature
- Fixed stale docs
- Opened #435 to follow up