### PR TITLE
Add V0 tensor layout generation

### DIFF
--- a/include/ttmlir/Dialect/TTIR/Analysis/LegalGridAnalysis.h
+++ b/include/ttmlir/Dialect/TTIR/Analysis/LegalGridAnalysis.h
@@ -15,6 +15,7 @@ struct LegalGridAnalysisInput {
   ChipDescAttr chipDesc;
   GridAttr maxGrid;
   RankedTensorType tensorType;
+  int64_t maxShardedGrids = 64;
   llvm::StringMap<SmallVector<int64_t, 2>> *gridSizeOverrides;
 
   LegalGridAnalysisInput()

--- a/lib/Dialect/TTIR/Analysis/LegalGridAnalysis.cpp
+++ b/lib/Dialect/TTIR/Analysis/LegalGridAnalysis.cpp
@@ -6,6 +6,11 @@
 
 namespace mlir::tt::ttir {
 
+bool mock_is_output_tensor_legal_for_op(Operation *op, LayoutAttr layout) {
+  // Placeholder, needs to be replaced with a call the the TTNN op interface.
+  return true;
+}
+
 bool LegalGridAnalysis::applyOverrides() {
   // Lookup grid size overrides based on location information for current
   // operation.
@@ -36,17 +41,71 @@ bool LegalGridAnalysis::applyOverrides() {
 }
 
 void LegalGridAnalysis::analysisImplementation() {
-  // Placeholder, needs to be implemented. Go through all the grid sizes and
-  // check if they are legal based on tensor type and device/chip attributes.
-  // For now result of analysis is maximum supported grid size.
-  //
+  // A first incomplete implementation of the LegalGridAnalysis.
+  // This implementation is a placeholder and is meant to just enable testing of
+  // other components.
+
+  // Get output tensor type.
+  // TODO: This ignores multiple outputs...?
   RankedTensorType tensorType =
       mlir::cast<RankedTensorType>(op->getResult(0).getType());
   LayoutAttr layout = mlir::cast<LayoutAttr>(tensorType.getEncoding());
-  llvm::ArrayRef<int64_t> tensorShape = tensorType.getShape();
 
-  analysisResult.push_back(layout.withGrid(
-      op->getContext(), tensorShape,
-      GridAttr::get(op->getContext(), analysisInput.maxGrid.getShape())));
+  // DRAM
+  // No grid is set since the tensor is not sharded.
+  // TODO: Is this a viable solution or should we have a grid?
+  LayoutAttr dram =
+      layout.withMemorySpace(op->getContext(), MemorySpace::DeviceDRAM);
+  analysisResult.push_back(dram);
+
+  // L1 Interleaved (same as above)
+  LayoutAttr l1Interleaved =
+      layout.withMemorySpace(op->getContext(), MemorySpace::DeviceL1);
+  analysisResult.push_back(l1Interleaved);
+
+  // L1 Sharded
+  LayoutAttr shardedBase =
+      layout.withMemorySpace(op->getContext(), MemorySpace::DeviceL1);
+
+  // Block Sharded
+  for (auto width = 2; width <= analysisInput.maxGrid.getShape()[0]; ++width) {
+    for (auto height = 2; height <= analysisInput.maxGrid.getShape()[1];
+         ++height) {
+      analysisResult.push_back(shardedBase.withGrid(
+          op->getContext(), tensorType,
+          GridAttr::get(op->getContext(), {width, height})));
+    }
+  }
+
+  auto numCores =
+      analysisInput.maxGrid.getShape()[0] * analysisInput.maxGrid.getShape()[1];
+  // Height Sharded
+  // TODO: Missing affine mapping to actual grid.
+  // TODO: Can we have every shape of 1d grid? Probably not, need to check what
+  // is divisible by grid sides.
+  // TODO: Limit the number of options to some reasonable number.
+  // TODO: Put all of this into the same loop.
+  for (auto height = 2; height <= numCores; ++height) {
+    analysisResult.push_back(
+        shardedBase.withGrid(op->getContext(), tensorType,
+                             GridAttr::get(op->getContext(), {height, 1})));
+  }
+
+  // Width Sharded
+  for (auto width = 2; width <= numCores; ++width) {
+    analysisResult.push_back(
+        shardedBase.withGrid(op->getContext(), tensorType,
+                             GridAttr::get(op->getContext(), {1, width})));
+  }
+
+  // Filter layouts based on output tensor legality for current op.
+  analysisResult.erase(
+      std::remove_if(analysisResult.begin(), analysisResult.end(),
+                     [this](LayoutAttr layout) {
+                       return !mock_is_output_tensor_legal_for_op(op, layout);
+                     }),
+      analysisResult.end());
+
+  // TODO: Potetialy filter out tensors that dont fit into L1 at all.
 }
 } // namespace mlir::tt::ttir

--- a/lib/Dialect/TTIR/Analysis/LegalGridAnalysis.cpp
+++ b/lib/Dialect/TTIR/Analysis/LegalGridAnalysis.cpp
@@ -98,7 +98,8 @@ void LegalGridAnalysis::analysisImplementation() {
   LayoutAttr dram =
       layout.withMemorySpace(op->getContext(), MemorySpace::DeviceDRAM)
           .withMemoryLayout(op->getContext(), TensorMemoryLayout::Interleaved)
-          .withGrid(op->getContext(), tensorType, analysisInput.maxGrid);
+          .withGrid(op->getContext(), tensorType, GridAttr::get(op->getContext(),
+                                                               analysisInput.maxGrid.getShape()));
   if (mock_is_output_tensor_legal_for_op(op, dram)) {
     analysisResult.push_back(dram);
   }
@@ -107,7 +108,8 @@ void LegalGridAnalysis::analysisImplementation() {
   LayoutAttr l1Interleaved =
       layout.withMemorySpace(op->getContext(), MemorySpace::DeviceL1)
           .withMemoryLayout(op->getContext(), TensorMemoryLayout::Interleaved)
-          .withGrid(op->getContext(), tensorType, analysisInput.maxGrid);
+          .withGrid(op->getContext(), tensorType, GridAttr::get(op->getContext(),
+                                                               analysisInput.maxGrid.getShape()));
   if (mock_is_output_tensor_legal_for_op(op, l1Interleaved)) {
     analysisResult.push_back(l1Interleaved);
   }

--- a/lib/Dialect/TTIR/Analysis/LegalGridAnalysis.cpp
+++ b/lib/Dialect/TTIR/Analysis/LegalGridAnalysis.cpp
@@ -74,13 +74,15 @@ void LegalGridAnalysis::analysisImplementation() {
   // This implementation is a placeholder and is meant to just enable testing of
   // other components.
 
-  // Skip mlir ops.
+  // Process only TTIR ops.
   if (not llvm::isa<TTIROp>(op)) {
     return;
   }
   // Skip operations that don't have output tensors.
-  if (llvm::isa<ToLayoutOp>(op) || llvm::isa<DeallocOp>(op) ||
-      llvm::isa<YieldOp>(op)) {
+  if (op->getNumResults() == 0) {
+    return;
+  }
+  if (llvm::isa<ToLayoutOp>(op)) {
     return;
   }
 

--- a/lib/Dialect/TTIR/Analysis/LegalGridAnalysis.cpp
+++ b/lib/Dialect/TTIR/Analysis/LegalGridAnalysis.cpp
@@ -97,7 +97,8 @@ void LegalGridAnalysis::analysisImplementation() {
   // compute gird. (not implemented in runtime atm)
   LayoutAttr dram =
       layout.withMemorySpace(op->getContext(), MemorySpace::DeviceDRAM)
-          .withMemoryLayout(op->getContext(), TensorMemoryLayout::Interleaved);
+          .withMemoryLayout(op->getContext(), TensorMemoryLayout::Interleaved)
+          .withGrid(op->getContext(), tensorType, analysisInput.maxGrid);
   if (mock_is_output_tensor_legal_for_op(op, dram)) {
     analysisResult.push_back(dram);
   }
@@ -105,7 +106,8 @@ void LegalGridAnalysis::analysisImplementation() {
   // L1 Interleaved (same as above).
   LayoutAttr l1Interleaved =
       layout.withMemorySpace(op->getContext(), MemorySpace::DeviceL1)
-          .withMemoryLayout(op->getContext(), TensorMemoryLayout::Interleaved);
+          .withMemoryLayout(op->getContext(), TensorMemoryLayout::Interleaved)
+          .withGrid(op->getContext(), tensorType, analysisInput.maxGrid);
   if (mock_is_output_tensor_legal_for_op(op, l1Interleaved)) {
     analysisResult.push_back(l1Interleaved);
   }

--- a/lib/Dialect/TTIR/Analysis/LegalGridAnalysis.cpp
+++ b/lib/Dialect/TTIR/Analysis/LegalGridAnalysis.cpp
@@ -98,8 +98,9 @@ void LegalGridAnalysis::analysisImplementation() {
   LayoutAttr dram =
       layout.withMemorySpace(op->getContext(), MemorySpace::DeviceDRAM)
           .withMemoryLayout(op->getContext(), TensorMemoryLayout::Interleaved)
-          .withGrid(op->getContext(), tensorType, GridAttr::get(op->getContext(),
-                                                               analysisInput.maxGrid.getShape()));
+          .withGrid(op->getContext(), tensorType,
+                    GridAttr::get(op->getContext(),
+                                  analysisInput.maxGrid.getShape()));
   if (mock_is_output_tensor_legal_for_op(op, dram)) {
     analysisResult.push_back(dram);
   }
@@ -108,8 +109,9 @@ void LegalGridAnalysis::analysisImplementation() {
   LayoutAttr l1Interleaved =
       layout.withMemorySpace(op->getContext(), MemorySpace::DeviceL1)
           .withMemoryLayout(op->getContext(), TensorMemoryLayout::Interleaved)
-          .withGrid(op->getContext(), tensorType, GridAttr::get(op->getContext(),
-                                                               analysisInput.maxGrid.getShape()));
+          .withGrid(op->getContext(), tensorType,
+                    GridAttr::get(op->getContext(),
+                                  analysisInput.maxGrid.getShape()));
   if (mock_is_output_tensor_legal_for_op(op, l1Interleaved)) {
     analysisResult.push_back(l1Interleaved);
   }

--- a/lib/Dialect/TTIR/Analysis/OptimalTargetGridAnalysis.cpp
+++ b/lib/Dialect/TTIR/Analysis/OptimalTargetGridAnalysis.cpp
@@ -25,7 +25,9 @@ void OptimalTargetGridAnalysis::analysisImplementation() {
   // Placeholder: pick the first legal grid.
   //
   for (auto opGrids : analysisInput.legalGrids) {
-    analysisResult[opGrids.first] = opGrids.second[0];
+    if (not opGrids.second.empty()) {
+      analysisResult[opGrids.first] = opGrids.second[0];
+    }
   }
 }
 } // namespace mlir::tt::ttir

--- a/lib/Dialect/TTIR/Transforms/Passes.cpp
+++ b/lib/Dialect/TTIR/Transforms/Passes.cpp
@@ -1102,7 +1102,7 @@ public:
               optimalTargetGridAnalysis.getResult().at(op));
 
           op->getResult(0).setType(newTensorType);
-          
+
           if (llvm::isa<mlir::DestinationStyleOpInterface>(op)) {
             // Update dps operand layout as well.
             op->getOperands().back().setType(newTensorType);

--- a/lib/Dialect/TTIR/Transforms/Passes.cpp
+++ b/lib/Dialect/TTIR/Transforms/Passes.cpp
@@ -1095,9 +1095,11 @@ public:
 
         // Update the output layout attribute with the new grid size.
         //
-        op->getResult(0).setType(RankedTensorType::get(
-            tensorShape, tensorType.getElementType(),
-            optimalTargetGridAnalysis.getResult().at(op)));
+        if (optimalTargetGridAnalysis.getResult().contains(op)) {
+          op->getResult(0).setType(RankedTensorType::get(
+              tensorShape, tensorType.getElementType(),
+              optimalTargetGridAnalysis.getResult().at(op)));
+        }
       });
 
       // Update the function type to reflect the updated return operation's

--- a/lib/Dialect/TTIR/Transforms/Passes.cpp
+++ b/lib/Dialect/TTIR/Transforms/Passes.cpp
@@ -22,6 +22,7 @@
 #include "ttmlir/Dialect/TTIR/Analysis/OptimalTargetGridAnalysis.h"
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
 #include "ttmlir/Utils.h"
+#include <mlir/Interfaces/DestinationStyleOpInterface.h>
 
 namespace mlir::tt::ttir {
 #define GEN_PASS_DEF_TTIRGENERICKERNEL
@@ -1096,9 +1097,16 @@ public:
         // Update the output layout attribute with the new grid size.
         //
         if (optimalTargetGridAnalysis.getResult().contains(op)) {
-          op->getResult(0).setType(RankedTensorType::get(
+          RankedTensorType newTensorType = RankedTensorType::get(
               tensorShape, tensorType.getElementType(),
-              optimalTargetGridAnalysis.getResult().at(op)));
+              optimalTargetGridAnalysis.getResult().at(op));
+
+          op->getResult(0).setType(newTensorType);
+          
+          if (llvm::isa<mlir::DestinationStyleOpInterface>(op)) {
+            // Update dps operand layout as well.
+            op->getOperands().back().setType(newTensorType);
+          }
         }
       });
 

--- a/test/ttmlir/Dialect/TTIR/test_grid_set.mlir
+++ b/test/ttmlir/Dialect/TTIR/test_grid_set.mlir
@@ -3,8 +3,8 @@
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
     %0 = tensor.empty() : tensor<64x128xf32>
-    // CHECK: #[[LAYOUT_1:.*]] = #tt.layout<(d0, d1) -> (d0, d1), undef, <8x8>, memref<8x16xf32, #dram>, interleaved>
-    // CHECK: %[[C:.*]] = "ttir.multiply"[[C:.*]] -> tensor<64x128xf32, #[[LAYOUT_1]]>
+    // CHECK: #[[LAYOUT_2:.*]] = #tt.layout<(d0, d1) -> (d0, d1), undef, <8x8>, memref<8x16xf32, #dram>, interleaved>
+    // CHECK: %[[C:.*]] = "ttir.multiply"[[C:.*]] -> tensor<64x128xf32, #[[LAYOUT_2]]>
     %1 = "ttir.multiply"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
     return %1 : tensor<64x128xf32>
   }

--- a/test/ttmlir/Dialect/TTNN/multiple_add_with_loc.mlir
+++ b/test/ttmlir/Dialect/TTNN/multiple_add_with_loc.mlir
@@ -3,15 +3,15 @@
 #loc = loc("test_ops.py:17_0_0":0:0)
 module attributes {} {
   func.func @main(%arg0: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0), %arg1: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0), %arg2: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0)) -> (tensor<1x32x32xf32>, tensor<1x32x32xf32>) {
-    // CHECK: #[[LAYOUT_1:.*]] = #tt.layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), undef, <8x8>, memref<4x4xf32, #dram>, interleaved>
+    // CHECK: #[[LAYOUT_2:.*]] = #tt.layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), undef, <8x8>, memref<4x4xf32, #dram>, interleaved>
     %0 = tensor.empty() : tensor<1x32x32xf32> loc(#loc5)
-    // CHECK: %[[C:.*]] = "ttnn.add"[[C:.*]] -> tensor<1x32x32xf32, #[[LAYOUT_1]]>
+    // CHECK: %[[C:.*]] = "ttnn.add"[[C:.*]] -> tensor<1x32x32xf32, #[[LAYOUT_2]]>
     %1 = "ttir.add"(%arg1, %arg2, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<1x32x32xf32>, tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> tensor<1x32x32xf32> loc(#loc5)
     %2 = tensor.empty() : tensor<1x32x32xf32> loc(#loc6)
-    // CHECK: %[[C:.*]] = "ttnn.add"[[C:.*]] -> tensor<1x32x32xf32, #[[LAYOUT_1]]>
+    // CHECK: %[[C:.*]] = "ttnn.add"[[C:.*]] -> tensor<1x32x32xf32, #[[LAYOUT_2]]>
     %3 = "ttir.add"(%1, %arg0, %2) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<1x32x32xf32>, tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> tensor<1x32x32xf32> loc(#loc6)
     %4 = tensor.empty() : tensor<1x32x32xf32> loc(#loc7)
-    // CHECK: %[[C:.*]] = "ttnn.add"[[C:.*]] -> tensor<1x32x32xf32, #[[LAYOUT_1]]>
+    // CHECK: %[[C:.*]] = "ttnn.add"[[C:.*]] -> tensor<1x32x32xf32, #[[LAYOUT_2]]>
     %5 = "ttir.add"(%arg2, %arg1, %4) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<1x32x32xf32>, tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> tensor<1x32x32xf32> loc(#loc7)
     // CHECK: return %[[R0:.*]], %[[R1:.*]] : tensor<1x32x32xf32, #layout>, tensor<1x32x32xf32, #layout>
     return %3, %5 : tensor<1x32x32xf32>, tensor<1x32x32xf32> loc(#loc4)

--- a/test/ttmlir/Dialect/TTNN/multiple_add_with_loc.mlir
+++ b/test/ttmlir/Dialect/TTNN/multiple_add_with_loc.mlir
@@ -13,7 +13,7 @@ module attributes {} {
     %4 = tensor.empty() : tensor<1x32x32xf32> loc(#loc7)
     // CHECK: %[[C:.*]] = "ttnn.add"[[C:.*]] -> tensor<1x32x32xf32, #[[LAYOUT_1]]>
     %5 = "ttir.add"(%arg2, %arg1, %4) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<1x32x32xf32>, tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> tensor<1x32x32xf32> loc(#loc7)
-    // CHECK: return %[[R0:.*]], %[[R1:.*]] : tensor<1x32x32xf32, #layout1>, tensor<1x32x32xf32, #layout1>
+    // CHECK: return %[[R0:.*]], %[[R1:.*]] : tensor<1x32x32xf32, #layout>, tensor<1x32x32xf32, #layout>
     return %3, %5 : tensor<1x32x32xf32>, tensor<1x32x32xf32> loc(#loc4)
   } loc(#loc)
 } loc(#loc)

--- a/test/ttmlir/Dialect/TTNN/multiple_add_with_loc_grid_override.mlir
+++ b/test/ttmlir/Dialect/TTNN/multiple_add_with_loc_grid_override.mlir
@@ -3,9 +3,9 @@
 #loc = loc("test_ops.py:17_0_0":0:0)
 module attributes {} {
   func.func @main(%arg0: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0), %arg1: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0), %arg2: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0)) -> (tensor<1x32x32xf32>, tensor<1x32x32xf32>) {
-    // CHECK: #[[LAYOUT_0:.*]] = #tt.layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), undef, <8x8>, memref<4x4xf32, #system>>
+    // CHECK: #[[LAYOUT_0:.*]] = #tt.layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), undef, <1x1>, memref<32x32xf32, #system>>
     // CHECK: #[[LAYOUT_1:.*]] = #tt.layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), undef, <4x4>, memref<8x8xf32, #dram>, interleaved>
-    // CHECK: #[[LAYOUT_2:.*]] = #tt.layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), undef, <8x8>, memref<4x4xf32, #dram>, interleaved>
+    // CHECK: #[[LAYOUT_3:.*]] = #tt.layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), undef, <8x8>, memref<4x4xf32, #dram>, interleaved>
     %0 = tensor.empty() : tensor<1x32x32xf32> loc(#loc5)
     // CHECK: %[[C:.*]] = "ttnn.add"[[C:.*]] -> tensor<1x32x32xf32, #[[LAYOUT_1]]>
     %1 = "ttir.add"(%arg1, %arg2, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<1x32x32xf32>, tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> tensor<1x32x32xf32> loc(#loc5)
@@ -13,7 +13,7 @@ module attributes {} {
     // CHECK: %[[C:.*]] = "ttnn.add"[[C:.*]] -> tensor<1x32x32xf32, #[[LAYOUT_1]]>
     %3 = "ttir.add"(%1, %arg0, %2) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<1x32x32xf32>, tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> tensor<1x32x32xf32> loc(#loc6)
     %4 = tensor.empty() : tensor<1x32x32xf32> loc(#loc7)
-    // CHECK: %[[C:.*]] = "ttnn.add"[[C:.*]] -> tensor<1x32x32xf32, #[[LAYOUT_2]]>
+    // CHECK: %[[C:.*]] = "ttnn.add"[[C:.*]] -> tensor<1x32x32xf32, #[[LAYOUT_3]]>
     %5 = "ttir.add"(%arg2, %arg1, %4) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<1x32x32xf32>, tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> tensor<1x32x32xf32> loc(#loc7)
     // CHECK: return %[[R0:.*]], %[[R1:.*]] : tensor<1x32x32xf32, #[[LAYOUT_0]]>, tensor<1x32x32xf32, #[[LAYOUT_0]]>
     return %3, %5 : tensor<1x32x32xf32>, tensor<1x32x32xf32> loc(#loc4)

--- a/test/ttmlir/Dialect/TTNN/ttir_to_ttnn_pipeline.mlir
+++ b/test/ttmlir/Dialect/TTNN/ttir_to_ttnn_pipeline.mlir
@@ -2,11 +2,11 @@
 #any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    // CHECK: #[[LAYOUT_1:.*]] = #tt.layout<(d0, d1) -> (d0, d1), undef, <8x8>, memref<8x16xf32, #dram>, interleaved>
+    // CHECK: #[[LAYOUT_2:.*]] = #tt.layout<(d0, d1) -> (d0, d1), undef, <8x8>, memref<8x16xf32, #dram>, interleaved>
     // CHECK: %[[C:.*]] = "ttnn.open_device"[[C:.*]]
     // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
     %0 = tensor.empty() : tensor<64x128xf32>
-    // CHECK: %[[C:.*]] = "ttnn.multiply"[[C:.*]] -> tensor<64x128xf32, #[[LAYOUT_1]]>
+    // CHECK: %[[C:.*]] = "ttnn.multiply"[[C:.*]] -> tensor<64x128xf32, #[[LAYOUT_2]]>
     %1 = "ttir.multiply"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
     // CHECK: "ttnn.close_device"[[C:.*]]
     return %1 : tensor<64x128xf32>

--- a/test/ttmlir/Silicon/TTNN/sharded/simple_eltwise_sharded.mlir
+++ b/test/ttmlir/Silicon/TTNN/sharded/simple_eltwise_sharded.mlir
@@ -3,114 +3,114 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 #l1_block_sharded = #tt.operand_constraint<l1_block_sharded>
 
-func.func @subtract(%arg0: tensor<1792x256xf32>, %arg1: tensor<1792x256xf32>) -> tensor<1792x256xf32> {
+func.func @subtract(%arg0: tensor<224x64xf32>, %arg1: tensor<224x64xf32>) -> tensor<224x64xf32> {
   // CHECK: %[[C:.*]] = "ttnn.open_device"[[C:.*]]
   // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
-  %0 = tensor.empty() : tensor<1792x256xf32>
+  %0 = tensor.empty() : tensor<224x64xf32>
   // CHECK: %[[C:.*]] = "ttnn.subtract"[[C:.*]]
-  %1 = "ttir.subtract"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#l1_block_sharded, #l1_block_sharded, #l1_block_sharded]}> : (tensor<1792x256xf32>, tensor<1792x256xf32>, tensor<1792x256xf32>) -> tensor<1792x256xf32>
+  %1 = "ttir.subtract"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#l1_block_sharded, #l1_block_sharded, #l1_block_sharded]}> : (tensor<224x64xf32>, tensor<224x64xf32>, tensor<224x64xf32>) -> tensor<224x64xf32>
   // CHECK: "ttnn.close_device"[[C:.*]]
-  return %1 : tensor<1792x256xf32>
+  return %1 : tensor<224x64xf32>
 }
 
-func.func @div(%arg0: tensor<1792x256xf32>, %arg1: tensor<1792x256xf32>) -> tensor<1792x256xf32> {
+func.func @div(%arg0: tensor<224x64xf32>, %arg1: tensor<224x64xf32>) -> tensor<224x64xf32> {
   // CHECK: %[[C:.*]] = "ttnn.open_device"[[C:.*]]
   // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
-  %0 = tensor.empty() : tensor<1792x256xf32>
+  %0 = tensor.empty() : tensor<224x64xf32>
   // CHECK: %[[C:.*]] = "ttnn.div"[[C:.*]]
-  %1 = "ttir.div"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#l1_block_sharded, #l1_block_sharded, #l1_block_sharded]}> : (tensor<1792x256xf32>, tensor<1792x256xf32>, tensor<1792x256xf32>) -> tensor<1792x256xf32>
+  %1 = "ttir.div"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#l1_block_sharded, #l1_block_sharded, #l1_block_sharded]}> : (tensor<224x64xf32>, tensor<224x64xf32>, tensor<224x64xf32>) -> tensor<224x64xf32>
   // CHECK: "ttnn.close_device"[[C:.*]]
-  return %1 : tensor<1792x256xf32>
+  return %1 : tensor<224x64xf32>
 }
 
-func.func @multiply(%arg0: tensor<1792x256xf32>, %arg1: tensor<1792x256xf32>) -> tensor<1792x256xf32> {
+func.func @multiply(%arg0: tensor<224x64xf32>, %arg1: tensor<224x64xf32>) -> tensor<224x64xf32> {
   // CHECK: %[[C:.*]] = "ttnn.open_device"[[C:.*]]
   // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
-  %0 = tensor.empty() : tensor<1792x256xf32>
+  %0 = tensor.empty() : tensor<224x64xf32>
   // CHECK: %[[C:.*]] = "ttnn.multiply"[[C:.*]]
-  %1 = "ttir.multiply"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#l1_block_sharded, #l1_block_sharded, #l1_block_sharded]}> : (tensor<1792x256xf32>, tensor<1792x256xf32>, tensor<1792x256xf32>) -> tensor<1792x256xf32>
+  %1 = "ttir.multiply"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#l1_block_sharded, #l1_block_sharded, #l1_block_sharded]}> : (tensor<224x64xf32>, tensor<224x64xf32>, tensor<224x64xf32>) -> tensor<224x64xf32>
   // CHECK: "ttnn.close_device"[[C:.*]]
-  return %1 : tensor<1792x256xf32>
+  return %1 : tensor<224x64xf32>
 }
 
-func.func @relu(%arg0: tensor<1792x256xf32>) -> tensor<1792x256xf32> {
+func.func @relu(%arg0: tensor<224x64xf32>) -> tensor<224x64xf32> {
   // CHECK: %[[C:.*]] = "ttnn.open_device"[[C:.*]]
   // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
-  %0 = tensor.empty() : tensor<1792x256xf32>
+  %0 = tensor.empty() : tensor<224x64xf32>
   // CHECK: %[[C:.*]] = "ttnn.relu"[[C:.*]]
-  %1 = "ttir.relu"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>, operand_constraints = [#l1_block_sharded, #l1_block_sharded]}> : (tensor<1792x256xf32>, tensor<1792x256xf32>) -> tensor<1792x256xf32>
+  %1 = "ttir.relu"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>, operand_constraints = [#l1_block_sharded, #l1_block_sharded]}> : (tensor<224x64xf32>, tensor<224x64xf32>) -> tensor<224x64xf32>
   // CHECK: "ttnn.close_device"[[C:.*]]
-  return %1 : tensor<1792x256xf32>
+  return %1 : tensor<224x64xf32>
 }
 
-func.func @ge(%arg0: tensor<1792x256xf32>, %arg1: tensor<1792x256xf32>) -> tensor<1792x256xf32> {
+func.func @ge(%arg0: tensor<224x64xf32>, %arg1: tensor<224x64xf32>) -> tensor<224x64xf32> {
   // CHECK: %[[C:.*]] = "ttnn.open_device"[[C:.*]]
   // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
-  %0 = tensor.empty() : tensor<1792x256xf32>
+  %0 = tensor.empty() : tensor<224x64xf32>
   // CHECK: %[[C:.*]] = "ttnn.ge"[[C:.*]]
-  %1 = "ttir.ge"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#l1_block_sharded, #l1_block_sharded, #l1_block_sharded]}> : (tensor<1792x256xf32>, tensor<1792x256xf32>, tensor<1792x256xf32>) -> tensor<1792x256xf32>
+  %1 = "ttir.ge"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#l1_block_sharded, #l1_block_sharded, #l1_block_sharded]}> : (tensor<224x64xf32>, tensor<224x64xf32>, tensor<224x64xf32>) -> tensor<224x64xf32>
   // CHECK: "ttnn.close_device"[[C:.*]]
-  return %1 : tensor<1792x256xf32>
+  return %1 : tensor<224x64xf32>
 }
 
-func.func @reshape(%arg0: tensor<4x2x1792x256xbf16>) -> tensor<2x4x1792x256xbf16> {
-  %0 = tensor.empty() : tensor<2x4x1792x256xbf16>
+func.func @reshape(%arg0: tensor<4x2x224x64xbf16>) -> tensor<2x4x224x64xbf16> {
+  %0 = tensor.empty() : tensor<2x4x224x64xbf16>
   // CHECK: %[[C:.*]] = "ttnn.reshape"[[C:.*]]
-  %1 = "ttir.reshape"(%arg0, %0) <{shape = [2: i32, 4: i32, 1792: i32, 256: i32] , operand_constraints = [#l1_block_sharded, #l1_block_sharded]}> : (tensor<4x2x1792x256xbf16>, tensor<2x4x1792x256xbf16>) -> tensor<2x4x1792x256xbf16>
-  return %1 : tensor<2x4x1792x256xbf16>
+  %1 = "ttir.reshape"(%arg0, %0) <{shape = [2: i32, 4: i32, 224: i32, 64: i32] , operand_constraints = [#l1_block_sharded, #l1_block_sharded]}> : (tensor<4x2x224x64xbf16>, tensor<2x4x224x64xbf16>) -> tensor<2x4x224x64xbf16>
+  return %1 : tensor<2x4x224x64xbf16>
 }
 
-func.func @squeeze(%arg0: tensor<1x2x1x1792x256xbf16>) -> tensor<1x2x1792x256xbf16> {
-  %0 = tensor.empty() : tensor<1x2x1792x256xbf16>
+func.func @squeeze(%arg0: tensor<1x2x1x224x64xbf16>) -> tensor<1x2x224x64xbf16> {
+  %0 = tensor.empty() : tensor<1x2x224x64xbf16>
   // CHECK: %[[C:.*]] = "ttnn.reshape"[[C:.*]]
-  %1 = "ttir.squeeze"(%arg0, %0) <{dim = 2 : si32, operand_constraints = [#l1_block_sharded, #l1_block_sharded]}> : (tensor<1x2x1x1792x256xbf16>, tensor<1x2x1792x256xbf16>) -> tensor<1x2x1792x256xbf16>
-  return %1 : tensor<1x2x1792x256xbf16>
+  %1 = "ttir.squeeze"(%arg0, %0) <{dim = 2 : si32, operand_constraints = [#l1_block_sharded, #l1_block_sharded]}> : (tensor<1x2x1x224x64xbf16>, tensor<1x2x224x64xbf16>) -> tensor<1x2x224x64xbf16>
+  return %1 : tensor<1x2x224x64xbf16>
 }
 
-func.func @reciprocal(%arg0: tensor<1792x256xf32>) -> tensor<1792x256xf32> {
+func.func @reciprocal(%arg0: tensor<224x64xf32>) -> tensor<224x64xf32> {
   // CHECK: %[[C:.*]] = "ttnn.open_device"[[C:.*]]
   // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
-  %0 = tensor.empty() : tensor<1792x256xf32>
+  %0 = tensor.empty() : tensor<224x64xf32>
   // CHECK: %[[C:.*]] = "ttnn.reciprocal"[[C:.*]]
-  %1 = "ttir.reciprocal"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>, operand_constraints = [#l1_block_sharded, #l1_block_sharded]}> : (tensor<1792x256xf32>, tensor<1792x256xf32>) -> tensor<1792x256xf32>
+  %1 = "ttir.reciprocal"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>, operand_constraints = [#l1_block_sharded, #l1_block_sharded]}> : (tensor<224x64xf32>, tensor<224x64xf32>) -> tensor<224x64xf32>
   // CHECK: "ttnn.close_device"[[C:.*]]
-  return %1 : tensor<1792x256xf32>
+  return %1 : tensor<224x64xf32>
 }
 
-func.func @sigmoid(%arg0: tensor<1792x256xf32>) -> tensor<1792x256xf32> {
+func.func @sigmoid(%arg0: tensor<224x64xf32>) -> tensor<224x64xf32> {
   // CHECK: %[[C:.*]] = "ttnn.open_device"[[C:.*]]
   // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
-  %0 = tensor.empty() : tensor<1792x256xf32>
+  %0 = tensor.empty() : tensor<224x64xf32>
   // CHECK: %[[C:.*]] = "ttnn.sigmoid"[[C:.*]]
-  %1 = "ttir.sigmoid"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>, operand_constraints = [#l1_block_sharded, #l1_block_sharded]}> : (tensor<1792x256xf32>, tensor<1792x256xf32>) -> tensor<1792x256xf32>
+  %1 = "ttir.sigmoid"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>, operand_constraints = [#l1_block_sharded, #l1_block_sharded]}> : (tensor<224x64xf32>, tensor<224x64xf32>) -> tensor<224x64xf32>
   // CHECK: "ttnn.close_device"[[C:.*]]
-  return %1 : tensor<1792x256xf32>
+  return %1 : tensor<224x64xf32>
 }
 
-func.func @sqrt(%arg0: tensor<1792x256xf32>) -> tensor<1792x256xf32> {
+func.func @sqrt(%arg0: tensor<224x64xf32>) -> tensor<224x64xf32> {
   // CHECK: %[[C:.*]] = "ttnn.open_device"[[C:.*]]
   // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
-  %0 = tensor.empty() : tensor<1792x256xf32>
+  %0 = tensor.empty() : tensor<224x64xf32>
   // CHECK: %[[C:.*]] = "ttnn.sqrt"[[C:.*]]
-  %1 = "ttir.sqrt"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>, operand_constraints = [#l1_block_sharded, #l1_block_sharded]}> : (tensor<1792x256xf32>, tensor<1792x256xf32>) -> tensor<1792x256xf32>
+  %1 = "ttir.sqrt"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>, operand_constraints = [#l1_block_sharded, #l1_block_sharded]}> : (tensor<224x64xf32>, tensor<224x64xf32>) -> tensor<224x64xf32>
   // CHECK: "ttnn.close_device"[[C:.*]]
-  return %1 : tensor<1792x256xf32>
+  return %1 : tensor<224x64xf32>
 }
 
-func.func @softmax(%arg0: tensor<1792x256xbf16>) -> tensor<1792x256xbf16> {
+func.func @softmax(%arg0: tensor<224x64xbf16>) -> tensor<224x64xbf16> {
   // CHECK: %[[C:.*]] = "ttnn.open_device"[[C:.*]]
   // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
-  %0 = tensor.empty() : tensor<1792x256xbf16>
+  %0 = tensor.empty() : tensor<224x64xbf16>
   // CHECK: %[[C:.*]] = "ttnn.softmax"[[C:.*]]
   // Check for positive dimension attribute
-  %1 = "ttir.softmax"(%arg0, %0) <{dimension = 1 : si32, operand_constraints = [#l1_block_sharded, #l1_block_sharded]}> : (tensor<1792x256xbf16>, tensor<1792x256xbf16>) -> tensor<1792x256xbf16>
+  %1 = "ttir.softmax"(%arg0, %0) <{dimension = 1 : si32, operand_constraints = [#l1_block_sharded, #l1_block_sharded]}> : (tensor<224x64xbf16>, tensor<224x64xbf16>) -> tensor<224x64xbf16>
   // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
-  %2 = tensor.empty() : tensor<1792x256xbf16>
+  %2 = tensor.empty() : tensor<224x64xbf16>
   // CHECK: %[[C:.*]] = "ttnn.softmax"[[C:.*]]
   // Check for negative dimension attribute
-  %3 = "ttir.softmax"(%1, %2) <{dimension = -1 : si32, operand_constraints = [#l1_block_sharded, #l1_block_sharded]}> : (tensor<1792x256xbf16>, tensor<1792x256xbf16>) -> tensor<1792x256xbf16>
+  %3 = "ttir.softmax"(%1, %2) <{dimension = -1 : si32, operand_constraints = [#l1_block_sharded, #l1_block_sharded]}> : (tensor<224x64xbf16>, tensor<224x64xbf16>) -> tensor<224x64xbf16>
   // CHECK: "ttnn.close_device"[[C:.*]]
-  return %3 : tensor<1792x256xbf16>
+  return %3 : tensor<224x64xbf16>
 }
 
 /////////////////////////////////////////

--- a/test/ttmlir/Silicon/TTNN/sharded/simple_eltwise_sharded.mlir
+++ b/test/ttmlir/Silicon/TTNN/sharded/simple_eltwise_sharded.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-grid-set=false" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 #l1_block_sharded = #tt.operand_constraint<l1_block_sharded>


### PR DESCRIPTION
A first implementation of generating possible op configurations. Starting with generating a few sharded tensor layouts for now. Much of the details here are incomplete and this is meant to unblock further optimizer and runtime development.

Waiting on #541 in order to add appropriate TensorMemoryLayout before merge. 

Closes #572 