### PR TITLE
Multi stage docker build

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -3,8 +3,6 @@ SHELL ["/bin/bash", "-c"]
 
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
-ENV TTMLIR_TOOLCHAIN_DIR=/opt/ttmlir-toolchain
-ARG GIT_SHA
 
 # Install dependencies
 RUN apt-get update && apt-get install -y \
@@ -53,41 +51,3 @@ RUN git clone https://github.com/google/googletest.git -b release-1.12.1 && \
     make install && \
     cd ../.. && \
     rm -rf googletest
-
-# Create a directory for the build and toolchain
-ARG BUILD_DIR=/home/build
-RUN mkdir -p $BUILD_DIR && \
-    mkdir -p $TTMLIR_TOOLCHAIN_DIR
-
-# Clone the project and update submodules
-RUN git clone https://github.com/tenstorrent/tt-mlir.git $BUILD_DIR/tt-mlir && \
-    cd $BUILD_DIR/tt-mlir && \
-    git checkout $GIT_SHA && \
-    git submodule update --init --recursive -f
-
-# Build the toolchain
-WORKDIR $BUILD_DIR/tt-mlir
-RUN cmake -B env/build env && \
-    cmake --build env/build
-
-# Build project to test the container
-RUN source env/activate && \
-    cmake -G Ninja \
-    -B build \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_C_COMPILER=clang \
-    -DCMAKE_CXX_COMPILER=clang++ \
-    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-    -DTTMLIR_ENABLE_RUNTIME=ON \
-    -DTTMLIR_ENABLE_RUNTIME_TESTS=ON \
-    -DTTMLIR_ENABLE_STABLEHLO=ON && \
-    cmake --build build --config Release
-
-# Run clang-tidy
-RUN cmake --build build -- clang-tidy || true
-
-# Run the tests
-RUN cmake --build build -- check-ttmlir || true
-
-# Clean up the build directory
-RUN rm -rf $BUILD_DIR/tt-mlir

--- a/.github/Dockerfile.ci
+++ b/.github/Dockerfile.ci
@@ -1,0 +1,48 @@
+ARG GIT_SHA
+ARG FROM_TAG=${GIT_SHA:-latest}
+
+FROM ghcr.io/tenstorrent/tt-mlir/tt-mlir-base-ubuntu-22-04:${FROM_TAG}
+SHELL ["/bin/bash", "-c"]
+
+# Create a directory for the build and toolchain
+ARG BUILD_DIR=/home/build
+ENV TTMLIR_TOOLCHAIN_DIR=/opt/ttmlir-toolchain
+RUN mkdir -p $BUILD_DIR && \
+    mkdir -p $TTMLIR_TOOLCHAIN_DIR
+
+# Clone the project and update submodules
+RUN git clone https://github.com/tenstorrent/tt-mlir.git $BUILD_DIR/tt-mlir && \
+    cd $BUILD_DIR/tt-mlir && \
+    git checkout $GIT_SHA
+
+# Build the toolchain
+WORKDIR $BUILD_DIR/tt-mlir
+RUN cmake -B env/build env && \
+    cmake --build env/build
+
+# Self-test
+
+# Build project to test the container
+RUN source env/activate && \
+    cmake -G Ninja \
+    -B build \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER=clang++ \
+    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+    -DTTMLIR_ENABLE_RUNTIME=ON \
+    -DTTMLIR_ENABLE_RUNTIME_TESTS=ON \
+    -DTTMLIR_ENABLE_STABLEHLO=ON
+
+RUN cmake --build build --config Release
+
+RUN cmake --build build -- ttrt
+
+# Run clang-tidy
+RUN cmake --build build -- clang-tidy || true
+
+# Run the tests
+RUN cmake --build build -- check-ttmlir
+
+# Clean up the build directory
+RUN rm -rf $BUILD_DIR/tt-mlir

--- a/.github/Dockerfile.ci
+++ b/.github/Dockerfile.ci
@@ -1,5 +1,6 @@
 ARG GIT_SHA
 ARG FROM_TAG=${GIT_SHA:-latest}
+ARG PROJECT_NAME=tt-mlir
 
 FROM ghcr.io/tenstorrent/tt-mlir/tt-mlir-base-ubuntu-22-04:${FROM_TAG}
 SHELL ["/bin/bash", "-c"]
@@ -11,12 +12,12 @@ RUN mkdir -p $BUILD_DIR && \
     mkdir -p $TTMLIR_TOOLCHAIN_DIR
 
 # Clone the project and update submodules
-RUN git clone https://github.com/tenstorrent/tt-mlir.git $BUILD_DIR/tt-mlir && \
-    cd $BUILD_DIR/tt-mlir && \
+RUN git clone https://github.com/tenstorrent/$PROJECT_NAME.git $BUILD_DIR/$PROJECT_NAME && \
+    cd $BUILD_DIR/$PROJECT_NAME && \
     git checkout $GIT_SHA
 
 # Build the toolchain
-WORKDIR $BUILD_DIR/tt-mlir
+WORKDIR $BUILD_DIR/$PROJECT_NAME
 RUN cmake -B env/build env && \
     cmake --build env/build
 
@@ -45,4 +46,4 @@ RUN cmake --build build -- clang-tidy || true
 RUN cmake --build build -- check-ttmlir
 
 # Clean up the build directory
-RUN rm -rf $BUILD_DIR/tt-mlir
+RUN rm -rf $BUILD_DIR/$PROJECT_NAME

--- a/.github/Dockerfile.ci
+++ b/.github/Dockerfile.ci
@@ -1,12 +1,12 @@
 ARG GIT_SHA
 ARG FROM_TAG=${GIT_SHA:-latest}
-ARG PROJECT_NAME=tt-mlir
+ENV PROJECT_NAME=tt-mlir
 
 FROM ghcr.io/tenstorrent/tt-mlir/tt-mlir-base-ubuntu-22-04:${FROM_TAG}
 SHELL ["/bin/bash", "-c"]
 
 # Create a directory for the build and toolchain
-ARG BUILD_DIR=/home/build
+ENV BUILD_DIR=/home/build
 ENV TTMLIR_TOOLCHAIN_DIR=/opt/ttmlir-toolchain
 RUN mkdir -p $BUILD_DIR && \
     mkdir -p $TTMLIR_TOOLCHAIN_DIR

--- a/.github/Dockerfile.ci
+++ b/.github/Dockerfile.ci
@@ -35,15 +35,19 @@ RUN source env/activate && \
     -DTTMLIR_ENABLE_RUNTIME_TESTS=ON \
     -DTTMLIR_ENABLE_STABLEHLO=ON
 
-RUN cmake --build build --config Release
+RUN source env/activate && \
+    cmake --build build --config Release
 
-RUN cmake --build build -- ttrt
+RUN source env/activate && \
+    cmake --build build -- ttrt
 
 # Run clang-tidy
-RUN cmake --build build -- clang-tidy || true
+RUN source env/activate && \
+    cmake --build build -- clang-tidy || true
 
 # Run the tests
-RUN cmake --build build -- check-ttmlir
+RUN source env/activate && \
+    cmake --build build -- check-ttmlir
 
 # Clean up the build directory
 RUN rm -rf $BUILD_DIR/$PROJECT_NAME

--- a/.github/Dockerfile.ci
+++ b/.github/Dockerfile.ci
@@ -1,11 +1,11 @@
 ARG GIT_SHA
 ARG FROM_TAG=${GIT_SHA:-latest}
-ENV PROJECT_NAME=tt-mlir
 
 FROM ghcr.io/tenstorrent/tt-mlir/tt-mlir-base-ubuntu-22-04:${FROM_TAG}
 SHELL ["/bin/bash", "-c"]
 
 # Create a directory for the build and toolchain
+ENV PROJECT_NAME=tt-mlir
 ENV BUILD_DIR=/home/build
 ENV TTMLIR_TOOLCHAIN_DIR=/opt/ttmlir-toolchain
 RUN mkdir -p $BUILD_DIR && \

--- a/.github/Dockerfile.ird
+++ b/.github/Dockerfile.ird
@@ -21,13 +21,13 @@ RUN mkdir -p $TTMLIR_TOOLCHAIN_DIR && \
     chmod -R 777 $TTMLIR_TOOLCHAIN_DIR
 
 # Install GDB 14.2
-RUN sudo apt install libmpfr-dev -y
-    wget https://ftp.gnu.org/gnu/gdb/gdb-14.2.tar.gz
-    tar -xvf gdb-14.2.tar.gz
-    cd gdb-14.2
-    ./configure
-    make -j$(nproc)
-    sudo make install    
-    cd ..
-    rm -rf gdb-14.2 gdb-14.2.tar.gz
+RUN sudo apt install libmpfr-dev -y && \
+    wget https://ftp.gnu.org/gnu/gdb/gdb-14.2.tar.gz && \
+    tar -xvf gdb-14.2.tar.gz && \
+    cd gdb-14.2 && \
+    ./configure && \
+    make -j$(nproc) && \
+    sudo make install && \ 
+    cd ..  && \
+    rm -rf gdb-14.2 gdb-14.2.tar.gz  && \
     gdb --version

--- a/.github/Dockerfile.ird
+++ b/.github/Dockerfile.ird
@@ -13,6 +13,7 @@ ENV TTMLIR_TOOLCHAIN_DIR=/opt/ttmlir-toolchain
 RUN apt-get update && apt-get install -y \
     ssh \
     sudo \
+    wget \
     vim
 
 # Create a directory for the toolchain and set permissions
@@ -30,4 +31,3 @@ RUN sudo apt install libmpfr-dev -y
     cd ..
     rm -rf gdb-14.2 gdb-14.2.tar.gz
     gdb --version
-    

--- a/.github/Dockerfile.ird
+++ b/.github/Dockerfile.ird
@@ -15,5 +15,19 @@ RUN apt-get update && apt-get install -y \
     sudo \
     vim
 
+# Create a directory for the toolchain and set permissions
 RUN mkdir -p $TTMLIR_TOOLCHAIN_DIR && \
     chmod -R 777 $TTMLIR_TOOLCHAIN_DIR
+
+# Install GDB 14.2
+RUN sudo apt install libmpfr-dev -y
+    wget https://ftp.gnu.org/gnu/gdb/gdb-14.2.tar.gz
+    tar -xvf gdb-14.2.tar.gz
+    cd gdb-14.2
+    ./configure
+    make -j$(nproc)
+    sudo make install    
+    cd ..
+    rm -rf gdb-14.2 gdb-14.2.tar.gz
+    gdb --version
+    

--- a/.github/Dockerfile.ird
+++ b/.github/Dockerfile.ird
@@ -1,0 +1,19 @@
+ARG GIT_SHA
+ARG FROM_IMAGE=${GIT_SHA:-base}
+ARG FROM_TAG=${GIT_SHA:-latest}
+
+FROM ghcr.io/tenstorrent/tt-mlir/tt-mlir-${FROM_IMAGE}-ubuntu-22-04:${FROM_TAG}
+SHELL ["/bin/bash", "-c"]
+
+# Set environment variables
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TTMLIR_TOOLCHAIN_DIR=/opt/ttmlir-toolchain
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    ssh \
+    sudo \
+    vim
+
+RUN mkdir -p $TTMLIR_TOOLCHAIN_DIR && \
+    chmod -R 777 $TTMLIR_TOOLCHAIN_DIR

--- a/.github/Dockerfile.ird
+++ b/.github/Dockerfile.ird
@@ -27,7 +27,7 @@ RUN sudo apt install libmpfr-dev -y && \
     cd gdb-14.2 && \
     ./configure && \
     make -j$(nproc) && \
-    sudo make install && \ 
+    sudo make install && \
     cd ..  && \
     rm -rf gdb-14.2 gdb-14.2.tar.gz  && \
     gdb --version

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.build.runs-on }}
 
     container:
-      image: ghcr.io/${{ github.repository }}/tt-mlir-ubuntu-22-04:latest
+      image: ghcr.io/${{ github.repository }}/tt-mlir-ci-ubuntu-22-04:latest
       options: --user root
 
     steps:
@@ -111,7 +111,7 @@ jobs:
       - ${{ matrix.build.runs-on }}
 
     container:
-      image: ghcr.io/${{ github.repository }}/tt-mlir-ubuntu-22-04:latest
+      image: ghcr.io/${{ github.repository }}/tt-mlir-ci-ubuntu-22-04:latest
       options: --user root --device /dev/tenstorrent/0
       volumes:
         - /dev/hugepages:/dev/hugepages

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,9 @@ jobs:
           {runs-on: builder, enable_perf: ON, name: "perf"},
         ]
 
-    runs-on: ${{ matrix.build.runs-on }}
+    runs-on:
+      - in-service
+      - ${{ matrix.build.runs-on }}
 
     container:
       image: ghcr.io/${{ github.repository }}/tt-mlir-ci-ubuntu-22-04:latest
@@ -95,7 +97,7 @@ jobs:
         echo $version
 
   run-tests:
-  
+
     timeout-minutes: 30
     needs: build-ttmlir
     strategy:
@@ -109,7 +111,7 @@ jobs:
         ]
 
     runs-on:
-      - self-hosted
+      - in-service
       - ${{ matrix.build.runs-on }}
 
     container:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,9 +5,9 @@ on:
   workflow_call:
 
 jobs:
-
   build-ttmlir:
 
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -95,6 +95,8 @@ jobs:
         echo $version
 
   run-tests:
+  
+    timeout-minutes: 30
     needs: build-ttmlir
     strategy:
       fail-fast: false

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           context: .github
           file: .github/Dockerfile.base
+          push: true
           build-args: |
             GIT_SHA=${{ github.sha }}
           tags: |
@@ -53,6 +54,7 @@ jobs:
         with:
           context: .github
           file: .github/Dockerfile.ird
+          push: true
           build-args: |
             GIT_SHA=${{ github.sha }}
             FROM_IMAGE=base
@@ -64,6 +66,7 @@ jobs:
         with:
           context: .github
           file: .github/Dockerfile.ci
+          push: true
           build-args: |
             GIT_SHA=${{ github.sha }}
           tags: |
@@ -74,6 +77,7 @@ jobs:
         with:
           context: .github
           file: .github/Dockerfile.ird
+          push: true
           build-args: |
             GIT_SHA=${{ github.sha }}
             FROM_IMAGE=ci
@@ -87,6 +91,7 @@ jobs:
         with:
           context: .github
           file: .github/Dockerfile.base
+          push: true
           build-args: |
             GIT_SHA=${{ github.sha }}
           tags: |
@@ -97,6 +102,7 @@ jobs:
         with:
           context: .github
           file: .github/Dockerfile.ird
+          push: true
           build-args: |
             GIT_SHA=${{ github.sha }}
             FROM_IMAGE=base
@@ -108,6 +114,7 @@ jobs:
         with:
           context: .github
           file: .github/Dockerfile.ci
+          push: true
           build-args: |
             GIT_SHA=${{ github.sha }}
           tags: |
@@ -118,6 +125,7 @@ jobs:
         with:
           context: .github
           file: .github/Dockerfile.ird
+          push: true
           build-args: |
             GIT_SHA=${{ github.sha }}
             FROM_IMAGE=ci

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -54,7 +54,6 @@ jobs:
         with:
           context: .github
           file: .github/Dockerfile.ird
-          push: false
           build-args: |
             GIT_SHA=${{ github.sha }}
             FROM_IMAGE=base
@@ -66,7 +65,6 @@ jobs:
         with:
           context: .github
           file: .github/Dockerfile.ci
-          push: false
           build-args: |
             GIT_SHA=${{ github.sha }}
           tags: |
@@ -77,21 +75,19 @@ jobs:
         with:
           context: .github
           file: .github/Dockerfile.ird
-          push: false
           build-args: |
             GIT_SHA=${{ github.sha }}
             FROM_IMAGE=ci
           tags: |
             ${{ env.IRD_IMAGE_NAME}}:${{ github.sha }}
 
-      # Push images
+      # Tag images as latest
 
       - name: Build and push base Docker image
         uses: docker/build-push-action@v6
         with:
           context: .github
           file: .github/Dockerfile.base
-          push: true
           build-args: |
             GIT_SHA=${{ github.sha }}
           tags: |
@@ -102,7 +98,6 @@ jobs:
         with:
           context: .github
           file: .github/Dockerfile.ird
-          push: true
           build-args: |
             GIT_SHA=${{ github.sha }}
             FROM_IMAGE=base
@@ -114,7 +109,6 @@ jobs:
         with:
           context: .github
           file: .github/Dockerfile.ci
-          push: true
           build-args: |
             GIT_SHA=${{ github.sha }}
           tags: |
@@ -125,7 +119,6 @@ jobs:
         with:
           context: .github
           file: .github/Dockerfile.ird
-          push: true
           build-args: |
             GIT_SHA=${{ github.sha }}
             FROM_IMAGE=ci

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -21,6 +21,9 @@ jobs:
 
     steps:
 
+      - name: Fix permissions
+        run: sudo chmod 777 -R $GITHUB_WORKSPACE
+
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -3,7 +3,6 @@ name: Build and Publish Docker Image
 on:
   workflow_dispatch:
   workflow_call:
-  push:
 
 jobs:
   build:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -5,9 +5,9 @@ on:
   workflow_call:
   push:
 
-permissions:
-  contents: read
-  packages: write
+# permissions:
+#   contents: read
+#   packages: write
 
 jobs:
   build:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -3,10 +3,14 @@ name: Build and Publish Docker Image
 on:
   workflow_dispatch:
   workflow_call:
+  push:
 
 jobs:
   build:
-    runs-on: builder
+
+    runs-on:
+      - in-service
+      - builder
 
     env:
       BASE_IMAGE_NAME:      ghcr.io/${{ github.repository }}/tt-mlir-base-ubuntu-22-04
@@ -32,6 +36,56 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Build images
+
+      - name: Build and export base Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .github
+          file: .github/Dockerfile.base
+          push: false
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+          tags: |
+            ${{ env.BASE_IMAGE_NAME}}:${{ github.sha }}
+
+      - name: Build and export base IRD Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .github
+          file: .github/Dockerfile.ird
+          push: false
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+            FROM_IMAGE=base
+          tags: |
+            ${{ env.BASE_IRD_IMAGE_NAME}}:${{ github.sha }}
+
+      - name: Build and export CI Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .github
+          file: .github/Dockerfile.ci
+          push: false
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+          tags: |
+            ${{ env.CI_IMAGE_NAME}}:${{ github.sha }}
+
+      - name: Build and export IRD Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .github
+          file: .github/Dockerfile.ird
+          push: false
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+            FROM_IMAGE=ci
+          tags: |
+            ${{ env.IRD_IMAGE_NAME}}:${{ github.sha }}
+
+      # Push images
+
       - name: Build and push base Docker image
         uses: docker/build-push-action@v6
         with:
@@ -41,7 +95,6 @@ jobs:
           build-args: |
             GIT_SHA=${{ github.sha }}
           tags: |
-            ${{ env.BASE_IMAGE_NAME}}:${{ github.sha }}
             ${{ env.BASE_IMAGE_NAME}}:latest
 
       - name: Build and push base IRD Docker image
@@ -54,7 +107,6 @@ jobs:
             GIT_SHA=${{ github.sha }}
             FROM_IMAGE=base
           tags: |
-            ${{ env.BASE_IRD_IMAGE_NAME}}:${{ github.sha }}
             ${{ env.BASE_IRD_IMAGE_NAME}}:latest
 
       - name: Build and push CI Docker image
@@ -66,7 +118,6 @@ jobs:
           build-args: |
             GIT_SHA=${{ github.sha }}
           tags: |
-            ${{ env.CI_IMAGE_NAME}}:${{ github.sha }}
             ${{ env.CI_IMAGE_NAME}}:latest
 
       - name: Build and push IRD Docker image
@@ -79,5 +130,4 @@ jobs:
             GIT_SHA=${{ github.sha }}
             FROM_IMAGE=ci
           tags: |
-            ${{ env.IRD_IMAGE_NAME}}:${{ github.sha }}
             ${{ env.IRD_IMAGE_NAME}}:latest

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -43,7 +43,6 @@ jobs:
         with:
           context: .github
           file: .github/Dockerfile.base
-          push: false
           build-args: |
             GIT_SHA=${{ github.sha }}
           tags: |

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: builder
 
     env:
       BASE_IMAGE_NAME:      ghcr.io/${{ github.repository }}/tt-mlir-base-ubuntu-22-04

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -3,11 +3,6 @@ name: Build and Publish Docker Image
 on:
   workflow_dispatch:
   workflow_call:
-  push:
-
-# permissions:
-#   contents: read
-#   packages: write
 
 jobs:
   build:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -3,12 +3,26 @@ name: Build and Publish Docker Image
 on:
   workflow_dispatch:
   workflow_call:
+  push:
+
+permissions:
+  contents: read
+  packages: write
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
+
+    env:
+      BASE_IMAGE_NAME:      ghcr.io/${{ github.repository }}/tt-mlir-base-ubuntu-22-04
+      CI_IMAGE_NAME:        ghcr.io/${{ github.repository }}/tt-mlir-ci-ubuntu-22-04
+      BASE_IRD_IMAGE_NAME:  ghcr.io/${{ github.repository }}/tt-mlir-base-ird-ubuntu-22-04
+      IRD_IMAGE_NAME:       ghcr.io/${{ github.repository }}/tt-mlir-ird-ubuntu-22-04
 
     steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -20,14 +34,52 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image
+      - name: Build and push base Docker image
         uses: docker/build-push-action@v6
         with:
           context: .github
-          file: .github/Dockerfile
+          file: .github/Dockerfile.base
           push: true
           build-args: |
             GIT_SHA=${{ github.sha }}
           tags: |
-            ghcr.io/${{ github.repository }}/tt-mlir-ubuntu-22-04:${{ github.sha }}
-            ghcr.io/${{ github.repository }}/tt-mlir-ubuntu-22-04:latest
+            ${{ env.BASE_IMAGE_NAME}}:${{ github.sha }}
+            ${{ env.BASE_IMAGE_NAME}}:latest
+
+      - name: Build and push base IRD Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .github
+          file: .github/Dockerfile.ird
+          push: true
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+            FROM_IMAGE=base
+          tags: |
+            ${{ env.BASE_IRD_IMAGE_NAME}}:${{ github.sha }}
+            ${{ env.BASE_IRD_IMAGE_NAME}}:latest
+
+      - name: Build and push CI Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .github
+          file: .github/Dockerfile.ci
+          push: true
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+          tags: |
+            ${{ env.CI_IMAGE_NAME}}:${{ github.sha }}
+            ${{ env.CI_IMAGE_NAME}}:latest
+
+      - name: Build and push IRD Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .github
+          file: .github/Dockerfile.ird
+          push: true
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+            FROM_IMAGE=ci
+          tags: |
+            ${{ env.IRD_IMAGE_NAME}}:${{ github.sha }}
+            ${{ env.IRD_IMAGE_NAME}}:latest

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -16,7 +16,9 @@ jobs:
           {runs-on: builder, build_type: Release, enable_runtime: ON}
         ]
 
-    runs-on: ${{ matrix.build.runs-on }}
+    runs-on:
+      - in-service
+      - ${{ matrix.build.runs-on }}
 
     container:
       image: ghcr.io/${{ github.repository }}/tt-mlir-ci-${{ matrix.image }}:latest

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.build.runs-on }}
 
     container:
-      image: ghcr.io/${{ github.repository }}/tt-mlir-${{ matrix.image }}:latest
+      image: ghcr.io/${{ github.repository }}/tt-mlir-ci-${{ matrix.image }}:latest
       options: --user root
 
     steps:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -7,13 +7,12 @@ on:
 jobs:
 
   build-and-test:
-
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         image: ["ubuntu-22-04"]
         build: [
-          {runs-on: ubuntu-latest, build_type: Release, enable_runtime: OFF},
           {runs-on: builder, build_type: Release, enable_runtime: ON}
         ]
 

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -2,8 +2,8 @@ name: On PR
 
 on:
   workflow_dispatch:
-  # pull_request:
-  #   branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
 
 jobs:
   pre-commit:

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -2,8 +2,8 @@ name: On PR
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches: [ "main" ]
+  # pull_request:
+  #   branches: [ "main" ]
 
 jobs:
   pre-commit:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,6 +17,8 @@ concurrency:
 
 jobs:
   build:
+
+    timeout-minutes: 30
     runs-on: macos-latest
     env:
       MDBOOK_VERSION: 0.4.36

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,8 +6,9 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: macos-latest
 
+    timeout-minutes: 10
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/spdx.yml
+++ b/.github/workflows/spdx.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   check-spdx-headers:
+
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
     - name: checkout

--- a/docs/src/internal-build.md
+++ b/docs/src/internal-build.md
@@ -15,45 +15,32 @@ Components:
   - Workflow for building Docker image
   - Project build using Docker image
 
-Overview:
+### Overview
 
-The [Dockerfile](.github/Dockerfile) describes how to create an image for building the tt-mlir project file. It starts with a supported base image (Ubuntu 22.04) and installs the necessary packages. The purpose of the Docker build is to:
+We use docker images to prepare project enviroment, install dependancies, tooling and prebuild toolchain.
+Project builds four docker images:
 
-  - Set up build dependencies
-  - Prepare the tt-mlir toolchain
+Base image `tt-mlir-base-ubuntu-22-04` [Dockerfile.base](.github/Dockerfile.base)
+CI image `tt-mlir-ci-ubuntu-22-04` [Dockerfile.ci](.github/Dockerfile.ci)
+Base IRD image `tt-mlir-base-ird-ubuntu-22-04`[Dockerfile.ird](.github/Dockerfile.ird)
+IRD image `tt-mlir-ird-ubuntu-22-04` [Dockerfile.ird](.github/Dockerfile.ird)
 
-During the Docker build, the project is built and tests are run to ensure that everything is set up correctly. If any dependencies are missing, the Docker build will fail.
+Base image starts with a supported base image (Ubuntu 22.04) and installs dependancies for project build. From there we build CI image that contains prebuild toolcahin and is used in CI to shoten the build time. IRD image contain dev tools like GDB, vim etc and shh and are use in IRD enviroments.
 
-This process also prepopulates caches for Python packages and the ccache cache in the image, which should make subsequent builds faster.
+During the CI Docker build, the project is built and tests are run to ensure that everything is set up correctly. If any dependencies are missing, the Docker build will fail.
 
 ### Building the Docker Image using GitHub Actions
 
-The GitHub Actions workflow [Build and Publish Docker Image](.github/workflows/build-image.yml) builds the Docker image and uploads it to GitHub Packages at https://github.com/orgs/tenstorrent/packages?repo_name=tt-mlir. The image name is tt-mlir-ubuntu-22-04, and we use the git SHA we build from as the tag.
+The GitHub Actions workflow [Build and Publish Docker Image](.github/workflows/build-image.yml) builds the Docker images and uploads them to GitHub Packages at https://github.com/orgs/tenstorrent/packages?repo_name=tt-mlir. We use the git SHA we build from as the tag.
 
 ### Building the Docker Image Locally
 
 To test the changes and build the image locally, use the following command:
 ```bash
-docker build -f .github/Dockerfile -t tt-mlir-ubuntu-22-04:latest .
-```
-
-### Pushing the Docker Image to GitHub
-
-Images built locally can be pushed to GitHub. First, we need to generate a PAT token with the "write:packages" access enabled. Go to GitHub -> Settings -> Developer settings -> Personal access tokens -> Generate new token.
-
-Authenticate with GitHub Container Registry:
-```bash
-echo "<my-github-pat>" | docker login ghcr.io -u <username> --password-stdin
-```
-
-Add a tag to the built image:
-```bash
-docker tag tt-mlir-ubuntu-22-04:latest ghcr.io/tenstorrent/tt-mlir/tt-mlir-ubuntu-22-04:latest
-```
-
-Push the image:
-```bash
-docker push ghcr.io/tenstorrent/tt-mlir/tt-mlir-ubuntu-22-04:latest
+docker build -f .github/Dockerfile.base -t ghcr.io/tenstorrent/tt-mlir/tt-mlir-base-ubuntu-22-04:latest .
+docker build -f .github/Dockerfile.ci -t ghcr.io/tenstorrent/tt-mlir/tt-mlir-ci-ubuntu-22-04:latest .
+docker build -f .github/Dockerfile.ird -build-args FROM_IMAGE=base -t ghcr.io/tenstorrent/tt-mlir/tt-mlir-ird-base-ubuntu-22-04:latest .
+docker build -f .github/Dockerfile.ird -build-args FROM_IMAGE=ci -t ghcr.io/tenstorrent/tt-mlir/tt-mlir-ird-ubuntu-22-04:latest .
 ```
 
 ### Using the Image in GitHub Actions Jobs
@@ -61,6 +48,6 @@ docker push ghcr.io/tenstorrent/tt-mlir/tt-mlir-ubuntu-22-04:latest
 The GitHub Actions workflow [Build in Docker](.github/workflows/docker-build.yml) uses a Docker container for building:
 ```yaml
     container:
-      image: ghcr.io/${{ github.repository }}/tt-mlir-ubuntu-22-04:latest
+      image: ghcr.io/${{ github.repository }}/tt-mlir-ci-ubuntu-22-04:latest
       options: --user root
 ```


### PR DESCRIPTION
Split docker image builds into steps, so now we have base image containing only build dependencies, ci image that contains prebuilt toolchain and ird image that add dev tools and ssh to these images. Also adds GDB 14.2 to IRD images.

- added GDB 14.2 to IRD images
- replace image in workflows with new ci image
- update docs
- set job timeout to 30 minutes
- add "in-service" to runner selection

Closes: #481 
Closes: #593 