### PR TITLE
Use GH_TOKEN to trigger workflow

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -19,9 +19,9 @@ jobs:
   # When a PR runs on the uplift branch trigger the downstream checks
   downstream-checks:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.ref == 'uplift'
+    # if: github.event.pull_request.head.ref == 'uplift'
     env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
     steps:
       - name: Trigger tt-forge-fe
         shell: bash

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -36,4 +36,4 @@ jobs:
             --field mlir_override=${{ github.sha }}
           gh run list --workflow=${{ env.WORKFLOW_NAME }} --repo ${{ env.TARGET_REPO }} --limit 1
           echo "Triggered ${{ env.TARGET_REPO }}"
-          echo "### Triggered [${{ env.TARGET_REPO }}] (https://github.com/${{ env.TARGET_REPO }}/actions/workflows/${{ env.WORKFLOW_NAME }}) :rocket:" >> $GITHUB_STEP_SUMMARY
+          echo "### Triggered [${{ env.TARGET_REPO }}](https://github.com/${{ env.TARGET_REPO }}/actions/workflows/${{ env.WORKFLOW_NAME }}) :rocket:" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -12,22 +12,28 @@ jobs:
   spdx:
     uses: ./.github/workflows/spdx.yml
     secrets: inherit
-  build-and-test:
-    uses: ./.github/workflows/build-and-test.yml
-    secrets: inherit
+  # build-and-test:
+  #   uses: ./.github/workflows/build-and-test.yml
+  #   secrets: inherit
 
   # When a PR runs on the uplift branch trigger the downstream checks
   downstream-checks:
     runs-on: ubuntu-latest
+    needs: pre-commit
+    # needs: build-and-test
     # if: github.event.pull_request.head.ref == 'uplift'
     env:
         GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        TARGET_REPO: tenstorrent/tt-forge-fe
+        WORKFLOW_NAME: build-and-test.yml
     steps:
-      - name: Trigger tt-forge-fe
+      - name: Trigger ${{ env.TARGET_REPO }}
         shell: bash
         run: |
-          gh workflow run build-and-test.yml \
-            --repo tenstorrent/tt-forge-fe --ref main \
+          gh workflow run ${{ env.WORKFLOW_NAME }} \
+            --repo ${{ env.TARGET_REPO }} --ref main \
             --field test_mark=push \
             --field mlir_override=${{ github.sha }}
-          gh run list --workflow=build-and-test.yml --repo tenstorrent/tt-forge-fe --limit 1
+          gh run list --workflow=${{ env.WORKFLOW_NAME }} --repo ${{ env.TARGET_REPO }} --limit 1
+          echo "Triggered ${{ env.TARGET_REPO }}"
+          echo "### Triggered [${{ env.TARGET_REPO }}] (https://github.com/${{ env.TARGET_REPO }}/actions/workflows/${{ env.WORKFLOW_NAME }}) :rocket:" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -12,16 +12,15 @@ jobs:
   spdx:
     uses: ./.github/workflows/spdx.yml
     secrets: inherit
-  # build-and-test:
-  #   uses: ./.github/workflows/build-and-test.yml
-  #   secrets: inherit
+  build-and-test:
+    uses: ./.github/workflows/build-and-test.yml
+    secrets: inherit
 
   # When a PR runs on the uplift branch trigger the downstream checks
   downstream-checks:
     runs-on: ubuntu-latest
-    needs: pre-commit
-    # needs: build-and-test
-    # if: github.event.pull_request.head.ref == 'uplift'
+    needs: build-and-test
+    if: github.event.pull_request.head.ref == 'uplift'
     env:
         GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         TARGET_REPO: tenstorrent/tt-forge-fe


### PR DESCRIPTION
Use PAT token GH_TOKEN to trigger workflow in downstream project
- use GH_TOKEN
- wait for build-and-test to finish
- move parameters to env
- print step summary