### PR TITLE
Support tt-metal semaphores

### DIFF
--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -587,7 +587,7 @@ def TTKernel_NocSemaphoreWaitMinOp : TTKernel_Op<"noc_semaphore_wait_min"> {
     let summary = "NocSemaphoreWaitMin";
     let description = [{
       A blocking call that waits until the value of a local L1 memory address on
-      the Tensix core executing this function becomes equal to a target value.
+      the Tensix core executing this function becomes equal or greater than a target value.
       This L1 memory address is used as a semaphore of size 4 Bytes, as a
       synchronization mechanism. Also, see *noc_semaphore_set*.
     }];
@@ -613,7 +613,11 @@ def TTKernel_NocSemaphoreSetMulticastOp : TTKernel_Op<"noc_semaphore_set_multica
       *noc_semaphore_set_multicast_loopback_src* can be used.
     }];
 
-    let arguments = (ins TTKernel_L1Addr:$src_local_l1_addr, TTKernel_NocAddr:$dst_noc_addr_multicast, I32:$num_dests, BoolAttr:$linked, BoolAttr:$multicast_path_reserve);
+    let arguments = (ins TTKernel_L1Addr:$src_local_l1_addr,
+                         TTKernel_NocAddr:$dst_noc_addr_multicast,
+                         I32:$num_dests,
+                         BoolAttr:$linked,
+                         BoolAttr:$multicast_path_reserve);
 }
 
 def TTKernel_NocSemaphoreSetMulticastLoopbackOp : TTKernel_Op<"noc_semaphore_set_multicast_loopback_src"> {
@@ -634,7 +638,11 @@ def TTKernel_NocSemaphoreSetMulticastLoopbackOp : TTKernel_Op<"noc_semaphore_set
       regular non multicast operations such as *noc_async_write* in this case.
     }];
 
-    let arguments = (ins TTKernel_L1Addr:$src_local_l1_addr, TTKernel_NocAddr:$dst_noc_addr_multicast, I32:$num_dests, BoolAttr:$linked, BoolAttr:$multicast_path_reserve);
+    let arguments = (ins TTKernel_L1Addr:$src_local_l1_addr,
+                         TTKernel_NocAddr:$dst_noc_addr_multicast,
+                         I32:$num_dests,
+                         BoolAttr:$linked,
+                         BoolAttr:$multicast_path_reserve);
 }
 
 //===----------------------------------------------------------------------===//
@@ -649,7 +657,7 @@ def TTKernel_GetArgValOp : TTKernel_Op<"get_arg_val"> {
 
     let arguments = (ins I32:$arg_index);
 
-    let results = (outs I32:$arg_val);
+    let results = (outs AnyTypeOf<[TTKernel_Semaphore, I32]>:$arg_val);
 }
 
 //===----------------------------------------------------------------------===//
@@ -662,9 +670,18 @@ def TTKernel_CastToL1PtrOp : TTKernel_Op<"reinterpret_cast<volatile tt_l1_ptr ui
       Cast specified addr to L1 pointer.
     }];
 
-    let arguments = (ins TTKernel_L1Addr:$addr);
+    let arguments = (ins AnyTypeOf<[I32, TTKernel_L1Addr]>:$addr);
 
     let results = (outs TTKernel_L1AddrPtr:$l1_ptr);
+}
+
+def TTKernel_StoreToL1Op : TTKernel_Op<"store_to_l1"> {
+    let summary = "StoreToL1";
+    let description = [{
+      Store value to L1.
+    }];
+
+    let arguments = (ins I32:$value, TTKernel_L1AddrPtr:$l1_ptr, I32:$offset);
 }
 
 //===----------------------------------------------------------------------===//
@@ -788,26 +805,6 @@ def TTKernel_GetWritePtrOp : TTKernel_Op<"get_write_ptr"> {
 
     let arguments = (ins TTKernel_CB:$cb);
     let results = (outs I32:$writePtr);
-}
-
-def TTKernel_CastToL1PtrOp : TTKernel_Op<"reinterpret_cast<volatile tt_l1_ptr uint32_t*>"> {
-    let summary = "CastToL1Ptr";
-    let description = [{
-      Cast specified addr to L1 pointer.
-    }];
-
-    let arguments = (ins AnyTypeOf<[I32, TTKernel_L1Addr]>:$addr);
-
-    let results = (outs TTKernel_L1AddrPtr:$l1_ptr);
-}
-
-def TTKernel_StoreToL1Op : TTKernel_Op<"store_to_l1"> {
-    let summary = "StoreToL1";
-    let description = [{
-      Store value to L1.
-    }];
-
-    let arguments = (ins I32:$value, TTKernel_L1AddrPtr:$l1_ptr, I32:$offset);
 }
 
 #endif

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -568,7 +568,7 @@ def TTKernel_NocSemaphoreSetOp : TTKernel_Op<"noc_semaphore_set"> {
       *noc_semaphore_wait*.
     }];
 
-    let arguments = (ins I32:$sem_addr, I32:$val);
+    let arguments = (ins TTKernel_L1AddrPtr:$sem_addr, I32:$val);
 }
 
 def TTKernel_NocSemaphoreWaitOp : TTKernel_Op<"noc_semaphore_wait"> {
@@ -613,7 +613,7 @@ def TTKernel_NocSemaphoreSetMulticastOp : TTKernel_Op<"noc_semaphore_set_multica
       *noc_semaphore_set_multicast_loopback_src* can be used.
     }];
 
-    let arguments = (ins I32:$src_local_l1_addr, TTKernel_NocAddr:$dst_noc_addr_multicast, I32:$num_dests, BoolAttr:$linked, BoolAttr:$multicast_path_reserve);
+    let arguments = (ins TTKernel_L1Addr:$src_local_l1_addr, TTKernel_NocAddr:$dst_noc_addr_multicast, I32:$num_dests, BoolAttr:$linked, BoolAttr:$multicast_path_reserve);
 }
 
 def TTKernel_NocSemaphoreSetMulticastLoopbackOp : TTKernel_Op<"noc_semaphore_set_multicast_loopback_src"> {
@@ -634,7 +634,7 @@ def TTKernel_NocSemaphoreSetMulticastLoopbackOp : TTKernel_Op<"noc_semaphore_set
       regular non multicast operations such as *noc_async_write* in this case.
     }];
 
-    let arguments = (ins I32:$src_local_l1_addr, TTKernel_NocAddr:$dst_noc_addr_multicast, I32:$num_dests, BoolAttr:$linked, BoolAttr:$multicast_path_reserve);
+    let arguments = (ins TTKernel_L1Addr:$src_local_l1_addr, TTKernel_NocAddr:$dst_noc_addr_multicast, I32:$num_dests, BoolAttr:$linked, BoolAttr:$multicast_path_reserve);
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -537,6 +537,136 @@ def TTKernel_NocAsyncWriteBarrierOp : TTKernel_Op<"noc_async_write_barrier"> {
     }];
 }
 
+def TTKernel_GetSemaphoreOp : TTKernel_Op<"get_semaphore"> {
+    let summary = "GetSemaphoreOp";
+    let description = [{
+      Get L1 addr of the semaphore with specified semaphore id
+    }];
+
+    let arguments = (ins I32:$semaphore_id);
+    let results = (outs TTKernel_L1Addr:$sem_addr);
+}
+
+def TTKernel_NocSemaphoreIncOp : TTKernel_Op<"noc_semaphore_inc"> {
+    let summary = "NocSemaphoreInc";
+    let description = [{
+      The Tensix core executing this function call initiates an atomic increment
+      (with 32-bit wrap) of a remote Tensix core L1 memory address. This L1 memory
+      address is used as a semaphore of size 4 Bytes, as a synchronization
+      mechanism.
+    }];
+
+    let arguments = (ins TTKernel_NocAddr:$addr, I32:$incr, I32:$noc_id);
+}
+
+def TTKernel_NocSemaphoreSetOp : TTKernel_Op<"noc_semaphore_set"> {
+    let summary = "NocSemaphoreSet";
+    let description = [{
+      Sets the value of a local L1 memory address on the Tensix core executing
+      this function to a specific value. This L1 memory address is used as a
+      semaphore of size 4 Bytes, as a synchronization mechanism. Also, see
+      *noc_semaphore_wait*.
+    }];
+
+    let arguments = (ins I32:$sem_addr, I32:$val);
+}
+
+def TTKernel_NocSemaphoreWaitOp : TTKernel_Op<"noc_semaphore_wait"> {
+    let summary = "NocSemaphoreWait";
+    let description = [{
+      A blocking call that waits until the value of a local L1 memory address on
+      the Tensix core executing this function becomes equal to a target value.
+      This L1 memory address is used as a semaphore of size 4 Bytes, as a
+      synchronization mechanism. Also, see *noc_semaphore_set*.
+    }];
+
+    let arguments = (ins TTKernel_L1AddrPtr:$sem_addr, I32:$val);
+}
+
+def TTKernel_NocSemaphoreWaitMinOp : TTKernel_Op<"noc_semaphore_wait_min"> {
+    let summary = "NocSemaphoreWaitMin";
+    let description = [{
+      A blocking call that waits until the value of a local L1 memory address on
+      the Tensix core executing this function becomes equal to a target value.
+      This L1 memory address is used as a semaphore of size 4 Bytes, as a
+      synchronization mechanism. Also, see *noc_semaphore_set*.
+    }];
+
+    let arguments = (ins TTKernel_L1AddrPtr:$sem_addr, I32:$val);
+}
+
+def TTKernel_NocSemaphoreSetMulticastOp : TTKernel_Op<"noc_semaphore_set_multicast"> {
+    let summary = "NocSemaphoreSetMulticast";
+    let description = [{
+      Initiates an asynchronous write from a source address in L1 memory on the
+      Tensix core executing this function call to a rectangular destination grid.
+      The destinations are specified using a uint64_t encoding referencing an
+      on-chip grid of nodes located at NOC coordinate range
+      (x_start,y_start,x_end,y_end) and a local address created using
+      *get_noc_multicast_addr* function. The size of data that is sent is 4 Bytes.
+      This is usually used to set a semaphore value at the destination nodes, as a
+      way of a synchronization mechanism. The same as *noc_async_write_multicast*
+      with preset size of 4 Bytes.
+      With this API, the multicast sender cannot be part of the multicast
+      destinations. If the multicast sender has to be in the multicast
+      destinations (i.e. must perform a local L1 write), the other API variant
+      *noc_semaphore_set_multicast_loopback_src* can be used.
+    }];
+
+    let arguments = (ins I32:$src_local_l1_addr, TTKernel_NocAddr:$dst_noc_addr_multicast, I32:$num_dests, BoolAttr:$linked, BoolAttr:$multicast_path_reserve);
+}
+
+def TTKernel_NocSemaphoreSetMulticastLoopbackOp : TTKernel_Op<"noc_semaphore_set_multicast_loopback_src"> {
+    let summary = "NocSemaphoreSetMulticastLoopback";
+    let description = [{
+      Initiates an asynchronous write from a source address in L1 memory on the
+      Tensix core executing this function call to a rectangular destination grid.
+      The destinations are specified using a uint64_t encoding referencing an
+      on-chip grid of nodes located at NOC coordinate range
+      (x_start,y_start,x_end,y_end) and a local address created using
+      *get_noc_multicast_addr* function. The size of data that is sent is 4 Bytes.
+      This is usually used to set a semaphore value at the destination nodes, as a
+      way of a synchronization mechanism. The same as *noc_async_write_multicast*
+      with preset size of 4 Bytes.
+      Note: With this API, sending data only to the source node (when num_dests
+      is 1) may result in unexpected behaviour. For some parameters, hangs have
+      been observed. For some other parameters, nothing may happen. Consider using
+      regular non multicast operations such as *noc_async_write* in this case.
+    }];
+
+    let arguments = (ins I32:$src_local_l1_addr, TTKernel_NocAddr:$dst_noc_addr_multicast, I32:$num_dests, BoolAttr:$linked, BoolAttr:$multicast_path_reserve);
+}
+
+//===----------------------------------------------------------------------===//
+// TTKernel Compile and runtime arguments operations
+//===----------------------------------------------------------------------===//
+
+def TTKernel_GetArgValOp : TTKernel_Op<"get_arg_val"> {
+    let summary = "Get runtime arg value.";
+    let description = [{
+      Get runtime argument value at specified index.
+    }];
+
+    let arguments = (ins I32:$arg_index);
+
+    let results = (outs I32:$arg_val);
+}
+
+//===----------------------------------------------------------------------===//
+// TTKernel Helper functions
+//===----------------------------------------------------------------------===//
+
+def TTKernel_CastToL1PtrOp : TTKernel_Op<"reinterpret_cast<volatile tt_l1_ptr uint32_t*>"> {
+    let summary = "CastToL1Ptr";
+    let description = [{
+      Cast specified addr to L1 pointer.
+    }];
+
+    let arguments = (ins TTKernel_L1Addr:$addr);
+
+    let results = (outs TTKernel_L1AddrPtr:$l1_ptr);
+}
+
 //===----------------------------------------------------------------------===//
 // TTKernel Multicast NoC operations
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
@@ -117,16 +117,6 @@ def TTKernel_NocAddr : TTKernel_Type<"NocAddr", "noc_addr"> {
     let description = "Noc address type in TTKernel dialect";
 }
 
-def TTKernel_L1Addr : TTKernel_Type<"L1Addr", "l1_addr"> {
-    let summary = "TTKernel l1 address";
-    let description = "L1 address type in TTKernel dialect";
-}
-
-def TTKernel_L1AddrPtr : TTKernel_Type<"L1AddrPtr", "l1_addr_ptr"> {
-    let summary = "TTKernel l1 address pointer";
-    let description = "L1 pointer address type in TTKernel dialect";
-}
-
 def TTKernel_ThreadTypeAttr : EnumAttr<TTKernel_Dialect, TTKernel_ThreadType, "thread"> {
   let assemblyFormat = "`<` $value `>`";
 }

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
@@ -105,9 +105,26 @@ def TTKernel_CB : TTKernel_Type<"CB", "cb"> {
     }];
 }
 
+def TTKernel_Semaphore : TTKernel_Type<"Semaphore", "semaphore"> {
+  let summary = "TTKernel semaphore";
+  let description = "Semaphore type in TTKernel dialect";
+  let parameters = (ins "uint32_t":$initial_value);
+  let assemblyFormat = "`<` $initial_value `>`";
+}
+
 def TTKernel_NocAddr : TTKernel_Type<"NocAddr", "noc_addr"> {
     let summary = "TTKernel noc address";
     let description = "Noc address type in TTKernel dialect";
+}
+
+def TTKernel_L1Addr : TTKernel_Type<"L1Addr", "l1_addr"> {
+    let summary = "TTKernel l1 address";
+    let description = "L1 address type in TTKernel dialect";
+}
+
+def TTKernel_L1AddrPtr : TTKernel_Type<"L1AddrPtr", "l1_addr_ptr"> {
+    let summary = "TTKernel l1 address pointer";
+    let description = "L1 pointer address type in TTKernel dialect";
 }
 
 def TTKernel_ThreadTypeAttr : EnumAttr<TTKernel_Dialect, TTKernel_ThreadType, "thread"> {

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -125,10 +125,10 @@ public:
       return Builder(ctx).getI32Type();
     });
     addConversion(
-    [ctx](mlir::tt::ttkernel::L1AddrPtrType type) -> emitc::PointerType {
-      return emitc::PointerType::get(
-          emitc::OpaqueType::get(ctx, "volatile tt_l1_ptr uint32_t"));
-    });
+        [ctx](mlir::tt::ttkernel::L1AddrPtrType type) -> emitc::PointerType {
+          return emitc::PointerType::get(
+              emitc::OpaqueType::get(ctx, "volatile tt_l1_ptr uint32_t"));
+        });
   }
 };
 
@@ -287,8 +287,8 @@ public:
           emitc::OpaqueAttr::get(op.getContext(), "uint32_t"));
       return ArrayAttr::get(op.getContext(), template_args);
     }
-      return ArrayAttr();
-    }
+    return ArrayAttr();
+  }
 
   LogicalResult
   matchAndRewrite(SourceOp op, Adaptor adaptor,
@@ -451,8 +451,7 @@ public:
           TTMetalToEmitCOpaqueRewriter<ttkernel::CopyTileOp>,
           TTMetalToEmitCOpaqueRewriter<ttkernel::ExpTileInitOp>,
           TTMetalToEmitCOpaqueRewriter<ttkernel::ExpTileOp>,
-          TTMetalToEmitCOpaqueRewriter<ttkernel::GetWritePtrOp>,
-          TTMetalToEmitCOpaqueRewriter<ttkernel::CastToL1PtrOp>>(
+          TTMetalToEmitCOpaqueRewriter<ttkernel::GetWritePtrOp>>(
           typeConverter, funcOp.getContext());
 
       patterns.add<TTMetalToEmitCOpaqueRewriter<ttkernel::GetNocAddrXYOp>>(

--- a/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
+++ b/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
@@ -89,8 +89,8 @@ namespace mlir::tt::ttmetal {
   // Assert block inputs are CBs
   for (auto &region : getRegions()) {
     for (auto arg : region.getArguments()) {
-      if (not(mlir::isa<ttkernel::CBType>(arg.getType()) ||
-              mlir::isa<ttkernel::SemaphoreType>(arg.getType()))) {
+      if (!(mlir::isa<ttkernel::CBType>(arg.getType()) ||
+            mlir::isa<ttkernel::SemaphoreType>(arg.getType()))) {
         return emitOpError("Block inputs must be CBType or SemType");
       }
     }

--- a/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
+++ b/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
@@ -89,8 +89,8 @@ namespace mlir::tt::ttmetal {
   // Assert block inputs are CBs
   for (auto &region : getRegions()) {
     for (auto arg : region.getArguments()) {
-      if (!(mlir::isa<ttkernel::CBType>(arg.getType()) ||
-            mlir::isa<ttkernel::SemaphoreType>(arg.getType()))) {
+      if (!mlir::isa<ttkernel::CBType>(arg.getType()) &&
+          !mlir::isa<ttkernel::SemaphoreType>(arg.getType())) {
         return emitOpError("Block inputs must be CBType or SemType");
       }
     }

--- a/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
+++ b/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
@@ -89,8 +89,9 @@ namespace mlir::tt::ttmetal {
   // Assert block inputs are CBs
   for (auto &region : getRegions()) {
     for (auto arg : region.getArguments()) {
-      if (not mlir::isa<ttkernel::CBType>(arg.getType())) {
-        return emitOpError("Block inputs must be CBType");
+      if (not(mlir::isa<ttkernel::CBType>(arg.getType()) ||
+              mlir::isa<ttkernel::SemaphoreType>(arg.getType()))) {
+        return emitOpError("Block inputs must be CBType or SemType");
       }
     }
   }


### PR DESCRIPTION
Fix #915 

Add support for all tt-metal semaphore functions, as well as some utility functions that are useful for using semaphores through compiler

For example, code below

```cpp
Value zero = i32(0, builder);
auto sem_id = builder.create<ttkernel::GetArgValOp>(arithOrMathOp.getLoc(), zero);
auto sem_addr = builder.create<ttkernel::GetSemaphoreOp>(arithOrMathOp.getLoc(), sem_id);
auto sem_l1_ptr = builder.create<ttkernel::CastToL1PtrOp>(arithOrMathOp.getLoc(), sem_addr);
builder.create<ttkernel::NocSemaphoreWaitOp>(arithOrMathOp.getLoc(), sem_l1_ptr, zero);
```

will generate kernel code

```cpp
int32_t v5 = get_arg_val<uint32_t>(v4);
int32_t v6 = get_semaphore(v5);
volatile tt_l1_ptr uint32_t*  v7 = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(v6);
noc_semaphore_wait(v7, v4);
```

### TODO

- [ ] Implement conversion to `tt_l1_ptr` properly