### PR TITLE
Fix: input and output must have same shape for matching shapes

### DIFF
--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -42,7 +42,7 @@ namespace mlir::tt::ttnn {
   const RankedTensorType outputTensorType =
       mlir::cast<RankedTensorType>(outputs.front().getType());
 
-  if (inputTensorType != outputTensorType) {
+  if (inputTensorType.getShape() != outputTensorType.getShape()) {
     return emitOpError("input and output must have same shape.");
   }
 


### PR DESCRIPTION
Fixes #1360 

Logs with `error: 'ttnn.clamp' op input and output must have same shape.`
[distilbert_before.log](https://github.com/user-attachments/files/17841299/distilbert_before.log)
[bart_before.log](https://github.com/user-attachments/files/17841304/bart_before.log)

Logs after fix:
[distilbert_log.log](https://github.com/user-attachments/files/17841302/distilbert_log.log)
[bart_log.log](https://github.com/user-attachments/files/17841303/bart_log.log)
