### PR TITLE
Runtime cleanup: Remove legacy submit API, update includes

### DIFF
--- a/runtime/include/tt/runtime/detail/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn.h
@@ -118,19 +118,6 @@ Tensor getOpOutputTensor(OpContext opContextHandle,
 
 std::vector<float> getTensorData(Tensor tensor);
 
-namespace legacy {
-/* Will be deprecated soon once FEs migrate to new API */
-
-Event submit(Device deviceHandle, Binary executableHandle,
-             std::uint32_t programIndex, std::vector<Tensor> const &inputs,
-             std::vector<Tensor> const &outputs);
-
-void runProgram(::ttnn::MeshDevice &meshDevice, Binary &executableHandle,
-                std::uint32_t programIndex,
-                std::vector<::ttnn::Tensor *> const &inputs,
-                std::vector<::ttnn::Tensor *> const &outputs);
-} // namespace legacy
-
 std::vector<Tensor> submit(Device deviceHandle, Binary executableHandle,
                            std::uint32_t programIndex,
                            std::vector<Tensor> const &inputs);

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -456,11 +456,8 @@ Event submit(Device deviceHandle, Binary executableHandle,
              std::vector<Tensor> const &outputHandles) {
 #if defined(TT_RUNTIME_ENABLE_TTNN)
   if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    LOG_WARNING("This submit API will soon be deprecated. Please switch to the "
-                "new API.");
-    return ::tt::runtime::ttnn::legacy::submit(deviceHandle, executableHandle,
-                                               programIndex, inputHandles,
-                                               outputHandles);
+    LOG_FATAL("This submit API is deprecated for TTNN. Please switch to the "
+              "new API.");
   }
 #endif
 

--- a/runtime/lib/ttnn/CMakeLists.txt
+++ b/runtime/lib/ttnn/CMakeLists.txt
@@ -24,6 +24,9 @@ add_library(TTRuntimeTTNN
 )
 # We have to set the C++ standard to 20 because tt-metal requires it
 set_property(TARGET TTRuntimeTTNN PROPERTY CXX_STANDARD 20)
+target_include_directories(TTRuntimeTTNN PRIVATE
+  ${PROJECT_SOURCE_DIR}/runtime/lib/ttnn
+)
 target_include_directories(TTRuntimeTTNN PUBLIC
   ${PROJECT_SOURCE_DIR}/runtime/include
   ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common

--- a/runtime/lib/ttnn/operations/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/CMakeLists.txt
@@ -44,6 +44,9 @@ add_library(TTRuntimeTTNNOps
 
 set_property(TARGET TTRuntimeTTNNOps PROPERTY CXX_STANDARD 20)
 target_compile_options(TTRuntimeTTNNOps PUBLIC -mavx -mavx2 -fsized-deallocation)
+target_include_directories(TTRuntimeTTNNOps PRIVATE
+  ${PROJECT_SOURCE_DIR}/runtime/lib/ttnn
+)
 target_include_directories(TTRuntimeTTNNOps PUBLIC
   ${PROJECT_SOURCE_DIR}/runtime/include
   ${PROJECT_SOURCE_DIR}/runtime/lib/ttnn/include

--- a/runtime/lib/ttnn/operations/ccl/all_gather.cpp
+++ b/runtime/lib/ttnn/operations/ccl/all_gather.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "all_gather.h"
+#include "operations/ccl/all_gather.h"
 #include "tt/runtime/detail/ttnn.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"

--- a/runtime/lib/ttnn/operations/context/get_device.cpp
+++ b/runtime/lib/ttnn/operations/context/get_device.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "get_device.h"
+#include "operations/context/get_device.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
 #include "tt/runtime/ttnn/operations/utils.h"

--- a/runtime/lib/ttnn/operations/conv/conv2d.cpp
+++ b/runtime/lib/ttnn/operations/conv/conv2d.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "conv2d.h"
+#include "operations/conv/conv2d.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
 #include "tt/runtime/ttnn/operations/utils.h"

--- a/runtime/lib/ttnn/operations/creation/arange.cpp
+++ b/runtime/lib/ttnn/operations/creation/arange.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "arange.h"
+#include "operations/creation/arange.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"

--- a/runtime/lib/ttnn/operations/creation/empty.cpp
+++ b/runtime/lib/ttnn/operations/creation/empty.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "empty.h"
+#include "operations/creation/empty.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
 #include "tt/runtime/detail/workarounds.h"

--- a/runtime/lib/ttnn/operations/creation/full.cpp
+++ b/runtime/lib/ttnn/operations/creation/full.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "full.h"
+#include "operations/creation/full.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
 #include "tt/runtime/detail/workarounds.h"

--- a/runtime/lib/ttnn/operations/creation/ones.cpp
+++ b/runtime/lib/ttnn/operations/creation/ones.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ones.h"
+#include "operations/creation/ones.h"
 
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/ttnn/operations/utils.h"
@@ -38,9 +38,9 @@ void run(const ::tt::target::ttnn::OnesOp *op, ProgramContext &context) {
   if (op->device()) {
     DeviceVariant targetDevice =
         context.getTargetDevice(op->device()->global_id());
-    assert(std::holds_alternative<std::reference_wrapper<::ttnn::Device>>(
-               targetDevice) &&
-           "ttnn::ones does not support MeshDevice.");
+    LOG_ASSERT(std::holds_alternative<std::reference_wrapper<::ttnn::Device>>(
+                   targetDevice),
+               "ttnn::ones does not support MeshDevice.");
     device = std::get<std::reference_wrapper<::ttnn::Device>>(targetDevice);
   }
 

--- a/runtime/lib/ttnn/operations/data_movement/concat.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/concat.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "concat.h"
+#include "operations/data_movement/concat.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
 

--- a/runtime/lib/ttnn/operations/data_movement/reshape.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/reshape.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "reshape.h"
+#include "operations/data_movement/reshape.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
 

--- a/runtime/lib/ttnn/operations/data_movement/slice.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/slice.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "slice.h"
+#include "operations/data_movement/slice.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
 #include "ttmlir/Target/TTNN/program_generated.h"

--- a/runtime/lib/ttnn/operations/data_movement/transpose.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/transpose.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "transpose.h"
+#include "operations/data_movement/transpose.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
 #include "tt/runtime/ttnn/operations/utils.h"

--- a/runtime/lib/ttnn/operations/deletion/deallocate.cpp
+++ b/runtime/lib/ttnn/operations/deletion/deallocate.cpp
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
-#include "deallocate.h"
+#include "operations/deletion/deallocate.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
 

--- a/runtime/lib/ttnn/operations/eltwise/binary/binary.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/binary/binary.cpp
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
-#include "binary.h"
+#include "operations/eltwise/binary/binary.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
 #include "tt/runtime/ttnn/operations/eltwise/binary/utils.h"

--- a/runtime/lib/ttnn/operations/eltwise/binary/binary_composite.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/binary/binary_composite.cpp
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
-#include "binary_composite.h"
+#include "operations/eltwise/binary/binary_composite.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
 #include "tt/runtime/ttnn/operations/eltwise/binary/utils.h"

--- a/runtime/lib/ttnn/operations/eltwise/ternary/ternary.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/ternary/ternary.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ternary.h"
+#include "operations/eltwise/ternary/ternary.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
 #include "tt/runtime/ttnn/operations/eltwise/ternary/utils.h"

--- a/runtime/lib/ttnn/operations/eltwise/unary/unary.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/unary/unary.cpp
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
-#include "unary.h"
+#include "operations/eltwise/unary/unary.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
 #include "tt/runtime/ttnn/operations/eltwise/unary/utils.h"

--- a/runtime/lib/ttnn/operations/eltwise/unary/unary_composite.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/unary/unary_composite.cpp
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
-#include "unary_composite.h"
+#include "operations/eltwise/unary/unary_composite.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
 #include "tt/runtime/ttnn/operations/eltwise/unary/utils.h"

--- a/runtime/lib/ttnn/operations/embedding/embedding.cpp
+++ b/runtime/lib/ttnn/operations/embedding/embedding.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "embedding.h"
+#include "operations/embedding/embedding.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
 #include "tt/runtime/ttnn/operations/utils.h"

--- a/runtime/lib/ttnn/operations/embedding/embedding_backward.cpp
+++ b/runtime/lib/ttnn/operations/embedding/embedding_backward.cpp
@@ -2,14 +2,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "embedding_backward.h"
+#include "operations/embedding/embedding_backward.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
 #include "ttmlir/Target/TTNN/program_generated.h"
-#include <ttnn/operations/embedding_backward/embedding_backward.hpp>
-#include <ttnn/tensor/tensor.hpp>
+#include "ttnn/operations/embedding_backward/embedding_backward.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 namespace tt::runtime::ttnn::operations::embedding_backward {
 void run(const ::tt::target::ttnn::EmbeddingBackwardOp *op,

--- a/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/eltwise/binary/utils.cpp
+++ b/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/eltwise/binary/utils.cpp
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
-#include "utils.h"
+#include "tt/runtime/ttnn/operations/eltwise/binary/utils.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/workarounds.h"
 

--- a/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/eltwise/ternary/utils.cpp
+++ b/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/eltwise/ternary/utils.cpp
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
-#include "utils.h"
+#include "tt/runtime/ttnn/operations/eltwise/ternary/utils.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/workarounds.h"
 

--- a/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/eltwise/unary/utils.cpp
+++ b/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/eltwise/unary/utils.cpp
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
-#include "utils.h"
+#include "tt/runtime/ttnn/operations/eltwise/unary/utils.h"
 #include "tt/runtime/detail/logger.h"
 
 namespace tt::runtime::ttnn::operations::unary {

--- a/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/utils.cpp
+++ b/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/utils.cpp
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
-#include "utils.h"
+#include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/ttnn/utils.h"
 

--- a/runtime/lib/ttnn/operations/kv_cache/fill_cache.cpp
+++ b/runtime/lib/ttnn/operations/kv_cache/fill_cache.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "fill_cache.h"
+#include "operations/kv_cache/fill_cache.h"
 
 namespace tt::runtime::ttnn::operations::kv_cache {
 void run(const ::tt::target::ttnn::FillCacheOp *op, ProgramContext &context) {

--- a/runtime/lib/ttnn/operations/kv_cache/update_cache.cpp
+++ b/runtime/lib/ttnn/operations/kv_cache/update_cache.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "update_cache.h"
+#include "operations/kv_cache/update_cache.h"
 
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/workarounds.h"

--- a/runtime/lib/ttnn/operations/layout/from_device.cpp
+++ b/runtime/lib/ttnn/operations/layout/from_device.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "to_device.h"
+#include "operations/layout/from_device.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
 #include "tt/runtime/ttnn/operations/utils.h"

--- a/runtime/lib/ttnn/operations/layout/to_device.cpp
+++ b/runtime/lib/ttnn/operations/layout/to_device.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "to_device.h"
+#include "operations/layout/to_device.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
 #include "tt/runtime/ttnn/operations/utils.h"

--- a/runtime/lib/ttnn/operations/layout/to_layout.cpp
+++ b/runtime/lib/ttnn/operations/layout/to_layout.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "to_layout.h"
+#include "operations/layout/to_layout.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
 #include "tt/runtime/ttnn/operations/utils.h"

--- a/runtime/lib/ttnn/operations/layout/to_memory_config.cpp
+++ b/runtime/lib/ttnn/operations/layout/to_memory_config.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "to_memory_config.h"
+#include "operations/layout/to_memory_config.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
 #include "tt/runtime/ttnn/operations/utils.h"

--- a/runtime/lib/ttnn/operations/layout/typecast.cpp
+++ b/runtime/lib/ttnn/operations/layout/typecast.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "typecast.h"
+#include "operations/layout/typecast.h"
 #include "tt/runtime/detail/ttnn.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"

--- a/runtime/lib/ttnn/operations/matmul/matmul.cpp
+++ b/runtime/lib/ttnn/operations/matmul/matmul.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "matmul.h"
+#include "operations/matmul/matmul.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
 #include "tt/runtime/ttnn/operations/utils.h"

--- a/runtime/lib/ttnn/operations/normalization/softmax.cpp
+++ b/runtime/lib/ttnn/operations/normalization/softmax.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "softmax.h"
+#include "operations/normalization/softmax.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
 #include "tt/runtime/ttnn/operations/utils.h"

--- a/runtime/lib/ttnn/operations/pool/maxpool2d.cpp
+++ b/runtime/lib/ttnn/operations/pool/maxpool2d.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "maxpool2d.h"
+#include "operations/pool/maxpool2d.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
 #include "tt/runtime/detail/workarounds.h"

--- a/runtime/lib/ttnn/operations/reduction/reduction.cpp
+++ b/runtime/lib/ttnn/operations/reduction/reduction.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "reduction.h"
+#include "operations/reduction/reduction.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
 #include "tt/runtime/ttnn/operations/utils.h"

--- a/runtime/lib/ttnn/program.cpp
+++ b/runtime/lib/ttnn/program.cpp
@@ -45,7 +45,7 @@
 namespace tt::runtime::ttnn {
 using LogType = ::tt::runtime::logger::LogType;
 
-void tracyLogOpLocation(const ::tt::target::ttnn::Operation *op) {
+static void tracyLogOpLocation(const ::tt::target::ttnn::Operation *op) {
 #ifdef TT_RUNTIME_ENABLE_PERF_TRACE
   TracyMessage(op->loc_info()->c_str(), op->loc_info()->size());
 #endif
@@ -234,76 +234,6 @@ void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
   }
   }
 }
-
-namespace legacy {
-
-static bool handleNopProgram(::tt::target::ttnn::Program const *program,
-                             std::vector<::ttnn::Tensor *> const &inputs,
-                             std::vector<::ttnn::Tensor *> const &outputs) {
-
-  bool isNop = program->inputs()->size() == 1 &&
-               program->outputs()->size() == 1 &&
-               program->inputs()->Get(0)->global_id() ==
-                   program->outputs()->Get(0)->global_id();
-
-  if (isNop) {
-    void *src = ::tt::tt_metal::get_raw_host_data_ptr(*inputs.at(0));
-    void *dst = ::tt::tt_metal::get_raw_host_data_ptr(*outputs.at(0));
-    std::uint32_t size = outputs[0]->volume() * outputs[0]->element_size();
-    std::memcpy(dst, src, size);
-  }
-  return isNop;
-}
-
-void runProgram(::ttnn::MeshDevice &meshDevice, Binary &executableHandle,
-                std::uint32_t programIndex,
-                std::vector<::ttnn::Tensor *> const &inputs,
-                std::vector<::ttnn::Tensor *> const &outputs) {
-  ::tt::target::ttnn::TTNNBinary const &fbb = *getBinary(executableHandle);
-  ::tt::target::ttnn::Program const *program =
-      fbb.programs()->Get(programIndex);
-  if (handleNopProgram(program, inputs, outputs)) {
-    return;
-  }
-  std::unordered_map<uint32_t, ::ttnn::Tensor *> liveTensors;
-  std::vector<uint32_t> programInputs;
-  int inputIndex = 0;
-  LOG_ASSERT(program->inputs()->size() == inputs.size(),
-             "Program input size mismatch: ", program->inputs()->size(),
-             " != ", inputs.size());
-  for (::tt::target::TensorRef const *input : *program->inputs()) {
-    auto [iter, inserted] =
-        liveTensors.try_emplace(input->global_id(), inputs[inputIndex++]);
-    LOG_ASSERT(inserted, "Duplicate input tensor");
-    programInputs.push_back(input->global_id());
-  }
-
-  int outputIndex = 0;
-  std::vector<uint32_t> programOutputs;
-  LOG_ASSERT(program->outputs()->size() == outputs.size());
-  for (::tt::target::TensorRef const *output : *program->outputs()) {
-    auto [iter, inserted] =
-        liveTensors.try_emplace(output->global_id(), outputs[outputIndex++]);
-    LOG_ASSERT(inserted, "Duplicate output tensor");
-    programOutputs.push_back(output->global_id());
-  }
-  ProgramExecutor executor(executableHandle, liveTensors, programInputs,
-                           programOutputs, &meshDevice);
-  executor.execute(program);
-  outputIndex = 0;
-  for (uint32_t outputId : programOutputs) {
-    const ::ttnn::Tensor &src =
-        executor.getContext().getTensorPool().at(outputId);
-    const ::ttnn::Tensor &dst = *(outputs[outputIndex++]);
-    size_t srcSize = src.volume() * src.element_size();
-    size_t dstSize = dst.volume() * dst.element_size();
-    LOG_ASSERT(srcSize == dstSize, "Output tensor size mismatch");
-    const void *srcPtr = ::tt::tt_metal::get_raw_host_data_ptr(src);
-    void *dstPtr = ::tt::tt_metal::get_raw_host_data_ptr(dst);
-    std::memcpy(dstPtr, srcPtr, dstSize);
-  }
-}
-} // namespace legacy
 
 std::vector<Tensor> runProgram(::ttnn::MeshDevice &meshDevice,
                                Binary executableHandle,

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -489,34 +489,6 @@ std::vector<float> getTensorData(Tensor tensor) {
                             static_cast<float *>(dataPtr) + nnTensor->volume());
 }
 
-namespace legacy {
-
-Event submit(Device deviceHandle, Binary executableHandle,
-             std::uint32_t programIndex,
-             std::vector<Tensor> const &inputHandles,
-             std::vector<Tensor> const &outputHandles) {
-  ::ttnn::MeshDevice &meshDevice =
-      deviceHandle.as<::ttnn::MeshDevice>(DeviceRuntime::TTNN);
-  std::vector<::ttnn::Tensor *> inputs;
-  inputs.reserve(inputHandles.size());
-  for (auto &input : inputHandles) {
-    LOG_ASSERT(input.matchesRuntime(DeviceRuntime::TTNN));
-    inputs.push_back(static_cast<::ttnn::Tensor *>(input.handle.get()));
-  }
-
-  std::vector<::ttnn::Tensor *> outputs;
-  outputs.reserve(outputHandles.size());
-  for (auto &output : outputHandles) {
-    LOG_ASSERT(output.matchesRuntime(DeviceRuntime::TTNN));
-    outputs.push_back(static_cast<::ttnn::Tensor *>(output.handle.get()));
-  }
-
-  tt::runtime::ttnn::legacy::runProgram(meshDevice, executableHandle,
-                                        programIndex, inputs, outputs);
-  return Event(nullptr, DeviceRuntime::TTNN);
-}
-} // namespace legacy
-
 std::vector<Tensor> submit(Device deviceHandle, Binary executableHandle,
                            std::uint32_t programIndex,
                            std::vector<Tensor> const &inputHandles) {


### PR DESCRIPTION
[tt-xla](https://github.com/tenstorrent/tt-xla/pull/107), [tt-torch](https://github.com/tenstorrent/tt-torch/pull/108) have updated to the new submit API.

[tt-forge-fe](https://github.com/tenstorrent/tt-forge-fe/pull/925) will be updated soon.

Therefore removing the legacy submit API from tt-mlir. Also did some minor cleanup in runtime. Will merge this in after tt-forge is updated.

