### PR TITLE
Default conv weights on host

### DIFF
--- a/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
@@ -495,6 +495,13 @@ private:
       if (mlir::isa<ttir::MeshShardOp>(user)) {
         return true;
       }
+      // For the weight input of the conv2d op, it specifically needs to be on
+      // host (issue https://github.com/tenstorrent/tt-mlir/issues/1528).
+      if ((mlir::isa<ttir::Conv2dOp>(user) ||
+           mlir::isa<ttir::ConvTranspose2dOp>(user)) &&
+          user->getOperand(1) == arg) {
+        return true;
+      }
     }
     return false;
   }


### PR DESCRIPTION
Defaults conv weights layout to host since they need to be prepared on host anyway. Patches uplift CI failures on tt-torch and tt-forge-fe.

FYI: @kmabeeTT @AleksKnezevic @pilkicTT 