### PR TITLE
Fixing logic for biasType retrieval in the event there is no bias input

### DIFF
--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -390,8 +390,9 @@ void mlir::tt::ttir::MultiplyOp::buildGenericRegion(
 ::mlir::LogicalResult mlir::tt::ttir::Conv2dOp::verify() {
   ::mlir::RankedTensorType inputType = getInput().getType();
   ::mlir::RankedTensorType weightType = getWeight().getType();
-  ::mlir::RankedTensorType biasType =
-      getBias().getImpl() ? getBias().getType() : nullptr;
+  std::optional<::mlir::RankedTensorType> biasType =
+      getBias().getImpl() ? std::make_optional(getBias().getType())
+                          : std::nullopt;
 
   if (inputType.getRank() < 3) {
     return emitOpError("Input must be at least a 3D tensor");
@@ -399,8 +400,8 @@ void mlir::tt::ttir::MultiplyOp::buildGenericRegion(
   if (weightType.getRank() != 4) {
     return emitOpError("Weight must be a 4D tensor");
   }
-  if (biasType) {
-    if (biasType.getRank() != 4) {
+  if (biasType.has_value()) {
+    if (biasType->getRank() != 4) {
       return emitOpError("Bias must be a 4D tensor");
     }
   }

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -391,7 +391,8 @@ void mlir::tt::ttir::MultiplyOp::buildGenericRegion(
   ::mlir::RankedTensorType inputType = getInput().getType();
   ::mlir::RankedTensorType weightType = getWeight().getType();
   ::mlir::RankedTensorType biasType =
-      llvm::dyn_cast_or_null<::mlir::RankedTensorType>(getBias().getType());
+      getBias().getImpl() ? getBias().getType() : nullptr;
+
   if (inputType.getRank() < 3) {
     return emitOpError("Input must be at least a 3D tensor");
   }

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -8,6 +8,7 @@
 #include "ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNN.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsTypes.h"
+#include <optional>
 
 #define GET_OP_CLASSES
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.cpp.inc"
@@ -251,8 +252,9 @@ namespace mlir::tt::ttnn {
 ::mlir::LogicalResult mlir::tt::ttnn::Conv2dOp::verify() {
   ::mlir::RankedTensorType inputType = getInput().getType();
   ::mlir::RankedTensorType weightType = getWeight().getType();
-  ::mlir::RankedTensorType biasType =
-      getBias().getImpl() ? getBias().getType() : nullptr;
+  std::optional<::mlir::RankedTensorType> biasType =
+      getBias().getImpl() ? std::make_optional(getBias().getType())
+                          : std::nullopt;
 
   if (inputType.getRank() < 3) {
     return emitOpError("Input must be at least a 3D tensor");
@@ -260,11 +262,11 @@ namespace mlir::tt::ttnn {
   if (weightType.getRank() != 4) {
     return emitOpError("Weight must be a 4D tensor");
   }
-  if (biasType) {
-    if (biasType.getRank() != 4) {
+  if (biasType.has_value()) {
+    if (biasType->getRank() != 4) {
       return emitOpError("Bias must be a 4D tensor");
     }
-    auto biasShape = biasType.getShape();
+    auto biasShape = biasType->getShape();
     if (biasShape[0] != 1 || biasShape[1] != 1 || biasShape[2] != 1) {
       return emitOpError("Bias must only have data on the final dimenstion");
     }

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -252,7 +252,7 @@ namespace mlir::tt::ttnn {
   ::mlir::RankedTensorType inputType = getInput().getType();
   ::mlir::RankedTensorType weightType = getWeight().getType();
   ::mlir::RankedTensorType biasType =
-      llvm::dyn_cast_or_null<::mlir::RankedTensorType>(getBias().getType());
+      getBias().getImpl() ? getBias().getType() : nullptr;
 
   if (inputType.getRank() < 3) {
     return emitOpError("Input must be at least a 3D tensor");


### PR DESCRIPTION
The original method of retrieving the bias:
```
llvm::dyn_cast_or_null<::mlir::RankedTensorType>(getBias().getType());
```
resulted in a segmentation fault because `getBias()` itself would return an incomplete object. Thus, `getBias().getType()` would attempt to dereference a `nullptr` at some point.