### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,18 +1,21 @@
+*.cmake @nsmithtt
 *.fbs @tapspatel
+*.txt @nsmithtt
 /.github/ @vmilosevic
-/include/ttmlir/Conversion/TTIRToTTNN/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @rpavlovicTT
-/include/ttmlir/Conversion/TTNNToEmitC/ @svuckovicTT @rpavlovicTT @sdjordjevicTT @mtopalovicTT
-/include/ttmlir/Dialect/TT/ @sdjordjevicTT @nsmithtt @rpavlovicTT @svuckovicTT @mtopalovicTT @mrakitaTT @nobradovictt
-/include/ttmlir/Dialect/TTIR/ @sdjordjevicTT @nsmithtt @rpavlovicTT @svuckovicTT @mtopalovicTT @mrakitaTT @nobradovictt
+/include/ttmlir/Conversion/TTIRToTTNN/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @rpavlovicTT @jserbedzijaTT
+/include/ttmlir/Conversion/TTNNToEmitC/ @svuckovicTT @rpavlovicTT @sdjordjevicTT @mtopalovicTT @jserbedzijaTT
+/include/ttmlir/Dialect/TT/ @sdjordjevicTT @nsmithtt @rpavlovicTT @svuckovicTT @mtopalovicTT @mrakitaTT @nobradovictt @jserbedzijaTT
+/include/ttmlir/Dialect/TTIR/ @sdjordjevicTT @nsmithtt @rpavlovicTT @svuckovicTT @mtopalovicTT @mrakitaTT @nobradovictt @jserbedzijaTT
 /include/ttmlir/Dialect/TTKernel/ @nsmithtt @rpavlovicTT @rjakovljevicTT
 /include/ttmlir/Dialect/TTMetal/ @nsmithtt @rpavlovicTT
-/include/ttmlir/Dialect/TTNN/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @rpavlovicTT @nobradovictt
-/lib/Conversion/TTIRToTTNN/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @rpavlovicTT
-/lib/Conversion/TTNNToEmitC/ @svuckovicTT @rpavlovicTT @sdjordjevicTT @mtopalovicTT
-/lib/Dialect/TT/ @sdjordjevicTT @nsmithtt @rpavlovicTT @svuckovicTT @mtopalovicTT @mrakitaTT @nobradovictt
-/lib/Dialect/TTIR/ @sdjordjevicTT @nsmithtt @rpavlovicTT @svuckovicTT @mtopalovicTT @mrakitaTT @nobradovictt
+/include/ttmlir/Dialect/TTNN/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @rpavlovicTT @nobradovictt @jserbedzijaTT
+/lib/Conversion/TTIRToTTNN/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @rpavlovicTT @jserbedzijaTT
+/lib/Conversion/TTNNToEmitC/ @svuckovicTT @rpavlovicTT @sdjordjevicTT @mtopalovicTT @jserbedzijaTT
+/lib/Dialect/TT/ @sdjordjevicTT @nsmithtt @rpavlovicTT @svuckovicTT @mtopalovicTT @mrakitaTT @nobradovictt @jserbedzijaTT
+/lib/Dialect/TTIR/ @sdjordjevicTT @nsmithtt @rpavlovicTT @svuckovicTT @mtopalovicTT @mrakitaTT @nobradovictt @jserbedzijaTT
 /lib/Dialect/TTKernel/ @nsmithtt @rpavlovicTT @rjakovljevicTT
 /lib/Dialect/TTMetal/ @nsmithtt @rpavlovicTT
-/lib/Dialect/TTNN/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @rpavlovicTT @nobradovictt
+/lib/Dialect/TTNN/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @rpavlovicTT @nobradovictt @jserbedzijaTT
+/python/ @nsmithtt
 /runtime/ @jnie-TT @kmabeeTT @AleksKnezevic @pilkicTT
 /runtime/tools/ @tapspatel

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,15 +1,17 @@
 * @nsmithtt
 *.fbs @tapspatel
 /.github/ @vmilosevic
-/include/ttmlir/Conversion/TTNNToEmitC/ @svuckovicTT
-/include/ttmlir/Dialect/TT/ @sdjordjevicTT @rpavlovicTT @mrakitaTT @nobradovictt
-/include/ttmlir/Dialect/TTIR/ @sdjordjevicTT @rpavlovicTT @mrakitaTT @nobradovictt
+/include/ttmlir/Conversion/TTIRToTTNN/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @rpavlovicTT
+/include/ttmlir/Conversion/TTNNToEmitC/ @svuckovicTT @rpavlovicTT @sdjordjevicTT @mtopalovicTT
+/include/ttmlir/Dialect/TT/ @sdjordjevicTT @rpavlovicTT @svuckovicTT @mtopalovicTT @mrakitaTT @nobradovictt
+/include/ttmlir/Dialect/TTIR/ @sdjordjevicTT @rpavlovicTT @svuckovicTT @mtopalovicTT @mrakitaTT @nobradovictt
 /include/ttmlir/Dialect/TTKernel/ @rjakovljevicTT
-/include/ttmlir/Dialect/TTNN/ @sdjordjevicTT @rpavlovicTT @nobradovictt
-/lib/Conversion/TTNNToEmitC/ @svuckovicTT
-/lib/Dialect/TT/ @sdjordjevicTT @rpavlovicTT @mrakitaTT @nobradovictt
-/lib/Dialect/TTIR/ @sdjordjevicTT @rpavlovicTT @mrakitaTT @nobradovictt
+/include/ttmlir/Dialect/TTNN/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @rpavlovicTT @nobradovictt
+/lib/Conversion/TTIRToTTNN/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @rpavlovicTT
+/lib/Conversion/TTNNToEmitC/ @svuckovicTT @rpavlovicTT @sdjordjevicTT @mtopalovicTT
+/lib/Dialect/TT/ @sdjordjevicTT @rpavlovicTT @svuckovicTT @mtopalovicTT @mrakitaTT @nobradovictt
+/lib/Dialect/TTIR/ @sdjordjevicTT @rpavlovicTT @svuckovicTT @mtopalovicTT @mrakitaTT @nobradovictt
 /lib/Dialect/TTKernel/ @rjakovljevicTT
-/lib/Dialect/TTNN/ @sdjordjevicTT @rpavlovicTT @nobradovictt
+/lib/Dialect/TTNN/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @rpavlovicTT @nobradovictt
 /runtime/ @jnie-TT @kmabeeTT @AleksKnezevic @pilkicTT
 /runtime/tools/ @tapspatel

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,17 +1,18 @@
-* @nsmithtt
 *.fbs @tapspatel
 /.github/ @vmilosevic
 /include/ttmlir/Conversion/TTIRToTTNN/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @rpavlovicTT
 /include/ttmlir/Conversion/TTNNToEmitC/ @svuckovicTT @rpavlovicTT @sdjordjevicTT @mtopalovicTT
-/include/ttmlir/Dialect/TT/ @sdjordjevicTT @rpavlovicTT @svuckovicTT @mtopalovicTT @mrakitaTT @nobradovictt
-/include/ttmlir/Dialect/TTIR/ @sdjordjevicTT @rpavlovicTT @svuckovicTT @mtopalovicTT @mrakitaTT @nobradovictt
-/include/ttmlir/Dialect/TTKernel/ @rjakovljevicTT
+/include/ttmlir/Dialect/TT/ @sdjordjevicTT @nsmithtt @rpavlovicTT @svuckovicTT @mtopalovicTT @mrakitaTT @nobradovictt
+/include/ttmlir/Dialect/TTIR/ @sdjordjevicTT @nsmithtt @rpavlovicTT @svuckovicTT @mtopalovicTT @mrakitaTT @nobradovictt
+/include/ttmlir/Dialect/TTKernel/ @nsmithtt @rpavlovicTT @rjakovljevicTT
+/include/ttmlir/Dialect/TTMetal/ @nsmithtt @rpavlovicTT
 /include/ttmlir/Dialect/TTNN/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @rpavlovicTT @nobradovictt
 /lib/Conversion/TTIRToTTNN/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @rpavlovicTT
 /lib/Conversion/TTNNToEmitC/ @svuckovicTT @rpavlovicTT @sdjordjevicTT @mtopalovicTT
-/lib/Dialect/TT/ @sdjordjevicTT @rpavlovicTT @svuckovicTT @mtopalovicTT @mrakitaTT @nobradovictt
-/lib/Dialect/TTIR/ @sdjordjevicTT @rpavlovicTT @svuckovicTT @mtopalovicTT @mrakitaTT @nobradovictt
-/lib/Dialect/TTKernel/ @rjakovljevicTT
+/lib/Dialect/TT/ @sdjordjevicTT @nsmithtt @rpavlovicTT @svuckovicTT @mtopalovicTT @mrakitaTT @nobradovictt
+/lib/Dialect/TTIR/ @sdjordjevicTT @nsmithtt @rpavlovicTT @svuckovicTT @mtopalovicTT @mrakitaTT @nobradovictt
+/lib/Dialect/TTKernel/ @nsmithtt @rpavlovicTT @rjakovljevicTT
+/lib/Dialect/TTMetal/ @nsmithtt @rpavlovicTT
 /lib/Dialect/TTNN/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @rpavlovicTT @nobradovictt
 /runtime/ @jnie-TT @kmabeeTT @AleksKnezevic @pilkicTT
 /runtime/tools/ @tapspatel


### PR DESCRIPTION
- Update CODEOWNERS
- Added folks from "mlir core belgrade" team (@sdjordjevicTT @mtopalovicTT @rpavlovicTT @svuckovicTT) to relevant sections
- Ideally, we would have teams, such as "mlir-core-belgrade" team, then we could substitute above aliases with a single `@tenstorrent/mlir-core-belgrade` item and make it easier to read and understand _why_ someone is a codeowner
  - @warthog9 can we sync on this? I'd like to understand the overhead of managing this