### PR TITLE
#2061: Updated all_gather shlo conversion into ttir and ttnn

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -1876,7 +1876,8 @@ def TTIR_AllGatherOp : TTIR_DPSOp<"all_gather"> {
 
     let arguments = (ins AnyRankedTensor:$input,
                          AnyRankedTensor:$output,
-                         SI32Attr:$dim);
+                         SI32Attr:$all_gather_dim,
+                         UI32Attr:$cluster_axis);
 
     let results = (outs AnyRankedTensor:$result);
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1341,8 +1341,9 @@ def TTNN_AllGatherOp: TTNN_Op<"all_gather"> {
 
     let arguments = (ins AnyRankedTensor:$input,
                          TT_Device:$device,
-                         SI32Attr:$dim,
-                         DefaultValuedAttr<SI32Attr, "1">:$num_links);
+                         SI32Attr:$all_gather_dim,
+                         UI32Attr:$cluster_axis,
+                         DefaultValuedAttr<UI32Attr, "1">:$num_links);
 
     let results = (outs AnyRankedTensor:$result);
 

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -367,7 +367,8 @@ table AllGatherOp {
   in: tt.target.TensorRef;
   out: tt.target.TensorRef;
   device: tt.target.DeviceRef;
-  dim: uint32;
+  all_gather_dim: int32;
+  cluster_axis: uint32;
   num_links: uint32;
 }
 

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -1349,9 +1349,11 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
 
     auto device = ::ttnn::utils::getOrInsertDevice(rewriter, op);
+
     rewriter.replaceOpWithNewOp<ttnn::AllGatherOp>(
         op, this->getTypeConverter()->convertType(op.getType()),
-        adaptor.getInput(), device, adaptor.getDim());
+        adaptor.getInput(), device, adaptor.getAllGatherDim(),
+        static_cast<uint32_t>(adaptor.getClusterAxis()));
     return success();
   }
 };

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -1850,10 +1850,14 @@ mlir::tt::ttir::LinearOp::canonicalize(ttir::LinearOp op,
 // AllGatherOp verification
 ::mlir::LogicalResult mlir::tt::ttir::AllGatherOp::verify() {
   ::mlir::RankedTensorType inputType = getInput().getType();
-  int32_t dim = getDim();
+  int32_t gatherDim = getAllGatherDim();
 
-  if (dim >= inputType.getRank() || dim < -inputType.getRank()) {
-    return emitOpError("Invalid dimension for all gather op.");
+  if (gatherDim >= inputType.getRank() || gatherDim < -inputType.getRank()) {
+    return emitOpError(
+               "Invalid dimension for all gather op. Gather dimension must be "
+               ">= to "
+               "input tensor rank or < -input tensor rank, got gather_dim = ")
+           << gatherDim;
   }
 
   return success();

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -1337,9 +1337,9 @@ mlir::tt::ttnn::ToLayoutOp::canonicalize(ToLayoutOp toLayoutOp,
 
 ::mlir::LogicalResult AllGatherOp::verify() {
   ::mlir::RankedTensorType inputType = getInput().getType();
-  int32_t dim = getDim();
+  int32_t gatherDim = getAllGatherDim();
 
-  if (dim >= inputType.getRank() || dim < -inputType.getRank()) {
+  if (gatherDim >= inputType.getRank() || gatherDim < -inputType.getRank()) {
     return emitOpError("Invalid dimension for all gather op.");
   }
 

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkarounds.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkarounds.cpp
@@ -341,6 +341,9 @@ public:
     int32_t scatter_num = op.getScatterNum();
     Value deviceValue = op.getDevice();
     Location loc = op.getLoc();
+    uint32_t clusterAxis =
+        1; // TODO(tapspatel) Hard-code to 1 to prevent any changing behaviour
+           // while all_reduce code is updated with new algorithm.
 
     // TODO(wooseoklee): Once it supports two dimensional tensor
     // (https://github.com/tenstorrent/tt-metal/issues/15010), we can remove
@@ -387,7 +390,7 @@ public:
 
       ttnn::AllGatherOp allGatherOp = rewriter.create<ttnn::AllGatherOp>(
           loc, Type(reshapedOutputType), reduceScatterOp.getResult(),
-          deviceValue, scatter_dim);
+          deviceValue, scatter_dim, clusterAxis);
 
       ArrayAttr reshapedOutputShapeAttr = rewriter.getI32ArrayAttr(
           std::vector<int32_t>(outputTypeShape.begin(), outputTypeShape.end()));
@@ -410,7 +413,7 @@ public:
 
       rewriter.replaceOpWithNewOp<ttnn::AllGatherOp>(
           op, op.getType(), reduceScatterOp.getResult(), deviceValue,
-          scatter_dim);
+          scatter_dim, clusterAxis);
     }
     return success();
   }

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -557,7 +557,7 @@ createOp(FlatbufferObjectCache &cache, AllGatherOp op) {
   auto device = getOperandThroughDPSOps(op.getDevice());
   return ::tt::target::ttnn::CreateAllGatherOp(
       *cache.fbb, input, output, cache.at<::tt::target::DeviceRef>(device),
-      op.getDim(), op.getNumLinks());
+      op.getAllGatherDim(), op.getClusterAxis(), op.getNumLinks());
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::ReduceScatterOp>

--- a/runtime/lib/ttnn/operations/ccl/all_gather.cpp
+++ b/runtime/lib/ttnn/operations/ccl/all_gather.cpp
@@ -13,8 +13,9 @@ namespace tt::runtime::ttnn::operations::ccl {
 void run(const ::tt::target::ttnn::AllGatherOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
   const ::ttnn::Tensor &input = tensorPool.at(op->in()->global_id());
-  int32_t gatherDim = op->dim();
-  int32_t numLinks = op->num_links();
+  int32_t allGatherDim = op->all_gather_dim();
+  uint32_t clusterAxis = op->cluster_axis();
+  uint32_t numLinks = op->num_links();
   LOG_ASSERT(
       input.storage_type() == ::tt::tt_metal::StorageType::MULTI_DEVICE,
       "Input of all_gather must be MULTIDEVICE. id:", op->in()->global_id());
@@ -22,9 +23,10 @@ void run(const ::tt::target::ttnn::AllGatherOp *op, ProgramContext &context) {
       ::tt::runtime::ttnn::utils::createMemoryConfig(op->out());
   ::ttnn::MeshDevice &meshDevice =
       context.getSubMesh(op->device()->global_id());
-  ::ttnn::Tensor out = ::ttnn::all_gather(
-      input, gatherDim, 1, meshDevice, numLinks, outputMemoryConfig,
-      std::nullopt, std::nullopt, ::ttnn::ccl::Topology::Linear);
+  ::ttnn::Tensor out =
+      ::ttnn::all_gather(input, allGatherDim, clusterAxis, meshDevice, numLinks,
+                         outputMemoryConfig, std::nullopt, std::nullopt,
+                         ::ttnn::ccl::Topology::Linear);
   tensorPool.insert_or_assign(op->out()->global_id(), out);
 }
 } // namespace tt::runtime::ttnn::operations::ccl

--- a/test/ttmlir/Conversion/StableHLOToTTIR/ccl_ops.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/ccl_ops.mlir
@@ -196,8 +196,36 @@ module @all_reduce_1x32 attributes {mhlo.num_partitions = 32 : i32, mhlo.num_rep
   }
 }
 
+// jax/pjrt sharding target 1x2 for n300 all_gather cluster_axis=0 rank=2
+module @all_gather_1x2_rank_2_cluster_0 attributes {mhlo.num_partitions = 2 : i32, mhlo.num_replicas = 1 : i32} {
+  func.func public @main(%arg0: tensor<8192x800xf32>) -> (tensor<8192x800xf32> {jax.result_info = ""}) {
+    %0 = stablehlo.custom_call @Sharding(%arg0) {backend_config = "", mhlo.sharding = "{devices=[1,2]<=[2]}"} : (tensor<8192x800xf32>) -> tensor<8192x800xf32>
+    %1 = stablehlo.custom_call @SPMDFullToShardShape(%0) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<8192x800xf32>) -> tensor<8192x400xf32>
+    // CHECK: "ttir.mesh_shard"
+    // CHECK-SAME: shard_dims = array<i64: -1, 1>
+    // CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
+    // CHECK-SAME: shard_shape = array<i64: 1, 2>
+    // CHECK-SAME: shard_type = #tt.shard_type<devices>
+    %2 = call @shmap_body(%1) : (tensor<8192x400xf32>) -> tensor<8192x400xf32>
+    %3 = stablehlo.custom_call @Sharding(%2) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<8192x400xf32>) -> tensor<8192x400xf32>
+    %4 = stablehlo.custom_call @SPMDShardToFullShape(%3) {backend_config = "", mhlo.sharding = "{devices=[1,2]<=[2]}"} : (tensor<8192x400xf32>) -> tensor<8192x800xf32>
+    // CHECK: "ttir.mesh_shard"
+    // CHECK-SAME: shard_dims = array<i64: -1, 1>
+    // CHECK-SAME: shard_direction = #tt.shard_direction<shard_to_full>
+    // CHECK-SAME: shard_shape = array<i64: 1, 2>
+    // CHECK-SAME: shard_type = #tt.shard_type<devices>
+    return %4 : tensor<8192x800xf32>
+  }
+  func.func private @shmap_body(%arg0: tensor<8192x400xf32>) -> (tensor<8192x400xf32> {jax.result_info = "[('batch',), ('model',)]"}) {
+    %0 = "stablehlo.all_gather"(%arg0) <{all_gather_dim = 1 : i64, channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>, replica_groups = dense<[[0], [1]]> : tensor<2x1xi64>, use_global_device_ids}> : (tensor<8192x400xf32>) -> tensor<8192x400xf32>
+    // CHECK: "ttir.all_gather"
+    // CHECK-SAME: cluster_axis = 0 : ui32
+    return %0 : tensor<8192x400xf32>
+  }
+}
+
 // jax/pjrt sharding target 1x2 for n300 all_gather rank=2
-module @all_gather_1x2_rank_2 attributes {mhlo.num_partitions = 2 : i32, mhlo.num_replicas = 1 : i32} {
+module @all_gather_1x2_rank_2_cluster_1 attributes {mhlo.num_partitions = 2 : i32, mhlo.num_replicas = 1 : i32} {
   func.func public @main(%arg0: tensor<8192x800xf32>) -> (tensor<16384x800xf32> {jax.result_info = ""}) {
     %0 = stablehlo.custom_call @Sharding(%arg0) {backend_config = "", mhlo.sharding = "{devices=[2,1]<=[2]}"} : (tensor<8192x800xf32>) -> tensor<8192x800xf32>
     %1 = stablehlo.custom_call @SPMDFullToShardShape(%0) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<8192x800xf32>) -> tensor<4096x800xf32>
@@ -218,13 +246,42 @@ module @all_gather_1x2_rank_2 attributes {mhlo.num_partitions = 2 : i32, mhlo.nu
   }
   func.func private @shmap_body(%arg0: tensor<4096x800xf32>) -> (tensor<8192x800xf32> {jax.result_info = "[('batch',), ('model',)]"}) {
     %0 = "stablehlo.all_gather"(%arg0) <{all_gather_dim = 0 : i64, channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>, replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>, use_global_device_ids}> : (tensor<4096x800xf32>) -> tensor<8192x800xf32>
-    // CHECK: %[[C:.*]] = "ttir.all_gather"[[C:.*]]
+    // CHECK: "ttir.all_gather"
+    // CHECK-SAME: cluster_axis = 1 : ui32
     return %0 : tensor<8192x800xf32>
   }
 }
 
+// jax/pjrt sharding target 1x2 for n300 all_gather cluster_axis=0 rank=4
+module @all_gather_1x2_rank_4_cluster_0 attributes {mhlo.num_partitions = 2 : i32, mhlo.num_replicas = 1 : i32} {
+  func.func public @main(%arg0: tensor<1x1x8192x512xf32>) -> (tensor<1x1x8192x512xf32> {jax.result_info = ""}) {
+    %0 = stablehlo.custom_call @Sharding(%arg0) {backend_config = "", mhlo.sharding = "{devices=[1,1,1,2]<=[2]}"} : (tensor<1x1x8192x512xf32>) -> tensor<1x1x8192x512xf32>
+    %1 = stablehlo.custom_call @SPMDFullToShardShape(%0) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<1x1x8192x512xf32>) -> tensor<1x1x8192x256xf32>
+    // CHECK: "ttir.mesh_shard"
+    // CHECK-SAME: shard_dims = array<i64: -1, 3>
+    // CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
+    // CHECK-SAME: shard_shape = array<i64: 1, 1, 1, 2>
+    // CHECK-SAME: shard_type = #tt.shard_type<devices>
+    %2 = call @shmap_body(%1) : (tensor<1x1x8192x256xf32>) -> tensor<1x1x8192x256xf32>
+    %3 = stablehlo.custom_call @Sharding(%2) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<1x1x8192x256xf32>) -> tensor<1x1x8192x256xf32>
+    %4 = stablehlo.custom_call @SPMDShardToFullShape(%3) {backend_config = "", mhlo.sharding = "{devices=[1,1,1,2]<=[2]}"} : (tensor<1x1x8192x256xf32>) -> tensor<1x1x8192x512xf32>
+    // CHECK: "ttir.mesh_shard"
+    // CHECK-SAME: shard_dims = array<i64: -1, 3>
+    // CHECK-SAME: shard_direction = #tt.shard_direction<shard_to_full>
+    // CHECK-SAME: shard_shape = array<i64: 1, 1, 1, 2>
+    // CHECK-SAME: shard_type = #tt.shard_type<devices>
+    return %4 : tensor<1x1x8192x512xf32>
+  }
+  func.func private @shmap_body(%arg0: tensor<1x1x8192x256xf32>) -> (tensor<1x1x8192x256xf32> {jax.result_info = "[None, None, ('batch',), ('model',)]"}) {
+    %0 = "stablehlo.all_gather"(%arg0) <{all_gather_dim = 2 : i64, channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>, replica_groups = dense<[[0], [1]]> : tensor<2x1xi64>, use_global_device_ids}> : (tensor<1x1x8192x256xf32>) -> tensor<1x1x8192x256xf32>
+    // CHECK: "ttir.all_gather"
+    // CHECK-SAME: cluster_axis = 0 : ui32
+    return %0 : tensor<1x1x8192x256xf32>
+  }
+}
+
 // jax/pjrt sharding target 1x2 for n300 all_gather rank=4
-module @all_gather_1x2_rank_4 attributes {mhlo.num_partitions = 2 : i32, mhlo.num_replicas = 1 : i32} {
+module @all_gather_1x2_rank_4_cluster_1 attributes {mhlo.num_partitions = 2 : i32, mhlo.num_replicas = 1 : i32} {
   func.func public @main(%arg0: tensor<1x1x8192x784xf32>) -> (tensor<1x1x16384x784xf32> {jax.result_info = ""}) {
     %0 = stablehlo.custom_call @Sharding(%arg0) {backend_config = "", mhlo.sharding = "{devices=[1,1,2,1]<=[2]}"} : (tensor<1x1x8192x784xf32>) -> tensor<1x1x8192x784xf32>
     %1 = stablehlo.custom_call @SPMDFullToShardShape(%0) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<1x1x8192x784xf32>) -> tensor<1x1x4096x784xf32>
@@ -245,13 +302,42 @@ module @all_gather_1x2_rank_4 attributes {mhlo.num_partitions = 2 : i32, mhlo.nu
   }
   func.func private @shmap_body(%arg0: tensor<1x1x4096x784xf32>) -> (tensor<1x1x8192x784xf32> {jax.result_info = "[None, None, ('model',), None]"}) {
     %0 = "stablehlo.all_gather"(%arg0) <{all_gather_dim = 2 : i64, channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>, replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>, use_global_device_ids}> : (tensor<1x1x4096x784xf32>) -> tensor<1x1x8192x784xf32>
-    // CHECK: %[[C:.*]] = "ttir.all_gather"[[C:.*]]
+    // CHECK: "ttir.all_gather"
+    // CHECK-SAME: cluster_axis = 1 : ui32
     return %0 : tensor<1x1x8192x784xf32>
   }
 }
 
+// jax/pjrt sharding target 1x8 for t3k all_gather cluster_axis=0 rank=2
+module @all_gather_1x8_rank_2_cluster_0 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas = 1 : i32} {
+  func.func public @main(%arg0: tensor<8192x800xf32>) -> (tensor<8192x800xf32> {jax.result_info = ""}) {
+    %0 = stablehlo.custom_call @Sharding(%arg0) {backend_config = "", mhlo.sharding = "{devices=[1,8]<=[8]}"} : (tensor<8192x800xf32>) -> tensor<8192x800xf32>
+    %1 = stablehlo.custom_call @SPMDFullToShardShape(%0) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<8192x800xf32>) -> tensor<8192x100xf32>
+    // CHECK: "ttir.mesh_shard"
+    // CHECK-SAME: shard_dims = array<i64: -1, 1>
+    // CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
+    // CHECK-SAME: shard_shape = array<i64: 1, 8>
+    // CHECK-SAME: shard_type = #tt.shard_type<devices>
+    %2 = call @shmap_body(%1) : (tensor<8192x100xf32>) -> tensor<8192x100xf32>
+    %3 = stablehlo.custom_call @Sharding(%2) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<8192x100xf32>) -> tensor<8192x100xf32>
+    %4 = stablehlo.custom_call @SPMDShardToFullShape(%3) {backend_config = "", mhlo.sharding = "{devices=[1,8]<=[8]}"} : (tensor<8192x100xf32>) -> tensor<8192x800xf32>
+    // CHECK: "ttir.mesh_shard"
+    // CHECK-SAME: shard_dims = array<i64: -1, 1>
+    // CHECK-SAME: shard_direction = #tt.shard_direction<shard_to_full>
+    // CHECK-SAME: shard_shape = array<i64: 1, 8>
+    // CHECK-SAME: shard_type = #tt.shard_type<devices>
+    return %4 : tensor<8192x800xf32>
+  }
+  func.func private @shmap_body(%arg0: tensor<8192x100xf32>) -> (tensor<8192x100xf32> {jax.result_info = "[('batch',), ('model',)]"}) {
+    %0 = "stablehlo.all_gather"(%arg0) <{all_gather_dim = 1 : i64, channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>, replica_groups = dense<[[0], [1], [2], [3], [4], [5], [6], [7]]> : tensor<8x1xi64>, use_global_device_ids}> : (tensor<8192x100xf32>) -> tensor<8192x100xf32>
+    // CHECK: "ttir.all_gather"
+    // CHECK-SAME: cluster_axis = 0 : ui32
+    return %0 : tensor<8192x100xf32>
+  }
+}
+
 // jax/pjrt sharding target 1x8 for t3k all_gather rank=2
-module @all_gather_1x8_rank_2 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas = 1 : i32} {
+module @all_gather_1x8_rank_2_cluster_1 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas = 1 : i32} {
   func.func public @main(%arg0: tensor<8192x800xf32>) -> (tensor<65536x800xf32> {jax.result_info = ""}) {
     %0 = stablehlo.custom_call @Sharding(%arg0) {backend_config = "", mhlo.sharding = "{devices=[8,1]<=[8]}"} : (tensor<8192x800xf32>) -> tensor<8192x800xf32>
     %1 = stablehlo.custom_call @SPMDFullToShardShape(%0) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<8192x800xf32>) -> tensor<1024x800xf32>
@@ -272,13 +358,42 @@ module @all_gather_1x8_rank_2 attributes {mhlo.num_partitions = 8 : i32, mhlo.nu
   }
   func.func private @shmap_body(%arg0: tensor<1024x800xf32>) -> (tensor<8192x800xf32> {jax.result_info = "[('batch',), ('model',)]"}) {
     %0 = "stablehlo.all_gather"(%arg0) <{all_gather_dim = 0 : i64, channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>, replica_groups = dense<[[0, 1, 2, 3, 4, 5, 6, 7]]> : tensor<1x8xi64>, use_global_device_ids}> : (tensor<1024x800xf32>) -> tensor<8192x800xf32>
-    // CHECK: %[[C:.*]] = "ttir.all_gather"[[C:.*]]
+    // CHECK: "ttir.all_gather"
+    // CHECK-SAME: cluster_axis = 1 : ui32
     return %0 : tensor<8192x800xf32>
   }
 }
 
+// jax/pjrt sharding target 1x8 for t3k all_gather cluster_axis=0 rank=4
+module @all_gather_1x8_rank_4_cluster_0 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas = 1 : i32} {
+  func.func public @main(%arg0: tensor<1x1x8192x512xf32>) -> (tensor<1x1x8192x512xf32> {jax.result_info = ""}) {
+    %0 = stablehlo.custom_call @Sharding(%arg0) {backend_config = "", mhlo.sharding = "{devices=[1,1,1,8]<=[8]}"} : (tensor<1x1x8192x512xf32>) -> tensor<1x1x8192x512xf32>
+    %1 = stablehlo.custom_call @SPMDFullToShardShape(%0) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<1x1x8192x512xf32>) -> tensor<1x1x8192x64xf32>
+    // CHECK: "ttir.mesh_shard"
+    // CHECK-SAME: shard_dims = array<i64: -1, 3>
+    // CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
+    // CHECK-SAME: shard_shape = array<i64: 1, 1, 1, 8>
+    // CHECK-SAME: shard_type = #tt.shard_type<devices>
+    %2 = call @shmap_body(%1) : (tensor<1x1x8192x64xf32>) -> tensor<1x1x8192x64xf32>
+    %3 = stablehlo.custom_call @Sharding(%2) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<1x1x8192x64xf32>) -> tensor<1x1x8192x64xf32>
+    %4 = stablehlo.custom_call @SPMDShardToFullShape(%3) {backend_config = "", mhlo.sharding = "{devices=[1,1,1,8]<=[8]}"} : (tensor<1x1x8192x64xf32>) -> tensor<1x1x8192x512xf32>
+    // CHECK: "ttir.mesh_shard"
+    // CHECK-SAME: shard_dims = array<i64: -1, 3>
+    // CHECK-SAME: shard_direction = #tt.shard_direction<shard_to_full>
+    // CHECK-SAME: shard_shape = array<i64: 1, 1, 1, 8>
+    // CHECK-SAME: shard_type = #tt.shard_type<devices>
+    return %4 : tensor<1x1x8192x512xf32>
+  }
+  func.func private @shmap_body(%arg0: tensor<1x1x8192x64xf32>) -> (tensor<1x1x8192x64xf32> {jax.result_info = "[None, None, ('batch',), ('model',)]"}) {
+    %0 = "stablehlo.all_gather"(%arg0) <{all_gather_dim = 2 : i64, channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>, replica_groups = dense<[[0], [1], [2], [3], [4], [5], [6], [7]]> : tensor<8x1xi64>, use_global_device_ids}> : (tensor<1x1x8192x64xf32>) -> tensor<1x1x8192x64xf32>
+    // CHECK: "ttir.all_gather"
+    // CHECK-SAME: cluster_axis = 0 : ui32
+    return %0 : tensor<1x1x8192x64xf32>
+  }
+}
+
 // jax/pjrt sharding target 1x8 for t3k all_gather rank=4
-module @all_gather_1x8_rank4 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas = 1 : i32} {
+module @all_gather_1x8_rank_4_cluster_1 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas = 1 : i32} {
   func.func public @main(%arg0: tensor<1x1x8192x784xf32>) -> (tensor<1x1x65536x784xf32> {jax.result_info = ""}) {
     %0 = stablehlo.custom_call @Sharding(%arg0) {backend_config = "", mhlo.sharding = "{devices=[1,1,8,1]<=[8]}"} : (tensor<1x1x8192x784xf32>) -> tensor<1x1x8192x784xf32>
     %1 = stablehlo.custom_call @SPMDFullToShardShape(%0) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<1x1x8192x784xf32>) -> tensor<1x1x1024x784xf32>
@@ -299,13 +414,42 @@ module @all_gather_1x8_rank4 attributes {mhlo.num_partitions = 8 : i32, mhlo.num
   }
   func.func private @shmap_body(%arg0: tensor<1x1x1024x784xf32>) -> (tensor<1x1x8192x784xf32> {jax.result_info = "[None, None, ('model',), None]"}) {
     %0 = "stablehlo.all_gather"(%arg0) <{all_gather_dim = 2 : i64, channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>, replica_groups = dense<[[0, 1, 2, 3, 4, 5, 6, 7]]> : tensor<1x8xi64>, use_global_device_ids}> : (tensor<1x1x1024x784xf32>) -> tensor<1x1x8192x784xf32>
-    // CHECK: %[[C:.*]] = "ttir.all_gather"[[C:.*]]
+    // CHECK: "ttir.all_gather"
+    // CHECK-SAME: cluster_axis = 1 : ui32
     return %0 : tensor<1x1x8192x784xf32>
   }
 }
 
+// jax/pjrt sharding target 2x4 for t3k all_gather cluster_axis=0 rank=2
+module @all_gather_2x4_rank_2_cluster_0 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas = 1 : i32} {
+  func.func public @main(%arg0: tensor<8192x800xf32>) -> (tensor<8192x1600xf32> {jax.result_info = ""}) {
+    %0 = stablehlo.custom_call @Sharding(%arg0) {backend_config = "", mhlo.sharding = "{devices=[4,2]<=[2,4]T(1,0)}"} : (tensor<8192x800xf32>) -> tensor<8192x800xf32>
+    %1 = stablehlo.custom_call @SPMDFullToShardShape(%0) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<8192x800xf32>) -> tensor<2048x400xf32>
+    // CHECK: "ttir.mesh_shard"
+    // CHECK-SAME: shard_dims = array<i64: 1, 0>
+    // CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
+    // CHECK-SAME: shard_shape = array<i64: 4, 2>
+    // CHECK-SAME: shard_type = #tt.shard_type<devices>
+    %2 = call @shmap_body(%1) : (tensor<2048x400xf32>) -> tensor<2048x800xf32>
+    %3 = stablehlo.custom_call @Sharding(%2) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<2048x800xf32>) -> tensor<2048x800xf32>
+    %4 = stablehlo.custom_call @SPMDShardToFullShape(%3) {backend_config = "", mhlo.sharding = "{devices=[4,2]<=[2,4]T(1,0)}"} : (tensor<2048x800xf32>) -> tensor<8192x1600xf32>
+    // CHECK: "ttir.mesh_shard"
+    // CHECK-SAME: shard_dims = array<i64: 1, 0>
+    // CHECK-SAME: shard_direction = #tt.shard_direction<shard_to_full>
+    // CHECK-SAME: shard_shape = array<i64: 4, 2>
+    // CHECK-SAME: shard_type = #tt.shard_type<devices>
+    return %4 : tensor<8192x1600xf32>
+  }
+  func.func private @shmap_body(%arg0: tensor<2048x400xf32>) -> (tensor<2048x800xf32> {jax.result_info = "[('batch',), ('model',)]"}) {
+    %0 = "stablehlo.all_gather"(%arg0) <{all_gather_dim = 1 : i64, channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>, replica_groups = dense<[[0, 4], [1, 5], [2, 6], [3, 7]]> : tensor<4x2xi64>, use_global_device_ids}> : (tensor<2048x400xf32>) -> tensor<2048x800xf32>
+    // CHECK: "ttir.all_gather"
+    // CHECK-SAME: cluster_axis = 0 : ui32
+    return %0 : tensor<2048x800xf32>
+  }
+}
+
 // jax/pjrt sharding target 2x4 for t3k all_gather rank=2
-module @all_gather_2x4_rank_2 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas = 1 : i32} {
+module @all_gather_2x4_rank_2_cluster_1 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas = 1 : i32} {
   func.func public @main(%arg0: tensor<8192x800xf32>) -> (tensor<32768x800xf32> {jax.result_info = ""}) {
     %0 = stablehlo.custom_call @Sharding(%arg0) {backend_config = "", mhlo.sharding = "{devices=[4,2]<=[2,4]T(1,0)}"} : (tensor<8192x800xf32>) -> tensor<8192x800xf32>
     %1 = stablehlo.custom_call @SPMDFullToShardShape(%0) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<8192x800xf32>) -> tensor<2048x400xf32>
@@ -326,13 +470,42 @@ module @all_gather_2x4_rank_2 attributes {mhlo.num_partitions = 8 : i32, mhlo.nu
   }
   func.func private @shmap_body(%arg0: tensor<2048x400xf32>) -> (tensor<8192x400xf32> {jax.result_info = "[('batch',), ('model',)]"}) {
     %0 = "stablehlo.all_gather"(%arg0) <{all_gather_dim = 0 : i64, channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>, replica_groups = dense<[[0, 1, 2, 3], [4, 5, 6, 7]]> : tensor<2x4xi64>, use_global_device_ids}> : (tensor<2048x400xf32>) -> tensor<8192x400xf32>
-    // CHECK: %[[C:.*]] = "ttir.all_gather"[[C:.*]]
+    // CHECK: "ttir.all_gather"
+    // CHECK-SAME: cluster_axis = 1 : ui32
     return %0 : tensor<8192x400xf32>
   }
 }
 
+// jax/pjrt sharding target 2x4 for t3k all_gather cluster_axis=0 rank=4
+module @all_gather_2x4_rank_4_cluster_0 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas = 1 : i32} {
+  func.func public @main(%arg0: tensor<1x1x8192x512xf32>) -> (tensor<1x1x16384x512xf32> {jax.result_info = ""}) {
+    %0 = stablehlo.custom_call @Sharding(%arg0) {backend_config = "", mhlo.sharding = "{devices=[1,1,2,4]<=[8]}"} : (tensor<1x1x8192x512xf32>) -> tensor<1x1x8192x512xf32>
+    %1 = stablehlo.custom_call @SPMDFullToShardShape(%0) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<1x1x8192x512xf32>) -> tensor<1x1x4096x128xf32>
+    // CHECK: "ttir.mesh_shard"
+    // CHECK-SAME: shard_dims = array<i64: 2, 3>
+    // CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
+    // CHECK-SAME: shard_shape = array<i64: 1, 1, 2, 4>
+    // CHECK-SAME: shard_type = #tt.shard_type<devices>
+    %2 = call @shmap_body(%1) : (tensor<1x1x4096x128xf32>) -> tensor<1x1x8192x128xf32>
+    %3 = stablehlo.custom_call @Sharding(%2) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<1x1x8192x128xf32>) -> tensor<1x1x8192x128xf32>
+    %4 = stablehlo.custom_call @SPMDShardToFullShape(%3) {backend_config = "", mhlo.sharding = "{devices=[1,1,2,4]<=[8]}"} : (tensor<1x1x8192x128xf32>) -> tensor<1x1x16384x512xf32>
+    // CHECK: "ttir.mesh_shard"
+    // CHECK-SAME: shard_dims = array<i64: 2, 3>
+    // CHECK-SAME: shard_direction = #tt.shard_direction<shard_to_full>
+    // CHECK-SAME: shard_shape = array<i64: 1, 1, 2, 4>
+    // CHECK-SAME: shard_type = #tt.shard_type<devices>
+    return %4 : tensor<1x1x16384x512xf32>
+  }
+  func.func private @shmap_body(%arg0: tensor<1x1x4096x128xf32>) -> (tensor<1x1x8192x128xf32> {jax.result_info = "[None, None, ('batch',), ('model',)]"}) {
+    %0 = "stablehlo.all_gather"(%arg0) <{all_gather_dim = 2 : i64, channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>, replica_groups = dense<[[0, 4], [1, 5], [2, 6], [3, 7]]> : tensor<4x2xi64>, use_global_device_ids}> : (tensor<1x1x4096x128xf32>) -> tensor<1x1x8192x128xf32>
+    // CHECK: "ttir.all_gather"
+    // CHECK-SAME: cluster_axis = 0 : ui32
+    return %0 : tensor<1x1x8192x128xf32>
+  }
+}
+
 // jax/pjrt sharding target 2x4 for t3k all_gather rank=4
-module @all_gather_2x4_rank4 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas = 1 : i32} {
+module @all_gather_2x4_rank_4_cluster_1 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas = 1 : i32} {
   func.func public @main(%arg0: tensor<1x1x8192x784xf32>) -> (tensor<1x1x32768x784xf32> {jax.result_info = ""}) {
     %0 = stablehlo.custom_call @Sharding(%arg0) {backend_config = "", mhlo.sharding = "{devices=[1,1,4,2]<=[2,4]T(1,0)}"} : (tensor<1x1x8192x784xf32>) -> tensor<1x1x8192x784xf32>
     %1 = stablehlo.custom_call @SPMDFullToShardShape(%0) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<1x1x8192x784xf32>) -> tensor<1x1x2048x392xf32>
@@ -353,13 +526,42 @@ module @all_gather_2x4_rank4 attributes {mhlo.num_partitions = 8 : i32, mhlo.num
   }
   func.func private @shmap_body(%arg0: tensor<1x1x2048x392xf32>) -> (tensor<1x1x8192x392xf32> {jax.result_info = "[None, None, ('model',), ('batch',)]"}) {
     %0 = "stablehlo.all_gather"(%arg0) <{all_gather_dim = 2 : i64, channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>, replica_groups = dense<[[0, 1, 2, 3], [4, 5, 6, 7]]> : tensor<2x4xi64>, use_global_device_ids}> : (tensor<1x1x2048x392xf32>) -> tensor<1x1x8192x392xf32>
-    // CHECK: %[[C:.*]] = "ttir.all_gather"[[C:.*]]
+    // CHECK: "ttir.all_gather"
+    // CHECK-SAME: cluster_axis = 1 : ui32
     return %0 : tensor<1x1x8192x392xf32>
   }
 }
 
+// jax/pjrt sharding target 1x32 for tg all_gather cluster_axis=0 rank=2
+module @all_gather_1x32_rank_2_cluster_0 attributes {mhlo.num_partitions = 32 : i32, mhlo.num_replicas = 1 : i32} {
+  func.func public @main(%arg0: tensor<8192x800xf32>) -> (tensor<8192x800xf32> {jax.result_info = ""}) {
+    %0 = stablehlo.custom_call @Sharding(%arg0) {backend_config = "", mhlo.sharding = "{devices=[1,32]<=[32]}"} : (tensor<8192x800xf32>) -> tensor<8192x800xf32>
+    %1 = stablehlo.custom_call @SPMDFullToShardShape(%0) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<8192x800xf32>) -> tensor<8192x25xf32>
+    // CHECK: "ttir.mesh_shard"
+    // CHECK-SAME: shard_dims = array<i64: -1, 1>
+    // CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
+    // CHECK-SAME: shard_shape = array<i64: 1, 32>
+    // CHECK-SAME: shard_type = #tt.shard_type<devices>
+    %2 = call @shmap_body(%1) : (tensor<8192x25xf32>) -> tensor<8192x25xf32>
+    %3 = stablehlo.custom_call @Sharding(%2) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<8192x25xf32>) -> tensor<8192x25xf32>
+    %4 = stablehlo.custom_call @SPMDShardToFullShape(%3) {backend_config = "", mhlo.sharding = "{devices=[1,32]<=[32]}"} : (tensor<8192x25xf32>) -> tensor<8192x800xf32>
+    // CHECK: "ttir.mesh_shard"
+    // CHECK-SAME: shard_dims = array<i64: -1, 1>
+    // CHECK-SAME: shard_direction = #tt.shard_direction<shard_to_full>
+    // CHECK-SAME: shard_shape = array<i64: 1, 32>
+    // CHECK-SAME: shard_type = #tt.shard_type<devices>
+    return %4 : tensor<8192x800xf32>
+  }
+  func.func private @shmap_body(%arg0: tensor<8192x25xf32>) -> (tensor<8192x25xf32> {jax.result_info = "[('batch',), ('model',)]"}) {
+    %0 = "stablehlo.all_gather"(%arg0) <{all_gather_dim = 1 : i64, channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>, replica_groups = dense<[[0], [1], [2], [3], [4], [5], [6], [7], [8], [9], [10], [11], [12], [13], [14], [15], [16], [17], [18], [19], [20], [21], [22], [23], [24], [25], [26], [27], [28], [29], [30], [31]]> : tensor<32x1xi64>, use_global_device_ids}> : (tensor<8192x25xf32>) -> tensor<8192x25xf32>
+    // CHECK: "ttir.all_gather"
+    // CHECK-SAME: cluster_axis = 0 : ui32
+    return %0 : tensor<8192x25xf32>
+  }
+}
+
 // jax/pjrt sharding target 1x32 for tg all_gather rank=2
-module @all_gather_1x32_rank_2 attributes {mhlo.num_partitions = 32 : i32, mhlo.num_replicas = 1 : i32} {
+module @all_gather_1x32_rank_2_cluster_1 attributes {mhlo.num_partitions = 32 : i32, mhlo.num_replicas = 1 : i32} {
   func.func public @main(%arg0: tensor<8192x800xf32>) -> (tensor<262144x800xf32> {jax.result_info = ""}) {
     %0 = stablehlo.custom_call @Sharding(%arg0) {backend_config = "", mhlo.sharding = "{devices=[32,1]<=[32]}"} : (tensor<8192x800xf32>) -> tensor<8192x800xf32>
     %1 = stablehlo.custom_call @SPMDFullToShardShape(%0) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<8192x800xf32>) -> tensor<256x800xf32>
@@ -380,13 +582,42 @@ module @all_gather_1x32_rank_2 attributes {mhlo.num_partitions = 32 : i32, mhlo.
   }
   func.func private @shmap_body(%arg0: tensor<256x800xf32>) -> (tensor<8192x800xf32> {jax.result_info = "[('batch',), ('model',)]"}) {
     %0 = "stablehlo.all_gather"(%arg0) <{all_gather_dim = 0 : i64, channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>, replica_groups = dense<[[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]]> : tensor<1x32xi64>, use_global_device_ids}> : (tensor<256x800xf32>) -> tensor<8192x800xf32>
-    // CHECK: %[[C:.*]] = "ttir.all_gather"[[C:.*]]
+    // CHECK: "ttir.all_gather"
+    // CHECK-SAME: cluster_axis = 1 : ui32
     return %0 : tensor<8192x800xf32>
   }
 }
 
+// jax/pjrt sharding target 1x32 for tg all_gather cluster_axis=0 rank=4
+module @all_gather_1x32_rank_4_cluster_0 attributes {mhlo.num_partitions = 32 : i32, mhlo.num_replicas = 1 : i32} {
+  func.func public @main(%arg0: tensor<1x1x8192x512xf32>) -> (tensor<1x1x8192x512xf32> {jax.result_info = ""}) {
+    %0 = stablehlo.custom_call @Sharding(%arg0) {backend_config = "", mhlo.sharding = "{devices=[1,1,1,32]<=[32]}"} : (tensor<1x1x8192x512xf32>) -> tensor<1x1x8192x512xf32>
+    %1 = stablehlo.custom_call @SPMDFullToShardShape(%0) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<1x1x8192x512xf32>) -> tensor<1x1x8192x16xf32>
+    // CHECK: "ttir.mesh_shard"
+    // CHECK-SAME: shard_dims = array<i64: -1, 3>
+    // CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
+    // CHECK-SAME: shard_shape = array<i64: 1, 1, 1, 32>
+    // CHECK-SAME: shard_type = #tt.shard_type<devices>
+    %2 = call @shmap_body(%1) : (tensor<1x1x8192x16xf32>) -> tensor<1x1x8192x16xf32>
+    %3 = stablehlo.custom_call @Sharding(%2) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<1x1x8192x16xf32>) -> tensor<1x1x8192x16xf32>
+    %4 = stablehlo.custom_call @SPMDShardToFullShape(%3) {backend_config = "", mhlo.sharding = "{devices=[1,1,1,32]<=[32]}"} : (tensor<1x1x8192x16xf32>) -> tensor<1x1x8192x512xf32>
+    // CHECK: "ttir.mesh_shard"
+    // CHECK-SAME: shard_dims = array<i64: -1, 3>
+    // CHECK-SAME: shard_direction = #tt.shard_direction<shard_to_full>
+    // CHECK-SAME: shard_shape = array<i64: 1, 1, 1, 32>
+    // CHECK-SAME: shard_type = #tt.shard_type<devices>
+    return %4 : tensor<1x1x8192x512xf32>
+  }
+  func.func private @shmap_body(%arg0: tensor<1x1x8192x16xf32>) -> (tensor<1x1x8192x16xf32> {jax.result_info = "[None, None, ('batch',), ('model',)]"}) {
+    %0 = "stablehlo.all_gather"(%arg0) <{all_gather_dim = 2 : i64, channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>, replica_groups = dense<[[0], [1], [2], [3], [4], [5], [6], [7], [8], [9], [10], [11], [12], [13], [14], [15], [16], [17], [18], [19], [20], [21], [22], [23], [24], [25], [26], [27], [28], [29], [30], [31]]> : tensor<32x1xi64>, use_global_device_ids}> : (tensor<1x1x8192x16xf32>) -> tensor<1x1x8192x16xf32>
+    // CHECK: "ttir.all_gather"
+    // CHECK-SAME: cluster_axis = 0 : ui32
+    return %0 : tensor<1x1x8192x16xf32>
+  }
+}
+
 // jax/pjrt sharding target 1x32 for tg all_gather rank4
-module @all_gather_1x32_rank4 attributes {mhlo.num_partitions = 32 : i32, mhlo.num_replicas = 1 : i32} {
+module @all_gather_1x32_rank_4_cluster_1 attributes {mhlo.num_partitions = 32 : i32, mhlo.num_replicas = 1 : i32} {
   func.func public @main(%arg0: tensor<1x1x8192x784xf32>) -> (tensor<1x1x262144x784xf32> {jax.result_info = ""}) {
     %0 = stablehlo.custom_call @Sharding(%arg0) {backend_config = "", mhlo.sharding = "{devices=[1,1,32,1]<=[32]}"} : (tensor<1x1x8192x784xf32>) -> tensor<1x1x8192x784xf32>
     %1 = stablehlo.custom_call @SPMDFullToShardShape(%0) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<1x1x8192x784xf32>) -> tensor<1x1x256x784xf32>
@@ -407,13 +638,42 @@ module @all_gather_1x32_rank4 attributes {mhlo.num_partitions = 32 : i32, mhlo.n
   }
   func.func private @shmap_body(%arg0: tensor<1x1x256x784xf32>) -> (tensor<1x1x8192x784xf32> {jax.result_info = "[None, None, ('model',), None]"}) {
     %0 = "stablehlo.all_gather"(%arg0) <{all_gather_dim = 2 : i64, channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>, replica_groups = dense<[[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]]> : tensor<1x32xi64>, use_global_device_ids}> : (tensor<1x1x256x784xf32>) -> tensor<1x1x8192x784xf32>
-    // CHECK: %[[C:.*]] = "ttir.all_gather"[[C:.*]]
+    // CHECK: "ttir.all_gather"
+    // CHECK-SAME: cluster_axis = 1 : ui32
     return %0 : tensor<1x1x8192x784xf32>
   }
 }
 
+// jax/pjrt sharding target 8x4 for tg all_gather cluster_axis=0 rank=2
+module @all_gather_8x4_rank_2_cluster_0 attributes {mhlo.num_partitions = 32 : i32, mhlo.num_replicas = 1 : i32} {
+  func.func public @main(%arg0: tensor<8192x800xf32>) -> (tensor<8192x6400xf32> {jax.result_info = ""}) {
+    %0 = stablehlo.custom_call @Sharding(%arg0) {backend_config = "", mhlo.sharding = "{devices=[4,8]<=[8,4]T(1,0)}"} : (tensor<8192x800xf32>) -> tensor<8192x800xf32>
+    %1 = stablehlo.custom_call @SPMDFullToShardShape(%0) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<8192x800xf32>) -> tensor<2048x100xf32>
+    // CHECK: "ttir.mesh_shard"
+    // CHECK-SAME: shard_dims = array<i64: 1, 0>
+    // CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
+    // CHECK-SAME: shard_shape = array<i64: 4, 8>
+    // CHECK-SAME: shard_type = #tt.shard_type<devices>
+    %2 = call @shmap_body(%1) : (tensor<2048x100xf32>) -> tensor<2048x800xf32>
+    %3 = stablehlo.custom_call @Sharding(%2) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<2048x800xf32>) -> tensor<2048x800xf32>
+    %4 = stablehlo.custom_call @SPMDShardToFullShape(%3) {backend_config = "", mhlo.sharding = "{devices=[4,8]<=[8,4]T(1,0)}"} : (tensor<2048x800xf32>) -> tensor<8192x6400xf32>
+    // CHECK: "ttir.mesh_shard"
+    // CHECK-SAME: shard_dims = array<i64: 1, 0>
+    // CHECK-SAME: shard_direction = #tt.shard_direction<shard_to_full>
+    // CHECK-SAME: shard_shape = array<i64: 4, 8>
+    // CHECK-SAME: shard_type = #tt.shard_type<devices>
+    return %4 : tensor<8192x6400xf32>
+  }
+  func.func private @shmap_body(%arg0: tensor<2048x100xf32>) -> (tensor<2048x800xf32> {jax.result_info = "[('batch',), ('model',)]"}) {
+    %0 = "stablehlo.all_gather"(%arg0) <{all_gather_dim = 1 : i64, channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>, replica_groups = dense<[[0, 4, 8, 12, 16, 20, 24, 28], [1, 5, 9, 13, 17, 21, 25, 29], [2, 6, 10, 14, 18, 22, 26, 30], [3, 7, 11, 15, 19, 23, 27, 31]]> : tensor<4x8xi64>, use_global_device_ids}> : (tensor<2048x100xf32>) -> tensor<2048x800xf32>
+    // CHECK: "ttir.all_gather"
+    // CHECK-SAME: cluster_axis = 0 : ui32
+    return %0 : tensor<2048x800xf32>
+  }
+}
+
 // jax/pjrt sharding target 8x4 for tg all_gather rank=2
-module @all_gather_4x8_rank_2 attributes {mhlo.num_partitions = 32 : i32, mhlo.num_replicas = 1 : i32} {
+module @all_gather_4x8_rank_2_cluster_1 attributes {mhlo.num_partitions = 32 : i32, mhlo.num_replicas = 1 : i32} {
   func.func public @main(%arg0: tensor<8192x800xf32>) -> (tensor<65536x800xf32> {jax.result_info = ""}) {
     %0 = stablehlo.custom_call @Sharding(%arg0) {backend_config = "", mhlo.sharding = "{devices=[8,4]<=[4,8]T(1,0)}"} : (tensor<8192x800xf32>) -> tensor<8192x800xf32>
     %1 = stablehlo.custom_call @SPMDFullToShardShape(%0) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<8192x800xf32>) -> tensor<1024x200xf32>
@@ -434,13 +694,42 @@ module @all_gather_4x8_rank_2 attributes {mhlo.num_partitions = 32 : i32, mhlo.n
   }
   func.func private @shmap_body(%arg0: tensor<1024x200xf32>) -> (tensor<8192x200xf32> {jax.result_info = "[('batch',), ('model',)]"}) {
     %0 = "stablehlo.all_gather"(%arg0) <{all_gather_dim = 0 : i64, channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>, replica_groups = dense<[[0, 1, 2, 3, 4, 5, 6, 7], [8, 9, 10, 11, 12, 13, 14, 15], [16, 17, 18, 19, 20, 21, 22, 23], [24, 25, 26, 27, 28, 29, 30, 31]]> : tensor<4x8xi64>, use_global_device_ids}> : (tensor<1024x200xf32>) -> tensor<8192x200xf32>
-    // CHECK: %[[C:.*]] = "ttir.all_gather"[[C:.*]]
+    // CHECK: "ttir.all_gather"
+    // CHECK-SAME: cluster_axis = 1 : ui32
     return %0 : tensor<8192x200xf32>
   }
 }
 
+// jax/pjrt sharding target 8x4 for tg all_gather cluster_axis=0 rank=4
+module @all_gather_8x4_rank_4_cluster_0 attributes {mhlo.num_partitions = 32 : i32, mhlo.num_replicas = 1 : i32} {
+  func.func public @main(%arg0: tensor<1x1x8192x512xf32>) -> (tensor<1x1x65536x512xf32> {jax.result_info = ""}) {
+    %0 = stablehlo.custom_call @Sharding(%arg0) {backend_config = "", mhlo.sharding = "{devices=[1,1,8,4]<=[32]}"} : (tensor<1x1x8192x512xf32>) -> tensor<1x1x8192x512xf32>
+    %1 = stablehlo.custom_call @SPMDFullToShardShape(%0) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<1x1x8192x512xf32>) -> tensor<1x1x1024x128xf32>
+    // CHECK: "ttir.mesh_shard"
+    // CHECK-SAME: shard_dims = array<i64: 2, 3>
+    // CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
+    // CHECK-SAME: shard_shape = array<i64: 1, 1, 8, 4>
+    // CHECK-SAME: shard_type = #tt.shard_type<devices>
+    %2 = call @shmap_body(%1) : (tensor<1x1x1024x128xf32>) -> tensor<1x1x8192x128xf32>
+    %3 = stablehlo.custom_call @Sharding(%2) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<1x1x8192x128xf32>) -> tensor<1x1x8192x128xf32>
+    %4 = stablehlo.custom_call @SPMDShardToFullShape(%3) {backend_config = "", mhlo.sharding = "{devices=[1,1,8,4]<=[32]}"} : (tensor<1x1x8192x128xf32>) -> tensor<1x1x65536x512xf32>
+    // CHECK: "ttir.mesh_shard"
+    // CHECK-SAME: shard_dims = array<i64: 2, 3>
+    // CHECK-SAME: shard_direction = #tt.shard_direction<shard_to_full>
+    // CHECK-SAME: shard_shape = array<i64: 1, 1, 8, 4>
+    // CHECK-SAME: shard_type = #tt.shard_type<devices>
+    return %4 : tensor<1x1x65536x512xf32>
+  }
+  func.func private @shmap_body(%arg0: tensor<1x1x1024x128xf32>) -> (tensor<1x1x8192x128xf32> {jax.result_info = "[None, None, ('batch',), ('model',)]"}) {
+    %0 = "stablehlo.all_gather"(%arg0) <{all_gather_dim = 2 : i64, channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>, replica_groups = dense<[[0, 4, 8, 12, 16, 20, 24, 28], [1, 5, 9, 13, 17, 21, 25, 29], [2, 6, 10, 14, 18, 22, 26, 30], [3, 7, 11, 15, 19, 23, 27, 31]]> : tensor<4x8xi64>, use_global_device_ids}> : (tensor<1x1x1024x128xf32>) -> tensor<1x1x8192x128xf32>
+    // CHECK: "ttir.all_gather"
+    // CHECK-SAME: cluster_axis = 0 : ui32
+    return %0 : tensor<1x1x8192x128xf32>
+  }
+}
+
 // jax/pjrt sharding target 8x4 for tg all_gather rank4
-module @all_gather_8x4_rank4 attributes {mhlo.num_partitions = 32 : i32, mhlo.num_replicas = 1 : i32} {
+module @all_gather_8x4_rank_4_cluster_1 attributes {mhlo.num_partitions = 32 : i32, mhlo.num_replicas = 1 : i32} {
   func.func public @main(%arg0: tensor<1x1x8192x784xf32>) -> (tensor<1x1x32768x784xf32> {jax.result_info = ""}) {
     %0 = stablehlo.custom_call @Sharding(%arg0) {backend_config = "", mhlo.sharding = "{devices=[1,1,4,8]<=[8,4]T(1,0)}"} : (tensor<1x1x8192x784xf32>) -> tensor<1x1x8192x784xf32>
     %1 = stablehlo.custom_call @SPMDFullToShardShape(%0) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<1x1x8192x784xf32>) -> tensor<1x1x2048x98xf32>
@@ -461,7 +750,8 @@ module @all_gather_8x4_rank4 attributes {mhlo.num_partitions = 32 : i32, mhlo.nu
   }
   func.func private @shmap_body(%arg0: tensor<1x1x2048x98xf32>) -> (tensor<1x1x8192x98xf32> {jax.result_info = "[None, None, ('model',), ('batch',)]"}) {
     %0 = "stablehlo.all_gather"(%arg0) <{all_gather_dim = 2 : i64, channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>, replica_groups = dense<[[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11], [12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23], [24, 25, 26, 27], [28, 29, 30, 31]]> : tensor<8x4xi64>, use_global_device_ids}> : (tensor<1x1x2048x98xf32>) -> tensor<1x1x8192x98xf32>
-    // CHECK: %[[C:.*]] = "ttir.all_gather"[[C:.*]]
+    // CHECK: "ttir.all_gather"
+    // CHECK-SAME: cluster_axis = 1 : ui32
     return %0 : tensor<1x1x8192x98xf32>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/ccl/all_gather.mlir
+++ b/test/ttmlir/Dialect/TTNN/ccl/all_gather.mlir
@@ -2,8 +2,8 @@
 module attributes {} {
   func.func @forward(%arg0: tensor<1x1x32x32xbf16>) -> tensor<1x1x32x128xbf16> {
     %0 = tensor.empty() : tensor<1x1x32x128xbf16>
-    %1 = "ttir.all_gather"(%arg0, %0) <{dim = 3 : si32}> : (tensor<1x1x32x32xbf16>, tensor<1x1x32x128xbf16>) -> tensor<1x1x32x128xbf16>
-    // CHECK: %[[C:.*]] = "ttnn.all_gather"[[C:.*]]
+    %1 = "ttir.all_gather"(%arg0, %0) <{all_gather_dim = 3 : si32, channel_handle = 1 : si32, replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>, cluster_axis = 1 : ui32}> : (tensor<1x1x32x32xbf16>, tensor<1x1x32x128xbf16>) -> tensor<1x1x32x128xbf16>
+    // CHECK: "ttnn.all_gather"
     return %1 : tensor<1x1x32x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/ccl/all_gather_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/ccl/all_gather_negative.mlir
@@ -3,7 +3,7 @@
 module attributes {} {
   func.func @forward(%arg0: tensor<1x1x32x32xbf16>) -> tensor<1x1x32x128xbf16> {
     %0 = tensor.empty() : tensor<1x1x32x128xbf16>
-    %1 = "ttir.all_gather"(%arg0, %0) <{dim = 4 : si32}> : (tensor<1x1x32x32xbf16>, tensor<1x1x32x128xbf16>) -> tensor<1x1x32x128xbf16>
+    %1 = "ttir.all_gather"(%arg0, %0) <{all_gather_dim = 4 : si32, channel_handle = 1 : si32, replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>, cluster_axis = 1 : ui32}> : (tensor<1x1x32x32xbf16>, tensor<1x1x32x128xbf16>) -> tensor<1x1x32x128xbf16>
     return %1 : tensor<1x1x32x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/ccl/all_reduce.mlir
+++ b/test/ttmlir/Dialect/TTNN/ccl/all_reduce.mlir
@@ -10,8 +10,8 @@ module attributes {} {
   }
 }
 // CHECK: %[[C:.*]] = "ttnn.reshape"[[C:.*]]
-// CHECK: %[[C:.*]] = "ttnn.reduce_scatter"[[C:.*]]
-// CHECK: %[[C:.*]] = "ttnn.all_gather"[[C:.*]]
+// CHECK: "ttnn.reduce_scatter"
+// CHECK: "ttnn.all_gather"
 // CHECK: %[[C:.*]] = "ttnn.reshape"[[C:.*]]
 
 // -----
@@ -25,6 +25,6 @@ module attributes {} {
   }
 }
 // CHECK-NOT: %[[C:.*]] = "ttnn.reshape"[[C:.*]]
-// CHECK: %[[C:.*]] = "ttnn.reduce_scatter"[[C:.*]]
-// CHECK: %[[C:.*]] = "ttnn.all_gather"[[C:.*]]
+// CHECK: "ttnn.reduce_scatter"
+// CHECK: "ttnn.all_gather"
 // CHECK-NOT: %[[C:.*]] = "ttnn.reshape"[[C:.*]]

--- a/test/ttmlir/Silicon/TTNN/llmbox/ccl/ccl_1x8.mlir
+++ b/test/ttmlir/Silicon/TTNN/llmbox/ccl/ccl_1x8.mlir
@@ -1,17 +1,16 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% mesh-shape=1,8" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-// UNSUPPORTED: true
 
-func.func @forward(%arg0: tensor<1x1x32x128xf32>) -> tensor<1x1x32x128xf32> {
+func.func @all_gather_cluster1(%arg0: tensor<1x1x32x128xf32>) -> tensor<1x1x32x128xf32> {
   %0 = tensor.empty() : tensor<1x1x32x16xf32>
   %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: -1, 3>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 1, 8>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x32x128xf32>, tensor<1x1x32x16xf32>) -> tensor<1x1x32x16xf32>
-  // CHECK: %[[C:.*]] = "ttnn.mesh_shard"[[C:.*]]
+  // CHECK: "ttnn.mesh_shard"
   %2 = tensor.empty() : tensor<1x1x32x128xf32>
-  %3 = "ttir.all_gather"(%1, %2) <{dim = 3 : si32}> : (tensor<1x1x32x16xf32>, tensor<1x1x32x128xf32>) -> tensor<1x1x32x128xf32>
-  // CHECK: %[[C:.*]] = "ttnn.all_gather"[[C:.*]]
+  %3 = "ttir.all_gather"(%1, %2) <{all_gather_dim = 3 : si32, replica_groups = dense<[[0, 1, 2, 3, 4, 5, 6, 7]]> : tensor<1x8xi64>, cluster_axis = 1 : ui32}> : (tensor<1x1x32x16xf32>, tensor<1x1x32x128xf32>) -> tensor<1x1x32x128xf32>
+  // CHECK: "ttnn.all_gather"
   %4 = tensor.empty() : tensor<1x1x32x128xf32>
   %5 = "ttir.mesh_shard"(%3, %4) <{shard_dims = array<i64: -1>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1>, shard_type = #tt.shard_type<replicate>}> : (tensor<1x1x32x128xf32>, tensor<1x1x32x128xf32>) -> tensor<1x1x32x128xf32>
-  // CHECK: %[[C:.*]] = "ttnn.mesh_shard"[[C:.*]]
+  // CHECK: "ttnn.mesh_shard"
   return %5 : tensor<1x1x32x128xf32>
 }

--- a/test/ttmlir/Silicon/TTNN/llmbox/ccl/ccl_2x4.mlir
+++ b/test/ttmlir/Silicon/TTNN/llmbox/ccl/ccl_2x4.mlir
@@ -2,29 +2,42 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @forward(%arg0: tensor<1x1x256x512xf32>) -> tensor<1x1x256x512xf32> {
+func.func public @all_gather_cluster0(%arg0: tensor<1x1x8192x512xf32>) -> (tensor<1x1x16384x512xf32> {jax.result_info = ""}) {
+  %0 = tensor.empty() : tensor<1x1x4096x128xf32>
+  %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 2, 4>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x8192x512xf32>, tensor<1x1x4096x128xf32>) -> tensor<1x1x4096x128xf32>
+  // CHECK: "ttnn.mesh_shard"
+  %2 = tensor.empty() : tensor<1x1x8192x128xf32>
+  %3 = "ttir.all_gather"(%1, %2) <{all_gather_dim = 2 : si32, channel_handle = 1 : si32, replica_groups = dense<[[0, 4], [1, 5], [2, 6], [3, 7]]> : tensor<4x2xi64>, use_global_device_ids, cluster_axis = 0 : ui32}> : (tensor<1x1x4096x128xf32>, tensor<1x1x8192x128xf32>) -> tensor<1x1x8192x128xf32>
+  // CHECK: "ttnn.all_gather"
+  %4 = tensor.empty() : tensor<1x1x16384x512xf32>
+  %5 = "ttir.mesh_shard"(%3, %4) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1, 1, 2, 4>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x8192x128xf32>, tensor<1x1x16384x512xf32>) -> tensor<1x1x16384x512xf32>
+  // CHECK: "ttnn.mesh_shard"
+  return %5 : tensor<1x1x16384x512xf32>
+}
+
+func.func @all_gather_cluster1(%arg0: tensor<1x1x256x512xf32>) -> tensor<1x1x256x512xf32> {
   %0 = tensor.empty() : tensor<1x1x128x128xf32>
   %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 2, 4>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x256x512xf32>, tensor<1x1x128x128xf32>) -> tensor<1x1x128x128xf32>
-  // CHECK: %[[C:.*]] = "ttnn.mesh_shard"[[C:.*]]
+  // CHECK: "ttnn.mesh_shard"
   %2 = tensor.empty() : tensor<1x1x128x512xf32>
-  %3 = "ttir.all_gather"(%1, %2) <{dim = 3 : si32}> : (tensor<1x1x128x128xf32>, tensor<1x1x128x512xf32>) -> tensor<1x1x128x512xf32>
-  // CHECK: %[[C:.*]] = "ttnn.all_gather"[[C:.*]]
+  %3 = "ttir.all_gather"(%1, %2) <{all_gather_dim = 3 : si32, replica_groups = dense<[[0, 1, 2, 3], [4, 5, 6, 7]]> : tensor<2x4xi64>, cluster_axis = 1 : ui32}> : (tensor<1x1x128x128xf32>, tensor<1x1x128x512xf32>) -> tensor<1x1x128x512xf32>
+  // CHECK: "ttnn.all_gather"
   %4 = tensor.empty() : tensor<1x1x256x512xf32>
   %5 = "ttir.mesh_shard"(%3, %4) <{shard_dims = array<i64: 2, -1>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1, 1, 2, 1>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x128x512xf32>, tensor<1x1x256x512xf32>) -> tensor<1x1x256x512xf32>
-  // CHECK: %[[C:.*]] = "ttnn.mesh_shard"[[C:.*]]
+  // CHECK: "ttnn.mesh_shard"
   return %5 : tensor<1x1x256x512xf32>
 }
 
 func.func @forward2(%arg0: tensor<1x1x256x512xf32>) -> tensor<1x1x256x128xf32> {
   %0 = tensor.empty() : tensor<1x1x128x128xf32>
   %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 2, 4>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x256x512xf32>, tensor<1x1x128x128xf32>) -> tensor<1x1x128x128xf32>
-  // CHECK: %[[C:.*]] = "ttnn.mesh_shard"[[C:.*]]
+  // CHECK: "ttnn.mesh_shard"
   %2 = tensor.empty() : tensor<1x1x128x128xf32>
   %3 = "ttir.all_reduce"(%1, %2) <{channel_handle = 1 : si32, dim = 3 : si32, reduce_type = #tt.reduce_type<sum>, replica_groups = dense<[[0, 1, 2, 3], [4, 5, 6, 7]]> : tensor<2x4xi64>, use_global_device_ids}> : (tensor<1x1x128x128xf32>, tensor<1x1x128x128xf32>) -> tensor<1x1x128x128xf32>
-  // CHECK: %[[C:.*]] = "ttnn.reduce_scatter"[[C:.*]]
-  // CHECK: %[[C:.*]] = "ttnn.all_gather"[[C:.*]]
+  // CHECK: "ttnn.reduce_scatter"
+  // CHECK: "ttnn.all_gather"
   %4 = tensor.empty() : tensor<1x1x256x128xf32>
   %5 = "ttir.mesh_shard"(%3, %4) <{shard_dims = array<i64: 2, -1>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1, 1, 2, 1>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x128x128xf32>, tensor<1x1x256x128xf32>) -> tensor<1x1x256x128xf32>
-  // CHECK: %[[C:.*]] = "ttnn.mesh_shard"[[C:.*]]
+  // CHECK: "ttnn.mesh_shard"
   return %5 : tensor<1x1x256x128xf32>
 }

--- a/test/ttmlir/Silicon/TTNN/llmbox/perf/all_gather.mlir
+++ b/test/ttmlir/Silicon/TTNN/llmbox/perf/all_gather.mlir
@@ -5,12 +5,12 @@
 func.func @forward(%arg0: tensor<1x1x256x512xf32>) -> tensor<1x1x256x512xf32> {
   %0 = tensor.empty() : tensor<1x1x128x128xf32>
   %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 2, 4>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x256x512xf32>, tensor<1x1x128x128xf32>) -> tensor<1x1x128x128xf32>
-  // CHECK: %[[C:.*]] = "ttnn.mesh_shard"[[C:.*]]
+  // CHECK: "ttnn.mesh_shard"
   %2 = tensor.empty() : tensor<1x1x128x512xf32>
-  %3 = "ttir.all_gather"(%1, %2) <{dim = 3 : si32}> : (tensor<1x1x128x128xf32>, tensor<1x1x128x512xf32>) -> tensor<1x1x128x512xf32>
-  // CHECK: %[[C:.*]] = "ttnn.all_gather"[[C:.*]]
+  %3 = "ttir.all_gather"(%1, %2) <{all_gather_dim = 3 : si32, channel_handle = 1 : si32, replica_groups = dense<[[0, 1, 2, 3], [4, 5, 6, 7]]> : tensor<2x4xi64>, use_global_device_ids, cluster_axis = 1 : ui32}> : (tensor<1x1x128x128xf32>, tensor<1x1x128x512xf32>) -> tensor<1x1x128x512xf32>
+  // CHECK: "ttnn.all_gather"
   %4 = tensor.empty() : tensor<1x1x256x512xf32>
   %5 = "ttir.mesh_shard"(%3, %4) <{shard_dims = array<i64: 2, -1>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1, 1, 2, 1>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x128x512xf32>, tensor<1x1x256x512xf32>) -> tensor<1x1x256x512xf32>
-  // CHECK: %[[C:.*]] = "ttnn.mesh_shard"[[C:.*]]
+  // CHECK: "ttnn.mesh_shard"
   return %5 : tensor<1x1x256x512xf32>
 }

--- a/test/ttmlir/Silicon/TTNN/llmbox/perf/all_reduce.mlir
+++ b/test/ttmlir/Silicon/TTNN/llmbox/perf/all_reduce.mlir
@@ -5,13 +5,13 @@
 func.func @forward2(%arg0: tensor<1x1x256x512xf32>) -> tensor<1x1x256x128xf32> {
   %0 = tensor.empty() : tensor<1x1x128x128xf32>
   %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 2, 4>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x256x512xf32>, tensor<1x1x128x128xf32>) -> tensor<1x1x128x128xf32>
-  // CHECK: %[[C:.*]] = "ttnn.mesh_shard"[[C:.*]]
+  // CHECK: "ttnn.mesh_shard"
   %2 = tensor.empty() : tensor<1x1x128x128xf32>
   %3 = "ttir.all_reduce"(%1, %2) <{channel_handle = 1 : si32, dim = 3 : si32, reduce_type = #tt.reduce_type<sum>, replica_groups = dense<[[0, 1, 2, 3], [4, 5, 6, 7]]> : tensor<2x4xi64>, use_global_device_ids}> : (tensor<1x1x128x128xf32>, tensor<1x1x128x128xf32>) -> tensor<1x1x128x128xf32>
-  // CHECK: %[[C:.*]] = "ttnn.reduce_scatter"[[C:.*]]
-  // CHECK: %[[C:.*]] = "ttnn.all_gather"[[C:.*]]
+  // CHECK: "ttnn.reduce_scatter"
+  // CHECK: "ttnn.all_gather"
   %4 = tensor.empty() : tensor<1x1x256x128xf32>
   %5 = "ttir.mesh_shard"(%3, %4) <{shard_dims = array<i64: 2, -1>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1, 1, 2, 1>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x128x128xf32>, tensor<1x1x256x128xf32>) -> tensor<1x1x256x128xf32>
-  // CHECK: %[[C:.*]] = "ttnn.mesh_shard"[[C:.*]]
+  // CHECK: "ttnn.mesh_shard"
   return %5 : tensor<1x1x256x128xf32>
 }

--- a/test/ttmlir/Silicon/TTNN/n300/ccl/ccl_1x2.mlir
+++ b/test/ttmlir/Silicon/TTNN/n300/ccl/ccl_1x2.mlir
@@ -2,46 +2,46 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @forward(%arg0: tensor<1x1x32x128xf32>) -> tensor<1x1x32x128xf32> {
+func.func @all_gather_cluster1(%arg0: tensor<1x1x32x128xf32>) -> tensor<1x1x32x128xf32> {
   %0 = tensor.empty() : tensor<1x1x32x64xf32>
   %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: -1, 3>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 1, 2>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x32x128xf32>, tensor<1x1x32x64xf32>) -> tensor<1x1x32x64xf32>
-  // CHECK: %[[C:.*]] = "ttnn.mesh_shard"[[C:.*]]
+  // CHECK: "ttnn.mesh_shard"
   %2 = tensor.empty() : tensor<1x1x32x128xf32>
-  %3 = "ttir.all_gather"(%1, %2) <{dim = 3 : si32}> : (tensor<1x1x32x64xf32>, tensor<1x1x32x128xf32>) -> tensor<1x1x32x128xf32>
-  // CHECK: %[[C:.*]] = "ttnn.all_gather"[[C:.*]]
+  %3 = "ttir.all_gather"(%1, %2) <{all_gather_dim = 3 : si32, replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>, cluster_axis = 1 : ui32}> : (tensor<1x1x32x64xf32>, tensor<1x1x32x128xf32>) -> tensor<1x1x32x128xf32>
+  // CHECK: "ttnn.all_gather"
   %4 = tensor.empty() : tensor<1x1x32x128xf32>
   %5 = "ttir.mesh_shard"(%3, %4) <{shard_dims = array<i64: -1>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1>, shard_type = #tt.shard_type<replicate>}> : (tensor<1x1x32x128xf32>, tensor<1x1x32x128xf32>) -> tensor<1x1x32x128xf32>
-  // CHECK: %[[C:.*]] = "ttnn.mesh_shard"[[C:.*]]
+  // CHECK: "ttnn.mesh_shard"
   return %5 : tensor<1x1x32x128xf32>
 }
 
 func.func @forward2(%arg0: tensor<1x1x256x512xf32>) -> tensor<1x1x256x256xf32> {
   %0 = tensor.empty() : tensor<1x1x256x256xf32>
   %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: -1, 3>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 1, 2>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x256x512xf32>, tensor<1x1x256x256xf32>) -> tensor<1x1x256x256xf32>
-  // CHECK: %[[C:.*]] = "ttnn.mesh_shard"[[C:.*]]
+  // CHECK: "ttnn.mesh_shard"
   %2 = tensor.empty() : tensor<1x1x256x256xf32>
   %3 = "ttir.all_reduce"(%1, %2) <{channel_handle = 1 : si32, dim = 3 : si32, reduce_type = #tt.reduce_type<sum>, replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>, use_global_device_ids}> : (tensor<1x1x256x256xf32>, tensor<1x1x256x256xf32>) -> tensor<1x1x256x256xf32>
-  // CHECK: %[[C:.*]] = "ttnn.reduce_scatter"[[C:.*]]
-  // CHECK: %[[C:.*]] = "ttnn.all_gather"[[C:.*]]
+  // CHECK: "ttnn.reduce_scatter"
+  // CHECK: "ttnn.all_gather"
   %4 = tensor.empty() : tensor<1x1x256x256xf32>
   %5 = "ttir.mesh_shard"(%3, %4) <{shard_dims = array<i64: -1>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1>, shard_type = #tt.shard_type<replicate>}> : (tensor<1x1x256x256xf32>, tensor<1x1x256x256xf32>) -> tensor<1x1x256x256xf32>
-  // CHECK: %[[C:.*]] = "ttnn.mesh_shard"[[C:.*]]
+  // CHECK: "ttnn.mesh_shard"
   return %5 : tensor<1x1x256x256xf32>
 }
 
 func.func public @main(%arg0: tensor<8192x784xf32> {mhlo.layout_mode = "default"}, %arg1: tensor<784x16384xf32> {mhlo.layout_mode = "default"}) -> (tensor<8192x16384xf32> {jax.result_info = "", mhlo.layout_mode = "default"}) {
   %0 = tensor.empty() : tensor<8192x392xf32>
   %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: -1, 1>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 2>, shard_type = #tt.shard_type<devices>}> : (tensor<8192x784xf32>, tensor<8192x392xf32>) -> tensor<8192x392xf32>
-  // CHECK: %[[C:.*]] = "ttnn.mesh_shard"[[C:.*]]
+  // CHECK: "ttnn.mesh_shard"
   %2 = tensor.empty() : tensor<392x16384xf32>
   %3 = "ttir.mesh_shard"(%arg1, %2) <{shard_dims = array<i64: -1, 0>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 2, 1>,  shard_type = #tt.shard_type<devices>}> : (tensor<784x16384xf32>, tensor<392x16384xf32>) -> tensor<392x16384xf32>
-  // CHECK: %[[C:.*]] = "ttnn.mesh_shard"[[C:.*]]
+  // CHECK: "ttnn.mesh_shard"
   %4 = tensor.empty() : tensor<8192x16384xf32>
   %5 = "ttir.matmul"(%1, %3, %4) : (tensor<8192x392xf32>, tensor<392x16384xf32>, tensor<8192x16384xf32>) -> tensor<8192x16384xf32>
   %6 = tensor.empty() : tensor<8192x16384xf32>
   %7 = "ttir.all_reduce"(%5, %6) <{channel_handle = 1 : si32, dim = 1 : si32, reduce_type = #tt.reduce_type<sum>, replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>, use_global_device_ids}> : (tensor<8192x16384xf32>, tensor<8192x16384xf32>) -> tensor<8192x16384xf32>
   %8 = tensor.empty() : tensor<8192x16384xf32>
   %9 = "ttir.mesh_shard"(%7, %8) <{shard_dims = array<i64: -1>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1>, shard_type = #tt.shard_type<replicate>}> : (tensor<8192x16384xf32>, tensor<8192x16384xf32>) -> tensor<8192x16384xf32>
-  // CHECK: %[[C:.*]] = "ttnn.mesh_shard"[[C:.*]]
+  // CHECK: "ttnn.mesh_shard"
   return %9 : tensor<8192x16384xf32>
 }

--- a/test/ttmlir/Silicon/TTNN/n300/perf/all_gather.mlir
+++ b/test/ttmlir/Silicon/TTNN/n300/perf/all_gather.mlir
@@ -5,12 +5,12 @@
 func.func @forward(%arg0: tensor<1x1x32x128xf32>) -> tensor<1x1x32x128xf32> {
   %0 = tensor.empty() : tensor<1x1x32x64xf32>
   %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: -1, 3>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 1, 2>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x32x128xf32>, tensor<1x1x32x64xf32>) -> tensor<1x1x32x64xf32>
-  // CHECK: %[[C:.*]] = "ttnn.mesh_shard"[[C:.*]]
+  // CHECK: "ttnn.mesh_shard"
   %2 = tensor.empty() : tensor<1x1x32x128xf32>
-  %3 = "ttir.all_gather"(%1, %2) <{dim = 3 : si32}> : (tensor<1x1x32x64xf32>, tensor<1x1x32x128xf32>) -> tensor<1x1x32x128xf32>
-  // CHECK: %[[C:.*]] = "ttnn.all_gather"[[C:.*]]
+  %3 = "ttir.all_gather"(%1, %2) <{all_gather_dim = 3 : si32, channel_handle = 1 : si32, replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>, use_global_device_ids, cluster_axis = 1 : ui32}> : (tensor<1x1x32x64xf32>, tensor<1x1x32x128xf32>) -> tensor<1x1x32x128xf32>
+  // CHECK: "ttnn.all_gather"
   %4 = tensor.empty() : tensor<1x1x32x128xf32>
   %5 = "ttir.mesh_shard"(%3, %4) <{shard_dims = array<i64: -1>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1>, shard_type = #tt.shard_type<replicate>}> : (tensor<1x1x32x128xf32>, tensor<1x1x32x128xf32>) -> tensor<1x1x32x128xf32>
-  // CHECK: %[[C:.*]] = "ttnn.mesh_shard"[[C:.*]]
+  // CHECK: "ttnn.mesh_shard"
   return %5 : tensor<1x1x32x128xf32>
 }

--- a/test/ttmlir/Silicon/TTNN/n300/perf/all_reduce.mlir
+++ b/test/ttmlir/Silicon/TTNN/n300/perf/all_reduce.mlir
@@ -5,13 +5,13 @@
 func.func @forward2(%arg0: tensor<1x1x256x512xf32>) -> tensor<1x1x256x256xf32> {
   %0 = tensor.empty() : tensor<1x1x256x256xf32>
   %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: -1, 3>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 1, 2>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x256x512xf32>, tensor<1x1x256x256xf32>) -> tensor<1x1x256x256xf32>
-  // CHECK: %[[C:.*]] = "ttnn.mesh_shard"[[C:.*]]
+  // CHECK: "ttnn.mesh_shard"
   %2 = tensor.empty() : tensor<1x1x256x256xf32>
   %3 = "ttir.all_reduce"(%1, %2) <{channel_handle = 1 : si32, dim = 3 : si32, reduce_type = #tt.reduce_type<sum>, replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>, use_global_device_ids}> : (tensor<1x1x256x256xf32>, tensor<1x1x256x256xf32>) -> tensor<1x1x256x256xf32>
-  // CHECK: %[[C:.*]] = "ttnn.reduce_scatter"[[C:.*]]
-  // CHECK: %[[C:.*]] = "ttnn.all_gather"[[C:.*]]
+  // CHECK: "ttnn.reduce_scatter"
+  // CHECK: "ttnn.all_gather"
   %4 = tensor.empty() : tensor<1x1x256x256xf32>
   %5 = "ttir.mesh_shard"(%3, %4) <{shard_dims = array<i64: -1>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1>, shard_type = #tt.shard_type<replicate>}> : (tensor<1x1x256x256xf32>, tensor<1x1x256x256xf32>) -> tensor<1x1x256x256xf32>
-  // CHECK: %[[C:.*]] = "ttnn.mesh_shard"[[C:.*]]
+  // CHECK: "ttnn.mesh_shard"
   return %5 : tensor<1x1x256x256xf32>
 }

--- a/test/ttmlir/Silicon/TTNN/tg/ccl/ccl_1x32.mlir
+++ b/test/ttmlir/Silicon/TTNN/tg/ccl/ccl_1x32.mlir
@@ -1,31 +1,27 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% mesh-shape=1,32" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-// UNSUPPORTED: true
 
-func.func @forward(%arg0: tensor<1x1x32x128xf32>) -> tensor<1x1x32x128xf32> {
-  %0 = tensor.empty() : tensor<1x1x32x4xf32>
-  %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: -1, 3>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 1, 32>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x32x128xf32>, tensor<1x1x32x4xf32>) -> tensor<1x1x32x4xf32>
-  // CHECK: %[[C:.*]] = "ttnn.mesh_shard"[[C:.*]]
-  %2 = tensor.empty() : tensor<1x1x32x128xf32>
-  %3 = "ttir.all_gather"(%1, %2) <{dim = 3 : si32}> : (tensor<1x1x32x4xf32>, tensor<1x1x32x128xf32>) -> tensor<1x1x32x128xf32>
-  // CHECK: %[[C:.*]] = "ttnn.all_gather"[[C:.*]]
-  %4 = tensor.empty() : tensor<1x1x32x128xf32>
-  %5 = "ttir.mesh_shard"(%3, %4) <{shard_dims = array<i64: -1>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape =  array<i64: 1>, shard_type = #tt.shard_type<replicate>}> : (tensor<1x1x32x128xf32>, tensor<1x1x32x128xf32>) -> tensor<1x1x32x128xf32>
-  // CHECK: %[[C:.*]] = "ttnn.mesh_shard"[[C:.*]]
-  return %5 : tensor<1x1x32x128xf32>
+func.func public @all_gather_cluster1(%arg0: tensor<1x1x8192x2048xf32>) -> (tensor<1x1x8192x65536xf32> {jax.result_info = ""}) {
+  %0 = tensor.empty() : tensor<1x1x8192x64xf32>
+  %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: -1, 3>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 1, 32>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x8192x2048xf32>, tensor<1x1x8192x64xf32>) -> tensor<1x1x8192x64xf32>
+  %2 = tensor.empty() : tensor<1x1x8192x2048xf32>
+  %3 = "ttir.all_gather"(%1, %2) <{all_gather_dim = 3 : si32, channel_handle = 1 : si32, replica_groups = dense<[[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]]> : tensor<1x32xi64>, use_global_device_ids, cluster_axis = 1 : ui32}> : (tensor<1x1x8192x64xf32>, tensor<1x1x8192x2048xf32>) -> tensor<1x1x8192x2048xf32>
+  %4 = tensor.empty() : tensor<1x1x8192x65536xf32>
+  %5 = "ttir.mesh_shard"(%3, %4) <{shard_dims = array<i64: -1, 3>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1, 1, 1, 32>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x8192x2048xf32>, tensor<1x1x8192x65536xf32>) -> tensor<1x1x8192x65536xf32>
+  return %5 : tensor<1x1x8192x65536xf32>
 }
 
 func.func @forward2(%arg0: tensor<1x1x256x512xf32>) -> tensor<1x1x256x16xf32> {
   %0 = tensor.empty() : tensor<1x1x256x16xf32>
   %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: -1, 3>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 1, 32>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x256x512xf32>, tensor<1x1x256x16xf32>) -> tensor<1x1x256x16xf32>
-  // CHECK: %[[C:.*]] = "ttnn.mesh_shard"[[C:.*]]
+  // CHECK: "ttnn.mesh_shard"
   %2 = tensor.empty() : tensor<1x1x256x16xf32>
   %3 = "ttir.all_reduce"(%1, %2) <{channel_handle = 1 : si32, dim = 3 : si32, reduce_type = #tt.reduce_type<sum>, replica_groups = dense<[[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]]> : tensor<1x32xi64>, use_global_device_ids}> : (tensor<1x1x256x16xf32>, tensor<1x1x256x16xf32>) -> tensor<1x1x256x16xf32>
-  // CHECK: %[[C:.*]] = "ttnn.reduce_scatter"[[C:.*]]
-  // CHECK: %[[C:.*]] = "ttnn.all_gather"[[C:.*]]
+  // CHECK: "ttnn.reduce_scatter"
+  // CHECK: "ttnn.all_gather"
   %4 = tensor.empty() : tensor<1x1x256x16xf32>
   %5 = "ttir.mesh_shard"(%3, %4) <{shard_dims = array<i64: -1>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1>, shard_type = #tt.shard_type<replicate>}> : (tensor<1x1x256x16xf32>, tensor<1x1x256x16xf32>) -> tensor<1x1x256x16xf32>
-  // CHECK: %[[C:.*]] = "ttnn.mesh_shard"[[C:.*]]
+  // CHECK: "ttnn.mesh_shard"
   return %5 : tensor<1x1x256x16xf32>
 }

--- a/test/ttmlir/Silicon/TTNN/tg/ccl/ccl_8x4.mlir
+++ b/test/ttmlir/Silicon/TTNN/tg/ccl/ccl_8x4.mlir
@@ -2,15 +2,28 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @forward(%arg0: tensor<1x1x256x512xf32>) -> tensor<1x1x256x512xf32> {
+func.func public @all_gather_cluster0(%arg0: tensor<1x1x8192x512xf32>) -> (tensor<1x1x65536x512xf32> {jax.result_info = ""}) {
+  %0 = tensor.empty() : tensor<1x1x1024x128xf32>
+  %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 8, 4>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x8192x512xf32>, tensor<1x1x1024x128xf32>) -> tensor<1x1x1024x128xf32>
+  // CHECK: "ttnn.mesh_shard"
+  %2 = tensor.empty() : tensor<1x1x8192x128xf32>
+  %3 = "ttir.all_gather"(%1, %2) <{all_gather_dim = 2 : si32, channel_handle = 1 : si32, replica_groups = dense<[[0, 4, 8, 12, 16, 20, 24, 28], [1, 5, 9, 13, 17, 21, 25, 29], [2, 6, 10, 14, 18, 22, 26, 30], [3, 7, 11, 15, 19, 23, 27, 31]]> : tensor<4x8xi64>, use_global_device_ids, cluster_axis = 0 : ui32}> : (tensor<1x1x1024x128xf32>, tensor<1x1x8192x128xf32>) -> tensor<1x1x8192x128xf32>
+  // CHECK: "ttnn.all_gather"
+  %4 = tensor.empty() : tensor<1x1x65536x512xf32>
+  %5 = "ttir.mesh_shard"(%3, %4) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1, 1, 8, 4>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x8192x128xf32>, tensor<1x1x65536x512xf32>) -> tensor<1x1x65536x512xf32>
+  // CHECK: "ttnn.mesh_shard"
+  return %5 : tensor<1x1x65536x512xf32>
+}
+
+func.func @all_gather_cluster1(%arg0: tensor<1x1x256x512xf32>) -> tensor<1x1x256x512xf32> {
   %0 = tensor.empty() : tensor<1x1x32x128xf32>
   %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 8, 4>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x256x512xf32>, tensor<1x1x32x128xf32>) -> tensor<1x1x32x128xf32>
-  // CHECK: %[[C:.*]] = "ttnn.mesh_shard"[[C:.*]]
+  // CHECK: "ttnn.mesh_shard"
   %2 = tensor.empty() : tensor<1x1x32x512xf32>
-  %3 = "ttir.all_gather"(%1, %2) <{dim = 3 : si32}> : (tensor<1x1x32x128xf32>, tensor<1x1x32x512xf32>) -> tensor<1x1x32x512xf32>
-  // CHECK: %[[C:.*]] = "ttnn.all_gather"[[C:.*]]
+  %3 = "ttir.all_gather"(%1, %2) <{all_gather_dim = 3 : si32, replica_groups = dense<[[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11], [12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23], [24, 25, 26, 27], [28, 29, 30, 31]]> : tensor<8x4xi64>}> : (tensor<1x1x32x128xf32>, tensor<1x1x32x512xf32>) -> tensor<1x1x32x512xf32>
+  // CHECK: "ttnn.all_gather"
   %4 = tensor.empty() : tensor<1x1x256x512xf32>
   %5 = "ttir.mesh_shard"(%3, %4) <{shard_dims = array<i64: 2, -1>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1, 1, 8, 1>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x32x512xf32>, tensor<1x1x256x512xf32>) -> tensor<1x1x256x512xf32>
-  // CHECK: %[[C:.*]] = "ttnn.mesh_shard"[[C:.*]]
+  // CHECK: "ttnn.mesh_shard"
   return %5 : tensor<1x1x256x512xf32>
 }

--- a/test/ttmlir/Silicon/TTNN/tg/perf/all_gather.mlir
+++ b/test/ttmlir/Silicon/TTNN/tg/perf/all_gather.mlir
@@ -5,12 +5,12 @@
 func.func @forward(%arg0: tensor<1x1x256x512xf32>) -> tensor<1x1x256x512xf32> {
   %0 = tensor.empty() : tensor<1x1x32x128xf32>
   %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 8, 4>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x256x512xf32>, tensor<1x1x32x128xf32>) -> tensor<1x1x32x128xf32>
-  // CHECK: %[[C:.*]] = "ttnn.mesh_shard"[[C:.*]]
+  // CHECK: "ttnn.mesh_shard"
   %2 = tensor.empty() : tensor<1x1x32x512xf32>
-  %3 = "ttir.all_gather"(%1, %2) <{dim = 3 : si32}> : (tensor<1x1x32x128xf32>, tensor<1x1x32x512xf32>) -> tensor<1x1x32x512xf32>
-  // CHECK: %[[C:.*]] = "ttnn.all_gather"[[C:.*]]
+  %3 = "ttir.all_gather"(%1, %2) <{all_gather_dim = 3 : si32, replica_groups = dense<[[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11], [12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23], [24, 25, 26, 27], [28, 29, 30, 31]]> : tensor<8x4xi64>, cluster_axis = 1 : ui32}> : (tensor<1x1x32x128xf32>, tensor<1x1x32x512xf32>) -> tensor<1x1x32x512xf32>
+  // CHECK: "ttnn.all_gather"
   %4 = tensor.empty() : tensor<1x1x256x512xf32>
   %5 = "ttir.mesh_shard"(%3, %4) <{shard_dims = array<i64: 2, -1>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1, 1, 8, 1>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x32x512xf32>, tensor<1x1x256x512xf32>) -> tensor<1x1x256x512xf32>
-  // CHECK: %[[C:.*]] = "ttnn.mesh_shard"[[C:.*]]
+  // CHECK: "ttnn.mesh_shard"
   return %5 : tensor<1x1x256x512xf32>
 }


### PR DESCRIPTION
Captured all all_gather attributes in shlo dialect into ttir. Kept consistent naming convention for attributes found in shlo across tt-mlir stack. Updated ttir to ttnn conversion to account for dynamic cluster_axis and removed cluster axis constraint of being 1 in runtime code for all_gather.

We model all_gather in ttir dialect as the following

```
let arguments = (ins AnyRankedTensor:$input,
                         AnyRankedTensor:$output,
                         SI32Attr:$all_gather_dim,
                         OptionalAttr<SI32Attr>:$channel_handle,
                         UnitAttr:$use_global_device_ids,
                         I64ElementsAttr:$replica_groups);
```

ttnn model
```
let arguments = (ins AnyRankedTensor:$input,
                         TT_Device:$device,
                         SI32Attr:$all_gather_dim,
                         SI32Attr:$cluster_axis,
                         DefaultValuedAttr<SI32Attr, "1">:$num_links);
```

Previously, cluster_axis was set to 1 in runtime, however, if we open our mesh as the following, which is a valid test case in llmbox (ie data parallelism across 4 devices, with model parallelism across 2 devices)

```
mesh = jax.make_mesh((2, 4), ('model', 'batch'))
```

We need the ability to perform all_gather across cluster_axis=0.

GSPMD style multi-device does not propagate cluster_axis in which we perform all_gather against. It only groups devices in a replica_groups 2D tensor, which each group containing list of devices that will perform all_gather with each other. Simple algorithm was introduced to figure out cluster_axis from replica_groups.