### PR TITLE
E2E Conv2D Implementation

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -377,6 +377,37 @@ def TTIR_ConcatOp : TTIR_DPSOp<"concat"> {
     let arguments = (ins Variadic<AnyRankedTensor>:$inputs,
                          AnyRankedTensor:$output,
                          SI32Attr:$dim,
+
+    TT_OperandConstraintArrayAttr:$operand_constraints);
+
+    let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      MutableOperandRange getDpsInitsMutable() { return getOutputMutable(); }
+    }];
+
+    let hasVerifier = 1;
+}
+
+def TTIR_Conv2dOp : TTIR_DPSOp<"conv2d"> {
+    let summary = "Conv2d operation.";
+    let description = [{
+     Applies a 2D convolution over an input image composed of several input planes.
+    }];
+
+    let arguments = (ins AnyRankedTensor:$input,
+                         AnyRankedTensor:$weight,
+                         Optional<AnyRankedTensor>:$bias,
+                         AnyRankedTensor:$output,
+                         SI32Attr:$stride_height,
+                         SI32Attr:$stride_width,
+                         SI32Attr:$dilation_height,
+                         SI32Attr:$dilation_width,
+                         SI32Attr:$groups,
+                         SI32Attr:$padding_left,
+                         SI32Attr:$padding_right,
+                         SI32Attr:$padding_top,
+                         SI32Attr:$padding_bottom,
                          TT_OperandConstraintArrayAttr:$operand_constraints);
 
     let results = (outs AnyRankedTensor:$result);

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -304,6 +304,40 @@ def TTNN_MatmulOp : TTNN_NamedDPSOp<"matmul"> {
 }
 // ANCHOR_END: adding_an_op_matmul_ttnn
 
+def TTNN_Conv2dOp : TTNN_NamedDPSOp<"conv2d"> {
+    let summary = "Conv2d operation.";
+    let description = [{
+      Applies a 2D convolution over an input image composed of several input planes.
+    }];
+
+    let arguments = (ins AnyRankedTensor:$input,
+                         AnyRankedTensor:$weight,
+                         Optional<AnyRankedTensor>:$bias,
+                         AnyRankedTensor:$output,
+                         I32Attr:$in_channels,
+                         I32Attr:$out_channels,
+                         I32Attr:$batch_size,
+                         I32Attr:$input_height,
+                         I32Attr:$input_width,
+                         I32Attr:$kernel_height,
+                         I32Attr:$kernel_width,
+                         I32Attr:$stride_height,
+                         I32Attr:$stride_width,
+                         I32Attr:$padding_height,
+                         I32Attr:$padding_width,
+                         I32Attr:$dilation_height,
+                         I32Attr:$dilation_width,
+                         I32Attr:$groups);
+
+    let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      MutableOperandRange getDpsInitsMutable() { return getOutputMutable(); }
+    }];
+
+    let hasVerifier = 1;
+}
+
 def TTNN_EmptyOp : TTNN_Op<"empty"> {
     let summary = "Empty op.";
     let description = [{

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -100,6 +100,27 @@ table MatmulOp {
 }
 // ANCHOR_END: adding_an_op_matmul_fbs
 
+table Conv2dOp {
+  input: tt.target.TensorRef;
+  weight: tt.target.TensorRef;
+  bias: tt.target.TensorRef;
+  out: tt.target.TensorRef;
+  in_channels: uint32;
+  out_channels: uint32;
+  batch_size: uint32;
+  input_height: uint32;
+  input_width: uint32;
+  kernel_height: uint32;
+  kernel_width: uint32;
+  stride_height: uint32;
+  stride_width: uint32;
+  padding_height: uint32;
+  padding_width: uint32;
+  dilation_height: uint32;
+  dilation_width: uint32;
+  groups: uint32;
+}
+
 union OpType {
   OpenDeviceOp,
   CloseDeviceOp,
@@ -112,6 +133,7 @@ union OpType {
   EmbeddingOp,
   SoftmaxOp,
   TransposeOp,
+  Conv2dOp,
   ConcatOp,
   ReshapeOp
 }

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -203,6 +203,10 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
   patterns.add<DefaultOpConversionPattern<ttnn::SumOp>>(typeConverter, ctx);
   patterns.add<DefaultOpConversionPattern<ttnn::MeanOp>>(typeConverter, ctx);
 
+  // Conv ops
+  //
+  patterns.add<DefaultOpConversionPattern<ttnn::Conv2dOp>>(typeConverter, ctx);
+
   // Other ops
   //
   patterns.add<DefaultOpConversionPattern<ttnn::SoftmaxOp>>(typeConverter, ctx);

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -387,6 +387,25 @@ void mlir::tt::ttir::MultiplyOp::buildGenericRegion(
 }
 // ANCHOR_END: adding_an_op_matmul_ttir_verify
 
+::mlir::LogicalResult mlir::tt::ttir::Conv2dOp::verify() {
+  ::mlir::RankedTensorType inputType = getInput().getType();
+  ::mlir::RankedTensorType weightType = getWeight().getType();
+  ::mlir::RankedTensorType biasType =
+      llvm::dyn_cast_or_null<::mlir::RankedTensorType>(getBias().getType());
+  if (inputType.getRank() < 3) {
+    return emitOpError("Input must be at least a 3D tensor");
+  }
+  if (weightType.getRank() != 4) {
+    return emitOpError("Weight must be a 4D tensor");
+  }
+  if (biasType) {
+    if (biasType.getRank() != 4) {
+      return emitOpError("Bias must be a 4D tensor");
+    }
+  }
+  return success();
+}
+
 ::mlir::LogicalResult mlir::tt::ttir::AllocOp::verify() {
   auto layout = mlir::dyn_cast_or_null<mlir::tt::LayoutAttr>(
       getResult().getType().getEncoding());

--- a/lib/Dialect/TTIR/Transforms/Passes.cpp
+++ b/lib/Dialect/TTIR/Transforms/Passes.cpp
@@ -572,6 +572,11 @@ public:
     for (auto &operand : op->getOpOperands()) {
       bool isResult = op.isDpsInit(&operand);
 
+      // TTNN Conv2d moves input, weight, and bias from host to device
+      // itself. Inserting the ToLayoutOp on these operands is thus problematic.
+      if (mlir::isa<Conv2dOp>(op.getOperation()) && !isResult) {
+        continue;
+      }
       auto operandConstraint =
           mlir::cast<OperandConstraintAttr>(
               mlir::cast<TTIROp>(op.getOperation())

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -248,6 +248,30 @@ namespace mlir::tt::ttnn {
 }
 // ANCHOR_END: adding_an_op_matmul_ttnn_verify
 
+::mlir::LogicalResult mlir::tt::ttnn::Conv2dOp::verify() {
+  ::mlir::RankedTensorType inputType = getInput().getType();
+  ::mlir::RankedTensorType weightType = getWeight().getType();
+  ::mlir::RankedTensorType biasType =
+      llvm::dyn_cast_or_null<::mlir::RankedTensorType>(getBias().getType());
+
+  if (inputType.getRank() < 3) {
+    return emitOpError("Input must be at least a 3D tensor");
+  }
+  if (weightType.getRank() != 4) {
+    return emitOpError("Weight must be a 4D tensor");
+  }
+  if (biasType) {
+    if (biasType.getRank() != 4) {
+      return emitOpError("Bias must be a 4D tensor");
+    }
+    auto biasShape = biasType.getShape();
+    if (biasShape[0] != 1 || biasShape[1] != 1 || biasShape[2] != 1) {
+      return emitOpError("Bias must only have data on the final dimenstion");
+    }
+  }
+  return success();
+}
+
 ::mlir::LogicalResult AllocOp::verify() {
   auto layout = mlir::dyn_cast_or_null<mlir::tt::LayoutAttr>(
       getResult().getType().getEncoding());

--- a/runtime/include/tt/runtime/detail/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn.h
@@ -39,8 +39,10 @@
 #pragma clang diagnostic ignored "-Wunused-but-set-variable"
 #pragma clang diagnostic ignored "-Wlogical-op-parentheses"
 #pragma clang diagnostic ignored "-Wundefined-inline"
+
 #define FMT_HEADER_ONLY
 #include "ttnn/device.hpp"
+#include "ttnn/operations/conv/conv2d/conv2d.hpp"
 #include "ttnn/operations/copy.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/creation.hpp"
@@ -58,6 +60,9 @@
 #include "ttmlir/Target/TTNN/Target.h"
 
 namespace tt::runtime::ttnn {
+
+// Default L1 small size to use for the ttnn runtime (32kb).
+constexpr std::size_t kL1SmallSize = 1 << 15;
 
 std::pair<SystemDesc, DeviceIds> getCurrentSystemDesc();
 

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -60,7 +60,7 @@ Device openDevice(std::vector<int> const &deviceIds,
                   std::vector<std::uint8_t> const &numHWCQs) {
   assert(deviceIds.size() == 1 && "Only one device is supported for now");
   assert(numHWCQs.empty() && "HWCQs are not supported for now");
-  auto &device = ::ttnn::open_device(deviceIds.front());
+  auto &device = ::ttnn::open_device(deviceIds.front(), kL1SmallSize);
   return Device::borrow(device, DeviceRuntime::TTNN);
 }
 

--- a/test/ttmlir/Dialect/TTNN/simple_conv.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_conv.mlir
@@ -1,0 +1,10 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
+#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
+module attributes {} {
+  func.func @forward(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x32x32x64xbf16> {
+    %0 = tensor.empty() : tensor<1x32x32x64xbf16>
+    // CHECK: %[[C:.*]] = "ttnn.conv2d"[[C:.*]]
+    %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0) <{stride_height=1: si32, stride_width=1: si32, dilation_height=1: si32, dilation_width=1: si32, groups=1: si32, padding_left=1: si32, padding_right=1: si32, padding_top=1: si32, padding_bottom=1: si32, is_convtranspose2d=0: si32, output_height_transpose=0: si32, output_width_transpose=0: si32, stride_transpose=0: si32, operand_constraints = [#any_device, #any_device, #any_device, #any_device]}> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, tensor<1x32x32x64xbf16>) -> tensor<1x32x32x64xbf16>
+    return %1 : tensor<1x32x32x64xbf16>
+  }
+}


### PR DESCRIPTION
Changes:
- Updated MLIR to latest main and added my changes
- TTIR, TTNN MLIR support
- TTNN runtime support
- ToMemoryConfig ops should not be placed on the input activations, weight, or bias of the conv2d op as the conv2d op transforms these tensors on host and then moves them to device on its own (hack here)
- Typecast on the output ToMemoryConfig doesn't work on host (hack here)
-  MaxPool2d op definitions in TTIR and TTNN

TTForge PR: https://github.com/tenstorrent/tt-forge-fe/pull/168