### PR TITLE
remove reduce ops workaround for keepDim attribute

### DIFF
--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkarounds.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkarounds.cpp
@@ -426,13 +426,13 @@ public:
       RewritePatternSet patterns(&getContext());
       patterns.add<TTNNAllReduceWorkarounds,
                    workarounds::decomposition::ReduceOpsKeepDimRewritePattern<
-                       ttnn::SumOp>,
+                       ttnn::SumOp, /*keepDimUnsupported*/ false>,
                    workarounds::decomposition::ReduceOpsKeepDimRewritePattern<
-                       ttnn::MaxOp>,
+                       ttnn::MaxOp, /*keepDimUnsupported*/ false>,
                    workarounds::decomposition::ReduceOpsKeepDimRewritePattern<
-                       ttnn::MeanOp>,
+                       ttnn::MeanOp, /*keepDimUnsupported*/ false>,
                    workarounds::decomposition::ReduceOpsKeepDimRewritePattern<
-                       ttnn::MinOp>,
+                       ttnn::MinOp, /*keepDimUnsupported*/ false>,
                    workarounds::decomposition::ReduceOpsAllDimsRewritePattern<
                        ttnn::SumOp>,
                    workarounds::decomposition::ReduceOpsAllDimsRewritePattern<

--- a/test/ttmlir/Dialect/TTNN/reduction/simple_reduce_min.mlir
+++ b/test/ttmlir/Dialect/TTNN/reduction/simple_reduce_min.mlir
@@ -6,13 +6,9 @@ module attributes {} {
     %0 = tensor.empty() : tensor<128x32x4xf32>
     // CHECK: %[[MIN:[0-9]+]] = "ttnn.min"
     // CHECK-SAME: dim_arg = [1 : i32]
-    // CHECK-SAME: keep_dim = true
+    // CHECK-SAME: keep_dim = false
     // CHECK-SAME: (tensor<128x10x32x4xf32,
-    // CHECK-SAME: -> tensor<128x1x32x4xf32,
-    // CHECK: "ttnn.reshape"(%[[MIN]])
-    // CHECK-SAME: shape = [128 : i32, 32 : i32, 4 : i32]
-    // CHECK-SAME: tensor<128x1x32x4xf32,
-    // CHECK-SAME: -> tensor<128x32x4xf32
+    // CHECK-SAME: -> tensor<128x32x4xf32,
     %1 = "ttir.min"(%arg0, %0) <{dim_arg = [1: i32], keep_dim = false}> : (tensor<128x10x32x4xf32>, tensor<128x32x4xf32>) -> tensor<128x32x4xf32>
     return %1 : tensor<128x32x4xf32>
   }
@@ -38,13 +34,9 @@ module attributes {} {
     %0 = tensor.empty() : tensor<128x4xf32>
     // CHECK: %[[MIN:[0-9]+]] = "ttnn.min"
     // CHECK-SAME: dim_arg = [1 : i32]
-    // CHECK-SAME: keep_dim = true
+    // CHECK-SAME: keep_dim = false
     // CHECK-SAME: (tensor<128x10x4xf32,
-    // CHECK-SAME: -> tensor<128x1x4xf32,
-    // CHECK: "ttnn.reshape"(%[[MIN]])
-    // CHECK-SAME: shape = [128 : i32, 4 : i32]
-    // CHECK-SAME: tensor<128x1x4xf32,
-    // CHECK-SAME: -> tensor<128x4xf32
+    // CHECK-SAME: -> tensor<128x4xf32,
     %1 = "ttir.min"(%arg0, %0) <{dim_arg = [1: i32], keep_dim = false}> : (tensor<128x10x4xf32>, tensor<128x4xf32>) -> tensor<128x4xf32>
     return %1 : tensor<128x4xf32>
   }

--- a/test/ttmlir/Silicon/StableHLO/n150/reduction/reduce_add_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/reduction/reduce_add_op.mlir
@@ -4,11 +4,6 @@
 // RUN: ttmlir-opt --stablehlo-to-ttir-pipeline --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck --input-file=%t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-// UNSUPPORTED: true
-// These tests are currently failing until a fix for this issue is uplifted
-// with new version of Metal: https://github.com/tenstorrent/tt-metal/issues/16104
-// TODO(mrakita): Enable and edit these tests after the Metal issue is fixed.
-// Tracked by: https://github.com/tenstorrent/tt-mlir/issues/1640
 
 module @jit_reduce_add attributes {} {
   func.func public @test_reduce_add_4to0dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
@@ -20,7 +15,6 @@ module @jit_reduce_add attributes {} {
     // CHECK: "ttnn.reshape"
     // CHECK-SAME: shape = [1 : i32]
     // CHECK-SAME: tensor<1x1x1x1xf32,
-    // CHECK-SAME: -> tensor<1xf32,
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [0, 1, 2, 3] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<f32>
     return %0 : tensor<f32>
   }
@@ -28,12 +22,8 @@ module @jit_reduce_add attributes {} {
   func.func public @test_reduce_add_3to2dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128x4xf32> {
     // CHECK: "ttnn.sum"
     // CHECK-SAME: dim_arg = [1 : i32]
-    // CHECK-SAME: keep_dim = true
+    // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10x4xf32,
-    // CHECK-SAME: -> tensor<128x1x4xf32,
-    // CHECK: "ttnn.reshape"
-    // CHECK-SAME: shape = [128 : i32, 4 : i32]
-    // CHECK-SAME: tensor<128x1x4xf32,
     // CHECK-SAME: -> tensor<128x4xf32,
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [1] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128x4xf32>
     return %0 : tensor<128x4xf32>
@@ -42,12 +32,8 @@ module @jit_reduce_add attributes {} {
   func.func public @test_reduce_add_3to1dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
     // CHECK: "ttnn.sum"
     // CHECK-SAME: dim_arg = [1 : i32, 2 : i32]
-    // CHECK-SAME: keep_dim = true
+    // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10x4xf32,
-    // CHECK-SAME: -> tensor<128x1x1xf32,
-    // CHECK: "ttnn.reshape"
-    // CHECK-SAME: shape = [128 : i32]
-    // CHECK-SAME: tensor<128x1x1xf32,
     // CHECK-SAME: -> tensor<128xf32,
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [1, 2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128xf32>
     return %0 : tensor<128xf32>
@@ -62,7 +48,6 @@ module @jit_reduce_add attributes {} {
     // CHECK: "ttnn.reshape"
     // CHECK-SAME: shape = [1 : i32]
     // CHECK-SAME: tensor<1x1x1xf32,
-    // CHECK-SAME: -> tensor<1xf32,
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [0, 1, 2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<f32>
     return %0 : tensor<f32>
   }
@@ -70,12 +55,8 @@ module @jit_reduce_add attributes {} {
   func.func public @test_reduce_add_2to1dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
     // CHECK: "ttnn.sum"
     // CHECK-SAME: dim_arg = [1 : i32]
-    // CHECK-SAME: keep_dim = true
+    // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10xf32,
-    // CHECK-SAME: -> tensor<128x1xf32,
-    // CHECK: "ttnn.reshape"
-    // CHECK-SAME: shape = [128 : i32]
-    // CHECK-SAME: tensor<128x1xf32,
     // CHECK-SAME: -> tensor<128xf32,
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<128xf32>
     return %0 : tensor<128xf32>
@@ -90,7 +71,6 @@ module @jit_reduce_add attributes {} {
     // CHECK: "ttnn.reshape"
     // CHECK-SAME: shape = [1 : i32]
     // CHECK-SAME: tensor<1x1xf32,
-    // CHECK-SAME: -> tensor<1xf32,
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [0, 1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<f32>
     return %0 : tensor<f32>
   }

--- a/test/ttmlir/Silicon/StableHLO/n150/reduction/reduce_maximum_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/reduction/reduce_maximum_op.mlir
@@ -4,11 +4,6 @@
 // RUN: ttmlir-opt --stablehlo-to-ttir-pipeline --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck --input-file=%t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-// UNSUPPORTED: true
-// These tests are currently failing until a fix for this issue is uplifted
-// with new version of Metal: https://github.com/tenstorrent/tt-metal/issues/16104
-// TODO(mrakita): Enable and edit these tests after the Metal issue is fixed.
-// Tracked by: https://github.com/tenstorrent/tt-mlir/issues/1640
 
 module @jit_reduce_maximum attributes {} {
   func.func public @test_reduce_maximum_4to0dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
@@ -20,7 +15,6 @@ module @jit_reduce_maximum attributes {} {
     // CHECK: "ttnn.reshape"
     // CHECK-SAME: shape = [1 : i32]
     // CHECK-SAME: tensor<1x1x1x1xf32,
-    // CHECK-SAME: -> tensor<1xf32,
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0, 1, 2, 3] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<f32>
     return %0 : tensor<f32>
   }
@@ -28,12 +22,8 @@ module @jit_reduce_maximum attributes {} {
   func.func public @test_reduce_maximum_3to2dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128x4xf32> {
     // CHECK: "ttnn.max"
     // CHECK-SAME: dim_arg = [1 : i32]
-    // CHECK-SAME: keep_dim = true
+    // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10x4xf32,
-    // CHECK-SAME: -> tensor<128x1x4xf32,
-    // CHECK: "ttnn.reshape"
-    // CHECK-SAME: shape = [128 : i32, 4 : i32]
-    // CHECK-SAME: tensor<128x1x4xf32,
     // CHECK-SAME: -> tensor<128x4xf32,
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128x4xf32>
     return %0 : tensor<128x4xf32>
@@ -42,12 +32,8 @@ module @jit_reduce_maximum attributes {} {
   func.func public @test_reduce_maximum_3to1dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
     // CHECK: "ttnn.max"
     // CHECK-SAME: dim_arg = [1 : i32, 2 : i32]
-    // CHECK-SAME: keep_dim = true
+    // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10x4xf32,
-    // CHECK-SAME: -> tensor<128x1x1xf32,
-    // CHECK: "ttnn.reshape"
-    // CHECK-SAME: shape = [128 : i32]
-    // CHECK-SAME: tensor<128x1x1xf32,
     // CHECK-SAME: -> tensor<128xf32,
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1, 2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128xf32>
     return %0 : tensor<128xf32>
@@ -62,7 +48,6 @@ module @jit_reduce_maximum attributes {} {
     // CHECK: "ttnn.reshape"
     // CHECK-SAME: shape = [1 : i32]
     // CHECK-SAME: tensor<1x1x1xf32,
-    // CHECK-SAME: -> tensor<1xf32,
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0, 1, 2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<f32>
     return %0 : tensor<f32>
   }
@@ -70,12 +55,8 @@ module @jit_reduce_maximum attributes {} {
   func.func public @test_reduce_maximum_2to1dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
     // CHECK: "ttnn.max"
     // CHECK-SAME: dim_arg = [1 : i32]
-    // CHECK-SAME: keep_dim = true
+    // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10xf32,
-    // CHECK-SAME: -> tensor<128x1xf32,
-    // CHECK: "ttnn.reshape"
-    // CHECK-SAME: shape = [128 : i32]
-    // CHECK-SAME: tensor<128x1xf32,
     // CHECK-SAME: -> tensor<128xf32,
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<128xf32>
     return %0 : tensor<128xf32>
@@ -90,7 +71,6 @@ module @jit_reduce_maximum attributes {} {
     // CHECK: "ttnn.reshape"
     // CHECK-SAME: shape = [1 : i32]
     // CHECK-SAME: tensor<1x1xf32,
-    // CHECK-SAME: -> tensor<1xf32,
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0, 1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<f32>
     return %0 : tensor<f32>
   }

--- a/test/ttmlir/Silicon/StableHLO/n150/reduction/reduce_min_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/reduction/reduce_min_op.mlir
@@ -24,12 +24,8 @@ module @jit_reduce_minimum attributes {} {
   func.func public @test_reduce_minimum_3to2dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128x4xf32> {
     // CHECK: "ttnn.min"
     // CHECK-SAME: dim_arg = [1 : i32]
-    // CHECK-SAME: keep_dim = true
+    // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10x4xf32,
-    // CHECK-SAME: -> tensor<128x1x4xf32,
-    // CHECK: "ttnn.reshape"
-    // CHECK-SAME: shape = [128 : i32, 4 : i32]
-    // CHECK-SAME: tensor<128x1x4xf32,
     // CHECK-SAME: -> tensor<128x4xf32,
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [1] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128x4xf32>
     return %0 : tensor<128x4xf32>
@@ -38,12 +34,8 @@ module @jit_reduce_minimum attributes {} {
   func.func public @test_reduce_minimum_3to1dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
     // CHECK: "ttnn.min"
     // CHECK-SAME: dim_arg = [1 : i32, 2 : i32]
-    // CHECK-SAME: keep_dim = true
+    // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10x4xf32,
-    // CHECK-SAME: -> tensor<128x1x1xf32,
-    // CHECK: "ttnn.reshape"
-    // CHECK-SAME: shape = [128 : i32]
-    // CHECK-SAME: tensor<128x1x1xf32,
     // CHECK-SAME: -> tensor<128xf32,
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [1, 2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128xf32>
     return %0 : tensor<128xf32>
@@ -66,12 +58,8 @@ module @jit_reduce_minimum attributes {} {
   func.func public @test_reduce_minimum_2to1dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
     // CHECK: "ttnn.min"
     // CHECK-SAME: dim_arg = [1 : i32]
-    // CHECK-SAME: keep_dim = true
+    // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10xf32,
-    // CHECK-SAME: -> tensor<128x1xf32,
-    // CHECK: "ttnn.reshape"
-    // CHECK-SAME: shape = [128 : i32]
-    // CHECK-SAME: tensor<128x1xf32,
     // CHECK-SAME: -> tensor<128xf32,
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<128xf32>
     return %0 : tensor<128xf32>

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_reduce_min.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_reduce_min.mlir
@@ -10,12 +10,8 @@ module {
     %0 = tensor.empty() : tensor<128x32x4xf32>
     // CHECK: "ttnn.min"
     // CHECK-SAME: dim_arg = [1 : i32]
-    // CHECK-SAME: keep_dim = true
+    // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10x32x4xf32,
-    // CHECK-SAME: -> tensor<128x1x32x4xf32,
-    // CHECK: "ttnn.reshape"
-    // CHECK-SAME: shape = [128 : i32, 32 : i32, 4 : i32]
-    // CHECK-SAME: tensor<128x1x32x4xf32,
     // CHECK-SAME: -> tensor<128x32x4xf32,
     %1 = "ttir.min"(%arg0, %0) <{dim_arg = [1: i32], keep_dim = false}> : (tensor<128x10x32x4xf32>, tensor<128x32x4xf32>) -> tensor<128x32x4xf32>
     return %1 : tensor<128x32x4xf32>

--- a/test/ttmlir/Silicon/TTNN/n150/simple_max.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_max.mlir
@@ -3,23 +3,14 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-// UNSUPPORTED: true
-// These tests are currently failing until a fix for this issue is uplifted
-// with new version of Metal: https://github.com/tenstorrent/tt-metal/issues/16104
-// TODO(mrakita): Enable and edit these tests after the Metal issue is fixed.
-// Tracked by: https://github.com/tenstorrent/tt-mlir/issues/1640
 
 module {
   func.func public @reduce_not_keep_dim(%arg0: tensor<128x10xf32>) -> tensor<128xf32> {
     %0 = tensor.empty() : tensor<128xf32>
     // CHECK: "ttnn.max"
     // CHECK-SAME: dim_arg = [1 : i32]
-    // CHECK-SAME: keep_dim = true
+    // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10xf32,
-    // CHECK-SAME: -> tensor<128x1xf32,
-    // CHECK: "ttnn.reshape"
-    // CHECK-SAME: shape = [128 : i32]
-    // CHECK-SAME: tensor<128x1xf32,
     // CHECK-SAME: -> tensor<128xf32,
     %1 = "ttir.max"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x10xf32>, tensor<128xf32>) -> tensor<128xf32>
     return %1 : tensor<128xf32>

--- a/test/ttmlir/Silicon/TTNN/n150/simple_mean.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_mean.mlir
@@ -3,23 +3,14 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-// UNSUPPORTED: true
-// These tests are currently failing until a fix for this issue is uplifted
-// with new version of Metal: https://github.com/tenstorrent/tt-metal/issues/16104
-// TODO(mrakita): Enable and edit these tests after the Metal issue is fixed.
-// Tracked by: https://github.com/tenstorrent/tt-mlir/issues/1640
 
 module {
   func.func public @reduce_not_keep_dim(%arg0: tensor<128x10xf32>) -> tensor<128xf32> {
     %0 = tensor.empty() : tensor<128xf32>
     // CHECK: "ttnn.mean"
     // CHECK-SAME: dim_arg = [1 : i32]
-    // CHECK-SAME: keep_dim = true
+    // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10xf32,
-    // CHECK-SAME: -> tensor<128x1xf32,
-    // CHECK: "ttnn.reshape"
-    // CHECK-SAME: shape = [128 : i32]
-    // CHECK-SAME: tensor<128x1xf32,
     // CHECK-SAME: -> tensor<128xf32,
     %1 = "ttir.mean"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x10xf32>, tensor<128xf32>) -> tensor<128xf32>
     return %1 : tensor<128xf32>

--- a/test/ttmlir/Silicon/TTNN/n150/simple_reduce_min.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_reduce_min.mlir
@@ -10,12 +10,8 @@ module {
     %0 = tensor.empty() : tensor<128x32x4xf32>
     // CHECK: "ttnn.min"
     // CHECK-SAME: dim_arg = [1 : i32]
-    // CHECK-SAME: keep_dim = true
+    // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10x32x4xf32,
-    // CHECK-SAME: -> tensor<128x1x32x4xf32,
-    // CHECK: "ttnn.reshape"
-    // CHECK-SAME: shape = [128 : i32, 32 : i32, 4 : i32]
-    // CHECK-SAME: tensor<128x1x32x4xf32,
     // CHECK-SAME: -> tensor<128x32x4xf32,
     %1 = "ttir.min"(%arg0, %0) <{dim_arg = [1: i32], keep_dim = false}> : (tensor<128x10x32x4xf32>, tensor<128x32x4xf32>) -> tensor<128x32x4xf32>
     return %1 : tensor<128x32x4xf32>

--- a/test/ttmlir/Silicon/TTNN/n150/simple_sum.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_sum.mlir
@@ -3,7 +3,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-// UNSUPPORTED: true
 // These tests are currently failing until a fix for this issue is uplifted
 // with new version of Metal: https://github.com/tenstorrent/tt-metal/issues/16104
 // TODO(mrakita): Enable and edit these tests after the Metal issue is fixed.
@@ -14,12 +13,8 @@ module {
     %0 = tensor.empty() : tensor<128xf32>
     // CHECK: "ttnn.sum"
     // CHECK-SAME: dim_arg = [1 : i32]
-    // CHECK-SAME: keep_dim = true
+    // CHECK-SAME: keep_dim = false
     // CHECK-SAME: tensor<128x10xf32,
-    // CHECK-SAME: -> tensor<128x1xf32,
-    // CHECK: "ttnn.reshape"
-    // CHECK-SAME: shape = [128 : i32]
-    // CHECK-SAME: tensor<128x1xf32,
     // CHECK-SAME: -> tensor<128xf32,
     %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x10xf32>, tensor<128xf32>) -> tensor<128xf32>
     return %1 : tensor<128xf32>


### PR DESCRIPTION
This workaround is still required in case of reducing entire tensor.

closes #1640 