### PR TITLE
Fix for downstream check during uplift

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -32,7 +32,7 @@ jobs:
           gh workflow run ${{ env.WORKFLOW_NAME }} \
             --repo ${{ env.TARGET_REPO }} --ref main \
             --field test_mark=push \
-            --field mlir_override=${{ github.sha }}
+            --field mlir_override=${{ github.event.pull_request.head.sha }}
           gh run list --workflow=${{ env.WORKFLOW_NAME }} --repo ${{ env.TARGET_REPO }} --limit 1
           echo "Triggered ${{ env.TARGET_REPO }}"
           echo "### Triggered [${{ env.TARGET_REPO }}](https://github.com/${{ env.TARGET_REPO }}/actions/workflows/${{ env.WORKFLOW_NAME }}) :rocket:" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Use pull request sha when triggering downstream check (github.event.pull_request.head.sha) instead of github.sha. It seems that github.sha is pointing to temp merge that is created to run the PR workflow, and not the original commit.