### PR TITLE
#697: Enable async mode by default in ttnn runtime

### DIFF
--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -61,6 +61,7 @@ Device openDevice(std::vector<int> const &deviceIds,
   assert(deviceIds.size() == 1 && "Only one device is supported for now");
   assert(numHWCQs.empty() && "HWCQs are not supported for now");
   auto &device = ::ttnn::open_device(deviceIds.front(), kL1SmallSize);
+  device.enable_async(true);
   return Device::borrow(device, DeviceRuntime::TTNN);
 }
 


### PR DESCRIPTION
closes #697 
Enable async mode implicitly by default, there's no reason not to. Even for single device it can reduce the time the main thread blocks.

Close device will automatically reset the async work executor, so when the device is reopened the state is cleared and it will run in synchronous mode again. 

