### PR TITLE
ASAN fix of failing tests

### DIFF
--- a/lib/Dialect/TTNN/Transforms/Passes.cpp
+++ b/lib/Dialect/TTNN/Transforms/Passes.cpp
@@ -143,7 +143,7 @@ private:
     ttnn::Layout layoutEnum;
     DataType dataType;
     ttnn::TensorMemoryLayoutAttr tensorMemoryLayout;
-    llvm::ArrayRef<int64_t> shardShape;
+    llvm::SmallVector<int64_t> shardShape;
 
     ttnn::MemoryConfigAttr createMemoryConfigAttr(MLIRContext *context) const {
       return ttnn::MemoryConfigAttr::get(
@@ -233,7 +233,8 @@ private:
     output.tensorMemoryLayout = outputMemoryConfig.getTensorMemoryLayout();
 
     input.shardShape = inputLayoutAttr.getShardShape();
-    output.shardShape = outputMemoryConfig.getShardShapeArray();
+    output.shardShape =
+        llvm::SmallVector<int64_t>{outputMemoryConfig.getShardShapeArray()};
     return {input, output};
   }
 

--- a/lib/Dialect/TTNN/Utils/TransformUtils.cpp
+++ b/lib/Dialect/TTNN/Utils/TransformUtils.cpp
@@ -21,7 +21,7 @@ Value getOrInsertDevice(PatternRewriter &rewriter, Operation *op) {
   DeviceAttr deviceAttr = getCurrentScopeDevice(op);
   auto currentInsertionPoint = rewriter.saveInsertionPoint();
   rewriter.setInsertionPoint(block, block->begin());
-  auto meshShape = deviceAttr.getMeshShape();
+  llvm::SmallVector<int64_t> meshShape{deviceAttr.getMeshShape()};
   if (meshShape.empty()) {
     meshShape = llvm::SmallVector<int64_t, 2>{1, 1};
   }


### PR DESCRIPTION
This PR introduces some changes https://github.com/tenstorrent/tt-mlir/pull/1566, but it seems that it doesn't fix the majority of failing tests. Both bugs are a result of dangling references of `ArrayRef` objects, because they receive temporary `SmallVector` objects.

I've rebased this branch on https://github.com/tenstorrent/tt-mlir/pull/1562, for the ability to build with ASAN flag.
    
Fixes https://github.com/tenstorrent/tt-mlir/issues/1565