### PR TITLE
Fix codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,5 +28,5 @@
 /test/ttmlir/Dialect/TTNN/optimizer/ @nobradovictt @odjuricicTT
 /test/ttmlir/Silicon/TTNN/optimizer/ @nobradovictt @odjuricicTT
 /test/unittests/Optimizer @nobradovictt @odjuricicTT
-/tools/explorer/ @odjuricicTT @nobradovictt @vprajapati-tt
 /tools/ @svuckovicTT @mtopalovicTT
+/tools/explorer/ @odjuricicTT @nobradovictt @vprajapati-tt


### PR DESCRIPTION
Every new line in CODEOWNERS overrides all previous owners so child directories must always come after parents.