### PR TITLE
Split TTIRtoTTNNPipeline into thirds, add python bindings for these thirds.

### DIFF
--- a/include/ttmlir/Bindings/Python/TTMLIRModule.h
+++ b/include/ttmlir/Bindings/Python/TTMLIRModule.h
@@ -19,6 +19,7 @@
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTNN/Transforms/TTNNToCpp.h"
 #include "ttmlir/RegisterAll.h"
+#include "llvm/Support/CommandLine.h"
 
 namespace py = pybind11;
 

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -121,6 +121,10 @@ void createTTIRPipelineFirst(OpPassManager &pm,
 void createTTNNPipelineSecond(OpPassManager &pm,
                               const TTIRToTTNNBackendPipelineOptions &options);
 
+void createTTIRPipelineFirstFromString(OpPassManager &pm, std::string options);
+
+void createTTNNPipelineSecondFromString(OpPassManager &pm, std::string options);
+
 void createTTIRToTTNNBackendPipeline(
     OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options);
 

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -87,6 +87,14 @@ struct TTIRToTTNNBackendPipelineOptions
           llvm::cl::desc("Override grid sizes for specific ops."),
           llvm::cl::init(llvm::StringMap<SmallVector<int64_t, 2>>())};
 
+  // If this option is true, skip the conversion from TTIR to TTNN, runs
+  // override passes and all other TTIR passes.
+  Option<bool> skipTTNNConversion{
+      *this, "skip-ttnn-conversion",
+      llvm::cl::desc(
+          "Skips adding TTNN Conversion passes to TTIRtoTTNN pipeline."),
+      llvm::cl::init(false)};
+
   // If this option is true, run sharding pass and try to shard ops.
   //
   Option<bool> shardingPassEnabled{

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -87,14 +87,6 @@ struct TTIRToTTNNBackendPipelineOptions
           llvm::cl::desc("Override grid sizes for specific ops."),
           llvm::cl::init(llvm::StringMap<SmallVector<int64_t, 2>>())};
 
-  // If this option is true, skip the conversion from TTIR to TTNN, runs
-  // override passes and all other TTIR passes.
-  Option<bool> skipTTNNConversion{
-      *this, "skip-ttnn-conversion",
-      llvm::cl::desc(
-          "Skips adding TTNN Conversion passes to TTIRtoTTNN pipeline."),
-      llvm::cl::init(false)};
-
   // If this option is true, run sharding pass and try to shard ops.
   //
   Option<bool> shardingPassEnabled{

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -115,6 +115,12 @@ struct TTIRToTTNNBackendPipelineOptions
       *this, "mesh-shape", llvm::cl::desc("Set the multi-device mesh shape.")};
 };
 
+void createTTIRPipelineFirst(OpPassManager &pm,
+                             const TTIRToTTNNBackendPipelineOptions &options);
+
+void createTTNNPipelineSecond(OpPassManager &pm,
+                              const TTIRToTTNNBackendPipelineOptions &options);
+
 void createTTIRToTTNNBackendPipeline(
     OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options);
 

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -107,15 +107,23 @@ struct TTIRToTTNNBackendPipelineOptions
       *this, "mesh-shape", llvm::cl::desc("Set the multi-device mesh shape.")};
 };
 
-void createTTIRPipelineFirst(OpPassManager &pm,
-                             const TTIRToTTNNBackendPipelineOptions &options);
+void createTTNNPipelineTTIRPasses(
+    OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options);
 
-void createTTNNPipelineSecond(OpPassManager &pm,
-                              const TTIRToTTNNBackendPipelineOptions &options);
+void createTTNNPipelineAnalysisPasses(
+    OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options);
 
-void createTTIRPipelineFirstFromString(OpPassManager &pm, std::string options);
+void createTTNNPipelineLoweringPasses(
+    OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options);
 
-void createTTNNPipelineSecondFromString(OpPassManager &pm, std::string options);
+void createTTNNPipelineTTIRPassesFromString(OpPassManager &pm,
+                                            std::string options);
+
+void createTTNNPipelineAnalysisPassesFromString(OpPassManager &pm,
+                                                std::string options);
+
+void createTTNNPipelineLoweringPassesFromString(OpPassManager &pm,
+                                                std::string options);
 
 void createTTIRToTTNNBackendPipeline(
     OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options);

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -45,6 +45,19 @@ void createTTNNPipelineSecond(OpPassManager &pm,
   pm.addPass(createConvertTTIRToTTNNPass());
 }
 
+void createTTIRPipelineFirstFromString(OpPassManager &pm, std::string options) {
+  auto optionsStruct =
+      TTIRToTTNNBackendPipelineOptions::createFromString(options);
+  createTTIRPipelineFirst(pm, *optionsStruct);
+}
+
+void createTTNNPipelineSecondFromString(OpPassManager &pm,
+                                        std::string options) {
+  auto optionsStruct =
+      TTIRToTTNNBackendPipelineOptions::createFromString(options);
+  createTTNNPipelineSecond(pm, *optionsStruct);
+}
+
 void createTTIRToTTNNBackendPipeline(
     OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options) {
   createTTIRPipelineFirst(pm, options);

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -39,7 +39,11 @@ void createTTIRToTTNNBackendPipeline(
     optimizerOptions.shardingPassEnabled = options.shardingPassEnabled;
     pm.addPass(mlir::tt::ttir::createTTIROptimizer(optimizerOptions));
   }
-  pm.addPass(createConvertTTIRToTTNNPass());
+
+  if (not options.skipTTNNConversion) {
+    // Passes to convert TTIR -> TTNN.
+    pm.addPass(createConvertTTIRToTTNNPass());
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/python/Passes.cpp
+++ b/python/Passes.cpp
@@ -21,14 +21,9 @@ void populatePassesModule(py::module &m) {
       "ttir_first_pipeline",
       [](MlirModule module, std::string options = "") {
         mlir::Operation *moduleOp = unwrap(mlirModuleGetOperation(module));
-        mlir::PassManager pm(moduleOp->getName());
-        mlir::OpPassManager &opm = pm.nest<mlir::ModuleOp>();
+        mlir::PassManager pm(moduleOp->getContext());
 
-        // Register the options fed into the pipeline.
-        auto optionsStruct =
-            tt::ttnn::TTIRToTTNNBackendPipelineOptions::createFromString(
-                options);
-        createTTIRPipelineFirst(opm, *optionsStruct);
+        tt::ttnn::createTTIRPipelineFirstFromString(pm, options);
 
         if (mlir::failed(pm.run(moduleOp))) {
           throw std::runtime_error("Failed to run pass manager");
@@ -40,13 +35,9 @@ void populatePassesModule(py::module &m) {
       "ttnn_second_pipeline",
       [](MlirModule module, std::string options = "") {
         mlir::Operation *moduleOp = unwrap(mlirModuleGetOperation(module));
-        mlir::PassManager pm(moduleOp->getName());
-        mlir::OpPassManager &opm = pm.nest<mlir::ModuleOp>();
+        mlir::PassManager pm(moduleOp->getContext());
 
-        auto optionsStruct =
-            tt::ttnn::TTIRToTTNNBackendPipelineOptions::createFromString(
-                options);
-        createTTNNPipelineSecond(opm, *optionsStruct);
+        tt::ttnn::createTTNNPipelineSecondFromString(pm, options);
 
         if (mlir::failed(pm.run(moduleOp))) {
           throw std::runtime_error("Failed to run pass manager");

--- a/python/Passes.cpp
+++ b/python/Passes.cpp
@@ -18,12 +18,12 @@ void populatePassesModule(py::module &m) {
   mlir::registerAllTranslations();
 
   m.def(
-      "ttir_first_pipeline",
+      "ttnn_pipeline_ttir_passes",
       [](MlirModule module, std::string options = "") {
         mlir::Operation *moduleOp = unwrap(mlirModuleGetOperation(module));
         mlir::PassManager pm(moduleOp->getContext());
 
-        tt::ttnn::createTTIRPipelineFirstFromString(pm, options);
+        tt::ttnn::createTTNNPipelineTTIRPassesFromString(pm, options);
 
         if (mlir::failed(pm.run(moduleOp))) {
           throw std::runtime_error("Failed to run pass manager");
@@ -32,12 +32,26 @@ void populatePassesModule(py::module &m) {
       py::arg("module"), py::arg("options") = "");
 
   m.def(
-      "ttnn_second_pipeline",
+      "ttnn_pipeline_analysis_passes",
       [](MlirModule module, std::string options = "") {
         mlir::Operation *moduleOp = unwrap(mlirModuleGetOperation(module));
         mlir::PassManager pm(moduleOp->getContext());
 
-        tt::ttnn::createTTNNPipelineSecondFromString(pm, options);
+        tt::ttnn::createTTNNPipelineAnalysisPassesFromString(pm, options);
+
+        if (mlir::failed(pm.run(moduleOp))) {
+          throw std::runtime_error("Failed to run pass manager");
+        }
+      },
+      py::arg("module"), py::arg("options") = "");
+
+  m.def(
+      "ttnn_pipeline_lowering_passes",
+      [](MlirModule module, std::string options = "") {
+        mlir::Operation *moduleOp = unwrap(mlirModuleGetOperation(module));
+        mlir::PassManager pm(moduleOp->getContext());
+
+        tt::ttnn::createTTNNPipelineLoweringPassesFromString(pm, options);
 
         if (mlir::failed(pm.run(moduleOp))) {
           throw std::runtime_error("Failed to run pass manager");

--- a/python/ttmlir/passes.py
+++ b/python/ttmlir/passes.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ._mlir_libs._ttmlir import passes
+from ._mlir_libs._ttmlir.passes import *


### PR DESCRIPTION
Closes #661, _depends_ on #714 (not really).

**Implemented**
- Path of least resistance, added `skip-ttnn-conversion` option to `TTIRtoTTNNPipeline` (TTNNPipelines.h)
- Skips adding conversion passes to the pipeline. Simple change. (TTNNPipelines.cpp)