### PR TITLE
Add codeowners for ttnn-standalone

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,3 +34,4 @@
 /test/unittests/OpModel @odjuricicTT @tt-mpantic @sdjordjevicTT @nobradovictt
 /tools/ @svuckovicTT @mtopalovicTT
 /tools/explorer/ @odjuricicTT @tt-mpantic @sdjordjevicTT @nobradovictt @vprajapati-tt @vcanicTT
+/tools/ttnn-standalone @svuckovicTT @mtopalovicTT @sdjordjevicTT @azecevicTT @jserbedzijaTT


### PR DESCRIPTION
Adding dialect folks as owners of `tools/ttnn-standalone`.