### PR TITLE
Uplift third_party/tt-metal to 5d0a53211ef2bfbf5f45b9f632bf360a4519a7d8 2024-12-19

### DIFF
--- a/test/ttmlir/Silicon/TTNN/regression/reshape_5d.mlir
+++ b/test/ttmlir/Silicon/TTNN/regression/reshape_5d.mlir
@@ -1,0 +1,20 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+// UNSUPPORTED: true
+// For ND tensors, shape dimensions greater than 4 should be 1, shape at index0 is 2
+
+module @ReshapeTest attributes {} {
+  func.func @forward(%arg0: tensor<4x49x384xf32> {ttir.name = "inp_1"}, %arg1: tensor<4x49x384xf32> {ttir.name = "inp_2"}) -> (tensor<196x384xf32> {ttir.name = "ReshapeTest_295.output_reshape_743"}) {
+    %0 = tensor.empty() : tensor<4x49x384xf32>
+    %1 = "ttir.add"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<4x49x384xf32>, tensor<4x49x384xf32>, tensor<4x49x384xf32>) -> tensor<4x49x384xf32>
+    %2 = tensor.empty() : tensor<2x2x7x7x384xf32>
+    %3 = "ttir.reshape"(%1, %2) <{shape = [2 : i32, 2 : i32, 7 : i32, 7 : i32, 384 : i32]}> : (tensor<4x49x384xf32>, tensor<2x2x7x7x384xf32>) -> tensor<2x2x7x7x384xf32>
+    %4 = tensor.empty() : tensor<2x7x2x7x384xf32>
+    // CHECK: %[[C:.*]] = "ttnn.transpose"[[C:.*]]
+    %5 = "ttir.transpose"(%3, %4) <{dim0 = -4 : si32, dim1 = -3 : si32}> : (tensor<2x2x7x7x384xf32>, tensor<2x7x2x7x384xf32>) -> tensor<2x7x2x7x384xf32>
+    %6 = tensor.empty() : tensor<196x384xf32>
+    %7 = "ttir.reshape"(%5, %6) <{shape = [196 : i32, 384 : i32]}> : (tensor<2x7x2x7x384xf32>, tensor<196x384xf32>) -> tensor<196x384xf32>
+    return %7 : tensor<196x384xf32>
+  }
+}

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "eacc150772450e8046249467ac4a0d61d3b3a319")
+set(TT_METAL_VERSION "581ef5f2e0517be410161ff22b6a2f197d4f61f6")
 
 if ("$ENV{ARCH_NAME}" STREQUAL "grayskull")
   set(ARCH_NAME "grayskull")

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "bbce2c3359e128273a38e2afdcf5e346a0941858")
+set(TT_METAL_VERSION "eacc150772450e8046249467ac4a0d61d3b3a319")
 
 if ("$ENV{ARCH_NAME}" STREQUAL "grayskull")
   set(ARCH_NAME "grayskull")
@@ -27,6 +27,7 @@ set(TTMETAL_INCLUDE_DIRS
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/hw/inc/${ARCH_NAME}
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/hw/inc/${ARCH_EXTRA_DIR}
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/umd/src/firmware/riscv/${ARCH_NAME}
+  ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/tracy/public
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_eager
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal-build/include
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/reflect/e75434c4c5f669e4a74e4d84e0a30d7249c1e66f


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to 5d0a53211ef2bfbf5f45b9f632bf360a4519a7d8 + cherry-picks/reverts 2024-12-19 (Evening)

  - for hang fix (https://github.com/tenstorrent/tt-metal/issues/16141) needed for tt-forge-fe ReshapeOp test hang (was xfail, assert before)
 - Need to add new include path to find Tracy.hpp
 - Uplift to tt-metal branch kmabee/metal-dec19-5d0a53211-with-patches to get something stable
 - Add Unsupported reshape_5d.mlir test copied from tt-forge-fe ReshapeTest

