### PR TITLE
Remove maxpool2d preshard workaround

### DIFF
--- a/runtime/include/tt/runtime/detail/workarounds.h
+++ b/runtime/include/tt/runtime/detail/workarounds.h
@@ -15,7 +15,7 @@ struct Env {
 #else
   constexpr static Env
 #endif
-  get(bool maxpool2dPreshard = true, bool swapBinaryOperands = true,
+  get(bool swapBinaryOperands = true,
       bool readUpdateIndexFromDeviceForKVCache = true,
       bool toLayoutAPIAssumeSingleChip = true,
       bool usePaddingPairSignatureWithQueueId = true)
@@ -23,13 +23,9 @@ struct Env {
       ;
 #else
   {
-    return Env(true, true, true, true, true);
+    return Env(true, true, true, true);
   }
 #endif
-  // TODO(bug #855): Ideally we should have an op that preshards for maxpool2d
-  // instead of adding a method in runtime
-  bool maxpool2dPreshard;
-
   // TODO(bug #1124): We're currently swapping the operands for binary ops
   // in runtime if the lhs operand is smaller (and requires broadcast onto the
   // rhs operand). We should add this check in the compiler.
@@ -60,12 +56,11 @@ struct Env {
   bool usePaddingPairSignatureWithQueueId;
 
 private:
-  constexpr Env(bool maxpool2dPreshard, bool swapBinaryOperands,
+  constexpr Env(bool swapBinaryOperands,
                 bool readUpdateIndexFromDeviceForKVCache,
                 bool toLayoutAPIAssumeSingleChip,
                 bool usePaddingPairSignatureWithQueueId)
-      : maxpool2dPreshard(maxpool2dPreshard),
-        swapBinaryOperands(swapBinaryOperands),
+      : swapBinaryOperands(swapBinaryOperands),
         readUpdateIndexFromDeviceForKVCache(
             readUpdateIndexFromDeviceForKVCache),
         toLayoutAPIAssumeSingleChip(toLayoutAPIAssumeSingleChip),
@@ -75,8 +70,6 @@ private:
 
 inline std::ostream &operator<<(std::ostream &os, const Env &env) {
   os << "workaround::Env{\n";
-  os << "\t"
-     << "maxpool2dPreshard: " << env.maxpool2dPreshard << ",\n";
   os << "\t"
      << "swapBinaryOperands: " << env.swapBinaryOperands << ",\n";
   os << "\t"

--- a/runtime/lib/common/workarounds.cpp
+++ b/runtime/lib/common/workarounds.cpp
@@ -6,14 +6,13 @@
 
 namespace tt::runtime::workaround {
 #if defined(TT_RUNTIME_WORKAROUNDS) && TT_RUNTIME_WORKAROUNDS == 1
-const Env &Env::get(bool maxpool2dPreshard, bool swapBinaryOperands,
+const Env &Env::get(bool swapBinaryOperands,
                     bool readUpdateIndexFromDeviceForKVCache,
                     bool toLayoutAPIAssumeSingleChip,
                     bool usePaddingPairSignatureWithQueueId) {
-  static const Env config(maxpool2dPreshard, swapBinaryOperands,
-                          readUpdateIndexFromDeviceForKVCache,
-                          toLayoutAPIAssumeSingleChip,
-                          usePaddingPairSignatureWithQueueId);
+  static const Env config(
+      swapBinaryOperands, readUpdateIndexFromDeviceForKVCache,
+      toLayoutAPIAssumeSingleChip, usePaddingPairSignatureWithQueueId);
   return config;
 }
 #endif

--- a/runtime/tools/python/test/test_run.py
+++ b/runtime/tools/python/test/test_run.py
@@ -309,20 +309,3 @@ def test_enable_async_ttnn_run():
 def test_enable_async_ttnn_cmd_run():
     command = f"ttrt run {BINARY_FILE_PATH} --enable-async-ttnn --log-file ttrt-results/{inspect.currentframe().f_code.co_name}.log --result-file ttrt-results/{inspect.currentframe().f_code.co_name}.json"
     sub_process_command(command)
-
-
-def test_disable_maxpool2d_preshard_run():
-    API.initialize_apis()
-    custom_args = {}
-    custom_args[
-        "--result-file"
-    ] = f"ttrt-results/{inspect.currentframe().f_code.co_name}.json"
-    custom_args["binary"] = BINARY_FILE_PATH
-    custom_args["--disable-maxpool2d-preshard"] = True
-    run_instance = API.Run(args=custom_args)
-    run_instance()
-
-
-def test_disable_maxpool2d_preshard_cmd_run():
-    command = f"ttrt run {BINARY_FILE_PATH} --disable-maxpool2d-preshard --log-file ttrt-results/{inspect.currentframe().f_code.co_name}.log --result-file ttrt-results/{inspect.currentframe().f_code.co_name}.json"
-    sub_process_command(command)

--- a/runtime/tools/python/ttrt/common/run.py
+++ b/runtime/tools/python/ttrt/common/run.py
@@ -120,13 +120,6 @@ class Run:
             help="enable async mode device execution for TTNN runtime",
         )
         Run.register_arg(
-            name="--disable-maxpool2d-preshard",
-            type=bool,
-            default=False,
-            choices=[True, False],
-            help="disable maxpool2d preshard workaround",
-        )
-        Run.register_arg(
             name="--disable-swap-binary-operands",
             type=bool,
             default=False,
@@ -421,7 +414,6 @@ class Run:
             debug_env = ttrt.runtime.DebugEnv.get(self["--load-kernels-from-disk"])
             self.logging.debug(f"setting tt runtime debug env={debug_env}")
             workaround_env = ttrt.runtime.WorkaroundEnv.get(
-                not self["--disable-maxpool2d-preshard"],
                 not self["--disable-swap-binary-operands"],
                 not self["--disable-read-update-index-for-kv-cache"],
                 not self["--disable-to-layout-api-assume-single-chip"],


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/855

### Problem description
We currently pre-shard the input to ttnn::max_pool2d in the runtime.

### What's changed
I've removed this workaround since this is taken care of within the ttnn::max_pool2d op.

