### PR TITLE
Runtime multi-device bootstrap

### DIFF
--- a/runtime/include/tt/runtime/detail/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal.h
@@ -63,8 +63,9 @@ inline Tensor createTensor(std::shared_ptr<void> data, TensorDesc const &desc) {
 
 tt::target::DataType getTensorDataType(Tensor tensor);
 
-Device openDevice(std::vector<int> const &deviceIds = {0},
-                  std::vector<uint8_t> const &numHWCQs = {});
+size_t getNumAvailableDevices();
+
+Device openDevice(DeviceIds const &deviceIds, size_t numHWCQs = 1);
 
 void closeDevice(Device device);
 

--- a/runtime/include/tt/runtime/detail/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn.h
@@ -42,6 +42,9 @@
 #pragma clang diagnostic ignored "-Wc99-extensions"
 
 #define FMT_HEADER_ONLY
+#include "host_api.hpp"
+#include "hostdevcommon/common_values.hpp"
+#include "impl/device/mesh_device.hpp"
 #include "ttnn/device.hpp"
 #include "ttnn/operations/conv/conv2d/conv2d.hpp"
 #include "ttnn/operations/copy.hpp"
@@ -59,7 +62,6 @@
 #include "ttnn/operations/reduction/generic/generic_reductions.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/types.hpp"
-
 #pragma clang diagnostic pop
 
 #include "tt/runtime/types.h"
@@ -84,8 +86,9 @@ inline Tensor createTensor(std::shared_ptr<void> data, TensorDesc const &desc) {
 
 tt::target::DataType getTensorDataType(Tensor tensor);
 
-Device openDevice(std::vector<int> const &deviceIds = {0},
-                  std::vector<std::uint8_t> const &numHWCQs = {});
+size_t getNumAvailableDevices();
+
+Device openDevice(DeviceIds const &deviceIds, size_t numHWCQs = 1);
 
 void closeDevice(Device device);
 
@@ -97,7 +100,7 @@ Event submit(Device device, Binary executable, std::uint32_t programIndex,
 
 void wait(Event event);
 
-void runProgram(::ttnn::Device &device,
+void runProgram(::ttnn::MeshDevice &meshDevice,
                 ::tt::target::ttnn::Program const *program,
                 std::vector<::ttnn::Tensor *> const &inputs,
                 std::vector<::ttnn::Tensor *> const &outputs);

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -43,8 +43,9 @@ inline Tensor createTensor(std::shared_ptr<void> data, TensorDesc const &desc) {
 
 tt::target::DataType getTensorDataType(Tensor tensor);
 
-Device openDevice(std::vector<int> const &deviceIds = {0},
-                  std::vector<std::uint8_t> const &numHWCQs = {});
+size_t getNumAvailableDevices();
+
+Device openDevice(DeviceIds const &deviceIds, size_t numHWCQs = 1);
 
 void closeDevice(Device device);
 

--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -104,10 +104,6 @@ struct Binary : public Flatbuffer {
 
 struct Device : public detail::RuntimeCheckedObjectImpl {
   using detail::RuntimeCheckedObjectImpl::RuntimeCheckedObjectImpl;
-
-  template <typename T> static Device borrow(T &object, DeviceRuntime runtime) {
-    return Device(utils::unsafe_borrow_shared(&object), runtime);
-  }
 };
 
 struct Event : public detail::RuntimeCheckedObjectImpl {

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -138,8 +138,22 @@ tt::target::DataType getTensorDataType(Tensor tensor) {
   throw std::runtime_error("runtime is not enabled");
 }
 
-Device openDevice(std::vector<int> const &deviceIds,
-                  std::vector<std::uint8_t> const &numHWCQs) {
+size_t getNumAvailableDevices() {
+#if defined(TT_RUNTIME_ENABLE_TTNN)
+  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
+    return ::tt::runtime::ttnn::getNumAvailableDevices();
+  }
+#endif
+
+#if defined(TT_RUNTIME_ENABLE_TTMETAL)
+  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
+    return ::tt::runtime::ttmetal::getNumAvailableDevices();
+  }
+#endif
+  throw std::runtime_error("runtime is not enabled");
+}
+
+Device openDevice(DeviceIds const &deviceIds, size_t numHWCQs) {
 #if defined(TT_RUNTIME_ENABLE_TTNN)
   if (getCurrentRuntime() == DeviceRuntime::TTNN) {
     return ::tt::runtime::ttnn::openDevice(deviceIds, numHWCQs);

--- a/runtime/lib/ttnn/operations/context/get_device.cpp
+++ b/runtime/lib/ttnn/operations/context/get_device.cpp
@@ -8,16 +8,52 @@
 #include "ttmlir/Target/TTNN/program_generated.h"
 
 namespace tt::runtime::ttnn::operations::context {
-void run(const ::tt::target::ttnn::GetDeviceOp *op, ProgramContext &context) {
-  DeviceMap &devicePool = context.devicePool;
-  DeviceMap &allDevices = context.allDevices;
-  const flatbuffers::Vector<uint32_t> *chipIds = op->chip_ids();
-  assert(chipIds->size() == 1 && "Expected 1 chip id");
-  for (const uint32_t chipId : *chipIds) {
-    assert(allDevices.contains(chipId) && "Device not found");
-    auto [iter, inserted] =
-        devicePool.try_emplace(chipId, allDevices.at(chipId));
-    assert(inserted && "Duplicate device");
+
+static std::pair<::tt::tt_metal::Coordinate, ::tt::tt_metal::Coordinate>
+deriveMeshViewCoordinates(const ::ttnn::MeshDevice &meshDevice,
+                          const std::unordered_set<uint32_t> &desiredDeviceIds,
+                          const ::tt::target::Dim2d *meshViewShape) {
+  ::tt::tt_metal::Coordinate topLeft, bottomRight;
+  for (int row = 0; row < meshDevice.num_rows(); row++) {
+    for (int col = 0; col < meshDevice.num_cols(); col++) {
+      const ::ttnn::Device *currDevice = meshDevice.get_device(row, col);
+      if (desiredDeviceIds.contains(currDevice->id())) {
+        topLeft.row = row;
+        topLeft.col = col;
+        // coords are inclusive when constructing mesh view
+        bottomRight.row = topLeft.row + meshViewShape->y() - 1;
+        bottomRight.col = topLeft.col + meshViewShape->x() - 1;
+        return std::make_pair(topLeft, bottomRight);
+      }
+    }
   }
+  throw std::runtime_error("Device not found in mesh for get device op");
+}
+
+static std::unique_ptr<::ttnn::MeshDeviceView>
+constructMeshView(const ::ttnn::MeshDevice &meshDevice,
+                  const std::unordered_set<uint32_t> &desiredDeviceIds,
+                  const ::tt::target::Dim2d *meshViewShape) {
+  // Carve out a mesh view from MeshDevice
+  auto [topLeft, bottomRight] =
+      deriveMeshViewCoordinates(meshDevice, desiredDeviceIds, meshViewShape);
+
+  return std::make_unique<::ttnn::MeshDeviceView>(meshDevice, topLeft,
+                                                  bottomRight);
+}
+
+void run(const ::tt::target::ttnn::GetDeviceOp *op, ProgramContext &context) {
+  const ::ttnn::MeshDevice &meshDevice = context.getMeshDevice();
+  const ::tt::target::Dim2d *meshViewShape = op->mesh();
+  assert(meshViewShape->y() == 1 &&
+         "Expected 1xN mesh shape for get device op");
+  const ::flatbuffers::Vector<uint32_t> *deviceIds = op->chip_ids();
+  std::unordered_set<uint32_t> desiredDeviceIds(deviceIds->begin(),
+                                                deviceIds->end());
+  assert(desiredDeviceIds.size() == deviceIds->size() &&
+         "Duplicate device ids in get device op");
+  std::unique_ptr<::ttnn::MeshDeviceView> meshView =
+      constructMeshView(meshDevice, desiredDeviceIds, meshViewShape);
+  context.addMeshView(op->out()->global_id(), std::move(meshView));
 }
 } // namespace tt::runtime::ttnn::operations::context

--- a/runtime/lib/ttnn/operations/conv/conv2d.cpp
+++ b/runtime/lib/ttnn/operations/conv/conv2d.cpp
@@ -9,8 +9,11 @@
 
 namespace tt::runtime::ttnn::operations::conv {
 void run(const ::tt::target::ttnn::Conv2dOp *op, ProgramContext &context) {
-  ProgramTensorPool &tensorPool = context.tensorPool;
-  DeviceMap &devicePool = context.devicePool;
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+  // TODO (jnie): Update this once we support multi device tensors
+  // Investigate how to handle multi device in conv2d
+  ::ttnn::Device &device =
+      context.getDeviceFromView(op->device()->global_id(), 0);
   const ::ttnn::Tensor &input = tensorPool.at(op->input()->global_id());
   const ::ttnn::Tensor &weight = tensorPool.at(op->weight()->global_id());
   std::optional<::ttnn::Tensor> bias =
@@ -19,7 +22,6 @@ void run(const ::tt::target::ttnn::Conv2dOp *op, ProgramContext &context) {
   auto config = ::ttnn::operations::conv::conv2d::Conv2dConfig();
   config.dtype = utils::getDataType(op->input());
   config.weights_dtype = utils::getDataType(op->weight());
-  ::ttnn::Device &device = utils::getDevice(op->device(), devicePool);
   ::ttnn::Tensor out =
       std::get<0>(::ttnn::operations::conv::conv2d::conv2d<::ttnn::Device>(
           input, weight, &device, op->in_channels(), op->out_channels(),

--- a/runtime/lib/ttnn/operations/creation/full.cpp
+++ b/runtime/lib/ttnn/operations/creation/full.cpp
@@ -9,9 +9,10 @@
 
 namespace tt::runtime::ttnn::operations::creation {
 void run(const ::tt::target::ttnn::FullOp *op, ProgramContext &context) {
-  ProgramTensorPool &tensorPool = context.tensorPool;
-  DeviceMap devicePool = context.devicePool;
-  ::ttnn::Device &device = utils::getDevice(op->device(), devicePool);
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+  // TODO (jnie): Update this once we support multi device tensors
+  ::ttnn::Device &device =
+      context.getDeviceFromView(op->device()->global_id(), 0);
   ::ttnn::DataType outputDataType = utils::getDataType(op->out());
   auto shape = ::ttnn::Shape(::tt::tt_metal::LegacyShape(
       ::tt::runtime::ttnn::utils::toShapeFromFBShape(

--- a/runtime/lib/ttnn/operations/data_movement/concat.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/concat.cpp
@@ -7,12 +7,13 @@
 
 namespace tt::runtime::ttnn::operations::data_movement {
 void run(const ::tt::target::ttnn::ConcatOp *op, ProgramContext &context) {
+  ProgramTensorPool &tensorPool = context.getTensorPool();
   std::vector<::ttnn::Tensor> inputs;
   for (const auto &input : *op->inputs()) {
-    inputs.push_back(context.tensorPool.at(input->global_id()));
+    inputs.push_back(tensorPool.at(input->global_id()));
   }
   int32_t dim = op->dim();
   ::ttnn::Tensor out = ::ttnn::concat(inputs, dim);
-  context.tensorPool.insert_or_assign(op->out()->global_id(), out);
+  tensorPool.insert_or_assign(op->out()->global_id(), out);
 }
 } // namespace tt::runtime::ttnn::operations::data_movement

--- a/runtime/lib/ttnn/operations/data_movement/reshape.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/reshape.cpp
@@ -25,7 +25,7 @@ static ::ttnn::Tensor invoke_reshape(const ::ttnn::Tensor &tensor,
 }
 
 void run(const ::tt::target::ttnn::ReshapeOp *op, ProgramContext &context) {
-  ProgramTensorPool &tensorPool = context.tensorPool;
+  ProgramTensorPool &tensorPool = context.getTensorPool();
   const ::ttnn::Tensor &in = tensorPool.at(op->in()->global_id());
   const auto *fbShape = op->shape();
   std::vector<int32_t> shape(fbShape->begin(), fbShape->end());

--- a/runtime/lib/ttnn/operations/data_movement/transpose.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/transpose.cpp
@@ -8,7 +8,7 @@
 
 namespace tt::runtime::ttnn::operations::data_movement {
 void run(const ::tt::target::ttnn::TransposeOp *op, ProgramContext &context) {
-  ProgramTensorPool &tensorPool = context.tensorPool;
+  ProgramTensorPool &tensorPool = context.getTensorPool();
   const ::ttnn::Tensor &in = tensorPool.at(op->in()->global_id());
   int32_t dim0 = op->dim0();
   int32_t dim1 = op->dim1();

--- a/runtime/lib/ttnn/operations/deletion/dealloc.cpp
+++ b/runtime/lib/ttnn/operations/deletion/dealloc.cpp
@@ -7,7 +7,7 @@
 namespace tt::runtime::ttnn::operations::deletion {
 void run(const ::tt::target::ttnn::DeallocOp *op, ProgramContext &context) {
   bool force = true;
-  ProgramTensorPool &tensorPool = context.tensorPool;
+  ProgramTensorPool &tensorPool = context.getTensorPool();
   ::ttnn::Tensor &tensor = tensorPool.at(op->in()->global_id());
   tensor.deallocate(force);
   tensorPool.erase(op->in()->global_id());

--- a/runtime/lib/ttnn/operations/eltwise/binary.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/binary.cpp
@@ -60,7 +60,7 @@ static void runEltwiseBinaryCompositeOP(
 
 void run(const ::tt::target::ttnn::EltwiseOp *op, ProgramContext &context) {
   assert(isBinaryOp(op) && "Expected binary operation");
-  ProgramTensorPool &tensorPool = context.tensorPool;
+  ProgramTensorPool &tensorPool = context.getTensorPool();
   switch (op->type()) {
   /* Eltwise Binary */
   case ::tt::target::ttnn::EltwiseOpType::Add: {

--- a/runtime/lib/ttnn/operations/eltwise/unary.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/unary.cpp
@@ -54,7 +54,7 @@ static void runEltwiseUnaryWithFastAndApproximateModeOP(
 
 void run(const ::tt::target::ttnn::EltwiseOp *op, ProgramContext &context) {
   assert(isUnaryOp(op) && "Expected binary operation");
-  ProgramTensorPool &tensorPool = context.tensorPool;
+  ProgramTensorPool &tensorPool = context.getTensorPool();
   switch (op->type()) {
   case ::tt::target::ttnn::EltwiseOpType::Abs: {
     runEltwiseUnaryOP(op, tensorPool, ::ttnn::abs);

--- a/runtime/lib/ttnn/operations/embedding/embedding.cpp
+++ b/runtime/lib/ttnn/operations/embedding/embedding.cpp
@@ -9,7 +9,7 @@
 namespace tt::runtime::ttnn::operations::embedding {
 void run(const ::tt::target::ttnn::EmbeddingOp *op, ProgramContext &context) {
 
-  ProgramTensorPool &tensorPool = context.tensorPool;
+  ProgramTensorPool &tensorPool = context.getTensorPool();
   const ::ttnn::Tensor &input = tensorPool.at(op->input()->global_id());
   const ::ttnn::Tensor &weight = tensorPool.at(op->weight()->global_id());
   // default params for embedding op

--- a/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/utils.cpp
+++ b/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/utils.cpp
@@ -27,13 +27,6 @@ bool isOnDevice(const ::ttnn::Tensor &tensor) {
       tensorRef->desc()->layout()->memory_desc()->data_type());
 }
 
-::ttnn::Device &getDevice(const ::tt::target::DeviceRef *deviceRef,
-                          DeviceMap &devicePool) {
-  uint32_t deviceId = deviceRef->global_id();
-  assert(devicePool.contains(deviceId) && "Device not found in device pool");
-  return *devicePool.at(deviceId);
-}
-
 CoreRangeSet toCoreRangeSet(
     const ::flatbuffers::Vector<const tt::target::Dim2dRange *> *coreRangeSet) {
   std::set<CoreRange> coreRanges;

--- a/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/utils.h
+++ b/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/utils.h
@@ -19,9 +19,6 @@ bool isOnDevice(const ::ttnn::Tensor &tensor);
 
 ::ttnn::DataType getDataType(const ::tt::target::TensorRef *tensorRef);
 
-::ttnn::Device &getDevice(const ::tt::target::DeviceRef *deviceRef,
-                          DeviceMap &devicePool);
-
 CoreRangeSet toCoreRangeSet(
     const ::flatbuffers::Vector<const tt::target::Dim2dRange *> *coreRangeSet);
 

--- a/runtime/lib/ttnn/operations/layout/from_device.cpp
+++ b/runtime/lib/ttnn/operations/layout/from_device.cpp
@@ -9,7 +9,7 @@
 
 namespace tt::runtime::ttnn::operations::layout {
 void run(const ::tt::target::ttnn::FromDeviceOp *op, ProgramContext &context) {
-  ProgramTensorPool &tensorPool = context.tensorPool;
+  ProgramTensorPool &tensorPool = context.getTensorPool();
   const ::ttnn::Tensor &inputTensor = tensorPool.at(op->in()->global_id());
   assert(utils::isOnDevice(inputTensor) &&
          "Calling ttnn::from_device on a host tensor");

--- a/runtime/lib/ttnn/operations/layout/to_device.cpp
+++ b/runtime/lib/ttnn/operations/layout/to_device.cpp
@@ -9,15 +9,17 @@
 
 namespace tt::runtime::ttnn::operations::layout {
 void run(const ::tt::target::ttnn::ToDeviceOp *op, ProgramContext &context) {
-  ProgramTensorPool &tensorPool = context.tensorPool;
-  DeviceMap &devicePool = context.devicePool;
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+  // TODO (jnie): Update this once we support multi device tensors
+  ::ttnn::Device &device =
+      context.getDeviceFromView(op->device()->global_id(), 0);
   const ::ttnn::Tensor &inputTensor = tensorPool.at(op->in()->global_id());
   assert(utils::isOnHost(inputTensor) &&
          "Calling ttnn::to_device on a device tensor");
 
   ::ttnn::MemoryConfig memoryConfig =
       utils::createMemoryConfig(op->memcfg(), op->out());
-  ::ttnn::Device &device = utils::getDevice(op->device(), devicePool);
+
   ::ttnn::Tensor out = ::ttnn::to_device(inputTensor, &device, memoryConfig);
 
   tensorPool.try_emplace(op->out()->global_id(), out);

--- a/runtime/lib/ttnn/operations/layout/to_layout.cpp
+++ b/runtime/lib/ttnn/operations/layout/to_layout.cpp
@@ -8,8 +8,10 @@
 
 namespace tt::runtime::ttnn::operations::layout {
 void run(const ::tt::target::ttnn::ToLayoutOp *op, ProgramContext &context) {
-  ProgramTensorPool &tensorPool = context.tensorPool;
-  DeviceMap &devicePool = context.devicePool;
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+  // TODO (jnie): Update this once we support multi device tensors
+  ::ttnn::Device &device =
+      context.getDeviceFromView(op->device()->global_id(), 0);
   const ::ttnn::Tensor &inputTensor = tensorPool.at(op->in()->global_id());
   assert((utils::isOnHost(inputTensor) or utils::isOnDevice(inputTensor)) &&
          "Unsupported storage type");
@@ -27,7 +29,6 @@ void run(const ::tt::target::ttnn::ToLayoutOp *op, ProgramContext &context) {
     break;
   }
 
-  ::ttnn::Device &device = utils::getDevice(op->device(), devicePool);
   ::ttnn::Tensor out = ::ttnn::to_layout(inputTensor, layout, std::nullopt,
                                          std::nullopt, &device);
 

--- a/runtime/lib/ttnn/operations/layout/to_memory_config.cpp
+++ b/runtime/lib/ttnn/operations/layout/to_memory_config.cpp
@@ -197,8 +197,7 @@ handleToL1MemoryConfigOp(::ttnn::Device &device,
 void run(const ::tt::target::ttnn::ToMemoryConfigOp *op,
          ProgramContext &context) {
 
-  ProgramTensorPool &tensorPool = context.tensorPool;
-  DeviceMap &devicePool = context.devicePool;
+  ProgramTensorPool &tensorPool = context.getTensorPool();
   const ::ttnn::Tensor &inputTensor = tensorPool.at(op->in0()->global_id());
   assert(utils::isOnHost(inputTensor) or
          utils::isOnDevice(inputTensor) && "Unsupported storage type");
@@ -220,12 +219,16 @@ void run(const ::tt::target::ttnn::ToMemoryConfigOp *op,
     break;
   }
   case ::tt::target::MemorySpace::DeviceDRAM: {
-    ::ttnn::Device &device = utils::getDevice(op->device(), devicePool);
+    // TODO (jnie): Update this once we support multi device tensors
+    ::ttnn::Device &device =
+        context.getDeviceFromView(op->device()->global_id(), 0);
     handleToDramMemoryConfigOp(device, op->in0(), op->out(), tensorPool);
     break;
   }
   case ::tt::target::MemorySpace::DeviceL1: {
-    ::ttnn::Device &device = utils::getDevice(op->device(), devicePool);
+    // TODO (jnie): Update this once we support multi device tensors
+    ::ttnn::Device &device =
+        context.getDeviceFromView(op->device()->global_id(), 0);
     handleToL1MemoryConfigOp(device, op->in0(), op->out(), tensorPool);
     break;
   }

--- a/runtime/lib/ttnn/operations/matmul/matmul.cpp
+++ b/runtime/lib/ttnn/operations/matmul/matmul.cpp
@@ -9,7 +9,7 @@
 namespace tt::runtime::ttnn::operations::matmul {
 // ANCHOR: adding_an_op_matmul_runtime
 void run(const ::tt::target::ttnn::MatmulOp *op, ProgramContext &context) {
-  ProgramTensorPool &tensorPool = context.tensorPool;
+  ProgramTensorPool &tensorPool = context.getTensorPool();
   const ::ttnn::Tensor &lhs = tensorPool.at(op->in0()->global_id());
   const ::ttnn::Tensor &rhs = tensorPool.at(op->in1()->global_id());
   ::ttnn::DataType outputDataType = utils::getDataType(op->out());

--- a/runtime/lib/ttnn/operations/normalization/softmax.cpp
+++ b/runtime/lib/ttnn/operations/normalization/softmax.cpp
@@ -8,7 +8,7 @@
 
 namespace tt::runtime::ttnn::operations::normalization {
 void run(const ::tt::target::ttnn::SoftmaxOp *op, ProgramContext &context) {
-  ProgramTensorPool &tensorPool = context.tensorPool;
+  ProgramTensorPool &tensorPool = context.getTensorPool();
   const ::ttnn::Tensor &in = tensorPool.at(op->in()->global_id());
   int32_t dimension = op->dimension();
   ::tt::tt_metal::MemoryConfig outputMemoryConfig =

--- a/runtime/lib/ttnn/operations/pool/maxpool2d.cpp
+++ b/runtime/lib/ttnn/operations/pool/maxpool2d.cpp
@@ -37,12 +37,13 @@ preshardForMaxPool2d(const ::tt::target::ttnn::MaxPool2dOp *op,
 }
 
 void run(const ::tt::target::ttnn::MaxPool2dOp *op, ProgramContext &context) {
-  ProgramTensorPool &tensorPool = context.tensorPool;
-  DeviceMap &devicePool = context.devicePool;
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+  // TODO (jnie): Update this once we support multi device tensors
+  // Investigate how to handle multi device in maxpool2d
+  ::ttnn::Device &device =
+      context.getDeviceFromView(op->device()->global_id(), 0);
   const ::ttnn::operations::pool::MaxPool2DOp operation =
       ::ttnn::operations::pool::MaxPool2DOp();
-
-  ::ttnn::Device &device = utils::getDevice(op->device(), devicePool);
 
   const ::ttnn::Tensor preShardedInput =
       preshardForMaxPool2d(op, device, tensorPool);

--- a/runtime/lib/ttnn/operations/reduction/reduction.cpp
+++ b/runtime/lib/ttnn/operations/reduction/reduction.cpp
@@ -33,7 +33,7 @@ static void runReductionOp(
 }
 
 void run(const ::tt::target::ttnn::ReductionOp *op, ProgramContext &context) {
-  ProgramTensorPool &tensorPool = context.tensorPool;
+  ProgramTensorPool &tensorPool = context.getTensorPool();
   switch (op->type()) {
   case ::tt::target::ttnn::ReductionOpType::Sum: {
     runReductionOp(op, tensorPool, ::ttnn::sum);

--- a/runtime/test/ttnn/test_subtract.cpp
+++ b/runtime/test/ttnn/test_subtract.cpp
@@ -46,7 +46,10 @@ TEST(TTNNSubtract, Equal) {
     outputTensors.emplace_back(::tt::runtime::createTensor(data, desc));
   }
 
-  auto device = ::tt::runtime::openDevice();
+  size_t numDevices = ::tt::runtime::getNumAvailableDevices();
+  std::vector<int> deviceIds(numDevices);
+  std::iota(deviceIds.begin(), deviceIds.end(), 0);
+  auto device = ::tt::runtime::openDevice(deviceIds);
   auto ev = ::tt::runtime::submit(device, fbb, 0, inputTensors, outputTensors);
   ::tt::runtime::closeDevice(device);
 

--- a/runtime/tools/python/ttrt/common/run.py
+++ b/runtime/tools/python/ttrt/common/run.py
@@ -241,8 +241,8 @@ class Run:
             self.logging.debug(f"setting torch manual seed={self['--seed']}")
             torch.manual_seed(self["--seed"])
             ttrt.runtime.set_compatible_runtime(binaries[0].fbb)
-            self.logging.debug(f"opening device id={self.query.device_ids[0]}")
-            device = ttrt.runtime.open_device([self.query.device_ids[0]])
+            self.logging.debug(f"opening devices={self.query.device_ids}")
+            device = ttrt.runtime.open_device(self.query.device_ids)
 
             try:
                 for bin in binaries:

--- a/runtime/tools/python/ttrt/runtime/module.cpp
+++ b/runtime/tools/python/ttrt/runtime/module.cpp
@@ -14,8 +14,7 @@ namespace py = pybind11;
 
 PYBIND11_MODULE(_C, m) {
   m.doc() = "ttrt.runtime python extension for interacting with the "
-            "Tenstorrent devies";
-
+            "Tenstorrent devices";
   py::class_<tt::runtime::Device>(m, "Device")
       .def("deallocate_buffers", &tt::runtime::detail::deallocateBuffers);
   py::class_<tt::runtime::Event>(m, "Event");
@@ -58,11 +57,12 @@ PYBIND11_MODULE(_C, m) {
             shape, stride, itemsize, dataType);
       },
       "Create a tensor with borrowed memory");
-  m.def("open_device", &tt::runtime::openDevice,
-        py::arg("device_ids") = std::vector<int>{0},
-        py::arg("num_hw_cqs") = std::vector<std::uint8_t>{},
-        "Open a device for execution");
-  m.def("close_device", &tt::runtime::closeDevice, "Close a device");
+  m.def("get_num_available_devices", &tt::runtime::getNumAvailableDevices,
+        "Get the number of available devices");
+  m.def("open_device", &tt::runtime::openDevice, py::arg("device_ids"),
+        py::arg("num_hw_cqs") = size_t{1},
+        "Open a mesh of devices for execution");
+  m.def("close_device", &tt::runtime::closeDevice, "Close a mesh device");
   m.def("submit", &tt::runtime::submit, py::arg("device"),
         py::arg("executable"), py::arg("program_index"), py::arg("inputs"),
         py::arg("outputs"), "Submit a binary for execution");


### PR DESCRIPTION
closes #695 

- Replace all uses of Device with MeshDevice
- Add openMeshDevice, closeMeshDevice APIs, currently only supports opening the entire device grid (cannot open a sub-grid of devices)
- Use MeshDeviceView in TTNN runtime to create subviews of the MeshDevice for program execution, replacing devicePool
- Construct device list with MeshDevice in metal backend. Currently only using the first device (since there's an assert that we only support single device in metal backend)
- Update ttrt accordingly

