### PR TITLE
Conv2d implementation (without runtime support)

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -301,10 +301,8 @@ def TTIR_Conv2dOp : TTIR_DPSOp<"conv2d"> {
 
     let arguments = (ins AnyRankedTensor:$input,
                          AnyRankedTensor:$weight,
-                         AnyRankedTensor:$bias,
+                         Optional<AnyRankedTensor>:$bias,
                          AnyRankedTensor:$output,
-                         SI32Attr:$kernel_height,
-                         SI32Attr:$kernel_width,
                          SI32Attr:$stride_height,
                          SI32Attr:$stride_width,
                          SI32Attr:$dilation,
@@ -313,10 +311,6 @@ def TTIR_Conv2dOp : TTIR_DPSOp<"conv2d"> {
                          SI32Attr:$padding_right,
                          SI32Attr:$padding_top,
                          SI32Attr:$padding_bottom,
-                         SI32Attr:$is_convtranspose2d,
-                         SI32Attr:$output_height_transpose,
-                         SI32Attr:$output_width_transpose,
-                         SI32Attr:$stride_transpose,
                          TT_OperandConstraintArrayAttr:$operand_constraints);
 
     let results = (outs AnyRankedTensor:$result);

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -292,6 +292,42 @@ def TTIR_MatmulOp : TTIR_DPSOp<"matmul"> {
 }
 // ANCHOR_END: adding_an_op_matmul_ttir
 
+
+def TTIR_Conv2dOp : TTIR_DPSOp<"conv2d"> {
+    let summary = "Conv2d operation.";
+    let description = [{
+      Conv2d operation.
+    }];
+
+    let arguments = (ins AnyRankedTensor:$input,
+                         AnyRankedTensor:$weight,
+                         AnyRankedTensor:$bias,
+                         AnyRankedTensor:$output,
+                         SI32Attr:$kernel_height,
+                         SI32Attr:$kernel_width,
+                         SI32Attr:$stride_height,
+                         SI32Attr:$stride_width,
+                         SI32Attr:$dilation,
+                         SI32Attr:$groups,
+                         SI32Attr:$padding_left,
+                         SI32Attr:$padding_right,
+                         SI32Attr:$padding_top,
+                         SI32Attr:$padding_bottom,
+                         SI32Attr:$is_convtranspose2d,
+                         SI32Attr:$output_height_transpose,
+                         SI32Attr:$output_width_transpose,
+                         SI32Attr:$stride_transpose,
+                         TT_OperandConstraintArrayAttr:$operand_constraints);
+
+    let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      MutableOperandRange getDpsInitsMutable() { return getOutputMutable(); }
+    }];
+
+    let hasVerifier = 1;
+}
+
 //===----------------------------------------------------------------------===//
 // TTIR region ops (ops that may appear inside of ttir.generic region)
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -192,6 +192,40 @@ def TTNN_MatmulOp : TTNN_NamedDPSOp<"matmul"> {
 }
 // ANCHOR_END: adding_an_op_matmul_ttnn
 
+def TTNN_Conv2dOp : TTNN_NamedDPSOp<"conv2d"> {
+    let summary = "Conv2d operation.";
+    let description = [{
+      Conv2d operation.
+    }];
+
+    let arguments = (ins AnyRankedTensor:$input,
+                         AnyRankedTensor:$weight,
+                         AnyRankedTensor:$bias,
+                         AnyRankedTensor:$output,
+                         I32Attr:$in_channels,
+                         I32Attr:$out_channels,
+                         I32Attr:$batch_size,
+                         I32Attr:$input_height,
+                         I32Attr:$input_width,
+                         I32Attr:$kernel_height,
+                         I32Attr:$kernel_width,
+                         I32Attr:$stride_height,
+                         I32Attr:$stride_width,
+                         I32Attr:$padding_height,
+                         I32Attr:$padding_width,
+                         I32Attr:$dilation_vertical,
+                         I32Attr:$dilation_horizontal,
+                         I32Attr:$groups);
+
+    let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      MutableOperandRange getDpsInitsMutable() { return getOutputMutable(); }
+    }];
+
+    let hasVerifier = 1;
+}
+
 def TTNN_FullOp : TTNN_Op<"full"> {
     let summary = "Full op.";
     let description = [{

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -145,6 +145,68 @@ public:
 };
 // ANCHOR_END: adding_an_op_matmul_op_rewriter
 
+class Conv2dOpConversionPattern : public OpConversionPattern<ttir::Conv2dOp> {
+public:
+  using OpConversionPattern<ttir::Conv2dOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttir::Conv2dOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    // auto kernel_ty = mlir::cast<RankedTensorType>(adaptor.getWeight().getType());
+    // llvm::ArrayRef<std::int64_t> kernel_shape = kernel_ty.getShape();
+
+    auto input_ty = mlir::cast<RankedTensorType>(adaptor.getInput().getType());
+    llvm::ArrayRef<std::int64_t> input_shape = input_ty.getShape();
+
+    auto output_ty = mlir::cast<RankedTensorType>(adaptor.getOutput().getType());
+    llvm::ArrayRef<std::int64_t> output_shape = output_ty.getShape();
+
+
+    auto in_channels = rewriter.getI32IntegerAttr(input_shape[input_shape.size()-1]);
+    auto out_channels = rewriter.getI32IntegerAttr(output_shape[output_shape.size()-1]);
+    auto batch_size = rewriter.getI32IntegerAttr(input_shape[input_shape.size()-4]);
+    auto input_height = rewriter.getI32IntegerAttr(input_shape[input_shape.size()-3]);
+    auto input_width = rewriter.getI32IntegerAttr(input_shape[input_shape.size()-2]);
+
+    auto kernel_height = rewriter.getI32IntegerAttr(adaptor.getKernelHeight());
+    auto kernel_width = rewriter.getI32IntegerAttr(adaptor.getKernelWidth());
+
+    auto stride_height = rewriter.getI32IntegerAttr(adaptor.getStrideHeight());
+    auto stride_width = rewriter.getI32IntegerAttr(adaptor.getStrideWidth());
+
+    assert(adaptor.getPaddingBottom() == adaptor.getPaddingTop());
+    assert(adaptor.getPaddingLeft() == adaptor.getPaddingRight()); 
+
+    auto padding_height = rewriter.getI32IntegerAttr(adaptor.getPaddingTop());
+    auto padding_width = rewriter.getI32IntegerAttr(adaptor.getPaddingRight());
+
+    auto dilation_vertical = rewriter.getI32IntegerAttr(adaptor.getDilation());
+    auto dilation_horizontal = rewriter.getI32IntegerAttr(adaptor.getDilation());
+
+    auto groups = rewriter.getI32IntegerAttr(adaptor.getGroups());
+
+    rewriter.replaceOpWithNewOp<ttnn::Conv2dOp>(
+        op, this->getTypeConverter()->convertType(op.getType()), adaptor.getInput(),
+        adaptor.getWeight(), adaptor.getBias(), adaptor.getOutput(), 
+        in_channels, 
+        out_channels, 
+        batch_size, 
+        input_width, 
+        input_height, 
+        kernel_height, 
+        kernel_width, 
+        stride_height, 
+        stride_width,
+        padding_height,
+        padding_width, 
+        dilation_vertical,
+        dilation_horizontal,
+        groups);
+    return success();
+  }
+};
+
 namespace mlir::tt {
 
 void populateTTIRToTTNNPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
@@ -163,7 +225,8 @@ void populateTTIRToTTNNPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
            ReductionOpConversionPattern<ttir::MeanOp, ttnn::MeanOp>,
            TransposeOpConversionPattern,
            SoftmaxOpConversionPattern,
-           MatmulOpConversionPattern
+           MatmulOpConversionPattern,
+           Conv2dOpConversionPattern
            >(typeConverter, ctx);
   // ANCHOR_END: adding_an_op_matmul_rewrite_pattern_set
   // clang-format on

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -153,8 +153,8 @@ public:
   matchAndRewrite(ttir::Conv2dOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    // auto kernel_ty = mlir::cast<RankedTensorType>(adaptor.getWeight().getType());
-    // llvm::ArrayRef<std::int64_t> kernel_shape = kernel_ty.getShape();
+    auto kernel_ty = mlir::cast<RankedTensorType>(adaptor.getWeight().getType());
+    llvm::ArrayRef<std::int64_t> kernel_shape = kernel_ty.getShape();
 
     auto input_ty = mlir::cast<RankedTensorType>(adaptor.getInput().getType());
     llvm::ArrayRef<std::int64_t> input_shape = input_ty.getShape();
@@ -162,15 +162,19 @@ public:
     auto output_ty = mlir::cast<RankedTensorType>(adaptor.getOutput().getType());
     llvm::ArrayRef<std::int64_t> output_shape = output_ty.getShape();
 
-
     auto in_channels = rewriter.getI32IntegerAttr(input_shape[input_shape.size()-1]);
     auto out_channels = rewriter.getI32IntegerAttr(output_shape[output_shape.size()-1]);
-    auto batch_size = rewriter.getI32IntegerAttr(input_shape[input_shape.size()-4]);
+
+    auto batch_size = rewriter.getI32IntegerAttr(1);
+    if (input_shape.size() == 4) {
+      batch_size = rewriter.getI32IntegerAttr(input_shape[input_shape.size()-4]);
+    }
+
     auto input_height = rewriter.getI32IntegerAttr(input_shape[input_shape.size()-3]);
     auto input_width = rewriter.getI32IntegerAttr(input_shape[input_shape.size()-2]);
 
-    auto kernel_height = rewriter.getI32IntegerAttr(adaptor.getKernelHeight());
-    auto kernel_width = rewriter.getI32IntegerAttr(adaptor.getKernelWidth());
+    auto kernel_height = rewriter.getI32IntegerAttr(kernel_shape[kernel_shape.size()-2]);
+    auto kernel_width = rewriter.getI32IntegerAttr(kernel_shape[kernel_shape.size()-2]);
 
     auto stride_height = rewriter.getI32IntegerAttr(adaptor.getStrideHeight());
     auto stride_width = rewriter.getI32IntegerAttr(adaptor.getStrideWidth());

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -125,6 +125,10 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
   //
   patterns.add<DefaultOpConversionPattern<ttnn::SumOp>>(typeConverter, ctx);
   patterns.add<DefaultOpConversionPattern<ttnn::MeanOp>>(typeConverter, ctx);
+
+  // Conv ops
+  //
+  patterns.add<DefaultOpConversionPattern<ttnn::Conv2dOp>>(typeConverter, ctx);
 }
 
 } // namespace mlir::tt

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -120,6 +120,28 @@
 }
 // ANCHOR_END: adding_an_op_matmul_ttir_verify
 
+::mlir::LogicalResult mlir::tt::ttir::Conv2dOp::verify() {
+  ::mlir::RankedTensorType inputType = getInput().getType();
+  ::mlir::RankedTensorType weightType = getWeight().getType();
+  ::mlir::RankedTensorType biasType = getBias().getType();
+  ::mlir::RankedTensorType outputType = getOutput().getType();
+  auto inputShape = inputType.getShape();
+  auto weightShape = weightType.getShape();
+  auto biasShape = biasType.getShape();
+  auto outputShape = outputType.getShape();
+  if (inputShape.size() < 3) {
+    return emitOpError("Input must be at least a 3D tensor");
+  }
+  if (weightShape.size() != 4) {
+    return emitOpError("Weight must be a 4D tensor");
+  }
+  if (biasShape != outputShape and biasShape.size() != 1) {
+    return emitOpError("Bias must be a 1D tensor or match the shape of the output");
+  }
+  return success();
+}
+
+
 ::mlir::LogicalResult mlir::tt::ttir::AllocOp::verify() {
   auto layout = mlir::dyn_cast_or_null<mlir::tt::LayoutAttr>(
       getResult().getType().getEncoding());

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -121,6 +121,27 @@ namespace mlir::tt::ttnn {
 }
 // ANCHOR_END: adding_an_op_matmul_ttnn_verify
 
+::mlir::LogicalResult mlir::tt::ttnn::Conv2dOp::verify() {
+  ::mlir::RankedTensorType inputType = getInput().getType();
+  ::mlir::RankedTensorType weightType = getWeight().getType();
+  ::mlir::RankedTensorType biasType = getBias().getType();
+  ::mlir::RankedTensorType outputType = getOutput().getType();
+  auto inputShape = inputType.getShape();
+  auto weightShape = weightType.getShape();
+  auto biasShape = biasType.getShape();
+  auto outputShape = outputType.getShape();
+  if (inputShape.size() < 3) {
+    return emitOpError("Input must be at least a 3D tensor");
+  }
+  if (weightShape.size() != 4) {
+    return emitOpError("Weight must be a 4D tensor");
+  }
+  if (biasShape != outputShape and biasShape.size() != 1) {
+    return emitOpError("Bias must be a 1D tensor or match the shape of the output");
+  }
+  return success();
+}
+
 ::mlir::LogicalResult AllocOp::verify() {
   auto layout = mlir::dyn_cast_or_null<mlir::tt::LayoutAttr>(
       getResult().getType().getEncoding());

--- a/test/ttmlir/Dialect/TTNN/simple_conv.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_conv.mlir
@@ -1,0 +1,10 @@
+// RUN: ttmlir-opt --ttir-load-system-desc --ttir-layout --ttnn-open-device --convert-ttir-to-ttnn %s | FileCheck %s
+#any_device_tile = #tt.operand_constraint<dram|l1|tile|any_device_tile>
+module attributes {} {
+  func.func @forward(%arg0: tensor<1x32x32x1xbf16>, %arg1: tensor<1x1x3x3xbf16>, %arg2: tensor<1x32x32x1xbf16>) -> tensor<1x32x32x1xbf16> {
+    %0 = tensor.empty() : tensor<1x32x32x1xbf16> 
+    // CHECK: %[[C:.*]] = "ttnn.conv2d"[[C:.*]]
+    %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0) <{kernel_height=3: si32, kernel_width=3: si32, stride_height=1: si32, stride_width=1: si32, dilation=1: si32, groups=1: si32, padding_left=1: si32, padding_right=1: si32, padding_top=1: si32, padding_bottom=1: si32, is_convtranspose2d=0: si32, output_height_transpose=0: si32, output_width_transpose=0: si32, stride_transpose=0: si32, operand_constraints = [#any_device_tile, #any_device_tile, #any_device_tile, #any_device_tile]}> : (tensor<1x32x32x1xbf16>, tensor<1x1x3x3xbf16>, tensor<1x32x32x1xbf16>, tensor<1x32x32x1xbf16>) -> tensor<1x32x32x1xbf16>
+    return %1 : tensor<1x32x32x1xbf16> 
+  }
+}


### PR DESCRIPTION
Define ttir and ttnn representations of the conv2d op in mlir.

For issue: https://github.com/tenstorrent/tt-mlir/issues/440