### PR TITLE
Uplift third_party/tt-metal to a8396fa5071ea9b0d6754c0317b68871c65d3283 2025-01-17

### DIFF
--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -480,7 +480,7 @@ public:
           getDeviceOp = currGetDeviceOp;
         });
 
-    // Create ttnn::Shape() call
+    // Create ttnn::SimpleShape() call
     //
     emitc::ExpressionOp shapeExpressionOp = ttnn_to_emitc::utils::createShapeOp(
         rewriter, shapeAttr, srcOp->getBlock(), srcOp.getLoc());
@@ -502,7 +502,7 @@ public:
     // Create ArrayAttr object holding attributes and pointers to operands
     //
     ArrayAttr arrayAttr = rewriter.getArrayAttr({
-        rewriter.getIndexAttr(0), // ttnn::Shape
+        rewriter.getIndexAttr(0), // ttnn::SimpleShape
         ttnn_to_emitc::utils::convertDType(rewriter, dataTypeAttr),
         ttnn_to_emitc::utils::convertLayoutAttr(rewriter, layoutAttr),
         rewriter.getIndexAttr(1), // ttnn::Device
@@ -547,16 +547,16 @@ public:
     // Attrs (like shape) need to be instantiated into objects before being
     // passed to the op. Therefore:
     //
-    // We first create a ttnn::Shape object (SSA) by calling createShapeOp()
-    // and add it to the operands vector, but also add an IndexAttr in
-    // ArrayAttr to reference it (this is an EmitC mechanism that allows for
-    // combining Attrs and Values when calling an OpaqueOp). All the other
-    // input params are optional, so we create them on-the-fly into the
+    // We first create a ttnn::SimpleShape object (SSA) by calling
+    // createShapeOp() and add it to the operands vector, but also add an
+    // IndexAttr in ArrayAttr to reference it (this is an EmitC mechanism that
+    // allows for combining Attrs and Values when calling an OpaqueOp). All the
+    // other input params are optional, so we create them on-the-fly into the
     // ArrayAttr, whether they are an actual Attr, or a Value pointed to by
     // IndexAttr. If they are present, we create the object and pass it to the
     // op. If not, we pass std::nullopt.
 
-    // Create ttnn::Shape() call
+    // Create ttnn::SimpleShape() call
     //
     emitc::ExpressionOp shapeExpressionOp = ttnn_to_emitc::utils::createShapeOp(
         rewriter, srcOp.getShapeAttr(), srcOp->getBlock(), srcOp.getLoc());
@@ -572,7 +572,7 @@ public:
     //
     size_t operandIndex = 0;
     ArrayAttr arrayAttr = rewriter.getArrayAttr({
-        rewriter.getIndexAttr(operandIndex++), // ttnn::Shape
+        rewriter.getIndexAttr(operandIndex++), // ttnn::SimpleShape
         srcOp.getDtype().has_value()
             ? ttnn_to_emitc::utils::convertDType(rewriter, srcOp.getDtypeAttr())
             : ttnn_to_emitc::utils::createStdNullopt(

--- a/lib/Conversion/TTNNToEmitC/Utils.cpp
+++ b/lib/Conversion/TTNNToEmitC/Utils.cpp
@@ -167,7 +167,8 @@ emitc::ExpressionOp createShapeOp(ConversionPatternRewriter &rewriter,
   // together into a single SSA value
   //
   emitc::ExpressionOp shapeExpressionOp = rewriter.create<emitc::ExpressionOp>(
-      loc, emitc::OpaqueType::get(rewriter.getContext(), "ttnn::Shape"), false);
+      loc, emitc::OpaqueType::get(rewriter.getContext(), "ttnn::SimpleShape"),
+      false);
 
   // Add a block to the ExpressionOp, save current insertion point, and set
   // insertion point to newly added block
@@ -186,11 +187,11 @@ emitc::ExpressionOp createShapeOp(ConversionPatternRewriter &rewriter,
       rewriter.getArrayAttr(convertShape(rewriter, shapeAttr)), nullptr,
       ValueRange());
 
-  // Create a ttnn::Shape object
+  // Create a ttnn::SimpleShape object
   //
   emitc::CallOpaqueOp ttnnShapeOp = rewriter.create<emitc::CallOpaqueOp>(
-      loc, emitc::OpaqueType::get(rewriter.getContext(), "ttnn::Shape"),
-      rewriter.getStringAttr("ttnn::Shape"), nullptr, nullptr,
+      loc, emitc::OpaqueType::get(rewriter.getContext(), "ttnn::SimpleShape"),
+      rewriter.getStringAttr("ttnn::SimpleShape"), nullptr, nullptr,
       metalShapeOp->getResults());
   rewriter.create<emitc::YieldOp>(loc, ttnnShapeOp->getResult(0));
 

--- a/lib/OpModel/TTNN/MetalHeaders.h
+++ b/lib/OpModel/TTNN/MetalHeaders.h
@@ -51,6 +51,11 @@
 
 #define FMT_HEADER_ONLY
 
+#include "tt_metal/api/tt-metalium/buffer.hpp"
+#include "tt_metal/api/tt-metalium/buffer_constants.hpp"
+#include "tt_metal/api/tt-metalium/core_coord.hpp"
+#include "tt_metal/api/tt-metalium/device_impl.hpp"
+#include "tt_metal/api/tt-metalium/host_api.hpp"
 #include "ttnn/graph/graph_processor.hpp"
 #include "ttnn/graph/graph_query_op_constraints.hpp"
 #include "ttnn/graph/graph_trace_utils.hpp"
@@ -62,11 +67,6 @@
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/tensor_spec.hpp"
 #include "ttnn/tensor/types.hpp"
-#include <tt-metalium/buffer.hpp>
-#include <tt-metalium/buffer_constants.hpp>
-#include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/device_impl.hpp>
-#include <tt-metalium/host_api.hpp>
 
 #pragma clang diagnostic pop
 

--- a/lib/OpModel/TTNN/MetalHeaders.h
+++ b/lib/OpModel/TTNN/MetalHeaders.h
@@ -51,11 +51,11 @@
 
 #define FMT_HEADER_ONLY
 
-#include "tt_metal/api/tt-metalium/buffer.hpp"
-#include "tt_metal/api/tt-metalium/buffer_constants.hpp"
-#include "tt_metal/api/tt-metalium/core_coord.hpp"
-#include "tt_metal/api/tt-metalium/device_impl.hpp"
-#include "tt_metal/api/tt-metalium/host_api.hpp"
+#include "tt-metalium/buffer.hpp"
+#include "tt-metalium/buffer_constants.hpp"
+#include "tt-metalium/core_coord.hpp"
+#include "tt-metalium/device_impl.hpp"
+#include "tt-metalium/host_api.hpp"
 #include "ttnn/graph/graph_processor.hpp"
 #include "ttnn/graph/graph_query_op_constraints.hpp"
 #include "ttnn/graph/graph_trace_utils.hpp"

--- a/lib/OpModel/TTNN/MetalHeaders.h
+++ b/lib/OpModel/TTNN/MetalHeaders.h
@@ -51,11 +51,6 @@
 
 #define FMT_HEADER_ONLY
 
-#include "host_api.hpp"
-#include "impl/buffers/buffer_constants.hpp"
-#include "tt_metal/common/core_coord.hpp"
-#include "tt_metal/impl/buffers/buffer.hpp"
-#include "tt_metal/impl/device/device.hpp"
 #include "ttnn/graph/graph_processor.hpp"
 #include "ttnn/graph/graph_query_op_constraints.hpp"
 #include "ttnn/graph/graph_trace_utils.hpp"
@@ -67,6 +62,11 @@
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/tensor_spec.hpp"
 #include "ttnn/tensor/types.hpp"
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/buffer_constants.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/device_impl.hpp>
+#include <tt-metalium/host_api.hpp>
 
 #pragma clang diagnostic pop
 

--- a/runtime/include/tt/runtime/detail/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal.h
@@ -6,12 +6,12 @@
 #define TT_RUNTIME_DETAIL_TTMETAL_H
 
 #define FMT_HEADER_ONLY
-#include <tt-metalium/circular_buffer.hpp>
-#include <tt-metalium/event.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/memory_reporter.hpp>
-#include <tt-metalium/mesh_device.hpp>
-#include <tt-metalium/tt_metal.hpp>
+#include "tt-metalium/circular_buffer.hpp"
+#include "tt-metalium/event.hpp"
+#include "tt-metalium/host_api.hpp"
+#include "tt-metalium/memory_reporter.hpp"
+#include "tt-metalium/mesh_device.hpp"
+#include "tt-metalium/tt_metal.hpp"
 
 #include "tt/runtime/types.h"
 #include "tt/runtime/utils.h"

--- a/runtime/include/tt/runtime/detail/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal.h
@@ -6,12 +6,12 @@
 #define TT_RUNTIME_DETAIL_TTMETAL_H
 
 #define FMT_HEADER_ONLY
-#include "distributed/mesh_device.hpp"
-#include "impl/buffers/circular_buffer.hpp"
-#include "impl/event/event.hpp"
-#include "tt_metal/detail/reports/memory_reporter.hpp"
-#include "tt_metal/detail/tt_metal.hpp"
-#include "tt_metal/host_api.hpp"
+#include <tt-metalium/circular_buffer.hpp>
+#include <tt-metalium/event.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/memory_reporter.hpp>
+#include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/tt_metal.hpp>
 
 #include "tt/runtime/types.h"
 #include "tt/runtime/utils.h"

--- a/runtime/include/tt/runtime/detail/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn.h
@@ -7,6 +7,9 @@
 
 #define FMT_HEADER_ONLY
 #include "hostdevcommon/common_values.hpp"
+#include "tt-metalium/host_api.hpp"
+#include "tt-metalium/memory_reporter.hpp"
+#include "tt-metalium/mesh_device.hpp"
 #include "ttnn/device.hpp"
 #include "ttnn/operations/ccl/all_gather/all_gather.hpp"
 #include "ttnn/operations/conv/conv2d/conv2d.hpp"
@@ -33,9 +36,6 @@
 #include "ttnn/tensor/shape/shape.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/types.hpp"
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/memory_reporter.hpp>
-#include <tt-metalium/mesh_device.hpp>
 
 #include "tt/runtime/types.h"
 #include "ttmlir/Target/TTNN/Target.h"

--- a/runtime/include/tt/runtime/detail/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn.h
@@ -6,10 +6,7 @@
 #define TT_RUNTIME_DETAIL_TTNN_H
 
 #define FMT_HEADER_ONLY
-#include "distributed/mesh_device.hpp"
-#include "host_api.hpp"
 #include "hostdevcommon/common_values.hpp"
-#include "tt_metal/detail/reports/memory_reporter.hpp"
 #include "ttnn/device.hpp"
 #include "ttnn/operations/ccl/all_gather/all_gather.hpp"
 #include "ttnn/operations/conv/conv2d/conv2d.hpp"
@@ -36,6 +33,9 @@
 #include "ttnn/tensor/shape/shape.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/types.hpp"
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/memory_reporter.hpp>
+#include <tt-metalium/mesh_device.hpp>
 
 #include "tt/runtime/types.h"
 #include "ttmlir/Target/TTNN/Target.h"

--- a/runtime/lib/common/system_desc.cpp
+++ b/runtime/lib/common/system_desc.cpp
@@ -11,11 +11,11 @@
 #include <vector>
 
 #define FMT_HEADER_ONLY
-#include "distributed/mesh_device.hpp"
 #include "eth_l1_address_map.h"
-#include "host_api.hpp"
 #include "hostdevcommon/common_values.hpp"
 #include "noc/noc_parameters.h"
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/mesh_device.hpp>
 
 namespace tt::runtime::system_desc {
 static ::tt::target::Dim2d toFlatbuffer(const CoreCoord &coreCoord) {

--- a/runtime/lib/common/system_desc.cpp
+++ b/runtime/lib/common/system_desc.cpp
@@ -14,8 +14,8 @@
 #include "eth_l1_address_map.h"
 #include "hostdevcommon/common_values.hpp"
 #include "noc/noc_parameters.h"
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/mesh_device.hpp>
+#include "tt-metalium/host_api.hpp"
+#include "tt-metalium/mesh_device.hpp"
 
 namespace tt::runtime::system_desc {
 static ::tt::target::Dim2d toFlatbuffer(const CoreCoord &coreCoord) {

--- a/runtime/lib/ttnn/operations/creation/empty.cpp
+++ b/runtime/lib/ttnn/operations/creation/empty.cpp
@@ -11,7 +11,7 @@
 
 namespace tt::runtime::ttnn::operations::creation {
 struct EmptyTensorConfig {
-  ::ttnn::Shape shape;
+  ::ttnn::SimpleShape shape;
   ::ttnn::DataType dtype;
   ::ttnn::Layout layout;
   uint32_t numShards;

--- a/runtime/lib/ttnn/operations/creation/full.cpp
+++ b/runtime/lib/ttnn/operations/creation/full.cpp
@@ -11,7 +11,7 @@
 
 namespace tt::runtime::ttnn::operations::creation {
 struct FullTensorConfig {
-  ::ttnn::Shape shape;
+  ::ttnn::SimpleShape shape;
   ::ttnn::DataType dtype;
   ::ttnn::Layout layout;
   float fillValue;

--- a/runtime/lib/ttnn/operations/creation/ones.cpp
+++ b/runtime/lib/ttnn/operations/creation/ones.cpp
@@ -18,8 +18,8 @@ namespace tt::runtime::ttnn::operations::creation {
 void run(const ::tt::target::ttnn::OnesOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
 
-  const ::ttnn::Shape shape = ::ttnn::Shape(::tt::tt_metal::LegacyShape(
-      ::tt::runtime::ttnn::utils::toShapeFromFBShape(*op->shape())));
+  const ::ttnn::SimpleShape shape = ::ttnn::SimpleShape(
+      ::tt::runtime::ttnn::utils::toShapeFromFBShape(*op->shape()));
 
   std::optional<::ttnn::DataType> dtype = std::optional<::ttnn::DataType>();
   std::optional<::ttnn::Layout> layout = std::optional<::ttnn::Layout>();

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -175,7 +175,7 @@ Tensor createTensor(Device device, Layout layout,
   ::ttnn::Tensor tensor = std::visit(
       [&](auto &&device) -> ::ttnn::Tensor {
         return ::ttnn::operations::core::allocate_tensor_on_device(
-            ::ttnn::Shape(shape), layoutDesc.dataType, layoutDesc.layout,
+            ::ttnn::SimpleShape(shape), layoutDesc.dataType, layoutDesc.layout,
             &(device.get()), layoutDesc.memoryConfig);
       },
       targetDevice);

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "eadc98f1c0f714c423fdfc97689afbc50c0dca3b")
+set(TT_METAL_VERSION "a8396fa5071ea9b0d6754c0317b68871c65d3283")
 
 if ("$ENV{ARCH_NAME}" STREQUAL "grayskull")
   set(ARCH_NAME "grayskull")

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -17,9 +17,10 @@ endif()
 
 set(METAL_INSTALL_PREFIX "${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal-build/")
 set(TTMETAL_INCLUDE_DIRS
+  ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/ttnn
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/ttnn/cpp
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/deprecated
-  ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal
+  ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/api
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/include
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/hostdevcommon/api
@@ -30,6 +31,7 @@ set(TTMETAL_INCLUDE_DIRS
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/hw/inc/${ARCH_EXTRA_DIR}
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/umd/src/firmware/riscv/${ARCH_NAME}
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/tracy/public
+  ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/taskflow
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_eager
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal-build/include
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/reflect/e75434c4c5f669e4a74e4d84e0a30d7249c1e66f

--- a/tools/ttnn-standalone/CMakeLists.txt
+++ b/tools/ttnn-standalone/CMakeLists.txt
@@ -65,20 +65,22 @@ set(INCLUDE_DIRS
 
     # Metalium
     $ENV{TT_METAL_HOME}
-    $ENV{TT_METAL_HOME}/tt_metal
-    $ENV{TT_METAL_HOME}/tt_metal/include
+    $ENV{TT_METAL_HOME}/tt_metal/api
     $ENV{TT_METAL_HOME}/tt_metal/hostdevcommon/api
+    $ENV{TT_METAL_HOME}/tt_metal/hw/inc
+    $ENV{TT_METAL_HOME}/tt_metal/hw/inc/${ARCH_EXTRA_DIR}
+    $ENV{TT_METAL_HOME}/tt_metal/hw/inc/${ARCH_NAME}
+    $ENV{TT_METAL_HOME}/tt_metal/include
+    $ENV{TT_METAL_HOME}/tt_metal/third_party/fmt
+    $ENV{TT_METAL_HOME}/tt_metal/third_party/magic_enum
+    $ENV{TT_METAL_HOME}/tt_metal/third_party/taskflow
+    $ENV{TT_METAL_HOME}/tt_metal/third_party/tracy/public
     $ENV{TT_METAL_HOME}/tt_metal/third_party/umd
     $ENV{TT_METAL_HOME}/tt_metal/third_party/umd/device/api
-    $ENV{TT_METAL_HOME}/tt_metal/third_party/fmt
-    $ENV{TT_METAL_HOME}/tt_metal/hw/inc
-    $ENV{TT_METAL_HOME}/tt_metal/hw/inc/${ARCH_NAME}
-    $ENV{TT_METAL_HOME}/tt_metal/hw/inc/${ARCH_EXTRA_DIR}
     $ENV{TT_METAL_HOME}/tt_metal/third_party/umd/src/firmware/riscv/${ARCH_NAME}
-    $ENV{TT_METAL_HOME}/tt_metal/third_party/magic_enum
-    $ENV{TT_METAL_HOME}/tt_metal/third_party/tracy/public
 
     # TTNN
+    $ENV{TT_METAL_HOME}/ttnn
     $ENV{TT_METAL_HOME}/ttnn/cpp
     $ENV{TT_METAL_HOME}/ttnn/cpp/ttnn
     $ENV{TT_METAL_HOME}/ttnn/cpp/ttnn/deprecated

--- a/tools/ttnn-standalone/ttnn-dylib.cpp
+++ b/tools/ttnn-standalone/ttnn-dylib.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+
 template <typename... T>
 std::vector<ttnn::Tensor> utilCreateVec(T &&...t) {
   return std::vector<ttnn::Tensor>{std::forward<T>(t)...};
@@ -19,10 +20,35 @@ std::vector<ttnn::Tensor> add(std::vector<ttnn::Tensor> v1, ttnn::IDevice* v2) {
   ttnn::Tensor v9 = ttnn::to_device(v4, v2, v8);
   ttnn::Tensor v10 = ttnn::to_layout(v9, ttnn::Layout::TILE, std::nullopt, std::nullopt, static_cast<::ttnn::IDevice *>(nullptr));
   ttnn::deallocate(v9, false);
-  ttnn::Shape v11 = ttnn::Shape(tt::tt_metal::LegacyShape({32, 32, }));
+  ttnn::SimpleShape v11 = ttnn::SimpleShape(tt::tt_metal::LegacyShape({32, 32, }));
   ttnn::MemoryConfig v12 = ttnn::MemoryConfig(ttnn::TensorMemoryLayout::INTERLEAVED, ttnn::BufferType::DRAM);
   ttnn::Tensor v13 = ttnn::empty(v11, ttnn::DataType::BFLOAT16, ttnn::Layout::TILE, v2, v12);
   ttnn::Tensor v14 = ttnn::add(v7, v10, std::nullopt, std::nullopt, v13);
+  ttnn::deallocate(v10, false);
+  ttnn::deallocate(v7, false);
+  ttnn::Tensor v15 = ttnn::from_device(v14);
+  ttnn::deallocate(v13, false);
+  ttnn::Tensor v16 = ttnn::to_layout(v15, ttnn::Layout::ROW_MAJOR, std::nullopt, std::nullopt, static_cast<::ttnn::IDevice *>(nullptr));
+  ttnn::deallocate(v15, false);
+  std::vector<ttnn::Tensor> v17 = utilCreateVec(v16);
+  return v17;
+}
+
+std::vector<ttnn::Tensor> subtract(std::vector<ttnn::Tensor> v1, ttnn::IDevice* v2) {
+  ttnn::Tensor v3 = v1[0];
+  ttnn::Tensor v4 = v1[1];
+  ttnn::MemoryConfig v5 = ttnn::MemoryConfig(ttnn::TensorMemoryLayout::INTERLEAVED, ttnn::BufferType::DRAM);
+  ttnn::Tensor v6 = ttnn::to_device(v3, v2, v5);
+  ttnn::Tensor v7 = ttnn::to_layout(v6, ttnn::Layout::TILE, std::nullopt, std::nullopt, static_cast<::ttnn::IDevice *>(nullptr));
+  ttnn::deallocate(v6, false);
+  ttnn::MemoryConfig v8 = ttnn::MemoryConfig(ttnn::TensorMemoryLayout::INTERLEAVED, ttnn::BufferType::DRAM);
+  ttnn::Tensor v9 = ttnn::to_device(v4, v2, v8);
+  ttnn::Tensor v10 = ttnn::to_layout(v9, ttnn::Layout::TILE, std::nullopt, std::nullopt, static_cast<::ttnn::IDevice *>(nullptr));
+  ttnn::deallocate(v9, false);
+  ttnn::SimpleShape v11 = ttnn::SimpleShape(tt::tt_metal::LegacyShape({32, 32, }));
+  ttnn::MemoryConfig v12 = ttnn::MemoryConfig(ttnn::TensorMemoryLayout::INTERLEAVED, ttnn::BufferType::DRAM);
+  ttnn::Tensor v13 = ttnn::empty(v11, ttnn::DataType::BFLOAT16, ttnn::Layout::TILE, v2, v12);
+  ttnn::Tensor v14 = ttnn::subtract(v7, v10, std::nullopt, std::nullopt, v13);
   ttnn::deallocate(v10, false);
   ttnn::deallocate(v7, false);
   ttnn::Tensor v15 = ttnn::from_device(v14);

--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -5,7 +5,6 @@
 #ifndef TOOLS_TTNN_STANDALONE_TTNN_PRECOMPILED_HPP
 #define TOOLS_TTNN_STANDALONE_TTNN_PRECOMPILED_HPP
 
-#include "common/bfloat16.hpp"
 #include "core.hpp"
 #include "device.hpp"
 #include "operations/core/core.hpp"
@@ -17,6 +16,7 @@
 #include "tensor/tensor.hpp"
 #include "tensor/types.hpp"
 #include "types.hpp"
+#include <tt-metalium/bfloat16.hpp>
 
 #include <cstddef>
 #include <iostream>

--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -15,8 +15,8 @@
 #include "operations/matmul/matmul.hpp"
 #include "tensor/tensor.hpp"
 #include "tensor/types.hpp"
+#include "tt-metalium/bfloat16.hpp"
 #include "types.hpp"
-#include <tt-metalium/bfloat16.hpp>
 
 #include <cstddef>
 #include <iostream>

--- a/tools/ttnn-standalone/ttnn-standalone.cpp
+++ b/tools/ttnn-standalone/ttnn-standalone.cpp
@@ -25,10 +25,10 @@ ttnn::Tensor forward(ttnn::Tensor v1, ttnn::Tensor v2) {
       ttnn::to_layout(v8, ttnn::Layout::TILE, std::nullopt, std::nullopt,
                       static_cast<::ttnn::IDevice *>(nullptr));
   ttnn::deallocate(v8, false);
-  ttnn::Shape v10 = ttnn::Shape(tt::tt_metal::LegacyShape({
+  ttnn::SimpleShape v10 = ttnn::SimpleShape({
       32,
       32,
-  }));
+  });
   ttnn::MemoryConfig v11 = ttnn::MemoryConfig(
       ttnn::TensorMemoryLayout::INTERLEAVED, ttnn::BufferType::DRAM);
   ttnn::Tensor v12 =
@@ -50,10 +50,10 @@ int main() {
   //
   const size_t tensor_height = 32;
   const size_t tensor_width = 32;
-  ttnn::Shape xs =
-      ttnn::Shape(tt::tt_metal::LegacyShape{1, 1, tensor_height, tensor_width});
-  ttnn::Shape ys =
-      ttnn::Shape(tt::tt_metal::LegacyShape{1, 1, tensor_height, tensor_width});
+  ttnn::SimpleShape xs =
+      ttnn::SimpleShape({1, 1, tensor_height, tensor_width});
+  ttnn::SimpleShape ys =
+      ttnn::SimpleShape({1, 1, tensor_height, tensor_width});
 
   // Create tensors on cpu
   //


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the a8396fa5071ea9b0d6754c0317b68871c65d3283

- Update header include paths for tt-metal public API reorg at fa45b9b1a1
   - cpp/hpp/h include updates from running script from afuller
     'git ls-files '*.cpp' '*.hpp' '*.h' | xargs sed -Ef reorg-api.consumer.sed -i'
   - Modify include paths to pick up metal headers, can remove root
   third_party/tt-metal/src/tt-metal include dir not needed anymore.
- Use SimpleShape instead of legacy shape following metal change at 80c4aac