### PR TITLE
#364: Rename metal ops to be consistent with host_api.hpp

### DIFF
--- a/docs/src/dialects-overview.md
+++ b/docs/src/dialects-overview.md
@@ -18,4 +18,4 @@ individual dialect documentation for more details.:
   - `ttkernel.[matmul|add|multiply]`: Computations on tiles in source register space, store the result in dest register space.
   - `ttkernel.sfpu_*`: Computations on tiles in dest register space using sfpu coprocessor.
 - `ttmetal`: Operations that dispatch work from host to device.
-  - `ttmetal.dispatch`: Dispatch a grid of compute work.
+  - `ttmetal.enqueue_program`: Dispatch a grid of compute work.

--- a/include/ttmlir/Conversion/TTKernelToEmitC/TTKernelToEmitC.h
+++ b/include/ttmlir/Conversion/TTKernelToEmitC/TTKernelToEmitC.h
@@ -30,9 +30,9 @@ LogicalResult emitOpRegionAsCpp(Region *region, std::string &regionCpp,
 LogicalResult emitOpRegionAsCpp(Region *region, llvm::raw_ostream &os,
                                 const ttkernel::ThreadType &threadType);
 
-// Converts dispatch op's regions to C++ code.
+// Converts enqueue program op's regions to C++ code.
 LogicalResult
-emitDispatchOpRegionsAsCpp(ttmetal::DispatchOp dispatchOp,
+emitEnqueueProgramOpRegionsAsCpp(ttmetal::EnqueueProgramOp enqueueProgramOp,
                            llvm::SmallVector<std::string> &cppStrings);
 
 LogicalResult emitKernelAsCpp(mlir::ModuleOp op, llvm::raw_ostream &os,

--- a/include/ttmlir/Conversion/TTKernelToEmitC/TTKernelToEmitC.h
+++ b/include/ttmlir/Conversion/TTKernelToEmitC/TTKernelToEmitC.h
@@ -33,7 +33,7 @@ LogicalResult emitOpRegionAsCpp(Region *region, llvm::raw_ostream &os,
 // Converts enqueue program op's regions to C++ code.
 LogicalResult
 emitEnqueueProgramOpRegionsAsCpp(ttmetal::EnqueueProgramOp enqueueProgramOp,
-                           llvm::SmallVector<std::string> &cppStrings);
+                                 llvm::SmallVector<std::string> &cppStrings);
 
 LogicalResult emitKernelAsCpp(mlir::ModuleOp op, llvm::raw_ostream &os,
                               const ttkernel::ThreadType &threadType);

--- a/include/ttmlir/Dialect/TTMetal/IR/TTMetalOps.td
+++ b/include/ttmlir/Dialect/TTMetal/IR/TTMetalOps.td
@@ -86,10 +86,10 @@ def TTMetal_CreateBufferOp : TTMetal_Op<"create_buffer"> {
     let hasVerifier = 1;
 }
 
-def TTMetal_DeallocOp : TTMetal_Op<"dealloc"> {
-    let summary = "Dealloc op.";
+def TTMetal_DeallocateBufferOp : TTMetal_Op<"deallocate_buffer"> {
+    let summary = "Deallocate buffer op.";
     let description = [{
-      Tensor Dealloc operation
+      Deallocate buffer operation
     }];
 
     let arguments = (ins AnyRankedTensor:$input);

--- a/include/ttmlir/Dialect/TTMetal/IR/TTMetalOps.td
+++ b/include/ttmlir/Dialect/TTMetal/IR/TTMetalOps.td
@@ -57,10 +57,10 @@ def TTMetal_EnqueueWriteBufferOp : TTMetal_Op<"enqueue_write_buffer", [Destinati
     let hasVerifier = 1;
 }
 
-def TTMetal_HostReadOp : TTMetal_Op<"host_read", [DestinationStyleOpInterface]> {
-    let summary = "Host read op.";
+def TTMetal_EnqueueReadBufferOp : TTMetal_Op<"enqueue_read_buffer", [DestinationStyleOpInterface]> {
+    let summary = "Enqueue read buffer op.";
     let description = [{
-      Host read operation
+      Enqueue read buffer operation
     }];
 
     let arguments = (ins AnyRankedTensor:$input,

--- a/include/ttmlir/Dialect/TTMetal/IR/TTMetalOps.td
+++ b/include/ttmlir/Dialect/TTMetal/IR/TTMetalOps.td
@@ -74,10 +74,10 @@ def TTMetal_EnqueueReadBufferOp : TTMetal_Op<"enqueue_read_buffer", [Destination
     let hasVerifier = 1;
 }
 
-def TTMetal_AllocOp : TTMetal_Op<"alloc"> {
-    let summary = "Alloc op.";
+def TTMetal_CreateBufferOp : TTMetal_Op<"create_buffer"> {
+    let summary = "Create buffer op.";
     let description = [{
-      Tensor Alloc operation
+      Create buffer operation
     }];
 
     let arguments = (ins I64Attr:$address, I64Attr:$size, TT_MemorySpaceAttr:$memory_space);

--- a/include/ttmlir/Dialect/TTMetal/IR/TTMetalOps.td
+++ b/include/ttmlir/Dialect/TTMetal/IR/TTMetalOps.td
@@ -21,10 +21,10 @@ class AtLeastRegion<int numBlocks> : Region<
   CPred<"$_self.getBlocks().size() >= " # numBlocks>,
   "region with " # numBlocks # " blocks">;
 
-def TTMetal_DispatchOp : TTMetal_Op<"dispatch", [DestinationStyleOpInterface, AttrSizedOperandSegments]> {
-    let summary = "Dispatch op.";
+def TTMetal_EnqueueProgramOp : TTMetal_Op<"enqueue_program", [DestinationStyleOpInterface, AttrSizedOperandSegments]> {
+    let summary = "Enqueue program op.";
     let description = [{
-      Dispatch operation
+      Enqueue program operation
     }];
 
     let arguments = (ins Variadic<AnyRankedTensor>:$inputs,

--- a/include/ttmlir/Dialect/TTMetal/IR/TTMetalOps.td
+++ b/include/ttmlir/Dialect/TTMetal/IR/TTMetalOps.td
@@ -41,10 +41,10 @@ def TTMetal_EnqueueProgramOp : TTMetal_Op<"enqueue_program", [DestinationStyleOp
     let hasVerifier = 1;
 }
 
-def TTMetal_HostWriteOp : TTMetal_Op<"host_write", [DestinationStyleOpInterface]> {
-    let summary = "Host write op.";
+def TTMetal_EnqueueWriteBufferOp : TTMetal_Op<"enqueue_write_buffer", [DestinationStyleOpInterface]> {
+    let summary = "Enqueue write buffer op.";
     let description = [{
-      Host write operation
+      Enqueue write buffer operation
     }];
 
     let arguments = (ins AnyRankedTensor:$output, ElementsAttr:$value);

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
@@ -1835,7 +1835,7 @@ public:
 
   LogicalResult matchAndRewrite(ttir::FillOp op,
                                 PatternRewriter &rewriter) const final {
-    rewriter.replaceOpWithNewOp<ttmetal::HostWriteOp>(
+    rewriter.replaceOpWithNewOp<ttmetal::EnqueueWriteBufferOp>(
         op, op.getResult().getType(), op.getOutput(), op.getValue());
     return success();
   }

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
@@ -51,8 +51,8 @@ namespace mlir::tt::ttmetal {
 
 // This routine walks the SSA value chain to find the address of the value.
 // It runs into and gets the address from one of the following:
-//   - ttir::CreateBufferOp: The address is the address of the allocation is embedded
-//   in the op attributes.
+//   - ttir::CreateBufferOp: The address is the address of the allocation is
+//   embedded in the op attributes.
 //   - func::FuncOp Argument: The address is taken from ArgumentAllocationAttr.
 //
 // This routine is used to lookup the address of tensors for address generation
@@ -286,7 +286,8 @@ public:
 
     int regIdx = 0;
     for (auto [dstCoord, transactions] : dm) {
-      Block *block = rewriter.createBlock(&metalEnqueueProgram.getRegion(regIdx++));
+      Block *block =
+          rewriter.createBlock(&metalEnqueueProgram.getRegion(regIdx++));
       createDataMovementThread(op->getLoc(), block, inputBaseAddress,
                                outputBaseAddress, transactions,
                                physicalCoordMapping, addressAlignment);
@@ -373,7 +374,8 @@ public:
 
     std::int64_t inputBaseAddress = lookupAddress(op.getInput());
     std::int64_t outputBaseAddress = lookupAddress(op.getOutput());
-    Block *tensixBlock = rewriter.createBlock(&metalEnqueueProgram.getRegion(0));
+    Block *tensixBlock =
+        rewriter.createBlock(&metalEnqueueProgram.getRegion(0));
     OpBuilder tensixBuilder(tensixBlock, tensixBlock->begin());
     uint64_t pageSize = inputLayout.isTiled()
                             ? inputLayout.getElementSizeBytes()
@@ -503,7 +505,8 @@ public:
   }
 };
 
-class TTIRToTTMetalEnqueueProgramRewriter : public OpRewritePattern<ttir::GenericOp> {
+class TTIRToTTMetalEnqueueProgramRewriter
+    : public OpRewritePattern<ttir::GenericOp> {
 public:
   using OpRewritePattern<ttir::GenericOp>::OpRewritePattern;
 
@@ -1632,10 +1635,10 @@ public:
         continue;
       }
       for (auto [dstCoord, srcs] : operand.dataMovement) {
-        Block *block =
-            coordToBlock.find(dstCoord) == coordToBlock.end()
-                ? rewriter.createBlock(&metalEnqueueProgram.getRegion(dmThreadIdx++))
-                : coordToBlock[dstCoord];
+        Block *block = coordToBlock.find(dstCoord) == coordToBlock.end()
+                           ? rewriter.createBlock(
+                                 &metalEnqueueProgram.getRegion(dmThreadIdx++))
+                           : coordToBlock[dstCoord];
         coordToBlock[dstCoord] = block;
 
         block->addArgument(rewrittenBlockArgumentTypes[operand.blockArgIndex],
@@ -1760,8 +1763,8 @@ public:
           getContext(), {dstCoord.y, dstCoord.x}, gridShape));
     }
 
-    // Wire generic's operands to enqueue program op's operands with respect to the CB
-    // mapping.
+    // Wire generic's operands to enqueue program op's operands with respect to
+    // the CB mapping.
     SmallVector<Value> inputsToEnqueueProgramOp;
     for (size_t i = 0; i < op.getInputs().size(); ++i) {
       auto operand = op.getOperandCbMapping()[i] == -1
@@ -1782,16 +1785,17 @@ public:
     }
 
     generateDataMovementThreads(op, tensixBlock, streamedOperands, rewriter,
-                                metalEnqueueProgram, rewrittenBlockArgumentTypes);
+                                metalEnqueueProgram,
+                                rewrittenBlockArgumentTypes);
 
     lowerBlock(&op->getRegion(0).front(), tensixBlock, op.getIteratorTypes(),
                op.getIndexingMaps(), op.getInputs().size());
 
     addSyncronizationForDataMovement(op, tensixBlock, streamedOperands);
 
-    // Regions for enqueue program op are allocated up-front, but some of them may be
-    // empty at the end of lowering due to no data movement requirements. Insert
-    // return op in those regions.
+    // Regions for enqueue program op are allocated up-front, but some of them
+    // may be empty at the end of lowering due to no data movement requirements.
+    // Insert return op in those regions.
     for (Region &reg : metalEnqueueProgram->getRegions()) {
       if (reg.empty()) {
         auto &block = reg.emplaceBlock();
@@ -1824,7 +1828,8 @@ public:
 
   LogicalResult matchAndRewrite(ttir::DeallocOp op,
                                 PatternRewriter &rewriter) const final {
-    rewriter.replaceOpWithNewOp<ttmetal::DeallocateBufferOp>(op, op.getResult());
+    rewriter.replaceOpWithNewOp<ttmetal::DeallocateBufferOp>(op,
+                                                             op.getResult());
     return success();
   }
 };

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
@@ -471,7 +471,7 @@ public:
         assert(false && "System memory to device memory is not supported yet");
       } else if (outputLayout.isSystemMemorySpace()) {
         assert(inputLayout.isDeviceMemorySpace());
-        rewriter.replaceOpWithNewOp<ttmetal::HostReadOp>(
+        rewriter.replaceOpWithNewOp<ttmetal::EnqueueReadBufferOp>(
             op, outputTy, op.getInput(), op.getOutput());
       } else {
         return relayout(op, rewriter);

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
@@ -51,7 +51,7 @@ namespace mlir::tt::ttmetal {
 
 // This routine walks the SSA value chain to find the address of the value.
 // It runs into and gets the address from one of the following:
-//   - ttir::AllocOp: The address is the address of the allocation is embedded
+//   - ttir::CreateBufferOp: The address is the address of the allocation is embedded
 //   in the op attributes.
 //   - func::FuncOp Argument: The address is taken from ArgumentAllocationAttr.
 //
@@ -1812,7 +1812,7 @@ public:
 
   LogicalResult matchAndRewrite(ttir::AllocOp op,
                                 PatternRewriter &rewriter) const final {
-    rewriter.replaceOpWithNewOp<ttmetal::AllocOp>(
+    rewriter.replaceOpWithNewOp<ttmetal::CreateBufferOp>(
         op, op.getType(), op.getAddress(), op.getSize(), op.getMemorySpace());
     return success();
   }

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
@@ -1824,7 +1824,7 @@ public:
 
   LogicalResult matchAndRewrite(ttir::DeallocOp op,
                                 PatternRewriter &rewriter) const final {
-    rewriter.replaceOpWithNewOp<ttmetal::DeallocOp>(op, op.getResult());
+    rewriter.replaceOpWithNewOp<ttmetal::DeallocateBufferOp>(op, op.getResult());
     return success();
   }
 };

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -585,7 +585,7 @@ LogicalResult emitOpRegionAsCpp(Region *region, llvm::raw_ostream &os,
 
 LogicalResult
 emitEnqueueProgramOpRegionsAsCpp(ttmetal::EnqueueProgramOp enqueueProgramOp,
-                           llvm::SmallVector<std::string> &cppStrings) {
+                                 llvm::SmallVector<std::string> &cppStrings) {
   assert(cppStrings.size() == enqueueProgramOp.getNumRegions() &&
          "cppStrings size must match number of regions");
 

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -584,14 +584,14 @@ LogicalResult emitOpRegionAsCpp(Region *region, llvm::raw_ostream &os,
 }
 
 LogicalResult
-emitDispatchOpRegionsAsCpp(ttmetal::DispatchOp dispatchOp,
+emitEnqueueProgramOpRegionsAsCpp(ttmetal::EnqueueProgramOp enqueueProgramOp,
                            llvm::SmallVector<std::string> &cppStrings) {
-  assert(cppStrings.size() == dispatchOp.getNumRegions() &&
+  assert(cppStrings.size() == enqueueProgramOp.getNumRegions() &&
          "cppStrings size must match number of regions");
 
-  for (auto &reg : dispatchOp->getRegions()) {
+  for (auto &reg : enqueueProgramOp->getRegions()) {
     auto kernelConfig = mlir::cast<ttkernel::KernelConfigInterface>(
-        dispatchOp.getKernelConfigs()[reg.getRegionNumber()]);
+        enqueueProgramOp.getKernelConfigs()[reg.getRegionNumber()]);
     if (emitOpRegionAsCpp(&reg, cppStrings[reg.getRegionNumber()],
                           kernelConfig.getThreadType())
             .failed()) {

--- a/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
@@ -43,28 +43,32 @@ static bool insideEnqueueProgramOpRegion(mlir::Operation *op) {
 
 ::mlir::LogicalResult CBPushBackOp::verify() {
   if (!insideEnqueueProgramOpRegion(getOperation())) {
-    return emitOpError("CBPushBackOp must be inside of a EnqueueProgramOp region");
+    return emitOpError(
+        "CBPushBackOp must be inside of a EnqueueProgramOp region");
   }
   return success();
 }
 
 ::mlir::LogicalResult CBPopFrontOp::verify() {
   if (!insideEnqueueProgramOpRegion(getOperation())) {
-    return emitOpError("CBPopFrontOp must be inside of a EnqueueProgramOp region");
+    return emitOpError(
+        "CBPopFrontOp must be inside of a EnqueueProgramOp region");
   }
   return success();
 }
 
 ::mlir::LogicalResult CBReserveBackOp::verify() {
   if (!insideEnqueueProgramOpRegion(getOperation())) {
-    return emitOpError("CBReserveBackOp must be inside of a EnqueueProgramOp region");
+    return emitOpError(
+        "CBReserveBackOp must be inside of a EnqueueProgramOp region");
   }
   return success();
 }
 
 ::mlir::LogicalResult CBWaitFrontOp::verify() {
   if (!insideEnqueueProgramOpRegion(getOperation())) {
-    return emitOpError("CBWaitFrontOp must be inside of a EnqueueProgramOp region");
+    return emitOpError(
+        "CBWaitFrontOp must be inside of a EnqueueProgramOp region");
   }
   return success();
 }
@@ -87,7 +91,8 @@ static std::string verifyTilizeUntilizeCBs(CBType tilizedCB, CBType scalarCB) {
 
 ::mlir::LogicalResult TilizeInitOp::verify() {
   if (!insideEnqueueProgramOpRegion(getOperation())) {
-    return emitOpError("TilizeInitOp must be inside of a EnqueueProgramOp region");
+    return emitOpError(
+        "TilizeInitOp must be inside of a EnqueueProgramOp region");
   }
   std::string err =
       verifyTilizeUntilizeCBs(getCbOut().getType(), getCbIn().getType());
@@ -99,7 +104,8 @@ static std::string verifyTilizeUntilizeCBs(CBType tilizedCB, CBType scalarCB) {
 
 ::mlir::LogicalResult UntilizeInitOp::verify() {
   if (!insideEnqueueProgramOpRegion(getOperation())) {
-    return emitOpError("UntilizeInitOp must be inside of a EnqueueProgramOp region");
+    return emitOpError(
+        "UntilizeInitOp must be inside of a EnqueueProgramOp region");
   }
   std::string err =
       verifyTilizeUntilizeCBs(getCbIn().getType(), getCbOut().getType());
@@ -111,7 +117,8 @@ static std::string verifyTilizeUntilizeCBs(CBType tilizedCB, CBType scalarCB) {
 
 ::mlir::LogicalResult TilizeBlockOp::verify() {
   if (!insideEnqueueProgramOpRegion(getOperation())) {
-    return emitOpError("TilizeBlockOp must be inside of a EnqueueProgramOp region");
+    return emitOpError(
+        "TilizeBlockOp must be inside of a EnqueueProgramOp region");
   }
   std::string err =
       verifyTilizeUntilizeCBs(getCbOut().getType(), getCbIn().getType());
@@ -123,7 +130,8 @@ static std::string verifyTilizeUntilizeCBs(CBType tilizedCB, CBType scalarCB) {
 
 ::mlir::LogicalResult UntilizeBlockOp::verify() {
   if (!insideEnqueueProgramOpRegion(getOperation())) {
-    return emitOpError("UntilizeBlockOp must be inside of a EnqueueProgramOp region");
+    return emitOpError(
+        "UntilizeBlockOp must be inside of a EnqueueProgramOp region");
   }
   std::string err =
       verifyTilizeUntilizeCBs(getCbIn().getType(), getCbOut().getType());

--- a/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
@@ -16,14 +16,14 @@
 
 namespace mlir::tt::ttkernel {
 
-static bool insideDispatchOpRegion(mlir::Operation *op) {
+static bool insideEnqueueProgramOpRegion(mlir::Operation *op) {
   mlir::Operation *parentOp = op->getParentOp();
 
   if (!parentOp) {
     return false;
   }
 
-  if (dyn_cast_or_null<ttmetal::DispatchOp>(parentOp)) {
+  if (dyn_cast_or_null<ttmetal::EnqueueProgramOp>(parentOp)) {
     return true;
   }
 
@@ -31,40 +31,40 @@ static bool insideDispatchOpRegion(mlir::Operation *op) {
       dyn_cast_or_null<mlir::ModuleOp>(parentOp->getParentOp())) {
     return true;
   }
-  return insideDispatchOpRegion(parentOp);
+  return insideEnqueueProgramOpRegion(parentOp);
 }
 
 ::mlir::LogicalResult BuiltinOp::verify() {
-  if (!insideDispatchOpRegion(getOperation())) {
-    return emitOpError("KernelOp must be inside of a DispatchOp region");
+  if (!insideEnqueueProgramOpRegion(getOperation())) {
+    return emitOpError("KernelOp must be inside of a EnqueueProgramOp region");
   }
   return success();
 }
 
 ::mlir::LogicalResult CBPushBackOp::verify() {
-  if (!insideDispatchOpRegion(getOperation())) {
-    return emitOpError("CBPushBackOp must be inside of a DispatchOp region");
+  if (!insideEnqueueProgramOpRegion(getOperation())) {
+    return emitOpError("CBPushBackOp must be inside of a EnqueueProgramOp region");
   }
   return success();
 }
 
 ::mlir::LogicalResult CBPopFrontOp::verify() {
-  if (!insideDispatchOpRegion(getOperation())) {
-    return emitOpError("CBPopFrontOp must be inside of a DispatchOp region");
+  if (!insideEnqueueProgramOpRegion(getOperation())) {
+    return emitOpError("CBPopFrontOp must be inside of a EnqueueProgramOp region");
   }
   return success();
 }
 
 ::mlir::LogicalResult CBReserveBackOp::verify() {
-  if (!insideDispatchOpRegion(getOperation())) {
-    return emitOpError("CBReserveBackOp must be inside of a DispatchOp region");
+  if (!insideEnqueueProgramOpRegion(getOperation())) {
+    return emitOpError("CBReserveBackOp must be inside of a EnqueueProgramOp region");
   }
   return success();
 }
 
 ::mlir::LogicalResult CBWaitFrontOp::verify() {
-  if (!insideDispatchOpRegion(getOperation())) {
-    return emitOpError("CBWaitFrontOp must be inside of a DispatchOp region");
+  if (!insideEnqueueProgramOpRegion(getOperation())) {
+    return emitOpError("CBWaitFrontOp must be inside of a EnqueueProgramOp region");
   }
   return success();
 }
@@ -86,8 +86,8 @@ static std::string verifyTilizeUntilizeCBs(CBType tilizedCB, CBType scalarCB) {
 }
 
 ::mlir::LogicalResult TilizeInitOp::verify() {
-  if (!insideDispatchOpRegion(getOperation())) {
-    return emitOpError("TilizeInitOp must be inside of a DispatchOp region");
+  if (!insideEnqueueProgramOpRegion(getOperation())) {
+    return emitOpError("TilizeInitOp must be inside of a EnqueueProgramOp region");
   }
   std::string err =
       verifyTilizeUntilizeCBs(getCbOut().getType(), getCbIn().getType());
@@ -98,8 +98,8 @@ static std::string verifyTilizeUntilizeCBs(CBType tilizedCB, CBType scalarCB) {
 }
 
 ::mlir::LogicalResult UntilizeInitOp::verify() {
-  if (!insideDispatchOpRegion(getOperation())) {
-    return emitOpError("UntilizeInitOp must be inside of a DispatchOp region");
+  if (!insideEnqueueProgramOpRegion(getOperation())) {
+    return emitOpError("UntilizeInitOp must be inside of a EnqueueProgramOp region");
   }
   std::string err =
       verifyTilizeUntilizeCBs(getCbIn().getType(), getCbOut().getType());
@@ -110,8 +110,8 @@ static std::string verifyTilizeUntilizeCBs(CBType tilizedCB, CBType scalarCB) {
 }
 
 ::mlir::LogicalResult TilizeBlockOp::verify() {
-  if (!insideDispatchOpRegion(getOperation())) {
-    return emitOpError("TilizeBlockOp must be inside of a DispatchOp region");
+  if (!insideEnqueueProgramOpRegion(getOperation())) {
+    return emitOpError("TilizeBlockOp must be inside of a EnqueueProgramOp region");
   }
   std::string err =
       verifyTilizeUntilizeCBs(getCbOut().getType(), getCbIn().getType());
@@ -122,8 +122,8 @@ static std::string verifyTilizeUntilizeCBs(CBType tilizedCB, CBType scalarCB) {
 }
 
 ::mlir::LogicalResult UntilizeBlockOp::verify() {
-  if (!insideDispatchOpRegion(getOperation())) {
-    return emitOpError("UntilizeBlockOp must be inside of a DispatchOp region");
+  if (!insideEnqueueProgramOpRegion(getOperation())) {
+    return emitOpError("UntilizeBlockOp must be inside of a EnqueueProgramOp region");
   }
   std::string err =
       verifyTilizeUntilizeCBs(getCbIn().getType(), getCbOut().getType());
@@ -134,8 +134,8 @@ static std::string verifyTilizeUntilizeCBs(CBType tilizedCB, CBType scalarCB) {
 }
 
 ::mlir::LogicalResult ReturnOp::verify() {
-  if (!insideDispatchOpRegion(getOperation())) {
-    return emitOpError("ReturnOp must be inside of a DispatchOp region");
+  if (!insideEnqueueProgramOpRegion(getOperation())) {
+    return emitOpError("ReturnOp must be inside of a EnqueueProgramOp region");
   }
   return success();
 }

--- a/lib/Dialect/TTMetal/IR/TTMetalDialect.cpp
+++ b/lib/Dialect/TTMetal/IR/TTMetalDialect.cpp
@@ -44,9 +44,9 @@ struct TTMetalDialectFoldInterface : public DialectFoldInterface {
   /// operation that is *not* isolated from above, should be used when
   /// materializing constants.
   bool shouldMaterializeInto(Region *region) const final {
-    // If this is a DispatchOp, protect it from hoisting constants outside of
+    // If this is a EnqueueProgramOp, protect it from hoisting constants outside of
     // its region body
-    return isa<DispatchOp>(region->getParentOp());
+    return isa<EnqueueProgramOp>(region->getParentOp());
   }
 };
 

--- a/lib/Dialect/TTMetal/IR/TTMetalDialect.cpp
+++ b/lib/Dialect/TTMetal/IR/TTMetalDialect.cpp
@@ -44,8 +44,8 @@ struct TTMetalDialectFoldInterface : public DialectFoldInterface {
   /// operation that is *not* isolated from above, should be used when
   /// materializing constants.
   bool shouldMaterializeInto(Region *region) const final {
-    // If this is a EnqueueProgramOp, protect it from hoisting constants outside of
-    // its region body
+    // If this is a EnqueueProgramOp, protect it from hoisting constants outside
+    // of its region body
     return isa<EnqueueProgramOp>(region->getParentOp());
   }
 };

--- a/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
+++ b/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
@@ -40,7 +40,7 @@ namespace mlir::tt::ttmetal {
   return success();
 }
 
-::mlir::LogicalResult AllocOp::verify() {
+::mlir::LogicalResult CreateBufferOp::verify() {
   auto layout = mlir::dyn_cast_or_null<mlir::tt::MetalLayoutAttr>(
       getResult().getType().getEncoding());
   if (not layout) {

--- a/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
+++ b/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
@@ -14,7 +14,7 @@
 
 namespace mlir::tt::ttmetal {
 
-::mlir::LogicalResult HostWriteOp::verify() {
+::mlir::LogicalResult EnqueueWriteBufferOp::verify() {
   ::mlir::RankedTensorType outputTy = getOutput().getType();
   auto outputLayout =
       mlir::dyn_cast_or_null<mlir::tt::MetalLayoutAttr>(outputTy.getEncoding());

--- a/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
+++ b/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
@@ -27,7 +27,7 @@ namespace mlir::tt::ttmetal {
   return success();
 }
 
-::mlir::LogicalResult HostReadOp::verify() {
+::mlir::LogicalResult EnqueueReadBufferOp::verify() {
   ::mlir::RankedTensorType outputTy = getOutput().getType();
   auto outputLayout =
       mlir::dyn_cast_or_null<mlir::tt::MetalLayoutAttr>(outputTy.getEncoding());

--- a/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
+++ b/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
@@ -73,7 +73,7 @@ namespace mlir::tt::ttmetal {
   return success();
 }
 
-::mlir::LogicalResult DispatchOp::verify() {
+::mlir::LogicalResult EnqueueProgramOp::verify() {
   // Assert inputs/outputs device memspace
   for (auto operand : getOperands()) {
     auto layout = mlir::dyn_cast_or_null<mlir::tt::MetalLayoutAttr>(

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -353,12 +353,12 @@ static std::shared_ptr<void> translateModuleToFlatbuffer(
                 cache.getOrCreate(createBufferOp.getResult(), tensorValueToFlatbuffer,
                                   createBufferOp.getAddress(), createBufferOp.getSize())),
             op);
-      } else if (auto deallocOp = dyn_cast_or_null<tt::ttmetal::DeallocOp>(op);
-                 deallocOp) {
+      } else if (auto deallocateBufferOp = dyn_cast_or_null<tt::ttmetal::DeallocateBufferOp>(op);
+                 deallocateBufferOp) {
         cqBuilder.appendCommand(
             ::tt::target::metal::CreateDeallocateBufferCommand(
                 fbb, cache.at<::tt::target::TensorRef>(
-                         getOperandThroughDPSOps(deallocOp.getInput()))),
+                         getOperandThroughDPSOps(deallocateBufferOp.getInput()))),
             op);
       } else if (auto enqueueReadBufferOp =
                      dyn_cast_or_null<tt::ttmetal::EnqueueReadBufferOp>(op);

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -371,16 +371,16 @@ static std::shared_ptr<void> translateModuleToFlatbuffer(
                 cache.at<::tt::target::TensorRef>(
                     getOperandThroughDPSOps(hostReadOp.getOutput()))),
             op);
-      } else if (auto hostWriteOp =
-                     dyn_cast_or_null<tt::ttmetal::HostWriteOp>(op);
-                 hostWriteOp) {
+      } else if (auto enqueueWriteBufferOp =
+                     dyn_cast_or_null<tt::ttmetal::EnqueueWriteBufferOp>(op);
+                 enqueueWriteBufferOp) {
         auto [hostBufferType, hostBuffer] =
-            hostBufferToFlatbuffer(cache, hostWriteOp.getValue());
+            hostBufferToFlatbuffer(cache, enqueueWriteBufferOp.getValue());
         cqBuilder.appendCommand(
             ::tt::target::metal::CreateEnqueueWriteBufferCommand(
                 fbb, hostBufferType, hostBuffer,
                 cache.at<::tt::target::TensorRef>(
-                    getOperandThroughDPSOps(hostWriteOp.getOutput()))),
+                    getOperandThroughDPSOps(enqueueWriteBufferOp.getOutput()))),
             op);
       } else if (auto returnOp = dyn_cast_or_null<func::ReturnOp>(op);
                  returnOp) {

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -289,7 +289,8 @@ static std::shared_ptr<void> translateModuleToFlatbuffer(
     }
 
     entry->walk([&](mlir::Operation *op) {
-      if (auto enqueueProgramOp = dyn_cast_or_null<tt::ttmetal::EnqueueProgramOp>(op);
+      if (auto enqueueProgramOp =
+              dyn_cast_or_null<tt::ttmetal::EnqueueProgramOp>(op);
           enqueueProgramOp) {
         std::vector<::flatbuffers::Offset<::tt::target::TensorRef>> operands;
         for (auto operand : enqueueProgramOp.getOperands()) {
@@ -300,7 +301,8 @@ static std::shared_ptr<void> translateModuleToFlatbuffer(
         std::vector<::flatbuffers::Offset<::tt::target::metal::KernelDesc>>
             kernels;
 
-        llvm::SmallVector<std::string> cppKernels(enqueueProgramOp->getNumRegions());
+        llvm::SmallVector<std::string> cppKernels(
+            enqueueProgramOp->getNumRegions());
         llvm::LogicalResult success =
             emitEnqueueProgramOpRegionsAsCpp(enqueueProgramOp, cppKernels);
         assert(success.succeeded() &&
@@ -345,20 +347,23 @@ static std::shared_ptr<void> translateModuleToFlatbuffer(
             ::tt::target::metal::CreateEnqueueProgramCommandDirect(
                 fbb, &operands, program),
             op);
-      } else if (auto createBufferOp = dyn_cast_or_null<tt::ttmetal::CreateBufferOp>(op);
+      } else if (auto createBufferOp =
+                     dyn_cast_or_null<tt::ttmetal::CreateBufferOp>(op);
                  createBufferOp) {
         cqBuilder.appendCommand(
             ::tt::target::metal::CreateCreateBufferCommand(
-                fbb,
-                cache.getOrCreate(createBufferOp.getResult(), tensorValueToFlatbuffer,
-                                  createBufferOp.getAddress(), createBufferOp.getSize())),
+                fbb, cache.getOrCreate(createBufferOp.getResult(),
+                                       tensorValueToFlatbuffer,
+                                       createBufferOp.getAddress(),
+                                       createBufferOp.getSize())),
             op);
-      } else if (auto deallocateBufferOp = dyn_cast_or_null<tt::ttmetal::DeallocateBufferOp>(op);
+      } else if (auto deallocateBufferOp =
+                     dyn_cast_or_null<tt::ttmetal::DeallocateBufferOp>(op);
                  deallocateBufferOp) {
         cqBuilder.appendCommand(
             ::tt::target::metal::CreateDeallocateBufferCommand(
-                fbb, cache.at<::tt::target::TensorRef>(
-                         getOperandThroughDPSOps(deallocateBufferOp.getInput()))),
+                fbb, cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(
+                         deallocateBufferOp.getInput()))),
             op);
       } else if (auto enqueueReadBufferOp =
                      dyn_cast_or_null<tt::ttmetal::EnqueueReadBufferOp>(op);

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -345,13 +345,13 @@ static std::shared_ptr<void> translateModuleToFlatbuffer(
             ::tt::target::metal::CreateEnqueueProgramCommandDirect(
                 fbb, &operands, program),
             op);
-      } else if (auto allocOp = dyn_cast_or_null<tt::ttmetal::AllocOp>(op);
-                 allocOp) {
+      } else if (auto createBufferOp = dyn_cast_or_null<tt::ttmetal::CreateBufferOp>(op);
+                 createBufferOp) {
         cqBuilder.appendCommand(
             ::tt::target::metal::CreateCreateBufferCommand(
                 fbb,
-                cache.getOrCreate(allocOp.getResult(), tensorValueToFlatbuffer,
-                                  allocOp.getAddress(), allocOp.getSize())),
+                cache.getOrCreate(createBufferOp.getResult(), tensorValueToFlatbuffer,
+                                  createBufferOp.getAddress(), createBufferOp.getSize())),
             op);
       } else if (auto deallocOp = dyn_cast_or_null<tt::ttmetal::DeallocOp>(op);
                  deallocOp) {

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -360,16 +360,16 @@ static std::shared_ptr<void> translateModuleToFlatbuffer(
                 fbb, cache.at<::tt::target::TensorRef>(
                          getOperandThroughDPSOps(deallocOp.getInput()))),
             op);
-      } else if (auto hostReadOp =
-                     dyn_cast_or_null<tt::ttmetal::HostReadOp>(op);
-                 hostReadOp) {
+      } else if (auto enqueueReadBufferOp =
+                     dyn_cast_or_null<tt::ttmetal::EnqueueReadBufferOp>(op);
+                 enqueueReadBufferOp) {
         cqBuilder.appendCommand(
             ::tt::target::metal::CreateEnqueueReadBufferCommand(
                 fbb,
                 cache.at<::tt::target::TensorRef>(
-                    getOperandThroughDPSOps(hostReadOp.getInput())),
+                    getOperandThroughDPSOps(enqueueReadBufferOp.getInput())),
                 cache.at<::tt::target::TensorRef>(
-                    getOperandThroughDPSOps(hostReadOp.getOutput()))),
+                    getOperandThroughDPSOps(enqueueReadBufferOp.getOutput()))),
             op);
       } else if (auto enqueueWriteBufferOp =
                      dyn_cast_or_null<tt::ttmetal::EnqueueWriteBufferOp>(op);

--- a/test/ttmlir/Silicon/TTMetal/perf_unit/test_perf_add.mlir
+++ b/test/ttmlir/Silicon/TTMetal/perf_unit/test_perf_add.mlir
@@ -5,7 +5,7 @@
 func.func @add(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
   // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
   %0 = tensor.empty() : tensor<64x128xf32>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.add"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
   return %1 : tensor<64x128xf32>
 }

--- a/test/ttmlir/Silicon/TTMetal/perf_unit/test_perf_add.mlir
+++ b/test/ttmlir/Silicon/TTMetal/perf_unit/test_perf_add.mlir
@@ -3,7 +3,7 @@
 // RUN: ttmlir-translate --ttmetal-to-flatbuffer %t.mlir > %t.ttm
 
 func.func @add(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.create_buffer"[[C:.*]]
   %0 = tensor.empty() : tensor<64x128xf32>
   // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.add"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>

--- a/test/ttmlir/Silicon/TTMetal/perf_unit/test_perf_div.mlir
+++ b/test/ttmlir/Silicon/TTMetal/perf_unit/test_perf_div.mlir
@@ -5,7 +5,7 @@
 func.func @div(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
   // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
   %0 = tensor.empty() : tensor<64x128xf32>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.div"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
   return %1 : tensor<64x128xf32>
 }

--- a/test/ttmlir/Silicon/TTMetal/perf_unit/test_perf_div.mlir
+++ b/test/ttmlir/Silicon/TTMetal/perf_unit/test_perf_div.mlir
@@ -3,7 +3,7 @@
 // RUN: ttmlir-translate --ttmetal-to-flatbuffer %t.mlir > %t.ttm
 
 func.func @div(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.create_buffer"[[C:.*]]
   %0 = tensor.empty() : tensor<64x128xf32>
   // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.div"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>

--- a/test/ttmlir/Silicon/TTMetal/perf_unit/test_perf_exp.mlir
+++ b/test/ttmlir/Silicon/TTMetal/perf_unit/test_perf_exp.mlir
@@ -3,7 +3,7 @@
 // RUN: ttmlir-translate --ttmetal-to-flatbuffer %t.mlir > %t.ttm
 
 func.func @exp(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.create_buffer"[[C:.*]]
   %0 = tensor.empty() : tensor<64x128xf32>
   // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.exp"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>

--- a/test/ttmlir/Silicon/TTMetal/perf_unit/test_perf_exp.mlir
+++ b/test/ttmlir/Silicon/TTMetal/perf_unit/test_perf_exp.mlir
@@ -5,7 +5,7 @@
 func.func @exp(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
   // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
   %0 = tensor.empty() : tensor<64x128xf32>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.exp"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
   return %1 : tensor<64x128xf32>
 }

--- a/test/ttmlir/Silicon/TTMetal/perf_unit/test_perf_max.mlir
+++ b/test/ttmlir/Silicon/TTMetal/perf_unit/test_perf_max.mlir
@@ -3,7 +3,7 @@
 // RUN: ttmlir-translate --ttmetal-to-flatbuffer %t.mlir > %t.ttm
 
 func.func @maximum(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.create_buffer"[[C:.*]]
   %0 = tensor.empty() : tensor<64x128xf32>
   // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.maximum"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>

--- a/test/ttmlir/Silicon/TTMetal/perf_unit/test_perf_max.mlir
+++ b/test/ttmlir/Silicon/TTMetal/perf_unit/test_perf_max.mlir
@@ -5,7 +5,7 @@
 func.func @maximum(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
   // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
   %0 = tensor.empty() : tensor<64x128xf32>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.maximum"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
   return %1 : tensor<64x128xf32>
 }

--- a/test/ttmlir/Silicon/TTMetal/perf_unit/test_perf_multiply.mlir
+++ b/test/ttmlir/Silicon/TTMetal/perf_unit/test_perf_multiply.mlir
@@ -3,7 +3,7 @@
 // RUN: ttmlir-translate --ttmetal-to-flatbuffer %t.mlir > %t.ttm
 
 func.func @multiply(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.create_buffer"[[C:.*]]
   %0 = tensor.empty() : tensor<64x128xf32>
   // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.multiply"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>

--- a/test/ttmlir/Silicon/TTMetal/perf_unit/test_perf_multiply.mlir
+++ b/test/ttmlir/Silicon/TTMetal/perf_unit/test_perf_multiply.mlir
@@ -5,7 +5,7 @@
 func.func @multiply(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
   // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
   %0 = tensor.empty() : tensor<64x128xf32>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.multiply"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
   return %1 : tensor<64x128xf32>
 }

--- a/test/ttmlir/Silicon/TTMetal/simple_constant.mlir
+++ b/test/ttmlir/Silicon/TTMetal/simple_constant.mlir
@@ -4,7 +4,7 @@
 
 func.func public @add5(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
   // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
-  // CHECK: %[[C:.*]] = "ttmetal.host_write"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_write_buffer"[[C:.*]]
   %0 = "ttir.constant"() <{value = dense<5.0> : tensor<32x32xf32>}> : () -> tensor<32x32xf32>
   %1 = tensor.empty() : tensor<32x32xf32>
   %2 = "ttir.add"(%arg0, %0, %1) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>

--- a/test/ttmlir/Silicon/TTMetal/simple_constant.mlir
+++ b/test/ttmlir/Silicon/TTMetal/simple_constant.mlir
@@ -3,7 +3,7 @@
 // RUN: ttmlir-translate --ttmetal-to-flatbuffer %t.mlir > %t.ttm
 
 func.func public @add5(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
-  // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.create_buffer"[[C:.*]]
   // CHECK: %[[C:.*]] = "ttmetal.enqueue_write_buffer"[[C:.*]]
   %0 = "ttir.constant"() <{value = dense<5.0> : tensor<32x32xf32>}> : () -> tensor<32x32xf32>
   %1 = tensor.empty() : tensor<32x32xf32>

--- a/test/ttmlir/Silicon/TTMetal/simple_eltwise.mlir
+++ b/test/ttmlir/Silicon/TTMetal/simple_eltwise.mlir
@@ -2,7 +2,7 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttmetal-to-flatbuffer %t.mlir > %t.ttm
 func.func @multiply(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.create_buffer"[[C:.*]]
   %0 = tensor.empty() : tensor<64x128xf32>
   // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.multiply"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
@@ -10,7 +10,7 @@ func.func @multiply(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> ten
 }
 
 func.func @add(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.create_buffer"[[C:.*]]
   %0 = tensor.empty() : tensor<64x128xf32>
   // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.add"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
@@ -18,7 +18,7 @@ func.func @add(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<6
 }
 
 func.func @exp(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.create_buffer"[[C:.*]]
   %0 = tensor.empty() : tensor<64x128xf32>
   // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.exp"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
@@ -26,7 +26,7 @@ func.func @exp(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
 }
 
 func.func @div(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.create_buffer"[[C:.*]]
   %0 = tensor.empty() : tensor<64x128xf32>
   // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.div"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>

--- a/test/ttmlir/Silicon/TTMetal/simple_eltwise.mlir
+++ b/test/ttmlir/Silicon/TTMetal/simple_eltwise.mlir
@@ -4,7 +4,7 @@
 func.func @multiply(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
   // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
   %0 = tensor.empty() : tensor<64x128xf32>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.multiply"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
   return %1 : tensor<64x128xf32>
 }
@@ -12,7 +12,7 @@ func.func @multiply(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> ten
 func.func @add(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
   // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
   %0 = tensor.empty() : tensor<64x128xf32>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.add"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
   return %1 : tensor<64x128xf32>
 }
@@ -20,7 +20,7 @@ func.func @add(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<6
 func.func @exp(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
   // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
   %0 = tensor.empty() : tensor<64x128xf32>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.exp"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
   return %1 : tensor<64x128xf32>
 }
@@ -28,7 +28,7 @@ func.func @exp(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
 func.func @div(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
   // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
   %0 = tensor.empty() : tensor<64x128xf32>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.div"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
   return %1 : tensor<64x128xf32>
 }

--- a/test/ttmlir/Silicon/TTMetal/simple_max.mlir
+++ b/test/ttmlir/Silicon/TTMetal/simple_max.mlir
@@ -3,7 +3,7 @@
 // RUN: ttmlir-translate --ttmetal-to-flatbuffer %t.mlir > %t.ttm
 
 func.func @maximum(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.create_buffer"[[C:.*]]
   %0 = tensor.empty() : tensor<64x128xf32>
   // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.maximum"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>

--- a/test/ttmlir/Silicon/TTMetal/simple_max.mlir
+++ b/test/ttmlir/Silicon/TTMetal/simple_max.mlir
@@ -5,7 +5,7 @@
 func.func @maximum(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
   // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
   %0 = tensor.empty() : tensor<64x128xf32>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.maximum"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
   return %1 : tensor<64x128xf32>
 }

--- a/test/ttmlir/Silicon/TTMetal/simple_reduce.mlir
+++ b/test/ttmlir/Silicon/TTMetal/simple_reduce.mlir
@@ -5,7 +5,7 @@
 
 func.func @reduceW(%arg0: tensor<256x384xf32, #layout1>) -> tensor<256x32xf32, #layout2> {
   %0 = tensor.empty() : tensor<256x32xf32, #layout2>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.sum"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
                                dim_arg = [-1: i32],
                                keep_dim = true}> :
@@ -16,7 +16,7 @@ func.func @reduceW(%arg0: tensor<256x384xf32, #layout1>) -> tensor<256x32xf32, #
 #layout3 = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <1x4>, memref<32x96xf32, #l1_>>
 func.func @reduceH(%arg0: tensor<256x384xf32, #layout1>) -> tensor<32x384xf32, #layout3> {
   %0 = tensor.empty() : tensor<32x384xf32, #layout3>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.sum"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
                                dim_arg = [-2: i32],
                                keep_dim = true}> :
@@ -27,7 +27,7 @@ func.func @reduceH(%arg0: tensor<256x384xf32, #layout1>) -> tensor<32x384xf32, #
 #layout4 = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<32x32xf32, #l1_>>
 func.func @reduceWH(%arg0: tensor<256x384xf32, #layout1>) -> tensor<32x32xf32, #layout4> {
   %0 = tensor.empty() : tensor<32x32xf32, #layout4>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.sum"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
                                dim_arg = [-1: i32, -2: i32],
                                keep_dim = true}> :
@@ -37,7 +37,7 @@ func.func @reduceWH(%arg0: tensor<256x384xf32, #layout1>) -> tensor<32x32xf32, #
 
 func.func @maxReduceWH(%arg0: tensor<256x384xf32, #layout1>) -> tensor<32x32xf32, #layout4> {
   %0 = tensor.empty() : tensor<32x32xf32, #layout4>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.max" (%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
                                dim_arg = [-1: i32, -2: i32],
                                keep_dim = true}> :

--- a/test/ttmlir/Silicon/TTMetal/simple_reduce_1x1.mlir
+++ b/test/ttmlir/Silicon/TTMetal/simple_reduce_1x1.mlir
@@ -3,7 +3,7 @@
 
 func.func @reduceW(%arg0: tensor<64x256xf32>) -> tensor<64x32xf32> {
   %0 = tensor.empty() : tensor<64x32xf32>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.sum"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
                                dim_arg = [-1: i32],
                                keep_dim = true}> :
@@ -13,7 +13,7 @@ func.func @reduceW(%arg0: tensor<64x256xf32>) -> tensor<64x32xf32> {
 
 func.func @reduceH(%arg0: tensor<256x64xf32>) -> tensor<32x64xf32> {
   %0 = tensor.empty() : tensor<32x64xf32>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.sum"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
                                dim_arg = [-2: i32],
                                keep_dim = true}> :
@@ -23,7 +23,7 @@ func.func @reduceH(%arg0: tensor<256x64xf32>) -> tensor<32x64xf32> {
 
 func.func @reduceWH(%arg0: tensor<256x64xf32>) -> tensor<32x32xf32> {
   %0 = tensor.empty() : tensor<32x32xf32>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.sum"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
                                dim_arg = [-1: i32, -2: i32],
                                keep_dim = true}> :

--- a/test/ttmlir/Silicon/TTMetal/tiled_reblock.mlir
+++ b/test/ttmlir/Silicon/TTMetal/tiled_reblock.mlir
@@ -9,15 +9,15 @@
 #tilized2x2 = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <2x2>, memref<1x2x!tt.tile<32 x 32, f32>, #l1_>>
 #untilized2x2 = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <2x2>, memref<32x64xf32, #l1_>>
 func.func @tilize_reblock_2D(%arg0: tensor<64x128xf32, #untilized>) -> tensor<64x128xf32, #untilized2x2> {
-  // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.create_buffer"[[C:.*]]
   %0 = tensor.empty() : tensor<64x128xf32, #tilized>
   // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.to_layout"(%arg0, %0) : (tensor<64x128xf32, #untilized>, tensor<64x128xf32, #tilized>) -> tensor<64x128xf32, #tilized>
-  // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.create_buffer"[[C:.*]]
   %2 = tensor.empty() : tensor<64x128xf32, #tilized2x2>
   // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %3 = "ttir.to_layout"(%1, %2) : (tensor<64x128xf32, #tilized>, tensor<64x128xf32, #tilized2x2>) -> tensor<64x128xf32, #tilized2x2>
-  // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.create_buffer"[[C:.*]]
   %4 = tensor.empty() : tensor<64x128xf32, #untilized2x2>
   // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %5 = "ttir.to_layout"(%3, %4) : (tensor<64x128xf32, #tilized2x2>, tensor<64x128xf32, #untilized2x2>) -> tensor<64x128xf32, #untilized2x2>
@@ -30,17 +30,17 @@ func.func @tilize_reblock_2D(%arg0: tensor<64x128xf32, #untilized>) -> tensor<64
 #tilized4D_2x2 = #tt.metal_layout<(d0, d1, d2, d3) -> (d0 * 192 + d1 * 64 + d2, d3), undef, <2x2>, memref<6x2x!tt.tile<32 x 32, f32>, #l1_>>
 #untilized4D_2x2 = #tt.metal_layout<(d0, d1, d2, d3) -> (d0 * 192 + d1 * 64 + d2, d3), undef, <2x2>, memref<192x64xf32, #l1_>>
 func.func @tilize_reblock_4D(%arg0: tensor<2x3x64x128xf32, #untilized4D>) -> tensor<2x3x64x128xf32, #untilized4D_2x2> {
-  // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.create_buffer"[[C:.*]]
   %0 = tensor.empty() : tensor<2x3x64x128xf32, #tilized4D>
   // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.to_layout"(%arg0, %0) : (tensor<2x3x64x128xf32, #untilized4D>, tensor<2x3x64x128xf32, #tilized4D>) -> tensor<2x3x64x128xf32, #tilized4D>
 
-  // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.create_buffer"[[C:.*]]
   %2 = tensor.empty() : tensor<2x3x64x128xf32, #tilized4D_2x2>
   // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %3 = "ttir.to_layout"(%1, %2) : (tensor<2x3x64x128xf32, #tilized4D>, tensor<2x3x64x128xf32, #tilized4D_2x2>) -> tensor<2x3x64x128xf32, #tilized4D_2x2>
 
-  // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.create_buffer"[[C:.*]]
   %4 = tensor.empty() : tensor<2x3x64x128xf32, #untilized4D_2x2>
   // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %5 = "ttir.to_layout"(%3, %4) : (tensor<2x3x64x128xf32, #tilized4D_2x2>, tensor<2x3x64x128xf32, #untilized4D_2x2>) -> tensor<2x3x64x128xf32, #untilized4D_2x2>
@@ -54,31 +54,31 @@ func.func @tilize_reblock_4D(%arg0: tensor<2x3x64x128xf32, #untilized4D>) -> ten
 #tilized_big_3x6 = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <3x6>, memref<1x1x!tt.tile<32 x 32, f32>, #l1_>>
 func.func @tilize_reblock_big(%arg0: tensor<96x192xf32, #untilized_big>) -> tensor<96x192xf32, #untilized_big> {
   // move to tilized 1x1
-  // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.create_buffer"[[C:.*]]
   %0 = tensor.empty() : tensor<96x192xf32, #tilized_big>
   // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.to_layout"(%arg0, %0) : (tensor<96x192xf32, #untilized_big>, tensor<96x192xf32, #tilized_big>) -> tensor<96x192xf32, #tilized_big>
 
   // move to tilized 2x3
-  // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.create_buffer"[[C:.*]]
   %2 = tensor.empty() : tensor<96x192xf32, #tilized_big_3x2>
   // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %3 = "ttir.to_layout"(%1, %2) : (tensor<96x192xf32, #tilized_big>, tensor<96x192xf32, #tilized_big_3x2>) -> tensor<96x192xf32, #tilized_big_3x2>
 
   // move to tilized 3x3
-  // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.create_buffer"[[C:.*]]
   %4 = tensor.empty() : tensor<96x192xf32, #tilized_big_3x6>
   // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %5 = "ttir.to_layout"(%3, %4) : (tensor<96x192xf32, #tilized_big_3x2>, tensor<96x192xf32, #tilized_big_3x6>) -> tensor<96x192xf32, #tilized_big_3x6>
 
   // move back to tilized 1x1
-  // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.create_buffer"[[C:.*]]
   %6 = tensor.empty() : tensor<96x192xf32, #tilized_big>
   // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %7 = "ttir.to_layout"(%5, %6) : (tensor<96x192xf32, #tilized_big_3x6>, tensor<96x192xf32, #tilized_big>) -> tensor<96x192xf32, #tilized_big>
 
   // untilize
-  // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.create_buffer"[[C:.*]]
   %8 = tensor.empty() : tensor<96x192xf32, #untilized_big>
   // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %9 = "ttir.to_layout"(%7, %8) : (tensor<96x192xf32, #tilized_big>, tensor<96x192xf32, #untilized_big>) -> tensor<96x192xf32, #untilized_big>

--- a/test/ttmlir/Silicon/TTMetal/tiled_reblock.mlir
+++ b/test/ttmlir/Silicon/TTMetal/tiled_reblock.mlir
@@ -11,15 +11,15 @@
 func.func @tilize_reblock_2D(%arg0: tensor<64x128xf32, #untilized>) -> tensor<64x128xf32, #untilized2x2> {
   // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
   %0 = tensor.empty() : tensor<64x128xf32, #tilized>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.to_layout"(%arg0, %0) : (tensor<64x128xf32, #untilized>, tensor<64x128xf32, #tilized>) -> tensor<64x128xf32, #tilized>
   // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
   %2 = tensor.empty() : tensor<64x128xf32, #tilized2x2>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %3 = "ttir.to_layout"(%1, %2) : (tensor<64x128xf32, #tilized>, tensor<64x128xf32, #tilized2x2>) -> tensor<64x128xf32, #tilized2x2>
   // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
   %4 = tensor.empty() : tensor<64x128xf32, #untilized2x2>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %5 = "ttir.to_layout"(%3, %4) : (tensor<64x128xf32, #tilized2x2>, tensor<64x128xf32, #untilized2x2>) -> tensor<64x128xf32, #untilized2x2>
   return %5 : tensor<64x128xf32, #untilized2x2>
 }
@@ -32,17 +32,17 @@ func.func @tilize_reblock_2D(%arg0: tensor<64x128xf32, #untilized>) -> tensor<64
 func.func @tilize_reblock_4D(%arg0: tensor<2x3x64x128xf32, #untilized4D>) -> tensor<2x3x64x128xf32, #untilized4D_2x2> {
   // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
   %0 = tensor.empty() : tensor<2x3x64x128xf32, #tilized4D>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.to_layout"(%arg0, %0) : (tensor<2x3x64x128xf32, #untilized4D>, tensor<2x3x64x128xf32, #tilized4D>) -> tensor<2x3x64x128xf32, #tilized4D>
 
   // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
   %2 = tensor.empty() : tensor<2x3x64x128xf32, #tilized4D_2x2>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %3 = "ttir.to_layout"(%1, %2) : (tensor<2x3x64x128xf32, #tilized4D>, tensor<2x3x64x128xf32, #tilized4D_2x2>) -> tensor<2x3x64x128xf32, #tilized4D_2x2>
 
   // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
   %4 = tensor.empty() : tensor<2x3x64x128xf32, #untilized4D_2x2>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %5 = "ttir.to_layout"(%3, %4) : (tensor<2x3x64x128xf32, #tilized4D_2x2>, tensor<2x3x64x128xf32, #untilized4D_2x2>) -> tensor<2x3x64x128xf32, #untilized4D_2x2>
 
   return %5 : tensor<2x3x64x128xf32, #untilized4D_2x2>
@@ -56,31 +56,31 @@ func.func @tilize_reblock_big(%arg0: tensor<96x192xf32, #untilized_big>) -> tens
   // move to tilized 1x1
   // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
   %0 = tensor.empty() : tensor<96x192xf32, #tilized_big>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.to_layout"(%arg0, %0) : (tensor<96x192xf32, #untilized_big>, tensor<96x192xf32, #tilized_big>) -> tensor<96x192xf32, #tilized_big>
 
   // move to tilized 2x3
   // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
   %2 = tensor.empty() : tensor<96x192xf32, #tilized_big_3x2>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %3 = "ttir.to_layout"(%1, %2) : (tensor<96x192xf32, #tilized_big>, tensor<96x192xf32, #tilized_big_3x2>) -> tensor<96x192xf32, #tilized_big_3x2>
 
   // move to tilized 3x3
   // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
   %4 = tensor.empty() : tensor<96x192xf32, #tilized_big_3x6>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %5 = "ttir.to_layout"(%3, %4) : (tensor<96x192xf32, #tilized_big_3x2>, tensor<96x192xf32, #tilized_big_3x6>) -> tensor<96x192xf32, #tilized_big_3x6>
 
   // move back to tilized 1x1
   // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
   %6 = tensor.empty() : tensor<96x192xf32, #tilized_big>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %7 = "ttir.to_layout"(%5, %6) : (tensor<96x192xf32, #tilized_big_3x6>, tensor<96x192xf32, #tilized_big>) -> tensor<96x192xf32, #tilized_big>
 
   // untilize
   // CHECK: %[[C:.*]] = "ttmetal.alloc"[[C:.*]]
   %8 = tensor.empty() : tensor<96x192xf32, #untilized_big>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %9 = "ttir.to_layout"(%7, %8) : (tensor<96x192xf32, #tilized_big>, tensor<96x192xf32, #untilized_big>) -> tensor<96x192xf32, #untilized_big>
 
   return %9 : tensor<96x192xf32, #untilized_big>

--- a/test/ttmlir/Silicon/TTMetal/to_layout.mlir
+++ b/test/ttmlir/Silicon/TTMetal/to_layout.mlir
@@ -9,7 +9,7 @@
 #layout1 = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <2x2>, memref<2x8xf32, #l1_>>
 func.func @simple(%arg0: tensor<4x16xf32, #layout>) -> tensor<4x16xf32, #layout1> {
   %0 = tensor.empty() : tensor<4x16xf32, #layout1>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.to_layout"(%arg0, %0) : (tensor<4x16xf32, #layout>, tensor<4x16xf32, #layout1>) -> tensor<4x16xf32, #layout1>
   return %1 : tensor<4x16xf32, #layout1>
 }
@@ -18,10 +18,10 @@ func.func @simple(%arg0: tensor<4x16xf32, #layout>) -> tensor<4x16xf32, #layout1
 #tilized = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<2x4x!tt.tile<32 x 32, f32>, #l1_>>
 func.func @tilize(%arg0: tensor<64x128xf32, #untilized>) -> tensor<64x128xf32, #untilized> {
   %0 = tensor.empty() : tensor<64x128xf32, #tilized>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.to_layout"(%arg0, %0) : (tensor<64x128xf32, #untilized>, tensor<64x128xf32, #tilized>) -> tensor<64x128xf32, #tilized>
   %2 = tensor.empty() : tensor<64x128xf32, #untilized>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %3 = "ttir.to_layout"(%1, %2) : (tensor<64x128xf32, #tilized>, tensor<64x128xf32, #untilized>) -> tensor<64x128xf32, #untilized>
   return %3 : tensor<64x128xf32, #untilized>
 }
@@ -33,27 +33,27 @@ func.func @tilize(%arg0: tensor<64x128xf32, #untilized>) -> tensor<64x128xf32, #
 #untilized1x4_l1 = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <1x4>, memref<16x16xf32, #l1_>>
 func.func @dram_to_l1(%arg0: tensor<16x64xf32, #untilized_dram>) -> tensor<16x64xf32, #untilized_l1> {
   %0 = tensor.empty() : tensor<16x64xf32, #untilized_l1>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.to_layout"(%arg0, %0) : (tensor<16x64xf32, #untilized_dram>, tensor<16x64xf32, #untilized_l1>) -> tensor<16x64xf32, #untilized_l1>
   return %1 : tensor<16x64xf32, #untilized_l1>
 }
 
 func.func @l1_to_dram(%arg0: tensor<16x64xf32, #untilized_l1>) -> tensor<16x64xf32, #untilized_dram> {
   %0 = tensor.empty() : tensor<16x64xf32, #untilized_dram>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.to_layout"(%arg0, %0) : (tensor<16x64xf32, #untilized_l1>, tensor<16x64xf32, #untilized_dram>) -> tensor<16x64xf32, #untilized_dram>
   return %1 : tensor<16x64xf32, #untilized_dram>
 }
 
 func.func @l1dram_reblock0(%arg0: tensor<16x64xf32, #untilized_l1>) -> tensor<16x64xf32, #untilized_l1> {
   %0 = tensor.empty() : tensor<16x64xf32, #untilized2x2_dram>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %1 = "ttir.to_layout"(%arg0, %0) : (tensor<16x64xf32, #untilized_l1>, tensor<16x64xf32, #untilized2x2_dram>) -> tensor<16x64xf32, #untilized2x2_dram>
   %2 = tensor.empty() : tensor<16x64xf32, #untilized1x4_l1>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %3 = "ttir.to_layout"(%1, %2) : (tensor<16x64xf32, #untilized2x2_dram>, tensor<16x64xf32, #untilized1x4_l1>) -> tensor<16x64xf32, #untilized1x4_l1>
   %4 = tensor.empty() : tensor<16x64xf32, #untilized_l1>
-  // CHECK: %[[C:.*]] = "ttmetal.dispatch"[[C:.*]]
+  // CHECK: %[[C:.*]] = "ttmetal.enqueue_program"[[C:.*]]
   %5 = "ttir.to_layout"(%3, %4) : (tensor<16x64xf32, #untilized1x4_l1>, tensor<16x64xf32, #untilized_l1>) -> tensor<16x64xf32, #untilized_l1>
   return %5 : tensor<16x64xf32, #untilized_l1>
 }


### PR DESCRIPTION
Ticket: #364 

Refactors:
- DispatchOp -> EnqueueProgramOp
- HostWriteOp -> EnqueueWriteBufferOp
- HostReadOp -> EnqueueReadBufferOp
- AllocOp -> CreateBufferOp
- DeallocOp -> DeallocateBufferOp