### PR TITLE
#860: For creation ops, check if the output is borrowed from the user

### DIFF
--- a/runtime/lib/ttnn/operations/creation/empty.cpp
+++ b/runtime/lib/ttnn/operations/creation/empty.cpp
@@ -35,7 +35,10 @@ void run(const ::tt::target::ttnn::EmptyOp *op, ProgramContext &context) {
   } else {
     out = ::ttnn::zeros(shape, dtype, layout);
   }
-
-  tensorPool.try_emplace(op->out()->global_id(), out);
+  if (tensorPool.isUserOutput(op->out()->global_id())) {
+    tensorPool.copyTensorToUserOutput(out, op->out()->global_id());
+  } else {
+    tensorPool.insert_or_assign(op->out()->global_id(), out);
+  }
 }
 } // namespace tt::runtime::ttnn::operations::creation

--- a/runtime/lib/ttnn/operations/creation/full.cpp
+++ b/runtime/lib/ttnn/operations/creation/full.cpp
@@ -45,11 +45,13 @@ void run(const ::tt::target::ttnn::FullOp *op, ProgramContext &context) {
     outputMemoryConfig =
         std::make_optional(utils::createMemoryConfig(op->out()));
   }
-
   ::ttnn::Tensor out =
       ::ttnn::full(shape, fillValue, outputDataType, outputLayout, outputDevice,
                    outputMemoryConfig);
-
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+  if (tensorPool.isUserOutput(op->out()->global_id())) {
+    tensorPool.copyTensorToUserOutput(out, op->out()->global_id());
+  } else {
+    tensorPool.insert_or_assign(op->out()->global_id(), out);
+  }
 }
 } // namespace tt::runtime::ttnn::operations::creation


### PR DESCRIPTION
Closes #860 