### PR TITLE
Update the return type of the get_op_constraints API to match tt-metal

### DIFF
--- a/lib/OpModel/TTNN/TTNNOpModelLib.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModelLib.cpp
@@ -47,7 +47,7 @@ std::tuple<bool, std::optional<std::tuple<size_t, size_t, size_t>>,
            std::optional<std::string>>
 getOpConstraints(const std::string_view &name, Callable &callable,
                  auto &&...args) {
-  ::ttnn::graph::QueryResponse query;
+  ::ttnn::graph::ConstraintQueryResponse query;
   try {
     query = callable(std::forward<decltype(args)>(args)...);
   } catch (const std::exception &e) {


### PR DESCRIPTION
Issue: #1922 

In https://github.com/tenstorrent/tt-metal/pull/16921 I am proposing to change the name of a struct that is defined in metal but also used and explicitly named in this repo. This PR updates the name to match the proposed name in metal

Note: both PRs need to be sequenced properly with the metal uplift to ensure the mlir build is unaffected