### PR TITLE
Infer shape in builder from golden output

### DIFF
--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -354,6 +354,17 @@ def test_minimum(in0: Operand, in1: Operand, builder: TTIRBuilder):
     return builder.minimum(in0, in1)
 
 
+@compile_to_flatbuffer(
+    [
+        (32, 64),
+        (64, 128),
+    ],
+    targets=["ttnn"],
+)
+def test_matmul(in0: Operand, in1: Operand, builder: TTIRBuilder):
+    return builder.matmul(in0, in1)
+
+
 # @compile_to_flatbuffer(
 #   [
 #       (64, 64),


### PR DESCRIPTION
This change streamlines our bindings within the TTIR builder by having the output shape passed to the TTIR op be computed from the golden (torch) output. This both makes adding new ops easier, and reduces the chance of a bug in how we manually calculate shapes.

During testing, I also discovered we have no single test for a matmul through the builder, so I added one to show that the new feature works