### PR TITLE
Fix docker tagging logic

### DIFF
--- a/.github/build-docker-images.sh
+++ b/.github/build-docker-images.sh
@@ -39,12 +39,12 @@ build_and_push() {
 
         echo "Pushing image $image_name:$DOCKER_TAG"
         docker push $image_name:$DOCKER_TAG
+    fi
 
-        # If we are on main branch also push the latest tag
-        if [ "$on_main" = "true" ]; then
-            echo "Pushing image $image_name:latest"
-            docker push $image_name:latest
-        fi
+    # If we are on main branch also push the latest tag
+    if [ "$on_main" = "true" ]; then
+        echo "Pushing image $image_name:latest"
+        docker push $image_name:latest
     fi
 }
 

--- a/.github/build-docker-images.sh
+++ b/.github/build-docker-images.sh
@@ -45,8 +45,8 @@ build_and_push() {
         if [ "$on_main" = "true" ]; then
             if ! diff <(docker manifest inspect $image_name:latest | jq -S .) <(docker manifest inspect $image_name:$DOCKER_TAG | jq -S .); then
                 echo "Image content changed, updating latest tag"
-                docker tag $image_name:$DOCKER_TAG $image_name:latest
-                docker push $image_name:latest
+                docker manifest create $image_name:latest --amend $image_name:$DOCKER_TAG
+                docker manifest push $image_name:latest
             else
                 echo "Image content unchanged, skipping latest tag"
             fi

--- a/.github/build-docker-images.sh
+++ b/.github/build-docker-images.sh
@@ -42,15 +42,10 @@ build_and_push() {
     fi
 
     # If we are on main branch also push the latest tag
-        if [ "$on_main" = "true" ]; then
-            if ! diff <(docker manifest inspect $image_name:latest | jq -S .) <(docker manifest inspect $image_name:$DOCKER_TAG | jq -S .); then
-                echo "Image content changed, updating latest tag"
-                docker manifest create $image_name:latest --amend $image_name:$DOCKER_TAG
-                docker manifest push $image_name:latest
-            else
-                echo "Image content unchanged, skipping latest tag"
-            fi
-        fi
+    if [ "$on_main" = "true" ]; then
+        docker manifest create $image_name:latest --amend $image_name:$DOCKER_TAG
+        docker manifest push $image_name:latest
+    fi
 }
 
 build_and_push $BASE_IMAGE_NAME .github/Dockerfile.base $ON_MAIN


### PR DESCRIPTION
### Problem description
Docker images haven't been auto-tagged with latest

### What's changed
Issue seems to be: when you create PR, new docker image is created.  When you merge PR, cached docker image from PR is found => we don't tag with latest.  Idea here is to move the latest tag logic out of the if/else s.t. it always runs on main.  Apparently, similar fix was made for tt-forge-fe and works there.

### Checklist
- [ ] Green CI run
