### PR TITLE
Undo hardcoded tile layout in TTIR->TTNN

### DIFF
--- a/include/ttmlir/Target/Common/types.fbs
+++ b/include/ttmlir/Target/Common/types.fbs
@@ -77,6 +77,10 @@ enum BufferType: ushort {
 table MemoryConfigDesc {
   tensor_memory_layout: TensorMemoryLayout;
   buffer_type: BufferType;
+  // TODO(bug #620):
+  // Add support for ShardSpec and remove shard_shape
+  //
+  shard_shape: [int64];
 }
 
 table MemoryDesc {

--- a/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/utils.cpp
+++ b/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/utils.cpp
@@ -120,19 +120,18 @@ createMemoryConfig(const tt::target::MemoryConfigDesc *memcfg,
   const ::tt::target::LayoutDesc *layout = tensorRef->desc()->layout();
   const ::flatbuffers::Vector<const tt::target::Dim2dRange *>
       *targetCoreRangeSet = layout->core_range_set();
-  const ::flatbuffers::Vector<int32_t> *targetShardShape =
-      layout->memory_desc()->shape();
   CoreRangeSet ttnnCoreRangeSet = toCoreRangeSet(targetCoreRangeSet);
-  std::array<uint32_t, 2> ttnnShardShape;
-  std::copy(targetShardShape->begin(), targetShardShape->end(),
-            ttnnShardShape.begin());
+  const ::flatbuffers::Vector<int64_t> *shardShape = memcfg->shard_shape();
+  std::array<uint32_t, 2> ttnnShardShape = {
+      static_cast<uint32_t>(shardShape->Get(0)),
+      static_cast<uint32_t>(shardShape->Get(1))};
+
   ::tt::tt_metal::ShardSpec shardSpec(
       ttnnCoreRangeSet, ttnnShardShape,
       ::tt::tt_metal::ShardOrientation::ROW_MAJOR, false);
 
   ::ttnn::MemoryConfig memoryConfig = {tensorMemoryLayout, bufferType,
                                        shardSpec};
-
   return memoryConfig;
 }
 


### PR DESCRIPTION
// old desc
- Undo hardcoded tile layout in TTIR->TTNN
- Updated silicon tests to pass
- Dialect tests not updated here

// end old desc

- Override how layout (tile/rowmajor) is set in TTIR->TTNN path for conv/maxpool ops
- Pass shardshape to memoryconfig (this was relevant in previous iteration, but is still a good change, so leaving it in)