### PR TITLE
Improve ModifySignaturesForDylib pass

### DIFF
--- a/include/ttmlir/Conversion/TTNNToEmitC/Utils.h
+++ b/include/ttmlir/Conversion/TTNNToEmitC/Utils.h
@@ -12,6 +12,16 @@
 
 namespace mlir::tt::ttnn_to_emitc::utils {
 
+// Name for the function that creates a std::vector from a variadic number of
+// `ttnn::Tensor`s
+//
+inline constexpr char kCreateVectorFunctionName[] = "utilCreateVec";
+
+// Inserts a func::FuncOp to top of the caller's module that takes in a variadic
+// number of `ttnn::Tensor`s and returns them packed into a `std::vector`
+//
+bool insertVecCreateFnIfNotExists(PatternRewriter &rewriter, Operation *op);
+
 // Create emitc::OpaqueAttr for ttnn::Shape
 //
 emitc::OpaqueAttr convertShape(Builder &builder, ttnn::ShapeAttr attr);

--- a/include/ttmlir/Dialect/TT/IR/TTOps.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOps.td
@@ -17,7 +17,7 @@ def TT_GetTupleElementOp: TT_Op<"get_tuple_element", [Pure, DeclareOpInterfaceMe
 
       Example:
       ```mlir
-      %result = tt.get_tuple_element %operand[0] : (tuple<tensor<32x32xbf16>, tuple<tensor<1x32xf32>>>) -> tensor<32x32xbf16>
+      %result = tt.get_tuple_element %operand[0] : (tuple<tensor<32x32xbf16>, tensor<1x32xf32>>) -> tensor<32x32xbf16>
       ```
     }];
 
@@ -25,11 +25,30 @@ def TT_GetTupleElementOp: TT_Op<"get_tuple_element", [Pure, DeclareOpInterfaceMe
                          ConfinedAttr<I32Attr, [IntNonNegative]>:$index
     );
 
-    let results = (outs TT_TupleReturnType:$result);
+    let results = (outs TT_TupleMemberType:$result);
 
     let assemblyFormat = [{
       $operand `[` $index `]` attr-dict `:` functional-type(operands, results)
     }];
+}
+
+def TT_TupleOp : TT_Op<"tuple", [Pure, DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
+  let summary = "Tuple operation";
+  let description = [{
+    Produces a `result` tuple from operands `operands`.
+
+    Example:
+    ```mlir
+    %result = tt.tuple %operand0, %operand1 : tuple<tensor<32xbf16, tensor<1x32xf32>>
+    ```
+  }];
+
+  let arguments = (ins Variadic<TT_TupleMemberType>:$operands);
+  let results = (outs TT_Tuple:$result);
+
+  let assemblyFormat = [{
+    $operands attr-dict `:` custom<TupleOpType>(type($operands), type($result))
+  }];
 }
 
 #endif

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -494,6 +494,6 @@ def TT_Device : TT_Type<"Device", "device", []> {
 
 def TT_Tuple : NestedTupleOf<[AnyRankedTensor]>;
 
-def TT_TupleReturnType : AnyTypeOf<[AnyRankedTensor]>;
+def TT_TupleMemberType : AnyTypeOf<[AnyRankedTensor]>;
 
 #endif

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -95,24 +95,35 @@ def TTNNModifySignaturesForDylib: Pass<"ttnn-modify-signatures-for-dylib", "::ml
     form. Essentially, input tensors are packed into a tuple and then accessed
     in the function body. This allows for easier interfacing with the generated
     dylib as the signatures are then uniform across all forward functions.
+    Device object is hoisted from func body to the signature as well. Return
+    type is also modified to be a tuple.
 
     Given a forward function like this:
 
     ```mlir
     func.func @add(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>) -> tensor<32x32xbf16> {
-      %0 = "ttnn.add"(%arg0, %arg1) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
-      return %0 : tensor<32x32xbf16>
+      %0 = "ttnn.get_device"() : () -> !tt.device<#device>
+      %1 = "ttnn.to_device"(%arg0, %0) : (tensor<32x32xbf16, !tt.device<#device>) -> tensor<32x32xbf16>
+      %2 = "ttnn.to_device"(%arg1, %0) : (tensor<32x32xbf16, !tt.device<#device>) -> tensor<32x32xbf16>
+      %3 = "ttnn.add"(%1, %2) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+      return %3 : tensor<32x32xbf16>
     }
     ```
 
-    The pass will modify the signature and prepend unpacking ops like so:
+    The pass will modify the signature such that:
+    - input tensors are packed into a tuple
+    - get_device op is removed and device object is hoisted to the signature
+    - return type is modified to be a tuple
 
     ```mlir
-    func.func @add(%arg0: tuple<tensor<32x32xbf16>, tensor<32x32xbf16>>) -> tensor<32x32xbf16> {
+    func.func @add(%arg0: tuple<tensor<32x32xbf16>, tensor<32x32xbf16>>, %arg1: !tt.device<#device>) -> tuple<tensor<32x32xbf16>> {
       %0 = tt.get_tuple_element %arg0[0] : (tuple<tensor<32x32xbf16>, tensor<32x32xbf16>>) -> tensor<32x32xbf16>
       %1 = tt.get_tuple_element %arg0[1] : (tuple<tensor<32x32xbf16>, tensor<32x32xbf16>>) -> tensor<32x32xbf16>
-      %2 = "ttnn.add"(%0, %1) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
-      return %2 : tensor<32x32xbf16>
+      %2 = "ttnn.to_device"(%0, %arg1) : (tensor<32x32xbf16, !tt.device<#device>) -> tensor<32x32xbf16>
+      %3 = "ttnn.to_device"(%1, %arg1) : (tensor<32x32xbf16, !tt.device<#device>) -> tensor<32x32xbf16>
+      %4 = "ttnn.add"(%2, %3) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+      %5 = tt.tuple %4 : tuple<tensor<32x32xbf16>>
+      return %5 : tuple<tensor<32x32xbf16>>
     }
     ```
   }];

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -613,6 +613,31 @@ public:
   }
 };
 
+class TupleOpConversionPattern : public OpConversionPattern<tt::TupleOp> {
+
+public:
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(tt::TupleOp tupleOp, tt::TupleOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // EmitC doesn't offer a way to create a vector from a list of values, so we
+    // need to create a utility function that does this. This is achieved by
+    // using EmitC's VerbatimOp.
+
+    // Try to find if utility vec creation function is already defined in the
+    // module. If not, insert it.
+    //
+    ttnn_to_emitc::utils::insertVecCreateFnIfNotExists(rewriter, tupleOp);
+
+    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
+        tupleOp, this->getTypeConverter()->convertType(tupleOp.getType()),
+        ttnn_to_emitc::utils::kCreateVectorFunctionName, nullptr, nullptr,
+        adaptor.getOperands());
+    return success();
+  }
+};
+
 // Module Op conversion pattern
 //
 // This conversion pattern removes attributes from the ModuleOp. Previously,
@@ -772,13 +797,14 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
   //
   patterns.add<ArithConstantOpConversionPattern>(typeConverter, ctx);
 
-  // Module op
-  //
-  patterns.add<ModuleOpConversionPattern>(typeConverter, ctx);
-
   // Tuple ops
   //
   patterns.add<GetTupleElementOpConversionPattern>(typeConverter, ctx);
+  patterns.add<TupleOpConversionPattern>(typeConverter, ctx);
+
+  // Module op
+  //
+  patterns.add<ModuleOpConversionPattern>(typeConverter, ctx);
 }
 
 } // namespace mlir::tt

--- a/lib/Conversion/TTNNToEmitC/Utils.cpp
+++ b/lib/Conversion/TTNNToEmitC/Utils.cpp
@@ -10,6 +10,8 @@
 
 namespace mlir::tt::ttnn_to_emitc::utils {
 
+// Returns the closest parent module of the given operation
+//
 mlir::ModuleOp getParentModule(mlir::Operation *op) {
   while (op) {
     if (auto moduleOp = llvm::dyn_cast<mlir::ModuleOp>(op)) {
@@ -20,6 +22,9 @@ mlir::ModuleOp getParentModule(mlir::Operation *op) {
   return nullptr;
 }
 
+// The func::FuncOp is inserted by creating an emitc::VerbatimOp with the
+// function definition and inserting it at the start of the module.
+//
 bool insertVecCreateFnIfNotExists(PatternRewriter &rewriter, Operation *op) {
   ModuleOp moduleOp = getParentModule(op);
   assert(op && "Could not find top-level module");

--- a/lib/Conversion/TTNNToEmitC/Utils.cpp
+++ b/lib/Conversion/TTNNToEmitC/Utils.cpp
@@ -31,8 +31,8 @@ bool insertVecCreateFnIfNotExists(PatternRewriter &rewriter, Operation *op) {
 
   static constexpr const char *vecCreateFnAsStr = R"(
 template <typename... T>
-std::vector<ttnn::Tensor> utilCreateVec(const T &&...t) {
-  return std::vector<ttnn::Tensor>{std::forward(t)...};
+std::vector<ttnn::Tensor> utilCreateVec(T &&...t) {
+  return std::vector<ttnn::Tensor>{std::forward<T>(t)...};
 }
 )";
 

--- a/lib/Dialect/TT/IR/TTOps.cpp
+++ b/lib/Dialect/TT/IR/TTOps.cpp
@@ -5,6 +5,30 @@
 #include "ttmlir/Dialect/TT/IR/TTOps.h"
 #include "ttmlir/Dialect/TT/IR/TT.h"
 
+using namespace mlir;
+
+static void printTupleOpType(OpAsmPrinter &p, Operation *, TypeRange,
+                             Type result) {
+  p.printType(result);
+}
+
+static ParseResult parseTupleOpType(OpAsmParser &parser,
+                                    SmallVectorImpl<Type> &operands,
+                                    Type &result) {
+  // Result type must be tuple type.
+  llvm::SMLoc loc = parser.getCurrentLocation();
+  if (parser.parseType(result))
+    return failure();
+
+  auto tupType = dyn_cast<TupleType>(result);
+  if (!tupType)
+    return parser.emitError(loc, "expected tuple type");
+
+  // Assign operand types to tuple types
+  llvm::append_range(operands, tupType.getTypes());
+  return success();
+}
+
 #define GET_OP_CLASSES
 #include "ttmlir/Dialect/TT/IR/TTOps.cpp.inc"
 
@@ -28,6 +52,25 @@ LogicalResult GetTupleElementOp::inferReturnTypes(
   }
 
   inferredReturnTypes.push_back(operandType.getType(adaptor.getIndex()));
+  return success();
+}
+
+LogicalResult inferTupleOp(MLIRContext *context, std::optional<Location>,
+                           ValueRange val,
+                           SmallVectorImpl<Type> &inferredReturnTypes) {
+  inferredReturnTypes.push_back(TupleType::get(context, val.getTypes()));
+  return success();
+}
+
+LogicalResult TupleOp::inferReturnTypes(
+    MLIRContext *context, std::optional<Location> location, ValueRange operands,
+    DictionaryAttr attributes, OpaqueProperties properties, RegionRange regions,
+    SmallVectorImpl<Type> &inferredReturnTypes) {
+
+  TupleOp::Adaptor adaptor(operands, attributes, properties, regions);
+
+  inferredReturnTypes.push_back(
+      TupleType::get(context, adaptor.getOperands().getTypes()));
   return success();
 }
 

--- a/lib/Dialect/TT/IR/TTOps.cpp
+++ b/lib/Dialect/TT/IR/TTOps.cpp
@@ -17,12 +17,14 @@ static ParseResult parseTupleOpType(OpAsmParser &parser,
                                     Type &result) {
   // Result type must be tuple type.
   llvm::SMLoc loc = parser.getCurrentLocation();
-  if (parser.parseType(result))
+  if (parser.parseType(result)) {
     return failure();
+  }
 
   auto tupType = dyn_cast<TupleType>(result);
-  if (!tupType)
+  if (!tupType) {
     return parser.emitError(loc, "expected tuple type");
+  }
 
   // Assign operand types to tuple types
   llvm::append_range(operands, tupType.getTypes());

--- a/test/ttmlir/Dialect/TTNN/Transforms/ttnn_modify_signatures_for_dylib_0.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/ttnn_modify_signatures_for_dylib_0.mlir
@@ -1,12 +1,24 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" --ttnn-modify-signatures-for-dylib %s | FileCheck %s
 
 module attributes {} {
-  // CHECK: func.func @add(%arg0: tuple<[[TENSOR_A:.*>]], [[TENSOR_B:.*>]]>) -> tensor<32x32xbf16, #ttnn_layout> {
+  // CHECK: func.func @add(%arg0: tuple<[[TENSOR_A:.*>]], [[TENSOR_B:.*>]]>, %arg1: !tt.device<#device>) -> tuple<tensor<32x32xbf16, #ttnn_layout>> {
   func.func @add(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>) -> tensor<32x32xbf16> {
     // CHECK-NEXT: %0 = tt.get_tuple_element %arg0[0] : (tuple<[[TENSOR_A]], [[TENSOR_B]]>) -> [[TENSOR_A]]
     // CHECK-NEXT: %1 = tt.get_tuple_element %arg0[1] : (tuple<[[TENSOR_A]], [[TENSOR_B]]>) -> [[TENSOR_B]]
     %0 = tensor.empty() : tensor<32x32xbf16>
     %1 = "ttir.add"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
     return %1 : tensor<32x32xbf16>
+  }
+
+  // CHECK: func.func @multiple_returns(%arg0: tuple<[[TENSOR_A:.*>]], [[TENSOR_B:.*>]], [[TENSOR_C:.*>]]>, %arg1: !tt.device<#device>) -> tuple<tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout>> {
+  func.func @multiple_returns(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>, %arg2: tensor<32x32xbf16>) -> (tensor<32x32xbf16>, tensor<32x32xbf16>) {
+    // CHECK-NEXT: %0 = tt.get_tuple_element %arg0[0] : (tuple<[[TENSOR_A]], [[TENSOR_B]], [[TENSOR_C]]>) -> [[TENSOR_A]]
+    // CHECK-NEXT: %1 = tt.get_tuple_element %arg0[1] : (tuple<[[TENSOR_A]], [[TENSOR_B]], [[TENSOR_C]]>) -> [[TENSOR_B]]
+    // CHECK-NEXT: %2 = tt.get_tuple_element %arg0[2] : (tuple<[[TENSOR_A]], [[TENSOR_B]], [[TENSOR_C]]>) -> [[TENSOR_C]]
+    %0 = tensor.empty() : tensor<32x32xbf16>
+    %1 = "ttir.add"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+    %2 = tensor.empty() : tensor<32x32xbf16>
+    %3 = "ttir.add"(%arg1, %arg2, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+    return %1, %3 : tensor<32x32xbf16>, tensor<32x32xbf16>
   }
 }


### PR DESCRIPTION
ModifySignaturesForDylib pass now packs return values into a tuple. It also hoists the `ttnn::GetDeviceOp` from function's body into its signature, as `DeviceType`.

`tt::TupleOp` was added to allow for creation of tuples.

There was a slightly tricky part in `TTNNToEmitC` pass when converting the new `tt::TupleOp` into a `std::vector`. EmitC doesn't provide any way to call a function (e.g. vector constructor) with an initializer list, nor does it allow calling of member functions (it is emitc after all, not emitcpp 😢) which would've been an avenue for `vec.push_back()`. Instead, I've used `emitc::VerbatimOp` to create a utility function at the top of the func's module. The utility function takes in a variadic number of tensors and packs them into a vector:

```C++
template <typename... T>
std::vector<ttnn::Tensor> utilCreateVec(T &&...t) {
  return std::vector<ttnn::Tensor>{std::forward<T>(t)...};
}
```

Closes #1643 