### PR TITLE
Add ttnn::zeros op

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -1439,6 +1439,23 @@ def TTIR_ArangeOp : TTIR_Op<"arange"> {
   let hasVerifier = 1;
 }
 
+def TTIR_ZerosOp : TTIR_Op<"zeros"> {
+  let summary = "Creates a tensor filled with zeros.";
+  let description = [{
+    Tensor operation to create a tensor filled with zeros.
+
+    Given a `shape`, produces a tensor with the shape, filled with zeros.
+
+    Example:
+      %0 = "ttir.zeros"() <{shape = array<i32:64, 28, 28>}> : () -> tensor<64x28x28xbf16>
+      // %0: [[[0, 0, 0, ..., 0], [0, 0, 0, ..., 0], ..., [0, 0, 0, ..., 0]]]
+  }];
+
+  let arguments = (ins DenseI32ArrayAttr:$shape);
+
+  let results = (outs AnyRankedTensor:$result);
+}
+
 def TTIR_OnesOp : TTIR_Op<"ones"> {
   let summary = "Creates a tensor filled with ones.";
   let description = [{

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1147,6 +1147,27 @@ def TTNN_ArangeOp : TTNN_Op<"arange"> {
   let hasVerifier = 1;
 }
 
+def TTNN_ZerosOp : TTNN_Op<"zeros"> {
+  let summary = "Creates a tensor filled with zeros.";
+  let description = [{
+    Tensor operation to create a tensor filled with zeros.
+
+    Given a ShapeAttr `shape`, produces a tensor with the same shape, filled with zeros.
+
+    Example:
+      %0 = "ttnn.zeros"() <{shape = array<i32:64, 28, 28>}> : () -> tensor<64x28x28xbf16>
+      // %0: [[[0, 0, 0, ..., 0], [0, 0, 0, ..., 0], ..., [0, 0, 0, ..., 0]]]
+  }];
+
+  let arguments = (ins TTNN_ShapeAttr:$shape,
+                       OptionalAttr<TT_DataTypeAttr>:$dtype,
+                       OptionalAttr<TTNN_LayoutAttr>:$layout,
+                       Optional<TT_Device>:$device,
+                       OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
+
+  let results = (outs AnyRankedTensor:$result);
+}
+
 def TTNN_OnesOp : TTNN_Op<"ones"> {
   let summary = "Creates a tensor filled with ones.";
   let description = [{

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -66,6 +66,15 @@ table EmptyOp {
   out: tt.target.TensorRef;
 }
 
+table ZerosOp {
+  shape: [int64];
+  dtype: DataType = null;
+  layout: TensorLayout = null;
+  device: tt.target.DeviceRef;
+  memcfg: tt.target.MemoryConfigDesc;
+  out: tt.target.TensorRef;
+}
+
 table OnesOp {
   shape: [int64];
   dtype: DataType = null;
@@ -401,6 +410,7 @@ union OpType {
   ToDeviceOp,
   FromDeviceOp,
   EmptyOp,
+  ZerosOp,
   OnesOp,
   FullOp,
   EltwiseOp,

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -882,6 +882,88 @@ public:
 };
 } // namespace
 
+// ZerosOp conversion pattern
+//
+class ZerosOpConversionPattern
+    : public TTNNToEmitCBaseOpConversionPattern<ttnn::ZerosOp> {
+
+public:
+  using TTNNToEmitCBaseOpConversionPattern<
+      ttnn::ZerosOp>::TTNNToEmitCBaseOpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttnn::ZerosOp srcOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    // ttnn:ZerosOp has 5 input params:
+    //
+    // let arguments = (ins TTNN_ShapeAttr:$shape,
+    //                      OptionalAttr<TT_DataTypeAttr>:$dtype,
+    //                      OptionalAttr<TTNN_LayoutAttr>:$layout,
+    //                      Optional<TT_Device>:$device,
+    //                      OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
+    //
+    // Some of them are Attrs, some are Values. ShapeAttr is required, while
+    // others are optional. Additionally, in the context of C++, some of the
+    // Attrs (like shape) need to be instantiated into objects before being
+    // passed to the op. Therefore:
+    //
+    // We first create a ttnn::SimpleShape object (SSA) by calling
+    // createShapeOp() and add it to the operands vector, but also add an
+    // IndexAttr in ArrayAttr to reference it (this is an EmitC mechanism that
+    // allows for combining Attrs and Values when calling an OpaqueOp). All the
+    // other input params are optional, so we create them on-the-fly into the
+    // ArrayAttr, whether they are an actual Attr, or a Value pointed to by
+    // IndexAttr. If they are present, we create the object and pass it to the
+    // op. If not, we pass std::nullopt.
+
+    // Create ttnn::SimpleShape() call
+    //
+    emitc::CallOpaqueOp shapeOp = ttnn_to_emitc::utils::createShapeOp(
+        rewriter, srcOp.getShapeAttr(), srcOp.getLoc());
+
+    llvm::SmallVector<Value, 3> operands{
+        shapeOp->getResult(0),
+    };
+
+    // Create ArrayAttr object holding attributes and pointers to operands
+    //
+    // Params that are Values are added to the operands vector on-the-fly, and
+    // a corresponding IndexAttr is added to the ArrayAttr to reference them.
+    //
+    size_t operandIndex = 0;
+    ArrayAttr arrayAttr = rewriter.getArrayAttr({
+        rewriter.getIndexAttr(operandIndex++), // ttnn::SimpleShape
+        srcOp.getDtype().has_value()
+            ? ttnn_to_emitc::utils::convertDType(rewriter, srcOp.getDtypeAttr())
+            : ttnn_to_emitc::utils::createStdNullopt(
+                  rewriter), // ttnn::DataType
+        srcOp.getLayout().has_value()
+            ? ttnn_to_emitc::utils::convertLayoutAttr(rewriter,
+                                                      srcOp.getLayoutAttr())
+            : ttnn_to_emitc::utils::createStdNullopt(rewriter), // ttnn::Layout
+        adaptor.getDevice()
+            ? (operands.append(1, adaptor.getDevice()),
+               mlir::cast<Attribute>(rewriter.getIndexAttr(operandIndex++)))
+            : ttnn_to_emitc::utils::createStdNullopt(rewriter), // ttnn::Device
+        srcOp.getMemoryConfig().has_value()
+            ? (operands.append(
+                   1, ttnn_to_emitc::utils::createMemoryConfigOp(
+                          rewriter, srcOp.getMemoryConfigAttr(), srcOp.getLoc())
+                          ->getResult(0)),
+               mlir::cast<Attribute>(rewriter.getIndexAttr(operandIndex++)))
+            : ttnn_to_emitc::utils::createStdNullopt(
+                  rewriter), // ttnn::MemoryConfig
+    });
+
+    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
+        srcOp, this->getTypeConverter()->convertType(srcOp.getType()),
+        this->convertOpName(srcOp), arrayAttr, nullptr, operands);
+
+    return success();
+  }
+};
+
 // OnesOp conversion pattern
 //
 namespace {
@@ -1137,6 +1219,7 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
   //
   // clang-format off
   patterns.add<EmptyOpConversionPattern,
+               ZerosOpConversionPattern,
                OnesOpConversionPattern,
                DefaultOpConversionPattern<ttnn::FullOp>,
                DefaultOpConversionPattern<ttnn::ArangeOp>>(typeConverter, ctx);

--- a/runtime/lib/ttnn/operations/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/CMakeLists.txt
@@ -10,6 +10,7 @@ set(TTNN_OPS_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/creation/arange.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/conv/conv_transpose2d.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/creation/empty.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/creation/zeros.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/creation/ones.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/creation/full.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/data_movement/concat.cpp

--- a/runtime/lib/ttnn/operations/creation/zeros.cpp
+++ b/runtime/lib/ttnn/operations/creation/zeros.cpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "operations/creation/zeros.h"
+
+#include "tt/runtime/detail/logger.h"
+#include "tt/runtime/ttnn/operations/utils.h"
+#include "tt/runtime/ttnn/utils.h"
+#include "ttmlir/Target/TTNN/program_generated.h"
+#include "ttnn/types.hpp"
+
+#include <functional>
+#include <optional>
+#include <variant>
+
+namespace tt::runtime::ttnn::operations::creation {
+void run(const ::tt::target::ttnn::ZerosOp *op, ProgramContext &context) {
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+
+  const ::ttnn::Shape shape = ::ttnn::Shape(
+      ::tt::runtime::ttnn::utils::toShapeFromFBShape(*op->shape()));
+
+  std::optional<::ttnn::DataType> dtype = std::optional<::ttnn::DataType>();
+  std::optional<::ttnn::Layout> layout = std::optional<::ttnn::Layout>();
+  std::optional<std::reference_wrapper<::ttnn::IDevice>> device = std::nullopt;
+  std::optional<::ttnn::MemoryConfig> memoryConfig =
+      std::optional<::ttnn::MemoryConfig>();
+
+  if (op->dtype()) {
+    dtype = ::tt::runtime::ttnn::utils::toTTNNDataType(*(op->dtype()));
+  }
+
+  if (op->layout()) {
+    layout = ::tt::runtime::ttnn::utils::toTTNNLayout(*(op->layout()));
+  }
+
+  if (op->device()) {
+    DeviceVariant targetDevice =
+        context.getTargetDevice(op->device()->global_id());
+    LOG_ASSERT(std::holds_alternative<std::reference_wrapper<::ttnn::IDevice>>(
+                   targetDevice),
+               "ttnn::zeros does not support MeshDevice.");
+    device = std::get<std::reference_wrapper<::ttnn::IDevice>>(targetDevice);
+  }
+
+  if (op->memcfg()) {
+    memoryConfig = utils::createMemoryConfig(op->memcfg(), op->out());
+  }
+
+  ::ttnn::Tensor out =
+      ::ttnn::zeros(shape, dtype, layout, device, memoryConfig);
+
+  tensorPool.insert_or_assign(op->out()->global_id(), out);
+}
+} // namespace tt::runtime::ttnn::operations::creation

--- a/runtime/lib/ttnn/operations/creation/zeros.h
+++ b/runtime/lib/ttnn/operations/creation/zeros.h
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef RUNTIME_LIB_TTNN_OPERATIONS_CREATION_ZEROS_H
+#define RUNTIME_LIB_TTNN_OPERATIONS_CREATION_ZEROS_H
+
+#include "tt/runtime/ttnn/types.h"
+#include "ttmlir/Target/TTNN/program_generated.h"
+
+namespace tt::runtime::ttnn::operations::creation {
+
+void run(const ::tt::target::ttnn::ZerosOp *op, ProgramContext &context);
+
+} // namespace tt::runtime::ttnn::operations::creation
+
+#endif // RUNTIME_LIB_TTNN_OPERATIONS_CREATION_ZEROS_H

--- a/runtime/lib/ttnn/program.cpp
+++ b/runtime/lib/ttnn/program.cpp
@@ -11,6 +11,7 @@
 #include "operations/creation/empty.h"
 #include "operations/creation/full.h"
 #include "operations/creation/ones.h"
+#include "operations/creation/zeros.h"
 #include "operations/data_movement/concat.h"
 #include "operations/data_movement/permute.h"
 #include "operations/data_movement/repeat.h"
@@ -174,6 +175,9 @@ void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
   }
   case ::tt::target::ttnn::OpType::EmptyOp: {
     return operations::creation::run(op->type_as_EmptyOp(), context);
+  }
+  case ::tt::target::ttnn::OpType::ZerosOp: {
+    return operations::creation::run(op->type_as_ZerosOp(), context);
   }
   case ::tt::target::ttnn::OpType::OnesOp: {
     return operations::creation::run(op->type_as_OnesOp(), context);

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -443,6 +443,10 @@ Tensor getOpOutputTensor(OpContext opContextHandle,
     globalId = opContext.type_as_EmptyOp()->out()->global_id();
     break;
   }
+  case ::tt::target::ttnn::OpType::ZerosOp: {
+    globalId = opContext.type_as_ZerosOp()->out()->global_id();
+    break;
+  }
   case ::tt::target::ttnn::OpType::OnesOp: {
     globalId = opContext.type_as_OnesOp()->out()->global_id();
     break;

--- a/test/ttmlir/Conversion/TTNNToEmitC/zeros.mlir
+++ b/test/ttmlir/Conversion/TTNNToEmitC/zeros.mlir
@@ -1,0 +1,19 @@
+// RUN: ttmlir-opt --convert-ttnn-to-emitc %s | FileCheck %s
+
+#system_memory = #ttnn.buffer_type<system_memory>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1344 + d1 * 56 + d2, d3), <1x1>, memref<17472x42xbf16, #system_memory>>
+#ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 64 + d1, d2), <1x1>, memref<2048x128xf32, #system_memory>>
+
+module  {
+  func.func @zeros_4d_irregular_shapes() -> tensor<13x24x56x42xbf16, #ttnn_layout> {
+    // CHECK: %{{[0-9]+}} = emitc.call_opaque "ttnn::zeros"{{.*}} -> !emitc.opaque<"ttnn::Tensor">
+    %0 = "ttnn.zeros"() <{dtype = #tt.supportedDataTypes<bf16>, layout = #ttnn.layout<row_major>, shape = #ttnn.shape<13x24x56x42>}> : () -> tensor<13x24x56x42xbf16, #ttnn_layout>
+    return %0 : tensor<13x24x56x42xbf16, #ttnn_layout>
+  }
+
+  func.func @zeros_f32() -> tensor<32x64x128xf32, #ttnn_layout1> {
+    // CHECK: %{{[0-9]+}} = emitc.call_opaque "ttnn::zeros"{{.*}} -> !emitc.opaque<"ttnn::Tensor">
+    %0 = "ttnn.zeros"() <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, shape = #ttnn.shape<32x64x128>}> : () -> tensor<32x64x128xf32, #ttnn_layout1>
+    return %0 : tensor<32x64x128xf32, #ttnn_layout1>
+  }
+}

--- a/test/ttmlir/EmitC/TTNN/tensor/ones.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/ones.mlir
@@ -1,0 +1,12 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
+// RUN: ttmlir-opt --ttnn-modify-signatures-for-dylib --convert-ttnn-to-emitc %t.mlir > %t2.mlir
+// RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
+//
+// UNSUPPORTED: true
+// Outstanding bug: https://github.com/tenstorrent/tt-mlir/issues/2072
+
+func.func @ones() -> tensor<13x24x56x42xbf16> {
+  %0 = "ttir.ones"() <{shape = array<i32:13, 24, 56, 42>}> : () -> tensor<13x24x56x42xbf16>
+  return %0 : tensor<13x24x56x42xbf16>
+}

--- a/test/ttmlir/EmitC/TTNN/tensor/zeros.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/zeros.mlir
@@ -1,0 +1,12 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
+// RUN: ttmlir-opt --ttnn-modify-signatures-for-dylib --convert-ttnn-to-emitc %t.mlir > %t2.mlir
+// RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
+//
+// UNSUPPORTED: true
+// Outstanding bug: https://github.com/tenstorrent/tt-mlir/issues/2072
+
+func.func @zeros() -> tensor<13x24x56x42xbf16> {
+  %0 = "ttir.zeros"() <{shape = array<i32:13, 24, 56, 42>}> : () -> tensor<13x24x56x42xbf16>
+  return %0 : tensor<13x24x56x42xbf16>
+}

--- a/test/ttmlir/Silicon/TTNN/zeros.mlir
+++ b/test/ttmlir/Silicon/TTNN/zeros.mlir
@@ -1,0 +1,29 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+
+module {
+  func.func @ozeros_2d() -> tensor<32x128xbf16> {
+    // CHECK: {{.*}} = "ttnn.zeros"() {{.*}}
+    %0 = "ttir.zeros"() <{shape = array<i32:32, 128>}> : () -> tensor<32x128xbf16>
+    return %0 : tensor<32x128xbf16>
+  }
+
+  func.func @zeros_3d() -> tensor<32x64x128xbf16> {
+    // CHECK: {{.*}} = "ttnn.zeros"() {{.*}}
+    %0 = "ttir.zeros"() <{shape = array<i32:32, 64, 128>}> : () -> tensor<32x64x128xbf16>
+    return %0 : tensor<32x64x128xbf16>
+  }
+
+  func.func @zeros_4d_irregular_shapes() -> tensor<13x24x56x42xbf16> {
+    // CHECK: {{.*}} = "ttnn.zeros"() {{.*}} -> tensor<13x24x56x42xbf16{{.*}}>
+    %0 = "ttir.zeros"() <{shape = array<i32:13, 24, 56, 42>}> : () -> tensor<13x24x56x42xbf16>
+    return %0 : tensor<13x24x56x42xbf16>
+  }
+
+  func.func @zeros_f32() -> tensor<32x64x128xf32> {
+    // CHECK: {{.*}} = "ttnn.zeros"() {{.*}} -> tensor<32x64x128xf32{{.*}}>
+    %0 = "ttir.zeros"() <{shape = array<i32:32, 64, 128>}> : () -> tensor<32x64x128xf32>
+    return %0 : tensor<32x64x128xf32>
+  }
+}


### PR DESCRIPTION
Adds `ttnn::zeros` op support.

Closes #374

Edit:
I've also added EmitC tests for both ttnn::ones and ttnn::zeros - they however failed. Opened #2072 to track.