### PR TITLE
Add improvements to Adding-an-op docs, specifically emitc sections

### DIFF
--- a/docs/src/adding-an-op.md
+++ b/docs/src/adding-an-op.md
@@ -105,6 +105,8 @@ For more details on adding ops to the TTNN dialect, refer to [TTNN Dialect Contr
 
 ## 3. Convert / Implement the Op in the TTNN passes
 
+### TTIR to TTNN
+
 Next we will implement the conversion from the TTIR `matmul` Op to the TTNN `matmul` Op.
 This is a trivial conversion, as the Ops are identical in their semantics, so
 the changeset isn't going to be very instructive, but will at least point to the
@@ -150,10 +152,21 @@ Invoked as part of the rewrite set:
 MatmulOpConversionPattern
 ```
 
-### Note:
-We also need to add this op to the C++ emitter,
-`lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp` see
-`populateTTNNToEmitCPatterns(...)`.
+### TTNN to EmitC
+
+Similarly, we also need to add a pattern to convert from TTNN dialect to EmitC dialect.
+
+Method to populate rewrite patterns can be found in `lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp`:
+
+```cpp
+{{#include ../../../lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp:op_rewriter_pattern_set_emitc}}
+```
+
+Conversion pattern for matmul op:
+
+```cpp
+{{#include ../../../lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp:adding_an_op_matmul_op_rewriter_emitc}}
+```
 
 ## 4. Add a compiler unit test for the Op
 
@@ -332,3 +345,9 @@ TTNN EmitC tests live in the `test/ttmlir/EmitC/TTNN` path. In our case, the tes
 ```
 
 The first two `RUN` lines create a flatbuffer. The third and forth convert to EmitC dialect, translate to C++, then output the result to `matmul.mlir.cpp` file.
+
+Additionally, the op's header file `operations/matmul/matmul.hpp` should be added to the list of includes in `tools/ttnn-standalone/ttnn-precompiled.hpp`:
+
+```cpp
+{{#include ../../../tools/ttnn-standalone/ttnn-precompiled.hpp:standalone_includes}}
+```

--- a/docs/src/adding-an-op.md
+++ b/docs/src/adding-an-op.md
@@ -162,7 +162,53 @@ Method to populate rewrite patterns can be found in `lib/Conversion/TTNNToEmitC/
 {{#include ../../../lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp:op_rewriter_pattern_set_emitc}}
 ```
 
-Conversion pattern for matmul op:
+Writing conversion patterns to EmitC is a little tricky at first. In general case, we will be converting an op that has operands (SSAs) and attributes (e.g. data type) as arguments. We want to flatten these arguments at call site.
+
+We'll use EmitC's `CallOpaqueOp` as the target op. Let's take a look at our matmul IR within TTNN dialect:
+```
+"ttnn.matmul"(%2, %4, %5) : (tensor<64x128xbf16, #ttnn_layout4>, tensor<128x96xbf16, #ttnn_layout6>, tensor<64x96xbf16, #ttnn_layout7>) -> tensor<64x96xbf16, #ttnn_layout7>
+```
+
+Now let's look at matmul's call signature in TTNN lib:
+```cpp
+    static Tensor invoke(
+        const Tensor& input_tensor_a,
+        const Tensor& input_tensor_b,
+        const bool transpose_a = false,
+        const bool transpose_b = false,
+        const std::optional<const MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<const DataType> dtype = std::nullopt,
+        const std::optional<const MatmulProgramConfig>& program_config = std::nullopt,
+        const std::optional<const std::string>& activation = std::nullopt,
+        const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+        const std::optional<const CoreGrid> core_grid = std::nullopt,
+        const std::optional<const tt::tt_metal::Tile>& output_tile = std::nullopt,
+        std::optional<Tensor> optional_output_tensor = std::nullopt,
+        const std::optional<const DeviceGlobalCircularBuffer>& global_cb = std::nullopt);
+```
+
+If we look closely, we'll notice that the IR has way less arguments than can be seen in the actual signature of the op - as we're lowering to EmitC, which gets translated into actual C++ code, we need to correct for this (ideally the op would be perfectly modelled with all the arguments, but that is not the case today).
+
+We do this by filling in the gaps. EmitC's `CallOpaqueOp` takes in an array of attributes, and an array of operands, which need to be combined. The combining is done by extending the array of attributes with "pointers" into operands, like so:
+```cpp
+{{#include ../../../lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp:adding_an_op_matmul_ttnn_to_emitc_array_attrs}}
+```
+
+Pointers are denoted with `IndexType`s, wrapped into `IntegerAttr`s. Attributes are converted into EmitC's `OpaqueAttr` which can, for practical purposes, be treated as strings: a `BoolAttr` carrying "false" as value needs to be converted into an `OpaqueAttr` whose value is a string `"false"`, which is what the `convertBoolAttr` function does.
+
+This is our final converted EmitC `CallOpaqueOp`:
+
+```mlir
+emitc.call_opaque "ttnn::matmul"(%3, %6, %9) {args = [0 : index, 1 : index, #emitc.opaque<"false">, #emitc.opaque<"false">, #emitc.opaque<"std::nullopt">, #emitc.opaque<"std::nullopt">, #emitc.opaque<"std::nullopt">, #emitc.opaque<"std::nullopt">, #emitc.opaque<"std::nullopt">, #emitc.opaque<"std::nullopt">, #emitc.opaque<"std::nullopt">, 2 : index]} : (!emitc.opaque<"ttnn::Tensor">, !emitc.opaque<"ttnn::Tensor">, !emitc.opaque<"ttnn::Tensor">) -> !emitc.opaque<"ttnn::Tensor">
+```
+
+which, when translated to C++ code, looks like:
+
+```cpp
+ttnn::matmul(v6, v9, false, false, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, v12);
+```
+
+Full conversion pattern for matmul op:
 
 ```cpp
 {{#include ../../../lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp:adding_an_op_matmul_op_rewriter_emitc}}

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -302,25 +302,33 @@ public:
   matchAndRewrite(ttnn::MatmulOp matmulOp, ttnn::MatmulOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
+    // ANCHOR: adding_an_op_matmul_ttnn_to_emitc_array_attrs
     // emitc::CallOpaqueOp needs to know positions of operands vs attributes, so
     // an ArrayAttr object holding IndexTypes is created to denote this.
     //
     ArrayAttr arrayAttrs = rewriter.getArrayAttr({
-        mlir::IntegerAttr::get(rewriter.getIndexType(), 0),
-        mlir::IntegerAttr::get(rewriter.getIndexType(), 1),
+        mlir::IntegerAttr::get(rewriter.getIndexType(),
+                               0), // points to operand 0
+        mlir::IntegerAttr::get(rewriter.getIndexType(),
+                               1), // points to operand 1
+        ttnn_to_emitc::utils::convertBoolAttr(
+            rewriter,
+            BoolAttr::get(
+                rewriter.getContext(),
+                false)), // bool attr denoting transposeA is set to false
         ttnn_to_emitc::utils::convertBoolAttr(
             rewriter, BoolAttr::get(rewriter.getContext(), false)),
-        ttnn_to_emitc::utils::convertBoolAttr(
-            rewriter, BoolAttr::get(rewriter.getContext(), false)),
+        ttnn_to_emitc::utils::createStdNullopt(rewriter), // std::nullopt
         ttnn_to_emitc::utils::createStdNullopt(rewriter),
         ttnn_to_emitc::utils::createStdNullopt(rewriter),
         ttnn_to_emitc::utils::createStdNullopt(rewriter),
         ttnn_to_emitc::utils::createStdNullopt(rewriter),
         ttnn_to_emitc::utils::createStdNullopt(rewriter),
         ttnn_to_emitc::utils::createStdNullopt(rewriter),
-        ttnn_to_emitc::utils::createStdNullopt(rewriter),
-        mlir::IntegerAttr::get(rewriter.getIndexType(), 2),
+        mlir::IntegerAttr::get(rewriter.getIndexType(),
+                               2), // points to operand 2
     });
+    // ANCHOR_END: adding_an_op_matmul_ttnn_to_emitc_array_attrs
 
     rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
         matmulOp, this->getTypeConverter()->convertType(matmulOp.getType()),

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -289,6 +289,7 @@ public:
 
 // Matmul op conversion pattern
 //
+// ANCHOR: adding_an_op_matmul_op_rewriter_emitc
 namespace {
 class MatmulOpConversionPattern
     : public TTNNToEmitCBaseOpConversionPattern<ttnn::MatmulOp> {
@@ -330,6 +331,7 @@ public:
   }
 };
 } // namespace
+// ANCHOR_END: adding_an_op_matmul_op_rewriter_emitc
 
 // Softmax op conversion pattern
 //
@@ -1115,6 +1117,7 @@ public:
 
 namespace mlir::tt {
 
+// ANCHOR: op_rewriter_pattern_set_emitc
 void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
                                  mlir::RewritePatternSet &patterns,
                                  TypeConverter &typeConverter) {
@@ -1260,5 +1263,6 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
   //
   patterns.add<ModuleOpConversionPattern>(typeConverter, ctx);
 }
+// ANCHOR_END: op_rewriter_pattern_set_emitc
 
 } // namespace mlir::tt

--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -5,6 +5,7 @@
 #ifndef TOOLS_TTNN_STANDALONE_TTNN_PRECOMPILED_HPP
 #define TOOLS_TTNN_STANDALONE_TTNN_PRECOMPILED_HPP
 
+// ANCHOR: standalone_includes
 #include "core.hpp"
 #include "device.hpp"
 #include "operations/copy.hpp"
@@ -27,6 +28,7 @@
 #include "tensor/types.hpp"
 #include "tt-metalium/bfloat16.hpp"
 #include "types.hpp"
+// ANCHOR_END: standalone_includes
 
 #include <cstddef>
 #include <iostream>


### PR DESCRIPTION
### Problem description
Following suggestions from https://github.com/tenstorrent/tt-mlir/pull/1928#issuecomment-2619423303, updating the docs.

### What's changed
Improved Adding-an-op docs, specifically emitc section - added note on adding op conversion from ttnn to emitc and including header in `ttnn-precompiled.hpp`.
