### PR TITLE
Runtime support for RuntimeArgs on KernelDesc (Tensor Addr + Semaphores) 

### DIFF
--- a/include/ttmlir/Target/TTMetal/program.fbs
+++ b/include/ttmlir/Target/TTMetal/program.fbs
@@ -18,6 +18,11 @@ enum BinaryType : ushort {
   ERISC = 5,
 }
 
+enum CoreType : ushort {
+  WORKER = 0,
+  ETH = 1,
+}
+
 table KernelSource {
   source_type: SourceType;
   source: string;
@@ -34,10 +39,25 @@ union Kernel {
   KernelBinary,
 }
 
+table RuntimeArgTensorAddress {
+  operand_idx: uint32;
+}
+
+table RuntimeArgSemaphoreAddress {
+  initial_value: uint32;
+  core_type: CoreType;
+}
+
+union RuntimeArg {
+  RuntimeArgTensorAddress,
+  RuntimeArgSemaphoreAddress,
+}
+
 table KernelDesc {
   kernel: Kernel;
   core_range_set: [Dim2dRange];
   cbs: [CBRef];
+  runtime_args: [RuntimeArg];
   debug_info: string;
 }
 

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -189,7 +189,8 @@ static std::shared_ptr<void> translateModuleToFlatbuffer(Operation *op) {
               ::tt::target::metal::CreateKernelSourceDirect(
                   fbb, toFlatbuffer(threadType), source.c_str())
                   .Union(),
-              &coreRangeSet, &cbs, nullptr /*TODO debug info*/));
+              &coreRangeSet, &cbs, nullptr, nullptr, /* TODO rtargs*/
+              nullptr /*TODO debug info*/));
         }
         ::flatbuffers::Offset<::tt::target::metal::ProgramDesc> program =
             ::tt::target::metal::CreateProgramDescDirect(fbb, &kernels);


### PR DESCRIPTION
Closes #361 and Closes #267

 - 2 types of runtime_args today: RuntimeArgTensorAddress, RuntimeArgSemaphoreAddress where runtime will resolve tensor address or semaphore id, and call metal APIs SetRuntimeArgs() and CreateSemaphore()

 - Compiler support not included, so did some light testing with various dummy values for each type in flatbuffer via TTMetalToFlatbuffer.cpp changes, and tested assertions. For now, keep nullptr in .ttm for runtime_args and runtime_args_types