### PR TITLE
Fix for ttir.arange decomposition

### DIFF
--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -267,7 +267,7 @@ protected:
   }
 };
 
-// A decompostion pattern that matches to a ttir.convolution op that does 1D
+// A decomposition pattern that matches to a ttir.convolution op that does 1D
 // convolution. Since that is not supported in ttnn, we reshape the inputs and
 // the output to match a 2D ttir.convolution op. The expectation is that the new
 // ttir.convolution op will be picked up by the ConvolutionToConv2dPattern and
@@ -1099,7 +1099,8 @@ public:
 
     int64_t arangeLength = (end - start) / step;
 
-    ArrayRef<int64_t> ttnnShape = {1, 1, 1, arangeLength};
+    const int64_t requiredShape[] = {1, 1, 1, arangeLength};
+    ArrayRef<int64_t> ttnnShape(&requiredShape[0], 4);
     if (ttnnShape == outputType.getShape()) {
       return success();
     }

--- a/test/ttmlir/Decomposition/TTIR/arange/arange_tests_positive.mlir
+++ b/test/ttmlir/Decomposition/TTIR/arange/arange_tests_positive.mlir
@@ -1,0 +1,19 @@
+// RUN: ttmlir-opt --ttir-to-ttir-decomposition %s | FileCheck %s
+#any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>
+module attributes {} {
+  func.func @forward(%arg0: tensor<1x32x128x128xf32>) -> tensor<1x32x128x128xf32> {
+    // CHECK: %[[ARANGE:[0-9]+]] = "ttir.arange"
+    // CHECK-SAME: {arange_dimension = 3 : i64, end = 32 : si64, start = 0 : si64, step = 1 : si64}
+    // CHECK-SAME: -> tensor<1x1x1x32xf32>
+    // CHECK: %[[TRANSPOSE:[0-9]+]] = "ttir.transpose"(%[[ARANGE]],
+    // CHECK-SAME: {dim0 = 1 : si32, dim1 = 3 : si32,
+    // CHECK-SAME: (tensor<1x1x1x32xf32>, tensor<1x32x1x1xf32>) -> tensor<1x32x1x1xf32>
+    // CHECK: %[[BROADCAST:[0-9]+]] = "ttir.broadcast"(%[[TRANSPOSE]],
+    // CHECK-SAME: {dimension = [2, 3]
+    // CHECK-SAME: (tensor<1x32x1x1xf32>, tensor<1x32x128x128xf32>) -> tensor<1x32x128x128xf32>
+    %1 = "ttir.arange"() <{start = 0: si64, end = 32: si64, step = 1: si64, arange_dimension = 1: i64}> : () -> tensor<1x32x128x128xf32>
+    %dps = tensor.empty() : tensor<1x32x128x128xf32>
+    %2 = "ttir.multiply"(%arg0, %1, %dps) <{operandSegmentSizes = array<i32: 2, 1>, operand_constraints = [#any_device, #any_device, #any_device]}> : (tensor<1x32x128x128xf32>, tensor<1x32x128x128xf32>, tensor<1x32x128x128xf32>) -> tensor<1x32x128x128xf32>
+    return %2 : tensor<1x32x128x128xf32>
+  }
+}


### PR DESCRIPTION
* ArrayRef is created with temporary array (rvalue) which is not available afterwards and causes address sanitizer error (stack-use-after-scope).

Fixes #1563 