### PR TITLE
Use ttnn::transpose instead of runtime decomposing transpose

### DIFF
--- a/runtime/include/tt/runtime/detail/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn.h
@@ -56,6 +56,7 @@
 #include "ttnn/operations/creation.hpp"
 #include "ttnn/operations/data_movement/concat/concat.hpp"
 #include "ttnn/operations/data_movement/permute/permute.hpp"
+#include "ttnn/operations/data_movement/transpose/transpose.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/eltwise/binary/binary_composite.hpp"
 #include "ttnn/operations/eltwise/ternary/where.hpp"

--- a/runtime/lib/ttnn/operations/data_movement/transpose.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/transpose.cpp
@@ -14,30 +14,9 @@ void run(const ::tt::target::ttnn::TransposeOp *op, ProgramContext &context) {
   DEBUG_ASSERT(in.is_allocated());
   int32_t dim0 = op->dim0();
   int32_t dim1 = op->dim1();
-  auto inputRank = op->in()->desc()->layout()->stride()->size();
-  // for the current version of permute, we need to work in 4D, so we add
-  // leading dimensions of size 1
-  std::vector<std::int64_t> dimensionOrder(4);
-  std::iota(dimensionOrder.begin(), dimensionOrder.end(), 0);
-  if (dim0 < 0) {
-    dim0 += 4;
-  } else {
-    dim0 = dim0 + 4 - inputRank;
-  }
-  if (dim1 < 0) {
-    dim1 += 4;
-  } else {
-    dim1 = dim1 + 4 - inputRank;
-  }
-  std::swap(dimensionOrder[dim0], dimensionOrder[dim1]);
-  // Ideally this would use ttnn::transpose, but since ttnn::transpose doesn't
-  // work at the moment, we use this temporary solution.
-  ::ttnn::Tensor unsqueezedInput = ::ttnn::unsqueeze_to_4D(in);
   ::tt::tt_metal::MemoryConfig outputMemoryConfig =
       utils::createMemoryConfig(op->out());
-  ::ttnn::Tensor out =
-      ::ttnn::permute(unsqueezedInput, dimensionOrder, outputMemoryConfig);
-  out = ::ttnn::squeeze_from_4D(out, inputRank);
+  ::ttnn::Tensor out = ::ttnn::transpose(in, dim0, dim1, outputMemoryConfig);
   tensorPool.insert_or_assign(op->out()->global_id(), out);
 }
 } // namespace tt::runtime::ttnn::operations::data_movement


### PR DESCRIPTION
Previously, transpose was decomposed in runtime to permute. This PR transfers directly to ttnn::transpose. 
I ran transpose tests on forge with this change and everything seems fine. 

@vladimirjovanovicTT do you have some insight for why you added this decomposition? Was that a workaround due to some transpose case failing or transpose wan't implemented (less likely)?

