### PR TITLE
Added as_int methods to LayoutAttr Pybind

### DIFF
--- a/python/TTModule.cpp
+++ b/python/TTModule.cpp
@@ -84,11 +84,23 @@ void populateTTModule(py::module &m) {
             return std::vector<std::int64_t>(stride.begin(), stride.end());
           })
       .def_property_readonly("oobval", &tt::LayoutAttr::getOobVal)
+      .def_property_readonly("oobval_as_int",
+                             [](tt::LayoutAttr la) {
+                               return static_cast<uint32_t>(la.getOobVal());
+                             })
       .def_property_readonly("grid_attr", &tt::LayoutAttr::getGrid)
       .def_property_readonly("memref", &tt::LayoutAttr::getMemref)
       .def_property_readonly("memory_space", &tt::LayoutAttr::getMemorySpace)
+      .def_property_readonly("memory_sapce_as_int",
+                             [](tt::LayoutAttr la) {
+                               return static_cast<uint32_t>(
+                                   la.getMemorySpace());
+                             })
       .def_property_readonly("shard_shape", &tt::LayoutAttr::getShardShape)
-      .def_property_readonly("memory_layout", &tt::LayoutAttr::getMemLayout);
+      .def_property_readonly("memory_layout", &tt::LayoutAttr::getMemLayout)
+      .def_property_readonly("memory_layout_as_int", [](tt::LayoutAttr la) {
+        return static_cast<uint32_t>(la.getMemLayout());
+      });
 
   py::class_<tt::GridAttr>(m, "GridAttr")
       .def_static("get",


### PR DESCRIPTION
Addresses #833 

**Implemented**
- Simply added `static_cast`s for `...as_int` methods for all the enums that the LayoutAttr Pybind returns.