### PR TITLE
Remove XFAIL for now-passing test

### DIFF
--- a/test/ttmlir/Dialect/TTNN/embedding/embedding_1d_tensor.mlir
+++ b/test/ttmlir/Dialect/TTNN/embedding/embedding_1d_tensor.mlir
@@ -1,5 +1,4 @@
 // RUN: ttmlir-opt --ttir-load-system-desc --ttir-layout --ttnn-open-device --convert-ttir-to-ttnn %s | FileCheck %s
-// XFAIL: true
 #any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module attributes {} {
   func.func @forward(%arg0: tensor<32xf32>, %arg1: tensor<512x128xf32>) -> tensor<32x128xf32> {


### PR DESCRIPTION
- On PR #473 I have added a test for embedding op, marked with XFAIL
- A fix (PR #478) was merged to main before I merged
- My tests still showed as passing on the PR, and I hadn't seen that #478 was already in (yay Friday merges!)
- Reproed error locally, fixed, confirmed it's good
