### PR TITLE
[TTIR] Support passing 4 values for padding in ConvTranspose2d

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -1086,31 +1086,44 @@ def TTIR_ConvTranspose2dOp : TTIR_DPSOp<"conv_transpose2d"> {
       Applies a 2D transposed convolution operator over an input image composed of several input planes.
 
       Inputs:
-      - `input` AnyRankedTensor: NHWC format (batch_size x height x width x channels)
-      - `weight` AnyRankedTensor: OIHW format (output_channels x input_channels x height x width)
-      - `bias` Optional<AnyRankedTensor>: (1 x 1 x 1 x output_channels)
-      - `output` AnyRankedTensor: NHWC format (batch_size x height x width x channels)
+        - `input` AnyRankedTensor: expected in the following format (N, H_in, W_in, C) where:
+          - N is the batch size
+          - H_in is the height of the input planes
+          - W_in is the width of the input planes
+          - C is the number of channels
+
+        - `weight` AnyRankedTensor: expected in the following format (C, O/G, K_H, K_W).
+        - `bias` Optional<AnyRankedTensor>: expected in the following format (1, 1, 1, O) where:
+          - C is the number of input channels
+          - O is the number of output channels
+          - G is the number of groups
+          - K_H is the height of the kernel
+          - K_W is the width of the kernel
+
+        - `output` AnyRankedTensor: expected in the following format (N, H_out, W_out, O) where:
+          - H_out = (H_in - 1) * stride[0] - (padding_top + padding_bottom) + dilation[0] * (K_H - 1) + output_padding[0] + 1
+          - W_out = (W_in - 1) * stride[1] - (padding_left + padding_right) + dilation[1] * (K_W - 1) + output_padding[1] + 1
 
       Attributes:
-      - `stride` (i32 | array<i32>): Controls the stride for the cross-correlation.
-      - `padding` (i32 | array<i32>): Controls the amount of implicit zero padding on both sides for dilation * (kernel_size - 1) - padding number of points.
-      - `output_padding` (i32 | array<i32>): Controls the additional size added to one side of the output shape.
-      - `dilation` (i32 | array<i32>): Controls the spacing between the kernel points
-      - `groups` i32: Controls the connections between inputs and outputs. Must be divisible by input and output channels.
+        - `stride` (i32 | array<2xi32>): Controls the stride for the cross-correlation.
+        - `padding` (i32 | array<2xi32> | array<4xi32>): Controls the amount of implicit zero padding on both sides for dilation * (kernel_size - 1) - padding number of points.
+        - `output_padding` (i32 | array<2xi32>): Controls the additional size added to one side of the output shape.
+        - `dilation` (i32 | array<2xi32>): Controls the spacing between the kernel points
+        - `groups` i32: Controls the connections between inputs and outputs. Must be divisible by input and output channels.
 
       Example:
-        %input = tensor.empty() : () -> tensor<256x256x3x3xbf16>
+        %input = tensor.empty() : () -> tensor<3x8x8x256xbf16>
         %weight = tensor.empty() : () -> tensor<256x256x3x3xbf16>
         %bias = tensor.empty() : () -> tensor<1x1x1x256xbf16>
         %output = tensor.empty() : () -> tensor<1x10x10x256xbf16>
         %0 = "ttir.conv_transpose2d"(%input, %weight, %bias, %output)
           <{
-            stride = = array<i32: 1, 1>,
+            stride = 1: i32,
             padding = 0: i32,
             output_padding = 0: i32,
             dilation = 1: i32,
             groups = 1: i32
-          > : (tensor<1x8x8x256xbf16>, tensor<256x256x3x3xbf16>, tensor<1x1x1x256xbf16>, tensor<1x10x10x256xbf16>) -> tensor<1x10x10x256xbf16>
+          > : (tensor<3x8x8x256xbf16>, tensor<256x256x3x3xbf16>, tensor<1x1x1x256xbf16>, tensor<3x10x10x256xbf16>) -> tensor<3x10x10x256xbf16>
     }];
 
     let arguments = (ins AnyRankedTensor:$input,

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1040,23 +1040,56 @@ def TTNN_ConvTranspose2dOp : TTNN_NamedDPSOp<"conv_transpose2d"> {
       Applies a 2D transposed convolution operator over an input image composed of several input planes.
 
       Inputs:
-      - `input` AnyRankedTensor: NHWC format (batch_size x height x width x channels)
-      - `weight` AnyRankedTensor: OIHW format (output_channels x input_channels x height x width)
-      - `bias` Optional<AnyRankedTensor>: (1 x 1 x 1 x output_channels)
-      - `output` AnyRankedTensor: (1 x 1 x (batch_size * height * width) x channels)
+        - `input` AnyRankedTensor: expected in the following format (N, H_in, W_in, C) where:
+          - N is the batch size
+          - H_in is the height of the input planes
+          - W_in is the width of the input planes
+          - C is the number of channels
+
+        - `weight` AnyRankedTensor: expected in the following format (C, O/G, K_H, K_W).
+        - `bias` Optional<AnyRankedTensor>: expected in the following format (1, 1, 1, O) where:
+          - C is the number of input channels
+          - O is the number of output channels
+          - G is the number of groups
+          - K_H is the height of the kernel
+          - K_W is the width of the kernel
+
+        - `output` AnyRankedTensor: expected in the following format (N, H_out, W_out, O) where:
+          - H_out = (H_in - 1) * stride[0] - 2 * padding[0] + dilation[0] * (K_H - 1) + output_padding[0] + 1
+          - W_out = (W_in - 1) * stride[1] - 2 * padding[1] + dilation[1] * (K_W - 1) + output_padding[1] + 1
 
       Attributes:
-      - `in_channels` i32: The number of input channels.
-      - `out_channels` i32: The number of output channels.
-      - `batch_size` i32: The batch size.
-      - `input_height` i32: The input height.
-      - `input_width` i32: The input width.
-      - `kernel_size` array<i32>: The kernel size.
-      - `stride` array<i32>: Controls the stride for the cross-correlation.
-      - `padding` array<i32>: Controls the amount of implicit zero padding on both sides for dilation * (kernel_size - 1) - padding number of points.
-      - `output_padding` array<i32>: Controls the additional size added to one side of the output shape.
-      - `dilation` array<i32>: Controls the spacing between the kernel points
-      - `groups` i32: Controls the connections between inputs and outputs. Must be divisible by input and output channels.
+        - `in_channels` i32: The number of input channels.
+        - `out_channels` i32: The number of output channels.
+        - `batch_size` i32: The batch size.
+        - `input_height` i32: The input height.
+        - `input_width` i32: The input width.
+        - `kernel_size` array<2xi32>: The kernel size.
+        - `stride` array<2xi32>: Controls the stride for the cross-correlation.
+        - `padding` array<2xi32>: Controls the amount of implicit zero padding on both sides for dilation * (kernel_size - 1) - padding number of points.
+        - `output_padding` array<2xi32>: Controls the additional size added to one side of the output shape.
+        - `dilation` array<2xi32>: Controls the spacing between the kernel points
+        - `groups` i32: Controls the connections between inputs and outputs. Must be divisible by input and output channels.
+
+      Example:
+        // %input: tensor<3x8x8x256xbf16>
+        // %weight: tensor<256x256x3x3xbf16>
+        // %bias: tensor<1x1x1x256xbf16>
+        // %output: tensor<3x10x10x256xbf16>
+        %0 = "ttnn.conv_transpose2d"(%input, %weight, %bias, %output, %device)
+          <{
+            batch_size = 3: i32,
+            dilation = array<i32: 1, 1>,
+            groups = 1: i32,
+            in_channels = 256: i32,
+            input_height = 8: i32,
+            input_width = 8: i32,
+            kernel_size = array<i32: 3, 3>,
+            out_channels = 256: i32,
+            output_padding = array<i32: 0, 0>,
+            padding = array<i32: 0, 0>,
+            stride = array<i32: 1, 1>
+          > : (tensor<3x8x8x256xbf16>, tensor<256x256x3x3xbf16>, tensor<1x1x1x256xbf16>, tensor<3x10x10x256xbf16>) -> tensor<3x10x10x256xbf16>
     }];
 
     let arguments = (ins AnyRankedTensor:$input,

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -230,13 +230,18 @@ mlir::LogicalResult mlir::tt::ttir::ConvTranspose2dOp::verify() {
     return emitOpError("Stride values must be greater than 0");
   }
 
-  auto padding = ttmlir::utils::getPairOfInteger<int32_t>(getPadding());
+  auto padding = ttmlir::utils::getQuadrupleOfInteger<int32_t>(getPadding());
   if (auto error = padding.takeError()) {
     return emitOpError() << llvm::toString(std::move(error)) << " for padding";
   }
-  if (padding->first < 0 || padding->second < 0) {
+
+  auto [paddingTop, paddingLeft, paddingBottom, paddingRight] = *padding;
+  if (paddingTop < 0 || paddingBottom < 0 || paddingLeft < 0 ||
+      paddingRight < 0) {
     return emitOpError("Padding values must be greater or equal than 0");
   }
+  int32_t verticalPadding = paddingTop + paddingBottom;
+  int32_t horizontalPadding = paddingLeft + paddingRight;
 
   auto outputPadding =
       ttmlir::utils::getPairOfInteger<int32_t>(getOutputPadding());
@@ -308,10 +313,10 @@ mlir::LogicalResult mlir::tt::ttir::ConvTranspose2dOp::verify() {
   int32_t Hin = inputType.getDimSize(inputType.getRank() - 3);
   int32_t Win = inputType.getDimSize(inputType.getRank() - 2);
 
-  int32_t expectedHOut = (Hin - 1) * stride->first - 2 * padding->first +
+  int32_t expectedHOut = (Hin - 1) * stride->first - verticalPadding +
                          dilation->first * (kernelHeight - 1) +
                          outputPadding->first + 1;
-  int32_t expectedWOut = (Win - 1) * stride->second - 2 * padding->second +
+  int32_t expectedWOut = (Win - 1) * stride->second - horizontalPadding +
                          dilation->second * (kernelWidth - 1) +
                          outputPadding->second + 1;
   if (expectedHOut < 0 || expectedWOut < 0) {

--- a/runtime/lib/ttnn/operations/conv/conv_transpose2d.cpp
+++ b/runtime/lib/ttnn/operations/conv/conv_transpose2d.cpp
@@ -24,14 +24,21 @@ void run(const ::tt::target::ttnn::ConvTranspose2dOp *op,
       op->bias() ? std::make_optional(tensorPool.at(op->bias()->global_id()))
                  : std::nullopt;
 
+  LOG_ASSERT(op->kernel_size()->size() == 2,
+             "Kernel size expected to have 2 elements");
+  LOG_ASSERT(op->stride()->size() == 2, "Stride expected to have 2 elements");
+  LOG_ASSERT(op->padding()->size() == 2, "Padding expected to have 2 elements");
+  LOG_ASSERT(op->output_padding()->size() == 2,
+             "Output padding expected to have 2 elements");
+  LOG_ASSERT(op->dilation()->size() == 2,
+             "Dilation expected to have 2 elements");
+
   std::array<uint32_t, 2> kernelSize, stride, padding, outputPadding, dilation;
-  std::copy(op->kernel_size()->begin(), op->kernel_size()->end(),
-            kernelSize.begin());
-  std::copy(op->stride()->begin(), op->stride()->end(), stride.begin());
-  std::copy(op->padding()->begin(), op->padding()->end(), padding.begin());
-  std::copy(op->output_padding()->begin(), op->output_padding()->end(),
-            outputPadding.begin());
-  std::copy(op->dilation()->begin(), op->dilation()->end(), dilation.begin());
+  std::copy_n(op->kernel_size()->begin(), 2, kernelSize.begin());
+  std::copy_n(op->stride()->begin(), 2, stride.begin());
+  std::copy_n(op->padding()->begin(), 2, padding.begin());
+  std::copy_n(op->output_padding()->begin(), 2, outputPadding.begin());
+  std::copy_n(op->dilation()->begin(), 2, dilation.begin());
 
   auto config = ::ttnn::operations::conv::Conv2dConfig();
   config.dtype = utils::getDataType(op->input());

--- a/test/ttmlir/Dialect/TTIR/conv_transpose2d/conv_transpose2d_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/conv_transpose2d/conv_transpose2d_tests_negative.mlir
@@ -108,7 +108,7 @@ module attributes {} {
 module attributes {} {
   func.func @conv_transpose2d_invalid_padding_shape(%arg0: tensor<1x8x8x256xbf16>, %arg1: tensor<256x256x3x3xbf16>, %arg2: tensor<1x1x1x256xbf16>) -> tensor<1x10x10x256xbf16> {
     %0 = tensor.empty() : tensor<1x10x10x256xbf16>
-    // CHECK: error: 'ttir.conv_transpose2d' op Expected integer or pair of integers, got tuple of size 3 for padding
+    // CHECK: error: 'ttir.conv_transpose2d' op Expected integer, pair, or tuple of size 4, but got tuple of size 3 for padding
     %1 = "ttir.conv_transpose2d"(%arg0, %arg1, %arg2, %0)
             <{
               stride = 1: i32,

--- a/test/ttmlir/Dialect/TTIR/conv_transpose2d/conv_transpose2d_tests_positive.mlir
+++ b/test/ttmlir/Dialect/TTIR/conv_transpose2d/conv_transpose2d_tests_positive.mlir
@@ -43,6 +43,20 @@ module attributes {} {
     return %1 : tensor<1x73x67x256xbf16>
   }
 
+  func.func @conv_transpose2d_padding_4(%arg0: tensor<1x64x64x256xbf16>, %arg1: tensor<256x256x16x16xbf16>, %arg2: tensor<1x1x1x256xbf16>) -> tensor<1x73x67x256xbf16> {
+    %0 = tensor.empty() : tensor<1x73x67x256xbf16>
+    // CHECK: %[[C:.*]] = "ttir.conv_transpose2d"[[C:.*]]
+    %1 = "ttir.conv_transpose2d"(%arg0, %arg1, %arg2, %0)
+            <{
+              stride = 1: i32,
+              padding = array<i32: 3, 6, 3, 6>,
+              output_padding = 0: i32,
+              dilation = 1: i32,
+              groups = 1: i32}
+            > : (tensor<1x64x64x256xbf16>, tensor<256x256x16x16xbf16>, tensor<1x1x1x256xbf16>, tensor<1x73x67x256xbf16>) -> tensor<1x73x67x256xbf16>
+    return %1 : tensor<1x73x67x256xbf16>
+  }
+
   func.func @conv_transpose2d_output_padding(%arg0: tensor<1x32x32x128xbf16>, %arg1: tensor<128x256x8x8xbf16>, %arg2: tensor<1x1x1x256xbf16>) -> tensor<1x45x47x256xbf16> {
     %0 = tensor.empty() : tensor<1x45x47x256xbf16>
     // CHECK: %[[C:.*]] = "ttir.conv_transpose2d"[[C:.*]]


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/2073)

### Problem description
The padding attribute in ConvTranspose2dOp currently only accepts 1 or 2 values, but not 4.

### What's changed
Added support for passing 4 values for the padding attribute and made minor updates to the ConvTranspose2dOp documentation and verification.
