### PR TITLE
[Metal Direct] Added support for ttir.exp op

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -128,8 +128,6 @@ def TTIR_DeallocOp : TTIR_Op<"dealloc"> {
 
 //===----------------------------------------------------------------------===//
 // TTIR top level named ops
-//  A named op is one that is not generic and has a specific name. For example
-//  "add", "multiply", "matmul", "concat", etc. They do not carry a region.
 //===----------------------------------------------------------------------===//
 
 class TTIR_ElementwiseOp<string mnemonic, list<Trait> traits = []> :
@@ -160,104 +158,6 @@ class TTIR_ElementwiseUnaryOp<string mnemonic, list<Trait> traits = []> :
         build($_builder, $_state, {out.getType()}, in, out, operand_constraints);
       }]>
     ];
-}
-
-class TTIR_ElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
-    TTIR_ElementwiseOp<mnemonic, traits> {
-    let summary = "Eltwise binary op.";
-    let description = [{
-      Eltwise binary op.
-    }];
-
-    let builders =
-    [
-      OpBuilder<(ins "Value": $lhs, "Value": $rhs, "Value": $out, "ArrayAttr": $operand_constraints),
-      [{
-        build($_builder, $_state, {out.getType()}, {lhs, rhs}, out, operand_constraints);
-      }]>
-    ];
-}
-
-class TTIR_GenericElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
-    TTIR_ElementwiseBinaryOp<mnemonic, !listconcat(traits, [TTIR_GenericRegionOpInterface])> {
-
-    let extraClassDeclaration = [{
-      MutableOperandRange getDpsInitsMutable() { return getOutputsMutable(); }
-
-      void buildGenericRegion(::mlir::OpBuilder &opBuilder, ::mlir::Block* block);
-
-      std::pair<::mlir::ArrayAttr, ::mlir::ArrayAttr> getIndexingMaps(Builder &builder) {
-        assert(sameRank(getOperands()) &&
-               "For now all operands must have the same rank");
-        auto rank = mlir::cast<RankedTensorType>(getOperand(0).getType()).getRank();
-        SmallVector<AffineMap> indexingMaps(getNumOperands(),
-                                            builder.getMultiDimIdentityMap(rank));
-        SmallVector<Attribute> iteratorTypes(
-            rank, builder.getAttr<IteratorTypeAttr>(IteratorType::Parallel));
-        return {builder.getAffineMapArrayAttr(indexingMaps),
-                builder.getArrayAttr(iteratorTypes)};
-      }
-
-      static bool sameRank(mlir::OperandRange operands) {
-        if (operands.empty()) {
-          return true;
-        }
-        auto rank = mlir::cast<RankedTensorType>(operands[0].getType()).getRank();
-        for (auto operand : operands) {
-          if (mlir::cast<RankedTensorType>(operand.getType()).getRank() != rank) {
-            return false;
-          }
-        }
-        return true;
-      }
-    }];
-}
-
-def TTIR_AddOp : TTIR_GenericElementwiseBinaryOp<"add"> {
-    let summary = "Eltwise add.";
-    let description = [{
-      Eltwise add operation.
-    }];
-}
-
-def TTIR_DivOp : TTIR_ElementwiseBinaryOp<"div"> {
-    let summary = "Eltwise divide.";
-    let description = [{
-      Eltwise divide operation.
-    }];
-}
-
-def TTIR_SubtractOp : TTIR_ElementwiseBinaryOp<"subtract"> {
-    let summary = "Eltwise subtract.";
-    let description = [{
-      Eltwise subtract operation.
-    }];
-}
-
-def TTIR_MultiplyOp : TTIR_GenericElementwiseBinaryOp<"multiply"> {
-    let summary = "Eltwise multiply.";
-    let description = [{
-      Eltwise multiply operation.
-    }];
-}
-
-def TTIR_GreaterEqualOp :  TTIR_ElementwiseBinaryOp<"ge"> {
-    let summary = "Eltwise greater than or equal to.";
-    let description = [{
-      Eltwise greater than or equal to operation.
-    }];
-}
-
-def TTIR_MaximumOp :  TTIR_ElementwiseBinaryOp<"maximum"> {
-    let summary = "Eltwise maximum OP.";
-    let description = [{
-      Calculates maximum of input tensors' values element-wise and stores result in output tensor.
-
-      Example:
-        %lhs: [[3, 2, 7], [1, 4, 4]]
-        %rhs: [[1, 4, 2], [1, 2, 3]]
-        "ttir.maximum"(%lhs, %rhs, %out) -> %out: [[3, 4, 7], [1, 4, 4]]
-    }];
 }
 
 def TTIR_AbsOp: TTIR_ElementwiseUnaryOp<"abs"> {
@@ -309,10 +209,52 @@ def TTIR_SigmoidOp: TTIR_ElementwiseUnaryOp<"sigmoid"> {
     }];
 }
 
-def TTIR_ExpOp: TTIR_ElementwiseUnaryOp<"exp"> {
-    let summary = "Eltwise exponential op.";
+class TTIR_ElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
+    TTIR_ElementwiseOp<mnemonic, traits> {
+    let summary = "Eltwise binary op.";
     let description = [{
-      Eltwise exponential operation.
+      Eltwise binary op.
+    }];
+
+    let builders =
+    [
+      OpBuilder<(ins "Value": $lhs, "Value": $rhs, "Value": $out, "ArrayAttr": $operand_constraints),
+      [{
+        build($_builder, $_state, {out.getType()}, {lhs, rhs}, out, operand_constraints);
+      }]>
+    ];
+}
+
+def TTIR_DivOp : TTIR_ElementwiseBinaryOp<"div"> {
+    let summary = "Eltwise divide.";
+    let description = [{
+      Eltwise divide operation.
+    }];
+}
+
+def TTIR_SubtractOp : TTIR_ElementwiseBinaryOp<"subtract"> {
+    let summary = "Eltwise subtract.";
+    let description = [{
+      Eltwise subtract operation.
+    }];
+}
+
+def TTIR_GreaterEqualOp :  TTIR_ElementwiseBinaryOp<"ge"> {
+    let summary = "Eltwise greater than or equal to.";
+    let description = [{
+      Eltwise greater than or equal to operation.
+    }];
+}
+
+def TTIR_MaximumOp :  TTIR_ElementwiseBinaryOp<"maximum"> {
+    let summary = "Eltwise maximum OP.";
+    let description = [{
+      Calculates maximum of input tensors' values element-wise and stores result in output tensor.
+
+      Example:
+        %lhs: [[3, 2, 7], [1, 4, 4]]
+        %rhs: [[1, 4, 2], [1, 2, 3]]
+        "ttir.maximum"(%lhs, %rhs, %out) -> %out: [[3, 4, 7], [1, 4, 4]]
     }];
 }
 
@@ -642,6 +584,104 @@ def TTIR_MatmulOp : TTIR_DPSOp<"matmul"> {
     let hasVerifier = 1;
 }
 // ANCHOR_END: adding_an_op_matmul_ttir
+
+//===----------------------------------------------------------------------===//
+// TTIR top level generic ops
+//===----------------------------------------------------------------------===//
+
+class TTIR_GenericElementwiseUnaryOp<string mnemonic, list<Trait> traits = []> :
+    TTIR_ElementwiseUnaryOp<mnemonic, !listconcat(traits, [TTIR_GenericRegionOpInterface])> {
+
+    let extraClassDeclaration = [{
+      MutableOperandRange getDpsInitsMutable() { return getOutputsMutable(); }
+
+      void buildGenericRegion(::mlir::OpBuilder &opBuilder, ::mlir::Block* block);
+
+      std::pair<::mlir::ArrayAttr, ::mlir::ArrayAttr> getIndexingMaps(Builder &builder) {
+        assert(getNumOperands() == 2 && "Input and output operand must have the same rank");
+        assert(sameRank(getOperands()) &&
+               "Elementwise unary op must have only one input and one output operand.");
+
+        auto rank = mlir::cast<RankedTensorType>(getOperand(0).getType()).getRank();
+
+        SmallVector<AffineMap> indexingMaps(2, builder.getMultiDimIdentityMap(rank));
+        SmallVector<Attribute> iteratorTypes(
+            rank, builder.getAttr<IteratorTypeAttr>(IteratorType::Parallel));
+
+        return {builder.getAffineMapArrayAttr(indexingMaps),
+                builder.getArrayAttr(iteratorTypes)};
+      }
+
+      static bool sameRank(mlir::OperandRange operands) {
+        if (operands.empty()) {
+          return true;
+        }
+        auto rank = mlir::cast<RankedTensorType>(operands[0].getType()).getRank();
+        for (auto operand : operands) {
+          if (mlir::cast<RankedTensorType>(operand.getType()).getRank() != rank) {
+            return false;
+          }
+        }
+        return true;
+      }
+    }];
+}
+
+def TTIR_ExpOp: TTIR_GenericElementwiseUnaryOp<"exp"> {
+    let summary = "Eltwise exponential op.";
+    let description = [{
+      Eltwise exponential operation. Calculates e^x for all elements x in input tensor.
+    }];
+}
+
+class TTIR_GenericElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
+    TTIR_ElementwiseBinaryOp<mnemonic, !listconcat(traits, [TTIR_GenericRegionOpInterface])> {
+
+    let extraClassDeclaration = [{
+      MutableOperandRange getDpsInitsMutable() { return getOutputsMutable(); }
+
+      void buildGenericRegion(::mlir::OpBuilder &opBuilder, ::mlir::Block* block);
+
+      std::pair<::mlir::ArrayAttr, ::mlir::ArrayAttr> getIndexingMaps(Builder &builder) {
+        assert(sameRank(getOperands()) &&
+               "For now all operands must have the same rank");
+        auto rank = mlir::cast<RankedTensorType>(getOperand(0).getType()).getRank();
+        SmallVector<AffineMap> indexingMaps(getNumOperands(),
+                                            builder.getMultiDimIdentityMap(rank));
+        SmallVector<Attribute> iteratorTypes(
+            rank, builder.getAttr<IteratorTypeAttr>(IteratorType::Parallel));
+        return {builder.getAffineMapArrayAttr(indexingMaps),
+                builder.getArrayAttr(iteratorTypes)};
+      }
+
+      static bool sameRank(mlir::OperandRange operands) {
+        if (operands.empty()) {
+          return true;
+        }
+        auto rank = mlir::cast<RankedTensorType>(operands[0].getType()).getRank();
+        for (auto operand : operands) {
+          if (mlir::cast<RankedTensorType>(operand.getType()).getRank() != rank) {
+            return false;
+          }
+        }
+        return true;
+      }
+    }];
+}
+
+def TTIR_AddOp : TTIR_GenericElementwiseBinaryOp<"add"> {
+    let summary = "Eltwise add.";
+    let description = [{
+      Eltwise add operation.
+    }];
+}
+
+def TTIR_MultiplyOp : TTIR_GenericElementwiseBinaryOp<"multiply"> {
+    let summary = "Eltwise multiply.";
+    let description = [{
+      Eltwise multiply operation.
+    }];
+}
 
 //===----------------------------------------------------------------------===//
 // TTIR region ops (ops that may appear inside of ttir.generic region)

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -65,20 +65,6 @@ def TTKernel_UnpackABOp : TTKernel_Op<"unpack_ab"> {
     let arguments = (ins TTKernel_CB:$cb_a, I32:$src_a_index, TTKernel_CB:$cb_b, I32:$src_b_index);
 }
 
-def TTKernel_AcquireDstOp : TTKernel_Op<"acquire_dst"> {
-    let summary = "Aquire dest call.";
-    let description = [{
-      Aquire dest operation
-    }];
-}
-
-def TTKernel_ReleaseDstOp : TTKernel_Op<"release_dst"> {
-    let summary = "Release dest call.";
-    let description = [{
-      Release dest operation
-    }];
-}
-
 def TTKernel_TileRegsAcquireOp : TTKernel_Op<"tile_regs_acquire"> {
     let summary = "tile_regs_acquire";
     let description = [{
@@ -120,7 +106,7 @@ def TTKernel_PackTileOp : TTKernel_Op<"pack_tile"> {
       number n > 0 of tiles in the output CB. out_tile_index = 0 then references
       the first tile in the reserved section of the CB, up to index n - 1, which will
       then be visible to the consumer in the same order after a cb_push_back call.
-      The DST register buffer must be in acquired state via *acquire_dst* call.
+      The DST register buffer must be in acquired state via *tile_regs_acquire* call.
       This call is blocking and is only available on the compute engine.
 
       Each subsequent pack call will increment the write pointer in the cb by single
@@ -137,6 +123,23 @@ def TTKernel_PackTileOp : TTKernel_Op<"pack_tile"> {
     }];
 
     let arguments = (ins I32:$dst_index, TTKernel_CB:$out_cb, I32:$out_index);
+}
+
+def TTKernel_CopyTileOp : TTKernel_Op<"copy_tile"> {
+    let summary = "copy_tile";
+    let description = [{
+      Copies a single tile from the specified input CB and writes the result to
+      DST at a specified index. The function will employ unpacker to first unpack into SRC
+      registers and then perform move into DST registers, at a specified index.
+      For the in_tile_index to be valid for this call, cb_wait_front(n) had to be
+      previously called to ensure that at least some number n>0 of tiles are available
+      in the input CB. The CB index 0 then references the first tile in the received section of the CB,
+      up to index n-1 (in a FIFO order). The DST register buffer must be in acquired state via
+      tile_regs_acquire call. This call is blocking and is only available on the compute
+      engine.
+    }];
+
+    let arguments = (ins TTKernel_CB:$cb0, I32:$tile_index_0, I32:$tile_index_1);
 }
 
 //===----------------------------------------------------------------------===//
@@ -202,7 +205,7 @@ def TTKernel_AddTilesOp : TTKernel_Op<"add_tiles"> {
     let description = [{
       Performs element-wise addition C=A+B of tiles in two CBs at given indices
       and writes the result to the DST register at index dst_tile_index. The DST
-      register buffer must be in acquired state via *acquire_dst* call. This call
+      register buffer must be in acquired state via *tile_regs_acquire* call. This call
       is blocking and is only available on the compute engine.
     }];
 
@@ -223,11 +226,40 @@ def TTKernel_MulTilesOp : TTKernel_Op<"mul_tiles"> {
     let description = [{
       Performs element-wise multiplication C=A*B of tiles in two CBs at given
       indices and writes the result to the DST register at index dst_tile_index.
-      The DST register buffer must be in acquired state via *acquire_dst* call.
+      The DST register buffer must be in acquired state via *tile_regs_acquire* call.
       This call is blocking and is only available on the compute engine.
     }];
 
     let arguments = (ins TTKernel_CB:$in0_cb, TTKernel_CB:$in1_cb, I32:$in0_tile_index, I32:$in1_tile_index, I32:$dst_index);
+}
+
+def TTKernel_UnaryOpInitCommonOp : TTKernel_Op<"unary_op_init_common"> {
+    let summary = "Initialization function for unary operations.";
+    let description = [{
+      This operation initializes all necessary components for unary operations,
+      including unpacking, packing, and math configurations.
+    }];
+
+    let arguments = (ins TTKernel_CB:$icb, TTKernel_CB:$ocb);
+}
+
+def TTKernel_ExpTileInitOp : TTKernel_Op<"exp_tile_init"> {
+    let summary = "Short init function which configures compute unit for execution of exp_tile.";
+    let description = [{
+      Must be run before exp_tile.
+    }];
+}
+
+def TTKernel_ExpTileOp : TTKernel_Op<"exp_tile"> {
+    let summary = "Exp operation";
+    let description = [{
+      Performs element-wise computation of exponential on each element of a tile
+      in DST register at index tile_index. The DST register buffer must be in
+      acquired state via *tile_regs_acquire* call. This call is blocking and is only
+      available on the compute engine.
+    }];
+
+    let arguments = (ins I32:$tile_index);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -283,7 +283,11 @@ public:
                TTMetalToEmitCOpaqueRewriter<ttkernel::NocAsyncReadOp>,
                TTMetalToEmitCOpaqueRewriter<ttkernel::NocAsyncReadBarrierOp>,
                TTMetalToEmitCOpaqueRewriter<ttkernel::NocAsyncWriteOp>,
-               TTMetalToEmitCOpaqueRewriter<ttkernel::NocAsyncWriteBarrierOp>>(
+               TTMetalToEmitCOpaqueRewriter<ttkernel::NocAsyncWriteBarrierOp>,
+               TTMetalToEmitCOpaqueRewriter<ttkernel::UnaryOpInitCommonOp>,
+               TTMetalToEmitCOpaqueRewriter<ttkernel::CopyTileOp>,
+               TTMetalToEmitCOpaqueRewriter<ttkernel::ExpTileInitOp>,
+               TTMetalToEmitCOpaqueRewriter<ttkernel::ExpTileOp>>(
               typeConverter, funcOp.getContext());
 
       if (failed(applyFullConversion(funcOp, target, std::move(patterns)))) {
@@ -324,6 +328,21 @@ public:
       builder->create<emitc::IncludeOp>(loc,
                                         "compute_kernel_api/eltwise_binary.h",
                                         /*isStandard=*/false);
+      builder->create<emitc::IncludeOp>(loc,
+                                        "compute_kernel_api/tile_move_copy.h",
+                                        /*isStandard=*/false);
+      builder->create<emitc::IncludeOp>(
+          loc, "compute_kernel_api/eltwise_unary/eltwise_unary.h",
+          /*isStandard=*/false);
+      // TODO (kmitrovic) exp.h is an ExpOp-specific include. Every op has one,
+      // should be handled in general, not like this.
+      // Issue: https://github.com/tenstorrent/tt-mlir/issues/772
+      builder->create<emitc::IncludeOp>(
+          loc, "compute_kernel_api/eltwise_unary/exp.h",
+          /*isStandard=*/false);
+      builder->create<emitc::IncludeOp>(
+          loc, "compute_kernel_api/eltwise_unary/sfpu_split_includes.h",
+          /*isStandard=*/false);
       builder->create<emitc::VerbatimOp>(loc, "namespace NAMESPACE {");
     }
   }

--- a/test/python/simple_kernel.py
+++ b/test/python/simple_kernel.py
@@ -20,8 +20,8 @@ class TTKernelBuilder(ast.NodeVisitor):
         "pop": ttkernel.cb_pop_front,
     }
     t6_fn_map = {
-        "acquire_dst": ttkernel.acquire_dst,
-        "release_dst": ttkernel.release_dst,
+        "tile_regs_acquire": ttkernel.tile_regs_acquire,
+        "tile_regs_release": ttkernel.tile_regs_release,
         "pack": ttkernel.pack,
         "unpack_a": ttkernel.unpack_a,
         "unpack_ab": ttkernel.unpack_ab,
@@ -210,10 +210,10 @@ class Tensix:
     def __init__(self, srcA_dtype, srcB_dtype, dst_dtype):
         pass
 
-    def acquire_dst(self):
+    def tile_regs_acquire(self):
         pass
 
-    def release_dst(self):
+    def tile_regs_release(self):
         pass
 
 
@@ -244,11 +244,11 @@ def ttkernel_compile(f):
         # CHECK: "scf.for"[[C:.*]]
         # CHECK: "ttkernel.cb_wait_front"[[C:.*]]
         # CHECK: "ttkernel.cb_reserve_back"[[C:.*]]
-        # CHECK: "ttkernel.acquire_dst"[[C:.*]]
+        # CHECK: "ttkernel.tile_regs_acquire"[[C:.*]]
         # CHECK: "ttkernel.unpack_ab"[[C:.*]]
         # CHECK: "ttkernel.add"[[C:.*]]
         # CHECK: "ttkernel.pack"[[C:.*]]
-        # CHECK: "ttkernel.release_dst"[[C:.*]]
+        # CHECK: "ttkernel.tile_regs_release"[[C:.*]]
         # CHECK: "ttkernel.cb_pop_front"[[C:.*]]
         # CHECK: "ttkernel.cb_push_back"[[C:.*]]
         print(b.module)
@@ -277,11 +277,11 @@ def eltwise(
                 in0.wait()
                 in1.wait()
                 out.reserve()
-                t6.acquire_dst()
+                t6.tile_regs_acquire()
                 t6.unpack_ab(in0, 0, in1, 0)
                 t6.add(0)
                 t6.pack(0, out, 0)
-                t6.release_dst()
+                t6.tile_regs_release()
                 in0.pop()
                 in1.pop()
                 out.push()

--- a/test/ttmlir/Silicon/TTMetal/simple_eltwise.mlir
+++ b/test/ttmlir/Silicon/TTMetal/simple_eltwise.mlir
@@ -19,3 +19,11 @@ func.func @add(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<6
   %1 = "ttir.add"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
   return %1 : tensor<64x128xf32>
 }
+
+func.func @exp(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
+  %0 = tensor.empty() : tensor<64x128xf32>
+  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  %1 = "ttir.exp"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>, operand_constraints = [#any_device, #any_device]}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  return %1 : tensor<64x128xf32>
+}


### PR DESCRIPTION
## Summary

Fixes https://github.com/tenstorrent/tt-mlir/issues/534.

Added TTIR_GenericElementwiseUnaryOp. Made TTIR_ExpOp inherit from it. Handled lowering to ttkernel.

- Refactored TTIRToTTMetalDispatchRewriter to include common building steps as well as some separate steps for unary and binary ops
- Deprecated AcquireDstOp and ReleaseDstOp in favor of up-to-date metal tile_regs_* API: acquire, commit, wait, release

## Example:

Running `ttmlir-opt` on 
```mlir
func.func @exp(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
  // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
  %0 = tensor.empty() : tensor<64x128xf32>
  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
  %1 = "ttir.exp"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>, operand_constraints = [#any_device, #any_device]}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
  return %1 : tensor<64x128xf32>
}
```

produces (only actual compute kernel shown)

```mlir
%3 = "ttmetal.dispatch"(%1, %2) <{core_ranges = [#ttmetal.core_range<0x0, 1x1>], kernelConfigs = [#ttkernel.tensix_config<hifi4, false, false, false>], operandSegmentSizes = array<i32: 1, 1>}> ({
^bb0(%arg1: !ttkernel.cb<cb_in0, 140128, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, %arg2: !ttkernel.cb<cb_out0, 172896, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>):
  %c4_i32 = arith.constant 4 : i32
  %c1_i32 = arith.constant 1 : i32
  %c2_i32 = arith.constant 2 : i32
  %c0_i32 = arith.constant 0 : i32
  "ttkernel.unary_op_init_common"(%arg1, %arg2) : (!ttkernel.cb<cb_in0, 140128, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, !ttkernel.cb<cb_out0, 172896, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>) -> ()
  "ttkernel.exp_tile_init"() : () -> ()
  %6 = scf.for %arg3 = %c0_i32 to %c2_i32 step %c1_i32 iter_args(%arg4 = %c0_i32) -> (i32)  : i32 {
    %7 = scf.for %arg5 = %c0_i32 to %c4_i32 step %c1_i32 iter_args(%arg6 = %arg4) -> (i32)  : i32 {
      "ttkernel.tile_regs_acquire"() : () -> ()
      "ttkernel.copy_tile"(%arg1, %arg6, %c0_i32) : (!ttkernel.cb<cb_in0, 140128, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, i32, i32) -> ()
      "ttkernel.exp_tile"(%c0_i32) : (i32) -> ()
      "ttkernel.tile_regs_commit"() : () -> ()
      "ttkernel.tile_regs_wait"() : () -> ()
      "ttkernel.pack_tile"(%c0_i32, %arg2, %arg6) : (i32, !ttkernel.cb<cb_out0, 172896, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, i32) -> ()
      "ttkernel.tile_regs_release"() : () -> ()
      %8 = arith.addi %arg6, %c1_i32 : i32
      scf.yield %8 : i32
    }
    scf.yield %7 : i32
  }
  "ttkernel.return"() : () -> ()
}) : (tensor<64x128xf32, #layout1>, tensor<64x128xf32, #layout1>) -> tensor<64x128xf32, #layout1>
```

which resembles already existing form for binary ops like

```mlir
    %5 = "ttmetal.dispatch"(%1, %3, %4) <{core_ranges = [#ttmetal.core_range<0x0, 1x1>], kernelConfigs = [#ttkernel.tensix_config<hifi4, false, false, false>], operandSegmentSizes = array<i32: 2, 1>}> ({
    ^bb0(%arg2: !ttkernel.cb<cb_in0, 172896, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, %arg3: !ttkernel.cb<cb_in1, 205664, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, %arg4: !ttkernel.cb<cb_out0, 238432, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>):
      %c4_i32 = arith.constant 4 : i32
      %c1_i32 = arith.constant 1 : i32
      %c2_i32 = arith.constant 2 : i32
      %c0_i32 = arith.constant 0 : i32
      "ttkernel.binary_op_init_common"(%arg2, %arg3, %arg4) : (!ttkernel.cb<cb_in0, 172896, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, !ttkernel.cb<cb_in1, 205664, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, !ttkernel.cb<cb_out0, 238432, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>) -> ()
      "ttkernel.add_tiles_init"(%arg2, %arg3) : (!ttkernel.cb<cb_in0, 172896, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, !ttkernel.cb<cb_in1, 205664, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>) -> ()
      %8 = scf.for %arg5 = %c0_i32 to %c2_i32 step %c1_i32 iter_args(%arg6 = %c0_i32) -> (i32)  : i32 {
        %9 = scf.for %arg7 = %c0_i32 to %c4_i32 step %c1_i32 iter_args(%arg8 = %arg6) -> (i32)  : i32 {
          "ttkernel.tile_regs_acquire"() : () -> ()
          "ttkernel.add_tiles"(%arg2, %arg3, %arg8, %arg8, %c0_i32) : (!ttkernel.cb<cb_in0, 172896, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, !ttkernel.cb<cb_in1, 205664, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, i32, i32, i32) -> ()
          "ttkernel.tile_regs_commit"() : () -> ()
          "ttkernel.tile_regs_wait"() : () -> ()
          "ttkernel.pack_tile"(%c0_i32, %arg4, %arg8) : (i32, !ttkernel.cb<cb_out0, 238432, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, i32) -> ()
          "ttkernel.tile_regs_release"() : () -> ()
          %10 = arith.addi %arg8, %c1_i32 : i32
          scf.yield %10 : i32
        }
        scf.yield %9 : i32
      }
      "ttkernel.return"() : () -> ()
    }) : (tensor<64x128xf32, #layout1>, tensor<64x128xf32, #layout1>, tensor<64x128xf32, #layout1>) -> tensor<64x128xf32, #layout1>
```

even though it is different from original `tt_metal/kernels/compute/eltwise_sfpu.cpp` form, because this way made more sense logically (like executing `tile_regs_wait` after `tile_regs_commit`, not after `tile_regs_acquire`, like moving unary-op-specific init function before for loops, not right before unary op itself, etc).

Running this through `ttrt` produces kernel

```cpp
void kernel_main() {
  ::tt::CB v1 = ::tt::CB::c_in0;
  ::tt::CB v2 = ::tt::CB::c_out0;
  int32_t v3 = 4;
  int32_t v4 = 1;
  int32_t v5 = 2;
  int32_t v6 = 0;
  unary_op_init_common(v1, v2);
  exp_tile_init();
  int32_t v7;
  v7 = v6;
  for (int32_t v8 = v6; v8 < v5; v8 += v4) {
    int32_t v9;
    v9 = v7;
    for (int32_t v10 = v6; v10 < v3; v10 += v4) {
      tile_regs_acquire();
      copy_tile(v1, v9, v6);
      exp_tile(v6);
      tile_regs_commit();
      tile_regs_wait();
      pack_tile(v6, v2, v9);
      tile_regs_release();
      uint32_t v11 = (uint32_t) v9;
      uint32_t v12 = (uint32_t) v4;
      uint32_t v13 = v11 + v12;
      int32_t v14 = (int32_t) v13;
      v9 = v14;
    };
    v7 = v9;
  }
  return;
}
```

Collecting generated input and output tensor and passing them through python script (PR here https://github.com/tenstorrent/tt-mlir/pull/760) comparing `golden = numpy.exp(input)` with device generated output gives `True` for `np.allclose(output_tile, golden_tile, rtol=1e-1, atol=1e-1)` for each tile in tensor.
