### PR TITLE
#2029: Added option in ttrt to disable putting dispatch on ethernet cores

### DIFF
--- a/runtime/include/tt/runtime/detail/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal.h
@@ -19,7 +19,8 @@
 
 namespace tt::runtime::ttmetal {
 
-std::pair<SystemDesc, DeviceIds> getCurrentSystemDesc();
+std::pair<SystemDesc, DeviceIds> getCurrentSystemDesc(
+    std::optional<DispatchCoreType> dispatchCoreType = std::nullopt);
 
 Tensor createTensor(std::shared_ptr<void> data,
                     std::vector<std::uint32_t> const &shape,

--- a/runtime/include/tt/runtime/detail/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn.h
@@ -49,7 +49,8 @@ namespace tt::runtime::ttnn {
 // Default L1 small size to use for the ttnn runtime (32kb).
 constexpr std::size_t kL1SmallSize = 1 << 15;
 
-std::pair<SystemDesc, DeviceIds> getCurrentSystemDesc();
+std::pair<SystemDesc, DeviceIds> getCurrentSystemDesc(
+    std::optional<DispatchCoreType> dispatchCoreType = std::nullopt);
 
 Tensor createTensor(std::shared_ptr<void> data,
                     std::vector<std::uint32_t> const &shape,

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -14,7 +14,8 @@
 namespace tt::runtime {
 
 namespace system_desc {
-std::pair<SystemDesc, DeviceIds> getCurrentSystemDesc();
+std::pair<SystemDesc, DeviceIds> getCurrentSystemDesc(
+    std::optional<DispatchCoreType> dispatchCoreType = std::nullopt);
 } // namespace system_desc
 
 namespace detail {
@@ -43,7 +44,8 @@ void setCurrentRuntime(const DeviceRuntime &runtime);
 
 void setCompatibleRuntime(const Binary &binary);
 
-std::pair<SystemDesc, DeviceIds> getCurrentSystemDesc();
+std::pair<SystemDesc, DeviceIds> getCurrentSystemDesc(
+    std::optional<DispatchCoreType> dispatchCoreType = std::nullopt);
 
 Tensor createTensor(std::shared_ptr<void> data,
                     std::vector<std::uint32_t> const &shape,

--- a/runtime/lib/common/system_desc.cpp
+++ b/runtime/lib/common/system_desc.cpp
@@ -257,10 +257,11 @@ static std::unique_ptr<::tt::runtime::SystemDesc> getCurrentSystemDescImpl(
   return std::make_unique<::tt::runtime::SystemDesc>(handle);
 }
 
-std::pair<::tt::runtime::SystemDesc, DeviceIds> getCurrentSystemDesc() {
+std::pair<::tt::runtime::SystemDesc, DeviceIds> getCurrentSystemDesc(
+    std::optional<DispatchCoreType> dispatchCoreType = std::nullopt) {
   size_t numDevices = ::tt::tt_metal::GetNumAvailableDevices();
-  ::tt::tt_metal::DispatchCoreType dispatchCoreType =
-      tt::runtime::common::getDispatchCoreType(std::nullopt);
+  ::tt::tt_metal::DispatchCoreType type =
+      tt::runtime::common::getDispatchCoreType(dispatchCoreType);
   std::vector<chip_id_t> deviceIds(numDevices);
   std::iota(deviceIds.begin(), deviceIds.end(), 0);
   ::tt::tt_metal::distributed::MeshShape meshShape = {1, numDevices};
@@ -268,8 +269,7 @@ std::pair<::tt::runtime::SystemDesc, DeviceIds> getCurrentSystemDesc() {
       ::tt::tt_metal::distributed::MeshDevice::create(
           ::tt::tt_metal::distributed::MeshDeviceConfig{.mesh_shape =
                                                             meshShape},
-          DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 1,
-          dispatchCoreType);
+          DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 1, type);
   CoreCoord logical_grid_size = meshDevice->compute_with_storage_grid_size();
   LOG_INFO("Grid size = { ", logical_grid_size.x, ", ", logical_grid_size.y,
            "}");

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -127,9 +127,10 @@ void setCompatibleRuntime(const Binary &binary) {
   LOG_FATAL("Unsupported binary file identifier or runtime not enabled");
 }
 
-std::pair<SystemDesc, DeviceIds> getCurrentSystemDesc() {
+std::pair<SystemDesc, DeviceIds>
+getCurrentSystemDesc(std::optional<DispatchCoreType> dispatchCoreType) {
 #if defined(TT_RUNTIME_ENABLE_TTNN) || defined(TT_RUNTIME_ENABLE_TTMETAL)
-  return system_desc::getCurrentSystemDesc();
+  return system_desc::getCurrentSystemDesc(dispatchCoreType);
 #endif
   LOG_FATAL("runtime is not enabled");
 }

--- a/runtime/tools/python/ttrt/common/query.py
+++ b/runtime/tools/python/ttrt/common/query.py
@@ -60,6 +60,13 @@ class Query:
             help="suppress system desc from being printed",
         )
         Query.register_arg(
+            name="--disable-eth-dispatch",
+            type=bool,
+            default=False,
+            choices=[True, False],
+            help="disable putting dispatch on ethernet cores - place it on worker cores instead",
+        )
+        Query.register_arg(
             name="--result-file",
             type=str,
             default="query_results.json",
@@ -121,11 +128,16 @@ class Query:
         import ttrt.runtime
 
         try:
+            dispatch_core_type = ttrt.runtime.DispatchCoreType.ETH
+
+            if self["--disable-eth-dispatch"]:
+                dispatch_core_type = ttrt.runtime.DispatchCoreType.WORKER
+
             self.logging.debug(f"getting system descriptor")
             (
                 self.system_desc,
                 self.device_ids,
-            ) = ttrt.runtime.get_current_system_desc()
+            ) = ttrt.runtime.get_current_system_desc(dispatch_core_type)
 
             if not self["--quiet"]:
                 self.logging.info(self.system_desc.as_json())

--- a/runtime/tools/python/ttrt/common/run.py
+++ b/runtime/tools/python/ttrt/common/run.py
@@ -204,6 +204,13 @@ class Run:
             help="check for memory leaks (use in conjunction with --memory)",
         )
         Run.register_arg(
+            name="--disable-eth-dispatch",
+            type=bool,
+            default=False,
+            choices=[True, False],
+            help="disable putting dispatch on ethernet cores - place it on worker cores instead",
+        )
+        Run.register_arg(
             name="binary",
             type=str,
             default="",
@@ -407,8 +414,15 @@ class Run:
             ttrt.runtime.set_compatible_runtime(binaries[0].fbb)
             current_runtime = ttrt.runtime.get_current_runtime()
             self.logging.debug(f"opening devices={self.query.device_ids}")
+            dispatch_core_type = ttrt.runtime.DispatchCoreType.ETH
+
+            if self["--disable-eth-dispatch"]:
+                dispatch_core_type = ttrt.runtime.DispatchCoreType.WORKER
+
             device = ttrt.runtime.open_device(
-                self.query.device_ids, enable_async_ttnn=self["--enable-async-ttnn"]
+                self.query.device_ids,
+                dispatch_core_type=dispatch_core_type,
+                enable_async_ttnn=self["--enable-async-ttnn"],
             )
 
             callback_runtime_config = CallbackRuntimeConfig(

--- a/runtime/tools/python/ttrt/runtime/__init__.py
+++ b/runtime/tools/python/ttrt/runtime/__init__.py
@@ -10,6 +10,7 @@ try:
         MemoryBufferType,
         DataType,
         DeviceRuntime,
+        DispatchCoreType,
         DebugEnv,
         DebugHooks,
         get_current_runtime,


### PR DESCRIPTION
This is needed because galaxy does not support dispatch on ethernet cores.
