### PR TITLE
Deleting the asserts preventing reshaping of more than 4D tensors

### DIFF
--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -338,11 +338,6 @@ mlir::tt::ttir::GetDimensionSizeOp::fold(FoldAdaptor adaptor) {
     return emitOpError("Shape attribute must be non-empty");
   }
 
-  // Check that the shape attribute has at most 5 elements
-  if (shape_size > 5) {
-    return emitOpError("Shape attribute must have at most 5 elements");
-  }
-
   // Cardinality of the input and output tensors must be the same
   if (inputType.getNumElements() != outputType.getNumElements()) {
     return emitOpError(

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -303,11 +303,6 @@ namespace mlir::tt::ttnn {
     return emitOpError("Shape attribute must be non-empty");
   }
 
-  // Check that the shape attribute has at most 5 elements
-  if (shape_size > 5) {
-    return emitOpError("Shape attribute must have at most 5 elements");
-  }
-
   // Cardinality of the input and output tensors must be the same
   if (inputType.getNumElements() != outputType.getNumElements()) {
     return emitOpError(


### PR DESCRIPTION
Previously, the ttnn reshape op did not support changing from or to shapes which had more than 4 dimensions, and we had asserts on the TT-IR side to check for this. The metal PR https://github.com/tenstorrent/tt-mlir/pull/1512 fixed this, and we can remove the asserts in question. 

Fixes issue https://github.com/tenstorrent/tt-mlir/issues/1344