### PR TITLE
Uplift third_party/tt-metal to 3a9637d52b003d5d5eda455cc72fbeb75a689f32 2025-01-15

### DIFF
--- a/runtime/lib/common/system_desc.cpp
+++ b/runtime/lib/common/system_desc.cpp
@@ -262,7 +262,9 @@ std::pair<::tt::runtime::SystemDesc, DeviceIds> getCurrentSystemDesc() {
   ::tt::tt_metal::distributed::MeshShape meshShape = {1, numDevices};
   std::shared_ptr<::tt::tt_metal::distributed::MeshDevice> meshDevice =
       ::tt::tt_metal::distributed::MeshDevice::create(
-          ::tt::tt_metal::distributed::MeshDeviceConfig{.mesh_shape = meshShape}, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 1,
+          ::tt::tt_metal::distributed::MeshDeviceConfig{.mesh_shape =
+                                                            meshShape},
+          DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 1,
           ::tt::tt_metal::DispatchCoreType::WORKER);
   std::exception_ptr eptr = nullptr;
   std::unique_ptr<::tt::runtime::SystemDesc> desc;

--- a/runtime/lib/common/system_desc.cpp
+++ b/runtime/lib/common/system_desc.cpp
@@ -262,7 +262,7 @@ std::pair<::tt::runtime::SystemDesc, DeviceIds> getCurrentSystemDesc() {
   ::tt::tt_metal::distributed::MeshShape meshShape = {1, numDevices};
   std::shared_ptr<::tt::tt_metal::distributed::MeshDevice> meshDevice =
       ::tt::tt_metal::distributed::MeshDevice::create(
-          meshShape, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 1,
+          ::tt::tt_metal::distributed::MeshDeviceConfig{.mesh_shape = meshShape}, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 1,
           ::tt::tt_metal::DispatchCoreType::WORKER);
   std::exception_ptr eptr = nullptr;
   std::unique_ptr<::tt::runtime::SystemDesc> desc;
@@ -271,7 +271,7 @@ std::pair<::tt::runtime::SystemDesc, DeviceIds> getCurrentSystemDesc() {
   } catch (...) {
     eptr = std::current_exception();
   }
-  meshDevice->close_devices();
+  meshDevice->close();
   if (eptr) {
     std::rethrow_exception(eptr);
   }

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -74,7 +74,7 @@ Device openDevice(DeviceIds const &deviceIds, size_t numHWCQs,
   size_t l1SmallSizeValue = l1SmallSize.value_or(DEFAULT_L1_SMALL_SIZE);
   std::shared_ptr<::tt::tt_metal::distributed::MeshDevice> meshDevice =
       ::tt::tt_metal::distributed::MeshDevice::create(
-          grid, l1SmallSizeValue, DEFAULT_TRACE_REGION_SIZE, numHWCQs,
+          ::tt::tt_metal::distributed::MeshDeviceConfig{.mesh_shape = grid}, l1SmallSizeValue, DEFAULT_TRACE_REGION_SIZE, numHWCQs,
           ::tt::tt_metal::DispatchCoreType::WORKER);
 
   return Device(std::static_pointer_cast<void>(meshDevice),
@@ -92,7 +92,7 @@ void closeDevice(Device device) {
     ::tt::tt_metal::detail::DumpDeviceProfileResults(ttmetalDevice);
   }
 #endif
-  ttmetalMeshDevice.close_devices();
+  ttmetalMeshDevice.close();
 }
 
 void deallocateBuffers(Device deviceHandle) {

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -74,7 +74,8 @@ Device openDevice(DeviceIds const &deviceIds, size_t numHWCQs,
   size_t l1SmallSizeValue = l1SmallSize.value_or(DEFAULT_L1_SMALL_SIZE);
   std::shared_ptr<::tt::tt_metal::distributed::MeshDevice> meshDevice =
       ::tt::tt_metal::distributed::MeshDevice::create(
-          ::tt::tt_metal::distributed::MeshDeviceConfig{.mesh_shape = grid}, l1SmallSizeValue, DEFAULT_TRACE_REGION_SIZE, numHWCQs,
+          ::tt::tt_metal::distributed::MeshDeviceConfig{.mesh_shape = grid},
+          l1SmallSizeValue, DEFAULT_TRACE_REGION_SIZE, numHWCQs,
           ::tt::tt_metal::DispatchCoreType::WORKER);
 
   return Device(std::static_pointer_cast<void>(meshDevice),

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -184,7 +184,7 @@ Device openDevice(DeviceIds const &deviceIds, size_t numHWCQs,
   ::tt::tt_metal::distributed::MeshShape grid = {1, deviceIds.size()};
   size_t l1SmallSizeValue = l1SmallSize.value_or(kL1SmallSize);
   std::shared_ptr<::ttnn::MeshDevice> meshDevice = ::ttnn::MeshDevice::create(
-      grid, l1SmallSizeValue, DEFAULT_TRACE_REGION_SIZE, numHWCQs,
+      ::tt::tt_metal::distributed::MeshDeviceConfig{.mesh_shape = grid}, l1SmallSizeValue, DEFAULT_TRACE_REGION_SIZE, numHWCQs,
       ::tt::tt_metal::DispatchCoreType::WORKER);
 
   bool enableAsync = debug::Env::get().enableAsyncTTNN;
@@ -205,7 +205,7 @@ void closeDevice(Device device) {
   }
 #endif
 
-  ttnnMeshDevice.close_devices();
+  ttnnMeshDevice.close();
 }
 
 void deallocateBuffers(Device deviceHandle) {

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -184,7 +184,8 @@ Device openDevice(DeviceIds const &deviceIds, size_t numHWCQs,
   ::tt::tt_metal::distributed::MeshShape grid = {1, deviceIds.size()};
   size_t l1SmallSizeValue = l1SmallSize.value_or(kL1SmallSize);
   std::shared_ptr<::ttnn::MeshDevice> meshDevice = ::ttnn::MeshDevice::create(
-      ::tt::tt_metal::distributed::MeshDeviceConfig{.mesh_shape = grid}, l1SmallSizeValue, DEFAULT_TRACE_REGION_SIZE, numHWCQs,
+      ::tt::tt_metal::distributed::MeshDeviceConfig{.mesh_shape = grid},
+      l1SmallSizeValue, DEFAULT_TRACE_REGION_SIZE, numHWCQs,
       ::tt::tt_metal::DispatchCoreType::WORKER);
 
   bool enableAsync = debug::Env::get().enableAsyncTTNN;

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "5d4c047dacf2606dd56c7b4d51d5049bf2c6846a")
+set(TT_METAL_VERSION "3a9637d52b003d5d5eda455cc72fbeb75a689f32")
 
 if ("$ENV{ARCH_NAME}" STREQUAL "grayskull")
   set(ARCH_NAME "grayskull")


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 3a9637d52b003d5d5eda455cc72fbeb75a689f32

- Use `MeshDeviceConfig` explicit constructor instead of passing in `MeshShape` implicitly due to metal commit 2c4a641