### PR TITLE
Create `ttmlir-lsp-server` (#1383)

### DIFF
--- a/lib/Conversion/TTKernelToEmitC/CMakeLists.txt
+++ b/lib/Conversion/TTKernelToEmitC/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_mlir_library(TTMLIRTTKernelToEmitC
+add_mlir_conversion_library(TTMLIRTTKernelToEmitC
   TTKernelToEmitC.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(ttmlir-opt)
+add_subdirectory(ttmlir-lsp-server)
 add_subdirectory(ttmlir-translate)
 add_subdirectory(explorer)

--- a/tools/ttmlir-lsp-server/CMakeLists.txt
+++ b/tools/ttmlir-lsp-server/CMakeLists.txt
@@ -1,0 +1,18 @@
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
+get_property(extension_libs GLOBAL PROPERTY MLIR_EXTENSION_LIBS)
+
+set(LIBS ${dialect_libs} ${conversion_libs} ${extension_libs}
+  MLIROptLib
+  MLIRTargetCpp
+  TTMLIRStatic
+  MLIRLspServerLib
+)
+
+add_llvm_executable(ttmlir-lsp-server ttmlir-lsp-server.cpp DISABLE_LLVM_LINK_LLVM_DYLIB)
+llvm_update_compile_flags(ttmlir-lsp-server)
+target_link_libraries(ttmlir-lsp-server PRIVATE ${LIBS})
+
+mlir_check_all_link_libraries(ttmlir-lsp-server)
+
+install(TARGETS ttmlir-lsp-server DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT Test EXCLUDE_FROM_ALL)

--- a/tools/ttmlir-lsp-server/ttmlir-lsp-server.cpp
+++ b/tools/ttmlir-lsp-server/ttmlir-lsp-server.cpp
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "mlir/InitAllDialects.h"
+#include "ttmlir/RegisterAll.h"
+
+#include "mlir/Tools/mlir-lsp-server/MlirLspServerMain.h"
+
+int main(int argc, char **argv) {
+  mlir::DialectRegistry registry;
+  mlir::tt::registerAllDialects(registry);
+
+  return mlir::failed(mlir::MlirLspServerMain(argc, argv, registry));
+}


### PR DESCRIPTION
This change introduces the tool `ttmlir-lsp-server`. It will fall under `build/bin`, and is built alongside the rest of the compiler via `cmake --build build`. This is a language server that should be used alongside your IDE/Text editor to give you IDE like features while editing `.mlir` files. For more info, please see [here](https://mlir.llvm.org/docs/Tools/MLIRLSP/#mlir-lsp-language-server--mlir-lsp-server)

Closes #1383 