### PR TITLE
Add cluster_descriptor.yaml to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ ttrt-artifacts/*
 query_results.json
 run_results.json
 ttrt_report.xml
+cluster_descriptor.yaml


### PR DESCRIPTION
- Keeps getting autogenerated from UMD, seems handy to just ignore it.