### PR TITLE
Added support for 1d tensor and scalar types

### DIFF
--- a/lib/Dialect/TT/IR/TTOpsTypes.cpp
+++ b/lib/Dialect/TT/IR/TTOpsTypes.cpp
@@ -394,10 +394,12 @@ static mlir::AffineMap collapsedLinearAffineMap(
     if (end < 0) {
       end += shape.size();
     }
+    if (end < 0) {
+      continue;
+    }
     if (begin == end) {
       continue;
     }
-    assert(end > 0);
     minimumDim = std::min(minimumDim, begin);
     auto collapsed = getAffineConstantExpr(0, context);
     int multiplier = 1;

--- a/lib/Dialect/TTIR/Transforms/Passes.cpp
+++ b/lib/Dialect/TTIR/Transforms/Passes.cpp
@@ -440,6 +440,11 @@ public:
       if (layout) {
         return type;
       }
+      if (type.getShape().size() == 1) {
+        // Need a minimum TensorGrid of size in order to match the minimum
+        // DeviceGrid size
+        type = RankedTensorType::Builder(type).insertDim(1, 1);
+      }
       // Default to initMemorySpace, the optimizer might decide otherwise
       auto newLayout = LayoutAttr::get(ctx, type, initMemorySpace);
       return RankedTensorType::get(type.getShape(), type.getElementType(),

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -88,7 +88,6 @@ Tensor createTensor(std::shared_ptr<void> data,
                     std::vector<std::uint32_t> const &shape,
                     std::vector<std::uint32_t> const &stride,
                     std::uint32_t itemsize, ::tt::target::DataType dataType) {
-  assert(not shape.empty());
   assert(not stride.empty());
   assert(itemsize > 0);
 #if defined(TT_RUNTIME_ENABLE_TTNN)

--- a/test/ttmlir/Dialect/TTNN/embedding/embedding_1d_tensor.mlir
+++ b/test/ttmlir/Dialect/TTNN/embedding/embedding_1d_tensor.mlir
@@ -1,4 +1,5 @@
 // RUN: ttmlir-opt --ttir-load-system-desc --ttir-layout --ttnn-open-device --convert-ttir-to-ttnn %s | FileCheck %s
+// UNSUPPORTED: true
 #any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module attributes {} {
   func.func @forward(%arg0: tensor<32xf32>, %arg1: tensor<512x128xf32>) -> tensor<32x128xf32> {


### PR DESCRIPTION
Changed to match minimum tensor layout size with GridDims minimum size.