### PR TITLE
Create varg dimension assembly printer

### DIFF
--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.h
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.h
@@ -62,6 +62,27 @@ parseDimensionList(::mlir::AsmParser &odsParser,
   return odsParser.parseDimensionList(dimensions, false, false);
 }
 
+template <typename... Args>
+inline void printVargDimensionList(::mlir::AsmPrinter &printer, Args... dims) {
+  printDimensionList(printer, ::llvm::SmallVector<int64_t>({dims...}));
+}
+
+template <typename... Args>
+inline ::mlir::ParseResult parseVargDimensionList(::mlir::AsmParser &odsParser,
+                                                  Args &...dims) {
+  ::llvm::SmallVector<int64_t> dimensions;
+  ::mlir::ParseResult result = parseDimensionList(odsParser, dimensions);
+  if (succeeded(result)) {
+    ::llvm::SmallVector<std::tuple_element_t<0, std::tuple<Args...>> *> copy(
+        {&dims...});
+    assert(dimensions.size() == sizeof...(dims));
+    for (size_t i = 0; i < dimensions.size(); ++i) {
+      *copy[i] = dimensions[i];
+    }
+  }
+  return result;
+}
+
 inline DataType elementTypeToDataType(Type elementType) {
   DataType dtype = DataType::Float32;
   if (isa<FloatType>(elementType)) {

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -66,7 +66,7 @@ def TT_CoreCoordAttr : TT_Attr<"CoreCoord", "core_coord"> {
   }];
 
   let parameters = (ins "int64_t":$y, "int64_t":$x);
-  let assemblyFormat = "`(` $y `,` $x `)`";
+  let assemblyFormat = "custom<VargDimensionList>($y, $x)";
 }
 
 def TT_TileSizeAttr : TT_Attr<"TileSize", "tile_size"> {
@@ -76,7 +76,7 @@ def TT_TileSizeAttr : TT_Attr<"TileSize", "tile_size"> {
   }];
 
   let parameters = (ins "int64_t":$y, "int64_t":$x);
-  let assemblyFormat = "`(` $y `x` $x `)`";
+  let assemblyFormat = "custom<VargDimensionList>($y, $x)";
 }
 
 
@@ -140,7 +140,7 @@ def TT_ChipCoordAttr : TT_Attr<"ChipCoord", "chip_coord"> {
   }];
 
   let parameters = (ins "unsigned":$rack, "unsigned":$shelf, "unsigned":$y, "unsigned":$x);
-  let assemblyFormat = "`<` $rack `,` $shelf `,` $y `,` $x `>`";
+  let assemblyFormat = "custom<VargDimensionList>($rack, $shelf, $y, $x)";
 }
 
 def TT_ChipChannelAttr : TT_Attr<"ChipChannel", "chip_channel"> {

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
@@ -74,7 +74,7 @@ def TTNN_MeshShapeAttr : TTNN_Attr<"MeshShape", "mesh_shape"> {
   }];
 
   let parameters = (ins "int64_t":$y, "int64_t":$x);
-  let assemblyFormat = "`<` $y `,` $x `>`";
+  let assemblyFormat = "custom<VargDimensionList>($y, $x)";
 }
 
 #endif  // TTMLIR_TTMLIR_DIALECT_TTNN_TTNNOPSATTRS_TD


### PR DESCRIPTION
Support printing shapes with named dims with a varg printer/parser:

    let assemblyFormat = "custom<VargDimensionList>($y, $x)";

For e.g.:

    3x4