### PR TITLE
Canonicalization of TTIR ops

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIRBase.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRBase.td
@@ -43,4 +43,16 @@ def TTIR_Dialect : Dialect {
 class TTIR_Op<string mnemonic, list<Trait> traits = []> :
         Op<TTIR_Dialect, mnemonic, !listconcat(traits, [Pure])>;
 
+//===----------------------------------------------------------------------===//
+// TTIR traits definition.
+//===----------------------------------------------------------------------===//
+
+class TTIR_Trait<string name> : NativeOpTrait<""> {
+  let trait = name;
+  let cppNamespace = "::mlir::tt::ttir::OpTrait";
+}
+
+def ConditionalDPSInvolution : TTIR_Trait<"ConditionalDPSInvolution">;
+def ConditionalDPSIdempotence : TTIR_Trait<"ConditionalDPSIdempotence">;
+
 #endif

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRBase.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRBase.td
@@ -57,8 +57,14 @@ class TTIR_Trait<string name, list<Trait> traits = []> : NativeOpTrait<name, tra
   let cppNamespace = "::mlir::tt::ttir::OpTrait";
 }
 
+// Involution is property of an operation where applying the operation twice results in the original value.
+// Example: not(not(x)) == x
 def TTIR_Involution : TTIR_Trait<"TTIRInvolution", [DestinationStyleOpInterface, TwoOperands, NoMemoryEffect]>;
+// Idempotence is property of an operation where applying the operation twice results in the same value as applying it once.
+// Example: abs(abs(x)) == abs(x)
 def TTIR_Idempotence : TTIR_Trait<"TTIRIdempotence", [DestinationStyleOpInterface, TwoOperands, NoMemoryEffect]>;
+// BinaryIdempotence is property of a binary operation where applying the operation on the same value results in the same value.
+// Example: and(x, x) == x
 def TTIR_BinaryIdempotence : TTIR_Trait<"TTIRBinaryIdempotence", [DestinationStyleOpInterface, ThreeOperands, NoMemoryEffect]>;
 
 #endif

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRBase.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRBase.td
@@ -59,5 +59,6 @@ class TTIR_Trait<string name, list<Trait> traits = []> : NativeOpTrait<name, tra
 
 def TTIR_Involution : TTIR_Trait<"TTIRInvolution", [DestinationStyleOpInterface, TwoOperands, NoMemoryEffect]>;
 def TTIR_Idempotence : TTIR_Trait<"TTIRIdempotence", [DestinationStyleOpInterface, TwoOperands, NoMemoryEffect]>;
+def TTIR_BinaryIdempotence : TTIR_Trait<"TTIRBinaryIdempotence", [DestinationStyleOpInterface, ThreeOperands, NoMemoryEffect]>;
 
 #endif

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRBase.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRBase.td
@@ -6,9 +6,8 @@
 #define TTMLIR_TTMLIR_DIALECT_TTIR_TTIRDIALECT_TD
 
 include "mlir/IR/OpBase.td"
-include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/Interfaces/DestinationStyleOpInterface.td"
-
+include "mlir/Interfaces/SideEffectInterfaces.td"
 
 //===----------------------------------------------------------------------===//
 // TTIR dialect definition.

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRBase.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRBase.td
@@ -7,6 +7,8 @@
 
 include "mlir/IR/OpBase.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/Interfaces/DestinationStyleOpInterface.td"
+
 
 //===----------------------------------------------------------------------===//
 // TTIR dialect definition.
@@ -41,18 +43,21 @@ def TTIR_Dialect : Dialect {
 //===----------------------------------------------------------------------===//
 
 class TTIR_Op<string mnemonic, list<Trait> traits = []> :
-        Op<TTIR_Dialect, mnemonic, !listconcat(traits, [Pure])>;
+        Op<TTIR_Dialect, mnemonic, !listconcat([Pure], traits)>;
 
 //===----------------------------------------------------------------------===//
 // TTIR traits definition.
 //===----------------------------------------------------------------------===//
 
-class TTIR_Trait<string name> : NativeOpTrait<""> {
-  let trait = name;
+def TwoOperands : ParamNativeOpTrait<"NOperands", "2">;
+def ThreeOperands : ParamNativeOpTrait<"NOperands", "3">;
+def FourOperands : ParamNativeOpTrait<"NOperands", "4">;
+
+class TTIR_Trait<string name, list<Trait> traits = []> : NativeOpTrait<name, traits> {
   let cppNamespace = "::mlir::tt::ttir::OpTrait";
 }
 
-def ConditionalDPSInvolution : TTIR_Trait<"ConditionalDPSInvolution">;
-def ConditionalDPSIdempotence : TTIR_Trait<"ConditionalDPSIdempotence">;
+def TTIR_Involution : TTIR_Trait<"TTIRInvolution", [DestinationStyleOpInterface, TwoOperands, NoMemoryEffect]>;
+def TTIR_Idempotence : TTIR_Trait<"TTIRIdempotence", [DestinationStyleOpInterface, TwoOperands, NoMemoryEffect]>;
 
 #endif

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.h
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.h
@@ -5,18 +5,18 @@
 #ifndef TTMLIR_DIALECT_TTIR_IR_TTIROPS_H
 #define TTMLIR_DIALECT_TTIR_IR_TTIROPS_H
 
+#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIROpsInterfaces.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIRTraits.h"
 
 #include "mlir/Bytecode/BytecodeOpInterface.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/PatternMatch.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Interfaces/DestinationStyleOpInterface.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
-#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
-
-#include "TTIROpsInterfaces.h"
 
 #include "ttmlir/Dialect/TTIR/IR/TTIROpsEnums.h.inc"
 

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.h
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.h
@@ -5,6 +5,8 @@
 #ifndef TTMLIR_DIALECT_TTIR_IR_TTIROPS_H
 #define TTMLIR_DIALECT_TTIR_IR_TTIROPS_H
 
+#include "ttmlir/Dialect/TTIR/IR/TTIRTraits.h"
+
 #include "mlir/Bytecode/BytecodeOpInterface.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OpDefinition.h"

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -752,7 +752,6 @@ def TTIR_SoftmaxOp : TTIR_DPSOp<"softmax"> {
     let hasVerifier = 1;
 }
 
-// TODO (azecevic): FOLDABLE
 def TTIR_TransposeOp : TTIR_DPSOp<"transpose"> {
     let summary = "Transpose op.";
     let description = [{
@@ -771,6 +770,8 @@ def TTIR_TransposeOp : TTIR_DPSOp<"transpose"> {
     }];
 
     let hasVerifier = 1;
+
+    let hasCanonicalizer = 1;
 }
 
 def TTIR_ConcatOp : TTIR_DPSOp<"concat"> {

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -1328,6 +1328,8 @@ def TTIR_LinearOp : TTIR_DPSOp<"linear"> {
     }];
 
     let hasVerifier = 1;
+
+    let hasCanonicalizeMethod = 1;
 }
 
 // ANCHOR: adding_an_op_matmul_ttir

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -191,7 +191,7 @@ def ThreeOperands : ParamNativeOpTrait<"NOperands", "3">;
 def FourOperands : ParamNativeOpTrait<"NOperands", "4">;
 
 class TTIR_ElementwiseOp<string mnemonic, list<Trait> traits = []> :
-    TTIR_DPSOp<mnemonic, !listconcat(traits, [AttrSizedOperandSegments, TTIR_Broadcastable])> {
+    TTIR_DPSOp<mnemonic, !listconcat(traits, [AttrSizedOperandSegments, TTIR_Broadcastable, Pure])> {
 
     let description = [{
       Base class for elementwise operations. Elementwise operations can take inputs with different shape,
@@ -242,7 +242,7 @@ class TTIR_ElementwiseUnaryOp<string mnemonic, list<Trait> traits = []> :
     ];
 }
 
-def TTIR_AbsOp: TTIR_ElementwiseUnaryOp<"abs"> {
+def TTIR_AbsOp: TTIR_ElementwiseUnaryOp<"abs", [ConditionalDPSIdempotence]> {
     let summary = "Eltwise absolute op.";
     let description = [{
       Eltwise absolute operation.
@@ -256,7 +256,7 @@ def TTIR_CbrtOp: TTIR_ElementwiseUnaryOp<"cbrt"> {
     }];
 }
 
-def TTIR_CeilOp: TTIR_ElementwiseUnaryOp<"ceil"> {
+def TTIR_CeilOp: TTIR_ElementwiseUnaryOp<"ceil", [ConditionalDPSIdempotence]> {
     let summary = "Eltwise ceil op.";
     let description = [{
       Eltwise ceil operation.
@@ -270,7 +270,7 @@ def TTIR_CosOp: TTIR_ElementwiseUnaryOp<"cos"> {
     }];
 }
 
-def TTIR_FloorOp: TTIR_ElementwiseUnaryOp<"floor"> {
+def TTIR_FloorOp: TTIR_ElementwiseUnaryOp<"floor", [ConditionalDPSIdempotence]> {
     let summary = "Eltwise floor op.";
     let description = [{
       Eltwise floor operation.
@@ -284,21 +284,21 @@ def TTIR_GeluOp: TTIR_ElementwiseUnaryOp<"gelu"> {
   }];
 }
 
-def TTIR_IsFiniteOp: TTIR_ElementwiseUnaryOp<"isfinite"> {
+def TTIR_IsFiniteOp: TTIR_ElementwiseUnaryOp<"isfinite", [ConditionalDPSIdempotence]> {
     let summary = "Eltwise isfinite op.";
     let description = [{
       Eltwise isfinite operation.
     }];
 }
 
-def TTIR_LogicalNotOp: TTIR_ElementwiseUnaryOp<"logical_not"> {
+def TTIR_LogicalNotOp: TTIR_ElementwiseUnaryOp<"logical_not", [ConditionalDPSInvolution]> {
     let summary = "Eltwise logical not op.";
     let description = [{
       Eltwise logical not operation.
     }];
 }
 
-def TTIR_BitwiseNotOp : TTIR_ElementwiseUnaryOp<"bitwise_not"> {
+def TTIR_BitwiseNotOp : TTIR_ElementwiseUnaryOp<"bitwise_not", [ConditionalDPSInvolution]> {
     let summary = "Eltwise bitwise NOT.";
     let description = [{
         Performs element-wise NOT of tensor `operand` and produces a `result` tensor.
@@ -311,7 +311,7 @@ def TTIR_BitwiseNotOp : TTIR_ElementwiseUnaryOp<"bitwise_not"> {
     }];
 }
 
-def TTIR_NegOp: TTIR_ElementwiseUnaryOp<"neg"> {
+def TTIR_NegOp: TTIR_ElementwiseUnaryOp<"neg", [ConditionalDPSInvolution]> {
     let summary = "Eltwise negate op.";
     let description = [{
       Eltwise negate operation.
@@ -332,20 +332,21 @@ def TTIR_TanhOp: TTIR_ElementwiseUnaryOp<"tanh"> {
     }];
 }
 
-def TTIR_ReciprocalOp : TTIR_ElementwiseUnaryOp<"reciprocal"> {
+def TTIR_ReciprocalOp : TTIR_ElementwiseUnaryOp<"reciprocal", [ConditionalDPSInvolution]> {
     let summary = "Eltwise reciprocal.";
     let description = [{
       Eltwise reciprocal operation.
     }];
 }
 
-def TTIR_ReluOp : TTIR_ElementwiseUnaryOp<"relu"> {
+def TTIR_ReluOp : TTIR_ElementwiseUnaryOp<"relu", [ConditionalDPSIdempotence]> {
     let summary = "Eltwise ReLU.";
     let description = [{
       Eltwise ReLU operation.
     }];
 }
 
+// TODO (azecevic): CHECK THIS OP
 def TTIR_RsqrtOp : TTIR_ElementwiseUnaryOp<"rsqrt"> {
     let summary = "Eltwise reciprocal square root.";
     let description = [{
@@ -360,7 +361,7 @@ def TTIR_SigmoidOp: TTIR_ElementwiseUnaryOp<"sigmoid"> {
     }];
 }
 
-def TTIR_SignOp: TTIR_ElementwiseUnaryOp<"sign"> {
+def TTIR_SignOp: TTIR_ElementwiseUnaryOp<"sign", [ConditionalDPSIdempotence]> {
     let summary = "Eltwise sign operation.";
     let description = [{
       Returns the sign of the `operand` element-wise and produces a `result`
@@ -386,6 +387,7 @@ def TTIR_SqrtOp : TTIR_ElementwiseUnaryOp<"sqrt"> {
     }];
 }
 
+// TODO (azecevic): FOLDABLE
 def TTIR_TypecastOp: TTIR_ElementwiseUnaryOp<"typecast"> {
     let summary = "Eltwise cast op.";
     let description = [{
@@ -754,6 +756,7 @@ def TTIR_SoftmaxOp : TTIR_DPSOp<"softmax"> {
     let hasVerifier = 1;
 }
 
+// TODO (azecevic): FOLDABLE
 def TTIR_TransposeOp : TTIR_DPSOp<"transpose"> {
     let summary = "Transpose op.";
     let description = [{

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -288,9 +288,7 @@ def TTIR_IsFiniteOp: TTIR_ElementwiseUnaryOp<"isfinite"> {
     }];
 }
 
-// TODO (azecevic): Semantics of LOGICAL_NOT and INVOLUTION are not clear.
-// logical_not(5) = 0, logical_not(0) = 1???
-def TTIR_LogicalNotOp: TTIR_ElementwiseUnaryOp<"logical_not", [TTIR_Involution]> {
+def TTIR_LogicalNotOp: TTIR_ElementwiseUnaryOp<"logical_not"> {
     let summary = "Eltwise logical not op.";
     let description = [{
       Eltwise logical not operation.
@@ -486,6 +484,7 @@ class TTIR_ElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
     ];
 }
 
+// TODO (azecevic): NaN != NaN, otherwise eq(x, x) == 1.
 def TTIR_EqualOp : TTIR_ElementwiseBinaryOp<"eq"> {
     let summary = "Eltwise equal to.";
     let description = [{
@@ -493,6 +492,7 @@ def TTIR_EqualOp : TTIR_ElementwiseBinaryOp<"eq"> {
     }];
 }
 
+// TODO (azecevic): NaN != NaN, otherwise ne(x, x) == 0.
 def TTIR_NotEqualOp : TTIR_ElementwiseBinaryOp<"ne"> {
     let summary = "Eltwise not equal to.";
     let description = [{
@@ -500,6 +500,7 @@ def TTIR_NotEqualOp : TTIR_ElementwiseBinaryOp<"ne"> {
     }];
 }
 
+// TODO (azecevic): NaN != NaN, otherwise ge(x, x) == 1.
 def TTIR_GreaterEqualOp : TTIR_ElementwiseBinaryOp<"ge"> {
     let summary = "Eltwise greater than or equal to.";
     let description = [{
@@ -507,6 +508,7 @@ def TTIR_GreaterEqualOp : TTIR_ElementwiseBinaryOp<"ge"> {
     }];
 }
 
+// TODO (azecevic): NaN != NaN, otherwise gt(x, x) == 0.
 def TTIR_GreaterThanOp : TTIR_ElementwiseBinaryOp<"gt"> {
     let summary = "Eltwise greater than.";
     let description = [{
@@ -514,6 +516,7 @@ def TTIR_GreaterThanOp : TTIR_ElementwiseBinaryOp<"gt"> {
     }];
 }
 
+// TODO (azecevic): NaN != NaN, otherwise le(x, x) == 1.
 def TTIR_LessEqualOp : TTIR_ElementwiseBinaryOp<"le"> {
     let summary = "Eltwise less than or equal to.";
     let description = [{
@@ -521,6 +524,7 @@ def TTIR_LessEqualOp : TTIR_ElementwiseBinaryOp<"le"> {
     }];
 }
 
+// TODO (azecevic): NaN != NaN, otherwise lt(x, x) == 0.
 def TTIR_LessThanOp : TTIR_ElementwiseBinaryOp<"lt"> {
     let summary = "Eltwise less than.";
     let description = [{
@@ -860,6 +864,8 @@ def TTIR_BroadcastOp : TTIR_DPSOp<"broadcast"> {
     }];
 
     let hasVerifier = 1;
+
+    let hasFolder = 1;
 }
 
 def TTIR_Conv2dOp : TTIR_DPSOp<"conv2d"> {
@@ -1370,6 +1376,8 @@ def TTIR_PermuteOp : TTIR_DPSOp<"permute"> {
     }];
 
     let hasVerifier = 1;
+
+    let hasCanonicalizer = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -383,7 +383,6 @@ def TTIR_SqrtOp : TTIR_ElementwiseUnaryOp<"sqrt"> {
     }];
 }
 
-// TODO (azecevic): FOLDABLE
 def TTIR_TypecastOp: TTIR_ElementwiseUnaryOp<"typecast"> {
     let summary = "Eltwise cast op.";
     let description = [{
@@ -545,7 +544,7 @@ def TTIR_LogicalXorOp : TTIR_ElementwiseBinaryOp<"logical_xor"> {
     }];
 }
 
-def TTIR_BitwiseAndOp : TTIR_ElementwiseBinaryOp<"bitwise_and"> {
+def TTIR_BitwiseAndOp : TTIR_ElementwiseBinaryOp<"bitwise_and", [TTIR_BinaryIdempotence]> {
     let summary = "Eltwise bitwise AND.";
     let description = [{
         Performs element-wise bitwise AND of two tensors `lhs` and `rhs`
@@ -559,7 +558,7 @@ def TTIR_BitwiseAndOp : TTIR_ElementwiseBinaryOp<"bitwise_and"> {
     }];
 }
 
-def TTIR_BitwiseOrOp : TTIR_ElementwiseBinaryOp<"bitwise_or"> {
+def TTIR_BitwiseOrOp : TTIR_ElementwiseBinaryOp<"bitwise_or", [TTIR_BinaryIdempotence]> {
     let summary = "Eltwise bitwise OR.";
     let description = [{
         Performs element-wise bitwise OR of two tensors `lhs` and `rhs`
@@ -587,7 +586,7 @@ def TTIR_BitwiseXorOp : TTIR_ElementwiseBinaryOp<"bitwise_xor"> {
     }];
 }
 
-def TTIR_MinimumOp :  TTIR_ElementwiseBinaryOp<"minimum"> {
+def TTIR_MinimumOp :  TTIR_ElementwiseBinaryOp<"minimum", [TTIR_BinaryIdempotence]> {
     let summary = "Eltwise minimum OP.";
     let description = [{
       Calculates minimum of input tensors' values element-wise and stores result
@@ -1245,6 +1244,8 @@ def TTIR_ReverseOp : TTIR_DPSOp<"reverse", [AllShapesMatch<["input", "result"]>]
     }];
 
     let hasVerifier = 1;
+
+    let hasCanonicalizer = 1;
 }
 
 def TTIR_ConstantOp : TTIR_Op<"constant", [ConstantLike,

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -191,7 +191,7 @@ def ThreeOperands : ParamNativeOpTrait<"NOperands", "3">;
 def FourOperands : ParamNativeOpTrait<"NOperands", "4">;
 
 class TTIR_ElementwiseOp<string mnemonic, list<Trait> traits = []> :
-    TTIR_DPSOp<mnemonic, !listconcat(traits, [AttrSizedOperandSegments, TTIR_Broadcastable, Pure])> {
+    TTIR_DPSOp<mnemonic, !listconcat(traits, [AttrSizedOperandSegments, TTIR_Broadcastable])> {
 
     let description = [{
       Base class for elementwise operations. Elementwise operations can take inputs with different shape,

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -98,8 +98,9 @@ def TTIR_GetDimensionSizeOp : TTIR_Op<"get_dimension_size"> {
 
   let results = (outs AnyRankedTensor:$result);
 
-  let hasFolder = 1;
   let hasVerifier = 1;
+
+  let hasFolder = 1;
 }
 
 def TTIR_ToLayoutOp : TTIR_Op<"to_layout", [DestinationStyleOpInterface, TTIROpInterface]> {

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -281,13 +281,15 @@ def TTIR_GeluOp: TTIR_ElementwiseUnaryOp<"gelu"> {
   }];
 }
 
-def TTIR_IsFiniteOp: TTIR_ElementwiseUnaryOp<"isfinite", [TTIR_Idempotence]> {
+def TTIR_IsFiniteOp: TTIR_ElementwiseUnaryOp<"isfinite"> {
     let summary = "Eltwise isfinite op.";
     let description = [{
       Eltwise isfinite operation.
     }];
 }
 
+// TODO (azecevic): Semantics of LOGICAL_NOT and INVOLUTION are not clear.
+// logical_not(5) = 0, logical_not(0) = 1???
 def TTIR_LogicalNotOp: TTIR_ElementwiseUnaryOp<"logical_not", [TTIR_Involution]> {
     let summary = "Eltwise logical not op.";
     let description = [{
@@ -329,6 +331,9 @@ def TTIR_TanhOp: TTIR_ElementwiseUnaryOp<"tanh"> {
     }];
 }
 
+// TODO (azecevic): What should we do with 0.0 case?
+// 1/0.0 = inf, 1/inf = 0.0, but TTNN isn't IEEE754 compliant.
+// https://github.com/tenstorrent/tt-metal/blob/main/tech_reports/Handling_Special_Value/special_values.md
 def TTIR_ReciprocalOp : TTIR_ElementwiseUnaryOp<"reciprocal", [TTIR_Involution]> {
     let summary = "Eltwise reciprocal.";
     let description = [{
@@ -584,6 +589,8 @@ def TTIR_BitwiseXorOp : TTIR_ElementwiseBinaryOp<"bitwise_xor"> {
           %result = "ttir.bitwise_xor"(%lhs, %rhs) : (tensor<2x2xi32>, tensor<2x2xi32>) -> tensor<2x2xi32>
           // %result: [[4, 4], [4, 12]]
     }];
+
+    let hasCanonicalizer = 1;
 }
 
 def TTIR_MinimumOp :  TTIR_ElementwiseBinaryOp<"minimum", [TTIR_BinaryIdempotence]> {

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -19,7 +19,7 @@ include "mlir/IR/CommonAttrConstraints.td"
 include "mlir/IR/OpBase.td"
 
 class TTIR_DPSOp<string mnemonic, list<Trait> traits = []> :
-    TTIR_Op<mnemonic, !listconcat(traits, [TTIROpInterface, DestinationStyleOpInterface])> {
+    TTIR_Op<mnemonic, !listconcat([TTIROpInterface, DestinationStyleOpInterface], traits)> {
     let extraClassDeclaration = [{
       MutableOperandRange getDpsInitsMutable() { return getOutputsMutable(); }
     }];
@@ -186,12 +186,8 @@ def TTIR_DeallocOp : TTIR_Op<"dealloc"> {
 // TTIR top level named ops
 //===----------------------------------------------------------------------===//
 
-def TwoOperands : ParamNativeOpTrait<"NOperands", "2">;
-def ThreeOperands : ParamNativeOpTrait<"NOperands", "3">;
-def FourOperands : ParamNativeOpTrait<"NOperands", "4">;
-
 class TTIR_ElementwiseOp<string mnemonic, list<Trait> traits = []> :
-    TTIR_DPSOp<mnemonic, !listconcat(traits, [AttrSizedOperandSegments, TTIR_Broadcastable])> {
+    TTIR_DPSOp<mnemonic, !listconcat([AttrSizedOperandSegments, TTIR_Broadcastable], traits)> {
 
     let description = [{
       Base class for elementwise operations. Elementwise operations can take inputs with different shape,
@@ -204,7 +200,7 @@ class TTIR_ElementwiseOp<string mnemonic, list<Trait> traits = []> :
 }
 
 class TTIR_ElementwiseTernaryOp<string mnemonic, list<Trait> traits = []> :
-    TTIR_ElementwiseOp<mnemonic, !listconcat(traits, [FourOperands])> {
+    TTIR_ElementwiseOp<mnemonic, !listconcat([FourOperands], traits)> {
     let summary = "Eltwise ternary op.";
     let description = [{
       Eltwise ternary op.
@@ -227,7 +223,7 @@ def TTIR_WhereOp: TTIR_ElementwiseTernaryOp<"where"> {
 }
 
 class TTIR_ElementwiseUnaryOp<string mnemonic, list<Trait> traits = []> :
-    TTIR_ElementwiseOp<mnemonic, !listconcat(traits, [TwoOperands])> {
+    TTIR_ElementwiseOp<mnemonic, !listconcat([TwoOperands], traits)> {
     let summary = "Eltwise unary op.";
     let description = [{
       Eltwise unary op.
@@ -242,7 +238,7 @@ class TTIR_ElementwiseUnaryOp<string mnemonic, list<Trait> traits = []> :
     ];
 }
 
-def TTIR_AbsOp: TTIR_ElementwiseUnaryOp<"abs", [ConditionalDPSIdempotence]> {
+def TTIR_AbsOp: TTIR_ElementwiseUnaryOp<"abs", [TTIR_Idempotence]> {
     let summary = "Eltwise absolute op.";
     let description = [{
       Eltwise absolute operation.
@@ -256,7 +252,7 @@ def TTIR_CbrtOp: TTIR_ElementwiseUnaryOp<"cbrt"> {
     }];
 }
 
-def TTIR_CeilOp: TTIR_ElementwiseUnaryOp<"ceil", [ConditionalDPSIdempotence]> {
+def TTIR_CeilOp: TTIR_ElementwiseUnaryOp<"ceil", [TTIR_Idempotence]> {
     let summary = "Eltwise ceil op.";
     let description = [{
       Eltwise ceil operation.
@@ -270,7 +266,7 @@ def TTIR_CosOp: TTIR_ElementwiseUnaryOp<"cos"> {
     }];
 }
 
-def TTIR_FloorOp: TTIR_ElementwiseUnaryOp<"floor", [ConditionalDPSIdempotence]> {
+def TTIR_FloorOp: TTIR_ElementwiseUnaryOp<"floor", [TTIR_Idempotence]> {
     let summary = "Eltwise floor op.";
     let description = [{
       Eltwise floor operation.
@@ -284,21 +280,21 @@ def TTIR_GeluOp: TTIR_ElementwiseUnaryOp<"gelu"> {
   }];
 }
 
-def TTIR_IsFiniteOp: TTIR_ElementwiseUnaryOp<"isfinite", [ConditionalDPSIdempotence]> {
+def TTIR_IsFiniteOp: TTIR_ElementwiseUnaryOp<"isfinite", [TTIR_Idempotence]> {
     let summary = "Eltwise isfinite op.";
     let description = [{
       Eltwise isfinite operation.
     }];
 }
 
-def TTIR_LogicalNotOp: TTIR_ElementwiseUnaryOp<"logical_not", [ConditionalDPSInvolution]> {
+def TTIR_LogicalNotOp: TTIR_ElementwiseUnaryOp<"logical_not", [TTIR_Involution]> {
     let summary = "Eltwise logical not op.";
     let description = [{
       Eltwise logical not operation.
     }];
 }
 
-def TTIR_BitwiseNotOp : TTIR_ElementwiseUnaryOp<"bitwise_not", [ConditionalDPSInvolution]> {
+def TTIR_BitwiseNotOp : TTIR_ElementwiseUnaryOp<"bitwise_not", [TTIR_Involution]> {
     let summary = "Eltwise bitwise NOT.";
     let description = [{
         Performs element-wise NOT of tensor `operand` and produces a `result` tensor.
@@ -311,7 +307,7 @@ def TTIR_BitwiseNotOp : TTIR_ElementwiseUnaryOp<"bitwise_not", [ConditionalDPSIn
     }];
 }
 
-def TTIR_NegOp: TTIR_ElementwiseUnaryOp<"neg", [ConditionalDPSInvolution]> {
+def TTIR_NegOp: TTIR_ElementwiseUnaryOp<"neg", [TTIR_Involution]> {
     let summary = "Eltwise negate op.";
     let description = [{
       Eltwise negate operation.
@@ -332,14 +328,14 @@ def TTIR_TanhOp: TTIR_ElementwiseUnaryOp<"tanh"> {
     }];
 }
 
-def TTIR_ReciprocalOp : TTIR_ElementwiseUnaryOp<"reciprocal", [ConditionalDPSInvolution]> {
+def TTIR_ReciprocalOp : TTIR_ElementwiseUnaryOp<"reciprocal", [TTIR_Involution]> {
     let summary = "Eltwise reciprocal.";
     let description = [{
       Eltwise reciprocal operation.
     }];
 }
 
-def TTIR_ReluOp : TTIR_ElementwiseUnaryOp<"relu", [ConditionalDPSIdempotence]> {
+def TTIR_ReluOp : TTIR_ElementwiseUnaryOp<"relu", [TTIR_Idempotence]> {
     let summary = "Eltwise ReLU.";
     let description = [{
       Eltwise ReLU operation.
@@ -361,7 +357,7 @@ def TTIR_SigmoidOp: TTIR_ElementwiseUnaryOp<"sigmoid"> {
     }];
 }
 
-def TTIR_SignOp: TTIR_ElementwiseUnaryOp<"sign", [ConditionalDPSIdempotence]> {
+def TTIR_SignOp: TTIR_ElementwiseUnaryOp<"sign", [TTIR_Idempotence]> {
     let summary = "Eltwise sign operation.";
     let description = [{
       Returns the sign of the `operand` element-wise and produces a `result`
@@ -471,7 +467,7 @@ def TTIR_LeakyReluOp : TTIR_ElementwiseUnaryWithFloatParameterOp<"leaky_relu"> {
 }
 
 class TTIR_ElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
-    TTIR_ElementwiseOp<mnemonic, !listconcat(traits, [ThreeOperands])> {
+    TTIR_ElementwiseOp<mnemonic, !listconcat([ThreeOperands], traits)> {
     let summary = "Eltwise binary op.";
     let description = [{
       Eltwise binary op.
@@ -627,7 +623,7 @@ def TTIR_RemainderOp : TTIR_ElementwiseBinaryOp<"remainder"> {
 }
 
 class TTIR_ReductionOp<string mnemonic, list<Trait> traits = []> :
-    TTIR_DPSOp<mnemonic, !listconcat(traits, [TTIR_GenericRegionOpInterface])> {
+    TTIR_DPSOp<mnemonic, !listconcat([TTIR_GenericRegionOpInterface], traits)> {
 
     let summary = "Reduction op.";
     let description = [{
@@ -1372,7 +1368,7 @@ def TTIR_PermuteOp : TTIR_DPSOp<"permute"> {
 //===----------------------------------------------------------------------===//
 
 class TTIR_GenericElementwiseUnaryOp<string mnemonic, list<Trait> traits = []> :
-    TTIR_ElementwiseUnaryOp<mnemonic, !listconcat(traits, [TTIR_GenericRegionOpInterface])> {
+    TTIR_ElementwiseUnaryOp<mnemonic, !listconcat([TTIR_GenericRegionOpInterface], traits)> {
 
     let extraClassDeclaration = [{
       MutableOperandRange getDpsInitsMutable() { return getOutputsMutable(); }
@@ -1403,7 +1399,7 @@ def TTIR_ExpOp: TTIR_GenericElementwiseUnaryOp<"exp"> {
 }
 
 class TTIR_GenericElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
-    TTIR_ElementwiseBinaryOp<mnemonic, !listconcat(traits, [TTIR_GenericRegionOpInterface])> {
+    TTIR_ElementwiseBinaryOp<mnemonic, !listconcat([TTIR_GenericRegionOpInterface], traits)> {
 
     let extraClassDeclaration = [{
       MutableOperandRange getDpsInitsMutable() { return getOutputsMutable(); }

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -343,7 +343,6 @@ def TTIR_ReluOp : TTIR_ElementwiseUnaryOp<"relu", [TTIR_Idempotence]> {
     }];
 }
 
-// TODO (azecevic): CHECK THIS OP
 def TTIR_RsqrtOp : TTIR_ElementwiseUnaryOp<"rsqrt"> {
     let summary = "Eltwise reciprocal square root.";
     let description = [{
@@ -525,14 +524,14 @@ def TTIR_LessThanOp : TTIR_ElementwiseBinaryOp<"lt"> {
     }];
 }
 
-def TTIR_LogicalAndOp : TTIR_ElementwiseBinaryOp<"logical_and"> {
+def TTIR_LogicalAndOp : TTIR_ElementwiseBinaryOp<"logical_and", [TTIR_BinaryIdempotence]> {
     let summary = "Eltwise logical and.";
     let description = [{
       Eltwise logical and operation.
     }];
 }
 
-def TTIR_LogicalOrOp : TTIR_ElementwiseBinaryOp<"logical_or"> {
+def TTIR_LogicalOrOp : TTIR_ElementwiseBinaryOp<"logical_or", [TTIR_BinaryIdempotence]> {
     let summary = "Eltwise logical or.";
     let description = [{
       Eltwise logical or operation.

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRTraits.h
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRTraits.h
@@ -87,6 +87,33 @@ private:
   }
 };
 
+template <typename ConcreteType>
+class TTIRBinaryIdempotence
+    : public mlir::TypeTrait::TraitBase<ConcreteType, TTIRBinaryIdempotence> {
+public:
+  static mlir::LogicalResult foldTrait(mlir::Operation *op,
+                                       ArrayRef<Attribute> operands,
+                                       SmallVectorImpl<OpFoldResult> &results) {
+    if (isFoldableOperation(op)) {
+      results.push_back(op->getOperand(0));
+      return mlir::success();
+    }
+    return mlir::failure();
+  }
+
+private:
+  // Op is foldable iff:
+  // 1. Both inputs are the same.
+  // 2. Inputs and result types are the same.
+  static bool isFoldableOperation(mlir::Operation *op) {
+    if (op->getOperand(0) != op->getOperand(1)) {
+      return false;
+    }
+
+    return op->getResult(0).getType() == op->getOperand(0).getType();
+  }
+};
+
 } // namespace OpTrait
 } // namespace ttir
 } // namespace tt

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRTraits.h
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRTraits.h
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_TTMLIR_DIALECT_TTIR_TTIRTRAITS_H
+#define TTMLIR_TTMLIR_DIALECT_TTIR_TTIRTRAITS_H
+
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/Interfaces/DestinationStyleOpInterface.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace mlir {
+namespace tt {
+namespace ttir {
+namespace OpTrait {
+
+template <typename ConcreteType>
+class ConditionalDPSInvolution
+    : public mlir::TypeTrait::TraitBase<ConcreteType,
+                                        ConditionalDPSInvolution> {
+public:
+  static mlir::LogicalResult verifyTrait(mlir::Operation *op) {
+    static_assert(ConcreteType::template hasTrait<
+                      mlir::DestinationStyleOpInterface::Trait>(),
+                  "expected destination passing style operation");
+    static_assert(
+        ConcreteType::template hasTrait<mlir::OpTrait::NOperands<2>::Impl>(),
+        "expected operation to take two operands");
+    // Operation does have the expected traits, foldability has to be
+    // dinamically checked.
+    return mlir::success();
+  }
+
+  static mlir::LogicalResult foldTrait(mlir::Operation *op,
+                                       ArrayRef<Attribute> operands,
+                                       SmallVectorImpl<OpFoldResult> &results) {
+    llvm::errs() << "FOLDING DPS INVOLUTION\n";
+    if (isFoldableOperation(op)) {
+      results.push_back(op->getOperand(0).getDefiningOp()->getOperand(0));
+      return mlir::success();
+    }
+    return failure();
+  }
+
+private:
+  // Op is foldable iff:
+  // 1. argment and result types are the same.
+  // 2. argument is defined by the same op.
+  // 3. 1) is true for the producing op of the argument.
+  // op(op(T a, T r0), T r1)
+
+  // TODO (azecevic): refactor this into the separate function
+  static bool isFoldableOperation(mlir::Operation *op) {
+    // TODO (azecevic): LEAVE A COMMENT ABOUT OPERANDS(1) == RESULT(0) BECAUSE
+    // OF DPS
+    llvm::errs() << "FOLDABILITY CHECK\n";
+    auto operandAndResultSameType = [](Operation *op) {
+      return llvm::all_equal(op->getOperandTypes());
+    };
+    if (!operandAndResultSameType(op)) {
+      return false;
+    }
+    Operation *producerOp = op->getOperand(0).getDefiningOp();
+    if (!producerOp || producerOp->getName() != op->getName()) {
+      return false;
+    }
+    return operandAndResultSameType(producerOp);
+  }
+};
+
+template <typename ConcreteType>
+class ConditionalDPSIdempotence
+    : public mlir::TypeTrait::TraitBase<ConcreteType,
+                                        ConditionalDPSIdempotence> {
+public:
+  static mlir::LogicalResult verifyTrait(mlir::Operation *op) {
+    static_assert(ConcreteType::template hasTrait<
+                      mlir::DestinationStyleOpInterface::Trait>(),
+                  "expected destination passing style operation");
+    static_assert(
+        ConcreteType::template hasTrait<mlir::OpTrait::NOperands<2>::Impl>(),
+        "expected operation to take two operands");
+    // Operation does have the expected traits, foldability has to be
+    // dinamically checked.
+    return mlir::success();
+  }
+
+  static mlir::LogicalResult foldTrait(mlir::Operation *op,
+                                       ArrayRef<Attribute> operands,
+                                       SmallVectorImpl<OpFoldResult> &results) {
+    llvm::errs() << "FOLDING DPS INVOLUTION\n";
+    if (isFoldableOperation(op)) {
+      results.push_back(op->getOperand(0));
+      return mlir::success();
+    }
+    return failure();
+  }
+
+private:
+  // Op is foldable iff:
+  // 1. argment and result types are the same.
+  // 2. argument is defined by the same op.
+  // 3. 1) is true for the producing op of the argument.
+  // op(op(T a, T r0), T r1)
+  static bool isFoldableOperation(mlir::Operation *op) {
+    // TODO (azecevic): LEAVE A COMMENT ABOUT OPERANDS(1) == RESULT(0) BECAUSE
+    // OF DPS
+    llvm::errs() << "FOLDABILITY CHECK\n";
+    auto operandAndResultSameType = [](Operation *op) {
+      return llvm::all_equal(op->getOperandTypes());
+    };
+    if (!operandAndResultSameType(op)) {
+      return false;
+    }
+    Operation *producerOp = op->getOperand(0).getDefiningOp();
+    if (!producerOp || producerOp->getName() != op->getName()) {
+      return false;
+    }
+    return operandAndResultSameType(producerOp);
+  }
+};
+
+} // namespace OpTrait
+} // namespace ttir
+} // namespace tt
+} // namespace mlir
+
+#endif // TTMLIR_TTMLIR_DIALECT_TTIR_TTIRTRAITS_H

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRTraits.h
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRTraits.h
@@ -17,8 +17,7 @@ template <typename ConcreteType>
 class TTIRInvolution
     : public mlir::TypeTrait::TraitBase<ConcreteType, TTIRInvolution> {
 public:
-  static mlir::LogicalResult foldTrait(mlir::Operation *op,
-                                       ArrayRef<Attribute> operands,
+  static mlir::LogicalResult foldTrait(mlir::Operation *op, ArrayRef<Attribute>,
                                        SmallVectorImpl<OpFoldResult> &results) {
     if (isFoldableOperation(op)) {
       results.push_back(op->getOperand(0).getDefiningOp()->getOperand(0));
@@ -54,8 +53,7 @@ template <typename ConcreteType>
 class TTIRIdempotence
     : public mlir::TypeTrait::TraitBase<ConcreteType, TTIRIdempotence> {
 public:
-  static mlir::LogicalResult foldTrait(mlir::Operation *op,
-                                       ArrayRef<Attribute> operands,
+  static mlir::LogicalResult foldTrait(mlir::Operation *op, ArrayRef<Attribute>,
                                        SmallVectorImpl<OpFoldResult> &results) {
     if (isFoldableOperation(op)) {
       results.push_back(op->getOperand(0));
@@ -91,8 +89,7 @@ template <typename ConcreteType>
 class TTIRBinaryIdempotence
     : public mlir::TypeTrait::TraitBase<ConcreteType, TTIRBinaryIdempotence> {
 public:
-  static mlir::LogicalResult foldTrait(mlir::Operation *op,
-                                       ArrayRef<Attribute> operands,
+  static mlir::LogicalResult foldTrait(mlir::Operation *op, ArrayRef<Attribute>,
                                        SmallVectorImpl<OpFoldResult> &results) {
     if (isFoldableOperation(op)) {
       results.push_back(op->getOperand(0));

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRTraits.h
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRTraits.h
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef TTMLIR_TTMLIR_DIALECT_TTIR_TTIRTRAITS_H
-#define TTMLIR_TTMLIR_DIALECT_TTIR_TTIRTRAITS_H
+#ifndef TTMLIR_DIALECT_TTIR_IR_TTIRTRAITS_H
+#define TTMLIR_DIALECT_TTIR_IR_TTIRTRAITS_H
 
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Support/LLVM.h"
@@ -72,4 +72,4 @@ public:
 } // namespace tt
 } // namespace mlir
 
-#endif // TTMLIR_TTMLIR_DIALECT_TTIR_TTIRTRAITS_H
+#endif // TTMLIR_DIALECT_TTIR_IR_TTIRTRAITS_H

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRTraits.h
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRTraits.h
@@ -6,7 +6,7 @@
 #define TTMLIR_TTMLIR_DIALECT_TTIR_TTIRTRAITS_H
 
 #include "mlir/IR/OpDefinition.h"
-#include <mlir/Support/LLVM.h>
+#include "mlir/Support/LLVM.h"
 
 namespace mlir {
 namespace tt {

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -1078,37 +1078,6 @@ public:
   }
 };
 
-<<<<<<< HEAD
-=======
-// class GetDimensionSizeToConstantConversionPattern
-//     : public OpConversionPattern<ttir::GetDimensionSizeOp> {
-// public:
-//   using OpConversionPattern<ttir::GetDimensionSizeOp>::OpConversionPattern;
-
-//   LogicalResult
-//   matchAndRewrite(ttir::GetDimensionSizeOp op, OpAdaptor adaptor,
-//                   ConversionPatternRewriter &rewriter) const override {
-
-//     const RankedTensorType inputTensorType =
-//         mlir::cast<RankedTensorType>(op.getOperand().getType());
-
-//     int64_t dimensionIndex = op.getDimension();
-
-//     int32_t dimSize = inputTensorType.getShape()[dimensionIndex];
-
-//     mlir::ShapedType valueType = mlir::cast<mlir::ShapedType>(op.getType());
-
-//     mlir::ElementsAttr valueAttr =
-//         mlir::DenseElementsAttr::get<int>(valueType, dimSize);
-
-//     rewriter.replaceOpWithNewOp<mlir::tt::ttir::ConstantOp>(op, valueType,
-//                                                             valueAttr);
-
-//     return success();
-//   }
-// };
-
->>>>>>> dbdc634f (TTIR constant materialization)
 // SelectOp is converted to a series of SliceOp and potentially a ConcatOp if
 // the sliced dimension is sliced multiple times. For example, if the input
 // tensor is

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -1078,6 +1078,37 @@ public:
   }
 };
 
+<<<<<<< HEAD
+=======
+// class GetDimensionSizeToConstantConversionPattern
+//     : public OpConversionPattern<ttir::GetDimensionSizeOp> {
+// public:
+//   using OpConversionPattern<ttir::GetDimensionSizeOp>::OpConversionPattern;
+
+//   LogicalResult
+//   matchAndRewrite(ttir::GetDimensionSizeOp op, OpAdaptor adaptor,
+//                   ConversionPatternRewriter &rewriter) const override {
+
+//     const RankedTensorType inputTensorType =
+//         mlir::cast<RankedTensorType>(op.getOperand().getType());
+
+//     int64_t dimensionIndex = op.getDimension();
+
+//     int32_t dimSize = inputTensorType.getShape()[dimensionIndex];
+
+//     mlir::ShapedType valueType = mlir::cast<mlir::ShapedType>(op.getType());
+
+//     mlir::ElementsAttr valueAttr =
+//         mlir::DenseElementsAttr::get<int>(valueType, dimSize);
+
+//     rewriter.replaceOpWithNewOp<mlir::tt::ttir::ConstantOp>(op, valueType,
+//                                                             valueAttr);
+
+//     return success();
+//   }
+// };
+
+>>>>>>> dbdc634f (TTIR constant materialization)
 // SelectOp is converted to a series of SliceOp and potentially a ConcatOp if
 // the sliced dimension is sliced multiple times. For example, if the input
 // tensor is

--- a/lib/Dialect/TTIR/IR/CMakeLists.txt
+++ b/lib/Dialect/TTIR/IR/CMakeLists.txt
@@ -2,6 +2,7 @@ add_mlir_dialect_library(MLIRTTIRDialect
         TTIRDialect.cpp
         TTIROps.cpp
         TTIROpsInterfaces.cpp
+        TTIRTraits.cpp
 
         ADDITIONAL_HEADER_DIRS
         ${PROJECT_SOURCE_DIR}/include/ttmlir

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -1087,8 +1087,8 @@ mlir::tt::ttir::ToLayoutOp::compoundComponents() {
     // Verify that the batch dimensions of input A and B are broadcast
     // compatible.
     llvm::SmallVector<int64_t, 4> broadcastedShape;
-    if (!OpTrait::util::getBroadcastedShape(inputABatchDims, inputBBatchDims,
-                                            broadcastedShape)) {
+    if (!mlir::OpTrait::util::getBroadcastedShape(
+            inputABatchDims, inputBBatchDims, broadcastedShape)) {
 
       return emitOpError("Batch dimensions of input A(" +
                          ttmlir::utils::join(inputABatchDims, ",") +
@@ -1125,8 +1125,8 @@ mlir::tt::ttir::ToLayoutOp::compoundComponents() {
     // Verify that the dimensions of the matmul of A and B are broadcast
     // compatible with input bias.
     llvm::SmallVector<int64_t> matmulShape = expectedOutputShape;
-    if (!OpTrait::util::getBroadcastedShape(matmulShape, biasShape,
-                                            expectedOutputShape)) {
+    if (!mlir::OpTrait::util::getBroadcastedShape(matmulShape, biasShape,
+                                                  expectedOutputShape)) {
       return emitOpError("Bias shape(" + ttmlir::utils::join(biasShape, ",") +
                          ") is not broadcast compatible with the matmul output "
                          "shape(" +
@@ -1238,8 +1238,8 @@ mlir::tt::ttir::ToLayoutOp::compoundComponents() {
     // Verify that the batch dimensions of input A and B are broadcast
     // compatible
     llvm::SmallVector<int64_t, 4> broadcastedShape;
-    if (!OpTrait::util::getBroadcastedShape(inputABatchDims, inputBBatchDims,
-                                            broadcastedShape)) {
+    if (!mlir::OpTrait::util::getBroadcastedShape(
+            inputABatchDims, inputBBatchDims, broadcastedShape)) {
 
       return emitOpError("Batch dimensions of input A(" +
                          ttmlir::utils::join(inputABatchDims, ",") +

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -1846,7 +1846,7 @@ void mlir::tt::ttir::PermuteOp::getCanonicalizationPatterns(
                     });
 
     rewriter.replaceOpWithNewOp<ttir::PermuteOp>(
-        producerOp, op.getType(), producerOp.getInput(), op.getOutput(),
+        op, op.getType(), producerOp.getInput(), op.getOutput(),
         composedPermutation);
     return mlir::success();
   });

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -92,16 +92,6 @@
 // GetDimensionSizeOp
 //===----------------------------------------------------------------------===//
 
-// GetDimensionSizeOp folder
-::mlir::OpFoldResult
-mlir::tt::ttir::GetDimensionSizeOp::fold(FoldAdaptor adaptor) {
-  RankedTensorType inputTensorType = getOperand().getType();
-  uint32_t dimensionIndex = getDimension();
-  int32_t dimSize = inputTensorType.getShape()[dimensionIndex];
-
-  return mlir::DenseElementsAttr::get<int32_t>(getType(), dimSize);
-}
-
 // GetDimensionSizeOp verification
 ::mlir::LogicalResult mlir::tt::ttir::GetDimensionSizeOp::verify() {
   RankedTensorType inputTensorType = getOperand().getType();
@@ -114,6 +104,16 @@ mlir::tt::ttir::GetDimensionSizeOp::fold(FoldAdaptor adaptor) {
   };
 
   return success();
+}
+
+// GetDimensionSizeOp folder
+::mlir::OpFoldResult
+mlir::tt::ttir::GetDimensionSizeOp::fold(FoldAdaptor adaptor) {
+  RankedTensorType inputTensorType = getOperand().getType();
+  uint32_t dimensionIndex = getDimension();
+  int32_t dimSize = inputTensorType.getShape()[dimensionIndex];
+
+  return mlir::DenseElementsAttr::get<int32_t>(getType(), dimSize);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -883,7 +883,7 @@ void mlir::tt::ttir::TransposeOp::getCanonicalizationPatterns(
 
         rewriter.replaceOpWithNewOp<mlir::tt::ttir::TransposeOp>(
             op, op.getType(), op.getInput(), op.getOutput(), op.getDim1(),
-            op.getDim0(), op.getOperandConstraints());
+            op.getDim0());
         return mlir::success();
       });
 

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -3,10 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIROpsInterfaces.cpp.inc"
 
+#include "mlir/Rewrite/FrozenRewritePatternSet.h"
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIR.h"
-#include "ttmlir/Dialect/TTIR/IR/TTIROpsInterfaces.cpp.inc"
 #include "ttmlir/Utils.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -111,7 +112,7 @@ mlir::tt::ttir::GetDimensionSizeOp::fold(FoldAdaptor adaptor) {
       static_cast<int64_t>(inputTensorType.getShape().size())) {
     return failure();
   };
-  
+
   return success();
 }
 
@@ -376,7 +377,6 @@ mlir::tt::ttir::GetDimensionSizeOp::fold(FoldAdaptor adaptor) {
 
 // ReshapeOp folder
 ::mlir::OpFoldResult mlir::tt::ttir::ReshapeOp::fold(FoldAdaptor adaptor) {
-
   if (getType() == getOperand(0).getType()) {
     return getOperand(0);
   }
@@ -857,6 +857,54 @@ mlir::tt::ttir::GetDimensionSizeOp::fold(FoldAdaptor adaptor) {
     return emitOpError("Input-output transpose dimension mismatch.");
   }
   return success();
+}
+
+// TransposeOp canonicalization
+void mlir::tt::ttir::TransposeOp::getCanonicalizationPatterns(
+    mlir::RewritePatternSet &patterns, mlir::MLIRContext *context) {
+  // TransposeOp can be removed if the both 'dim0' and 'dim1' are the same.
+  patterns.add(
+      +[](mlir::tt::ttir::TransposeOp op, mlir::PatternRewriter &rewriter) {
+        if (op.getDim0() != op.getDim1()) {
+          return mlir::failure();
+        }
+
+        rewriter.replaceAllOpUsesWith(op, op.getInput());
+        return success();
+      });
+
+  // Rewrite a transpose of to a canonical form where the 'dim0' is less than
+  // 'dim1'.
+  patterns.add(
+      +[](mlir::tt::ttir::TransposeOp op, mlir::PatternRewriter &rewriter) {
+        if (op.getDim0() <= op.getDim1()) {
+          return mlir::failure();
+        }
+
+        rewriter.replaceOpWithNewOp<mlir::tt::ttir::TransposeOp>(
+            op, op.getType(), op.getInput(), op.getOutput(), op.getDim1(),
+            op.getDim0(), op.getOperandConstraints());
+        return mlir::success();
+      });
+
+  // Transposing twice in the row over the same dimensions results in identity,
+  // hence y = T(T(x)) can be replaced with y = x.
+  patterns.add(
+      +[](mlir::tt::ttir::TransposeOp op, mlir::PatternRewriter &rewriter) {
+        auto producerOp =
+            op.getInput().getDefiningOp<mlir::tt::ttir::TransposeOp>();
+        if (!producerOp || op->getName() != producerOp->getName()) {
+          return mlir::failure();
+        }
+
+        if (op.getDim0() != producerOp.getDim0() ||
+            op.getDim1() != producerOp.getDim1()) {
+          return mlir::failure();
+        }
+
+        rewriter.replaceAllOpUsesWith(op, producerOp.getInput());
+        return mlir::success();
+      });
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -932,6 +932,27 @@ void mlir::tt::ttir::TransposeOp::getCanonicalizationPatterns(
         return mlir::success();
       });
 
+  // Rewrite a tranpose dims to a canonical form where the 'dim0' and 'dim1' are
+  // in range [0, N), where N is a rank of input tensor.
+  patterns.add(
+      +[](mlir::tt::ttir::TransposeOp op, mlir::PatternRewriter &rewriter) {
+        int64_t rank = op.getInput().getType().getRank();
+        int32_t dim0 = op.getDim0();
+        int32_t dim1 = op.getDim1();
+
+        if (dim0 >= 0 && dim1 >= 0) {
+          return mlir::failure();
+        }
+
+        if (dim0 < 0) {
+          op.setDim0(dim0 + rank);
+        }
+        if (dim1 < 0) {
+          op.setDim1(dim1 + rank);
+        }
+        return mlir::success();
+      });
+
   // Transposing twice in the row over the same dimensions results in identity,
   // hence y = T(T(x)) can be replaced with y = x.
   patterns.add(

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -111,7 +111,7 @@ mlir::tt::ttir::GetDimensionSizeOp::fold(FoldAdaptor adaptor) {
       static_cast<int64_t>(inputTensorType.getShape().size())) {
     return failure();
   };
-
+  
   return success();
 }
 

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -1266,6 +1266,20 @@ mlir::tt::ttir::ToLayoutOp::compoundComponents() {
   return success();
 }
 
+// LinearOp canonicalize method
+::mlir::LogicalResult
+mlir::tt::ttir::LinearOp::canonicalize(ttir::LinearOp op,
+                                       mlir::PatternRewriter &rewriter) {
+  if (op.getBias()) {
+    llvm::errs() << "No bias\n";
+    return mlir::failure();
+  }
+  llvm::errs() << "With bias\n";
+  rewriter.replaceOpWithNewOp<ttir::MatmulOp>(op, op.getType(), op.getA(),
+                                              op.getB(), op.getOutput());
+  return mlir::success();
+}
+
 //===----------------------------------------------------------------------===//
 // MatmulOp
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -3,11 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
-#include "ttmlir/Dialect/TTIR/IR/TTIROpsInterfaces.cpp.inc"
 
-#include "mlir/Rewrite/FrozenRewritePatternSet.h"
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
-#include "ttmlir/Dialect/TTIR/IR/TTIR.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIROpsInterfaces.cpp.inc"
 #include "ttmlir/Utils.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -1271,10 +1269,9 @@ mlir::tt::ttir::ToLayoutOp::compoundComponents() {
 mlir::tt::ttir::LinearOp::canonicalize(ttir::LinearOp op,
                                        mlir::PatternRewriter &rewriter) {
   if (op.getBias()) {
-    llvm::errs() << "No bias\n";
     return mlir::failure();
   }
-  llvm::errs() << "With bias\n";
+
   rewriter.replaceOpWithNewOp<ttir::MatmulOp>(op, op.getType(), op.getA(),
                                               op.getB(), op.getOutput());
   return mlir::success();

--- a/lib/Dialect/TTIR/IR/TTIRTraits.cpp
+++ b/lib/Dialect/TTIR/IR/TTIRTraits.cpp
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTIR/IR/TTIRTraits.h"
+
+// Op is foldable iff:
+// 1. argment and result types are the same.
+// 2. argument is defined by the same op.
+// 3. 1) is true for the producing op of the argument.
+// op(op(T a, T r0), T r1)
+bool mlir::tt::ttir::OpTrait::impl::verifyInvolution(mlir::Operation *op) {
+  // Dependant trait of TTIRInvolution is DestionationStyleOpInterface, hence
+  // operands include the result.
+  auto operandAndResultSameType = [](Operation *op) {
+    return llvm::all_equal(op->getOperandTypes());
+  };
+  if (!operandAndResultSameType(op)) {
+    return false;
+  }
+  Operation *producerOp = op->getOperand(0).getDefiningOp();
+  if (!producerOp || producerOp->getName() != op->getName()) {
+    return false;
+  }
+  return operandAndResultSameType(producerOp);
+}
+
+// Op is foldable iff:
+// 1. argment and result types are the same.
+// 2. argument is defined by the same op.
+// 3. 1) is true for the producing op of the argument.
+// op(op(T a, T r0), T r1)
+bool mlir::tt::ttir::OpTrait::impl::verifyIdempotence(mlir::Operation *op) {
+  // Dependant trait of TTIRIdempotence is DestionationStyleOpInterface, hence
+  // operands include the result.
+  auto operandAndResultSameType = [](mlir::Operation *op) {
+    return llvm::all_equal(op->getOperandTypes());
+  };
+  if (!operandAndResultSameType(op)) {
+    return false;
+  }
+  mlir::Operation *producerOp = op->getOperand(0).getDefiningOp();
+  if (!producerOp || producerOp->getName() != op->getName()) {
+    return false;
+  }
+  return operandAndResultSameType(producerOp);
+}
+
+// Op is foldable iff:
+// 1. Both inputs are the same.
+// 2. Inputs and result types are the same.
+bool mlir::tt::ttir::OpTrait::impl::verifyBinaryIdempotence(
+    mlir::Operation *op) {
+  if (op->getOperand(0) != op->getOperand(1)) {
+    return false;
+  }
+
+  return op->getResult(0).getType() == op->getOperand(0).getType();
+}
+
+mlir::OpFoldResult
+mlir::tt::ttir::OpTrait::impl::foldInvolution(mlir::Operation *op) {
+  return op->getOperand(0).getDefiningOp()->getOperand(0);
+}
+
+mlir::OpFoldResult
+mlir::tt::ttir::OpTrait::impl::foldIdempotence(mlir::Operation *op) {
+  return op->getOperand(0);
+}
+
+mlir::OpFoldResult
+mlir::tt::ttir::OpTrait::impl::foldBinaryIdempotence(mlir::Operation *op) {
+  return op->getOperand(0);
+}

--- a/lib/Dialect/TTIR/IR/TTIRTraits.cpp
+++ b/lib/Dialect/TTIR/IR/TTIRTraits.cpp
@@ -4,17 +4,19 @@
 
 #include "ttmlir/Dialect/TTIR/IR/TTIRTraits.h"
 
-// Op is foldable iff:
-// 1. argment and result types are the same.
-// 2. argument is defined by the same op.
+// Check if all operands and result have the same type. Function assumes op has
+// at least one operand and exactly one result.
+static bool operandAndResultSameType(mlir::Operation *op) {
+  return llvm::all_equal(op->getOperandTypes()) &&
+         op->getOperand(0).getType() == op->getResult(0).getType();
+}
+
+// If Op has TTIRInvolution trait, then it's foldable if:
+// 1. Argument and result types are the same.
+// 2. Argument is defined by the same op.
 // 3. 1) is true for the producing op of the argument.
 // op(op(T a, T r0), T r1)
 bool mlir::tt::ttir::OpTrait::impl::verifyInvolution(mlir::Operation *op) {
-  // Dependant trait of TTIRInvolution is DestionationStyleOpInterface, hence
-  // operands include the result.
-  auto operandAndResultSameType = [](Operation *op) {
-    return llvm::all_equal(op->getOperandTypes());
-  };
   if (!operandAndResultSameType(op)) {
     return false;
   }
@@ -25,17 +27,12 @@ bool mlir::tt::ttir::OpTrait::impl::verifyInvolution(mlir::Operation *op) {
   return operandAndResultSameType(producerOp);
 }
 
-// Op is foldable iff:
-// 1. argment and result types are the same.
-// 2. argument is defined by the same op.
+// If Op has TTIRIdempotence trait, then it's foldable if:
+// 1. Argument and result types are the same.
+// 2. Argument is defined by the same op.
 // 3. 1) is true for the producing op of the argument.
 // op(op(T a, T r0), T r1)
 bool mlir::tt::ttir::OpTrait::impl::verifyIdempotence(mlir::Operation *op) {
-  // Dependant trait of TTIRIdempotence is DestionationStyleOpInterface, hence
-  // operands include the result.
-  auto operandAndResultSameType = [](mlir::Operation *op) {
-    return llvm::all_equal(op->getOperandTypes());
-  };
   if (!operandAndResultSameType(op)) {
     return false;
   }
@@ -46,7 +43,7 @@ bool mlir::tt::ttir::OpTrait::impl::verifyIdempotence(mlir::Operation *op) {
   return operandAndResultSameType(producerOp);
 }
 
-// Op is foldable iff:
+// If Op has TTIRBinaryIdempotence trait, then it's foldable if:
 // 1. Both inputs are the same.
 // 2. Inputs and result types are the same.
 bool mlir::tt::ttir::OpTrait::impl::verifyBinaryIdempotence(

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -22,7 +22,9 @@ void createTTNNPipelineTTIRPasses(
   ttir::TTIRLoadSystemDescOptions systemDescOptions;
   systemDescOptions.path = options.systemDescPath;
 
+  pm.addPass(mlir::createCanonicalizerPass());
   pm.addPass(mlir::tt::createTTIRToTTIRDecompositionPass());
+  pm.addPass(mlir::createCanonicalizerPass());
 
   // Inlines all private functions. I.e flattens the program into the main
   // function. Removes all private functions.

--- a/test/ttmlir/Dialect/TTIR/canonicalize/binary_idempotence_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/binary_idempotence_tests.mlir
@@ -1,0 +1,9 @@
+// RUN: ttmlir-opt -canonicalize %s | FileCheck %s
+module {
+  func.func @binary_idempotence(%arg0: tensor<64x64xf32>) -> tensor<64x64xf32> {
+    // CHECK-NOT: "ttir.logical_and"
+    %0 = tensor.empty() : tensor<64x64xf32>
+    %1 = "ttir.logical_and"(%arg0, %arg0, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %1 : tensor<64x64xf32>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/canonicalize/bitwise_xor_canonicalize_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/bitwise_xor_canonicalize_tests.mlir
@@ -1,0 +1,22 @@
+// RUN: ttmlir-opt -canonicalize %s | FileCheck %s
+module {
+  func.func @bitwise_xor_integer(%arg0: tensor<64x128xui16>) -> tensor<64x128xui16> {
+    // CHECK-NOT: "ttir.bitwise_xor"
+    // CHECK: "ttir.constant"
+    // CHECK-SAME: value = dense<0> : tensor<64x128xui16>
+    // CHECK-NOT: "ttir.bitwise_xor"
+    %0 = tensor.empty() : tensor<64x128xui16>
+    %1 = "ttir.bitwise_xor"(%arg0, %arg0, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xui16>, tensor<64x128xui16>, tensor<64x128xui16>) -> tensor<64x128xui16>
+    return %1 : tensor<64x128xui16>
+  }
+
+  func.func @bitwise_xor_float(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    // CHECK-NOT: "ttir.bitwise_xor"
+    // CHECK:  "ttir.constant"
+    // CHECK-SAME: value = dense<0.000000e+00> : tensor<64x128xbf16>
+    // CHECK-NOT: "ttir.bitwise_xor"
+    %0 = tensor.empty() : tensor<64x128xbf16>
+    %1 = "ttir.bitwise_xor"(%arg0, %arg0, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+    return %1 : tensor<64x128xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/canonicalize/broadcast_fold_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/broadcast_fold_tests.mlir
@@ -1,0 +1,9 @@
+// RUN: ttmlir-opt -canonicalize %s | FileCheck %s
+module {
+  func.func @broadcast_noop(%arg0: tensor<1x2x3x4x5xbf16>) -> tensor<1x2x3x4x5xbf16> {
+    // CHECK-NOT: "ttir.broadcast"
+    %0 = tensor.empty() : tensor<1x2x3x4x5xbf16>
+    %1 = "ttir.broadcast"(%arg0, %0) <{broadcast_dimensions = array<i32: 1, 1, 1, 1, 1>}> : (tensor<1x2x3x4x5xbf16>, tensor<1x2x3x4x5xbf16>) -> tensor<1x2x3x4x5xbf16>
+    return %1 : tensor<1x2x3x4x5xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/canonicalize/idempotence_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/idempotence_tests.mlir
@@ -1,0 +1,34 @@
+// RUN: ttmlir-opt -canonicalize %s | FileCheck %s
+module {
+  func.func @idempotence_two_in_the_row(%arg0: tensor<64x64xf32>) -> tensor<64x64xf32> {
+    // CHECK: "ttir.relu"
+    // CHECK-NOT: "ttir.relu"
+    %0 = tensor.empty() : tensor<64x64xf32>
+    %1 = "ttir.relu"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
+    %2 = tensor.empty() : tensor<64x64xf32>
+    %3 = "ttir.relu"(%1, %2) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %3 : tensor<64x64xf32>
+  }
+
+  func.func @idempotence_three_in_the_row(%arg0: tensor<64x64xf32>) -> tensor<64x64xf32> {
+    // CHECK: "ttir.relu"
+    // CHECK-NOT: "ttir.relu"
+    %0 = tensor.empty() : tensor<64x64xf32>
+    %1 = "ttir.relu"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
+    %2 = tensor.empty() : tensor<64x64xf32>
+    %3 = "ttir.relu"(%1, %2) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
+    %4 = tensor.empty() : tensor<64x64xf32>
+    %5 = "ttir.relu"(%2, %4) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %5 : tensor<64x64xf32>
+  }
+
+  func.func @not_idempotence_diffrent_types(%arg0: tensor<64x64xf32>) -> tensor<64x64xf32> {
+    // CHECK: "ttir.relu"
+    // CHECK: "ttir.relu"
+    %0 = tensor.empty() : tensor<64x64xbf16>
+    %1 = "ttir.relu"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x64xf32>, tensor<64x64xbf16>) -> tensor<64x64xbf16>
+    %2 = tensor.empty() : tensor<64x64xf32>
+    %3 = "ttir.relu"(%1, %2) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x64xbf16>, tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %3 : tensor<64x64xf32>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/canonicalize/involution_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/involution_tests.mlir
@@ -1,0 +1,23 @@
+// RUN: ttmlir-opt -canonicalize %s | FileCheck %s
+module {
+  func.func @involution_two_in_the_row(%arg0: tensor<64x64xf32>) -> tensor<64x64xf32> {
+    // CHECK-NOT: "ttir.neg"
+    %0 = tensor.empty() : tensor<64x64xf32>
+    %1 = "ttir.neg"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
+    %2 = tensor.empty() : tensor<64x64xf32>
+    %3 = "ttir.neg"(%1, %2) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %3 : tensor<64x64xf32>
+  }
+
+  func.func @involution_three_in_the_row(%arg0: tensor<64x64xf32>) -> tensor<64x64xf32> {
+    // CHECK: "ttir.neg"
+    // CHECK-NOT: "ttir.neg"
+    %0 = tensor.empty() : tensor<64x64xf32>
+    %1 = "ttir.neg"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
+    %2 = tensor.empty() : tensor<64x64xf32>
+    %3 = "ttir.neg"(%1, %2) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
+    %4 = tensor.empty() : tensor<64x64xf32>
+    %5 = "ttir.neg"(%3, %4) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x64xf32>, tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %5 : tensor<64x64xf32>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/canonicalize/linear_op_fold_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/linear_op_fold_tests.mlir
@@ -1,0 +1,11 @@
+// RUN: ttmlir-opt -canonicalize %s | FileCheck %s
+module {
+  func.func @linear_1d_1d(%arg0: tensor<3x64x128xbf16>, %arg1: tensor<128x64xbf16>) -> tensor<3x64x64xbf16> {
+    %0 = tensor.empty() : tensor<3x64x64xbf16>
+    // CHECK-NOT: "ttir.linear"
+    // CHECK: "ttir.matmul"(%arg0, %arg1, %0)
+    // CHECK-NOT: "ttir.linear"
+    %1 = "ttir.linear"(%arg0, %arg1, %0) : (tensor<3x64x128xbf16>, tensor<128x64xbf16>, tensor<3x64x64xbf16>) -> tensor<3x64x64xbf16>
+    return %1 : tensor<3x64x64xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/canonicalize/permute_op_canonicalize_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/permute_op_canonicalize_tests.mlir
@@ -1,10 +1,10 @@
 // RUN: ttmlir-opt -canonicalize %s | FileCheck %s
 module {
   func.func @permute_composition(%arg0: tensor<1x2x3x4x5xbf16>) -> tensor<3x2x1x5x4xbf16> {
-    %0 = tensor.empty() : tensor<3x2x5x4x1xbf16>
     // CHECK: "ttir.permute"
     // CHECK-SAME: permutation = array<i64: 2, 1, 0, 4, 3>
     // CHECK-NOT: "ttir.permute"
+    %0 = tensor.empty() : tensor<3x2x5x4x1xbf16>
     %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 2, 1, 4, 3, 0>}> : (tensor<1x2x3x4x5xbf16>, tensor<3x2x5x4x1xbf16>) -> tensor<3x2x5x4x1xbf16>
     %2 = tensor.empty() : tensor<3x2x1x5x4xbf16>
     %3 = "ttir.permute"(%1, %2) <{permutation = array<i64: 0, 1, 4, 2, 3>}> : (tensor<3x2x5x4x1xbf16>, tensor<3x2x1x5x4xbf16>) -> tensor<3x2x1x5x4xbf16>
@@ -12,8 +12,8 @@ module {
   }
 
   func.func @permute_noop(%arg0: tensor<1x2x3x4x5xbf16>) -> tensor<1x2x3x4x5xbf16> {
-    %0 = tensor.empty() : tensor<1x2x3x4x5xbf16>
     // CHECK-NOT: "ttir.permute"
+    %0 = tensor.empty() : tensor<1x2x3x4x5xbf16>
     %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 0, 1, 2, 3, 4>}> : (tensor<1x2x3x4x5xbf16>, tensor<1x2x3x4x5xbf16>) -> tensor<1x2x3x4x5xbf16>
     return %1 : tensor<1x2x3x4x5xbf16>
   }

--- a/test/ttmlir/Dialect/TTIR/canonicalize/permute_op_canonicalize_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/permute_op_canonicalize_tests.mlir
@@ -1,0 +1,20 @@
+// RUN: ttmlir-opt -canonicalize %s | FileCheck %s
+module {
+  func.func @permute_composition(%arg0: tensor<1x2x3x4x5xbf16>) -> tensor<3x2x1x5x4xbf16> {
+    %0 = tensor.empty() : tensor<3x2x5x4x1xbf16>
+    // CHECK: "ttir.permute"
+    // CHECK-SAME: permutation = array<i64: 2, 1, 0, 4, 3>
+    // CHECK-NOT: "ttir.permute"
+    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 2, 1, 4, 3, 0>}> : (tensor<1x2x3x4x5xbf16>, tensor<3x2x5x4x1xbf16>) -> tensor<3x2x5x4x1xbf16>
+    %2 = tensor.empty() : tensor<3x2x1x5x4xbf16>
+    %3 = "ttir.permute"(%1, %2) <{permutation = array<i64: 0, 1, 4, 2, 3>}> : (tensor<3x2x5x4x1xbf16>, tensor<3x2x1x5x4xbf16>) -> tensor<3x2x1x5x4xbf16>
+    return %3 : tensor<3x2x1x5x4xbf16>
+  }
+
+  func.func @permute_noop(%arg0: tensor<1x2x3x4x5xbf16>) -> tensor<1x2x3x4x5xbf16> {
+    %0 = tensor.empty() : tensor<1x2x3x4x5xbf16>
+    // CHECK-NOT: "ttir.permute"
+    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 0, 1, 2, 3, 4>}> : (tensor<1x2x3x4x5xbf16>, tensor<1x2x3x4x5xbf16>) -> tensor<1x2x3x4x5xbf16>
+    return %1 : tensor<1x2x3x4x5xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/canonicalize/revese_op_canonicalize_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/revese_op_canonicalize_tests.mlir
@@ -1,0 +1,29 @@
+// RUN: ttmlir-opt -canonicalize %s | FileCheck %s
+module {
+  func.func @reverse_composition(%arg0: tensor<1x2x3x4x5xbf16>) -> tensor<1x2x3x4x5xbf16> {
+    %0 = tensor.empty() : tensor<1x2x3x4x5xbf16>
+    // CHECK: "ttir.reverse"
+    // CHECK-SAME: dimensions = array<i64: 1, 4>
+    // CHECK-NOT: "ttir.reverse"
+    %1 = "ttir.reverse"(%arg0, %0) <{dimensions = array<i64: 1, 0, 3>}> : (tensor<1x2x3x4x5xbf16>, tensor<1x2x3x4x5xbf16>) -> tensor<1x2x3x4x5xbf16>
+    %2 = tensor.empty() : tensor<1x2x3x4x5xbf16>
+    %3 = "ttir.reverse"(%1, %2) <{dimensions = array<i64: 0, 3, 4>}> : (tensor<1x2x3x4x5xbf16>, tensor<1x2x3x4x5xbf16>) -> tensor<1x2x3x4x5xbf16>
+    return %3 : tensor<1x2x3x4x5xbf16>
+  }
+
+  func.func @reverse_noop(%arg0: tensor<1x2x3x4x5xbf16>) -> tensor<1x2x3x4x5xbf16> {
+    %0 = tensor.empty() : tensor<1x2x3x4x5xbf16>
+    // CHECK-NOT: "ttir.reverse"
+    %1 = "ttir.reverse"(%arg0, %0) <{dimensions = array<i64>}> : (tensor<1x2x3x4x5xbf16>, tensor<1x2x3x4x5xbf16>) -> tensor<1x2x3x4x5xbf16>
+    return %1 : tensor<1x2x3x4x5xbf16>
+  }
+
+  func.func @reverse_composition_noop(%arg0: tensor<1x2x3x4x5xbf16>) -> tensor<1x2x3x4x5xbf16> {
+    %0 = tensor.empty() : tensor<1x2x3x4x5xbf16>
+    // CHECK-NOT: "ttir.reverse"
+    %1 = "ttir.reverse"(%arg0, %0) <{dimensions = array<i64: 1, 0, 3>}> : (tensor<1x2x3x4x5xbf16>, tensor<1x2x3x4x5xbf16>) -> tensor<1x2x3x4x5xbf16>
+    %2 = tensor.empty() : tensor<1x2x3x4x5xbf16>
+    %3 = "ttir.reverse"(%1, %2) <{dimensions = array<i64: 3, 1, 0>}> : (tensor<1x2x3x4x5xbf16>, tensor<1x2x3x4x5xbf16>) -> tensor<1x2x3x4x5xbf16>
+    return %3 : tensor<1x2x3x4x5xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/canonicalize/revese_op_canonicalize_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/revese_op_canonicalize_tests.mlir
@@ -1,10 +1,10 @@
 // RUN: ttmlir-opt -canonicalize %s | FileCheck %s
 module {
   func.func @reverse_composition(%arg0: tensor<1x2x3x4x5xbf16>) -> tensor<1x2x3x4x5xbf16> {
-    %0 = tensor.empty() : tensor<1x2x3x4x5xbf16>
     // CHECK: "ttir.reverse"
     // CHECK-SAME: dimensions = array<i64: 1, 4>
     // CHECK-NOT: "ttir.reverse"
+    %0 = tensor.empty() : tensor<1x2x3x4x5xbf16>
     %1 = "ttir.reverse"(%arg0, %0) <{dimensions = array<i64: 1, 0, 3>}> : (tensor<1x2x3x4x5xbf16>, tensor<1x2x3x4x5xbf16>) -> tensor<1x2x3x4x5xbf16>
     %2 = tensor.empty() : tensor<1x2x3x4x5xbf16>
     %3 = "ttir.reverse"(%1, %2) <{dimensions = array<i64: 0, 3, 4>}> : (tensor<1x2x3x4x5xbf16>, tensor<1x2x3x4x5xbf16>) -> tensor<1x2x3x4x5xbf16>
@@ -12,15 +12,16 @@ module {
   }
 
   func.func @reverse_noop(%arg0: tensor<1x2x3x4x5xbf16>) -> tensor<1x2x3x4x5xbf16> {
-    %0 = tensor.empty() : tensor<1x2x3x4x5xbf16>
     // CHECK-NOT: "ttir.reverse"
+    %0 = tensor.empty() : tensor<1x2x3x4x5xbf16>
     %1 = "ttir.reverse"(%arg0, %0) <{dimensions = array<i64>}> : (tensor<1x2x3x4x5xbf16>, tensor<1x2x3x4x5xbf16>) -> tensor<1x2x3x4x5xbf16>
     return %1 : tensor<1x2x3x4x5xbf16>
   }
 
-  func.func @reverse_composition_noop(%arg0: tensor<1x2x3x4x5xbf16>) -> tensor<1x2x3x4x5xbf16> {
-    %0 = tensor.empty() : tensor<1x2x3x4x5xbf16>
+
+    func.func @reverse_composition_noop(%arg0: tensor<1x2x3x4x5xbf16>) -> tensor<1x2x3x4x5xbf16> {
     // CHECK-NOT: "ttir.reverse"
+    %0 = tensor.empty() : tensor<1x2x3x4x5xbf16>
     %1 = "ttir.reverse"(%arg0, %0) <{dimensions = array<i64: 1, 0, 3>}> : (tensor<1x2x3x4x5xbf16>, tensor<1x2x3x4x5xbf16>) -> tensor<1x2x3x4x5xbf16>
     %2 = tensor.empty() : tensor<1x2x3x4x5xbf16>
     %3 = "ttir.reverse"(%1, %2) <{dimensions = array<i64: 3, 1, 0>}> : (tensor<1x2x3x4x5xbf16>, tensor<1x2x3x4x5xbf16>) -> tensor<1x2x3x4x5xbf16>

--- a/test/ttmlir/Dialect/TTIR/canonicalize/transpose_fold_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/transpose_fold_tests.mlir
@@ -1,0 +1,11 @@
+// RUN: ttmlir-opt -canonicalize %s | FileCheck %s
+module {
+  func.func @transpose_involution(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    // CHECK-NOT: "ttir.transpose"
+    %0 = tensor.empty() : tensor<128x64xbf16>
+    %1 = "ttir.transpose"(%arg0, %0) <{dim0 = 0 : si32, dim1 = 1 : si32}> : (tensor<64x128xbf16>, tensor<128x64xbf16>) -> tensor<128x64xbf16>
+    %2 = tensor.empty() : tensor<64x128xbf16>
+    %3 = "ttir.transpose"(%1, %2) <{dim0 = 1 : si32, dim1 = 0 : si32}> : (tensor<128x64xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+    return %3 : tensor<64x128xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/canonicalize/transpose_fold_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/transpose_fold_tests.mlir
@@ -8,4 +8,13 @@ module {
     %3 = "ttir.transpose"(%1, %2) <{dim0 = 1 : si32, dim1 = 0 : si32}> : (tensor<128x64xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     return %3 : tensor<64x128xbf16>
   }
+
+  func.func @transpose_normalize_range(%arg0: tensor<32x64x128xbf16>) -> tensor<32x128x64xbf16> {
+    // CHECK: "ttir.transpose"
+    // CHECK-SAME: dim0 = 1 : si32
+    // CHECK-SAME: dim1 = 2 : si32
+    %0 = tensor.empty() : tensor<32x128x64xbf16>
+    %1 = "ttir.transpose"(%arg0, %0) <{dim0 = -1 : si32, dim1 = -2 : si32}> : (tensor<32x64x128xbf16>, tensor<32x128x64xbf16>) -> tensor<32x128x64xbf16>
+    return %1 : tensor<32x128x64xbf16>
+  }
 }

--- a/test/ttmlir/Dialect/TTNN/convolution/simple_conv1d.mlir
+++ b/test/ttmlir/Dialect/TTNN/convolution/simple_conv1d.mlir
@@ -8,8 +8,6 @@ module {
     // CHECK-SAME: shape = [1024 : i32, 256 : i32, 1 : i32, 1 : i32]
     // CHECK: "ttnn.permute"
     // CHECK-SAME: permutation = array<i64: 0, 2, 3, 1>
-    // CHECK: "ttnn.permute"
-    // CHECK-SAME: permutation = array<i64: 0, 1, 2, 3>
     // CHECK: "ttnn.conv2d"
     // CHECK: "ttnn.permute"
     // CHECK-SAME: permutation = array<i64: 0, 3, 1, 2>

--- a/test/ttmlir/Dialect/TTNN/linear/linear_tests_positive.mlir
+++ b/test/ttmlir/Dialect/TTNN/linear/linear_tests_positive.mlir
@@ -4,7 +4,7 @@ module {
     // CHECK: "ttnn.empty"
     // CHECK-SAME: tensor<1xbf16
     %0 = tensor.empty() : tensor<1xbf16>
-    // CHECK: "ttnn.linear"
+    // CHECK: "ttnn.matmul"
     // CHECK-SAME: tensor<128xbf16
     // CHECK-SAME: tensor<128xbf16
     // CHECK-SAME: tensor<1xbf16
@@ -45,7 +45,7 @@ module {
     // CHECK: "ttnn.empty"
     // CHECK-SAME: tensor<64xbf16
     %0 = tensor.empty() : tensor<64xbf16>
-    // CHECK: "ttnn.linear"
+    // CHECK: "ttnn.matmul"
     // CHECK-SAME: tensor<64x128xbf16
     // CHECK-SAME: tensor<128xbf16
     // CHECK-SAME: tensor<64xbf16
@@ -58,7 +58,7 @@ module {
     // CHECK: "ttnn.empty"
     // CHECK-SAME: tensor<64x64xbf16
     %0 = tensor.empty() : tensor<64x64xbf16>
-    // CHECK: "ttnn.linear"
+    // CHECK: "ttnn.matmul"
     // CHECK-SAME: tensor<64x128xbf16
     // CHECK-SAME: tensor<128x64xbf16
     // CHECK-SAME: tensor<64x64xbf16
@@ -85,7 +85,7 @@ module {
     // CHECK: "ttnn.empty"
     // CHECK-SAME: tensor<12x7x64xbf16
     %0 = tensor.empty() : tensor<12x7x64xbf16>
-    // CHECK: "ttnn.linear"
+    // CHECK: "ttnn.matmul"
     // CHECK-SAME: tensor<128xbf16
     // CHECK-SAME: tensor<12x7x128x64xbf16
     // CHECK-SAME: tensor<12x7x64xbf16
@@ -98,7 +98,7 @@ module {
     // CHECK: "ttnn.empty"
     // CHECK-SAME: tensor<12x7x128xbf16
     %0 = tensor.empty() : tensor<12x7x128xbf16>
-    // CHECK: "ttnn.linear"
+    // CHECK: "ttnn.matmul"
     // CHECK-SAME: tensor<12x7x128x64xbf16
     // CHECK-SAME: tensor<64xbf16
     // CHECK-SAME: tensor<12x7x128xbf16
@@ -111,7 +111,7 @@ module {
     // CHECK: "ttnn.empty"
     // CHECK-SAME: tensor<12x7x64x64xbf16
     %0 = tensor.empty() : tensor<12x7x64x64xbf16>
-    // CHECK: "ttnn.linear"
+    // CHECK: "ttnn.matmul"
     // CHECK-SAME: tensor<64x128xbf16
     // CHECK-SAME: tensor<12x7x128x64xbf16
     // CHECK-SAME: tensor<12x7x64x64xbf16
@@ -124,7 +124,7 @@ module {
     // CHECK: "ttnn.empty"
     // CHECK-SAME: tensor<12x7x128x128xbf16
     %0 = tensor.empty() : tensor<12x7x128x128xbf16>
-    // CHECK: "ttnn.linear"
+    // CHECK: "ttnn.matmul"
     // CHECK-SAME: tensor<12x7x128x64xbf16
     // CHECK-SAME: tensor<64x128xbf16
     // CHECK-SAME: tensor<12x7x128x128xbf16
@@ -138,7 +138,7 @@ module {
     // CHECK: "ttnn.empty"
     // CHECK-SAME: tensor<7x64x64xbf16
     %0 = tensor.empty() : tensor<7x64x64xbf16>
-    // CHECK: "ttnn.linear"
+    // CHECK: "ttnn.matmul"
     // CHECK-SAME: tensor<7x64x128xbf16
     // CHECK-SAME: tensor<7x128x64xbf16
     // CHECK-SAME: tensor<7x64x64xbf16
@@ -151,7 +151,7 @@ module {
     // CHECK: "ttnn.empty"
     // CHECK-SAME: tensor<7x64x64xbf16
     %0 = tensor.empty() : tensor<7x64x64xbf16>
-    // CHECK: "ttnn.linear"
+    // CHECK: "ttnn.matmul"
     // CHECK-SAME: tensor<7x64x128xbf16
     // CHECK-SAME: tensor<1x128x64xbf16
     // CHECK-SAME: tensor<7x64x64xbf16
@@ -164,7 +164,7 @@ module {
     // CHECK: "ttnn.empty"
     // CHECK-SAME: tensor<7x7x64x64xbf16
     %0 = tensor.empty() : tensor<7x7x64x64xbf16>
-    // CHECK: "ttnn.linear"
+    // CHECK: "ttnn.matmul"
     // CHECK-SAME: tensor<1x7x64x128xbf16
     // CHECK-SAME: tensor<7x1x128x64xbf16
     // CHECK-SAME: tensor<7x7x64x64xbf16
@@ -177,7 +177,7 @@ module {
     // CHECK: "ttnn.empty"
     // CHECK-SAME: tensor<12x7x7x64x64xbf16
     %0 = tensor.empty() : tensor<12x7x7x64x64xbf16>
-    // CHECK: "ttnn.linear"
+    // CHECK: "ttnn.matmul"
     // CHECK-SAME: tensor<12x1x7x64x128xbf16
     // CHECK-SAME: tensor<7x1x128x64xbf16
     // CHECK-SAME: tensor<12x7x7x64x64xbf16

--- a/test/ttmlir/Dialect/TTNN/linear/linear_tests_positive.mlir
+++ b/test/ttmlir/Dialect/TTNN/linear/linear_tests_positive.mlir
@@ -1,18 +1,5 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module {
-  func.func @linear_1d_1d(%arg0: tensor<128xbf16>, %arg1: tensor<128xbf16>) -> tensor<1xbf16> {
-    // CHECK: "ttnn.empty"
-    // CHECK-SAME: tensor<1xbf16
-    %0 = tensor.empty() : tensor<1xbf16>
-    // CHECK: "ttnn.matmul"
-    // CHECK-SAME: tensor<128xbf16
-    // CHECK-SAME: tensor<128xbf16
-    // CHECK-SAME: tensor<1xbf16
-    // CHECK-SAME: tensor<1xbf16
-    %1 = "ttir.linear"(%arg0, %arg1, %0) : (tensor<128xbf16>, tensor<128xbf16>, tensor<1xbf16>) -> tensor<1xbf16>
-    return %1 : tensor<1xbf16>
-  }
-
   func.func @linear_1d_1d_bias(%arg0: tensor<128xbf16>, %arg1: tensor<128xbf16>, %bias: tensor<1xbf16>) -> tensor<1xbf16> {
     // CHECK: "ttnn.empty"
     // CHECK-SAME: tensor<1xbf16
@@ -41,33 +28,7 @@ module {
     return %1 : tensor<128xbf16>
   }
 
-  func.func @linear_2d_1d(%arg0: tensor<64x128xbf16>, %arg1: tensor<128xbf16>) -> tensor<64xbf16> {
-    // CHECK: "ttnn.empty"
-    // CHECK-SAME: tensor<64xbf16
-    %0 = tensor.empty() : tensor<64xbf16>
-    // CHECK: "ttnn.matmul"
-    // CHECK-SAME: tensor<64x128xbf16
-    // CHECK-SAME: tensor<128xbf16
-    // CHECK-SAME: tensor<64xbf16
-    // CHECK-SAME: tensor<64xbf16
-    %1 = "ttir.linear"(%arg0, %arg1, %0) : (tensor<64x128xbf16>, tensor<128xbf16>, tensor<64xbf16>) -> tensor<64xbf16>
-    return %1 : tensor<64xbf16>
-  }
-
-  func.func @linear_2d_2d(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x64xbf16>) -> tensor<64x64xbf16> {
-    // CHECK: "ttnn.empty"
-    // CHECK-SAME: tensor<64x64xbf16
-    %0 = tensor.empty() : tensor<64x64xbf16>
-    // CHECK: "ttnn.matmul"
-    // CHECK-SAME: tensor<64x128xbf16
-    // CHECK-SAME: tensor<128x64xbf16
-    // CHECK-SAME: tensor<64x64xbf16
-    // CHECK-SAME: tensor<64x64xbf16
-    %1 = "ttir.linear"(%arg0, %arg1, %0) : (tensor<64x128xbf16>, tensor<128x64xbf16>, tensor<64x64xbf16>) -> tensor<64x64xbf16>
-    return %1 : tensor<64x64xbf16>
-  }
-
-    func.func @linear_2d_2d_bias(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x64xbf16>, %bias: tensor<64x64xbf16>) -> tensor<64x64xbf16> {
+  func.func @linear_2d_2d_bias(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x64xbf16>, %bias: tensor<64x64xbf16>) -> tensor<64x64xbf16> {
     // CHECK: "ttnn.empty"
     // CHECK-SAME: tensor<64x64xbf16
     %0 = tensor.empty() : tensor<64x64xbf16>
@@ -81,111 +42,7 @@ module {
     return %1 : tensor<64x64xbf16>
   }
 
-  func.func @linear_1d_nd(%arg0: tensor<128xbf16>, %arg1: tensor<12x7x128x64xbf16>) -> tensor<12x7x64xbf16> {
-    // CHECK: "ttnn.empty"
-    // CHECK-SAME: tensor<12x7x64xbf16
-    %0 = tensor.empty() : tensor<12x7x64xbf16>
-    // CHECK: "ttnn.matmul"
-    // CHECK-SAME: tensor<128xbf16
-    // CHECK-SAME: tensor<12x7x128x64xbf16
-    // CHECK-SAME: tensor<12x7x64xbf16
-    // CHECK-SAME: tensor<12x7x64xbf16
-    %1 = "ttir.linear"(%arg0, %arg1, %0) : (tensor<128xbf16>, tensor<12x7x128x64xbf16>, tensor<12x7x64xbf16>) -> tensor<12x7x64xbf16>
-    return %1 : tensor<12x7x64xbf16>
-  }
-
-  func.func @linear_nd_1d(%arg0: tensor<12x7x128x64xbf16>, %arg1: tensor<64xbf16>) -> tensor<12x7x128xbf16> {
-    // CHECK: "ttnn.empty"
-    // CHECK-SAME: tensor<12x7x128xbf16
-    %0 = tensor.empty() : tensor<12x7x128xbf16>
-    // CHECK: "ttnn.matmul"
-    // CHECK-SAME: tensor<12x7x128x64xbf16
-    // CHECK-SAME: tensor<64xbf16
-    // CHECK-SAME: tensor<12x7x128xbf16
-    // CHECK-SAME: tensor<12x7x128xbf16
-    %1 = "ttir.linear"(%arg0, %arg1, %0) : (tensor<12x7x128x64xbf16>, tensor<64xbf16>, tensor<12x7x128xbf16>) -> tensor<12x7x128xbf16>
-    return %1 : tensor<12x7x128xbf16>
-  }
-
-  func.func @linear_2d_nd(%arg0: tensor<64x128xbf16>, %arg1: tensor<12x7x128x64xbf16>) -> tensor<12x7x64x64xbf16> {
-    // CHECK: "ttnn.empty"
-    // CHECK-SAME: tensor<12x7x64x64xbf16
-    %0 = tensor.empty() : tensor<12x7x64x64xbf16>
-    // CHECK: "ttnn.matmul"
-    // CHECK-SAME: tensor<64x128xbf16
-    // CHECK-SAME: tensor<12x7x128x64xbf16
-    // CHECK-SAME: tensor<12x7x64x64xbf16
-    // CHECK-SAME: tensor<12x7x64x64xbf16
-    %1 = "ttir.linear"(%arg0, %arg1, %0) : (tensor<64x128xbf16>, tensor<12x7x128x64xbf16>, tensor<12x7x64x64xbf16>) -> tensor<12x7x64x64xbf16>
-    return %1 : tensor<12x7x64x64xbf16>
-  }
-
-  func.func @linear_nd_2d(%arg0: tensor<12x7x128x64xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<12x7x128x128xbf16> {
-    // CHECK: "ttnn.empty"
-    // CHECK-SAME: tensor<12x7x128x128xbf16
-    %0 = tensor.empty() : tensor<12x7x128x128xbf16>
-    // CHECK: "ttnn.matmul"
-    // CHECK-SAME: tensor<12x7x128x64xbf16
-    // CHECK-SAME: tensor<64x128xbf16
-    // CHECK-SAME: tensor<12x7x128x128xbf16
-    // CHECK-SAME: tensor<12x7x128x128xbf16
-    %1 = "ttir.linear"(%arg0, %arg1, %0) : (tensor<12x7x128x64xbf16>, tensor<64x128xbf16>, tensor<12x7x128x128xbf16>) -> tensor<12x7x128x128xbf16>
-    return %1 : tensor<12x7x128x128xbf16>
-  }
-
   // linear nd - nd tests
-  func.func @linear_nd_nd_same_rank_same_dims(%arg0: tensor<7x64x128xbf16>, %arg1: tensor<7x128x64xbf16>) -> tensor<7x64x64xbf16> {
-    // CHECK: "ttnn.empty"
-    // CHECK-SAME: tensor<7x64x64xbf16
-    %0 = tensor.empty() : tensor<7x64x64xbf16>
-    // CHECK: "ttnn.matmul"
-    // CHECK-SAME: tensor<7x64x128xbf16
-    // CHECK-SAME: tensor<7x128x64xbf16
-    // CHECK-SAME: tensor<7x64x64xbf16
-    // CHECK-SAME: tensor<7x64x64xbf16
-    %1 = "ttir.linear"(%arg0, %arg1, %0) : (tensor<7x64x128xbf16>, tensor<7x128x64xbf16>, tensor<7x64x64xbf16>) -> tensor<7x64x64xbf16>
-    return %1 : tensor<7x64x64xbf16>
-  }
-
-  func.func @linear_nd_nd_same_rank_broadcastable_dims_1(%arg0: tensor<7x64x128xbf16>, %arg1: tensor<1x128x64xbf16>) -> tensor<7x64x64xbf16> {
-    // CHECK: "ttnn.empty"
-    // CHECK-SAME: tensor<7x64x64xbf16
-    %0 = tensor.empty() : tensor<7x64x64xbf16>
-    // CHECK: "ttnn.matmul"
-    // CHECK-SAME: tensor<7x64x128xbf16
-    // CHECK-SAME: tensor<1x128x64xbf16
-    // CHECK-SAME: tensor<7x64x64xbf16
-    // CHECK-SAME: tensor<7x64x64xbf16
-    %1 = "ttir.linear"(%arg0, %arg1, %0) : (tensor<7x64x128xbf16>, tensor<1x128x64xbf16>, tensor<7x64x64xbf16>) -> tensor<7x64x64xbf16>
-    return %1 : tensor<7x64x64xbf16>
-  }
-
-  func.func @linear_nd_nd_same_rank_broadcastable_dims_2(%arg0: tensor<1x7x64x128xbf16>, %arg1: tensor<7x1x128x64xbf16>) -> tensor<7x7x64x64xbf16> {
-    // CHECK: "ttnn.empty"
-    // CHECK-SAME: tensor<7x7x64x64xbf16
-    %0 = tensor.empty() : tensor<7x7x64x64xbf16>
-    // CHECK: "ttnn.matmul"
-    // CHECK-SAME: tensor<1x7x64x128xbf16
-    // CHECK-SAME: tensor<7x1x128x64xbf16
-    // CHECK-SAME: tensor<7x7x64x64xbf16
-    // CHECK-SAME: tensor<7x7x64x64xbf16
-    %1 = "ttir.linear"(%arg0, %arg1, %0) : (tensor<1x7x64x128xbf16>, tensor<7x1x128x64xbf16>, tensor<7x7x64x64xbf16>) -> tensor<7x7x64x64xbf16>
-    return %1 : tensor<7x7x64x64xbf16>
-  }
-
-  func.func @linear_nd_nd_different_rank_broadcastable_dims_2(%arg0: tensor<12x1x7x64x128xbf16>, %arg1: tensor<7x1x128x64xbf16>) -> tensor<12x7x7x64x64xbf16> {
-    // CHECK: "ttnn.empty"
-    // CHECK-SAME: tensor<12x7x7x64x64xbf16
-    %0 = tensor.empty() : tensor<12x7x7x64x64xbf16>
-    // CHECK: "ttnn.matmul"
-    // CHECK-SAME: tensor<12x1x7x64x128xbf16
-    // CHECK-SAME: tensor<7x1x128x64xbf16
-    // CHECK-SAME: tensor<12x7x7x64x64xbf16
-    // CHECK-SAME: tensor<12x7x7x64x64xbf16
-    %1 = "ttir.linear"(%arg0, %arg1, %0) : (tensor<12x1x7x64x128xbf16>, tensor<7x1x128x64xbf16>, tensor<12x7x7x64x64xbf16>) -> tensor<12x7x7x64x64xbf16>
-    return %1 : tensor<12x7x7x64x64xbf16>
-  }
-
   func.func @linear_nd_nd_bias_broadcast_bias(%arg0: tensor<14x7x32x32xbf16>, %arg1:tensor<14x1x32x64xbf16>, %bias: tensor<64xbf16>) -> tensor<14x7x32x64xbf16> {
     // CHECK: "ttnn.empty"
     // CHECK-SAME: tensor<14x7x32x64xbf16

--- a/test/ttmlir/Dialect/TTNN/linear/simple_linear.mlir
+++ b/test/ttmlir/Dialect/TTNN/linear/simple_linear.mlir
@@ -1,19 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 
 module {
-  func.func @simple_linear_without_bias(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x64xbf16>) -> tensor<64x64xbf16> {
-    // CHECK: "ttnn.empty"
-    // CHECK-SAME: tensor<64x64xbf16
-    %0 = tensor.empty() : tensor<64x64xbf16>
-    // CHECK: "ttnn.matmul"
-    // CHECK-SAME: tensor<64x128xbf16
-    // CHECK-SAME: tensor<128x64xbf16
-    // CHECK-SAME: tensor<64x64xbf16
-    // CHECK-SAME: tensor<64x64xbf16
-    %1 = "ttir.linear"(%arg0, %arg1, %0) : (tensor<64x128xbf16>, tensor<128x64xbf16>, tensor<64x64xbf16>) -> tensor<64x64xbf16>
-    return %1 : tensor<64x64xbf16>
-  }
-
   func.func @simple_linear_with_bias(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x64xbf16>, %bias: tensor<64x64xbf16>) -> tensor<64x64xbf16> {
     // CHECK: "ttnn.empty"
     // CHECK-SAME: tensor<64x64xbf16

--- a/test/ttmlir/Dialect/TTNN/linear/simple_linear.mlir
+++ b/test/ttmlir/Dialect/TTNN/linear/simple_linear.mlir
@@ -5,7 +5,7 @@ module {
     // CHECK: "ttnn.empty"
     // CHECK-SAME: tensor<64x64xbf16
     %0 = tensor.empty() : tensor<64x64xbf16>
-    // CHECK: "ttnn.linear"
+    // CHECK: "ttnn.matmul"
     // CHECK-SAME: tensor<64x128xbf16
     // CHECK-SAME: tensor<128x64xbf16
     // CHECK-SAME: tensor<64x64xbf16

--- a/test/ttmlir/Dialect/TTNN/optimizer/greedy_l1_interleaved_policy/fork_join.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/greedy_l1_interleaved_policy/fork_join.mlir
@@ -27,7 +27,7 @@ module attributes {} {
     // CHECK: %{{.*}} = "ttnn.relu"{{.*}} -> tensor<64x64xbf16, #[[LAYOUT_3]]>
     %1 = "ttir.relu"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x64xbf16>, tensor<64x64xbf16>) -> tensor<64x64xbf16>
     %2 = tensor.empty() : tensor<64x64xbf16>
-    %3 = "ttir.relu"(%1, %2) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x64xbf16>, tensor<64x64xbf16>) -> tensor<64x64xbf16>
+    %3 = "ttir.gelu"(%1, %2) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x64xbf16>, tensor<64x64xbf16>) -> tensor<64x64xbf16>
     %4 = tensor.empty() : tensor<64x32xbf16>
     %5 = "ttir.matmul"(%1, %arg1, %4) : (tensor<64x64xbf16>, tensor<64x32xbf16>, tensor<64x32xbf16>) -> tensor<64x32xbf16>
     %6 = tensor.empty() : tensor<64x32xbf16>
@@ -35,7 +35,7 @@ module attributes {} {
     %8 = tensor.empty() : tensor<64x32xbf16>
     // CHECK: %{{.*}} = "ttnn.matmul"{{.*}} -> tensor<64x32xbf16, #[[LAYOUT_5]]>
     // CHECK: %{{.*}} = "ttnn.relu"{{.*}} -> tensor<64x32xbf16, #[[LAYOUT_5]]>
-    // CHECK: %{{.*}} = "ttnn.relu"{{.*}} -> tensor<64x64xbf16, #[[LAYOUT_5]]>
+    // CHECK: %{{.*}} = "ttnn.gelu"{{.*}} -> tensor<64x64xbf16, #[[LAYOUT_5]]>
     // CHECK: %{{.*}} = "ttnn.matmul"{{.*}} -> tensor<64x32xbf16, #[[LAYOUT_5]]>
     %9 = "ttir.matmul"(%3, %7, %8) : (tensor<64x64xbf16>, tensor<64x32xbf16>, tensor<64x32xbf16>) -> tensor<64x32xbf16>
     return %9 : tensor<64x32xbf16>

--- a/test/ttmlir/Dialect/TTNN/permute/permute_tests_positive.mlir
+++ b/test/ttmlir/Dialect/TTNN/permute/permute_tests_positive.mlir
@@ -1,15 +1,5 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module {
-  func.func @permute_identity(%arg0: tensor<8x32x64x128xf32>) -> tensor<8x32x64x128xf32> {
-    %0 = tensor.empty() : tensor<8x32x64x128xf32>
-    // CHECK: "ttnn.permute"
-    // CHECK-SAME: permutation = array<i64: 0, 1, 2, 3>
-    // CHECK-SAME: tensor<8x32x64x128xf32
-    // CHECK-SAME: tensor<8x32x64x128xf32
-    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 0, 1, 2, 3>}> : (tensor<8x32x64x128xf32>, tensor<8x32x64x128xf32>) -> tensor<8x32x64x128xf32>
-    return %1 : tensor<8x32x64x128xf32>
-  }
-
   func.func @permute_general(%arg0: tensor<8x32x64x128xf32>) -> tensor<64x8x128x32xf32> {
     %0 = tensor.empty() : tensor<64x8x128x32xf32>
     // CHECK: "ttnn.permute"
@@ -18,15 +8,5 @@ module {
     // CHECK-SAME: tensor<64x8x128x32xf32
     %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 2, 0, 3, 1>}> : (tensor<8x32x64x128xf32>, tensor<64x8x128x32xf32>) -> tensor<64x8x128x32xf32>
     return %1 : tensor<64x8x128x32xf32>
-  }
-
-  func.func @permute_1d(%arg0: tensor<32xf32>) -> tensor<32xf32> {
-    %0 = tensor.empty() : tensor<32xf32>
-    // CHECK: "ttnn.permute"
-    // CHECK-SAME: permutation = array<i64: 0>
-    // CHECK-SAME: tensor<32xf32
-    // CHECK-SAME: tensor<32xf32
-    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 0>}> : (tensor<32xf32>, tensor<32xf32>) -> tensor<32xf32>
-    return %1 : tensor<32xf32>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/simple_linear.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_linear.mlir
@@ -3,19 +3,6 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
 module {
-  func.func @simple_linear_without_bias(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x64xbf16>) -> tensor<64x64xbf16> {
-    // CHECK: "ttnn.empty"
-    // CHECK-SAME: tensor<64x64xbf16
-    %0 = tensor.empty() : tensor<64x64xbf16>
-    // CHECK: "ttnn.matmul"
-    // CHECK-SAME: tensor<64x128xbf16
-    // CHECK-SAME: tensor<128x64xbf16
-    // CHECK-SAME: tensor<64x64xbf16
-    // CHECK-SAME: tensor<64x64xbf16
-    %1 = "ttir.linear"(%arg0, %arg1, %0) : (tensor<64x128xbf16>, tensor<128x64xbf16>, tensor<64x64xbf16>) -> tensor<64x64xbf16>
-    return %1 : tensor<64x64xbf16>
-  }
-
   func.func @simple_linear_with_bias(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x64xbf16>, %bias: tensor<64x64xbf16>) -> tensor<64x64xbf16> {
     // CHECK: "ttnn.empty"
     // CHECK-SAME: tensor<64x64xbf16

--- a/test/ttmlir/Silicon/TTNN/simple_linear.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_linear.mlir
@@ -7,7 +7,7 @@ module {
     // CHECK: "ttnn.empty"
     // CHECK-SAME: tensor<64x64xbf16
     %0 = tensor.empty() : tensor<64x64xbf16>
-    // CHECK: "ttnn.linear"
+    // CHECK: "ttnn.matmul"
     // CHECK-SAME: tensor<64x128xbf16
     // CHECK-SAME: tensor<128x64xbf16
     // CHECK-SAME: tensor<64x64xbf16


### PR DESCRIPTION
Canonicalization can be roughly divided into three forms:
1. Traits (properties) of some ops that allows them to be folded (Involution, Idempotence)
2. Per op foldings
4. Per op canonicalization (pattern rewriters)

The first one allows us to decleratively add folding for a large class of ops. While traits like `Involution` already exists in `MLIR` infrastructure it doesn't account for DPS, so I added a new one that takes care of it.
The second one allows us in practice to define some simple graph rewritings where we replace the producing value of op with some existing value (or constant).
The third one gives us the most freedom, where we can do arbitrary graph rewritings, we usually use it when we have to create a new op during rewriting.

I added a `canonicalize` pass both before and after `ttir-to-ttir-decomposition-pass` in `ttir-to-ttnn-backend-pipeline`, as there are many graph rewritings during that pass, so we might benefit form canonicalization both before and after.

I plan to cover one big part of canonicalization in the future, and that's constant folding. I will also write a short document on adding a canonicalization for new and existing ops. While this PR covers a lot of patterns, it's definitely not an exhaustive list. This MLIR [doc](https://mlir.llvm.org/docs/Canonicalization/) is already a great source of information, I just believe we might also benefit from the additional context of TTIR dialect.

This PR should cover a big part of https://github.com/tenstorrent/tt-mlir/issues/1264, as I said the missing part is constant folding.