### PR TITLE
Replacing LayoutAttr with TensorConfigAttr

### DIFF
--- a/include/ttmlir/Dialect/TT/Utils/OperandConstraints.h
+++ b/include/ttmlir/Dialect/TT/Utils/OperandConstraints.h
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TT_UTILS_OPERANDCONSTRAINTS_H
+#define TTMLIR_DIALECT_TT_UTILS_OPERANDCONSTRAINTS_H
+
+#include "ttmlir/Dialect/TT/IR/TT.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+
+namespace mlir::tt {
+
+inline OperandConstraint
+memorySpaceAsOperandConstraint(MemorySpace memorySpace) {
+  switch (memorySpace) {
+  case MemorySpace::System:
+  case MemorySpace::SystemMMIO:
+    return OperandConstraint::System;
+  case MemorySpace::DeviceDRAM:
+    return OperandConstraint::DRAM;
+  case MemorySpace::DeviceL1:
+    return OperandConstraint::L1;
+  }
+}
+
+inline OperandConstraint
+memoryLayoutAsOperandConstraint(TensorMemoryLayout memoryLayout) {
+  switch (memoryLayout) {
+  case TensorMemoryLayout::None:
+    return OperandConstraint::None;
+  case TensorMemoryLayout::Interleaved:
+    return OperandConstraint::Interleaved;
+  case TensorMemoryLayout::SingleBank:
+    return OperandConstraint::SingleBank;
+  case TensorMemoryLayout::HeightSharded:
+    return OperandConstraint::HeightSharded;
+  case TensorMemoryLayout::WidthSharded:
+    return OperandConstraint::WidthSharded;
+  case TensorMemoryLayout::BlockSharded:
+    return OperandConstraint::BlockSharded;
+  }
+}
+
+inline MemorySpace getLegalMemorySpace(OperandConstraint operandConstraint,
+                                       MemorySpace defaultMemorySpace) {
+  if (bitEnumContainsAny(operandConstraint,
+                         memorySpaceAsOperandConstraint(defaultMemorySpace))) {
+    return defaultMemorySpace;
+  }
+  if (bitEnumContainsAny(operandConstraint, OperandConstraint::DRAM)) {
+    return MemorySpace::DeviceDRAM;
+  }
+  if (bitEnumContainsAny(operandConstraint, OperandConstraint::L1)) {
+    return MemorySpace::DeviceL1;
+  }
+  return MemorySpace::System;
+}
+
+inline TensorMemoryLayout
+getLegalTensorMemoryLayout(OperandConstraint operandConstraint,
+                           MemorySpace targetMemorySpace,
+                           TensorMemoryLayout defaultDeviceMemLayout) {
+  if (defaultDeviceMemLayout == TensorMemoryLayout::None) {
+    return TensorMemoryLayout::None;
+  }
+
+  if (isSystemMemorySpace(targetMemorySpace)) {
+    return TensorMemoryLayout::None;
+  }
+
+  assert(isDeviceMemorySpace(targetMemorySpace));
+  if (bitEnumContainsAny(operandConstraint, memoryLayoutAsOperandConstraint(
+                                                defaultDeviceMemLayout))) {
+    return defaultDeviceMemLayout;
+  }
+
+  std::map<OperandConstraint, TensorMemoryLayout> validLayoutsMap = {
+      {OperandConstraint::Interleaved, TensorMemoryLayout::Interleaved},
+      {OperandConstraint::SingleBank, TensorMemoryLayout::SingleBank},
+      {OperandConstraint::HeightSharded, TensorMemoryLayout::HeightSharded},
+      {OperandConstraint::WidthSharded, TensorMemoryLayout::WidthSharded},
+      {OperandConstraint::BlockSharded, TensorMemoryLayout::BlockSharded}};
+
+  for (const auto &[constraintLayout, memLayout] : validLayoutsMap) {
+    if (bitEnumContainsAny(operandConstraint, constraintLayout)) {
+      return memLayout;
+    }
+  }
+
+  return TensorMemoryLayout::None;
+}
+
+} // namespace mlir::tt
+
+#endif // TTMLIR_DIALECT_TT_UTILS_OPERANDCONSTRAINTS_H

--- a/include/ttmlir/Dialect/TTNN/Analysis/DFShardingPolicy.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/DFShardingPolicy.h
@@ -8,6 +8,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "ttmlir/Dialect/TTNN/Analysis/L1ChainConfig.h"
 #include "ttmlir/Dialect/TTNN/Analysis/MemoryLayoutAnalysisPolicy.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 
 namespace mlir::tt::ttnn {
 
@@ -23,7 +24,7 @@ private:
 public:
   DFShardingPolicy(
       Operation *rootOp, std::vector<L1ChainConfig> &l1ChainConfigs,
-      const llvm::DenseMap<Operation *, std::vector<tt::LayoutAttr>>
+      const llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>>
           &legalLayouts,
       llvm::DenseMap<func::FuncOp, llvm::SmallVector<Operation *>> &schedule,
       unsigned usableL1CacheSize)

--- a/include/ttmlir/Dialect/TTNN/Analysis/DFShardingPolicy.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/DFShardingPolicy.h
@@ -24,7 +24,7 @@ private:
 public:
   DFShardingPolicy(
       Operation *rootOp, std::vector<L1ChainConfig> &l1ChainConfigs,
-      const llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>>
+      const llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>>
           &legalLayouts,
       llvm::DenseMap<func::FuncOp, llvm::SmallVector<Operation *>> &schedule,
       unsigned usableL1CacheSize)

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1ChainConfig.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1ChainConfig.h
@@ -23,7 +23,7 @@ struct OpL1MemSpec {
 
   // Layout of the output tensor of the op.
   //
-  tt::LayoutAttr layout;
+  TensorConfigAttr layout;
 };
 
 // Enum to track the state of the L1 chain.
@@ -47,15 +47,15 @@ public:
   L1ChainConfig() : opL1MemSpecs(), state() {}
 
   ShardSolver resolveWithSolver(
-      const llvm::DenseMap<Operation *, std::vector<tt::LayoutAttr>>
+      const llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>>
           &legalLayouts,
       unsigned usableL1CacheSize,
       const std::unordered_set<Edge> &overrideReshardEdges);
   void resolve();
   void build();
-  void
-  complete(const llvm::DenseMap<Operation *, tt::LayoutAttr> &selectedOpLayout,
-           std::unordered_set<Edge> &memReconfigEdges);
+  void complete(
+      const llvm::DenseMap<Operation *, TensorConfigAttr> &selectedOpLayout,
+      std::unordered_set<Edge> &memReconfigEdges);
 
   bool isEmpty() { return opL1MemSpecs.empty(); }
   void addOpL1MemSpec(OpL1MemSpec &&spec) {

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1ChainConfig.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1ChainConfig.h
@@ -23,7 +23,7 @@ struct OpL1MemSpec {
 
   // Layout of the output tensor of the op.
   //
-  TensorConfigAttr layout;
+  TTNNLayoutAttr layout;
 };
 
 // Enum to track the state of the L1 chain.
@@ -47,15 +47,15 @@ public:
   L1ChainConfig() : opL1MemSpecs(), state() {}
 
   ShardSolver resolveWithSolver(
-      const llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>>
+      const llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>>
           &legalLayouts,
       unsigned usableL1CacheSize,
       const std::unordered_set<Edge> &overrideReshardEdges);
   void resolve();
   void build();
-  void complete(
-      const llvm::DenseMap<Operation *, TensorConfigAttr> &selectedOpLayout,
-      std::unordered_set<Edge> &memReconfigEdges);
+  void
+  complete(const llvm::DenseMap<Operation *, TTNNLayoutAttr> &selectedOpLayout,
+           std::unordered_set<Edge> &memReconfigEdges);
 
   bool isEmpty() { return opL1MemSpecs.empty(); }
   void addOpL1MemSpec(OpL1MemSpec &&spec) {

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1InterleavedPolicy.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1InterleavedPolicy.h
@@ -15,7 +15,7 @@ class L1InterleavedPolicy : public MemoryLayoutAnalysisPolicy {
 public:
   L1InterleavedPolicy(
       Operation *rootOp, std::vector<L1ChainConfig> &l1ChainConfigs,
-      const llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>>
+      const llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>>
           &legalLayouts,
       llvm::DenseMap<func::FuncOp, llvm::SmallVector<Operation *>> &schedule,
       unsigned usableL1CacheSize)

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1InterleavedPolicy.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1InterleavedPolicy.h
@@ -15,7 +15,7 @@ class L1InterleavedPolicy : public MemoryLayoutAnalysisPolicy {
 public:
   L1InterleavedPolicy(
       Operation *rootOp, std::vector<L1ChainConfig> &l1ChainConfigs,
-      const llvm::DenseMap<Operation *, std::vector<tt::LayoutAttr>>
+      const llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>>
           &legalLayouts,
       llvm::DenseMap<func::FuncOp, llvm::SmallVector<Operation *>> &schedule,
       unsigned usableL1CacheSize)

--- a/include/ttmlir/Dialect/TTNN/Analysis/LegalGridAnalysis.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/LegalGridAnalysis.h
@@ -42,8 +42,8 @@ struct LegalGridAnalysisInput {
   }
 };
 
-class LegalGridAnalysis
-    : public TTNNAnalysis<LegalGridAnalysisInput, std::vector<tt::LayoutAttr>> {
+class LegalGridAnalysis : public TTNNAnalysis<LegalGridAnalysisInput,
+                                              std::vector<TensorConfigAttr>> {
 private:
   void analysisImplementation() override;
   bool applyOverrides() override;

--- a/include/ttmlir/Dialect/TTNN/Analysis/LegalGridAnalysis.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/LegalGridAnalysis.h
@@ -42,8 +42,8 @@ struct LegalGridAnalysisInput {
   }
 };
 
-class LegalGridAnalysis : public TTNNAnalysis<LegalGridAnalysisInput,
-                                              std::vector<TensorConfigAttr>> {
+class LegalGridAnalysis
+    : public TTNNAnalysis<LegalGridAnalysisInput, std::vector<TTNNLayoutAttr>> {
 private:
   void analysisImplementation() override;
   bool applyOverrides() override;

--- a/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutAnalysis.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutAnalysis.h
@@ -14,7 +14,7 @@
 namespace mlir::tt::ttnn {
 
 struct MemoryLayoutAnalysisInput {
-  llvm::DenseMap<Operation *, std::vector<tt::LayoutAttr>> legalLayouts;
+  llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>> legalLayouts;
   unsigned usableL1CacheSize = 0;
   std::unordered_set<Edge> overrideReshardEdges;
   MemoryLayoutAnalysisPolicyType policy;
@@ -22,7 +22,7 @@ struct MemoryLayoutAnalysisInput {
   MemoryLayoutAnalysisInput() : legalLayouts() {}
 
   MemoryLayoutAnalysisInput(
-      const llvm::DenseMap<Operation *, std::vector<tt::LayoutAttr>>
+      const llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>>
           &legalLayouts,
       unsigned usableL1CacheSize,
       const std::unordered_set<Edge> &overrideReshardEdges,
@@ -40,7 +40,7 @@ struct MemoryLayoutAnalysisInput {
 };
 
 struct MemoryLayoutAnalysisResult {
-  llvm::DenseMap<Operation *, std::vector<tt::LayoutAttr>> legalLayouts;
+  llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>> legalLayouts;
   std::unordered_set<Edge> memReconfigEdges;
   llvm::DenseMap<func::FuncOp, llvm::SmallVector<Operation *>> schedule;
 
@@ -48,7 +48,7 @@ struct MemoryLayoutAnalysisResult {
       : legalLayouts(), memReconfigEdges(), schedule() {}
 
   MemoryLayoutAnalysisResult(
-      const llvm::DenseMap<Operation *, std::vector<tt::LayoutAttr>>
+      const llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>>
           &legalLayouts,
       const std::unordered_set<Edge> &memReconfigEdges)
       : legalLayouts(legalLayouts), memReconfigEdges(memReconfigEdges) {}

--- a/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutAnalysis.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutAnalysis.h
@@ -14,7 +14,7 @@
 namespace mlir::tt::ttnn {
 
 struct MemoryLayoutAnalysisInput {
-  llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>> legalLayouts;
+  llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>> legalLayouts;
   unsigned usableL1CacheSize = 0;
   std::unordered_set<Edge> overrideReshardEdges;
   MemoryLayoutAnalysisPolicyType policy;
@@ -22,7 +22,7 @@ struct MemoryLayoutAnalysisInput {
   MemoryLayoutAnalysisInput() : legalLayouts() {}
 
   MemoryLayoutAnalysisInput(
-      const llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>>
+      const llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>>
           &legalLayouts,
       unsigned usableL1CacheSize,
       const std::unordered_set<Edge> &overrideReshardEdges,
@@ -40,7 +40,7 @@ struct MemoryLayoutAnalysisInput {
 };
 
 struct MemoryLayoutAnalysisResult {
-  llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>> legalLayouts;
+  llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>> legalLayouts;
   std::unordered_set<Edge> memReconfigEdges;
   llvm::DenseMap<func::FuncOp, llvm::SmallVector<Operation *>> schedule;
 
@@ -48,7 +48,7 @@ struct MemoryLayoutAnalysisResult {
       : legalLayouts(), memReconfigEdges(), schedule() {}
 
   MemoryLayoutAnalysisResult(
-      const llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>>
+      const llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>>
           &legalLayouts,
       const std::unordered_set<Edge> &memReconfigEdges)
       : legalLayouts(legalLayouts), memReconfigEdges(memReconfigEdges) {}

--- a/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutAnalysisPolicy.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutAnalysisPolicy.h
@@ -14,7 +14,7 @@ class MemoryLayoutAnalysisPolicy {
 protected:
   Operation *rootOp;
   std::vector<L1ChainConfig> *l1ChainConfigs;
-  llvm::DenseMap<Operation *, std::vector<tt::LayoutAttr>> legalLayouts;
+  llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>> legalLayouts;
   llvm::DenseMap<func::FuncOp, llvm::SmallVector<Operation *>> *schedule;
   unsigned usableL1CacheSize = 0;
 
@@ -23,7 +23,7 @@ public:
 
   MemoryLayoutAnalysisPolicy(
       Operation *rootOp, std::vector<L1ChainConfig> &l1ChainConfigs,
-      const llvm::DenseMap<Operation *, std::vector<tt::LayoutAttr>>
+      const llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>>
           &legalLayouts,
       llvm::DenseMap<func::FuncOp, llvm::SmallVector<Operation *>> &schedule,
       unsigned usableL1CacheSize)

--- a/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutAnalysisPolicy.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutAnalysisPolicy.h
@@ -14,7 +14,7 @@ class MemoryLayoutAnalysisPolicy {
 protected:
   Operation *rootOp;
   std::vector<L1ChainConfig> *l1ChainConfigs;
-  llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>> legalLayouts;
+  llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>> legalLayouts;
   llvm::DenseMap<func::FuncOp, llvm::SmallVector<Operation *>> *schedule;
   unsigned usableL1CacheSize = 0;
 
@@ -23,7 +23,7 @@ public:
 
   MemoryLayoutAnalysisPolicy(
       Operation *rootOp, std::vector<L1ChainConfig> &l1ChainConfigs,
-      const llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>>
+      const llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>>
           &legalLayouts,
       llvm::DenseMap<func::FuncOp, llvm::SmallVector<Operation *>> &schedule,
       unsigned usableL1CacheSize)

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpConfigAnalysis.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpConfigAnalysis.h
@@ -11,17 +11,17 @@
 namespace mlir::tt::ttnn {
 
 struct OpConfigAnalysisInput {
-  llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>> legalGrids;
+  llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>> legalGrids;
 
   OpConfigAnalysisInput() : legalGrids() {}
 
   OpConfigAnalysisInput(
-      const llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>>
+      const llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>>
           &&legalGrids)
       : legalGrids(std::move(legalGrids)) {}
 
   OpConfigAnalysisInput(
-      const llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>>
+      const llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>>
           &legalGrids)
       : legalGrids(legalGrids) {}
 
@@ -38,7 +38,7 @@ struct OpConfigAnalysisInput {
 //
 class OpConfigAnalysis
     : public TTNNAnalysis<OpConfigAnalysisInput,
-                          llvm::DenseMap<Operation *, TensorConfigAttr>> {
+                          llvm::DenseMap<Operation *, TTNNLayoutAttr>> {
 
 private:
   void analysisImplementation() override;

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpConfigAnalysis.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpConfigAnalysis.h
@@ -5,23 +5,23 @@
 #ifndef TTMLIR_DIALECT_TTNN_ANALYSIS_OPCONFIGANALYSIS_H
 #define TTMLIR_DIALECT_TTNN_ANALYSIS_OPCONFIGANALYSIS_H
 
-#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
 #include "ttmlir/Dialect/TTNN/Analysis/TTNNAnalysis.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 
 namespace mlir::tt::ttnn {
 
 struct OpConfigAnalysisInput {
-  llvm::DenseMap<Operation *, std::vector<tt::LayoutAttr>> legalGrids;
+  llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>> legalGrids;
 
   OpConfigAnalysisInput() : legalGrids() {}
 
   OpConfigAnalysisInput(
-      const llvm::DenseMap<Operation *, std::vector<tt::LayoutAttr>>
+      const llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>>
           &&legalGrids)
       : legalGrids(std::move(legalGrids)) {}
 
   OpConfigAnalysisInput(
-      const llvm::DenseMap<Operation *, std::vector<tt::LayoutAttr>>
+      const llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>>
           &legalGrids)
       : legalGrids(legalGrids) {}
 
@@ -38,7 +38,7 @@ struct OpConfigAnalysisInput {
 //
 class OpConfigAnalysis
     : public TTNNAnalysis<OpConfigAnalysisInput,
-                          llvm::DenseMap<Operation *, tt::LayoutAttr>> {
+                          llvm::DenseMap<Operation *, TensorConfigAttr>> {
 
 private:
   void analysisImplementation() override;

--- a/include/ttmlir/Dialect/TTNN/Analysis/ShardSolver.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/ShardSolver.h
@@ -19,11 +19,11 @@ namespace mlir::tt::ttnn {
 struct OpL1MemSpec;
 
 struct ShardSolverSolution {
-  llvm::DenseMap<Operation *, TensorConfigAttr> selectedOpLayout;
+  llvm::DenseMap<Operation *, TTNNLayoutAttr> selectedOpLayout;
   std::unordered_set<Edge> memReconfigEdges;
 
   ShardSolverSolution(
-      const llvm::DenseMap<Operation *, TensorConfigAttr> &selectedOpLayout,
+      const llvm::DenseMap<Operation *, TTNNLayoutAttr> &selectedOpLayout,
       const std::unordered_set<Edge> &memReconfigEdges)
       : selectedOpLayout(selectedOpLayout), memReconfigEdges(memReconfigEdges) {
   }
@@ -44,7 +44,7 @@ public:
   struct RemainingLayoutAttrs {
     class Iterator {
       std::uint64_t i = 0;
-      std::vector<TensorConfigAttr> const *p = nullptr;
+      std::vector<TTNNLayoutAttr> const *p = nullptr;
       Bitset mask = 0;
 
     private:
@@ -63,12 +63,12 @@ public:
 
     public:
       using iterator_category = std::input_iterator_tag;
-      using value_type = const TensorConfigAttr;
-      using difference_type = const TensorConfigAttr;
-      using pointer = const TensorConfigAttr *;
-      using reference = const TensorConfigAttr &;
+      using value_type = const TTNNLayoutAttr;
+      using difference_type = const TTNNLayoutAttr;
+      using pointer = const TTNNLayoutAttr *;
+      using reference = const TTNNLayoutAttr &;
 
-      Iterator(std::vector<TensorConfigAttr> const *p, const Bitset &mask,
+      Iterator(std::vector<TTNNLayoutAttr> const *p, const Bitset &mask,
                std::uint64_t i = 0)
           : i(i), p(p), mask(mask) {
         nextValid();
@@ -95,7 +95,7 @@ public:
       std::uint64_t index() const { return i; }
     };
 
-    RemainingLayoutAttrs(std::vector<TensorConfigAttr> const &p,
+    RemainingLayoutAttrs(std::vector<TTNNLayoutAttr> const &p,
                          const Bitset &mask)
         : p(&p), mask(mask) {}
 
@@ -105,7 +105,7 @@ public:
     }
     size_t size() const { return mask.count(); }
 
-    std::vector<TensorConfigAttr> const *p = nullptr;
+    std::vector<TTNNLayoutAttr> const *p = nullptr;
     Bitset mask = 0;
   };
 
@@ -253,7 +253,7 @@ private:
     Paths paths;
   };
 
-  const std::vector<TensorConfigAttr> &
+  const std::vector<TTNNLayoutAttr> &
   getLegalLayouts(Operation *operation) const;
   void reset();
 
@@ -277,26 +277,25 @@ private:
 
   void preprocessFirstOp();
   bool checkShardCompatible(Operation *producerOp,
-                            TensorConfigAttr const &producerLayout,
+                            TTNNLayoutAttr const &producerLayout,
                             Operation *consumerOp,
-                            TensorConfigAttr const &consumerLayout) const;
+                            TTNNLayoutAttr const &consumerLayout) const;
 
 public:
-  ShardSolver(const llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>>
+  ShardSolver(const llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>>
                   &legalLayouts,
               const std::vector<OpL1MemSpec> &shardSpecs,
               const llvm::DenseSet<Operation *> &shardedOps,
               const unsigned usableL1CacheSize,
               const std::unordered_set<Edge> &overrideReshardEdges);
   RemainingLayoutAttrs at(Operation *operation) const;
-  void set(Operation *operation, TensorConfigAttr const &layout);
+  void set(Operation *operation, TTNNLayoutAttr const &layout);
   static bool supportsInterleavedInputShardedOutput(Operation *op);
   llvm::DenseMap<Operation *, SmallVector<float, 64>> produceMaxCoreUsage();
   ShardSolverSolution finish() const;
 
 private:
-  const llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>>
-      *legalLayouts;
+  const llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>> *legalLayouts;
   const std::vector<OpL1MemSpec> *shardSpecs;
   const llvm::DenseSet<Operation *> *shardedOps;
   unsigned usableL1CacheSize;
@@ -309,7 +308,7 @@ private:
   std::unordered_map<Edge, PathSetId> pathSetIds;
   std::unordered_map<Operation *, BitsetId> bitsetIds;
 
-  llvm::DenseMap<Operation *, TensorConfigAttr> selectedOpLayout;
+  llvm::DenseMap<Operation *, TTNNLayoutAttr> selectedOpLayout;
   std::unordered_set<Edge> memReconfigEdges;
 };
 

--- a/include/ttmlir/Dialect/TTNN/Analysis/ShardSolver.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/ShardSolver.h
@@ -7,6 +7,7 @@
 
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
 #include "ttmlir/Dialect/TTNN/Analysis/Edge.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include <algorithm>
 #include <bitset>
 #include <unordered_map>
@@ -18,11 +19,11 @@ namespace mlir::tt::ttnn {
 struct OpL1MemSpec;
 
 struct ShardSolverSolution {
-  llvm::DenseMap<Operation *, tt::LayoutAttr> selectedOpLayout;
+  llvm::DenseMap<Operation *, TensorConfigAttr> selectedOpLayout;
   std::unordered_set<Edge> memReconfigEdges;
 
   ShardSolverSolution(
-      const llvm::DenseMap<Operation *, tt::LayoutAttr> &selectedOpLayout,
+      const llvm::DenseMap<Operation *, TensorConfigAttr> &selectedOpLayout,
       const std::unordered_set<Edge> &memReconfigEdges)
       : selectedOpLayout(selectedOpLayout), memReconfigEdges(memReconfigEdges) {
   }
@@ -43,7 +44,7 @@ public:
   struct RemainingLayoutAttrs {
     class Iterator {
       std::uint64_t i = 0;
-      std::vector<tt::LayoutAttr> const *p = nullptr;
+      std::vector<TensorConfigAttr> const *p = nullptr;
       Bitset mask = 0;
 
     private:
@@ -62,12 +63,12 @@ public:
 
     public:
       using iterator_category = std::input_iterator_tag;
-      using value_type = const tt::LayoutAttr;
-      using difference_type = const tt::LayoutAttr;
-      using pointer = const tt::LayoutAttr *;
-      using reference = const tt::LayoutAttr &;
+      using value_type = const TensorConfigAttr;
+      using difference_type = const TensorConfigAttr;
+      using pointer = const TensorConfigAttr *;
+      using reference = const TensorConfigAttr &;
 
-      Iterator(std::vector<tt::LayoutAttr> const *p, const Bitset &mask,
+      Iterator(std::vector<TensorConfigAttr> const *p, const Bitset &mask,
                std::uint64_t i = 0)
           : i(i), p(p), mask(mask) {
         nextValid();
@@ -94,7 +95,7 @@ public:
       std::uint64_t index() const { return i; }
     };
 
-    RemainingLayoutAttrs(std::vector<tt::LayoutAttr> const &p,
+    RemainingLayoutAttrs(std::vector<TensorConfigAttr> const &p,
                          const Bitset &mask)
         : p(&p), mask(mask) {}
 
@@ -104,7 +105,7 @@ public:
     }
     size_t size() const { return mask.count(); }
 
-    std::vector<tt::LayoutAttr> const *p = nullptr;
+    std::vector<TensorConfigAttr> const *p = nullptr;
     Bitset mask = 0;
   };
 
@@ -252,7 +253,7 @@ private:
     Paths paths;
   };
 
-  const std::vector<tt::LayoutAttr> &
+  const std::vector<TensorConfigAttr> &
   getLegalLayouts(Operation *operation) const;
   void reset();
 
@@ -276,25 +277,26 @@ private:
 
   void preprocessFirstOp();
   bool checkShardCompatible(Operation *producerOp,
-                            tt::LayoutAttr const &producerLayout,
+                            TensorConfigAttr const &producerLayout,
                             Operation *consumerOp,
-                            tt::LayoutAttr const &consumerLayout) const;
+                            TensorConfigAttr const &consumerLayout) const;
 
 public:
-  ShardSolver(const llvm::DenseMap<Operation *, std::vector<tt::LayoutAttr>>
+  ShardSolver(const llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>>
                   &legalLayouts,
               const std::vector<OpL1MemSpec> &shardSpecs,
               const llvm::DenseSet<Operation *> &shardedOps,
               const unsigned usableL1CacheSize,
               const std::unordered_set<Edge> &overrideReshardEdges);
   RemainingLayoutAttrs at(Operation *operation) const;
-  void set(Operation *operation, tt::LayoutAttr const &layout);
+  void set(Operation *operation, TensorConfigAttr const &layout);
   static bool supportsInterleavedInputShardedOutput(Operation *op);
   llvm::DenseMap<Operation *, SmallVector<float, 64>> produceMaxCoreUsage();
   ShardSolverSolution finish() const;
 
 private:
-  const llvm::DenseMap<Operation *, std::vector<tt::LayoutAttr>> *legalLayouts;
+  const llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>>
+      *legalLayouts;
   const std::vector<OpL1MemSpec> *shardSpecs;
   const llvm::DenseSet<Operation *> *shardedOps;
   unsigned usableL1CacheSize;
@@ -307,7 +309,7 @@ private:
   std::unordered_map<Edge, PathSetId> pathSetIds;
   std::unordered_map<Operation *, BitsetId> bitsetIds;
 
-  llvm::DenseMap<Operation *, tt::LayoutAttr> selectedOpLayout;
+  llvm::DenseMap<Operation *, TensorConfigAttr> selectedOpLayout;
   std::unordered_set<Edge> memReconfigEdges;
 };
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.td
@@ -19,7 +19,7 @@ def TTNN_OpModelInterface : OpInterface<"OpModel"> {
             }],
             /*retTy=*/"size_t",
             /*methodName=*/"getOpPerfCycles",
-            /*args=*/(ins "const std::vector<TensorConfigAttr>&":$input_layouts, "const TensorConfigAttr&":$output_layout),
+            /*args=*/(ins "const std::vector<TTNNLayoutAttr>&":$input_layouts, "const TTNNLayoutAttr&":$output_layout),
             /*methodBody=*/"",
             /*defaultImplementation=*/"return std::numeric_limits<size_t>::max();"
         >,
@@ -32,7 +32,7 @@ def TTNN_OpModelInterface : OpInterface<"OpModel"> {
             }],
             /*retTy=*/"std::tuple<size_t, size_t, size_t>",
             /*methodName=*/"getOpL1Usage",
-            /*args=*/(ins "const std::vector<TensorConfigAttr>&":$input_layouts, "const TensorConfigAttr&":$output_layout),
+            /*args=*/(ins "const std::vector<TTNNLayoutAttr>&":$input_layouts, "const TTNNLayoutAttr&":$output_layout),
             /*methodBody=*/"",
             /*defaultImplementation=*/"return std::make_tuple(0,0,0);"
         >,
@@ -42,7 +42,7 @@ def TTNN_OpModelInterface : OpInterface<"OpModel"> {
             }],
             /*retTy=*/"bool",
             /*methodName=*/"isOpLegal",
-            /*args=*/(ins "const std::vector<TensorConfigAttr>&":$input_layouts, "const TensorConfigAttr&":$output_layout),
+            /*args=*/(ins "const std::vector<TTNNLayoutAttr>&":$input_layouts, "const TTNNLayoutAttr&":$output_layout),
             /*methodBody=*/"",
             /*defaultImplementation=*/"return true;"
         >,

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.td
@@ -19,7 +19,7 @@ def TTNN_OpModelInterface : OpInterface<"OpModel"> {
             }],
             /*retTy=*/"size_t",
             /*methodName=*/"getOpPerfCycles",
-            /*args=*/(ins "const std::vector<tt::LayoutAttr>&":$input_layouts, "const tt::LayoutAttr&":$output_layout),
+            /*args=*/(ins "const std::vector<TensorConfigAttr>&":$input_layouts, "const TensorConfigAttr&":$output_layout),
             /*methodBody=*/"",
             /*defaultImplementation=*/"return std::numeric_limits<size_t>::max();"
         >,
@@ -32,7 +32,7 @@ def TTNN_OpModelInterface : OpInterface<"OpModel"> {
             }],
             /*retTy=*/"std::tuple<size_t, size_t, size_t>",
             /*methodName=*/"getOpL1Usage",
-            /*args=*/(ins "const std::vector<tt::LayoutAttr>&":$input_layouts, "const tt::LayoutAttr&":$output_layout),
+            /*args=*/(ins "const std::vector<TensorConfigAttr>&":$input_layouts, "const TensorConfigAttr&":$output_layout),
             /*methodBody=*/"",
             /*defaultImplementation=*/"return std::make_tuple(0,0,0);"
         >,
@@ -42,7 +42,7 @@ def TTNN_OpModelInterface : OpInterface<"OpModel"> {
             }],
             /*retTy=*/"bool",
             /*methodName=*/"isOpLegal",
-            /*args=*/(ins "const std::vector<tt::LayoutAttr>&":$input_layouts, "const tt::LayoutAttr&":$output_layout),
+            /*args=*/(ins "const std::vector<TensorConfigAttr>&":$input_layouts, "const TensorConfigAttr&":$output_layout),
             /*methodBody=*/"",
             /*defaultImplementation=*/"return true;"
         >,

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.h
@@ -14,9 +14,10 @@
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
-#include "ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.h.inc"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsTypes.h"
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.h.inc"
 
 #define GET_OP_CLASSES
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h.inc"

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -732,7 +732,7 @@ def TTNN_AllocOp : TTNN_Op<"alloc"> {
       Tensor Alloc operation
     }];
 
-    let arguments = (ins I64Attr:$address, I64Attr:$size, TT_MemorySpaceAttr:$memory_space);
+    let arguments = (ins I64Attr:$address, I64Attr:$size, TTNN_BufferTypeAttr:$buffer_type);
     let results = (outs AnyRankedTensor:$result);
 
     let hasVerifier = 1;

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h
@@ -9,7 +9,27 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
 
+#include "ttmlir/Dialect/TTNN/IR/TTNN.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsEnums.h.inc"
+
+namespace mlir::tt::ttnn {
+
+inline bool isSystemBufferType(mlir::tt::ttnn::BufferType bufferType) {
+  return bufferType == mlir::tt::ttnn::BufferType::SystemMemory;
+}
+
+inline bool isDeviceBufferType(mlir::tt::ttnn::BufferType bufferType) {
+  return bufferType == mlir::tt::ttnn::BufferType::L1 ||
+         bufferType == mlir::tt::ttnn::BufferType::DRAM ||
+         bufferType == mlir::tt::ttnn::BufferType::L1Small;
+}
+
+inline bool isShardedMemoryLayout(TensorMemoryLayout layout) {
+  return layout == TensorMemoryLayout::HeightSharded ||
+         layout == TensorMemoryLayout::WidthSharded ||
+         layout == TensorMemoryLayout::BlockSharded;
+}
+} // namespace mlir::tt::ttnn
 
 #define GET_ATTRDEF_CLASSES
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrDefs.h.inc"

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
@@ -105,10 +105,10 @@ def TTNN_MeshShapeAttr : TTNN_Attr<"MeshShape", "mesh_shape"> {
   let assemblyFormat = "custom<VargDimensionList>($y, $x)";
 }
 
-def TTNN_TensorConfig: TTNN_Attr<"TensorConfig", "tensor_config"> {
-  let summary = "Tensor config attribute in ttnn";
+def TTNN_TTNNLayoutAttr: TTNN_Attr<"TTNNLayout", "tensor_config"> {
+  let summary = "Tensor encoding attribute used for types in ttnn";
   let description = [{
-    Tensor config attribute in ttnn. This attribute is used to describe the memory layout of a tensor..
+    Layout attribute in ttnn. This attribute is used to encode different information about tensor memory layout.
   }];
 
   let parameters = (ins AttrParameter<"AffineMap", "An affine map that defines how the logical tensor dimensions map to a grid shape.">:$linear,
@@ -117,7 +117,7 @@ def TTNN_TensorConfig: TTNN_Attr<"TensorConfig", "tensor_config"> {
                         DefaultValuedParameter<"TensorMemoryLayout", "TensorMemoryLayout::None", "The layout of the tensor in memory.">:$mem_layout);
   let assemblyFormat = "`<` $linear`,` $grid`,` $memref (`,` $mem_layout^)? `>`";
   let extraClassDeclaration = [{
-    static TensorConfigAttr get(::mlir::MLIRContext *context,
+    static TTNNLayoutAttr get(::mlir::MLIRContext *context,
                         ArrayRef<int64_t> tensorShape,
                         Type elementType,
                         BufferType bufferType,
@@ -126,15 +126,15 @@ def TTNN_TensorConfig: TTNN_Attr<"TensorConfig", "tensor_config"> {
                         ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}});
       uint64_t getShardSizeInBytes() const;
       BufferType getBufferType() const;
-      TensorConfigAttr withGrid(::mlir::MLIRContext *context, ArrayRef<int64_t> tensorShape, GridAttr grid, ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}});
-      TensorConfigAttr withGrid(::mlir::MLIRContext *context,
+      TTNNLayoutAttr withGrid(::mlir::MLIRContext *context, ArrayRef<int64_t> tensorShape, GridAttr grid, ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}});
+      TTNNLayoutAttr withGrid(::mlir::MLIRContext *context,
                           RankedTensorType ty,
                           GridAttr grid,
                           ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}});
-      TensorConfigAttr withElementType(::mlir::MLIRContext *context, Type elementType);
-      TensorConfigAttr withBufferType(::mlir::MLIRContext *context, BufferType bufferType);
-      TensorConfigAttr withMemoryLayout(::mlir::MLIRContext *context, TensorMemoryLayout memLayout);
-      TensorConfigAttr withShardShape(::mlir::MLIRContext *context, llvm::SmallVector<int64_t> shardShape);
+      TTNNLayoutAttr withElementType(::mlir::MLIRContext *context, Type elementType);
+      TTNNLayoutAttr withBufferType(::mlir::MLIRContext *context, BufferType bufferType);
+      TTNNLayoutAttr withMemoryLayout(::mlir::MLIRContext *context, TensorMemoryLayout memLayout);
+      TTNNLayoutAttr withShardShape(::mlir::MLIRContext *context, llvm::SmallVector<int64_t> shardShape);
 
       bool isSystemBufferType() const { return ::mlir::tt::ttnn::isSystemBufferType(getBufferType()); }
       bool isDeviceBufferType() const { return ::mlir::tt::ttnn::isDeviceBufferType(getBufferType()); }

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
@@ -105,7 +105,7 @@ def TTNN_MeshShapeAttr : TTNN_Attr<"MeshShape", "mesh_shape"> {
   let assemblyFormat = "custom<VargDimensionList>($y, $x)";
 }
 
-def TTNN_TTNNLayoutAttr: TTNN_Attr<"TTNNLayout", "tensor_config"> {
+def TTNN_TTNNLayoutAttr: TTNN_Attr<"TTNNLayout", "ttnn_layout"> {
   let summary = "Tensor encoding attribute used for types in ttnn";
   let description = [{
     Layout attribute in ttnn. This attribute is used to encode different information about tensor memory layout.

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
@@ -105,4 +105,55 @@ def TTNN_MeshShapeAttr : TTNN_Attr<"MeshShape", "mesh_shape"> {
   let assemblyFormat = "custom<VargDimensionList>($y, $x)";
 }
 
+def TTNN_TensorConfig: TTNN_Attr<"TensorConfig", "tensor_config"> {
+  let summary = "Tensor config attribute in ttnn";
+  let description = [{
+    Tensor config attribute in ttnn. This attribute is used to describe the memory layout of a tensor..
+  }];
+
+  let parameters = (ins AttrParameter<"AffineMap", "An affine map that defines how the logical tensor dimensions map to a grid shape.">:$linear,
+                        AttrParameter<"GridAttr", "The grid shape that this tensor is divided onto.">:$grid,
+                        AttrParameter<"MemRefType", "A memref that describes the physical footprint allocation of the shard. It must also have a shape with rank equal to grid.">:$memref,
+                        DefaultValuedParameter<"TensorMemoryLayout", "TensorMemoryLayout::None", "The layout of the tensor in memory.">:$mem_layout);
+  let assemblyFormat = "`<` $linear`,` $grid`,` $memref (`,` $mem_layout^)? `>`";
+  let extraClassDeclaration = [{
+    static TensorConfigAttr get(::mlir::MLIRContext *context,
+                        ArrayRef<int64_t> tensorShape,
+                        Type elementType,
+                        BufferType bufferType,
+                        GridAttr grid,
+                        TensorMemoryLayout memoryLayout,
+                        ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}});
+      uint64_t getShardSizeInBytes() const;
+      BufferType getBufferType() const;
+      TensorConfigAttr withGrid(::mlir::MLIRContext *context, ArrayRef<int64_t> tensorShape, GridAttr grid, ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}});
+      TensorConfigAttr withGrid(::mlir::MLIRContext *context,
+                          RankedTensorType ty,
+                          GridAttr grid,
+                          ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}});
+      TensorConfigAttr withElementType(::mlir::MLIRContext *context, Type elementType);
+      TensorConfigAttr withBufferType(::mlir::MLIRContext *context, BufferType bufferType);
+      TensorConfigAttr withMemoryLayout(::mlir::MLIRContext *context, TensorMemoryLayout memLayout);
+      TensorConfigAttr withShardShape(::mlir::MLIRContext *context, llvm::SmallVector<int64_t> shardShape);
+
+      bool isSystemBufferType() const { return ::mlir::tt::ttnn::isSystemBufferType(getBufferType()); }
+      bool isDeviceBufferType() const { return ::mlir::tt::ttnn::isDeviceBufferType(getBufferType()); }
+      bool hasShardedTensorMemoryLayout() const;
+      bool hasShardedL1TensorMemoryLayout() const;
+      bool hasInterleavedL1TensorMemoryLayout() const;
+      bool isTiled() const;
+      Type getElementType() const;
+      DataType getDataTypeFromMemRef() const;
+      uint64_t getElementSizeBytes() const;
+      int64_t getTensorSizeInBytes(ArrayRef<int64_t> tensorShape, ::mlir::tt::DeviceAttr device) const;
+      llvm::SmallVector<int64_t> getStride(ArrayRef<int64_t> logicalShape) const;
+      llvm::SmallVector<int64_t> getPhysicalShape(ArrayRef<int64_t> logicalShape) const;
+      llvm::SmallVector<int64_t> getShardShape(bool convertTileToScalar = true) const;
+      AffineMap replaceMemoryMapSymbolsWithShardShape(AffineMap physicalMemoryMap) const;
+      AffineMap projectOnto(AffineMap linearMap, AffineMap physicalMemoryMap) const;
+      AffineMap getIdentityTileLinearMap() const;
+      llvm::SmallVector<int64_t> getTiledShape(ArrayRef<int64_t> logicalTensorShape) const;
+  }];
+}
+
 #endif  // TTMLIR_TTMLIR_DIALECT_TTNN_TTNNOPSATTRS_TD

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.h
@@ -11,6 +11,7 @@
 #include "ttmlir/Dialect/TTNN/Analysis/MemoryLayoutAnalysis.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNN.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Optimizer.h"
 #include "ttmlir/Dialect/TTNN/Utils/OptimizerOverrides.h"
 

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -21,4 +21,11 @@ def TTNNDecomposeLayouts: Pass<"ttnn-decompose-layouts", "::mlir::ModuleOp"> {
   }];
 }
 
+def TTNNLayout : Pass<"ttnn-layout", "::mlir::ModuleOp"> {
+  let summary = "Add layout information to tensors.";
+  let description = [{
+    This pass adds layout information to tensors.
+  }];
+}
+
 #endif

--- a/include/ttmlir/Dialect/TTNN/Utils/OptimizerOverrides.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/OptimizerOverrides.h
@@ -14,9 +14,9 @@ namespace mlir::tt::ttnn {
 
 struct OutputLayoutOverrideParams {
   SmallVector<int64_t, 2> grid;
-  tt::MemorySpace memorySpace;
-  tt::TensorMemoryLayout tensorMemoryLayout; // INTERLEAVED / SHARDED etc...
-  tt::ttnn::Layout memoryLayout;             // ROW_MAJOR / TILE
+  BufferType bufferType;
+  TensorMemoryLayout tensorMemoryLayout; // INTERLEAVED / SHARDED etc...
+  Layout memoryLayout;                   // ROW_MAJOR / TILE
   tt::DataType dataType;
 };
 

--- a/include/ttmlir/Dialect/TTNN/Utils/Utils.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/Utils.h
@@ -11,15 +11,25 @@
 
 namespace mlir::tt::ttnn::utils {
 
-// Map TT::MemorySpace to TTNN::BufferType
+// Map tt::MemorySpace to ttnn::BufferType
 //
 mlir::tt::ttnn::BufferType
 toTTNNBufferType(const mlir::tt::MemorySpace memorySpace);
 
-// Map TT::TensorMemoryLayout to TTNN::TensorMemoryLayout
+// Map tt::TensorMemoryLayout to ttnn::TensorMemoryLayout
 //
 ttnn::TensorMemoryLayout
 toTTNNTensorMemoryLayout(const tt::TensorMemoryLayout ttTensorMemoryLayout);
+
+// Map ttnn::BufferType to tt::MemorySpace
+//
+mlir::tt::TensorMemoryLayout toTTTensorMemoryLayout(
+    const ::mlir::tt::ttnn::TensorMemoryLayout ttnnTensorMemoryLayout);
+
+// Map ttnn::BufferType to tt::MemorySpace
+//
+mlir::tt::MemorySpace
+toTTMemorySpace(const mlir::tt::ttnn::BufferType bufferType);
 
 DataType getDataTypeFromMemRef(mlir::MemRefType memref);
 

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -21,8 +21,8 @@ flatbuffers::Offset<::tt::target::LayoutDesc>
 layoutAttrToFlatbuffer(FlatbufferObjectCache &cache, LayoutAttr attr,
                        ArrayRef<int64_t> logicalShape, DeviceAttr deviceAttr);
 
-flatbuffers::Offset<::tt::target::LayoutDesc> tensorConfigAttrToFlatbuffer(
-    FlatbufferObjectCache &cache, ttnn::TensorConfigAttr attr,
+flatbuffers::Offset<::tt::target::LayoutDesc> ttnnLayoutAttrToFlatbuffer(
+    FlatbufferObjectCache &cache, ttnn::TTNNLayoutAttr attr,
     ArrayRef<int64_t> logicalShape, DeviceAttr deviceAttr);
 
 struct GoldenTensor {
@@ -443,9 +443,9 @@ encodingToFlatbuffer(FlatbufferObjectCache &cache, Attribute attr,
                                   deviceAttr);
   }
 
-  if (isa<ttnn::TensorConfigAttr>(attr)) {
-    return tensorConfigAttrToFlatbuffer(
-        cache, cast<ttnn::TensorConfigAttr>(attr), logicalShape, deviceAttr);
+  if (isa<ttnn::TTNNLayoutAttr>(attr)) {
+    return ttnnLayoutAttrToFlatbuffer(cache, cast<ttnn::TTNNLayoutAttr>(attr),
+                                      logicalShape, deviceAttr);
   }
 
   assert(false && "unsupported layout attr");

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -10,11 +10,21 @@
 
 #include "flatbuffers/flatbuffers.h"
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/Target/Common/Target.h"
 #include "ttmlir/Target/Utils/FlatbufferObjectCache.h"
 #include "ttmlir/Utils.h"
 
 namespace mlir::tt {
+
+flatbuffers::Offset<::tt::target::LayoutDesc>
+layoutAttrToFlatbuffer(FlatbufferObjectCache &cache, LayoutAttr attr,
+                       ArrayRef<int64_t> logicalShape, DeviceAttr deviceAttr);
+
+flatbuffers::Offset<::tt::target::LayoutDesc> tensorConfigAttrToFlatbuffer(
+    FlatbufferObjectCache &cache, ttnn::TensorConfigAttr attr,
+    ArrayRef<int64_t> logicalShape, DeviceAttr deviceAttr);
+
 struct GoldenTensor {
   std::string name;
   std::vector<int64_t> shape;
@@ -425,59 +435,20 @@ toFlatbuffer(FlatbufferObjectCache &cache, ElementsAttr elementsAttr) {
   return toFlatbuffer(cache, ArrayRef<uint32_t>(data));
 }
 
-inline flatbuffers::Offset<::tt::target::MemoryDesc>
-memrefAttrToFlatbuffer(FlatbufferObjectCache &cache, MemRefType memref,
-                       ::mlir::tt::TensorMemoryLayout memLayout) {
-  auto shapeInt64 = memref.getShape();
-  std::vector<int32_t> shape(shapeInt64.begin(), shapeInt64.end());
-  DataType dtype = DataType::Float32;
-  ::tt::target::Dim2d tileShape(1, 1);
-  Type elementType = memref.getElementType();
-  std::uint64_t elementSize = 0;
-  if (isa<TileType>(elementType)) {
-    auto tileType = mlir::cast<TileType>(elementType);
-    dtype = tileType.getDataType();
-    tileShape = ::tt::target::Dim2d(tileType.getHeight(), tileType.getWidth());
-    elementSize = tileType.getSizeBytes();
-  } else {
-    dtype = elementTypeToDataType(elementType);
-    elementSize = getElementSizeBytes(dtype);
-  }
-
-  std::uint64_t size = elementSize;
-  for (auto dim : shapeInt64) {
-    size *= dim;
-  }
-
-  return ::tt::target::CreateMemoryDescDirect(
-      *cache.fbb, &shape, &tileShape, toFlatbuffer(cache, dtype),
-      toFlatbuffer(
-          cache,
-          mlir::cast<MemorySpaceAttr>(memref.getMemorySpace()).getValue()),
-      toFlatbuffer(cache, memLayout), size);
-}
-
 inline flatbuffers::Offset<::tt::target::LayoutDesc>
-layoutAttrToFlatbuffer(FlatbufferObjectCache &cache, Attribute attr,
-                       ArrayRef<int64_t> logicalShape, DeviceAttr deviceAttr) {
-  assert(isa<LayoutAttr>(attr) && "expected a tensor type");
-  auto layoutAttr = mlir::cast<LayoutAttr>(attr);
-  auto strideInt64 = layoutAttr.getStride(logicalShape);
-  std::vector<int32_t> stride(strideInt64.begin(), strideInt64.end());
-  auto coreRangeSet =
-      toFlatbuffer(cache, layoutAttr.getGrid(), deviceAttr.getWorkerGrid());
-  ::tt::target::DistributedTensorConfig distributionType =
-      ::tt::target::DistributedTensorConfig::NONE;
-  ::flatbuffers::Offset<void> distribution = 0;
-  flatbuffers::Offset<::tt::target::DistributionStrategy> strategy =
-      ::tt::target::CreateDistributionStrategy(*cache.fbb, distributionType,
-                                               distribution);
-  return ::tt::target::CreateLayoutDescDirect(
-      *cache.fbb, &stride, toFlatbuffer(cache, layoutAttr.getOobVal()),
-      &coreRangeSet,
-      cache.getOrCreate(layoutAttr.getMemref(), memrefAttrToFlatbuffer,
-                        layoutAttr.getMemLayout()),
-      strategy);
+encodingToFlatbuffer(FlatbufferObjectCache &cache, Attribute attr,
+                     ArrayRef<int64_t> logicalShape, DeviceAttr deviceAttr) {
+  if (isa<LayoutAttr>(attr)) {
+    return layoutAttrToFlatbuffer(cache, cast<LayoutAttr>(attr), logicalShape,
+                                  deviceAttr);
+  }
+
+  if (isa<ttnn::TensorConfigAttr>(attr)) {
+    return tensorConfigAttrToFlatbuffer(
+        cache, cast<ttnn::TensorConfigAttr>(attr), logicalShape, deviceAttr);
+  }
+
+  assert(false && "unsupported layout attr");
 }
 
 inline flatbuffers::Offset<::tt::target::TensorDesc>
@@ -488,7 +459,7 @@ tensorTypeToFlatbuffer(FlatbufferObjectCache &cache, Type type,
   std::vector<int32_t> shape(shapeInt64.begin(), shapeInt64.end());
   return ::tt::target::CreateTensorDescDirect(
       *cache.fbb, &shape,
-      cache.getOrCreate(tensorType.getEncoding(), layoutAttrToFlatbuffer,
+      cache.getOrCreate(tensorType.getEncoding(), encodingToFlatbuffer,
                         shapeInt64, deviceAttr));
 }
 

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -58,9 +58,9 @@ public:
   matchAndRewrite(tensor::EmptyOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    // Get ttnn::TensorConfigAttr of the result type
+    // Get ttnn::TTNNLayoutAttr of the result type
     //
-    ttnn::TensorConfigAttr layoutAttr = mlir::cast<ttnn::TensorConfigAttr>(
+    ttnn::TTNNLayoutAttr layoutAttr = mlir::cast<ttnn::TTNNLayoutAttr>(
         op.getResult().getType().getEncoding());
 
     // Get the shape of the tensor, tensor layout, and data type
@@ -134,7 +134,7 @@ public:
       rewriter.eraseOp(emptyOp);
     }
 
-    auto outputLayoutAttr = mlir::cast<ttnn::TensorConfigAttr>(
+    auto outputLayoutAttr = mlir::cast<ttnn::TTNNLayoutAttr>(
         op.getResult().getType().getEncoding());
 
     auto outputMemref = outputLayoutAttr.getMemref();
@@ -175,7 +175,7 @@ public:
             getLayoutForcedResultTensor(rewriter, result, newOutputLayoutEnum);
         op.getResult().setType(result);
         outputLayoutAttr =
-            mlir::cast<ttnn::TensorConfigAttr>(result.getEncoding());
+            mlir::cast<ttnn::TTNNLayoutAttr>(result.getEncoding());
         outputMemref = outputLayoutAttr.getMemref();
         outputLayoutEnum = newOutputLayoutEnum;
       }
@@ -221,7 +221,7 @@ private:
                               RankedTensorType oldOutput,
                               ttnn::Layout newOutputLayoutEnum) const {
     auto oldOutputLayoutAttr =
-        mlir::cast<ttnn::TensorConfigAttr>(oldOutput.getEncoding());
+        mlir::cast<ttnn::TTNNLayoutAttr>(oldOutput.getEncoding());
     auto oldOutputMemref = oldOutputLayoutAttr.getMemref();
     DataType outputDtype = ttnn::utils::getDataTypeFromMemRef(oldOutputMemref);
     llvm::ArrayRef<std::int64_t> oldShardShape = oldOutputMemref.getShape();
@@ -772,8 +772,8 @@ public:
     auto result = ::llvm::cast<::mlir::TypedValue<::mlir::RankedTensorType>>(
         *op.getResults().begin());
 
-    ttnn::TensorConfigAttr outputLayoutAttr =
-        mlir::cast<ttnn::TensorConfigAttr>(result.getType().getEncoding());
+    ttnn::TTNNLayoutAttr outputLayoutAttr =
+        mlir::cast<ttnn::TTNNLayoutAttr>(result.getType().getEncoding());
 
     mlir::MemRefType outputMemref = outputLayoutAttr.getMemref();
 

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -58,14 +58,14 @@ public:
   matchAndRewrite(tensor::EmptyOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    // Get tt::LayoutAttr of the result type
+    // Get ttnn::TensorConfigAttr of the result type
     //
-    tt::LayoutAttr ttLayoutAttr =
-        mlir::cast<tt::LayoutAttr>(op.getResult().getType().getEncoding());
+    ttnn::TensorConfigAttr layoutAttr = mlir::cast<ttnn::TensorConfigAttr>(
+        op.getResult().getType().getEncoding());
 
     // Get the shape of the tensor, tensor layout, and data type
     //
-    mlir::MemRefType memref = ttLayoutAttr.getMemref();
+    mlir::MemRefType memref = layoutAttr.getMemref();
     ttnn::ShapeAttr shapeAttr = ttnn::ShapeAttr::get(
         rewriter.getContext(),
         mlir::cast<RankedTensorType>(op->getResult(0).getType()).getShape());
@@ -87,8 +87,8 @@ public:
     // If the tensor is not going to device, we can create the op without
     // device-specific attributes
     //
-    tt::TensorMemoryLayout ttTensorMemoryLayout = ttLayoutAttr.getMemLayout();
-    if (ttTensorMemoryLayout == TensorMemoryLayout::None) {
+    ttnn::TensorMemoryLayout memLayout = layoutAttr.getMemLayout();
+    if (memLayout == ttnn::TensorMemoryLayout::None) {
       rewriter.replaceOpWithNewOp<ttnn::EmptyOp>(
           op, this->getTypeConverter()->convertType(op.getType()), nullptr,
           shapeAttr, dTypeAttr, tensorLayoutAttr, nullptr);
@@ -96,17 +96,14 @@ public:
       return success();
     }
 
-    ttnn::BufferType bufferType =
-        ttnn::utils::toTTNNBufferType(ttLayoutAttr.getMemorySpace());
-    ttnn::TensorMemoryLayout tensorMemoryLayout =
-        ttnn::utils::toTTNNTensorMemoryLayout(ttLayoutAttr.getMemLayout());
+    ttnn::BufferType bufferType = layoutAttr.getBufferType();
 
     // Create MemoryConfigAttr
     //
     auto device = getOrInsertDevice(rewriter, op);
     ttnn::MemoryConfigAttr memoryConfigAttr = ttnn::MemoryConfigAttr::get(
         op.getContext(),
-        ttnn::TensorMemoryLayoutAttr::get(op.getContext(), tensorMemoryLayout),
+        ttnn::TensorMemoryLayoutAttr::get(op.getContext(), memLayout),
         ttnn::BufferTypeAttr::get(op.getContext(), bufferType),
         ttnn::ShardSpecAttr::get(
             op.getContext(),
@@ -137,8 +134,8 @@ public:
       rewriter.eraseOp(emptyOp);
     }
 
-    auto outputLayoutAttr =
-        mlir::cast<tt::LayoutAttr>(op.getResult().getType().getEncoding());
+    auto outputLayoutAttr = mlir::cast<ttnn::TensorConfigAttr>(
+        op.getResult().getType().getEncoding());
 
     auto outputMemref = outputLayoutAttr.getMemref();
 
@@ -148,8 +145,7 @@ public:
         DataTypeAttr::get(rewriter.getContext(), dtype);
 
     // Determine the output layout (tile or row major)
-    ttnn::BufferType outputBufferType =
-        ttnn::utils::toTTNNBufferType(outputLayoutAttr.getMemorySpace());
+    ttnn::BufferType outputBufferType = outputLayoutAttr.getBufferType();
 
     ttnn::Layout outputLayoutEnum =
         ttnn::utils::getLayoutFromMemRef(outputMemref);
@@ -178,7 +174,8 @@ public:
         result =
             getLayoutForcedResultTensor(rewriter, result, newOutputLayoutEnum);
         op.getResult().setType(result);
-        outputLayoutAttr = mlir::cast<tt::LayoutAttr>(result.getEncoding());
+        outputLayoutAttr =
+            mlir::cast<ttnn::TensorConfigAttr>(result.getEncoding());
         outputMemref = outputLayoutAttr.getMemref();
         outputLayoutEnum = newOutputLayoutEnum;
       }
@@ -189,7 +186,7 @@ public:
 
     // Determine output memory config attr
     ttnn::TensorMemoryLayout outputTensorMemoryLayout =
-        ttnn::utils::toTTNNTensorMemoryLayout(outputLayoutAttr.getMemLayout());
+        outputLayoutAttr.getMemLayout();
     ttnn::MemoryConfigAttr outputMemConfigAttr = ttnn::MemoryConfigAttr::get(
         rewriter.getContext(),
         ttnn::TensorMemoryLayoutAttr::get(rewriter.getContext(),
@@ -224,7 +221,7 @@ private:
                               RankedTensorType oldOutput,
                               ttnn::Layout newOutputLayoutEnum) const {
     auto oldOutputLayoutAttr =
-        mlir::cast<tt::LayoutAttr>(oldOutput.getEncoding());
+        mlir::cast<ttnn::TensorConfigAttr>(oldOutput.getEncoding());
     auto oldOutputMemref = oldOutputLayoutAttr.getMemref();
     DataType outputDtype = ttnn::utils::getDataTypeFromMemRef(oldOutputMemref);
     llvm::ArrayRef<std::int64_t> oldShardShape = oldOutputMemref.getShape();
@@ -775,8 +772,8 @@ public:
     auto result = ::llvm::cast<::mlir::TypedValue<::mlir::RankedTensorType>>(
         *op.getResults().begin());
 
-    tt::LayoutAttr outputLayoutAttr =
-        mlir::cast<tt::LayoutAttr>(result.getType().getEncoding());
+    ttnn::TensorConfigAttr outputLayoutAttr =
+        mlir::cast<ttnn::TensorConfigAttr>(result.getType().getEncoding());
 
     mlir::MemRefType outputMemref = outputLayoutAttr.getMemref();
 

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -773,16 +773,6 @@ mlir::tt::ttir::GetDimensionSizeOp::fold(FoldAdaptor adaptor) {
 ::mlir::LogicalResult mlir::tt::ttir::ToLayoutOp::verify() {
   ::mlir::RankedTensorType inputTy = getInput().getType();
   ::mlir::RankedTensorType outputTy = getOutput().getType();
-  auto inputLayout =
-      mlir::dyn_cast_or_null<mlir::tt::LayoutAttr>(inputTy.getEncoding());
-  auto outputLayout =
-      mlir::dyn_cast_or_null<mlir::tt::LayoutAttr>(outputTy.getEncoding());
-  if (not inputLayout) {
-    return emitOpError("Input tensor type missing layout attribute");
-  }
-  if (not outputLayout) {
-    return emitOpError("Output tensor type missing layout attribute");
-  }
   if (inputTy.getShape() != outputTy.getShape()) {
     return emitOpError("Input and output shapes must be the same");
   }

--- a/lib/Dialect/TTIR/Transforms/Layout.cpp
+++ b/lib/Dialect/TTIR/Transforms/Layout.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Dialect/TT/IR/TT.h"
+#include "ttmlir/Dialect/TT/Utils/OperandConstraints.h"
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -14,90 +15,6 @@ namespace mlir::tt::ttir {
 #define GEN_PASS_DEF_TTIRLAYOUT
 #define GEN_PASS_DEF_TTIRSPLITCOMPOUNDLAYOUT
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h.inc"
-
-//===----------------------------------------------------------------------===//
-// Helper methods
-//===----------------------------------------------------------------------===//
-
-inline OperandConstraint
-memorySpaceAsOperandConstraint(MemorySpace memorySpace) {
-  switch (memorySpace) {
-  case MemorySpace::System:
-  case MemorySpace::SystemMMIO:
-    return OperandConstraint::System;
-  case MemorySpace::DeviceDRAM:
-    return OperandConstraint::DRAM;
-  case MemorySpace::DeviceL1:
-    return OperandConstraint::L1;
-  }
-}
-
-inline OperandConstraint
-memoryLayoutAsOperandConstraint(TensorMemoryLayout memoryLayout) {
-  switch (memoryLayout) {
-  case TensorMemoryLayout::None:
-    return OperandConstraint::None;
-  case TensorMemoryLayout::Interleaved:
-    return OperandConstraint::Interleaved;
-  case TensorMemoryLayout::SingleBank:
-    return OperandConstraint::SingleBank;
-  case TensorMemoryLayout::HeightSharded:
-    return OperandConstraint::HeightSharded;
-  case TensorMemoryLayout::WidthSharded:
-    return OperandConstraint::WidthSharded;
-  case TensorMemoryLayout::BlockSharded:
-    return OperandConstraint::BlockSharded;
-  }
-}
-
-inline MemorySpace getLegalMemorySpace(OperandConstraint operandConstraint,
-                                       MemorySpace defaultMemorySpace) {
-  if (bitEnumContainsAny(operandConstraint,
-                         memorySpaceAsOperandConstraint(defaultMemorySpace))) {
-    return defaultMemorySpace;
-  }
-  if (bitEnumContainsAny(operandConstraint, OperandConstraint::DRAM)) {
-    return MemorySpace::DeviceDRAM;
-  }
-  if (bitEnumContainsAny(operandConstraint, OperandConstraint::L1)) {
-    return MemorySpace::DeviceL1;
-  }
-  return MemorySpace::System;
-}
-
-inline TensorMemoryLayout
-getLegalTensorMemoryLayout(OperandConstraint operandConstraint,
-                           MemorySpace targetMemorySpace,
-                           TensorMemoryLayout defaultDeviceMemLayout) {
-  if (defaultDeviceMemLayout == TensorMemoryLayout::None) {
-    return TensorMemoryLayout::None;
-  }
-
-  if (isSystemMemorySpace(targetMemorySpace)) {
-    return TensorMemoryLayout::None;
-  }
-
-  assert(isDeviceMemorySpace(targetMemorySpace));
-  if (bitEnumContainsAny(operandConstraint, memoryLayoutAsOperandConstraint(
-                                                defaultDeviceMemLayout))) {
-    return defaultDeviceMemLayout;
-  }
-
-  std::map<OperandConstraint, TensorMemoryLayout> validLayoutsMap = {
-      {OperandConstraint::Interleaved, TensorMemoryLayout::Interleaved},
-      {OperandConstraint::SingleBank, TensorMemoryLayout::SingleBank},
-      {OperandConstraint::HeightSharded, TensorMemoryLayout::HeightSharded},
-      {OperandConstraint::WidthSharded, TensorMemoryLayout::WidthSharded},
-      {OperandConstraint::BlockSharded, TensorMemoryLayout::BlockSharded}};
-
-  for (const auto &[constraintLayout, memLayout] : validLayoutsMap) {
-    if (bitEnumContainsAny(operandConstraint, constraintLayout)) {
-      return memLayout;
-    }
-  }
-
-  return TensorMemoryLayout::None;
-}
 
 inline Location appendInputSuffix(Location loc, int64_t operandIndex) {
   if (isa<NameLoc>(loc)) {

--- a/lib/Dialect/TTNN/Analysis/DFShardingPolicy.cpp
+++ b/lib/Dialect/TTNN/Analysis/DFShardingPolicy.cpp
@@ -87,24 +87,23 @@ void DFShardingPolicy::run() {
             // currentOp output tensor shard spec, nextOp exec and nextOp output
             // tensor.
             //
-            tt::LayoutAttr currentOpLayout =
+            TensorConfigAttr currentOpLayout =
                 legalLayouts.lookup(currentOp).front();
             assert(currentOpLayout.hasShardedL1TensorMemoryLayout());
             llvm::ArrayRef<int64_t> currentOpOutputTensorShape =
                 mlir::cast<RankedTensorType>(currentOp->getResult(0).getType())
                     .getShape();
-            uint64_t currentOpL1OutputUsage = deviceAttr.getLayoutSizeBytes(
-                currentOpOutputTensorShape, currentOpLayout,
-                currentOpLayout.getMemorySpace());
+            uint64_t currentOpL1OutputUsage =
+                currentOpLayout.getTensorSizeInBytes(currentOpOutputTensorShape,
+                                                     deviceAttr);
 
-            tt::LayoutAttr nextOpLayout = legalLayouts.lookup(nextOp).front();
+            TensorConfigAttr nextOpLayout = legalLayouts.lookup(nextOp).front();
             assert(nextOpLayout.hasShardedL1TensorMemoryLayout());
             llvm::ArrayRef<int64_t> nextOpOutputTensorShape =
                 mlir::cast<RankedTensorType>(nextOp->getResult(0).getType())
                     .getShape();
-            uint64_t nextOpL1OutputUsage = deviceAttr.getLayoutSizeBytes(
-                nextOpOutputTensorShape, nextOpLayout,
-                nextOpLayout.getMemorySpace());
+            uint64_t nextOpL1OutputUsage = nextOpLayout.getTensorSizeInBytes(
+                nextOpOutputTensorShape, deviceAttr);
 
             // Figure out this const based on exec data, but will be replaced
             // with API.
@@ -133,23 +132,23 @@ void DFShardingPolicy::run() {
                                                      .getDefiningOp()
                                                      ->getResult(0)
                                                      .getType());
-                tt::LayoutAttr firstOpInputLayout = mlir::cast<tt::LayoutAttr>(
-                    firstOpInputTensorType.getEncoding());
+                TensorConfigAttr firstOpInputLayout =
+                    mlir::cast<TensorConfigAttr>(
+                        firstOpInputTensorType.getEncoding());
 
-                tt::LayoutAttr firstOpInputShardedLayout =
+                TensorConfigAttr firstOpInputShardedLayout =
                     firstOpInputLayout
-                        .withMemorySpace(currentOp->getContext(),
-                                         currentOpLayout.getMemorySpace())
+                        .withBufferType(currentOp->getContext(),
+                                        currentOpLayout.getBufferType())
                         .withMemoryLayout(currentOp->getContext(),
                                           currentOpLayout.getMemLayout())
                         .withGrid(currentOp->getContext(),
                                   firstOpInputTensorType,
                                   currentOpLayout.getGrid());
 
-                uint64_t firstInputL1Usage = deviceAttr.getLayoutSizeBytes(
-                    firstOpInputTensorType.getShape(),
-                    firstOpInputShardedLayout,
-                    firstOpInputShardedLayout.getMemorySpace());
+                uint64_t firstInputL1Usage =
+                    firstOpInputShardedLayout.getTensorSizeInBytes(
+                        firstOpInputTensorType.getShape(), deviceAttr);
 
                 firstInputL1UsageValid =
                     (firstInputL1Usage + currentOpL1OutputUsage) <
@@ -211,7 +210,7 @@ void DFShardingPolicy::pickOpShardLayouts(ShardSolver &shardSolver,
   for (const auto &shardSpec : l1ChainConfig.getOpL1MemSpecs()) {
     Operation *op = shardSpec.op;
     ShardSolver::RemainingLayoutAttrs validLayouts = shardSolver.at(op);
-    const tt::LayoutAttr *selectedLayout = validLayouts.begin().get();
+    const TensorConfigAttr *selectedLayout = validLayouts.begin().get();
     float maxCoreUsage = 0;
     for (auto layoutIterator = validLayouts.begin();
          layoutIterator != validLayouts.end(); ++layoutIterator) {

--- a/lib/Dialect/TTNN/Analysis/DFShardingPolicy.cpp
+++ b/lib/Dialect/TTNN/Analysis/DFShardingPolicy.cpp
@@ -87,7 +87,7 @@ void DFShardingPolicy::run() {
             // currentOp output tensor shard spec, nextOp exec and nextOp output
             // tensor.
             //
-            TensorConfigAttr currentOpLayout =
+            TTNNLayoutAttr currentOpLayout =
                 legalLayouts.lookup(currentOp).front();
             assert(currentOpLayout.hasShardedL1TensorMemoryLayout());
             llvm::ArrayRef<int64_t> currentOpOutputTensorShape =
@@ -97,7 +97,7 @@ void DFShardingPolicy::run() {
                 currentOpLayout.getTensorSizeInBytes(currentOpOutputTensorShape,
                                                      deviceAttr);
 
-            TensorConfigAttr nextOpLayout = legalLayouts.lookup(nextOp).front();
+            TTNNLayoutAttr nextOpLayout = legalLayouts.lookup(nextOp).front();
             assert(nextOpLayout.hasShardedL1TensorMemoryLayout());
             llvm::ArrayRef<int64_t> nextOpOutputTensorShape =
                 mlir::cast<RankedTensorType>(nextOp->getResult(0).getType())
@@ -132,11 +132,10 @@ void DFShardingPolicy::run() {
                                                      .getDefiningOp()
                                                      ->getResult(0)
                                                      .getType());
-                TensorConfigAttr firstOpInputLayout =
-                    mlir::cast<TensorConfigAttr>(
-                        firstOpInputTensorType.getEncoding());
+                TTNNLayoutAttr firstOpInputLayout = mlir::cast<TTNNLayoutAttr>(
+                    firstOpInputTensorType.getEncoding());
 
-                TensorConfigAttr firstOpInputShardedLayout =
+                TTNNLayoutAttr firstOpInputShardedLayout =
                     firstOpInputLayout
                         .withBufferType(currentOp->getContext(),
                                         currentOpLayout.getBufferType())
@@ -210,7 +209,7 @@ void DFShardingPolicy::pickOpShardLayouts(ShardSolver &shardSolver,
   for (const auto &shardSpec : l1ChainConfig.getOpL1MemSpecs()) {
     Operation *op = shardSpec.op;
     ShardSolver::RemainingLayoutAttrs validLayouts = shardSolver.at(op);
-    const TensorConfigAttr *selectedLayout = validLayouts.begin().get();
+    const TTNNLayoutAttr *selectedLayout = validLayouts.begin().get();
     float maxCoreUsage = 0;
     for (auto layoutIterator = validLayouts.begin();
          layoutIterator != validLayouts.end(); ++layoutIterator) {
@@ -221,7 +220,7 @@ void DFShardingPolicy::pickOpShardLayouts(ShardSolver &shardSolver,
         // If we have a tie, prefer layout that is not BlockSharded.
         //
         if (layoutIterator->getMemLayout() !=
-            tt::TensorMemoryLayout::BlockSharded) {
+            ttnn::TensorMemoryLayout::BlockSharded) {
           selectedLayout = layoutIterator.get();
         }
       }

--- a/lib/Dialect/TTNN/Analysis/L1ChainConfig.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1ChainConfig.cpp
@@ -19,7 +19,7 @@ void L1ChainConfig::resolve() {
 }
 
 ShardSolver L1ChainConfig::resolveWithSolver(
-    const llvm::DenseMap<Operation *, std::vector<tt::LayoutAttr>>
+    const llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>>
         &legalLayouts,
     unsigned usableL1CacheSize,
     const std::unordered_set<Edge> &overrideReshardEdges) {
@@ -36,7 +36,7 @@ ShardSolver L1ChainConfig::resolveWithSolver(
 }
 
 void L1ChainConfig::complete(
-    const llvm::DenseMap<Operation *, tt::LayoutAttr> &selectedOpLayout,
+    const llvm::DenseMap<Operation *, TensorConfigAttr> &selectedOpLayout,
     std::unordered_set<Edge> &memReconfigEdges) {
   assert(state == L1ChainState::Resolved);
   for (auto &opL1MemSpec : opL1MemSpecs) {

--- a/lib/Dialect/TTNN/Analysis/L1ChainConfig.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1ChainConfig.cpp
@@ -19,7 +19,7 @@ void L1ChainConfig::resolve() {
 }
 
 ShardSolver L1ChainConfig::resolveWithSolver(
-    const llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>>
+    const llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>>
         &legalLayouts,
     unsigned usableL1CacheSize,
     const std::unordered_set<Edge> &overrideReshardEdges) {
@@ -36,7 +36,7 @@ ShardSolver L1ChainConfig::resolveWithSolver(
 }
 
 void L1ChainConfig::complete(
-    const llvm::DenseMap<Operation *, TensorConfigAttr> &selectedOpLayout,
+    const llvm::DenseMap<Operation *, TTNNLayoutAttr> &selectedOpLayout,
     std::unordered_set<Edge> &memReconfigEdges) {
   assert(state == L1ChainState::Resolved);
   for (auto &opL1MemSpec : opL1MemSpecs) {

--- a/lib/Dialect/TTNN/Analysis/L1InterleavedPolicy.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1InterleavedPolicy.cpp
@@ -11,9 +11,9 @@ namespace mlir::tt::ttnn {
 
 uint64_t getOpOutputLayoutUsage(
     Operation *op,
-    llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>> &legalLayouts,
+    llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>> &legalLayouts,
     DeviceAttr &deviceAttr) {
-  TensorConfigAttr opLayout = legalLayouts.lookup(op).front();
+  TTNNLayoutAttr opLayout = legalLayouts.lookup(op).front();
   assert(opLayout.hasInterleavedL1TensorMemoryLayout());
 
   llvm::ArrayRef<int64_t> opOutputTensorShape =
@@ -29,7 +29,7 @@ void L1InterleavedPolicy::run() {
     DeviceAttr deviceAttr = getCurrentScopeDevice(func);
     mlir::tt::scheduler::Scheduler scheduler(&func);
     llvm::SmallVector<mlir::Operation *> scheduleableOps;
-    llvm::DenseMap<Operation *, TensorConfigAttr> selectedOpLayout;
+    llvm::DenseMap<Operation *, TTNNLayoutAttr> selectedOpLayout;
     Operation *currentOp = nullptr;
 
     // TODO(fbajraktari): Add algorithm description. Currently, the algorithm

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutAnalysis.cpp
@@ -16,12 +16,12 @@ bool MemoryLayoutAnalysis::applyOverrides() {
   return false;
 }
 
-llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>> filterShardedOnly(
-    const llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>>
-        &legalLayouts) {
-  llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>> shardedLayouts;
+llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>>
+filterShardedOnly(const llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>>
+                      &legalLayouts) {
+  llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>> shardedLayouts;
   for (const auto &opLayouts : legalLayouts) {
-    std::vector<TensorConfigAttr> opShardedLayouts;
+    std::vector<TTNNLayoutAttr> opShardedLayouts;
     for (const auto &layout : opLayouts.second) {
       if (layout.hasShardedL1TensorMemoryLayout()) {
         opShardedLayouts.push_back(layout);
@@ -34,14 +34,13 @@ llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>> filterShardedOnly(
   return shardedLayouts;
 }
 
-llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>>
+llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>>
 filterL1InterleavedOnly(
-    const llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>>
+    const llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>>
         &legalLayouts) {
-  llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>>
-      l1InterleavedLayouts;
+  llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>> l1InterleavedLayouts;
   for (const auto &opLayouts : legalLayouts) {
-    std::vector<TensorConfigAttr> opL1InterleavedLayouts;
+    std::vector<TTNNLayoutAttr> opL1InterleavedLayouts;
     for (const auto &layout : opLayouts.second) {
       if (layout.hasInterleavedL1TensorMemoryLayout()) {
         opL1InterleavedLayouts.push_back(layout);
@@ -86,7 +85,7 @@ void MemoryLayoutAnalysis::analysisImplementation() {
     assert(l1ChainConfig.getState() == L1ChainState::Completed);
     for (const auto &opL1MemSpec : l1ChainConfig.getOpL1MemSpecs()) {
       analysisResult.legalLayouts[opL1MemSpec.op] =
-          std::vector<TensorConfigAttr>{opL1MemSpec.layout};
+          std::vector<TTNNLayoutAttr>{opL1MemSpec.layout};
     }
 
     analysisResult.memReconfigEdges.insert(

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutAnalysis.cpp
@@ -16,12 +16,12 @@ bool MemoryLayoutAnalysis::applyOverrides() {
   return false;
 }
 
-llvm::DenseMap<Operation *, std::vector<tt::LayoutAttr>>
-filterShardedOnly(const llvm::DenseMap<Operation *, std::vector<tt::LayoutAttr>>
-                      &legalLayouts) {
-  llvm::DenseMap<Operation *, std::vector<tt::LayoutAttr>> shardedLayouts;
+llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>> filterShardedOnly(
+    const llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>>
+        &legalLayouts) {
+  llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>> shardedLayouts;
   for (const auto &opLayouts : legalLayouts) {
-    std::vector<tt::LayoutAttr> opShardedLayouts;
+    std::vector<TensorConfigAttr> opShardedLayouts;
     for (const auto &layout : opLayouts.second) {
       if (layout.hasShardedL1TensorMemoryLayout()) {
         opShardedLayouts.push_back(layout);
@@ -34,13 +34,14 @@ filterShardedOnly(const llvm::DenseMap<Operation *, std::vector<tt::LayoutAttr>>
   return shardedLayouts;
 }
 
-llvm::DenseMap<Operation *, std::vector<tt::LayoutAttr>>
+llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>>
 filterL1InterleavedOnly(
-    const llvm::DenseMap<Operation *, std::vector<tt::LayoutAttr>>
+    const llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>>
         &legalLayouts) {
-  llvm::DenseMap<Operation *, std::vector<tt::LayoutAttr>> l1InterleavedLayouts;
+  llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>>
+      l1InterleavedLayouts;
   for (const auto &opLayouts : legalLayouts) {
-    std::vector<tt::LayoutAttr> opL1InterleavedLayouts;
+    std::vector<TensorConfigAttr> opL1InterleavedLayouts;
     for (const auto &layout : opLayouts.second) {
       if (layout.hasInterleavedL1TensorMemoryLayout()) {
         opL1InterleavedLayouts.push_back(layout);
@@ -85,7 +86,7 @@ void MemoryLayoutAnalysis::analysisImplementation() {
     assert(l1ChainConfig.getState() == L1ChainState::Completed);
     for (const auto &opL1MemSpec : l1ChainConfig.getOpL1MemSpecs()) {
       analysisResult.legalLayouts[opL1MemSpec.op] =
-          std::vector<tt::LayoutAttr>{opL1MemSpec.layout};
+          std::vector<TensorConfigAttr>{opL1MemSpec.layout};
     }
 
     analysisResult.memReconfigEdges.insert(

--- a/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
+++ b/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
@@ -14,7 +14,7 @@ namespace mlir::tt::ttnn {
 ShardSolver::Bitset ShardSolver::kBitsetAll = ~kBitsetNone;
 
 ShardSolver::ShardSolver(
-    const llvm::DenseMap<Operation *, std::vector<tt::LayoutAttr>>
+    const llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>>
         &legalLayouts,
     const std::vector<OpL1MemSpec> &shardSpecs,
     const llvm::DenseSet<Operation *> &shardedOps,
@@ -73,7 +73,7 @@ bool ShardSolver::resolveStep() {
   for (const auto shardSpec : *shardSpecs) {
     Operation *consumerOp = shardSpec.op;
     Bitset *consumerBitset = getOrInsertBitset(consumerOp, kBitsetAll);
-    std::vector<tt::LayoutAttr> const &consumerLayouts =
+    std::vector<TensorConfigAttr> const &consumerLayouts =
         getLegalLayouts(consumerOp);
 
     for (Edge edge : operandOpEdges[consumerOp]) {
@@ -82,7 +82,7 @@ bool ShardSolver::resolveStep() {
 
       Operation *producerOp = edge.producerOp;
       Bitset *producerBitset = getOrInsertBitset(producerOp, kBitsetAll);
-      std::vector<tt::LayoutAttr> const &producerLayouts =
+      std::vector<TensorConfigAttr> const &producerLayouts =
           getLegalLayouts(producerOp);
 
       assert(not(consumerLayouts.empty() && producerLayouts.empty()));
@@ -97,7 +97,7 @@ bool ShardSolver::resolveStep() {
       for (std::uint64_t producerId = 0; producerId < producer_count;
            ++producerId) {
         // If the producer cannot accomodate this path, continue.
-        // Also if this is not the tt::LayoutAttr we selected, continue.
+        // Also if this is not the TensorConfigAttr we selected, continue.
         //
         if (!producerBitset->test(producerId)) {
           continue;
@@ -205,13 +205,14 @@ void ShardSolver::preprocessFirstOp() {
   }
 
   Bitset *firstOpBitset = getOrInsertBitset(firstOp, kBitsetAll);
-  std::vector<tt::LayoutAttr> const &firstOpLayouts = getLegalLayouts(firstOp);
+  std::vector<TensorConfigAttr> const &firstOpLayouts =
+      getLegalLayouts(firstOp);
   Operation *operandOp = firstOp->getOperand(0).getDefiningOp();
 
   RankedTensorType firstOpInputTensorType =
       mlir::cast<RankedTensorType>(operandOp->getResult(0).getType());
-  tt::LayoutAttr firstOpInputLayout =
-      mlir::cast<tt::LayoutAttr>(firstOpInputTensorType.getEncoding());
+  TensorConfigAttr firstOpInputLayout =
+      mlir::cast<TensorConfigAttr>(firstOpInputTensorType.getEncoding());
   constexpr float tensorL1UsageCap = 0.8;
 
   for (size_t i = 0; i < firstOpLayouts.size(); ++i) {
@@ -219,25 +220,24 @@ void ShardSolver::preprocessFirstOp() {
       continue;
     }
 
-    tt::LayoutAttr firstOpLayout = firstOpLayouts[i];
+    TensorConfigAttr firstOpLayout = firstOpLayouts[i];
     assert(firstOpLayout.hasShardedL1TensorMemoryLayout());
 
-    tt::LayoutAttr firstOpInputShardedLayout =
+    TensorConfigAttr firstOpInputShardedLayout =
         firstOpInputLayout
-            .withMemorySpace(firstOp->getContext(),
-                             firstOpLayout.getMemorySpace())
+            .withBufferType(firstOp->getContext(),
+                            firstOpLayout.getBufferType())
             .withMemoryLayout(firstOp->getContext(),
                               firstOpLayout.getMemLayout())
             .withGrid(firstOp->getContext(), firstOpInputTensorType,
                       firstOpLayout.getGrid());
 
-    uint64_t firstInputL1Usage = deviceAttr.getLayoutSizeBytes(
-        firstOpInputTensorType.getShape(), firstOpInputShardedLayout,
-        firstOpInputShardedLayout.getMemorySpace());
-    uint64_t firstOpL1OutputUsage = deviceAttr.getLayoutSizeBytes(
+    uint64_t firstInputL1Usage = firstOpInputShardedLayout.getTensorSizeInBytes(
+        firstOpInputTensorType.getShape(), deviceAttr);
+    uint64_t firstOpL1OutputUsage = firstOpLayout.getTensorSizeInBytes(
         mlir::cast<RankedTensorType>(firstOp->getResult(0).getType())
             .getShape(),
-        firstOpLayout, firstOpLayout.getMemorySpace());
+        deviceAttr);
 
     if ((firstInputL1Usage + firstOpL1OutputUsage) >=
         tensorL1UsageCap * usableL1CacheSize) {
@@ -457,9 +457,9 @@ ShardSolver::Bitset *ShardSolver::getOrInsertBitset(Operation *op,
 
 // Returns vector of legal LayoutAttrs for passed in op.
 //
-const std::vector<tt::LayoutAttr> &
+const std::vector<TensorConfigAttr> &
 ShardSolver::getLegalLayouts(Operation *op) const {
-  static std::vector<tt::LayoutAttr> nullLayouts;
+  static std::vector<TensorConfigAttr> nullLayouts;
 
   const auto legalIt = legalLayouts->find(op);
 
@@ -476,7 +476,7 @@ ShardSolver::RemainingLayoutAttrs ShardSolver::at(Operation *op) const {
   return layouts;
 }
 
-void ShardSolver::set(Operation *op, tt::LayoutAttr const &layout) {
+void ShardSolver::set(Operation *op, TensorConfigAttr const &layout) {
   assert(selectedOpLayout.count(op) == 0);
 
   selectedOpLayout[op] = layout;
@@ -503,8 +503,8 @@ void ShardSolver::set(Operation *op, tt::LayoutAttr const &layout) {
 }
 
 bool ShardSolver::checkShardCompatible(
-    Operation *producerOp, tt::LayoutAttr const &producerLayout,
-    Operation *consumerOp, tt::LayoutAttr const &consumerLayout) const {
+    Operation *producerOp, TensorConfigAttr const &producerLayout,
+    Operation *consumerOp, TensorConfigAttr const &consumerLayout) const {
 
   // TEMP : Dummy mock implementation, will be replaced.
   //

--- a/lib/Dialect/TTNN/IR/CMakeLists.txt
+++ b/lib/Dialect/TTNN/IR/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_mlir_dialect_library(MLIRTTNNDialect
+        TTNNOpsAttrs.cpp
         TTNNDialect.cpp
         TTNNOps.cpp
         TTNNOpModelInterface.cpp

--- a/lib/Dialect/TTNN/IR/TTNNDialect.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNDialect.cpp
@@ -32,7 +32,7 @@ struct TTNNOpAsmDialectInterface : public OpAsmDialectInterface {
   using OpAsmDialectInterface::OpAsmDialectInterface;
 
   AliasResult getAlias(Attribute attr, raw_ostream &os) const override {
-    if (llvm::isa<TensorConfigAttr>(attr)) {
+    if (llvm::isa<TTNNLayoutAttr>(attr)) {
       os << "tensor_config";
       return AliasResult::OverridableAlias;
     }

--- a/lib/Dialect/TTNN/IR/TTNNDialect.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNDialect.cpp
@@ -28,6 +28,23 @@ parseDimensionList(::mlir::AsmParser &odsParser,
 }
 } // namespace mlir::tt::ttnn
 
+struct TTNNOpAsmDialectInterface : public OpAsmDialectInterface {
+  using OpAsmDialectInterface::OpAsmDialectInterface;
+
+  AliasResult getAlias(Attribute attr, raw_ostream &os) const override {
+    if (llvm::isa<TensorConfigAttr>(attr)) {
+      os << "tensor_config";
+      return AliasResult::OverridableAlias;
+    }
+    if (llvm::isa<BufferTypeAttr>(attr)) {
+      os << mlir::cast<BufferTypeAttr>(attr).getValue();
+      return AliasResult::OverridableAlias;
+    }
+
+    return AliasResult::NoAlias;
+  }
+};
+
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsDialect.cpp.inc"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsEnums.cpp.inc"
 
@@ -49,4 +66,5 @@ void TTNNDialect::initialize() {
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrDefs.cpp.inc"
       >();
   registerTypes();
+  addInterfaces<TTNNOpAsmDialectInterface>();
 }

--- a/lib/Dialect/TTNN/IR/TTNNDialect.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNDialect.cpp
@@ -33,7 +33,7 @@ struct TTNNOpAsmDialectInterface : public OpAsmDialectInterface {
 
   AliasResult getAlias(Attribute attr, raw_ostream &os) const override {
     if (llvm::isa<TTNNLayoutAttr>(attr)) {
-      os << "tensor_config";
+      os << "ttnn_layout";
       return AliasResult::OverridableAlias;
     }
     if (llvm::isa<BufferTypeAttr>(attr)) {

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -13,20 +13,20 @@ namespace mlir::tt::ttnn {
 // ReluOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-size_t ReluOp::getOpPerfCycles(const std::vector<tt::LayoutAttr> &input_layouts,
+size_t ReluOp::getOpPerfCycles(const std::vector<TensorConfigAttr> &input_layouts,
                                const tt::LayoutAttr &output_layout) {
   // TODO(mbezulj) wire to tt-metal once we have API
   return 5;
 }
 
 std::tuple<size_t, size_t, size_t>
-ReluOp::getOpL1Usage(const std::vector<tt::LayoutAttr> &input_layouts,
+ReluOp::getOpL1Usage(const std::vector<TensorConfigAttr> &input_layouts,
                      const tt::LayoutAttr &output_layout) {
   // TODO(mbezulj) wire to tt-metal once we have API
   return std::make_tuple(1024, 2048, 1024);
 }
 
-bool ReluOp::isOpLegal(const std::vector<tt::LayoutAttr> &input_layouts,
+bool ReluOp::isOpLegal(const std::vector<TensorConfigAttr> &input_layouts,
                        const tt::LayoutAttr &output_layout) {
   // TODO(mbezulj) wire to tt-metal once we have API
   return true;

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -13,21 +13,21 @@ namespace mlir::tt::ttnn {
 // ReluOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-size_t ReluOp::getOpPerfCycles(const std::vector<TensorConfigAttr> &input_layouts,
-                               const tt::LayoutAttr &output_layout) {
+size_t ReluOp::getOpPerfCycles(const std::vector<TTNNLayoutAttr> &input_layouts,
+                               const TTNNLayoutAttr &output_layout) {
   // TODO(mbezulj) wire to tt-metal once we have API
   return 5;
 }
 
 std::tuple<size_t, size_t, size_t>
-ReluOp::getOpL1Usage(const std::vector<TensorConfigAttr> &input_layouts,
-                     const tt::LayoutAttr &output_layout) {
+ReluOp::getOpL1Usage(const std::vector<TTNNLayoutAttr> &input_layouts,
+                     const TTNNLayoutAttr &output_layout) {
   // TODO(mbezulj) wire to tt-metal once we have API
   return std::make_tuple(1024, 2048, 1024);
 }
 
-bool ReluOp::isOpLegal(const std::vector<TensorConfigAttr> &input_layouts,
-                       const tt::LayoutAttr &output_layout) {
+bool ReluOp::isOpLegal(const std::vector<TTNNLayoutAttr> &input_layouts,
+                       const TTNNLayoutAttr &output_layout) {
   // TODO(mbezulj) wire to tt-metal once we have API
   return true;
 }

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -155,9 +155,9 @@ namespace mlir::tt::ttnn {
   assert(::llvm::isa<RankedTensorType>(getResult().getType()));
   RankedTensorType output = mlir::cast<RankedTensorType>(getResult().getType());
 
-  assert(::llvm::isa<tt::LayoutAttr>(output.getEncoding()));
-  tt::LayoutAttr ttLayoutAttr =
-      mlir::cast<tt::LayoutAttr>(output.getEncoding());
+  assert(::llvm::isa<TensorConfigAttr>(output.getEncoding()));
+  TensorConfigAttr layoutAttr =
+      mlir::cast<TensorConfigAttr>(output.getEncoding());
 
   // Shape
   //
@@ -165,7 +165,7 @@ namespace mlir::tt::ttnn {
 
   // DataType and Layout
   //
-  mlir::MemRefType memref = ttLayoutAttr.getMemref();
+  mlir::MemRefType memref = layoutAttr.getMemref();
   Type elementType = memref.getElementType();
   if (getLayout().has_value()) {
     ttnn::Layout ttnnLayoutEnum;
@@ -192,11 +192,8 @@ namespace mlir::tt::ttnn {
   // attrs with output tensor attrs.
   //
   if (getMemoryConfig().has_value()) {
-    ttnn::BufferType bufferType =
-        mlir::tt::ttnn::utils::toTTNNBufferType(ttLayoutAttr.getMemorySpace());
-    ttnn::TensorMemoryLayout tensorMemoryLayout =
-        mlir::tt::ttnn::utils::toTTNNTensorMemoryLayout(
-            ttLayoutAttr.getMemLayout());
+    ttnn::BufferType bufferType = layoutAttr.getBufferType();
+    ttnn::TensorMemoryLayout tensorMemoryLayout = layoutAttr.getMemLayout();
     assert(bufferType == getMemoryConfig()->getBufferType().getValue());
     assert(tensorMemoryLayout ==
            getMemoryConfig()->getTensorMemoryLayout().getValue());
@@ -538,9 +535,9 @@ namespace mlir::tt::ttnn {
 //===----------------------------------------------------------------------===//
 
 // Utility methods
-static bool isValidDeviceLayout(::mlir::tt::TensorMemoryLayout layout) {
-  return layout == ::mlir::tt::TensorMemoryLayout::Interleaved ||
-         ::mlir::tt::isShardedMemoryLayout(layout);
+static bool isValidDeviceLayout(TensorMemoryLayout layout) {
+  return layout == TensorMemoryLayout::Interleaved ||
+         isShardedMemoryLayout(layout);
 }
 
 // ToMemoryConfigOp verification
@@ -548,31 +545,30 @@ static bool isValidDeviceLayout(::mlir::tt::TensorMemoryLayout layout) {
   ::mlir::RankedTensorType inputTy = getInput().getType();
   ::mlir::RankedTensorType outputTy = getResult().getType();
   auto inputLayout =
-      mlir::dyn_cast_or_null<mlir::tt::LayoutAttr>(inputTy.getEncoding());
+      mlir::dyn_cast_or_null<TensorConfigAttr>(inputTy.getEncoding());
   auto outputLayout =
-      mlir::dyn_cast_or_null<mlir::tt::LayoutAttr>(outputTy.getEncoding());
+      mlir::dyn_cast_or_null<TensorConfigAttr>(outputTy.getEncoding());
   if (not inputLayout) {
     return emitOpError("Input tensor type missing layout attribute");
   }
   if (not outputLayout) {
     return emitOpError("Output tensor type missing layout attribute");
   }
-  ::mlir::tt::MemorySpace outputMemorySpace = outputLayout.getMemorySpace();
-  ::mlir::tt::TensorMemoryLayout outputMemoryLayout =
-      outputLayout.getMemLayout();
-  if (::mlir::tt::isSystemMemorySpace(outputMemorySpace) &&
-      outputMemoryLayout != ::mlir::tt::TensorMemoryLayout::None) {
+  BufferType outputBufferType = outputLayout.getBufferType();
+  TensorMemoryLayout outputMemoryLayout = outputLayout.getMemLayout();
+  if (isSystemBufferType(outputBufferType) &&
+      outputMemoryLayout != TensorMemoryLayout::None) {
     return emitOpError("System memory space only supports undef memory layout");
   }
 
-  if (::mlir::tt::isDeviceMemorySpace(outputMemorySpace) &&
+  if (isDeviceBufferType(outputBufferType) &&
       !isValidDeviceLayout(outputMemoryLayout)) {
     return emitOpError("Device memory space only supports interleaved or "
                        "sharded memory layouts");
   }
 
-  if (outputMemorySpace == ::mlir::tt::MemorySpace::DeviceDRAM &&
-      outputMemoryLayout != ::mlir::tt::TensorMemoryLayout::Interleaved) {
+  if (outputBufferType == BufferType::DRAM &&
+      outputMemoryLayout != TensorMemoryLayout::Interleaved) {
     return emitOpError(
         "Device DRAM memory space only supports interleaved memory layout");
   }
@@ -586,7 +582,7 @@ static bool isValidDeviceLayout(::mlir::tt::TensorMemoryLayout layout) {
     if (shardShape.size() != 2) {
       return emitOpError("Shard shape must be 2D");
     }
-    if (outputMemoryLayout == ::mlir::tt::TensorMemoryLayout::BlockSharded) {
+    if (outputMemoryLayout == TensorMemoryLayout::BlockSharded) {
       // TTNN tiles are (32, 32), shard shape must evenly divide the tile shape
       if (shardShape[0] % TILE_HEIGHT != 0 or shardShape[1] % TILE_WIDTH != 0) {
         return emitOpError(
@@ -735,7 +731,7 @@ static bool isValidDeviceLayout(::mlir::tt::TensorMemoryLayout layout) {
 
 // AllocOp verification
 ::mlir::LogicalResult AllocOp::verify() {
-  auto layout = mlir::dyn_cast_or_null<mlir::tt::LayoutAttr>(
+  auto layout = mlir::dyn_cast_or_null<TensorConfigAttr>(
       getResult().getType().getEncoding());
   if (not layout) {
     return emitOpError("Result type missing layout attribute");
@@ -745,20 +741,18 @@ static bool isValidDeviceLayout(::mlir::tt::TensorMemoryLayout layout) {
     return emitOpError("Alloc size must be non-zero");
   }
 
-  auto memref = layout.getMemref();
-  auto memspace =
-      mlir::cast<mlir::tt::MemorySpaceAttr>(memref.getMemorySpace()).getValue();
-  if (memspace != getMemorySpace()) {
+  auto bufferType = layout.getBufferType();
+  if (bufferType != getBufferType()) {
     return emitOpError(
         "Input tensor layout memory space must match alloc memory space");
   }
 
-  if (isSystemMemorySpace(getMemorySpace()) and getAddress() != 0) {
+  if (isSystemBufferType(getBufferType()) and getAddress() != 0) {
     return emitOpError("Allocating from system memory space must have address "
                        "set to 0, implicitly allocated by the runtime");
   }
 
-  if (isDeviceMemorySpace(memspace) and getAddress() == 0) {
+  if (isDeviceBufferType(bufferType) and getAddress() == 0) {
     return emitOpError(
         "Allocating from a device memory space must have address "
         "set to a non-zero value, device addresses are statically allocated");

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -155,9 +155,8 @@ namespace mlir::tt::ttnn {
   assert(::llvm::isa<RankedTensorType>(getResult().getType()));
   RankedTensorType output = mlir::cast<RankedTensorType>(getResult().getType());
 
-  assert(::llvm::isa<TensorConfigAttr>(output.getEncoding()));
-  TensorConfigAttr layoutAttr =
-      mlir::cast<TensorConfigAttr>(output.getEncoding());
+  assert(::llvm::isa<TTNNLayoutAttr>(output.getEncoding()));
+  TTNNLayoutAttr layoutAttr = mlir::cast<TTNNLayoutAttr>(output.getEncoding());
 
   // Shape
   //
@@ -545,9 +544,9 @@ static bool isValidDeviceLayout(TensorMemoryLayout layout) {
   ::mlir::RankedTensorType inputTy = getInput().getType();
   ::mlir::RankedTensorType outputTy = getResult().getType();
   auto inputLayout =
-      mlir::dyn_cast_or_null<TensorConfigAttr>(inputTy.getEncoding());
+      mlir::dyn_cast_or_null<TTNNLayoutAttr>(inputTy.getEncoding());
   auto outputLayout =
-      mlir::dyn_cast_or_null<TensorConfigAttr>(outputTy.getEncoding());
+      mlir::dyn_cast_or_null<TTNNLayoutAttr>(outputTy.getEncoding());
   if (not inputLayout) {
     return emitOpError("Input tensor type missing layout attribute");
   }
@@ -731,7 +730,7 @@ static bool isValidDeviceLayout(TensorMemoryLayout layout) {
 
 // AllocOp verification
 ::mlir::LogicalResult AllocOp::verify() {
-  auto layout = mlir::dyn_cast_or_null<TensorConfigAttr>(
+  auto layout = mlir::dyn_cast_or_null<TTNNLayoutAttr>(
       getResult().getType().getEncoding());
   if (not layout) {
     return emitOpError("Result type missing layout attribute");

--- a/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp
@@ -1,0 +1,421 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <numeric>
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+#include "ttmlir/Utils.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace mlir::tt::ttnn;
+
+// Check if tensor is on host
+inline bool isSystemBufferType(BufferType bufferType) {
+  return bufferType == BufferType::SystemMemory;
+}
+
+// Check if the tensor is on device
+inline bool isDeviceBufferType(BufferType bufferType) {
+  return bufferType == BufferType::DRAM || bufferType == BufferType::L1;
+}
+
+// Check if tensor is in L1 memory
+inline bool isL1BufferType(BufferType bufferType) {
+  return bufferType == BufferType::L1;
+}
+
+// Check if the tensor is tiled
+bool TensorConfigAttr::isTiled() const {
+  return ::mlir::isa<::mlir::tt::TileType>(getElementType());
+}
+
+// Check if the tensor memory layout is sharded
+bool TensorConfigAttr::hasShardedTensorMemoryLayout() const {
+  return (getMemLayout() == TensorMemoryLayout::HeightSharded ||
+          getMemLayout() == TensorMemoryLayout::WidthSharded ||
+          getMemLayout() == TensorMemoryLayout::BlockSharded);
+}
+
+// Check if the tensor memory layout is sharded in L1 memory
+bool TensorConfigAttr::hasShardedL1TensorMemoryLayout() const {
+  return isL1BufferType(getBufferType()) &&
+         (getMemLayout() == TensorMemoryLayout::HeightSharded ||
+          getMemLayout() == TensorMemoryLayout::WidthSharded ||
+          getMemLayout() == TensorMemoryLayout::BlockSharded);
+}
+
+// Check if the tensor memory layout is interleaved and in L1 memory
+bool TensorConfigAttr::hasInterleavedL1TensorMemoryLayout() const {
+  return isL1BufferType(getBufferType()) &&
+         (getMemLayout() == TensorMemoryLayout::Interleaved);
+}
+
+// Get stride given tensor logical shape
+llvm::SmallVector<int64_t>
+TensorConfigAttr::getStride(ArrayRef<int64_t> logicalShape) const {
+
+  llvm::SmallVector<int64_t> stride(logicalShape.size());
+  AffineMap linearMap = getLinear();
+
+  // Calculate the physical shape of the tensor.
+  // Given tensor (6x15x10) and linear (d0, d1, d2) -> (d0 * 15 + d1, d2)
+  // The physical shape is (90, 10)
+  auto physicalShape = ttmlir::utils::evalShape(linearMap, logicalShape);
+
+  // Origin point in the logical space (0, 0)
+  SmallVector<AffineExpr> originPoint(logicalShape.size(),
+                                      getAffineConstantExpr(0, getContext()));
+
+  size_t prevDimElems = 1;
+
+  // Iterates through physical dimensions (starting from the inner one).
+  for (int i = linearMap.getNumResults() - 1; i >= 0; i--) {
+    AffineExpr expr = linearMap.getResult(i);
+
+    // Get coordinate of the i-th dimension (in physical space) of the origin
+    // (in logical space).
+    AffineExpr constantExpr = expr.replaceDims(originPoint);
+    std::int64_t valueAtZero =
+        llvm::cast<AffineConstantExpr>(constantExpr).getValue();
+
+    for (size_t j = 0; j < logicalShape.size(); j++) {
+      if (!expr.isFunctionOfDim(j)) {
+        continue;
+      }
+
+      // Move from the origin point by one in the j-th dimension,
+      // and get the coordinate of the i-th dimension (in physical space).
+      auto newPoint = originPoint;
+      newPoint[j] = getAffineConstantExpr(1, getContext());
+      constantExpr = expr.replaceDims(newPoint);
+      std::int64_t valueAtOne =
+          llvm::cast<AffineConstantExpr>(constantExpr).getValue();
+
+      // One step in the j-th dimension, jumps delta * prevDimElems elements in
+      // the physical space.
+      int64_t delta = valueAtOne - valueAtZero;
+      stride[j] = prevDimElems * delta;
+    }
+
+    prevDimElems *= physicalShape[i];
+  }
+
+  return stride;
+}
+
+// Get the buffer type (DRAM/L1/SystemMemory)
+BufferType TensorConfigAttr::getBufferType() const {
+  return mlir::cast<BufferTypeAttr>(getMemref().getMemorySpace()).getValue();
+}
+
+// Get element type i.e FloatType/IntegerType/TileType
+mlir::Type TensorConfigAttr::getElementType() const {
+  return getMemref().getElementType();
+}
+
+// Extract data type from the memref. Example:
+// memref<2x2xf32> -> f32
+// memref<2x2x!tt.tile<32x32xf32>> -> f32
+mlir::tt::DataType TensorConfigAttr::getDataTypeFromMemRef() const {
+  Type elementType = getElementType();
+  DataType dtype = DataType::Float32;
+  if (llvm::isa<TileType>(elementType)) {
+    auto tileType = mlir::cast<TileType>(elementType);
+    dtype = tileType.getDataType();
+  } else {
+    dtype = elementTypeToDataType(elementType);
+  }
+  return dtype;
+}
+
+// Gets the size of shard in bytes
+//
+// This function returns the size of the shard in bytes.
+// Size is calculated by multiplying shard shape with element size.
+//
+// /return The size of the shard in bytes.
+uint64_t TensorConfigAttr::getElementSizeBytes() const {
+  mlir::Type elementType = getElementType();
+  if (mlir::isa<TileType>(elementType)) {
+    auto tileType = mlir::cast<TileType>(elementType);
+    return tileType.getSizeBytes();
+  }
+  return elementType.getIntOrFloatBitWidth() / 8;
+}
+
+// Get shard shape
+//
+// This function returns the shape of the shard. If element type is TileType
+// and convertTileToScalar is true, then the shape is converted to scalar shape.
+// Example: (convertToScalar = true) memref<2x2x!tt.tile<32x32xf32>> -> {64, 64}
+// Example: (convertToScalar = false) memref<2x2x!tt.tile<32x32xf32>> -> {2, 2}
+// Example: memref<128x128xf32> -> {128, 128}
+//
+// /param convertTileToScalar If true, convert tile shape to scalar shape.
+// /return The shape of the shard.
+llvm::SmallVector<int64_t>
+TensorConfigAttr::getShardShape(bool convertTileToScalar) const {
+  SmallVector<int64_t> shardShape(getMemref().getShape());
+  auto elementType = getElementType();
+  if (mlir::isa<TileType>(elementType) && convertTileToScalar) {
+    return mlir::cast<TileType>(elementType).getScalarShape(shardShape);
+  }
+  return shardShape;
+}
+
+// Get size of tensor in tiles
+//
+// This function returns the size of the tensor in tiles.
+// Size is calculate by pluging the tensor shape into the linear map.
+// This result is then divided by the tile shape.
+// Example: tensor shape (6x15x10), linear map (d0, d1, d2) -> (d0 * 15 + d1,
+// d2) and tile shape (32, 32) The result is (90, 10) which is then divided by
+// tile shape (32, 32) -> (3, 1)
+//
+// /param tensorShape The shape of the tensor
+// /return The size of the tensor in tiles.
+llvm::SmallVector<int64_t>
+TensorConfigAttr::getTiledShape(llvm::ArrayRef<int64_t> tensorShape) const {
+  assert(isTiled() && "Expected a tiled layout");
+
+  // Affine map in form of (d0, d1, d2) -> (d0 * 15 + d1, d2)
+  mlir::AffineMap linear = getLinear();
+  uint32_t rank = linear.getNumResults();
+  assert(rank >= 2 && "Expected at least two results in linear map");
+  mlir::AffineExpr y = linear.getResult(rank - 2);
+  mlir::AffineExpr x = linear.getResult(rank - 1);
+
+  TileType tileType = mlir::cast<TileType>(getElementType());
+  int64_t tileH = tileType.getHeight();
+  int64_t tileW = tileType.getWidth();
+
+  // Construct new affine map with where x and y are divided by tile width and
+  // height respectively. Example:
+  // (d0, d1, d2) -> (d0 * 15 + d1) / 32, d2 / 32
+  // Note: even though we floorDiv the result, eval will return ceiled...
+  mlir::AffineMap tiled =
+      linear.replace(mlir::DenseMap<mlir::AffineExpr, mlir::AffineExpr>{
+          {y, y.floorDiv(tileH)}, {x, x.floorDiv(tileW)}});
+
+  // Get tiled shape by evaluating the affine map with tensor shape.
+  return ttmlir::utils::evalShape(tiled, tensorShape);
+}
+
+// Get the size of shard in bytes
+//
+// This function returns the size of the shard in bytes.
+// Size is calculated by multiplying shard shape with element size.
+// Element size for TileType is tile width * tile height * sizeof(element).
+// For scalar types, element size is sizeof(element).
+//
+// /return The size of the shard in bytes.
+uint64_t TensorConfigAttr::getShardSizeInBytes() const {
+  MemRefType ty = getMemref();
+  auto shape = ty.getShape();
+  uint64_t size = getElementSizeBytes();
+  return std::accumulate(shape.begin(), shape.end(), size,
+                         std::multiplies<uint64_t>());
+}
+
+// Get new identity affine map i.e (d0, d1) -> (d0, d1)
+//
+// This function returns a new identity affine map
+// with the same number of dimensions as the linear map.
+//
+// /return The new identity affine map.
+mlir::AffineMap TensorConfigAttr::getIdentityTileLinearMap() const {
+  assert(isTiled() && "Expected a tiled layout");
+
+  return mlir::AffineMap::getMultiDimIdentityMap(getLinear().getNumResults(),
+                                                 getContext());
+}
+
+// Takes phyisical memory map and replaces the symbols with the shard shape
+//
+// This function takes a physical memory map and replaces the symbols with the
+// shard shape
+//
+// /param physicalMemoryMap The physical memory map (d0, d1)[s0, s1]
+// /return New memory map with symbols replaced with shard shape.
+mlir::AffineMap TensorConfigAttr::replaceMemoryMapSymbolsWithShardShape(
+    AffineMap physicalMemoryMap) const {
+  mlir::SmallVector<int64_t> shardShape =
+      getShardShape(false /*convertTileToScalar*/);
+  assert(physicalMemoryMap.getNumSymbols() == shardShape.size() &&
+         "Physical memory map must have same number of symbols as logical "
+         "shard rank");
+
+  SmallVector<AffineExpr> symReplacements;
+  for (unsigned i = 0; i < physicalMemoryMap.getNumSymbols(); ++i) {
+    symReplacements.push_back(
+        getAffineConstantExpr(shardShape[i], getContext()));
+  }
+
+  SmallVector<AffineExpr> dimReplacements;
+  for (unsigned i = 0; i < physicalMemoryMap.getNumDims(); ++i) {
+    dimReplacements.push_back(getAffineDimExpr(i, getContext()));
+  }
+
+  return physicalMemoryMap.replaceDimsAndSymbols(
+      dimReplacements, symReplacements, physicalMemoryMap.getNumDims(), 0);
+}
+
+// TODO (milant) figure out what is going on here...
+int64_t TensorConfigAttr::getTensorSizeInBytes(ArrayRef<int64_t> tensorShape,
+                                               DeviceAttr device) const {
+  SmallVector<int64_t> shape = isTiled() ? getTiledShape(tensorShape)
+                                         : SmallVector<int64_t>(tensorShape);
+  MemorySpace memorySpace = utils::toTTMemorySpace(getBufferType());
+  AffineMap linearMap = isTiled() ? getIdentityTileLinearMap() : getLinear();
+  mlir::SmallVector<std::int64_t> linearShape =
+      ttmlir::utils::evalShape(linearMap, shape);
+  AffineMap memoryMap = replaceMemoryMapSymbolsWithShardShape(
+      device.getMapForMemorySpace(memorySpace));
+  mlir::SmallVector<std::int64_t> physicalMemory =
+      ttmlir::utils::evalShape(memoryMap, linearShape);
+  std::int64_t elementSize = getElementSizeBytes();
+  uint64_t sizeBytes =
+      physicalMemory[MemoryMapResultIdx::ShardOffset] * elementSize;
+  return sizeBytes;
+}
+
+// Construct a new TensorConfigAttr
+//
+// This function creates a new TensorConfigAttr with the given parameters.
+// The element type, buffer type and memory layout are preserved.
+//
+// /param context The MLIR context.
+// /param tensorShape The shape of the tensor (i.e 6x10x10)
+// /param grid The grid where the tensor will be placed (i.e 2x3)
+// /param collapseIntervals The intervals to collapse (i.e. {{0, -1}})
+// /return The constructed TensorConfigAttr
+TensorConfigAttr TensorConfigAttr::withGrid(
+    ::mlir::MLIRContext *context, ArrayRef<int64_t> tensorShape, GridAttr grid,
+    ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals) {
+  return get(context, tensorShape, getElementType(), getBufferType(), grid,
+             getMemLayout(), collapseIntervals);
+}
+
+// Construct a new TensorConfigAttr
+//
+// This function creates a new TensorConfigAttr with the given parameters.
+// The shape of the tensor, buffer type, element type and memory layout are
+// preserved.
+//
+// /param context The MLIR context.
+// /param grid The grid where the tensor will be placed.
+// /param collapseIntervals The intervals to collapse (i.e. {{0, -1}})
+// /return The constructed TensorConfigAttr
+TensorConfigAttr TensorConfigAttr::withGrid(
+    ::mlir::MLIRContext *context, RankedTensorType ty, GridAttr grid,
+    ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals) {
+  assert(ty);
+  return TensorConfigAttr::withGrid(context, ty.getShape(), grid,
+                                    collapseIntervals);
+}
+
+// Construct a new TensorConfigAttr
+//
+// This function creates a deep copy of the current TensorConfigAttr and
+// replaces the element type with the given one.
+//
+// /param context The MLIR context.
+// /param elementType The new element type.
+// /return The new TensorConfigAttr with the given element type.
+TensorConfigAttr TensorConfigAttr::withElementType(::mlir::MLIRContext *context,
+                                                   Type elementType) {
+  return TensorConfigAttr::get(
+      context, getLinear(), getGrid(),
+      buildMemRef<BufferType, BufferTypeAttr>(context, getShardShape(),
+                                              elementType, getBufferType()),
+      getMemLayout());
+}
+
+// Construct a new TensorConfigAttr
+//
+// This function creates a deep copy of the current TensorConfigAttr and
+// replaces the memory space with the given one.
+//
+// /param context The MLIR context.
+// /param memorySpace The new memory space.
+// /return The new TensorConfigAttr with the given memory space.
+TensorConfigAttr TensorConfigAttr::withBufferType(::mlir::MLIRContext *context,
+                                                  BufferType memorySpace) {
+  return TensorConfigAttr::get(
+      context, getLinear(), getGrid(),
+      buildMemRef<BufferType, BufferTypeAttr>(context, getShardShape(),
+                                              getElementType(), memorySpace),
+      getMemLayout());
+}
+
+// Construct a new TensorConfigAttr
+//
+// This function creates a deep copy of the current TensorConfigAttr and
+// replaces the memory layout with the given one.
+//
+// /param context The MLIR context.
+// /param memLayout The new memory layout.
+// /return The new TensorConfigAttr with the given memory layout.
+TensorConfigAttr
+TensorConfigAttr::withMemoryLayout(::mlir::MLIRContext *context,
+                                   TensorMemoryLayout memLayout) {
+  return TensorConfigAttr::get(
+      context, getLinear(), getGrid(),
+      buildMemRef<BufferType, BufferTypeAttr>(
+          context, getShardShape(), getElementType(), getBufferType()),
+      memLayout);
+}
+
+// Construct a new TensorConfigAttr
+//
+// This function creates a deep copy of the current TensorConfigAttr and
+// replaces shard shape with the given one.
+//
+// /param context The MLIR context.
+// /param shardShape The new shard shape.
+// /return The new TensorConfigAttr with the given shard shape.
+TensorConfigAttr
+TensorConfigAttr::withShardShape(::mlir::MLIRContext *context,
+                                 llvm::SmallVector<int64_t> shardShape) {
+  return TensorConfigAttr::get(
+      context, getLinear(), getGrid(),
+      buildMemRef<BufferType, BufferTypeAttr>(
+          context, shardShape, getElementType(), getBufferType()),
+      getMemLayout());
+}
+
+// Construct a new TensorConfigAttr
+//
+// This function constructs a new TensorConfigAttr with the given parameters.
+//
+// /param context The MLIR context.
+// /param tensorShape The shape of the tensor (i.e 6x10x10)
+// /param elementType The type of the element i.e TileType/FloatType/IntegerType
+// /param bufferType The type of the buffer
+// /param grid The grid where the tensor will be placed (i.e 2x3)
+// /param collapseIntervals The intervals to collapse (i.e. {{0, -1}})
+// /param memLayout The memory layout of the tensor
+// /return The constructed TensorConfigAttr
+TensorConfigAttr TensorConfigAttr::get(
+    ::mlir::MLIRContext *context, ArrayRef<int64_t> tensorShape,
+    Type elementType, BufferType bufferType, GridAttr grid,
+    TensorMemoryLayout memLayout,
+    ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals) {
+  // Construct a new affine map which will be used to map from logical
+  // space to physical space
+  AffineMap linear = collapsedLinearAffineMap(
+      context, tensorShape, grid.getShape(), collapseIntervals);
+  // Calculate shard shape by evaluating the linear map with last element
+  // of the tensor shape and dividing it by the grid shape
+  mlir::SmallVector<int64_t, 4> shardShape =
+      calculateLogicalShardShape(tensorShape, linear, grid);
+  // Build memref type with the given parameters
+  MemRefType memRefType = buildMemRef<BufferType, BufferTypeAttr>(
+      context, shardShape, elementType, bufferType);
+  return get(context, linear, grid, memRefType, memLayout);
+}

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -33,12 +33,6 @@ void createTTNNPipelineTTIRPasses(
   implicitDeviceOptions.meshShape = ::llvm::SmallVector<int64_t>(
       options.meshShape.begin(), options.meshShape.end());
   pm.addPass(mlir::tt::ttir::createTTIRImplicitDevice(implicitDeviceOptions));
-  mlir::tt::ttir::TTIRLayoutOptions layoutOptions;
-  layoutOptions.initMemorySpace = mlir::tt::MemorySpace::System;
-  layoutOptions.defaultMemorySpace = mlir::tt::MemorySpace::DeviceDRAM;
-  layoutOptions.defaultDeviceMemoryLayout =
-      mlir::tt::TensorMemoryLayout::Interleaved;
-  pm.addPass(mlir::tt::ttir::createTTIRLayout(layoutOptions));
 }
 
 void createTTNNPipelineAnalysisPasses(
@@ -59,6 +53,8 @@ void createTTNNPipelineAnalysisPasses(
 
 void createTTNNPipelineLoweringPasses(
     OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options) {
+  // Add pass to add layout information.
+  pm.addPass(createTTNNLayout());
   // Add pass to convert TTIR to TTNN.
   pm.addPass(createConvertTTIRToTTNNPass());
   // Add pass to remove unused values.

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_mlir_dialect_library(MLIRTTNNTransforms
+        TTNNLayout.cpp
         Passes.cpp
         Optimizer.cpp
         TTNNToCpp.cpp
@@ -10,6 +11,9 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         MLIRTTNNOpsIncGen
         MLIRTTNNPassesIncGen
         MLIRTTOpsIncGen
+
+        LINK_LIBS PUBLIC
+        MLIRTTNNDialect
         )
 
 target_include_directories(MLIRTTNNTransforms PUBLIC ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common)

--- a/lib/Dialect/TTNN/Transforms/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/Optimizer.cpp
@@ -159,7 +159,7 @@ public:
     SystemDescAttr systemDesc = mlir::cast<tt::SystemDescAttr>(
         moduleOp->getAttr(tt::SystemDescAttr::name));
     ChipDescAttr chipDesc = systemDesc.getChipDescs()[0];
-    llvm::DenseMap<Operation *, std::vector<TensorConfigAttr>> legalLayouts;
+    llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>> legalLayouts;
 
     moduleOp->walk([&](Operation *op) {
       if (op->getNumResults() == 0) {
@@ -261,8 +261,8 @@ public:
 
           // Update the memory space and layout of the op.
           //
-          TensorConfigAttr layoutAttr =
-              mlir::cast<TensorConfigAttr>(newTensorType.getEncoding());
+          TTNNLayoutAttr layoutAttr =
+              mlir::cast<TTNNLayoutAttr>(newTensorType.getEncoding());
 
           op->getResult(0).setType(newTensorType);
 
@@ -419,7 +419,7 @@ private:
       Operation *producerOp = edge.producerOp;
       Operation *consumerOp = edge.consumerOp;
 
-      TensorConfigAttr consumerOpOutputLayout = mlir::cast<TensorConfigAttr>(
+      TTNNLayoutAttr consumerOpOutputLayout = mlir::cast<TTNNLayoutAttr>(
           mlir::cast<RankedTensorType>(consumerOp->getResult(0).getType())
               .getEncoding());
 
@@ -427,8 +427,8 @@ private:
           mlir::cast<RankedTensorType>(producerOp->getResult(0).getType());
       llvm::ArrayRef<int64_t> producerOpTensorShape =
           producerOpTensorType.getShape();
-      TensorConfigAttr producerOpLayout =
-          mlir::cast<TensorConfigAttr>(producerOpTensorType.getEncoding());
+      TTNNLayoutAttr producerOpLayout =
+          mlir::cast<TTNNLayoutAttr>(producerOpTensorType.getEncoding());
 
       // TODO(nobradovic): Match memory space and layout of consumer op.
       // This actually needs to be properly resolved based on op type, output

--- a/lib/Dialect/TTNN/Transforms/Passes.cpp
+++ b/lib/Dialect/TTNN/Transforms/Passes.cpp
@@ -214,7 +214,7 @@ private:
     LayoutInfo input, output;
 
     auto inputLayoutAttr =
-        mlir::cast<TensorConfigAttr>(op.getInput().getType().getEncoding());
+        mlir::cast<TTNNLayoutAttr>(op.getInput().getType().getEncoding());
     auto inputMemref = inputLayoutAttr.getMemref();
 
     assert(op.getMemoryConfig().has_value());

--- a/lib/Dialect/TTNN/Transforms/Passes.cpp
+++ b/lib/Dialect/TTNN/Transforms/Passes.cpp
@@ -214,14 +214,13 @@ private:
     LayoutInfo input, output;
 
     auto inputLayoutAttr =
-        mlir::cast<tt::LayoutAttr>(op.getInput().getType().getEncoding());
+        mlir::cast<TensorConfigAttr>(op.getInput().getType().getEncoding());
     auto inputMemref = inputLayoutAttr.getMemref();
 
     assert(op.getMemoryConfig().has_value());
     MemoryConfigAttr outputMemoryConfig = op.getMemoryConfig().value();
 
-    input.bufferType =
-        ttnn::utils::toTTNNBufferType(inputLayoutAttr.getMemorySpace());
+    input.bufferType = inputLayoutAttr.getBufferType();
     output.bufferType = outputMemoryConfig.getBufferType().getValue();
 
     input.layoutEnum = getLayoutFromMemRef(inputMemref);
@@ -231,8 +230,7 @@ private:
     assert(op.getDtype().has_value());
     output.dataType = op.getDtype().value();
 
-    input.tensorMemoryLayout =
-        ttnn::utils::toTTNNTensorMemoryLayout(inputLayoutAttr.getMemLayout());
+    input.tensorMemoryLayout = inputLayoutAttr.getMemLayout();
     output.tensorMemoryLayout =
         outputMemoryConfig.getTensorMemoryLayout().getValue();
 

--- a/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
@@ -1,0 +1,389 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TT/Utils/OperandConstraints.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+
+namespace mlir::tt::ttnn {
+#define GEN_PASS_DEF_TTNNLAYOUT
+#include "ttmlir/Dialect/TTNN/Transforms/Passes.h.inc"
+
+// Default collapse dims for affine map (d0, d1, d2) -> (d0 <> d1, d2)
+static const std::array<std::pair<int64_t, int64_t>, 1> g_defaultCollapseDims =
+    {{{0, -1}}};
+
+// Default memory space for tensors on host
+static const BufferType g_defaultMemorySpaceHost = BufferType::SystemMemory;
+
+// Default memory space for tesnors on device
+static const BufferType g_defaultMemorySpaceDevice = BufferType::DRAM;
+
+// Default memory layout for tensors on device
+static const TensorMemoryLayout g_defaultMemoryLayout =
+    TensorMemoryLayout::Interleaved;
+
+//===----------------------------------------------------------------------===//
+// Helper methods
+//===----------------------------------------------------------------------===//
+
+inline Location appendInputSuffix(Location loc, int64_t operandIndex) {
+  if (isa<NameLoc>(loc)) {
+    NameLoc oldLoc = mlir::cast<NameLoc>(loc);
+    StringAttr newName = StringAttr::get(
+        loc->getContext(), oldLoc.getName().str() + "_in_" +
+                               std::to_string(operandIndex) + "_layout");
+
+    return NameLoc::get(newName, oldLoc.getChildLoc());
+  }
+
+  return loc;
+}
+
+//===----------------------------------------------------------------------===//
+// To layout pass
+//===----------------------------------------------------------------------===//
+
+// Converts tensor types to have a tensor config attribute with default values
+//
+// Example: tensor<15x10x32xf32> -> tensor<15x10x32xf32, tensor_config<...>>
+// where tensor_config<...> is constructed with default values
+// SystemMemory, MemoryLayout::None, Grid<1x1>
+class TTNNLayoutTensorTypeConverter : public TypeConverter {
+public:
+  TTNNLayoutTensorTypeConverter(MLIRContext *ctx, GridAttr deviceGrid) {
+    addConversion([](Type type) { return type; });
+    addConversion([ctx, deviceGrid](RankedTensorType type) -> Type {
+      auto layout = type.getEncoding();
+      if (layout) {
+        return type;
+      }
+
+      std::int64_t deviceGridRank = deviceGrid.getShape().size();
+
+      // Default to single core grid
+      auto tensorGrid = GridAttr::get(ctx, deviceGridRank);
+
+      llvm::ArrayRef<std::pair<int64_t, int64_t>> collapseDimsRef(
+          g_defaultCollapseDims);
+
+      auto newLayout = TensorConfigAttr::get(
+          ctx, type.getShape(), type.getElementType(), g_defaultMemorySpaceHost,
+          tensorGrid, TensorMemoryLayout::None, collapseDimsRef);
+      return RankedTensorType::get(type.getShape(), type.getElementType(),
+                                   newLayout);
+    });
+  }
+};
+
+// Rewrites tensor types to have a tensor config attribute with default values
+class TTNNLayoutTensorTypeRewriter : public RewritePattern {
+public:
+  TTNNLayoutTensorTypeRewriter(const TypeConverter &converter, MLIRContext *ctx)
+      : RewritePattern(MatchAnyOpTypeTag(), /*benefit=*/1, ctx),
+        converter(&converter) {}
+
+  bool convertTypes(ValueRange valueRange, SmallVector<Type> &newTypes) const {
+    if (failed(converter->convertTypes(valueRange.getTypes(), newTypes))) {
+      return false;
+    }
+
+    bool updated = false;
+    for (auto [value, newType] : llvm::zip(valueRange, newTypes)) {
+      if (value.getType() != newType) {
+        value.setType(newType);
+        updated = true;
+      }
+    }
+    return updated;
+  }
+
+  // FuncOp requires special handling because it has a FunctionType attribute
+  bool convertFuncType(Operation *op, PatternRewriter &rewriter) const {
+    auto funcOp = dyn_cast<func::FuncOp>(op);
+    if (!funcOp) {
+      return false;
+    }
+    SmallVector<Type> inputTypes(funcOp.getArgumentTypes());
+    SmallVector<Type> outputTypes(funcOp.getResultTypes());
+
+    for (Type &ty : inputTypes) {
+      ty = converter->convertType(ty);
+    }
+    for (Type &ty : outputTypes) {
+      ty = converter->convertType(ty);
+    }
+    auto newType = rewriter.getType<FunctionType>(inputTypes, outputTypes);
+    if (funcOp.getFunctionType() == newType) {
+      return false;
+    }
+    funcOp.setFunctionType(newType);
+
+    Block &entryBlock = funcOp.getBody().front();
+    for (unsigned i = 0; i < entryBlock.getNumArguments(); ++i) {
+      entryBlock.getArgument(i).setType(inputTypes[i]);
+    }
+
+    return true;
+  }
+
+  LogicalResult matchAndRewrite(Operation *op,
+                                PatternRewriter &rewriter) const override {
+    bool updated = false;
+    SmallVector<Type> operands;
+    SmallVector<Type> results;
+    updated |= convertTypes(op->getOperands(), operands);
+    updated |= convertTypes(op->getResults(), results);
+    updated |= convertFuncType(op, rewriter);
+    return updated ? success() : failure();
+  }
+
+  const TypeConverter *converter;
+};
+
+// Given desired buffer type, memory layout and type checks if the input tensor
+// needs to be converted to the desired layout. If so, creates a ToLayou
+static std::optional<Value>
+createToLayoutOp(PatternRewriter &rewriter, Location loc, Value input,
+                 BufferType desiredBufferType,
+                 TensorMemoryLayout desiredMemLayout, bool tiled) {
+
+  // Get type
+  auto ty = mlir::cast<RankedTensorType>(input.getType());
+
+  // Get tensor config from the type
+  auto tensorConfig = mlir::cast<TensorConfigAttr>(ty.getEncoding());
+
+  // Get buffer type (i.e DRAM/L1 etc)
+  auto currBufferType = tensorConfig.getBufferType();
+
+  // Get the current element type (i.e bf16/TileType etc)
+  auto currElementType = tensorConfig.getElementType();
+
+  // Get the mem layout attribute (i.e interleaved/sharded or null in case of
+  // System)
+  auto currMemLayout = tensorConfig.getMemLayout();
+
+  // Get element type that should be used in the new tensor config
+  auto desiredElementType =
+      tiled ? rewriter.getType<TileType>(ty.getElementType())
+            : ty.getElementType();
+
+  // If the current buffer type, element type and memory layout are the same as
+  // the desired ones, we don't need to do anything
+  if (currBufferType == desiredBufferType &&
+      currElementType == desiredElementType &&
+      currMemLayout == desiredMemLayout) {
+    return std::nullopt;
+  }
+
+  // Create a new tensor config with the desired buffer type, element type and
+  // memory layout
+  auto desiredLayout = rewriter.getAttr<TensorConfigAttr>(
+      ty.getShape(), desiredElementType, desiredBufferType,
+      tensorConfig.getGrid(), desiredMemLayout, g_defaultCollapseDims);
+
+  // If the input tensor is a constant or empty tensor, we can replace it with a
+  // new tensor with the desired layout
+  tensor::EmptyOp existingEmpty = input.getDefiningOp<tensor::EmptyOp>();
+  if (existingEmpty) {
+    return rewriter
+        .replaceOpWithNewOp<tensor::EmptyOp>(existingEmpty, ty.getShape(),
+                                             ty.getElementType(), desiredLayout)
+        .getResult();
+  }
+
+  // If the input tensor is a constant, we can replace it with a new constant
+  // with the desired layout
+  ttir::ConstantOp existingConstant = input.getDefiningOp<ttir::ConstantOp>();
+  if (existingConstant) {
+    return rewriter
+        .replaceOpWithNewOp<ttir::ConstantOp>(
+            existingConstant,
+            mlir::RankedTensorType::get(ty.getShape(), ty.getElementType(),
+                                        desiredLayout),
+            existingConstant.getValue())
+        .getResult();
+  }
+
+  // If the input tensor is not a constant or empty tensor, we need to create a
+  // new tensor with the desired layout which will be used as the output of the
+  // ToLayoutOp
+  tensor::EmptyOp output = rewriter.create<tensor::EmptyOp>(
+      loc, ty.getShape(), ty.getElementType(), desiredLayout);
+
+  // Create the ToLayoutOp which will convert the input tensor to the desired
+  // layout
+  return rewriter
+      .create<ttir::ToLayoutOp>(loc, output.getType(), input, output)
+      ->getResult(0);
+}
+
+static std::optional<Value>
+createToLayoutOp(PatternRewriter &rewriter, Location loc, Value input,
+                 OperandConstraint operandConstraint) {
+  // Find out which buffer type we want
+  tt::MemorySpace ttDefaultMemSpace =
+      utils::toTTMemorySpace(g_defaultMemorySpaceDevice);
+  tt::MemorySpace desiredMemorySpace =
+      getLegalMemorySpace(operandConstraint, ttDefaultMemSpace);
+  BufferType desiredBufferType = utils::toTTNNBufferType(desiredMemorySpace);
+
+  // Find out which memory layout we want
+  tt::TensorMemoryLayout ttMemoryLayout =
+      utils::toTTTensorMemoryLayout(g_defaultMemoryLayout);
+  tt::TensorMemoryLayout desiredMemoryLayout = getLegalTensorMemoryLayout(
+      operandConstraint, desiredMemorySpace, ttMemoryLayout);
+  TensorMemoryLayout ttnnMemoryLayout =
+      utils::toTTNNTensorMemoryLayout(desiredMemoryLayout);
+
+  // Check if the tensor should be tiled
+  bool tiled =
+      !bitEnumContainsAny(operandConstraint, OperandConstraint::Scalar);
+
+  return createToLayoutOp(rewriter, loc, input, desiredBufferType,
+                          ttnnMemoryLayout, tiled);
+}
+
+// Updates the layout of the operands of a TTIR ops which have DPS operands.
+// This function rewrites the operands and result to have the correct layout
+// with respect to operand constraints.
+class TTNNLayoutDPSOperandsRewriter
+    : public OpInterfaceRewritePattern<DestinationStyleOpInterface> {
+public:
+  TTNNLayoutDPSOperandsRewriter(MLIRContext *ctx)
+      : OpInterfaceRewritePattern<DestinationStyleOpInterface>(ctx) {}
+
+  LogicalResult matchAndRewrite(DestinationStyleOpInterface op,
+                                PatternRewriter &rewriter) const final {
+    // To layout op is a special case, we don't want to rewrite it
+    if (mlir::isa<ttir::ToLayoutOp>(op.getOperation())) {
+      return failure();
+    }
+
+    assert(op->template hasTrait<ttir::TTIROp::Trait>());
+    bool modified = false;
+    for (auto &operand : op->getOpOperands()) {
+      // Check if the operand is a dps result
+      bool isResult = op.isDpsInit(&operand);
+
+      // TTNN Conv2d moves input, weight, and bias from host to device
+      // itself. Inserting the ToLayoutOp on these operands is thus problematic.
+      if (mlir::isa<ttir::Conv2dOp>(op.getOperation()) && !isResult) {
+        continue;
+      }
+
+      // Read operand constrait for current operand
+      auto operandConstraint =
+          mlir::cast<OperandConstraintAttr>(
+              mlir::cast<ttir::TTIROp>(op.getOperation())
+                  .getOperandConstraints()[operand.getOperandNumber()])
+              .getValue();
+      Location newLoc =
+          appendInputSuffix(op.getLoc(), operand.getOperandNumber());
+      // Given the operand constraint, create the desired layout for the operand
+      auto desiredLayout =
+          createToLayoutOp(rewriter, newLoc, operand.get(), operandConstraint);
+
+      // If layout changed update the operand
+      if (desiredLayout) {
+        rewriter.modifyOpInPlace(op, [&]() {
+          modified = true;
+          op->setOperand(operand.getOperandNumber(), *desiredLayout);
+          // If operand is dps result, update the result type on current op
+          if (isResult) {
+            op->getResult(0).setType(desiredLayout->getType());
+          }
+        });
+      }
+    }
+
+    return modified ? success() : failure();
+  }
+};
+
+// Updates the layout of the operands of a func::ReturnOp.
+// The intent is to move the result to host.
+class TTNNLayoutFuncReturnRewriter
+    : public OpRewritePattern<mlir::func::ReturnOp> {
+public:
+  TTNNLayoutFuncReturnRewriter(MLIRContext *ctx)
+      : OpRewritePattern<mlir::func::ReturnOp>(ctx) {}
+
+  LogicalResult matchAndRewrite(mlir::func::ReturnOp op,
+                                PatternRewriter &rewriter) const final {
+    bool modified = false;
+    for (auto &operand : op->getOpOperands()) {
+      Location newLoc =
+          appendInputSuffix(op.getLoc(), operand.getOperandNumber());
+      auto layout = createToLayoutOp(
+          rewriter, newLoc, operand.get(), BufferType::SystemMemory,
+          TensorMemoryLayout::None, false /* tiled */);
+      if (layout.has_value()) {
+        rewriter.modifyOpInPlace(
+            op, [&]() { op.setOperand(operand.getOperandNumber(), *layout); });
+        modified = true;
+      }
+    }
+    return modified ? success() : failure();
+  }
+
+private:
+};
+
+class TTNNLayout : public impl::TTNNLayoutBase<TTNNLayout> {
+public:
+  using impl::TTNNLayoutBase<TTNNLayout>::TTNNLayoutBase;
+
+  void runOnOperation() final {
+    // First add default attribute to all tensors. Example:
+    // Given tensor type: tensor<15x10x32xf32>
+    // we construct a tensor config attribute with default values:
+    // tensor_config<affine_map, grid<1x1>, memref<<15x64>xf32, #system_memory>
+    {
+      auto device = getCurrentScopeDevice(getOperation());
+      assert(device && "Device not found");
+      TTNNLayoutTensorTypeConverter typeConverter(&getContext(),
+                                                  device.getWorkerGrid());
+      RewritePatternSet patterns(&getContext());
+      patterns.add<TTNNLayoutTensorTypeRewriter>(typeConverter, &getContext());
+      FrozenRewritePatternSet patternSet(std::move(patterns));
+      if (failed(applyPatternsAndFoldGreedily(getOperation(), patternSet))) {
+        signalPassFailure();
+        return;
+      }
+    }
+    {
+      RewritePatternSet patterns(&getContext());
+      // Takes all TTIR ops which have DPS operands
+      // and rewrites its operands and result to have the correct layout
+      // with respect to operand constraints.
+      patterns.add<TTNNLayoutDPSOperandsRewriter>(&getContext());
+      // Takes func::Return op and sets layout which will
+      // move it's operands to host
+      patterns.add<TTNNLayoutFuncReturnRewriter>(&getContext());
+      FrozenRewritePatternSet patternSet(std::move(patterns));
+      GreedyRewriteConfig config = GreedyRewriteConfig();
+      config.useTopDownTraversal = true;
+      if (failed(applyPatternsAndFoldGreedily(getOperation(), patternSet,
+                                              config))) {
+        signalPassFailure();
+        return;
+      }
+    }
+  }
+
+  void getDependentDialects(mlir::DialectRegistry &registry) const override {
+    registry.insert<mlir::tt::ttir::TTIRDialect>();
+    registry.insert<mlir::tt::TTDialect>();
+    registry.insert<mlir::func::FuncDialect>();
+  }
+};
+
+} // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Utils/OptimizerOverrides.cpp
+++ b/lib/Dialect/TTNN/Utils/OptimizerOverrides.cpp
@@ -58,17 +58,16 @@ bool OutputLayoutOverrideParser::parse(
     }
 
     // Parse memory space.
-    std::optional<mlir::tt::MemorySpace> memorySpace =
-        mlir::tt::symbolizeMemorySpace(layoutParamParts[iMemorySpace]);
-    if (!memorySpace.has_value()) {
+    std::optional<BufferType> bufferType =
+        symbolizeBufferType(layoutParamParts[iMemorySpace]);
+    if (!bufferType.has_value()) {
       opt.error("Invalid memory space: " + layoutParamParts[iMemorySpace]);
       return true;
     }
 
     // Parse tensor memory layout.
-    std::optional<mlir::tt::TensorMemoryLayout> tensorMemoryLayout =
-        mlir::tt::symbolizeTensorMemoryLayout(
-            layoutParamParts[iTensorMemoryLayout]);
+    std::optional<TensorMemoryLayout> tensorMemoryLayout =
+        symbolizeTensorMemoryLayout(layoutParamParts[iTensorMemoryLayout]);
     if (!tensorMemoryLayout.has_value()) {
       opt.error("Invalid tensor memory layout: " +
                 layoutParamParts[iTensorMemoryLayout]);
@@ -93,7 +92,7 @@ bool OutputLayoutOverrideParser::parse(
 
     // Set parsed op overrides.
     value[opOverrideParts[iOpName]] = OutputLayoutOverrideParams{
-        std::move(grid), memorySpace.value(), tensorMemoryLayout.value(),
+        std::move(grid), bufferType.value(), tensorMemoryLayout.value(),
         memoryLayout.value(), dataType.value()};
   }
   return false;
@@ -115,9 +114,10 @@ void OutputLayoutOverrideParser::print(
       }
     }
     // Print memory space and memory layout
-    os << ":" << mlir::tt::stringifyMemorySpace(params.memorySpace);
+    os << ":" << mlir::tt::ttnn::stringifyBufferType(params.bufferType);
     os << ":"
-       << mlir::tt::stringifyTensorMemoryLayout(params.tensorMemoryLayout);
+       << mlir::tt::ttnn::stringifyTensorMemoryLayout(
+              params.tensorMemoryLayout);
     os << ":" << mlir::tt::ttnn::stringifyLayout(params.memoryLayout);
     os << ":" << mlir::tt::DataTypeEnumToString(params.dataType);
     if (++count < value.size()) {

--- a/lib/Dialect/TTNN/Utils/Utils.cpp
+++ b/lib/Dialect/TTNN/Utils/Utils.cpp
@@ -45,6 +45,43 @@ mlir::tt::ttnn::TensorMemoryLayout toTTNNTensorMemoryLayout(
   llvm_unreachable("Unknown TensorMemoryLayout");
 }
 
+mlir::tt::TensorMemoryLayout toTTTensorMemoryLayout(
+    const ::mlir::tt::ttnn::TensorMemoryLayout ttnnTensorMemoryLayout) {
+
+  switch (ttnnTensorMemoryLayout) {
+  case ttnn::TensorMemoryLayout::HeightSharded:
+    return ::mlir::tt::TensorMemoryLayout::HeightSharded;
+  case ttnn::TensorMemoryLayout::Interleaved:
+    return ::mlir::tt::TensorMemoryLayout::Interleaved;
+  case ttnn::TensorMemoryLayout::WidthSharded:
+    return ::mlir::tt::TensorMemoryLayout::WidthSharded;
+  case ttnn::TensorMemoryLayout::BlockSharded:
+    return ::mlir::tt::TensorMemoryLayout::BlockSharded;
+  case ttnn::TensorMemoryLayout::SingleBank:
+    return ::mlir::tt::TensorMemoryLayout::SingleBank;
+  case ttnn::TensorMemoryLayout::None:
+    return ::mlir::tt::TensorMemoryLayout::None;
+  }
+}
+
+mlir::tt::MemorySpace
+toTTMemorySpace(const mlir::tt::ttnn::BufferType bufferType) {
+  switch (bufferType) {
+  case ttnn::BufferType::SystemMemory:
+    return MemorySpace::System;
+  case ttnn::BufferType::DRAM:
+    return MemorySpace::DeviceDRAM;
+  case ttnn::BufferType::L1:
+    return MemorySpace::DeviceL1;
+  case ttnn::BufferType::L1Small:
+    assert(false && "BufferType::L1Small not supported");
+  case ttnn::BufferType::Trace:
+    assert(false && "BufferType::Trace not supported");
+  }
+
+  llvm_unreachable("Unknown MemorySpace");
+}
+
 DataType getDataTypeFromMemRef(mlir::MemRefType memref) {
   Type elementType = memref.getElementType();
   DataType dtype = DataType::Float32;

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -102,7 +102,7 @@ memrefAttrToFlatbuffer(FlatbufferObjectCache &cache, mlir::MemRefType memref,
 }
 
 flatbuffers::Offset<::tt::target::LayoutDesc> tensorConfigAttrToFlatbuffer(
-    FlatbufferObjectCache &cache, ttnn::TensorConfigAttr layoutAttr,
+    FlatbufferObjectCache &cache, ttnn::TTNNLayoutAttr layoutAttr,
     mlir::ArrayRef<int64_t> logicalShape, DeviceAttr deviceAttr) {
   auto strideInt64 = layoutAttr.getStride(logicalShape);
   std::vector<int32_t> stride(strideInt64.begin(), strideInt64.end());

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -101,7 +101,7 @@ memrefAttrToFlatbuffer(FlatbufferObjectCache &cache, mlir::MemRefType memref,
       toFlatbuffer(cache, memLayout), size);
 }
 
-flatbuffers::Offset<::tt::target::LayoutDesc> tensorConfigAttrToFlatbuffer(
+flatbuffers::Offset<::tt::target::LayoutDesc> ttnnLayoutAttrToFlatbuffer(
     FlatbufferObjectCache &cache, ttnn::TTNNLayoutAttr layoutAttr,
     mlir::ArrayRef<int64_t> logicalShape, DeviceAttr deviceAttr) {
   auto strideInt64 = layoutAttr.getStride(logicalShape);

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -35,6 +35,86 @@
 #include <fstream>
 #include <optional>
 
+namespace mlir::tt {
+
+::tt::target::TensorMemoryLayout
+toFlatbuffer(FlatbufferObjectCache &, ttnn::TensorMemoryLayout memLayout) {
+  switch (memLayout) {
+  case ttnn::TensorMemoryLayout::SingleBank:
+    return ::tt::target::TensorMemoryLayout::SingleBank;
+  case ttnn::TensorMemoryLayout::Interleaved:
+    return ::tt::target::TensorMemoryLayout::Interleaved;
+  case ttnn::TensorMemoryLayout::HeightSharded:
+    return ::tt::target::TensorMemoryLayout::HeightSharded;
+  case ttnn::TensorMemoryLayout::WidthSharded:
+    return ::tt::target::TensorMemoryLayout::WidthSharded;
+  case ttnn::TensorMemoryLayout::BlockSharded:
+    return ::tt::target::TensorMemoryLayout::BlockSharded;
+  case ttnn::TensorMemoryLayout::None:
+    return ::tt::target::TensorMemoryLayout::None;
+  }
+}
+
+::tt::target::MemorySpace toFlatbuffer(FlatbufferObjectCache &,
+                                       ttnn::BufferType bufferType) {
+  switch (bufferType) {
+  case ttnn::BufferType::SystemMemory:
+    return ::tt::target::MemorySpace::System;
+  case ttnn::BufferType::DRAM:
+    return ::tt::target::MemorySpace::DeviceDRAM;
+  case ttnn::BufferType::L1:
+    return ::tt::target::MemorySpace::DeviceL1;
+  default:
+    llvm_unreachable("unhandled buffer type");
+  }
+}
+
+flatbuffers::Offset<::tt::target::MemoryDesc>
+memrefAttrToFlatbuffer(FlatbufferObjectCache &cache, mlir::MemRefType memref,
+                       ttnn::TensorMemoryLayout memLayout) {
+  auto shapeInt64 = memref.getShape();
+  std::vector<int32_t> shape(shapeInt64.begin(), shapeInt64.end());
+  DataType dtype = DataType::Float32;
+  ::tt::target::Dim2d tileShape(1, 1);
+  mlir::Type elementType = memref.getElementType();
+  std::uint64_t elementSize = 0;
+  if (mlir::isa<TileType>(elementType)) {
+    auto tileType = mlir::cast<TileType>(elementType);
+    dtype = tileType.getDataType();
+    tileShape = ::tt::target::Dim2d(tileType.getHeight(), tileType.getWidth());
+    elementSize = tileType.getSizeBytes();
+  } else {
+    dtype = elementTypeToDataType(elementType);
+    elementSize = getElementSizeBytes(dtype);
+  }
+
+  std::uint64_t size = elementSize;
+  for (auto dim : shapeInt64) {
+    size *= dim;
+  }
+
+  return ::tt::target::CreateMemoryDescDirect(
+      *cache.fbb, &shape, &tileShape, toFlatbuffer(cache, dtype),
+      toFlatbuffer(
+          cache,
+          mlir::cast<ttnn::BufferTypeAttr>(memref.getMemorySpace()).getValue()),
+      toFlatbuffer(cache, memLayout), size);
+}
+
+flatbuffers::Offset<::tt::target::LayoutDesc> tensorConfigAttrToFlatbuffer(
+    FlatbufferObjectCache &cache, ttnn::TensorConfigAttr layoutAttr,
+    mlir::ArrayRef<int64_t> logicalShape, DeviceAttr deviceAttr) {
+  auto strideInt64 = layoutAttr.getStride(logicalShape);
+  std::vector<int32_t> stride(strideInt64.begin(), strideInt64.end());
+  auto coreRangeSet =
+      toFlatbuffer(cache, layoutAttr.getGrid(), deviceAttr.getWorkerGrid());
+  return ::tt::target::CreateLayoutDescDirect(
+      *cache.fbb, &stride, toFlatbuffer(cache, OOBVal::Undef), &coreRangeSet,
+      cache.getOrCreate(layoutAttr.getMemref(), memrefAttrToFlatbuffer,
+                        layoutAttr.getMemLayout()));
+}
+} // namespace mlir::tt
+
 namespace mlir::tt::ttnn {
 
 constexpr uint64_t kHostAllocatedSize = 0;
@@ -42,13 +122,6 @@ constexpr uint64_t kHostAllocatedAddress = 0;
 
 #define GEN_PASS_DEF_TTNNSERIALIZETOBINARY
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h.inc"
-
-::tt::target::Dim2dRange toFlatbuffer(CoreRangeAttr coreRange) {
-  auto offset = coreRange.getOffset();
-  auto size = coreRange.getSize();
-  return ::tt::target::Dim2dRange(::tt::target::Dim2d(offset[0], offset[1]),
-                                  ::tt::target::Dim2d(size[0], size[1]));
-}
 
 ::flatbuffers::Offset<::tt::target::ShardSpec>
 shardSpecToFlatbuffer(FlatbufferObjectCache &cache,

--- a/test/ttmlir/Dialect/TTNN/eltwise/unary/relu/simple_relu.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/unary/relu/simple_relu.mlir
@@ -1,16 +1,16 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 #any_device = #tt.operand_constraint<any_device>
-#l1 = #tt.memory_space<l1>
-#system = #tt.memory_space<system>
-#layout = #tt.layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<64x128xf32, #system>>
-#layout1 = #tt.layout<(d0, d1) -> (d0, d1), undef, <8x8>, memref<8x16xf32, #system>>
-#layout2 = #tt.layout<(d0, d1) -> (d0, d1), undef, <8x8>, memref<8x16xf32, #l1>, interleaved>
+#l1 = #ttnn.buffer_type<l1>
+#system = #ttnn.buffer_type<system_memory>
+#tensor_config = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <1x1>, memref<64x128xf32, #system>>
+#tensor_config1 = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <8x8>, memref<8x16xf32, #system>>
+#tensor_config2 = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <8x8>, memref<8x16xf32, #l1>, interleaved>
 module attributes {} {
-  func.func @forward(%arg0: tensor<64x128xf32, #layout>) -> tensor<64x128xf32, #layout1> {
+  func.func @forward(%arg0: tensor<64x128xf32, #tensor_config>) -> tensor<64x128xf32, #tensor_config1> {
     // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
-    %0 = tensor.empty() : tensor<64x128xf32, #layout1>
+    %0 = tensor.empty() : tensor<64x128xf32, #tensor_config1>
     // CHECK: %[[C:.*]] = "ttnn.relu"[[C:.*]]
-    %1 = "ttir.relu"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>, operand_constraints = [#any_device, #any_device]}> : (tensor<64x128xf32, #layout>, tensor<64x128xf32, #layout1>) -> tensor<64x128xf32, #layout1>
-    return %1 : tensor<64x128xf32, #layout1>
+    %1 = "ttir.relu"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>, operand_constraints = [#any_device, #any_device]}> : (tensor<64x128xf32, #tensor_config>, tensor<64x128xf32, #tensor_config1>) -> tensor<64x128xf32, #tensor_config1>
+    return %1 : tensor<64x128xf32, #tensor_config1>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/unary/relu/simple_relu.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/unary/relu/simple_relu.mlir
@@ -2,15 +2,15 @@
 #any_device = #tt.operand_constraint<any_device>
 #l1 = #ttnn.buffer_type<l1>
 #system = #ttnn.buffer_type<system_memory>
-#tensor_config = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <1x1>, memref<64x128xf32, #system>>
-#tensor_config1 = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <8x8>, memref<8x16xf32, #system>>
-#tensor_config2 = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <8x8>, memref<8x16xf32, #l1>, interleaved>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<64x128xf32, #system>>
+#ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <8x8>, memref<8x16xf32, #system>>
+#ttnn_layout2 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <8x8>, memref<8x16xf32, #l1>, interleaved>
 module attributes {} {
-  func.func @forward(%arg0: tensor<64x128xf32, #tensor_config>) -> tensor<64x128xf32, #tensor_config1> {
+  func.func @forward(%arg0: tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1> {
     // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
-    %0 = tensor.empty() : tensor<64x128xf32, #tensor_config1>
+    %0 = tensor.empty() : tensor<64x128xf32, #ttnn_layout1>
     // CHECK: %[[C:.*]] = "ttnn.relu"[[C:.*]]
-    %1 = "ttir.relu"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>, operand_constraints = [#any_device, #any_device]}> : (tensor<64x128xf32, #tensor_config>, tensor<64x128xf32, #tensor_config1>) -> tensor<64x128xf32, #tensor_config1>
-    return %1 : tensor<64x128xf32, #tensor_config1>
+    %1 = "ttir.relu"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>, operand_constraints = [#any_device, #any_device]}> : (tensor<64x128xf32, #ttnn_layout>, tensor<64x128xf32, #ttnn_layout1>) -> tensor<64x128xf32, #ttnn_layout1>
+    return %1 : tensor<64x128xf32, #ttnn_layout1>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/matmul/simple_matmul.mlir
+++ b/test/ttmlir/Dialect/TTNN/matmul/simple_matmul.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 #any_device_tile = #tt.operand_constraint<dram|l1|tile|any_device_tile>
-// CHECK: #[[TILED_LAYOUT:.*]] = #tt.layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<2x4x!tt.tile<32x32, bf16>, #dram>, interleaved>
+// CHECK: #[[TILED_LAYOUT:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!tt.tile<32x32, bf16>, #dram>, interleaved>
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x96xbf16>) -> tensor<64x96xbf16> {
     %0 = tensor.empty() : tensor<64x96xbf16>

--- a/test/ttmlir/Dialect/TTNN/matmul/simple_matmul.mlir
+++ b/test/ttmlir/Dialect/TTNN/matmul/simple_matmul.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 #any_device_tile = #tt.operand_constraint<dram|l1|tile|any_device_tile>
-// CHECK: #[[TILED_LAYOUT:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!tt.tile<32x32, bf16>, #dram>, interleaved>
+// CHECK: #[[TILED_LAYOUT:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!tt.tile<32x32, bf16>, #dram>, interleaved>
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x96xbf16>) -> tensor<64x96xbf16> {
     %0 = tensor.empty() : tensor<64x96xbf16>

--- a/test/ttmlir/Dialect/TTNN/optimizer/input_layout_loc_override.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/input_layout_loc_override.mlir
@@ -4,13 +4,13 @@
 // CHECK-DAG: #[[LOC_MATMUL_IN0:.*]] = loc("matmul_1_in_0_layout"(#loc3))
 // CHECK-DAG: #[[LOC_MATMUL_IN1:.*]] = loc("matmul_1_in_1_layout"(#loc3))
 // CHECK-DAG: #[[LOC_MATMUL:.*]] = loc("matmul_1"(#loc3))
-// CHECK-DAG: #[[IN_1_LAYOUT:.*]] = #tt.layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<4x3x!tt.tile<32x32, bf16>, #l1_>, interleaved>
+// CHECK-DAG: #[[IN_1_LAYOUT:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <1x1>, memref<4x3x!tt.tile<32x32, bf16>, #l1_>, interleaved>
 
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x96xbf16>) -> tensor<64x96xbf16> {
     %0 = tensor.empty() : tensor<64x96xbf16> loc(#loc2)
     // CHECK-DAG: %{{.*}} = "ttnn.to_device"{{.*}} loc(#[[LOC_MATMUL_IN0]])
-    // CHECK-DAG: %{{.*}} = "ttnn.to_device"{{.*}} <{memory_config = #ttnn.memory_config<<interleaved>, <l1>, <<4x3>>>}> : {{.*}} -> tensor<128x96xbf16, #[[IN_1_LAYOUT]]> loc(#[[LOC_MATMUL_IN1]])
+    // CHECK-DAG: %{{.*}} = "ttnn.to_device"{{.*}} <{memory_config = #ttnn.memory_config<<interleaved>, #l1_, <<4x3>>>}> : {{.*}} -> tensor<128x96xbf16, #[[IN_1_LAYOUT]]> loc(#[[LOC_MATMUL_IN1]])
     // CHECK-DAG: %{{.*}} = "ttnn.matmul"{{.*}} loc(#[[LOC_MATMUL]])
     %1 = "ttir.matmul"(%arg0, %arg1, %0) <{operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<64x128xbf16>, tensor<128x96xbf16>, tensor<64x96xbf16>) -> tensor<64x96xbf16> loc(#loc2)
     return %1 : tensor<64x96xbf16>

--- a/test/ttmlir/Dialect/TTNN/optimizer/input_layout_loc_override.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/input_layout_loc_override.mlir
@@ -4,7 +4,7 @@
 // CHECK-DAG: #[[LOC_MATMUL_IN0:.*]] = loc("matmul_1_in_0_layout"(#loc3))
 // CHECK-DAG: #[[LOC_MATMUL_IN1:.*]] = loc("matmul_1_in_1_layout"(#loc3))
 // CHECK-DAG: #[[LOC_MATMUL:.*]] = loc("matmul_1"(#loc3))
-// CHECK-DAG: #[[IN_1_LAYOUT:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <1x1>, memref<4x3x!tt.tile<32x32, bf16>, #l1_>, interleaved>
+// CHECK-DAG: #[[IN_1_LAYOUT:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x3x!tt.tile<32x32, bf16>, #l1_>, interleaved>
 
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x96xbf16>) -> tensor<64x96xbf16> {

--- a/test/ttmlir/Dialect/TTNN/optimizer/mnist_sharding.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/mnist_sharding.mlir
@@ -3,8 +3,8 @@
 #loc = loc("MNISTLinear":4294967295:0)
 module @"tt-forge-graph" attributes {} {
   func.func @main(%arg0: tensor<1x784xf32> loc("MNISTLinear":4294967295:0), %arg1: tensor<1x10xf32> loc("MNISTLinear":4294967295:0), %arg2: tensor<256x10xf32> loc("MNISTLinear":4294967295:0), %arg3: tensor<1x256xf32> loc("MNISTLinear":4294967295:0), %arg4: tensor<784x256xf32> loc("MNISTLinear":4294967295:0)) -> tensor<1x10xf32> {
-    // CHECK: #[[LAYOUT_10:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <1x8>, memref<1x32xf32, #l1_>, width_sharded>
-    // CHECK: #[[LAYOUT_11:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <1x1>, memref<1x10xf32, #l1_>, width_sharded>
+    // CHECK: #[[LAYOUT_10:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x8>, memref<1x32xf32, #l1_>, width_sharded>
+    // CHECK: #[[LAYOUT_11:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x10xf32, #l1_>, width_sharded>
     %0 = tensor.empty() : tensor<1x256xf32> loc(#loc8)
     // CHECK: %[[C:.*]] = "ttnn.matmul"[[C:.*]] -> tensor<1x256xf32, #[[LAYOUT_10]]>
     %1 = "ttir.matmul"(%arg0, %arg4, %0) <{operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<1x784xf32>, tensor<784x256xf32>, tensor<1x256xf32>) -> tensor<1x256xf32> loc(#loc8)

--- a/test/ttmlir/Dialect/TTNN/optimizer/mnist_sharding.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/mnist_sharding.mlir
@@ -3,8 +3,8 @@
 #loc = loc("MNISTLinear":4294967295:0)
 module @"tt-forge-graph" attributes {} {
   func.func @main(%arg0: tensor<1x784xf32> loc("MNISTLinear":4294967295:0), %arg1: tensor<1x10xf32> loc("MNISTLinear":4294967295:0), %arg2: tensor<256x10xf32> loc("MNISTLinear":4294967295:0), %arg3: tensor<1x256xf32> loc("MNISTLinear":4294967295:0), %arg4: tensor<784x256xf32> loc("MNISTLinear":4294967295:0)) -> tensor<1x10xf32> {
-    // CHECK: #[[LAYOUT_10:.*]] = #tt.layout<(d0, d1) -> (d0, d1), undef, <1x8>, memref<1x32xf32, #l1_>, width_sharded>
-    // CHECK: #[[LAYOUT_11:.*]] = #tt.layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<1x10xf32, #l1_>, width_sharded>
+    // CHECK: #[[LAYOUT_10:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <1x8>, memref<1x32xf32, #l1_>, width_sharded>
+    // CHECK: #[[LAYOUT_11:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <1x1>, memref<1x10xf32, #l1_>, width_sharded>
     %0 = tensor.empty() : tensor<1x256xf32> loc(#loc8)
     // CHECK: %[[C:.*]] = "ttnn.matmul"[[C:.*]] -> tensor<1x256xf32, #[[LAYOUT_10]]>
     %1 = "ttir.matmul"(%arg0, %arg4, %0) <{operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<1x784xf32>, tensor<784x256xf32>, tensor<1x256xf32>) -> tensor<1x256xf32> loc(#loc8)

--- a/test/ttmlir/Dialect/TTNN/optimizer/multiple_add_with_loc.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/multiple_add_with_loc.mlir
@@ -3,7 +3,7 @@
 #loc = loc("test_ops.py:17_0_0":0:0)
 module attributes {} {
   func.func @main(%arg0: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0), %arg1: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0), %arg2: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0)) -> (tensor<1x32x32xf32>, tensor<1x32x32xf32>) {
-    // CHECK: #[[LAYOUT_2:.*]] = #tt.layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), undef, <8x8>, memref<4x4xf32, #dram>, interleaved>
+    // CHECK: #[[LAYOUT_2:.*]] = #ttnn.tensor_config<(d0, d1, d2) -> (d0 * 32 + d1, d2), <8x8>, memref<4x4xf32, #dram>, interleaved>
     %0 = tensor.empty() : tensor<1x32x32xf32> loc(#loc5)
     // CHECK: %[[C:.*]] = "ttnn.add"[[C:.*]] -> tensor<1x32x32xf32, #[[LAYOUT_2]]>
     %1 = "ttir.add"(%arg1, %arg2, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<1x32x32xf32>, tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> tensor<1x32x32xf32> loc(#loc5)
@@ -13,7 +13,7 @@ module attributes {} {
     %4 = tensor.empty() : tensor<1x32x32xf32> loc(#loc7)
     // CHECK: %[[C:.*]] = "ttnn.add"[[C:.*]] -> tensor<1x32x32xf32, #[[LAYOUT_2]]>
     %5 = "ttir.add"(%arg2, %arg1, %4) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<1x32x32xf32>, tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> tensor<1x32x32xf32> loc(#loc7)
-    // CHECK: return %[[R0:.*]], %[[R1:.*]] : tensor<1x32x32xf32, #layout>, tensor<1x32x32xf32, #layout>
+    // CHECK: return %[[R0:.*]], %[[R1:.*]] : tensor<1x32x32xf32, #tensor_config>, tensor<1x32x32xf32, #tensor_config>
     return %3, %5 : tensor<1x32x32xf32>, tensor<1x32x32xf32> loc(#loc4)
   } loc(#loc)
 } loc(#loc)

--- a/test/ttmlir/Dialect/TTNN/optimizer/multiple_add_with_loc.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/multiple_add_with_loc.mlir
@@ -3,7 +3,7 @@
 #loc = loc("test_ops.py:17_0_0":0:0)
 module attributes {} {
   func.func @main(%arg0: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0), %arg1: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0), %arg2: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0)) -> (tensor<1x32x32xf32>, tensor<1x32x32xf32>) {
-    // CHECK: #[[LAYOUT_2:.*]] = #ttnn.tensor_config<(d0, d1, d2) -> (d0 * 32 + d1, d2), <8x8>, memref<4x4xf32, #dram>, interleaved>
+    // CHECK: #[[LAYOUT_2:.*]] = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <8x8>, memref<4x4xf32, #dram>, interleaved>
     %0 = tensor.empty() : tensor<1x32x32xf32> loc(#loc5)
     // CHECK: %[[C:.*]] = "ttnn.add"[[C:.*]] -> tensor<1x32x32xf32, #[[LAYOUT_2]]>
     %1 = "ttir.add"(%arg1, %arg2, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<1x32x32xf32>, tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> tensor<1x32x32xf32> loc(#loc5)
@@ -13,7 +13,7 @@ module attributes {} {
     %4 = tensor.empty() : tensor<1x32x32xf32> loc(#loc7)
     // CHECK: %[[C:.*]] = "ttnn.add"[[C:.*]] -> tensor<1x32x32xf32, #[[LAYOUT_2]]>
     %5 = "ttir.add"(%arg2, %arg1, %4) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<1x32x32xf32>, tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> tensor<1x32x32xf32> loc(#loc7)
-    // CHECK: return %[[R0:.*]], %[[R1:.*]] : tensor<1x32x32xf32, #tensor_config>, tensor<1x32x32xf32, #tensor_config>
+    // CHECK: return %[[R0:.*]], %[[R1:.*]] : tensor<1x32x32xf32, #ttnn_layout>, tensor<1x32x32xf32, #ttnn_layout>
     return %3, %5 : tensor<1x32x32xf32>, tensor<1x32x32xf32> loc(#loc4)
   } loc(#loc)
 } loc(#loc)

--- a/test/ttmlir/Dialect/TTNN/optimizer/multiple_add_with_loc_input_layout_override.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/multiple_add_with_loc_input_layout_override.mlir
@@ -3,9 +3,9 @@
 #loc = loc("test_ops.py:17_0_0":0:0)
 module attributes {} {
   func.func @main(%arg0: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0), %arg1: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0), %arg2: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0)) -> tensor<1x32x32xf32> {
-    // CHECK: #[[L1_:.*]] = #tt.memory_space<l1>
-    // CHECK-DAG: #[[LAYOUT_1:.*]] = #tt.layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), undef, <1x1>, memref<32x32xf32, #l1_>, width_sharded>
-    // CHECK-DAG: #[[LAYOUT_2:.*]] = #tt.layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), undef, <1x1>, memref<32x32xf32, #dram>, interleaved>
+    // CHECK: #[[L1_:.*]] = #ttnn.buffer_type<l1>
+    // CHECK-DAG: #[[LAYOUT_1:.*]] = #ttnn.tensor_config<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x32xf32, #l1_>, width_sharded>
+    // CHECK-DAG: #[[LAYOUT_2:.*]] = #ttnn.tensor_config<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x32xf32, #dram>, interleaved>
     %0 = tensor.empty() : tensor<1x32x32xf32> loc(#loc5)
     // CHECK: %[[C:.*]] = "ttnn.add"{{.*}} -> tensor<1x32x32xf32, #[[LAYOUT_2]]>
     %1 = "ttir.add"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<1x32x32xf32>, tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> tensor<1x32x32xf32> loc(#loc5)

--- a/test/ttmlir/Dialect/TTNN/optimizer/multiple_add_with_loc_input_layout_override.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/multiple_add_with_loc_input_layout_override.mlir
@@ -4,8 +4,8 @@
 module attributes {} {
   func.func @main(%arg0: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0), %arg1: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0), %arg2: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0)) -> tensor<1x32x32xf32> {
     // CHECK: #[[L1_:.*]] = #ttnn.buffer_type<l1>
-    // CHECK-DAG: #[[LAYOUT_1:.*]] = #ttnn.tensor_config<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x32xf32, #l1_>, width_sharded>
-    // CHECK-DAG: #[[LAYOUT_2:.*]] = #ttnn.tensor_config<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x32xf32, #dram>, interleaved>
+    // CHECK-DAG: #[[LAYOUT_1:.*]] = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x32xf32, #l1_>, width_sharded>
+    // CHECK-DAG: #[[LAYOUT_2:.*]] = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x32xf32, #dram>, interleaved>
     %0 = tensor.empty() : tensor<1x32x32xf32> loc(#loc5)
     // CHECK: %[[C:.*]] = "ttnn.add"{{.*}} -> tensor<1x32x32xf32, #[[LAYOUT_2]]>
     %1 = "ttir.add"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<1x32x32xf32>, tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> tensor<1x32x32xf32> loc(#loc5)

--- a/test/ttmlir/Dialect/TTNN/optimizer/multiple_add_with_loc_output_layout_override.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/multiple_add_with_loc_output_layout_override.mlir
@@ -3,11 +3,11 @@
 #loc = loc("test_ops.py:17_0_0":0:0)
 module attributes {} {
   func.func @main(%arg0: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0), %arg1: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0), %arg2: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0)) -> (tensor<1x32x32xf32>, tensor<1x32x32xf32>) {
-    // CHECK: #[[L1_:.*]] = #tt.memory_space<l1>
-    // CHECK: #[[LAYOUT_0:.*]] = #tt.layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), undef, <1x1>, memref<32x32xf32, #system>>
-    // CHECK: #[[LAYOUT_1:.*]] = #tt.layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), undef, <4x4>, memref<8x8xbf16, #dram>, interleaved>
-    // CHECK: #[[LAYOUT_2:.*]] = #tt.layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), undef, <4x4>, memref<1x1x!tt.tile<32x32, f32>, #l1_>, interleaved>
-    // CHECK: #[[LAYOUT_3:.*]] = #tt.layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), undef, <8x8>, memref<4x4xf32, #dram>, interleaved>
+    // CHECK: #[[L1_:.*]] = #ttnn.buffer_type<l1>
+    // CHECK: #[[LAYOUT_0:.*]] = #ttnn.tensor_config<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x32xf32, #system_memory>>
+    // CHECK: #[[LAYOUT_1:.*]] = #ttnn.tensor_config<(d0, d1, d2) -> (d0 * 32 + d1, d2), <4x4>, memref<8x8xbf16, #dram>, interleaved>
+    // CHECK: #[[LAYOUT_2:.*]] = #ttnn.tensor_config<(d0, d1, d2) -> (d0 * 32 + d1, d2), <4x4>, memref<1x1x!tt.tile<32x32, f32>, #l1_>, interleaved>
+    // CHECK: #[[LAYOUT_3:.*]] = #ttnn.tensor_config<(d0, d1, d2) -> (d0 * 32 + d1, d2), <8x8>, memref<4x4xf32, #dram>, interleaved>
     %0 = tensor.empty() : tensor<1x32x32xf32> loc(#loc5)
     // CHECK: %[[C:.*]] = "ttnn.add"[[C:.*]] -> tensor<1x32x32xf32, #[[LAYOUT_1]]>
     %1 = "ttir.add"(%arg1, %arg2, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<1x32x32xf32>, tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> tensor<1x32x32xf32> loc(#loc5)

--- a/test/ttmlir/Dialect/TTNN/optimizer/multiple_add_with_loc_output_layout_override.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/multiple_add_with_loc_output_layout_override.mlir
@@ -4,10 +4,10 @@
 module attributes {} {
   func.func @main(%arg0: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0), %arg1: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0), %arg2: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0)) -> (tensor<1x32x32xf32>, tensor<1x32x32xf32>) {
     // CHECK: #[[L1_:.*]] = #ttnn.buffer_type<l1>
-    // CHECK: #[[LAYOUT_0:.*]] = #ttnn.tensor_config<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x32xf32, #system_memory>>
-    // CHECK: #[[LAYOUT_1:.*]] = #ttnn.tensor_config<(d0, d1, d2) -> (d0 * 32 + d1, d2), <4x4>, memref<8x8xbf16, #dram>, interleaved>
-    // CHECK: #[[LAYOUT_2:.*]] = #ttnn.tensor_config<(d0, d1, d2) -> (d0 * 32 + d1, d2), <4x4>, memref<1x1x!tt.tile<32x32, f32>, #l1_>, interleaved>
-    // CHECK: #[[LAYOUT_3:.*]] = #ttnn.tensor_config<(d0, d1, d2) -> (d0 * 32 + d1, d2), <8x8>, memref<4x4xf32, #dram>, interleaved>
+    // CHECK: #[[LAYOUT_0:.*]] = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x32xf32, #system_memory>>
+    // CHECK: #[[LAYOUT_1:.*]] = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <4x4>, memref<8x8xbf16, #dram>, interleaved>
+    // CHECK: #[[LAYOUT_2:.*]] = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <4x4>, memref<1x1x!tt.tile<32x32, f32>, #l1_>, interleaved>
+    // CHECK: #[[LAYOUT_3:.*]] = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <8x8>, memref<4x4xf32, #dram>, interleaved>
     %0 = tensor.empty() : tensor<1x32x32xf32> loc(#loc5)
     // CHECK: %[[C:.*]] = "ttnn.add"[[C:.*]] -> tensor<1x32x32xf32, #[[LAYOUT_1]]>
     %1 = "ttir.add"(%arg1, %arg2, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<1x32x32xf32>, tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> tensor<1x32x32xf32> loc(#loc5)

--- a/test/ttmlir/Dialect/TTNN/optimizer/sharding_matmul_override_0.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/sharding_matmul_override_0.mlir
@@ -2,7 +2,7 @@
 #any_device_tile = #tt.operand_constraint<dram|l1|tile|any_device_tile>
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x96xbf16>, %arg2: tensor<96x64xbf16>) -> tensor<64x64xbf16> {
-    // CHECK: #[[LAYOUT_7:layout7]] = #tt.layout<{{.*}}, memref<{{.*}}, #dram>, {{.*}}>
+    // CHECK: #[[LAYOUT_7:tensor_config7]] = #ttnn.tensor_config<{{.*}}, memref<{{.*}}, #dram>, {{.*}}>
     %0 = tensor.empty() : tensor<64x96xbf16>
     // CHECK: {{.*}} = "ttnn.matmul"{{.*}} -> tensor<64x96xbf16, #[[LAYOUT_7]]>
     %1 = "ttir.matmul"(%arg0, %arg1, %0) <{operand_constraints = [#any_device_tile, #any_device_tile, #any_device_tile]}> : (tensor<64x128xbf16>, tensor<128x96xbf16>, tensor<64x96xbf16>) -> tensor<64x96xbf16>

--- a/test/ttmlir/Dialect/TTNN/optimizer/sharding_matmul_override_0.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/sharding_matmul_override_0.mlir
@@ -2,7 +2,7 @@
 #any_device_tile = #tt.operand_constraint<dram|l1|tile|any_device_tile>
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x96xbf16>, %arg2: tensor<96x64xbf16>) -> tensor<64x64xbf16> {
-    // CHECK: #[[LAYOUT_7:tensor_config7]] = #ttnn.tensor_config<{{.*}}, memref<{{.*}}, #dram>, {{.*}}>
+    // CHECK: #[[LAYOUT_7:ttnn_layout7]] = #ttnn.ttnn_layout<{{.*}}, memref<{{.*}}, #dram>, {{.*}}>
     %0 = tensor.empty() : tensor<64x96xbf16>
     // CHECK: {{.*}} = "ttnn.matmul"{{.*}} -> tensor<64x96xbf16, #[[LAYOUT_7]]>
     %1 = "ttir.matmul"(%arg0, %arg1, %0) <{operand_constraints = [#any_device_tile, #any_device_tile, #any_device_tile]}> : (tensor<64x128xbf16>, tensor<128x96xbf16>, tensor<64x96xbf16>) -> tensor<64x96xbf16>

--- a/test/ttmlir/Dialect/TTNN/optimizer/sharding_matmul_override_32.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/sharding_matmul_override_32.mlir
@@ -2,8 +2,8 @@
 #any_device_tile = #tt.operand_constraint<dram|l1|tile|any_device_tile>
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x96xbf16>, %arg2: tensor<96x64xbf16>) -> tensor<64x64xbf16> {
-    // CHECK: #[[L1_:.*]] = #tt.memory_space<l1>
-    // CHECK: #[[LAYOUT_7:layout7]] = #tt.layout<{{.*}}, memref<{{.*}}, #l1_>, {{.*}}>
+    // CHECK: #[[L1_:.*]] = #ttnn.buffer_type<l1>
+    // CHECK: #[[LAYOUT_7:tensor_config7]] = #ttnn.tensor_config<{{.*}}, memref<{{.*}}, #l1_>, {{.*}}>
     %0 = tensor.empty() : tensor<64x96xbf16>
     // CHECK: {{.*}} = "ttnn.matmul"{{.*}} -> tensor<64x96xbf16, #[[LAYOUT_7]]>
     %1 = "ttir.matmul"(%arg0, %arg1, %0) <{operand_constraints = [#any_device_tile, #any_device_tile, #any_device_tile]}> : (tensor<64x128xbf16>, tensor<128x96xbf16>, tensor<64x96xbf16>) -> tensor<64x96xbf16>

--- a/test/ttmlir/Dialect/TTNN/optimizer/sharding_matmul_override_32.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/sharding_matmul_override_32.mlir
@@ -3,7 +3,7 @@
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x96xbf16>, %arg2: tensor<96x64xbf16>) -> tensor<64x64xbf16> {
     // CHECK: #[[L1_:.*]] = #ttnn.buffer_type<l1>
-    // CHECK: #[[LAYOUT_7:tensor_config7]] = #ttnn.tensor_config<{{.*}}, memref<{{.*}}, #l1_>, {{.*}}>
+    // CHECK: #[[LAYOUT_7:ttnn_layout7]] = #ttnn.ttnn_layout<{{.*}}, memref<{{.*}}, #l1_>, {{.*}}>
     %0 = tensor.empty() : tensor<64x96xbf16>
     // CHECK: {{.*}} = "ttnn.matmul"{{.*}} -> tensor<64x96xbf16, #[[LAYOUT_7]]>
     %1 = "ttir.matmul"(%arg0, %arg1, %0) <{operand_constraints = [#any_device_tile, #any_device_tile, #any_device_tile]}> : (tensor<64x128xbf16>, tensor<128x96xbf16>, tensor<64x96xbf16>) -> tensor<64x96xbf16>

--- a/test/ttmlir/Dialect/TTNN/optimizer/test_grid_set.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/test_grid_set.mlir
@@ -1,20 +1,20 @@
 // RUN: ttmlir-opt --ttir-load-system-desc --ttnn-optimizer %s | FileCheck %s
 #device = #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, d0 floordiv s0, d1 floordiv s1, (d0 mod s0) * s1 + d1 mod s1), dramMap = (d0, d1)[s0, s1] -> (0, 0, ((((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 8192) mod 12, (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 98304 + (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) mod 8192), meshShape = , chipIds = [0]>
-#dram = #tt.memory_space<dram>
-#system = #tt.memory_space<system>
-#layout = #tt.layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<64x128xf32, #system>>
-#layout1 = #tt.layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<2x4x!tt.tile<32x32, f32>, #dram>, interleaved>
-#layout2 = #tt.layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<64x128xf32, #dram>, interleaved>
+#dram = #ttnn.buffer_type<dram>
+#system_memory = #ttnn.buffer_type<system_memory>
+#tensor_confg = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <1x1>, memref<64x128xf32, #system_memory>>
+#tensor_config1 = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!tt.tile<32x32, f32>, #dram>, interleaved>
+#tensor_config2 = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <1x1>, memref<64x128xf32, #dram>, interleaved>
 module attributes {tt.device = #device} {
-  func.func @forward(%arg0: tensor<64x128xf32, #layout>, %arg1: tensor<64x128xf32, #layout>) -> tensor<64x128xf32, #layout> {
+  func.func @forward(%arg0: tensor<64x128xf32, #tensor_config>, %arg1: tensor<64x128xf32, #tensor_config>) -> tensor<64x128xf32, #tensor_config> {
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
-    %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<64x128>>>}> : (tensor<64x128xf32, #layout>, !tt.device<#device>) -> tensor<64x128xf32, #layout1>
-    %2 = "ttnn.to_layout"(%arg1, %0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<64x128>>>}> : (tensor<64x128xf32, #layout>, !tt.device<#device>) -> tensor<64x128xf32, #layout1>
-    %3 = "ttnn.empty"(%0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<64x128>>>, shape = #ttnn.shape<64x128>}> : (!tt.device<#device>) -> tensor<64x128xf32, #layout2>
-    %4 = "ttnn.multiply"(%1, %2, %3) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32, #layout1>, tensor<64x128xf32, #layout1>, tensor<64x128xf32, #layout2>) -> tensor<64x128xf32, #layout2>
-    // CHECK: #[[LAYOUT_2:.*]] = #tt.layout<(d0, d1) -> (d0, d1), undef, <8x8>, memref<8x16xf32, #dram>, interleaved>
+    %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<64x128>>>}> : (tensor<64x128xf32, #tensor_config>, !tt.device<#device>) -> tensor<64x128xf32, #tensor_config1>
+    %2 = "ttnn.to_layout"(%arg1, %0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<64x128>>>}> : (tensor<64x128xf32, #tensor_config>, !tt.device<#device>) -> tensor<64x128xf32, #tensor_config1>
+    %3 = "ttnn.empty"(%0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<64x128>>>, shape = #ttnn.shape<64x128>}> : (!tt.device<#device>) -> tensor<64x128xf32, #tensor_config2>
+    %4 = "ttnn.multiply"(%1, %2, %3) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32, #tensor_config1>, tensor<64x128xf32, #tensor_config1>, tensor<64x128xf32, #tensor_config2>) -> tensor<64x128xf32, #tensor_config2>
+    // CHECK: #[[LAYOUT_2:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <8x8>, memref<8x16xf32, #dram>, interleaved>
     // CHECK: %{{.+}} = "ttnn.multiply"{{.+}} -> tensor<64x128xf32, #[[LAYOUT_2]]>
-    %5 = "ttnn.to_layout"(%4) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<none>, <system_memory>, <<64x128>>>}> : (tensor<64x128xf32, #layout2>) -> tensor<64x128xf32, #layout>
-    return %5 : tensor<64x128xf32, #layout>
+    %5 = "ttnn.to_layout"(%4) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<none>, <system_memory>, <<64x128>>>}> : (tensor<64x128xf32, #tensor_config2>) -> tensor<64x128xf32, #tensor_config>
+    return %5 : tensor<64x128xf32, #tensor_config>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/optimizer/test_grid_set.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/test_grid_set.mlir
@@ -2,7 +2,7 @@
 #device = #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, d0 floordiv s0, d1 floordiv s1, (d0 mod s0) * s1 + d1 mod s1), dramMap = (d0, d1)[s0, s1] -> (0, 0, ((((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 8192) mod 12, (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 98304 + (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) mod 8192), meshShape = , chipIds = [0]>
 #dram = #ttnn.buffer_type<dram>
 #system_memory = #ttnn.buffer_type<system_memory>
-#tensor_confg = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <1x1>, memref<64x128xf32, #system_memory>>
+#tensor_config = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <1x1>, memref<64x128xf32, #system_memory>>
 #tensor_config1 = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!tt.tile<32x32, f32>, #dram>, interleaved>
 #tensor_config2 = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <1x1>, memref<64x128xf32, #dram>, interleaved>
 module attributes {tt.device = #device} {

--- a/test/ttmlir/Dialect/TTNN/optimizer/test_grid_set.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/test_grid_set.mlir
@@ -2,19 +2,19 @@
 #device = #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, d0 floordiv s0, d1 floordiv s1, (d0 mod s0) * s1 + d1 mod s1), dramMap = (d0, d1)[s0, s1] -> (0, 0, ((((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 8192) mod 12, (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 98304 + (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) mod 8192), meshShape = , chipIds = [0]>
 #dram = #ttnn.buffer_type<dram>
 #system_memory = #ttnn.buffer_type<system_memory>
-#tensor_config = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <1x1>, memref<64x128xf32, #system_memory>>
-#tensor_config1 = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!tt.tile<32x32, f32>, #dram>, interleaved>
-#tensor_config2 = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <1x1>, memref<64x128xf32, #dram>, interleaved>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<64x128xf32, #system_memory>>
+#ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!tt.tile<32x32, f32>, #dram>, interleaved>
+#ttnn_layout2 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<64x128xf32, #dram>, interleaved>
 module attributes {tt.device = #device} {
-  func.func @forward(%arg0: tensor<64x128xf32, #tensor_config>, %arg1: tensor<64x128xf32, #tensor_config>) -> tensor<64x128xf32, #tensor_config> {
+  func.func @forward(%arg0: tensor<64x128xf32, #ttnn_layout>, %arg1: tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout> {
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
-    %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<64x128>>>}> : (tensor<64x128xf32, #tensor_config>, !tt.device<#device>) -> tensor<64x128xf32, #tensor_config1>
-    %2 = "ttnn.to_layout"(%arg1, %0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<64x128>>>}> : (tensor<64x128xf32, #tensor_config>, !tt.device<#device>) -> tensor<64x128xf32, #tensor_config1>
-    %3 = "ttnn.empty"(%0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<64x128>>>, shape = #ttnn.shape<64x128>}> : (!tt.device<#device>) -> tensor<64x128xf32, #tensor_config2>
-    %4 = "ttnn.multiply"(%1, %2, %3) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32, #tensor_config1>, tensor<64x128xf32, #tensor_config1>, tensor<64x128xf32, #tensor_config2>) -> tensor<64x128xf32, #tensor_config2>
-    // CHECK: #[[LAYOUT_2:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <8x8>, memref<8x16xf32, #dram>, interleaved>
+    %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<64x128>>>}> : (tensor<64x128xf32, #ttnn_layout>, !tt.device<#device>) -> tensor<64x128xf32, #ttnn_layout1>
+    %2 = "ttnn.to_layout"(%arg1, %0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<64x128>>>}> : (tensor<64x128xf32, #ttnn_layout>, !tt.device<#device>) -> tensor<64x128xf32, #ttnn_layout1>
+    %3 = "ttnn.empty"(%0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<64x128>>>, shape = #ttnn.shape<64x128>}> : (!tt.device<#device>) -> tensor<64x128xf32, #ttnn_layout2>
+    %4 = "ttnn.multiply"(%1, %2, %3) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32, #ttnn_layout1>, tensor<64x128xf32, #ttnn_layout1>, tensor<64x128xf32, #ttnn_layout2>) -> tensor<64x128xf32, #ttnn_layout2>
+    // CHECK: #[[LAYOUT_2:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <8x8>, memref<8x16xf32, #dram>, interleaved>
     // CHECK: %{{.+}} = "ttnn.multiply"{{.+}} -> tensor<64x128xf32, #[[LAYOUT_2]]>
-    %5 = "ttnn.to_layout"(%4) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<none>, <system_memory>, <<64x128>>>}> : (tensor<64x128xf32, #tensor_config2>) -> tensor<64x128xf32, #tensor_config>
-    return %5 : tensor<64x128xf32, #tensor_config>
+    %5 = "ttnn.to_layout"(%4) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<none>, <system_memory>, <<64x128>>>}> : (tensor<64x128xf32, #ttnn_layout2>) -> tensor<64x128xf32, #ttnn_layout>
+    return %5 : tensor<64x128xf32, #ttnn_layout>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/optimizer/test_override_reshard_edges.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/test_override_reshard_edges.mlir
@@ -5,7 +5,7 @@
 #tensor_config = #ttnn.tensor_config<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x32xf32, #system_memory>>
 #tensor_config1 = #ttnn.tensor_config<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x32xf32, #dram>, interleaved>
 module attributes {tt.device = #device} {
-  func.func @main(%arg0: tensor<1x32x32xf32, #tensor_config1, %arg1: tensor<1x32x32xf32, #tensor_config1, %arg2: tensor<1x32x32xf32, #tensor_config1) -> tensor<1x32x32xf32, #tensor_config1 {
+  func.func @main(%arg0: tensor<1x32x32xf32, #tensor_config>, %arg1: tensor<1x32x32xf32, #tensor_config>, %arg2: tensor<1x32x32xf32, #tensor_config>) -> tensor<1x32x32xf32, #tensor_config> {
     // CHECK: #[[LAYOUT_1:.*]] = #ttnn.tensor_config<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x32xf32, #dram>, interleaved>
     // CHECK: #[[LAYOUT_2:.*]] = #ttnn.tensor_config<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x32xf32, #l1_>, width_sharded>
     // CHECK: #[[LAYOUT_3:.*]] = #ttnn.tensor_config<(d0, d1, d2) -> (d0 * 32 + d1, d2), <8x8>, memref<4x4xf32, #dram>, interleaved>

--- a/test/ttmlir/Dialect/TTNN/optimizer/test_override_reshard_edges.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/test_override_reshard_edges.mlir
@@ -1,28 +1,28 @@
 // RUN: ttmlir-opt --ttir-load-system-desc --ttnn-optimizer="memory-layout-analysis-enabled=true memreconfig-enabled=true insert-memreconfig=add_0_1_2=0 override-output-layout=add_1_2=1x1:dram:interleaved:row_major:f32" %s | FileCheck %s
 #device = #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, d0 floordiv s0, d1 floordiv s1, (d0 mod s0) * s1 + d1 mod s1), dramMap = (d0, d1)[s0, s1] -> (0, 0, ((((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 8192) mod 12, (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 98304 + (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) mod 8192), meshShape = , chipIds = [0]>
-#dram = #tt.memory_space<dram>
-#system = #tt.memory_space<system>
-#layout = #tt.layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), undef, <1x1>, memref<32x32xf32, #system>>
-#layout1 = #tt.layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), undef, <1x1>, memref<32x32xf32, #dram>, interleaved>
+#dram = #ttnn.buffer_type<dram>
+#system_memory = #ttnn.buffer_type<system_memory>
+#tensor_config = #ttnn.tensor_config<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x32xf32, #system_memory>>
+#tensor_config1 = #ttnn.tensor_config<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x32xf32, #dram>, interleaved>
 module attributes {tt.device = #device} {
-  func.func @main(%arg0: tensor<1x32x32xf32, #layout>, %arg1: tensor<1x32x32xf32, #layout>, %arg2: tensor<1x32x32xf32, #layout>) -> tensor<1x32x32xf32, #layout> {
-    // CHECK: #[[LAYOUT_1:.*]] = #tt.layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), undef, <1x1>, memref<32x32xf32, #dram>, interleaved>
-    // CHECK: #[[LAYOUT_2:.*]] = #tt.layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), undef, <1x1>, memref<32x32xf32, #l1_>, width_sharded>
-    // CHECK: #[[LAYOUT_3:.*]] = #tt.layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), undef, <8x8>, memref<4x4xf32, #dram>, interleaved>
+  func.func @main(%arg0: tensor<1x32x32xf32, #tensor_config1, %arg1: tensor<1x32x32xf32, #tensor_config1, %arg2: tensor<1x32x32xf32, #tensor_config1) -> tensor<1x32x32xf32, #tensor_config1 {
+    // CHECK: #[[LAYOUT_1:.*]] = #ttnn.tensor_config<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x32xf32, #dram>, interleaved>
+    // CHECK: #[[LAYOUT_2:.*]] = #ttnn.tensor_config<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x32xf32, #l1_>, width_sharded>
+    // CHECK: #[[LAYOUT_3:.*]] = #ttnn.tensor_config<(d0, d1, d2) -> (d0 * 32 + d1, d2), <8x8>, memref<4x4xf32, #dram>, interleaved>
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
-    %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<32x32>>>}> : (tensor<1x32x32xf32, #layout>, !tt.device<#device>) -> tensor<1x32x32xf32, #layout1>
-    %2 = "ttnn.to_layout"(%arg1, %0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<32x32>>>}> : (tensor<1x32x32xf32, #layout>, !tt.device<#device>) -> tensor<1x32x32xf32, #layout1>
-    %3 = "ttnn.empty"(%0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<32x32>>>, shape = #ttnn.shape<1x32x32>}> : (!tt.device<#device>) -> tensor<1x32x32xf32, #layout1> loc(#loc1)
+    %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<32x32>>>}> : (tensor<1x32x32xf32, #tensor_config>, !tt.device<#device>) -> tensor<1x32x32xf32, #tensor_config1>
+    %2 = "ttnn.to_layout"(%arg1, %0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<32x32>>>}> : (tensor<1x32x32xf32, #tensor_config>, !tt.device<#device>) -> tensor<1x32x32xf32, #tensor_config1>
+    %3 = "ttnn.empty"(%0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<32x32>>>, shape = #ttnn.shape<1x32x32>}> : (!tt.device<#device>) -> tensor<1x32x32xf32, #tensor_config1> loc(#loc1)
     // CHECK: %[[C:.*]] = "ttnn.add"{{.*}} -> tensor<1x32x32xf32, #[[LAYOUT_1]]>
-    %4 = "ttnn.add"(%1, %2, %3) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xf32, #layout1>, tensor<1x32x32xf32, #layout1>, tensor<1x32x32xf32, #layout1>) -> tensor<1x32x32xf32, #layout1> loc(#loc1)
-    %5 = "ttnn.to_layout"(%arg0, %0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<32x32>>>}> : (tensor<1x32x32xf32, #layout>, !tt.device<#device>) -> tensor<1x32x32xf32, #layout1>
-    %6 = "ttnn.empty"(%0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<32x32>>>, shape = #ttnn.shape<1x32x32>}> : (!tt.device<#device>) -> tensor<1x32x32xf32, #layout1> loc(#loc2)
+    %4 = "ttnn.add"(%1, %2, %3) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xf32, #tensor_config1>, tensor<1x32x32xf32, #tensor_config1>, tensor<1x32x32xf32, #tensor_config1>) -> tensor<1x32x32xf32, #tensor_config1> loc(#loc1)
+    %5 = "ttnn.to_layout"(%arg0, %0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<32x32>>>}> : (tensor<1x32x32xf32, #tensor_config>, !tt.device<#device>) -> tensor<1x32x32xf32, #tensor_config1>
+    %6 = "ttnn.empty"(%0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<32x32>>>, shape = #ttnn.shape<1x32x32>}> : (!tt.device<#device>) -> tensor<1x32x32xf32, #tensor_config1> loc(#loc2)
     // CHECK: %{{.*}} = "ttnn.to_layout"(%[[C]], %0) {{.*}} -> tensor<1x32x32xf32, #[[LAYOUT_2]]>
-    %7 = "ttnn.add"(%4, %6, %6) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xf32, #layout1>, tensor<1x32x32xf32, #layout1>, tensor<1x32x32xf32, #layout1>) -> tensor<1x32x32xf32, #layout1> loc(#loc2)
-    %8 = "ttnn.empty"(%0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<32x32>>>, shape = #ttnn.shape<1x32x32>}> : (!tt.device<#device>) -> tensor<1x32x32xf32, #layout1> loc(#loc3)
-    %9 = "ttnn.relu"(%7, %8) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x32x32xf32, #layout1>, tensor<1x32x32xf32, #layout1>) -> tensor<1x32x32xf32, #layout1> loc(#loc3)
-    %10 = "ttnn.to_layout"(%9) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<none>, <system_memory>, <<32x32>>>}> : (tensor<1x32x32xf32, #layout1>) -> tensor<1x32x32xf32, #layout>
-    return %10 : tensor<1x32x32xf32, #layout>
+    %7 = "ttnn.add"(%4, %6, %6) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xf32, #tensor_config1>, tensor<1x32x32xf32, #tensor_config1>, tensor<1x32x32xf32, #tensor_config1>) -> tensor<1x32x32xf32, #tensor_config1> loc(#loc2)
+    %8 = "ttnn.empty"(%0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<32x32>>>, shape = #ttnn.shape<1x32x32>}> : (!tt.device<#device>) -> tensor<1x32x32xf32, #tensor_config1> loc(#loc3)
+    %9 = "ttnn.relu"(%7, %8) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x32x32xf32, #tensor_config1>, tensor<1x32x32xf32, #tensor_config1>) -> tensor<1x32x32xf32, #tensor_config1> loc(#loc3)
+    %10 = "ttnn.to_layout"(%9) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<none>, <system_memory>, <<32x32>>>}> : (tensor<1x32x32xf32, #tensor_config1>) -> tensor<1x32x32xf32, #tensor_config>
+    return %10 : tensor<1x32x32xf32, #tensor_config>
   }
 }
 #loc1 = loc("add_1_2")

--- a/test/ttmlir/Dialect/TTNN/optimizer/test_override_reshard_edges.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/test_override_reshard_edges.mlir
@@ -2,27 +2,27 @@
 #device = #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, d0 floordiv s0, d1 floordiv s1, (d0 mod s0) * s1 + d1 mod s1), dramMap = (d0, d1)[s0, s1] -> (0, 0, ((((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 8192) mod 12, (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 98304 + (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) mod 8192), meshShape = , chipIds = [0]>
 #dram = #ttnn.buffer_type<dram>
 #system_memory = #ttnn.buffer_type<system_memory>
-#tensor_config = #ttnn.tensor_config<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x32xf32, #system_memory>>
-#tensor_config1 = #ttnn.tensor_config<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x32xf32, #dram>, interleaved>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x32xf32, #system_memory>>
+#ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x32xf32, #dram>, interleaved>
 module attributes {tt.device = #device} {
-  func.func @main(%arg0: tensor<1x32x32xf32, #tensor_config>, %arg1: tensor<1x32x32xf32, #tensor_config>, %arg2: tensor<1x32x32xf32, #tensor_config>) -> tensor<1x32x32xf32, #tensor_config> {
-    // CHECK: #[[LAYOUT_1:.*]] = #ttnn.tensor_config<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x32xf32, #dram>, interleaved>
-    // CHECK: #[[LAYOUT_2:.*]] = #ttnn.tensor_config<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x32xf32, #l1_>, width_sharded>
-    // CHECK: #[[LAYOUT_3:.*]] = #ttnn.tensor_config<(d0, d1, d2) -> (d0 * 32 + d1, d2), <8x8>, memref<4x4xf32, #dram>, interleaved>
+  func.func @main(%arg0: tensor<1x32x32xf32, #ttnn_layout>, %arg1: tensor<1x32x32xf32, #ttnn_layout>, %arg2: tensor<1x32x32xf32, #ttnn_layout>) -> tensor<1x32x32xf32, #ttnn_layout> {
+    // CHECK: #[[LAYOUT_1:.*]] = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x32xf32, #dram>, interleaved>
+    // CHECK: #[[LAYOUT_2:.*]] = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x32xf32, #l1_>, width_sharded>
+    // CHECK: #[[LAYOUT_3:.*]] = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <8x8>, memref<4x4xf32, #dram>, interleaved>
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
-    %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<32x32>>>}> : (tensor<1x32x32xf32, #tensor_config>, !tt.device<#device>) -> tensor<1x32x32xf32, #tensor_config1>
-    %2 = "ttnn.to_layout"(%arg1, %0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<32x32>>>}> : (tensor<1x32x32xf32, #tensor_config>, !tt.device<#device>) -> tensor<1x32x32xf32, #tensor_config1>
-    %3 = "ttnn.empty"(%0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<32x32>>>, shape = #ttnn.shape<1x32x32>}> : (!tt.device<#device>) -> tensor<1x32x32xf32, #tensor_config1> loc(#loc1)
+    %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<32x32>>>}> : (tensor<1x32x32xf32, #ttnn_layout>, !tt.device<#device>) -> tensor<1x32x32xf32, #ttnn_layout1>
+    %2 = "ttnn.to_layout"(%arg1, %0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<32x32>>>}> : (tensor<1x32x32xf32, #ttnn_layout>, !tt.device<#device>) -> tensor<1x32x32xf32, #ttnn_layout1>
+    %3 = "ttnn.empty"(%0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<32x32>>>, shape = #ttnn.shape<1x32x32>}> : (!tt.device<#device>) -> tensor<1x32x32xf32, #ttnn_layout1> loc(#loc1)
     // CHECK: %[[C:.*]] = "ttnn.add"{{.*}} -> tensor<1x32x32xf32, #[[LAYOUT_1]]>
-    %4 = "ttnn.add"(%1, %2, %3) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xf32, #tensor_config1>, tensor<1x32x32xf32, #tensor_config1>, tensor<1x32x32xf32, #tensor_config1>) -> tensor<1x32x32xf32, #tensor_config1> loc(#loc1)
-    %5 = "ttnn.to_layout"(%arg0, %0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<32x32>>>}> : (tensor<1x32x32xf32, #tensor_config>, !tt.device<#device>) -> tensor<1x32x32xf32, #tensor_config1>
-    %6 = "ttnn.empty"(%0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<32x32>>>, shape = #ttnn.shape<1x32x32>}> : (!tt.device<#device>) -> tensor<1x32x32xf32, #tensor_config1> loc(#loc2)
+    %4 = "ttnn.add"(%1, %2, %3) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xf32, #ttnn_layout1>, tensor<1x32x32xf32, #ttnn_layout1>, tensor<1x32x32xf32, #ttnn_layout1>) -> tensor<1x32x32xf32, #ttnn_layout1> loc(#loc1)
+    %5 = "ttnn.to_layout"(%arg0, %0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<32x32>>>}> : (tensor<1x32x32xf32, #ttnn_layout>, !tt.device<#device>) -> tensor<1x32x32xf32, #ttnn_layout1>
+    %6 = "ttnn.empty"(%0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<32x32>>>, shape = #ttnn.shape<1x32x32>}> : (!tt.device<#device>) -> tensor<1x32x32xf32, #ttnn_layout1> loc(#loc2)
     // CHECK: %{{.*}} = "ttnn.to_layout"(%[[C]], %0) {{.*}} -> tensor<1x32x32xf32, #[[LAYOUT_2]]>
-    %7 = "ttnn.add"(%4, %6, %6) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xf32, #tensor_config1>, tensor<1x32x32xf32, #tensor_config1>, tensor<1x32x32xf32, #tensor_config1>) -> tensor<1x32x32xf32, #tensor_config1> loc(#loc2)
-    %8 = "ttnn.empty"(%0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<32x32>>>, shape = #ttnn.shape<1x32x32>}> : (!tt.device<#device>) -> tensor<1x32x32xf32, #tensor_config1> loc(#loc3)
-    %9 = "ttnn.relu"(%7, %8) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x32x32xf32, #tensor_config1>, tensor<1x32x32xf32, #tensor_config1>) -> tensor<1x32x32xf32, #tensor_config1> loc(#loc3)
-    %10 = "ttnn.to_layout"(%9) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<none>, <system_memory>, <<32x32>>>}> : (tensor<1x32x32xf32, #tensor_config1>) -> tensor<1x32x32xf32, #tensor_config>
-    return %10 : tensor<1x32x32xf32, #tensor_config>
+    %7 = "ttnn.add"(%4, %6, %6) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xf32, #ttnn_layout1>, tensor<1x32x32xf32, #ttnn_layout1>, tensor<1x32x32xf32, #ttnn_layout1>) -> tensor<1x32x32xf32, #ttnn_layout1> loc(#loc2)
+    %8 = "ttnn.empty"(%0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<interleaved>, <dram>, <<32x32>>>, shape = #ttnn.shape<1x32x32>}> : (!tt.device<#device>) -> tensor<1x32x32xf32, #ttnn_layout1> loc(#loc3)
+    %9 = "ttnn.relu"(%7, %8) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x32x32xf32, #ttnn_layout1>, tensor<1x32x32xf32, #ttnn_layout1>) -> tensor<1x32x32xf32, #ttnn_layout1> loc(#loc3)
+    %10 = "ttnn.to_layout"(%9) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<none>, <system_memory>, <<32x32>>>}> : (tensor<1x32x32xf32, #ttnn_layout1>) -> tensor<1x32x32xf32, #ttnn_layout>
+    return %10 : tensor<1x32x32xf32, #ttnn_layout>
   }
 }
 #loc1 = loc("add_1_2")

--- a/test/ttmlir/Dialect/TTNN/optimizer/ttir_to_ttnn_pipeline.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/ttir_to_ttnn_pipeline.mlir
@@ -2,7 +2,7 @@
 #any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    // CHECK: #[[LAYOUT_2:.*]] = #tt.layout<(d0, d1) -> (d0, d1), undef, <8x8>, memref<8x16xf32, #dram>, interleaved>
+    // CHECK: #[[LAYOUT_2:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <8x8>, memref<8x16xf32, #dram>, interleaved>
     // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
     %0 = tensor.empty() : tensor<64x128xf32>
     // CHECK: %[[C:.*]] = "ttnn.multiply"[[C:.*]] -> tensor<64x128xf32, #[[LAYOUT_2]]>

--- a/test/ttmlir/Dialect/TTNN/optimizer/ttir_to_ttnn_pipeline.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/ttir_to_ttnn_pipeline.mlir
@@ -2,7 +2,7 @@
 #any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    // CHECK: #[[LAYOUT_2:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <8x8>, memref<8x16xf32, #dram>, interleaved>
+    // CHECK: #[[LAYOUT_2:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <8x8>, memref<8x16xf32, #dram>, interleaved>
     // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
     %0 = tensor.empty() : tensor<64x128xf32>
     // CHECK: %[[C:.*]] = "ttnn.multiply"[[C:.*]] -> tensor<64x128xf32, #[[LAYOUT_2]]>

--- a/test/ttmlir/Dialect/TTNN/simple_clamp.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_clamp.mlir
@@ -7,7 +7,7 @@ module attributes {} {
     // CHECK: %[[LAYOUT:.*]] = "ttnn.to_layout"(%[[DEVICE]])
     // CHECK: = "ttnn.clamp"(%[[LAYOUT]])
     // CHECK-SAME: {max = 3.000000e+00 : f32, min = 2.000000e+00 : f32}
-    // CHECK-SAME: [[TENSOR:tensor<64x128xbf16]], #tensor_config{{[0-9]+}}>) -> [[TENSOR]]
+    // CHECK-SAME: [[TENSOR:tensor<64x128xbf16]], #ttnn_layout{{[0-9]+}}>) -> [[TENSOR]]
     %1 = "ttir.clamp"(%arg0, %0) <{max = 3.000000e+00 : f32, min = 2.000000e+00 : f32, operand_constraints = [#any_device_tile, #any_device_tile, #any_device_tile, #any_device_tile]}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     return %1 : tensor<64x128xbf16>
   }

--- a/test/ttmlir/Dialect/TTNN/simple_clamp.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_clamp.mlir
@@ -7,7 +7,7 @@ module attributes {} {
     // CHECK: %[[LAYOUT:.*]] = "ttnn.to_layout"(%[[DEVICE]])
     // CHECK: = "ttnn.clamp"(%[[LAYOUT]])
     // CHECK-SAME: {max = 3.000000e+00 : f32, min = 2.000000e+00 : f32}
-    // CHECK-SAME: [[TENSOR:tensor<64x128xbf16]], #layout{{[0-9]+}}>) -> [[TENSOR]]
+    // CHECK-SAME: [[TENSOR:tensor<64x128xbf16]], #tensor_config{{[0-9]+}}>) -> [[TENSOR]]
     %1 = "ttir.clamp"(%arg0, %0) <{max = 3.000000e+00 : f32, min = 2.000000e+00 : f32, operand_constraints = [#any_device_tile, #any_device_tile, #any_device_tile, #any_device_tile]}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     return %1 : tensor<64x128xbf16>
   }

--- a/test/ttmlir/Dialect/TTNN/ttir_to_ttnn_pipeline_custom_opt.mlir
+++ b/test/ttmlir/Dialect/TTNN/ttir_to_ttnn_pipeline_custom_opt.mlir
@@ -2,7 +2,7 @@
 #any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    // CHECK: #[[LAYOUT_1:.*]] = #tt.layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<64x128xf32, #dram>, interleaved>
+    // CHECK: #[[LAYOUT_1:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <1x1>, memref<64x128xf32, #dram>, interleaved>
     // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
     %0 = tensor.empty() : tensor<64x128xf32>
     // CHECK: %[[C:.*]] = "ttnn.multiply"[[C:.*]] -> tensor<64x128xf32, #[[LAYOUT_1:.*]]>

--- a/test/ttmlir/Dialect/TTNN/ttir_to_ttnn_pipeline_custom_opt.mlir
+++ b/test/ttmlir/Dialect/TTNN/ttir_to_ttnn_pipeline_custom_opt.mlir
@@ -2,7 +2,7 @@
 #any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    // CHECK: #[[LAYOUT_1:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <1x1>, memref<64x128xf32, #dram>, interleaved>
+    // CHECK: #[[LAYOUT_1:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<64x128xf32, #dram>, interleaved>
     // CHECK: %[[C:.*]] = "ttnn.empty"[[C:.*]]
     %0 = tensor.empty() : tensor<64x128xf32>
     // CHECK: %[[C:.*]] = "ttnn.multiply"[[C:.*]] -> tensor<64x128xf32, #[[LAYOUT_1:.*]]>

--- a/test/ttmlir/Silicon/TTNN/optimizer/all_l1_interleaved_policy.mlir
+++ b/test/ttmlir/Silicon/TTNN/optimizer/all_l1_interleaved_policy.mlir
@@ -5,9 +5,9 @@
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x96xbf16>, %arg2: tensor<64x96xbf16>, %arg3: tensor<96x32xbf16>, %arg4: tensor<64x32xbf16>) -> tensor<64x32xbf16> {
     // CHECK: #[[L1_:.*]] = #ttnn.buffer_type<l1>
-    // CHECK: #[[LAYOUT_6:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <{{.*}}>, memref<{{.*}}, #l1_>, interleaved>
-    // CHECK: #[[LAYOUT_7:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <{{.*}}>, memref<{{.*}}, #l1_>, interleaved>
-    // CHECK: #[[LAYOUT_8:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <{{.*}}>, memref<{{.*}}, #dram>, interleaved>
+    // CHECK: #[[LAYOUT_6:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <{{.*}}>, memref<{{.*}}, #l1_>, interleaved>
+    // CHECK: #[[LAYOUT_7:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <{{.*}}>, memref<{{.*}}, #l1_>, interleaved>
+    // CHECK: #[[LAYOUT_8:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <{{.*}}>, memref<{{.*}}, #dram>, interleaved>
     %0 = tensor.empty() : tensor<64x96xbf16>
     // CHECK: %{{.*}} = "ttnn.matmul"{{.*}} -> tensor<64x96xbf16, #[[LAYOUT_6]]>
     %1 = "ttir.matmul"(%arg0, %arg1, %0) <{operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<64x128xbf16>, tensor<128x96xbf16>, tensor<64x96xbf16>) -> tensor<64x96xbf16>

--- a/test/ttmlir/Silicon/TTNN/optimizer/all_l1_interleaved_policy.mlir
+++ b/test/ttmlir/Silicon/TTNN/optimizer/all_l1_interleaved_policy.mlir
@@ -4,10 +4,10 @@
 #any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x96xbf16>, %arg2: tensor<64x96xbf16>, %arg3: tensor<96x32xbf16>, %arg4: tensor<64x32xbf16>) -> tensor<64x32xbf16> {
-    // CHECK: #[[L1_:.*]] = #tt.memory_space<l1>
-    // CHECK: #[[LAYOUT_6:.*]] = #tt.layout<(d0, d1) -> (d0, d1), undef, <{{.*}}>, memref<{{.*}}, #l1_>, interleaved>
-    // CHECK: #[[LAYOUT_7:.*]] = #tt.layout<(d0, d1) -> (d0, d1), undef, <{{.*}}>, memref<{{.*}}, #l1_>, interleaved>
-    // CHECK: #[[LAYOUT_8:.*]] = #tt.layout<(d0, d1) -> (d0, d1), undef, <{{.*}}>, memref<{{.*}}, #dram>, interleaved>
+    // CHECK: #[[L1_:.*]] = #ttnn.buffer_type<l1>
+    // CHECK: #[[LAYOUT_6:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <{{.*}}>, memref<{{.*}}, #l1_>, interleaved>
+    // CHECK: #[[LAYOUT_7:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <{{.*}}>, memref<{{.*}}, #l1_>, interleaved>
+    // CHECK: #[[LAYOUT_8:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <{{.*}}>, memref<{{.*}}, #dram>, interleaved>
     %0 = tensor.empty() : tensor<64x96xbf16>
     // CHECK: %{{.*}} = "ttnn.matmul"{{.*}} -> tensor<64x96xbf16, #[[LAYOUT_6]]>
     %1 = "ttir.matmul"(%arg0, %arg1, %0) <{operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<64x128xbf16>, tensor<128x96xbf16>, tensor<64x96xbf16>) -> tensor<64x96xbf16>

--- a/test/ttmlir/Silicon/TTNN/optimizer/large_tensors.mlir
+++ b/test/ttmlir/Silicon/TTNN/optimizer/large_tensors.mlir
@@ -4,7 +4,7 @@
 #any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module attributes {} {
   func.func @forward(%arg0: tensor<8192x8192xbf16>, %arg1: tensor<8192x8192xbf16>, %arg2: tensor<8192x8192xbf16>) -> tensor<8192x8192xbf16> {
-    // CHECK: #[[LAYOUT_2:tensor_config2]] = #ttnn.tensor_config<{{.*}}, memref<{{.*}}, #dram>, {{.*}}>
+    // CHECK: #[[LAYOUT_2:ttnn_layout2]] = #ttnn.ttnn_layout<{{.*}}, memref<{{.*}}, #dram>, {{.*}}>
     %0 = tensor.empty() : tensor<8192x8192xbf16>
     // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<8192x8192xbf16, #[[LAYOUT_2]]>
     %1 = "ttir.add"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<8192x8192xbf16>, tensor<8192x8192xbf16>, tensor<8192x8192xbf16>) -> tensor<8192x8192xbf16>

--- a/test/ttmlir/Silicon/TTNN/optimizer/large_tensors.mlir
+++ b/test/ttmlir/Silicon/TTNN/optimizer/large_tensors.mlir
@@ -4,7 +4,7 @@
 #any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module attributes {} {
   func.func @forward(%arg0: tensor<8192x8192xbf16>, %arg1: tensor<8192x8192xbf16>, %arg2: tensor<8192x8192xbf16>) -> tensor<8192x8192xbf16> {
-    // CHECK: #[[LAYOUT_2:layout2]] = #tt.layout<{{.*}}, memref<{{.*}}, #dram>, {{.*}}>
+    // CHECK: #[[LAYOUT_2:tensor_config2]] = #ttnn.tensor_config<{{.*}}, memref<{{.*}}, #dram>, {{.*}}>
     %0 = tensor.empty() : tensor<8192x8192xbf16>
     // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<8192x8192xbf16, #[[LAYOUT_2]]>
     %1 = "ttir.add"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<8192x8192xbf16>, tensor<8192x8192xbf16>, tensor<8192x8192xbf16>) -> tensor<8192x8192xbf16>

--- a/test/ttmlir/Silicon/TTNN/optimizer/mnist_l1_interleaved.mlir
+++ b/test/ttmlir/Silicon/TTNN/optimizer/mnist_l1_interleaved.mlir
@@ -5,9 +5,9 @@
 #loc = loc("MNISTLinear":4294967295:0)
 module @"tt-forge-graph" attributes {} {
   func.func @main(%arg0: tensor<1x784xf32> loc("MNISTLinear":4294967295:0), %arg1: tensor<1x10xf32> loc("MNISTLinear":4294967295:0), %arg2: tensor<256x10xf32> loc("MNISTLinear":4294967295:0), %arg3: tensor<1x256xf32> loc("MNISTLinear":4294967295:0), %arg4: tensor<784x256xf32> loc("MNISTLinear":4294967295:0)) -> tensor<1x10xf32> {
-    // CHECK: #[[LAYOUT_6:.*]] = #tt.layout<(d0, d1) -> (d0, d1), undef, <{{.*}}>, memref<{{.*}}, #l1_>, interleaved>
-    // CHECK: #[[LAYOUT_7:.*]] = #tt.layout<(d0, d1) -> (d0, d1), undef, <{{.*}}>, memref<{{.*}}, #l1_>, interleaved>
-    // CHECK: #[[LAYOUT_8:.*]] = #tt.layout<(d0, d1) -> (d0, d1), undef, <{{.*}}>, memref<{{.*}}, #dram>, interleaved>
+    // CHECK: #[[LAYOUT_6:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <{{.*}}>, memref<{{.*}}, #l1_>, interleaved>
+    // CHECK: #[[LAYOUT_7:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <{{.*}}>, memref<{{.*}}, #l1_>, interleaved>
+    // CHECK: #[[LAYOUT_8:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <{{.*}}>, memref<{{.*}}, #dram>, interleaved>
     %0 = tensor.empty() : tensor<1x256xf32> loc(#loc8)
     // CHECK: %[[C:.*]] = "ttnn.matmul"[[C:.*]] -> tensor<1x256xf32, #[[LAYOUT_6]]>
     %1 = "ttir.matmul"(%arg0, %arg4, %0) <{operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<1x784xf32>, tensor<784x256xf32>, tensor<1x256xf32>) -> tensor<1x256xf32> loc(#loc8)

--- a/test/ttmlir/Silicon/TTNN/optimizer/mnist_l1_interleaved.mlir
+++ b/test/ttmlir/Silicon/TTNN/optimizer/mnist_l1_interleaved.mlir
@@ -5,9 +5,9 @@
 #loc = loc("MNISTLinear":4294967295:0)
 module @"tt-forge-graph" attributes {} {
   func.func @main(%arg0: tensor<1x784xf32> loc("MNISTLinear":4294967295:0), %arg1: tensor<1x10xf32> loc("MNISTLinear":4294967295:0), %arg2: tensor<256x10xf32> loc("MNISTLinear":4294967295:0), %arg3: tensor<1x256xf32> loc("MNISTLinear":4294967295:0), %arg4: tensor<784x256xf32> loc("MNISTLinear":4294967295:0)) -> tensor<1x10xf32> {
-    // CHECK: #[[LAYOUT_6:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <{{.*}}>, memref<{{.*}}, #l1_>, interleaved>
-    // CHECK: #[[LAYOUT_7:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <{{.*}}>, memref<{{.*}}, #l1_>, interleaved>
-    // CHECK: #[[LAYOUT_8:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <{{.*}}>, memref<{{.*}}, #dram>, interleaved>
+    // CHECK: #[[LAYOUT_6:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <{{.*}}>, memref<{{.*}}, #l1_>, interleaved>
+    // CHECK: #[[LAYOUT_7:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <{{.*}}>, memref<{{.*}}, #l1_>, interleaved>
+    // CHECK: #[[LAYOUT_8:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <{{.*}}>, memref<{{.*}}, #dram>, interleaved>
     %0 = tensor.empty() : tensor<1x256xf32> loc(#loc8)
     // CHECK: %[[C:.*]] = "ttnn.matmul"[[C:.*]] -> tensor<1x256xf32, #[[LAYOUT_6]]>
     %1 = "ttir.matmul"(%arg0, %arg4, %0) <{operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<1x784xf32>, tensor<784x256xf32>, tensor<1x256xf32>) -> tensor<1x256xf32> loc(#loc8)

--- a/test/ttmlir/Silicon/TTNN/optimizer/mnist_sharding_tiled.mlir
+++ b/test/ttmlir/Silicon/TTNN/optimizer/mnist_sharding_tiled.mlir
@@ -5,8 +5,8 @@
 #loc = loc("MNISTLinear":4294967295:0)
 module @"tt-forge-graph" attributes {} {
   func.func @main(%arg0: tensor<32x784xf32> loc("MNISTLinear":4294967295:0), %arg1: tensor<32xf32> loc("MNISTLinear":4294967295:0), %arg2: tensor<256x32xf32> loc("MNISTLinear":4294967295:0), %arg3: tensor<256xf32> loc("MNISTLinear":4294967295:0), %arg4: tensor<784x256xf32> loc("MNISTLinear":4294967295:0)) -> tensor<32x32xf32> {
-    // CHECK-DAG: #[[LAYOUT_1:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <1x8>, memref<32x32xf32, #l1_>, width_sharded>
-    // CHECK-DAG: #[[LAYOUT_2:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <1x1>, memref<32x32xf32, #l1_>, width_sharded>
+    // CHECK-DAG: #[[LAYOUT_1:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x8>, memref<32x32xf32, #l1_>, width_sharded>
+    // CHECK-DAG: #[[LAYOUT_2:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<32x32xf32, #l1_>, width_sharded>
     %0 = tensor.empty() : tensor<32x256xf32> loc(#loc8)
     // CHECK: %{{.*}} = "ttnn.matmul"{{.*}} -> tensor<32x256xf32, #[[LAYOUT_1]]>
     %1 = "ttir.matmul"(%arg0, %arg4, %0) <{operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<32x784xf32>, tensor<784x256xf32>, tensor<32x256xf32>) -> tensor<32x256xf32> loc(#loc8)

--- a/test/ttmlir/Silicon/TTNN/optimizer/mnist_sharding_tiled.mlir
+++ b/test/ttmlir/Silicon/TTNN/optimizer/mnist_sharding_tiled.mlir
@@ -5,8 +5,8 @@
 #loc = loc("MNISTLinear":4294967295:0)
 module @"tt-forge-graph" attributes {} {
   func.func @main(%arg0: tensor<32x784xf32> loc("MNISTLinear":4294967295:0), %arg1: tensor<32xf32> loc("MNISTLinear":4294967295:0), %arg2: tensor<256x32xf32> loc("MNISTLinear":4294967295:0), %arg3: tensor<256xf32> loc("MNISTLinear":4294967295:0), %arg4: tensor<784x256xf32> loc("MNISTLinear":4294967295:0)) -> tensor<32x32xf32> {
-    // CHECK-DAG: #[[LAYOUT_1:.*]] = #tt.layout<(d0, d1) -> (d0, d1), undef, <1x8>, memref<32x32xf32, #l1_>, width_sharded>
-    // CHECK-DAG: #[[LAYOUT_2:.*]] = #tt.layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<32x32xf32, #l1_>, width_sharded>
+    // CHECK-DAG: #[[LAYOUT_1:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <1x8>, memref<32x32xf32, #l1_>, width_sharded>
+    // CHECK-DAG: #[[LAYOUT_2:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <1x1>, memref<32x32xf32, #l1_>, width_sharded>
     %0 = tensor.empty() : tensor<32x256xf32> loc(#loc8)
     // CHECK: %{{.*}} = "ttnn.matmul"{{.*}} -> tensor<32x256xf32, #[[LAYOUT_1]]>
     %1 = "ttir.matmul"(%arg0, %arg4, %0) <{operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<32x784xf32>, tensor<784x256xf32>, tensor<32x256xf32>) -> tensor<32x256xf32> loc(#loc8)

--- a/test/ttmlir/Silicon/TTNN/perf_unit/test_perf_clamp.mlir
+++ b/test/ttmlir/Silicon/TTNN/perf_unit/test_perf_clamp.mlir
@@ -11,7 +11,7 @@ func.func @clamp(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
   // CHECK: %[[LAYOUT:.*]] = "ttnn.to_layout"(%[[DEVICE]])
   // CHECK: = "ttnn.clamp"(%[[LAYOUT]])
   // CHECK-SAME: {max = 3.000000e+00 : f32, min = 2.000000e+00 : f32}
-  // CHECK-SAME: [[TENSOR:tensor<64x128xbf16]], #layout{{[0-9]+}}>) -> [[TENSOR]]
+  // CHECK-SAME: [[TENSOR:tensor<64x128xbf16]], #tensor_config{{[0-9]+}}>) -> [[TENSOR]]
   %1 = "ttir.clamp"(%arg0, %0) <{max = 3.000000e+00 : f32, min = 2.000000e+00 : f32, operand_constraints = [#any_device_tile, #any_device_tile, #any_device_tile, #any_device_tile]}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/perf_unit/test_perf_clamp.mlir
+++ b/test/ttmlir/Silicon/TTNN/perf_unit/test_perf_clamp.mlir
@@ -11,7 +11,7 @@ func.func @clamp(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
   // CHECK: %[[LAYOUT:.*]] = "ttnn.to_layout"(%[[DEVICE]])
   // CHECK: = "ttnn.clamp"(%[[LAYOUT]])
   // CHECK-SAME: {max = 3.000000e+00 : f32, min = 2.000000e+00 : f32}
-  // CHECK-SAME: [[TENSOR:tensor<64x128xbf16]], #tensor_config{{[0-9]+}}>) -> [[TENSOR]]
+  // CHECK-SAME: [[TENSOR:tensor<64x128xbf16]], #ttnn_layout{{[0-9]+}}>) -> [[TENSOR]]
   %1 = "ttir.clamp"(%arg0, %0) <{max = 3.000000e+00 : f32, min = 2.000000e+00 : f32, operand_constraints = [#any_device_tile, #any_device_tile, #any_device_tile, #any_device_tile]}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/perf_unit/test_perf_matmul.mlir
+++ b/test/ttmlir/Silicon/TTNN/perf_unit/test_perf_matmul.mlir
@@ -2,7 +2,7 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 #any_device_tile = #tt.operand_constraint<dram|l1|tile|any_device_tile>
-// CHECK: #[[TILED_LAYOUT:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!tt.tile<32x32, bf16>, #dram>, interleaved>
+// CHECK: #[[TILED_LAYOUT:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!tt.tile<32x32, bf16>, #dram>, interleaved>
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x96xbf16>) -> tensor<64x96xbf16> {
     %0 = tensor.empty() : tensor<64x96xbf16>

--- a/test/ttmlir/Silicon/TTNN/perf_unit/test_perf_matmul.mlir
+++ b/test/ttmlir/Silicon/TTNN/perf_unit/test_perf_matmul.mlir
@@ -2,7 +2,7 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 #any_device_tile = #tt.operand_constraint<dram|l1|tile|any_device_tile>
-// CHECK: #[[TILED_LAYOUT:.*]] = #tt.layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<2x4x!tt.tile<32x32, bf16>, #dram>, interleaved>
+// CHECK: #[[TILED_LAYOUT:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!tt.tile<32x32, bf16>, #dram>, interleaved>
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x96xbf16>) -> tensor<64x96xbf16> {
     %0 = tensor.empty() : tensor<64x96xbf16>

--- a/test/ttmlir/Silicon/TTNN/simple_eltwise.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_eltwise.mlir
@@ -25,7 +25,7 @@ func.func @clamp(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
   // CHECK: %[[LAYOUT:.*]] = "ttnn.to_layout"(%[[DEVICE]])
   // CHECK: = "ttnn.clamp"(%[[LAYOUT]])
   // CHECK-SAME: {max = 3.000000e+00 : f32, min = 2.000000e+00 : f32}
-  // CHECK-SAME: [[TENSOR:tensor<64x128xbf16]], #layout{{[0-9]+}}>) -> [[TENSOR]]
+  // CHECK-SAME: [[TENSOR:tensor<64x128xbf16]], #tensor_config{{[0-9]+}}>) -> [[TENSOR]]
   %1 = "ttir.clamp"(%arg0, %0) <{max = 3.000000e+00 : f32, min = 2.000000e+00 : f32, operand_constraints = [#any_device_tile, #any_device_tile, #any_device_tile, #any_device_tile]}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/simple_eltwise.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_eltwise.mlir
@@ -25,7 +25,7 @@ func.func @clamp(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
   // CHECK: %[[LAYOUT:.*]] = "ttnn.to_layout"(%[[DEVICE]])
   // CHECK: = "ttnn.clamp"(%[[LAYOUT]])
   // CHECK-SAME: {max = 3.000000e+00 : f32, min = 2.000000e+00 : f32}
-  // CHECK-SAME: [[TENSOR:tensor<64x128xbf16]], #tensor_config{{[0-9]+}}>) -> [[TENSOR]]
+  // CHECK-SAME: [[TENSOR:tensor<64x128xbf16]], #ttnn_layout{{[0-9]+}}>) -> [[TENSOR]]
   %1 = "ttir.clamp"(%arg0, %0) <{max = 3.000000e+00 : f32, min = 2.000000e+00 : f32, operand_constraints = [#any_device_tile, #any_device_tile, #any_device_tile, #any_device_tile]}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/simple_matmul.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_matmul.mlir
@@ -2,7 +2,7 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 #any_device_tile = #tt.operand_constraint<dram|l1|tile|any_device_tile>
-// CHECK: #[[TILED_LAYOUT:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!tt.tile<32x32, bf16>, #dram>, interleaved>
+// CHECK: #[[TILED_LAYOUT:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!tt.tile<32x32, bf16>, #dram>, interleaved>
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x96xbf16>) -> tensor<64x96xbf16> {
     %0 = tensor.empty() : tensor<64x96xbf16>

--- a/test/ttmlir/Silicon/TTNN/simple_matmul.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_matmul.mlir
@@ -2,7 +2,7 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 #any_device_tile = #tt.operand_constraint<dram|l1|tile|any_device_tile>
-// CHECK: #[[TILED_LAYOUT:.*]] = #tt.layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<2x4x!tt.tile<32x32, bf16>, #dram>, interleaved>
+// CHECK: #[[TILED_LAYOUT:.*]] = #ttnn.tensor_config<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!tt.tile<32x32, bf16>, #dram>, interleaved>
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x96xbf16>) -> tensor<64x96xbf16> {
     %0 = tensor.empty() : tensor<64x96xbf16>

--- a/test/ttmlir/Silicon/TTNN/simple_nop.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_nop.mlir
@@ -3,7 +3,7 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 module @jit_convert_element_type attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
   func.func public @main(%arg0: tensor<2x2xf32> {mhlo.layout_mode = "default"}) -> (tensor<2x2xf32> {jax.result_info = "", mhlo.layout_mode = "default"}) {
-    // CHECK: return %arg0 : tensor<2x2xf32, #tensor_config>
+    // CHECK: return %arg0 : tensor<2x2xf32, #ttnn_layout>
     return %arg0 : tensor<2x2xf32>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/simple_nop.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_nop.mlir
@@ -3,7 +3,7 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 module @jit_convert_element_type attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
   func.func public @main(%arg0: tensor<2x2xf32> {mhlo.layout_mode = "default"}) -> (tensor<2x2xf32> {jax.result_info = "", mhlo.layout_mode = "default"}) {
-    // CHECK: return %arg0 : tensor<2x2xf32, #layout>
+    // CHECK: return %arg0 : tensor<2x2xf32, #tensor_config>
     return %arg0 : tensor<2x2xf32>
   }
 }


### PR DESCRIPTION
Replaced the `TTIRLayout` pass with the new `TTNNLayout` pass, which creates a `TensorConfigAttr`. This attribute mirrors the structure of `LayoutAttr` but omits the `OOB` value and excludes functions unused in TTNN. The `TTNNLayout` pass is added before the `TTIRToTTNN` conversion due to the strong dependency on TensorConfigAttr.

* Moved operand constraints from Layout.cpp to separate to Utils for reuse in TTIR and TTNN layout pass
* Moved some functions from TTOpsTypes.cpp to TTOpsTypes.h since we want to use them for both TTIR and TTNN layout pass
* Optimizer - updated all uses of `tt::LayoutAttr` to `ttnn::TensorConfigAttr`
* `ttir::ToLayoutOp` validate check: Removed layout validation in TTIROpsTypes for ToLayoutOp that previously enforced LayoutAttr on inputs and outputs. Depending on the backend (Metal or TTNN), the encoding can differ (LayoutAttr for Metal, TensorConfigAttr for TTNN). Although we could add conditional checks, I wanted to avoid TTNN dependencies in TT libraries, especially with the upcoming removal of layouts.

Note: Renamed the attribute to `TensorConfigAttr` to avoid confusion with existing Layout classes. Maybe better name is `TensorSpecAttr`?