### PR TITLE
Adding `unsqueeze`  op

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -428,6 +428,26 @@ def TTIR_SqueezeOp : TTIR_DPSOp<"squeeze"> {
     let hasVerifier = 1;
 }
 
+def TTIR_UnsqueezeOp : TTIR_DPSOp<"unsqueeze"> {
+    let summary = "Unsqueeze op.";
+    let description = [{
+      Unsqueeze tensor.
+    }];
+
+    let arguments = (ins AnyRankedTensor:$input,
+                         AnyRankedTensor:$output,
+                         SI32Attr:$dim,
+                         TT_OperandConstraintArrayAttr:$operand_constraints);
+
+    let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      MutableOperandRange getDpsInitsMutable() { return getOutputMutable(); }
+    }];
+
+    let hasVerifier = 1;
+}
+
 // ANCHOR: adding_an_op_matmul_ttir
 def TTIR_MatmulOp : TTIR_DPSOp<"matmul"> {
     let summary = "Matrix multiply operation.";

--- a/test/ttmlir/Dialect/TTNN/simple_unsqueeze.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_unsqueeze.mlir
@@ -1,0 +1,10 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s| FileCheck %s
+#any_device_tile = #tt.operand_constraint<dram|l1|tile|any_device_tile>
+module attributes {} {
+  func.func @forward(%arg0: tensor<4x2x32x32xbf16>) -> tensor<4x1x2x32x32xbf16> {
+    %0 = tensor.empty() : tensor<4x1x2x32x32xbf16>
+    // CHECK: %[[C:.*]] = "ttnn.reshape"[[C:.*]]
+    %1 = "ttir.unsqueeze"(%arg0, %0) <{dim = -4 : si32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<4x2x32x32xbf16>, tensor<4x1x2x32x32xbf16>) -> tensor<4x1x2x32x32xbf16>
+    return %1 : tensor<4x1x2x32x32xbf16>
+  }
+}


### PR DESCRIPTION
Adding `unsqueeze` through `reshape`

Verifications checks:
* that `dim` is valid int in range `[0, inputType.getRank()]`
* that the dimension `dim` is `1` in the output tensor
* that the rank of the input tensor is one less than the output tensor
* that the dimensions of the output tensor are the same as the input tensor except for dimension `dim`

closes #490 