### PR TITLE
Fix concatOp StableHLO to TTIR Constraint [#864]

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -723,7 +723,7 @@ public:
         rewriter.getSI32IntegerAttr(
             static_cast<int32_t>(adaptor.getDimension())), // dimension
         rewriter.getArrayAttr( // operand constraints
-            SmallVector<Attribute>(adaptor.getInputs().size(),
+            SmallVector<Attribute>(adaptor.getOperands().size() + 1,
                                    rewriter.getAttr<OperandConstraintAttr>(
                                        OperandConstraint::AnyDeviceTile))));
     return success();

--- a/test/ttmlir/Conversion/StableHLOToTTIR/concat_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/concat_op.mlir
@@ -6,7 +6,7 @@ module @jit_concat attributes {} {
     dimension = 1 : i64
     } : (tensor<32x32xf32>, tensor<32x64xf32>) -> tensor<32x96xf32>
     // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttir.concat"(%arg0, %arg1, %0) <{dim = 1 : si32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<32x32xf32>, tensor<32x64xf32>, tensor<32x96xf32>) -> tensor<32x96xf32>
+    // CHECK: %[[C:.*]] = "ttir.concat"(%arg0, %arg1, %0) <{dim = 1 : si32, operand_constraints = [#any_device_tile, #any_device_tile, #any_device_tile]}> : (tensor<32x32xf32>, tensor<32x64xf32>, tensor<32x96xf32>) -> tensor<32x96xf32>
     return %0 : tensor<32x96xf32>
   }
 
@@ -15,7 +15,7 @@ module @jit_concat attributes {} {
     dimension = 0 : i64
     } : (tensor<3x2xi64>, tensor<1x2xi64>) -> tensor<4x2xi64>
     // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttir.concat"(%arg0, %arg1, %0) <{dim = 0 : si32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<3x2xi64>, tensor<1x2xi64>, tensor<4x2xi64>) -> tensor<4x2xi64>
+    // CHECK: %[[C:.*]] = "ttir.concat"(%arg0, %arg1, %0) <{dim = 0 : si32, operand_constraints = [#any_device_tile, #any_device_tile, #any_device_tile]}> : (tensor<3x2xi64>, tensor<1x2xi64>, tensor<4x2xi64>) -> tensor<4x2xi64>
     return %0 : tensor<4x2xi64>
   }
 
@@ -24,7 +24,7 @@ module @jit_concat attributes {} {
     dimension = 1 : i64
     } : (tensor<4x3xf32>, tensor<4x5xf32>) -> tensor<4x8xf32>
     // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttir.concat"(%arg0, %arg1, %0) <{dim = 1 : si32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<4x3xf32>, tensor<4x5xf32>, tensor<4x8xf32>) -> tensor<4x8xf32>
+    // CHECK: %[[C:.*]] = "ttir.concat"(%arg0, %arg1, %0) <{dim = 1 : si32, operand_constraints = [#any_device_tile, #any_device_tile, #any_device_tile]}> : (tensor<4x3xf32>, tensor<4x5xf32>, tensor<4x8xf32>) -> tensor<4x8xf32>
     return %0 : tensor<4x8xf32>
   }
 
@@ -33,7 +33,7 @@ module @jit_concat attributes {} {
       dimension = 1 : i64
     } : (tensor<128x64xf32>, tensor<128x96xf32>) -> tensor<128x160xf32>
     // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttir.concat"(%arg0, %arg1, %0) <{dim = 1 : si32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<128x64xf32>, tensor<128x96xf32>, tensor<128x160xf32>) -> tensor<128x160xf32>
+    // CHECK: %[[C:.*]] = "ttir.concat"(%arg0, %arg1, %0) <{dim = 1 : si32, operand_constraints = [#any_device_tile, #any_device_tile, #any_device_tile]}> : (tensor<128x64xf32>, tensor<128x96xf32>, tensor<128x160xf32>) -> tensor<128x160xf32>
     return %0 : tensor<128x160xf32>
   }
 
@@ -42,7 +42,7 @@ module @jit_concat attributes {} {
       dimension = 1 : i64
     } : (tensor<256x512xi64>, tensor<256x256xi64>) -> tensor<256x768xi64>
     // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttir.concat"(%arg0, %arg1, %0) <{dim = 1 : si32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<256x512xi64>, tensor<256x256xi64>, tensor<256x768xi64>) -> tensor<256x768xi64>
+    // CHECK: %[[C:.*]] = "ttir.concat"(%arg0, %arg1, %0) <{dim = 1 : si32, operand_constraints = [#any_device_tile, #any_device_tile, #any_device_tile]}> : (tensor<256x512xi64>, tensor<256x256xi64>, tensor<256x768xi64>) -> tensor<256x768xi64>
     return %0 : tensor<256x768xi64>
   }
 
@@ -51,7 +51,7 @@ module @jit_concat attributes {} {
       dimension = 1 : i64
     } : (tensor<64x32xf64>, tensor<64x64xf64>) -> tensor<64x96xf64>
     // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttir.concat"(%arg0, %arg1, %0) <{dim = 1 : si32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<64x32xf64>, tensor<64x64xf64>, tensor<64x96xf64>) -> tensor<64x96xf64>
+    // CHECK: %[[C:.*]] = "ttir.concat"(%arg0, %arg1, %0) <{dim = 1 : si32, operand_constraints = [#any_device_tile, #any_device_tile, #any_device_tile]}> : (tensor<64x32xf64>, tensor<64x64xf64>, tensor<64x96xf64>) -> tensor<64x96xf64>
     return %0 : tensor<64x96xf64>
   }
 
@@ -60,7 +60,7 @@ module @jit_concat attributes {} {
       dimension = 0 : i64
     } : (tensor<1000x128xi32>, tensor<500x128xi32>) -> tensor<1500x128xi32>
     // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttir.concat"(%arg0, %arg1, %0) <{dim = 0 : si32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<1000x128xi32>, tensor<500x128xi32>, tensor<1500x128xi32>) -> tensor<1500x128xi32>
+    // CHECK: %[[C:.*]] = "ttir.concat"(%arg0, %arg1, %0) <{dim = 0 : si32, operand_constraints = [#any_device_tile, #any_device_tile, #any_device_tile]}> : (tensor<1000x128xi32>, tensor<500x128xi32>, tensor<1500x128xi32>) -> tensor<1500x128xi32>
     return %0 : tensor<1500x128xi32>
   }
 
@@ -69,7 +69,7 @@ module @jit_concat attributes {} {
       dimension = 3 : i64
     } : (tensor<3x2x4x5xf64>, tensor<3x2x4x3xf64>) -> tensor<3x2x4x8xf64>
     // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttir.concat"(%arg0, %arg1, %0) <{dim = 3 : si32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<3x2x4x5xf64>, tensor<3x2x4x3xf64>, tensor<3x2x4x8xf64>) -> tensor<3x2x4x8xf64>
+    // CHECK: %[[C:.*]] = "ttir.concat"(%arg0, %arg1, %0) <{dim = 3 : si32, operand_constraints = [#any_device_tile, #any_device_tile, #any_device_tile]}> : (tensor<3x2x4x5xf64>, tensor<3x2x4x3xf64>, tensor<3x2x4x8xf64>) -> tensor<3x2x4x8xf64>
     return %0 : tensor<3x2x4x8xf64>
   }
 
@@ -78,7 +78,7 @@ module @jit_concat attributes {} {
       dimension = 2 : i64
     } : (tensor<8x4x6xi32>, tensor<8x4x2xi32>) -> tensor<8x4x8xi32>
     // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttir.concat"(%arg0, %arg1, %0) <{dim = 2 : si32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<8x4x6xi32>, tensor<8x4x2xi32>, tensor<8x4x8xi32>) -> tensor<8x4x8xi32>
+    // CHECK: %[[C:.*]] = "ttir.concat"(%arg0, %arg1, %0) <{dim = 2 : si32, operand_constraints = [#any_device_tile, #any_device_tile, #any_device_tile]}> : (tensor<8x4x6xi32>, tensor<8x4x2xi32>, tensor<8x4x8xi32>) -> tensor<8x4x8xi32>
     return %0 : tensor<8x4x8xi32>
   }
 }


### PR DESCRIPTION
Add operand constraints for all arguments, not just inputs.