### PR TITLE
Uplift third_party/tt-metal to 2024-11-15 (42035c1711 + cherry-pick fix)

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "1d79aeef7a28911bd817a2da78ad925da3ed06f5")
+set(TT_METAL_VERSION "f16cadfabebd7654baef73e4ac2c3240b12b0d1d")
 
 if ("$ENV{ARCH_NAME}" STREQUAL "grayskull")
   set(ARCH_NAME "grayskull")


### PR DESCRIPTION
This gets us another week (Nov8 -> Nov15) of tt-metal.  Using stable tt-metal [42035c1711](https://github.com/tenstorrent/tt-metal/commit/42035c171179b945d71d8a16390c30bf177cb575) from tt-metal main plus a cherry pick fix for an assertion fix (not yet on tt-metal main, but expected to go in soon).

CI Runs:

tt-mlir (Passing): [link](https://github.com/tenstorrent/tt-mlir/actions/runs/11862788450)
tt-forge-fe (Running) : [link](https://github.com/tenstorrent/tt-forge-fe/actions/runs/11863453098)

Would merge if approved and if tt-forge-fe is passing.