### PR TITLE
Ignore `*.ttnn` & `*.ttm` Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ query_results.json
 run_results.json
 ttrt_report.xml
 cluster_descriptor.yaml
+
+# TTNN and TTMetal flatbuffers
+*.ttnn
+*.ttm


### PR DESCRIPTION
These flatbuffer files are generated as part of `test_infra`, and should not be comitted.