### PR TITLE
[Optimizer] DF sharding policy - part2.

### DIFF
--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -283,6 +283,7 @@ def TT_LayoutAttr : TT_Attr<"Layout", "layout"> {
       bool isSystemMemorySpace() const { return ::mlir::tt::isSystemMemorySpace(getMemorySpace()); }
       bool isDeviceMemorySpace() const { return ::mlir::tt::isDeviceMemorySpace(getMemorySpace()); }
       bool hasShardedTensorMemoryLayout() const;
+      bool hasShardedL1TensorMemoryLayout() const;
       bool isTiled() const;
       Type getElementType() const;
       Type getScalarElementType() const;

--- a/include/ttmlir/Dialect/TTIR/Analysis/DFShardingPolicy.h
+++ b/include/ttmlir/Dialect/TTIR/Analysis/DFShardingPolicy.h
@@ -17,18 +17,18 @@ class DFShardingPolicy {
 private:
   Operation *rootOp;
   std::vector<ShardChainConfig> *shardChainConfigs;
-  llvm::DenseMap<Operation *, std::vector<LayoutAttr>> legalGrids;
+  llvm::DenseMap<Operation *, std::vector<LayoutAttr>> legalLayouts;
   llvm::DenseMap<func::FuncOp, llvm::SmallVector<Operation *>> *schedule;
   unsigned usableL1CacheSize = 0;
 
 public:
   DFShardingPolicy(
       Operation *rootOp, std::vector<ShardChainConfig> &shardChainConfigs,
-      const llvm::DenseMap<Operation *, std::vector<LayoutAttr>> &legalGrids,
+      const llvm::DenseMap<Operation *, std::vector<LayoutAttr>> &legalLayouts,
       llvm::DenseMap<func::FuncOp, llvm::SmallVector<Operation *>> &schedule,
       unsigned usableL1CacheSize)
       : rootOp(rootOp), shardChainConfigs(&shardChainConfigs),
-        legalGrids(legalGrids), schedule(&schedule),
+        legalLayouts(legalLayouts), schedule(&schedule),
         usableL1CacheSize(usableL1CacheSize) {}
 
   void run();

--- a/include/ttmlir/Dialect/TTIR/Analysis/ShardChainConfig.h
+++ b/include/ttmlir/Dialect/TTIR/Analysis/ShardChainConfig.h
@@ -37,7 +37,7 @@ public:
   ShardChainConfig() : shardSpecs(), state() {}
 
   ShardSolver resolve(
-      const llvm::DenseMap<Operation *, std::vector<LayoutAttr>> &legalGrids,
+      const llvm::DenseMap<Operation *, std::vector<LayoutAttr>> &legalLayouts,
       unsigned usableL1CacheSize);
   void build();
   void complete(const llvm::DenseMap<Operation *, LayoutAttr> &selectedOpLayout,
@@ -51,6 +51,9 @@ public:
   }
   const std::vector<ShardSpec> &getShardSpecs() const { return shardSpecs; }
   ShardChainState getState() const { return state; }
+  const std::unordered_set<Edge> &getReshardedEdges() const {
+    return reshardedEdges;
+  }
 };
 
 } // namespace mlir::tt::ttir

--- a/include/ttmlir/Dialect/TTIR/Analysis/ShardSolver.h
+++ b/include/ttmlir/Dialect/TTIR/Analysis/ShardSolver.h
@@ -246,7 +246,7 @@ private:
     Paths paths;
   };
 
-  const std::vector<LayoutAttr> &getLegalGrids(Operation *operation) const;
+  const std::vector<LayoutAttr> &getLegalLayouts(Operation *operation) const;
   void reset();
 
   PathSet *getPathSetPt(const Edge &edge);
@@ -267,14 +267,15 @@ private:
   void addOperandsAndUsers(Operation *op, std::vector<Operation *> &needsUpdate,
                            Operation *ignoreOp = nullptr);
 
-  bool checkShardCompatible(const Operation *producerOp,
+  void preprocessFirstOp();
+  bool checkShardCompatible(Operation *producerOp,
                             LayoutAttr const &producerLayout,
-                            const Operation *consumerOp,
+                            Operation *consumerOp,
                             LayoutAttr const &consumerLayout) const;
 
 public:
   ShardSolver(
-      const llvm::DenseMap<Operation *, std::vector<LayoutAttr>> &legalGrids,
+      const llvm::DenseMap<Operation *, std::vector<LayoutAttr>> &legalLayouts,
       const std::vector<ShardSpec> &shardSpecs,
       const llvm::DenseSet<Operation *> &shardedOps,
       const unsigned usableL1CacheSize);
@@ -282,10 +283,11 @@ public:
   void set(Operation *operation, LayoutAttr const &layout);
 
 private:
-  const llvm::DenseMap<Operation *, std::vector<LayoutAttr>> *legalGrids;
+  const llvm::DenseMap<Operation *, std::vector<LayoutAttr>> *legalLayouts;
   const std::vector<ShardSpec> *shardSpecs;
   const llvm::DenseSet<Operation *> *shardedOps;
   unsigned usableL1CacheSize;
+  DeviceAttr deviceAttr;
 
   llvm::DenseMap<Operation *, std::vector<Edge>> operandOpEdges;
   llvm::DenseMap<Operation *, std::vector<Edge>> userOpEdges;

--- a/include/ttmlir/Dialect/TTIR/Analysis/ShardingAnalysis.h
+++ b/include/ttmlir/Dialect/TTIR/Analysis/ShardingAnalysis.h
@@ -17,18 +17,18 @@ enum class ShardingPolicyType {
 };
 
 struct ShardingAnalysisInput {
-  llvm::DenseMap<Operation *, std::vector<LayoutAttr>> legalGrids;
+  llvm::DenseMap<Operation *, std::vector<LayoutAttr>> legalLayouts;
   unsigned usableL1CacheSize = 0;
 
-  ShardingAnalysisInput() : legalGrids() {}
+  ShardingAnalysisInput() : legalLayouts() {}
 
   ShardingAnalysisInput(
-      const llvm::DenseMap<Operation *, std::vector<LayoutAttr>> &legalGrids,
+      const llvm::DenseMap<Operation *, std::vector<LayoutAttr>> &legalLayouts,
       unsigned usableL1CacheSize)
-      : legalGrids(legalGrids), usableL1CacheSize(usableL1CacheSize) {}
+      : legalLayouts(legalLayouts), usableL1CacheSize(usableL1CacheSize) {}
 
   bool operator==(const ShardingAnalysisInput &rhs) const {
-    return legalGrids == rhs.legalGrids;
+    return legalLayouts == rhs.legalLayouts;
   }
 
   bool operator!=(const ShardingAnalysisInput &rhs) const {
@@ -37,16 +37,16 @@ struct ShardingAnalysisInput {
 };
 
 struct ShardingAnalysisResult {
-  llvm::DenseMap<Operation *, std::vector<LayoutAttr>> legalGrids;
+  llvm::DenseMap<Operation *, std::vector<LayoutAttr>> legalLayouts;
   std::unordered_set<Edge> reshardedEdges;
   llvm::DenseMap<func::FuncOp, llvm::SmallVector<Operation *>> schedule;
 
-  ShardingAnalysisResult() : legalGrids(), reshardedEdges(), schedule() {}
+  ShardingAnalysisResult() : legalLayouts(), reshardedEdges(), schedule() {}
 
   ShardingAnalysisResult(
-      const llvm::DenseMap<Operation *, std::vector<LayoutAttr>> &legalGrids,
+      const llvm::DenseMap<Operation *, std::vector<LayoutAttr>> &legalLayouts,
       const std::unordered_set<Edge> &reshardedEdges)
-      : legalGrids(legalGrids), reshardedEdges(reshardedEdges) {}
+      : legalLayouts(legalLayouts), reshardedEdges(reshardedEdges) {}
 };
 
 // Determine shard chain configs.

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -93,7 +93,7 @@ def TTIRAllocate: Pass<"ttir-allocate", "::mlir::ModuleOp"> {
   }];
 }
 
-def TTIRGridSet: Pass<"ttir-grid-set", "::mlir::ModuleOp"> {
+def TTIROptimizer: Pass<"ttir-optimizer", "::mlir::ModuleOp"> {
   let summary = "Determine grid size for ops.";
   let description = [{
     Go through the ops, set grid size for each op based on grid analysis,
@@ -108,6 +108,10 @@ def TTIRGridSet: Pass<"ttir-grid-set", "::mlir::ModuleOp"> {
           "bool",
           /*default=*/"false",
            "Enable sharding pass.">,
+    Option<"reshardingEnabled", "resharding-enabled",
+          "bool",
+          /*default=*/"false",
+          "Resharding pass. Temp disabled till we support all types of shard specs.">,
   ];
 }
 

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -64,12 +64,11 @@ public:
 //
 struct TTIRToTTNNBackendPipelineOptions
     : public PassPipelineOptions<TTIRToTTNNBackendPipelineOptions> {
-  // If this option is true, run GridSet pass and try setting max available grid
-  // size for OP execution.
-  // If this option is false, skip running GridSet pass,
-  // thus leaving all ops on 1x1 grid.
-  Option<bool> gridSetPassEnabled{
-      *this, "enable-grid-set",
+  // If this option is true, run Optimizer trying to set optimal Op
+  // configuration for max performance. If this option is false, skip running
+  // Optimizer pass, thus leaving all ops on default configuration.
+  Option<bool> optimizerPassEnabled{
+      *this, "enable-optimizer",
       llvm::cl::desc("Determine and set max valid grid for Op execution."),
       llvm::cl::init(true)};
 
@@ -80,7 +79,7 @@ struct TTIRToTTNNBackendPipelineOptions
   //
   // This will set the grid size for op1 to 2x2 and op2 to 4x4.
   //
-  // Note: This option is only valid if gridSetPassEnabled is true.
+  // Note: This option is only valid if optimizerPassEnabled is true.
   //
   Option<llvm::StringMap<SmallVector<int64_t, 2>>, GridSizeOverrideParser>
       overrideGridSizes{

--- a/lib/Dialect/TT/IR/TTOpsTypes.cpp
+++ b/lib/Dialect/TT/IR/TTOpsTypes.cpp
@@ -573,6 +573,12 @@ mlir::Type LayoutAttr::getScalarElementType() const {
 }
 
 bool LayoutAttr::hasShardedTensorMemoryLayout() const {
+  return (getMemLayout() == TensorMemoryLayout::HeightSharded or
+          getMemLayout() == TensorMemoryLayout::WidthSharded or
+          getMemLayout() == TensorMemoryLayout::BlockSharded);
+}
+
+bool LayoutAttr::hasShardedL1TensorMemoryLayout() const {
   return ::mlir::tt::isL1MemorySpace(getMemorySpace()) and
          (getMemLayout() == TensorMemoryLayout::HeightSharded or
           getMemLayout() == TensorMemoryLayout::WidthSharded or

--- a/lib/Dialect/TTIR/Analysis/DFShardingPolicy.cpp
+++ b/lib/Dialect/TTIR/Analysis/DFShardingPolicy.cpp
@@ -10,6 +10,7 @@ namespace mlir::tt::ttir {
 
 void DFShardingPolicy::run() {
   rootOp->walk([&](func::FuncOp func) {
+    DeviceAttr deviceAttr = getCurrentScopeDevice(func);
     mlir::tt::scheduler::Scheduler scheduler(&func);
     shardChainConfigs->push_back(ShardChainConfig());
     llvm::SmallVector<mlir::Operation *> scheduleableOps;
@@ -77,59 +78,94 @@ void DFShardingPolicy::run() {
           // fork/join op.
           //
           bool validForSharding = currentOp->hasOneUse() &&
-                                  legalGrids.lookup(currentOp).size() > 0 &&
-                                  legalGrids.lookup(nextOp).size() > 0;
-
-          // TODO(nobradovic)
-          // It seems that bunch of TTNN ops have constraints which prevent
-          // them from being sharded if both inputs are interleaved, so my
-          // proposal is to try to resolve this by starting a shard chain with
-          // reshard op(at later phase only when necessary)
-          //
+                                  legalLayouts.lookup(currentOp).size() > 0 &&
+                                  legalLayouts.lookup(nextOp).size() > 0;
 
           if (validForSharding) {
-            // Fetch largest legal sharded L1 grids for currentOp and nextOp.
+            // Fetch largest legal sharded L1 layouts for currentOp and nextOp.
             //
             // Calculate L1 tensor memory usage based on :
             // currentOp output tensor shard spec, nextOp exec and nextOp output
             // tensor.
             //
-            LayoutAttr currentOpLayout = legalGrids.lookup(currentOp).front();
-            llvm::SmallVector<int64_t> currentOpShardShape =
-                currentOpLayout.getShardShape(false /*convertTileToScalar*/);
-            uint64_t l1InputUsage = currentOpLayout.getElementSizeBytes();
-            for (int64_t dim : currentOpShardShape) {
-              l1InputUsage *= dim;
-            }
+            LayoutAttr currentOpLayout = legalLayouts.lookup(currentOp).front();
+            assert(currentOpLayout.hasShardedL1TensorMemoryLayout());
+            llvm::ArrayRef<int64_t> currentOpOutputTensorShape =
+                mlir::cast<RankedTensorType>(currentOp->getResult(0).getType())
+                    .getShape();
+            uint64_t currentOpL1OutputUsage = deviceAttr.getLayoutSizeBytes(
+                currentOpOutputTensorShape, currentOpLayout,
+                currentOpLayout.getMemorySpace());
 
-            LayoutAttr nextOpLayout = legalGrids.lookup(nextOp).front();
-            llvm::SmallVector<int64_t> nextOpShardShape =
-                nextOpLayout.getShardShape(false /*convertTileToScalar*/);
-            uint64_t l1OutputUsage = nextOpLayout.getElementSizeBytes();
-            for (int64_t dim : nextOpShardShape) {
-              l1OutputUsage *= dim;
-            }
+            LayoutAttr nextOpLayout = legalLayouts.lookup(nextOp).front();
+            assert(nextOpLayout.hasShardedL1TensorMemoryLayout());
+            llvm::ArrayRef<int64_t> nextOpOutputTensorShape =
+                mlir::cast<RankedTensorType>(nextOp->getResult(0).getType())
+                    .getShape();
+            uint64_t nextOpL1OutputUsage = deviceAttr.getLayoutSizeBytes(
+                nextOpOutputTensorShape, nextOpLayout,
+                nextOpLayout.getMemorySpace());
 
             // Figure out this const based on exec data, but will be replaced
             // with API.
             //
             constexpr float tensorL1UsageCap = 0.8;
-            bool l1UsageValid = (l1InputUsage + l1OutputUsage) <
+            bool l1UsageValid = (currentOpL1OutputUsage + nextOpL1OutputUsage) <
                                 tensorL1UsageCap * usableL1CacheSize;
 
             if (l1UsageValid) {
-              // Add to shard chain config.
+              // TODO(nobradovic)
+              // It seems that bunch of TTNN ops have constraints which prevent
+              // them from being sharded if both inputs are interleaved,
+              // so proposal for now is starting a shard chain
+              // with reshard op(at later phase only when necessary based on op
+              // type) For this reason we also need to validate that currentOp
+              // can fit into L1 with its first input sharded.
               //
-              ShardSpec shardSpec;
-              shardSpec.op = currentOp;
+              bool firstInputL1UsageValid = true;
+              if (shardChainConfigs->back().isEmpty()) {
+                RankedTensorType firstOpInputTensorType =
+                    mlir::cast<RankedTensorType>(currentOp->getOperand(0)
+                                                     .getDefiningOp()
+                                                     ->getResult(0)
+                                                     .getType());
+                LayoutAttr firstOpInputLayout = mlir::cast<LayoutAttr>(
+                    firstOpInputTensorType.getEncoding());
 
-              // Hardcoded tensor split factor for now, until pipeline OP
-              // support is added.
-              //
-              shardSpec.tensorSplitFactor = 1;
-              shardChainConfigs->back().addShardSpec(std::move(shardSpec));
-              currentOp = nextOp;
-              continue;
+                LayoutAttr firstOpInputShardedLayout =
+                    firstOpInputLayout
+                        .withMemorySpace(currentOp->getContext(),
+                                         currentOpLayout.getMemorySpace())
+                        .withMemoryLayout(currentOp->getContext(),
+                                          currentOpLayout.getMemLayout())
+                        .withGrid(currentOp->getContext(),
+                                  firstOpInputTensorType,
+                                  currentOpLayout.getGrid());
+
+                uint64_t firstInputL1Usage = deviceAttr.getLayoutSizeBytes(
+                    firstOpInputTensorType.getShape(),
+                    firstOpInputShardedLayout,
+                    firstOpInputShardedLayout.getMemorySpace());
+
+                firstInputL1UsageValid =
+                    (firstInputL1Usage + currentOpL1OutputUsage) <
+                    tensorL1UsageCap * usableL1CacheSize;
+              }
+
+              if (firstInputL1UsageValid) {
+                // Add to shard chain config.
+                //
+                ShardSpec shardSpec;
+                shardSpec.op = currentOp;
+
+                // Hardcoded tensor split factor for now, until pipeline OP
+                // support is added.
+                //
+                shardSpec.tensorSplitFactor = 1;
+                shardChainConfigs->back().addShardSpec(std::move(shardSpec));
+                currentOp = nextOp;
+                continue;
+              }
             }
           }
         }
@@ -154,7 +190,7 @@ void DFShardingPolicy::run() {
   //
   for (auto &shardChainConfig : *shardChainConfigs) {
     ShardSolver shardSolver =
-        shardChainConfig.resolve(legalGrids, usableL1CacheSize);
+        shardChainConfig.resolve(legalLayouts, usableL1CacheSize);
 
     // TODO(nobradovic)
     // For now dummy fetch first legal(largest grid) for shard spec.

--- a/lib/Dialect/TTIR/Analysis/ShardChainConfig.cpp
+++ b/lib/Dialect/TTIR/Analysis/ShardChainConfig.cpp
@@ -13,14 +13,14 @@ void ShardChainConfig::build() {
 }
 
 ShardSolver ShardChainConfig::resolve(
-    const llvm::DenseMap<Operation *, std::vector<LayoutAttr>> &legalGrids,
+    const llvm::DenseMap<Operation *, std::vector<LayoutAttr>> &legalLayouts,
     unsigned usableL1CacheSize) {
   assert(state == ShardChainState::Built);
 
   // Reconcile adjacent shard specs.
   // Generate reshard specs where needed.
   //
-  ShardSolver shardSolver(legalGrids, shardSpecs, shardedOps,
+  ShardSolver shardSolver(legalLayouts, shardSpecs, shardedOps,
                           usableL1CacheSize);
   state = ShardChainState::Resolved;
 
@@ -32,10 +32,10 @@ void ShardChainConfig::complete(
     std::unordered_set<Edge> &reshardedEdges) {
   assert(state == ShardChainState::Resolved);
   for (auto &shardSpec : shardSpecs) {
-    auto legalGridsIter = selectedOpLayout.find(shardSpec.op);
-    assert(legalGridsIter != selectedOpLayout.end());
+    auto legalLayoutsIter = selectedOpLayout.find(shardSpec.op);
+    assert(legalLayoutsIter != selectedOpLayout.end());
 
-    shardSpec.layout = legalGridsIter->second;
+    shardSpec.layout = legalLayoutsIter->second;
   }
 
   this->reshardedEdges.swap(reshardedEdges);

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -33,11 +33,11 @@ void createTTIRToTTNNBackendPipeline(
       mlir::tt::TensorMemoryLayout::Interleaved;
   pm.addPass(mlir::tt::ttir::createTTIRLayout(layoutOptions));
 
-  if (options.gridSetPassEnabled) {
-    ttir::TTIRGridSetOptions gridSetOptions;
-    gridSetOptions.overrideGridSizes = options.overrideGridSizes;
-    gridSetOptions.shardingPassEnabled = options.shardingPassEnabled;
-    pm.addPass(mlir::tt::ttir::createTTIRGridSet(gridSetOptions));
+  if (options.optimizerPassEnabled) {
+    ttir::TTIROptimizerOptions optimizerOptions;
+    optimizerOptions.overrideGridSizes = options.overrideGridSizes;
+    optimizerOptions.shardingPassEnabled = options.shardingPassEnabled;
+    pm.addPass(mlir::tt::ttir::createTTIROptimizer(optimizerOptions));
   }
   pm.addPass(createConvertTTIRToTTNNPass());
 }

--- a/test/ttmlir/Dialect/TTIR/test_grid_set.mlir
+++ b/test/ttmlir/Dialect/TTIR/test_grid_set.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttir-load-system-desc --ttir-implicit-device --ttir-layout --ttir-grid-set %s | FileCheck %s
+// RUN: ttmlir-opt --ttir-load-system-desc --ttir-implicit-device --ttir-layout --ttir-optimizer %s | FileCheck %s
 #any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/Dialect/TTNN/ttir_to_ttnn_pipeline_custom_opt.mlir
+++ b/test/ttmlir/Dialect/TTNN/ttir_to_ttnn_pipeline_custom_opt.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-grid-set=false" %s | FileCheck %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=false" %s | FileCheck %s
 #any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/Silicon/TTNN/sharded/simple_eltwise_sharded.mlir
+++ b/test/ttmlir/Silicon/TTNN/sharded/simple_eltwise_sharded.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-grid-set=false" %s > %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-optimizer=false" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 #l1_block_sharded = #tt.operand_constraint<l1_block_sharded>


### PR DESCRIPTION
Follow-up change on DF sharding policy implementation:

- Resharding pass added.
- Handling of firstOp/chain start added.
- Updated L1 shard size calc to common API in DeviceAttr.
- Minor refactor(naming).

Closes #570.