### PR TITLE
Fixing reduction ops

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -625,12 +625,12 @@ class TTIR_ReductionOp<string mnemonic, list<Trait> traits = []> :
       void buildGenericRegion(::mlir::OpBuilder &opBuilder, ::mlir::Block* block);
 
       SmallVector<int64_t> getReduceDims() {
-        mlir::Attribute reduceDimsAttr = getDim().value_or(mlir::Attribute{});
-        SmallVector<int64_t> reduceDimsVec;
-        if (!reduceDimsAttr) {
-          return reduceDimsVec;
+        if (!getDim()) {
+          return {};
         }
 
+        mlir::Attribute reduceDimsAttr = getDim().value();
+        SmallVector<int64_t> reduceDimsVec;
         if (auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(reduceDimsAttr)) {
           reduceDimsVec.push_back(intAttr.getSInt());
         } else {

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -615,7 +615,7 @@ class TTIR_ReductionOp<string mnemonic, list<Trait> traits = []> :
     let arguments = (ins AnyRankedTensor:$input,
                          AnyRankedTensor:$output,
                          BoolAttr:$keep_dim,
-                         OptionalAttr<I32ArrayAttr>:$dim_arg);
+                         OptionalAttr<AnyAttrOf<[SI32Attr, I32ArrayAttr]>>:$dim);
 
     let results = (outs AnyRankedTensor:$result);
 
@@ -623,6 +623,26 @@ class TTIR_ReductionOp<string mnemonic, list<Trait> traits = []> :
       MutableOperandRange getDpsInitsMutable() { return getOutputMutable(); }
 
       void buildGenericRegion(::mlir::OpBuilder &opBuilder, ::mlir::Block* block);
+
+      SmallVector<int64_t> getReduceDims() {
+        mlir::Attribute reduceDimsAttr = getDim().value_or(mlir::Attribute{});
+        SmallVector<int64_t> reduceDimsVec;
+        if (!reduceDimsAttr) {
+          return reduceDimsVec;
+        }
+
+        if (auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(reduceDimsAttr)) {
+          reduceDimsVec.push_back(intAttr.getSInt());
+        } else {
+          auto arrayAttr = mlir::cast<mlir::ArrayAttr>(reduceDimsAttr);
+          for (auto dimAttr : arrayAttr) {
+            int64_t dim = mlir::cast<mlir::IntegerAttr>(dimAttr).getInt();
+            reduceDimsVec.push_back(dim);
+          }
+        }
+
+        return reduceDimsVec;
+      }
 
       // Returns the indexing maps and iterator types for the reduction op.
       // Indexing maps are identity maps with dropped dimensions corresponding to the
@@ -635,10 +655,9 @@ class TTIR_ReductionOp<string mnemonic, list<Trait> traits = []> :
         SmallVector<Attribute> iteratorTypes(
             rank, builder.getAttr<IteratorTypeAttr>(IteratorType::Parallel));
 
-        auto reduceDims = getDimArgAttr();
+        SmallVector<int64_t> reduceDims = getReduceDims();
         auto resultIndexingMap = indexingMaps.back();
-        for (auto reduceDim : reduceDims) {
-          int64_t reduceDimInt = mlir::cast<IntegerAttr>(reduceDim).getInt();
+        for (auto reduceDimInt : reduceDims) {
           if (reduceDimInt < 0) {
             reduceDimInt += rank;
           }

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -578,9 +578,31 @@ class TTNN_ReductionOp<string mnemonic, list<Trait> traits = []> : TTNN_Op<mnemo
 
     let arguments = (ins AnyRankedTensor:$input,
                          BoolAttr:$keep_dim,
-                         OptionalAttr<I32ArrayAttr>:$dim_arg);
+                         OptionalAttr<AnyAttrOf<[SI32Attr, I32ArrayAttr]>>:$dim);
 
     let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      SmallVector<int64_t> getReduceDims() {
+        mlir::Attribute reduceDimsAttr = getDim().value_or(mlir::Attribute{});
+        SmallVector<int64_t> reduceDimsVec;
+        if (!reduceDimsAttr) {
+          return reduceDimsVec;
+        }
+
+        if (auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(reduceDimsAttr)) {
+          reduceDimsVec.push_back(intAttr.getSInt());
+        } else {
+          auto arrayAttr = mlir::cast<mlir::ArrayAttr>(reduceDimsAttr);
+          for (auto dimAttr : arrayAttr) {
+            int64_t dim = mlir::cast<mlir::IntegerAttr>(dimAttr).getInt();
+            reduceDimsVec.push_back(dim);
+          }
+        }
+
+        return reduceDimsVec;
+      }
+    }];
 
     let hasVerifier = 1;
 }

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -584,12 +584,12 @@ class TTNN_ReductionOp<string mnemonic, list<Trait> traits = []> : TTNN_Op<mnemo
 
     let extraClassDeclaration = [{
       SmallVector<int64_t> getReduceDims() {
-        mlir::Attribute reduceDimsAttr = getDim().value_or(mlir::Attribute{});
-        SmallVector<int64_t> reduceDimsVec;
-        if (!reduceDimsAttr) {
-          return reduceDimsVec;
+        if (!getDim()) {
+          return {};
         }
 
+        mlir::Attribute reduceDimsAttr = getDim().value();
+        SmallVector<int64_t> reduceDimsVec;
         if (auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(reduceDimsAttr)) {
           reduceDimsVec.push_back(intAttr.getSInt());
         } else {

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -174,7 +174,7 @@ table ReductionOp {
   type: ReductionOpType;
   in: tt.target.TensorRef;
   out: tt.target.TensorRef;
-  dim_arg: [int32];
+  dim: [int32];
   keep_dim: bool;
 }
 

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -332,7 +332,7 @@ public:
     rewriter.replaceOpWithNewOp<TTNNOpTy>(
         op, this->getTypeConverter()->convertType(op.getType()),
         adaptor.getInput(), adaptor.getKeepDim(),
-        adaptor.getDimArg().value_or(nullptr));
+        adaptor.getDim().value_or(nullptr));
     return success();
   }
 };

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceOpsRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceOpsRewritePattern.cpp
@@ -9,24 +9,9 @@
 namespace mlir::tt::ttnn::workarounds::decomposition {
 
 llvm::SmallVector<int64_t>
-getReduceDims(const std::optional<mlir::ArrayAttr> &dimArg) {
-  llvm::SmallVector<int64_t, 4> reduceDims;
-  if (!dimArg) {
-    return reduceDims;
-  }
-
-  for (const mlir::Attribute &reduceDim : *dimArg) {
-    reduceDims.push_back(mlir::cast<mlir::IntegerAttr>(reduceDim).getInt());
-  }
-
-  return reduceDims;
-}
-
-llvm::SmallVector<int64_t>
 calculateNewReduceShape(RankedTensorType inputType,
-                        const std::optional<mlir::ArrayAttr> &dimArg) {
+                        const llvm::SmallVector<int64_t> &reduceDims) {
   llvm::SmallVector<int64_t> outputShapeVec(inputType.getShape());
-  llvm::SmallVector<int64_t> reduceDims = getReduceDims(dimArg);
 
   if (reduceDims.empty()) {
     // When reduce dimensions are not specified that means we are reducing over

--- a/runtime/lib/ttnn/operations/reduction/reduction.cpp
+++ b/runtime/lib/ttnn/operations/reduction/reduction.cpp
@@ -22,11 +22,11 @@ static void runReductionOp(
   const ::ttnn::Tensor &in = tensorPool.at(op->in()->global_id());
   DEBUG_ASSERT(in.is_allocated());
 
-  const auto *fbDimArg = op->dim_arg();
+  const auto *fbDim = op->dim();
   std::optional<::ttnn::SmallVector<int>> dimArg =
-      fbDimArg ? std::make_optional(::ttnn::SmallVector<int>(fbDimArg->begin(),
-                                                             fbDimArg->end()))
-               : std::nullopt;
+      fbDim ? std::make_optional(
+                  ::ttnn::SmallVector<int>(fbDim->begin(), fbDim->end()))
+            : std::nullopt;
 
   ::ttnn::Tensor out = ttnnOp(
       in, dimArg, op->keep_dim(), outputMemoryConfig /* memory_config_arg */,

--- a/test/ttmlir/Conversion/StableHLOToTTIR/reduce_add_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/reduce_add_op.mlir
@@ -4,7 +4,7 @@ module @jit_reduce_add attributes {} {
   func.func public @test_reduce_add_4to3dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<128x32x4xf32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.sum"
-    // CHECK-SAME: dim_arg = [1 : i32]
+    // CHECK-SAME: dim = [1 : i32]
     // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10x32x4xf32>
     // CHECK-SAME: -> tensor<128x32x4xf32>
@@ -15,7 +15,7 @@ module @jit_reduce_add attributes {} {
   func.func public @test_reduce_add_4to2dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<128x32xf32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.sum"
-    // CHECK-SAME: dim_arg = [1 : i32, 3 : i32]
+    // CHECK-SAME: dim = [1 : i32, 3 : i32]
     // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10x32x4xf32>
     // CHECK-SAME: -> tensor<128x32xf32>
@@ -26,7 +26,7 @@ module @jit_reduce_add attributes {} {
   func.func public @test_reduce_add_4to1dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.sum"
-    // CHECK-SAME: dim_arg = [1 : i32, 2 : i32, 3 : i32]
+    // CHECK-SAME: dim = [1 : i32, 2 : i32, 3 : i32]
     // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10x32x4xf32>
     // CHECK-SAME: -> tensor<128xf32>
@@ -37,7 +37,7 @@ module @jit_reduce_add attributes {} {
   func.func public @test_reduce_add_4to0dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.sum"
-    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32, 3 : i32]
+    // CHECK-SAME: dim = [0 : i32, 1 : i32, 2 : i32, 3 : i32]
     // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10x32x4xf32>
     // CHECK-SAME: -> tensor<1xf32>
@@ -48,7 +48,7 @@ module @jit_reduce_add attributes {} {
   func.func public @test_reduce_add_3to2dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128x4xf32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.sum"
-    // CHECK-SAME: dim_arg = [1 : i32]
+    // CHECK-SAME: dim = [1 : i32]
     // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10x4xf32>
     // CHECK-SAME: -> tensor<128x4xf32>
@@ -59,7 +59,7 @@ module @jit_reduce_add attributes {} {
   func.func public @test_reduce_add_3to1dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.sum"
-    // CHECK-SAME: dim_arg = [1 : i32, 2 : i32]
+    // CHECK-SAME: dim = [1 : i32, 2 : i32]
     // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10x4xf32>
     // CHECK-SAME: -> tensor<128xf32>
@@ -70,7 +70,7 @@ module @jit_reduce_add attributes {} {
   func.func public @test_reduce_add_3to0dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.sum"
-    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32]
+    // CHECK-SAME: dim = [0 : i32, 1 : i32, 2 : i32]
     // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10x4xf32>
     // CHECK-SAME: -> tensor<1xf32>
@@ -81,7 +81,7 @@ module @jit_reduce_add attributes {} {
   func.func public @test_reduce_add_2to1dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.sum"
-    // CHECK-SAME: dim_arg = [1 : i32]
+    // CHECK-SAME: dim = [1 : i32]
     // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10xf32>
     // CHECK-SAME: -> tensor<128xf32>
@@ -92,7 +92,7 @@ module @jit_reduce_add attributes {} {
   func.func public @test_reduce_add_2to0dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.sum"
-    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32]
+    // CHECK-SAME: dim = [0 : i32, 1 : i32]
     // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10xf32>
     // CHECK-SAME: -> tensor<1xf32>
@@ -103,7 +103,7 @@ module @jit_reduce_add attributes {} {
   func.func public @test_reduce_add_1to0dim(%arg0: tensor<128xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.sum"
-    // CHECK-SAME: dim_arg = [0 : i32]
+    // CHECK-SAME: dim = [0 : i32]
     // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128xf32>
     // CHECK-SAME: -> tensor<1xf32>

--- a/test/ttmlir/Conversion/StableHLOToTTIR/reduce_maximum_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/reduce_maximum_op.mlir
@@ -4,7 +4,7 @@ module @jit_reduce_maximum attributes {} {
   func.func public @test_reduce_maximum_4to3dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<128x32x4xf32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.max"
-    // CHECK-SAME: dim_arg = [1 : i32]
+    // CHECK-SAME: dim = [1 : i32]
     // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10x32x4xf32>
     // CHECK-SAME: -> tensor<128x32x4xf32>
@@ -15,7 +15,7 @@ module @jit_reduce_maximum attributes {} {
   func.func public @test_reduce_maximum_4to2dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<128x32xf32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.max"
-    // CHECK-SAME: dim_arg = [1 : i32, 3 : i32]
+    // CHECK-SAME: dim = [1 : i32, 3 : i32]
     // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10x32x4xf32>
     // CHECK-SAME: -> tensor<128x32xf32>
@@ -26,7 +26,7 @@ module @jit_reduce_maximum attributes {} {
   func.func public @test_reduce_maximum_4to1dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.max"
-    // CHECK-SAME: dim_arg = [1 : i32, 2 : i32, 3 : i32]
+    // CHECK-SAME: dim = [1 : i32, 2 : i32, 3 : i32]
     // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10x32x4xf32>
     // CHECK-SAME: -> tensor<128xf32>
@@ -37,7 +37,7 @@ module @jit_reduce_maximum attributes {} {
   func.func public @test_reduce_maximum_4to0dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.max"
-    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32, 3 : i32]
+    // CHECK-SAME: dim = [0 : i32, 1 : i32, 2 : i32, 3 : i32]
     // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10x32x4xf32>
     // CHECK-SAME: -> tensor<1xf32>
@@ -48,7 +48,7 @@ module @jit_reduce_maximum attributes {} {
   func.func public @test_reduce_maximum_3to2dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128x4xf32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.max"
-    // CHECK-SAME: dim_arg = [1 : i32]
+    // CHECK-SAME: dim = [1 : i32]
     // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10x4xf32>
     // CHECK-SAME: -> tensor<128x4xf32>
@@ -59,7 +59,7 @@ module @jit_reduce_maximum attributes {} {
   func.func public @test_reduce_maximum_3to1dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.max"
-    // CHECK-SAME: dim_arg = [1 : i32, 2 : i32]
+    // CHECK-SAME: dim = [1 : i32, 2 : i32]
     // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10x4xf32>
     // CHECK-SAME: -> tensor<128xf32>
@@ -70,7 +70,7 @@ module @jit_reduce_maximum attributes {} {
   func.func public @test_reduce_maximum_3to0dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.max"
-    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32]
+    // CHECK-SAME: dim = [0 : i32, 1 : i32, 2 : i32]
     // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10x4xf32>
     // CHECK-SAME: -> tensor<1xf32>
@@ -81,7 +81,7 @@ module @jit_reduce_maximum attributes {} {
   func.func public @test_reduce_maximum_2to1dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.max"
-    // CHECK-SAME: dim_arg = [1 : i32]
+    // CHECK-SAME: dim = [1 : i32]
     // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10xf32>
     // CHECK-SAME: -> tensor<128xf32>
@@ -92,7 +92,7 @@ module @jit_reduce_maximum attributes {} {
   func.func public @test_reduce_maximum_2to0dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.max"
-    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32]
+    // CHECK-SAME: dim = [0 : i32, 1 : i32]
     // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10xf32>
     // CHECK-SAME: -> tensor<1xf32>
@@ -103,7 +103,7 @@ module @jit_reduce_maximum attributes {} {
   func.func public @test_reduce_maximum_1to0dim(%arg0: tensor<128xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: tensor.empty
     // CHECK: "ttir.max"
-    // CHECK-SAME: dim_arg = [0 : i32]
+    // CHECK-SAME: dim = [0 : i32]
     // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128xf32>
     // CHECK-SAME: -> tensor<1xf32>

--- a/test/ttmlir/Dialect/TTIR/reduce_ops/negative_invalid_dim_high.mlir
+++ b/test/ttmlir/Dialect/TTIR/reduce_ops/negative_invalid_dim_high.mlir
@@ -4,6 +4,6 @@
 // CHECK: error: 'ttir.sum' op Reduce dimensions are out of range
 func.func public @test_reduce_add_invalid_dim_high(%arg0: tensor<128x10xf32>, %arg1: tensor<1xf32>) -> tensor<128xf32> {
   %0 = tensor.empty() : tensor<128xf32>
-  %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<128x10xf32>, tensor<128xf32>) -> tensor<128xf32>
+  %1 = "ttir.sum"(%arg0, %0) <{dim = [2 : i32], keep_dim = false}> : (tensor<128x10xf32>, tensor<128xf32>) -> tensor<128xf32>
   return %1 : tensor<128xf32>
 }

--- a/test/ttmlir/Dialect/TTIR/reduce_ops/negative_invalid_dim_low.mlir
+++ b/test/ttmlir/Dialect/TTIR/reduce_ops/negative_invalid_dim_low.mlir
@@ -4,6 +4,6 @@
 // CHECK: error: 'ttir.sum' op Reduce dimensions are out of range
 func.func public @test_reduce_add_invalid_dim_low(%arg0: tensor<128x10xf32>, %arg1: tensor<1xf32>) -> tensor<128xf32> {
   %0 = tensor.empty() : tensor<128xf32>
-  %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [-3 : i32], keep_dim = false}> : (tensor<128x10xf32>, tensor<128xf32>) -> tensor<128xf32>
+  %1 = "ttir.sum"(%arg0, %0) <{dim = [-3 : i32], keep_dim = false}> : (tensor<128x10xf32>, tensor<128xf32>) -> tensor<128xf32>
   return %1 : tensor<128xf32>
 }

--- a/test/ttmlir/Dialect/TTIR/reduce_ops/negative_repeating_dims.mlir
+++ b/test/ttmlir/Dialect/TTIR/reduce_ops/negative_repeating_dims.mlir
@@ -4,6 +4,6 @@
 // CHECK: error: 'ttir.sum' op Reduce dimensions are not unique
 func.func public @test_reduce_add_repeating_dims(%arg0: tensor<128x10x32x4xf32>, %arg1: tensor<1xf32>) -> tensor<128xf32> {
   %0 = tensor.empty() : tensor<128xf32>
-  %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [1 : i32, 2 : i32, 3 : i32, 2 : i32], keep_dim = false}> : (tensor<128x10x32x4xf32>, tensor<128xf32>) -> tensor<128xf32>
+  %1 = "ttir.sum"(%arg0, %0) <{dim = [1 : i32, 2 : i32, 3 : i32, 2 : i32], keep_dim = false}> : (tensor<128x10x32x4xf32>, tensor<128xf32>) -> tensor<128xf32>
   return %1 : tensor<128xf32>
 }

--- a/test/ttmlir/Dialect/TTNN/reduction/max_op_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/reduction/max_op_negative.mlir
@@ -4,7 +4,7 @@ module {
   func.func @forward(%arg0: tensor<128x32x10x4xbf16>) -> tensor<128x1x1x1xbf16> {
     %0 = tensor.empty() : tensor<128x1x1x1xbf16>
     // CHECK: error: 'ttnn.max' op Reduce on more than two dimensions is not currently supported by TTNN
-    %1 = "ttir.max"(%arg0, %0) <{dim_arg = [1: i32, 2: i32, 3: i32], keep_dim = true}> : (tensor<128x32x10x4xbf16>, tensor<128x1x1x1xbf16>) -> tensor<128x1x1x1xbf16>
+    %1 = "ttir.max"(%arg0, %0) <{dim = [1: i32, 2: i32, 3: i32], keep_dim = true}> : (tensor<128x32x10x4xbf16>, tensor<128x1x1x1xbf16>) -> tensor<128x1x1x1xbf16>
     return %1 : tensor<128x1x1x1xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/reduction/mean_op_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/reduction/mean_op_negative.mlir
@@ -4,7 +4,7 @@ module {
   func.func @forward(%arg0: tensor<128x32x10x4xbf16>) -> tensor<128x1x1x1xbf16> {
     %0 = tensor.empty() : tensor<128x1x1x1xbf16>
     // CHECK: error: 'ttnn.mean' op Reduce on more than two dimensions is not currently supported by TTNN
-    %1 = "ttir.mean"(%arg0, %0) <{dim_arg = [1: i32, 2: i32, 3: i32], keep_dim = true}> : (tensor<128x32x10x4xbf16>, tensor<128x1x1x1xbf16>) -> tensor<128x1x1x1xbf16>
+    %1 = "ttir.mean"(%arg0, %0) <{dim = [1: i32, 2: i32, 3: i32], keep_dim = true}> : (tensor<128x32x10x4xbf16>, tensor<128x1x1x1xbf16>) -> tensor<128x1x1x1xbf16>
     return %1 : tensor<128x1x1x1xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/reduction/sum_op_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/reduction/sum_op_negative.mlir
@@ -4,7 +4,7 @@ module {
   func.func @forward(%arg0: tensor<128x32x10x4xbf16>) -> tensor<128x1x1x1xbf16> {
     %0 = tensor.empty() : tensor<128x1x1x1xbf16>
     // CHECK: error: 'ttnn.sum' op Reduce on more than two dimensions is not currently supported by TTNN
-    %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [1: i32, 2: i32, 3: i32], keep_dim = true}> : (tensor<128x32x10x4xbf16>, tensor<128x1x1x1xbf16>) -> tensor<128x1x1x1xbf16>
+    %1 = "ttir.sum"(%arg0, %0) <{dim = [1: i32, 2: i32, 3: i32], keep_dim = true}> : (tensor<128x32x10x4xbf16>, tensor<128x1x1x1xbf16>) -> tensor<128x1x1x1xbf16>
     return %1 : tensor<128x1x1x1xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/simple_max.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_max.mlir
@@ -3,7 +3,7 @@ module attributes {} {
   func.func @forward(%arg0: tensor<512x32xbf16>) -> tensor<512xbf16> {
     %0 = tensor.empty() : tensor<512xbf16>
     // CHECK: %[[C:.*]] = "ttnn.max"[[C:.*]]
-    %1 = "ttir.max"(%arg0, %0) <{dim_arg = [1: i32], keep_dim = false}> : (tensor<512x32xbf16>, tensor<512xbf16>) -> tensor<512xbf16>
+    %1 = "ttir.max"(%arg0, %0) <{dim = [1: i32], keep_dim = false}> : (tensor<512x32xbf16>, tensor<512xbf16>) -> tensor<512xbf16>
     return %1 : tensor<512xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/simple_mean.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_mean.mlir
@@ -3,7 +3,7 @@ module {
   func.func @forward(%arg0: tensor<512x1024xbf16>) -> tensor<512x32xbf16> {
     %0 = tensor.empty() : tensor<512x32xbf16>
     // CHECK: %[[C:.*]] = "ttnn.mean"[[C:.*]]
-    %1 = "ttir.mean"(%arg0, %0) <{dim_arg = [-1: i32], keep_dim = true}> : (tensor<512x1024xbf16>, tensor<512x32xbf16>) -> tensor<512x32xbf16>
+    %1 = "ttir.mean"(%arg0, %0) <{dim = [-1: i32], keep_dim = true}> : (tensor<512x1024xbf16>, tensor<512x32xbf16>) -> tensor<512x32xbf16>
     return %1 : tensor<512x32xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/simple_sum.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_sum.mlir
@@ -3,7 +3,7 @@ module attributes {} {
   func.func @forward(%arg0: tensor<512x1024xbf16>) -> tensor<512x32xbf16> {
     %0 = tensor.empty() : tensor<512x32xbf16>
     // CHECK: %[[C:.*]] = "ttnn.sum"[[C:.*]]
-    %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [-1: i32], keep_dim = true}> : (tensor<512x1024xbf16>, tensor<512x32xbf16>) -> tensor<512x32xbf16>
+    %1 = "ttir.sum"(%arg0, %0) <{dim = [-1: i32], keep_dim = true}> : (tensor<512x1024xbf16>, tensor<512x32xbf16>) -> tensor<512x32xbf16>
     return %1 : tensor<512x32xbf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/reduce_add_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/reduce_add_op.mlir
@@ -13,7 +13,7 @@
 module @jit_reduce_add attributes {} {
   func.func public @test_reduce_add_4to0dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: "ttnn.sum"
-    // CHECK-NOT: dim_arg
+    // CHECK-NOT: dim
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128x10x32x4xf32,
     // CHECK-SAME: -> tensor<1x1x1x1xf32,
@@ -27,7 +27,7 @@ module @jit_reduce_add attributes {} {
 
   func.func public @test_reduce_add_3to2dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128x4xf32> {
     // CHECK: "ttnn.sum"
-    // CHECK-SAME: dim_arg = [1 : i32]
+    // CHECK-SAME: dim = [1 : i32]
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128x10x4xf32,
     // CHECK-SAME: -> tensor<128x1x4xf32,
@@ -41,7 +41,7 @@ module @jit_reduce_add attributes {} {
 
   func.func public @test_reduce_add_3to1dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
     // CHECK: "ttnn.sum"
-    // CHECK-SAME: dim_arg = [1 : i32, 2 : i32]
+    // CHECK-SAME: dim = [1 : i32, 2 : i32]
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128x10x4xf32,
     // CHECK-SAME: -> tensor<128x1x1xf32,
@@ -55,7 +55,7 @@ module @jit_reduce_add attributes {} {
 
   func.func public @test_reduce_add_3to0dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: "ttnn.sum"
-    // CHECK-NOT: dim_arg
+    // CHECK-NOT: dim
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128x10x4xf32,
     // CHECK-SAME: -> tensor<1x1x1xf32,
@@ -69,7 +69,7 @@ module @jit_reduce_add attributes {} {
 
   func.func public @test_reduce_add_2to1dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
     // CHECK: "ttnn.sum"
-    // CHECK-SAME: dim_arg = [1 : i32]
+    // CHECK-SAME: dim = [1 : i32]
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128x10xf32,
     // CHECK-SAME: -> tensor<128x1xf32,
@@ -83,7 +83,7 @@ module @jit_reduce_add attributes {} {
 
   func.func public @test_reduce_add_2to0dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: "ttnn.sum"
-    // CHECK-NOT: dim_arg
+    // CHECK-NOT: dim
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128x10xf32,
     // CHECK-SAME: -> tensor<1x1xf32,
@@ -97,7 +97,7 @@ module @jit_reduce_add attributes {} {
 
   func.func public @test_reduce_add_1to0dim(%arg0: tensor<128xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: "ttnn.sum"
-    // CHECK-NOT: dim_arg
+    // CHECK-NOT: dim
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128xf32,
     // CHECK-SAME: -> tensor<1xf32,

--- a/test/ttmlir/Silicon/StableHLO/reduce_maximum_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/reduce_maximum_op.mlir
@@ -13,7 +13,7 @@
 module @jit_reduce_maximum attributes {} {
   func.func public @test_reduce_maximum_4to0dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: "ttnn.max"
-    // CHECK-NOT: dim_arg
+    // CHECK-NOT: dim
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128x10x32x4xf32,
     // CHECK-SAME: -> tensor<1x1x1x1xf32,
@@ -27,7 +27,7 @@ module @jit_reduce_maximum attributes {} {
 
   func.func public @test_reduce_maximum_3to2dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128x4xf32> {
     // CHECK: "ttnn.max"
-    // CHECK-SAME: dim_arg = [1 : i32]
+    // CHECK-SAME: dim = [1 : i32]
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128x10x4xf32,
     // CHECK-SAME: -> tensor<128x1x4xf32,
@@ -41,7 +41,7 @@ module @jit_reduce_maximum attributes {} {
 
   func.func public @test_reduce_maximum_3to1dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
     // CHECK: "ttnn.max"
-    // CHECK-SAME: dim_arg = [1 : i32, 2 : i32]
+    // CHECK-SAME: dim = [1 : i32, 2 : i32]
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128x10x4xf32,
     // CHECK-SAME: -> tensor<128x1x1xf32,
@@ -55,7 +55,7 @@ module @jit_reduce_maximum attributes {} {
 
   func.func public @test_reduce_maximum_3to0dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: "ttnn.max"
-    // CHECK-NOT: dim_arg
+    // CHECK-NOT: dim
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128x10x4xf32,
     // CHECK-SAME: -> tensor<1x1x1xf32,
@@ -69,7 +69,7 @@ module @jit_reduce_maximum attributes {} {
 
   func.func public @test_reduce_maximum_2to1dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
     // CHECK: "ttnn.max"
-    // CHECK-SAME: dim_arg = [1 : i32]
+    // CHECK-SAME: dim = [1 : i32]
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128x10xf32,
     // CHECK-SAME: -> tensor<128x1xf32,
@@ -83,7 +83,7 @@ module @jit_reduce_maximum attributes {} {
 
   func.func public @test_reduce_maximum_2to0dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: "ttnn.max"
-    // CHECK-NOT: dim_arg
+    // CHECK-NOT: dim
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128x10xf32,
     // CHECK-SAME: -> tensor<1x1xf32,
@@ -97,7 +97,7 @@ module @jit_reduce_maximum attributes {} {
 
   func.func public @test_reduce_maximum_1to0dim(%arg0: tensor<128xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: "ttnn.max"
-    // CHECK-NOT: dim_arg
+    // CHECK-NOT: dim
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128xf32,
     // CHECK-SAME: -> tensor<1xf32,

--- a/test/ttmlir/Silicon/TTMetal/simple_reduce.mlir
+++ b/test/ttmlir/Silicon/TTMetal/simple_reduce.mlir
@@ -7,7 +7,7 @@ func.func @reduceW(%arg0: tensor<256x384xf32, #layout1>) -> tensor<256x32xf32, #
   %0 = tensor.empty() : tensor<256x32xf32, #layout2>
   // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
   %1 = "ttir.sum"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
-                               dim_arg = [-1: i32],
+                               dim = [-1: i32],
                                keep_dim = true}> :
     (tensor<256x384xf32, #layout1>, tensor<256x32xf32, #layout2>) -> tensor<256x32xf32, #layout2>
   return %1 : tensor<256x32xf32, #layout2>
@@ -18,7 +18,7 @@ func.func @reduceH(%arg0: tensor<256x384xf32, #layout1>) -> tensor<32x384xf32, #
   %0 = tensor.empty() : tensor<32x384xf32, #layout3>
   // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
   %1 = "ttir.sum"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
-                               dim_arg = [-2: i32],
+                               dim = [-2: i32],
                                keep_dim = true}> :
     (tensor<256x384xf32, #layout1>, tensor<32x384xf32, #layout3>) -> tensor<32x384xf32, #layout3>
   return %1 : tensor<32x384xf32, #layout3>
@@ -29,7 +29,7 @@ func.func @reduceWH(%arg0: tensor<256x384xf32, #layout1>) -> tensor<32x32xf32, #
   %0 = tensor.empty() : tensor<32x32xf32, #layout4>
   // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
   %1 = "ttir.sum"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
-                               dim_arg = [-1: i32, -2: i32],
+                               dim = [-1: i32, -2: i32],
                                keep_dim = true}> :
     (tensor<256x384xf32, #layout1>, tensor<32x32xf32, #layout4>) -> tensor<32x32xf32, #layout4>
   return %1 : tensor<32x32xf32, #layout4>
@@ -39,7 +39,7 @@ func.func @maxReduceWH(%arg0: tensor<256x384xf32, #layout1>) -> tensor<32x32xf32
   %0 = tensor.empty() : tensor<32x32xf32, #layout4>
   // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
   %1 = "ttir.max" (%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
-                               dim_arg = [-1: i32, -2: i32],
+                               dim = [-1: i32, -2: i32],
                                keep_dim = true}> :
     (tensor<256x384xf32, #layout1>, tensor<32x32xf32, #layout4>) -> tensor<32x32xf32, #layout4>
   return %1 : tensor<32x32xf32, #layout4>

--- a/test/ttmlir/Silicon/TTMetal/simple_reduce_1x1.mlir
+++ b/test/ttmlir/Silicon/TTMetal/simple_reduce_1x1.mlir
@@ -5,7 +5,7 @@ func.func @reduceW(%arg0: tensor<64x256xf32>) -> tensor<64x32xf32> {
   %0 = tensor.empty() : tensor<64x32xf32>
   // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
   %1 = "ttir.sum"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
-                               dim_arg = [-1: i32],
+                               dim = [-1: i32],
                                keep_dim = true}> :
     (tensor<64x256xf32>, tensor<64x32xf32>) -> tensor<64x32xf32>
   return %1 : tensor<64x32xf32>
@@ -15,7 +15,7 @@ func.func @reduceH(%arg0: tensor<256x64xf32>) -> tensor<32x64xf32> {
   %0 = tensor.empty() : tensor<32x64xf32>
   // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
   %1 = "ttir.sum"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
-                               dim_arg = [-2: i32],
+                               dim = [-2: i32],
                                keep_dim = true}> :
     (tensor<256x64xf32>, tensor<32x64xf32>) -> tensor<32x64xf32>
   return %1 : tensor<32x64xf32>
@@ -25,7 +25,7 @@ func.func @reduceWH(%arg0: tensor<256x64xf32>) -> tensor<32x32xf32> {
   %0 = tensor.empty() : tensor<32x32xf32>
   // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
   %1 = "ttir.sum"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
-                               dim_arg = [-1: i32, -2: i32],
+                               dim = [-1: i32, -2: i32],
                                keep_dim = true}> :
     (tensor<256x64xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
   return %1 : tensor<32x32xf32>

--- a/test/ttmlir/Silicon/TTNN/perf_unit/test_perf_max.mlir
+++ b/test/ttmlir/Silicon/TTNN/perf_unit/test_perf_max.mlir
@@ -4,6 +4,6 @@
 func.func @max(%arg0: tensor<1x1x512x64xbf16>) -> tensor<1x1x512xbf16> {
   %0 = tensor.empty() : tensor<1x1x512xbf16>
   // CHECK: %[[C:.*]] = "ttnn.max"[[C:.*]]
-  %1 = "ttir.max"(%arg0, %0) <{dim_arg = [-1: i32], keep_dim = true}> : (tensor<1x1x512x64xbf16>, tensor<1x1x512xbf16>) -> tensor<1x1x512xbf16>
+  %1 = "ttir.max"(%arg0, %0) <{dim = [-1: i32], keep_dim = true}> : (tensor<1x1x512x64xbf16>, tensor<1x1x512xbf16>) -> tensor<1x1x512xbf16>
   return %1 : tensor<1x1x512xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/perf_unit/test_perf_sum.mlir
+++ b/test/ttmlir/Silicon/TTNN/perf_unit/test_perf_sum.mlir
@@ -4,6 +4,6 @@
 func.func @sum(%arg0: tensor<1x1x512x64xbf16>) -> tensor<1x1x512xbf16> {
   %0 = tensor.empty() : tensor<1x1x512xbf16>
   // CHECK: %[[C:.*]] = "ttnn.sum"[[C:.*]]
-  %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [-1: i32], keep_dim = true}> : (tensor<1x1x512x64xbf16>, tensor<1x1x512xbf16>) -> tensor<1x1x512xbf16>
+  %1 = "ttir.sum"(%arg0, %0) <{dim = [-1: i32], keep_dim = true}> : (tensor<1x1x512x64xbf16>, tensor<1x1x512xbf16>) -> tensor<1x1x512xbf16>
   return %1 : tensor<1x1x512xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/simple_max.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_max.mlir
@@ -13,7 +13,7 @@ module {
   func.func public @reduce_not_keep_dim(%arg0: tensor<128x10xf32>) -> tensor<128xf32> {
     %0 = tensor.empty() : tensor<128xf32>
     // CHECK: "ttnn.max"
-    // CHECK-SAME: dim_arg = [1 : i32]
+    // CHECK-SAME: dim = [1 : i32]
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128x10xf32,
     // CHECK-SAME: -> tensor<128x1xf32,
@@ -21,19 +21,19 @@ module {
     // CHECK-SAME: shape = [128 : i32]
     // CHECK-SAME: tensor<128x1xf32,
     // CHECK-SAME: -> tensor<128xf32,
-    %1 = "ttir.max"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x10xf32>, tensor<128xf32>) -> tensor<128xf32>
+    %1 = "ttir.max"(%arg0, %0) <{dim = [1 : i32], keep_dim = false}> : (tensor<128x10xf32>, tensor<128xf32>) -> tensor<128xf32>
     return %1 : tensor<128xf32>
   }
 
   func.func public @reduce_keep_dim(%arg0: tensor<128x10xf32>) -> tensor<128x1xf32> {
     %0 = tensor.empty() : tensor<128x1xf32>
     // CHECK: "ttnn.max"
-    // CHECK-SAME: dim_arg = [1 : i32]
+    // CHECK-SAME: dim = [1 : i32]
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128x10xf32,
     // CHECK-SAME: -> tensor<128x1xf32,
     // CHECK-NOT: "ttnn.reshape"
-    %1 = "ttir.max"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<128x10xf32>, tensor<128x1xf32>) -> tensor<128x1xf32>
+    %1 = "ttir.max"(%arg0, %0) <{dim = [1 : i32], keep_dim = true}> : (tensor<128x10xf32>, tensor<128x1xf32>) -> tensor<128x1xf32>
     return %1 : tensor<128x1xf32>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/simple_mean.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_mean.mlir
@@ -37,7 +37,7 @@ module {
     return %1 : tensor<128x1xf32>
   }
 
-  func.func public @mean_into_reshape_dim_array(%arg0: tensor<1x1x49x2048xf32>) -> (tensor<1x2048x1x1xf32> {ttir.name = "AvgPool2d.output_avg_pool2d_0"}) {
+  func.func public @mean_into_reshape_dim_array(%arg0: tensor<1x1x49x2048xf32>) -> tensor<1x2048x1x1xf32> {
     // CHECK: "ttnn.mean"
     // CHECK-SAME: {dim = [-2 : i32], keep_dim = true}
     // CHECK: "ttnn.reshape"
@@ -48,7 +48,7 @@ module {
     return %4 : tensor<1x2048x1x1xf32>
   }
 
-  func.func public @mean_into_reshape_dim_scalar(%arg0: tensor<1x1x49x2048xf32>) -> (tensor<1x2048x1x1xf32> {ttir.name = "AvgPool2d.output_avg_pool2d_0"}) {
+  func.func public @mean_into_reshape_dim_scalar(%arg0: tensor<1x1x49x2048xf32>) -> tensor<1x2048x1x1xf32> {
     // CHECK: "ttnn.mean"
     // CHECK-SAME: {dim = -2 : si32, keep_dim = true}
     // CHECK: "ttnn.reshape"

--- a/test/ttmlir/Silicon/TTNN/simple_mean.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_mean.mlir
@@ -13,7 +13,7 @@ module {
   func.func public @reduce_not_keep_dim(%arg0: tensor<128x10xf32>) -> tensor<128xf32> {
     %0 = tensor.empty() : tensor<128xf32>
     // CHECK: "ttnn.mean"
-    // CHECK-SAME: dim_arg = [1 : i32]
+    // CHECK-SAME: dim = [1 : i32]
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128x10xf32,
     // CHECK-SAME: -> tensor<128x1xf32,
@@ -21,19 +21,19 @@ module {
     // CHECK-SAME: shape = [128 : i32]
     // CHECK-SAME: tensor<128x1xf32,
     // CHECK-SAME: -> tensor<128xf32,
-    %1 = "ttir.mean"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x10xf32>, tensor<128xf32>) -> tensor<128xf32>
+    %1 = "ttir.mean"(%arg0, %0) <{dim = [1 : i32], keep_dim = false}> : (tensor<128x10xf32>, tensor<128xf32>) -> tensor<128xf32>
     return %1 : tensor<128xf32>
   }
 
   func.func public @reduce_keep_dim(%arg0: tensor<128x10xf32>) -> tensor<128x1xf32> {
     %0 = tensor.empty() : tensor<128x1xf32>
     // CHECK: "ttnn.mean"
-    // CHECK-SAME: dim_arg = [1 : i32]
+    // CHECK-SAME: dim = [1 : i32]
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128x10xf32,
     // CHECK-SAME: -> tensor<128x1xf32,
     // CHECK-NOT: "ttnn.reshape"
-    %1 = "ttir.mean"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<128x10xf32>, tensor<128x1xf32>) -> tensor<128x1xf32>
+    %1 = "ttir.mean"(%arg0, %0) <{dim = [1 : i32], keep_dim = true}> : (tensor<128x10xf32>, tensor<128x1xf32>) -> tensor<128x1xf32>
     return %1 : tensor<128x1xf32>
   }
 

--- a/test/ttmlir/Silicon/TTNN/simple_mean.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_mean.mlir
@@ -36,4 +36,26 @@ module {
     %1 = "ttir.mean"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<128x10xf32>, tensor<128x1xf32>) -> tensor<128x1xf32>
     return %1 : tensor<128x1xf32>
   }
+
+  func.func public @mean_into_reshape_dim_array(%arg0: tensor<1x1x49x2048xf32>) -> (tensor<1x2048x1x1xf32> {ttir.name = "AvgPool2d.output_avg_pool2d_0"}) {
+    // CHECK: "ttnn.mean"
+    // CHECK-SAME: {dim = [-2 : i32], keep_dim = true}
+    // CHECK: "ttnn.reshape"
+    %1 = tensor.empty() : tensor<1x1x1x2048xf32>
+    %2 = "ttir.mean"(%arg0, %1) <{dim = [-2 : i32], keep_dim = true}> : (tensor<1x1x49x2048xf32>, tensor<1x1x1x2048xf32>) -> tensor<1x1x1x2048xf32>
+    %3 = tensor.empty() : tensor<1x2048x1x1xf32>
+    %4 = "ttir.reshape"(%2, %3) <{shape = [1 : i32, 2048 : i32, 1 : i32, 1 : i32]}> : (tensor<1x1x1x2048xf32>, tensor<1x2048x1x1xf32>) -> tensor<1x2048x1x1xf32>
+    return %4 : tensor<1x2048x1x1xf32>
+  }
+
+  func.func public @mean_into_reshape_dim_scalar(%arg0: tensor<1x1x49x2048xf32>) -> (tensor<1x2048x1x1xf32> {ttir.name = "AvgPool2d.output_avg_pool2d_0"}) {
+    // CHECK: "ttnn.mean"
+    // CHECK-SAME: {dim = -2 : si32, keep_dim = true}
+    // CHECK: "ttnn.reshape"
+    %1 = tensor.empty() : tensor<1x1x1x2048xf32>
+    %2 = "ttir.mean"(%arg0, %1) <{dim = -2 : si32, keep_dim = true}> : (tensor<1x1x49x2048xf32>, tensor<1x1x1x2048xf32>) -> tensor<1x1x1x2048xf32>
+    %3 = tensor.empty() : tensor<1x2048x1x1xf32>
+    %4 = "ttir.reshape"(%2, %3) <{shape = [1 : i32, 2048 : i32, 1 : i32, 1 : i32]}> : (tensor<1x1x1x2048xf32>, tensor<1x2048x1x1xf32>) -> tensor<1x2048x1x1xf32>
+    return %4 : tensor<1x2048x1x1xf32>
+  }
 }

--- a/test/ttmlir/Silicon/TTNN/simple_reductions.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_reductions.mlir
@@ -4,47 +4,47 @@
 func.func @sum(%arg0: tensor<1x1x512x64xbf16>) -> tensor<1x1x512xbf16> {
   %0 = tensor.empty() : tensor<1x1x512xbf16>
   // CHECK: %[[C:.*]] = "ttnn.sum"[[C:.*]]
-  %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [-1: i32], keep_dim = true}> : (tensor<1x1x512x64xbf16>, tensor<1x1x512xbf16>) -> tensor<1x1x512xbf16>
+  %1 = "ttir.sum"(%arg0, %0) <{dim = [-1: i32], keep_dim = true}> : (tensor<1x1x512x64xbf16>, tensor<1x1x512xbf16>) -> tensor<1x1x512xbf16>
   return %1 : tensor<1x1x512xbf16>
 }
 
 func.func @sum_last_2_dims(%arg0: tensor<1x32x512x64xbf16>) -> tensor<1x32xbf16> {
   %0 = tensor.empty() : tensor<1x32xbf16>
   // CHECK: %[[C:.*]] = "ttnn.sum"[[C:.*]]
-  %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [-1: i32, -2: i32], keep_dim = true}> : (tensor<1x32x512x64xbf16>, tensor<1x32xbf16>) -> tensor<1x32xbf16>
+  %1 = "ttir.sum"(%arg0, %0) <{dim = [-1: i32, -2: i32], keep_dim = true}> : (tensor<1x32x512x64xbf16>, tensor<1x32xbf16>) -> tensor<1x32xbf16>
   return %1 : tensor<1x32xbf16>
 }
 
 func.func @sum_first_dim(%arg0: tensor<64x10xf32>) -> tensor<1x10xf32> {
   %0 = tensor.empty() : tensor<1x10xf32>
-  %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [-2 : i32], keep_dim = true}> : (tensor<64x10xf32>, tensor<1x10xf32>) -> tensor<1x10xf32>
+  %1 = "ttir.sum"(%arg0, %0) <{dim = [-2 : i32], keep_dim = true}> : (tensor<64x10xf32>, tensor<1x10xf32>) -> tensor<1x10xf32>
   return %1: tensor<1x10xf32>
 }
 
 func.func @mean(%arg0: tensor<1x1x512x64xbf16>) -> tensor<1x1x512xbf16> {
   %0 = tensor.empty() : tensor<1x1x512xbf16>
   // CHECK: %[[C:.*]] = "ttnn.mean"[[C:.*]]
-  %1 = "ttir.mean"(%arg0, %0) <{dim_arg = [-1: i32], keep_dim = true}> : (tensor<1x1x512x64xbf16>, tensor<1x1x512xbf16>) -> tensor<1x1x512xbf16>
+  %1 = "ttir.mean"(%arg0, %0) <{dim = [-1: i32], keep_dim = true}> : (tensor<1x1x512x64xbf16>, tensor<1x1x512xbf16>) -> tensor<1x1x512xbf16>
   return %1 : tensor<1x1x512xbf16>
 }
 
 func.func @mean_last_2_dims(%arg0: tensor<1x32x512x64xbf16>) -> tensor<1x32xbf16> {
   %0 = tensor.empty() : tensor<1x32xbf16>
   // CHECK: %[[C:.*]] = "ttnn.mean"[[C:.*]]
-  %1 = "ttir.mean"(%arg0, %0) <{dim_arg = [-1: i32, -2: i32], keep_dim = true}> : (tensor<1x32x512x64xbf16>, tensor<1x32xbf16>) -> tensor<1x32xbf16>
+  %1 = "ttir.mean"(%arg0, %0) <{dim = [-1: i32, -2: i32], keep_dim = true}> : (tensor<1x32x512x64xbf16>, tensor<1x32xbf16>) -> tensor<1x32xbf16>
   return %1 : tensor<1x32xbf16>
 }
 
 func.func @max(%arg0: tensor<1x1x512x64xbf16>) -> tensor<1x1x512xbf16> {
   %0 = tensor.empty() : tensor<1x1x512xbf16>
   // CHECK: %[[C:.*]] = "ttnn.max"[[C:.*]]
-  %1 = "ttir.max"(%arg0, %0) <{dim_arg = [-1: i32], keep_dim = true}> : (tensor<1x1x512x64xbf16>, tensor<1x1x512xbf16>) -> tensor<1x1x512xbf16>
+  %1 = "ttir.max"(%arg0, %0) <{dim = [-1: i32], keep_dim = true}> : (tensor<1x1x512x64xbf16>, tensor<1x1x512xbf16>) -> tensor<1x1x512xbf16>
   return %1 : tensor<1x1x512xbf16>
 }
 
 func.func @max_last_2_dims(%arg0: tensor<1x32x512x64xbf16>) -> tensor<1x32xbf16> {
   %0 = tensor.empty() : tensor<1x32xbf16>
   // CHECK: %[[C:.*]] = "ttnn.max"[[C:.*]]
-  %1 = "ttir.max"(%arg0, %0) <{dim_arg = [-1: i32, -2: i32], keep_dim = true}> : (tensor<1x32x512x64xbf16>, tensor<1x32xbf16>) -> tensor<1x32xbf16>
+  %1 = "ttir.max"(%arg0, %0) <{dim = [-1: i32, -2: i32], keep_dim = true}> : (tensor<1x32x512x64xbf16>, tensor<1x32xbf16>) -> tensor<1x32xbf16>
   return %1 : tensor<1x32xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/simple_sum.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_sum.mlir
@@ -13,7 +13,7 @@ module {
   func.func public @reduce_not_keep_dim(%arg0: tensor<128x10xf32>) -> tensor<128xf32> {
     %0 = tensor.empty() : tensor<128xf32>
     // CHECK: "ttnn.sum"
-    // CHECK-SAME: dim_arg = [1 : i32]
+    // CHECK-SAME: dim = [1 : i32]
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128x10xf32,
     // CHECK-SAME: -> tensor<128x1xf32,
@@ -21,19 +21,19 @@ module {
     // CHECK-SAME: shape = [128 : i32]
     // CHECK-SAME: tensor<128x1xf32,
     // CHECK-SAME: -> tensor<128xf32,
-    %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x10xf32>, tensor<128xf32>) -> tensor<128xf32>
+    %1 = "ttir.sum"(%arg0, %0) <{dim = [1 : i32], keep_dim = false}> : (tensor<128x10xf32>, tensor<128xf32>) -> tensor<128xf32>
     return %1 : tensor<128xf32>
   }
 
   func.func public @reduce_keep_dim(%arg0: tensor<128x10xf32>) -> tensor<128x1xf32> {
     %0 = tensor.empty() : tensor<128x1xf32>
     // CHECK: "ttnn.sum"
-    // CHECK-SAME: dim_arg = [1 : i32]
+    // CHECK-SAME: dim = [1 : i32]
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128x10xf32,
     // CHECK-SAME: -> tensor<128x1xf32,
     // CHECK-NOT: "ttnn.reshape"
-    %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<128x10xf32>, tensor<128x1xf32>) -> tensor<128x1xf32>
+    %1 = "ttir.sum"(%arg0, %0) <{dim = [1 : i32], keep_dim = true}> : (tensor<128x10xf32>, tensor<128x1xf32>) -> tensor<128x1xf32>
     return %1 : tensor<128x1xf32>
   }
 }


### PR DESCRIPTION
Currently all reduction ops when lowered from forge are failing. Reduction ops in `TTIR/TTNN` have optional `dim_arg` attribute which can be used to specify dimension along which reduce should be applied.
Forge uses `dim` attribute to specify reduction dims, so when lowered to `TTIR` is completly ignored by our compiler.
This PR fixes the naming of this attribute and also aligns possible values for this attribute from:
`OptionalAttr<I32ArrayAttr>` -> `OptionalAttr<AnyAttrOf<[SI32Attr, I32ArrayAttr]>>`

IR before change:
```
%2 = "ttir.mean"(%arg0, %1) <{dim_arg = [-2 : i32], keep_dim = true}> : (tensor<1x1x49x2048xf32>, tensor<1x1x1x2048xf32>) -> tensor<1x1x1x2048xf32>
```
IR after change:
```
%2 = "ttir.mean"(%arg0, %1) <{dim = [-2 : i32], keep_dim = true}> : (tensor<1x1x49x2048xf32>, tensor<1x1x1x2048xf32>) -> tensor<1x1x1x2048xf32>
%2 = "ttir.mean"(%arg0, %1) <{dim = -2 : si32, keep_dim = true}> : (tensor<1x1x49x2048xf32>, tensor<1x1x1x2048xf32>) -> tensor<1x1x1x2048xf32>
```

fixes #1574 