### PR TITLE
Added load_from_capsule functionality to TTRT and Python Bindings

### DIFF
--- a/python/Passes.cpp
+++ b/python/Passes.cpp
@@ -49,6 +49,16 @@ void populatePassesModule(py::module &m) {
         mlir::Operation *moduleOp = unwrap(mlirModuleGetOperation(module));
         data = mlir::tt::ttnn::ttnnToFlatbuffer(moduleOp);
       });
+
+  m.def("ttnn_to_flatbuffer_binary", [](MlirModule module) {
+    mlir::Operation *moduleOp = unwrap(mlirModuleGetOperation(module));
+    std::shared_ptr<void> *binary = new std::shared_ptr<void>();
+    *binary = mlir::tt::ttnn::ttnnToFlatbuffer(moduleOp);
+    return py::capsule((void *)binary, [](void *data) {
+      std::shared_ptr<void> *bin = static_cast<std::shared_ptr<void> *>(data);
+      delete bin;
+    });
+  });
 }
 
 } // namespace mlir::ttmlir::python

--- a/runtime/tools/python/ttrt/binary/__init__.py
+++ b/runtime/tools/python/ttrt/binary/__init__.py
@@ -5,6 +5,7 @@
 from ._C import (
     load_from_path,
     load_binary_from_path,
+    load_binary_from_capsule,
     load_system_desc_from_path,
     Flatbuffer,
 )

--- a/runtime/tools/python/ttrt/binary/module.cpp
+++ b/runtime/tools/python/ttrt/binary/module.cpp
@@ -38,5 +38,11 @@ PYBIND11_MODULE(_C, m) {
       .def("store", &tt::runtime::SystemDesc::store);
   m.def("load_from_path", &tt::runtime::Flatbuffer::loadFromPath);
   m.def("load_binary_from_path", &tt::runtime::Binary::loadFromPath);
+  m.def("load_binary_from_capsule", [](py::capsule capsule) {
+    std::shared_ptr<void> *binary =
+        static_cast<std::shared_ptr<void> *>(capsule.get_pointer());
+    return tt::runtime::Flatbuffer(
+        *binary); // Dereference capsule, and then dereference shared_ptr*
+  });
   m.def("load_system_desc_from_path", &tt::runtime::SystemDesc::loadFromPath);
 }

--- a/runtime/tools/python/ttrt/common/util.py
+++ b/runtime/tools/python/ttrt/common/util.py
@@ -448,13 +448,13 @@ class Flatbuffer:
     ttmetal_file_extension = ".ttm"
     ttsys_file_extension = ".ttsys"
 
-    def __init__(self, logger, file_manager, file_path):
+    def __init__(self, logger, file_manager, file_path, capsule=None):
         import ttrt.binary
 
         self.logger = logger
         self.logging = self.logger.get_logger()
         self.file_manager = file_manager
-        self.file_path = file_path
+        self.file_path = file_path if file_path != None else "<binary-from-capsule>"
         self.name = self.file_manager.get_file_name(file_path)
         self.extension = self.file_manager.get_file_extension(file_path)
         self.version = None
@@ -489,12 +489,15 @@ class Flatbuffer:
 
 
 class Binary(Flatbuffer):
-    def __init__(self, logger, file_manager, file_path):
-        super().__init__(logger, file_manager, file_path)
+    def __init__(self, logger, file_manager, file_path, capsule=None):
+        super().__init__(logger, file_manager, file_path, capsule=capsule)
 
         import ttrt.binary
 
-        self.fbb = ttrt.binary.load_binary_from_path(file_path)
+        if not capsule:
+            self.fbb = ttrt.binary.load_binary_from_path(file_path)
+        else:
+            self.fbb = ttrt.binary.load_binary_from_capsule(capsule)
         self.fbb_dict = ttrt.binary.as_dict(self.fbb)
         self.version = self.fbb.version
         self.programs = []


### PR DESCRIPTION
- Added functionality with the magic of `py::capsule`
- Can now run the entire transformation from TTIR -> Flatbuffer -> Perf Modelling with only python calls.
- Fixed a small bug