### PR TITLE
Uplift third_party/tt-metal to 182c42462cd61515f60a11a46ee84f303ed073ee 2025-01-23

### DIFF
--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -130,6 +130,8 @@ def TTKernel_CopyTileInitOp : TTKernel_Op<"copy_tile_init"> {
     let description = [{
       Must be called before copy_tile.
     }];
+
+    let arguments = (ins TTKernel_CB:$cb0);
 }
 
 def TTKernel_CopyTileOp : TTKernel_Op<"copy_tile"> {

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
@@ -875,6 +875,7 @@ public:
 
     // For all unary ops first copy tile from input CB at inCBTileIndex to DST
     // register at dstTileIndex.
+    builder.create<ttkernel::CopyTileInitOp>(location, inCB);
     builder.create<ttkernel::CopyTileOp>(location, inCB, inCBTileIndex,
                                          dstTileIndex);
 
@@ -1010,9 +1011,10 @@ public:
     builder.create<ttkernel::TileRegsAcquireOp>(location);
     {
       // copy inCB0[inCB0TileIndex] and inCB1[inCB1TileIndex] to DST:
-      builder.create<ttkernel::CopyTileInitOp>(location);
+      builder.create<ttkernel::CopyTileInitOp>(location, inCB0);
       builder.create<ttkernel::CopyTileOp>(location, inCB0, inCB0TileIndex,
                                            dstLhsTileIndex);
+      builder.create<ttkernel::CopyTileInitOp>(location, inCB1);
       builder.create<ttkernel::CopyTileOp>(location, inCB1, inCB1TileIndex,
                                            dstRhsTileIndex);
       // SFPU operates on DST tiles:
@@ -1077,7 +1079,7 @@ public:
     auto inputCB = cbOperands[operandIndices[0]];
     auto outputCB = inputCB;
 
-    builder.create<ttkernel::CopyTileInitOp>(op.getLoc());
+    builder.create<ttkernel::CopyTileInitOp>(op.getLoc(), inputCB);
     builder.create<ttkernel::CBReserveBackOp>(op.getLoc(), inputCB, one);
     builder.create<ttkernel::TileRegsAcquireOp>(op.getLoc());
     builder.create<ttkernel::RecipTileInitOp>(op.getLoc());

--- a/lib/OpModel/TTNN/TTNNOpModelLib.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModelLib.cpp
@@ -47,7 +47,7 @@ std::tuple<bool, std::optional<std::tuple<size_t, size_t, size_t>>,
            std::optional<std::string>>
 getOpConstraints(const std::string_view &name, Callable &callable,
                  auto &&...args) {
-  ::ttnn::graph::QueryResponse query;
+  ::ttnn::graph::ConstraintQueryResponse query;
   try {
     query = callable(std::forward<decltype(args)>(args)...);
   } catch (const std::exception &e) {

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -81,7 +81,7 @@ createOwnedTensor(std::shared_ptr<void> data,
 
   return ::ttnn::Tensor(
       createStorage<OwnedStorage>(data.get(), numElements, dataType),
-      ::ttnn::Shape(small_vector_shape), utils::toTTNNDataType(dataType),
+      ::ttnn::SimpleShape(small_vector_shape), utils::toTTNNDataType(dataType),
       ::ttnn::Layout::ROW_MAJOR);
 }
 
@@ -128,7 +128,7 @@ Tensor createTensor(std::shared_ptr<void> data,
 
   auto tensor = std::make_shared<::ttnn::Tensor>(
       createStorage<BorrowedStorage>(data.get(), numElements, dataType),
-      ::ttnn::Shape(small_vector_shape), utils::toTTNNDataType(dataType),
+      ::ttnn::SimpleShape(small_vector_shape), utils::toTTNNDataType(dataType),
       ::ttnn::Layout::ROW_MAJOR);
   return Tensor(std::static_pointer_cast<void>(tensor), nullptr,
                 DeviceRuntime::TTNN);

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -39,7 +39,7 @@ set(TTMETAL_INCLUDE_DIRS
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/fmt/73b5ec45edbd92babfd91c3777a9e1ab9cac8238/include
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/magic_enum/4d76fe0a5b27a0e62d6c15976d02b33c54207096/include
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/boost_core/e679bef5c160cf29d0f37d549881dc5f5a58c332/include
-  ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/json/230202b6f5267cbf0c8e5a2f17301964d95f83ff/include
+  ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/json/798e0374658476027d9723eeb67a262d0f3c8308/include
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/xtensor/4a957e26c765b48cbec4a4235fe9e518d5a85d3d/include
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/xtensor-blas/190c3a4314355b67291a7d78b20a2100de3f8f54/include
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/xtl/0918808959d33a292c551b9f014a0e808bc4a95c/include
@@ -72,6 +72,7 @@ ExternalProject_Add(
     -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
     -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
     -DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}
+    -DCMAKE_CXX_SCAN_FOR_MODULES=FALSE
     -DENABLE_TRACY=${TT_RUNTIME_ENABLE_PERF_TRACE}
     -DENABLE_LIBCXX=OFF
   GIT_REPOSITORY https://github.com/tenstorrent/tt-metal.git

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "78f2c0b774ab48bf243093d3111717a8c880dc78")
+set(TT_METAL_VERSION "182c42462cd61515f60a11a46ee84f303ed073ee")
 
 if ("$ENV{ARCH_NAME}" STREQUAL "grayskull")
   set(ARCH_NAME "grayskull")

--- a/tools/ttnn-standalone/CMakeLists.txt
+++ b/tools/ttnn-standalone/CMakeLists.txt
@@ -61,7 +61,7 @@ set(INCLUDE_DIRS
     $ENV{TT_METAL_HOME}/.cpmcache/fmt/73b5ec45edbd92babfd91c3777a9e1ab9cac8238/include
     $ENV{TT_METAL_HOME}/.cpmcache/magic_enum/4d76fe0a5b27a0e62d6c15976d02b33c54207096/include
     $ENV{TT_METAL_HOME}/.cpmcache/boost_core/e679bef5c160cf29d0f37d549881dc5f5a58c332/include
-    $ENV{TT_METAL_HOME}/.cpmcache/json/230202b6f5267cbf0c8e5a2f17301964d95f83ff/include
+    $ENV{TT_METAL_HOME}/.cpmcache/json/798e0374658476027d9723eeb67a262d0f3c8308/include
 
     # Metalium
     $ENV{TT_METAL_HOME}


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 182c42462cd61515f60a11a46ee84f303ed073ee

- update type name (QueryResponse is now ConstraintQueryResponse)
- Remove reference to Tensor constructor deprecated in metal commit ba35246703
- Update json cpmcache hash include dir and use temp workaround to set -DCMAKE_CXX_SCAN_FOR_MODULES=FALSE
- Update copy_tile_init API to accept CB argument
