### PR TITLE
MLIR Op locations

### DIFF
--- a/include/ttmlir/Conversion/TTIRToTTNN/TTIRToTTNN.h
+++ b/include/ttmlir/Conversion/TTIRToTTNN/TTIRToTTNN.h
@@ -5,10 +5,27 @@
 #ifndef TTMLIR_CONVERSION_TTIRTOTTNN_TTIRTOTTNN_H
 #define TTMLIR_CONVERSION_TTIRTOTTNN_TTIRTOTTNN_H
 
+#include "ttmlir/Dialect/TTIR/IR/TTIR.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNN.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Location/PassOpLoc.h"
+
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 
 namespace mlir::tt {
+
+#define GEN_PASS_DEF_CONVERTTTIRTOTTNN
+#include "ttmlir/Conversion/Passes.h.inc"
+
+namespace ttir {
+struct ConvertTTIRToTTNNPass
+    : public impl::ConvertTTIRToTTNNBase<ConvertTTIRToTTNNPass> {
+  void runOnOperation() final;
+  inline static mlir::ttmlir::PassOpLocFrom loc =
+      mlir::ttmlir::PassOpLocFrom(ConvertTTIRToTTNNPass::getArgumentName());
+};
+} // namespace ttir
 
 void populateTTIRToTTNNPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
                                 TypeConverter &typeConverter);

--- a/include/ttmlir/Dialect/TTIR/Transforms/Layout.h
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Layout.h
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TT/IR/TT.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
+#include "ttmlir/Location/PassOpLoc.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir {
+namespace tt {
+namespace ttir {
+#define GEN_PASS_DEF_TTIRLAYOUT
+#define GEN_PASS_DEF_TTIRSPLITCOMPOUNDLAYOUT
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h.inc"
+
+class TTIRLayout : public impl::TTIRLayoutBase<TTIRLayout> {
+public:
+  using impl::TTIRLayoutBase<TTIRLayout>::TTIRLayoutBase;
+
+  void runOnOperation() final;
+  void getDependentDialects(mlir::DialectRegistry &registry) const override;
+
+  inline static mlir::ttmlir::PassOpLocFrom loc =
+      mlir::ttmlir::PassOpLocFrom(TTIRLayout::getArgumentName());
+};
+
+class TTIRSplitCompoundLayout
+    : public impl::TTIRSplitCompoundLayoutBase<TTIRSplitCompoundLayout> {
+public:
+  using impl::TTIRSplitCompoundLayoutBase<
+      TTIRSplitCompoundLayout>::TTIRSplitCompoundLayoutBase;
+
+  void runOnOperation() final;
+
+  void getDependentDialects(mlir::DialectRegistry &registry) const override;
+
+  inline static mlir::ttmlir::PassOpLocFrom loc =
+      mlir::ttmlir::PassOpLocFrom(TTIRLayout::getArgumentName());
+};
+} // namespace ttir
+} // namespace tt
+} // namespace mlir

--- a/include/ttmlir/Dialect/TTNN/Utils/TransformUtils.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/TransformUtils.h
@@ -14,30 +14,10 @@
 
 namespace mlir::tt::ttnn::utils {
 // Get or insert device for the given operation.
-inline GetDeviceOp
+GetDeviceOp
 getOrInsertDevice(mlir::PatternRewriter &rewriter, mlir::Operation *op,
                   llvm::function_ref<mlir::Location(mlir::Location)> locFn =
-                      ::ttmlir::utils::identity<mlir::Location>) {
-  Block *block = op->getBlock();
-  for (auto &op : block->getOperations()) {
-    if (auto deviceOp = dyn_cast<ttnn::GetDeviceOp>(op)) {
-      return deviceOp;
-    }
-  }
-
-  DeviceAttr deviceAttr = getCurrentScopeDevice(op);
-  auto currentInsertionPoint = rewriter.saveInsertionPoint();
-  rewriter.setInsertionPoint(block, block->begin());
-  llvm::SmallVector<int64_t> meshShape{deviceAttr.getMeshShape()};
-  if (meshShape.empty()) {
-    meshShape = llvm::SmallVector<int64_t, 2>{1, 1};
-  }
-  auto deviceOp = rewriter.create<ttnn::GetDeviceOp>(
-      locFn(op->getLoc()), rewriter.getType<DeviceType>(deviceAttr),
-      ttnn::MeshShapeAttr::get(op->getContext(), meshShape[0], meshShape[1]));
-  rewriter.restoreInsertionPoint(currentInsertionPoint);
-  return deviceOp;
-}
+                      ::ttmlir::utils::identity<mlir::Location>);
 
 // Helper method to insert a ToLayoutOp to convert the input operand to the
 // desired tensor layout, buffer type and memory layout.
@@ -47,7 +27,9 @@ createToLayoutOp(mlir::Operation *op,
                  PatternRewriter &rewriter, Layout targetTensorLayout,
                  BufferType targetTensorBufferType,
                  std::optional<TensorMemoryLayout> targetTensorMemoryLayout,
-                 DataType targetTensorDataType);
+                 DataType targetTensorDataType,
+                 llvm::function_ref<mlir::Location(mlir::Location)> locFn =
+                     ::ttmlir::utils::identity<mlir::Location>);
 } // namespace mlir::tt::ttnn::utils
 
 #endif

--- a/include/ttmlir/Location/PassOpLoc.h
+++ b/include/ttmlir/Location/PassOpLoc.h
@@ -17,6 +17,9 @@ public:
   using NameLoc::NameLoc;
 
   static PassOpLoc get(mlir::StringRef name, mlir::Location loc) {
+    if (auto passOpLoc = mlir::dyn_cast<PassOpLoc>(loc)) {
+      loc = passOpLoc.getChildLoc();
+    }
     return mlir::cast<PassOpLoc>(mlir::NameLoc::get(
         mlir::StringAttr::get(loc.getContext(), prefix + name), loc));
   }
@@ -30,7 +33,7 @@ public:
   static constexpr llvm::StringRef name = "ttmlir.pass_op_loc";
 
 private:
-  static constexpr llvm::StringRef prefix = "-";
+  static constexpr llvm::StringRef prefix = "pass-";
 };
 
 class PassOpLocFrom {

--- a/include/ttmlir/Location/PassOpLoc.h
+++ b/include/ttmlir/Location/PassOpLoc.h
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_LOCATION_PASSOPLOC_H
+#define TTMLIR_LOCATION_PASSOPLOC_H
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Location.h"
+#include <llvm/ADT/StringRef.h>
+
+namespace mlir {
+namespace ttmlir {
+
+class PassOpLoc : public mlir::NameLoc {
+public:
+  using NameLoc::NameLoc;
+
+  static PassOpLoc get(mlir::StringRef name, mlir::Location loc) {
+    return mlir::cast<PassOpLoc>(mlir::NameLoc::get(
+        mlir::StringAttr::get(loc.getContext(), prefix + name), loc));
+  }
+
+  static bool classof(const mlir::Attribute attr) {
+    return llvm::isa<mlir::NameLoc>(attr) &&
+           llvm::cast<mlir::NameLoc>(attr).getName().strref().starts_with(
+               prefix);
+  }
+
+  static constexpr llvm::StringRef name = "ttmlir.pass_op_loc";
+
+private:
+  static constexpr llvm::StringRef prefix = "-";
+};
+
+class PassOpLocFrom {
+public:
+  PassOpLocFrom(llvm::StringRef passName) : m_name{passName} {}
+
+  PassOpLoc operator()(mlir::Location loc) const {
+    return PassOpLoc::get(m_name, loc);
+  }
+
+private:
+  std::string m_name;
+};
+
+} // namespace ttmlir
+} // namespace mlir
+
+#endif // TTMLIR_LOCATION_PASSOPLOC_H

--- a/lib/Dialect/TTNN/Transforms/Passes.cpp
+++ b/lib/Dialect/TTNN/Transforms/Passes.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
+#include "ttmlir/Location/PassOpLoc.h"
 
 #include "ttmlir/Dialect/TT/IR/TTOps.h"
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
@@ -106,11 +107,14 @@ public:
           }
 
           rewriter.setInsertionPointAfter(lastOp);
-          rewriter.create<DeallocateOp>(lastOp->getLoc(), result);
+          rewriter.create<DeallocateOp>(loc(lastOp->getLoc()), result);
         }
       });
     });
   }
+
+  inline static mlir::ttmlir::PassOpLocFrom loc =
+      mlir::ttmlir::PassOpLocFrom(TTNNDeallocate::getArgumentName());
 };
 
 class TTNNCreateInputGenerators

--- a/lib/Dialect/TTNN/Transforms/TTNNDecomposeLayouts.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNDecomposeLayouts.cpp
@@ -4,6 +4,7 @@
 
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+#include "ttmlir/Location/PassOpLoc.h"
 
 namespace mlir::tt::ttnn {
 #define GEN_PASS_DEF_TTNNDECOMPOSELAYOUTS
@@ -216,7 +217,7 @@ private:
                        mlir::Value currentInput, Args... args) const {
 
     rewriter.setInsertionPoint(op);
-    return rewriter.create<OpType>(op.getLoc(), op.getType(), currentInput,
+    return rewriter.create<OpType>(loc(op.getLoc()), op.getType(), currentInput,
                                    args...);
   }
 
@@ -783,5 +784,9 @@ private:
     }
     handleDeviceInputLayoutConversion(op, rewriter, currentInput, info);
   }
+
+public:
+  inline static mlir::ttmlir::PassOpLocFrom loc =
+      mlir::ttmlir::PassOpLocFrom(TTNNDecomposeLayouts::getArgumentName());
 };
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
@@ -371,8 +371,8 @@ public:
         continue;
       }
 
-      Location newLoc =
-          appendInputSuffix(op.getLoc(), operand.getOperandNumber());
+      Location newLoc = TTNNLayout::loc(
+          appendInputSuffix(op.getLoc(), operand.getOperandNumber()));
       // Given the operand constraint, create the desired layout for the operand
       std::optional<Value> desiredLayout = createToLayoutOp(
           rewriter, newLoc, operand.get(), g_defaultMemorySpaceDevice,
@@ -409,8 +409,8 @@ public:
                                 PatternRewriter &rewriter) const final {
     bool modified = false;
     for (OpOperand &operand : op->getOpOperands()) {
-      Location newLoc =
-          appendInputSuffix(op.getLoc(), operand.getOperandNumber());
+      Location newLoc = TTNNLayout::loc(
+          appendInputSuffix(op.getLoc(), operand.getOperandNumber()));
       std::optional<Value> layout = createToLayoutOp(
           rewriter, newLoc, operand.get(), BufferType::SystemMemory,
           nullptr /* tensorMemoryLayoutAttr */, false /* tiled */);

--- a/lib/Dialect/TTNN/Utils/TransformUtils.cpp
+++ b/lib/Dialect/TTNN/Utils/TransformUtils.cpp
@@ -9,30 +9,6 @@
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 
 namespace mlir::tt::ttnn::utils {
-// Gets or inserts a GetDeviceOp at the top of the current block of the given
-// operation.
-GetDeviceOp getOrInsertDevice(PatternRewriter &rewriter, Operation *op) {
-  Block *block = op->getBlock();
-  for (auto &op : block->getOperations()) {
-    if (auto deviceOp = dyn_cast<ttnn::GetDeviceOp>(op)) {
-      return deviceOp;
-    }
-  }
-
-  DeviceAttr deviceAttr = getCurrentScopeDevice(op);
-  auto currentInsertionPoint = rewriter.saveInsertionPoint();
-  rewriter.setInsertionPoint(block, block->begin());
-  llvm::SmallVector<int64_t> meshShape{deviceAttr.getMeshShape()};
-  if (meshShape.empty()) {
-    meshShape = llvm::SmallVector<int64_t, 2>{1, 1};
-  }
-  auto deviceOp = rewriter.create<ttnn::GetDeviceOp>(
-      op->getLoc(), rewriter.getType<DeviceType>(deviceAttr),
-      ttnn::MeshShapeAttr::get(op->getContext(), meshShape[0], meshShape[1]));
-  rewriter.restoreInsertionPoint(currentInsertionPoint);
-  return deviceOp;
-}
-
 // Helper method to insert a ToLayoutOp to convert the input operand to the
 // desired tensor layout, buffer type and memory layout.
 ToLayoutOp


### PR DESCRIPTION
**THIS IS A DRAFT PR TO GET EARLY FEEDBACK**

I've implemented `PassOpLoc` from the linked issue design proposal and added it in a few passes, there are still some passes that should wrap their locations, but I've intentionally left them out in case there is a flow in design, not to waste the time. I haven't found any case of fusion yet, but as I said in the design proposal there is already a builtin `FusedLoc` so the hardest part will be enforcing it, but for defining infrastructure already exists.

If this looks okay to stakeholders I will continue adding a location wrapper in the rest of the passes, and refactor some of the existing code. I will also add some examples of fusion just to be able to test it.

@tapspatel This is not exactly the same as your example from the design proposal, the main difference is with `arg0`. What I found is that location is the property of any `Value` not just an `Op`, so you might be able to get the same effect if you set location of `arg0` to `arg0` (though `to_layout(%arg0)...` will still set it as `PassOpLoc` wrapped around `arg0`, so I'm not sure if it makes it ambiguous, and how we should treat this case).

Linked issue: https://github.com/tenstorrent/tt-mlir/issues/1745