### PR TITLE
Flatten and Reshape Golden Tensors

### DIFF
--- a/python/test_infra/ttir_builder.py
+++ b/python/test_infra/ttir_builder.py
@@ -86,6 +86,9 @@ class Golden:
         s += f"\nGolden tensor:\n{self.tensor}"
         return s
 
+    def contiguous(self) -> Golden:
+        return Golden(self.tensor.contiguous())
+
 
 class TTIRBuilder:
     """Builder class providing API for creating TTIR ops."""
@@ -168,6 +171,7 @@ class TTIRBuilder:
     def get_golden_map(self) -> Dict:
         golden_info = {}
         for name, golden_tensor in self.id_golden_map.items():
+            golden_tensor = golden_tensor.contiguous()
             golden_info[name] = create_golden_tensor(
                 name,
                 list(golden_tensor.tensor.shape),

--- a/runtime/tools/python/ttrt/common/util.py
+++ b/runtime/tools/python/ttrt/common/util.py
@@ -621,8 +621,11 @@ class Binary(Flatbuffer):
         def populate_inputs(self, init_fn, golden_inputs=[]):
             if len(golden_inputs) > 0:
                 assert len(golden_inputs) == len(self.program["inputs"])
-                for golden_input in golden_inputs:
-                    self.input_tensors.append(golden_input)
+                for index, input_fb in enumerate(self.program["inputs"]):
+                    reshaped = torch.reshape(
+                        golden_inputs[index], input_fb["desc"]["shape"]
+                    )
+                    self.input_tensors.append(reshaped)
             else:
                 for i in self.program["inputs"]:
                     torch_tensor = init_fn(


### PR DESCRIPTION
This change (originally authored by @tapspatel) implements some flattening and unflattening logic for golden tensors across the flatbuffer barrier. This is a temporary strategy and will be rolled back once multidimensonal flatbuffer arrays are implemented for our schema.