### PR TITLE
Add StableHLO conversion for concatenate. [#751]

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -368,134 +368,213 @@ public:
       break;
     }
     }
-    return success();
-  }
+    class StableHLOToTTIRConcatOpConversionPattern
+        : public OpConversionPattern<mlir::stablehlo::ConcatenateOp> {
 
-private:
-  template <typename DestOp>
-  LogicalResult
-  matchAndRewriteInternal(mlir::stablehlo::CompareOp srcOp,
-                          mlir::stablehlo::CompareOp::Adaptor adaptor,
-                          ConversionPatternRewriter &rewriter) const {
-    // TTNN doesn't support boolean data type. TTNN compare operations have same
-    // output data type as of input data type (e.g. comparing float32 will
-    // produce float32 result). So input operand is used to create output type
-    // and output tensor and the generated output tensor will be different type
-    // (instead of boolean) depending on input operands.
-    mlir::RankedTensorType outputType = mlir::cast<RankedTensorType>(
-        this->getTypeConverter()->convertType(srcOp->getOperand(0).getType()));
-    tensor::EmptyOp outputTensor = rewriter.create<tensor::EmptyOp>(
-        srcOp.getLoc(), outputType.getShape(), outputType.getElementType());
+      using OpConversionPattern<
+          mlir::stablehlo::ConcatenateOp>::OpConversionPattern;
 
-    DestOp TTIROp = rewriter.replaceOpWithNewOp<DestOp>(
-        srcOp,
-        TypeRange(
-            this->getTypeConverter()->convertType(outputTensor.getType())),
-        adaptor.getOperands(), ValueRange(outputTensor),
-        rewriter.getArrayAttr(
-            SmallVector<Attribute>(adaptor.getOperands().size() + 1,
-                                   rewriter.getAttr<OperandConstraintAttr>(
-                                       OperandConstraint::AnyDeviceTile))));
+    public:
+      LogicalResult
+      matchAndRewrite(mlir::stablehlo::ConcatenateOp srcOp,
+                      mlir::stablehlo::ConcatenateOp::Adaptor adaptor,
+                      ConversionPatternRewriter &rewriter) const override {
 
-    // rewriter may miss replacing all uses due to different output tensor type.
-    // Replacing all uses of srcOp explicitly.
-    rewriter.replaceAllOpUsesWith(srcOp, TTIROp);
+        // Check legality of the operation
+        LogicalResult err = checkBasicLegality(srcOp, adaptor, rewriter);
+        if (failed(err)) {
+          return err;
+        }
 
-    return success();
-  }
-};
+        // Create the output tensor type based on inputs
+        auto outputType = mlir::cast<RankedTensorType>(
+            getTypeConverter()->convertType(srcOp.getResult().getType()));
 
-void addElementwiseUnaryOpsConversionPatterns(MLIRContext *ctx,
-                                              RewritePatternSet &patterns,
-                                              TypeConverter &typeConverter) {
+        // Create an empty output tensor with the computed shape
+        tensor::EmptyOp outputTensor = rewriter.create<tensor::EmptyOp>(
+            srcOp.getLoc(), outputType.getShape(), outputType.getElementType());
 
-  patterns.add<StableHLOToTTIROpDefaultConversionPattern<
-      mlir::stablehlo::AbsOp, mlir::tt::ttir::AbsOp>>(typeConverter, ctx);
-  patterns.add<StableHLOToTTIROpDefaultConversionPattern<
-      mlir::stablehlo::ConvertOp, mlir::tt::ttir::TypecastOp>>(typeConverter,
-                                                               ctx);
-  patterns.add<StableHLOToTTIROpDefaultConversionPattern<
-      mlir::stablehlo::ExpOp, mlir::tt::ttir::ExpOp>>(typeConverter, ctx);
-  patterns.add<StableHLOToTTIROpDefaultConversionPattern<
-      mlir::stablehlo::NegOp, mlir::tt::ttir::NegOp>>(typeConverter, ctx);
-  patterns.add<StableHLOToTTIROpDefaultConversionPattern<
-      mlir::stablehlo::RsqrtOp, mlir::tt::ttir::RsqrtOp>>(typeConverter, ctx);
-  patterns.add<StableHLOToTTIROpDefaultConversionPattern<
-      mlir::stablehlo::SqrtOp, mlir::tt::ttir::SqrtOp>>(typeConverter, ctx);
-}
+        // Replace the original ConcatOp with the destination operation
+        rewriter.replaceOpWithNewOp<mlir::tt::ttir::ConcatOp>(
+            srcOp,
+            outputType,          // result type
+            adaptor.getInputs(), // input values
+            Value(outputTensor), // output value
+            rewriter.getSI32IntegerAttr(
+                static_cast<int32_t>(adaptor.getDimension())), // dimension
+            rewriter.getArrayAttr( // operand constraints
+                SmallVector<Attribute>(adaptor.getInputs().size(),
+                                       rewriter.getAttr<OperandConstraintAttr>(
+                                           OperandConstraint::AnyDeviceTile))));
+        return success();
+      }
 
-void addElementwiseBinaryOpsConversionPatterns(MLIRContext *ctx,
+    private:
+      template <typename DestOp>
+      LogicalResult
+      matchAndRewriteInternal(mlir::stablehlo::CompareOp srcOp,
+                              mlir::stablehlo::CompareOp::Adaptor adaptor,
+                              ConversionPatternRewriter &rewriter) const {
+        // TTNN doesn't support boolean data type. TTNN compare operations have
+        // same output data type as of input data type (e.g. comparing float32
+        // will produce float32 result). So input operand is used to create
+        // output type and output tensor and the generated output tensor will be
+        // different type (instead of boolean) depending on input operands.
+        mlir::RankedTensorType outputType =
+            mlir::cast<RankedTensorType>(this->getTypeConverter()->convertType(
+                srcOp->getOperand(0).getType()));
+        tensor::EmptyOp outputTensor = rewriter.create<tensor::EmptyOp>(
+            srcOp.getLoc(), outputType.getShape(), outputType.getElementType());
+
+        DestOp TTIROp = rewriter.replaceOpWithNewOp<DestOp>(
+            srcOp,
+            TypeRange(
+                this->getTypeConverter()->convertType(outputTensor.getType())),
+            adaptor.getOperands(), ValueRange(outputTensor),
+            rewriter.getArrayAttr(
+                SmallVector<Attribute>(adaptor.getOperands().size() + 1,
+                                       rewriter.getAttr<OperandConstraintAttr>(
+                                           OperandConstraint::AnyDeviceTile))));
+
+        // rewriter may miss replacing all uses due to different output tensor
+        // type. Replacing all uses of srcOp explicitly.
+        rewriter.replaceAllOpUsesWith(srcOp, TTIROp);
+        LogicalResult checkBasicLegality(
+            mlir::stablehlo::ConcatenateOp & srcOp,
+            mlir::stablehlo::ConcatenateOp::Adaptor adaptor,
+            ConversionPatternRewriter & rewriter) const {
+          if (srcOp.getInputs().empty()) {
+            return rewriter.notifyMatchFailure(
+                srcOp, "ConcatOp must have at least one input.");
+          }
+          if (adaptor.getDimension() >=
+              INT32_MAX) { // stablehlo.concatenate dimension is i64,
+                           // ttir.concat dimension is si32
+            return rewriter.notifyMatchFailure(
+                srcOp, "ConcatOp dimension is too large.");
+          }
+
+          auto rankedTensorType = mlir::dyn_cast<mlir::RankedTensorType>(
+              srcOp.getOperand(0).getType());
+          if (static_cast<int64_t>(adaptor.getDimension()) >=
+              rankedTensorType.getRank()) {
+            return rewriter.notifyMatchFailure(
+                srcOp, "Invalid concatenation dimension.");
+          }
+
+          return success();
+        }
+      };
+
+      void
+      addElementwiseUnaryOpsConversionPatterns(MLIRContext *ctx,
                                                RewritePatternSet &patterns,
                                                TypeConverter &typeConverter) {
 
-  patterns.add<StableHLOToTTIROpDefaultConversionPattern<
-      mlir::stablehlo::AddOp, mlir::tt::ttir::AddOp>>(typeConverter, ctx);
-  patterns.add<StableHLOToTTIROpDefaultConversionPattern<
-      mlir::stablehlo::SubtractOp, mlir::tt::ttir::SubtractOp>>(typeConverter,
+        patterns.add<StableHLOToTTIROpDefaultConversionPattern<
+            mlir::stablehlo::AbsOp, mlir::tt::ttir::AbsOp>>(typeConverter, ctx);
+        patterns.add<StableHLOToTTIROpDefaultConversionPattern<
+            mlir::stablehlo::ConvertOp, mlir::tt::ttir::TypecastOp>>(
+            typeConverter, ctx);
+        patterns.add<StableHLOToTTIROpDefaultConversionPattern<
+            mlir::stablehlo::ExpOp, mlir::tt::ttir::ExpOp>>(typeConverter, ctx);
+        patterns.add<StableHLOToTTIROpDefaultConversionPattern<
+            mlir::stablehlo::NegOp, mlir::tt::ttir::NegOp>>(typeConverter, ctx);
+        patterns.add<StableHLOToTTIROpDefaultConversionPattern<
+            mlir::stablehlo::RsqrtOp, mlir::tt::ttir::RsqrtOp>>(typeConverter,
                                                                 ctx);
-  patterns.add<StableHLOToTTIROpDefaultConversionPattern<
-      mlir::stablehlo::MulOp, mlir::tt::ttir::MultiplyOp>>(typeConverter, ctx);
-  patterns.add<StableHLOToTTIROpDefaultConversionPattern<
-      mlir::stablehlo::DivOp, mlir::tt::ttir::DivOp>>(typeConverter, ctx);
-  patterns.add<StableHLOToTTIROpDefaultConversionPattern<
-      mlir::stablehlo::MaxOp, mlir::tt::ttir::MaximumOp>>(typeConverter, ctx);
-}
+        patterns.add<StableHLOToTTIROpDefaultConversionPattern<
+            mlir::stablehlo::SqrtOp, mlir::tt::ttir::SqrtOp>>(typeConverter,
+                                                              ctx);
+      }
 
-void addReduceOpsConversionPatterns(MLIRContext *ctx,
-                                    RewritePatternSet &patterns,
-                                    TypeConverter &typeConverter) {
-  patterns.add<StableHLOToTTIRReduceOpConversionPattern>(typeConverter, ctx);
-}
+      void
+      addElementwiseBinaryOpsConversionPatterns(MLIRContext *ctx,
+                                                RewritePatternSet &patterns,
+                                                TypeConverter &typeConverter) {
 
-void addTransposeOpsConversionPatterns(MLIRContext *ctx,
-                                       RewritePatternSet &patterns,
-                                       TypeConverter &typeConverter) {
-
-  patterns.add<StableHLOToTTIRTransposeOpConversionPattern>(typeConverter, ctx);
-}
-
-void addMatmulOpsConversionPatterns(MLIRContext *ctx,
-                                    RewritePatternSet &patterns,
-                                    TypeConverter &typeConverter) {
-  patterns.add<StableHLOToTTIRDotGeneralOpConversionPattern>(typeConverter,
-                                                             ctx);
-}
-
-void addTensorCreationOpsConversionPatterns(MLIRContext *ctx,
-                                            RewritePatternSet &patterns,
-                                            TypeConverter &typeConverter) {
-  patterns.add<StableHLOToTTIRConstantOpConversionPattern>(typeConverter, ctx);
-}
-
-void addBroadcastOpConversionPattern(MLIRContext *ctx,
-                                     RewritePatternSet &patterns,
-                                     TypeConverter &typeConverter) {
-
-  patterns.add<StableHLOToTTIRBroadcastInDimOpConversionPattern>(typeConverter,
+        patterns.add<StableHLOToTTIROpDefaultConversionPattern<
+            mlir::stablehlo::AddOp, mlir::tt::ttir::AddOp>>(typeConverter, ctx);
+        patterns.add<StableHLOToTTIROpDefaultConversionPattern<
+            mlir::stablehlo::SubtractOp, mlir::tt::ttir::SubtractOp>>(
+            typeConverter, ctx);
+        patterns.add<StableHLOToTTIROpDefaultConversionPattern<
+            mlir::stablehlo::MulOp, mlir::tt::ttir::MultiplyOp>>(typeConverter,
                                                                  ctx);
-}
+        patterns.add<StableHLOToTTIROpDefaultConversionPattern<
+            mlir::stablehlo::DivOp, mlir::tt::ttir::DivOp>>(typeConverter, ctx);
+        patterns.add<StableHLOToTTIROpDefaultConversionPattern<
+            mlir::stablehlo::MaxOp, mlir::tt::ttir::MaximumOp>>(typeConverter,
+                                                                ctx);
+      }
 
-void addCompareOpsConversionPatterns(MLIRContext *ctx,
-                                     RewritePatternSet &patterns,
-                                     TypeConverter &typeConverter) {
-  patterns.add<StableHLOToTTIRCompareOpConversionPattern>(typeConverter, ctx);
-}
+      void addReduceOpsConversionPatterns(MLIRContext *ctx,
+                                          RewritePatternSet &patterns,
+                                          TypeConverter &typeConverter) {
+        patterns.add<StableHLOToTTIRReduceOpConversionPattern>(typeConverter,
+                                                               ctx);
+      }
 
-} // namespace
+      void addTransposeOpsConversionPatterns(MLIRContext *ctx,
+                                             RewritePatternSet &patterns,
+                                             TypeConverter &typeConverter) {
 
-namespace mlir::tt {
+        patterns.add<StableHLOToTTIRTransposeOpConversionPattern>(typeConverter,
+                                                                  ctx);
+      }
 
-void populateStableHLOToTTIRPatterns(MLIRContext *ctx,
-                                     RewritePatternSet &patterns,
-                                     TypeConverter &typeConverter) {
-  addElementwiseUnaryOpsConversionPatterns(ctx, patterns, typeConverter);
-  addElementwiseBinaryOpsConversionPatterns(ctx, patterns, typeConverter);
-  addReduceOpsConversionPatterns(ctx, patterns, typeConverter);
-  addTransposeOpsConversionPatterns(ctx, patterns, typeConverter);
-  addMatmulOpsConversionPatterns(ctx, patterns, typeConverter);
-  addTensorCreationOpsConversionPatterns(ctx, patterns, typeConverter);
-  addBroadcastOpConversionPattern(ctx, patterns, typeConverter);
-  addCompareOpsConversionPatterns(ctx, patterns, typeConverter);
-}
+      void addMatmulOpsConversionPatterns(MLIRContext *ctx,
+                                          RewritePatternSet &patterns,
+                                          TypeConverter &typeConverter) {
+        patterns.add<StableHLOToTTIRDotGeneralOpConversionPattern>(
+            typeConverter, ctx);
+      }
 
-} // namespace mlir::tt
+      void
+      addTensorCreationOpsConversionPatterns(MLIRContext *ctx,
+                                             RewritePatternSet &patterns,
+                                             TypeConverter &typeConverter) {
+        patterns.add<StableHLOToTTIRConstantOpConversionPattern>(typeConverter,
+                                                                 ctx);
+      }
+
+      void addBroadcastOpConversionPattern(MLIRContext *ctx,
+                                           RewritePatternSet &patterns,
+                                           TypeConverter &typeConverter) {
+
+        patterns.add<StableHLOToTTIRBroadcastInDimOpConversionPattern>(
+            typeConverter, ctx);
+      }
+
+      void addCompareOpsConversionPatterns(MLIRContext *ctx,
+                                           RewritePatternSet &patterns,
+                                           TypeConverter &typeConverter) {
+        patterns.add<StableHLOToTTIRCompareOpConversionPattern>(typeConverter,
+                                                                ctx);
+        void addConcatOpConversionPattern(MLIRContext * ctx,
+                                          RewritePatternSet & patterns,
+                                          TypeConverter & typeConverter) {
+
+          patterns.add<StableHLOToTTIRConcatOpConversionPattern>(typeConverter,
+                                                                 ctx);
+        }
+
+      } // namespace
+
+      namespace mlir::tt {
+
+      void populateStableHLOToTTIRPatterns(MLIRContext *ctx,
+                                           RewritePatternSet &patterns,
+                                           TypeConverter &typeConverter) {
+        addElementwiseUnaryOpsConversionPatterns(ctx, patterns, typeConverter);
+        addElementwiseBinaryOpsConversionPatterns(ctx, patterns, typeConverter);
+        addReduceOpsConversionPatterns(ctx, patterns, typeConverter);
+        addTransposeOpsConversionPatterns(ctx, patterns, typeConverter);
+        addMatmulOpsConversionPatterns(ctx, patterns, typeConverter);
+        addTensorCreationOpsConversionPatterns(ctx, patterns, typeConverter);
+        addBroadcastOpConversionPattern(ctx, patterns, typeConverter);
+        addCompareOpsConversionPatterns(ctx, patterns, typeConverter);
+        addConcatOpConversionPattern(ctx, patterns, typeConverter);
+      }
+
+      } // namespace mlir::tt

--- a/test/ttmlir/Conversion/StableHLOToTTIR/concat_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/concat_op.mlir
@@ -9,4 +9,76 @@ module @jit_concat attributes {} {
     // CHECK: %[[C:.*]] = "ttir.concat"(%arg0, %arg1, %0) <{dim = 1 : si32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<32x32xf32>, tensor<32x64xf32>, tensor<32x96xf32>) -> tensor<32x96xf32>
     return %0 : tensor<32x96xf32>
   }
+
+  func.func public @test_concat_2(%arg0: tensor<3x2xi64>, %arg1: tensor<1x2xi64>) -> tensor<4x2xi64> {
+    %0 = "stablehlo.concatenate"(%arg0, %arg1) {
+    dimension = 0 : i64
+    } : (tensor<3x2xi64>, tensor<1x2xi64>) -> tensor<4x2xi64>
+    // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
+    // CHECK: %[[C:.*]] = "ttir.concat"(%arg0, %arg1, %0) <{dim = 0 : si32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<3x2xi64>, tensor<1x2xi64>, tensor<4x2xi64>) -> tensor<4x2xi64>
+    return %0 : tensor<4x2xi64>
+  }
+
+  func.func public @test_concat_3(%arg0: tensor<4x3xf32>, %arg1: tensor<4x5xf32>) -> tensor<4x8xf32> {
+    %0 = "stablehlo.concatenate"(%arg0, %arg1) {
+    dimension = 1 : i64
+    } : (tensor<4x3xf32>, tensor<4x5xf32>) -> tensor<4x8xf32>
+    // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
+    // CHECK: %[[C:.*]] = "ttir.concat"(%arg0, %arg1, %0) <{dim = 1 : si32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<4x3xf32>, tensor<4x5xf32>, tensor<4x8xf32>) -> tensor<4x8xf32>
+    return %0 : tensor<4x8xf32>
+  }
+
+  func.func public @test_concat_4(%arg0: tensor<128x64xf32>, %arg1: tensor<128x96xf32>) -> tensor<128x160xf32> {
+    %0 = "stablehlo.concatenate"(%arg0, %arg1) {
+      dimension = 1 : i64
+    } : (tensor<128x64xf32>, tensor<128x96xf32>) -> tensor<128x160xf32>
+    // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
+    // CHECK: %[[C:.*]] = "ttir.concat"(%arg0, %arg1, %0) <{dim = 1 : si32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<128x64xf32>, tensor<128x96xf32>, tensor<128x160xf32>) -> tensor<128x160xf32>
+    return %0 : tensor<128x160xf32>
+  }
+
+  func.func public @test_concat_5(%arg0: tensor<256x512xi64>, %arg1: tensor<256x256xi64>) -> tensor<256x768xi64> {
+    %0 = "stablehlo.concatenate"(%arg0, %arg1) {
+      dimension = 1 : i64
+    } : (tensor<256x512xi64>, tensor<256x256xi64>) -> tensor<256x768xi64>
+    // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
+    // CHECK: %[[C:.*]] = "ttir.concat"(%arg0, %arg1, %0) <{dim = 1 : si32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<256x512xi64>, tensor<256x256xi64>, tensor<256x768xi64>) -> tensor<256x768xi64>
+    return %0 : tensor<256x768xi64>
+  }
+
+  func.func public @test_concat_6(%arg0: tensor<64x32xf64>, %arg1: tensor<64x64xf64>) -> tensor<64x96xf64> {
+    %0 = "stablehlo.concatenate"(%arg0, %arg1) {
+      dimension = 1 : i64
+    } : (tensor<64x32xf64>, tensor<64x64xf64>) -> tensor<64x96xf64>
+    // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
+    // CHECK: %[[C:.*]] = "ttir.concat"(%arg0, %arg1, %0) <{dim = 1 : si32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<64x32xf64>, tensor<64x64xf64>, tensor<64x96xf64>) -> tensor<64x96xf64>
+    return %0 : tensor<64x96xf64>
+  }
+
+  func.func public @test_concat_7(%arg0: tensor<1000x128xi32>, %arg1: tensor<500x128xi32>) -> tensor<1500x128xi32> {
+    %0 = "stablehlo.concatenate"(%arg0, %arg1) {
+      dimension = 0 : i64
+    } : (tensor<1000x128xi32>, tensor<500x128xi32>) -> tensor<1500x128xi32>
+    // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
+    // CHECK: %[[C:.*]] = "ttir.concat"(%arg0, %arg1, %0) <{dim = 0 : si32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<1000x128xi32>, tensor<500x128xi32>, tensor<1500x128xi32>) -> tensor<1500x128xi32>
+    return %0 : tensor<1500x128xi32>
+  }
+
+  func.func public @test_concat_8(%arg0: tensor<3x2x4x5xf64>, %arg1: tensor<3x2x4x3xf64>) -> tensor<3x2x4x8xf64> {
+    %0 = "stablehlo.concatenate"(%arg0, %arg1) {
+      dimension = 3 : i64
+    } : (tensor<3x2x4x5xf64>, tensor<3x2x4x3xf64>) -> tensor<3x2x4x8xf64>
+    // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
+    // CHECK: %[[C:.*]] = "ttir.concat"(%arg0, %arg1, %0) <{dim = 3 : si32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<3x2x4x5xf64>, tensor<3x2x4x3xf64>, tensor<3x2x4x8xf64>) -> tensor<3x2x4x8xf64>
+    return %0 : tensor<3x2x4x8xf64>
+  }
+
+  func.func public @test_concat_9(%arg0: tensor<8x4x6xi32>, %arg1: tensor<8x4x2xi32>) -> tensor<8x4x8xi32> {
+    %0 = "stablehlo.concatenate"(%arg0, %arg1) {
+      dimension = 2 : i64
+    } : (tensor<8x4x6xi32>, tensor<8x4x2xi32>) -> tensor<8x4x8xi32>
+    // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
+    // CHECK: %[[C:.*]] = "ttir.concat"(%arg0, %arg1, %0) <{dim = 2 : si32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<8x4x6xi32>, tensor<8x4x2xi32>, tensor<8x4x8xi32>) -> tensor<8x4x8xi32>
+    return %0 : tensor<8x4x8xi32>
+  }
 }

--- a/test/ttmlir/Conversion/StableHLOToTTIR/concat_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/concat_op.mlir
@@ -1,0 +1,12 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s | FileCheck %s
+module @jit_concat attributes {} {
+  func.func public @test_concat(%arg0: tensor<32x32xf32>, %arg1: tensor<32x64xf32>) -> tensor<32x96xf32> {
+    %0 = "stablehlo.concatenate"(%arg0, %arg1) {
+    dimension = 1 : i64
+    } : (tensor<32x32xf32>, tensor<32x64xf32>) -> tensor<32x96xf32>
+    // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
+    // CHECK: %[[C:.*]] = "ttir.concat"(%arg0, %arg1, %0) <{dim = 1 : si32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<32x32xf32>, tensor<32x64xf32>, tensor<32x96xf32>) -> tensor<32x96xf32>
+    return %0 : tensor<32x96xf32>
+  }
+}


### PR DESCRIPTION
Add concatenate end-to-end along with required conversion for stablehlo. 

Dimension is i64 for stablehlo, si32 for ttir/ttnn concat. 