### PR TITLE
Added ttnn_to_flatbuffer_file to directly dump module to file

### DIFF
--- a/python/Passes.cpp
+++ b/python/Passes.cpp
@@ -61,6 +61,25 @@ void populatePassesModule(py::module &m) {
       delete bin;
     });
   });
+
+  m.def("ttnn_to_flatbuffer_file",
+        [](MlirModule module, std::string &filepath) {
+          mlir::Operation *moduleOp = unwrap(mlirModuleGetOperation(module));
+
+          std::error_code fileError;
+          llvm::raw_fd_ostream file(filepath, fileError);
+
+          if (fileError) {
+            throw std::runtime_error("Failed to open file: " + filepath +
+                                     ". Error: " + fileError.message());
+          }
+
+          if (mlir::failed(
+                  mlir::tt::ttnn::translateTTNNToFlatbuffer(moduleOp, file))) {
+            throw std::runtime_error("Failed to write flatbuffer to file: " +
+                                     filepath);
+          }
+        });
 }
 
 } // namespace mlir::ttmlir::python

--- a/runtime/tools/python/ttrt/binary/module.cpp
+++ b/runtime/tools/python/ttrt/binary/module.cpp
@@ -41,8 +41,9 @@ PYBIND11_MODULE(_C, m) {
   m.def("load_binary_from_capsule", [](py::capsule capsule) {
     std::shared_ptr<void> *binary =
         static_cast<std::shared_ptr<void> *>(capsule.get_pointer());
-    return tt::runtime::Flatbuffer(
-        *binary); // Dereference capsule, and then dereference shared_ptr*
+    return tt::runtime::Binary(
+        tt::runtime::Flatbuffer(*binary)
+            .handle); // Dereference capsule, and then dereference shared_ptr*
   });
   m.def("load_system_desc_from_path", &tt::runtime::SystemDesc::loadFromPath);
 }


### PR DESCRIPTION
Closes #610 

**Implemented**
- Added `ttnn_to_flatbuffer_file` to pybind `ttmlir.passes` module.
- Simple bugfix for loading capsules into TTRT (Carried over from 1-line hotfix).