### PR TITLE
Fix tensor read (device->host path)

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -59,6 +59,16 @@ def TTNN_ToDeviceOp : TTNN_Op<"to_device"> {
     let results = (outs AnyRankedTensor:$result);
 }
 
+def TTNN_FromDeviceOp : TTNN_Op<"from_device"> {
+    let summary = "FromDevice op.";
+    let description = [{
+    }];
+
+    let arguments = (ins AnyRankedTensor:$input);
+    let results = (outs AnyRankedTensor:$result);
+}
+
+
 class TTNN_NamedDPSOp<string mnemonic, list<Trait> traits = []> :
     TTNN_Op<mnemonic, !listconcat(traits, [DestinationStyleOpInterface])> {
     let extraClassDeclaration = [{

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -29,6 +29,11 @@ table ToDeviceOp {
   out: tt.target.TensorRef;
 }
 
+table FromDeviceOp {
+  in: tt.target.TensorRef;
+  out: tt.target.TensorRef;
+}
+
 table EmptyOp {
   shape: [int64];
   dtype: DataType;
@@ -169,6 +174,7 @@ union OpType {
   ToMemoryConfigOp,
   ToLayoutOp,
   ToDeviceOp,
+  FromDeviceOp,
   EmptyOp,
   FullOp,
   EltwiseOp,

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -331,6 +331,30 @@ public:
   }
 };
 
+// FromDeviceOp conversion pattern
+//
+class FromDeviceOpConversionPattern
+    : public TTNNToEmitCBaseOpConversionPattern<ttnn::FromDeviceOp> {
+
+public:
+  FromDeviceOpConversionPattern(const TypeConverter &typeConverter,
+                                MLIRContext *context,
+                                PatternBenefit benefit = 1)
+      : TTNNToEmitCBaseOpConversionPattern<ttnn::FromDeviceOp>(
+            typeConverter, context, benefit) {}
+
+  LogicalResult
+  matchAndRewrite(ttnn::FromDeviceOp srcOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
+        srcOp, this->getTypeConverter()->convertType(srcOp.getType()),
+        this->convertOpName(srcOp), nullptr, nullptr, adaptor.getOperands());
+
+    return success();
+  }
+};
+
 // ToLayoutOp conversion pattern
 //
 class ToLayoutOpConversionPattern
@@ -488,11 +512,10 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
 
   // Memory ops
   //
-  patterns
-      .add<ToLayoutOpConversionPattern,
-           DefaultOpConversionPattern<ttnn::ToMemoryConfigOp>,
-           ToDeviceOpConversionPattern /*, MemoryConfigOpConversionPattern*/>(
-          typeConverter, ctx);
+  patterns.add<ToLayoutOpConversionPattern,
+               DefaultOpConversionPattern<ttnn::ToMemoryConfigOp>,
+               ToDeviceOpConversionPattern, FromDeviceOpConversionPattern>(
+      typeConverter, ctx);
 
   // Tensor ops
   //

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -137,6 +137,19 @@ createOp(FlatbufferObjectCache &cache, ToDeviceOp op) {
       memoryConfigDesc, output);
 }
 
+::flatbuffers::Offset<::tt::target::ttnn::FromDeviceOp>
+createOp(FlatbufferObjectCache &cache, FromDeviceOp op) {
+  constexpr uint64_t kHostAllocatedAddress = 0;
+  constexpr uint64_t kHostAllocatedSize = 0;
+  auto input =
+      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
+
+  auto output = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
+                                  kHostAllocatedAddress, kHostAllocatedSize);
+
+  return ::tt::target::ttnn::CreateFromDeviceOp(*cache.fbb, input, output);
+}
+
 ::flatbuffers::Offset<::tt::target::ttnn::EmptyOp>
 createOp(FlatbufferObjectCache &cache, EmptyOp op) {
   constexpr uint64_t kHostAllocatedAddress = 0;
@@ -404,6 +417,9 @@ emitTTNNOperation(FlatbufferObjectCache &cache, Operation *op,
   }
   if (auto toDeviceOp = dyn_cast<ToDeviceOp>(op); toDeviceOp) {
     return createOperation(cache, createOp(cache, toDeviceOp), debugString);
+  }
+  if (auto fromDeviceOp = dyn_cast<FromDeviceOp>(op); fromDeviceOp) {
+    return createOperation(cache, createOp(cache, fromDeviceOp), debugString);
   }
   if (auto emptyOp = dyn_cast<EmptyOp>(op); emptyOp) {
     return createOperation(cache, createOp(cache, emptyOp), debugString);

--- a/runtime/lib/ttnn/operations/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/CMakeLists.txt
@@ -11,6 +11,7 @@ set(TTNN_OPS_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/eltwise/unary.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/embedding/embedding.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/layout/to_device.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/layout/from_device.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/layout/to_layout.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/layout/to_memory_config.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/matmul/matmul.cpp

--- a/runtime/lib/ttnn/operations/layout/from_device.cpp
+++ b/runtime/lib/ttnn/operations/layout/from_device.cpp
@@ -8,17 +8,13 @@
 #include "tt/runtime/ttnn/utils.h"
 
 namespace tt::runtime::ttnn::operations::layout {
-void run(const ::tt::target::ttnn::ToDeviceOp *op, ProgramContext &context) {
+void run(const ::tt::target::ttnn::FromDeviceOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.tensorPool;
-  DeviceMap &devicePool = context.devicePool;
   const ::ttnn::Tensor &inputTensor = tensorPool.at(op->in()->global_id());
-  assert(utils::isOnHost(inputTensor) &&
-         "Calling ttnn::to_device on a device tensor");
+  assert(utils::isOnDevice(inputTensor) &&
+         "Calling ttnn::from_device on a host tensor");
 
-  ::ttnn::MemoryConfig memoryConfig =
-      utils::createMemoryConfig(op->memcfg(), op->out());
-  ::ttnn::Device &device = utils::getDevice(op->device(), devicePool);
-  ::ttnn::Tensor out = ::ttnn::to_device(inputTensor, &device, memoryConfig);
+  ::ttnn::Tensor out = ::ttnn::from_device(inputTensor);
 
   tensorPool.try_emplace(op->out()->global_id(), out);
 }

--- a/runtime/lib/ttnn/operations/layout/from_device.h
+++ b/runtime/lib/ttnn/operations/layout/from_device.h
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTNN_RUNTIME_FROM_DEVICE_H
+#define TTNN_RUNTIME_FROM_DEVICE_H
+
+#include "tt/runtime/ttnn/types.h"
+#include "ttmlir/Target/TTNN/program_generated.h"
+
+namespace tt::runtime::ttnn::operations::layout {
+void run(const ::tt::target::ttnn::FromDeviceOp *op, ProgramContext &context);
+} // namespace tt::runtime::ttnn::operations::layout
+
+#endif // TTNN_RUNTIME_FROM_DEVICE_H

--- a/runtime/lib/ttnn/program.cpp
+++ b/runtime/lib/ttnn/program.cpp
@@ -12,6 +12,7 @@
 #include "operations/eltwise/binary.h"
 #include "operations/eltwise/unary.h"
 #include "operations/embedding/embedding.h"
+#include "operations/layout/from_device.h"
 #include "operations/layout/to_device.h"
 #include "operations/layout/to_layout.h"
 #include "operations/layout/to_memory_config.h"
@@ -52,6 +53,9 @@ void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
   }
   case ::tt::target::ttnn::OpType::ToDeviceOp: {
     return operations::layout::run(op->type_as_ToDeviceOp(), context);
+  }
+  case ::tt::target::ttnn::OpType::FromDeviceOp: {
+    return operations::layout::run(op->type_as_FromDeviceOp(), context);
   }
   case ::tt::target::ttnn::OpType::EmptyOp: {
     return operations::creation::run(op->type_as_EmptyOp(), context);

--- a/tools/ttnn-standalone/ttnn-standalone.cpp
+++ b/tools/ttnn-standalone/ttnn-standalone.cpp
@@ -34,8 +34,10 @@ ttnn::Tensor forward(ttnn::Tensor v1, ttnn::Tensor v2) {
   ttnn::Tensor v13 = ttnn::empty(v10, ttnn::DataType::FLOAT32,
                                  ttnn::Layout::ROW_MAJOR, v11, v12);
   ttnn::Tensor v14 = ttnn::multiply(v6, v9, std::nullopt, std::nullopt, v13);
-  // ttnn::Tensor v15 = ttnn::to_memory_config(v14, v3);
-  return v14.cpu();
+  ttnn::Tensor v15 = ttnn::from_device(v14);
+  ttnn::Tensor v16 = ttnn::to_layout(v15, ttnn::Layout::ROW_MAJOR, std::nullopt,
+                                     std::nullopt, v3);
+  return v16;
 }
 
 int main() {

--- a/tools/ttnn-standalone/ttnn-standalone.cpp
+++ b/tools/ttnn-standalone/ttnn-standalone.cpp
@@ -34,9 +34,9 @@ ttnn::Tensor forward(ttnn::Tensor v1, ttnn::Tensor v2) {
   ttnn::Tensor v13 = ttnn::empty(v10, ttnn::DataType::FLOAT32,
                                  ttnn::Layout::ROW_MAJOR, v11, v12);
   ttnn::Tensor v14 = ttnn::multiply(v6, v9, std::nullopt, std::nullopt, v13);
-  ttnn::Tensor v15 = ttnn::from_device(v14);
-  ttnn::Tensor v16 = ttnn::to_layout(v15, ttnn::Layout::ROW_MAJOR, std::nullopt,
+  ttnn::Tensor v15 = ttnn::to_layout(v14, ttnn::Layout::ROW_MAJOR, std::nullopt,
                                      std::nullopt, v3);
+  ttnn::Tensor v16 = ttnn::from_device(v15);
   return v16;
 }
 


### PR DESCRIPTION
Currently, we're calling to_memory_config to get tensor from device to host. This isn't correct, so we're changing to the approach used in ttnn lib, which is to call `FromDevice` + `ToLayout` ops, as can be seen in the `to_torch` method in `third_party/tt-metal/src/tt-metal/ttnn/ttnn/operations/core.py`:
```py
    if ttnn.is_tensor_storage_on_device(tensor):
        tensor = ttnn.from_device(tensor, cq_id=cq_id)

    if tensor.layout != ttnn.ROW_MAJOR_LAYOUT:
        tensor = tensor.to(ttnn.ROW_MAJOR_LAYOUT, device)
```

This PR updates the conversion of `ToLayout` op from TTIR to TTNN. It also adds the `FromDevice` op.