### PR TITLE
Enable choosing of input type for lowering tests

### DIFF
--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -5,6 +5,7 @@
 # RUN: SYSTEM_DESC_PATH=%system_desc_path% %python %s
 
 import inspect
+import torch
 
 from ttmlir.test_utils import compile_to_flatbuffer
 from ttmlir.ttir_builder import Operand, TTIRBuilder, Attribute
@@ -40,11 +41,11 @@ def test_logical_not(in0: Operand, builder: TTIRBuilder):
     return builder.logical_not(in0)
 
 
-# TODO: uncomment once we have control over generated input types (bitwise ops
-# don't support floats) (see issue #1765)
-# @compile_to_flatbuffer([(128, 128)], targets=["ttnn"])
-# def test_bitwise_not(in0: Operand, builder: TTIRBuilder):
-#    return builder.bitwise_not(in0)
+# NOTE: The generated flatbuffer will currently fail to run due to only floats
+# being supported by the runtime. See issue #1775 for tracking
+@compile_to_flatbuffer([(128, 128)], inputs_types=[torch.int8], targets=["ttnn"])
+def test_bitwise_not(in0: Operand, builder: TTIRBuilder):
+    return builder.bitwise_not(in0)
 
 
 @compile_to_flatbuffer([(128, 128)], targets=["ttnn"])
@@ -190,39 +191,46 @@ def test_logical_xor(in0: Operand, in1: Operand, builder: TTIRBuilder):
     return builder.logical_xor(in0, in1)
 
 
-# TODO: uncomment once we have control over generated input types (bitwise ops
-# don't support floats) (see issue #1765)
-# @compile_to_flatbuffer(
-#    [
-#        (64, 64),
-#        (64, 64),
-#    ],
-#    targets=["ttnn"],
-# )
-# def test_bitwise_and(in0: Operand, in1: Operand, builder: TTIRBuilder):
-#    return builder.bitwise_and(in0, in1)
-#
-#
-# @compile_to_flatbuffer(
-#    [
-#        (64, 64),
-#        (64, 64),
-#    ],
-#    targets=["ttnn"],
-# )
-# def test_bitwise_or(in0: Operand, in1: Operand, builder: TTIRBuilder):
-#    return builder.bitwise_or(in0, in1)
-#
-#
-# @compile_to_flatbuffer(
-#    [
-#        (64, 64),
-#        (64, 64),
-#    ],
-#    targets=["ttnn"],
-# )
-# def test_bitwise_xor(in0: Operand, in1: Operand, builder: TTIRBuilder):
-#    return builder.bitwise_xor(in0, in1)
+# NOTE: The generated flatbuffer will currently fail to run due to only floats
+# being supported by the runtime. See issue #1775 for tracking
+@compile_to_flatbuffer(
+    [
+        (64, 64),
+        (64, 64),
+    ],
+    inputs_types=[torch.int8, torch.int8],
+    targets=["ttnn"],
+)
+def test_bitwise_and(in0: Operand, in1: Operand, builder: TTIRBuilder):
+    return builder.bitwise_and(in0, in1)
+
+
+# NOTE: The generated flatbuffer will currently fail to run due to only floats
+# being supported by the runtime. See issue #1775 for tracking
+@compile_to_flatbuffer(
+    [
+        (64, 64),
+        (64, 64),
+    ],
+    inputs_types=[torch.int8, torch.int8],
+    targets=["ttnn"],
+)
+def test_bitwise_or(in0: Operand, in1: Operand, builder: TTIRBuilder):
+    return builder.bitwise_or(in0, in1)
+
+
+# NOTE: The generated flatbuffer will currently fail to run due to only floats
+# being supported by the runtime. See issue #1775 for tracking
+@compile_to_flatbuffer(
+    [
+        (64, 64),
+        (64, 64),
+    ],
+    inputs_types=[torch.int8, torch.int8],
+    targets=["ttnn"],
+)
+def test_bitwise_xor(in0: Operand, in1: Operand, builder: TTIRBuilder):
+    return builder.bitwise_xor(in0, in1)
 
 
 @compile_to_flatbuffer(
@@ -346,17 +354,18 @@ def test_minimum(in0: Operand, in1: Operand, builder: TTIRBuilder):
     return builder.minimum(in0, in1)
 
 
-# TODO: uncomment when we have control over the input types
 # @compile_to_flatbuffer(
-#    [
-#        (64, 64),
-#        (64, 64),
-#        (64, 64),
-#    ],
-#    targets=["ttnn"],
+#   [
+#       (64, 64),
+#       (64, 64),
+#       (64, 64),
+#   ],
+#   inputs_types = [torch.int8, torch.float32, torch.float32],
+#   targets=["ttnn"],
 # )
 # def test_where(in0: Operand, in1: Operand, in2: Operand, builder: TTIRBuilder):
-#    return builder.where(in0, in1, in2)
+#   return builder.where(in0, in1, in2)
+#
 
 
 @compile_to_flatbuffer(


### PR DESCRIPTION
Allows the choosing of input types to generated MLIR and golden checks via `inputs_types` kwarg. Take `torch.dtype`s as inputs, then converts them to MLIR `Type`s upon context introduction.

Closes #1765