### PR TITLE
Fix ttnn-standalone build

### DIFF
--- a/tools/ttnn-standalone/CMakeLists.txt
+++ b/tools/ttnn-standalone/CMakeLists.txt
@@ -63,7 +63,7 @@ set(INCLUDE_DIRS
     $ENV{TT_METAL_HOME}
     $ENV{TT_METAL_HOME}/tt_metal
     $ENV{TT_METAL_HOME}/tt_metal/third_party/umd
-    $ENV{TT_METAL_HOME}/tt_metal/third_party/umd/device
+    $ENV{TT_METAL_HOME}/tt_metal/third_party/umd/device/api
     $ENV{TT_METAL_HOME}/tt_metal/third_party/fmt
     $ENV{TT_METAL_HOME}/tt_metal/hw/inc
     $ENV{TT_METAL_HOME}/tt_metal/hw/inc/${ARCH_NAME}


### PR DESCRIPTION
Path for device api in metal changed, updated ttnn-standalone's cmake file.