### PR TITLE
Fix code references in op decomposition documentation

### DIFF
--- a/docs/src/decomposing-an-op-in-ttir.md
+++ b/docs/src/decomposing-an-op-in-ttir.md
@@ -17,13 +17,13 @@ The more information regarding this step can be found here: [Define the Op in th
 I updated the `TTIROps.td` as following:
 
 ```td
-{{#include ../../../include/ttmlir/Dialect/TTIR/IR/TTIROps.td:adding_an_op_index_ttir}}
+{{#include ../../../include/ttmlir/Dialect/TTIR/IR/TTIROps.td:decomposing_an_op_index_ttir}}
 ```
 
 The verification function has been added as well:
 
 ```cpp
-{{#include ../../../lib/Dialect/TTIR/IR/TTIROps.cpp:adding_an_op_index_ttir}}
+{{#include ../../../lib/Dialect/TTIR/IR/TTIROps.cpp:decomposing_an_op_index_ttir_verify}}
 ```
 
 ## 2. Create a conversion pattern
@@ -35,7 +35,7 @@ A conversion pattern defines how MLIR should rewrite the Op. It can be implement
 For the `Index` operation, we use the C++ conversion pattern because it involves changing the Op’s input types from integers to arrays, which TableGen lacks flexibility for.
 
 ```
-{{#include ../../../include/ttmlir/Dialect/TTNN/IR/TTNNOps.td:adding_an_op_index_ttir}}
+{{#include ../../../lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp:decomposing_an_op_index_ttir_decompose_pattern}}
 ```
 
 The `matchAndRewrite` method from `OpConversionPattern` is implemented to replace the matched Op with the newly created Op. Since decomposition is implemented as a conversion pass, `OpAdaptor` is used to access the attributes of the original Op in their converted types. Finally, we instantiate the new Op and call the `replaceOp` method on `ConversionPatternRewriter` to replace the original Op.

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -804,7 +804,7 @@ def TTIR_SliceOp: TTIR_DPSOp<"slice"> {
     let hasVerifier = 1;
 }
 
-// ANCHOR: adding_an_op_index_ttir
+// ANCHOR: decomposing_an_op_index_ttir
 def TTIR_IndexOp: TTIR_DPSOp<"index"> {
     let summary = "Index op.";
     let description = [{
@@ -829,7 +829,7 @@ def TTIR_IndexOp: TTIR_DPSOp<"index"> {
 
     let hasVerifier = 1;
 }
-// ANCHOR: adding_an_op_index_ttir
+// ANCHOR_END: decomposing_an_op_index_ttir
 
 def TTIR_SqueezeOp : TTIR_DPSOp<"squeeze"> {
     let summary = "Squeeze op.";

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -34,7 +34,7 @@ namespace mlir::tt {
 // IndexOp decomposition
 //===----------------------------------------------------------------------===//
 
-// ANCHOR: adding_an_op_index_ttir
+// ANCHOR: decomposing_an_op_index_ttir_decompose_pattern
 // This transformation adjusts IndexOp attributes so that `begin`, `end`, and
 // `step` become arrays, where each array element corresponds to a dimension of
 // the input tensor. For dimensions other than the sliced dimension, default
@@ -76,7 +76,7 @@ struct IndexToSliceConversionPattern
     return success();
   }
 };
-// ANCHOR_END: adding_an_op_index_ttir
+// ANCHOR_END: decomposing_an_op_index_ttir_decompose_pattern
 
 //===----------------------------------------------------------------------===//
 // Convolution passes

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -434,7 +434,7 @@ mlir::tt::ttir::GetDimensionSizeOp::fold(FoldAdaptor adaptor) {
 // IndexOp
 //===----------------------------------------------------------------------===//
 
-// ANCHOR: adding_an_op_index_ttir
+// ANCHOR: decomposing_an_op_index_ttir_verify
 // IndexOp verification
 ::mlir::LogicalResult mlir::tt::ttir::IndexOp::verify() {
   ::mlir::RankedTensorType inputType = getInput().getType();
@@ -540,7 +540,7 @@ mlir::tt::ttir::GetDimensionSizeOp::fold(FoldAdaptor adaptor) {
 
   return success();
 }
-// ANCHOR: adding_an_op_index_ttir
+// ANCHOR_END: decomposing_an_op_index_ttir_verify
 
 //===----------------------------------------------------------------------===//
 // SqueezeOp


### PR DESCRIPTION
The code snippets were not rendered correctly so I fixed anchor names throughout the referenced files in the documentation