### PR TITLE
Fix TTIRLayout pass generating unnecessary ToLayoutOps

### DIFF
--- a/lib/Dialect/TTIR/Transforms/Passes.cpp
+++ b/lib/Dialect/TTIR/Transforms/Passes.cpp
@@ -755,7 +755,10 @@ public:
       patterns.add<TTIRLayoutFuncReturnRewriter>(&getContext(), initMemorySpace,
                                                  defaultDeviceMemoryLayout);
       FrozenRewritePatternSet patternSet(std::move(patterns));
-      if (failed(applyPatternsAndFoldGreedily(getOperation(), patternSet))) {
+      GreedyRewriteConfig config = GreedyRewriteConfig();
+      config.useTopDownTraversal = true;
+      if (failed(applyPatternsAndFoldGreedily(getOperation(), patternSet,
+                                              config))) {
         signalPassFailure();
         return;
       }


### PR DESCRIPTION
Fix traversal order of TTIRLayout pass, default is bottom up. Reduces number of ToLayout ops inserted as operands are transformed first allowing their layout to be reused.
Closes #653