### PR TITLE
fix build warning -Wreturn-type

### DIFF
--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -443,12 +443,9 @@ encodingToFlatbuffer(FlatbufferObjectCache &cache, Attribute attr,
                                   deviceAttr);
   }
 
-  if (isa<ttnn::TTNNLayoutAttr>(attr)) {
-    return ttnnLayoutAttrToFlatbuffer(cache, cast<ttnn::TTNNLayoutAttr>(attr),
-                                      logicalShape, deviceAttr);
-  }
-
-  assert(false && "unsupported layout attr");
+  assert(isa<ttnn::TTNNLayoutAttr>(attr) && "unsupported layout attr");
+  return ttnnLayoutAttrToFlatbuffer(cache, cast<ttnn::TTNNLayoutAttr>(attr),
+                                    logicalShape, deviceAttr);
 }
 
 inline flatbuffers::Offset<::tt::target::TensorDesc>


### PR DESCRIPTION
We are hitting build failure in `tt-forge-fe` for latest `tt-mlir` (build warning treated as error):

error: non-void function does not return a value in all control paths

Refactored function so that it always returns.

Issue (tt-forge) [726](https://github.com/tenstorrent/tt-forge-fe/issues/726)