### PR TITLE
Workaround pass - Initial implementation

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/CMakeLists.txt
+++ b/include/ttmlir/Dialect/TTNN/IR/CMakeLists.txt
@@ -3,6 +3,7 @@ add_mlir_doc(TTNNBase TTNNDialect src/autogen/md/Dialect/ -gen-dialect-doc)
 add_mlir_doc(TTNNOps TTNNOp src/autogen/md/Dialect/ -gen-op-doc)
 
 add_mlir_interface(TTNNOpModelInterface)
+add_mlir_interface(TTNNWorkaroundInterface)
 
 set(LLVM_TARGET_DEFINITIONS TTNNOpsEnums.td)
 mlir_tablegen(TTNNOpsEnums.h.inc -gen-enum-decls)

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNBase.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNBase.td
@@ -7,6 +7,7 @@
 
 include "mlir/IR/OpBase.td"
 include "ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.td"
+include "ttmlir/Dialect/TTNN/IR/TTNNWorkaroundInterface.td"
 
 //===----------------------------------------------------------------------===//
 // TTNN dialect definition.
@@ -44,6 +45,6 @@ def TTNN_Dialect : Dialect {
 //===----------------------------------------------------------------------===//
 
 class TTNN_Op<string mnemonic, list<Trait> traits = []> :
-        Op<TTNN_Dialect, mnemonic, !listconcat(traits, [TTNN_OpModelInterface])>;
+        Op<TTNN_Dialect, mnemonic, !listconcat(traits, [TTNN_OpModelInterface, TTNN_WorkaroundInterface])>;
 
 #endif

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.h
@@ -18,6 +18,7 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsTypes.h"
 
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.h.inc"
+#include "ttmlir/Dialect/TTNN/IR/TTNNWorkaroundInterface.h"
 
 #define GET_OP_CLASSES
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h.inc"

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -174,6 +174,17 @@ def TTNN_AbsOp : TTNN_ElementwiseUnaryOp<"abs"> {
     let description = [{
       Eltwise absolute operation.
     }];
+
+    let extraClassDeclaration = [{
+      MutableOperandRange getDpsInitsMutable() { return getOutputsMutable(); }
+      wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
+        wa::TTNNOperandWorkarounds tileLayoutWorkaround = wa::TTNNOperandWorkarounds(Layout::Tile);
+        return wa::TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
+        .addInputOperandWorkaround(tileLayoutWorkaround)
+        .addInputOperandWorkaround(tileLayoutWorkaround)
+        .addOutputOperandWorkaround(tileLayoutWorkaround);
+      }
+    }];
 }
 
 def TTNN_CbrtOp : TTNN_ElementwiseUnaryOp<"cbrt"> {
@@ -325,7 +336,7 @@ def TTNN_Expm1Op: TTNN_ElementwiseUnaryOp<"expm1"> {
   }];
 }
 
-class TTIR_ElementwiseUnaryWithFloatParameterOp<string mnemonic, list<Trait> traits = []> :
+class TTNN_ElementwiseUnaryWithFloatParameterOp<string mnemonic, list<Trait> traits = []> :
     TTNN_ElementwiseUnaryOp<mnemonic, traits> {
     let summary = "Eltwise unary op with the float parameter.";
     let description = [{
@@ -345,7 +356,7 @@ class TTIR_ElementwiseUnaryWithFloatParameterOp<string mnemonic, list<Trait> tra
     ];
 }
 
-def TTIR_LeakyReluOp : TTIR_ElementwiseUnaryWithFloatParameterOp<"leaky_relu"> {
+def TTNN_LeakyReluOp : TTNN_ElementwiseUnaryWithFloatParameterOp<"leaky_relu"> {
     let summary = "Eltwise leaky relu operation.";
     let description = [{
       The Leaky ReLU (Rectified Linear Unit) operation computes an element-wise
@@ -783,6 +794,14 @@ def TTNN_EmptyOp : TTNN_Op<"empty", [NoMemoryEffect]> {
                          OptionalAttr<TTNN_LayoutAttr>:$layout,
                          OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
     let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
+        wa::TTNNOperandWorkarounds rowMajorLayoutWorkaround = wa::TTNNOperandWorkarounds(Layout::RowMajor);
+        return wa::TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
+        .addOutputOperandWorkaround(rowMajorLayoutWorkaround);
+      }
+    }];
 
     let hasVerifier = 1;
 }

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
@@ -92,6 +92,9 @@ def TTNN_MemoryConfigAttr : TTNN_Attr<"MemoryConfig", "memory_config"> {
     {
       return this->getShardSpec().getShardShape().getShape();
     }
+
+    MemoryConfigAttr withBufferType(::mlir::MLIRContext *context, BufferType bufferType);
+    MemoryConfigAttr withMemoryLayout(::mlir::MLIRContext *context, TensorMemoryLayout memLayout);
   }];
 }
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundInterface.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundInterface.h
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+#ifndef TTMLIR_DIALECT_TTNN_IR_TTNNWORKAROUNDINTERFACE_H
+#define TTMLIR_DIALECT_TTNN_IR_TTNNWORKAROUNDINTERFACE_H
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNWorkarounds.h"
+
+#include "mlir/IR/Operation.h"
+
+namespace mlir::tt::ttnn::wa {
+// Verifies the TTNNWorkaroundInterface
+mlir::LogicalResult verifyTTNNWorkaroundInterface(mlir::Operation *op);
+} // namespace mlir::tt::ttnn::wa
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNWorkaroundInterface.h.inc"
+
+#endif

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundInterface.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundInterface.td
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_TTMLIR_DIALECT_TTNN_IR_TTNN_WORKAROUND_INTERFACE_TD
+#define TTMLIR_TTMLIR_DIALECT_TTNN_IR_TTNN_WORKAROUND_INTERFACE_TD
+
+include "mlir/IR/OpBase.td"
+
+// This interface is used to specify workarounds for TTNN operations.
+def TTNN_WorkaroundInterface : OpInterface<"TTNNWorkaroundInterface"> {
+  let cppNamespace = "::mlir::tt::ttnn::wa";
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns the workarounds associated with each operand and result of this operation.
+        If the operation is a Destination-Passing Style (DPS) operation, the same workarounds
+        must apply to both the DPS initial operands and the operation results. These constraints
+        are verified through the interface verifier.
+
+        For example, consider the following ttnn operations:
+        %0 = "ttnn.empty"() : () -> tensor<1x1xf32>
+        %1 = "ttnn.abs"(%arg0, %0) : (tensor<1x1xf32>, tensor<1x1xf32>) -> tensor<1x1xf32>
+
+        In this example:
+          - The ttnn.abs operation has two input operand workarounds.
+          - It has one output operand workaround.
+          - The output workaround must match the workaround for the second input operand,
+          ensuring consistency as required by the DPS pattern.
+      }],
+      /*retTy=*/"TTNNOperandsWorkarounds",
+      /*methodName=*/"getOperandsWorkarounds",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        // Return default empty workarounds for all input and output operands
+        return TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds(this->getOperation());
+      }]
+    >,
+  ];
+
+  let verify = [{
+    return verifyTTNNWorkaroundInterface($_op);
+  }];
+}
+
+#endif

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkarounds.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkarounds.h
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_IR_TTNNWORKAROUNDS_H
+#define TTMLIR_DIALECT_TTNN_IR_TTNNWORKAROUNDS_H
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+
+#include "mlir/IR/Operation.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <optional>
+
+namespace mlir::tt::ttnn::wa {
+using TensorLayoutWorkaround = std::optional<Layout>;
+using TensorBufferTypeWorkaround = std::optional<BufferType>;
+using TensorMemoryLayoutWorkaround = std::optional<TensorMemoryLayout>;
+
+// Struct that encapsulates operand workarounds.
+// It contains tensor layout, tensor buffer type and tensor memory layout
+// workarounds.
+struct TTNNOperandWorkarounds {
+  // Tensor layout workaround.
+  TensorLayoutWorkaround tensorLayoutWorkaround;
+
+  // Tensor buffer type workaround.
+  TensorBufferTypeWorkaround tensorBufferTypeWorkaround;
+
+  // Tensor memory layout workaround.
+  TensorMemoryLayoutWorkaround tensorMemoryLayoutWorkaround;
+
+  TTNNOperandWorkarounds() = default;
+
+  // Constructor that takes tensor layout, tensor buffer type and tensor memory.
+  TTNNOperandWorkarounds(
+      TensorLayoutWorkaround tensorLayoutWorkaround,
+      TensorBufferTypeWorkaround tensorBufferTypeWorkaround,
+      TensorMemoryLayoutWorkaround tensorMemoryLayoutWorkaround)
+      : tensorLayoutWorkaround(tensorLayoutWorkaround),
+        tensorBufferTypeWorkaround(tensorBufferTypeWorkaround),
+        tensorMemoryLayoutWorkaround(tensorMemoryLayoutWorkaround) {}
+
+  // Constructor that takes tensor layout workaround and sets the other
+  // workarounds to nullopt.
+  TTNNOperandWorkarounds(TensorLayoutWorkaround tensorLayoutWorkaround)
+      : TTNNOperandWorkarounds(tensorLayoutWorkaround, std::nullopt,
+                               std::nullopt) {}
+
+  // Constructor that takes tensor buffer type workaround and sets the other
+  // workarounds to nullopt.
+  TTNNOperandWorkarounds(TensorBufferTypeWorkaround tensorBufferTypeWorkaround)
+      : TTNNOperandWorkarounds(std::nullopt, tensorBufferTypeWorkaround,
+                               std::nullopt) {}
+
+  // Constructor that takes tensor memory layout workaround and sets the other
+  // workarounds to nullopt.
+  TTNNOperandWorkarounds(
+      TensorMemoryLayoutWorkaround tensorMemoryLayoutWorkaround)
+      : TTNNOperandWorkarounds(std::nullopt, std::nullopt,
+                               tensorMemoryLayoutWorkaround) {}
+
+  // Operand workarounds factory methods.
+  static TTNNOperandWorkarounds createEmptyTTNNOperandWorkarounds();
+
+  // Equality operator.
+  bool operator==(const TTNNOperandWorkarounds &rhs) const {
+    return tensorLayoutWorkaround == rhs.tensorLayoutWorkaround &&
+           tensorBufferTypeWorkaround == rhs.tensorBufferTypeWorkaround &&
+           tensorMemoryLayoutWorkaround == rhs.tensorMemoryLayoutWorkaround;
+  }
+
+  // Inequality operator.
+  bool operator!=(const TTNNOperandWorkarounds &rhs) const {
+    return !(*this == rhs);
+  }
+
+  // Returns true if any of the workarounds is set.
+  bool hasAnyWorkaround() const {
+    return tensorLayoutWorkaround || tensorBufferTypeWorkaround ||
+           tensorMemoryLayoutWorkaround;
+  }
+};
+
+// Struct that encapsulates the result of applying the workarounds.
+// It contains the target tensor layout, buffer type and tensor memory layout
+// results and a flag indicating whether the workarounds were applied.
+struct WorkaroundResult {
+  // Target tensor layout.
+  std::pair<Layout, bool> targetTensorLayoutResult;
+
+  // Target tensor buffer type.
+  std::pair<BufferType, bool> targetTensorBufferTypeResult;
+
+  // Target tensor memory layout.
+  std::pair<TensorMemoryLayout, bool> targetTensorMemoryLayoutResult;
+
+  // Returns true if any of the workarounds were applied.
+  bool modified() const {
+    return targetTensorLayoutResult.second ||
+           targetTensorBufferTypeResult.second ||
+           targetTensorMemoryLayoutResult.second;
+  }
+};
+
+// Apply the operand workarounds to the layout attribute that contains
+// tensor layout, buffer type and tensor memory layout arguments.
+// Returns the result of applying the workarounds.
+WorkaroundResult applyWorkarounds(const TTNNOperandWorkarounds &workaround,
+                                  const TTNNLayoutAttr &inputLayoutAttr);
+
+// Class that encapsulates operands workarounds.
+// It contains input and output workarounds for operands.
+class TTNNOperandsWorkarounds {
+public:
+  // Returns input operand workarounds.
+  llvm::ArrayRef<TTNNOperandWorkarounds> getInputOperandWorkarounds() const {
+    return inputOperandWorkarounds;
+  }
+
+  // Returns output operand workarounds.
+  llvm::ArrayRef<TTNNOperandWorkarounds> getOutputOperandWorkarounds() const {
+    return outputOperandWorkarounds;
+  }
+
+  // Adds input operand workaround.
+  TTNNOperandsWorkarounds &
+  addInputOperandWorkaround(TTNNOperandWorkarounds inputOperandWorkaround) {
+    inputOperandWorkarounds.emplace_back(inputOperandWorkaround);
+    return *this;
+  }
+
+  // Adds output operand workaround.
+  TTNNOperandsWorkarounds &
+  addOutputOperandWorkaround(TTNNOperandWorkarounds outputOperandWorkaround) {
+    outputOperandWorkarounds.emplace_back(outputOperandWorkaround);
+    return *this;
+  }
+
+  // Operands workarounds factory method.
+  static TTNNOperandsWorkarounds
+  createEmptyTTNNOperandsWorkarounds(int inputSize, int outputSize);
+
+  // Operands workarounds factory method.
+  static TTNNOperandsWorkarounds createEmptyTTNNOperandsWorkarounds() {
+    return createEmptyTTNNOperandsWorkarounds(0, 0);
+  }
+
+  // Operands workarounds factory method.
+  static TTNNOperandsWorkarounds
+  createEmptyTTNNOperandsWorkarounds(Operation *op);
+
+private:
+  // Default constructor with no workarounds.
+  TTNNOperandsWorkarounds() {}
+
+  // Constructor that takes input and output workarounds for operands.
+  TTNNOperandsWorkarounds(
+      llvm::SmallVector<TTNNOperandWorkarounds> inputOperandWorkarounds,
+      llvm::SmallVector<TTNNOperandWorkarounds> outputOperandWorkarounds)
+      : inputOperandWorkarounds(std::move(inputOperandWorkarounds)),
+        outputOperandWorkarounds(std::move(outputOperandWorkarounds)) {}
+
+  // Workarounds for input operands.
+  llvm::SmallVector<TTNNOperandWorkarounds> inputOperandWorkarounds;
+
+  // Workarounds for output operands.
+  llvm::SmallVector<TTNNOperandWorkarounds> outputOperandWorkarounds;
+};
+
+} // namespace mlir::tt::ttnn::wa
+
+#endif

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -112,6 +112,12 @@ struct TTIRToTTNNBackendPipelineOptions
 
   ListOption<int64_t> meshShape{
       *this, "mesh-shape", llvm::cl::desc("Set the multi-device mesh shape.")};
+
+  // Option to enable/disable the workaround pass.
+  //
+  Option<bool> workaroundPassEnabled{*this, "enable-workaround-pass",
+                                     llvm::cl::desc("Enable workaround pass."),
+                                     llvm::cl::init(false)};
 };
 
 // TTIR to EmitC pipeline options.

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -28,4 +28,12 @@ def TTNNLayout : Pass<"ttnn-layout", "::mlir::ModuleOp"> {
   }];
 }
 
+def TTNNWorkarounds : Pass<"ttnn-workaround", "::mlir::ModuleOp"> {
+  let summary = "Apply TTNN workarounds to the IR.";
+  let description = [{
+    This pass applies necessary TTNN workarounds to the IR in order to create
+    a valid and functional IR that can be executed on the hardware.
+  }];
+}
+
 #endif

--- a/include/ttmlir/Dialect/TTNN/Utils/TransformUtils.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/TransformUtils.h
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_UTILS_TRANSFORMUTILS_H
+#define TTMLIR_DIALECT_TTNN_UTILS_TRANSFORMUTILS_H
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Value.h"
+
+namespace mlir::tt::ttnn::utils {
+// Get or insert device for the given operation.
+mlir::Value getOrInsertDevice(mlir::PatternRewriter &rewriter,
+                              mlir::Operation *op);
+} // namespace mlir::tt::ttnn::utils
+
+#endif

--- a/include/ttmlir/Dialect/TTNN/Utils/Utils.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/Utils.h
@@ -11,6 +11,8 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsTypes.h"
 
+#include "mlir/IR/BuiltinTypes.h"
+
 namespace mlir::tt::ttnn::utils {
 
 // Map tt::MemorySpace to ttnn::BufferType
@@ -35,6 +37,11 @@ toTTMemorySpace(const mlir::tt::ttnn::BufferType bufferType);
 
 mlir::Type createRowMajorTypeFromDtype(::mlir::MLIRContext *context,
                                        DataType dtype);
+
+// Helper method to create a RankedTensorType with the given encoding
+RankedTensorType
+createRankedTensorTypeWithEncoding(RankedTensorType tensorType,
+                                   ttnn::TTNNLayoutAttr encoding);
 
 } // namespace mlir::tt::ttnn::utils
 

--- a/include/ttmlir/Utils.h
+++ b/include/ttmlir/Utils.h
@@ -127,6 +127,11 @@ inline MlirAttribute wrapArrayOfMlirAttributesAsAttribute(
   return wrap(mlir::ArrayAttr::get(unwrap(ctx), unwrappedAttributesArray));
 }
 
+// Checks if the type of the given `mlir::Value` is a ranked tensor type.
+inline bool isRankedTensor(mlir::Value v) {
+  return mlir::isa<mlir::RankedTensorType>(v.getType());
+}
+
 } // namespace ttmlir::utils
 
 #endif

--- a/lib/Conversion/TTIRToTTNN/CMakeLists.txt
+++ b/lib/Conversion/TTIRToTTNN/CMakeLists.txt
@@ -11,4 +11,5 @@ add_mlir_library(TTMLIRTTIRToTTNN
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRPass
+  TTMLIRTTNNUtils
 )

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -9,6 +9,7 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/Dialect/TTNN/Types/Types.h"
+#include "ttmlir/Dialect/TTNN/Utils/TransformUtils.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
@@ -27,27 +28,6 @@ using namespace mlir;
 using namespace mlir::tt;
 
 namespace {
-
-// Gets or inserts a GetDeviceOp at the top of the current block of the given
-// operation.
-static Value getOrInsertDevice(ConversionPatternRewriter &rewriter,
-                               Operation *op) {
-  Block *block = op->getBlock();
-  for (auto &op : block->getOperations()) {
-    if (auto deviceOp = dyn_cast<ttnn::GetDeviceOp>(op)) {
-      return deviceOp.getResult();
-    }
-  }
-
-  DeviceAttr deviceAttr = getCurrentScopeDevice(op);
-  auto currentInsertionPoint = rewriter.saveInsertionPoint();
-  rewriter.setInsertionPoint(block, block->begin());
-  auto deviceOp = rewriter.create<ttnn::GetDeviceOp>(
-      op->getLoc(), rewriter.getType<DeviceType>(deviceAttr),
-      ttnn::MeshShapeAttr::get(op->getContext(), 1, 1));
-  rewriter.restoreInsertionPoint(currentInsertionPoint);
-  return deviceOp.getResult();
-}
 
 class TensorEmptyConversionPattern
     : public OpConversionPattern<tensor::EmptyOp> {
@@ -95,7 +75,7 @@ public:
 
     // Create MemoryConfigAttr
     //
-    auto device = getOrInsertDevice(rewriter, op);
+    auto device = ::ttnn::utils::getOrInsertDevice(rewriter, op);
     llvm::SmallVector<int64_t> shardShape = layoutAttr.getShardShape();
     ttnn::MemoryConfigAttr memoryConfigAttr = ttnn::MemoryConfigAttr::get(
         op.getContext(),
@@ -193,7 +173,8 @@ public:
     rewriter.replaceOpWithNewOp<ttnn::ToLayoutOp>(
         op, this->getTypeConverter()->convertType(result), adaptor.getInput(),
         outputLayout, outputDataType, outputMemConfigAttr,
-        isOutputOnHost ? nullptr : getOrInsertDevice(rewriter, op));
+        isOutputOnHost ? nullptr
+                       : ::ttnn::utils::getOrInsertDevice(rewriter, op));
 
     return success();
   }
@@ -520,7 +501,7 @@ public:
     }
 
     if (valueAttr.isSplat()) {
-      Value device = getOrInsertDevice(rewriter, op);
+      Value device = ::ttnn::utils::getOrInsertDevice(rewriter, op);
       float fillValue =
           valueAttr.getElementType().isInteger()
               ? getIntegerValue(valueAttr)
@@ -634,7 +615,7 @@ public:
   matchAndRewrite(ttir::Conv2dOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    auto device = getOrInsertDevice(rewriter, op);
+    auto device = ::ttnn::utils::getOrInsertDevice(rewriter, op);
     auto kernel_ty =
         mlir::cast<RankedTensorType>(adaptor.getWeight().getType());
     llvm::ArrayRef<std::int64_t> kernel_shape = kernel_ty.getShape();
@@ -732,7 +713,7 @@ public:
            "TTNN max_pool2d does not support padding top/bottom/left/right "
            "separately");
 
-    auto device = getOrInsertDevice(rewriter, op);
+    auto device = mlir::tt::ttnn::utils::getOrInsertDevice(rewriter, op);
     auto input_ty = mlir::cast<RankedTensorType>(adaptor.getInput().getType());
     llvm::ArrayRef<std::int64_t> input_shape = input_ty.getShape();
 
@@ -836,7 +817,7 @@ public:
       // addOp(lhs, negOp(rhs))
 
     } else {
-      Value device = getOrInsertDevice(rewriter, srcOp);
+      Value device = ::ttnn::utils::getOrInsertDevice(rewriter, srcOp);
       tensor::EmptyOp negEmptyOp = rewriter.create<tensor::EmptyOp>(
           srcOp.getLoc(), this->getTypeConverter()->convertType(rhsType),
           device);
@@ -862,7 +843,7 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     RankedTensorType type =
         mlir::cast<RankedTensorType>(adaptor.getInput().getType());
-    Value device = getOrInsertDevice(rewriter, op);
+    Value device = ::ttnn::utils::getOrInsertDevice(rewriter, op);
     tensor::EmptyOp emptyOp = rewriter.create<tensor::EmptyOp>(
         op.getLoc(), this->getTypeConverter()->convertType(type), device);
 
@@ -895,7 +876,7 @@ public:
 
     DataTypeAttr dtypeAttr = rewriter.getAttr<DataTypeAttr>(
         elementTypeToDataType(outputType.getElementType()));
-    Value device = getOrInsertDevice(rewriter, op);
+    Value device = mlir::tt::ttnn::utils::getOrInsertDevice(rewriter, op);
 
     ttnn::MemoryConfigAttr memConfigAttr =
         rewriter.getAttr<ttnn::MemoryConfigAttr>(

--- a/lib/Dialect/TTNN/IR/CMakeLists.txt
+++ b/lib/Dialect/TTNN/IR/CMakeLists.txt
@@ -4,6 +4,8 @@ add_mlir_dialect_library(MLIRTTNNDialect
         TTNNOps.cpp
         TTNNOpModelInterface.cpp
         TTNNOpsTypes.cpp
+        TTNNWorkaroundInterface.cpp
+        TTNNWorkarounds.cpp
 
         ADDITIONAL_HEADER_DIRS
         ${PROJECT_SOURCE_DIR}/include/ttmlir
@@ -11,6 +13,7 @@ add_mlir_dialect_library(MLIRTTNNDialect
         DEPENDS
         MLIRTTNNOpsIncGen
         MLIRTTOpsIncGen
+        MLIRTTNNWorkaroundInterfaceIncGen
         TTNNOpModelLib
 
         LINK_LIBS PUBLIC

--- a/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp
@@ -431,3 +431,34 @@ TTNNLayoutAttr TTNNLayoutAttr::get(
       context, shardShape, elementType, bufferType);
   return get(context, linear, grid, memRefType, memLayout);
 }
+
+// Construct a new MemoryConfig
+//
+// This function creates a deep copy of the current MemoryConfigAttr and
+// replaces the buffer type with the given one.
+//
+// param context The MLIR context.
+// param buffer type The new buffer type.
+// return The new MemoryConfigAttr with the given buffer type.
+MemoryConfigAttr MemoryConfigAttr::withBufferType(::mlir::MLIRContext *context,
+                                                  BufferType bufferType) {
+  return MemoryConfigAttr::get(context, getTensorMemoryLayout(),
+                               BufferTypeAttr::get(context, bufferType),
+                               getShardSpec());
+}
+
+// Construct a new MemoryConfig
+//
+// This function creates a deep copy of the current MemoryConfig and
+// replaces the memory layout with the given one.
+//
+// param context The MLIR context.
+// param memLayout The new memory layout.
+// return The new MemoryConfig with the given memory layout.
+MemoryConfigAttr
+MemoryConfigAttr::withMemoryLayout(::mlir::MLIRContext *context,
+                                   TensorMemoryLayout memLayout) {
+  return MemoryConfigAttr::get(context,
+                               TensorMemoryLayoutAttr::get(context, memLayout),
+                               getBufferType(), getShardSpec());
+}

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundInterface.cpp
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+#include "ttmlir/Dialect/TTNN/IR/TTNNWorkaroundInterface.h"
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNWorkarounds.h"
+#include "ttmlir/Utils.h"
+
+#include "mlir/Interfaces/DestinationStyleOpInterface.h"
+#include <llvm/Support/raw_ostream.h>
+
+namespace mlir::tt::ttnn::wa {
+#include "ttmlir/Dialect/TTNN/IR/TTNNWorkaroundInterface.cpp.inc"
+
+// Verifier function for TTNN Workaround Interface.
+mlir::LogicalResult verifyTTNNWorkaroundInterface(mlir::Operation *op) {
+
+  // Verify that the number of input and output operand workarounds is the same
+  // as the number of tensor operands and tensor results.
+  size_t cntTensorInputs =
+      llvm::count_if(op->getOperands(), ttmlir::utils::isRankedTensor);
+  size_t cntTensorResults =
+      llvm::count_if(op->getResults(), ttmlir::utils::isRankedTensor);
+
+  TTNNWorkaroundInterface workaroundOp =
+      mlir::cast<TTNNWorkaroundInterface>(op);
+
+  TTNNOperandsWorkarounds workarounds = workaroundOp.getOperandsWorkarounds();
+
+  if (workarounds.getInputOperandWorkarounds().size() != cntTensorInputs) {
+    return op->emitOpError()
+           << "Number of input operand workarounds "
+           << workarounds.getInputOperandWorkarounds().size()
+           << " does not match the number of tensor inputs " << cntTensorInputs;
+  }
+
+  if (workarounds.getOutputOperandWorkarounds().size() != cntTensorResults) {
+    return op->emitOpError() << "Number of output operand workarounds "
+                             << " does not match the number of tensor results "
+                             << cntTensorResults;
+  }
+
+  // For DPS ops, verify that the output workaround is the same as the input
+  // init workaround.
+  if (mlir::isa<DestinationStyleOpInterface>(op)) {
+    DestinationStyleOpInterface dpsOp =
+        mlir::cast<DestinationStyleOpInterface>(op);
+
+    // Go through all the operands and for each DPS init operand, check if the
+    // output workaround is the same.
+    int dpsDestinationIndex = 0;
+    for (int64_t i = 0; i < op->getNumOperands(); i++) {
+      OpOperand &operand = op->getOpOperand(i);
+
+      // Skip if the output result isn't a tensor.
+      if (!ttmlir::utils::isRankedTensor(operand.get())) {
+        dpsDestinationIndex++;
+        continue;
+      }
+
+      // Skip if the operand is not a DPS init.
+      if (!dpsOp.isDpsInit(&operand)) {
+        dpsDestinationIndex++;
+        continue;
+      }
+
+      // Get the tied output result for the DPS destination operand.
+      OpResult tiedOutputResult = dpsOp.getTiedOpResult(&operand);
+
+      // Check if the output workaround is the same as the input DPS destination
+      // workaround.
+      if (workarounds.getOutputOperandWorkarounds()[tiedOutputResult
+                                                        .getResultNumber()] !=
+          workarounds.getInputOperandWorkarounds()[dpsDestinationIndex]) {
+        return op->emitOpError()
+               << "DPS output workaround does not match "
+                  "the input DPS destination operand workaround "
+               << tiedOutputResult.getResultNumber() << " and "
+               << dpsDestinationIndex;
+      }
+
+      dpsDestinationIndex++;
+    }
+  }
+
+  // All checks passed, return success.
+  return mlir::success();
+}
+} // namespace mlir::tt::ttnn::wa

--- a/lib/Dialect/TTNN/IR/TTNNWorkarounds.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkarounds.cpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNWorkarounds.h"
+
+#include "ttmlir/Utils.h"
+
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir::tt::ttnn::wa {
+
+// Operand workarounds factory method
+TTNNOperandWorkarounds
+TTNNOperandWorkarounds::createEmptyTTNNOperandWorkarounds() {
+  return TTNNOperandWorkarounds();
+}
+
+// Operands workarounds factory method
+TTNNOperandsWorkarounds
+TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds(int inputSize,
+                                                            int outputSize) {
+  llvm::SmallVector<TTNNOperandWorkarounds> inputOperandWorkarounds(
+      inputSize, TTNNOperandWorkarounds::createEmptyTTNNOperandWorkarounds());
+  llvm::SmallVector<TTNNOperandWorkarounds> outputOperandWorkarounds(
+      outputSize, TTNNOperandWorkarounds::createEmptyTTNNOperandWorkarounds());
+  return TTNNOperandsWorkarounds(inputOperandWorkarounds,
+                                 outputOperandWorkarounds);
+}
+
+// Method to apply tensor workarounds. If the workaround is present, it
+// applies the workaround, and returns both the target workaround argument and
+// a flag indicating whether the workaround was applied.
+WorkaroundResult applyWorkarounds(const TTNNOperandWorkarounds &workaround,
+                                  const TTNNLayoutAttr &inputLayoutAttr) {
+  WorkaroundResult result;
+  result.targetTensorLayoutResult.first =
+      workaround.tensorLayoutWorkaround.value_or(inputLayoutAttr.getLayout());
+  result.targetTensorLayoutResult.second =
+      result.targetTensorLayoutResult.first != inputLayoutAttr.getLayout();
+
+  result.targetTensorBufferTypeResult.first =
+      workaround.tensorBufferTypeWorkaround.value_or(
+          inputLayoutAttr.getBufferType());
+  result.targetTensorBufferTypeResult.second =
+      result.targetTensorBufferTypeResult.first !=
+      inputLayoutAttr.getBufferType();
+
+  result.targetTensorMemoryLayoutResult.first =
+      workaround.tensorMemoryLayoutWorkaround.value_or(
+          inputLayoutAttr.getMemLayout());
+  result.targetTensorMemoryLayoutResult.second =
+      result.targetTensorMemoryLayoutResult.first !=
+      inputLayoutAttr.getMemLayout();
+
+  return result;
+}
+
+// Operands workarounds factory method.
+TTNNOperandsWorkarounds
+TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds(Operation *op) {
+  size_t tensorInputs =
+      llvm::count_if(op->getOperands(), ttmlir::utils::isRankedTensor);
+  size_t tensorResults =
+      llvm::count_if(op->getResults(), ttmlir::utils::isRankedTensor);
+
+  return TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds(
+      tensorInputs, tensorResults);
+}
+} // namespace mlir::tt::ttnn::wa

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -62,6 +62,14 @@ void createTTNNPipelineLoweringPasses(
   pm.addPass(mlir::createRemoveDeadValuesPass());
 }
 
+// Create a pass to workaround issues in the TTNN dialect.
+void createTTNNPipelineWorkaroundPass(
+    OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options) {
+  if (options.workaroundPassEnabled) {
+    pm.addPass(createTTNNWorkarounds());
+  }
+}
+
 void createTTNNPipelineLayoutDecompositionPass(
     OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options) {
   pm.addPass(createTTNNDecomposeLayouts());
@@ -124,6 +132,7 @@ void createTTIRToTTNNBackendPipeline(
   createTTNNPipelineTTIRPasses(pm, options);
   createTTNNPipelineTTIRBroadcastFoldPass(pm, options);
   createTTNNPipelineLoweringPasses(pm, options);
+  createTTNNPipelineWorkaroundPass(pm, options);
   createTTNNPipelineAnalysisPasses(pm, options);
   createTTNNPipelineLayoutDecompositionPass(pm, options);
   createTTNNPipelineDeallocPass(pm, options);

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -1,8 +1,9 @@
 add_mlir_dialect_library(MLIRTTNNTransforms
-        TTNNLayout.cpp
-        Passes.cpp
         Optimizer.cpp
+        Passes.cpp
+        TTNNLayout.cpp
         TTNNToCpp.cpp
+        TTNNWorkarounds.cpp
 
         ADDITIONAL_HEADER_DIRS
         ${PROJECT_SOURCE_DIR}/include/ttmlir

--- a/lib/Dialect/TTNN/Transforms/TTNNWorkarounds.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNWorkarounds.cpp
@@ -1,0 +1,399 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
+
+#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNWorkarounds.h"
+#include "ttmlir/Dialect/TTNN/Types/Types.h"
+#include "ttmlir/Dialect/TTNN/Utils/TransformUtils.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Value.h"
+#include "mlir/IR/ValueRange.h"
+#include "mlir/Interfaces/DestinationStyleOpInterface.h"
+#include "mlir/Rewrite/FrozenRewritePatternSet.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "ttmlir/Utils.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <optional>
+#include <tuple>
+#include <utility>
+
+namespace mlir::tt::ttnn {
+#define GEN_PASS_DEF_TTNNWORKAROUNDS
+#include "ttmlir/Dialect/TTNN/Transforms/Passes.h.inc"
+
+// Helper method to get the tensor layout attribute from the op operand.
+static TTNNLayoutAttr getLayoutAttrFromOpOperand(OpOperand &opOperand) {
+  auto tensorType = mlir::cast<RankedTensorType>(opOperand.get().getType());
+  return mlir::cast<TTNNLayoutAttr>(tensorType.getEncoding());
+}
+
+// Helper method to get the tensor layout attribute from the op result.
+static TTNNLayoutAttr getLayoutAttrFromOpResult(OpResult &opResult) {
+  auto tensorType = mlir::cast<RankedTensorType>(opResult.getType());
+  return mlir::cast<TTNNLayoutAttr>(tensorType.getEncoding());
+}
+
+// Helper method to get the element type for the given tensor layout and data.
+static Type getElementType(MLIRContext *context, Layout tensorLayout,
+                           DataType dataType) {
+  return tensorLayout == Layout::Tile
+             ? TileType::get(context, {ttnn::TILE_HEIGHT, ttnn::TILE_WIDTH},
+                             dataType)
+             : ttnn::utils::createRowMajorTypeFromDtype(context, dataType);
+}
+
+// Helper method to insert a ToLayoutOp to convert the input operand to the
+// desired tensor layout, buffer type and memory layout.
+static mlir::Value
+createToLayoutOp(wa::TTNNWorkaroundInterface &op, OpOperand &inputOperand,
+                 PatternRewriter &rewriter, Layout targetTensorLayout,
+                 BufferType targetTensorBufferType,
+                 TensorMemoryLayout targetTensorMemoryLayout) {
+  TTNNLayoutAttr inputLayoutAttr = getLayoutAttrFromOpOperand(inputOperand);
+
+  // Create element type based on tensor layout.
+  Type elementType = getElementType(rewriter.getContext(), targetTensorLayout,
+                                    inputLayoutAttr.getDataType());
+
+  // Create the output memory config attribute.
+  ttnn::MemoryConfigAttr outputMemConfigAttr = ttnn::MemoryConfigAttr::get(
+      rewriter.getContext(),
+      ttnn::TensorMemoryLayoutAttr::get(rewriter.getContext(),
+                                        targetTensorMemoryLayout),
+      ttnn::BufferTypeAttr::get(rewriter.getContext(), targetTensorBufferType),
+      ttnn::ShardSpecAttr::get(
+          op.getContext(),
+          ttnn::ShapeAttr::get(rewriter.getContext(),
+                               inputLayoutAttr.getMemref().getShape())));
+
+  // Get the input operand type.
+  RankedTensorType inputOperandType =
+      mlir::cast<RankedTensorType>(inputOperand.get().getType());
+
+  // Create a ToLayoutOp to convert the input operand to the desired
+  // tensor layout, buffer type and memory layout.
+  return rewriter
+      .create<ttnn::ToLayoutOp>(
+          op.getLoc(),
+          ttnn::utils::createRankedTensorTypeWithEncoding(
+              inputOperandType,
+              inputLayoutAttr
+                  .withElementType(rewriter.getContext(), elementType)
+                  .withBufferType(rewriter.getContext(), targetTensorBufferType)
+                  .withMemoryLayout(rewriter.getContext(),
+                                    targetTensorMemoryLayout)),
+          inputOperand.get(),
+          LayoutAttr::get(rewriter.getContext(), targetTensorLayout),
+          DataTypeAttr::get(rewriter.getContext(),
+                            inputLayoutAttr.getDataType()),
+          outputMemConfigAttr,
+          (targetTensorBufferType == ttnn::BufferType::SystemMemory)
+              ? nullptr
+              : utils::getOrInsertDevice(rewriter, op))
+      ->getResult(0);
+}
+
+// Helper method to apply workarounds to an input operand. This method inserts a
+// ToLayoutOp with the specified tensor layout, buffer type, and memory layout.
+// It returns true if the workarounds were successfully applied.
+static bool workaroundInputOperand(
+    OpOperand &inputOperand, const wa::TTNNOperandWorkarounds &inputWorkaround,
+    PatternRewriter &rewriter, wa::TTNNWorkaroundInterface op) {
+  // Get the current input tensor layout, buffer type and memory layout from the
+  // input operand.
+  TTNNLayoutAttr inputLayoutAttr = getLayoutAttrFromOpOperand(inputOperand);
+
+  // Apply the workarounds on the input operand workaround arguments
+  wa::WorkaroundResult inputWorkaroundResult =
+      applyWorkarounds(inputWorkaround, inputLayoutAttr);
+
+  // If there were no modifications by workarounds, return false.
+  if (!inputWorkaroundResult.modified()) {
+    return false;
+  }
+
+  // Apply the workarounds on the input operand by inserting the ToLayoutOp with
+  // the desired tensor layout, buffer type and memory layout.
+  mlir::Value insertedToLayoutOpValue = createToLayoutOp(
+      op, inputOperand, rewriter,
+      inputWorkaroundResult.targetTensorLayoutResult.first,
+      inputWorkaroundResult.targetTensorBufferTypeResult.first,
+      inputWorkaroundResult.targetTensorMemoryLayoutResult.first);
+
+  // Insert to layout op between the current op and the input operand
+  // to convert the input operand to the desired tensor layout, buffer type.
+  rewriter.modifyOpInPlace(op, [&]() {
+    // Update the input operand with the new toLayout op operand.
+    op->setOperand(inputOperand.getOperandNumber(), insertedToLayoutOpValue);
+  });
+
+  return true;
+}
+
+// Helper method to apply workarounds to output results.
+// - For DPS results, this method only verifies that the output result matches
+// the
+//   corresponding DPS destination operand. At this stage, DPS results should
+//   already be propagated.
+// - For non-DPS operations, this method applies the necessary workarounds to
+// the
+//   output result and returns true if the workarounds were successfully
+//   applied.
+static bool workaroundOutputOperand(
+    OpResult &opResult, const wa::TTNNOperandWorkarounds &outputWorkaround,
+    PatternRewriter &rewriter, wa::TTNNWorkaroundInterface op) {
+  // Get the current output tensor layout, buffer type and memory layout from
+  // the input operand.
+  TTNNLayoutAttr opResultLayoutAttr = getLayoutAttrFromOpResult(opResult);
+
+  // Apply the workarounds on the output result workaround arguments
+  wa::WorkaroundResult outputWorkaroundResult =
+      wa::applyWorkarounds(outputWorkaround, opResultLayoutAttr);
+
+  // At this point, the DPS result should already be propagated, hence we only
+  // need to verify that the output workaround is in sync with the current DPS
+  // result.
+  assert(!(outputWorkaroundResult.modified() &&
+           mlir::isa<DestinationStyleOpInterface>(op.getOperation())) &&
+         "Output operand workarounds not supported for DPS ops");
+
+  // If there were no modifications by workarounds, return false.
+  if (!outputWorkaroundResult.modified()) {
+    return false;
+  }
+
+  // Create the data type attribute.
+  Type elementType =
+      getElementType(rewriter.getContext(),
+                     outputWorkaroundResult.targetTensorLayoutResult.first,
+                     opResultLayoutAttr.getDataType());
+
+  // Get the input operand type.
+  RankedTensorType opResultType =
+      mlir::cast<RankedTensorType>(opResult.getType());
+
+  // Create the new output result type with the updated tensor layout, buffer
+  // type and memory layout.
+  RankedTensorType newOutputResultType =
+      ttnn::utils::createRankedTensorTypeWithEncoding(
+          opResultType,
+          opResultLayoutAttr.withElementType(rewriter.getContext(), elementType)
+              .withBufferType(
+                  rewriter.getContext(),
+                  outputWorkaroundResult.targetTensorBufferTypeResult.first)
+              .withMemoryLayout(
+                  rewriter.getContext(),
+                  outputWorkaroundResult.targetTensorMemoryLayoutResult.first));
+
+  // Update the type of result with applied workarounds.
+  rewriter.modifyOpInPlace(op, [&]() {
+    opResult.setType(newOutputResultType);
+
+    // Some ops defines attributes with tensor layout, buffer type and memory
+    // layout, hence we need to update the attributes as well. For example,
+    // the empty op defines layout and memory_config attributes.
+    if (outputWorkaroundResult.targetTensorLayoutResult.second &&
+        op->getAttrDictionary().get("layout")) {
+      LayoutAttr updatedLayoutAttr = rewriter.getAttr<LayoutAttr>(
+          outputWorkaroundResult.targetTensorLayoutResult.first);
+      op->setAttr("layout", updatedLayoutAttr);
+    }
+
+    if ((outputWorkaroundResult.targetTensorBufferTypeResult.second ||
+         outputWorkaroundResult.targetTensorMemoryLayoutResult.second) &&
+        op->getAttrDictionary().get("memory_config")) {
+
+      MemoryConfigAttr currentMemoryConfig =
+          mlir::cast<MemoryConfigAttr>(op->getAttr("memory_config"));
+
+      // Create the output memory config attribute.
+      // Check if the buffer type got updated.
+      if (outputWorkaroundResult.targetTensorBufferTypeResult.second) {
+        currentMemoryConfig = currentMemoryConfig.withBufferType(
+            rewriter.getContext(),
+            outputWorkaroundResult.targetTensorBufferTypeResult.first);
+      }
+
+      // Check if the memory layout got updated.
+      if (outputWorkaroundResult.targetTensorMemoryLayoutResult.second) {
+        currentMemoryConfig = currentMemoryConfig.withMemoryLayout(
+            rewriter.getContext(),
+            outputWorkaroundResult.targetTensorMemoryLayoutResult.first);
+      }
+
+      // Update the changed memory config attribute.
+      op->setAttr("memory_config", currentMemoryConfig);
+    }
+  });
+
+  return true;
+}
+
+// Propagate the workaround changes for DPS input operands if they are applied
+// in above graph transforms, either in a pattern for a current op, or in a
+// pattern matched for a previous ops.
+static bool propagateDpsInitChangesToDpsResults(wa::TTNNWorkaroundInterface &op,
+                                                PatternRewriter &rewriter) {
+  // Check if the op is a DPS op.
+  if (!mlir::isa<DestinationStyleOpInterface>(op.getOperation())) {
+    return false;
+  }
+
+  bool modified = false;
+
+  auto dpsOp = mlir::cast<DestinationStyleOpInterface>(op.getOperation());
+  mlir::OperandRange dpsInits = dpsOp.getDpsInits();
+
+  // Iterate through all dps destination operands and propagate the changes if
+  // any.
+  for (size_t dpsInitIndex = 0; dpsInitIndex < dpsInits.size();
+       dpsInitIndex++) {
+    OpOperand *dpsInit = dpsOp.getDpsInitOperand(dpsInitIndex);
+    OpResult tiedDpsResult = dpsOp.getTiedOpResult(dpsInit);
+
+    // If the DPS destination is changed, update the DPS result as well.
+    if (tiedDpsResult.getType() != dpsInit->get().getType()) {
+      modified = true;
+      rewriter.modifyOpInPlace(
+          op, [&]() { tiedDpsResult.setType(dpsInit->get().getType()); });
+    }
+  }
+
+  return modified;
+}
+
+// TTNNWorkaroundInterface rewriter applies workarounds to the operands of TTNN
+// operations. TTNNWorkaroundInterface is an interface on TTNN_Op, so this
+// pattern should match each op in the IR.
+//
+// The rewriter processes both input and output operands of TTNN operations:
+// 1. **Input Operands**: The rewriter iterates through all input tensor
+// operands and applies the necessary workarounds.
+//    - Workarounds are applied by inserting ToLayoutOp with the desired tensor
+//    layout, buffer type, and memory layout.
+// 2. **DPS result propagation**: The rewriter propagates changes to tied DPS
+// destination operands to ensure consistency with previous graph
+// transformations, either in the current op match or previous op matches.
+// 3. **Output Operands**: Output workarounds are applied only if the operation
+// is not a DPS op.
+//    - At this stage, all DPS result changes should be propagated. An assertion
+//    ensures that the output result workaround matches
+//      the corresponding DPS output result.
+//    - Workarounds are applied by updating the output result type with the new
+//    tensor layout, buffer type, and memory layout.
+//    - For operations that define attributes with tensor layout, buffer type,
+//    and memory layout, these attributes are also updated.
+//      For example, the empty op defines layout and memory_config attributes.
+class TTNNOperandsWorkaroundsRewriter
+    : public OpInterfaceRewritePattern<wa::TTNNWorkaroundInterface> {
+public:
+  TTNNOperandsWorkaroundsRewriter(MLIRContext *ctx)
+      : OpInterfaceRewritePattern<wa::TTNNWorkaroundInterface>(ctx) {}
+
+  LogicalResult matchAndRewrite(wa::TTNNWorkaroundInterface op,
+                                PatternRewriter &rewriter) const final {
+
+    // To layout op is a special case, we don't want to rewrite it.
+    if (mlir::isa<ttnn::ToLayoutOp>(op.getOperation())) {
+      return failure();
+    }
+
+    bool modified = false;
+    // Get the operands workarounds for the current operation.
+    wa::TTNNOperandsWorkarounds operandsWorkarounds =
+        op.getOperandsWorkarounds();
+
+    // Filter out all the input tensor operands.
+    auto inputTensorsOperands =
+        llvm::make_filter_range(op->getOpOperands(), [](OpOperand &v) {
+          return ttmlir::utils::isRankedTensor(v.get());
+        });
+
+    // Apply workarounds to all input tensor operands.
+    llvm::for_each(
+        llvm::zip_equal(inputTensorsOperands,
+                        operandsWorkarounds.getInputOperandWorkarounds()),
+        [&](std::tuple<mlir::OpOperand &, const wa::TTNNOperandWorkarounds &>
+                pair) {
+          modified = std::get<1>(pair).hasAnyWorkaround() &&
+                     workaroundInputOperand(std::get<0>(pair),
+                                            std::get<1>(pair), rewriter, op);
+        });
+
+    // Propagate the workaround changes for DPS input operands to DPS results if
+    // they are applied in above graph transforms, either in a pattern for a
+    // current op, or in a pattern matched for a previous ops.
+    modified |= propagateDpsInitChangesToDpsResults(op, rewriter);
+
+    // Filter out all the output tensor results.
+    auto outputTensorResults =
+        llvm::make_filter_range(op->getOpResults(), [](OpResult v) {
+          return ttmlir::utils::isRankedTensor(v);
+        });
+
+    // Apply workarounds to all output tensor results.
+    llvm::for_each(
+        llvm::zip_equal(outputTensorResults,
+                        operandsWorkarounds.getOutputOperandWorkarounds()),
+        [&](std::tuple<mlir::OpResult, const wa::TTNNOperandWorkarounds &>
+                pair) {
+          modified |= std::get<1>(pair).hasAnyWorkaround() &&
+                      workaroundOutputOperand(std::get<0>(pair),
+                                              std::get<1>(pair), rewriter, op);
+        });
+
+    // Return success if the transformations were applied.
+    return modified ? success() : failure();
+  }
+};
+
+// Pass to apply workarounds to the operands of TTNN operations.
+class TTNNWorkarounds : public impl::TTNNWorkaroundsBase<TTNNWorkarounds> {
+public:
+  using impl::TTNNWorkaroundsBase<TTNNWorkarounds>::TTNNWorkaroundsBase;
+
+  void runOnOperation() final {
+    {
+      // Placeholder for workaround decomposition patterns.
+    }
+    {
+      RewritePatternSet patterns(&getContext());
+      patterns.add<TTNNOperandsWorkaroundsRewriter>(&getContext());
+
+      FrozenRewritePatternSet patternSet(std::move(patterns));
+      GreedyRewriteConfig config = GreedyRewriteConfig();
+      // This configuration specifies that the rewriter should traverse the IR
+      // in a top-down order.
+      config.useTopDownTraversal = true;
+      // This configuration specifies the maximum number of iterations the
+      // rewriter will perform on the IR. The rewriter will iterate through the
+      // IR until a fixpoint is reached. All workarounds should be applied
+      // during the first iteration. If the workarounds are not applied in the
+      // first iteration, it indicates a bug in the workarounds implementation.
+      // Although the workarounds are applied in the first iteration, the
+      // rewriter must iterate through the IR once more to confirm that the
+      // fixpoint is reached. If the fixpoint is not reached in the second
+      // iteration, it indicates a bug in the workarounds implementation.
+      config.maxIterations = 2;
+      if (failed(applyPatternsAndFoldGreedily(getOperation(), patternSet,
+                                              config))) {
+        signalPassFailure();
+        return;
+      }
+    }
+  }
+};
+} // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Utils/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Utils/CMakeLists.txt
@@ -1,7 +1,9 @@
 add_mlir_dialect_library(TTMLIRTTNNUtils
-  Utils.cpp
   OptimizerOverrides.cpp
   PassOverrides.cpp
+  TransformUtils.cpp
+  Utils.cpp
+
 
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/TTNN

--- a/lib/Dialect/TTNN/Utils/TransformUtils.cpp
+++ b/lib/Dialect/TTNN/Utils/TransformUtils.cpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Utils/TransformUtils.h"
+
+#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+
+namespace mlir::tt::ttnn::utils {
+// Gets or inserts a GetDeviceOp at the top of the current block of the given
+// operation.
+Value getOrInsertDevice(PatternRewriter &rewriter, Operation *op) {
+  Block *block = op->getBlock();
+  for (auto &op : block->getOperations()) {
+    if (auto deviceOp = dyn_cast<ttnn::GetDeviceOp>(op)) {
+      return deviceOp.getResult();
+    }
+  }
+
+  DeviceAttr deviceAttr = getCurrentScopeDevice(op);
+  auto currentInsertionPoint = rewriter.saveInsertionPoint();
+  rewriter.setInsertionPoint(block, block->begin());
+  auto deviceOp = rewriter.create<ttnn::GetDeviceOp>(
+      op->getLoc(), rewriter.getType<DeviceType>(deviceAttr),
+      ttnn::MeshShapeAttr::get(op->getContext(), 1, 1));
+  rewriter.restoreInsertionPoint(currentInsertionPoint);
+  return deviceOp.getResult();
+}
+} // namespace mlir::tt::ttnn::utils

--- a/lib/Dialect/TTNN/Utils/Utils.cpp
+++ b/lib/Dialect/TTNN/Utils/Utils.cpp
@@ -134,4 +134,12 @@ Type createRowMajorTypeFromDtype(::mlir::MLIRContext *context, DataType dtype) {
   }
 }
 
+// Helper method to create a RankedTensorType with the given encoding
+RankedTensorType
+createRankedTensorTypeWithEncoding(RankedTensorType tensorType,
+                                   ttnn::TTNNLayoutAttr encoding) {
+  return RankedTensorType::get(tensorType.getShape(),
+                               tensorType.getElementType(), encoding);
+}
+
 } // namespace mlir::tt::ttnn::utils

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/simple_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/simple_workaround.mlir
@@ -1,0 +1,31 @@
+// RUN: ttmlir-opt --ttnn-workaround %s | FileCheck %s
+#device = #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, d0 floordiv s0, d1 floordiv s1, (d0 mod s0) * s1 + d1 mod s1), dramMap = (d0, d1)[s0, s1] -> (0, 0, ((((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 8192) mod 12, (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 98304 + (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) mod 8192), meshShape = , chipIds = [0]>
+#dram = #ttnn.buffer_type<dram>
+#system_memory = #ttnn.buffer_type<system_memory>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<64x128xf32, #system_memory>>
+#ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<64x128xf32, #dram>, interleaved>
+#ttnn_layout2 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!tt.tile<32x32, f32>, #dram>, interleaved>
+module attributes {tt.device = #device} {
+  func.func @forward(%arg0: tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout> {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
+    // CHECK: %[[DEVICE_OP:.*]] = "ttnn.get_device"[[C:.*]]
+    %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<interleaved>, #dram, <<2x4>>>}> : (tensor<64x128xf32, #ttnn_layout>, !tt.device<#device>) -> tensor<64x128xf32, #ttnn_layout1>
+    // CHECK-NEXT: %[[RM_DEVICE_LAYOUT_OP:.*]] = "ttnn.to_layout"(%arg0, %[[DEVICE_OP]])
+    // CHECK-SAME: layout = #ttnn.layout<row_major>
+    // CHECK-SAME: -> tensor<64x128xf32, #ttnn_layout1>
+    %2 = "ttnn.empty"(%0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<<interleaved>, #dram, <<64x128>>>, shape = #ttnn.shape<64x128>}> : (!tt.device<#device>) -> tensor<64x128xf32, #ttnn_layout2>
+    // CHECK-NEXT: %[[EMPTY_OP:.*]] = "ttnn.empty"(%[[DEVICE_OP]])
+    // CHECK-SAME: layout = #ttnn.layout<row_major>
+    // CHECK-SAME: memory_config = #ttnn.memory_config<<interleaved>, #dram, <<64x128>>>
+    // CHECK-SAME: -> tensor<64x128xf32, #ttnn_layout1>
+    %3 = "ttnn.abs"(%1, %2) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32, #ttnn_layout1>, tensor<64x128xf32, #ttnn_layout2>) -> tensor<64x128xf32, #ttnn_layout2>
+    // CHECK-NEXT: %[[TO_LAYOUT_LEFT:.*]] = "ttnn.to_layout"(%[[RM_DEVICE_LAYOUT_OP]], %[[DEVICE_OP]])
+    // CHECK-SAME: layout = #ttnn.layout<tile>
+    // CHECK-SAME: -> tensor<64x128xf32, #ttnn_layout2>
+    // CHECK-NEXT: %[[TO_LAYOUT_RIGHT:.*]] = "ttnn.to_layout"(%[[EMPTY_OP]], %[[DEVICE_OP]])
+    // CHECK-SAME: layout = #ttnn.layout<tile>
+    // CHECK-SAME: -> tensor<64x128xf32, #ttnn_layout2>
+    %4 = "ttnn.to_layout"(%3) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<none>, #system_memory, <<64x128>>>}> : (tensor<64x128xf32, #ttnn_layout2>) -> tensor<64x128xf32, #ttnn_layout>
+    return %4 : tensor<64x128xf32, #ttnn_layout>
+  }
+}


### PR DESCRIPTION
This PR introduces the initial implementation of a workaround pass in the TTNN dialect. It establishes the foundation for handling operation-specific workarounds by defining interfaces and data structures and includes the initial logic for applying these workarounds. While the logic is disabled by default in this PR, future updates will gradually enable it in the compiler. Below is a summary of the changes:

- Introduced TTNNWorkaround classes to abstract the workarounds we can currently specify
- Introduced the TTNNWorkaroundInterface in the TTNN dialect
  - Interface for now retrieves the operation operand workarounds mentioned above for:
    - Tensor Layout
    - Tensor Buffer Type
    - Tensor Memory Layout
  - For now, the interface provides default values. However, as a proof of concept, custom workarounds have been implemented for the empty and abs operations, along with the corresponding test. Future PRs will extend and refine these workarounds.
- New TTNN Workaround pass that utilizes the above interface to apply workarounds and produce the valid IR.
  - This pass is not yet enabled by default. Subsequent PRs will enable it incrementally as the implementation matures.

Closes https://github.com/tenstorrent/tt-mlir/issues/1136
Closes https://github.com/tenstorrent/tt-mlir/issues/1135



