### PR TITLE
[DebugExp] Set Clang as default llvm toolchain compiler.

### DIFF
--- a/env/CMakeLists.txt
+++ b/env/CMakeLists.txt
@@ -43,8 +43,8 @@ ExternalProject_Add(
     -DPython3_FIND_VIRTUALENV=ONLY
     -DPython3_EXECUTABLE=${TTMLIR_TOOLCHAIN_DIR}/venv/bin/python
     -DCMAKE_INSTALL_PREFIX=${TTMLIR_TOOLCHAIN_DIR}
-    -DCMAKE_C_COMPILER=clang-17
-    -DCMAKE_CXX_COMPILER=clang++-17
+    -DCMAKE_C_COMPILER=clang
+    -DCMAKE_CXX_COMPILER=clang++
     -DLLVM_ENABLE_PROJECTS=mlir
     -DLLVM_INSTALL_UTILS=ON
     # Build shared libraries

--- a/env/CMakeLists.txt
+++ b/env/CMakeLists.txt
@@ -43,6 +43,8 @@ ExternalProject_Add(
     -DPython3_FIND_VIRTUALENV=ONLY
     -DPython3_EXECUTABLE=${TTMLIR_TOOLCHAIN_DIR}/venv/bin/python
     -DCMAKE_INSTALL_PREFIX=${TTMLIR_TOOLCHAIN_DIR}
+    -DCMAKE_C_COMPILER=clang-17
+    -DCMAKE_CXX_COMPILER=clang++-17
     -DLLVM_ENABLE_PROJECTS=mlir
     -DLLVM_INSTALL_UTILS=ON
     # Build shared libraries


### PR DESCRIPTION
I have root caused LLDB hanging/crashing issue to be caused by "LLVMlib.so DW_TAG_member extends beyond the bounds error" which seems to be caused by a default C++ compiler on Ubuntu. 
Resolved by using Clang for compiling LLVM toolchain which aligns with how we build tt-mlir.