### PR TITLE
Container retention

### DIFF
--- a/.github/workflows/container_retention.yml
+++ b/.github/workflows/container_retention.yml
@@ -1,7 +1,7 @@
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 1 * *"  # run every 1 day of a month
+    - cron: "0 0 * * *"  # run every day at midnight
 
 jobs:
   delete-package-versions:

--- a/.github/workflows/container_retention.yml
+++ b/.github/workflows/container_retention.yml
@@ -1,7 +1,8 @@
 on:
   push:
-  # schedule:
-  #   - cron: "0 0 * * *"  # run every day at midnight, utc
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 1 * *"  # run every 1 day of a month
 
 jobs:
   delete-package-versions:
@@ -14,4 +15,4 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
           image-names: "tt-mlir*"
           cut-off: 4w
-          dry-run: true
+          dry-run: false

--- a/.github/workflows/container_retention.yml
+++ b/.github/workflows/container_retention.yml
@@ -1,5 +1,4 @@
 on:
-  push:
   workflow_dispatch:
   schedule:
     - cron: "0 0 1 * *"  # run every 1 day of a month

--- a/.github/workflows/container_retention.yml
+++ b/.github/workflows/container_retention.yml
@@ -1,0 +1,17 @@
+on:
+  push:
+  # schedule:
+  #   - cron: "0 0 * * *"  # run every day at midnight, utc
+
+jobs:
+  delete-package-versions:
+    name: Delete package versions older than 4 weeks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: snok/container-retention-policy@v3.0.0
+        with:
+          account: tenstorrent
+          token: ${{ secrets.GH_TOKEN }}
+          image-names: "tt-mlir*"
+          cut-off: 4w
+          dry-run: true

--- a/.github/workflows/nightly-uplift.yml
+++ b/.github/workflows/nightly-uplift.yml
@@ -5,7 +5,7 @@ name: Nighty Uplift
 
 on:
   schedule:
-    - cron: '0 8 * * *'  # Runs at 08:00 UTC every day
+    - cron: "0 0 * * *"  # run every day at midnight
   workflow_dispatch:  # Manual trigger
 
 jobs:


### PR DESCRIPTION
Set up a container retention policy to clean up images older than one month in GitHub Container Registry (GHCR). 

The Docker build process uses caching and will automatically create images if they don't exist, so there’s no issue if a repository remains unchanged for a month. This policy guarantees that we’ll have a fresh image at least once a month.

Additionally, reschedule the nightly uplift to run at midnight UTC.