### PR TITLE
Support 1d tensors #461 #471

### DIFF
--- a/test/python/tensor_layout.py
+++ b/test/python/tensor_layout.py
@@ -56,3 +56,26 @@ print(parallelize(t0, [3, 2]).wrapped())
 t1 = createTensorLayout([2, 3, 64, 128], [2, 2, 4], collapseIntervals=[(1, -1)])
 print(tilize(t1, tt.DataType.BFP_BFloat8).wrapped())
 print(parallelize(t1, [3, 2]).wrapped())
+
+t2 = createTensorLayout([128], [4], collapseIntervals=[(0, -1)])
+# CHECK: tensor<128xf32, #tt.layout<(d0) -> (d0), undef, <4>, memref<32xf32, #tt.memory_space<l1>>>>
+print(t2)
+# CHECK: #tt.layout<(d0) -> (d0), undef, <2>, memref<64xf32, #tt.memory_space<l1>>>
+print(parallelize(t2, [2]).wrapped())
+# CHECK: #tt.layout<(d0) -> (0, d0), undef, <1x2>, memref<1x64xf32, #tt.memory_space<l1>>>
+print(parallelize(t2, [1, 2]).wrapped())
+
+t3 = createTensorLayout([128], [1, 4], collapseIntervals=[(0, -1)])
+# CHECK: tensor<128xf32, #tt.layout<(d0) -> (0, d0), undef, <1x4>, memref<1x32xf32, #tt.memory_space<l1>>>>
+print(t3)
+# CHECK: #tt.layout<(d0) -> (0, d0), undef, <1x4>, memref<1x1x!tt.tile<32x32, bfp_bf8>, #tt.memory_space<l1>>>
+print(tilize(t3, tt.DataType.BFP_BFloat8).wrapped())
+
+t4 = createTensorLayout([128], [1, 2, 4], collapseIntervals=[(0, -1)])
+# CHECK: tensor<128xf32, #tt.layout<(d0) -> (0, 0, d0), undef, <1x2x4>, memref<1x1x32xf32, #tt.memory_space<l1>>>>
+print(t4)
+
+# CHECK: #tt.layout<(d0) -> (0, 0, d0), undef, <1x2x4>, memref<1x1x1x!tt.tile<32x32, bfp_bf8>, #tt.memory_space<l1>>>
+print(tilize(t4, tt.DataType.BFP_BFloat8).wrapped())
+# CHECK: #tt.layout<(d0) -> (0, d0), undef, <1x2>, memref<1x64xf32, #tt.memory_space<l1>>>
+print(parallelize(t4, [1, 2]).wrapped())


### PR DESCRIPTION
This commit adds a fix to support 1d tensors:
- Handle special case where the collapse interval distance is 0
- Support grid rank > shape rank by backfilling 0's