### PR TITLE
Add builder nodes to tt-mlir CI

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,6 +3,7 @@ name: Build in Docker
 on:
   workflow_dispatch:
   workflow_call:
+  push:
 
 jobs:
 
@@ -15,6 +16,7 @@ jobs:
         build: [
           {runs-on: ubuntu-latest, build_type: Release, enable_runtime: OFF},
           {runs-on: self-hosted, build_type: Release, enable_runtime: ON},
+          {runs-on: builder, build_type: Release, enable_runtime: ON}
         ]
 
     runs-on: ${{ matrix.build.runs-on }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,7 +3,6 @@ name: Build in Docker
 on:
   workflow_dispatch:
   workflow_call:
-  push:
 
 jobs:
 
@@ -15,7 +14,6 @@ jobs:
         image: ["ubuntu-22-04"]
         build: [
           {runs-on: ubuntu-latest, build_type: Release, enable_runtime: OFF},
-          {runs-on: self-hosted, build_type: Release, enable_runtime: ON},
           {runs-on: builder, build_type: Release, enable_runtime: ON}
         ]
 


### PR DESCRIPTION
Set up and register new builder machines for Github CI. These machines perform build and lint tasks 2x faster than standard silicon runners. 

- install docker on bileder VMs
- register builder nodes as Github self-hosted runners
- add them to tt-mlir project
- tag them with "builder" label
- update CI workflow to use "builder" nodes