### PR TITLE
Introduce FillOp + lowering ttir.constant to ttmetal

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -591,6 +591,29 @@ def TTIR_ConstantOp : TTIR_Op<"constant", [ConstantLike,
     let hasFolder = 1;
 }
 
+def TTIR_FillOp : TTIR_DPSOp<"fill", [AllShapesMatch<["value", "result"]>]> {
+    let summary = "Fill operation.";
+    let description = [{
+      Produces tensor filled with given fill value.
+
+      Examples:
+        %0 = tensor.empty() : () -> tensor<2x3xi32>
+        %1 = "ttir.fill"(%0) {value = dense<0> : tensor<2x3xi32>} : () -> tensor<2x3xi32>
+        %2 = tensor.empty() : () -> tensor<2xf32>
+        %3 = "ttir.fill"(%2) {value = dense<[0.2, 1.3]> : tensor<2xf32>} : () -> tensor<2xf32>
+    }];
+
+    let arguments = (ins AnyRankedTensor:$output,
+                         ElementsAttr:$value,
+                         TT_OperandConstraintArrayAttr:$operand_constraints);
+
+    let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      MutableOperandRange getDpsInitsMutable() { return getOutputMutable(); }
+    }];
+}
+
 // ANCHOR: adding_an_op_matmul_ttir
 def TTIR_MatmulOp : TTIR_DPSOp<"matmul"> {
     let summary = "Matrix multiply operation.";

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -79,6 +79,14 @@ def TTIRSplitCompoundLayout: Pass<"ttir-split-compound-layout", "::mlir::ModuleO
   }];
 }
 
+def TTIRConstantAsFill: Pass<"ttir-constant-as-fill", "::mlir::ModuleOp"> {
+  let summary = "Converts constant ops to empty + fill.";
+  let description = [{
+    This pass converts constant ops to empty + fill ops to allow for better
+    optimization and easier lowering for some backend targets.
+  }];
+}
+
 def TTIRAllocate: Pass<"ttir-allocate", "::mlir::ModuleOp"> {
   let summary = "Insert allocate/deallocate ops for tensors.";
   let description = [{

--- a/include/ttmlir/Dialect/TTMetal/IR/TTMetalOps.td
+++ b/include/ttmlir/Dialect/TTMetal/IR/TTMetalOps.td
@@ -47,8 +47,7 @@ def TTMetal_HostWriteOp : TTMetal_Op<"host_write", [DestinationStyleOpInterface]
       Host write operation
     }];
 
-    let arguments = (ins AnyRankedTensor:$input,
-                         AnyRankedTensor:$output);
+    let arguments = (ins AnyRankedTensor:$output, ElementsAttr:$value);
     let results = (outs AnyRankedTensor:$result);
 
     let extraClassDeclaration = [{

--- a/include/ttmlir/Target/Common/types.fbs
+++ b/include/ttmlir/Target/Common/types.fbs
@@ -98,7 +98,6 @@ table LayoutDesc {
 table TensorDesc {
   shape: [int];
   layout: LayoutDesc;
-  constant_data: [ubyte];
 }
 
 table CBDesc {

--- a/include/ttmlir/Target/TTMetal/command.fbs
+++ b/include/ttmlir/Target/TTMetal/command.fbs
@@ -8,8 +8,27 @@ table EnqueueProgramCommand {
   program: ProgramDesc;
 }
 
+table ConstantBuffer8 {
+  data: [uint8];
+}
+
+table ConstantBuffer16 {
+  data: [uint16];
+}
+
+table ConstantBuffer32 {
+  data: [uint32];
+}
+
+union HostBuffer {
+  TensorRef,
+  ConstantBuffer8,
+  ConstantBuffer16,
+  ConstantBuffer32,
+}
+
 table EnqueueWriteBufferCommand {
-  src: TensorRef;
+  src: HostBuffer;
   dst: TensorRef;
 }
 

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -365,6 +365,23 @@ arrayAttrToFlatbuffer(FlatbufferObjectCache &cache,
                                   : 0;
 }
 
+inline flatbuffers::Offset<flatbuffers::Vector<uint32_t>>
+toFlatbuffer(FlatbufferObjectCache &cache, ElementsAttr elementsAttr) {
+  assert(elementsAttr.getElementType().isIntOrIndexOrFloat() &&
+         "unsupported elements attr type");
+  assert(elementsAttr.isSplat() && "expected a splat elements attr");
+  assert(elementsAttr.getElementType().getIntOrFloatBitWidth() == 32 &&
+         "unsupported elements attr bit width");
+  uint32_t value = 0;
+  if (elementsAttr.getElementType().isInteger()) {
+    value = elementsAttr.getSplatValue<int>();
+  } else {
+    *(reinterpret_cast<float *>(&value)) = elementsAttr.getSplatValue<float>();
+  }
+  SmallVector<uint32_t> data({value});
+  return toFlatbuffer(cache, ArrayRef<uint32_t>(data));
+}
+
 inline flatbuffers::Offset<::tt::target::MemoryDesc>
 memrefAttrToFlatbuffer(FlatbufferObjectCache &cache, MemRefType memref,
                        ::mlir::tt::TensorMemoryLayout memLayout) {

--- a/lib/Dialect/TTIR/Transforms/Passes.cpp
+++ b/lib/Dialect/TTIR/Transforms/Passes.cpp
@@ -38,6 +38,7 @@ namespace mlir::tt::ttir {
 #define GEN_PASS_DEF_TTIRGENERICREGIONOPERANDSTOMEMREF
 #define GEN_PASS_DEF_TTIRLAYOUT
 #define GEN_PASS_DEF_TTIRSPLITCOMPOUNDLAYOUT
+#define GEN_PASS_DEF_TTIRCONSTANTASFILL
 #define GEN_PASS_DEF_TTIRALLOCATE
 #define GEN_PASS_DEF_TTIROPTIMIZER
 #define GEN_PASS_DEF_TTIRIMPLICITDEVICE
@@ -1030,6 +1031,47 @@ public:
   void runOnOperation() final {
     RewritePatternSet patterns(&getContext());
     patterns.add<TTIRSplitCompoundLayoutRewriter>(&getContext());
+    FrozenRewritePatternSet patternSet(std::move(patterns));
+    if (failed(applyPatternsAndFoldGreedily(getOperation(), patternSet))) {
+      signalPassFailure();
+      return;
+    }
+  }
+
+  void getDependentDialects(mlir::DialectRegistry &registry) const override {
+    registry.insert<mlir::tt::ttir::TTIRDialect>();
+    registry.insert<mlir::tt::TTDialect>();
+  }
+};
+
+class TTIRConstantAsFillRewriter : public OpRewritePattern<ConstantOp> {
+public:
+  using OpRewritePattern<ConstantOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ConstantOp op,
+                                PatternRewriter &rewriter) const final {
+    auto resultTy = op.getResult().getType();
+    auto empty = rewriter.create<tensor::EmptyOp>(
+        op.getLoc(), resultTy.getShape(), resultTy.getElementType(),
+        resultTy.getEncoding());
+    auto operandConstraints = rewriter.getArrayAttr(SmallVector<Attribute>(
+        1,
+        rewriter.getAttr<OperandConstraintAttr>(OperandConstraint::AnyDevice)));
+    rewriter.replaceOpWithNewOp<ttir::FillOp>(
+        op, resultTy, empty, op.getValue(), operandConstraints);
+    return success();
+  }
+};
+
+class TTIRConstantAsFill
+    : public impl::TTIRConstantAsFillBase<TTIRConstantAsFill> {
+public:
+  using impl::TTIRConstantAsFillBase<
+      TTIRConstantAsFill>::TTIRConstantAsFillBase;
+
+  void runOnOperation() final {
+    RewritePatternSet patterns(&getContext());
+    patterns.add<TTIRConstantAsFillRewriter>(&getContext());
     FrozenRewritePatternSet patternSet(std::move(patterns));
     if (failed(applyPatternsAndFoldGreedily(getOperation(), patternSet))) {
       signalPassFailure();

--- a/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
+++ b/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
@@ -15,20 +15,11 @@
 namespace mlir::tt::ttmetal {
 
 ::mlir::LogicalResult HostWriteOp::verify() {
-  ::mlir::RankedTensorType inputTy = getInput().getType();
   ::mlir::RankedTensorType outputTy = getOutput().getType();
-  auto inputLayout =
-      mlir::dyn_cast_or_null<mlir::tt::LayoutAttr>(inputTy.getEncoding());
-  if (not inputLayout) {
-    return emitOpError("Input tensor missing layout attribute");
-  }
   auto outputLayout =
       mlir::dyn_cast_or_null<mlir::tt::LayoutAttr>(outputTy.getEncoding());
   if (not outputLayout) {
     return emitOpError("Input tensor missing layout attribute");
-  }
-  if (not inputLayout.isSystemMemorySpace()) {
-    return emitOpError("Input tensor must be in system memory space");
   }
   if (not outputLayout.isDeviceMemorySpace()) {
     return emitOpError("Output tensor must be in device memory space");
@@ -37,13 +28,7 @@ namespace mlir::tt::ttmetal {
 }
 
 ::mlir::LogicalResult HostReadOp::verify() {
-  ::mlir::RankedTensorType inputTy = getInput().getType();
   ::mlir::RankedTensorType outputTy = getOutput().getType();
-  auto inputLayout =
-      mlir::dyn_cast_or_null<mlir::tt::LayoutAttr>(inputTy.getEncoding());
-  if (not inputLayout) {
-    return emitOpError("Input tensor missing layout attribute");
-  }
   auto outputLayout =
       mlir::dyn_cast_or_null<mlir::tt::LayoutAttr>(outputTy.getEncoding());
   if (not outputLayout) {
@@ -51,9 +36,6 @@ namespace mlir::tt::ttmetal {
   }
   if (not outputLayout.isSystemMemorySpace()) {
     return emitOpError("Output tensor must be in system memory space");
-  }
-  if (not inputLayout.isDeviceMemorySpace()) {
-    return emitOpError("Input tensor must be in device memory space");
   }
   return success();
 }

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -20,6 +20,7 @@ void createTTIRToTTMetalBackendPipeline(
   ttir::TTIRImplicitDeviceOptions implicitDeviceOptions;
   implicitDeviceOptions.meshShape = options.meshShape;
   pm.addPass(mlir::tt::ttir::createTTIRImplicitDevice(implicitDeviceOptions));
+  pm.addPass(mlir::tt::ttir::createTTIRConstantAsFill());
   pm.addPass(mlir::tt::ttir::createTTIRGenericRegion());
   mlir::tt::ttir::TTIRLayoutOptions layoutOptions;
   layoutOptions.initMemorySpace = mlir::tt::MemorySpace::DeviceL1;

--- a/runtime/lib/ttmetal/command_queue.cpp
+++ b/runtime/lib/ttmetal/command_queue.cpp
@@ -426,8 +426,6 @@ void CQExecutor::execute(
 void CQExecutor::execute(
     ::tt::target::metal::EnqueueWriteBufferCommand const *command) {
   ZoneScopedN("EnqueueWriteBufferCommand");
-  assert(command->src()->desc()->constant_data() != nullptr &&
-         "Only constant data supported");
   throw std::runtime_error("Unsupported EnqueueWriteBufferCommand");
 }
 

--- a/test/ttmlir/Dialect/TTIR/constant_as_fill.mlir
+++ b/test/ttmlir/Dialect/TTIR/constant_as_fill.mlir
@@ -1,0 +1,13 @@
+// RUN: ttmlir-opt --ttir-constant-as-fill %s | FileCheck %s
+
+#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
+
+func.func public @add5(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+  // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttir.fill"[[C:.*]]
+  %0 = "ttir.constant"() <{value = dense<5.000000e+00> : tensor<32x32xf32>}> : () -> tensor<32x32xf32>
+  // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
+  %1 = tensor.empty() : tensor<32x32xf32>
+  %2 = "ttir.add"(%arg0, %0, %1) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+  return %2 : tensor<32x32xf32>
+}

--- a/test/ttmlir/Silicon/TTMetal/simple_constant.mlir
+++ b/test/ttmlir/Silicon/TTMetal/simple_constant.mlir
@@ -1,0 +1,15 @@
+// RUN: ttmlir-opt --ttir-load-system-desc="path=%system_desc_path%" --ttir-to-ttmetal-backend-pipeline %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttmetal-to-flatbuffer %t.mlir > %t.ttm
+// UNSUPPORTED: true
+
+#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
+
+func.func public @add5(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+  // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.host_write"[[C:.*]]
+  %0 = "ttir.constant"() <{value = dense<5.0> : tensor<32x32xf32>}> : () -> tensor<32x32xf32>
+  %1 = tensor.empty() : tensor<32x32xf32>
+  %2 = "ttir.add"(%arg0, %0, %1) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+  return %2 : tensor<32x32xf32>
+}


### PR DESCRIPTION
- Introduce `ttir.fill` op
- Introduce pass the converts `ttir.constant` into an empty + fill
- Support lowering `ttir.fill` to `ttmetal.host_write`

The purpose of this change is to support lowering of `ttir.constant` into the ttmetal backend.  An issue that arises with `ttir.constant` is that the allocator pass only knows how to convert `ttir.empty`'s into `ttir.allocate`, and we probably don't want to support lowering `ttir.constant` in the same way because otherwise we'd have to store the constant value attribute on the `ttir.allocate` op which would be an awkward place to put it.  The best solution I could come up with is to create a `ttir.fill` op, which is essentially just a DPS version of `ttir.constant`, but now more naturally fits the allocation pass. Further, this also better fits lowering to ttmetal host_write op because it too expects a pre-allocated device destination, i.e. DPS style.

Closes #758