### PR TITLE
Uplift third_party/tt-metal to fe6a3da9cf5d064a61a4fc626502cf1544446eb9 2025-01-04

### DIFF
--- a/runtime/lib/ttnn/operations/data_movement/permute.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/permute.cpp
@@ -16,8 +16,8 @@ void run(const ::tt::target::ttnn::PermuteOp *op, ProgramContext &context) {
   const ::ttnn::Tensor &in = tensorPool.at(op->in()->global_id());
   DEBUG_ASSERT(in.is_allocated());
 
-  std::vector<int64_t> permutation(op->permutation()->begin(),
-                                   op->permutation()->end());
+  ::ttnn::SmallVector<int64_t> permutation(op->permutation()->begin(),
+                                           op->permutation()->end());
   std::optional<tt::tt_metal::MemoryConfig> memoryConfig =
       op->memory_config() ? std::make_optional(utils::createMemoryConfig(
                                 op->memory_config(), op->out()))

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "c066c3f3d2202c87258ed400307e7f6e26d372a7")
+set(TT_METAL_VERSION "fe6a3da9cf5d064a61a4fc626502cf1544446eb9")
 
 if ("$ENV{ARCH_NAME}" STREQUAL "grayskull")
   set(ARCH_NAME "grayskull")


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the fe6a3da9cf5d064a61a4fc626502cf1544446eb9

 - Update runtime code to to use ::ttnn::SmallVector<int64_t> for ::ttnn::permute()
    Fixes compile error "no known conversion from 'std::vector<long>' to 'const SmallVector<int64_t>'"