### PR TITLE
Specify python version (3.10)

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -23,7 +23,7 @@ jobs:
 
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: '3.10'
 
     - name: Install build dependencies
       uses: ./.github/actions/install-deps

--- a/env/build_venv.sh
+++ b/env/build_venv.sh
@@ -5,8 +5,9 @@
 
 OS=$(uname)
 TTMLIR_VENV=$TTMLIR_TOOLCHAIN_DIR/venv
+TTMLIR_PYTHON_VERSION="${TTMLIR_PYTHON_VERSION:-python3.10}"
 
-python3 -m venv $TTMLIR_VENV
+$TTMLIR_PYTHON_VERSION -m venv $TTMLIR_VENV
 source $CURRENT_SOURCE_DIR/activate
 python -m pip install --upgrade pip
 pip install -r $CURRENT_SOURCE_DIR/build-requirements.txt


### PR DESCRIPTION
If the default python version is 3.13, build on OS X will fail, because torch 2.3.0 (specified in https://github.com/tenstorrent/tt-mlir/blob/main/test/python/requirements.txt) isn't available for python 3.13. This change should fix it.