### PR TITLE
Adding negative dim support for `squeeze`

### DIFF
--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -200,6 +200,10 @@ public:
     // Get the squeeze dimension
     int32_t dim = adaptor.getDim();
 
+    if (dim < 0) {
+      dim += inputType.getRank();
+    }
+
     // Get the shape of the input tensor
     auto inputShape = inputType.getShape();
     llvm::SmallVector<int32_t, 4> newShape;

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -267,6 +267,10 @@ void mlir::tt::ttir::MultiplyOp::buildGenericRegion(
   ::mlir::RankedTensorType outputType = getOutput().getType();
   int32_t dim = getDim();
 
+  if (dim < 0) {
+    dim += inputType.getRank();
+  }
+
   // Check that the dimension `dim` is valid.
   if (dim < 0 || dim >= inputType.getRank()) {
     return emitOpError() << "Invalid dimension " << dim << " for squeezing.";

--- a/test/ttmlir/Dialect/TTNN/simple_squeeze.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_squeeze.mlir
@@ -4,7 +4,7 @@ module attributes {} {
   func.func @forward(%arg0: tensor<1x2x1x32x32xbf16>) -> tensor<1x2x32x32xbf16> {
     %0 = tensor.empty() : tensor<1x2x32x32xbf16>
     // CHECK: %[[C:.*]] = "ttnn.reshape"[[C:.*]]
-    %1 = "ttir.squeeze"(%arg0, %0) <{dim = 2 : si32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<1x2x1x32x32xbf16>, tensor<1x2x32x32xbf16>) -> tensor<1x2x32x32xbf16>
+    %1 = "ttir.squeeze"(%arg0, %0) <{dim = -3 : si32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<1x2x1x32x32xbf16>, tensor<1x2x32x32xbf16>) -> tensor<1x2x32x32xbf16>
     return %1 : tensor<1x2x32x32xbf16>
   }
 }


### PR DESCRIPTION
Adding negative dim support for `squeeze`

For `unsqueeze` this is already added as part of #544 

closes #550 