### PR TITLE
Remove dep. on runtime workaround in `binary.cpp`

### DIFF
--- a/runtime/include/tt/runtime/detail/workarounds.h
+++ b/runtime/include/tt/runtime/detail/workarounds.h
@@ -17,14 +17,13 @@ struct Env {
 #endif
   get(bool maxpool2dPreshard = true, bool swapBinaryOperands = true,
       bool readUpdateIndexFromDeviceForKVCache = true,
-      bool defaultStrideComputation = true,
       bool toLayoutAPIAssumeSingleChip = true,
       bool usePaddingPairSignatureWithQueueId = true)
 #if defined(TT_RUNTIME_WORKAROUNDS) && TT_RUNTIME_WORKAROUNDS == 1
       ;
 #else
   {
-    return Env(true, true, true, true, true, true);
+    return Env(true, true, true, true, true);
   }
 #endif
   // TODO(bug #855): Ideally we should have an op that preshards for maxpool2d
@@ -41,13 +40,6 @@ struct Env {
   // as a tensor with integer elements. For now, to get this op to work we need
   // to be able to pluck this update index from a runtime tensor.
   bool readUpdateIndexFromDeviceForKVCache;
-
-  // TODO(bug #2045): Our current stride calculation is incorrect for tilized
-  // tensors. The current solution is to remove stride entirely from the
-  // flatbuffer and calculate the stride in runtime assuming using the default
-  // method ignoring details like grid, layout etc. Once we have a more
-  // sophisticated way for handling this, we can remove this workaround.
-  bool defaultStrideComputation;
 
   // TODO(bug #1778): We currently don't have device grid information (mesh
   // shape, offset) in the flatbuffer TensorDesc nor in the mlir LayoutAttr. We
@@ -70,13 +62,12 @@ struct Env {
 private:
   constexpr Env(bool maxpool2dPreshard, bool swapBinaryOperands,
                 bool readUpdateIndexFromDeviceForKVCache,
-                bool defaultStrideComputation, bool toLayoutAPIAssumeSingleChip,
+                bool toLayoutAPIAssumeSingleChip,
                 bool usePaddingPairSignatureWithQueueId)
       : maxpool2dPreshard(maxpool2dPreshard),
         swapBinaryOperands(swapBinaryOperands),
         readUpdateIndexFromDeviceForKVCache(
             readUpdateIndexFromDeviceForKVCache),
-        defaultStrideComputation(defaultStrideComputation),
         toLayoutAPIAssumeSingleChip(toLayoutAPIAssumeSingleChip),
         usePaddingPairSignatureWithQueueId(usePaddingPairSignatureWithQueueId) {
   }
@@ -91,8 +82,6 @@ inline std::ostream &operator<<(std::ostream &os, const Env &env) {
   os << "\t"
      << "readUpdateIndexFromDeviceForKVCache: "
      << env.readUpdateIndexFromDeviceForKVCache << "\n";
-  os << "\t"
-     << "defaultStrideComputation: " << env.defaultStrideComputation << "\n";
   os << "\t"
      << "toLayoutAPIAssumeSingleChip: " << env.toLayoutAPIAssumeSingleChip
      << "\n";

--- a/runtime/lib/binary.cpp
+++ b/runtime/lib/binary.cpp
@@ -38,6 +38,11 @@ static std::string asJson(void const *fbb, uint8_t const *binarySchema,
 
 static std::vector<uint32_t>
 calculateStride(std::vector<uint32_t> const &shape) {
+  // TODO(bug #2045): Our current stride calculation is incorrect for tilized
+  // tensors. The current solution is to remove stride entirely from the
+  // flatbuffer and calculate the stride in runtime assuming using the default
+  // method ignoring details like grid, layout etc. Once we have a more
+  // sophisticated way for handling this, we can remove this workaround.
   LOG_ASSERT(!shape.empty());
   std::vector<uint32_t> stride(shape.size(), 1);
   for (size_t i = shape.size() - 1; i > 0; i--) {

--- a/runtime/lib/binary.cpp
+++ b/runtime/lib/binary.cpp
@@ -7,7 +7,6 @@
 #include "flatbuffers/idl.h"
 
 #include "tt/runtime/detail/logger.h"
-#include "tt/runtime/detail/workarounds.h"
 #include "tt/runtime/types.h"
 #include "tt/runtime/utils.h"
 #include "ttmlir/Target/Common/system_desc_bfbs_generated.h"
@@ -39,10 +38,6 @@ static std::string asJson(void const *fbb, uint8_t const *binarySchema,
 
 static std::vector<uint32_t>
 calculateStride(std::vector<uint32_t> const &shape) {
-  LOG_ASSERT(
-      workaround::Env::get().defaultStrideComputation,
-      "Stride currently removed from flatbuffer thus defaultStrideComputation"
-      "workaround must be enabled");
   LOG_ASSERT(!shape.empty());
   std::vector<uint32_t> stride(shape.size(), 1);
   for (size_t i = shape.size() - 1; i > 0; i--) {

--- a/runtime/lib/common/workarounds.cpp
+++ b/runtime/lib/common/workarounds.cpp
@@ -8,12 +8,11 @@ namespace tt::runtime::workaround {
 #if defined(TT_RUNTIME_WORKAROUNDS) && TT_RUNTIME_WORKAROUNDS == 1
 const Env &Env::get(bool maxpool2dPreshard, bool swapBinaryOperands,
                     bool readUpdateIndexFromDeviceForKVCache,
-                    bool defaultStrideComputation,
                     bool toLayoutAPIAssumeSingleChip,
                     bool usePaddingPairSignatureWithQueueId) {
   static const Env config(maxpool2dPreshard, swapBinaryOperands,
                           readUpdateIndexFromDeviceForKVCache,
-                          defaultStrideComputation, toLayoutAPIAssumeSingleChip,
+                          toLayoutAPIAssumeSingleChip,
                           usePaddingPairSignatureWithQueueId);
   return config;
 }

--- a/runtime/tools/python/ttrt/common/run.py
+++ b/runtime/tools/python/ttrt/common/run.py
@@ -141,13 +141,6 @@ class Run:
             help="disable read update index for kv cache workaround",
         )
         Run.register_arg(
-            name="--disable-default-stride-computation",
-            type=bool,
-            default=False,
-            choices=[True, False],
-            help="disable runtime default stride computation workaround",
-        )
-        Run.register_arg(
             name="--disable-to-layout-api-assume-single-chip",
             type=bool,
             default=False,
@@ -431,7 +424,6 @@ class Run:
                 not self["--disable-maxpool2d-preshard"],
                 not self["--disable-swap-binary-operands"],
                 not self["--disable-read-update-index-for-kv-cache"],
-                not self["--disable-default-stride-computation"],
                 not self["--disable-to-layout-api-assume-single-chip"],
                 not self["--disable-pad-op-padding-pairs-signature"],
             )


### PR DESCRIPTION
This change is made to avert an innocuous bug where `ttrt` can't find a symbol when it is built in debug mode.

### Problem description
Sometimes the symbol `_ZN2tt7runtime10workaround3Env3getEbbbbb` is missing from a `Debug` built `ttrt`.

### What's changed
The code that introduces a dependency on that symbol has been removed