### PR TITLE
Fix python tests in debug round 2

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -95,9 +95,9 @@ declare_mlir_python_extension(TTMLIRPythonExtensions.Main
     LLVMSupport
     ${dialect_libs}
     ${conversion_libs}
-    ${extension_libs}
     ${translation_libs}
     TTMLIRStatic
+    ${extension_libs}
 )
 
 set(TTMLIR_PYTHON_SOURCES


### PR DESCRIPTION
Change the link order to put extension libs last so the linker can find all necessary extension symbols for TTMLIRStatic target.