### PR TITLE
make emitted cpp code compileable

### DIFF
--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(ttmlir_cmake_builddir "${CMAKE_BINARY_DIR}/lib/cmake/ttmlir")
 
-set_property(GLOBAL APPEND PROPERTY TTMLIR_EXPORTS "MLIRTTDialect;MLIRTTNNDialect;MLIRTTKernelDialect;MLIRTTMetalDialect;MLIRTTNNTransforms;")
+set_property(GLOBAL APPEND PROPERTY TTMLIR_EXPORTS "MLIRTTDialect;MLIRTTNNDialect;TTMLIRTTNNUtils;MLIRTTKernelDialect;MLIRTTMetalDialect;MLIRTTNNTransforms;")
 get_property(TTMLIR_EXPORTS GLOBAL PROPERTY TTMLIR_EXPORTS)
 export(TARGETS ${TTMLIR_EXPORTS} FILE ${ttmlir_cmake_builddir}/TTMLIRTargets.cmake)
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -432,6 +432,8 @@ def TTNN_EmptyOp : TTNN_Op<"empty"> {
                          OptionalAttr<TTNN_LayoutAttr>:$layout,
                          OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
     let results = (outs AnyRankedTensor:$result);
+
+    let hasVerifier = 1;
 }
 
 def TTNN_FullOp : TTNN_Op<"full"> {

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -426,7 +426,11 @@ def TTNN_EmptyOp : TTNN_Op<"empty"> {
       Tensor empty operation
     }];
 
-    let arguments = (ins TT_Device:$device);
+    let arguments = (ins Optional<TT_Device>:$device,
+                         TTNN_ShapeAttr:$shape,
+                         OptionalAttr<TT_DataTypeAttr>:$dtype,
+                         OptionalAttr<TTNN_LayoutAttr>:$layout,
+                         OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
     let results = (outs AnyRankedTensor:$result);
 }
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
@@ -67,6 +67,16 @@ def TTNN_MemoryConfigAttr : TTNN_Attr<"MemoryConfig", "memory_config"> {
   let assemblyFormat = "`<` params `>`";
 }
 
+def TTNN_ShapeAttr : TTNN_Attr<"Shape", "shape"> {
+  let summary = "TTNN Shape attribute";
+  let description = [{
+    TTNN shape attribute
+  }];
+
+  let parameters = (ins ArrayRefParameter<"int64_t">:$shape);
+  let assemblyFormat = "`<` custom<DimensionList>($shape) `>`";
+}
+
 def TTNN_MeshShapeAttr : TTNN_Attr<"MeshShape", "mesh_shape"> {
   let summary = "TTNN Mesh Shape";
   let description = [{

--- a/include/ttmlir/Dialect/TTNN/Utils/Utils.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/Utils.h
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_UTILS_UTILS_H
+#define TTMLIR_DIALECT_TTNN_UTILS_UTILS_H
+
+#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsTypes.h"
+
+namespace mlir::tt::ttnn::utils {
+
+// Map TT::MemorySpace to TTNN::BufferType
+//
+mlir::tt::ttnn::BufferType
+toTTNNBufferType(const mlir::tt::MemorySpace memorySpace);
+
+// Map TT::TensorMemoryLayout to TTNN::TensorMemoryLayout
+//
+ttnn::TensorMemoryLayout
+toTTNNTensorMemoryLayout(const tt::TensorMemoryLayout ttTensorMemoryLayout);
+
+} // namespace mlir::tt::ttnn::utils
+
+#endif // TTMLIR_DIALECT_TTNN_UTILS_UTILS_H

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -30,7 +30,11 @@ table ToDeviceOp {
 }
 
 table EmptyOp {
-  device: tt.target.DeviceRef;
+  shape: [int64];
+  dtype: DataType;
+  layout: TensorLayout;
+  device: tt.target.DeviceRef;         // optional
+  memcfg: tt.target.MemoryConfigDesc;  // optional
   out: tt.target.TensorRef;
 }
 

--- a/include/ttmlir/Target/TTNN/utils.h
+++ b/include/ttmlir/Target/TTNN/utils.h
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_TARGET_TTNN_UTILS_H
+#define TTMLIR_TARGET_TTNN_UTILS_H
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsTypes.h"
+#include "ttmlir/Target/Common/types_generated.h"
+#include <llvm/Support/ErrorHandling.h>
+
+namespace tt::mlir::ttnn::utils {
+
+::tt::target::TensorMemoryLayout toTargetTensorMemoryLayout(
+    ::mlir::tt::ttnn::TensorMemoryLayout tensorMemoryLayout) {
+
+  switch (tensorMemoryLayout) {
+  case ::mlir::tt::ttnn::TensorMemoryLayout::Interleaved:
+    return ::tt::target::TensorMemoryLayout::Interleaved;
+  case ::mlir::tt::ttnn::TensorMemoryLayout::SingleBank:
+    return ::tt::target::TensorMemoryLayout::SingleBank;
+  case ::mlir::tt::ttnn::TensorMemoryLayout::HeightSharded:
+    return ::tt::target::TensorMemoryLayout::HeightSharded;
+  case ::mlir::tt::ttnn::TensorMemoryLayout::WidthSharded:
+    return ::tt::target::TensorMemoryLayout::WidthSharded;
+  case ::mlir::tt::ttnn::TensorMemoryLayout::BlockSharded:
+    return ::tt::target::TensorMemoryLayout::BlockSharded;
+  }
+
+  llvm_unreachable("Unsupported TensorMemoryLayout");
+}
+
+::tt::target::BufferType
+toTargetBufferType(::mlir::tt::ttnn::BufferType bufferType) {
+
+  switch (bufferType) {
+  case ::mlir::tt::ttnn::BufferType::DRAM:
+    return ::tt::target::BufferType::DRAM;
+  case ::mlir::tt::ttnn::BufferType::L1:
+    return ::tt::target::BufferType::L1;
+  case ::mlir::tt::ttnn::BufferType::SystemMemory:
+    return ::tt::target::BufferType::SystemMemory;
+  case ::mlir::tt::ttnn::BufferType::L1Small:
+    return ::tt::target::BufferType::L1Small;
+  case ::mlir::tt::ttnn::BufferType::Trace:
+    return ::tt::target::BufferType::Trace;
+  }
+
+  llvm_unreachable("Unsupported BufferType");
+}
+
+::tt::target::TensorLayout
+toTargetTensorLayout(::mlir::tt::ttnn::Layout layout) {
+  switch (layout) {
+  case ::mlir::tt::ttnn::Layout::RowMajor:
+    return ::tt::target::TensorLayout::RowMajor;
+  case ::mlir::tt::ttnn::Layout::Tile:
+    return ::tt::target::TensorLayout::Tile;
+  case ::mlir::tt::ttnn::Layout::Invalid:
+    llvm_unreachable("Unsupported Layout");
+  }
+
+  llvm_unreachable("Unsupported Layout");
+}
+
+::tt::target::DataType toTargetDataType(::mlir::tt::DataType dataType) {
+  switch (dataType) {
+  case ::mlir::tt::DataType::BFloat16:
+    return ::tt::target::DataType::BFloat16;
+  case ::mlir::tt::DataType::Float32:
+    return ::tt::target::DataType::Float32;
+  case ::mlir::tt::DataType::UInt32:
+    return ::tt::target::DataType::UInt32;
+  case ::mlir::tt::DataType::BFP_BFloat8:
+    return ::tt::target::DataType::BFP_BFloat8;
+  case ::mlir::tt::DataType::BFP_BFloat4:
+    return ::tt::target::DataType::BFP_BFloat4;
+  case ::mlir::tt::DataType::UInt8:
+    return ::tt::target::DataType::UInt8;
+  case ::mlir::tt::DataType::UInt16:
+    return ::tt::target::DataType::UInt16;
+  case ::mlir::tt::DataType::Float16:
+  case ::mlir::tt::DataType::BFP_Float2:
+  case ::mlir::tt::DataType::BFP_Float4:
+  case ::mlir::tt::DataType::BFP_Float8:
+  case ::mlir::tt::DataType::BFP_BFloat2:
+    llvm_unreachable("Unsupported DataType");
+  }
+
+  llvm_unreachable("Unsupported DataType");
+}
+
+} // namespace tt::mlir::ttnn::utils
+
+#endif // TTMLIR_TARGET_TTNN_UTILS_H

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -65,8 +65,9 @@ public:
     // Get the shape of the tensor, tensor layout, and data type
     //
     mlir::MemRefType memref = ttLayoutAttr.getMemref();
-    ttnn::ShapeAttr shapeAttr =
-        ttnn::ShapeAttr::get(rewriter.getContext(), memref.getShape());
+    ttnn::ShapeAttr shapeAttr = ttnn::ShapeAttr::get(
+        rewriter.getContext(),
+        mlir::cast<RankedTensorType>(op->getResult(0).getType()).getShape());
     Type elementType = memref.getElementType();
     DataType dtype = DataType::Float32;
     ttnn::Layout ttnnLayoutEnum = ttnn::Layout::RowMajor;

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -19,12 +19,53 @@
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/LogicalResult.h"
 
 using namespace mlir;
 using namespace mlir::tt;
 
 namespace {
+
+// Map TT::MemorySpace to TTNN::BufferType
+//
+ttnn::BufferType toTTNNBufferType(const tt::MemorySpace memorySpace) {
+
+  switch (memorySpace) {
+  case tt::MemorySpace::System:
+  case tt::MemorySpace::SystemMMIO:
+    return ttnn::BufferType::SystemMemory;
+  case tt::MemorySpace::DeviceDRAM:
+    return ttnn::BufferType::DRAM;
+  case tt::MemorySpace::DeviceL1:
+    return ttnn::BufferType::L1;
+  }
+
+  llvm_unreachable("Unknown MemorySpace");
+}
+
+// Map TT::TensorMemoryLayout to TTNN::TensorMemoryLayout
+//
+ttnn::TensorMemoryLayout
+toTTNNTensorMemoryLayout(const tt::TensorMemoryLayout ttTensorMemoryLayout) {
+
+  switch (ttTensorMemoryLayout) {
+  case tt::TensorMemoryLayout::HeightSharded:
+    return ttnn::TensorMemoryLayout::HeightSharded;
+  case tt::TensorMemoryLayout::Interleaved:
+    return ttnn::TensorMemoryLayout::Interleaved;
+  case tt::TensorMemoryLayout::WidthSharded:
+    return ttnn::TensorMemoryLayout::WidthSharded;
+  case tt::TensorMemoryLayout::BlockSharded:
+    return ttnn::TensorMemoryLayout::BlockSharded;
+  case tt::TensorMemoryLayout::SingleBank:
+    return ttnn::TensorMemoryLayout::SingleBank;
+  case tt::TensorMemoryLayout::None:
+    assert(false && "TensorMemoryLayout::None not supported");
+  }
+
+  llvm_unreachable("Unknown TensorMemoryLayout");
+}
 
 // Gets or inserts a GetDeviceOp at the top of the current block of the given
 // operation.
@@ -54,9 +95,61 @@ public:
   LogicalResult
   matchAndRewrite(tensor::EmptyOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+
+    // Get tt::LayoutAttr of the result type
+    //
+    tt::LayoutAttr ttLayoutAttr =
+        mlir::cast<tt::LayoutAttr>(op.getResult().getType().getEncoding());
+
+    // Get the shape of the tensor, tensor layout, and data type
+    //
+    mlir::MemRefType memref = ttLayoutAttr.getMemref();
+    ttnn::ShapeAttr shapeAttr =
+        ttnn::ShapeAttr::get(rewriter.getContext(), memref.getShape());
+    Type elementType = memref.getElementType();
+    DataType dtype = DataType::Float32;
+    ttnn::Layout ttnnLayoutEnum = ttnn::Layout::RowMajor;
+    if (llvm::isa<TileType>(elementType)) {
+      ttnnLayoutEnum = ttnn::Layout::Tile;
+      auto tileType = mlir::cast<TileType>(elementType);
+      dtype = tileType.getDataType();
+    } else {
+      ttnnLayoutEnum = ttnn::Layout::RowMajor;
+      dtype = elementTypeToDataType(elementType);
+    }
+    DataTypeAttr dTypeAttr = DataTypeAttr::get(rewriter.getContext(), dtype);
+    ttnn::LayoutAttr tensorLayoutAttr =
+        ttnn::LayoutAttr::get(op.getContext(), ttnnLayoutEnum);
+
+    // If the tensor is not going to device, we can create the op without
+    // device-specific attributes
+    //
+    tt::TensorMemoryLayout ttTensorMemoryLayout = ttLayoutAttr.getMemLayout();
+    if (ttTensorMemoryLayout == TensorMemoryLayout::None) {
+      rewriter.replaceOpWithNewOp<ttnn::EmptyOp>(
+          op, this->getTypeConverter()->convertType(op.getType()), nullptr,
+          shapeAttr, dTypeAttr, tensorLayoutAttr, nullptr);
+
+      return success();
+    }
+
+    ttnn::BufferType bufferType =
+        toTTNNBufferType(ttLayoutAttr.getMemorySpace());
+    ttnn::TensorMemoryLayout tensorMemoryLayout =
+        toTTNNTensorMemoryLayout(ttLayoutAttr.getMemLayout());
+
+    // Create MemoryConfigAttr
+    //
     auto device = getOrInsertDevice(rewriter, op);
+    ttnn::MemoryConfigAttr memoryConfigAttr = ttnn::MemoryConfigAttr::get(
+        op.getContext(),
+        ttnn::TensorMemoryLayoutAttr::get(op.getContext(), tensorMemoryLayout),
+        ttnn::BufferTypeAttr::get(op.getContext(), bufferType));
+
     rewriter.replaceOpWithNewOp<ttnn::EmptyOp>(
-        op, this->getTypeConverter()->convertType(op.getType()), device);
+        op, this->getTypeConverter()->convertType(op.getType()), device,
+        shapeAttr, dTypeAttr, tensorLayoutAttr, memoryConfigAttr);
+
     return success();
   }
 };
@@ -118,27 +211,15 @@ public:
     }
 
     // TODO(bug #665):
-    // Binary ops fail with row major layout in ttnn, defaulting to tile layout
-    // for all ops...
+    // Binary ops fail with row major layout in ttnn, defaulting to tile
+    // layout for all ops...
     //
     ttnnLayoutEnum = ttnn::Layout::Tile;
 
     // Map TT::MemorySpace to TTNN::BufferType
     //
-    tt::MemorySpace memorySpace = ttLayoutAttr.getMemorySpace();
-    ttnn::BufferType bufferType = ttnn::BufferType::DRAM; // default to DRAM
-    switch (memorySpace) {
-    case tt::MemorySpace::System:
-    case tt::MemorySpace::SystemMMIO:
-      bufferType = ttnn::BufferType::SystemMemory;
-      break;
-    case tt::MemorySpace::DeviceDRAM:
-      bufferType = ttnn::BufferType::DRAM;
-      break;
-    case tt::MemorySpace::DeviceL1:
-      bufferType = ttnn::BufferType::L1;
-      break;
-    }
+    ttnn::BufferType bufferType =
+        toTTNNBufferType(ttLayoutAttr.getMemorySpace());
 
     // If the ToLayoutOp is applied to empty tensor, we need to check whether
     // the empty tensor is going back to system memory; if so, we should not
@@ -154,27 +235,7 @@ public:
     // Set the tensor memory layout
     //
     ttnn::TensorMemoryLayout tensorMemoryLayout =
-        ttnn::TensorMemoryLayout::HeightSharded;
-    switch (ttLayoutAttr.getMemLayout()) {
-    case tt::TensorMemoryLayout::None:
-      assert(false && "TensorMemoryLayout::None not supported");
-      break;
-    case tt::TensorMemoryLayout::HeightSharded:
-      tensorMemoryLayout = ttnn::TensorMemoryLayout::HeightSharded;
-      break;
-    case tt::TensorMemoryLayout::Interleaved:
-      tensorMemoryLayout = ttnn::TensorMemoryLayout::Interleaved;
-      break;
-    case tt::TensorMemoryLayout::WidthSharded:
-      tensorMemoryLayout = ttnn::TensorMemoryLayout::WidthSharded;
-      break;
-    case tt::TensorMemoryLayout::BlockSharded:
-      tensorMemoryLayout = ttnn::TensorMemoryLayout::BlockSharded;
-      break;
-    case tt::TensorMemoryLayout::SingleBank:
-      tensorMemoryLayout = ttnn::TensorMemoryLayout::SingleBank;
-      break;
-    }
+        toTTNNTensorMemoryLayout(ttLayoutAttr.getMemLayout());
 
     // TODO(bug #621):
     // Add ttnn::Tensor(tensor, dtype) op call once tt-metal is updated
@@ -433,7 +494,7 @@ public:
                             ? static_cast<float>(valueAttr.getSplatValue<int>())
                             : valueAttr.getSplatValue<float>();
       if (fillValue == 0) {
-        rewriter.replaceOpWithNewOp<ttnn::EmptyOp>(
+        rewriter.replaceOpWithNewOp<tensor::EmptyOp>(
             op, this->getTypeConverter()->convertType(op.getType()), device);
       } else {
         ::mlir::FloatAttr fillValueAttr = rewriter.getF32FloatAttr(fillValue);

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -107,18 +107,8 @@ emitc::OpaqueAttr convertBufferType(Builder &builder,
 //
 emitc::OpaqueAttr convertShape(Builder &builder, ttnn::ShapeAttr attr) {
   llvm::ArrayRef shape = attr.getShape();
-
-  // auto s = fmt::format("{}",fmt::join(elems,delim));
-  // std::vector<std::string> shapeStrings = std::apply(std::to_string, shape);
-  // assert(!shape.empty());
-  // std::string q =
-  //     std::accumulate(std::next(shape.begin()), shape.end(), shape[0],
-  //                     [](const int64_t a, const int64_t b) {
-  //                       return std::to_string(a) + ", " + std::to_string(b);
-  //                     });
   std::ostringstream oss;
   std::copy(shape.begin(), shape.end(), std::ostream_iterator<int>(oss, ", "));
-  // oss.seekp(-2, std::ios_base::end);
   return builder.getType<emitc::OpaqueAttr>("{" + oss.str() + "}");
 }
 

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -13,18 +13,22 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Func/Transforms/FuncConversions.h"
 #include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Value.h"
+#include "mlir/IR/ValueRange.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/LogicalResult.h"
 
 using namespace mlir;
@@ -32,10 +36,14 @@ using namespace mlir::tt;
 
 namespace {
 
+// Create emitc::OpaqueAttr for std::nullopt
+//
 emitc::OpaqueAttr createStdNullopt(Builder &builder) {
   return builder.getType<emitc::OpaqueAttr>("std::nullopt");
 }
 
+// Create emitc::OpaqueAttr for ttnn::Layout
+//
 emitc::OpaqueAttr convertLayoutAttr(Builder &builder, ttnn::LayoutAttr attr) {
   switch (attr.getValue()) {
   case ttnn::Layout::RowMajor:
@@ -45,8 +53,107 @@ emitc::OpaqueAttr convertLayoutAttr(Builder &builder, ttnn::LayoutAttr attr) {
   case ttnn::Layout::Invalid:
     return builder.getType<emitc::OpaqueAttr>("ttnn::Layout::INVALID");
   }
+
+  llvm_unreachable("Unknown ttnn::Layout");
+}
+
+// Create emitc::OpaqueAttr for ttnn::TensorMemoryLayout
+//
+emitc::OpaqueAttr convertTensorMemoryLayout(Builder &builder,
+                                            ttnn::TensorMemoryLayoutAttr attr) {
+  switch (attr.getValue()) {
+  case ttnn::TensorMemoryLayout::BlockSharded:
+    return builder.getType<emitc::OpaqueAttr>(
+        "ttnn::TensorMemoryLayout::BLOCK_SHARDED");
+  case ttnn::TensorMemoryLayout::HeightSharded:
+    return builder.getType<emitc::OpaqueAttr>(
+        "ttnn::TensorMemoryLayout::HEIGHT_SHARDED");
+  case ttnn::TensorMemoryLayout::Interleaved:
+    return builder.getType<emitc::OpaqueAttr>(
+        "ttnn::TensorMemoryLayout::INTERLEAVED");
+  case ttnn::TensorMemoryLayout::SingleBank:
+    return builder.getType<emitc::OpaqueAttr>(
+        "ttnn::TensorMemoryLayout::SINGLE_BANK");
+  case ttnn::TensorMemoryLayout::WidthSharded:
+    return builder.getType<emitc::OpaqueAttr>(
+        "ttnn::TensorMemoryLayout::WIDTH_SHARDED");
+  }
+
   llvm_unreachable("Unknown ttnn::TensorMemoryLayout");
-  return nullptr;
+}
+
+// Create emitc::OpaqueAttr for ttnn::BufferType
+//
+emitc::OpaqueAttr convertBufferType(Builder &builder,
+                                    ttnn::BufferTypeAttr attr) {
+  switch (attr.getValue()) {
+  case ttnn::BufferType::DRAM:
+    return builder.getType<emitc::OpaqueAttr>("ttnn::BufferType::DRAM");
+  case ttnn::BufferType::L1:
+    return builder.getType<emitc::OpaqueAttr>("ttnn::BufferType::L1");
+  case ttnn::BufferType::L1Small:
+    return builder.getType<emitc::OpaqueAttr>("ttnn::BufferType::L1_SMALL");
+  case ttnn::BufferType::SystemMemory:
+    return builder.getType<emitc::OpaqueAttr>(
+        "ttnn::BufferType::SYSTEM_MEMORY");
+  case ttnn::BufferType::Trace:
+    return builder.getType<emitc::OpaqueAttr>("ttnn::BufferType::TRACE");
+  }
+
+  llvm_unreachable("Unknown ttnn::BufferType");
+}
+
+// Create emitc::OpaqueAttr for ttnn::Shape
+//
+emitc::OpaqueAttr convertShape(Builder &builder, ttnn::ShapeAttr attr) {
+  llvm::ArrayRef shape = attr.getShape();
+
+  // auto s = fmt::format("{}",fmt::join(elems,delim));
+  // std::vector<std::string> shapeStrings = std::apply(std::to_string, shape);
+  // assert(!shape.empty());
+  // std::string q =
+  //     std::accumulate(std::next(shape.begin()), shape.end(), shape[0],
+  //                     [](const int64_t a, const int64_t b) {
+  //                       return std::to_string(a) + ", " + std::to_string(b);
+  //                     });
+  std::ostringstream oss;
+  std::copy(shape.begin(), shape.end(), std::ostream_iterator<int>(oss, ", "));
+  // oss.seekp(-2, std::ios_base::end);
+  return builder.getType<emitc::OpaqueAttr>("{" + oss.str() + "}");
+}
+
+// Create emitc::OpaqueAttr for ttnn::DataType
+//
+emitc::OpaqueAttr convertDType(Builder &builder, tt::DataTypeAttr attr) {
+  switch (attr.getValue()) {
+  case tt::DataType::BFloat16:
+    return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::BFLOAT16");
+  case tt::DataType::Float32:
+    return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::FLOAT32");
+  case tt::DataType::UInt32:
+    return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::UINT32");
+  case tt::DataType::BFP_BFloat8:
+    return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::BFLOAT8_B");
+  case tt::DataType::BFP_BFloat4:
+    return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::BFLOAT4_B");
+  case tt::DataType::UInt8:
+    return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::UINT8");
+  case tt::DataType::UInt16:
+    return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::UINT16");
+  // TODO(svuckovic):
+  // Add support for INT32
+  //
+  // case tt::DataType::Int32:
+  //   return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::INT32");
+  case tt::DataType::Float16:
+  case tt::DataType::BFP_Float2:
+  case tt::DataType::BFP_Float4:
+  case tt::DataType::BFP_Float8:
+  case tt::DataType::BFP_BFloat2:
+    llvm_unreachable("Unsupported ttnn::DataType");
+  }
+
+  llvm_unreachable("Unkonwn tt::DataType");
 }
 
 // Base class for TTNN to EmitC OpConversionPattern
@@ -163,6 +270,14 @@ public:
 class GetDeviceOpConversionPattern
     : public TTNNToEmitCBaseOpConversionPattern<ttnn::GetDeviceOp> {
 
+private:
+  std::string getPrefixSearchPattern() const override {
+    return "ttnn.get_device";
+  }
+  std::string getPrefixSwapPattern() const override {
+    return "ttnn::DeviceGetter::getInstance";
+  }
+
 public:
   GetDeviceOpConversionPattern(const TypeConverter &typeConverter,
                                MLIRContext *context, PatternBenefit benefit = 1)
@@ -172,11 +287,10 @@ public:
   LogicalResult
   matchAndRewrite(ttnn::GetDeviceOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto resultTy =
-        this->getTypeConverter()->convertType(srcOp->getResult(0).getType());
 
-    rewriter.replaceOpWithNewOp<emitc::VariableOp>(
-        srcOp, resultTy, rewriter.getAttr<emitc::OpaqueAttr>("device"));
+    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
+        srcOp, this->getTypeConverter()->convertType(srcOp.getType()),
+        this->convertOpName(srcOp), nullptr, nullptr, adaptor.getOperands());
 
     return success();
   }
@@ -198,9 +312,30 @@ public:
   matchAndRewrite(ttnn::ToDeviceOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
+    // Create ArrayAttr object holding MemoryConfig attributes
+    //
+    ArrayAttr arrayAttrs = rewriter.getArrayAttr(
+        {convertTensorMemoryLayout(
+             rewriter, srcOp.getMemoryConfig().getTensorMemoryLayout()),
+         convertBufferType(rewriter, srcOp.getMemoryConfig().getBufferType())});
+
+    // Create MemoryConfig object first, then pass it to the op
+    //
+    emitc::CallOpaqueOp memCfgOp = rewriter.create<emitc::CallOpaqueOp>(
+        srcOp->getLoc(),
+        emitc::OpaqueType::get(rewriter.getContext(), "ttnn::MemoryConfig"),
+        "ttnn::MemoryConfig", arrayAttrs, nullptr, ValueRange());
+
+    // Concat operands and MemoryConfig object
+    //
+    llvm::SmallVector<Value, 3> operands(adaptor.getOperands());
+    operands.append(1, memCfgOp.getResult(0));
+
+    // Convert ToDeviceOp
+    //
     rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
         srcOp, this->getTypeConverter()->convertType(srcOp.getType()),
-        this->convertOpName(srcOp), nullptr, nullptr, adaptor.getOperands());
+        this->convertOpName(srcOp), nullptr, nullptr, operands);
 
     return success();
   }
@@ -222,18 +357,6 @@ public:
   matchAndRewrite(ttnn::ToLayoutOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    llvm::StringRef amp = llvm::StringRef("&");
-    emitc::ApplyOp ampApplyOp = rewriter.create<emitc::ApplyOp>(
-        srcOp->getLoc(),
-        emitc::PointerType::get(
-            emitc::OpaqueType::get(rewriter.getContext(), "ttnn::Device")),
-        amp, adaptor.getOperands().back());
-
-    llvm::SmallVector<Value, 4> operands(adaptor.getOperands().begin(),
-                                         adaptor.getOperands().end());
-    operands.pop_back(); // erase device
-    operands.push_back(ampApplyOp);
-
     llvm::SmallVector<Attribute, 5> attrs;
     attrs.push_back(mlir::IntegerAttr::get(rewriter.getIndexType(), 0));
     attrs.push_back(convertLayoutAttr(rewriter, srcOp.getLayoutAttr()));
@@ -245,7 +368,118 @@ public:
 
     rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
         srcOp, this->getTypeConverter()->convertType(srcOp.getType()),
-        this->convertOpName(srcOp), arrayAttrs, nullptr, operands);
+        this->convertOpName(srcOp), arrayAttrs, nullptr, adaptor.getOperands());
+
+    return success();
+  }
+};
+
+// EmptyOp conversion pattern
+//
+class EmptyOpConversionPattern
+    : public TTNNToEmitCBaseOpConversionPattern<ttnn::EmptyOp> {
+
+public:
+  EmptyOpConversionPattern(const TypeConverter &typeConverter,
+                           MLIRContext *context, PatternBenefit benefit = 1)
+      : TTNNToEmitCBaseOpConversionPattern<ttnn::EmptyOp>(typeConverter,
+                                                          context, benefit) {}
+
+  LogicalResult
+  matchAndRewrite(ttnn::EmptyOp srcOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    ttnn::ShapeAttr shapeAttr = srcOp.getShapeAttr();
+    tt::DataTypeAttr dataTypeAttr = srcOp.getDtypeAttr();
+    ttnn::LayoutAttr layoutAttr = srcOp.getLayoutAttr();
+
+    // Create ttnn::Shape() call
+    //
+    // ttnn:Shape has a couple constructors, but they are explicit and require
+    // specific datatypes on input. However, one of the constructors takes in a
+    // tt_metal::Shape - given that it's much easier to construct a
+    // tt_metal::Shape, we opted to do that here. The call looks like this:
+    // ttnn::Shape(tt::tt_metal::Shape{dim0, dim1, dim2, ...});
+    //
+    // To make it easier on the eyes, these two calls are packed into one, using
+    // EmitC's ExpressionOp.
+    //
+    emitc::ExpressionOp shapeExpressionOp =
+        rewriter.create<emitc::ExpressionOp>(
+            srcOp->getLoc(),
+            emitc::OpaqueType::get(rewriter.getContext(), "ttnn::Shape"),
+            false);
+    mlir::Block &bodyBlock = shapeExpressionOp.getBodyRegion().emplaceBlock();
+    auto currentPoint = rewriter.getInsertionPoint();
+    rewriter.setInsertionPointToStart(&bodyBlock);
+    emitc::CallOpaqueOp metalShapeOp = rewriter.create<emitc::CallOpaqueOp>(
+        srcOp->getLoc(),
+        emitc::OpaqueType::get(rewriter.getContext(), "tt::metal::Shape"),
+        rewriter.getStringAttr("Shape"),
+        rewriter.getArrayAttr(convertShape(rewriter, shapeAttr)), nullptr,
+        ValueRange());
+    emitc::CallOpaqueOp ttnnShapeOp = rewriter.create<emitc::CallOpaqueOp>(
+        srcOp->getLoc(),
+        emitc::OpaqueType::get(rewriter.getContext(), "ttnn::Shape"),
+        rewriter.getStringAttr("ttnn::Shape"), nullptr, nullptr,
+        metalShapeOp->getResults());
+    rewriter.create<emitc::YieldOp>(srcOp->getLoc(), ttnnShapeOp->getResult(0));
+    rewriter.setInsertionPoint(srcOp->getBlock(), currentPoint);
+
+    llvm::SmallVector<Value, 3> operands{
+        shapeExpressionOp->getResult(0),
+    };
+
+    // If there is a device operand, create tensor on device
+    //
+    ArrayAttr arrayAttr;
+    if (adaptor.getDevice()) {
+      mlir::emitc::ApplyOp derefDevice = rewriter.create<emitc::ApplyOp>(
+          srcOp->getLoc(), rewriter.getType<emitc::OpaqueType>("ttnn::Device&"),
+          "*", adaptor.getDevice());
+      operands.append(1, derefDevice->getResult(0));
+
+      // Create ArrayAttr object holding MemoryConfig attributes
+      //
+      ArrayAttr memCfgArrayAttrs = rewriter.getArrayAttr(
+          {convertTensorMemoryLayout(
+               rewriter, srcOp.getMemoryConfig()->getTensorMemoryLayout()),
+           convertBufferType(rewriter,
+                             srcOp.getMemoryConfig()->getBufferType())});
+
+      // Create MemoryConfig object first, then pass it to the op
+      //
+      emitc::CallOpaqueOp memCfgOp = rewriter.create<emitc::CallOpaqueOp>(
+          srcOp->getLoc(),
+          emitc::OpaqueType::get(rewriter.getContext(), "ttnn::MemoryConfig"),
+          "ttnn::MemoryConfig", memCfgArrayAttrs, nullptr, ValueRange());
+
+      // Concat operands and MemoryConfig object
+      //
+      operands.append(1, memCfgOp.getResult(0));
+
+      // Create ArrayAttr object holding attributes and pointers to operands
+      //
+      arrayAttr = rewriter.getArrayAttr({
+          rewriter.getIndexAttr(0), // ttnn::Shape
+          convertDType(rewriter, dataTypeAttr),
+          convertLayoutAttr(rewriter, layoutAttr),
+          rewriter.getIndexAttr(1), // ttnn::Device
+          rewriter.getIndexAttr(2), // ttnn::MemoryConfig
+      });
+    } else {
+      arrayAttr = rewriter.getArrayAttr({
+          rewriter.getIndexAttr(0), // ttnn::Shape
+          convertDType(rewriter, dataTypeAttr),
+          convertLayoutAttr(rewriter, layoutAttr),
+      });
+    }
+
+    // Finally, convert ttir::EmptyOp to ttnn::EmptyOp
+    //
+    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
+        srcOp, this->getTypeConverter()->convertType(srcOp.getType()),
+        this->convertOpName(srcOp), arrayAttr, nullptr, operands);
 
     return success();
   }
@@ -272,8 +506,9 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
 
   // Tensor ops
   //
-  patterns.add<DefaultOpConversionPattern<ttnn::EmptyOp>,
-               DefaultOpConversionPattern<ttnn::FullOp>>(typeConverter, ctx);
+  patterns
+      .add<EmptyOpConversionPattern, DefaultOpConversionPattern<ttnn::FullOp>>(
+          typeConverter, ctx);
 
   // Eltwise unary ops
   //

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitCPass.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitCPass.cpp
@@ -33,8 +33,9 @@ class TTNNToEmitCTypeConverter : public TypeConverter {
 public:
   TTNNToEmitCTypeConverter(MLIRContext *ctx) {
     addConversion([](Type type) { return type; });
-    addConversion([ctx](tt::DeviceType type) -> emitc::OpaqueType {
-      return emitc::OpaqueType::get(ctx, "ttnn::Device");
+    addConversion([ctx](tt::DeviceType type) -> emitc::PointerType {
+      return emitc::PointerType::get(
+          emitc::OpaqueType::get(ctx, "ttnn::Device"));
     });
     addConversion([ctx](mlir::TensorType type) -> emitc::OpaqueType {
       return emitc::OpaqueType::get(ctx, "ttnn::Tensor");

--- a/lib/Dialect/TTNN/CMakeLists.txt
+++ b/lib/Dialect/TTNN/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(IR)
 add_subdirectory(Pipelines)
 add_subdirectory(Transforms)
+add_subdirectory(Utils)

--- a/lib/Dialect/TTNN/IR/CMakeLists.txt
+++ b/lib/Dialect/TTNN/IR/CMakeLists.txt
@@ -9,4 +9,7 @@ add_mlir_dialect_library(MLIRTTNNDialect
         DEPENDS
         MLIRTTNNOpsIncGen
         MLIRTTOpsIncGen
+
+        LINK_LIBS PUBLIC
+        TTMLIRTTNNUtils
         )

--- a/lib/Dialect/TTNN/Utils/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Utils/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_mlir_dialect_library(TTMLIRTTNNUtils
+  Utils.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/TTNN
+)

--- a/lib/Dialect/TTNN/Utils/Utils.cpp
+++ b/lib/Dialect/TTNN/Utils/Utils.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+
+// Map TT::MemorySpace to TTNN::BufferType
+//
+mlir::tt::ttnn::BufferType mlir::tt::ttnn::utils::toTTNNBufferType(
+    const mlir::tt::MemorySpace memorySpace) {
+  switch (memorySpace) {
+  case MemorySpace::System:
+  case MemorySpace::SystemMMIO:
+    return BufferType::SystemMemory;
+  case MemorySpace::DeviceDRAM:
+    return BufferType::DRAM;
+  case MemorySpace::DeviceL1:
+    return BufferType::L1;
+  }
+
+  llvm_unreachable("Unknown MemorySpace");
+}
+
+// Map TT::TensorMemoryLayout to TTNN::TensorMemoryLayout
+//
+mlir::tt::ttnn::TensorMemoryLayout
+mlir::tt::ttnn::utils::toTTNNTensorMemoryLayout(
+    const ::mlir::tt::TensorMemoryLayout ttTensorMemoryLayout) {
+
+  switch (ttTensorMemoryLayout) {
+  case ::mlir::tt::TensorMemoryLayout::HeightSharded:
+    return ttnn::TensorMemoryLayout::HeightSharded;
+  case ::mlir::tt::TensorMemoryLayout::Interleaved:
+    return ttnn::TensorMemoryLayout::Interleaved;
+  case ::mlir::tt::TensorMemoryLayout::WidthSharded:
+    return ttnn::TensorMemoryLayout::WidthSharded;
+  case ::mlir::tt::TensorMemoryLayout::BlockSharded:
+    return ttnn::TensorMemoryLayout::BlockSharded;
+  case ::mlir::tt::TensorMemoryLayout::SingleBank:
+    return ttnn::TensorMemoryLayout::SingleBank;
+  case ::mlir::tt::TensorMemoryLayout::None:
+    assert(false && "TensorMemoryLayout::None not supported");
+  }
+
+  llvm_unreachable("Unknown TensorMemoryLayout");
+}

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -154,8 +154,8 @@ createOp(FlatbufferObjectCache &cache, EmptyOp op) {
   //
   if (!op.getDevice()) {
     return ::tt::target::ttnn::CreateEmptyOp(
-        *cache.fbb, cache.fbb->CreateVector<int64_t>(shape), dtype, layout, 0,
-        0,
+        *cache.fbb, cache.fbb->CreateVector<int64_t>(shape), dtype, layout,
+        /* device */ 0, /* memcfg */ 0,
         cache.getOrCreate(output, tensorValueToFlatbuffer,
                           kHostAllocatedAddress, kHostAllocatedSize));
   }

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -2,14 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <fstream>
-
-#include <llvm/Support/Casting.h>
-
-#include "mlir/Dialect/EmitC/IR/EmitC.h"
-#include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Support/LogicalResult.h"
-#include "llvm/Support/raw_ostream.h"
+#include "ttmlir/Target/TTNN/TTNNToFlatbuffer.h"
 
 #include "ttmlir/Dialect/TT/IR/TT.h"
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
@@ -21,15 +14,25 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsTypes.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTNN/Transforms/TTNNToCpp.h"
-#include "ttmlir/Target/TTNN/TTNNToFlatbuffer.h"
 #include "ttmlir/Target/TTNN/Target.h"
 #include "ttmlir/Target/TTNN/binary_generated.h"
 #include "ttmlir/Target/TTNN/program_generated.h"
+#include "ttmlir/Target/TTNN/utils.h"
 #include "ttmlir/Target/Utils/FlatbufferObjectCache.h"
 #include "ttmlir/Target/Utils/FuncOpToProgram.h"
 #include "ttmlir/Target/Utils/MLIRToFlatbuffer.h"
 #include "ttmlir/Version.h"
 #include "types_generated.h"
+
+#include "mlir/Dialect/EmitC/IR/EmitC.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Support/LogicalResult.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <cassert>
+#include <fstream>
 
 namespace mlir::tt::ttnn {
 
@@ -97,21 +100,9 @@ createOp(FlatbufferObjectCache &cache, ToLayoutOp op) {
   constexpr uint64_t kHostAllocatedSize = 0;
   auto input =
       cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
+  ::tt::target::TensorLayout layout =
+      ::tt::mlir::ttnn::utils::toTargetTensorLayout(op.getLayout());
   auto device = getOperandThroughDPSOps(op.getDevice());
-
-  ::tt::target::TensorLayout layout;
-  switch (op.getLayout()) {
-  case Layout::RowMajor:
-    layout = ::tt::target::TensorLayout::RowMajor;
-    break;
-  case Layout::Tile:
-    layout = ::tt::target::TensorLayout::Tile;
-    break;
-  case Layout::Invalid:
-    layout = ::tt::target::TensorLayout::Invalid;
-    break;
-  }
-
   auto output = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
                                   kHostAllocatedAddress, kHostAllocatedSize);
 
@@ -128,46 +119,12 @@ createOp(FlatbufferObjectCache &cache, ToDeviceOp op) {
       cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
   auto device = getOperandThroughDPSOps(op.getDevice());
 
-  op.getMemoryConfig();
-
-  ::tt::target::TensorMemoryLayout tensorMemoryLayout;
-  ::tt::target::BufferType bufferType;
-
-  switch (op.getMemoryConfig().getTensorMemoryLayout().getValue()) {
-  case ::mlir::tt::ttnn::TensorMemoryLayout::Interleaved:
-    tensorMemoryLayout = ::tt::target::TensorMemoryLayout::Interleaved;
-    break;
-  case ::mlir::tt::ttnn::TensorMemoryLayout::SingleBank:
-    tensorMemoryLayout = ::tt::target::TensorMemoryLayout::SingleBank;
-    break;
-  case ::mlir::tt::ttnn::TensorMemoryLayout::HeightSharded:
-    tensorMemoryLayout = ::tt::target::TensorMemoryLayout::HeightSharded;
-    break;
-  case ::mlir::tt::ttnn::TensorMemoryLayout::WidthSharded:
-    tensorMemoryLayout = ::tt::target::TensorMemoryLayout::WidthSharded;
-    break;
-  case ::mlir::tt::ttnn::TensorMemoryLayout::BlockSharded:
-    tensorMemoryLayout = ::tt::target::TensorMemoryLayout::BlockSharded;
-    break;
-  }
-
-  switch (op.getMemoryConfig().getBufferType().getValue()) {
-  case ::mlir::tt::ttnn::BufferType::DRAM:
-    bufferType = ::tt::target::BufferType::DRAM;
-    break;
-  case ::mlir::tt::ttnn::BufferType::L1:
-    bufferType = ::tt::target::BufferType::L1;
-    break;
-  case ::mlir::tt::ttnn::BufferType::SystemMemory:
-    bufferType = ::tt::target::BufferType::SystemMemory;
-    break;
-  case ::mlir::tt::ttnn::BufferType::L1Small:
-    bufferType = ::tt::target::BufferType::L1Small;
-    break;
-  case ::mlir::tt::ttnn::BufferType::Trace:
-    bufferType = ::tt::target::BufferType::Trace;
-    break;
-  }
+  ::tt::target::TensorMemoryLayout tensorMemoryLayout =
+      ::tt::mlir::ttnn::utils::toTargetTensorMemoryLayout(
+          op.getMemoryConfig().getTensorMemoryLayout().getValue());
+  ::tt::target::BufferType bufferType =
+      ::tt::mlir::ttnn::utils::toTargetBufferType(
+          op.getMemoryConfig().getBufferType().getValue());
 
   auto memoryConfigDesc =
       CreateMemoryConfigDesc(*cache.fbb, tensorMemoryLayout, bufferType);
@@ -184,10 +141,38 @@ createOp(FlatbufferObjectCache &cache, ToDeviceOp op) {
 createOp(FlatbufferObjectCache &cache, EmptyOp op) {
   constexpr uint64_t kHostAllocatedAddress = 0;
   constexpr uint64_t kHostAllocatedSize = 0;
-  auto device = getOperandThroughDPSOps(op.getDevice());
+
+  ::llvm::ArrayRef<int64_t> shape = op.getShape().getShape();
+  ::tt::target::DataType dtype =
+      ::tt::mlir::ttnn::utils::toTargetDataType(op.getDtype().value());
+  ::tt::target::TensorLayout layout =
+      ::tt::mlir::ttnn::utils::toTargetTensorLayout(op.getLayout().value());
+
   auto output = getOperandThroughDPSOps(op.getResult());
+
+  // If the device is not set, we create on host
+  //
+  if (!op.getDevice()) {
+    return ::tt::target::ttnn::CreateEmptyOp(
+        *cache.fbb, cache.fbb->CreateVector<int64_t>(shape), dtype, layout, 0,
+        0,
+        cache.getOrCreate(output, tensorValueToFlatbuffer,
+                          kHostAllocatedAddress, kHostAllocatedSize));
+  }
+
+  auto device = getOperandThroughDPSOps(op.getDevice());
+  ::tt::target::TensorMemoryLayout tensorMemoryLayout =
+      ::tt::mlir::ttnn::utils::toTargetTensorMemoryLayout(
+          op.getMemoryConfig()->getTensorMemoryLayout().getValue());
+  ::tt::target::BufferType bufferType =
+      ::tt::mlir::ttnn::utils::toTargetBufferType(
+          op.getMemoryConfig()->getBufferType().getValue());
+
+  auto memoryConfigDesc =
+      CreateMemoryConfigDesc(*cache.fbb, tensorMemoryLayout, bufferType);
   return ::tt::target::ttnn::CreateEmptyOp(
-      *cache.fbb, cache.at<::tt::target::DeviceRef>(device),
+      *cache.fbb, cache.fbb->CreateVector<int64_t>(shape), dtype, layout,
+      cache.at<::tt::target::DeviceRef>(device), memoryConfigDesc,
       cache.getOrCreate(output, tensorValueToFlatbuffer, kHostAllocatedAddress,
                         kHostAllocatedSize));
 }

--- a/runtime/lib/ttnn/include/tt/runtime/ttnn/utils.h
+++ b/runtime/lib/ttnn/include/tt/runtime/ttnn/utils.h
@@ -8,6 +8,7 @@
 #include "flatbuffers/vector.h"
 #include "ttmlir/Target/TTNN/Target.h"
 #include "ttnn/types.hpp"
+#include "types_generated.h"
 
 namespace tt::runtime::ttnn::utils {
 
@@ -56,25 +57,39 @@ inline ::tt::target::DataType fromTTNNDataType(::ttnn::DataType dataType) {
   }
 }
 
-inline ::tt::tt_metal::TensorMemoryLayout
-toTTNNTensorMemoryLayout(::tt::target::TensorMemoryLayout memLayout) {
-  switch (memLayout) {
-  case ::tt::target::TensorMemoryLayout::Interleaved:
-    return ::tt::tt_metal::TensorMemoryLayout::INTERLEAVED;
-  case ::tt::target::TensorMemoryLayout::SingleBank:
-    return ::tt::tt_metal::TensorMemoryLayout::SINGLE_BANK;
-  case ::tt::target::TensorMemoryLayout::HeightSharded:
-    return ::tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED;
-  case ::tt::target::TensorMemoryLayout::WidthSharded:
-    return ::tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED;
-  case ::tt::target::TensorMemoryLayout::BlockSharded:
-    return ::tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED;
-
+inline ::ttnn::Layout toTTNNLayout(::tt::target::TensorLayout layout) {
+  switch (layout) {
+  case ::tt::target::TensorLayout::Tile:
+    return ::ttnn::Layout::TILE;
+  case ::tt::target::TensorLayout::RowMajor:
+    return ::ttnn::Layout::ROW_MAJOR;
   default:
-    throw std::runtime_error("Unsupported memory layout");
+    throw std::runtime_error("Unsupported layout");
   }
 }
 
+inline ::ttnn::TensorMemoryLayout
+toTTNNTensorMemoryLayout(::tt::target::TensorMemoryLayout tensorMemoryLayout) {
+
+  switch (tensorMemoryLayout) {
+  case ::tt::target::TensorMemoryLayout::Interleaved:
+    return ::ttnn::TensorMemoryLayout::INTERLEAVED;
+  case ::tt::target::TensorMemoryLayout::SingleBank:
+    return ::ttnn::TensorMemoryLayout::SINGLE_BANK;
+  case ::tt::target::TensorMemoryLayout::HeightSharded:
+    return ::ttnn::TensorMemoryLayout::HEIGHT_SHARDED;
+  case ::tt::target::TensorMemoryLayout::WidthSharded:
+    return ::ttnn::TensorMemoryLayout::WIDTH_SHARDED;
+  case ::tt::target::TensorMemoryLayout::BlockSharded:
+    return ::ttnn::TensorMemoryLayout::BLOCK_SHARDED;
+  case ::tt::target::TensorMemoryLayout::None:
+    assert(false &&
+           "Unsupported tensor memory layout TensorMemoryLayout::None");
+  }
+}
+
+// This method will be deprecated in favor of method below
+//
 inline ::tt::tt_metal::BufferType
 toTTNNBufferType(::tt::target::MemorySpace memorySpace) {
   switch (memorySpace) {
@@ -87,6 +102,25 @@ toTTNNBufferType(::tt::target::MemorySpace memorySpace) {
     return ::tt::tt_metal::BufferType::L1;
   }
 }
+
+// Prefer to use this method
+//
+inline ::ttnn::BufferType
+toTTNNBufferType(::tt::target::BufferType bufferType) {
+
+  switch (bufferType) {
+  case ::tt::target::BufferType::DRAM:
+    return ::ttnn::BufferType::DRAM;
+  case ::tt::target::BufferType::L1:
+    return ::ttnn::BufferType::L1;
+  case ::tt::target::BufferType::SystemMemory:
+    return ::ttnn::BufferType::SYSTEM_MEMORY;
+  case ::tt::target::BufferType::L1Small:
+    return ::ttnn::BufferType::L1_SMALL;
+  case ::tt::target::BufferType::Trace:
+    return ::ttnn::BufferType::TRACE;
+  }
+};
 
 inline std::vector<uint32_t>
 toShapeFromFBShape(const flatbuffers::Vector<int32_t> &vec) {

--- a/runtime/lib/ttnn/operations/creation/empty.cpp
+++ b/runtime/lib/ttnn/operations/creation/empty.cpp
@@ -18,8 +18,8 @@ void run(const ::tt::target::ttnn::EmptyOp *op, ProgramContext &context) {
   ::ttnn::Layout layout __attribute__((unused)) =
       ::tt::runtime::ttnn::utils::toTTNNLayout(op->layout());
   layout = ::ttnn::Layout::ROW_MAJOR;
-  ::ttnn::Shape shape =
-      ::ttnn::Shape(Shape(::tt::runtime::ttnn::utils::toShapeFromFBShape(
+  ::ttnn::Shape shape = ::ttnn::Shape(
+      tt_metal::Shape(::tt::runtime::ttnn::utils::toShapeFromFBShape(
           *op->out()->desc()->shape())));
 
   const tt::target::DeviceRef *device = op->device();

--- a/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/utils.h
+++ b/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/utils.h
@@ -28,5 +28,9 @@ CoreRangeSet toCoreRangeSet(
 ::tt::tt_metal::MemoryConfig
 createMemoryConfig(const ::tt::target::TensorRef *tensorRef);
 
+::tt::tt_metal::MemoryConfig
+createMemoryConfig(const tt::target::MemoryConfigDesc *memcfg,
+                   const ::tt::target::TensorRef *tensorRef);
+
 } // namespace tt::runtime::ttnn::operations::utils
 #endif

--- a/runtime/lib/ttnn/operations/layout/to_device.cpp
+++ b/runtime/lib/ttnn/operations/layout/to_device.cpp
@@ -15,48 +15,8 @@ void run(const ::tt::target::ttnn::ToDeviceOp *op, ProgramContext &context) {
   assert((utils::isOnHost(inputTensor) or utils::isOnDevice(inputTensor)) &&
          "Unsupported storage type");
 
-  ::ttnn::TensorMemoryLayout tensorMemoryLayout =
-      ::tt::runtime::ttnn::utils::toTTNNTensorMemoryLayout(
-          op->memcfg()->tensor_memory_layout());
-
-  ::ttnn::BufferType bufferType;
-  switch (op->memcfg()->buffer_type()) {
-  case ::tt::target::BufferType::DRAM:
-    bufferType = ::ttnn::BufferType::DRAM;
-    break;
-  case ::tt::target::BufferType::L1:
-    bufferType = ::ttnn::BufferType::L1;
-    break;
-  case ::tt::target::BufferType::SystemMemory:
-    bufferType = ::ttnn::BufferType::SYSTEM_MEMORY;
-    break;
-  case ::tt::target::BufferType::L1Small:
-    bufferType = ::ttnn::BufferType::L1_SMALL;
-    break;
-  case ::tt::target::BufferType::Trace:
-    bufferType = ::ttnn::BufferType::TRACE;
-    break;
-  }
-
-  // TODO(bug #620):
-  // Until ShardSpec support is added in TTNN, read it from the output tensor.
-  // If ShardSpec is not supplied, an error will be thrown in ttnn lib.
-  //
-  const ::tt::target::LayoutDesc *layout = op->out()->desc()->layout();
-  const ::flatbuffers::Vector<const tt::target::Dim2dRange *>
-      *targetCoreRangeSet = layout->core_range_set();
-  const ::flatbuffers::Vector<int32_t> *targetShardShape =
-      layout->memory_desc()->shape();
-  CoreRangeSet ttnnCoreRangeSet = utils::toCoreRangeSet(targetCoreRangeSet);
-  std::array<uint32_t, 2> ttnnShardShape;
-  std::copy(targetShardShape->begin(), targetShardShape->end(),
-            ttnnShardShape.begin());
-  ::tt::tt_metal::ShardSpec shardSpec(
-      ttnnCoreRangeSet, ttnnShardShape,
-      ::tt::tt_metal::ShardOrientation::ROW_MAJOR, false);
-
-  ::ttnn::MemoryConfig memoryConfig = {tensorMemoryLayout, bufferType,
-                                       shardSpec};
+  ::ttnn::MemoryConfig memoryConfig =
+      utils::createMemoryConfig(op->memcfg(), op->out());
   ::ttnn::Device &device = utils::getDevice(op->device(), devicePool);
   ::ttnn::Tensor out = ::ttnn::to_device(inputTensor, &device, memoryConfig);
 

--- a/test/ttmlir/Silicon/TTNN/sharded/simple_eltwise_sharded.mlir
+++ b/test/ttmlir/Silicon/TTNN/sharded/simple_eltwise_sharded.mlir
@@ -2,6 +2,7 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 #l1_block_sharded = #tt.operand_constraint<l1_block_sharded>
+#l1_height_sharded = #tt.operand_constraint<l1|height_sharded|scalar|tile>
 
 func.func @subtract(%arg0: tensor<224x64xf32>, %arg1: tensor<224x64xf32>) -> tensor<224x64xf32> {
   // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
@@ -46,14 +47,14 @@ func.func @ge(%arg0: tensor<224x64xf32>, %arg1: tensor<224x64xf32>) -> tensor<22
 func.func @reshape(%arg0: tensor<4x2x224x64xbf16>) -> tensor<2x4x224x64xbf16> {
   %0 = tensor.empty() : tensor<2x4x224x64xbf16>
   // CHECK: %[[C:.*]] = "ttnn.reshape"[[C:.*]]
-  %1 = "ttir.reshape"(%arg0, %0) <{shape = [2: i32, 4: i32, 224: i32, 64: i32] , operand_constraints = [#l1_block_sharded, #l1_block_sharded]}> : (tensor<4x2x224x64xbf16>, tensor<2x4x224x64xbf16>) -> tensor<2x4x224x64xbf16>
+  %1 = "ttir.reshape"(%arg0, %0) <{shape = [2: i32, 4: i32, 224: i32, 64: i32] , operand_constraints = [#l1_height_sharded, #l1_height_sharded]}> : (tensor<4x2x224x64xbf16>, tensor<2x4x224x64xbf16>) -> tensor<2x4x224x64xbf16>
   return %1 : tensor<2x4x224x64xbf16>
 }
 
 func.func @squeeze(%arg0: tensor<1x2x1x224x64xbf16>) -> tensor<1x2x224x64xbf16> {
   %0 = tensor.empty() : tensor<1x2x224x64xbf16>
   // CHECK: %[[C:.*]] = "ttnn.reshape"[[C:.*]]
-  %1 = "ttir.squeeze"(%arg0, %0) <{dim = 2 : si32, operand_constraints = [#l1_block_sharded, #l1_block_sharded]}> : (tensor<1x2x1x224x64xbf16>, tensor<1x2x224x64xbf16>) -> tensor<1x2x224x64xbf16>
+  %1 = "ttir.squeeze"(%arg0, %0) <{dim = 2 : si32, operand_constraints = [#l1_height_sharded, #l1_height_sharded]}> : (tensor<1x2x1x224x64xbf16>, tensor<1x2x224x64xbf16>) -> tensor<1x2x224x64xbf16>
   return %1 : tensor<1x2x224x64xbf16>
 }
 

--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -2,6 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#ifndef TOOLS_TTNN_STANDALONE_TTNN_PRECOMPILED_HPP
+#define TOOLS_TTNN_STANDALONE_TTNN_PRECOMPILED_HPP
+
 #include "common/bfloat16.hpp"
 #include "core.hpp"
 #include "device.hpp"
@@ -15,3 +18,31 @@
 #include <cstddef>
 #include <iostream>
 #include <vector>
+
+namespace ttnn {
+
+// DeviceGetter class
+//
+// Singleton implementation for Device
+//
+class DeviceGetter {
+public:
+  static ttnn::Device *getInstance() {
+    static ttnn::Device *instance = &ttnn::open_device(0);
+
+    return instance;
+  }
+
+private:
+  ~DeviceGetter() { ttnn::close_device(*device); }
+
+public:
+  DeviceGetter(DeviceGetter const &) = delete;
+  void operator=(DeviceGetter const &) = delete;
+
+  ttnn::Device *device;
+};
+
+} // namespace ttnn
+
+#endif // TOOLS_TTNN_STANDALONE_TTNN_PRECOMPILED_HPP

--- a/tools/ttnn-standalone/ttnn-standalone.cpp
+++ b/tools/ttnn-standalone/ttnn-standalone.cpp
@@ -4,52 +4,38 @@
 
 #include "ttnn-precompiled.hpp"
 
-// Below is a snippet generated with:
-// ./build/bin/ttmlir-opt --ttir-load-system-desc --ttir-layout
-//  --convert-ttir-to-ttnn --convert-ttnn-to-emitc
+// To generate forward function, run:
+// ./build/bin/ttmlir-opt --ttir-load-system-desc --ttir-implicit-device
+// --ttir-layout --convert-ttir-to-ttnn --convert-ttnn-to-emitc
 // test/ttmlir/Dialect/TTNN/simple_multiply.mlir | ./build/bin/ttmlir-translate
 // -mlir-to-cpp -allow-unregistered-dialect
+
+// Forward function example
 //
-// #include "pch.hpp"
-// ttnn::Tensor forward(ttnn::Tensor v1, ttnn::Tensor v2) {
-//   ttnn::device::Device& v3 = ttnn::device::open_device(0);
-//   ttnn::Tensor v4 = ttnn::full(v3);
-//   ttnn::Tensor v5 = ttnn::to_memory_config(v1, v4);
-//   ttnn::Tensor v6 = ttnn::full(v3);
-//   ttnn::Tensor v7 = ttnn::to_memory_config(v2, v6);
-//   ttnn::Tensor v8 = ttnn::full(v3);
-//   ttnn::Tensor v9 = ttnn::multiply(v5, v7, v8);
-//   ttnn::Tensor v10 = ttnn::full(v3);
-//   ttnn::Tensor v11 = ttnn::to_memory_config(v9, v10);
-//   ttnn::device::close_device(v3);
-//   return v11;
-// }
-
 ttnn::Tensor forward(ttnn::Tensor v1, ttnn::Tensor v2) {
-  ttnn::Device &v3 = ttnn::open_device(0);
-
-  MemoryConfig memConfig = ttnn::MemoryConfig{
-      .memory_layout = ttnn::TensorMemoryLayout::INTERLEAVED,
-      .buffer_type = ttnn::BufferType::DRAM,
-      // .shard_spec = std::nullopt,
-  };
-
+  ttnn::Device *v3 = ttnn::DeviceGetter::getInstance();
   ttnn::Tensor v4 =
-      ttnn::to_layout(v1, ttnn::Layout::TILE, std::nullopt, std::nullopt, &v3);
-  ttnn::Tensor v5 = ttnn::to_device(v4, &v3, memConfig);
-  ttnn::Tensor v6 =
-      ttnn::to_layout(v2, ttnn::Layout::TILE, std::nullopt, std::nullopt, &v3);
-  ttnn::Tensor v7 = ttnn::to_device(v6, &v3, memConfig);
-
-  ttnn::Tensor v8 = ttnn::empty(v2.shape(), v2.tensor_attributes->dtype,
-                                v2.tensor_attributes->layout, v3);
-  ttnn::multiply(v5, v7, std::nullopt, std::nullopt, v8, std::nullopt,
-                 std::nullopt);
-
-  v8 = v8.cpu(); // move to CPU
-  ttnn::close_device(v3);
-
-  return v8;
+      ttnn::to_layout(v1, ttnn::Layout::TILE, std::nullopt, std::nullopt, v3);
+  ttnn::MemoryConfig v5 = ttnn::MemoryConfig(
+      ttnn::TensorMemoryLayout::INTERLEAVED, ttnn::BufferType::DRAM);
+  ttnn::Tensor v6 = ttnn::to_device(v4, v3, v5);
+  ttnn::Tensor v7 =
+      ttnn::to_layout(v2, ttnn::Layout::TILE, std::nullopt, std::nullopt, v3);
+  ttnn::MemoryConfig v8 = ttnn::MemoryConfig(
+      ttnn::TensorMemoryLayout::INTERLEAVED, ttnn::BufferType::DRAM);
+  ttnn::Tensor v9 = ttnn::to_device(v7, v3, v8);
+  ttnn::Shape v10 = ttnn::Shape(Shape({
+      64,
+      128,
+  }));
+  ttnn::Device &v11 = *v3;
+  ttnn::MemoryConfig v12 = ttnn::MemoryConfig(
+      ttnn::TensorMemoryLayout::INTERLEAVED, ttnn::BufferType::DRAM);
+  ttnn::Tensor v13 = ttnn::empty(v10, ttnn::DataType::FLOAT32,
+                                 ttnn::Layout::ROW_MAJOR, v11, v12);
+  ttnn::Tensor v14 = ttnn::multiply(v6, v9, std::nullopt, std::nullopt, v13);
+  // ttnn::Tensor v15 = ttnn::to_memory_config(v14, v3);
+  return v14.cpu();
 }
 
 int main() {
@@ -57,8 +43,10 @@ int main() {
   //
   const size_t tensor_width = 32;
   const size_t tensor_height = 32;
-  ttnn::Shape xs = ttnn::Shape(Shape{1, 1, tensor_width, tensor_height});
-  ttnn::Shape ys = ttnn::Shape(Shape{1, 1, tensor_width, tensor_height});
+  ttnn::Shape xs =
+      ttnn::Shape(tt::tt_metal::Shape{1, 1, tensor_width, tensor_height});
+  ttnn::Shape ys =
+      ttnn::Shape(tt::tt_metal::Shape{1, 1, tensor_width, tensor_height});
 
   // Create tensors on cpu
   //


### PR DESCRIPTION
Introduce few changes to make emitted cpp code compileable. There's another small issue to tackle (#721) which I'll post the PR for soon.

Parameterize EmptyOp, pipe thru ttnn runtime, fix 2 tests that require height sharding.

If you want to play with this, you can run:
```
./build/bin/ttmlir-opt --ttir-load-system-desc --ttir-implicit-device --ttir-layout --convert-ttir-to-ttnn --convert-ttnn-to-emitc test/ttmlir/Dialect/TTNN/simple_multiply.mlir | ./build/bin/ttmlir-translate -mlir-to-cpp -allow-unregistered-dialect
```
which will generate:
```cpp
#include "ttnn-precompiled.hpp"
ttnn::Tensor forward(ttnn::Tensor v1, ttnn::Tensor v2) {
  ttnn::Device* v3 = ttnn::DeviceGetter::getInstance();
  ttnn::Tensor v4 = ttnn::to_layout(v1, ttnn::Layout::TILE, std::nullopt, std::nullopt, v3);
  ttnn::MemoryConfig v5 = ttnn::MemoryConfig(ttnn::TensorMemoryLayout::INTERLEAVED, ttnn::BufferType::DRAM);
  ttnn::Tensor v6 = ttnn::to_device(v4, v3, v5);
  ttnn::Tensor v7 = ttnn::to_layout(v2, ttnn::Layout::TILE, std::nullopt, std::nullopt, v3);
  ttnn::MemoryConfig v8 = ttnn::MemoryConfig(ttnn::TensorMemoryLayout::INTERLEAVED, ttnn::BufferType::DRAM);
  ttnn::Tensor v9 = ttnn::to_device(v7, v3, v8);
  ttnn::Shape v10 = ttnn::Shape(Shape({64, 128, }));
  ttnn::Device& v11 = *v3;
  ttnn::MemoryConfig v12 = ttnn::MemoryConfig(ttnn::TensorMemoryLayout::INTERLEAVED, ttnn::BufferType::DRAM);
  ttnn::Tensor v13 = ttnn::empty(v10, ttnn::DataType::FLOAT32, ttnn::Layout::ROW_MAJOR, v11, v12);
  ttnn::Tensor v14 = ttnn::multiply(v6, v9, std::nullopt, std::nullopt, v13);
  ttnn::Tensor v15 = ttnn::to_memory_config(v14, v3);
  return v15;
}
```