### PR TITLE
Adjust optimizer team codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,7 @@
 /docs/ @nsmithtt
 /env/ @nsmithtt
 /.github/ @vmilosevic @tapspatel
+/.github/CODEOWNERS @vmilosevic @tapspatel @nsmithtt @sdjordjevicTT
 /include/ttmlir/Conversion/TTIRToTTNN/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @jserbedzijaTT @jnie-TT @azecevicTT
 /include/ttmlir/Conversion/TTNNToEmitC/ @svuckovicTT @sdjordjevicTT @mtopalovicTT @jserbedzijaTT @azecevicTT
 /include/ttmlir/Dialect/TT/ @sdjordjevicTT @nsmithtt @svuckovicTT @mtopalovicTT @mrakitaTT @nobradovictt @jserbedzijaTT @azecevicTT
@@ -12,7 +13,8 @@
 /include/ttmlir/Dialect/TTKernel/ @nsmithtt @rjakovljevicTT
 /include/ttmlir/Dialect/TTMetal/ @nsmithtt
 /include/ttmlir/Dialect/TTNN/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @nobradovictt @jserbedzijaTT @azecevicTT
-/include/ttmlir/Dialect/TTNN/Analysis/ @nobradovictt @odjuricicTT
+/include/ttmlir/Dialect/TTNN/Analysis/ @odjuricicTT @tt-mpantic @sdjordjevicTT @nobradovictt
+/include/ttmlir/OpModel/ @odjuricicTT @tt-mpantic @sdjordjevicTT @nobradovictt
 /lib/Conversion/TTIRToTTNN/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @jserbedzijaTT @azecevicTT
 /lib/Conversion/TTNNToEmitC/ @svuckovicTT @sdjordjevicTT @mtopalovicTT @jserbedzijaTT @azecevicTT
 /lib/Dialect/TT/ @sdjordjevicTT @nsmithtt @svuckovicTT @mtopalovicTT @mrakitaTT @nobradovictt @jserbedzijaTT @azecevicTT
@@ -21,12 +23,14 @@
 /lib/Dialect/TTMetal/ @nsmithtt
 /lib/Dialect/TTNN/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @nobradovictt @jserbedzijaTT @jnie-TT @azecevicTT
 /lib/Dialect/TTNN/Analysis/ @odjuricicTT @nobradovictt
-/python/ @nsmithtt @tapspatel @odjuricicTT @vprajapati-tt
+/lib/OpModel/ @odjuricicTT @tt-mpantic @sdjordjevicTT @nobradovictt
+/python/ @nsmithtt @tapspatel @odjuricicTT @vprajapati-tt @vcanicTT
 /python/test_infra/ @nsmithtt @tapspatel @vprajapati-tt
 /runtime/ @jnie-TT @kmabeeTT @AleksKnezevic @pilkicTT
 /runtime/tools/ @tapspatel @nsmithtt
-/test/ttmlir/Dialect/TTNN/optimizer/ @nobradovictt @odjuricicTT
-/test/ttmlir/Silicon/TTNN/optimizer/ @nobradovictt @odjuricicTT
-/test/unittests/Optimizer @nobradovictt @odjuricicTT
+/test/ttmlir/Dialect/TTNN/optimizer/ @odjuricicTT @tt-mpantic @sdjordjevicTT @nobradovictt
+/test/ttmlir/Silicon/TTNN/optimizer/ @odjuricicTT @tt-mpantic @sdjordjevicTT @nobradovictt
+/test/unittests/Optimizer @odjuricicTT @tt-mpantic @sdjordjevicTT @nobradovictt
+/test/unittests/OpModel @odjuricicTT @tt-mpantic @sdjordjevicTT @nobradovictt
 /tools/ @svuckovicTT @mtopalovicTT
-/tools/explorer/ @odjuricicTT @nobradovictt @vprajapati-tt
+/tools/explorer/ @odjuricicTT @tt-mpantic @sdjordjevicTT @nobradovictt @vprajapati-tt

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 /docs/ @nsmithtt
 /env/ @nsmithtt
 /.github/ @vmilosevic @tapspatel
-/.github/CODEOWNERS @vmilosevic @tapspatel @nsmithtt @sdjordjevicTT
+/.github/CODEOWNERS @vmilosevic @tapspatel @nsmithtt @sdjordjevicTT @tt-mpantic
 /include/ttmlir/Conversion/TTIRToTTNN/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @jserbedzijaTT @jnie-TT @azecevicTT
 /include/ttmlir/Conversion/TTNNToEmitC/ @svuckovicTT @sdjordjevicTT @mtopalovicTT @jserbedzijaTT @azecevicTT
 /include/ttmlir/Dialect/TT/ @sdjordjevicTT @nsmithtt @svuckovicTT @mtopalovicTT @mrakitaTT @nobradovictt @jserbedzijaTT @azecevicTT


### PR DESCRIPTION
1. Add additional codeowners for optimizer components to account for Nikola leaving.
2. Add ownership of TTNN Interface implementation.
3. Add two more people to own the CODEOWNERS file itself to have more redundancy.