### PR TITLE
Script for breaking up a model into isolated op tests

### DIFF
--- a/include/ttmlir/Bindings/Python/TTMLIRModule.h
+++ b/include/ttmlir/Bindings/Python/TTMLIRModule.h
@@ -25,6 +25,7 @@ namespace py = pybind11;
 
 namespace mlir::ttmlir::python {
 void populateTTModule(py::module &m);
+void populateTTIRModule(py::module &m);
 void populateTTKernelModule(py::module &m);
 void populateTTNNModule(py::module &m);
 void populateOverridesModule(py::module &m);

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -81,6 +81,7 @@ declare_mlir_python_extension(TTMLIRPythonExtensions.Main
   SOURCES
     TTMLIRModule.cpp
     TTModule.cpp
+    TTIRModule.cpp
     TTKernelModule.cpp
     TTNNModule.cpp
     Overrides.cpp

--- a/python/TTIRModule.cpp
+++ b/python/TTIRModule.cpp
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Bindings/Python/TTMLIRModule.h"
+
+#include "mlir/CAPI/IR.h"
+
+namespace mlir::ttmlir::python {
+void populateTTIRModule(py::module &m) {
+  m.def("is_dps", [](MlirOperation op) {
+    return mlir::isa<DestinationStyleOpInterface>(unwrap(op));
+  });
+}
+} // namespace mlir::ttmlir::python

--- a/python/TTMLIRModule.cpp
+++ b/python/TTMLIRModule.cpp
@@ -29,6 +29,8 @@ PYBIND11_MODULE(_ttmlir, m) {
 
   auto tt_ir = m.def_submodule("tt_ir", "TT IR Bindings");
   mlir::ttmlir::python::populateTTModule(tt_ir);
+  auto ttir_ir = m.def_submodule("ttir_ir", "TTIR IR Bindings");
+  mlir::ttmlir::python::populateTTIRModule(ttir_ir);
   auto ttkernel_ir = m.def_submodule("ttkernel_ir", "TTKernel IR Bindings");
   mlir::ttmlir::python::populateTTKernelModule(ttkernel_ir);
   auto ttnn_ir = m.def_submodule("ttnn_ir", "TTNN IR Bindings");

--- a/python/ttmlir/dialects/ttir.py
+++ b/python/ttmlir/dialects/ttir.py
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from ._ttir_ops_gen import *
-from .._mlir_libs._ttmlir import register_dialect
+from .._mlir_libs._ttmlir import register_dialect, ttir_ir as ir

--- a/tools/scripts/parted.py
+++ b/tools/scripts/parted.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import ttmlir
+from ttmlir.ir import *
+from ttmlir.dialects import ttir, func, tt, tensor
+import sys
+
+uid = -1
+
+
+def filter_dialect_ops(module, dialects=["ttir", "ttnn"]):
+    for entry in module.body.operations:
+        if isinstance(entry, func.FuncOp):
+            for block in entry.body:
+                for op in block.operations:
+                    dialect = op.name.split(".")[0]
+                    if dialect in dialects:
+                        yield op
+
+
+def get_line_number(location):
+    global uid
+    try:
+        line = str(location).split(":")[2]
+        if int(line) > 1000000:
+            uid += 1
+            return "unknown" + str(uid)
+        else:
+            return line
+    except:
+        uid += 1
+        return "unknown" + str(uid)
+
+
+def get_entry_name(op):
+    original_entry_name = op.parent.attributes["sym_name"]
+    line_number = get_line_number(op.location)
+    entry_name = f"{original_entry_name}_{op.name}_{line_number}"
+    entry_name = entry_name.replace(".", "_").replace('"', "")
+    return entry_name
+
+
+def get_op_operands(op):
+    if "operandSegmentSizes" in op.attributes:
+        segments = op.attributes["operandSegmentSizes"]
+        assert len(segments) == 2
+        ins, outs = segments
+        assert ins + outs == len(op.operands)
+        return (op.operands[:ins], op.operands[ins:])
+    elif ttir.ir.is_dps(op):
+        return (op.operands[:-1], op.operands[-1:])
+    return (op.operands, [])
+
+
+def emit_op_as_entry_point(op, ip=None, loc=None):
+    results = op.results
+    op_inputs, op_outputs = get_op_operands(op)
+    input_types = [op_input.type for op_input in op_inputs]
+    output_types = [op_output.type for op_output in op_outputs]
+    result_types = [result.type for result in results]
+    entry = func.FuncOp(get_entry_name(op), (input_types, result_types), ip=ip, loc=loc)
+    entry_block = Block.create_at_start(entry.body, input_types)
+    with InsertionPoint(entry_block) as ip, Location.unknown() as loc:
+        operands = [arg for arg in entry_block.arguments]
+        for output_type in output_types:
+            operands.append(
+                tensor.empty(
+                    output_type.shape,
+                    output_type.element_type,
+                    encoding=output_type.encoding,
+                    ip=ip,
+                    loc=loc,
+                )
+            )
+        attrs = {attr.name: attr.attr for attr in op.attributes}
+        assert len(op.regions) == 0, "Regions are not supported yet."
+        new_op = Operation.create(
+            name=op.name,
+            results=result_types,
+            operands=operands,
+            attributes=attrs,
+            successors=op.successors,
+            regions=len(op.regions),
+            loc=loc,
+            ip=ip,
+        )
+        new_op.verify()
+
+        ret_op = Operation.create(
+            name="func.return",
+            results=[],
+            operands=[new_op.result],
+            loc=loc,
+            ip=ip,
+        )
+
+
+def parted(in_module):
+    cursor = Location.unknown(in_module.context)
+    out_module = Module.create(cursor)
+    with InsertionPoint(out_module.body) as ip, Location.unknown() as loc:
+        for op in filter_dialect_ops(in_module):
+            emit_op_as_entry_point(op, ip=ip, loc=loc)
+    return out_module
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="parted: a tool for filtering out operations from a module for isolated op testing"
+    )
+
+    parser.add_argument("mlir", type=str, help="Path to the mlir file")
+    args = parser.parse_args()
+
+    with Context() as ctx, open(args.mlir, "r") as mlir_fd:
+        ctx.allow_unregistered_dialects = True
+        ttir.register_dialect(ctx)
+        module = Module.parse(mlir_fd.read(), ctx)
+        print(parted(module))


### PR DESCRIPTION
The script parted.py can be run like:

    source env/activate
    python tools/scripts/parted.py test/ttmlir/Dialect/TTNN/mnist_sharding.mlir

It will walk every op in the file and break it out into separated entry functions suitable for unit testing ops in isolation. It should largely be TTIR/TTNN dialect agnostic.