### PR TITLE
Add ttnn::ones() op

### DIFF
--- a/include/ttmlir/Conversion/TTNNToEmitC/Utils.h
+++ b/include/ttmlir/Conversion/TTNNToEmitC/Utils.h
@@ -10,7 +10,7 @@
 #include "mlir/Dialect/EmitC/IR/EmitC.h"
 #include "mlir/Transforms/DialectConversion.h"
 
-namespace mlir::tt::ttnntoemitc::utils {
+namespace mlir::tt::ttnn_to_emitc::utils {
 
 // Create emitc::OpaqueAttr for ttnn::Shape
 //
@@ -63,6 +63,6 @@ emitc::CallOpaqueOp createMemoryConfigOp(ConversionPatternRewriter &rewriter,
                                          ttnn::MemoryConfigAttr memoryConfig,
                                          Location loc);
 
-} // namespace mlir::tt::ttnntoemitc::utils
+} // namespace mlir::tt::ttnn_to_emitc::utils
 
 #endif // TTMLIR_CONVERSION_TTNNTOEMITC_UTILS_H

--- a/include/ttmlir/Conversion/TTNNToEmitC/Utils.h
+++ b/include/ttmlir/Conversion/TTNNToEmitC/Utils.h
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_CONVERSION_TTNNTOEMITC_UTILS_H
+#define TTMLIR_CONVERSION_TTNNTOEMITC_UTILS_H
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+
+#include "mlir/Dialect/EmitC/IR/EmitC.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir::tt::ttnntoemitc::utils {
+
+// Create emitc::OpaqueAttr for ttnn::Shape
+//
+emitc::OpaqueAttr convertShape(Builder &builder, ttnn::ShapeAttr attr);
+
+// Create emitc::OpaqueAttr for ttnn::TensorMemoryLayout
+//
+emitc::OpaqueAttr convertTensorMemoryLayout(Builder &builder,
+                                            ttnn::TensorMemoryLayoutAttr attr);
+
+// Create emitc::OpaqueAttr for ttnn::BufferType
+//
+emitc::OpaqueAttr convertBufferType(Builder &builder,
+                                    ttnn::BufferTypeAttr attr);
+
+// Create emitc::OpaqueAttr for ttnn::Layout
+//
+emitc::OpaqueAttr convertLayoutAttr(Builder &builder, ttnn::LayoutAttr attr);
+
+// Create emitc::OpaqueAttr for BoolAttr
+//
+emitc::OpaqueAttr convertBoolAttr(Builder &builder, BoolAttr attr);
+
+// Create emitc::OpaqueAttr for ttnn::DataType
+//
+emitc::OpaqueAttr convertDType(Builder &builder, tt::DataTypeAttr attr);
+
+// Create emitc::OpaqueAttr for std::nullopt
+//
+emitc::OpaqueAttr createStdNullopt(Builder &builder);
+
+// Create ttnn::Shape and return emitc::ExpressionOp
+//
+// ttnn:Shape has a couple constructors, but they are explicit and require
+// specific datatypes on input. However, one of the constructors takes in a
+// tt_metal::Shape - given that it's much easier to construct a
+// tt_metal::Shape, we opted to do that here. The call looks like this:
+// ttnn::Shape(tt::tt_metal::LegacyShape{dim0, dim1, dim2, ...});
+//
+// To make it easier on the eyes, these two calls are packed into one, using
+// EmitC's ExpressionOp.
+//
+emitc::ExpressionOp createShapeOp(ConversionPatternRewriter &rewriter,
+                                  ttnn::ShapeAttr shapeAttr,
+                                  Block *containingBlock, Location loc);
+
+// Create ttnn::MemoryConfig and return emitc::CallOpaqueOp
+//
+emitc::CallOpaqueOp createMemoryConfigOp(ConversionPatternRewriter &rewriter,
+                                         ttnn::MemoryConfigAttr memoryConfig,
+                                         Location loc);
+
+} // namespace mlir::tt::ttnntoemitc::utils
+
+#endif // TTMLIR_CONVERSION_TTNNTOEMITC_UTILS_H

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -1118,6 +1118,23 @@ def TTIR_ArangeOp : TTIR_Op<"arange"> {
   let hasVerifier = 1;
 }
 
+def TTIR_OnesOp : TTIR_Op<"ones"> {
+  let summary = "Creates a tensor filled with ones.";
+  let description = [{
+    Tensor operation to create a tensor filled with ones.
+
+    Given a `shape`, produces a tensor with the shape, filled with ones.
+
+    Example:
+      %0 = "ttir.ones"() <{shape = array<i32:64, 28, 28>}> : () -> tensor<64x28x28xbf16>
+      // %0: [[[1, 1, 1, ..., 1], [1, 1, 1, ..., 1], ..., [1, 1, 1, ..., 1]]]
+  }];
+
+  let arguments = (ins DenseI32ArrayAttr:$shape);
+
+  let results = (outs AnyRankedTensor:$result);
+}
+
 def TTIR_ConstantOp : TTIR_Op<"constant", [ConstantLike,
                                            AllShapesMatch<["value", "result"]>]> {
     let summary = "Constant op.";

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -871,6 +871,27 @@ def TTNN_ArangeOp : TTNN_Op<"arange"> {
   let hasVerifier = 1;
 }
 
+def TTNN_OnesOp : TTNN_Op<"ones"> {
+  let summary = "Creates a tensor filled with ones.";
+  let description = [{
+    Tensor operation to create a tensor filled with ones.
+
+    Given a ShapeAttr `shape`, produces a tensor with the same shape, filled with ones.
+
+    Example:
+      %0 = "ttnn.ones"() <{shape = array<i32:64, 28, 28>}> : () -> tensor<64x28x28xbf16>
+      // %0: [[[1, 1, 1, ..., 1], [1, 1, 1, ..., 1], ..., [1, 1, 1, ..., 1]]]
+  }];
+
+  let arguments = (ins TTNN_ShapeAttr:$shape,
+                       OptionalAttr<TT_DataTypeAttr>:$dtype,
+                       OptionalAttr<TTNN_LayoutAttr>:$layout,
+                       Optional<TT_Device>:$device,
+                       OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
+
+  let results = (outs AnyRankedTensor:$result);
+}
+
 def TTNN_FullOp : TTNN_Op<"full"> {
     let summary = "Full op.";
     let description = [{

--- a/include/ttmlir/Dialect/TTNN/Utils/Utils.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/Utils.h
@@ -35,10 +35,6 @@ mlir::tt::TensorMemoryLayout toTTTensorMemoryLayout(
 mlir::tt::MemorySpace
 toTTMemorySpace(const mlir::tt::ttnn::BufferType bufferType);
 
-// Get Layout from MemRefType
-//
-Layout getLayoutFromMemRef(mlir::MemRefType memref);
-
 mlir::Type createRowMajorTypeFromDtype(::mlir::MLIRContext *context,
                                        DataType dtype);
 

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -60,9 +60,18 @@ table EmptyOp {
   dtype: DataType;
   layout: TensorLayout;
   num_shards: uint32;
-  device: tt.target.DeviceRef;         // optional
-  memcfg: tt.target.MemoryConfigDesc;  // optional
+  device: tt.target.DeviceRef;
+  memcfg: tt.target.MemoryConfigDesc;
   strategy: tt.target.DistributionStrategy;
+  out: tt.target.TensorRef;
+}
+
+table OnesOp {
+  shape: [int64];
+  dtype: DataType = null;
+  layout: TensorLayout = null;
+  device: tt.target.DeviceRef;
+  memcfg: tt.target.MemoryConfigDesc;
   out: tt.target.TensorRef;
 }
 
@@ -78,9 +87,9 @@ table ArangeOp {
   start: float;
   end: float;
   step: float;
-  dtype: tt.target.DataType = null; // optional
-  device: tt.target.DeviceRef; // optional
-  memcfg: tt.target.MemoryConfigDesc;  // optional
+  dtype: tt.target.DataType = null;
+  device: tt.target.DeviceRef;
+  memcfg: tt.target.MemoryConfigDesc;
   out: tt.target.TensorRef;
 }
 
@@ -299,6 +308,7 @@ union OpType {
   ToDeviceOp,
   FromDeviceOp,
   EmptyOp,
+  OnesOp,
   FullOp,
   EltwiseOp,
   LinearOp,

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -5,15 +5,16 @@
 #ifndef TTMLIR_TARGET_UTILS_MLIRTOFLATBUFFER_H
 #define TTMLIR_TARGET_UTILS_MLIRTOFLATBUFFER_H
 
-#include <numeric>
-#include <type_traits>
-
-#include "flatbuffers/flatbuffers.h"
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/Target/Common/Target.h"
 #include "ttmlir/Target/Utils/FlatbufferObjectCache.h"
 #include "ttmlir/Utils.h"
+
+#include "flatbuffers/flatbuffers.h"
+
+#include <numeric>
+#include <type_traits>
 
 namespace mlir::tt {
 
@@ -134,6 +135,35 @@ inline ::tt::target::DataType toFlatbuffer(FlatbufferObjectCache &,
   case DataType::UInt8:
     return ::tt::target::DataType::UInt8;
   }
+}
+
+inline ::flatbuffers::Optional<::tt::target::DataType>
+toFlatbufferOptional(FlatbufferObjectCache &cache,
+                     ::std::optional<::mlir::tt::DataType> dataType) {
+  return dataType.has_value() ? ::flatbuffers::Optional<::tt::target::DataType>(
+                                    toFlatbuffer(cache, dataType.value()))
+                              : ::flatbuffers::nullopt;
+}
+
+inline ::tt::target::TensorLayout toFlatbuffer(FlatbufferObjectCache &cache,
+                                               ttnn::Layout layout) {
+  switch (layout) {
+  case ttnn::Layout::RowMajor:
+    return ::tt::target::TensorLayout::RowMajor;
+  case ttnn::Layout::Tile:
+    return ::tt::target::TensorLayout::Tile;
+  case ttnn::Layout::Invalid:
+    return ::tt::target::TensorLayout::Invalid;
+  }
+}
+
+inline ::flatbuffers::Optional<::tt::target::TensorLayout>
+toFlatbufferOptional(FlatbufferObjectCache &cache,
+                     ::std::optional<mlir::tt::ttnn::Layout> layout) {
+  return layout.has_value()
+             ? ::flatbuffers::Optional<::tt::target::TensorLayout>(
+                   toFlatbuffer(cache, layout.value()))
+             : ::flatbuffers::nullopt;
 }
 
 inline ::tt::target::MemorySpace toFlatbuffer(FlatbufferObjectCache &,

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -92,6 +92,63 @@ public:
   }
 };
 
+class OnesOpConversionPattern : public OpConversionPattern<ttir::OnesOp> {
+public:
+  using OpConversionPattern<ttir::OnesOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttir::OnesOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Get ttnn::TTNNLayoutAttr of the result type
+    //
+    ttnn::TTNNLayoutAttr layoutAttr = mlir::cast<ttnn::TTNNLayoutAttr>(
+        op.getResult().getType().getEncoding());
+
+    // Get the shape of tensor
+    //
+    // TODO(svuckovic): (#1435) ShapeAttr accepts int64_t, when it should be
+    // uint32_t
+    //
+    ttnn::ShapeAttr shapeAttr = ttnn::ShapeAttr::get(
+        rewriter.getContext(), llvm::SmallVector<int64_t, 4>(
+                                   op.getShape().begin(), op.getShape().end()));
+
+    // Get memref
+    //
+    mlir::MemRefType memref = layoutAttr.getMemref();
+
+    // Get data type, tensor layout, device and memory config
+    //
+    DataTypeAttr dTypeAttr = DataTypeAttr::get(
+        rewriter.getContext(), layoutAttr.getDataType());
+    ttnn::BufferType bufferType = layoutAttr.getBufferType();
+    ttnn::Layout ttnnLayoutEnum = llvm::isa<TileType>(memref.getElementType())
+                                      ? ttnn::Layout::Tile
+                                      : ttnn::Layout::RowMajor;
+    ttnn::LayoutAttr tensorLayoutAttr =
+        ttnn::LayoutAttr::get(op.getContext(), ttnnLayoutEnum);
+    ttnn::TensorMemoryLayoutAttr memLayout = layoutAttr.getMemLayout();
+
+    // Device only exists if ttnn::TensorMemoryLayout is None
+    //
+    auto device =
+        memLayout ? nullptr : ::ttnn::utils::getOrInsertDevice(rewriter, op);
+
+    ttnn::MemoryConfigAttr memoryConfigAttr = ttnn::MemoryConfigAttr::get(
+        op.getContext(), ttnn::BufferTypeAttr::get(op.getContext(), bufferType),
+        ttnn::ShardSpecAttr::get(
+            op.getContext(),
+            ttnn::ShapeAttr::get(op.getContext(), memref.getShape())),
+        memLayout);
+
+    rewriter.replaceOpWithNewOp<ttnn::OnesOp>(
+        op, this->getTypeConverter()->convertType(op.getType()), shapeAttr,
+        dTypeAttr, tensorLayoutAttr, device, memoryConfigAttr);
+
+    return success();
+  }
+};
+
 class ToLayoutOpConversionPattern
     : public OpConversionPattern<ttir::ToLayoutOp> {
 public:
@@ -1018,6 +1075,7 @@ void populateTTIRToTTNNPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
   // ANCHOR: op_rewriter_pattern_set
   patterns
       .add<TensorEmptyConversionPattern,
+           OnesOpConversionPattern,
            ToLayoutOpConversionPattern,
            ElementwiseOpConversionPattern<ttir::AbsOp, ttnn::AbsOp>,
            ElementwiseOpConversionPattern<ttir::AddOp, ttnn::AddOp>,

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -129,17 +129,23 @@ public:
         ttnn::LayoutAttr::get(op.getContext(), ttnnLayoutEnum);
     ttnn::TensorMemoryLayoutAttr memLayout = layoutAttr.getMemLayout();
 
-    // Device only exists if ttnn::TensorMemoryLayout is None
+    // Device only exists if memLayout is *not* null
     //
     auto device =
-        memLayout ? nullptr : ::ttnn::utils::getOrInsertDevice(rewriter, op);
+        memLayout ? ::ttnn::utils::getOrInsertDevice(rewriter, op) : nullptr;
 
-    ttnn::MemoryConfigAttr memoryConfigAttr = ttnn::MemoryConfigAttr::get(
-        op.getContext(), ttnn::BufferTypeAttr::get(op.getContext(), bufferType),
-        ttnn::ShardSpecAttr::get(
-            op.getContext(),
-            ttnn::ShapeAttr::get(op.getContext(), memref.getShape())),
-        memLayout);
+    // MemoryConfigAttr only exists if memLayout is *not* null
+    //
+    ttnn::MemoryConfigAttr memoryConfigAttr =
+        memLayout
+            ? ttnn::MemoryConfigAttr::get(
+                  op.getContext(),
+                  ttnn::BufferTypeAttr::get(op.getContext(), bufferType),
+                  ttnn::ShardSpecAttr::get(
+                      op.getContext(),
+                      ttnn::ShapeAttr::get(op.getContext(), memref.getShape())),
+                  memLayout)
+            : nullptr;
 
     rewriter.replaceOpWithNewOp<ttnn::OnesOp>(
         op, this->getTypeConverter()->convertType(op.getType()), shapeAttr,

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -119,8 +119,8 @@ public:
 
     // Get data type, tensor layout, device and memory config
     //
-    DataTypeAttr dTypeAttr = DataTypeAttr::get(
-        rewriter.getContext(), layoutAttr.getDataType());
+    DataTypeAttr dTypeAttr =
+        DataTypeAttr::get(rewriter.getContext(), layoutAttr.getDataType());
     ttnn::BufferType bufferType = layoutAttr.getBufferType();
     ttnn::Layout ttnnLayoutEnum = llvm::isa<TileType>(memref.getElementType())
                                       ? ttnn::Layout::Tile

--- a/lib/Conversion/TTNNToEmitC/CMakeLists.txt
+++ b/lib/Conversion/TTNNToEmitC/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mlir_library(TTMLIRTTNNToEmitC
   TTNNToEmitC.cpp
   TTNNToEmitCPass.cpp
+  Utils.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${PROJECT_SOURCE_DIR}/include/ttmlir/Conversion/TTNNToEmitC

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -4,6 +4,7 @@
 
 #include "ttmlir/Conversion/TTNNToEmitC/TTNNToEmitC.h"
 
+#include "ttmlir/Conversion/TTNNToEmitC/Utils.h"
 #include "ttmlir/Dialect/TT/IR/TTOpsDialect.h.inc"
 #include "ttmlir/Dialect/TTNN/IR/TTNN.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
@@ -37,121 +38,9 @@ using namespace mlir::tt;
 
 namespace {
 
-// Create emitc::OpaqueAttr for std::nullopt
-//
-emitc::OpaqueAttr createStdNullopt(Builder &builder) {
-  return builder.getType<emitc::OpaqueAttr>("std::nullopt");
-}
-
 emitc::OpaqueAttr createNullDevicePointer(Builder &builder) {
   return builder.getType<emitc::OpaqueAttr>(
       "static_cast<::ttnn::Device *>(nullptr)");
-}
-
-// Create emitc::OpaqueAttr for ttnn::Layout
-//
-emitc::OpaqueAttr convertLayoutAttr(Builder &builder, ttnn::LayoutAttr attr) {
-  switch (attr.getValue()) {
-  case ttnn::Layout::RowMajor:
-    return builder.getType<emitc::OpaqueAttr>("ttnn::Layout::ROW_MAJOR");
-  case ttnn::Layout::Tile:
-    return builder.getType<emitc::OpaqueAttr>("ttnn::Layout::TILE");
-  case ttnn::Layout::Invalid:
-    return builder.getType<emitc::OpaqueAttr>("ttnn::Layout::INVALID");
-  }
-
-  llvm_unreachable("Unknown ttnn::Layout");
-}
-
-emitc::OpaqueAttr convertBoolAttr(Builder &builder, BoolAttr attr) {
-  return builder.getType<emitc::OpaqueAttr>(attr.getValue() ? "true" : "false");
-}
-
-// Create emitc::OpaqueAttr for ttnn::TensorMemoryLayout
-//
-emitc::OpaqueAttr convertTensorMemoryLayout(Builder &builder,
-                                            ttnn::TensorMemoryLayoutAttr attr) {
-  switch (attr.getValue()) {
-  case ttnn::TensorMemoryLayout::BlockSharded:
-    return builder.getType<emitc::OpaqueAttr>(
-        "ttnn::TensorMemoryLayout::BLOCK_SHARDED");
-  case ttnn::TensorMemoryLayout::HeightSharded:
-    return builder.getType<emitc::OpaqueAttr>(
-        "ttnn::TensorMemoryLayout::HEIGHT_SHARDED");
-  case ttnn::TensorMemoryLayout::Interleaved:
-    return builder.getType<emitc::OpaqueAttr>(
-        "ttnn::TensorMemoryLayout::INTERLEAVED");
-  case ttnn::TensorMemoryLayout::SingleBank:
-    return builder.getType<emitc::OpaqueAttr>(
-        "ttnn::TensorMemoryLayout::SINGLE_BANK");
-  case ttnn::TensorMemoryLayout::WidthSharded:
-    return builder.getType<emitc::OpaqueAttr>(
-        "ttnn::TensorMemoryLayout::WIDTH_SHARDED");
-  }
-}
-
-// Create emitc::OpaqueAttr for ttnn::BufferType
-//
-emitc::OpaqueAttr convertBufferType(Builder &builder,
-                                    ttnn::BufferTypeAttr attr) {
-  switch (attr.getValue()) {
-  case ttnn::BufferType::DRAM:
-    return builder.getType<emitc::OpaqueAttr>("ttnn::BufferType::DRAM");
-  case ttnn::BufferType::L1:
-    return builder.getType<emitc::OpaqueAttr>("ttnn::BufferType::L1");
-  case ttnn::BufferType::L1Small:
-    return builder.getType<emitc::OpaqueAttr>("ttnn::BufferType::L1_SMALL");
-  case ttnn::BufferType::SystemMemory:
-    return builder.getType<emitc::OpaqueAttr>(
-        "ttnn::BufferType::SYSTEM_MEMORY");
-  case ttnn::BufferType::Trace:
-    return builder.getType<emitc::OpaqueAttr>("ttnn::BufferType::TRACE");
-  }
-
-  llvm_unreachable("Unknown ttnn::BufferType");
-}
-
-// Create emitc::OpaqueAttr for ttnn::Shape
-//
-emitc::OpaqueAttr convertShape(Builder &builder, ttnn::ShapeAttr attr) {
-  llvm::ArrayRef shape = attr.getShape();
-  std::ostringstream oss;
-  std::copy(shape.begin(), shape.end(), std::ostream_iterator<int>(oss, ", "));
-  return builder.getType<emitc::OpaqueAttr>("{" + oss.str() + "}");
-}
-
-// Create emitc::OpaqueAttr for ttnn::DataType
-//
-emitc::OpaqueAttr convertDType(Builder &builder, tt::DataTypeAttr attr) {
-  switch (attr.getValue()) {
-  case tt::DataType::BFloat16:
-    return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::BFLOAT16");
-  case tt::DataType::Float32:
-    return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::FLOAT32");
-  case tt::DataType::UInt32:
-    return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::UINT32");
-  case tt::DataType::BFP_BFloat8:
-    return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::BFLOAT8_B");
-  case tt::DataType::BFP_BFloat4:
-    return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::BFLOAT4_B");
-  case tt::DataType::UInt8:
-    return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::UINT8");
-  case tt::DataType::UInt16:
-    return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::UINT16");
-  // TODO(svuckovic):
-  // Add support for INT32
-  //
-  // case tt::DataType::Int32:
-  //   return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::INT32");
-  case tt::DataType::Float16:
-  case tt::DataType::BFP_Float2:
-  case tt::DataType::BFP_Float4:
-  case tt::DataType::BFP_Float8:
-  case tt::DataType::BFP_BFloat2:
-    llvm_unreachable("Unsupported ttnn::DataType");
-  }
-
-  llvm_unreachable("Unkonwn tt::DataType");
 }
 
 // Base class for TTNN to EmitC OpConversionPattern
@@ -248,8 +137,8 @@ public:
     llvm::SmallVector<Attribute, 5> attrs;
     attrs.push_back(mlir::IntegerAttr::get(rewriter.getIndexType(), 0));
     attrs.push_back(mlir::IntegerAttr::get(rewriter.getIndexType(), 1));
-    attrs.push_back(createStdNullopt(rewriter));
-    attrs.push_back(createStdNullopt(rewriter));
+    attrs.push_back(ttnntoemitc::utils::createStdNullopt(rewriter));
+    attrs.push_back(ttnntoemitc::utils::createStdNullopt(rewriter));
     attrs.push_back(mlir::IntegerAttr::get(rewriter.getIndexType(), 2));
 
     ArrayAttr arrayAttrs = ArrayAttr::get(srcOp->getContext(), attrs);
@@ -318,10 +207,10 @@ public:
       // Create ArrayAttr object holding MemoryConfig attributes
       //
       ArrayAttr arrayAttrs = rewriter.getArrayAttr(
-          {convertTensorMemoryLayout(
+          {ttnntoemitc::utils::convertTensorMemoryLayout(
                rewriter, srcOp.getMemoryConfig()->getTensorMemoryLayout()),
-           convertBufferType(rewriter,
-                             srcOp.getMemoryConfig()->getBufferType())});
+           ttnntoemitc::utils::convertBufferType(
+               rewriter, srcOp.getMemoryConfig()->getBufferType())});
 
       // Create MemoryConfig object first, then pass it to the op
       //
@@ -332,7 +221,7 @@ public:
       operands.append(1, memCfgOp.getResult(0));
       attrs.push_back(mlir::IntegerAttr::get(rewriter.getIndexType(), 2));
     } else {
-      attrs.push_back(createStdNullopt(rewriter));
+      attrs.push_back(ttnntoemitc::utils::createStdNullopt(rewriter));
     }
 
     ArrayAttr finalAttrs = ArrayAttr::get(srcOp->getContext(), attrs);
@@ -415,9 +304,10 @@ public:
     // Create ArrayAttr object holding MemoryConfig attributes
     //
     ArrayAttr arrayAttrs = rewriter.getArrayAttr(
-        {convertTensorMemoryLayout(
+        {ttnntoemitc::utils::convertTensorMemoryLayout(
              rewriter, srcOp.getMemoryConfig().getTensorMemoryLayout()),
-         convertBufferType(rewriter, srcOp.getMemoryConfig().getBufferType())});
+         ttnntoemitc::utils::convertBufferType(
+             rewriter, srcOp.getMemoryConfig().getBufferType())});
 
     // Create MemoryConfig object first, then pass it to the op
     //
@@ -434,7 +324,7 @@ public:
     llvm::SmallVector<Attribute, 3> attrs;
     attrs.push_back(mlir::IntegerAttr::get(rewriter.getIndexType(), 0));
     attrs.push_back(mlir::IntegerAttr::get(rewriter.getIndexType(), 1));
-    attrs.push_back(createStdNullopt(rewriter));
+    attrs.push_back(ttnntoemitc::utils::createStdNullopt(rewriter));
 
     ArrayAttr finalAttrs = ArrayAttr::get(srcOp->getContext(), attrs);
 
@@ -464,9 +354,10 @@ public:
 
     llvm::SmallVector<Attribute, 5> attrs;
     attrs.push_back(mlir::IntegerAttr::get(rewriter.getIndexType(), 0));
-    attrs.push_back(convertLayoutAttr(rewriter, srcOp.getLayoutAttr()));
-    attrs.push_back(createStdNullopt(rewriter));
-    attrs.push_back(createStdNullopt(rewriter));
+    attrs.push_back(
+        ttnntoemitc::utils::convertLayoutAttr(rewriter, srcOp.getLayoutAttr()));
+    attrs.push_back(ttnntoemitc::utils::createStdNullopt(rewriter));
+    attrs.push_back(ttnntoemitc::utils::createStdNullopt(rewriter));
     attrs.push_back(createNullDevicePointer(rewriter));
 
     ArrayAttr arrayAttrs = ArrayAttr::get(srcOp->getContext(), attrs);
@@ -500,37 +391,8 @@ public:
 
     // Create ttnn::Shape() call
     //
-    // ttnn:Shape has a couple constructors, but they are explicit and require
-    // specific datatypes on input. However, one of the constructors takes in a
-    // tt_metal::Shape - given that it's much easier to construct a
-    // tt_metal::Shape, we opted to do that here. The call looks like this:
-    // ttnn::Shape(tt::tt_metal::LegacyShape{dim0, dim1, dim2, ...});
-    //
-    // To make it easier on the eyes, these two calls are packed into one, using
-    // EmitC's ExpressionOp.
-    //
-    emitc::ExpressionOp shapeExpressionOp =
-        rewriter.create<emitc::ExpressionOp>(
-            srcOp->getLoc(),
-            emitc::OpaqueType::get(rewriter.getContext(), "ttnn::Shape"),
-            false);
-    mlir::Block &bodyBlock = shapeExpressionOp.getBodyRegion().emplaceBlock();
-    auto currentPoint = rewriter.getInsertionPoint();
-    rewriter.setInsertionPointToStart(&bodyBlock);
-    emitc::CallOpaqueOp metalShapeOp = rewriter.create<emitc::CallOpaqueOp>(
-        srcOp->getLoc(),
-        emitc::OpaqueType::get(rewriter.getContext(),
-                               "tt::tt_metal::LegacyShape"),
-        rewriter.getStringAttr("tt::tt_metal::LegacyShape"),
-        rewriter.getArrayAttr(convertShape(rewriter, shapeAttr)), nullptr,
-        ValueRange());
-    emitc::CallOpaqueOp ttnnShapeOp = rewriter.create<emitc::CallOpaqueOp>(
-        srcOp->getLoc(),
-        emitc::OpaqueType::get(rewriter.getContext(), "ttnn::Shape"),
-        rewriter.getStringAttr("ttnn::Shape"), nullptr, nullptr,
-        metalShapeOp->getResults());
-    rewriter.create<emitc::YieldOp>(srcOp->getLoc(), ttnnShapeOp->getResult(0));
-    rewriter.setInsertionPoint(srcOp->getBlock(), currentPoint);
+    emitc::ExpressionOp shapeExpressionOp = ttnntoemitc::utils::createShapeOp(
+        rewriter, shapeAttr, srcOp->getBlock(), srcOp.getLoc());
 
     llvm::SmallVector<Value, 3> operands{
         shapeExpressionOp->getResult(0),
@@ -542,20 +404,10 @@ public:
     if (adaptor.getDevice()) {
       operands.append(1, adaptor.getDevice());
 
-      // Create ArrayAttr object holding MemoryConfig attributes
-      //
-      ArrayAttr memCfgArrayAttrs = rewriter.getArrayAttr(
-          {convertTensorMemoryLayout(
-               rewriter, srcOp.getMemoryConfig()->getTensorMemoryLayout()),
-           convertBufferType(rewriter,
-                             srcOp.getMemoryConfig()->getBufferType())});
-
       // Create MemoryConfig object first, then pass it to the op
       //
-      emitc::CallOpaqueOp memCfgOp = rewriter.create<emitc::CallOpaqueOp>(
-          srcOp->getLoc(),
-          emitc::OpaqueType::get(rewriter.getContext(), "ttnn::MemoryConfig"),
-          "ttnn::MemoryConfig", memCfgArrayAttrs, nullptr, ValueRange());
+      emitc::CallOpaqueOp memCfgOp = ttnntoemitc::utils::createMemoryConfigOp(
+          rewriter, srcOp.getMemoryConfig().value(), srcOp.getLoc());
 
       // Concat operands and MemoryConfig object
       //
@@ -565,21 +417,104 @@ public:
       //
       arrayAttr = rewriter.getArrayAttr({
           rewriter.getIndexAttr(0), // ttnn::Shape
-          convertDType(rewriter, dataTypeAttr),
-          convertLayoutAttr(rewriter, layoutAttr),
+          ttnntoemitc::utils::convertDType(rewriter, dataTypeAttr),
+          ttnntoemitc::utils::convertLayoutAttr(rewriter, layoutAttr),
           rewriter.getIndexAttr(1), // ttnn::Device
           rewriter.getIndexAttr(2), // ttnn::MemoryConfig
       });
     } else {
       arrayAttr = rewriter.getArrayAttr({
           rewriter.getIndexAttr(0), // ttnn::Shape
-          convertDType(rewriter, dataTypeAttr),
-          convertLayoutAttr(rewriter, layoutAttr),
+          ttnntoemitc::utils::convertDType(rewriter, dataTypeAttr),
+          ttnntoemitc::utils::convertLayoutAttr(rewriter, layoutAttr),
       });
     }
 
     // Finally, convert ttir::EmptyOp to ttnn::EmptyOp
     //
+    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
+        srcOp, this->getTypeConverter()->convertType(srcOp.getType()),
+        this->convertOpName(srcOp), arrayAttr, nullptr, operands);
+
+    return success();
+  }
+};
+
+// OnesOp conversion pattern
+//
+class OnesOpConversionPattern
+    : public TTNNToEmitCBaseOpConversionPattern<ttnn::OnesOp> {
+
+public:
+  OnesOpConversionPattern(const TypeConverter &typeConverter,
+                          MLIRContext *context, PatternBenefit benefit = 1)
+      : TTNNToEmitCBaseOpConversionPattern<ttnn::OnesOp>(typeConverter, context,
+                                                         benefit) {}
+
+  LogicalResult
+  matchAndRewrite(ttnn::OnesOp srcOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    // ttnn:OnesOp has 5 input params:
+    //
+    // let arguments = (ins TTNN_ShapeAttr:$shape,
+    //                      OptionalAttr<TT_DataTypeAttr>:$dtype,
+    //                      OptionalAttr<TTNN_LayoutAttr>:$layout,
+    //                      Optional<TT_Device>:$device,
+    //                      OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
+    //
+    // Some of them are Attrs, some are Values. ShapeAttr is required, while
+    // others are optional. Additionally, in the context of C++, some of the
+    // Attrs (like shape) need to be instantiated into objects before being
+    // passed to the op. Therefore:
+    //
+    // We first create a ttnn::Shape object (SSA) by calling createShapeOp() and
+    // add it to the operands vector, but also add an IndexAttr in ArrayAttr to
+    // reference it (this is an EmitC mechanism that allows for combining Attrs
+    // and Values when calling an OpaqueOp).
+    // All the other input params are optional, so we create them on-the-fly
+    // into the ArrayAttr, whether they are an actual Attr, or a Value pointed
+    // to by IndexAttr. If they are present, we create the object and pass it to
+    // the op. If not, we pass std::nullopt.
+
+    // Create ttnn::Shape() call
+    //
+    emitc::ExpressionOp shapeExpressionOp = ttnntoemitc::utils::createShapeOp(
+        rewriter, srcOp.getShapeAttr(), srcOp->getBlock(), srcOp.getLoc());
+
+    llvm::SmallVector<Value, 3> operands{
+        shapeExpressionOp->getResult(0),
+    };
+
+    // Create ArrayAttr object holding attributes and pointers to operands
+    //
+    // Params that are Values are added to the operands vector on-the-fly, and a
+    // corresponding IndexAttr is added to the ArrayAttr to reference them.
+    //
+    size_t operandIndex = 0;
+    ArrayAttr arrayAttr = rewriter.getArrayAttr({
+        rewriter.getIndexAttr(operandIndex++), // ttnn::Shape
+        srcOp.getDtype().has_value()
+            ? ttnntoemitc::utils::convertDType(rewriter, srcOp.getDtypeAttr())
+            : ttnntoemitc::utils::createStdNullopt(rewriter), // ttnn::DataType
+        srcOp.getLayout().has_value()
+            ? ttnntoemitc::utils::convertLayoutAttr(rewriter,
+                                                    srcOp.getLayoutAttr())
+            : ttnntoemitc::utils::createStdNullopt(rewriter), // ttnn::Layout
+        adaptor.getDevice()
+            ? (operands.append(1, adaptor.getDevice()),
+               mlir::cast<Attribute>(rewriter.getIndexAttr(operandIndex++)))
+            : ttnntoemitc::utils::createStdNullopt(rewriter), // ttnn::Device
+        srcOp.getMemoryConfig().has_value()
+            ? (operands.append(
+                   1, ttnntoemitc::utils::createMemoryConfigOp(
+                          rewriter, srcOp.getMemoryConfigAttr(), srcOp.getLoc())
+                          ->getResult(0)),
+               mlir::cast<Attribute>(rewriter.getIndexAttr(operandIndex++)))
+            : ttnntoemitc::utils::createStdNullopt(
+                  rewriter), // ttnn::MemoryConfig
+    });
+
     rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
         srcOp, this->getTypeConverter()->convertType(srcOp.getType()),
         this->convertOpName(srcOp), arrayAttr, nullptr, operands);
@@ -606,7 +541,7 @@ public:
 
     ArrayAttr arrayAttr = rewriter.getArrayAttr({
         rewriter.getIndexAttr(0),
-        convertBoolAttr(rewriter, srcOp.getForceAttr()),
+        ttnntoemitc::utils::convertBoolAttr(rewriter, srcOp.getForceAttr()),
     });
 
     rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
@@ -682,16 +617,23 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
 
   // Memory ops
   //
-  patterns.add<ToLayoutOpConversionPattern, ToMemoryConfigOpConversionPattern,
-               TypecastOpConversionPattern, ToDeviceOpConversionPattern,
-               FromDeviceOpConversionPattern, DeallocateOpConversionPattern>(
-      typeConverter, ctx);
+  // clang-format off
+  patterns.add<ToLayoutOpConversionPattern,
+               ToMemoryConfigOpConversionPattern,
+               TypecastOpConversionPattern,
+               ToDeviceOpConversionPattern,
+               FromDeviceOpConversionPattern,
+               DeallocateOpConversionPattern>(typeConverter, ctx);
+  // clang-format on
 
   // Tensor ops
   //
-  patterns
-      .add<EmptyOpConversionPattern, DefaultOpConversionPattern<ttnn::FullOp>,
-           DefaultOpConversionPattern<ttnn::ArangeOp>>(typeConverter, ctx);
+  // clang-format off
+  patterns.add<EmptyOpConversionPattern,
+               OnesOpConversionPattern,
+               DefaultOpConversionPattern<ttnn::FullOp>,
+               DefaultOpConversionPattern<ttnn::ArangeOp>>(typeConverter, ctx);
+  // clang-format on
 
   // Eltwise unary ops
   //

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -137,8 +137,8 @@ public:
     llvm::SmallVector<Attribute, 5> attrs;
     attrs.push_back(mlir::IntegerAttr::get(rewriter.getIndexType(), 0));
     attrs.push_back(mlir::IntegerAttr::get(rewriter.getIndexType(), 1));
-    attrs.push_back(ttnntoemitc::utils::createStdNullopt(rewriter));
-    attrs.push_back(ttnntoemitc::utils::createStdNullopt(rewriter));
+    attrs.push_back(ttnn_to_emitc::utils::createStdNullopt(rewriter));
+    attrs.push_back(ttnn_to_emitc::utils::createStdNullopt(rewriter));
     attrs.push_back(mlir::IntegerAttr::get(rewriter.getIndexType(), 2));
 
     ArrayAttr arrayAttrs = ArrayAttr::get(srcOp->getContext(), attrs);
@@ -207,9 +207,9 @@ public:
       // Create ArrayAttr object holding MemoryConfig attributes
       //
       ArrayAttr arrayAttrs = rewriter.getArrayAttr(
-          {ttnntoemitc::utils::convertTensorMemoryLayout(
+          {ttnn_to_emitc::utils::convertTensorMemoryLayout(
                rewriter, srcOp.getMemoryConfig()->getTensorMemoryLayout()),
-           ttnntoemitc::utils::convertBufferType(
+           ttnn_to_emitc::utils::convertBufferType(
                rewriter, srcOp.getMemoryConfig()->getBufferType())});
 
       // Create MemoryConfig object first, then pass it to the op
@@ -221,7 +221,7 @@ public:
       operands.append(1, memCfgOp.getResult(0));
       attrs.push_back(mlir::IntegerAttr::get(rewriter.getIndexType(), 2));
     } else {
-      attrs.push_back(ttnntoemitc::utils::createStdNullopt(rewriter));
+      attrs.push_back(ttnn_to_emitc::utils::createStdNullopt(rewriter));
     }
 
     ArrayAttr finalAttrs = ArrayAttr::get(srcOp->getContext(), attrs);
@@ -304,9 +304,9 @@ public:
     // Create ArrayAttr object holding MemoryConfig attributes
     //
     ArrayAttr arrayAttrs = rewriter.getArrayAttr(
-        {ttnntoemitc::utils::convertTensorMemoryLayout(
+        {ttnn_to_emitc::utils::convertTensorMemoryLayout(
              rewriter, srcOp.getMemoryConfig().getTensorMemoryLayout()),
-         ttnntoemitc::utils::convertBufferType(
+         ttnn_to_emitc::utils::convertBufferType(
              rewriter, srcOp.getMemoryConfig().getBufferType())});
 
     // Create MemoryConfig object first, then pass it to the op
@@ -324,7 +324,7 @@ public:
     llvm::SmallVector<Attribute, 3> attrs;
     attrs.push_back(mlir::IntegerAttr::get(rewriter.getIndexType(), 0));
     attrs.push_back(mlir::IntegerAttr::get(rewriter.getIndexType(), 1));
-    attrs.push_back(ttnntoemitc::utils::createStdNullopt(rewriter));
+    attrs.push_back(ttnn_to_emitc::utils::createStdNullopt(rewriter));
 
     ArrayAttr finalAttrs = ArrayAttr::get(srcOp->getContext(), attrs);
 
@@ -354,10 +354,10 @@ public:
 
     llvm::SmallVector<Attribute, 5> attrs;
     attrs.push_back(mlir::IntegerAttr::get(rewriter.getIndexType(), 0));
-    attrs.push_back(
-        ttnntoemitc::utils::convertLayoutAttr(rewriter, srcOp.getLayoutAttr()));
-    attrs.push_back(ttnntoemitc::utils::createStdNullopt(rewriter));
-    attrs.push_back(ttnntoemitc::utils::createStdNullopt(rewriter));
+    attrs.push_back(ttnn_to_emitc::utils::convertLayoutAttr(
+        rewriter, srcOp.getLayoutAttr()));
+    attrs.push_back(ttnn_to_emitc::utils::createStdNullopt(rewriter));
+    attrs.push_back(ttnn_to_emitc::utils::createStdNullopt(rewriter));
     attrs.push_back(createNullDevicePointer(rewriter));
 
     ArrayAttr arrayAttrs = ArrayAttr::get(srcOp->getContext(), attrs);
@@ -391,7 +391,7 @@ public:
 
     // Create ttnn::Shape() call
     //
-    emitc::ExpressionOp shapeExpressionOp = ttnntoemitc::utils::createShapeOp(
+    emitc::ExpressionOp shapeExpressionOp = ttnn_to_emitc::utils::createShapeOp(
         rewriter, shapeAttr, srcOp->getBlock(), srcOp.getLoc());
 
     llvm::SmallVector<Value, 3> operands{
@@ -406,7 +406,7 @@ public:
 
       // Create MemoryConfig object first, then pass it to the op
       //
-      emitc::CallOpaqueOp memCfgOp = ttnntoemitc::utils::createMemoryConfigOp(
+      emitc::CallOpaqueOp memCfgOp = ttnn_to_emitc::utils::createMemoryConfigOp(
           rewriter, srcOp.getMemoryConfig().value(), srcOp.getLoc());
 
       // Concat operands and MemoryConfig object
@@ -417,16 +417,16 @@ public:
       //
       arrayAttr = rewriter.getArrayAttr({
           rewriter.getIndexAttr(0), // ttnn::Shape
-          ttnntoemitc::utils::convertDType(rewriter, dataTypeAttr),
-          ttnntoemitc::utils::convertLayoutAttr(rewriter, layoutAttr),
+          ttnn_to_emitc::utils::convertDType(rewriter, dataTypeAttr),
+          ttnn_to_emitc::utils::convertLayoutAttr(rewriter, layoutAttr),
           rewriter.getIndexAttr(1), // ttnn::Device
           rewriter.getIndexAttr(2), // ttnn::MemoryConfig
       });
     } else {
       arrayAttr = rewriter.getArrayAttr({
           rewriter.getIndexAttr(0), // ttnn::Shape
-          ttnntoemitc::utils::convertDType(rewriter, dataTypeAttr),
-          ttnntoemitc::utils::convertLayoutAttr(rewriter, layoutAttr),
+          ttnn_to_emitc::utils::convertDType(rewriter, dataTypeAttr),
+          ttnn_to_emitc::utils::convertLayoutAttr(rewriter, layoutAttr),
       });
     }
 
@@ -479,7 +479,7 @@ public:
 
     // Create ttnn::Shape() call
     //
-    emitc::ExpressionOp shapeExpressionOp = ttnntoemitc::utils::createShapeOp(
+    emitc::ExpressionOp shapeExpressionOp = ttnn_to_emitc::utils::createShapeOp(
         rewriter, srcOp.getShapeAttr(), srcOp->getBlock(), srcOp.getLoc());
 
     llvm::SmallVector<Value, 3> operands{
@@ -495,23 +495,24 @@ public:
     ArrayAttr arrayAttr = rewriter.getArrayAttr({
         rewriter.getIndexAttr(operandIndex++), // ttnn::Shape
         srcOp.getDtype().has_value()
-            ? ttnntoemitc::utils::convertDType(rewriter, srcOp.getDtypeAttr())
-            : ttnntoemitc::utils::createStdNullopt(rewriter), // ttnn::DataType
+            ? ttnn_to_emitc::utils::convertDType(rewriter, srcOp.getDtypeAttr())
+            : ttnn_to_emitc::utils::createStdNullopt(
+                  rewriter), // ttnn::DataType
         srcOp.getLayout().has_value()
-            ? ttnntoemitc::utils::convertLayoutAttr(rewriter,
-                                                    srcOp.getLayoutAttr())
-            : ttnntoemitc::utils::createStdNullopt(rewriter), // ttnn::Layout
+            ? ttnn_to_emitc::utils::convertLayoutAttr(rewriter,
+                                                      srcOp.getLayoutAttr())
+            : ttnn_to_emitc::utils::createStdNullopt(rewriter), // ttnn::Layout
         adaptor.getDevice()
             ? (operands.append(1, adaptor.getDevice()),
                mlir::cast<Attribute>(rewriter.getIndexAttr(operandIndex++)))
-            : ttnntoemitc::utils::createStdNullopt(rewriter), // ttnn::Device
+            : ttnn_to_emitc::utils::createStdNullopt(rewriter), // ttnn::Device
         srcOp.getMemoryConfig().has_value()
             ? (operands.append(
-                   1, ttnntoemitc::utils::createMemoryConfigOp(
+                   1, ttnn_to_emitc::utils::createMemoryConfigOp(
                           rewriter, srcOp.getMemoryConfigAttr(), srcOp.getLoc())
                           ->getResult(0)),
                mlir::cast<Attribute>(rewriter.getIndexAttr(operandIndex++)))
-            : ttnntoemitc::utils::createStdNullopt(
+            : ttnn_to_emitc::utils::createStdNullopt(
                   rewriter), // ttnn::MemoryConfig
     });
 
@@ -541,7 +542,7 @@ public:
 
     ArrayAttr arrayAttr = rewriter.getArrayAttr({
         rewriter.getIndexAttr(0),
-        ttnntoemitc::utils::convertBoolAttr(rewriter, srcOp.getForceAttr()),
+        ttnn_to_emitc::utils::convertBoolAttr(rewriter, srcOp.getForceAttr()),
     });
 
     rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(

--- a/lib/Conversion/TTNNToEmitC/Utils.cpp
+++ b/lib/Conversion/TTNNToEmitC/Utils.cpp
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Conversion/TTNNToEmitC/Utils.h"
+
+#include "mlir/Pass/Pass.h"
+
+namespace mlir::tt::ttnntoemitc::utils {
+
+emitc::OpaqueAttr convertShape(Builder &builder, ttnn::ShapeAttr attr) {
+  llvm::ArrayRef shape = attr.getShape();
+  std::ostringstream oss;
+  std::copy(shape.begin(), shape.end(), std::ostream_iterator<int>(oss, ", "));
+  return builder.getType<emitc::OpaqueAttr>("{" + oss.str() + "}");
+}
+
+emitc::OpaqueAttr convertTensorMemoryLayout(Builder &builder,
+                                            ttnn::TensorMemoryLayoutAttr attr) {
+  switch (attr.getValue()) {
+  case ttnn::TensorMemoryLayout::BlockSharded:
+    return builder.getType<emitc::OpaqueAttr>(
+        "ttnn::TensorMemoryLayout::BLOCK_SHARDED");
+  case ttnn::TensorMemoryLayout::HeightSharded:
+    return builder.getType<emitc::OpaqueAttr>(
+        "ttnn::TensorMemoryLayout::HEIGHT_SHARDED");
+  case ttnn::TensorMemoryLayout::Interleaved:
+    return builder.getType<emitc::OpaqueAttr>(
+        "ttnn::TensorMemoryLayout::INTERLEAVED");
+  case ttnn::TensorMemoryLayout::SingleBank:
+    return builder.getType<emitc::OpaqueAttr>(
+        "ttnn::TensorMemoryLayout::SINGLE_BANK");
+  case ttnn::TensorMemoryLayout::WidthSharded:
+    return builder.getType<emitc::OpaqueAttr>(
+        "ttnn::TensorMemoryLayout::WIDTH_SHARDED");
+  }
+
+  llvm_unreachable("Unknown ttnn::TensorMemoryLayout");
+}
+
+emitc::OpaqueAttr convertBufferType(Builder &builder,
+                                    ttnn::BufferTypeAttr attr) {
+  switch (attr.getValue()) {
+  case ttnn::BufferType::DRAM:
+    return builder.getType<emitc::OpaqueAttr>("ttnn::BufferType::DRAM");
+  case ttnn::BufferType::L1:
+    return builder.getType<emitc::OpaqueAttr>("ttnn::BufferType::L1");
+  case ttnn::BufferType::L1Small:
+    return builder.getType<emitc::OpaqueAttr>("ttnn::BufferType::L1_SMALL");
+  case ttnn::BufferType::SystemMemory:
+    return builder.getType<emitc::OpaqueAttr>(
+        "ttnn::BufferType::SYSTEM_MEMORY");
+  case ttnn::BufferType::Trace:
+    return builder.getType<emitc::OpaqueAttr>("ttnn::BufferType::TRACE");
+  }
+
+  llvm_unreachable("Unknown ttnn::BufferType");
+}
+
+emitc::OpaqueAttr convertLayoutAttr(Builder &builder, ttnn::LayoutAttr attr) {
+  switch (attr.getValue()) {
+  case ttnn::Layout::RowMajor:
+    return builder.getType<emitc::OpaqueAttr>("ttnn::Layout::ROW_MAJOR");
+  case ttnn::Layout::Tile:
+    return builder.getType<emitc::OpaqueAttr>("ttnn::Layout::TILE");
+  case ttnn::Layout::Invalid:
+    return builder.getType<emitc::OpaqueAttr>("ttnn::Layout::INVALID");
+  }
+
+  llvm_unreachable("Unknown ttnn::Layout");
+}
+
+emitc::OpaqueAttr convertBoolAttr(Builder &builder, BoolAttr attr) {
+  return builder.getType<emitc::OpaqueAttr>(attr.getValue() ? "true" : "false");
+}
+
+emitc::OpaqueAttr convertDType(Builder &builder, tt::DataTypeAttr attr) {
+  switch (attr.getValue()) {
+  case tt::DataType::BFloat16:
+    return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::BFLOAT16");
+  case tt::DataType::Float32:
+    return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::FLOAT32");
+  case tt::DataType::UInt32:
+    return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::UINT32");
+  case tt::DataType::BFP_BFloat8:
+    return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::BFLOAT8_B");
+  case tt::DataType::BFP_BFloat4:
+    return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::BFLOAT4_B");
+  case tt::DataType::UInt8:
+    return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::UINT8");
+  case tt::DataType::UInt16:
+    return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::UINT16");
+  // TODO(svuckovic):
+  // Add support for INT32
+  //
+  // case tt::DataType::Int32:
+  //   return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::INT32");
+  case tt::DataType::Float16:
+  case tt::DataType::BFP_Float2:
+  case tt::DataType::BFP_Float4:
+  case tt::DataType::BFP_Float8:
+  case tt::DataType::BFP_BFloat2:
+    llvm_unreachable("Unsupported ttnn::DataType");
+  }
+
+  llvm_unreachable("Unkonwn tt::DataType");
+}
+
+emitc::OpaqueAttr createStdNullopt(Builder &builder) {
+  return builder.getType<emitc::OpaqueAttr>("std::nullopt");
+}
+
+emitc::ExpressionOp createShapeOp(ConversionPatternRewriter &rewriter,
+                                  ttnn::ShapeAttr shapeAttr,
+                                  Block *containingBlock, Location loc) {
+  // Create ExpressionOp to hold multiple nested op calls, but will bundle them
+  // together into a single SSA value
+  //
+  emitc::ExpressionOp shapeExpressionOp = rewriter.create<emitc::ExpressionOp>(
+      loc, emitc::OpaqueType::get(rewriter.getContext(), "ttnn::Shape"), false);
+
+  // Add a block to the ExpressionOp, save current insertion point, and set
+  // insertion point to newly added block
+  //
+  mlir::Block &bodyBlock = shapeExpressionOp.getBodyRegion().emplaceBlock();
+  Block::iterator currentPoint = rewriter.getInsertionPoint();
+  rewriter.setInsertionPointToStart(&bodyBlock);
+
+  // Create a LegacyShape object
+  //
+  emitc::CallOpaqueOp metalShapeOp = rewriter.create<emitc::CallOpaqueOp>(
+      loc,
+      emitc::OpaqueType::get(rewriter.getContext(),
+                             "tt::tt_metal::LegacyShape"),
+      rewriter.getStringAttr("tt::tt_metal::LegacyShape"),
+      rewriter.getArrayAttr(convertShape(rewriter, shapeAttr)), nullptr,
+      ValueRange());
+
+  // Create a ttnn::Shape object
+  //
+  emitc::CallOpaqueOp ttnnShapeOp = rewriter.create<emitc::CallOpaqueOp>(
+      loc, emitc::OpaqueType::get(rewriter.getContext(), "ttnn::Shape"),
+      rewriter.getStringAttr("ttnn::Shape"), nullptr, nullptr,
+      metalShapeOp->getResults());
+  rewriter.create<emitc::YieldOp>(loc, ttnnShapeOp->getResult(0));
+
+  // Reset to original insertion point
+  //
+  rewriter.setInsertionPoint(containingBlock, currentPoint);
+
+  return shapeExpressionOp;
+}
+
+emitc::CallOpaqueOp createMemoryConfigOp(ConversionPatternRewriter &rewriter,
+                                         ttnn::MemoryConfigAttr memoryConfig,
+                                         Location loc) {
+  // Create ArrayAttr object holding MemoryConfig attributes
+  //
+  // TODO(svuckovic): (#620) Currently missing ShardSpec
+  //
+  ArrayAttr memCfgArrayAttrs = rewriter.getArrayAttr(
+      {convertTensorMemoryLayout(rewriter,
+                                 memoryConfig.getTensorMemoryLayout()),
+       convertBufferType(rewriter, memoryConfig.getBufferType())});
+
+  // Create MemoryConfig object
+  //
+  emitc::CallOpaqueOp memCfgOp = rewriter.create<emitc::CallOpaqueOp>(
+      loc, emitc::OpaqueType::get(rewriter.getContext(), "ttnn::MemoryConfig"),
+      "ttnn::MemoryConfig", memCfgArrayAttrs, nullptr, ValueRange());
+
+  return memCfgOp;
+}
+
+} // namespace mlir::tt::ttnntoemitc::utils

--- a/lib/Conversion/TTNNToEmitC/Utils.cpp
+++ b/lib/Conversion/TTNNToEmitC/Utils.cpp
@@ -6,7 +6,7 @@
 
 #include "mlir/Pass/Pass.h"
 
-namespace mlir::tt::ttnntoemitc::utils {
+namespace mlir::tt::ttnn_to_emitc::utils {
 
 emitc::OpaqueAttr convertShape(Builder &builder, ttnn::ShapeAttr attr) {
   llvm::ArrayRef shape = attr.getShape();
@@ -172,4 +172,4 @@ emitc::CallOpaqueOp createMemoryConfigOp(ConversionPatternRewriter &rewriter,
   return memCfgOp;
 }
 
-} // namespace mlir::tt::ttnntoemitc::utils
+} // namespace mlir::tt::ttnn_to_emitc::utils

--- a/lib/Dialect/TTNN/Utils/Utils.cpp
+++ b/lib/Dialect/TTNN/Utils/Utils.cpp
@@ -80,17 +80,6 @@ toTTMemorySpace(const mlir::tt::ttnn::BufferType bufferType) {
   llvm_unreachable("Unknown MemorySpace");
 }
 
-Layout getLayoutFromMemRef(mlir::MemRefType memref) {
-  ttnn::Layout ttnnLayoutEnum = ttnn::Layout::RowMajor;
-  Type elementType = memref.getElementType();
-  if (llvm::isa<TileType>(elementType)) {
-    ttnnLayoutEnum = ttnn::Layout::Tile;
-  } else {
-    ttnnLayoutEnum = ttnn::Layout::RowMajor;
-  }
-  return ttnnLayoutEnum;
-}
-
 Type createRowMajorTypeFromDtype(::mlir::MLIRContext *context, DataType dtype) {
   switch (dtype) {
   case DataType::Float32:

--- a/runtime/lib/ttnn/include/tt/runtime/ttnn/utils.h
+++ b/runtime/lib/ttnn/include/tt/runtime/ttnn/utils.h
@@ -51,6 +51,13 @@ createMemoryConfig(const ::tt::target::TensorRef *tensorRef);
 
 Tensor createRuntimeTensorFromTTNN(const ::ttnn::Tensor &tensor);
 
+// TODO: (#1435): Fix int types across shapes
+//
+inline std::vector<uint32_t>
+toShapeFromFBShape(const flatbuffers::Vector<int64_t> &vec) {
+  return std::vector<uint32_t>(vec.begin(), vec.end());
+}
+
 } // namespace tt::runtime::ttnn::utils
 
 #endif

--- a/runtime/lib/ttnn/operations/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/CMakeLists.txt
@@ -7,6 +7,7 @@ set(TTNN_OPS_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/conv/conv2d.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/creation/arange.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/creation/empty.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/creation/ones.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/creation/full.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/data_movement/concat.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/data_movement/reshape.cpp

--- a/runtime/lib/ttnn/operations/creation/ones.cpp
+++ b/runtime/lib/ttnn/operations/creation/ones.cpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ones.h"
+
+#include "tt/runtime/detail/logger.h"
+#include "tt/runtime/ttnn/operations/utils.h"
+#include "tt/runtime/ttnn/utils.h"
+#include "ttmlir/Target/TTNN/program_generated.h"
+#include "ttnn/types.hpp"
+
+#include <functional>
+#include <optional>
+#include <variant>
+
+namespace tt::runtime::ttnn::operations::creation {
+void run(const ::tt::target::ttnn::OnesOp *op, ProgramContext &context) {
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+
+  const ::ttnn::Shape shape = ::ttnn::Shape(::tt::tt_metal::LegacyShape(
+      ::tt::runtime::ttnn::utils::toShapeFromFBShape(*op->shape())));
+
+  std::optional<::ttnn::DataType> dtype = std::optional<::ttnn::DataType>();
+  std::optional<::ttnn::Layout> layout = std::optional<::ttnn::Layout>();
+  std::optional<std::reference_wrapper<::ttnn::Device>> device = std::nullopt;
+  std::optional<::ttnn::MemoryConfig> memoryConfig =
+      std::optional<::ttnn::MemoryConfig>();
+
+  if (op->dtype()) {
+    dtype = ::tt::runtime::ttnn::utils::toTTNNDataType(*(op->dtype()));
+  }
+
+  if (op->layout()) {
+    layout = ::tt::runtime::ttnn::utils::toTTNNLayout(*(op->layout()));
+  }
+
+  if (op->device()) {
+    DeviceVariant targetDevice =
+        context.getTargetDevice(op->device()->global_id());
+    assert(std::holds_alternative<std::reference_wrapper<::ttnn::Device>>(
+               targetDevice) &&
+           "ttnn::ones does not support MeshDevice.");
+    device = std::get<std::reference_wrapper<::ttnn::Device>>(targetDevice);
+  }
+
+  if (op->memcfg()) {
+    memoryConfig = utils::createMemoryConfig(op->memcfg(), op->out());
+  }
+
+  ::ttnn::Tensor out = ::ttnn::ones(shape, dtype, layout, device, memoryConfig);
+
+  tensorPool.insert_or_assign(op->out()->global_id(), out);
+}
+} // namespace tt::runtime::ttnn::operations::creation

--- a/runtime/lib/ttnn/operations/creation/ones.h
+++ b/runtime/lib/ttnn/operations/creation/ones.h
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef RUNTIME_LIB_TTNN_OPERATIONS_CREATION_ONES_H
+#define RUNTIME_LIB_TTNN_OPERATIONS_CREATION_ONES_H
+
+#include "tt/runtime/ttnn/types.h"
+#include "ttmlir/Target/TTNN/program_generated.h"
+
+namespace tt::runtime::ttnn::operations::creation {
+
+void run(const ::tt::target::ttnn::OnesOp *op, ProgramContext &context);
+
+} // namespace tt::runtime::ttnn::operations::creation
+
+#endif // RUNTIME_LIB_TTNN_OPERATIONS_CREATION_ONES_H

--- a/runtime/lib/ttnn/program.cpp
+++ b/runtime/lib/ttnn/program.cpp
@@ -7,6 +7,7 @@
 #include "operations/creation/arange.h"
 #include "operations/creation/empty.h"
 #include "operations/creation/full.h"
+#include "operations/creation/ones.h"
 #include "operations/data_movement/concat.h"
 #include "operations/data_movement/reshape.h"
 #include "operations/data_movement/slice.h"
@@ -163,6 +164,9 @@ void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
   }
   case ::tt::target::ttnn::OpType::EmptyOp: {
     return operations::creation::run(op->type_as_EmptyOp(), context);
+  }
+  case ::tt::target::ttnn::OpType::OnesOp: {
+    return operations::creation::run(op->type_as_OnesOp(), context);
   }
   case ::tt::target::ttnn::OpType::FullOp: {
     return operations::creation::run(op->type_as_FullOp(), context);

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -382,6 +382,10 @@ Tensor getOpOutputTensor(OpContext opContextHandle,
     globalId = opContext.type_as_EmptyOp()->out()->global_id();
     break;
   }
+  case ::tt::target::ttnn::OpType::OnesOp: {
+    globalId = opContext.type_as_OnesOp()->out()->global_id();
+    break;
+  }
   case ::tt::target::ttnn::OpType::FullOp: {
     globalId = opContext.type_as_FullOp()->out()->global_id();
     break;

--- a/test/ttmlir/Conversion/TTNNToEmitC/ones.mlir
+++ b/test/ttmlir/Conversion/TTNNToEmitC/ones.mlir
@@ -1,0 +1,19 @@
+// RUN: ttmlir-opt --convert-ttnn-to-emitc %s | FileCheck %s
+
+#system_memory = #ttnn.buffer_type<system_memory>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1344 + d1 * 56 + d2, d3), <1x1>, memref<17472x42xbf16, #system_memory>>
+#ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 64 + d1, d2), <1x1>, memref<2048x128xf32, #system_memory>>
+
+module  {
+  func.func @ones_4d_irregular_shapes() -> tensor<13x24x56x42xbf16, #ttnn_layout> {
+    // CHECK: %{{[0-9]+}} = emitc.call_opaque "ttnn::ones"{{.*}} -> !emitc.opaque<"ttnn::Tensor">
+    %0 = "ttnn.ones"() <{dtype = #tt.supportedDataTypes<bf16>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<none>, #system_memory, <<17472x42>>>, shape = #ttnn.shape<13x24x56x42>}> : () -> tensor<13x24x56x42xbf16, #ttnn_layout>
+    return %0 : tensor<13x24x56x42xbf16, #ttnn_layout>
+  }
+
+  func.func @ones_f32() -> tensor<32x64x128xf32, #ttnn_layout1> {
+    // CHECK: %{{[0-9]+}} = emitc.call_opaque "ttnn::ones"{{.*}} -> !emitc.opaque<"ttnn::Tensor">
+    %0 = "ttnn.ones"() <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<none>, #system_memory, <<2048x128>>>, shape = #ttnn.shape<32x64x128>}> : () -> tensor<32x64x128xf32, #ttnn_layout1>
+    return %0 : tensor<32x64x128xf32, #ttnn_layout1>
+  }
+}

--- a/test/ttmlir/Conversion/TTNNToEmitC/ones.mlir
+++ b/test/ttmlir/Conversion/TTNNToEmitC/ones.mlir
@@ -7,13 +7,13 @@
 module  {
   func.func @ones_4d_irregular_shapes() -> tensor<13x24x56x42xbf16, #ttnn_layout> {
     // CHECK: %{{[0-9]+}} = emitc.call_opaque "ttnn::ones"{{.*}} -> !emitc.opaque<"ttnn::Tensor">
-    %0 = "ttnn.ones"() <{dtype = #tt.supportedDataTypes<bf16>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<none>, #system_memory, <<17472x42>>>, shape = #ttnn.shape<13x24x56x42>}> : () -> tensor<13x24x56x42xbf16, #ttnn_layout>
+    %0 = "ttnn.ones"() <{dtype = #tt.supportedDataTypes<bf16>, layout = #ttnn.layout<row_major>, shape = #ttnn.shape<13x24x56x42>}> : () -> tensor<13x24x56x42xbf16, #ttnn_layout>
     return %0 : tensor<13x24x56x42xbf16, #ttnn_layout>
   }
 
   func.func @ones_f32() -> tensor<32x64x128xf32, #ttnn_layout1> {
     // CHECK: %{{[0-9]+}} = emitc.call_opaque "ttnn::ones"{{.*}} -> !emitc.opaque<"ttnn::Tensor">
-    %0 = "ttnn.ones"() <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<<none>, #system_memory, <<2048x128>>>, shape = #ttnn.shape<32x64x128>}> : () -> tensor<32x64x128xf32, #ttnn_layout1>
+    %0 = "ttnn.ones"() <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, shape = #ttnn.shape<32x64x128>}> : () -> tensor<32x64x128xf32, #ttnn_layout1>
     return %0 : tensor<32x64x128xf32, #ttnn_layout1>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/ones.mlir
+++ b/test/ttmlir/Silicon/TTNN/ones.mlir
@@ -1,0 +1,30 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+
+#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
+module {
+  func.func @ones_2d() -> tensor<32x128xbf16> {
+    // CHECK: {{.*}} = "ttnn.ones"() {{.*}}
+    %0 = "ttir.ones"() <{shape = array<i32:32, 128>}> : () -> tensor<32x128xbf16>
+    return %0 : tensor<32x128xbf16>
+  }
+
+  func.func @ones_3d() -> tensor<32x64x128xbf16> {
+    // CHECK: {{.*}} = "ttnn.ones"() {{.*}}
+    %0 = "ttir.ones"() <{shape = array<i32:32, 64, 128>}> : () -> tensor<32x64x128xbf16>
+    return %0 : tensor<32x64x128xbf16>
+  }
+
+  func.func @ones_4d_irregular_shapes() -> tensor<13x24x56x42xbf16> {
+    // CHECK: {{.*}} = "ttnn.ones"() {{.*}} -> tensor<13x24x56x42xbf16{{.*}}>
+    %0 = "ttir.ones"() <{shape = array<i32:13, 24, 56, 42>}> : () -> tensor<13x24x56x42xbf16>
+    return %0 : tensor<13x24x56x42xbf16>
+  }
+
+  func.func @ones_f32() -> tensor<32x64x128xf32> {
+    // CHECK: {{.*}} = "ttnn.ones"() {{.*}} -> tensor<32x64x128xf32{{.*}}>
+    %0 = "ttir.ones"() <{shape = array<i32:32, 64, 128>}> : () -> tensor<32x64x128xf32>
+    return %0 : tensor<32x64x128xf32>
+  }
+}


### PR DESCRIPTION
This PR adds support for `ttnn::ones()` op.

- A ttnn-to-emitc utils file has been added
- In `MLIRToFlatbuffer.h`, two `toFlatbufferOptional` method have been added to make the `TTNNToFlatbuffer.cpp` code cleaner, as all the optional stuff is abstracted away
- More streamlined conversion of the op in `TTNNToEmitC.cpp`, would like to try to apply this to other ops, and hopefully create a generic solution that would work for most ops without any special case handling
- In a similar manner, `run()` method in `runtime/lib/ttnn/operations/creation/ones.cpp` has been written so that it "mechanically" unpacks a flatbuffer and calls the appropriate ttnn method - it would be great if we could make this generic so that we don't need to manually handle each op

N̶o̶t̶e̶:̶ ̶t̶h̶e̶r̶e̶'̶s̶ ̶a̶ ̶p̶i̶e̶c̶e̶ ̶o̶f̶ ̶c̶o̶d̶e̶ ̶`̶l̶i̶b̶/̶C̶o̶n̶v̶e̶r̶s̶i̶o̶n̶/̶T̶T̶N̶N̶T̶o̶E̶m̶i̶t̶C̶/̶U̶t̶i̶l̶s̶.̶c̶p̶p̶`̶ ̶t̶h̶a̶t̶ ̶I̶ ̶c̶h̶a̶n̶g̶e̶d̶ ̶j̶u̶s̶t̶ ̶t̶o̶ ̶m̶a̶k̶e̶ ̶t̶h̶e̶ ̶t̶e̶s̶t̶s̶ ̶r̶u̶n̶,̶ ̶I̶'̶l̶l̶ ̶m̶a̶r̶k̶ ̶i̶t̶ ̶w̶i̶t̶h̶ ̶a̶ ̶c̶o̶m̶m̶e̶n̶t̶,̶ ̶t̶h̶a̶t̶ ̶w̶i̶l̶l̶ ̶b̶e̶ ̶r̶e̶m̶o̶v̶e̶d̶ ̶b̶e̶f̶o̶r̶e̶ ̶t̶h̶i̶s̶ ̶P̶R̶ ̶i̶s̶ ̶m̶e̶r̶g̶e̶d̶ ̶w̶i̶t̶h̶ ̶m̶a̶i̶n̶ ̶-̶ ̶@̶m̶t̶o̶p̶a̶l̶o̶v̶i̶c̶T̶T̶ ̶h̶a̶s̶ ̶a̶ ̶f̶i̶x̶ ̶i̶n̶ ̶t̶h̶e̶ ̶w̶o̶r̶k̶s̶.̶