### PR TITLE
[build] fix install of tt-metal shared libs

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -157,7 +157,7 @@ install(CODE
     file(
         INSTALL
         ${library_paths}
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}
         TYPE SHARED_LIBRARY
         FOLLOW_SYMLINK_CHAIN
     )"


### PR DESCRIPTION
After commit 62517e0 the installation path for `tt-metal` shared libs is wrong. It does not respect `CMAKE_INSTALL_PREFIX`.

When using `install(FILES)` and specifying `DESTINATION`, cmake will append it to the `CMAKE_INSTALL_PREFIX` under the hood. However, `file(INSTALL)` does not do that.

Fixing so that the full path is provided to the `file(INSTALL)` command.