### PR TITLE
#1772: Added support for remaining ttnn pipeline pybinds and refactored naming convention for ttnn pipeline passes

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -143,38 +143,91 @@ struct TTIRToTTNNBackendPipelineOptions
 //
 struct TTIRToEmitCPipelineOptions : public TTIRToTTNNBackendPipelineOptions {};
 
-void createTTNNPipelineTTIRPasses(
+void createTTNNOptimizerHelper(OpPassManager &pm,
+                               const TTIRToTTNNBackendPipelineOptions &options);
+
+void createTTNNWorkaroundsHelper(
     OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options);
 
-void createTTNNPipelineAnalysisPasses(
+void createTTNNDeallocateHelper(
+    OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options);
+
+void createTTIRImplicitDeviceHelper(
+    OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options);
+
+void createTTIRToTTIRDecompositionPassHelper(
+    OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options);
+
+void createInlinerPassHelper(OpPassManager &pm,
+                             const TTIRToTTNNBackendPipelineOptions &options);
+
+void createTTIRLoadSystemDescHelper(
+    OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options);
+
+void createTTNNLayoutHelper(OpPassManager &pm,
+                            const TTIRToTTNNBackendPipelineOptions &options);
+
+void createConvertTTIRToTTNNPassHelper(
+    OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options);
+
+void createRemoveDeadValuesPassHelper(
+    OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options);
+
+void createCanonicalizerPassHelper(
+    OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options);
+
+void createTTNNDecomposeLayoutsHelper(
     OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options);
 
 void createTTNNPipelineLoweringPasses(
     OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options);
 
-void createTTNNPipelineLayoutDecompositionPass(
+void createTTNNPipelineTTIRPasses(
     OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options);
 
-void createTTNNPipelineDeallocPass(
+void createTTNNPipelineWorkaroundPass(
     OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options);
 
-void createTTNNPipelineTTIRPassesFromString(OpPassManager &pm,
-                                            std::string options);
+void createTTIRToTTNNBackendPipeline(
+    OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options);
 
-void createTTNNPipelineAnalysisPassesFromString(OpPassManager &pm,
+void createTTNNDecomposeLayoutsHelperFromString(OpPassManager &pm,
                                                 std::string options);
+
+void createTTNNDeallocateHelperFromString(OpPassManager &pm,
+                                          std::string options);
+
+void createTTIRToTTIRDecompositionPassFromString(OpPassManager &pm,
+                                                 std::string options);
+
+void createInlinerPassFromString(OpPassManager &pm, std::string options);
+
+void createTTIRLoadSystemDescFromString(OpPassManager &pm, std::string options);
+
+void createTTIRImplicitDeviceFromString(OpPassManager &pm, std::string options);
+
+void createTTNNLayoutFromString(OpPassManager &pm, std::string options);
+
+void createConvertTTIRToTTNNPassFromString(OpPassManager &pm,
+                                           std::string options);
+
+void createRemoveDeadValuesPassFromString(OpPassManager &pm,
+                                          std::string options);
 
 void createTTNNPipelineLoweringPassesFromString(OpPassManager &pm,
                                                 std::string options);
 
-void createTTNNPipelineLayoutDecompositionPassFromString(OpPassManager &pm,
-                                                         std::string options);
+void createTTNNPipelineTTIRPassesFromString(OpPassManager &pm,
+                                            std::string options);
 
-void createTTNNPipelineDeallocPassFromString(OpPassManager &pm,
-                                             std::string options);
+void createTTNNWorkaroundsFromString(OpPassManager &pm, std::string options);
 
-void createTTIRToTTNNBackendPipeline(
-    OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options);
+void createCanonicalizerPassFromString(OpPassManager &pm, std::string options);
+
+void createTTNNPipelineWorkaroundPassFromString(OpPassManager &pm,
+                                                std::string options);
+
+void createTTNNOptimizerFromString(OpPassManager &pm, std::string options);
 
 void createTTIRToEmitCPipeline(OpPassManager &pm,
                                const TTIRToEmitCPipelineOptions &options);

--- a/python/Passes.cpp
+++ b/python/Passes.cpp
@@ -24,12 +24,12 @@ void populatePassesModule(py::module &m) {
   mlir::tt::ttnn::registerTTNNToFlatbuffer();
 
   m.def(
-      "ttnn_pipeline_ttir_passes",
+      "ttnn_decompose_layouts",
       [](MlirModule module, std::string options = "") {
         mlir::Operation *moduleOp = unwrap(mlirModuleGetOperation(module));
         mlir::PassManager pm(moduleOp->getContext());
 
-        tt::ttnn::createTTNNPipelineTTIRPassesFromString(pm, options);
+        tt::ttnn::createTTNNDecomposeLayoutsHelperFromString(pm, options);
 
         if (mlir::failed(pm.run(moduleOp))) {
           throw std::runtime_error("Failed to run pass manager");
@@ -38,12 +38,110 @@ void populatePassesModule(py::module &m) {
       py::arg("module"), py::arg("options") = "");
 
   m.def(
-      "ttnn_pipeline_analysis_passes",
+      "ttnn_deallocate",
       [](MlirModule module, std::string options = "") {
         mlir::Operation *moduleOp = unwrap(mlirModuleGetOperation(module));
         mlir::PassManager pm(moduleOp->getContext());
 
-        tt::ttnn::createTTNNPipelineAnalysisPassesFromString(pm, options);
+        tt::ttnn::createTTNNDeallocateHelperFromString(pm, options);
+
+        if (mlir::failed(pm.run(moduleOp))) {
+          throw std::runtime_error("Failed to run pass manager");
+        }
+      },
+      py::arg("module"), py::arg("options") = "");
+
+  m.def(
+      "ttir_to_ttir_decomposition_pass",
+      [](MlirModule module, std::string options = "") {
+        mlir::Operation *moduleOp = unwrap(mlirModuleGetOperation(module));
+        mlir::PassManager pm(moduleOp->getContext());
+
+        tt::ttnn::createTTIRToTTIRDecompositionPassFromString(pm, options);
+
+        if (mlir::failed(pm.run(moduleOp))) {
+          throw std::runtime_error("Failed to run pass manager");
+        }
+      },
+      py::arg("module"), py::arg("options") = "");
+
+  m.def(
+      "inliner_pass",
+      [](MlirModule module, std::string options = "") {
+        mlir::Operation *moduleOp = unwrap(mlirModuleGetOperation(module));
+        mlir::PassManager pm(moduleOp->getContext());
+
+        tt::ttnn::createInlinerPassFromString(pm, options);
+
+        if (mlir::failed(pm.run(moduleOp))) {
+          throw std::runtime_error("Failed to run pass manager");
+        }
+      },
+      py::arg("module"), py::arg("options") = "");
+
+  m.def(
+      "ttir_load_system_desc",
+      [](MlirModule module, std::string options = "") {
+        mlir::Operation *moduleOp = unwrap(mlirModuleGetOperation(module));
+        mlir::PassManager pm(moduleOp->getContext());
+
+        tt::ttnn::createTTIRLoadSystemDescFromString(pm, options);
+
+        if (mlir::failed(pm.run(moduleOp))) {
+          throw std::runtime_error("Failed to run pass manager");
+        }
+      },
+      py::arg("module"), py::arg("options") = "");
+
+  m.def(
+      "ttir_implicit_device",
+      [](MlirModule module, std::string options = "") {
+        mlir::Operation *moduleOp = unwrap(mlirModuleGetOperation(module));
+        mlir::PassManager pm(moduleOp->getContext());
+
+        tt::ttnn::createTTIRImplicitDeviceFromString(pm, options);
+
+        if (mlir::failed(pm.run(moduleOp))) {
+          throw std::runtime_error("Failed to run pass manager");
+        }
+      },
+      py::arg("module"), py::arg("options") = "");
+
+  m.def(
+      "ttnn_layout",
+      [](MlirModule module, std::string options = "") {
+        mlir::Operation *moduleOp = unwrap(mlirModuleGetOperation(module));
+        mlir::PassManager pm(moduleOp->getContext());
+
+        tt::ttnn::createTTNNLayoutFromString(pm, options);
+
+        if (mlir::failed(pm.run(moduleOp))) {
+          throw std::runtime_error("Failed to run pass manager");
+        }
+      },
+      py::arg("module"), py::arg("options") = "");
+
+  m.def(
+      "convert_ttir_to_ttnn_pass",
+      [](MlirModule module, std::string options = "") {
+        mlir::Operation *moduleOp = unwrap(mlirModuleGetOperation(module));
+        mlir::PassManager pm(moduleOp->getContext());
+
+        tt::ttnn::createConvertTTIRToTTNNPassFromString(pm, options);
+
+        if (mlir::failed(pm.run(moduleOp))) {
+          throw std::runtime_error("Failed to run pass manager");
+        }
+      },
+      py::arg("module"), py::arg("options") = "");
+
+  m.def(
+      "remove_dead_values_pass",
+      [](MlirModule module, std::string options = "") {
+        mlir::Operation *moduleOp = unwrap(mlirModuleGetOperation(module));
+        mlir::PassManager pm(moduleOp->getContext());
+
+        tt::ttnn::createRemoveDeadValuesPassFromString(pm, options);
 
         if (mlir::failed(pm.run(moduleOp))) {
           throw std::runtime_error("Failed to run pass manager");
@@ -66,13 +164,12 @@ void populatePassesModule(py::module &m) {
       py::arg("module"), py::arg("options") = "");
 
   m.def(
-      "ttnn_pipeline_layout_decomposition_pass",
+      "ttnn_pipeline_ttir_passes",
       [](MlirModule module, std::string options = "") {
         mlir::Operation *moduleOp = unwrap(mlirModuleGetOperation(module));
         mlir::PassManager pm(moduleOp->getContext());
 
-        tt::ttnn::createTTNNPipelineLayoutDecompositionPassFromString(pm,
-                                                                      options);
+        tt::ttnn::createTTNNPipelineTTIRPassesFromString(pm, options);
 
         if (mlir::failed(pm.run(moduleOp))) {
           throw std::runtime_error("Failed to run pass manager");
@@ -81,12 +178,54 @@ void populatePassesModule(py::module &m) {
       py::arg("module"), py::arg("options") = "");
 
   m.def(
-      "ttnn_pipeline_dealloc_pass",
+      "ttnn_workarounds",
       [](MlirModule module, std::string options = "") {
         mlir::Operation *moduleOp = unwrap(mlirModuleGetOperation(module));
         mlir::PassManager pm(moduleOp->getContext());
 
-        tt::ttnn::createTTNNPipelineDeallocPassFromString(pm, options);
+        tt::ttnn::createTTNNWorkaroundsFromString(pm, options);
+
+        if (mlir::failed(pm.run(moduleOp))) {
+          throw std::runtime_error("Failed to run pass manager");
+        }
+      },
+      py::arg("module"), py::arg("options") = "");
+
+  m.def(
+      "canonicalizer_pass",
+      [](MlirModule module, std::string options = "") {
+        mlir::Operation *moduleOp = unwrap(mlirModuleGetOperation(module));
+        mlir::PassManager pm(moduleOp->getContext());
+
+        tt::ttnn::createCanonicalizerPassFromString(pm, options);
+
+        if (mlir::failed(pm.run(moduleOp))) {
+          throw std::runtime_error("Failed to run pass manager");
+        }
+      },
+      py::arg("module"), py::arg("options") = "");
+
+  m.def(
+      "ttnn_pipeline_workaround_pass",
+      [](MlirModule module, std::string options = "") {
+        mlir::Operation *moduleOp = unwrap(mlirModuleGetOperation(module));
+        mlir::PassManager pm(moduleOp->getContext());
+
+        tt::ttnn::createTTNNPipelineWorkaroundPassFromString(pm, options);
+
+        if (mlir::failed(pm.run(moduleOp))) {
+          throw std::runtime_error("Failed to run pass manager");
+        }
+      },
+      py::arg("module"), py::arg("options") = "");
+
+  m.def(
+      "ttnn_optimizer",
+      [](MlirModule module, std::string options = "") {
+        mlir::Operation *moduleOp = unwrap(mlirModuleGetOperation(module));
+        mlir::PassManager pm(moduleOp->getContext());
+
+        tt::ttnn::createTTNNOptimizerFromString(pm, options);
 
         if (mlir::failed(pm.run(moduleOp))) {
           throw std::runtime_error("Failed to run pass manager");


### PR DESCRIPTION
This allows the user to write custom mlir modules through ttir_builder (or personally) and run individual passes in python

Sample use
```
def run_ttir_to_ttir_decomposition_pass(module, dump_module = False):
    ttir_to_ttir_decomposition_pass(module)

    if dump_module:
        print(module)

def run_ttir_load_system_desc(module, dump_module = False):
    ttir_load_system_desc(module)

    if dump_module:
        print(module)

def run_ttir_implicit_device(module, dump_module = False):
    ttir_implicit_device(module)

    if dump_module:
        print(module)

def run_ttnn_layout(module, dump_module = False):
    ttnn_layout(module)

    if dump_module:
        print(module)

def run_convert_ttir_to_ttnn_pass(module, dump_module = False):
    convert_ttir_to_ttnn_pass(module)

    if dump_module:
        print(module)

def run_remove_dead_values_pass(module, dump_module = False):
    remove_dead_values_pass(module)

    if dump_module:
        print(module)

def run_ttnn_workarounds(module, dump_module = False):
    ttnn_workarounds(module)

    if dump_module:
        print(module)

def run_canonicalizer_pass(module, dump_module = False):
    canonicalizer_pass(module)

    if dump_module:
        print(module)

def run_ttnn_decompose_layouts(module, dump_module = False):
    ttnn_decompose_layouts(module)

    if dump_module:
        print(module)

def run_ttnn_deallocate(module, dump_module = False):
    ttnn_deallocate(module)

    if dump_module:
        print(module)


def test_relu_decomp():
    function_name = inspect.currentframe().f_code.co_name
    golden_map = {}

    with Context() as ctx, Location.name(f"{function_name}"):
        parent_location = Location.name(f"{function_name}")
        tt.register_dialect(ctx)
        ttir.register_dialect(ctx)

        module = Module.create()
        with InsertionPoint(module.body):

            input_shape_list = [(128, 128)]

            input_operands = []
            for shape in input_shape_list:
                input_operands.append(RankedTensorType.get(shape, F32Type.get()))

            golden_inputs = []
            for shape in input_shape_list:
                golden_inputs.append(torch.randn(shape, dtype=torch.float32))

            @func.func(*input_operands, name=f"{function_name}")
            def relu(inputs):

                ttir_op_res, golden_dict = create_relu(
                    inputs, [(128, 128)], golden_inputs
                )
                golden_map[golden_dict["location"]] = golden_dict["golden_output"]
                return ttir_op_res

        run_ttir_to_ttir_decomposition_pass(module, False)
        run_ttir_load_system_desc(module, False)
        run_ttir_implicit_device(module, False)
        run_ttnn_layout(module, True)
        run_convert_ttir_to_ttnn_pass(module, False)
        run_remove_dead_values_pass(module, False)
        run_ttnn_workarounds(module, False)
        run_canonicalizer_pass(module, False)
        run_ttnn_decompose_layouts(module, False)
        run_ttnn_deallocate(module, False)
        print(module)
```

```
def get_type(input: Operand):
    if isinstance(input, Value):
        type = input.type
    elif isinstance(input, OpView):
        type = input.operation.result.type
    elif isinstance(input, Operation):
        type = input.result.type
    else:
        raise TypeError(f"Invalid input {type(input)}")

    assert isinstance(type, RankedTensorType), "Only ranked tensors are supported"

    return type


def output_type_operands(output_shape_list):
    output_operands = []
    output_type_list = []

    for shape in output_shape_list:
        output_operands.append(create_empty(shape))

    for operand in output_operands:
        output_type_list.append(get_type(operand))

    return output_operands, output_type_list


empty_index = 0


def create_empty(shape):
    global empty_index

    res = tensor.EmptyOp(
        shape, F32Type.get(), loc=Location.name(f"empty_{empty_index}")
    )
    empty_index += 1
    return res

relu_index = 0


def create_relu(inputs, output_shape_list, golden_inputs):
    global relu_index
    location = f"relu_{relu_index}"

    relu_output_operands, relu_output_type_list = output_type_operands(
        output_shape_list
    )
    res = ttir.ReluOp(
        relu_output_type_list,
        [inputs],
        relu_output_operands,
        loc=Location.name(location),
    )
    relu_index += 1

    golden_output = torch.relu(*golden_inputs)

    return res, {"location": location, "golden_output": golden_output}
```