### PR TITLE
Added maybe_downcast & hardened TT Attrs and Types to include better support

### DIFF
--- a/include/ttmlir-c/TTAttrs.h
+++ b/include/ttmlir-c/TTAttrs.h
@@ -75,6 +75,14 @@ MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTOperandConstraintArrayAttrGet(
     MlirContext ctx, uint32_t *OperandConstraints,
     size_t OperandConstraintsSize);
 
+MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTTileSizeAttrGet(MlirContext ctx,
+                                                         int64_t y, int64_t x);
+
+MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTChipPhysicalCoresAttrGet(
+    MlirContext ctx, MlirAttribute *worker, size_t workerSize,
+    MlirAttribute *dram, size_t dramSize, MlirAttribute *eth, size_t ethSize,
+    MlirAttribute *eth_inactive, size_t eth_inactiveSize);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/ttmlir/Bindings/Python/TTMLIRModule.h
+++ b/include/ttmlir/Bindings/Python/TTMLIRModule.h
@@ -33,10 +33,10 @@ py::class_<T> tt_attribute_class(py::module &m, const char *class_name) {
   cls.def_static("maybe_downcast",
                  [](MlirAttribute attr) -> std::variant<T, py::object> {
                    auto res = mlir::dyn_cast<T>(unwrap(attr));
-                   if (res)
+                   if (res) {
                      return res;
-                   else
-                     return py::none();
+                   }
+                   return py::none();
                  });
   return cls;
 }
@@ -47,10 +47,10 @@ py::class_<T> tt_type_class(py::module &m, const char *class_name) {
   cls.def_static("maybe_downcast",
                  [](MlirType type) -> std::variant<T, py::object> {
                    auto res = mlir::dyn_cast<T>(unwrap(type));
-                   if (res)
+                   if (res) {
                      return res;
-                   else
-                     return py::none();
+                   }
+                   return py::none();
                  });
   return cls;
 }

--- a/include/ttmlir/Bindings/Python/TTMLIRModule.h
+++ b/include/ttmlir/Bindings/Python/TTMLIRModule.h
@@ -21,9 +21,40 @@
 #include "ttmlir/RegisterAll.h"
 #include "llvm/Support/CommandLine.h"
 
+#include <variant>
+
 namespace py = pybind11;
 
 namespace mlir::ttmlir::python {
+
+template <typename T>
+py::class_<T> tt_attribute_class(py::module &m, const char *class_name) {
+  py::class_<T> cls(m, class_name);
+  cls.def_static("maybe_downcast",
+                 [](MlirAttribute attr) -> std::variant<T, py::object> {
+                   auto res = mlir::dyn_cast<T>(unwrap(attr));
+                   if (res)
+                     return res;
+                   else
+                     return py::none();
+                 });
+  return cls;
+}
+
+template <typename T>
+py::class_<T> tt_type_class(py::module &m, const char *class_name) {
+  py::class_<T> cls(m, class_name);
+  cls.def_static("maybe_downcast",
+                 [](MlirType type) -> std::variant<T, py::object> {
+                   auto res = mlir::dyn_cast<T>(unwrap(type));
+                   if (res)
+                     return res;
+                   else
+                     return py::none();
+                 });
+  return cls;
+}
+
 void populateTTModule(py::module &m);
 void populateTTIRModule(py::module &m);
 void populateTTKernelModule(py::module &m);

--- a/lib/CAPI/TTAttrs.cpp
+++ b/lib/CAPI/TTAttrs.cpp
@@ -182,4 +182,34 @@ ttmlirTTOperandConstraintArrayAttrGet(MlirContext ctx,
   return wrap(ArrayAttr::get(unwrap(ctx), operandConstraintsArray));
 }
 
+MlirAttribute ttmlirTTTileSizeAttrGet(MlirContext ctx, int64_t y, int64_t x) {
+  return wrap(TileSizeAttr::get(unwrap(ctx), y, x));
+}
+
+MlirAttribute ttmlirTTChipPhysicalCoresAttrGet(
+    MlirContext ctx, MlirAttribute *worker, size_t workerSize,
+    MlirAttribute *dram, size_t dramSize, MlirAttribute *eth, size_t ethSize,
+    MlirAttribute *eth_inactive, size_t eth_inactiveSize) {
+  std::vector<CoreCoordAttr> workerVec, dramVec, ethVec, ethInactiveVec;
+  for (size_t i = 0; i < workerSize; i++) {
+    workerVec.push_back(mlir::cast<CoreCoordAttr>(unwrap(worker[i])));
+  }
+
+  for (size_t i = 0; i < dramSize; i++) {
+    dramVec.push_back(mlir::cast<CoreCoordAttr>(unwrap(dram[i])));
+  }
+
+  for (size_t i = 0; i < ethSize; i++) {
+    ethVec.push_back(mlir::cast<CoreCoordAttr>(unwrap(eth[i])));
+  }
+
+  for (size_t i = 0; i < eth_inactiveSize; i++) {
+    ethInactiveVec.push_back(
+        mlir::cast<CoreCoordAttr>(unwrap(eth_inactive[i])));
+  }
+
+  return wrap(ChipPhysicalCoresAttr::get(unwrap(ctx), workerVec, dramVec,
+                                         ethVec, ethInactiveVec));
+}
+
 } // namespace mlir::tt

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -102,6 +102,7 @@ declare_mlir_python_extension(TTMLIRPythonExtensions.Main
 
 set(TTMLIR_PYTHON_SOURCES
   MLIRPythonSources.Core
+  MLIRPythonSources.Dialects.affine
   MLIRPythonSources.Dialects.arith
   MLIRPythonSources.Dialects.func
   MLIRPythonSources.Dialects.tensor

--- a/python/TTModule.cpp
+++ b/python/TTModule.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
-#include <variant>
 #include <vector>
 
 #include "ttmlir/Bindings/Python/TTMLIRModule.h"
@@ -12,12 +11,7 @@
 #include "mlir/CAPI/IR.h"
 
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wcovered-switch-default"
-#include "ttmlir/Target/Common/types_generated.h"
-#pragma clang diagnostic pop
-
+#include "ttmlir/Target/Common/Target.h"
 #include "ttmlir/Utils.h"
 
 namespace mlir::ttmlir::python {

--- a/python/TTModule.cpp
+++ b/python/TTModule.cpp
@@ -22,7 +22,7 @@
 
 namespace mlir::ttmlir::python {
 void populateTTModule(py::module &m) {
-  py::class_<tt::LayoutAttr>(m, "LayoutAttr")
+  tt_attribute_class<tt::LayoutAttr>(m, "LayoutAttr")
       .def_static("get",
                   [](MlirContext ctx, MlirType rankedTensorType,
                      uint32_t memorySpaceValue, MlirAttribute grid,
@@ -109,85 +109,48 @@ void populateTTModule(py::module &m) {
         return static_cast<uint32_t>(la.getMemLayout());
       });
 
-  py::class_<tt::GridAttr>(m, "GridAttr")
+  tt_attribute_class<tt::GridAttr>(m, "GridAttr")
       .def_static("get",
                   [](MlirContext ctx, std::vector<int64_t> shape) {
                     return wrap(tt::GridAttr::get(unwrap(ctx), shape));
                   })
-      .def_static(
-          "maybe_downcast",
-          [](MlirAttribute attr) -> std::variant<tt::GridAttr, py::object> {
-            auto res = mlir::dyn_cast<tt::GridAttr>(unwrap(attr));
-            if (res)
-              return res;
-            else
-              return py::none();
-          })
       .def_property_readonly(
           "shape", [](tt::GridAttr const &ga) { return ga.getShape().vec(); });
 
-  py::class_<tt::ChipCapabilityAttr>(m, "ChipCapabilityAttr")
+  tt_attribute_class<tt::ChipCapabilityAttr>(m, "ChipCapabilityAttr")
       .def_static(
           "get",
           [](MlirContext ctx, uint32_t chipCapability) {
             return wrap(tt::ChipCapabilityAttr::get(
                 unwrap(ctx), static_cast<tt::ChipCapability>(chipCapability)));
           })
-      .def_static("maybe_downcast",
-                  [](MlirAttribute attr)
-                      -> std::variant<tt::ChipCapabilityAttr, py::object> {
-                    auto res =
-                        mlir::dyn_cast<tt::ChipCapabilityAttr>(unwrap(attr));
-                    if (res)
-                      return res;
-                    else
-                      return py::none();
-                  })
       .def_property_readonly("capability_as_int",
                              [](tt::ChipCapabilityAttr self) {
                                return static_cast<uint32_t>(self.getValue());
                              });
 
-  py::class_<tt::ArchAttr>(m, "ArchAttr")
+  tt_attribute_class<tt::ArchAttr>(m, "ArchAttr")
       .def_static("get",
                   [](MlirContext ctx, uint32_t arch) {
                     return wrap(tt::ArchAttr::get(unwrap(ctx),
                                                   static_cast<tt::Arch>(arch)));
                   })
-      .def_static(
-          "maybe_downcast",
-          [](MlirAttribute attr) -> std::variant<tt::ArchAttr, py::object> {
-            auto res = mlir::dyn_cast<tt::ArchAttr>(unwrap(attr));
-            if (res)
-              return res;
-            else
-              return py::none();
-          })
       .def_property_readonly("arch_as_int", [](tt::ArchAttr self) {
         return static_cast<uint32_t>(self.getValue());
       });
 
-  py::class_<tt::DataTypeAttr>(m, "DataTypeAttr")
+  tt_attribute_class<tt::DataTypeAttr>(m, "DataTypeAttr")
       .def_static(
           "get",
           [](MlirContext ctx, uint16_t *supportedDataTypes) {
             return wrap(tt::DataTypeAttr::get(
                 unwrap(ctx), static_cast<tt::DataType>(*supportedDataTypes)));
           })
-      .def_static(
-          "maybe_downcast",
-          [](MlirAttribute attr) -> std::variant<tt::DataTypeAttr, py::object> {
-            auto res = mlir::dyn_cast<tt::DataTypeAttr>(unwrap(attr));
-            if (res)
-              return res;
-            else
-              return py::none();
-          })
       .def_property_readonly("data_type_as_int", [](tt::DataTypeAttr self) {
         return static_cast<uint16_t>(self.getValue());
       });
 
-  py::class_<tt::ChipDescAttr>(m, "ChipDescAttr")
+  tt_attribute_class<tt::ChipDescAttr>(m, "ChipDescAttr")
       .def_static(
           "get",
           [](MlirContext ctx, MlirAttribute arch, std::vector<int64_t> grid,
@@ -209,15 +172,6 @@ void populateTTModule(py::module &m) {
                 mlir::cast<tt::DataTypeAttr>(unwrap(supportedDataTypes)),
                 mlir::cast<tt::TileSizeAttr>(unwrap(supportedTileSizes)),
                 numCBs));
-          })
-      .def_static(
-          "maybe_downcast",
-          [](MlirAttribute attr) -> std::variant<tt::ChipDescAttr, py::object> {
-            auto res = mlir::dyn_cast<tt::ChipDescAttr>(unwrap(attr));
-            if (res)
-              return res;
-            else
-              return py::none();
           })
       .def_property_readonly("usable_l1_size",
                              &tt::ChipDescAttr::getUsableL1Size)
@@ -257,24 +211,15 @@ void populateTTModule(py::module &m) {
                              })
       .def_property_readonly("num_cbs", &tt::ChipDescAttr::getNumCBs);
 
-  py::class_<tt::TileSizeAttr>(m, "TileSizeAttr")
+  tt_attribute_class<tt::TileSizeAttr>(m, "TileSizeAttr")
       .def_static("get",
                   [](MlirContext ctx, int64_t y, int64_t x) {
                     return wrap(tt::TileSizeAttr::get(unwrap(ctx), y, x));
                   })
-      .def_static(
-          "maybe_downcast",
-          [](MlirAttribute attr) -> std::variant<tt::TileSizeAttr, py::object> {
-            auto res = mlir::dyn_cast<tt::TileSizeAttr>(unwrap(attr));
-            if (res)
-              return res;
-            else
-              return py::none();
-          })
       .def_property_readonly("y", &tt::TileSizeAttr::getY)
       .def_property_readonly("x", &tt::TileSizeAttr::getX);
 
-  py::class_<tt::ChipPhysicalCoresAttr>(m, "ChipPhysicalCoresAttr")
+  tt_attribute_class<tt::ChipPhysicalCoresAttr>(m, "ChipPhysicalCoresAttr")
       .def_static("get",
                   [](MlirContext ctx, std::vector<tt::CoreCoordAttr> worker,
                      std::vector<tt::CoreCoordAttr> dram,
@@ -282,16 +227,6 @@ void populateTTModule(py::module &m) {
                      std::vector<tt::CoreCoordAttr> eth_inactive) {
                     return wrap(tt::ChipPhysicalCoresAttr::get(
                         unwrap(ctx), worker, dram, eth, eth_inactive));
-                  })
-      .def_static("maybe_downcast",
-                  [](MlirAttribute attr)
-                      -> std::variant<tt::ChipPhysicalCoresAttr, py::object> {
-                    auto res =
-                        mlir::dyn_cast<tt::ChipPhysicalCoresAttr>(unwrap(attr));
-                    if (res)
-                      return res;
-                    else
-                      return py::none();
                   })
       .def_property_readonly(
           "worker",
@@ -307,28 +242,19 @@ void populateTTModule(py::module &m) {
                                return self.getEthInactive().vec();
                              });
 
-  py::class_<tt::ChipCoordAttr>(m, "ChipCoordAttr")
+  tt_attribute_class<tt::ChipCoordAttr>(m, "ChipCoordAttr")
       .def_static("get",
                   [](MlirContext ctx, unsigned rack, unsigned shelf, unsigned y,
                      unsigned x) {
                     return wrap(
                         tt::ChipCoordAttr::get(unwrap(ctx), rack, shelf, y, x));
                   })
-      .def_static("maybe_downcast",
-                  [](MlirAttribute attr)
-                      -> std::variant<tt::ChipCoordAttr, py::object> {
-                    auto res = mlir::dyn_cast<tt::ChipCoordAttr>(unwrap(attr));
-                    if (res)
-                      return res;
-                    else
-                      return py::none();
-                  })
       .def_property_readonly("rack", &tt::ChipCoordAttr::getRack)
       .def_property_readonly("shelf", &tt::ChipCoordAttr::getShelf)
       .def_property_readonly("y", &tt::ChipCoordAttr::getY)
       .def_property_readonly("x", &tt::ChipCoordAttr::getX);
 
-  py::class_<tt::ChipChannelAttr>(m, "ChipChannelAttr")
+  tt_attribute_class<tt::ChipChannelAttr>(m, "ChipChannelAttr")
       .def_static(
           "get",
           [](MlirContext ctx, unsigned deviceId0,
@@ -338,16 +264,6 @@ void populateTTModule(py::module &m) {
                                                  ethernetCoreCoord0, deviceId1,
                                                  ethernetCoreCoord1));
           })
-      .def_static("maybe_downcast",
-                  [](MlirAttribute attr)
-                      -> std::variant<tt::ChipChannelAttr, py::object> {
-                    auto res =
-                        mlir::dyn_cast<tt::ChipChannelAttr>(unwrap(attr));
-                    if (res)
-                      return res;
-                    else
-                      return py::none();
-                  })
       .def_property_readonly("device_id0", &tt::ChipChannelAttr::getDeviceId0)
       .def_property_readonly("ethernet_core_coord0",
                              [](tt::ChipChannelAttr self) {
@@ -359,7 +275,7 @@ void populateTTModule(py::module &m) {
                                return self.getEthernetCoreCoord1().vec();
                              });
 
-  py::class_<tt::SystemDescAttr>(m, "SystemDescAttr")
+  tt_attribute_class<tt::SystemDescAttr>(m, "SystemDescAttr")
       .def_static("get_default",
                   [](MlirContext ctx) {
                     return wrap(tt::SystemDescAttr::getDefault(unwrap(ctx)));
@@ -396,15 +312,6 @@ void populateTTModule(py::module &m) {
                 chipCapabilitiesUnwrapped, chipCoordsUnwrapped,
                 chipChannelsUnwrapped));
           })
-      .def_static("maybe_downcast",
-                  [](MlirAttribute attr)
-                      -> std::variant<tt::SystemDescAttr, py::object> {
-                    auto res = mlir::dyn_cast<tt::SystemDescAttr>(unwrap(attr));
-                    if (res)
-                      return res;
-                    else
-                      return py::none();
-                  })
       .def_property_readonly(
           "chip_descs",
           [](tt::SystemDescAttr self) { return self.getChipDescs().vec(); })
@@ -423,92 +330,53 @@ void populateTTModule(py::module &m) {
         return self.getChipChannels().vec();
       });
 
-  py::class_<tt::MemorySpaceAttr>(m, "MemorySpaceAttr")
+  tt_attribute_class<tt::MemorySpaceAttr>(m, "MemorySpaceAttr")
       .def_static(
           "get",
           [](MlirContext ctx, uint32_t memorySpace) {
             return wrap(tt::MemorySpaceAttr::get(
                 unwrap(ctx), static_cast<tt::MemorySpace>(memorySpace)));
           })
-      .def_static("maybe_downcast",
-                  [](MlirAttribute attr)
-                      -> std::variant<tt::MemorySpaceAttr, py::object> {
-                    auto res =
-                        mlir::dyn_cast<tt::MemorySpaceAttr>(unwrap(attr));
-                    if (res)
-                      return res;
-                    else
-                      return py::none();
-                  })
       .def_property_readonly("memory_space_as_int",
                              [](tt::MemorySpaceAttr self) {
                                return static_cast<uint32_t>(self.getValue());
                              });
 
-  py::class_<tt::OOBValAttr>(m, "OOBValAttr")
+  tt_attribute_class<tt::OOBValAttr>(m, "OOBValAttr")
       .def_static("get",
                   [](MlirContext ctx, uint32_t oobVal) {
                     return wrap(tt::OOBValAttr::get(
                         unwrap(ctx), static_cast<tt::OOBVal>(oobVal)));
                   })
-      .def_static(
-          "maybe_downcast",
-          [](MlirAttribute attr) -> std::variant<tt::OOBValAttr, py::object> {
-            auto res = mlir::dyn_cast<tt::OOBValAttr>(unwrap(attr));
-            if (res)
-              return res;
-            else
-              return py::none();
-          })
       .def_property_readonly("oob_val_as_int", [](tt::OOBValAttr self) {
         return static_cast<uint32_t>(self.getValue());
       });
 
-  py::class_<tt::TensorMemoryLayoutAttr>(m, "TensorMemoryLayoutAttr")
+  tt_attribute_class<tt::TensorMemoryLayoutAttr>(m, "TensorMemoryLayoutAttr")
       .def_static(
           "get",
           [](MlirContext ctx, uint32_t memLayout) {
             return wrap(tt::TensorMemoryLayoutAttr::get(
                 unwrap(ctx), static_cast<tt::TensorMemoryLayout>(memLayout)));
           })
-      .def_static("maybe_downcast",
-                  [](MlirAttribute attr)
-                      -> std::variant<tt::TensorMemoryLayoutAttr, py::object> {
-                    auto res = mlir::dyn_cast<tt::TensorMemoryLayoutAttr>(
-                        unwrap(attr));
-                    if (res)
-                      return res;
-                    else
-                      return py::none();
-                  })
       .def_property_readonly("mem_layout_as_int",
                              [](tt::TensorMemoryLayoutAttr self) {
                                return static_cast<uint32_t>(self.getValue());
                              });
 
-  py::class_<tt::IteratorTypeAttr>(m, "IteratorTypeAttr")
+  tt_attribute_class<tt::IteratorTypeAttr>(m, "IteratorTypeAttr")
       .def_static(
           "get",
           [](MlirContext ctx, uint32_t iteratorType) {
             return wrap(tt::IteratorTypeAttr::get(
                 unwrap(ctx), static_cast<tt::IteratorType>(iteratorType)));
           })
-      .def_static("maybe_downcast",
-                  [](MlirAttribute attr)
-                      -> std::variant<tt::IteratorTypeAttr, py::object> {
-                    auto res =
-                        mlir::dyn_cast<tt::IteratorTypeAttr>(unwrap(attr));
-                    if (res)
-                      return res;
-                    else
-                      return py::none();
-                  })
       .def_property_readonly("iterator_type_as_int",
                              [](tt::IteratorTypeAttr self) {
                                return static_cast<uint32_t>(self.getValue());
                              });
 
-  py::class_<tt::OperandConstraintAttr>(m, "OperandConstraintAttr")
+  tt_attribute_class<tt::OperandConstraintAttr>(m, "OperandConstraintAttr")
       .def_static("get",
                   [](MlirContext ctx, uint32_t operandConstraint) {
                     return wrap(tt::OperandConstraintAttr::get(
@@ -521,42 +389,23 @@ void populateTTModule(py::module &m) {
             return ::ttmlir::utils::wrapArrayOfMlirAttributesAsAttribute(
                 ctx, attributesArray);
           })
-      .def_static("maybe_downcast",
-                  [](MlirAttribute attr)
-                      -> std::variant<tt::OperandConstraintAttr, py::object> {
-                    auto res =
-                        mlir::dyn_cast<tt::OperandConstraintAttr>(unwrap(attr));
-                    if (res)
-                      return res;
-                    else
-                      return py::none();
-                  })
       .def_property_readonly("operand_constraint_as_int",
                              [](tt::OperandConstraintAttr self) {
                                return static_cast<uint32_t>(self.getValue());
                              });
 
-  py::class_<tt::DeviceType>(m, "DeviceType")
+  tt_type_class<tt::DeviceType>(m, "DeviceType")
       .def_static(
           "get",
           [](MlirContext ctx, MlirAttribute deviceAttr) {
             return wrap(tt::DeviceType::get(
                 unwrap(ctx), mlir::cast<tt::DeviceAttr>(unwrap(deviceAttr))));
           })
-      .def_static(
-          "maybe_downcast",
-          [](MlirType type) -> std::variant<tt::DeviceType, py::object> {
-            auto res = mlir::dyn_cast<tt::DeviceType>(unwrap(type));
-            if (res)
-              return res;
-            else
-              return py::none();
-          })
       .def_property_readonly("device_attr", [](tt::DeviceType const &self) {
         return self.getDesc();
       });
 
-  py::class_<tt::DeviceAttr>(m, "DeviceAttr")
+  tt_attribute_class<tt::DeviceAttr>(m, "DeviceAttr")
       .def_static("from_system_desc",
                   [](MlirContext ctx, MlirAttribute systemDesc,
                      std::vector<int64_t> meshShape) {
@@ -586,34 +435,17 @@ void populateTTModule(py::module &m) {
       .def_property_readonly(
           "mesh_shape",
           [](tt::DeviceAttr const &self) { return self.getMeshShape().vec(); })
-      .def_property_readonly(
-          "chip_ids",
-          [](tt::DeviceAttr const &self) { return self.getChipIds().vec(); })
-      .def_static(
-          "maybe_downcast",
-          [](MlirAttribute attr) -> std::variant<tt::DeviceAttr, py::object> {
-            auto res = mlir::dyn_cast<tt::DeviceAttr>(unwrap(attr));
-            if (res)
-              return res;
-            else
-              return py::none();
-          });
+      .def_property_readonly("chip_ids", [](tt::DeviceAttr const &self) {
+        return self.getChipIds().vec();
+      });
 
-  py::class_<tt::TileType>(m, "TileType")
+  tt_type_class<tt::TileType>(m, "TileType")
       .def_static("get",
                   [](MlirContext ctx, std::int64_t height, std::int64_t width,
                      uint32_t dataType) {
                     return wrap(tt::TileType::get(
                         unwrap(ctx), SmallVector<std::int64_t>{height, width},
                         static_cast<tt::DataType>(dataType)));
-                  })
-      .def_static("maybe_downcast",
-                  [](MlirType type) -> std::variant<tt::TileType, py::object> {
-                    auto res = mlir::dyn_cast<tt::TileType>(unwrap(type));
-                    if (res)
-                      return res;
-                    else
-                      return py::none();
                   })
       .def_property_readonly("data_type", &tt::TileType::getDataType)
       .def_property_readonly("shape", [](tt::TileType const &tile) {

--- a/python/TTModule.cpp
+++ b/python/TTModule.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
+#include <variant>
 #include <vector>
 
 #include "ttmlir/Bindings/Python/TTMLIRModule.h"
@@ -11,7 +12,12 @@
 #include "mlir/CAPI/IR.h"
 
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
-#include "ttmlir/Target/Common/Target.h"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#include "ttmlir/Target/Common/types_generated.h"
+#pragma clang diagnostic pop
+
 #include "ttmlir/Utils.h"
 
 namespace mlir::ttmlir::python {
@@ -108,26 +114,77 @@ void populateTTModule(py::module &m) {
                   [](MlirContext ctx, std::vector<int64_t> shape) {
                     return wrap(tt::GridAttr::get(unwrap(ctx), shape));
                   })
-      .def_property_readonly("shape", [](tt::GridAttr const &ga) {
-        return std::vector<int64_t>(ga.getShape().begin(), ga.getShape().end());
-      });
+      .def_static(
+          "maybe_downcast",
+          [](MlirAttribute attr) -> std::variant<tt::GridAttr, py::object> {
+            auto res = mlir::dyn_cast<tt::GridAttr>(unwrap(attr));
+            if (res)
+              return res;
+            else
+              return py::none();
+          })
+      .def_property_readonly(
+          "shape", [](tt::GridAttr const &ga) { return ga.getShape().vec(); });
 
   py::class_<tt::ChipCapabilityAttr>(m, "ChipCapabilityAttr")
-      .def_static("get", [](MlirContext ctx, uint32_t chipCapability) {
-        return wrap(tt::ChipCapabilityAttr::get(
-            unwrap(ctx), static_cast<tt::ChipCapability>(chipCapability)));
-      });
+      .def_static(
+          "get",
+          [](MlirContext ctx, uint32_t chipCapability) {
+            return wrap(tt::ChipCapabilityAttr::get(
+                unwrap(ctx), static_cast<tt::ChipCapability>(chipCapability)));
+          })
+      .def_static("maybe_downcast",
+                  [](MlirAttribute attr)
+                      -> std::variant<tt::ChipCapabilityAttr, py::object> {
+                    auto res =
+                        mlir::dyn_cast<tt::ChipCapabilityAttr>(unwrap(attr));
+                    if (res)
+                      return res;
+                    else
+                      return py::none();
+                  })
+      .def_property_readonly("capability_as_int",
+                             [](tt::ChipCapabilityAttr self) {
+                               return static_cast<uint32_t>(self.getValue());
+                             });
 
   py::class_<tt::ArchAttr>(m, "ArchAttr")
-      .def_static("get", [](MlirContext ctx, uint32_t arch) {
-        return wrap(
-            tt::ArchAttr::get(unwrap(ctx), static_cast<tt::Arch>(arch)));
+      .def_static("get",
+                  [](MlirContext ctx, uint32_t arch) {
+                    return wrap(tt::ArchAttr::get(unwrap(ctx),
+                                                  static_cast<tt::Arch>(arch)));
+                  })
+      .def_static(
+          "maybe_downcast",
+          [](MlirAttribute attr) -> std::variant<tt::ArchAttr, py::object> {
+            auto res = mlir::dyn_cast<tt::ArchAttr>(unwrap(attr));
+            if (res)
+              return res;
+            else
+              return py::none();
+          })
+      .def_property_readonly("arch_as_int", [](tt::ArchAttr self) {
+        return static_cast<uint32_t>(self.getValue());
       });
 
   py::class_<tt::DataTypeAttr>(m, "DataTypeAttr")
-      .def_static("get", [](MlirContext ctx, uint16_t *supportedDataTypes) {
-        return wrap(tt::DataTypeAttr::get(
-            unwrap(ctx), static_cast<tt::DataType>(*supportedDataTypes)));
+      .def_static(
+          "get",
+          [](MlirContext ctx, uint16_t *supportedDataTypes) {
+            return wrap(tt::DataTypeAttr::get(
+                unwrap(ctx), static_cast<tt::DataType>(*supportedDataTypes)));
+          })
+      .def_static(
+          "maybe_downcast",
+          [](MlirAttribute attr) -> std::variant<tt::DataTypeAttr, py::object> {
+            auto res = mlir::dyn_cast<tt::DataTypeAttr>(unwrap(attr));
+            if (res)
+              return res;
+            else
+              return py::none();
+          })
+      .def_property_readonly("data_type_as_int", [](tt::DataTypeAttr self) {
+        return static_cast<uint16_t>(self.getValue());
       });
 
   py::class_<tt::ChipDescAttr>(m, "ChipDescAttr")
@@ -152,84 +209,304 @@ void populateTTModule(py::module &m) {
                 mlir::cast<tt::DataTypeAttr>(unwrap(supportedDataTypes)),
                 mlir::cast<tt::TileSizeAttr>(unwrap(supportedTileSizes)),
                 numCBs));
-          });
+          })
+      .def_static(
+          "maybe_downcast",
+          [](MlirAttribute attr) -> std::variant<tt::ChipDescAttr, py::object> {
+            auto res = mlir::dyn_cast<tt::ChipDescAttr>(unwrap(attr));
+            if (res)
+              return res;
+            else
+              return py::none();
+          })
+      .def_property_readonly("usable_l1_size",
+                             &tt::ChipDescAttr::getUsableL1Size)
+      .def_property_readonly("usable_dram_channel_size",
+                             &tt::ChipDescAttr::getUsableDramChannelSize)
+      .def_property_readonly("arch", &tt::ChipDescAttr::getArch)
+      .def_property_readonly(
+          "grid", [](tt::ChipDescAttr self) { return self.getGrid().vec(); })
+      .def_property_readonly("l1_size", &tt::ChipDescAttr::getL1Size)
+      .def_property_readonly("num_dram_channels",
+                             &tt::ChipDescAttr::getNumDramChannels)
+      .def_property_readonly("dram_channel_size",
+                             &tt::ChipDescAttr::getDramChannelSize)
+      .def_property_readonly("noc_l1_address_align_bytes",
+                             &tt::ChipDescAttr::getNocL1AddressAlignBytes)
+      .def_property_readonly("pcie_address_align_bytes",
+                             &tt::ChipDescAttr::getPcieAddressAlignBytes)
+      .def_property_readonly("noc_dram_address_align_bytes",
+                             &tt::ChipDescAttr::getNocDRAMAddressAlignBytes)
+      .def_property_readonly("l1_unreserved_base",
+                             &tt::ChipDescAttr::getL1UnreservedBase)
+      .def_property_readonly("erisc_l1_unreserved_base",
+                             &tt::ChipDescAttr::getEriscL1UnreservedBase)
+      .def_property_readonly("dram_unreserved_base",
+                             &tt::ChipDescAttr::getDramUnreservedBase)
+      .def_property_readonly("dram_unreserved_end",
+                             &tt::ChipDescAttr::getDramUnreservedEnd)
+      .def_property_readonly("chip_physical_cores",
+                             &tt::ChipDescAttr::getChipPhysicalCores)
+      .def_property_readonly("supported_data_types",
+                             [](tt::ChipDescAttr self) {
+                               return self.getSupportedDataTypes().vec();
+                             })
+      .def_property_readonly("supported_tile_sizes",
+                             [](tt::ChipDescAttr self) {
+                               return self.getSupportedTileSizes().vec();
+                             })
+      .def_property_readonly("num_cbs", &tt::ChipDescAttr::getNumCBs);
+
+  py::class_<tt::TileSizeAttr>(m, "TileSizeAttr")
+      .def_static("get",
+                  [](MlirContext ctx, int64_t y, int64_t x) {
+                    return wrap(tt::TileSizeAttr::get(unwrap(ctx), y, x));
+                  })
+      .def_static(
+          "maybe_downcast",
+          [](MlirAttribute attr) -> std::variant<tt::TileSizeAttr, py::object> {
+            auto res = mlir::dyn_cast<tt::TileSizeAttr>(unwrap(attr));
+            if (res)
+              return res;
+            else
+              return py::none();
+          })
+      .def_property_readonly("y", &tt::TileSizeAttr::getY)
+      .def_property_readonly("x", &tt::TileSizeAttr::getX);
+
+  py::class_<tt::ChipPhysicalCoresAttr>(m, "ChipPhysicalCoresAttr")
+      .def_static("get",
+                  [](MlirContext ctx, std::vector<tt::CoreCoordAttr> worker,
+                     std::vector<tt::CoreCoordAttr> dram,
+                     std::vector<tt::CoreCoordAttr> eth,
+                     std::vector<tt::CoreCoordAttr> eth_inactive) {
+                    return wrap(tt::ChipPhysicalCoresAttr::get(
+                        unwrap(ctx), worker, dram, eth, eth_inactive));
+                  })
+      .def_static("maybe_downcast",
+                  [](MlirAttribute attr)
+                      -> std::variant<tt::ChipPhysicalCoresAttr, py::object> {
+                    auto res =
+                        mlir::dyn_cast<tt::ChipPhysicalCoresAttr>(unwrap(attr));
+                    if (res)
+                      return res;
+                    else
+                      return py::none();
+                  })
+      .def_property_readonly(
+          "worker",
+          [](tt::ChipPhysicalCoresAttr self) { return self.getWorker().vec(); })
+      .def_property_readonly(
+          "dram",
+          [](tt::ChipPhysicalCoresAttr self) { return self.getDram().vec(); })
+      .def_property_readonly(
+          "eth",
+          [](tt::ChipPhysicalCoresAttr self) { return self.getEth().vec(); })
+      .def_property_readonly("eth_inactive",
+                             [](tt::ChipPhysicalCoresAttr self) {
+                               return self.getEthInactive().vec();
+                             });
 
   py::class_<tt::ChipCoordAttr>(m, "ChipCoordAttr")
-      .def_static("get", [](MlirContext ctx, unsigned rack, unsigned shelf,
-                            unsigned y, unsigned x) {
-        return wrap(tt::ChipCoordAttr::get(unwrap(ctx), rack, shelf, y, x));
-      });
+      .def_static("get",
+                  [](MlirContext ctx, unsigned rack, unsigned shelf, unsigned y,
+                     unsigned x) {
+                    return wrap(
+                        tt::ChipCoordAttr::get(unwrap(ctx), rack, shelf, y, x));
+                  })
+      .def_static("maybe_downcast",
+                  [](MlirAttribute attr)
+                      -> std::variant<tt::ChipCoordAttr, py::object> {
+                    auto res = mlir::dyn_cast<tt::ChipCoordAttr>(unwrap(attr));
+                    if (res)
+                      return res;
+                    else
+                      return py::none();
+                  })
+      .def_property_readonly("rack", &tt::ChipCoordAttr::getRack)
+      .def_property_readonly("shelf", &tt::ChipCoordAttr::getShelf)
+      .def_property_readonly("y", &tt::ChipCoordAttr::getY)
+      .def_property_readonly("x", &tt::ChipCoordAttr::getX);
 
   py::class_<tt::ChipChannelAttr>(m, "ChipChannelAttr")
-      .def_static("get", [](MlirContext ctx, unsigned deviceId0,
-                            std::vector<int64_t> ethernetCoreCoord0,
-                            unsigned deviceId1,
-                            std::vector<int64_t> ethernetCoreCoord1) {
-        return wrap(tt::ChipChannelAttr::get(unwrap(ctx), deviceId0,
-                                             ethernetCoreCoord0, deviceId1,
-                                             ethernetCoreCoord1));
-      });
+      .def_static(
+          "get",
+          [](MlirContext ctx, unsigned deviceId0,
+             std::vector<int64_t> ethernetCoreCoord0, unsigned deviceId1,
+             std::vector<int64_t> ethernetCoreCoord1) {
+            return wrap(tt::ChipChannelAttr::get(unwrap(ctx), deviceId0,
+                                                 ethernetCoreCoord0, deviceId1,
+                                                 ethernetCoreCoord1));
+          })
+      .def_static("maybe_downcast",
+                  [](MlirAttribute attr)
+                      -> std::variant<tt::ChipChannelAttr, py::object> {
+                    auto res =
+                        mlir::dyn_cast<tt::ChipChannelAttr>(unwrap(attr));
+                    if (res)
+                      return res;
+                    else
+                      return py::none();
+                  })
+      .def_property_readonly("device_id0", &tt::ChipChannelAttr::getDeviceId0)
+      .def_property_readonly("ethernet_core_coord0",
+                             [](tt::ChipChannelAttr self) {
+                               return self.getEthernetCoreCoord0().vec();
+                             })
+      .def_property_readonly("device_id1", &tt::ChipChannelAttr::getDeviceId1)
+      .def_property_readonly("ethernet_core_coord1",
+                             [](tt::ChipChannelAttr self) {
+                               return self.getEthernetCoreCoord1().vec();
+                             });
 
   py::class_<tt::SystemDescAttr>(m, "SystemDescAttr")
       .def_static("get_default",
                   [](MlirContext ctx) {
                     return wrap(tt::SystemDescAttr::getDefault(unwrap(ctx)));
                   })
-      .def_static("get", [](MlirContext ctx,
-                            std::vector<MlirAttribute> chipDescs,
-                            std::vector<unsigned> chipDescIndices,
-                            std::vector<MlirAttribute> chipCapabilities,
-                            std::vector<MlirAttribute> chipCoords,
-                            std::vector<MlirAttribute> chipChannels) {
-        std::vector<tt::ChipDescAttr> chipDescsUnwrapped;
-        for (auto chipDesc : chipDescs) {
-          chipDescsUnwrapped.push_back(
-              mlir::cast<tt::ChipDescAttr>(unwrap(chipDesc)));
-        }
-        std::vector<tt::ChipCapabilityAttr> chipCapabilitiesUnwrapped;
-        for (auto chipCapability : chipCapabilities) {
-          chipCapabilitiesUnwrapped.push_back(
-              mlir::cast<tt::ChipCapabilityAttr>(unwrap(chipCapability)));
-        }
-        std::vector<tt::ChipCoordAttr> chipCoordsUnwrapped;
-        for (auto chipCoord : chipCoords) {
-          chipCoordsUnwrapped.push_back(
-              mlir::cast<tt::ChipCoordAttr>(unwrap(chipCoord)));
-        }
-        std::vector<tt::ChipChannelAttr> chipChannelsUnwrapped;
-        for (auto chipChannel : chipChannels) {
-          chipChannelsUnwrapped.push_back(
-              mlir::cast<tt::ChipChannelAttr>(unwrap(chipChannel)));
-        }
-        return wrap(tt::SystemDescAttr::get(
-            unwrap(ctx), chipDescsUnwrapped, chipDescIndices,
-            chipCapabilitiesUnwrapped, chipCoordsUnwrapped,
-            chipChannelsUnwrapped));
+      .def_static(
+          "get",
+          [](MlirContext ctx, std::vector<MlirAttribute> chipDescs,
+             std::vector<unsigned> chipDescIndices,
+             std::vector<MlirAttribute> chipCapabilities,
+             std::vector<MlirAttribute> chipCoords,
+             std::vector<MlirAttribute> chipChannels) {
+            std::vector<tt::ChipDescAttr> chipDescsUnwrapped;
+            for (auto chipDesc : chipDescs) {
+              chipDescsUnwrapped.push_back(
+                  mlir::cast<tt::ChipDescAttr>(unwrap(chipDesc)));
+            }
+            std::vector<tt::ChipCapabilityAttr> chipCapabilitiesUnwrapped;
+            for (auto chipCapability : chipCapabilities) {
+              chipCapabilitiesUnwrapped.push_back(
+                  mlir::cast<tt::ChipCapabilityAttr>(unwrap(chipCapability)));
+            }
+            std::vector<tt::ChipCoordAttr> chipCoordsUnwrapped;
+            for (auto chipCoord : chipCoords) {
+              chipCoordsUnwrapped.push_back(
+                  mlir::cast<tt::ChipCoordAttr>(unwrap(chipCoord)));
+            }
+            std::vector<tt::ChipChannelAttr> chipChannelsUnwrapped;
+            for (auto chipChannel : chipChannels) {
+              chipChannelsUnwrapped.push_back(
+                  mlir::cast<tt::ChipChannelAttr>(unwrap(chipChannel)));
+            }
+            return wrap(tt::SystemDescAttr::get(
+                unwrap(ctx), chipDescsUnwrapped, chipDescIndices,
+                chipCapabilitiesUnwrapped, chipCoordsUnwrapped,
+                chipChannelsUnwrapped));
+          })
+      .def_static("maybe_downcast",
+                  [](MlirAttribute attr)
+                      -> std::variant<tt::SystemDescAttr, py::object> {
+                    auto res = mlir::dyn_cast<tt::SystemDescAttr>(unwrap(attr));
+                    if (res)
+                      return res;
+                    else
+                      return py::none();
+                  })
+      .def_property_readonly(
+          "chip_descs",
+          [](tt::SystemDescAttr self) { return self.getChipDescs().vec(); })
+      .def_property_readonly("chip_desc_indices",
+                             [](tt::SystemDescAttr self) {
+                               return self.getChipDescIndices().vec();
+                             })
+      .def_property_readonly("chip_capabilities",
+                             [](tt::SystemDescAttr self) {
+                               return self.getChipCapabilities().vec();
+                             })
+      .def_property_readonly(
+          "chip_coords",
+          [](tt::SystemDescAttr self) { return self.getChipCoords().vec(); })
+      .def_property_readonly("chip_channels", [](tt::SystemDescAttr self) {
+        return self.getChipChannels().vec();
       });
 
   py::class_<tt::MemorySpaceAttr>(m, "MemorySpaceAttr")
-      .def_static("get", [](MlirContext ctx, uint32_t memorySpace) {
-        return wrap(tt::MemorySpaceAttr::get(
-            unwrap(ctx), static_cast<tt::MemorySpace>(memorySpace)));
-      });
+      .def_static(
+          "get",
+          [](MlirContext ctx, uint32_t memorySpace) {
+            return wrap(tt::MemorySpaceAttr::get(
+                unwrap(ctx), static_cast<tt::MemorySpace>(memorySpace)));
+          })
+      .def_static("maybe_downcast",
+                  [](MlirAttribute attr)
+                      -> std::variant<tt::MemorySpaceAttr, py::object> {
+                    auto res =
+                        mlir::dyn_cast<tt::MemorySpaceAttr>(unwrap(attr));
+                    if (res)
+                      return res;
+                    else
+                      return py::none();
+                  })
+      .def_property_readonly("memory_space_as_int",
+                             [](tt::MemorySpaceAttr self) {
+                               return static_cast<uint32_t>(self.getValue());
+                             });
 
   py::class_<tt::OOBValAttr>(m, "OOBValAttr")
-      .def_static("get", [](MlirContext ctx, uint32_t oobVal) {
-        return wrap(
-            tt::OOBValAttr::get(unwrap(ctx), static_cast<tt::OOBVal>(oobVal)));
+      .def_static("get",
+                  [](MlirContext ctx, uint32_t oobVal) {
+                    return wrap(tt::OOBValAttr::get(
+                        unwrap(ctx), static_cast<tt::OOBVal>(oobVal)));
+                  })
+      .def_static(
+          "maybe_downcast",
+          [](MlirAttribute attr) -> std::variant<tt::OOBValAttr, py::object> {
+            auto res = mlir::dyn_cast<tt::OOBValAttr>(unwrap(attr));
+            if (res)
+              return res;
+            else
+              return py::none();
+          })
+      .def_property_readonly("oob_val_as_int", [](tt::OOBValAttr self) {
+        return static_cast<uint32_t>(self.getValue());
       });
 
   py::class_<tt::TensorMemoryLayoutAttr>(m, "TensorMemoryLayoutAttr")
-      .def_static("get", [](MlirContext ctx, uint32_t memLayout) {
-        return wrap(tt::TensorMemoryLayoutAttr::get(
-            unwrap(ctx), static_cast<tt::TensorMemoryLayout>(memLayout)));
-      });
+      .def_static(
+          "get",
+          [](MlirContext ctx, uint32_t memLayout) {
+            return wrap(tt::TensorMemoryLayoutAttr::get(
+                unwrap(ctx), static_cast<tt::TensorMemoryLayout>(memLayout)));
+          })
+      .def_static("maybe_downcast",
+                  [](MlirAttribute attr)
+                      -> std::variant<tt::TensorMemoryLayoutAttr, py::object> {
+                    auto res = mlir::dyn_cast<tt::TensorMemoryLayoutAttr>(
+                        unwrap(attr));
+                    if (res)
+                      return res;
+                    else
+                      return py::none();
+                  })
+      .def_property_readonly("mem_layout_as_int",
+                             [](tt::TensorMemoryLayoutAttr self) {
+                               return static_cast<uint32_t>(self.getValue());
+                             });
 
   py::class_<tt::IteratorTypeAttr>(m, "IteratorTypeAttr")
-      .def_static("get", [](MlirContext ctx, uint32_t iteratorType) {
-        return wrap(tt::IteratorTypeAttr::get(
-            unwrap(ctx), static_cast<tt::IteratorType>(iteratorType)));
-      });
+      .def_static(
+          "get",
+          [](MlirContext ctx, uint32_t iteratorType) {
+            return wrap(tt::IteratorTypeAttr::get(
+                unwrap(ctx), static_cast<tt::IteratorType>(iteratorType)));
+          })
+      .def_static("maybe_downcast",
+                  [](MlirAttribute attr)
+                      -> std::variant<tt::IteratorTypeAttr, py::object> {
+                    auto res =
+                        mlir::dyn_cast<tt::IteratorTypeAttr>(unwrap(attr));
+                    if (res)
+                      return res;
+                    else
+                      return py::none();
+                  })
+      .def_property_readonly("iterator_type_as_int",
+                             [](tt::IteratorTypeAttr self) {
+                               return static_cast<uint32_t>(self.getValue());
+                             });
 
   py::class_<tt::OperandConstraintAttr>(m, "OperandConstraintAttr")
       .def_static("get",
@@ -238,16 +515,45 @@ void populateTTModule(py::module &m) {
                         unwrap(ctx),
                         static_cast<tt::OperandConstraint>(operandConstraint)));
                   })
-      .def_static("get", [](MlirContext ctx,
-                            std::vector<MlirAttribute> attributesArray) {
-        return ::ttmlir::utils::wrapArrayOfMlirAttributesAsAttribute(
-            ctx, attributesArray);
-      });
+      .def_static(
+          "get",
+          [](MlirContext ctx, std::vector<MlirAttribute> attributesArray) {
+            return ::ttmlir::utils::wrapArrayOfMlirAttributesAsAttribute(
+                ctx, attributesArray);
+          })
+      .def_static("maybe_downcast",
+                  [](MlirAttribute attr)
+                      -> std::variant<tt::OperandConstraintAttr, py::object> {
+                    auto res =
+                        mlir::dyn_cast<tt::OperandConstraintAttr>(unwrap(attr));
+                    if (res)
+                      return res;
+                    else
+                      return py::none();
+                  })
+      .def_property_readonly("operand_constraint_as_int",
+                             [](tt::OperandConstraintAttr self) {
+                               return static_cast<uint32_t>(self.getValue());
+                             });
 
   py::class_<tt::DeviceType>(m, "DeviceType")
-      .def_static("get", [](MlirContext ctx, MlirAttribute deviceAttr) {
-        return wrap(tt::DeviceType::get(
-            unwrap(ctx), mlir::cast<tt::DeviceAttr>(unwrap(deviceAttr))));
+      .def_static(
+          "get",
+          [](MlirContext ctx, MlirAttribute deviceAttr) {
+            return wrap(tt::DeviceType::get(
+                unwrap(ctx), mlir::cast<tt::DeviceAttr>(unwrap(deviceAttr))));
+          })
+      .def_static(
+          "maybe_downcast",
+          [](MlirType type) -> std::variant<tt::DeviceType, py::object> {
+            auto res = mlir::dyn_cast<tt::DeviceType>(unwrap(type));
+            if (res)
+              return res;
+            else
+              return py::none();
+          })
+      .def_property_readonly("device_attr", [](tt::DeviceType const &self) {
+        return self.getDesc();
       });
 
   py::class_<tt::DeviceAttr>(m, "DeviceAttr")
@@ -270,9 +576,28 @@ void populateTTModule(py::module &m) {
                                           unwrap(workerGridMapping)),
                         unwrap(l1Map), unwrap(dramMap), meshShape, chipIds));
                   })
-      .def("unwrap", [](MlirAttribute const &self) {
-        return mlir::cast<tt::DeviceAttr>(unwrap(self));
-      });
+      .def("unwrap",
+           [](MlirAttribute const &self) {
+             return mlir::cast<tt::DeviceAttr>(unwrap(self));
+           })
+      .def_property_readonly("grid_attr", &tt::DeviceAttr::getWorkerGrid)
+      .def_property_readonly("l1_map", &tt::DeviceAttr::getL1Map)
+      .def_property_readonly("dram_map", &tt::DeviceAttr::getDramMap)
+      .def_property_readonly(
+          "mesh_shape",
+          [](tt::DeviceAttr const &self) { return self.getMeshShape().vec(); })
+      .def_property_readonly(
+          "chip_ids",
+          [](tt::DeviceAttr const &self) { return self.getChipIds().vec(); })
+      .def_static(
+          "maybe_downcast",
+          [](MlirAttribute attr) -> std::variant<tt::DeviceAttr, py::object> {
+            auto res = mlir::dyn_cast<tt::DeviceAttr>(unwrap(attr));
+            if (res)
+              return res;
+            else
+              return py::none();
+          });
 
   py::class_<tt::TileType>(m, "TileType")
       .def_static("get",
@@ -281,6 +606,14 @@ void populateTTModule(py::module &m) {
                     return wrap(tt::TileType::get(
                         unwrap(ctx), SmallVector<std::int64_t>{height, width},
                         static_cast<tt::DataType>(dataType)));
+                  })
+      .def_static("maybe_downcast",
+                  [](MlirType type) -> std::variant<tt::TileType, py::object> {
+                    auto res = mlir::dyn_cast<tt::TileType>(unwrap(type));
+                    if (res)
+                      return res;
+                    else
+                      return py::none();
                   })
       .def_property_readonly("data_type", &tt::TileType::getDataType)
       .def_property_readonly("shape", [](tt::TileType const &tile) {

--- a/python/TTNNModule.cpp
+++ b/python/TTNNModule.cpp
@@ -8,7 +8,7 @@
 namespace mlir::ttmlir::python {
 void populateTTNNModule(py::module &m) {
 
-  py::class_<tt::ttnn::CoreRangeAttr>(m, "CoreRangeAttr")
+  tt_attribute_class<tt::ttnn::CoreRangeAttr>(m, "CoreRangeAttr")
       .def_static("get",
                   [](MlirContext ctx, std::vector<int64_t> offset,
                      std::vector<int64_t> size) {
@@ -29,102 +29,56 @@ void populateTTNNModule(py::module &m) {
           },
           py::arg("ctx"), py::arg("grid"),
           py::arg("offset") = std::vector<int64_t>{0, 0})
-      .def_static("maybe_downcast",
-                  [](MlirAttribute attr)
-                      -> std::variant<tt::ttnn::CoreRangeAttr, py::object> {
-                    auto res =
-                        mlir::dyn_cast<tt::ttnn::CoreRangeAttr>(unwrap(attr));
-                    if (res)
-                      return res;
-                    else
-                      return py::none();
-                  })
       .def_property_readonly(
           "offset",
           [](tt::ttnn::CoreRangeAttr self) { return self.getOffset().vec(); })
       .def_property_readonly("size", [](tt::ttnn::CoreRangeAttr self) {
         return self.getSize().vec();
       });
-  py::class_<tt::ttnn::LayoutAttr>(m, "LayoutAttr")
+
+  tt_attribute_class<tt::ttnn::LayoutAttr>(m, "LayoutAttr")
       .def_static("get",
                   [](MlirContext ctx, uint32_t layout) {
                     return wrap(tt::ttnn::LayoutAttr::get(
                         unwrap(ctx), static_cast<tt::ttnn::Layout>(layout)));
                   })
-      .def_static("maybe_downcast",
-                  [](MlirAttribute attr)
-                      -> std::variant<tt::ttnn::LayoutAttr, py::object> {
-                    auto res =
-                        mlir::dyn_cast<tt::ttnn::LayoutAttr>(unwrap(attr));
-                    if (res)
-                      return res;
-                    else
-                      return py::none();
-                  })
       .def_property_readonly("value", [](tt::ttnn::LayoutAttr self) {
         return static_cast<uint32_t>(self.getValue());
       });
-  py::class_<tt::ttnn::TensorMemoryLayoutAttr>(m, "TensorMemoryLayoutAttr")
+
+  tt_attribute_class<tt::ttnn::TensorMemoryLayoutAttr>(m,
+                                                       "TensorMemoryLayoutAttr")
       .def_static("get",
                   [](MlirContext ctx, uint32_t tensorMemoryLayout) {
                     return wrap(tt::ttnn::TensorMemoryLayoutAttr::get(
                         unwrap(ctx), static_cast<tt::ttnn::TensorMemoryLayout>(
                                          tensorMemoryLayout)));
                   })
-      .def_static(
-          "maybe_downcast",
-          [](MlirAttribute attr)
-              -> std::variant<tt::ttnn::TensorMemoryLayoutAttr, py::object> {
-            auto res =
-                mlir::dyn_cast<tt::ttnn::TensorMemoryLayoutAttr>(unwrap(attr));
-            if (res)
-              return res;
-            else
-              return py::none();
-          })
       .def_property_readonly("value",
                              [](tt::ttnn::TensorMemoryLayoutAttr self) {
                                return static_cast<uint32_t>(self.getValue());
                              });
-  py::class_<tt::ttnn::BufferTypeAttr>(m, "BufferTypeAttr")
+  tt_attribute_class<tt::ttnn::BufferTypeAttr>(m, "BufferTypeAttr")
       .def_static(
           "get",
           [](MlirContext ctx, uint32_t bufferType) {
             return wrap(tt::ttnn::BufferTypeAttr::get(
                 unwrap(ctx), static_cast<tt::ttnn::BufferType>(bufferType)));
           })
-      .def_static("maybe_downcast",
-                  [](MlirAttribute attr)
-                      -> std::variant<tt::ttnn::BufferTypeAttr, py::object> {
-                    auto res =
-                        mlir::dyn_cast<tt::ttnn::BufferTypeAttr>(unwrap(attr));
-                    if (res)
-                      return res;
-                    else
-                      return py::none();
-                  })
       .def_property_readonly("value", [](tt::ttnn::BufferTypeAttr self) {
         return static_cast<uint32_t>(self.getValue());
       });
-  py::class_<tt::ttnn::ShardSpecAttr>(m, "ShardSpecAttr")
+
+  tt_attribute_class<tt::ttnn::ShardSpecAttr>(m, "ShardSpecAttr")
       .def_static("get",
                   [](MlirContext ctx, tt::ttnn::ShapeAttr shardShape) {
                     return wrap(
                         tt::ttnn::ShardSpecAttr::get(unwrap(ctx), shardShape));
                   })
-      .def_static("maybe_downcast",
-                  [](MlirAttribute attr)
-                      -> std::variant<tt::ttnn::ShardSpecAttr, py::object> {
-                    auto res =
-                        mlir::dyn_cast<tt::ttnn::ShardSpecAttr>(unwrap(attr));
-                    if (res)
-                      return res;
-                    else
-                      return py::none();
-                  })
       .def_property_readonly("shard_shape",
                              &tt::ttnn::ShardSpecAttr::getShardShape);
-  py::class_<tt::ttnn::MemoryConfigAttr>(m, "MemoryConfigAttr")
+
+  tt_attribute_class<tt::ttnn::MemoryConfigAttr>(m, "MemoryConfigAttr")
       .def_static("get",
                   [](MlirContext ctx,
                      tt::ttnn::TensorMemoryLayoutAttr tensorMemoryLayoutAttr,
@@ -149,56 +103,28 @@ void populateTTNNModule(py::module &m) {
                     unwrap(ctx),
                     tt::ttnn::ShapeAttr::get(unwrap(ctx), shardShape))));
           })
-      .def_static("maybe_downcast",
-                  [](MlirAttribute attr)
-                      -> std::variant<tt::ttnn::MemoryConfigAttr, py::object> {
-                    auto res = mlir::dyn_cast<tt::ttnn::MemoryConfigAttr>(
-                        unwrap(attr));
-                    if (res)
-                      return res;
-                    else
-                      return py::none();
-                  })
       .def_property_readonly("tensor_memory_layout",
                              &tt::ttnn::MemoryConfigAttr::getTensorMemoryLayout)
       .def_property_readonly("buffer_type",
                              &tt::ttnn::MemoryConfigAttr::getBufferType)
       .def_property_readonly("shard_spec",
                              &tt::ttnn::MemoryConfigAttr::getShardSpec);
-  py::class_<tt::ttnn::ShapeAttr>(m, "ShapeAttr")
+
+  tt_attribute_class<tt::ttnn::ShapeAttr>(m, "ShapeAttr")
       .def_static("get",
                   [](MlirContext ctx, std::vector<int64_t> shape) {
                     return wrap(tt::ttnn::ShapeAttr::get(unwrap(ctx), shape));
-                  })
-      .def_static("maybe_downcast",
-                  [](MlirAttribute attr)
-                      -> std::variant<tt::ttnn::ShapeAttr, py::object> {
-                    auto res =
-                        mlir::dyn_cast<tt::ttnn::ShapeAttr>(unwrap(attr));
-                    if (res)
-                      return res;
-                    else
-                      return py::none();
                   })
       .def_property_readonly("shape", [](tt::ttnn::ShapeAttr self) {
         return std::vector<int64_t>(self.getShape().begin(),
                                     self.getShape().end());
       });
-  py::class_<tt::ttnn::MeshShapeAttr>(m, "MeshShapeAttr")
+
+  tt_attribute_class<tt::ttnn::MeshShapeAttr>(m, "MeshShapeAttr")
       .def_static("get",
                   [](MlirContext ctx, int64_t y, int64_t x) {
                     return wrap(
                         tt::ttnn::MeshShapeAttr::get(unwrap(ctx), y, x));
-                  })
-      .def_static("maybe_downcast",
-                  [](MlirAttribute attr)
-                      -> std::variant<tt::ttnn::MeshShapeAttr, py::object> {
-                    auto res =
-                        mlir::dyn_cast<tt::ttnn::MeshShapeAttr>(unwrap(attr));
-                    if (res)
-                      return res;
-                    else
-                      return py::none();
                   })
       .def_property_readonly("y", &tt::ttnn::MeshShapeAttr::getY)
       .def_property_readonly("x", &tt::ttnn::MeshShapeAttr::getX);

--- a/python/TTNNModule.cpp
+++ b/python/TTNNModule.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Bindings/Python/TTMLIRModule.h"
-#include <variant>
 
 namespace mlir::ttmlir::python {
 void populateTTNNModule(py::module &m) {

--- a/python/TTNNModule.cpp
+++ b/python/TTNNModule.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Bindings/Python/TTMLIRModule.h"
+#include <variant>
 
 namespace mlir::ttmlir::python {
 void populateTTNNModule(py::module &m) {
@@ -27,12 +28,38 @@ void populateTTNNModule(py::module &m) {
                 offsetVec));
           },
           py::arg("ctx"), py::arg("grid"),
-          py::arg("offset") = std::vector<int64_t>{0, 0});
+          py::arg("offset") = std::vector<int64_t>{0, 0})
+      .def_static("maybe_downcast",
+                  [](MlirAttribute attr)
+                      -> std::variant<tt::ttnn::CoreRangeAttr, py::object> {
+                    auto res =
+                        mlir::dyn_cast<tt::ttnn::CoreRangeAttr>(unwrap(attr));
+                    if (res)
+                      return res;
+                    else
+                      return py::none();
+                  })
+      .def_property_readonly(
+          "offset",
+          [](tt::ttnn::CoreRangeAttr self) { return self.getOffset().vec(); })
+      .def_property_readonly("size", [](tt::ttnn::CoreRangeAttr self) {
+        return self.getSize().vec();
+      });
   py::class_<tt::ttnn::LayoutAttr>(m, "LayoutAttr")
       .def_static("get",
                   [](MlirContext ctx, uint32_t layout) {
                     return wrap(tt::ttnn::LayoutAttr::get(
                         unwrap(ctx), static_cast<tt::ttnn::Layout>(layout)));
+                  })
+      .def_static("maybe_downcast",
+                  [](MlirAttribute attr)
+                      -> std::variant<tt::ttnn::LayoutAttr, py::object> {
+                    auto res =
+                        mlir::dyn_cast<tt::ttnn::LayoutAttr>(unwrap(attr));
+                    if (res)
+                      return res;
+                    else
+                      return py::none();
                   })
       .def_property_readonly("value", [](tt::ttnn::LayoutAttr self) {
         return static_cast<uint32_t>(self.getValue());
@@ -44,6 +71,17 @@ void populateTTNNModule(py::module &m) {
                         unwrap(ctx), static_cast<tt::ttnn::TensorMemoryLayout>(
                                          tensorMemoryLayout)));
                   })
+      .def_static(
+          "maybe_downcast",
+          [](MlirAttribute attr)
+              -> std::variant<tt::ttnn::TensorMemoryLayoutAttr, py::object> {
+            auto res =
+                mlir::dyn_cast<tt::ttnn::TensorMemoryLayoutAttr>(unwrap(attr));
+            if (res)
+              return res;
+            else
+              return py::none();
+          })
       .def_property_readonly("value",
                              [](tt::ttnn::TensorMemoryLayoutAttr self) {
                                return static_cast<uint32_t>(self.getValue());
@@ -55,6 +93,16 @@ void populateTTNNModule(py::module &m) {
             return wrap(tt::ttnn::BufferTypeAttr::get(
                 unwrap(ctx), static_cast<tt::ttnn::BufferType>(bufferType)));
           })
+      .def_static("maybe_downcast",
+                  [](MlirAttribute attr)
+                      -> std::variant<tt::ttnn::BufferTypeAttr, py::object> {
+                    auto res =
+                        mlir::dyn_cast<tt::ttnn::BufferTypeAttr>(unwrap(attr));
+                    if (res)
+                      return res;
+                    else
+                      return py::none();
+                  })
       .def_property_readonly("value", [](tt::ttnn::BufferTypeAttr self) {
         return static_cast<uint32_t>(self.getValue());
       });
@@ -63,6 +111,16 @@ void populateTTNNModule(py::module &m) {
                   [](MlirContext ctx, tt::ttnn::ShapeAttr shardShape) {
                     return wrap(
                         tt::ttnn::ShardSpecAttr::get(unwrap(ctx), shardShape));
+                  })
+      .def_static("maybe_downcast",
+                  [](MlirAttribute attr)
+                      -> std::variant<tt::ttnn::ShardSpecAttr, py::object> {
+                    auto res =
+                        mlir::dyn_cast<tt::ttnn::ShardSpecAttr>(unwrap(attr));
+                    if (res)
+                      return res;
+                    else
+                      return py::none();
                   })
       .def_property_readonly("shard_shape",
                              &tt::ttnn::ShardSpecAttr::getShardShape);
@@ -91,6 +149,16 @@ void populateTTNNModule(py::module &m) {
                     unwrap(ctx),
                     tt::ttnn::ShapeAttr::get(unwrap(ctx), shardShape))));
           })
+      .def_static("maybe_downcast",
+                  [](MlirAttribute attr)
+                      -> std::variant<tt::ttnn::MemoryConfigAttr, py::object> {
+                    auto res = mlir::dyn_cast<tt::ttnn::MemoryConfigAttr>(
+                        unwrap(attr));
+                    if (res)
+                      return res;
+                    else
+                      return py::none();
+                  })
       .def_property_readonly("tensor_memory_layout",
                              &tt::ttnn::MemoryConfigAttr::getTensorMemoryLayout)
       .def_property_readonly("buffer_type",
@@ -102,6 +170,16 @@ void populateTTNNModule(py::module &m) {
                   [](MlirContext ctx, std::vector<int64_t> shape) {
                     return wrap(tt::ttnn::ShapeAttr::get(unwrap(ctx), shape));
                   })
+      .def_static("maybe_downcast",
+                  [](MlirAttribute attr)
+                      -> std::variant<tt::ttnn::ShapeAttr, py::object> {
+                    auto res =
+                        mlir::dyn_cast<tt::ttnn::ShapeAttr>(unwrap(attr));
+                    if (res)
+                      return res;
+                    else
+                      return py::none();
+                  })
       .def_property_readonly("shape", [](tt::ttnn::ShapeAttr self) {
         return std::vector<int64_t>(self.getShape().begin(),
                                     self.getShape().end());
@@ -111,6 +189,16 @@ void populateTTNNModule(py::module &m) {
                   [](MlirContext ctx, int64_t y, int64_t x) {
                     return wrap(
                         tt::ttnn::MeshShapeAttr::get(unwrap(ctx), y, x));
+                  })
+      .def_static("maybe_downcast",
+                  [](MlirAttribute attr)
+                      -> std::variant<tt::ttnn::MeshShapeAttr, py::object> {
+                    auto res =
+                        mlir::dyn_cast<tt::ttnn::MeshShapeAttr>(unwrap(attr));
+                    if (res)
+                      return res;
+                    else
+                      return py::none();
                   })
       .def_property_readonly("y", &tt::ttnn::MeshShapeAttr::getY)
       .def_property_readonly("x", &tt::ttnn::MeshShapeAttr::getX);


### PR DESCRIPTION
- Manually defined downcasting methods. Goal is to autogenerate these, should be decently easy to integrate with tblgen for the cpp methods, but difficult to throw into the pybind declaration itself. Was easier to do a short sighted fix where these methods are manually defined.
- Used `dyn_cast` instead of `cast` for a safer call signature. Failure will be defined through the function resulting in `None` instead of a full failure.
- 