### PR TITLE
#563: Enable mixed ttnn and ttm runtime in ttrt

### DIFF
--- a/runtime/tools/python/CMakeLists.txt
+++ b/runtime/tools/python/CMakeLists.txt
@@ -4,7 +4,7 @@ add_custom_target(ttrt-copy-files
 )
 
 add_custom_target(ttrt
-  COMMAND rm -f *.whl
+  COMMAND rm -f build/*.whl
   COMMAND TTMLIR_ENABLE_RUNTIME=${TTMLIR_ENABLE_RUNTIME}
           TT_RUNTIME_ENABLE_TTNN=${TT_RUNTIME_ENABLE_TTNN}
           TT_RUNTIME_ENABLE_TTMETAL=${TT_RUNTIME_ENABLE_TTMETAL}


### PR DESCRIPTION
Before: Registering an atexit close device function on program termination
Now: try finally block to always close device after ttnn binaries are executed and ttmetal. Takes care of exceptions/unexpected situations