### PR TITLE
Support tiled data movement in TTMetal

### DIFF
--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -234,7 +234,7 @@ def TT_LayoutAttr : TT_Attr<"Layout", "layout"> {
       llvm::SmallVector<int64_t> getPhysicalShape(ArrayRef<int64_t> logicalShape) const;
       llvm::SmallVector<int64_t> getShardShape() const;
       AffineMap projectOnto(AffineMap linearMap, ArrayRef<int64_t> logicalTensorShape, GridAttr grid) const;
-      AffineMap getTileLinearMap() const;
+      AffineMap getIdentityTileLinearMap() const;
       llvm::SmallVector<int64_t> getTiledShape(ArrayRef<int64_t> logicalTensorShape) const;
   }];
 }

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -233,7 +233,9 @@ def TT_LayoutAttr : TT_Attr<"Layout", "layout"> {
       llvm::SmallVector<int64_t> getStride(ArrayRef<int64_t> logicalShape) const;
       llvm::SmallVector<int64_t> getPhysicalShape(ArrayRef<int64_t> logicalShape) const;
       llvm::SmallVector<int64_t> getShardShape() const;
-      AffineMap projectOnto(ArrayRef<int64_t> logicalTensorShape, GridAttr grid) const;
+      AffineMap projectOnto(AffineMap linearMap, ArrayRef<int64_t> logicalTensorShape, GridAttr grid) const;
+      AffineMap getTileLinearMap() const;
+      llvm::SmallVector<int64_t> getTiledShape(ArrayRef<int64_t> logicalTensorShape) const;
   }];
 }
 

--- a/include/ttmlir/Utils.h
+++ b/include/ttmlir/Utils.h
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 
+#include "mlir/IR/AffineMap.h"
 #include "llvm/ADT/SmallVector.h"
 
 namespace ttmlir::utils {
@@ -32,6 +33,21 @@ inline void sample(Vector const &shape, Fn fn) {
     fn(index);
   }
 }
+
+template <typename Vector>
+llvm::SmallVector<int64_t> evalShape(mlir::AffineMap map, Vector shape) {
+  mlir::SmallVector<int64_t> lastIndex;
+  for (auto dim : shape) {
+    lastIndex.push_back(dim - 1);
+  }
+
+  auto result = map.compose(lastIndex);
+  for (auto &dim : result) {
+    dim += 1;
+  }
+  return result;
+}
+
 } // namespace ttmlir::utils
 
 #endif

--- a/lib/Dialect/TT/IR/TTOpsTypes.cpp
+++ b/lib/Dialect/TT/IR/TTOpsTypes.cpp
@@ -6,6 +6,7 @@
 #include <numeric>
 
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
+#include "ttmlir/Utils.h"
 
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -15,8 +16,6 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
-
-#include "ttmlir/Utils.h"
 
 using namespace mlir::tt;
 
@@ -513,8 +512,67 @@ MemorySpace LayoutAttr::getMemorySpace() const {
       .getValue();
 }
 
-mlir::AffineMap LayoutAttr::projectOnto(ArrayRef<int64_t> logicalTensorShape,
-                                        GridAttr grid) const {
+// Returns shape of the tensor after tilization is applied.
+llvm::SmallVector<int64_t>
+LayoutAttr::getTiledShape(llvm::ArrayRef<int64_t> tensorShape) const {
+  assert(isTiled() && "Expected a tiled layout");
+
+  auto tileLinearMap = getTileLinearMap();
+
+  return ttmlir::utils::evalShape(tileLinearMap, tensorShape);
+}
+
+// Returns an affine map that maps tensor original dimensions to the tile linear
+// space instead of scalar space.
+// Example:
+// scalar linear: (d0, d1, d2, d3) -> (d0 * 192 + d1 * 64 + d2, d3),
+// tile linear: (d0, d1, d2, d3) -> (d0 * 6 + d1 * 2 + d2 floordiv 32, d3
+// floordiv 32).
+mlir::AffineMap LayoutAttr::getTileLinearMap() const {
+  assert(isTiled() && "Expected a tiled layout");
+
+  mlir::AffineMap linear = getLinear();
+  mlir::SmallVector<AffineExpr> tileLinearExprs;
+
+  TileType tileType = mlir::cast<TileType>(getElementType());
+  int64_t tileH = tileType.getHeight();
+  int64_t tileW = tileType.getWidth();
+
+  mlir::AffineExpr d0 = getAffineDimExpr(0, getContext());
+  mlir::AffineExpr d1 = getAffineDimExpr(1, getContext());
+  tileLinearExprs.push_back(d0.floorDiv(tileH));
+  tileLinearExprs.push_back(d1.floorDiv(tileW));
+
+  mlir::AffineMap tilingMap =
+      AffineMap::get(2 /* tile rank */, 0, tileLinearExprs, getContext());
+
+  // If the linear map has more than two results, drop the first results and
+  // leave the last two. This is needed before composition with the tiling map.
+  // The dropped results are added back after composition.
+  mlir::SmallVector<int64_t> dropPositions;
+  mlir::SmallVector<AffineExpr> droppedResults;
+  assert(linear.getNumResults() >= 2);
+  for (uint i = 0; i < linear.getNumResults() - 2; ++i) {
+    dropPositions.push_back(i);
+    droppedResults.push_back(linear.getResult(i));
+  }
+  mlir::AffineMap linearLastTwoResults = linear.dropResults(dropPositions);
+
+  mlir::AffineMap tiledResultMap = tilingMap.compose(linearLastTwoResults);
+  for (uint i = 0; i < droppedResults.size(); ++i) {
+    tiledResultMap = tiledResultMap.insertResult(droppedResults[i], i);
+  }
+
+  return tiledResultMap;
+}
+
+// Projects tensor layout onto the device grid. Uses given linear map to derive
+// the shard shape and the projection of shard indexes onto the logical grid.
+// Then it composes the logical grid projection with physical grid mapping.
+mlir::AffineMap
+LayoutAttr::projectOnto(mlir::AffineMap linearMap,
+                        llvm::ArrayRef<int64_t> logicalTensorShape,
+                        GridAttr grid) const {
   assert(getGrid().getShape().size() == grid.getShape().size() &&
          "Layout and device grids must have same number of dimensions");
   assert(getLinear().getNumResults() == grid.getShape().size() &&
@@ -525,19 +583,19 @@ mlir::AffineMap LayoutAttr::projectOnto(ArrayRef<int64_t> logicalTensorShape,
            "Layout grid dimensions must be less than or equal to device grid");
   }
 
-  auto linear = getLinear();
-  auto logicalShardShape = calculateLogicalShardShape(
-      getContext(), logicalTensorShape, linear, getGrid());
+  mlir::SmallVector<int64_t> logicalShardShape = calculateLogicalShardShape(
+      getContext(), logicalTensorShape, linearMap, getGrid());
 
   // Compute the projection of the layout onto its own logical grid.
   // Simultaneously compute the indexing of shards within each core.
-  SmallVector<AffineExpr> logicalGridProjection(linear.getNumResults());
-  AffineExpr shardIndexing = getAffineConstantExpr(0, getContext());
+  mlir::SmallVector<AffineExpr> logicalGridProjection(
+      linearMap.getNumResults());
+  mlir::AffineExpr shardIndexing = getAffineConstantExpr(0, getContext());
   int shardVolume = 1;
-  assert(logicalShardShape.size() == linear.getNumResults() &&
+  assert(logicalShardShape.size() == linearMap.getNumResults() &&
          "Logical shard shape and linear map must have same number of dims");
-  for (int i = linear.getNumResults() - 1; i >= 0; i--) {
-    mlir::AffineExpr expr = linear.getResult(i);
+  for (int i = linearMap.getNumResults() - 1; i >= 0; i--) {
+    mlir::AffineExpr expr = linearMap.getResult(i);
     mlir::AffineExpr shardDim =
         getAffineConstantExpr(logicalShardShape[i], getContext());
     mlir::AffineExpr shardVolumeExpr =
@@ -554,7 +612,7 @@ mlir::AffineMap LayoutAttr::projectOnto(ArrayRef<int64_t> logicalTensorShape,
           logicalTensorShape.size(), 0, logicalGridProjection, getContext()));
 
   // Finally we append the indexing of shards within each core.
-  SmallVector<AffineExpr> projection(gridProjection.getResults());
+  mlir::SmallVector<AffineExpr> projection(gridProjection.getResults());
   projection.push_back(shardIndexing);
   return mlir::AffineMap::get(logicalTensorShape.size(), 0, projection,
                               getContext());


### PR DESCRIPTION
Fix #322

This commit adds support for data movement between tiled layouts. Few key pieces:
1. TiledLinearMap - original linear space map translated into tile space. Example:
```
// tensor: tensor<2x3x64x128xf32,
//		  #tt.layout<(d0, d1, d2, d3) -> (d0 * 192 + d1 * 64 + d2, d3),
//		  undef, <1x1>, memref<384x128xf32, #tt.memory_space<l1>>>> 
// scalar linear: (d0, d1, d2, d3) -> (d0 * 192 + d1 * 64 + d2, d3), 
// tile linear: (d0, d1, d2, d3) -> (d0 * 6 + d1 * 2 + d2 floordiv 32, d3 floordiv 32).
```

3. TiledShape - same as original except that dims are computed with TiledLinearMap. Given above example: 
```
// originalScalarShape: [384, 128]
// tiledShape: [12, 4]
```

5. postLinearIndexToVisitingIndex - cpp map that keeps mapping between tiled indexes and initial linear index. Then when tile space is traversed we can easily map to linear space and then to physical space.

Added few unit tests that can be run on silicon with: 
```
ttmlir-opt --ttir-load-system-desc="path=n300.ttsys" --ttir-implicit-device
  --ttir-allocate --convert-ttir-to-ttmetal --ttmetal-serialize-to-binary="output=out.ttm"
  test/ttmlir/Silicon/TTMetal/tiled_reblock.mlir
ttrt run --program-index <idx> --identity --atol 1e-02 out.ttm
```

They should pass since no data modification is done.