### PR TITLE
Add support for get_dimension_size op

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -98,6 +98,9 @@ def TTIR_GetDimensionSizeOp : TTIR_Op<"get_dimension_size"> {
                        I32Attr:$dimension);
 
   let results = (outs AnyRankedTensor:$result);
+
+  let hasFolder = 1;
+  let hasVerifier = 1;
 }
 
 def TTIR_ToLayoutOp : TTIR_Op<"to_layout", [DestinationStyleOpInterface, TTIROpInterface]> {

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -98,6 +98,8 @@ def TTIR_GetDimensionSizeOp : TTIR_Op<"get_dimension_size"> {
                        I32Attr:$dimension);
 
   let results = (outs AnyRankedTensor:$result);
+
+  let hasFolder = 1;  
 }
 
 def TTIR_ToLayoutOp : TTIR_Op<"to_layout", [DestinationStyleOpInterface, TTIROpInterface]> {

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -98,8 +98,6 @@ def TTIR_GetDimensionSizeOp : TTIR_Op<"get_dimension_size"> {
                        I32Attr:$dimension);
 
   let results = (outs AnyRankedTensor:$result);
-
-  let hasFolder = 1;  
 }
 
 def TTIR_ToLayoutOp : TTIR_Op<"to_layout", [DestinationStyleOpInterface, TTIROpInterface]> {

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -84,6 +84,22 @@ def TTIR_GenericOp : TTIR_DPSOp<"generic", [AttrSizedOperandSegments]> {
     }];
 }
 
+def TTIR_GetDimensionSizeOp : TTIR_Op<"get_dimension_size"> {
+  let summary = "GetDimensionSize op.";
+  let description = [{
+      Produces the size of the given `dimension` of the `operand`.
+
+      Example:
+        %operand: [[3, 2, 7], [1, 4, 4]]
+        "ttir.get_dimension_size"(%operand, value = dense<0>, %out) -> %out: [[3]]
+  }];
+
+  let arguments = (ins AnyRankedTensor:$operand,
+                       I32Attr:$dimension);
+
+  let results = (outs AnyRankedTensor:$result);
+}
+
 def TTIR_ToLayoutOp : TTIR_Op<"to_layout", [DestinationStyleOpInterface, TTIROpInterface]> {
     let summary = "Layout op.";
     let description = [{

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -307,12 +307,6 @@ public:
   matchAndRewrite(mlir::stablehlo::GetDimensionSizeOp srcOp,
                   mlir::stablehlo::GetDimensionSizeOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-
-    LogicalResult legalityResult = checkBasicLegality(srcOp, rewriter);
-    if (!legalityResult.succeeded()) {
-      return legalityResult;
-    }
-
     IntegerType intType = IntegerType::get(getContext(), 32);
     RankedTensorType outputType = RankedTensorType::get({1}, intType);
     mlir::OpBuilder builder(getContext());
@@ -321,21 +315,6 @@ public:
 
     rewriter.replaceOpWithNewOp<mlir::tt::ttir::GetDimensionSizeOp>(
         srcOp, outputType, srcOp.getOperand(), dimension_attr);
-
-    return success();
-  }
-
-private:
-  LogicalResult checkBasicLegality(mlir::stablehlo::GetDimensionSizeOp &srcOp,
-                                   ConversionPatternRewriter &rewriter) const {
-    if (srcOp.getOperand().getType().getShape().empty() &&
-        !srcOp.getOperand().getType().getElementType().isIntOrFloat()) {
-      return rewriter.notifyMatchFailure(srcOp, "Unsupported element type.");
-    }
-    if (!mlir::cast<RankedTensorType>(srcOp.getOperand().getType())) {
-      return rewriter.notifyMatchFailure(srcOp,
-                                         "Unsupported first operator type.");
-    }
 
     return success();
   }

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -296,6 +296,51 @@ private:
   }
 };
 
+class StableHLOToTTIRGetDimensionSizeOpConversionPattern
+    : public OpConversionPattern<mlir::stablehlo::GetDimensionSizeOp> {
+
+  using OpConversionPattern<
+      mlir::stablehlo::GetDimensionSizeOp>::OpConversionPattern;
+
+public:
+  LogicalResult
+  matchAndRewrite(mlir::stablehlo::GetDimensionSizeOp srcOp,
+                  mlir::stablehlo::GetDimensionSizeOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    LogicalResult legalityResult = checkBasicLegality(srcOp, rewriter);
+    if (!legalityResult.succeeded()) {
+      return legalityResult;
+    }
+
+    IntegerType intType = IntegerType::get(getContext(), 32);
+    RankedTensorType outputType = RankedTensorType::get({1}, intType);
+    mlir::OpBuilder builder(getContext());
+    IntegerAttr dimension_attr = builder.getIntegerAttr(
+        intType, static_cast<int32_t>(srcOp.getDimension()));
+
+    rewriter.replaceOpWithNewOp<mlir::tt::ttir::GetDimensionSizeOp>(
+        srcOp, outputType, srcOp.getOperand(), dimension_attr);
+
+    return success();
+  }
+
+private:
+  LogicalResult checkBasicLegality(mlir::stablehlo::GetDimensionSizeOp &srcOp,
+                                   ConversionPatternRewriter &rewriter) const {
+    if (srcOp.getOperand().getType().getShape().empty() &&
+        !srcOp.getOperand().getType().getElementType().isIntOrFloat()) {
+      return rewriter.notifyMatchFailure(srcOp, "Unsupported element type.");
+    }
+    if (!mlir::cast<RankedTensorType>(srcOp.getOperand().getType())) {
+      return rewriter.notifyMatchFailure(srcOp,
+                                         "Unsupported first operator type.");
+    }
+
+    return success();
+  }
+};
+
 class StableHLOToTTIRConstantOpConversionPattern
     : public OpConversionPattern<mlir::stablehlo::ConstantOp> {
 
@@ -973,6 +1018,13 @@ void addMatmulOpsConversionPatterns(MLIRContext *ctx,
                                                              ctx);
 }
 
+void addGetDimensionSizeOpsConversionPatterns(MLIRContext *ctx,
+                                              RewritePatternSet &patterns,
+                                              TypeConverter &typeConverter) {
+  patterns.add<StableHLOToTTIRGetDimensionSizeOpConversionPattern>(
+      typeConverter, ctx);
+}
+
 void addTensorCreationOpsConversionPatterns(MLIRContext *ctx,
                                             RewritePatternSet &patterns,
                                             TypeConverter &typeConverter) {
@@ -1048,6 +1100,7 @@ void populateStableHLOToTTIRPatterns(MLIRContext *ctx,
   addReduceOpsConversionPatterns(ctx, patterns, typeConverter);
   addTransposeOpsConversionPatterns(ctx, patterns, typeConverter);
   addMatmulOpsConversionPatterns(ctx, patterns, typeConverter);
+  addGetDimensionSizeOpsConversionPatterns(ctx, patterns, typeConverter);
   addTensorCreationOpsConversionPatterns(ctx, patterns, typeConverter);
   addBroadcastOpConversionPattern(ctx, patterns, typeConverter);
   addConv2dOpConversionPattern(ctx, patterns, typeConverter);

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -406,11 +406,62 @@ public:
   }
 };
 
+class GetDimensionSizeToConstantConversionPattern : 
+    public OpConversionPattern<ttir::GetDimensionSizeOp>
+{
+public:
+  using OpConversionPattern<ttir::GetDimensionSizeOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttir::GetDimensionSizeOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    LogicalResult legalityResult = checkBasicLegality(op, rewriter);
+    if (!legalityResult.succeeded()) {
+      return legalityResult;
+    }
+    const RankedTensorType inputTensorType =
+        mlir::cast<RankedTensorType>(op.getOperand().getType());
+
+    int64_t dimensionIndex = op.getDimension();
+
+    if (dimensionIndex >=
+        static_cast<int64_t>(inputTensorType.getShape().size())) {
+      return failure();
+    };
+    int32_t dimSize = inputTensorType.getShape()[dimensionIndex];
+
+    mlir::ShapedType valueType = mlir::cast<mlir::ShapedType>(op.getType());
+
+    mlir::ElementsAttr valueAttr = mlir::DenseElementsAttr::get<int>(valueType, dimSize);
+
+    rewriter.replaceOpWithNewOp<mlir::tt::ttir::ConstantOp>(op, valueType, valueAttr);
+
+    return success();
+  }
+
+private:
+  LogicalResult checkBasicLegality(::ttir::GetDimensionSizeOp &op,
+                                   ConversionPatternRewriter &rewriter) const {
+    if (op.getOperand().getType().getShape().empty() &&
+        !op.getOperand().getType().getElementType().isIntOrFloat()) {
+      return rewriter.notifyMatchFailure(op, "Unsupported element type.");
+    }
+    if (!mlir::cast<RankedTensorType>(op.getOperand().getType())) {
+      return rewriter.notifyMatchFailure(op,
+                                         "Unsupported first operator type.");
+    }
+
+    return success();
+  }
+};
+
 void populateTTIRToTTIRDecompositionPatterns(MLIRContext *ctx,
                                              RewritePatternSet &patterns,
                                              TypeConverter &typeConverter) {
   patterns.add<IndexToSliceConversionPattern>(typeConverter, ctx);
   patterns.add<ConvolutionToConv2dPattern>(typeConverter, ctx);
+  patterns.add<GetDimensionSizeToConstantConversionPattern>(typeConverter, ctx);
 }
 
 } // namespace mlir::tt

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -406,9 +406,8 @@ public:
   }
 };
 
-class GetDimensionSizeToConstantConversionPattern : 
-    public OpConversionPattern<ttir::GetDimensionSizeOp>
-{
+class GetDimensionSizeToConstantConversionPattern
+    : public OpConversionPattern<ttir::GetDimensionSizeOp> {
 public:
   using OpConversionPattern<ttir::GetDimensionSizeOp>::OpConversionPattern;
 
@@ -416,41 +415,20 @@ public:
   matchAndRewrite(ttir::GetDimensionSizeOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    LogicalResult legalityResult = checkBasicLegality(op, rewriter);
-    if (!legalityResult.succeeded()) {
-      return legalityResult;
-    }
     const RankedTensorType inputTensorType =
         mlir::cast<RankedTensorType>(op.getOperand().getType());
 
     int64_t dimensionIndex = op.getDimension();
 
-    if (dimensionIndex >=
-        static_cast<int64_t>(inputTensorType.getShape().size())) {
-      return failure();
-    };
     int32_t dimSize = inputTensorType.getShape()[dimensionIndex];
 
     mlir::ShapedType valueType = mlir::cast<mlir::ShapedType>(op.getType());
 
-    mlir::ElementsAttr valueAttr = mlir::DenseElementsAttr::get<int>(valueType, dimSize);
+    mlir::ElementsAttr valueAttr =
+        mlir::DenseElementsAttr::get<int>(valueType, dimSize);
 
-    rewriter.replaceOpWithNewOp<mlir::tt::ttir::ConstantOp>(op, valueType, valueAttr);
-
-    return success();
-  }
-
-private:
-  LogicalResult checkBasicLegality(::ttir::GetDimensionSizeOp &op,
-                                   ConversionPatternRewriter &rewriter) const {
-    if (op.getOperand().getType().getShape().empty() &&
-        !op.getOperand().getType().getElementType().isIntOrFloat()) {
-      return rewriter.notifyMatchFailure(op, "Unsupported element type.");
-    }
-    if (!mlir::cast<RankedTensorType>(op.getOperand().getType())) {
-      return rewriter.notifyMatchFailure(op,
-                                         "Unsupported first operator type.");
-    }
+    rewriter.replaceOpWithNewOp<mlir::tt::ttir::ConstantOp>(op, valueType,
+                                                            valueAttr);
 
     return success();
   }

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecompositionPass.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecompositionPass.cpp
@@ -48,6 +48,7 @@ struct TTIRToTTIRDecompositionPass
     // These are the ops we intend to remove entirely with this pass
     target.addIllegalOp<ttir::IndexOp>();
     target.addIllegalOp<ttir::ConvolutionOp>();
+    target.addIllegalOp<ttir::GetDimensionSizeOp>();
 
     TypeConverter typeConverter;
     // All types map 1:1.

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -486,61 +486,6 @@ public:
   }
 };
 
-class GetDimensionSizeOpConversionPattern
-    : public OpConversionPattern<ttir::GetDimensionSizeOp> {
-public:
-  using OpConversionPattern<ttir::GetDimensionSizeOp>::OpConversionPattern;
-
-  LogicalResult
-  matchAndRewrite(ttir::GetDimensionSizeOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-
-    LogicalResult legalityResult = checkBasicLegality(op, rewriter);
-    if (!legalityResult.succeeded()) {
-      return legalityResult;
-    }
-    const RankedTensorType inputTensorType =
-        mlir::cast<RankedTensorType>(op.getOperand().getType());
-
-    int64_t dimensionIndex = op.getDimension();
-
-    if (dimensionIndex >=
-        static_cast<int64_t>(inputTensorType.getShape().size())) {
-      return failure();
-    }
-
-    int32_t dimSize = inputTensorType.getShape()[dimensionIndex];
-    Type output_type =
-        this->getTypeConverter()->convertType(op->getResult(0).getType());
-    Value device = getOrInsertDevice(rewriter, op);
-
-    if (dimSize == 0) {
-      rewriter.replaceOpWithNewOp<tensor::EmptyOp>(op, output_type, device);
-    } else {
-      ::mlir::FloatAttr fillValueAttr = rewriter.getF32FloatAttr(dimSize);
-      rewriter.replaceOpWithNewOp<ttnn::FullOp>(op, output_type, device,
-                                                fillValueAttr);
-    }
-
-    return success();
-  }
-
-private:
-  LogicalResult checkBasicLegality(::ttir::GetDimensionSizeOp &op,
-                                   ConversionPatternRewriter &rewriter) const {
-    if (op.getOperand().getType().getShape().empty() &&
-        !op.getOperand().getType().getElementType().isIntOrFloat()) {
-      return rewriter.notifyMatchFailure(op, "Unsupported element type.");
-    }
-    if (!mlir::cast<RankedTensorType>(op.getOperand().getType())) {
-      return rewriter.notifyMatchFailure(op,
-                                         "Unsupported first operator type.");
-    }
-
-    return success();
-  }
-};
-
 class ConstantOpConversionPattern
     : public OpConversionPattern<ttir::ConstantOp> {
 public:
@@ -963,8 +908,7 @@ void populateTTIRToTTNNPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
            Conv2dOpConversionPattern,
            MaxPool2dOpConversionPattern,
            SubtractOpConversionPattern,
-           AllGatherOpConversionPattern,
-           GetDimensionSizeOpConversionPattern
+           AllGatherOpConversionPattern
            >(typeConverter, ctx);
   // ANCHOR_END: op_rewriter_pattern_set
   // clang-format on

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNNPass.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNNPass.cpp
@@ -42,8 +42,6 @@ struct ConvertTTIRToTTNNPass
     typeConverter.addConversion([](Type type) { return type; });
 
     RewritePatternSet patterns(&getContext());
-    populateTTIRToTTIRDecompositionPatterns(&getContext(), patterns,
-                                            typeConverter);
     populateTTIRToTTNNPatterns(&getContext(), patterns, typeConverter);
 
     // Apply full conversion

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNNPass.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNNPass.cpp
@@ -5,6 +5,7 @@
 #include "ttmlir/Conversion/TTIRToTTNN/TTIRToTTNN.h"
 
 #include "mlir/Dialect/Func/Transforms/FuncConversions.h"
+#include "ttmlir/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.h"
 #include "mlir/IR/BuiltinDialect.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
@@ -41,6 +42,7 @@ struct ConvertTTIRToTTNNPass
     typeConverter.addConversion([](Type type) { return type; });
 
     RewritePatternSet patterns(&getContext());
+    populateTTIRToTTIRDecompositionPatterns(&getContext(), patterns, typeConverter);
     populateTTIRToTTNNPatterns(&getContext(), patterns, typeConverter);
 
     // Apply full conversion

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNNPass.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNNPass.cpp
@@ -5,12 +5,12 @@
 #include "ttmlir/Conversion/TTIRToTTNN/TTIRToTTNN.h"
 
 #include "mlir/Dialect/Func/Transforms/FuncConversions.h"
-#include "ttmlir/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.h"
 #include "mlir/IR/BuiltinDialect.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "ttmlir/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIR.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNN.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
@@ -42,7 +42,8 @@ struct ConvertTTIRToTTNNPass
     typeConverter.addConversion([](Type type) { return type; });
 
     RewritePatternSet patterns(&getContext());
-    populateTTIRToTTIRDecompositionPatterns(&getContext(), patterns, typeConverter);
+    populateTTIRToTTIRDecompositionPatterns(&getContext(), patterns,
+                                            typeConverter);
     populateTTIRToTTNNPatterns(&getContext(), patterns, typeConverter);
 
     // Apply full conversion

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -37,6 +37,44 @@
 }
 
 //===----------------------------------------------------------------------===//
+// GetDimensionSizeOp
+//===----------------------------------------------------------------------===//
+
+::mlir::OpFoldResult
+mlir::tt::ttir::GetDimensionSizeOp::fold(FoldAdaptor adaptor) {
+
+  const RankedTensorType inputTensorType =
+      mlir::cast<RankedTensorType>(getOperand().getType());
+
+  int64_t dimensionIndex = getDimension();
+
+  if (dimensionIndex >=
+      static_cast<int64_t>(inputTensorType.getShape().size())) {
+    return nullptr;
+  };
+
+  int32_t dimSize = inputTensorType.getShape()[dimensionIndex];
+
+  mlir::ShapedType valueType = mlir::cast<mlir::ShapedType>(getType());
+
+  return mlir::DenseElementsAttr::get<int>(valueType, dimSize);
+}
+
+::mlir::LogicalResult mlir::tt::ttir::GetDimensionSizeOp::verify() {
+  const RankedTensorType inputTensorType =
+      mlir::cast<RankedTensorType>(getOperand().getType());
+
+  int64_t dimensionIndex = getDimension();
+
+  if (dimensionIndex >=
+      static_cast<int64_t>(inputTensorType.getShape().size())) {
+    return failure();
+  };
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // Conv2dOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -36,26 +36,6 @@
   return getValueAttr();
 }
 
-::mlir::OpFoldResult mlir::tt::ttir::GetDimensionSizeOp::fold(FoldAdaptor adaptor) {
-    const RankedTensorType inputTensorType =
-        mlir::cast<RankedTensorType>(getOperand().getType());
-
-    int64_t dimensionIndex = getDimension();
-
-    if (dimensionIndex >=
-        static_cast<int64_t>(inputTensorType.getShape().size())) {
-      return nullptr;
-    }
-
-    int32_t dimSize = inputTensorType.getShape()[dimensionIndex];
-    auto tensorShape = mlir::RankedTensorType::get({1}, mlir::IntegerType::get(getContext(), 32, mlir::IntegerType::Unsigned));
-
-    auto attr = mlir::DenseElementsAttr::get(tensorShape, {dimSize});
-
-    return attr;
- 
-}
-
 //===----------------------------------------------------------------------===//
 // Conv2dOp
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -36,6 +36,26 @@
   return getValueAttr();
 }
 
+::mlir::OpFoldResult mlir::tt::ttir::GetDimensionSizeOp::fold(FoldAdaptor adaptor) {
+    const RankedTensorType inputTensorType =
+        mlir::cast<RankedTensorType>(getOperand().getType());
+
+    int64_t dimensionIndex = getDimension();
+
+    if (dimensionIndex >=
+        static_cast<int64_t>(inputTensorType.getShape().size())) {
+      return nullptr;
+    }
+
+    int32_t dimSize = inputTensorType.getShape()[dimensionIndex];
+    auto tensorShape = mlir::RankedTensorType::get({1}, mlir::IntegerType::get(getContext(), 32, mlir::IntegerType::Unsigned));
+
+    auto attr = mlir::DenseElementsAttr::get(tensorShape, {dimSize});
+
+    return attr;
+ 
+}
+
 //===----------------------------------------------------------------------===//
 // Conv2dOp
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -40,6 +40,7 @@
 // GetDimensionSizeOp
 //===----------------------------------------------------------------------===//
 
+// GetDimensionSizeOp folder
 ::mlir::OpFoldResult
 mlir::tt::ttir::GetDimensionSizeOp::fold(FoldAdaptor adaptor) {
 
@@ -60,6 +61,7 @@ mlir::tt::ttir::GetDimensionSizeOp::fold(FoldAdaptor adaptor) {
   return mlir::DenseElementsAttr::get<int>(valueType, dimSize);
 }
 
+// GetDimensionSizeOp verification
 ::mlir::LogicalResult mlir::tt::ttir::GetDimensionSizeOp::verify() {
   const RankedTensorType inputTensorType =
       mlir::cast<RankedTensorType>(getOperand().getType());

--- a/test/ttmlir/Conversion/StableHLOToTTIR/get_dimension_size_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/get_dimension_size_op.mlir
@@ -1,0 +1,11 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s | FileCheck %s
+#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
+module @jit_get_dimension_size attributes {} {
+  func.func public @test_get_dimension_size(%arg0: tensor<13x21x3xf32>) -> tensor<i32> {
+    %0 = stablehlo.get_dimension_size %arg0, dim = 1 : (tensor<13x21x3xf32>) -> tensor<i32>
+    // CHECK: [[VAL:%[0-9]+]] = "ttir.get_dimension_size"(%arg0) <{dimension = 1 : i32}> : (tensor<{{[0-9]+}}x{{[0-9]+}}x{{[0-9]+}}xf32>) -> tensor<1xi32>
+    return %0 : tensor<i32>
+    // CHECK: return [[VAL]] : tensor<1xi32>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/simple_get_dimension_size.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_get_dimension_size.mlir
@@ -1,0 +1,10 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
+#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
+module attributes {} {
+  func.func @forward(%arg0: tensor<13x21x3xf32>) -> tensor<1xi32> {
+    %0 = "ttir.get_dimension_size"(%arg0) <{dimension = 1 : i32}> : (tensor<13x21x3xf32>) -> tensor<1xi32>
+    // CHECK: [[VAL:%[0-9]+]] = "ttnn.full"(%{{[0-9]+}}) <{fillValue = 2.100000e+01 : f32}> : (!tt.device<#device>) -> tensor<1xi32, #layout1>
+    return %0 : tensor<1xi32>
+    // CHECK: return [[VAL]] : tensor<1xi32, #layout1>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/simple_get_dimension_size.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_get_dimension_size.mlir
@@ -3,7 +3,7 @@
 module attributes {} {
   func.func @forward(%arg0: tensor<13x21x3xf32>) -> tensor<1xi32> {
     %0 = "ttir.get_dimension_size"(%arg0) <{dimension = 1 : i32}> : (tensor<13x21x3xf32>) -> tensor<1xi32>
-    // CHECK: [[VAL:%[0-9]+]] = "ttnn.full"(%{{[0-9]+}}) <{fillValue = 2.100000e+01 : f32}> : (!tt.device<#device>) -> tensor<1xi32, #layout1>
+    // CHECK: [[VAL:%[0-9]+]] = "ttnn.full"(%{{[0-9]+}}) <{fillValue = 2.100000e+01 : f32}> : (!tt.device<#device>) -> tensor<1xi32, {{.*}}>
     return %0 : tensor<1xi32>
     // CHECK: return [[VAL]] : tensor<1xi32, #layout1>
   }

--- a/test/ttmlir/Dialect/TTNN/simple_get_dimension_size.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_get_dimension_size.mlir
@@ -5,6 +5,6 @@ module attributes {} {
     %0 = "ttir.get_dimension_size"(%arg0) <{dimension = 1 : i32}> : (tensor<13x21x3xf32>) -> tensor<1xi32>
     // CHECK: [[VAL:%[0-9]+]] = "ttnn.full"(%{{[0-9]+}}) <{fillValue = 2.100000e+01 : f32}> : (!tt.device<#device>) -> tensor<1xi32, {{.*}}>
     return %0 : tensor<1xi32>
-    // CHECK: return [[VAL]] : tensor<1xi32, #layout1>
+    // CHECK: return [[VAL]] : tensor<1xi32, {{.*}}>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/simple_eltwise.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_eltwise.mlir
@@ -256,5 +256,5 @@ func.func @get_dimension_size(%arg0: tensor<13x21x3xf32>) -> tensor<1xi32> {
   %0 = "ttir.get_dimension_size"(%arg0) <{dimension = 1 : i32}> : (tensor<13x21x3xf32>) -> tensor<1xi32>
   // CHECK: [[VAL:%[0-9]+]] = "ttnn.full"(%{{[0-9]+}}) <{fillValue = 2.100000e+01 : f32}> : (!tt.device<#device>) -> tensor<1xi32, {{.*}}>
   return %0 : tensor<1xi32>
-  // CHECK: return [[VAL]] : tensor<1xi32, #layout1>
+  // CHECK: return [[VAL]] : tensor<1xi32, {{.*}}>
 }

--- a/test/ttmlir/Silicon/TTNN/simple_eltwise.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_eltwise.mlir
@@ -251,3 +251,10 @@ func.func @remainder(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tens
   return %1 : tensor<32x32xf32>
   // CHECK: return {{.*}} : tensor<32x32xf32, {{.*}}
 }
+
+func.func @get_dimension_size(%arg0: tensor<13x21x3xf32>) -> tensor<1xi32> {
+  %0 = "ttir.get_dimension_size"(%arg0) <{dimension = 1 : i32}> : (tensor<13x21x3xf32>) -> tensor<1xi32>
+  // CHECK: [[VAL:%[0-9]+]] = "ttnn.full"(%{{[0-9]+}}) <{fillValue = 2.100000e+01 : f32}> : (!tt.device<#device>) -> tensor<1xi32, #layout1>
+  return %0 : tensor<1xi32>
+  // CHECK: return [[VAL]] : tensor<1xi32, #layout1>
+}

--- a/test/ttmlir/Silicon/TTNN/simple_eltwise.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_eltwise.mlir
@@ -254,7 +254,7 @@ func.func @remainder(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tens
 
 func.func @get_dimension_size(%arg0: tensor<13x21x3xf32>) -> tensor<1xi32> {
   %0 = "ttir.get_dimension_size"(%arg0) <{dimension = 1 : i32}> : (tensor<13x21x3xf32>) -> tensor<1xi32>
-  // CHECK: [[VAL:%[0-9]+]] = "ttnn.full"(%{{[0-9]+}}) <{fillValue = 2.100000e+01 : f32}> : (!tt.device<#device>) -> tensor<1xi32, #layout1>
+  // CHECK: [[VAL:%[0-9]+]] = "ttnn.full"(%{{[0-9]+}}) <{fillValue = 2.100000e+01 : f32}> : (!tt.device<#device>) -> tensor<1xi32, {{.*}}>
   return %0 : tensor<1xi32>
   // CHECK: return [[VAL]] : tensor<1xi32, #layout1>
 }


### PR DESCRIPTION
- Add end-to-end implementation of the get_dimension_size op in the HLODIalect
- It can be folded in the compiler, on the ttir level, producing a constant op
- Related to issue https://github.com/tenstorrent/tt-mlir/issues/1016