### PR TITLE
ConstantOp in TTNN and runtime

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1507,7 +1507,7 @@ def TTNN_UpsampleOp : TTNN_Op<"upsample"> {
     let hasVerifier = 1;
 }
 
-def TTNN_ConstantOp : TTNN_Op<"constant"> {
+def TTNN_ConstantOp : TTNN_Op<"constant", [AllShapesMatch<["value", "result"]>]> {
     let summary = "Constant op.";
     let description = [{
       Produces tensor filled with given constant value.

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1513,9 +1513,9 @@ def TTNN_ConstantOp : TTNN_Op<"constant"> {
       Produces tensor filled with given constant value.
 
       Examples:
-        %0 = "ttir.constant"() {value = dense<0> : tensor<2x3xi32>} : () -> tensor<2x3xi32>
-        // %0: [[0, 0, 0], [0, 0, 0]]
-        %1 = "ttir.constant"() {value = dense<[0.2, 1.3]> : tensor<2xf32>} : () -> tensor<2xf32>
+        %0 = "ttnn.constant"() {value = dense<[[3, 4, 2], [1, 7, 8]]> : tensor<2x3xui16>} : () -> tensor<2x3xui16>
+        // %0: [[3, 4, 2], [1, 7, 8]]
+        %1 = "ttnn.constant"() {value = dense<[0.2, 1.3]> : tensor<2xf32>} : () -> tensor<2xf32>
         // %1: [0.2, 1.3]
     }];
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1507,4 +1507,21 @@ def TTNN_UpsampleOp : TTNN_Op<"upsample"> {
     let hasVerifier = 1;
 }
 
+def TTNN_ConstantOp : TTNN_Op<"constant"> {
+    let summary = "Constant op.";
+    let description = [{
+      Produces tensor filled with given constant value.
+
+      Examples:
+        %0 = "ttir.constant"() {value = dense<0> : tensor<2x3xi32>} : () -> tensor<2x3xi32>
+        // %0: [[0, 0, 0], [0, 0, 0]]
+        %1 = "ttir.constant"() {value = dense<[0.2, 1.3]> : tensor<2xf32>} : () -> tensor<2xf32>
+        // %1: [0.2, 1.3]
+    }];
+
+    let arguments = (ins ElementsAttr:$value);
+
+    let results = (outs AnyRankedTensor:$result);
+}
+
 #endif

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1522,6 +1522,12 @@ def TTNN_ConstantOp : TTNN_Op<"constant"> {
     let arguments = (ins ElementsAttr:$value);
 
     let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
+        return wa::TTNNOperandsWorkaroundsFactory::createConstantOpOperandsWorkarounds();
+      }
+    }];
 }
 
 #endif

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkarounds.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkarounds.h
@@ -246,6 +246,8 @@ public:
                                    mlir::ArrayAttr begins,
                                    mlir::ArrayAttr step);
 
+  // Workaround for tensor creation that is modeled as ConstantOp in TTNN
+  // dialect.
   static TTNNOperandsWorkarounds createConstantOpOperandsWorkarounds();
 };
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkarounds.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkarounds.h
@@ -245,6 +245,8 @@ public:
   createSliceOpOperandsWorkarounds(ttnn::TTNNLayoutAttr layoutAttr,
                                    mlir::ArrayAttr begins,
                                    mlir::ArrayAttr step);
+
+  static TTNNOperandsWorkarounds createConstantOpOperandsWorkarounds();
 };
 
 } // namespace mlir::tt::ttnn::wa

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -482,6 +482,7 @@ union OpType {
   UpsampleOp,
   PadOp,
   CpuOp,
+  ConstantOp,
 }
 
 table Operation {

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -435,6 +435,11 @@ table CpuOp {
   dylib_id: uint32;
 }
 
+table ConstantOp {
+  out: tt.target.TensorRef;
+  data: [ubyte];
+}
+
 union OpType {
   GetDeviceOp,
   ToMemoryConfigOp,

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -27,8 +27,6 @@
 #include "mlir/Transforms/DialectConversion.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
-#include "llvm/Support/ErrorHandling.h"
-#include "llvm/Support/LogicalResult.h"
 
 #include <cstdint>
 #include <optional>
@@ -872,39 +870,39 @@ public:
   LogicalResult
   matchAndRewrite(ttir::ConstantOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    // TODO(azecevic): This is fallback if value is not splat attr.
-    rewriter.replaceOpWithNewOp<ttnn::ConstantOp>(
-        op, this->getTypeConverter()->convertType(op.getType()),
-        adaptor.getValue());
+    ::mlir::ElementsAttr valueAttr = op.getValue();
+
+    LogicalResult legalityResult = checkBasicLegality(op, valueAttr, rewriter);
+    if (!legalityResult.succeeded()) {
+      return legalityResult;
+    }
+
+    // If the value is a splat (i.e. single value), we can use the ttnn::FullOp
+    // to create the tensor.
+    if (valueAttr.isSplat()) {
+      auto device = ::ttnn::utils::getOrInsertDevice(rewriter, op);
+
+      mlir::APFloat fillValue(mlir::APFloat::IEEEsingle());
+      if (valueAttr.getElementType().isInteger()) {
+        fillValue.convertFromAPInt(valueAttr.getSplatValue<llvm::APInt>(),
+                                   valueAttr.getElementType().isSignedInteger(),
+                                   llvm::RoundingMode::TowardZero);
+      } else {
+        fillValue = valueAttr.getSplatValue<mlir::APFloat>();
+      }
+
+      rewriter.replaceOpWithNewOp<ttnn::FullOp>(
+          op, this->getTypeConverter()->convertType(op.getType()), device,
+          rewriter.getF32FloatAttr(fillValue.convertToFloat()));
+
+      // Otherwise, we use the ttnn::ConstantOp to create the tensor.
+    } else {
+      rewriter.replaceOpWithNewOp<ttnn::ConstantOp>(
+          op, this->getTypeConverter()->convertType(op.getType()),
+          adaptor.getValue());
+    }
 
     return success();
-
-    // ::mlir::ElementsAttr valueAttr = op.getValue();
-
-    // LogicalResult legalityResult = checkBasicLegality(op, valueAttr,
-    // rewriter); if (!legalityResult.succeeded()) {
-    //   return legalityResult;
-    // }
-
-    // if (valueAttr.isSplat()) {
-    //   Value device = ::ttnn::utils::getOrInsertDevice(rewriter, op);
-    //   float fillValue =
-    //       valueAttr.getElementType().isInteger()
-    //           ? getFloatFromIntegerValue(valueAttr)
-    //           : valueAttr.getSplatValue<mlir::APFloat>().convertToFloat();
-
-    //   ::mlir::FloatAttr fillValueAttr = rewriter.getF32FloatAttr(fillValue);
-    //   rewriter.replaceOpWithNewOp<ttnn::FullOp>(
-    //       op, this->getTypeConverter()->convertType(op.getType()), device,
-    //       fillValueAttr);
-
-    // } else {
-    //   return rewriter.notifyMatchFailure(
-    //       op, "TTNN doesn't currently support tensor creation from multiple "
-    //           "given values (issue #685)");
-    // }
-
-    // return success();
   }
 
 private:
@@ -918,33 +916,6 @@ private:
     }
 
     return success();
-  }
-
-  float getFloatFromIntegerValue(mlir::ElementsAttr valueAttr) const {
-    size_t bitWidth = valueAttr.getElementType().getIntOrFloatBitWidth();
-    Type elementType = valueAttr.getElementType();
-
-    switch (bitWidth) {
-    case 1:
-      return static_cast<float>(valueAttr.getSplatValue<bool>());
-    case 8:
-      return elementType.isUnsignedInteger()
-                 ? static_cast<float>(valueAttr.getSplatValue<uint8_t>())
-                 : static_cast<float>(valueAttr.getSplatValue<int8_t>());
-    case 16:
-      return elementType.isUnsignedInteger()
-                 ? static_cast<float>(valueAttr.getSplatValue<uint16_t>())
-                 : static_cast<float>(valueAttr.getSplatValue<int16_t>());
-    case 32:
-      return elementType.isUnsignedInteger()
-                 ? static_cast<float>(valueAttr.getSplatValue<uint32_t>())
-                 : static_cast<float>(valueAttr.getSplatValue<int32_t>());
-    case 64:
-      return elementType.isUnsignedInteger()
-                 ? static_cast<float>(valueAttr.getSplatValue<uint64_t>())
-                 : static_cast<float>(valueAttr.getSplatValue<int64_t>());
-    }
-    assert(false && "Unsupported integer type.");
   }
 };
 } // namespace

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -1335,7 +1335,8 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
                ZerosOpConversionPattern,
                OnesOpConversionPattern,
                DefaultOpConversionPattern<ttnn::FullOp>,
-               DefaultOpConversionPattern<ttnn::ArangeOp>>(typeConverter, ctx);
+               DefaultOpConversionPattern<ttnn::ArangeOp>,
+               DefaultOpConversionPattern<ttnn::ConstantOp>>(typeConverter, ctx);
   // clang-format on
 
   // Eltwise unary ops

--- a/lib/Dialect/TTNN/IR/TTNNWorkarounds.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkarounds.cpp
@@ -316,12 +316,16 @@ TTNNOperandsWorkaroundsFactory::createSliceOpOperandsWorkarounds(
       .addOutputOperandWorkaround(rowMajorLayoutBF16Workaround);
 }
 
+// ConstantOp is not a TTNN (lib) operation, but it is used to create TTNN
+// tensors. Tensor is expected to be on host in ROW_MAJOR layout. This
+// workaround is used to gurantee those ivariants.
 TTNNOperandsWorkarounds
 TTNNOperandsWorkaroundsFactory::createConstantOpOperandsWorkarounds() {
-  TTNNOperandWorkarounds systemMemoryWA =
-      TTNNOperandWorkarounds(BufferType::SystemMemory);
+  TTNNOperandWorkarounds hostRowMajorWorkaround = TTNNOperandWorkarounds();
+  hostRowMajorWorkaround.tensorBufferTypeWorkaround = BufferType::SystemMemory;
+  hostRowMajorWorkaround.tensorLayoutWorkaround = Layout::RowMajor;
   return TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
-      .addOutputOperandWorkaround(systemMemoryWA);
+      .addOutputOperandWorkaround(hostRowMajorWorkaround);
 }
 
 } // namespace mlir::tt::ttnn::wa

--- a/lib/Dialect/TTNN/IR/TTNNWorkarounds.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkarounds.cpp
@@ -4,6 +4,7 @@
 
 #include "ttmlir/Dialect/TTNN/IR/TTNNWorkarounds.h"
 
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/Utils.h"
 
 #include "mlir/IR/BuiltinAttributes.h"
@@ -314,4 +315,13 @@ TTNNOperandsWorkaroundsFactory::createSliceOpOperandsWorkarounds(
       .addInputOperandWorkaround(rowMajorLayoutBF16Workaround)
       .addOutputOperandWorkaround(rowMajorLayoutBF16Workaround);
 }
+
+TTNNOperandsWorkarounds
+TTNNOperandsWorkaroundsFactory::createConstantOpOperandsWorkarounds() {
+  TTNNOperandWorkarounds systemMemoryWA =
+      TTNNOperandWorkarounds(BufferType::SystemMemory);
+  return TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
+      .addOutputOperandWorkaround(systemMemoryWA);
+}
+
 } // namespace mlir::tt::ttnn::wa

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -739,6 +739,19 @@ createOp(FlatbufferObjectCache &cache, FillCacheOp op) {
                                                op.getBatchOffset());
 }
 
+::flatbuffers::Offset<::tt::target::ttnn::ConstantOp>
+createOp(FlatbufferObjectCache &cache, ttnn::ConstantOp op) {
+  auto output = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
+                                  kHostAllocatedAddress, kHostAllocatedSize);
+
+  auto value = cache.fbb->CreateVector(std::vector<uint8_t>(
+      reinterpret_cast<const uint8_t *>(op.getValue().getAsOpaquePointer()),
+      reinterpret_cast<const uint8_t *>(op.getValue().getAsOpaquePointer()) +
+          op.getValue().getElementType().getIntOrFloatBitWidth() *
+              op.getValue().size()));
+  return ::tt::target::ttnn::CreateConstantOp(*cache.fbb, output, value);
+}
+
 template <typename EltwiseOp>
 ::flatbuffers::Offset<::tt::target::ttnn::EltwiseOp>
 createNonDPSEltwiseOp(FlatbufferObjectCache &cache, EltwiseOp op) {

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -747,8 +747,8 @@ createOp(FlatbufferObjectCache &cache, ttnn::ConstantOp op) {
   auto rawData =
       mlir::dyn_cast<mlir::DenseElementsAttr>(op.getValue()).getRawData();
   auto rawVector = std::vector<uint8_t>(rawData.begin(), rawData.end());
-  auto value = cache.fbb->CreateVector(rawVector);
-  return ::tt::target::ttnn::CreateConstantOp(*cache.fbb, output, value);
+  return ::tt::target::ttnn::CreateConstantOpDirect(*cache.fbb, output,
+                                                    &rawVector);
 }
 
 template <typename EltwiseOp>

--- a/runtime/lib/ttnn/include/tt/runtime/ttnn/utils.h
+++ b/runtime/lib/ttnn/include/tt/runtime/ttnn/utils.h
@@ -48,6 +48,51 @@ createMemoryConfig(const ::tt::target::TensorRef *tensorRef);
 
 Tensor createRuntimeTensorFromTTNN(const ::ttnn::Tensor &tensor);
 
+// TODO: (#1435): Fix int types across shapes
+//
+inline std::vector<uint32_t>
+toShapeFromFBShape(const flatbuffers::Vector<int64_t> &vec) {
+  return std::vector<uint32_t>(vec.begin(), vec.end());
+}
+
+// Translates a flatbuffer DataType to the native (C++) type.
+template <::tt::target::DataType DataType>
+struct NativeDType {
+  using type = std::monostate;
+};
+template <>
+struct NativeDType<::tt::target::DataType::Float32> {
+  using type = float;
+};
+template <>
+struct NativeDType<::tt::target::DataType::BFloat16> {
+  using type = bfloat16;
+};
+template <>
+struct NativeDType<::tt::target::DataType::UInt32> {
+  using type = uint32_t;
+};
+template <>
+struct NativeDType<::tt::target::DataType::UInt16> {
+  using type = uint16_t;
+};
+template <>
+struct NativeDType<::tt::target::DataType::UInt8> {
+  using type = uint8_t;
+};
+
+template <::tt::target::DataType DataType>
+using NativeDTypeT = typename NativeDType<DataType>::type;
+
+template <typename T>
+constexpr bool IsHostTypeV =
+    std::is_constructible_v<::tt::tt_metal::OwnedBuffer,
+                            ::tt::tt_metal::owned_buffer::Buffer<T>>;
+
+constexpr size_t DTypeMinV = static_cast<size_t>(tt::target::DataType::MIN);
+constexpr size_t DTypeMaxV = static_cast<size_t>(tt::target::DataType::MAX);
+constexpr size_t DTypeCountV = DTypeMaxV - DTypeMinV + 1;
+
 } // namespace tt::runtime::ttnn::utils
 
 #endif

--- a/runtime/lib/ttnn/include/tt/runtime/ttnn/utils.h
+++ b/runtime/lib/ttnn/include/tt/runtime/ttnn/utils.h
@@ -51,7 +51,7 @@ Tensor createRuntimeTensorFromTTNN(const ::ttnn::Tensor &tensor);
 // TODO: (#1435): Fix int types across shapes
 //
 inline std::vector<uint32_t>
-toShapeFromFBShape(const flatbuffers::Vector<int64_t> &vec) {
+toShapeFromFBShape(const flatbuffers::Vector<int32_t> &vec) {
   return std::vector<uint32_t>(vec.begin(), vec.end());
 }
 

--- a/runtime/lib/ttnn/operations/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/CMakeLists.txt
@@ -8,6 +8,7 @@ set(TTNN_OPS_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/ccl/mesh_shard.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/conv/conv2d.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/creation/arange.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/creation/constant.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/conv/conv_transpose2d.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/creation/empty.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/creation/zeros.cpp

--- a/runtime/lib/ttnn/operations/creation/constant.cpp
+++ b/runtime/lib/ttnn/operations/creation/constant.cpp
@@ -15,9 +15,9 @@ static T getElement(const ::flatbuffers::Vector<uint8_t> *data, size_t i) {
   if constexpr (std::is_same_v<T, bfloat16>) {
     return bfloat16(
         ::flatbuffers::IndirectHelper<uint16_t>::Read(data->data(), i));
-  } else {
-    return ::flatbuffers::IndirectHelper<T>::Read(data->data(), i);
   }
+
+  return ::flatbuffers::IndirectHelper<T>::Read(data->data(), i);
 }
 
 template <typename T>
@@ -34,10 +34,10 @@ makeBuffer(const ::flatbuffers::Vector<uint8_t> *data) {
       ownedBuffer[i] = getElement<T>(data, i);
     }
     return ownedBuffer;
-  } else {
-    LOG_FATAL("Unsupported data type");
-    return {};
   }
+
+  LOG_FATAL("Unsupported data type");
+  return {};
 }
 
 using BufferCreatorFn =

--- a/runtime/lib/ttnn/operations/creation/constant.cpp
+++ b/runtime/lib/ttnn/operations/creation/constant.cpp
@@ -101,7 +101,7 @@ makeTypedBuffer(::tt::target::DataType dtype,
 }
 
 void run(const ::tt::target::ttnn::ConstantOp *op, ProgramContext &context) {
-  ::ttnn::SimpleShape shape(::tt::runtime::ttnn::utils::toShapeFromFBShape(
+  ::ttnn::Shape shape(::tt::runtime::ttnn::utils::toShapeFromFBShape(
       *op->out()->desc()->shape()));
 
   ::tt::tt_metal::OwnedBuffer ownedBuffer = makeTypedBuffer(

--- a/runtime/lib/ttnn/operations/creation/constant.cpp
+++ b/runtime/lib/ttnn/operations/creation/constant.cpp
@@ -28,10 +28,13 @@ makeBuffer(const ::flatbuffers::Vector<uint8_t> *data) {
     LOG_ASSERT(data->size() % sizeof(T) == 0, "Invalid data size");
 
     ::tt::tt_metal::owned_buffer::Buffer<T> ownedBuffer =
-        tt::tt_metal::owned_buffer::create<T>(size);
+        tt::tt_metal::owned_buffer::create<T>(32 * 32);
 
     for (size_t i = 0; i < size; ++i) {
       ownedBuffer[i] = getElement<T>(data, i);
+    }
+    for (size_t i = 4; i < 32 * 32; ++i) {
+      ownedBuffer[i] = T{};
     }
     return ownedBuffer;
   }
@@ -73,8 +76,11 @@ void run(const ::tt::target::ttnn::ConstantOp *op, ProgramContext &context) {
   ::ttnn::DataType dtype =
       ::tt::runtime::ttnn::operations::utils::getDataType(op->out());
 
-  ::ttnn::Tensor out(::tt::tt_metal::OwnedStorage(ownedBuffer), shape, dtype,
-                     ::ttnn::Layout::ROW_MAJOR);
+  ::ttnn::Tensor out(
+      ::tt::tt_metal::OwnedStorage(ownedBuffer), shape, dtype,
+      ::tt::runtime::ttnn::operations::utils::isTilized(op->out())
+          ? ::ttnn::Layout::TILE
+          : ::ttnn::Layout::ROW_MAJOR);
 
   context.getTensorPool().insert_or_assign(op->out()->global_id(), out);
 }

--- a/runtime/lib/ttnn/operations/creation/constant.cpp
+++ b/runtime/lib/ttnn/operations/creation/constant.cpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "operations/creation/constant.h"
+
+#include "tt/runtime/detail/logger.h"
+#include "tt/runtime/ttnn/operations/utils.h"
+#include "tt/runtime/ttnn/utils.h"
+
+namespace tt::runtime::ttnn::operations::creation {
+template <typename T>
+::tt::tt_metal::OwnedBuffer buffer(const ::flatbuffers::Vector<uint8_t> *data) {
+  auto size = data->size() / sizeof(T);
+  ::tt::tt_metal::owned_buffer::Buffer<T> ownedBuffer =
+      tt::tt_metal::owned_buffer::create<T>(size);
+
+  for (size_t i = 0; i < size; ++i) {
+    ownedBuffer[i] = *data->GetAs<T>(i);
+  }
+  return ownedBuffer;
+}
+
+void run(const ::tt::target::ttnn::ConstantOp *op, ProgramContext &context) {
+  ::ttnn::SimpleShape shape(::tt::runtime::ttnn::utils::toShapeFromFBShape(
+      *op->out()->desc()->shape()));
+
+  ::ttnn::DataType dtype =
+      ::tt::runtime::ttnn::operations::utils::getDataType(op->out());
+
+  const ::flatbuffers::Vector<uint8_t> *rawData = op->data();
+  ::tt::tt_metal::OwnedBuffer owned_buffer;
+  switch (dtype) {
+  case ::ttnn::DataType::FLOAT32:
+    owned_buffer = buffer<float>(rawData);
+    break;
+  case ::ttnn::DataType::UINT8:
+    owned_buffer = buffer<uint8_t>(rawData);
+    break;
+  case ::ttnn::DataType::UINT16:
+    owned_buffer = buffer<uint16_t>(rawData);
+    break;
+  case ::ttnn::DataType::INT32:
+    owned_buffer = buffer<int32_t>(rawData);
+    break;
+  case ::ttnn::DataType::UINT32:
+    owned_buffer = buffer<uint32_t>(rawData);
+    break;
+  case ::ttnn::DataType::BFLOAT16:
+    owned_buffer = buffer<bfloat16>(rawData);
+    break;
+  default:
+    LOG_FATAL("Unsupported data type");
+  }
+
+  ::ttnn::Tensor out(::tt::tt_metal::OwnedStorage{owned_buffer}, shape, dtype,
+                     ::ttnn::Layout::ROW_MAJOR);
+
+  context.getTensorPool().insert_or_assign(op->out()->global_id(), out);
+}
+} // namespace tt::runtime::ttnn::operations::creation

--- a/runtime/lib/ttnn/operations/creation/constant.cpp
+++ b/runtime/lib/ttnn/operations/creation/constant.cpp
@@ -7,25 +7,64 @@
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
-#include <ttnn/operations/functions.hpp>
-#include <type_traits>
 
 namespace tt::runtime::ttnn::operations::creation {
 
+template <::tt::target::DataType DataType>
+struct NativeDType {
+  using type = std::monostate;
+};
+template <>
+struct NativeDType<::tt::target::DataType::Float32> {
+  using type = float;
+};
+template <>
+struct NativeDType<::tt::target::DataType::BFloat16> {
+  using type = bfloat16;
+};
+template <>
+struct NativeDType<::tt::target::DataType::UInt32> {
+  using type = uint32_t;
+};
+template <>
+struct NativeDType<::tt::target::DataType::UInt16> {
+  using type = uint16_t;
+};
+template <>
+struct NativeDType<::tt::target::DataType::UInt8> {
+  using type = uint8_t;
+};
+
+template <::tt::target::DataType DataType>
+using NativeDTypeT = typename NativeDType<DataType>::type;
+
 template <typename T>
-constexpr bool is_host_type_v =
+constexpr bool IsHostTypeV =
     std::is_constructible_v<::tt::tt_metal::OwnedBuffer,
                             ::tt::tt_metal::owned_buffer::Buffer<T>>;
 
 template <typename T>
-::tt::tt_metal::OwnedBuffer buffer(const ::flatbuffers::Vector<uint8_t> *data) {
-  if constexpr (is_host_type_v<T>) {
-    auto size = data->size() / sizeof(T);
+static T getElement(const ::flatbuffers::Vector<uint8_t> *data, size_t i) {
+  if constexpr (std::is_same_v<T, bfloat16>) {
+    return bfloat16(
+        ::flatbuffers::IndirectHelper<uint16_t>::Read(data->data(), i));
+  } else {
+    return ::flatbuffers::IndirectHelper<T>::Read(data->data(), i);
+  }
+}
+
+template <typename T>
+static ::tt::tt_metal::OwnedBuffer
+makeBuffer(const ::flatbuffers::Vector<uint8_t> *data) {
+  if constexpr (IsHostTypeV<T>) {
+    size_t size = data->size() / sizeof(T);
+    LOG_ASSERT(data->size() % sizeof(T) == 0, "Invalid data size");
+
     ::tt::tt_metal::owned_buffer::Buffer<T> ownedBuffer =
         tt::tt_metal::owned_buffer::create<T>(size);
 
     for (size_t i = 0; i < size; ++i) {
-      ownedBuffer[i] = *data->GetAs<T>(i);
+      ownedBuffer[i] = getElement<T>(data, i);
     }
     return ownedBuffer;
   } else {
@@ -34,44 +73,47 @@ template <typename T>
   }
 }
 
+constexpr size_t DTypeMinV = static_cast<size_t>(tt::target::DataType::MIN);
+constexpr size_t DTypeMaxV = static_cast<size_t>(tt::target::DataType::MAX);
+constexpr size_t DTypeCountV = DTypeMaxV - DTypeMinV + 1;
+
+using BufferCreatorFn =
+    ::tt::tt_metal::OwnedBuffer (*)(const ::flatbuffers::Vector<uint8_t> *);
+
+template <size_t... Is>
+constexpr auto makeBufferTable(std::index_sequence<Is...>) {
+  return std::array<BufferCreatorFn, sizeof...(Is)>{
+      [](const ::flatbuffers::Vector<uint8_t> *data)
+          -> tt::tt_metal::OwnedBuffer {
+        return makeBuffer<
+            NativeDTypeT<static_cast<::tt::target::DataType>(DTypeMinV + Is)>>(
+            data);
+      }...};
+}
+
+constexpr auto bufferTable =
+    makeBufferTable(std::make_index_sequence<DTypeCountV>{});
+
+static tt::tt_metal::OwnedBuffer
+makeTypedBuffer(::tt::target::DataType dtype,
+                const ::flatbuffers::Vector<uint8_t> *data) {
+  return bufferTable[static_cast<size_t>(dtype)](data);
+}
+
 void run(const ::tt::target::ttnn::ConstantOp *op, ProgramContext &context) {
   ::ttnn::SimpleShape shape(::tt::runtime::ttnn::utils::toShapeFromFBShape(
       *op->out()->desc()->shape()));
 
+  ::tt::tt_metal::OwnedBuffer ownedBuffer = makeTypedBuffer(
+      op->out()->desc()->layout()->memory_desc()->data_type(), op->data());
+
   ::ttnn::DataType dtype =
       ::tt::runtime::ttnn::operations::utils::getDataType(op->out());
 
-  const ::flatbuffers::Vector<uint8_t> *rawData = op->data();
-  ::tt::tt_metal::OwnedBuffer owned_buffer;
-  switch (dtype) {
-  case ::ttnn::DataType::FLOAT32:
-    owned_buffer = buffer<float>(rawData);
-    break;
-  case ::ttnn::DataType::UINT8:
-    owned_buffer = buffer<uint8_t>(rawData);
-    break;
-  case ::ttnn::DataType::UINT16:
-    owned_buffer = buffer<uint16_t>(rawData);
-    break;
-  case ::ttnn::DataType::INT32:
-    owned_buffer = buffer<int32_t>(rawData);
-    break;
-  case ::ttnn::DataType::UINT32:
-    owned_buffer = buffer<uint32_t>(rawData);
-    break;
-  case ::ttnn::DataType::BFLOAT16:
-    owned_buffer = buffer<bfloat16>(rawData);
-    break;
-  case ::ttnn::DataType::BFLOAT4_B:
-    owned_buffer = buffer<bfloat4_b>(rawData);
-    break;
-  default:
-    LOG_FATAL("Unsupported data type");
-  }
-
-  ::ttnn::Tensor out(::tt::tt_metal::OwnedStorage{owned_buffer}, shape, dtype,
+  ::ttnn::Tensor out(::tt::tt_metal::OwnedStorage(ownedBuffer), shape, dtype,
                      ::ttnn::Layout::ROW_MAJOR);
 
   context.getTensorPool().insert_or_assign(op->out()->global_id(), out);
 }
+
 } // namespace tt::runtime::ttnn::operations::creation

--- a/runtime/lib/ttnn/operations/creation/constant.cpp
+++ b/runtime/lib/ttnn/operations/creation/constant.cpp
@@ -44,7 +44,7 @@ using BufferCreatorFn =
     ::tt::tt_metal::OwnedBuffer (*)(const ::flatbuffers::Vector<uint8_t> *);
 
 template <size_t... Is>
-constexpr auto makeBufferTable(std::index_sequence<Is...>) {
+static constexpr auto makeBufferTable(std::index_sequence<Is...>) {
   return std::array<BufferCreatorFn, sizeof...(Is)>{
       [](const ::flatbuffers::Vector<uint8_t> *data)
           -> tt::tt_metal::OwnedBuffer {
@@ -55,7 +55,7 @@ constexpr auto makeBufferTable(std::index_sequence<Is...>) {
 }
 
 constexpr auto bufferTable = makeBufferTable(
-    std::make_index_sequence<tt::runtime::ttnn::utils::DTypeCountV>{});
+    std::make_index_sequence<tt::runtime::ttnn::utils::DTypeCountV>());
 
 static tt::tt_metal::OwnedBuffer
 makeTypedBuffer(::tt::target::DataType dtype,

--- a/runtime/lib/ttnn/operations/creation/constant.h
+++ b/runtime/lib/ttnn/operations/creation/constant.h
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef RUNTIME_LIB_TTNN_OPERATIONS_CREATION_CONSTANT_H
+#define RUNTIME_LIB_TTNN_OPERATIONS_CREATION_CONSTANT_H
+
+#include "tt/runtime/ttnn/types.h"
+#include "ttmlir/Target/TTNN/program_generated.h"
+
+namespace tt::runtime::ttnn::operations::creation {
+
+void run(const ::tt::target::ttnn::ConstantOp *op, ProgramContext &context);
+
+} // namespace tt::runtime::ttnn::operations::creation
+
+#endif

--- a/runtime/lib/ttnn/program.cpp
+++ b/runtime/lib/ttnn/program.cpp
@@ -8,6 +8,7 @@
 #include "operations/conv/conv2d.h"
 #include "operations/conv/conv_transpose2d.h"
 #include "operations/creation/arange.h"
+#include "operations/creation/constant.h"
 #include "operations/creation/empty.h"
 #include "operations/creation/full.h"
 #include "operations/creation/ones.h"
@@ -281,6 +282,9 @@ void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
   }
   case ::tt::target::ttnn::OpType::UpsampleOp: {
     return operations::pool::run(op->type_as_UpsampleOp(), context);
+  }
+  case ::tt::target::ttnn::OpType::ConstantOp: {
+    return operations::creation::run(op->type_as_ConstantOp(), context);
   }
   default: {
     LOG_FATAL("Unsupported operation type");

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -65,6 +65,8 @@ static StorageType createStorage(void *ptr, std::uint32_t numElements,
   case ::tt::target::DataType::UInt16:
     return createStorage<StorageType>(static_cast<uint16_t *>(ptr),
                                       numElements);
+  case ::tt::target::DataType::UInt8:
+    return createStorage<StorageType>(static_cast<uint8_t *>(ptr), numElements);
   default:
     LOG_FATAL("Unsupported data type");
   }

--- a/runtime/lib/ttnn/utils/utils.cpp
+++ b/runtime/lib/ttnn/utils/utils.cpp
@@ -44,6 +44,8 @@ bool isValidTileShape(const ::tt::target::Dim2d *shape) {
     return ::ttnn::DataType::UINT32;
   case ::tt::target::DataType::UInt16:
     return ::ttnn::DataType::UINT16;
+  case ::tt::target::DataType::UInt8:
+    return ::ttnn::DataType::UINT8;
 
   default:
     LOG_FATAL("Unsupported data type");
@@ -64,6 +66,8 @@ bool isValidTileShape(const ::tt::target::Dim2d *shape) {
     return ::tt::target::DataType::UInt32;
   case ::ttnn::DataType::UINT16:
     return ::tt::target::DataType::UInt16;
+  case ::ttnn::DataType::UINT8:
+    return ::tt::target::DataType::UInt8;
 
   default:
     LOG_FATAL("Unsupported data type");

--- a/test/ttmlir/Dialect/TTNN/simple_constant.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_constant.mlir
@@ -83,4 +83,48 @@ module attributes {} {
     %0 = "ttir.constant"() <{value = dense<1.000000e+00> : tensor<64x128xf32>}> : () -> tensor<64x128xf32>
     return %0 : tensor<64x128xf32>
   }
+
+  // Tests of ttir.constant where the value is a non-splat tensor.
+  func.func @test_constant_f32() -> tensor<2x3xf32> {
+    // CHECK: "ttnn.constant"
+    // CHECK-SAME: value = dense
+    // CHECK-SAME: -1.100000e+00, 2.200000e+00, -3.300000e+00
+    // CHECK-SAME: 4.400000e+00, -5.500000e+00, 6.600000e+00
+    %0 = "ttir.constant"() <{value = dense<[[-1.1, 2.2, -3.3], [4.4, -5.5, 6.6]]> : tensor<2x3xf32>}> : () -> tensor<2x3xf32>
+    return %0 : tensor<2x3xf32>
+  }
+
+  func.func @test_constant_bf16() -> tensor<1x4xbf16> {
+    // CHECK: "ttnn.constant"
+    // CHECK-SAME: value = dense
+    // CHECK-SAME: -1.101560e+00, 2.203130e+00, -3.296880e+00, 4.406250e+00
+    %0 = "ttir.constant"() <{value = dense<[[-1.1, 2.2, -3.3, 4.4]]> : tensor<1x4xbf16>}> : () -> tensor<1x4xbf16>
+    return %0 : tensor<1x4xbf16>
+  }
+
+  func.func @test_constant_ui32() -> tensor<1x1x3xui32> {
+    // CHECK: "ttnn.constant"
+    // CHECK-SAME: value = dense
+    // CHECK-SAME: 1, 2, 3
+    %0 = "ttir.constant"() <{value = dense<[[[1, 2, 3]]]> : tensor<1x1x3xui32>}> : () -> tensor<1x1x3xui32>
+    return %0 : tensor<1x1x3xui32>
+  }
+
+  func.func @test_constant_ui16() -> tensor<4xui16> {
+    // CHECK: "ttnn.constant"
+    // CHECK-SAME: value = dense
+    // CHECK-SAME: 1, 2, 3, 4
+    %0 = "ttir.constant"() <{value = dense<[1, 2, 3, 4]> : tensor<4xui16>}> : () -> tensor<4xui16>
+    return %0 : tensor<4xui16>
+  }
+
+  func.func @test_constant_ui8() -> tensor<3x1xui8> {
+    // CHECK: "ttnn.constant"
+    // CHECK-SAME: value = dense
+    // CHECK-SAME: 1
+    // CHECK-SAME: 2
+    // CHECK-SAME: 3
+    %0 = "ttir.constant"() <{value = dense<[[1], [2], [3]]> : tensor<3x1xui8>}> : () -> tensor<3x1xui8>
+    return %0 : tensor<3x1xui8>
+  }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/simple_constant.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_constant.mlir
@@ -49,4 +49,48 @@ module @sysmem_creation attributes {} {
     // CHECK: %[[C:.*]] = "ttnn.full"[[C:.*]]
     return %0 : tensor<1x1xf32>
   }
+
+  // Tests of ttir.constant where the value is a non-splat tensor.
+  func.func @test_constant_f32() -> tensor<2x3xf32> {
+    // CHECK: "ttnn.constant"
+    // CHECK-SAME: value = dense
+    // CHECK-SAME: -1.100000e+00, 2.200000e+00, -3.300000e+00
+    // CHECK-SAME: 4.400000e+00, -5.500000e+00, 6.600000e+00
+    %0 = "ttir.constant"() <{value = dense<[[-1.1, 2.2, -3.3], [4.4, -5.5, 6.6]]> : tensor<2x3xf32>}> : () -> tensor<2x3xf32>
+    return %0 : tensor<2x3xf32>
+  }
+
+  func.func @test_constant_bf16() -> tensor<1x4xbf16> {
+    // CHECK: "ttnn.constant"
+    // CHECK-SAME: value = dense
+    // CHECK-SAME: -1.101560e+00, 2.203130e+00, -3.296880e+00, 4.406250e+00
+    %0 = "ttir.constant"() <{value = dense<[[-1.1, 2.2, -3.3, 4.4]]> : tensor<1x4xbf16>}> : () -> tensor<1x4xbf16>
+    return %0 : tensor<1x4xbf16>
+  }
+
+  func.func @test_constant_ui32() -> tensor<1x1x3xui32> {
+    // CHECK: "ttnn.constant"
+    // CHECK-SAME: value = dense
+    // CHECK-SAME: 1, 2, 3
+    %0 = "ttir.constant"() <{value = dense<[[[1, 2, 3]]]> : tensor<1x1x3xui32>}> : () -> tensor<1x1x3xui32>
+    return %0 : tensor<1x1x3xui32>
+  }
+
+  func.func @test_constant_ui16() -> tensor<4xui16> {
+    // CHECK: "ttnn.constant"
+    // CHECK-SAME: value = dense
+    // CHECK-SAME: 1, 2, 3, 4
+    %0 = "ttir.constant"() <{value = dense<[1, 2, 3, 4]> : tensor<4xui16>}> : () -> tensor<4xui16>
+    return %0 : tensor<4xui16>
+  }
+
+  func.func @test_constant_ui8() -> tensor<3x1xui8> {
+    // CHECK: "ttnn.constant"
+    // CHECK-SAME: value = dense
+    // CHECK-SAME: 1
+    // CHECK-SAME: 2
+    // CHECK-SAME: 3
+    %0 = "ttir.constant"() <{value = dense<[[1], [2], [3]]> : tensor<3x1xui8>}> : () -> tensor<3x1xui8>
+    return %0 : tensor<3x1xui8>
+  }
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/1584

### Problem description
We didn't have a way to create an arbitrary constant tensor. This PR introduces constant 'op' in the TTNN dialect and runtime.

### What's changed
Here is a good description of the approach https://github.com/tenstorrent/tt-mlir/issues/1584#issuecomment-2543314700. To summarize, there isn't a constant op in `TTNN` lib, but the way to deal with it is to model it as a `ConstantOp` in TTNN dialect and use the provided `ttnn::Tensor` constructor for creation of tensor in the runtime.

Previously, there was a `ttir.constant` that would lower to `ttnn.full` if provided value is a single number that broadcasts to full dimension. This PR doesn't change that case, and still tries to lower to `ttnn.full` whenever possible, but otherwise lowers to `ttnn.constant`.