### PR TITLE
#1190: Added runtime support for doing golden comparision for flatbuffers in ttrt

### DIFF
--- a/docs/src/ttrt.md
+++ b/docs/src/ttrt.md
@@ -58,7 +58,7 @@ ttrt query --save-artifacts
 4. Use ttmlir-opt tool in compiler to feed system descriptor. See the [ttmlir-opt](./ttmlir-opt.md) documentation for more information on how to generate .mlir files.
 ```bash
 ./build/bin/ttmlir-opt --ttir-load-system-desc="path=/path/to/system_desc.ttsys" --ttir-to-ttnn-backend-pipeline test/ttmlir/Dialect/TTNN/simple_subtract.mlir -o ttnn.mlir
-or (pip path directly into ttir-to-ttnn-backend-pipeline)
+or (pipe path directly into ttir-to-ttnn-backend-pipeline)
 ./build/bin/ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=/path/to/system_desc.ttsys" test/ttmlir/Dialect/TTNN/simple_subtract.mlir -o ttnn.mlir
 ```
 5. Use ttmlir-translate tool in compiler to generate the flatbuffer executable. See the [ttmlir-translate](./ttmlir-translate.md) documentation for more information on how to generate flatbuffer files.

--- a/python/test_infra/ttir_builder.py
+++ b/python/test_infra/ttir_builder.py
@@ -304,9 +304,7 @@ class TTIRBuilder:
                 inputs,
                 [output],
                 self._get_operand_constraint_attr(3),
-                loc=Location.file(
-                    filename=stack[0].filename, line=stack[0].lineno, col=id
-                ),
+                loc=Location.name(str(id)),
             )
 
             goldens = []

--- a/runtime/include/tt/runtime/detail/debug.h
+++ b/runtime/include/tt/runtime/detail/debug.h
@@ -5,7 +5,11 @@
 #ifndef TT_RUNTIME_DETAIL_DEBUG_H
 #define TT_RUNTIME_DETAIL_DEBUG_H
 
+#include <functional>
+#include <optional>
 #include <ostream>
+
+#include "tt/runtime/types.h"
 
 namespace tt::runtime::debug {
 
@@ -37,6 +41,46 @@ inline std::ostream &operator<<(std::ostream &os, Env const &env) {
   os << "debug::Env{\n"
      << "\t" << "loadKernelsFromDisk: " << env.loadKernelsFromDisk << ",\n"
      << "\t" << "enableAsyncTTNN: " << env.enableAsyncTTNN << "\n"
+     << "}";
+  return os;
+}
+
+struct Hooks {
+#if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
+  static Hooks const &
+  get(std::optional<std::function<void(Binary, CallbackContext, OpContext)>>
+          operatorCallback = std::nullopt);
+#else
+  constexpr static Hooks get() { return Hooks(); }
+#endif
+
+  std::optional<std::function<void(Binary, CallbackContext, OpContext)>>
+  getOperatorCallback() const {
+#if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
+    return operatorCallback;
+#else
+    return std::nullopt;
+#endif
+  }
+
+private:
+#if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
+  Hooks(std::optional<std::function<void(Binary, CallbackContext, OpContext)>>
+            operatorCallback)
+      : operatorCallback(operatorCallback) {}
+
+  std::optional<std::function<void(Binary, CallbackContext, OpContext)>>
+      operatorCallback;
+#else
+  constexpr Hooks() = default;
+#endif
+};
+
+inline std::ostream &operator<<(std::ostream &os, Hooks const &hooks) {
+  os << "debug::Hooks{\n"
+     << "\t"
+     << "operatorCallback: " << static_cast<bool>(hooks.getOperatorCallback())
+     << ",\n"
      << "}";
   return os;
 }

--- a/runtime/include/tt/runtime/detail/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal.h
@@ -79,6 +79,13 @@ Event submit(Device device, Binary executable, std::uint32_t programIndex,
 
 void wait(Event event);
 
+std::string getOpDebugString(OpContext opContextHandle);
+
+Tensor getOpOutputTensor(OpContext opContextHandle,
+                         CallbackContext programContextHandle);
+
+std::vector<float> getTensorData(Tensor tensor);
+
 using InputBuffer =
     std::tuple<std::uint32_t, std::shared_ptr<::tt::tt_metal::Buffer>,
                std::shared_ptr<::tt::tt_metal::Event>>;

--- a/runtime/include/tt/runtime/detail/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn.h
@@ -120,8 +120,15 @@ Event submit(Device device, Binary executable, std::uint32_t programIndex,
 
 void wait(Event event);
 
-void runProgram(::ttnn::MeshDevice &meshDevice,
-                ::tt::target::ttnn::Program const *program,
+std::string getOpDebugString(OpContext opContextHandle);
+
+Tensor getOpOutputTensor(OpContext opContextHandle,
+                         CallbackContext programContextHandle);
+
+std::vector<float> getTensorData(Tensor tensor);
+
+void runProgram(::ttnn::MeshDevice &meshDevice, Binary &executableHandle,
+                std::uint32_t programIndex,
                 std::vector<::ttnn::Tensor *> const &inputs,
                 std::vector<::ttnn::Tensor *> const &outputs);
 

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -69,6 +69,13 @@ Event submit(Device device, Binary executable, std::uint32_t programIndex,
 
 void wait(Event event);
 
+std::string getOpDebugString(OpContext opContextHandle);
+
+Tensor getOpOutputTensor(OpContext opContextHandle,
+                         CallbackContext programContextHandle);
+
+std::vector<float> getTensorData(Tensor tensor);
+
 } // namespace tt::runtime
 
 #endif

--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -12,6 +12,7 @@
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include "ttmlir/Target/Common/debug_info_generated.h"
 #include "ttmlir/Target/Common/system_desc_generated.h"
 #include "ttmlir/Target/Common/types_generated.h"
 #pragma clang diagnostic pop
@@ -108,6 +109,7 @@ struct Binary : public Flatbuffer {
 
   std::vector<TensorDesc> getProgramInputs(std::uint32_t programIndex) const;
   std::vector<TensorDesc> getProgramOutputs(std::uint32_t programIndex) const;
+  const ::tt::target::GoldenTensor *getDebugInfoGolden(std::string &loc) const;
 };
 
 struct Device : public detail::RuntimeCheckedObjectImpl {
@@ -120,9 +122,18 @@ struct Event : public detail::RuntimeCheckedObjectImpl {
 
 struct Tensor : public detail::RuntimeCheckedObjectImpl {
   std::shared_ptr<void> data;
+
   Tensor(std::shared_ptr<void> handle, std::shared_ptr<void> data,
          DeviceRuntime runtime)
       : detail::RuntimeCheckedObjectImpl(handle, runtime), data(data) {}
+};
+
+struct CallbackContext : public detail::RuntimeCheckedObjectImpl {
+  using detail::RuntimeCheckedObjectImpl::RuntimeCheckedObjectImpl;
+};
+
+struct OpContext : public detail::RuntimeCheckedObjectImpl {
+  using detail::RuntimeCheckedObjectImpl::RuntimeCheckedObjectImpl;
 };
 
 } // namespace tt::runtime

--- a/runtime/lib/binary.cpp
+++ b/runtime/lib/binary.cpp
@@ -103,6 +103,23 @@ std::vector<TensorDesc> getProgramOutputs(Flatbuffer binary,
   return outputs;
 }
 
+const ::tt::target::GoldenTensor *getDebugInfoGolden(Flatbuffer binary,
+                                                     std::string &loc) {
+  auto const *programs = getBinary(binary)->programs();
+  for (auto const *program : *programs) {
+    for (const ::tt::target::GoldenKV *goldenKV :
+         *program->debug_info()->golden_info()->golden_map()) {
+      if (std::string(goldenKV->key()->c_str()) == loc) {
+        return goldenKV->value();
+        ;
+      }
+    }
+  }
+
+  LOG_WARNING("Golden information not found");
+  return nullptr;
+}
+
 } // namespace ttnn
 
 namespace metal {
@@ -175,6 +192,12 @@ std::vector<TensorDesc> getProgramOutputs(Flatbuffer binary,
     outputs.push_back(desc);
   }
   return outputs;
+}
+
+const ::tt::target::GoldenTensor *getDebugInfoGolden(Flatbuffer binary,
+                                                     std::string &loc) {
+  LOG_WARNING("Debug golden information not enabled for metal yet!");
+  return nullptr;
 }
 
 } // namespace metal
@@ -342,6 +365,22 @@ Binary::getProgramOutputs(std::uint32_t programIndex) const {
   }
 
   throw std::runtime_error("Unsupported binary format");
+}
+
+const ::tt::target::GoldenTensor *
+Binary::getDebugInfoGolden(std::string &loc) const {
+  if (::tt::target::ttnn::SizePrefixedTTNNBinaryBufferHasIdentifier(
+          handle.get())) {
+    return ttnn::getDebugInfoGolden(*this, loc);
+  }
+
+  if (::tt::target::metal::SizePrefixedTTMetalBinaryBufferHasIdentifier(
+          handle.get())) {
+    return metal::getDebugInfoGolden(*this, loc);
+  }
+
+  throw std::runtime_error(
+      "Unsupported binary format for obtaining golden information");
 }
 
 } // namespace tt::runtime

--- a/runtime/lib/common/debug.cpp
+++ b/runtime/lib/common/debug.cpp
@@ -13,6 +13,17 @@ Env const &Env::get(bool loadKernelsFromDisk, bool enableAsyncTTNN) {
   return config;
 }
 
+#if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
+Hooks const &Hooks::get(
+    std::optional<std::function<void(Binary, CallbackContext, OpContext)>>
+        operatorCallback) {
+  static Hooks config(operatorCallback);
+  return config;
+}
+#else
+Hooks get() { return Hooks(); }
+#endif
+
 } // namespace tt::runtime::debug
 
 #endif

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -10,6 +10,7 @@
 
 #if defined(TT_RUNTIME_ENABLE_TTNN)
 #include "tt/runtime/detail/ttnn.h"
+#include "tt/runtime/ttnn/types.h"
 #endif
 
 #if defined(TT_RUNTIME_ENABLE_TTMETAL)
@@ -242,6 +243,55 @@ void wait(Event event) {
     return ::tt::runtime::ttmetal::wait(event);
   }
 #endif
+  throw std::runtime_error("runtime is not enabled");
+}
+
+std::string getOpDebugString(OpContext opContextHandle) {
+#if defined(TT_RUNTIME_ENABLE_TTNN)
+  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
+    return ::tt::runtime::ttnn::getOpDebugString(opContextHandle);
+  }
+#endif
+
+#if defined(TT_RUNTIME_ENABLE_TTMETAL)
+  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
+    return ::tt::runtime::ttmetal::getOpDebugString(opContextHandle);
+  }
+#endif
+  throw std::runtime_error("runtime is not enabled");
+}
+
+Tensor getOpOutputTensor(OpContext opContextHandle,
+                         CallbackContext programContextHandle) {
+#if defined(TT_RUNTIME_ENABLE_TTNN)
+  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
+    return ::tt::runtime::ttnn::getOpOutputTensor(opContextHandle,
+                                                  programContextHandle);
+  }
+#endif
+
+#if defined(TT_RUNTIME_ENABLE_TTMETAL)
+  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
+    return ::tt::runtime::ttmetal::getOpOutputTensor(opContextHandle,
+                                                     programContextHandle);
+  }
+#endif
+  throw std::runtime_error("runtime is not enabled");
+}
+
+std::vector<float> getTensorData(Tensor tensor) {
+#if defined(TT_RUNTIME_ENABLE_TTNN)
+  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
+    return ::tt::runtime::ttnn::getTensorData(tensor);
+  }
+#endif
+
+#if defined(TT_RUNTIME_ENABLE_TTMETAL)
+  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
+    return ::tt::runtime::ttmetal::getTensorData(tensor);
+  }
+#endif
+
   throw std::runtime_error("runtime is not enabled");
 }
 

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -29,6 +29,10 @@ static ::tt::target::metal::TTMetalBinary const *getBinary(Flatbuffer binary) {
   return ::tt::target::metal::GetSizePrefixedTTMetalBinary(binary.handle.get());
 }
 
+static Tensor createNullTensor() {
+  return Tensor(nullptr, nullptr, DeviceRuntime::TTMetal);
+}
+
 Tensor createTensor(std::shared_ptr<void> data,
                     std::vector<std::uint32_t> const &shape,
                     std::vector<std::uint32_t> const &stride,
@@ -250,6 +254,25 @@ void wait(Event event) {
   for (auto e : events) {
     ::tt::tt_metal::EventSynchronize(e);
   }
+}
+
+std::string getOpDebugString(OpContext opContextHandle) {
+  // Not implemented
+  LOG_WARNING("obtaining op debug string for metal runtime not implemented");
+  return "";
+}
+
+Tensor getOpOutputTensor(OpContext opContextHandle,
+                         CallbackContext programContextHandle) {
+  // Not implemented
+  LOG_WARNING("obtaining op output tensor for metal runtime not implemented");
+  return createNullTensor();
+}
+
+std::vector<float> getTensorData(Tensor tensor) {
+  // Not implemented
+  LOG_WARNING("obtaining tensor data for metal runtime not implemented");
+  return {};
 }
 
 } // namespace tt::runtime::ttmetal

--- a/runtime/lib/ttnn/include/tt/runtime/ttnn/types.h
+++ b/runtime/lib/ttnn/include/tt/runtime/ttnn/types.h
@@ -46,6 +46,11 @@ public:
     return *liveTensors.at(globalId);
   }
 
+  const ::ttnn::Tensor &at(std::uint32_t globalId) const {
+    assert(liveTensors.contains(globalId));
+    return *liveTensors.at(globalId);
+  }
+
   size_t erase(std::uint32_t globalId) {
     assert(liveTensors.contains(globalId) &&
            intermedTensors.contains(globalId));
@@ -161,6 +166,7 @@ public:
   // Tensor Pool Operations
   //
   ProgramTensorPool &getTensorPool() { return tensorPool; }
+  const ProgramTensorPool &getTensorPool() const { return tensorPool; }
 
 private:
   ProgramTensorPool tensorPool;

--- a/runtime/lib/ttnn/program.cpp
+++ b/runtime/lib/ttnn/program.cpp
@@ -26,33 +26,62 @@
 #include "operations/normalization/softmax.h"
 #include "operations/pool/maxpool2d.h"
 #include "operations/reduction/reduction.h"
+#include "tt/runtime/detail/debug.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/ttnn/types.h"
+#include "tt/runtime/utils.h"
 #include "ttmlir/Target/TTNN/program_generated.h"
 
 namespace tt::runtime::ttnn {
 using LogType = ::tt::runtime::logger::LogType;
 
+static ::tt::target::ttnn::TTNNBinary const *getBinary(Flatbuffer binary) {
+  bool isTTNN = ::tt::target::ttnn::SizePrefixedTTNNBinaryBufferHasIdentifier(
+      binary.handle.get());
+  if (not isTTNN) {
+    throw std::runtime_error("Unsupported binary format");
+  }
+  return ::tt::target::ttnn::GetSizePrefixedTTNNBinary(binary.handle.get());
+}
+
 class ProgramExecutor {
 public:
-  ProgramExecutor(const TensorMap &liveTensors,
+  ProgramExecutor(Binary &executableHandle, const TensorMap &liveTensors,
                   const std::unordered_set<uint32_t> &programInputs,
                   const std::unordered_set<uint32_t> &programOutputs,
                   ::ttnn::MeshDevice *meshDevice)
-      : context(ProgramContext(liveTensors, programInputs, programOutputs,
+      : executableHandle(executableHandle),
+        context(ProgramContext(liveTensors, programInputs, programOutputs,
                                meshDevice)) {}
+
+  void runCallback(Binary &executableHandle,
+                   const ::tt::target::ttnn::Operation *opContext,
+                   ProgramContext *programContext) {
+    if (auto callback = debug::Hooks::get().getOperatorCallback(); callback) {
+      std::shared_ptr<void> programContextPtr =
+          ::tt::runtime::utils::unsafe_borrow_shared(programContext);
+      std::shared_ptr<void> opContextPtr =
+          ::tt::runtime::utils::unsafe_borrow_shared(
+              const_cast<::tt::target::ttnn::Operation *>(opContext));
+      (*callback)(executableHandle,
+                  CallbackContext(programContextPtr, DeviceRuntime::TTNN),
+                  OpContext(opContextPtr, DeviceRuntime::TTNN));
+    }
+  }
 
   void execute(const ::tt::target::ttnn::Program *program) {
     for (const ::tt::target::ttnn::Operation *op : *program->operations()) {
       LOG_DEBUG(LogType::LogRuntimeTTNN,
                 "Executing operation: ", op->debug_info()->c_str());
       runOperation(op);
+      runCallback(executableHandle, op, &context);
     }
   }
 
   ProgramContext &getContext() { return context; }
 
 private:
+  Binary executableHandle;
   ProgramContext context;
   void runOperation(const ::tt::target::ttnn::Operation *op);
   void runEltwiseOperation(const ::tt::target::ttnn::EltwiseOp *op);
@@ -117,8 +146,7 @@ void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
     return operations::creation::run(op->type_as_FullOp(), context);
   }
   case ::tt::target::ttnn::OpType::EltwiseOp: {
-    const ::tt::target::ttnn::EltwiseOp *eltwiseOp = op->type_as_EltwiseOp();
-    return runEltwiseOperation(eltwiseOp);
+    return runEltwiseOperation(op->type_as_EltwiseOp());
   }
   // ANCHOR: adding_an_op_matmul_runtime_program
   case ::tt::target::ttnn::OpType::MatmulOp: {
@@ -183,10 +211,13 @@ static bool handleNopProgram(::tt::target::ttnn::Program const *program,
   return isNop;
 }
 
-void runProgram(::ttnn::MeshDevice &meshDevice,
-                ::tt::target::ttnn::Program const *program,
+void runProgram(::ttnn::MeshDevice &meshDevice, Binary &executableHandle,
+                std::uint32_t programIndex,
                 std::vector<::ttnn::Tensor *> const &inputs,
                 std::vector<::ttnn::Tensor *> const &outputs) {
+  ::tt::target::ttnn::TTNNBinary const &fbb = *getBinary(executableHandle);
+  ::tt::target::ttnn::Program const *program =
+      fbb.programs()->Get(programIndex);
   if (handleNopProgram(program, inputs, outputs)) {
     return;
   }
@@ -212,8 +243,8 @@ void runProgram(::ttnn::MeshDevice &meshDevice,
     LOG_ASSERT(inserted, "Duplicate output tensor");
     programOutputs.emplace(output->global_id());
   }
-  ProgramExecutor executor(liveTensors, programInputs, programOutputs,
-                           &meshDevice);
+  ProgramExecutor executor(executableHandle, liveTensors, programInputs,
+                           programOutputs, &meshDevice);
   executor.execute(program);
 }
 

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -5,6 +5,7 @@
 #include "tt/runtime/detail/debug.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
+#include "tt/runtime/ttnn/types.h"
 #include "tt/runtime/ttnn/utils.h"
 #include "tt/runtime/utils.h"
 #include "ttmlir/Target/TTNN/Target.h"
@@ -69,6 +70,10 @@ createOwnedTensor(std::shared_ptr<void> data,
       createStorage<OwnedStorage>(data.get(), numElements, dataType),
       ::ttnn::Shape(small_vector_shape), utils::toTTNNDataType(dataType),
       ::ttnn::Layout::ROW_MAJOR);
+}
+
+static Tensor createNullTensor() {
+  return Tensor(nullptr, nullptr, DeviceRuntime::TTNN);
 }
 
 Tensor createTensor(std::shared_ptr<void> data,
@@ -161,33 +166,27 @@ void deallocateBuffers(Device deviceHandle) {
   }
 }
 
-static ::tt::target::ttnn::TTNNBinary const *getBinary(Flatbuffer binary) {
-  bool isTTNN = ::tt::target::ttnn::SizePrefixedTTNNBinaryBufferHasIdentifier(
-      binary.handle.get());
-  LOG_ASSERT(isTTNN, "Unsupported binary format");
-  return ::tt::target::ttnn::GetSizePrefixedTTNNBinary(binary.handle.get());
-}
-
 Event submit(Device deviceHandle, Binary executableHandle,
              std::uint32_t programIndex,
              std::vector<Tensor> const &inputHandles,
              std::vector<Tensor> const &outputHandles) {
   ::ttnn::MeshDevice &meshDevice =
       deviceHandle.as<::ttnn::MeshDevice>(DeviceRuntime::TTNN);
-  ::tt::target::ttnn::TTNNBinary const &fbb = *getBinary(executableHandle);
   std::vector<::ttnn::Tensor *> inputs;
   inputs.reserve(inputHandles.size());
   for (auto &input : inputHandles) {
     LOG_ASSERT(input.matchesRuntime(DeviceRuntime::TTNN));
     inputs.push_back(static_cast<::ttnn::Tensor *>(input.handle.get()));
   }
+
   std::vector<::ttnn::Tensor *> outputs;
   outputs.reserve(outputHandles.size());
   for (auto &output : outputHandles) {
     LOG_ASSERT(output.matchesRuntime(DeviceRuntime::TTNN));
     outputs.push_back(static_cast<::ttnn::Tensor *>(output.handle.get()));
   }
-  tt::runtime::ttnn::runProgram(meshDevice, fbb.programs()->Get(programIndex),
+
+  tt::runtime::ttnn::runProgram(meshDevice, executableHandle, programIndex,
                                 inputs, outputs);
   return Event(nullptr, DeviceRuntime::TTNN);
 }
@@ -195,6 +194,151 @@ Event submit(Device deviceHandle, Binary executableHandle,
 void wait(Event event) {
   // Not implemented
   LOG_ASSERT(event.matchesRuntime(DeviceRuntime::TTNN));
+}
+
+std::string getOpDebugString(OpContext opContextHandle) {
+  auto const &opContext =
+      opContextHandle.as<::tt::target::ttnn::Operation>(DeviceRuntime::TTNN);
+  return std::string(opContext.debug_info()->c_str());
+}
+
+Tensor getOpOutputTensor(OpContext opContextHandle,
+                         CallbackContext programContextHandle) {
+  auto const &programContext =
+      programContextHandle.as<tt::runtime::ttnn::ProgramContext>(
+          DeviceRuntime::TTNN);
+  auto const &opContext =
+      opContextHandle.as<::tt::target::ttnn::Operation>(DeviceRuntime::TTNN);
+  const ttnn::ProgramTensorPool &tensorPool = programContext.getTensorPool();
+  std::int32_t globalId{-1};
+  const ::ttnn::Tensor *outPtr = nullptr;
+
+  switch (opContext.type_type()) {
+  case ::tt::target::ttnn::OpType::GetDeviceOp: {
+    globalId = opContext.type_as_GetDeviceOp()->out()->global_id();
+    break;
+  }
+  case ::tt::target::ttnn::OpType::ToMemoryConfigOp: {
+    globalId = opContext.type_as_ToMemoryConfigOp()->out()->global_id();
+    break;
+  }
+  case ::tt::target::ttnn::OpType::ToLayoutOp: {
+    globalId = opContext.type_as_ToLayoutOp()->out()->global_id();
+    break;
+  }
+  case ::tt::target::ttnn::OpType::TypecastOp: {
+    globalId = opContext.type_as_TypecastOp()->out()->global_id();
+    break;
+  }
+  case ::tt::target::ttnn::OpType::ToDeviceOp: {
+    globalId = opContext.type_as_ToDeviceOp()->out()->global_id();
+    break;
+  }
+  case ::tt::target::ttnn::OpType::FromDeviceOp: {
+    globalId = opContext.type_as_FromDeviceOp()->out()->global_id();
+    break;
+  }
+  case ::tt::target::ttnn::OpType::EmptyOp: {
+    globalId = opContext.type_as_EmptyOp()->out()->global_id();
+    break;
+  }
+  case ::tt::target::ttnn::OpType::FullOp: {
+    globalId = opContext.type_as_FullOp()->out()->global_id();
+    break;
+  }
+  case ::tt::target::ttnn::OpType::EltwiseOp: {
+    globalId = opContext.type_as_EltwiseOp()->out()->global_id();
+    break;
+  }
+  case ::tt::target::ttnn::OpType::MatmulOp: {
+    globalId = opContext.type_as_MatmulOp()->out()->global_id();
+    break;
+  }
+  case ::tt::target::ttnn::OpType::ReductionOp: {
+    globalId = opContext.type_as_ReductionOp()->out()->global_id();
+    break;
+  }
+  case ::tt::target::ttnn::OpType::EmbeddingOp: {
+    globalId = opContext.type_as_EmbeddingOp()->out()->global_id();
+    break;
+  }
+  case ::tt::target::ttnn::OpType::SoftmaxOp: {
+    globalId = opContext.type_as_SoftmaxOp()->out()->global_id();
+    break;
+  }
+  case ::tt::target::ttnn::OpType::TransposeOp: {
+    globalId = opContext.type_as_TransposeOp()->out()->global_id();
+    break;
+  }
+  case ::tt::target::ttnn::OpType::ConcatOp: {
+    globalId = opContext.type_as_ConcatOp()->out()->global_id();
+    break;
+  }
+  case ::tt::target::ttnn::OpType::ReshapeOp: {
+    globalId = opContext.type_as_ReshapeOp()->out()->global_id();
+    break;
+  }
+  case ::tt::target::ttnn::OpType::SliceOp: {
+    globalId = opContext.type_as_SliceOp()->out()->global_id();
+    break;
+  }
+  case ::tt::target::ttnn::OpType::Conv2dOp: {
+    globalId = opContext.type_as_Conv2dOp()->out()->global_id();
+    break;
+  }
+  case ::tt::target::ttnn::OpType::MaxPool2dOp: {
+    globalId = opContext.type_as_MaxPool2dOp()->out()->global_id();
+    break;
+  }
+  case ::tt::target::ttnn::OpType::AllGatherOp: {
+    globalId = opContext.type_as_AllGatherOp()->out()->global_id();
+    break;
+  }
+  case ::tt::target::ttnn::OpType::DeallocateOp: {
+    LOG_WARNING("getting output tensor for DeallocateOp is not supported");
+    return createNullTensor();
+  }
+  default: {
+    throw std::runtime_error("Unsupported operation type");
+  }
+  }
+
+  if (tensorPool.contains(globalId)) {
+    outPtr = &tensorPool.at(globalId);
+  } else {
+    LOG_WARNING("Output tensor not found in tensor pool");
+    return createNullTensor();
+  }
+
+  ::ttnn::Tensor hostTensor = ::ttnn::from_device(*outPtr);
+  ::ttnn::Tensor outCopy =
+      ::ttnn::to_layout(hostTensor, ::ttnn::ROW_MAJOR_LAYOUT, std::nullopt,
+                        std::nullopt, static_cast<::ttnn::Device *>(nullptr));
+
+  void *src = ::tt::tt_metal::get_raw_host_data_ptr(outCopy);
+  std::uint32_t outCopySize = outCopy.volume() * outCopy.element_size();
+  std::shared_ptr<void> data = ::tt::runtime::utils::malloc_shared(outCopySize);
+  std::memcpy(data.get(), src, outCopySize);
+
+  auto tensor = std::make_shared<::ttnn::Tensor>(
+      ttnn::createStorage<BorrowedStorage>(data.get(), outCopy.volume(),
+                                           ::tt::target::DataType::Float32),
+      outCopy.shape().value, ::ttnn::DataType::FLOAT32,
+      ::ttnn::Layout::ROW_MAJOR);
+
+  return Tensor(std::static_pointer_cast<void>(tensor), data,
+                DeviceRuntime::TTNN);
+}
+
+std::vector<float> getTensorData(Tensor tensor) {
+  ::ttnn::Tensor *nnTensor = static_cast<::ttnn::Tensor *>(tensor.handle.get());
+  if (nnTensor == nullptr) {
+    return {};
+  }
+
+  void *dataPtr = ::tt::tt_metal::get_raw_host_data_ptr(*nnTensor);
+  return std::vector<float>(static_cast<float *>(dataPtr),
+                            static_cast<float *>(dataPtr) + nnTensor->volume());
 }
 
 } // namespace tt::runtime::ttnn

--- a/runtime/tools/python/ttrt/binary/module.cpp
+++ b/runtime/tools/python/ttrt/binary/module.cpp
@@ -2,9 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <numeric>
+
 #include "tt/runtime/types.h"
 
+#include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 namespace py = pybind11;
 
@@ -27,7 +31,23 @@ PYBIND11_MODULE(_C, m) {
       .def_property_readonly("file_identifier",
                              &tt::runtime::Binary::getFileIdentifier)
       .def("as_json", &tt::runtime::Binary::asJson)
-      .def("store", &tt::runtime::Binary::store);
+      .def("store", &tt::runtime::Binary::store)
+      .def("get_debug_info_golden", [](tt::runtime::Binary &binary,
+                                       std::string &loc) {
+        const ::tt::target::GoldenTensor *goldenTensor =
+            binary.getDebugInfoGolden(loc);
+        if (goldenTensor == nullptr) {
+          return std::vector<float>();
+        }
+
+        int totalDataSize = std::accumulate((*goldenTensor->shape()).begin(),
+                                            (*goldenTensor->shape()).end(), 1,
+                                            std::multiplies<int64_t>());
+        std::vector<float> dataVec(totalDataSize);
+        std::memcpy(dataVec.data(), goldenTensor->data()->data(),
+                    totalDataSize * sizeof(float));
+        return dataVec;
+      });
   py::class_<tt::runtime::SystemDesc>(m, "SystemDesc")
       .def_property_readonly("version", &tt::runtime::SystemDesc::getVersion)
       .def_property_readonly("ttmlir_git_hash",

--- a/runtime/tools/python/ttrt/common/golden.py
+++ b/runtime/tools/python/ttrt/common/golden.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import json
+import importlib.machinery
+import sys
+import signal
+import os
+import io
+import subprocess
+import time
+import socket
+from pkg_resources import get_distribution
+import shutil
+import atexit
+import re
+
+from ttrt.common.util import *
+
+
+def get_atol_rtol_pcc(golden, calculated):
+    import numpy as np
+    import torch
+
+    # Calculate atol and rtol
+    cal_atol = torch.max(torch.abs(golden - calculated)).item()
+    cal_rtol = torch.max(torch.abs(golden - calculated) / torch.abs(calculated)).item()
+
+    # Calculate PCC
+    def get_pcc(golden, calculated):
+        # Both tensors are nan
+        if torch.all(torch.isnan(golden)) and torch.all(torch.isnan(calculated)):
+            print("Both tensors are 'nan'")
+            return 1.0
+        # Test if either is completely zero
+        elif torch.any(golden.bool()) != torch.any(calculated.bool()):
+            return 0.0
+        # One tensor is all nan, the other is not
+        elif torch.all(torch.isnan(golden)) or torch.all(torch.isnan(calculated)):
+            print("One tensor is all nan, the other is not.")
+            return 0.0
+        else:
+            # For now, mask all infs and nans so that we check the rest... TODO
+            golden = golden.clone()
+            golden[
+                torch.logical_or(
+                    torch.isnan(golden),
+                    torch.logical_or(torch.isinf(golden), torch.isneginf(golden)),
+                )
+            ] = 0
+            calculated = calculated.clone()
+            calculated[
+                torch.logical_or(
+                    torch.isnan(calculated),
+                    torch.logical_or(
+                        torch.isinf(calculated), torch.isneginf(calculated)
+                    ),
+                )
+            ] = 0
+
+            if torch.equal(golden, calculated):
+                return 1.0
+
+            if golden.dtype == torch.bfloat16:
+                golden = golden.type(torch.float32)
+                calculated = calculated.type(torch.float32)
+
+            # Single element case
+            if golden.numel() == 1:
+                return float(torch.equal(golden, calculated))
+
+            # If both tensors are contant
+            if torch.max(golden) == torch.min(golden) and torch.max(
+                calculated
+            ) == torch.min(calculated):
+                return torch.isclose(torch.max(golden), torch.max(calculated)).item()
+
+            cal_pcc = np.ma.corrcoef(
+                np.ma.masked_invalid(torch.squeeze(golden).detach().numpy()).flatten(),
+                np.ma.masked_invalid(
+                    torch.squeeze(calculated).detach().numpy()
+                ).flatten(),
+            )
+            # Remove correlation coefficient with self (typically always 1.0)
+            mask = np.ones(cal_pcc.shape, dtype=bool)
+            np.fill_diagonal(mask, 0)
+            cal_pcc = np.min(cal_pcc[mask])
+
+            if isinstance(cal_pcc, np.ma.core.MaskedConstant):
+                return 1.0
+
+            return cal_pcc
+
+    cal_pcc = get_pcc(golden, calculated)
+
+    return (
+        cal_atol,
+        cal_rtol,
+        cal_pcc,
+        f"Max ATOL Delta: {cal_atol}, Max RTOL Delta: {cal_rtol}, PCC: {cal_pcc}",
+    )
+
+
+def golden(binary, programContext, opContext):
+    import torch
+    import ttrt.runtime
+    import ttrt.binary
+
+    print("-----------executing golden comparision-----------")
+
+    try:
+        op_debug_str = ttrt.runtime.get_op_debug_str(opContext)
+
+        # find matching golden tensor based on loc in op debug string
+        match = re.search(r"loc\(([^)]+)\)", op_debug_str)
+
+        if not match:
+            print(f"debug_str={op_debug_str}")
+            print("No location found in debug string - skipping golden comparison")
+            return
+
+        loc = match.group(1).replace('"', "")
+        print(f"found location={loc}")
+
+        op_golden_tensor = binary.get_debug_info_golden(loc)
+        op_output_tensor = ttrt.runtime.get_op_output_tensor(opContext, programContext)
+
+        if len(op_golden_tensor) == 0:
+            print("Golden tensor is empty - skipping golden comparison")
+            return
+
+        if len(op_output_tensor) == 0:
+            print("Output tensor is empty - skipping golden comparison")
+            return
+
+        if len(op_golden_tensor) != len(op_output_tensor):
+            print(
+                "Golden and output tensor sizes do not match - skipping golden comparison"
+            )
+            return
+
+        golden_tensor_torch = torch.tensor(
+            op_golden_tensor, dtype=torch.float32
+        ).flatten()
+        output_tensor_torch = torch.tensor(
+            op_output_tensor, dtype=torch.float32
+        ).flatten()
+
+        _, _, cal_pcc, output_str = get_atol_rtol_pcc(
+            golden_tensor_torch, output_tensor_torch
+        )
+
+        print(f"PCC={cal_pcc}")
+        print(output_str)
+    finally:
+        print("-----------finished executing golden comparision-----------")

--- a/runtime/tools/python/ttrt/runtime/__init__.py
+++ b/runtime/tools/python/ttrt/runtime/__init__.py
@@ -10,6 +10,7 @@ try:
         DataType,
         DeviceRuntime,
         DebugEnv,
+        DebugHooks,
         get_current_runtime,
         set_compatible_runtime,
         get_current_system_desc,
@@ -19,6 +20,8 @@ try:
         create_tensor,
         create_multi_device_tensor,
         wait,
+        get_op_output_tensor,
+        get_op_debug_str,
         WorkaroundEnv,
     )
 except ModuleNotFoundError:


### PR DESCRIPTION
The goal of this PR is to introduce golden support in runtime. The design was taken into account that other runtimes can plug into MLIR runtime (ttrt is just one possible frontend for mlir runtime). The frontend building off MLIR runtime can register a "callback" function through python, which will return ProgramContext* and Operation* - to be run after every op is executed. The frontend can then call supporting APIs to return currently running data.

- golden information embedded into the flatbuffer as a golden_map
  - key = loc() of the operation
  - value = vector(float)
- ability to dump debug string from both Operation* and it's OpType*
- added Hook callback function to execute after every op
  - python interface with C++ runtime can initialize a callback function that will return ProgramContext* and Operation* void ptrs
  - getOpOutputTensor(programcontext, operation) pybind function support to get a tensor from device for a particular op
  - getOpDebugString(programcontext, operation) pybind function support to get an op debug string
    - this is needed to get the loc() information for the op (which is key in golden map)
- ttrt callback module which does golden comparision against device tensor using pcc
- ttrt golden option which sets a golden function and triggers golden comparision for each op in runtime

Some ops have bad pcc: following up bad pcc ops in separate issues. Parent issue: https://github.com/tenstorrent/tt-mlir/issues/1219
