### PR TITLE
#1200: Save all ttrt perf artifacts by default

### DIFF
--- a/runtime/tools/python/test/test_perf.py
+++ b/runtime/tools/python/test/test_perf.py
@@ -74,25 +74,6 @@ def test_clean_artifacts_cmd_perf():
     sub_process_command(command)
 
 
-def test_save_artifacts_perf():
-    API.initialize_apis()
-    custom_args = {}
-    custom_args[
-        "--result-file"
-    ] = f"ttrt-results/{inspect.currentframe().f_code.co_name}.json"
-    custom_args["binary"] = PERF_BINARY_FILE_PATH
-    custom_args["--host-only"] = True
-    custom_args["--clean-artifacts"] = True
-    custom_args["--save-artifacts"] = True
-    perf_instance = API.Perf(args=custom_args)
-    perf_instance()
-
-
-def test_save_artifacts_cmd_perf():
-    command = f"ttrt perf {PERF_BINARY_FILE_PATH} --clean-artifacts --save-artifacts --host-only --log-file ttrt-results/{inspect.currentframe().f_code.co_name}.log --result-file ttrt-results/{inspect.currentframe().f_code.co_name}.json"
-    sub_process_command(command)
-
-
 def test_log_file_perf():
     API.initialize_apis()
     custom_args = {}
@@ -108,26 +89,6 @@ def test_log_file_perf():
 
 def test_log_file_cmd_perf():
     command = f"ttrt perf {PERF_BINARY_FILE_PATH} --host-only --log-file ttrt-results/{inspect.currentframe().f_code.co_name}.log --result-file ttrt-results/{inspect.currentframe().f_code.co_name}.json"
-    sub_process_command(command)
-
-
-def test_artifact_dir_perf():
-    API.initialize_apis()
-    custom_args = {}
-    custom_args[
-        "--result-file"
-    ] = f"ttrt-results/{inspect.currentframe().f_code.co_name}.json"
-    custom_args["binary"] = PERF_BINARY_FILE_PATH
-    custom_args["--host-only"] = True
-    custom_args["--clean-artifacts"] = True
-    custom_args["--save-artifacts"] = True
-    custom_args["--artifact-dir"] = f"{os.getcwd()}/ttrt-artifacts"
-    perf_instance = API.Perf(args=custom_args)
-    perf_instance()
-
-
-def test_artifact_dir_cmd_perf():
-    command = f"ttrt perf {PERF_BINARY_FILE_PATH} --clean-artifacts --save-artifacts --artifact-dir {os.getcwd()}/ttrt-artifacts --host-only --log-file ttrt-results/{inspect.currentframe().f_code.co_name}.log --result-file ttrt-results/{inspect.currentframe().f_code.co_name}.json"
     sub_process_command(command)
 
 

--- a/runtime/tools/python/ttrt/common/perf.py
+++ b/runtime/tools/python/ttrt/common/perf.py
@@ -35,13 +35,6 @@ class Perf:
             help="clean all artifacts from previous runs",
         )
         Perf.register_arg(
-            name="--save-artifacts",
-            type=bool,
-            default=False,
-            choices=[True, False],
-            help="save all artifacts during run",
-        )
-        Perf.register_arg(
             name="--log-file",
             type=str,
             default="",
@@ -448,19 +441,19 @@ class Perf:
 
                     # copy all relevant files into perf folder for this test
                     perf_folder_path = self.artifacts.get_binary_perf_folder_path(bin)
-                    if self["--save-artifacts"]:
-                        self.file_manager.copy_file(perf_folder_path, tracy_file_path)
-                        self.file_manager.copy_file(
-                            perf_folder_path, tracy_ops_times_file_path
-                        )
-                        self.file_manager.copy_file(
-                            perf_folder_path, tracy_ops_data_file_path
-                        )
+                    self.artifacts.save_binary(bin, self.query)
+                    self.file_manager.copy_file(perf_folder_path, tracy_file_path)
+                    self.file_manager.copy_file(
+                        perf_folder_path, tracy_ops_times_file_path
+                    )
+                    self.file_manager.copy_file(
+                        perf_folder_path, tracy_ops_data_file_path
+                    )
 
-                        if not self["--host-only"]:
-                            self.file_manager.copy_file(
-                                perf_folder_path, profiler_device_side_log_path
-                            )
+                    if not self["--host-only"]:
+                        self.file_manager.copy_file(
+                            perf_folder_path, profiler_device_side_log_path
+                        )
 
                     process_ops(None, None, False)
                     self.file_manager.copy_file(
@@ -506,13 +499,6 @@ class Perf:
 
     def postprocess(self):
         self.logging.debug(f"------postprocessing perf API")
-
-        if self["--save-artifacts"]:
-            for bin in self.ttnn_binaries:
-                self.artifacts.save_binary(bin, self.query)
-
-            for bin in self.ttmetal_binaries:
-                self.artifacts.save_binary(bin, self.query)
 
         for bin in self.ttnn_binaries:
             if bin.test_result == "pass":


### PR DESCRIPTION
The reason for this is running perf mode means the user definitely wants to see the perf result that got dumped (which happens by default) but this also dumps all the intermediate perf files generated (which is useful for users) eg. host.tracy file which can be uploaded into the GUI.

If we don't save by default, it becomes a game of trying to figure out what files not to copy into the artifacts dir (and the metal perf scripts will query the artifacts directory to do device side processing).

Closes this issue: https://github.com/tenstorrent/tt-mlir/issues/1200. (easier to just dump everything for perf than track when to dump/when not to.)