### PR TITLE
Erase reduce_window init values

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -775,15 +775,10 @@ def TTIR_PoolingOp : TTIR_DPSOp<"pooling", [AttrSizedOperandSegments]> {
     Variadic<AnyRankedTensor>:$outputs,
     TTIR_PoolingMethodAttr:$pooling_method,
     DenseI64ArrayAttr:$window_dimensions,
-
-    // Default stride of 1 over every dimension
-    DefaultValuedOptionalAttr<DenseI64ArrayAttr, "SmallVector<int64_t>(getWindowDimensions().size(), 1)">:$window_strides,
-    // Default dilation of 1 over every dimension
-    DefaultValuedOptionalAttr<DenseI64ArrayAttr, "SmallVector<int64_t>(getWindowDimensions().size(), 1)">:$base_dilations,
-    // Default dilation of 1 over every dimension
-    DefaultValuedOptionalAttr<DenseI64ArrayAttr, "SmallVector<int64_t>(getWindowDimensions().size(), 1)">:$window_dilations,
-    // Default padding of 0 over every dimension
-    DefaultValuedOptionalAttr<DenseI64ArrayAttr, "SmallVector<int64_t>(getWindowDimensions().size() * 2, 0)">:$padding,
+    DenseI64ArrayAttr:$window_strides,
+    DenseI64ArrayAttr:$base_dilations,
+    DenseI64ArrayAttr:$window_dilations,
+    DenseI64ArrayAttr:$padding,
     TT_OperandConstraintArrayAttr:$operand_constraints
   );
 

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -58,6 +58,14 @@ namespace mlir::tt::ttnn {
 ::mlir::LogicalResult mlir::tt::ttnn::MaxPool2dOp::verify() {
   ::mlir::RankedTensorType inputType = getInput().getType();
   ::llvm::ArrayRef<int64_t> inputShape = getInput().getType().getShape();
+
+  if (!inputType.getElementType().isBF16()) {
+    return emitOpError()
+           << "ttnn.max_pool2d currently only supports an input type of "
+              "bfloat16. Recieved "
+           << inputType.getElementType() << ".";
+  }
+
   if (getKernelHeight() > getInputHeight()) {
     return emitOpError() << "Kernel height " << getKernelHeight()
                          << " is greater than input height " << getInputHeight()

--- a/test/ttmlir/Dialect/TTNN/pooling/complex_pooling.mlir
+++ b/test/ttmlir/Dialect/TTNN/pooling/complex_pooling.mlir
@@ -10,6 +10,9 @@ module attributes {} {
         pooling_method = #ttir<pooling_method Max>,
         window_dimensions = array<i64: 1, 1, 2, 2>,
         window_strides = array<i64: 1, 1, 2, 2>,
+        base_dilations = array<i64: 1, 1, 1, 1>,
+        window_dilations = array<i64: 1, 1, 1, 1>,
+        padding = array<i64: 0, 0, 0, 0, 0, 0, 0, 0>,
         operand_constraints = [#any_device, #any_device]}> : (tensor<1x32x128x128xbf16>, tensor<1x32x128x128xbf16>, tensor<1x32x64x64xbf16>, tensor<1x32x64x64xbf16>) -> (tensor<1x32x64x64xbf16>, tensor<1x32x64x64xbf16>)
 
     %4 = tensor.empty() : tensor<1x32x64x64xbf16>

--- a/test/ttmlir/Dialect/TTNN/pooling/simple_pooling.mlir
+++ b/test/ttmlir/Dialect/TTNN/pooling/simple_pooling.mlir
@@ -9,6 +9,9 @@ module attributes {} {
         pooling_method = #ttir<pooling_method Max>,
         window_dimensions = array<i64: 1, 1, 2, 2>,
         window_strides = array<i64: 1, 1, 2, 2>,
+        base_dilations = array<i64: 1, 1, 1, 1>,
+        window_dilations = array<i64: 1, 1, 1, 1>,
+        padding = array<i64: 0, 0, 0, 0, 0, 0, 0, 0>,
         operand_constraints = [#any_device, #any_device]}> : (tensor<1x32x128x128xbf16>, tensor<1x32x64x64xbf16>) -> tensor<1x32x64x64xbf16>
     return %1 : tensor<1x32x64x64xbf16>
   }

--- a/test/ttmlir/Silicon/TTNN/pooling/complex_pooling.mlir
+++ b/test/ttmlir/Silicon/TTNN/pooling/complex_pooling.mlir
@@ -12,6 +12,9 @@ module attributes {} {
         pooling_method = #ttir<pooling_method Max>,
         window_dimensions = array<i64: 1, 1, 2, 2>,
         window_strides = array<i64: 1, 1, 2, 2>,
+        base_dilations = array<i64: 1, 1, 1, 1>,
+        window_dilations = array<i64: 1, 1, 1, 1>,
+        padding = array<i64: 0, 0, 0, 0, 0, 0, 0, 0>,
         operand_constraints = [#any_device, #any_device]}> : (tensor<1x32x128x128xbf16>, tensor<1x32x128x128xbf16>, tensor<1x32x64x64xbf16>, tensor<1x32x64x64xbf16>) -> (tensor<1x32x64x64xbf16>, tensor<1x32x64x64xbf16>)
     return %2, %3 : tensor<1x32x64x64xbf16>,tensor<1x32x64x64xbf16>
   }

--- a/test/ttmlir/Silicon/TTNN/pooling/simple_pooling.mlir
+++ b/test/ttmlir/Silicon/TTNN/pooling/simple_pooling.mlir
@@ -11,6 +11,9 @@ module attributes {} {
         pooling_method = #ttir<pooling_method Max>,
         window_dimensions = array<i64: 1, 1, 2, 2>,
         window_strides = array<i64: 1, 1, 2, 2>,
+        base_dilations = array<i64: 1, 1, 1, 1>,
+        window_dilations = array<i64: 1, 1, 1, 1>,
+        padding = array<i64: 0, 0, 0, 0, 0, 0, 0, 0>,
         operand_constraints = [#any_device, #any_device]}> : (tensor<1x32x128x128xbf16>, tensor<1x32x64x64xbf16>) -> tensor<1x32x64x64xbf16>
     return %1 : tensor<1x32x64x64xbf16>
   }


### PR DESCRIPTION
The crash reported in this issue comes from the initialization of a tensor using `ttnn.full`. However, this `ttnn.full` call is actually dangling code and should be removed from the program entirely. 

Also fixed a bug where inputs with non-bf16 data formats wouldn't pattern match when converting from `stablehlo.reduce_window`. There is now a verification for `ttnn.max_pool2d` that will return an error if the input is not bf16.

Issue: https://github.com/tenstorrent/tt-xla/issues/64