### PR TITLE
Wrap all classes declared in cpp file in anonymous namespace

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -34,7 +34,6 @@ using namespace mlir;
 using namespace mlir::tt;
 
 namespace {
-
 template <typename SrcOp, typename DestOp,
           typename Adaptor = typename SrcOp::Adaptor>
 class StableHLOToTTIROpDefaultConversionPattern
@@ -58,7 +57,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class StableHLOToTTIRReduceOpConversionPattern
     : public OpConversionPattern<mlir::stablehlo::ReduceOp> {
 
@@ -154,7 +155,9 @@ private:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class StableHLOToTTIRDotGeneralOpConversionPattern
     : public OpConversionPattern<mlir::stablehlo::DotGeneralOp> {
   using OpConversionPattern<mlir::stablehlo::DotGeneralOp>::OpConversionPattern;
@@ -179,7 +182,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class StableHLOToTTIRTransposeOpConversionPattern
     : public OpConversionPattern<mlir::stablehlo::TransposeOp> {
   using OpConversionPattern<mlir::stablehlo::TransposeOp>::OpConversionPattern;
@@ -200,7 +205,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class StableHLOToTTIRReshapeOpConversionPattern
     : public OpConversionPattern<mlir::stablehlo::ReshapeOp> {
   using OpConversionPattern<mlir::stablehlo::ReshapeOp>::OpConversionPattern;
@@ -226,7 +233,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class StableHLOToTTIRGetDimensionSizeOpConversionPattern
     : public OpConversionPattern<mlir::stablehlo::GetDimensionSizeOp> {
 
@@ -250,7 +259,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class StableHLOToTTIRConstantOpConversionPattern
     : public OpConversionPattern<mlir::stablehlo::ConstantOp> {
 
@@ -392,7 +403,9 @@ private:
     return mlir::DenseElementsAttr::get(valueType, IntegerValue);
   }
 };
+} // namespace
 
+namespace {
 class StableHLOToTTIRConvolutionOpConversionPattern
     : public OpConversionPattern<mlir::stablehlo::ConvolutionOp> {
   using OpConversionPattern<
@@ -461,7 +474,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class StableHLOToTTIRReduceWindowOpConversionPattern
     : public OpConversionPattern<mlir::stablehlo::ReduceWindowOp> {
   using OpConversionPattern<
@@ -851,7 +866,9 @@ private:
     return true;
   }
 };
+} // namespace
 
+namespace {
 class StableHLOToTTIRBroadcastInDimOpConversionPattern
     : public OpConversionPattern<mlir::stablehlo::BroadcastInDimOp> {
   using OpConversionPattern<
@@ -960,7 +977,9 @@ private:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class StableHLOToTTIRCompareOpConversionPattern
     : public OpConversionPattern<mlir::stablehlo::CompareOp> {
   using OpConversionPattern<mlir::stablehlo::CompareOp>::OpConversionPattern;
@@ -1031,7 +1050,9 @@ private:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class StableHLOToTTIRConcatOpConversionPattern
     : public OpConversionPattern<mlir::stablehlo::ConcatenateOp> {
 
@@ -1096,6 +1117,7 @@ private:
     return success();
   }
 };
+} // namespace
 
 // Class implementing conversion from StableHLO to TTIR logical and bitwise ops.
 // StableHLO has AND, OR, XOR and NOT ops defined in such a way that they do two
@@ -1104,6 +1126,7 @@ private:
 // version of the op. We made a decision to make those two cases completely
 // distinct ops in TTIR. Thus, a StableHLO `SrcOp` is rewritten to one of
 // `DestOp`s based on operand types.
+namespace {
 template <typename SrcOp, typename LogicalDestOp, typename BitwiseDestOp,
           typename Adaptor = typename SrcOp::Adaptor>
 class StableHLOToTTIRLogicalAndBitwiseOpConversionPattern
@@ -1160,6 +1183,7 @@ private:
         adaptor.getOperands(), ValueRange(outputTensor));
   }
 };
+} // namespace
 
 template <typename SrcOpTy>
 LogicalResult getReduceType(SrcOpTy &srcOp, ReduceType &reduceType) {
@@ -1204,6 +1228,7 @@ enum StableHLOChannelType {
   kChannelTypeHostToDevice = 3,
 };
 
+namespace {
 class StableHLOToTTIRAllReduceOpConversionPattern
     : public OpConversionPattern<mlir::stablehlo::AllReduceOp> {
 
@@ -1319,8 +1344,10 @@ private:
 
     return success();
   }
-}; // namespace
+};
+} // namespace
 
+namespace {
 class StableHLOToTTIRCustomCallOpConversionPattern
     : public OpConversionPattern<mlir::stablehlo::CustomCallOp> {
 
@@ -1576,8 +1603,10 @@ private:
 
     return success();
   }
-}; // namespace
+};
+} // namespace
 
+namespace {
 class StableHLOToTTIRSliceOpConversionPattern
     : public OpConversionPattern<mlir::stablehlo::SliceOp> {
 
@@ -1615,7 +1644,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class StableHLOToTTIROpClampOpConversionPattern
     : public OpConversionPattern<mlir::stablehlo::ClampOp> {
 
@@ -1671,7 +1702,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class StableHLOToTTIRGatherOpConversionPattern
     : public OpConversionPattern<mlir::stablehlo::GatherOp> {
   using OpConversionPattern<mlir::stablehlo::GatherOp>::OpConversionPattern;
@@ -1701,7 +1734,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 template <typename SrcIotaOp, typename Adaptor = typename SrcIotaOp::Adaptor>
 class StableHLOToTTIROpIotaOpConversionPattern
     : public OpConversionPattern<SrcIotaOp> {
@@ -1720,8 +1755,8 @@ public:
         1, adaptor.getIotaDimension());
 
     // Dynamic Iota has an output_shape attribute but the output shape is
-    // already known by the result type This is to remove the operand that will
-    // become dead code
+    // already known by the result type This is to remove the operand that
+    // will become dead code
     for (auto operand : adaptor.getOperands()) {
       if (operand.getDefiningOp()) {
         rewriter.eraseOp(operand.getDefiningOp());
@@ -1731,7 +1766,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class StableHLOToTTIRScatterOpConversionPattern
     : public OpConversionPattern<mlir::stablehlo::ScatterOp> {
 
@@ -1840,7 +1877,9 @@ private:
     }
   }
 };
+} // namespace
 
+namespace {
 class StableHLOToTTIRReturnOpConversionPattern
     : public OpConversionPattern<mlir::stablehlo::ReturnOp> {
 
@@ -1858,7 +1897,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class StableHLOToTTIROpReverseOpConversionPattern
     : public OpConversionPattern<mlir::stablehlo::ReverseOp> {
 
@@ -1885,10 +1926,12 @@ public:
     return success();
   }
 };
+} // namespace
 
-void addElementwiseUnaryOpsConversionPatterns(MLIRContext *ctx,
-                                              RewritePatternSet &patterns,
-                                              TypeConverter &typeConverter) {
+static void
+addElementwiseUnaryOpsConversionPatterns(MLIRContext *ctx,
+                                         RewritePatternSet &patterns,
+                                         TypeConverter &typeConverter) {
 
   patterns.add<StableHLOToTTIROpDefaultConversionPattern<
       mlir::stablehlo::AbsOp, mlir::tt::ttir::AbsOp>>(typeConverter, ctx);
@@ -1933,9 +1976,10 @@ void addElementwiseUnaryOpsConversionPatterns(MLIRContext *ctx,
       mlir::stablehlo::LogOp, mlir::tt::ttir::LogOp>>(typeConverter, ctx);
 }
 
-void addElementwiseBinaryOpsConversionPatterns(MLIRContext *ctx,
-                                               RewritePatternSet &patterns,
-                                               TypeConverter &typeConverter) {
+static void
+addElementwiseBinaryOpsConversionPatterns(MLIRContext *ctx,
+                                          RewritePatternSet &patterns,
+                                          TypeConverter &typeConverter) {
 
   patterns.add<StableHLOToTTIROpDefaultConversionPattern<
       mlir::stablehlo::AddOp, mlir::tt::ttir::AddOp>>(typeConverter, ctx);
@@ -1956,87 +2000,92 @@ void addElementwiseBinaryOpsConversionPatterns(MLIRContext *ctx,
       mlir::stablehlo::SelectOp, mlir::tt::ttir::WhereOp>>(typeConverter, ctx);
 }
 
-void addReduceOpsConversionPatterns(MLIRContext *ctx,
-                                    RewritePatternSet &patterns,
-                                    TypeConverter &typeConverter) {
+static void addReduceOpsConversionPatterns(MLIRContext *ctx,
+                                           RewritePatternSet &patterns,
+                                           TypeConverter &typeConverter) {
   patterns.add<StableHLOToTTIRReduceOpConversionPattern>(typeConverter, ctx);
 }
 
-void addDotGeneralOpConversionPatterns(MLIRContext *ctx,
-                                       RewritePatternSet &patterns,
-                                       TypeConverter &typeConverter) {
+static void addDotGeneralOpConversionPatterns(MLIRContext *ctx,
+                                              RewritePatternSet &patterns,
+                                              TypeConverter &typeConverter) {
   patterns.add<StableHLOToTTIRDotGeneralOpConversionPattern>(typeConverter,
                                                              ctx);
 }
 
-void addGetDimensionSizeOpsConversionPatterns(MLIRContext *ctx,
-                                              RewritePatternSet &patterns,
-                                              TypeConverter &typeConverter) {
+static void
+addGetDimensionSizeOpsConversionPatterns(MLIRContext *ctx,
+                                         RewritePatternSet &patterns,
+                                         TypeConverter &typeConverter) {
   patterns.add<StableHLOToTTIRGetDimensionSizeOpConversionPattern>(
       typeConverter, ctx);
 }
 
-void addTensorCreationOpsConversionPatterns(MLIRContext *ctx,
-                                            RewritePatternSet &patterns,
-                                            TypeConverter &typeConverter) {
+static void
+addTensorCreationOpsConversionPatterns(MLIRContext *ctx,
+                                       RewritePatternSet &patterns,
+                                       TypeConverter &typeConverter) {
   patterns.add<StableHLOToTTIRConstantOpConversionPattern>(typeConverter, ctx);
 }
 
-void addBroadcastOpConversionPattern(MLIRContext *ctx,
-                                     RewritePatternSet &patterns,
-                                     TypeConverter &typeConverter) {
+static void addBroadcastOpConversionPattern(MLIRContext *ctx,
+                                            RewritePatternSet &patterns,
+                                            TypeConverter &typeConverter) {
 
   patterns.add<StableHLOToTTIRBroadcastInDimOpConversionPattern>(typeConverter,
                                                                  ctx);
 }
 
-void addConv2dOpConversionPattern(MLIRContext *ctx, RewritePatternSet &patterns,
-                                  TypeConverter &typeConverter) {
+static void addConv2dOpConversionPattern(MLIRContext *ctx,
+                                         RewritePatternSet &patterns,
+                                         TypeConverter &typeConverter) {
   patterns.add<StableHLOToTTIRConvolutionOpConversionPattern>(typeConverter,
                                                               ctx);
 }
 
-void addReduceWindowOpConversionPattern(MLIRContext *ctx,
-                                        RewritePatternSet &patterns,
-                                        TypeConverter &typeConverter) {
+static void addReduceWindowOpConversionPattern(MLIRContext *ctx,
+                                               RewritePatternSet &patterns,
+                                               TypeConverter &typeConverter) {
   patterns.add<StableHLOToTTIRReduceWindowOpConversionPattern>(typeConverter,
                                                                ctx);
 }
 
-void addCompareOpsConversionPatterns(MLIRContext *ctx,
-                                     RewritePatternSet &patterns,
-                                     TypeConverter &typeConverter) {
+static void addCompareOpsConversionPatterns(MLIRContext *ctx,
+                                            RewritePatternSet &patterns,
+                                            TypeConverter &typeConverter) {
   patterns.add<StableHLOToTTIRCompareOpConversionPattern>(typeConverter, ctx);
 }
 
-void addConcatOpsConversionPatterns(MLIRContext *ctx,
-                                    RewritePatternSet &patterns,
-                                    TypeConverter &typeConverter) {
+static void addConcatOpsConversionPatterns(MLIRContext *ctx,
+                                           RewritePatternSet &patterns,
+                                           TypeConverter &typeConverter) {
   patterns.add<StableHLOToTTIRConcatOpConversionPattern>(typeConverter, ctx);
 }
 
-void addTransposeOpConversionPattern(MLIRContext *ctx,
-                                     RewritePatternSet &patterns,
-                                     TypeConverter &typeConverter) {
+static void addTransposeOpConversionPattern(MLIRContext *ctx,
+                                            RewritePatternSet &patterns,
+                                            TypeConverter &typeConverter) {
   patterns.add<StableHLOToTTIRTransposeOpConversionPattern>(typeConverter, ctx);
 }
 
-void addReshapeOpConversionPattern(MLIRContext *ctx,
-                                   RewritePatternSet &patterns,
-                                   TypeConverter &typeConverter) {
+static void addReshapeOpConversionPattern(MLIRContext *ctx,
+                                          RewritePatternSet &patterns,
+                                          TypeConverter &typeConverter) {
   patterns.add<StableHLOToTTIRReshapeOpConversionPattern>(typeConverter, ctx);
 }
 
-void addCCLOpsConversionPattern(MLIRContext *ctx, RewritePatternSet &patterns,
-                                TypeConverter &typeConverter) {
+static void addCCLOpsConversionPattern(MLIRContext *ctx,
+                                       RewritePatternSet &patterns,
+                                       TypeConverter &typeConverter) {
   patterns.add<StableHLOToTTIRAllReduceOpConversionPattern>(typeConverter, ctx);
   patterns.add<StableHLOToTTIRCustomCallOpConversionPattern>(typeConverter,
                                                              ctx);
 }
 
-void addLogicalAndBitwiseOpsConversionPatterns(MLIRContext *ctx,
-                                               RewritePatternSet &patterns,
-                                               TypeConverter &typeConverter) {
+static void
+addLogicalAndBitwiseOpsConversionPatterns(MLIRContext *ctx,
+                                          RewritePatternSet &patterns,
+                                          TypeConverter &typeConverter) {
   patterns.add<StableHLOToTTIRLogicalAndBitwiseOpConversionPattern<
       mlir::stablehlo::AndOp, mlir::tt::ttir::LogicalAndOp,
       mlir::tt::ttir::BitwiseAndOp>>(typeConverter, ctx);
@@ -2051,23 +2100,27 @@ void addLogicalAndBitwiseOpsConversionPatterns(MLIRContext *ctx,
       mlir::tt::ttir::BitwiseNotOp>>(typeConverter, ctx);
 }
 
-void addSliceOpConversionPattern(MLIRContext *ctx, RewritePatternSet &patterns,
-                                 TypeConverter &typeConverter) {
+static void addSliceOpConversionPattern(MLIRContext *ctx,
+                                        RewritePatternSet &patterns,
+                                        TypeConverter &typeConverter) {
   patterns.add<StableHLOToTTIRSliceOpConversionPattern>(typeConverter, ctx);
 }
 
-void addClampOpConversionPattern(MLIRContext *ctx, RewritePatternSet &patterns,
-                                 TypeConverter &typeConverter) {
+static void addClampOpConversionPattern(MLIRContext *ctx,
+                                        RewritePatternSet &patterns,
+                                        TypeConverter &typeConverter) {
   patterns.add<StableHLOToTTIROpClampOpConversionPattern>(typeConverter, ctx);
 }
 
-void addGatherOpConversionPattern(MLIRContext *ctx, RewritePatternSet &patterns,
-                                  TypeConverter &typeConverter) {
+static void addGatherOpConversionPattern(MLIRContext *ctx,
+                                         RewritePatternSet &patterns,
+                                         TypeConverter &typeConverter) {
   patterns.add<StableHLOToTTIRGatherOpConversionPattern>(typeConverter, ctx);
 }
 
-void addIotaOpConversionPattern(MLIRContext *ctx, RewritePatternSet &patterns,
-                                TypeConverter &typeConverter) {
+static void addIotaOpConversionPattern(MLIRContext *ctx,
+                                       RewritePatternSet &patterns,
+                                       TypeConverter &typeConverter) {
   patterns.add<StableHLOToTTIROpIotaOpConversionPattern<stablehlo::IotaOp>>(
       typeConverter, ctx);
   patterns
@@ -2075,25 +2128,23 @@ void addIotaOpConversionPattern(MLIRContext *ctx, RewritePatternSet &patterns,
           typeConverter, ctx);
 }
 
-void addScatterOpConversionPatterns(MLIRContext *ctx,
-                                    RewritePatternSet &patterns,
-                                    TypeConverter &typeConverter) {
+static void addScatterOpConversionPatterns(MLIRContext *ctx,
+                                           RewritePatternSet &patterns,
+                                           TypeConverter &typeConverter) {
   patterns.add<StableHLOToTTIRScatterOpConversionPattern>(typeConverter, ctx);
 }
 
-void addReturnOpConversionPatterns(MLIRContext *ctx,
-                                   RewritePatternSet &patterns,
-                                   TypeConverter &typeConverter) {
+static void addReturnOpConversionPatterns(MLIRContext *ctx,
+                                          RewritePatternSet &patterns,
+                                          TypeConverter &typeConverter) {
   patterns.add<StableHLOToTTIRReturnOpConversionPattern>(typeConverter, ctx);
 }
 
-void addReverseOpConversionPattern(MLIRContext *ctx,
-                                   RewritePatternSet &patterns,
-                                   TypeConverter &typeConverter) {
+static void addReverseOpConversionPattern(MLIRContext *ctx,
+                                          RewritePatternSet &patterns,
+                                          TypeConverter &typeConverter) {
   patterns.add<StableHLOToTTIROpReverseOpConversionPattern>(typeConverter, ctx);
 }
-
-} // namespace
 
 namespace mlir::tt {
 

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -34,6 +34,7 @@ namespace mlir::tt {
 // the input tensor. For dimensions other than the sliced dimension, default
 // values are used.
 //
+namespace {
 struct IndexToSliceConversionPattern
     : public OpConversionPattern<ttir::IndexOp> {
   using OpConversionPattern<ttir::IndexOp>::OpConversionPattern;
@@ -71,6 +72,7 @@ struct IndexToSliceConversionPattern
     return success();
   }
 };
+} // namespace
 // ANCHOR_END: decomposing_an_op_index_ttir_decompose_pattern
 
 //===----------------------------------------------------------------------===//
@@ -93,6 +95,7 @@ static PaddingMatrix<NDims> getPaddingMatrix(ArrayRef<int64_t> padding) {
   return paddingMatrix;
 }
 
+namespace {
 struct ConvolutionDecompositionPattern
     : public OpConversionPattern<ttir::ConvolutionOp> {
 public:
@@ -189,12 +192,14 @@ protected:
                                               ttnnConvolutionKernelLayout);
   }
 };
+} // namespace
 
 // A decomposition pattern that matches to a ttir.convolution op that does 1D
 // convolution. Since that is not supported in ttnn, we reshape the inputs and
 // the output to match a 2D ttir.convolution op. The expectation is that the new
 // ttir.convolution op will be picked up by the ConvolutionToConv2dPattern and
 // translated into ttir.conv2d op.
+namespace {
 struct Legalize1DConvolutionPattern : public ConvolutionDecompositionPattern {
 public:
   using ConvolutionDecompositionPattern::ConvolutionDecompositionPattern;
@@ -341,7 +346,9 @@ private:
     return rewriter.getDenseBoolArrayAttr(newDenseArray);
   }
 };
+} // namespace
 
+namespace {
 struct ConvolutionToConv2dPattern : public ConvolutionDecompositionPattern {
 public:
   using ConvolutionDecompositionPattern::ConvolutionDecompositionPattern;
@@ -451,11 +458,13 @@ public:
     return success();
   }
 };
+} // namespace
 
 //===----------------------------------------------------------------------===//
 // Gather Pattern Matching
 //===----------------------------------------------------------------------===//
 
+namespace {
 struct GatherToEmbeddingConversionPattern
     : public OpConversionPattern<ttir::GatherOp> {
   using OpConversionPattern<ttir::GatherOp>::OpConversionPattern;
@@ -614,6 +623,7 @@ struct GatherToEmbeddingConversionPattern
     return success();
   }
 };
+} // namespace
 
 //===----------------------------------------------------------------------===//
 /*
@@ -630,6 +640,7 @@ in both tensors. This allows DotGeneralOp to handle cases beyond the typical
 MatmulOp constraints, enabling more complex tensor operations.
 */
 
+namespace {
 struct DotGeneralToMatmulConversionPattern
     : public OpConversionPattern<ttir::DotGeneralOp> {
   using OpConversionPattern<ttir::DotGeneralOp>::OpConversionPattern;
@@ -850,7 +861,9 @@ private:
     return product;
   }
 };
+} // namespace
 
+namespace {
 struct PoolingToPool2dPattern : public OpConversionPattern<ttir::PoolingOp> {
 public:
   using OpConversionPattern<ttir::PoolingOp>::OpConversionPattern;
@@ -1070,6 +1083,7 @@ public:
                 std::to_string(numSpatialDims) + " spatial dimensions");
   }
 };
+} // namespace
 
 // SelectOp is converted to a series of SliceOp and potentially a ConcatOp if
 // the sliced dimension is sliced multiple times. For example, if the input
@@ -1101,6 +1115,7 @@ public:
 // In this case 2 slices are created and concatenated to form the output tensor.
 // First slice has begins=[0, 0, 0], ends=[2, 2, 3], steps=[1, 1, 1], and the
 // second slice has begins=[0, 4, 0], ends=[2, 6, 3], steps=[1, 1, 1].
+namespace {
 struct SelectToSliceConversionPattern
     : public OpConversionPattern<ttir::SelectOp> {
 public:
@@ -1185,6 +1200,7 @@ public:
     return success();
   }
 };
+} // namespace
 
 /*
  * This pattern rewrites ArangeOp by forcing the arange_dimension to be
@@ -1202,6 +1218,7 @@ public:
  * the TTIR dialect only and so this explication of the TMs implicit in ArangeOp
  * must be done in TTIR.
  */
+namespace {
 struct ArangeForceLastDimensionPattern
     : public OpConversionPattern<ttir::ArangeOp> {
 public:
@@ -1319,6 +1336,7 @@ public:
     return success();
   }
 };
+} // namespace
 
 // TTNN does not support reduction operation for logical and. So this reduction
 // is performed by decomposing/converting into reduction product (ttnn.prod op).

--- a/lib/Conversion/TTIRToTTMetal/AttachMetalLayout.cpp
+++ b/lib/Conversion/TTIRToTTMetal/AttachMetalLayout.cpp
@@ -13,6 +13,8 @@
 namespace mlir::tt::ttir {
 #define GEN_PASS_DEF_TTIRATTACHMETALLAYOUT
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h.inc"
+
+namespace {
 class TTIRLayoutTensorTypeConverter : public TypeConverter {
 public:
   TTIRLayoutTensorTypeConverter(MLIRContext *ctx, MemorySpace initMemorySpace,
@@ -35,7 +37,9 @@ public:
         });
   }
 };
+} // namespace
 
+namespace {
 class TTIRLayoutTensorTypeRewriter : public RewritePattern {
 public:
   TTIRLayoutTensorTypeRewriter(const TypeConverter &converter, MLIRContext *ctx)
@@ -103,7 +107,9 @@ public:
 
   const TypeConverter *converter;
 };
+} // namespace
 
+namespace {
 class TTIRAttachMetalLayout
     : public impl::TTIRAttachMetalLayoutBase<TTIRAttachMetalLayout> {
 
@@ -129,5 +135,6 @@ class TTIRAttachMetalLayout
     registry.insert<mlir::tt::TTDialect>();
   }
 };
+} // namespace
 
 } // namespace mlir::tt::ttir

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
@@ -83,6 +83,7 @@ static uint64_t lookupAddress(Value value) {
   return allocOp.getAddress();
 }
 
+namespace {
 class TTIRToTTMetalLayoutRewriter : public OpRewritePattern<ttir::ToLayoutOp> {
 public:
   using OpRewritePattern<ttir::ToLayoutOp>::OpRewritePattern;
@@ -544,7 +545,9 @@ public:
     return failure();
   }
 };
+} // namespace
 
+namespace {
 class TTIRToTTMetalEnqueueProgramRewriter
     : public OpRewritePattern<ttir::GenericOp> {
 public:
@@ -1850,8 +1853,10 @@ public:
 
     return success();
   }
-}; // namespace mlir::tt::ttmetal
+};
+} // namespace
 
+namespace {
 class TTIRToTTMetalAllocRewriter : public OpRewritePattern<ttir::AllocOp> {
 public:
   using OpRewritePattern<ttir::AllocOp>::OpRewritePattern;
@@ -1863,7 +1868,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class TTIRToTTMetalDeallocRewriter : public OpRewritePattern<ttir::DeallocOp> {
 public:
   using OpRewritePattern<ttir::DeallocOp>::OpRewritePattern;
@@ -1875,7 +1882,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class TTIRToTTMetalFillRewriter : public OpRewritePattern<ttir::FillOp> {
 public:
   using OpRewritePattern<ttir::FillOp>::OpRewritePattern;
@@ -1887,6 +1896,7 @@ public:
     return success();
   }
 };
+} // namespace
 
 } // namespace mlir::tt::ttmetal
 

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -35,7 +35,6 @@ using namespace mlir;
 using namespace mlir::tt;
 
 namespace {
-
 class TensorEmptyConversionPattern
     : public OpConversionPattern<tensor::EmptyOp> {
 public:
@@ -90,7 +89,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class OnesOpConversionPattern : public OpConversionPattern<ttir::OnesOp> {
 public:
   using OpConversionPattern<ttir::OnesOp>::OpConversionPattern;
@@ -154,7 +155,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class ToLayoutOpConversionPattern
     : public OpConversionPattern<ttir::ToLayoutOp> {
 public:
@@ -297,7 +300,9 @@ private:
     llvm_unreachable("Unreachable code path. Unexpected output layout enum");
   }
 };
+} // namespace
 
+namespace {
 template <typename TTIROpTy, typename TTNNOpTy,
           typename OpAdaptor = typename TTIROpTy::Adaptor>
 class ElementwiseOpConversionPattern : public OpConversionPattern<TTIROpTy> {
@@ -318,7 +323,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 template <typename TTIROpTy, typename TTNNOpTy,
           typename OpAdaptor = typename TTIROpTy::Adaptor>
 class ReductionOpConversionPattern : public OpConversionPattern<TTIROpTy> {
@@ -335,7 +342,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class ReductionProdOpConversionPattern
     : public OpConversionPattern<ttir::ProdOp> {
 public:
@@ -369,7 +378,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class EmbeddingOpConversionPattern
     : public OpConversionPattern<ttir::EmbeddingOp> {
 public:
@@ -385,7 +396,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class EmbeddingBackwardOpConversionPattern
     : public OpConversionPattern<ttir::EmbeddingBackwardOp> {
 public:
@@ -438,7 +451,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class CumSumOpConversionPattern : public OpConversionPattern<ttir::CumSumOp> {
 public:
   using OpConversionPattern<ttir::CumSumOp>::OpConversionPattern;
@@ -452,7 +467,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class RepeatInterleaveOpConversionPattern
     : public OpConversionPattern<ttir::RepeatInterleaveOp> {
 public:
@@ -468,7 +485,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class SoftmaxOpConversionPattern : public OpConversionPattern<ttir::SoftmaxOp> {
 public:
   using OpConversionPattern<ttir::SoftmaxOp>::OpConversionPattern;
@@ -482,7 +501,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class TransposeOpConversionPattern
     : public OpConversionPattern<ttir::TransposeOp> {
 public:
@@ -497,7 +518,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class ClampOpConversionPattern : public OpConversionPattern<ttir::ClampOp> {
 public:
   using OpConversionPattern<ttir::ClampOp>::OpConversionPattern;
@@ -511,7 +534,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class UpdateCacheOpConversionPattern
     : public OpConversionPattern<ttir::UpdateCacheOp> {
 public:
@@ -547,7 +572,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class FillCacheOpConversionPattern
     : public OpConversionPattern<ttir::FillCacheOp> {
 public:
@@ -583,7 +610,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 template <typename TTIROpTy, typename TTNNOpTy,
           typename OpAdaptor = typename TTIROpTy::Adaptor>
 class ElementwiseUnaryWithFloatParameterOpConversionPattern
@@ -600,7 +629,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class ConcatOpConversionPattern : public OpConversionPattern<ttir::ConcatOp> {
 public:
   using OpConversionPattern<ttir::ConcatOp>::OpConversionPattern;
@@ -619,7 +650,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class ReshapeOpConversionPattern : public OpConversionPattern<ttir::ReshapeOp> {
 public:
   using OpConversionPattern<ttir::ReshapeOp>::OpConversionPattern;
@@ -633,7 +666,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class SliceOpConversionPattern : public OpConversionPattern<ttir::SliceOp> {
 public:
   using OpConversionPattern<ttir::SliceOp>::OpConversionPattern;
@@ -648,7 +683,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class SqueezeOpConversionPattern : public OpConversionPattern<ttir::SqueezeOp> {
 public:
   using OpConversionPattern<ttir::SqueezeOp>::OpConversionPattern;
@@ -690,7 +727,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class BroadcastOpConversionPattern
     : public OpConversionPattern<ttir::BroadcastOp> {
   using OpConversionPattern<ttir::BroadcastOp>::OpConversionPattern;
@@ -728,7 +767,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class UnsqueezeOpConversionPattern
     : public OpConversionPattern<ttir::UnsqueezeOp> {
 public:
@@ -776,7 +817,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class ConstantOpConversionPattern
     : public OpConversionPattern<ttir::ConstantOp> {
 public:
@@ -853,7 +896,9 @@ private:
     assert(false && "Unsupported integer type.");
   }
 };
+} // namespace
 
+namespace {
 class LinearOpConversionPattern : public OpConversionPattern<ttir::LinearOp> {
 public:
   using OpConversionPattern<ttir::LinearOp>::OpConversionPattern;
@@ -867,8 +912,10 @@ public:
     return success();
   }
 };
+} // namespace
 
 // ANCHOR: adding_an_op_matmul_op_rewriter
+namespace {
 class MatmulOpConversionPattern : public OpConversionPattern<ttir::MatmulOp> {
 public:
   using OpConversionPattern<ttir::MatmulOp>::OpConversionPattern;
@@ -882,8 +929,10 @@ public:
     return success();
   }
 };
+} // namespace
 // ANCHOR_END: adding_an_op_matmul_op_rewriter
 
+namespace {
 class Conv2dOpConversionPattern : public OpConversionPattern<ttir::Conv2dOp> {
 public:
   using OpConversionPattern<ttir::Conv2dOp>::OpConversionPattern;
@@ -976,7 +1025,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class ConvTranspose2dOpConversionPattern
     : public OpConversionPattern<ttir::ConvTranspose2dOp> {
 public:
@@ -1075,7 +1126,9 @@ private:
     return rewriter.getDenseI32ArrayAttr({pair->first, pair->second});
   }
 };
+} // namespace
 
+namespace {
 class MaxPool2dOpConversionPattern
     : public OpConversionPattern<ttir::MaxPool2dOp> {
 public:
@@ -1144,7 +1197,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class TypecastOpConversionPattern
     : public OpConversionPattern<ttir::TypecastOp> {
   using OpConversionPattern<ttir::TypecastOp>::OpConversionPattern;
@@ -1170,7 +1225,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class SubtractOpConversionPattern
     : public OpConversionPattern<ttir::SubtractOp> {
   using OpConversionPattern<ttir::SubtractOp>::OpConversionPattern;
@@ -1210,7 +1267,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class AllReduceOpConversionPattern
     : public OpConversionPattern<ttir::AllReduceOp> {
 public:
@@ -1235,7 +1294,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class MeshShardOpConversionPattern
     : public OpConversionPattern<ttir::MeshShardOp> {
 public:
@@ -1254,7 +1315,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class AllGatherOpConversionPattern
     : public OpConversionPattern<ttir::AllGatherOp> {
 public:
@@ -1271,7 +1334,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class ArangeOpConversionPattern : public OpConversionPattern<ttir::ArangeOp> {
 public:
   using OpConversionPattern<ttir::ArangeOp>::OpConversionPattern;
@@ -1310,7 +1375,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class ScatterOpConversionPattern : public OpConversionPattern<ttir::ScatterOp> {
 public:
   using OpConversionPattern<ttir::ScatterOp>::OpConversionPattern;
@@ -1326,7 +1393,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class PermuteOpConversionPattern : public OpConversionPattern<ttir::PermuteOp> {
 public:
   using OpConversionPattern<ttir::PermuteOp>::OpConversionPattern;
@@ -1342,7 +1411,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class UpsampleOpConversionPattern
     : public OpConversionPattern<ttir::Upsample2dOp> {
 public:
@@ -1359,7 +1430,6 @@ public:
     return success();
   }
 };
-
 } // namespace
 
 namespace mlir::tt {

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -47,7 +47,6 @@ namespace mlir::tt::ttkernel {
 } // namespace mlir::tt::ttkernel
 
 // ............................................................................
-namespace {
 
 emitc::OpaqueAttr convertCBPort(Builder &builder, ttkernel::CBPort port) {
   switch (port) {
@@ -122,14 +121,17 @@ emitc::OpaqueAttr convertCBPort(Builder &builder, ttkernel::CBPort port) {
 
 // A no-op type converter:
 // (note that the trivial T->T conversion is necessary)
+namespace {
 class NullTypeConverter : public TypeConverter {
 public:
   NullTypeConverter() {
     addConversion([](Type type) { return type; });
   }
 };
+} // namespace
 
 // Type converter used for TTKernel/TTMetal conversions:
+namespace {
 class TTKernelToEmitCTypeConverter : public NullTypeConverter {
 public:
   TTKernelToEmitCTypeConverter(MLIRContext *ctx) {
@@ -151,7 +153,9 @@ public:
         });
   }
 };
+} // namespace
 
+namespace {
 class TTKernelStoreToL1OpToEmitCOpRewriter
     : public OpConversionPattern<ttkernel::StoreToL1Op> {
 
@@ -183,7 +187,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class TTMetalToEmitCFuncArgsRewriter
     : public OpConversionPattern<func::FuncOp> {
 public:
@@ -226,7 +232,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class TTMetalToEmitCReturnRewriter
     : public OpConversionPattern<ttkernel::ReturnOp> {
 public:
@@ -244,7 +252,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 template <typename SourceOp, typename Adaptor = typename SourceOp::Adaptor>
 class TTMetalToEmitCOpaqueRewriter : public OpConversionPattern<SourceOp> {
 public:
@@ -329,7 +339,9 @@ public:
 private:
   std::string opName;
 };
+} // namespace
 
+namespace {
 template <typename Op, typename Adaptor = typename Op::Adaptor>
 class TTKernelMacroOpToEmitCOpRewriter : public OpConversionPattern<Op> {
 public:
@@ -354,15 +366,19 @@ public:
     return success();
   }
 };
+} // namespace
 
 // Context used for the analysis step before 'ConvertNocTransactionsTableOp'
+namespace {
 struct GlobalArrayDefTable {
   std::unordered_map<std::string,
                      std::tuple<mlir::MemRefType, mlir::DenseI32ArrayAttr>>
       defs;
   std::int32_t unique = 0;
 };
+} // namespace
 
+namespace {
 struct ConvertNocTransactionsTableOp
     : public OpConversionPattern<ttkernel::NocTransactionsTableOp> {
 
@@ -428,7 +444,9 @@ struct ConvertNocTransactionsTableOp
   GlobalArrayDefTable *globalDefs;
 
 }; // end of class
+} // namespace
 
+namespace {
 class ConvertTTKernelToEmitCPass
     : public ttkernel::impl::ConvertTTKernelToEmitCBase<
           ConvertTTKernelToEmitCPass> {
@@ -611,8 +629,8 @@ public:
     }
   }
 };
-
 } // namespace
+
 // ............................................................................
 
 namespace mlir::tt {
@@ -622,10 +640,10 @@ std::unique_ptr<::mlir::Pass> createConvertTTKernelToEmitC() {
 }
 
 // ............................................................................
-namespace {
 
 // Class used to add includes and other boilerplate code to the generated
 // kernel.
+namespace {
 class ThreadConfigHelper {
 public:
   ThreadConfigHelper(OpBuilder *builder, Location loc,
@@ -695,8 +713,8 @@ private:
   Location loc;
   ttkernel::ThreadType threadType;
 };
-
 } // namespace
+
 // ............................................................................
 
 inline FailureOr<mlir::ModuleOp>

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -37,8 +37,6 @@
 using namespace mlir;
 using namespace mlir::tt;
 
-namespace {
-
 emitc::OpaqueAttr createNullDevicePointer(Builder &builder) {
   return builder.getType<emitc::OpaqueAttr>(
       "static_cast<::ttnn::IDevice *>(nullptr)");
@@ -46,6 +44,7 @@ emitc::OpaqueAttr createNullDevicePointer(Builder &builder) {
 
 // Base class for TTNN to EmitC OpConversionPattern.
 //
+namespace {
 template <typename SourceOp>
 class TTNNToEmitCBaseOpConversionPattern
     : public OpConversionPattern<SourceOp> {
@@ -71,9 +70,11 @@ public:
                               getPrefixSwapPattern());
   }
 };
+} // namespace
 
 // Default op conversion pattern, used to convert most ops.
 //
+namespace {
 template <typename SourceOp>
 class DefaultOpConversionPattern
     : public TTNNToEmitCBaseOpConversionPattern<SourceOp> {
@@ -109,12 +110,14 @@ public:
     return success();
   }
 };
+} // namespace
 
 // Eltwise Unary op conversion pattern
 //
 // Currently, it has to insert nullopts for some parameters that are not
 // modelled in the dialect (memcfg).
 //
+namespace {
 template <typename SourceOp>
 class EltwiseUnaryOpConversionPattern
     : public TTNNToEmitCBaseOpConversionPattern<SourceOp> {
@@ -144,6 +147,7 @@ public:
     return success();
   }
 };
+} // namespace
 
 // EltwiseUnaryWithFastAndApproximateModeOp conversion pattern
 //
@@ -217,6 +221,7 @@ public:
 // Currently, it has to insert nullopts for some parameters that are not
 // modelled in the dialect (output dtype, memcfg).
 //
+namespace {
 template <typename SourceOp>
 class EltwiseBinaryOpConversionPattern
     : public TTNNToEmitCBaseOpConversionPattern<SourceOp> {
@@ -249,6 +254,7 @@ public:
     return success();
   }
 };
+} // namespace
 
 // Linear op conversion pattern
 //
@@ -283,6 +289,7 @@ public:
 
 // Matmul op conversion pattern
 //
+namespace {
 class MatmulOpConversionPattern
     : public TTNNToEmitCBaseOpConversionPattern<ttnn::MatmulOp> {
 
@@ -322,6 +329,7 @@ public:
     return success();
   }
 };
+} // namespace
 
 // Softmax op conversion pattern
 //
@@ -591,6 +599,7 @@ public:
 
 // GetDeviceOp conversion pattern
 //
+namespace {
 class GetDeviceOpConversionPattern
     : public TTNNToEmitCBaseOpConversionPattern<ttnn::GetDeviceOp> {
 
@@ -617,9 +626,11 @@ public:
     return success();
   }
 };
+} // namespace
 
 // ToDeviceOp conversion pattern
 //
+namespace {
 class ToDeviceOpConversionPattern
     : public TTNNToEmitCBaseOpConversionPattern<ttnn::ToDeviceOp> {
 
@@ -672,9 +683,11 @@ public:
     return success();
   }
 };
+} // namespace
 
 // FromDeviceOp conversion pattern
 //
+namespace {
 class FromDeviceOpConversionPattern
     : public TTNNToEmitCBaseOpConversionPattern<ttnn::FromDeviceOp> {
 
@@ -693,9 +706,11 @@ public:
     return success();
   }
 };
+} // namespace
 
 // TypecastOp conversion pattern
 //
+namespace {
 class TypecastOpConversionPattern
     : public TTNNToEmitCBaseOpConversionPattern<ttnn::TypecastOp> {
 
@@ -718,9 +733,11 @@ public:
     return success();
   }
 };
+} // namespace
 
 // ToMemoryConfig conversion pattern
 //
+namespace {
 class ToMemoryConfigOpConversionPattern
     : public TTNNToEmitCBaseOpConversionPattern<ttnn::ToMemoryConfigOp> {
 
@@ -765,9 +782,11 @@ public:
     return success();
   }
 };
+} // namespace
 
 // ToLayoutOp conversion pattern
 //
+namespace {
 class ToLayoutOpConversionPattern
     : public TTNNToEmitCBaseOpConversionPattern<ttnn::ToLayoutOp> {
 
@@ -796,9 +815,11 @@ public:
     return success();
   }
 };
+} // namespace
 
 // EmptyOp conversion pattern
 //
+namespace {
 class EmptyOpConversionPattern
     : public TTNNToEmitCBaseOpConversionPattern<ttnn::EmptyOp> {
 
@@ -860,9 +881,11 @@ public:
     return success();
   }
 };
+} // namespace
 
 // OnesOp conversion pattern
 //
+namespace {
 class OnesOpConversionPattern
     : public TTNNToEmitCBaseOpConversionPattern<ttnn::OnesOp> {
 
@@ -942,9 +965,11 @@ public:
     return success();
   }
 };
+} // namespace
 
 // DeallocateOp conversion pattern
 //
+namespace {
 class DeallocateOpConversionPattern
     : public TTNNToEmitCBaseOpConversionPattern<ttnn::DeallocateOp> {
 
@@ -968,9 +993,11 @@ public:
     return success();
   }
 };
+} // namespace
 
 // arith::ConstantOp conversion pattern
 //
+namespace {
 class ArithConstantOpConversionPattern
     : public OpConversionPattern<arith::ConstantOp> {
 
@@ -991,7 +1018,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class GetTupleElementOpConversionPattern
     : public OpConversionPattern<tt::GetTupleElementOp> {
 
@@ -1027,7 +1056,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class TupleOpConversionPattern : public OpConversionPattern<tt::TupleOp> {
 
 public:
@@ -1052,6 +1083,7 @@ public:
     return success();
   }
 };
+} // namespace
 
 // Module Op conversion pattern
 //
@@ -1059,6 +1091,7 @@ public:
 // ttmlir-translate would complain when translating to C++ if there were any
 // attributes from "unregistered" dialects.
 //
+namespace {
 class ModuleOpConversionPattern
     : public TTNNToEmitCBaseOpConversionPattern<mlir::ModuleOp> {
 
@@ -1079,7 +1112,6 @@ public:
     return success();
   }
 };
-
 } // namespace
 
 namespace mlir::tt {

--- a/lib/Conversion/TosaToTTIR/TosaToTTIRPatterns.cpp
+++ b/lib/Conversion/TosaToTTIR/TosaToTTIRPatterns.cpp
@@ -18,11 +18,10 @@
 using namespace mlir;
 using namespace mlir::tt;
 
-namespace {
-
 // TODO(sdjukic): extract this pattern into separate file and use it for both
 // TOSA and StableHLO
 
+namespace {
 template <typename SrcOp, typename DestOp,
           typename Adaptor = typename SrcOp::Adaptor>
 class TosaToTTIRDefaultDPSOpConversionPattern
@@ -57,7 +56,9 @@ private:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class TosaToTTIRMultiplyOpConversionPattern
     : public TosaToTTIRDefaultDPSOpConversionPattern<
           tosa::MulOp, mlir::tt::ttir::MultiplyOp> {
@@ -76,7 +77,9 @@ private:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class TosaToTTIRClampOpConversionPattern
     : public OpConversionPattern<tosa::ClampOp> {
   using OpConversionPattern<tosa::ClampOp>::OpConversionPattern;
@@ -97,7 +100,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class TosaToTTIRConcatOpConversionPattern
     : public OpConversionPattern<tosa::ConcatOp> {
   using OpConversionPattern<tosa::ConcatOp>::OpConversionPattern;
@@ -118,7 +123,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class TosaToTTIRMatmulOpConversionPattern
     : public OpConversionPattern<tosa::MatMulOp> {
   using OpConversionPattern<tosa::MatMulOp>::OpConversionPattern;
@@ -156,7 +163,9 @@ private:
     return success();
   }
 };
+} // namespace
 
+namespace {
 template <typename SrcOp, typename DestOp,
           typename Adaptor = typename SrcOp::Adaptor>
 class TosaToTTIRReduceOpConversionPattern : public OpConversionPattern<SrcOp> {
@@ -179,7 +188,9 @@ public:
     return success();
   }
 };
+} // namespace
 
+namespace {
 class TosaToTTIRMaxPool2DOpConversionPattern
     : public OpConversionPattern<tosa::MaxPool2dOp> {
   using OpConversionPattern<tosa::MaxPool2dOp>::OpConversionPattern;
@@ -204,10 +215,12 @@ public:
     return success();
   }
 };
+} // namespace
 
-void addElementwiseUnaryOpsConversionPatterns(MLIRContext *ctx,
-                                              RewritePatternSet &patterns,
-                                              TypeConverter &typeConverter) {
+static void
+addElementwiseUnaryOpsConversionPatterns(MLIRContext *ctx,
+                                         RewritePatternSet &patterns,
+                                         TypeConverter &typeConverter) {
   patterns.add<TosaToTTIRDefaultDPSOpConversionPattern<tosa::AbsOp,
                                                        mlir::tt::ttir::AbsOp>>(
       typeConverter, ctx);
@@ -238,9 +251,10 @@ void addElementwiseUnaryOpsConversionPatterns(MLIRContext *ctx,
       typeConverter, ctx);
 }
 
-void addElementwiseBinaryOpsConversionPatterns(MLIRContext *ctx,
-                                               RewritePatternSet &patterns,
-                                               TypeConverter &typeConverter) {
+static void
+addElementwiseBinaryOpsConversionPatterns(MLIRContext *ctx,
+                                          RewritePatternSet &patterns,
+                                          TypeConverter &typeConverter) {
   patterns.add<TosaToTTIRDefaultDPSOpConversionPattern<tosa::AddOp,
                                                        mlir::tt::ttir::AddOp>>(
       typeConverter, ctx);
@@ -253,16 +267,17 @@ void addElementwiseBinaryOpsConversionPatterns(MLIRContext *ctx,
       tosa::SubOp, mlir::tt::ttir::SubtractOp>>(typeConverter, ctx);
 }
 
-void addElementwiseTernaryOpsConversionPatterns(MLIRContext *ctx,
-                                                RewritePatternSet &patterns,
-                                                TypeConverter &typeConverter) {
+static void
+addElementwiseTernaryOpsConversionPatterns(MLIRContext *ctx,
+                                           RewritePatternSet &patterns,
+                                           TypeConverter &typeConverter) {
   patterns.add<TosaToTTIRDefaultDPSOpConversionPattern<
       tosa::SelectOp, mlir::tt::ttir::WhereOp>>(typeConverter, ctx);
 }
 
-void addLogicalOpsConversionPatterns(MLIRContext *ctx,
-                                     RewritePatternSet &patterns,
-                                     TypeConverter &typeConverter) {
+static void addLogicalOpsConversionPatterns(MLIRContext *ctx,
+                                            RewritePatternSet &patterns,
+                                            TypeConverter &typeConverter) {
   patterns.add<TosaToTTIRDefaultDPSOpConversionPattern<
       tosa::LogicalAndOp, mlir::tt::ttir::LogicalAndOp>>(typeConverter, ctx);
   patterns.add<TosaToTTIRDefaultDPSOpConversionPattern<
@@ -273,9 +288,9 @@ void addLogicalOpsConversionPatterns(MLIRContext *ctx,
       tosa::LogicalXorOp, mlir::tt::ttir::LogicalXorOp>>(typeConverter, ctx);
 }
 
-void addCompareOpsConversionPatterns(MLIRContext *ctx,
-                                     RewritePatternSet &patterns,
-                                     TypeConverter &typeConverter) {
+static void addCompareOpsConversionPatterns(MLIRContext *ctx,
+                                            RewritePatternSet &patterns,
+                                            TypeConverter &typeConverter) {
   patterns.add<TosaToTTIRDefaultDPSOpConversionPattern<
       tosa::EqualOp, mlir::tt::ttir::EqualOp>>(typeConverter, ctx);
   patterns.add<TosaToTTIRDefaultDPSOpConversionPattern<
@@ -285,15 +300,15 @@ void addCompareOpsConversionPatterns(MLIRContext *ctx,
       tosa::GreaterOp, mlir::tt::ttir::GreaterThanOp>>(typeConverter, ctx);
 }
 
-void addMatmulOpsConversionPatterns(MLIRContext *ctx,
-                                    RewritePatternSet &patterns,
-                                    TypeConverter &typeConverter) {
+static void addMatmulOpsConversionPatterns(MLIRContext *ctx,
+                                           RewritePatternSet &patterns,
+                                           TypeConverter &typeConverter) {
   patterns.add<TosaToTTIRMatmulOpConversionPattern>(typeConverter, ctx);
 }
 
-void addReductionOpsConversionPatterns(MLIRContext *ctx,
-                                       RewritePatternSet &patterns,
-                                       TypeConverter &typeConverter) {
+static void addReductionOpsConversionPatterns(MLIRContext *ctx,
+                                              RewritePatternSet &patterns,
+                                              TypeConverter &typeConverter) {
   patterns.add<TosaToTTIRReduceOpConversionPattern<tosa::ReduceMaxOp,
                                                    mlir::tt::ttir::MaxOp>>(
       typeConverter, ctx);
@@ -302,12 +317,11 @@ void addReductionOpsConversionPatterns(MLIRContext *ctx,
       typeConverter, ctx);
 }
 
-void addPoolingOpsConversionPatterns(MLIRContext *ctx,
-                                     RewritePatternSet &patterns,
-                                     TypeConverter &typeConverter) {
+static void addPoolingOpsConversionPatterns(MLIRContext *ctx,
+                                            RewritePatternSet &patterns,
+                                            TypeConverter &typeConverter) {
   patterns.add<TosaToTTIRMaxPool2DOpConversionPattern>(typeConverter, ctx);
 }
-} // namespace
 
 namespace mlir::tt {
 


### PR DESCRIPTION
See LLVM Docs for more information.

The code transformation wraps all classes or structs declared inside of a .cpp file in an anonymous namespace:

```
namespace {
class TTIRAttachMetalLayout
  : public impl::TTIRAttachMetalLayoutBase<TTIRAttachMetalLayout> {
  ...
};
} // namespace
```

Closes #1982 