### PR TITLE
[Optimizer/Test] Add ability to pass in custom constraint check function.

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/ShardSolver.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/ShardSolver.h
@@ -287,7 +287,10 @@ public:
               const std::vector<OpL1MemSpec> &shardSpecs,
               const llvm::DenseSet<Operation *> &shardedOps,
               const unsigned usableL1CacheSize,
-              const std::unordered_set<Edge> &overrideReshardEdges);
+              const std::unordered_set<Edge> &overrideReshardEdges,
+              std::function<bool(mlir::Operation *, TTNNLayoutAttr const &,
+                                 mlir::Operation *, TTNNLayoutAttr const &)>
+                  customCheckShardCompatible = nullptr);
   RemainingLayoutAttrs at(Operation *operation) const;
   void set(Operation *operation, TTNNLayoutAttr const &layout);
   static bool supportsInterleavedInputShardedOutput(Operation *op);
@@ -310,6 +313,9 @@ private:
 
   llvm::DenseMap<Operation *, TTNNLayoutAttr> selectedOpLayout;
   std::unordered_set<Edge> memReconfigEdges;
+  std::function<bool(mlir::Operation *, TTNNLayoutAttr const &,
+                     mlir::Operation *, TTNNLayoutAttr const &)>
+      customCheckShardCompatible;
 };
 
 } // namespace mlir::tt::ttnn

--- a/test/unittests/Optimizer/TestShardSolver.cpp
+++ b/test/unittests/Optimizer/TestShardSolver.cpp
@@ -217,8 +217,26 @@ TEST_F(ShardSolverBase, VerifyProduceMaxCoreUsage) {
   addLayoutForOp(op, legalLayouts, BufferType::L1,
                  TensorMemoryLayout::BlockSharded, 1, 1);
 
+  // Create custom checkShardCompatible function.
+  //
+  std::function<bool(mlir::Operation *, TTNNLayoutAttr const &,
+                     mlir::Operation *, TTNNLayoutAttr const &)>
+      checkShardCompatible = [](mlir::Operation *producerOp,
+                                TTNNLayoutAttr const &producerLayout,
+                                mlir::Operation *consumerOp,
+                                TTNNLayoutAttr const &consumerLayout) {
+        // Simple shard compat assumption. Try to keep same shard layout.
+        //
+        if (producerLayout.getMemLayout() != consumerLayout.getMemLayout()) {
+          return false;
+        }
+
+        return true;
+      };
+
   ShardSolver shardSolver(legalLayouts, opL1MemSpecs, l1ChainedOps,
-                          usableL1CacheSize, overrideReshardEdges);
+                          usableL1CacheSize, overrideReshardEdges,
+                          checkShardCompatible);
 
   llvm::DenseMap<mlir::Operation *, llvm::SmallVector<float, 64>>
       accMaxCoreUsage = shardSolver.produceMaxCoreUsage();


### PR DESCRIPTION
Extend Shardsolver with support for passing in custom constraint check function. 
Integrate custom check function in unit tests so that they are not impacted with future implementation of proper E2E constraint check API.

Closes #1287.