### PR TITLE
Static link all targets and tools

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -14,7 +14,6 @@ if (TTMLIR_ENABLE_RUNTIME)
 endif()
 
 set(link_libs
-MLIR
 MLIRTTDialect
 MLIRTTIRDialect
 MLIRTTIRTransforms

--- a/lib/Conversion/StableHLOToTTIR/CMakeLists.txt
+++ b/lib/Conversion/StableHLOToTTIR/CMakeLists.txt
@@ -14,5 +14,6 @@ add_mlir_library(TTMLIRStableHLOToTTIR
   TTMLIRConversionPassIncGen
 
   LINK_LIBS PUBLIC
-  MLIR
+  MLIRIR
+  MLIRPass
 )

--- a/lib/Conversion/TTIRToTTMetal/CMakeLists.txt
+++ b/lib/Conversion/TTIRToTTMetal/CMakeLists.txt
@@ -9,5 +9,6 @@ add_mlir_library(TTMLIRTTIRToTTMetal
   TTMLIRConversionPassIncGen
 
   LINK_LIBS PUBLIC
-  MLIR
+  MLIRIR
+  MLIRPass
 )

--- a/lib/Conversion/TTIRToTTNN/CMakeLists.txt
+++ b/lib/Conversion/TTIRToTTNN/CMakeLists.txt
@@ -9,5 +9,6 @@ add_mlir_library(TTMLIRTTIRToTTNN
   TTMLIRConversionPassIncGen
 
   LINK_LIBS PUBLIC
-  MLIR
+  MLIRIR
+  MLIRPass
 )

--- a/lib/Conversion/TTKernelToEmitC/CMakeLists.txt
+++ b/lib/Conversion/TTKernelToEmitC/CMakeLists.txt
@@ -8,5 +8,9 @@ add_mlir_library(TTMLIRTTKernelToEmitC
   TTMLIRConversionPassIncGen
 
   LINK_LIBS PUBLIC
-  MLIR
+  MLIRIR
+  MLIRPass
+  MLIRArithToEmitC
+  MLIREmitCDialect
+  MLIRTransformUtils
 )

--- a/lib/Conversion/TTNNToEmitC/CMakeLists.txt
+++ b/lib/Conversion/TTNNToEmitC/CMakeLists.txt
@@ -9,5 +9,9 @@ add_mlir_library(TTMLIRTTNNToEmitC
   TTMLIRConversionPassIncGen
 
   LINK_LIBS PUBLIC
-  MLIR
+  MLIRIR
+  MLIRPass
+  MLIRSCFToEmitC
+  MLIREmitCDialect
+  MLIRFuncTransforms
 )

--- a/lib/Conversion/TosaToTTIR/CMakeLists.txt
+++ b/lib/Conversion/TosaToTTIR/CMakeLists.txt
@@ -8,5 +8,6 @@ add_mlir_library(TTMLIRTosaToTTIR
   TTMLIRConversionPassIncGen
 
   LINK_LIBS PUBLIC
-  MLIR
+  MLIRIR
+  MLIRPass
 )

--- a/lib/Dialect/TTNN/IR/CMakeLists.txt
+++ b/lib/Dialect/TTNN/IR/CMakeLists.txt
@@ -12,4 +12,7 @@ add_mlir_dialect_library(MLIRTTNNDialect
 
         LINK_LIBS PUBLIC
         TTMLIRTTNNUtils
+        MLIRSCFToEmitC
+        MLIRLinalgDialect
+        MLIRMLProgramDialect
         )

--- a/lib/RegisterAll.cpp
+++ b/lib/RegisterAll.cpp
@@ -27,8 +27,8 @@ void mlir::tt::registerAllDialects(mlir::DialectRegistry &registry) {
   registry
       .insert<mlir::tt::TTDialect, mlir::tt::ttir::TTIRDialect,
               mlir::tt::ttnn::TTNNDialect, mlir::tt::ttmetal::TTMetalDialect,
-              mlir::tt::ttkernel::TTKernelDialect, mlir::arith::ArithDialect,
-              mlir::func::FuncDialect, mlir::ml_program::MLProgramDialect,
+              mlir::tt::ttkernel::TTKernelDialect, mlir::func::FuncDialect,
+              mlir::arith::ArithDialect, mlir::ml_program::MLProgramDialect,
               mlir::tensor::TensorDialect, mlir::linalg::LinalgDialect,
               mlir::scf::SCFDialect, mlir::cf::ControlFlowDialect,
               mlir::tosa::TosaDialect, mlir::vector::VectorDialect,

--- a/lib/Scheduler/CMakeLists.txt
+++ b/lib/Scheduler/CMakeLists.txt
@@ -5,5 +5,6 @@ add_mlir_library(MLIRScheduler
     ${PROJECT_SOURCE_DIR}/include/ttmlir/Scheduler
 
     LINK_LIBS PUBLIC
-    MLIR
+      MLIRIR
+      MLIRPass
 )

--- a/lib/Target/TTNN/CMakeLists.txt
+++ b/lib/Target/TTNN/CMakeLists.txt
@@ -10,6 +10,8 @@ add_mlir_translation_library(TTNNTargetFlatbuffer
     MLIRTTIRDialect
     MLIRTTDialect
     MLIRTTKernelDialect
+    MLIRTTNNTransforms
+    TTMLIRTTNNToEmitC
 )
 
 target_include_directories(TTNNTargetFlatbuffer PUBLIC ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -9,6 +9,7 @@ add_compile_definitions("MLIR_PYTHON_PACKAGE_PREFIX=ttmlir.")
 
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
+get_property(extension_libs GLOBAL PROPERTY MLIR_EXTENSION_LIBS)
 get_property(translation_libs GLOBAL PROPERTY MLIR_TRANSLATION_LIBS)
 
 declare_mlir_python_sources(TTMLIRPythonSources)
@@ -80,8 +81,8 @@ declare_mlir_python_extension(TTMLIRPythonExtensions.Main
     LLVMSupport
     ${dialect_libs}
     ${conversion_libs}
+    ${extension_libs}
     ${translation_libs}
-    MLIR
     TTMLIRStatic
 )
 

--- a/tools/ttmlir-opt/CMakeLists.txt
+++ b/tools/ttmlir-opt/CMakeLists.txt
@@ -1,7 +1,10 @@
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
-set(LIBS ${dialect_libs} ${conversion_libs} MLIROptLib MLIRTargetCpp TTMLIRStatic)
-add_llvm_executable(ttmlir-opt ttmlir-opt.cpp)
+get_property(extension_libs GLOBAL PROPERTY MLIR_EXTENSION_LIBS)
+
+set(LIBS ${dialect_libs} ${conversion_libs} ${extension_libs} MLIROptLib MLIRTargetCpp TTMLIRStatic)
+
+add_llvm_executable(ttmlir-opt ttmlir-opt.cpp DISABLE_LLVM_LINK_LLVM_DYLIB)
 
 llvm_update_compile_flags(ttmlir-opt)
 target_link_libraries(ttmlir-opt PRIVATE ${LIBS})

--- a/tools/ttmlir-translate/CMakeLists.txt
+++ b/tools/ttmlir-translate/CMakeLists.txt
@@ -1,12 +1,19 @@
-add_llvm_executable(ttmlir-translate ttmlir-translate.cpp)
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
+get_property(extension_libs GLOBAL PROPERTY MLIR_EXTENSION_LIBS)
+get_property(translation_libs GLOBAL PROPERTY MLIR_TRANSLATION_LIBS)
+
+add_llvm_executable(ttmlir-translate ttmlir-translate.cpp DISABLE_LLVM_LINK_LLVM_DYLIB)
 
 llvm_update_compile_flags(ttmlir-translate)
 target_link_libraries(ttmlir-translate PRIVATE
-  TTNNTargetFlatbuffer
-  TTMetalTargetFlatbuffer
-  MLIRTTNNTransforms
-  TTMLIRTTNNToEmitC
-  TTMLIRTTKernelToEmitC
+  ${dialect_libs}
+  ${conversion_libs}
+  ${translation_libs}
+  ${extension_libs}
+  MLIRIR
+  MLIRSupport
+  MLIRTranslateLib
 )
 
 mlir_check_link_libraries(ttmlir-translate)


### PR DESCRIPTION
We cannot mix static and dynamic linking when building targets because otherwise we can end up with multiple global constructors which MLIR isn't happy about.  We need to manually enforce that all cmake targets are statically linked, i.e. _don't_ use target `MLIR`, the only exception being the SharedLibrary target.