### PR TITLE
Adding squeeze op from 4D to input rank for Transpose in runtime

### DIFF
--- a/runtime/lib/ttnn/operations/data_movement/transpose.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/transpose.cpp
@@ -35,6 +35,7 @@ void run(const ::tt::target::ttnn::TransposeOp *op, ProgramContext &context) {
       utils::createMemoryConfig(op->out());
   ::ttnn::Tensor out =
       ::ttnn::permute(unsqueezedInput, dimensionOrder, outputMemoryConfig);
+  out = ::ttnn::squeeze_from_4D(out, inputRank);
   tensorPool.insert_or_assign(op->out()->global_id(), out);
 }
 } // namespace tt::runtime::ttnn::operations::data_movement


### PR DESCRIPTION
Solves #729. Adding squeeze op from 4D to input rank for Transpose, because we used unsqueeze_to_4D and we shouldn't leave tensor with changed rank after transpose. 