### PR TITLE
Add an preliminary conversion for stablehlo.dot_general op

### DIFF
--- a/include/ttmlir/Conversion/StableHLOToTTIR/StableHLOToTTIR.h
+++ b/include/ttmlir/Conversion/StableHLOToTTIR/StableHLOToTTIR.h
@@ -5,11 +5,8 @@
 #ifndef TTMLIR_CONVERSION_STABLEHLOTOTTIR_STABLEHLOTOTTIR_H
 #define TTMLIR_CONVERSION_STABLEHLOTOTTIR_STABLEHLOTOTTIR_H
 
-#define DEBUG_TYPE "stablehlo-to-ttir-conversion"
-
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
-#include "llvm/Support/Debug.h"
 
 namespace mlir::tt {
 

--- a/include/ttmlir/Conversion/StableHLOToTTIR/StableHLOToTTIR.h
+++ b/include/ttmlir/Conversion/StableHLOToTTIR/StableHLOToTTIR.h
@@ -5,8 +5,11 @@
 #ifndef TTMLIR_CONVERSION_STABLEHLOTOTTIR_STABLEHLOTOTTIR_H
 #define TTMLIR_CONVERSION_STABLEHLOTOTTIR_STABLEHLOTOTTIR_H
 
+#define DEBUG_TYPE "stablehlo-to-ttir-conversion"
+
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "llvm/Support/Debug.h"
 
 namespace mlir::tt {
 

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -181,9 +181,8 @@ public:
     // ttir.permute and ttir.broadcast_in_dim become available.
 
     if (!checkBasicLegality(srcOp, adaptor)) {
-      LLVM_DEBUG(llvm::dbgs() << "Failed legality checks in the handling of Op "
-                              << srcOp->getName());
-      return failure();
+      return rewriter.notifyMatchFailure(
+          srcOp, "Failed legality checks in the handling of Op");
     }
 
     rewriter.replaceOpWithNewOp<mlir::tt::ttir::MatmulOp>(
@@ -278,9 +277,9 @@ void addTransposeOpsConversionPatterns(MLIRContext *ctx,
   patterns.add<StableHLOToTTIRTransposeOpConversionPattern>(typeConverter, ctx);
 }
 
-void addDotGeneralOpsConversionPatterns(MLIRContext *ctx,
-                                        RewritePatternSet &patterns,
-                                        TypeConverter &typeConverter) {
+void addMatmulOpsConversionPatterns(MLIRContext *ctx,
+                                    RewritePatternSet &patterns,
+                                    TypeConverter &typeConverter) {
   patterns.add<StableHLOToTTIRDotGeneralOpConversionPattern>(typeConverter,
                                                              ctx);
 }
@@ -296,7 +295,7 @@ void populateStableHLOToTTIRPatterns(MLIRContext *ctx,
   addElementwiseBinaryOpsConversionPatterns(ctx, patterns, typeConverter);
   addReduceOpsConversionPatterns(ctx, patterns, typeConverter);
   addTransposeOpsConversionPatterns(ctx, patterns, typeConverter);
-  addDotGeneralOpsConversionPatterns(ctx, patterns, typeConverter);
+  addMatmulOpsConversionPatterns(ctx, patterns, typeConverter);
 }
 
 } // namespace mlir::tt

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -134,9 +134,8 @@ public:
         srcOp.getLoc(), outputType.getShape(), outputType.getElementType());
 
     if (!checkBasicLegality(srcOp, adaptor)) {
-      LLVM_DEBUG(llvm::dbgs() << "Failed legality checks in the handling of Op "
-                              << srcOp->getName());
-      return failure();
+      return rewriter.notifyMatchFailure(
+          srcOp, "Failed legality checks in the handling of Op");
     }
 
     rewriter.replaceOpWithNewOp<mlir::tt::ttir::TransposeOp>(

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -162,26 +162,27 @@ public:
     auto outputTensor = rewriter.create<tensor::EmptyOp>(
         srcOp.getLoc(), outputType.getShape(), outputType.getElementType());
 
-    // This is a simplistic version of that can only work for matmul cases.
-    // The op should be extended as other ops such as ttir.permute and
-    // ttir.broadcast_in_dim become available.
+    // This is a basic version that can only work for cases that can be directly
+    // converted to matmul. The op should be extended as other ops such as
+    // ttir.permute and ttir.broadcast_in_dim become available.
 
-    auto dimensions = adaptor.getDotDimensionNumbers();
+    ::mlir::stablehlo::DotDimensionNumbersAttr dimensions =
+        adaptor.getDotDimensionNumbers();
     if (dimensions.getLhsContractingDimensions().size()) {
       assert(dimensions.getLhsContractingDimensions()[0] == 1 &&
-             "ttir dot_general only supports matmul operation");
+             "ttir dot_general only supports matmul operation.");
     }
 
     if (dimensions.getRhsContractingDimensions().size()) {
       assert(dimensions.getRhsContractingDimensions()[0] == 0 &&
-             "ttir dot_general only supports matmul operation");
+             "ttir dot_general only supports matmul operation.");
     }
 
     assert(dimensions.getLhsBatchingDimensions().empty() &&
-           "ttir dot_general only supports matmul operation");
+           "ttir dot_general only supports matmul operation.");
 
     assert(dimensions.getRhsBatchingDimensions().empty() &&
-           "ttir dot_general only supports matmul operation");
+           "ttir dot_general only supports matmul operation.");
 
     rewriter.replaceOpWithNewOp<mlir::tt::ttir::MatmulOp>(
         srcOp, outputTensor.getType(), adaptor.getLhs(), adaptor.getRhs(),

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -162,6 +162,10 @@ public:
     auto outputTensor = rewriter.create<tensor::EmptyOp>(
         srcOp.getLoc(), outputType.getShape(), outputType.getElementType());
 
+    // This is a simplistic version of that can only work for matmul cases.
+    // The op should be extended as other ops such as ttir.permute and
+    // ttir.broadcast_in_dim become available.
+
     auto dimensions = adaptor.getDotDimensionNumbers();
     if (dimensions.getLhsContractingDimensions().size()) {
       assert(dimensions.getLhsContractingDimensions()[0] == 1 &&

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -163,8 +163,8 @@ public:
     auto outputTensor = rewriter.create<tensor::EmptyOp>(
         srcOp.getLoc(), outputType.getShape(), outputType.getElementType());
 
-    assert(adaptor.getDotDimensionNumbers().getLhsContractingDimensions().data().empty());
-    assert(adaptor.getDotDimensionNumbers().getRhsContractingDimensions().data().empty());
+    assert(adaptor.getDotDimensionNumbers().getLhsContractingDimensions().empty() == 0);
+    assert(adaptor.getDotDimensionNumbers().getRhsContractingDimensions().empty() == 0);
 
     rewriter.replaceOpWithNewOp<mlir::tt::ttir::MatmulOp>(
         srcOp, outputTensor.getType(), adaptor.getLhs(), adaptor.getRhs(),

--- a/test/ttmlir/Conversion/StableHLOToTTIR/dot_general_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/dot_general_op.mlir
@@ -1,10 +1,10 @@
 // REQUIRES: stablehlo
 // RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s | FileCheck %s
 module @jit_eltwise_subtract attributes {} {
-  func.func public @test_dot_general(%arg0 : tensor<32x32xf32>, %arg1 : tensor<32x32xf32>) -> tensor<32x32xf32> {
-    %0 = stablehlo.dot_general %arg0, %arg1, contracting_dims = [1] x [0] : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+  func.func public @test_dot_general(%arg0 : tensor<16x32xf32>, %arg1 : tensor<32x8xf32>) -> tensor<16x8xf32> {
+    %0 = stablehlo.dot_general %arg0, %arg1, contracting_dims = [1] x [0] : (tensor<16x32xf32>, tensor<32x8xf32>) -> tensor<16x8xf32>
     // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
     // CHECK: %[[C:.*]] = "ttir.matmul"[[C:.*]]
-    return %0 : tensor<32x32xf32>
+    return %0 : tensor<16x8xf32>
   }
 }

--- a/test/ttmlir/Conversion/StableHLOToTTIR/dot_general_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/dot_general_op.mlir
@@ -1,0 +1,10 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s | FileCheck %s
+module @jit_eltwise_subtract attributes {} {
+  func.func public @test_dot_general(%arg0 : tensor<32x32xf32>, %arg1 : tensor<32x32xf32>) -> tensor<32x32xf32> {
+    %0 = stablehlo.dot_general %arg0, %arg1, contracting_dims = [0] x [0] : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
+    // CHECK: %[[C:.*]] = "ttir.matmul"[[C:.*]]
+    return %0 : tensor<32x32xf32>
+  }
+}

--- a/test/ttmlir/Conversion/StableHLOToTTIR/dot_general_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/dot_general_op.mlir
@@ -1,6 +1,6 @@
 // REQUIRES: stablehlo
 // RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s | FileCheck %s
-module @jit_eltwise_subtract attributes {} {
+module @jit_dot_general attributes {} {
   func.func public @test_dot_general(%arg0 : tensor<16x32xf32>, %arg1 : tensor<32x8xf32>) -> tensor<16x8xf32> {
     %0 = stablehlo.dot_general %arg0, %arg1, contracting_dims = [1] x [0] : (tensor<16x32xf32>, tensor<32x8xf32>) -> tensor<16x8xf32>
     // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]

--- a/test/ttmlir/Conversion/StableHLOToTTIR/dot_general_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/dot_general_op.mlir
@@ -2,7 +2,7 @@
 // RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s | FileCheck %s
 module @jit_eltwise_subtract attributes {} {
   func.func public @test_dot_general(%arg0 : tensor<32x32xf32>, %arg1 : tensor<32x32xf32>) -> tensor<32x32xf32> {
-    %0 = stablehlo.dot_general %arg0, %arg1, contracting_dims = [0] x [0] : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %0 = stablehlo.dot_general %arg0, %arg1, contracting_dims = [1] x [0] : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
     // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
     // CHECK: %[[C:.*]] = "ttir.matmul"[[C:.*]]
     return %0 : tensor<32x32xf32>


### PR DESCRIPTION
This conversion only works for cases that can be directly converted for ttir.matmul op in order to support the case in MNIST examples. 

It will be enhanced further as other required ops are supported e.g. permute and broadcast_in_dim. 