### PR TITLE
[Metal Direct] Implement div op

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -232,13 +232,6 @@ class TTIR_ElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
     ];
 }
 
-def TTIR_DivOp : TTIR_ElementwiseBinaryOp<"div"> {
-    let summary = "Eltwise divide.";
-    let description = [{
-      Eltwise divide operation.
-    }];
-}
-
 def TTIR_SubtractOp : TTIR_ElementwiseBinaryOp<"subtract"> {
     let summary = "Eltwise subtract.";
     let description = [{
@@ -722,6 +715,13 @@ def TTIR_MultiplyOp : TTIR_GenericElementwiseBinaryOp<"multiply"> {
     let summary = "Eltwise multiply.";
     let description = [{
       Eltwise multiply operation.
+    }];
+}
+
+def TTIR_DivOp : TTIR_GenericElementwiseBinaryOp<"div"> {
+    let summary = "Eltwise divide.";
+    let description = [{
+      Eltwise divide operation.
     }];
 }
 

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -142,7 +142,7 @@ def TTKernel_CopyTileOp : TTKernel_Op<"copy_tile"> {
       previously called to ensure that at least some number n>0 of tiles are available
       in the input CB. The CB index 0 then references the first tile in the received section of the CB,
       up to index n-1 (in a FIFO order). The DST register buffer must be in acquired state via
-      acquire_dst call. This call is blocking and is only available on the compute
+      tile_regs_acquire call. This call is blocking and is only available on the compute
       engine.
     }];
 
@@ -288,7 +288,7 @@ def TTKernel_RecipTileOp : TTKernel_Op<"recip_tile"> {
     let description = [{
       Performs element-wise computation of the reciprocal on each element of a tile
       in DST register at index tile_index. The DST register buffer must be in
-      acquired state via *acquire_dst* call. This call is blocking and is only
+      acquired state via *tile_regs_acquire* call. This call is blocking and is only
       available on the compute engine.
       Only works for Float32, Float16_b, Bfp8_b data formats for full accuracy.
     }];

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -125,8 +125,15 @@ def TTKernel_PackTileOp : TTKernel_Op<"pack_tile"> {
     let arguments = (ins I32:$dst_index, TTKernel_CB:$out_cb, I32:$out_index);
 }
 
+def TTKernel_CopyTileInitOp : TTKernel_Op<"copy_tile_init"> {
+    let summary = "Perform the init for copy tile. This does not reconfigure the unpacker data types.";
+    let description = [{
+      Must be called before copy_tile.
+    }];
+}
+
 def TTKernel_CopyTileOp : TTKernel_Op<"copy_tile"> {
-    let summary = "copy_tile";
+    let summary = "Copy tile from specified CB to DST.";
     let description = [{
       Copies a single tile from the specified input CB and writes the result to
       DST at a specified index. The function will employ unpacker to first unpack into SRC
@@ -135,11 +142,11 @@ def TTKernel_CopyTileOp : TTKernel_Op<"copy_tile"> {
       previously called to ensure that at least some number n>0 of tiles are available
       in the input CB. The CB index 0 then references the first tile in the received section of the CB,
       up to index n-1 (in a FIFO order). The DST register buffer must be in acquired state via
-      tile_regs_acquire call. This call is blocking and is only available on the compute
+      acquire_dst call. This call is blocking and is only available on the compute
       engine.
     }];
 
-    let arguments = (ins TTKernel_CB:$cb0, I32:$tile_index_0, I32:$tile_index_1);
+    let arguments = (ins TTKernel_CB:$cb0, I32:$tile_index_cb, I32:$tile_index_dst);
 }
 
 //===----------------------------------------------------------------------===//
@@ -221,6 +228,13 @@ def TTKernel_MulTilesInitOp : TTKernel_Op<"mul_tiles_init"> {
     let arguments = (ins TTKernel_CB:$in0_cb, TTKernel_CB:$in1_cb);
 }
 
+def TTKernel_MulTilesInitFOp : TTKernel_Op<"mul_tiles_init_f"> {
+    let summary = "Short init function. Init for math only.";
+    let description = [{
+      Must be run before mul_tiles.
+    }];
+}
+
 def TTKernel_MulTilesOp : TTKernel_Op<"mul_tiles"> {
     let summary = "Mul operation";
     let description = [{
@@ -257,6 +271,26 @@ def TTKernel_ExpTileOp : TTKernel_Op<"exp_tile"> {
       in DST register at index tile_index. The DST register buffer must be in
       acquired state via *tile_regs_acquire* call. This call is blocking and is only
       available on the compute engine.
+    }];
+
+    let arguments = (ins I32:$tile_index);
+}
+
+def TTKernel_RecipTileInitOp : TTKernel_Op<"recip_tile_init"> {
+    let summary = "Init function for recip_tile operation. Refer to documentation for any init function.";
+    let description = [{
+      Must be called before recip_tile function.
+    }];
+}
+
+def TTKernel_RecipTileOp : TTKernel_Op<"recip_tile"> {
+    let summary = "Recip tile in the DST at specified index.";
+    let description = [{
+      Performs element-wise computation of the reciprocal on each element of a tile
+      in DST register at index tile_index. The DST register buffer must be in
+      acquired state via *acquire_dst* call. This call is blocking and is only
+      available on the compute engine.
+      Only works for Float32, Float16_b, Bfp8_b data formats for full accuracy.
     }];
 
     let arguments = (ins I32:$tile_index);

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
@@ -694,6 +694,8 @@ public:
     } else if (mlir::isa<arith::MulFOp>(arithOrMathOp)) {
       builder.create<ttkernel::MulTilesInitOp>(arithOrMathOp.getLoc(), inCB0,
                                                inCB1);
+    } else if (mlir::isa<arith::DivFOp>(arithOrMathOp)) {
+      builder.create<ttkernel::MulTilesInitFOp>(arithOrMathOp.getLoc());
     } else {
       llvm_unreachable("Unhandled binary op init conversion.");
     }
@@ -722,7 +724,7 @@ public:
                              ArrayRef<BlockArgument> cbOperands,
                              ArrayRef<BlockArgument> iterators,
                              SmallVector<unsigned> blockArgIteratorMapping,
-                             Value dstTileIndex, OpBuilder &builder) const {
+                             OpBuilder &builder) const {
     assert(cbOperands.size() == 2 &&
            "Expected one input and one output CB for unary op.");
 
@@ -731,6 +733,13 @@ public:
 
     // For all unary ops first copy tile from input CB at inCBTileIndex to DST
     // register at dstTileIndex.
+    // We always operate on the first and only tile in DST register.
+    Value dstTileIndex = i32(0, builder);
+    auto outCBTileIndex = iterators[blockArgIteratorMapping.back()];
+    auto outCB = cbOperands.back();
+
+    builder.create<ttkernel::TileRegsAcquireOp>(arithOrMathOp.getLoc());
+
     builder.create<ttkernel::CopyTileOp>(arithOrMathOp.getLoc(), inCB,
                                          inCBTileIndex, dstTileIndex);
 
@@ -741,13 +750,26 @@ public:
     } else {
       llvm_unreachable("Unhandled unary op compute conversion.");
     }
+
+    builder.create<ttkernel::TileRegsCommitOp>(arithOrMathOp.getLoc());
+
+    builder.create<ttkernel::TileRegsWaitOp>(arithOrMathOp.getLoc());
+
+    // Copy tile from DST at dstTileIndex to outCB at outCBTileIndex.
+    // outCBTileIndex increments as loops iterate, thus placing one result tile
+    // after another in outCB.
+    builder.create<ttkernel::PackTileOp>(arithOrMathOp.getLoc(), dstTileIndex,
+                                         outCB, outCBTileIndex);
+
+    // PACK releases lock on DST.
+    builder.create<ttkernel::TileRegsReleaseOp>(arithOrMathOp.getLoc());
   }
 
   void convertComputeBinaryOp(Operation &arithOrMathOp,
                               ArrayRef<BlockArgument> cbOperands,
                               ArrayRef<BlockArgument> iterators,
                               SmallVector<unsigned> blockArgIteratorMapping,
-                              Value dstTileIndex, OpBuilder &builder) const {
+                              OpBuilder &builder) const {
     assert(cbOperands.size() == 3 &&
            "Expected two input and one output CB for binary op.");
 
@@ -755,20 +777,108 @@ public:
     auto inCB0 = cbOperands[0];
     auto inCB1TileIndex = iterators[blockArgIteratorMapping[1]];
     auto inCB1 = cbOperands[1];
+    auto outCB = cbOperands[2];
 
     // Perform computation C = A (*) B on tile A from inCB0 and tile B from
     // inCB1 and store the result C in DST register on dstTileIndex.
+
     if (mlir::isa<arith::AddFOp>(arithOrMathOp)) {
+      Value dstIndex = i32(0, builder);
+      builder.create<ttkernel::TileRegsAcquireOp>(arithOrMathOp.getLoc());
       builder.create<ttkernel::AddTilesOp>(arithOrMathOp.getLoc(), inCB0, inCB1,
                                            inCB0TileIndex, inCB1TileIndex,
-                                           dstTileIndex);
+                                           dstIndex);
+      builder.create<ttkernel::TileRegsCommitOp>(arithOrMathOp.getLoc());
+      builder.create<ttkernel::TileRegsWaitOp>(arithOrMathOp.getLoc());
+      builder.create<ttkernel::PackTileOp>(
+          arithOrMathOp.getLoc(), dstIndex, outCB,
+          iterators[blockArgIteratorMapping[2]]);
+      builder.create<ttkernel::TileRegsReleaseOp>(arithOrMathOp.getLoc());
     } else if (mlir::isa<arith::MulFOp>(arithOrMathOp)) {
-      builder.create<ttkernel::MulTilesOp>(arithOrMathOp.getLoc(), inCB0, inCB1,
-                                           inCB0TileIndex, inCB1TileIndex,
-                                           dstTileIndex);
+      commonComputeMulOp(arithOrMathOp, cbOperands, iterators,
+                         blockArgIteratorMapping, builder);
+    } else if (mlir::isa<arith::DivFOp>(arithOrMathOp)) {
+
+      SmallVector<std::int64_t> operandIndicesRecip;
+      // For DIV, input 1 is going through reciprocal.
+      operandIndicesRecip.push_back(1);
+      commonComputeRecipOp(arithOrMathOp, cbOperands, iterators,
+                           blockArgIteratorMapping, builder,
+                           operandIndicesRecip);
+
+      builder.create<ttkernel::MulTilesInitOp>(arithOrMathOp.getLoc(), inCB0,
+                                               inCB1);
+
+      commonComputeMulOp(arithOrMathOp, cbOperands, iterators,
+                         blockArgIteratorMapping, builder);
+
+      Value one = i32(1, builder);
+      builder.create<ttkernel::CBPopFrontOp>(arithOrMathOp.getLoc(), inCB1,
+                                             one);
     } else {
-      llvm_unreachable("Unhandled binary op compute conversion.");
+      llvm_unreachable("Unhandled conversion for operation which is neither "
+                       "unary nor binary.");
     }
+  }
+
+  void commonComputeMulOp(Operation &op, ArrayRef<BlockArgument> cbOperands,
+                          ArrayRef<BlockArgument> iterators,
+                          SmallVector<unsigned> blockArgIteratorMapping,
+                          OpBuilder &builder) const {
+
+    auto inCB0 = cbOperands[0];
+    auto inCB1 = cbOperands[1];
+    auto outCB = cbOperands[2];
+
+    Value dstIndex = i32(0, builder);
+
+    builder.create<ttkernel::TileRegsAcquireOp>(op.getLoc());
+    if (mlir::isa<arith::MulFOp>(op)) {
+      builder.create<ttkernel::MulTilesOp>(
+          op.getLoc(), inCB0, inCB1, iterators[blockArgIteratorMapping[0]],
+          iterators[blockArgIteratorMapping[0]], dstIndex);
+    } else if (mlir::isa<arith::DivFOp>(op)) {
+      builder.create<ttkernel::MulTilesOp>(
+          op.getLoc(), inCB0, inCB1, iterators[blockArgIteratorMapping[0]],
+          dstIndex, dstIndex);
+    } else {
+      llvm_unreachable("Common compute for multiplying tiles should be called "
+                       "only on MulFOp and DivFOp");
+    }
+
+    builder.create<ttkernel::TileRegsCommitOp>(op.getLoc());
+    builder.create<ttkernel::TileRegsWaitOp>(op.getLoc());
+    builder.create<ttkernel::PackTileOp>(op.getLoc(), dstIndex, outCB,
+                                         iterators[blockArgIteratorMapping[2]]);
+    builder.create<ttkernel::TileRegsReleaseOp>(op.getLoc());
+  }
+
+  void commonComputeRecipOp(Operation &op, ArrayRef<BlockArgument> cbOperands,
+                            ArrayRef<BlockArgument> iterators,
+                            SmallVector<unsigned> blockArgIteratorMapping,
+                            OpBuilder &builder,
+                            SmallVector<std::int64_t> &operandIndices) const {
+    Value dstIndex = i32(0, builder);
+    Value one = i32(1, builder);
+
+    builder.create<ttkernel::CopyTileInitOp>(op.getLoc());
+    builder.create<ttkernel::CBReserveBackOp>(
+        op.getLoc(), cbOperands[operandIndices[0]], one);
+    builder.create<ttkernel::TileRegsAcquireOp>(op.getLoc());
+    builder.create<ttkernel::RecipTileInitOp>(op.getLoc());
+    builder.create<ttkernel::CopyTileOp>(
+        op.getLoc(), cbOperands[operandIndices[0]], dstIndex, dstIndex);
+    builder.create<ttkernel::RecipTileOp>(op.getLoc(), dstIndex);
+    builder.create<ttkernel::TileRegsCommitOp>(op.getLoc());
+
+    builder.create<ttkernel::TileRegsWaitOp>(op.getLoc());
+    builder.create<ttkernel::PackTileOp>(
+        op.getLoc(), dstIndex, cbOperands[operandIndices[0]], dstIndex);
+    builder.create<ttkernel::TileRegsReleaseOp>(op.getLoc());
+    builder.create<ttkernel::CBPushBackOp>(op.getLoc(),
+                                           cbOperands[operandIndices[0]], one);
+    builder.create<ttkernel::CBWaitFrontOp>(op.getLoc(),
+                                            cbOperands[operandIndices[0]], one);
   }
 
   // Convert arith and math dialect operations into ttkernel tile operations.
@@ -779,15 +889,14 @@ public:
                         ArrayRef<BlockArgument> cbOperands,
                         ArrayRef<BlockArgument> iterators,
                         SmallVector<unsigned> blockArgIteratorMapping,
-                        Value dstTileIndex, OpBuilder &builder,
-                        std::int64_t numDpsInputs) const {
+                        OpBuilder &builder, std::int64_t numDpsInputs) const {
 
     if (numDpsInputs == 1) {
       convertComputeUnaryOp(arithOrMathOp, cbOperands, iterators,
-                            blockArgIteratorMapping, dstTileIndex, builder);
+                            blockArgIteratorMapping, builder);
     } else if (numDpsInputs == 2) {
       convertComputeBinaryOp(arithOrMathOp, cbOperands, iterators,
-                             blockArgIteratorMapping, dstTileIndex, builder);
+                             blockArgIteratorMapping, builder);
     } else {
       llvm_unreachable("Unhandled conversion for operation which is neither "
                        "unary nor binary.");
@@ -817,7 +926,6 @@ public:
     // The loop nest is created from outermost to innermost. Get the inner loop
     // and place computation calls inside it.
     Region *innerLoopRegion = loopNest.loopRegions.back();
-    const Location &location = innerLoopRegion->getLoc();
     ArrayRef<BlockArgument> iterators =
         loopNest.loops.back().getRegionIterArgs();
     SmallVector<unsigned> blockArgIteratorMapping =
@@ -826,34 +934,10 @@ public:
     OpBuilder innerLoopBuilder(&innerLoopRegion->front(),
                                innerLoopRegion->front().begin());
 
-    // We always operate on the first and only tile in DST register.
-    Value dstTileIndex = i32(0, innerLoopBuilder);
-    auto outCBTileIndex = iterators[blockArgIteratorMapping.back()];
-    auto outCB = cbOperands.back();
-
-    // MATH acquires lock on DST register.
-    innerLoopBuilder.create<ttkernel::TileRegsAcquireOp>(location);
-
     // Call compute function to execute on each tile. Result will be stored in
     // DST.
     convertComputeOp(arithOrMathOp, cbOperands, iterators,
-                     blockArgIteratorMapping, dstTileIndex, innerLoopBuilder,
-                     numDPSInputs);
-
-    // MATH releases lock on DST.
-    innerLoopBuilder.create<ttkernel::TileRegsCommitOp>(location);
-
-    // PACK acquires lock on DST register. Blocked until MATH releases it.
-    innerLoopBuilder.create<ttkernel::TileRegsWaitOp>(location);
-
-    // Copy tile from DST at dstTileIndex to outCB at outCBTileIndex.
-    // outCBTileIndex increments as loops iterate, thus placing one result tile
-    // after another in outCB.
-    innerLoopBuilder.create<ttkernel::PackTileOp>(location, dstTileIndex, outCB,
-                                                  outCBTileIndex);
-
-    // PACK releases lock on DST.
-    innerLoopBuilder.create<ttkernel::TileRegsReleaseOp>(location);
+                     blockArgIteratorMapping, innerLoopBuilder, numDPSInputs);
   }
 
   // Builds instructions to execute after loops are finished.
@@ -868,7 +952,7 @@ public:
   // expanded loop nest and inner loop that implements the underlying arith or
   // math operation as a tile operation.
   void lowerBlock(Block *origGenericOpBlock, Block *dispatchOpBlock,
-                  std::int64_t numDPSInputs) const {
+                  std::int64_t numDPSInputs, PatternRewriter &rewriter) const {
     Block::OpListType &operations = origGenericOpBlock->getOperations();
     assert(operations.size() == 2);
     Operation::user_range users = operations.front().getUsers();
@@ -937,7 +1021,8 @@ public:
       tensixBlock->addArgument(ty, op.getLoc());
     }
 
-    lowerBlock(&op->getRegion(0).front(), tensixBlock, op.getNumDpsInputs());
+    lowerBlock(&op->getRegion(0).front(), tensixBlock, op.getNumDpsInputs(),
+               rewriter);
 
     rewriter.replaceOp(op, metalDispatch);
 

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -261,6 +261,9 @@ public:
       patterns
           .add<TTMetalToEmitCFuncArgsRewriter, TTMetalToEmitCReturnRewriter,
                TTMetalToEmitCOpaqueRewriter<ttkernel::BuiltinOp>,
+               TTMetalToEmitCOpaqueRewriter<ttkernel::CopyTileInitOp>,
+               TTMetalToEmitCOpaqueRewriter<ttkernel::RecipTileInitOp>,
+               TTMetalToEmitCOpaqueRewriter<ttkernel::RecipTileOp>,
                TTMetalToEmitCOpaqueRewriter<ttkernel::TileRegsAcquireOp>,
                TTMetalToEmitCOpaqueRewriter<ttkernel::TileRegsCommitOp>,
                TTMetalToEmitCOpaqueRewriter<ttkernel::TileRegsWaitOp>,
@@ -277,6 +280,7 @@ public:
                TTMetalToEmitCOpaqueRewriter<ttkernel::BinaryOpInitCommonOp>,
                TTMetalToEmitCOpaqueRewriter<ttkernel::AddTilesInitOp>,
                TTMetalToEmitCOpaqueRewriter<ttkernel::MulTilesInitOp>,
+               TTMetalToEmitCOpaqueRewriter<ttkernel::MulTilesInitFOp>,
                TTMetalToEmitCOpaqueRewriter<ttkernel::AddTilesOp>,
                TTMetalToEmitCOpaqueRewriter<ttkernel::MulTilesOp>,
                TTMetalToEmitCOpaqueRewriter<ttkernel::GetNocAddrOp>,
@@ -342,6 +346,9 @@ public:
           /*isStandard=*/false);
       builder->create<emitc::IncludeOp>(
           loc, "compute_kernel_api/eltwise_unary/sfpu_split_includes.h",
+          /*isStandard=*/false);
+      builder->create<emitc::IncludeOp>(
+          loc, "compute_kernel_api/eltwise_unary/recip.h",
           /*isStandard=*/false);
       builder->create<emitc::VerbatimOp>(loc, "namespace NAMESPACE {");
     }

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -109,6 +109,12 @@ void mlir::tt::ttir::ExpOp::buildGenericRegion(::mlir::OpBuilder &opBuilder,
   buildGenericEltwiseUnaryRegion<math::ExpOp>(getLoc(), opBuilder, block);
 }
 
+void mlir::tt::ttir::DivOp::buildGenericRegion(::mlir::OpBuilder &opBuilder,
+                                               ::mlir::Block *block) {
+  return buildGenericEltwiseBinaryRegion<arith::DivFOp>(getLoc(), opBuilder,
+                                                        block);
+}
+
 ::mlir::LogicalResult mlir::tt::ttir::EmbeddingOp::verify() {
   ::mlir::RankedTensorType inputType = getInput().getType();
   ::mlir::RankedTensorType weightType = getWeight().getType();

--- a/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
@@ -5,6 +5,7 @@
 #include "ttmlir/Dialect/TTKernel/IR/TTKernelOps.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "ttmlir/Dialect/TT/IR/TT.h"
 #include "ttmlir/Dialect/TTKernel/IR/TTKernel.h"
@@ -17,9 +18,15 @@ namespace mlir::tt::ttkernel {
 
 static bool insideDispatchOpRegion(mlir::Operation *op) {
   mlir::Operation *parentOp = op->getParentOp();
+
   if (dyn_cast_or_null<ttmetal::DispatchOp>(parentOp)) {
     return true;
   }
+
+  if (dyn_cast_or_null<scf::ForOp>(parentOp)) {
+    return true;
+  }
+
   if (dyn_cast_or_null<func::FuncOp>(parentOp) &&
       dyn_cast_or_null<mlir::ModuleOp>(parentOp->getParentOp())) {
     return true;

--- a/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
@@ -19,11 +19,11 @@ namespace mlir::tt::ttkernel {
 static bool insideDispatchOpRegion(mlir::Operation *op) {
   mlir::Operation *parentOp = op->getParentOp();
 
-  if (dyn_cast_or_null<ttmetal::DispatchOp>(parentOp)) {
-    return true;
+  if (!parentOp) {
+    return false;
   }
 
-  if (dyn_cast_or_null<scf::ForOp>(parentOp)) {
+  if (dyn_cast_or_null<ttmetal::DispatchOp>(parentOp)) {
     return true;
   }
 
@@ -31,7 +31,7 @@ static bool insideDispatchOpRegion(mlir::Operation *op) {
       dyn_cast_or_null<mlir::ModuleOp>(parentOp->getParentOp())) {
     return true;
   }
-  return false;
+  return insideDispatchOpRegion(parentOp);
 }
 
 ::mlir::LogicalResult BuiltinOp::verify() {

--- a/test/ttmlir/Silicon/TTMetal/simple_eltwise.mlir
+++ b/test/ttmlir/Silicon/TTMetal/simple_eltwise.mlir
@@ -27,3 +27,11 @@ func.func @exp(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
   %1 = "ttir.exp"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>, operand_constraints = [#any_device, #any_device]}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
   return %1 : tensor<64x128xf32>
 }
+
+func.func @div(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
+  %0 = tensor.empty() : tensor<64x128xf32>
+  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  %1 = "ttir.div"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  return %1 : tensor<64x128xf32>
+}


### PR DESCRIPTION
Fixes #535 

Implement Div op for tt-metal backend.

Important notes for review

- Div op is implemented using recip + mul. Input 1 of the div is going to go through the recip using DST register, and then input 0 and recip input 1 are multiplied to get the div.

- To avoid intermediate buffers, input 1 CB is used to pack recip tiles of the original input 1. Then input 0 and input 1 are regularly used as inputs for multiply part

- More code is moved to convert compute init and convert compute functions, since the code that was outside of those functions was mostly for eltwise ops, and we need to do recip now as well, we cannot keep that code outside of functions

Generated kernel 

```cpp
#include <cstdint>
#include "compute_kernel_api/common.h"
#include "compute_kernel_api/tilize.h"
#include "compute_kernel_api/untilize.h"
#include "compute_kernel_api/eltwise_binary.h"
#include "compute_kernel_api/tile_move_copy.h"
#include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
#include "compute_kernel_api/eltwise_unary/recip.h"
namespace NAMESPACE {
void kernel_main() {
  ::tt::CB v1 = ::tt::CB::c_in0;
  ::tt::CB v2 = ::tt::CB::c_in1;
  ::tt::CB v3 = ::tt::CB::c_out0;
  binary_op_init_common(v1, v2, v3);
  mul_tiles_init_f();
  int32_t v4 = 0;
  int32_t v5 = 0;
  int32_t v6 = 2;
  int32_t v7 = 1;
  int32_t v8;
  v8 = v4;
  for (int32_t v9 = v5; v9 < v6; v9 += v7) {
    int32_t v10 = 0;
    int32_t v11 = 4;
    int32_t v12 = 1;
    int32_t v13;
    v13 = v8;
    for (int32_t v14 = v10; v14 < v11; v14 += v12) {
      int32_t v15 = 0;
      int32_t v16 = 1;
      copy_tile_to_dst_init_short();
      cb_reserve_back(v2, v16);
      tile_regs_acquire();
      recip_tile_init();
      copy_tile(v2, v15, v15);
      recip_tile(v15);
      tile_regs_commit();
      tile_regs_wait();
      pack_tile(v15, v2, v15);
      tile_regs_release();
      cb_push_back(v2, v16);
      cb_wait_front(v2, v16);
      mul_tiles_init(v1, v2);
      int32_t v17 = 0;
      tile_regs_acquire();
      mul_tiles(v1, v2, v13, v17, v17);
      tile_regs_commit();
      tile_regs_wait();
      pack_tile(v17, v3, v13);
      tile_regs_release();
      int32_t v18 = 1;
      cb_pop_front(v2, v18);
      int32_t v19 = 1;
      uint32_t v20 = (uint32_t) v13;
      uint32_t v21 = (uint32_t) v19;
      uint32_t v22 = v20 + v21;
      int32_t v23 = (int32_t) v22;
      v13 = v23;
    };
    int32_t v24 = 0;
    v8 = v13;
  }
  return;
}

void MAIN { kernel_main(); }
}

```