### PR TITLE
Removed dead code check for typecast

### DIFF
--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -801,10 +801,6 @@ public:
 
     DataType outputDataType = outputLayoutAttr.getDataType();
 
-    if (op->getUsers().empty()) {
-      return rewriter.notifyMatchFailure(
-          op, "ttir.typecast op should have at least one use.");
-    }
     rewriter.replaceOpWithNewOp<ttnn::TypecastOp>(
         op, this->getTypeConverter()->convertType(op.getType(0)), input,
         outputDataType);


### PR DESCRIPTION
Issue https://github.com/tenstorrent/tt-mlir/issues/1471 was raised because the typecast operation translation from `ttir` to `ttnn` dialects failed due to the typecast operation in question being dead code. This PR removes this check. 

The code snippet in the issue will still fail on silicon because of the fact that full ops is not currently produced in TILE format and therefore typecast op cannot run the operand. See issue https://github.com/tenstorrent/tt-mlir/issues/850

Fixes https://github.com/tenstorrent/tt-mlir/issues/1471