### PR TITLE
Async TTNN: Use fields from flatbuffer when possible, update APIs

### DIFF
--- a/docs/src/ttrt.md
+++ b/docs/src/ttrt.md
@@ -176,7 +176,7 @@ ttrt run /dir/of/flatbuffers --loops 10
 ttrt run /dir/of/flatbuffers --log-file ttrt.log
 ttrt run out.ttnn --save-artifacts --artifact-dir /path/to/some/dir
 ttrt run out.ttnn --load-kernels-from-disk
-ttrt run out.ttnn --disable-async-ttnn
+ttrt run out.ttnn --enable-async-ttnn
 ```
 
 ### query

--- a/runtime/include/tt/runtime/detail/debug.h
+++ b/runtime/include/tt/runtime/detail/debug.h
@@ -15,7 +15,7 @@ struct Env {
 #else
   constexpr static Env
 #endif
-  get(bool loadKernelsFromDisk = false, bool disableAsyncTTNN = false)
+  get(bool loadKernelsFromDisk = false, bool enableAsyncTTNN = false)
 #if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
       ;
 #else
@@ -25,18 +25,18 @@ struct Env {
 #endif
 
   bool loadKernelsFromDisk;
-  bool disableAsyncTTNN;
+  bool enableAsyncTTNN;
 
 private:
-  constexpr Env(bool loadKernelsFromDisk, bool disableAsyncTTNN)
+  constexpr Env(bool loadKernelsFromDisk, bool enableAsyncTTNN)
       : loadKernelsFromDisk(loadKernelsFromDisk),
-        disableAsyncTTNN(disableAsyncTTNN) {}
+        enableAsyncTTNN(enableAsyncTTNN) {}
 };
 
 inline std::ostream &operator<<(std::ostream &os, Env const &env) {
   os << "Env{\n"
      << "\t" << "loadKernelsFromDisk: " << env.loadKernelsFromDisk << ",\n"
-     << "\t" << "disableAsyncTTNN: " << env.disableAsyncTTNN << "\n"
+     << "\t" << "enableAsyncTTNN: " << env.enableAsyncTTNN << "\n"
      << "}";
   return os;
 }

--- a/runtime/lib/common/debug.cpp
+++ b/runtime/lib/common/debug.cpp
@@ -8,8 +8,8 @@
 
 namespace tt::runtime::debug {
 
-Env const &Env::get(bool loadKernelsFromDisk, bool disableAsyncTTNN) {
-  static Env config(loadKernelsFromDisk, disableAsyncTTNN);
+Env const &Env::get(bool loadKernelsFromDisk, bool enableAsyncTTNN) {
+  static Env config(loadKernelsFromDisk, enableAsyncTTNN);
   return config;
 }
 

--- a/runtime/lib/ttnn/operations/conv/conv2d.cpp
+++ b/runtime/lib/ttnn/operations/conv/conv2d.cpp
@@ -17,8 +17,8 @@ void run(const ::tt::target::ttnn::Conv2dOp *op, ProgramContext &context) {
       op->bias() ? std::make_optional(tensorPool.at(op->bias()->global_id()))
                  : std::nullopt;
   auto config = ::ttnn::operations::conv::conv2d::Conv2dConfig();
-  config.dtype = input.dtype();
-  config.weights_dtype = weight.dtype();
+  config.dtype = utils::getDataType(op->input());
+  config.weights_dtype = utils::getDataType(op->weight());
   ::ttnn::Device &device = utils::getDevice(op->device(), devicePool);
   ::ttnn::Tensor out =
       std::get<0>(::ttnn::operations::conv::conv2d::conv2d<::ttnn::Device>(
@@ -29,7 +29,6 @@ void run(const ::tt::target::ttnn::Conv2dOp *op, ProgramContext &context) {
           {op->padding_height(), op->padding_width()},
           {op->dilation_height(), op->dilation_width()}, op->groups(), bias,
           config));
-
   tensorPool.insert_or_assign(op->out()->global_id(), out);
 }
 } // namespace tt::runtime::ttnn::operations::conv

--- a/runtime/lib/ttnn/operations/data_movement/transpose.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/transpose.cpp
@@ -12,7 +12,7 @@ void run(const ::tt::target::ttnn::TransposeOp *op, ProgramContext &context) {
   const ::ttnn::Tensor &in = tensorPool.at(op->in()->global_id());
   int32_t dim0 = op->dim0();
   int32_t dim1 = op->dim1();
-  auto inputRank = in.get_shape().rank();
+  auto inputRank = op->in()->desc()->layout()->stride()->size();
   // for the current version of permute, we need to work in 4D, so we add
   // leading dimensions of size 1
   std::vector<std::int64_t> dimensionOrder(4);

--- a/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/utils.cpp
+++ b/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/utils.cpp
@@ -21,6 +21,7 @@ bool isOnDevice(const ::ttnn::Tensor &tensor) {
   return ::tt::runtime::ttnn::utils::toTTNNDataType(
       tensorRef->desc()->layout()->memory_desc()->data_type());
 }
+
 ::ttnn::Device &getDevice(const ::tt::target::DeviceRef *deviceRef,
                           DeviceMap &devicePool) {
   uint32_t deviceId = deviceRef->global_id();

--- a/runtime/lib/ttnn/operations/layout/to_memory_config.cpp
+++ b/runtime/lib/ttnn/operations/layout/to_memory_config.cpp
@@ -29,6 +29,9 @@ static ::ttnn::Tensor convertDataType(const ::ttnn::Tensor &input,
   }
 
   if (utils::isOnDevice(input)) {
+    // TODO (bug #272): right now hardcoding tilize/untilize
+    // should determine layout with tile shape instead of calling a getter
+    // function
     if (input.get_layout() != ::ttnn::TILE_LAYOUT) {
       // typecast op requires tilized tensor
       ::ttnn::Tensor converted =
@@ -46,19 +49,17 @@ static ::ttnn::Tensor convertDataType(const ::ttnn::Tensor &input,
  * tile_shape */
 static ::ttnn::Tensor
 updateLayoutAndDataType(const ::ttnn::Tensor &inputTensor,
-                        const ::ttnn::DataType targetDataType,
+                        const ::ttnn::DataType &inputDataType,
+                        const ::ttnn::DataType &targetDataType,
                         const bool shouldTilize, const bool shouldUntilize) {
 
   ::ttnn::Tensor outputTensor = inputTensor;
-  const bool shouldConvertDataType = inputTensor.get_dtype() != targetDataType;
+  const bool shouldConvertDataType = (inputDataType != targetDataType);
   // const int targetTileX = targetTileShape->x();
   // const int targetTileY = targetTileShape->y();
   // const bool shouldTilize =
-  //     targetTileX == 32 and targetTileY == 32 and
-  //     inputTensor.get_layout() == ::ttnn::ROW_MAJOR_LAYOUT;
-  // const bool shouldUntilize = (targetTileX != 32 or targetTileY != 32) and
-  //                             inputTensor.get_layout() ==
-  //                             ::ttnn::TILE_LAYOUT;
+  //     targetTileX == 32 and targetTileY == 32;
+  // const bool shouldUntilize = (targetTileX != 32 or targetTileY != 32);
   assert(not(shouldTilize and shouldUntilize) &&
          "Cannot tilize and untilize tensor at the same time");
   if (shouldTilize) {
@@ -73,22 +74,27 @@ updateLayoutAndDataType(const ::ttnn::Tensor &inputTensor,
 }
 
 static void
-handleToHostMemoryConfigOp(const ::ttnn::Tensor &inputTensor,
+handleToHostMemoryConfigOp(const ::tt::target::TensorRef *inputTensorRef,
                            const ::tt::target::TensorRef *outputTensorRef,
                            ProgramTensorPool &tensorPool) {
   ::ttnn::Tensor result;
+  const ::ttnn::Tensor &inputTensor =
+      tensorPool.at(inputTensorRef->global_id());
+  ::ttnn::DataType inputDataTypeTTNN = utils::getDataType(inputTensorRef);
   ::ttnn::DataType targetDataTypeTTNN = utils::getDataType(outputTensorRef);
   bool shouldTilize, shouldUntilize;
   if (utils::isOnHost(inputTensor)) {
     shouldTilize = false;
     shouldUntilize = true;
-    result = updateLayoutAndDataType(inputTensor, targetDataTypeTTNN,
-                                     shouldTilize, shouldUntilize);
+    result = updateLayoutAndDataType(inputTensor, inputDataTypeTTNN,
+                                     targetDataTypeTTNN, shouldTilize,
+                                     shouldUntilize);
   } else if (utils::isOnDevice(inputTensor)) {
     shouldTilize = false;
     shouldUntilize = true;
-    result = updateLayoutAndDataType(inputTensor.cpu(), targetDataTypeTTNN,
-                                     shouldTilize, shouldUntilize);
+    result = updateLayoutAndDataType(inputTensor.cpu(), inputDataTypeTTNN,
+                                     targetDataTypeTTNN, shouldTilize,
+                                     shouldUntilize);
   }
   // copy the output to the output tensor if it exists
   if (tensorPool.contains(outputTensorRef->global_id())) {
@@ -104,9 +110,12 @@ handleToHostMemoryConfigOp(const ::ttnn::Tensor &inputTensor,
 
 static void
 handleToDramMemoryConfigOp(::ttnn::Device &device,
-                           const ::ttnn::Tensor &inputTensor,
+                           const ::tt::target::TensorRef *inputTensorRef,
                            const ::tt::target::TensorRef *outputTensorRef,
                            ProgramTensorPool &tensorPool) {
+  const ::ttnn::Tensor &inputTensor =
+      tensorPool.at(inputTensorRef->global_id());
+  ::ttnn::DataType inputDataTypeTTNN = utils::getDataType(inputTensorRef);
   ::ttnn::DataType targetDataTypeTTNN = utils::getDataType(outputTensorRef);
   ::tt::tt_metal::MemoryConfig targetMemoryConfig =
       utils::createMemoryConfig(outputTensorRef);
@@ -116,19 +125,21 @@ handleToDramMemoryConfigOp(::ttnn::Device &device,
     shouldTilize = true;
     shouldUntilize = false;
     // device tilize requires BFLOAT16, if not then tilize on host
-    if (result.get_dtype() != ::ttnn::DataType::BFLOAT16) {
+    if (inputDataTypeTTNN != ::ttnn::DataType::BFLOAT16) {
       result = tilize(result);
       shouldTilize = false;
     }
     result = ::ttnn::to_device(result, &device, targetMemoryConfig);
-    result = updateLayoutAndDataType(result, targetDataTypeTTNN, shouldTilize,
-                                     shouldUntilize);
+    result =
+        updateLayoutAndDataType(result, inputDataTypeTTNN, targetDataTypeTTNN,
+                                shouldTilize, shouldUntilize);
     tensorPool.insert_or_assign(outputTensorRef->global_id(), result);
   } else if (utils::isOnDevice(inputTensor)) {
     shouldTilize = false;
     shouldUntilize = false;
     ::ttnn::Tensor result = updateLayoutAndDataType(
-        inputTensor, targetDataTypeTTNN, shouldTilize, shouldUntilize);
+        inputTensor, inputDataTypeTTNN, targetDataTypeTTNN, shouldTilize,
+        shouldUntilize);
     result = ::ttnn::to_memory_config(result, targetMemoryConfig, std::nullopt);
     tensorPool.insert_or_assign(outputTensorRef->global_id(), result);
   }
@@ -136,9 +147,12 @@ handleToDramMemoryConfigOp(::ttnn::Device &device,
 
 static void
 handleToL1MemoryConfigOp(::ttnn::Device &device,
-                         const ::ttnn::Tensor &inputTensor,
+                         const ::tt::target::TensorRef *inputTensorRef,
                          const ::tt::target::TensorRef *outputTensorRef,
                          ProgramTensorPool &tensorPool) {
+  const ::ttnn::Tensor &inputTensor =
+      tensorPool.at(inputTensorRef->global_id());
+  ::ttnn::DataType inputDataTypeTTNN = utils::getDataType(inputTensorRef);
   ::ttnn::DataType targetDataTypeTTNN = utils::getDataType(outputTensorRef);
   ::tt::tt_metal::MemoryConfig targetMemoryConfig =
       utils::createMemoryConfig(outputTensorRef);
@@ -146,21 +160,23 @@ handleToL1MemoryConfigOp(::ttnn::Device &device,
   if (utils::isOnHost(inputTensor)) {
     ::ttnn::Tensor result = inputTensor;
     // device tilize requires BFLOAT16, if not then tilize on host
-    if (result.get_dtype() != ::ttnn::DataType::BFLOAT16) {
+    if (inputDataTypeTTNN != ::ttnn::DataType::BFLOAT16) {
       result = tilize(result);
       result = ::ttnn::to_device(result, &device, targetMemoryConfig);
       shouldTilize = false;
       shouldUntilize = false;
-      result = updateLayoutAndDataType(result, targetDataTypeTTNN, shouldTilize,
-                                       shouldUntilize);
+      result =
+          updateLayoutAndDataType(result, inputDataTypeTTNN, targetDataTypeTTNN,
+                                  shouldTilize, shouldUntilize);
     } else {
       shouldTilize = true;
       shouldUntilize = false;
       // device tilize op requires height sharded or interleaved tensors
       // thus tilize first with default mem config, then convert memory config
       result = ::ttnn::to_device(result, &device, std::nullopt);
-      result = updateLayoutAndDataType(result, targetDataTypeTTNN, shouldTilize,
-                                       shouldUntilize);
+      result =
+          updateLayoutAndDataType(result, inputDataTypeTTNN, targetDataTypeTTNN,
+                                  shouldTilize, shouldUntilize);
       result =
           ::ttnn::to_memory_config(result, targetMemoryConfig, std::nullopt);
     }
@@ -169,7 +185,8 @@ handleToL1MemoryConfigOp(::ttnn::Device &device,
     shouldTilize = false;
     shouldUntilize = false;
     ::ttnn::Tensor result = updateLayoutAndDataType(
-        inputTensor, targetDataTypeTTNN, shouldTilize, shouldUntilize);
+        inputTensor, inputDataTypeTTNN, targetDataTypeTTNN, shouldTilize,
+        shouldUntilize);
     result = ::ttnn::to_memory_config(result, targetMemoryConfig, std::nullopt);
     tensorPool.insert_or_assign(outputTensorRef->global_id(), result);
   }
@@ -199,17 +216,17 @@ void run(const ::tt::target::ttnn::ToMemoryConfigOp *op,
   // program
   case ::tt::target::MemorySpace::System:
   case ::tt::target::MemorySpace::SystemMMIO: {
-    handleToHostMemoryConfigOp(inputTensor, op->out(), tensorPool);
+    handleToHostMemoryConfigOp(op->in0(), op->out(), tensorPool);
     break;
   }
   case ::tt::target::MemorySpace::DeviceDRAM: {
     ::ttnn::Device &device = utils::getDevice(op->device(), devicePool);
-    handleToDramMemoryConfigOp(device, inputTensor, op->out(), tensorPool);
+    handleToDramMemoryConfigOp(device, op->in0(), op->out(), tensorPool);
     break;
   }
   case ::tt::target::MemorySpace::DeviceL1: {
     ::ttnn::Device &device = utils::getDevice(op->device(), devicePool);
-    handleToL1MemoryConfigOp(device, inputTensor, op->out(), tensorPool);
+    handleToL1MemoryConfigOp(device, op->in0(), op->out(), tensorPool);
     break;
   }
   }

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -62,7 +62,7 @@ Device openDevice(std::vector<int> const &deviceIds,
   assert(deviceIds.size() == 1 && "Only one device is supported for now");
   assert(numHWCQs.empty() && "HWCQs are not supported for now");
   auto &device = ::ttnn::open_device(deviceIds.front(), kL1SmallSize);
-  bool enableAsync = not debug::Env::get().disableAsyncTTNN;
+  bool enableAsync = debug::Env::get().enableAsyncTTNN;
   device.enable_async(enableAsync);
   return Device::borrow(device, DeviceRuntime::TTNN);
 }

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -54,7 +54,7 @@ Tensor createTensor(std::shared_ptr<void> data,
 tt::target::DataType getTensorDataType(Tensor tensor) {
   const ::ttnn::Tensor &nnTensor =
       tensor.as<::ttnn::Tensor>(DeviceRuntime::TTNN);
-  return utils::fromTTNNDataType(nnTensor.dtype());
+  return utils::fromTTNNDataType(nnTensor.get_dtype());
 }
 
 Device openDevice(std::vector<int> const &deviceIds,

--- a/runtime/tools/python/test/test_run.py
+++ b/runtime/tools/python/test/test_run.py
@@ -265,15 +265,15 @@ def test_load_kernels_from_disk_cmd():
     sub_process_command(command)
 
 
-def test_disable_async_ttnn():
+def test_enable_async_ttnn():
     API.initialize_apis()
     custom_args = {}
     custom_args["binary"] = BINARY_FILE_PATH
-    custom_args["--disable-async-ttnn"] = True
+    custom_args["--enable-async-ttnn"] = True
     run_instance = API.Run(args=custom_args)
     run_instance()
 
 
-def test_disable_async_ttnn_cmd():
-    command = f"ttrt run {BINARY_FILE_PATH} --disable-async-ttnn --log-file {test_disable_async_ttnn_cmd.__name__}_run.log"
+def test_enable_async_ttnn_cmd():
+    command = f"ttrt run {BINARY_FILE_PATH} --enable-async-ttnn --log-file {test_enable_async_ttnn_cmd.__name__}_run.log"
     sub_process_command(command)

--- a/runtime/tools/python/ttrt/common/run.py
+++ b/runtime/tools/python/ttrt/common/run.py
@@ -117,7 +117,7 @@ class Run:
             help="pickup the kernels from disk (/tmp) instead of the flatbuffer",
         )
         Run.register_arg(
-            name="--disable-async-ttnn",
+            name="--enable-async-ttnn",
             type=bool,
             default=False,
             choices=[True, False],
@@ -234,7 +234,7 @@ class Run:
                 return
 
             debug_env = ttrt.runtime.DebugEnv.get(
-                self["--load-kernels-from-disk"], self["--disable-async-ttnn"]
+                self["--load-kernels-from-disk"], self["--enable-async-ttnn"]
             )
             self.logging.debug(f"setting tt runtime debug env={debug_env}")
 

--- a/test/ttmlir/Silicon/TTNN/simple_conv.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_conv.mlir
@@ -1,0 +1,12 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
+module attributes {} {
+  func.func @forward(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x32x32x64xbf16> {
+    %0 = tensor.empty() : tensor<1x32x32x64xbf16>
+    // CHECK: %[[C:.*]] = "ttnn.conv2d"[[C:.*]]
+    %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0) <{stride_height=1: si32, stride_width=1: si32, dilation_height=1: si32, dilation_width=1: si32, groups=1: si32, padding_left=1: si32, padding_right=1: si32, padding_top=1: si32, padding_bottom=1: si32, is_convtranspose2d=0: si32, output_height_transpose=0: si32, output_width_transpose=0: si32, stride_transpose=0: si32, operand_constraints = [#any_device, #any_device, #any_device, #any_device]}> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, tensor<1x32x32x64xbf16>) -> tensor<1x32x32x64xbf16>
+    return %1 : tensor<1x32x32x64xbf16>
+  }
+}

--- a/test/ttmlir/Silicon/TTNN/simple_maxpool2d.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_maxpool2d.mlir
@@ -1,0 +1,12 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
+module attributes {} {
+  func.func @forward(%arg0: tensor<1x128x128x32xbf16>) -> tensor<1x64x64x32xbf16> {
+    %0 = tensor.empty() : tensor<1x64x64x32xbf16>
+    // CHECK: %[[C:.*]] = "ttnn.max_pool2d"[[C:.*]]
+    %1 = "ttir.max_pool2d"(%arg0, %0) <{kernel_height=2: si32, kernel_width=2: si32, stride_height=2: si32, stride_width=2: si32, dilation_height=1: si32, dilation_width=1: si32, ceil_mode=false, padding_left=0: si32, padding_right=0: si32, padding_top=0: si32, padding_bottom=0: si32, operand_constraints = [#any_device, #any_device]}> : (tensor<1x128x128x32xbf16>, tensor<1x64x64x32xbf16>) -> tensor<1x64x64x32xbf16>
+    return %1 : tensor<1x64x64x32xbf16>
+  }
+}


### PR DESCRIPTION
With async mode enabled, when querying metadata from ttnn tensors, we must use the get_* APIs. The normal APIs won't block on the worker thread, and so the metadata returned may not be correct.

When possible, we should query this metadata from the flatbuffer tensor descriptor instead of the ttnn tensor directly, as these get_ APIs do have a performance cost.

Added conv2d and maxpool to silicon tests. 

FYI @LPanosTT 