### PR TITLE
Uplift third_party/tt-metal to a6ec1c0a02c3b9dc55e769618639e0439ef9c06b 2025-01-13

### DIFF
--- a/lib/OpModel/TTNN/Conversion.cpp
+++ b/lib/OpModel/TTNN/Conversion.cpp
@@ -88,7 +88,7 @@ getShardSpec(const mlir::tt::ttnn::TTNNLayoutAttr &layout) {
   return isShardedMemoryLayout(layout.getMemLayout().getValue())
              ? std::make_optional(ShardSpec(getCoreRangeSet(layout),
                                             getShardShape(layout),
-                                            ShardOrientation::ROW_MAJOR, false))
+                                            ShardOrientation::ROW_MAJOR))
              : std::nullopt;
 }
 

--- a/runtime/lib/ttnn/include/tt/runtime/ttnn/utils.cpp
+++ b/runtime/lib/ttnn/include/tt/runtime/ttnn/utils.cpp
@@ -200,7 +200,7 @@ createMemoryConfig(const ::tt::target::TensorRef *tensorRef) {
 
   ::tt::tt_metal::ShardSpec shardSpec(
       ttnnCoreRangeSet, ttnnShardShape,
-      ::tt::tt_metal::ShardOrientation::ROW_MAJOR, false);
+      ::tt::tt_metal::ShardOrientation::ROW_MAJOR);
 
   std::optional<::tt::tt_metal::ShardSpec> shardSpecOpt =
       ttnnMemLayout == tt_metal::TensorMemoryLayout::INTERLEAVED

--- a/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/utils.cpp
+++ b/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/utils.cpp
@@ -67,7 +67,7 @@ createMemoryConfig(const ::tt::target::MemoryConfigDesc *memcfg,
 
   ::tt::tt_metal::ShardSpec shardSpec(
       ttnnCoreRangeSet, ttnnShardShape,
-      ::tt::tt_metal::ShardOrientation::ROW_MAJOR, false);
+      ::tt::tt_metal::ShardOrientation::ROW_MAJOR);
 
   ::ttnn::MemoryConfig memoryConfig = {
       tensorMemoryLayout, bufferType,

--- a/test/unittests/OpModel/TTNN/Conversion/TestConversion.cpp
+++ b/test/unittests/OpModel/TTNN/Conversion/TestConversion.cpp
@@ -294,7 +294,6 @@ TEST_P(ShardSpecFixture, ShardSpec) {
   // Purpose of testing them is to update the test
   // if the compiler side changes.
   EXPECT_EQ(shardSpec->orientation, ShardOrientation::ROW_MAJOR);
-  EXPECT_EQ(shardSpec->halo, false);
   EXPECT_EQ(shardSpec->mode, ShardMode::PHYSICAL);
   EXPECT_EQ(shardSpec->physical_shard_shape.has_value(), false);
 }

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "9c5a0b2e0a0edba747613d2afb3e56dacb5776ac")
+set(TT_METAL_VERSION "a6ec1c0a02c3b9dc55e769618639e0439ef9c06b")
 
 if ("$ENV{ARCH_NAME}" STREQUAL "grayskull")
   set(ARCH_NAME "grayskull")


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the a6ec1c0a02c3b9dc55e769618639e0439ef9c06b
 - This brings 1D tensor fix for forge fails blocking uplifts recently, and increased matmul precision fixes in some caes
 - Remove halo=false on ShardSpec, was removed in tt-metal at df59448e
