### PR TITLE
Add optimizer overrides to explorer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,4 +33,4 @@
 /test/unittests/Optimizer @odjuricicTT @tt-mpantic @sdjordjevicTT @nobradovictt
 /test/unittests/OpModel @odjuricicTT @tt-mpantic @sdjordjevicTT @nobradovictt
 /tools/ @svuckovicTT @mtopalovicTT
-/tools/explorer/ @odjuricicTT @tt-mpantic @sdjordjevicTT @nobradovictt @vprajapati-tt
+/tools/explorer/ @odjuricicTT @tt-mpantic @sdjordjevicTT @nobradovictt @vprajapati-tt @vcanicTT

--- a/include/ttmlir/Dialect/TTNN/Utils/OptimizerOverrides.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/OptimizerOverrides.h
@@ -76,9 +76,8 @@ public:
 
   // Wrapper methods we use to expose the adders to the python bindings
   void addInputLayoutOverridePybindWrapper(std::string, std::vector<int64_t> &);
-  void addOutputLayoutOverridePybindWrapper(std::string, std::vector<int64_t> &,
-                                            BufferType, TensorMemoryLayout,
-                                            tt::ttnn::Layout, tt::DataType);
+  void addOutputLayoutOverridePybindWrapper(std::string,
+                                            OutputLayoutOverrideParams);
 
 private:
   // Flags for enabling/disabling the optimizer passes

--- a/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
@@ -5,13 +5,10 @@
 #ifndef TTMLIR_DIALECT_TTNN_UTILS_PASSOVERRIDES_H
 #define TTMLIR_DIALECT_TTNN_UTILS_PASSOVERRIDES_H
 
-#include <string_view>
-
 #include <llvm/Support/CommandLine.h>
 
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
-#include "ttmlir/Dialect/TTNN/IR/TTNNOpsTypes.h"
 
 namespace mlir::tt::ttnn {
 
@@ -31,12 +28,12 @@ struct OptionNames {
 };
 
 struct OutputLayoutOverrideParams {
-  std::optional<SmallVector<int64_t, 2>> grid;
-  std::optional<BufferType> bufferType;
-  std::optional<TensorMemoryLayout>
-      tensorMemoryLayout;             // INTERLEAVED / SHARDED etc...
-  std::optional<Layout> memoryLayout; // ROW_MAJOR / TILE
-  std::optional<tt::DataType> dataType;
+  std::optional<SmallVector<int64_t, 2>> grid = std::nullopt;
+  std::optional<BufferType> bufferType = std::nullopt;
+  std::optional<TensorMemoryLayout> tensorMemoryLayout =
+      std::nullopt; // INTERLEAVED / SHARDED etc...
+  std::optional<Layout> memoryLayout = std::nullopt; // ROW_MAJOR / TILE
+  std::optional<tt::DataType> dataType = std::nullopt;
 
   // Check if all layout parameters that are generated in LegalLayoutAnalysis
   // are overridden. DataType is the only that is not.
@@ -45,7 +42,7 @@ struct OutputLayoutOverrideParams {
            tensorMemoryLayout.has_value() && memoryLayout.has_value();
   }
 
-  bool operator==(const OutputLayoutOverrideParams rhs) const {
+  bool operator==(const OutputLayoutOverrideParams &rhs) const {
     if (grid.has_value() != rhs.grid.has_value()) {
       return false;
     }

--- a/lib/Dialect/TTNN/Utils/OptimizerOverrides.cpp
+++ b/lib/Dialect/TTNN/Utils/OptimizerOverrides.cpp
@@ -22,6 +22,7 @@ void OptimizerOverridesHandler::setEnableMemoryLayoutAnalysisPolicy(
 }
 void OptimizerOverridesHandler::setMemoryLayoutAnalysisPolicy(
     MemoryLayoutAnalysisPolicyType value) {
+  enableMemoryLayoutAnalysisPolicy = true;
   memoryLayoutAnalysisPolicy = value;
 }
 
@@ -198,13 +199,9 @@ void OptimizerOverridesHandler::addInputLayoutOverridePybindWrapper(
 }
 
 void OptimizerOverridesHandler::addOutputLayoutOverridePybindWrapper(
-    std::string opName, std::vector<int64_t> &grid, BufferType bufferType,
-    TensorMemoryLayout tensorMemoryLayout, tt::ttnn::Layout memoryLayout,
-    tt::DataType dataType) {
+    std::string opName, OutputLayoutOverrideParams overrideParams) {
   StringRef opNameStringRef(opName);
-  SmallVector<int64_t> gridSmallVector(grid.begin(), grid.end());
-  addOutputLayoutOverride(opNameStringRef, gridSmallVector, bufferType,
-                          tensorMemoryLayout, memoryLayout, dataType);
+  addOutputLayoutOverride(opNameStringRef, overrideParams);
 }
 
 } // namespace mlir::tt::ttnn

--- a/python/OptimizerOverrides.cpp
+++ b/python/OptimizerOverrides.cpp
@@ -4,6 +4,7 @@
 
 #include "ttmlir/Dialect/TTNN/Utils/OptimizerOverrides.h"
 #include "ttmlir/Bindings/Python/TTMLIRModule.h"
+#include <optional>
 
 namespace mlir::ttmlir::python {
 
@@ -133,12 +134,20 @@ void populateOptimizerOverridesModule(py::module &m) {
           "grid",
           [](const mlir::tt::ttnn::OutputLayoutOverrideParams &obj) {
             // Getter: Convert SmallVector to std::vector
-            return std::vector<int64_t>(obj.grid->begin(), obj.grid->end());
+            if (obj.grid.has_value()) {
+              return std::make_optional<std::vector<int64_t>>(obj.grid->begin(),
+                                                              obj.grid->end());
+            }
+            return std::make_optional<std::vector<int64_t>>();
           },
           [](mlir::tt::ttnn::OutputLayoutOverrideParams &obj,
              const std::vector<int64_t> &input) {
             // Setter: Convert std::vector to SmallVector
-            obj.grid->clear();
+            if (!obj.grid.has_value()) {
+              obj.grid = SmallVector<int64_t, 2>();
+            } else {
+              obj.grid->clear();
+            }
             obj.grid->append(input.begin(), input.end());
           })
       .def_readwrite("buffer_type",
@@ -149,7 +158,45 @@ void populateOptimizerOverridesModule(py::module &m) {
       .def_readwrite("memory_layout",
                      &mlir::tt::ttnn::OutputLayoutOverrideParams::memoryLayout)
       .def_readwrite("data_type",
-                     &mlir::tt::ttnn::OutputLayoutOverrideParams::dataType);
+                     &mlir::tt::ttnn::OutputLayoutOverrideParams::dataType)
+      .def("set_buffer_type_from_str",
+           [](mlir::tt::ttnn::OutputLayoutOverrideParams &obj,
+              const std::string &value) {
+             if (auto bufferType = mlir::tt::ttnn::symbolizeBufferType(value)) {
+               obj.bufferType = bufferType;
+             } else {
+               throw std::invalid_argument("Invalid buffer type: " + value);
+             }
+           })
+      .def("set_tensor_memory_layout_from_str",
+           [](mlir::tt::ttnn::OutputLayoutOverrideParams &obj,
+              const std::string &value) {
+             if (auto tensorMemoryLayout =
+                     mlir::tt::ttnn::symbolizeTensorMemoryLayout(value)) {
+               obj.tensorMemoryLayout = tensorMemoryLayout;
+             } else {
+               throw std::invalid_argument("Invalid tensor memory layout: " +
+                                           value);
+             }
+           })
+      .def("set_memory_layout_from_str",
+           [](mlir::tt::ttnn::OutputLayoutOverrideParams &obj,
+              const std::string &value) {
+             if (auto memoryLayout = mlir::tt::ttnn::symbolizeLayout(value)) {
+               obj.memoryLayout = memoryLayout;
+             } else {
+               throw std::invalid_argument("Invalid memory layout: " + value);
+             }
+           })
+      .def("set_data_type_from_str",
+           [](mlir::tt::ttnn::OutputLayoutOverrideParams &obj,
+              const std::string &value) {
+             if (auto dataType = mlir::tt::DataTypeStringToEnum(value)) {
+               obj.dataType = dataType;
+             } else {
+               throw std::invalid_argument("Invalid data type: " + value);
+             }
+           });
 }
 
 } // namespace mlir::ttmlir::python

--- a/python/TTNNModule.cpp
+++ b/python/TTNNModule.cpp
@@ -173,7 +173,5 @@ void populateTTNNModule(py::module &m) {
                              [](tt::ttnn::TTNNLayoutAttr self) {
                                return static_cast<uint32_t>(self.getDataType());
                              });
-  // .def_property_readonly("data_type",
-  //                        &tt::ttnn::TTNNLayoutAttr::getDataType);
 }
 } // namespace mlir::ttmlir::python

--- a/python/TTNNModule.cpp
+++ b/python/TTNNModule.cpp
@@ -156,7 +156,7 @@ void populateTTNNModule(py::module &m) {
       .def_property_readonly(
           "memref",
           [](tt::ttnn::TTNNLayoutAttr self) { return wrap(self.getMemref()); })
-      .def_property_readonly("memory_layout_as_int",
+      .def_property_readonly("tensor_memory_layout_as_int",
                              [](tt::ttnn::TTNNLayoutAttr self)
                                  -> std::variant<uint32_t, py::object> {
                                if (!self.getMemLayout()) {
@@ -164,6 +164,16 @@ void populateTTNNModule(py::module &m) {
                                }
                                return static_cast<uint32_t>(
                                    self.getMemLayout().getValue());
+                             })
+      .def_property_readonly("memory_layout_as_int",
+                             [](tt::ttnn::TTNNLayoutAttr self) {
+                               return static_cast<uint32_t>(self.getLayout());
+                             })
+      .def_property_readonly("data_type_as_int",
+                             [](tt::ttnn::TTNNLayoutAttr self) {
+                               return static_cast<uint32_t>(self.getDataType());
                              });
+  // .def_property_readonly("data_type",
+  //                        &tt::ttnn::TTNNLayoutAttr::getDataType);
 }
 } // namespace mlir::ttmlir::python

--- a/python/Util.cpp
+++ b/python/Util.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Bindings/Python/TTMLIRModule.h"
+#include <pybind11/pytypes.h>
+#include <variant>
 
 namespace mlir::ttmlir::python {
 
@@ -17,25 +19,26 @@ void populateUtilModule(py::module &m) {
     return source;
   });
 
-  m.def("get_loc_name", [](MlirLocation _loc) -> std::string {
-    mlir::Location loc = unwrap(_loc);
-    if (mlir::isa<mlir::NameLoc>(loc)) {
-      mlir::NameLoc nameLoc = mlir::cast<mlir::NameLoc>(loc);
-      return nameLoc.getName().str();
-    }
-    return "-";
-  });
+  m.def("get_loc_name",
+        [](MlirLocation _loc) -> std::variant<std::string, py::object> {
+          mlir::Location loc = unwrap(_loc);
+          if (mlir::isa<mlir::NameLoc>(loc)) {
+            mlir::NameLoc nameLoc = mlir::cast<mlir::NameLoc>(loc);
+            return nameLoc.getName().str();
+          }
+          return py::none();
+        });
 
-  m.def("get_loc_full", [](MlirLocation _loc) -> std::string {
-    mlir::Location loc = unwrap(_loc);
-    if (mlir::isa<mlir::FileLineColLoc>(loc)) {
-      mlir::FileLineColLoc fileLoc = mlir::cast<mlir::FileLineColLoc>(loc);
-      return fileLoc.getFilename().str() + ":" +
-             std::to_string(fileLoc.getLine()) + ":" +
-             std::to_string(fileLoc.getColumn());
-    }
-    return "-";
-  });
+  m.def("get_loc_full",
+        [](MlirLocation _loc) -> std::variant<std::string, py::object> {
+          mlir::Location loc = unwrap(_loc);
+
+          std::string locationStr;
+          llvm::raw_string_ostream output(locationStr);
+          loc.print(output);
+
+          return locationStr;
+        });
 }
 
 } // namespace mlir::ttmlir::python

--- a/tools/explorer/CMakeLists.txt
+++ b/tools/explorer/CMakeLists.txt
@@ -3,7 +3,7 @@ include(ExternalProject)
 set(TT_EXPLORER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/run.py)
 set(TTMLIR_BUILD_BIN_DIR ${TTMLIR_BINARY_DIR}/bin)
 
-set(MODEL_EXPLORER_VERSION "ca884d5eb3291507e7f4e76776957e231b2d9b6d")
+set(MODEL_EXPLORER_VERSION "4ffe3f0c11969b8eb628e1309bcde1990bb470b7")
 ExternalProject_Add(
   model-explorer
   PREFIX ${CMAKE_CURRENT_SOURCE_DIR}/model-explorer

--- a/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
@@ -5,19 +5,10 @@
 import re
 from collections import defaultdict
 from model_explorer import graph_builder, node_data_builder
-import dataclasses
 
 from ttmlir.dialects import tt, ttnn, ttir
 from ttmlir import ir, util
-
-
-# TODO(odjuricic): Also change the KeyValue to support editable instead of this.
-def make_editable_kv(kv, editable):
-    obj = dataclasses.asdict(kv)
-    obj["editable"] = editable
-    return dataclasses.make_dataclass(
-        "KeyValue", ((k, type(v)) for k, v in obj.items())
-    )(**obj)
+from . import utils
 
 
 def parse_loc_string(loc_str):
@@ -408,7 +399,7 @@ def parse_ttnn_ttnn_layout(attr):
     memory_layout = layout.tensor_memory_layout_as_int
     if memory_layout is not None:
         result.append(
-            make_editable_kv(
+            utils.make_editable_kv(
                 graph_builder.KeyValue(
                     key="tensor_memory_layout",
                     value=str(ttnn.TensorMemoryLayout(memory_layout)),
@@ -420,7 +411,7 @@ def parse_ttnn_ttnn_layout(attr):
             )
         )
     result.append(
-        make_editable_kv(
+        utils.make_editable_kv(
             graph_builder.KeyValue(
                 key="grid_shape", value="x".join(map(str, layout.grid_attr.shape))
             ),
@@ -438,7 +429,7 @@ def parse_ttnn_ttnn_layout(attr):
     )
     buffer_attr = ttnn.ir.BufferTypeAttr.maybe_downcast(layout.memref.memory_space)
     result.append(
-        make_editable_kv(
+        utils.make_editable_kv(
             graph_builder.KeyValue(
                 key="buffer_type", value=str(ttnn.BufferType(buffer_attr.value))
             ),
@@ -450,7 +441,7 @@ def parse_ttnn_ttnn_layout(attr):
     )
 
     result.append(
-        make_editable_kv(
+        utils.make_editable_kv(
             graph_builder.KeyValue(
                 key="memory_layout",
                 value=str(ttnn.Layout(layout.memory_layout_as_int)),
@@ -463,7 +454,7 @@ def parse_ttnn_ttnn_layout(attr):
     )
 
     result.append(
-        make_editable_kv(
+        utils.make_editable_kv(
             graph_builder.KeyValue(
                 key="data_type",
                 value=str(tt.DataType(layout.data_type_as_int)),

--- a/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
@@ -5,19 +5,29 @@
 import re
 from collections import defaultdict
 from model_explorer import graph_builder, node_data_builder
+import dataclasses
 
 from ttmlir.dialects import tt, ttnn, ttir
 from ttmlir import ir, util
 
 
-def get_loc_str(loc):
-    try:
-        res = util.get_loc_name(loc)
-        if res == "-":
-            res = util.get_loc_full(loc)
-    except:
-        res = "unknown"
-    return res
+# TODO(odjuricic): Also change the KeyValue to support editable instead of this.
+def make_editable_kv(kv, editable):
+    obj = dataclasses.asdict(kv)
+    obj["editable"] = editable
+    return dataclasses.make_dataclass(
+        "KeyValue", ((k, type(v)) for k, v in obj.items())
+    )(**obj)
+
+
+def parse_loc_string(loc_str):
+    """
+    This can be replaced by ttmlir.ir.Module.parse, but requires some further wodo to extract the actual location object from the module.
+    """
+    match = re.match(r'^loc\("([^"]+)"', loc_str)
+    if match:
+        return match.group(1)
+    return None
 
 
 class AttrHandler:
@@ -395,29 +405,73 @@ def parse_ttnn_ttnn_layout(attr):
     layout = ttnn.ir.TTNNLayoutAttr.maybe_downcast(attr)
     result = []
     result.append(graph_builder.KeyValue(key="linear", value=str(layout.linear)))
-    memory_layout = layout.memory_layout_as_int
+    memory_layout = layout.tensor_memory_layout_as_int
     if memory_layout is not None:
         result.append(
-            graph_builder.KeyValue(
-                key="memory_layout",
-                value=str(ttnn.TensorMemoryLayout(memory_layout)),
+            make_editable_kv(
+                graph_builder.KeyValue(
+                    key="tensor_memory_layout",
+                    value=str(ttnn.TensorMemoryLayout(memory_layout)),
+                ),
+                editable={
+                    "input_type": "value_list",
+                    "options": [str(o) for o in ttnn.TensorMemoryLayout],
+                },
             )
         )
     result.append(
-        graph_builder.KeyValue(
-            key="grid_shape", value="x".join(map(str, layout.grid_attr.shape))
+        make_editable_kv(
+            graph_builder.KeyValue(
+                key="grid_shape", value="x".join(map(str, layout.grid_attr.shape))
+            ),
+            editable={
+                "input_type": "grid",
+                "separator": "x",
+                "min_value": 1,
+                "max_value": 100,
+                "step": 1,
+            },
         )
     )
     result.append(
         graph_builder.KeyValue(key="memref_shape", value=str(layout.memref.shape))
     )
-    result.append(
-        graph_builder.KeyValue(key="memref_rank", value=str(layout.memref.rank))
-    )
     buffer_attr = ttnn.ir.BufferTypeAttr.maybe_downcast(layout.memref.memory_space)
     result.append(
-        graph_builder.KeyValue(
-            key="memref_memory_space", value=str(ttnn.BufferType(buffer_attr.value))
+        make_editable_kv(
+            graph_builder.KeyValue(
+                key="buffer_type", value=str(ttnn.BufferType(buffer_attr.value))
+            ),
+            editable={
+                "input_type": "value_list",
+                "options": [str(o) for o in ttnn.BufferType],
+            },
+        )
+    )
+
+    result.append(
+        make_editable_kv(
+            graph_builder.KeyValue(
+                key="memory_layout",
+                value=str(ttnn.Layout(layout.memory_layout_as_int)),
+            ),
+            editable={
+                "input_type": "value_list",
+                "options": [str(o) for o in ttnn.Layout],
+            },
+        )
+    )
+
+    result.append(
+        make_editable_kv(
+            graph_builder.KeyValue(
+                key="data_type",
+                value=str(tt.DataType(layout.data_type_as_int)),
+            ),
+            editable={
+                "input_type": "value_list",
+                "options": [str(o) for o in tt.DataType],
+            },
         )
     )
     return result
@@ -429,11 +483,12 @@ class OpHandler:
 
     def __init__(self, op):
         self.op = op
-        self.location = get_loc_str(self.op.location)
+        self.named_location = util.get_loc_name(self.op.location)
+        self.full_location = util.get_loc_full(self.op.location)
         self.id = self._create_unique_id()
 
     def _create_unique_id(self):
-        name = self.location
+        name = self.full_location if self.full_location else "unknown"
         name_num = self.name_dict[name]
         id = name + "__" + str(name_num)
         self.name_dict[name] += 1
@@ -441,16 +496,60 @@ class OpHandler:
 
     def get_namespace(self, parent_op=None):
         op = self.op if not parent_op else parent_op
-        name = get_loc_str(op.location)
+        name = util.get_loc_name(op.location)
         if op.parent and op.parent.name != "builtin.module":
-            return self.get_namespace(op.parent) + "/" + name
-        return name
+            parent_name = self.get_namespace(op.parent)
+            if parent_name:
+                return parent_name + "/" + name
+        return name or ""
 
     def get_attributes(self):
         # Parse Op Attributes themselves
         result = []
         for attr in self.op.attributes:
             result.extend(AttrHandler.parse_attr(attr))
+
+        # Add location as an attribute
+        if self.named_location:
+            result.append(
+                graph_builder.KeyValue(key="named_location", value=self.named_location)
+            )
+        if self.full_location:
+            result.append(
+                graph_builder.KeyValue(key="full_location", value=self.full_location)
+            )
+
+        # Add output tensor attriributes to the op itself
+        if self.op.results:
+            output_tensor = self.op.result
+            output_attrs = []
+            if isinstance(output_tensor.type, ir.RankedTensorType):
+                output_attrs = [
+                    graph_builder.KeyValue(
+                        key="shape", value=str(output_tensor.type.shape)
+                    ),
+                    graph_builder.KeyValue(
+                        key="dtype", value=str(output_tensor.type.element_type)
+                    ),
+                    graph_builder.KeyValue(
+                        key="rank", value=str(output_tensor.type.rank)
+                    ),
+                ]
+            if hasattr(output_tensor.type, "encoding") and output_tensor.type.encoding:
+                if "ttnn_layout" in str(output_tensor.type.encoding):
+                    output_attrs.extend(
+                        AttrHandler.parse_attr(
+                            output_tensor.type.encoding.get_named("ttnn_layout")
+                        )
+                    )
+                else:
+                    # Parse as a standard layout
+                    output_attrs.extend(
+                        AttrHandler.parse_attr(
+                            output_tensor.type.encoding.get_named("tt.layout")
+                        )
+                    )
+            result.extend(output_attrs)
         return result
 
     def make_graph_node(self):
@@ -477,6 +576,7 @@ EMPTY_OPS = [
 FILTERED_OPS = [
     "ttnn.deallocate",
     "ttnn.get_device",
+    *EMPTY_OPS,
 ]
 
 
@@ -491,9 +591,10 @@ def build_graph(module, perf_trace=None):
     loc_to_perf = {}
     if perf_trace is not None:
         for _, row in perf_trace.iterrows():
-            loc = get_loc_str(row["LOC"])
+            loc = parse_loc_string(row["LOC"])
             assert loc not in loc_to_perf
-            loc_to_perf[loc] = row["DEVICE FW DURATION [ns]"]
+            if loc:
+                loc_to_perf[loc] = row["DEVICE FW DURATION [ns]"]
 
     module_op = OpHandler(module.operation)
     module_attrs = module_op.get_attributes()
@@ -511,12 +612,15 @@ def build_graph(module, perf_trace=None):
                     operation = OpHandler(op)
                     graph_node = operation.make_graph_node()
 
-                    if operation.location in loc_to_perf:
+                    if (
+                        operation.named_location in loc_to_perf
+                        and operation.op.name not in EMPTY_OPS
+                    ):
                         perf_node_data[operation.id] = node_data_builder.NodeDataResult(
-                            loc_to_perf[operation.location]
+                            loc_to_perf[operation.named_location]
                         )
 
-                    if op.name in EMPTY_OPS:
+                    if op.name not in FILTERED_OPS and op.name in EMPTY_OPS:
                         append_later.append(graph_node)
                     elif op.name not in FILTERED_OPS:
                         graph.nodes.append(graph_node)

--- a/tools/explorer/tt_adapter/src/tt_adapter/runner.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/runner.py
@@ -19,24 +19,40 @@ class ExplorerRunException(Exception):
     pass
 
 
+class ModelState:
+    """
+    After a model is compiled and executed we keep track of all additional data that was created.
+    """
+
+    # Path to the compiled TTNN IR file.
+    optimized_model_path = None
+    # Path to the output directory where ttrt dumps all model files (perf trace, memory state, etc)
+    model_output_dir = None
+    # Overrides, changes that the user made to op configurations.
+    overrides = None
+
+
 class ModelRunner:
     """
     ModelRunner is a singleton class used for compilation and running of models. Ensuring only one can be run at a time.
     This is necessary because the adaptor class is reinitialized on every request from the frontend, so it cannot keep state.
     """
 
+    # Global static runner state. Initialized once.
     _instance = None
     _explorer_artifacts_dir = None
     _build_dir = None
 
-    # State variables.
+    # Singleton runner state. Initialized on every run.
     runner_thread = None
     runner_error = None
+    log_queue = queue.Queue()
     # progress should be a number between 0 and 100.
     progress = 0
-    log_queue = queue.Queue()
-    optimized_model_path = None
-    ttrt_output_dir = None
+
+    # State for models that have been executed.
+    # Contains a mapping from model path to ModelState.
+    model_state = dict()
 
     def __new__(cls, *args, **kwargs):
         if not cls._instance:
@@ -70,17 +86,27 @@ class ModelRunner:
 
         print("ModelRunner initialized.")
 
-    def get_optimized_model_path(self):
-        return self.optimized_model_path
+    def get_optimized_model_path(self, model_path):
+        if model_path in self.model_state:
+            return self.model_state[model_path].optimized_model_path
+        return None
 
-    def get_output_dir(self):
-        return self.ttrt_output_dir
+    def get_output_dir(self, model_path):
+        return self.model_state[model_path].model_output_dir
+
+    def get_overrides(self, model_path):
+        if model_path in self.model_state:
+            return self.model_state[model_path].overrides
+        return None
 
     def get_error(self):
         return self.runner_error
 
     def get_progress(self):
         return self.progress
+
+    def get_artifacts_dir(self):
+        return self._explorer_artifacts_dir
 
     def is_busy(self):
         return self.runner_thread and self.runner_thread.is_alive()
@@ -91,28 +117,31 @@ class ModelRunner:
             logs.append(self.log_queue.get())
         return "\n".join(logs)
 
-    def reset_state(self):
+    def reset_state(self, model_path):
         assert not self.is_busy()
         self.runner_thread = None
-        self.log_queue.queue.clear()
-        self.optimized_model_path = None
         self.runner_error = None
         self.progress = 0
-        self.ttrt_output_dir = None
+        self.log_queue.queue.clear()
+
+        if model_path in self.model_state:
+            del self.model_state[model_path]
 
     def log(self, message):
         print(message)
         self.log_queue.put(message)
 
-    def get_perf_trace(self):
-        op_perf_file = f"{self.ttrt_output_dir}/perf/ops_perf_results.csv"
+    def get_perf_trace(self, model_path):
+        op_perf_file = (
+            f"{self.model_state[model_path].model_output_dir}/perf/ops_perf_results.csv"
+        )
         if not os.path.exists(op_perf_file):
             raise FileNotFoundError(f"Performance file {op_perf_file} not found.")
 
         return pd.read_csv(op_perf_file)
 
     def run_in_subprocess(self, command):
-        self.log(f"Running command:\n{''.join(command)}\n")
+        self.log(f"Running command:\n{' '.join(command)}\n")
 
         process = subprocess.Popen(
             command,
@@ -145,22 +174,24 @@ class ModelRunner:
     def compile_and_run(self, model_path, overrides_string):
         model_name = os.path.basename(model_path)
         flatbuffer_file = model_name + ".ttnn"
-        self.ttrt_output_dir = self._explorer_artifacts_dir + "/" + flatbuffer_file
+        state = self.model_state[model_path]
 
-        if os.path.exists(self.ttrt_output_dir):
+        state.model_output_dir = self._explorer_artifacts_dir + "/" + flatbuffer_file
+
+        if os.path.exists(state.model_output_dir):
             self.log("Removing artifacts of previous run.")
-            os.system(f"rm -rf {self.ttrt_output_dir}")
+            os.system(f"rm -rf {state.model_output_dir}")
 
-        os.makedirs(self.ttrt_output_dir)
+        os.makedirs(state.model_output_dir)
         # Copy the model to the run directory.
-        os.system(f"cp {model_path} {self.ttrt_output_dir}")
+        os.system(f"cp {model_path} {state.model_output_dir}")
 
         self.progress = 10
 
         ############################### Compile ##################################
 
         ttnn_ir_file = (
-            f"{self.ttrt_output_dir}/{model_name.replace('.mlir', '_ttnn.mlir')}"
+            f"{state.model_output_dir}/{model_name.replace('.mlir', '_ttnn.mlir')}"
         )
         compile_command = [
             f"{self._build_dir}/bin/ttmlir-opt",
@@ -215,7 +246,7 @@ class ModelRunner:
             self.log(error)
             raise ExplorerRunException(error)
 
-        perf = self.get_perf_trace()
+        perf = self.get_perf_trace(model_path)
         columns = [
             "GLOBAL CALL COUNT",
             "OP CODE",
@@ -229,32 +260,21 @@ class ModelRunner:
 
         print("Total device duration: ", perf["DEVICE FW DURATION [ns]"].sum(), "ns")
 
-        self.optimized_model_path = ttnn_ir_file
+        state.optimized_model_path = ttnn_ir_file
         self.progress = 100
 
-    def run(
-        self, model_path, memory_layout_analysis_enabled, memory_layout_analysis_policy
-    ):
+    def run(self, model_path, compile_options, overrides):
         # Check if a run is already in progress
         if self.is_busy():
             raise RuntimeError(
                 "A model is already being processed. Please wait for it to finish."
             )
-        self.reset_state()
-
-        options = [
-            f'system-desc-path={f"{self._explorer_artifacts_dir}/system_desc.ttsys"}',
-            "enable-optimizer=true",
-            f"memory-layout-analysis-enabled={memory_layout_analysis_enabled}",
-        ]
-        if memory_layout_analysis_policy:
-            options.append(
-                f"memory-layout-analysis-policy={memory_layout_analysis_policy}"
-            )
-        options_string = " ".join(options)
+        self.reset_state(model_path)
+        self.model_state[model_path] = ModelState()
+        self.model_state[model_path].overrides = overrides
 
         # Start compile and run in a new thread
         self.runner_thread = threading.Thread(
-            target=self.compile_and_run_wrapper, args=(model_path, options_string)
+            target=self.compile_and_run_wrapper, args=(model_path, compile_options)
         )
         self.runner_thread.start()

--- a/tools/explorer/tt_adapter/src/tt_adapter/utils.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/utils.py
@@ -30,3 +30,10 @@ def add_to_dataclass(dataclass, new_attr_name: str, new_attr_value):
 def to_adapter_format(*objs):
     res = [x if is_dataclass(x) else to_dataclass(x) for x in objs]
     return {"graphs": res}
+
+
+# TODO(odjuricic): Better way would be to change KeyValue class to support editable instead.
+def make_editable_kv(kv, editable):
+    obj = asdict(kv)
+    obj["editable"] = editable
+    return make_dataclass("KeyValue", ((k, type(v)) for k, v in obj.items()))(**obj)


### PR DESCRIPTION
TT-explorer now supports editing output tensor layout of ops from the UI.

Changes made:
* Create editable fields for op output layout instead of readonly attributes.
* Keep perf trace as state for every executed model on the backend
* Clean up location parsing logic
* Fix a few bugs in override parsing / handling

Closes #1178 