### PR TITLE
Remove nop check

### DIFF
--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -327,6 +327,9 @@ void memcpy(Tensor dst, Tensor src) {
 
 void deallocateTensor(Tensor &tensor, bool force) {
   ::ttnn::Tensor &ttnnTensor = tensor.as<::ttnn::Tensor>(DeviceRuntime::TTNN);
+  if (ttnnTensor.storage_type() == ::tt::tt_metal::StorageType::BORROWED) {
+    return;
+  }
   ::ttnn::deallocate(ttnnTensor, force);
 }
 


### PR DESCRIPTION
The new submit API does not need to check for nops as it generically returns tensors based on global id, regardless of if it's an input tensor or not.
