### PR TITLE
Uplift third_party/tt-metal to eadc98f1c0f714c423fdfc97689afbc50c0dca3b 2025-01-16

### DIFF
--- a/runtime/lib/ttnn/operations/ccl/mesh_shard.cpp
+++ b/runtime/lib/ttnn/operations/ccl/mesh_shard.cpp
@@ -17,8 +17,9 @@ void FullToShardShape(const ::ttnn::Tensor &input, ::ttnn::Tensor &out,
                       const std::vector<int64_t> &shardShape) {
   if (shardType == ::tt::target::MeshShardType::Replicate) {
     out = ::ttnn::distributed::distribute_tensor(
-        input, meshDevice,
-        *::ttnn::distributed::replicate_tensor_to_mesh_mapper(meshDevice));
+        input,
+        *::ttnn::distributed::replicate_tensor_to_mesh_mapper(meshDevice),
+        meshDevice);
   } else {
     LOG_ASSERT(
         input.get_shape().rank() > 1,

--- a/runtime/lib/ttnn/operations/ccl/mesh_shard.cpp
+++ b/runtime/lib/ttnn/operations/ccl/mesh_shard.cpp
@@ -49,9 +49,10 @@ void FullToShardShape(const ::ttnn::Tensor &input, ::ttnn::Tensor &out,
     }
 
     out = ::ttnn::distributed::distribute_tensor(
-        input, meshDevice,
+        input,
         *::ttnn::distributed::shard_tensor_to_2d_mesh_mapper(
-            meshDevice, meshDevice.shape(), shard2dConfig));
+            meshDevice, meshDevice.shape(), shard2dConfig),
+        meshDevice);
   }
 }
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "3a9637d52b003d5d5eda455cc72fbeb75a689f32")
+set(TT_METAL_VERSION "eadc98f1c0f714c423fdfc97689afbc50c0dca3b")
 
 if ("$ENV{ARCH_NAME}" STREQUAL "grayskull")
   set(ARCH_NAME "grayskull")


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the eadc98f1c0f714c423fdfc97689afbc50c0dca3b

- Update order of arguments passed into `distributed::distribute_tensor` due to parameters changed in tt-metal commit abc55d2