### PR TITLE
PyBind `GoldenTensor` w/ Integral Types (#1294)

### DIFF
--- a/python/test_infra/ttir_builder.py
+++ b/python/test_infra/ttir_builder.py
@@ -290,9 +290,6 @@ class TTIRBuilder:
         while len(stack) > 0 and stack[0].filename == cur_filename:
             stack = stack[1:]
 
-        id = self.get_next_global_id()
-        loc = Location.file(stack[0].filename, stack[0].lineno, id)
-
         assert (
             len(stack) > 0
         ), "Top of callstack to builder funcs must be outside this file"
@@ -300,12 +297,14 @@ class TTIRBuilder:
         with self._ctx, self._loc:
             output = self.empty(self.get_shape(inputs[0]))
 
+            id = self.get_next_global_id()
+
             op = op_ttir_function(
                 [self._get_type(output)],
                 inputs,
                 [output],
                 self._get_operand_constraint_attr(3),
-                loc=loc,
+                loc=Location.name(str(id)),
             )
 
             goldens = []
@@ -313,7 +312,7 @@ class TTIRBuilder:
                 goldens.append(self._get_golden_tensor(input))
 
             golden = Golden(op_golden_function(*goldens))
-            self.id_golden_map[str(loc)] = golden
+            self.id_golden_map[str(id)] = golden
             self._store_golden(op, golden)
             self._override_golden(output, golden)
 

--- a/runtime/include/tt/runtime/detail/debug.h
+++ b/runtime/include/tt/runtime/detail/debug.h
@@ -77,6 +77,7 @@ private:
 
   mutable std::optional<std::function<void(Binary, CallbackContext, OpContext)>>
       operatorCallback;
+
 #else
   constexpr Hooks() = default;
 #endif

--- a/runtime/tools/python/ttrt/binary/__init__.py
+++ b/runtime/tools/python/ttrt/binary/__init__.py
@@ -8,6 +8,7 @@ from ._C import (
     load_binary_from_capsule,
     load_system_desc_from_path,
     Flatbuffer,
+    GoldenTensor,
 )
 from . import stats
 

--- a/runtime/tools/python/ttrt/binary/module.cpp
+++ b/runtime/tools/python/ttrt/binary/module.cpp
@@ -38,7 +38,6 @@ PYBIND11_MODULE(_C, m) {
              const ::tt::target::GoldenTensor *goldenTensor =
                  binary.getDebugInfoGolden(loc);
              if (goldenTensor == nullptr) {
-               ::flatbuffers::FlatBufferBuilder fbb;
                return py::none();
              }
              return goldenTensor;

--- a/runtime/tools/python/ttrt/binary/module.cpp
+++ b/runtime/tools/python/ttrt/binary/module.cpp
@@ -57,7 +57,39 @@ PYBIND11_MODULE(_C, m) {
    * Binding for the `GoldenTensor` type
    */
   py::class_<tt::target::GoldenTensor>(m, "GoldenTensor", py::buffer_protocol())
-      // TODO: bind shape, name, and stride properties
+      .def_property_readonly(
+          "name",
+          [](::tt::target::GoldenTensor const *t) -> std::string {
+            if (t == nullptr) {
+              throw std::runtime_error("GoldenTensor cannot be null");
+            }
+            if (t->name() == nullptr) {
+              throw std::runtime_error("GoldenTensor `name` is null");
+            }
+            return t->name()->str();
+          })
+      .def_property_readonly(
+          "shape",
+          [](::tt::target::GoldenTensor const *t) -> std::vector<int> {
+            if (t == nullptr) {
+              throw std::runtime_error("GoldenTensor cannot be null");
+            }
+            if (t->shape() == nullptr) {
+              throw std::runtime_error("GoldenTensor `shape` pointer is null");
+            }
+            return std::vector<int>(t->shape()->begin(), t->shape()->end());
+          })
+      .def_property_readonly(
+          "stride",
+          [](::tt::target::GoldenTensor const *t) -> std::vector<int> {
+            if (t == nullptr) {
+              throw std::runtime_error("GoldenTensor cannot be null");
+            }
+            if (t->stride() == nullptr) {
+              throw std::runtime_error("GoldenTensor `stride` pointer is null");
+            }
+            return std::vector<int>(t->stride()->begin(), t->stride()->end());
+          })
       .def_property_readonly("dtype", &::tt::target::GoldenTensor::dtype)
       .def_buffer([](tt::target::GoldenTensor const *t) -> py::buffer_info {
         // NULL checks

--- a/runtime/tools/python/ttrt/binary/module.cpp
+++ b/runtime/tools/python/ttrt/binary/module.cpp
@@ -32,16 +32,8 @@ PYBIND11_MODULE(_C, m) {
                              &tt::runtime::Binary::getFileIdentifier)
       .def("as_json", &tt::runtime::Binary::asJson)
       .def("store", &tt::runtime::Binary::store)
-      .def("get_debug_info_golden",
-           [](tt::runtime::Binary &binary, std::string &loc)
-               -> std::variant<const ::tt::target::GoldenTensor *, py::object> {
-             const ::tt::target::GoldenTensor *goldenTensor =
-                 binary.getDebugInfoGolden(loc);
-             if (goldenTensor == nullptr) {
-               return py::none();
-             }
-             return goldenTensor;
-           });
+      .def("get_debug_info_golden", &::tt::runtime::Binary::getDebugInfoGolden,
+           py::return_value_policy::reference);
   py::class_<tt::runtime::SystemDesc>(m, "SystemDesc")
       .def_property_readonly("version", &tt::runtime::SystemDesc::getVersion)
       .def_property_readonly("ttmlir_git_hash",

--- a/runtime/tools/python/ttrt/binary/module.cpp
+++ b/runtime/tools/python/ttrt/binary/module.cpp
@@ -60,54 +60,25 @@ PYBIND11_MODULE(_C, m) {
       .def_property_readonly(
           "name",
           [](::tt::target::GoldenTensor const *t) -> std::string {
-            if (t == nullptr) {
-              throw std::runtime_error("GoldenTensor cannot be null");
-            }
-            if (t->name() == nullptr) {
-              throw std::runtime_error("GoldenTensor `name` is null");
-            }
+            assert(t != nullptr && t->name() != nullptr);
             return t->name()->str();
           })
       .def_property_readonly(
           "shape",
           [](::tt::target::GoldenTensor const *t) -> std::vector<int> {
-            if (t == nullptr) {
-              throw std::runtime_error("GoldenTensor cannot be null");
-            }
-            if (t->shape() == nullptr) {
-              throw std::runtime_error("GoldenTensor `shape` pointer is null");
-            }
+            assert(t != nullptr && t->shape() != nullptr);
             return std::vector<int>(t->shape()->begin(), t->shape()->end());
           })
       .def_property_readonly(
           "stride",
           [](::tt::target::GoldenTensor const *t) -> std::vector<int> {
-            if (t == nullptr) {
-              throw std::runtime_error("GoldenTensor cannot be null");
-            }
-            if (t->stride() == nullptr) {
-              throw std::runtime_error("GoldenTensor `stride` pointer is null");
-            }
+            assert(t != nullptr && t->stride() != nullptr);
             return std::vector<int>(t->stride()->begin(), t->stride()->end());
           })
       .def_property_readonly("dtype", &::tt::target::GoldenTensor::dtype)
       .def_buffer([](tt::target::GoldenTensor const *t) -> py::buffer_info {
-        // NULL checks
-        if (t == nullptr) {
-          throw std::runtime_error("Cannot bind a null pointer");
-        }
-
-        if (t->data() == nullptr) {
-          throw std::runtime_error("GoldenTensor `data` pointer is null!");
-        }
-
-        if (t->shape() == nullptr) {
-          throw std::runtime_error("GoldenTensor `shape` pointer is null!");
-        }
-
-        if (t->stride() == nullptr) {
-          throw std::runtime_error("GoldenTensor `stride` pointer is null!");
-        }
+        assert(t != nullptr && t->data() != nullptr && t->shape() != nullptr &&
+               t->stride() != nullptr);
 
         // Format string to be passed to `py::buffer_info`
         std::string format;

--- a/runtime/tools/python/ttrt/binary/module.cpp
+++ b/runtime/tools/python/ttrt/binary/module.cpp
@@ -57,6 +57,8 @@ PYBIND11_MODULE(_C, m) {
    * Binding for the `GoldenTensor` type
    */
   py::class_<tt::target::GoldenTensor>(m, "GoldenTensor", py::buffer_protocol())
+      // TODO: bind shape, name, and stride properties
+      .def_property_readonly("dtype", &::tt::target::GoldenTensor::dtype)
       .def_buffer([](tt::target::GoldenTensor const *t) -> py::buffer_info {
         // NULL checks
         if (t == nullptr) {

--- a/runtime/tools/python/ttrt/common/golden.py
+++ b/runtime/tools/python/ttrt/common/golden.py
@@ -117,7 +117,7 @@ def golden_partial_function(
     print("-----------executing golden comparision-----------")
 
     try:
-        op_debug_str = ttrt.runtime.get_op_debug_str(op_context)
+        op_debug_str = ttrt.runtime.get_op_debug_str(opContext)
 
         # find matching golden tensor based on loc in op debug string
         match = re.search(r"loc\(([^)]+)\)", op_debug_str)

--- a/runtime/tools/python/ttrt/common/golden.py
+++ b/runtime/tools/python/ttrt/common/golden.py
@@ -148,9 +148,9 @@ def golden_partial_function(
             op_context, program_context
         )
 
-        # if len(op_golden_tensor) == 0:
-        #    print("Golden tensor is empty - skipping golden comparison")
-        #    return
+        if op_golden_tensor is None:
+            print("Golden tensor is None - skipping golden comparison")
+            return
 
         # if len(op_output_tensor) == 0:
         #    print("Output tensor is empty - skipping golden comparison")
@@ -165,7 +165,8 @@ def golden_partial_function(
         golden_tensor_torch = torch.frombuffer(
             op_golden_tensor, dtype=torch.float32
         ).flatten()
-        output_tensor_torch = torch.frombuffer(
+
+        output_tensor_torch = torch.tensor(
             op_output_tensor, dtype=torch.float32
         ).flatten()
 

--- a/runtime/tools/python/ttrt/common/golden.py
+++ b/runtime/tools/python/ttrt/common/golden.py
@@ -19,7 +19,7 @@ import re
 from functools import partial
 
 from ttrt.common.util import *
-from ttrt.runtime import DataType
+from ttrt.runtime._C import DataType
 
 
 class GoldenRuntimeConfig:
@@ -157,22 +157,8 @@ def golden_partial_function(
             print("Output tensor is empty - skipping golden comparison")
             return
 
-        # Determine the element type of the golden tensor
-        match op_golden_tensor.dtype:
-            case DataType.Float32:
-                dtype = torch.float32
-            case DataType.UInt32:
-                dtype = torch.uint32
-            case DataType.UInt16:
-                dtype = torch.uint16
-            case DataType.UInt8:
-                dtype = torch.uint8
-            case _:
-                raise ValueError(
-                    "Only F32 and unsigned integers are supported for `GoldenTensor`s"
-                )
+        dtype = ttrt_datatype_to_torch_dtype(op_golden_tensor.dtype)
 
-        # Convert golden tensor buffer to a torch tensor
         golden_tensor_torch = torch.frombuffer(op_golden_tensor, dtype=dtype).flatten()
 
         output_tensor_torch = torch.tensor(op_output_tensor, dtype=dtype).flatten()

--- a/runtime/tools/python/ttrt/common/golden.py
+++ b/runtime/tools/python/ttrt/common/golden.py
@@ -2,19 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import os
-import json
-import importlib.machinery
-import sys
-import signal
-import os
-import io
-import subprocess
-import time
-import socket
-from pkg_resources import get_distribution
-import shutil
-import atexit
 import re
 from functools import partial
 

--- a/runtime/tools/python/ttrt/common/golden.py
+++ b/runtime/tools/python/ttrt/common/golden.py
@@ -117,7 +117,7 @@ def golden_partial_function(
     print("-----------executing golden comparision-----------")
 
     try:
-        op_debug_str = ttrt.runtime.get_op_debug_str(opContext)
+        op_debug_str = ttrt.runtime.get_op_debug_str(op_context)
 
         # find matching golden tensor based on loc in op debug string
         match = re.search(r"loc\(([^)]+)\)", op_debug_str)

--- a/runtime/tools/python/ttrt/common/golden.py
+++ b/runtime/tools/python/ttrt/common/golden.py
@@ -162,10 +162,10 @@ def golden_partial_function(
             )
             return
 
-        golden_tensor_torch = torch.tensor(
+        golden_tensor_torch = torch.frombuffer(
             op_golden_tensor, dtype=torch.float32
         ).flatten()
-        output_tensor_torch = torch.tensor(
+        output_tensor_torch = torch.frombuffer(
             op_output_tensor, dtype=torch.float32
         ).flatten()
 

--- a/runtime/tools/python/ttrt/common/golden.py
+++ b/runtime/tools/python/ttrt/common/golden.py
@@ -152,20 +152,17 @@ def golden_partial_function(
             print("Golden tensor is None - skipping golden comparison")
             return
 
-        # if len(op_output_tensor) == 0:
-        #    print("Output tensor is empty - skipping golden comparison")
-        #    return
+        if len(op_output_tensor) == 0:
+            print("Output tensor is empty - skipping golden comparison")
+            return
 
-        # if len(op_golden_tensor) != len(op_output_tensor):
-        #    print(
-        #        "Golden and output tensor sizes do not match - skipping golden comparison"
-        #    )
-        #    return
-
+        # Convert golden tensor buffer to a torch tensor
+        # TODO: figure out how to glean the intended type from the buffer
         golden_tensor_torch = torch.frombuffer(
             op_golden_tensor, dtype=torch.float32
         ).flatten()
 
+        # TODO: figure out how to glean the intended type from the buffer
         output_tensor_torch = torch.tensor(
             op_output_tensor, dtype=torch.float32
         ).flatten()
@@ -179,6 +176,12 @@ def golden_partial_function(
                 output_tensor_torch,
                 f"{golden_runtime_config.artifact_dir}/{loc}_device.pt",
             )
+
+        if golden_tensor_torch.shape != output_tensor_torch.shape:
+            print(
+                "Golden and output tensor shapes do not match - skipping golden comparison"
+            )
+            return
 
         _, _, cal_pcc, output_str = get_atol_rtol_pcc(
             golden_tensor_torch, output_tensor_torch

--- a/runtime/tools/python/ttrt/common/golden.py
+++ b/runtime/tools/python/ttrt/common/golden.py
@@ -148,19 +148,19 @@ def golden_partial_function(
             op_context, program_context
         )
 
-        if len(op_golden_tensor) == 0:
-            print("Golden tensor is empty - skipping golden comparison")
-            return
+        # if len(op_golden_tensor) == 0:
+        #    print("Golden tensor is empty - skipping golden comparison")
+        #    return
 
-        if len(op_output_tensor) == 0:
-            print("Output tensor is empty - skipping golden comparison")
-            return
+        # if len(op_output_tensor) == 0:
+        #    print("Output tensor is empty - skipping golden comparison")
+        #    return
 
-        if len(op_golden_tensor) != len(op_output_tensor):
-            print(
-                "Golden and output tensor sizes do not match - skipping golden comparison"
-            )
-            return
+        # if len(op_golden_tensor) != len(op_output_tensor):
+        #    print(
+        #        "Golden and output tensor sizes do not match - skipping golden comparison"
+        #    )
+        #    return
 
         golden_tensor_torch = torch.frombuffer(
             op_golden_tensor, dtype=torch.float32

--- a/runtime/tools/python/ttrt/common/golden.py
+++ b/runtime/tools/python/ttrt/common/golden.py
@@ -19,7 +19,6 @@ import re
 from functools import partial
 
 from ttrt.common.util import *
-from ttrt.runtime._C import DataType
 
 
 class GoldenRuntimeConfig:

--- a/runtime/tools/python/ttrt/common/run.py
+++ b/runtime/tools/python/ttrt/common/run.py
@@ -20,8 +20,6 @@ from ttrt.common.util import *
 from ttrt.common.query import Query
 from ttrt.common.golden import get_golden_fn, GoldenRuntimeConfig
 
-from ttrt.runtime._C import DataType
-
 
 class Run:
     registered_args = {}
@@ -594,6 +592,7 @@ class Run:
                         continue
             finally:
                 ttrt.runtime.close_device(device)
+                ttrt.runtime.unregister_hooks()
 
         self.logging.debug(f"executing ttnn binaries")
         _execute(self.ttnn_binaries)

--- a/runtime/tools/python/ttrt/common/run.py
+++ b/runtime/tools/python/ttrt/common/run.py
@@ -406,10 +406,15 @@ class Run:
                                     f"input_{i}"
                                 )
 
-                                if len(golden_tensor) != 0:
-                                    golden_inputs.append(
-                                        torch.tensor(golden_tensor, dtype=torch.float32)
-                                    )
+                                golden_tensor_torch = torch.frombuffer(
+                                    golden_tensor, dtype=torch.float32
+                                )
+                                print(
+                                    "Converted a `GoldenTensor` buffer to a `torch.tensor`"
+                                )
+
+                                if len(golden_tensor_torch) != 0:
+                                    golden_inputs.append(golden_tensor_torch)
 
                             program.populate_inputs(
                                 Run.TorchInitializer.get_initilizer(self["--init"]),

--- a/runtime/tools/python/ttrt/common/run.py
+++ b/runtime/tools/python/ttrt/common/run.py
@@ -20,7 +20,7 @@ from ttrt.common.util import *
 from ttrt.common.query import Query
 from ttrt.common.golden import get_golden_fn, GoldenRuntimeConfig
 
-from ttrt.runtime import DataType
+from ttrt.runtime._C import DataType
 
 
 class Run:
@@ -409,20 +409,10 @@ class Run:
                                 )
 
                                 if golden_tensor is not None:
-                                    # Determine the element type of the golden tensor
-                                    match golden_tensor.dtype:
-                                        case DataType.Float32:
-                                            dtype = torch.float32
-                                        case DataType.UInt32:
-                                            dtype = torch.uint32
-                                        case DataType.UInt16:
-                                            dtype = torch.uint16
-                                        case DataType.UInt8:
-                                            dtype = torch.uint8
-                                        case _:
-                                            raise ValueError(
-                                                "Only F32 and unsigned integers are supported for `GoldenTensor`s"
-                                            )
+
+                                    dtype = ttrt_datatype_to_torch_dtype(
+                                        golden_tensor.dtype
+                                    )
 
                                     golden_tensor_torch = torch.frombuffer(
                                         golden_tensor, dtype=dtype

--- a/runtime/tools/python/ttrt/common/run.py
+++ b/runtime/tools/python/ttrt/common/run.py
@@ -592,7 +592,6 @@ class Run:
                         continue
             finally:
                 ttrt.runtime.close_device(device)
-                ttrt.runtime.unregister_hooks()
 
         self.logging.debug(f"executing ttnn binaries")
         _execute(self.ttnn_binaries)

--- a/runtime/tools/python/ttrt/common/run.py
+++ b/runtime/tools/python/ttrt/common/run.py
@@ -406,14 +406,10 @@ class Run:
                                     f"input_{i}"
                                 )
 
-                                golden_tensor_torch = torch.frombuffer(
-                                    golden_tensor, dtype=torch.float32
-                                )
-                                print(
-                                    "Converted a `GoldenTensor` buffer to a `torch.tensor`"
-                                )
-
-                                if len(golden_tensor_torch) != 0:
+                                if golden_tensor is not None:
+                                    golden_tensor_torch = torch.frombuffer(
+                                        golden_tensor, dtype=torch.float32
+                                    )
                                     golden_inputs.append(golden_tensor_torch)
 
                             program.populate_inputs(

--- a/runtime/tools/python/ttrt/common/run.py
+++ b/runtime/tools/python/ttrt/common/run.py
@@ -20,6 +20,8 @@ from ttrt.common.util import *
 from ttrt.common.query import Query
 from ttrt.common.golden import get_golden_fn, GoldenRuntimeConfig
 
+from ttrt.runtime import DataType
+
 
 class Run:
     registered_args = {}
@@ -407,8 +409,23 @@ class Run:
                                 )
 
                                 if golden_tensor is not None:
+                                    # Determine the element type of the golden tensor
+                                    match golden_tensor.dtype:
+                                        case DataType.Float32:
+                                            dtype = torch.float32
+                                        case DataType.UInt32:
+                                            dtype = torch.uint32
+                                        case DataType.UInt16:
+                                            dtype = torch.uint16
+                                        case DataType.UInt8:
+                                            dtype = torch.uint8
+                                        case _:
+                                            raise ValueError(
+                                                "Only F32 and unsigned integers are supported for `GoldenTensor`s"
+                                            )
+
                                     golden_tensor_torch = torch.frombuffer(
-                                        golden_tensor, dtype=torch.float32
+                                        golden_tensor, dtype=dtype
                                     )
                                     golden_inputs.append(golden_tensor_torch)
 

--- a/runtime/tools/python/ttrt/common/run.py
+++ b/runtime/tools/python/ttrt/common/run.py
@@ -3,18 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-import json
-import importlib.machinery
-import sys
-import signal
-import os
-import io
-import subprocess
-import time
-import socket
-from pkg_resources import get_distribution
-import shutil
-import atexit
 
 from ttrt.common.util import *
 from ttrt.common.query import Query

--- a/runtime/tools/python/ttrt/common/util.py
+++ b/runtime/tools/python/ttrt/common/util.py
@@ -11,7 +11,6 @@ import shutil
 
 import torch
 
-from ttrt.runtime._C import DataType
 
 # environment tweaks
 if "LOGGER_LEVEL" not in os.environ:
@@ -20,7 +19,9 @@ if "TT_METAL_LOGGER_LEVEL" not in os.environ:
     os.environ["TT_METAL_LOGGER_LEVEL"] = "FATAL"
 
 
-def ttrt_datatype_to_torch_dtype(dtype: DataType) -> torch.dtype:
+def ttrt_datatype_to_torch_dtype(dtype) -> torch.dtype:
+    from ttrt.runtime._C import DataType
+
     """Converts a PyBound `::tt::target::DataType` into a `torch.dtype`.
 
     Currently, only `float32`, `uint32`, `uint16`, & `uint8` are supported for

--- a/runtime/tools/python/ttrt/common/util.py
+++ b/runtime/tools/python/ttrt/common/util.py
@@ -16,13 +16,54 @@ import socket
 from pkg_resources import get_distribution
 import shutil
 
+import torch
+
 import ttrt.binary
+from ttrt.runtime._C import DataType
 
 # environment tweaks
 if "LOGGER_LEVEL" not in os.environ:
     os.environ["LOGGER_LEVEL"] = "FATAL"
 if "TT_METAL_LOGGER_LEVEL" not in os.environ:
     os.environ["TT_METAL_LOGGER_LEVEL"] = "FATAL"
+
+
+def ttrt_datatype_to_torch_dtype(dtype: DataType) -> torch.dtype:
+    """Converts a PyBound `::tt::target::DataType` into a `torch.dtype`.
+
+    Currently, only `float32`, `uint32`, `uint16`, & `uint8` are supported for
+    this conversion
+
+    Arguments
+    ---------
+
+    dtype : DataType
+        A datatype from the PyBound `DataType` enum from ttrt
+
+    Returns
+    -------
+
+    A `torch.dtype` corresponding to `dtype`
+
+    Throws
+    ------
+
+    A `ValueError` if `dtype` is not one of `Float32`, `UInt32`, `UInt16`, or `UInt8`
+
+    """
+    match dtype:
+        case DataType.Float32:
+            return torch.float32
+        case DataType.UInt32:
+            return torch.uint32
+        case DataType.UInt16:
+            return torch.uint16
+        case DataType.UInt8:
+            return torch.uint8
+        case _:
+            raise ValueError(
+                "Only F32 and unsigned integers are supported in the runtime"
+            )
 
 
 def get_ttrt_metal_home_path():

--- a/runtime/tools/python/ttrt/common/util.py
+++ b/runtime/tools/python/ttrt/common/util.py
@@ -6,19 +6,11 @@ import os
 import json
 import importlib.machinery
 import importlib.util
-import sys
-import signal
-import os
-import io
-import subprocess
-import time
-import socket
 from pkg_resources import get_distribution
 import shutil
 
 import torch
 
-import ttrt.binary
 from ttrt.runtime._C import DataType
 
 # environment tweaks

--- a/runtime/tools/python/ttrt/runtime/__init__.py
+++ b/runtime/tools/python/ttrt/runtime/__init__.py
@@ -31,6 +31,7 @@ try:
         deallocate_tensor,
         WorkaroundEnv,
         get_op_loc_info,
+        unregister_hooks,
     )
 except ModuleNotFoundError:
     raise ImportError(

--- a/runtime/tools/python/ttrt/runtime/module.cpp
+++ b/runtime/tools/python/ttrt/runtime/module.cpp
@@ -234,13 +234,9 @@ PYBIND11_MODULE(_C, m) {
         []() { ::tt::runtime::debug::Hooks::get().unregisterHooks(); });
   /**
    * Cleanup code to force a well ordered destruction w.r.t. the GIL
-   *
-   * TODO: `clangd` reports that `capsule` is deprecated, figure out how to do
-   * this canonically
    */
-  static int unused; // the capsule needs something to reference
-  py::capsule cleanup(&unused, [](PyObject *) {
+  auto cleanup_callback = []() {
     ::tt::runtime::debug::Hooks::get().unregisterHooks();
-  });
-  m.add_object("_cleanup", cleanup);
+  };
+  m.add_object("_cleanup", py::capsule(cleanup_callback));
 }

--- a/runtime/tools/python/ttrt/runtime/module.cpp
+++ b/runtime/tools/python/ttrt/runtime/module.cpp
@@ -232,11 +232,4 @@ PYBIND11_MODULE(_C, m) {
   m.add_object("_cleanup", py::capsule(cleanup_callback));
   m.def("unregister_hooks",
         []() { ::tt::runtime::debug::Hooks::get().unregisterHooks(); });
-  /**
-   * Cleanup code to force a well ordered destruction w.r.t. the GIL
-   */
-  auto cleanup_callback = []() {
-    ::tt::runtime::debug::Hooks::get().unregisterHooks();
-  };
-  m.add_object("_cleanup", py::capsule(cleanup_callback));
 }

--- a/runtime/tools/python/ttrt/runtime/module.cpp
+++ b/runtime/tools/python/ttrt/runtime/module.cpp
@@ -230,4 +230,6 @@ PYBIND11_MODULE(_C, m) {
     ::tt::runtime::debug::Hooks::get().unregisterHooks();
   };
   m.add_object("_cleanup", py::capsule(cleanup_callback));
+  m.def("unregister_hooks",
+        []() { ::tt::runtime::debug::Hooks::get().unregisterHooks(); });
 }

--- a/runtime/tools/python/ttrt/runtime/module.cpp
+++ b/runtime/tools/python/ttrt/runtime/module.cpp
@@ -232,4 +232,15 @@ PYBIND11_MODULE(_C, m) {
   m.add_object("_cleanup", py::capsule(cleanup_callback));
   m.def("unregister_hooks",
         []() { ::tt::runtime::debug::Hooks::get().unregisterHooks(); });
+  /**
+   * Cleanup code to force a well ordered destruction w.r.t. the GIL
+   *
+   * TODO: `clangd` reports that `capsule` is deprecated, figure out how to do
+   * this canonically
+   */
+  static int unused; // the capsule needs something to reference
+  py::capsule cleanup(&unused, [](PyObject *) {
+    ::tt::runtime::debug::Hooks::get().unregisterHooks();
+  });
+  m.add_object("_cleanup", cleanup);
 }


### PR DESCRIPTION
This change introduces a PyBound class `GoldenTensor` that reflects the same type from TTRT. This binding supports the following element types for a `GoldenTensor`:
  - uint8
  - uint16
  - uint32
  - float32

Closes #1294 