### PR TITLE
TTIR constant materialization

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIRBase.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRBase.td
@@ -32,6 +32,8 @@ def TTIR_Dialect : Dialect {
       "::mlir::cf::ControlFlowDialect",
       "::mlir::tt::TTDialect"
     ];
+
+    let hasConstantMaterializer = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -901,34 +901,6 @@ public:
   }
 };
 
-// class GetDimensionSizeToConstantConversionPattern
-//     : public OpConversionPattern<ttir::GetDimensionSizeOp> {
-// public:
-//   using OpConversionPattern<ttir::GetDimensionSizeOp>::OpConversionPattern;
-
-//   LogicalResult
-//   matchAndRewrite(ttir::GetDimensionSizeOp op, OpAdaptor adaptor,
-//                   ConversionPatternRewriter &rewriter) const override {
-
-//     const RankedTensorType inputTensorType =
-//         mlir::cast<RankedTensorType>(op.getOperand().getType());
-
-//     int64_t dimensionIndex = op.getDimension();
-
-//     int32_t dimSize = inputTensorType.getShape()[dimensionIndex];
-
-//     mlir::ShapedType valueType = mlir::cast<mlir::ShapedType>(op.getType());
-
-//     mlir::ElementsAttr valueAttr =
-//         mlir::DenseElementsAttr::get<int>(valueType, dimSize);
-
-//     rewriter.replaceOpWithNewOp<mlir::tt::ttir::ConstantOp>(op, valueType,
-//                                                             valueAttr);
-
-//     return success();
-//   }
-// };
-
 // SelectOp is converted to a series of SliceOp and potentially a ConcatOp if
 // the sliced dimension is sliced multiple times. For example, if the input
 // tensor is
@@ -1179,7 +1151,6 @@ void populateTTIRToTTIRDecompositionPatterns(MLIRContext *ctx,
   patterns.add<IndexToSliceConversionPattern>(typeConverter, ctx);
   patterns.add<Legalize1DConvolutionPattern>(typeConverter, ctx);
   patterns.add<ConvolutionToConv2dPattern>(typeConverter, ctx);
-  // patterns.add<GetDimensionSizeToConstantConversionPattern>(typeConverter, ctx);
   patterns.add<GatherToEmbeddingConversionPattern>(typeConverter, ctx);
   patterns.add<SelectToSliceConversionPattern>(typeConverter, ctx);
   patterns.add<ArangeForceLastDimensionPattern>(typeConverter, ctx);

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -901,33 +901,33 @@ public:
   }
 };
 
-class GetDimensionSizeToConstantConversionPattern
-    : public OpConversionPattern<ttir::GetDimensionSizeOp> {
-public:
-  using OpConversionPattern<ttir::GetDimensionSizeOp>::OpConversionPattern;
+// class GetDimensionSizeToConstantConversionPattern
+//     : public OpConversionPattern<ttir::GetDimensionSizeOp> {
+// public:
+//   using OpConversionPattern<ttir::GetDimensionSizeOp>::OpConversionPattern;
 
-  LogicalResult
-  matchAndRewrite(ttir::GetDimensionSizeOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
+//   LogicalResult
+//   matchAndRewrite(ttir::GetDimensionSizeOp op, OpAdaptor adaptor,
+//                   ConversionPatternRewriter &rewriter) const override {
 
-    const RankedTensorType inputTensorType =
-        mlir::cast<RankedTensorType>(op.getOperand().getType());
+//     const RankedTensorType inputTensorType =
+//         mlir::cast<RankedTensorType>(op.getOperand().getType());
 
-    int64_t dimensionIndex = op.getDimension();
+//     int64_t dimensionIndex = op.getDimension();
 
-    int32_t dimSize = inputTensorType.getShape()[dimensionIndex];
+//     int32_t dimSize = inputTensorType.getShape()[dimensionIndex];
 
-    mlir::ShapedType valueType = mlir::cast<mlir::ShapedType>(op.getType());
+//     mlir::ShapedType valueType = mlir::cast<mlir::ShapedType>(op.getType());
 
-    mlir::ElementsAttr valueAttr =
-        mlir::DenseElementsAttr::get<int>(valueType, dimSize);
+//     mlir::ElementsAttr valueAttr =
+//         mlir::DenseElementsAttr::get<int>(valueType, dimSize);
 
-    rewriter.replaceOpWithNewOp<mlir::tt::ttir::ConstantOp>(op, valueType,
-                                                            valueAttr);
+//     rewriter.replaceOpWithNewOp<mlir::tt::ttir::ConstantOp>(op, valueType,
+//                                                             valueAttr);
 
-    return success();
-  }
-};
+//     return success();
+//   }
+// };
 
 // SelectOp is converted to a series of SliceOp and potentially a ConcatOp if
 // the sliced dimension is sliced multiple times. For example, if the input
@@ -1179,7 +1179,7 @@ void populateTTIRToTTIRDecompositionPatterns(MLIRContext *ctx,
   patterns.add<IndexToSliceConversionPattern>(typeConverter, ctx);
   patterns.add<Legalize1DConvolutionPattern>(typeConverter, ctx);
   patterns.add<ConvolutionToConv2dPattern>(typeConverter, ctx);
-  patterns.add<GetDimensionSizeToConstantConversionPattern>(typeConverter, ctx);
+  // patterns.add<GetDimensionSizeToConstantConversionPattern>(typeConverter, ctx);
   patterns.add<GatherToEmbeddingConversionPattern>(typeConverter, ctx);
   patterns.add<SelectToSliceConversionPattern>(typeConverter, ctx);
   patterns.add<ArangeForceLastDimensionPattern>(typeConverter, ctx);

--- a/lib/Dialect/TTIR/IR/TTIRDialect.cpp
+++ b/lib/Dialect/TTIR/IR/TTIRDialect.cpp
@@ -72,3 +72,16 @@ void TTIRDialect::initialize() {
 #include "ttmlir/Dialect/TTIR/IR/TTIROpsAttrs.cpp.inc"
       >();
 }
+
+//===----------------------------------------------------------------------===//
+// TTIR constant materializer.
+//===----------------------------------------------------------------------===//
+
+::mlir::Operation *TTIRDialect::materializeConstant(OpBuilder &builder,
+                                                    Attribute value, Type type,
+                                                    Location loc) {
+  if (auto elementsAttr = mlir::dyn_cast<mlir::ElementsAttr>(value)) {
+    return builder.create<ttir::ConstantOp>(loc, type, elementsAttr);
+  }
+  return {};
+}

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -92,28 +92,18 @@
 // GetDimensionSizeOp folder
 ::mlir::OpFoldResult
 mlir::tt::ttir::GetDimensionSizeOp::fold(FoldAdaptor adaptor) {
-
-  const RankedTensorType inputTensorType =
-      mlir::cast<RankedTensorType>(getOperand().getType());
-
-  int64_t dimensionIndex = getDimension();
-
-  if (dimensionIndex >=
-      static_cast<int64_t>(inputTensorType.getShape().size())) {
-    return nullptr;
-  };
-
+  RankedTensorType inputTensorType = getOperand().getType();
+  uint32_t dimensionIndex = getDimension();
   int32_t dimSize = inputTensorType.getShape()[dimensionIndex];
 
   mlir::ShapedType valueType = mlir::cast<mlir::ShapedType>(getType());
 
-  return mlir::DenseElementsAttr::get<int>(valueType, dimSize);
+  return mlir::DenseElementsAttr::get<int32_t>(valueType, dimSize);
 }
 
 // GetDimensionSizeOp verification
 ::mlir::LogicalResult mlir::tt::ttir::GetDimensionSizeOp::verify() {
-  const RankedTensorType inputTensorType =
-      mlir::cast<RankedTensorType>(getOperand().getType());
+  RankedTensorType inputTensorType = getOperand().getType();
 
   int64_t dimensionIndex = getDimension();
 
@@ -121,7 +111,7 @@ mlir::tt::ttir::GetDimensionSizeOp::fold(FoldAdaptor adaptor) {
       static_cast<int64_t>(inputTensorType.getShape().size())) {
     return failure();
   };
-
+  
   return success();
 }
 

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -96,9 +96,7 @@ mlir::tt::ttir::GetDimensionSizeOp::fold(FoldAdaptor adaptor) {
   uint32_t dimensionIndex = getDimension();
   int32_t dimSize = inputTensorType.getShape()[dimensionIndex];
 
-  mlir::ShapedType valueType = mlir::cast<mlir::ShapedType>(getType());
-
-  return mlir::DenseElementsAttr::get<int32_t>(valueType, dimSize);
+  return mlir::DenseElementsAttr::get<int32_t>(getType(), dimSize);
 }
 
 // GetDimensionSizeOp verification
@@ -111,7 +109,7 @@ mlir::tt::ttir::GetDimensionSizeOp::fold(FoldAdaptor adaptor) {
       static_cast<int64_t>(inputTensorType.getShape().size())) {
     return failure();
   };
-  
+
   return success();
 }
 

--- a/test/ttmlir/Dialect/TTIR/Decomposition/get_dimension_size_decomposition.mlir
+++ b/test/ttmlir/Dialect/TTIR/Decomposition/get_dimension_size_decomposition.mlir
@@ -1,0 +1,10 @@
+// RUN: ttmlir-opt --ttir-to-ttir-decomposition %s | FileCheck %s
+module  {
+  func.func @get_dimension_size_decomposition(%arg0: tensor<32x64x128xf32>) -> tensor<1xi32> {
+    // CHECK: [[VAL:%.+]] = "ttir.constant"
+    // CHECK-SAME: value = dense<128> : tensor<1xi32>
+    // CHECK: return [[VAL]] : tensor<1xi32>
+    %0 = "ttir.get_dimension_size"(%arg0) <{dimension = 2 : i32}> : (tensor<32x64x128xf32>) -> tensor<1xi32>
+    return %0 : tensor<1xi32>
+  }
+}


### PR DESCRIPTION
`ConstantOp` in the TTIR dialect has a `ConstantLike` trait so constants can be materialized into `ttir.constant` operation. We already have one use case, where `GetDimensionSizeOp` is folded into `Attribute`, so instead of decomposition, a folding into `Attribute` and materialization into `ConstantOp` takes a more natural approach.

For all future use cases of `FooOpToConstantOp` conversions, instead of implementing pattern rewriting, it's enough to fold `FooOp` into `mlir::ElementsAttr`.