### PR TITLE
Pykernel examples - eltwise_sfpu and add_2_integers

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -149,6 +149,7 @@ if(TTMLIR_ENABLE_PYKERNEL)
     ROOT_DIR "${TTPYKERNEL_ROOT_DIR}"
     SOURCES
       pykernel_ast.py
+      types.py
   )
   add_mlir_python_modules(TTPykernelModules
     ROOT_PREFIX "${TTMLIR_PYTHON_PACKAGES_DIR}/pykernel"

--- a/python/pykernel/pykernel_ast.py
+++ b/python/pykernel/pykernel_ast.py
@@ -108,9 +108,6 @@ class TTKernelCompiler(ast.NodeVisitor):
         self.initial_cbs = args
         self.symbol_tables = []
         self.supported_nodes = get_supported_nodes()
-        self.ttkernel_keywords = {  # this should not be the way we're doing this..
-            "type_int": IntegerType.get_signless(32, self.ctx),
-        }
 
         ttkernel.register_dialect(self.ctx)
 
@@ -268,8 +265,11 @@ class TTKernelCompiler(ast.NodeVisitor):
     # Statements
     def visit_Name(self, node):
         var_name = node.id
-        if var_name in self.ttkernel_keywords:
-            return self.ttkernel_keywords[var_name]
+
+        # NOTE: some kernelops require passing return type as arg
+        if var_name == "int":
+            return IntegerType.get_signless(32, self.ctx)
+
         existing_var_table = self.var_exists(var_name)
         if existing_var_table:
             return existing_var_table[var_name]
@@ -320,9 +320,6 @@ class TTKernelCompiler(ast.NodeVisitor):
             func_args.append(func_arg)
 
         return func(*func_args)  # how do i make sure the types are correct?
-
-    def visit_arguments(self, node):
-        print(f"visit_arguments")
 
     # Expressions
     def visit_Expr(self, node):

--- a/python/pykernel/pykernel_ast.py
+++ b/python/pykernel/pykernel_ast.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -285,7 +285,7 @@ class TTKernelCompiler(ast.NodeVisitor):
         value = self.visit(node.value)
         sym_table = self.symbol_tables[-1]
         var_name = node.targets[0].id
-        # print(var.type)
+
         if hasattr(var, "type") and isinstance(var.type, MemRefType):
             memref.StoreOp(value, var, [arith.ConstantOp(IndexType.get(self.ctx), 0)])
         else:
@@ -313,7 +313,6 @@ class TTKernelCompiler(ast.NodeVisitor):
 
     # Function calls
     def visit_Call(self, node):
-        # print(f"visit_Call")
         assert (
             node.func.id in self.ttkernel_fn_map
         ), f"Function {node.func.id} not supported"
@@ -448,9 +447,9 @@ def ttkernel_compile(f):
         b = TTKernelCompiler(f.__name__, args)
         # print(ast.dump(m, indent=4) + "\n")
         b.visit(m)
-        print(b.module)
 
         # Check if generated IR is valid
+        print(b.module)
         b.module.operation.verify()
 
     return _wrapper

--- a/python/pykernel/types.py
+++ b/python/pykernel/types.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/python/pykernel/types.py
+++ b/python/pykernel/types.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+class CircularBuffer:
+    def __init__(self, cb_id, tensor_shape=(8, 128, 128), dtype="Float32"):
+        self.cb_id = cb_id
+        self.tensor_shape = tensor_shape
+        self.tile_shape = 32  # default to 32x32 tile shape
+        self.tilized_shape = self.get_tilized_memref_shape()
+        self.dtype = dtype
+
+    def get_tilized_memref_shape(self):
+        tilized_shape = list(self.tensor_shape)
+        tilized_shape[-2] = (tilized_shape[-2] + self.tile_shape - 1) // self.tile_shape
+        tilized_shape[-1] = (tilized_shape[-1] + self.tile_shape - 1) // self.tile_shape
+        return tilized_shape

--- a/test/pykernel/add_2_integers_in_compute/add_2_tiles.py
+++ b/test/pykernel/add_2_integers_in_compute/add_2_tiles.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/test/pykernel/add_2_integers_in_compute/add_2_tiles.py
+++ b/test/pykernel/add_2_integers_in_compute/add_2_tiles.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# RUN: %python %s
+# REQUIRES: pykernel
+
+from pykernel.pykernel_ast import *
+from pykernel.types import *
+
+
+@ttkernel_compile
+def add_2_tiles(cb_in0: CircularBuffer, cb_in1: CircularBuffer, cb_out: CircularBuffer):
+    binary_op_init_common(cb_in0, cb_in1, cb_out)
+    add_tiles_init(cb_in0, cb_in1)
+
+    # wait for a block of tiles in each of input CBs
+    cb_wait_front(cb_in0, 1)
+    cb_wait_front(cb_in1, 1)
+
+    tile_regs_acquire()  # acquire 8 tile registers
+
+    add_tiles(cb_in0, cb_in1, 0, 0, 0)
+
+    tile_regs_commit()  # signal the packer
+
+    tile_regs_wait()  # packer waits here
+    pack_tile(0, cb_out, 0)
+    tile_regs_release()  # packer releases
+
+    cb_pop_front(cb_in0, 1)
+    cb_pop_front(cb_in1, 1)
+
+    cb_push_back(cb_out, 1)
+
+    return
+
+
+cb_in0 = CircularBuffer(0)
+cb_in1 = CircularBuffer(1)
+cb_out = CircularBuffer(16)
+add_2_tiles(cb_in0, cb_in1, cb_out)

--- a/test/pykernel/add_2_integers_in_compute/add_2_tiles.py
+++ b/test/pykernel/add_2_integers_in_compute/add_2_tiles.py
@@ -14,19 +14,18 @@ def add_2_tiles(cb_in0: CircularBuffer, cb_in1: CircularBuffer, cb_out: Circular
     binary_op_init_common(cb_in0, cb_in1, cb_out)
     add_tiles_init(cb_in0, cb_in1)
 
-    # wait for a block of tiles in each of input CBs
     cb_wait_front(cb_in0, 1)
     cb_wait_front(cb_in1, 1)
 
-    tile_regs_acquire()  # acquire 8 tile registers
+    tile_regs_acquire()
 
     add_tiles(cb_in0, cb_in1, 0, 0, 0)
 
-    tile_regs_commit()  # signal the packer
+    tile_regs_commit()
 
-    tile_regs_wait()  # packer waits here
+    tile_regs_wait()
     pack_tile(0, cb_out, 0)
-    tile_regs_release()  # packer releases
+    tile_regs_release()
 
     cb_pop_front(cb_in0, 1)
     cb_pop_front(cb_in1, 1)

--- a/test/pykernel/add_2_integers_in_compute/reader_binary_1_tile.py
+++ b/test/pykernel/add_2_integers_in_compute/reader_binary_1_tile.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/test/pykernel/add_2_integers_in_compute/reader_binary_1_tile.py
+++ b/test/pykernel/add_2_integers_in_compute/reader_binary_1_tile.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# RUN: %python %s
+# REQUIRES: pykernel
+
+from pykernel.pykernel_ast import *
+from pykernel.types import *
+
+
+@ttkernel_compile
+def reader_binary_1_tile(cb_in0: CircularBuffer, cb_in1: CircularBuffer):
+    src0_addr = get_arg_val(int, 0)
+    src1_addr = get_arg_val(int, 1)
+    src0_bank_id = get_arg_val(int, 2)
+    src1_bank_id = get_arg_val(int, 3)
+
+    src0_noc_addr = get_noc_addr_from_bank_id(src0_bank_id, src0_addr)
+    src1_noc_addr = get_noc_addr_from_bank_id(src1_bank_id, src1_addr)
+
+    # single-tile ublocks
+    ublock_size_bytes_0 = get_tile_size(cb_in0)
+    ublock_size_bytes_1 = get_tile_size(cb_in1)
+
+    l1_write_addr_in0 = get_write_ptr(cb_in0)
+    l1_write_addr_in1 = get_write_ptr(cb_in1)
+
+    # read ublocks from src0/src1 to CB0/CB1, then push ublocks to compute (unpacker)
+    cb_reserve_back(cb_in0, 1)
+    noc_async_read(src0_noc_addr, l1_write_addr_in0, ublock_size_bytes_0)
+    noc_async_read_barrier()
+    cb_push_back(cb_in0, 1)
+
+    cb_reserve_back(cb_in1, 1)
+    noc_async_read(src1_noc_addr, l1_write_addr_in1, ublock_size_bytes_1)
+    noc_async_read_barrier()
+    cb_push_back(cb_in1, 1)
+
+    return
+
+
+cb_in0 = CircularBuffer(0)
+cb_in1 = CircularBuffer(1)
+reader_binary_1_tile(cb_in0, cb_in1)

--- a/test/pykernel/add_2_integers_in_compute/reader_binary_1_tile.py
+++ b/test/pykernel/add_2_integers_in_compute/reader_binary_1_tile.py
@@ -19,14 +19,12 @@ def reader_binary_1_tile(cb_in0: CircularBuffer, cb_in1: CircularBuffer):
     src0_noc_addr = get_noc_addr_from_bank_id(src0_bank_id, src0_addr)
     src1_noc_addr = get_noc_addr_from_bank_id(src1_bank_id, src1_addr)
 
-    # single-tile ublocks
     ublock_size_bytes_0 = get_tile_size(cb_in0)
     ublock_size_bytes_1 = get_tile_size(cb_in1)
 
     l1_write_addr_in0 = get_write_ptr(cb_in0)
     l1_write_addr_in1 = get_write_ptr(cb_in1)
 
-    # read ublocks from src0/src1 to CB0/CB1, then push ublocks to compute (unpacker)
     cb_reserve_back(cb_in0, 1)
     noc_async_read(src0_noc_addr, l1_write_addr_in0, ublock_size_bytes_0)
     noc_async_read_barrier()

--- a/test/pykernel/add_2_integers_in_compute/writer_1_tile.py
+++ b/test/pykernel/add_2_integers_in_compute/writer_1_tile.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/test/pykernel/add_2_integers_in_compute/writer_1_tile.py
+++ b/test/pykernel/add_2_integers_in_compute/writer_1_tile.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# RUN: %python %s
+# REQUIRES: pykernel
+
+from pykernel.pykernel_ast import *
+from pykernel.types import *
+
+
+@ttkernel_compile
+def write_1_tile(cb_out: CircularBuffer):
+    dst_addr = get_arg_val(int, 0)
+    dst_bank_id = get_arg_val(int, 1)
+
+    dst_noc_addr = get_noc_addr_from_bank_id(dst_bank_id, dst_addr)
+
+    ublock_size_bytes = get_tile_size(cb_out)
+    l1_read_addr = get_read_ptr(cb_out)
+
+    cb_wait_front(cb_out, 1)
+    noc_async_write(l1_read_addr, dst_noc_addr, ublock_size_bytes)
+    noc_async_write_barrier()
+    cb_pop_front(cb_out, 1)
+
+    return
+
+
+cb_out = CircularBuffer(16)
+write_1_tile(cb_out)

--- a/test/pykernel/eltwise_sfpu/eltwise_sfpu.py
+++ b/test/pykernel/eltwise_sfpu/eltwise_sfpu.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/test/pykernel/eltwise_sfpu/eltwise_sfpu.py
+++ b/test/pykernel/eltwise_sfpu/eltwise_sfpu.py
@@ -1,0 +1,72 @@
+# // SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# //
+# // SPDX-License-Identifier: Apache-2.0
+
+# #include <cstdint>
+# #include "compute_kernel_api/common.h"
+# #include "compute_kernel_api/tile_move_copy.h"
+# #include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
+# #include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
+
+# namespace NAMESPACE {
+# void MAIN {
+#     uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
+#     uint32_t per_core_block_dim = get_compile_time_arg_val(1);
+
+#     init_sfpu(tt::CBIndex::c_0, tt::CBIndex::c_16);
+#     for (uint32_t block_index = 0; block_index < per_core_block_cnt; block_index++) {
+#         cb_reserve_back(tt::CBIndex::c_16, per_core_block_dim);
+#         for (uint32_t tile_index = 0; tile_index < per_core_block_dim; ++tile_index) {
+#             acquire_dst();
+
+#             // Pop tile after tile, copy to DST and pack
+#             cb_wait_front(tt::CBIndex::c_0, 1);
+
+#             copy_tile(tt::CBIndex::c_0, 0, 0);
+
+# #ifdef SFPU_OP_CHAIN_0
+#             SFPU_OP_CHAIN_0
+# #endif
+
+#             pack_tile(0, tt::CBIndex::c_16);
+
+#             cb_pop_front(tt::CBIndex::c_0, 1);
+
+#             release_dst();
+#         }
+#         cb_push_back(tt::CBIndex::c_16, per_core_block_dim);
+#     }
+# }
+# }  // namespace NAMESPACE
+
+from pykernel.pykernel_ast import *
+
+
+@ttkernel_compile
+def eltwise_sfpu(cb_in: int, cb_out: int):
+    per_core_block_cnt = 1  # get_compile_time_arg_val(0)                 # get_compile_time_arg_val not implemented
+    per_core_block_dim = 1  # get_compile_time_arg_val(1)
+
+    unary_op_init_common(
+        cb_in, cb_out
+    )  # init_sfpu is wrapper around unary_op_init_ocmmon - these are both CBIndex
+    for i in range(0, per_core_block_cnt, 1):
+        cb_reserve_back(cb_out, per_core_block_dim)
+        for j in range(0, per_core_block_dim, 1):
+            tile_regs_acquire()  # acquire_dst() is deprecated, use tile_regs_acquire instead
+            cb_wait_front(cb_in, 1)
+
+            copy_tile(cb_in, 0, 0)
+            pack_tile(
+                0, cb_out, 0
+            )  # last parameter is a optional index in c++ but not optional in pybind
+
+            cb_pop_front(cb_in, 1)
+            tile_regs_release()
+
+        cb_push_back(cb_out, per_core_block_dim)
+
+    return
+
+
+eltwise_sfpu(0, 16)

--- a/test/pykernel/eltwise_sfpu/eltwise_sfpu.py
+++ b/test/pykernel/eltwise_sfpu/eltwise_sfpu.py
@@ -51,8 +51,8 @@ def eltwise_sfpu(cb_in: int, cb_out: int):
     # CHECK: func.func @{{.*}}(%[[arg0:.*]]: !ttkernel.cb<{{.*}}>, %[[arg1:.*]]: !ttkernel.cb<{{.*}}>) {
     # CHECK: {{.*}}"ttkernel.get_compile_time_arg_val"{{.*}}
     # CHECK: {{.*}}"ttkernel.get_compile_time_arg_val"{{.*}}
-    per_core_block_cnt = get_compile_time_arg_val(type_int, 0)
-    per_core_block_dim = get_compile_time_arg_val(type_int, 1)
+    per_core_block_cnt = get_compile_time_arg_val(int, 0)
+    per_core_block_dim = get_compile_time_arg_val(int, 1)
 
     # CHECK: "ttkernel.unary_op_init_common"(%[[arg0]], %[[arg1]]){{.*}}
     unary_op_init_common(cb_in, cb_out)

--- a/test/pykernel/eltwise_sfpu/eltwise_sfpu.py
+++ b/test/pykernel/eltwise_sfpu/eltwise_sfpu.py
@@ -1,6 +1,6 @@
-# // SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
-# //
-# // SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
 
 # #include <cstdint>
 # #include "compute_kernel_api/common.h"
@@ -39,31 +39,44 @@
 # }
 # }  // namespace NAMESPACE
 
+# RUN: %python %s | FileCheck %s
+# REQUIRES: pykernel
+
 from pykernel.pykernel_ast import *
 
 
 @ttkernel_compile
 def eltwise_sfpu(cb_in: int, cb_out: int):
+    # CHECK: module {
+    # CHECK: func.func @{{.*}}(%[[arg0:.*]]: !ttkernel.cb<{{.*}}>, %[[arg1:.*]]: !ttkernel.cb<{{.*}}>) {
     per_core_block_cnt = 1  # get_compile_time_arg_val(0)                 # get_compile_time_arg_val not implemented
     per_core_block_dim = 1  # get_compile_time_arg_val(1)
 
-    unary_op_init_common(
-        cb_in, cb_out
-    )  # init_sfpu is wrapper around unary_op_init_ocmmon - these are both CBIndex
+    # CHECK: "ttkernel.unary_op_init_common"(%[[arg0]], %[[arg1]]){{.*}}
+    unary_op_init_common(cb_in, cb_out)
+
     for i in range(0, per_core_block_cnt, 1):
+        # CHECK: "ttkernel.cb_reserve_back"{{.*}}
         cb_reserve_back(cb_out, per_core_block_dim)
         for j in range(0, per_core_block_dim, 1):
+            # CHECK: "ttkernel.tile_regs_acquire"(){{.*}}
+            # CHECK: "ttkernel.cb_wait_front"{{.*}}
             tile_regs_acquire()  # acquire_dst() is deprecated, use tile_regs_acquire instead
             cb_wait_front(cb_in, 1)
 
+            # CHECK: "ttkernel.copy_tile"{{.*}}
+            # CHECK: "ttkernel.pack_tile"{{.*}}
             copy_tile(cb_in, 0, 0)
             pack_tile(
                 0, cb_out, 0
             )  # last parameter is a optional index in c++ but not optional in pybind
 
+            # CHECK: "ttkernel.cb_pop_front"{{.*}}
+            # CHECK: "ttkernel.tile_regs_release"(){{.*}}
             cb_pop_front(cb_in, 1)
             tile_regs_release()
 
+        # CHECK: "ttkernel.cb_push_back"{{.*}}
         cb_push_back(cb_out, per_core_block_dim)
 
     return

--- a/test/pykernel/eltwise_sfpu/eltwise_sfpu.py
+++ b/test/pykernel/eltwise_sfpu/eltwise_sfpu.py
@@ -43,10 +43,11 @@
 # REQUIRES: pykernel
 
 from pykernel.pykernel_ast import *
+from pykernel.types import *
 
 
 @ttkernel_compile
-def eltwise_sfpu(cb_in: int, cb_out: int):
+def eltwise_sfpu(cb_in: CircularBuffer, cb_out: CircularBuffer):
     # CHECK: module {
     # CHECK: func.func @{{.*}}(%[[arg0:.*]]: !ttkernel.cb<{{.*}}>, %[[arg1:.*]]: !ttkernel.cb<{{.*}}>) {
     # CHECK: {{.*}}"ttkernel.get_compile_time_arg_val"{{.*}}
@@ -83,4 +84,6 @@ def eltwise_sfpu(cb_in: int, cb_out: int):
     return
 
 
-eltwise_sfpu(0, 16)
+cb_in = CircularBuffer(0)
+cb_out = CircularBuffer(16)
+eltwise_sfpu(cb_in, cb_out)

--- a/test/pykernel/eltwise_sfpu/eltwise_sfpu.py
+++ b/test/pykernel/eltwise_sfpu/eltwise_sfpu.py
@@ -2,43 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# #include <cstdint>
-# #include "compute_kernel_api/common.h"
-# #include "compute_kernel_api/tile_move_copy.h"
-# #include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
-# #include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
-
-# namespace NAMESPACE {
-# void MAIN {
-#     uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
-#     uint32_t per_core_block_dim = get_compile_time_arg_val(1);
-
-#     init_sfpu(tt::CBIndex::c_0, tt::CBIndex::c_16);
-#     for (uint32_t block_index = 0; block_index < per_core_block_cnt; block_index++) {
-#         cb_reserve_back(tt::CBIndex::c_16, per_core_block_dim);
-#         for (uint32_t tile_index = 0; tile_index < per_core_block_dim; ++tile_index) {
-#             acquire_dst();
-
-#             // Pop tile after tile, copy to DST and pack
-#             cb_wait_front(tt::CBIndex::c_0, 1);
-
-#             copy_tile(tt::CBIndex::c_0, 0, 0);
-
-# #ifdef SFPU_OP_CHAIN_0
-#             SFPU_OP_CHAIN_0
-# #endif
-
-#             pack_tile(0, tt::CBIndex::c_16);
-
-#             cb_pop_front(tt::CBIndex::c_0, 1);
-
-#             release_dst();
-#         }
-#         cb_push_back(tt::CBIndex::c_16, per_core_block_dim);
-#     }
-# }
-# }  // namespace NAMESPACE
-
 # RUN: %python %s | FileCheck %s
 # REQUIRES: pykernel
 
@@ -49,7 +12,7 @@ from pykernel.types import *
 @ttkernel_compile
 def eltwise_sfpu(cb_in: CircularBuffer, cb_out: CircularBuffer):
     # CHECK: module {
-    # CHECK: func.func @{{.*}}(%[[arg0:.*]]: !ttkernel.cb<{{.*}}>, %[[arg1:.*]]: !ttkernel.cb<{{.*}}>) {
+    # CHECK: func.func @{{.*}}(%arg0: !ttkernel.cb<{{.*}}>, %arg1: !ttkernel.cb<{{.*}}>) {
     # CHECK: {{.*}}"ttkernel.get_compile_time_arg_val"{{.*}}
     # CHECK: {{.*}}"ttkernel.get_compile_time_arg_val"{{.*}}
     per_core_block_cnt = get_compile_time_arg_val(int, 0)

--- a/test/pykernel/eltwise_sfpu/reader_unary.py
+++ b/test/pykernel/eltwise_sfpu/reader_unary.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/test/pykernel/eltwise_sfpu/reader_unary.py
+++ b/test/pykernel/eltwise_sfpu/reader_unary.py
@@ -1,0 +1,69 @@
+# // SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# //
+# // SPDX-License-Identifier: Apache-2.0
+
+# #include <stdint.h>
+
+# #include "dataflow_api.h"
+
+# void kernel_main() {
+#     uint32_t src_addr  = get_arg_val<uint32_t>(0);
+#     uint32_t bank_id = get_arg_val<uint32_t>(1);
+#     uint32_t num_tiles = get_arg_val<uint32_t>(2);
+
+#     constexpr uint32_t cb_id_in0 = 0;
+
+#     // ublocks size defined in tiles
+#     constexpr uint32_t ublock_size_tiles = 1;
+#     uint32_t ublock_size_bytes = get_tile_size(cb_id_in0) * ublock_size_tiles;
+
+#     // read a ublock of tiles from src to CB, and then push the ublock to unpacker
+#     for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
+#         uint64_t src_noc_addr = get_noc_addr_from_bank_id<true>(bank_id, src_addr);
+
+#         cb_reserve_back(cb_id_in0, ublock_size_tiles);
+#         uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+#         noc_async_read(src_noc_addr, l1_write_addr, ublock_size_bytes);
+
+#         noc_async_read_barrier();
+
+#         cb_push_back(cb_id_in0, ublock_size_tiles);
+#         src_addr += ublock_size_bytes;
+#     }
+# }
+
+# CBIndex is just uint8_t
+
+from pykernel.pykernel_ast import *
+
+
+@ttkernel_compile
+def reader_unary(cb_in: int, cb_out: int):
+    # let arguments = (ins I32:$arg_index); let results = (outs AnyTypeOf<[TTKernel_Semaphore, I32]>:$arg_val);
+    # get_arg_val requires you pass in the return type in the first parameter?
+    src_addr = get_arg_val(type_int, 0)
+    bank_id = get_arg_val(type_int, 1)
+    num_tiles = get_arg_val(type_int, 2)
+
+    ublock_size_tiles = 1
+    ublock_size_bytes = 5  # get_tile_size(0) * ublock_size_tiles                    # get_tile_size not implemented
+
+    for i in range(0, num_tiles, ublock_size_tiles):
+        #     src_noc_addr = get_noc_addr_from_bank_id(True, bank_id, src_addr)       # get_noc_addr_from_bank_id not implemented
+
+        cb_reserve_back(cb_in, ublock_size_tiles)
+        #     l1_write_addr = get_write_ptr(0)                                        # get_write_ptr not implemented
+
+        #     # let arguments = (ins TTKernel_NocAddr:$srcNocAddr, I32:$dstLocalL1Addr, I32:$size);
+        #     noc_async_read(src_noc_addr, l1_write_addr, ublock_size_bytes)
+
+        noc_async_read_barrier()
+
+        cb_push_back(cb_in, ublock_size_tiles)
+
+        src_addr = src_addr + ublock_size_bytes
+
+    return
+
+
+reader_unary(0, 16)

--- a/test/pykernel/eltwise_sfpu/reader_unary.py
+++ b/test/pykernel/eltwise_sfpu/reader_unary.py
@@ -45,7 +45,7 @@ def reader_unary(cb_in: int, cb_out: int):
     # CHECK: {{.*}}"ttkernel.get_arg_val"{{.*}}
     # CHECK: {{.*}}"ttkernel.get_arg_val"{{.*}}
     # CHECK: {{.*}}"ttkernel.get_arg_val"{{.*}}
-    src_addr = get_arg_val(int, 0)
+    src_addr: int = get_arg_val(int, 0)
     bank_id = get_arg_val(int, 1)
     num_tiles = get_arg_val(int, 2)
 

--- a/test/pykernel/eltwise_sfpu/reader_unary.py
+++ b/test/pykernel/eltwise_sfpu/reader_unary.py
@@ -36,10 +36,11 @@
 # REQUIRES: pykernel
 
 from pykernel.pykernel_ast import *
+from pykernel.types import *
 
 
 @ttkernel_compile
-def reader_unary(cb_in: int, cb_out: int):
+def reader_unary(cb_in: CircularBuffer, cb_out: CircularBuffer):
     # CHECK: module {
     # CHECK: func.func @{{.*}}(%[[arg0:.*]]: !ttkernel.cb<{{.*}}>, %[[arg1:.*]]: !ttkernel.cb<{{.*}}>) {
     # CHECK: {{.*}}"ttkernel.get_arg_val"{{.*}}
@@ -75,4 +76,6 @@ def reader_unary(cb_in: int, cb_out: int):
     return
 
 
-reader_unary(0, 16)
+cb_in = CircularBuffer(0)
+cb_out = CircularBuffer(16)
+reader_unary(cb_in, cb_out)

--- a/test/pykernel/eltwise_sfpu/reader_unary.py
+++ b/test/pykernel/eltwise_sfpu/reader_unary.py
@@ -45,9 +45,9 @@ def reader_unary(cb_in: int, cb_out: int):
     # CHECK: {{.*}}"ttkernel.get_arg_val"{{.*}}
     # CHECK: {{.*}}"ttkernel.get_arg_val"{{.*}}
     # CHECK: {{.*}}"ttkernel.get_arg_val"{{.*}}
-    src_addr = get_arg_val(type_int, 0)
-    bank_id = get_arg_val(type_int, 1)
-    num_tiles = get_arg_val(type_int, 2)
+    src_addr = get_arg_val(int, 0)
+    bank_id = get_arg_val(int, 1)
+    num_tiles = get_arg_val(int, 2)
 
     # CHECK: {{.*}}"ttkernel.get_tile_size"{{.*}}
     ublock_size_tiles = 1

--- a/test/pykernel/eltwise_sfpu/writer_unary.py
+++ b/test/pykernel/eltwise_sfpu/writer_unary.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/test/pykernel/eltwise_sfpu/writer_unary.py
+++ b/test/pykernel/eltwise_sfpu/writer_unary.py
@@ -34,10 +34,11 @@
 # REQUIRES: pykernel
 
 from pykernel.pykernel_ast import *
+from pykernel.types import *
 
 
 @ttkernel_compile
-def writer_unary(cb_in: int, cb_out: int):
+def writer_unary(cb_in: CircularBuffer, cb_out: CircularBuffer):
     # CHECK: module {
     # CHECK: func.func @{{.*}}(%[[arg0:.*]]: !ttkernel.cb<{{.*}}>, %[[arg1:.*]]: !ttkernel.cb<{{.*}}>) {
     # CHECK: {{.*}}"ttkernel.get_arg_val"{{.*}}
@@ -50,8 +51,6 @@ def writer_unary(cb_in: int, cb_out: int):
     # CHECK: {{.*}}"ttkernel.get_tile_size"{{.*}}
     ublock_size_bytes = get_tile_size(cb_out)
     ublock_size_tiles = 1
-
-    cb_id_out0 = 16
 
     for i in range(0, num_tiles, ublock_size_tiles):
         # CHECK: %[[DST_NOC_ADDR:.*]] = "ttkernel.get_noc_addr_from_bank_id"{{.*}}
@@ -74,4 +73,6 @@ def writer_unary(cb_in: int, cb_out: int):
     return
 
 
-writer_unary(0, 16)
+cb_in = CircularBuffer(0)
+cb_out = CircularBuffer(16)
+writer_unary(cb_in, cb_out)

--- a/test/pykernel/eltwise_sfpu/writer_unary.py
+++ b/test/pykernel/eltwise_sfpu/writer_unary.py
@@ -43,7 +43,7 @@ def writer_unary(cb_in: int, cb_out: int):
     # CHECK: {{.*}}"ttkernel.get_arg_val"{{.*}}
     # CHECK: {{.*}}"ttkernel.get_arg_val"{{.*}}
     # CHECK: {{.*}}"ttkernel.get_arg_val"{{.*}}
-    dst_addr = get_arg_val(int, 0)
+    dst_addr: int = get_arg_val(int, 0)
     bank_id = get_arg_val(int, 1)
     num_tiles = get_arg_val(int, 2)
 

--- a/test/pykernel/eltwise_sfpu/writer_unary.py
+++ b/test/pykernel/eltwise_sfpu/writer_unary.py
@@ -2,34 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# #include "dataflow_api.h"
-# #include "debug/dprint.h"
-
-# void kernel_main() {
-#     uint32_t dst_addr  = get_arg_val<uint32_t>(0);
-#     uint32_t bank_id = get_arg_val<uint32_t>(1);
-#     uint32_t num_tiles = get_arg_val<uint32_t>(2);
-
-#     constexpr uint32_t cb_id_out0 = tt::CBIndex::c_16;
-
-#     // single-tile ublocks
-#     uint32_t ublock_size_bytes = get_tile_size(cb_id_out0);
-#     uint32_t ublock_size_tiles = 1;
-
-#     for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
-#         uint64_t dst_noc_addr = get_noc_addr_from_bank_id<true>(bank_id, dst_addr);
-
-#         cb_wait_front(cb_id_out0, ublock_size_tiles);
-#         uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
-#         noc_async_write(l1_read_addr, dst_noc_addr, ublock_size_bytes);
-
-#         noc_async_write_barrier();
-
-#         cb_pop_front(cb_id_out0, ublock_size_tiles);
-#         dst_addr += ublock_size_bytes;
-#     }
-# }
-
 # RUN: %python %s | FileCheck %s
 # REQUIRES: pykernel
 
@@ -40,9 +12,10 @@ from pykernel.types import *
 @ttkernel_compile
 def writer_unary(cb_in: CircularBuffer, cb_out: CircularBuffer):
     # CHECK: module {
-    # CHECK: func.func @{{.*}}(%[[arg0:.*]]: !ttkernel.cb<{{.*}}>, %[[arg1:.*]]: !ttkernel.cb<{{.*}}>) {
+    # CHECK: func.func @{{.*}}(%arg0: !ttkernel.cb<{{.*}}>, %arg1: !ttkernel.cb<{{.*}}>) {
     # CHECK: {{.*}}"ttkernel.get_arg_val"{{.*}}
-    # CHECK: {{.*}}"ttkernel.get_arg_val"{{.*}}
+    # CHECK: %[[DST_ADDR:.*]] = memref.alloca(){{.*}}
+    # CHECK: %[[BANK_ID:.*]] = "ttkernel.get_arg_val"{{.*}}
     # CHECK: {{.*}}"ttkernel.get_arg_val"{{.*}}
     dst_addr: int = get_arg_val(int, 0)
     bank_id = get_arg_val(int, 1)
@@ -53,7 +26,7 @@ def writer_unary(cb_in: CircularBuffer, cb_out: CircularBuffer):
     ublock_size_tiles = 1
 
     for i in range(0, num_tiles, ublock_size_tiles):
-        # CHECK: %[[DST_NOC_ADDR:.*]] = "ttkernel.get_noc_addr_from_bank_id"{{.*}}
+        # CHECK: %[[DST_NOC_ADDR:.*]] = "ttkernel.get_noc_addr_from_bank_id"(%[[BANK_ID]],{{.*}}
         dst_noc_addr = get_noc_addr_from_bank_id(bank_id, dst_addr)
 
         # CHECK: "ttkernel.cb_wait_front"{{.*}}
@@ -68,6 +41,10 @@ def writer_unary(cb_in: CircularBuffer, cb_out: CircularBuffer):
 
         # CHECK: "ttkernel.cb_pop_front"{{.*}}
         cb_pop_front(cb_out, ublock_size_tiles)
+
+        # CHECK: {{.*}}memref.load %[[DST_ADDR]]{{.*}}
+        # CHECK: {{.*}}arith.addi{{.*}}
+        # CHECK: memref.store {{.*}} %[[DST_ADDR]]{{.*}}
         dst_addr = dst_addr + ublock_size_bytes
 
     return

--- a/test/pykernel/eltwise_sfpu/writer_unary.py
+++ b/test/pykernel/eltwise_sfpu/writer_unary.py
@@ -1,0 +1,59 @@
+# // SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# //
+# // SPDX-License-Identifier: Apache-2.0
+
+# #include "dataflow_api.h"
+# #include "debug/dprint.h"
+
+# void kernel_main() {
+#     uint32_t dst_addr  = get_arg_val<uint32_t>(0);
+#     uint32_t bank_id = get_arg_val<uint32_t>(1);
+#     uint32_t num_tiles = get_arg_val<uint32_t>(2);
+
+#     constexpr uint32_t cb_id_out0 = tt::CBIndex::c_16;
+
+#     // single-tile ublocks
+#     uint32_t ublock_size_bytes = get_tile_size(cb_id_out0);
+#     uint32_t ublock_size_tiles = 1;
+
+#     for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
+#         uint64_t dst_noc_addr = get_noc_addr_from_bank_id<true>(bank_id, dst_addr);
+
+#         cb_wait_front(cb_id_out0, ublock_size_tiles);
+#         uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
+#         noc_async_write(l1_read_addr, dst_noc_addr, ublock_size_bytes);
+
+#         noc_async_write_barrier();
+
+#         cb_pop_front(cb_id_out0, ublock_size_tiles);
+#         dst_addr += ublock_size_bytes;
+#     }
+# }
+
+# CBIndex is just uint8_t
+
+from pykernel.pykernel_ast import *
+
+
+@ttkernel_compile
+def write_unary(cb_in, cb_out):
+    dst_addr = get_arg_val(type_int, 0)
+    bank_id = get_arg_val(type_int, 1)
+    num_tiles = get_arg_val(type_int, 2)
+
+    ublock_size_bytes = 5  # get_tile_size(16)                                   # get_tile_size not implemented
+    ublock_size_tiles = 1
+
+    cb_id_out0 = 16
+
+    for i in range(0, num_tiles, ublock_size_tiles):
+        # dst_noc_addr = get_noc_addr_from_bank_id(True, bank_id, dst_addr)   # get_noc_addr_from_bank_id not implemented
+
+        cb_wait_front(cb_out, ublock_size_tiles)
+        # l1_read_addr = get_read_ptr(cb_out)                                     # get_read_ptr not implemented - returns uint32_t
+        # noc_async_write(l1_read_addr, dst_noc_addr, ublock_size_bytes)
+
+        noc_async_write_barrier()
+
+        cb_pop_front(cb_out, ublock_size_tiles)
+        dst_addr += ublock_size_bytes

--- a/test/pykernel/eltwise_sfpu/writer_unary.py
+++ b/test/pykernel/eltwise_sfpu/writer_unary.py
@@ -40,27 +40,31 @@ from pykernel.pykernel_ast import *
 def writer_unary(cb_in: int, cb_out: int):
     # CHECK: module {
     # CHECK: func.func @{{.*}}(%[[arg0:.*]]: !ttkernel.cb<{{.*}}>, %[[arg1:.*]]: !ttkernel.cb<{{.*}}>) {
-    # CHECK: "ttkernel.get_arg_val"{{.*}}
-    # CHECK: "ttkernel.get_arg_val"{{.*}}
-    # CHECK: "ttkernel.get_arg_val"{{.*}}
+    # CHECK: {{.*}}"ttkernel.get_arg_val"{{.*}}
+    # CHECK: {{.*}}"ttkernel.get_arg_val"{{.*}}
+    # CHECK: {{.*}}"ttkernel.get_arg_val"{{.*}}
     dst_addr = get_arg_val(type_int, 0)
     bank_id = get_arg_val(type_int, 1)
     num_tiles = get_arg_val(type_int, 2)
 
-    ublock_size_bytes = 5  # get_tile_size(16)                                   # get_tile_size not implemented
+    # CHECK: {{.*}}"ttkernel.get_tile_size"{{.*}}
+    ublock_size_bytes = get_tile_size(cb_out)
     ublock_size_tiles = 1
 
     cb_id_out0 = 16
 
     for i in range(0, num_tiles, ublock_size_tiles):
-        # dst_noc_addr = get_noc_addr_from_bank_id(True, bank_id, dst_addr)   # get_noc_addr_from_bank_id not implemented
+        # CHECK: %[[DST_NOC_ADDR:.*]] = "ttkernel.get_noc_addr_from_bank_id"{{.*}}
+        dst_noc_addr = get_noc_addr_from_bank_id(bank_id, dst_addr)
 
         # CHECK: "ttkernel.cb_wait_front"{{.*}}
+        # CHECK: {{.*}}"ttkernel.get_read_ptr"{{.*}}
         cb_wait_front(cb_out, ublock_size_tiles)
-        # l1_read_addr = get_read_ptr(cb_out)                                     # get_read_ptr not implemented - returns uint32_t
-        # noc_async_write(l1_read_addr, dst_noc_addr, ublock_size_bytes)
+        l1_read_addr = get_read_ptr(cb_out)
 
+        # CHECK: "ttkernel.noc_async_write"({{.*}}, %[[DST_NOC_ADDR]], {{.*}}){{.*}}
         # CHECK: "ttkernel.noc_async_write_barrier"{{.*}}
+        noc_async_write(l1_read_addr, dst_noc_addr, ublock_size_bytes)
         noc_async_write_barrier()
 
         # CHECK: "ttkernel.cb_pop_front"{{.*}}

--- a/test/pykernel/eltwise_sfpu/writer_unary.py
+++ b/test/pykernel/eltwise_sfpu/writer_unary.py
@@ -43,9 +43,9 @@ def writer_unary(cb_in: int, cb_out: int):
     # CHECK: {{.*}}"ttkernel.get_arg_val"{{.*}}
     # CHECK: {{.*}}"ttkernel.get_arg_val"{{.*}}
     # CHECK: {{.*}}"ttkernel.get_arg_val"{{.*}}
-    dst_addr = get_arg_val(type_int, 0)
-    bank_id = get_arg_val(type_int, 1)
-    num_tiles = get_arg_val(type_int, 2)
+    dst_addr = get_arg_val(int, 0)
+    bank_id = get_arg_val(int, 1)
+    num_tiles = get_arg_val(int, 2)
 
     # CHECK: {{.*}}"ttkernel.get_tile_size"{{.*}}
     ublock_size_bytes = get_tile_size(cb_out)

--- a/test/pykernel/unit_tests.py
+++ b/test/pykernel/unit_tests.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/test/pykernel/unit_tests.py
+++ b/test/pykernel/unit_tests.py
@@ -72,6 +72,17 @@ def test_for():
     for i in range(0, 10, 1):
         a = 1
 
+    x = 0
+    y = 10
+    z = 1
+    for i in range(0, 10, 1):
+        # CHECK: %[[X:.*]] = memref.load{{.*}}
+        # CHECK: %[[Y:.*]] = memref.load{{.*}}
+        # CHECK: %[[Z:.*]] = memref.load{{.*}}
+        # CHECK: scf.for {{.*}} = %[[X]] to %[[Y]] step %[[Z]] {{.*}}
+        for j in range(x, y, z):
+            a = 1
+
     return
 
 


### PR DESCRIPTION
This PR lowers 2 basic kernels into MLIR
- eltwise kernel example: https://github.com/tenstorrent/tt-mlir/issues/1850
- [add_2_integers kernel](https://github.com/tenstorrent/tt-metal/tree/main/tt_metal/programming_examples/add_2_integers_in_compute) example: 

Changes made to support: 
- all assign statements will default to SSA only unless using AnnAssign (eg: `x: int = 1`) which will use memref
- a `CircularBuffer` type in Python to [interface with kernel function](https://github.com/tenstorrent/tt-mlir/issues/1849), this is basically the `class Tensor` defined in `simple_kernel.py`

