### PR TITLE
Adding `squeeze` op

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -401,6 +401,26 @@ def TTIR_ReshapeOp: TTIR_DPSOp<"reshape"> {
     let hasVerifier = 1;
 }
 
+def TTIR_SqueezeOp : TTIR_DPSOp<"squeeze"> {
+    let summary = "Squeeze op.";
+    let description = [{
+      Squeeze tensor.
+    }];
+
+    let arguments = (ins AnyRankedTensor:$input,
+                         AnyRankedTensor:$output,
+                         SI32Attr:$dim,
+                         TT_OperandConstraintArrayAttr:$operand_constraints);
+
+    let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      MutableOperandRange getDpsInitsMutable() { return getOutputMutable(); }
+    }];
+
+    let hasVerifier = 1;
+}
+
 // ANCHOR: adding_an_op_matmul_ttir
 def TTIR_MatmulOp : TTIR_DPSOp<"matmul"> {
     let summary = "Matrix multiply operation.";

--- a/test/ttmlir/Dialect/TTNN/simple_squeeze.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_squeeze.mlir
@@ -1,0 +1,10 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s| FileCheck %s
+#any_device_tile = #tt.operand_constraint<dram|l1|tile|any_device_tile>
+module attributes {} {
+  func.func @forward(%arg0: tensor<1x2x1x32x32xbf16>) -> tensor<1x2x32x32xbf16> {
+    %0 = tensor.empty() : tensor<1x2x32x32xbf16>
+    // CHECK: %[[C:.*]] = "ttnn.reshape"[[C:.*]]
+    %1 = "ttir.squeeze"(%arg0, %0) <{dim = 2 : si32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<1x2x1x32x32xbf16>, tensor<1x2x32x32xbf16>) -> tensor<1x2x32x32xbf16>
+    return %1 : tensor<1x2x32x32xbf16>
+  }
+}


### PR DESCRIPTION
`squeeze` is implemented through `reshape`

Validate checks:
* that `dim` is valid int in range `[0, inputType.getRank() - 1]`
* that the dimension `dim` is `1` in the input tensor
* that the output tensor has at least one dimension
* that the rank of the output tensor is one less than the input tensor
* that the dimensions of the output tensor are the same as the input tensor except for dimension `dim`