### PR TITLE
Optionally disable debug strings in flatbuffer, greatly reduces compile time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,11 @@ option(TTMLIR_ENABLE_RUNTIME "Enable runtime" OFF)
 option(TTMLIR_ENABLE_STABLEHLO "Enable StableHLO support" OFF)
 option(TTMLIR_ENABLE_OPMODEL "Enable OpModel support" OFF)
 option(TTMLIR_ENABLE_SHARED_LIB "Enable Shared lib building" ON)
+option(TTMLIR_ENABLE_DEBUG_STRINGS "Enable debug strings in flatbuffer" ON)
+
+if (TTMLIR_ENABLE_DEBUG_STRINGS)
+  add_compile_definitions(TTMLIR_ENABLE_DEBUG_STRINGS)
+endif()
 
 if (NOT TTMLIR_ENABLE_RUNTIME)
   set (TTMLIR_ENABLE_SHARED_LIB OFF)

--- a/include/ttmlir/Target/Utils/FuncOpToProgram.h
+++ b/include/ttmlir/Target/Utils/FuncOpToProgram.h
@@ -25,10 +25,14 @@ struct Program {
 
 inline std::string getOpDebugString(mlir::Operation *op,
                                     OpPrintingFlags printFlags) {
+#ifdef TTMLIR_ENABLE_DEBUG_STRINGS
   std::string str;
   llvm::raw_string_ostream os(str);
   op->print(os, printFlags);
   return str;
+#else
+  return "";
+#endif
 };
 
 inline std::string getOpLocInfo(mlir::Operation *op) {


### PR DESCRIPTION
e2e compile time from stableHLO to flatbuffer is dominated by flatbuffer generation (>99%). Disabling debug strings lowers flatbuffer generation time to 25% of total, lowering e2e times from, for example, 2.5 min to 2 sec.