### PR TITLE
StreamLayoutAttr replaces BufferAccessAttr in d2m

### DIFF
--- a/include/ttmlir/Dialect/TT/IR/TTOpsEnums.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsEnums.td
@@ -138,14 +138,23 @@ def TT_ChipCapability : I32BitEnumAttr<"ChipCapability", "TT Chip Capabilities",
   let cppNamespace = "::mlir::tt";
 }
 
-def TT_BufferAccessAlias : I32BitEnumAttrCaseBit<"Alias", 0, "alias">;
-def TT_BufferAccessStream : I32BitEnumAttrCaseBit<"Stream", 1, "stream">;
+def TT_StreamModeAlias : I32BitEnumAttrCaseBit<"Alias", 0, "alias">;
+def TT_StreamModeStream : I32BitEnumAttrCaseBit<"Stream", 1, "stream">;
+
+def TT_StreamMode : I32BitEnumAttr<"StreamMode", "TT Stream Mode",
+                           [
+                            TT_StreamModeAlias,
+                            TT_StreamModeStream,
+                           ]> {
+  let genSpecializedAttr = 0;
+  let cppNamespace = "::mlir::tt";
+}
 
 def TT_BufferAccess : I32BitEnumAttr<"BufferAccess", "TT Buffer Access",
                            [
-                            TT_BufferAccessAlias ,
-                            TT_BufferAccessStream,
-                           ]> {
+                            TT_StreamModeAlias,
+                            TT_StreamModeStream,
+                           ]>, Deprecated<"use TT_StreamMode instead"> {
   let genSpecializedAttr = 0;
   let cppNamespace = "::mlir::tt";
 }

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.h
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.h
@@ -135,16 +135,19 @@ calculateLogicalShardShape(mlir::ArrayRef<int64_t> tensorShape,
 template <typename T, typename TAttr>
 mlir::MemRefType buildMemRef(::mlir::MLIRContext *context,
                              ::llvm::ArrayRef<int64_t> shardShape,
-                             ::mlir::Type elementType, T memorySpace) {
+                             ::mlir::Type elementType, T memorySpace,
+                             mlir::tt::StreamLayoutAttr layout = {}) {
   ::llvm::SmallVector<int64_t> scalarShardShape(shardShape);
   if (mlir::isa<mlir::tt::TileType>(elementType)) {
     scalarShardShape = mlir::cast<mlir::tt::TileType>(elementType)
                            .getTiledShape(scalarShardShape);
   }
-  return mlir::MemRefType::get(
-      scalarShardShape, elementType,
-      mlir::AffineMap::getMultiDimIdentityMap(scalarShardShape.size(), context),
-      TAttr::get(context, memorySpace));
+  return layout ? mlir::MemRefType::get(scalarShardShape, elementType, layout,
+                                        TAttr::get(context, memorySpace))
+                : mlir::MemRefType::get(scalarShardShape, elementType,
+                                        mlir::AffineMap::getMultiDimIdentityMap(
+                                            shardShape.size(), context),
+                                        TAttr::get(context, memorySpace));
 }
 
 #endif

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.h
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.h
@@ -146,7 +146,7 @@ mlir::MemRefType buildMemRef(::mlir::MLIRContext *context,
                                         TAttr::get(context, memorySpace))
                 : mlir::MemRefType::get(scalarShardShape, elementType,
                                         mlir::AffineMap::getMultiDimIdentityMap(
-                                            shardShape.size(), context),
+                                            scalarShardShape.size(), context),
                                         TAttr::get(context, memorySpace));
 }
 

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -251,6 +251,8 @@ def TT_StreamLayoutAttr : TT_Attr<"StreamLayout", "stream", [MemRefLayoutAttrInt
         }
       };
   }];
+
+  let genVerifyDecl = 1;
 }
 
 def TT_MetalLayoutAttr : TT_Attr<"MetalLayout", "metal_layout"> {

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -235,7 +235,7 @@ def TT_StreamLayoutAttr : TT_Attr<"StreamLayout", "stream", [MemRefLayoutAttrInt
     - AffineMap: Provides affine map indexing into the associated data stream.
     - StreamMode: Encodes 'Alias' or 'Stream' mode.
     - NumBuffers: Number of back buffers used for double buffering, I/O latency hiding, etc
-                  (always 1 in 'Alias' stream mode).  
+                  (always 1 in 'Alias' stream mode).
   }];
   let parameters = (ins "AffineMap":$affineMap,
                         AttrParameter<"StreamMode", "Encodes 'Alias' or 'Stream' mode.">:$streamMode,
@@ -248,9 +248,9 @@ def TT_StreamLayoutAttr : TT_Attr<"StreamLayout", "stream", [MemRefLayoutAttrInt
         switch (memorySpace) {
           case MemorySpace::DeviceL1: return { StreamMode::Alias, 1 };
           default: return { StreamMode::Stream, 1 };
-        } 
+        }
       };
-  }];      
+  }];
 }
 
 def TT_MetalLayoutAttr : TT_Attr<"MetalLayout", "metal_layout"> {
@@ -354,7 +354,7 @@ def TT_MetalLayoutAttr : TT_Attr<"MetalLayout", "metal_layout"> {
       MetalLayoutAttr withMemoryLayout(::mlir::MLIRContext *context, TensorMemoryLayout memLayout);
       MetalLayoutAttr withShardShape(::mlir::MLIRContext *context, llvm::SmallVector<int64_t> shardShape);
       MetalLayoutAttr withStreamLayout(::mlir::MLIRContext *context, StreamLayoutAttr stream);
-      
+
 
       uint64_t getMemrefSizeBytes() const;
       MemorySpace getMemorySpace() const;

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -356,6 +356,10 @@ def TT_MetalLayoutAttr : TT_Attr<"MetalLayout", "metal_layout"> {
       MetalLayoutAttr withMemoryLayout(::mlir::MLIRContext *context, TensorMemoryLayout memLayout);
       MetalLayoutAttr withShardShape(::mlir::MLIRContext *context, llvm::SmallVector<int64_t> shardShape);
       MetalLayoutAttr withStreamLayout(::mlir::MLIRContext *context, StreamLayoutAttr stream);
+      MetalLayoutAttr withOuterScale(::mlir::MLIRContext *context,
+                          llvm::ArrayRef<int64_t> outerScale,
+                          StreamMode streamMode,
+                          std::uint32_t numBuffers);
 
 
       uint64_t getMemrefSizeBytes() const;

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -7,8 +7,10 @@
 
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/EnumAttr.td"
+include "mlir/IR/BuiltinAttributeInterfaces.td"
 include "mlir/IR/BuiltinTypeInterfaces.td"
 include "mlir/IR/CommonTypeConstraints.td"
+
 include "ttmlir/Dialect/TT/IR/TTBase.td"
 include "ttmlir/Dialect/TT/IR/TTOpsEnums.td"
 
@@ -214,6 +216,43 @@ def TT_SystemDescAttr : TT_Attr<"SystemDesc", "system_desc"> {
   }];
 }
 
+def TT_StreamModeAttr : EnumAttr<TT_Dialect, TT_StreamMode, "stream_mode"> {
+  let description = [{
+    Describes mode of a data stream:
+    - Alias: Data stream is a buffer that aliases data directly in L1. No data movement is necessary
+             to co-locate data with kernel calculations.
+    - Stream: Data stream references remote memory (e.g., in DRAM or another core's L1). Data movement
+              is necessary to get remote data into local buffer(s), possibly via a sequence of steps that use
+              local buffer(s) as temporary destination(s).
+  }];
+  let assemblyFormat = "$value";
+}
+
+def TT_StreamLayoutAttr : TT_Attr<"StreamLayout", "stream", [MemRefLayoutAttrInterface]> {
+  let summary = "Stream layout attribute in TT dialect";
+  let description = [{
+    Describes stream mode- and buffering-aware layout of a memref buffer.
+    - AffineMap: Provides affine map indexing into the associated data stream.
+    - StreamMode: Encodes 'Alias' or 'Stream' mode.
+    - NumBuffers: Number of back buffers used for double buffering, I/O latency hiding, etc
+                  (always 1 in 'Alias' stream mode).  
+  }];
+  let parameters = (ins "AffineMap":$affineMap,
+                        AttrParameter<"StreamMode", "Encodes 'Alias' or 'Stream' mode.">:$streamMode,
+                        DefaultValuedParameter<"uint32_t", "1">:$numBuffers);
+
+  let assemblyFormat = "`<` $affineMap`,` $streamMode(`,` $numBuffers^)? `>`";
+
+  let extraClassDeclaration = [{
+      static constexpr std::tuple<StreamMode, uint32_t> getDefaults(MemorySpace memorySpace) {
+        switch (memorySpace) {
+          case MemorySpace::DeviceL1: return { StreamMode::Alias, 1 };
+          default: return { StreamMode::Stream, 1 };
+        } 
+      };
+  }];      
+}
+
 def TT_MetalLayoutAttr : TT_Attr<"MetalLayout", "metal_layout"> {
   let summary = "Tensor layout attribute";
   let description = [{
@@ -314,6 +353,8 @@ def TT_MetalLayoutAttr : TT_Attr<"MetalLayout", "metal_layout"> {
       MetalLayoutAttr withMemorySpace(::mlir::MLIRContext *context, MemorySpace memorySpace);
       MetalLayoutAttr withMemoryLayout(::mlir::MLIRContext *context, TensorMemoryLayout memLayout);
       MetalLayoutAttr withShardShape(::mlir::MLIRContext *context, llvm::SmallVector<int64_t> shardShape);
+      MetalLayoutAttr withStreamLayout(::mlir::MLIRContext *context, StreamLayoutAttr stream);
+      
 
       uint64_t getMemrefSizeBytes() const;
       MemorySpace getMemorySpace() const;
@@ -337,11 +378,8 @@ def TT_MetalLayoutAttr : TT_Attr<"MetalLayout", "metal_layout"> {
   }];
 }
 
-def TT_BufferAccessAttr : EnumAttr<TT_Dialect, TT_BufferAccess, "buffer_access"> {
-  let assemblyFormat = "$value";
-}
 
-def TT_BufferAttr : TT_Attr<"Buffer", "buffer", []> {
+def TT_BufferAttr : TT_Attr<"Buffer", "buffer", []>, Deprecated<"use TT_StreamModeAttr instead"> {
   let summary = "Buffer attribute in TT dialect";
   let description = [{
     Describes the physical footprint and layout of a buffer in L1. Its memref must also have a shape with rank equal to DeviceAttr grid.

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -30,7 +30,11 @@ def TTIRAttachMetalLayout: Pass<"ttir-attach-metal-layout", "::mlir::ModuleOp"> 
     Option<"initMemorySpace", "init-memory-space",
           "::mlir::tt::MemorySpace",
           /*default=*/"::mlir::tt::MemorySpace::DeviceL1",
-           "Set the initial memory space for tensors to start in">
+           "set the initial memory space for tensors to start in">,
+    Option<"useStreamLayout", "use-stream-layout",
+          "bool",
+          /*default=*/"false",
+           "turn on #tt.stream layout decoration">
   ];
 }
 

--- a/include/ttmlir/Dialect/TTMetal/Pipelines/TTMetalPipelines.h
+++ b/include/ttmlir/Dialect/TTMetal/Pipelines/TTMetalPipelines.h
@@ -23,6 +23,13 @@ struct TTIRToTTMetalBackendPipelineOptions
       llvm::cl::desc(
           "Pass in a system descriptor flatbuffer to compile against."),
       llvm::cl::init("")};
+
+  // Option to select pipeline variant/version.
+  //
+  Option<std::size_t> version{
+      *this, "version",
+      llvm::cl::desc("Select pipeline implementation version (default: 0)."),
+      llvm::cl::init(0)};
 };
 
 void createTTIRToTTMetalBackendPipeline(

--- a/lib/Conversion/TTIRToTTMetal/AttachMetalLayout.cpp
+++ b/lib/Conversion/TTIRToTTMetal/AttachMetalLayout.cpp
@@ -44,6 +44,10 @@ public:
         std::tie(streamMode, streamBuffers) =
             StreamLayoutAttr::getDefaults(initMemorySpace);
 
+        // TODO(vroubtsovTT): the streamAffineMap calc below is not correct, it
+        // needs to derive the map from what's set on 'layout' plus some
+        // assumptions about "outer" indexing (e.g '1x1x...layoutxf12')
+
         auto streamAffineMap = mlir::AffineMap::getMultiDimIdentityMap(
             type.getShape().size(), ctx);
         auto streamLayout = StreamLayoutAttr::get(ctx, streamAffineMap,

--- a/lib/Dialect/TT/IR/TTOpsTypes.cpp
+++ b/lib/Dialect/TT/IR/TTOpsTypes.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <fstream>
 #include <mlir/IR/BuiltinTypes.h>
+#include <mlir/Support/LLVM.h>
 #include <numeric>
 
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
@@ -373,6 +374,19 @@ unsigned SystemDescAttr::getNocDRAMAddressAlignBytes(unsigned chipIndex) const {
 
 unsigned SystemDescAttr::getPcieAddressAlignBytes(unsigned chipIndex) const {
   return getChipDescs()[chipIndex].getPcieAddressAlignBytes();
+}
+
+::llvm::LogicalResult StreamLayoutAttr::verify(
+    ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
+    AffineMap affineMap, StreamMode streamMode, uint32_t numBuffers) {
+  if (streamMode == StreamMode::Alias) {
+    if (numBuffers != 1) {
+      emitError() << "'Alias' mode must imply no buffering: numBuffers = "
+                  << numBuffers;
+      return ::mlir::failure();
+    }
+  }
+  return ::mlir::success();
 }
 
 //

--- a/lib/Dialect/TT/IR/TTOpsTypes.cpp
+++ b/lib/Dialect/TT/IR/TTOpsTypes.cpp
@@ -2,23 +2,24 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstdint>
-#include <fstream>
-#include <mlir/IR/BuiltinTypes.h>
-#include <mlir/Support/LLVM.h>
-#include <numeric>
-
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
-#include "ttmlir/Utils.h"
 
-#include "mlir/IR/Builders.h"
-#include "mlir/IR/BuiltinOps.h"
-#include "mlir/IR/DialectImplementation.h"
 #include "ttmlir/Dialect/TT/IR/TT.h"
 #include "ttmlir/Target/Common/Target.h"
-#include "llvm/ADT/SmallVector.h"
-#include "llvm/ADT/StringExtras.h"
-#include "llvm/ADT/TypeSwitch.h"
+#include "ttmlir/Utils.h"
+
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/ADT/StringExtras.h>
+#include <llvm/ADT/TypeSwitch.h>
+#include <mlir/IR/BuiltinTypes.h>
+#include <mlir/IR/Builders.h>
+#include <mlir/IR/BuiltinOps.h>
+#include <mlir/IR/DialectImplementation.h>
+#include <mlir/Support/LLVM.h>
+
+#include <cstdint>
+#include <fstream>
+#include <numeric>
 
 using namespace mlir::tt;
 

--- a/lib/Dialect/TT/IR/TTOpsTypes.cpp
+++ b/lib/Dialect/TT/IR/TTOpsTypes.cpp
@@ -693,6 +693,15 @@ MetalLayoutAttr::withShardShape(::mlir::MLIRContext *context,
       getMemLayout());
 }
 
+MetalLayoutAttr MetalLayoutAttr::withStreamLayout(::mlir::MLIRContext *context,
+                                                  StreamLayoutAttr layout) {
+  return MetalLayoutAttr::get(
+      context, getLinear(), getOobVal(), getGrid(),
+      buildMemRef<MemorySpace, MemorySpaceAttr>(
+          context, getShardShape(), getElementType(), getMemorySpace(), layout),
+      getMemLayout());
+}
+
 MemorySpace MetalLayoutAttr::getMemorySpace() const {
   return mlir::cast<mlir::tt::MemorySpaceAttr>(getMemref().getMemorySpace())
       .getValue();

--- a/lib/Dialect/TT/IR/TTOpsTypes.cpp
+++ b/lib/Dialect/TT/IR/TTOpsTypes.cpp
@@ -11,9 +11,9 @@
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringExtras.h>
 #include <llvm/ADT/TypeSwitch.h>
-#include <mlir/IR/BuiltinTypes.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinOps.h>
+#include <mlir/IR/BuiltinTypes.h>
 #include <mlir/IR/DialectImplementation.h>
 #include <mlir/Support/LLVM.h>
 

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -17,19 +17,31 @@ namespace mlir::tt::ttmetal {
 void createTTIRToTTMetalBackendPipeline(
     OpPassManager &pm, const TTIRToTTMetalBackendPipelineOptions &options) {
   ttir::TTIRLoadSystemDescOptions systemDescOptions;
-  systemDescOptions.path = options.systemDescPath;
+  { systemDescOptions.path = options.systemDescPath; }
   pm.addPass(mlir::tt::ttir::createTTIRLoadSystemDesc(systemDescOptions));
   ttir::TTIRImplicitDeviceOptions implicitDeviceOptions;
-  implicitDeviceOptions.meshShape = ::llvm::SmallVector<int64_t>(
-      options.meshShape.begin(), options.meshShape.end());
+  {
+    implicitDeviceOptions.meshShape = ::llvm::SmallVector<int64_t>(
+        options.meshShape.begin(), options.meshShape.end());
+  }
   pm.addPass(mlir::tt::ttir::createTTIRImplicitDevice(implicitDeviceOptions));
   pm.addPass(mlir::tt::ttir::createTTIRConstantAsFill());
-  pm.addPass(mlir::tt::ttir::createTTIRAttachMetalLayout());
+  ttir::TTIRAttachMetalLayoutOptions attachMetalLayoutOptions;
+  {
+    // TODO(vroubtsovTT): 'options.version' is WIP until once StreamLayout is ok
+    // to use end-to-end
+    attachMetalLayoutOptions.useStreamLayout = options.version > 0;
+  }
+  pm.addPass(
+      mlir::tt::ttir::createTTIRAttachMetalLayout(attachMetalLayoutOptions));
   pm.addPass(mlir::tt::ttir::createTTIRGenericRegion());
   mlir::tt::ttir::TTIRLayoutOptions layoutOptions;
-  layoutOptions.initMemorySpace = mlir::tt::MemorySpace::DeviceL1;
-  layoutOptions.defaultMemorySpace = mlir::tt::MemorySpace::DeviceL1;
-  layoutOptions.defaultDeviceMemoryLayout = mlir::tt::TensorMemoryLayout::None;
+  {
+    layoutOptions.initMemorySpace = mlir::tt::MemorySpace::DeviceL1;
+    layoutOptions.defaultMemorySpace = mlir::tt::MemorySpace::DeviceL1;
+    layoutOptions.defaultDeviceMemoryLayout =
+        mlir::tt::TensorMemoryLayout::None;
+  }
   pm.addPass(mlir::tt::ttir::createTTIRLayout(layoutOptions));
   pm.addPass(mlir::tt::ttir::createTTIRGenericOpCBs());
   pm.addPass(mlir::tt::ttir::createTTIRGenericRegionOperandsToMemref());


### PR DESCRIPTION
This is WIP for #1895. Because this breaks several .mlir tests that match on `#tt.metal_layout`, want to get some quick feedback.

When the stream layout parameter is set on a `metal_layout`, things get more verbose:
```
#tt.metal_layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<64x128xf32, #tt.stream<(d0, d1) -> (d0, d1), stream, 2>, #l1_>>
```
for streams and and
```
#tt.metal_layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<64x128xf32, #tt.stream<(d0, d1) -> (d0, d1), alias>, #l1_>>
```
for aliases.  Whenever `numBuffers` is 1 it is not shown.

Questions:

1. `TT_BufferAttr` is also going away, correct?
2. I assume we want to start using (default) alias stream layouts starting at AttachMetalLayout, correct?