### PR TITLE
Uplift third_party/tt-metal to 064646adfcb5f0b923a24a633d532552bd43e06d 2025-01-30

### DIFF
--- a/runtime/lib/common/system_desc.cpp
+++ b/runtime/lib/common/system_desc.cpp
@@ -142,7 +142,8 @@ calculateDRAMUnreservedEnd(const ::tt::tt_metal::IDevice *device) {
                              device->get_active_ethernet_cores().size();
   std::uint32_t totalDramCores = dramGridSize.x * dramGridSize.y;
   std::uint32_t programCarveOutPerCore =
-      device->get_base_allocator_addr(::tt::tt_metal::HalMemType::L1);
+      device->allocator()->get_base_allocator_addr(
+          ::tt::tt_metal::HalMemType::L1);
   std::uint32_t totalProgramCarveOut = programCarveOutPerCore * totalCores;
   // The total carve out can be interleaved between all dram channels
   std::uint32_t programCarveOutDramSpace =
@@ -174,10 +175,10 @@ static std::unique_ptr<::tt::runtime::SystemDesc> getCurrentSystemDescImpl(
   ::flatbuffers::FlatBufferBuilder fbb;
 
   for (const ::tt::tt_metal::IDevice *device : devices) {
-    size_t l1UnreservedBase =
-        device->get_base_allocator_addr(::tt::tt_metal::HalMemType::L1);
-    size_t dramUnreservedBase =
-        device->get_base_allocator_addr(::tt::tt_metal::HalMemType::DRAM);
+    size_t l1UnreservedBase = device->allocator()->get_base_allocator_addr(
+        ::tt::tt_metal::HalMemType::L1);
+    size_t dramUnreservedBase = device->allocator()->get_base_allocator_addr(
+        ::tt::tt_metal::HalMemType::DRAM);
 
     // Construct chip descriptor
     ::tt::target::Dim2d deviceGrid =

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -123,7 +123,7 @@ void deallocateBuffers(Device deviceHandle) {
           DeviceRuntime::TTMetal);
 
   for (::tt::tt_metal::IDevice *device : meshDevice.get_devices()) {
-    device->deallocate_buffers();
+    device->allocator()->deallocate_buffers();
   }
 }
 

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -230,7 +230,7 @@ void deallocateBuffers(Device deviceHandle) {
   ::ttnn::MeshDevice &meshDevice =
       deviceHandle.as<::ttnn::MeshDevice>(DeviceRuntime::TTNN);
   for (::ttnn::IDevice *device : meshDevice.get_devices()) {
-    device->deallocate_buffers();
+    device->allocator()->deallocate_buffers();
   }
 }
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "3adec9c1702bd61f3015d3c659da802fe130be27")
+set(TT_METAL_VERSION "064646adfcb5f0b923a24a633d532552bd43e06d")
 
 if ("$ENV{ARCH_NAME}" STREQUAL "grayskull")
   set(ARCH_NAME "grayskull")


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 064646adfcb5f0b923a24a633d532552bd43e06d

- Call allocator APIs from allocator, not IDevice, after metal change 2b8c66c