### PR TITLE
`get_noc_addr_from_bank_id` needed for first eltwise PyKernel

### DIFF
--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -479,6 +479,16 @@ def TTKernel_GetNocAddrXYOp : TTKernel_Op<"get_noc_addr_xy"> {
     let results = (outs TTKernel_NocAddr:$nocAddr);
 }
 
+def TTKernel_GetNocAddrFromBankIDOp: TTKernel_Op<"get_noc_addr_from_bank_id"> {
+    let summary = "GetNocAddrFromBankID";
+    let description = [{
+      GetNocAddrFromBankID api
+    }];
+
+    let arguments = (ins I32:$bank_id, I32:$bankAddressOffset);
+    let results = (outs TTKernel_NocAddr:$nocAddr);
+}
+
 def TTKernel_GetNocAddrOp : TTKernel_Op<"get_noc_addr"> {
     let summary = "GetNocAddr";
     let description = [{

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -313,6 +313,13 @@ public:
       template_args.push_back(
           emitc::OpaqueAttr::get(op.getContext(), "uint32_t"));
       return ArrayAttr::get(op.getContext(), template_args);
+    } else if constexpr (std::is_same_v<SourceOp,
+                                        ttkernel::GetNocAddrFromBankIDOp>) {
+      SmallVector<Attribute, 1> template_args;
+
+      template_args.push_back(
+          emitc::OpaqueAttr::get(op.getContext(), "true")); // default to DRAM
+      return ArrayAttr::get(op.getContext(), template_args);
     }
     return ArrayAttr();
   }

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -613,7 +613,8 @@ public:
           TTMetalToEmitCOpaqueRewriter<ttkernel::GetWritePtrOp>,
           TTMetalToEmitCOpaqueRewriter<ttkernel::GetReadPtrOp>,
           TTMetalToEmitCOpaqueRewriter<ttkernel::GetTileSizeOp>,
-          TTMetalToEmitCOpaqueRewriter<ttkernel::GetCompileArgValOp>>(
+          TTMetalToEmitCOpaqueRewriter<ttkernel::GetCompileArgValOp>,
+          TTMetalToEmitCOpaqueRewriter<ttkernel::GetNocAddrFromBankIDOp>>(
           typeConverter, funcOp.getContext());
 
       patterns.add<TTMetalToEmitCOpaqueRewriter<ttkernel::GetNocAddrXYOp>>(

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -22,6 +22,8 @@ module attributes {} {
     %4 = "ttkernel.get_noc_addr_xy"(%c0_i32, %c0_i32, %c262208_i32) : (i32, i32, i32) -> !ttkernel.noc_addr
     // CHECK: emitc.call_opaque "noc_async_read"[[C:.*]]
     "ttkernel.noc_async_read"(%4, %c262432_i32, %c32_i32) : (!ttkernel.noc_addr, i32, i32) -> ()
+    // CHECK: [[C:.*]] = emitc.call_opaque "get_noc_addr_from_bank_id"[[C:.*]] {template_args = [#emitc.opaque<"true">]} [[C:.*]]
+    %5 = "ttkernel.get_noc_addr_from_bank_id"(%c32_i32, %c262432_i32) : (i32, i32) -> !ttkernel.noc_addr
     // CHECK: emitc.call_opaque "noc_async_read_barrier"[[C:.*]]
     "ttkernel.noc_async_read_barrier"() : () -> ()
     "ttkernel.return"() : () -> ()

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -22,8 +22,10 @@ module attributes {} {
     %4 = "ttkernel.get_noc_addr_xy"(%c0_i32, %c0_i32, %c262208_i32) : (i32, i32, i32) -> !ttkernel.noc_addr
     // CHECK: emitc.call_opaque "noc_async_read"[[C:.*]]
     "ttkernel.noc_async_read"(%4, %c262432_i32, %c32_i32) : (!ttkernel.noc_addr, i32, i32) -> ()
-    // CHECK: [[C:.*]] = emitc.call_opaque "get_noc_addr_from_bank_id"[[C:.*]] {template_args = [#emitc.opaque<"true">]} [[C:.*]]
-    %5 = "ttkernel.get_noc_addr_from_bank_id"(%c32_i32, %c262432_i32) : (i32, i32) -> !ttkernel.noc_addr
+    %bank_id = arith.constant 1 : i32
+    %addr_offset = arith.constant 262400 : i32
+    %noc_addr = "ttkernel.get_noc_addr_from_bank_id"(%bank_id, %addr_offset) : (i32, i32) -> !ttkernel.noc_addr
+    // CHECK: = emitc.call_opaque "get_noc_addr_from_bank_id"({{.*}}) {template_args = [#emitc.opaque<"true">]}
     // CHECK: emitc.call_opaque "noc_async_read_barrier"[[C:.*]]
     "ttkernel.noc_async_read_barrier"() : () -> ()
     "ttkernel.return"() : () -> ()


### PR DESCRIPTION
This PR implements the last TTKernel op needed by [eltwise kernel example](https://github.com/tenstorrent/tt-mlir/issues/1984)

`get_noc_addr_from_bank_id` is templated in `dataflow_api.h` on the metal side
```
template <bool DRAM>
get_noc_addr_from_bank_id(uint32_t bank_id, uint32_t bank_address_offset, uint8_t noc = noc_index) {
```
Further investigation shows that every kernel written sets `DRAM` to true. 

Similar API like `get_noc_addr` is templated the same way and this template is not exposed in the tablegen for mlir (would love to know how to expose it), so I will also not expose it.
