### PR TITLE
Double tilization in to_layout bugfix

### DIFF
--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -255,13 +255,9 @@ private:
       TileType tileType =
           TileType::get(rewriter.getContext(),
                         {ttnn::TILE_HEIGHT, ttnn::TILE_WIDTH}, outputDtype);
-      llvm::SmallVector<int64_t> newShardShape =
-          tileType.getTiledShape(llvm::SmallVector<int64_t>(
-              oldShardShape.begin(), oldShardShape.end()));
       RankedTensorType result = RankedTensorType::get(
           oldOutput.getShape(), oldOutput.getElementType(),
-          oldOutputLayoutAttr.withElementType(rewriter.getContext(), tileType)
-              .withShardShape(rewriter.getContext(), newShardShape));
+          oldOutputLayoutAttr.withElementType(rewriter.getContext(), tileType));
       return result;
     }
 


### PR DESCRIPTION
The issue is the double 'tilization' done in both `withElementType()` and `withShardShape()`. `shardShape` is already calculated in `withElementType()`, so the call to `withShardShape()` is redundant.

Closes https://github.com/tenstorrent/tt-mlir/issues/1209