### PR TITLE
Add Conversion from StableHLO Padding Op along with end-to-end Implementation

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -1256,6 +1256,41 @@ def TTIR_ReshapeOp: TTIR_DPSOp<"reshape"> {
     let hasFolder = 1;
 }
 
+def TTIR_PadOp: TTIR_Op<"pad"> {
+    let summary = "Pad op.";
+    let description = [{
+      Pad input tensor with tuple of padding values.
+
+      The `padding` attribute must be a sequence of integers that is twice the size as the rank of the input.
+      Each pair of integers in the padding attribute represents the amount of padding to add to the low and high of that dimension.
+      I.e: an input tensor of shape <1x30x30x64xf32> with padding attribute <0, 0, 1, 1, 1, 1, 0, 0> will return a tensor of shape <1x32x32x64xf32>,
+      and so will a padding attribute of <0, 0, 0, 2, 0, 2, 0, 0>.
+
+      Example:
+      input: [[1, 2, 3],
+              [4, 5, 6]]
+
+      // padding dimensions:
+      padding: (1, 0, 1, 1) // format: (dim0_low, dim0_high, dim1_low, dim1_high)
+
+      // padding value:
+      // value: 0
+
+      // padded output:
+      output: [[0, 0, 0, 0, 0],
+               [0, 1, 2, 3, 0],
+               [0, 4, 5, 6, 0]]
+    }];
+
+    let arguments = (ins AnyRankedTensor:$input,
+                         DenseI32ArrayAttr:$padding,
+                         F32Attr:$value);
+
+    let results = (outs AnyRankedTensor:$result);
+
+    let hasVerifier = 1;
+}
+
 def TTIR_SliceOp: TTIR_DPSOp<"slice"> {
     let summary = "Slice op.";
     let description = [{

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -910,6 +910,28 @@ def TTNN_RepeatOp : TTNN_Op<"repeat"> {
     let hasVerifier = 1;
 }
 
+def TTNN_PadOp: TTNN_Op<"pad"> {
+    let summary = "Pad op.";
+    let description = [{
+      Pad input tensor by padding the input_shape to output_shape using the provided value.
+
+      The `padding` attribute must be a sequence of integers that is twice the size as the rank of the input.
+      Each pair of integers in the padding attribute represents the amount of padding to add to the low and high of that dimension.
+      I.e: an input tensor of shape <1x30x30x64xf32> with padding attribute <0, 0, 1, 1, 1, 1, 0, 0> will return a tensor of shape <1x32x32x64xf32>,
+      and so will a padding attribute of <0, 0, 0, 2, 0, 2, 0, 0>.
+    }];
+
+    let arguments = (ins AnyRankedTensor:$input,
+                         DenseI32ArrayAttr:$padding,
+                         F32Attr:$value,
+                         BoolAttr:$use_multicore,
+                         OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
+
+    let results = (outs AnyRankedTensor:$result);
+
+    let hasVerifier = 1;
+}
+
 def TTNN_SliceOp: TTNN_NamedDPSOp<"slice"> {
     let summary = "Slice op.";
     let description = [{

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -265,6 +265,15 @@ table RepeatOp {
   repeat_dims: [int64];
 }
 
+table PadOp {
+  in: tt.target.TensorRef;
+  out: tt.target.TensorRef;
+  padding: [uint32];
+  value: float;
+  use_multicore: bool;
+  memcfg: MemoryConfigDesc;
+}
+
 table SliceOp {
   in: tt.target.TensorRef;
   out: tt.target.TensorRef;
@@ -448,6 +457,7 @@ union OpType {
   PermuteOp,
   RepeatOp,
   UpsampleOp,
+  PadOp,
 }
 
 table Operation {

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -1324,7 +1324,8 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
                ReshapeOpConversionPattern, RepeatOpConversionPattern,
                DefaultOpConversionPattern<ttnn::RepeatInterleaveOp>,
                DefaultOpConversionPattern<ttnn::SliceOp>,
-               DefaultOpConversionPattern<ttnn::PermuteOp>>(typeConverter, ctx);
+               DefaultOpConversionPattern<ttnn::PermuteOp>,
+               DefaultOpConversionPattern<ttnn::PadOp>>(typeConverter, ctx);
 
   // Matmul ops
   //

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -502,6 +502,42 @@ mlir::LogicalResult mlir::tt::ttir::ConvTranspose2dOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// PadOp
+//===----------------------------------------------------------------------===//
+
+// PadOp verification
+::mlir::LogicalResult mlir::tt::ttir::PadOp::verify() {
+
+  ::mlir::RankedTensorType inputType = getInput().getType();
+
+  // Check that size of padding is correct
+  if (static_cast<int64_t>(getPadding().size()) != 2 * inputType.getRank()) {
+    return emitOpError("Padding must have the same number of elements as twice "
+                       "the rank of the input tensor");
+  }
+
+  std::vector<int64_t> inferredShapeVec = inputType.getShape().vec();
+  llvm::ArrayRef<int32_t> padding = getPadding();
+  for (int64_t i = 0; i < inputType.getRank(); i++) {
+    inferredShapeVec[i] += padding[2 * i];
+    inferredShapeVec[i] += padding[2 * i + 1];
+  }
+  llvm::ArrayRef<int64_t> inferredShape = inferredShapeVec;
+
+  // Check that the output tensor shape is correct
+  ::mlir::RankedTensorType resultType = getResult().getType();
+  llvm::ArrayRef<int64_t> resultShape = resultType.getShape();
+  if (resultShape != inferredShape) {
+    return emitOpError("Output tensor shape (" +
+                       ttmlir::utils::join(resultShape, ",") +
+                       ") must match the inferred shape: (" +
+                       ttmlir::utils::join(inferredShape, ",") + ")");
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // ReshapeOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -12,6 +12,7 @@
 
 #include "mlir/Dialect/Traits.h"
 
+#include <llvm/ADT/ArrayRef.h>
 #include <numeric>
 #include <optional>
 
@@ -528,6 +529,42 @@ namespace mlir::tt::ttnn {
   if (has_negative && inputType.getNumElements() % known_dim_product != 0) {
     return emitOpError("Invalid shape: the dimensions do not multiply to the "
                        "total number of elements in the tensor");
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// PadOp
+//===----------------------------------------------------------------------===//
+
+// PadOp verification
+::mlir::LogicalResult mlir::tt::ttnn::PadOp::verify() {
+
+  ::mlir::RankedTensorType inputType = getInput().getType();
+
+  // Check that size of padding is correct
+  if (static_cast<int64_t>(getPadding().size()) != 2 * inputType.getRank()) {
+    return emitOpError("Padding must have the same number of elements as twice "
+                       "the rank of the input tensor");
+  }
+
+  std::vector<int64_t> inferredShapeVec = inputType.getShape().vec();
+  llvm::ArrayRef<int32_t> padding = getPadding();
+  for (int64_t i = 0; i < inputType.getRank(); i++) {
+    inferredShapeVec[i] += padding[2 * i];
+    inferredShapeVec[i] += padding[2 * i + 1];
+  }
+  llvm::ArrayRef<int64_t> inferredShape = inferredShapeVec;
+
+  // Check that the output tensor shape is correct
+  ::mlir::RankedTensorType resultType = getResult().getType();
+  llvm::ArrayRef<int64_t> resultShape = resultType.getShape();
+  if (resultShape != inferredShape) {
+    return emitOpError("Output tensor shape (" +
+                       ttmlir::utils::join(resultShape, ",") +
+                       ") must match the inferred shape: (" +
+                       ttmlir::utils::join(inferredShape, ",") + ")");
   }
 
   return success();

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -989,6 +989,25 @@ createRepeatOp(FlatbufferObjectCache &cache, RepeatOp op) {
       *cache.fbb, in, out, cache.fbb->CreateVector<int64_t>(repeatDims));
 }
 
+::flatbuffers::Offset<::tt::target::ttnn::PadOp>
+createPadOp(FlatbufferObjectCache &cache, PadOp op) {
+  flatbuffers::Offset<::tt::target::TensorRef> in =
+      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
+  std::vector<uint32_t> padding(op.getPadding().begin(), op.getPadding().end());
+  float value = op.getValue().convertToFloat();
+  flatbuffers::Offset<::tt::target::TensorRef> out =
+      cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
+                        kHostAllocatedAddress, kHostAllocatedSize);
+
+  flatbuffers::Offset<::tt::target::MemoryConfigDesc> memoryConfigDesc =
+      op.getMemoryConfig()
+          ? cache.getOrCreate(*op.getMemoryConfig(), memoryConfigToFlatbuffer)
+          : 0;
+  return ::tt::target::ttnn::CreatePadOp(
+      *cache.fbb, in, out, cache.fbb->CreateVector<uint32_t>(padding), value,
+      op.getUseMulticore(), memoryConfigDesc);
+}
+
 ::flatbuffers::Offset<::tt::target::ttnn::SliceOp>
 createSliceOp(FlatbufferObjectCache &cache, SliceOp op) {
   auto in =
@@ -1357,6 +1376,10 @@ emitTTNNOperation(FlatbufferObjectCache &cache, Operation *op,
   }
   if (auto repeatOp = dyn_cast<RepeatOp>(op); repeatOp) {
     return createOperation(cache, createRepeatOp(cache, repeatOp), debugString,
+                           locInfo);
+  }
+  if (auto padOp = dyn_cast<PadOp>(op); padOp) {
+    return createOperation(cache, createPadOp(cache, padOp), debugString,
                            locInfo);
   }
   if (auto sliceOp = dyn_cast<SliceOp>(op); sliceOp) {

--- a/runtime/include/tt/runtime/detail/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn.h
@@ -18,6 +18,7 @@
 #include "ttnn/operations/creation.hpp"
 #include "ttnn/operations/data_movement/clone/clone.hpp"
 #include "ttnn/operations/data_movement/concat/concat.hpp"
+#include "ttnn/operations/data_movement/pad/pad.hpp"
 #include "ttnn/operations/data_movement/permute/permute.hpp"
 #include "ttnn/operations/data_movement/repeat/repeat.hpp"
 #include "ttnn/operations/data_movement/repeat_interleave/repeat_interleave.hpp"

--- a/runtime/lib/common/workarounds.cpp
+++ b/runtime/lib/common/workarounds.cpp
@@ -9,11 +9,12 @@ namespace tt::runtime::workaround {
 const Env &Env::get(bool maxpool2dPreshard, bool swapBinaryOperands,
                     bool readUpdateIndexFromDeviceForKVCache,
                     bool defaultStrideComputation,
-                    bool toLayoutAPIAssumeSingleChip) {
+                    bool toLayoutAPIAssumeSingleChip,
+                    bool usePaddingPairSignatureWithQueueId) {
   static const Env config(maxpool2dPreshard, swapBinaryOperands,
                           readUpdateIndexFromDeviceForKVCache,
-                          defaultStrideComputation,
-                          toLayoutAPIAssumeSingleChip);
+                          defaultStrideComputation, toLayoutAPIAssumeSingleChip,
+                          usePaddingPairSignatureWithQueueId);
   return config;
 }
 #endif

--- a/runtime/lib/ttnn/operations/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/CMakeLists.txt
@@ -20,6 +20,7 @@ set(TTNN_OPS_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/data_movement/repeat_interleave.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/data_movement/slice.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/data_movement/transpose.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/data_movement/pad.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/deletion/deallocate.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/eltwise/binary/binary.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/eltwise/binary/binary_composite.cpp

--- a/runtime/lib/ttnn/operations/data_movement/pad.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/pad.cpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "operations/data_movement/pad.h"
+#include "tt-metalium/span.hpp"
+#include "tt/runtime/detail/logger.h"
+#include "tt/runtime/detail/workarounds.h"
+#include "tt/runtime/ttnn/operations/utils.h"
+
+#include <optional>
+
+namespace tt::runtime::ttnn::operations::data_movement {
+void run(const ::tt::target::ttnn::PadOp *op, ProgramContext &context) {
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+
+  const ::ttnn::Tensor &in = tensorPool.at(op->in()->global_id());
+  DEBUG_ASSERT(in.is_allocated());
+
+  float padValue = op->value();
+
+  ::ttnn::Tensor out;
+
+  std::vector<std::pair<uint32_t, uint32_t>> padding;
+  for (uint32_t i = 0; i < op->padding()->size(); i += 2) {
+    padding.push_back(
+        std::make_pair(op->padding()->Get(i), op->padding()->Get(i + 1)));
+  }
+
+  std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
+      op->memcfg() ? std::make_optional(
+                         utils::createMemoryConfig(op->memcfg(), op->out()))
+                   : std::nullopt;
+
+  if (workaround::Env::get().usePaddingPairSignatureWithQueueId) {
+    out = ::ttnn::pad(0, in, padding, padValue, op->use_multicore(),
+                      outputMemoryConfig);
+  } else {
+    LOG_FATAL("Currently, the only ::ttnn::pad signature which supports "
+              "padding pairs as input has queue_id in its signature. The only "
+              "way to execute the operation currently is to use the workaround "
+              "enabled by the flag \"usePaddingPairSignatureWithQueueId\"");
+  }
+
+  tensorPool.insert_or_assign(op->out()->global_id(), out);
+}
+} // namespace tt::runtime::ttnn::operations::data_movement

--- a/runtime/lib/ttnn/operations/data_movement/pad.h
+++ b/runtime/lib/ttnn/operations/data_movement/pad.h
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef RUNTIME_LIB_TTNN_OPERATIONS_DATA_MOVEMENT_PAD_H
+#define RUNTIME_LIB_TTNN_OPERATIONS_DATA_MOVEMENT_PAD_H
+
+#include "tt/runtime/ttnn/types.h"
+#include "ttmlir/Target/TTNN/program_generated.h"
+
+namespace tt::runtime::ttnn::operations::data_movement {
+void run(const ::tt::target::ttnn::PadOp *op, ProgramContext &context);
+} // namespace tt::runtime::ttnn::operations::data_movement
+
+#endif

--- a/runtime/lib/ttnn/program.cpp
+++ b/runtime/lib/ttnn/program.cpp
@@ -13,6 +13,7 @@
 #include "operations/creation/ones.h"
 #include "operations/creation/zeros.h"
 #include "operations/data_movement/concat.h"
+#include "operations/data_movement/pad.h"
 #include "operations/data_movement/permute.h"
 #include "operations/data_movement/repeat.h"
 #include "operations/data_movement/repeat_interleave.h"
@@ -221,6 +222,9 @@ void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
   }
   case ::tt::target::ttnn::OpType::TransposeOp: {
     return operations::data_movement::run(op->type_as_TransposeOp(), context);
+  }
+  case ::tt::target::ttnn::OpType::PadOp: {
+    return operations::data_movement::run(op->type_as_PadOp(), context);
   }
   case ::tt::target::ttnn::OpType::ConcatOp: {
     return operations::data_movement::run(op->type_as_ConcatOp(), context);

--- a/runtime/tools/python/ttrt/common/run.py
+++ b/runtime/tools/python/ttrt/common/run.py
@@ -155,6 +155,13 @@ class Run:
             help="disable runtime to_layout api assume single chip workaround",
         )
         Run.register_arg(
+            name="--disable-pad-op-padding-pairs-signature",
+            type=bool,
+            default=False,
+            choices=[True, False],
+            help="disable pad op padding pairs signature workaround",
+        )
+        Run.register_arg(
             name="--result-file",
             type=str,
             default="run_results.json",
@@ -426,6 +433,7 @@ class Run:
                 not self["--disable-read-update-index-for-kv-cache"],
                 not self["--disable-default-stride-computation"],
                 not self["--disable-to-layout-api-assume-single-chip"],
+                not self["--disable-pad-op-padding-pairs-signature"],
             )
             self.logging.debug(f"setting tt runtime workaround env={workaround_env}")
             self.logging.debug(f"setting torch manual seed={self['--seed']}")

--- a/test/ttmlir/Conversion/StableHLOToTTIR/pad_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/pad_op.mlir
@@ -1,0 +1,43 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s | FileCheck %s
+module {
+  func.func @main(%arg0: tensor<1x128x128x384xf32>) -> tensor<1x132x132x384xf32> {
+    // CHECK: ttir.pad
+    // CHECK-SAME: padding = array<i32: 0, 0, 0, 4, 0, 4, 0, 0>
+    // CHECK-SAME: value = 0.000000e+00 : f32
+    // CHECK-SAME: (tensor<1x128x128x384xf32>) -> tensor<1x132x132x384xf32>
+    %cst = arith.constant dense<0.000000e+00> : tensor<1xf64>
+    %0 = stablehlo.convert %cst : (tensor<1xf64>) -> tensor<1xf32>
+    %1 = stablehlo.reshape %0 : (tensor<1xf32>) -> tensor<f32>
+    %2 = stablehlo.pad %arg0, %1, low = [0, 0, 0, 0], high = [0, 4, 4, 0], interior = [0, 0, 0, 0] : (tensor<1x128x128x384xf32>, tensor<f32>) -> tensor<1x132x132x384xf32>
+    return %2 : tensor<1x132x132x384xf32>
+  }
+}
+
+module {
+  func.func @main(%arg0: tensor<1x64x64x384xf32>) -> tensor<1x72x72x384xf32> {
+    // CHECK: ttir.pad
+    // CHECK-SAME: padding = array<i32: 0, 0, 0, 8, 0, 8, 0, 0>
+    // CHECK-SAME: value = 0.000000e+00 : f32
+    // CHECK-SAME: (tensor<1x64x64x384xf32>) -> tensor<1x72x72x384xf32>
+    %cst = arith.constant dense<0.000000e+00> : tensor<1xf64>
+    %0 = stablehlo.convert %cst : (tensor<1xf64>) -> tensor<1xf32>
+    %1 = stablehlo.reshape %0 : (tensor<1xf32>) -> tensor<f32>
+    %2 = stablehlo.pad %arg0, %1, low = [0, 0, 0, 0], high = [0, 8, 8, 0], interior = [0, 0, 0, 0] : (tensor<1x64x64x384xf32>, tensor<f32>) -> tensor<1x72x72x384xf32>
+    return %2 : tensor<1x72x72x384xf32>
+  }
+}
+
+module {
+  func.func @main(%arg0: tensor<1x64x64x768xf32>) -> tensor<1x72x72x768xf32> {
+    // CHECK: ttir.pad
+    // CHECK-SAME: padding = array<i32: 0, 0, 0, 8, 0, 8, 0, 0>
+    // CHECK-SAME: value = 0.000000e+00 : f32
+    // CHECK-SAME: (tensor<1x64x64x768xf32>) -> tensor<1x72x72x768xf32>
+    %cst = arith.constant dense<0.000000e+00> : tensor<1xf64>
+    %0 = stablehlo.convert %cst : (tensor<1xf64>) -> tensor<1xf32>
+    %1 = stablehlo.reshape %0 : (tensor<1xf32>) -> tensor<f32>
+    %2 = stablehlo.pad %arg0, %1, low = [0, 0, 0, 0], high = [0, 8, 8, 0], interior = [0, 0, 0, 0] : (tensor<1x64x64x768xf32>, tensor<f32>) -> tensor<1x72x72x768xf32>
+    return %2 : tensor<1x72x72x768xf32>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/simple_pad.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_pad.mlir
@@ -1,0 +1,10 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
+
+module {
+  func.func @main(%arg0: tensor<1x1x5x5xbf16>) -> tensor<1x1x7x7xbf16> {
+    // CHECK: ttnn.pad
+    // CHECK: padding = array<i32: 0, 0, 0, 0, 1, 1, 1, 1>
+    %1 = "ttir.pad"(%arg0) <{padding = array<i32: 0, 0, 0, 0, 1, 1, 1, 1>, value = 0.000000e+00 : f32}> : (tensor<1x1x5x5xbf16>) -> tensor<1x1x7x7xbf16>
+    return %1 : tensor<1x1x7x7xbf16>
+  }
+}

--- a/test/ttmlir/EmitC/TTNN/other/pad.mlir
+++ b/test/ttmlir/EmitC/TTNN/other/pad.mlir
@@ -1,0 +1,14 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
+// RUN: ttmlir-opt --ttnn-modify-signatures-for-dylib --convert-ttnn-to-emitc %t.mlir > %t2.mlir
+// RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
+//
+// UNSUPPORTED: true
+// Outstanding bug: https://github.com/tenstorrent/tt-mlir/issues/2072
+module {
+  func.func @main(%arg0: tensor<1x1x5x5xbf16>) -> tensor<1x1x7x7xbf16> {
+    // CHECK: ttnn.pad
+    %1 = "ttir.pad"(%arg0) <{padding = array<i32: 0, 0, 0, 0, 1, 1, 1, 1>, value = 0.000000e+00 : f32}> : (tensor<1x1x5x5xbf16>) -> tensor<1x1x7x7xbf16>
+    return %1 : tensor<1x1x7x7xbf16>
+  }
+}

--- a/test/ttmlir/Silicon/TTNN/simple_pad.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_pad.mlir
@@ -1,0 +1,10 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
+
+module {
+  func.func @main(%arg0: tensor<1x128x128x384xf32>) -> tensor<1x132x132x384xf32> {
+    // CHECK: ttnn.pad
+    // CHECK-SAME: padding = array<i32: 0, 0, 2, 2, 2, 2, 0, 0>
+    %1 = "ttir.pad"(%arg0) <{padding = array<i32: 0, 0, 2, 2, 2, 2, 0, 0>, value = 0.000000e+00 : f32}> : (tensor<1x128x128x384xf32>) -> tensor<1x132x132x384xf32>
+    return %1 : tensor<1x132x132x384xf32>
+  }
+}


### PR DESCRIPTION
- Added PadOp in ttnn, ttir dialects.
- Flatbuffer/Runtime implementations for PadOp
- Stablehlo --> ttir lowering for PadOp

Closes https://github.com/tenstorrent/tt-mlir/issues/421
