### PR TITLE
ASAN build fixes for TTNNLayoutAttr class

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
@@ -165,7 +165,7 @@ def TTNN_TTNNLayoutAttr: TTNN_Attr<"TTNNLayout", "ttnn_layout"> {
     uint64_t getElementSizeBytes() const;
     int64_t getTensorSizeInBytes(ArrayRef<int64_t> tensorShape, ::mlir::tt::DeviceAttr device) const;
     llvm::SmallVector<int64_t> getStride(ArrayRef<int64_t> logicalShape) const;
-    llvm::SmallVector<int64_t> getShardShape() const;
+    llvm::ArrayRef<int64_t> getShardShape() const;
     llvm::SmallVector<int64_t> getScalarShardShape() const;
     AffineMap getIdentityTileLinearMap() const;
     llvm::SmallVector<int64_t> getTiledShape(ArrayRef<int64_t> logicalTensorShape) const;

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -77,7 +77,7 @@ public:
     // Create MemoryConfigAttr
     //
     auto device = ::ttnn::utils::getOrInsertDevice(rewriter, op);
-    llvm::SmallVector<int64_t> shardShape = layoutAttr.getShardShape();
+    llvm::ArrayRef<int64_t> shardShape = layoutAttr.getShardShape();
     ttnn::MemoryConfigAttr memoryConfigAttr = ttnn::MemoryConfigAttr::get(
         op.getContext(), ttnn::BufferTypeAttr::get(op.getContext(), bufferType),
         ttnn::ShardSpecAttr::get(
@@ -154,8 +154,7 @@ public:
 
     ttnn::LayoutAttr outputLayout =
         ttnn::LayoutAttr::get(rewriter.getContext(), outputLayoutEnum);
-    llvm::SmallVector<int64_t> outputShardShape =
-        outputLayoutAttr.getShardShape();
+    llvm::ArrayRef<int64_t> outputShardShape = outputLayoutAttr.getShardShape();
 
     ttnn::MemoryConfigAttr outputMemConfigAttr = ttnn::MemoryConfigAttr::get(
         rewriter.getContext(),
@@ -193,8 +192,7 @@ private:
     auto oldOutputLayoutAttr =
         mlir::cast<ttnn::TTNNLayoutAttr>(oldOutput.getEncoding());
     DataType outputDtype = oldOutputLayoutAttr.getDataType();
-    SmallVector<std::int64_t> oldShardShape =
-        oldOutputLayoutAttr.getShardShape();
+    ArrayRef<std::int64_t> oldShardShape = oldOutputLayoutAttr.getShardShape();
     size_t shardShapeSize = oldShardShape.size();
     assert(shardShapeSize >= 2 && "expected at least 2D shape");
 

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -582,7 +582,7 @@ static bool isValidDeviceLayout(TensorMemoryLayoutAttr memLayoutAttr) {
     if (not outputLayout.hasShardedL1TensorMemoryLayout()) {
       return emitOpError("Sharded tensors layout must reside in L1");
     }
-    ::llvm::SmallVector<int64_t> shardShape = outputLayout.getShardShape();
+    ::llvm::ArrayRef<int64_t> shardShape = outputLayout.getShardShape();
     // Currently TTNN backend only supports 2D shard shape
     if (shardShape.size() != 2) {
       return emitOpError("Shard shape must be 2D");

--- a/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp
@@ -180,8 +180,8 @@ uint64_t TTNNLayoutAttr::getElementSizeBytes() const {
 // Example: memref<2x3!tt.tile<32x32xf32>> -> { 2, 3 }
 //
 // return The shape of the shard.
-llvm::SmallVector<int64_t> TTNNLayoutAttr::getShardShape() const {
-  return SmallVector<int64_t>(getMemref().getShape());
+llvm::ArrayRef<int64_t> TTNNLayoutAttr::getShardShape() const {
+  return getMemref().getShape();
 }
 
 // Get scalar shard shape
@@ -249,7 +249,7 @@ TTNNLayoutAttr::getTiledShape(llvm::ArrayRef<int64_t> tensorShape) const {
 //
 // return The size of the shard in bytes.
 uint64_t TTNNLayoutAttr::getShardSizeInBytes() const {
-  SmallVector<int64_t> shape = getShardShape();
+  llvm::ArrayRef<int64_t> shape = getShardShape();
   uint64_t size = getElementSizeBytes();
   return std::accumulate(shape.begin(), shape.end(), size,
                          std::multiplies<uint64_t>());
@@ -277,7 +277,7 @@ mlir::AffineMap TTNNLayoutAttr::getIdentityTileLinearMap() const {
 // return New memory map with symbols replaced with shard shape.
 mlir::AffineMap TTNNLayoutAttr::replaceMemoryMapSymbolsWithShardShape(
     AffineMap physicalMemoryMap) const {
-  mlir::SmallVector<int64_t> shardShape = getShardShape();
+  llvm::ArrayRef<int64_t> shardShape = getShardShape();
   assert(physicalMemoryMap.getNumSymbols() == shardShape.size() &&
          "Physical memory map must have same number of symbols as logical "
          "shard rank");

--- a/lib/Dialect/TTNN/Transforms/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/Optimizer.cpp
@@ -460,7 +460,7 @@ private:
       TensorMemoryLayoutAttr outputTensorMemoryLayoutAttr =
           consumerOpOutputLayout.getMemLayout();
 
-      llvm::SmallVector<int64_t> shardShape =
+      llvm::ArrayRef<int64_t> shardShape =
           consumerOpOutputLayout.getShardShape();
       MemoryConfigAttr outputMemConfigAttr = MemoryConfigAttr::get(
           consumerOp->getContext(),


### PR DESCRIPTION
* TTNNLayoutAttr::getShardShape() uses llvm::ArrayRef to create llvm::SmallVector object and crashes for ASAN build due to non-owning nature of llvm::ArrayRef. This change uses llvm::ArrayRef directly to avoid address sanitization error.


fixes #1565 