### PR TITLE
Added E2E PermuteOp support

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -1309,9 +1309,17 @@ def TTIR_MatmulOp : TTIR_DPSOp<"matmul"> {
 // ANCHOR_END: adding_an_op_matmul_ttir
 
 def TTIR_PermuteOp : TTIR_DPSOp<"permute"> {
-    let summary = "Permute op.";
+    let summary = "Permute operation.";
     let description = [{
-      Permute tensor.
+      Permute input tensor dimensions.
+
+      Attributes:
+        - `permutation` array<i64>: The permutation of the input tensor dimensions.
+
+      Example:
+      %a = tensor.empty() : () -> tensor<2x3x4xi32>
+      %output = tensor.empty() : () -> tensor<3x4x2xi32>
+      %0 = "ttir.permute"(%a, %output) {permutation = array<i64: 1, 2, 0>} : (tensor<2x3x4xi32>, tensor<3x4x2xi32>) -> tensor<3x4x2xi32>
     }];
 
     let arguments = (ins AnyRankedTensor:$input,

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -1316,7 +1316,7 @@ def TTIR_PermuteOp : TTIR_DPSOp<"permute"> {
 
     let arguments = (ins AnyRankedTensor:$input,
                          AnyRankedTensor:$output,
-                         DenseI32ArrayAttr:$permutation);
+                         DenseI64ArrayAttr:$permutation);
 
     let results = (outs AnyRankedTensor:$result);
 

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -1308,6 +1308,25 @@ def TTIR_MatmulOp : TTIR_DPSOp<"matmul"> {
 }
 // ANCHOR_END: adding_an_op_matmul_ttir
 
+def TTIR_PermuteOp : TTIR_DPSOp<"permute"> {
+    let summary = "Permute op.";
+    let description = [{
+      Permute tensor.
+    }];
+
+    let arguments = (ins AnyRankedTensor:$input,
+                         AnyRankedTensor:$output,
+                         DenseI32ArrayAttr:$permutation);
+
+    let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      MutableOperandRange getDpsInitsMutable() { return getOutputMutable(); }
+    }];
+
+    let hasVerifier = 1;
+}
+
 //===----------------------------------------------------------------------===//
 // TTIR top level generic ops
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1062,4 +1062,18 @@ def TTNN_MeshShardOp: TTNN_Op<"mesh_shard"> {
     let hasVerifier = 1;
 }
 
+def TTNN_PermuteOp : TTNN_Op<"permute"> {
+    let summary = "Permute op.";
+    let description = [{
+      Permute tensor.
+    }];
+
+    let arguments = (ins AnyRankedTensor:$input,
+                         DenseI32ArrayAttr:$permutation);
+
+    let results = (outs AnyRankedTensor:$result);
+
+    let hasVerifier = 1;
+}
+
 #endif

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1069,7 +1069,7 @@ def TTNN_PermuteOp : TTNN_Op<"permute"> {
     }];
 
     let arguments = (ins AnyRankedTensor:$input,
-                         DenseI32ArrayAttr:$permutation);
+                         DenseI64ArrayAttr:$permutation);
 
     let results = (outs AnyRankedTensor:$result);
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1076,7 +1076,9 @@ def TTNN_PermuteOp : TTNN_Op<"permute"> {
     }];
 
     let arguments = (ins AnyRankedTensor:$input,
-                         DenseI64ArrayAttr:$permutation);
+                         DenseI64ArrayAttr:$permutation,
+                         OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config,
+                         DefaultValuedOptionalAttr<F32Attr, "0.0f">:$pad_value);
 
     let results = (outs AnyRankedTensor:$result);
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1063,9 +1063,16 @@ def TTNN_MeshShardOp: TTNN_Op<"mesh_shard"> {
 }
 
 def TTNN_PermuteOp : TTNN_Op<"permute"> {
-    let summary = "Permute op.";
+    let summary = "Permute operation.";
     let description = [{
-      Permute tensor.
+      Permute input tensor dimensions.
+
+      Attributes:
+        - `permutation` array<i64>: The permutation of the input tensor dimensions.
+
+      Example:
+      %a = tensor.empty() : () -> tensor<2x3x4xi32>
+      %0 = "ttir.permute"(%a) {permutation = array<i64: 1, 2, 0>} : (tensor<2x3x4xi32>) -> tensor<3x4x2xi32>
     }];
 
     let arguments = (ins AnyRankedTensor:$input,

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -315,7 +315,7 @@ table MeshShardOp {
 
 table PermuteOp {
   in: tt.target.TensorRef;
-  permutation: [int32];
+  permutation: [int64];
   out: tt.target.TensorRef;
 }
 

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -295,6 +295,14 @@ table AllGatherOp {
   num_links: uint32;
 }
 
+table PermuteOp {
+  in: tt.target.TensorRef;
+  permutation: [int64];
+  memory_config: MemoryConfigDesc;
+  pad_value: float;
+  out: tt.target.TensorRef;
+}
+
 table ReduceScatterOp {
   in: tt.target.TensorRef;
   out: tt.target.TensorRef;
@@ -311,12 +319,6 @@ table MeshShardOp {
   shard_direction: uint32;
   shard_type: uint32;
   shard_shape: [int64];
-}
-
-table PermuteOp {
-  in: tt.target.TensorRef;
-  permutation: [int64];
-  out: tt.target.TensorRef;
 }
 
 union OpType {

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -313,6 +313,12 @@ table MeshShardOp {
   shard_shape: [int64];
 }
 
+table PermuteOp {
+  in: tt.target.TensorRef;
+  permutation: [int32];
+  out: tt.target.TensorRef;
+}
+
 union OpType {
   GetDeviceOp,
   ToMemoryConfigOp,
@@ -343,6 +349,7 @@ union OpType {
   ArangeOp,
   UpdateCacheOp,
   FillCacheOp,
+  PermuteOp,
 }
 
 table Operation {

--- a/include/ttmlir/Utils.h
+++ b/include/ttmlir/Utils.h
@@ -72,6 +72,9 @@ constexpr std::underlying_type_t<Enum> enum_as_int(Enum e) {
   return static_cast<std::underlying_type_t<Enum>>(e);
 }
 
+// Returns a string that is the concatenation of the string representations of
+// Range R elements interleaved with separator. Example: join({1, 2, 3}, ", ")
+// -> "1, 2, 3"
 template <typename Range>
 std::string join(Range &&R, llvm::StringRef separator) {
   return llvm::join(

--- a/include/ttmlir/Utils.h
+++ b/include/ttmlir/Utils.h
@@ -6,13 +6,13 @@
 #define TTMLIR_UTILS_H
 
 #include <cstdint>
-#include <sstream>
 
 #include "mlir-c/IR.h"
 #include "mlir/CAPI/IR.h"
 #include "mlir/IR/AffineMap.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringExtras.h"
 
 namespace ttmlir::utils {
 template <typename T>
@@ -72,17 +72,11 @@ constexpr std::underlying_type_t<Enum> enum_as_int(Enum e) {
   return static_cast<std::underlying_type_t<Enum>>(e);
 }
 
-template <typename T>
-std::string join(const llvm::SmallVector<T> &vec,
-                 const std::string &delimiter) {
-  std::ostringstream result;
-  for (size_t i = 0; i < vec.size(); ++i) {
-    result << vec[i];
-    if (i != vec.size() - 1) {
-      result << delimiter;
-    }
-  }
-  return result.str();
+template <typename Range>
+std::string join(Range &&R, llvm::StringRef separator) {
+  return llvm::join(
+      llvm::map_range(R, [](auto &v) { return llvm::Twine(v).str(); }),
+      separator);
 }
 
 // Prepacks `MlirAttribute`s stored in input array into a vector of

--- a/include/ttmlir/Utils.h
+++ b/include/ttmlir/Utils.h
@@ -125,6 +125,17 @@ inline bool isRankedTensor(mlir::Value v) {
   return mlir::isa<mlir::RankedTensorType>(v.getType());
 }
 
+template <typename T>
+llvm::SmallVector<T> applyPermutation(llvm::ArrayRef<T> input,
+                                      llvm::ArrayRef<int64_t> permutation) {
+  llvm::SmallVector<T> output(input.size());
+
+  llvm::transform(permutation, output.begin(),
+                  [&](const int64_t i) { return input[i]; });
+
+  return output;
+}
+
 } // namespace ttmlir::utils
 
 #endif

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -138,45 +138,15 @@ public:
   matchAndRewrite(mlir::stablehlo::TransposeOp srcOp,
                   mlir::stablehlo::TransposeOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-
-    auto input = Value(adaptor.getOperand());
-    auto transposes = getPermutationTransposes(adaptor.getPermutation().vec());
-
-    for (auto transposeDims : transposes) {
-      auto dim0 = std::get<0>(transposeDims);
-      auto dim1 = std::get<1>(transposeDims);
-
-      auto inputType = mlir::cast<RankedTensorType>(input.getType());
-      auto outputShape = inputType.getShape().vec();
-      std::swap(outputShape[dim0], outputShape[dim1]);
-
-      auto outputType = RankedTensorType::get(
-          outputShape, inputType.getElementType(), inputType.getEncoding());
-
-      auto outputTensor = rewriter.create<tensor::EmptyOp>(
-          srcOp.getLoc(), outputShape, outputType.getElementType());
-
-      input = rewriter.create<mlir::tt::ttir::TransposeOp>(
-          srcOp.getLoc(), outputType, input, outputTensor,
-          rewriter.getSI32IntegerAttr(dim0), rewriter.getSI32IntegerAttr(dim1));
-    }
-    rewriter.replaceOp(srcOp, input);
+    ::mlir::RankedTensorType outputType = mlir::cast<mlir::RankedTensorType>(
+        this->getTypeConverter()->convertType(srcOp.getResult().getType()));
+    tensor::EmptyOp outputTensor = rewriter.create<tensor::EmptyOp>(
+        srcOp.getLoc(), outputType.getShape(), outputType.getElementType());
+    // stablehlo.transpose and ttir.permute have the same semantics.
+    rewriter.replaceOpWithNewOp<mlir::tt::ttir::PermuteOp>(
+        srcOp, getTypeConverter()->convertType(srcOp.getResult().getType()),
+        adaptor.getOperand(), outputTensor, adaptor.getPermutation());
     return success();
-  }
-
-private:
-  std::vector<std::tuple<int64_t, int64_t>>
-  getPermutationTransposes(std::vector<int64_t> permutation) const {
-    std::vector<std::tuple<int64_t, int64_t>> transposes;
-    for (uint32_t i = 0; i < permutation.size(); i++) {
-      while (i != permutation[i]) {
-        transposes.push_back(
-            std::make_tuple(permutation[i], permutation[permutation[i]]));
-        std::swap(permutation[i], permutation[permutation[i]]);
-      }
-    }
-
-    return transposes;
   }
 };
 
@@ -202,19 +172,6 @@ public:
     rewriter.replaceOpWithNewOp<mlir::tt::ttir::ReshapeOp>(
         srcOp, getTypeConverter()->convertType(outputTensor.getType()),
         adaptor.getOperand(), outputTensor, new_shape_attr);
-    return success();
-  }
-
-  LogicalResult
-  checkBasicLegality(mlir::stablehlo::TransposeOp &srcOp,
-                     mlir::stablehlo::TransposeOp::Adaptor &adaptor,
-                     ConversionPatternRewriter &rewriter) const {
-
-    if (adaptor.getPermutation().size() != 2) {
-      return rewriter.notifyMatchFailure(
-          srcOp, "TTIR supports only two dimensional transposeOp.");
-    }
-
     return success();
   }
 };
@@ -1831,13 +1788,6 @@ void addReduceOpsConversionPatterns(MLIRContext *ctx,
   patterns.add<StableHLOToTTIRReduceOpConversionPattern>(typeConverter, ctx);
 }
 
-void addTransposeOpsConversionPatterns(MLIRContext *ctx,
-                                       RewritePatternSet &patterns,
-                                       TypeConverter &typeConverter) {
-
-  patterns.add<StableHLOToTTIRTransposeOpConversionPattern>(typeConverter, ctx);
-}
-
 void addMatmulOpsConversionPatterns(MLIRContext *ctx,
                                     RewritePatternSet &patterns,
                                     TypeConverter &typeConverter) {
@@ -1889,6 +1839,12 @@ void addConcatOpsConversionPatterns(MLIRContext *ctx,
                                     RewritePatternSet &patterns,
                                     TypeConverter &typeConverter) {
   patterns.add<StableHLOToTTIRConcatOpConversionPattern>(typeConverter, ctx);
+}
+
+void addTransposeOpConversionPattern(MLIRContext *ctx,
+                                     RewritePatternSet &patterns,
+                                     TypeConverter &typeConverter) {
+  patterns.add<StableHLOToTTIRTransposeOpConversionPattern>(typeConverter, ctx);
 }
 
 void addReshapeOpConversionPattern(MLIRContext *ctx,
@@ -1973,7 +1929,6 @@ void populateStableHLOToTTIRPatterns(MLIRContext *ctx,
   addElementwiseUnaryOpsConversionPatterns(ctx, patterns, typeConverter);
   addElementwiseBinaryOpsConversionPatterns(ctx, patterns, typeConverter);
   addReduceOpsConversionPatterns(ctx, patterns, typeConverter);
-  addTransposeOpsConversionPatterns(ctx, patterns, typeConverter);
   addMatmulOpsConversionPatterns(ctx, patterns, typeConverter);
   addGetDimensionSizeOpsConversionPatterns(ctx, patterns, typeConverter);
   addTensorCreationOpsConversionPatterns(ctx, patterns, typeConverter);
@@ -1982,6 +1937,7 @@ void populateStableHLOToTTIRPatterns(MLIRContext *ctx,
   addReduceWindowOpConversionPattern(ctx, patterns, typeConverter);
   addCompareOpsConversionPatterns(ctx, patterns, typeConverter);
   addConcatOpsConversionPatterns(ctx, patterns, typeConverter);
+  addTransposeOpConversionPattern(ctx, patterns, typeConverter);
   addReshapeOpConversionPattern(ctx, patterns, typeConverter);
   addCCLOpsConversionPattern(ctx, patterns, typeConverter);
   addLogicalAndBitwiseOpsConversionPatterns(ctx, patterns, typeConverter);

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -1120,6 +1120,22 @@ public:
     return success();
   }
 };
+
+class PermuteOpConversionPattern : public OpConversionPattern<ttir::PermuteOp> {
+public:
+  using OpConversionPattern<ttir::PermuteOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttir::PermuteOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<ttnn::PermuteOp>(
+        op, this->getTypeConverter()->convertType(op.getType()),
+        adaptor.getInput(), adaptor.getPermutation());
+
+    return success();
+  }
+};
+
 } // namespace
 
 namespace mlir::tt {
@@ -1201,7 +1217,8 @@ void populateTTIRToTTNNPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
            ArangeOpConversionPattern,
            UpdateCacheOpConversionPattern,
            FillCacheOpConversionPattern,
-           ScatterOpConversionPattern
+           ScatterOpConversionPattern,
+           PermuteOpConversionPattern
            >(typeConverter, ctx);
   // ANCHOR_END: op_rewriter_pattern_set
   // clang-format on

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -26,6 +26,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/ErrorHandling.h"
+
 #include <cstdint>
 
 using namespace mlir;
@@ -1130,7 +1131,8 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     rewriter.replaceOpWithNewOp<ttnn::PermuteOp>(
         op, this->getTypeConverter()->convertType(op.getType()),
-        adaptor.getInput(), adaptor.getPermutation());
+        adaptor.getInput(), adaptor.getPermutationAttr(),
+        ttnn::MemoryConfigAttr(), mlir::FloatAttr());
 
     return success();
   }
@@ -1217,7 +1219,6 @@ void populateTTIRToTTNNPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
            ArangeOpConversionPattern,
            UpdateCacheOpConversionPattern,
            FillCacheOpConversionPattern,
-           ScatterOpConversionPattern,
            ScatterOpConversionPattern,
            PermuteOpConversionPattern
            >(typeConverter, ctx);

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -1218,6 +1218,7 @@ void populateTTIRToTTNNPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
            UpdateCacheOpConversionPattern,
            FillCacheOpConversionPattern,
            ScatterOpConversionPattern,
+           ScatterOpConversionPattern,
            PermuteOpConversionPattern
            >(typeConverter, ctx);
   // ANCHOR_END: op_rewriter_pattern_set

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -755,7 +755,8 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
   patterns.add<DefaultOpConversionPattern<ttnn::TransposeOp>,
                DefaultOpConversionPattern<ttnn::ConcatOp>,
                DefaultOpConversionPattern<ttnn::ReshapeOp>,
-               DefaultOpConversionPattern<ttnn::SliceOp>>(typeConverter, ctx);
+               DefaultOpConversionPattern<ttnn::SliceOp>,
+               DefaultOpConversionPattern<ttnn::PermuteOp>>(typeConverter, ctx);
 
   // Matmul ops
   //

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -1592,8 +1592,8 @@ bool matchSimpleBlock(mlir::Region &region) {
 
   // Check that given attribute `permutation` is a valid permutation of the
   // dimensions.
-  llvm::ArrayRef<int32_t> permutation = getPermutation();
-  llvm::SmallVector<int32_t> dimensions(inputRank);
+  llvm::ArrayRef<int64_t> permutation = getPermutation();
+  llvm::SmallVector<int64_t> dimensions(inputRank);
   std::iota(dimensions.begin(), dimensions.end(), 0);
   if (inputRank != permutation.size() ||
       !std::is_permutation(permutation.begin(), permutation.end(),
@@ -1607,7 +1607,7 @@ bool matchSimpleBlock(mlir::Region &region) {
   // permutation is applied.
   llvm::SmallVector<int64_t> expectedResultShape(inputShape.size());
   llvm::transform(permutation, expectedResultShape.begin(),
-                  [&](const int32_t i) { return inputShape[i]; });
+                  [&](const int64_t i) { return inputShape[i]; });
   if (!llvm::equal(expectedResultShape, resultShape)) {
     return emitOpError("Expected result shape (" +
                        ttmlir::utils::join(expectedResultShape, ", ") +

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -1588,7 +1588,7 @@ bool matchSimpleBlock(mlir::Region &region) {
 ::mlir::LogicalResult mlir::tt::ttir::PermuteOp::verify() {
   llvm::ArrayRef<int64_t> inputShape = getInput().getType().getShape();
   const size_t inputRank = inputShape.size();
-  llvm::ArrayRef<int64_t> outputShape = getOutput().getType().getShape();
+  llvm::ArrayRef<int64_t> resultShape = getResult().getType().getShape();
 
   // Check that given attribute `permutation` is a valid permutation of the
   // dimensions.
@@ -1601,13 +1601,13 @@ bool matchSimpleBlock(mlir::Region &region) {
     return emitOpError("Invalid permutation");
   }
 
-  // Check that the output shape matches the shape of input tensor after
+  // Check that the result shape matches the shape of input tensor after
   // permutation is applied.
-  llvm::SmallVector<int64_t> expectedOutputShape(inputShape.size());
-  llvm::transform(permutation, expectedOutputShape.begin(),
+  llvm::SmallVector<int64_t> expectedResultShape(inputShape.size());
+  llvm::transform(permutation, expectedResultShape.begin(),
                   [&](const int32_t i) { return inputShape[i]; });
-  if (!llvm::equal(expectedOutputShape, outputShape)) {
-    return emitOpError("Output shape does not match the expected output shape");
+  if (!llvm::equal(expectedResultShape, resultShape)) {
+    return emitOpError("Result shape does not match the expected result shape");
   }
 
   return success();

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -1598,7 +1598,9 @@ bool matchSimpleBlock(mlir::Region &region) {
   if (inputRank != permutation.size() ||
       !std::is_permutation(permutation.begin(), permutation.end(),
                            dimensions.begin())) {
-    return emitOpError("Invalid permutation");
+    return emitOpError("Expected a permutation of {k | 0 <= k < " +
+                       std::to_string(inputRank) + "} got (" +
+                       ttmlir::utils::join(permutation, ", ") + ")");
   }
 
   // Check that the result shape matches the shape of input tensor after
@@ -1607,7 +1609,10 @@ bool matchSimpleBlock(mlir::Region &region) {
   llvm::transform(permutation, expectedResultShape.begin(),
                   [&](const int32_t i) { return inputShape[i]; });
   if (!llvm::equal(expectedResultShape, resultShape)) {
-    return emitOpError("Result shape does not match the expected result shape");
+    return emitOpError("Expected result shape (" +
+                       ttmlir::utils::join(expectedResultShape, ", ") +
+                       "), got (" + ttmlir::utils::join(resultShape, ", ") +
+                       ")");
   }
 
   return success();

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -1593,13 +1593,14 @@ bool matchSimpleBlock(mlir::Region &region) {
   // Check that given attribute `permutation` is a valid permutation of the
   // dimensions.
   llvm::ArrayRef<int64_t> permutation = getPermutation();
-  auto dimensions = llvm::seq<int64_t>(inputRank);
+  llvm::SmallVector<int64_t> dimensions(inputRank);
+  std::iota(dimensions.begin(), dimensions.end(), 0);
   if (inputRank != permutation.size() ||
       !std::is_permutation(permutation.begin(), permutation.end(),
                            dimensions.begin())) {
-    return emitOpError("Expected a permutation of {k | 0 <= k < " +
-                       std::to_string(inputRank) + "} got (" +
-                       ttmlir::utils::join(permutation, ", ") + ")");
+    return emitOpError("Expected a permutation of (")
+           << ttmlir::utils::join(dimensions, ", ")
+           << "), got (" + ttmlir::utils::join(permutation, ", ") << ")";
   }
 
   // Check that the result shape matches the shape of input tensor after
@@ -1607,10 +1608,9 @@ bool matchSimpleBlock(mlir::Region &region) {
   llvm::SmallVector<int64_t> expectedResultShape =
       ttmlir::utils::applyPermutation(inputShape, permutation);
   if (!llvm::equal(expectedResultShape, resultShape)) {
-    return emitOpError("Expected result shape (" +
-                       ttmlir::utils::join(expectedResultShape, ", ") +
-                       "), got (" + ttmlir::utils::join(resultShape, ", ") +
-                       ")");
+    return emitOpError("Expected result shape (")
+           << ttmlir::utils::join(expectedResultShape, ", ") << "), got ("
+           << ttmlir::utils::join(resultShape, ", ") << ")";
   }
 
   return success();

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -22,6 +22,7 @@
 #include "llvm/Support/LogicalResult.h"
 
 #include <cstdint>
+#include <numeric>
 #include <string>
 
 #define GET_OP_CLASSES
@@ -1574,6 +1575,39 @@ bool matchSimpleBlock(mlir::Region &region) {
       return emitOpError("all dimensions should be in interval [0, ")
              << operandTy.getRank() << "). Got dimension: " << dim;
     }
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// PermuteOp
+//===----------------------------------------------------------------------===//
+
+// PermuteOp verification
+::mlir::LogicalResult mlir::tt::ttir::PermuteOp::verify() {
+  llvm::ArrayRef<int64_t> inputShape = getInput().getType().getShape();
+  const size_t inputRank = inputShape.size();
+  llvm::ArrayRef<int64_t> outputShape = getOutput().getType().getShape();
+
+  // Check that given attribute `permutation` is a valid permutation of the
+  // dimensions.
+  llvm::ArrayRef<int32_t> permutation = getPermutation();
+  llvm::SmallVector<int32_t> dimensions(inputRank);
+  std::iota(dimensions.begin(), dimensions.end(), 0);
+  if (inputRank != permutation.size() ||
+      !std::is_permutation(permutation.begin(), permutation.end(),
+                           dimensions.begin())) {
+    return emitOpError("Invalid permutation");
+  }
+
+  // Check that the output shape matches the shape of input tensor after
+  // permutation is applied.
+  llvm::SmallVector<int64_t> expectedOutputShape(inputShape.size());
+  llvm::transform(permutation, expectedOutputShape.begin(),
+                  [&](const int32_t i) { return inputShape[i]; });
+  if (!llvm::equal(expectedOutputShape, outputShape)) {
+    return emitOpError("Output shape does not match the expected output shape");
   }
 
   return success();

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -1593,8 +1593,7 @@ bool matchSimpleBlock(mlir::Region &region) {
   // Check that given attribute `permutation` is a valid permutation of the
   // dimensions.
   llvm::ArrayRef<int64_t> permutation = getPermutation();
-  llvm::SmallVector<int64_t> dimensions(inputRank);
-  std::iota(dimensions.begin(), dimensions.end(), 0);
+  auto dimensions = llvm::seq<int64_t>(inputRank);
   if (inputRank != permutation.size() ||
       !std::is_permutation(permutation.begin(), permutation.end(),
                            dimensions.begin())) {
@@ -1605,9 +1604,8 @@ bool matchSimpleBlock(mlir::Region &region) {
 
   // Check that the result shape matches the shape of input tensor after
   // permutation is applied.
-  llvm::SmallVector<int64_t> expectedResultShape(inputShape.size());
-  llvm::transform(permutation, expectedResultShape.begin(),
-                  [&](const int64_t i) { return inputShape[i]; });
+  llvm::SmallVector<int64_t> expectedResultShape =
+      ttmlir::utils::applyPermutation(inputShape, permutation);
   if (!llvm::equal(expectedResultShape, resultShape)) {
     return emitOpError("Expected result shape (" +
                        ttmlir::utils::join(expectedResultShape, ", ") +

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -1291,7 +1291,9 @@ mlir::tt::ttnn::ToLayoutOp::canonicalize(ToLayoutOp toLayoutOp,
   if (inputRank != permutation.size() ||
       !std::is_permutation(permutation.begin(), permutation.end(),
                            dimensions.begin())) {
-    return emitOpError("Invalid permutation");
+    return emitOpError("Expected a permutation of {k | 0 <= k < " +
+                       std::to_string(inputRank) + "} got (" +
+                       ttmlir::utils::join(permutation, ", ") + ")");
   }
 
   // Check that the result shape matches the shape of input tensor after
@@ -1300,7 +1302,10 @@ mlir::tt::ttnn::ToLayoutOp::canonicalize(ToLayoutOp toLayoutOp,
   llvm::transform(permutation, expectedResultShape.begin(),
                   [&](const int32_t i) { return inputShape[i]; });
   if (!llvm::equal(expectedResultShape, resultShape)) {
-    return emitOpError("Result shape does not match the expected result shape");
+    return emitOpError("Expected result shape (" +
+                       ttmlir::utils::join(expectedResultShape, ", ") +
+                       "), got (" + ttmlir::utils::join(resultShape, ", ") +
+                       ")");
   }
 
   return success();

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -1291,16 +1291,15 @@ mlir::tt::ttnn::ToLayoutOp::canonicalize(ToLayoutOp toLayoutOp,
   if (inputRank != permutation.size() ||
       !std::is_permutation(permutation.begin(), permutation.end(),
                            dimensions.begin())) {
-    return emitOpError("Expected a permutation of {k | 0 <= k < " +
-                       std::to_string(inputRank) + "} got (" +
-                       ttmlir::utils::join(permutation, ", ") + ")");
+    return emitOpError("Expected a permutation of (")
+           << ttmlir::utils::join(dimensions, ", ")
+           << "), got (" + ttmlir::utils::join(permutation, ", ") << ")";
   }
 
   // Check that the result shape matches the shape of input tensor after
   // permutation is applied.
-  llvm::SmallVector<int64_t> expectedResultShape(inputShape.size());
-  llvm::transform(permutation, expectedResultShape.begin(),
-                  [&](const int64_t i) { return inputShape[i]; });
+  llvm::SmallVector<int64_t> expectedResultShape =
+      ttmlir::utils::applyPermutation(inputShape, permutation);
   if (!llvm::equal(expectedResultShape, resultShape)) {
     return emitOpError("Expected result shape (" +
                        ttmlir::utils::join(expectedResultShape, ", ") +

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -1285,8 +1285,8 @@ mlir::tt::ttnn::ToLayoutOp::canonicalize(ToLayoutOp toLayoutOp,
 
   // Check that given attribute `permutation` is a valid permutation of the
   // dimensions.
-  llvm::ArrayRef<int32_t> permutation = getPermutation();
-  llvm::SmallVector<int32_t> dimensions(inputRank);
+  llvm::ArrayRef<int64_t> permutation = getPermutation();
+  llvm::SmallVector<int64_t> dimensions(inputRank);
   std::iota(dimensions.begin(), dimensions.end(), 0);
   if (inputRank != permutation.size() ||
       !std::is_permutation(permutation.begin(), permutation.end(),
@@ -1300,7 +1300,7 @@ mlir::tt::ttnn::ToLayoutOp::canonicalize(ToLayoutOp toLayoutOp,
   // permutation is applied.
   llvm::SmallVector<int64_t> expectedResultShape(inputShape.size());
   llvm::transform(permutation, expectedResultShape.begin(),
-                  [&](const int32_t i) { return inputShape[i]; });
+                  [&](const int64_t i) { return inputShape[i]; });
   if (!llvm::equal(expectedResultShape, resultShape)) {
     return emitOpError("Expected result shape (" +
                        ttmlir::utils::join(expectedResultShape, ", ") +

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -34,8 +34,6 @@
 #include "llvm/Support/raw_ostream.h"
 
 #include <cassert>
-#include <fstream>
-#include <mlir/Support/LLVM.h>
 #include <optional>
 
 namespace mlir::tt {

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -518,7 +518,8 @@ createOp(FlatbufferObjectCache &cache, MeshShardOp op) {
 
 ::flatbuffers::Offset<::tt::target::ttnn::PermuteOp>
 createOp(FlatbufferObjectCache &cache, PermuteOp op) {
-  auto input = cache.at<::tt::target::TensorRef>(op.getInput());
+  auto input =
+      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
   auto permutation = toFlatbuffer(cache, op.getPermutation());
   auto output = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
                                   kHostAllocatedAddress, kHostAllocatedSize);
@@ -1176,7 +1177,8 @@ emitTTNNOperation(FlatbufferObjectCache &cache, Operation *op,
                            locInfo);
   }
   if (auto fillCacheOp = dyn_cast<FillCacheOp>(op); fillCacheOp) {
-    return createOperation(cache, createOp(cache, fillCacheOp), debugString, locInfo);
+    return createOperation(cache, createOp(cache, fillCacheOp), debugString,
+                           locInfo);
   }
   if (auto permuteOp = dyn_cast<PermuteOp>(op); permuteOp) {
     return createOperation(cache, createOp(cache, permuteOp), debugString,

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -35,6 +35,7 @@
 
 #include <cassert>
 #include <fstream>
+#include <mlir/Support/LLVM.h>
 #include <optional>
 
 namespace mlir::tt {
@@ -515,6 +516,16 @@ createOp(FlatbufferObjectCache &cache, MeshShardOp op) {
       static_cast<uint32_t>(op.getShardDirection()),
       static_cast<uint32_t>(op.getShardType()),
       cache.fbb->CreateVector<int64_t>(shardShape));
+}
+
+::flatbuffers::Offset<::tt::target::ttnn::PermuteOp>
+createOp(FlatbufferObjectCache &cache, PermuteOp op) {
+  auto input = cache.at<::tt::target::TensorRef>(op.getInput());
+  auto permutation = toFlatbuffer(cache, op.getPermutation());
+  auto output = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
+                                  kHostAllocatedAddress, kHostAllocatedSize);
+  return ::tt::target::ttnn::CreatePermuteOp(*cache.fbb, input, permutation,
+                                             output);
 }
 
 template <typename EltwiseOp, typename EltwiseOpParams>
@@ -1167,7 +1178,10 @@ emitTTNNOperation(FlatbufferObjectCache &cache, Operation *op,
                            locInfo);
   }
   if (auto fillCacheOp = dyn_cast<FillCacheOp>(op); fillCacheOp) {
-    return createOperation(cache, createOp(cache, fillCacheOp), debugString,
+    return createOperation(cache, createOp(cache, fillCacheOp), debugString, locInfo);
+  }
+  if (auto permuteOp = dyn_cast<PermuteOp>(op); permuteOp) {
+    return createOperation(cache, createOp(cache, permuteOp), debugString,
                            locInfo);
   }
 

--- a/runtime/lib/ttnn/operations/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/CMakeLists.txt
@@ -10,6 +10,7 @@ set(TTNN_OPS_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/creation/ones.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/creation/full.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/data_movement/concat.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/data_movement/permute.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/data_movement/reshape.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/data_movement/slice.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/data_movement/transpose.cpp

--- a/runtime/lib/ttnn/operations/data_movement/permute.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/permute.cpp
@@ -6,7 +6,6 @@
 
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/ttnn/operations/utils.h"
-#include "ttnn/common/constants.hpp"
 
 #include <vector>
 
@@ -25,13 +24,7 @@ void run(const ::tt::target::ttnn::PermuteOp *op, ProgramContext &context) {
                           : std::nullopt;
   float padValue = op->pad_value();
 
-  // Has to called with the verbose invoke, since calling it with composite=true
-  // results in an error with the message "Only 4D tensor are supported for
-  // permute."
-  ::ttnn::Tensor out =
-      ::ttnn::permute(/*queue_id=*/::ttnn::DefaultQueueId, /*input_tensor=*/in,
-                      /*dims=*/permutation, /*memory_config=*/memoryConfig,
-                      /*composite=*/false, /*pad_value=*/padValue);
+  ::ttnn::Tensor out = ::ttnn::permute(in, permutation, memoryConfig, padValue);
   tensorPool.insert_or_assign(op->out()->global_id(), out);
 }
 } // namespace tt::runtime::ttnn::operations::data_movement

--- a/runtime/lib/ttnn/operations/data_movement/permute.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/permute.cpp
@@ -5,9 +5,7 @@
 #include "permute.h"
 
 #include "tt/runtime/detail/logger.h"
-#include "tt/runtime/detail/ttnn.h"
-#include "tt/runtime/ttnn/operations/utils.h"
-#include "tt/runtime/ttnn/utils.h"
+#include "ttnn/common/constants.hpp"
 
 #include <vector>
 
@@ -21,7 +19,13 @@ void run(const ::tt::target::ttnn::PermuteOp *op, ProgramContext &context) {
   std::vector<int64_t> permutation(op->permutation()->begin(),
                                    op->permutation()->end());
 
-  ::ttnn::Tensor out = ::ttnn::permute(in, permutation);
+  // Has to called with the verbose invoke, since calling it with composite=true
+  // results in an error with the message "Only 4D tensor are supported for
+  // permute."
+  ::ttnn::Tensor out =
+      ::ttnn::permute(/*queue_id=*/::ttnn::DefaultQueueId, /*input_tensor=*/in,
+                      /*dims=*/permutation, /*memory_config=*/std::nullopt,
+                      /*composite=*/false, /*pad_value=*/std::nullopt);
   tensorPool.insert_or_assign(op->out()->global_id(), out);
 }
 } // namespace tt::runtime::ttnn::operations::data_movement

--- a/runtime/lib/ttnn/operations/data_movement/permute.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/permute.cpp
@@ -5,6 +5,7 @@
 #include "permute.h"
 
 #include "tt/runtime/detail/logger.h"
+#include "tt/runtime/ttnn/operations/utils.h"
 #include "ttnn/common/constants.hpp"
 
 #include <vector>
@@ -18,14 +19,19 @@ void run(const ::tt::target::ttnn::PermuteOp *op, ProgramContext &context) {
 
   std::vector<int64_t> permutation(op->permutation()->begin(),
                                    op->permutation()->end());
+  std::optional<tt::tt_metal::MemoryConfig> memoryConfig =
+      op->memory_config() ? std::make_optional(utils::createMemoryConfig(
+                                op->memory_config(), op->out()))
+                          : std::nullopt;
+  float padValue = op->pad_value();
 
   // Has to called with the verbose invoke, since calling it with composite=true
   // results in an error with the message "Only 4D tensor are supported for
   // permute."
   ::ttnn::Tensor out =
       ::ttnn::permute(/*queue_id=*/::ttnn::DefaultQueueId, /*input_tensor=*/in,
-                      /*dims=*/permutation, /*memory_config=*/std::nullopt,
-                      /*composite=*/false, /*pad_value=*/std::nullopt);
+                      /*dims=*/permutation, /*memory_config=*/memoryConfig,
+                      /*composite=*/false, /*pad_value=*/padValue);
   tensorPool.insert_or_assign(op->out()->global_id(), out);
 }
 } // namespace tt::runtime::ttnn::operations::data_movement

--- a/runtime/lib/ttnn/operations/data_movement/permute.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/permute.cpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "permute.h"
+
+#include "tt/runtime/detail/logger.h"
+#include "tt/runtime/detail/ttnn.h"
+#include "tt/runtime/ttnn/operations/utils.h"
+#include "tt/runtime/ttnn/utils.h"
+
+#include <vector>
+
+namespace tt::runtime::ttnn::operations::data_movement {
+void run(const ::tt::target::ttnn::PermuteOp *op, ProgramContext &context) {
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+
+  const ::ttnn::Tensor &in = tensorPool.at(op->in()->global_id());
+  DEBUG_ASSERT(in.is_allocated());
+
+  std::vector<int64_t> permutation(op->permutation()->begin(),
+                                   op->permutation()->end());
+
+  ::ttnn::Tensor out = ::ttnn::permute(in, permutation);
+  tensorPool.insert_or_assign(op->out()->global_id(), out);
+}
+} // namespace tt::runtime::ttnn::operations::data_movement

--- a/runtime/lib/ttnn/operations/data_movement/permute.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/permute.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "permute.h"
+#include "operations/data_movement/permute.h"
 
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/ttnn/operations/utils.h"

--- a/runtime/lib/ttnn/operations/data_movement/permute.h
+++ b/runtime/lib/ttnn/operations/data_movement/permute.h
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef RUNTIME_LIB_TTNN_OPERATIONS_DATA_MOVEMENT_PERMUTE_H
+#define RUNTIME_LIB_TTNN_OPERATIONS_DATA_MOVEMENT_PERMUTE_H
+
+#include "tt/runtime/ttnn/types.h"
+#include "ttmlir/Target/TTNN/program_generated.h"
+
+namespace tt::runtime::ttnn::operations::data_movement {
+void run(const ::tt::target::ttnn::PermuteOp *op, ProgramContext &context);
+} // namespace tt::runtime::ttnn::operations::data_movement
+
+#endif

--- a/runtime/lib/ttnn/program.cpp
+++ b/runtime/lib/ttnn/program.cpp
@@ -9,6 +9,7 @@
 #include "operations/creation/full.h"
 #include "operations/creation/ones.h"
 #include "operations/data_movement/concat.h"
+#include "operations/data_movement/permute.h"
 #include "operations/data_movement/reshape.h"
 #include "operations/data_movement/slice.h"
 #include "operations/data_movement/transpose.h"
@@ -201,6 +202,9 @@ void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
   }
   case ::tt::target::ttnn::OpType::ConcatOp: {
     return operations::data_movement::run(op->type_as_ConcatOp(), context);
+  }
+  case ::tt::target::ttnn::OpType::PermuteOp: {
+    return operations::data_movement::run(op->type_as_PermuteOp(), context);
   }
   case ::tt::target::ttnn::OpType::ReshapeOp: {
     return operations::data_movement::run(op->type_as_ReshapeOp(), context);

--- a/test/ttmlir/Conversion/StableHLOToTTIR/unary/permute_transpose_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/unary/permute_transpose_op.mlir
@@ -2,8 +2,8 @@
 // RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s | FileCheck %s
 module {
   func.func @main(%arg0: tensor<1x32x64x128xf32>) -> tensor<1x128x32x64xf32> {
-    // CHECK: %[[C:.*]] = "ttir.transpose"[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttir.transpose"[[C:.*]]
+    // CHECK: "ttir.permute"
+    // CHECK-SAME: permutation = array<i64: 0, 3, 1, 2>
     %0 = stablehlo.transpose %arg0, dims = [0, 3, 1, 2] : (tensor<1x32x64x128xf32>) -> tensor<1x128x32x64xf32>
     return %0 : tensor<1x128x32x64xf32>
   }

--- a/test/ttmlir/Conversion/StableHLOToTTIR/unary/transpose_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/unary/transpose_op.mlir
@@ -3,8 +3,9 @@
 module @jit_transpose attributes {} {
   func.func public @test_transpose(%arg0: tensor<64x128xf32>) -> tensor<128x64xf32> {
     %0 = stablehlo.transpose %arg0, dims = [1,0] : (tensor<64x128xf32>) -> tensor<128x64xf32>
-    // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttir.transpose"[[C:.*]]
+    // CHECK: tensor.empty
+    // CHECK: "ttir.permute"
+    // CHECK-SAME: permutation = array<i64: 1, 0>
     return %0 : tensor<128x64xf32>
   }
 }

--- a/test/ttmlir/Dialect/TTIR/permute/permute_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/permute/permute_tests_negative.mlir
@@ -2,35 +2,32 @@
 // Negative tests for matmul operation
 
 // Verfiy that given attribute `permutation` is a valid permutation of the dimensions.
-#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module {
   func.func @permute_non_valid_permutation(%arg0: tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16> {
     // CHECK: error: 'ttir.permute' op Expected a permutation of {k | 0 <= k < 3} got (0, 1, 0)
     %0 = tensor.empty() : tensor<16x32x64xbf16>
-    %1 = "ttir.permute"(%arg0, %0) <{operand_constraints = [#any_device, #any_device], permutation = array<i64: 0, 1, 0>}> : (tensor<16x32x64xbf16>, tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
+    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 0, 1, 0>}> : (tensor<16x32x64xbf16>, tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
     return %1 : tensor<16x32x64xbf16>
   }
 }
 
 // -----
-#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module {
   func.func @permute_subset_permutation(%arg0: tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16> {
     // CHECK: error: 'ttir.permute' op Expected a permutation of {k | 0 <= k < 3} got (0, 1)
     %0 = tensor.empty() : tensor<16x32x64xbf16>
-    %1 = "ttir.permute"(%arg0, %0) <{operand_constraints = [#any_device, #any_device], permutation = array<i64: 0, 1>}> : (tensor<16x32x64xbf16>, tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
+    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 0, 1>}> : (tensor<16x32x64xbf16>, tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
     return %1 : tensor<16x32x64xbf16>
   }
 }
 
 // Verify that the result shape matches the shape of the input tensor after permutation is applied.
 // -----
-#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module {
   func.func @permute_non_valid_shape(%arg0: tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16> {
     // CHECK: error: 'ttir.permute' op Expected result shape (16, 64, 32), got (16, 32, 64)
     %0 = tensor.empty() : tensor<16x32x64xbf16>
-    %1 = "ttir.permute"(%arg0, %0) <{operand_constraints = [#any_device, #any_device], permutation = array<i64: 0, 2, 1>}> : (tensor<16x32x64xbf16>, tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
+    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 0, 2, 1>}> : (tensor<16x32x64xbf16>, tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
     return %1 : tensor<16x32x64xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTIR/permute/permute_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/permute/permute_tests_negative.mlir
@@ -1,11 +1,11 @@
 // RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
 // Negative tests for matmul operation
 
-// Verfiy that given attribute `permutation` is a valid permutation of the dimensions
+// Verfiy that given attribute `permutation` is a valid permutation of the dimensions.
 #any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module {
   func.func @permute_non_valid_permutation(%arg0: tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16> {
-    // CHECK: error: 'ttir.permute' op Invalid permutation
+    // CHECK: error: 'ttir.permute' op Expected a permutation of {k | 0 <= k < 3} got (0, 1, 0)
     %0 = tensor.empty() : tensor<16x32x64xbf16>
     %1 = "ttir.permute"(%arg0, %0) <{operand_constraints = [#any_device, #any_device], permutation = array<i32: 0, 1, 0>}> : (tensor<16x32x64xbf16>, tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
     return %1 : tensor<16x32x64xbf16>
@@ -16,9 +16,21 @@ module {
 #any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module {
   func.func @permute_non_valid_permutation(%arg0: tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16> {
-    // CHECK: error: 'ttir.permute' op Invalid permutation
+    // CHECK: error: 'ttir.permute' op Expected a permutation of {k | 0 <= k < 3} got (0, 1)
     %0 = tensor.empty() : tensor<16x32x64xbf16>
     %1 = "ttir.permute"(%arg0, %0) <{operand_constraints = [#any_device, #any_device], permutation = array<i32: 0, 1>}> : (tensor<16x32x64xbf16>, tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
+    return %1 : tensor<16x32x64xbf16>
+  }
+}
+
+// Verify that the result shape matches the shape of the input tensor after permutation is applied.
+// -----
+#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
+module {
+  func.func @permute_non_valid_permutation(%arg0: tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16> {
+    // CHECK: error: 'ttir.permute' op Expected result shape (16, 64, 32), got (16, 32, 64)
+    %0 = tensor.empty() : tensor<16x32x64xbf16>
+    %1 = "ttir.permute"(%arg0, %0) <{operand_constraints = [#any_device, #any_device], permutation = array<i32: 0, 2, 1>}> : (tensor<16x32x64xbf16>, tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
     return %1 : tensor<16x32x64xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTIR/permute/permute_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/permute/permute_tests_negative.mlir
@@ -1,0 +1,24 @@
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+// Negative tests for matmul operation
+
+// Verfiy that given attribute `permutation` is a valid permutation of the dimensions
+#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
+module {
+  func.func @permute_non_valid_permutation(%arg0: tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16> {
+    // CHECK: error: 'ttir.permute' op Invalid permutation
+    %0 = tensor.empty() : tensor<16x32x64xbf16>
+    %1 = "ttir.permute"(%arg0, %0) <{operand_constraints = [#any_device, #any_device], permutation = array<i32: 0, 1, 0>}> : (tensor<16x32x64xbf16>, tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
+    return %1 : tensor<16x32x64xbf16>
+  }
+}
+
+// -----
+#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
+module {
+  func.func @permute_non_valid_permutation(%arg0: tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16> {
+    // CHECK: error: 'ttir.permute' op Invalid permutation
+    %0 = tensor.empty() : tensor<16x32x64xbf16>
+    %1 = "ttir.permute"(%arg0, %0) <{operand_constraints = [#any_device, #any_device], permutation = array<i32: 0, 1>}> : (tensor<16x32x64xbf16>, tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
+    return %1 : tensor<16x32x64xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/permute/permute_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/permute/permute_tests_negative.mlir
@@ -15,7 +15,7 @@ module {
 // -----
 #any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module {
-  func.func @permute_non_valid_permutation(%arg0: tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16> {
+  func.func @permute_subset_permutation(%arg0: tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16> {
     // CHECK: error: 'ttir.permute' op Expected a permutation of {k | 0 <= k < 3} got (0, 1)
     %0 = tensor.empty() : tensor<16x32x64xbf16>
     %1 = "ttir.permute"(%arg0, %0) <{operand_constraints = [#any_device, #any_device], permutation = array<i64: 0, 1>}> : (tensor<16x32x64xbf16>, tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
@@ -27,7 +27,7 @@ module {
 // -----
 #any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module {
-  func.func @permute_non_valid_permutation(%arg0: tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16> {
+  func.func @permute_non_valid_shape(%arg0: tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16> {
     // CHECK: error: 'ttir.permute' op Expected result shape (16, 64, 32), got (16, 32, 64)
     %0 = tensor.empty() : tensor<16x32x64xbf16>
     %1 = "ttir.permute"(%arg0, %0) <{operand_constraints = [#any_device, #any_device], permutation = array<i64: 0, 2, 1>}> : (tensor<16x32x64xbf16>, tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>

--- a/test/ttmlir/Dialect/TTIR/permute/permute_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/permute/permute_tests_negative.mlir
@@ -7,7 +7,7 @@ module {
   func.func @permute_non_valid_permutation(%arg0: tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16> {
     // CHECK: error: 'ttir.permute' op Expected a permutation of {k | 0 <= k < 3} got (0, 1, 0)
     %0 = tensor.empty() : tensor<16x32x64xbf16>
-    %1 = "ttir.permute"(%arg0, %0) <{operand_constraints = [#any_device, #any_device], permutation = array<i32: 0, 1, 0>}> : (tensor<16x32x64xbf16>, tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
+    %1 = "ttir.permute"(%arg0, %0) <{operand_constraints = [#any_device, #any_device], permutation = array<i64: 0, 1, 0>}> : (tensor<16x32x64xbf16>, tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
     return %1 : tensor<16x32x64xbf16>
   }
 }
@@ -18,7 +18,7 @@ module {
   func.func @permute_non_valid_permutation(%arg0: tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16> {
     // CHECK: error: 'ttir.permute' op Expected a permutation of {k | 0 <= k < 3} got (0, 1)
     %0 = tensor.empty() : tensor<16x32x64xbf16>
-    %1 = "ttir.permute"(%arg0, %0) <{operand_constraints = [#any_device, #any_device], permutation = array<i32: 0, 1>}> : (tensor<16x32x64xbf16>, tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
+    %1 = "ttir.permute"(%arg0, %0) <{operand_constraints = [#any_device, #any_device], permutation = array<i64: 0, 1>}> : (tensor<16x32x64xbf16>, tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
     return %1 : tensor<16x32x64xbf16>
   }
 }
@@ -30,7 +30,7 @@ module {
   func.func @permute_non_valid_permutation(%arg0: tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16> {
     // CHECK: error: 'ttir.permute' op Expected result shape (16, 64, 32), got (16, 32, 64)
     %0 = tensor.empty() : tensor<16x32x64xbf16>
-    %1 = "ttir.permute"(%arg0, %0) <{operand_constraints = [#any_device, #any_device], permutation = array<i32: 0, 2, 1>}> : (tensor<16x32x64xbf16>, tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
+    %1 = "ttir.permute"(%arg0, %0) <{operand_constraints = [#any_device, #any_device], permutation = array<i64: 0, 2, 1>}> : (tensor<16x32x64xbf16>, tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
     return %1 : tensor<16x32x64xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTIR/permute/permute_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/permute/permute_tests_negative.mlir
@@ -1,10 +1,10 @@
 // RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
-// Negative tests for matmul operation
+// Negative tests for permute operation
 
 // Verfiy that given attribute `permutation` is a valid permutation of the dimensions.
 module {
   func.func @permute_non_valid_permutation(%arg0: tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16> {
-    // CHECK: error: 'ttir.permute' op Expected a permutation of {k | 0 <= k < 3} got (0, 1, 0)
+    // CHECK: error: 'ttir.permute' op Expected a permutation of (0, 1, 2), got (0, 1, 0)
     %0 = tensor.empty() : tensor<16x32x64xbf16>
     %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 0, 1, 0>}> : (tensor<16x32x64xbf16>, tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
     return %1 : tensor<16x32x64xbf16>
@@ -14,7 +14,7 @@ module {
 // -----
 module {
   func.func @permute_subset_permutation(%arg0: tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16> {
-    // CHECK: error: 'ttir.permute' op Expected a permutation of {k | 0 <= k < 3} got (0, 1)
+    // CHECK: error: 'ttir.permute' op Expected a permutation of (0, 1, 2), got (0, 1)
     %0 = tensor.empty() : tensor<16x32x64xbf16>
     %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 0, 1>}> : (tensor<16x32x64xbf16>, tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
     return %1 : tensor<16x32x64xbf16>

--- a/test/ttmlir/Dialect/TTNN/convolution/complex_conv_channel_first.mlir
+++ b/test/ttmlir/Dialect/TTNN/convolution/complex_conv_channel_first.mlir
@@ -2,9 +2,11 @@
 module @jit_convolution {
   func.func public @test_NCHW_IOHW_to_NHWC_OIHW_conv2d(%arg0: tensor<1x3x100x100xbf16>, %arg1: tensor<7x3x3x3xbf16>) -> tensor<1x7x100x100xbf16> {
     %0 = tensor.empty() : tensor<1x7x100x100xbf16>
-    // CHECK: %[[C:.*]] = "ttnn.transpose"[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttnn.transpose"[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttnn.conv2d"[[C:.*]]
+    // CHECK: "ttnn.permute"
+    // CHECK-SAME: permutation = array<i64: 0, 2, 3, 1>
+    // CHECK: "ttnn.conv2d"
+    // CHECK: "ttnn.permute"
+    // CHECK-SAME: permutation = array<i64: 0, 3, 1, 2>
     %1 = "ttir.convolution"(%arg0, %arg1, %0) <{
       batch_group_count = 1 : i64,
       convolution_layout = #ttir<convolution_layout
@@ -25,8 +27,6 @@ module @jit_convolution {
       window_reversal = array<i1: false, false>,
       window_strides = array<i64: 1, 1>
     }> : (tensor<1x3x100x100xbf16>, tensor<7x3x3x3xbf16>, tensor<1x7x100x100xbf16>) -> tensor<1x7x100x100xbf16>
-    // CHECK: %[[C:.*]] = "ttnn.transpose"[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttnn.transpose"[[C:.*]]
     return %1 : tensor<1x7x100x100xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/convolution/simple_conv1d.mlir
+++ b/test/ttmlir/Dialect/TTNN/convolution/simple_conv1d.mlir
@@ -2,13 +2,19 @@
 module {
   func.func @main(%arg0: tensor<1x256x512xf32>, %arg1: tensor<1024x256x1xf32>, %arg2: tensor<1024xf32>) -> tensor<1x1024x512xf32> {
     %0 = tensor.empty() : tensor<1x1024x512xf32>
-    // CHECK: [[VAL0:%[0-9]+]] = "ttnn.reshape"(%{{.*}}) <{shape = [1 : i32, 256 : i32, 512 : i32, 1 : i32]}> : (tensor<[[TENSOR_SHAPE0:[0-9]+x[0-9]+x[0-9]+xf32]], #{{.*}}) -> tensor<[[TENSOR_SHAPE1:[0-9]+x[0-9]+x[0-9]+x1xf32]], #{{.*}}>
-    // CHECK: [[VAL1:%[0-9]+]] = "ttnn.reshape"(%{{.*}}) <{shape = [1024 : i32, 256 : i32, 1 : i32, 1 : i32]}> : (tensor<[[TENSOR_SHAPE2:[0-9]+x[0-9]+x[0-9]+xf32]], #{{.*}}>) -> tensor<[[TENSOR_SHAPE3:[0-9]+x[0-9]+x[0-9]+x1xf32]], #{{.*}}>
-    // CHECK: [[VAL2:%[0-9]+]] = "ttnn.transpose"([[VAL0]]) <{dim0 = 1 : si32, dim1 = 2 : si32}> : (tensor<[[TENSOR_SHAPE1]], #{{.*}}>) -> tensor<[[TENSOR_SHAPE4:[0-9]+x[0-9]+x[0-9]+x1xf32]], #{{.*}}>
-    // CHECK: [[VAL3:%[0-9]+]] = "ttnn.transpose"([[VAL2]]) <{dim0 = 2 : si32, dim1 = 3 : si32}> : (tensor<[[TENSOR_SHAPE4]], #{{.*}}>) -> tensor<[[TENSOR_SHAPE5:[0-9]+x[0-9]+x[0-9]+x[0-9]+xf32]], #{{.*}}>
-    // CHECK: [[VAL4:%[0-9]+]] = "ttnn.reshape"([[VAL3]]) <{shape = [1 : i32, 1 : i32, 512 : i32, 256 : i32]}> : (tensor<[[TENSOR_SHAPE5]], #{{.*}}>) -> tensor<[[TENSOR_SHAPE6:[0-9]+x[0-9]+x[0-9]+x[0-9]+xf32]], #{{.*}}>
-    // CHECK: [[VAL5:%[0-9]+]] = "ttnn.conv2d"([[VAL4]], %10, %{{[0-9]+}}, %{{[0-9]+}})
-    // CHECK: (tensor<[[TENSOR_SHAPE6]], #{{.*}}>, tensor<1024x256x1x1xf32,  #{{.*}}>, tensor<1x1x512x1024xf32, #{{.*}}>, !tt.device<#device>) -> tensor<1x1x512x1024xf32,  #{{.*}}>
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: shape = [1 : i32, 256 : i32, 512 : i32, 1 : i32]
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: shape = [1024 : i32, 256 : i32, 1 : i32, 1 : i32]
+    // CHECK: "ttnn.permute"
+    // CHECK-SAME: permutation = array<i64: 0, 2, 3, 1>
+    // CHECK: "ttnn.permute"
+    // CHECK-SAME: permutation = array<i64: 0, 1, 2, 3>
+    // CHECK: "ttnn.conv2d"
+    // CHECK: "ttnn.permute"
+    // CHECK-SAME: permutation = array<i64: 0, 3, 1, 2>
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: shape = [1 : i32, 1024 : i32, 512 : i32]
     %1 = "ttir.convolution"(%arg0, %arg1, %0) <{batch_group_count = 1 : i64, convolution_layout = #ttir<convolution_layout input_batch = 0, input_feature = 1, input_spatial_dimensions = 2, kernel_output_feature = 0, kernel_input_feature = 1, kernel_spatial_dimensions = 2, output_batch = 0, output_feature = 1, output_spatial_dimensions = 2>, feature_group_count = 1 : i64, input_dilation = array<i64: 1>, padding = array<i64: 0, 0>, weight_dilation = array<i64: 1>, window_reversal = array<i1: false>, window_strides = array<i64: 1>}> : (tensor<1x256x512xf32>, tensor<1024x256x1xf32>, tensor<1x1024x512xf32>) -> tensor<1x1024x512xf32>
     // CHECK: return %{{.*}} : tensor<1x1024x512xf32, #ttnn_layout3>
     return %1 : tensor<1x1024x512xf32>

--- a/test/ttmlir/Dialect/TTNN/permute/permute_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/permute/permute_tests_negative.mlir
@@ -14,7 +14,7 @@ module {
 // -----
 #any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module {
-  func.func @permute_non_valid_permutation(%arg0: tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16> {
+  func.func @permute_subset_permutation(%arg0: tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16> {
     // CHECK: error: 'ttnn.permute' op Expected a permutation of {k | 0 <= k < 3} got (0, 1)
     %0 = "ttnn.permute"(%arg0) <{permutation = array<i64: 0, 1>}> : (tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
     return %0 : tensor<16x32x64xbf16>
@@ -25,7 +25,7 @@ module {
 // -----
 #any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module {
-  func.func @permute_non_valid_permutation(%arg0: tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16> {
+  func.func @permute_non_valid_shape(%arg0: tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16> {
     // CHECK: error: 'ttnn.permute' op Expected result shape (16, 64, 32), got (16, 32, 64)
     %0 = "ttnn.permute"(%arg0) <{permutation = array<i64: 0, 2, 1>}> : (tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
     return %0 : tensor<16x32x64xbf16>

--- a/test/ttmlir/Dialect/TTNN/permute/permute_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/permute/permute_tests_negative.mlir
@@ -6,7 +6,7 @@
 module {
   func.func @permute_non_valid_permutation(%arg0: tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16> {
     // CHECK: error: 'ttnn.permute' op Expected a permutation of {k | 0 <= k < 3} got (0, 1, 0)
-    %0 = "ttnn.permute"(%arg0) <{permutation = array<i32: 0, 1, 0>}> : (tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
+    %0 = "ttnn.permute"(%arg0) <{permutation = array<i64: 0, 1, 0>}> : (tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
     return %0 : tensor<16x32x64xbf16>
   }
 }
@@ -16,7 +16,7 @@ module {
 module {
   func.func @permute_non_valid_permutation(%arg0: tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16> {
     // CHECK: error: 'ttnn.permute' op Expected a permutation of {k | 0 <= k < 3} got (0, 1)
-    %0 = "ttnn.permute"(%arg0) <{permutation = array<i32: 0, 1>}> : (tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
+    %0 = "ttnn.permute"(%arg0) <{permutation = array<i64: 0, 1>}> : (tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
     return %0 : tensor<16x32x64xbf16>
   }
 }
@@ -27,7 +27,7 @@ module {
 module {
   func.func @permute_non_valid_permutation(%arg0: tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16> {
     // CHECK: error: 'ttnn.permute' op Expected result shape (16, 64, 32), got (16, 32, 64)
-    %0 = "ttnn.permute"(%arg0) <{permutation = array<i32: 0, 2, 1>}> : (tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
+    %0 = "ttnn.permute"(%arg0) <{permutation = array<i64: 0, 2, 1>}> : (tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
     return %0 : tensor<16x32x64xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/permute/permute_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/permute/permute_tests_negative.mlir
@@ -2,7 +2,6 @@
 // Negative tests for matmul operation
 
 // Verfiy that given attribute `permutation` is a valid permutation of the dimensions.
-#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module {
   func.func @permute_non_valid_permutation(%arg0: tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16> {
     // CHECK: error: 'ttnn.permute' op Expected a permutation of {k | 0 <= k < 3} got (0, 1, 0)
@@ -12,7 +11,6 @@ module {
 }
 
 // -----
-#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module {
   func.func @permute_subset_permutation(%arg0: tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16> {
     // CHECK: error: 'ttnn.permute' op Expected a permutation of {k | 0 <= k < 3} got (0, 1)
@@ -23,7 +21,6 @@ module {
 
 // Verify that the result shape matches the shape of the input tensor after permutation is applied.
 // -----
-#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module {
   func.func @permute_non_valid_shape(%arg0: tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16> {
     // CHECK: error: 'ttnn.permute' op Expected result shape (16, 64, 32), got (16, 32, 64)

--- a/test/ttmlir/Dialect/TTNN/permute/permute_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/permute/permute_tests_negative.mlir
@@ -1,0 +1,33 @@
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+// Negative tests for matmul operation
+
+// Verfiy that given attribute `permutation` is a valid permutation of the dimensions.
+#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
+module {
+  func.func @permute_non_valid_permutation(%arg0: tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16> {
+    // CHECK: error: 'ttnn.permute' op Expected a permutation of {k | 0 <= k < 3} got (0, 1, 0)
+    %0 = "ttnn.permute"(%arg0) <{permutation = array<i32: 0, 1, 0>}> : (tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
+    return %0 : tensor<16x32x64xbf16>
+  }
+}
+
+// -----
+#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
+module {
+  func.func @permute_non_valid_permutation(%arg0: tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16> {
+    // CHECK: error: 'ttnn.permute' op Expected a permutation of {k | 0 <= k < 3} got (0, 1)
+    %0 = "ttnn.permute"(%arg0) <{permutation = array<i32: 0, 1>}> : (tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
+    return %0 : tensor<16x32x64xbf16>
+  }
+}
+
+// Verify that the result shape matches the shape of the input tensor after permutation is applied.
+// -----
+#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
+module {
+  func.func @permute_non_valid_permutation(%arg0: tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16> {
+    // CHECK: error: 'ttnn.permute' op Expected result shape (16, 64, 32), got (16, 32, 64)
+    %0 = "ttnn.permute"(%arg0) <{permutation = array<i32: 0, 2, 1>}> : (tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
+    return %0 : tensor<16x32x64xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/permute/permute_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/permute/permute_tests_negative.mlir
@@ -1,10 +1,10 @@
 // RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
-// Negative tests for matmul operation
+// Negative tests for permute operation
 
 // Verfiy that given attribute `permutation` is a valid permutation of the dimensions.
 module {
   func.func @permute_non_valid_permutation(%arg0: tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16> {
-    // CHECK: error: 'ttnn.permute' op Expected a permutation of {k | 0 <= k < 3} got (0, 1, 0)
+    // CHECK: error: 'ttnn.permute' op Expected a permutation of (0, 1, 2), got (0, 1, 0)
     %0 = "ttnn.permute"(%arg0) <{permutation = array<i64: 0, 1, 0>}> : (tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
     return %0 : tensor<16x32x64xbf16>
   }
@@ -13,7 +13,7 @@ module {
 // -----
 module {
   func.func @permute_subset_permutation(%arg0: tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16> {
-    // CHECK: error: 'ttnn.permute' op Expected a permutation of {k | 0 <= k < 3} got (0, 1)
+    // CHECK: error: 'ttnn.permute' op Expected a permutation of (0, 1, 2), got (0, 1)
     %0 = "ttnn.permute"(%arg0) <{permutation = array<i64: 0, 1>}> : (tensor<16x32x64xbf16>) -> tensor<16x32x64xbf16>
     return %0 : tensor<16x32x64xbf16>
   }

--- a/test/ttmlir/Dialect/TTNN/permute/permute_tests_positive.mlir
+++ b/test/ttmlir/Dialect/TTNN/permute/permute_tests_positive.mlir
@@ -1,5 +1,4 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
-#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module {
   func.func @permute_identity(%arg0: tensor<8x32x64x128xf32>) -> tensor<8x32x64x128xf32> {
     %0 = tensor.empty() : tensor<8x32x64x128xf32>
@@ -7,7 +6,7 @@ module {
     // CHECK-SAME: permutation = array<i64: 0, 1, 2, 3>
     // CHECK-SAME: tensor<8x32x64x128xf32
     // CHECK-SAME: tensor<8x32x64x128xf32
-    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 0, 1, 2, 3>, operand_constraints = [#any_device, #any_device]}> : (tensor<8x32x64x128xf32>, tensor<8x32x64x128xf32>) -> tensor<8x32x64x128xf32>
+    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 0, 1, 2, 3>}> : (tensor<8x32x64x128xf32>, tensor<8x32x64x128xf32>) -> tensor<8x32x64x128xf32>
     return %1 : tensor<8x32x64x128xf32>
   }
 
@@ -17,7 +16,7 @@ module {
     // CHECK-SAME: permutation = array<i64: 2, 0, 3, 1>
     // CHECK-SAME: tensor<8x32x64x128xf32
     // CHECK-SAME: tensor<64x8x128x32xf32
-    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 2, 0, 3, 1>, operand_constraints = [#any_device, #any_device]}> : (tensor<8x32x64x128xf32>, tensor<64x8x128x32xf32>) -> tensor<64x8x128x32xf32>
+    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 2, 0, 3, 1>}> : (tensor<8x32x64x128xf32>, tensor<64x8x128x32xf32>) -> tensor<64x8x128x32xf32>
     return %1 : tensor<64x8x128x32xf32>
   }
 
@@ -27,7 +26,7 @@ module {
     // CHECK-SAME: permutation = array<i64: 0>
     // CHECK-SAME: tensor<32xf32
     // CHECK-SAME: tensor<32xf32
-    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 0>, operand_constraints = [#any_device, #any_device]}> : (tensor<32xf32>, tensor<32xf32>) -> tensor<32xf32>
+    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 0>}> : (tensor<32xf32>, tensor<32xf32>) -> tensor<32xf32>
     return %1 : tensor<32xf32>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/permute/permute_tests_positive.mlir
+++ b/test/ttmlir/Dialect/TTNN/permute/permute_tests_positive.mlir
@@ -4,30 +4,30 @@ module {
   func.func @permute_identity(%arg0: tensor<8x32x64x128xf32>) -> tensor<8x32x64x128xf32> {
     %0 = tensor.empty() : tensor<8x32x64x128xf32>
     // CHECK: "ttnn.permute"
-    // CHECK-SAME: permutation = array<i32: 0, 1, 2, 3>
+    // CHECK-SAME: permutation = array<i64: 0, 1, 2, 3>
     // CHECK-SAME: tensor<8x32x64x128xf32
     // CHECK-SAME: tensor<8x32x64x128xf32
-    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i32: 0, 1, 2, 3>, operand_constraints = [#any_device, #any_device]}> : (tensor<8x32x64x128xf32>, tensor<8x32x64x128xf32>) -> tensor<8x32x64x128xf32>
+    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 0, 1, 2, 3>, operand_constraints = [#any_device, #any_device]}> : (tensor<8x32x64x128xf32>, tensor<8x32x64x128xf32>) -> tensor<8x32x64x128xf32>
     return %1 : tensor<8x32x64x128xf32>
   }
 
   func.func @permute_general(%arg0: tensor<8x32x64x128xf32>) -> tensor<64x8x128x32xf32> {
     %0 = tensor.empty() : tensor<64x8x128x32xf32>
     // CHECK: "ttnn.permute"
-    // CHECK-SAME: permutation = array<i32: 2, 0, 3, 1>
+    // CHECK-SAME: permutation = array<i64: 2, 0, 3, 1>
     // CHECK-SAME: tensor<8x32x64x128xf32
     // CHECK-SAME: tensor<64x8x128x32xf32
-    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i32: 2, 0, 3, 1>, operand_constraints = [#any_device, #any_device]}> : (tensor<8x32x64x128xf32>, tensor<64x8x128x32xf32>) -> tensor<64x8x128x32xf32>
+    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 2, 0, 3, 1>, operand_constraints = [#any_device, #any_device]}> : (tensor<8x32x64x128xf32>, tensor<64x8x128x32xf32>) -> tensor<64x8x128x32xf32>
     return %1 : tensor<64x8x128x32xf32>
   }
 
   func.func @permute_1d(%arg0: tensor<32xf32>) -> tensor<32xf32> {
     %0 = tensor.empty() : tensor<32xf32>
     // CHECK: "ttnn.permute"
-    // CHECK-SAME: permutation = array<i32: 0>
+    // CHECK-SAME: permutation = array<i64: 0>
     // CHECK-SAME: tensor<32xf32
     // CHECK-SAME: tensor<32xf32
-    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i32: 0>, operand_constraints = [#any_device, #any_device]}> : (tensor<32xf32>, tensor<32xf32>) -> tensor<32xf32>
+    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 0>, operand_constraints = [#any_device, #any_device]}> : (tensor<32xf32>, tensor<32xf32>) -> tensor<32xf32>
     return %1 : tensor<32xf32>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/permute/permute_tests_positive.mlir
+++ b/test/ttmlir/Dialect/TTNN/permute/permute_tests_positive.mlir
@@ -1,0 +1,33 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
+#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
+module {
+  func.func @permute_identity(%arg0: tensor<8x32x64x128xf32>) -> tensor<8x32x64x128xf32> {
+    %0 = tensor.empty() : tensor<8x32x64x128xf32>
+    // CHECK: "ttnn.permute"
+    // CHECK-SAME: permutation = array<i32: 0, 1, 2, 3>
+    // CHECK-SAME: tensor<8x32x64x128xf32
+    // CHECK-SAME: tensor<8x32x64x128xf32
+    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i32: 0, 1, 2, 3>, operand_constraints = [#any_device, #any_device]}> : (tensor<8x32x64x128xf32>, tensor<8x32x64x128xf32>) -> tensor<8x32x64x128xf32>
+    return %1 : tensor<8x32x64x128xf32>
+  }
+
+  func.func @permute_general(%arg0: tensor<8x32x64x128xf32>) -> tensor<64x8x128x32xf32> {
+    %0 = tensor.empty() : tensor<64x8x128x32xf32>
+    // CHECK: "ttnn.permute"
+    // CHECK-SAME: permutation = array<i32: 2, 0, 3, 1>
+    // CHECK-SAME: tensor<8x32x64x128xf32
+    // CHECK-SAME: tensor<64x8x128x32xf32
+    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i32: 2, 0, 3, 1>, operand_constraints = [#any_device, #any_device]}> : (tensor<8x32x64x128xf32>, tensor<64x8x128x32xf32>) -> tensor<64x8x128x32xf32>
+    return %1 : tensor<64x8x128x32xf32>
+  }
+
+  func.func @permute_1d(%arg0: tensor<32xf32>) -> tensor<32xf32> {
+    %0 = tensor.empty() : tensor<32xf32>
+    // CHECK: "ttnn.permute"
+    // CHECK-SAME: permutation = array<i32: 0>
+    // CHECK-SAME: tensor<32xf32
+    // CHECK-SAME: tensor<32xf32
+    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i32: 0>, operand_constraints = [#any_device, #any_device]}> : (tensor<32xf32>, tensor<32xf32>) -> tensor<32xf32>
+    return %1 : tensor<32xf32>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/permute/simple_permute.mlir
+++ b/test/ttmlir/Dialect/TTNN/permute/simple_permute.mlir
@@ -4,10 +4,10 @@ module {
   func.func @forward(%arg0: tensor<1x4x32x64xf32>) -> tensor<4x32x64x1xf32> {
     %0 = tensor.empty() : tensor<4x32x64x1xf32>
     // CHECK: "ttnn.permute"
-    // CHECK-SAME: permutation = array<i32: 1, 2, 3, 0>
+    // CHECK-SAME: permutation = array<i64: 1, 2, 3, 0>
     // CHECK-SAME: tensor<1x4x32x64xf32
     // CHECK-SAME: tensor<4x32x64x1xf32
-    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i32: 1, 2, 3, 0>, operand_constraints = [#any_device, #any_device]}> : (tensor<1x4x32x64xf32>, tensor<4x32x64x1xf32>) -> tensor<4x32x64x1xf32>
+    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 1, 2, 3, 0>, operand_constraints = [#any_device, #any_device]}> : (tensor<1x4x32x64xf32>, tensor<4x32x64x1xf32>) -> tensor<4x32x64x1xf32>
     return %1 : tensor<4x32x64x1xf32>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/permute/simple_permute.mlir
+++ b/test/ttmlir/Dialect/TTNN/permute/simple_permute.mlir
@@ -1,7 +1,7 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 #any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module {
-  func.func @forward(%arg0: tensor<1x4x32x64xf32>) -> tensor<4x32x64x1xf32> {
+  func.func @permute(%arg0: tensor<1x4x32x64xf32>) -> tensor<4x32x64x1xf32> {
     %0 = tensor.empty() : tensor<4x32x64x1xf32>
     // CHECK: "ttnn.permute"
     // CHECK-SAME: permutation = array<i64: 1, 2, 3, 0>

--- a/test/ttmlir/Dialect/TTNN/permute/simple_permute.mlir
+++ b/test/ttmlir/Dialect/TTNN/permute/simple_permute.mlir
@@ -1,9 +1,7 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
-// RUN: FileCheck %s --input-file=%t.mlir
-// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 #any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module {
-  func.func @permute(%arg0: tensor<1x4x32x64xf32>) -> tensor<4x32x64x1xf32> {
+  func.func @forward(%arg0: tensor<1x4x32x64xf32>) -> tensor<4x32x64x1xf32> {
     %0 = tensor.empty() : tensor<4x32x64x1xf32>
     // CHECK: "ttnn.permute"
     // CHECK-SAME: permutation = array<i32: 1, 2, 3, 0>

--- a/test/ttmlir/Dialect/TTNN/permute/simple_permute.mlir
+++ b/test/ttmlir/Dialect/TTNN/permute/simple_permute.mlir
@@ -1,5 +1,4 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
-#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module {
   func.func @permute(%arg0: tensor<1x4x32x64xf32>) -> tensor<4x32x64x1xf32> {
     %0 = tensor.empty() : tensor<4x32x64x1xf32>
@@ -7,7 +6,7 @@ module {
     // CHECK-SAME: permutation = array<i64: 1, 2, 3, 0>
     // CHECK-SAME: tensor<1x4x32x64xf32
     // CHECK-SAME: tensor<4x32x64x1xf32
-    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 1, 2, 3, 0>, operand_constraints = [#any_device, #any_device]}> : (tensor<1x4x32x64xf32>, tensor<4x32x64x1xf32>) -> tensor<4x32x64x1xf32>
+    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 1, 2, 3, 0>}> : (tensor<1x4x32x64xf32>, tensor<4x32x64x1xf32>) -> tensor<4x32x64x1xf32>
     return %1 : tensor<4x32x64x1xf32>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/pooling/simple_pooling.mlir
+++ b/test/ttmlir/Dialect/TTNN/pooling/simple_pooling.mlir
@@ -2,7 +2,11 @@
 module attributes {} {
   func.func @forward(%arg0: tensor<1x32x128x128xbf16>) -> tensor<1x32x64x64xbf16> {
     %0 = tensor.empty() : tensor<1x32x64x64xbf16>
-    // CHECK: %[[C:.*]] = "ttnn.max_pool2d"[[C:.*]]
+    // CHECK: "ttnn.permute"
+    // CHECK-SAME: permutation = array<i64: 0, 2, 3, 1>
+    // CHECK: "ttnn.max_pool2d"
+    // CHECK: "ttnn.permute"
+    // CHECK-SAME: permutation = array<i64: 0, 3, 1, 2>
     %1 = "ttir.pooling"(%arg0, %0) <{
         operandSegmentSizes = array<i32: 1, 1>,
         pooling_method = #ttir<pooling_method Max>,

--- a/test/ttmlir/Dialect/TTNN/simple_permute.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_permute.mlir
@@ -1,0 +1,10 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
+module {
+  func.func @forward(%arg0: tensor<1x4x32x64xf32>) -> tensor<4x32x64x1xf32> {
+    %0 = tensor.empty() : tensor<4x32x64x1xf32>
+    // CHECK: "ttnn.permute"
+    // CHECK-SAME: permutation = array<i64: 1, 2, 3, 0>
+    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 1, 2, 3, 0>}> : (tensor<1x4x32x64xf32>, tensor<4x32x64x1xf32>) -> tensor<4x32x64x1xf32>
+    return %1 : tensor<4x32x64x1xf32>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/simple_permute.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_permute.mlir
@@ -1,0 +1,11 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
+#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
+module {
+  func.func @forward(%arg0: tensor<1x4x32x64xf32>) -> tensor<4x32x64x1xf32> {
+    %0 = tensor.empty() : tensor<4x32x64x1xf32>
+    // CHECK: "ttnn.permute"
+    // CHECK-SAME: permutation = array<i32: 1, 2, 3, 0>
+    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i32: 1, 2, 3, 0>, operand_constraints = [#any_device, #any_device]}> : (tensor<1x4x32x64xf32>, tensor<4x32x64x1xf32>) -> tensor<4x32x64x1xf32>
+    return %1 : tensor<4x32x64x1xf32>
+  }
+}

--- a/test/ttmlir/Silicon/StableHLO/Unary/permute_transpose_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/Unary/permute_transpose_op.mlir
@@ -9,13 +9,9 @@
 module {
   func.func public @test_permute_transpose(%arg0: tensor<1x32x64x128xf32>) -> tensor<1x128x32x64xf32> {
     // CHECK-LABEL: func.func public @test_permute_transpose
-    // CHECK: %[[VAL:[0-9]+]] = "ttnn.transpose"
-    // CHECK-SAME: {dim0 = 3 : si32, dim1 = 2 : si32}
+    // CHECK: %[[VAL:[0-9]+]] = "ttnn.permute"
+    // CHECK-SAME: permutation = array<i64: 0, 3, 1, 2>
     // CHECK-SAME: tensor<1x32x64x128xf32,
-    // CHECK-SAME: -> tensor<1x32x128x64xf32
-    // CHECK: "ttnn.transpose"(%[[VAL]])
-    // CHECK-SAME: {dim0 = 2 : si32, dim1 = 1 : si32}
-    // CHECK-SAME: tensor<1x32x128x64xf32,
     // CHECK-SAME: -> tensor<1x128x32x64xf32,
     %0 = stablehlo.transpose %arg0, dims = [0, 3, 1, 2] : (tensor<1x32x64x128xf32>) -> tensor<1x128x32x64xf32>
     return %0 : tensor<1x128x32x64xf32>

--- a/test/ttmlir/Silicon/StableHLO/Unary/tranpose_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/Unary/tranpose_op.mlir
@@ -9,8 +9,8 @@
 module @jit_transpose attributes {} {
   func.func public @test_transpose(%arg0: tensor<64x128xf32>) -> tensor<128x64xf32> {
     // CHECK-LABEL: func.func public @test_transpose
-    // CHECK: ttnn.transpose
-    // CHECK-SAME: {dim0 = 1 : si32, dim1 = 0 : si32}
+    // CHECK: "ttnn.permute"
+    // CHECK-SAME: permutation = array<i64: 1, 0>
     // CHECK-SAME: tensor<64x128xf32,
     // CHECK-SAME: -> tensor<128x64xf32,
     %0 = stablehlo.transpose %arg0, dims = [1,0] : (tensor<64x128xf32>) -> tensor<128x64xf32>

--- a/test/ttmlir/Silicon/TTNN/complex_conv_channel_first.mlir
+++ b/test/ttmlir/Silicon/TTNN/complex_conv_channel_first.mlir
@@ -4,9 +4,11 @@
 module @jit_convolution {
   func.func public @test_NCHW_IOHW_to_NHWC_OIHW_conv2d(%arg0: tensor<1x3x100x100xbf16>, %arg1: tensor<7x3x3x3xbf16>) -> tensor<1x7x100x100xbf16> {
     %0 = tensor.empty() : tensor<1x7x100x100xbf16>
-    // CHECK: %[[C:.*]] = "ttnn.transpose"[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttnn.transpose"[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttnn.conv2d"[[C:.*]]
+    // CHECK: "ttnn.permute"
+    // CHECK-SAME: permutation = array<i64: 0, 2, 3, 1>
+    // CHECK: "ttnn.conv2d"
+    // CHECK: "ttnn.permute"
+    // CHECK-SAME: permutation = array<i64: 0, 3, 1, 2>
     %1 = "ttir.convolution"(%arg0, %arg1, %0) <{
       batch_group_count = 1 : i64,
       convolution_layout = #ttir<convolution_layout
@@ -27,8 +29,6 @@ module @jit_convolution {
       window_reversal = array<i1: false, false>,
       window_strides = array<i64: 1, 1>
     }> : (tensor<1x3x100x100xbf16>, tensor<7x3x3x3xbf16>, tensor<1x7x100x100xbf16>) -> tensor<1x7x100x100xbf16>
-    // CHECK: %[[C:.*]] = "ttnn.transpose"[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttnn.transpose"[[C:.*]]
     return %1 : tensor<1x7x100x100xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/perf_unit/test_perf_permute.mlir
+++ b/test/ttmlir/Silicon/TTNN/perf_unit/test_perf_permute.mlir
@@ -1,10 +1,14 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 #any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module {
-  func.func @forward(%arg0: tensor<1x4x32x64xf32>) -> tensor<4x32x64x1xf32> {
+  func.func @permute(%arg0: tensor<1x4x32x64xf32>) -> tensor<4x32x64x1xf32> {
     %0 = tensor.empty() : tensor<4x32x64x1xf32>
     // CHECK: "ttnn.permute"
     // CHECK-SAME: permutation = array<i32: 1, 2, 3, 0>
+    // CHECK-SAME: tensor<1x4x32x64xf32
+    // CHECK-SAME: tensor<4x32x64x1xf32
     %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i32: 1, 2, 3, 0>, operand_constraints = [#any_device, #any_device]}> : (tensor<1x4x32x64xf32>, tensor<4x32x64x1xf32>) -> tensor<4x32x64x1xf32>
     return %1 : tensor<4x32x64x1xf32>
   }

--- a/test/ttmlir/Silicon/TTNN/perf_unit/test_perf_permute.mlir
+++ b/test/ttmlir/Silicon/TTNN/perf_unit/test_perf_permute.mlir
@@ -6,10 +6,10 @@ module {
   func.func @permute(%arg0: tensor<1x4x32x64xf32>) -> tensor<4x32x64x1xf32> {
     %0 = tensor.empty() : tensor<4x32x64x1xf32>
     // CHECK: "ttnn.permute"
-    // CHECK-SAME: permutation = array<i32: 1, 2, 3, 0>
+    // CHECK-SAME: permutation = array<i64: 1, 2, 3, 0>
     // CHECK-SAME: tensor<1x4x32x64xf32
     // CHECK-SAME: tensor<4x32x64x1xf32
-    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i32: 1, 2, 3, 0>, operand_constraints = [#any_device, #any_device]}> : (tensor<1x4x32x64xf32>, tensor<4x32x64x1xf32>) -> tensor<4x32x64x1xf32>
+    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 1, 2, 3, 0>, operand_constraints = [#any_device, #any_device]}> : (tensor<1x4x32x64xf32>, tensor<4x32x64x1xf32>) -> tensor<4x32x64x1xf32>
     return %1 : tensor<4x32x64x1xf32>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/perf_unit/test_perf_permute.mlir
+++ b/test/ttmlir/Silicon/TTNN/perf_unit/test_perf_permute.mlir
@@ -1,7 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module {
   func.func @permute(%arg0: tensor<1x4x32x64xf32>) -> tensor<4x32x64x1xf32> {
     %0 = tensor.empty() : tensor<4x32x64x1xf32>
@@ -9,7 +8,7 @@ module {
     // CHECK-SAME: permutation = array<i64: 1, 2, 3, 0>
     // CHECK-SAME: tensor<1x4x32x64xf32
     // CHECK-SAME: tensor<4x32x64x1xf32
-    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 1, 2, 3, 0>, operand_constraints = [#any_device, #any_device]}> : (tensor<1x4x32x64xf32>, tensor<4x32x64x1xf32>) -> tensor<4x32x64x1xf32>
+    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 1, 2, 3, 0>}> : (tensor<1x4x32x64xf32>, tensor<4x32x64x1xf32>) -> tensor<4x32x64x1xf32>
     return %1 : tensor<4x32x64x1xf32>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/pooling/simple_pooling.mlir
+++ b/test/ttmlir/Silicon/TTNN/pooling/simple_pooling.mlir
@@ -4,7 +4,11 @@
 module attributes {} {
   func.func @forward(%arg0: tensor<1x32x128x128xbf16>) -> tensor<1x32x64x64xbf16> {
     %0 = tensor.empty() : tensor<1x32x64x64xbf16>
-    // CHECK: %[[C:.*]] = "ttnn.max_pool2d"[[C:.*]]
+    // CHECK: "ttnn.permute"
+    // CHECK-SAME: permutation = array<i64: 0, 2, 3, 1>
+    // CHECK: "ttnn.max_pool2d"
+    // CHECK: "ttnn.permute"
+    // CHECK-SAME: permutation = array<i64: 0, 3, 1, 2>
     %1 = "ttir.pooling"(%arg0, %0) <{
         operandSegmentSizes = array<i32: 1, 1>,
         pooling_method = #ttir<pooling_method Max>,

--- a/test/ttmlir/Silicon/TTNN/simple_permute.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_permute.mlir
@@ -1,0 +1,13 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
+module {
+  func.func @forward(%arg0: tensor<1x4x32x64xf32>) -> tensor<4x32x64x1xf32> {
+    %0 = tensor.empty() : tensor<4x32x64x1xf32>
+    // CHECK: "ttnn.permute"
+    // CHECK-SAME: permutation = array<i32: 1, 2, 3, 0>
+    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i32: 1, 2, 3, 0>, operand_constraints = [#any_device, #any_device]}> : (tensor<1x4x32x64xf32>, tensor<4x32x64x1xf32>) -> tensor<4x32x64x1xf32>
+    return %1 : tensor<4x32x64x1xf32>
+  }
+}

--- a/test/ttmlir/Silicon/TTNN/simple_permute.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_permute.mlir
@@ -6,10 +6,10 @@ module {
   func.func @permute(%arg0: tensor<1x4x32x64xf32>) -> tensor<4x32x64x1xf32> {
     %0 = tensor.empty() : tensor<4x32x64x1xf32>
     // CHECK: "ttnn.permute"
-    // CHECK-SAME: permutation = array<i32: 1, 2, 3, 0>
+    // CHECK-SAME: permutation = array<i64: 1, 2, 3, 0>
     // CHECK-SAME: tensor<1x4x32x64xf32
     // CHECK-SAME: tensor<4x32x64x1xf32
-    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i32: 1, 2, 3, 0>, operand_constraints = [#any_device, #any_device]}> : (tensor<1x4x32x64xf32>, tensor<4x32x64x1xf32>) -> tensor<4x32x64x1xf32>
+    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 1, 2, 3, 0>, operand_constraints = [#any_device, #any_device]}> : (tensor<1x4x32x64xf32>, tensor<4x32x64x1xf32>) -> tensor<4x32x64x1xf32>
     return %1 : tensor<4x32x64x1xf32>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/simple_permute.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_permute.mlir
@@ -1,7 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
 module {
   func.func @permute(%arg0: tensor<1x4x32x64xf32>) -> tensor<4x32x64x1xf32> {
     %0 = tensor.empty() : tensor<4x32x64x1xf32>
@@ -9,7 +8,7 @@ module {
     // CHECK-SAME: permutation = array<i64: 1, 2, 3, 0>
     // CHECK-SAME: tensor<1x4x32x64xf32
     // CHECK-SAME: tensor<4x32x64x1xf32
-    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 1, 2, 3, 0>, operand_constraints = [#any_device, #any_device]}> : (tensor<1x4x32x64xf32>, tensor<4x32x64x1xf32>) -> tensor<4x32x64x1xf32>
+    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 1, 2, 3, 0>}> : (tensor<1x4x32x64xf32>, tensor<4x32x64x1xf32>) -> tensor<4x32x64x1xf32>
     return %1 : tensor<4x32x64x1xf32>
   }
 }


### PR DESCRIPTION
Added support for PermuteOp, since it's already supported in [ttnn](https://docs.tenstorrent.com/tt-metal/latest/ttnn/ttnn/api/ttnn.permute.html#ttnn.permute).

`stablehlo.transpose` and `ttir.permute` have the same semantics, so decomposition of `stablehlo.transpose` into series of `ttir.transpose`es is not needed anymore.

Closes https://github.com/tenstorrent/tt-mlir/issues/652