### PR TITLE
Runtime support for multi-chip tensors/ops

### DIFF
--- a/include/ttmlir/Target/Common/Target.h
+++ b/include/ttmlir/Target/Common/Target.h
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_TARGET_COMMON_TARGET_H
+#define TTMLIR_TARGET_COMMON_TARGET_H
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+
+#include "ttmlir/Target/Common/debug_info_generated.h"
+#include "ttmlir/Target/Common/system_desc_generated.h"
+#include "ttmlir/Target/Common/types_generated.h"
+#include "ttmlir/Target/Common/version_generated.h"
+
+#pragma clang diagnostic pop
+
+#endif

--- a/include/ttmlir/Target/Common/types.fbs
+++ b/include/ttmlir/Target/Common/types.fbs
@@ -85,6 +85,33 @@ table MemoryConfigDesc {
   shard_spec: ShardSpec;
 }
 
+table ReplicateTensor {
+  replication_factor: uint32;
+}
+
+table ShardTensor {
+  shard_dim: uint32;
+}
+
+table ShardTensor2D {
+  shard_mesh: Dim2d;
+}
+
+table AllGatherTensor {
+
+}
+
+union DistributedTensorConfig {
+  ReplicateTensor,
+  ShardTensor,
+  ShardTensor2D,
+  AllGatherTensor
+}
+
+table DistributionStrategy {
+  strategy: DistributedTensorConfig;
+}
+
 table MemoryDesc {
   shape: [int];
   tile_shape: Dim2d;
@@ -99,6 +126,7 @@ table LayoutDesc {
   oob_val: OOBVal;
   core_range_set: [Dim2dRange];
   memory_desc: MemoryDesc;
+  strategy: DistributionStrategy;
 }
 
 table TensorDesc {

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -46,14 +46,18 @@ table EmptyOp {
   shape: [int64];
   dtype: DataType;
   layout: TensorLayout;
+  num_shards: uint32;
   device: tt.target.DeviceRef;         // optional
   memcfg: tt.target.MemoryConfigDesc;  // optional
+  strategy: tt.target.DistributionStrategy;
   out: tt.target.TensorRef;
 }
 
 table FullOp {
   device: tt.target.DeviceRef;
   fill_value: float;
+  num_shards: uint32;
+  strategy: tt.target.DistributionStrategy;
   out: tt.target.TensorRef;
 }
 

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -10,8 +10,7 @@
 
 #include "flatbuffers/flatbuffers.h"
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
-#include "ttmlir/Target/Common/debug_info_generated.h"
-#include "ttmlir/Target/Common/types_generated.h"
+#include "ttmlir/Target/Common/Target.h"
 #include "ttmlir/Target/Utils/FlatbufferObjectCache.h"
 #include "ttmlir/Utils.h"
 
@@ -449,11 +448,18 @@ layoutAttrToFlatbuffer(FlatbufferObjectCache &cache, Attribute attr,
   std::vector<int32_t> stride(strideInt64.begin(), strideInt64.end());
   auto coreRangeSet =
       toFlatbuffer(cache, layoutAttr.getGrid(), deviceAttr.getWorkerGrid());
+  ::tt::target::DistributedTensorConfig distributionType =
+      ::tt::target::DistributedTensorConfig::NONE;
+  ::flatbuffers::Offset<void> distribution = 0;
+  flatbuffers::Offset<::tt::target::DistributionStrategy> strategy =
+      ::tt::target::CreateDistributionStrategy(*cache.fbb, distributionType,
+                                               distribution);
   return ::tt::target::CreateLayoutDescDirect(
       *cache.fbb, &stride, toFlatbuffer(cache, layoutAttr.getOobVal()),
       &coreRangeSet,
       cache.getOrCreate(layoutAttr.getMemref(), memrefAttrToFlatbuffer,
-                        layoutAttr.getMemLayout()));
+                        layoutAttr.getMemLayout()),
+      strategy);
 }
 
 inline flatbuffers::Offset<::tt::target::TensorDesc>

--- a/lib/Dialect/TT/IR/TTOpsTypes.cpp
+++ b/lib/Dialect/TT/IR/TTOpsTypes.cpp
@@ -12,7 +12,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "ttmlir/Dialect/TT/IR/TT.h"
-#include "ttmlir/Target/Common/system_desc_generated.h"
+#include "ttmlir/Target/Common/Target.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/TypeSwitch.h"

--- a/python/TTModule.cpp
+++ b/python/TTModule.cpp
@@ -11,7 +11,7 @@
 #include "mlir/CAPI/IR.h"
 
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
-#include "ttmlir/Target/Common/types_generated.h"
+#include "ttmlir/Target/Common/Target.h"
 #include "ttmlir/Utils.h"
 
 namespace mlir::ttmlir::python {

--- a/runtime/include/tt/runtime/detail/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal.h
@@ -45,6 +45,7 @@
 #pragma clang diagnostic pop
 
 #include "tt/runtime/types.h"
+#include "tt/runtime/utils.h"
 #include "ttmlir/Target/TTMetal/Target.h"
 
 namespace tt::runtime::ttmetal {

--- a/runtime/include/tt/runtime/detail/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn.h
@@ -62,6 +62,7 @@
 #include "ttnn/operations/normalization/softmax/softmax.hpp"
 #include "ttnn/operations/pool/maxpool/max_pool2d.hpp"
 #include "ttnn/operations/reduction/generic/generic_reductions.hpp"
+#include "ttnn/tensor/host_buffer/functions.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/types.hpp"
 #pragma clang diagnostic pop
@@ -81,9 +82,23 @@ Tensor createTensor(std::shared_ptr<void> data,
                     std::vector<std::uint32_t> const &stride,
                     std::uint32_t itemsize, ::tt::target::DataType dataType);
 
+Tensor
+createTensor(std::vector<std::shared_ptr<void>> &data,
+             std::vector<std::uint32_t> const &shape,
+             std::vector<std::uint32_t> const &stride, std::uint32_t itemsize,
+             ::tt::target::DataType dataType,
+             std::unordered_map<std::string, std::string> const &strategy);
+
 inline Tensor createTensor(std::shared_ptr<void> data, TensorDesc const &desc) {
   return createTensor(data, desc.shape, desc.stride, desc.itemsize,
                       desc.dataType);
+}
+
+inline Tensor
+createTensor(std::vector<std::shared_ptr<void>> &data, TensorDesc const &desc,
+             std::unordered_map<std::string, std::string> const &strategy) {
+  return createTensor(data, desc.shape, desc.stride, desc.itemsize,
+                      desc.dataType, strategy);
 }
 
 tt::target::DataType getTensorDataType(Tensor tensor);

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -36,9 +36,23 @@ Tensor createTensor(std::shared_ptr<void> data,
                     std::vector<std::uint32_t> const &stride,
                     std::uint32_t itemsize, ::tt::target::DataType dataType);
 
+Tensor
+createTensor(std::vector<std::shared_ptr<void>> &data,
+             std::vector<std::uint32_t> const &shape,
+             std::vector<std::uint32_t> const &stride, std::uint32_t itemsize,
+             ::tt::target::DataType dataType,
+             std::unordered_map<std::string, std::string> const &strategy);
+
 inline Tensor createTensor(std::shared_ptr<void> data, TensorDesc const &desc) {
   return createTensor(data, desc.shape, desc.stride, desc.itemsize,
                       desc.dataType);
+}
+
+inline Tensor
+createTensor(std::vector<std::shared_ptr<void>> &data, TensorDesc const &desc,
+             std::unordered_map<std::string, std::string> const &strategy) {
+  return createTensor(data, desc.shape, desc.stride, desc.itemsize,
+                      desc.dataType, strategy);
 }
 
 tt::target::DataType getTensorDataType(Tensor tensor);

--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -10,9 +10,11 @@
 #include <string_view>
 #include <vector>
 
-#include "tt/runtime/utils.h"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
 #include "ttmlir/Target/Common/system_desc_generated.h"
 #include "ttmlir/Target/Common/types_generated.h"
+#pragma clang diagnostic pop
 
 namespace tt::runtime {
 

--- a/runtime/include/tt/runtime/utils.h
+++ b/runtime/include/tt/runtime/utils.h
@@ -7,7 +7,10 @@
 
 #include <memory>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
 #include "ttmlir/Target/Common/types_generated.h"
+#pragma clang diagnostic pop
 
 namespace tt::runtime::utils {
 

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -124,6 +124,30 @@ Tensor createTensor(std::shared_ptr<void> data,
   throw std::runtime_error("runtime is not enabled");
 }
 
+Tensor
+createTensor(std::vector<std::shared_ptr<void>> &data,
+             std::vector<std::uint32_t> const &shape,
+             std::vector<std::uint32_t> const &stride, std::uint32_t itemsize,
+             ::tt::target::DataType dataType,
+             std::unordered_map<std::string, std::string> const &strategy) {
+  LOG_ASSERT(not shape.empty());
+  LOG_ASSERT(not stride.empty());
+  LOG_ASSERT(itemsize > 0);
+#if defined(TT_RUNTIME_ENABLE_TTNN)
+  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
+    return ::tt::runtime::ttnn::createTensor(data, shape, stride, itemsize,
+                                             dataType, strategy);
+  }
+#endif
+
+#if defined(TT_RUNTIME_ENABLE_TTMETAL)
+  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
+    throw std::runtime_error("Not implemented");
+  }
+#endif
+  throw std::runtime_error("runtime is not enabled");
+}
+
 tt::target::DataType getTensorDataType(Tensor tensor) {
 #if defined(TT_RUNTIME_ENABLE_TTNN)
   if (getCurrentRuntime() == DeviceRuntime::TTNN) {

--- a/runtime/lib/ttnn/include/tt/runtime/ttnn/types.h
+++ b/runtime/lib/ttnn/include/tt/runtime/ttnn/types.h
@@ -10,12 +10,20 @@
 namespace tt::runtime::ttnn {
 
 using TensorMap = std::unordered_map<uint32_t, ::ttnn::Tensor *>;
-struct ProgramTensorPool {
+using DeviceVariant = std::variant<std::reference_wrapper<::ttnn::Device>,
+                                   std::reference_wrapper<::ttnn::MeshDevice>>;
+
+class ProgramTensorPool {
+public:
   ProgramTensorPool(const TensorMap &liveTensors,
                     const std::unordered_set<uint32_t> &programInputs,
                     const std::unordered_set<uint32_t> &programOutputs)
       : programInputs(programInputs), programOutputs(programOutputs),
         liveTensors(liveTensors) {}
+  ProgramTensorPool(const ProgramTensorPool &) = delete;
+  ProgramTensorPool &operator=(const ProgramTensorPool &) = delete;
+  ProgramTensorPool(ProgramTensorPool &&) = default;
+  ProgramTensorPool &operator=(ProgramTensorPool &&) = default;
 
   auto try_emplace(std::uint32_t globalId, const ::ttnn::Tensor &tensor) {
     auto it = liveTensors.find(globalId);
@@ -45,8 +53,8 @@ struct ProgramTensorPool {
     return liveTensors.erase(globalId);
   }
 
-  void copyTensorToUserOutput(const ::ttnn::Tensor &srcTensor,
-                              std::uint32_t outputGlobalId) {
+  void copyTensorToUserOutput(std::uint32_t outputGlobalId,
+                              const ::ttnn::Tensor &srcTensor) {
     assert(liveTensors.contains(outputGlobalId));
     assert(isUserOutput(outputGlobalId));
     ::ttnn::Tensor &outputTensor = *liveTensors.at(outputGlobalId);
@@ -89,50 +97,81 @@ public:
   ProgramContext(const TensorMap &liveTensors,
                  const std::unordered_set<uint32_t> &programInputs,
                  const std::unordered_set<uint32_t> &programOutputs,
-                 ::ttnn::MeshDevice *meshDevice)
+                 ::ttnn::MeshDevice *parentMesh)
       : tensorPool(
             ProgramTensorPool(liveTensors, programInputs, programOutputs)),
-        meshDevice(meshDevice) {}
+        parentMesh(parentMesh) {
+    assert(parentMesh && "Parent mesh cannot be null");
+  }
+  ProgramContext(const ProgramContext &) = delete;
+  ProgramContext &operator=(const ProgramContext &) = delete;
+  ProgramContext(ProgramContext &&) = default;
+  ProgramContext &operator=(ProgramContext &&) = default;
 
-  const ::ttnn::MeshDevice &getMeshDevice() const {
-    assert(meshDevice && "Mesh device not initialized");
-    return *meshDevice;
+  //
+  // Parent Mesh Operations
+  //
+  ::ttnn::MeshDevice &getParentMesh() { return *parentMesh; }
+
+  const ::ttnn::MeshDevice &getParentMesh() const { return *parentMesh; }
+
+  size_t parentMeshSize() const { return parentMesh->num_devices(); }
+
+  //
+  // Sub Mesh Operations
+  //
+  void addSubMesh(uint32_t meshId,
+                  std::shared_ptr<::ttnn::MeshDevice> subMesh) {
+    auto [it, inserted] = subMeshes.try_emplace(meshId, subMesh);
+    assert(inserted && "Submesh already exists");
   }
 
-  ::ttnn::MeshDeviceView &getMeshView(uint32_t globalId) {
-    assert(meshViews.contains(globalId) &&
-           "Mesh view with global id not initialized");
-    return *(meshViews.at(globalId));
+  ::ttnn::MeshDevice &getSubMesh(uint32_t meshId) {
+    assert(subMeshes.contains(meshId));
+    return *subMeshes.at(meshId);
   }
 
+  size_t subMeshSize(uint32_t meshId) const {
+    assert(subMeshes.contains(meshId));
+    return subMeshes.at(meshId)->num_devices();
+  }
+
+  ::ttnn::Device &getDeviceFromSubMesh(uint32_t meshId, int physicalDeviceId) {
+    assert(subMeshes.contains(meshId));
+    auto &subMesh = *subMeshes.at(meshId);
+    return *subMesh.get_device(physicalDeviceId);
+  }
+
+  ::ttnn::Device &getDeviceIndexFromSubMesh(uint32_t meshId, int deviceIndex) {
+    assert(subMeshes.contains(meshId));
+    auto &subMesh = *subMeshes.at(meshId);
+    return *subMesh.get_device_index(deviceIndex);
+  }
+
+  DeviceVariant getTargetDevice(uint32_t meshId) {
+    assert(subMeshes.contains(meshId));
+    auto &subMesh = *subMeshes.at(meshId);
+    if (subMesh.num_devices() == 1) {
+      return std::ref(*subMesh.get_device_index(0));
+    }
+    return std::ref(subMesh);
+  }
+
+  //
+  // Tensor Pool Operations
+  //
   ProgramTensorPool &getTensorPool() { return tensorPool; }
-
-  void addMeshView(uint32_t globalId,
-                   std::unique_ptr<::ttnn::MeshDeviceView> view) {
-    assert(not meshViews.contains(globalId) &&
-           "Mesh view with globalId already set");
-    meshViews.try_emplace(globalId, std::move(view));
-  }
-
-  ::ttnn::Device &getDeviceFromView(uint32_t globalId, int deviceId) {
-    assert(meshViews.contains(globalId) && "Mesh view not initialized");
-    ::tt::tt_metal::distributed::Coordinate deviceCoord =
-        meshViews.at(globalId)->find_device(deviceId);
-    return *(
-        meshViews.at(globalId)->get_device(deviceCoord.row, deviceCoord.col));
-  }
 
 private:
   ProgramTensorPool tensorPool;
 
   // Contains all devices borrowed from the user that are available to the
   // program
-  ::ttnn::MeshDevice *meshDevice = nullptr;
+  ::ttnn::MeshDevice *parentMesh = nullptr;
 
-  // Contains various views of meshDevice that is used by the program
-  // Will be populated by get_device ops
-  std::unordered_map<uint32_t, std::unique_ptr<::ttnn::MeshDeviceView>>
-      meshViews;
+  // Contains subMeshes of the parentMesh that are used by the program
+  // Will be populated by GetDevice ops
+  std::unordered_map<uint32_t, std::shared_ptr<::ttnn::MeshDevice>> subMeshes;
 };
 } // namespace tt::runtime::ttnn
 

--- a/runtime/lib/ttnn/include/tt/runtime/ttnn/utils.h
+++ b/runtime/lib/ttnn/include/tt/runtime/ttnn/utils.h
@@ -6,9 +6,9 @@
 #define TTNN_RUNTIME_UTILS_H
 
 #include "flatbuffers/vector.h"
+#include "ttmlir/Target/Common/types_generated.h"
 #include "ttmlir/Target/TTNN/Target.h"
 #include "ttnn/types.hpp"
-#include "types_generated.h"
 
 namespace tt::runtime::ttnn::utils {
 

--- a/runtime/lib/ttnn/operations/context/get_device.cpp
+++ b/runtime/lib/ttnn/operations/context/get_device.cpp
@@ -10,53 +10,49 @@
 
 namespace tt::runtime::ttnn::operations::context {
 
-static std::pair<::tt::tt_metal::distributed::Coordinate,
-                 ::tt::tt_metal::distributed::Coordinate>
-deriveMeshViewCoordinates(const ::ttnn::MeshDevice &meshDevice,
-                          const std::unordered_set<uint32_t> &desiredDeviceIds,
-                          const ::tt::target::Dim2d *meshViewShape) {
-  ::tt::tt_metal::distributed::Coordinate topLeft, bottomRight;
-  for (size_t row = 0; row < meshDevice.num_rows(); row++) {
-    for (size_t col = 0; col < meshDevice.num_cols(); col++) {
-      const ::ttnn::Device *currDevice = meshDevice.get_device(row, col);
+using ::tt::tt_metal::distributed::MeshOffset;
+using ::tt::tt_metal::distributed::MeshShape;
+using ::tt::tt_metal::distributed::MeshType;
+
+static MeshOffset
+calculateMeshOffset(const ::ttnn::MeshDevice &parentMesh,
+                    const std::unordered_set<uint32_t> &desiredDeviceIds,
+                    const ::tt::target::Dim2d *subMeshShape) {
+  for (size_t row = 0; row < parentMesh.num_rows(); row++) {
+    for (size_t col = 0; col < parentMesh.num_cols(); col++) {
+      const ::ttnn::Device *currDevice = parentMesh.get_device(row, col);
       if (desiredDeviceIds.contains(currDevice->id())) {
-        topLeft.row = row;
-        topLeft.col = col;
-        // coords are inclusive when constructing mesh view
-        bottomRight.row = topLeft.row + meshViewShape->y() - 1;
-        bottomRight.col = topLeft.col + meshViewShape->x() - 1;
-        return std::make_pair(topLeft, bottomRight);
+        return MeshOffset(row, col);
       }
     }
   }
-  throw std::runtime_error("Device not found in mesh for get device op");
+  throw std::runtime_error("Could not find any desired device in parent mesh");
 }
 
-static std::unique_ptr<::ttnn::MeshDeviceView>
-constructMeshView(const ::ttnn::MeshDevice &meshDevice,
-                  const std::unordered_set<uint32_t> &desiredDeviceIds,
-                  const ::tt::target::Dim2d *meshViewShape) {
-  // Carve out a mesh view from MeshDevice
-  auto [topLeft, bottomRight] =
-      deriveMeshViewCoordinates(meshDevice, desiredDeviceIds, meshViewShape);
-
-  return std::make_unique<::ttnn::MeshDeviceView>(meshDevice, topLeft,
-                                                  bottomRight);
+static std::shared_ptr<::ttnn::MeshDevice>
+createSubMesh(::ttnn::MeshDevice &parentMesh,
+              const std::unordered_set<uint32_t> &desiredDeviceIds,
+              const ::tt::target::Dim2d *subMeshShape) {
+  // Carve out a submesh from the parentMesh
+  MeshShape meshShape(subMeshShape->y(), subMeshShape->x());
+  MeshOffset offset =
+      calculateMeshOffset(parentMesh, desiredDeviceIds, subMeshShape);
+  return parentMesh.create_submesh(meshShape, offset, MeshType::RowMajor);
 }
 
 void run(const ::tt::target::ttnn::GetDeviceOp *op, ProgramContext &context) {
-  const ::ttnn::MeshDevice &meshDevice = context.getMeshDevice();
-  const ::tt::target::Dim2d *meshViewShape = op->mesh();
-  LOG_ASSERT(
-      meshViewShape->y() == 1,
-      "Expected mesh row = 1 for get device op, got: ", meshViewShape->y());
+  ::ttnn::MeshDevice &meshDevice = context.getParentMesh();
+  const ::tt::target::Dim2d *subMeshShape = op->mesh();
   const ::flatbuffers::Vector<uint32_t> *deviceIds = op->chip_ids();
   std::unordered_set<uint32_t> desiredDeviceIds(deviceIds->begin(),
                                                 deviceIds->end());
+  LOG_ASSERT(
+      subMeshShape->y() == 1,
+      "Expected mesh row = 1 for get device op, got: ", subMeshShape->y());
   LOG_ASSERT(desiredDeviceIds.size() == deviceIds->size(),
              "Duplicate device ids in get device op");
-  std::unique_ptr<::ttnn::MeshDeviceView> meshView =
-      constructMeshView(meshDevice, desiredDeviceIds, meshViewShape);
-  context.addMeshView(op->out()->global_id(), std::move(meshView));
+  std::shared_ptr<::ttnn::MeshDevice> subMesh =
+      createSubMesh(meshDevice, desiredDeviceIds, subMeshShape);
+  context.addSubMesh(op->out()->global_id(), subMesh);
 }
 } // namespace tt::runtime::ttnn::operations::context

--- a/runtime/lib/ttnn/operations/conv/conv2d.cpp
+++ b/runtime/lib/ttnn/operations/conv/conv2d.cpp
@@ -12,10 +12,6 @@
 namespace tt::runtime::ttnn::operations::conv {
 void run(const ::tt::target::ttnn::Conv2dOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  // TODO (jnie): Update this once we support multi device tensors
-  // Investigate how to handle multi device in conv2d
-  ::ttnn::Device &device =
-      context.getDeviceFromView(op->device()->global_id(), 0);
   const ::ttnn::Tensor &input = tensorPool.at(op->input()->global_id());
   const ::ttnn::Tensor &weight = tensorPool.at(op->weight()->global_id());
   DEBUG_ASSERT(input.is_allocated());
@@ -28,15 +24,21 @@ void run(const ::tt::target::ttnn::Conv2dOp *op, ProgramContext &context) {
   config.dtype = utils::getDataType(op->input());
   config.weights_dtype = utils::getDataType(op->weight());
   ::ttnn::MemoryConfig outMemConfig = utils::createMemoryConfig(op->out());
-  ::ttnn::Tensor out =
-      std::get<0>(::ttnn::operations::conv::conv2d::conv2d<::ttnn::Device>(
-          input, weight, &device, op->in_channels(), op->out_channels(),
-          op->batch_size(), op->input_height(), op->input_width(),
-          {op->kernel_height(), op->kernel_width()},
-          {op->stride_height(), op->stride_width()},
-          {op->padding_height(), op->padding_width()},
-          {op->dilation_height(), op->dilation_width()}, op->groups(), bias,
-          config, outMemConfig));
+  DeviceVariant targetDevice =
+      context.getTargetDevice(op->device()->global_id());
+  ::ttnn::Tensor out = std::visit(
+      [&](auto &&targetDevice) -> ::ttnn::Tensor {
+        return std::get<0>(::ttnn::operations::conv::conv2d::conv2d(
+            input, weight, &(targetDevice.get()), op->in_channels(),
+            op->out_channels(), op->batch_size(), op->input_height(),
+            op->input_width(), {op->kernel_height(), op->kernel_width()},
+            {op->stride_height(), op->stride_width()},
+            {op->padding_height(), op->padding_width()},
+            {op->dilation_height(), op->dilation_width()}, op->groups(), bias,
+            config, outMemConfig));
+      },
+      targetDevice);
+
   tensorPool.insert_or_assign(op->out()->global_id(), out);
 }
 } // namespace tt::runtime::ttnn::operations::conv

--- a/runtime/lib/ttnn/operations/creation/empty.cpp
+++ b/runtime/lib/ttnn/operations/creation/empty.cpp
@@ -3,42 +3,104 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "empty.h"
+#include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
 #include "tt/runtime/detail/workarounds.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
 
 namespace tt::runtime::ttnn::operations::creation {
+struct EmptyTensorConfig {
+  ::ttnn::Shape shape;
+  ::ttnn::DataType dtype;
+  ::ttnn::Layout layout;
+  uint32_t numShards;
+  const ::tt::target::DistributionStrategy *strategy = nullptr;
+  std::optional<::ttnn::MemoryConfig> memoryConfig = std::nullopt;
+
+  EmptyTensorConfig(const ::tt::target::ttnn::EmptyOp *op)
+      : shape(::tt::runtime::ttnn::utils::toShapeFromFBShape(
+            *op->out()->desc()->shape())),
+        dtype(::tt::runtime::ttnn::operations::utils::getDataType(op->out())),
+        numShards(op->num_shards()), strategy(op->strategy()) {
+    layout = ::tt::runtime::ttnn::utils::toTTNNLayout(op->layout());
+    // TODO(bug #582): ttnn::empty doesn't work properly with tile layout,
+    // using ROW_MAJOR until we fix it
+    if (workaround::Env::get().emptyOpForceRowMajor) {
+      layout = ::ttnn::Layout::ROW_MAJOR;
+    }
+    if (op->device()) {
+      LOG_ASSERT(op->memcfg(),
+                 "Memory config must be provided when device is provided");
+      memoryConfig = ::tt::runtime::ttnn::operations::utils::createMemoryConfig(
+          op->memcfg(), op->out());
+    }
+    validate();
+  }
+
+  void validate() const {
+    LOG_ASSERT(strategy, "Strategy must be provided");
+    LOG_ASSERT(numShards > 0, "Number of shards must be greater than 0");
+    LOG_ASSERT(numShards == 1 ||
+                   strategy->strategy_type() !=
+                       ::tt::target::DistributedTensorConfig::NONE,
+               "Strategy must be provided when num shards is greater than 1");
+    LOG_ASSERT(strategy->strategy_type() !=
+                   ::tt::target::DistributedTensorConfig::AllGatherTensor,
+               "AllGatherTensor is not supported");
+  }
+
+  ::tt::tt_metal::DistributedTensorConfig distributedTensorConfig() const {
+    return ::tt::runtime::ttnn::operations::utils::
+        distributedTensorConfigFromFlatbuffer(strategy);
+  }
+};
+
+static ::ttnn::Tensor
+createEmptyOnMultiDevice(ProgramContext &context, EmptyTensorConfig &config,
+                         const ::tt::target::DeviceRef *deviceRef) {
+  ::tt::tt_metal::DistributedTensorConfig strategy =
+      config.distributedTensorConfig();
+  std::vector<::ttnn::Tensor> tensorShards;
+  tensorShards.resize(config.numShards);
+  std::generate_n(
+      tensorShards.begin(), config.numShards, [&config]() -> ::ttnn::Tensor {
+        return ::ttnn::zeros(config.shape, config.dtype, config.layout);
+      });
+  ::ttnn::Tensor out = ::ttnn::distributed::api::create_multi_device_tensor(
+      tensorShards, ::tt::tt_metal::StorageType::MULTI_DEVICE_HOST, strategy);
+  if (deviceRef) {
+    ::ttnn::MeshDevice &meshDevice = context.getSubMesh(deviceRef->global_id());
+    LOG_ASSERT(config.numShards == meshDevice.num_devices());
+    out = ::ttnn::to_device(out, &meshDevice, config.memoryConfig);
+  }
+  return out;
+}
+
+static ::ttnn::Tensor
+createEmptyOnSingleDevice(ProgramContext &context, EmptyTensorConfig &config,
+                          const ::tt::target::DeviceRef *deviceRef) {
+  if (deviceRef) {
+    ::ttnn::MeshDevice &subMesh = context.getSubMesh(deviceRef->global_id());
+    LOG_ASSERT(subMesh.num_devices() == 1);
+    ::ttnn::Device *device = subMesh.get_device_index(0);
+    return ::ttnn::empty(config.shape, config.dtype, config.layout, device,
+                         config.memoryConfig.value());
+  }
+  return ::ttnn::zeros(config.shape, config.dtype, config.layout);
+}
+
 void run(const ::tt::target::ttnn::EmptyOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  ::ttnn::DataType dtype = utils::getDataType(op->out());
-  ::ttnn::Layout layout [[maybe_unused]] =
-      ::tt::runtime::ttnn::utils::toTTNNLayout(op->layout());
-
-  // TODO(bug #582): ttnn::empty doesn't work properly with tile layout,
-  // using ROW_MAJOR until we fix it
-  if (workaround::Env::get().emptyOpForceRowMajor) {
-    layout = ::ttnn::Layout::ROW_MAJOR;
-  }
-
-  ::ttnn::Shape shape = ::ttnn::Shape(::tt::tt_metal::LegacyShape(
-      ::tt::runtime::ttnn::utils::toShapeFromFBShape(
-          *op->out()->desc()->shape())));
+  EmptyTensorConfig config(op);
   ::ttnn::Tensor out;
-  if (not utils::inSystemMemory(op->out())) {
-    // TODO (jnie): Update this once we support multi device tensors
-    ::ttnn::Device &device =
-        context.getDeviceFromView(op->device()->global_id(), 0);
-    ::ttnn::MemoryConfig memoryConfig =
-        utils::createMemoryConfig(op->memcfg(), op->out());
-    out = ::ttnn::empty(shape, dtype, layout, &device, memoryConfig);
+  if (config.numShards == 1) {
+    out = createEmptyOnSingleDevice(context, config, op->device());
+  } else if (config.numShards > 1) {
+    out = createEmptyOnMultiDevice(context, config, op->device());
   } else {
-    out = ::ttnn::zeros(shape, dtype, layout);
+    throw std::invalid_argument("Unsupported num shards");
   }
-  if (tensorPool.isUserOutput(op->out()->global_id())) {
-    tensorPool.copyTensorToUserOutput(out, op->out()->global_id());
-  } else {
-    tensorPool.insert_or_assign(op->out()->global_id(), out);
-  }
+  utils::updateTensorPool(tensorPool, out, op->out()->global_id());
 }
 } // namespace tt::runtime::ttnn::operations::creation

--- a/runtime/lib/ttnn/operations/creation/full.cpp
+++ b/runtime/lib/ttnn/operations/creation/full.cpp
@@ -3,55 +3,119 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "full.h"
+#include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
 #include "tt/runtime/detail/workarounds.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
 
 namespace tt::runtime::ttnn::operations::creation {
+struct FullTensorConfig {
+  ::ttnn::Shape shape;
+  ::ttnn::DataType dtype;
+  ::ttnn::Layout layout;
+  float fillValue;
+  uint32_t numShards;
+  const ::tt::target::DistributionStrategy *strategy = nullptr;
+  std::optional<::ttnn::MemoryConfig> memoryConfig = std::nullopt;
+
+  FullTensorConfig(const ::tt::target::ttnn::FullOp *op)
+      : shape(::tt::runtime::ttnn::utils::toShapeFromFBShape(
+            *op->out()->desc()->shape())),
+        dtype(::tt::runtime::ttnn::operations::utils::getDataType(op->out())),
+        fillValue(op->fill_value()), numShards(op->num_shards()),
+        strategy(op->strategy()) {
+
+    layout = utils::inferLayoutFromTileShape(op->out());
+
+    // TODO(bug #272), determine correct layout by tile shape in the future
+    // currently tile shape is not set correctly, so as a workaround, hardcode
+    // layout
+    if (workaround::Env::get().ignoreTileShape) {
+      layout = ::ttnn::Layout::TILE;
+    }
+
+    // TODO(bug #582): ttnn::empty doesn't work properly with tile layout,
+    // using ROW_MAJOR until we fix it
+    if (workaround::Env::get().fullOpForceRowMajor) {
+      layout = ::ttnn::Layout::ROW_MAJOR;
+    }
+
+    if (!utils::inSystemMemory(op->out())) {
+      memoryConfig =
+          ::tt::runtime::ttnn::operations::utils::createMemoryConfig(op->out());
+    }
+    validate();
+  }
+
+  void validate() const {
+    LOG_ASSERT(strategy, "Strategy must be provided");
+    LOG_ASSERT(numShards > 0, "Number of shards must be greater than 0");
+    LOG_ASSERT(numShards == 1 ||
+                   strategy->strategy_type() !=
+                       ::tt::target::DistributedTensorConfig::NONE,
+               "Strategy must be provided when num shards is greater than 1");
+    LOG_ASSERT(strategy->strategy_type() !=
+                   ::tt::target::DistributedTensorConfig::AllGatherTensor,
+               "AllGatherTensor is not supported");
+  }
+
+  ::tt::tt_metal::DistributedTensorConfig distributedTensorConfig() const {
+    return ::tt::runtime::ttnn::operations::utils::
+        distributedTensorConfigFromFlatbuffer(strategy);
+  }
+};
+
+static ::ttnn::Tensor
+createFullOnMultiDevice(ProgramContext &context, FullTensorConfig &config,
+                        const ::tt::target::DeviceRef *deviceRef) {
+  ::tt::tt_metal::DistributedTensorConfig strategy =
+      config.distributedTensorConfig();
+  std::vector<::ttnn::Tensor> tensorShards;
+  tensorShards.resize(config.numShards);
+  std::generate_n(tensorShards.begin(), config.numShards,
+                  [&config]() -> ::ttnn::Tensor {
+                    return ::ttnn::full(config.shape, config.fillValue,
+                                        config.dtype, config.layout);
+                  });
+  ::ttnn::Tensor out = ::ttnn::distributed::api::create_multi_device_tensor(
+      tensorShards, ::tt::tt_metal::StorageType::MULTI_DEVICE_HOST, strategy);
+  if (deviceRef) {
+    ::ttnn::MeshDevice &meshDevice = context.getSubMesh(deviceRef->global_id());
+    LOG_ASSERT(config.numShards == meshDevice.num_devices());
+    out = ::ttnn::to_device(out, &meshDevice, config.memoryConfig);
+  }
+  return out;
+}
+
+static ::ttnn::Tensor
+createFullOnSingleDevice(ProgramContext &context, FullTensorConfig &config,
+                         const ::tt::target::DeviceRef *deviceRef) {
+  std::optional<std::reference_wrapper<::ttnn::Device>> device = std::nullopt;
+  if (deviceRef) {
+    ::ttnn::MeshDevice &subMesh = context.getSubMesh(deviceRef->global_id());
+    LOG_ASSERT(subMesh.num_devices() == 1);
+    LOG_ASSERT(config.memoryConfig.has_value());
+    device = std::make_optional(std::ref(*subMesh.get_device_index(0)));
+  }
+  return ::ttnn::full(config.shape, config.fillValue, config.dtype,
+                      config.layout, device, config.memoryConfig);
+}
+
 void run(const ::tt::target::ttnn::FullOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  ::ttnn::DataType outputDataType = utils::getDataType(op->out());
-  auto shape = ::ttnn::Shape(::tt::tt_metal::LegacyShape(
-      ::tt::runtime::ttnn::utils::toShapeFromFBShape(
-          *op->out()->desc()->shape())));
-  float fillValue = op->fill_value();
+  FullTensorConfig config(op);
+  ::ttnn::Tensor out;
+  const ::tt::target::DeviceRef *deviceRef =
+      !utils::inSystemMemory(op->out()) ? op->device() : nullptr;
 
-  ::ttnn::Layout outputLayout [[maybe_unused]] =
-      utils::inferLayoutFromTileShape(op->out());
-
-  // TODO(bug #272), determine correct layout by tile shape in the future
-  // currently tile shape is not set correctly, so as a workaround, hardcode
-  // layout
-  if (workaround::Env::get().ignoreTileShape) {
-    outputLayout = ::ttnn::Layout::TILE;
-  }
-
-  // TODO(bug #582): ttnn::empty doesn't work properly with tile layout,
-  // using ROW_MAJOR until we fix it
-  if (workaround::Env::get().fullOpForceRowMajor) {
-    outputLayout = ::ttnn::Layout::ROW_MAJOR;
-  }
-
-  std::optional<std::reference_wrapper<::ttnn::Device>> outputDevice =
-      std::nullopt;
-  std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig = std::nullopt;
-
-  if (not utils::inSystemMemory(op->out())) {
-    // TODO (jnie): Update this once we support multi device tensors
-    ::ttnn::Device &device =
-        context.getDeviceFromView(op->device()->global_id(), 0);
-    outputDevice = std::make_optional(std::ref(device));
-    outputMemoryConfig =
-        std::make_optional(utils::createMemoryConfig(op->out()));
-  }
-  ::ttnn::Tensor out =
-      ::ttnn::full(shape, fillValue, outputDataType, outputLayout, outputDevice,
-                   outputMemoryConfig);
-  if (tensorPool.isUserOutput(op->out()->global_id())) {
-    tensorPool.copyTensorToUserOutput(out, op->out()->global_id());
+  if (config.numShards == 1) {
+    out = createFullOnSingleDevice(context, config, deviceRef);
+  } else if (config.numShards > 1) {
+    out = createFullOnMultiDevice(context, config, deviceRef);
   } else {
-    tensorPool.insert_or_assign(op->out()->global_id(), out);
+    throw std::invalid_argument("Unsupported num shards");
   }
+  utils::updateTensorPool(tensorPool, out, op->out()->global_id());
 }
 } // namespace tt::runtime::ttnn::operations::creation

--- a/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/utils.h
+++ b/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/utils.h
@@ -21,6 +21,9 @@ bool isTilized(const ::tt::target::TensorRef *tensorRef);
 
 bool inSystemMemory(const ::tt::target::TensorRef *tensorRef);
 
+void updateTensorPool(ProgramTensorPool &tensorPool,
+                      const ::ttnn::Tensor &tensor, uint32_t outputGlobalId);
+
 ::tt::target::MemorySpace
 getMemorySpace(const ::tt::target::TensorRef *tensorRef);
 
@@ -39,6 +42,9 @@ createMemoryConfig(const ::tt::target::TensorRef *tensorRef);
 ::tt::tt_metal::MemoryConfig
 createMemoryConfig(const ::tt::target::MemoryConfigDesc *memcfg,
                    const ::tt::target::TensorRef *tensorRef);
+
+::tt::tt_metal::DistributedTensorConfig distributedTensorConfigFromFlatbuffer(
+    const ::tt::target::DistributionStrategy *strategy);
 
 } // namespace tt::runtime::ttnn::operations::utils
 #endif

--- a/runtime/lib/ttnn/operations/layout/from_device.cpp
+++ b/runtime/lib/ttnn/operations/layout/from_device.cpp
@@ -7,7 +7,6 @@
 #include "tt/runtime/detail/ttnn.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
-
 namespace tt::runtime::ttnn::operations::layout {
 void run(const ::tt::target::ttnn::FromDeviceOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
@@ -17,11 +16,6 @@ void run(const ::tt::target::ttnn::FromDeviceOp *op, ProgramContext &context) {
              "Calling ttnn::from_device on a host tensor");
 
   ::ttnn::Tensor out = ::ttnn::from_device(inputTensor);
-
-  if (tensorPool.isUserOutput(op->out()->global_id())) {
-    tensorPool.copyTensorToUserOutput(out, op->out()->global_id());
-  } else {
-    tensorPool.insert_or_assign(op->out()->global_id(), out);
-  }
+  utils::updateTensorPool(tensorPool, out, op->out()->global_id());
 }
 } // namespace tt::runtime::ttnn::operations::layout

--- a/runtime/lib/ttnn/operations/layout/to_device.cpp
+++ b/runtime/lib/ttnn/operations/layout/to_device.cpp
@@ -10,24 +10,26 @@
 
 namespace tt::runtime::ttnn::operations::layout {
 void run(const ::tt::target::ttnn::ToDeviceOp *op, ProgramContext &context) {
+  LOG_ASSERT(op->device(), "ToDeviceOp must have a device");
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  // TODO (jnie): Update this once we support multi device tensors
-  ::ttnn::Device &device =
-      context.getDeviceFromView(op->device()->global_id(), 0);
   const ::ttnn::Tensor &inputTensor = tensorPool.at(op->in()->global_id());
   DEBUG_ASSERT(inputTensor.is_allocated());
-  LOG_ASSERT(utils::isOnHost(inputTensor),
-             "Calling ttnn::to_device on a device tensor");
-
+  DEBUG_ASSERT(utils::isOnHost(inputTensor),
+               "Calling ttnn::to_device on a device tensor");
   std::optional<::ttnn::MemoryConfig> memoryConfig = std::nullopt;
 
   if (op->memcfg()) {
     memoryConfig =
         std::make_optional(utils::createMemoryConfig(op->memcfg(), op->out()));
   }
-
-  ::ttnn::Tensor out = ::ttnn::to_device(inputTensor, &device, memoryConfig);
-
+  DeviceVariant targetDevice =
+      context.getTargetDevice(op->device()->global_id());
+  ::ttnn::Tensor out = std::visit(
+      [&](auto &&targetDevice) -> ::ttnn::Tensor {
+        return ::ttnn::to_device(inputTensor, &(targetDevice.get()),
+                                 memoryConfig);
+      },
+      targetDevice);
   tensorPool.insert_or_assign(op->out()->global_id(), out);
 }
 

--- a/runtime/lib/ttnn/operations/layout/to_layout.cpp
+++ b/runtime/lib/ttnn/operations/layout/to_layout.cpp
@@ -33,7 +33,6 @@ void run(const ::tt::target::ttnn::ToLayoutOp *op, ProgramContext &context) {
   ::ttnn::Layout layout = toTTNNLayout(op->layout());
   std::optional<::ttnn::DataType> dtype = std::nullopt;
   std::optional<::ttnn::MemoryConfig> memoryConfig = std::nullopt;
-  ::ttnn::Device *device = nullptr;
 
   if (op->dtype()) {
     dtype = ::tt::runtime::ttnn::utils::toTTNNDataType(*(op->dtype()));
@@ -44,18 +43,21 @@ void run(const ::tt::target::ttnn::ToLayoutOp *op, ProgramContext &context) {
         std::make_optional(utils::createMemoryConfig(op->memcfg(), op->out()));
   }
 
+  ::ttnn::Tensor out;
   if (op->device()) {
-    device = &context.getDeviceFromView(op->device()->global_id(), 0);
-  }
-
-  ::ttnn::Tensor out =
-      ::ttnn::to_layout(inputTensor, layout, dtype, memoryConfig, device);
-
-  if (tensorPool.isUserOutput(op->out()->global_id())) {
-    tensorPool.copyTensorToUserOutput(out, op->out()->global_id());
+    DeviceVariant targetDevice =
+        context.getTargetDevice(op->device()->global_id());
+    out = std::visit(
+        [&](auto &&targetDevice) -> ::ttnn::Tensor {
+          return ::ttnn::to_layout(inputTensor, layout, dtype, memoryConfig,
+                                   &(targetDevice.get()));
+        },
+        targetDevice);
   } else {
-    tensorPool.insert_or_assign(op->out()->global_id(), out);
+    out = ::ttnn::to_layout(inputTensor, layout, dtype, memoryConfig,
+                            static_cast<::ttnn::Device *>(nullptr));
   }
+  utils::updateTensorPool(tensorPool, out, op->out()->global_id());
 }
 
 } // namespace tt::runtime::ttnn::operations::layout

--- a/runtime/lib/ttnn/operations/layout/typecast.cpp
+++ b/runtime/lib/ttnn/operations/layout/typecast.cpp
@@ -17,12 +17,7 @@ void run(const ::tt::target::ttnn::TypecastOp *op, ProgramContext &context) {
       ::tt::runtime::ttnn::utils::toTTNNDataType(op->dtype());
 
   ::ttnn::Tensor out = ::ttnn::typecast(inputTensor, targetDataType);
-
-  if (tensorPool.isUserOutput(op->out()->global_id())) {
-    tensorPool.copyTensorToUserOutput(out, op->out()->global_id());
-  } else {
-    tensorPool.insert_or_assign(op->out()->global_id(), out);
-  }
+  utils::updateTensorPool(tensorPool, out, op->out()->global_id());
 }
 
 } // namespace tt::runtime::ttnn::operations::layout

--- a/runtime/lib/ttnn/program.cpp
+++ b/runtime/lib/ttnn/program.cpp
@@ -32,7 +32,8 @@
 namespace tt::runtime::ttnn {
 using LogType = ::tt::runtime::logger::LogType;
 
-struct ProgramExecutor {
+class ProgramExecutor {
+public:
   ProgramExecutor(const TensorMap &liveTensors,
                   const std::unordered_set<uint32_t> &programInputs,
                   const std::unordered_set<uint32_t> &programOutputs,

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -12,32 +12,58 @@
 namespace tt::runtime::ttnn {
 
 using ::tt::runtime::DeviceRuntime;
+using ::tt::tt_metal::BorrowedStorage;
+using ::tt::tt_metal::DistributedTensorConfig;
+using ::tt::tt_metal::MultiDeviceHostStorage;
+using ::tt::tt_metal::OwnedBuffer;
+using ::tt::tt_metal::OwnedStorage;
+using ::tt::tt_metal::raise_unsupported_storage;
+using ::tt::tt_metal::ShardTensor;
 
-template <typename T>
-static BorrowedStorage createStorage(void *ptr, std::uint32_t numElements) {
-  return BorrowedStorage(
-      borrowed_buffer::Buffer<T>(static_cast<T *>(ptr), numElements), [] {},
-      [] {});
+template <typename StorageType, typename ElementType>
+static StorageType createStorage(ElementType *ptr, std::uint32_t numElements) {
+  if constexpr (std::is_same_v<StorageType, BorrowedStorage>) {
+    return BorrowedStorage(
+        ::tt::tt_metal::borrowed_buffer::Buffer<ElementType>(ptr, numElements),
+        [] {}, [] {});
+  } else if constexpr (std::is_same_v<StorageType, OwnedStorage>) {
+    auto data = std::vector<ElementType>(ptr, ptr + numElements);
+    auto buffer = ::tt::tt_metal::owned_buffer::create(std::move(data));
+    return OwnedStorage(std::move(buffer));
+  } else {
+    raise_unsupported_storage<StorageType>();
+  }
 }
 
-static BorrowedStorage createStorage(void *ptr, std::uint32_t numElements,
-                                     ::tt::target::DataType dataType) {
+template <typename StorageType>
+static StorageType createStorage(void *ptr, std::uint32_t numElements,
+                                 ::tt::target::DataType dataType) {
   switch (dataType) {
   case ::tt::target::DataType::Float32:
-    return createStorage<float>(ptr, numElements);
-  // case ::tt::target::DataType::Float16:
-  //   return createStorage<float16>(ptr, numElements);
+    return createStorage<StorageType>(static_cast<float *>(ptr), numElements);
   case ::tt::target::DataType::BFloat16:
-    return createStorage<bfloat16>(ptr, numElements);
+    return createStorage<StorageType>(static_cast<bfloat16 *>(ptr),
+                                      numElements);
   case ::tt::target::DataType::UInt32:
-    return createStorage<std::uint32_t>(ptr, numElements);
+    return createStorage<StorageType>(static_cast<uint32_t *>(ptr),
+                                      numElements);
   case ::tt::target::DataType::UInt16:
-    return createStorage<std::uint16_t>(ptr, numElements);
-  // case ::tt::target::DataType::UInt8:
-  //   return createStorage<std::uint8_t>(ptr, numElements);
+    return createStorage<StorageType>(static_cast<uint16_t *>(ptr),
+                                      numElements);
   default:
     throw std::runtime_error("Unsupported data type");
   }
+}
+
+static ::ttnn::Tensor
+createOwnedTensor(std::shared_ptr<void> data,
+                  std::vector<std::uint32_t> const &shape,
+                  std::vector<std::uint32_t> const &stride,
+                  std::uint32_t itemsize, ::tt::target::DataType dataType) {
+  std::uint32_t numElements = shape[0] * stride[0];
+  return ::ttnn::Tensor(
+      createStorage<OwnedStorage>(data.get(), numElements, dataType), shape,
+      utils::toTTNNDataType(dataType), ::ttnn::Layout::ROW_MAJOR);
 }
 
 Tensor createTensor(std::shared_ptr<void> data,
@@ -46,9 +72,36 @@ Tensor createTensor(std::shared_ptr<void> data,
                     std::uint32_t itemsize, ::tt::target::DataType dataType) {
   std::uint32_t numElements = shape[0] * stride[0];
   auto tensor = std::make_shared<::ttnn::Tensor>(
-      createStorage(data.get(), numElements, dataType), shape,
+      createStorage<BorrowedStorage>(data.get(), numElements, dataType), shape,
       utils::toTTNNDataType(dataType), ::ttnn::Layout::ROW_MAJOR);
-  return Tensor(tensor, data, DeviceRuntime::TTNN);
+  return Tensor(std::static_pointer_cast<void>(tensor), data,
+                DeviceRuntime::TTNN);
+}
+
+Tensor
+createTensor(std::vector<std::shared_ptr<void>> &data,
+             std::vector<std::uint32_t> const &shape,
+             std::vector<std::uint32_t> const &stride, std::uint32_t itemsize,
+             ::tt::target::DataType dataType,
+             std::unordered_map<std::string, std::string> const &strategy) {
+  std::vector<::ttnn::Tensor> tensorShards;
+  tensorShards.resize(data.size());
+  std::transform(data.begin(), data.end(), tensorShards.begin(),
+                 [&](std::shared_ptr<void> &dataShard) -> ::ttnn::Tensor {
+                   return createOwnedTensor(dataShard, shape, stride, itemsize,
+                                            dataType);
+                 });
+  DistributedTensorConfig distributionStrategy =
+      ::tt::tt_metal::get_distributed_tensor_config(strategy);
+  std::shared_ptr<::ttnn::Tensor> tensor = std::make_shared<::ttnn::Tensor>(
+      ::ttnn::distributed::api::create_multi_device_tensor(
+          tensorShards, ::tt::tt_metal::StorageType::MULTI_DEVICE_HOST,
+          distributionStrategy));
+  std::shared_ptr<std::vector<std::shared_ptr<void>>> borrowedData =
+      std::make_shared<std::vector<std::shared_ptr<void>>>(data);
+  return Tensor(std::static_pointer_cast<void>(tensor),
+                std::static_pointer_cast<void>(borrowedData),
+                DeviceRuntime::TTNN);
 }
 
 tt::target::DataType getTensorDataType(Tensor tensor) {

--- a/runtime/tools/python/ttrt/runtime/__init__.py
+++ b/runtime/tools/python/ttrt/runtime/__init__.py
@@ -17,6 +17,7 @@ try:
         close_device,
         submit,
         create_tensor,
+        create_multi_device_tensor,
         wait,
         WorkaroundEnv,
     )

--- a/runtime/tools/python/ttrt/runtime/module.cpp
+++ b/runtime/tools/python/ttrt/runtime/module.cpp
@@ -7,6 +7,7 @@
 #include "tt/runtime/detail/debug.h"
 #include "tt/runtime/detail/workarounds.h"
 #include "tt/runtime/runtime.h"
+#include "tt/runtime/utils.h"
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -58,6 +59,24 @@ PYBIND11_MODULE(_C, m) {
             shape, stride, itemsize, dataType);
       },
       "Create a tensor with borrowed memory");
+  m.def(
+      "create_multi_device_tensor",
+      [](std::vector<std::uintptr_t> &ptrs,
+         std::vector<std::uint32_t> const &shape,
+         std::vector<std::uint32_t> const &stride, std::uint32_t itemsize,
+         ::tt::target::DataType dataType,
+         std::unordered_map<std::string, std::string> const &strategy) {
+        std::vector<std::shared_ptr<void>> data;
+        data.resize(ptrs.size());
+        std::transform(ptrs.begin(), ptrs.end(), data.begin(),
+                       [](std::uintptr_t ptr) {
+                         return ::tt::runtime::utils::unsafe_borrow_shared(
+                             reinterpret_cast<void *>(ptr));
+                       });
+        return tt::runtime::createTensor(data, shape, stride, itemsize,
+                                         dataType, strategy);
+      },
+      "Create a multi-device host tensor with owned memory");
   m.def("get_num_available_devices", &tt::runtime::getNumAvailableDevices,
         "Get the number of available devices");
   m.def("open_device", &tt::runtime::openDevice, py::arg("device_ids"),


### PR DESCRIPTION
closes #696 
Added API overload for createTensor that allows for creating multi-device host tensors. 

Updated program context to use parentMesh/subMesh model instead of meshDeviceViews. When subMeshes go out of scope, if the parent is still alive, no devices will be closed.

Updated ops that explicitly require device to adapt to meshDevice accordingly.

As a POC, successfully ran a simple eltwise add op on both chips of n300 through ttrt on this branch: `jnie/multi_device_tensor_test`. Had to add a couple hacks in the mlir/flatbuffer translate, since compiler doesn't fully support multi chip attributes yet.

Current runtime caveats:

- Did not test conv2d/maxpool on multi device. These ops explicitly require the device so updated them to be able to accept  meshDevice as well, though I doubt these complex ops will just work. Might need some further work there to validate.

- Currently there's no way to directly copy a multi-device tensor to the user output tensor. We could insert an all-gather op to gather the tensors and copy the content of the first buffer, or we need to concat the tensors in the C++ world (link torch?) which is not ideal. 
  - I'm thinking this will be fixed once the `runtime.submit` refactor proposed in runtime stitching goes in, where we explicitly return the tensors instead of copying - we could return a map that maps global ID to a vector of tensor(s), and it'd be up to the user to concat/merge them together if needed. 

