### PR TITLE
Adding EnqueueWriteBuffer and EnqueueReadBuffer

### DIFF
--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cassert>
+#include <iostream>
 #include <memory>
 
 #include "mlir/Dialect/EmitC/IR/EmitC.h"
@@ -22,9 +23,11 @@
 #include "ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.h"
 #include "ttmlir/Dialect/TTMetal/IR/TTMetalOpsTypes.h"
 #include "ttmlir/Target/TTMetal/Target.h"
+#include "ttmlir/Target/TTMetal/command_generated.h"
 #include "ttmlir/Target/Utils/FlatbufferObjectCache.h"
 #include "ttmlir/Target/Utils/MLIRToFlatbuffer.h"
 #include "ttmlir/Version.h"
+#include "types_generated.h"
 
 namespace mlir::tt::ttmetal {
 
@@ -215,8 +218,34 @@ static std::shared_ptr<void> translateModuleToFlatbuffer(Operation *op) {
           cache.getOrCreate(input, tensorValueToFlatbuffer,
                             argAlloc.getAddress(), argAlloc.getSize()));
     }
-
+    int temp = -1;
     entry->walk([&](mlir::Operation *op) {
+      temp++;
+      if (temp == 1) {
+        std::cout << "Debug mode" << std::endl;
+        std::vector<uint8_t> byte_vector_write = {0x01, 0x02, 0x03, 0x04};
+        auto vector_offset_write = fbb.CreateVector(byte_vector_write);
+        std::vector<uint8_t> byte_vector_read = {0x05, 0x06, 0x07, 0x08};
+        auto vector_offset_read = fbb.CreateVector(byte_vector_read);
+        uint32_t global_id = 3;
+        uint64_t address = 8;
+        auto tensorDescWrite =
+            ::tt::target::CreateTensorDesc(fbb, 0, 0, vector_offset_write);
+        auto tensorDescRead =
+            ::tt::target::CreateTensorDesc(fbb, 0, 0, vector_offset_read);
+        auto tensorRefWrite = ::tt::target::CreateTensorRef(
+            fbb, global_id, address, 0, tensorDescWrite);
+        auto tensorRefRead = ::tt::target::CreateTensorRef(
+            fbb, global_id, address, 0, tensorDescRead);
+        cqBuilder.appendCommand(
+            ::tt::target::metal::CreateEnqueueWriteBufferCommand(
+                fbb, tensorRefWrite, tensorRefWrite),
+            op);
+        cqBuilder.appendCommand(
+            ::tt::target::metal::CreateEnqueueReadBufferCommand(
+                fbb, tensorRefRead, tensorRefRead),
+            op);
+      }
       if (auto dispatchOp = dyn_cast_or_null<tt::ttmetal::DispatchOp>(op);
           dispatchOp) {
         std::vector<::flatbuffers::Offset<::tt::target::TensorRef>> operands;
@@ -275,6 +304,7 @@ static std::shared_ptr<void> translateModuleToFlatbuffer(Operation *op) {
             op);
       } else if (auto allocOp = dyn_cast_or_null<tt::ttmetal::AllocOp>(op);
                  allocOp) {
+        std::cout << "AllocOp - temp: " << temp << std::endl;
         cqBuilder.appendCommand(
             ::tt::target::metal::CreateCreateBufferCommand(
                 fbb,

--- a/runtime/lib/ttmetal/command_queue.cpp
+++ b/runtime/lib/ttmetal/command_queue.cpp
@@ -432,7 +432,7 @@ void CQExecutor::execute(
          "Buffer not allocated");
   constexpr bool blocking = false;
   ::tt::tt_metal::EnqueueWriteBuffer(
-      *cq, buffers[command->src()->global_id()],
+      *cq, buffers[command->dst()->global_id()],
       command->src()->desc()->constant_data()->data(), blocking);
 }
 
@@ -444,7 +444,7 @@ void CQExecutor::execute(
          "Buffer not allocated");
   constexpr bool blocking = false;
   ::tt::tt_metal::EnqueueReadBuffer(
-      *cq, buffers[command->dst()->global_id()],
+      *cq, buffers[command->src()->global_id()],
       reinterpret_cast<void *>(command->dst()->address()), blocking);
 }
 

--- a/runtime/lib/ttmetal/command_queue.cpp
+++ b/runtime/lib/ttmetal/command_queue.cpp
@@ -425,6 +425,8 @@ void CQExecutor::execute(
 
 void CQExecutor::execute(
     ::tt::target::metal::EnqueueWriteBufferCommand const *command) {
+  std::cout << "Buffer address "
+            << buffers[command->dst()->global_id()]->address() << std::endl;
   ZoneScopedN("EnqueueWriteBufferCommand");
   assert(command->src()->desc()->constant_data() != nullptr &&
          "Only constant data supported");
@@ -455,6 +457,8 @@ void CQExecutor::execute(
     buffers[command->ref()->global_id()] =
         createBufferFromTensorRef(device, command->ref());
   }
+  std::cout << "id at command_queue.cpp " << command->ref()->global_id()
+            << std::endl;
 }
 
 void CQExecutor::execute(

--- a/runtime/lib/ttmetal/command_queue.cpp
+++ b/runtime/lib/ttmetal/command_queue.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <iostream>
 #include <unordered_map>
 
 #include "tt/runtime/detail/debug.h"
@@ -11,7 +10,6 @@
 #include "tt/runtime/utils.h"
 
 #include "ttmlir/Target/TTMetal/Target.h"
-#include "ttmlir/Target/TTMetal/command_generated.h"
 #include "ttmlir/Version.h"
 
 namespace tt::runtime::ttmetal {
@@ -436,7 +434,6 @@ void CQExecutor::execute(
   ::tt::tt_metal::EnqueueWriteBuffer(
       *cq, buffers[command->src()->global_id()],
       command->src()->desc()->constant_data()->data(), blocking);
-  std::cout << "EnqueueWriteBufferCommand completed." << std::endl;
 }
 
 void CQExecutor::execute(
@@ -446,9 +443,6 @@ void CQExecutor::execute(
   assert(buffers[command->dst()->global_id()] != nullptr &&
          "Buffer not allocated");
   constexpr bool blocking = false;
-  std::cout << "At EnqueueReadBufferCommand" << std::endl;
-  std::cout << "Global id: " << command->dst()->global_id() << std::endl;
-  std::cout << "Address: " << command->dst()->address() << std::endl;
   ::tt::tt_metal::EnqueueReadBuffer(
       *cq, buffers[command->dst()->global_id()],
       reinterpret_cast<void *>(command->dst()->address()), blocking);
@@ -457,8 +451,6 @@ void CQExecutor::execute(
 void CQExecutor::execute(
     ::tt::target::metal::CreateBufferCommand const *command) {
   ZoneScopedN("CreateBufferCommand");
-  std::cout << "CreateBufferCommand global_id: " << command->ref()->global_id()
-            << std::endl;
   if (buffers.find(command->ref()->global_id()) == buffers.end()) {
     buffers[command->ref()->global_id()] =
         createBufferFromTensorRef(device, command->ref());

--- a/runtime/lib/ttmetal/command_queue.cpp
+++ b/runtime/lib/ttmetal/command_queue.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <iostream>
 #include <unordered_map>
 
 #include "tt/runtime/detail/debug.h"
@@ -10,6 +11,7 @@
 #include "tt/runtime/utils.h"
 
 #include "ttmlir/Target/TTMetal/Target.h"
+#include "ttmlir/Target/TTMetal/command_generated.h"
 #include "ttmlir/Version.h"
 
 namespace tt::runtime::ttmetal {
@@ -434,6 +436,7 @@ void CQExecutor::execute(
   ::tt::tt_metal::EnqueueWriteBuffer(
       *cq, buffers[command->src()->global_id()],
       command->src()->desc()->constant_data()->data(), blocking);
+  std::cout << "EnqueueWriteBufferCommand completed." << std::endl;
 }
 
 void CQExecutor::execute(
@@ -443,6 +446,9 @@ void CQExecutor::execute(
   assert(buffers[command->dst()->global_id()] != nullptr &&
          "Buffer not allocated");
   constexpr bool blocking = false;
+  std::cout << "At EnqueueReadBufferCommand" << std::endl;
+  std::cout << "Global id: " << command->dst()->global_id() << std::endl;
+  std::cout << "Address: " << command->dst()->address() << std::endl;
   ::tt::tt_metal::EnqueueReadBuffer(
       *cq, buffers[command->dst()->global_id()],
       reinterpret_cast<void *>(command->dst()->address()), blocking);
@@ -451,6 +457,8 @@ void CQExecutor::execute(
 void CQExecutor::execute(
     ::tt::target::metal::CreateBufferCommand const *command) {
   ZoneScopedN("CreateBufferCommand");
+  std::cout << "CreateBufferCommand global_id: " << command->ref()->global_id()
+            << std::endl;
   if (buffers.find(command->ref()->global_id()) == buffers.end()) {
     buffers[command->ref()->global_id()] =
         createBufferFromTensorRef(device, command->ref());


### PR DESCRIPTION
This is a draft PR. 
There are two commits on this draft PR, the last one is just demonstrating how I "debugged/validated" functionality and this commit will not be in the final version. 
For debugging, I tried running EnqueueWriteBuffer and EnqueueReadBuffer right after CreateBufferCommand was ran, using the global_id used by CreateBufferCommand. This is assuming that the program will create the buffer before writing and reading from it. Therefore, the global_id is hardcoded. 