### PR TITLE
Flatten ZY reduce

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.20.0)
 project(tt-mlir LANGUAGES CXX C)
-
+set(CMAKE_BUILD_TYPE Debug)
 if (NOT DEFINED ENV{TTMLIR_ENV_ACTIVATED})
   message(FATAL_ERROR "tt-mlir environment not activated. Please run 'source env/activate'.")
 endif()

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.h
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.h
@@ -17,6 +17,7 @@
 #include "TTIROpsInterfaces.h"
 
 #define GET_OP_CLASSES
+#include "mlir/Dialect/Tensor/IR/TensorInferTypeOpInterfaceImpl.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h.inc"
 
 #endif

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -672,4 +672,62 @@ def TTIR_YieldOp : TTIR_Op<"yield", [Pure, ReturnLike, Terminator]> {
     let arguments = (ins Variadic<AnyRankedTensorOrMemRef>:$values);
 }
 
+// def TTIR_EmptyOp : TTIR_Op<"empty",
+//     [Pure,
+//      DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>, DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
+//   let summary = "empty tensor operation";
+
+//   let description = [{
+//     `tensor.empty` is an operation that defines a tensor of a particular shape.
+//     The shape could be dynamic or static. The contents of the tensor are
+//     unspecified and the only purpose of the op result is to materialize the
+//     specified shape in IR and make it available to other transformations.
+
+//     `tensor.empty` is useful in transformations that expect destination style
+//     ops. I.e., ops that implement `DestinationStyleOpInterface`. Ops that are
+//     not in destination style can be made compatible with such transformations
+//     with a `tensor.empty` destination.
+
+//     Note: This op can be lowered to a `bufferization.alloc_tensor`, at which
+//     point it turns into an explicit buffer allocation.
+//   }];
+
+//   let arguments = (ins Variadic<Index>:$dynamicSizes);
+
+//   let results = (outs AnyRankedTensor:$result);
+
+//   let assemblyFormat = "`(`$dynamicSizes`)` attr-dict `:` type($result)";
+
+//   let extraClassDeclaration = [{
+//     RankedTensorType getType() {
+//       return ::llvm::cast<RankedTensorType>(getResult().getType());
+//     }
+
+//     // Return both static and dynamic sizes as a list of `OpFoldResult`.
+//     SmallVector<OpFoldResult> getMixedSizes();
+
+//     // Return the Value of the dynamic size of the tensor at dimension `idx`.
+//     // Asserts that the shape is dynamic at that `idx`.
+//     Value getDynamicSize(unsigned idx);
+//   }];
+
+//   let builders = [
+//     // Build with fully static sizes.
+//     OpBuilder<(ins "ArrayRef<int64_t>":$staticShape, "Type":$elementType,
+//                    CArg<"Attribute", "{}">:$encoding)>,
+
+//     // Build with mixed static/dynamic sizes.
+//     OpBuilder<(ins "ArrayRef<int64_t>":$staticShape, "Type":$elementType,
+//                    "ValueRange":$dynamicSizes,
+//                    CArg<"Attribute", "{}">:$encoding)>,
+
+//     // Build with mixed static/dynamic sizes.
+//     OpBuilder<(ins "ArrayRef<OpFoldResult>":$sizes, "Type":$elementType,
+//                    CArg<"Attribute", "{}">:$encoding)>
+//   ];
+
+//   let hasCanonicalizer = 1;
+//   let hasVerifier = 1;
+// }
+
 #endif

--- a/include/ttmlir/Dialect/TTIR/Transforms/CMakeLists.txt
+++ b/include/ttmlir/Dialect/TTIR/Transforms/CMakeLists.txt
@@ -2,3 +2,32 @@ set(LLVM_TARGET_DEFINITIONS Passes.td)
 mlir_tablegen(Passes.h.inc --gen-pass-decls)
 add_public_tablegen_target(MLIRTTIRPassesIncGen)
 add_dependencies(mlir-headers MLIRTTIRPassesIncGen)
+add_mlir_pdll_library(MLIRTTIRPatternsIncGen
+  FlattenZYReduce.pdll
+  FlattenZYReducePatterns.h.inc
+)
+
+  add_dependencies(mlir-headers MLIRTTIRPatternsIncGen)
+
+# Exclude tests from libMLIR.so
+# add_mlir_library(MLIRTestPDLL2
+#   TestPDLL2.cpp
+
+#   EXCLUDE_FROM_LIBMLIR
+
+#   ADDITIONAL_HEADER_DIRS
+#   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Tools/PDLL
+
+#   DEPENDS
+#   MLIRTestPDLL2PatternsIncGen
+
+#   LINK_LIBS PUBLIC
+#   MLIRCastInterfaces
+#   MLIRIR
+#   MLIRPass
+#   MLIRPDLInterpDialect
+#   MLIRPDLDialect
+#   MLIRSupport
+#   MLIRTestDialect
+#   MLIRTransformUtils
+#   )

--- a/include/ttmlir/Dialect/TTIR/Transforms/FlattenZYReduce.pdll
+++ b/include/ttmlir/Dialect/TTIR/Transforms/FlattenZYReduce.pdll
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.td"
+#include "mlir/Dialect/Tensor/IR/TensorOps.td"
+#include "mlir/IR/BuiltinTypes.td"
+
+Constraint hasSingleDimArg(attr: I32ArrayAttr) [{
+    return mlir::success(attr.size() == 1);
+}];
+
+Constraint dimArgIsZ(attr: I32ArrayAttr) [{
+    return mlir::success(mlir::cast<mlir::IntegerAttr>(attr[0]).getInt() == -3);
+}];
+
+Constraint dimArgIsY(attr: I32ArrayAttr) [{
+    return mlir::success(mlir::cast<mlir::IntegerAttr>(attr[0]).getInt() == -2);
+}];
+
+Constraint keepDimTrue(attr: BoolAttr) [{
+    return mlir::success(mlir::cast<mlir::BoolAttr>(attr).getValue());
+}];
+
+Rewrite BuildZYFlattenReshapeDPS(input: Value, operand_constraints: ArrayAttr) -> Op [{
+    auto shapei64 = mlir::cast<mlir::RankedTensorType>(input.getType()).getShape().vec();
+    int64_t zdim = shapei64.size() - 3;
+    int64_t ydim = shapei64.size() - 2;
+
+    shapei64[ydim] = shapei64[ydim]*shapei64[zdim];
+    shapei64[zdim] = 1;
+
+    auto ty = mlir::cast<mlir::RankedTensorType>(input.getType());
+    auto output =
+        rewriter.create<mlir::tensor::EmptyOp>(input.getLoc(), shapei64, ty.getElementType());
+
+    auto shape_attr = rewriter.getI32ArrayAttr(
+        {static_cast<int32_t>(shapei64[0]), static_cast<int32_t>(shapei64[1]),
+         static_cast<int32_t>(shapei64[2]), static_cast<int32_t>(shapei64[3])});
+
+    return rewriter.create<mlir::tt::ttir::ReshapeOp>(input.getLoc(), output.getType(), input, output, shape_attr, operand_constraints);
+}];
+
+Rewrite GetSecondReduceDPSOutput(new_reshape: Value) -> Op [{
+    auto ty = mlir::cast<mlir::RankedTensorType>(new_reshape.getType());
+    auto shape = mlir::cast<mlir::RankedTensorType>(new_reshape.getType()).getShape().vec();
+    shape[shape.size()-2] = 1;
+    auto output =
+        rewriter.create<mlir::tensor::EmptyOp>(new_reshape.getLoc(), shape, ty.getElementType());
+    return output;
+}];
+
+Pattern FlattenZYReduce {
+    let input: Value;
+    let reduce1_empty = op<tensor.empty>();
+    let reduce2_empty = op<tensor.empty>() -> (reduce2_type: Builtin_RankedTensor);
+    let reduce1 = op<ttir.mean>(input, reduce1_empty) {dim_arg = reduce1_dim: I32ArrayAttr, keep_dim = reduce1_keepdim: BoolAttr, operand_constraints = reduce1_constraints: TT_OperandConstraintArrayAttr};
+    let reduce2 = op<ttir.mean>(reduce1, reduce2_empty) {dim_arg = reduce2_dim: I32ArrayAttr, keep_dim = reduce2_keepdim: BoolAttr, operand_constraints = reduce2_constraints: TT_OperandConstraintArrayAttr};
+
+    // Ensure both reduces have exactly one dim arg
+    hasSingleDimArg(reduce1_dim);
+    hasSingleDimArg(reduce2_dim);
+
+    // Ensure the pattern is reduce(-3) --> reduce(-2)
+    dimArgIsZ(reduce1_dim);
+    dimArgIsY(reduce2_dim);
+
+    // Ensure both reduce ops have keepdim = True
+    keepDimTrue(reduce1_keepdim);
+    keepDimTrue(reduce2_keepdim);
+
+    rewrite reduce2 with {
+        // Use native function to build dps reshape since we need to acces and change the shape attr
+        let reshape = BuildZYFlattenReshapeDPS(input, reduce1_constraints);
+        replace reduce1 with reshape;
+
+        // Use native function to build DPS output for second reduce since we need to access the shape attr of the reshape.
+        let reduce2_empty_new = GetSecondReduceDPSOutput(reshape);
+        let new_reduce = op<ttir.mean>(reshape, reduce2_empty_new) {dim_arg = attr<"[-2: i32]">, keep_dim =  attr<"true">, operand_constraints = reduce1_constraints} -> (reduce2_type);
+        replace reduce2 with new_reduce;
+    };
+}

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.h
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.h
@@ -5,10 +5,19 @@
 #ifndef TTMLIR_DIALECT_TTIR_TRANSFORMS_PASSES_H
 #define TTMLIR_DIALECT_TTIR_TRANSFORMS_PASSES_H
 
+#include "mlir/Dialect/PDL/IR/PDL.h"
+#include "mlir/Dialect/PDLInterp/IR/PDLInterp.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Parser/Parser.h"
 #include "mlir/Pass/Pass.h"
 #include "ttmlir/Dialect/TT/Utils/OverrideParams.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIR.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+
+#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+#pragma clang diagnostic ignored "-Wunused-local-typedef"
+#include "ttmlir/Dialect/TTIR/Transforms/FlattenZYReducePatterns.h.inc"
+
 #include <memory>
 
 namespace mlir::tt::ttir {

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -6,6 +6,8 @@
 #define TTMLIR_TTMLIR_DIALECT_TTIR_TTIRPASSES_TD
 
 include "mlir/Pass/PassBase.td"
+include "mlir/Dialect/PDL/IR/PDLDialect.td"
+include "mlir/Dialect/PDLInterp/IR/PDLInterpOps.td"
 
 def TTIRImplicitDevice: Pass<"ttir-implicit-device", "::mlir::ModuleOp"> {
   let summary = "Create an implicit device";
@@ -17,6 +19,18 @@ def TTIRImplicitDevice: Pass<"ttir-implicit-device", "::mlir::ModuleOp"> {
   let options = [
     ListOption<"meshShape", "mesh-shape", "int64_t",
                "Set the multi-device mesh shape.">,
+  ];
+}
+
+def TTIRFlattenZYReduction: Pass<"ttir-flatten-zy-reduction", "::mlir::ModuleOp"> {
+  let summary = "";
+  let description = [{
+    Transforms the pattern reduce(-3) --> reduce(-2) to reshape(W, 1, Z*Y, X) --> reduce(-2)
+  }];
+
+  let dependentDialects = [
+    "::mlir::pdl::PDLDialect",
+    "::mlir::pdl_interp::PDLInterpDialect",
   ];
 }
 

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
+#include <mlir/IR/BuiltinAttributes.h>
+#include <mlir/Support/LLVM.h>
 #include <string>
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -590,3 +592,198 @@ void mlir::tt::ttir::MultiplyOp::buildGenericRegion(
 
   return success();
 }
+
+// InferType
+
+// ::llvm::LogicalResult
+// mlir::tt::ttir::ReshapeOp::inferReturnTypes(::mlir::MLIRContext *context,
+//                                               ::std::optional<::mlir::Location>
+//                                               location,
+//                                               ::mlir::ValueRange operands,
+//                                               ::mlir::DictionaryAttr
+//                                               attributes,
+//                                               ::mlir::OpaqueProperties
+//                                               properties,
+//                                               ::mlir::RegionRange regions,
+//                                               ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes)
+//                                               {
+
+//    std::vector<int64_t> shape_vec;
+//    mlir::tt::ttir::ReshapeOp::Adaptor adaptor(operands, attributes,
+//    properties, regions); for (int64_t dim :
+//    mlir::cast<RankedTensorType>(operands[0].getType()).getShape()) {
+//     shape_vec.push_back(dim);
+//    }
+
+//    ArrayRef<int64_t> new_shape_i64(shape_vec);
+
+//    auto input_type = mlir::cast<RankedTensorType>(operands[0].getType());
+//    inferredReturnTypes.push_back(input_type.cloneWith(new_shape_i64,
+//    input_type.getElementType())); return success();
+// }
+
+// ::llvm::LogicalResult
+// mlir::tt::ttir::MeanOp::inferReturnTypes(::mlir::MLIRContext *context,
+//                                               ::std::optional<::mlir::Location>
+//                                               location,
+//                                               ::mlir::ValueRange operands,
+//                                               ::mlir::DictionaryAttr
+//                                               attributes,
+//                                               ::mlir::OpaqueProperties
+//                                               properties,
+//                                               ::mlir::RegionRange regions,
+//                                               ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes)
+//                                               {
+
+//    mlir::tt::ttir::MeanOp::Adaptor adaptor(operands, attributes, properties,
+//    regions);
+
+//    std::vector<int64_t> shape_vec;
+//    for (int64_t dim :
+//    mlir::cast<RankedTensorType>(operands[0].getType()).getShape()) {
+//     shape_vec.push_back(dim);
+//    }
+//    auto outty = mlir::cast<RankedTensorType>(operands[1].getType());
+//    (void)outty;
+
+//    bool keepdim = true; //attributes.contains("keep_dim");
+
+//    if (adaptor.getDimArg().has_value()) {
+//     ArrayRef reduce_dims_ = adaptor.getDimArg()->getValue();
+//     std::vector<int32_t> reduce_dims;
+//     for (Attribute dim_attr : reduce_dims_) {
+//       int32_t dim = mlir::cast<IntegerAttr>(dim_attr).getInt();
+//       if (dim < 0) {
+//         dim += shape_vec.size();
+//       }
+//       reduce_dims.push_back(dim);
+//     }
+
+//     if (keepdim) {
+//       for (int32_t dim : reduce_dims) {
+//         shape_vec[dim] = 1;
+//       }
+//     } else {
+//       std::sort(reduce_dims.begin(), reduce_dims.end());
+//       for (int32_t dim : reduce_dims) {
+//         shape_vec.erase(shape_vec.begin() + dim);
+//       }
+//       // In the event the reduce brings the tensor to a single value, make
+//       sure shape is still [1] if (shape_vec.size() == 0) {
+//         shape_vec = {1};
+//       }
+//     }
+
+//    } else {
+//     if (keepdim) {
+//       for (uint64_t i = 0; i < shape_vec.size(); i++) {
+//         shape_vec[i] = 1;
+//       }
+//     } else {
+//       shape_vec = {1};
+//     }
+//    }
+
+//     auto input_type = mlir::cast<RankedTensorType>(operands[0].getType());
+//     inferredReturnTypes.push_back(input_type.cloneWith(shape_vec,
+//     input_type.getElementType()));
+//    return success();
+// }
+
+// ::llvm::LogicalResult
+// mlir::tt::ttir::MaxOp::inferReturnTypes(::mlir::MLIRContext *context,
+//                                               ::std::optional<::mlir::Location>
+//                                               location,
+//                                               ::mlir::ValueRange operands,
+//                                               ::mlir::DictionaryAttr
+//                                               attributes,
+//                                               ::mlir::OpaqueProperties
+//                                               properties,
+//                                               ::mlir::RegionRange regions,
+//                                               ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes)
+//                                               {
+
+//    std::vector<int64_t> shape_vec;
+//    for (int64_t dim :
+//    mlir::cast<RankedTensorType>(operands[0].getType()).getShape()) {
+//     shape_vec.push_back(dim);
+//    }
+//    bool keepdim = attributes.getAs<BoolAttr>("keep_dim").getValue();
+
+//    if (attributes.getAs<ArrayAttr>("dim_arg")) {
+//     int32_t reduce_dim =
+//     mlir::cast<IntegerAttr>(attributes.getAs<ArrayAttr>("dim_arg")[0]).getInt();
+//     if (reduce_dim < 0) {
+//       reduce_dim += shape_vec.size();
+//     }
+
+//     if (keepdim) {
+//       shape_vec[reduce_dim] = 1;
+//     } else {
+//       shape_vec.erase(shape_vec.begin() + reduce_dim);
+//     }
+
+//    } else {
+//     if (keepdim) {
+//       for (uint64_t i = 0; i < shape_vec.size(); i++) {
+//         shape_vec[i] = 1;
+//       }
+//     } else {
+//       shape_vec = {1};
+//     }
+//    }
+
+//     auto input_type = mlir::cast<RankedTensorType>(operands[0].getType());
+//     inferredReturnTypes.push_back(input_type.cloneWith(shape_vec,
+//     input_type.getElementType()));
+//    return success();
+// }
+
+// ::llvm::LogicalResult
+// mlir::tt::ttir::SumOp::inferReturnTypes(::mlir::MLIRContext *context,
+//                                               ::std::optional<::mlir::Location>
+//                                               location,
+//                                               ::mlir::ValueRange operands,
+//                                               ::mlir::DictionaryAttr
+//                                               attributes,
+//                                               ::mlir::OpaqueProperties
+//                                               properties,
+//                                               ::mlir::RegionRange regions,
+//                                               ::llvm::SmallVectorImpl<::mlir::Type>&inferredReturnTypes)
+//                                               {
+
+//    std::vector<int64_t> shape_vec;
+//    for (int64_t dim :
+//    mlir::cast<RankedTensorType>(operands[0].getType()).getShape()) {
+//     shape_vec.push_back(dim);
+//    }
+//    bool keepdim = attributes.getAs<BoolAttr>("keep_dim").getValue();
+
+//    if (attributes.getAs<ArrayAttr>("dim_arg")) {
+//     int32_t reduce_dim =
+//     mlir::cast<IntegerAttr>(attributes.getAs<ArrayAttr>("dim_arg")[0]).getInt();
+//     if (reduce_dim < 0) {
+//       reduce_dim += shape_vec.size();
+//     }
+
+//     if (keepdim) {
+//       shape_vec[reduce_dim] = 1;
+//     } else {
+//       shape_vec.erase(shape_vec.begin() + reduce_dim);
+//     }
+
+//    } else {
+//     if (keepdim) {
+//       for (uint64_t i = 0; i < shape_vec.size(); i++) {
+//         shape_vec[i] = 1;
+//       }
+//     } else {
+//       shape_vec = {1};
+//     }
+//    }
+
+//     auto input_type = mlir::cast<RankedTensorType>(operands[0].getType());
+//     inferredReturnTypes.push_back(input_type.cloneWith(shape_vec,
+//     input_type.getElementType()));
+//    return success();
+// }

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -20,6 +20,7 @@ void createTTNNPipelineTTIRPasses(
   ttir::TTIRLoadSystemDescOptions systemDescOptions;
   systemDescOptions.path = options.systemDescPath;
   pm.addPass(mlir::tt::ttir::createTTIRSlidingWindow2dFixShapes());
+  pm.addPass(mlir::tt::ttir::createTTIRFlattenZYReduction());
   pm.addPass(mlir::tt::ttir::createTTIRLoadSystemDesc(systemDescOptions));
 
   ttir::TTIRImplicitDeviceOptions implicitDeviceOptions;

--- a/test/ttmlir/Dialect/TTNN/dual_mean_flatten.mlir
+++ b/test/ttmlir/Dialect/TTNN/dual_mean_flatten.mlir
@@ -1,0 +1,12 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
+#any_device = #tt.operand_constraint<dram|l1|tile|any_device|any_device_tile>
+module {
+  func.func @forward(%arg0: tensor<1x32x512x1024xbf16>) -> tensor<1x1x1x1024xbf16> {
+    %0 = tensor.empty() : tensor<1x1x512x1024xbf16>
+    %1 = "ttir.mean"(%arg0, %0) <{dim_arg = [-3: i32], keep_dim = true, operand_constraints = [#any_device, #any_device]}> : (tensor<1x32x512x1024xbf16>, tensor<1x1x512x1024xbf16>) -> tensor<1x1x512x1024xbf16>
+    %2 = tensor.empty() : tensor<1x1x1x1024xbf16>
+    %3 = "ttir.mean"(%1, %2) <{dim_arg = [-2: i32], keep_dim = true, operand_constraints = [#any_device, #any_device]}> : (tensor<1x1x512x1024xbf16>, tensor<1x1x1x1024xbf16>) -> tensor<1x1x1x1024xbf16>
+
+    return %3 : tensor<1x1x1x1024xbf16>
+  }
+}


### PR DESCRIPTION
Added a pass that takes the pattern mean(-3) --> mean(-2)  to reshape(..., 1, Z*Y, X) --> mean(-2)

Necessary for channel-last resnet until ttnn provides us with reduce on dim -3: https://github.com/tenstorrent/tt-metal/issues/12845

I've confirmed that this works for the specific shape used by resnet50, although in some instances we run into sharding/ tile layout issues.

I've also done some research on MLIR's PDLL for defining pattern rewrites, which is less tedious than writing them entirely in C++, and is supposed to work more smoothly than doing it in the TDRR paradigm. More here: https://mlir.llvm.org/docs/PDLL/

@nvukobratTT @nsmithtt @AleksKnezevic @uazizTT @mrakitaTT 

**NOTE:** The copyright/license header comment was not enforced by the linter on the PDLL file, so that needs to be fixed.