### PR TITLE
Add output verifier shape for reduction ops and fix erroneous tests

### DIFF
--- a/test/ttmlir/Dialect/TTNN/reduction/simple_mean.mlir
+++ b/test/ttmlir/Dialect/TTNN/reduction/simple_mean.mlir
@@ -1,9 +1,9 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module {
-  func.func @forward(%arg0: tensor<512x1024xbf16>) -> tensor<512x32xbf16> {
-    %0 = tensor.empty() : tensor<512x32xbf16>
+  func.func @forward(%arg0: tensor<512x1024xbf16>) -> tensor<512x1xbf16> {
+    %0 = tensor.empty() : tensor<512x1xbf16>
     // CHECK: %[[C:.*]] = "ttnn.mean"[[C:.*]]
-    %1 = "ttir.mean"(%arg0, %0) <{dim_arg = [-1: i32], keep_dim = true}> : (tensor<512x1024xbf16>, tensor<512x32xbf16>) -> tensor<512x32xbf16>
-    return %1 : tensor<512x32xbf16>
+    %1 = "ttir.mean"(%arg0, %0) <{dim_arg = [-1: i32], keep_dim = true}> : (tensor<512x1024xbf16>, tensor<512x1xbf16>) -> tensor<512x1xbf16>
+    return %1 : tensor<512x1xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/reduction/simple_sum.mlir
+++ b/test/ttmlir/Dialect/TTNN/reduction/simple_sum.mlir
@@ -1,9 +1,9 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @forward(%arg0: tensor<512x1024xbf16>) -> tensor<512x32xbf16> {
-    %0 = tensor.empty() : tensor<512x32xbf16>
+  func.func @forward(%arg0: tensor<512x1024xbf16>) -> tensor<512x1xbf16> {
+    %0 = tensor.empty() : tensor<512x1xbf16>
     // CHECK: %[[C:.*]] = "ttnn.sum"[[C:.*]]
-    %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [-1: i32], keep_dim = true}> : (tensor<512x1024xbf16>, tensor<512x32xbf16>) -> tensor<512x32xbf16>
-    return %1 : tensor<512x32xbf16>
+    %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [-1: i32], keep_dim = true}> : (tensor<512x1024xbf16>, tensor<512x1xbf16>) -> tensor<512x1xbf16>
+    return %1 : tensor<512x1xbf16>
   }
 }

--- a/test/ttmlir/EmitC/TTNN/reduction/mean.mlir
+++ b/test/ttmlir/EmitC/TTNN/reduction/mean.mlir
@@ -2,13 +2,9 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
 // RUN: ttmlir-opt --ttnn-modify-signatures-for-dylib --convert-ttnn-to-emitc %t.mlir > %t2.mlir
 // RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
-//
-// UNSUPPORTED: true
-// This test works in EmitC path, but not in TTRT path:
-// https://github.com/tenstorrent/tt-mlir/issues/1942
 
-func.func @forward(%arg0: tensor<512x1024xbf16>) -> tensor<512x32xbf16> {
-  %0 = tensor.empty() : tensor<512x32xbf16>
-  %1 = "ttir.mean"(%arg0, %0) <{dim_arg = [-1: i32], keep_dim = true}> : (tensor<512x1024xbf16>, tensor<512x32xbf16>) -> tensor<512x32xbf16>
-  return %1 : tensor<512x32xbf16>
+func.func @forward(%arg0: tensor<512x1024xbf16>) -> tensor<512x1xbf16> {
+  %0 = tensor.empty() : tensor<512x1xbf16>
+  %1 = "ttir.mean"(%arg0, %0) <{dim_arg = [-1: i32], keep_dim = true}> : (tensor<512x1024xbf16>, tensor<512x1xbf16>) -> tensor<512x1xbf16>
+  return %1 : tensor<512x1xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/perf_unit/test_perf_max.mlir
+++ b/test/ttmlir/Silicon/TTNN/perf_unit/test_perf_max.mlir
@@ -1,9 +1,9 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-func.func @max(%arg0: tensor<1x1x512x64xbf16>) -> tensor<1x1x512xbf16> {
-  %0 = tensor.empty() : tensor<1x1x512xbf16>
+func.func @max(%arg0: tensor<1x1x512x64xbf16>) -> tensor<1x1x512x1xbf16> {
+  %0 = tensor.empty() : tensor<1x1x512x1xbf16>
   // CHECK: %[[C:.*]] = "ttnn.max"[[C:.*]]
-  %1 = "ttir.max"(%arg0, %0) <{dim_arg = [-1: i32], keep_dim = true}> : (tensor<1x1x512x64xbf16>, tensor<1x1x512xbf16>) -> tensor<1x1x512xbf16>
-  return %1 : tensor<1x1x512xbf16>
+  %1 = "ttir.max"(%arg0, %0) <{dim_arg = [-1: i32], keep_dim = true}> : (tensor<1x1x512x64xbf16>, tensor<1x1x512x1xbf16>) -> tensor<1x1x512x1xbf16>
+  return %1 : tensor<1x1x512x1xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/perf_unit/test_perf_sum.mlir
+++ b/test/ttmlir/Silicon/TTNN/perf_unit/test_perf_sum.mlir
@@ -1,9 +1,9 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-func.func @sum(%arg0: tensor<1x1x512x64xbf16>) -> tensor<1x1x512xbf16> {
-  %0 = tensor.empty() : tensor<1x1x512xbf16>
+func.func @sum(%arg0: tensor<1x1x512x64xbf16>) -> tensor<1x1x512x1xbf16> {
+  %0 = tensor.empty() : tensor<1x1x512x1xbf16>
   // CHECK: %[[C:.*]] = "ttnn.sum"[[C:.*]]
-  %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [-1: i32], keep_dim = true}> : (tensor<1x1x512x64xbf16>, tensor<1x1x512xbf16>) -> tensor<1x1x512xbf16>
-  return %1 : tensor<1x1x512xbf16>
+  %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [-1: i32], keep_dim = true}> : (tensor<1x1x512x64xbf16>, tensor<1x1x512x1xbf16>) -> tensor<1x1x512x1xbf16>
+  return %1 : tensor<1x1x512x1xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/simple_reductions.mlir
+++ b/test/ttmlir/Silicon/TTNN/simple_reductions.mlir
@@ -1,18 +1,18 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-func.func @sum(%arg0: tensor<1x1x512x64xbf16>) -> tensor<1x1x512xbf16> {
-  %0 = tensor.empty() : tensor<1x1x512xbf16>
+func.func @sum(%arg0: tensor<1x1x512x64xbf16>) -> tensor<1x1x512x1xbf16> {
+  %0 = tensor.empty() : tensor<1x1x512x1xbf16>
   // CHECK: %[[C:.*]] = "ttnn.sum"[[C:.*]]
-  %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [-1: i32], keep_dim = true}> : (tensor<1x1x512x64xbf16>, tensor<1x1x512xbf16>) -> tensor<1x1x512xbf16>
-  return %1 : tensor<1x1x512xbf16>
+  %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [-1: i32], keep_dim = true}> : (tensor<1x1x512x64xbf16>, tensor<1x1x512x1xbf16>) -> tensor<1x1x512x1xbf16>
+  return %1 : tensor<1x1x512x1xbf16>
 }
 
-func.func @sum_last_2_dims(%arg0: tensor<1x32x512x64xbf16>) -> tensor<1x32xbf16> {
-  %0 = tensor.empty() : tensor<1x32xbf16>
+func.func @sum_last_2_dims(%arg0: tensor<1x32x512x64xbf16>) -> tensor<1x32x1x1xbf16> {
+  %0 = tensor.empty() : tensor<1x32x1x1xbf16>
   // CHECK: %[[C:.*]] = "ttnn.sum"[[C:.*]]
-  %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [-1: i32, -2: i32], keep_dim = true}> : (tensor<1x32x512x64xbf16>, tensor<1x32xbf16>) -> tensor<1x32xbf16>
-  return %1 : tensor<1x32xbf16>
+  %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [-1: i32, -2: i32], keep_dim = true}> : (tensor<1x32x512x64xbf16>, tensor<1x32x1x1xbf16>) -> tensor<1x32x1x1xbf16>
+  return %1 : tensor<1x32x1x1xbf16>
 }
 
 func.func @sum_first_dim(%arg0: tensor<64x10xf32>) -> tensor<1x10xf32> {
@@ -21,30 +21,30 @@ func.func @sum_first_dim(%arg0: tensor<64x10xf32>) -> tensor<1x10xf32> {
   return %1: tensor<1x10xf32>
 }
 
-func.func @mean(%arg0: tensor<1x1x512x64xbf16>) -> tensor<1x1x512xbf16> {
-  %0 = tensor.empty() : tensor<1x1x512xbf16>
+func.func @mean(%arg0: tensor<1x1x512x64xbf16>) -> tensor<1x1x512x1xbf16> {
+  %0 = tensor.empty() : tensor<1x1x512x1xbf16>
   // CHECK: %[[C:.*]] = "ttnn.mean"[[C:.*]]
-  %1 = "ttir.mean"(%arg0, %0) <{dim_arg = [-1: i32], keep_dim = true}> : (tensor<1x1x512x64xbf16>, tensor<1x1x512xbf16>) -> tensor<1x1x512xbf16>
-  return %1 : tensor<1x1x512xbf16>
+  %1 = "ttir.mean"(%arg0, %0) <{dim_arg = [-1: i32], keep_dim = true}> : (tensor<1x1x512x64xbf16>, tensor<1x1x512x1xbf16>) -> tensor<1x1x512x1xbf16>
+  return %1 : tensor<1x1x512x1xbf16>
 }
 
-func.func @mean_last_2_dims(%arg0: tensor<1x32x512x64xbf16>) -> tensor<1x32xbf16> {
-  %0 = tensor.empty() : tensor<1x32xbf16>
+func.func @mean_last_2_dims(%arg0: tensor<1x32x512x64xbf16>) -> tensor<1x32x1x1xbf16> {
+  %0 = tensor.empty() : tensor<1x32x1x1xbf16>
   // CHECK: %[[C:.*]] = "ttnn.mean"[[C:.*]]
-  %1 = "ttir.mean"(%arg0, %0) <{dim_arg = [-1: i32, -2: i32], keep_dim = true}> : (tensor<1x32x512x64xbf16>, tensor<1x32xbf16>) -> tensor<1x32xbf16>
-  return %1 : tensor<1x32xbf16>
+  %1 = "ttir.mean"(%arg0, %0) <{dim_arg = [-1: i32, -2: i32], keep_dim = true}> : (tensor<1x32x512x64xbf16>, tensor<1x32x1x1xbf16>) -> tensor<1x32x1x1xbf16>
+  return %1 : tensor<1x32x1x1xbf16>
 }
 
-func.func @max(%arg0: tensor<1x1x512x64xbf16>) -> tensor<1x1x512xbf16> {
-  %0 = tensor.empty() : tensor<1x1x512xbf16>
+func.func @max(%arg0: tensor<1x1x512x64xbf16>) -> tensor<1x1x512x1xbf16> {
+  %0 = tensor.empty() : tensor<1x1x512x1xbf16>
   // CHECK: %[[C:.*]] = "ttnn.max"[[C:.*]]
-  %1 = "ttir.max"(%arg0, %0) <{dim_arg = [-1: i32], keep_dim = true}> : (tensor<1x1x512x64xbf16>, tensor<1x1x512xbf16>) -> tensor<1x1x512xbf16>
-  return %1 : tensor<1x1x512xbf16>
+  %1 = "ttir.max"(%arg0, %0) <{dim_arg = [-1: i32], keep_dim = true}> : (tensor<1x1x512x64xbf16>, tensor<1x1x512x1xbf16>) -> tensor<1x1x512x1xbf16>
+  return %1 : tensor<1x1x512x1xbf16>
 }
 
-func.func @max_last_2_dims(%arg0: tensor<1x32x512x64xbf16>) -> tensor<1x32xbf16> {
-  %0 = tensor.empty() : tensor<1x32xbf16>
+func.func @max_last_2_dims(%arg0: tensor<1x32x512x64xbf16>) -> tensor<1x32x1x1xbf16> {
+  %0 = tensor.empty() : tensor<1x32x1x1xbf16>
   // CHECK: %[[C:.*]] = "ttnn.max"[[C:.*]]
-  %1 = "ttir.max"(%arg0, %0) <{dim_arg = [-1: i32, -2: i32], keep_dim = true}> : (tensor<1x32x512x64xbf16>, tensor<1x32xbf16>) -> tensor<1x32xbf16>
-  return %1 : tensor<1x32xbf16>
+  %1 = "ttir.max"(%arg0, %0) <{dim_arg = [-1: i32, -2: i32], keep_dim = true}> : (tensor<1x32x512x64xbf16>, tensor<1x32x1x1xbf16>) -> tensor<1x32x1x1xbf16>
+  return %1 : tensor<1x32x1x1xbf16>
 }


### PR DESCRIPTION
- Added verifier for reduction ops - tests whether output shape matches what the op will return.
- Fixed tests so that IRs are correct

Closes #1942