### PR TITLE
Removed Asserts in Python Bindings

### DIFF
--- a/python/TTModule.cpp
+++ b/python/TTModule.cpp
@@ -65,14 +65,17 @@ void populateTTModule(py::module &m) {
                 .withElementType(unwrap(ctx), unwrap(elementType));
           })
       .def("getLayout",
-           [](MlirType &type) {
-             assert(isa<RankedTensorType>(
-                 unwrap(type))); // Make sure that this is operating on a
-                                 // RankedTensorType object
+           [](MlirType &type) -> std::variant<tt::MetalLayoutAttr, py::object> {
+             // Make sure that this is operating on a RankedTensorType object
+             if (not isa<RankedTensorType>(unwrap(type))) {
+               return py::none();
+             }
              RankedTensorType tensor =
                  mlir::cast<RankedTensorType>(unwrap(type));
-             assert(tensor.getEncoding()); // Make sure that this Tensor has an
-                                           // encoding value
+             // Make sure that this Tensor has an encoding value
+             if (not tensor.getEncoding()) {
+               return py::none();
+             }
              tt::MetalLayoutAttr layout =
                  mlir::cast<tt::MetalLayoutAttr>(tensor.getEncoding());
              return layout;

--- a/python/TTNNModule.cpp
+++ b/python/TTNNModule.cpp
@@ -156,12 +156,14 @@ void populateTTNNModule(py::module &m) {
       .def_property_readonly(
           "memref",
           [](tt::ttnn::TTNNLayoutAttr self) { return wrap(self.getMemref()); })
-      .def_property_readonly(
-          "memory_layout_as_int", [](tt::ttnn::TTNNLayoutAttr self) {
-            if (!self.getMemLayout()) {
-              assert(false && "Memory layout is not set");
-            }
-            return static_cast<uint32_t>(self.getMemLayout().getValue());
-          });
+      .def_property_readonly("memory_layout_as_int",
+                             [](tt::ttnn::TTNNLayoutAttr self)
+                                 -> std::variant<uint32_t, py::object> {
+                               if (!self.getMemLayout()) {
+                                 return py::none();
+                               }
+                               return static_cast<uint32_t>(
+                                   self.getMemLayout().getValue());
+                             });
 }
 } // namespace mlir::ttmlir::python


### PR DESCRIPTION
- Asserts cause failure of a whole python module if set in C++, replaced asserts with `None` behaviour, type checking and error handling can now be handled in python instead of crashing whole module.