### PR TITLE
Pair of tt-metal uplift improvements (new test, remove dep on libfmt.so)

### DIFF
--- a/runtime/tools/python/setup.py
+++ b/runtime/tools/python/setup.py
@@ -66,7 +66,7 @@ if enable_ttmetal:
     linklibs += ["TTRuntimeTTMetal", "tt_metal"]
 
 if enable_ttnn or enable_ttmetal:
-    runlibs += ["libdevice.so", "libnng.so.1", "libuv.so.1", "libfmt.so.11"]
+    runlibs += ["libdevice.so", "libnng.so.1", "libuv.so.1"]
     linklibs += ["TTRuntimeSysDesc", "TTRuntimeDebug", "TTRuntimeWorkarounds"]
 
 if enable_perf:

--- a/test/ttmlir/Silicon/TTNN/simple_reductions.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_reductions.mlir
@@ -17,6 +17,12 @@ func.func @sum_last_2_dims(%arg0: tensor<1x32x512x64xbf16>) -> tensor<1x32xbf16>
   return %1 : tensor<1x32xbf16>
 }
 
+func.func @sum_first_dim(%arg0: tensor<64x10xf32>) -> tensor<1x10xf32> {
+  %0 = tensor.empty() : tensor<1x10xf32>
+  %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [-2 : i32], keep_dim = true, operand_constraints = [#any_device, #any_device]}> : (tensor<64x10xf32>, tensor<1x10xf32>) -> tensor<1x10xf32>
+  return %1: tensor<1x10xf32>
+}
+
 func.func @mean(%arg0: tensor<1x1x512x64xbf16>) -> tensor<1x1x512xbf16> {
   %0 = tensor.empty() : tensor<1x1x512xbf16>
   // CHECK: %[[C:.*]] = "ttnn.mean"[[C:.*]]


### PR DESCRIPTION
2 small changes independent from but related to tt-metal uplifts.  Was sitting on this for a bit un un-approved metal uplift PR, so spawning to it's own dedicated PR:

 - remove dep on libfmt.so required to solve compile error with upcoming tt-metal uplifts
 - new test to cover tt-metal bug caught by tt-forge-fe but not tt-mlir during my recent tt-metal uplift effort (https://github.com/tenstorrent/tt-metal/issues/15167)