### PR TITLE
Interface for DPS op creation

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -1802,6 +1802,7 @@ def TTIR_ScatterOp: TTIR_DPSOp<"scatter"> {
   let arguments = (ins AnyRankedTensor:$input,
                        AnyRankedTensor:$scatter_indices,
                        AnyRankedTensor:$update,
+                       AnyRankedTensor:$output,
                        DenseI32ArrayAttr:$update_window_dims,
                        DenseI32ArrayAttr:$inserted_window_dims,
                        DenseI32ArrayAttr:$input_batching_dims,
@@ -1809,8 +1810,7 @@ def TTIR_ScatterOp: TTIR_DPSOp<"scatter"> {
                        DenseI32ArrayAttr:$scatter_dims_to_operand_dims,
                        I32Attr:$index_vector_dim,
                        BoolAttr:$indices_are_sorted,
-                       BoolAttr:$unique_indices,
-                       AnyRankedTensor:$output);
+                       BoolAttr:$unique_indices);
 
   let regions = (region SizedRegion<1>:$update_computation);
 

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -480,6 +480,10 @@ class TTIR_ElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
       OpBuilder<(ins "Value": $lhs, "Value": $rhs, "Value": $out),
       [{
         build($_builder, $_state, {out.getType()}, {lhs, rhs}, out);
+      }]>,
+      OpBuilder<(ins "Type":$outputType, "Value": $lhs, "Value": $rhs, "Value": $out),
+      [{
+        build($_builder, $_state, {outputType}, {lhs, rhs}, out);
       }]>
     ];
 }

--- a/include/ttmlir/Utils.h
+++ b/include/ttmlir/Utils.h
@@ -5,19 +5,15 @@
 #ifndef TTMLIR_UTILS_H
 #define TTMLIR_UTILS_H
 
-#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
-
 #include "mlir-c/IR.h"
 #include "mlir/CAPI/IR.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/AffineMap.h"
 #include "mlir/IR/BuiltinAttributes.h"
-#include "mlir/IR/PatternMatch.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/Error.h"
 
-#include <cstddef>
 #include <cstdint>
 #include <type_traits>
 

--- a/include/ttmlir/Utils.h
+++ b/include/ttmlir/Utils.h
@@ -16,6 +16,7 @@
 #include "llvm/Support/Error.h"
 
 #include <cstdint>
+#include <utility>
 
 namespace ttmlir::utils {
 template <typename T>
@@ -270,6 +271,54 @@ OpTy createDPSOp(mlir::PatternRewriter &rewriter, mlir::Location loc,
   auto outputType =
       mlir::RankedTensorType::get(outputShape, outputElementType, encoding);
   return createDPSOp<OpTy>(rewriter, loc, outputType, input,
+                           std::forward<AttributeTy>(attrs)...);
+}
+
+template <typename OpTy, typename... AttributeTy>
+OpTy createDPSOp(mlir::PatternRewriter &rewriter, mlir::Location loc,
+                 mlir::RankedTensorType outputType, mlir::Value lhs,
+                 mlir::Value rhs, AttributeTy &&...attrs) {
+  auto DPSOutput = rewriter.create<mlir::tensor::EmptyOp>(
+      loc, outputType.getShape(), outputType.getElementType(),
+      outputType.getEncoding());
+
+  return rewriter.create<OpTy>(loc, outputType, lhs, rhs, DPSOutput,
+                               std::forward<AttributeTy>(attrs)...);
+}
+
+template <typename OpTy, typename... AttributeTy>
+OpTy createDPSOp(mlir::PatternRewriter &rewriter, mlir::Location loc,
+                 llvm::ArrayRef<int64_t> outputShape,
+                 mlir::Type outputElementType, mlir::Attribute encoding,
+                 mlir::Value lhs, mlir::Value rhs, AttributeTy &&...attrs) {
+  auto outputType =
+      mlir::RankedTensorType::get(outputShape, outputElementType, encoding);
+  return createDPSOp<OpTy>(rewriter, loc, outputType, lhs, rhs,
+                           std::forward<AttributeTy>(attrs)...);
+}
+
+template <typename OpTy, typename... AttributeTy>
+OpTy createDPSOp(mlir::PatternRewriter &rewriter, mlir::Location loc,
+                 mlir::RankedTensorType outputType, mlir::Value first,
+                 mlir::Value second, mlir::Value third,
+                 AttributeTy &&...attrs) {
+  auto DPSOutput = rewriter.create<mlir::tensor::EmptyOp>(
+      loc, outputType.getShape(), outputType.getElementType(),
+      outputType.getEncoding());
+
+  return rewriter.create<OpTy>(loc, outputType, first, second, third, DPSOutput,
+                               std::forward<AttributeTy>(attrs)...);
+}
+
+template <typename OpTy, typename... AttributeTy>
+OpTy createDPSOp(mlir::PatternRewriter &rewriter, mlir::Location loc,
+                 llvm::ArrayRef<int64_t> outputShape,
+                 mlir::Type outputElementType, mlir::Attribute encoding,
+                 mlir::Value first, mlir::Value second, mlir::Value third,
+                 AttributeTy &&...attrs) {
+  auto outputType =
+      mlir::RankedTensorType::get(outputShape, outputElementType, encoding);
+  return createDPSOp<OpTy>(rewriter, loc, outputType, first, second, third,
                            std::forward<AttributeTy>(attrs)...);
 }
 

--- a/include/ttmlir/Utils.h
+++ b/include/ttmlir/Utils.h
@@ -263,9 +263,11 @@ struct count_consecutive<> {
 
 template <typename First, typename... Rest>
 struct count_consecutive<First, Rest...> {
-  static constexpr size_t value = std::is_convertible_v<First, mlir::Value>
-                                      ? 1 + count_consecutive_v<Rest...>
-                                      : 0;
+  static constexpr size_t value =
+      std::is_convertible_v<First, mlir::Value> ||
+              std::is_convertible_v<First, mlir::ValueRange>
+          ? 1 + count_consecutive_v<Rest...>
+          : 0;
 };
 
 template <typename OpTy, typename IndexSeqFirst, typename IndexSeqRest>

--- a/include/ttmlir/Utils.h
+++ b/include/ttmlir/Utils.h
@@ -16,7 +16,6 @@
 #include "llvm/Support/Error.h"
 
 #include <cstdint>
-#include <utility>
 
 namespace ttmlir::utils {
 template <typename T>
@@ -251,75 +250,102 @@ getPairOfInteger(mlir::Attribute attr) {
   return std::make_pair(x, y);
 }
 
-template <typename OpTy, typename... AttributeTy>
+template <typename... Args>
+struct count_consecutive;
+
+template <typename... Args>
+inline constexpr size_t count_consecutive_v = count_consecutive<Args...>::value;
+
+template <>
+struct count_consecutive<> {
+  static constexpr size_t value = 0;
+};
+
+template <typename First, typename... Rest>
+struct count_consecutive<First, Rest...> {
+  static constexpr size_t value = std::is_convertible_v<First, mlir::Value>
+                                      ? 1 + count_consecutive_v<Rest...>
+                                      : 0;
+};
+
+template <typename OpTy, typename IndexSeqFirst, typename IndexSeqRest>
+struct SplitCaller;
+
+template <typename OpTy, size_t... Is, size_t... Js>
+struct SplitCaller<OpTy, std::index_sequence<Is...>,
+                   std::index_sequence<Js...>> {
+  template <typename... Args>
+  static auto call(mlir::PatternRewriter &rewriter, mlir::Location loc,
+                   mlir::Value output, Args &&...args) {
+    return rewriter.create<OpTy>(
+        loc, output.getType(),
+        std::get<Is>(std::forward_as_tuple(std::forward<Args>(args)...))...,
+        output,
+        std::get<sizeof...(Is) + Js>(
+            std::forward_as_tuple(std::forward<Args>(args)...))...);
+  }
+};
+
+template <typename OpTy, size_t OperandCount, size_t AttributeCount>
+struct SplitImpl {
+  template <typename... Args>
+  static auto call(mlir::PatternRewriter &rewriter, mlir::Location loc,
+                   mlir::Value dpsOutput, Args &&...args) {
+    return SplitCaller<OpTy, std::make_index_sequence<OperandCount>,
+                       std::make_index_sequence<AttributeCount>>::
+        call(rewriter, loc, dpsOutput, std::forward<Args>(args)...);
+  }
+};
+
+template <typename OpTy, typename... Args>
+auto splitAndCall(mlir::PatternRewriter &rewriter, mlir::Location loc,
+                  mlir::Value output, Args &&...args) {
+  constexpr size_t count = count_consecutive_v<Args...>;
+
+  return SplitImpl<OpTy, count, sizeof...(Args) - count>::call(
+      rewriter, loc, output, std::forward<Args>(args)...);
+}
+
+template <typename OpTy, typename... Args>
 OpTy createDPSOp(mlir::PatternRewriter &rewriter, mlir::Location loc,
-                 mlir::RankedTensorType outputType, mlir::Value input,
-                 AttributeTy &&...attrs) {
-  auto DPSOutput = rewriter.create<mlir::tensor::EmptyOp>(
+                 mlir::RankedTensorType outputType, Args &&...args) {
+  auto output = rewriter.create<mlir::tensor::EmptyOp>(
       loc, outputType.getShape(), outputType.getElementType(),
       outputType.getEncoding());
 
-  return rewriter.create<OpTy>(loc, outputType, input, DPSOutput,
-                               std::forward<AttributeTy>(attrs)...);
+  return splitAndCall<OpTy>(rewriter, loc, output, std::forward<Args>(args)...);
 }
 
-template <typename OpTy, typename... AttributeTy>
+template <typename OpTy, typename... Args>
 OpTy createDPSOp(mlir::PatternRewriter &rewriter, mlir::Location loc,
                  llvm::ArrayRef<int64_t> outputShape,
-                 mlir::Type outputElementType, mlir::Attribute encoding,
-                 mlir::Value input, AttributeTy &&...attrs) {
-  auto outputType =
-      mlir::RankedTensorType::get(outputShape, outputElementType, encoding);
-  return createDPSOp<OpTy>(rewriter, loc, outputType, input,
-                           std::forward<AttributeTy>(attrs)...);
+                 mlir::Type outputElementType, mlir::Attribute outputEncoding,
+                 Args &&...args) {
+  auto outputType = mlir::RankedTensorType::get(outputShape, outputElementType,
+                                                outputEncoding);
+  return createDPSOp<OpTy>(rewriter, loc, outputType,
+                           std::forward<Args>(args)...);
 }
 
-template <typename OpTy, typename... AttributeTy>
-OpTy createDPSOp(mlir::PatternRewriter &rewriter, mlir::Location loc,
-                 mlir::RankedTensorType outputType, mlir::Value lhs,
-                 mlir::Value rhs, AttributeTy &&...attrs) {
-  auto DPSOutput = rewriter.create<mlir::tensor::EmptyOp>(
-      loc, outputType.getShape(), outputType.getElementType(),
-      outputType.getEncoding());
-
-  return rewriter.create<OpTy>(loc, outputType, lhs, rhs, DPSOutput,
-                               std::forward<AttributeTy>(attrs)...);
+template <typename OpTy, typename... Args>
+OpTy replaceOpWithNewDPSOp(mlir::PatternRewriter &rewriter, mlir::Operation *op,
+                           mlir::RankedTensorType outputType, Args &&...args) {
+  auto newOp = createDPSOp<OpTy>(rewriter, op->getLoc(), outputType,
+                                 std::forward<Args>(args)...);
+  rewriter.replaceOp(op, newOp.getOperation());
+  return newOp;
 }
 
-template <typename OpTy, typename... AttributeTy>
-OpTy createDPSOp(mlir::PatternRewriter &rewriter, mlir::Location loc,
-                 llvm::ArrayRef<int64_t> outputShape,
-                 mlir::Type outputElementType, mlir::Attribute encoding,
-                 mlir::Value lhs, mlir::Value rhs, AttributeTy &&...attrs) {
-  auto outputType =
-      mlir::RankedTensorType::get(outputShape, outputElementType, encoding);
-  return createDPSOp<OpTy>(rewriter, loc, outputType, lhs, rhs,
-                           std::forward<AttributeTy>(attrs)...);
-}
-
-template <typename OpTy, typename... AttributeTy>
-OpTy createDPSOp(mlir::PatternRewriter &rewriter, mlir::Location loc,
-                 mlir::RankedTensorType outputType, mlir::Value first,
-                 mlir::Value second, mlir::Value third,
-                 AttributeTy &&...attrs) {
-  auto DPSOutput = rewriter.create<mlir::tensor::EmptyOp>(
-      loc, outputType.getShape(), outputType.getElementType(),
-      outputType.getEncoding());
-
-  return rewriter.create<OpTy>(loc, outputType, first, second, third, DPSOutput,
-                               std::forward<AttributeTy>(attrs)...);
-}
-
-template <typename OpTy, typename... AttributeTy>
-OpTy createDPSOp(mlir::PatternRewriter &rewriter, mlir::Location loc,
-                 llvm::ArrayRef<int64_t> outputShape,
-                 mlir::Type outputElementType, mlir::Attribute encoding,
-                 mlir::Value first, mlir::Value second, mlir::Value third,
-                 AttributeTy &&...attrs) {
-  auto outputType =
-      mlir::RankedTensorType::get(outputShape, outputElementType, encoding);
-  return createDPSOp<OpTy>(rewriter, loc, outputType, first, second, third,
-                           std::forward<AttributeTy>(attrs)...);
+template <typename OpTy, typename... Args>
+OpTy replaceOpWithNewDPSOp(mlir::PatternRewriter &rewriter, mlir::Operation *op,
+                           llvm::ArrayRef<int64_t> outputShape,
+                           mlir::Type outputElementType,
+                           mlir::Attribute outputEncoding, Args &&...args) {
+  auto newOp =
+      createDPSOp<OpTy>(rewriter, op->getLoc(), outputShape, outputElementType,
+                        outputEncoding, std::forward<Args>(args)...);
+  rewriter.replaceOp(op, newOp.getOperation());
+  return newOp;
 }
 
 } // namespace ttmlir::utils

--- a/include/ttmlir/Utils.h
+++ b/include/ttmlir/Utils.h
@@ -5,6 +5,8 @@
 #ifndef TTMLIR_UTILS_H
 #define TTMLIR_UTILS_H
 
+#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
+
 #include "mlir-c/IR.h"
 #include "mlir/CAPI/IR.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
@@ -264,8 +266,10 @@ struct count_consecutive<> {
 template <typename First, typename... Rest>
 struct count_consecutive<First, Rest...> {
   static constexpr size_t value =
-      std::is_convertible_v<First, mlir::Value> ||
-              std::is_convertible_v<First, mlir::ValueRange>
+      (std::is_convertible_v<First, mlir::Value> ||
+       std::is_convertible_v<First, mlir::ValueRange>) &&
+              !std::is_convertible_v<First,
+                                     mlir::TypedValue<mlir::tt::DeviceType>>
           ? 1 + count_consecutive_v<Rest...>
           : 0;
 };

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -448,7 +448,7 @@ public:
 
     ttmlir::utils::replaceOpWithNewDPSOp<mlir::tt::ttir::ConvolutionOp>(
         rewriter, srcOp, outputType, adaptor.getLhs(), adaptor.getRhs(),
-        nullptr, windowStridesAttr, paddingAttr, inputDilationAttr,
+        Value(), windowStridesAttr, paddingAttr, inputDilationAttr,
         kernelDilationAttr, windowReversalAttr,
         mlir::tt::ttir::ConvolutionLayoutAttr::get(
             getContext(), dimNums.getInputBatchDimension(),

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -3,9 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cmath>
-#include <cstdint>
 #include <limits>
-#include <llvm/ADT/SmallVector.h>
 #include <vector>
 
 #include "mlir/Dialect/Traits.h"

--- a/lib/Conversion/TTIRToLinalg/TTIRToLinalg.cpp
+++ b/lib/Conversion/TTIRToLinalg/TTIRToLinalg.cpp
@@ -16,6 +16,7 @@
 #include "mlir/IR/ValueRange.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "ttmlir/Utils.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/ErrorHandling.h"

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -1152,15 +1152,9 @@ public:
 
     assert(!slices.empty());
     if (slices.size() > 1) {
-      // TODO (azecevic): ValueRange
-      auto concatDpsResult = rewriter.create<tensor::EmptyOp>(
-          op.getLoc(), outputType.getShape(), outputType.getElementType());
-
-      auto concatOp = rewriter.create<ttir::ConcatOp>(
-          op.getLoc(), outputType, slices, concatDpsResult,
-          rewriter.getSI32IntegerAttr(dim));
-
-      rewriter.replaceOp(op, concatOp.getResult());
+      auto concatOp = ttmlir::utils::createDPSOp<ttir::ConcatOp>(
+          rewriter, op.getLoc(), outputType, slices, dim);
+      rewriter.replaceOp(op, concatOp);
     } else {
       rewriter.replaceOp(op, slices[0]);
     }

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -277,7 +277,7 @@ public:
 
     auto new2dConvolutionOp = ttmlir::utils::createDPSOp<ttir::ConvolutionOp>(
         rewriter, op.getLoc(), conv2dOutputShape, outputType.getElementType(),
-        outputType.getEncoding(), reshapeInput, reshapeWeight, nullptr,
+        outputType.getEncoding(), reshapeInput, reshapeWeight, Value(),
         conv2dOpWindowsStridesAttr, conv2dOpPaddingAttr,
         conv2dOpInputDilationAttr, conv2dOpWeightDilationAttr,
         conv2dOpWindowReversalAttr,

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -223,12 +223,8 @@ public:
     auto outputType =
         mlir::cast<RankedTensorType>(adaptor.getOutput().getType());
     llvm::ArrayRef<int64_t> outputShape = outputType.getShape();
-    llvm::SmallVector<int64_t, 4> conv2dOutputShape(outputShape.begin(),
-                                                    outputShape.end());
+    llvm::SmallVector<int64_t> conv2dOutputShape(outputShape);
     conv2dOutputShape.push_back(1);
-    auto DPSConv2dOutput = rewriter.create<tensor::EmptyOp>(
-        op->getLoc(), conv2dOutputShape, outputType.getElementType());
-    RankedTensorType conv2dOutputType = DPSConv2dOutput.getType();
 
     auto inputType = mlir::cast<RankedTensorType>(adaptor.getInput().getType());
     llvm::ArrayRef<int64_t> inputShape = inputType.getShape();
@@ -244,9 +240,9 @@ public:
     reshapeWeightShape.push_back(1);
 
     ttir::ReshapeOp reshapeInput = createReshapeOp(
-        op.getLoc(), adaptor.getInput(), reshapeInputShape, rewriter);
+        rewriter, op.getLoc(), adaptor.getInput(), reshapeInputShape);
     ttir::ReshapeOp reshapeWeight = createReshapeOp(
-        op.getLoc(), adaptor.getWeight(), reshapeWeightShape, rewriter);
+        rewriter, op.getLoc(), adaptor.getWeight(), reshapeWeightShape);
 
     mlir::DenseI64ArrayAttr conv2dOpWindowsStridesAttr =
         addIntegerToDenseArrayAttr(rewriter, adaptor.getWindowStridesAttr(), 1);
@@ -267,41 +263,38 @@ public:
 
     // The additional spatial dimension is added at the and (3rd in 0 indexed
     // array).
-    llvm::SmallVector<int64_t, 4> conv2dInputSpatialDimensions(
-        convolutionLayout.getInputSpatialDimensions().begin(),
-        convolutionLayout.getInputSpatialDimensions().end());
+    llvm::SmallVector<int64_t> conv2dInputSpatialDimensions(
+        convolutionLayout.getInputSpatialDimensions());
     conv2dInputSpatialDimensions.push_back(3);
 
-    llvm::SmallVector<int64_t, 4> conv2dKernelSpatialDimensions(
-        convolutionLayout.getKernelSpatialDimensions().begin(),
-        convolutionLayout.getKernelSpatialDimensions().end());
+    llvm::SmallVector<int64_t> conv2dKernelSpatialDimensions(
+        convolutionLayout.getKernelSpatialDimensions());
     conv2dKernelSpatialDimensions.push_back(3);
 
-    llvm::SmallVector<int64_t, 4> conv2dOutputSpatialDimensions(
-        convolutionLayout.getOutputSpatialDimensions().begin(),
-        convolutionLayout.getOutputSpatialDimensions().end());
+    llvm::SmallVector<int64_t> conv2dOutputSpatialDimensions(
+        convolutionLayout.getOutputSpatialDimensions());
     conv2dOutputSpatialDimensions.push_back(3);
 
-    mlir::tt::ttir::ConvolutionOp new2dConvolutionOp =
-        rewriter.create<mlir::tt::ttir::ConvolutionOp>(
-            op.getLoc(), conv2dOutputType, reshapeInput, reshapeWeight,
-            mlir::Value(nullptr), DPSConv2dOutput, conv2dOpWindowsStridesAttr,
-            conv2dOpPaddingAttr, conv2dOpInputDilationAttr,
-            conv2dOpWeightDilationAttr, conv2dOpWindowReversalAttr,
-            mlir::tt::ttir::ConvolutionLayoutAttr::get(
-                getContext(), convolutionLayout.getInputBatchDimension(),
-                convolutionLayout.getInputFeatureDimension(),
-                conv2dInputSpatialDimensions,
-                convolutionLayout.getKernelOutputFeatureDimension(),
-                convolutionLayout.getKernelInputFeatureDimension(),
-                conv2dKernelSpatialDimensions,
-                convolutionLayout.getOutputBatchDimension(),
-                convolutionLayout.getOutputFeatureDimension(),
-                conv2dOutputSpatialDimensions),
-            adaptor.getFeatureGroupCountAttr(),
-            adaptor.getBatchGroupCountAttr());
+    auto new2dConvolutionOp = ttmlir::utils::createDPSOp<ttir::ConvolutionOp>(
+        rewriter, op.getLoc(), conv2dOutputShape, outputType.getElementType(),
+        outputType.getEncoding(), Value(reshapeInput), Value(reshapeWeight),
+        Value(), conv2dOpWindowsStridesAttr, conv2dOpPaddingAttr,
+        conv2dOpInputDilationAttr, conv2dOpWeightDilationAttr,
+        conv2dOpWindowReversalAttr,
+        mlir::tt::ttir::ConvolutionLayoutAttr::get(
+            getContext(), convolutionLayout.getInputBatchDimension(),
+            convolutionLayout.getInputFeatureDimension(),
+            conv2dInputSpatialDimensions,
+            convolutionLayout.getKernelOutputFeatureDimension(),
+            convolutionLayout.getKernelInputFeatureDimension(),
+            conv2dKernelSpatialDimensions,
+            convolutionLayout.getOutputBatchDimension(),
+            convolutionLayout.getOutputFeatureDimension(),
+            conv2dOutputSpatialDimensions),
+        adaptor.getFeatureGroupCountAttr(), adaptor.getBatchGroupCountAttr());
+
     ttir::ReshapeOp reshapeOutput =
-        createReshapeOp(op.getLoc(), new2dConvolutionOp, outputShape, rewriter);
+        createReshapeOp(rewriter, op.getLoc(), new2dConvolutionOp, outputShape);
 
     rewriter.replaceOp(op, reshapeOutput);
 
@@ -309,23 +302,16 @@ public:
   }
 
 private:
-  ttir::ReshapeOp createReshapeOp(Location loc, Value tensor,
-                                  llvm::ArrayRef<int64_t> target_input_shape,
-                                  ConversionPatternRewriter &rewriter) const {
-    auto inputType = mlir::cast<RankedTensorType>(tensor.getType());
+  ttir::ReshapeOp createReshapeOp(PatternRewriter &rewriter, Location loc,
+                                  Value input,
+                                  ::llvm::ArrayRef<int64_t> targetShape) const {
+    auto inputType = mlir::cast<mlir::RankedTensorType>(input.getType());
+    auto shapeAttr =
+        rewriter.getI32ArrayAttr(llvm::SmallVector<int32_t>(targetShape));
 
-    auto DPSReshapeOutput = rewriter.create<tensor::EmptyOp>(
-        loc, llvm::ArrayRef<int64_t>(target_input_shape),
-        inputType.getElementType());
-    llvm::SmallVector<int32_t, 2> shapei32(target_input_shape.begin(),
-                                           target_input_shape.end());
-    auto shape_attr = rewriter.getI32ArrayAttr(shapei32);
-
-    return rewriter.create<ttir::ReshapeOp>(
-        loc,
-        mlir::RankedTensorType::get(target_input_shape,
-                                    inputType.getElementType()),
-        tensor, DPSReshapeOutput, shape_attr);
+    return ttmlir::utils::createDPSOp<ttir::ReshapeOp>(
+        rewriter, loc, targetShape, inputType.getElementType(),
+        inputType.getEncoding(), input, shapeAttr);
   }
 
   mlir::DenseI64ArrayAttr
@@ -394,6 +380,7 @@ public:
     auto paddingMatrix =
         getPaddingMatrix<NUM_SPATIAL_DIMS>(adaptor.getPadding());
     auto paddingTopAttr =
+        // paddingMatrix[SPATIAL_DIM_HEIGHT][0];
         rewriter.getSI32IntegerAttr(paddingMatrix[SPATIAL_DIM_HEIGHT][0]);
     auto paddingBottomAttr =
         rewriter.getSI32IntegerAttr(paddingMatrix[SPATIAL_DIM_HEIGHT][1]);
@@ -415,21 +402,16 @@ public:
         outputShape[adaptor.getConvolutionLayout()
                         .getOutputFeatureDimension()]};
 
-    auto inputType = mlir::cast<RankedTensorType>(adaptor.getInput().getType());
-    auto outputType =
-        inputType.cloneWith(newOutputShape, inputType.getElementType());
-
-    auto convDPSOutput = rewriter.create<tensor::EmptyOp>(
-        op.getLoc(), newOutputShape, outputType.getElementType());
+    RankedTensorType inputType =
+        mlir::cast<RankedTensorType>(adaptor.getInput().getType());
+    RankedTensorType outputType = inputType.clone(newOutputShape);
 
     auto permutation = generateConvPermutation(op, conv2dLayout);
     auto permuteOutputShape =
-        ::ttmlir::utils::applyPermutation(inputType.getShape(), permutation);
-    auto permuteDPSOutput = rewriter.create<tensor::EmptyOp>(
-        op.getLoc(), permuteOutputShape, inputType.getElementType());
-    auto input = rewriter.create<ttir::PermuteOp>(
-        op.getLoc(), permuteDPSOutput.getType(), adaptor.getInput(),
-        permuteDPSOutput, permutation);
+        ttmlir::utils::applyPermutation(inputType.getShape(), permutation);
+    auto input = ttmlir::utils::createDPSOp<ttir::PermuteOp>(
+        rewriter, op.getLoc(), permuteOutputShape, inputType.getElementType(),
+        inputType.getEncoding(), adaptor.getInput(), permutation);
 
     auto weightType =
         mlir::cast<RankedTensorType>(adaptor.getWeight().getType());
@@ -438,16 +420,15 @@ public:
     auto weightOutputShape = ::ttmlir::utils::applyPermutation(
         mlir::cast<RankedTensorType>(adaptor.getWeight().getType()).getShape(),
         kernelPermutation);
-    auto weightDPSOutput = rewriter.create<tensor::EmptyOp>(
-        op.getLoc(), weightOutputShape, weightType.getElementType());
-    auto weight = rewriter.create<ttir::PermuteOp>(
-        op.getLoc(), weightDPSOutput.getType(), adaptor.getWeight(),
-        weightDPSOutput, kernelPermutation);
-    ttir::Conv2dOp newConv = rewriter.create<ttir::Conv2dOp>(
-        op.getLoc(), outputType, input, weight, adaptor.getBias(),
-        convDPSOutput, strideHeightAttr, strideWidthAttr, dilationHeightAttr,
-        dilationWidthAttr, groupsAttr, paddingLeftAttr, paddingRightAttr,
-        paddingTopAttr, paddingBottomAttr);
+    auto weight = ttmlir::utils::createDPSOp<ttir::PermuteOp>(
+        rewriter, op.getLoc(), weightOutputShape, weightType.getElementType(),
+        weightType.getEncoding(), adaptor.getWeight(), kernelPermutation);
+
+    ttir::Conv2dOp newConv = ttmlir::utils::createDPSOp<ttir::Conv2dOp>(
+        rewriter, op.getLoc(), outputType, Value(input), Value(weight),
+        adaptor.getBias(), strideHeightAttr, strideWidthAttr,
+        dilationHeightAttr, dilationWidthAttr, groupsAttr, paddingLeftAttr,
+        paddingRightAttr, paddingTopAttr, paddingBottomAttr);
 
     // Applying the inverse of permutation to the output will restore the
     // tensor to the original layout.
@@ -542,22 +523,6 @@ struct GatherToEmbeddingConversionPattern
     return success();
   }
 
-  ttir::ReshapeOp createReshapeOp(PatternRewriter &rewriter, Location loc,
-                                  Value input,
-                                  ::llvm::ArrayRef<int64_t> shapei64) const {
-
-    // reshape start indices (input) to remove the last dimension
-    auto ty = mlir::cast<RankedTensorType>(input.getType());
-    auto output = rewriter.create<tensor::EmptyOp>(
-        loc, llvm::ArrayRef<int64_t>(shapei64), ty.getElementType());
-    std::vector<int32_t> shapei32(shapei64.begin(), shapei64.end());
-    auto shape_attr = rewriter.getI32ArrayAttr(shapei32);
-
-    return rewriter.create<ttir::ReshapeOp>(
-        loc, mlir::RankedTensorType::get(shapei64, ty.getElementType()), input,
-        output, shape_attr);
-  }
-
   /**
    * Lowers Gather Op into Embedding Op (and applies Reshape Op, if necessary)
    *
@@ -621,6 +586,19 @@ struct GatherToEmbeddingConversionPattern
     rewriter.replaceOp(op, embeddingOp);
 
     return success();
+  }
+
+private:
+  ttir::ReshapeOp createReshapeOp(PatternRewriter &rewriter, Location loc,
+                                  Value input,
+                                  ::llvm::ArrayRef<int64_t> targetShape) const {
+    auto inputType = mlir::cast<mlir::RankedTensorType>(input.getType());
+    auto shapeAttr =
+        rewriter.getI32ArrayAttr(llvm::SmallVector<int32_t>(targetShape));
+
+    return ttmlir::utils::createDPSOp<ttir::ReshapeOp>(
+        rewriter, loc, targetShape, inputType.getElementType(),
+        inputType.getEncoding(), input, shapeAttr);
   }
 };
 } // namespace
@@ -1009,34 +987,27 @@ public:
 
       auto inputPermuteShape =
           ::ttmlir::utils::applyPermutation(inputTy.getShape(), permutation);
-      auto inputDPSOutput = rewriter.create<tensor::EmptyOp>(
-          op.getLoc(), inputPermuteShape, inputTy.getElementType());
-      input = rewriter.create<ttir::PermuteOp>(op.getLoc(),
-                                               inputDPSOutput.getType(), input,
-                                               inputDPSOutput, permutation);
+      input = ttmlir::utils::createDPSOp<ttir::PermuteOp>(
+          rewriter, op.getLoc(), inputPermuteShape, inputTy.getElementType(),
+          inputTy.getEncoding(), input, permutation);
 
       auto outputType = mlir::cast<RankedTensorType>(op.getResult(0).getType());
       auto newOutputShape =
           ::ttmlir::utils::applyPermutation(outputType.getShape(), permutation);
-      auto newOutputType =
-          outputType.cloneWith(newOutputShape, outputType.getElementType());
-      auto outputTensor = rewriter.create<tensor::EmptyOp>(
-          op.getLoc(), newOutputType.getShape(),
-          newOutputType.getElementType());
 
-      auto newPool = rewriter.create<PoolOpType>(
-          op.getLoc(), newOutputType, input, outputTensor, kernelHeightAttr,
-          kernelWidthAttr, strideHeightAttr, strideWidthAttr,
-          dilationHeightAttr, dilationWidthAttr, ceilModeAttr, paddingTopAttr,
-          paddingBottomAttr, paddingLeftAttr, paddingRightAttr);
+      auto newPool = ttmlir::utils::createDPSOp<PoolOpType>(
+          rewriter, op.getLoc(), newOutputShape, outputType.getElementType(),
+          outputType.getEncoding(), input, kernelHeightAttr, kernelWidthAttr,
+          strideHeightAttr, strideWidthAttr, dilationHeightAttr,
+          dilationWidthAttr, ceilModeAttr, paddingTopAttr, paddingBottomAttr,
+          paddingLeftAttr, paddingRightAttr);
 
       // Applying the inverse of permutation to the output will restore the
       // tensor to the original layout.
-      auto reversePoolDPSOuput = rewriter.create<tensor::EmptyOp>(
-          op.getLoc(), outputType.getShape(), outputType.getElementType());
-      Value output = rewriter.create<ttir::PermuteOp>(
-          op.getLoc(), reversePoolDPSOuput.getType(), newPool,
-          reversePoolDPSOuput, inverseOfPermutation);
+      auto output = ttmlir::utils::createDPSOp<ttir::PermuteOp>(
+          rewriter, op.getLoc(), outputType.getShape(),
+          outputType.getElementType(), outputType.getEncoding(), newPool,
+          inverseOfPermutation);
 
       outputs.push_back(output);
     }
@@ -1167,24 +1138,21 @@ public:
       // Make a copy of the input shape and update the dim size.
       llvm::SmallVector<int64_t> resultShape(inputShape);
       resultShape[dim] = newEnd - newBegin;
-      auto resultType =
-          RankedTensorType::get(resultShape, inputType.getElementType());
-
-      auto sliceDpsResult = rewriter.create<tensor::EmptyOp>(
-          op.getLoc(), resultShape, inputType.getElementType());
 
       begins[dim] = newBegin;
       ends[dim] = newEnd;
 
-      auto newOp = rewriter.create<ttir::SliceOp>(
-          op.getLoc(), resultType, adaptor.getInput(), sliceDpsResult,
+      auto newOp = ttmlir::utils::createDPSOp<ttir::SliceOp>(
+          rewriter, op.getLoc(), resultShape, inputType.getElementType(),
+          inputType.getEncoding(), adaptor.getInput(),
           rewriter.getI32ArrayAttr(begins), rewriter.getI32ArrayAttr(ends),
           rewriter.getI32ArrayAttr(steps));
-      slices.push_back(newOp->getResult(0));
+      slices.push_back(newOp);
     }
 
     assert(!slices.empty());
     if (slices.size() > 1) {
+      // TODO (azecevic): ValueRange
       auto concatDpsResult = rewriter.create<tensor::EmptyOp>(
           op.getLoc(), outputType.getShape(), outputType.getElementType());
 
@@ -1267,40 +1235,32 @@ public:
           transposeShape, arangeOutputType.getElementType(),
           arangeOutputType.getEncoding());
 
-      tensor::EmptyOp dpsOutput = rewriter.create<tensor::EmptyOp>(
-          op.getLoc(), transposeShape, transposeType.getElementType());
-
-      output = rewriter.create<ttir::TransposeOp>(
-          op.getLoc(), transposeType, output, dpsOutput,
+      output = ttmlir::utils::createDPSOp<ttir::TransposeOp>(
+          rewriter, op.getLoc(), transposeShape, transposeType.getElementType(),
+          transposeType.getEncoding(), output,
           arangeDimensionNegative + transposeShape.size(),
           arangeOutputType.getRank() - 1);
 
-      outputShape = transposeShape;
+      outputShape = std::move(transposeShape);
     }
 
     // Must match up the rank of the output with the rank of the intended output
     // from the original arange, with the arangeDimension in the correct
     // position
     if (outputType.getRank() != static_cast<int64_t>(outputShape.size())) {
-      std::vector<int32_t> reshapeShape;
+      std::vector<int64_t> reshapeShape;
       for (uint32_t i = 0; i < outputType.getRank(); i++) {
         i == arangeDimension ? reshapeShape.push_back(end)
                              : reshapeShape.push_back(1);
       }
 
-      RankedTensorType reshapeType = RankedTensorType::get(
-          SmallVector<int64_t>(reshapeShape.begin(), reshapeShape.end()),
-          outputType.getElementType(), outputType.getEncoding());
-      tensor::EmptyOp dpsOutput = rewriter.create<tensor::EmptyOp>(
-          op.getLoc(),
-          SmallVector<int64_t>(reshapeShape.begin(), reshapeShape.end()),
-          reshapeType.getElementType());
-      output = rewriter.create<ttir::ReshapeOp>(
-          op.getLoc(), reshapeType, output, dpsOutput,
-          rewriter.getI32ArrayAttr(reshapeShape));
+      output = ttmlir::utils::createDPSOp<ttir::ReshapeOp>(
+          rewriter, op.getLoc(), reshapeShape, outputType.getElementType(),
+          outputType.getEncoding(), output,
+          rewriter.getI32ArrayAttr(llvm::SmallVector<int32_t>(
+              reshapeShape.begin(), reshapeShape.end())));
 
-      outputShape =
-          std::vector<int64_t>(reshapeShape.begin(), reshapeShape.end());
+      outputShape = std::move(reshapeShape);
     }
 
     // Must broadcast the rest of the dimensions

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -277,8 +277,8 @@ public:
 
     auto new2dConvolutionOp = ttmlir::utils::createDPSOp<ttir::ConvolutionOp>(
         rewriter, op.getLoc(), conv2dOutputShape, outputType.getElementType(),
-        outputType.getEncoding(), Value(reshapeInput), Value(reshapeWeight),
-        Value(), conv2dOpWindowsStridesAttr, conv2dOpPaddingAttr,
+        outputType.getEncoding(), reshapeInput, reshapeWeight, nullptr,
+        conv2dOpWindowsStridesAttr, conv2dOpPaddingAttr,
         conv2dOpInputDilationAttr, conv2dOpWeightDilationAttr,
         conv2dOpWindowReversalAttr,
         mlir::tt::ttir::ConvolutionLayoutAttr::get(

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -1251,8 +1251,7 @@ public:
         mlir::cast<mlir::RankedTensorType>(output.getType()).getShape();
 
     SmallVector<int64_t> broadcastShape =
-        ttmlir::utils::getBroadcastDimensions<int64_t>(inputShape,
-                                                        outputShape);
+        ttmlir::utils::getBroadcastDimensions<int64_t>(inputShape, outputShape);
 
     assert(mlir::cast<RankedTensorType>(output.getType()).getShape() ==
                outputType.getShape() &&
@@ -1277,13 +1276,10 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     RankedTensorType reduceOutputType = mlir::cast<RankedTensorType>(
         getTypeConverter()->convertType(op.getResult().getType()));
-    tensor::EmptyOp reduceOutputTensor = rewriter.create<tensor::EmptyOp>(
-        op.getLoc(), reduceOutputType.getShape(),
-        reduceOutputType.getElementType());
 
-    rewriter.replaceOpWithNewOp<mlir::tt::ttir::ProdOp>(
-        op, reduceOutputType, op.getInput(), reduceOutputTensor,
-        op.getKeepDim(), op.getDimArgAttr());
+    ttmlir::utils::replaceOpWithNewDPSOp<ttir::ProdOp>(
+        rewriter, op, reduceOutputType, adaptor.getInput(), op.getKeepDim(),
+        op.getDimArgAttr());
 
     return success();
   }

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -25,7 +25,6 @@
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/DialectConversion.h"
-#include "ttmlir/Utils.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/ErrorHandling.h"

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -1244,12 +1244,8 @@ public:
       // addOp(lhs, negOp(rhs))
 
     } else {
-      Value device = ::ttnn::utils::getOrInsertDevice(rewriter, srcOp);
-      tensor::EmptyOp negEmptyOp = rewriter.create<tensor::EmptyOp>(
-          srcOp.getLoc(), this->getTypeConverter()->convertType(rhsType),
-          device);
-      ttnn::NegOp negOp = rewriter.create<ttnn::NegOp>(
-          srcOp.getLoc(), adaptor.getInputs().back(), negEmptyOp);
+      ttnn::NegOp negOp = ttmlir::utils::createDPSOp<ttnn::NegOp>(
+          rewriter, srcOp.getLoc(), rhsType, adaptor.getInputs().back());
 
       rewriter.replaceOpWithNewOp<ttnn::AddOp>(
           srcOp, adaptor.getInputs().front(), negOp.getResults().front(),

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -1015,20 +1015,12 @@ public:
                                              outputType.getElementType(),
                                              outputType.getEncoding());
 
-    // Using a tensor::EmptyOp so that the rewriter for EmptyOp can handle the
-    // attribute determination.
-    auto convDPSOutput = rewriter.replaceOpWithNewOp<tensor::EmptyOp>(
-        adaptor.getOutput().getDefiningOp(), outputType.getShape(),
-        outputType.getElementType(), outputType.getEncoding());
-
-    // TODO (azecevic): TT_Device is type, so `device` is Value, this isn't
-    // covered under ttmlir::utils::createDPSOp pattern.
-    ttnn::Conv2dOp newConv = rewriter.create<ttnn::Conv2dOp>(
-        op.getLoc(), outputType, flattenedInput, adaptor.getWeight(),
-        adaptor.getBias(), convDPSOutput, device, inChannels, outChannels,
-        batchSize, inputHeight, inputWidth, kernelHeight, kernelWidth,
-        strideHeight, strideWidth, paddingHeight, paddingWidth, dilationHeight,
-        dilationWidth, groups);
+    ttnn::Conv2dOp newConv = ttmlir::utils::createDPSOp<ttnn::Conv2dOp>(
+        rewriter, op.getLoc(), outputType, flattenedInput, adaptor.getWeight(),
+        adaptor.getBias(), device, inChannels, outChannels, batchSize,
+        inputHeight, inputWidth, kernelHeight, kernelWidth, strideHeight,
+        strideWidth, paddingHeight, paddingWidth, dilationHeight, dilationWidth,
+        groups);
 
     Value output =
         ttir_to_ttnn::utils::generateReshape(newConv, outputShape, rewriter);

--- a/lib/Conversion/TosaToTTIR/TosaToTTIRPatterns.cpp
+++ b/lib/Conversion/TosaToTTIR/TosaToTTIRPatterns.cpp
@@ -14,6 +14,7 @@
 #include "ttmlir/Conversion/TosaToTTIR/TosaToTTIR.h"
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+#include "ttmlir/Utils.h"
 
 using namespace mlir;
 using namespace mlir::tt;
@@ -39,13 +40,12 @@ public:
       return legalityResult;
     }
 
-    RankedTensorType outputType =
-        mlir::cast<RankedTensorType>(srcOp.getResult().getType());
-    tensor::EmptyOp outputTensor = rewriter.create<tensor::EmptyOp>(
-        srcOp.getLoc(), outputType.getShape(), outputType.getElementType());
-    rewriter.replaceOpWithNewOp<DestOp>(
-        srcOp, TypeRange(outputTensor.getType()), adaptor.getOperands(),
-        ValueRange(outputTensor));
+    auto outputType = mlir::cast<RankedTensorType>(
+        this->getTypeConverter()->convertType(srcOp.getResult().getType()));
+
+    ttmlir::utils::replaceOpWithNewDPSOp<DestOp>(rewriter, srcOp, outputType,
+                                                 adaptor.getOperands());
+
     return success();
   }
 
@@ -88,15 +88,13 @@ public:
   LogicalResult
   matchAndRewrite(tosa::ClampOp srcOp, tosa::ClampOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    RankedTensorType outputType =
-        mlir::cast<RankedTensorType>(srcOp.getResult().getType());
+    auto outputType = mlir::cast<RankedTensorType>(
+        this->getTypeConverter()->convertType(srcOp.getResult().getType()));
 
-    tensor::EmptyOp outputTensor = rewriter.create<tensor::EmptyOp>(
-        srcOp.getLoc(), outputType.getShape(), outputType.getElementType());
+    ttmlir::utils::replaceOpWithNewDPSOp<ttir::ClampOp>(
+        rewriter, srcOp, outputType, adaptor.getInput(), adaptor.getMinFp(),
+        adaptor.getMaxFp());
 
-    rewriter.replaceOpWithNewOp<mlir::tt::ttir::ClampOp>(
-        srcOp, TypeRange(outputTensor.getType()), adaptor.getOperands()[0],
-        outputTensor, adaptor.getMinFp(), adaptor.getMaxFp());
     return success();
   }
 };
@@ -111,15 +109,12 @@ public:
   LogicalResult
   matchAndRewrite(tosa::ConcatOp srcOp, tosa::ConcatOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    RankedTensorType outputType =
-        mlir::cast<RankedTensorType>(srcOp.getResult().getType());
+    auto outputType = mlir::cast<RankedTensorType>(
+        this->getTypeConverter()->convertType(srcOp.getResult().getType()));
 
-    tensor::EmptyOp outputTensor = rewriter.create<tensor::EmptyOp>(
-        srcOp.getLoc(), outputType.getShape(), outputType.getElementType());
+    ttmlir::utils::replaceOpWithNewDPSOp<ttir::ConcatOp>(
+        rewriter, srcOp, outputType, adaptor.getOperands(), adaptor.getAxis());
 
-    rewriter.replaceOpWithNewOp<mlir::tt::ttir::ConcatOp>(
-        srcOp, TypeRange(outputTensor.getType()), adaptor.getOperands(),
-        Value(outputTensor), adaptor.getAxis());
     return success();
   }
 };
@@ -140,15 +135,13 @@ public:
     if (!legalityResult.succeeded()) {
       return legalityResult;
     }
-    RankedTensorType outputType =
-        mlir::cast<RankedTensorType>(srcOp.getResult().getType());
-    tensor::EmptyOp outputTensor = rewriter.create<tensor::EmptyOp>(
-        srcOp.getLoc(), outputType.getShape(), outputType.getElementType());
-    ValueRange operands = adaptor.getOperands();
 
-    rewriter.replaceOpWithNewOp<mlir::tt::ttir::MatmulOp>(
-        srcOp, TypeRange(outputTensor.getType()), operands[0], operands[1],
-        outputTensor);
+    auto outputType = mlir::cast<RankedTensorType>(
+        this->getTypeConverter()->convertType(srcOp.getResult().getType()));
+
+    ttmlir::utils::replaceOpWithNewDPSOp<ttir::MatmulOp>(
+        rewriter, srcOp, outputType, adaptor.getA(), adaptor.getB());
+
     return success();
   }
 
@@ -175,16 +168,13 @@ public:
   LogicalResult
   matchAndRewrite(SrcOp srcOp, Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    RankedTensorType outputType =
-        mlir::cast<RankedTensorType>(srcOp.getResult().getType());
-    tensor::EmptyOp outputTensor = rewriter.create<tensor::EmptyOp>(
-        srcOp.getLoc(), outputType.getShape(), outputType.getElementType());
+    auto outputType = mlir::cast<RankedTensorType>(
+        this->getTypeConverter()->convertType(srcOp.getResult().getType()));
 
-    rewriter.replaceOpWithNewOp<DestOp>(
-        srcOp, outputTensor.getType(), adaptor.getInput(), outputTensor,
-        true /*keepdim*/,
-        rewriter.getArrayAttr(
-            SmallVector<Attribute>(1, adaptor.getAxisAttr())));
+    ttmlir::utils::replaceOpWithNewDPSOp<DestOp>(
+        rewriter, srcOp, outputType, adaptor.getInput(), /*keep_dim=*/true,
+        rewriter.getI32ArrayAttr(adaptor.getAxis()));
+
     return success();
   }
 };
@@ -200,18 +190,18 @@ public:
   LogicalResult
   matchAndRewrite(tosa::MaxPool2dOp srcOp, Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    auto outputType = mlir::cast<RankedTensorType>(
+        this->getTypeConverter()->convertType(srcOp.getResult().getType()));
 
-    auto outputType = mlir::cast<RankedTensorType>(srcOp.getResult().getType());
-    auto outputTensor = rewriter.create<tensor::EmptyOp>(
-        srcOp.getLoc(), outputType.getShape(), outputType.getElementType());
+    auto dims = srcOp.getKernel();
+    auto strides = srcOp.getStride();
+    auto pad = srcOp.getPad();
 
-    auto dims = srcOp.getKernelAttr();
-    auto strides = srcOp.getStrideAttr();
-    auto pad = srcOp.getPadAttr();
-    rewriter.replaceOpWithNewOp<mlir::tt::ttir::MaxPool2dOp>(
-        srcOp, TypeRange(outputTensor.getType()), adaptor.getInput(),
-        outputTensor, dims[0], dims[1], strides[0], strides[1], 1, 1, false,
-        pad[2], pad[3], pad[0], pad[1]);
+    // TODO (azecevic) Add comment about the parameters.
+    ttmlir::utils::replaceOpWithNewDPSOp<ttir::MaxPool2dOp>(
+        rewriter, srcOp, outputType, adaptor.getInput(), dims[0], dims[1],
+        strides[0], strides[1], 1, 1, false, pad[2], pad[3], pad[0], pad[1]);
+
     return success();
   }
 };

--- a/lib/Dialect/TTIR/Transforms/Constant.cpp
+++ b/lib/Dialect/TTIR/Transforms/Constant.cpp
@@ -4,6 +4,7 @@
 
 #include "ttmlir/Dialect/TT/IR/TT.h"
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
+#include "ttmlir/Utils.h"
 
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -22,12 +23,9 @@ public:
 
   LogicalResult matchAndRewrite(ConstantOp op,
                                 PatternRewriter &rewriter) const final {
-    auto resultTy = op.getResult().getType();
-    auto empty = rewriter.create<tensor::EmptyOp>(
-        op.getLoc(), resultTy.getShape(), resultTy.getElementType(),
-        resultTy.getEncoding());
-    rewriter.replaceOpWithNewOp<ttir::FillOp>(op, resultTy, empty,
-                                              op.getValue());
+    ttmlir::utils::replaceOpWithNewDPSOp<FillOp>(rewriter, op, op.getType(),
+                                                 op.getValue());
+
     return success();
   }
 };
@@ -50,7 +48,6 @@ public:
 
   void getDependentDialects(mlir::DialectRegistry &registry) const override {
     registry.insert<mlir::tt::ttir::TTIRDialect>();
-    registry.insert<mlir::tt::TTDialect>();
   }
 };
 

--- a/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
@@ -5,12 +5,12 @@
 #include "ttmlir/Dialect/TT/IR/TT.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
+#include "ttmlir/Utils.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
-#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 
 namespace mlir::tt::ttnn {
 #define GEN_PASS_DEF_TTNNLAYOUT
@@ -255,17 +255,10 @@ createToLayoutOp(PatternRewriter &rewriter, Location loc, Value input,
             .getResult();
   }
 
-  // If the input tensor is not a constant or empty tensor, we need to create a
-  // new tensor with the desired layout which will be used as the output of the
-  // ToLayoutOp
-  tensor::EmptyOp output = rewriter.create<tensor::EmptyOp>(
-      loc, ty.getShape(), ty.getElementType(), desiredLayout);
-
   // Create the ToLayoutOp which will convert the input tensor to the desired
-  // layout
-  return rewriter
-      .create<ttir::ToLayoutOp>(loc, output.getType(), input, output)
-      ->getResult(0);
+  // layout.
+  return ttmlir::utils::createDPSOp<ttir::ToLayoutOp>(
+      rewriter, loc, ty.getShape(), ty.getElementType(), desiredLayout, input);
 }
 
 static bool changeLayoutToHost(DestinationStyleOpInterface &op,

--- a/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
@@ -5,6 +5,7 @@
 #include "ttmlir/Dialect/TT/IR/TT.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 #include "ttmlir/Utils.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -90,7 +91,7 @@ public:
 
       TTNNLayoutAttr newLayout = createLayoutAttr(ctx, deviceGrid, type);
       // Convert mlir data types to tt data types
-      Type elementType = utils::dataTypeToElementType(
+      Type elementType = mlir::tt::ttnn::utils::dataTypeToElementType(
           ctx, elementTypeToDataType(type.getElementType()));
       return RankedTensorType::get(type.getShape(), elementType, newLayout);
     });


### PR DESCRIPTION
The goal of this PR is to simplify the creation of DPS ops. Most DPS ops follow the same pattern, where op is defined in TableGen as:
```
def DPSOp {
    ...
    let arguments = (ins
                                       AnyRankedTensor:$input1,
                                       ...,
                                       AnyRankedTensor:$inputN,
                                       AnyRankedTensor:$output,
                                       Attribute:$attr1,
                                       ...,
                                       Attribute:$attrM);
    ...
}
```
 with the appropriate builder where arguments follow the order of operands and attributes in the op definition. Frontends from which we lower to TTIR are non-DPS, so when we lower from those frontends to TTIR we end up (in the best case) with the following code:

```cpp
    RankedTensorType outputType = mlir::cast<RankedTensorType>(
        this->getTypeConverter()->convertType(srcOp.getResult().getType()));
    tensor::EmptyOp output = rewriter.create<tensor::EmptyOp>(
        adaptor.getLoc(), outputType.getShape(), outputType.getElementType());
    rewriter.replaceOpWithNewOp<DestOp>(
        srcOp, outputType, adaptor.getInput1(),..., adaptor.getInputN(), output, adaptor.getAttr1(),..., adaptor.getAttrM());
```

I mentioned "in the best case" specifically because this whole process is repeating and error-prone, so even though it's not a big block of code, there are still a lot of places where it could get wrong. There are a lot of places where it did get wrong, a most notable example is the double type conversion of output type that happened during the StableHLOToTTIR conversion, and that's actually the code that has compiled and executed as expected because the way type converter is currently(!) defined doesn't involve any transitive conversion, but whoever worked with DPS ops in more complicated decompositions knows how easy is to make a mistake that takes some time to find.

Proposed functions `createDPSOp` and `replaceOpWithNewDPSOp` should be almost a drop-in replacement for `createOp` and `replaceOpWithNewOp` respectively. So for the aforementioned example, the replacement would look like this.

```cpp
    RankedTensorType outputType = mlir::cast<RankedTensorType>(
        this->getTypeConverter()->convertType(srcOp.getResult().getType()));
   replaceOpWithNewDPSOp<DestOp>(
        rewriter, srcOp, outputType, adaptor.getInput1(),..., adaptor.getInputN(), adaptor.getAttr1(),..., adaptor.getAttrM());
```

These functions are template functions, that rely on the previously mentioned structure (all inputs, output, all attributes). As it's a template function, it can be challenging to recognize where operands end (or attributes begin), because we can't use RTTI. So the way I currently define an operand is like this:

```cpp
(std::is_convertible_v<T, mlir::Value> ||
 std::is_convertible_v<T, mlir::ValueRange>) &&
!std::is_convertible_v<T, mlir::TypedValue<mlir::tt::DeviceType>>
```

It's not ideal, but this is something that works for most of our use cases (note that `device` is the only exception, because it's convertible to `Value` but it behaves more like an attribute in DPS ops in which it's defined). This definition doesn't aim to be the most comprehensive, just to cover most cases. At the end of the day these functions are here for convenience (with all the benefits that come with DRY), we can still fall back to the old way of defining when we encounter some cases that aren't covered with this pattern (there are some cases not covered still left, most notably DPS ops with multiple results). I'm open to suggestions for improvement, especially for the way how to find the boundary between operands and attributes.

Closes https://github.com/tenstorrent/tt-mlir/issues/1671