### PR TITLE
Remove the BF16 type constraint from TTIR gather to embedding conversion

### DIFF
--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -498,13 +498,6 @@ struct GatherToEmbeddingConversionPattern
     // collapsed slice dims of the gather op
     auto collapsedSliceDims = op.getCollapsedSliceDims();
 
-    RankedTensorType operandType =
-        mlir::cast<RankedTensorType>(op->getOperand(0).getType());
-    if (!operandType.getElementType().isBF16()) {
-      return rewriter.notifyMatchFailure(
-          op, "only supports bfloat16 input tensor.");
-    }
-
     if (shape.size() > 1) {
       auto hiddenDim = shape[shape.size() - 1];
       // check if sliceSizes has more than one element

--- a/test/ttmlir/Dialect/TTNN/embedding/gather_to_embedding.mlir
+++ b/test/ttmlir/Dialect/TTNN/embedding/gather_to_embedding.mlir
@@ -50,4 +50,24 @@ module attributes {} {
       }> : (tensor<51864x384xbf16>, tensor<1x2xi32>, tensor<1x2x384xbf16>) -> tensor<1x2x384xbf16>
     return %1 : tensor<1x2x384xbf16>
   }
+
+  func.func @gather_3(%operand: tensor<32000x1024xf32>, %start_indices: tensor<1x32xi32>) -> tensor<1x32x1024xf32> {
+    %0 = tensor.empty() : tensor<1x32x1024xf32>
+    // CHECK: "ttnn.embedding"
+    // CHECK-SAME: tensor<32000x1024xbf16
+    %1 = "ttir.gather"(%operand, %start_indices, %0) {
+        offset_dims = array<i64: 2>,
+        collapsed_slice_dims = array<i64: 0>,
+        operand_batching_dims = array<i64: 0>,
+        start_indices_batching_dims = array<i64: 0>,
+        start_index_map = array<i64: 0>,
+        index_vector_dim = 1 : si64,
+        slice_sizes = array<i64: 1, 1024>,
+        indices_are_sorted = false
+    } : (tensor<32000x1024xf32>, tensor<1x32xi32>, tensor<1x32x1024xf32>) -> tensor<1x32x1024xf32>
+    // CHECK: "ttnn.typecast"
+    // CHECK-SAME: tensor<1x32x1024xbf16
+    // CHECK-SAME:  -> tensor<1x32x1024xf32
+    return %1 : tensor<1x32x1024xf32>
+  }
 }

--- a/test/ttmlir/Dialect/TTNN/embedding/gather_to_embedding_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/embedding/gather_to_embedding_negative.mlir
@@ -100,23 +100,3 @@ module attributes {} {
     return %1 : tensor<1x2x384xf32>
   }
 }
-
-// Verify that the parsing fails for data type other than bfloat16.
-// -----
-module attributes {} {
-  func.func @gather_0(%operand: tensor<32000x1024xf32>, %start_indices: tensor<1x32xi32>) -> tensor<1x32x1024xf32> {
-    %0 = tensor.empty() : tensor<1x32x1024xf32>
-    // CHECK: error: failed to legalize operation 'ttir.gather' that was explicitly marked illegal
-    %1 = "ttir.gather"(%operand, %start_indices, %0) {
-        offset_dims = array<i64: 2>,
-        collapsed_slice_dims = array<i64: 0>,
-        operand_batching_dims = array<i64: 0>,
-        start_indices_batching_dims = array<i64: 0>,
-        start_index_map = array<i64: 0>,
-        index_vector_dim = 1 : si64,
-        slice_sizes = array<i64: 1, 1024>,
-        indices_are_sorted = false
-    } : (tensor<32000x1024xf32>, tensor<1x32xi32>, tensor<1x32x1024xf32>) -> tensor<1x32x1024xf32>
-    return %1 : tensor<1x32x1024xf32>
-  }
-}


### PR DESCRIPTION
After the workarounds pass was added and workarounds were enabled for EmbeddingOp, the constraint that operands have to be in BF16 for GatherOp -> EmbeddingOp conversion should no longer be necessary. This PR removes it.