### PR TITLE
TTNN utils generate reshape fix

### DIFF
--- a/include/ttmlir/Conversion/TTIRToTTNN/Utils.h
+++ b/include/ttmlir/Conversion/TTIRToTTNN/Utils.h
@@ -12,15 +12,17 @@
 
 namespace mlir::tt::ttir_to_ttnn::utils {
 // Generates a reshape operation for the given input tensor with the new shape.
-mlir::tt::ttnn::ReshapeOp generateReshape(mlir::Value input,
-                                          llvm::ArrayRef<int64_t> newShape,
-                                          mlir::PatternRewriter &rewriter);
+mlir::tt::ttnn::ReshapeOp
+generateReshape(mlir::TypedValue<mlir::RankedTensorType> input,
+                llvm::ArrayRef<int64_t> newShape,
+                mlir::PatternRewriter &rewriter);
 
 // Generates a reshape operation for the given input tensor that returns 4D
 // tensor. Assumes that the input tensor is 4D. First 3 dimensions are flattened
 // into 3rd dimension and 4th dimension is kept as is.
-mlir::tt::ttnn::ReshapeOp generateNHWFlatten(mlir::Value input,
-                                             mlir::PatternRewriter &rewriter);
+mlir::tt::ttnn::ReshapeOp
+generateNHWFlatten(mlir::TypedValue<mlir::RankedTensorType> input,
+                   mlir::PatternRewriter &rewriter);
 
 } // namespace mlir::tt::ttir_to_ttnn::utils
 

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -377,7 +377,8 @@ public:
     llvm::SmallVector<int64_t, 4> reshapedGradShape{1, 1, R, gradShape.back()};
 
     auto reshapedGrad = mlir::tt::ttir_to_ttnn::utils::generateReshape(
-        adaptor.getInGradient(), reshapedGradShape, rewriter);
+        mlir::cast<TypedValue<mlir::RankedTensorType>>(adaptor.getInGradient()),
+        reshapedGradShape, rewriter);
 
     // Get TTNNLayoutAttr of the result type.
     ttnn::TTNNLayoutAttr layoutAttr = mlir::cast<ttnn::TTNNLayoutAttr>(
@@ -849,8 +850,9 @@ public:
 
     std::vector<int64_t> flattenedInputShape = {
         1, 1, input_shape[0] * input_shape[1] * input_shape[2], input_shape[3]};
-    Value flattenedInput =
-        ttir_to_ttnn::utils::generateNHWFlatten(adaptor.getInput(), rewriter);
+    Value flattenedInput = ttir_to_ttnn::utils::generateNHWFlatten(
+        mlir::cast<mlir::TypedValue<RankedTensorType>>(adaptor.getInput()),
+        rewriter);
 
     std::vector<int64_t> flattenedOutputShape = {
         1, 1, output_shape[0] * output_shape[1] * output_shape[2],
@@ -908,8 +910,9 @@ public:
     auto channels =
         rewriter.getSI32IntegerAttr(input_shape[input_shape.size() - 1]);
 
-    Value flattenedInput =
-        ttir_to_ttnn::utils::generateNHWFlatten(adaptor.getInput(), rewriter);
+    Value flattenedInput = ttir_to_ttnn::utils::generateNHWFlatten(
+        mlir::cast<mlir::TypedValue<RankedTensorType>>(adaptor.getInput()),
+        rewriter);
 
     auto output_ty =
         mlir::cast<RankedTensorType>(adaptor.getOutput().getType());

--- a/lib/Conversion/TTIRToTTNN/Utils.cpp
+++ b/lib/Conversion/TTIRToTTNN/Utils.cpp
@@ -3,28 +3,43 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Conversion/TTIRToTTNN/Utils.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include <llvm/ADT/SmallVector.h>
+#include <mlir/IR/BuiltinTypes.h>
 
 namespace mlir {
 namespace tt {
 namespace ttir_to_ttnn::utils {
-ttnn::ReshapeOp generateReshape(Value input, ArrayRef<int64_t> newShape,
+ttnn::ReshapeOp generateReshape(mlir::TypedValue<mlir::RankedTensorType> input,
+                                ArrayRef<int64_t> newShape,
                                 PatternRewriter &rewriter) {
-  auto inputType = mlir::cast<RankedTensorType>(input.getType());
-  auto outputType = inputType.cloneWith(newShape, inputType.getElementType());
+  // With reshape op, the output layout changes due to new output shape, hence
+  // we need to create a new output layout attribute with the new shape.
+  RankedTensorType inputType = input.getType();
+  ttnn::TTNNLayoutAttr inputLayoutAttr =
+      mlir::cast<ttnn::TTNNLayoutAttr>(inputType.getEncoding());
+  ttnn::TTNNLayoutAttr outputLayoutAttr =
+      inputLayoutAttr.withTensorShape(rewriter.getContext(), newShape);
 
-  std::vector<int32_t> newShapeI32(newShape.begin(), newShape.end());
+  // Create a new output type for reshape operation with new shape and new
+  // output layout.
+  RankedTensorType outputType = RankedTensorType::get(
+      newShape, inputType.getElementType(), outputLayoutAttr);
+
+  llvm::SmallVector<int32_t> newShapeI32(newShape.begin(), newShape.end());
   return rewriter.create<ttnn::ReshapeOp>(
       input.getLoc(), outputType, input, rewriter.getI32ArrayAttr(newShapeI32));
 }
 
-ttnn::ReshapeOp generateNHWFlatten(Value input, PatternRewriter &rewriter) {
-  std::vector<int64_t> shape =
-      mlir::cast<RankedTensorType>(input.getType()).getShape().vec();
+ttnn::ReshapeOp
+generateNHWFlatten(mlir::TypedValue<mlir::RankedTensorType> input,
+                   PatternRewriter &rewriter) {
+  llvm::ArrayRef<int64_t> shape = input.getType().getShape();
 
   assert(shape.size() == 4 && "Must have 4-dim tensor as conv2d input");
 
-  std::vector<int64_t> newShape = {1, 1, shape[0] * shape[1] * shape[2],
-                                   shape[3]};
+  llvm::SmallVector<int64_t> newShape = {1, 1, shape[0] * shape[1] * shape[2],
+                                         shape[3]};
   return generateReshape(input, newShape, rewriter);
 }
 

--- a/test/ttmlir/Dialect/TTNN/embedding/simple_embedding_backward.mlir
+++ b/test/ttmlir/Dialect/TTNN/embedding/simple_embedding_backward.mlir
@@ -1,0 +1,16 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
+module attributes {} {
+  func.func @backward(%arg0: tensor<1x32xbf16>, %arg1: tensor<512x128xbf16>, %arg2: tensor<1x32x128xbf16>) -> tensor<512x128xbf16> {
+    // Capture reshape output layout for validation
+    // CHECK: [[RESHAPE_OUTPUT_LAYOUT:.*]] = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1 * 32 + d2, d3), <1x1>, memref<1x4x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
+    %0 = tensor.empty() : tensor<512x128xbf16>
+    // CHECK: "ttnn.empty"
+    // Verify inserted reshape op
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: <{shape = [1 : i32, 1 : i32, 32 : i32, 128 : i32]}>
+    // CHECK-SAME: -> tensor<1x1x32x128xbf16, [[RESHAPE_OUTPUT_LAYOUT]]>
+    %1 = "ttir.embedding_backward"(%arg0, %arg1, %arg2, %0) : (tensor<1x32xbf16>, tensor<512x128xbf16>, tensor<1x32x128xbf16>, tensor<512x128xbf16>) -> tensor<512x128xbf16>
+    // CHECK: "ttnn.embedding_bw"
+    return %1 : tensor<512x128xbf16>
+  }
+}


### PR DESCRIPTION
A utils function in:
lib/Conversion/TTIRToTTNN/Utils.cpp
```C++
ttnn::ReshapeOp generateReshape(Value input, ArrayRef<int64_t> newShape,
                                PatternRewriter &rewriter);
```

It doesn't account for the output layout change of a reshaped op. This PR fixes the output layout of a newly generated reshape op.

Added a simple test to capture this.

Closes #1855 