### PR TITLE
D2M Pass 1: Attach Metal Layout

### DIFF
--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -32,6 +32,13 @@ def TTIRAttachMetalLayout: Pass<"ttir-attach-metal-layout", "::mlir::ModuleOp"> 
   let description = [{
     Attach a TTMetal layout to operands of a TTIR op.
   }];
+
+  let options = [
+    Option<"initMemorySpace", "init-memory-space",
+          "::mlir::tt::MemorySpace",
+          /*default=*/"::mlir::tt::MemorySpace::System",
+           "Set the initial memory space for tensors to start in">
+  ];
 }
 
 def TTIRGenericRegion: Pass<"ttir-generic", "::mlir::ModuleOp"> {

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -27,6 +27,13 @@ def TTIRGenericKernel: Pass<"ttir-generic-kernel", "::mlir::ModuleOp"> {
   }];
 }
 
+def TTIRAttachMetalLayout: Pass<"ttir-attach-metal-layout", "::mlir::ModuleOp"> {
+  let summary = "";
+  let description = [{
+    Attach a TTMetal layout to operands of a TTIR op.
+  }];
+}
+
 def TTIRGenericRegion: Pass<"ttir-generic", "::mlir::ModuleOp"> {
   let summary = "";
   let description = [{

--- a/lib/Conversion/TTIRToTTMetal/AttachMetalLayout.cpp
+++ b/lib/Conversion/TTIRToTTMetal/AttachMetalLayout.cpp
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TT/IR/TT.h"
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/IR/PatternMatch.h>
+#include <mlir/Rewrite/FrozenRewritePatternSet.h>
+#include <mlir/Transforms/GreedyPatternRewriteDriver.h>
+
+namespace mlir::tt::ttir {
+#define GEN_PASS_DEF_TTIRATTACHMETALLAYOUT
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h.inc"
+
+class TTIRAttachMetalLayoutRewriter : public OpRewritePattern<func::FuncOp> {
+  using OpRewritePattern<func::FuncOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(func::FuncOp op,
+                                PatternRewriter &rewriter) const final {
+    if (mlir::isa<GenericOp>(op.getOperation()->getParentOp())) {
+      return failure();
+    } // might not be necessary
+
+    for (auto operand : op.getFunctionType().getInputs()) {
+      if (isa<RankedTensorType>(operand)) {
+        auto operandType = mlir::cast<RankedTensorType>(operand);
+        if (operandType.getEncoding()) {
+          return failure();
+        }
+      }
+    }
+
+    auto appendLayoutToType = [&](Type type) -> Type {
+      auto operandType = mlir::cast<RankedTensorType>(type);
+      auto layout = rewriter.getAttr<MetalLayoutAttr>(
+          operandType, MemorySpace::DeviceL1, GridAttr());
+      auto newTensorType = RankedTensorType::get(
+          operandType.getShape(), operandType.getElementType(), layout);
+      return newTensorType;
+    };
+
+    auto appendLayoutToValue = [&](Value operand) {
+      if (isa<RankedTensorType>(operand.getType())) {
+        auto operandType = mlir::cast<RankedTensorType>(operand.getType());
+        auto layout = rewriter.getAttr<MetalLayoutAttr>(
+            operandType, MemorySpace::DeviceL1, GridAttr());
+        operand.setType(RankedTensorType::get(
+            operandType.getShape(), operandType.getElementType(), layout));
+      }
+    };
+
+    op.walk([&](Operation *op) {
+      if (isa<func::FuncOp>(op)) {
+        auto funcOp = mlir::cast<func::FuncOp>(op);
+        std::vector inputs = std::vector<Type>();
+        std::vector results = std::vector<Type>();
+        for (auto operand : funcOp.getFunctionType().getInputs()) {
+          if (isa<RankedTensorType>(operand)) {
+            inputs.push_back(appendLayoutToType(operand));
+          }
+        }
+        for (auto result : funcOp.getFunctionType().getResults()) {
+          if (isa<RankedTensorType>(result)) {
+            results.push_back(appendLayoutToType(result));
+          }
+        }
+        mlir::FunctionType newFuncType =
+            FunctionType::get(funcOp.getContext(), inputs, results);
+        funcOp.setFunctionType(newFuncType);
+        return;
+      }
+      for (auto operand : op->getOperands()) {
+        appendLayoutToValue(operand);
+      }
+      for (auto result : op->getResults()) {
+        appendLayoutToValue(result);
+      }
+    });
+
+    return success();
+  }
+};
+
+class TTIRAttachMetalLayout
+    : public impl::TTIRAttachMetalLayoutBase<TTIRAttachMetalLayout> {
+
+  using impl::TTIRAttachMetalLayoutBase<
+      TTIRAttachMetalLayout>::TTIRAttachMetalLayoutBase;
+
+  void runOnOperation() final {
+    RewritePatternSet patterns(&getContext());
+    patterns.add<TTIRAttachMetalLayoutRewriter>(&getContext());
+    FrozenRewritePatternSet patternSet(std::move(patterns));
+    if (failed(applyPatternsAndFoldGreedily(getOperation(), patternSet))) {
+      signalPassFailure();
+    }
+  }
+
+  void getDependentDialects(mlir::DialectRegistry &registry) const override {
+    registry.insert<mlir::tt::ttir::TTIRDialect>();
+    registry.insert<mlir::tt::TTDialect>();
+  }
+};
+
+} // namespace mlir::tt::ttir

--- a/lib/Conversion/TTIRToTTMetal/CMakeLists.txt
+++ b/lib/Conversion/TTIRToTTMetal/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mlir_library(TTMLIRTTIRToTTMetal
   TTIRToTTMetal.cpp
   TTIRToTTMetalPass.cpp
+  AttachMetalLayout.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${PROJECT_SOURCE_DIR}/include/ttmlir/Conversion/TTIRToTTMetal

--- a/test/ttmlir/Dialect/TTMetal/simple_attach_metal_layout.mlir
+++ b/test/ttmlir/Dialect/TTMetal/simple_attach_metal_layout.mlir
@@ -1,0 +1,31 @@
+// RUN: ttmlir-opt --ttir-load-system-desc --ttir-implicit-device --ttir-attach-metal-layout %s | FileCheck %s
+// CHECK-LABEL: func.func @maximum(
+// CHECK-SAME: %arg0: tensor<64x128xf32, #layout>
+// CHECK-SAME: %arg1: tensor<64x128xf32, #layout>
+// CHECK-SAME: ) -> tensor<64x128xf32, #layout>
+func.func @maximum(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  // CHECK: %[[C0:.*]] = tensor.empty() : tensor<64x128xf32, #layout>
+  // CHECK: %[[C1:.*]] = "ttir.maximum"(%arg0, %arg1, %[[C0]]) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32, #layout>, tensor<64x128xf32, #layout>, tensor<64x128xf32, #layout>) -> tensor<64x128xf32, #layout>
+  %0 = tensor.empty() : tensor<64x128xf32>
+  %1 = "ttir.maximum"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  // CHECK: return %[[C1]] : tensor<64x128xf32, #layout>
+  return %1 : tensor<64x128xf32>
+}
+
+#l1_ = #tt.memory_space<l1>
+#layout1 = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <4x4>, memref<64x96xf32, #l1_>>
+#layout2 = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <4x1>, memref<64x32xf32, #l1_>>
+// CHECK-LABEL: func.func @reduceW(
+// CHECK-SAME: %arg0: tensor<256x384xf32, #layout1>
+// CHECK-SAME: ) -> tensor<256x32xf32, #layout2>
+func.func @reduceW(%arg0: tensor<256x384xf32, #layout1>) -> tensor<256x32xf32, #layout2> {
+  // CHECK: %[[C0:.*]] = tensor.empty() : tensor<256x32xf32, #layout2>
+  // CHECK: %[[C1:.*]] = "ttir.sum"(%arg0, %0) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<256x384xf32, #layout1>, tensor<256x32xf32, #layout2>) -> tensor<256x32xf32, #layout2>
+  %0 = tensor.empty() : tensor<256x32xf32, #layout2>
+  %1 = "ttir.sum"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
+                               dim_arg = [-1: i32],
+                               keep_dim = true}> :
+    (tensor<256x384xf32, #layout1>, tensor<256x32xf32, #layout2>) -> tensor<256x32xf32, #layout2>
+  // CHECK: return %[[C1]] : tensor<256x32xf32, #layout2>
+  return %1 : tensor<256x32xf32, #layout2>
+}

--- a/test/ttmlir/Dialect/TTMetal/simple_attach_metal_layout.mlir
+++ b/test/ttmlir/Dialect/TTMetal/simple_attach_metal_layout.mlir
@@ -1,14 +1,14 @@
 // RUN: ttmlir-opt --ttir-load-system-desc --ttir-implicit-device --ttir-attach-metal-layout %s | FileCheck %s
 // CHECK-LABEL: func.func @maximum(
-// CHECK-SAME: %arg0: tensor<64x128xf32, #layout>
-// CHECK-SAME: %arg1: tensor<64x128xf32, #layout>
+// CHECK-SAME: %arg0: tensor<64x128xf32, #[[LAYOUT:layout]]>
+// CHECK-SAME: %arg1: tensor<64x128xf32, #[[LAYOUT]]>
 // CHECK-SAME: ) -> tensor<64x128xf32, #layout>
 func.func @maximum(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  // CHECK: %[[C0:.*]] = tensor.empty() : tensor<64x128xf32, #layout>
-  // CHECK: %[[C1:.*]] = "ttir.maximum"(%arg0, %arg1, %[[C0]]) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32, #layout>, tensor<64x128xf32, #layout>, tensor<64x128xf32, #layout>) -> tensor<64x128xf32, #layout>
+  // CHECK: %[[C0:.*]] = tensor.empty() : tensor<64x128xf32, #[[LAYOUT]]>
+  // CHECK: %[[C1:.*]] = "ttir.maximum"(%arg0, %arg1, %[[C0]]) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32, #[[LAYOUT]]>, tensor<64x128xf32, #[[LAYOUT]]>, tensor<64x128xf32, #[[LAYOUT]]>) -> tensor<64x128xf32, #[[LAYOUT]]>
   %0 = tensor.empty() : tensor<64x128xf32>
   %1 = "ttir.maximum"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
-  // CHECK: return %[[C1]] : tensor<64x128xf32, #layout>
+  // CHECK: return %[[C1]] : tensor<64x128xf32, #[[LAYOUT]]>
   return %1 : tensor<64x128xf32>
 }
 
@@ -16,16 +16,16 @@ func.func @maximum(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tens
 #layout1 = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <4x4>, memref<64x96xf32, #l1_>>
 #layout2 = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <4x1>, memref<64x32xf32, #l1_>>
 // CHECK-LABEL: func.func @reduceW(
-// CHECK-SAME: %arg0: tensor<256x384xf32, #layout1>
-// CHECK-SAME: ) -> tensor<256x32xf32, #layout2>
+// CHECK-SAME: %arg0: tensor<256x384xf32, #[[LAYOUT1:layout1]]>
+// CHECK-SAME: ) -> tensor<256x32xf32, #[[LAYOUT2:layout2]]>
 func.func @reduceW(%arg0: tensor<256x384xf32, #layout1>) -> tensor<256x32xf32, #layout2> {
-  // CHECK: %[[C0:.*]] = tensor.empty() : tensor<256x32xf32, #layout2>
-  // CHECK: %[[C1:.*]] = "ttir.sum"(%arg0, %0) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<256x384xf32, #layout1>, tensor<256x32xf32, #layout2>) -> tensor<256x32xf32, #layout2>
+  // CHECK: %[[C0:.*]] = tensor.empty() : tensor<256x32xf32, #[[LAYOUT2]]>
+  // CHECK: %[[C1:.*]] = "ttir.sum"(%arg0, %0) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<256x384xf32, #[[LAYOUT1]]>, tensor<256x32xf32, #[[LAYOUT2]]>) -> tensor<256x32xf32, #[[LAYOUT2]]>
   %0 = tensor.empty() : tensor<256x32xf32, #layout2>
   %1 = "ttir.sum"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
                                dim_arg = [-1: i32],
                                keep_dim = true}> :
     (tensor<256x384xf32, #layout1>, tensor<256x32xf32, #layout2>) -> tensor<256x32xf32, #layout2>
-  // CHECK: return %[[C1]] : tensor<256x32xf32, #layout2>
+  // CHECK: return %[[C1]] : tensor<256x32xf32, #[[LAYOUT2]]>
   return %1 : tensor<256x32xf32, #layout2>
 }


### PR DESCRIPTION
Add an initial pass to attach canonical `tt.metal_layout` to all tensors in the graph.

i.e.

```mlir
func.func @maximum(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
  %0 = tensor.empty() : tensor<64x128xf32>
  %1 = "ttir.maximum"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
  return %1 : tensor<64x128xf32>
}
```

becomes

```mlir
#l1_ = #tt.memory_space<l1>
#layout = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<64x128xf32, #l1_>>
module {
  func.func @maximum(%arg0: tensor<64x128xf32, #layout>, %arg1: tensor<64x128xf32, #layout>) -> tensor<64x128xf32, #layout> {
    %0 = tensor.empty() : tensor<64x128xf32, #layout>
    %1 = "ttir.maximum"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32, #layout>, tensor<64x128xf32, #layout>, tensor<64x128xf32, #layout>) -> tensor<64x128xf32, #layout>
    return %1 : tensor<64x128xf32, #layout>
  }
}
```

The following remains the same because all tensors already have layout attributes:
```mlir
#l1_ = #tt.memory_space<l1>
#layout1 = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <4x4>, memref<64x96xf32, #l1_>>
#layout2 = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <4x1>, memref<64x32xf32, #l1_>>

func.func @reduceW(%arg0: tensor<256x384xf32, #layout1>) -> tensor<256x32xf32, #layout2> {
  %0 = tensor.empty() : tensor<256x32xf32, #layout2>
  %1 = "ttir.sum"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
                               dim_arg = [-1: i32],
                               keep_dim = true}> :
    (tensor<256x384xf32, #layout1>, tensor<256x32xf32, #layout2>) -> tensor<256x32xf32, #layout2>
  return %1 : tensor<256x32xf32, #layout2>
}

#layout3 = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <1x4>, memref<32x96xf32, #l1_>>
func.func @reduceH(%arg0: tensor<256x384xf32, #layout1>) -> tensor<32x384xf32, #layout3> {
  %0 = tensor.empty() : tensor<32x384xf32, #layout3>
  %1 = "ttir.sum"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
                               dim_arg = [-2: i32],
                               keep_dim = true}> :
    (tensor<256x384xf32, #layout1>, tensor<32x384xf32, #layout3>) -> tensor<32x384xf32, #layout3>
  return %1 : tensor<32x384xf32, #layout3>
}

#layout4 = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<32x32xf32, #l1_>>
func.func @reduceWH(%arg0: tensor<256x384xf32, #layout1>) -> tensor<32x32xf32, #layout4> {
  %0 = tensor.empty() : tensor<32x32xf32, #layout4>
  %1 = "ttir.sum"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
                               dim_arg = [-1: i32, -2: i32],
                               keep_dim = true}> :
    (tensor<256x384xf32, #layout1>, tensor<32x32xf32, #layout4>) -> tensor<32x32xf32, #layout4>
  return %1 : tensor<32x32xf32, #layout4>
}

func.func @maxReduceWH(%arg0: tensor<256x384xf32, #layout1>) -> tensor<32x32xf32, #layout4> {
  %0 = tensor.empty() : tensor<32x32xf32, #layout4>
  %1 = "ttir.max" (%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
                               dim_arg = [-1: i32, -2: i32],
                               keep_dim = true}> :
    (tensor<256x384xf32, #layout1>, tensor<32x32xf32, #layout4>) -> tensor<32x32xf32, #layout4>
  return %1 : tensor<32x32xf32, #layout4>
}
```
