### PR TITLE
Uplift third_party/tt-metal to 8ab8736293d4213be6dd9e7585a80c2acdcac855 2024-12-20

### DIFF
--- a/test/ttmlir/Silicon/TTNN/regression/unsqueeze.mlir
+++ b/test/ttmlir/Silicon/TTNN/regression/unsqueeze.mlir
@@ -1,0 +1,11 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+module @Unsqueeze attributes {} {
+  func.func @forward(%arg0: tensor<32xbf16> {ttir.name = "a"}) -> (tensor<1x32xbf16> {ttir.name = "Unsqueeze_393.output_unsqueeze_1214"}) {
+    %0 = tensor.empty() : tensor<1x32xbf16>
+    // CHECK: %[[C:.*]] = "ttnn.reshape"[[C:.*]]
+    %1 = "ttir.unsqueeze"(%arg0, %0) <{dim = 0 : si32}> : (tensor<32xbf16>, tensor<1x32xbf16>) -> tensor<1x32xbf16>
+    return %1 : tensor<1x32xbf16>
+  }
+}

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "581ef5f2e0517be410161ff22b6a2f197d4f61f6")
+set(TT_METAL_VERSION "8ab8736293d4213be6dd9e7585a80c2acdcac855")
 
 if ("$ENV{ARCH_NAME}" STREQUAL "grayskull")
   set(ARCH_NAME "grayskull")


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 8ab8736293d4213be6dd9e7585a80c2acdcac855

Include a unsqueeze.mlir test from tt-forge-fe that was previously failing recently, but appears fixed now