### PR TITLE
[Optimizer] DF sharding policy v0 - part 1.

### DIFF
--- a/include/ttmlir/Dialect/TTIR/Analysis/DFShardingPolicy.h
+++ b/include/ttmlir/Dialect/TTIR/Analysis/DFShardingPolicy.h
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTIR_ANALYSIS_DFSHARDINGPOLICY_H
+#define TTMLIR_DIALECT_TTIR_ANALYSIS_DFSHARDINGPOLICY_H
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "ttmlir/Dialect/TTIR/Analysis/ShardChainConfig.h"
+
+namespace mlir::tt::ttir {
+
+// Process ops in DFS schedulable order and build shard chain configs.
+// Schedule is also produced as a side effect of sharding.
+//
+class DFShardingPolicy {
+private:
+  Operation *rootOp;
+  std::vector<ShardChainConfig> *shardChainConfigs;
+  llvm::DenseMap<Operation *, std::vector<LayoutAttr>> legalGrids;
+  llvm::DenseMap<func::FuncOp, llvm::SmallVector<Operation *>> *schedule;
+  unsigned usableL1CacheSize = 0;
+
+public:
+  DFShardingPolicy(
+      Operation *rootOp, std::vector<ShardChainConfig> &shardChainConfigs,
+      const llvm::DenseMap<Operation *, std::vector<LayoutAttr>> &legalGrids,
+      llvm::DenseMap<func::FuncOp, llvm::SmallVector<Operation *>> &schedule,
+      unsigned usableL1CacheSize)
+      : rootOp(rootOp), shardChainConfigs(&shardChainConfigs),
+        legalGrids(legalGrids), schedule(&schedule),
+        usableL1CacheSize(usableL1CacheSize) {}
+
+  void run();
+};
+
+} // namespace mlir::tt::ttir
+
+#endif // TTMLIR_DIALECT_TTIR_ANALYSIS_DFSHARDINGPOLICY_H

--- a/include/ttmlir/Dialect/TTIR/Analysis/Edge.h
+++ b/include/ttmlir/Dialect/TTIR/Analysis/Edge.h
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTIR_ANALYSIS_EDGE_H
+#define TTMLIR_DIALECT_TTIR_ANALYSIS_EDGE_H
+
+#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
+
+namespace mlir::tt::ttir {
+struct Edge {
+  Operation *producerOp = nullptr;
+  Operation *consumerOp = nullptr;
+  size_t operandIndex = 0;
+
+  Edge(Operation *producerOp, Operation *consumerOp, size_t operandIndex)
+      : producerOp(producerOp), consumerOp(consumerOp),
+        operandIndex(operandIndex) {}
+
+  bool operator==(const Edge &other) const {
+    return producerOp == other.producerOp && consumerOp == other.consumerOp &&
+           operandIndex == other.operandIndex;
+  }
+};
+
+} // namespace mlir::tt::ttir
+
+namespace std {
+template <> struct hash<mlir::tt::ttir::Edge> {
+  size_t operator()(const mlir::tt::ttir::Edge &edge) const noexcept {
+    llvm::hash_code code = llvm::hash_value(edge.operandIndex);
+    code = llvm::hash_combine(code, edge.producerOp);
+    code = llvm::hash_combine(code, edge.consumerOp);
+    return code;
+  }
+};
+} // namespace std
+
+#endif // TTMLIR_DIALECT_TTIR_ANALYSIS_EDGE_H

--- a/include/ttmlir/Dialect/TTIR/Analysis/OpConfigAnalysis.h
+++ b/include/ttmlir/Dialect/TTIR/Analysis/OpConfigAnalysis.h
@@ -2,36 +2,40 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef TTMLIR_DIALECT_TTIR_ANALYSIS_OPTIMALTARGETGRIDANALYSIS_H
-#define TTMLIR_DIALECT_TTIR_ANALYSIS_OPTIMALTARGETGRIDANALYSIS_H
+#ifndef TTMLIR_DIALECT_TTIR_ANALYSIS_OPCONFIGANALYSIS_H
+#define TTMLIR_DIALECT_TTIR_ANALYSIS_OPCONFIGANALYSIS_H
 
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
 #include "ttmlir/Dialect/TTIR/Analysis/TTIRAnalysis.h"
 
 namespace mlir::tt::ttir {
 
-struct OptimalTargetGridAnalysisInput {
+struct OpConfigAnalysisInput {
   llvm::DenseMap<Operation *, std::vector<LayoutAttr>> legalGrids;
 
-  OptimalTargetGridAnalysisInput() : legalGrids() {}
+  OpConfigAnalysisInput() : legalGrids() {}
 
-  OptimalTargetGridAnalysisInput(
+  OpConfigAnalysisInput(
       const llvm::DenseMap<Operation *, std::vector<LayoutAttr>> &&legalGrids)
       : legalGrids(std::move(legalGrids)) {}
 
-  bool operator==(const OptimalTargetGridAnalysisInput &rhs) const {
+  OpConfigAnalysisInput(
+      const llvm::DenseMap<Operation *, std::vector<LayoutAttr>> &legalGrids)
+      : legalGrids(legalGrids) {}
+
+  bool operator==(const OpConfigAnalysisInput &rhs) const {
     return legalGrids == rhs.legalGrids;
   }
 
-  bool operator!=(const OptimalTargetGridAnalysisInput &rhs) const {
+  bool operator!=(const OpConfigAnalysisInput &rhs) const {
     return !(*this == rhs);
   }
 };
 
-// Determine optimal target grid size for each op.
+// Determine optimal configuration for each op.
 //
-class OptimalTargetGridAnalysis
-    : public TTIRAnalysis<OptimalTargetGridAnalysisInput,
+class OpConfigAnalysis
+    : public TTIRAnalysis<OpConfigAnalysisInput,
                           llvm::DenseMap<Operation *, LayoutAttr>> {
 
 private:
@@ -39,8 +43,8 @@ private:
   bool applyOverrides() override;
 
 public:
-  OptimalTargetGridAnalysis(Operation *op) : TTIRAnalysis(op) {}
+  OpConfigAnalysis(Operation *op) : TTIRAnalysis(op) {}
 };
 } // namespace mlir::tt::ttir
 
-#endif // TTMLIR_DIALECT_TTIR_ANALYSIS_OPTIMALTARGETGRIDANALYSIS_H
+#endif // TTMLIR_DIALECT_TTIR_ANALYSIS_OPCONFIGANALYSIS_H

--- a/include/ttmlir/Dialect/TTIR/Analysis/ShardChainConfig.h
+++ b/include/ttmlir/Dialect/TTIR/Analysis/ShardChainConfig.h
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTIR_ANALYSIS_SHARDCHAINCONFIG_H
+#define TTMLIR_DIALECT_TTIR_ANALYSIS_SHARDCHAINCONFIG_H
+
+#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
+#include "ttmlir/Dialect/TTIR/Analysis/ShardSolver.h"
+#include <unordered_set>
+
+namespace mlir::tt::ttir {
+
+struct ShardSpec {
+  Operation *op;
+  uint tensorSplitFactor;
+  LayoutAttr layout;
+};
+
+// Enum to track the state of the shard chain.
+// InBuild: Shard chain is being built. ShardSpecs can be added.
+// Built: Shard chain is built, but not resolved yet. ShardSolver can be run.
+// Resolved: Shard chain is resolved. Reshards are computed. We can pick legal
+// layouts for each op. Completed: Shard chain is completed. ShardSpecs are
+// resolved to a single layout.
+//
+enum class ShardChainState { InBuild, Built, Resolved, Completed };
+
+class ShardChainConfig {
+private:
+  std::vector<ShardSpec> shardSpecs;
+  llvm::DenseSet<Operation *> shardedOps;
+  std::unordered_set<Edge> reshardedEdges;
+  ShardChainState state = ShardChainState::InBuild;
+
+public:
+  ShardChainConfig() : shardSpecs(), state() {}
+
+  ShardSolver resolve(
+      const llvm::DenseMap<Operation *, std::vector<LayoutAttr>> &legalGrids,
+      unsigned usableL1CacheSize);
+  void build();
+  void complete(const llvm::DenseMap<Operation *, LayoutAttr> &selectedOpLayout,
+                std::unordered_set<Edge> &reshardedEdges);
+
+  bool isEmpty() { return shardSpecs.empty(); }
+  void addShardSpec(ShardSpec &&spec) {
+    assert(state == ShardChainState::InBuild);
+    shardedOps.insert(spec.op);
+    shardSpecs.push_back(std::move(spec));
+  }
+  const std::vector<ShardSpec> &getShardSpecs() const { return shardSpecs; }
+  ShardChainState getState() const { return state; }
+};
+
+} // namespace mlir::tt::ttir
+
+#endif // TTMLIR_DIALECT_TTIR_ANALYSIS_SHARDCHAINCONFIG_H

--- a/include/ttmlir/Dialect/TTIR/Analysis/ShardSolver.h
+++ b/include/ttmlir/Dialect/TTIR/Analysis/ShardSolver.h
@@ -1,0 +1,303 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTIR_ANALYSIS_SHARDSOLVER_H
+#define TTMLIR_DIALECT_TTIR_ANALYSIS_SHARDSOLVER_H
+
+#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
+#include "ttmlir/Dialect/TTIR/Analysis/Edge.h"
+#include <algorithm>
+#include <bitset>
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace mlir::tt::ttir {
+
+struct ShardSpec;
+
+struct ShardSolverSolution {
+  llvm::DenseMap<Operation *, LayoutAttr> selectedOpLayout;
+  std::unordered_set<Edge> reshardedEdges;
+
+  ShardSolverSolution(
+      const llvm::DenseMap<Operation *, LayoutAttr> &selectedOpLayout,
+      const std::unordered_set<Edge> &reshardedEdges)
+      : selectedOpLayout(selectedOpLayout), reshardedEdges(reshardedEdges) {}
+};
+
+class ShardSolver {
+private:
+  static constexpr size_t kNumBitsetBits = 64;
+  using Bitset = std::bitset<kNumBitsetBits>;
+  static Bitset kBitsetAll;
+  static constexpr Bitset kBitsetNone = Bitset{};
+
+public:
+  struct RemainingLayoutAttrs {
+    class Iterator {
+      std::uint64_t i = 0;
+      std::vector<LayoutAttr> const *p = nullptr;
+      Bitset mask = 0;
+
+    private:
+      void nextValid() {
+        if (mask == Bitset{}) {
+          i = p->size();
+          return;
+        }
+
+        while (mask.any() and not mask[i]) {
+          ++i;
+        }
+
+        mask.reset(i);
+      }
+
+    public:
+      using iterator_category = std::input_iterator_tag;
+      using value_type = const LayoutAttr;
+      using difference_type = const LayoutAttr;
+      using pointer = const LayoutAttr *;
+      using reference = const LayoutAttr &;
+
+      Iterator(std::vector<LayoutAttr> const *p, const Bitset &mask,
+               std::uint64_t i = 0)
+          : i(i), p(p), mask(mask) {
+        nextValid();
+      }
+
+      Iterator &operator++() {
+        nextValid();
+        return *this;
+      }
+
+      Iterator operator++(int) {
+        auto r = *this;
+        nextValid();
+        return r;
+      }
+
+      bool operator==(Iterator other) const {
+        return (p == other.p) and (i == other.i);
+      }
+      bool operator!=(Iterator other) const { return not(*this == other); }
+      reference operator*() const { return (*p)[i]; }
+    };
+
+    RemainingLayoutAttrs(std::vector<LayoutAttr> const &p, const Bitset &mask)
+        : p(&p), mask(mask) {}
+
+    Iterator begin() const { return Iterator(p, mask); }
+    Iterator end() const {
+      return Iterator(p, 0, std::min(kNumBitsetBits, p->size()));
+    }
+    size_t size() const { return mask.count(); }
+
+    std::vector<LayoutAttr> const *p = nullptr;
+    Bitset mask = 0;
+  };
+
+  ShardSolverSolution const finish();
+
+private:
+  static Bitset bitset(std::uint64_t bit) {
+    Bitset b;
+    b.set(bit);
+    return b;
+  }
+  // is `a` a subset of `b`
+  static bool isSubset(const Bitset &a, const Bitset &b) {
+    return a == (a & b);
+  }
+
+  using PathSetId = int;
+  using BitsetId = int;
+
+  class OperationPathsProcessor {
+  public:
+    void addOp(Operation *operation) {
+      if (controlSet.count(operation) == 0) {
+        queue.push_back(operation);
+        controlSet.insert(operation);
+      }
+    }
+
+    void process(ShardSolver *shardSolver) {
+      while (!queue.empty()) {
+        Operation *operation = queue.back();
+        queue.pop_back();
+        controlSet.erase(operation);
+
+        auto operandPathSets = shardSolver->getOperandPathSetsPts(operation);
+        auto userPathSets = shardSolver->getUserPathSetsPts(operation);
+        for (auto *path_set : operandPathSets) {
+          path_set->updateOperationProcessor(shardSolver->bitsets, this);
+        }
+        for (auto *path_set : userPathSets) {
+          path_set->updateOperationProcessor(shardSolver->bitsets, this);
+        }
+      }
+    }
+
+  private:
+    llvm::SmallVector<Operation *> queue;
+    llvm::DenseSet<Operation *> controlSet;
+  };
+
+  struct Path {
+    std::uint16_t producerId = 0;
+    std::uint16_t consumerId = 0;
+
+    Path() = default;
+    Path(std::uint16_t producerId, std::uint16_t consumerId)
+        : producerId(producerId), consumerId(consumerId) {}
+  };
+
+  class PathSet {
+  public:
+    using Paths = llvm::SmallVector<Path, 16>;
+
+    PathSet(BitsetId producerSetId, BitsetId consumerSetId,
+            Operation *producerOperation, Operation *consumerOperation,
+            Paths const &paths)
+        : producerSetId(producerSetId), consumerSetId(consumerSetId),
+          producerOperation(producerOperation),
+          consumerOperation(consumerOperation), paths(paths) {}
+
+    bool empty(const std::vector<Bitset> &bitsets) const {
+      return paths.empty() or (bitsets[producerSetId] == 0) or
+             (bitsets[consumerSetId] == 0);
+    }
+
+    bool update(std::vector<Bitset> &bitsets) {
+      Bitset validProducerSet = 0;
+      Bitset validConsumerSet = 0;
+      Bitset producer = bitsets[producerSetId];
+      Bitset consumer = bitsets[consumerSetId];
+
+      for (size_t i = 0; i < paths.size(); i++) {
+        Path const &path = paths[i];
+        if (consumer[path.consumerId] and producer[path.producerId]) {
+          validProducerSet.set(path.producerId);
+          validConsumerSet.set(path.consumerId);
+        } else {
+          paths[i] = paths.back();
+          paths.pop_back();
+          i--;
+        }
+      }
+
+      bool isProducerSub = isSubset(producer, validProducerSet);
+      bool isConsumerSub = isSubset(consumer, validConsumerSet);
+      bool unchanged = isProducerSub and isConsumerSub;
+
+      if (!unchanged) {
+        bitsets[producerSetId] &= validProducerSet;
+        bitsets[consumerSetId] &= validConsumerSet;
+      }
+
+      return not unchanged;
+    }
+
+    void
+    updateOperationProcessor(std::vector<Bitset> &bitsets,
+                             OperationPathsProcessor *operation_processor) {
+      Bitset validProducerSet = 0;
+      Bitset validConsumerSet = 0;
+      Bitset producer = bitsets[producerSetId];
+      Bitset consumer = bitsets[consumerSetId];
+      for (size_t i = 0; i < paths.size(); i++) {
+        Path const &path = paths[i];
+        if (consumer[path.consumerId] and producer[path.producerId]) {
+          validProducerSet.set(path.producerId);
+          validConsumerSet.set(path.consumerId);
+        } else {
+          paths[i] = paths.back();
+          paths.pop_back();
+          i--;
+        }
+      }
+
+      if (!isSubset(producer, validProducerSet)) {
+        operation_processor->addOp(consumerOperation);
+        operation_processor->addOp(producerOperation);
+        bitsets[producerSetId] &= validProducerSet;
+      }
+
+      if (!isSubset(consumer, validConsumerSet)) {
+        operation_processor->addOp(producerOperation);
+        operation_processor->addOp(consumerOperation);
+        bitsets[consumerSetId] &= validConsumerSet;
+      }
+    }
+
+    Operation *getProducerOp() const { return producerOperation; }
+    Operation *getConsumerOp() const { return consumerOperation; }
+
+  private:
+  private:
+    BitsetId producerSetId = -1;
+    BitsetId consumerSetId = -1;
+    Operation *producerOperation = nullptr;
+    Operation *consumerOperation = nullptr;
+    Paths paths;
+  };
+
+  const std::vector<LayoutAttr> &getLegalGrids(Operation *operation) const;
+  void reset();
+
+  PathSet *getPathSetPt(const Edge &edge);
+  SmallVector<PathSet *> getOperandPathSetsPts(Operation *operation);
+  SmallVector<PathSet *> getUserPathSetsPts(Operation *operation);
+
+  void handleNoPathsLeftOnUpdate(bool invokedBySet);
+  void updateSolver(Operation *root, bool expand_root = true,
+                    bool invokedBySet = false);
+
+  Bitset *getBitset(Operation *op);
+  Bitset const *getBitset(Operation *op) const;
+  Bitset *getOrInsertBitset(Operation *op, const Bitset &init);
+
+  void resolve();
+  bool resolveStep();
+  void insertReshard(const Edge &edge);
+  void addOperandsAndUsers(Operation *op, std::vector<Operation *> &needsUpdate,
+                           Operation *ignoreOp = nullptr);
+
+  bool checkShardCompatible(const Operation *producerOp,
+                            LayoutAttr const &producerLayout,
+                            const Operation *consumerOp,
+                            LayoutAttr const &consumerLayout) const;
+
+public:
+  ShardSolver(
+      const llvm::DenseMap<Operation *, std::vector<LayoutAttr>> &legalGrids,
+      const std::vector<ShardSpec> &shardSpecs,
+      const llvm::DenseSet<Operation *> &shardedOps,
+      const unsigned usableL1CacheSize);
+  RemainingLayoutAttrs at(Operation *operation) const;
+  void set(Operation *operation, LayoutAttr const &layout);
+
+private:
+  const llvm::DenseMap<Operation *, std::vector<LayoutAttr>> *legalGrids;
+  const std::vector<ShardSpec> *shardSpecs;
+  const llvm::DenseSet<Operation *> *shardedOps;
+  unsigned usableL1CacheSize;
+
+  llvm::DenseMap<Operation *, std::vector<Edge>> operandOpEdges;
+  llvm::DenseMap<Operation *, std::vector<Edge>> userOpEdges;
+  std::vector<PathSet> pathSets;
+  std::vector<Bitset> bitsets;
+  std::unordered_map<Edge, PathSetId> pathSetIds;
+  std::unordered_map<Operation *, BitsetId> bitsetIds;
+
+  llvm::DenseMap<Operation *, LayoutAttr> selectedOpLayout;
+  std::unordered_set<Edge> reshardedEdges;
+};
+
+} // namespace mlir::tt::ttir
+
+#endif // TTMLIR_DIALECT_TTIR_ANALYSIS_SHARDSOLVER_H

--- a/include/ttmlir/Dialect/TTIR/Analysis/ShardingAnalysis.h
+++ b/include/ttmlir/Dialect/TTIR/Analysis/ShardingAnalysis.h
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTIR_ANALYSIS_SHARDINGANALYSIS_H
+#define TTMLIR_DIALECT_TTIR_ANALYSIS_SHARDINGANALYSIS_H
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "ttmlir/Dialect/TTIR/Analysis/Edge.h"
+#include "ttmlir/Dialect/TTIR/Analysis/ShardChainConfig.h"
+#include "ttmlir/Dialect/TTIR/Analysis/TTIRAnalysis.h"
+
+namespace mlir::tt::ttir {
+
+enum class ShardingPolicyType {
+  DFSharding,
+};
+
+struct ShardingAnalysisInput {
+  llvm::DenseMap<Operation *, std::vector<LayoutAttr>> legalGrids;
+  unsigned usableL1CacheSize = 0;
+
+  ShardingAnalysisInput() : legalGrids() {}
+
+  ShardingAnalysisInput(
+      const llvm::DenseMap<Operation *, std::vector<LayoutAttr>> &legalGrids,
+      unsigned usableL1CacheSize)
+      : legalGrids(legalGrids), usableL1CacheSize(usableL1CacheSize) {}
+
+  bool operator==(const ShardingAnalysisInput &rhs) const {
+    return legalGrids == rhs.legalGrids;
+  }
+
+  bool operator!=(const ShardingAnalysisInput &rhs) const {
+    return !(*this == rhs);
+  }
+};
+
+struct ShardingAnalysisResult {
+  llvm::DenseMap<Operation *, std::vector<LayoutAttr>> legalGrids;
+  std::unordered_set<Edge> reshardedEdges;
+  llvm::DenseMap<func::FuncOp, llvm::SmallVector<Operation *>> schedule;
+
+  ShardingAnalysisResult() : legalGrids(), reshardedEdges(), schedule() {}
+
+  ShardingAnalysisResult(
+      const llvm::DenseMap<Operation *, std::vector<LayoutAttr>> &legalGrids,
+      const std::unordered_set<Edge> &reshardedEdges)
+      : legalGrids(legalGrids), reshardedEdges(reshardedEdges) {}
+};
+
+// Determine shard chain configs.
+//
+class ShardingAnalysis
+    : public TTIRAnalysis<ShardingAnalysisInput, ShardingAnalysisResult> {
+
+private:
+  void analysisImplementation() override;
+  bool applyOverrides() override;
+  std::vector<ShardChainConfig> shardChainConfigs;
+
+public:
+  ShardingAnalysis(Operation *op) : TTIRAnalysis(op) {}
+};
+} // namespace mlir::tt::ttir
+
+#endif // TTMLIR_DIALECT_TTIR_ANALYSIS_SHARDINGANALYSIS_H

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -104,6 +104,10 @@ def TTIRGridSet: Pass<"ttir-grid-set", "::mlir::ModuleOp"> {
           "llvm::StringMap<SmallVector<int64_t, 2>>",
           /*default=*/"llvm::StringMap<SmallVector<int64_t, 2>>()",
            "Override grid sizes for specific ops.">,
+    Option<"shardingPassEnabled", "sharding-pass-enabled",
+          "bool",
+          /*default=*/"false",
+           "Enable sharding pass.">,
   ];
 }
 

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -88,7 +88,16 @@ struct TTIRToTTNNBackendPipelineOptions
           llvm::cl::desc("Override grid sizes for specific ops."),
           llvm::cl::init(llvm::StringMap<SmallVector<int64_t, 2>>())};
 
-  // Option to provide a system descriptor flatbuffer file to compile against
+  // If this option is true, run sharding pass and try to shard ops.
+  //
+  Option<bool> shardingPassEnabled{
+      *this, "sharding-pass-enabled",
+      llvm::cl::desc("Enable sharding pass to shard ops."),
+      llvm::cl::init(false)};
+
+  // Option to provide a system descriptor flatbuffer file to compile
+  // against.
+  //
   Option<std::string> systemDescPath{
       *this, "system-desc-path",
       llvm::cl::desc(

--- a/lib/Dialect/TTIR/Analysis/CMakeLists.txt
+++ b/lib/Dialect/TTIR/Analysis/CMakeLists.txt
@@ -1,6 +1,10 @@
 add_mlir_dialect_library(MLIRTTIRAnalysis
         LegalGridAnalysis.cpp
-        OptimalTargetGridAnalysis.cpp
+        OpConfigAnalysis.cpp
+        ShardingAnalysis.cpp
+        ShardChainConfig.cpp
+        DFShardingPolicy.cpp
+        ShardSolver.cpp
 
         ADDITIONAL_HEADER_DIRS
         ${PROJECT_SOURCE_DIR}/include/ttmlir
@@ -9,4 +13,7 @@ add_mlir_dialect_library(MLIRTTIRAnalysis
         MLIRTTIROpsIncGen
         MLIRTTIRPassesIncGen
         MLIRTTOpsIncGen
+
+        LINK_LIBS
+        MLIRScheduler
         )

--- a/lib/Dialect/TTIR/Analysis/DFShardingPolicy.cpp
+++ b/lib/Dialect/TTIR/Analysis/DFShardingPolicy.cpp
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTIR/Analysis/DFShardingPolicy.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+#include "ttmlir/Scheduler/Scheduler.h"
+
+namespace mlir::tt::ttir {
+
+void DFShardingPolicy::run() {
+  rootOp->walk([&](func::FuncOp func) {
+    mlir::tt::scheduler::Scheduler scheduler(&func);
+    shardChainConfigs->push_back(ShardChainConfig());
+    llvm::SmallVector<mlir::Operation *> scheduleableOps;
+    Operation *currentOp = nullptr;
+
+    // Produce shard chain configs.
+    // 1. Schedule ops in DFS order.
+    // 2. Check if currentOp has a valid successor. (no forking for now)
+    // 3. Check if currentOp/nextOp pair is valid for sharding.
+    // 4. Op is considered sharded if its output is sharded to L1.
+    //
+    while (scheduler.hasUnscheduledOps()) {
+      scheduleableOps = scheduler.getScheduleableOps();
+
+      // Before starting a sharding chain, schedule ttir.to_layout ops first
+      // until they are exhausted from schedulable ops.
+      // TODO(nobradovic) :
+      // We need to examine type of to_layout op and determine if for
+      // example we have a space in DRAM to perform this?(system->dram, double
+      // check this)
+      //
+      if (shardChainConfigs->back().isEmpty()) {
+        for (auto *op : scheduleableOps) {
+          if (isa<ttir::ToLayoutOp>(op)) {
+            currentOp = op;
+            break;
+          }
+        }
+      }
+
+      if (currentOp == nullptr) {
+        currentOp = scheduleableOps[0];
+      }
+
+      // Schedule currentOp.
+      //
+      scheduler.scheduleOp(currentOp);
+
+      // Skip sharding process if currentOp is a ttir.to_layout op.
+      //
+      if (shardChainConfigs->back().isEmpty() &&
+          isa<ttir::ToLayoutOp>(currentOp)) {
+        currentOp = nullptr;
+        continue;
+      }
+
+      if (scheduler.hasUnscheduledOps()) {
+        scheduleableOps = scheduler.getScheduleableOps();
+
+        // Check if currentOp has a valid successor.
+        //
+        Operation *nextOp = nullptr;
+        for (auto *op : scheduleableOps) {
+          for (auto operand : op->getOperands()) {
+            if (operand.getDefiningOp() == currentOp) {
+              nextOp = op;
+              break;
+            }
+          }
+        }
+
+        if (nextOp) {
+
+          // V0 Before adding to shard chain config check that currentOp is not
+          // fork/join op.
+          //
+          bool validForSharding = currentOp->hasOneUse() &&
+                                  legalGrids.lookup(currentOp).size() > 0 &&
+                                  legalGrids.lookup(nextOp).size() > 0;
+
+          // TODO(nobradovic)
+          // It seems that bunch of TTNN ops have constraints which prevent
+          // them from being sharded if both inputs are interleaved, so my
+          // proposal is to try to resolve this by starting a shard chain with
+          // reshard op(at later phase only when necessary)
+          //
+
+          if (validForSharding) {
+            // Fetch largest legal sharded L1 grids for currentOp and nextOp.
+            //
+            // Calculate L1 tensor memory usage based on :
+            // currentOp output tensor shard spec, nextOp exec and nextOp output
+            // tensor.
+            //
+            LayoutAttr currentOpLayout = legalGrids.lookup(currentOp).front();
+            llvm::SmallVector<int64_t> currentOpShardShape =
+                currentOpLayout.getShardShape(false /*convertTileToScalar*/);
+            uint64_t l1InputUsage = currentOpLayout.getElementSizeBytes();
+            for (int64_t dim : currentOpShardShape) {
+              l1InputUsage *= dim;
+            }
+
+            LayoutAttr nextOpLayout = legalGrids.lookup(nextOp).front();
+            llvm::SmallVector<int64_t> nextOpShardShape =
+                nextOpLayout.getShardShape(false /*convertTileToScalar*/);
+            uint64_t l1OutputUsage = nextOpLayout.getElementSizeBytes();
+            for (int64_t dim : nextOpShardShape) {
+              l1OutputUsage *= dim;
+            }
+
+            // Figure out this const based on exec data, but will be replaced
+            // with API.
+            //
+            constexpr float tensorL1UsageCap = 0.8;
+            bool l1UsageValid = (l1InputUsage + l1OutputUsage) <
+                                tensorL1UsageCap * usableL1CacheSize;
+
+            if (l1UsageValid) {
+              // Add to shard chain config.
+              //
+              ShardSpec shardSpec;
+              shardSpec.op = currentOp;
+
+              // Hardcoded tensor split factor for now, until pipeline OP
+              // support is added.
+              //
+              shardSpec.tensorSplitFactor = 1;
+              shardChainConfigs->back().addShardSpec(std::move(shardSpec));
+              currentOp = nextOp;
+              continue;
+            }
+          }
+        }
+
+        currentOp = nullptr;
+      }
+
+      if (!shardChainConfigs->back().isEmpty()) {
+        shardChainConfigs->back().build();
+        shardChainConfigs->push_back(ShardChainConfig());
+      }
+    }
+
+    (*schedule)[func] = scheduler.getSchedule();
+  });
+
+  if (shardChainConfigs->back().isEmpty()) {
+    shardChainConfigs->pop_back();
+  }
+
+  // Resolve shard chain configs.
+  //
+  for (auto &shardChainConfig : *shardChainConfigs) {
+    ShardSolver shardSolver =
+        shardChainConfig.resolve(legalGrids, usableL1CacheSize);
+
+    // TODO(nobradovic)
+    // For now dummy fetch first legal(largest grid) for shard spec.
+    //
+    for (const auto &shardSpec : shardChainConfig.getShardSpecs()) {
+      Operation *op = shardSpec.op;
+      auto validLayouts = shardSolver.at(op);
+      shardSolver.set(op, *validLayouts.begin());
+    }
+
+    ShardSolverSolution resolvedShardSolution = shardSolver.finish();
+    shardChainConfig.complete(resolvedShardSolution.selectedOpLayout,
+                              resolvedShardSolution.reshardedEdges);
+  }
+}
+
+} // namespace mlir::tt::ttir

--- a/lib/Dialect/TTIR/Analysis/OpConfigAnalysis.cpp
+++ b/lib/Dialect/TTIR/Analysis/OpConfigAnalysis.cpp
@@ -2,26 +2,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttmlir/Dialect/TTIR/Analysis/OptimalTargetGridAnalysis.h"
+#include "ttmlir/Dialect/TTIR/Analysis/OpConfigAnalysis.h"
 
 namespace mlir::tt::ttir {
 
-bool OptimalTargetGridAnalysis::applyOverrides() {
+bool OpConfigAnalysis::applyOverrides() {
 
   // Placeholder, no overrides for now.
   //
   return false;
 }
 
-void OptimalTargetGridAnalysis::analysisImplementation() {
+void OpConfigAnalysis::analysisImplementation() {
 
-  // Implement GraphSolver like algorithm to eliminate illegal grid combinations
-  // from graph globaly.
-  // Entry point for graphsolving.
-  //
-
-  // Balancer/GridPicker implementation.
-  // Future entrypoint for balancing and picking optimal grid.
+  // Future entrypoint for picking optimal op config.
   // Placeholder: pick the first legal grid.
   //
   for (auto opGrids : analysisInput.legalGrids) {

--- a/lib/Dialect/TTIR/Analysis/ShardChainConfig.cpp
+++ b/lib/Dialect/TTIR/Analysis/ShardChainConfig.cpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTIR/Analysis/ShardChainConfig.h"
+#include "ttmlir/Dialect/TTIR/Analysis/ShardSolver.h"
+
+namespace mlir::tt::ttir {
+
+void ShardChainConfig::build() {
+  assert(state == ShardChainState::InBuild);
+  state = ShardChainState::Built;
+}
+
+ShardSolver ShardChainConfig::resolve(
+    const llvm::DenseMap<Operation *, std::vector<LayoutAttr>> &legalGrids,
+    unsigned usableL1CacheSize) {
+  assert(state == ShardChainState::Built);
+
+  // Reconcile adjacent shard specs.
+  // Generate reshard specs where needed.
+  //
+  ShardSolver shardSolver(legalGrids, shardSpecs, shardedOps,
+                          usableL1CacheSize);
+  state = ShardChainState::Resolved;
+
+  return shardSolver;
+}
+
+void ShardChainConfig::complete(
+    const llvm::DenseMap<Operation *, LayoutAttr> &selectedOpLayout,
+    std::unordered_set<Edge> &reshardedEdges) {
+  assert(state == ShardChainState::Resolved);
+  for (auto &shardSpec : shardSpecs) {
+    auto legalGridsIter = selectedOpLayout.find(shardSpec.op);
+    assert(legalGridsIter != selectedOpLayout.end());
+
+    shardSpec.layout = legalGridsIter->second;
+  }
+
+  this->reshardedEdges.swap(reshardedEdges);
+  state = ShardChainState::Completed;
+}
+
+} // namespace mlir::tt::ttir

--- a/lib/Dialect/TTIR/Analysis/ShardSolver.cpp
+++ b/lib/Dialect/TTIR/Analysis/ShardSolver.cpp
@@ -1,0 +1,467 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTIR/Analysis/ShardSolver.h"
+#include "ttmlir/Dialect/TTIR/Analysis/ShardChainConfig.h"
+#include <mlir/Interfaces/DestinationStyleOpInterface.h>
+
+namespace mlir::tt::ttir {
+
+ShardSolver::Bitset ShardSolver::kBitsetAll = ~kBitsetNone;
+
+ShardSolver::ShardSolver(
+    const llvm::DenseMap<Operation *, std::vector<LayoutAttr>> &legalGrids,
+    const std::vector<ShardSpec> &shardSpecs,
+    const llvm::DenseSet<Operation *> &shardedOps,
+    const unsigned usableL1CacheSize)
+    : legalGrids(&legalGrids), shardSpecs(&shardSpecs), shardedOps(&shardedOps),
+      usableL1CacheSize(usableL1CacheSize) {
+  pathSets.reserve(shardSpecs.size());
+  pathSetIds.reserve(shardSpecs.size());
+  bitsets.reserve(shardedOps.size());
+  bitsetIds.reserve(shardedOps.size());
+
+  // Populate operandOpEdges and userOpEdges.
+  //
+  for (const auto shardSpec : shardSpecs) {
+    Operation *op = shardSpec.op;
+    for (size_t operandIndex = 0; operandIndex < op->getNumOperands();
+         operandIndex++) {
+      Value operand = op->getOperand(operandIndex);
+      Operation *operandOp = operand.getDefiningOp();
+      if (operandOp && shardedOps.count(operandOp) > 0) {
+        operandOpEdges[op].emplace_back(Edge(operandOp, op, operandIndex));
+        userOpEdges[operandOp].emplace_back(Edge(operandOp, op, operandIndex));
+      }
+    }
+  }
+
+  // Resolve shard chain.
+  //
+  resolve();
+}
+
+void ShardSolver::reset() {
+  pathSets.clear();
+  pathSetIds.clear();
+  bitsets.clear();
+  bitsetIds.clear();
+}
+
+bool ShardSolver::resolveStep() {
+  OperationPathsProcessor opProcessor;
+  bitsets.reserve(shardedOps->size());
+  bitsetIds.reserve(shardedOps->size());
+  selectedOpLayout.reserve(shardedOps->size());
+  bool reshardInserted = false;
+
+  for (const auto shardSpec : *shardSpecs) {
+    Operation *consumerOp = shardSpec.op;
+    Bitset *consumerBitset = getOrInsertBitset(consumerOp, kBitsetAll);
+    std::vector<LayoutAttr> const &consumerGrids = getLegalGrids(consumerOp);
+
+    for (Edge edge : operandOpEdges[consumerOp]) {
+
+      bool reshardOnEdge = reshardedEdges.count(edge) > 0;
+
+      Operation *producerOp = edge.producerOp;
+      Bitset *producerBitset = getOrInsertBitset(producerOp, kBitsetAll);
+      std::vector<LayoutAttr> const &producerGrids = getLegalGrids(producerOp);
+
+      assert(not(consumerGrids.empty() && producerGrids.empty()));
+
+      PathSet::Paths paths;
+      Bitset edgeProducerBitset = kBitsetNone;
+      Bitset edgeConsumerBitset = kBitsetNone;
+      std::uint64_t producer_count =
+          std::min(kNumBitsetBits, std::max(1lu, producerGrids.size()));
+      std::uint64_t consumer_count =
+          std::min(kNumBitsetBits, std::max(1lu, consumerGrids.size()));
+      for (std::uint64_t producerId = 0; producerId < producer_count;
+           ++producerId) {
+        // If the producer cannot accomodate this path, continue.
+        // Also if this is not the LayoutAttr we selected, continue.
+        //
+        if (!producerBitset->test(producerId)) {
+          continue;
+        }
+
+        for (std::uint64_t consumerId = 0; consumerId < consumer_count;
+             ++consumerId) {
+
+          // If the consumer cannot accomodate this path, continue.
+          //
+          if (!consumerBitset->test(consumerId)) {
+            continue;
+          }
+
+          // TODO(nobradovic):
+          // Update checkShardCompatible with op type, other input
+          // spec(weight).
+          //
+          bool validShardPair =
+              reshardOnEdge ||
+              checkShardCompatible(producerOp, producerGrids[producerId],
+                                   consumerOp, consumerGrids[consumerId]);
+
+          if (validShardPair) {
+            assert(producerId <=
+                   std::numeric_limits<decltype(Path::producerId)>::max());
+            assert(consumerId <=
+                   std::numeric_limits<decltype(Path::consumerId)>::max());
+            paths.push_back(Path(producerId, consumerId));
+            edgeProducerBitset.set(producerId);
+            edgeConsumerBitset.set(consumerId);
+          }
+        }
+      }
+
+      if (paths.empty() || ((*producerBitset & edgeProducerBitset) == 0) ||
+          ((*consumerBitset & edgeConsumerBitset) == 0)) {
+
+        // No valid paths found for this edge, lets try self-cutting if enabled.
+        //
+        insertReshard(edge);
+        reshardInserted = true;
+        *consumerBitset = kBitsetAll;
+      }
+
+      if (!isSubset(*producerBitset, edgeProducerBitset) && !reshardInserted) {
+        opProcessor.addOp(producerOp);
+      }
+
+      *producerBitset &= edgeProducerBitset;
+      *consumerBitset &= edgeConsumerBitset;
+      assert(pathSetIds.find(edge) == pathSetIds.end());
+      PathSetId pathSetId = static_cast<PathSetId>(pathSets.size());
+      pathSets.emplace_back(bitsetIds[producerOp], bitsetIds[consumerOp],
+                            producerOp, consumerOp, paths);
+      pathSetIds.emplace(edge, pathSetId);
+    }
+
+    if (!reshardInserted) {
+      opProcessor.process(this);
+    }
+  }
+
+  if (reshardInserted) {
+    return false;
+  }
+
+  for (const auto shardSpec : *shardSpecs) {
+    Operation *op = shardSpec.op;
+
+    // No need to expand root as we are calling for all ops anyway.
+    //
+    updateSolver(op, false /* expand_root */);
+  }
+
+  return true;
+}
+
+void ShardSolver::insertReshard(const Edge &edge) {
+  // Same edge should not be resharded twice!
+  //
+  assert(reshardedEdges.count(edge) == 0);
+  reshardedEdges.insert(edge);
+}
+
+void ShardSolver::resolve() {
+
+  const int max_retry_step = shardedOps->size() + 1;
+  int retry_step = 1;
+  bool resolved = false;
+
+  do {
+    // Reset ShardSolver to default state.
+    //
+    reset();
+
+    // Try to resolve shard chain. Retry if not resolved(resharding).
+    //
+    resolved = resolveStep();
+    retry_step++;
+  } while (!resolved && retry_step <= max_retry_step);
+
+  assert(resolved);
+}
+
+ShardSolver::PathSet *ShardSolver::getPathSetPt(const Edge &edge) {
+  if (pathSetIds.count(edge) > 0) {
+    return &pathSets[pathSetIds.at(edge)];
+  }
+
+  return nullptr;
+}
+
+SmallVector<ShardSolver::PathSet *>
+ShardSolver::getOperandPathSetsPts(Operation *op) {
+  SmallVector<PathSet *> operandPathSets;
+  for (auto edge : operandOpEdges[op]) {
+    PathSet *el = getPathSetPt(edge);
+    if (nullptr != el) {
+      operandPathSets.push_back(el);
+    }
+  }
+
+  return operandPathSets;
+}
+
+SmallVector<ShardSolver::PathSet *>
+ShardSolver::getUserPathSetsPts(Operation *op) {
+  SmallVector<PathSet *> userPathSets;
+  for (auto edge : userOpEdges[op]) {
+    PathSet *el = getPathSetPt(edge);
+    if (nullptr != el) {
+      userPathSets.push_back(el);
+    }
+  }
+
+  return userPathSets;
+}
+
+void ShardSolver::addOperandsAndUsers(Operation *op,
+                                      std::vector<Operation *> &needsUpdate,
+                                      Operation *ignoreOp) {
+
+  for (auto operand : op->getOperands()) {
+    Operation *opOperand = operand.getDefiningOp();
+    if (opOperand == nullptr ||
+        !llvm::isa<mlir::DestinationStyleOpInterface>(opOperand) ||
+        opOperand == ignoreOp || shardedOps->count(opOperand) == 0) {
+      continue;
+    }
+
+    needsUpdate.push_back(opOperand);
+  }
+
+  for (Operation *opUser : op->getUsers()) {
+    if (opUser == nullptr || opUser == ignoreOp ||
+        shardedOps->count(opUser) == 0) {
+      continue;
+    }
+
+    needsUpdate.push_back(opUser);
+  }
+}
+
+void ShardSolver::handleNoPathsLeftOnUpdate(bool invokedBySet) {
+  // We ended-up in a situation without valid solution due to circular
+  // dependency.
+  //
+  assert(invokedBySet);
+
+  // Invoking resolve again will use resharding to resolve the issue.
+  //
+  return resolve();
+}
+
+void ShardSolver::updateSolver(Operation *root, bool expand_root,
+                               bool invokedBySet) {
+  std::vector<Operation *> needsUpdate = {root};
+
+  if (expand_root) {
+    auto operandPathSets = getOperandPathSetsPts(root);
+    auto userPathSets = getUserPathSetsPts(root);
+
+    for (auto *path_set : operandPathSets) {
+      path_set->update(bitsets);
+    }
+
+    for (auto *path_set : userPathSets) {
+      path_set->update(bitsets);
+    }
+
+    // When op bitsets are updated(set of valid op grids), we need to update
+    // paths for all operands and users.
+    //
+    addOperandsAndUsers(root, needsUpdate);
+  }
+
+  // Iterate through the ops that need to be updated and update their operand
+  // and user path sets.
+  while (not needsUpdate.empty()) {
+    auto *op = needsUpdate.back();
+
+    // Get path sets for incoming edges
+    auto operandPathSets = getOperandPathSetsPts(op);
+    // Get path sets for outgoing edges
+    auto userPathSets = getUserPathSetsPts(op);
+
+    bool edge_changed = false;
+
+    std::vector<bool> producersChanged(operandPathSets.size());
+    for (size_t i = 0; i < operandPathSets.size(); i++) {
+      auto *operandPathSet = operandPathSets[i];
+      producersChanged[i] = operandPathSet->update(bitsets);
+
+      if (operandPathSet->empty(bitsets)) {
+        return handleNoPathsLeftOnUpdate(invokedBySet);
+      }
+    }
+
+    std::vector<bool> consumers_changed(userPathSets.size());
+    for (size_t i = 0; i < userPathSets.size(); i++) {
+      auto *userPathSet = userPathSets[i];
+      consumers_changed[i] = userPathSet->update(bitsets);
+
+      if (userPathSet->empty(bitsets)) {
+        return handleNoPathsLeftOnUpdate(invokedBySet);
+      }
+    }
+
+    // If any of the paths between producer and this consumer changed, we need
+    // to visit producer op and add its operands and users to the needsUpdate
+    // list.
+    for (size_t i = 0; i < producersChanged.size(); i++) {
+      if (producersChanged[i]) {
+        Operation *producerOp = operandPathSets[i]->getProducerOp();
+        needsUpdate.push_back(producerOp);
+        addOperandsAndUsers(producerOp, needsUpdate, op);
+
+        edge_changed = true;
+      }
+    }
+
+    // If any of the paths between this producer and consumer changed, we need
+    // to visit consumer op and add its operands and users to the needsUpdate
+    // list.
+    for (size_t i = 0; i < consumers_changed.size(); i++) {
+      if (consumers_changed[i]) {
+        Operation *consumerOp = userPathSets[i]->getConsumerOp();
+        needsUpdate.push_back(consumerOp);
+        addOperandsAndUsers(consumerOp, needsUpdate, op);
+
+        edge_changed = true;
+      }
+    }
+
+    if (not edge_changed) {
+      needsUpdate.pop_back();
+    }
+  }
+}
+
+ShardSolver::Bitset *ShardSolver::getBitset(Operation *op) {
+  return &bitsets[bitsetIds.at(op)];
+}
+
+ShardSolver::Bitset const *ShardSolver::getBitset(Operation *op) const {
+  return &bitsets[bitsetIds.at(op)];
+}
+
+ShardSolver::Bitset *ShardSolver::getOrInsertBitset(Operation *op,
+                                                    const Bitset &init) {
+  auto match = bitsetIds.find(op);
+  if (match == bitsetIds.end()) {
+    BitsetId bitset_id = bitsets.size();
+    bitsetIds.insert({op, bitset_id});
+    auto *tmp = bitsets.data();
+    bitsets.push_back(init);
+
+    // Bitsets reallocated, pointers invalid.
+    //
+    assert(tmp == bitsets.data());
+    return &bitsets.back();
+  }
+
+  return &bitsets[match->second];
+}
+
+// Returns vector of legal LayoutAttrs for passed in op.
+//
+const std::vector<LayoutAttr> &ShardSolver::getLegalGrids(Operation *op) const {
+  static std::vector<LayoutAttr> nullGrids;
+
+  const auto legalIt = legalGrids->find(op);
+
+  if (legalIt != legalGrids->end()) {
+    return legalIt->second;
+  }
+
+  return nullGrids;
+}
+
+ShardSolver::RemainingLayoutAttrs ShardSolver::at(Operation *op) const {
+  auto grids = RemainingLayoutAttrs(getLegalGrids(op), *getBitset(op));
+  assert(grids.begin() != grids.end());
+  return grids;
+}
+
+void ShardSolver::set(Operation *op, LayoutAttr const &grid) {
+  assert(selectedOpLayout.count(op) == 0);
+
+  selectedOpLayout[op] = grid;
+
+  auto const &grids = getLegalGrids(op);
+  assert(!grids.empty());
+  size_t selection = grids.size();
+  for (size_t i = 0; i < grids.size(); ++i) {
+    if (grids[i] == grid) {
+      selection = i;
+      break;
+    }
+  }
+
+  Bitset *op_bitset = getBitset(op);
+
+  assert(selection != grids.size());
+  assert((*op_bitset)[selection]);
+
+  op_bitset->reset();
+  op_bitset->set(selection);
+
+  updateSolver(op, true /*expand_root*/, true /*invokedBySet*/);
+}
+
+bool ShardSolver::checkShardCompatible(const Operation *producerOp,
+                                       LayoutAttr const &producerLayout,
+                                       const Operation *consumerOp,
+                                       LayoutAttr const &consumerLayout) const {
+
+  // TEMP : Dummy mock implementation, will be replaced.
+  //
+
+  // May need to fetch other inputs for consumerOp(weights/join node).
+  //
+
+  // Need to plug shard checking API.
+  //
+
+  // Need to plug API for L1 usage.
+  //
+  // Calculate L1 tensor memory usage based on :
+  // currentOp output tensor shard spec, nextOp exec and nextOp output
+  // tensor.
+  //
+  llvm::SmallVector<int64_t> producerOpShardShape =
+      producerLayout.getShardShape(false /*convertTileToScalar*/);
+  uint64_t l1InputUsage = producerLayout.getElementSizeBytes();
+  for (int64_t dim : producerOpShardShape) {
+    l1InputUsage *= dim;
+  }
+
+  llvm::SmallVector<int64_t> consumerOpShardShape =
+      consumerLayout.getShardShape(false /*convertTileToScalar*/);
+  uint64_t l1OutputUsage = consumerLayout.getElementSizeBytes();
+  for (int64_t dim : consumerOpShardShape) {
+    l1OutputUsage *= dim;
+  }
+
+  // Figure out this const based on exec data, but will be replaced
+  // with API.
+  //
+  constexpr float tensorL1UsageCap = 0.8;
+  bool l1UsageValid =
+      (l1InputUsage + l1OutputUsage) < tensorL1UsageCap * usableL1CacheSize;
+
+  return l1UsageValid;
+}
+
+// Returns ShardSolverSolution.
+//
+ShardSolverSolution const ShardSolver::finish() {
+  return ShardSolverSolution(selectedOpLayout, reshardedEdges);
+}
+} // namespace mlir::tt::ttir

--- a/lib/Dialect/TTIR/Analysis/ShardingAnalysis.cpp
+++ b/lib/Dialect/TTIR/Analysis/ShardingAnalysis.cpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTIR/Analysis/ShardingAnalysis.h"
+#include "ttmlir/Dialect/TTIR/Analysis/DFShardingPolicy.h"
+
+namespace mlir::tt::ttir {
+
+bool ShardingAnalysis::applyOverrides() {
+
+  // TODO(nobradovic):
+  // Placeholder, no overrides for now.
+  //
+  return false;
+}
+
+llvm::DenseMap<Operation *, std::vector<LayoutAttr>> filterShardedOnly(
+    const llvm::DenseMap<Operation *, std::vector<LayoutAttr>> &legalGrids) {
+  llvm::DenseMap<Operation *, std::vector<LayoutAttr>> shardedGrids;
+  for (const auto &opGrids : legalGrids) {
+    std::vector<LayoutAttr> shardedLayouts;
+    for (const auto &layout : opGrids.second) {
+      if (layout.hasShardedTensorMemoryLayout()) {
+        shardedLayouts.push_back(layout);
+      }
+    }
+
+    shardedGrids[opGrids.first] = shardedLayouts;
+  }
+
+  return shardedGrids;
+}
+
+void ShardingAnalysis::analysisImplementation() {
+  ShardingPolicyType policy = ShardingPolicyType::DFSharding;
+
+  switch (policy) {
+  case ShardingPolicyType::DFSharding:
+    DFShardingPolicy dfShardingPolicy(
+        op, shardChainConfigs, filterShardedOnly(analysisInput.legalGrids),
+        analysisResult.schedule, analysisInput.usableL1CacheSize);
+    dfShardingPolicy.run();
+    break;
+  }
+
+  // Copy over default legal layouts.
+  //
+  analysisResult.legalGrids = analysisInput.legalGrids;
+
+  // Override with shard chain configs where applicable.
+  //
+  for (const auto &shardChainConfig : shardChainConfigs) {
+    assert(shardChainConfig.getState() == ShardChainState::Completed);
+    for (const auto &shardSpec : shardChainConfig.getShardSpecs()) {
+      analysisResult.legalGrids[shardSpec.op] =
+          std::vector<LayoutAttr>{shardSpec.layout};
+    }
+  }
+}
+} // namespace mlir::tt::ttir

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -36,6 +36,7 @@ void createTTIRToTTNNBackendPipeline(
   if (options.gridSetPassEnabled) {
     ttir::TTIRGridSetOptions gridSetOptions;
     gridSetOptions.overrideGridSizes = options.overrideGridSizes;
+    gridSetOptions.shardingPassEnabled = options.shardingPassEnabled;
     pm.addPass(mlir::tt::ttir::createTTIRGridSet(gridSetOptions));
   }
   pm.addPass(createConvertTTIRToTTNNPass());

--- a/test/ttmlir/Dialect/TTNN/mnist_sharding.mlir
+++ b/test/ttmlir/Dialect/TTNN/mnist_sharding.mlir
@@ -1,0 +1,40 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="sharding-pass-enabled=true" %s | FileCheck %s
+#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
+#loc = loc("MNISTLinear":4294967295:0)
+module @"tt-forge-graph" attributes {} {
+  func.func @main(%arg0: tensor<1x784xf32> loc("MNISTLinear":4294967295:0), %arg1: tensor<1x10xf32> loc("MNISTLinear":4294967295:0), %arg2: tensor<256x10xf32> loc("MNISTLinear":4294967295:0), %arg3: tensor<1x256xf32> loc("MNISTLinear":4294967295:0), %arg4: tensor<784x256xf32> loc("MNISTLinear":4294967295:0)) -> tensor<1x10xf32> {
+    // CHECK: #[[LAYOUT_10:.*]] = #tt.layout<(d0, d1) -> (d0, d1), undef, <1x8>, memref<1x32xf32, #l1_>, block_sharded>
+    // CHECK: #[[LAYOUT_11:.*]] = #tt.layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<1x10xf32, #l1_>, block_sharded>
+    %0 = tensor.empty() : tensor<1x256xf32> loc(#loc8)
+    // CHECK: %[[C:.*]] = "ttnn.matmul"[[C:.*]] -> tensor<1x256xf32, #[[LAYOUT_10]]>
+    %1 = "ttir.matmul"(%arg0, %arg4, %0) <{operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<1x784xf32>, tensor<784x256xf32>, tensor<1x256xf32>) -> tensor<1x256xf32> loc(#loc8)
+    %2 = tensor.empty() : tensor<1x256xf32> loc(#loc9)
+    // CHECK: %[[C:.*]] = "ttnn.add"[[C:.*]] -> tensor<1x256xf32, #[[LAYOUT_10]]>
+    %3 = "ttir.add"(%1, %arg3, %2) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<1x256xf32>, tensor<1x256xf32>, tensor<1x256xf32>) -> tensor<1x256xf32> loc(#loc9)
+    %4 = tensor.empty() : tensor<1x256xf32> loc(#loc10)
+    // CHECK: %[[C:.*]] = "ttnn.relu"[[C:.*]] -> tensor<1x256xf32, #[[LAYOUT_10]]>
+    %5 = "ttir.relu"(%3, %4) <{operandSegmentSizes = array<i32: 1, 1>, operand_constraints = [#any_device, #any_device]}> : (tensor<1x256xf32>, tensor<1x256xf32>) -> tensor<1x256xf32> loc(#loc10)
+    %6 = tensor.empty() : tensor<1x10xf32> loc(#loc11)
+    // CHECK: %[[C:.*]] = "ttnn.matmul"[[C:.*]] -> tensor<1x10xf32, #[[LAYOUT_11]]>
+    %7 = "ttir.matmul"(%5, %arg2, %6) <{operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<1x256xf32>, tensor<256x10xf32>, tensor<1x10xf32>) -> tensor<1x10xf32> loc(#loc11)
+    %8 = tensor.empty() : tensor<1x10xf32> loc(#loc12)
+    // CHECK: %[[C:.*]] = "ttnn.add"[[C:.*]] -> tensor<1x10xf32, #[[LAYOUT_11]]>
+    %9 = "ttir.add"(%7, %arg1, %8) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<1x10xf32>, tensor<1x10xf32>, tensor<1x10xf32>) -> tensor<1x10xf32> loc(#loc12)
+    %10 = tensor.empty() : tensor<1x10xf32> loc(#loc13)
+    %11 = "ttir.softmax"(%9, %10) <{dimension = 1 : si32, operand_constraints = [#any_device, #any_device]}> : (tensor<1x10xf32>, tensor<1x10xf32>) -> tensor<1x10xf32> loc(#loc13)
+    return %11 : tensor<1x10xf32> loc(#loc7)
+  } loc(#loc)
+} loc(#loc)
+#loc1 = loc("MNISTLinear":4294967295:10)
+#loc2 = loc("MNISTLinear":4294967295:8)
+#loc3 = loc("MNISTLinear":4294967295:6)
+#loc4 = loc("MNISTLinear":4294967295:4)
+#loc5 = loc("MNISTLinear":4294967295:3)
+#loc6 = loc("MNISTLinear":4294967295:2)
+#loc7 = loc(unknown)
+#loc8 = loc("matmul_1"(#loc1))
+#loc9 = loc("add_2"(#loc2))
+#loc10 = loc("relu_3"(#loc3))
+#loc11 = loc("matmul_5"(#loc4))
+#loc12 = loc("add_6"(#loc5))
+#loc13 = loc("softmax_7"(#loc6))


### PR DESCRIPTION
First iteration of DF sharding policy v0 per Optimizer design spec.
Implemented so far:
Core of DF Sharding policy, Shard chan config, Shard spec and Shard solver.
Scheduler integration into DFSp and corresponding transformation via MLIR op reordering.
Base analysis for reshard generation.

Lots of work remains to be done and is pending, this is current snapshot before moving on. Sharding pass option added to pass and TTNN pipeline, will remain in default off until code is more stable(under construction).
TTNN Op constraints are already big issue(sharding ones for start) and prevent MNIST model running E2E with current change.

More details: Issue related #570 
