### PR TITLE
Cut down on CI build artifacts

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -190,6 +190,7 @@ jobs:
       shell: bash
       run: |
         source env/activate
+        export LD_LIBRARY_PATH="${TTMLIR_TOOLCHAIN_DIR}/lib:${LD_LIBRARY_PATH}"
         export SYSTEM_DESC_PATH="${GITHUB_WORKSPACE}/ttrt-artifacts/system_desc.ttsys"
         ln -sf ${{ steps.strings.outputs.install-output-dir }} ${{ steps.strings.outputs.build-output-dir }}
         llvm-lit -sv ${{ steps.strings.outputs.build-output-dir }}/test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-ttmlir:
 
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -35,6 +35,7 @@ jobs:
       run: |
         echo "work-dir=$(pwd)" >> "$GITHUB_OUTPUT"
         echo "build-output-dir=$(pwd)/build" >> "$GITHUB_OUTPUT"
+        echo "install-output-dir=$(pwd)/install" >> "$GITHUB_OUTPUT"
 
     - name: Git safe dir
       run: git config --global --add safe.directory ${{ steps.strings.outputs.work-dir }}
@@ -54,6 +55,7 @@ jobs:
         -DCMAKE_CXX_COMPILER=clang++-17 \
         -DCMAKE_C_COMPILER=clang-17 \
         -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=${{ steps.strings.outputs.install-output-dir }} \
         -DTTMLIR_ENABLE_RUNTIME=ON \
         -DTTMLIR_ENABLE_RUNTIME_TESTS=ON \
         -DTT_RUNTIME_ENABLE_PERF_TRACE=${{ matrix.build.enable_perf }} \
@@ -65,6 +67,7 @@ jobs:
       run: |
         source env/activate
         cmake --build ${{ steps.strings.outputs.build-output-dir }}
+        cmake --install ${{ steps.strings.outputs.build-output-dir }} --component Test
 
     - name: Build ttrt
       shell: bash
@@ -78,11 +81,16 @@ jobs:
         name: ttrt-whl-${{ matrix.build.name }}
         path: build/runtime/tools/python/build/ttrt*.whl
 
-    - name: Upload build folder to archive
+    # This is needed to preserve file permissions
+    # https://github.com/actions/upload-artifact?tab=readme-ov-file#permission-loss
+    - name: 'Tar install directory'
+      run: tar cvf ${{ steps.strings.outputs.install-output-dir }}.tar -C ${{ steps.strings.outputs.install-output-dir }} .
+
+    - name: Upload install folder to archive
       uses: actions/upload-artifact@v4
       with:
-        name: build-artifacts-${{ matrix.build.name }}
-        path: build
+        name: install-artifacts-${{ matrix.build.name }}
+        path: ${{ steps.strings.outputs.install-output-dir }}.tar
 
     - name: Get the latest tag
       shell: bash
@@ -135,6 +143,7 @@ jobs:
       run: |
         echo "work-dir=$(pwd)" >> "$GITHUB_OUTPUT"
         echo "build-output-dir=$(pwd)/build" >> "$GITHUB_OUTPUT"
+        echo "install-output-dir=$(pwd)/install" >> "$GITHUB_OUTPUT"
 
     - name: Git safe dir
       run: git config --global --add safe.directory ${{ steps.strings.outputs.work-dir }}
@@ -142,22 +151,14 @@ jobs:
     - name: Use build artifacts
       uses: actions/download-artifact@v4
       with:
-        name: build-artifacts-${{ matrix.build.name }}
-        path: build
+        name: install-artifacts-${{ matrix.build.name }}
+        path: ${{ steps.strings.outputs.install-output-dir }}
 
-    - name: Config compiler
+    # This is needed to preserve file permissions
+    # https://github.com/actions/upload-artifact?tab=readme-ov-file#permission-loss
+    - name: 'Untar install directory'
       shell: bash
-      run: |
-        source env/activate
-        cmake -G Ninja \
-        -B build \
-        -DCMAKE_CXX_COMPILER=clang++-17 \
-        -DCMAKE_C_COMPILER=clang-17 \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DTTMLIR_ENABLE_RUNTIME=ON \
-        -DTTMLIR_ENABLE_RUNTIME_TESTS=ON \
-        -DTT_RUNTIME_ENABLE_PERF_TRACE=${{ matrix.build.enable_perf }} \
-        -DTTMLIR_ENABLE_STABLEHLO=ON \
+      run: tar xvf install.tar -C ${{ steps.strings.outputs.install-output-dir }}
 
     - name: Remove existing whls files
       shell: bash
@@ -187,10 +188,11 @@ jobs:
       run: |
         source env/activate
         export SYSTEM_DESC_PATH="${GITHUB_WORKSPACE}/ttrt-artifacts/system_desc.ttsys"
-        cmake --build build -- check-ttmlir
+        ln -sf ${{ steps.strings.outputs.install-output-dir }} ${{ steps.strings.outputs.build-output-dir }}
+        llvm-lit -sv ${{ steps.strings.outputs.build-output-dir }}/test
 
     - name: Run tests
       shell: bash
       run: |
         source env/activate
-        ttrt ${{ matrix.build.name }} ${GITHUB_WORKSPACE}/build/test/ttmlir/Silicon
+        ttrt ${{ matrix.build.name }} ${{ steps.strings.outputs.build-output-dir }}/test/ttmlir/Silicon

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -152,13 +152,16 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: install-artifacts-${{ matrix.build.name }}
-        path: ${{ steps.strings.outputs.install-output-dir }}
+        path: ${{ steps.strings.outputs.install-output-dir }}.tar
 
     # This is needed to preserve file permissions
     # https://github.com/actions/upload-artifact?tab=readme-ov-file#permission-loss
     - name: 'Untar install directory'
       shell: bash
-      run: tar xvf install.tar -C ${{ steps.strings.outputs.install-output-dir }}
+      run: |
+        rm -rf ${{ steps.strings.outputs.install-output-dir }}
+        mkdir -p ${{ steps.strings.outputs.install-output-dir }}
+        tar xvf install.tar -C ${{ steps.strings.outputs.install-output-dir }}
 
     - name: Remove existing whls files
       shell: bash

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -84,13 +84,15 @@ jobs:
     # This is needed to preserve file permissions
     # https://github.com/actions/upload-artifact?tab=readme-ov-file#permission-loss
     - name: 'Tar install directory'
-      run: tar cvf ${{ steps.strings.outputs.install-output-dir }}.tar -C ${{ steps.strings.outputs.install-output-dir }} .
+      shell: bash
+      working-directory: ${{ steps.strings.outputs.install-output-dir }}
+      run: tar cvf artifact.tar .
 
     - name: Upload install folder to archive
       uses: actions/upload-artifact@v4
       with:
         name: install-artifacts-${{ matrix.build.name }}
-        path: ${{ steps.strings.outputs.install-output-dir }}.tar
+        path: ${{ steps.strings.outputs.install-output-dir }}/artifact.tar
 
     - name: Get the latest tag
       shell: bash
@@ -152,16 +154,14 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: install-artifacts-${{ matrix.build.name }}
-        path: ${{ steps.strings.outputs.install-output-dir }}.tar
+        path: ${{ steps.strings.outputs.install-output-dir }}
 
     # This is needed to preserve file permissions
     # https://github.com/actions/upload-artifact?tab=readme-ov-file#permission-loss
     - name: 'Untar install directory'
       shell: bash
-      run: |
-        rm -rf ${{ steps.strings.outputs.install-output-dir }}
-        mkdir -p ${{ steps.strings.outputs.install-output-dir }}
-        tar xvf install.tar -C ${{ steps.strings.outputs.install-output-dir }}
+      working-directory: ${{ steps.strings.outputs.install-output-dir }}
+      run: tar xvf artifact.tar
 
     - name: Remove existing whls files
       shell: bash

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -7,7 +7,7 @@ on:
 jobs:
 
   build-and-test:
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -104,3 +104,6 @@ add_mlir_python_modules(TTMLIRPythonModules
   COMMON_CAPI_LINK_LIBS
     TTMLIRPythonCAPI
   )
+
+install(DIRECTORY ${CMAKE_BINARY_DIR}/python/dialects/ DESTINATION python/dialects COMPONENT Test EXCLUDE_FROM_ALL)
+install(DIRECTORY ${CMAKE_BINARY_DIR}/python_packages/ DESTINATION python_packages COMPONENT Test EXCLUDE_FROM_ALL)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,3 +26,5 @@ add_lit_testsuite(check-ttmlir "Running the ttmlir regression tests"
 set_target_properties(check-ttmlir PROPERTIES FOLDER "Tests")
 
 add_lit_testsuites(TTMLIRStatic ${CMAKE_CURRENT_SOURCE_DIR} DEPENDS ${TTMLIR_TEST_DEPENDS})
+
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/ DESTINATION test COMPONENT Test EXCLUDE_FROM_ALL)

--- a/tools/ttmlir-opt/CMakeLists.txt
+++ b/tools/ttmlir-opt/CMakeLists.txt
@@ -7,3 +7,5 @@ llvm_update_compile_flags(ttmlir-opt)
 target_link_libraries(ttmlir-opt PRIVATE ${LIBS})
 
 mlir_check_all_link_libraries(ttmlir-opt)
+
+install(TARGETS ttmlir-opt DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT Test EXCLUDE_FROM_ALL)

--- a/tools/ttmlir-translate/CMakeLists.txt
+++ b/tools/ttmlir-translate/CMakeLists.txt
@@ -10,3 +10,5 @@ target_link_libraries(ttmlir-translate PRIVATE
 )
 
 mlir_check_link_libraries(ttmlir-translate)
+
+install(TARGETS ttmlir-translate DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT Test EXCLUDE_FROM_ALL)


### PR DESCRIPTION
This change introduces a new cmake install component named Test. Where running cmake command:

  cmake --install build --component Test

Will install all of the build artifacts necessary for testing.  This should cut down on the artifact size down to ~42 MB.