### PR TITLE
TTNN Runtime workaround to support NOP program (input returned as output)

### DIFF
--- a/test/ttmlir/Silicon/TTNN/simple_nop.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_nop.mlir
@@ -1,0 +1,11 @@
+// RUN: ttmlir-opt --ttir-load-system-desc="path=%system_desc_path%" --ttir-implicit-device --ttir-layout --ttnn-open-device --convert-ttir-to-ttnn %s  > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+
+module @jit_convert_element_type attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
+  func.func public @main(%arg0: tensor<2x2xf32> {mhlo.layout_mode = "default"}) -> (tensor<2x2xf32> {jax.result_info = "", mhlo.layout_mode = "default"}) {
+    // CHECK: %[[C:.*]] = "ttnn.open_device"[[C:.*]]
+    // CHECK: "ttnn.close_device"[[C:.*]]
+    return %arg0 : tensor<2x2xf32>
+  }
+}


### PR DESCRIPTION
Closes #426

 - Discussed a bit offline, other more complicated solutions could exist including new ops, but this is simplest for now, and simplifies some future runtime refactoring that might occur.

 - Added original testcase generated from XLA that exposed this and added CHECK attributes inline