### PR TITLE
Remove ttnn::LegacyShape, ttnn::SimpleShape doesn't need it

### DIFF
--- a/include/ttmlir/Conversion/TTNNToEmitC/Utils.h
+++ b/include/ttmlir/Conversion/TTNNToEmitC/Utils.h
@@ -63,22 +63,13 @@ emitc::OpaqueAttr convertArrayAttrToSpan(Builder &builder, ArrayAttr attr);
 emitc::OpaqueAttr createStdNullopt(Builder &builder);
 
 // Helper enum to differentiate between ttnn::Shape and ttnn::SimpleShape
+//
 enum class ShapeType { SimpleShape = 0, Shape = 1 };
 
-// Create ttnn::Shape and return emitc::ExpressionOp
+// Create emitc::CallOpaqueOp to ttnn::SimpleShape (Shape) constructor
 //
-// ttnn:Shape has a couple constructors, but they are explicit and require
-// specific datatypes on input. However, one of the constructors takes in a
-// tt_metal::Shape - given that it's much easier to construct a
-// tt_metal::Shape, we opted to do that here. The call looks like this:
-// ttnn::Shape(tt::tt_metal::LegacyShape{dim0, dim1, dim2, ...});
-//
-// To make it easier on the eyes, these two calls are packed into one, using
-// EmitC's ExpressionOp.
-//
-emitc::ExpressionOp createShapeOp(ConversionPatternRewriter &rewriter,
-                                  ttnn::ShapeAttr shapeAttr,
-                                  Block *containingBlock, Location loc,
+emitc::CallOpaqueOp createShapeOp(ConversionPatternRewriter &rewriter,
+                                  ttnn::ShapeAttr shapeAttr, Location loc,
                                   ShapeType shapeType = ShapeType::SimpleShape);
 
 // Create ttnn::MemoryConfig and return emitc::CallOpaqueOp

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -529,15 +529,15 @@ public:
 
     // Create ttnn::Shape() call
     //
-    emitc::ExpressionOp shapeExpressionOp = ttnn_to_emitc::utils::createShapeOp(
-        rewriter, repeatDims, repeatOp->getBlock(), repeatOp.getLoc(),
+    emitc::CallOpaqueOp shapeOp = ttnn_to_emitc::utils::createShapeOp(
+        rewriter, repeatDims, repeatOp.getLoc(),
         ttnn_to_emitc::utils::ShapeType::Shape);
 
     // Create operands vector
     //
     llvm::SmallVector<Value, 2> operands{
         adaptor.getOperands()[0], // input tensor
-        shapeExpressionOp->getResult(0)};
+        shapeOp->getResult(0)};
 
     // Create ArrayAttr object holding attributes and pointers to operands
     //
@@ -791,12 +791,12 @@ public:
 
     // Create ttnn::SimpleShape() call.
     //
-    emitc::ExpressionOp shapeExpressionOp = ttnn_to_emitc::utils::createShapeOp(
-        rewriter, shapeAttr, srcOp->getBlock(), srcOp.getLoc());
+    emitc::CallOpaqueOp shapeOp = ttnn_to_emitc::utils::createShapeOp(
+        rewriter, shapeAttr, srcOp.getLoc());
 
     // Create operands vector.
     //
-    llvm::SmallVector<Value, 3> operands{shapeExpressionOp->getResult(0),
+    llvm::SmallVector<Value, 3> operands{shapeOp->getResult(0),
                                          adaptor.getDevice()};
 
     // Create MemoryConfig object first, then pass it to the op.
@@ -865,11 +865,11 @@ public:
 
     // Create ttnn::SimpleShape() call
     //
-    emitc::ExpressionOp shapeExpressionOp = ttnn_to_emitc::utils::createShapeOp(
-        rewriter, srcOp.getShapeAttr(), srcOp->getBlock(), srcOp.getLoc());
+    emitc::CallOpaqueOp shapeOp = ttnn_to_emitc::utils::createShapeOp(
+        rewriter, srcOp.getShapeAttr(), srcOp.getLoc());
 
     llvm::SmallVector<Value, 3> operands{
-        shapeExpressionOp->getResult(0),
+        shapeOp->getResult(0),
     };
 
     // Create ArrayAttr object holding attributes and pointers to operands


### PR DESCRIPTION
Before `ttnn::SimpleShape` was introduced, the easiest way for us to create `ttnn::Shape` objects was to do `ttnn::Shape(ttnn::LegacyShape(c, h, w, ...))` - but the `ttnn::LegacyShape()` constructor is NOT needed anymore, as `ttnn::SimpleShape` accepts an initializer list.