### PR TITLE
Remove ttnn::CompositeToLayoutOp, use ttnn::ToLayoutOp instead

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -27,22 +27,6 @@ def TTNN_GetDeviceOp : TTNN_Op<"get_device"> {
     let results = (outs TT_Device:$device);
 }
 
-def TTNN_CompositeToLayoutOp : TTNN_Op<"composite_to_layout"> {
-  let summary = "Composite toLayout op.";
-  let description = [{
-      This op wraps all layout information gathered from ttir.toLayout. It is used/updated by the optimizer
-      to perform optimizations, and later broken down into specific memory/layout operations (toDevice, toMemoryConfig, toLayout etc.).
-  }];
-
-  let arguments = (ins AnyRankedTensor:$input,
-                       TTNN_LayoutAttr:$layout,
-                       TT_DataTypeAttr:$dtype,
-                       TTNN_MemoryConfigAttr:$memory_config,
-                       Optional<TT_Device>:$device);
-
-  let results = (outs AnyRankedTensor:$result);
-}
-
 def TTNN_ToMemoryConfigOp : TTNN_Op<"to_memory_config"> {
     let summary = "ToMemoryConfig op.";
     let description = [{
@@ -65,10 +49,10 @@ def TTNN_ToMemoryConfigOp : TTNN_Op<"to_memory_config"> {
 def TTNN_ToLayoutOp : TTNN_Op<"to_layout"> {
     let summary = "ToLayout op.";
     let description = [{
-      This op converts the layout of the input tensor based on the given layout.
-      It handles:
-        - ROW_MAJOR to TILE
-        - TILE to ROW_MAJOR
+      This op wraps all layout information gathered from ttir.toLayout. It is used/updated by the optimizer
+      to perform optimizations, and later broken down into specific memory/layout operations (toDevice, toMemoryConfig etc.).
+      Currently in the TTNN backend, we use this op solely for tilize/untilize, therefore marking all other attrs as optional.
+      Once ttnn::to_layout supports other attrs, we can remove the optional tag.
     }];
 
     let arguments = (ins AnyRankedTensor:$input,

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -14,10 +14,10 @@ def TTNNDeallocate: Pass<"ttnn-deallocate", "::mlir::ModuleOp"> {
   }];
 }
 
-def TTNNDecomposeCompositeLayouts: Pass<"ttnn-decompose-composite-layouts", "::mlir::ModuleOp"> {
-  let summary = "Decompose composite layout ops to according memory ops.";
+def TTNNDecomposeLayouts: Pass<"ttnn-decompose-layouts", "::mlir::ModuleOp"> {
+  let summary = "Decompose ToLayoutOps to more granular memory ops.";
   let description = [{
-    This pass decomposes composite layouts to memory ops (e.g. toDevice, toMemoryConfig etc.).
+    This pass decomposes ToLayoutOps to memory ops (e.g. toDevice, toMemoryConfig etc.).
   }];
 }
 

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -200,7 +200,7 @@ public:
             op.getContext(), ttnn::ShapeAttr::get(rewriter.getContext(),
                                                   outputMemref.getShape())));
 
-    rewriter.replaceOpWithNewOp<ttnn::CompositeToLayoutOp>(
+    rewriter.replaceOpWithNewOp<ttnn::ToLayoutOp>(
         op, this->getTypeConverter()->convertType(result), adaptor.getInput(),
         outputLayout, outputDataType, outputMemConfigAttr,
         isOutputOnHost ? nullptr : getOrInsertDevice(rewriter, op));

--- a/lib/Dialect/TTNN/Analysis/DFShardingPolicy.cpp
+++ b/lib/Dialect/TTNN/Analysis/DFShardingPolicy.cpp
@@ -8,10 +8,6 @@
 
 namespace mlir::tt::ttnn {
 
-bool isCompositeToLayoutOp(mlir::Operation *op) {
-  return isa<ttnn::CompositeToLayoutOp>(op);
-}
-
 void DFShardingPolicy::run(
     const std::unordered_set<Edge> &overrideReshardEdges) {
   rootOp->walk([&](func::FuncOp func) {
@@ -39,7 +35,7 @@ void DFShardingPolicy::run(
       //
       if (l1ChainConfigs->back().isEmpty()) {
         for (auto *op : scheduleableOps) {
-          if (isCompositeToLayoutOp(op)) {
+          if (isa<ttnn::ToLayoutOp>(op)) {
             currentOp = op;
             break;
           }
@@ -57,7 +53,7 @@ void DFShardingPolicy::run(
       // Skip starting sharding chain if currentOp is a memory management op.
       //
       if (l1ChainConfigs->back().isEmpty() &&
-          isCompositeToLayoutOp(currentOp)) {
+          isa<ttnn::ToLayoutOp>(currentOp)) {
         currentOp = nullptr;
         continue;
       }

--- a/lib/Dialect/TTNN/Analysis/LegalGridAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/LegalGridAnalysis.cpp
@@ -52,7 +52,7 @@ bool cantChangeOutputLayout(Operation *op) {
     return true;
   }
 
-  if (llvm::isa<CompositeToLayoutOp>(op)) {
+  if (llvm::isa<ToLayoutOp>(op)) {
     return true;
   }
 

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -64,7 +64,7 @@ void createTTNNPipelineLoweringPasses(
 
 void createTTNNPipelineLayoutDecompositionPass(
     OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options) {
-  pm.addPass(createTTNNDecomposeCompositeLayouts());
+  pm.addPass(createTTNNDecomposeLayouts());
 }
 
 void createTTNNPipelineDeallocPass(

--- a/test/ttmlir/Dialect/TTNN/test_grid_set.mlir
+++ b/test/ttmlir/Dialect/TTNN/test_grid_set.mlir
@@ -9,13 +9,13 @@
 module attributes {tt.device = #device, tt.system_desc = #system_desc} {
   func.func @forward(%arg0: tensor<64x128xf32, #layout>, %arg1: tensor<64x128xf32, #layout>) -> tensor<64x128xf32, #layout> {
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
-    %1 = "ttnn.composite_to_layout"(%arg0, %0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<64x128>>>}> : (tensor<64x128xf32, #layout>, !tt.device<#device>) -> tensor<64x128xf32, #layout1>
-    %2 = "ttnn.composite_to_layout"(%arg1, %0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<64x128>>>}> : (tensor<64x128xf32, #layout>, !tt.device<#device>) -> tensor<64x128xf32, #layout1>
+    %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<64x128>>>}> : (tensor<64x128xf32, #layout>, !tt.device<#device>) -> tensor<64x128xf32, #layout1>
+    %2 = "ttnn.to_layout"(%arg1, %0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<64x128>>>}> : (tensor<64x128xf32, #layout>, !tt.device<#device>) -> tensor<64x128xf32, #layout1>
     %3 = "ttnn.empty"(%0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<64x128>>>, shape = #ttnn.shape<64x128>}> : (!tt.device<#device>) -> tensor<64x128xf32, #layout2>
     %4 = "ttnn.multiply"(%1, %2, %3) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32, #layout1>, tensor<64x128xf32, #layout1>, tensor<64x128xf32, #layout2>) -> tensor<64x128xf32, #layout2>
     // CHECK: #[[LAYOUT_2:.*]] = #tt.layout<(d0, d1) -> (d0, d1), undef, <8x8>, memref<8x16xf32, #dram>, interleaved>
     // CHECK: %{{.+}} = "ttnn.multiply"{{.+}} -> tensor<64x128xf32, #[[LAYOUT_2]]>
-    %5 = "ttnn.composite_to_layout"(%4) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<none>, <system_memory>, <<64x128>>>}> : (tensor<64x128xf32, #layout2>) -> tensor<64x128xf32, #layout>
+    %5 = "ttnn.to_layout"(%4) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<none>, <system_memory>, <<64x128>>>}> : (tensor<64x128xf32, #layout2>) -> tensor<64x128xf32, #layout>
     return %5 : tensor<64x128xf32, #layout>
   }
 }


### PR DESCRIPTION
Closes #1090 
As discussed in #840, we'll use ttnn.ToLayoutOp both prior to and after decomposition, however in ttnn backend this op will only be used for tilize/untilize. Once ttnn::to_layout is properly implemented to support all parameter combinations, we can simply remove the lowering pass and use this op directly for all cases.