### PR TITLE
Add Reduce ops workaround for keepDim=false

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -651,6 +651,8 @@ class TTIR_ReductionOp<string mnemonic, list<Trait> traits = []> :
         return {builder.getAffineMapArrayAttr(indexingMaps),
                 builder.getArrayAttr(iteratorTypes)};}
     }];
+
+    let hasVerifier = 1;
 }
 
 def TTIR_SumOp : TTIR_ReductionOp<"sum"> {

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -581,6 +581,8 @@ class TTNN_ReductionOp<string mnemonic, list<Trait> traits = []> : TTNN_Op<mnemo
                          OptionalAttr<I32ArrayAttr>:$dim_arg);
 
     let results = (outs AnyRankedTensor:$result);
+
+    let hasVerifier = 1;
 }
 
 def TTNN_SumOp : TTNN_ReductionOp<"sum"> {

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
@@ -145,6 +145,7 @@ def TTNN_TTNNLayoutAttr: TTNN_Attr<"TTNNLayout", "ttnn_layout"> {
     TTNNLayoutAttr withMemoryLayout(::mlir::MLIRContext *context, TensorMemoryLayoutAttr memLayoutAttr);
     TTNNLayoutAttr withMemoryLayout(::mlir::MLIRContext *context, TensorMemoryLayout memLayout);
     TTNNLayoutAttr withShardShape(::mlir::MLIRContext *context, llvm::SmallVector<int64_t> shardShape);
+    TTNNLayoutAttr withTensorShape(::mlir::MLIRContext *context, ArrayRef<int64_t> tensorShape);
 
     bool isSystemBufferType() const { return ::mlir::tt::ttnn::isSystemBufferType(getBufferType()); }
     bool isDeviceBufferType() const { return ::mlir::tt::ttnn::isDeviceBufferType(getBufferType()); }

--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceOpsRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceOpsRewritePattern.h
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_REDUCEOPSREWRITEPATTERN_H
+#define TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_REDUCEOPSREWRITEPATTERN_H
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+
+std::vector<int64_t>
+calculateNewReduceShape(const std::optional<mlir::ArrayAttr> &dimArg,
+                        const RankedTensorType &inputType);
+
+template <typename ReduceOp>
+class ReduceOpsRewritePattern : public OpRewritePattern<ReduceOp> {
+public:
+  using OpRewritePattern<ReduceOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ReduceOp srcOp,
+                                PatternRewriter &rewriter) const override {
+    if (srcOp.getKeepDim()) {
+      return failure();
+    }
+
+    RankedTensorType inputType =
+        mlir::cast<RankedTensorType>(srcOp.getInput().getType());
+    RankedTensorType outputType =
+        mlir::cast<RankedTensorType>(srcOp.getResult().getType());
+
+    ReduceOp newReduceOp =
+        createReduceOpWithKeepDim(srcOp, rewriter, inputType, outputType);
+
+    if (outputType.getShape().size() < inputType.getShape().size()) {
+      createReshapeOp(srcOp, newReduceOp, rewriter, outputType);
+    } else {
+      rewriter.replaceOp(srcOp, newReduceOp);
+    }
+
+    return success();
+  }
+
+private:
+  ReduceOp createReduceOpWithKeepDim(ReduceOp &srcOp, PatternRewriter &rewriter,
+                                     const RankedTensorType &inputType,
+                                     const RankedTensorType &outputType) const {
+    std::vector<int64_t> outputShapeVec =
+        calculateNewReduceShape(srcOp.getDimArg(), inputType);
+
+    RankedTensorType newOutputType = RankedTensorType::get(
+        llvm::ArrayRef<int64_t>(outputShapeVec), outputType.getElementType(),
+        outputType.getEncoding());
+
+    return rewriter.create<ReduceOp>(srcOp.getLoc(), newOutputType,
+                                     srcOp.getInput(), true /*keep_dim*/,
+                                     srcOp.getDimArg().value_or(nullptr));
+  }
+
+  void createReshapeOp(ReduceOp &srcOp, ReduceOp &newReduceOp,
+                       PatternRewriter &rewriter,
+                       RankedTensorType &outputType) const {
+    mlir::ArrayAttr shapeAttr = rewriter.getI32ArrayAttr(std::vector<int32_t>(
+        outputType.getShape().begin(), outputType.getShape().end()));
+
+    rewriter.replaceOpWithNewOp<mlir::tt::ttnn::ReshapeOp>(
+        srcOp, outputType, newReduceOp, shapeAttr);
+  }
+};
+
+} // namespace mlir::tt::ttnn::workarounds::decomposition
+
+#endif // TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_REDUCEOPSREWRITEPATTERN_H

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -116,10 +116,10 @@ private:
     tensor::EmptyOp outputTensor = rewriter.create<tensor::EmptyOp>(
         srcOp.getLoc(), outputType.getShape(), outputType.getElementType());
 
-    mlir::ArrayAttr dimArg = rewriter.getArrayAttr(SmallVector<Attribute>(
-        1, rewriter.getI32IntegerAttr(adaptor.getDimensionsAttr().size() > 0
-                                          ? adaptor.getDimensionsAttr()[0]
-                                          : 1)));
+    // Can't reuse the original dimensions attribute because it uses i64 type.
+    mlir::ArrayAttr dimArg =
+        rewriter.getI32ArrayAttr(llvm::ArrayRef<int32_t>(std::vector<int32_t>(
+            srcOp.getDimensions().begin(), srcOp.getDimensions().end())));
 
     rewriter.replaceOpWithNewOp<DestOp>(
         srcOp, outputType, adaptor.getInputs().front(), outputTensor,

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -117,9 +117,8 @@ private:
         srcOp.getLoc(), outputType.getShape(), outputType.getElementType());
 
     // Can't reuse the original dimensions attribute because it uses i64 type.
-    mlir::ArrayAttr dimArg =
-        rewriter.getI32ArrayAttr(llvm::ArrayRef<int32_t>(std::vector<int32_t>(
-            srcOp.getDimensions().begin(), srcOp.getDimensions().end())));
+    mlir::ArrayAttr dimArg = rewriter.getI32ArrayAttr(
+        llvm::SmallVector<int32_t>(srcOp.getDimensions()));
 
     rewriter.replaceOpWithNewOp<DestOp>(
         srcOp, outputType, adaptor.getInputs().front(), outputTensor,

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -337,19 +337,6 @@ public:
   LogicalResult
   matchAndRewrite(TTIROpTy op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    int64_t inputTensorRank =
-        mlir::cast<::mlir::RankedTensorType>(adaptor.getInput().getType())
-            .getRank();
-
-    // TODO(mrakita): Only last two dimensions can be reduced, check for that
-    // too. Should this check be in verifier?
-    if (adaptor.getDimArg() && adaptor.getDimArg()->size() > 2 &&
-        static_cast<int64_t>(adaptor.getDimArg()->size()) != inputTensorRank) {
-      return rewriter.notifyMatchFailure(op,
-                                         "Reduce on more than two dimensions "
-                                         "is not currently supported by TTNN");
-    }
-
     rewriter.replaceOpWithNewOp<TTNNOpTy>(
         op, this->getTypeConverter()->convertType(op.getType()),
         adaptor.getInput(), adaptor.getKeepDim(),

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -343,10 +343,8 @@ public:
 
     // TODO(mrakita): Only last two dimensions can be reduced, check for that
     // too. Should this check be in verifier?
-    if (adaptor.getDimArg().has_value() &&
-        adaptor.getDimArg().value().size() > 2 &&
-        static_cast<int64_t>(adaptor.getDimArg().value().size()) !=
-            inputTensorRank) {
+    if (adaptor.getDimArg() && adaptor.getDimArg()->size() > 2 &&
+        static_cast<int64_t>(adaptor.getDimArg()->size()) != inputTensorRank) {
       return rewriter.notifyMatchFailure(op,
                                          "Reduce on more than two dimensions "
                                          "is not currently supported by TTNN");

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -25,7 +25,6 @@
 #include <cstdint>
 #include <numeric>
 #include <string>
-#include <unordered_set>
 
 #define GET_OP_CLASSES
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.cpp.inc"
@@ -1729,15 +1728,13 @@ static void createReduceOp(::mlir::OpBuilder &opBuilder, ::mlir::Block *block,
 
 // Common verifier for all Reduce ops.
 static mlir::LogicalResult
-verifyReduceOp(mlir::Operation *reduceOp,
+verifyReduceOp(mlir::Operation *reduceOp, mlir::RankedTensorType inputType,
                const std::optional<mlir::ArrayAttr> &reduceDims) {
   if (!reduceDims) {
     return mlir::success();
   }
 
-  int64_t inputTensorRank =
-      mlir::cast<mlir::RankedTensorType>(*reduceOp->getOperandTypes().begin())
-          .getRank();
+  int64_t inputTensorRank = inputType.getRank();
 
   llvm::SmallSet<int64_t, 4> uniqueReduceDims;
   for (mlir::Attribute reduceDim : *reduceDims) {
@@ -1773,7 +1770,7 @@ void mlir::tt::ttir::MaxOp::buildGenericRegion(::mlir::OpBuilder &opBuilder,
 
 // MaxOp verification
 ::mlir::LogicalResult mlir::tt::ttir::MaxOp::verify() {
-  return verifyReduceOp(getOperation(), getDimArg());
+  return verifyReduceOp(getOperation(), getInput().getType(), getDimArg());
 }
 
 //===----------------------------------------------------------------------===//
@@ -1789,7 +1786,7 @@ void mlir::tt::ttir::MeanOp::buildGenericRegion(::mlir::OpBuilder &opBuilder,
 
 // MeanOp verification
 ::mlir::LogicalResult mlir::tt::ttir::MeanOp::verify() {
-  return verifyReduceOp(getOperation(), getDimArg());
+  return verifyReduceOp(getOperation(), getInput().getType(), getDimArg());
 }
 
 //===----------------------------------------------------------------------===//
@@ -1805,5 +1802,5 @@ void mlir::tt::ttir::SumOp::buildGenericRegion(::mlir::OpBuilder &opBuilder,
 
 // SumOp verification
 ::mlir::LogicalResult mlir::tt::ttir::SumOp::verify() {
-  return verifyReduceOp(getOperation(), getDimArg());
+  return verifyReduceOp(getOperation(), getInput().getType(), getDimArg());
 }

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -1673,32 +1673,32 @@ static void buildGenericEltwiseUnaryRegion(::mlir::Location loc,
   opBuilder.create<mlir::tt::ttir::YieldOp>(loc, mlir::ValueRange({result}));
 }
 
-// AddOp generic region builder
+// AddOp generic region builder.
 void mlir::tt::ttir::AddOp::buildGenericRegion(::mlir::OpBuilder &opBuilder,
                                                ::mlir::Block *block) {
   buildGenericEltwiseBinaryRegion<arith::AddFOp>(getLoc(), opBuilder, block);
 }
 
-// MultiplyOp generic region builder
+// MultiplyOp generic region builder.
 void mlir::tt::ttir::MultiplyOp::buildGenericRegion(
     ::mlir::OpBuilder &opBuilder, ::mlir::Block *block) {
   buildGenericEltwiseBinaryRegion<arith::MulFOp>(getLoc(), opBuilder, block);
 }
 
-// ExpOp generic region builder
+// ExpOp generic region builder.
 void mlir::tt::ttir::ExpOp::buildGenericRegion(::mlir::OpBuilder &opBuilder,
                                                ::mlir::Block *block) {
   buildGenericEltwiseUnaryRegion<math::ExpOp>(getLoc(), opBuilder, block);
 }
 
-// DivOp generic region builder
+// DivOp generic region builder.
 void mlir::tt::ttir::DivOp::buildGenericRegion(::mlir::OpBuilder &opBuilder,
                                                ::mlir::Block *block) {
   return buildGenericEltwiseBinaryRegion<arith::DivFOp>(getLoc(), opBuilder,
                                                         block);
 }
 
-// MaximumOp generic region builder
+// MaximumOp generic region builder.
 void mlir::tt::ttir::MaximumOp::buildGenericRegion(::mlir::OpBuilder &opBuilder,
                                                    ::mlir::Block *block) {
   buildGenericEltwiseBinaryRegion<arith::MaximumFOp>(getLoc(), opBuilder,
@@ -1709,7 +1709,7 @@ void mlir::tt::ttir::MaximumOp::buildGenericRegion(::mlir::OpBuilder &opBuilder,
 // KernelOp
 //===----------------------------------------------------------------------===//
 
-// KernelOp builders
+// KernelOp builders.
 static mlir::tt::ttir::KernelOp
 buildKernelOp(::mlir::OpBuilder &opBuilder, ::mlir::Location loc,
               ::mlir::StringRef kernelName, ::mlir::StringRef kernelKind,
@@ -1718,7 +1718,7 @@ buildKernelOp(::mlir::OpBuilder &opBuilder, ::mlir::Location loc,
       loc, outputs.getTypes(), kernelName, kernelKind, inputs, outputs);
 }
 
-// Reduce op kernel builder
+// Reduce op kernel builder.
 static void createReduceOp(::mlir::OpBuilder &opBuilder, ::mlir::Block *block,
                            mlir::Location loc, ::mlir::StringRef kernelKind) {
   auto kernelOp = buildKernelOp(opBuilder, loc, "reduce", kernelKind,
@@ -1761,14 +1761,14 @@ verifyReduceOp(mlir::Operation *reduceOp, mlir::RankedTensorType inputType,
 // MaxOp
 //===----------------------------------------------------------------------===//
 
-// MaxOp kernel builder
+// MaxOp kernel builder.
 void mlir::tt::ttir::MaxOp::buildGenericRegion(::mlir::OpBuilder &opBuilder,
                                                ::mlir::Block *block) {
   // NOLINTNEXTLINE
   createReduceOp(opBuilder, block, getLoc(), "max");
 }
 
-// MaxOp verification
+// MaxOp verification.
 ::mlir::LogicalResult mlir::tt::ttir::MaxOp::verify() {
   return verifyReduceOp(getOperation(), getInput().getType(), getDimArg());
 }
@@ -1777,14 +1777,14 @@ void mlir::tt::ttir::MaxOp::buildGenericRegion(::mlir::OpBuilder &opBuilder,
 // MeanOp
 //===----------------------------------------------------------------------===//
 
-// MeanOp kernel builder
+// MeanOp kernel builder.
 void mlir::tt::ttir::MeanOp::buildGenericRegion(::mlir::OpBuilder &opBuilder,
                                                 ::mlir::Block *block) {
   // NOLINTNEXTLINE
   createReduceOp(opBuilder, block, getLoc(), "mean");
 }
 
-// MeanOp verification
+// MeanOp verification.
 ::mlir::LogicalResult mlir::tt::ttir::MeanOp::verify() {
   return verifyReduceOp(getOperation(), getInput().getType(), getDimArg());
 }
@@ -1793,14 +1793,14 @@ void mlir::tt::ttir::MeanOp::buildGenericRegion(::mlir::OpBuilder &opBuilder,
 // SumOp
 //===----------------------------------------------------------------------===//
 
-// SumOp kernel builder
+// SumOp kernel builder.
 void mlir::tt::ttir::SumOp::buildGenericRegion(::mlir::OpBuilder &opBuilder,
                                                ::mlir::Block *block) {
   // NOLINTNEXTLINE
   createReduceOp(opBuilder, block, getLoc(), "sum");
 }
 
-// SumOp verification
+// SumOp verification.
 ::mlir::LogicalResult mlir::tt::ttir::SumOp::verify() {
   return verifyReduceOp(getOperation(), getInput().getType(), getDimArg());
 }

--- a/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp
@@ -496,6 +496,24 @@ TTNNLayoutAttr::withShardShape(::mlir::MLIRContext *context,
 
 // Construct a new TTNNLayoutAttr
 //
+// This function creates a deep copy of the current TTNNLayoutAttr and
+// applies changes necessary to fit new tensor shape.
+//
+// param context The MLIR context.
+// param tensorShape The new tensor shape.
+// return The new TTNNLayoutAttr with the given tensor shape.
+TTNNLayoutAttr TTNNLayoutAttr::withTensorShape(::mlir::MLIRContext *context,
+                                               ArrayRef<int64_t> tensorShape) {
+  // TODO(mrakita): This leaves default value of collapseIntervals parameter,
+  // which might be different than the original value used to create the layout
+  // attribute. This will work for now since we always use default value, but in
+  // the future we would need to take this into account.
+  return TTNNLayoutAttr::get(context, tensorShape, getElementType(),
+                             getBufferType(), getGrid(), getMemLayout());
+}
+
+// Construct a new TTNNLayoutAttr
+//
 // This function constructs a new TTNNLayoutAttr with the given parameters.
 //
 // param context The MLIR context.

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -3,7 +3,8 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         Passes.cpp
         TTNNLayout.cpp
         TTNNToCpp.cpp
-        TTNNWorkarounds.cpp
+        Workarounds/Decomposition/ReduceOpsRewritePattern.cpp
+        Workarounds/TTNNWorkarounds.cpp
 
         ADDITIONAL_HEADER_DIRS
         ${PROJECT_SOURCE_DIR}/include/ttmlir

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceOpsRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceOpsRewritePattern.cpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceOpsRewritePattern.h"
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+
+std::vector<int64_t>
+calculateNewReduceShape(const std::optional<mlir::ArrayAttr> &dimArg,
+                        const RankedTensorType &inputType) {
+  std::vector<int64_t> outputShapeVec = inputType.getShape().vec();
+
+  if (dimArg.has_value()) {
+    for (const mlir::Attribute &reduceDim : dimArg.value()) {
+      int64_t reduceDimInt = mlir::cast<mlir::IntegerAttr>(reduceDim).getInt();
+      outputShapeVec[reduceDimInt < 0 ? outputShapeVec.size() -
+                                            static_cast<size_t>(-reduceDimInt)
+                                      : static_cast<size_t>(reduceDimInt)] = 1;
+    }
+  } else {
+    for (size_t i = 0; i < outputShapeVec.size(); ++i) {
+      outputShapeVec[i] = 1;
+    }
+  }
+
+  return outputShapeVec;
+}
+
+} // namespace mlir::tt::ttnn::workarounds::decomposition

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceOpsRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceOpsRewritePattern.cpp
@@ -4,15 +4,13 @@
 
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceOpsRewritePattern.h"
 
-#include "llvm/ADT/SmallSet.h"
-
 #include <algorithm>
 
 namespace mlir::tt::ttnn::workarounds::decomposition {
 
 llvm::SmallVector<int64_t>
 getReduceDims(const std::optional<mlir::ArrayAttr> &dimArg) {
-  llvm::SmallVector<int64_t> reduceDims;
+  llvm::SmallVector<int64_t, 4> reduceDims;
   if (!dimArg) {
     return reduceDims;
   }
@@ -47,28 +45,6 @@ calculateNewReduceShape(RankedTensorType inputType,
   }
 
   return outputShapeVec;
-}
-
-mlir::ArrayAttr
-createNewReduceDimArg(RankedTensorType inputType,
-                      const std::optional<mlir::ArrayAttr> &dimArg) {
-  llvm::SmallVector<int64_t> reduceDims = getReduceDims(dimArg);
-  if (reduceDims.empty()) {
-    return nullptr;
-  }
-
-  llvm::SmallSet<int64_t, 4> uniqueReduceDims(reduceDims.begin(),
-                                              reduceDims.end());
-  if (uniqueReduceDims.size() == inputType.getShape().size()) {
-    // In case when reduce is done over all dimensions of the input nullptr is
-    // returned, because Metal supports reduce over all dimensions for any
-    // tensor rank when reduce dimensions are not specified, but it doesn't
-    // support reduce for tensors with rank larger than 2 when reduce
-    // dimensions are specified.
-    return nullptr;
-  }
-
-  return *dimArg;
 }
 
 } // namespace mlir::tt::ttnn::workarounds::decomposition

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceOpsRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceOpsRewritePattern.cpp
@@ -4,27 +4,59 @@
 
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceOpsRewritePattern.h"
 
+#include <algorithm>
+#include <unordered_set>
+
 namespace mlir::tt::ttnn::workarounds::decomposition {
+
+std::vector<int64_t>
+getReduceDims(const std::optional<mlir::ArrayAttr> &dimArg) {
+  std::vector<int64_t> reduceDims;
+  if (!dimArg.has_value()) {
+    return reduceDims;
+  }
+
+  for (const mlir::Attribute &reduceDim : dimArg.value()) {
+    reduceDims.push_back(mlir::cast<mlir::IntegerAttr>(reduceDim).getInt());
+  }
+
+  return reduceDims;
+}
 
 std::vector<int64_t>
 calculateNewReduceShape(const std::optional<mlir::ArrayAttr> &dimArg,
                         const RankedTensorType &inputType) {
   std::vector<int64_t> outputShapeVec = inputType.getShape().vec();
+  std::vector<int64_t> reduceDims = getReduceDims(dimArg);
 
-  if (dimArg.has_value()) {
-    for (const mlir::Attribute &reduceDim : dimArg.value()) {
-      int64_t reduceDimInt = mlir::cast<mlir::IntegerAttr>(reduceDim).getInt();
-      outputShapeVec[reduceDimInt < 0 ? outputShapeVec.size() -
-                                            static_cast<size_t>(-reduceDimInt)
-                                      : static_cast<size_t>(reduceDimInt)] = 1;
-    }
+  if (reduceDims.empty()) {
+    std::fill(outputShapeVec.begin(), outputShapeVec.end(), 1);
   } else {
-    for (size_t i = 0; i < outputShapeVec.size(); ++i) {
-      outputShapeVec[i] = 1;
+    for (const int64_t reduceDim : reduceDims) {
+      outputShapeVec[reduceDim < 0 ? outputShapeVec.size() -
+                                         static_cast<size_t>(-reduceDim)
+                                   : static_cast<size_t>(reduceDim)] = 1;
     }
   }
 
   return outputShapeVec;
+}
+
+mlir::ArrayAttr
+calculateNewReduceDimArg(const RankedTensorType &inputType,
+                         const std::optional<mlir::ArrayAttr> &dimArg) {
+  std::vector<int64_t> reduceDims = getReduceDims(dimArg);
+  if (reduceDims.empty()) {
+    return nullptr;
+  }
+
+  std::unordered_set<int64_t> uniqueReduceDims(reduceDims.begin(),
+                                               reduceDims.end());
+  if (uniqueReduceDims.size() == inputType.getShape().size()) {
+    return nullptr;
+  }
+
+  return dimArg.value();
 }
 
 } // namespace mlir::tt::ttnn::workarounds::decomposition

--- a/test/ttmlir/Conversion/StableHLOToTTIR/reduce_add_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/reduce_add_op.mlir
@@ -1,10 +1,17 @@
 // REQUIRES: stablehlo
 // RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s | FileCheck %s
 module @jit_reduce_add attributes {} {
-  func.func public @test_reduce_add(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
+  func.func public @test_reduce_add_2to1dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<128xf32>
     // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
     // CHECK: %[[C:.*]] = "ttir.sum"[[C:.*]]
     return %0 : tensor<128xf32>
+  }
+
+  func.func public @test_reduce_add_2to0dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [0, 1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<f32>
+    // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
+    // CHECK: %[[C:.*]] = "ttir.sum"[[C:.*]]
+    return %0 : tensor<f32>
   }
 }

--- a/test/ttmlir/Conversion/StableHLOToTTIR/reduce_add_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/reduce_add_op.mlir
@@ -1,17 +1,113 @@
 // REQUIRES: stablehlo
 // RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s | FileCheck %s
 module @jit_reduce_add attributes {} {
+  func.func public @test_reduce_add_4to3dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<128x32x4xf32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.sum"
+    // CHECK-SAME: dim_arg = [1 : i32],
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x32x4xf32>,
+    // CHECK-SAME: -> tensor<128x32x4xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [1] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<128x32x4xf32>
+    return %0 : tensor<128x32x4xf32>
+  }
+
+  func.func public @test_reduce_add_4to2dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<128x32xf32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.sum"
+    // CHECK-SAME: dim_arg = [1 : i32, 3 : i32],
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x32x4xf32>,
+    // CHECK-SAME: -> tensor<128x32xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [1, 3] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<128x32xf32>
+    return %0 : tensor<128x32xf32>
+  }
+
+  func.func public @test_reduce_add_4to1dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.sum"
+    // CHECK-SAME: dim_arg = [1 : i32, 2 : i32, 3 : i32],
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x32x4xf32>,
+    // CHECK-SAME: -> tensor<128xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [1, 2, 3] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<128xf32>
+    return %0 : tensor<128xf32>
+  }
+
+  func.func public @test_reduce_add_4to0dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.sum"
+    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32, 3 : i32],
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x32x4xf32>,
+    // CHECK-SAME: -> tensor<1xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [0, 1, 2, 3] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<f32>
+    return %0 : tensor<f32>
+  }
+
+  func.func public @test_reduce_add_3to2dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128x4xf32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.sum"
+    // CHECK-SAME: dim_arg = [1 : i32],
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x4xf32>,
+    // CHECK-SAME: -> tensor<128x4xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [1] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128x4xf32>
+    return %0 : tensor<128x4xf32>
+  }
+
+  func.func public @test_reduce_add_3to1dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.sum"
+    // CHECK-SAME: dim_arg = [1 : i32, 2 : i32],
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x4xf32>,
+    // CHECK-SAME: -> tensor<128xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [1, 2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128xf32>
+    return %0 : tensor<128xf32>
+  }
+
+  func.func public @test_reduce_add_3to0dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.sum"
+    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32],
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x4xf32>,
+    // CHECK-SAME: -> tensor<1xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [0, 1, 2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<f32>
+    return %0 : tensor<f32>
+  }
+
   func.func public @test_reduce_add_2to1dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.sum"
+    // CHECK-SAME: dim_arg = [1 : i32],
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10xf32>,
+    // CHECK-SAME: -> tensor<128xf32>
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<128xf32>
-    // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttir.sum"[[C:.*]]
     return %0 : tensor<128xf32>
   }
 
   func.func public @test_reduce_add_2to0dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.sum"
+    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32],
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10xf32>,
+    // CHECK-SAME: -> tensor<1xf32>
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [0, 1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<f32>
-    // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttir.sum"[[C:.*]]
+    return %0 : tensor<f32>
+  }
+
+  func.func public @test_reduce_add_1to0dim(%arg0: tensor<128xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.sum"
+    // CHECK-SAME: dim_arg = [0 : i32],
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128xf32>,
+    // CHECK-SAME: -> tensor<1xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [0] : (tensor<128xf32>, tensor<f32>) -> tensor<f32>
     return %0 : tensor<f32>
   }
 }

--- a/test/ttmlir/Conversion/StableHLOToTTIR/reduce_add_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/reduce_add_op.mlir
@@ -4,9 +4,9 @@ module @jit_reduce_add attributes {} {
   func.func public @test_reduce_add_4to3dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<128x32x4xf32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.sum"
-    // CHECK-SAME: dim_arg = [1 : i32],
+    // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x32x4xf32>,
+    // CHECK-SAME: tensor<128x10x32x4xf32>
     // CHECK-SAME: -> tensor<128x32x4xf32>
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [1] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<128x32x4xf32>
     return %0 : tensor<128x32x4xf32>
@@ -15,9 +15,9 @@ module @jit_reduce_add attributes {} {
   func.func public @test_reduce_add_4to2dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<128x32xf32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.sum"
-    // CHECK-SAME: dim_arg = [1 : i32, 3 : i32],
+    // CHECK-SAME: dim_arg = [1 : i32, 3 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x32x4xf32>,
+    // CHECK-SAME: tensor<128x10x32x4xf32>
     // CHECK-SAME: -> tensor<128x32xf32>
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [1, 3] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<128x32xf32>
     return %0 : tensor<128x32xf32>
@@ -26,9 +26,9 @@ module @jit_reduce_add attributes {} {
   func.func public @test_reduce_add_4to1dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.sum"
-    // CHECK-SAME: dim_arg = [1 : i32, 2 : i32, 3 : i32],
+    // CHECK-SAME: dim_arg = [1 : i32, 2 : i32, 3 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x32x4xf32>,
+    // CHECK-SAME: tensor<128x10x32x4xf32>
     // CHECK-SAME: -> tensor<128xf32>
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [1, 2, 3] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<128xf32>
     return %0 : tensor<128xf32>
@@ -37,9 +37,9 @@ module @jit_reduce_add attributes {} {
   func.func public @test_reduce_add_4to0dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.sum"
-    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32, 3 : i32],
+    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32, 3 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x32x4xf32>,
+    // CHECK-SAME: tensor<128x10x32x4xf32>
     // CHECK-SAME: -> tensor<1xf32>
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [0, 1, 2, 3] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<f32>
     return %0 : tensor<f32>
@@ -48,9 +48,9 @@ module @jit_reduce_add attributes {} {
   func.func public @test_reduce_add_3to2dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128x4xf32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.sum"
-    // CHECK-SAME: dim_arg = [1 : i32],
+    // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x4xf32>,
+    // CHECK-SAME: tensor<128x10x4xf32>
     // CHECK-SAME: -> tensor<128x4xf32>
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [1] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128x4xf32>
     return %0 : tensor<128x4xf32>
@@ -59,9 +59,9 @@ module @jit_reduce_add attributes {} {
   func.func public @test_reduce_add_3to1dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.sum"
-    // CHECK-SAME: dim_arg = [1 : i32, 2 : i32],
+    // CHECK-SAME: dim_arg = [1 : i32, 2 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x4xf32>,
+    // CHECK-SAME: tensor<128x10x4xf32>
     // CHECK-SAME: -> tensor<128xf32>
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [1, 2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128xf32>
     return %0 : tensor<128xf32>
@@ -70,9 +70,9 @@ module @jit_reduce_add attributes {} {
   func.func public @test_reduce_add_3to0dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.sum"
-    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32],
+    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x4xf32>,
+    // CHECK-SAME: tensor<128x10x4xf32>
     // CHECK-SAME: -> tensor<1xf32>
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [0, 1, 2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<f32>
     return %0 : tensor<f32>
@@ -81,9 +81,9 @@ module @jit_reduce_add attributes {} {
   func.func public @test_reduce_add_2to1dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.sum"
-    // CHECK-SAME: dim_arg = [1 : i32],
+    // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10xf32>,
+    // CHECK-SAME: tensor<128x10xf32>
     // CHECK-SAME: -> tensor<128xf32>
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<128xf32>
     return %0 : tensor<128xf32>
@@ -92,9 +92,9 @@ module @jit_reduce_add attributes {} {
   func.func public @test_reduce_add_2to0dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.sum"
-    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32],
+    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10xf32>,
+    // CHECK-SAME: tensor<128x10xf32>
     // CHECK-SAME: -> tensor<1xf32>
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [0, 1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<f32>
     return %0 : tensor<f32>
@@ -103,9 +103,9 @@ module @jit_reduce_add attributes {} {
   func.func public @test_reduce_add_1to0dim(%arg0: tensor<128xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.sum"
-    // CHECK-SAME: dim_arg = [0 : i32],
+    // CHECK-SAME: dim_arg = [0 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128xf32>,
+    // CHECK-SAME: tensor<128xf32>
     // CHECK-SAME: -> tensor<1xf32>
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [0] : (tensor<128xf32>, tensor<f32>) -> tensor<f32>
     return %0 : tensor<f32>

--- a/test/ttmlir/Conversion/StableHLOToTTIR/reduce_maximum_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/reduce_maximum_op.mlir
@@ -4,9 +4,9 @@ module @jit_reduce_maximum attributes {} {
   func.func public @test_reduce_maximum_4to3dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<128x32x4xf32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.max"
-    // CHECK-SAME: dim_arg = [1 : i32],
+    // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x32x4xf32>,
+    // CHECK-SAME: tensor<128x10x32x4xf32>
     // CHECK-SAME: -> tensor<128x32x4xf32>
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<128x32x4xf32>
     return %0 : tensor<128x32x4xf32>
@@ -15,9 +15,9 @@ module @jit_reduce_maximum attributes {} {
   func.func public @test_reduce_maximum_4to2dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<128x32xf32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.max"
-    // CHECK-SAME: dim_arg = [1 : i32, 3 : i32],
+    // CHECK-SAME: dim_arg = [1 : i32, 3 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x32x4xf32>,
+    // CHECK-SAME: tensor<128x10x32x4xf32>
     // CHECK-SAME: -> tensor<128x32xf32>
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1, 3] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<128x32xf32>
     return %0 : tensor<128x32xf32>
@@ -26,9 +26,9 @@ module @jit_reduce_maximum attributes {} {
   func.func public @test_reduce_maximum_4to1dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.max"
-    // CHECK-SAME: dim_arg = [1 : i32, 2 : i32, 3 : i32],
+    // CHECK-SAME: dim_arg = [1 : i32, 2 : i32, 3 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x32x4xf32>,
+    // CHECK-SAME: tensor<128x10x32x4xf32>
     // CHECK-SAME: -> tensor<128xf32>
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1, 2, 3] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<128xf32>
     return %0 : tensor<128xf32>
@@ -37,9 +37,9 @@ module @jit_reduce_maximum attributes {} {
   func.func public @test_reduce_maximum_4to0dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.max"
-    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32, 3 : i32],
+    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32, 3 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x32x4xf32>,
+    // CHECK-SAME: tensor<128x10x32x4xf32>
     // CHECK-SAME: -> tensor<1xf32>
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0, 1, 2, 3] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<f32>
     return %0 : tensor<f32>
@@ -48,9 +48,9 @@ module @jit_reduce_maximum attributes {} {
   func.func public @test_reduce_maximum_3to2dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128x4xf32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.max"
-    // CHECK-SAME: dim_arg = [1 : i32],
+    // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x4xf32>,
+    // CHECK-SAME: tensor<128x10x4xf32>
     // CHECK-SAME: -> tensor<128x4xf32>
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128x4xf32>
     return %0 : tensor<128x4xf32>
@@ -59,9 +59,9 @@ module @jit_reduce_maximum attributes {} {
   func.func public @test_reduce_maximum_3to1dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.max"
-    // CHECK-SAME: dim_arg = [1 : i32, 2 : i32],
+    // CHECK-SAME: dim_arg = [1 : i32, 2 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x4xf32>,
+    // CHECK-SAME: tensor<128x10x4xf32>
     // CHECK-SAME: -> tensor<128xf32>
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1, 2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128xf32>
     return %0 : tensor<128xf32>
@@ -70,9 +70,9 @@ module @jit_reduce_maximum attributes {} {
   func.func public @test_reduce_maximum_3to0dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.max"
-    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32],
+    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x4xf32>,
+    // CHECK-SAME: tensor<128x10x4xf32>
     // CHECK-SAME: -> tensor<1xf32>
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0, 1, 2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<f32>
     return %0 : tensor<f32>
@@ -81,9 +81,9 @@ module @jit_reduce_maximum attributes {} {
   func.func public @test_reduce_maximum_2to1dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.max"
-    // CHECK-SAME: dim_arg = [1 : i32],
+    // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10xf32>,
+    // CHECK-SAME: tensor<128x10xf32>
     // CHECK-SAME: -> tensor<128xf32>
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<128xf32>
     return %0 : tensor<128xf32>
@@ -92,9 +92,9 @@ module @jit_reduce_maximum attributes {} {
   func.func public @test_reduce_maximum_2to0dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.max"
-    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32],
+    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10xf32>,
+    // CHECK-SAME: tensor<128x10xf32>
     // CHECK-SAME: -> tensor<1xf32>
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0, 1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<f32>
     return %0 : tensor<f32>
@@ -103,9 +103,9 @@ module @jit_reduce_maximum attributes {} {
   func.func public @test_reduce_maximum_1to0dim(%arg0: tensor<128xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.max"
-    // CHECK-SAME: dim_arg = [0 : i32],
+    // CHECK-SAME: dim_arg = [0 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128xf32>,
+    // CHECK-SAME: tensor<128xf32>
     // CHECK-SAME: -> tensor<1xf32>
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0] : (tensor<128xf32>, tensor<f32>) -> tensor<f32>
     return %0 : tensor<f32>

--- a/test/ttmlir/Conversion/StableHLOToTTIR/reduce_maximum_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/reduce_maximum_op.mlir
@@ -1,10 +1,113 @@
 // REQUIRES: stablehlo
 // RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s | FileCheck %s
 module @jit_reduce_maximum attributes {} {
-  func.func public @test_reduce_maximum(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<128xf32>
-    // CHECK: %[[C:.*]] = tensor.empty[[C:.*]]
-    // CHECK: %[[C:.*]] = "ttir.max"[[C:.*]]
+  func.func public @test_reduce_maximum_4to3dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<128x32x4xf32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.max"
+    // CHECK-SAME: dim_arg = [1 : i32],
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x32x4xf32>,
+    // CHECK-SAME: -> tensor<128x32x4xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<128x32x4xf32>
+    return %0 : tensor<128x32x4xf32>
+  }
+
+  func.func public @test_reduce_maximum_4to2dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<128x32xf32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.max"
+    // CHECK-SAME: dim_arg = [1 : i32, 3 : i32],
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x32x4xf32>,
+    // CHECK-SAME: -> tensor<128x32xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1, 3] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<128x32xf32>
+    return %0 : tensor<128x32xf32>
+  }
+
+  func.func public @test_reduce_maximum_4to1dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.max"
+    // CHECK-SAME: dim_arg = [1 : i32, 2 : i32, 3 : i32],
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x32x4xf32>,
+    // CHECK-SAME: -> tensor<128xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1, 2, 3] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<128xf32>
     return %0 : tensor<128xf32>
+  }
+
+  func.func public @test_reduce_maximum_4to0dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.max"
+    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32, 3 : i32],
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x32x4xf32>,
+    // CHECK-SAME: -> tensor<1xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0, 1, 2, 3] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<f32>
+    return %0 : tensor<f32>
+  }
+
+  func.func public @test_reduce_maximum_3to2dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128x4xf32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.max"
+    // CHECK-SAME: dim_arg = [1 : i32],
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x4xf32>,
+    // CHECK-SAME: -> tensor<128x4xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128x4xf32>
+    return %0 : tensor<128x4xf32>
+  }
+
+  func.func public @test_reduce_maximum_3to1dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.max"
+    // CHECK-SAME: dim_arg = [1 : i32, 2 : i32],
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x4xf32>,
+    // CHECK-SAME: -> tensor<128xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1, 2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128xf32>
+    return %0 : tensor<128xf32>
+  }
+
+  func.func public @test_reduce_maximum_3to0dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.max"
+    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32],
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x4xf32>,
+    // CHECK-SAME: -> tensor<1xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0, 1, 2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<f32>
+    return %0 : tensor<f32>
+  }
+
+  func.func public @test_reduce_maximum_2to1dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.max"
+    // CHECK-SAME: dim_arg = [1 : i32],
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10xf32>,
+    // CHECK-SAME: -> tensor<128xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<128xf32>
+    return %0 : tensor<128xf32>
+  }
+
+  func.func public @test_reduce_maximum_2to0dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.max"
+    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32],
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10xf32>,
+    // CHECK-SAME: -> tensor<1xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0, 1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<f32>
+    return %0 : tensor<f32>
+  }
+
+  func.func public @test_reduce_maximum_1to0dim(%arg0: tensor<128xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.max"
+    // CHECK-SAME: dim_arg = [0 : i32],
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128xf32>,
+    // CHECK-SAME: -> tensor<1xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0] : (tensor<128xf32>, tensor<f32>) -> tensor<f32>
+    return %0 : tensor<f32>
   }
 }

--- a/test/ttmlir/Dialect/TTIR/reduce_ops/negative_invalid_dim_high.mlir
+++ b/test/ttmlir/Dialect/TTIR/reduce_ops/negative_invalid_dim_high.mlir
@@ -1,0 +1,9 @@
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+// Negative tests for reduce ops
+
+// CHECK: error: 'ttir.sum' op Reduce dimensions are out of range
+func.func public @test_reduce_add_invalid_dim_high(%arg0: tensor<128x10xf32>, %arg1: tensor<1xf32>) -> tensor<128xf32> {
+  %0 = tensor.empty() : tensor<128xf32>
+  %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<128x10xf32>, tensor<128xf32>) -> tensor<128xf32>
+  return %1 : tensor<128xf32>
+}

--- a/test/ttmlir/Dialect/TTIR/reduce_ops/negative_invalid_dim_low.mlir
+++ b/test/ttmlir/Dialect/TTIR/reduce_ops/negative_invalid_dim_low.mlir
@@ -1,0 +1,9 @@
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+// Negative tests for reduce ops
+
+// CHECK: error: 'ttir.sum' op Reduce dimensions are out of range
+func.func public @test_reduce_add_invalid_dim_low(%arg0: tensor<128x10xf32>, %arg1: tensor<1xf32>) -> tensor<128xf32> {
+  %0 = tensor.empty() : tensor<128xf32>
+  %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [-3 : i32], keep_dim = false}> : (tensor<128x10xf32>, tensor<128xf32>) -> tensor<128xf32>
+  return %1 : tensor<128xf32>
+}

--- a/test/ttmlir/Dialect/TTIR/reduce_ops/negative_repeating_dims.mlir
+++ b/test/ttmlir/Dialect/TTIR/reduce_ops/negative_repeating_dims.mlir
@@ -1,0 +1,9 @@
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+// Negative tests for reduce ops
+
+// CHECK: error: 'ttir.sum' op Reduce dimensions are not unique
+func.func public @test_reduce_add_repeating_dims(%arg0: tensor<128x10x32x4xf32>, %arg1: tensor<1xf32>) -> tensor<128xf32> {
+  %0 = tensor.empty() : tensor<128xf32>
+  %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [1 : i32, 2 : i32, 3 : i32, 2 : i32], keep_dim = false}> : (tensor<128x10x32x4xf32>, tensor<128xf32>) -> tensor<128xf32>
+  return %1 : tensor<128xf32>
+}

--- a/test/ttmlir/Dialect/TTNN/reduction/max_op_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/reduction/max_op_negative.mlir
@@ -1,4 +1,4 @@
-// RUN: not ttmlir-opt --split-input-file --ttir-to-ttnn-backend-pipeline="system-desc-path=ttrt-artifacts/system_desc.ttsys" %s 2>&1 | FileCheck %s
+// RUN: not ttmlir-opt --split-input-file --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s 2>&1 | FileCheck %s
 // Negative tests for Max op.
 module {
   func.func @forward(%arg0: tensor<128x32x10x4xbf16>) -> tensor<128x1x1x1xbf16> {

--- a/test/ttmlir/Dialect/TTNN/reduction/max_op_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/reduction/max_op_negative.mlir
@@ -1,0 +1,10 @@
+// RUN: not ttmlir-opt --split-input-file --ttir-to-ttnn-backend-pipeline="system-desc-path=ttrt-artifacts/system_desc.ttsys" %s 2>&1 | FileCheck %s
+// Negative tests for Max op.
+module {
+  func.func @forward(%arg0: tensor<128x32x10x4xbf16>) -> tensor<128x1x1x1xbf16> {
+    %0 = tensor.empty() : tensor<128x1x1x1xbf16>
+    // CHECK: error: 'ttnn.max' op Reduce on more than two dimensions is not currently supported by TTNN
+    %1 = "ttir.max"(%arg0, %0) <{dim_arg = [1: i32, 2: i32, 3: i32], keep_dim = true}> : (tensor<128x32x10x4xbf16>, tensor<128x1x1x1xbf16>) -> tensor<128x1x1x1xbf16>
+    return %1 : tensor<128x1x1x1xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/reduction/mean_op_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/reduction/mean_op_negative.mlir
@@ -1,4 +1,4 @@
-// RUN: not ttmlir-opt --split-input-file --ttir-to-ttnn-backend-pipeline="system-desc-path=ttrt-artifacts/system_desc.ttsys" %s 2>&1 | FileCheck %s
+// RUN: not ttmlir-opt --split-input-file --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s 2>&1 | FileCheck %s
 // Negative tests for Mean op.
 module {
   func.func @forward(%arg0: tensor<128x32x10x4xbf16>) -> tensor<128x1x1x1xbf16> {

--- a/test/ttmlir/Dialect/TTNN/reduction/mean_op_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/reduction/mean_op_negative.mlir
@@ -1,0 +1,10 @@
+// RUN: not ttmlir-opt --split-input-file --ttir-to-ttnn-backend-pipeline="system-desc-path=ttrt-artifacts/system_desc.ttsys" %s 2>&1 | FileCheck %s
+// Negative tests for Mean op.
+module {
+  func.func @forward(%arg0: tensor<128x32x10x4xbf16>) -> tensor<128x1x1x1xbf16> {
+    %0 = tensor.empty() : tensor<128x1x1x1xbf16>
+    // CHECK: error: 'ttnn.mean' op Reduce on more than two dimensions is not currently supported by TTNN
+    %1 = "ttir.mean"(%arg0, %0) <{dim_arg = [1: i32, 2: i32, 3: i32], keep_dim = true}> : (tensor<128x32x10x4xbf16>, tensor<128x1x1x1xbf16>) -> tensor<128x1x1x1xbf16>
+    return %1 : tensor<128x1x1x1xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/reduction/sum_op_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/reduction/sum_op_negative.mlir
@@ -1,4 +1,4 @@
-// RUN: not ttmlir-opt --split-input-file --ttir-to-ttnn-backend-pipeline="system-desc-path=ttrt-artifacts/system_desc.ttsys" %s 2>&1 | FileCheck %s
+// RUN: not ttmlir-opt --split-input-file --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s 2>&1 | FileCheck %s
 // Negative tests for Sum op.
 module {
   func.func @forward(%arg0: tensor<128x32x10x4xbf16>) -> tensor<128x1x1x1xbf16> {

--- a/test/ttmlir/Dialect/TTNN/reduction/sum_op_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/reduction/sum_op_negative.mlir
@@ -1,0 +1,10 @@
+// RUN: not ttmlir-opt --split-input-file --ttir-to-ttnn-backend-pipeline="system-desc-path=ttrt-artifacts/system_desc.ttsys" %s 2>&1 | FileCheck %s
+// Negative tests for Sum op.
+module {
+  func.func @forward(%arg0: tensor<128x32x10x4xbf16>) -> tensor<128x1x1x1xbf16> {
+    %0 = tensor.empty() : tensor<128x1x1x1xbf16>
+    // CHECK: error: 'ttnn.sum' op Reduce on more than two dimensions is not currently supported by TTNN
+    %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [1: i32, 2: i32, 3: i32], keep_dim = true}> : (tensor<128x32x10x4xbf16>, tensor<128x1x1x1xbf16>) -> tensor<128x1x1x1xbf16>
+    return %1 : tensor<128x1x1x1xbf16>
+  }
+}

--- a/test/ttmlir/Silicon/StableHLO/reduce_add_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/reduce_add_op.mlir
@@ -7,14 +7,80 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module @jit_reduce_add attributes {} {
-  func.func public @test_reduce_add(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
-    // CHECK-LABEL: func.func public @test_reduce_add
-    // CHECK: ttnn.sum
+  func.func public @test_reduce_add_4to0dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.sum"
+    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32, 3 : i32],
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x32x4xf32>,
+    // CHECK-SAME: -> tensor<1xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [0, 1, 2, 3] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<f32>
+    return %0 : tensor<f32>
+  }
+
+  func.func public @test_reduce_add_3to2dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128x4xf32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.sum"
     // CHECK-SAME: dim_arg = [1 : i32],
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10xf32
-    // CHECK-SAME: -> tensor<128xf32,
+    // CHECK-SAME: tensor<128x10x4xf32>,
+    // CHECK-SAME: -> tensor<128x4xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [1] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128x4xf32>
+    return %0 : tensor<128x4xf32>
+  }
+
+  func.func public @test_reduce_add_3to1dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.sum"
+    // CHECK-SAME: dim_arg = [1 : i32, 2 : i32],
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x4xf32>,
+    // CHECK-SAME: -> tensor<128xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [1, 2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128xf32>
+    return %0 : tensor<128xf32>
+  }
+
+  func.func public @test_reduce_add_3to0dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.sum"
+    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32],
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x4xf32>,
+    // CHECK-SAME: -> tensor<1xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [0, 1, 2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<f32>
+    return %0 : tensor<f32>
+  }
+
+  func.func public @test_reduce_add_2to1dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.sum"
+    // CHECK-SAME: dim_arg = [1 : i32],
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10xf32>,
+    // CHECK-SAME: -> tensor<128xf32>
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<128xf32>
     return %0 : tensor<128xf32>
+  }
+
+  func.func public @test_reduce_add_2to0dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.sum"
+    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32],
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10xf32>,
+    // CHECK-SAME: -> tensor<1xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [0, 1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<f32>
+    return %0 : tensor<f32>
+  }
+
+  func.func public @test_reduce_add_1to0dim(%arg0: tensor<128xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.sum"
+    // CHECK-SAME: dim_arg = [0 : i32],
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128xf32>,
+    // CHECK-SAME: -> tensor<1xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [0] : (tensor<128xf32>, tensor<f32>) -> tensor<f32>
+    return %0 : tensor<f32>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/reduce_add_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/reduce_add_op.mlir
@@ -1,85 +1,107 @@
 // REQUIRES: stablehlo
 // RUN: rm -rf %t.ttnn
 // RUN: rm -rf %t.mlir
-// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s | \
-// RUN:     ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" > %t.mlir
-// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" > %t.mlir
 // RUN: FileCheck --input-file=%t.mlir %s
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+// UNSUPPORTED: true
+// These tests are currently failing until a fix for this issue is uplifted
+// with new version of Metal: https://github.com/tenstorrent/tt-metal/issues/16104
+// TODO(mrakita): Enable and edit these tests after the Metal issue is fixed.
+// Tracked by: https://github.com/tenstorrent/tt-mlir/issues/1640
 
 module @jit_reduce_add attributes {} {
   func.func public @test_reduce_add_4to0dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
-    // CHECK: tensor.empty
-    // CHECK: "ttir.sum"
-    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32, 3 : i32],
-    // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x32x4xf32>,
-    // CHECK-SAME: -> tensor<1xf32>
+    // CHECK: "ttnn.sum"
+    // CHECK-NOT: dim_arg
+    // CHECK-SAME: keep_dim = true
+    // CHECK-SAME: tensor<128x10x32x4xf32,
+    // CHECK-SAME: -> tensor<1x1x1x1xf32,
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: shape = [1 : i32]
+    // CHECK-SAME: tensor<1x1x1x1xf32,
+    // CHECK-SAME: -> tensor<1xf32,
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [0, 1, 2, 3] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<f32>
     return %0 : tensor<f32>
   }
 
   func.func public @test_reduce_add_3to2dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128x4xf32> {
-    // CHECK: tensor.empty
-    // CHECK: "ttir.sum"
-    // CHECK-SAME: dim_arg = [1 : i32],
-    // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x4xf32>,
-    // CHECK-SAME: -> tensor<128x4xf32>
+    // CHECK: "ttnn.sum"
+    // CHECK-SAME: dim_arg = [1 : i32]
+    // CHECK-SAME: keep_dim = true
+    // CHECK-SAME: tensor<128x10x4xf32,
+    // CHECK-SAME: -> tensor<128x1x4xf32,
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: shape = [128 : i32, 4 : i32]
+    // CHECK-SAME: tensor<128x1x4xf32,
+    // CHECK-SAME: -> tensor<128x4xf32,
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [1] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128x4xf32>
     return %0 : tensor<128x4xf32>
   }
 
   func.func public @test_reduce_add_3to1dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
-    // CHECK: tensor.empty
-    // CHECK: "ttir.sum"
-    // CHECK-SAME: dim_arg = [1 : i32, 2 : i32],
-    // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x4xf32>,
-    // CHECK-SAME: -> tensor<128xf32>
+    // CHECK: "ttnn.sum"
+    // CHECK-SAME: dim_arg = [1 : i32, 2 : i32]
+    // CHECK-SAME: keep_dim = true
+    // CHECK-SAME: tensor<128x10x4xf32,
+    // CHECK-SAME: -> tensor<128x1x1xf32,
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: shape = [128 : i32]
+    // CHECK-SAME: tensor<128x1x1xf32,
+    // CHECK-SAME: -> tensor<128xf32,
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [1, 2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128xf32>
     return %0 : tensor<128xf32>
   }
 
   func.func public @test_reduce_add_3to0dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
-    // CHECK: tensor.empty
-    // CHECK: "ttir.sum"
-    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32],
-    // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x4xf32>,
-    // CHECK-SAME: -> tensor<1xf32>
+    // CHECK: "ttnn.sum"
+    // CHECK-NOT: dim_arg
+    // CHECK-SAME: keep_dim = true
+    // CHECK-SAME: tensor<128x10x4xf32,
+    // CHECK-SAME: -> tensor<1x1x1xf32,
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: shape = [1 : i32]
+    // CHECK-SAME: tensor<1x1x1xf32,
+    // CHECK-SAME: -> tensor<1xf32,
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [0, 1, 2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<f32>
     return %0 : tensor<f32>
   }
 
   func.func public @test_reduce_add_2to1dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
-    // CHECK: tensor.empty
-    // CHECK: "ttir.sum"
-    // CHECK-SAME: dim_arg = [1 : i32],
-    // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10xf32>,
-    // CHECK-SAME: -> tensor<128xf32>
+    // CHECK: "ttnn.sum"
+    // CHECK-SAME: dim_arg = [1 : i32]
+    // CHECK-SAME: keep_dim = true
+    // CHECK-SAME: tensor<128x10xf32,
+    // CHECK-SAME: -> tensor<128x1xf32,
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: shape = [128 : i32]
+    // CHECK-SAME: tensor<128x1xf32,
+    // CHECK-SAME: -> tensor<128xf32,
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<128xf32>
     return %0 : tensor<128xf32>
   }
 
   func.func public @test_reduce_add_2to0dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
-    // CHECK: tensor.empty
-    // CHECK: "ttir.sum"
-    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32],
-    // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10xf32>,
-    // CHECK-SAME: -> tensor<1xf32>
+    // CHECK: "ttnn.sum"
+    // CHECK-NOT: dim_arg
+    // CHECK-SAME: keep_dim = true
+    // CHECK-SAME: tensor<128x10xf32,
+    // CHECK-SAME: -> tensor<1x1xf32,
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: shape = [1 : i32]
+    // CHECK-SAME: tensor<1x1xf32,
+    // CHECK-SAME: -> tensor<1xf32,
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [0, 1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<f32>
     return %0 : tensor<f32>
   }
 
   func.func public @test_reduce_add_1to0dim(%arg0: tensor<128xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
-    // CHECK: tensor.empty
-    // CHECK: "ttir.sum"
-    // CHECK-SAME: dim_arg = [0 : i32],
-    // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128xf32>,
-    // CHECK-SAME: -> tensor<1xf32>
+    // CHECK: "ttnn.sum"
+    // CHECK-NOT: dim_arg
+    // CHECK-SAME: keep_dim = true
+    // CHECK-SAME: tensor<128xf32,
+    // CHECK-SAME: -> tensor<1xf32,
+    // CHECK-NOT: "ttnn.reshape"
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [0] : (tensor<128xf32>, tensor<f32>) -> tensor<f32>
     return %0 : tensor<f32>
   }

--- a/test/ttmlir/Silicon/StableHLO/reduce_add_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/reduce_add_op.mlir
@@ -5,8 +5,6 @@
 // RUN:     ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" > %t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 // RUN: FileCheck --input-file=%t.mlir %s
-// UNSUPPORTED: true
-// error: keepdim=False is not supported
 
 module @jit_reduce_add attributes {} {
   func.func public @test_reduce_add(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {

--- a/test/ttmlir/Silicon/StableHLO/reduce_maximum_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/reduce_maximum_op.mlir
@@ -5,18 +5,82 @@
 // RUN:     ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" > %t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 // RUN: FileCheck --input-file=%t.mlir %s
-// UNSUPPORTED: true
-// error: keepdim=False is not supported
 
 module @jit_reduce_maximum attributes {} {
-  func.func public @test_reduce_maximum(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
-    // CHECK-LABEL: func.func public @test_reduce_maximum
-    // CHECK: ttnn.max
+  func.func public @test_reduce_maximum_4to0dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.max"
+    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32, 3 : i32],
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x32x4xf32>,
+    // CHECK-SAME: -> tensor<1xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0, 1, 2, 3] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<f32>
+    return %0 : tensor<f32>
+  }
+
+  func.func public @test_reduce_maximum_3to2dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128x4xf32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.max"
     // CHECK-SAME: dim_arg = [1 : i32],
-    // CHECK-SAME: keep_dim = false}
-    // CHECK-SAME: tensor<128x10xf32,
-    // CHECK-SAME: -> tensor<128xf32
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x4xf32>,
+    // CHECK-SAME: -> tensor<128x4xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128x4xf32>
+    return %0 : tensor<128x4xf32>
+  }
+
+  func.func public @test_reduce_maximum_3to1dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.max"
+    // CHECK-SAME: dim_arg = [1 : i32, 2 : i32],
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x4xf32>,
+    // CHECK-SAME: -> tensor<128xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1, 2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128xf32>
+    return %0 : tensor<128xf32>
+  }
+
+  func.func public @test_reduce_maximum_3to0dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.max"
+    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32],
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x4xf32>,
+    // CHECK-SAME: -> tensor<1xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0, 1, 2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<f32>
+    return %0 : tensor<f32>
+  }
+
+  func.func public @test_reduce_maximum_2to1dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.max"
+    // CHECK-SAME: dim_arg = [1 : i32],
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10xf32>,
+    // CHECK-SAME: -> tensor<128xf32>
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<128xf32>
     return %0 : tensor<128xf32>
+  }
+
+  func.func public @test_reduce_maximum_2to0dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.max"
+    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32],
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10xf32>,
+    // CHECK-SAME: -> tensor<1xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0, 1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<f32>
+    return %0 : tensor<f32>
+  }
+
+  func.func public @test_reduce_maximum_1to0dim(%arg0: tensor<128xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+    // CHECK: tensor.empty
+    // CHECK: "ttir.max"
+    // CHECK-SAME: dim_arg = [0 : i32],
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128xf32>,
+    // CHECK-SAME: -> tensor<1xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0] : (tensor<128xf32>, tensor<f32>) -> tensor<f32>
+    return %0 : tensor<f32>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/reduce_maximum_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/reduce_maximum_op.mlir
@@ -1,85 +1,107 @@
 // REQUIRES: stablehlo
 // RUN: rm -rf %t.ttnn
 // RUN: rm -rf %t.mlir
-// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s | \
-// RUN:     ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" > %t.mlir
-// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" > %t.mlir
 // RUN: FileCheck --input-file=%t.mlir %s
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+// UNSUPPORTED: true
+// These tests are currently failing until a fix for this issue is uplifted
+// with new version of Metal: https://github.com/tenstorrent/tt-metal/issues/16104
+// TODO(mrakita): Enable and edit these tests after the Metal issue is fixed.
+// Tracked by: https://github.com/tenstorrent/tt-mlir/issues/1640
 
 module @jit_reduce_maximum attributes {} {
   func.func public @test_reduce_maximum_4to0dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
-    // CHECK: tensor.empty
-    // CHECK: "ttir.max"
-    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32, 3 : i32],
-    // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x32x4xf32>,
-    // CHECK-SAME: -> tensor<1xf32>
+    // CHECK: "ttnn.max"
+    // CHECK-NOT: dim_arg
+    // CHECK-SAME: keep_dim = true
+    // CHECK-SAME: tensor<128x10x32x4xf32,
+    // CHECK-SAME: -> tensor<1x1x1x1xf32,
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: shape = [1 : i32]
+    // CHECK-SAME: tensor<1x1x1x1xf32,
+    // CHECK-SAME: -> tensor<1xf32,
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0, 1, 2, 3] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<f32>
     return %0 : tensor<f32>
   }
 
   func.func public @test_reduce_maximum_3to2dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128x4xf32> {
-    // CHECK: tensor.empty
-    // CHECK: "ttir.max"
-    // CHECK-SAME: dim_arg = [1 : i32],
-    // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x4xf32>,
-    // CHECK-SAME: -> tensor<128x4xf32>
+    // CHECK: "ttnn.max"
+    // CHECK-SAME: dim_arg = [1 : i32]
+    // CHECK-SAME: keep_dim = true
+    // CHECK-SAME: tensor<128x10x4xf32,
+    // CHECK-SAME: -> tensor<128x1x4xf32,
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: shape = [128 : i32, 4 : i32]
+    // CHECK-SAME: tensor<128x1x4xf32,
+    // CHECK-SAME: -> tensor<128x4xf32,
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128x4xf32>
     return %0 : tensor<128x4xf32>
   }
 
   func.func public @test_reduce_maximum_3to1dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
-    // CHECK: tensor.empty
-    // CHECK: "ttir.max"
-    // CHECK-SAME: dim_arg = [1 : i32, 2 : i32],
-    // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x4xf32>,
-    // CHECK-SAME: -> tensor<128xf32>
+    // CHECK: "ttnn.max"
+    // CHECK-SAME: dim_arg = [1 : i32, 2 : i32]
+    // CHECK-SAME: keep_dim = true
+    // CHECK-SAME: tensor<128x10x4xf32,
+    // CHECK-SAME: -> tensor<128x1x1xf32,
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: shape = [128 : i32]
+    // CHECK-SAME: tensor<128x1x1xf32,
+    // CHECK-SAME: -> tensor<128xf32,
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1, 2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128xf32>
     return %0 : tensor<128xf32>
   }
 
   func.func public @test_reduce_maximum_3to0dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
-    // CHECK: tensor.empty
-    // CHECK: "ttir.max"
-    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32],
-    // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x4xf32>,
-    // CHECK-SAME: -> tensor<1xf32>
+    // CHECK: "ttnn.max"
+    // CHECK-NOT: dim_arg
+    // CHECK-SAME: keep_dim = true
+    // CHECK-SAME: tensor<128x10x4xf32,
+    // CHECK-SAME: -> tensor<1x1x1xf32,
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: shape = [1 : i32]
+    // CHECK-SAME: tensor<1x1x1xf32,
+    // CHECK-SAME: -> tensor<1xf32,
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0, 1, 2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<f32>
     return %0 : tensor<f32>
   }
 
   func.func public @test_reduce_maximum_2to1dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
-    // CHECK: tensor.empty
-    // CHECK: "ttir.max"
-    // CHECK-SAME: dim_arg = [1 : i32],
-    // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10xf32>,
-    // CHECK-SAME: -> tensor<128xf32>
+    // CHECK: "ttnn.max"
+    // CHECK-SAME: dim_arg = [1 : i32]
+    // CHECK-SAME: keep_dim = true
+    // CHECK-SAME: tensor<128x10xf32,
+    // CHECK-SAME: -> tensor<128x1xf32,
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: shape = [128 : i32]
+    // CHECK-SAME: tensor<128x1xf32,
+    // CHECK-SAME: -> tensor<128xf32,
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<128xf32>
     return %0 : tensor<128xf32>
   }
 
   func.func public @test_reduce_maximum_2to0dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
-    // CHECK: tensor.empty
-    // CHECK: "ttir.max"
-    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32],
-    // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10xf32>,
-    // CHECK-SAME: -> tensor<1xf32>
+    // CHECK: "ttnn.max"
+    // CHECK-NOT: dim_arg
+    // CHECK-SAME: keep_dim = true
+    // CHECK-SAME: tensor<128x10xf32,
+    // CHECK-SAME: -> tensor<1x1xf32,
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: shape = [1 : i32]
+    // CHECK-SAME: tensor<1x1xf32,
+    // CHECK-SAME: -> tensor<1xf32,
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0, 1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<f32>
     return %0 : tensor<f32>
   }
 
   func.func public @test_reduce_maximum_1to0dim(%arg0: tensor<128xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
-    // CHECK: tensor.empty
-    // CHECK: "ttir.max"
-    // CHECK-SAME: dim_arg = [0 : i32],
-    // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128xf32>,
-    // CHECK-SAME: -> tensor<1xf32>
+    // CHECK: "ttnn.max"
+    // CHECK-NOT: dim_arg
+    // CHECK-SAME: keep_dim = true
+    // CHECK-SAME: tensor<128xf32,
+    // CHECK-SAME: -> tensor<1xf32,
+    // CHECK-NOT: "ttnn.reshape"
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0] : (tensor<128xf32>, tensor<f32>) -> tensor<f32>
     return %0 : tensor<f32>
   }

--- a/test/ttmlir/Silicon/TTNN/simple_max.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_max.mlir
@@ -12,7 +12,7 @@
 module {
   func.func public @reduce_not_keep_dim(%arg0: tensor<128x10xf32>) -> tensor<128xf32> {
     %0 = tensor.empty() : tensor<128xf32>
-    // CHECK: "ttnn.mean"
+    // CHECK: "ttnn.max"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128x10xf32,
@@ -21,19 +21,19 @@ module {
     // CHECK-SAME: shape = [128 : i32]
     // CHECK-SAME: tensor<128x1xf32,
     // CHECK-SAME: -> tensor<128xf32,
-    %1 = "ttir.mean"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x10xf32>, tensor<128xf32>) -> tensor<128xf32>
+    %1 = "ttir.max"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x10xf32>, tensor<128xf32>) -> tensor<128xf32>
     return %1 : tensor<128xf32>
   }
 
   func.func public @reduce_keep_dim(%arg0: tensor<128x10xf32>) -> tensor<128x1xf32> {
     %0 = tensor.empty() : tensor<128x1xf32>
-    // CHECK: "ttnn.mean"
+    // CHECK: "ttnn.max"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128x10xf32,
     // CHECK-SAME: -> tensor<128x1xf32,
     // CHECK-NOT: "ttnn.reshape"
-    %1 = "ttir.mean"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<128x10xf32>, tensor<128x1xf32>) -> tensor<128x1xf32>
+    %1 = "ttir.max"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<128x10xf32>, tensor<128x1xf32>) -> tensor<128x1xf32>
     return %1 : tensor<128x1xf32>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/simple_sum.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_sum.mlir
@@ -12,7 +12,7 @@
 module {
   func.func public @reduce_not_keep_dim(%arg0: tensor<128x10xf32>) -> tensor<128xf32> {
     %0 = tensor.empty() : tensor<128xf32>
-    // CHECK: "ttnn.mean"
+    // CHECK: "ttnn.sum"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128x10xf32,
@@ -21,19 +21,19 @@ module {
     // CHECK-SAME: shape = [128 : i32]
     // CHECK-SAME: tensor<128x1xf32,
     // CHECK-SAME: -> tensor<128xf32,
-    %1 = "ttir.mean"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x10xf32>, tensor<128xf32>) -> tensor<128xf32>
+    %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x10xf32>, tensor<128xf32>) -> tensor<128xf32>
     return %1 : tensor<128xf32>
   }
 
   func.func public @reduce_keep_dim(%arg0: tensor<128x10xf32>) -> tensor<128x1xf32> {
     %0 = tensor.empty() : tensor<128x1xf32>
-    // CHECK: "ttnn.mean"
+    // CHECK: "ttnn.sum"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128x10xf32,
     // CHECK-SAME: -> tensor<128x1xf32,
     // CHECK-NOT: "ttnn.reshape"
-    %1 = "ttir.mean"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<128x10xf32>, tensor<128x1xf32>) -> tensor<128x1xf32>
+    %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<128x10xf32>, tensor<128x1xf32>) -> tensor<128x1xf32>
     return %1 : tensor<128x1xf32>
   }
 }


### PR DESCRIPTION
This PR adds TTNN workarounds for these Metal issues:
- https://github.com/tenstorrent/tt-metal/issues/13361 - By decomposing `reduce(keepDim=false)` into `reduce(keepDim=true) + reshape`
- https://github.com/tenstorrent/tt-metal/issues/16118 - By annulling dimensions argument when all dims are being reduced

As part of this work I've also:
- Enabled conversion of `stablehlo.reduce` op with multiple reduce dimensions
- Added reduce ops verifiers in TTIR
- Added a separate function in TTNNWorkarounds to run rewrite patterns for decomposition and layout workarounds
- Added lots of unit tests for reduce ops to cover conversions and verifiers
- Added lots of silicon tests for reduce ops

Opened issue https://github.com/tenstorrent/tt-mlir/issues/1624 on myself to revert these workarounds once Metal issues are fixed.

Closes #805, #848

After implementing these workarounds and running tests, I've encountered [another Metal issue](https://github.com/tenstorrent/tt-metal/issues/16104), this time in `reshape` op. I've debugged it and I have a local fix, I will send a PR to fix it in Metal repo, confirmed with reshape op owners. I've opened myself an issue https://github.com/tenstorrent/tt-mlir/issues/1640 to enable Reduce ops silicon tests after this fix is uplifted.

Another issue that I've encountered while working on this is that after the workaround pass decompositions, if we are changing the shapes of the ops tensors, that means that their layout needs to be changed too, but layout pass is done before the workaround pass. I've managed to solve it by reusing the layout of the input tensor, but I am not sure if that is a good solution and maybe we need to repeat some of the layout logic again after workaround decompositions. FYI @sdjordjevicTT 

Here is the example TTNN IR before the workarounds:
```
%3 = "ttnn.sum"(%2) <{dim_arg = [0: i32, 1 : i32, 2: i32], keep_dim = false}> : (tensor<128x32x4xf32, #ttnn_layout2>) -> tensor<1xf32, #ttnn_layout2>
```

and after the workarounds:
```
%3 = "ttnn.sum"(%2) <{keep_dim = true}> : (tensor<128x32x4xf32, #ttnn_layout2>) -> tensor<1x1x1xf32, #ttnn_layout2>
%4 = "ttnn.reshape"(%3) <{shape = [1 : i32]}> : (tensor<1x1x1xf32, #ttnn_layout2>) -> tensor<1xf32, #ttnn_layout3>
```