### PR TITLE
Multi-chip spec update, add meshShape to DeviceAttr

### DIFF
--- a/docs/src/specs/device.md
+++ b/docs/src/specs/device.md
@@ -351,7 +351,7 @@ perspectives:
   divided by `meshShape` to determine the shape of the tensor slice on each device.
   Broadcasting rules can be applied to determine which [Distribution Strategy](https://github.com/tenstorrent/tt-metal/blob/main/tech_reports/Programming%20Mesh%20of%20Devices/Programming%20Mesh%20of%20Devices%20with%20TT-NN.md#3-distributing-tensor-to-meshdevice)
   to use:
-    - **Sharding**: If the tensor grid is > 1 along the `meshShape` dimensions,
+    - **Mesh Sharded**: If the tensor grid is > 1 along the `meshShape` dimensions,
       the tensor will be sharded across the mesh devices.
     - **Replication**: If the tensor needs to be broadcasted for this op, by
       extension the tensor layout will be replicated across the mesh devices.

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -328,17 +328,22 @@ def TT_DeviceAttr : TT_Attr<"Device", "device", []> {
     - A grid attribute that describes the device's compute grid shape.  It not only describes the shape of the compute grid, but also
       carries an affine map that describes how the logical grid maps to the physical grid.
     - Two affine maps that describe how a tensor layout's linear attribute maps to the L1 and DRAM memory spaces.
-    - An array of chip ids that this device is made up of.
+    - A mesh shape that describes the virtual layout of the chips with respect to each other. Note that in a multi-chip system, this grid
+      encapsulates the entire system's grid shape, e.g. 8x16 grid could be made up of a 1x2 mesh of chips side-by-side. The mesh
+      attribute configures how the above grid/map attributes are created such that they implement this mesh topology.
+    - An array of chip ids that this device is made up of. This array's length must match the volume of the mesh shape and should be
+      interpreted in row-major order.
   }];
   let parameters = (ins TT_GridAttr:$workerGrid,
                         "AffineMap":$l1Map,
                         "AffineMap":$dramMap,
+                        ArrayRefParameter<"int64_t">:$meshShape,
                         ArrayRefParameter<"unsigned">:$chipIds);
-  let assemblyFormat = "`<` `workerGrid` `=` qualified($workerGrid) `,` `l1Map` `=` qualified($l1Map) `,` `dramMap` `=` qualified($dramMap) `,` `chipIds` `=` `[` $chipIds `]` `>`";
+  let assemblyFormat = "`<` `workerGrid` `=` qualified($workerGrid) `,` `l1Map` `=` qualified($l1Map) `,` `dramMap` `=` qualified($dramMap) `,` `meshShape` `=` custom<DimensionList>($meshShape) `,` `chipIds` `=` `[` $chipIds `]` `>`";
 
   let extraClassDeclaration = [{
-      static DeviceAttr get(::mlir::MLIRContext *context, SystemDescAttr systemDesc, ArrayRef<unsigned> chipIds);
-      static DeviceAttr get(::mlir::MLIRContext *context, SystemDescAttr systemDesc, bool enableMultichip = false);
+      static DeviceAttr get(::mlir::MLIRContext *context, SystemDescAttr systemDesc, ArrayRef<int64_t> meshShape, ArrayRef<unsigned> chipIds);
+      static DeviceAttr get(::mlir::MLIRContext *context, SystemDescAttr systemDesc, ArrayRef<int64_t> meshShape = {});
       AffineMap getMapForMemorySpace(MemorySpace memorySpace) const {
         switch (memorySpace) {
         case MemorySpace::DeviceL1:

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -13,6 +13,11 @@ def TTIRImplicitDevice: Pass<"ttir-implicit-device", "::mlir::ModuleOp"> {
     This pass will take a view of the system descriptor and create an implicit
     device around it.
   }];
+
+  let options = [
+    ListOption<"meshShape", "mesh-shape", "int64_t",
+               "Set the multi-device mesh shape.">,
+  ];
 }
 
 def TTIRGenericKernel: Pass<"ttir-generic-kernel", "::mlir::ModuleOp"> {

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -94,6 +94,9 @@ struct TTIRToTTNNBackendPipelineOptions
       llvm::cl::desc(
           "Pass in a system descriptor flatbuffer to compile against."),
       llvm::cl::init("")};
+
+  ListOption<int64_t> meshShape{
+      *this, "mesh-shape", llvm::cl::desc("Set the multi-device mesh shape.")};
 };
 
 void createTTIRToTTNNBackendPipeline(

--- a/include/ttmlir/Utils.h
+++ b/include/ttmlir/Utils.h
@@ -52,6 +52,14 @@ llvm::SmallVector<int64_t> evalShape(mlir::AffineMap map, Vector shape) {
   return result;
 }
 
+template <typename IntType> IntType volume(mlir::ArrayRef<IntType> shape) {
+  IntType result = 1;
+  for (auto dim : shape) {
+    result *= dim;
+  }
+  return result;
+}
+
 template <typename Enum>
 constexpr std::underlying_type_t<Enum> enum_as_int(Enum e) {
   return static_cast<std::underlying_type_t<Enum>>(e);

--- a/lib/Dialect/TT/IR/TTDialect.cpp
+++ b/lib/Dialect/TT/IR/TTDialect.cpp
@@ -46,6 +46,14 @@ struct TTOpAsmDialectInterface : public OpAsmDialectInterface {
       }
       return AliasResult::OverridableAlias;
     }
+    if (llvm::isa<DeviceAttr>(attr)) {
+      os << "device";
+      return AliasResult::OverridableAlias;
+    }
+    if (llvm::isa<SystemDescAttr>(attr)) {
+      os << "system_desc";
+      return AliasResult::OverridableAlias;
+    }
     return AliasResult::NoAlias;
   }
 };

--- a/lib/Dialect/TTIR/Transforms/Passes.cpp
+++ b/lib/Dialect/TTIR/Transforms/Passes.cpp
@@ -57,7 +57,8 @@ public:
       module->setAttr(
           tt::DeviceAttr::name,
           tt::DeviceAttr::get(&getContext(),
-                              mlir::cast<tt::SystemDescAttr>(systemDesc)));
+                              mlir::cast<tt::SystemDescAttr>(systemDesc),
+                              meshShape));
     }
   }
 

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -23,7 +23,9 @@ void createTTIRToTTNNBackendPipeline(
   pm.addPass(mlir::tt::ttir::createTTIRSlidingWindow2dFixShapes());
   pm.addPass(mlir::tt::ttir::createTTIRLoadSystemDesc(systemDescOptions));
 
-  pm.addPass(mlir::tt::ttir::createTTIRImplicitDevice());
+  ttir::TTIRImplicitDeviceOptions implicitDeviceOptions;
+  implicitDeviceOptions.meshShape = options.meshShape;
+  pm.addPass(mlir::tt::ttir::createTTIRImplicitDevice(implicitDeviceOptions));
   mlir::tt::ttir::TTIRLayoutOptions layoutOptions;
   layoutOptions.initMemorySpace = mlir::tt::MemorySpace::System;
   layoutOptions.defaultMemorySpace = mlir::tt::MemorySpace::DeviceDRAM;

--- a/python/TTModule.cpp
+++ b/python/TTModule.cpp
@@ -232,20 +232,23 @@ void populateTTModule(py::module &m) {
 
   py::class_<tt::DeviceAttr>(m, "DeviceAttr")
       .def_static("from_system_desc",
-                  [](MlirContext ctx, MlirAttribute systemDesc) {
+                  [](MlirContext ctx, MlirAttribute systemDesc,
+                     std::vector<int64_t> meshShape) {
                     return wrap(tt::DeviceAttr::get(
                         unwrap(ctx),
-                        mlir::cast<tt::SystemDescAttr>(unwrap(systemDesc))));
+                        mlir::cast<tt::SystemDescAttr>(unwrap(systemDesc)),
+                        meshShape));
                   })
       .def_static("get",
-                  [](MlirContext ctx, std::vector<int64_t> shape,
+                  [](MlirContext ctx, std::vector<int64_t> gridShape,
                      MlirAffineMap workerGridMapping, MlirAffineMap l1Map,
-                     MlirAffineMap dramMap, std::vector<unsigned> chipIds) {
+                     MlirAffineMap dramMap, std::vector<int64_t> meshShape,
+                     std::vector<unsigned> chipIds) {
                     return wrap(tt::DeviceAttr::get(
                         unwrap(ctx),
-                        tt::GridAttr::get(unwrap(ctx), shape,
+                        tt::GridAttr::get(unwrap(ctx), gridShape,
                                           unwrap(workerGridMapping)),
-                        unwrap(l1Map), unwrap(dramMap), chipIds));
+                        unwrap(l1Map), unwrap(dramMap), meshShape, chipIds));
                   })
       .def("unwrap", [](MlirAttribute const &self) {
         return mlir::cast<tt::DeviceAttr>(unwrap(self));

--- a/test/python/device_attr.py
+++ b/test/python/device_attr.py
@@ -22,17 +22,12 @@ def volume(shape):
     return vol
 
 
-def getTotalDevices(grid, physicalGrid=[8, 8]):
-    return volume(grid) // volume(physicalGrid)
-
-
-def inferWorkerGridMap(grid, physicalGrid=[8, 8]):
+def inferWorkerGridMap(grid, physicalGrid=[8, 8], mesh=[1]):
     assert len(grid) >= 2
-    mesh = grid[:-2] + [
-        updiv(grid[-2], physicalGrid[-2]),
-        updiv(grid[-1], physicalGrid[-1]),
-    ]
-    totalDevices = getTotalDevices(grid, physicalGrid=physicalGrid)
+    mesh = mesh.copy()
+    while len(mesh) < len(grid):
+        mesh.append(1)
+    totalDevices = volume(mesh)
     p0 = AffineConstantExpr.get(physicalGrid[0], ctx)
     p1 = AffineConstantExpr.get(physicalGrid[1], ctx)
     dZ = AffineConstantExpr.get(0, ctx)
@@ -40,7 +35,10 @@ def inferWorkerGridMap(grid, physicalGrid=[8, 8]):
     dX = AffineDimExpr.get(len(grid) - 1, ctx)
     if totalDevices > 1:
         v = mesh[-1]
-        dZ = AffineFloorDivExpr.get(dY, p0) * v + AffineFloorDivExpr.get(dX, p1)
+        if mesh[-1] > 1:
+            dZ = dZ + AffineFloorDivExpr.get(dX, p1)
+        if mesh[-2] > 1:
+            dZ = dZ + AffineFloorDivExpr.get(dY, p0) * v
         for d in range(len(mesh) - 3, -1, -1):
             v *= mesh[d + 1]
             dn = AffineDimExpr.get(d, ctx)
@@ -63,24 +61,30 @@ def inferMemoryMap(grid):
 
 
 def createDeviceAttr(
-    grid, physicalGrid=[8, 8], deviceStartIdx=0, workerGridMap=None, system_desc=None
+    grid,
+    physicalGrid=[8, 8],
+    deviceStartIdx=0,
+    workerGridMap=None,
+    system_desc=None,
+    mesh_shape=[1],
 ):
     if system_desc is not None:
-        return tt.ir.DeviceAttr.from_system_desc(ctx, system_desc)
-    totalDevices = getTotalDevices(grid, physicalGrid=physicalGrid)
+        return tt.ir.DeviceAttr.from_system_desc(ctx, system_desc, mesh_shape)
     workerGridMap = (
         workerGridMap
         if workerGridMap is not None
-        else inferWorkerGridMap(grid, physicalGrid)
+        else inferWorkerGridMap(grid, physicalGrid, mesh=mesh_shape)
     )
     l1Map = inferMemoryMap(grid)
     dramMap = inferMemoryMap(grid)
+    totalDevices = volume(mesh_shape)
     return tt.ir.DeviceAttr.get(
         ctx,
         grid,
         workerGridMap,
         l1Map,
         dramMap,
+        mesh_shape,
         list(range(deviceStartIdx, deviceStartIdx + totalDevices)),
     )
 
@@ -96,57 +100,65 @@ d1 = d(1)
 d2 = d(2)
 
 print("=== From SystemDesc ===")
-# CHECK: tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], chipIds = [0]>
+# CHECK: tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 1, chipIds = [0]>
 print("", createDeviceAttr([8, 8], system_desc=tt.ir.SystemDescAttr.get_default(ctx)))
 
 # ------------------------------------------------------------------------------
 
 print("=== Simple single device ===")
-# CHECK: tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], chipIds = [0]>
+# CHECK: tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 1, chipIds = [0]>
 print("", createDeviceAttr([8, 8]))
 
 # ------------------------------------------------------------------------------
 
 print("\n=== Data parallel over batch ===")
-# CHECK: tt.device<workerGrid = #tt.grid<2x8x8, (d0, d1, d2) -> (d0 + d1 floordiv 8 + d2 floordiv 8, d1, d2)>, l1Map = [[M:.*]], dramMap = [[M:.*]], chipIds = [0, 1]>
-print("divide batch by 2\n", createDeviceAttr([2, 8, 8]))
-# CHECK: tt.device<workerGrid = #tt.grid<4x8x8, (d0, d1, d2) -> (d0 + d1 floordiv 8 + d2 floordiv 8, d1, d2)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], chipIds = [0, 1, 2, 3]>
-print("divide batch by 4\n", createDeviceAttr([4, 8, 8]))
+# CHECK: tt.device<workerGrid = #tt.grid<2x8x8, (d0, d1, d2) -> (d0, d1, d2)>, l1Map = [[M:.*]], dramMap = [[M:.*]], meshShape = 2x1x1, chipIds = [0, 1]>
+print("divide batch by 2\n", createDeviceAttr([2, 8, 8], mesh_shape=[2, 1, 1]))
+# CHECK: tt.device<workerGrid = #tt.grid<4x8x8, (d0, d1, d2) -> (d0, d1, d2)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 4x1x1, chipIds = [0, 1, 2, 3]>
+print("divide batch by 4\n", createDeviceAttr([4, 8, 8], mesh_shape=[4, 1, 1]))
 
 # ------------------------------------------------------------------------------
 
 print("\n=== Data parallel over 2d ===")
-# CHECK: tt.device<workerGrid = #tt.grid<8x16, (d0, d1) -> ((d0 floordiv 8) * 2 + d1 floordiv 8, d0, d1 mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], chipIds = [0, 1]>
+# CHECK: tt.device<workerGrid = #tt.grid<8x16, (d0, d1) -> (d1 floordiv 8, d0, d1 mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 1x2, chipIds = [0, 1]>
 print(
-    "Reinterpret 2 devices as grid side by side, 1x2 mesh\n", createDeviceAttr([8, 16])
+    "Reinterpret 2 devices as grid side by side, 1x2 mesh\n",
+    createDeviceAttr([8, 16], mesh_shape=[1, 2]),
 )
-# CHECK: tt.device<workerGrid = #tt.grid<16x8, (d0, d1) -> (d0 floordiv 8 + d1 floordiv 8, d0 mod 8, d1)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], chipIds = [0, 1]>
+# CHECK: tt.device<workerGrid = #tt.grid<16x8, (d0, d1) -> (d0 floordiv 8, d0 mod 8, d1)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 2x1, chipIds = [0, 1]>
 print(
-    "Reinterpret 2 devices as grid top to bottom, 2x1 mesh\n", createDeviceAttr([16, 8])
+    "Reinterpret 2 devices as grid top to bottom, 2x1 mesh\n",
+    createDeviceAttr([16, 8], mesh_shape=[2, 1]),
 )
-# CHECK: tt.device<workerGrid = #tt.grid<16x32, (d0, d1) -> ((d0 floordiv 8) * 4 + d1 floordiv 8, d0 mod 8, d1 mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], chipIds = [0, 1, 2, 3, 4, 5, 6, 7]>
-print("8 devices 2x4 mesh\n", createDeviceAttr([16, 32]))
-# CHECK: tt.device<workerGrid = #tt.grid<32x16, (d0, d1) -> ((d0 floordiv 8) * 2 + d1 floordiv 8, d0 mod 8, d1 mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], chipIds = [0, 1, 2, 3, 4, 5, 6, 7]>
-print("8 devices 4x2 mesh\n", createDeviceAttr([32, 16]))
+# CHECK: tt.device<workerGrid = #tt.grid<16x32, (d0, d1) -> (d1 floordiv 8 + (d0 floordiv 8) * 4, d0 mod 8, d1 mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 2x4, chipIds = [0, 1, 2, 3, 4, 5, 6, 7]>
+print("8 devices 2x4 mesh\n", createDeviceAttr([16, 32], mesh_shape=[2, 4]))
+# CHECK: tt.device<workerGrid = #tt.grid<32x16, (d0, d1) -> (d1 floordiv 8 + (d0 floordiv 8) * 2, d0 mod 8, d1 mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 4x2, chipIds = [0, 1, 2, 3, 4, 5, 6, 7]>
+print("8 devices 4x2 mesh\n", createDeviceAttr([32, 16], mesh_shape=[4, 2]))
 
 # ------------------------------------------------------------------------------
 
 print("\n=== Data parallel over 2d and batch (3d) ===")
-# CHECK: tt.device<workerGrid = #tt.grid<2x8x16, (d0, d1, d2) -> (d0 * 2 + (d1 floordiv 8) * 2 + d2 floordiv 8, d1, d2 mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], chipIds = [0, 1, 2, 3]>
-print("divide batch by 2, 2x1x2 mesh\n", createDeviceAttr([2, 8, 16]))
-# CHECK: tt.device<workerGrid = #tt.grid<3x24x8, (d0, d1, d2) -> (d0 * 3 + d1 floordiv 8 + d2 floordiv 8, d1 mod 8, d2)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], chipIds = [0, 1, 2, 3, 4, 5, 6, 7, 8]>
-print("divide batch by 3, 3x3x1 mesh\n", createDeviceAttr([3, 24, 8]))
+# CHECK: tt.device<workerGrid = #tt.grid<2x8x16, (d0, d1, d2) -> (d0 * 2 + d2 floordiv 8, d1, d2 mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 2x1x2, chipIds = [0, 1, 2, 3]>
+print(
+    "divide batch by 2, 2x1x2 mesh\n",
+    createDeviceAttr([2, 8, 16], mesh_shape=[2, 1, 2]),
+)
+# CHECK: tt.device<workerGrid = #tt.grid<3x24x8, (d0, d1, d2) -> (d0 * 3 + d1 floordiv 8, d1 mod 8, d2)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 3x3x1, chipIds = [0, 1, 2, 3, 4, 5, 6, 7, 8]>
+print(
+    "divide batch by 3, 3x3x1 mesh\n",
+    createDeviceAttr([3, 24, 8], mesh_shape=[3, 3, 1]),
+)
 
 # ------------------------------------------------------------------------------
 
 print("\n=== nD ===")
-# CHECK: tt.device<workerGrid = #tt.grid<3x2x8x8, (d0, d1, d2, d3) -> (d0 * 2 + d1 + d2 floordiv 8 + d3 floordiv 8, d2, d3)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], chipIds = [0, 1, 2, 3, 4, 5]>
-print("", createDeviceAttr([3, 2, 8, 8]))
+# CHECK: tt.device<workerGrid = #tt.grid<3x2x8x8, (d0, d1, d2, d3) -> (d0 * 2 + d1, d2, d3)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 3x2x1x1, chipIds = [0, 1, 2, 3, 4, 5]>
+print("", createDeviceAttr([3, 2, 8, 8], mesh_shape=[3, 2, 1, 1]))
 
 # ------------------------------------------------------------------------------
 
 print("\n=== Data parallel batch on single device ===")
-# CHECK: tt.device<workerGrid = #tt.grid<2x4x8, (d0, d1, d2) -> (0, d0 * 4 + d1, d2)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], chipIds = [0]>
+# CHECK: tt.device<workerGrid = #tt.grid<2x4x8, (d0, d1, d2) -> (0, d0 * 4 + d1, d2)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 1, chipIds = [0]>
 print(
     "divide batch by 2, top 4 rows get batch 0, bottom 4 rows get batch 1\n",
     createDeviceAttr([2, 4, 8], workerGridMap=amap(3, [c0, d0 * 4 + d1, d2])),
@@ -155,24 +167,30 @@ print(
 # ------------------------------------------------------------------------------
 
 print("\n=== Pipeline parallel ===")
-# CHECK: tt.device<workerGrid = #tt.grid<2x8x16, (d0, d1, d2) -> (d0 * 2 + (d1 floordiv 8) * 2 + d2 floordiv 8, d1, d2 mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], chipIds = [0, 1, 2, 3]>
-print("view devices 0-3 in one way\n", createDeviceAttr([2, 8, 16], deviceStartIdx=0))
-# CHECK: tt.device<workerGrid = #tt.grid<16x16, (d0, d1) -> ((d0 floordiv 8) * 2 + d1 floordiv 8, d0 mod 8, d1 mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], chipIds = [4, 5, 6, 7]>
-print("view devices 4-7 in another way\n", createDeviceAttr([16, 16], deviceStartIdx=4))
+# CHECK: tt.device<workerGrid = #tt.grid<2x8x16, (d0, d1, d2) -> (d0 * 2 + d2 floordiv 8, d1, d2 mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 2x1x2, chipIds = [0, 1, 2, 3]>
+print(
+    "view devices 0-3 in one way\n",
+    createDeviceAttr([2, 8, 16], deviceStartIdx=0, mesh_shape=[2, 1, 2]),
+)
+# CHECK: tt.device<workerGrid = #tt.grid<16x16, (d0, d1) -> (d1 floordiv 8 + (d0 floordiv 8) * 2, d0 mod 8, d1 mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 2x2, chipIds = [4, 5, 6, 7]>
+print(
+    "view devices 4-7 in another way\n",
+    createDeviceAttr([16, 16], deviceStartIdx=4, mesh_shape=[2, 2]),
+)
 
 # ------------------------------------------------------------------------------
 
 print("\n=== Reinterpreted Grids ===")
-# CHECK: tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d1, d0)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], chipIds = [0]>
+# CHECK: tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d1, d0)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 1, chipIds = [0]>
 print("transposed\n", createDeviceAttr([8, 8], workerGridMap=amap(2, [c0, d1, d0])))
-# CHECK: tt.device<workerGrid = #tt.grid<1x64, (d0, d1) -> (0, d0 * 8 + d1 floordiv 8, d1 mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], chipIds = [0]>
+# CHECK: tt.device<workerGrid = #tt.grid<1x64, (d0, d1) -> (0, d0 * 8 + d1 floordiv 8, d1 mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 1, chipIds = [0]>
 print(
     "extra wide\n",
     createDeviceAttr(
         [1, 64], workerGridMap=amap(2, [c0, d0 * 8 + floordiv(d1, c(8)), d1 % 8])
     ),
 )
-# CHECK: tt.device<workerGrid = #tt.grid<64x1, (d0, d1) -> (0, d1 * 8 + d0 floordiv 8, d0 mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], chipIds = [0]>
+# CHECK: tt.device<workerGrid = #tt.grid<64x1, (d0, d1) -> (0, d1 * 8 + d0 floordiv 8, d0 mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 1, chipIds = [0]>
 print(
     "extra tall transposed\n",
     createDeviceAttr(
@@ -180,7 +198,7 @@ print(
         workerGridMap=amap(2, [c0, d1 * 8 + floordiv(d0, c(8)), d0 % 8]),
     ),
 )
-# CHECK: tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, (d0 + d1) mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], chipIds = [0]>
+# CHECK: tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, (d0 + d1) mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 1, chipIds = [0]>
 print(
     "staircase systolic\n",
     createDeviceAttr([8, 8], workerGridMap=amap(2, [c0, d0, (d0 + d1) % 8])),

--- a/test/ttmlir/Silicon/TTNN/multi_device.mlir
+++ b/test/ttmlir/Silicon/TTNN/multi_device.mlir
@@ -1,0 +1,15 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% mesh-shape=2,1,1" %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+// XFAIL: true
+// REQUIRES: multi-chip
+#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
+#any_device_tile = #tt.operand_constraint<dram|l1|tile|any_device_tile>
+
+func.func @multiply(%arg0: tensor<8x64x128xf32>, %arg1: tensor<8x64x128xf32>) -> tensor<8x64x128xf32> {
+  // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
+  %0 = tensor.empty() : tensor<8x64x128xf32>
+  // CHECK: %[[C:.*]] = "ttnn.multiply"[[C:.*]]
+  %1 = "ttir.multiply"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<8x64x128xf32>, tensor<8x64x128xf32>, tensor<8x64x128xf32>) -> tensor<8x64x128xf32>
+  return %1 : tensor<8x64x128xf32>
+}

--- a/test/ttmlir/Silicon/TTNN/multi_device.mlir
+++ b/test/ttmlir/Silicon/TTNN/multi_device.mlir
@@ -1,7 +1,7 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% mesh-shape=2,1,1" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-// XFAIL: true
+// UNSUPPORTED: true
 // REQUIRES: multi-chip
 #any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 #any_device_tile = #tt.operand_constraint<dram|l1|tile|any_device_tile>


### PR DESCRIPTION
- Updated the device spec to outline new meshShape attribute usage and lowering to TTNN.
- Add meshShape to DeviceAttr which drives interpretation of multi-device device and tensor grids.
- Add pass and pipeline option "mesh-shape" for providing a mesh shape to the device attribute creation.
- Make device and system_desc attributes as alias attributes, i.e. hoisted in mlir printing.
- Add llvm lit config features based on provided system_desc
- Update `test/python/device_attr.py` to match spec
- Add simple test marked as XFAIL for now