### PR TITLE
Adding matmul workaround and adding workaorund docs

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -25,6 +25,7 @@
 - [Coding Guidelines](./coding-guidelines.md)
 - [Adding an op](./adding-an-op.md)
 - [Decomposing an op in TTIR](./decomposing-an-op-in-ttir.md)
+- [TTNN Workarounds](./ttnn-workarounds.md)
 - [Doxygen](./doxygen.md)
 - [Specifications](./specs/specs.md)
   - [Runtime Stitching](./specs/runtime-stitching.md)

--- a/docs/src/ttnn-workarounds.md
+++ b/docs/src/ttnn-workarounds.md
@@ -1,0 +1,159 @@
+# TTNN Workarounds
+
+The current state of TTNN ops isn’t ideal for a generic compiler development. For example, element-wise operations and the matmul operation only work with tensors in the tile layout. As a result, we’ve added assumptions throughout the compiler and runtime to handle this. Tracking all these assumptions throughout the code has become difficult. Therefore, we developed a workaround framework for the TTNN dialect to systematically centralize all the necessary workarounds.
+
+The workaround framework is implemented as a TTNN pass within the TTNN backend pipeline. This pass is executed after lowering the TTIR dialect to the TTNN dialect, ensuring that all necessary workarounds are systematically applied.
+
+```c++
+void createTTIRToTTNNBackendPipeline(
+    OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options) {
+  createTTNNPipelineTTIRPasses(pm, options);
+  createTTNNPipelineTTIRBroadcastFoldPass(pm, options);
+  createTTNNPipelineLoweringPasses(pm, options);
+  createTTNNPipelineWorkaroundPass(pm, options); // Workaround pass
+  createTTNNPipelineAnalysisPasses(pm, options);
+  createTTNNPipelineLayoutDecompositionPass(pm, options);
+  createTTNNPipelineDeallocPass(pm, options);
+}
+```
+
+Workaround pass consists of two main sub-passes:
+1. Decomposition workaround pass
+2. Layout workaround pass
+
+## Decomposition workaround pass
+Some TTNN operations have limitations that can be addressed by decomposing them into a set of other TTNN operations known to function correctly. To manage these workarounds, we introduced a decomposition sub-pass within the workaround pass.
+
+### How to add new decomposition workaround
+The decompositions are implemented by extending the `OpRewritePattern` and overriding the matchAndRewrite function of the inherited class.
+```C++
+class ReduceOpsKeepDimRewritePattern : public OpRewritePattern<ReduceOp> {
+//...
+  LogicalResult matchAndRewrite(ReduceOp srcOp,
+                                PatternRewriter &rewriter) const override {
+  // Decomposition logic...
+  }
+}
+```
+
+1. Define a decomposition workaround pattern in [/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition](/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition) folder.
+2. Register your decomposition rewrite pattern in decomposition sub-pass in [/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkarounds.cpp](/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkarounds.cpp):
+```C++
+    if (decompositionWorkaroundsEnabled) {
+      // Workaround decompositions
+      RewritePatternSet patterns(&getContext());
+      patterns.add<TTNNAllReduceWorkarounds,
+                   workarounds::decomposition::ReduceOpsKeepDimRewritePattern<
+                       ttnn::SumOp>,
+                   workarounds::decomposition::ReduceOpsKeepDimRewritePattern<
+                       ttnn::MaxOp>,
+                   workarounds::decomposition::ReduceOpsKeepDimRewritePattern<
+                       ttnn::MeanOp>,
+                   workarounds::decomposition::ReduceOpsAllDimsRewritePattern<
+                       ttnn::SumOp>,
+                   workarounds::decomposition::ReduceOpsAllDimsRewritePattern<
+                       ttnn::MaxOp>,
+                   workarounds::decomposition::ReduceOpsAllDimsRewritePattern<
+                       ttnn::MeanOp>>(&getContext());
+
+      runRewritePatterns(std::move(patterns),
+                         GreedyRewriteConfig::kNoLimit /*maxIterations*/);
+    }
+```
+
+## Layout workaround pass
+As mentioned earlier, some TTNN operations do not support all tensor configurations. For instance, the matmul operation only supports inputs in a tile layout, while the maxpool operation only supports inputs in the bf16 data format. The layout workaround pass addresses these limitations by inserting `ttnn::to_layout` operations to adjust the inputs and outputs of the affected operations. This approach ensures that the workaround is localized to the specific operation requiring it.
+
+The graphical representation of applying layout workarounds is presented here. Imagine that this op only supports row major input and produces a single row-major output:
+
+```C++
+            |                                           |
+            | (input tile layout)                       | (input tile layout)
+    -----------------                           -----------------
+    |      Op X     |                           |   to_layout   |
+    |               |                  =>       |               |
+    -----------------                           -----------------
+            | (output tile layout)                      | (output row-major layout)
+            |                                           |
+                                                -----------------
+                                                |      Op X     |
+                                                |               |
+                                                -----------------
+                                                        | (output row-major layout)
+                                                        |
+                                                -----------------
+                                                |   to_layout   |
+                                                |               |
+                                                -----------------
+                                                        | (output tile layout)
+                                                        |
+```
+
+For now, following part of the layout are supported for workaround:
+- Tensor Layout workaround: **Tile**, **RowMajor**
+- Tensor Buffer Type workaround: **SystemMemory**, **DRAM**, **L1**
+- Tensor Memory Layout workaround: **Interleaved**, **SingleBank**, **HeightSharded**, **WidthSharded**, **BlockSharded**
+- Tensor Data Type workaround: **Float32**, **Float16**, **BFloat16**, **BFP_Float8**, **BFP_BFloat8**, **BFP_Float4**, **BFP_BFloat4**, **BFP_Float2**, **BFP_BFloat2**, **UInt32**, **UInt16**, **UInt8**
+
+### How to add new layout workaround
+
+Layout workarounds are implemented with the following MLIR op interface defined for each TTNN op:
+```C++
+TTNNOperandsWorkarounds mlir::tt::ttnn::wa::TTNNWorkaroundInterface::getOperandsWorkarounds() {}
+```
+
+By default each op has an empty list of workarounds, but in case of need we can easily override the default implementation.
+1. Create a factory method for your op workaround in [/include/ttmlir/Dialect/TTNN/IR/TTNNWorkarounds.h](/include/ttmlir/Dialect/TTNN/IR/TTNNWorkarounds.h). The purpose of this is to locate all the op layout workarounds in one central place:
+```C++
+// Workaround factory class that creates workarounds for ops.
+class TTNNOperandsWorkaroundsFactory {
+public:
+/// ...
+  // Create workarounds for matmul op operands.
+  static TTNNOperandsWorkarounds createMatmulOpOperandsWorkarounds();
+/// ...
+}
+```
+2. Implement the factory method in [/lib/Dialect/TTNN/IR/TTNNWorkarounds.cpp](/lib/Dialect/TTNN/IR/TTNNWorkarounds.cpp). Ensure to create issues for the workarounds on the tt-metal side and link them in the comments for tracking purposes. This will help in removing the workarounds when they are no longer needed.
+```C++
+// ...
+// Factory method to create a set of workarounds for matmul operation operands.
+// The matmul operation expects the input to be in tile layout and it produce
+// output in tile layout.
+//
+// Metal issue for input and output operand workaround:
+// TBD
+TTNNOperandsWorkarounds
+TTNNOperandsWorkaroundsFactory::createMatmulOpOperandsWorkarounds() {
+  TTNNOperandWorkarounds tileLayoutWorkaround = TTNNOperandWorkarounds(Layout::Tile);
+  return TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds(0, 0)
+      .addInputOperandWorkaround(tileLayoutWorkaround)      // Input A workaround
+      .addInputOperandWorkaround(tileLayoutWorkaround)      // Input B workaround
+      .addInputOperandWorkaround(tileLayoutWorkaround)      // DPS output workaround
+      .addOutputOperandWorkaround(tileLayoutWorkaround);    // Output workaround
+}
+// ...
+```
+  <span style="color:gray">**Note 1**</span>: Workarounds must be applied to each operand in the operation. The order of the workarounds should match the order of operands as defined in the MLIR TableGen file for the operation. For example, in the TableGen file for the matmul operation, the inputs are defined as input $a, input $b, and DPS $output.
+  <br/><span style="color:gray">**Note 2**</span>: If an operand does not require a workaround, an empty workaround must be provided in the corresponding position according to the defined order of inputs/outputs.
+  <br/><span style="color:gray">**Note 3**</span>: DPS input and output workarounds must match, and this is enforced by the interface verifier.
+
+3. Override MLIR interface method in a [TTNN op table definition file](/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td) by calling the above factory method:
+```td
+def TTNN_MatmulOp : TTNN_NamedDPSOp<"matmul"> {
+    // ...
+
+    let extraClassDeclaration = [{
+      // ...
+      wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
+        return wa::TTNNOperandsWorkaroundsFactory::createMatmulOpOperandsWorkarounds();
+      }
+      // ...
+    }];
+
+    // ...
+}
+```
+  <span style="color:gray">**Note 1**</span> About extraClassDeclaration section, in TableGen, when you inherit from a parent definition, fields are overridden, not extended. If you redefine a field or a list in a child definition, it completely replaces the parent’s value, so don't forget to copy\paste all other defined functions from a parent.
+
+4. Add a test under the [/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/](/test/ttmlir/Dialect/TTNN/Transforms/Workarounds) to verify your workaround.

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -798,6 +798,9 @@ def TTNN_MatmulOp : TTNN_NamedDPSOp<"matmul"> {
 
     let extraClassDeclaration = [{
       MutableOperandRange getDpsInitsMutable() { return getOutputMutable(); }
+      wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
+        return wa::TTNNOperandsWorkaroundsFactory::createMatmulOpOperandsWorkarounds();
+      }
     }];
 
     let hasVerifier = 1;

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkarounds.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkarounds.h
@@ -218,6 +218,9 @@ public:
 
   // Create workarounds for embedding op operands.
   static TTNNOperandsWorkarounds createEmbeddingOpOperandsWorkarounds();
+
+  // Create workarounds for matmul op operands.
+  static TTNNOperandsWorkarounds createMatmulOpOperandsWorkarounds();
 };
 
 } // namespace mlir::tt::ttnn::wa

--- a/lib/Dialect/TTNN/IR/TTNNWorkarounds.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkarounds.cpp
@@ -105,7 +105,7 @@ TTNNOperandsWorkaroundsFactory::createMaxPool2DOpOperandsWorkarounds() {
 // Metal issue for input operand workaround:
 // https://github.com/tenstorrent/tt-metal/issues/14915
 //
-// Metal issue weight operand workaround:
+// Metal issue for weight operand workaround:
 // TBD
 TTNNOperandsWorkarounds
 TTNNOperandsWorkaroundsFactory::createEmbeddingOpOperandsWorkarounds() {
@@ -120,5 +120,22 @@ TTNNOperandsWorkaroundsFactory::createEmbeddingOpOperandsWorkarounds() {
       .addInputOperandWorkaround(weightWorkaround)
       .addInputOperandWorkaround(weightWorkaround)
       .addOutputOperandWorkaround(weightWorkaround);
+}
+
+// Factory method to create a set of workarounds for matmul operation operands.
+// The matmul operation expects the input to be in tile layout and it produce
+// output in tile layout.
+//
+// Metal issue for input and output operand workaround:
+// TBD
+TTNNOperandsWorkarounds
+TTNNOperandsWorkaroundsFactory::createMatmulOpOperandsWorkarounds() {
+  TTNNOperandWorkarounds tileLayoutWorkaround =
+      TTNNOperandWorkarounds(Layout::Tile);
+  return TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds(0, 0)
+      .addInputOperandWorkaround(tileLayoutWorkaround)
+      .addInputOperandWorkaround(tileLayoutWorkaround)
+      .addInputOperandWorkaround(tileLayoutWorkaround)
+      .addOutputOperandWorkaround(tileLayoutWorkaround);
 }
 } // namespace mlir::tt::ttnn::wa

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkarounds.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkarounds.cpp
@@ -417,6 +417,7 @@ public:
 
   void runOnOperation() final {
     if (decompositionWorkaroundsEnabled) {
+      // Workaround decompositions
       RewritePatternSet patterns(&getContext());
       patterns.add<TTNNAllReduceWorkarounds,
                    workarounds::decomposition::ReduceOpsKeepDimRewritePattern<
@@ -436,6 +437,7 @@ public:
                          GreedyRewriteConfig::kNoLimit /*maxIterations*/);
     }
     if (layouotWorkaroundsEnabled) {
+      // Layout workarounds
       RewritePatternSet patterns(&getContext());
       patterns.add<TTNNOperandsWorkaroundsRewriter>(&getContext());
 

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/matmul_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/matmul_workaround.mlir
@@ -1,0 +1,44 @@
+// RUN: ttmlir-opt --ttnn-workaround --canonicalize %s | FileCheck %s
+#device = #tt.device<workerGrid = #tt.grid<7x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, d0 floordiv s0, d1 floordiv s1, (d0 mod s0) * s1 + d1 mod s1), dramMap = (d0, d1)[s0, s1] -> (0, 0, ((((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 8192) mod 12, (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 98304 + (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) mod 8192), meshShape = , chipIds = [0]>
+#dram = #ttnn.buffer_type<dram>
+#system_desc = #tt.system_desc<[{role = host, target_triple = "x86_64-pc-linux"}], [{arch = <wormhole_b0>, grid = 7x8, l1_size = 1499136, num_dram_channels = 12, dram_channel_size = 1073741824, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32, l1_unreserved_base = 99104, erisc_l1_unreserved_base = 102400, dram_unreserved_base = 32, dram_unreserved_end = 1073196736, physical_cores = {worker = [ 18x18,  18x19,  18x20,  18x21,  18x22,  18x23,  18x24,  18x25,  19x18,  19x19,  19x20,  19x21,  19x22,  19x23,  19x24,  19x25,  20x18,  20x19,  20x20,  20x21,  20x22,  20x23,  20x24,  20x25,  21x18,  21x19,  21x20,  21x21,  21x22,  21x23,  21x24,  21x25,  22x18,  22x19,  22x20,  22x21,  22x22,  22x23,  22x24,  22x25,  23x18,  23x19,  23x20,  23x21,  23x22,  23x23,  23x24,  23x25,  24x18,  24x19,  24x20,  24x21,  24x22,  24x23,  24x24,  24x25] dram = [ 0x0,  0x1,  0x2,  0x3,  0x4,  0x5,  0x6,  0x7,  0x8,  0x9,  0x10,  0x11] eth = [ 17x25] eth_inactive = [ 16x18,  16x19,  16x20,  16x21,  16x22,  16x23,  16x24,  16x25,  17x19,  17x20,  17x22,  17x23,  17x24]}, supported_data_types = [<f32>, <f16>, <bf16>, <bfp_f8>, <bfp_bf8>, <bfp_f4>, <bfp_bf4>, <bfp_f2>, <bfp_bf2>, <u32>, <u16>, <u8>], supported_tile_sizes = [ 4x16,  16x16,  32x16,  4x32,  16x32,  32x32], num_cbs = 32}, {arch = <wormhole_b0>, grid = 7x8, l1_size = 1499136, num_dram_channels = 12, dram_channel_size = 1073741824, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32, l1_unreserved_base = 99104, erisc_l1_unreserved_base = 102400, dram_unreserved_base = 32, dram_unreserved_end = 1073196736, physical_cores = {worker = [ 18x18,  18x19,  18x20,  18x21,  18x22,  18x23,  18x24,  18x25,  19x18,  19x19,  19x20,  19x21,  19x22,  19x23,  19x24,  19x25,  20x18,  20x19,  20x20,  20x21,  20x22,  20x23,  20x24,  20x25,  21x18,  21x19,  21x20,  21x21,  21x22,  21x23,  21x24,  21x25,  22x18,  22x19,  22x20,  22x21,  22x22,  22x23,  22x24,  22x25,  23x18,  23x19,  23x20,  23x21,  23x22,  23x23,  23x24,  23x25,  24x18,  24x19,  24x20,  24x21,  24x22,  24x23,  24x24,  24x25] dram = [ 0x0,  0x1,  0x2,  0x3,  0x4,  0x5,  0x6,  0x7,  0x8,  0x9,  0x10,  0x11] eth = [ 16x25] eth_inactive = [ 16x19,  16x20,  16x21,  16x22,  16x23,  16x24,  17x18,  17x19,  17x20,  17x21,  17x22,  17x23,  17x24,  17x25]}, supported_data_types = [<f32>, <f16>, <bf16>, <bfp_f8>, <bfp_bf8>, <bfp_f4>, <bfp_bf4>, <bfp_f2>, <bfp_bf2>, <u32>, <u16>, <u8>], supported_tile_sizes = [ 4x16,  16x16,  32x16,  4x32,  16x32,  32x32], num_cbs = 32}], [0, 1], [3 : i32, 0 : i32], [ 0x0x0x0], [<[0, 8, 0], [1, 0, 0]>]>
+#system_memory = #ttnn.buffer_type<system_memory>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<64x128xbf16, #system_memory>>
+#ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<128x96xbf16, #system_memory>>
+#ttnn_layout2 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<64x96xbf16, #system_memory>>
+#ttnn_layout3 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<64x96xbf16, #dram>, <interleaved>>
+module attributes {tt.device = #device, tt.system_desc = #system_desc} {
+  func.func @forward(%arg0: tensor<64x128xbf16, #ttnn_layout>, %arg1: tensor<128x96xbf16, #ttnn_layout1>) -> tensor<64x96xbf16, #ttnn_layout2> {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
+    // CHECK: %[[DEVICE_OP:.*]] = "ttnn.get_device"
+    %1 = "ttnn.empty"(%0) <{dtype = #tt.supportedDataTypes<bf16>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <<2x3>>, <interleaved>>, shape = #ttnn.shape<64x96>}> : (!tt.device<#device>) -> tensor<64x96xbf16, #ttnn_layout3>
+    // CHECK: %[[EMPTY_OP:.*]] = "ttnn.empty"(%[[DEVICE_OP]])
+    // Check that the input operands are transformed into the tile layout.
+    // CHECK-NEXT: %[[TO_LAYOUT_INPUT_A:.*]] = "ttnn.to_layout"
+    // CHECK-SAME: dtype = #tt.supportedDataTypes<bf16>
+    // CHECK-SAME: layout = #ttnn.layout<tile>
+    // CHECK-SAME: memory_config = #ttnn.memory_config<#system_memory, <<2x4>>>
+    // CHECK-SAME: -> tensor<64x128xbf16
+    // CHECK-NEXT: %[[TO_LAYOUT_INPUT_B:.*]] = "ttnn.to_layout"
+    // CHECK-SAME: dtype = #tt.supportedDataTypes<bf16>
+    // CHECK-SAME: layout = #ttnn.layout<tile>
+    // CHECK-SAME: memory_config = #ttnn.memory_config<#system_memory, <<4x3>>>
+    // CHECK-SAME: -> tensor<128x96xbf16
+    // Check that the output operand is transformed into the tile layout.
+    // CHECK-NEXT: %[[TO_LAYOUT_OUTPUT_DPS:.*]] = "ttnn.to_layout"(%[[EMPTY_OP]], %[[DEVICE_OP]])
+    // CHECK-SAME: dtype = #tt.supportedDataTypes<bf16>
+    // CHECK-SAME: layout = #ttnn.layout<tile>
+    // CHECK-SAME: memory_config = #ttnn.memory_config<#dram, <<2x3>>, <interleaved>>
+    // CHECK-SAME: -> tensor<64x96xbf16
+    %2 = "ttnn.matmul"(%arg0, %arg1, %1) : (tensor<64x128xbf16, #ttnn_layout>, tensor<128x96xbf16, #ttnn_layout1>, tensor<64x96xbf16, #ttnn_layout3>) -> tensor<64x96xbf16, #ttnn_layout3>
+    // CHECK-NEXT: %[[MATMUL_OP:.*]] = "ttnn.matmul"(%[[TO_LAYOUT_INPUT_A]], %[[TO_LAYOUT_INPUT_B]], %[[TO_LAYOUT_OUTPUT_DPS]])
+    %3 = "ttnn.to_layout"(%2) <{dtype = #tt.supportedDataTypes<bf16>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory, <<64x96>>>}> : (tensor<64x96xbf16, #ttnn_layout3>) -> tensor<64x96xbf16, #ttnn_layout2>
+    // Check that the output operand is transformed back into the row_major layout.
+    // CHECK-NEXT: %[[TO_LAYOUT_OUTPUT:.*]] = "ttnn.to_layout"(%[[MATMUL_OP]])
+    // CHECK-SAME: dtype = #tt.supportedDataTypes<bf16>
+    // CHECK-SAME: layout = #ttnn.layout<row_major>
+    // CHECK-SAME: memory_config = #ttnn.memory_config<#system_memory, <<64x96>>>
+    // CHECK-SAME: -> tensor<64x96xbf16
+    return %3 : tensor<64x96xbf16, #ttnn_layout2>
+  }
+}


### PR DESCRIPTION
Matmul operation requires both inputs to be in the TILE layout and it produces an output in the TILE layout. This PR introduces a workaround for matmul operation.

Additionally, this PR includes documentation regarding the workaround framework and outlines the steps necessary to add a new workaround.

Closes #829