### PR TITLE
[Direct Metal] Insert scaler CB in reduce kernels

### DIFF
--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -144,8 +144,8 @@ def TT_ChipDescAttr : TT_Attr<"ChipDesc", "chip_desc"> {
 
   let extraClassDeclaration = [{
     unsigned getUsableL1Size() const { return getL1Size() - getL1UnreservedBase(); }
-    unsigned getGlobalL1RegionAddress() const;
-    unsigned getGlobalL1RegionSize() const;
+    unsigned getScratchL1RegionAddress() const;
+    unsigned getScratchL1RegionSize() const;
     unsigned getUsableDramChannelSize() const { return getDramUnreservedEnd() - getDramUnreservedBase(); }
   }];
 }

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -144,6 +144,8 @@ def TT_ChipDescAttr : TT_Attr<"ChipDesc", "chip_desc"> {
 
   let extraClassDeclaration = [{
     unsigned getUsableL1Size() const { return getL1Size() - getL1UnreservedBase(); }
+    unsigned getGlobalL1RegionAddress() const;
+    unsigned getGlobalL1RegionSize() const;
     unsigned getUsableDramChannelSize() const { return getDramUnreservedEnd() - getDramUnreservedBase(); }
   }];
 }

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -433,13 +433,23 @@ def TTKernel_UntilizeBlockOp : TTKernel_Op<"untilize_block"> {
 // TTKernel NOC operations
 //===----------------------------------------------------------------------===//
 
+def TTKernel_GetNocAddrXYOp : TTKernel_Op<"get_noc_addr_xy"> {
+    let summary = "GetNocAddrXY";
+    let description = [{
+      GetNocAddr api including core coordinates
+    }];
+
+    let arguments = (ins I32:$x, I32:$y, I32:$l1Address);
+    let results = (outs TTKernel_NocAddr:$nocAddr);
+}
+
 def TTKernel_GetNocAddrOp : TTKernel_Op<"get_noc_addr"> {
     let summary = "GetNocAddr";
     let description = [{
       GetNocAddr
     }];
 
-    let arguments = (ins I32:$x, I32:$y, I32:$l1Address);
+    let arguments = (ins I32:$l1Address);
     let results = (outs TTKernel_NocAddr:$nocAddr);
 }
 
@@ -450,6 +460,24 @@ def TTKernel_NocAsyncReadOp : TTKernel_Op<"noc_async_read"> {
     }];
 
     let arguments = (ins TTKernel_NocAddr:$srcNocAddr, I32:$dstLocalL1Addr, I32:$size);
+}
+
+def TTKernel_NocAsyncReadOnePacketSetStateOp : TTKernel_Op<"noc_async_read_one_packet_set_state"> {
+    let summary = "NocAsyncReadOnePacketSetState";
+    let description = [{
+      NocAsyncReadOnePacketSetState
+    }];
+
+    let arguments = (ins TTKernel_NocAddr:$srcNocAddr, I32:$size);
+}
+
+def TTKernel_NocAsyncReadOnePacketWithStateOp : TTKernel_Op<"noc_async_read_one_packet_with_state"> {
+    let summary = "NocAsyncReadOnePacketWithState";
+    let description = [{
+      NocAsyncReadOnePacketWithState
+    }];
+
+    let arguments = (ins TTKernel_NocAddr:$srcNocAddr, AnyTypeOf<[I32, TTKernel_L1Addr]>:$dstLocalL1Addr);
 }
 
 def TTKernel_NocAsyncReadBarrierOp : TTKernel_Op<"noc_async_read_barrier"> {
@@ -506,6 +534,47 @@ def TTKernel_UnreachableOp : TTKernel_Op<"unreachable", [Pure, ReturnLike, Termi
     let description = [{
       Unreachable operation
     }];
+}
+
+def TTKernel_MacroOp : TTKernel_Op<"macro"> {
+    let summary = "Macro op.";
+    let description = [{
+      Macro operation to mimic C++ macros
+    }];
+
+    let arguments = (ins FlatSymbolRefAttr:$name);
+
+    let results = (outs I32:$result);
+}
+
+def TTKernel_GetWritePtrOp : TTKernel_Op<"get_write_ptr"> {
+    let summary = "GetWritePtr";
+    let description = [{
+      GetWritePtr operation
+    }];
+
+    let arguments = (ins TTKernel_CB:$cb);
+    let results = (outs I32:$writePtr);
+}
+
+def TTKernel_CastToL1PtrOp : TTKernel_Op<"reinterpret_cast<volatile tt_l1_ptr uint32_t*>"> {
+    let summary = "CastToL1Ptr";
+    let description = [{
+      Cast specified addr to L1 pointer.
+    }];
+
+    let arguments = (ins AnyTypeOf<[I32, TTKernel_L1Addr]>:$addr);
+
+    let results = (outs TTKernel_L1AddrPtr:$l1_ptr);
+}
+
+def TTKernel_StoreToL1Op : TTKernel_Op<"store_to_l1"> {
+    let summary = "StoreToL1";
+    let description = [{
+      Store value to L1.
+    }];
+
+    let arguments = (ins I32:$value, TTKernel_L1AddrPtr:$l1_ptr, I32:$offset);
 }
 
 #endif

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -536,13 +536,20 @@ def TTKernel_UnreachableOp : TTKernel_Op<"unreachable", [Pure, ReturnLike, Termi
     }];
 }
 
-def TTKernel_MacroOp : TTKernel_Op<"macro"> {
-    let summary = "Macro op.";
+def TTKernel_MemZerosBaseOp : TTKernel_Op<"mem_zeros_base"> {
+    let summary = "Op corresponding to MEM_ZEROS_BASE macro in kernels.";
     let description = [{
-      Macro operation to mimic C++ macros
+      Op corresponding to MEM_ZEROS_BASE macro in kernels.
     }];
 
-    let arguments = (ins FlatSymbolRefAttr:$name);
+    let results = (outs I32:$result);
+}
+
+def TTKernel_MemZerosSizeOp : TTKernel_Op<"mem_zeros_size"> {
+    let summary = "Op corresponding to MEM_ZEROS_SIZE macro in kernels.";
+    let description = [{
+      Op corresponding to MEM_ZEROS_SIZE macro in kernels.
+    }];
 
     let results = (outs I32:$result);
 }

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
@@ -81,14 +81,16 @@ def TTKernel_CB : TTKernel_Type<"CB", "cb"> {
                           "uint64_t":$address,
                           "MemRefType":$memref,
                           "uint64_t":$page_size,
-                          "uint64_t":$num_buffers);
-    let assemblyFormat = "`<` $port`,` $address`,` $memref`,` $page_size`,` $num_buffers `>`";
+                          "uint64_t":$num_buffers,
+                          "bool":$is_internal);
+    let assemblyFormat = "`<` $port`,` $address`,` $memref`,` $page_size`,` $num_buffers`,` $is_internal `>`";
 
     let extraClassDeclaration = [{
         static CBType get(::mlir::MLIRContext *context,
                               CBPort port,
                               uint64_t address,
-                              MemRefType memref) {
+                              MemRefType memref,
+                              bool is_internal = false) {
           uint64_t numBuffers = 1;
           uint64_t pageSize = 0;
           if (::mlir::isa<::mlir::tt::TileType>(memref.getElementType())) {
@@ -96,7 +98,7 @@ def TTKernel_CB : TTKernel_Type<"CB", "cb"> {
           } else {
             pageSize = memref.getShape().back() * (memref.getElementType().getIntOrFloatBitWidth() / 8);
           }
-          return CBType::get(context, port, address, memref, pageSize, numBuffers);
+          return CBType::get(context, port, address, memref, pageSize, numBuffers, is_internal);
         }
 
         ::llvm::ArrayRef<int64_t> getShape() const {
@@ -122,6 +124,16 @@ def TTKernel_ReduceTypeAttr : EnumAttr<TTKernel_Dialect, TTKernel_ReduceType, "r
 
 def TTKernel_ReduceDimAttr : EnumAttr<TTKernel_Dialect, TTKernel_ReduceDim, "reduce_dim"> {
   let assemblyFormat = "`<` $value `>`";
+}
+
+def TTKernel_L1Addr : TTKernel_Type<"L1Addr", "l1_addr"> {
+    let summary = "TTKernel l1 address";
+    let description = "L1 address type in TTKernel dialect";
+}
+
+def TTKernel_L1AddrPtr : TTKernel_Type<"L1AddrPtr", "l1_addr_ptr"> {
+    let summary = "TTKernel l1 address pointer";
+    let description = "L1 pointer address type in TTKernel dialect";
 }
 
 #endif

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
@@ -81,16 +81,14 @@ def TTKernel_CB : TTKernel_Type<"CB", "cb"> {
                           "uint64_t":$address,
                           "MemRefType":$memref,
                           "uint64_t":$page_size,
-                          "uint64_t":$num_buffers,
-                          "bool":$is_internal);
-    let assemblyFormat = "`<` $port`,` $address`,` $memref`,` $page_size`,` $num_buffers`,` $is_internal `>`";
+                          "uint64_t":$num_buffers);
+    let assemblyFormat = "`<` $port`,` $address`,` $memref`,` $page_size`,` $num_buffers `>`";
 
     let extraClassDeclaration = [{
         static CBType get(::mlir::MLIRContext *context,
                               CBPort port,
                               uint64_t address,
-                              MemRefType memref,
-                              bool is_internal = false) {
+                              MemRefType memref) {
           uint64_t numBuffers = 1;
           uint64_t pageSize = 0;
           if (::mlir::isa<::mlir::tt::TileType>(memref.getElementType())) {
@@ -98,7 +96,7 @@ def TTKernel_CB : TTKernel_Type<"CB", "cb"> {
           } else {
             pageSize = memref.getShape().back() * (memref.getElementType().getIntOrFloatBitWidth() / 8);
           }
-          return CBType::get(context, port, address, memref, pageSize, numBuffers, is_internal);
+          return CBType::get(context, port, address, memref, pageSize, numBuffers);
         }
 
         ::llvm::ArrayRef<int64_t> getShape() const {

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
@@ -2,11 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "mlir/IR/Builders.h"
-#include "mlir/IR/Operation.h"
-#include "llvm/ADT/ArrayRef.h"
-#include <cstdint>
-
 #include "ttmlir/Dialect/TTMetal/Transforms/Passes.h"
 
 #include "mlir/Analysis/Liveness.h"
@@ -15,10 +10,13 @@
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Block.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Location.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Types.h"
 #include "mlir/IR/Value.h"
 #include "mlir/IR/ValueRange.h"
 #include "mlir/Pass/PassManager.h"
@@ -31,17 +29,14 @@
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
 #include "ttmlir/Dialect/TTMetal/IR/TTMetal.h"
 #include "ttmlir/Dialect/TTMetal/IR/TTMetalOps.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cstdint>
-#include <llvm/ADT/DenseMap.h>
-#include <llvm/ADT/SmallSet.h>
-#include <mlir/IR/Block.h>
-#include <mlir/IR/BuiltinTypes.h>
-#include <mlir/IR/Types.h>
 #include <utility>
 
 #include "ttmlir/Dialect/TT/Utils/PhysicalCoreCoord.h"

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
@@ -1194,8 +1194,6 @@ public:
     assert(mlir::isa<ttir::YieldOp>(*users.begin()));
     assert(computeBlock->getNumArguments() > numDPSInputs);
 
-    llvm::errs() << "lowering block, numDPSInputs: " << numDPSInputs << "\n";
-
     auto outputMemref = mlir::cast<ttkernel::CBType>(
                             computeBlock->getArgument(numDPSInputs).getType())
                             .getMemref()
@@ -1220,10 +1218,6 @@ public:
     OpBuilder builder(computeBlock, computeBlock->begin());
     Operation &arithOrMathOp = operations.front();
     auto cbOperands = computeBlock->getArguments();
-
-    for (auto operand : cbOperands) {
-      llvm::errs() << "operand: " << operand << "\n";
-    }
 
     buildInitSection(arithOrMathOp, builder, cbOperands, kernelReduceDim,
                      numDPSInputs);

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
@@ -13,6 +13,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -36,6 +37,11 @@
 #include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cstdint>
+#include <llvm/ADT/DenseMap.h>
+#include <llvm/ADT/SmallSet.h>
+#include <mlir/IR/Block.h>
+#include <mlir/IR/BuiltinTypes.h>
+#include <mlir/IR/Types.h>
 #include <utility>
 
 #include "ttmlir/Dialect/TT/Utils/PhysicalCoreCoord.h"
@@ -183,13 +189,13 @@ public:
     auto size = nocBuilder.create<arith::ConstantOp>(
         loc, nocBuilder.getI32Type(), nocBuilder.getI32IntegerAttr(nocTx.size));
     if (nocTx.type == NocTx::Type::Read) {
-      auto srcRemoteNocAddr =
-          nocBuilder.create<ttkernel::GetNocAddrOp>(loc, x, y, srcLocalL1Addr);
+      auto srcRemoteNocAddr = nocBuilder.create<ttkernel::GetNocAddrXYOp>(
+          loc, x, y, srcLocalL1Addr);
       nocBuilder.create<ttkernel::NocAsyncReadOp>(loc, srcRemoteNocAddr,
                                                   dstLocalL1Addr, size);
     } else {
-      auto dstRemoteNocAddr =
-          nocBuilder.create<ttkernel::GetNocAddrOp>(loc, x, y, dstLocalL1Addr);
+      auto dstRemoteNocAddr = nocBuilder.create<ttkernel::GetNocAddrXYOp>(
+          loc, x, y, dstLocalL1Addr);
       nocBuilder.create<ttkernel::NocAsyncWriteOp>(loc, srcLocalL1Addr,
                                                    dstRemoteNocAddr, size);
     }
@@ -289,6 +295,8 @@ public:
       createDataMovementThread(op->getLoc(), block, inputBaseAddress,
                                outputBaseAddress, transactions,
                                physicalCoordMapping, addressAlignment);
+      OpBuilder endBuilder = OpBuilder::atBlockEnd(block);
+      endBuilder.create<ttkernel::ReturnOp>(op->getLoc());
     }
     rewriter.replaceOp(op, metalDispatch);
 
@@ -305,7 +313,7 @@ public:
     assert(outputBaseAddress);
     assert(inputBaseAddress % addressAlignment == 0);
     assert(outputBaseAddress % addressAlignment == 0);
-    OpBuilder nocBuilder(block, block->begin());
+    OpBuilder nocBuilder = OpBuilder::atBlockEnd(block);
     NocTx::Type type = transactions.front().type;
     for (auto tx : transactions) {
       assert(tx.type == type);
@@ -334,7 +342,6 @@ public:
         nocBuilder.create<ttkernel::NocAsyncWriteBarrierOp>(loc);
       }
     }
-    nocBuilder.create<ttkernel::ReturnOp>(loc, ValueRange());
   }
 
   LogicalResult reformat(ttir::ToLayoutOp op, PatternRewriter &rewriter) const {
@@ -379,11 +386,11 @@ public:
     Type inputCBTy = rewriter.getType<ttkernel::CBType>(
         ttkernel::CBPort::In0, inputBaseAddress,
         mlir::cast<MemRefType>(inputLayout.getMemref()), pageSize,
-        /*num_buffers*/ 1);
+        /*num_buffers*/ 1, false /* is_internal */);
     Type outputCBTy = rewriter.getType<ttkernel::CBType>(
         ttkernel::CBPort::Out0, outputBaseAddress,
         mlir::cast<MemRefType>(outputLayout.getMemref()), pageSize,
-        /*num_buffers*/ 1);
+        /*num_buffers*/ 1, false /* is_internal */);
     tensixBlock->addArgument(inputCBTy, op.getLoc());
     tensixBlock->addArgument(outputCBTy, op.getLoc());
 
@@ -710,7 +717,10 @@ public:
           assert(innerOffset.size() == 1);
           innerIndices.push_back(innerLoopRegion.create<arith::AddIOp>(
               output.getLoc(), forOp.getRegionIterArg(i),
-              i32(innerOffset[0], innerLoopRegion)));
+              i32(innerOffset[0], innerLoopRegion),
+              arith::IntegerOverflowFlagsAttr::get(
+                  innerLoopRegion.getContext(),
+                  arith::IntegerOverflowFlags::nsw)));
           ++i;
         }
         innerLoopRegion.create<scf::YieldOp>(output.getLoc(), innerIndices);
@@ -736,7 +746,10 @@ public:
           std::int64_t offset =
               outerOffset[0] - innerOffset[0] * walkingShape[dim];
           outerIndices.push_back(regionBuilder.create<arith::AddIOp>(
-              output.getLoc(), forOp.getResult(i), i32(offset, regionBuilder)));
+              output.getLoc(), forOp.getResult(i), i32(offset, regionBuilder),
+              arith::IntegerOverflowFlagsAttr::get(
+                  regionBuilder.getContext(),
+                  arith::IntegerOverflowFlags::nsw)));
           ++i;
         }
         regionBuilder.create<scf::YieldOp>(output.getLoc(), outerIndices);
@@ -799,19 +812,22 @@ public:
   void convertInitReduceOp(Operation &reduceOp, ttkernel::ReduceDim reduceDim,
                            ArrayRef<BlockArgument> cbOperands,
                            OpBuilder &builder) const {
-    assert(cbOperands.size() == 2 &&
-           "Expected one input and one output CB for reduce op.");
+    assert(cbOperands.size() == 3 &&
+           "Expected two inputs and one output CB for reduce op.");
 
     auto kernelOp = mlir::cast<ttir::KernelOp>(reduceOp);
     assert(kernelOp.getOp() == "reduce");
-    auto type = kernelOp.getKind() == "sum" ? ttkernel::ReduceType::Sum
-                                            : ttkernel::ReduceType::Max;
+    auto type = kernelOp.getKind() == "max" ? ttkernel::ReduceType::Max
+                                            : ttkernel::ReduceType::Sum;
     builder.create<ttkernel::ReduceInitOp>(
-        reduceOp.getLoc(), cbOperands[0],
-        cbOperands[0], // TODO(rpavlovic) insert proper scaling cb
-        cbOperands[1],
+        reduceOp.getLoc(), cbOperands[0], cbOperands[2], cbOperands[1],
         ttkernel::ReduceTypeAttr::get(builder.getContext(), type),
         ttkernel::ReduceDimAttr::get(builder.getContext(), reduceDim));
+
+    // Wait for scaler to be ready.
+    auto one = i32(1, builder);
+    builder.create<ttkernel::CBWaitFrontOp>(reduceOp.getLoc(), cbOperands[2],
+                                            one);
   }
 
   // Convert arith and math dialect operations into ttkernel init tile
@@ -1013,17 +1029,17 @@ public:
 
     auto kernelOp = mlir::cast<ttir::KernelOp>(op);
     assert(kernelOp.getOp() == "reduce");
-    auto type = kernelOp.getKind() == "sum" ? ttkernel::ReduceType::Sum
-                                            : ttkernel::ReduceType::Max;
+    auto type = kernelOp.getKind() == "max" ? ttkernel::ReduceType::Max
+                                            : ttkernel::ReduceType::Sum;
+    OpBuilder mainBuilder(computeBlock, computeBlock->begin());
+    mainBuilder.setInsertionPointToEnd(computeBlock);
 
     OpBuilder innerLoopBuilder(&loopNest.loopRegions.back()->front(),
                                loopNest.loopRegions.back()->front().begin());
     auto dstIndex = i32(0, innerLoopBuilder);
 
     innerLoopBuilder.create<ttkernel::ReduceTileOp>(
-        op.getLoc(), cbOperands[0],
-        cbOperands[0], // TODO(rpavlovic) insert proper
-                       // scaling cb
+        op.getLoc(), cbOperands[0], cbOperands[2],
         iterators[blockArgIteratorMapping[0]],
         iterators[blockArgIteratorMapping[0]], dstIndex,
         ttkernel::ReduceTypeAttr::get(innerLoopBuilder.getContext(), type),
@@ -1064,8 +1080,8 @@ public:
     packingBuilder.create<ttkernel::TileRegsWaitOp>(
         computeBlock->front().getLoc());
     packingBuilder.create<ttkernel::PackTileOp>(
-        computeBlock->front().getLoc(), i32(0, packingBuilder),
-        cbOperands.back(), packingTileIndex);
+        computeBlock->front().getLoc(), i32(0, packingBuilder), cbOperands[1],
+        packingTileIndex);
     packingBuilder.create<ttkernel::TileRegsReleaseOp>(
         computeBlock->front().getLoc());
   }
@@ -1177,8 +1193,8 @@ public:
     assert(users.begin() != users.end());
     assert(mlir::isa<ttir::YieldOp>(*users.begin()));
     assert(computeBlock->getNumArguments() > numDPSInputs);
-    assert((computeBlock->getNumArguments() - numDPSInputs) == 1 &&
-           "Expected 1 output");
+
+    llvm::errs() << "lowering block, numDPSInputs: " << numDPSInputs << "\n";
 
     auto outputMemref = mlir::cast<ttkernel::CBType>(
                             computeBlock->getArgument(numDPSInputs).getType())
@@ -1205,6 +1221,10 @@ public:
     Operation &arithOrMathOp = operations.front();
     auto cbOperands = computeBlock->getArguments();
 
+    for (auto operand : cbOperands) {
+      llvm::errs() << "operand: " << operand << "\n";
+    }
+
     buildInitSection(arithOrMathOp, builder, cbOperands, kernelReduceDim,
                      numDPSInputs);
     buildLoopsAndComputation(computeBlock, arithOrMathOp, builder,
@@ -1217,6 +1237,7 @@ public:
     uint64_t srcAddress;
     uint64_t dstAddress;
     size_t blockArgIndex;
+    bool hasDataMovement;
     llvm::MapVector<PhysicalCoreCoord,
                     SmallVector<TTIRToTTMetalLayoutRewriter::NocTx>>
         dataMovement;
@@ -1225,13 +1246,15 @@ public:
 
     StreamedOperand(
         uint64_t srcAddress, uint64_t dstAddress, size_t blockArgIndex,
+        bool hasDataMovement,
         llvm::MapVector<PhysicalCoreCoord,
                         SmallVector<TTIRToTTMetalLayoutRewriter::NocTx>>
             dataMovement,
         uint64_t numTiles, const PhysicalCoreCoordMapping &coordMappping)
         : srcAddress(srcAddress), dstAddress(dstAddress),
-          blockArgIndex(blockArgIndex), dataMovement(dataMovement),
-          numTiles(numTiles), coordMappping(coordMappping) {}
+          blockArgIndex(blockArgIndex), hasDataMovement(hasDataMovement),
+          dataMovement(dataMovement), numTiles(numTiles),
+          coordMappping(coordMappping) {}
   };
 
   std::pair<SmallVector<Type>, SmallVector<StreamedOperand>>
@@ -1262,24 +1285,27 @@ public:
 
       rewrittenBlockArgumentTypes.push_back(
           rewriter.getType<ttkernel::CBType>(port, address, memref));
-      if (buffer.getBufferAccess() != BufferAccess::Stream) {
-        continue;
-      }
 
-      assert(cbMapping != -1 && "Expected streamed operand to have CB mapping");
-
-      auto matchingCB = op.getCbs()[cbMapping];
       uint64_t numTiles = memref.getShape()[memref.getRank() - 1] *
                           memref.getShape()[memref.getRank() - 2];
+
+      llvm::MapVector<PhysicalCoreCoord,
+                      SmallVector<TTIRToTTMetalLayoutRewriter::NocTx>>
+          dataMovement;
+      if (buffer.getBufferAccess() == BufferAccess::Stream) {
+        dataMovement = calculateDataMovement(
+            op.getIteratorTypes(),
+            mlir::cast<RankedTensorType>(matchingOperand.getType()),
+            mlir::cast<RankedTensorType>(correspondingOperand.getType()),
+            op.getDevice());
+      } else {
+        dataMovement[PhysicalCoreCoord()] =
+            SmallVector<TTIRToTTMetalLayoutRewriter::NocTx>();
+      }
       streamedOperands.push_back(StreamedOperand(
-          lookupAddress(matchingOperand), lookupAddress(matchingCB),
-          arg.getArgNumber(),
-          calculateDataMovement(
-              op.getIteratorTypes(),
-              mlir::cast<RankedTensorType>(matchingOperand.getType()),
-              mlir::cast<RankedTensorType>(matchingCB.getType()),
-              op.getDevice()),
-          numTiles,
+          lookupAddress(matchingOperand), lookupAddress(correspondingOperand),
+          arg.getArgNumber(), buffer.getBufferAccess() == BufferAccess::Stream,
+          dataMovement, numTiles,
           // TODO(rpavlovic) fix the assumption that input is always in L1.
           PhysicalCoreCoordMapping::getMemorySpaceMapping(
               op.getDevice().getChipIds(), op.getSystemDesc().getChipDescs(),
@@ -1344,6 +1370,268 @@ public:
     return dm;
   }
 
+  static bool needScaler(ttir::GenericOp op) {
+    Block &block = op.getRegion().front();
+    Operation &firstOp = block.getOperations().front();
+    if (!mlir::isa<ttir::KernelOp>(firstOp)) {
+      return false;
+    }
+
+    auto kernelOp = mlir::cast<ttir::KernelOp>(firstOp);
+    if (kernelOp.getOp() != "reduce") {
+      return false;
+    }
+
+    return true;
+  }
+
+  static Type addReduceScaler(ttir::GenericOp op, Block *dmBlock,
+                              ArrayRef<Type> rewrittenBlockArgumentTypes,
+                              PatternRewriter &rewriter) {
+    Block &block = op.getRegion().front();
+    Operation &firstOp = block.getOperations().front();
+    if (!mlir::isa<ttir::KernelOp>(firstOp)) {
+      return nullptr;
+    }
+
+    auto kernelOp = mlir::cast<ttir::KernelOp>(firstOp);
+    if (kernelOp.getOp() != "reduce") {
+      return nullptr;
+    }
+
+    // Take the port after the last input arg.
+    auto scalerCBPort = ttkernel::symbolizeCBPort(
+                            ttmlir::utils::enum_as_int(ttkernel::CBPort::In0) +
+                            op.getInputs().size())
+                            .value();
+    auto inputCB =
+        mlir::cast<ttkernel::CBType>(*rewrittenBlockArgumentTypes.begin());
+    auto inputTT = mlir::cast<TileType>(inputCB.getMemref().getElementType());
+    assert(inputTT);
+
+    // Single tile memref that will be used for the scaler.
+    MemRefType tileMemref = MemRefType::get(
+        {1, 1}, inputTT,
+        mlir::AffineMap::getMultiDimIdentityMap(2, op->getContext()),
+        MemorySpaceAttr::get(op->getContext(), MemorySpace::DeviceL1));
+
+    auto scalerCBType = ttkernel::CBType::get(
+        op.getContext(), scalerCBPort,
+        op.getSystemDesc().getChipDescs().front().getGlobalL1RegionAddress(),
+        tileMemref, true /* is_internal */);
+    auto scalerCB = dmBlock->addArgument(scalerCBType, op.getLoc());
+
+    auto reduceKind = kernelOp.getKind();
+    float scalerValue = 0.;
+    if (reduceKind == "sum" || reduceKind == "max") {
+      scalerValue = 1.;
+    }
+
+    if (reduceKind == "mean") {
+      int64_t numElements = 1;
+      auto inputType =
+          mlir::cast<RankedTensorType>(op.getInputs()[0].getType());
+
+      for (int64_t dim = 0; dim < inputType.getRank(); ++dim) {
+        auto iteratorType =
+            mlir::cast<IteratorTypeAttr>(op.getIteratorTypes()[dim]);
+        if (iteratorType.getValue() == IteratorType::Reduction) {
+          numElements *= inputType.getShape()[dim];
+        }
+      }
+      scalerValue = 1. / numElements;
+    }
+
+    generateScaler(op.getLoc(), dmBlock, scalerCB, scalerValue);
+
+    return scalerCBType;
+  }
+
+  // Given float value fValue, generate a scaler tile with value fValue. Tile
+  // should be populated in pattern such that only first row of each face is
+  // populated with fValue, while the rest of the tile is zeroed out.
+  static void generateScaler(Location loc, Block *block,
+                             BlockArgument &scalerCB, float fValue) {
+    OpBuilder builder(block, block->begin());
+
+    // Assumption is that scalerCB is tile of F16/BF16 values. Converting from
+    // float to 2byte float is truncating mantissa bits. To support lesser
+    // fortmats we need to add conversion from float to those formats, which is
+    // trickier than just truncating mantissa bits.
+    uint32_t iValue = *reinterpret_cast<uint32_t *>(&fValue);
+    iValue >>= 16;
+    uint16_t iValue16 = iValue & 0xFFFF;
+    auto scalerConst = builder.create<arith::ConstantOp>(
+        loc, builder.getI32Type(),
+        builder.getI32IntegerAttr(iValue16 | (iValue16 << 16)));
+
+    // Reserve single tile.
+    auto oneConst = builder.create<arith::ConstantOp>(
+        loc, builder.getI32Type(), builder.getI32IntegerAttr(1));
+    builder.create<ttkernel::CBReserveBackOp>(loc, scalerCB, oneConst);
+
+    // Prepare zero region read.
+    auto zerosBase = builder.create<ttkernel::MacroOp>(
+        loc, builder.getI32Type(), "MEM_ZEROS_BASE");
+    auto zerosNocAddr =
+        builder.create<ttkernel::GetNocAddrOp>(loc, zerosBase->getResult(0));
+    auto memZerosSize = builder.create<ttkernel::MacroOp>(
+        loc, builder.getI32Type(), "MEM_ZEROS_SIZE");
+    builder.create<ttkernel::NocAsyncReadOnePacketSetStateOp>(loc, zerosNocAddr,
+                                                              memZerosSize);
+
+    // Prepare pointer to scalerCB tile.
+    auto writeAddr = builder.create<ttkernel::GetWritePtrOp>(loc, scalerCB);
+    auto ptr = builder.create<ttkernel::CastToL1PtrOp>(loc, writeAddr);
+
+    // Zeros are read in few packets, so we need to calculate how many reads.
+    // Assumption is that scalerCB is 2048 bytes.
+    auto lowerBound = builder.create<arith::ConstantOp>(
+        loc, builder.getI32Type(), builder.getI32IntegerAttr(0));
+    auto cbSizeBytes = builder.create<arith::ConstantOp>(
+        loc, builder.getI32Type(), builder.getI32IntegerAttr(2048));
+    auto numZerosReads = builder.create<arith::DivSIOp>(
+        loc, builder.getI32Type(), cbSizeBytes, memZerosSize);
+    auto step = builder.create<arith::ConstantOp>(loc, builder.getI32Type(),
+                                                  builder.getI32IntegerAttr(1));
+
+    // Generate loop to read zeros and fill tile. Move address by memZerosSize
+    // in each iteration.
+    auto forOp = builder.create<scf::ForOp>(loc, lowerBound, numZerosReads,
+                                            step, ValueRange(writeAddr));
+    builder.setInsertionPointToStart(forOp.getBody());
+    builder.create<ttkernel::NocAsyncReadOnePacketWithStateOp>(
+        loc, zerosNocAddr, forOp.getRegionIterArg(0));
+    SmallVector<Value> newAddr;
+    newAddr.push_back(builder.create<arith::AddIOp>(
+        loc, forOp.getRegionIterArg(0), memZerosSize,
+        mlir::arith::IntegerOverflowFlagsAttr::get(
+            builder.getContext(), mlir::arith::IntegerOverflowFlags::nsw)));
+    builder.create<scf::YieldOp>(loc, newAddr);
+
+    builder.setInsertionPointAfter(forOp);
+    builder.create<ttkernel::NocAsyncReadBarrierOp>(loc);
+
+    // Fill the tile in 2 nested loops. Outer loop is for 4 faces.
+    auto numFaces = builder.create<arith::ConstantOp>(
+        loc, builder.getI32Type(), builder.getI32IntegerAttr(4));
+    auto fillingOuterLoop = builder.create<scf::ForOp>(
+        loc, lowerBound, numFaces, step, ValueRange{});
+
+    auto faceIndex = fillingOuterLoop.getInductionVar();
+    builder.setInsertionPointToStart(fillingOuterLoop.getBody());
+
+    // In each face, we want to fill first row of 16 datums, each datum being
+    // sized 2B. So we need to fill 32B in each face. Since we packed 4B in
+    // scalerConst, this gives us 8 stores in each face.
+    // After each face, we need to move to next face, which is 512B away (or
+    // 128x4B).
+    auto bytesStride = builder.create<arith::ConstantOp>(
+        loc, builder.getI32Type(), builder.getI32IntegerAttr(128));
+    auto offset = builder.create<arith::MulIOp>(
+        loc, faceIndex, bytesStride,
+        mlir::arith::IntegerOverflowFlagsAttr::get(
+            builder.getContext(), mlir::arith::IntegerOverflowFlags::nsw));
+
+    auto numStores = builder.create<arith::ConstantOp>(
+        loc, builder.getI32Type(), builder.getI32IntegerAttr(8));
+    auto fillingInnerLoop = builder.create<scf::ForOp>(
+        loc, lowerBound, numStores, step, ValueRange{});
+
+    builder.setInsertionPointToStart(fillingInnerLoop.getBody());
+    auto fillingIdx = builder.create<arith::AddIOp>(
+        loc, offset, fillingInnerLoop.getInductionVar(),
+        mlir::arith::IntegerOverflowFlagsAttr::get(
+            builder.getContext(), mlir::arith::IntegerOverflowFlags::nsw));
+    builder.create<ttkernel::StoreToL1Op>(loc, scalerConst, ptr, fillingIdx);
+
+    // Notify that we filled the tile.
+    builder.setInsertionPointAfter(fillingOuterLoop);
+    builder.create<ttkernel::CBPushBackOp>(loc, scalerCB, oneConst);
+  }
+
+  void generateDataMovementThreads(
+      ttir::GenericOp op, Block *tensixBlock,
+      ArrayRef<StreamedOperand> streamedOperands, PatternRewriter &rewriter,
+      ttmetal::DispatchOp &metalDispatch,
+      ArrayRef<Type> rewrittenBlockArgumentTypes) const {
+
+    // TODO(radenko) move TTIRToTTMetalLayoutRewriter::createDataMovementThreads
+    // (& other data movement logic) into common place
+    int dmThreadIdx = 1;
+    assert(!streamedOperands.empty());
+
+    llvm::DenseMap<PhysicalCoreCoord, Block *> coordToBlock;
+    for (auto operand : streamedOperands) {
+      if (!operand.hasDataMovement) {
+        continue;
+      }
+      for (auto [dstCoord, srcs] : operand.dataMovement) {
+        Block *block =
+            coordToBlock.find(dstCoord) == coordToBlock.end()
+                ? rewriter.createBlock(&metalDispatch.getRegion(dmThreadIdx++))
+                : coordToBlock[dstCoord];
+        coordToBlock[dstCoord] = block;
+
+        block->addArgument(rewrittenBlockArgumentTypes[operand.blockArgIndex],
+                           op.getLoc());
+
+        auto streamedCB = block->getArgument(0);
+
+        TTIRToTTMetalLayoutRewriter::createDataMovementThread(
+            op->getLoc(), block, operand.srcAddress, operand.dstAddress, srcs,
+            operand.coordMappping, op.getSystemDesc().getAddressAlignBytes(),
+            &streamedCB);
+      }
+    }
+
+    if (needScaler(op)) {
+      if (coordToBlock.empty()) {
+        // No data movement, so we need to add a block for the scaler.
+        coordToBlock[PhysicalCoreCoord()] =
+            rewriter.createBlock(&metalDispatch.getRegion(dmThreadIdx++));
+      }
+
+      Type scalerCBType;
+      for (auto [coord, block] : coordToBlock) {
+        scalerCBType =
+            addReduceScaler(op, block, rewrittenBlockArgumentTypes, rewriter);
+      }
+
+      // Propagate the scalerCBType to the compute thread.
+      tensixBlock->addArgument(scalerCBType, op.getLoc());
+    }
+
+    // Finish all blocks with return op.
+    for (auto [coord, block] : coordToBlock) {
+      OpBuilder builder = OpBuilder::atBlockEnd(block);
+      builder.create<ttkernel::ReturnOp>(op.getLoc());
+    }
+  }
+
+  static void
+  addSyncronizationForDataMovement(ttir::GenericOp op, Block *tensixBlock,
+                                   ArrayRef<StreamedOperand> streamedOperands) {
+    for (auto operand : streamedOperands) {
+      if (operand.hasDataMovement) {
+        // There is some data movement. Let's just insert waiting command at the
+        // start of compute block. We assume whole block is streamed.
+        OpBuilder builder(tensixBlock, tensixBlock->begin());
+        auto numPages = builder.create<arith::ConstantOp>(
+            op.getLoc(), builder.getI32Type(),
+            builder.getI32IntegerAttr(operand.numTiles));
+
+        auto streamedCB = tensixBlock->getArgument(operand.blockArgIndex);
+        builder.create<ttkernel::CBWaitFrontOp>(op.getLoc(), streamedCB,
+                                                numPages);
+
+        builder.setInsertionPoint(tensixBlock->getTerminator());
+        builder.create<ttkernel::CBPopFrontOp>(op.getLoc(), streamedCB,
+                                               numPages);
+      }
+    }
+  }
+
   LogicalResult matchAndRewrite(ttir::GenericOp op,
                                 PatternRewriter &rewriter) const final {
     // Temporary fix that allows ttir::KernelOp to be lowered directly into
@@ -1374,19 +1662,37 @@ public:
         getBlockArgumentTypesAsCBs(op, op->getRegion(0).getArguments(),
                                    rewriter);
 
-    assert(streamedOperands.size() <= 1 &&
-           "Expecting at most one streamed operand for now");
+    assert(!streamedOperands.empty());
 
-    if (!streamedOperands.empty()) {
-      auto &dm = streamedOperands[0].dataMovement;
-      for (auto [dstCoord, srcs] : dm) {
-        kernelConfigs.push_back(ttkernel::NocConfigAttr::get(
-            rewriter.getContext(),
-            ttkernel::NocIndex::Noc0)); // TODO(rpavlovic) choose Noc0 vs Noc1
-                                        // based off transaction type
-        coreRanges.push_back(ttmetal::CoreRangeAttr::get(
-            getContext(), {dstCoord.y, dstCoord.x}, {1, 1} /* size */));
+    // Minimal mapping to cover whole generic op grid w.r.t. data movement
+    // requirements of all operands. Today, each destination core gets its own
+    // unique kernel for data movement, while in the future we'll want to merge
+    // them into less kernels if possible and configure them through kernel
+    // configs. Operands that have no data movement simply cover whole op grid.
+    llvm::DenseMap<PhysicalCoreCoord, SmallVector<int64_t, 2>> allDstCoords;
+    for (auto operand : streamedOperands) {
+      for (auto [dstCoord, srcs] : operand.dataMovement) {
+        if (allDstCoords.find(dstCoord) != allDstCoords.end() &&
+            !operand.hasDataMovement) {
+          // Some other operand already added this dstCoord, we don't want to
+          // overwrite it by this operand which has no data movement.
+          continue;
+        }
+        allDstCoords.try_emplace(dstCoord, operand.hasDataMovement
+                                               ? SmallVector<int64_t>({1, 1})
+                                               : op.getGrid().getShape());
       }
+    }
+
+    assert(!allDstCoords.empty() && "There should be at least one dstCoord");
+
+    for (auto [dstCoord, gridShape] : allDstCoords) {
+      kernelConfigs.push_back(ttkernel::NocConfigAttr::get(
+          rewriter.getContext(), ttkernel::NocIndex::Noc0));
+      // If no data movement transactions are needed, let's cover whole op
+      // grid.
+      coreRanges.push_back(ttmetal::CoreRangeAttr::get(
+          getContext(), {dstCoord.y, dstCoord.x}, gridShape));
     }
 
     // Wire generic's operands to dispatch op's operands with respect to the CB
@@ -1410,45 +1716,13 @@ public:
       tensixBlock->addArgument(ty, op.getLoc());
     }
 
-    // TODO(radenko) move TTIRToTTMetalLayoutRewriter::createDataMovementThreads
-    // (& other data movement logic) into common place
-    int dmThreadIdx = 1;
-
-    if (!streamedOperands.empty()) {
-      for (auto [dstCoord, srcs] : streamedOperands[0].dataMovement) {
-        Block *block =
-            rewriter.createBlock(&metalDispatch.getRegion(dmThreadIdx++));
-        block->addArgument(
-            rewrittenBlockArgumentTypes[streamedOperands[0].blockArgIndex],
-            op.getLoc());
-        auto streamedCB = block->getArgument(0);
-
-        TTIRToTTMetalLayoutRewriter::createDataMovementThread(
-            op->getLoc(), block, streamedOperands[0].srcAddress,
-            streamedOperands[0].dstAddress, srcs,
-            streamedOperands[0].coordMappping,
-            op.getSystemDesc().getAddressAlignBytes(), &streamedCB);
-      }
-    }
+    generateDataMovementThreads(op, tensixBlock, streamedOperands, rewriter,
+                                metalDispatch, rewrittenBlockArgumentTypes);
 
     lowerBlock(&op->getRegion(0).front(), tensixBlock, op.getIteratorTypes(),
                op.getIndexingMaps(), op.getInputs().size());
 
-    if (kernelConfigs.size() > 1) {
-      // There is some data movement. Let's just insert waiting command at the
-      // start of compute block. We assume whole block is streamed.
-      OpBuilder builder(tensixBlock, tensixBlock->begin());
-      auto numPages = builder.create<arith::ConstantOp>(
-          op.getLoc(), builder.getI32Type(),
-          builder.getI32IntegerAttr(streamedOperands[0].numTiles));
-      auto streamedCB =
-          tensixBlock->getArgument(streamedOperands[0].blockArgIndex);
-      builder.create<ttkernel::CBWaitFrontOp>(op.getLoc(), streamedCB,
-                                              numPages);
-
-      builder.setInsertionPoint(tensixBlock->getTerminator());
-      builder.create<ttkernel::CBPopFrontOp>(op.getLoc(), streamedCB, numPages);
-    }
+    addSyncronizationForDataMovement(op, tensixBlock, streamedOperands);
 
     rewriter.replaceOp(op, metalDispatch);
 

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
@@ -386,11 +386,11 @@ public:
     Type inputCBTy = rewriter.getType<ttkernel::CBType>(
         ttkernel::CBPort::In0, inputBaseAddress,
         mlir::cast<MemRefType>(inputLayout.getMemref()), pageSize,
-        /*num_buffers*/ 1, false /* is_internal */);
+        /*num_buffers*/ 1);
     Type outputCBTy = rewriter.getType<ttkernel::CBType>(
         ttkernel::CBPort::Out0, outputBaseAddress,
         mlir::cast<MemRefType>(outputLayout.getMemref()), pageSize,
-        /*num_buffers*/ 1, false /* is_internal */);
+        /*num_buffers*/ 1);
     tensixBlock->addArgument(inputCBTy, op.getLoc());
     tensixBlock->addArgument(outputCBTy, op.getLoc());
 
@@ -1411,8 +1411,8 @@ public:
 
     auto scalerCBType = ttkernel::CBType::get(
         op.getContext(), scalerCBPort,
-        op.getSystemDesc().getChipDescs().front().getGlobalL1RegionAddress(),
-        tileMemref, true /* is_internal */);
+        op.getSystemDesc().getChipDescs().front().getScratchL1RegionAddress(),
+        tileMemref);
     auto scalerCB = dmBlock->addArgument(scalerCBType, op.getLoc());
 
     auto reduceKind = kernelOp.getKind();
@@ -1465,12 +1465,12 @@ public:
     builder.create<ttkernel::CBReserveBackOp>(loc, scalerCB, oneConst);
 
     // Prepare zero region read.
-    auto zerosBase = builder.create<ttkernel::MacroOp>(
-        loc, builder.getI32Type(), "MEM_ZEROS_BASE");
+    auto zerosBase =
+        builder.create<ttkernel::MemZerosBaseOp>(loc, builder.getI32Type());
     auto zerosNocAddr =
         builder.create<ttkernel::GetNocAddrOp>(loc, zerosBase->getResult(0));
-    auto memZerosSize = builder.create<ttkernel::MacroOp>(
-        loc, builder.getI32Type(), "MEM_ZEROS_SIZE");
+    auto memZerosSize =
+        builder.create<ttkernel::MemZerosSizeOp>(loc, builder.getI32Type());
     builder.create<ttkernel::NocAsyncReadOnePacketSetStateOp>(loc, zerosNocAddr,
                                                               memZerosSize);
 

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -145,8 +145,10 @@ public:
                   ConversionPatternRewriter &rewriter) const final {
     auto subscriptOp = rewriter.create<emitc::SubscriptOp>(
         op->getLoc(),
-        mlir::cast<emitc::PointerType>(adaptor.getL1Ptr().getType())
-            .getPointee(),
+        emitc::LValueType::get(
+            op.getContext(),
+            mlir::cast<emitc::PointerType>(adaptor.getL1Ptr().getType())
+                .getPointee()),
         adaptor.getL1Ptr(), adaptor.getOffset());
 
     // Cast rhs to volatile tt_l1_ptr uint32_t to match the pointed type.

--- a/lib/Dialect/TT/IR/TTOpsTypes.cpp
+++ b/lib/Dialect/TT/IR/TTOpsTypes.cpp
@@ -26,14 +26,14 @@ using namespace mlir::tt;
 #define GET_TYPEDEF_CLASSES
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.cpp.inc"
 
-unsigned mlir::tt::ChipDescAttr::getGlobalL1RegionSize() const {
-  // 4KB is the default size for the global L1 region.
-  constexpr uint32_t kGlobalL1RegionSize = 1 << 12;
-  return kGlobalL1RegionSize;
+unsigned mlir::tt::ChipDescAttr::getScratchL1RegionSize() const {
+  // 4KB is the default size for the scratch L1 region.
+  constexpr uint32_t kScratchL1RegionSize = 1 << 12;
+  return kScratchL1RegionSize;
 }
 
-unsigned mlir::tt::ChipDescAttr::getGlobalL1RegionAddress() const {
-  return getL1Size() - getGlobalL1RegionSize();
+unsigned mlir::tt::ChipDescAttr::getScratchL1RegionAddress() const {
+  return getL1Size() - getScratchL1RegionSize();
 }
 
 mlir::tt::SystemDescAttr

--- a/lib/Dialect/TT/IR/TTOpsTypes.cpp
+++ b/lib/Dialect/TT/IR/TTOpsTypes.cpp
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <cstdint>
 #include <fstream>
+#include <mlir/IR/BuiltinTypes.h>
 #include <numeric>
 
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
@@ -23,6 +25,16 @@ using namespace mlir::tt;
 
 #define GET_TYPEDEF_CLASSES
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.cpp.inc"
+
+unsigned mlir::tt::ChipDescAttr::getGlobalL1RegionSize() const {
+  // 4KB is the default size for the global L1 region.
+  constexpr uint32_t kGlobalL1RegionSize = 1 << 12;
+  return kGlobalL1RegionSize;
+}
+
+unsigned mlir::tt::ChipDescAttr::getGlobalL1RegionAddress() const {
+  return getL1Size() - getGlobalL1RegionSize();
+}
 
 mlir::tt::SystemDescAttr
 mlir::tt::SystemDescAttr::getDefault(MLIRContext *context) {

--- a/lib/Dialect/TTIR/Transforms/Allocate.cpp
+++ b/lib/Dialect/TTIR/Transforms/Allocate.cpp
@@ -108,7 +108,8 @@ public:
     memorySpaceInfo.resize(getMaxEnumValForMemorySpace() + 1llu);
     memorySpaceInfo[ttmlir::utils::enum_as_int(MemorySpace::DeviceL1)] =
         SimpleAllocator::MemorySpaceInfo(chipDesc.getL1UnreservedBase(),
-                                         chipDesc.getL1Size(),
+                                         chipDesc.getL1Size() -
+                                             chipDesc.getGlobalL1RegionSize(),
                                          chipDesc.getNocL1AddressAlignBytes());
     memorySpaceInfo[ttmlir::utils::enum_as_int(MemorySpace::DeviceDRAM)] =
         SimpleAllocator::MemorySpaceInfo(

--- a/lib/Dialect/TTIR/Transforms/Allocate.cpp
+++ b/lib/Dialect/TTIR/Transforms/Allocate.cpp
@@ -109,7 +109,7 @@ public:
     memorySpaceInfo[ttmlir::utils::enum_as_int(MemorySpace::DeviceL1)] =
         SimpleAllocator::MemorySpaceInfo(chipDesc.getL1UnreservedBase(),
                                          chipDesc.getL1Size() -
-                                             chipDesc.getGlobalL1RegionSize(),
+                                             chipDesc.getScratchL1RegionSize(),
                                          chipDesc.getNocL1AddressAlignBytes());
     memorySpaceInfo[ttmlir::utils::enum_as_int(MemorySpace::DeviceDRAM)] =
         SimpleAllocator::MemorySpaceInfo(

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -265,7 +265,8 @@ static std::shared_ptr<void> translateModuleToFlatbuffer(
           for (auto arg : region.getArguments()) {
             auto cbType = mlir::cast<ttkernel::CBType>(arg.getType());
             auto cbDesc = cache.getOrCreate(cbType, cbTypeToFlatbuffer);
-            auto tensorRef = cbType.getIsInternal() ? 0 : operands[argNumber++];
+            auto tensorRef =
+                argNumber >= operands.size() ? 0 : operands[argNumber++];
             cbs.push_back(
                 ::tt::target::CreateCBRef(fbb, cache.global_id++, tensorRef,
                                           cbType.getAddress(), cbDesc));

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cassert>
+#include <cstddef>
+#include <flatbuffers/buffer.h>
 #include <memory>
 
 #include "mlir/Dialect/EmitC/IR/EmitC.h"
@@ -25,6 +27,7 @@
 #include "ttmlir/Target/Utils/FlatbufferObjectCache.h"
 #include "ttmlir/Target/Utils/MLIRToFlatbuffer.h"
 #include "ttmlir/Version.h"
+#include "types_generated.h"
 
 namespace mlir::tt::ttmetal {
 
@@ -253,17 +256,16 @@ static std::shared_ptr<void> translateModuleToFlatbuffer(
             emitDispatchOpRegionsAsCpp(dispatchOp, cppKernels);
         assert(success.succeeded() &&
                "failed to emit dispatch op regions as cpp");
-
         for (auto &region : dispatchOp.getRegions()) {
           std::vector<::tt::target::Dim2dRange> coreRangeSet = {
               toFlatbuffer(mlir::cast<CoreRangeAttr>(
                   dispatchOp.getCoreRanges()[region.getRegionNumber()]))};
           std::vector<::flatbuffers::Offset<::tt::target::CBRef>> cbs;
+          size_t argNumber = 0;
           for (auto arg : region.getArguments()) {
-            assert(arg.getArgNumber() < operands.size());
             auto cbType = mlir::cast<ttkernel::CBType>(arg.getType());
             auto cbDesc = cache.getOrCreate(cbType, cbTypeToFlatbuffer);
-            auto tensorRef = operands[arg.getArgNumber()];
+            auto tensorRef = cbType.getIsInternal() ? 0 : operands[argNumber++];
             cbs.push_back(
                 ::tt::target::CreateCBRef(fbb, cache.global_id++, tensorRef,
                                           cbType.getAddress(), cbDesc));

--- a/runtime/include/tt/runtime/detail/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal.h
@@ -41,6 +41,7 @@
 #pragma clang diagnostic ignored "-Wzero-length-array"
 #define FMT_HEADER_ONLY
 #include "distributed/mesh_device.hpp"
+#include "impl/buffers/circular_buffer.hpp"
 #include "impl/event/event.hpp"
 #include "tt_metal/host_api.hpp"
 #pragma clang diagnostic pop

--- a/runtime/lib/ttmetal/command_queue.cpp
+++ b/runtime/lib/ttmetal/command_queue.cpp
@@ -31,13 +31,6 @@ struct CQExecutor {
   CQExecutor(::tt::tt_metal::Device *device, std::size_t cq_id,
              std::vector<InputBuffer> const &inputs,
              std::vector<OutputBuffer> const &outputs);
-  ~CQExecutor() {
-    ::tt::tt_metal::DeallocateBuffer(*buffers.at(kReservedBufferId));
-    buffers.erase(kReservedBufferId);
-  }
-
-  constexpr static uint32_t kReservedBufferId = 1 << 20;
-  void createReservedL1Buffer();
 
   std::shared_ptr<::tt::tt_metal::Event>
   execute(::tt::target::metal::CommandQueue const *commandQueue);
@@ -74,47 +67,6 @@ CQExecutor::CQExecutor(::tt::tt_metal::Device *device, std::size_t cq_id,
   }
 
   cq = &device->command_queue(cq_id);
-
-  createReservedL1Buffer();
-}
-
-void CQExecutor::createReservedL1Buffer() {
-  // Ideally size of the reserved space should be part of system desc.
-  constexpr uint32_t dimSize = 32;
-  constexpr uint32_t sizeKB = dimSize * dimSize * 4;
-  const uint32_t address = device->l1_size_per_core() - sizeKB;
-
-  CoreCoord cores = device->logical_grid_size();
-
-  std::array<uint32_t, 2> shape = {dimSize, dimSize};
-  ShardSpec shardSpec(
-      CoreRangeSet(
-          {CoreRange(CoreCoord(0, 0), CoreCoord(cores.x - 1, cores.y - 1))}),
-      shape);
-
-  array<uint32_t, 2> tensorShape = {static_cast<uint32_t>(cores.y),
-                                    static_cast<uint32_t>(cores.x)};
-  ShardSpecBuffer shardSpecBuffer(shardSpec, {dimSize, dimSize}, tensorShape);
-
-  tt::target::DataType dataType = tt::target::DataType::Float16;
-  uint64_t itemSize = ::tt::runtime::utils::dataTypeElementSize(dataType);
-  array<uint32_t, 2> pageShape = {dimSize, dimSize};
-  uint64_t pageSize = pageShape[0] * pageShape[1] * itemSize;
-  uint64_t size = pageSize * cores.x * cores.y;
-  ShardedBufferConfig shardConfig = {.device = device,
-                                     .size = size,
-                                     .page_size = pageSize,
-                                     .buffer_type = BufferType::L1,
-                                     .buffer_layout =
-                                         TensorMemoryLayout::BLOCK_SHARDED,
-                                     .shard_parameters = shardSpecBuffer,
-                                     .allocate = false};
-
-  std::shared_ptr<::tt::tt_metal::Buffer> buffer =
-      ::tt::tt_metal::CreateBuffer(shardConfig);
-  buffer->set_address(address);
-
-  buffers[kReservedBufferId] = buffer;
 }
 
 std::shared_ptr<::tt::tt_metal::Event>
@@ -420,14 +372,8 @@ static ::tt::tt_metal::CircularBufferConfig createCircularBufferConfig(
       toDataFormat(cbRef->desc()->memory_desc()->data_type());
 
   if (!cbRef->tensor_ref()) {
-    assert(cbRef->address() >=
-           buffers.at(CQExecutor::kReservedBufferId)->address());
-    // TODO specifying address to CB must be done through shadow buffer.
-    // However, in this case we're seeing weird behavior w.r.t. to results when
-    // using shadow buffer. This needs to be investigated further.
     return CircularBufferConfig(totalSize,
                                 {{cbRef->desc()->port(), dataFormat}})
-        // *buffers.at(CQExecutor::kReservedBufferId))
         .set_page_size(cbRef->desc()->port(), cbRef->desc()->page_size());
   }
 
@@ -521,7 +467,19 @@ void CQExecutor::execute(
       }
       ::tt::tt_metal::CircularBufferConfig config =
           createCircularBufferConfig(cbRef, buffers);
-      ::tt::tt_metal::CreateCircularBuffer(program, coreRangeSet, config);
+      CBHandle cbHandle =
+          ::tt::tt_metal::CreateCircularBuffer(program, coreRangeSet, config);
+
+      if (!cbRef->tensor_ref()) {
+        // Internally allocated CBs are not associated with any tensor ref. We
+        // need to set the address of the CB manually.
+        std::shared_ptr<CircularBuffer> cbPtr =
+            tt_metal::detail::GetCircularBuffer(program, cbHandle);
+        assert(!cbPtr->globally_allocated() &&
+               "CB should not be globally allocated");
+        cbPtr->set_locally_allocated_address(cbRef->address());
+      }
+
       createdCBs.insert(cbRef->desc()->port());
     }
 

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -15,11 +15,11 @@ module attributes {} {
     // CHECK: [[C:.*]] = "emitc.constant"[[C:.*]]
     %c262144_i32 = arith.constant 262144 : i32
     // CHECK: [[C:.*]] = emitc.call_opaque "get_noc_addr"[[C:.*]]
-    %3 = "ttkernel.get_noc_addr"(%c0_i32, %c0_i32, %c262144_i32) : (i32, i32, i32) -> !ttkernel.noc_addr
+    %3 = "ttkernel.get_noc_addr_xy"(%c0_i32, %c0_i32, %c262144_i32) : (i32, i32, i32) -> !ttkernel.noc_addr
     // CHECK: emitc.call_opaque "noc_async_read"[[C:.*]]
     "ttkernel.noc_async_read"(%3, %c262400_i32, %c32_i32) : (!ttkernel.noc_addr, i32, i32) -> ()
     // CHECK: [[C:.*]] = emitc.call_opaque "get_noc_addr"[[C:.*]]
-    %4 = "ttkernel.get_noc_addr"(%c0_i32, %c0_i32, %c262208_i32) : (i32, i32, i32) -> !ttkernel.noc_addr
+    %4 = "ttkernel.get_noc_addr_xy"(%c0_i32, %c0_i32, %c262208_i32) : (i32, i32, i32) -> !ttkernel.noc_addr
     // CHECK: emitc.call_opaque "noc_async_read"[[C:.*]]
     "ttkernel.noc_async_read"(%4, %c262432_i32, %c32_i32) : (!ttkernel.noc_addr, i32, i32) -> ()
     // CHECK: emitc.call_opaque "noc_async_read_barrier"[[C:.*]]
@@ -27,23 +27,23 @@ module attributes {} {
     "ttkernel.return"() : () -> ()
   }
 
-  func.func @ttkernel_tensix(%arg1: !ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>,
-                             %arg2: !ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1>) -> () {
+  func.func @ttkernel_tensix(%arg1: !ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1, false>,
+                             %arg2: !ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1, false>) -> () {
       %c4_i32 = arith.constant 4 : i32
       // CHECK: emitc.call_opaque "untilize_init"[[C:.*]]
-      "ttkernel.untilize_init"(%arg1, %arg2) : (!ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, !ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1>) -> ()
+      "ttkernel.untilize_init"(%arg1, %arg2) : (!ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1, false>, !ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1, false>) -> ()
       // CHECK: emitc.call_opaque "untilize_block"[[C:.*]]
-      "ttkernel.untilize_block"(%arg1, %c4_i32, %arg2) : (!ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, i32, !ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1>) -> ()
+      "ttkernel.untilize_block"(%arg1, %c4_i32, %arg2) : (!ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1, false>, i32, !ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1, false>) -> ()
       // CHECK: emitc.call_opaque "cb_pop_front"[[C:.*]]
-      "ttkernel.cb_pop_front"(%arg1, %c4_i32) : (!ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, i32) -> ()
+      "ttkernel.cb_pop_front"(%arg1, %c4_i32) : (!ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1, false>, i32) -> ()
       // CHECK: emitc.call_opaque "cb_push_back"[[C:.*]]
-      "ttkernel.cb_push_back"(%arg2, %c4_i32) : (!ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1>, i32) -> ()
+      "ttkernel.cb_push_back"(%arg2, %c4_i32) : (!ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1, false>, i32) -> ()
       // CHECK: emitc.call_opaque "untilize_block"[[C:.*]]
-      "ttkernel.untilize_block"(%arg1, %c4_i32, %arg2) : (!ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, i32, !ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1>) -> ()
+      "ttkernel.untilize_block"(%arg1, %c4_i32, %arg2) : (!ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1, false>, i32, !ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1, false>) -> ()
       // CHECK: emitc.call_opaque "cb_pop_front"[[C:.*]]
-      "ttkernel.cb_pop_front"(%arg1, %c4_i32) : (!ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, i32) -> ()
+      "ttkernel.cb_pop_front"(%arg1, %c4_i32) : (!ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1, false>, i32) -> ()
       // CHECK: emitc.call_opaque "cb_push_back"[[C:.*]]
-      "ttkernel.cb_push_back"(%arg2, %c4_i32) : (!ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1>, i32) -> ()
+      "ttkernel.cb_push_back"(%arg2, %c4_i32) : (!ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1, false>, i32) -> ()
       // CHECK: return
       "ttkernel.return"() : () -> ()
   }

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -27,23 +27,23 @@ module attributes {} {
     "ttkernel.return"() : () -> ()
   }
 
-  func.func @ttkernel_tensix(%arg1: !ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1, false>,
-                             %arg2: !ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1, false>) -> () {
+  func.func @ttkernel_tensix(%arg1: !ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>,
+                             %arg2: !ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1>) -> () {
       %c4_i32 = arith.constant 4 : i32
       // CHECK: emitc.call_opaque "untilize_init"[[C:.*]]
-      "ttkernel.untilize_init"(%arg1, %arg2) : (!ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1, false>, !ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1, false>) -> ()
+      "ttkernel.untilize_init"(%arg1, %arg2) : (!ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, !ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1>) -> ()
       // CHECK: emitc.call_opaque "untilize_block"[[C:.*]]
-      "ttkernel.untilize_block"(%arg1, %c4_i32, %arg2) : (!ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1, false>, i32, !ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1, false>) -> ()
+      "ttkernel.untilize_block"(%arg1, %c4_i32, %arg2) : (!ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, i32, !ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1>) -> ()
       // CHECK: emitc.call_opaque "cb_pop_front"[[C:.*]]
-      "ttkernel.cb_pop_front"(%arg1, %c4_i32) : (!ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1, false>, i32) -> ()
+      "ttkernel.cb_pop_front"(%arg1, %c4_i32) : (!ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, i32) -> ()
       // CHECK: emitc.call_opaque "cb_push_back"[[C:.*]]
-      "ttkernel.cb_push_back"(%arg2, %c4_i32) : (!ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1, false>, i32) -> ()
+      "ttkernel.cb_push_back"(%arg2, %c4_i32) : (!ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1>, i32) -> ()
       // CHECK: emitc.call_opaque "untilize_block"[[C:.*]]
-      "ttkernel.untilize_block"(%arg1, %c4_i32, %arg2) : (!ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1, false>, i32, !ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1, false>) -> ()
+      "ttkernel.untilize_block"(%arg1, %c4_i32, %arg2) : (!ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, i32, !ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1>) -> ()
       // CHECK: emitc.call_opaque "cb_pop_front"[[C:.*]]
-      "ttkernel.cb_pop_front"(%arg1, %c4_i32) : (!ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1, false>, i32) -> ()
+      "ttkernel.cb_pop_front"(%arg1, %c4_i32) : (!ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, i32) -> ()
       // CHECK: emitc.call_opaque "cb_push_back"[[C:.*]]
-      "ttkernel.cb_push_back"(%arg2, %c4_i32) : (!ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1, false>, i32) -> ()
+      "ttkernel.cb_push_back"(%arg2, %c4_i32) : (!ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1>, i32) -> ()
       // CHECK: return
       "ttkernel.return"() : () -> ()
   }


### PR DESCRIPTION
fixes #781 

When lowering reduce op, compiler will add additional CB that will represent scaler CB needed by LLK. ScalerCB is filled by constant according to type of reduce operation.

An idea is to leave preallocated space at the top of L1 memory for misc usage in kernels. Scaler CB should be placed inside of this region. Also, TTIR ops should not have context of scaler CB. It should appear only in TTKernel dialect as additional arg when lowering reduce operations.

ScalerCB is populated during kernel runtime, and that should be done in NOC thread since that thread can read zeros in a burst.

For example, loading scaler cb in data movement kernel looks like
```
 ::tt::CB v3 = ::tt::CB::c_in1;
  ::tt::CB v4 = v3;
  int32_t v5 = 1065369472;
  int32_t v6 = 1;
  cb_reserve_back(v4, v6);
  int32_t v7 = MEM_ZEROS_BASE;
  int64_t v8 = get_noc_addr(v7);
  int32_t v9 = MEM_ZEROS_SIZE;
  noc_async_read_one_packet_set_state(v8, v9);
  int32_t v10 = get_write_ptr(v4);
  volatile tt_l1_ptr uint32_t* v11 = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(v10);
  int32_t v12 = 0;
  int32_t v13 = 2048;
  int32_t v14 = v13 / v9;
  int32_t v15 = 1;
  int32_t v16;
  v16 = v10;
  for (int32_t v17 = v12; v17 < v14; v17 += v15) {
    int32_t v18 = v16;
    noc_async_read_one_packet_with_state(v8, v18);
    int32_t v19 = v18 + v9;
    v16 = v19;
  }
  int32_t v20 = v16;
  noc_async_read_barrier();
  int32_t v21 = 4;
  for (int32_t v22 = v12; v22 < v21; v22 += v15) {
    int32_t v23 = 128;
    int32_t v24 = v22 * v23;
    int32_t v25 = 8;
    for (int32_t v26 = v12; v26 < v25; v26 += v15) {
      int32_t v27 = v24 + v26;
      volatile tt_l1_ptr uint32_t v28 = (volatile tt_l1_ptr uint32_t) v5;
      v11[v27] = v28;
    };
  }
  cb_push_back(v4, v6);
```
