### PR TITLE
Uplift third_party/tt-metal to e6c029ed92adade7e1d42c4a5468df5a7af1a5b0 2025-01-07

### DIFF
--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -502,7 +502,7 @@ INSTANTIATE_TEST_SUITE_P(
             llvm::SmallVector<int64_t>{2048, 2048},
             mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
             mlir::tt::ttnn::BufferType::DRAM, llvm::SmallVector<int64_t>{8, 8},
-            llvm::SmallVector<int64_t>{8, 8}, true, 786432, 0, 0),
+            llvm::SmallVector<int64_t>{8, 8}, true, 753664, 0, 0),
         std::make_tuple(
             llvm::SmallVector<int64_t>{2048, 2048},
             mlir::tt::ttnn::TensorMemoryLayout::Interleaved,

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "cb02e398ca4021496be4b248834995e57aa98a24")
+set(TT_METAL_VERSION "7764bf559a3d6bd303e0a9fce8509a5a122c1681")
 
 if ("$ENV{ARCH_NAME}" STREQUAL "grayskull")
   set(ARCH_NAME "grayskull")

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "7764bf559a3d6bd303e0a9fce8509a5a122c1681")
+set(TT_METAL_VERSION "e6c029ed92adade7e1d42c4a5468df5a7af1a5b0")
 
 if ("$ENV{ARCH_NAME}" STREQUAL "grayskull")
   set(ARCH_NAME "grayskull")


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the e6c029ed92adade7e1d42c4a5468df5a7af1a5b0

 - Reduce MatmulInterleavedTests/OpModelMatmulParam.MatmulParam/0 expectedCbSize due to tt-metal 3787a8aa2f
 - this includes some tt-metal build time fixes