### PR TITLE
Fixup tensor size bytes for allocator

### DIFF
--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -289,7 +289,8 @@ def TT_LayoutAttr : TT_Attr<"Layout", "layout"> {
       uint64_t getElementSizeBytes() const;
       llvm::SmallVector<int64_t> getStride(ArrayRef<int64_t> logicalShape) const;
       llvm::SmallVector<int64_t> getPhysicalShape(ArrayRef<int64_t> logicalShape) const;
-      llvm::SmallVector<int64_t> getShardShape() const;
+      llvm::SmallVector<int64_t> getShardShape(bool convertTileToScalar = true) const;
+      AffineMap replaceMemoryMapSymbolsWithShardShape(AffineMap physicalMemoryMap) const;
       AffineMap projectOnto(AffineMap linearMap, AffineMap physicalMemoryMap, ArrayRef<int64_t> logicalTensorShape) const;
       AffineMap getIdentityTileLinearMap() const;
       llvm::SmallVector<int64_t> getTiledShape(ArrayRef<int64_t> logicalTensorShape) const;
@@ -348,6 +349,17 @@ def TT_DeviceAttr : TT_Attr<"Device", "device", []> {
           llvm_unreachable("Unsupported memory space");
         }
       }
+
+      // Returns the footprint size in bytes of the tensor layout distributed across the given memory space.
+      // The resulting size is a function of the memory space, roughly speaking this ends up being:
+      // - DeviceL1: This ends up being exactly the shard size
+      // - DeviceDRAM: Is more nuanced because the whole tensor size gets paged and interleaved between all dram channels,
+      //   due to paging and rounding the footprint ends up being close to: the_whole_tensor / num_dram_channels
+      uint64_t getLayoutSizeBytes(ArrayRef<int64_t> tensorShape, LayoutAttr layout, MemorySpace memorySpace) const;
+
+      // Returns the footprint size in bytes of the tensor distributed across the given memory space.
+      // Forwards to getLayoutSizeBytes, see comment there for more info.
+      uint64_t getTensorSizeBytes(RankedTensorType tensorType, MemorySpace memorySpace) const;
   }];
 
   let genVerifyDecl = 1;

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -68,9 +68,16 @@ def TTIRSplitCompoundLayout: Pass<"ttir-split-compound-layout", "::mlir::ModuleO
 }
 
 def TTIRAllocate: Pass<"ttir-allocate", "::mlir::ModuleOp"> {
-  let summary = "Allocate tensors.";
+  let summary = "Insert allocate/deallocate ops for tensors.";
   let description = [{
-    todo
+    This pass walks through the graph and does the following:
+      - Replaces tensor empty ops with allocate ops.
+      - Inserts deallocate ops after a tensor value's last use.
+      - Allocates storage for graph inputs.
+
+    Currently the allocator is built into the pass itself, but in the future
+    this should be replaced with an analysis pass that can make global allocation
+    decisions, followed by this pass that mechanically applies those decisions.
   }];
 }
 

--- a/include/ttmlir/Utils.h
+++ b/include/ttmlir/Utils.h
@@ -52,7 +52,8 @@ llvm::SmallVector<int64_t> evalShape(mlir::AffineMap map, Vector shape) {
   return result;
 }
 
-template <typename Enum> std::underlying_type_t<Enum> enum_as_int(Enum e) {
+template <typename Enum>
+constexpr std::underlying_type_t<Enum> enum_as_int(Enum e) {
   return static_cast<std::underlying_type_t<Enum>>(e);
 }
 } // namespace ttmlir::utils


### PR DESCRIPTION
This change fixes a few bugs and makes a few cleanups to do with memory map and allocation:

- Create utility function replaceMemoryMapSymbolsWithShardShape instead of just being inline with projectOnto.  Size estimation needs this too.
- Fix bug in dram memory map which had one of the address calculation dims flipped.
- Create convenience function getTensorSizeBytes to calculate the memory footprint of the tensor depending on memory space.
- Fixup the allocator to use this new function getTensorSizeBytes instead of doing a simple shard calc.

Closes #613