### PR TITLE
[Metal Direct] Reduce op 

### DIFF
--- a/include/ttmlir/Dialect/TT/IR/TTOpsEnums.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsEnums.td
@@ -126,12 +126,12 @@ def TT_OOBVal : I32EnumAttr<"OOBVal", "TT OOBVal",
   let cppNamespace = "::mlir::tt";
 }
 
-def TT_OperandConstraintSystem : I32BitEnumAttrCaseBit<"System", 0, "system">;
-def TT_OperandConstraintDRAM : I32BitEnumAttrCaseBit<"DRAM", 1, "dram">;
-def TT_OperandConstraintL1 : I32BitEnumAttrCaseBit<"L1", 2, "l1">;
-def TT_OperandConstraintScalar : I32BitEnumAttrCaseBit<"Scalar", 3, "scalar">;
-def TT_OperandConstraintTile : I32BitEnumAttrCaseBit<"Tile", 4, "tile">;
-def TT_OperandConstraintNone : I32BitEnumAttrCaseBit<"None", 5, "none">;
+def TT_OperandConstraintNone : I32BitEnumAttrCaseBit<"None", 0, "none">;
+def TT_OperandConstraintSystem : I32BitEnumAttrCaseBit<"System", 1, "system">;
+def TT_OperandConstraintDRAM : I32BitEnumAttrCaseBit<"DRAM", 2, "dram">;
+def TT_OperandConstraintL1 : I32BitEnumAttrCaseBit<"L1", 3, "l1">;
+def TT_OperandConstraintScalar : I32BitEnumAttrCaseBit<"Scalar", 4, "scalar">;
+def TT_OperandConstraintTile : I32BitEnumAttrCaseBit<"Tile", 5, "tile">;
 def TT_OperandConstraintInterleaved : I32BitEnumAttrCaseBit<"Interleaved", 6, "interleaved">;
 def TT_OperandConstraintSingleBank : I32BitEnumAttrCaseBit<"SingleBank", 7, "single_bank">;
 def TT_OperandConstraintHeightSharded : I32BitEnumAttrCaseBit<"HeightSharded", 8, "height_sharded">;
@@ -144,12 +144,12 @@ def TT_OperandConstraintAnyDeviceTile : I32BitEnumAttrCaseGroup<"AnyDeviceTile",
 def TT_OperandConstraintL1BlockSharded : I32BitEnumAttrCaseGroup<"L1BlockSharded", [TT_OperandConstraintL1, TT_OperandConstraintScalar, TT_OperandConstraintTile, TT_OperandConstraintBlockSharded], "l1_block_sharded">;
 def TT_OperandConstraint : I32BitEnumAttr<"OperandConstraint", "TT Operand Constraints",
                            [
+                            TT_OperandConstraintNone,
                             TT_OperandConstraintSystem,
                             TT_OperandConstraintDRAM,
                             TT_OperandConstraintL1,
                             TT_OperandConstraintScalar,
                             TT_OperandConstraintTile,
-                            TT_OperandConstraintNone,
                             TT_OperandConstraintInterleaved,
                             TT_OperandConstraintSingleBank,
                             TT_OperandConstraintHeightSharded,

--- a/include/ttmlir/Dialect/TT/IR/TTOpsEnums.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsEnums.td
@@ -126,12 +126,12 @@ def TT_OOBVal : I32EnumAttr<"OOBVal", "TT OOBVal",
   let cppNamespace = "::mlir::tt";
 }
 
-def TT_OperandConstraintNone : I32BitEnumAttrCaseBit<"None", 0, "none">;
-def TT_OperandConstraintSystem : I32BitEnumAttrCaseBit<"System", 1, "system">;
-def TT_OperandConstraintDRAM : I32BitEnumAttrCaseBit<"DRAM", 2, "dram">;
-def TT_OperandConstraintL1 : I32BitEnumAttrCaseBit<"L1", 3, "l1">;
-def TT_OperandConstraintScalar : I32BitEnumAttrCaseBit<"Scalar", 4, "scalar">;
-def TT_OperandConstraintTile : I32BitEnumAttrCaseBit<"Tile", 5, "tile">;
+def TT_OperandConstraintSystem : I32BitEnumAttrCaseBit<"System", 0, "system">;
+def TT_OperandConstraintDRAM : I32BitEnumAttrCaseBit<"DRAM", 1, "dram">;
+def TT_OperandConstraintL1 : I32BitEnumAttrCaseBit<"L1", 2, "l1">;
+def TT_OperandConstraintScalar : I32BitEnumAttrCaseBit<"Scalar", 3, "scalar">;
+def TT_OperandConstraintTile : I32BitEnumAttrCaseBit<"Tile", 4, "tile">;
+def TT_OperandConstraintNone : I32BitEnumAttrCaseBit<"None", 5, "none">;
 def TT_OperandConstraintInterleaved : I32BitEnumAttrCaseBit<"Interleaved", 6, "interleaved">;
 def TT_OperandConstraintSingleBank : I32BitEnumAttrCaseBit<"SingleBank", 7, "single_bank">;
 def TT_OperandConstraintHeightSharded : I32BitEnumAttrCaseBit<"HeightSharded", 8, "height_sharded">;
@@ -144,12 +144,12 @@ def TT_OperandConstraintAnyDeviceTile : I32BitEnumAttrCaseGroup<"AnyDeviceTile",
 def TT_OperandConstraintL1BlockSharded : I32BitEnumAttrCaseGroup<"L1BlockSharded", [TT_OperandConstraintL1, TT_OperandConstraintScalar, TT_OperandConstraintTile, TT_OperandConstraintBlockSharded], "l1_block_sharded">;
 def TT_OperandConstraint : I32BitEnumAttr<"OperandConstraint", "TT Operand Constraints",
                            [
-                            TT_OperandConstraintNone,
                             TT_OperandConstraintSystem,
                             TT_OperandConstraintDRAM,
                             TT_OperandConstraintL1,
                             TT_OperandConstraintScalar,
                             TT_OperandConstraintTile,
+                            TT_OperandConstraintNone,
                             TT_OperandConstraintInterleaved,
                             TT_OperandConstraintSingleBank,
                             TT_OperandConstraintHeightSharded,

--- a/include/ttmlir/Dialect/TT/IR/TTOpsEnums.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsEnums.td
@@ -95,12 +95,14 @@ def TT_TensorMemoryLayout : I32EnumAttr<"TensorMemoryLayout", "TT TensorMemoryLa
 def TT_Parallel : I32EnumAttrCase<"Parallel", 0, "parallel">;
 def TT_Systolic : I32EnumAttrCase<"Systolic", 1, "systolic">;
 def TT_Broadcast : I32EnumAttrCase<"Broadcast", 2, "broadcast">;
+def TT_Reduction : I32EnumAttrCase<"Reduction", 3, "reduction">;
 
 def TT_IteratorType : I32EnumAttr<"IteratorType", "TT IteratorType",
                            [
                             TT_Parallel,
                             TT_Systolic,
                             TT_Broadcast,
+                            TT_Reduction,
                            ]> {
   let genSpecializedAttr = 0;
   let cppNamespace = "::mlir::tt";

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -270,7 +270,7 @@ def TT_LayoutAttr : TT_Attr<"Layout", "layout"> {
                             MemorySpace memorySpace,
                             GridAttr grid,
                             Type elementType,
-                            TensorMemoryLayout memLayout);
+                            TensorMemoryLayout memLayout = TensorMemoryLayout::None);
       LayoutAttr withGrid(::mlir::MLIRContext *context, ArrayRef<int64_t> tensorShape, GridAttr grid, ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}});
       LayoutAttr withGrid(::mlir::MLIRContext *context,
                           RankedTensorType ty,

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -279,6 +279,8 @@ def TT_LayoutAttr : TT_Attr<"Layout", "layout"> {
       LayoutAttr withElementType(::mlir::MLIRContext *context, Type elementType);
       LayoutAttr withMemorySpace(::mlir::MLIRContext *context, MemorySpace memorySpace);
       LayoutAttr withMemoryLayout(::mlir::MLIRContext *context, TensorMemoryLayout memLayout);
+
+      uint64_t getMemrefSizeBytes() const;
       MemorySpace getMemorySpace() const;
       bool isSystemMemorySpace() const { return ::mlir::tt::isSystemMemorySpace(getMemorySpace()); }
       bool isDeviceMemorySpace() const { return ::mlir::tt::isDeviceMemorySpace(getMemorySpace()); }
@@ -292,7 +294,7 @@ def TT_LayoutAttr : TT_Attr<"Layout", "layout"> {
       llvm::SmallVector<int64_t> getPhysicalShape(ArrayRef<int64_t> logicalShape) const;
       llvm::SmallVector<int64_t> getShardShape(bool convertTileToScalar = true) const;
       AffineMap replaceMemoryMapSymbolsWithShardShape(AffineMap physicalMemoryMap) const;
-      AffineMap projectOnto(AffineMap linearMap, AffineMap physicalMemoryMap, ArrayRef<int64_t> logicalTensorShape) const;
+      AffineMap projectOnto(AffineMap linearMap, AffineMap physicalMemoryMap) const;
       AffineMap getIdentityTileLinearMap() const;
       llvm::SmallVector<int64_t> getTiledShape(ArrayRef<int64_t> logicalTensorShape) const;
   }];

--- a/include/ttmlir/Dialect/TT/Utils/PhysicalCoreCoord.h
+++ b/include/ttmlir/Dialect/TT/Utils/PhysicalCoreCoord.h
@@ -40,6 +40,11 @@ struct PhysicalCoreCoord {
   bool operator==(PhysicalCoreCoord const &other) const {
     return d == other.d && y == other.y && x == other.x;
   }
+
+  std::string toString() const {
+    return std::to_string(d) + " " + std::to_string(y) + " " +
+           std::to_string(x);
+  }
 };
 
 class PhysicalCoreCoordMapping {

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -42,7 +42,7 @@ def TTIR_GenericOp : TTIR_DPSOp<"generic", [AttrSizedOperandSegments]> {
         grid = #tt.grid<1x1>,                        // The grid range of cores to dispatch work to.
         indexing_maps = [#map, #map, #map],          // Affine maps for indexing into the input/output tensors. See linalg.generic
         iterator_types = [#parallel, #parallel],     // Iterator types for the input/output tensors. See linalg.generic
-        operandSegmentSizes = array<i32: 2, 1, 1>,   // Sizes of the operand segments, i.e. 2 inputs, 1 output and 1 cb.
+        operandSegmentSizes = array<i32: 2, 1, 1>,   // Sizes of the operand segments, i.e. 2 inputs, 1 cb and 1 output.
         operand_cb_mapping = array<i64: -1, 0, -1>,  // Mapping of input & output operands to cbs. -1 means no mapping.
                                                      // Mapped operands correspond to buffers in streaming mode.
                                                      // Non-mapped operands correspond to buffers in alias mode.

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -38,13 +38,18 @@ def TTIR_GenericOp : TTIR_DPSOp<"generic", [AttrSizedOperandSegments]> {
       details.
 
       ```llvm
-      %5 = "ttir.generic"(%1, %3, %4) <{
-        grid = #tt.grid<1x1>,                     // The grid range of cores to dispatch work to.
-        indexing_maps = [#map, #map, #map],       // Affine maps for indexing into the input/output tensors. See linalg.generic
-        iterator_types = [#parallel, #parallel],  // Iterator types for the input/output tensors. See linalg.generic
-        operandSegmentSizes = array<i32: 2, 1>,   // Sizes of the operand segments, i.e. 2 inputs and 1 output.
+      %5 = "ttir.generic"(%1, %3, %4, %2) <{
+        grid = #tt.grid<1x1>,                        // The grid range of cores to dispatch work to.
+        indexing_maps = [#map, #map, #map],          // Affine maps for indexing into the input/output tensors. See linalg.generic
+        iterator_types = [#parallel, #parallel],     // Iterator types for the input/output tensors. See linalg.generic
+        operandSegmentSizes = array<i32: 2, 1, 1>,   // Sizes of the operand segments, i.e. 2 inputs, 1 output and 1 cb.
+        operand_cb_mapping = array<i64: -1, 0, -1>,  // Mapping of input & output operands to cbs. -1 means no mapping.
+                                                     // Mapped operands correspond to buffers in streaming mode.
+                                                     // Non-mapped operands correspond to buffers in alias mode.
       ({
-      ^bb0(%arg2: memref<64x128xf32, #l1_>, %arg3: memref<64x128xf32, #l1_>, %arg4: memref<64x128xf32, #l1_>):
+      ^bb0(%arg2: tensor<64x128xf32, #tt.buffer<memref<64x128xf32, #l1_>, alias>>,
+           %arg3: tensor<64x128xf32, #tt.buffer<memref<64x128xf32, #l1_>, stream>>,
+           %arg4: tensor<64x128xf32, #tt.buffer<memref<64x128xf32, #l1_>, alias>>):
           // Region body, would contain some computation that represents the work each core does.
       }) : (tensor<64x128xf32, #layout1>, tensor<64x128xf32, #layout1>, tensor<64x128xf32, #layout1>) -> tensor<64x128xf32, #layout1>
       ```
@@ -52,10 +57,12 @@ def TTIR_GenericOp : TTIR_DPSOp<"generic", [AttrSizedOperandSegments]> {
 
     let arguments = (ins Variadic<AnyRankedTensor>:$inputs,
                          Variadic<AnyRankedTensor>:$outputs,
+                         Variadic<AnyRankedTensor>:$cbs,
                          TT_GridAttr:$grid,
                          AffineMapArrayAttr:$indexing_maps,
                          TT_IteratorTypeArrayAttr:$iterator_types,
-                         TT_OperandConstraintArrayAttr:$operand_constraints);
+                         TT_OperandConstraintArrayAttr:$operand_constraints,
+                         DefaultValuedOptionalAttr<DenseI64ArrayAttr, "{}">:$operand_cb_mapping); // index of input operand and index of cb go together
     let results = (outs Variadic<AnyRankedTensor>:$results);
     let regions = (region AnyRegion:$region);
     let hasVerifier = 1;
@@ -293,7 +300,9 @@ def TTIR_MaximumOp :  TTIR_ElementwiseBinaryOp<"maximum"> {
     }];
 }
 
-class TTIR_ReductionOp<string mnemonic, list<Trait> traits = []> : TTIR_DPSOp<mnemonic, traits> {
+class TTIR_ReductionOp<string mnemonic, list<Trait> traits = []> :
+    TTIR_DPSOp<mnemonic, !listconcat(traits, [TTIR_GenericRegionOpInterface])> {
+
     let summary = "Reduction op.";
     let description = [{
       Reduction op.
@@ -309,6 +318,31 @@ class TTIR_ReductionOp<string mnemonic, list<Trait> traits = []> : TTIR_DPSOp<mn
 
     let extraClassDeclaration = [{
       MutableOperandRange getDpsInitsMutable() { return getOutputMutable(); }
+
+      void buildGenericRegion(::mlir::OpBuilder &opBuilder, ::mlir::Block* block);
+
+      std::pair<::mlir::ArrayAttr, ::mlir::ArrayAttr> getIndexingMaps(Builder &builder) {
+        auto rank = mlir::cast<RankedTensorType>(getInput().getType()).getRank();
+        SmallVector<AffineMap> indexingMaps(getNumOperands(),
+                                            builder.getMultiDimIdentityMap(rank));
+        SmallVector<Attribute> iteratorTypes(
+            rank, builder.getAttr<IteratorTypeAttr>(IteratorType::Parallel));
+
+        auto reduceDims = getDimArgAttr();
+        auto resultIndexingMap = indexingMaps.back();
+        for (auto reduceDim : reduceDims) {
+          int64_t reduceDimInt = mlir::cast<IntegerAttr>(reduceDim).getInt();
+          if (reduceDimInt < 0) {
+            reduceDimInt += rank;
+          }
+          assert(reduceDimInt >= 0 && reduceDimInt < rank);
+          resultIndexingMap.dropResult(reduceDimInt);
+          iteratorTypes[reduceDimInt] =
+              builder.getAttr<IteratorTypeAttr>(IteratorType::Reduction);
+        }
+
+        return {builder.getAffineMapArrayAttr(indexingMaps),
+                builder.getArrayAttr(iteratorTypes)};}
     }];
 }
 

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -68,6 +68,8 @@ def TTIR_GenericOp : TTIR_DPSOp<"generic", [AttrSizedOperandSegments]> {
     let hasVerifier = 1;
 
     let extraClassDeclaration = [{
+      // For a given block argument index, return the corresponding operand of the surrounding generic op.
+      // This is needed because extra CB operands may be present in between the inputs and outputs.
       Value getMatchingOperand(size_t blockArgIndex) {
         return blockArgIndex < getInputs().size() ?
           getOperand(blockArgIndex) : getOperand(blockArgIndex + getCbs().size());

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -32,13 +32,13 @@ def TTIR_GenericOp : TTIR_DPSOp<"generic", [AttrSizedOperandSegments]> {
     let summary = "Generically dispatch work to a grid of cores.";
     let description = [{
       This generic op carries a region that represents the work each core does. The region is
-      expected to have the same signature as the op itself. The op is expected to be lowered
-      to a backend specific form by a consuming backend. This op is heavily inspired by the
-      linalg.generic op so it can be useful to refer to linalg.generic documentation for more
-      details.
+      expected to have the same signature as the op itself with respect to input and output
+      operands. The op is expected to be lowered to a backend specific form by a consuming backend.
+      This op is heavily inspired by the linalg.generic op so it can be useful to refer to
+      linalg.generic documentation for more details.
 
       ```llvm
-      %5 = "ttir.generic"(%1, %3, %4, %2) <{
+      %5 = "ttir.generic"(%1, %2, %3, %4) <{
         grid = #tt.grid<1x1>,                        // The grid range of cores to dispatch work to.
         indexing_maps = [#map, #map, #map],          // Affine maps for indexing into the input/output tensors. See linalg.generic
         iterator_types = [#parallel, #parallel],     // Iterator types for the input/output tensors. See linalg.generic
@@ -51,7 +51,7 @@ def TTIR_GenericOp : TTIR_DPSOp<"generic", [AttrSizedOperandSegments]> {
            %arg3: tensor<64x128xf32, #tt.buffer<memref<64x128xf32, #l1_>, stream>>,
            %arg4: tensor<64x128xf32, #tt.buffer<memref<64x128xf32, #l1_>, alias>>):
           // Region body, would contain some computation that represents the work each core does.
-      }) : (tensor<64x128xf32, #layout1>, tensor<64x128xf32, #layout1>, tensor<64x128xf32, #layout1>) -> tensor<64x128xf32, #layout1>
+      }) : (tensor<64x128xf32, #layout1>, tensor<64x128xf32, #layout1>, tensor<64x128xf32, #layout1>, tensor<64x128xf32, #layout1>) -> tensor<64x128xf32, #layout1>
       ```
     }];
 
@@ -71,6 +71,8 @@ def TTIR_GenericOp : TTIR_DPSOp<"generic", [AttrSizedOperandSegments]> {
       // For a given block argument index, return the corresponding operand of the surrounding generic op.
       // This is needed because extra CB operands may be present in between the inputs and outputs.
       Value getMatchingOperand(size_t blockArgIndex) {
+        assert(blockArgIndex < getInputs().size() + getOutputs().size() &&
+               "blockArgIndex should be within the range of inputs and outputs");
         return blockArgIndex < getInputs().size() ?
           getOperand(blockArgIndex) : getOperand(blockArgIndex + getCbs().size());
       }
@@ -334,6 +336,10 @@ class TTIR_ReductionOp<string mnemonic, list<Trait> traits = []> :
 
       void buildGenericRegion(::mlir::OpBuilder &opBuilder, ::mlir::Block* block);
 
+      // Returns the indexing maps and iterator types for the reduction op.
+      // Indexing maps are identity maps with dropped dimensions corresponding to the
+      // reduction dimensions. Iterator types are parallel for non-reduction dimensions
+      // and reduction for reduction dimensions.
       std::pair<::mlir::ArrayAttr, ::mlir::ArrayAttr> getIndexingMaps(Builder &builder) {
         auto rank = mlir::cast<RankedTensorType>(getInput().getType()).getRank();
         SmallVector<AffineMap> indexingMaps(getNumOperands(),

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -56,8 +56,8 @@ def TTIR_GenericOp : TTIR_DPSOp<"generic", [AttrSizedOperandSegments]> {
     }];
 
     let arguments = (ins Variadic<AnyRankedTensor>:$inputs,
-                         Variadic<AnyRankedTensor>:$outputs,
                          Variadic<AnyRankedTensor>:$cbs,
+                         Variadic<AnyRankedTensor>:$outputs,
                          TT_GridAttr:$grid,
                          AffineMapArrayAttr:$indexing_maps,
                          TT_IteratorTypeArrayAttr:$iterator_types,
@@ -66,6 +66,17 @@ def TTIR_GenericOp : TTIR_DPSOp<"generic", [AttrSizedOperandSegments]> {
     let results = (outs Variadic<AnyRankedTensor>:$results);
     let regions = (region AnyRegion:$region);
     let hasVerifier = 1;
+
+    let extraClassDeclaration = [{
+      Value getMatchingOperand(size_t blockArgIndex) {
+        return blockArgIndex < getInputs().size() ?
+          getOperand(blockArgIndex) : getOperand(blockArgIndex + getCbs().size());
+      }
+
+      MutableOperandRange getDpsInitsMutable() {
+        return getOutputsMutable();
+      }
+    }];
 }
 
 def TTIR_ToLayoutOp : TTIR_Op<"to_layout", [DestinationStyleOpInterface, TTIROpInterface]> {

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -34,6 +34,13 @@ def TTIRGenericRegion: Pass<"ttir-generic", "::mlir::ModuleOp"> {
   }];
 }
 
+def TTIRGenericOpCBs: Pass<"ttir-generic-op-cbs", "::mlir::ModuleOp"> {
+  let summary = "";
+  let description = [{
+    Insert circular buffer operands for generic ops.
+  }];
+}
+
 def TTIRGenericRegionOperandsToMemref: Pass<"ttir-generic-region-operands-to-memref", "::mlir::ModuleOp"> {
   let summary = "";
   let description = [{

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -296,6 +296,43 @@ def TTKernel_RecipTileOp : TTKernel_Op<"recip_tile"> {
     let arguments = (ins I32:$tile_index);
 }
 
+def TTKernel_ReduceInitOp : TTKernel_Op<"reduce_init"> {
+    let summary = "Init function";
+    let description = [{
+      Must be run before reduce_tile.
+    }];
+
+    let arguments = (ins TTKernel_CB:$in_cb,
+                         TTKernel_CB:$scaling_cb,
+                         TTKernel_CB:$out_cb,
+                         TTKernel_ReduceTypeAttr:$reduce_type,
+                         TTKernel_ReduceDimAttr:$reduce_dim);
+}
+
+def TTKernel_ReduceTileOp : TTKernel_Op<"reduce_tile"> {
+    let summary = "Reduce operation";
+    let description = [{
+      Performs a reduction operation *B = reduce(A)* using reduce_func for
+      dimension reduction on a tile in the CB at a given index and writes the
+      result to the DST register at index *dst_tile_index*. Reduction can be
+      either of type *Reduce::R*, *Reduce::C* or *Reduce::RC*, identifying the
+      dimension(s) to be reduced in size to 1. The DST register buffer must be in
+      acquired state via *acquire_dst* call.
+      The templates takes reduce_type which can be ReduceFunc::Sum, ReduceFunc::Max
+      and reduce_dim which can be Reduce::R, Reduce::C, Reduce::RC.
+      They can also be specified by defines REDUCE_OP and REDUCE_DIM.
+      This call is blocking and is only available on the compute engine.
+    }];
+
+    let arguments = (ins TTKernel_CB:$in_cb,
+                         TTKernel_CB:$scaling_cb,
+                         I32:$in_tile_index,
+                         I32:$scaling_tile_index,
+                         I32:$dst_index,
+                         TTKernel_ReduceTypeAttr:$reduce_type,
+                         TTKernel_ReduceDimAttr:$reduce_dim);
+}
+
 //===----------------------------------------------------------------------===//
 // TTKernel CB operations
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -317,7 +317,7 @@ def TTKernel_ReduceTileOp : TTKernel_Op<"reduce_tile"> {
       result to the DST register at index *dst_tile_index*. Reduction can be
       either of type *Reduce::R*, *Reduce::C* or *Reduce::RC*, identifying the
       dimension(s) to be reduced in size to 1. The DST register buffer must be in
-      acquired state via *acquire_dst* call.
+      acquired state via *tile_regs_acquire* call.
       The templates takes reduce_type which can be ReduceFunc::Sum, ReduceFunc::Max
       and reduce_dim which can be Reduce::R, Reduce::C, Reduce::RC.
       They can also be specified by defines REDUCE_OP and REDUCE_DIM.

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsEnums.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsEnums.td
@@ -133,29 +133,29 @@ def TTKernel_CBPort : I32EnumAttr<"CBPort", "TTKernel Circular Buffer Ports",
   let cppNamespace = "::mlir::tt::ttkernel";
 }
 
-def TTKernel_ReduceSUM : I32EnumAttrCase<"ReduceSUM", 0, "reduce_sum">;
-def TTKernel_ReduceMAX : I32EnumAttrCase<"ReduceMAX", 1, "reduce_max">;
+def TTKernel_ReduceSum : I32EnumAttrCase<"Sum", 0, "reduce_sum">;
+def TTKernel_ReduceMax : I32EnumAttrCase<"Max", 1, "reduce_max">;
 
 def TTKernel_ReduceType : I32EnumAttr<"ReduceType", "TTKernel Reduce Types",
                           [
-                            TTKernel_ReduceSUM,
-                            TTKernel_ReduceMAX
+                            TTKernel_ReduceSum,
+                            TTKernel_ReduceMax
                           ]> {
   let genSpecializedAttr = 0;
   let cppNamespace = "::mlir::tt::ttkernel";
 }
 
-def TTKernel_ReduceDimROW : I32EnumAttrCase<"ReduceDimROW", 0, "reduce_dim_row">;
-def TTKernel_ReduceDimCOL : I32EnumAttrCase<"ReduceDimCOL", 1, "reduce_dim_col">;
-def TTKernel_ReduceDimSCALAR : I32EnumAttrCase<"ReduceDimSCALAR", 2, "reduce_dim_scalar">;
-def TTKernel_ReduceDimNONE : I32EnumAttrCase<"ReduceDimNONE", 3, "reduce_dim_none">;
+def TTKernel_ReduceDimRow : I32EnumAttrCase<"Row", 0, "reduce_dim_row">;
+def TTKernel_ReduceDimCol : I32EnumAttrCase<"Col", 1, "reduce_dim_col">;
+def TTKernel_ReduceDimScalar : I32EnumAttrCase<"Scalar", 2, "reduce_dim_scalar">;
+def TTKernel_ReduceDimNone : I32EnumAttrCase<"None", 3, "reduce_dim_none">;
 
 def TTKernel_ReduceDim : I32EnumAttr<"ReduceDim", "TTKernel Reduce Dimensions",
                          [
-                           TTKernel_ReduceDimROW,
-                           TTKernel_ReduceDimCOL,
-                           TTKernel_ReduceDimSCALAR,
-                           TTKernel_ReduceDimNONE
+                           TTKernel_ReduceDimRow,
+                           TTKernel_ReduceDimCol,
+                           TTKernel_ReduceDimScalar,
+                           TTKernel_ReduceDimNone
                          ]> {
   let genSpecializedAttr = 0;
   let cppNamespace = "::mlir::tt::ttkernel";

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsEnums.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsEnums.td
@@ -133,4 +133,32 @@ def TTKernel_CBPort : I32EnumAttr<"CBPort", "TTKernel Circular Buffer Ports",
   let cppNamespace = "::mlir::tt::ttkernel";
 }
 
+def TTKernel_ReduceSUM : I32EnumAttrCase<"ReduceSUM", 0, "reduce_sum">;
+def TTKernel_ReduceMAX : I32EnumAttrCase<"ReduceMAX", 1, "reduce_max">;
+
+def TTKernel_ReduceType : I32EnumAttr<"ReduceType", "TTKernel Reduce Types",
+                          [
+                            TTKernel_ReduceSUM,
+                            TTKernel_ReduceMAX
+                          ]> {
+  let genSpecializedAttr = 0;
+  let cppNamespace = "::mlir::tt::ttkernel";
+}
+
+def TTKernel_ReduceDimROW : I32EnumAttrCase<"ReduceDimROW", 0, "reduce_dim_row">;
+def TTKernel_ReduceDimCOL : I32EnumAttrCase<"ReduceDimCOL", 1, "reduce_dim_col">;
+def TTKernel_ReduceDimSCALAR : I32EnumAttrCase<"ReduceDimSCALAR", 2, "reduce_dim_scalar">;
+def TTKernel_ReduceDimNONE : I32EnumAttrCase<"ReduceDimNONE", 3, "reduce_dim_none">;
+
+def TTKernel_ReduceDim : I32EnumAttr<"ReduceDim", "TTKernel Reduce Dimensions",
+                         [
+                           TTKernel_ReduceDimROW,
+                           TTKernel_ReduceDimCOL,
+                           TTKernel_ReduceDimSCALAR,
+                           TTKernel_ReduceDimNONE
+                         ]> {
+  let genSpecializedAttr = 0;
+  let cppNamespace = "::mlir::tt::ttkernel";
+}
+
 #endif

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
@@ -116,4 +116,12 @@ def TTKernel_ThreadTypeAttr : EnumAttr<TTKernel_Dialect, TTKernel_ThreadType, "t
 
 def TTKernel_ThreadTypeArrayAttr : TypedArrayAttrBase<TTKernel_ThreadTypeAttr, "">;
 
+def TTKernel_ReduceTypeAttr : EnumAttr<TTKernel_Dialect, TTKernel_ReduceType, "reduce_type"> {
+  let assemblyFormat = "`<` $value `>`";
+}
+
+def TTKernel_ReduceDimAttr : EnumAttr<TTKernel_Dialect, TTKernel_ReduceDim, "reduce_dim"> {
+  let assemblyFormat = "`<` $value `>`";
+}
+
 #endif

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -370,7 +370,7 @@ public:
       builder->create<emitc::IncludeOp>(loc, "dataflow_api.h",
                                         /*isStandard=*/false);
     }
-    if (threadType.getValue() == ttkernel::ThreadType::Tensix) {
+    if (kernelConfig.getThreadType() == ttkernel::ThreadType::Tensix) {
       builder->create<emitc::IncludeOp>(loc, "llk_defs.h",
                                         /*isStandard=*/false);
       builder->create<emitc::IncludeOp>(loc, "compute_kernel_api/common.h",

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -25,10 +25,6 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/raw_ostream.h"
-#include <llvm/ADT/StringRef.h>
-#include <mlir/IR/Attributes.h>
-#include <mlir/IR/BuiltinAttributes.h>
-#include <mlir/Support/LLVM.h>
 
 using namespace mlir;
 using namespace tt;
@@ -194,13 +190,13 @@ public:
   template <typename ReduceKindOp>
   std::pair<StringRef, StringRef> getReduceTypeAndDim(ReduceKindOp op) const {
     StringRef reduceType =
-        op.getReduceTypeAttr().getValue() == ttkernel::ReduceType::ReduceMAX
+        op.getReduceTypeAttr().getValue() == ttkernel::ReduceType::Max
             ? "PoolType::MAX"
             : "PoolType::SUM";
     StringRef reduceDim =
-        op.getReduceDimAttr().getValue() == ttkernel::ReduceDim::ReduceDimCOL
+        op.getReduceDimAttr().getValue() == ttkernel::ReduceDim::Col
             ? "ReduceDim::REDUCE_COL"
-        : op.getReduceDimAttr().getValue() == ttkernel::ReduceDim::ReduceDimROW
+        : op.getReduceDimAttr().getValue() == ttkernel::ReduceDim::Row
             ? "ReduceDim::REDUCE_ROW"
             : "ReduceDim::REDUCE_SCALAR";
     return {reduceType, reduceDim};

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -10,11 +10,10 @@
 #include "mlir/Dialect/Traits.h"
 #include "mlir/IR/BuiltinTypes.h"
 
-#include <llvm/ADT/ArrayRef.h>
-#include <llvm/ADT/SmallVector.h>
-#include <llvm/Support/LogicalResult.h>
 #include "mlir/IR/Location.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/LogicalResult.h"
 
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIR.h"

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -161,16 +161,19 @@ static void createReduceOp(::mlir::OpBuilder &opBuilder, ::mlir::Block *block,
 
 void mlir::tt::ttir::SumOp::buildGenericRegion(::mlir::OpBuilder &opBuilder,
                                                ::mlir::Block *block) {
+  // NOLINTNEXTLINE
   createReduceOp(opBuilder, block, getLoc(), "sum");
 }
 
 void mlir::tt::ttir::MeanOp::buildGenericRegion(::mlir::OpBuilder &opBuilder,
                                                 ::mlir::Block *block) {
+  // NOLINTNEXTLINE
   createReduceOp(opBuilder, block, getLoc(), "mean");
 }
 
 void mlir::tt::ttir::MaxOp::buildGenericRegion(::mlir::OpBuilder &opBuilder,
                                                ::mlir::Block *block) {
+  // NOLINTNEXTLINE
   createReduceOp(opBuilder, block, getLoc(), "max");
 }
 

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -167,6 +167,17 @@ void mlir::tt::ttir::MeanOp::buildGenericRegion(::mlir::OpBuilder &opBuilder,
   opBuilder.create<mlir::tt::ttir::YieldOp>(getLoc(), kernelOp->getResults());
 }
 
+void mlir::tt::ttir::MaxOp::buildGenericRegion(::mlir::OpBuilder &opBuilder,
+                                               ::mlir::Block *block) {
+  auto kernelOp = buildKernelOp(
+      opBuilder, getLoc(), "reduce", "max", block->getArgument(0),
+      block->getArgument(1),
+      opBuilder.getArrayAttr(SmallVector<Attribute>(
+          block->getNumArguments(), opBuilder.getAttr<OperandConstraintAttr>(
+                                        OperandConstraint::AnyDeviceTile))));
+  opBuilder.create<mlir::tt::ttir::YieldOp>(getLoc(), kernelOp->getResults());
+}
+
 ::mlir::LogicalResult mlir::tt::ttir::EmbeddingOp::verify() {
   ::mlir::RankedTensorType inputType = getInput().getType();
   ::mlir::RankedTensorType weightType = getWeight().getType();

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -14,7 +14,14 @@
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/Support/LogicalResult.h>
 
+#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIR.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIROpsInterfaces.cpp.inc"
 #include "ttmlir/Utils.h"
 
@@ -62,10 +69,23 @@ mlir::tt::ttir::ToLayoutOp::compoundComponents() {
 }
 
 ::mlir::LogicalResult mlir::tt::ttir::GenericOp::verify() {
-  if (getNumOperands() != getRegion().getNumArguments()) {
-    return emitOpError(
-        "The number of op operands and region/block operands must match");
+  if (getInputs().size() + getOutputs().size() !=
+      getRegion().getNumArguments()) {
+    return emitOpError("The number of input and output operands and "
+                       "region/block arguments must match");
   }
+
+  // Validate CB mappings.
+  auto operandCBmapping = getOperandCbMapping();
+  auto numCBs = getCbs().size();
+  if (!operandCBmapping.empty()) {
+    for (int64_t mapping : operandCBmapping) {
+      if (mapping >= 0 && static_cast<size_t>(mapping) >= numCBs) {
+        return emitOpError("CB index out of bounds");
+      }
+    }
+  }
+
   return success();
 }
 
@@ -113,6 +133,38 @@ void mlir::tt::ttir::DivOp::buildGenericRegion(::mlir::OpBuilder &opBuilder,
                                                ::mlir::Block *block) {
   return buildGenericEltwiseBinaryRegion<arith::DivFOp>(getLoc(), opBuilder,
                                                         block);
+}
+
+static mlir::tt::ttir::KernelOp
+buildKernelOp(::mlir::OpBuilder &opBuilder, ::mlir::Location loc,
+              ::mlir::StringRef kernelName, ::mlir::StringRef kernelKind,
+              ::mlir::ValueRange inputs, ::mlir::ValueRange outputs,
+              ::mlir::ArrayAttr operandConstraints) {
+  return opBuilder.create<mlir::tt::ttir::KernelOp>(
+      loc, outputs.getTypes(), kernelName, kernelKind, inputs, outputs,
+      operandConstraints);
+}
+
+void mlir::tt::ttir::SumOp::buildGenericRegion(::mlir::OpBuilder &opBuilder,
+                                               ::mlir::Block *block) {
+  auto kernelOp = buildKernelOp(
+      opBuilder, getLoc(), "reduce", "sum", block->getArgument(0),
+      block->getArgument(1),
+      opBuilder.getArrayAttr(SmallVector<Attribute>(
+          block->getNumArguments(), opBuilder.getAttr<OperandConstraintAttr>(
+                                        OperandConstraint::AnyDeviceTile))));
+  opBuilder.create<mlir::tt::ttir::YieldOp>(getLoc(), kernelOp->getResults());
+}
+
+void mlir::tt::ttir::MeanOp::buildGenericRegion(::mlir::OpBuilder &opBuilder,
+                                                ::mlir::Block *block) {
+  auto kernelOp = buildKernelOp(
+      opBuilder, getLoc(), "reduce", "mean", block->getArgument(0),
+      block->getArgument(1),
+      opBuilder.getArrayAttr(SmallVector<Attribute>(
+          block->getNumArguments(), opBuilder.getAttr<OperandConstraintAttr>(
+                                        OperandConstraint::AnyDeviceTile))));
+  opBuilder.create<mlir::tt::ttir::YieldOp>(getLoc(), kernelOp->getResults());
 }
 
 ::mlir::LogicalResult mlir::tt::ttir::EmbeddingOp::verify() {

--- a/lib/Dialect/TTIR/Transforms/Passes.cpp
+++ b/lib/Dialect/TTIR/Transforms/Passes.cpp
@@ -1550,14 +1550,23 @@ public:
       cbValues.push_back(emptyOp.getResult());
       operandCBMapping.push_back(cbValues.size() - 1);
 
-      OperandConstraint inherittedConstraint =
-          mlir::cast<OperandConstraintAttr>(
-              generic.getOperandConstraints()[operandIdx])
-              .getValue();
-      cbConstraints.push_back(rewriter.getAttr<OperandConstraintAttr>(
-          inherittedConstraint &
-              ~(OperandConstraint::System | OperandConstraint::DRAM) |
-          OperandConstraint::L1));
+      // Inheriting constraints from the original operand.
+      // OperandConstraint inherittedConstraint =
+      //     mlir::cast<OperandConstraintAttr>(
+      //         generic.getOperandConstraints()[operandIdx])
+      //         .getValue();
+      // inherittedConstraint =
+      //     bitEnumSet(inherittedConstraint, OperandConstraint::L1);
+      // inherittedConstraint =
+      //     bitEnumClear(inherittedConstraint, OperandConstraint::DRAM);
+      // inherittedConstraint =
+      //     bitEnumClear(inherittedConstraint, OperandConstraint::System);
+
+      // Fixing constraint to L1 for the CB operand.
+      // TODO(rpavlovic) remove or use code above when we decide on the operand
+      // constraints model.
+      cbConstraints.push_back(
+          rewriter.getAttr<OperandConstraintAttr>(OperandConstraint::L1));
     }
 
     SmallVector<Attribute> combinedConstraints;

--- a/lib/Dialect/TTIR/Transforms/Passes.cpp
+++ b/lib/Dialect/TTIR/Transforms/Passes.cpp
@@ -35,6 +35,7 @@ namespace mlir::tt::ttir {
 #define GEN_PASS_DEF_TTIRSLIDINGWINDOW2DFIXSHAPES
 #define GEN_PASS_DEF_TTIRGENERICKERNEL
 #define GEN_PASS_DEF_TTIRGENERICREGION
+#define GEN_PASS_DEF_TTIRGENERICOPCBS
 #define GEN_PASS_DEF_TTIRGENERICREGIONOPERANDSTOMEMREF
 #define GEN_PASS_DEF_TTIRLAYOUT
 #define GEN_PASS_DEF_TTIRSPLITCOMPOUNDLAYOUT
@@ -224,8 +225,8 @@ public:
         createOperandConstraints(rewriter, op.getKind(), op.getOperands());
     auto dispatch = rewriter.create<ttir::GenericOp>(
         op.getLoc(), op.getResults().getTypes(), op.getInputs(),
-        op.getOutputs(), rewriter.getAttr<GridAttr>(), indexingMaps,
-        iteratorTypes, constraints);
+        op.getOutputs(), ValueRange() /* cbs */, rewriter.getAttr<GridAttr>(),
+        indexingMaps, iteratorTypes, constraints);
 
     // Create a new basic block for the dispatch op and create block arguments
     Block *block = rewriter.createBlock(&dispatch.getRegion());
@@ -285,27 +286,28 @@ public:
 
     auto dps = cast<DestinationStyleOpInterface>(op.getOperation());
 
-    // Create a dispatch op
+    // Create a generic op.
     auto [indexingMaps, iteratorTypes] = op.getIndexingMaps(rewriter);
     auto constraints = rewriter.getArrayAttr(SmallVector<Attribute>(
         op->getNumOperands(), rewriter.getAttr<OperandConstraintAttr>(
                                   OperandConstraint::AnyDeviceTile)));
-    auto dispatch = rewriter.create<ttir::GenericOp>(
-        op.getLoc(), op->getResults().getTypes(), dps.getDpsInputs(),
-        dps.getDpsInits(), rewriter.getAttr<GridAttr>(), indexingMaps,
-        iteratorTypes, constraints);
 
-    // Create a new basic block for the dispatch op and create block arguments
-    Block *block = rewriter.createBlock(&dispatch.getRegion());
-    SmallVector<Location> blockArgumentLocs(dispatch.getOperands().size(),
-                                            dispatch.getLoc());
-    block->addArguments(TypeRange(dispatch.getOperandTypes()),
+    auto genericOp = rewriter.create<ttir::GenericOp>(
+        op.getLoc(), op->getResults().getTypes(), dps.getDpsInputs(),
+        dps.getDpsInits(), ValueRange() /* cbs */, rewriter.getAttr<GridAttr>(),
+        indexingMaps, iteratorTypes, constraints);
+
+    // Create a new basic block for the generic op and create block arguments.
+    Block *block = rewriter.createBlock(&genericOp.getRegion());
+    SmallVector<Location> blockArgumentLocs(genericOp.getOperands().size(),
+                                            genericOp.getLoc());
+    block->addArguments(TypeRange(genericOp.getOperandTypes()),
                         blockArgumentLocs);
 
-    // Convert the original op into arith/math and into the dispatch block
+    // Convert the original op into arith/math and into the generic block.
     OpBuilder blockBuilder = OpBuilder::atBlockEnd(block);
     op.buildGenericRegion(blockBuilder, block);
-    rewriter.replaceOp(op, dispatch);
+    rewriter.replaceOp(op, genericOp);
     return success();
   }
 };
@@ -349,18 +351,45 @@ struct TTIRGenericOperandsToMemrefRewriter
                   ConversionPatternRewriter &rewriter) const final {
     Block *entry = &generic.getRegion().front();
     auto firstEntryArgType = entry->getArguments()[0].getType();
-    bool isConverted = static_cast<bool>(
-        mlir::cast<RankedTensorType>(firstEntryArgType).getEncoding());
-    if (isConverted) {
-      // Already converted
+    auto encoding =
+        mlir::cast<RankedTensorType>(firstEntryArgType).getEncoding();
+    if (mlir::isa_and_nonnull<BufferAttr>(encoding)) {
+      // Already converted.
       return failure();
     }
 
     rewriter.modifyOpInPlace(generic, [&]() {
       DenseMap<Type, Type> typeMap;
-      for (auto [operand, blockArg] :
-           llvm::zip(generic->getOperands(), entry->getArguments())) {
-        auto ty = getTypeConverter()->convertType(operand.getType());
+      for (auto blockArg : entry->getArguments()) {
+        auto matchingOperand = generic->getOperand(blockArg.getArgNumber());
+        auto operandType = matchingOperand.getType();
+
+        auto bufferLayout = mlir::cast<LayoutAttr>(
+            mlir::cast<RankedTensorType>(operandType).getEncoding());
+        auto bufferType = operandType;
+
+        int64_t cbIndex =
+            generic.getOperandCbMapping()[blockArg.getArgNumber()];
+
+        if (cbIndex >= 0) {
+          assert(static_cast<size_t>(cbIndex) < generic.getCbs().size());
+          auto cb = generic.getCbs()[cbIndex];
+          auto cbType = cb.getType();
+          auto cbLayout = mlir::cast<LayoutAttr>(
+              mlir::cast<RankedTensorType>(cbType).getEncoding());
+          bufferLayout = cbLayout;
+          bufferType = cbType;
+        }
+
+        // TODO(rpavlovic): introduce multiplier for buffer.
+        auto buffer = BufferAttr::get(
+            getContext(), bufferLayout.getMemref(),
+            (cbIndex >= 0 ? BufferAccess::Stream : BufferAccess::Alias));
+
+        auto ty = RankedTensorType::get(
+            buffer.getShape(),
+            mlir::cast<RankedTensorType>(bufferType).getElementType(), buffer);
+
         typeMap[blockArg.getType()] = ty;
         blockArg.setType(ty);
       }
@@ -674,8 +703,13 @@ public:
 
   LogicalResult matchAndRewrite(DestinationStyleOpInterface op,
                                 PatternRewriter &rewriter) const final {
+    if (mlir::isa<GenericOp>(op->getParentOp())) {
+      // Skip if we're inside a GenericOp.
+      return failure();
+    }
+
     if (mlir::isa<ToLayoutOp>(op.getOperation())) {
-      // Skip the ToLayoutOp itself
+      // Skip the ToLayoutOp itself.
       return failure();
     }
 
@@ -1449,6 +1483,81 @@ public:
     } else if (not module->hasAttr(tt::SystemDescAttr::name)) {
       module->setAttr(tt::SystemDescAttr::name,
                       tt::SystemDescAttr::getDefault(&getContext()));
+    }
+  }
+};
+
+class TTIRGenericOpCBsRewriter : public OpRewritePattern<GenericOp> {
+public:
+  using OpRewritePattern<GenericOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(GenericOp generic,
+                                PatternRewriter &rewriter) const final {
+    if (!generic.getOperandCbMapping().empty()) {
+      // Already inserted CBs, therefore skip.
+      return failure();
+    }
+
+    rewriter.setInsertionPointToStart(generic->getBlock());
+
+    SmallVector<Value> cbValues;
+    SmallVector<int64_t> operandCBMapping;
+
+    for (auto operand : generic->getOperands()) {
+      auto ty = mlir::cast<RankedTensorType>(operand.getType());
+
+      // Enforcing tiled layout as in kernel we always want to work with tiles.
+      auto desiredElementType = rewriter.getType<TileType>(ty.getElementType());
+      auto desiredLayout = rewriter.getAttr<LayoutAttr>(
+          ty, MemorySpace::DeviceL1, generic.getGrid(), desiredElementType);
+
+      auto operandTy = operand.getType();
+      auto operandLayout = mlir::cast<LayoutAttr>(
+          mlir::cast<RankedTensorType>(operandTy).getEncoding());
+
+      if (desiredLayout.getGrid() == operandLayout.getGrid()) {
+        // TODO(rpavlovic): should we check other layout features such as
+        // linear?
+        operandCBMapping.push_back(-1);
+        continue;
+      }
+
+      auto emptyOp = rewriter.create<tensor::EmptyOp>(
+          generic->getLoc(), ty.getShape(), ty.getElementType(), desiredLayout);
+      cbValues.push_back(emptyOp.getResult());
+      operandCBMapping.push_back(cbValues.size() - 1);
+    }
+
+    // TODO(rpavlovic): CBs could have constraint L1.
+    auto newConstraints = rewriter.getArrayAttr(
+        SmallVector<Attribute>(generic->getNumOperands() + cbValues.size(),
+                               rewriter.getAttr<OperandConstraintAttr>(
+                                   OperandConstraint::AnyDeviceTile)));
+    rewriter.setInsertionPointAfter(generic);
+    auto newGenericOp = rewriter.create<ttir::GenericOp>(
+        generic->getLoc(), generic.getResultTypes(), generic.getInputs(),
+        generic.getOutputs(), cbValues, generic.getGrid(),
+        generic.getIndexingMaps(), generic.getIteratorTypes(), newConstraints,
+        operandCBMapping);
+
+    auto &oldRegion = generic.getRegion();
+    newGenericOp->getRegion(0).takeBody(oldRegion);
+
+    rewriter.replaceOp(generic, newGenericOp);
+    return success();
+  }
+};
+
+class TTIRGenericOpCBs : public impl::TTIRGenericOpCBsBase<TTIRGenericOpCBs> {
+public:
+  using impl::TTIRGenericOpCBsBase<TTIRGenericOpCBs>::TTIRGenericOpCBsBase;
+
+  void runOnOperation() final {
+    RewritePatternSet patterns(&getContext());
+    patterns.add<TTIRGenericOpCBsRewriter>(&getContext());
+    FrozenRewritePatternSet patternSet(std::move(patterns));
+    if (failed(applyPatternsAndFoldGreedily(getOperation(), patternSet))) {
+      signalPassFailure();
     }
   }
 };

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -27,6 +27,7 @@ void createTTIRToTTMetalBackendPipeline(
   layoutOptions.defaultMemorySpace = mlir::tt::MemorySpace::DeviceL1;
   layoutOptions.defaultDeviceMemoryLayout = mlir::tt::TensorMemoryLayout::None;
   pm.addPass(mlir::tt::ttir::createTTIRLayout(layoutOptions));
+  pm.addPass(mlir::tt::ttir::createTTIRGenericOpCBs());
   pm.addPass(mlir::tt::ttir::createTTIRGenericRegionOperandsToMemref());
   pm.addPass(mlir::tt::ttir::createTTIRAllocate());
   pm.addPass(createConvertTTIRToTTMetalPass());

--- a/runtime/lib/ttmetal/command_queue.cpp
+++ b/runtime/lib/ttmetal/command_queue.cpp
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <string>
 #include <cstdint>
+#include <string>
 #include <unordered_map>
 
 #include "tt/runtime/detail/debug.h"

--- a/runtime/lib/ttmetal/command_queue.cpp
+++ b/runtime/lib/ttmetal/command_queue.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <string>
+#include <cstdint>
 #include <unordered_map>
 
 #include "tt/runtime/detail/debug.h"
@@ -12,6 +13,7 @@
 
 #include "ttmlir/Target/TTMetal/Target.h"
 #include "ttmlir/Version.h"
+#include "types_generated.h"
 
 namespace tt::runtime::ttmetal {
 
@@ -415,6 +417,7 @@ void CQExecutor::execute(
   ZoneScopedN("EnqueueProgramCommand");
   ::tt::tt_metal::Program program = ::tt::tt_metal::CreateProgram();
 
+  std::unordered_set<uint32_t> createdCBs;
   for (::tt::target::metal::KernelDesc const *kernelDesc :
        *command->program()->kernels()) {
     ::tt::target::metal::KernelSource const *kernelSource =
@@ -434,9 +437,14 @@ void CQExecutor::execute(
         ::tt::tt_metal::CreateKernel(program, fileName, coreRangeSet, config);
 
     for (::tt::target::CBRef const *cbRef : *kernelDesc->cbs()) {
+      if (createdCBs.count(cbRef->desc()->port())) {
+        // Since kernels may share the same CB, we only need to create it once.
+        continue;
+      }
       ::tt::tt_metal::CircularBufferConfig config =
           createCircularBufferConfig(cbRef, buffers);
       ::tt::tt_metal::CreateCircularBuffer(program, coreRangeSet, config);
+      createdCBs.insert(cbRef->desc()->port());
     }
 
     // Process Kernel's runtime args based on variant and call metal APIs.

--- a/test/ttmlir/Silicon/TTMetal/simple_reduce.mlir
+++ b/test/ttmlir/Silicon/TTMetal/simple_reduce.mlir
@@ -1,17 +1,40 @@
 // RUN: ttmlir-opt --ttir-load-system-desc="path=%system_desc_path%" --ttir-to-ttmetal-backend-pipeline  %s | FileCheck %s
 #any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 #l1_ = #tt.memory_space<l1>
-#layout1 = #tt.layout<(d0, d1) -> (d0, d1), undef, <4x4>, memref<128x256xf32, #l1_>>
-#layout2 = #tt.layout<(d0, d1) -> (d0, d1), undef, <4x1>, memref<128x1024xf32, #l1_>>
-#layout3 = #tt.layout<(d0, d1) -> (d0, d1), undef, <4x1>, memref<128x32xf32, #l1_>>
+#layout1 = #tt.layout<(d0, d1) -> (d0, d1), undef, <4x4>, memref<64x96xf32, #l1_>>
+#layout2 = #tt.layout<(d0, d1) -> (d0, d1), undef, <4x1>, memref<64x32xf32, #l1_>>
 
-// TODO: add checks
-func.func @reduce(%arg0: tensor<512x1024xf32, #layout1>) -> tensor<512x32xf32, #layout3> {
-  %0 = tensor.empty() : tensor<512x32xf32, #layout3>
+func.func @reduceW(%arg0: tensor<256x384xf32, #layout1>) -> tensor<256x32xf32, #layout2> {
+  %0 = tensor.empty() : tensor<256x32xf32, #layout2>
+  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
   %1 = "ttir.sum"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
                                dim_arg = [-1: i32],
                                keep_dim = true,
                                operand_constraints = [#any_device, #any_device, #any_device]}> :
-    (tensor<512x1024xf32, #layout1>, tensor<512x32xf32, #layout3>) -> tensor<512x32xf32, #layout3>
-  return %1 : tensor<512x32xf32, #layout3>
+    (tensor<256x384xf32, #layout1>, tensor<256x32xf32, #layout2>) -> tensor<256x32xf32, #layout2>
+  return %1 : tensor<256x32xf32, #layout2>
+}
+
+#layout3 = #tt.layout<(d0, d1) -> (d0, d1), undef, <1x4>, memref<32x96xf32, #l1_>>
+func.func @reduceH(%arg0: tensor<256x384xf32, #layout1>) -> tensor<32x384xf32, #layout3> {
+  %0 = tensor.empty() : tensor<32x384xf32, #layout3>
+  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  %1 = "ttir.sum"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
+                               dim_arg = [-2: i32],
+                               keep_dim = true,
+                               operand_constraints = [#any_device, #any_device, #any_device]}> :
+    (tensor<256x384xf32, #layout1>, tensor<32x384xf32, #layout3>) -> tensor<32x384xf32, #layout3>
+  return %1 : tensor<32x384xf32, #layout3>
+}
+
+#layout4 = #tt.layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<32x32xf32, #l1_>>
+func.func @reduceWH(%arg0: tensor<256x384xf32, #layout1>) -> tensor<32x32xf32, #layout4> {
+  %0 = tensor.empty() : tensor<32x32xf32, #layout4>
+  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  %1 = "ttir.sum"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
+                               dim_arg = [-1: i32, -2: i32],
+                               keep_dim = true,
+                               operand_constraints = [#any_device, #any_device, #any_device]}> :
+    (tensor<256x384xf32, #layout1>, tensor<32x32xf32, #layout4>) -> tensor<32x32xf32, #layout4>
+  return %1 : tensor<32x32xf32, #layout4>
 }

--- a/test/ttmlir/Silicon/TTMetal/simple_reduce.mlir
+++ b/test/ttmlir/Silicon/TTMetal/simple_reduce.mlir
@@ -1,0 +1,17 @@
+// RUN: ttmlir-opt --ttir-load-system-desc="path=%system_desc_path%" --ttir-to-ttmetal-backend-pipeline  %s | FileCheck %s
+#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
+#l1_ = #tt.memory_space<l1>
+#layout1 = #tt.layout<(d0, d1) -> (d0, d1), undef, <4x4>, memref<128x256xf32, #l1_>>
+#layout2 = #tt.layout<(d0, d1) -> (d0, d1), undef, <4x1>, memref<128x1024xf32, #l1_>>
+#layout3 = #tt.layout<(d0, d1) -> (d0, d1), undef, <4x1>, memref<128x32xf32, #l1_>>
+
+// TODO: add checks
+func.func @reduce(%arg0: tensor<512x1024xf32, #layout1>) -> tensor<512x32xf32, #layout3> {
+  %0 = tensor.empty() : tensor<512x32xf32, #layout3>
+  %1 = "ttir.sum"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
+                               dim_arg = [-1: i32],
+                               keep_dim = true,
+                               operand_constraints = [#any_device, #any_device, #any_device]}> :
+    (tensor<512x1024xf32, #layout1>, tensor<512x32xf32, #layout3>) -> tensor<512x32xf32, #layout3>
+  return %1 : tensor<512x32xf32, #layout3>
+}

--- a/test/ttmlir/Silicon/TTMetal/simple_reduce.mlir
+++ b/test/ttmlir/Silicon/TTMetal/simple_reduce.mlir
@@ -38,3 +38,14 @@ func.func @reduceWH(%arg0: tensor<256x384xf32, #layout1>) -> tensor<32x32xf32, #
     (tensor<256x384xf32, #layout1>, tensor<32x32xf32, #layout4>) -> tensor<32x32xf32, #layout4>
   return %1 : tensor<32x32xf32, #layout4>
 }
+
+func.func @maxReduceWH(%arg0: tensor<256x384xf32, #layout1>) -> tensor<32x32xf32, #layout4> {
+  %0 = tensor.empty() : tensor<32x32xf32, #layout4>
+  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  %1 = "ttir.max" (%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
+                               dim_arg = [-1: i32, -2: i32],
+                               keep_dim = true,
+                               operand_constraints = [#any_device, #any_device, #any_device]}> :
+    (tensor<256x384xf32, #layout1>, tensor<32x32xf32, #layout4>) -> tensor<32x32xf32, #layout4>
+  return %1 : tensor<32x32xf32, #layout4>
+}

--- a/test/ttmlir/Silicon/TTMetal/simple_reduce_1x1.mlir
+++ b/test/ttmlir/Silicon/TTMetal/simple_reduce_1x1.mlir
@@ -1,0 +1,33 @@
+// RUN: ttmlir-opt --ttir-load-system-desc="path=%system_desc_path%" --ttir-to-ttmetal-backend-pipeline  %s | FileCheck %s
+#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
+#l1_ = #tt.memory_space<l1>
+
+func.func @reduceW(%arg0: tensor<64x256xf32>) -> tensor<64x32xf32> {
+  %0 = tensor.empty() : tensor<64x32xf32>
+  %1 = "ttir.sum"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
+                               dim_arg = [-1: i32],
+                               keep_dim = true,
+                               operand_constraints = [#any_device, #any_device, #any_device]}> :
+    (tensor<64x256xf32>, tensor<64x32xf32>) -> tensor<64x32xf32>
+  return %1 : tensor<64x32xf32>
+}
+
+func.func @reduceH(%arg0: tensor<256x64xf32>) -> tensor<32x64xf32> {
+  %0 = tensor.empty() : tensor<32x64xf32>
+  %1 = "ttir.sum"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
+                               dim_arg = [-2: i32],
+                               keep_dim = true,
+                               operand_constraints = [#any_device, #any_device, #any_device]}> :
+    (tensor<256x64xf32>, tensor<32x64xf32>) -> tensor<32x64xf32>
+  return %1 : tensor<32x64xf32>
+}
+
+func.func @reduceWH(%arg0: tensor<256x64xf32>) -> tensor<32x32xf32> {
+  %0 = tensor.empty() : tensor<32x32xf32>
+  %1 = "ttir.sum"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
+                               dim_arg = [-1: i32, -2: i32],
+                               keep_dim = true,
+                               operand_constraints = [#any_device, #any_device, #any_device]}> :
+    (tensor<256x64xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+  return %1 : tensor<32x32xf32>
+}

--- a/test/ttmlir/Silicon/TTMetal/simple_reduce_1x1.mlir
+++ b/test/ttmlir/Silicon/TTMetal/simple_reduce_1x1.mlir
@@ -4,6 +4,7 @@
 
 func.func @reduceW(%arg0: tensor<64x256xf32>) -> tensor<64x32xf32> {
   %0 = tensor.empty() : tensor<64x32xf32>
+  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
   %1 = "ttir.sum"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
                                dim_arg = [-1: i32],
                                keep_dim = true,
@@ -14,6 +15,7 @@ func.func @reduceW(%arg0: tensor<64x256xf32>) -> tensor<64x32xf32> {
 
 func.func @reduceH(%arg0: tensor<256x64xf32>) -> tensor<32x64xf32> {
   %0 = tensor.empty() : tensor<32x64xf32>
+  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
   %1 = "ttir.sum"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
                                dim_arg = [-2: i32],
                                keep_dim = true,
@@ -24,6 +26,7 @@ func.func @reduceH(%arg0: tensor<256x64xf32>) -> tensor<32x64xf32> {
 
 func.func @reduceWH(%arg0: tensor<256x64xf32>) -> tensor<32x32xf32> {
   %0 = tensor.empty() : tensor<32x32xf32>
+  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
   %1 = "ttir.sum"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
                                dim_arg = [-1: i32, -2: i32],
                                keep_dim = true,


### PR DESCRIPTION
## Summary

Fixes #536 

Adding reduce op support in metal backend path.

```
#layout3 = #tt.layout<(d0, d1) -> (d0, d1), undef, <1x4>, memref<32x96xf32, #l1_>>
func.func @reduceH(%arg0: tensor<256x384xf32, #layout1>) -> tensor<32x384xf32, #layout3> {
  %0 = tensor.empty() : tensor<32x384xf32, #layout3>
  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
  %1 = "ttir.sum"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
                               dim_arg = [-2: i32],
                               keep_dim = true,
                               operand_constraints = [#any_device, #any_device, #any_device]}> :
    (tensor<256x384xf32, #layout1>, tensor<32x384xf32, #layout3>) -> tensor<32x384xf32, #layout3>
  return %1 : tensor<32x384xf32, #layout3>
}
```

Consider about reduce sum. It will be placed on 4 cores (to match `layout3` width). This will be lowered to dispatch op:

```
    %4 = "ttmetal.dispatch"(%0, %3) <{core_ranges = [#ttmetal.core_range<0x0, 1x4>, #ttmetal.core_range<0x0, 1x1>, #ttmetal.core_range<0x1, 1x1>, #ttmetal.core_range<0x2, 1x1>, #ttmetal.core_range<0x3, 1x1>], kernelConfigs = [#ttkernel.tensix_config<hifi4, false, false, false>, #ttkernel.noc_config<noc0>, #ttkernel.noc_config<noc0>, #ttkernel.noc_config<noc0>, #ttkernel.noc_config<noc0>], operandSegmentSizes = array<i32: 1, 1>}> ({
```

It dispatches same compute kernel on all 4 cores, but 4 different DM kernels that will read column shards. 

## Details

Reduce op is lowered to ttir.generic. To produce result reduce op must bring data from all shards in the dim that is reduced. This means generic op must emit Tensix & Data movement kernels to work in parallel. 

```
    %4 = "ttir.generic"(%2, %0, %3) <{grid = #tt.grid<1x4>, indexing_maps = [#map, #map], iterator_types = [#reduction, #parallel], operandSegmentSizes = array<i32: 1, 1, 1>, operand_cb_mapping = array<i64: 0, -1>, operand_constraints = [#any_device_tile, #any_device_tile, #any_device_tile]}> ({
    ^bb0(%arg1: tensor<256x96xf32, #tt.buffer<memref<8x3x!tt.tile<32x32, f32>, #l1_>, stream>>, %arg2: tensor<32x96xf32, #tt.buffer<memref<1x3x!tt.tile<32x32, f32>, #l1_>, alias>>):
      %7 = "ttir.kernel"(%arg1, %arg2) <{kind = @sum, op = @reduce, operandSegmentSizes = array<i32: 1, 1>, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<256x96xf32, #tt.buffer<memref<8x3x!tt.tile<32x32, f32>, #l1_>, stream>>, tensor<32x96xf32, #tt.buffer<memref<1x3x!tt.tile<32x32, f32>, #l1_>, alias>>) -> tensor<32x96xf32, #tt.buffer<memref<1x3x!tt.tile<32x32, f32>, #l1_>, alias>>
      "ttir.yield"(%7) : (tensor<32x96xf32, #tt.buffer<memref<1x3x!tt.tile<32x32, f32>, #l1_>, alias>>) -> ()
    }) : (tensor<256x384xf32, #layout3>, tensor<256x384xf32, #layout2>, tensor<32x384xf32, #layout4>) -> tensor<32x384xf32, #layout4>
```

To express this at generic level, we introduce CB operands which are there for operands that will be streamed from remote locations into the local shard. This way allocation pass will know about extra memory that needs to be carved out for streaming purposes. `operand_cb_mapping` denotes which input/output operand maps to which CB.

Data movement kernel reads data in order such that compute kernel could process tile by tile if needed. So for example, if reduce H is performed data movement kernel reads column by column. Compute kernel still waits for all tiles to be read and then starts computation. To leverage the fact that DM kernel will bring data in the expected order, compute kernel should wait/pop for a single tile and not worry about inner loop indices (https://github.com/tenstorrent/tt-mlir/issues/778).

Note that if input tensor is sharded in such way that data shouldn't be moved to produce results, we will have only compute kernels employed.

TODOs:

- before mentioned https://github.com/tenstorrent/tt-mlir/issues/778
- support scaling in reduce op https://github.com/tenstorrent/tt-mlir/issues/781
- (not reduce op related) stream kernel outputs https://github.com/tenstorrent/tt-mlir/issues/782
- test and implement changes if needed for streamed dram inputs https://github.com/tenstorrent/tt-mlir/issues/783
- possible optimization https://github.com/tenstorrent/tt-mlir/issues/787