### PR TITLE
Bugfix of dangling llvm::function_ref

### DIFF
--- a/python/Passes.cpp
+++ b/python/Passes.cpp
@@ -109,9 +109,8 @@ void populatePassesModule(py::module &m) {
         const auto *pipeline =
             mlir::PassPipelineInfo::lookup("ttir-to-ttnn-backend-pipeline");
 
-        mlir::function_ref<mlir::LogicalResult(const llvm::Twine &)>
-            err_handler =
-                [](const llvm::Twine &loc) { return mlir::failure(); };
+        std::function<mlir::LogicalResult(const llvm::Twine &)> err_handler =
+            [](const llvm::Twine &) { return mlir::failure(); };
 
         if (mlir::failed(pipeline->addToPipeline(pm, options, err_handler))) {
           throw std::runtime_error("Failed to add pipeline to pass manager");
@@ -135,9 +134,8 @@ void populatePassesModule(py::module &m) {
         ctx->appendDialectRegistry(registry);
         const auto *pipeline =
             mlir::PassPipelineInfo::lookup("ttir-to-ttmetal-backend-pipeline");
-        mlir::function_ref<mlir::LogicalResult(const llvm::Twine &)>
-            err_handler =
-                [](const llvm::Twine &loc) { return mlir::failure(); };
+        std::function<mlir::LogicalResult(const llvm::Twine &)> err_handler =
+            [](const llvm::Twine &) { return mlir::failure(); };
         if (mlir::failed(pipeline->addToPipeline(pm, options, err_handler))) {
           throw std::runtime_error("Failed to add pipeline to pass manager");
         }


### PR DESCRIPTION
Closes https://github.com/tenstorrent/tt-mlir/issues/1753. The description is in the issue. I decided to change `llvm::function_ref` to `std::function`. The other option would be to inline lambda directly as an argument to the `addToPipeline`.