### PR TITLE
Introduce a TTIR decomposition pass

### DIFF
--- a/include/ttmlir/Conversion/Passes.h
+++ b/include/ttmlir/Conversion/Passes.h
@@ -9,6 +9,7 @@
 #include "ttmlir/Conversion/ArithToStableHLO/ArithToStableHLO.h"
 #include "ttmlir/Conversion/StableHLOToTTIR/StableHLOToTTIR.h"
 #endif
+#include "ttmlir/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.h"
 #include "ttmlir/Conversion/TTIRToTTMetal/TTIRToTTMetal.h"
 #include "ttmlir/Conversion/TTIRToTTNN/TTIRToTTNN.h"
 #include "ttmlir/Conversion/TTKernelToEmitC/TTKernelToEmitC.h"

--- a/include/ttmlir/Conversion/Passes.td
+++ b/include/ttmlir/Conversion/Passes.td
@@ -26,6 +26,12 @@ def ConvertTosaToTTIR : Pass<"convert-tosa-to-ttir", "::mlir::ModuleOp"> {
   let dependentDialects = ["mlir::tt::ttir::TTIRDialect"];
 }
 
+def TTIRToTTIRDecomposition: Pass<"ttir-to-ttir-decomposition", "::mlir::ModuleOp"> {
+  let summary = "Decomposes TTIR operations into simpler TTIR operations.";
+  let constructor = "createTTIRToTTIRDecompositionPass()";
+  let dependentDialects = ["mlir::tt::ttir::TTIRDialect"];
+}
+
 def ConvertTTIRToTTNN: Pass<"convert-ttir-to-ttnn", "::mlir::ModuleOp"> {
   let summary = "Convert TTIR dialect to TTNN dialect.";
   let constructor = "createConvertTTIRToTTNNPass()";

--- a/include/ttmlir/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.h
+++ b/include/ttmlir/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.h
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_CONVERSION_TTIRTOTTIRDECOMPOSITION_TTIRTOTTIRDECOMPOSITION_H
+#define TTMLIR_CONVERSION_TTIRTOTTIRDECOMPOSITION_TTIRTOTTIRDECOMPOSITION_H
+
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir::tt {
+
+void populateTTIRToTTIRDecompositionPatterns(MLIRContext *ctx,
+                                             RewritePatternSet &patterns,
+                                             TypeConverter &typeConverter);
+
+std::unique_ptr<OperationPass<ModuleOp>> createTTIRToTTIRDecompositionPass();
+
+} // namespace mlir::tt
+
+#endif // TTMLIR_CONVERSION_TTIRTOTTIRDECOMPOSITION_TTIRTOTTIRDECOMPOSITION_H

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -653,8 +653,9 @@ def TTIR_ReshapeOp: TTIR_DPSOp<"reshape"> {
 def TTIR_SliceOp: TTIR_DPSOp<"slice"> {
     let summary = "Slice op.";
     let description = [{
-      Extract a portion of a tensor based on the specified start (`begins`), stop (`ends`), and step
-      indices for each dimension.
+      Extract a sub-tensor (slice) from the input tensor across one or more dimensions.
+      The `begins`, `ends`, and `step` attributes specify the start, stop, and step indices
+      for each dimension of the tensor.
     }];
 
     let arguments = (ins AnyRankedTensor:$input,
@@ -662,6 +663,31 @@ def TTIR_SliceOp: TTIR_DPSOp<"slice"> {
                          I32ArrayAttr:$begins,
                          I32ArrayAttr:$ends,
                          I32ArrayAttr:$step,
+                         TT_OperandConstraintArrayAttr:$operand_constraints);
+
+    let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      MutableOperandRange getDpsInitsMutable() { return getOutputMutable(); }
+    }];
+
+    let hasVerifier = 1;
+}
+
+def TTIR_IndexOp: TTIR_DPSOp<"index"> {
+    let summary = "Index op.";
+    let description = [{
+      Extract a sub-tensor (slice) from the input tensor along a specified dimension.
+      The `begin`, `end`, and `step` attributes define the start, stop, and step indices for the
+      selected dimension (`dim`) of the tensor.
+    }];
+
+    let arguments = (ins AnyRankedTensor:$input,
+                         AnyRankedTensor:$output,
+                         I32Attr:$dim,
+                         I32Attr:$begin,
+                         I32Attr:$end,
+                         I32Attr:$step,
                          TT_OperandConstraintArrayAttr:$operand_constraints);
 
     let results = (outs AnyRankedTensor:$result);

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(TTMLIRConversions INTERFACE)
 
 add_subdirectory(TosaToTTIR)
+add_subdirectory(TTIRToTTIRDecomposition)
 add_subdirectory(TTNNToEmitC)
 add_subdirectory(TTIRToTTNN)
 add_subdirectory(TTIRToTTMetal)
@@ -14,6 +15,7 @@ include_directories(${TTMLIR_SOURCE_DIR}/include)
 
 set(link_libs
 TTMLIRTosaToTTIR
+TTMLIRTTIRToTTIRDecomposition
 TTMLIRTTNNToEmitC
 TTMLIRTTIRToTTNN
 TTMLIRTTIRToTTMetal

--- a/lib/Conversion/TTIRToTTIRDecomposition/CMakeLists.txt
+++ b/lib/Conversion/TTIRToTTIRDecomposition/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_mlir_library(TTMLIRTTIRToTTIRDecomposition
+  TTIRToTTIRDecomposition.cpp
+  TTIRToTTIRDecompositionPass.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${PROJECT_SOURCE_DIR}/include/ttmlir/Conversion/TTIRToTTIR
+
+  DEPENDS
+  TTMLIRConversionPassIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRPass
+)

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.h"
+
+#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsTypes.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Traits.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Types.h"
+#include "mlir/IR/ValueRange.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/LogicalResult.h"
+#include <llvm/Support/raw_ostream.h>
+#include <mlir/Support/LLVM.h>
+
+using namespace mlir;
+using namespace mlir::tt;
+
+namespace mlir::tt {
+
+// Decompose IndexOp into SliceOp
+//
+// This transformation adjusts IndexOp attributes so that `begin`, `end`, and
+// `step` become arrays, where each array element corresponds to a dimension of
+// the input tensor. For dimensions other than the sliced dimension, default
+// values are used.
+//
+struct IndexToSliceConversionPattern
+    : public OpConversionPattern<ttir::IndexOp> {
+  using OpConversionPattern<ttir::IndexOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttir::IndexOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto inputType =
+        ::mlir::dyn_cast<mlir::RankedTensorType>(adaptor.getInput().getType());
+    if (!inputType || !inputType.hasRank())
+      return failure();
+
+    int64_t rank = inputType.getRank();
+    llvm::SmallVector<mlir::Attribute, 4> begins, ends, steps;
+
+    for (int64_t i = 0; i < rank; ++i) {
+      if (i == op.getDim()) {
+        begins.push_back(rewriter.getI32IntegerAttr(adaptor.getBegin()));
+        ends.push_back(rewriter.getI32IntegerAttr(adaptor.getEnd()));
+        steps.push_back(rewriter.getI32IntegerAttr(adaptor.getStep()));
+      } else {
+        begins.push_back(rewriter.getI32IntegerAttr(0));
+        ends.push_back(rewriter.getI32IntegerAttr(inputType.getDimSize(i)));
+        steps.push_back(rewriter.getI32IntegerAttr(1));
+      }
+    }
+
+    auto newOp = rewriter.create<ttir::SliceOp>(
+        op.getLoc(), op.getType(), adaptor.getInput(), adaptor.getOutput(),
+        rewriter.getArrayAttr(begins), rewriter.getArrayAttr(ends),
+        rewriter.getArrayAttr(steps), adaptor.getOperandConstraints());
+
+    rewriter.replaceOp(op, newOp.getResult());
+    return success();
+  }
+};
+
+void populateTTIRToTTIRDecompositionPatterns(MLIRContext *ctx,
+                                             RewritePatternSet &patterns,
+                                             TypeConverter &typeConverter) {
+  patterns.add<IndexToSliceConversionPattern>(typeConverter, ctx);
+}
+
+} // namespace mlir::tt

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecompositionPass.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecompositionPass.cpp
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.h"
+
+#include "mlir/Dialect/Func/Transforms/FuncConversions.h"
+#include "mlir/IR/BuiltinDialect.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIR.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNN.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/Tensor/IR/Tensor.h>
+
+using namespace mlir;
+using namespace mlir::tt;
+
+namespace mlir::tt::ttir {
+
+#define GEN_PASS_DEF_TTIRTOTTIRDECOMPOSITION
+#include "ttmlir/Conversion/Passes.h.inc"
+
+} // namespace mlir::tt::ttir
+
+namespace {
+
+struct TTIRToTTIRDecompositionPass
+    : public ttir::impl::TTIRToTTIRDecompositionBase<
+          TTIRToTTIRDecompositionPass> {
+  void runOnOperation() final {
+    mlir::ConversionTarget target(getContext());
+    target.addLegalDialect<ttir::TTIRDialect>();
+
+    target.addIllegalOp<ttir::IndexOp>();
+
+    TypeConverter typeConverter;
+    // All types map 1:1.
+    typeConverter.addConversion([](Type type) { return type; });
+
+    RewritePatternSet patterns(&getContext());
+    populateTTIRToTTIRDecompositionPatterns(&getContext(), patterns,
+                                            typeConverter);
+
+    // Apply partial conversion
+    //
+    if (failed(applyPartialConversion(getOperation(), target,
+                                      std::move(patterns)))) {
+      signalPassFailure();
+      return;
+    }
+  }
+};
+
+} // namespace
+
+namespace mlir::tt {
+
+std::unique_ptr<OperationPass<ModuleOp>> createTTIRToTTIRDecompositionPass() {
+  return std::make_unique<TTIRToTTIRDecompositionPass>();
+}
+
+} // namespace mlir::tt

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -211,7 +211,8 @@ public:
 private:
   bool shouldForceRowMajor(ttir::ToLayoutOp op) const {
     for (mlir::Operation *user : op.getResult().getUsers()) {
-      if (isa<ttir::Conv2dOp>(user) || isa<ttir::MaxPool2dOp>(user)) {
+      if (isa<ttir::Conv2dOp>(user) || isa<ttir::MaxPool2dOp>(user) ||
+          isa<ttir::SliceOp>(user)) {
         return true;
       }
     }

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -21,6 +21,8 @@ void createTTNNPipelineTTIRPasses(
   ttir::TTIRLoadSystemDescOptions systemDescOptions;
   systemDescOptions.path = options.systemDescPath;
 
+  pm.addPass(mlir::tt::createTTIRToTTIRDecompositionPass());
+
   // Inlines all private functions. I.e flattens the program into the main
   // function. Removes all private functions.
   pm.addPass(mlir::createInlinerPass());

--- a/lib/SharedLib/CMakeLists.txt
+++ b/lib/SharedLib/CMakeLists.txt
@@ -15,6 +15,7 @@ set(TTMLIR_LIBS
     MLIRTTIRDialect
     MLIRTTNNDialect
     MLIRTTKernelDialect
+    TTMLIRTTIRToTTIRDecomposition
     TTMLIRTTIRToTTNN
     TTMLIRTTIRToTTMetal
     MLIRTTMetalDialect

--- a/test/ttmlir/Dialect/TTIR/index/index_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/index/index_tests_negative.mlir
@@ -1,0 +1,145 @@
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+// Negative tests for index operation
+
+// Verify that the parsing fails if the begins attribute is not a 3D tensor
+#any_device_tile = #tt.operand_constraint<dram|l1|tile|any_device_tile>
+module attributes {} {
+  func.func @index_negative_invalid_shape(%arg0: tensor<bf16>) -> tensor<1xbf16> {
+    %0 = tensor.empty() : tensor<1xbf16>
+    // CHECK: error: 'ttir.index' op Input must be at least a 1D tensor
+    %1 = "ttir.index"(%arg0, %0) <{dim = 0: i32, begin = 0: i32, end = 0: i32, step = 1: i32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<bf16>, tensor<1xbf16>) -> tensor<1xbf16>
+    return %1 : tensor<1xbf16>
+  }
+}
+
+// Verify that the parsing fails if the dim is not in the rank range of the input tensor
+// -----
+#any_device_tile = #tt.operand_constraint<dram|l1|tile|any_device_tile>
+module attributes {} {
+  func.func @index_negative_invalid_begins(%arg0: tensor<3x128x64xbf16>) -> tensor<3x128x64xbf16> {
+    %0 = tensor.empty() : tensor<3x128x64xbf16>
+    // CHECK: error: 'ttir.index' op Invalid dimension index 3. Input tensor rank is 3
+    %1 = "ttir.index"(%arg0, %0) <{dim = 3 : i32, begin = 0: i32, end = 0: i32, step = 1: i32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<3x128x64xbf16>, tensor<3x128x64xbf16>) -> tensor<3x128x64xbf16>
+    return %1 : tensor<3x128x64xbf16>
+  }
+}
+
+// Verify that the parsing fails if the output type is not equal to the input tensor type
+// -----
+#any_device_tile = #tt.operand_constraint<dram|l1|tile|any_device_tile>
+module attributes {} {
+  func.func @index_negative_invalid_output_datatype(%arg0: tensor<3x128x64xbf16>) -> tensor<3x128x32xf32> {
+    %0 = tensor.empty() : tensor<3x128x32xf32>
+    // CHECK: error: 'ttir.index' op Output tensor must have the same element type as the input tensor
+    %1 = "ttir.index"(%arg0, %0) <{dim = 2 : i32, begin = 0: i32, end = 32: i32, step = 1: i32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<3x128x64xbf16>, tensor<3x128x32xf32>) -> tensor<3x128x32xf32>
+    return %1 : tensor<3x128x32xf32>
+  }
+}
+
+// Verify that the parsing fails if the output rank is not equal to the input tensor rank
+// -----
+#any_device_tile = #tt.operand_constraint<dram|l1|tile|any_device_tile>
+module attributes {} {
+  func.func @index_negative_input_output_rank_missmatch(%arg0: tensor<3x128x64xbf16>) -> tensor<3x64x64x1xbf16> {
+    %0 = tensor.empty() : tensor<3x64x64x1xbf16>
+    // CHECK: error: 'ttir.index' op Output tensor must have the same rank as the input tensor
+    %1 = "ttir.index"(%arg0, %0) <{dim = 1: i32, begin = 0: i32, end = 64: i32, step = 1: i32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<3x128x64xbf16>, tensor<3x64x64x1xbf16>) -> tensor<3x64x64x1xbf16>
+    return %1 : tensor<3x64x64x1xbf16>
+  }
+}
+
+// Verify that the parsing fails if the begin value exceeds positive limit
+// -----
+#any_device_tile = #tt.operand_constraint<dram|l1|tile|any_device_tile>
+module attributes {} {
+  func.func @index_negative_invalid_begin_positive(%arg0: tensor<10x3x128x64xbf16>) -> tensor<10x1x128x64xbf16> {
+    %0 = tensor.empty() : tensor<10x1x128x64xbf16>
+    // CHECK: error: 'ttir.index' op Invalid begin index for dimension 1. Expected value in range [-3, 3), got 3. Input shape: (10, 3, 128, 64)
+    %1 = "ttir.index"(%arg0, %0) <{dim = 1: i32, begin = 3: i32, end = 3: i32, step = 1: i32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<10x3x128x64xbf16>, tensor<10x1x128x64xbf16>) -> tensor<10x1x128x64xbf16>
+    return %1 : tensor<10x1x128x64xbf16>
+  }
+}
+
+// Verify that the parsing fails if the begin value exceeds negative limit
+// -----
+#any_device_tile = #tt.operand_constraint<dram|l1|tile|any_device_tile>
+module attributes {} {
+  func.func @index_negative_invalid_begin_negative(%arg0: tensor<10x3x128x64xbf16>) -> tensor<10x3x64x64xbf16> {
+    %0 = tensor.empty() : tensor<10x3x64x64xbf16>
+    // CHECK: error: 'ttir.index' op Invalid begin index for dimension 2. Expected value in range [-128, 128), got -129. Input shape: (10, 3, 128, 64)
+    %1 = "ttir.index"(%arg0, %0) <{dim = 2: i32, begin = -129: i32, end = 64: i32, step = 1: i32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<10x3x128x64xbf16>, tensor<10x3x64x64xbf16>) -> tensor<10x3x64x64xbf16>
+    return %1 : tensor<10x3x64x64xbf16>
+  }
+}
+
+// Verify that the parsing fails if the end value exceeds positive limit
+// -----
+#any_device_tile = #tt.operand_constraint<dram|l1|tile|any_device_tile>
+module attributes {} {
+  func.func @index_negative_invalid_end_positive(%arg0: tensor<10x3x128x64xbf16>) -> tensor<10x3x128x64xbf16> {
+    %0 = tensor.empty() : tensor<10x3x128x64xbf16>
+    // CHECK: error: 'ttir.index' op Invalid end index for dimension 1. Expected value in range [-3, 3], got 4. Input shape: (10, 3, 128, 64)
+    %1 = "ttir.index"(%arg0, %0) <{dim = 1: i32, begin = 0: i32, end = 4: i32, step = 1: i32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<10x3x128x64xbf16>, tensor<10x3x128x64xbf16>) -> tensor<10x3x128x64xbf16>
+    return %1 : tensor<10x3x128x64xbf16>
+  }
+}
+
+// Verify that the parsing fails if the end value exceeds positive limit
+// -----
+#any_device_tile = #tt.operand_constraint<dram|l1|tile|any_device_tile>
+module attributes {} {
+  func.func @index_negative_invalid_end_negative(%arg0: tensor<10x3x128x64xbf16>) -> tensor<10x3x128x64xbf16> {
+    %0 = tensor.empty() : tensor<10x3x128x64xbf16>
+    // CHECK: error: 'ttir.index' op Invalid end index for dimension 1. Expected value in range [-3, 3], got -4. Input shape: (10, 3, 128, 64)
+    %1 = "ttir.index"(%arg0, %0) <{dim = 1: i32, begin = -1: i32, end = -4: i32, step = -1: i32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<10x3x128x64xbf16>, tensor<10x3x128x64xbf16>) -> tensor<10x3x128x64xbf16>
+    return %1 : tensor<10x3x128x64xbf16>
+  }
+}
+
+// Verify that the parsing fails if the step value is equal to zero
+// -----
+#any_device_tile = #tt.operand_constraint<dram|l1|tile|any_device_tile>
+module attributes {} {
+  func.func @index_negative_step_is_zero(%arg0: tensor<10x3x128x64xbf16>) -> tensor<10x3x128x64xbf16> {
+    %0 = tensor.empty() : tensor<10x3x128x64xbf16>
+    // CHECK: error: 'ttir.index' op Step value for dimension 1 cannot be zero
+    %1 = "ttir.index"(%arg0, %0) <{dim = 1: i32, begin = -1: i32, end = -3: i32, step = 0: i32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<10x3x128x64xbf16>, tensor<10x3x128x64xbf16>) -> tensor<10x3x128x64xbf16>
+    return %1 : tensor<10x3x128x64xbf16>
+  }
+}
+
+// Verify that the parsing fails if the begin index is greater than end and step is positive
+// -----
+#any_device_tile = #tt.operand_constraint<dram|l1|tile|any_device_tile>
+module attributes {} {
+  func.func @index_negative_begin_greater_than_end_positive_step(%arg0: tensor<10x3x128x64xbf16>) -> tensor<10x3x128x64xbf16> {
+    %0 = tensor.empty() : tensor<10x3x128x64xbf16>
+    // CHECK: error: 'ttir.index' op For positive step, begin index must be less than or equal to end index for dimension 2. Got begin: 2, end: 0, step: 1, input shape: (10, 3, 128, 64)
+    %1 = "ttir.index"(%arg0, %0) <{dim = 2: i32, begin = 2: i32, end = 0: i32, step = 1: i32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<10x3x128x64xbf16>, tensor<10x3x128x64xbf16>) -> tensor<10x3x128x64xbf16>
+    return %1 : tensor<10x3x128x64xbf16>
+  }
+}
+
+// Verify that the parsing fails if the end index is greater than begin and step is negative
+// -----
+#any_device_tile = #tt.operand_constraint<dram|l1|tile|any_device_tile>
+module attributes {} {
+  func.func @index_negative_begin_less_than_end_negative_step(%arg0: tensor<10x3x128x64xbf16>) -> tensor<10x3x128x64xbf16> {
+    %0 = tensor.empty() : tensor<10x3x128x64xbf16>
+    // CHECK: error: 'ttir.index' op For negative step, begin index must be greater than or equal to end index for dimension 3. Got begin: 0, end: 64, step: -1, input shape: (10, 3, 128, 64)
+    %1 = "ttir.index"(%arg0, %0) <{dim = 3: i32, begin = 0: i32, end = 64: i32, step = -1: i32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<10x3x128x64xbf16>, tensor<10x3x128x64xbf16>) -> tensor<10x3x128x64xbf16>
+    return %1 : tensor<10x3x128x64xbf16>
+  }
+}
+
+// Verify that the parsing fails if there is missmatch in output dimension
+// -----
+#any_device_tile = #tt.operand_constraint<dram|l1|tile|any_device_tile>
+module attributes {} {
+  func.func @index_negative_invalid_output_shape(%arg0: tensor<10x3x128x64xbf16>) -> tensor<10x3x128x32xbf16> {
+    %0 = tensor.empty() : tensor<10x3x128x32xbf16>
+    // CHECK: error: 'ttir.index' op Mismatch in dimension 3 of the output tensor: expected size 16, but got 32
+    %1 = "ttir.index"(%arg0, %0) <{dim = 3: i32, begin = 0: i32, end = 64: i32, step = 4: i32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<10x3x128x64xbf16>, tensor<10x3x128x32xbf16>) -> tensor<10x3x128x32xbf16>
+    return %1 : tensor<10x3x128x32xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/index/index_tests_positive.mlir
+++ b/test/ttmlir/Dialect/TTIR/index/index_tests_positive.mlir
@@ -1,0 +1,59 @@
+// RUN: ttmlir-opt %s | FileCheck %s
+#any_device_tile = #tt.operand_constraint<dram|l1|tile|any_device_tile>
+module attributes {} {
+  func.func @index_1d(%arg0: tensor<64xbf16>) -> tensor<32xbf16> {
+    %0 = tensor.empty() : tensor<32xbf16>
+    // CHECK: %[[C:.*]] = "ttir.index"[[C:.*]]
+    %1 = "ttir.index"(%arg0, %0) <{dim = 0: i32, begin = 0: i32, end = 32: i32, step = 1: i32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<64xbf16>, tensor<32xbf16>) -> tensor<32xbf16>
+    return %1 : tensor<32xbf16>
+  }
+
+  func.func @index_1d_step(%arg0: tensor<64xbf16>) -> tensor<16xbf16> {
+    %0 = tensor.empty() : tensor<16xbf16>
+    // CHECK: %[[C:.*]] = "ttir.index"[[C:.*]]
+    %1 = "ttir.index"(%arg0, %0) <{dim = 0: i32, begin = 0: i32, end = 32: i32, step = 2: i32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<64xbf16>, tensor<16xbf16>) -> tensor<16xbf16>
+    return %1 : tensor<16xbf16>
+  }
+
+  func.func @index_2d(%arg0: tensor<128x64xbf16>) -> tensor<128x32xbf16> {
+    %0 = tensor.empty() : tensor<128x32xbf16>
+    // CHECK: %[[C:.*]] = "ttir.index"[[C:.*]]
+    %1 = "ttir.index"(%arg0, %0) <{dim = 1: i32, begin = 0: i32, end = 32: i32, step = 1: i32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<128x64xbf16>, tensor<128x32xbf16>) -> tensor<128x32xbf16>
+    return %1 : tensor<128x32xbf16>
+  }
+
+  func.func @index_2d_step(%arg0: tensor<128x64xbf16>) -> tensor<128x16xbf16> {
+    %0 = tensor.empty() : tensor<128x16xbf16>
+    // CHECK: %[[C:.*]] = "ttir.index"[[C:.*]]
+    %1 = "ttir.index"(%arg0, %0) <{dim = 1: i32, begin = 32: i32, end = 64: i32, step = 2: i32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<128x64xbf16>, tensor<128x16xbf16>) -> tensor<128x16xbf16>
+    return %1 : tensor<128x16xbf16>
+  }
+
+  func.func @index_3d(%arg0: tensor<3x128x64xbf16>) -> tensor<3x128x32xbf16> {
+    %0 = tensor.empty() : tensor<3x128x32xbf16>
+    // CHECK: %[[C:.*]] = "ttir.index"[[C:.*]]
+    %1 = "ttir.index"(%arg0, %0) <{dim = 2: i32, begin = 0: i32, end = 32: i32, step = 1: i32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<3x128x64xbf16>, tensor<3x128x32xbf16>) -> tensor<3x128x32xbf16>
+    return %1 : tensor<3x128x32xbf16>
+  }
+
+  func.func @index_3d_step(%arg0: tensor<3x128x64xbf16>) -> tensor<3x128x8xbf16> {
+    %0 = tensor.empty() : tensor<3x128x8xbf16>
+    // CHECK: %[[C:.*]] = "ttir.index"[[C:.*]]
+    %1 = "ttir.index"(%arg0, %0) <{dim = 2: i32, begin = -1: i32, end = 0: i32, step = -8: i32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<3x128x64xbf16>, tensor<3x128x8xbf16>) -> tensor<3x128x8xbf16>
+    return %1 : tensor<3x128x8xbf16>
+  }
+
+  func.func @index_4d(%arg0: tensor<10x3x128x64xbf16>) -> tensor<10x3x128x32xbf16> {
+    %0 = tensor.empty() : tensor<10x3x128x32xbf16>
+    // CHECK: %[[C:.*]] = "ttir.index"[[C:.*]]
+    %1 = "ttir.index"(%arg0, %0) <{dim = 3: i32, begin = 0: i32, end = 32: i32, step = 1: i32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<10x3x128x64xbf16>, tensor<10x3x128x32xbf16>) -> tensor<10x3x128x32xbf16>
+    return %1 : tensor<10x3x128x32xbf16>
+  }
+
+  func.func @index_4d_step(%arg0: tensor<10x3x128x64xbf16>) -> tensor<10x3x128x24xbf16> {
+    %0 = tensor.empty() : tensor<10x3x128x24xbf16>
+    // CHECK: %[[C:.*]] = "ttir.index"[[C:.*]]
+    %1 = "ttir.index"(%arg0, %0) <{dim = 3: i32, begin = 0: i32, end = -16: i32, step = 2: i32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<10x3x128x64xbf16>, tensor<10x3x128x24xbf16>) -> tensor<10x3x128x24xbf16>
+    return %1 : tensor<10x3x128x24xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/slice/slice_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/slice/slice_tests_negative.mlir
@@ -88,7 +88,7 @@ module attributes {} {
 // -----
 #any_device_tile = #tt.operand_constraint<dram|l1|tile|any_device_tile>
 module attributes {} {
-  func.func @slice_negative_invalid_begin_positive(%arg0: tensor<10x3x128x64xbf16>) -> tensor<4x1x16x8xbf16> {
+  func.func @slice_negative_invalid_begin_negative(%arg0: tensor<10x3x128x64xbf16>) -> tensor<4x1x16x8xbf16> {
     %0 = tensor.empty() : tensor<4x1x16x8xbf16>
     // CHECK: error: 'ttir.slice' op Invalid begin index for dimension 2. Expected value in range [-128, 128), got -129. Input shape: (10, 3, 128, 64)
     %1 = "ttir.slice"(%arg0, %0) <{begins = [0: i32, 0: i32, -129: i32, 32: i32], ends = [10: i32, 3: i32, 128: i32, 64: i32], step = [3: i32, 3: i32, 8: i32, 4: i32], operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<10x3x128x64xbf16>, tensor<4x1x16x8xbf16>) -> tensor<4x1x16x8xbf16>
@@ -108,7 +108,7 @@ module attributes {} {
   }
 }
 
-// Verify that the parsing fails if the end value exceeds positive limit
+// Verify that the parsing fails if the end value exceeds negative limit
 // -----
 #any_device_tile = #tt.operand_constraint<dram|l1|tile|any_device_tile>
 module attributes {} {

--- a/test/ttmlir/Dialect/TTIR/slice/slice_tests_positive.mlir
+++ b/test/ttmlir/Dialect/TTIR/slice/slice_tests_positive.mlir
@@ -8,7 +8,7 @@ module attributes {} {
     return %1 : tensor<32xbf16>
   }
 
-  func.func @slice_1d_step_positive(%arg0: tensor<64xbf16>) -> tensor<16xbf16> {
+  func.func @slice_1d_step(%arg0: tensor<64xbf16>) -> tensor<16xbf16> {
     %0 = tensor.empty() : tensor<16xbf16>
     // CHECK: %[[C:.*]] = "ttir.slice"[[C:.*]]
     %1 = "ttir.slice"(%arg0, %0) <{begins = [0: i32], ends = [64: i32], step = [4: i32], operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<64xbf16>, tensor<16xbf16>) -> tensor<16xbf16>

--- a/test/ttmlir/Silicon/TTNN/simple_index.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_index.mlir
@@ -1,0 +1,12 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+#any_device_tile = #tt.operand_constraint<dram|l1|interleaved>
+module attributes {} {
+  func.func @forward(%arg0: tensor<4x32x32xbf16>) -> tensor<4x32x16xbf16> {
+    %0 = tensor.empty() : tensor<4x32x16xbf16>
+    // CHECK: %[[C:.*]] = "ttnn.slice"[[C:.*]]
+    %1 = "ttir.index"(%arg0, %0) <{dim = 2: i32, begin = 0: i32, end = 32: i32, step = 2: i32, operand_constraints = [#any_device_tile, #any_device_tile]}> : (tensor<4x32x32xbf16>, tensor<4x32x16xbf16>) -> tensor<4x32x16xbf16>
+    return %1 : tensor<4x32x16xbf16>
+  }
+}


### PR DESCRIPTION
- Create a  TTIR decomposition pass in mlir (see more here: https://github.com/tenstorrent/tt-mlir/issues/914)
- Implement an IndexOp that will be decomposed into a SliceOp. I chose not to use DRR in mlir for the decomposition of IndexOp since it involves modifying its attributes to adapt to SliceOp, and DRR is not very flexible in that regard. However, I plan to use DRR in the future for simpler decompositions.