### PR TITLE
Fix macos nightly build

### DIFF
--- a/test/ttmlir/Decomposition/TTIR/arange/arange_tests_positive.mlir
+++ b/test/ttmlir/Decomposition/TTIR/arange/arange_tests_positive.mlir
@@ -6,7 +6,7 @@ module attributes {} {
     // CHECK-SAME: {arange_dimension = 3 : i64, end = 32 : si64, start = 0 : si64, step = 1 : si64}
     // CHECK-SAME: -> tensor<1x1x1x32xf32>
     // CHECK: %[[TRANSPOSE:[0-9]+]] = "ttir.transpose"(%[[ARANGE]],
-    // CHECK-SAME: {dim0 = 1 : si32, dim1 = 3 : si32,
+    // CHECK-SAME: {dim0 = 1 : si32, dim1 = 3 : si32
     // CHECK-SAME: (tensor<1x1x1x32xf32>, tensor<1x32x1x1xf32>) -> tensor<1x32x1x1xf32>
     // CHECK: %[[BROADCAST:[0-9]+]] = "ttir.broadcast"(%[[TRANSPOSE]],
     // CHECK-SAME: {dimension = [2, 3]

--- a/test/unittests/Optimizer/CMakeLists.txt
+++ b/test/unittests/Optimizer/CMakeLists.txt
@@ -6,7 +6,6 @@ add_mlir_unittest(OptimizerTests
 
 target_link_libraries(OptimizerTests
     PRIVATE
-    MLIR
     MLIRTTDialect
     MLIRTTNNAnalysis
     MLIRTTNNPipelines


### PR DESCRIPTION
- Fix trailing comment that forms bad CHECK-SAME statement
- Don't link Optimizer tests against MLIR dylib