### PR TITLE
Adding workflow for community issues and PRs

### DIFF
--- a/.github/workflows/on-community-issue.yml
+++ b/.github/workflows/on-community-issue.yml
@@ -1,0 +1,67 @@
+name: "Issue Notification"
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  gh-slack-bridge:
+    runs-on: ubuntu-latest
+    permissions:      
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Set username and number based on event type
+        id: set-variables
+        run: |
+          if [ "${{ github.event_name }}" = "issues" ]; then
+            echo "USERNAME=${{ github.event.issue.user.login }}" >> $GITHUB_ENV
+            echo "NUMBER=${{ github.event.issue.number }}" >> $GITHUB_ENV
+            echo "EVENT_URL=${{ github.event.issue.html_url }}" >> $GITHUB_ENV
+            echo "EVENT_TYPE=issue" >> $GITHUB_ENV
+            echo "GH_COMMAND=issue" >> $GITHUB_ENV
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "USERNAME=${{ github.event.pull_request.user.login }}" >> $GITHUB_ENV
+            echo "NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+            echo "EVENT_URL=${{ github.event.pull_request.html_url }}" >> $GITHUB_ENV
+            echo "EVENT_TYPE=PR" >> $GITHUB_ENV
+            echo "GH_COMMAND=pr" >> $GITHUB_ENV
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            echo "USERNAME=${{ github.actor }}" >> $GITHUB_ENV
+            echo "EVENT_URL=https://github.com/${{ github.repository }}/commit/${{ github.sha }}" >> $GITHUB_ENV
+            echo "EVENT_TYPE=push" >> $GITHUB_ENV
+          fi
+      - name: Check if organization member
+        id: is_organization_member
+        env:
+          GITHUB_ORG: tenstorrent
+        run: |
+          http_status=$(curl -o /dev/null -s -w '%{http_code}' -H "Authorization: Bearer ${{ secrets.ORG_READ_GITHUB_TOKEN }}" https://api.github.com/orgs/${{ env.GITHUB_ORG }}/members/${{ env.USERNAME }})
+          if [ "$http_status" -eq 204 ]; then
+            echo "Detected org member"
+            echo "is_member=true" >> $GITHUB_OUTPUT
+          else
+            echo "Detected community member"
+            echo "is_member=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Add community label
+        if: ${{ steps.is_organization_member.outputs.is_member == 'false' && env.GH_COMMAND && env.NUMBER }}
+        run: |
+          gh ${{env.GH_COMMAND}} edit ${{ env.NUMBER }} --add-label ${{ env.LABELS }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          LABELS: community
+      - name: Send Notification
+        if: ${{ steps.is_organization_member.outputs.is_member == 'false' }}
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "A new ${{ env.EVENT_TYPE }} has been created by a non-org member `${{ env.USERNAME }}`: ${{ env.EVENT_URL }}",
+              "channel": "C07R5GYEW8J"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CHANNEL_WEBHOOK_URL }}


### PR DESCRIPTION
Adding a workflow to tag issues and prs with the `community` label. The corresponding secrets have been setup by @vmilosevic 
