### PR TITLE
Do not use default values for ttir.convolution

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -740,16 +740,12 @@ def TTIR_ConvolutionOp : TTIR_DPSOp<"convolution"> {
     AnyRankedTensor:$weight,
     Optional<AnyRankedTensor>:$bias,
     AnyRankedTensor:$output,
-    // Default value: one for each of the spatial dimension.
-    DefaultValuedOptionalAttr<DenseI64ArrayAttr, "SmallVector<int64_t>(getConvolutionLayout().getInputSpatialDimensions().size(), 1)">:$window_strides,
-    // Default value: two zeros for each of the spatial dimension.
-    DefaultValuedOptionalAttr<I64ElementsAttr, "SmallVector<int64_t>(getConvolutionLayout().getInputSpatialDimensions().size()*2, 0)">:$padding,
-    // Default value: one for each of the spatial dimension.
-    DefaultValuedOptionalAttr<DenseI64ArrayAttr, "SmallVector<int64_t>(getConvolutionLayout().getInputSpatialDimensions().size(), 1)">:$input_dilation,
-    // Default value: one for each of the spatial dimension.
-    DefaultValuedOptionalAttr<DenseI64ArrayAttr, "SmallVector<int64_t>(getConvolutionLayout().getInputSpatialDimensions().size(), 1)">:$weight_dilation,
-    // Default value: false for each of the spatial dimension.
-    DefaultValuedOptionalAttr<DenseBoolArrayAttr, "SmallVector<bool>(getConvolutionLayout().getInputSpatialDimensions().size(), false)">:$window_reversal,
+
+    DenseI64ArrayAttr:$window_strides,
+    DenseI64ArrayAttr:$padding,
+    DenseI64ArrayAttr:$input_dilation,
+    DenseI64ArrayAttr:$weight_dilation,
+    DenseBoolArrayAttr:$window_reversal,
     TTIR_ConvolutionLayoutAttr:$convolution_layout,
     ConfinedAttr<I64Attr, [IntPositive]>:$feature_group_count,
     ConfinedAttr<I64Attr, [IntPositive]>:$batch_group_count,

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -81,10 +81,9 @@ template <uint32_t NDims>
 using PaddingMatrix = std::array<std::array<int64_t, 2>, NDims>;
 
 template <uint32_t NDims>
-static PaddingMatrix<NDims> getPaddingMatrix(DenseIntElementsAttr paddingAttr) {
+static PaddingMatrix<NDims> getPaddingMatrix(ArrayRef<int64_t> padding) {
   PaddingMatrix<NDims> paddingMatrix;
-  std::vector<int64_t> paddingFlattened(paddingAttr.value_begin<int64_t>(),
-                                        paddingAttr.value_end<int64_t>());
+  std::vector<int64_t> paddingFlattened = padding.vec();
 
   for (uint32_t i = 0; i < 2 * NDims; i += 2) {
     paddingMatrix[i / 2] = {paddingFlattened[i], paddingFlattened[i + 1]};

--- a/test/ttmlir/Dialect/TTIR/convolution/convolution_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/convolution/convolution_tests_negative.mlir
@@ -21,7 +21,7 @@ module @jit_convolution_bad_spatial_dimensions {
       feature_group_count = 1 : i64,
       input_dilation = array<i64: 1, 1>,
       operand_constraints = [#any_device_tile, #any_device_tile, #any_device_tile],
-      padding = dense<1> : tensor<2x2xi64>,
+      padding = array<i64: 1, 1, 1 ,1>,
       weight_dilation = array<i64: 1, 1>,
       window_reversal = array<i1: false, false>,
       window_strides = array<i64: 1, 1>
@@ -52,7 +52,7 @@ module @jit_convolution_bad_stride_dimensions {
       feature_group_count = 1 : i64,
       input_dilation = array<i64: 1, 1>,
       operand_constraints = [#any_device_tile, #any_device_tile, #any_device_tile],
-      padding = dense<1> : tensor<2x2xi64>,
+      padding = array<i64: 1, 1, 1 ,1>,
       weight_dilation = array<i64: 1, 1>,
       window_reversal = array<i1: false, false>,
       window_strides = array<i64: 1, 1, 1>
@@ -83,7 +83,7 @@ module @jit_convolution_bad_input_tensor {
       feature_group_count = 1 : i64,
       input_dilation = array<i64: 1, 1>,
       operand_constraints = [#any_device_tile, #any_device_tile, #any_device_tile],
-      padding = dense<1> : tensor<2x2xi64>,
+      padding = array<i64: 1, 1, 1 ,1>,
       weight_dilation = array<i64: 1, 1>,
       window_reversal = array<i1: false, false>,
       window_strides = array<i64: 1, 1>
@@ -114,7 +114,7 @@ module @jit_convolution_bad_weight_tensor {
       feature_group_count = 1 : i64,
       input_dilation = array<i64: 1, 1>,
       operand_constraints = [#any_device_tile, #any_device_tile, #any_device_tile],
-      padding = dense<1> : tensor<2x2xi64>,
+      padding = array<i64: 1, 1, 1 ,1>,
       weight_dilation = array<i64: 1, 1>,
       window_reversal = array<i1: false, false>,
       window_strides = array<i64: 1, 1>
@@ -145,7 +145,7 @@ module @jit_convolution_bad_bias_tensor {
       feature_group_count = 1 : i64,
       input_dilation = array<i64: 1, 1>,
       operand_constraints = [#any_device_tile, #any_device_tile, #any_device_tile],
-      padding = dense<1> : tensor<2x2xi64>,
+      padding = array<i64: 1, 1, 1 ,1>,
       weight_dilation = array<i64: 1, 1>,
       window_reversal = array<i1: false, false>,
       window_strides = array<i64: 1, 1>

--- a/test/ttmlir/Dialect/TTNN/convolution/complex_conv_channel_first.mlir
+++ b/test/ttmlir/Dialect/TTNN/convolution/complex_conv_channel_first.mlir
@@ -22,7 +22,7 @@ module @jit_convolution {
       feature_group_count = 1 : i64,
       input_dilation = array<i64: 1, 1>,
       operand_constraints = [#any_device_tile, #any_device_tile, #any_device_tile],
-      padding = dense<1> : tensor<2x2xi64>,
+      padding = array<i64: 1, 1, 1 ,1>,
       weight_dilation = array<i64: 1, 1>,
       window_reversal = array<i1: false, false>,
       window_strides = array<i64: 1, 1>

--- a/test/ttmlir/Silicon/TTNN/complex_conv_channel_first.mlir
+++ b/test/ttmlir/Silicon/TTNN/complex_conv_channel_first.mlir
@@ -24,7 +24,7 @@ module @jit_convolution {
       feature_group_count = 1 : i64,
       input_dilation = array<i64: 1, 1>,
       operand_constraints = [#any_device_tile, #any_device_tile, #any_device_tile],
-      padding = dense<1> : tensor<2x2xi64>,
+      padding = array<i64: 1, 1, 1 ,1>,
       weight_dilation = array<i64: 1, 1>,
       window_reversal = array<i1: false, false>,
       window_strides = array<i64: 1, 1>


### PR DESCRIPTION
The tt-xla conv2d tests are failing because the default padding attribute for `ttir.convolution` is not being generated properly. 

- All `DefaultValuedOptionalAttr`s for `ttir.convolution` are now mandatory.
  - In conversion from stablehlo, if `stablehlo.convolution` is missing these attributes, we populate `ttir.convolution` with the default intended attribute for `stablehlo.convolution` as stated in the comments of `StablehloOps.td::StableHLO_ConvolutionOp`