### PR TITLE
[Optimizer] L1 Interleaved policy that solves simple fork-joins with the extension of solving chains in parallel

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/BFInterleavedPolicy.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/BFInterleavedPolicy.h
@@ -31,33 +31,6 @@ public:
     uint64_t allocOfL1Mem;
   };
 
-  // This enum is used to determine the type of action required before
-  // scheduling the next op.
-  //
-  // MergeL1ChainConfigsOp: Requirement for op to be of this type is to have L1
-  //                        Interleaved output layout tensor. Action for this
-  //                        type of op is to merge all L1ChainConfigs of its
-  //                        operands and isert op's OpL1MemSpec in newly merged
-  //                        L1ChainConfig.
-  //
-  // NewL1ChainConfigOp:    Requirement for op to be of this type is to have L1
-  //                        Interleaved output layout tensor and non of its
-  //                        operands belong to any L1ChainConfig. Action for
-  //                        this type of op is to isert op's OpL1MemSpec in
-  //                        DisjointL1ChainConfigsUnion which will result in
-  //                        creating new L1ChainConfig.
-  //
-  // NoL1ChainConfigOp:     Requirement for op to be of this type is to either
-  //                        be non-analyzable or its output layout tensor to
-  //                        have DRAM buffer type. There are no action for this
-  //                        type of op.
-  //
-  enum class NextOpType {
-    MergeL1ChainConfigsOp,
-    NewL1ChainConfigOp,
-    NoL1ChainConfigOp
-  };
-
 public:
   BFInterleavedPolicy(
       Operation *rootOp, std::vector<L1ChainConfig> &l1ChainConfigs,

--- a/include/ttmlir/Dialect/TTNN/Analysis/BFInterleavedPolicy.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/BFInterleavedPolicy.h
@@ -5,7 +5,9 @@
 #ifndef TTMLIR_DIALECT_TTNN_ANALYSIS_BFINTERLEAVEDPOLICY_H
 #define TTMLIR_DIALECT_TTNN_ANALYSIS_BFINTERLEAVEDPOLICY_H
 
+#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
 #include "ttmlir/Dialect/TTNN/Analysis/MemoryLayoutAnalysisPolicy.h"
+#include <cstdint>
 
 namespace mlir::tt::ttnn {
 
@@ -21,6 +23,12 @@ public:
   struct OpL1MemUsage {
     uint64_t l1MemUsagePerUser;
     uint64_t numOfUnscheduledUsers;
+  };
+
+  // TODO(fbajraktari): Add struct description.
+  struct LookaheadResult {
+    Operation *destOp;
+    uint64_t allocOfL1Mem;
   };
 
   // This enum is used to determine the type of action required before
@@ -63,6 +71,8 @@ public:
   void run() final;
 
 private:
+  DeviceAttr deviceAttr;
+
   // Check if the op is analyzable. Op is analyzable if it has at least one
   // legal layout.
   bool isAnalyzable(Operation *op);
@@ -73,6 +83,11 @@ private:
   //
   void walkOnAnalyzableOperands(Operation *op,
                                 function_ref<void(Operation *)> callback);
+
+  // TODO(fbajraktari): Add method description.
+  LookaheadResult lookahead(
+      Operation *op,
+      const llvm::DenseMap<Operation *, OpL1MemUsage> &currentL1UsagePerOp);
 
   // Fetch op's DRAM layout from legalLayouts.
   bool hasDRAMBufferType(Operation *op);


### PR DESCRIPTION
Instead of analyzing greedily the next state based on only currently scheduleable ops, this extended version of the policy introduces the lookahead. It is only restricted to simple chains of ops (no fork nor join ops in the lookahead). This way, the policy will make a decision based on the larger picture of the graph and avoid falling into the non-global optimum. This is only true if we assume that the lookahead stops when 1) we reach fork or join node, or 2) forced to do DRAM spill due to the shortage of L1 memory.