### PR TITLE
#2002: Enable Compile Time Op Runtime Estimation

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.td
@@ -16,13 +16,16 @@ def TTNN_OpModelInterface : OpInterface<"OpModel"> {
     let methods = [
         InterfaceMethod<
             /*desc=*/[{
-                Returns the op kernel estimate in clock cycles.
+                Returns a tuple of three values:**
+                1. A boolean indicating if runtime estimation was successful.
+                2. If the estimation was successful, the estimated op runtime in nanoseconds.
+                3. If the estimation failed, a string describing the failure.
             }],
-            /*retTy=*/"size_t",
-            /*methodName=*/"getOpPerfCycles",
+            /*retTy=*/"std::tuple<bool, std::optional<size_t>, std::optional<std::string>>",
+            /*methodName=*/"getOpRuntime",
             /*args=*/(ins "const std::vector<TTNNLayoutAttr>&":$inputs, "const TTNNLayoutAttr&":$output),
             /*methodBody=*/"",
-            /*defaultImplementation=*/"return std::numeric_limits<size_t>::max();"
+            /*defaultImplementation=*/"return std::make_tuple(true, 0, std::nullopt);"
         >,
         InterfaceMethod<
             /*desc=*/[{

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.td
@@ -25,7 +25,7 @@ def TTNN_OpModelInterface : OpInterface<"OpModel"> {
             /*methodName=*/"getOpRuntime",
             /*args=*/(ins "const std::vector<TTNNLayoutAttr>&":$inputs, "const TTNNLayoutAttr&":$output),
             /*methodBody=*/"",
-            /*defaultImplementation=*/"return std::make_tuple(true, 0, std::nullopt);"
+            /*defaultImplementation=*/"return std::make_tuple(false, 0, std::nullopt);"
         >,
         InterfaceMethod<
             /*desc=*/[{
@@ -41,7 +41,7 @@ def TTNN_OpModelInterface : OpInterface<"OpModel"> {
             /*methodName=*/"getOpConstraints",
             /*args=*/(ins "const std::vector<TTNNLayoutAttr>&":$inputs, "const TTNNLayoutAttr&":$output),
             /*methodBody=*/"",
-            /*defaultImplementation=*/"return std::make_tuple(true,std::make_tuple(0,0,0), std::nullopt);"
+            /*defaultImplementation=*/"return std::make_tuple(false, std::make_tuple(0,0,0), std::nullopt);"
         >,
         ];
 }

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.td
@@ -41,7 +41,7 @@ def TTNN_OpModelInterface : OpInterface<"OpModel"> {
             /*methodName=*/"getOpConstraints",
             /*args=*/(ins "const std::vector<TTNNLayoutAttr>&":$inputs, "const TTNNLayoutAttr&":$output),
             /*methodBody=*/"",
-            /*defaultImplementation=*/"return std::make_tuple(false, std::make_tuple(0,0,0), std::nullopt);"
+            /*defaultImplementation=*/"return std::make_tuple(true, std::make_tuple(0,0,0), std::nullopt);"
         >,
         ];
 }

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.td
@@ -17,9 +17,9 @@ def TTNN_OpModelInterface : OpInterface<"OpModel"> {
         InterfaceMethod<
             /*desc=*/[{
                 Returns a tuple of three values:**
-                1. A boolean indicating if runtime estimation was successful.
-                2. If the estimation was successful, the estimated op runtime in nanoseconds.
-                3. If the estimation failed, a string describing the failure.
+                1. A boolean indicating if runtime measurement was successful.
+                2. If the measurement was successful, the estimated op runtime in nanoseconds.
+                3. If the measurement failed, a string describing the failure.
             }],
             /*retTy=*/"std::tuple<bool, std::optional<size_t>, std::optional<std::string>>",
             /*methodName=*/"getOpRuntime",

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -398,7 +398,7 @@ def TTNN_LeakyReluOp : TTNN_ElementwiseUnaryWithFloatParameterOp<"leaky_relu"> {
 }
 
 def TTNN_AddOp : TTNN_ElementwiseBinaryOp<"add",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints"]>]
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
       > {
 
     let summary = "Eltwise add.";
@@ -766,7 +766,7 @@ def TTNN_MorehCumSumOp : TTNN_NamedDPSOp<"moreh_cumsum"> {
 }
 
 def TTNN_SoftmaxOp : TTNN_Op<"softmax",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints"]>]
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
       > {
 
     let summary = "Softmax op.";
@@ -923,7 +923,7 @@ def TTNN_LinearOp : TTNN_NamedDPSOp<"linear"> {
 
 // ANCHOR: adding_an_op_matmul_ttnn
 def TTNN_MatmulOp : TTNN_NamedDPSOp<"matmul",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints"]>]
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
       > {
     let arguments = (ins AnyRankedTensor:$a,
                          AnyRankedTensor:$b,

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -288,7 +288,7 @@ def TTNN_ReciprocalOp : TTNN_ElementwiseUnaryOp<"reciprocal"> {
 }
 
 def TTNN_ReluOp : TTNN_ElementwiseUnaryOp<"relu",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints"]>]
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
       > {
     let summary = "Eltwise ReLU.";
     let description = [{

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -33,6 +33,12 @@ getOpConstraints(const llvm::ArrayRef<int64_t> &inputShape,
                  const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout,
                  const llvm::ArrayRef<int64_t> &outputShape,
                  const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout);
+
+std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
+getOpRuntime(const llvm::ArrayRef<int64_t> &inputShape,
+                 const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout,
+                 const llvm::ArrayRef<int64_t> &outputShape,
+                 const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout);
 }; // namespace ReluOpInterface
 
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -48,18 +48,18 @@ getOpRuntime(const llvm::ArrayRef<int64_t> &inputShape,
 namespace AddOpInterface {
 std::tuple<bool, std::optional<std::tuple<size_t, size_t, size_t>>,
            std::optional<std::string>>
-getOpConstraints(const llvm::ArrayRef<int64_t> &inputShape_a,
-                 const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_a,
-                 const llvm::ArrayRef<int64_t> &inputShape_b,
-                 const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_b,
+getOpConstraints(const llvm::ArrayRef<int64_t> &inputShapeA,
+                 const mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutA,
+                 const llvm::ArrayRef<int64_t> &inputShapeB,
+                 const mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutB,
                  const llvm::ArrayRef<int64_t> &outputShape,
                  const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout);
 
 std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
-getOpRuntime(const llvm::ArrayRef<int64_t> &inputShape_a,
-             const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_a,
-             const llvm::ArrayRef<int64_t> &inputShape_b,
-             const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_b,
+getOpRuntime(const llvm::ArrayRef<int64_t> &inputShapeA,
+             const mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutA,
+             const llvm::ArrayRef<int64_t> &inputShapeB,
+             const mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutB,
              const llvm::ArrayRef<int64_t> &outputShape,
              const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout);
 
@@ -92,22 +92,22 @@ getOpRuntime(const llvm::ArrayRef<int64_t> &inputShape,
 namespace MatmulOpInterface {
 std::tuple<bool, std::optional<std::tuple<size_t, size_t, size_t>>,
            std::optional<std::string>>
-getOpConstraints(const llvm::ArrayRef<int64_t> &inputShape_a,
-                 const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_a,
-                 const llvm::ArrayRef<int64_t> &inputShape_b,
-                 const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_b,
+getOpConstraints(const llvm::ArrayRef<int64_t> &inputShapeA,
+                 const mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutA,
+                 const llvm::ArrayRef<int64_t> &inputShapeB,
+                 const mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutB,
                  const llvm::ArrayRef<int64_t> &outputShape,
                  const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout,
-                 bool transpose_a, bool transpose_b);
+                 bool transposeA, bool transposeB);
 
 std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
-getOpRuntime(const llvm::ArrayRef<int64_t> &inputShape_a,
-             const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_a,
-             const llvm::ArrayRef<int64_t> &inputShape_b,
-             const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_b,
+getOpRuntime(const llvm::ArrayRef<int64_t> &inputShapeA,
+             const mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutA,
+             const llvm::ArrayRef<int64_t> &inputShapeB,
+             const mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutB,
              const llvm::ArrayRef<int64_t> &outputShape,
              const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout,
-             bool transpose_a, bool transpose_b);
+             bool transposeA, bool transposeB);
 }; // namespace MatmulOpInterface
 
 } // namespace mlir::tt::op_model::ttnn

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -74,13 +74,13 @@ std::tuple<bool, std::optional<std::tuple<size_t, size_t, size_t>>,
            std::optional<std::string>>
 getOpConstraints(const llvm::ArrayRef<int64_t> &inputShape,
                  const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout,
-                 const int dim_arg, const llvm::ArrayRef<int64_t> &outputShape,
+                 const int dimArg, const llvm::ArrayRef<int64_t> &outputShape,
                  const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout);
 
 std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
 getOpRuntime(const llvm::ArrayRef<int64_t> &inputShape,
              const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout,
-             const int dim_arg, const llvm::ArrayRef<int64_t> &outputShape,
+             const int dimArg, const llvm::ArrayRef<int64_t> &outputShape,
              const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout);
 
 }; // namespace SoftmaxOpInterface

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -29,16 +29,16 @@ getDeviceConstraints(const mlir::tt::GridAttr &workerGrid);
 namespace ReluOpInterface {
 std::tuple<bool, std::optional<std::tuple<size_t, size_t, size_t>>,
            std::optional<std::string>>
-getOpConstraints(const llvm::ArrayRef<int64_t> &inputShape,
-                 const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout,
-                 const llvm::ArrayRef<int64_t> &outputShape,
-                 const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout);
+getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+                 llvm::ArrayRef<int64_t> outputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
 
 std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
-getOpRuntime(const llvm::ArrayRef<int64_t> &inputShape,
-             const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout,
-             const llvm::ArrayRef<int64_t> &outputShape,
-             const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout);
+getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+             llvm::ArrayRef<int64_t> outputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
 }; // namespace ReluOpInterface
 
 //===----------------------------------------------------------------------===//
@@ -48,20 +48,20 @@ getOpRuntime(const llvm::ArrayRef<int64_t> &inputShape,
 namespace AddOpInterface {
 std::tuple<bool, std::optional<std::tuple<size_t, size_t, size_t>>,
            std::optional<std::string>>
-getOpConstraints(const llvm::ArrayRef<int64_t> &inputShapeA,
-                 const mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutA,
-                 const llvm::ArrayRef<int64_t> &inputShapeB,
-                 const mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutB,
-                 const llvm::ArrayRef<int64_t> &outputShape,
-                 const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout);
+getOpConstraints(llvm::ArrayRef<int64_t> inputShapeA,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                 llvm::ArrayRef<int64_t> inputShapeB,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                 llvm::ArrayRef<int64_t> outputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
 
 std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
-getOpRuntime(const llvm::ArrayRef<int64_t> &inputShapeA,
-             const mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutA,
-             const llvm::ArrayRef<int64_t> &inputShapeB,
-             const mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutB,
-             const llvm::ArrayRef<int64_t> &outputShape,
-             const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout);
+getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+             llvm::ArrayRef<int64_t> inputShapeB,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+             llvm::ArrayRef<int64_t> outputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
 
 }; // namespace AddOpInterface
 
@@ -72,16 +72,16 @@ getOpRuntime(const llvm::ArrayRef<int64_t> &inputShapeA,
 namespace SoftmaxOpInterface {
 std::tuple<bool, std::optional<std::tuple<size_t, size_t, size_t>>,
            std::optional<std::string>>
-getOpConstraints(const llvm::ArrayRef<int64_t> &inputShape,
-                 const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout,
-                 const int dimArg, const llvm::ArrayRef<int64_t> &outputShape,
-                 const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout);
+getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayout, const int dimArg,
+                 llvm::ArrayRef<int64_t> outputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
 
 std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
-getOpRuntime(const llvm::ArrayRef<int64_t> &inputShape,
-             const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout,
-             const int dimArg, const llvm::ArrayRef<int64_t> &outputShape,
-             const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout);
+getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayout, const int dimArg,
+             llvm::ArrayRef<int64_t> outputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
 
 }; // namespace SoftmaxOpInterface
 
@@ -92,22 +92,22 @@ getOpRuntime(const llvm::ArrayRef<int64_t> &inputShape,
 namespace MatmulOpInterface {
 std::tuple<bool, std::optional<std::tuple<size_t, size_t, size_t>>,
            std::optional<std::string>>
-getOpConstraints(const llvm::ArrayRef<int64_t> &inputShapeA,
-                 const mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutA,
-                 const llvm::ArrayRef<int64_t> &inputShapeB,
-                 const mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutB,
-                 const llvm::ArrayRef<int64_t> &outputShape,
-                 const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout,
-                 bool transposeA, bool transposeB);
+getOpConstraints(llvm::ArrayRef<int64_t> inputShapeA,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                 llvm::ArrayRef<int64_t> inputShapeB,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                 llvm::ArrayRef<int64_t> outputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool transposeA,
+                 bool transposeB);
 
 std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
-getOpRuntime(const llvm::ArrayRef<int64_t> &inputShapeA,
-             const mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutA,
-             const llvm::ArrayRef<int64_t> &inputShapeB,
-             const mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutB,
-             const llvm::ArrayRef<int64_t> &outputShape,
-             const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout,
-             bool transposeA, bool transposeB);
+getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+             llvm::ArrayRef<int64_t> inputShapeB,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+             llvm::ArrayRef<int64_t> outputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool transposeA,
+             bool transposeB);
 }; // namespace MatmulOpInterface
 
 } // namespace mlir::tt::op_model::ttnn

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -36,9 +36,9 @@ getOpConstraints(const llvm::ArrayRef<int64_t> &inputShape,
 
 std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
 getOpRuntime(const llvm::ArrayRef<int64_t> &inputShape,
-                 const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout,
-                 const llvm::ArrayRef<int64_t> &outputShape,
-                 const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout);
+             const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout,
+             const llvm::ArrayRef<int64_t> &outputShape,
+             const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout);
 }; // namespace ReluOpInterface
 
 //===----------------------------------------------------------------------===//
@@ -55,13 +55,13 @@ getOpConstraints(const llvm::ArrayRef<int64_t> &inputShape_a,
                  const llvm::ArrayRef<int64_t> &outputShape,
                  const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout);
 
-std::tuple<bool, std::optional<size_t>,std::optional<std::string>>
+std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
 getOpRuntime(const llvm::ArrayRef<int64_t> &inputShape_a,
-                 const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_a,
-                 const llvm::ArrayRef<int64_t> &inputShape_b,
-                 const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_b,
-                 const llvm::ArrayRef<int64_t> &outputShape,
-                 const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout);
+             const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_a,
+             const llvm::ArrayRef<int64_t> &inputShape_b,
+             const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_b,
+             const llvm::ArrayRef<int64_t> &outputShape,
+             const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout);
 
 }; // namespace AddOpInterface
 
@@ -77,11 +77,11 @@ getOpConstraints(const llvm::ArrayRef<int64_t> &inputShape,
                  const int dim_arg, const llvm::ArrayRef<int64_t> &outputShape,
                  const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout);
 
-std::tuple<bool, std::optional<size_t>,std::optional<std::string>>
+std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
 getOpRuntime(const llvm::ArrayRef<int64_t> &inputShape,
-                 const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout,
-                 const int dim_arg, const llvm::ArrayRef<int64_t> &outputShape,
-                 const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout);
+             const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout,
+             const int dim_arg, const llvm::ArrayRef<int64_t> &outputShape,
+             const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout);
 
 }; // namespace SoftmaxOpInterface
 
@@ -100,14 +100,14 @@ getOpConstraints(const llvm::ArrayRef<int64_t> &inputShape_a,
                  const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout,
                  bool transpose_a, bool transpose_b);
 
-std::tuple<bool, std::optional<size_t>,std::optional<std::string>>
+std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
 getOpRuntime(const llvm::ArrayRef<int64_t> &inputShape_a,
-                 const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_a,
-                 const llvm::ArrayRef<int64_t> &inputShape_b,
-                 const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_b,
-                 const llvm::ArrayRef<int64_t> &outputShape,
-                 const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout,
-                 bool transpose_a, bool transpose_b);
+             const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_a,
+             const llvm::ArrayRef<int64_t> &inputShape_b,
+             const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_b,
+             const llvm::ArrayRef<int64_t> &outputShape,
+             const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout,
+             bool transpose_a, bool transpose_b);
 }; // namespace MatmulOpInterface
 
 } // namespace mlir::tt::op_model::ttnn

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -54,6 +54,15 @@ getOpConstraints(const llvm::ArrayRef<int64_t> &inputShape_a,
                  const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_b,
                  const llvm::ArrayRef<int64_t> &outputShape,
                  const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout);
+
+std::tuple<bool, std::optional<size_t>,std::optional<std::string>>
+getOpRuntime(const llvm::ArrayRef<int64_t> &inputShape_a,
+                 const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_a,
+                 const llvm::ArrayRef<int64_t> &inputShape_b,
+                 const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_b,
+                 const llvm::ArrayRef<int64_t> &outputShape,
+                 const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout);
+
 }; // namespace AddOpInterface
 
 //===----------------------------------------------------------------------===//
@@ -67,6 +76,13 @@ getOpConstraints(const llvm::ArrayRef<int64_t> &inputShape,
                  const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout,
                  const int dim_arg, const llvm::ArrayRef<int64_t> &outputShape,
                  const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout);
+
+std::tuple<bool, std::optional<size_t>,std::optional<std::string>>
+getOpRuntime(const llvm::ArrayRef<int64_t> &inputShape,
+                 const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout,
+                 const int dim_arg, const llvm::ArrayRef<int64_t> &outputShape,
+                 const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout);
+
 }; // namespace SoftmaxOpInterface
 
 //===----------------------------------------------------------------------===//
@@ -77,6 +93,15 @@ namespace MatmulOpInterface {
 std::tuple<bool, std::optional<std::tuple<size_t, size_t, size_t>>,
            std::optional<std::string>>
 getOpConstraints(const llvm::ArrayRef<int64_t> &inputShape_a,
+                 const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_a,
+                 const llvm::ArrayRef<int64_t> &inputShape_b,
+                 const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_b,
+                 const llvm::ArrayRef<int64_t> &outputShape,
+                 const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout,
+                 bool transpose_a, bool transpose_b);
+
+std::tuple<bool, std::optional<size_t>,std::optional<std::string>>
+getOpRuntime(const llvm::ArrayRef<int64_t> &inputShape_a,
                  const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_a,
                  const llvm::ArrayRef<int64_t> &inputShape_b,
                  const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_b,

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -64,19 +64,19 @@ ReluOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
 std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
 ReluOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                 const TTNNLayoutAttr &output) {
-        
-    assert(inputs.size() == 1);
+                     const TTNNLayoutAttr &output) {
 
-    const auto input_shape =
-        mlir::cast<RankedTensorType>(getDpsInputOperand(0)->get().getType())
-            .getShape();
+  assert(inputs.size() == 1);
 
-    const auto output_shape =
-        mlir::cast<RankedTensorType>(getResults().front().getType()).getShape();
+  const auto input_shape =
+      mlir::cast<RankedTensorType>(getDpsInputOperand(0)->get().getType())
+          .getShape();
 
-    return op_model::ttnn::ReluOpInterface::getOpRuntime(
-        input_shape, inputs[0], output_shape, output);
+  const auto output_shape =
+      mlir::cast<RankedTensorType>(getResults().front().getType()).getShape();
+
+  return op_model::ttnn::ReluOpInterface::getOpRuntime(input_shape, inputs[0],
+                                                       output_shape, output);
 }
 
 //===----------------------------------------------------------------------===//
@@ -108,7 +108,7 @@ AddOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
 std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
 AddOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                        const TTNNLayoutAttr &output) {
+                    const TTNNLayoutAttr &output) {
   assert(inputs.size() == 2);
 
   const auto input_shape_a =
@@ -122,7 +122,6 @@ AddOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   return op_model::ttnn::AddOpInterface::getOpRuntime(
       input_shape_a, inputs[0], input_shape_b, inputs[1], output_shape, output);
 }
-
 
 //===----------------------------------------------------------------------===//
 // SoftmaxOp - TTNN Op Model Interface
@@ -151,7 +150,7 @@ SoftmaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
 std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
 SoftmaxOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                            const TTNNLayoutAttr &output) {
+                        const TTNNLayoutAttr &output) {
   assert(inputs.size() == 1);
 
   const auto input_shape =
@@ -194,7 +193,7 @@ MatmulOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
 std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
 MatmulOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                           const TTNNLayoutAttr &output) {
+                       const TTNNLayoutAttr &output) {
   assert(inputs.size() == 2);
 
   const auto input_shape_a =

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -46,11 +46,11 @@ ReluOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                          const TTNNLayoutAttr &output) {
   assert(inputs.size() == 1);
 
-  const auto input_shape =
+  const auto inputShape =
       mlir::cast<RankedTensorType>(getDpsInputOperand(0)->get().getType())
           .getShape();
 
-  const auto output_shape =
+  const auto outputShape =
       mlir::cast<RankedTensorType>(getResults().front().getType()).getShape();
 
   auto check = detail::checkDeviceWorkerGrid(getOperation());
@@ -59,7 +59,7 @@ ReluOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   }
 
   return op_model::ttnn::ReluOpInterface::getOpConstraints(
-      input_shape, inputs[0], output_shape, output);
+      inputShape, inputs[0], outputShape, output);
 }
 
 std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
@@ -68,15 +68,15 @@ ReluOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 
   assert(inputs.size() == 1);
 
-  const auto input_shape =
+  const auto inputShape =
       mlir::cast<RankedTensorType>(getDpsInputOperand(0)->get().getType())
           .getShape();
 
-  const auto output_shape =
+  const auto outputShape =
       mlir::cast<RankedTensorType>(getResults().front().getType()).getShape();
 
-  return op_model::ttnn::ReluOpInterface::getOpRuntime(input_shape, inputs[0],
-                                                       output_shape, output);
+  return op_model::ttnn::ReluOpInterface::getOpRuntime(inputShape, inputs[0],
+                                                       outputShape, output);
 }
 
 //===----------------------------------------------------------------------===//
@@ -89,12 +89,12 @@ AddOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                         const TTNNLayoutAttr &output) {
   assert(inputs.size() == 2);
 
-  const auto input_shape_a =
+  const auto inputShapeA =
       mlir::cast<RankedTensorType>(getOperand(0).getType()).getShape();
-  const auto input_shape_b =
+  const auto inputShapeB =
       mlir::cast<RankedTensorType>(getOperand(1).getType()).getShape();
 
-  const auto output_shape =
+  const auto outputShape =
       mlir::cast<RankedTensorType>(getResult(0).getType()).getShape();
 
   auto check = detail::checkDeviceWorkerGrid(getOperation());
@@ -103,7 +103,7 @@ AddOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   }
 
   return op_model::ttnn::AddOpInterface::getOpConstraints(
-      input_shape_a, inputs[0], input_shape_b, inputs[1], output_shape, output);
+      inputShapeA, inputs[0], inputShapeB, inputs[1], outputShape, output);
 }
 
 std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
@@ -111,16 +111,16 @@ AddOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                     const TTNNLayoutAttr &output) {
   assert(inputs.size() == 2);
 
-  const auto input_shape_a =
+  const auto inputShapeA =
       mlir::cast<RankedTensorType>(getOperand(0).getType()).getShape();
-  const auto input_shape_b =
+  const auto inputShapeB =
       mlir::cast<RankedTensorType>(getOperand(1).getType()).getShape();
 
-  const auto output_shape =
+  const auto outputShape =
       mlir::cast<RankedTensorType>(getResult(0).getType()).getShape();
 
   return op_model::ttnn::AddOpInterface::getOpRuntime(
-      input_shape_a, inputs[0], input_shape_b, inputs[1], output_shape, output);
+      inputShapeA, inputs[0], inputShapeB, inputs[1], outputShape, output);
 }
 
 //===----------------------------------------------------------------------===//
@@ -133,10 +133,10 @@ SoftmaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                             const TTNNLayoutAttr &output) {
   assert(inputs.size() == 1);
 
-  const auto input_shape =
+  const auto inputShape =
       mlir::cast<RankedTensorType>(getOperand().getType()).getShape();
 
-  const auto output_shape =
+  const auto outputShape =
       mlir::cast<RankedTensorType>(getResult().getType()).getShape();
 
   auto check = detail::checkDeviceWorkerGrid(getOperation());
@@ -145,7 +145,7 @@ SoftmaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   }
 
   return op_model::ttnn::SoftmaxOpInterface::getOpConstraints(
-      input_shape, inputs[0], getDimension(), output_shape, output);
+      inputShape, inputs[0], getDimension(), outputShape, output);
 }
 
 std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
@@ -153,14 +153,14 @@ SoftmaxOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                         const TTNNLayoutAttr &output) {
   assert(inputs.size() == 1);
 
-  const auto input_shape =
+  const auto inputShape =
       mlir::cast<RankedTensorType>(getOperand().getType()).getShape();
 
-  const auto output_shape =
+  const auto outputShape =
       mlir::cast<RankedTensorType>(getResult().getType()).getShape();
 
   return op_model::ttnn::SoftmaxOpInterface::getOpRuntime(
-      input_shape, inputs[0], getDimension(), output_shape, output);
+      inputShape, inputs[0], getDimension(), outputShape, output);
 }
 
 //===----------------------------------------------------------------------===//
@@ -173,12 +173,12 @@ MatmulOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                            const TTNNLayoutAttr &output) {
   assert(inputs.size() == 2);
 
-  const auto input_shape_a =
+  const auto inputShapeA =
       mlir::cast<RankedTensorType>(getOperand(0).getType()).getShape();
-  const auto input_shape_b =
+  const auto inputShapeB =
       mlir::cast<RankedTensorType>(getOperand(1).getType()).getShape();
 
-  const auto output_shape =
+  const auto outputShape =
       mlir::cast<RankedTensorType>(getResult().getType()).getShape();
 
   auto check = detail::checkDeviceWorkerGrid(getOperation());
@@ -187,7 +187,7 @@ MatmulOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   }
 
   return op_model::ttnn::MatmulOpInterface::getOpConstraints(
-      input_shape_a, inputs[0], input_shape_b, inputs[1], output_shape, output,
+      inputShapeA, inputs[0], inputShapeB, inputs[1], outputShape, output,
       false, false);
 }
 
@@ -196,16 +196,16 @@ MatmulOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                        const TTNNLayoutAttr &output) {
   assert(inputs.size() == 2);
 
-  const auto input_shape_a =
+  const auto inputShapeA =
       mlir::cast<RankedTensorType>(getOperand(0).getType()).getShape();
-  const auto input_shape_b =
+  const auto inputShapeB =
       mlir::cast<RankedTensorType>(getOperand(1).getType()).getShape();
 
-  const auto output_shape =
+  const auto outputShape =
       mlir::cast<RankedTensorType>(getResult().getType()).getShape();
 
   return op_model::ttnn::MatmulOpInterface::getOpRuntime(
-      input_shape_a, inputs[0], input_shape_b, inputs[1], output_shape, output,
+      inputShapeA, inputs[0], inputShapeB, inputs[1], outputShape, output,
       false, false);
 }
 

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -62,6 +62,23 @@ ReluOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       input_shape, inputs[0], output_shape, output);
 }
 
+std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
+ReluOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                 const TTNNLayoutAttr &output) {
+        
+    assert(inputs.size() == 1);
+
+    const auto input_shape =
+        mlir::cast<RankedTensorType>(getDpsInputOperand(0)->get().getType())
+            .getShape();
+
+    const auto output_shape =
+        mlir::cast<RankedTensorType>(getResults().front().getType()).getShape();
+
+    return op_model::ttnn::ReluOpInterface::getOpRuntime(
+        input_shape, inputs[0], output_shape, output);
+}
+
 //===----------------------------------------------------------------------===//
 // AddOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -106,6 +106,24 @@ AddOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       input_shape_a, inputs[0], input_shape_b, inputs[1], output_shape, output);
 }
 
+std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
+AddOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                        const TTNNLayoutAttr &output) {
+  assert(inputs.size() == 2);
+
+  const auto input_shape_a =
+      mlir::cast<RankedTensorType>(getOperand(0).getType()).getShape();
+  const auto input_shape_b =
+      mlir::cast<RankedTensorType>(getOperand(1).getType()).getShape();
+
+  const auto output_shape =
+      mlir::cast<RankedTensorType>(getResult(0).getType()).getShape();
+
+  return op_model::ttnn::AddOpInterface::getOpRuntime(
+      input_shape_a, inputs[0], input_shape_b, inputs[1], output_shape, output);
+}
+
+
 //===----------------------------------------------------------------------===//
 // SoftmaxOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
@@ -128,6 +146,21 @@ SoftmaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   }
 
   return op_model::ttnn::SoftmaxOpInterface::getOpConstraints(
+      input_shape, inputs[0], getDimension(), output_shape, output);
+}
+
+std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
+SoftmaxOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                            const TTNNLayoutAttr &output) {
+  assert(inputs.size() == 1);
+
+  const auto input_shape =
+      mlir::cast<RankedTensorType>(getOperand().getType()).getShape();
+
+  const auto output_shape =
+      mlir::cast<RankedTensorType>(getResult().getType()).getShape();
+
+  return op_model::ttnn::SoftmaxOpInterface::getOpRuntime(
       input_shape, inputs[0], getDimension(), output_shape, output);
 }
 
@@ -155,6 +188,24 @@ MatmulOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   }
 
   return op_model::ttnn::MatmulOpInterface::getOpConstraints(
+      input_shape_a, inputs[0], input_shape_b, inputs[1], output_shape, output,
+      false, false);
+}
+
+std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
+MatmulOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                           const TTNNLayoutAttr &output) {
+  assert(inputs.size() == 2);
+
+  const auto input_shape_a =
+      mlir::cast<RankedTensorType>(getOperand(0).getType()).getShape();
+  const auto input_shape_b =
+      mlir::cast<RankedTensorType>(getOperand(1).getType()).getShape();
+
+  const auto output_shape =
+      mlir::cast<RankedTensorType>(getResult().getType()).getShape();
+
+  return op_model::ttnn::MatmulOpInterface::getOpRuntime(
       input_shape_a, inputs[0], input_shape_b, inputs[1], output_shape, output,
       false, false);
 }

--- a/lib/OpModel/TTNN/MetalHeaders.h
+++ b/lib/OpModel/TTNN/MetalHeaders.h
@@ -58,6 +58,7 @@
 #include "tt-metalium/host_api.hpp"
 #include "ttnn/graph/graph_processor.hpp"
 #include "ttnn/graph/graph_query_op_constraints.hpp"
+#include "ttnn/graph/graph_query_op_runtime.hpp"
 #include "ttnn/graph/graph_trace_utils.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"

--- a/lib/OpModel/TTNN/SingletonDeviceContext.cpp
+++ b/lib/OpModel/TTNN/SingletonDeviceContext.cpp
@@ -31,7 +31,8 @@ SingletonDeviceContext::~SingletonDeviceContext() {
 }
 
 SingletonDeviceContext &SingletonDeviceContext::getInstance() {
-  static SingletonDeviceContext instance = SingletonDeviceContext(OP_MODEL_DEFAULT_TRACE_REGION_SIZE);
+  static SingletonDeviceContext instance =
+      SingletonDeviceContext(OP_MODEL_DEFAULT_TRACE_REGION_SIZE);
   return instance;
 }
 

--- a/lib/OpModel/TTNN/SingletonDeviceContext.cpp
+++ b/lib/OpModel/TTNN/SingletonDeviceContext.cpp
@@ -9,6 +9,9 @@
 
 namespace mlir::tt::op_model::ttnn {
 
+// todo(arminaleTT): look into dynamically adjusting this
+static constexpr size_t OP_MODEL_DEFAULT_TRACE_REGION_SIZE = 200000;
+
 SingletonDeviceContext::SingletonDeviceContext(const size_t trace_region_size) {
 
   // todo: this replicates logic in runtime/include/tt/runtime/detail/common.h,
@@ -28,7 +31,7 @@ SingletonDeviceContext::~SingletonDeviceContext() {
 }
 
 SingletonDeviceContext &SingletonDeviceContext::getInstance() {
-  static SingletonDeviceContext instance = SingletonDeviceContext(200000);
+  static SingletonDeviceContext instance = SingletonDeviceContext(OP_MODEL_DEFAULT_TRACE_REGION_SIZE);
   return instance;
 }
 

--- a/lib/OpModel/TTNN/SingletonDeviceContext.cpp
+++ b/lib/OpModel/TTNN/SingletonDeviceContext.cpp
@@ -10,6 +10,9 @@
 namespace mlir::tt::op_model::ttnn {
 
 // todo(arminaleTT): look into dynamically adjusting this
+// getOpRuntime() uses trace capture to run and measure the runtime of an op.
+// This requires the device to be opened with sufficient trace region size. This
+// number is currently set based on manual testing of supported ops
 static constexpr size_t opModelDefaultTraceRegionSize = 200000;
 
 SingletonDeviceContext::SingletonDeviceContext(const size_t traceRegionSize) {

--- a/lib/OpModel/TTNN/SingletonDeviceContext.cpp
+++ b/lib/OpModel/TTNN/SingletonDeviceContext.cpp
@@ -10,9 +10,9 @@
 namespace mlir::tt::op_model::ttnn {
 
 // todo(arminaleTT): look into dynamically adjusting this
-static constexpr size_t OP_MODEL_DEFAULT_TRACE_REGION_SIZE = 200000;
+static constexpr size_t opModelDefaultTraceRegionSize = 200000;
 
-SingletonDeviceContext::SingletonDeviceContext(const size_t trace_region_size) {
+SingletonDeviceContext::SingletonDeviceContext(const size_t traceRegionSize) {
 
   // todo: this replicates logic in runtime/include/tt/runtime/detail/common.h,
   // move to shared location
@@ -23,7 +23,7 @@ SingletonDeviceContext::SingletonDeviceContext(const size_t trace_region_size) {
                                    : ::tt::tt_metal::DispatchCoreType::ETH;
   m_device = ::tt::tt_metal::CreateDevice(
       0, /* num_hw_cqs = */ 1, /* l1_small_size = */ DEFAULT_L1_SMALL_SIZE,
-      /* trace_region_size = */ trace_region_size, dispatchCoreType);
+      /* trace_region_size = */ traceRegionSize, dispatchCoreType);
 }
 
 SingletonDeviceContext::~SingletonDeviceContext() {
@@ -32,7 +32,7 @@ SingletonDeviceContext::~SingletonDeviceContext() {
 
 SingletonDeviceContext &SingletonDeviceContext::getInstance() {
   static SingletonDeviceContext instance =
-      SingletonDeviceContext(OP_MODEL_DEFAULT_TRACE_REGION_SIZE);
+      SingletonDeviceContext(opModelDefaultTraceRegionSize);
   return instance;
 }
 

--- a/lib/OpModel/TTNN/SingletonDeviceContext.cpp
+++ b/lib/OpModel/TTNN/SingletonDeviceContext.cpp
@@ -9,7 +9,7 @@
 
 namespace mlir::tt::op_model::ttnn {
 
-SingletonDeviceContext::SingletonDeviceContext() {
+SingletonDeviceContext::SingletonDeviceContext(const size_t trace_region_size) {
 
   // todo: this replicates logic in runtime/include/tt/runtime/detail/common.h,
   // move to shared location
@@ -20,7 +20,7 @@ SingletonDeviceContext::SingletonDeviceContext() {
                                    : ::tt::tt_metal::DispatchCoreType::ETH;
   m_device = ::tt::tt_metal::CreateDevice(
       0, /* num_hw_cqs = */ 1, /* l1_small_size = */ DEFAULT_L1_SMALL_SIZE,
-      /* trace_region_size = */ DEFAULT_TRACE_REGION_SIZE, dispatchCoreType);
+      /* trace_region_size = */ trace_region_size, dispatchCoreType);
 }
 
 SingletonDeviceContext::~SingletonDeviceContext() {
@@ -28,7 +28,7 @@ SingletonDeviceContext::~SingletonDeviceContext() {
 }
 
 SingletonDeviceContext &SingletonDeviceContext::getInstance() {
-  static SingletonDeviceContext instance;
+  static SingletonDeviceContext instance = SingletonDeviceContext(200000);
   return instance;
 }
 

--- a/lib/OpModel/TTNN/SingletonDeviceContext.h
+++ b/lib/OpModel/TTNN/SingletonDeviceContext.h
@@ -6,8 +6,8 @@
 #define TTMLIR_OPMODEL_TTNN_SINGLETONDEVICECONTEXT_H
 #ifdef TTMLIR_ENABLE_OPMODEL
 
-#include <cstddef>
 #include "hostdevcommon/common_values.hpp"
+#include <cstddef>
 
 namespace tt {
 namespace tt_metal {
@@ -33,7 +33,8 @@ public:
   ::tt::tt_metal::v0::IDevice *getDevice() { return m_device; }
 
 private:
-  SingletonDeviceContext(const size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE);
+  SingletonDeviceContext(
+      const size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE);
   ~SingletonDeviceContext();
 
   SingletonDeviceContext(const SingletonDeviceContext &) = delete;

--- a/lib/OpModel/TTNN/SingletonDeviceContext.h
+++ b/lib/OpModel/TTNN/SingletonDeviceContext.h
@@ -7,6 +7,7 @@
 #ifdef TTMLIR_ENABLE_OPMODEL
 
 #include <cstddef>
+#include "hostdevcommon/common_values.hpp"
 
 namespace tt {
 namespace tt_metal {
@@ -32,7 +33,7 @@ public:
   ::tt::tt_metal::v0::IDevice *getDevice() { return m_device; }
 
 private:
-  SingletonDeviceContext();
+  SingletonDeviceContext(const size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE);
   ~SingletonDeviceContext();
 
   SingletonDeviceContext(const SingletonDeviceContext &) = delete;

--- a/lib/OpModel/TTNN/TTNNOpModelLib.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModelLib.cpp
@@ -257,7 +257,7 @@ ReluOpInterface::getOpRuntime(
   return operation::getOpRuntime("ReluOpInterface", reluOpQuery, inputShape,
                                      inputLayout, outputShape, outputLayout);
 #else
-  return std::make_tuple(true, std::make_tuple(0, 0, 0), std::nullopt);
+  return std::make_tuple(true, 0, std::nullopt);
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 

--- a/lib/OpModel/TTNN/TTNNOpModelLib.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModelLib.cpp
@@ -207,16 +207,15 @@ Device::getDeviceConstraints(const mlir::tt::GridAttr &workerGrid) {
 //===----------------------------------------------------------------------===//
 std::tuple<bool, std::optional<std::tuple<size_t, size_t, size_t>>,
            std::optional<std::string>>
-ReluOpInterface::getOpConstraints(
-    const ::llvm::ArrayRef<int64_t> &inputShape,
-    const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout,
-    const ::llvm::ArrayRef<int64_t> &outputShape,
-    const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout) {
+ReluOpInterface::getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
+                                  mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+                                  llvm::ArrayRef<int64_t> outputShape,
+                                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  auto reluOpQuery = [](const ::llvm::ArrayRef<int64_t> &inputShape,
-                        const ::mlir::tt::ttnn::TTNNLayoutAttr &inputLayout,
-                        const ::llvm::ArrayRef<int64_t> &outputShape,
-                        const ::mlir::tt::ttnn::TTNNLayoutAttr &outputLayout) {
+  auto reluOpQuery = [](llvm::ArrayRef<int64_t> inputShape,
+                        mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+                        llvm::ArrayRef<int64_t> outputShape,
+                        mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
     // open device device, will close it at the end of function
     ::tt::tt_metal::v0::IDevice *device =
         SingletonDeviceContext::getInstance().getDevice();
@@ -240,16 +239,15 @@ ReluOpInterface::getOpConstraints(
 }
 
 std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
-ReluOpInterface::getOpRuntime(
-    const ::llvm::ArrayRef<int64_t> &inputShape,
-    const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout,
-    const ::llvm::ArrayRef<int64_t> &outputShape,
-    const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout) {
+ReluOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+                              mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+                              llvm::ArrayRef<int64_t> outputShape,
+                              mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  auto reluOpQuery = [](const ::llvm::ArrayRef<int64_t> &inputShape,
-                        const ::mlir::tt::ttnn::TTNNLayoutAttr &inputLayout,
-                        const ::llvm::ArrayRef<int64_t> &outputShape,
-                        const ::mlir::tt::ttnn::TTNNLayoutAttr &outputLayout) {
+  auto reluOpQuery = [](llvm::ArrayRef<int64_t> inputShape,
+                        mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+                        llvm::ArrayRef<int64_t> outputShape,
+                        mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
     // open device device, will close it at the end of function
     ::tt::tt_metal::v0::IDevice *device =
         SingletonDeviceContext::getInstance().getDevice();
@@ -276,20 +274,19 @@ ReluOpInterface::getOpRuntime(
 //===----------------------------------------------------------------------===//
 std::tuple<bool, std::optional<std::tuple<size_t, size_t, size_t>>,
            std::optional<std::string>>
-AddOpInterface::getOpConstraints(
-    const ::llvm::ArrayRef<int64_t> &inputShapeA,
-    const ::mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutA,
-    const ::llvm::ArrayRef<int64_t> &inputShapeB,
-    const ::mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutB,
-    const ::llvm::ArrayRef<int64_t> &outputShape,
-    const ::mlir::tt::ttnn::TTNNLayoutAttr &outputLayout) {
+AddOpInterface::getOpConstraints(llvm::ArrayRef<int64_t> inputShapeA,
+                                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                                 llvm::ArrayRef<int64_t> inputShapeB,
+                                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                                 llvm::ArrayRef<int64_t> outputShape,
+                                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  auto addOpQuery = [](const ::llvm::ArrayRef<int64_t> &inputShapeA,
-                       const ::mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutA,
-                       const ::llvm::ArrayRef<int64_t> &inputShapeB,
-                       const ::mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutB,
-                       const ::llvm::ArrayRef<int64_t> &outputShape,
-                       const ::mlir::tt::ttnn::TTNNLayoutAttr &outputLayout) {
+  auto addOpQuery = [](llvm::ArrayRef<int64_t> inputShapeA,
+                       mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                       llvm::ArrayRef<int64_t> inputShapeB,
+                       mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                       llvm::ArrayRef<int64_t> outputShape,
+                       mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
     // open device device, will close it at the end of function
     ::tt::tt_metal::v0::IDevice *device =
         SingletonDeviceContext::getInstance().getDevice();
@@ -315,20 +312,19 @@ AddOpInterface::getOpConstraints(
 }
 
 std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
-AddOpInterface::getOpRuntime(
-    const ::llvm::ArrayRef<int64_t> &inputShapeA,
-    const ::mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutA,
-    const ::llvm::ArrayRef<int64_t> &inputShapeB,
-    const ::mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutB,
-    const ::llvm::ArrayRef<int64_t> &outputShape,
-    const ::mlir::tt::ttnn::TTNNLayoutAttr &outputLayout) {
+AddOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
+                             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                             llvm::ArrayRef<int64_t> inputShapeB,
+                             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                             llvm::ArrayRef<int64_t> outputShape,
+                             mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  auto addOpQuery = [](const ::llvm::ArrayRef<int64_t> &inputShapeA,
-                       const ::mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutA,
-                       const ::llvm::ArrayRef<int64_t> &inputShapeB,
-                       const ::mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutB,
-                       const ::llvm::ArrayRef<int64_t> &outputShape,
-                       const ::mlir::tt::ttnn::TTNNLayoutAttr &outputLayout) {
+  auto addOpQuery = [](llvm::ArrayRef<int64_t> inputShapeA,
+                       mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                       llvm::ArrayRef<int64_t> inputShapeB,
+                       mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                       llvm::ArrayRef<int64_t> outputShape,
+                       mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
     // open device device, will close it at the end of function
     ::tt::tt_metal::v0::IDevice *device =
         SingletonDeviceContext::getInstance().getDevice();
@@ -359,16 +355,16 @@ AddOpInterface::getOpRuntime(
 std::tuple<bool, std::optional<std::tuple<size_t, size_t, size_t>>,
            std::optional<std::string>>
 SoftmaxOpInterface::getOpConstraints(
-    const llvm::ArrayRef<int64_t> &inputShape,
-    const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout, const int dimArg,
-    const llvm::ArrayRef<int64_t> &outputShape,
-    const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout) {
+    llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayout, const int dimArg,
+    llvm::ArrayRef<int64_t> outputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  auto softmaxOpQuery = [](const llvm::ArrayRef<int64_t> &inputShape,
-                           const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout,
+  auto softmaxOpQuery = [](llvm::ArrayRef<int64_t> inputShape,
+                           mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
                            const int dimArg,
-                           const llvm::ArrayRef<int64_t> &outputShape,
-                           const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout) {
+                           llvm::ArrayRef<int64_t> outputShape,
+                           mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
     // open device device, will close it at the end of function
     ::tt::tt_metal::v0::IDevice *device =
         SingletonDeviceContext::getInstance().getDevice();
@@ -393,17 +389,17 @@ SoftmaxOpInterface::getOpConstraints(
 }
 
 std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
-SoftmaxOpInterface::getOpRuntime(
-    const llvm::ArrayRef<int64_t> &inputShape,
-    const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout, const int dimArg,
-    const llvm::ArrayRef<int64_t> &outputShape,
-    const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout) {
+SoftmaxOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+                                 mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+                                 const int dimArg,
+                                 llvm::ArrayRef<int64_t> outputShape,
+                                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  auto softmaxOpQuery = [](const llvm::ArrayRef<int64_t> &inputShape,
-                           const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout,
+  auto softmaxOpQuery = [](llvm::ArrayRef<int64_t> inputShape,
+                           mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
                            const int dimArg,
-                           const llvm::ArrayRef<int64_t> &outputShape,
-                           const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout) {
+                           llvm::ArrayRef<int64_t> outputShape,
+                           mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
     // open device device, will close it at the end of function
     ::tt::tt_metal::v0::IDevice *device =
         SingletonDeviceContext::getInstance().getDevice();
@@ -431,21 +427,20 @@ SoftmaxOpInterface::getOpRuntime(
 //===----------------------------------------------------------------------===//
 std::tuple<bool, std::optional<std::tuple<size_t, size_t, size_t>>,
            std::optional<std::string>>
-MatmulOpInterface::getOpConstraints(
-    const llvm::ArrayRef<int64_t> &inputShapeA,
-    const mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutA,
-    const llvm::ArrayRef<int64_t> &inputShapeB,
-    const mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutB,
-    const llvm::ArrayRef<int64_t> &outputShape,
-    const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout, bool transposeA,
-    bool transposeB) {
+MatmulOpInterface::getOpConstraints(llvm::ArrayRef<int64_t> inputShapeA,
+                                    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                                    llvm::ArrayRef<int64_t> inputShapeB,
+                                    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                                    llvm::ArrayRef<int64_t> outputShape,
+                                    mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
+                                    bool transposeA, bool transposeB) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  auto matmulOpQuery = [](const llvm::ArrayRef<int64_t> &inputShapeA,
-                          const mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutA,
-                          const llvm::ArrayRef<int64_t> &inputShapeB,
-                          const mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutB,
-                          const llvm::ArrayRef<int64_t> &outputShape,
-                          const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout,
+  auto matmulOpQuery = [](llvm::ArrayRef<int64_t> inputShapeA,
+                          mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                          llvm::ArrayRef<int64_t> inputShapeB,
+                          mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                          llvm::ArrayRef<int64_t> outputShape,
+                          mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
                           bool transposeA, bool transposeB) {
     // open device device, will close it at the end of function
     ::tt::tt_metal::v0::IDevice *device =
@@ -474,21 +469,20 @@ MatmulOpInterface::getOpConstraints(
 }
 
 std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
-MatmulOpInterface::getOpRuntime(
-    const llvm::ArrayRef<int64_t> &inputShapeA,
-    const mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutA,
-    const llvm::ArrayRef<int64_t> &inputShapeB,
-    const mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutB,
-    const llvm::ArrayRef<int64_t> &outputShape,
-    const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout, bool transposeA,
-    bool transposeB) {
+MatmulOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
+                                mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                                llvm::ArrayRef<int64_t> inputShapeB,
+                                mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                                llvm::ArrayRef<int64_t> outputShape,
+                                mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
+                                bool transposeA, bool transposeB) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  auto matmulOpQuery = [](const llvm::ArrayRef<int64_t> &inputShapeA,
-                          const mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutA,
-                          const llvm::ArrayRef<int64_t> &inputShapeB,
-                          const mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutB,
-                          const llvm::ArrayRef<int64_t> &outputShape,
-                          const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout,
+  auto matmulOpQuery = [](llvm::ArrayRef<int64_t> inputShapeA,
+                          mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                          llvm::ArrayRef<int64_t> inputShapeB,
+                          mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                          llvm::ArrayRef<int64_t> outputShape,
+                          mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
                           bool transposeA, bool transposeB) {
     // open device device, will close it at the end of function
     ::tt::tt_metal::v0::IDevice *device =

--- a/lib/OpModel/TTNN/TTNNOpModelLib.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModelLib.cpp
@@ -222,14 +222,14 @@ ReluOpInterface::getOpConstraints(
         SingletonDeviceContext::getInstance().getDevice();
 
     // prepare io specs
-    const auto [input_spec, output_spec] = detail::convertToTensorSpec(
+    const auto [inputSpec, outputSpec] = detail::convertToTensorSpec(
         device, std::make_tuple(inputShape, inputLayout),
         std::make_tuple(outputShape, outputLayout));
 
     // run op constraint query
     return ::ttnn::graph::query_op_constraints(
-        ::ttnn::relu, device, input_spec,
-        output_spec.tensor_layout().get_memory_config());
+        ::ttnn::relu, device, inputSpec,
+        outputSpec.tensor_layout().get_memory_config());
   };
 
   return operation::getOpConstraints("ReluOpInterface", reluOpQuery, inputShape,
@@ -255,13 +255,13 @@ ReluOpInterface::getOpRuntime(
         SingletonDeviceContext::getInstance().getDevice();
 
     // prepare io specs
-    const auto [input_spec, output_spec] = detail::convertToTensorSpec(
+    const auto [inputSpec, outputSpec] = detail::convertToTensorSpec(
         device, std::make_tuple(inputShape, inputLayout),
         std::make_tuple(outputShape, outputLayout));
 
     return ::ttnn::graph::query_op_runtime(
-        ::ttnn::relu, device, input_spec,
-        output_spec.tensor_layout().get_memory_config());
+        ::ttnn::relu, device, inputSpec,
+        outputSpec.tensor_layout().get_memory_config());
   };
 
   return operation::getOpRuntime("ReluOpInterface", reluOpQuery, inputShape,
@@ -277,17 +277,17 @@ ReluOpInterface::getOpRuntime(
 std::tuple<bool, std::optional<std::tuple<size_t, size_t, size_t>>,
            std::optional<std::string>>
 AddOpInterface::getOpConstraints(
-    const ::llvm::ArrayRef<int64_t> &inputShape_a,
-    const ::mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_a,
-    const ::llvm::ArrayRef<int64_t> &inputShape_b,
-    const ::mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_b,
+    const ::llvm::ArrayRef<int64_t> &inputShapeA,
+    const ::mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutA,
+    const ::llvm::ArrayRef<int64_t> &inputShapeB,
+    const ::mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutB,
     const ::llvm::ArrayRef<int64_t> &outputShape,
     const ::mlir::tt::ttnn::TTNNLayoutAttr &outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  auto addOpQuery = [](const ::llvm::ArrayRef<int64_t> &inputShape_a,
-                       const ::mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_a,
-                       const ::llvm::ArrayRef<int64_t> &inputShape_b,
-                       const ::mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_b,
+  auto addOpQuery = [](const ::llvm::ArrayRef<int64_t> &inputShapeA,
+                       const ::mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutA,
+                       const ::llvm::ArrayRef<int64_t> &inputShapeB,
+                       const ::mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutB,
                        const ::llvm::ArrayRef<int64_t> &outputShape,
                        const ::mlir::tt::ttnn::TTNNLayoutAttr &outputLayout) {
     // open device device, will close it at the end of function
@@ -295,20 +295,19 @@ AddOpInterface::getOpConstraints(
         SingletonDeviceContext::getInstance().getDevice();
 
     // prepare io specs
-    const auto [input_spec_a, input_spec_b, output_spec] =
-        detail::convertToTensorSpec(
-            device, std::make_tuple(inputShape_a, inputLayout_a),
-            std::make_tuple(inputShape_b, inputLayout_b),
-            std::make_tuple(outputShape, outputLayout));
+    const auto [inputSpecA, inputSpecB, outputSpec] =
+        detail::convertToTensorSpec(device,
+                                    std::make_tuple(inputShapeA, inputLayoutA),
+                                    std::make_tuple(inputShapeB, inputLayoutB),
+                                    std::make_tuple(outputShape, outputLayout));
 
     return ::ttnn::graph::query_op_constraints(
-        ::ttnn::add, device, input_spec_a, input_spec_b,
-        output_spec.data_type(),
-        output_spec.tensor_layout().get_memory_config());
+        ::ttnn::add, device, inputSpecA, inputSpecB, outputSpec.data_type(),
+        outputSpec.tensor_layout().get_memory_config());
   };
 
-  return operation::getOpConstraints("AddOpInterface", addOpQuery, inputShape_a,
-                                     inputLayout_a, inputShape_b, inputLayout_b,
+  return operation::getOpConstraints("AddOpInterface", addOpQuery, inputShapeA,
+                                     inputLayoutA, inputShapeB, inputLayoutB,
                                      outputShape, outputLayout);
 #else
   return std::make_tuple(false, std::make_tuple(0, 0, 0), std::nullopt);
@@ -317,17 +316,17 @@ AddOpInterface::getOpConstraints(
 
 std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
 AddOpInterface::getOpRuntime(
-    const ::llvm::ArrayRef<int64_t> &inputShape_a,
-    const ::mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_a,
-    const ::llvm::ArrayRef<int64_t> &inputShape_b,
-    const ::mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_b,
+    const ::llvm::ArrayRef<int64_t> &inputShapeA,
+    const ::mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutA,
+    const ::llvm::ArrayRef<int64_t> &inputShapeB,
+    const ::mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutB,
     const ::llvm::ArrayRef<int64_t> &outputShape,
     const ::mlir::tt::ttnn::TTNNLayoutAttr &outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  auto addOpQuery = [](const ::llvm::ArrayRef<int64_t> &inputShape_a,
-                       const ::mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_a,
-                       const ::llvm::ArrayRef<int64_t> &inputShape_b,
-                       const ::mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_b,
+  auto addOpQuery = [](const ::llvm::ArrayRef<int64_t> &inputShapeA,
+                       const ::mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutA,
+                       const ::llvm::ArrayRef<int64_t> &inputShapeB,
+                       const ::mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutB,
                        const ::llvm::ArrayRef<int64_t> &outputShape,
                        const ::mlir::tt::ttnn::TTNNLayoutAttr &outputLayout) {
     // open device device, will close it at the end of function
@@ -335,20 +334,19 @@ AddOpInterface::getOpRuntime(
         SingletonDeviceContext::getInstance().getDevice();
 
     // prepare io specs
-    const auto [input_spec_a, input_spec_b, output_spec] =
-        detail::convertToTensorSpec(
-            device, std::make_tuple(inputShape_a, inputLayout_a),
-            std::make_tuple(inputShape_b, inputLayout_b),
-            std::make_tuple(outputShape, outputLayout));
+    const auto [inputSpecA, inputSpecB, outputSpec] =
+        detail::convertToTensorSpec(device,
+                                    std::make_tuple(inputShapeA, inputLayoutA),
+                                    std::make_tuple(inputShapeB, inputLayoutB),
+                                    std::make_tuple(outputShape, outputLayout));
 
     return ::ttnn::graph::query_op_runtime(
-        ::ttnn::add, device, input_spec_a, input_spec_b,
-        output_spec.data_type(),
-        output_spec.tensor_layout().get_memory_config());
+        ::ttnn::add, device, inputSpecA, inputSpecB, outputSpec.data_type(),
+        outputSpec.tensor_layout().get_memory_config());
   };
 
-  return operation::getOpRuntime("AddOpInterface", addOpQuery, inputShape_a,
-                                 inputLayout_a, inputShape_b, inputLayout_b,
+  return operation::getOpRuntime("AddOpInterface", addOpQuery, inputShapeA,
+                                 inputLayoutA, inputShapeB, inputLayoutB,
                                  outputShape, outputLayout);
 #else
   return std::make_tuple(false, 0, std::nullopt);
@@ -376,14 +374,14 @@ SoftmaxOpInterface::getOpConstraints(
         SingletonDeviceContext::getInstance().getDevice();
 
     // prepare io specs
-    const auto [input_spec, output_spec] = detail::convertToTensorSpec(
+    const auto [inputSpec, outputSpec] = detail::convertToTensorSpec(
         device, std::make_tuple(inputShape, inputLayout),
         std::make_tuple(outputShape, outputLayout));
 
     // run op constraint query
     return ::ttnn::graph::query_op_constraints(
-        ::ttnn::softmax, device, input_spec, dim_arg,
-        output_spec.tensor_layout().get_memory_config());
+        ::ttnn::softmax, device, inputSpec, dim_arg,
+        outputSpec.tensor_layout().get_memory_config());
   };
 
   return operation::getOpConstraints("SoftmaxOpInterface", softmaxOpQuery,
@@ -411,13 +409,13 @@ SoftmaxOpInterface::getOpRuntime(
         SingletonDeviceContext::getInstance().getDevice();
 
     // prepare io specs
-    const auto [input_spec, output_spec] = detail::convertToTensorSpec(
+    const auto [inputSpec, outputSpec] = detail::convertToTensorSpec(
         device, std::make_tuple(inputShape, inputLayout),
         std::make_tuple(outputShape, outputLayout));
 
     return ::ttnn::graph::query_op_runtime(
-        ::ttnn::softmax, device, input_spec, dim_arg,
-        output_spec.tensor_layout().get_memory_config());
+        ::ttnn::softmax, device, inputSpec, dim_arg,
+        outputSpec.tensor_layout().get_memory_config());
   };
 
   return operation::getOpRuntime("SoftmaxOpInterface", softmaxOpQuery,
@@ -434,43 +432,42 @@ SoftmaxOpInterface::getOpRuntime(
 std::tuple<bool, std::optional<std::tuple<size_t, size_t, size_t>>,
            std::optional<std::string>>
 MatmulOpInterface::getOpConstraints(
-    const llvm::ArrayRef<int64_t> &inputShape_a,
-    const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_a,
-    const llvm::ArrayRef<int64_t> &inputShape_b,
-    const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_b,
+    const llvm::ArrayRef<int64_t> &inputShapeA,
+    const mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutA,
+    const llvm::ArrayRef<int64_t> &inputShapeB,
+    const mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutB,
     const llvm::ArrayRef<int64_t> &outputShape,
-    const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout, bool transpose_a,
-    bool transpose_b) {
+    const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout, bool transposeA,
+    bool transposeB) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  auto matmulOpQuery = [](const llvm::ArrayRef<int64_t> &inputShape_a,
-                          const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_a,
-                          const llvm::ArrayRef<int64_t> &inputShape_b,
-                          const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_b,
+  auto matmulOpQuery = [](const llvm::ArrayRef<int64_t> &inputShapeA,
+                          const mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutA,
+                          const llvm::ArrayRef<int64_t> &inputShapeB,
+                          const mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutB,
                           const llvm::ArrayRef<int64_t> &outputShape,
                           const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout,
-                          bool transpose_a, bool transpose_b) {
+                          bool transposeA, bool transposeB) {
     // open device device, will close it at the end of function
     ::tt::tt_metal::v0::IDevice *device =
         SingletonDeviceContext::getInstance().getDevice();
 
     // prepare io specs
-    const auto [input_spec_a, input_spec_b, output_spec] =
-        detail::convertToTensorSpec(
-            device, std::make_tuple(inputShape_a, inputLayout_a),
-            std::make_tuple(inputShape_b, inputLayout_b),
-            std::make_tuple(outputShape, outputLayout));
+    const auto [inputSpecA, inputSpecB, outputSpec] =
+        detail::convertToTensorSpec(device,
+                                    std::make_tuple(inputShapeA, inputLayoutA),
+                                    std::make_tuple(inputShapeB, inputLayoutB),
+                                    std::make_tuple(outputShape, outputLayout));
 
     // run op constraint query
     return ::ttnn::graph::query_op_constraints(
-        ::ttnn::matmul, device, input_spec_a, input_spec_b, transpose_a,
-        transpose_b, output_spec.tensor_layout().get_memory_config(),
-        output_spec.data_type());
+        ::ttnn::matmul, device, inputSpecA, inputSpecB, transposeA, transposeB,
+        outputSpec.tensor_layout().get_memory_config(), outputSpec.data_type());
   };
 
   return operation::getOpConstraints("MatmulOpInterface", matmulOpQuery,
-                                     inputShape_a, inputLayout_a, inputShape_b,
-                                     inputLayout_b, outputShape, outputLayout,
-                                     transpose_a, transpose_b);
+                                     inputShapeA, inputLayoutA, inputShapeB,
+                                     inputLayoutB, outputShape, outputLayout,
+                                     transposeA, transposeB);
 #else
   return std::make_tuple(false, std::make_tuple(0, 0, 0), std::nullopt);
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -478,42 +475,41 @@ MatmulOpInterface::getOpConstraints(
 
 std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
 MatmulOpInterface::getOpRuntime(
-    const llvm::ArrayRef<int64_t> &inputShape_a,
-    const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_a,
-    const llvm::ArrayRef<int64_t> &inputShape_b,
-    const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_b,
+    const llvm::ArrayRef<int64_t> &inputShapeA,
+    const mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutA,
+    const llvm::ArrayRef<int64_t> &inputShapeB,
+    const mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutB,
     const llvm::ArrayRef<int64_t> &outputShape,
-    const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout, bool transpose_a,
-    bool transpose_b) {
+    const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout, bool transposeA,
+    bool transposeB) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  auto matmulOpQuery = [](const llvm::ArrayRef<int64_t> &inputShape_a,
-                          const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_a,
-                          const llvm::ArrayRef<int64_t> &inputShape_b,
-                          const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout_b,
+  auto matmulOpQuery = [](const llvm::ArrayRef<int64_t> &inputShapeA,
+                          const mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutA,
+                          const llvm::ArrayRef<int64_t> &inputShapeB,
+                          const mlir::tt::ttnn::TTNNLayoutAttr &inputLayoutB,
                           const llvm::ArrayRef<int64_t> &outputShape,
                           const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout,
-                          bool transpose_a, bool transpose_b) {
+                          bool transposeA, bool transposeB) {
     // open device device, will close it at the end of function
     ::tt::tt_metal::v0::IDevice *device =
         SingletonDeviceContext::getInstance().getDevice();
 
     // prepare io specs
-    const auto [input_spec_a, input_spec_b, output_spec] =
-        detail::convertToTensorSpec(
-            device, std::make_tuple(inputShape_a, inputLayout_a),
-            std::make_tuple(inputShape_b, inputLayout_b),
-            std::make_tuple(outputShape, outputLayout));
+    const auto [inputSpecA, inputSpecB, outputSpec] =
+        detail::convertToTensorSpec(device,
+                                    std::make_tuple(inputShapeA, inputLayoutA),
+                                    std::make_tuple(inputShapeB, inputLayoutB),
+                                    std::make_tuple(outputShape, outputLayout));
 
     return ::ttnn::graph::query_op_runtime(
-        ::ttnn::matmul, device, input_spec_a, input_spec_b, transpose_a,
-        transpose_b, output_spec.tensor_layout().get_memory_config(),
-        output_spec.data_type());
+        ::ttnn::matmul, device, inputSpecA, inputSpecB, transposeA, transposeB,
+        outputSpec.tensor_layout().get_memory_config(), outputSpec.data_type());
   };
 
   return operation::getOpRuntime("MatmulOpInterface", matmulOpQuery,
-                                 inputShape_a, inputLayout_a, inputShape_b,
-                                 inputLayout_b, outputShape, outputLayout,
-                                 transpose_a, transpose_b);
+                                 inputShapeA, inputLayoutA, inputShapeB,
+                                 inputLayoutB, outputShape, outputLayout,
+                                 transposeA, transposeB);
 #else
   return std::make_tuple(false, 0, std::nullopt);
 #endif // TTMLIR_ENABLE_OPMODEL

--- a/lib/OpModel/TTNN/TTNNOpModelLib.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModelLib.cpp
@@ -360,13 +360,13 @@ std::tuple<bool, std::optional<std::tuple<size_t, size_t, size_t>>,
            std::optional<std::string>>
 SoftmaxOpInterface::getOpConstraints(
     const llvm::ArrayRef<int64_t> &inputShape,
-    const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout, const int dim_arg,
+    const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout, const int dimArg,
     const llvm::ArrayRef<int64_t> &outputShape,
     const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   auto softmaxOpQuery = [](const llvm::ArrayRef<int64_t> &inputShape,
                            const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout,
-                           const int dim_arg,
+                           const int dimArg,
                            const llvm::ArrayRef<int64_t> &outputShape,
                            const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout) {
     // open device device, will close it at the end of function
@@ -380,12 +380,12 @@ SoftmaxOpInterface::getOpConstraints(
 
     // run op constraint query
     return ::ttnn::graph::query_op_constraints(
-        ::ttnn::softmax, device, inputSpec, dim_arg,
+        ::ttnn::softmax, device, inputSpec, dimArg,
         outputSpec.tensor_layout().get_memory_config());
   };
 
   return operation::getOpConstraints("SoftmaxOpInterface", softmaxOpQuery,
-                                     inputShape, inputLayout, dim_arg,
+                                     inputShape, inputLayout, dimArg,
                                      outputShape, outputLayout);
 #else
   return std::make_tuple(true, std::make_tuple(0, 0, 0), std::nullopt);
@@ -395,13 +395,13 @@ SoftmaxOpInterface::getOpConstraints(
 std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
 SoftmaxOpInterface::getOpRuntime(
     const llvm::ArrayRef<int64_t> &inputShape,
-    const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout, const int dim_arg,
+    const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout, const int dimArg,
     const llvm::ArrayRef<int64_t> &outputShape,
     const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   auto softmaxOpQuery = [](const llvm::ArrayRef<int64_t> &inputShape,
                            const mlir::tt::ttnn::TTNNLayoutAttr &inputLayout,
-                           const int dim_arg,
+                           const int dimArg,
                            const llvm::ArrayRef<int64_t> &outputShape,
                            const mlir::tt::ttnn::TTNNLayoutAttr &outputLayout) {
     // open device device, will close it at the end of function
@@ -414,12 +414,12 @@ SoftmaxOpInterface::getOpRuntime(
         std::make_tuple(outputShape, outputLayout));
 
     return ::ttnn::graph::query_op_runtime(
-        ::ttnn::softmax, device, inputSpec, dim_arg,
+        ::ttnn::softmax, device, inputSpec, dimArg,
         outputSpec.tensor_layout().get_memory_config());
   };
 
   return operation::getOpRuntime("SoftmaxOpInterface", softmaxOpQuery,
-                                 inputShape, inputLayout, dim_arg, outputShape,
+                                 inputShape, inputLayout, dimArg, outputShape,
                                  outputLayout);
 #else
   return std::make_tuple(false, 0, std::nullopt);

--- a/lib/OpModel/TTNN/TTNNOpModelLib.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModelLib.cpp
@@ -235,7 +235,7 @@ ReluOpInterface::getOpConstraints(
   return operation::getOpConstraints("ReluOpInterface", reluOpQuery, inputShape,
                                      inputLayout, outputShape, outputLayout);
 #else
-  return std::make_tuple(false, std::make_tuple(0, 0, 0), std::nullopt);
+  return std::make_tuple(true, std::make_tuple(0, 0, 0), std::nullopt);
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
@@ -310,7 +310,7 @@ AddOpInterface::getOpConstraints(
                                      inputLayoutA, inputShapeB, inputLayoutB,
                                      outputShape, outputLayout);
 #else
-  return std::make_tuple(false, std::make_tuple(0, 0, 0), std::nullopt);
+  return std::make_tuple(true, std::make_tuple(0, 0, 0), std::nullopt);
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
@@ -388,7 +388,7 @@ SoftmaxOpInterface::getOpConstraints(
                                      inputShape, inputLayout, dim_arg,
                                      outputShape, outputLayout);
 #else
-  return std::make_tuple(false, std::make_tuple(0, 0, 0), std::nullopt);
+  return std::make_tuple(true, std::make_tuple(0, 0, 0), std::nullopt);
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
@@ -469,7 +469,7 @@ MatmulOpInterface::getOpConstraints(
                                      inputLayoutB, outputShape, outputLayout,
                                      transposeA, transposeB);
 #else
-  return std::make_tuple(false, std::make_tuple(0, 0, 0), std::nullopt);
+  return std::make_tuple(true, std::make_tuple(0, 0, 0), std::nullopt);
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 

--- a/lib/OpModel/TTNN/TTNNOpModelLib.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModelLib.cpp
@@ -170,15 +170,15 @@ template <typename... Args,
                               std::tuple<::llvm::ArrayRef<int64_t>,
                                          ::mlir::tt::ttnn::TTNNLayoutAttr>> &&
                ...)>>
-auto convert_to_tensor_spec(::tt::tt_metal::v0::IDevice *device, Args... args) {
-  auto transform_arg = [device](auto &&arg) {
+auto convertToTensorSpec(::tt::tt_metal::v0::IDevice *device, Args... args) {
+  auto transformArg = [device](auto &&arg) {
     const ::ttnn::TensorSpec spec =
         conversion::getTensorSpec(std::get<0>(arg), std::get<1>(arg));
     detail::checkGrid(device->compute_with_storage_grid_size(),
                       spec.memory_config());
     return spec;
   };
-  return std::make_tuple(transform_arg(std::forward<Args>(args))...);
+  return std::make_tuple(transformArg(std::forward<Args>(args))...);
 }
 } // namespace detail
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -222,7 +222,7 @@ ReluOpInterface::getOpConstraints(
         SingletonDeviceContext::getInstance().getDevice();
 
     // prepare io specs
-    const auto [input_spec, output_spec] = detail::convert_to_tensor_spec(
+    const auto [input_spec, output_spec] = detail::convertToTensorSpec(
         device, std::make_tuple(inputShape, inputLayout),
         std::make_tuple(outputShape, outputLayout));
 
@@ -235,7 +235,7 @@ ReluOpInterface::getOpConstraints(
   return operation::getOpConstraints("ReluOpInterface", reluOpQuery, inputShape,
                                      inputLayout, outputShape, outputLayout);
 #else
-  return std::make_tuple(true, std::make_tuple(0, 0, 0), std::nullopt);
+  return std::make_tuple(false, std::make_tuple(0, 0, 0), std::nullopt);
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
@@ -255,7 +255,7 @@ ReluOpInterface::getOpRuntime(
         SingletonDeviceContext::getInstance().getDevice();
 
     // prepare io specs
-    const auto [input_spec, output_spec] = detail::convert_to_tensor_spec(
+    const auto [input_spec, output_spec] = detail::convertToTensorSpec(
         device, std::make_tuple(inputShape, inputLayout),
         std::make_tuple(outputShape, outputLayout));
 
@@ -267,7 +267,7 @@ ReluOpInterface::getOpRuntime(
   return operation::getOpRuntime("ReluOpInterface", reluOpQuery, inputShape,
                                  inputLayout, outputShape, outputLayout);
 #else
-  return std::make_tuple(true, 0, std::nullopt);
+  return std::make_tuple(false, 0, std::nullopt);
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
@@ -296,7 +296,7 @@ AddOpInterface::getOpConstraints(
 
     // prepare io specs
     const auto [input_spec_a, input_spec_b, output_spec] =
-        detail::convert_to_tensor_spec(
+        detail::convertToTensorSpec(
             device, std::make_tuple(inputShape_a, inputLayout_a),
             std::make_tuple(inputShape_b, inputLayout_b),
             std::make_tuple(outputShape, outputLayout));
@@ -311,7 +311,7 @@ AddOpInterface::getOpConstraints(
                                      inputLayout_a, inputShape_b, inputLayout_b,
                                      outputShape, outputLayout);
 #else
-  return std::make_tuple(true, std::make_tuple(0, 0, 0), std::nullopt);
+  return std::make_tuple(false, std::make_tuple(0, 0, 0), std::nullopt);
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
@@ -336,7 +336,7 @@ AddOpInterface::getOpRuntime(
 
     // prepare io specs
     const auto [input_spec_a, input_spec_b, output_spec] =
-        detail::convert_to_tensor_spec(
+        detail::convertToTensorSpec(
             device, std::make_tuple(inputShape_a, inputLayout_a),
             std::make_tuple(inputShape_b, inputLayout_b),
             std::make_tuple(outputShape, outputLayout));
@@ -351,7 +351,7 @@ AddOpInterface::getOpRuntime(
                                  inputLayout_a, inputShape_b, inputLayout_b,
                                  outputShape, outputLayout);
 #else
-  return std::make_tuple(true, 0, std::nullopt);
+  return std::make_tuple(false, 0, std::nullopt);
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
@@ -376,7 +376,7 @@ SoftmaxOpInterface::getOpConstraints(
         SingletonDeviceContext::getInstance().getDevice();
 
     // prepare io specs
-    const auto [input_spec, output_spec] = detail::convert_to_tensor_spec(
+    const auto [input_spec, output_spec] = detail::convertToTensorSpec(
         device, std::make_tuple(inputShape, inputLayout),
         std::make_tuple(outputShape, outputLayout));
 
@@ -390,7 +390,7 @@ SoftmaxOpInterface::getOpConstraints(
                                      inputShape, inputLayout, dim_arg,
                                      outputShape, outputLayout);
 #else
-  return std::make_tuple(true, std::make_tuple(0, 0, 0), std::nullopt);
+  return std::make_tuple(false, std::make_tuple(0, 0, 0), std::nullopt);
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
@@ -411,7 +411,7 @@ SoftmaxOpInterface::getOpRuntime(
         SingletonDeviceContext::getInstance().getDevice();
 
     // prepare io specs
-    const auto [input_spec, output_spec] = detail::convert_to_tensor_spec(
+    const auto [input_spec, output_spec] = detail::convertToTensorSpec(
         device, std::make_tuple(inputShape, inputLayout),
         std::make_tuple(outputShape, outputLayout));
 
@@ -424,7 +424,7 @@ SoftmaxOpInterface::getOpRuntime(
                                  inputShape, inputLayout, dim_arg, outputShape,
                                  outputLayout);
 #else
-  return std::make_tuple(true, 0, std::nullopt);
+  return std::make_tuple(false, 0, std::nullopt);
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
@@ -455,7 +455,7 @@ MatmulOpInterface::getOpConstraints(
 
     // prepare io specs
     const auto [input_spec_a, input_spec_b, output_spec] =
-        detail::convert_to_tensor_spec(
+        detail::convertToTensorSpec(
             device, std::make_tuple(inputShape_a, inputLayout_a),
             std::make_tuple(inputShape_b, inputLayout_b),
             std::make_tuple(outputShape, outputLayout));
@@ -472,7 +472,7 @@ MatmulOpInterface::getOpConstraints(
                                      inputLayout_b, outputShape, outputLayout,
                                      transpose_a, transpose_b);
 #else
-  return std::make_tuple(true, std::make_tuple(0, 0, 0), std::nullopt);
+  return std::make_tuple(false, std::make_tuple(0, 0, 0), std::nullopt);
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
@@ -499,7 +499,7 @@ MatmulOpInterface::getOpRuntime(
 
     // prepare io specs
     const auto [input_spec_a, input_spec_b, output_spec] =
-        detail::convert_to_tensor_spec(
+        detail::convertToTensorSpec(
             device, std::make_tuple(inputShape_a, inputLayout_a),
             std::make_tuple(inputShape_b, inputLayout_b),
             std::make_tuple(outputShape, outputLayout));
@@ -515,7 +515,7 @@ MatmulOpInterface::getOpRuntime(
                                  inputLayout_b, outputShape, outputLayout,
                                  transpose_a, transpose_b);
 #else
-  return std::make_tuple(true, 0, std::nullopt);
+  return std::make_tuple(false, 0, std::nullopt);
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -30,6 +30,7 @@ TEST_F(OpModelTest, ReluInterleaved) {
   size_t cb_size = 0;
   size_t peak_size = 0;
   size_t output_size = 0;
+  std::optional<size_t> runtime = 0;
 
   std::tie(legal, errorMsg) = Device::getDeviceConstraints(workerGrid);
   EXPECT_TRUE(legal);
@@ -43,6 +44,14 @@ TEST_F(OpModelTest, ReluInterleaved) {
   EXPECT_EQ(cb_size, 8192);
   EXPECT_EQ(output_size, 0);
   EXPECT_EQ(peak_size, 0);
+
+  std::tie(legal, runtime, errorMsg) = ReluOpInterface::getOpRuntime(
+      tensorShape, inputLayout_dram, tensorShape, inputLayout_dram);
+  EXPECT_TRUE(legal);
+  EXPECT_TRUE(runtime.has_value());
+  EXPECT_FALSE(errorMsg.has_value());
+  EXPECT_TRUE(runtime.value() > 0);
+  std::cout<<"Armin\n";
 
   std::tie(legal, l1Usage, errorMsg) = ReluOpInterface::getOpConstraints(
       tensorShape, inputLayout_dram, tensorShape, inputLayout_l1);

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -224,7 +224,7 @@ TEST_F(OpModelTest, SoftmaxInterleaved) {
                              {inputLayout_l1, inputLayout_l1}};
   for (const auto &[input_layout, output_layout] : layout_combinations) {
     std::tie(legal, runtime, errorMsg) = SoftmaxOpInterface::getOpRuntime(
-        tensorShape, input_layout,-1, tensorShape, output_layout);
+        tensorShape, input_layout, -1, tensorShape, output_layout);
     EXPECT_TRUE(legal);
     EXPECT_TRUE(runtime.has_value());
     EXPECT_FALSE(errorMsg.has_value());

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -99,9 +99,9 @@ TEST_F(OpModelBase, ReluInterface) {
   relu->setAttr(DeviceAttr::name, getFakeDeviceAttr());
 
   // test ReluOp interface
-  auto constraints_opt = getOpConstraints(relu.getOperation());
-  if (constraints_opt.has_value()) {
-    auto constraints = constraints_opt.value();
+  auto constraintsOpt = getOpConstraints(relu.getOperation());
+  if (constraintsOpt.has_value()) {
+    auto constraints = constraintsOpt.value();
     EXPECT_EQ(std::get<bool>(constraints), true);
     auto l1 = std::get<1>(constraints);
     if (l1.has_value()) {
@@ -117,9 +117,9 @@ TEST_F(OpModelBase, ReluInterface) {
     FAIL() << "Failed to cast ReluOp to OpModel";
   }
 
-  auto runtime_opt = getOpRuntime(relu.getOperation());
-  if (runtime_opt.has_value()) {
-    auto runtime = runtime_opt.value();
+  auto runtimeOpt = getOpRuntime(relu.getOperation());
+  if (runtimeOpt.has_value()) {
+    auto runtime = runtimeOpt.value();
     EXPECT_TRUE(std::get<0>(runtime));
     EXPECT_TRUE(std::get<1>(runtime).has_value());
     EXPECT_TRUE(std::get<1>(runtime).value() > 0);
@@ -140,9 +140,9 @@ TEST_F(OpModelBase, SoftmaxInterface) {
   softmax->setAttr(DeviceAttr::name, getFakeDeviceAttr());
 
   // test SoftmaxOp interface
-  auto value = getOpConstraints(softmax.getOperation());
-  if (value.has_value()) {
-    auto constraints = value.value();
+  auto constraintsOpt = getOpConstraints(softmax.getOperation());
+  if (constraintsOpt.has_value()) {
+    auto constraints = constraintsOpt.value();
     EXPECT_EQ(std::get<bool>(constraints), true);
     auto l1 = std::get<1>(constraints);
     if (l1.has_value()) {
@@ -157,9 +157,9 @@ TEST_F(OpModelBase, SoftmaxInterface) {
     FAIL() << "Failed to cast SoftmaxOp to OpModel";
   }
 
-  auto runtime_opt = getOpRuntime(softmax.getOperation());
-  if (runtime_opt.has_value()) {
-    auto runtime = runtime_opt.value();
+  auto runtimeOpt = getOpRuntime(softmax.getOperation());
+  if (runtimeOpt.has_value()) {
+    auto runtime = runtimeOpt.value();
     EXPECT_TRUE(std::get<0>(runtime));
     EXPECT_TRUE(std::get<1>(runtime).has_value());
     EXPECT_TRUE(std::get<1>(runtime).value() > 0);
@@ -182,9 +182,9 @@ TEST_F(OpModelBase, AddInterface) {
   add->setAttr(DeviceAttr::name, getFakeDeviceAttr());
 
   // test AddOp interface
-  auto value = getOpConstraints(add.getOperation());
-  if (value.has_value()) {
-    auto constraints = value.value();
+  auto constraintsOpt = getOpConstraints(add.getOperation());
+  if (constraintsOpt.has_value()) {
+    auto constraints = constraintsOpt.value();
     EXPECT_EQ(std::get<bool>(constraints), true);
     auto l1 = std::get<1>(constraints);
     if (l1.has_value()) {
@@ -199,9 +199,9 @@ TEST_F(OpModelBase, AddInterface) {
     FAIL() << "Failed to cast AddOp to OpModel";
   }
 
-  auto runtime_opt = getOpRuntime(add.getOperation());
-  if (runtime_opt.has_value()) {
-    auto runtime = runtime_opt.value();
+  auto runtimeOpt = getOpRuntime(add.getOperation());
+  if (runtimeOpt.has_value()) {
+    auto runtime = runtimeOpt.value();
     EXPECT_TRUE(std::get<0>(runtime));
     EXPECT_TRUE(std::get<1>(runtime).has_value());
     EXPECT_TRUE(std::get<1>(runtime).value() > 0);
@@ -227,9 +227,9 @@ TEST_F(OpModelBase, MatmulInterface) {
   matmul->setAttr(DeviceAttr::name, getFakeDeviceAttr());
 
   // test MatmulOp interface
-  auto value = getOpConstraints(matmul.getOperation());
-  if (value.has_value()) {
-    auto constraints = value.value();
+  auto constraintsOpt = getOpConstraints(matmul.getOperation());
+  if (constraintsOpt.has_value()) {
+    auto constraints = constraintsOpt.value();
     EXPECT_EQ(std::get<bool>(constraints), true);
     auto l1 = std::get<1>(constraints);
     if (l1.has_value()) {
@@ -244,9 +244,9 @@ TEST_F(OpModelBase, MatmulInterface) {
     FAIL() << "Failed to cast MatmulOp to OpModel";
   }
 
-  auto runtime_opt = getOpRuntime(matmul.getOperation());
-  if (runtime_opt.has_value()) {
-    auto runtime = runtime_opt.value();
+  auto runtimeOpt = getOpRuntime(matmul.getOperation());
+  if (runtimeOpt.has_value()) {
+    auto runtime = runtimeOpt.value();
     EXPECT_TRUE(std::get<0>(runtime));
     EXPECT_TRUE(std::get<1>(runtime).has_value());
     EXPECT_TRUE(std::get<1>(runtime).value() > 0);

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -17,15 +17,29 @@ namespace mlir::tt::ttnn {
 
 class OpModelBase : public OpModelFixture {
 public:
-  // helper function to extract op data and call into get op constraints
   std::optional<
       std::tuple<bool, std::optional<std::tuple<size_t, size_t, size_t>>,
                  std::optional<std::string>>>
   getOpConstraints(Operation *op) {
+    if (OpModel backend = dyn_cast<OpModel>(op)) {
+      return backend.getOpConstraints(getInputLayouts(op), getOutputLayout(op));
+    }
+    return std::nullopt;
+  }
+
+  std::optional<
+      std::tuple<bool, std::optional<size_t>, std::optional<std::string>>>
+  getOpRuntime(Operation *op) {
+    if (OpModel backend = dyn_cast<OpModel>(op)) {
+      return backend.getOpRuntime(getInputLayouts(op), getOutputLayout(op));
+    }
+    return std::nullopt;
+  }
+
+  std::vector<TTNNLayoutAttr> getInputLayouts(Operation *op) {
     std::vector<TTNNLayoutAttr> inputs;
 
     // TODO(odjuricic): check for DPS explicitly.
-    // create input layouts
     auto numOperand = op->getNumOperands();
     // some ops have multiple operands
     auto limit = (numOperand > 1) ? numOperand - 1 : numOperand;
@@ -37,20 +51,15 @@ public:
                                            TensorMemoryLayout::Interleaved);
       inputs.push_back(inputLayout);
     }
+    return inputs;
+  }
 
-    // create output layout
+  mlir::tt::ttnn::TTNNLayoutAttr getOutputLayout(Operation *op) {
     auto output = op->getResult(0);
     auto outputShape =
         mlir::cast<RankedTensorType>(output.getType()).getShape();
-    auto outputLayout = CreateTiledLayout(outputShape, BufferType::L1,
-                                          TensorMemoryLayout::Interleaved);
-
-    // call op model interface - getOpConstraints()
-    if (OpModel backend = dyn_cast<OpModel>(op)) {
-      auto constraints = backend.getOpConstraints(inputs, outputLayout);
-      return constraints;
-    }
-    return std::nullopt;
+    return CreateTiledLayout(outputShape, BufferType::L1,
+                             TensorMemoryLayout::Interleaved);
   }
 
   mlir::tt::DeviceAttr getFakeDeviceAttr() {
@@ -90,9 +99,9 @@ TEST_F(OpModelBase, ReluInterface) {
   relu->setAttr(DeviceAttr::name, getFakeDeviceAttr());
 
   // test ReluOp interface
-  auto value = getOpConstraints(relu.getOperation());
-  if (value.has_value()) {
-    auto constraints = value.value();
+  auto constraints_opt = getOpConstraints(relu.getOperation());
+  if (constraints_opt.has_value()) {
+    auto constraints = constraints_opt.value();
     EXPECT_EQ(std::get<bool>(constraints), true);
     auto l1 = std::get<1>(constraints);
     if (l1.has_value()) {
@@ -104,6 +113,17 @@ TEST_F(OpModelBase, ReluInterface) {
       FAIL() << "Missing L1 constraints; Error="
              << std::get<2>(constraints).value() << std::endl;
     }
+  } else {
+    FAIL() << "Failed to cast ReluOp to OpModel";
+  }
+
+  auto runtime_opt = getOpRuntime(relu.getOperation());
+  if (runtime_opt.has_value()) {
+    auto runtime = runtime_opt.value();
+    EXPECT_TRUE(std::get<0>(runtime));
+    EXPECT_TRUE(std::get<1>(runtime).has_value());
+    EXPECT_TRUE(std::get<1>(runtime).value() > 0);
+    EXPECT_FALSE(std::get<2>(runtime).has_value());
   } else {
     FAIL() << "Failed to cast ReluOp to OpModel";
   }
@@ -134,7 +154,18 @@ TEST_F(OpModelBase, SoftmaxInterface) {
       FAIL() << "Missing L1 constraints";
     }
   } else {
-    FAIL() << "Failed to cast ReluOp to OpModel";
+    FAIL() << "Failed to cast SoftmaxOp to OpModel";
+  }
+
+  auto runtime_opt = getOpRuntime(softmax.getOperation());
+  if (runtime_opt.has_value()) {
+    auto runtime = runtime_opt.value();
+    EXPECT_TRUE(std::get<0>(runtime));
+    EXPECT_TRUE(std::get<1>(runtime).has_value());
+    EXPECT_TRUE(std::get<1>(runtime).value() > 0);
+    EXPECT_FALSE(std::get<2>(runtime).has_value());
+  } else {
+    FAIL() << "Failed to cast SoftmaxOp to OpModel";
   }
 }
 
@@ -165,7 +196,18 @@ TEST_F(OpModelBase, AddInterface) {
       FAIL() << "Missing L1 constraints";
     }
   } else {
-    FAIL() << "Failed to cast ReluOp to OpModel";
+    FAIL() << "Failed to cast AddOp to OpModel";
+  }
+
+  auto runtime_opt = getOpRuntime(add.getOperation());
+  if (runtime_opt.has_value()) {
+    auto runtime = runtime_opt.value();
+    EXPECT_TRUE(std::get<0>(runtime));
+    EXPECT_TRUE(std::get<1>(runtime).has_value());
+    EXPECT_TRUE(std::get<1>(runtime).value() > 0);
+    EXPECT_FALSE(std::get<2>(runtime).has_value());
+  } else {
+    FAIL() << "Failed to cast AddOp to OpModel";
   }
 }
 
@@ -199,7 +241,18 @@ TEST_F(OpModelBase, MatmulInterface) {
       FAIL() << "Missing L1 constraints";
     }
   } else {
-    FAIL() << "Failed to cast ReluOp to OpModel";
+    FAIL() << "Failed to cast MatmulOp to OpModel";
+  }
+
+  auto runtime_opt = getOpRuntime(matmul.getOperation());
+  if (runtime_opt.has_value()) {
+    auto runtime = runtime_opt.value();
+    EXPECT_TRUE(std::get<0>(runtime));
+    EXPECT_TRUE(std::get<1>(runtime).has_value());
+    EXPECT_TRUE(std::get<1>(runtime).value() > 0);
+    EXPECT_FALSE(std::get<2>(runtime).has_value());
+  } else {
+    FAIL() << "Failed to cast MatmulOp to OpModel";
   }
 }
 


### PR DESCRIPTION
### Ticket
#2002 

### Problem Description
Enable compile time op runtime estimation for ops that already support constraints and L1 estimation
Builds on APIs from tt-metal in [#16921](https://github.com/tenstorrent/tt-metal/pull/16921)

Create a `getOpRuntime` API for ReLu, Softmax, Matmul, and add which:
- matches the interface of the `getOpConstraints` API
- translates ttmlir types to ttnn/metal types
- connects to the underlying API in tt-metal to run the op via trace capture and obtain a runtime estimate

### What's Changed
- Added `getOpRuntime` API to ReLu, Softmax, Matmul, and add
  - API exactly matches the interface and structure of the `getOpConstraints` API 
- Added unit tests 
- Small refactors to reduce code duplication between getOpConstraints and getOpRuntime

There is a big opportunity to refactor the unit tests, but this PR is getting long. I will do that separately