### PR TITLE
Add support for stablehlo.reduce op for logical and operator

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -725,6 +725,28 @@ def TTIR_MinOp : TTIR_ReductionOp<"min"> {
   }];
 }
 
+def TTIR_ReduceAndOp : TTIR_ReductionOp<"reduce_and"> {
+    let summary = "And reduction op.";
+    let description = [{
+      Reduces a given tensor using logical and operator along the given dimension(s).
+
+      Example:
+        input: [[True,  False, True, False],
+                [True,  True,  True, True],
+                [False, False, True, True],
+                [False, True,  True, False]]
+
+        // Reduction along dim 0
+        output: [False, False, True, False]
+
+        // Reduction along dim 1
+        output: [False, True, False, False]
+
+        // Reduction for both dimensions (entire tensor)
+        output: [False]
+    }];
+}
+
 def TTIR_ProdOp : TTIR_ReductionOp<"prod"> {
   let summary = "Product reduction op.";
   let description = [{

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecompositionPass.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecompositionPass.cpp
@@ -53,6 +53,7 @@ struct TTIRToTTIRDecompositionPass
     target.addIllegalOp<ttir::GatherOp>();
     target.addIllegalOp<ttir::SelectOp>();
     target.addIllegalOp<ttir::DotGeneralOp>();
+    target.addIllegalOp<ttir::ReduceAndOp>();
 
     // These are the ops that must satisfy some conditions after this pass
     target.addDynamicallyLegalOp<ttir::ArangeOp>([&](ttir::ArangeOp op) {

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -2292,3 +2292,19 @@ void mlir::tt::ttir::ProdOp::buildGenericRegion(::mlir::OpBuilder &opBuilder,
 ::mlir::LogicalResult mlir::tt::ttir::ProdOp::verify() {
   return verifyReduceOp(getOperation(), getInput().getType(), getDimArg());
 }
+
+//===----------------------------------------------------------------------===//
+// ReduceAndOp
+//===----------------------------------------------------------------------===//
+
+// ReduceAndOp kernel builder.
+void mlir::tt::ttir::ReduceAndOp::buildGenericRegion(
+    ::mlir::OpBuilder &opBuilder, ::mlir::Block *block) {
+  // NOLINTNEXTLINE
+  createReduceOp(opBuilder, block, getLoc(), "and");
+}
+
+// ReduceAndOp verification.
+::mlir::LogicalResult mlir::tt::ttir::ReduceAndOp::verify() {
+  return verifyReduceOp(getOperation(), getInput().getType(), getDimArg());
+}

--- a/test/ttmlir/Conversion/StableHLOToTTIR/reduction/reduce_and_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/reduction/reduce_and_op.mlir
@@ -1,0 +1,39 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s | FileCheck %s
+module @jit_reduce_and attributes {} {
+  func.func public @test_reduce_and_4to3dim(%arg0: tensor<128x10x32x4xi1>, %cst_0: tensor<i1>) -> tensor<128x10x32xi1> {
+    // CHECK-LABEL: func.func public @test_reduce_and_4to3dim
+    // CHECK: tensor.empty
+    // CHECK: "ttir.reduce_and"
+    // CHECK-SAME: dim_arg = [3 : i32]
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x32x4xbf16>
+    // CHECK-SAME: -> tensor<128x10x32xbf16>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.and across dimensions = [3] : (tensor<128x10x32x4xi1>, tensor<i1>) -> tensor<128x10x32xi1>
+    return %0 : tensor<128x10x32xi1>
+  }
+
+  func.func public @test_reduce_and_3to2dim(%arg0: tensor<128x10x4xi1>, %cst_0: tensor<i1>) -> tensor<128x4xi1> {
+    // CHECK-LABEL: func.func public @test_reduce_and_3to2dim
+    // CHECK: tensor.empty
+    // CHECK: "ttir.reduce_and"
+    // CHECK-SAME: dim_arg = [1 : i32]
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x4xbf16>
+    // CHECK-SAME: -> tensor<128x4xbf16>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.and across dimensions = [1] : (tensor<128x10x4xi1>, tensor<i1>) -> tensor<128x4xi1>
+    return %0 : tensor<128x4xi1>
+  }
+
+  func.func public @test_reduce_and_2to1dim(%arg0: tensor<128x10xi1>, %cst_0: tensor<i1>) -> tensor<10xi1> {
+    // CHECK-LABEL: func.func public @test_reduce_and_2to1dim
+    // CHECK: tensor.empty
+    // CHECK: "ttir.reduce_and"
+    // CHECK-SAME: dim_arg = [0 : i32]
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10xbf16>
+    // CHECK-SAME: -> tensor<10xbf16>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.and across dimensions = [0] : (tensor<128x10xi1>, tensor<i1>) -> tensor<10xi1>
+    return %0 : tensor<10xi1>
+  }
+}

--- a/test/ttmlir/Decomposition/TTIR/reduction/reduce_and.mlir
+++ b/test/ttmlir/Decomposition/TTIR/reduction/reduce_and.mlir
@@ -1,0 +1,41 @@
+// RUN: ttmlir-opt --ttir-to-ttir-decomposition %s | FileCheck %s
+module attributes {} {
+  func.func public @test_reduce_and_4to3dim(%arg0: tensor<128x10x32x4xbf16>, %arg1: tensor<1xbf16>) -> tensor<128x10x32xbf16> {
+    // CHECK-LABEL: func.func public @test_reduce_and_4to3dim
+    // CHECK: %[[PROD:[0-9]+]] = "ttir.prod"
+    // CHECK-SAME: dim_arg = [3 : i32]
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x32x4xbf16>
+    // CHECK-SAME: -> [[TENSOR:tensor<128x10x32xbf16>]]
+    // CHECK: return %[[PROD]]
+    %0 = tensor.empty() : tensor<128x10x32xbf16>
+    %1 = "ttir.reduce_and"(%arg0, %0) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<128x10x32x4xbf16>, tensor<128x10x32xbf16>) -> tensor<128x10x32xbf16>
+    return %1 : tensor<128x10x32xbf16>
+  }
+
+  func.func public @test_reduce_and_3to2dim(%arg0: tensor<128x10x4xbf16>, %arg1: tensor<1xbf16>) -> tensor<128x4xbf16> {
+    // CHECK-LABEL: func.func public @test_reduce_and_3to2dim
+    // CHECK: %[[PROD:[0-9]+]] = "ttir.prod"
+    // CHECK-SAME: dim_arg = [1 : i32]
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x4xbf16>
+    // CHECK-SAME: -> [[TENSOR:tensor<128x4xbf16>]]
+    // CHECK: return %[[PROD]]
+    %0 = tensor.empty() : tensor<128x4xbf16>
+    %1 = "ttir.reduce_and"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x10x4xbf16>, tensor<128x4xbf16>) -> tensor<128x4xbf16>
+    return %1 : tensor<128x4xbf16>
+  }
+
+  func.func public @test_reduce_and_2to1dim(%arg0: tensor<128x10xbf16>, %arg1: tensor<1xbf16>) -> tensor<10xbf16> {
+    // CHECK-LABEL: func.func public @test_reduce_and_2to1dim
+    // CHECK: %[[PROD:[0-9]+]] = "ttir.prod"
+    // CHECK-SAME: dim_arg = [0 : i32]
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10xbf16>
+    // CHECK-SAME: -> [[TENSOR:tensor<10xbf16>]]
+    // CHECK: return %[[PROD]]
+    %0 = tensor.empty() : tensor<10xbf16>
+    %1 = "ttir.reduce_and"(%arg0, %0) <{dim_arg = [0 : i32], keep_dim = false}> : (tensor<128x10xbf16>, tensor<10xbf16>) -> tensor<10xbf16>
+    return %1 : tensor<10xbf16>
+  }
+}

--- a/test/ttmlir/Decomposition/TTIR/reduction/reduce_and.mlir
+++ b/test/ttmlir/Decomposition/TTIR/reduction/reduce_and.mlir
@@ -6,7 +6,7 @@ module attributes {} {
     // CHECK-SAME: dim_arg = [3 : i32]
     // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10x32x4xbf16>
-    // CHECK-SAME: -> [[TENSOR:tensor<128x10x32xbf16>]]
+    // CHECK-SAME: -> tensor<128x10x32xbf16>
     // CHECK: return %[[PROD]]
     %0 = tensor.empty() : tensor<128x10x32xbf16>
     %1 = "ttir.reduce_and"(%arg0, %0) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<128x10x32x4xbf16>, tensor<128x10x32xbf16>) -> tensor<128x10x32xbf16>
@@ -19,7 +19,7 @@ module attributes {} {
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10x4xbf16>
-    // CHECK-SAME: -> [[TENSOR:tensor<128x4xbf16>]]
+    // CHECK-SAME: -> tensor<128x4xbf16>
     // CHECK: return %[[PROD]]
     %0 = tensor.empty() : tensor<128x4xbf16>
     %1 = "ttir.reduce_and"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x10x4xbf16>, tensor<128x4xbf16>) -> tensor<128x4xbf16>
@@ -32,7 +32,7 @@ module attributes {} {
     // CHECK-SAME: dim_arg = [0 : i32]
     // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10xbf16>
-    // CHECK-SAME: -> [[TENSOR:tensor<10xbf16>]]
+    // CHECK-SAME: -> tensor<10xbf16>
     // CHECK: return %[[PROD]]
     %0 = tensor.empty() : tensor<10xbf16>
     %1 = "ttir.reduce_and"(%arg0, %0) <{dim_arg = [0 : i32], keep_dim = false}> : (tensor<128x10xbf16>, tensor<10xbf16>) -> tensor<10xbf16>

--- a/test/ttmlir/Silicon/StableHLO/reduction/reduce_and_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/reduction/reduce_and_op.mlir
@@ -1,0 +1,20 @@
+// REQUIRES: stablehlo
+// RUN: rm -rf %t.ttnn
+// RUN: rm -rf %t.mlir
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline \
+// RUN:     --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+// RUN: FileCheck --input-file=%t.mlir %s
+
+module @jit_reduce_add attributes {} {
+  func.func public @test_reduce_and_4to3dim(%arg0: tensor<128x10x32x4xi1>, %cst_0: tensor<i1>) -> tensor<128x10x32xi1> {
+    // CHECK-LABEL: func.func public @test_reduce_and_4to3dim
+    // CHECK: %[[SUM:[0-9]+]] = "ttnn.prod"
+    // CHECK-SAME: dim_arg = 3
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: -> tensor<128x10x32xbf16,
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.and across dimensions = [3] : (tensor<128x10x32x4xi1>, tensor<i1>) -> tensor<128x10x32xi1>
+    return %0 : tensor<128x10x32xi1>
+  }
+
+}

--- a/test/ttmlir/Silicon/StableHLO/reduction/reduce_and_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/reduction/reduce_and_op.mlir
@@ -9,12 +9,11 @@
 module @jit_reduce_add attributes {} {
   func.func public @test_reduce_and_4to3dim(%arg0: tensor<128x10x32x4xi1>, %cst_0: tensor<i1>) -> tensor<128x10x32xi1> {
     // CHECK-LABEL: func.func public @test_reduce_and_4to3dim
-    // CHECK: %[[SUM:[0-9]+]] = "ttnn.prod"
+    // CHECK: "ttnn.prod"
     // CHECK-SAME: dim_arg = 3
     // CHECK-SAME: keep_dim = false
     // CHECK-SAME: -> tensor<128x10x32xbf16,
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.and across dimensions = [3] : (tensor<128x10x32x4xi1>, tensor<i1>) -> tensor<128x10x32xi1>
     return %0 : tensor<128x10x32xi1>
   }
-
 }


### PR DESCRIPTION
TTNN does not support reduction for logical and operator. So stablehlo.reduce
for stablehlo.and operator is decomposed into reduction sum op along give
dimension and then compared with the size of given dimension.