### PR TITLE
Add BufferAccess Attribute

### DIFF
--- a/include/ttmlir/Dialect/TT/IR/TTOpsEnums.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsEnums.td
@@ -139,4 +139,16 @@ def TT_ChipCapability : I32BitEnumAttr<"ChipCapability", "TT Chip Capabilities",
   let cppNamespace = "::mlir::tt";
 }
 
+def TT_BufferAccessAlias : I32BitEnumAttrCaseBit<"Alias", 0, "alias">;
+def TT_BufferAccessStream : I32BitEnumAttrCaseBit<"Stream", 1, "stream">;
+
+def TT_BufferAccess : I32BitEnumAttr<"BufferAccess", "TT Buffer Access",
+                           [
+                            TT_BufferAccessAlias ,
+                            TT_BufferAccessStream,
+                           ]> {
+  let genSpecializedAttr = 0;
+  let cppNamespace = "::mlir::tt";
+}
+
 #endif

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -237,13 +237,23 @@ def TT_LayoutAttr : TT_Attr<"Layout", "layout"> {
   }];
 }
 
+def TT_BufferAccessAttr : EnumAttr<TT_Dialect, TT_BufferAccess, "buffer_access"> {
+  let assemblyFormat = "$value";
+}
+
 def TT_BufferAttr : TT_Attr<"Buffer", "buffer", []> {
   let summary = "Buffer attribute in TT dialect";
   let description = [{
     Describes the physical footprint and layout of a buffer in L1. Its memref must also have a shape with rank equal to DeviceAttr grid.
+    It also carries a buffer access attribute which can be one of:
+    - Alias: This buffer aliases a persistent Tensor L1 allocation directly. Implies that no datamovement occurs and the compute kernel
+             just accesses the local allocation directly.
+    - Stream: This buffer is a temporary destination as a means to get remote data for local computation.  Remote data is most likely a
+              a tensor that is allocated in dram, but could also be data from a remote core.
   }];
-  let parameters = (ins AttrParameter<"MemRefType", "A memref that describes the physical footprint and layout of the buffer. It must also have a shape with rank equal to DeviceAttr grid.">:$memref);
-  let assemblyFormat = "`<` $memref `>`";
+  let parameters = (ins AttrParameter<"MemRefType", "A memref that describes the physical footprint and layout of the buffer. It must also have a shape with rank equal to DeviceAttr grid.">:$memref,
+                        AttrParameter<"BufferAccess", "How data is accessed through this buffer, alias or stream.">:$buffer_access);
+  let assemblyFormat = "`<` $memref `,` $buffer_access `>`";
 
   let extraClassDeclaration = [{
       ::mlir::Type getElementType() const;

--- a/lib/Dialect/TTIR/Transforms/Passes.cpp
+++ b/lib/Dialect/TTIR/Transforms/Passes.cpp
@@ -375,7 +375,8 @@ public:
         return type;
       }
       auto layout = mlir::cast<LayoutAttr>(type.getEncoding());
-      auto buffer = BufferAttr::get(ctx, layout.getMemref());
+      auto buffer =
+          BufferAttr::get(ctx, layout.getMemref(), BufferAccess::Alias);
       return RankedTensorType::get(buffer.getShape(), type.getElementType(),
                                    buffer);
     });


### PR DESCRIPTION
BufferAccess is a new attribute on BufferAttr that defines how tensor data is accessed by compute.  It currently can take 2 values:

- Alias: This buffer aliases a persistent Tensor L1 allocation directly. Implies that no datamovement occurs and the compute kernel just accesses the local allocation directly.
- Stream: This buffer is a temporary destination as a means to get remote data for local computation.  Remote data is most likely a tensor that is allocated in dram, but could also be data from a remote core.