### PR TITLE
Uplift third_party/tt-metal to b093594aa5fc01f7c008a0b5ffddbcf2713bd8f7 2025-02-06

### DIFF
--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -593,9 +593,7 @@ public:
     //
     ArrayAttr arrayAttrs = rewriter.getArrayAttr({
         rewriter.getIndexAttr(0), // input tensor
-        rewriter.getIndexAttr(1), // ttnn::Shape
-        ttnn_to_emitc::utils::createStdNullopt(
-            rewriter) // std::nullopt for memory config
+        rewriter.getIndexAttr(1)  // ttnn::Shape
     });
 
     rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -38,7 +38,7 @@ set(TTMETAL_INCLUDE_DIRS
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/nanomsg/28cc32d5bdb6a858fe53b3ccf7e923957e53eada/include
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/fmt/73b5ec45edbd92babfd91c3777a9e1ab9cac8238/include
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/magic_enum/4d76fe0a5b27a0e62d6c15976d02b33c54207096/include
-  ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/boost_core/e679bef5c160cf29d0f37d549881dc5f5a58c332/include
+  ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/boost/1359e136761ab2d10afa1c4e21086c8d824735cd/libs/core/include
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/json/798e0374658476027d9723eeb67a262d0f3c8308/include
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/xtensor/4a957e26c765b48cbec4a4235fe9e518d5a85d3d/include
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/xtensor-blas/190c3a4314355b67291a7d78b20a2100de3f8f54/include

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "b981271938b34827a53a9f74a49be9a0c3388eed")
+set(TT_METAL_VERSION "b093594aa5fc01f7c008a0b5ffddbcf2713bd8f7")
 
 if ("$ENV{ARCH_NAME}" STREQUAL "grayskull")
   set(ARCH_NAME "grayskull")

--- a/tools/ttnn-standalone/CMakeLists.txt
+++ b/tools/ttnn-standalone/CMakeLists.txt
@@ -60,7 +60,7 @@ set(INCLUDE_DIRS
     $ENV{TT_METAL_HOME}/.cpmcache/reflect/e75434c4c5f669e4a74e4d84e0a30d7249c1e66f
     $ENV{TT_METAL_HOME}/.cpmcache/fmt/73b5ec45edbd92babfd91c3777a9e1ab9cac8238/include
     $ENV{TT_METAL_HOME}/.cpmcache/magic_enum/4d76fe0a5b27a0e62d6c15976d02b33c54207096/include
-    $ENV{TT_METAL_HOME}/.cpmcache/boost_core/e679bef5c160cf29d0f37d549881dc5f5a58c332/include
+    $ENV{TT_METAL_HOME}/.cpmcache/boost/1359e136761ab2d10afa1c4e21086c8d824735cd/libs/core/include
     $ENV{TT_METAL_HOME}/.cpmcache/json/798e0374658476027d9723eeb67a262d0f3c8308/include
 
     # Metalium


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the b093594aa5fc01f7c008a0b5ffddbcf2713bd8f7

- Update boost core include dir after metal commit a1eb4d9
- Update repeat op invoke param to not pass in empty config after metal change b45f5a2