### PR TITLE
[Runtime][Minor fix] Support for creating uint typtes in ttrt

### DIFF
--- a/runtime/tools/python/ttrt/common/run.py
+++ b/runtime/tools/python/ttrt/common/run.py
@@ -641,6 +641,10 @@ class Run:
         def randn(shape, dtype):
             import torch
 
+            if dtype in (torch.uint8, torch.uint16, torch.uint32):
+                high = torch.iinfo(dtype).max + 1
+                return torch.randint(0, high, shape, dtype=dtype)
+
             return torch.randn(shape, dtype=dtype)
 
         @staticmethod

--- a/test/ttmlir/Silicon/TTNN/simple_add.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_add.mlir
@@ -1,0 +1,8 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
+func.func @add(%arg0: tensor<64x128xi32>, %arg1: tensor<64x128xi32>) -> tensor<64x128xi32> {
+  %0 = tensor.empty() : tensor<64x128xi32>
+  %1 = "ttir.add"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<64x128xi32>, tensor<64x128xi32>, tensor<64x128xi32>) -> tensor<64x128xi32>
+  return %1 : tensor<64x128xi32>
+}

--- a/test/ttmlir/Silicon/TTNN/simple_add.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_add.mlir
@@ -1,8 +1,0 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
-// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
-func.func @add(%arg0: tensor<64x128xi32>, %arg1: tensor<64x128xi32>) -> tensor<64x128xi32> {
-  %0 = tensor.empty() : tensor<64x128xi32>
-  %1 = "ttir.add"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<64x128xi32>, tensor<64x128xi32>, tensor<64x128xi32>) -> tensor<64x128xi32>
-  return %1 : tensor<64x128xi32>
-}

--- a/test/ttmlir/Silicon/TTNN/simple_eltwise.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_eltwise.mlir
@@ -281,3 +281,9 @@ func.func @gelu(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
   %1 = "ttir.gelu"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>, operand_constraints = [#any_device, #any_device]}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
   return %1 : tensor<64x128xf32>
 }
+
+func.func @addint32(%arg0: tensor<64x128xi32>, %arg1: tensor<64x128xi32>) -> tensor<64x128xi32> {
+  %0 = tensor.empty() : tensor<64x128xi32>
+  %1 = "ttir.add"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<64x128xi32>, tensor<64x128xi32>, tensor<64x128xi32>) -> tensor<64x128xi32>
+  return %1 : tensor<64x128xi32>
+}


### PR DESCRIPTION
Currently we convert all integer types (int/uint) to uint since metal only supports uint. TTRT doesn't support creating uint tensors (it throws exeception).