### PR TITLE
TT kernel operations needed for first eltwise PyKernel

### DIFF
--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -817,4 +817,14 @@ def TTKernel_GetReadPtrOp : TTKernel_Op<"get_read_ptr"> {
     let results = (outs I32:$readPtr);
 }
 
+def TTKernel_GetTileSizeOp : TTKernel_Op<"get_tile_size"> {
+    let summary = "Get the tile size in bytes of a given CB";
+    let description = [{
+      get_tile_size operation
+    }];
+    let arguments = (ins TTKernel_CB:$cb);
+    let results = (outs I32:$tileSizeBytes);
+}
+
+
 #endif

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -662,6 +662,17 @@ def TTKernel_GetArgValOp : TTKernel_Op<"get_arg_val"> {
     let results = (outs AnyTypeOf<[TTKernel_Semaphore, I32]>:$arg_val);
 }
 
+def TTKernel_GetCompileArgValOp : TTKernel_Op<"get_compile_time_arg_val"> {
+    let summary = "Get compile-time arg value.";
+    let description = [{
+      Get compile-time argument value at specified index.
+    }];
+
+    let arguments = (ins I32:$arg_index);
+
+    let results = (outs AnyTypeOf<[TTKernel_Semaphore, I32]>:$arg_val);
+}
+
 //===----------------------------------------------------------------------===//
 // TTKernel Helper functions
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -796,4 +796,14 @@ def TTKernel_GetWritePtrOp : TTKernel_Op<"get_write_ptr"> {
     let results = (outs I32:$writePtr);
 }
 
+def TTKernel_GetReadPtrOp : TTKernel_Op<"get_read_ptr"> {
+    let summary = "GetReadPtr";
+    let description = [{
+      GetReadPtr operation
+    }];
+
+    let arguments = (ins TTKernel_CB:$cb);
+    let results = (outs I32:$readPtr);
+}
+
 #endif

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -447,7 +447,10 @@ public:
           TTMetalToEmitCOpaqueRewriter<ttkernel::CopyTileOp>,
           TTMetalToEmitCOpaqueRewriter<ttkernel::ExpTileInitOp>,
           TTMetalToEmitCOpaqueRewriter<ttkernel::ExpTileOp>,
-          TTMetalToEmitCOpaqueRewriter<ttkernel::GetWritePtrOp>>(
+          TTMetalToEmitCOpaqueRewriter<ttkernel::GetWritePtrOp>,
+          TTMetalToEmitCOpaqueRewriter<ttkernel::GetReadPtrOp>,
+          TTMetalToEmitCOpaqueRewriter<ttkernel::GetTileSizeOp>,
+          TTMetalToEmitCOpaqueRewriter<ttkernel::GetCompileArgValOp>>(
           typeConverter, funcOp.getContext());
 
       patterns.add<TTMetalToEmitCOpaqueRewriter<ttkernel::GetNocAddrXYOp>>(


### PR DESCRIPTION
This PR implements the following TTKernel OPs needed by [first PyKernel eltwise example](https://github.com/tenstorrent/tt-mlir/issues/1984):

- [get_read_ptr](https://github.com/tenstorrent/tt-mlir/issues/1987) 
- [get_compile_time_arg_val](https://github.com/tenstorrent/tt-mlir/issues/1988)
- [get_tile_size](https://github.com/tenstorrent/tt-mlir/issues/1985) 