### PR TITLE
Add `tmux` & `clangd` to the IRD docker

### DIFF
--- a/.github/Dockerfile.ird
+++ b/.github/Dockerfile.ird
@@ -13,7 +13,9 @@ RUN apt-get update && apt-get install -y \
     ssh \
     sudo \
     wget \
-    vim
+    vim \
+    tmux \
+    clangd
 
 # Create a directory for the toolchain and set permissions
 RUN mkdir -p $TTMLIR_TOOLCHAIN_DIR && \

--- a/.github/Dockerfile.ird
+++ b/.github/Dockerfile.ird
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y \
     sudo \
     wget \
     vim \
+    nano \
     tmux \
     clangd
 


### PR DESCRIPTION
This change adds some QoL tools to the docker image for working with the compiler