### PR TITLE
#2046: Change OpModel APIs to return llvm::Expected and Refactor Unit Tests

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.h
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_IR_TTNNOPMODELINTERFACE_H
+#define TTMLIR_DIALECT_TTNN_IR_TTNNOPMODELINTERFACE_H
+
+// This include is required for llvm::Expected in the tablegen'd
+// TTNNOpModelInterface methods
+#include "llvm/Support/Error.h"
+
+#endif

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.td
@@ -37,7 +37,7 @@ def TTNN_OpModelInterface : OpInterface<"OpModel"> {
             /*methodName=*/"getOpConstraints",
             /*args=*/(ins "const std::vector<TTNNLayoutAttr>&":$inputs, "const TTNNLayoutAttr&":$output),
             /*methodBody=*/"",
-            /*defaultImplementation=*/"return std::make_tuple(0,0,0);"
+            /*defaultImplementation=*/"return llvm::createStringError(\"Not Implemented\");"
         >,
         ];
 }

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.td
@@ -21,11 +21,11 @@ def TTNN_OpModelInterface : OpInterface<"OpModel"> {
                 2. If the measurement was successful, the estimated op runtime in nanoseconds.
                 3. If the measurement failed, a string describing the failure.
             }],
-            /*retTy=*/"std::tuple<bool, std::optional<size_t>, std::optional<std::string>>",
+            /*retTy=*/"llvm::Expected<size_t>",
             /*methodName=*/"getOpRuntime",
             /*args=*/(ins "const std::vector<TTNNLayoutAttr>&":$inputs, "const TTNNLayoutAttr&":$output),
             /*methodBody=*/"",
-            /*defaultImplementation=*/"return std::make_tuple(false, 0, std::nullopt);"
+            /*defaultImplementation=*/"return llvm::createStringError(\"Not Implemented\");"
         >,
         InterfaceMethod<
             /*desc=*/[{

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.td
@@ -16,8 +16,8 @@ def TTNN_OpModelInterface : OpInterface<"OpModel"> {
     let methods = [
         InterfaceMethod<
             /*desc=*/[{
-                Measure and return the runtime of the op in nanoseconds by running it on the device.
-                If the op is illegal or execution fails, return an Error with a string describing the failure.
+                Measures and returns the runtime of the op in nanoseconds by running it on the device.
+                If the op is illegal or execution fails, returns an Error with a string describing the failure.
             }],
             /*retTy=*/"llvm::Expected<size_t>",
             /*methodName=*/"getOpRuntime",
@@ -27,11 +27,11 @@ def TTNN_OpModelInterface : OpInterface<"OpModel"> {
         >,
         InterfaceMethod<
             /*desc=*/[{
-                Check if the op is legal for the given input/output layout. If it is, returns a tuple of three values:**
+                Checks if the op is legal for the given input/output layout. If it is, returns a tuple of three values:**
                    - The first value is the CB L1 peak allocation in bytes.
                    - The second value is the Tensor L1 peak allocation in bytes.
                    - The third value is the Output L1 buffer allocation in bytes.
-                If the op is illegal, return an Error with a string describing the failure.
+                If the op is illegal, returns an Error with a string describing the failure.
             }],
             /*retTy=*/"llvm::Expected<std::tuple<size_t, size_t, size_t>>",
             /*methodName=*/"getOpConstraints",

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.td
@@ -16,10 +16,8 @@ def TTNN_OpModelInterface : OpInterface<"OpModel"> {
     let methods = [
         InterfaceMethod<
             /*desc=*/[{
-                Returns a tuple of three values:**
-                1. A boolean indicating if runtime measurement was successful.
-                2. If the measurement was successful, the estimated op runtime in nanoseconds.
-                3. If the measurement failed, a string describing the failure.
+                Measure and return the runtime of the op in nanoseconds by running it on the device.
+                If the op is illegal or execution fails, return an Error with a string describing the failure.
             }],
             /*retTy=*/"llvm::Expected<size_t>",
             /*methodName=*/"getOpRuntime",
@@ -29,19 +27,17 @@ def TTNN_OpModelInterface : OpInterface<"OpModel"> {
         >,
         InterfaceMethod<
             /*desc=*/[{
-                Returns a tuple of three values:**
-                1. A boolean indicating if the op is legal for the given input/output layouts.
-                2. If the op is legal, a tuple of three values representing the op memory L1 usage estimate in bytes.
+                Check if the op is legal for the given input/output layout. If it is, returns a tuple of three values:**
                    - The first value is the CB L1 peak allocation in bytes.
                    - The second value is the Tensor L1 peak allocation in bytes.
                    - The third value is the Output L1 buffer allocation in bytes.
-                3. If the op is illegal, a string describing the failure.
+                If the op is illegal, return an Error with a string describing the failure.
             }],
-            /*retTy=*/"std::tuple<bool, std::optional<std::tuple<size_t, size_t, size_t>>, std::optional<std::string>>",
+            /*retTy=*/"llvm::Expected<std::tuple<size_t, size_t, size_t>>",
             /*methodName=*/"getOpConstraints",
             /*args=*/(ins "const std::vector<TTNNLayoutAttr>&":$inputs, "const TTNNLayoutAttr&":$output),
             /*methodBody=*/"",
-            /*defaultImplementation=*/"return std::make_tuple(true, std::make_tuple(0,0,0), std::nullopt);"
+            /*defaultImplementation=*/"return std::make_tuple(0,0,0);"
         >,
         ];
 }

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.h
@@ -21,7 +21,11 @@
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
 #define GET_OP_CLASSES
+// clang-format off
+// Required for OpModel return types
+#include "llvm/Support/Error.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.h.inc"
+// clang-format on
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h.inc"
 
 #endif

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.h
@@ -6,6 +6,7 @@
 #define TTMLIR_DIALECT_TTNN_IR_TTNNOPS_H
 
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsTypes.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNWorkaroundInterface.h"
@@ -21,11 +22,7 @@
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
 #define GET_OP_CLASSES
-// clang-format off
-// Required for OpModel return types
-#include "llvm/Support/Error.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.h.inc"
-// clang-format on
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h.inc"
 
 #endif

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -5,10 +5,10 @@
 #ifndef TTMLIR_OPMODEL_TTNN_TTNNOPMODEL_H
 #define TTMLIR_OPMODEL_TTNN_TTNNOPMODEL_H
 
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 
 #include "llvm/ADT/ArrayRef.h"
-#include "llvm/Support/Error.h"
 
 #include <tuple>
 

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -19,8 +19,7 @@ namespace mlir::tt::op_model::ttnn {
 //===----------------------------------------------------------------------===//
 
 namespace Device {
-std::tuple<bool, std::optional<std::string>>
-getDeviceConstraints(const mlir::tt::GridAttr &workerGrid);
+llvm::Expected<bool> getDeviceConstraints(const mlir::tt::GridAttr &workerGrid);
 }; // namespace Device
 
 //===----------------------------------------------------------------------===//
@@ -28,8 +27,7 @@ getDeviceConstraints(const mlir::tt::GridAttr &workerGrid);
 //===----------------------------------------------------------------------===//
 
 namespace ReluOpInterface {
-std::tuple<bool, std::optional<std::tuple<size_t, size_t, size_t>>,
-           std::optional<std::string>>
+llvm::Expected<std::tuple<size_t, size_t, size_t>>
 getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
                  llvm::ArrayRef<int64_t> outputShape,
@@ -47,8 +45,7 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 //===----------------------------------------------------------------------===//
 
 namespace AddOpInterface {
-std::tuple<bool, std::optional<std::tuple<size_t, size_t, size_t>>,
-           std::optional<std::string>>
+llvm::Expected<std::tuple<size_t, size_t, size_t>>
 getOpConstraints(llvm::ArrayRef<int64_t> inputShapeA,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
                  llvm::ArrayRef<int64_t> inputShapeB,
@@ -71,8 +68,7 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
 //===----------------------------------------------------------------------===//
 
 namespace SoftmaxOpInterface {
-std::tuple<bool, std::optional<std::tuple<size_t, size_t, size_t>>,
-           std::optional<std::string>>
+llvm::Expected<std::tuple<size_t, size_t, size_t>>
 getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayout, const int dimArg,
                  llvm::ArrayRef<int64_t> outputShape,
@@ -91,8 +87,7 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 //===----------------------------------------------------------------------===//
 
 namespace MatmulOpInterface {
-std::tuple<bool, std::optional<std::tuple<size_t, size_t, size_t>>,
-           std::optional<std::string>>
+llvm::Expected<std::tuple<size_t, size_t, size_t>>
 getOpConstraints(llvm::ArrayRef<int64_t> inputShapeA,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
                  llvm::ArrayRef<int64_t> inputShapeB,

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -8,6 +8,7 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/Error.h"
 
 #include <tuple>
 
@@ -34,7 +35,7 @@ getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                  llvm::ArrayRef<int64_t> outputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
 
-std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
+llvm::Expected<size_t>
 getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
              mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
              llvm::ArrayRef<int64_t> outputShape,
@@ -55,7 +56,7 @@ getOpConstraints(llvm::ArrayRef<int64_t> inputShapeA,
                  llvm::ArrayRef<int64_t> outputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
 
-std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
+llvm::Expected<size_t>
 getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
              mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
              llvm::ArrayRef<int64_t> inputShapeB,
@@ -77,7 +78,7 @@ getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                  llvm::ArrayRef<int64_t> outputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
 
-std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
+llvm::Expected<size_t>
 getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
              mlir::tt::ttnn::TTNNLayoutAttr inputLayout, const int dimArg,
              llvm::ArrayRef<int64_t> outputShape,
@@ -100,14 +101,13 @@ getOpConstraints(llvm::ArrayRef<int64_t> inputShapeA,
                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool transposeA,
                  bool transposeB);
 
-std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
-getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
-             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
-             llvm::ArrayRef<int64_t> inputShapeB,
-             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
-             llvm::ArrayRef<int64_t> outputShape,
-             mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool transposeA,
-             bool transposeB);
+llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
+                                    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                                    llvm::ArrayRef<int64_t> inputShapeB,
+                                    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                                    llvm::ArrayRef<int64_t> outputShape,
+                                    mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
+                                    bool transposeA, bool transposeB);
 }; // namespace MatmulOpInterface
 
 } // namespace mlir::tt::op_model::ttnn

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -19,7 +19,7 @@ namespace mlir::tt::op_model::ttnn {
 //===----------------------------------------------------------------------===//
 
 namespace Device {
-llvm::Expected<bool> getDeviceConstraints(const mlir::tt::GridAttr &workerGrid);
+llvm::Expected<bool> getDeviceConstraints(mlir::tt::GridAttr workerGrid);
 }; // namespace Device
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
+++ b/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
@@ -566,16 +566,16 @@ bool ShardSolver::checkShardCompatible(
       }
     }
 
-    auto [legal, l1Usage, errorMsg] =
-        backend.getOpConstraints(inputLayouts, consumerLayout);
+    auto l1UsageExp = backend.getOpConstraints(inputLayouts, consumerLayout);
 
     constexpr bool debug = false;
-    if (false == legal) {
+    if (!l1UsageExp) {
       // early exit
       if (debug) {
         llvm::errs() << "OpModel constraints failed: ";
         llvm::errs() << producerOp->getName() << "->" << consumerOp->getName()
-                     << " :: " << errorMsg.value() << "\n";
+                     << " :: " << llvm::toString(l1UsageExp.takeError())
+                     << "\n";
         producerLayout.dump();
         consumerLayout.dump();
       }

--- a/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
+++ b/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
@@ -5,6 +5,7 @@
 #include "ttmlir/Dialect/TTNN/Analysis/ShardSolver.h"
 #include "ttmlir/Dialect/TTNN/Analysis/L1ChainConfig.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include <llvm/Support/Error.h>
 #include <mlir/Interfaces/DestinationStyleOpInterface.h>
 #include <mlir/Support/LLVM.h>
 #include <unordered_set>
@@ -578,6 +579,8 @@ bool ShardSolver::checkShardCompatible(
                      << "\n";
         producerLayout.dump();
         consumerLayout.dump();
+      } else {
+        llvm::consumeError(l1UsageExp.takeError());
       }
       return false;
     }

--- a/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
+++ b/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
@@ -5,7 +5,6 @@
 #include "ttmlir/Dialect/TTNN/Analysis/ShardSolver.h"
 #include "ttmlir/Dialect/TTNN/Analysis/L1ChainConfig.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
-#include <llvm/Support/Error.h>
 #include <mlir/Interfaces/DestinationStyleOpInterface.h>
 #include <mlir/Support/LLVM.h>
 #include <unordered_set>

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -11,9 +11,7 @@
 
 #include "mlir/IR/Operation.h"
 
-#include "llvm/Support/Error.h"
 #include <cassert>
-#include <cstddef>
 #include <optional>
 #include <tuple>
 

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -11,7 +11,9 @@
 
 #include "mlir/IR/Operation.h"
 
+#include "llvm/Support/Error.h"
 #include <cassert>
+#include <cstddef>
 #include <optional>
 #include <tuple>
 
@@ -62,7 +64,7 @@ ReluOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       inputShape, inputs[0], outputShape, output);
 }
 
-std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
+llvm::Expected<size_t>
 ReluOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                      const TTNNLayoutAttr &output) {
 
@@ -106,7 +108,7 @@ AddOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       inputShapeA, inputs[0], inputShapeB, inputs[1], outputShape, output);
 }
 
-std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
+llvm::Expected<size_t>
 AddOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                     const TTNNLayoutAttr &output) {
   assert(inputs.size() == 2);
@@ -148,7 +150,7 @@ SoftmaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       inputShape, inputs[0], getDimension(), outputShape, output);
 }
 
-std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
+llvm::Expected<size_t>
 SoftmaxOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                         const TTNNLayoutAttr &output) {
   assert(inputs.size() == 1);
@@ -191,7 +193,7 @@ MatmulOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       false, false);
 }
 
-std::tuple<bool, std::optional<size_t>, std::optional<std::string>>
+llvm::Expected<size_t>
 MatmulOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                        const TTNNLayoutAttr &output) {
   assert(inputs.size() == 2);

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -20,21 +20,11 @@
 namespace mlir::tt::ttnn {
 
 namespace detail {
-std::tuple<bool, std::optional<std::tuple<size_t, size_t, size_t>>,
-           std::optional<std::string>>
-checkDeviceWorkerGrid(mlir::Operation *op) {
-
+llvm::Expected<bool> checkDeviceWorkerGrid(mlir::Operation *op) {
   auto deviceAttr = mlir::tt::getCurrentScopeDevice(op);
   assert(deviceAttr);
-  auto checkWorkerGrid =
-      op_model::ttnn::Device::getDeviceConstraints(deviceAttr.getWorkerGrid());
-
-  if (std::get<0>(checkWorkerGrid) == false) {
-    return std::make_tuple(std::get<0>(checkWorkerGrid), std::nullopt,
-                           std::get<1>(checkWorkerGrid));
-  }
-
-  return std::make_tuple(true, std::nullopt, std::nullopt);
+  return op_model::ttnn::Device::getDeviceConstraints(
+      deviceAttr.getWorkerGrid());
 }
 } // namespace detail
 
@@ -42,8 +32,7 @@ checkDeviceWorkerGrid(mlir::Operation *op) {
 // ReluOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-std::tuple<bool, std::optional<std::tuple<size_t, size_t, size_t>>,
-           std::optional<std::string>>
+llvm::Expected<std::tuple<size_t, size_t, size_t>>
 ReluOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                          const TTNNLayoutAttr &output) {
   assert(inputs.size() == 1);
@@ -56,8 +45,8 @@ ReluOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       mlir::cast<RankedTensorType>(getResults().front().getType()).getShape();
 
   auto check = detail::checkDeviceWorkerGrid(getOperation());
-  if (std::get<bool>(check) == false) {
-    return check;
+  if (!check) {
+    return check.takeError();
   }
 
   return op_model::ttnn::ReluOpInterface::getOpConstraints(
@@ -85,8 +74,7 @@ ReluOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // AddOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-std::tuple<bool, std::optional<std::tuple<size_t, size_t, size_t>>,
-           std::optional<std::string>>
+llvm::Expected<std::tuple<size_t, size_t, size_t>>
 AddOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                         const TTNNLayoutAttr &output) {
   assert(inputs.size() == 2);
@@ -100,8 +88,8 @@ AddOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       mlir::cast<RankedTensorType>(getResult(0).getType()).getShape();
 
   auto check = detail::checkDeviceWorkerGrid(getOperation());
-  if (std::get<bool>(check) == false) {
-    return check;
+  if (!check) {
+    return check.takeError();
   }
 
   return op_model::ttnn::AddOpInterface::getOpConstraints(
@@ -129,8 +117,7 @@ AddOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // SoftmaxOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-std::tuple<bool, std::optional<std::tuple<size_t, size_t, size_t>>,
-           std::optional<std::string>>
+llvm::Expected<std::tuple<size_t, size_t, size_t>>
 SoftmaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                             const TTNNLayoutAttr &output) {
   assert(inputs.size() == 1);
@@ -142,8 +129,8 @@ SoftmaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       mlir::cast<RankedTensorType>(getResult().getType()).getShape();
 
   auto check = detail::checkDeviceWorkerGrid(getOperation());
-  if (std::get<bool>(check) == false) {
-    return check;
+  if (!check) {
+    return check.takeError();
   }
 
   return op_model::ttnn::SoftmaxOpInterface::getOpConstraints(
@@ -169,8 +156,7 @@ SoftmaxOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // MatmulOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-std::tuple<bool, std::optional<std::tuple<size_t, size_t, size_t>>,
-           std::optional<std::string>>
+llvm::Expected<std::tuple<size_t, size_t, size_t>>
 MatmulOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                            const TTNNLayoutAttr &output) {
   assert(inputs.size() == 2);
@@ -184,8 +170,8 @@ MatmulOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
       mlir::cast<RankedTensorType>(getResult().getType()).getShape();
 
   auto check = detail::checkDeviceWorkerGrid(getOperation());
-  if (std::get<bool>(check) == false) {
-    return check;
+  if (!check) {
+    return check.takeError();
   }
 
   return op_model::ttnn::MatmulOpInterface::getOpConstraints(

--- a/lib/OpModel/TTNN/TTNNOpModelLib.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModelLib.cpp
@@ -138,7 +138,7 @@ void checkGrid(const ::tt::tt_metal::CoreCoord &computeGridSize,
  * grid size.
  */
 void checkGrid(const ::tt::tt_metal::CoreCoord &computeGridSize,
-               const mlir::tt::GridAttr &workerGrid) {
+               mlir::tt::GridAttr workerGrid) {
   // metal CoreCoord holds x,y
   // GridAttr holds shape {y,x}
   if ((static_cast<size_t>(workerGrid.getShape()[1]) != computeGridSize.x) ||
@@ -182,7 +182,7 @@ auto convertToTensorSpec(::tt::tt_metal::v0::IDevice *device, Args... args) {
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<bool>
-Device::getDeviceConstraints(const mlir::tt::GridAttr &workerGrid) {
+Device::getDeviceConstraints(mlir::tt::GridAttr workerGrid) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   try {
     detail::checkGrid(SingletonDeviceContext::getInstance()

--- a/lib/OpModel/TTNN/TTNNOpModelLib.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModelLib.cpp
@@ -34,19 +34,17 @@ namespace operation {
  * and callable.
  *
  * This function attempts to query operation constraints using the provided
- * callable and arguments. It returns a tuple containing a boolean indicating
- * success or failure, an optional tuple with resource usage details (if
- * successful), and an optional error message (if failed).
+ * callable and arguments. If successful, it returns a tuple with resource usage
+ * details. Otherwise, an error message.
  *
  * @param name The name of the operation to query constraints for.
  * @param callable A callable object that performs the query.
  * @param args Additional arguments to be forwarded to the callable.
- * @return A tuple containing query results.
+ * @return A tuple containing query results or a string error.
  */
 template <class Callable>
 llvm::Expected<std::tuple<size_t, size_t, size_t>>
-getOpConstraints(const std::string_view &name, Callable &callable,
-                 auto &&...args) {
+getOpConstraints(std::string_view name, Callable &callable, auto &&...args) {
   ::ttnn::graph::ConstraintQueryResponse query;
   try {
     query = callable(std::forward<decltype(args)>(args)...);
@@ -67,8 +65,8 @@ getOpConstraints(const std::string_view &name, Callable &callable,
 }
 
 template <class Callable>
-llvm::Expected<size_t> getOpRuntime(const std::string_view &name,
-                                    Callable &callable, auto &&...args) {
+llvm::Expected<size_t> getOpRuntime(std::string_view name, Callable &callable,
+                                    auto &&...args) {
   ::ttnn::graph::RuntimeQueryResponse query;
   try {
     query = callable(std::forward<decltype(args)>(args)...);

--- a/lib/OpModel/TTNN/TTNNOpModelLib.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModelLib.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "TTNNOpModel.h"
-#include "llvm/Support/Error.h"
 #include <type_traits>
 
 #ifdef TTMLIR_ENABLE_OPMODEL
@@ -19,7 +18,6 @@
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Types.h"
 #include "llvm/Support/Casting.h"
-#include "llvm/Support/Error.h"
 
 #include <cstddef>
 #include <cstdint>

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -10,7 +10,6 @@
 
 #include "llvm/ADT/SmallVector.h"
 #include "gtest/gtest.h"
-#include <llvm/Support/Error.h>
 #include <optional>
 
 namespace mlir::tt::op_model::ttnn {

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -11,504 +11,297 @@
 #include "llvm/ADT/SmallVector.h"
 #include "gtest/gtest.h"
 #include <llvm/Support/Error.h>
+#include <optional>
 
 namespace mlir::tt::op_model::ttnn {
 
 class OpModelTest : public OpModelFixture {};
 
-TEST_F(OpModelTest, ReluInterleaved) {
-  const llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayout_dram =
-      CreateTiledLayout(tensorShape, mlir::tt::ttnn::BufferType::DRAM,
-                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayout_l1 =
-      CreateTiledLayout(tensorShape, mlir::tt::ttnn::BufferType::L1,
-                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
+namespace detail {
+struct TestTensor {
+  llvm::SmallVector<int64_t> shape;
+  mlir::tt::ttnn::TensorMemoryLayout layout;
+  mlir::tt::ttnn::BufferType bufferType;
+  std::optional<llvm::SmallVector<int64_t>> virtualGrid = std::nullopt;
+};
 
-  bool legal = false;
-  std::optional<std::tuple<size_t, size_t, size_t>> l1Usage = std::nullopt;
-  std::optional<std::string> errorMsg = "";
-  size_t cb_size = 0;
-  size_t peak_size = 0;
-  size_t output_size = 0;
+struct ExpectedResult {
+  bool expectedLegal = false;
+  size_t expectedCbSize = 0;
+  size_t expectedPeakSize = 0;
+  size_t expectedOutputSize = 0;
+};
+} // namespace detail
 
-  std::tie(legal, errorMsg) = Device::getDeviceConstraints(workerGrid);
-  EXPECT_TRUE(legal);
+class OpModelUnaryEltwiseParam : public OpModelTest,
+                                 public testing::WithParamInterface<
+                                     std::tuple<detail::TestTensor, // input
+                                                detail::TestTensor, // output
+                                                detail::ExpectedResult>> {};
 
-  std::tie(legal, l1Usage, errorMsg) = ReluOpInterface::getOpConstraints(
-      tensorShape, inputLayout_dram, tensorShape, inputLayout_dram);
-  EXPECT_TRUE(legal);
-  EXPECT_TRUE(l1Usage.has_value());
-  EXPECT_FALSE(errorMsg.has_value());
-  std::tie(cb_size, peak_size, output_size) = l1Usage.value();
-  EXPECT_EQ(cb_size, 8192);
-  EXPECT_EQ(output_size, 0);
-  EXPECT_EQ(peak_size, 0);
-
-  std::tie(legal, l1Usage, errorMsg) = ReluOpInterface::getOpConstraints(
-      tensorShape, inputLayout_dram, tensorShape, inputLayout_l1);
-  EXPECT_TRUE(legal);
-  EXPECT_TRUE(l1Usage.has_value());
-  EXPECT_FALSE(errorMsg.has_value());
-  std::tie(cb_size, peak_size, output_size) = l1Usage.value();
-  EXPECT_EQ(cb_size, 8192);
-  EXPECT_EQ(output_size, 2048);
-  EXPECT_EQ(peak_size, 2048);
-
-  std::tie(legal, l1Usage, errorMsg) = ReluOpInterface::getOpConstraints(
-      tensorShape, inputLayout_l1, tensorShape, inputLayout_dram);
-  EXPECT_TRUE(legal);
-  EXPECT_TRUE(l1Usage.has_value());
-  EXPECT_FALSE(errorMsg.has_value());
-  std::tie(cb_size, peak_size, output_size) = l1Usage.value();
-  EXPECT_EQ(cb_size, 8192);
-  EXPECT_EQ(output_size, 0);
-  EXPECT_EQ(peak_size, 0);
-
-  std::tie(legal, l1Usage, errorMsg) = ReluOpInterface::getOpConstraints(
-      tensorShape, inputLayout_l1, tensorShape, inputLayout_l1);
-  EXPECT_TRUE(legal);
-  EXPECT_TRUE(l1Usage.has_value());
-  EXPECT_FALSE(errorMsg.has_value());
-  std::tie(cb_size, peak_size, output_size) = l1Usage.value();
-  EXPECT_EQ(cb_size, 8192);
-  EXPECT_EQ(output_size, 2048);
-  EXPECT_EQ(peak_size, 2048);
-
-  std::vector<std::tuple<mlir::tt::ttnn::TTNNLayoutAttr,
-                         mlir::tt::ttnn::TTNNLayoutAttr>>
-      layout_combinations = {{inputLayout_dram, inputLayout_dram},
-                             {inputLayout_l1, inputLayout_dram},
-                             {inputLayout_dram, inputLayout_l1},
-                             {inputLayout_l1, inputLayout_l1}};
-  for (const auto &[input_layout, output_layout] : layout_combinations) {
-    auto runtimeExp = ReluOpInterface::getOpRuntime(tensorShape, input_layout,
-                                                    tensorShape, output_layout);
-
-    // Manually cast to bool because EXPECT_TRUE requires a const bool operator
-    // which llvm::Expected<T> does not have
-    EXPECT_TRUE(static_cast<bool>(runtimeExp));
-    EXPECT_TRUE(runtimeExp.get() > 0);
-  }
-}
-
-TEST_F(OpModelTest, ReluSharded) {
-  const llvm::SmallVector<int64_t> tensorShape = {14 * workerCoresN300 * 32,
-                                                  32};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayout_l1_hs =
-      CreateTiledLayout(tensorShape, mlir::tt::ttnn::BufferType::L1,
-                        mlir::tt::ttnn::TensorMemoryLayout::HeightSharded);
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayout_l1_i =
-      CreateTiledLayout(tensorShape, mlir::tt::ttnn::BufferType::L1,
-                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
-
-  bool legal = false;
-  std::optional<std::tuple<size_t, size_t, size_t>> l1Usage = std::nullopt;
-  std::optional<std::string> errorMsg = "";
-  size_t cb_size = 0;
-  size_t peak_size = 0;
-  size_t output_size = 0;
-
-  std::tie(legal, errorMsg) = Device::getDeviceConstraints(workerGrid);
-  EXPECT_TRUE(legal);
-
-  std::tie(legal, l1Usage, errorMsg) = ReluOpInterface::getOpConstraints(
-      tensorShape, inputLayout_l1_hs, tensorShape, inputLayout_l1_hs);
-  EXPECT_TRUE(legal);
-  EXPECT_TRUE(l1Usage.has_value());
-  EXPECT_FALSE(errorMsg.has_value());
-  std::tie(cb_size, peak_size, output_size) = l1Usage.value();
-  EXPECT_EQ(cb_size, 0);
-  EXPECT_EQ(output_size, tensorShape[0] * tensorShape[1] * 2 / workerCoresN300);
-  EXPECT_EQ(peak_size, tensorShape[0] * tensorShape[1] * 2 / workerCoresN300);
-
-  auto runtimeExp = ReluOpInterface::getOpRuntime(
-      tensorShape, inputLayout_l1_hs, tensorShape, inputLayout_l1_hs);
-  EXPECT_TRUE(static_cast<bool>(runtimeExp));
-  EXPECT_TRUE(runtimeExp.get() > 0);
-
-  legal = std::get<0>(ReluOpInterface::getOpConstraints(
-      tensorShape, inputLayout_l1_hs, tensorShape, inputLayout_l1_i));
-  // Unary operation requires Input and Output memory layout to match.
-  EXPECT_EQ(legal, false);
-  legal = std::get<0>(ReluOpInterface::getOpConstraints(
-      tensorShape, inputLayout_l1_i, tensorShape, inputLayout_l1_hs));
-  // Unary operation requires Input and Output memory layout to match.
-  EXPECT_EQ(legal, false);
-  runtimeExp = ReluOpInterface::getOpRuntime(tensorShape, inputLayout_l1_hs,
-                                             tensorShape, inputLayout_l1_i);
-  // Unary operation requires Input and Output memory layout to match.
-  EXPECT_FALSE(static_cast<bool>(runtimeExp));
-  llvm::consumeError(runtimeExp.takeError());
-}
-
-TEST_F(OpModelTest, SoftmaxInterleaved) {
-  const llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayout_dram =
-      CreateTiledLayout(tensorShape, mlir::tt::ttnn::BufferType::DRAM,
-                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayout_l1 =
-      CreateTiledLayout(tensorShape, mlir::tt::ttnn::BufferType::L1,
-                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
-
-  bool legal = false;
-  std::optional<std::tuple<size_t, size_t, size_t>> l1Usage = std::nullopt;
-  std::optional<std::string> errorMsg = "";
-  size_t cb_size = 0;
-  size_t peak_size = 0;
-  size_t output_size = 0;
-
-  std::tie(legal, errorMsg) = Device::getDeviceConstraints(workerGrid);
-  EXPECT_TRUE(legal);
-
-  std::tie(legal, l1Usage, errorMsg) = SoftmaxOpInterface::getOpConstraints(
-      tensorShape, inputLayout_dram, -1, tensorShape, inputLayout_dram);
-  EXPECT_EQ(legal, true);
-  EXPECT_TRUE(l1Usage.has_value());
-  EXPECT_FALSE(errorMsg.has_value());
-  std::tie(cb_size, peak_size, output_size) = l1Usage.value();
-  EXPECT_EQ(cb_size, 137216);
-  EXPECT_EQ(output_size, 0);
-  EXPECT_EQ(peak_size, 0);
-
-  std::tie(legal, l1Usage, errorMsg) = SoftmaxOpInterface::getOpConstraints(
-      tensorShape, inputLayout_dram, -1, tensorShape, inputLayout_l1);
-  EXPECT_EQ(legal, true);
-  EXPECT_TRUE(l1Usage.has_value());
-  EXPECT_FALSE(errorMsg.has_value());
-  std::tie(cb_size, peak_size, output_size) = l1Usage.value();
-  EXPECT_EQ(cb_size, 137216);
-  EXPECT_EQ(output_size, 2048);
-  EXPECT_EQ(peak_size, 2048);
-
-  std::tie(legal, l1Usage, errorMsg) = SoftmaxOpInterface::getOpConstraints(
-      tensorShape, inputLayout_l1, -1, tensorShape, inputLayout_dram);
-  EXPECT_EQ(legal, true);
-  EXPECT_TRUE(l1Usage.has_value());
-  EXPECT_FALSE(errorMsg.has_value());
-  std::tie(cb_size, peak_size, output_size) = l1Usage.value();
-  EXPECT_EQ(cb_size, 137216);
-  EXPECT_EQ(output_size, 0);
-  EXPECT_EQ(peak_size, 0);
-
-  std::tie(legal, l1Usage, errorMsg) = SoftmaxOpInterface::getOpConstraints(
-      tensorShape, inputLayout_l1, -1, tensorShape, inputLayout_l1);
-  EXPECT_EQ(legal, true);
-  EXPECT_TRUE(l1Usage.has_value());
-  EXPECT_FALSE(errorMsg.has_value());
-  std::tie(cb_size, peak_size, output_size) = l1Usage.value();
-  EXPECT_EQ(cb_size, 137216);
-  EXPECT_EQ(output_size, 2048);
-  EXPECT_EQ(peak_size, 2048);
-
-  std::tie(legal, l1Usage, errorMsg) = SoftmaxOpInterface::getOpConstraints(
-      tensorShape, inputLayout_dram, -1, tensorShape, inputLayout_dram);
-  EXPECT_TRUE(legal);
-  EXPECT_TRUE(l1Usage.has_value());
-  EXPECT_FALSE(errorMsg.has_value());
-  std::tie(cb_size, peak_size, output_size) = l1Usage.value();
-  EXPECT_EQ(cb_size, 137216);
-  EXPECT_EQ(output_size, 0);
-  EXPECT_EQ(peak_size, 0);
-
-  std::vector<std::tuple<mlir::tt::ttnn::TTNNLayoutAttr,
-                         mlir::tt::ttnn::TTNNLayoutAttr>>
-      layout_combinations = {{inputLayout_dram, inputLayout_dram},
-                             {inputLayout_l1, inputLayout_dram},
-                             {inputLayout_dram, inputLayout_l1},
-                             {inputLayout_l1, inputLayout_l1}};
-  for (const auto &[input_layout, output_layout] : layout_combinations) {
-    auto runtimeExp = SoftmaxOpInterface::getOpRuntime(
-        tensorShape, input_layout, -1, tensorShape, output_layout);
-    EXPECT_TRUE(static_cast<bool>(runtimeExp));
-    EXPECT_TRUE(runtimeExp.get() > 0);
-  }
-}
-
-TEST_F(OpModelTest, SoftmaxSharded) {
-  const llvm::SmallVector<int64_t> tensorShape = {16 * workerCoresN300 * 32,
-                                                  32};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayout_l1_hs =
-      CreateTiledLayout(tensorShape, mlir::tt::ttnn::BufferType::L1,
-                        mlir::tt::ttnn::TensorMemoryLayout::HeightSharded);
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayout_l1_i =
-      CreateTiledLayout(tensorShape, mlir::tt::ttnn::BufferType::L1,
-                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
-
-  bool legal = false;
-  std::optional<std::tuple<size_t, size_t, size_t>> l1Usage = std::nullopt;
-  std::optional<std::string> errorMsg = "";
-  size_t cb_size = 0;
-  size_t peak_size = 0;
-  size_t output_size = 0;
-
-  std::tie(legal, errorMsg) = Device::getDeviceConstraints(workerGrid);
-  EXPECT_TRUE(legal);
-
-  std::tie(legal, l1Usage, errorMsg) = SoftmaxOpInterface::getOpConstraints(
-      tensorShape, inputLayout_l1_hs, -2, tensorShape, inputLayout_l1_hs);
-  EXPECT_TRUE(legal);
-  EXPECT_TRUE(l1Usage.has_value());
-  EXPECT_FALSE(errorMsg.has_value());
-  std::tie(cb_size, peak_size, output_size) = l1Usage.value();
-  EXPECT_EQ(cb_size, 24576);
-  EXPECT_EQ(output_size, 32768);
-  EXPECT_EQ(peak_size, 32768);
-
-  std::tie(legal, l1Usage, errorMsg) = SoftmaxOpInterface::getOpConstraints(
-      tensorShape, inputLayout_l1_hs, -2, tensorShape, inputLayout_l1_i);
-  EXPECT_TRUE(legal);
-  EXPECT_TRUE(l1Usage.has_value());
-  EXPECT_FALSE(errorMsg.has_value());
-  std::tie(cb_size, peak_size, output_size) = l1Usage.value();
-  EXPECT_EQ(cb_size, 24576);
-  EXPECT_EQ(output_size, 32768);
-  EXPECT_EQ(peak_size, 32768);
-
-  std::tie(legal, l1Usage, errorMsg) = SoftmaxOpInterface::getOpConstraints(
-      tensorShape, inputLayout_l1_i, -2, tensorShape, inputLayout_l1_hs);
-  EXPECT_TRUE(legal);
-  EXPECT_TRUE(l1Usage.has_value());
-  EXPECT_FALSE(errorMsg.has_value());
-  std::tie(cb_size, peak_size, output_size) = l1Usage.value();
-  EXPECT_EQ(cb_size, 24576);
-  EXPECT_EQ(output_size, 32768);
-  EXPECT_EQ(peak_size, 32768);
-
-  auto runtimeExp = SoftmaxOpInterface::getOpRuntime(
-      tensorShape, inputLayout_l1_i, -2, tensorShape, inputLayout_l1_hs);
-  EXPECT_TRUE(static_cast<bool>(runtimeExp));
-  EXPECT_TRUE(runtimeExp.get() > 0);
-}
-
-TEST_F(OpModelTest, AddInterleaved) {
-  const llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayout_dram =
-      CreateTiledLayout(tensorShape, mlir::tt::ttnn::BufferType::DRAM,
-                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayout_l1 =
-      CreateTiledLayout(tensorShape, mlir::tt::ttnn::BufferType::L1,
-                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
-
-  bool legal = false;
-  std::optional<std::tuple<size_t, size_t, size_t>> l1Usage = std::nullopt;
-  std::optional<std::string> errorMsg = "";
-  size_t cb_size = 0;
-  size_t peak_size = 0;
-  size_t output_size = 0;
-
-  std::tie(legal, errorMsg) = Device::getDeviceConstraints(workerGrid);
-  EXPECT_TRUE(legal);
-
-  std::tie(legal, l1Usage, errorMsg) = AddOpInterface::getOpConstraints(
-      tensorShape, inputLayout_dram, tensorShape, inputLayout_dram, tensorShape,
-      inputLayout_dram);
-  EXPECT_TRUE(legal);
-  EXPECT_TRUE(l1Usage.has_value());
-  EXPECT_FALSE(errorMsg.has_value());
-  std::tie(cb_size, peak_size, output_size) = l1Usage.value();
-  EXPECT_EQ(cb_size, 12288);
-  EXPECT_EQ(peak_size, 0);
-  EXPECT_EQ(output_size, 0);
-
-  std::tie(legal, l1Usage, errorMsg) = AddOpInterface::getOpConstraints(
-      tensorShape, inputLayout_dram, tensorShape, inputLayout_dram, tensorShape,
-      inputLayout_l1);
-  EXPECT_TRUE(legal);
-  EXPECT_TRUE(l1Usage.has_value());
-  EXPECT_FALSE(errorMsg.has_value());
-  std::tie(cb_size, peak_size, output_size) = l1Usage.value();
-  EXPECT_EQ(cb_size, 12288);
-  EXPECT_EQ(peak_size, 2048);
-  EXPECT_EQ(output_size, 2048);
-
-  std::tie(legal, l1Usage, errorMsg) = AddOpInterface::getOpConstraints(
-      tensorShape, inputLayout_dram, tensorShape, inputLayout_l1, tensorShape,
-      inputLayout_dram);
-  EXPECT_TRUE(legal);
-  EXPECT_TRUE(l1Usage.has_value());
-  EXPECT_FALSE(errorMsg.has_value());
-  std::tie(cb_size, peak_size, output_size) = l1Usage.value();
-  EXPECT_EQ(cb_size, 12288);
-  EXPECT_EQ(peak_size, 0);
-  EXPECT_EQ(output_size, 0);
-
-  std::tie(legal, l1Usage, errorMsg) = AddOpInterface::getOpConstraints(
-      tensorShape, inputLayout_dram, tensorShape, inputLayout_l1, tensorShape,
-      inputLayout_l1);
-  EXPECT_TRUE(legal);
-  EXPECT_TRUE(l1Usage.has_value());
-  EXPECT_FALSE(errorMsg.has_value());
-  std::tie(cb_size, peak_size, output_size) = l1Usage.value();
-  EXPECT_EQ(cb_size, 12288);
-  EXPECT_EQ(peak_size, 2048);
-  EXPECT_EQ(output_size, 2048);
-
-  std::tie(legal, l1Usage, errorMsg) = AddOpInterface::getOpConstraints(
-      tensorShape, inputLayout_l1, tensorShape, inputLayout_dram, tensorShape,
-      inputLayout_dram);
-  EXPECT_TRUE(legal);
-  EXPECT_TRUE(l1Usage.has_value());
-  EXPECT_FALSE(errorMsg.has_value());
-  std::tie(cb_size, peak_size, output_size) = l1Usage.value();
-  EXPECT_EQ(cb_size, 12288);
-  EXPECT_EQ(peak_size, 0);
-  EXPECT_EQ(output_size, 0);
-
-  std::tie(legal, l1Usage, errorMsg) = AddOpInterface::getOpConstraints(
-      tensorShape, inputLayout_l1, tensorShape, inputLayout_dram, tensorShape,
-      inputLayout_l1);
-  EXPECT_TRUE(legal);
-  EXPECT_TRUE(l1Usage.has_value());
-  EXPECT_FALSE(errorMsg.has_value());
-  std::tie(cb_size, peak_size, output_size) = l1Usage.value();
-  EXPECT_EQ(cb_size, 12288);
-  EXPECT_EQ(peak_size, 2048);
-  EXPECT_EQ(output_size, 2048);
-
-  std::tie(legal, l1Usage, errorMsg) = AddOpInterface::getOpConstraints(
-      tensorShape, inputLayout_l1, tensorShape, inputLayout_l1, tensorShape,
-      inputLayout_dram);
-  EXPECT_TRUE(legal);
-  EXPECT_TRUE(l1Usage.has_value());
-  EXPECT_FALSE(errorMsg.has_value());
-  std::tie(cb_size, peak_size, output_size) = l1Usage.value();
-  EXPECT_EQ(cb_size, 12288);
-  EXPECT_EQ(peak_size, 0);
-  EXPECT_EQ(output_size, 0);
-
-  std::tie(legal, l1Usage, errorMsg) = AddOpInterface::getOpConstraints(
-      tensorShape, inputLayout_l1, tensorShape, inputLayout_l1, tensorShape,
-      inputLayout_l1);
-  EXPECT_TRUE(legal);
-  EXPECT_TRUE(l1Usage.has_value());
-  EXPECT_FALSE(errorMsg.has_value());
-  std::tie(cb_size, peak_size, output_size) = l1Usage.value();
-  EXPECT_EQ(cb_size, 12288);
-  EXPECT_EQ(peak_size, 2048);
-  EXPECT_EQ(output_size, 2048);
-
-  std::tie(legal, l1Usage, errorMsg) = AddOpInterface::getOpConstraints(
-      tensorShape, inputLayout_dram, tensorShape, inputLayout_dram, tensorShape,
-      inputLayout_dram);
-  EXPECT_TRUE(legal);
-  EXPECT_TRUE(l1Usage.has_value());
-  EXPECT_FALSE(errorMsg.has_value());
-  std::tie(cb_size, peak_size, output_size) = l1Usage.value();
-  EXPECT_EQ(cb_size, 12288);
-  EXPECT_EQ(output_size, 0);
-  EXPECT_EQ(peak_size, 0);
-
-  auto runtimeExp = AddOpInterface::getOpRuntime(tensorShape, inputLayout_dram,
-                                                 tensorShape, inputLayout_dram,
-                                                 tensorShape, inputLayout_dram);
-  EXPECT_TRUE(static_cast<bool>(runtimeExp));
-  EXPECT_TRUE(runtimeExp.get() > 0);
-}
-
-TEST_F(OpModelTest, AddSharded) {
-  const llvm::SmallVector<int64_t> tensorShape = {16 * workerCoresN300 * 32,
-                                                  32};
-  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayout_l1_hs =
-      CreateTiledLayout(tensorShape, mlir::tt::ttnn::BufferType::L1,
-                        mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
-                        llvm::SmallVector<int64_t>{8, 1});
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayout_dram =
-      CreateTiledLayout(tensorShape, mlir::tt::ttnn::BufferType::DRAM,
-                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
-
-  bool legal = false;
-  std::optional<std::tuple<size_t, size_t, size_t>> l1Usage = std::nullopt;
-  std::optional<std::string> errorMsg = "";
-  size_t cb_size = 0;
-  size_t peak_size = 0;
-  size_t output_size = 0;
-
-  std::tie(legal, errorMsg) = Device::getDeviceConstraints(workerGrid);
-  EXPECT_TRUE(legal);
-
-  std::tie(legal, l1Usage, errorMsg) = AddOpInterface::getOpConstraints(
-      tensorShape, inputLayout_l1_hs, tensorShape, inputLayout_dram,
-      tensorShape, inputLayout_l1_hs);
-  EXPECT_TRUE(legal);
-  EXPECT_TRUE(l1Usage.has_value());
-  EXPECT_FALSE(errorMsg.has_value());
-  std::tie(cb_size, peak_size, output_size) = l1Usage.value();
-  EXPECT_EQ(cb_size, 32768);
-  EXPECT_EQ(peak_size, 262144);
-  EXPECT_EQ(output_size, 262144);
-
-  std::tie(legal, l1Usage, errorMsg) = AddOpInterface::getOpConstraints(
-      tensorShape, inputLayout_l1_hs, tensorShape, inputLayout_dram,
-      tensorShape, inputLayout_dram);
-  EXPECT_TRUE(legal);
-  EXPECT_TRUE(l1Usage.has_value());
-  EXPECT_FALSE(errorMsg.has_value());
-  std::tie(cb_size, peak_size, output_size) = l1Usage.value();
-  EXPECT_EQ(cb_size, 65536);
-  EXPECT_EQ(peak_size, 0);
-  EXPECT_EQ(output_size, 0);
-
-  std::tie(legal, l1Usage, errorMsg) = AddOpInterface::getOpConstraints(
-      tensorShape, inputLayout_dram, tensorShape, inputLayout_dram, tensorShape,
-      inputLayout_l1_hs);
-  EXPECT_TRUE(legal);
-  EXPECT_TRUE(l1Usage.has_value());
-  EXPECT_FALSE(errorMsg.has_value());
-  std::tie(cb_size, peak_size, output_size) = l1Usage.value();
-  EXPECT_EQ(cb_size, 65536);
-  EXPECT_EQ(peak_size, 262144);
-  EXPECT_EQ(output_size, 262144);
-}
-
-class OpModelMatmulParam
-    : public OpModelTest,
-      public testing::WithParamInterface<
-          std::tuple<llvm::SmallVector<int64_t>,         // input shape A
-                     mlir::tt::ttnn::TensorMemoryLayout, // input layout A
-                     mlir::tt::ttnn::BufferType,         // input buffer type A
-                     llvm::SmallVector<int64_t>,         // input virtual grid A
-                     llvm::SmallVector<int64_t>,         // input shape B
-                     mlir::tt::ttnn::TensorMemoryLayout, // input layout B
-                     mlir::tt::ttnn::BufferType,         // input buffer type B
-                     llvm::SmallVector<int64_t>,         // input virtual grid B
-                     llvm::SmallVector<int64_t>,         // output shape
-                     mlir::tt::ttnn::TensorMemoryLayout, // output layout
-                     mlir::tt::ttnn::BufferType,         // output buffer type
-                     llvm::SmallVector<int64_t>,         // output virtual grid
-                     llvm::SmallVector<int64_t>,         // physical grid
-                     bool,                               // expected valid
-                     size_t,                             // expected cb size
-                     size_t,                             // expected peak size
-                     size_t                              // expected output size
-                     >> {};
-
-TEST_P(OpModelMatmulParam, MatmulParam) {
-
+TEST_P(OpModelUnaryEltwiseParam, Relu) {
   auto params = GetParam();
-  llvm::SmallVector<int64_t> inputShapeA = std::get<0>(params);
-  mlir::tt::ttnn::TensorMemoryLayout inputTensorLayoutA = std::get<1>(params);
-  mlir::tt::ttnn::BufferType inputBufferTypeA = std::get<2>(params);
-  llvm::SmallVector<int64_t> inputVirtualGridA = std::get<3>(params);
-  llvm::SmallVector<int64_t> inputShapeB = std::get<4>(params);
-  mlir::tt::ttnn::TensorMemoryLayout inputTensorLayoutB = std::get<5>(params);
-  mlir::tt::ttnn::BufferType inputBufferTypeB = std::get<6>(params);
-  llvm::SmallVector<int64_t> inputVirtualGridB = std::get<7>(params);
-  llvm::SmallVector<int64_t> outputShape = std::get<8>(params);
-  mlir::tt::ttnn::TensorMemoryLayout outputTensorLayout = std::get<9>(params);
-  mlir::tt::ttnn::BufferType outputBufferType = std::get<10>(params);
-  llvm::SmallVector<int64_t> outputVirtualGrid = std::get<11>(params);
-  llvm::SmallVector<int64_t> physicalGrid = std::get<12>(params);
-  bool expectedLegal = std::get<13>(params);
-  size_t expectedCbSize = std::get<14>(params);
-  size_t expectedPeakSize = std::get<15>(params);
-  size_t expectedOutputSize = std::get<16>(params);
+  const auto [inputShape, inputTensorLayout, inputBufferType,
+              inputVirtualGrid] = std::get<0>(params);
+
+  const auto [outputShape, outputTensorLayout, outputBufferType,
+              outputVirtualGrid] = std::get<1>(params);
+  const auto [expectedLegal, expectedCbSize, expectedPeakSize,
+              expectedOutputSize] = std::get<2>(params);
+
+  const mlir::tt::ttnn::TTNNLayoutAttr inputLayout = CreateTiledLayout(
+      inputShape, inputBufferType, inputTensorLayout, inputVirtualGrid);
+  const mlir::tt::ttnn::TTNNLayoutAttr outputLayout = CreateTiledLayout(
+      outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
+
+  auto constraintsExp = ReluOpInterface::getOpConstraints(
+      inputShape, inputLayout, outputShape, outputLayout);
+  // Manually cast to bool because EXPECT_TRUE requires a const bool operator
+  // which llvm::Expected<T> does not have
+  EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
+  if (expectedLegal) {
+    const auto [cbSize, peakSize, outputSize] = constraintsExp.get();
+    EXPECT_EQ(cbSize, expectedCbSize);
+    EXPECT_EQ(peakSize, expectedPeakSize);
+    EXPECT_EQ(outputSize, expectedOutputSize);
+  } else {
+    // Must clean up the error
+    llvm::consumeError(constraintsExp.takeError());
+  }
+
+  auto runtimeExp = ReluOpInterface::getOpRuntime(inputShape, inputLayout,
+                                                  outputShape, outputLayout);
+  EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
+  if (expectedLegal) {
+    EXPECT_TRUE(runtimeExp.get() > 0);
+  } else {
+    llvm::consumeError(runtimeExp.takeError());
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ReluTests, OpModelUnaryEltwiseParam,
+    ::testing::Values(
+        std::make_tuple(
+            detail::TestTensor{{OpModelFixture::workerCoresN300, 1024},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::TestTensor{{OpModelFixture::workerCoresN300, 1024},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::ExpectedResult{true, 8192, 0, 0}),
+        std::make_tuple(
+            detail::TestTensor{{OpModelFixture::workerCoresN300, 1024},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::TestTensor{{OpModelFixture::workerCoresN300, 1024},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1},
+            detail::ExpectedResult{true, 8192, 2048, 2048}),
+        std::make_tuple(
+            detail::TestTensor{{OpModelFixture::workerCoresN300, 1024},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1},
+            detail::TestTensor{{OpModelFixture::workerCoresN300, 1024},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::ExpectedResult{true, 8192, 0, 0}),
+        std::make_tuple(
+            detail::TestTensor{{OpModelFixture::workerCoresN300, 1024},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1},
+            detail::TestTensor{{OpModelFixture::workerCoresN300, 1024},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1},
+            detail::ExpectedResult{true, 8192, 2048, 2048}),
+        std::make_tuple(
+            detail::TestTensor{
+                {14 * OpModelFixture::workerCoresN300 * 32, 32},
+                mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
+                mlir::tt::ttnn::BufferType::L1},
+            detail::TestTensor{
+                {14 * OpModelFixture::workerCoresN300 * 32, 32},
+                mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
+                mlir::tt::ttnn::BufferType::L1},
+            detail::ExpectedResult{true, 0, 14 * 32 * 32 * 2,
+                                   14 * 32 * 32 * 2}),
+        std::make_tuple(
+            detail::TestTensor{{14 * OpModelFixture::workerCoresN300 * 32, 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1},
+            detail::TestTensor{
+                {14 * OpModelFixture::workerCoresN300 * 32, 32},
+                mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
+                mlir::tt::ttnn::BufferType::L1},
+            detail::ExpectedResult{false}),
+        std::make_tuple(
+            detail::TestTensor{
+                {14 * OpModelFixture::workerCoresN300 * 32, 32},
+                mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
+                mlir::tt::ttnn::BufferType::L1},
+            detail::TestTensor{{14 * OpModelFixture::workerCoresN300 * 32, 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1},
+            detail::ExpectedResult{false})));
+
+// TEST_F(OpModelTest, SoftmaxInterleaved) {
+//   const llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
+//   const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
+//   const mlir::tt::ttnn::TTNNLayoutAttr inputLayout_dram =
+//       CreateTiledLayout(tensorShape, mlir::tt::ttnn::BufferType::DRAM,
+//                         mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
+//   const mlir::tt::ttnn::TTNNLayoutAttr inputLayout_l1 =
+//       CreateTiledLayout(tensorShape, mlir::tt::ttnn::BufferType::L1,
+//                         mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
+
+//   bool legal = false;
+//   std::optional<std::tuple<size_t, size_t, size_t>> l1Usage = std::nullopt;
+//   std::optional<std::string> errorMsg = "";
+//   size_t cb_size = 0;
+//   size_t peak_size = 0;
+//   size_t output_size = 0;
+
+//   std::tie(legal, errorMsg) = Device::getDeviceConstraints(workerGrid);
+//   EXPECT_TRUE(legal);
+
+//   std::tie(legal, l1Usage, errorMsg) = SoftmaxOpInterface::getOpConstraints(
+//       tensorShape, inputLayout_dram, -1, tensorShape, inputLayout_dram);
+//   EXPECT_EQ(legal, true);
+//   EXPECT_TRUE(l1Usage.has_value());
+//   EXPECT_FALSE(errorMsg.has_value());
+//   std::tie(cb_size, peak_size, output_size) = l1Usage.value();
+//   EXPECT_EQ(cb_size, 137216);
+//   EXPECT_EQ(output_size, 0);
+//   EXPECT_EQ(peak_size, 0);
+
+//   std::tie(legal, l1Usage, errorMsg) = SoftmaxOpInterface::getOpConstraints(
+//       tensorShape, inputLayout_dram, -1, tensorShape, inputLayout_l1);
+//   EXPECT_EQ(legal, true);
+//   EXPECT_TRUE(l1Usage.has_value());
+//   EXPECT_FALSE(errorMsg.has_value());
+//   std::tie(cb_size, peak_size, output_size) = l1Usage.value();
+//   EXPECT_EQ(cb_size, 137216);
+//   EXPECT_EQ(output_size, 2048);
+//   EXPECT_EQ(peak_size, 2048);
+
+//   std::tie(legal, l1Usage, errorMsg) = SoftmaxOpInterface::getOpConstraints(
+//       tensorShape, inputLayout_l1, -1, tensorShape, inputLayout_dram);
+//   EXPECT_EQ(legal, true);
+//   EXPECT_TRUE(l1Usage.has_value());
+//   EXPECT_FALSE(errorMsg.has_value());
+//   std::tie(cb_size, peak_size, output_size) = l1Usage.value();
+//   EXPECT_EQ(cb_size, 137216);
+//   EXPECT_EQ(output_size, 0);
+//   EXPECT_EQ(peak_size, 0);
+
+//   std::tie(legal, l1Usage, errorMsg) = SoftmaxOpInterface::getOpConstraints(
+//       tensorShape, inputLayout_l1, -1, tensorShape, inputLayout_l1);
+//   EXPECT_EQ(legal, true);
+//   EXPECT_TRUE(l1Usage.has_value());
+//   EXPECT_FALSE(errorMsg.has_value());
+//   std::tie(cb_size, peak_size, output_size) = l1Usage.value();
+//   EXPECT_EQ(cb_size, 137216);
+//   EXPECT_EQ(output_size, 2048);
+//   EXPECT_EQ(peak_size, 2048);
+
+//   std::tie(legal, l1Usage, errorMsg) = SoftmaxOpInterface::getOpConstraints(
+//       tensorShape, inputLayout_dram, -1, tensorShape, inputLayout_dram);
+//   EXPECT_TRUE(legal);
+//   EXPECT_TRUE(l1Usage.has_value());
+//   EXPECT_FALSE(errorMsg.has_value());
+//   std::tie(cb_size, peak_size, output_size) = l1Usage.value();
+//   EXPECT_EQ(cb_size, 137216);
+//   EXPECT_EQ(output_size, 0);
+//   EXPECT_EQ(peak_size, 0);
+
+//   std::vector<std::tuple<mlir::tt::ttnn::TTNNLayoutAttr,
+//                          mlir::tt::ttnn::TTNNLayoutAttr>>
+//       layout_combinations = {{inputLayout_dram, inputLayout_dram},
+//                              {inputLayout_l1, inputLayout_dram},
+//                              {inputLayout_dram, inputLayout_l1},
+//                              {inputLayout_l1, inputLayout_l1}};
+//   for (const auto &[input_layout, output_layout] : layout_combinations) {
+//     auto runtimeExp = SoftmaxOpInterface::getOpRuntime(
+//         tensorShape, input_layout, -1, tensorShape, output_layout);
+//     EXPECT_TRUE(static_cast<bool>(runtimeExp));
+//     EXPECT_TRUE(runtimeExp.get() > 0);
+//   }
+// }
+
+// TEST_F(OpModelTest, SoftmaxSharded) {
+//   const llvm::SmallVector<int64_t> tensorShape = {16 * workerCoresN300 * 32,
+//                                                   32};
+//   const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
+//   const mlir::tt::ttnn::TTNNLayoutAttr inputLayout_l1_hs =
+//       CreateTiledLayout(tensorShape, mlir::tt::ttnn::BufferType::L1,
+//                         mlir::tt::ttnn::TensorMemoryLayout::HeightSharded);
+//   const mlir::tt::ttnn::TTNNLayoutAttr inputLayout_l1_i =
+//       CreateTiledLayout(tensorShape, mlir::tt::ttnn::BufferType::L1,
+//                         mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
+
+//   bool legal = false;
+//   std::optional<std::tuple<size_t, size_t, size_t>> l1Usage = std::nullopt;
+//   std::optional<std::string> errorMsg = "";
+//   size_t cb_size = 0;
+//   size_t peak_size = 0;
+//   size_t output_size = 0;
+
+//   std::tie(legal, errorMsg) = Device::getDeviceConstraints(workerGrid);
+//   EXPECT_TRUE(legal);
+
+//   std::tie(legal, l1Usage, errorMsg) = SoftmaxOpInterface::getOpConstraints(
+//       tensorShape, inputLayout_l1_hs, -2, tensorShape, inputLayout_l1_hs);
+//   EXPECT_TRUE(legal);
+//   EXPECT_TRUE(l1Usage.has_value());
+//   EXPECT_FALSE(errorMsg.has_value());
+//   std::tie(cb_size, peak_size, output_size) = l1Usage.value();
+//   EXPECT_EQ(cb_size, 24576);
+//   EXPECT_EQ(output_size, 32768);
+//   EXPECT_EQ(peak_size, 32768);
+
+//   std::tie(legal, l1Usage, errorMsg) = SoftmaxOpInterface::getOpConstraints(
+//       tensorShape, inputLayout_l1_hs, -2, tensorShape, inputLayout_l1_i);
+//   EXPECT_TRUE(legal);
+//   EXPECT_TRUE(l1Usage.has_value());
+//   EXPECT_FALSE(errorMsg.has_value());
+//   std::tie(cb_size, peak_size, output_size) = l1Usage.value();
+//   EXPECT_EQ(cb_size, 24576);
+//   EXPECT_EQ(output_size, 32768);
+//   EXPECT_EQ(peak_size, 32768);
+
+//   std::tie(legal, l1Usage, errorMsg) = SoftmaxOpInterface::getOpConstraints(
+//       tensorShape, inputLayout_l1_i, -2, tensorShape, inputLayout_l1_hs);
+//   EXPECT_TRUE(legal);
+//   EXPECT_TRUE(l1Usage.has_value());
+//   EXPECT_FALSE(errorMsg.has_value());
+//   std::tie(cb_size, peak_size, output_size) = l1Usage.value();
+//   EXPECT_EQ(cb_size, 24576);
+//   EXPECT_EQ(output_size, 32768);
+//   EXPECT_EQ(peak_size, 32768);
+
+//   auto runtimeExp = SoftmaxOpInterface::getOpRuntime(
+//       tensorShape, inputLayout_l1_i, -2, tensorShape, inputLayout_l1_hs);
+//   EXPECT_TRUE(static_cast<bool>(runtimeExp));
+//   EXPECT_TRUE(runtimeExp.get() > 0);
+// }
+
+class OpModelBinaryEltwiseParam : public OpModelTest,
+                                  public testing::WithParamInterface<
+                                      std::tuple<detail::TestTensor, // inputA
+                                                 detail::TestTensor, // inputB
+                                                 detail::TestTensor, // output
+                                                 detail::ExpectedResult>> {};
+
+TEST_P(OpModelBinaryEltwiseParam, Add) {
+  auto params = GetParam();
+  const auto [inputShapeA, inputTensorLayoutA, inputBufferTypeA,
+              inputVirtualGridA] = std::get<0>(params);
+  const auto [inputShapeB, inputTensorLayoutB, inputBufferTypeB,
+              inputVirtualGridB] = std::get<1>(params);
+  const auto [outputShape, outputTensorLayout, outputBufferType,
+              outputVirtualGrid] = std::get<2>(params);
+  const auto [expectedLegal, expectedCbSize, expectedPeakSize,
+              expectedOutputSize] = std::get<3>(params);
 
   const mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA = CreateTiledLayout(
       inputShapeA, inputBufferTypeA, inputTensorLayoutA, inputVirtualGridA);
@@ -517,210 +310,454 @@ TEST_P(OpModelMatmulParam, MatmulParam) {
   const mlir::tt::ttnn::TTNNLayoutAttr outputLayout = CreateTiledLayout(
       outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
 
-  bool legal = false;
-  std::optional<std::tuple<size_t, size_t, size_t>> l1Usage = std::nullopt;
-  std::optional<std::string> errorMsg = "";
-  size_t cbSize = 0;
-  size_t peakSize = 0;
-  size_t outputSize = 0;
-
-  std::tie(legal, l1Usage, errorMsg) = MatmulOpInterface::getOpConstraints(
-      inputShapeA, inputLayoutA, inputShapeB, inputLayoutB, outputShape,
-      outputLayout, false, false);
-  EXPECT_EQ(legal, expectedLegal);
-  EXPECT_EQ(l1Usage.has_value(), expectedLegal);
-  EXPECT_EQ(errorMsg.has_value(), !expectedLegal);
-
-  if (l1Usage.has_value()) {
-    std::tie(cbSize, peakSize, outputSize) = l1Usage.value();
+  auto constraintsExp =
+      AddOpInterface::getOpConstraints(inputShapeA, inputLayoutA, inputShapeB,
+                                       inputLayoutB, outputShape, outputLayout);
+  // Manually cast to bool because EXPECT_TRUE requires a const bool operator
+  // which llvm::Expected<T> does not have
+  EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
+  if (expectedLegal) {
+    const auto [cbSize, peakSize, outputSize] = constraintsExp.get();
     EXPECT_EQ(cbSize, expectedCbSize);
     EXPECT_EQ(peakSize, expectedPeakSize);
     EXPECT_EQ(outputSize, expectedOutputSize);
+  } else {
+    // Must clean up the error
+    llvm::consumeError(constraintsExp.takeError());
+  }
+
+  auto runtimeExp =
+      AddOpInterface::getOpRuntime(inputShapeA, inputLayoutA, inputShapeB,
+                                   inputLayoutB, outputShape, outputLayout);
+  EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
+  if (expectedLegal) {
+    EXPECT_TRUE(runtimeExp.get() > 0);
+  } else {
+    llvm::consumeError(runtimeExp.takeError());
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AddTests, OpModelBinaryEltwiseParam,
+    ::testing::Values(
+        std::make_tuple(
+            detail::TestTensor{{OpModelFixture::workerCoresN300, 1024},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::TestTensor{{OpModelFixture::workerCoresN300, 1024},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::TestTensor{{OpModelFixture::workerCoresN300, 1024},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::ExpectedResult{true, 12288, 0, 0}),
+        std::make_tuple(
+            detail::TestTensor{{OpModelFixture::workerCoresN300, 1024},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::TestTensor{{OpModelFixture::workerCoresN300, 1024},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1},
+            detail::TestTensor{{OpModelFixture::workerCoresN300, 1024},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::ExpectedResult{true, 12288, 0, 0}),
+        std::make_tuple(
+            detail::TestTensor{{OpModelFixture::workerCoresN300, 1024},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1},
+            detail::TestTensor{{OpModelFixture::workerCoresN300, 1024},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::TestTensor{{OpModelFixture::workerCoresN300, 1024},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::ExpectedResult{true, 12288, 0, 0}),
+        std::make_tuple(
+            detail::TestTensor{{OpModelFixture::workerCoresN300, 1024},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1},
+            detail::TestTensor{{OpModelFixture::workerCoresN300, 1024},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1},
+            detail::TestTensor{{OpModelFixture::workerCoresN300, 1024},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::ExpectedResult{true, 12288, 0, 0}),
+        std::make_tuple(
+            detail::TestTensor{{OpModelFixture::workerCoresN300, 1024},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1},
+            detail::TestTensor{{OpModelFixture::workerCoresN300, 1024},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1},
+            detail::TestTensor{{OpModelFixture::workerCoresN300, 1024},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1},
+            detail::ExpectedResult{true, 12288, 2048, 2048}),
+        std::make_tuple(
+            detail::TestTensor{{OpModelFixture::workerCoresN300, 1024},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::TestTensor{{OpModelFixture::workerCoresN300, 1024},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1},
+            detail::TestTensor{{OpModelFixture::workerCoresN300, 1024},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1},
+            detail::ExpectedResult{true, 12288, 2048, 2048}),
+        std::make_tuple(
+            detail::TestTensor{{OpModelFixture::workerCoresN300, 1024},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1},
+            detail::TestTensor{{OpModelFixture::workerCoresN300, 1024},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::TestTensor{{OpModelFixture::workerCoresN300, 1024},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1},
+            detail::ExpectedResult{true, 12288, 2048, 2048}),
+        std::make_tuple(
+            detail::TestTensor{{OpModelFixture::workerCoresN300, 1024},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::TestTensor{{OpModelFixture::workerCoresN300, 1024},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::TestTensor{{OpModelFixture::workerCoresN300, 1024},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1},
+            detail::ExpectedResult{true, 12288, 2048, 2048}),
+        std::make_tuple(
+            detail::TestTensor{
+                {16 * OpModelFixture::workerCoresN300 * 32, 32},
+                mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
+                mlir::tt::ttnn::BufferType::L1,
+                llvm::SmallVector<int64_t>{8, 1}},
+            detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::TestTensor{
+                {16 * OpModelFixture::workerCoresN300 * 32, 32},
+                mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
+                mlir::tt::ttnn::BufferType::L1,
+                llvm::SmallVector<int64_t>{8, 1}},
+            detail::ExpectedResult{true, 32768, 262144, 262144}),
+        std::make_tuple(
+            detail::TestTensor{
+                {16 * OpModelFixture::workerCoresN300 * 32, 32},
+                mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
+                mlir::tt::ttnn::BufferType::L1,
+                llvm::SmallVector<int64_t>{8, 1}},
+            detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::ExpectedResult{true, 65536, 0, 0}),
+        std::make_tuple(
+            detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::TestTensor{
+                {16 * OpModelFixture::workerCoresN300 * 32, 32},
+                mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
+                mlir::tt::ttnn::BufferType::L1,
+                llvm::SmallVector<int64_t>{8, 1}},
+            detail::ExpectedResult{true, 65536, 262144, 262144})));
+
+class OpModelMatmulParam
+    : public OpModelTest,
+      public testing::WithParamInterface<
+          std::tuple<detail::TestTensor,         // inputA
+                     detail::TestTensor,         // inputB
+                     detail::TestTensor,         // output,
+                     llvm::SmallVector<int64_t>, // physical grid
+                     detail::ExpectedResult>> {};
+
+TEST_P(OpModelMatmulParam, MatmulParam) {
+  auto params = GetParam();
+  const auto [inputShapeA, inputTensorLayoutA, inputBufferTypeA,
+              inputVirtualGridA] = std::get<0>(params);
+  const auto [inputShapeB, inputTensorLayoutB, inputBufferTypeB,
+              inputVirtualGridB] = std::get<1>(params);
+  const auto [outputShape, outputTensorLayout, outputBufferType,
+              outputVirtualGrid] = std::get<2>(params);
+  llvm::SmallVector<int64_t> physicalGrid = std::get<3>(params);
+  const auto [expectedLegal, expectedCbSize, expectedPeakSize,
+              expectedOutputSize] = std::get<4>(params);
+
+  const mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA = CreateTiledLayout(
+      inputShapeA, inputBufferTypeA, inputTensorLayoutA, inputVirtualGridA);
+  const mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB = CreateTiledLayout(
+      inputShapeB, inputBufferTypeB, inputTensorLayoutB, inputVirtualGridB);
+  const mlir::tt::ttnn::TTNNLayoutAttr outputLayout = CreateTiledLayout(
+      outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
+
+  auto constraintsExp = MatmulOpInterface::getOpConstraints(
+      inputShapeA, inputLayoutA, inputShapeB, inputLayoutB, outputShape,
+      outputLayout, false, false);
+
+  // Manually cast to bool because EXPECT_TRUE requires a const bool operator
+  // which llvm::Expected<T> does not have
+  EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
+  if (expectedLegal) {
+    const auto [cbSize, peakSize, outputSize] = constraintsExp.get();
+    EXPECT_EQ(cbSize, expectedCbSize);
+    EXPECT_EQ(peakSize, expectedPeakSize);
+    EXPECT_EQ(outputSize, expectedOutputSize);
+  } else {
+    // Must clean up the error
+    llvm::consumeError(constraintsExp.takeError());
   }
 
   auto runtimeExp = MatmulOpInterface::getOpRuntime(
       inputShapeA, inputLayoutA, inputShapeB, inputLayoutB, outputShape,
       outputLayout, false, false);
   EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
-  if (runtimeExp) {
+  if (expectedLegal) {
     EXPECT_TRUE(runtimeExp.get() > 0);
   } else {
     llvm::consumeError(runtimeExp.takeError());
   }
-  std::cout << errorMsg.value_or("No errors") << std::endl;
 }
 
 INSTANTIATE_TEST_SUITE_P(
     MatmulInterleavedTests, OpModelMatmulParam,
     ::testing::Values(
         std::make_tuple(
-            llvm::SmallVector<int64_t>{2048, 2048},
-            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-            mlir::tt::ttnn::BufferType::DRAM, llvm::SmallVector<int64_t>{8, 8},
-            llvm::SmallVector<int64_t>{2048, 2048},
-            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-            mlir::tt::ttnn::BufferType::DRAM, llvm::SmallVector<int64_t>{8, 8},
-            llvm::SmallVector<int64_t>{2048, 2048},
-            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-            mlir::tt::ttnn::BufferType::DRAM, llvm::SmallVector<int64_t>{8, 8},
-            llvm::SmallVector<int64_t>{8, 8}, true, 655360, 0, 0),
+            detail::TestTensor{{2048, 2048},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{8, 8}},
+            detail::TestTensor{{2048, 2048},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{8, 8}},
+            detail::TestTensor{{2048, 2048},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{8, 8}},
+            llvm::SmallVector<int64_t>{8, 8},
+            detail::ExpectedResult{true, 655360, 0, 0}),
         std::make_tuple(
-            llvm::SmallVector<int64_t>{2048, 2048},
-            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-            mlir::tt::ttnn::BufferType::DRAM, llvm::SmallVector<int64_t>{8, 8},
-            llvm::SmallVector<int64_t>{2048, 2048},
-            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-            mlir::tt::ttnn::BufferType::DRAM, llvm::SmallVector<int64_t>{8, 8},
-            llvm::SmallVector<int64_t>{2048, 2048},
-            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-            mlir::tt::ttnn::BufferType::L1, llvm::SmallVector<int64_t>{8, 8},
-            llvm::SmallVector<int64_t>{8, 8}, true, 786432, 131072, 131072),
+            detail::TestTensor{{2048, 2048},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{8, 8}},
+            detail::TestTensor{{2048, 2048},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{8, 8}},
+            detail::TestTensor{{2048, 2048},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{8, 8}},
+            llvm::SmallVector<int64_t>{8, 8},
+            detail::ExpectedResult{true, 786432, 131072, 131072}),
         std::make_tuple(
-            llvm::SmallVector<int64_t>{2048, 2048},
-            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-            mlir::tt::ttnn::BufferType::DRAM, llvm::SmallVector<int64_t>{8, 8},
-            llvm::SmallVector<int64_t>{2048, 2048},
-            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-            mlir::tt::ttnn::BufferType::L1, llvm::SmallVector<int64_t>{8, 8},
-            llvm::SmallVector<int64_t>{2048, 2048},
-            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-            mlir::tt::ttnn::BufferType::DRAM, llvm::SmallVector<int64_t>{8, 8},
-            llvm::SmallVector<int64_t>{8, 8}, true, 786432, 0, 0),
+            detail::TestTensor{{2048, 2048},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{8, 8}},
+            detail::TestTensor{{2048, 2048},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{8, 8}},
+            detail::TestTensor{{2048, 2048},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{8, 8}},
+            llvm::SmallVector<int64_t>{8, 8},
+            detail::ExpectedResult{true, 786432, 0, 0}),
         std::make_tuple(
-            llvm::SmallVector<int64_t>{2048, 2048},
-            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-            mlir::tt::ttnn::BufferType::DRAM, llvm::SmallVector<int64_t>{8, 8},
-            llvm::SmallVector<int64_t>{2048, 2048},
-            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-            mlir::tt::ttnn::BufferType::L1, llvm::SmallVector<int64_t>{8, 8},
-            llvm::SmallVector<int64_t>{2048, 2048},
-            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-            mlir::tt::ttnn::BufferType::L1, llvm::SmallVector<int64_t>{8, 8},
-            llvm::SmallVector<int64_t>{8, 8}, true, 786432, 131072, 131072),
+            detail::TestTensor{{2048, 2048},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{8, 8}},
+            detail::TestTensor{{2048, 2048},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{8, 8}},
+            detail::TestTensor{{2048, 2048},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{8, 8}},
+            llvm::SmallVector<int64_t>{8, 8},
+            detail::ExpectedResult{true, 786432, 131072, 131072}),
         std::make_tuple(
-            llvm::SmallVector<int64_t>{2048, 2048},
-            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-            mlir::tt::ttnn::BufferType::L1, llvm::SmallVector<int64_t>{8, 8},
-            llvm::SmallVector<int64_t>{2048, 2048},
-            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-            mlir::tt::ttnn::BufferType::DRAM, llvm::SmallVector<int64_t>{8, 8},
-            llvm::SmallVector<int64_t>{2048, 2048},
-            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-            mlir::tt::ttnn::BufferType::DRAM, llvm::SmallVector<int64_t>{8, 8},
-            llvm::SmallVector<int64_t>{8, 8}, true, 786432, 0, 0),
+            detail::TestTensor{{2048, 2048},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{8, 8}},
+            detail::TestTensor{{2048, 2048},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{8, 8}},
+            detail::TestTensor{{2048, 2048},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{8, 8}},
+            llvm::SmallVector<int64_t>{8, 8},
+            detail::ExpectedResult{true, 786432, 0, 0}),
         std::make_tuple(
-            llvm::SmallVector<int64_t>{2048, 2048},
-            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-            mlir::tt::ttnn::BufferType::L1, llvm::SmallVector<int64_t>{8, 8},
-            llvm::SmallVector<int64_t>{2048, 2048},
-            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-            mlir::tt::ttnn::BufferType::DRAM, llvm::SmallVector<int64_t>{8, 8},
-            llvm::SmallVector<int64_t>{2048, 2048},
-            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-            mlir::tt::ttnn::BufferType::L1, llvm::SmallVector<int64_t>{8, 8},
-            llvm::SmallVector<int64_t>{8, 8}, true, 786432, 131072, 131072),
+            detail::TestTensor{{2048, 2048},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{8, 8}},
+            detail::TestTensor{{2048, 2048},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{8, 8}},
+            detail::TestTensor{{2048, 2048},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{8, 8}},
+            llvm::SmallVector<int64_t>{8, 8},
+            detail::ExpectedResult{true, 786432, 131072, 131072}),
         std::make_tuple(
-            llvm::SmallVector<int64_t>{2048, 2048},
-            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-            mlir::tt::ttnn::BufferType::L1, llvm::SmallVector<int64_t>{8, 8},
-            llvm::SmallVector<int64_t>{2048, 2048},
-            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-            mlir::tt::ttnn::BufferType::L1, llvm::SmallVector<int64_t>{8, 8},
-            llvm::SmallVector<int64_t>{2048, 2048},
-            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-            mlir::tt::ttnn::BufferType::DRAM, llvm::SmallVector<int64_t>{8, 8},
-            llvm::SmallVector<int64_t>{8, 8}, true, 786432, 0, 0),
+            detail::TestTensor{{2048, 2048},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{8, 8}},
+            detail::TestTensor{{2048, 2048},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{8, 8}},
+            detail::TestTensor{{2048, 2048},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{8, 8}},
+            llvm::SmallVector<int64_t>{8, 8},
+            detail::ExpectedResult{true, 786432, 0, 0}),
         std::make_tuple(
-            llvm::SmallVector<int64_t>{2048, 2048},
-            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-            mlir::tt::ttnn::BufferType::L1, llvm::SmallVector<int64_t>{8, 8},
-            llvm::SmallVector<int64_t>{2048, 2048},
-            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-            mlir::tt::ttnn::BufferType::L1, llvm::SmallVector<int64_t>{8, 8},
-            llvm::SmallVector<int64_t>{2048, 2048},
-            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-            mlir::tt::ttnn::BufferType::L1, llvm::SmallVector<int64_t>{8, 8},
-            llvm::SmallVector<int64_t>{8, 8}, true, 786432, 131072, 131072)));
+            detail::TestTensor{{2048, 2048},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{8, 8}},
+            detail::TestTensor{{2048, 2048},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{8, 8}},
+            detail::TestTensor{{2048, 2048},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{8, 8}},
+            llvm::SmallVector<int64_t>{8, 8},
+            detail::ExpectedResult{true, 786432, 131072, 131072})));
 
 INSTANTIATE_TEST_SUITE_P(
     MatmulShardedTests, OpModelMatmulParam,
     ::testing::Values(
         std::make_tuple(
-            llvm::SmallVector<int64_t>{56 * 32, 56 * 32},
-            mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
-            mlir::tt::ttnn::BufferType::L1, llvm::SmallVector<int64_t>{7, 8},
-            llvm::SmallVector<int64_t>{56 * 32, 56 * 32},
-            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-            mlir::tt::ttnn::BufferType::DRAM, llvm::SmallVector<int64_t>{7, 8},
-            llvm::SmallVector<int64_t>{56 * 32, 56 * 32},
-            mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
-            mlir::tt::ttnn::BufferType::L1, llvm::SmallVector<int64_t>{7, 8},
-            llvm::SmallVector<int64_t>{7, 8}, true, 430144, 114688, 114688),
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            llvm::SmallVector<int64_t>{7, 8},
+            detail::ExpectedResult{true, 430144, 114688, 114688}),
         std::make_tuple(
-            llvm::SmallVector<int64_t>{56 * 32, 56 * 32},
-            mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
-            mlir::tt::ttnn::BufferType::L1, llvm::SmallVector<int64_t>{7, 8},
-            llvm::SmallVector<int64_t>{56 * 32, 56 * 32},
-            mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
-            mlir::tt::ttnn::BufferType::L1, llvm::SmallVector<int64_t>{7, 8},
-            llvm::SmallVector<int64_t>{56 * 32, 56 * 32},
-            mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
-            mlir::tt::ttnn::BufferType::L1, llvm::SmallVector<int64_t>{7, 8},
-            llvm::SmallVector<int64_t>{7, 8}, false, -1, -1, -1),
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            llvm::SmallVector<int64_t>{7, 8}, detail::ExpectedResult{false}),
         std::make_tuple(
-            llvm::SmallVector<int64_t>{56 * 32, 56 * 32},
-            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-            mlir::tt::ttnn::BufferType::DRAM, llvm::SmallVector<int64_t>{7, 8},
-            llvm::SmallVector<int64_t>{56 * 32, 56 * 32},
-            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-            mlir::tt::ttnn::BufferType::DRAM, llvm::SmallVector<int64_t>{7, 8},
-            llvm::SmallVector<int64_t>{56 * 32, 56 * 32},
-            mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
-            mlir::tt::ttnn::BufferType::L1, llvm::SmallVector<int64_t>{7, 8},
-            llvm::SmallVector<int64_t>{7, 8}, true, 262144, 401408,
-            401408), // matmul bug shards to less cores
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            llvm::SmallVector<int64_t>{7, 8},
+            detail::ExpectedResult{true, 262144, 401408,
+                                   401408}), // matmul bug shards to less cores
         std::make_tuple(
-            llvm::SmallVector<int64_t>{56 * 32, 56 * 32},
-            mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
-            mlir::tt::ttnn::BufferType::L1, llvm::SmallVector<int64_t>{7, 8},
-            llvm::SmallVector<int64_t>{56 * 32, 56 * 32},
-            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-            mlir::tt::ttnn::BufferType::DRAM, llvm::SmallVector<int64_t>{7, 8},
-            llvm::SmallVector<int64_t>{56 * 32, 56 * 32},
-            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-            mlir::tt::ttnn::BufferType::DRAM, llvm::SmallVector<int64_t>{7, 8},
-            llvm::SmallVector<int64_t>{7, 8}, true, 544832, 0, 0),
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            llvm::SmallVector<int64_t>{7, 8},
+            detail::ExpectedResult{true, 544832, 0, 0}),
         std::make_tuple(
-            llvm::SmallVector<int64_t>{56 * 32, 56 * 32},
-            mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
-            mlir::tt::ttnn::BufferType::L1, llvm::SmallVector<int64_t>{7, 8},
-            llvm::SmallVector<int64_t>{56 * 32, 56 * 32},
-            mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
-            mlir::tt::ttnn::BufferType::L1, llvm::SmallVector<int64_t>{56, 1},
-            llvm::SmallVector<int64_t>{56 * 32, 56 * 32},
-            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-            mlir::tt::ttnn::BufferType::DRAM, llvm::SmallVector<int64_t>{7, 8},
-            llvm::SmallVector<int64_t>{7, 8}, false, -1, -1, -1),
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            detail::TestTensor{
+                llvm::SmallVector<int64_t>{56 * 32, 56 * 32},
+                mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
+                mlir::tt::ttnn::BufferType::L1,
+                llvm::SmallVector<int64_t>{56, 1}},
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            llvm::SmallVector<int64_t>{7, 8}, detail::ExpectedResult{false}),
         std::make_tuple(
-            llvm::SmallVector<int64_t>{1 * 32, 56 * 32},
-            mlir::tt::ttnn::TensorMemoryLayout::WidthSharded,
-            mlir::tt::ttnn::BufferType::L1, llvm::SmallVector<int64_t>{1, 56},
-            llvm::SmallVector<int64_t>{56 * 32, 56 * 32},
-            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-            mlir::tt::ttnn::BufferType::DRAM, llvm::SmallVector<int64_t>{7, 8},
-            llvm::SmallVector<int64_t>{1 * 32, 56 * 32},
-            mlir::tt::ttnn::TensorMemoryLayout::WidthSharded,
-            mlir::tt::ttnn::BufferType::L1, llvm::SmallVector<int64_t>{1, 56},
-            llvm::SmallVector<int64_t>{7, 8}, true, 8256, 2048, 2048),
+            detail::TestTensor{llvm::SmallVector<int64_t>{1 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::WidthSharded,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{1, 56}},
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            detail::TestTensor{llvm::SmallVector<int64_t>{1 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::WidthSharded,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{1, 56}},
+            llvm::SmallVector<int64_t>{7, 8},
+            detail::ExpectedResult{true, 8256, 2048, 2048}),
         std::make_tuple(
-            llvm::SmallVector<int64_t>{56 * 32, 1 * 32},
-            mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
-            mlir::tt::ttnn::BufferType::L1, llvm::SmallVector<int64_t>{56, 1},
-            llvm::SmallVector<int64_t>{1 * 32, 56 * 32},
-            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-            mlir::tt::ttnn::BufferType::DRAM, llvm::SmallVector<int64_t>{7, 8},
-            llvm::SmallVector<int64_t>{56 * 32, 56 * 32},
-            mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
-            mlir::tt::ttnn::BufferType::L1, llvm::SmallVector<int64_t>{56, 1},
-            llvm::SmallVector<int64_t>{7, 8}, true, 114688, 114688, 114688)));
+            detail::TestTensor{
+                {56 * 32, 1 * 32},
+                mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
+                mlir::tt::ttnn::BufferType::L1,
+                llvm::SmallVector<int64_t>{56, 1}},
+            detail::TestTensor{llvm::SmallVector<int64_t>{1 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            detail::TestTensor{
+                llvm::SmallVector<int64_t>{56 * 32, 56 * 32},
+                mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
+                mlir::tt::ttnn::BufferType::L1,
+                llvm::SmallVector<int64_t>{56, 1}},
+            llvm::SmallVector<int64_t>{7, 8},
+            detail::ExpectedResult{true, 114688, 114688, 114688})));
 } // namespace mlir::tt::op_model::ttnn

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -17,6 +17,7 @@ namespace mlir::tt::op_model::ttnn {
 class OpModelTest : public OpModelFixture {};
 
 namespace detail {
+namespace {
 struct TestTensor {
   llvm::SmallVector<int64_t> shape;
   mlir::tt::ttnn::TensorMemoryLayout layout;
@@ -30,6 +31,7 @@ struct ExpectedResult {
   size_t expectedPeakSize = 0;
   size_t expectedOutputSize = 0;
 };
+} // namespace
 
 const TestTensor interleavedN300X1024Dram = {
     {OpModelFixture::workerCoresN300, 1024},

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -1,223 +1,223 @@
-// // SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
-// //
-// // SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
 
-// #include "OpModelFixture.h"
+#include "OpModelFixture.h"
 
-// #include "ttmlir/Dialect/TTNN/IR/TTNN.h"
-// #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
-// #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNN.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 
-// #include "mlir/IR/AffineExpr.h"
-// #include "gtest/gtest.h"
+#include "mlir/IR/AffineExpr.h"
+#include "gtest/gtest.h"
 
-// #include <cstddef>
-// #include <llvm/Support/Error.h>
-// #include <optional>
+#include <cstddef>
+#include <llvm/Support/Error.h>
+#include <optional>
 
-// namespace mlir::tt::ttnn {
+namespace mlir::tt::ttnn {
 
-// class OpModelBase : public OpModelFixture {
-// public:
-//   llvm::Expected<std::tuple<size_t, size_t, size_t>>
-//   getOpConstraints(Operation *op) {
-//     if (OpModel backend = dyn_cast<OpModel>(op)) {
-//       return backend.getOpConstraints(getInputLayouts(op),
-//       getOutputLayout(op));
-//     }
-//     return llvm::createStringError("Could not cast op to OpModel");
-//   }
+class OpModelBase : public OpModelFixture {
+public:
+  llvm::Expected<std::tuple<size_t, size_t, size_t>>
+  getOpConstraints(Operation *op) {
+    if (OpModel backend = dyn_cast<OpModel>(op)) {
+      return backend.getOpConstraints(getInputLayouts(op),
+      getOutputLayout(op));
+    }
+    return llvm::createStringError("Could not cast op to OpModel");
+  }
 
-//   llvm::Expected<size_t> getOpRuntime(Operation *op) {
-//     if (OpModel backend = dyn_cast<OpModel>(op)) {
-//       return backend.getOpRuntime(getInputLayouts(op), getOutputLayout(op));
-//     }
-//     return llvm::createStringError("Could not cast op to OpModel");
-//   }
+  llvm::Expected<size_t> getOpRuntime(Operation *op) {
+    if (OpModel backend = dyn_cast<OpModel>(op)) {
+      return backend.getOpRuntime(getInputLayouts(op), getOutputLayout(op));
+    }
+    return llvm::createStringError("Could not cast op to OpModel");
+  }
 
-//   std::vector<TTNNLayoutAttr> getInputLayouts(Operation *op) {
-//     std::vector<TTNNLayoutAttr> inputs;
+  std::vector<TTNNLayoutAttr> getInputLayouts(Operation *op) {
+    std::vector<TTNNLayoutAttr> inputs;
 
-//     // TODO(odjuricic): check for DPS explicitly.
-//     auto numOperand = op->getNumOperands();
-//     // some ops have multiple operands
-//     auto limit = (numOperand > 1) ? numOperand - 1 : numOperand;
-//     for (size_t i = 0; i < limit; i++) {
-//       auto operand = op->getOperand(i);
-//       auto inputShape =
-//           mlir::cast<RankedTensorType>(operand.getType()).getShape();
-//       auto inputLayout = CreateTiledLayout(inputShape, BufferType::L1,
-//                                            TensorMemoryLayout::Interleaved);
-//       inputs.push_back(inputLayout);
-//     }
-//     return inputs;
-//   }
+    // TODO(odjuricic): check for DPS explicitly.
+    auto numOperand = op->getNumOperands();
+    // some ops have multiple operands
+    auto limit = (numOperand > 1) ? numOperand - 1 : numOperand;
+    for (size_t i = 0; i < limit; i++) {
+      auto operand = op->getOperand(i);
+      auto inputShape =
+          mlir::cast<RankedTensorType>(operand.getType()).getShape();
+      auto inputLayout = CreateTiledLayout(inputShape, BufferType::L1,
+                                           TensorMemoryLayout::Interleaved);
+      inputs.push_back(inputLayout);
+    }
+    return inputs;
+  }
 
-//   mlir::tt::ttnn::TTNNLayoutAttr getOutputLayout(Operation *op) {
-//     auto output = op->getResult(0);
-//     auto outputShape =
-//         mlir::cast<RankedTensorType>(output.getType()).getShape();
-//     return CreateTiledLayout(outputShape, BufferType::L1,
-//                              TensorMemoryLayout::Interleaved);
-//   }
+  mlir::tt::ttnn::TTNNLayoutAttr getOutputLayout(Operation *op) {
+    auto output = op->getResult(0);
+    auto outputShape =
+        mlir::cast<RankedTensorType>(output.getType()).getShape();
+    return CreateTiledLayout(outputShape, BufferType::L1,
+                             TensorMemoryLayout::Interleaved);
+  }
 
-//   mlir::tt::DeviceAttr getFakeDeviceAttr() {
-//     auto deviceIdx = mlir::getAffineConstantExpr(0, &context);
-//     auto shardOffset = mlir::getAffineConstantExpr(0, &context);
-//     auto d0 = mlir::getAffineDimExpr(0, &context); // d0
-//     auto d1 = mlir::getAffineDimExpr(1, &context); // d1
-//     auto map3 = mlir::AffineMap::get(
-//         /*dimCount=*/2, /*symbolCount=*/0, {deviceIdx, d0, d1}, &context);
-//     auto map4 = mlir::AffineMap::get(
-//         /*dimCount=*/2, /*symbolCount=*/0, {deviceIdx, d0, d1, shardOffset},
-//         &context);
-//     auto workerGrid = GridAttr::get(&context, gridShapeHwN300, map3);
+  mlir::tt::DeviceAttr getFakeDeviceAttr() {
+    auto deviceIdx = mlir::getAffineConstantExpr(0, &context);
+    auto shardOffset = mlir::getAffineConstantExpr(0, &context);
+    auto d0 = mlir::getAffineDimExpr(0, &context); // d0
+    auto d1 = mlir::getAffineDimExpr(1, &context); // d1
+    auto map3 = mlir::AffineMap::get(
+        /*dimCount=*/2, /*symbolCount=*/0, {deviceIdx, d0, d1}, &context);
+    auto map4 = mlir::AffineMap::get(
+        /*dimCount=*/2, /*symbolCount=*/0, {deviceIdx, d0, d1, shardOffset},
+        &context);
+    auto workerGrid = GridAttr::get(&context, gridShapeHwN300, map3);
 
-//     return DeviceAttr::get(&context, workerGrid, map4, map4, {1}, {0});
-//   }
+    return DeviceAttr::get(&context, workerGrid, map4, map4, {1}, {0});
+  }
 
-//   mlir::Value createEmptyTensor(llvm::ArrayRef<int64_t> tensorShape) {
-//     Type elementType = builder.getBF16Type();
-//     RankedTensorType rankedTensorType =
-//         RankedTensorType::get(tensorShape, elementType);
-//     return builder.create<OnesOp>(builder.getUnknownLoc(), rankedTensorType,
-//                                   ShapeAttr::get(&context, tensorShape),
-//                                   nullptr, nullptr, nullptr, nullptr);
-//   }
-// };
+  mlir::Value createEmptyTensor(llvm::ArrayRef<int64_t> tensorShape) {
+    Type elementType = builder.getBF16Type();
+    RankedTensorType rankedTensorType =
+        RankedTensorType::get(tensorShape, elementType);
+    return builder.create<OnesOp>(builder.getUnknownLoc(), rankedTensorType,
+                                  ShapeAttr::get(&context, tensorShape),
+                                  nullptr, nullptr, nullptr, nullptr);
+  }
+};
 
-// TEST_F(OpModelBase, ReluInterface) {
-//   // create ReluOp
-//   llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
+TEST_F(OpModelBase, ReluInterface) {
+  // create ReluOp
+  llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
 
-//   auto input = createEmptyTensor(tensorShape);
-//   auto output = createEmptyTensor(tensorShape);
+  auto input = createEmptyTensor(tensorShape);
+  auto output = createEmptyTensor(tensorShape);
 
-//   auto relu = builder.create<ReluOp>(builder.getUnknownLoc(),
-//   output.getType(),
-//                                      ::mlir::ValueRange{input, output});
-//   relu->setAttr(DeviceAttr::name, getFakeDeviceAttr());
+  auto relu = builder.create<ReluOp>(builder.getUnknownLoc(),
+  output.getType(),
+                                     ::mlir::ValueRange{input, output});
+  relu->setAttr(DeviceAttr::name, getFakeDeviceAttr());
 
-//   // test ReluOp interface
-//   auto constraintsExp = getOpConstraints(relu.getOperation());
-//   if (constraintsExp) {
-//     auto l1 = constraintsExp.get();
-//     const auto [cb_size, peak_size, output_size] = l1;
-//     EXPECT_EQ(cb_size, 8192);
-//     EXPECT_EQ(peak_size, 2048);
-//     EXPECT_EQ(output_size, 2048);
-//   } else {
-//     FAIL() << "Missing L1 constraints; Error="
-//            << llvm::toString(constraintsExp.takeError()) << std::endl;
-//   }
+  // test ReluOp interface
+  auto constraintsExp = getOpConstraints(relu.getOperation());
+  if (constraintsExp) {
+    auto l1 = constraintsExp.get();
+    const auto [cb_size, peak_size, output_size] = l1;
+    EXPECT_EQ(cb_size, 8192);
+    EXPECT_EQ(peak_size, 2048);
+    EXPECT_EQ(output_size, 2048);
+  } else {
+    FAIL() << "Missing L1 constraints; Error="
+           << llvm::toString(constraintsExp.takeError()) << std::endl;
+  }
 
-//   auto runtimeExp = getOpRuntime(relu.getOperation());
-//   if (runtimeExp) {
-//     EXPECT_TRUE(runtimeExp.get() > 0);
-//   } else {
-//     FAIL() << llvm::toString(runtimeExp.takeError());
-//   }
-// }
-// TEST_F(OpModelBase, SoftmaxInterface) {
-//   // create SoftmaxOp
-//   llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
+  auto runtimeExp = getOpRuntime(relu.getOperation());
+  if (runtimeExp) {
+    EXPECT_TRUE(runtimeExp.get() > 0);
+  } else {
+    FAIL() << llvm::toString(runtimeExp.takeError());
+  }
+}
+TEST_F(OpModelBase, SoftmaxInterface) {
+  // create SoftmaxOp
+  llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
 
-//   auto input = createEmptyTensor(tensorShape);
-//   auto output = createEmptyTensor(tensorShape);
+  auto input = createEmptyTensor(tensorShape);
+  auto output = createEmptyTensor(tensorShape);
 
-//   auto softmax = builder.create<SoftmaxOp>(builder.getUnknownLoc(),
-//                                            output.getType(), input, -1);
-//   softmax->setAttr(DeviceAttr::name, getFakeDeviceAttr());
+  auto softmax = builder.create<SoftmaxOp>(builder.getUnknownLoc(),
+                                           output.getType(), input, -1);
+  softmax->setAttr(DeviceAttr::name, getFakeDeviceAttr());
 
-//   // test SoftmaxOp interface
-//   auto constraintsExp = getOpConstraints(softmax.getOperation());
-//   if (constraintsExp) {
-//     auto l1 = constraintsExp.get();
-//     const auto [cb_size, peak_size, output_size] = l1;
-//     EXPECT_EQ(cb_size, 137216);
-//     EXPECT_EQ(peak_size, 2048);
-//     EXPECT_EQ(output_size, 2048);
-//   } else {
-//     FAIL() << "Missing L1 constraints; Error="
-//            << llvm::toString(constraintsExp.takeError()) << std::endl;
-//   }
+  // test SoftmaxOp interface
+  auto constraintsExp = getOpConstraints(softmax.getOperation());
+  if (constraintsExp) {
+    auto l1 = constraintsExp.get();
+    const auto [cb_size, peak_size, output_size] = l1;
+    EXPECT_EQ(cb_size, 137216);
+    EXPECT_EQ(peak_size, 2048);
+    EXPECT_EQ(output_size, 2048);
+  } else {
+    FAIL() << "Missing L1 constraints; Error="
+           << llvm::toString(constraintsExp.takeError()) << std::endl;
+  }
 
-//   auto runtimeExp = getOpRuntime(softmax.getOperation());
-//   if (runtimeExp) {
-//     EXPECT_TRUE(runtimeExp.get() > 0);
-//   } else {
-//     FAIL() << llvm::toString(runtimeExp.takeError());
-//   }
-// }
+  auto runtimeExp = getOpRuntime(softmax.getOperation());
+  if (runtimeExp) {
+    EXPECT_TRUE(runtimeExp.get() > 0);
+  } else {
+    FAIL() << llvm::toString(runtimeExp.takeError());
+  }
+}
 
-// TEST_F(OpModelBase, AddInterface) {
-//   // create AddOp
-//   llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
+TEST_F(OpModelBase, AddInterface) {
+  // create AddOp
+  llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
 
-//   auto input1 = createEmptyTensor(tensorShape);
-//   auto input2 = createEmptyTensor(tensorShape);
-//   auto output = createEmptyTensor(tensorShape);
+  auto input1 = createEmptyTensor(tensorShape);
+  auto input2 = createEmptyTensor(tensorShape);
+  auto output = createEmptyTensor(tensorShape);
 
-//   auto add = builder.create<AddOp>(builder.getUnknownLoc(), output.getType(),
-//                                    ::mlir::ValueRange{input1, input2,
-//                                    output});
-//   add->setAttr(DeviceAttr::name, getFakeDeviceAttr());
+  auto add = builder.create<AddOp>(builder.getUnknownLoc(), output.getType(),
+                                   ::mlir::ValueRange{input1, input2,
+                                   output});
+  add->setAttr(DeviceAttr::name, getFakeDeviceAttr());
 
-//   // test AddOp interface
-//   auto constraintsExp = getOpConstraints(add.getOperation());
-//   if (constraintsExp) {
-//     auto l1 = constraintsExp.get();
-//     const auto [cb_size, peak_size, output_size] = l1;
-//     EXPECT_EQ(cb_size, 12288);
-//     EXPECT_EQ(peak_size, 2048);
-//     EXPECT_EQ(output_size, 2048);
-//   } else {
-//     FAIL() << "Missing L1 constraints; Error="
-//            << llvm::toString(constraintsExp.takeError()) << std::endl;
-//   }
+  // test AddOp interface
+  auto constraintsExp = getOpConstraints(add.getOperation());
+  if (constraintsExp) {
+    auto l1 = constraintsExp.get();
+    const auto [cb_size, peak_size, output_size] = l1;
+    EXPECT_EQ(cb_size, 12288);
+    EXPECT_EQ(peak_size, 2048);
+    EXPECT_EQ(output_size, 2048);
+  } else {
+    FAIL() << "Missing L1 constraints; Error="
+           << llvm::toString(constraintsExp.takeError()) << std::endl;
+  }
 
-//   auto runtimeExp = getOpRuntime(add.getOperation());
-//   if (runtimeExp) {
-//     EXPECT_TRUE(runtimeExp.get() > 0);
-//   } else {
-//     FAIL() << llvm::toString(runtimeExp.takeError());
-//   }
-// }
+  auto runtimeExp = getOpRuntime(add.getOperation());
+  if (runtimeExp) {
+    EXPECT_TRUE(runtimeExp.get() > 0);
+  } else {
+    FAIL() << llvm::toString(runtimeExp.takeError());
+  }
+}
 
-// TEST_F(OpModelBase, MatmulInterface) {
-//   // create MatmulOp
-//   llvm::SmallVector<int64_t> tensorShapeA = {2048, 1024};
-//   llvm::SmallVector<int64_t> tensorShapeB = {1024, 2048};
-//   llvm::SmallVector<int64_t> tensorShapeO = {2048, 2048};
+TEST_F(OpModelBase, MatmulInterface) {
+  // create MatmulOp
+  llvm::SmallVector<int64_t> tensorShapeA = {2048, 1024};
+  llvm::SmallVector<int64_t> tensorShapeB = {1024, 2048};
+  llvm::SmallVector<int64_t> tensorShapeO = {2048, 2048};
 
-//   auto inputA = createEmptyTensor(tensorShapeA);
-//   auto inputB = createEmptyTensor(tensorShapeB);
-//   auto output = createEmptyTensor(tensorShapeO);
+  auto inputA = createEmptyTensor(tensorShapeA);
+  auto inputB = createEmptyTensor(tensorShapeB);
+  auto output = createEmptyTensor(tensorShapeO);
 
-//   auto matmul =
-//       builder.create<MatmulOp>(builder.getUnknownLoc(), output.getType(),
-//                                ::mlir::ValueRange{inputA, inputB, output});
-//   matmul->setAttr(DeviceAttr::name, getFakeDeviceAttr());
+  auto matmul =
+      builder.create<MatmulOp>(builder.getUnknownLoc(), output.getType(),
+                               ::mlir::ValueRange{inputA, inputB, output});
+  matmul->setAttr(DeviceAttr::name, getFakeDeviceAttr());
 
-//   // test MatmulOp interface
-//   auto constraintsExp = getOpConstraints(matmul.getOperation());
-//   if (constraintsExp) {
-//     auto l1 = constraintsExp.get();
-//     const auto &[cb_size, peak_size, output_size] = l1;
-//     EXPECT_EQ(cb_size, 786432);
-//     EXPECT_EQ(peak_size, 131072);
-//     EXPECT_EQ(output_size, 131072);
-//   } else {
-//     FAIL() << "Missing L1 constraints; Error="
-//            << llvm::toString(constraintsExp.takeError()) << std::endl;
-//   }
+  // test MatmulOp interface
+  auto constraintsExp = getOpConstraints(matmul.getOperation());
+  if (constraintsExp) {
+    auto l1 = constraintsExp.get();
+    const auto &[cb_size, peak_size, output_size] = l1;
+    EXPECT_EQ(cb_size, 786432);
+    EXPECT_EQ(peak_size, 131072);
+    EXPECT_EQ(output_size, 131072);
+  } else {
+    FAIL() << "Missing L1 constraints; Error="
+           << llvm::toString(constraintsExp.takeError()) << std::endl;
+  }
 
-//   auto runtimeExp = getOpRuntime(matmul.getOperation());
-//   if (runtimeExp) {
-//     EXPECT_TRUE(runtimeExp.get() > 0);
-//   } else {
-//     FAIL() << llvm::toString(runtimeExp.takeError());
-//   }
-// }
+  auto runtimeExp = getOpRuntime(matmul.getOperation());
+  if (runtimeExp) {
+    EXPECT_TRUE(runtimeExp.get() > 0);
+  } else {
+    FAIL() << llvm::toString(runtimeExp.takeError());
+  }
+}
 
-// } // namespace mlir::tt::ttnn
+} // namespace mlir::tt::ttnn

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -11,8 +11,6 @@
 #include "mlir/IR/AffineExpr.h"
 #include "gtest/gtest.h"
 
-#include <cstddef>
-#include <llvm/Support/Error.h>
 #include <optional>
 
 namespace mlir::tt::ttnn {

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -11,6 +11,8 @@
 #include "mlir/IR/AffineExpr.h"
 #include "gtest/gtest.h"
 
+#include <cstddef>
+#include <llvm/Support/Error.h>
 #include <optional>
 
 namespace mlir::tt::ttnn {
@@ -27,13 +29,11 @@ public:
     return std::nullopt;
   }
 
-  std::optional<
-      std::tuple<bool, std::optional<size_t>, std::optional<std::string>>>
-  getOpRuntime(Operation *op) {
+  llvm::Expected<size_t> getOpRuntime(Operation *op) {
     if (OpModel backend = dyn_cast<OpModel>(op)) {
       return backend.getOpRuntime(getInputLayouts(op), getOutputLayout(op));
     }
-    return std::nullopt;
+    return llvm::createStringError("Could not cast op to OpModel");
   }
 
   std::vector<TTNNLayoutAttr> getInputLayouts(Operation *op) {
@@ -117,15 +117,11 @@ TEST_F(OpModelBase, ReluInterface) {
     FAIL() << "Failed to cast ReluOp to OpModel";
   }
 
-  auto runtimeOpt = getOpRuntime(relu.getOperation());
-  if (runtimeOpt.has_value()) {
-    auto runtime = runtimeOpt.value();
-    EXPECT_TRUE(std::get<0>(runtime));
-    EXPECT_TRUE(std::get<1>(runtime).has_value());
-    EXPECT_TRUE(std::get<1>(runtime).value() > 0);
-    EXPECT_FALSE(std::get<2>(runtime).has_value());
+  auto runtimeExp = getOpRuntime(relu.getOperation());
+  if (runtimeExp) {
+    EXPECT_TRUE(runtimeExp.get() > 0);
   } else {
-    FAIL() << "Failed to cast ReluOp to OpModel";
+    FAIL() << llvm::toString(runtimeExp.takeError());
   }
 }
 TEST_F(OpModelBase, SoftmaxInterface) {
@@ -157,15 +153,11 @@ TEST_F(OpModelBase, SoftmaxInterface) {
     FAIL() << "Failed to cast SoftmaxOp to OpModel";
   }
 
-  auto runtimeOpt = getOpRuntime(softmax.getOperation());
-  if (runtimeOpt.has_value()) {
-    auto runtime = runtimeOpt.value();
-    EXPECT_TRUE(std::get<0>(runtime));
-    EXPECT_TRUE(std::get<1>(runtime).has_value());
-    EXPECT_TRUE(std::get<1>(runtime).value() > 0);
-    EXPECT_FALSE(std::get<2>(runtime).has_value());
+  auto runtimeExp = getOpRuntime(softmax.getOperation());
+  if (runtimeExp) {
+    EXPECT_TRUE(runtimeExp.get() > 0);
   } else {
-    FAIL() << "Failed to cast SoftmaxOp to OpModel";
+    FAIL() << llvm::toString(runtimeExp.takeError());
   }
 }
 
@@ -199,15 +191,11 @@ TEST_F(OpModelBase, AddInterface) {
     FAIL() << "Failed to cast AddOp to OpModel";
   }
 
-  auto runtimeOpt = getOpRuntime(add.getOperation());
-  if (runtimeOpt.has_value()) {
-    auto runtime = runtimeOpt.value();
-    EXPECT_TRUE(std::get<0>(runtime));
-    EXPECT_TRUE(std::get<1>(runtime).has_value());
-    EXPECT_TRUE(std::get<1>(runtime).value() > 0);
-    EXPECT_FALSE(std::get<2>(runtime).has_value());
+  auto runtimeExp = getOpRuntime(add.getOperation());
+  if (runtimeExp) {
+    EXPECT_TRUE(runtimeExp.get() > 0);
   } else {
-    FAIL() << "Failed to cast AddOp to OpModel";
+    FAIL() << llvm::toString(runtimeExp.takeError());
   }
 }
 
@@ -244,15 +232,11 @@ TEST_F(OpModelBase, MatmulInterface) {
     FAIL() << "Failed to cast MatmulOp to OpModel";
   }
 
-  auto runtimeOpt = getOpRuntime(matmul.getOperation());
-  if (runtimeOpt.has_value()) {
-    auto runtime = runtimeOpt.value();
-    EXPECT_TRUE(std::get<0>(runtime));
-    EXPECT_TRUE(std::get<1>(runtime).has_value());
-    EXPECT_TRUE(std::get<1>(runtime).value() > 0);
-    EXPECT_FALSE(std::get<2>(runtime).has_value());
+  auto runtimeExp = getOpRuntime(matmul.getOperation());
+  if (runtimeExp) {
+    EXPECT_TRUE(runtimeExp.get() > 0);
   } else {
-    FAIL() << "Failed to cast MatmulOp to OpModel";
+    FAIL() << llvm::toString(runtimeExp.takeError());
   }
 }
 

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -1,243 +1,223 @@
-// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
-//
-// SPDX-License-Identifier: Apache-2.0
+// // SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+// //
+// // SPDX-License-Identifier: Apache-2.0
 
-#include "OpModelFixture.h"
+// #include "OpModelFixture.h"
 
-#include "ttmlir/Dialect/TTNN/IR/TTNN.h"
-#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
-#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+// #include "ttmlir/Dialect/TTNN/IR/TTNN.h"
+// #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+// #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 
-#include "mlir/IR/AffineExpr.h"
-#include "gtest/gtest.h"
+// #include "mlir/IR/AffineExpr.h"
+// #include "gtest/gtest.h"
 
-#include <cstddef>
-#include <llvm/Support/Error.h>
-#include <optional>
+// #include <cstddef>
+// #include <llvm/Support/Error.h>
+// #include <optional>
 
-namespace mlir::tt::ttnn {
+// namespace mlir::tt::ttnn {
 
-class OpModelBase : public OpModelFixture {
-public:
-  std::optional<
-      std::tuple<bool, std::optional<std::tuple<size_t, size_t, size_t>>,
-                 std::optional<std::string>>>
-  getOpConstraints(Operation *op) {
-    if (OpModel backend = dyn_cast<OpModel>(op)) {
-      return backend.getOpConstraints(getInputLayouts(op), getOutputLayout(op));
-    }
-    return std::nullopt;
-  }
+// class OpModelBase : public OpModelFixture {
+// public:
+//   llvm::Expected<std::tuple<size_t, size_t, size_t>>
+//   getOpConstraints(Operation *op) {
+//     if (OpModel backend = dyn_cast<OpModel>(op)) {
+//       return backend.getOpConstraints(getInputLayouts(op),
+//       getOutputLayout(op));
+//     }
+//     return llvm::createStringError("Could not cast op to OpModel");
+//   }
 
-  llvm::Expected<size_t> getOpRuntime(Operation *op) {
-    if (OpModel backend = dyn_cast<OpModel>(op)) {
-      return backend.getOpRuntime(getInputLayouts(op), getOutputLayout(op));
-    }
-    return llvm::createStringError("Could not cast op to OpModel");
-  }
+//   llvm::Expected<size_t> getOpRuntime(Operation *op) {
+//     if (OpModel backend = dyn_cast<OpModel>(op)) {
+//       return backend.getOpRuntime(getInputLayouts(op), getOutputLayout(op));
+//     }
+//     return llvm::createStringError("Could not cast op to OpModel");
+//   }
 
-  std::vector<TTNNLayoutAttr> getInputLayouts(Operation *op) {
-    std::vector<TTNNLayoutAttr> inputs;
+//   std::vector<TTNNLayoutAttr> getInputLayouts(Operation *op) {
+//     std::vector<TTNNLayoutAttr> inputs;
 
-    // TODO(odjuricic): check for DPS explicitly.
-    auto numOperand = op->getNumOperands();
-    // some ops have multiple operands
-    auto limit = (numOperand > 1) ? numOperand - 1 : numOperand;
-    for (size_t i = 0; i < limit; i++) {
-      auto operand = op->getOperand(i);
-      auto inputShape =
-          mlir::cast<RankedTensorType>(operand.getType()).getShape();
-      auto inputLayout = CreateTiledLayout(inputShape, BufferType::L1,
-                                           TensorMemoryLayout::Interleaved);
-      inputs.push_back(inputLayout);
-    }
-    return inputs;
-  }
+//     // TODO(odjuricic): check for DPS explicitly.
+//     auto numOperand = op->getNumOperands();
+//     // some ops have multiple operands
+//     auto limit = (numOperand > 1) ? numOperand - 1 : numOperand;
+//     for (size_t i = 0; i < limit; i++) {
+//       auto operand = op->getOperand(i);
+//       auto inputShape =
+//           mlir::cast<RankedTensorType>(operand.getType()).getShape();
+//       auto inputLayout = CreateTiledLayout(inputShape, BufferType::L1,
+//                                            TensorMemoryLayout::Interleaved);
+//       inputs.push_back(inputLayout);
+//     }
+//     return inputs;
+//   }
 
-  mlir::tt::ttnn::TTNNLayoutAttr getOutputLayout(Operation *op) {
-    auto output = op->getResult(0);
-    auto outputShape =
-        mlir::cast<RankedTensorType>(output.getType()).getShape();
-    return CreateTiledLayout(outputShape, BufferType::L1,
-                             TensorMemoryLayout::Interleaved);
-  }
+//   mlir::tt::ttnn::TTNNLayoutAttr getOutputLayout(Operation *op) {
+//     auto output = op->getResult(0);
+//     auto outputShape =
+//         mlir::cast<RankedTensorType>(output.getType()).getShape();
+//     return CreateTiledLayout(outputShape, BufferType::L1,
+//                              TensorMemoryLayout::Interleaved);
+//   }
 
-  mlir::tt::DeviceAttr getFakeDeviceAttr() {
-    auto deviceIdx = mlir::getAffineConstantExpr(0, &context);
-    auto shardOffset = mlir::getAffineConstantExpr(0, &context);
-    auto d0 = mlir::getAffineDimExpr(0, &context); // d0
-    auto d1 = mlir::getAffineDimExpr(1, &context); // d1
-    auto map3 = mlir::AffineMap::get(
-        /*dimCount=*/2, /*symbolCount=*/0, {deviceIdx, d0, d1}, &context);
-    auto map4 = mlir::AffineMap::get(
-        /*dimCount=*/2, /*symbolCount=*/0, {deviceIdx, d0, d1, shardOffset},
-        &context);
-    auto workerGrid = GridAttr::get(&context, gridShapeHwN300, map3);
+//   mlir::tt::DeviceAttr getFakeDeviceAttr() {
+//     auto deviceIdx = mlir::getAffineConstantExpr(0, &context);
+//     auto shardOffset = mlir::getAffineConstantExpr(0, &context);
+//     auto d0 = mlir::getAffineDimExpr(0, &context); // d0
+//     auto d1 = mlir::getAffineDimExpr(1, &context); // d1
+//     auto map3 = mlir::AffineMap::get(
+//         /*dimCount=*/2, /*symbolCount=*/0, {deviceIdx, d0, d1}, &context);
+//     auto map4 = mlir::AffineMap::get(
+//         /*dimCount=*/2, /*symbolCount=*/0, {deviceIdx, d0, d1, shardOffset},
+//         &context);
+//     auto workerGrid = GridAttr::get(&context, gridShapeHwN300, map3);
 
-    return DeviceAttr::get(&context, workerGrid, map4, map4, {1}, {0});
-  }
+//     return DeviceAttr::get(&context, workerGrid, map4, map4, {1}, {0});
+//   }
 
-  mlir::Value createEmptyTensor(llvm::ArrayRef<int64_t> tensorShape) {
-    Type elementType = builder.getBF16Type();
-    RankedTensorType rankedTensorType =
-        RankedTensorType::get(tensorShape, elementType);
-    return builder.create<OnesOp>(builder.getUnknownLoc(), rankedTensorType,
-                                  ShapeAttr::get(&context, tensorShape),
-                                  nullptr, nullptr, nullptr, nullptr);
-  }
-};
+//   mlir::Value createEmptyTensor(llvm::ArrayRef<int64_t> tensorShape) {
+//     Type elementType = builder.getBF16Type();
+//     RankedTensorType rankedTensorType =
+//         RankedTensorType::get(tensorShape, elementType);
+//     return builder.create<OnesOp>(builder.getUnknownLoc(), rankedTensorType,
+//                                   ShapeAttr::get(&context, tensorShape),
+//                                   nullptr, nullptr, nullptr, nullptr);
+//   }
+// };
 
-TEST_F(OpModelBase, ReluInterface) {
-  // create ReluOp
-  llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
+// TEST_F(OpModelBase, ReluInterface) {
+//   // create ReluOp
+//   llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
 
-  auto input = createEmptyTensor(tensorShape);
-  auto output = createEmptyTensor(tensorShape);
+//   auto input = createEmptyTensor(tensorShape);
+//   auto output = createEmptyTensor(tensorShape);
 
-  auto relu = builder.create<ReluOp>(builder.getUnknownLoc(), output.getType(),
-                                     ::mlir::ValueRange{input, output});
-  relu->setAttr(DeviceAttr::name, getFakeDeviceAttr());
+//   auto relu = builder.create<ReluOp>(builder.getUnknownLoc(),
+//   output.getType(),
+//                                      ::mlir::ValueRange{input, output});
+//   relu->setAttr(DeviceAttr::name, getFakeDeviceAttr());
 
-  // test ReluOp interface
-  auto constraintsOpt = getOpConstraints(relu.getOperation());
-  if (constraintsOpt.has_value()) {
-    auto constraints = constraintsOpt.value();
-    EXPECT_EQ(std::get<bool>(constraints), true);
-    auto l1 = std::get<1>(constraints);
-    if (l1.has_value()) {
-      const auto &[cb_size, peak_size, output_size] = l1.value();
-      EXPECT_EQ(cb_size, 8192);
-      EXPECT_EQ(peak_size, 2048);
-      EXPECT_EQ(output_size, 2048);
-    } else {
-      FAIL() << "Missing L1 constraints; Error="
-             << std::get<2>(constraints).value() << std::endl;
-    }
-  } else {
-    FAIL() << "Failed to cast ReluOp to OpModel";
-  }
+//   // test ReluOp interface
+//   auto constraintsExp = getOpConstraints(relu.getOperation());
+//   if (constraintsExp) {
+//     auto l1 = constraintsExp.get();
+//     const auto [cb_size, peak_size, output_size] = l1;
+//     EXPECT_EQ(cb_size, 8192);
+//     EXPECT_EQ(peak_size, 2048);
+//     EXPECT_EQ(output_size, 2048);
+//   } else {
+//     FAIL() << "Missing L1 constraints; Error="
+//            << llvm::toString(constraintsExp.takeError()) << std::endl;
+//   }
 
-  auto runtimeExp = getOpRuntime(relu.getOperation());
-  if (runtimeExp) {
-    EXPECT_TRUE(runtimeExp.get() > 0);
-  } else {
-    FAIL() << llvm::toString(runtimeExp.takeError());
-  }
-}
-TEST_F(OpModelBase, SoftmaxInterface) {
-  // create SoftmaxOp
-  llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
+//   auto runtimeExp = getOpRuntime(relu.getOperation());
+//   if (runtimeExp) {
+//     EXPECT_TRUE(runtimeExp.get() > 0);
+//   } else {
+//     FAIL() << llvm::toString(runtimeExp.takeError());
+//   }
+// }
+// TEST_F(OpModelBase, SoftmaxInterface) {
+//   // create SoftmaxOp
+//   llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
 
-  auto input = createEmptyTensor(tensorShape);
-  auto output = createEmptyTensor(tensorShape);
+//   auto input = createEmptyTensor(tensorShape);
+//   auto output = createEmptyTensor(tensorShape);
 
-  auto softmax = builder.create<SoftmaxOp>(builder.getUnknownLoc(),
-                                           output.getType(), input, -1);
-  softmax->setAttr(DeviceAttr::name, getFakeDeviceAttr());
+//   auto softmax = builder.create<SoftmaxOp>(builder.getUnknownLoc(),
+//                                            output.getType(), input, -1);
+//   softmax->setAttr(DeviceAttr::name, getFakeDeviceAttr());
 
-  // test SoftmaxOp interface
-  auto constraintsOpt = getOpConstraints(softmax.getOperation());
-  if (constraintsOpt.has_value()) {
-    auto constraints = constraintsOpt.value();
-    EXPECT_EQ(std::get<bool>(constraints), true);
-    auto l1 = std::get<1>(constraints);
-    if (l1.has_value()) {
-      const auto &[cb_size, peak_size, output_size] = l1.value();
-      EXPECT_EQ(cb_size, 137216);
-      EXPECT_EQ(peak_size, 2048);
-      EXPECT_EQ(output_size, 2048);
-    } else {
-      FAIL() << "Missing L1 constraints";
-    }
-  } else {
-    FAIL() << "Failed to cast SoftmaxOp to OpModel";
-  }
+//   // test SoftmaxOp interface
+//   auto constraintsExp = getOpConstraints(softmax.getOperation());
+//   if (constraintsExp) {
+//     auto l1 = constraintsExp.get();
+//     const auto [cb_size, peak_size, output_size] = l1;
+//     EXPECT_EQ(cb_size, 137216);
+//     EXPECT_EQ(peak_size, 2048);
+//     EXPECT_EQ(output_size, 2048);
+//   } else {
+//     FAIL() << "Missing L1 constraints; Error="
+//            << llvm::toString(constraintsExp.takeError()) << std::endl;
+//   }
 
-  auto runtimeExp = getOpRuntime(softmax.getOperation());
-  if (runtimeExp) {
-    EXPECT_TRUE(runtimeExp.get() > 0);
-  } else {
-    FAIL() << llvm::toString(runtimeExp.takeError());
-  }
-}
+//   auto runtimeExp = getOpRuntime(softmax.getOperation());
+//   if (runtimeExp) {
+//     EXPECT_TRUE(runtimeExp.get() > 0);
+//   } else {
+//     FAIL() << llvm::toString(runtimeExp.takeError());
+//   }
+// }
 
-TEST_F(OpModelBase, AddInterface) {
-  // create AddOp
-  llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
+// TEST_F(OpModelBase, AddInterface) {
+//   // create AddOp
+//   llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
 
-  auto input1 = createEmptyTensor(tensorShape);
-  auto input2 = createEmptyTensor(tensorShape);
-  auto output = createEmptyTensor(tensorShape);
+//   auto input1 = createEmptyTensor(tensorShape);
+//   auto input2 = createEmptyTensor(tensorShape);
+//   auto output = createEmptyTensor(tensorShape);
 
-  auto add = builder.create<AddOp>(builder.getUnknownLoc(), output.getType(),
-                                   ::mlir::ValueRange{input1, input2, output});
-  add->setAttr(DeviceAttr::name, getFakeDeviceAttr());
+//   auto add = builder.create<AddOp>(builder.getUnknownLoc(), output.getType(),
+//                                    ::mlir::ValueRange{input1, input2,
+//                                    output});
+//   add->setAttr(DeviceAttr::name, getFakeDeviceAttr());
 
-  // test AddOp interface
-  auto constraintsOpt = getOpConstraints(add.getOperation());
-  if (constraintsOpt.has_value()) {
-    auto constraints = constraintsOpt.value();
-    EXPECT_EQ(std::get<bool>(constraints), true);
-    auto l1 = std::get<1>(constraints);
-    if (l1.has_value()) {
-      const auto &[cb_size, peak_size, output_size] = l1.value();
-      EXPECT_EQ(cb_size, 12288);
-      EXPECT_EQ(peak_size, 2048);
-      EXPECT_EQ(output_size, 2048);
-    } else {
-      FAIL() << "Missing L1 constraints";
-    }
-  } else {
-    FAIL() << "Failed to cast AddOp to OpModel";
-  }
+//   // test AddOp interface
+//   auto constraintsExp = getOpConstraints(add.getOperation());
+//   if (constraintsExp) {
+//     auto l1 = constraintsExp.get();
+//     const auto [cb_size, peak_size, output_size] = l1;
+//     EXPECT_EQ(cb_size, 12288);
+//     EXPECT_EQ(peak_size, 2048);
+//     EXPECT_EQ(output_size, 2048);
+//   } else {
+//     FAIL() << "Missing L1 constraints; Error="
+//            << llvm::toString(constraintsExp.takeError()) << std::endl;
+//   }
 
-  auto runtimeExp = getOpRuntime(add.getOperation());
-  if (runtimeExp) {
-    EXPECT_TRUE(runtimeExp.get() > 0);
-  } else {
-    FAIL() << llvm::toString(runtimeExp.takeError());
-  }
-}
+//   auto runtimeExp = getOpRuntime(add.getOperation());
+//   if (runtimeExp) {
+//     EXPECT_TRUE(runtimeExp.get() > 0);
+//   } else {
+//     FAIL() << llvm::toString(runtimeExp.takeError());
+//   }
+// }
 
-TEST_F(OpModelBase, MatmulInterface) {
-  // create MatmulOp
-  llvm::SmallVector<int64_t> tensorShapeA = {2048, 1024};
-  llvm::SmallVector<int64_t> tensorShapeB = {1024, 2048};
-  llvm::SmallVector<int64_t> tensorShapeO = {2048, 2048};
+// TEST_F(OpModelBase, MatmulInterface) {
+//   // create MatmulOp
+//   llvm::SmallVector<int64_t> tensorShapeA = {2048, 1024};
+//   llvm::SmallVector<int64_t> tensorShapeB = {1024, 2048};
+//   llvm::SmallVector<int64_t> tensorShapeO = {2048, 2048};
 
-  auto inputA = createEmptyTensor(tensorShapeA);
-  auto inputB = createEmptyTensor(tensorShapeB);
-  auto output = createEmptyTensor(tensorShapeO);
+//   auto inputA = createEmptyTensor(tensorShapeA);
+//   auto inputB = createEmptyTensor(tensorShapeB);
+//   auto output = createEmptyTensor(tensorShapeO);
 
-  auto matmul =
-      builder.create<MatmulOp>(builder.getUnknownLoc(), output.getType(),
-                               ::mlir::ValueRange{inputA, inputB, output});
-  matmul->setAttr(DeviceAttr::name, getFakeDeviceAttr());
+//   auto matmul =
+//       builder.create<MatmulOp>(builder.getUnknownLoc(), output.getType(),
+//                                ::mlir::ValueRange{inputA, inputB, output});
+//   matmul->setAttr(DeviceAttr::name, getFakeDeviceAttr());
 
-  // test MatmulOp interface
-  auto constraintsOpt = getOpConstraints(matmul.getOperation());
-  if (constraintsOpt.has_value()) {
-    auto constraints = constraintsOpt.value();
-    EXPECT_EQ(std::get<bool>(constraints), true);
-    auto l1 = std::get<1>(constraints);
-    if (l1.has_value()) {
-      const auto &[cb_size, peak_size, output_size] = l1.value();
-      EXPECT_EQ(cb_size, 786432);
-      EXPECT_EQ(peak_size, 131072);
-      EXPECT_EQ(output_size, 131072);
-    } else {
-      FAIL() << "Missing L1 constraints";
-    }
-  } else {
-    FAIL() << "Failed to cast MatmulOp to OpModel";
-  }
+//   // test MatmulOp interface
+//   auto constraintsExp = getOpConstraints(matmul.getOperation());
+//   if (constraintsExp) {
+//     auto l1 = constraintsExp.get();
+//     const auto &[cb_size, peak_size, output_size] = l1;
+//     EXPECT_EQ(cb_size, 786432);
+//     EXPECT_EQ(peak_size, 131072);
+//     EXPECT_EQ(output_size, 131072);
+//   } else {
+//     FAIL() << "Missing L1 constraints; Error="
+//            << llvm::toString(constraintsExp.takeError()) << std::endl;
+//   }
 
-  auto runtimeExp = getOpRuntime(matmul.getOperation());
-  if (runtimeExp) {
-    EXPECT_TRUE(runtimeExp.get() > 0);
-  } else {
-    FAIL() << llvm::toString(runtimeExp.takeError());
-  }
-}
+//   auto runtimeExp = getOpRuntime(matmul.getOperation());
+//   if (runtimeExp) {
+//     EXPECT_TRUE(runtimeExp.get() > 0);
+//   } else {
+//     FAIL() << llvm::toString(runtimeExp.takeError());
+//   }
+// }
 
-} // namespace mlir::tt::ttnn
+// } // namespace mlir::tt::ttnn

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -22,8 +22,7 @@ public:
   llvm::Expected<std::tuple<size_t, size_t, size_t>>
   getOpConstraints(Operation *op) {
     if (OpModel backend = dyn_cast<OpModel>(op)) {
-      return backend.getOpConstraints(getInputLayouts(op),
-      getOutputLayout(op));
+      return backend.getOpConstraints(getInputLayouts(op), getOutputLayout(op));
     }
     return llvm::createStringError("Could not cast op to OpModel");
   }
@@ -93,8 +92,7 @@ TEST_F(OpModelBase, ReluInterface) {
   auto input = createEmptyTensor(tensorShape);
   auto output = createEmptyTensor(tensorShape);
 
-  auto relu = builder.create<ReluOp>(builder.getUnknownLoc(),
-  output.getType(),
+  auto relu = builder.create<ReluOp>(builder.getUnknownLoc(), output.getType(),
                                      ::mlir::ValueRange{input, output});
   relu->setAttr(DeviceAttr::name, getFakeDeviceAttr());
 
@@ -159,8 +157,7 @@ TEST_F(OpModelBase, AddInterface) {
   auto output = createEmptyTensor(tensorShape);
 
   auto add = builder.create<AddOp>(builder.getUnknownLoc(), output.getType(),
-                                   ::mlir::ValueRange{input1, input2,
-                                   output});
+                                   ::mlir::ValueRange{input1, input2, output});
   add->setAttr(DeviceAttr::name, getFakeDeviceAttr());
 
   // test AddOp interface


### PR DESCRIPTION
### Ticket
#2046 

### Problem description
- `getOpConstraints` and `getOpRuntime` APIs return a convoluted tuple of optionals that is confusing and verbose to use
- Unit tests for `getOpConstraints` and `getOpRuntime` have a lot of code duplication and do not allow easy testing of new ops. This is a problem as new ops

### What's changed
- Resolves #2046 
- Changed both `getOpConstraints` and `getOpRuntime` to return an `llvm::Expected` object
  - Updated tests, usage and documentation
- Heavily refactored unit tests for `getOpRuntime` and `getOpConstraints`
  - Mostly separated test data from test code
  - Changed ReLu and Add tests into parametrized tests. When adding the next unary or binary op(s), it is trivial to parametrize these on the op in addition to the data as the test code 100% will be identical 

### Checklist
- [X] New/Existing tests provide coverage for changes
