### PR TITLE
Canonicalize Eltwise binary ops for broadcast

### DIFF
--- a/runtime/lib/ttnn/operations/eltwise/binary.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/binary.cpp
@@ -31,6 +31,14 @@ static void runEltwiseBinaryOP(
   ::ttnn::Tensor *rhs = nullptr;
   getEltwiseBinaryOPInputTensors(op, tensorPool, &lhs, &rhs);
 
+  // Switch the order of operands if the second operand requires broadcast
+  if (op->ins()->Get(0)->desc()->shape()->Get(1) == 1 ||
+      op->ins()->Get(1)->desc()->shape()->Get(1) == 1) {
+    ::ttnn::Tensor *tmp = rhs;
+    rhs = lhs;
+    lhs = tmp;
+  }
+
   ::ttnn::DataType outputDataType = utils::getDataType(op->out());
   ::tt::tt_metal::MemoryConfig outputMemoryConfig =
       utils::createMemoryConfig(op->out());
@@ -50,6 +58,14 @@ static void runEltwiseBinaryCompositeOP(
   ::ttnn::Tensor *lhs = nullptr;
   ::ttnn::Tensor *rhs = nullptr;
   getEltwiseBinaryOPInputTensors(op, tensorPool, &lhs, &rhs);
+
+  // Switch the order of operands if the second operand requires broadcast
+  if (op->ins()->Get(0)->desc()->shape()->Get(1) == 1 ||
+      op->ins()->Get(1)->desc()->shape()->Get(1) == 1) {
+    ::ttnn::Tensor *tmp = rhs;
+    rhs = lhs;
+    lhs = tmp;
+  }
 
   ::tt::tt_metal::MemoryConfig outputMemoryConfig =
       utils::createMemoryConfig(op->out());

--- a/runtime/lib/ttnn/operations/eltwise/binary.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/binary.cpp
@@ -32,8 +32,7 @@ static void runEltwiseBinaryOP(
   getEltwiseBinaryOPInputTensors(op, tensorPool, &lhs, &rhs);
 
   // Switch the order of operands if the second operand requires broadcast
-  if (op->ins()->Get(0)->desc()->shape()->Get(1) == 1 ||
-      op->ins()->Get(1)->desc()->shape()->Get(1) == 1) {
+  if (rhs->volume() < lhs->volume()) {
     ::ttnn::Tensor *tmp = rhs;
     rhs = lhs;
     lhs = tmp;
@@ -60,8 +59,7 @@ static void runEltwiseBinaryCompositeOP(
   getEltwiseBinaryOPInputTensors(op, tensorPool, &lhs, &rhs);
 
   // Switch the order of operands if the second operand requires broadcast
-  if (op->ins()->Get(0)->desc()->shape()->Get(1) == 1 ||
-      op->ins()->Get(1)->desc()->shape()->Get(1) == 1) {
+  if (rhs->volume() < lhs->volume()) {
     ::ttnn::Tensor *tmp = rhs;
     rhs = lhs;
     lhs = tmp;

--- a/test/ttmlir/Dialect/TTNN/simple_subtract_to_add.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_subtract_to_add.mlir
@@ -1,0 +1,13 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
+#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
+module attributes {} {
+  func.func @forward(%arg0: tensor<64x128xf32>, %arg1: tensor<1x128xf32>) -> tensor<64x128xf32> {
+    // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
+    %0 = tensor.empty() : tensor<64x128xf32>
+    // CHECK: %[[C:.*]] = "ttnn.neg"[[C:.*]]
+    // CHECK: %[[C:.*]] = "ttnn.add"[[C:.*]]
+    // CHECK-NOT: %[[C:.*]] = "ttnn.subtract"[[C:.*]]
+    %1 = "ttir.subtract"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<64x128xf32>, tensor<1x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+    return %1 : tensor<64x128xf32>
+  }
+}


### PR DESCRIPTION
Canonicalize Eltwise binary ops by switching operands in case the `_rhs_` operand requires broadcast. 
Make SubtractOp commutative by converting it to combination of `NegOp` and `AddOp`: 
`SubtractOp(lhs, rhs) -> AddOp(lhs, NegOp(rhs)`

Fixes #815 