### PR TITLE
Memory config validation and adding memory config attribute to concat op

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.h
@@ -9,6 +9,7 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsTypes.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNTraits.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNWorkaroundInterface.h"
 
 #include "mlir/Bytecode/BytecodeOpInterface.h"

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -10,6 +10,7 @@ include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td"
 include "ttmlir/Dialect/TTNN/IR/TTNNBase.td"
 include "ttmlir/Dialect/TTNN/IR/TTNNOpsTypes.td"
 include "ttmlir/Dialect/TTNN/IR/TTNNOpsEnums.td"
+include "ttmlir/Dialect/TTNN/IR/TTNNTraits.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/DestinationStyleOpInterface.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
@@ -27,7 +28,7 @@ def TTNN_GetDeviceOp : TTNN_Op<"get_device"> {
     let results = (outs TT_Device:$device);
 }
 
-def TTNN_ToMemoryConfigOp : TTNN_Op<"to_memory_config"> {
+def TTNN_ToMemoryConfigOp : TTNN_Op<"to_memory_config", [HasMemoryConfigTrait]> {
     let summary = "ToMemoryConfig op.";
     let description = [{
       This op converts the memory config of the input tensor based on the given memory config.
@@ -859,7 +860,7 @@ def TTNN_RepeatInterleaveOp : TTNN_Op<"repeat_interleave"> {
     let hasVerifier = 1;
 }
 
-def TTNN_ConcatOp : TTNN_NamedDPSOp<"concat"> {
+def TTNN_ConcatOp : TTNN_NamedDPSOp<"concat", [HasMemoryConfigTrait]> {
     let summary = "Concat op.";
     let description = [{
       Concat tensors along a given dimension.
@@ -867,7 +868,8 @@ def TTNN_ConcatOp : TTNN_NamedDPSOp<"concat"> {
 
     let arguments = (ins Variadic<AnyRankedTensor>:$inputs,
                          AnyRankedTensor:$output,
-                         SI32Attr:$dim);
+                         SI32Attr:$dim,
+                         OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
 
     let results = (outs AnyRankedTensor:$result);
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
@@ -92,6 +92,8 @@ def TTNN_MemoryConfigAttr : TTNN_Attr<"MemoryConfig", "memory_config"> {
     MemoryConfigAttr withBufferType(::mlir::MLIRContext *context, BufferType bufferType);
     MemoryConfigAttr withMemoryLayout(::mlir::MLIRContext *context, TensorMemoryLayout memLayout);
   }];
+
+  let genVerifyDecl = 1;
 }
 
 def TTNN_MeshShapeAttr : TTNN_Attr<"MeshShape", "mesh_shape"> {

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNTraits.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNTraits.h
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_IR_TTNNTRAITS_H
+#define TTMLIR_DIALECT_TTNN_IR_TTNNTRAITS_H
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+
+#include "mlir/IR/OpDefinition.h"
+#include "llvm/ADT/STLExtras.h"
+
+namespace mlir::tt::ttnn {
+
+template <typename ConcreteType>
+class HasMemoryConfigTrait
+    : public mlir::OpTrait::TraitBase<ConcreteType, HasMemoryConfigTrait> {
+public:
+  static mlir::LogicalResult verifyTrait(mlir::Operation *op) {
+
+    // Check if the operation defines memory config attribute.
+    auto attributeNames = ConcreteType::getAttributeNames();
+    if (std::find(attributeNames.begin(), attributeNames.end(),
+                  MemoryConfigAttr::getMnemonic()) == attributeNames.end()) {
+      return op->emitOpError("Operation must define memory_config attribute.");
+    }
+
+    // Retrieve memory config attribute if it exist because it is optional.
+    MemoryConfigAttr memoryConfigAttr =
+        op->getAttrOfType<MemoryConfigAttr>(MemoryConfigAttr::getMnemonic());
+
+    if (!memoryConfigAttr) {
+      return mlir::success();
+    }
+
+    // Verify the output layout with the memory config attribute if exist.
+    assert(op->getResults().size() == 1 &&
+           "Operation should define only one result.");
+
+    // Retrieve output layout.
+    RankedTensorType output =
+        mlir::cast<RankedTensorType>(op->getResult(0).getType());
+    TTNNLayoutAttr outputLayoutAttr =
+        mlir::cast<TTNNLayoutAttr>(output.getEncoding());
+
+    // Verify if the buffer type is the same.
+    if (memoryConfigAttr.getBufferType().getValue() !=
+        outputLayoutAttr.getBufferType()) {
+      return op->emitOpError(
+          "Output tensor buffer type must match memory config buffer type.");
+    }
+
+    // Tensor memory layout is optional, if not set, it is assumed to be the
+    // same as the output tensor memory layout.
+    if (memoryConfigAttr.getTensorMemoryLayout() &&
+        memoryConfigAttr.getTensorMemoryLayout() !=
+            outputLayoutAttr.getMemLayout()) {
+      return op->emitOpError("Output tensor layout memory space must match "
+                             "memory config memory space.");
+    }
+
+    // Verify if the shard spec is the same.
+    if (!llvm::equal(memoryConfigAttr.getShardSpec().getShardShape().getShape(),
+                     outputLayoutAttr.getShardShape())) {
+      return op->emitOpError(
+          "Output tensor shard spec must match memory config shard spec.");
+    }
+
+    return mlir::success();
+  }
+};
+} // namespace mlir::tt::ttnn
+
+#endif

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNTraits.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNTraits.td
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_TTMLIR_DIALECT_TTNN_TTNNTRAITS_TD
+#define TTMLIR_TTMLIR_DIALECT_TTNN_TTNNTRAITS_TD
+
+include "mlir/IR/OpBase.td"
+
+// Trait for ops that have memory config attribute.
+def HasMemoryConfigTrait : NativeOpTrait<"HasMemoryConfigTrait">
+{
+  let cppNamespace = "mlir::tt::ttnn";
+}
+
+#endif // TTMLIR_TTMLIR_DIALECT_TTNN_TTNNTRAITS_TD

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -251,6 +251,7 @@ table ConcatOp {
  inputs: [tt.target.TensorRef];
  out: tt.target.TensorRef;
  dim: int32;
+ memory_config: MemoryConfigDesc;
 }
 
 table ReshapeOp {

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -631,7 +631,8 @@ public:
     }
     rewriter.replaceOpWithNewOp<ttnn::ConcatOp>(
         op, this->getTypeConverter()->convertType(op.getType()),
-        adaptor.getInputs(), adaptor.getOutput(), dim);
+        adaptor.getInputs(), adaptor.getOutput(), dim,
+        /* memory_config */ nullptr);
     return success();
   }
 };

--- a/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp
@@ -596,3 +596,21 @@ MemoryConfigAttr::withMemoryLayout(::mlir::MLIRContext *context,
   return MemoryConfigAttr::get(context, getBufferType(), getShardSpec(),
                                TensorMemoryLayoutAttr::get(context, memLayout));
 }
+
+// Verify memory config attribute
+::llvm::LogicalResult MemoryConfigAttr::verify(
+    ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
+    BufferTypeAttr bufferType, ShardSpecAttr shardSpec,
+    TensorMemoryLayoutAttr tensorMemoryLayout) {
+  // Verify that we don't have tensorMemoryLayout for BufferType::SystemMemory
+  if (bufferType.getValue() == BufferType::SystemMemory && tensorMemoryLayout) {
+    emitError() << "MemoryConfig with SystemMemory buffer type cannot have "
+                   "tensor memory layout.";
+    return ::llvm::failure();
+  }
+
+  // TODO(#2140): Once we complete #1628, we should add a verifier for
+  // ShardSpecAttr. ShardSpecAttr is only valid if the buffer type is L1.
+
+  return ::llvm::success();
+}

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -219,9 +219,8 @@ createOp(FlatbufferObjectCache &cache, ToLayoutOp op) {
           ? ::flatbuffers::Optional<::tt::target::DataType>(
                 ::tt::mlir::ttnn::utils::toTargetDataType(dtype.value()))
           : ::flatbuffers::nullopt,
-      memoryConfig.has_value()
-          ? cache.getOrCreate(memoryConfig.value(), memoryConfigToFlatbuffer)
-          : 0,
+      memoryConfig ? cache.getOrCreate(*memoryConfig, memoryConfigToFlatbuffer)
+                   : 0,
       device ? cache.at<::tt::target::DeviceRef>(device) : 0, output);
 }
 
@@ -922,7 +921,13 @@ createConcatOp(FlatbufferObjectCache &cache, ConcatOp op) {
       getOperandThroughDPSOps(op.getResult()));
   int32_t dim = op.getDim();
 
-  return ::tt::target::ttnn::CreateConcatOpDirect(*cache.fbb, &ins, out, dim);
+  std::optional<mlir::tt::ttnn::MemoryConfigAttr> memoryConfig =
+      op.getMemoryConfig();
+
+  return ::tt::target::ttnn::CreateConcatOpDirect(
+      *cache.fbb, &ins, out, dim,
+      memoryConfig ? cache.getOrCreate(*memoryConfig, memoryConfigToFlatbuffer)
+                   : 0);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::EmbeddingOp>
@@ -958,9 +963,8 @@ createEmbeddingBackwardOp(FlatbufferObjectCache &cache,
           ? ::flatbuffers::Optional<::tt::target::DataType>(
                 ::tt::mlir::ttnn::utils::toTargetDataType(dtype.value()))
           : ::flatbuffers::nullopt,
-      memoryConfig.has_value()
-          ? cache.getOrCreate(memoryConfig.value(), memoryConfigToFlatbuffer)
-          : 0,
+      memoryConfig ? cache.getOrCreate(*memoryConfig, memoryConfigToFlatbuffer)
+                   : 0,
       out);
 }
 

--- a/runtime/lib/ttnn/operations/data_movement/concat.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/concat.cpp
@@ -5,6 +5,7 @@
 #include "operations/data_movement/concat.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
+#include "tt/runtime/ttnn/operations/utils.h"
 
 namespace tt::runtime::ttnn::operations::data_movement {
 void run(const ::tt::target::ttnn::ConcatOp *op, ProgramContext &context) {
@@ -16,7 +17,11 @@ void run(const ::tt::target::ttnn::ConcatOp *op, ProgramContext &context) {
     inputs.push_back(in);
   }
   int32_t dim = op->dim();
-  ::ttnn::Tensor out = ::ttnn::concat(inputs, dim);
+  std::optional<tt::tt_metal::MemoryConfig> memoryConfig =
+      op->memory_config() ? std::make_optional(utils::createMemoryConfig(
+                                op->memory_config(), op->out()))
+                          : std::nullopt;
+  ::ttnn::Tensor out = ::ttnn::concat(inputs, dim, memoryConfig);
   tensorPool.insert_or_assign(op->out()->global_id(), out);
 }
 } // namespace tt::runtime::ttnn::operations::data_movement

--- a/test/ttmlir/Dialect/TTIR/data_movement/concat/concat_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/data_movement/concat/concat_tests_negative.mlir
@@ -1,0 +1,47 @@
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+// Negative tests for concat operation
+
+// Verify that verification fails when the given dimension is out of bounds and is negative.
+module {
+  func.func @concat_negative_dim_out_of_bounds_negative(%arg0: tensor<32x32xf32>, %arg1: tensor<32x64xf32>) -> tensor<32x96xf32> {
+    // CHECK: error: 'ttir.concat' op Invalid dimension -3 for concatenation.
+    %0 = tensor.empty() : tensor<32x96xf32>
+    %1 = "ttir.concat"(%arg0, %arg1, %0) <{dim = -3 : si32}> : (tensor<32x32xf32>, tensor<32x64xf32>, tensor<32x96xf32>) -> tensor<32x96xf32>
+    return %1 : tensor<32x96xf32>
+  }
+}
+// -----
+
+// Verify that verification fails when the given dimension is out of bounds and is positive.
+module {
+  func.func @concat_negative_dim_out_of_bounds_positive(%arg0: tensor<32x32xf32>, %arg1: tensor<32x64xf32>) -> tensor<32x96xf32> {
+    // CHECK: error: 'ttir.concat' op Invalid dimension 2 for concatenation.
+    %0 = tensor.empty() : tensor<32x96xf32>
+    %1 = "ttir.concat"(%arg0, %arg1, %0) <{dim = 2 : si32}> : (tensor<32x32xf32>, tensor<32x64xf32>, tensor<32x96xf32>) -> tensor<32x96xf32>
+    return %1 : tensor<32x96xf32>
+  }
+}
+
+// -----
+
+// Verify that verification fails if all input tensors doesn't have the same rank.
+module {
+  func.func @forward(%arg0: tensor<32x32xf32>, %arg1: tensor<1x32x64xf32>) -> tensor<32x96xf32> {
+    // CHECK: error: 'ttir.concat' op All input tensors must have the same rank.
+    %0 = tensor.empty() : tensor<32x96xf32>
+    %1 = "ttir.concat"(%arg0, %arg1, %0) <{dim = 0 : si32}> : (tensor<32x32xf32>, tensor<1x32x64xf32>, tensor<32x96xf32>) -> tensor<32x96xf32>
+    return %1 : tensor<32x96xf32>
+  }
+}
+
+// -----
+
+// Verify that verification fails if all input tensors have same rank but only the specified dim can have different size.
+module {
+  func.func @forward(%arg0: tensor<32x1x64xf32>, %arg1: tensor<32x64x2xf32>) -> tensor<32x65x64xf32> {
+    // CHECK: error: 'ttir.concat' op All input tensors must have the same dimensions, except for dimension 1.
+    %0 = tensor.empty() : tensor<32x96xf32>
+    %1 = "ttir.concat"(%arg0, %arg1, %0) <{dim = 1 : si32}> : (tensor<32x1x64xf32>, tensor<32x64x2xf32>, tensor<32x96xf32>) -> tensor<32x65x64xf32>
+    return %1 : tensor<32x65x64xf32>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/data_movement/concat/concat_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/data_movement/concat/concat_tests_negative.mlir
@@ -1,0 +1,47 @@
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+// Negative tests for concat operation
+
+// Verify that verification fails when the given dimension is out of bounds and is negative.
+module {
+  func.func @concat_negative_dim_out_of_bounds_negative(%arg0: tensor<32x32xf32>, %arg1: tensor<32x64xf32>) -> tensor<32x96xf32> {
+    // CHECK: error: 'ttnn.concat' op Invalid dimension -3 for concatenation.
+    %0 = tensor.empty() : tensor<32x96xf32>
+    %1 = "ttnn.concat"(%arg0, %arg1, %0) <{dim = -3 : si32}> : (tensor<32x32xf32>, tensor<32x64xf32>, tensor<32x96xf32>) -> tensor<32x96xf32>
+    return %1 : tensor<32x96xf32>
+  }
+}
+// -----
+
+// Verify that verification fails when the given dimension is out of bounds and is positive.
+module {
+  func.func @concat_negative_dim_out_of_bounds_positive(%arg0: tensor<32x32xf32>, %arg1: tensor<32x64xf32>) -> tensor<32x96xf32> {
+    // CHECK: error: 'ttnn.concat' op Invalid dimension 2 for concatenation.
+    %0 = tensor.empty() : tensor<32x96xf32>
+    %1 = "ttnn.concat"(%arg0, %arg1, %0) <{dim = 2 : si32}> : (tensor<32x32xf32>, tensor<32x64xf32>, tensor<32x96xf32>) -> tensor<32x96xf32>
+    return %1 : tensor<32x96xf32>
+  }
+}
+
+// -----
+
+// Verify that verification fails if all input tensors doesn't have the same rank.
+module {
+  func.func @forward(%arg0: tensor<32x32xf32>, %arg1: tensor<1x32x64xf32>) -> tensor<32x96xf32> {
+    // CHECK: error: 'ttnn.concat' op All input tensors must have the same rank.
+    %0 = tensor.empty() : tensor<32x96xf32>
+    %1 = "ttnn.concat"(%arg0, %arg1, %0) <{dim = 0 : si32}> : (tensor<32x32xf32>, tensor<1x32x64xf32>, tensor<32x96xf32>) -> tensor<32x96xf32>
+    return %1 : tensor<32x96xf32>
+  }
+}
+
+// -----
+
+// Verify that verification fails if all input tensors have same rank but only the specified dim can have different size.
+module {
+  func.func @forward(%arg0: tensor<32x1x64xf32>, %arg1: tensor<32x64x2xf32>) -> tensor<32x65x64xf32> {
+    // CHECK: error: 'ttnn.concat' op All input tensors must have the same dimensions, except for dimension 1.
+    %0 = tensor.empty() : tensor<32x96xf32>
+    %1 = "ttnn.concat"(%arg0, %arg1, %0) <{dim = 1 : si32}> : (tensor<32x1x64xf32>, tensor<32x64x2xf32>, tensor<32x96xf32>) -> tensor<32x65x64xf32>
+    return %1 : tensor<32x65x64xf32>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/data_movement/to_memory_config/to_memory_config_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/data_movement/to_memory_config/to_memory_config_tests_negative.mlir
@@ -1,0 +1,59 @@
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+// Negative tests for to_memory_config operation
+
+// Verify that verification fails if the output tensor buffer type is not the same as the memory_config one.
+#dram = #ttnn.buffer_type<dram>
+#system_memory = #ttnn.buffer_type<system_memory>
+#device_tile_layout1 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+#device_tile_layout2 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x3x!tt.tile<32x32, f32>, #system_memory>>
+module {
+  func.func @forward(%arg0: tensor<32x32xf32, #device_tile_layout1>) -> tensor<32x96xf32, #device_tile_layout2> {
+    // CHECK: error: 'ttnn.to_memory_config' op Output tensor buffer type must match memory config buffer type.
+    %1 = "ttnn.to_memory_config"(%arg0) <{memory_config = #ttnn.memory_config<#dram, <<1x3>>, <interleaved>>}> : (tensor<32x32xf32, #device_tile_layout1>) -> tensor<32x96xf32, #device_tile_layout2>
+    return %1 : tensor<32x96xf32, #device_tile_layout2>
+  }
+}
+
+// -----
+
+// Verify that verification fails if the output tensor buffer memory layout is not the same as the memory_config one.
+#dram = #ttnn.buffer_type<dram>
+#device_tile_layout1 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+#device_tile_layout2 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x3x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+module{
+  func.func @forward(%arg0: tensor<32x32xf32, #device_tile_layout1>) -> tensor<32x96xf32, #device_tile_layout2> {
+    // CHECK: error: 'ttnn.to_memory_config' op Output tensor layout memory space must match memory config memory space.
+    %1 = "ttnn.to_memory_config"(%arg0) <{memory_config = #ttnn.memory_config<#dram, <<1x3>>, <single_bank>>}> : (tensor<32x32xf32, #device_tile_layout1>) -> tensor<32x96xf32, #device_tile_layout2>
+    return %1 : tensor<32x96xf32, #device_tile_layout2>
+  }
+}
+
+// -----
+
+// Verify that verification fails if the output tensor sharding is not the same as the memory_config one.
+#dram = #ttnn.buffer_type<dram>
+#l1 = #ttnn.buffer_type<l1>
+#device_tile_layout1 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+#device_tile_layout2 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x3x!tt.tile<32x32, f32>, #l1>, <interleaved>>
+module {
+  func.func @forward(%arg0: tensor<32x32xf32, #device_tile_layout1>) -> tensor<32x96xf32, #device_tile_layout2> {
+    // CHECK: error: 'ttnn.to_memory_config' op Output tensor shard spec must match memory config shard spec.
+    %1 = "ttnn.to_memory_config"(%arg0) <{memory_config = #ttnn.memory_config<#l1, <<1x4>>, <interleaved>>}> : (tensor<32x32xf32, #device_tile_layout1>) -> tensor<32x96xf32, #device_tile_layout2>
+    return %1 : tensor<32x96xf32, #device_tile_layout2>
+  }
+}
+
+// -----
+
+// Verify that memory_config attribute can't have system memory buffer type and tensor memory layout
+#dram = #ttnn.buffer_type<dram>
+#system_memory = #ttnn.buffer_type<system_memory>
+#device_tile_layout1 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+#device_tile_layout2 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x3x!tt.tile<32x32, f32>, #system_memory>, <interleaved>>
+module {
+  func.func @forward(%arg0: tensor<32x32xf32, #device_tile_layout1>) -> tensor<32x96xf32, #device_tile_layout2> {
+    // CHECK: error: MemoryConfig with SystemMemory buffer type cannot have tensor memory layout.
+    %1 = "ttnn.to_memory_config"(%arg0) <{memory_config = #ttnn.memory_config<#system_memory, <<1x4>>, <interleaved>>}> : (tensor<32x32xf32, #device_tile_layout1>) -> tensor<32x96xf32, #device_tile_layout2>
+    return %1 : tensor<32x96xf32, #device_tile_layout2>
+  }
+}


### PR DESCRIPTION
### Ticket
Following GH issue contains all the ops that requires memory_config:
https://github.com/tenstorrent/tt-mlir/issues/1637

Concat op is one on the list.

### Problem description
TTNN Concat op requires a memory config attribute.

### What's changed
With this PR we changed:
- We defined the HasMemoryConfigTrait trait that verifies the layout of all the ops with this trait.
- We passed the memory config attribute from TTNN Dialect concat op definition down to the runtime.

### Checklist
- [x] New/Existing tests provide coverage for changes
