### PR TITLE
Remove stride from flatbuffer

### DIFF
--- a/include/ttmlir/Target/Common/types.fbs
+++ b/include/ttmlir/Target/Common/types.fbs
@@ -134,7 +134,6 @@ table MemoryDesc {
 }
 
 table LayoutDesc {
-  stride: [int];
   oob_val: OOBVal;
   core_range_set: [Dim2dRange];
   memory_desc: MemoryDesc;

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -65,12 +65,10 @@ memrefAttrToFlatbuffer(FlatbufferObjectCache &cache, MemRefType memref,
 flatbuffers::Offset<::tt::target::LayoutDesc> metalLayoutAttrToFlatbuffer(
     FlatbufferObjectCache &cache, MetalLayoutAttr metalLayoutAttr,
     ArrayRef<int64_t> logicalShape, DeviceAttr deviceAttr) {
-  auto strideInt64 = metalLayoutAttr.getStride(logicalShape);
-  std::vector<int32_t> stride(strideInt64.begin(), strideInt64.end());
   auto coreRangeSet = toFlatbuffer(cache, metalLayoutAttr.getGrid(),
                                    deviceAttr.getWorkerGrid());
   return ::tt::target::CreateLayoutDescDirect(
-      *cache.fbb, &stride, toFlatbuffer(cache, metalLayoutAttr.getOobVal()),
+      *cache.fbb, toFlatbuffer(cache, metalLayoutAttr.getOobVal()),
       &coreRangeSet,
       cache.getOrCreate(metalLayoutAttr.getMemref(), memrefAttrToFlatbuffer,
                         metalLayoutAttr.getMemLayout()));

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -105,12 +105,10 @@ memrefAttrToFlatbuffer(FlatbufferObjectCache &cache, mlir::MemRefType memref,
 flatbuffers::Offset<::tt::target::LayoutDesc> ttnnLayoutAttrToFlatbuffer(
     FlatbufferObjectCache &cache, ttnn::TTNNLayoutAttr layoutAttr,
     mlir::ArrayRef<int64_t> logicalShape, DeviceAttr deviceAttr) {
-  auto strideInt64 = layoutAttr.getStride(logicalShape);
-  std::vector<int32_t> stride(strideInt64.begin(), strideInt64.end());
   auto coreRangeSet =
       toFlatbuffer(cache, layoutAttr.getGrid(), deviceAttr.getWorkerGrid());
   return ::tt::target::CreateLayoutDescDirect(
-      *cache.fbb, &stride, toFlatbuffer(cache, OOBVal::Undef), &coreRangeSet,
+      *cache.fbb, toFlatbuffer(cache, OOBVal::Undef), &coreRangeSet,
       cache.getOrCreate(layoutAttr.getMemref(), memrefAttrToFlatbuffer,
                         layoutAttr.getMemLayout()));
 }

--- a/runtime/include/tt/runtime/detail/workarounds.h
+++ b/runtime/include/tt/runtime/detail/workarounds.h
@@ -17,12 +17,12 @@ struct Env {
 #endif
   get(bool maxpool2dPreshard = true, bool swapBinaryOperands = true,
       bool readUpdateIndexFromDeviceForKVCache = true,
-      bool toDtypeOnHost = true)
+      bool toDtypeOnHost = true, bool defaultStrideComputation = true)
 #if defined(TT_RUNTIME_WORKAROUNDS) && TT_RUNTIME_WORKAROUNDS == 1
       ;
 #else
   {
-    return Env(true, true, true, true);
+    return Env(true, true, true, true, true);
   }
 #endif
   // TODO(bug #855): Ideally we should have an op that preshards for maxpool2d
@@ -45,14 +45,23 @@ struct Env {
   // to handle this, we should remove this workaround.
   bool toDtypeOnHost;
 
+  // TODO(bug #2045): Our current stride calculation is incorrect for tilized
+  // tensors. The current solution is to remove stride entirely from the
+  // flatbuffer and calculate the stride in runtime assuming using the default
+  // method ignoring details like grid, layout etc. Once we have a more
+  // sophisticated way for handling this, we can remove this workaround.
+  bool defaultStrideComputation;
+
 private:
   constexpr Env(bool maxpool2dPreshard, bool swapBinaryOperands,
-                bool readUpdateIndexFromDeviceForKVCache, bool toDtypeOnHost)
+                bool readUpdateIndexFromDeviceForKVCache, bool toDtypeOnHost,
+                bool defaultStrideComputation)
       : maxpool2dPreshard(maxpool2dPreshard),
         swapBinaryOperands(swapBinaryOperands),
         readUpdateIndexFromDeviceForKVCache(
             readUpdateIndexFromDeviceForKVCache),
-        toDtypeOnHost(toDtypeOnHost) {}
+        toDtypeOnHost(toDtypeOnHost),
+        defaultStrideComputation(defaultStrideComputation) {}
 };
 
 inline std::ostream &operator<<(std::ostream &os, const Env &env) {
@@ -66,6 +75,8 @@ inline std::ostream &operator<<(std::ostream &os, const Env &env) {
      << env.readUpdateIndexFromDeviceForKVCache << "\n";
   os << "\t"
      << "toDtypeOnHost: " << env.toDtypeOnHost << "\n";
+  os << "\t"
+     << "defaultStrideComputation: " << env.defaultStrideComputation << "\n";
   os << "}";
   return os;
 }

--- a/runtime/lib/binary.cpp
+++ b/runtime/lib/binary.cpp
@@ -7,6 +7,7 @@
 #include "flatbuffers/idl.h"
 
 #include "tt/runtime/detail/logger.h"
+#include "tt/runtime/detail/workarounds.h"
 #include "tt/runtime/types.h"
 #include "tt/runtime/utils.h"
 #include "ttmlir/Target/Common/system_desc_bfbs_generated.h"
@@ -34,6 +35,20 @@ static std::string asJson(void const *fbb, uint8_t const *binarySchema,
   const char *err = ::flatbuffers::GenerateText(parser, fbb, &text);
   LOG_ASSERT(not err, "Failed to generate JSON: ", err);
   return text;
+}
+
+static std::vector<uint32_t>
+calculateStride(std::vector<uint32_t> const &shape) {
+  LOG_ASSERT(
+      workaround::Env::get().defaultStrideComputation,
+      "Stride currently removed from flatbuffer thus defaultStrideComputation"
+      "workaround must be enabled");
+  LOG_ASSERT(!shape.empty());
+  std::vector<uint32_t> stride(shape.size(), 1);
+  for (size_t i = shape.size() - 1; i > 0; i--) {
+    stride[i - 1] = stride[i] * shape[i];
+  }
+  return stride;
 }
 
 namespace ttnn {
@@ -70,8 +85,7 @@ std::vector<TensorDesc> getProgramInputs(Flatbuffer binary,
     TensorDesc desc;
     desc.shape = {input->desc()->shape()->begin(),
                   input->desc()->shape()->end()};
-    desc.stride = {input->desc()->layout()->stride()->begin(),
-                   input->desc()->layout()->stride()->end()};
+    desc.stride = calculateStride(desc.shape);
     desc.itemsize = ::tt::runtime::utils::dataTypeElementSize(
         input->desc()->layout()->memory_desc()->data_type());
     desc.dataType = input->desc()->layout()->memory_desc()->data_type();
@@ -88,8 +102,7 @@ std::vector<TensorDesc> getProgramOutputs(Flatbuffer binary,
     TensorDesc desc;
     desc.shape = {output->desc()->shape()->begin(),
                   output->desc()->shape()->end()};
-    desc.stride = {output->desc()->layout()->stride()->begin(),
-                   output->desc()->layout()->stride()->end()};
+    desc.stride = calculateStride(desc.shape);
     desc.itemsize = ::tt::runtime::utils::dataTypeElementSize(
         output->desc()->layout()->memory_desc()->data_type());
     desc.dataType = output->desc()->layout()->memory_desc()->data_type();
@@ -156,8 +169,7 @@ std::vector<TensorDesc> getProgramInputs(Flatbuffer binary,
     TensorDesc desc;
     desc.shape = {input->desc()->shape()->begin(),
                   input->desc()->shape()->end()};
-    desc.stride = {input->desc()->layout()->stride()->begin(),
-                   input->desc()->layout()->stride()->end()};
+    desc.stride = calculateStride(desc.shape);
     desc.itemsize = utils::dataTypeElementSize(
         input->desc()->layout()->memory_desc()->data_type());
     desc.dataType = input->desc()->layout()->memory_desc()->data_type();
@@ -177,8 +189,7 @@ std::vector<TensorDesc> getProgramOutputs(Flatbuffer binary,
     TensorDesc desc;
     desc.shape = {output->desc()->shape()->begin(),
                   output->desc()->shape()->end()};
-    desc.stride = {output->desc()->layout()->stride()->begin(),
-                   output->desc()->layout()->stride()->end()};
+    desc.stride = calculateStride(desc.shape);
     desc.itemsize = utils::dataTypeElementSize(
         output->desc()->layout()->memory_desc()->data_type());
     desc.dataType = output->desc()->layout()->memory_desc()->data_type();

--- a/runtime/lib/common/workarounds.cpp
+++ b/runtime/lib/common/workarounds.cpp
@@ -8,9 +8,10 @@ namespace tt::runtime::workaround {
 #if defined(TT_RUNTIME_WORKAROUNDS) && TT_RUNTIME_WORKAROUNDS == 1
 const Env &Env::get(bool maxpool2dPreshard, bool swapBinaryOperands,
                     bool readUpdateIndexFromDeviceForKVCache,
-                    bool toDtypeOnHost) {
+                    bool toDtypeOnHost, bool defaultStrideComputation) {
   static const Env config(maxpool2dPreshard, swapBinaryOperands,
-                          readUpdateIndexFromDeviceForKVCache, toDtypeOnHost);
+                          readUpdateIndexFromDeviceForKVCache, toDtypeOnHost,
+                          defaultStrideComputation);
   return config;
 }
 #endif

--- a/runtime/tools/python/ttrt/common/run.py
+++ b/runtime/tools/python/ttrt/common/run.py
@@ -148,6 +148,13 @@ class Run:
             help="disable to_dtype on host workaround",
         )
         Run.register_arg(
+            name="--disable-default-stride-computation",
+            type=bool,
+            default=False,
+            choices=[True, False],
+            help="disable runtime default stride computation workaround",
+        )
+        Run.register_arg(
             name="--result-file",
             type=str,
             default="run_results.json",
@@ -394,6 +401,7 @@ class Run:
                 not self["--disable-swap-binary-operands"],
                 not self["--disable-read-update-index-for-kv-cache"],
                 not self["--disable-to-dtype-on-host"],
+                not self["--disable-default-stride-computation"],
             )
             self.logging.debug(f"setting tt runtime workaround env={workaround_env}")
             self.logging.debug(f"setting torch manual seed={self['--seed']}")


### PR DESCRIPTION
Remove stride from flatbuffer, as they will not be valid for tilized tensors, we'll need a more sophisticated strategy to handle custom strides in runtime. For now adding a runtime workaround wherever we used to read the stride from the flatbuffer to calculate the stride instead.

FYI @nsmithtt @pilkicTT 