### PR TITLE
Add TOSA to TTIR conversion for matmul

### DIFF
--- a/lib/Conversion/TosaToTTIR/TosaToTTIRPatterns.cpp
+++ b/lib/Conversion/TosaToTTIR/TosaToTTIRPatterns.cpp
@@ -81,7 +81,7 @@ private:
   }
 };
 
-class TosaToTTIRMatMulOpConversionPattern
+class TosaToTTIRMatmulOpConversionPattern
     : public OpConversionPattern<tosa::MatMulOp> {
   using OpConversionPattern<tosa::MatMulOp>::OpConversionPattern;
   using Adaptor = tosa::MatMulOp::Adaptor;
@@ -99,6 +99,7 @@ public:
     auto outputTensor = rewriter.create<tensor::EmptyOp>(
         srcOp.getLoc(), outputType.getShape(), outputType.getElementType());
     auto operands = adaptor.getOperands();
+
     rewriter.replaceOpWithNewOp<mlir::tt::ttir::MatmulOp>(
         srcOp, TypeRange(outputTensor.getType()), operands[0], operands[1],
         outputTensor,
@@ -170,12 +171,6 @@ void addElementwiseBinaryOpsConversionPatterns(MLIRContext *ctx,
       tosa::SubOp, mlir::tt::ttir::SubtractOp>>(typeConverter, ctx);
 }
 
-void addMatMulOpsConversionPatterns(MLIRContext *ctx,
-                                    RewritePatternSet &patterns,
-                                    TypeConverter &typeConverter) {
-  patterns.add<TosaToTTIRMatMulOpConversionPattern>(typeConverter, ctx);
-}
-
 void addElementwiseTernaryOpsConversionPatterns(MLIRContext *ctx,
                                                 RewritePatternSet &patterns,
                                                 TypeConverter &typeConverter) {
@@ -208,6 +203,12 @@ void addCompareOpsConversionPatterns(MLIRContext *ctx,
       tosa::GreaterOp, mlir::tt::ttir::GreaterThanOp>>(typeConverter, ctx);
 }
 
+void addMatmulOpsConversionPatterns(MLIRContext *ctx,
+                                    RewritePatternSet &patterns,
+                                    TypeConverter &typeConverter) {
+  patterns.add<TosaToTTIRMatmulOpConversionPattern>(typeConverter, ctx);
+}
+
 } // namespace
 
 namespace mlir::tt {
@@ -219,7 +220,7 @@ void populateTosaToTTIRPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
   addElementwiseTernaryOpsConversionPatterns(ctx, patterns, typeConverter);
   addLogicalOpsConversionPatterns(ctx, patterns, typeConverter);
   addCompareOpsConversionPatterns(ctx, patterns, typeConverter);
-  addMatMulOpsConversionPatterns(ctx, patterns, typeConverter);
+  addMatmulOpsConversionPatterns(ctx, patterns, typeConverter);
 }
 
 } // namespace mlir::tt

--- a/test/ttmlir/Conversion/TosaToTTIR/matmul_op.mlir
+++ b/test/ttmlir/Conversion/TosaToTTIR/matmul_op.mlir
@@ -1,9 +1,11 @@
 // RUN: ttmlir-opt --convert-tosa-to-ttir %s | FileCheck %s
 module attributes {} {
   func.func @test_matmul(%arg0: tensor<13x21x16xf32>, %arg1: tensor<13x16x31xf32>) -> tensor<13x21x31xf32> {
+    // CHECK: func.func {{.+}}%arg{{[0-9]+}}: tensor<[[B:[0-9]+]]x[[I:[0-9]+]]x[[J:[0-9]+]]xf32>, %arg{{[0-9]+}}: tensor<[[B:[0-9]+]]x[[J:[0-9]+]]x[[K:[0-9]+]]xf32>
     %0 = tosa.matmul %arg0, %arg1 : (tensor<13x21x16xf32>, tensor<13x16x31xf32>) -> tensor<13x21x31xf32>
-    // CHECK: %[[OP_OUT:[0-9]+]] = tensor.empty() : tensor<13x21x31xf32>
-    // CHECK: %{{[0-9]+}} = "ttir.matmul"(%arg{{[0-9]+}}, %arg{{[0-9]+}}, %[[OP_OUT]]){{.+}} (tensor<13x21x16xf32>, tensor<13x16x31xf32>, tensor<13x21x31xf32>) -> tensor<13x21x31xf32>
+    // CHECK: %[[OP_OUT:[0-9]+]] = tensor.empty() : tensor<[[B]]x[[I]]x[[K]]xf32>
+    // CHECK: %[[VAL:[0-9]+]] = "ttir.matmul"(%arg{{[0-9]+}}, %arg{{[0-9]+}}, %[[OP_OUT]]){{.+}} (tensor<[[B]]x[[I]]x[[J]]xf32>, tensor<[[B]]x[[J]]x[[K]]xf32>, tensor<[[B]]x[[I]]x[[K]]xf32>) -> tensor<[[B]]x[[I]]x[[K]]xf32>
+    // CHECK: return %[[VAL]] : tensor<[[B]]x[[I]]x[[K]]xf32>
     return %0 : tensor<13x21x31xf32>
   }
 }

--- a/test/ttmlir/Conversion/TosaToTTIR/matmul_op.mlir
+++ b/test/ttmlir/Conversion/TosaToTTIR/matmul_op.mlir
@@ -2,8 +2,8 @@
 module attributes {} {
   func.func @test_matmul(%arg0: tensor<13x21x16xf32>, %arg1: tensor<13x16x31xf32>) -> tensor<13x21x31xf32> {
     %0 = tosa.matmul %arg0, %arg1 : (tensor<13x21x16xf32>, tensor<13x16x31xf32>) -> tensor<13x21x31xf32>
-    // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttir.matmul"[[C:.*]]
+    // CHECK: %[[OP_OUT:[0-9]+]] = tensor.empty() : tensor<13x21x31xf32>
+    // CHECK: %{{[0-9]+}} = "ttir.matmul"(%arg{{[0-9]+}}, %arg{{[0-9]+}}, %[[OP_OUT]]){{.+}} (tensor<13x21x16xf32>, tensor<13x16x31xf32>, tensor<13x21x31xf32>) -> tensor<13x21x31xf32>
     return %0 : tensor<13x21x31xf32>
   }
 }

--- a/test/ttmlir/Conversion/TosaToTTIR/matmul_op.mlir
+++ b/test/ttmlir/Conversion/TosaToTTIR/matmul_op.mlir
@@ -1,0 +1,9 @@
+// RUN: ttmlir-opt --convert-tosa-to-ttir %s | FileCheck %s
+module attributes {} {
+  func.func @test_matmul(%arg0: tensor<13x21x16xf32>, %arg1: tensor<13x16x31xf32>) -> tensor<13x21x31xf32> {
+    %0 = tosa.matmul %arg0, %arg1 : (tensor<13x21x16xf32>, tensor<13x16x31xf32>) -> tensor<13x21x31xf32>
+    // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
+    // CHECK: %[[C:.*]] = "ttir.matmul"[[C:.*]]
+    return %0 : tensor<13x21x31xf32>
+  }
+}


### PR DESCRIPTION
Adds conversion for [tosa.matmul](https://mlir.llvm.org/docs/Dialects/TOSA/#tosamatmul-mlirtosamatmulop)

closes #1416 