### PR TITLE
Add TTIR to EmitC pipeline

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -5,9 +5,10 @@
 #ifndef TTMLIR_DIALECT_TTNN_PIPELINES_TTNNPIPELINES_H
 #define TTMLIR_DIALECT_TTNN_PIPELINES_TTNNPIPELINES_H
 
-#include "mlir/Pass/PassOptions.h"
 #include "ttmlir/Dialect/TT/Utils/MemoryLayoutAnalysisParams.h"
 #include "ttmlir/Dialect/TTNN/Utils/OptimizerOverrides.h"
+
+#include "mlir/Pass/PassOptions.h"
 
 namespace mlir::tt::ttnn {
 
@@ -112,6 +113,11 @@ struct TTIRToTTNNBackendPipelineOptions
       *this, "mesh-shape", llvm::cl::desc("Set the multi-device mesh shape.")};
 };
 
+// TTIR to EmitC pipeline options.
+// Inherit from TTIRToTTNNBackendPipelineOptions to reuse the options.
+//
+struct TTIRToEmitCPipelineOptions : public TTIRToTTNNBackendPipelineOptions {};
+
 void createTTNNPipelineTTIRPasses(
     OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options);
 
@@ -144,6 +150,9 @@ void createTTNNPipelineDeallocPassFromString(OpPassManager &pm,
 
 void createTTIRToTTNNBackendPipeline(
     OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options);
+
+void createTTIRToEmitCPipeline(OpPassManager &pm,
+                               const TTIRToEmitCPipelineOptions &options);
 
 /// Registers all pipelines for the `bufferization` dialect. Currently,
 /// this includes only the "ttir-to-ttnn-backend-pipeline".

--- a/test/ttmlir/Dialect/TTNN/pipelines/ttir_to_emitc_add.mlir
+++ b/test/ttmlir/Dialect/TTNN/pipelines/ttir_to_emitc_add.mlir
@@ -1,0 +1,13 @@
+// RUN: ttmlir-opt --ttir-to-emitc-pipeline="system-desc-path=%system_desc_path%" %s > %direct.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" --convert-ttnn-to-emitc %s > %indirect.mlir
+// RUN: diff %direct.mlir %indirect.mlir
+//
+// This test checks that the (TTIR to EmitC pipeline) is equivalent to (TTIR to TTNN pipeline + dialect conversion from TTNN to EmitC).
+
+#any_device_tile = #tt.operand_constraint<dram|l1|tile|any_device_tile>
+
+func.func @add(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  %0 = tensor.empty() : tensor<64x128xf32>
+  %1 = "ttir.add"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device_tile, #any_device_tile, #any_device_tile]}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  return %1 : tensor<64x128xf32>
+}

--- a/test/ttmlir/Dialect/TTNN/pipelines/ttir_to_emitc_add.mlir
+++ b/test/ttmlir/Dialect/TTNN/pipelines/ttir_to_emitc_add.mlir
@@ -3,6 +3,7 @@
 // RUN: diff %direct.mlir %indirect.mlir
 //
 // This test checks that the (TTIR to EmitC pipeline) is equivalent to (TTIR to TTNN pipeline + dialect conversion from TTNN to EmitC).
+// The `diff` command will return 0 if files are identical, otherwise it will return the diff, which will make `llvm-lit` treat the test as failed.
 
 #any_device_tile = #tt.operand_constraint<dram|l1|tile|any_device_tile>
 


### PR DESCRIPTION
As outlined in the [EmitC spec](https://tenstorrent-my.sharepoint.com/:w:/r/personal/svuckovic_tenstorrent_com/Documents/EmitC%20Spec.docx?d=wca1db2049282411583a16ed46456814c&csf=1&web=1&e=eIJugr), adding a TTIR to EmitC pipeline. The pipeline runs the `--ttir-to-ttnn-backend-pipeline` under the hood, and then runs the `--convert-ttnn-to-emitc` pass. Its options also extend the `TTIRToEmitCPipelineOptions` struct.

So instead of running
```
./build/bin/ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=ttrt-artifacts/system_desc.ttsys" --convert-ttnn-to-emitc test/ttmlir/Silicon/TTNN/emitc/simple_add.mlir
```

One can now run
```
./build/bin/ttmlir-opt --ttir-to-emitc-pipeline="system-desc-path=ttrt-artifacts/system_desc.ttsys" test/ttmlir/Silicon/TTNN/emitc/simple_add.mlir
```

To get the IR in EmitC.

Pipeline was added in `TTNNPipelines.h` - might not be the right place. Even though it's TTIR to EmitC pipeline, to me it made the most sense to put it into `TTNNPipelines.h` as it's really a TTNN-centric pipeline.