### PR TITLE
optimize looping over NOC data movement ops

### DIFF
--- a/include/ttmlir/Conversion/Passes.td
+++ b/include/ttmlir/Conversion/Passes.td
@@ -50,7 +50,7 @@ def ConvertTTNNToEmitC : Pass<"convert-ttnn-to-emitc", "::mlir::ModuleOp"> {
   let dependentDialects = ["mlir::emitc::EmitCDialect", "mlir::tt::ttnn::TTNNDialect"];
 }
 
-def ConvertTTKernelToEmitC : Pass<"convert-ttkernel-to-emitc", "::func::FuncOp"> {
+def ConvertTTKernelToEmitC : Pass<"convert-ttkernel-to-emitc", "::mlir::ModuleOp"> {
   let summary = "Convert TTKernel dialect to EmitC dialect.";
   let dependentDialects = ["mlir::emitc::EmitCDialect", "mlir::func::FuncDialect",
                            "mlir::tt::ttkernel::TTKernelDialect"];

--- a/include/ttmlir/Conversion/TTKernelToEmitC/TTKernelToEmitC.h
+++ b/include/ttmlir/Conversion/TTKernelToEmitC/TTKernelToEmitC.h
@@ -5,36 +5,37 @@
 #ifndef TTMLIR_CONVERSION_TTKERNELTOEMITC_TTKERNELTOEMITC_H
 #define TTMLIR_CONVERSION_TTKERNELTOEMITC_TTKERNELTOEMITC_H
 
-#include "mlir/IR/BuiltinOps.h"
-#include "mlir/Pass/Pass.h"
-
 #include "ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.h"
 #include "ttmlir/Dialect/TTMetal/IR/TTMetalOps.h"
+
 #include <llvm/ADT/SmallVector.h>
+#include <mlir/IR/BuiltinOps.h>
+#include <mlir/Pass/Pass.h>
 
 namespace mlir::tt {
 #define GEN_PASS_DECL_CONVERTTTKERNELTOEMITC
 #include "ttmlir/Conversion/Passes.h.inc"
 
-// Runs a conversion pass to EmitC dialect on a func op containing given
-// region's body. Also, it adds boilerplate code such as includes and namespace
-// declarations.
-LogicalResult
-convertTTKernelRegionToEmitC(OpBuilder &builder, Region *region,
-                             const ttkernel::ThreadType &threadType);
+//===----------------------------------------------------------------------===//
+// IR -> C++ text codegen:
+//===----------------------------------------------------------------------===//
 
 // Converts given region to EmitC dialect and translates it to C++ code.
 LogicalResult emitOpRegionAsCpp(Region *region, std::string &regionCpp,
                                 const ttkernel::ThreadType &threadType);
 
+// Converts given region to EmitC dialect and writes it as C++ code to 'os'.
 LogicalResult emitOpRegionAsCpp(Region *region, llvm::raw_ostream &os,
                                 const ttkernel::ThreadType &threadType);
 
-// Converts enqueue program op's regions to C++ code.
+// Converts enqueue program op's regions to EmitC dialect and writes
+// them as C++ code to 'cppStrings' (in the same order as
+// 'enqueueProgramOp' regions).
 LogicalResult
 emitEnqueueProgramOpRegionsAsCpp(ttmetal::EnqueueProgramOp enqueueProgramOp,
                                  llvm::SmallVector<std::string> &cppStrings);
 
+// Converts all FuncOps in 'op' as if by emitOpRegionAsCpp().
 LogicalResult emitKernelAsCpp(mlir::ModuleOp op, llvm::raw_ostream &os,
                               const ttkernel::ThreadType &threadType);
 

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelBase.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelBase.td
@@ -28,6 +28,7 @@ def TTKernel_Dialect : Dialect {
     }];
     let dependentDialects = [
       "::mlir::arith::ArithDialect",
+      "::mlir::memref::MemRefDialect",
       "::mlir::scf::SCFDialect",
       "::mlir::cf::ControlFlowDialect",
       "::mlir::tt::TTDialect"

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -647,6 +647,23 @@ def TTKernel_NocSemaphoreSetMulticastLoopbackOp : TTKernel_Op<"noc_semaphore_set
                          BoolAttr:$multicast_path_reserve);
 }
 
+def TTKernel_NocOpsTableOp : TTKernel_Op<"noc_ops_table"> {
+    let summary = [{define an array of parameter entries for a sequence of NOC
+     read/write operations
+    }];
+    let description = [{
+      Encapsulates parameters for a group of NOC read/write operations as
+      an array of (dst, src, size, dst_x, dst_y, numElements) entries, with
+      each entry slot of type int32_t.
+      An entry defines an src->dst data movement operation and as either
+      a read (remote src, local dst) or a write (local src, remote dst) by
+      the calling core.
+    }];
+
+    let arguments = (ins DenseI32ArrayAttr:$entries);
+    let results = (outs AnyStaticShapeMemRef:$table);
+}
+
 //===----------------------------------------------------------------------===//
 // TTKernel Compile and runtime arguments operations
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -647,7 +647,7 @@ def TTKernel_NocSemaphoreSetMulticastLoopbackOp : TTKernel_Op<"noc_semaphore_set
                          BoolAttr:$multicast_path_reserve);
 }
 
-def TTKernel_NocOpsTableOp : TTKernel_Op<"noc_ops_table"> {
+def TTKernel_NocTransactionsTableOp : TTKernel_Op<"noc_transactions_table"> {
     let summary = [{define an array of parameter entries for a sequence of NOC
      read/write operations
     }];

--- a/lib/Conversion/TTKernelToEmitC/CMakeLists.txt
+++ b/lib/Conversion/TTKernelToEmitC/CMakeLists.txt
@@ -11,6 +11,7 @@ add_mlir_conversion_library(TTMLIRTTKernelToEmitC
   MLIRIR
   MLIRPass
   MLIRArithToEmitC
+  MLIRMemRefToEmitC
   MLIRSCFToEmitC
   MLIREmitCDialect
   MLIRTargetCpp

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -372,7 +372,7 @@ struct ConvertNocOpsTableOp
                        GlobalArrayDefTable &globalDefs,
                        PatternBenefit benefit = 1)
       : OpConversionPattern(typeConverter, context, benefit),
-        globalDefs(globalDefs) {}
+        globalDefs(&globalDefs) {}
 
   LogicalResult
   matchAndRewrite(Op op, typename Op::Adaptor adaptor,
@@ -387,7 +387,7 @@ struct ConvertNocOpsTableOp
           asValidCppId(generateGlobalName(op.getOperation()));
 
       auto inserted =
-          globalDefs.defs.emplace(globalName, std::make_tuple(type, entries));
+          globalDefs->defs.emplace(globalName, std::make_tuple(type, entries));
       assert(inserted.second); // every visit generates a unique global name
 
       auto cType =
@@ -409,7 +409,8 @@ struct ConvertNocOpsTableOp
       ss << (fop ? fop.getSymName() : op->getName().getStringRef()) << '.';
       op = op->getParentOp();
     } while (op != nullptr && !mlir::isa<mlir::ModuleOp>(op));
-    ss << (globalDefs.unique++);
+    ss << (globalDefs->unique++); // shared state mutation ok here, because we
+                                  // know it's nested under module root
     return ss.str();
   }
 
@@ -423,7 +424,7 @@ struct ConvertNocOpsTableOp
     return r;
   }
 
-  GlobalArrayDefTable &globalDefs;
+  GlobalArrayDefTable *globalDefs;
 
 }; // end of class
 

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -9,7 +9,6 @@
 #include "ttmlir/Dialect/TTMetal/IR/TTMetal.h"
 #include "ttmlir/Dialect/TTMetal/IR/TTMetalOps.h"
 
-#include <cctype>
 #include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringRef.h>
@@ -33,6 +32,7 @@
 #include <mlir/Target/Cpp/CppEmitter.h>
 #include <mlir/Transforms/DialectConversion.h>
 
+#include <cctype>
 #include <string>
 #include <unordered_map>
 

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -2,32 +2,39 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #include "ttmlir/Conversion/TTKernelToEmitC/TTKernelToEmitC.h"
+
 #include "ttmlir/Dialect/TTKernel/IR/TTKernel.h"
 #include "ttmlir/Dialect/TTKernel/IR/TTKernelOps.h"
 #include "ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.h"
 #include "ttmlir/Dialect/TTMetal/IR/TTMetal.h"
 #include "ttmlir/Dialect/TTMetal/IR/TTMetalOps.h"
 
-#include "mlir/Conversion/ArithToEmitC/ArithToEmitC.h"
-#include "mlir/Conversion/SCFToEmitC/SCFToEmitC.h"
-#include "mlir/Dialect/EmitC/IR/EmitC.h"
-#include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/IR/Builders.h"
-#include "mlir/IR/BuiltinOps.h"
-#include "mlir/IR/IRMapping.h"
-#include "mlir/IR/Location.h"
-#include "mlir/IR/Operation.h"
-#include "mlir/IR/Value.h"
-#include "mlir/Pass/PassManager.h"
-#include "mlir/Support/LLVM.h"
-#include "mlir/Target/Cpp/CppEmitter.h"
-#include "mlir/Transforms/DialectConversion.h"
-#include "llvm/ADT/SmallVector.h"
-#include "llvm/ADT/StringRef.h"
-#include "llvm/Support/LogicalResult.h"
-#include "llvm/Support/raw_ostream.h"
+#include <cctype>
+#include <llvm/ADT/DenseMap.h>
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/ADT/StringRef.h>
+#include <llvm/Support/LogicalResult.h>
+#include <llvm/Support/raw_ostream.h>
+#include <mlir/Conversion/ArithToEmitC/ArithToEmitC.h>
+#include <mlir/Conversion/MemRefToEmitC/MemRefToEmitC.h>
+#include <mlir/Conversion/SCFToEmitC/SCFToEmitC.h>
+#include <mlir/Dialect/EmitC/IR/EmitC.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/MemRef/IR/MemRef.h>
+#include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/IR/Builders.h>
+#include <mlir/IR/BuiltinOps.h>
+#include <mlir/IR/IRMapping.h>
+#include <mlir/IR/Location.h>
+#include <mlir/IR/Operation.h>
+#include <mlir/IR/Value.h>
+#include <mlir/Pass/PassManager.h>
+#include <mlir/Support/LLVM.h>
+#include <mlir/Target/Cpp/CppEmitter.h>
+#include <mlir/Transforms/DialectConversion.h>
+
 #include <string>
+#include <unordered_map>
 
 using namespace mlir;
 using namespace tt;
@@ -38,6 +45,9 @@ namespace mlir::tt::ttkernel {
 #include "ttmlir/Conversion/Passes.h.inc"
 
 } // namespace mlir::tt::ttkernel
+
+// ............................................................................
+namespace {
 
 emitc::OpaqueAttr convertCBPort(Builder &builder, ttkernel::CBPort port) {
   switch (port) {
@@ -110,7 +120,17 @@ emitc::OpaqueAttr convertCBPort(Builder &builder, ttkernel::CBPort port) {
   return nullptr;
 }
 
-class TTKernelToEmitCTypeConverter : public TypeConverter {
+// A no-op type converter:
+// (note that the trivial T->T conversion is necessary)
+class NullTypeConverter : public TypeConverter {
+public:
+  NullTypeConverter() {
+    addConversion([](Type type) { return type; });
+  }
+};
+
+// Type converter used for TTKernel/TTMetal conversions:
+class TTKernelToEmitCTypeConverter : public NullTypeConverter {
 public:
   TTKernelToEmitCTypeConverter(MLIRContext *ctx) {
     addConversion([](Type type) { return type; });
@@ -335,6 +355,78 @@ public:
   }
 };
 
+// Context used for the analysis step before 'ConvertNocOpsTableOp'
+struct GlobalArrayDefTable {
+  std::unordered_map<std::string,
+                     std::tuple<mlir::MemRefType, mlir::DenseI32ArrayAttr>>
+      defs;
+  std::int32_t unique = 0;
+};
+
+struct ConvertNocOpsTableOp
+    : public OpConversionPattern<ttkernel::NocOpsTableOp> {
+
+  using Op = ttkernel::NocOpsTableOp;
+
+  ConvertNocOpsTableOp(const TypeConverter &typeConverter, MLIRContext *context,
+                       GlobalArrayDefTable &globalDefs,
+                       PatternBenefit benefit = 1)
+      : OpConversionPattern(typeConverter, context, benefit),
+        globalDefs(globalDefs) {}
+
+  LogicalResult
+  matchAndRewrite(Op op, typename Op::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    if (op.getResult().getUses().empty()) {
+      rewriter.eraseOp(op);
+    } else {
+      mlir::MemRefType type = op.getResult().getType();
+      mlir::DenseI32ArrayAttr entries = op.getEntriesAttr();
+
+      std::string const globalName =
+          asValidCppId(generateGlobalName(op.getOperation()));
+
+      auto inserted =
+          globalDefs.defs.emplace(globalName, std::make_tuple(type, entries));
+      assert(inserted.second); // every visit generates a unique global name
+
+      auto cType =
+          emitc::ArrayType::get(type.getShape(), type.getElementType());
+      rewriter.replaceOpWithNewOp<emitc::GetGlobalOp>(op, cType, globalName);
+    }
+
+    return success();
+  }
+
+  // generate a conflict-free name by walking 'op' up to its first module parent
+  // and collecting func names along the way:
+  std::string generateGlobalName(Operation *op) const {
+    std::string name;
+    llvm::raw_string_ostream ss(name);
+    ss << "g_";
+    do {
+      auto fop = mlir::dyn_cast<func::FuncOp>(op);
+      ss << (fop ? fop.getSymName() : op->getName().getStringRef()) << '.';
+      op = op->getParentOp();
+    } while (op != nullptr && !mlir::isa<mlir::ModuleOp>(op));
+    ss << (globalDefs.unique++);
+    return ss.str();
+  }
+
+  static std::string asValidCppId(std::string const &s) {
+    std::string r(s);
+    for (std::size_t i = 0; i < r.size(); ++i) {
+      if (!std::isalnum(r[i])) {
+        r[i] = '_';
+      }
+    }
+    return r;
+  }
+
+  GlobalArrayDefTable &globalDefs;
+
+}; // end of class
+
 class ConvertTTKernelToEmitCPass
     : public ttkernel::impl::ConvertTTKernelToEmitCBase<
           ConvertTTKernelToEmitCPass> {
@@ -342,39 +434,90 @@ public:
   using ConvertTTKernelToEmitCBase<
       ConvertTTKernelToEmitCPass>::ConvertTTKernelToEmitCBase;
 
-  void runOnOperation() override {
-    auto funcOp = getOperation();
+  void runOnOperation() final {
+    auto wrapper = getOperation();
 
-    // Apply arith to emitc conversion first
+    assert(wrapper->getRegions().size() == 1);
+    auto &r = wrapper->getRegion(0);
+    assert(r.hasOneBlock());
+    auto &b = r.getBlocks().front();
+
+    OpBuilder builder = OpBuilder::atBlockEnd(&b);
+    // capture the insertion point before the first FuncOp, if any:
+    Block::iterator ip;
+
+    // collect all NocOpsTable definitions during the traversal:
+    GlobalArrayDefTable globals;
+
+    wrapper.walk([&, this](func::FuncOp funcOp) {
+      if (!ip.isValid()) {
+        OpBuilder::InsertionGuard ig(builder);
+
+        builder.setInsertionPoint(funcOp);
+        ip = builder.getInsertionPoint();
+      }
+
+      visit(funcOp, globals);
+    });
+
+    if (!globals.defs.empty()) {
+      assert(ip.isValid());
+      builder.setInsertionPoint(&b, ip);
+      ip = builder.getInsertionPoint();
+
+      for (auto const &[name, typeAndEntries] : globals.defs) {
+        mlir::MemRefType const &type = std::get<0>(typeAndEntries);
+        auto const &entries = std::get<1>(typeAndEntries);
+
+        auto cArrayType =
+            emitc::ArrayType::get(type.getShape(), type.getElementType());
+
+        auto shapedType =
+            mlir::RankedTensorType::get(type.getShape(), type.getElementType());
+        auto cInitAttr =
+            mlir::DenseIntElementsAttr::get(shapedType, entries.asArrayRef());
+
+        builder.create<emitc::GlobalOp>(
+            wrapper->getLoc(), StringAttr::get(builder.getContext(), name),
+            cArrayType, cInitAttr, false, true, true);
+      }
+    }
+  }
+
+  void visit(func::FuncOp funcOp, GlobalArrayDefTable &globals) {
+    // apply arith/scf/memref converters + replace NocOpsTableOp:
     {
       ConversionTarget target(*funcOp.getContext());
-      target.addLegalDialect<emitc::EmitCDialect>();
-      target.addIllegalDialect<arith::ArithDialect>();
-      RewritePatternSet arithPatterns(funcOp.getContext());
-      TypeConverter arithTypeConverter;
-      arithTypeConverter.addConversion([](Type type) { return type; });
-      populateArithToEmitCPatterns(arithTypeConverter, arithPatterns);
-      if (failed(applyPartialConversion(funcOp, target,
-                                        std::move(arithPatterns)))) {
+      {
+        target.addLegalDialect<emitc::EmitCDialect>();
+
+        target.addIllegalDialect<arith::ArithDialect>();
+        target.addIllegalDialect<scf::SCFDialect>();
+        target.addIllegalDialect<memref::MemRefDialect>();
+
+        target.addIllegalOp<ttkernel::NocOpsTableOp>();
+      }
+
+      NullTypeConverter typeConverter;
+      RewritePatternSet patterns(funcOp.getContext());
+      {
+        populateArithToEmitCPatterns(typeConverter, patterns);
+
+        populateSCFToEmitCConversionPatterns(patterns);
+
+        populateMemRefToEmitCTypeConversion(typeConverter);
+        populateMemRefToEmitCConversionPatterns(patterns, typeConverter);
+
+        patterns.add<ConvertNocOpsTableOp>(typeConverter, funcOp->getContext(),
+                                           globals);
+      }
+
+      if (failed(applyPartialConversion(funcOp, target, std::move(patterns)))) {
         signalPassFailure();
         return;
       }
     }
-
-    // Apply scf to emitc conversion next
-    {
-      ConversionTarget target(*funcOp.getContext());
-      target.addLegalDialect<emitc::EmitCDialect>();
-      target.addIllegalDialect<scf::SCFDialect>();
-      RewritePatternSet scfPatterns(funcOp.getContext());
-      populateSCFToEmitCConversionPatterns(scfPatterns);
-      if (failed(
-              applyPartialConversion(funcOp, target, std::move(scfPatterns)))) {
-        signalPassFailure();
-        return;
-      }
-    }
-
+    // apply TTKernel/TTMetal converters:
     {
       TTKernelToEmitCTypeConverter typeConverter(funcOp.getContext());
       RewritePatternSet patterns(funcOp.getContext());
@@ -464,11 +607,17 @@ public:
   }
 };
 
+} // namespace
+// ............................................................................
+
 namespace mlir::tt {
 
 std::unique_ptr<::mlir::Pass> createConvertTTKernelToEmitC() {
   return std::make_unique<ConvertTTKernelToEmitCPass>();
 }
+
+// ............................................................................
+namespace {
 
 // Class used to add includes and other boilerplate code to the generated
 // kernel.
@@ -542,25 +691,40 @@ private:
   ttkernel::ThreadType threadType;
 };
 
-LogicalResult
-convertTTKernelRegionToEmitC(OpBuilder &builder, Region *region,
+} // namespace
+// ............................................................................
+
+inline LogicalResult
+convertTTKernelRegionToEmitC(Region *region, std::optional<mlir::ModuleOp> &out,
                              const ttkernel::ThreadType &threadType) {
-  ThreadConfigHelper threadConfigHelper(&builder, region->getLoc(), threadType);
+  auto loc = region->getLoc();
+  auto *ctx = region->getContext();
 
-  auto funcOp = builder.create<func::FuncOp>(
-      region->getLoc(), "kernel_main",
-      builder.getType<FunctionType>(region->getArgumentTypes(), TypeRange()));
+  OpBuilder builder(ctx);
 
-  IRMapping irMapper;
-  region->cloneInto(&funcOp.getBody(), irMapper);
+  // We will wrap everything in a module op so that we can run the
+  // translation.
+  auto moduleWrapper = builder.create<mlir::ModuleOp>(loc, "module_wrapper");
+  builder.setInsertionPointToStart(moduleWrapper.getBody());
+  {
+    ThreadConfigHelper threadConfigHelper(&builder, loc, threadType);
 
-  auto pm = PassManager::on<func::FuncOp>(region->getContext());
-  pm.addPass(createConvertTTKernelToEmitC());
+    // Clone 'region' into a new func op nested inside 'moduleWrapper':
+    auto funcOp = builder.create<func::FuncOp>(
+        loc, "kernel_main",
+        builder.getType<FunctionType>(region->getArgumentTypes(), TypeRange()));
 
-  if (pm.run(funcOp).failed()) {
-    return failure();
+    IRMapping irMapper;
+    region->cloneInto(&funcOp.getBody(), irMapper);
+
+    auto pm = PassManager::on<mlir::ModuleOp>(ctx);
+    pm.addPass(createConvertTTKernelToEmitC());
+
+    if (pm.run(moduleWrapper).failed()) {
+      return failure();
+    }
   }
-
+  out = std::move(moduleWrapper);
   return success();
 }
 
@@ -580,18 +744,12 @@ LogicalResult emitOpRegionAsCpp(Region *region, llvm::raw_ostream &os,
   // load it here.
   region->getContext()->getOrLoadDialect<emitc::EmitCDialect>();
 
-  OpBuilder builder(region->getContext());
-  // We will wrap everything in a module op so that we can run the
-  // translation.
-  auto moduleWrapper =
-      builder.create<mlir::ModuleOp>(region->getLoc(), "module_wrapper");
-  builder.setInsertionPointToStart(moduleWrapper.getBody());
-
-  if (convertTTKernelRegionToEmitC(builder, region, threadType).failed()) {
+  std::optional<mlir::ModuleOp> moduleOp;
+  if (convertTTKernelRegionToEmitC(region, moduleOp, threadType).failed()) {
     return failure();
   }
 
-  if (emitc::translateToCpp(moduleWrapper, os).failed()) {
+  if (emitc::translateToCpp(*moduleOp, os).failed()) {
     return failure();
   }
 

--- a/test/ttmlir/Silicon/TTMetal/simple_reduce.mlir
+++ b/test/ttmlir/Silicon/TTMetal/simple_reduce.mlir
@@ -1,4 +1,6 @@
-// RUN: ttmlir-opt --ttir-to-ttmetal-backend-pipeline="system-desc-path=%system_desc_path%"  %s | FileCheck %s
+// RUN: ttmlir-opt --ttir-to-ttmetal-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttmetal-to-flatbuffer %t.mlir > %t.ttm
 #l1_ = #tt.memory_space<l1>
 #layout1 = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <4x4>, memref<64x96xf32, #l1_>>
 #layout2 = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <4x1>, memref<64x32xf32, #l1_>>


### PR DESCRIPTION
This is an onboarding ticket that resolves #496 and that has got a little out of hand. 

The salient changes are:

1. `memref` is now a supported dialect to use in TTKernel IR. There are builtin conversions for {alloca, global, get_global, load, store}.
2. `ConvertTTKernelToEmitCPass` is now a module pass -- this allows us to emit global constants and helper funcs at the module scope level
3. `TTKernelToEmitC` API has been cleaned up a little, to remove methods with odd Region parameters created by caller but populated by callee, etc
4. the original implementation of reduce ops used an "unrolled" loop over operations and could thus emit riscv code that was O(core grid size) in size, with some address calculations repeated redundantly -- the new implementation retains an emitc-level for-loop instead, resulting in much more compact riscv binary
5. a new TTKernel op `TTKernel_NocOpsTablOp` allows defining "arrays of NOC ops" as emitc.globals with memref value types.
6. ttmetal's simple_reduce.mlir test was not included in fb compilation tests, this has been fixed