### PR TITLE
Created Utils module + Pybound Loc Functionality

### DIFF
--- a/include/ttmlir/Bindings/Python/TTMLIRModule.h
+++ b/include/ttmlir/Bindings/Python/TTMLIRModule.h
@@ -62,6 +62,7 @@ void populateTTNNModule(py::module &m);
 void populateOverridesModule(py::module &m);
 void populateOptimizerOverridesModule(py::module &m);
 void populatePassesModule(py::module &m);
+void populateUtilModule(py::module &m);
 } // namespace mlir::ttmlir::python
 
 #endif // TTMLIR_BINDINGS_PYTHON_TTMLIRMODULE_H

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -75,6 +75,12 @@ declare_mlir_python_sources(TTMLIRPythonSources.Passes
   SOURCES passes.py
 )
 
+declare_mlir_python_sources(TTMLIRPythonSources.Util
+  ROOT_DIR "${TTMLIR_PYTHON_ROOT_DIR}"
+  ADD_TO_PARENT TTMLIRPythonSources
+  SOURCES util.py
+)
+
 declare_mlir_python_sources(TTMLIRPythonTestInfra.TestInfra
   ROOT_DIR "${TTMLIR_PYTHON_TEST_INFRA_ROOT_DIR}"
   ADD_TO_PARENT TTMLIRPythonTestInfra
@@ -95,6 +101,7 @@ declare_mlir_python_extension(TTMLIRPythonExtensions.Main
     Overrides.cpp
     OptimizerOverrides.cpp
     Passes.cpp
+    Util.cpp
   EMBED_CAPI_LINK_LIBS
     MLIRCAPITransforms
     TTMLIRCAPI

--- a/python/TTMLIRModule.cpp
+++ b/python/TTMLIRModule.cpp
@@ -43,4 +43,6 @@ PYBIND11_MODULE(_ttmlir, m) {
   auto optimizer_overrides = m.def_submodule(
       "optimizer_overrides", "Python-Bound Optimizer Overrides");
   mlir::ttmlir::python::populateOptimizerOverridesModule(optimizer_overrides);
+  auto util = m.def_submodule("util", "Python-Bound Utilities & Helpers");
+  mlir::ttmlir::python::populateUtilModule(util);
 }

--- a/python/Util.cpp
+++ b/python/Util.cpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Bindings/Python/TTMLIRModule.h"
+
+namespace mlir::ttmlir::python {
+
+void populateUtilModule(py::module &m) {
+  m.def("debug_print_module", [](MlirModule module) {
+    std::string source;
+    llvm::raw_string_ostream os(source);
+    mlir::OpPrintingFlags flags;
+    flags.enableDebugInfo(); // Enable the debug print
+    auto op = unwrap(mlirModuleGetOperation(module));
+    op->print(os, flags);
+    return source;
+  });
+
+  m.def("get_loc_name", [](MlirLocation _loc) -> std::string {
+    mlir::Location loc = unwrap(_loc);
+    if (mlir::isa<mlir::NameLoc>(loc)) {
+      mlir::NameLoc nameLoc = mlir::cast<mlir::NameLoc>(loc);
+      return nameLoc.getName().str();
+    }
+    return "-";
+  });
+
+  m.def("get_loc_full", [](MlirLocation _loc) -> std::string {
+    mlir::Location loc = unwrap(_loc);
+    if (mlir::isa<mlir::FileLineColLoc>(loc)) {
+      mlir::FileLineColLoc fileLoc = mlir::cast<mlir::FileLineColLoc>(loc);
+      return fileLoc.getFilename().str() + ":" +
+             std::to_string(fileLoc.getLine()) + ":" +
+             std::to_string(fileLoc.getColumn());
+    }
+    return "-";
+  });
+}
+
+} // namespace mlir::ttmlir::python

--- a/python/Util.cpp
+++ b/python/Util.cpp
@@ -12,7 +12,7 @@ void populateUtilModule(py::module &m) {
     llvm::raw_string_ostream os(source);
     mlir::OpPrintingFlags flags;
     flags.enableDebugInfo(); // Enable the debug print
-    auto op = unwrap(mlirModuleGetOperation(module));
+    auto *op = unwrap(mlirModuleGetOperation(module));
     op->print(os, flags);
     return source;
   });

--- a/python/ttmlir/util.py
+++ b/python/ttmlir/util.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from ._mlir_libs._ttmlir.util import *

--- a/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
@@ -7,20 +7,14 @@ from collections import defaultdict
 from model_explorer import graph_builder, node_data_builder
 
 from ttmlir.dialects import tt, ttnn, ttir
-from ttmlir import ir
+from ttmlir import ir, util
 
 
 def get_loc_str(loc):
     try:
-        # Constant loc( at the start of the location and ) at the end. Can just strip these characters
-        loc = str(loc)
-        if loc.startswith("loc(") and loc.endswith(")"):
-            # Fuzzy parse first string inside location
-            # 'loc("matmul_1"("MNISTLinear":4294967295:10))' -> matmul_1
-            # TODO(odjuricic) Need to have this pybinded.
-            res = re.search(r'"([^"]+)"', loc).group(1)
-        else:
-            res = loc  # This is a fallback to just visualize / see what the loc is if not processable.
+        res = util.get_loc_name(loc)
+        if res == "-":
+            res = util.get_loc_full(loc)
     except:
         res = "unknown"
     return res


### PR DESCRIPTION
- PR closes #1515 
- Creates a new `utils` module in `ttmlir` that provides utility functions
- Currently implemented
  - `utils.debug_print_module` Prints module with Debug flag active (prints locs + other data)
  - `utils.get_loc_name` Casts Loc to NameLoc if possible and returns the name
  - `utils.get_loc_full` Casts Loc to FileLineColLoc if possible and returns full FileLineCol str.
- New namespace parsing method: If module doesn't have location info (loc is `-`) then a full location is passed into the namespace, otherwise the name is used.