### PR TITLE
ChipDesc constants for fast dispatch memory carve outs

### DIFF
--- a/include/ttmlir-c/TTAttrs.h
+++ b/include/ttmlir-c/TTAttrs.h
@@ -26,7 +26,9 @@ MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTChipDescAttrGet(
     MlirContext ctx, MlirAttribute arch, int64_t *grid, size_t gridSize,
     unsigned l1Size, unsigned numDramChannels, unsigned dramChannelSize,
     unsigned nocL1AddressAlignBytes, unsigned pcieAddressAlignBytes,
-    unsigned nocDRAMAddressAlignBytes);
+    unsigned nocDRAMAddressAlignBytes, unsigned l1UnreservedBase,
+    unsigned eriscL1UnreservedBase, unsigned dramUnreservedBase,
+    MlirAttribute chipPhysicalCores);
 
 MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTChipCoordAttrGet(
     MlirContext ctx, unsigned rack, unsigned shelf, unsigned y, unsigned x);

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -78,8 +78,35 @@ def TT_ChipDescAttr : TT_Attr<"ChipDesc", "chip_desc"> {
     TT chip_desc attribute
   }];
 
-  let parameters = (ins "ArchAttr":$arch, ArrayRefParameter<"int64_t">:$grid, "unsigned":$l1Size, "unsigned":$numDramChannels, "unsigned":$dramChannelSize, "unsigned":$nocL1AddressAlignBytes, "unsigned":$pcieAddressAlignBytes, "unsigned":$nocDRAMAddressAlignBytes, "ChipPhysicalCoresAttr":$chipPhysicalCores);
-  let assemblyFormat = "`{` `arch` `=` $arch `,` `grid` `=` custom<DimensionList>($grid) `,` `l1_size` `=` $l1Size `,` `num_dram_channels` `=` $numDramChannels `,` `dram_channel_size` `=` $dramChannelSize `,` `noc_l1_address_align_bytes` `=` $nocL1AddressAlignBytes `,` `pcie_address_align_bytes` `=` $pcieAddressAlignBytes `,` `noc_dram_address_align_bytes` `=` $nocDRAMAddressAlignBytes  `,` `physical_cores` `=` $chipPhysicalCores  `}`";
+  let parameters = (ins "ArchAttr":$arch,
+                    ArrayRefParameter<"int64_t">:$grid,
+                    "unsigned":$l1Size,
+                    "unsigned":$numDramChannels,
+                    "unsigned":$dramChannelSize,
+                    "unsigned":$nocL1AddressAlignBytes,
+                    "unsigned":$pcieAddressAlignBytes,
+                    "unsigned":$nocDRAMAddressAlignBytes,
+                    "unsigned":$l1UnreservedBase,
+                    "unsigned":$eriscL1UnreservedBase,
+                    "unsigned":$dramUnreservedBase,
+                    "ChipPhysicalCoresAttr":$chipPhysicalCores);
+  let assemblyFormat = [{`{` `arch` `=` $arch `,`
+                             `grid` `=` custom<DimensionList>($grid) `,`
+                             `l1_size` `=` $l1Size `,`
+                             `num_dram_channels` `=` $numDramChannels `,`
+                             `dram_channel_size` `=` $dramChannelSize `,`
+                             `noc_l1_address_align_bytes` `=` $nocL1AddressAlignBytes `,`
+                             `pcie_address_align_bytes` `=` $pcieAddressAlignBytes `,`
+                             `noc_dram_address_align_bytes` `=` $nocDRAMAddressAlignBytes  `,`
+                             `l1_unreserved_base` `=` $l1UnreservedBase `,`
+                             `erisc_l1_unreserved_base` `=` $eriscL1UnreservedBase `,`
+                             `dram_unreserved_base` `=` $dramUnreservedBase `,`
+                             `physical_cores` `=` $chipPhysicalCores `}`}];
+
+  let extraClassDeclaration = [{
+    unsigned getUsableL1Size() const { return getL1Size() - getL1UnreservedBase(); }
+    unsigned getUsableDramChannelSize() const { return getDramChannelSize() - getDramUnreservedBase(); }
+  }];
 }
 
 def TT_ChipCoordAttr : TT_Attr<"ChipCoord", "chip_coord"> {

--- a/include/ttmlir/Target/Common/types.fbs
+++ b/include/ttmlir/Target/Common/types.fbs
@@ -102,6 +102,9 @@ table ChipDesc {
   noc_l1_address_align_bytes: uint32;
   pcie_address_align_bytes: uint32;
   noc_dram_address_align_bytes: uint32;
+  l1_unreserved_base: uint32;
+  erisc_l1_unreserved_base: uint32;
+  dram_unreserved_base: uint32;
   physical_cores: ChipPhysicalCores;
 }
 

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -231,7 +231,8 @@ toFlatbuffer(FlatbufferObjectCache &cache, ChipDescAttr chipDesc) {
       chipDesc.getL1Size(), chipDesc.getNumDramChannels(),
       chipDesc.getDramChannelSize(), chipDesc.getNocL1AddressAlignBytes(),
       chipDesc.getPcieAddressAlignBytes(),
-      chipDesc.getNocDRAMAddressAlignBytes(),
+      chipDesc.getNocDRAMAddressAlignBytes(), chipDesc.getL1UnreservedBase(),
+      chipDesc.getEriscL1UnreservedBase(), chipDesc.getDramUnreservedBase(),
       toFlatbuffer(cache, chipDesc.getChipPhysicalCores()));
 }
 

--- a/lib/CAPI/TTAttrs.cpp
+++ b/lib/CAPI/TTAttrs.cpp
@@ -30,12 +30,15 @@ MlirAttribute ttmlirTTChipDescAttrGet(
     MlirContext ctx, MlirAttribute arch, int64_t *grid, size_t gridSize,
     unsigned l1Size, unsigned numDramChannels, unsigned dramChannelSize,
     unsigned nocL1AddressAlignBytes, unsigned pcieAddressAlignBytes,
-    unsigned nocDRAMAddressAlignBytes, MlirAttribute chipPhysicalCores) {
+    unsigned nocDRAMAddressAlignBytes, unsigned l1UnreservedBase,
+    unsigned eriscL1UnreservedBase, unsigned dramUnreservedBase,
+    MlirAttribute chipPhysicalCores) {
   std::vector<int64_t> gridVec(grid, grid + gridSize);
   return wrap(ChipDescAttr::get(
       unwrap(ctx), mlir::dyn_cast<ArchAttr>(unwrap(arch)), gridVec, l1Size,
       numDramChannels, dramChannelSize, nocL1AddressAlignBytes,
-      pcieAddressAlignBytes, nocDRAMAddressAlignBytes,
+      pcieAddressAlignBytes, nocDRAMAddressAlignBytes, l1UnreservedBase,
+      eriscL1UnreservedBase, dramUnreservedBase,
       mlir::dyn_cast<ChipPhysicalCoresAttr>(unwrap(chipPhysicalCores))));
 }
 

--- a/lib/Dialect/TT/IR/TTOpsTypes.cpp
+++ b/lib/Dialect/TT/IR/TTOpsTypes.cpp
@@ -48,7 +48,7 @@ mlir::tt::SystemDescAttr::getDefault(MLIRContext *context) {
       {
           tt::ChipDescAttr::get(
               context, tt::ArchAttr::get(context, tt::Arch::WormholeB0),
-              gridShape, 1499136, 12, (1 << 30), 16, 32, 32,
+              gridShape, 1499136, 12, (1 << 30), 16, 32, 32, 0, 0, 0,
               tt::ChipPhysicalCoresAttr::get(context, workerCores, dramCores,
                                              {}, {})),
       },
@@ -140,7 +140,9 @@ mlir::tt::SystemDescAttr::getFromPath(MLIRContext *context, std::string &path) {
         element->l1_size(), element->num_dram_channels(),
         element->dram_channel_size(), element->noc_l1_address_align_bytes(),
         element->pcie_address_align_bytes(),
-        element->noc_dram_address_align_bytes(), chip_physical_cores_attr);
+        element->noc_dram_address_align_bytes(), element->l1_unreserved_base(),
+        element->erisc_l1_unreserved_base(), element->dram_unreserved_base(),
+        chip_physical_cores_attr);
     chip_desc_list.push_back(current_chip_desc_attr);
   }
 

--- a/python/TTModule.cpp
+++ b/python/TTModule.cpp
@@ -109,20 +109,23 @@ void populateTTModule(py::module &m) {
       });
 
   py::class_<tt::ChipDescAttr>(m, "ChipDescAttr")
-      .def_static("get", [](MlirContext ctx, MlirAttribute arch,
-                            std::vector<int64_t> grid, unsigned l1Size,
-                            unsigned numDramChannels, unsigned dramChannelSize,
-                            unsigned nocL1AddressAlignBytes,
-                            unsigned pcieAddressAlignBytes,
-                            unsigned nocDRAMAddressAlignBytes,
-                            MlirAttribute chipPhysicalCores) {
-        return wrap(tt::ChipDescAttr::get(
-            unwrap(ctx), mlir::cast<tt::ArchAttr>(unwrap(arch)), grid, l1Size,
-            numDramChannels, dramChannelSize, nocL1AddressAlignBytes,
-            pcieAddressAlignBytes, nocDRAMAddressAlignBytes,
-            mlir::dyn_cast<tt::ChipPhysicalCoresAttr>(
-                unwrap(chipPhysicalCores))));
-      });
+      .def_static(
+          "get",
+          [](MlirContext ctx, MlirAttribute arch, std::vector<int64_t> grid,
+             unsigned l1Size, unsigned numDramChannels,
+             unsigned dramChannelSize, unsigned nocL1AddressAlignBytes,
+             unsigned pcieAddressAlignBytes, unsigned nocDRAMAddressAlignBytes,
+             unsigned l1UnreservedBase, unsigned eriscL1UnreservedBase,
+             unsigned dramUnreservedBase, MlirAttribute chipPhysicalCores) {
+            return wrap(tt::ChipDescAttr::get(
+                unwrap(ctx), mlir::cast<tt::ArchAttr>(unwrap(arch)), grid,
+                l1Size, numDramChannels, dramChannelSize,
+                nocL1AddressAlignBytes, pcieAddressAlignBytes,
+                nocDRAMAddressAlignBytes, l1UnreservedBase,
+                eriscL1UnreservedBase, dramUnreservedBase,
+                mlir::dyn_cast<tt::ChipPhysicalCoresAttr>(
+                    unwrap(chipPhysicalCores))));
+          });
 
   py::class_<tt::ChipCoordAttr>(m, "ChipCoordAttr")
       .def_static("get", [](MlirContext ctx, unsigned rack, unsigned shelf,


### PR DESCRIPTION
Adds the following constants to chip descriptors:
- L1_UNRESERVED_BASE
- ERISC_L1_UNRESERVED_BASE
- DRAM_UNRESERVED_BASE

Each of these point to the end of the reserved section by fast dispatch for the respective memory space. Hence, it's where the unreserved section begins.