### PR TITLE
[Optimizer] Resharding ON by default.

### DIFF
--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -49,17 +49,17 @@ def TT_GridAttr : TT_Attr<"Grid", "grid"> {
         return GridAttr::get(context, SmallVector<std::int64_t>(rank, 1));
       }
 
-      uint64_t mutable cNumUsedCores = 0;
-      uint64_t getNumUsedCores() const {
-        if (cNumUsedCores != 0) {
-          return cNumUsedCores;
+      uint64_t mutable cGridVolume = 0;
+      uint64_t getGridVolume() const {
+        if (cGridVolume != 0) {
+          return cGridVolume;
         }
 
-        cNumUsedCores = 1;
+        cGridVolume = 1;
         for (int64_t dim : getShape()) {
-          cNumUsedCores *= dim;
+          cGridVolume *= dim;
         }
-        return cNumUsedCores;
+        return cGridVolume;
       }
   }];
 }

--- a/include/ttmlir/Dialect/TTNN/Analysis/ShardSolver.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/ShardSolver.h
@@ -289,6 +289,7 @@ public:
       const std::unordered_set<Edge> &overrideReshardEdges);
   RemainingLayoutAttrs at(Operation *operation) const;
   void set(Operation *operation, tt::LayoutAttr const &layout);
+  static bool supportsInterleavedInputShardedOutput(Operation *op);
 
 private:
   const llvm::DenseMap<Operation *, std::vector<tt::LayoutAttr>> *legalLayouts;

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -78,10 +78,8 @@ struct TTIRToTTNNBackendPipelineOptions
   //
   Option<bool> memReconfigEnabled{
       *this, "memreconfig-enabled",
-      llvm::cl::desc("Memory layout reconfiguration pass. Temp disabled till "
-                     "we support all types "
-                     "of shard specs."),
-      llvm::cl::init(false)};
+      llvm::cl::desc("Memory layout reconfiguration pass."),
+      llvm::cl::init(true)};
 
   // Specify policy for memory layout analysis.
   //

--- a/include/ttmlir/Dialect/TTNN/Transforms/Optimizer.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Optimizer.h
@@ -121,10 +121,8 @@ protected:
       ::llvm::cl::init(false)};
   ::mlir::Pass::Option<bool> memReconfigEnabled{
       *this, "memreconfig-enabled",
-      ::llvm::cl::desc("Memory layout reconfiguration pass. Temp disabled till "
-                       "we support all "
-                       "types of shard specs."),
-      ::llvm::cl::init(false)};
+      ::llvm::cl::desc("Memory layout reconfiguration pass."),
+      ::llvm::cl::init(true)};
   ::mlir::Pass::Option<mlir::tt::MemoryLayoutAnalysisPolicyType,
                        mlir::tt::MemoryLayoutAnalysisPolicyTypeParser>
       memoryLayoutAnalysisPolicy{

--- a/lib/Dialect/TTNN/Analysis/LegalGridAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/LegalGridAnalysis.cpp
@@ -196,8 +196,7 @@ void LegalGridAnalysis::analysisImplementation() {
   // Pick top largest sharded grids.
   std::sort(shardedResults.begin(), shardedResults.end(),
             [](tt::LayoutAttr a, tt::LayoutAttr b) {
-              return a.getGrid().getNumUsedCores() >
-                     b.getGrid().getNumUsedCores();
+              return a.getGrid().getGridVolume() > b.getGrid().getGridVolume();
             });
 
   analysisResult.insert(

--- a/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
+++ b/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
@@ -21,7 +21,8 @@ ShardSolver::ShardSolver(
     const unsigned usableL1CacheSize,
     const std::unordered_set<Edge> &overrideReshardEdges)
     : legalLayouts(&legalLayouts), shardSpecs(&shardSpecs),
-      shardedOps(&shardedOps), usableL1CacheSize(usableL1CacheSize) {
+      shardedOps(&shardedOps), usableL1CacheSize(usableL1CacheSize),
+      memReconfigEdges(overrideReshardEdges) {
   pathSets.reserve(shardSpecs.size());
   pathSetIds.reserve(shardSpecs.size());
   bitsets.reserve(shardedOps.size());
@@ -44,12 +45,6 @@ ShardSolver::ShardSolver(
         userOpEdges[operandOp].emplace_back(Edge(operandOp, op, operandIndex));
       }
     }
-  }
-
-  // Insert override resharding edges
-  //
-  for (const Edge &edge : overrideReshardEdges) {
-    insertReshard(edge);
   }
 
   // Resolve shard chain.
@@ -181,17 +176,27 @@ bool ShardSolver::resolveStep() {
   return true;
 }
 
+bool ShardSolver::supportsInterleavedInputShardedOutput(Operation *op) {
+  // TODO(nobradovic,mbezulj): Add check whether this op type can have sharded
+  // output from interleaved inputs. For now assuming it can.
+  //
+  return true;
+}
+
 // We need to check if first op requires sharded inputs and if so, insert
 // reshard edge, then invalidate all sharding options which would go above L1
 // size limits.
 //
 void ShardSolver::preprocessFirstOp() {
-  // TODO(nobradovic): Add check whether this op type can have sharded output
-  // from interleaved inputs. For now assuming it can not.
-  //
+  Operation *firstOp = shardSpecs->front().op;
+  if (supportsInterleavedInputShardedOutput(firstOp) &&
+      memReconfigEdges.count(
+          Edge(firstOp->getOperand(0).getDefiningOp(), firstOp, 0)) == 0) {
+    return;
+  }
+
   // Insert reshard edge for the first op to start the chain.
   //
-  Operation *firstOp = shardSpecs->front().op;
   Edge shardChainInputEdge =
       Edge(firstOp->getOperand(0).getDefiningOp(), firstOp, 0 /*operandIndex*/);
 


### PR DESCRIPTION
Enable resharding to be on by default when Optimizer and Memory layout analysis is enabled.
Reworked conditions for inserting resharding edge on first shard chain op. Assume it's not needed unless it is specified that targeted Op type requires it. Perform preprocessing also in case if resharding edge was passed in as override.

Closes [#1161](https://github.com/tenstorrent/tt-mlir/issues/1161)