### PR TITLE
Uplift third_party/tt-metal to 2024-11-08 (1d79aee)

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "d30c5e874d05f43c9e075f7062017df200fae44c")
+set(TT_METAL_VERSION "1d79aeef7a28911bd817a2da78ad925da3ed06f5")
 
 if ("$ENV{ARCH_NAME}" STREQUAL "grayskull")
   set(ARCH_NAME "grayskull")


### PR DESCRIPTION
Here is another tt-metal uplift to get the next week (Nov1 -> Nov8) of changes. Much easier (an hour) than last time (2 weeks) of effort.   

This is targeting a tt-metal commit that was a recent conv2d fix (that I previously cherry-picked into current in-use metal branch.  This has benefit of us not pointing to a branch of metal, but a real (recent) origin/main metal version.

CI Runs for this uplift:

tt-mlir (passing): [link](https://github.com/tenstorrent/tt-mlir/actions/runs/11826552731)
tt-forge-fe (passing): [link](https://github.com/tenstorrent/tt-forge-fe/actions/runs/11827094308)
