### PR TITLE
#552: Fixed collecting device related performance data in ttrt

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -228,8 +228,16 @@ jobs:
         ln -sf ${{ steps.strings.outputs.install-output-dir }} ${{ steps.strings.outputs.build-output-dir }}
         llvm-lit -sv ${{ steps.strings.outputs.build-output-dir }}/test
 
-    - name: Run tests
+    - name: Run functional tests
       shell: bash
+      if: matrix.build.enable_perf == 'OFF'
       run: |
         source env/activate
         ttrt ${{ matrix.build.name }} ${{ matrix.build.ttrt_flags }} ${{ steps.strings.outputs.build-output-dir }}/test/ttmlir/Silicon
+
+    - name: Run perf tests
+      shell: bash
+      if: matrix.build.enable_perf == 'ON'
+      run: |
+        source env/activate
+        ttrt ${{ matrix.build.name }} ${{ matrix.build.ttrt_flags }} ${{ steps.strings.outputs.build-output-dir }}/test/ttmlir/Silicon --host-only

--- a/docs/src/ttrt.md
+++ b/docs/src/ttrt.md
@@ -189,6 +189,9 @@ ttrt query --save-artifacts --log-file ttrt.log
 ### perf
 Run performance mode of a binary file or a directory of binary files
 Note: It's required to be on a system with silicon and to have a runtime enabled build `-DTTMLIR_ENABLE_RUNTIME=ON`. Also need perf enabled build `-DTT_RUNTIME_ENABLE_PERF_TRACE=ON`.
+Note: You can collect host only related performance data via `--host-only` flag. By default, host and device side performance data are both collected.
+Restriction: `/dir/of/flatbuffers` can only be used if collecting `--host-only` (as performance data is collected upon closing of device, if we run a directory of flatbuffers, we cannot get accurate device performance data since device is only closed at end of execution).
+Restriction: We can only run perf mode (for now) on .mlir files that have only 1 function (func.func)
 
 ```bash
 ttrt perf --help
@@ -198,10 +201,10 @@ ttrt perf out.ttnn --save-artifacts
 ttrt perf out.ttnn --loops 10
 ttrt perf --program-index all out.ttnn
 ttrt perf --program-index 0 out.ttnn
-ttrt perf --device out.ttnn
-ttrt perf /dir/of/flatbuffers
-ttrt perf /dir/of/flatbuffers --loops 10
-ttrt perf /dir/of/flatbuffers --log-file ttrt.log
+ttrt perf --host-only out.ttnn
+ttrt perf /dir/of/flatbuffers --host-only
+ttrt perf /dir/of/flatbuffers --loops 10 --host-only
+ttrt perf /dir/of/flatbuffers --log-file ttrt.log --host-only
 ```
 
 ### check

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -69,6 +69,9 @@ Device openDevice(std::vector<int> const &deviceIds,
 
 void closeDevice(Device device) {
   auto &ttnn_device = device.as<::ttnn::Device>(DeviceRuntime::TTNN);
+#if defined(TT_RUNTIME_ENABLE_PERF_TRACE)
+  ::tt::tt_metal::detail::DumpDeviceProfileResults(&ttnn_device);
+#endif
   ::ttnn::close_device(ttnn_device);
 }
 


### PR DESCRIPTION
Before: We were missing device performance related data in the perf csv file.

Missing: 
An API call which explicity dumps the performance data. This is found in metal's conftest.py file. 
Some env flags needed to clear the L1 cache (otherwise l1 data corruption occurs)
Copying the perf device log csv file to generated logs in ttrt whls path (metal's internal scripts parse relative to TT_METAL_HOME path)