### PR TITLE
Force all op outputs to be in DRAM-interleaved config.

### DIFF
--- a/include/ttmlir/Dialect/TT/IR/TTOpsEnums.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsEnums.td
@@ -72,12 +72,12 @@ def TT_MemorySpace : I32EnumAttr<"MemorySpace", "TT MemorySpace",
   let cppNamespace = "::mlir::tt";
 }
 
-def TT_TensorMemoryLayoutNone : I32EnumAttrCase<"None", 0, "none">;
-def TT_TensorMemoryLayoutInterleaved : I32EnumAttrCase<"Interleaved", 1, "interleaved">;
-def TT_TensorMemoryLayoutSingleBank : I32EnumAttrCase<"SingleBank", 2, "single_bank">;
-def TT_TensorMemoryLayoutHeightSharded : I32EnumAttrCase<"HeightSharded", 3, "height_sharded">;
-def TT_TensorMemoryLayoutWidthSharded : I32EnumAttrCase<"WidthSharded", 4, "width_sharded">;
-def TT_TensorMemoryLayoutBlockSharded : I32EnumAttrCase<"BlockSharded", 5, "block_sharded">;
+def TT_TensorMemoryLayoutInterleaved : I32EnumAttrCase<"Interleaved", 0, "interleaved">;
+def TT_TensorMemoryLayoutSingleBank : I32EnumAttrCase<"SingleBank", 1, "single_bank">;
+def TT_TensorMemoryLayoutHeightSharded : I32EnumAttrCase<"HeightSharded", 2, "height_sharded">;
+def TT_TensorMemoryLayoutWidthSharded : I32EnumAttrCase<"WidthSharded", 3, "width_sharded">;
+def TT_TensorMemoryLayoutBlockSharded : I32EnumAttrCase<"BlockSharded", 4, "block_sharded">;
+def TT_TensorMemoryLayoutNone : I32EnumAttrCase<"None", 5, "none">;
 
 def TT_TensorMemoryLayout : I32EnumAttr<"TensorMemoryLayout", "TT TensorMemoryLayout",
                            [

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -396,7 +396,8 @@ def TTNN_Conv2dOp : TTNN_NamedDPSOp<"conv2d"> {
                          I32Attr:$padding_width,
                          I32Attr:$dilation_height,
                          I32Attr:$dilation_width,
-                         I32Attr:$groups);
+                         I32Attr:$groups,
+                         I32Attr:$shard_layout);
 
     let results = (outs AnyRankedTensor:$result);
 

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -7,4 +7,8 @@
 
 include "mlir/Pass/PassBase.td"
 
+def TTNNForceDRAMInterleaved: Pass<"ttir-force-dram-interleaved", "::mlir::ModuleOp"> {
+    let summary = "Place to_memory_config ops on all op outputs that do not have dram interleaved outputs.";
+}
+
 #endif

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -145,6 +145,7 @@ table Conv2dOp {
   dilation_height: uint32;
   dilation_width: uint32;
   groups: uint32;
+  shard_layout: uint32;
 }
 
 table MaxPool2dOp {

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -46,6 +46,7 @@ void createTTNNPipelineAnalysisPasses(
 void createTTNNPipelineLoweringPasses(
     OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options) {
   pm.addPass(createConvertTTIRToTTNNPass());
+  pm.addPass(createTTNNForceDRAMInterleaved());
 }
 
 void createTTNNPipelineTTIRPassesFromString(OpPassManager &pm,

--- a/lib/Dialect/TTNN/Transforms/Passes.cpp
+++ b/lib/Dialect/TTNN/Transforms/Passes.cpp
@@ -17,6 +17,125 @@
 #include "ttmlir/Dialect/TTIR/IR/TTIR.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsTypes.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+#include <llvm/Support/LogicalResult.h>
+#include <mlir/IR/BuiltinAttributes.h>
+#include <mlir/IR/Operation.h>
 
-namespace mlir::tt::ttnn {} // namespace mlir::tt::ttnn
+namespace mlir::tt::ttnn {
+#define GEN_PASS_DEF_TTNNFORCEDRAMINTERLEAVED
+#include "ttmlir/Dialect/TTNN/Transforms/Passes.h.inc"
+
+static Value getOrInsertDevice(PatternRewriter &rewriter, Operation *op) {
+  Block *block = op->getBlock();
+  for (auto &op : block->getOperations()) {
+    if (auto deviceOp = dyn_cast<ttnn::GetDeviceOp>(op)) {
+      return deviceOp.getResult();
+    }
+  }
+
+  DeviceAttr deviceAttr = getCurrentScopeDevice(op);
+  auto currentInsertionPoint = rewriter.saveInsertionPoint();
+  rewriter.setInsertionPoint(block, block->begin());
+  auto deviceOp = rewriter.create<ttnn::GetDeviceOp>(
+      op->getLoc(), rewriter.getType<DeviceType>(deviceAttr),
+      ttnn::MeshShapeAttr::get(op->getContext(), 1, 1));
+  rewriter.restoreInsertionPoint(currentInsertionPoint);
+  return deviceOp.getResult();
+}
+
+class TTNNForceDRAMInterleavedRewriter : public RewritePattern {
+public:
+  TTNNForceDRAMInterleavedRewriter(MLIRContext *context)
+      : RewritePattern(MatchAnyOpTypeTag(), 1, context) {}
+
+  LogicalResult matchAndRewrite(Operation *op,
+                                PatternRewriter &rewriter) const final {
+
+    if (isa<ttnn::EmptyOp>(op) || isa<ttnn::ToMemoryConfigOp>(op) ||
+        isa<ttnn::FullOp>(op)) {
+      return failure();
+    }
+
+    if (op->getResults().size() == 0) {
+      return failure();
+    }
+    if (!isa<RankedTensorType>(op->getResult(0).getType())) {
+      return failure();
+    }
+
+    RankedTensorType result_type =
+        mlir::cast<RankedTensorType>(op->getResult(0).getType());
+    if (!isa<mlir::tt::LayoutAttr>(result_type.getEncoding())) {
+      return failure();
+    }
+
+    mlir::tt::LayoutAttr layout_attr =
+        mlir::cast<mlir::tt::LayoutAttr>(result_type.getEncoding());
+    if (layout_attr.getMemLayout() ==
+            mlir::tt::TensorMemoryLayout::Interleaved &&
+        layout_attr.getMemorySpace() == mlir::tt::MemorySpace::DeviceDRAM) {
+      return failure();
+    }
+    auto device = getOrInsertDevice(rewriter, op);
+
+    // Now we know that this op does NOT leave its output on device dram -
+    // interleaved If any of the ops that consumes this output are not
+    // to_memory_config, insert it on the output.
+    bool need_to_memcfg = false;
+    for (Operation *user : op->getUsers()) {
+      if (!isa<ToMemoryConfigOp>(user)) {
+        need_to_memcfg = true;
+      }
+    }
+    if (!need_to_memcfg) {
+      return failure();
+    }
+
+    layout_attr = layout_attr.withMemoryLayout(
+        rewriter.getContext(), mlir::tt::TensorMemoryLayout::Interleaved);
+    layout_attr = layout_attr.withMemorySpace(
+        rewriter.getContext(), mlir::tt::MemorySpace::DeviceDRAM);
+    auto new_type = RankedTensorType::get(
+        result_type.getShape(), result_type.getElementType(), layout_attr);
+
+    auto to_memory_config = rewriter.create<ToMemoryConfigOp>(
+        op->getLoc(), new_type, op->getResult(0), device);
+
+    // Want to replace all uses of the Op output with users of the
+    // to_memory_config output However, one of the Op users IS the
+    // to_memory_config, so we don't want to replace that with itself.
+    rewriter.replaceAllUsesExcept(op->getResult(0), to_memory_config,
+                                  to_memory_config);
+
+    // Move to_memory_config sequentially after the op to keep the IR properly
+    // ordered
+    to_memory_config->moveAfter(op);
+
+    return success();
+  }
+};
+
+class TTNNForceDRAMInterleaved
+    : public impl::TTNNForceDRAMInterleavedBase<TTNNForceDRAMInterleaved> {
+public:
+  using impl::TTNNForceDRAMInterleavedBase<
+      TTNNForceDRAMInterleaved>::TTNNForceDRAMInterleavedBase;
+
+  void runOnOperation() final {
+    auto device = getCurrentScopeDevice(getOperation());
+    assert(device && "Device not found");
+    RewritePatternSet patterns(&getContext());
+    patterns.add<TTNNForceDRAMInterleavedRewriter>(&getContext());
+    FrozenRewritePatternSet patternSet(std::move(patterns));
+    if (failed(applyPatternsAndFoldGreedily(getOperation(), patternSet))) {
+      getOperation()->dump();
+      signalPassFailure();
+      return;
+    }
+  }
+};
+
+} // namespace mlir::tt::ttnn

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -237,7 +237,7 @@ createOp(FlatbufferObjectCache &cache, Conv2dOp op) {
       op.getInputWidth(), op.getKernelHeight(), op.getKernelWidth(),
       op.getStrideHeight(), op.getStrideWidth(), op.getPaddingHeight(),
       op.getPaddingWidth(), op.getDilationHeight(), op.getDilationWidth(),
-      op.getGroups());
+      op.getGroups(), op.getShardLayout());
 }
 
 template <typename EltwiseOp>

--- a/runtime/lib/ttnn/operations/conv/conv2d.cpp
+++ b/runtime/lib/ttnn/operations/conv/conv2d.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "conv2d.h"
+#include "impl/buffers/buffer_constants.hpp"
 #include "tt/runtime/detail/ttnn.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "ttmlir/Target/TTNN/program_generated.h"
@@ -19,6 +20,7 @@ void run(const ::tt::target::ttnn::Conv2dOp *op, ProgramContext &context) {
   auto config = ::ttnn::operations::conv::conv2d::Conv2dConfig();
   config.dtype = utils::getDataType(op->input());
   config.weights_dtype = utils::getDataType(op->weight());
+  config.shard_layout = TensorMemoryLayout(op->shard_layout());
   ::ttnn::Device &device = utils::getDevice(op->device(), devicePool);
   ::ttnn::Tensor out =
       std::get<0>(::ttnn::operations::conv::conv2d::conv2d<::ttnn::Device>(


### PR DESCRIPTION
- Force all op outputs to be in DRAM-interleaved config
    - This is done using a pass on the TTNN dialect
- Fixed how the memory config of the output of Conv2d and MaxPool2d is modelled.
- Model the shard spec in the Conv2dOp in the TTNN dialect.
- Match the enum values for `TensorMemoryLayout` in the TTNN dialect to the equivalent `TensorMemoryLayout` enum used in tt-metal.

CC: @nvukobratTT 