### PR TITLE
Marked func::CallOp as legal in StableHLOToTTIRPass and in ArithToStableHLOPass

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/ArithToStableHLOPass.cpp
+++ b/lib/Conversion/StableHLOToTTIR/ArithToStableHLOPass.cpp
@@ -59,6 +59,7 @@ struct ConvertArithToStableHLOPass
     target.addLegalOp<mlir::ModuleOp>();
     target.addLegalOp<mlir::func::FuncOp>();
     target.addLegalOp<mlir::func::ReturnOp>();
+    target.addLegalOp<mlir::func::CallOp>();
 
     // For now keep the same type assuming StableHLO ops operate on builtin
     // tensor.

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPass.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPass.cpp
@@ -79,6 +79,7 @@ struct ConvertStableHLOToTTIRPass
     target.addLegalOp<mlir::ModuleOp>();
     target.addLegalOp<mlir::func::FuncOp>();
     target.addLegalOp<mlir::func::ReturnOp>();
+    target.addLegalOp<mlir::func::CallOp>();
 
     // For now keep the same type assuming StableHLO ops operate on builtin
     // tensor.


### PR DESCRIPTION
Fixes https://github.com/tenstorrent/tt-xla/issues/50.