### PR TITLE
Add gather op end-to-end [#754]

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -61,6 +61,33 @@ def TTIR_GenericOp : TTIR_DPSOp<"generic", [AttrSizedOperandSegments]> {
     let hasVerifier = 1;
 }
 
+def TTIR_GatherOp: TTIR_DPSOp<"gather"> {
+    let summary = "Gather operation.";
+    let description = [{
+      Gather operation.
+    }];
+
+    let arguments = (ins AnyRankedTensor:$input, // operand
+                         AnyRankedTensor:$output, // result
+                         AnyRankedTensor:$start_indices, // start_indices
+                         DenseI64ArrayAttr:$offset_dims, // offset_dims
+                         DenseI64ArrayAttr:$collapsed_slice_dims, // collapsed_slice_dims
+                         DenseI64ArrayAttr:$operand_batching_dims, // operand_batching_dims
+                         DenseI64ArrayAttr:$start_indices_batching_dims, // start_indices_batching_dims
+                         DenseI64ArrayAttr:$start_index_map, // start_index_map
+                         SI64Attr:$index_vector_dim, // index_vector_dim
+                         DenseI64ArrayAttr:$slice_sizes, // slice_sizes
+                         BoolAttr:$indices_are_sorted, // indices_are_sorted (bool)
+                         TT_OperandConstraintArrayAttr:$operand_constraints);
+
+    let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      MutableOperandRange getDpsInitsMutable() { return getOutputMutable(); }
+    }];
+
+}
+
 def TTIR_ToLayoutOp : TTIR_Op<"to_layout", [DestinationStyleOpInterface, TTIROpInterface]> {
     let summary = "Layout op.";
     let description = [{

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -134,4 +134,11 @@ def TTIRLoadSystemDesc: Pass<"ttir-load-system-desc", "::mlir::ModuleOp"> {
     ];
 }
 
+def TTIRGatherPatternMatch : Pass<"convert-ttir-to-ttir", "::mlir::ModuleOp"> {
+  let summary = "Convert GatherOp in TTIR dialect to EmbeddingOp in TTIR dialect.";
+  let description = [{
+    Convert GatherOp in TTIR dialect to EmbeddingOp in TTIR dialect. Add ReshapeOp to the input of EmbeddingOp if needed.
+  }];
+}
+
 #endif

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -757,6 +757,52 @@ private:
   }
 };
 
+class StableHLOToTTIRGatherOpConversionPattern
+    : public OpConversionPattern<mlir::stablehlo::GatherOp> {
+
+  using OpConversionPattern<mlir::stablehlo::GatherOp>::OpConversionPattern;
+
+public:
+  LogicalResult
+  matchAndRewrite(mlir::stablehlo::GatherOp srcOp,
+                  mlir::stablehlo::GatherOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    // Create the output tensor type based on inputs
+    auto outputType = mlir::cast<RankedTensorType>(
+        getTypeConverter()->convertType(srcOp.getResult().getType()));
+    // Create an empty output tensor with the computed shape
+    tensor::EmptyOp outputTensor = rewriter.create<tensor::EmptyOp>(
+        srcOp.getLoc(), outputType.getShape(), outputType.getElementType());
+
+    auto dimensionNumbers = srcOp.getDimensionNumbers();
+    rewriter.replaceOpWithNewOp<mlir::tt::ttir::GatherOp>(
+        srcOp,                            // The original operation to replace
+        outputType,                       // Result type
+        srcOp.getOperands()[0],           // Input tensor
+        Value(outputTensor),              // Output tensor
+        srcOp.getOperands()[1],           // Start indices
+        dimensionNumbers.getOffsetDims(), // offset_dims attribute
+        dimensionNumbers
+            .getCollapsedSliceDims(), // collapsed_slice_dims attribute
+        dimensionNumbers
+            .getOperandBatchingDims(), // operand_batching_dims attribute
+        dimensionNumbers
+            .getStartIndicesBatchingDims(),   // start_indices_batching_dims
+                                              // attribute
+        dimensionNumbers.getStartIndexMap(),  // start_index_map attribute
+        dimensionNumbers.getIndexVectorDim(), // index_vector_dim attribute
+        srcOp.getSliceSizesAttr(),            // slice_sizes attribute
+        false,                                // indices_are_sorted attribute
+        rewriter.getArrayAttr(                // operand constraints
+            SmallVector<Attribute>(adaptor.getOperands().size() + 1,
+                                   rewriter.getAttr<OperandConstraintAttr>(
+                                       OperandConstraint::AnyDeviceTile))));
+
+    return success();
+  }
+};
+
 void addElementwiseUnaryOpsConversionPatterns(MLIRContext *ctx,
                                               RewritePatternSet &patterns,
                                               TypeConverter &typeConverter) {
@@ -858,6 +904,11 @@ void addReshapeOpConversionPattern(MLIRContext *ctx,
   patterns.add<StableHLOToTTIRReshapeOpConversionPattern>(typeConverter, ctx);
 }
 
+void addGatherOpConversionPattern(MLIRContext *ctx, RewritePatternSet &patterns,
+                                  TypeConverter &typeConverter) {
+  patterns.add<StableHLOToTTIRGatherOpConversionPattern>(typeConverter, ctx);
+}
+
 } // namespace
 
 namespace mlir::tt {
@@ -877,6 +928,7 @@ void populateStableHLOToTTIRPatterns(MLIRContext *ctx,
   addCompareOpsConversionPatterns(ctx, patterns, typeConverter);
   addConcatOpsConversionPatterns(ctx, patterns, typeConverter);
   addReshapeOpConversionPattern(ctx, patterns, typeConverter);
+  addGatherOpConversionPattern(ctx, patterns, typeConverter);
 }
 
 } // namespace mlir::tt

--- a/lib/Dialect/TTIR/Transforms/Passes.cpp
+++ b/lib/Dialect/TTIR/Transforms/Passes.cpp
@@ -43,6 +43,7 @@ namespace mlir::tt::ttir {
 #define GEN_PASS_DEF_TTIROPTIMIZER
 #define GEN_PASS_DEF_TTIRIMPLICITDEVICE
 #define GEN_PASS_DEF_TTIRLOADSYSTEMDESC
+#define GEN_PASS_DEF_TTIRGATHERPATTERNMATCH
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h.inc"
 
 class TTIRImplicitDevice
@@ -1450,6 +1451,125 @@ public:
       module->setAttr(tt::SystemDescAttr::name,
                       tt::SystemDescAttr::getDefault(&getContext()));
     }
+  }
+};
+
+class GatherOpRewritePattern : public OpRewritePattern<GatherOp> {
+public:
+  using OpRewritePattern<GatherOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(GatherOp op,
+                                PatternRewriter &rewriter) const final {
+    bool reduceWeightTensorDim = false;
+    auto outputType = mlir::cast<RankedTensorType>(op.getResult().getType());
+    auto shape = outputType.getShape();
+    auto startIndices = op.getStartIndices(); // start indices of the gather op
+    auto startIndicesType =
+        mlir::cast<RankedTensorType>(startIndices.getType());
+    auto sliceSizes = op.getSliceSizes(); // slice sizes of the gather op
+    auto offsetDims = op.getOffsetDims();
+    auto collapsedSliceDims =
+        op.getCollapsedSliceDims(); // collapsed slice dims of the gather op
+
+    if (shape.size() > 1) {
+      auto hiddenDim = shape[1];
+      assert(sliceSizes.size() > 1 &&
+             "sliceSizes should have at least 2 elements");
+      if (sliceSizes[0] != 1 || sliceSizes[1] != hiddenDim) {
+        return rewriter.notifyMatchFailure(op, "Did not satisfy sliceSizes");
+      }
+    }
+    if (offsetDims.size() != 1 &&
+        std::vector<int64_t>(offsetDims.begin(), offsetDims.end()) !=
+            std::vector<int64_t>{2}) {
+      return rewriter.notifyMatchFailure(op, "Did not satisfy offsetDims");
+    }
+    if (collapsedSliceDims.size() != 1 &&
+        std::vector<int64_t>(collapsedSliceDims.begin(),
+                             collapsedSliceDims.end()) !=
+            std::vector<int64_t>{1}) {
+      return rewriter.notifyMatchFailure(op,
+                                         "Did not satisfy collapsedSliceDims");
+    }
+    if (shape.size() == startIndicesType.getShape().size()) {
+      if (startIndicesType.getShape()[shape.size() - 1] == 1) {
+        reduceWeightTensorDim = true;
+      } else {
+        return rewriter.notifyMatchFailure(op,
+                                           "Did not satisfy startIndicesType");
+      }
+    }
+
+    if (reduceWeightTensorDim) {
+      // insert reshape op to remove the last dimension of start indices
+      // before gather/ embedding op
+      std::vector<int32_t> newShape(startIndicesType.getShape().begin(),
+                                    startIndicesType.getShape().end() - 1);
+      std::vector<int64_t> newShapeInt64(newShape.begin(), newShape.end());
+      tensor::EmptyOp reshapeOutputTensor = rewriter.create<tensor::EmptyOp>(
+          op.getLoc(), llvm::ArrayRef<int64_t>(newShapeInt64),
+          startIndicesType.getElementType());
+      mlir::tt::ttir::ReshapeOp reshapeOp =
+          rewriter.create<mlir::tt::ttir::ReshapeOp>(
+              op.getLoc(),
+              mlir::RankedTensorType::get(newShapeInt64,
+                                          startIndicesType.getElementType()),
+              startIndices, reshapeOutputTensor,
+              rewriter.getI32ArrayAttr(newShape),
+              rewriter.getArrayAttr(SmallVector<Attribute>(
+                  startIndicesType.getShape().size() - 1,
+                  rewriter.getAttr<OperandConstraintAttr>(
+                      OperandConstraint::AnyDeviceTile))));
+      if (reshapeOp && op) {
+        reshapeOp->moveBefore(op);
+        EmbeddingOp embeddingOp = rewriter.create<EmbeddingOp>(
+            op.getLoc(), op.getResult().getType(),
+            reshapeOp.getResult(), // input - start indices
+            op.getOperands()[0],   // weight - input tensor
+            op.getOutput(),
+            rewriter.getArrayAttr( // operand constraints
+                SmallVector<Attribute>(op.getNumOperands() + 1,
+                                       rewriter.getAttr<OperandConstraintAttr>(
+                                           OperandConstraint::AnyDeviceTile))));
+        assert(embeddingOp != nullptr && "Failed to create embedding op");
+        rewriter.replaceOp(op, embeddingOp);
+        return success();
+      } else {
+        return rewriter.notifyMatchFailure(op, "Failed to create reshape op");
+      }
+    } else {
+      EmbeddingOp embeddingOp = rewriter.create<EmbeddingOp>(
+          op.getLoc(), op.getResult().getType(),
+          op.getStartIndices(), // input - start indices
+          op.getOperands()[0],  // weight - input tensor
+          op.getOutput(),
+          rewriter.getArrayAttr( // operand constraints
+              SmallVector<Attribute>(op.getNumOperands() + 1,
+                                     rewriter.getAttr<OperandConstraintAttr>(
+                                         OperandConstraint::AnyDeviceTile))));
+      assert(embeddingOp != nullptr && "Failed to create embedding op");
+      rewriter.replaceOp(op, embeddingOp);
+      return success();
+    }
+
+    return rewriter.notifyMatchFailure(op, "Failed to create embedding op");
+  }
+};
+
+class TTIRGatherPatternMatch
+    : public ttir::impl::TTIRGatherPatternMatchBase<TTIRGatherPatternMatch> {
+public:
+  using ttir::impl::TTIRGatherPatternMatchBase<
+      TTIRGatherPatternMatch>::TTIRGatherPatternMatchBase;
+  void runOnOperation() final {
+    RewritePatternSet patterns(&getContext());
+    patterns.add<GatherOpRewritePattern>(&getContext());
+    FrozenRewritePatternSet patternSet(std::move(patterns));
+    if (failed(applyPatternsAndFoldGreedily(getOperation(), patternSet))) {
+      getOperation()->dump();
+      signalPassFailure();
+      return;
+    }
+    getOperation()->dump();
   }
 };
 

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -20,6 +20,7 @@ void createTTNNPipelineTTIRPasses(
   ttir::TTIRLoadSystemDescOptions systemDescOptions;
   systemDescOptions.path = options.systemDescPath;
   pm.addPass(mlir::tt::ttir::createTTIRSlidingWindow2dFixShapes());
+  pm.addPass(mlir::tt::ttir::createTTIRGatherPatternMatch());
   pm.addPass(mlir::tt::ttir::createTTIRLoadSystemDesc(systemDescOptions));
 
   ttir::TTIRImplicitDeviceOptions implicitDeviceOptions;

--- a/test/ttmlir/Conversion/StableHLOToTTIR/gather_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/gather_op.mlir
@@ -1,0 +1,24 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s
+#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
+module @jit_gather attributes {} {
+  func.func public @test_gather_0(%operand: tensor<32000x1024xf32>, %start_indices: tensor<1x32xi32>) -> tensor<1x32x1024xf32> {
+    %0 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [2], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 1024>}> : (tensor<32000x1024xf32>, tensor<1x32xi32>) -> tensor<1x32x1024xf32>
+    // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
+    // CHECK: %[[C:.*]] = "ttir.embedding"[[C:.*]]
+    return %0 : tensor<1x32x1024xf32>
+  }
+    func.func public @test_gather_1(%operand: tensor<448x384xf32>, %start_indices: tensor<1x2x1xi64>) -> tensor<1x2x384xf32> {
+        %0 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [2], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 384>}> : (tensor<448x384xf32>, tensor<1x2x1xi64>) -> tensor<1x2x384xf32>
+        // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
+        // CHECK: %[[C:.*]] = "ttir.embedding"[[C:.*]]
+        return %0 : tensor<1x2x384xf32>
+    }
+
+    func.func public @test_gather_2(%operand: tensor<51864x384xf32>, %start_indices: tensor<1x2xi64>) -> tensor<1x2x384xf32> {
+      %0 = "stablehlo.gather"(%operand, %start_indices) <{dimension_numbers = #stablehlo.gather<offset_dims = [2], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 384>}> : (tensor<51864x384xf32>, tensor<1x2xi64>) -> tensor<1x2x384xf32>
+      // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
+      // CHECK: %[[C:.*]] = "ttir.embedding"[[C:.*]]
+      return %0 : tensor<1x2x384xf32>
+  }
+}


### PR DESCRIPTION
This is a draft PR to ask for feedback.

Gather is lowered into ttir::EmbeddingOp if possible. Metal currently only supports embedding, not gather.

The team decided to keep lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp as minimal of a conversion possible, but do op to a different op conversion in the TTIR layer. So we are mapping stablehlo::gather to ttir::gather 1-to-1 but ttir::gather is lowered to ttir::embedding if possible.

I added TTIR pass for gather to embedding. However, I need help with how to reduce last dimension of weight when it is 1. I.E. tensor<1x2x1xi64> --> tensor<1x2xi64> Currently, there is only an assert but that needs to be replaced with the new last-dimension-reduced weight tensor.

Also, the code might not be structured the best way. So, I want your input on how the code looks so far. 