### PR TITLE
adding pagination to find item ids

### DIFF
--- a/.github/workflows/issue-last-updated.yml
+++ b/.github/workflows/issue-last-updated.yml
@@ -8,7 +8,7 @@ on:
     types: [created]
 
 
-env:    
+env:
   GITHUB_TOKEN: ${{ secrets.ISSUE_TOKEN }}
 
 

--- a/.github/workflows/issue-last-updated.yml
+++ b/.github/workflows/issue-last-updated.yml
@@ -8,7 +8,7 @@ on:
     types: [created]
 
 
-env:
+env:    
   GITHUB_TOKEN: ${{ secrets.ISSUE_TOKEN }}
 
 
@@ -21,6 +21,7 @@ jobs:
           echo "project_id=PVT_kwDOA9MHEM4AjeTl" >> $GITHUB_ENV
           echo "field_id=PVTF_lADOA9MHEM4AjeTlzgiiU18" >> $GITHUB_ENV
 
+
       - name: Get Issue ID
         id: get_issue_id
         run: |
@@ -31,18 +32,94 @@ jobs:
 
 
       - name: Get Item ID for Issue
-        id: get_item_by_issue_id
+        id: get_item_id_by_issue_id
         run: |
-          ITEM_ID=$(curl -X POST -H "Authorization: Bearer $GITHUB_TOKEN" \
-               -H "Content-Type: application/json" \
-               -d '{
-                 "query": "query($projectId: ID!) { node(id: $projectId) { ... on ProjectV2 { items(first: 100) { nodes { id content { ... on Issue { id } } } } } } }",
-                 "variables": {
-                   "projectId": "'"${{ env.project_id }}"'"
-                 }
-               }' \
-               https://api.github.com/graphql | jq -r '.data.node.items.nodes[] | select(.content.id=="'"${{ env.issue_id }}"'") | .id')
-          echo "ITEM_ID=$ITEM_ID" >> $GITHUB_ENV
+          # Initialize variables
+          CURSOR=null
+          ITEM_ID=""
+
+
+          # Define the GraphQL query as a string
+          QUERY='query($projectId: ID!, $cursor: String) {
+            node(id: $projectId) {
+              ... on ProjectV2 {
+                items(first: 100, after: $cursor) {
+                  nodes {
+                    id
+                    content {
+                      ... on Issue {
+                        id
+                      }
+                    }
+                  }
+                  pageInfo {
+                    hasNextPage
+                    endCursor
+                  }
+                }
+              }
+            }
+          }'
+
+
+          while : ; do
+            # Construct JSON payload using jq for proper formatting
+            JSON_PAYLOAD=$(jq -n \
+              --arg query "$QUERY" \
+              --arg projectId "$PROJECT_ID" \
+              --arg cursor "$CURSOR" \
+              '{ query: $query, variables: { projectId: $projectId, cursor: $cursor }}')
+
+
+            # Make the GraphQL request
+            RESPONSE=$(curl -s -X POST -H "Authorization: Bearer $GITHUB_TOKEN" \
+                                 -H "Content-Type: application/json" \
+                                 -d "$JSON_PAYLOAD" \
+                                 https://api.github.com/graphql)
+
+
+            # Debug: print entire response
+            echo "RESPONSE: $RESPONSE"
+
+
+            # Check if the response contains `items` data
+            ITEMS_DATA=$(echo "$RESPONSE" | jq -r '.data.node.items.nodes' 2>/dev/null)
+            if [[ "$ITEMS_DATA" == "null" ]]; then
+              echo "Error: Items data not found. Please check your PROJECT_ID and GITHUB_TOKEN permissions."
+              break
+            fi
+
+
+            # Parse the item ID if it matches the ISSUE_NODE_ID
+            ITEM_ID=$(echo "$RESPONSE" | jq -r --arg ISSUE_NODE_ID "$ISSUE_NODE_ID" \
+                       '.data.node.items.nodes[] | select(.content.id==$ISSUE_NODE_ID) | .id')
+
+
+            # If ITEM_ID is found, output it and stop the loop
+            if [[ -n "$ITEM_ID" && "$ITEM_ID" != "null" ]]; then
+              echo "Found ITEM_ID: $ITEM_ID"
+              echo "ITEM_ID=$ITEM_ID" >> $GITHUB_ENV  # Save ITEM_ID to environment for future steps
+              break
+            fi
+
+
+            # Extract pagination information
+            HAS_NEXT_PAGE=$(echo "$RESPONSE" | jq -r '.data.node.items.pageInfo.hasNextPage')
+            CURSOR=$(echo "$RESPONSE" | jq -r '.data.node.items.pageInfo.endCursor')
+
+
+            # If no more pages, exit loop
+            if [[ "$HAS_NEXT_PAGE" != "true" ]]; then
+              echo "Issue not found in project items."
+              break
+            fi
+          done
+
+
+      - name: Use Found ITEM_ID
+        if: env.ITEM_ID  # Only runs if ITEM_ID was set
+        run: echo "The ITEM_ID is ${{ env.ITEM_ID }}"
+
 
       - name: Update Project Field
         run: |


### PR DESCRIPTION
The existing workflow will only work if the issue ID is found in the first  100 ITEM_IDs.

These updates should enable pagination to occur through all the existing issues.

I attempt to use `items(last: 100, before: $cursor) {` 
under the assumption that it would be faster to find the latest issues, however this functionality wasn't working with the API when I was testing it locally.

I got this code to run locally and paginate through the issues as expected(code below so this workflow update is to add this to the `get_item_id_by_issue_id` section of the workflow.

Please let me know what feedback or if you think there is a better way to accomplish this. 


```
#!/bin/bash

# Replace these with your actual values
GITHUB_TOKEN="YOUR_GITHUB_TOKEN"
PROJECT_ID="PVT_kwDOA9MHEM4AjeTl"  # Example Project ID
ISSUE_NODE_ID="I_kwDOMKpl8c6eFjOV"  # Example Issue Node ID to search for

# Initialize variables
CURSOR="null"
ITEM_ID=""

# Define GraphQL query as a string
QUERY='query($projectId: ID!, $cursor: String) {
  node(id: $projectId) {
    ... on ProjectV2 {
      items(first: 100, after: $cursor) {
        nodes {
          id
          content {
            ... on Issue {
              id
            }
          }
        }
        pageInfo {
          hasNextPage
          endCursor
        }
      }
    }
  }
}'

while : ; do
  # Construct JSON payload using jq for proper formatting
  JSON_PAYLOAD=$(jq -n \
    --arg query "$QUERY" \
    --arg projectId "$PROJECT_ID" \
    --arg cursor "$CURSOR" \
    '{ query: $query, variables: { projectId: $projectId, cursor: $cursor }}')

  # Make the GraphQL request
  RESPONSE=$(curl -s -X POST -H "Authorization: Bearer $GITHUB_TOKEN" \
                       -H "Content-Type: application/json" \
                       -d "$JSON_PAYLOAD" \
                       https://api.github.com/graphql)

  # Debug: print entire response
  echo "RESPONSE: $RESPONSE"

  # Check if the response contains `items` data
  ITEMS_DATA=$(echo "$RESPONSE" | jq -r '.data.node.items.nodes' 2>/dev/null)
  if [[ "$ITEMS_DATA" == "null" ]]; then
    echo "Error: Items data not found. Please check your PROJECT_ID and GITHUB_TOKEN permissions."
    break
  fi

  # Parse the item ID if it matches the ISSUE_NODE_ID
  ITEM_ID=$(echo "$RESPONSE" | jq -r --arg ISSUE_NODE_ID "$ISSUE_NODE_ID" \
             '.data.node.items.nodes[] | select(.content.id==$ISSUE_NODE_ID) | .id')

  # If ITEM_ID is found, output it and stop the loop
  if [[ -n "$ITEM_ID" && "$ITEM_ID" != "null" ]]; then
    echo "Found ITEM_ID: $ITEM_ID"
    break
  fi

  # Extract pagination information
  HAS_NEXT_PAGE=$(echo "$RESPONSE" | jq -r '.data.node.items.pageInfo.hasNextPage')
  CURSOR=$(echo "$RESPONSE" | jq -r '.data.node.items.pageInfo.endCursor')

  # If no more pages, exit loop
  if [[ "$HAS_NEXT_PAGE" != "true" ]]; then
    echo "Issue not found in project items."
    break
  fi
done
```

