### PR TITLE
Add argument type and pass which can populate them

### DIFF
--- a/include/ttmlir/Dialect/TT/IR/TTOpsEnums.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsEnums.td
@@ -210,4 +210,20 @@ def TT_CPURole : I32EnumAttr<"CPURole", "TT CPU Role",
   let cppNamespace = "::mlir::tt";
 }
 
+def TT_ArgumentType_Input : I32EnumAttrCase<"Input", 0, "input">;
+def TT_ArgumentType_Parameter: I32EnumAttrCase<"Parameter", 1, "parameter">;
+def TT_ArgumentType_Constant : I32EnumAttrCase<"Constant", 2, "constant">;
+
+def TT_ArgumentType : I32EnumAttr<"ArgumentType", "Argument Type",
+                            [
+                              TT_ArgumentType_Input,
+                              TT_ArgumentType_Parameter,
+                              TT_ArgumentType_Constant,
+                            ]> {
+  let genSpecializedAttr = 0;
+  let cppNamespace = "::mlir::tt";
+  let stringToSymbolFnName = "ArgumentTypeStringToEnum";
+  let symbolToStringFnName = "ArgumentTypeEnumToString";
+}
+
 #endif

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -519,4 +519,8 @@ def TT_Tuple : NestedTupleOf<[AnyRankedTensor]>;
 
 def TT_TupleMemberType : AnyTypeOf<[AnyRankedTensor]>;
 
+def TT_ArgumentTypeAttr : EnumAttr<TT_Dialect, TT_ArgumentType, "argument_type"> {
+  let assemblyFormat = "`<` $value `>`";
+}
+
 #endif

--- a/include/ttmlir/Dialect/TT/Utils/PopulateArgumentTypes.h
+++ b/include/ttmlir/Dialect/TT/Utils/PopulateArgumentTypes.h
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TT_UTILS_POPULATEARGUMENTTYPES_H
+#define TTMLIR_DIALECT_TT_UTILS_POPULATEARGUMENTTYPES_H
+
+#include "mlir/Pass/Pass.h"
+#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
+
+#include "llvm/Support/CommandLine.h"
+
+namespace mlir::tt {
+
+using TTArgumentTypeMap = llvm::StringMap<SmallVector<ArgumentType>>;
+
+struct OptionNames {
+  static constexpr StringRef argumentTypes = "argument-types";
+};
+
+struct ArgumentTypeMapParser : public llvm::cl::parser<TTArgumentTypeMap> {
+
+  ArgumentTypeMapParser(llvm::cl::Option &O)
+      : llvm::cl::parser<TTArgumentTypeMap>(O) {}
+
+  // parse - Return true on error.
+  bool parse(llvm::cl::Option &O, llvm::StringRef argName,
+             llvm::StringRef commandLineArg, TTArgumentTypeMap &val);
+
+  static void print(llvm::raw_ostream &os, const TTArgumentTypeMap &argTypeMap);
+};
+
+std::unique_ptr<::mlir::Pass> createTTPopulateArgumentTypes();
+std::unique_ptr<::mlir::Pass>
+createTTPopulateArgumentTypes(TTArgumentTypeMap options);
+
+//===----------------------------------------------------------------------===//
+// TTPopulateArgumentTypes Registration
+//===----------------------------------------------------------------------===//
+inline void registerTTPopulateArgumentTypes() {
+  ::mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
+    return createTTPopulateArgumentTypes();
+  });
+}
+} // namespace mlir::tt
+
+#endif

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -5,13 +5,13 @@
 #ifndef TTMLIR_DIALECT_TTNN_PIPELINES_TTNNPIPELINES_H
 #define TTMLIR_DIALECT_TTNN_PIPELINES_TTNNPIPELINES_H
 
+#include "ttmlir/Dialect/TT/Utils/PopulateArgumentTypes.h"
 #include "ttmlir/Dialect/TTNN/Utils/MemoryLayoutAnalysisParams.h"
 #include "ttmlir/Dialect/TTNN/Utils/PassOverrides.h"
 
 #include "mlir/Pass/PassOptions.h"
 
 namespace mlir::tt::ttnn {
-
 // Options for the TTIR to TTNN backend pipeline.
 //
 struct TTIRToTTNNBackendPipelineOptions
@@ -146,6 +146,22 @@ struct TTIRToTTNNBackendPipelineOptions
       *this, "enable-implicit-broadcast-folding-pass",
       llvm::cl::desc("Enable implicit broadcast folding pass."),
       llvm::cl::init(true)};
+
+  Option<tt::TTArgumentTypeMap, tt::ArgumentTypeMapParser> argumentTypeMap{
+      *this, tt::OptionNames::argumentTypes,
+      llvm::cl::desc(
+          "Map of function name to argument types. To use this option in the "
+          "command line, you must provide a whitespace-free string\n\t"
+          " which is a sequence of phrases in the form "
+          "\"<FUNC_NAME_STR>=<ARG_TYPES>\" separated by semicolons, where "
+          "<FUNC_NAME_STR>\n\t"
+          " is the name of a function and <ARG_TYPES> is a sequence of "
+          "argument types separated by commas. Each of which must be one\n\t"
+          " of \"input\", \"parameter\" or \"constant\". \n\t"
+          " Example: "
+          "\"argument-types=forward=input,parameter,parameter,constant\""
+          "\n\n"),
+      llvm::cl::init(TTArgumentTypeMap())};
 };
 
 // TTIR to EmitC pipeline options.

--- a/lib/Dialect/TT/CMakeLists.txt
+++ b/lib/Dialect/TT/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(IR)
 add_subdirectory(Transforms)
+add_subdirectory(Utils)

--- a/lib/Dialect/TT/Utils/CMakeLists.txt
+++ b/lib/Dialect/TT/Utils/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_mlir_dialect_library(MLIRTTUtils
+        PopulateArgumentTypes.cpp
+
+        ADDITIONAL_HEADER_DIRS
+        ${PROJECT_SOURCE_DIR}/include/ttmlir
+
+        DEPENDS
+        MLIRTTOpsIncGen
+        )

--- a/lib/Dialect/TT/Utils/PopulateArgumentTypes.cpp
+++ b/lib/Dialect/TT/Utils/PopulateArgumentTypes.cpp
@@ -1,0 +1,316 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TT/Utils/PopulateArgumentTypes.h"
+#include "ttmlir/Dialect/TT/IR/TT.h"
+#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
+#include "ttmlir/Utils.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "llvm/ADT/SmallSet.h"
+#include <llvm/Support/LogicalResult.h>
+#include <mlir/IR/Diagnostics.h>
+#include <mlir/Support/LLVM.h>
+
+namespace mlir::tt {
+
+bool ArgumentTypeMapParser::parse(
+    llvm::cl::Option &O, llvm::StringRef argName,
+    llvm::StringRef commandLineArg,
+    llvm::StringMap<SmallVector<ArgumentType>> &val) {
+  llvm::StringRef errorMessage =
+      "Invalid format. Expected: function=type1,type2;function=type1,type2";
+  llvm::StringRef arg = commandLineArg;
+
+  llvm::SmallVector<llvm::StringRef> entries;
+  arg.split(entries, ';'); // Split functions by `;`
+  // Entries would hold something like ["func1=input,param",
+  // "func2=param,param"].
+
+  for (llvm::StringRef entry : entries) {
+    auto [funcName, argsStr] = entry.split('=');
+    if (argsStr.empty()) {
+      llvm::errs() << errorMessage << "\n";
+      return true;
+    }
+
+    llvm::SmallVector<llvm::StringRef> argNames;
+    argsStr.split(argNames, ','); // Split arguments by `,`
+
+    // This allows the user to leave a trailing comma at the end of the argument
+    // list i.e "func1=input,param," We must do this instead of setting
+    // KeepEmpty=false in argStr.split() because that would not allow empty
+    // arguments in the middle of the list.
+    if (argNames.back() == "") {
+      argNames.pop_back();
+    }
+
+    // if an entry is something like "func1=" or "func1=," then it's invalid.
+    if (argNames.empty()) {
+      llvm::errs() << "Provided empty argument list for funtion name: \""
+                   << funcName << "\"" << "\n";
+      return true;
+    }
+    // If this enrty is  "func1=input,param" then argNames would hold ["input",
+    // "param"] now.
+
+    // Parse the argument type names into their respective enums.
+    llvm::SmallVector<ArgumentType> argTypes;
+    for (llvm::StringRef arg : argNames) {
+      auto argTypeEnum = ArgumentTypeStringToEnum(arg);
+      if (!argTypeEnum.has_value()) {
+        llvm::errs() << "Invalid argument type: " << arg << "\n";
+        return true;
+      }
+      argTypes.push_back(argTypeEnum.value());
+    }
+
+    val[funcName] = argTypes;
+  }
+
+  return false;
+}
+
+void ArgumentTypeMapParser::print(
+    llvm::raw_ostream &os,
+    const llvm::StringMap<SmallVector<ArgumentType>> &argTypeMap) {
+
+  SmallVector<llvm::StringRef> argTypeNames;
+  for (auto &kv : argTypeMap) {
+    for (auto argType : kv.second) {
+      argTypeNames.push_back(ArgumentTypeEnumToString(argType));
+    }
+  }
+
+  os << ttmlir::utils::join(argTypeNames, ",") << "\n";
+}
+
+namespace impl {
+
+namespace {
+std::unique_ptr<::mlir::Pass> createTTPopulateArgumentTypes();
+std::unique_ptr<::mlir::Pass>
+createTTPopulateArgumentTypes(TTArgumentTypeMap options);
+
+template <typename DerivedT>
+class TTPopulateArgumentTypesBase : public ::mlir::OperationPass<ModuleOp> {
+public:
+  using Base = TTPopulateArgumentTypesBase;
+
+  TTPopulateArgumentTypesBase()
+      : ::mlir::OperationPass<ModuleOp>(::mlir::TypeID::get<DerivedT>()) {}
+  TTPopulateArgumentTypesBase(const TTPopulateArgumentTypesBase &other)
+      : ::mlir::OperationPass<ModuleOp>(other) {}
+  TTPopulateArgumentTypesBase &
+  operator=(const TTPopulateArgumentTypesBase &) = delete;
+  TTPopulateArgumentTypesBase(TTPopulateArgumentTypesBase &&) = delete;
+  TTPopulateArgumentTypesBase &
+  operator=(TTPopulateArgumentTypesBase &&) = delete;
+  ~TTPopulateArgumentTypesBase() override = default;
+
+  /// Returns the command-line argument attached to this pass.
+  static constexpr ::llvm::StringLiteral getArgumentName() {
+    return "tt-populate-argument-types";
+  }
+
+  ::llvm::StringRef getArgument() const override {
+    return "tt-populate-argument-types";
+  }
+
+  ::llvm::StringRef getDescription() const override {
+    return "Populate argument types.";
+  }
+
+  /// Returns the derived pass name.
+  static constexpr ::llvm::StringLiteral getPassName() {
+    return "TTPopulateArgumentTypes";
+  }
+
+  ::llvm::StringRef getName() const override {
+    return "TTPopulateArgumentTypes";
+  }
+
+  /// Support isa/dyn_cast functionality for the derived pass class.
+  static bool classof(const ::mlir::Pass *pass) {
+    return pass->getTypeID() == ::mlir::TypeID::get<DerivedT>();
+  }
+
+  /// A clone method to create a copy of this pass.
+  std::unique_ptr<::mlir::Pass> clonePass() const override {
+    return std::make_unique<DerivedT>(*static_cast<const DerivedT *>(this));
+  }
+
+  /// Return the dialect that must be loaded in the context before this pass.
+  void getDependentDialects(::mlir::DialectRegistry &registry) const override {
+    registry.insert<mlir::tt::TTDialect>();
+  }
+
+  /// Explicitly declare the TypeID for this class. We declare an explicit
+  /// private instantiation because Pass classes should only be visible by the
+  /// current library.
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(
+      TTPopulateArgumentTypesBase<DerivedT>)
+
+  TTPopulateArgumentTypesBase(TTArgumentTypeMap argumentTypeMap)
+      : TTPopulateArgumentTypesBase() {
+    this->argumentTypeMap = std::move(argumentTypeMap);
+  }
+
+protected:
+  ::mlir::Pass::Option<TTArgumentTypeMap, ArgumentTypeMapParser>
+      argumentTypeMap{
+          *this, OptionNames::argumentTypes,
+          llvm::cl::desc(
+              "Map of function name to argument types. To use this option in "
+              "the command line, you must provide a whitespace-free string\n\t"
+              " which is a sequence of phrases in the form "
+              "\"<FUNC_NAME_STR>=<ARG_TYPES>\" separated by semicolons, where "
+              "<FUNC_NAME_STR>\n\t"
+              " is the name of a function and <ARG_TYPES> is a sequence of "
+              "argument types separated by commas. Each of which must be "
+              "one\n\t"
+              " of \"input\", \"parameter\" or \"constant\". \n\t"
+              " Example: "
+              "\"argument-types=forward=input,parameter,parameter,constant\""
+              "\n\n"),
+          llvm::cl::init(TTArgumentTypeMap())};
+
+private:
+  friend std::unique_ptr<::mlir::Pass> createTTPopulateArgumentTypes() {
+    return std::make_unique<DerivedT>();
+  }
+
+  friend std::unique_ptr<::mlir::Pass>
+  createTTPopulateArgumentTypes(TTArgumentTypeMap options) {
+    return std::make_unique<DerivedT>(options);
+  }
+};
+} // namespace
+} // namespace impl
+
+std::unique_ptr<::mlir::Pass> createTTPopulateArgumentTypes() {
+  return impl::createTTPopulateArgumentTypes();
+}
+
+std::unique_ptr<::mlir::Pass>
+createTTPopulateArgumentTypes(TTArgumentTypeMap options) {
+  return impl::createTTPopulateArgumentTypes(std::move(options));
+}
+
+class TTPopulateArgumentTypes
+    : public impl::TTPopulateArgumentTypesBase<TTPopulateArgumentTypes> {
+public:
+  using impl::TTPopulateArgumentTypesBase<
+      TTPopulateArgumentTypes>::TTPopulateArgumentTypesBase;
+
+  void runOnOperation() final {
+    // Currently, we will allow compile without assigning argument types.
+    if (failed(checkArgumentTypeMapPopulated())) {
+      emitWarning(getOperation().getLoc())
+          << "Empty argument type map provided. Skipping argument "
+             "type population. This may affect subsequent compile steps.\n";
+      return;
+    }
+    TTArgumentTypeMap map = argumentTypeMap.getValue();
+    if (failed(checkOnlyValidFunctionNamesProvided(map, getOperation()))) {
+      emitError(getOperation().getLoc())
+          << "At least one function name provided in the argument type map "
+             "does not exist in the module.\n";
+      signalPassFailure();
+      return;
+    }
+
+    // Iterate through every function as we may be assigning argument types to
+    // them.
+    for (auto func : getOperation().getOps<mlir::func::FuncOp>()) {
+      StringRef funcName = func.getName();
+
+      // If the map does not provide argument types for this function then skip
+      if (!map.contains(funcName)) {
+        continue;
+      }
+
+      SmallVector<ArgumentType> argTypes = map[funcName];
+      if (failed(checkNumProvidedArgsMatch(func, argTypes))) {
+        emitError(func.getLoc())
+            << "Did not provide the correct number of argument types for "
+               "function: \""
+            << func.getName() << "\". Expected: " << func.getNumArguments()
+            << " arguments, got: " << argTypes.size() << " arguments.\n";
+        signalPassFailure();
+        return;
+      }
+
+      for (uint32_t argIdx = 0; argIdx < func.getNumArguments(); argIdx++) {
+        applyFuncArgumentType(func, argIdx, argTypes[argIdx]);
+      }
+    }
+  }
+
+private:
+  LogicalResult checkArgumentTypeMapPopulated() {
+    return success(!argumentTypeMap.getValue().empty());
+  }
+
+  LogicalResult checkOnlyValidFunctionNamesProvided(TTArgumentTypeMap map,
+                                                    ModuleOp module) {
+    llvm::SmallSet<StringRef, 8> funcNames;
+    for (func::FuncOp func : module.getOps<mlir::func::FuncOp>()) {
+      funcNames.insert(func.getName());
+    }
+    for (StringRef funcName : map.keys()) {
+      if (!funcNames.contains(funcName)) {
+        emitError(module.getLoc())
+            << "Function: \"" << funcName
+            << "\" was provided in the argument types map, however it "
+               "was not found in module!\n";
+        return failure();
+      }
+    }
+    return success();
+  }
+
+  LogicalResult
+  checkNumProvidedArgsMatch(mlir::func::FuncOp func,
+                            SmallVector<ArgumentType> argTypeAttrs) {
+    return success(func.getNumArguments() == argTypeAttrs.size());
+  }
+
+  // Adds the argument type attribute to the function argument at the given
+  // index.
+  void applyFuncArgumentType(func::FuncOp func, uint32_t argIdx,
+                             ArgumentType argType) {
+    // The current argument may already have attributes, so we need to add
+    // the argument type to that DictonaryAttr rather than overwrite it.
+    SmallVector<mlir::NamedAttribute> newArgAttrs;
+    if (auto currentArgAttrDict = func.getArgAttrDict(argIdx)) {
+      if (currentArgAttrDict.contains(ArgumentTypeAttr::name)) {
+        emitWarning(func.getLoc())
+            << "Overwriting existing argument type attribute for "
+               "function: \""
+            << func->getName() << "\" argument: " << argIdx << "\n";
+        llvm::copy_if(
+            currentArgAttrDict.getValue(), std::back_inserter(newArgAttrs),
+            [&](mlir::NamedAttribute currentArgAttr) {
+              return currentArgAttr.getName() != ArgumentTypeAttr::name;
+            });
+      } else {
+        newArgAttrs =
+            SmallVector<mlir::NamedAttribute>(currentArgAttrDict.getValue());
+      }
+    }
+    newArgAttrs.emplace_back(
+        mlir::StringAttr::get(&getContext(), ArgumentTypeAttr::name),
+        ArgumentTypeAttr::get(&getContext(), argType));
+
+    func.setArgAttrs(argIdx,
+                     mlir::DictionaryAttr::get(&getContext(), newArgAttrs));
+  }
+};
+
+} // namespace mlir::tt

--- a/lib/Dialect/TTNN/Pipelines/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Pipelines/CMakeLists.txt
@@ -5,6 +5,7 @@ add_mlir_dialect_library(MLIRTTNNPipelines
   ${PROJECT_SOURCE_DIR}/include/ttmlir
 
   LINK_LIBS PUBLIC
+  MLIRTTUtils
   MLIRTTNNDialect
   MLIRTTNNTransforms
   MLIRPass

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -6,6 +6,7 @@
 
 #include "ttmlir/Conversion/Passes.h"
 #include "ttmlir/Conversion/TTNNToEmitC/TTNNToEmitC.h"
+#include "ttmlir/Dialect/TT/Utils/PopulateArgumentTypes.h"
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
 
@@ -22,6 +23,7 @@ void createTTNNPipelineTTIRPasses(
   ttir::TTIRLoadSystemDescOptions systemDescOptions;
   systemDescOptions.path = options.systemDescPath;
 
+  pm.addPass(mlir::tt::createTTPopulateArgumentTypes(options.argumentTypeMap));
   pm.addPass(mlir::createCanonicalizerPass());
   pm.addPass(mlir::tt::createTTIRToTTIRDecompositionPass());
   pm.addPass(mlir::createCanonicalizerPass());

--- a/lib/RegisterAll.cpp
+++ b/lib/RegisterAll.cpp
@@ -8,6 +8,7 @@
 #include "ttmlir/Dialect/LLVM/Transforms/Passes.h"
 #include "ttmlir/Dialect/TT/IR/TT.h"
 #include "ttmlir/Dialect/TT/Transforms/Passes.h"
+#include "ttmlir/Dialect/TT/Utils/PopulateArgumentTypes.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIR.h"
 #include "ttmlir/Dialect/TTIR/Pipelines/TTIRPipelines.h"
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
@@ -77,6 +78,7 @@ void mlir::tt::registerAllPasses() {
   mlir::registerPass(mlir::createRemoveDeadValuesPass);
 
   mlir::tt::registerPasses();
+  mlir::tt::registerTTPopulateArgumentTypes();
   mlir::tt::ttir::registerPasses();
   mlir::tt::ttnn::registerTTNNOptimizer();
   mlir::tt::ttnn::registerPasses();

--- a/test/ttmlir/Dialect/TTIR/populate_argument_types/negative/incorrect_arg_count_provided.mlir
+++ b/test/ttmlir/Dialect/TTIR/populate_argument_types/negative/incorrect_arg_count_provided.mlir
@@ -1,0 +1,7 @@
+// RUN: not ttmlir-opt --tt-populate-argument-types="argument-types=forward=input,parameter,parameter," %s 2>&1 | FileCheck %s
+module attributes {} {
+  // CHECK: error: Did not provide the correct number of argument types for function: "forward". Expected: 4 arguments, got: 3 arguments.
+  func.func @forward(%arg0: tensor<1x32x32x64xbf16> {ttir.name = "input_activations"}, %arg1: tensor<64x64x3x3xbf16> {ttir.name = "weights1"}, %arg2: tensor<1x1x1x64xbf16> {ttir.name = "weights2"}, %arg3: tensor<1x32x32x64xbf16> {ttir.name = "const_0"}) -> (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, tensor<1x32x32x64xbf16>) {
+    return %arg0, %arg1, %arg2, %arg3 : tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, tensor<1x32x32x64xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/populate_argument_types/negative/invalid_function_name_provided.mlir
+++ b/test/ttmlir/Dialect/TTIR/populate_argument_types/negative/invalid_function_name_provided.mlir
@@ -1,0 +1,7 @@
+// RUN: not ttmlir-opt --tt-populate-argument-types="argument-types=main=input,parameter,parameter,constant" %s 2>&1 | FileCheck %s
+module attributes {} {
+  // CHECK: error: Function: "main" was provided in the argument types map, however it was not found in module!
+  func.func @forward(%arg0: tensor<1x32x32x64xbf16> {ttir.name = "input_activations"}, %arg1: tensor<64x64x3x3xbf16> {ttir.name = "weights1"}, %arg2: tensor<1x1x1x64xbf16> {ttir.name = "weights2"}, %arg3: tensor<1x32x32x64xbf16> {ttir.name = "const_0"}) -> (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, tensor<1x32x32x64xbf16>) {
+    return %arg0, %arg1, %arg2, %arg3 : tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, tensor<1x32x32x64xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/populate_argument_types/positive/populate_multiple_funcs_with_existing_attrs.mlir
+++ b/test/ttmlir/Dialect/TTIR/populate_argument_types/positive/populate_multiple_funcs_with_existing_attrs.mlir
@@ -1,0 +1,26 @@
+// RUN: ttmlir-opt --tt-populate-argument-types="argument-types=forward1=input,parameter,parameter,constant;forward2=input,input,constant,parameter" %s | FileCheck %s
+module attributes {} {
+  // CHECK: tt.argument_type = #tt.argument_type<input>
+  // CHECK: ttir.name = "input_activations"
+  // CHECK: tt.argument_type = #tt.argument_type<parameter>
+  // CHECK: ttir.name = "weights1"
+  // CHECK: tt.argument_type = #tt.argument_type<parameter>
+  // CHECK: ttir.name = "weights2"
+  // CHECK: tt.argument_type = #tt.argument_type<constant>
+  // CHECK: ttir.name = "const_0"
+  func.func @forward1(%arg0: tensor<1x32x32x64xbf16> {ttir.name = "input_activations"}, %arg1: tensor<64x64x3x3xbf16> {ttir.name = "weights1"}, %arg2: tensor<1x1x1x64xbf16> {ttir.name = "weights2"}, %arg3: tensor<1x32x32x64xbf16> {ttir.name = "const_0"}) -> (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, tensor<1x32x32x64xbf16>) {
+    return %arg0, %arg1, %arg2, %arg3 : tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, tensor<1x32x32x64xbf16>
+  }
+
+  // CHECK: tt.argument_type = #tt.argument_type<input>
+  // CHECK: ttir.name = "input_activations"
+  // CHECK: tt.argument_type = #tt.argument_type<input>
+  // CHECK: ttir.name = "weights1"
+  // CHECK: tt.argument_type = #tt.argument_type<constant>
+  // CHECK: ttir.name = "weights2"
+  // CHECK: tt.argument_type = #tt.argument_type<parameter>
+  // CHECK: ttir.name = "const_0"
+  func.func @forward2(%arg0: tensor<1x32x32x64xbf16> {ttir.name = "input_activations"}, %arg1: tensor<64x64x3x3xbf16> {ttir.name = "weights1"}, %arg2: tensor<1x1x1x64xbf16> {ttir.name = "weights2"}, %arg3: tensor<1x32x32x64xbf16> {ttir.name = "const_0"}) -> (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, tensor<1x32x32x64xbf16>) {
+    return %arg0, %arg1, %arg2, %arg3 : tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, tensor<1x32x32x64xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/populate_argument_types/positive/populate_with_exsting_attrs.mlir
+++ b/test/ttmlir/Dialect/TTIR/populate_argument_types/positive/populate_with_exsting_attrs.mlir
@@ -1,0 +1,14 @@
+// RUN: ttmlir-opt --tt-populate-argument-types="argument-types=forward=input,parameter,parameter,constant" %s | FileCheck %s
+module attributes {} {
+  // CHECK: tt.argument_type = #tt.argument_type<input>
+  // CHECK: ttir.name = "input_activations"
+  // CHECK: tt.argument_type = #tt.argument_type<parameter>
+  // CHECK: ttir.name = "weights1"
+  // CHECK: tt.argument_type = #tt.argument_type<parameter>
+  // CHECK: ttir.name = "weights2"
+  // CHECK: tt.argument_type = #tt.argument_type<constant>
+  // CHECK: ttir.name = "const_0"
+  func.func @forward(%arg0: tensor<1x32x32x64xbf16> {ttir.name = "input_activations"}, %arg1: tensor<64x64x3x3xbf16> {ttir.name = "weights1"}, %arg2: tensor<1x1x1x64xbf16> {ttir.name = "weights2"}, %arg3: tensor<1x32x32x64xbf16> {ttir.name = "const_0"}) -> (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, tensor<1x32x32x64xbf16>) {
+    return %arg0, %arg1, %arg2, %arg3 : tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, tensor<1x32x32x64xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/populate_argument_types/positive/populate_with_no_existing_attrs.mlir
+++ b/test/ttmlir/Dialect/TTIR/populate_argument_types/positive/populate_with_no_existing_attrs.mlir
@@ -1,0 +1,10 @@
+// RUN: ttmlir-opt --tt-populate-argument-types="argument-types=forward=input,parameter,parameter,constant" %s | FileCheck %s
+module attributes {} {
+  // CHECK: tt.argument_type = #tt.argument_type<input>
+  // CHECK: tt.argument_type = #tt.argument_type<parameter>
+  // CHECK: tt.argument_type = #tt.argument_type<parameter>
+  // CHECK: tt.argument_type = #tt.argument_type<constant>
+  func.func @forward(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>, %arg3: tensor<1x32x32x64xbf16>) -> (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, tensor<1x32x32x64xbf16>) {
+    return %arg0, %arg1, %arg2, %arg3 : tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, tensor<1x32x32x64xbf16>
+  }
+}


### PR DESCRIPTION
Issue: https://github.com/tenstorrent/tt-mlir/issues/2032

- Create `TTPopulateArgumentTypes` pass which can be used to add argument types to the functions of a module. 
- Provide `TTIRToTTNNBackedPipeline` option which can be used to populate the argument types of all public functions in the MLIR module. `TTPopulateArgumentTypes` is added to `TTIRToTTNNBackendPipeline`
    - Argument types are stored in the `FuncOp`s `arg_attrs` attribute. 
- If this option is unpopulated it defaults to an empty `llvm::StringMap`, in which case the pass that populates the attributes returns immediately - doing nothing.
- If any arg attributes are populated before running this pass, they will remain. **Except** any existing `tt.argument_type` attributes. If this pass is run, the existing `tt.argument_type` attributes will be overwritten by the ones specified in `TTIRToTTNNBackendPipelineOptions`.
    - This means that a user of this pipeline is free to add these attributes on their own if they wish. To avoid overwriting these values they can simply not set the argument map in `TTIRToTTNNBackendPipelineOptions` as the default (empty map) causes the pass to not modify the module.