### PR TITLE
Add llama and resnet emitc tests

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Utils/TransformUtils.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/TransformUtils.h
@@ -13,7 +13,7 @@
 
 namespace mlir::tt::ttnn::utils {
 // Get or insert device for the given operation.
-GetDeviceOp getOrInsertDevice(mlir::PatternRewriter &rewriter,
+GetDeviceOp getOrInsertDevice(mlir::RewriterBase &rewriter,
                               mlir::Operation *op);
 
 // Helper method to insert a ToLayoutOp to convert the input operand to the

--- a/lib/Dialect/TTNN/Utils/TransformUtils.cpp
+++ b/lib/Dialect/TTNN/Utils/TransformUtils.cpp
@@ -11,7 +11,7 @@
 namespace mlir::tt::ttnn::utils {
 // Gets or inserts a GetDeviceOp at the top of the current block of the given
 // operation.
-GetDeviceOp getOrInsertDevice(PatternRewriter &rewriter, Operation *op) {
+GetDeviceOp getOrInsertDevice(RewriterBase &rewriter, Operation *op) {
   Block *block = op->getBlock();
   for (auto &op : block->getOperations()) {
     if (auto deviceOp = dyn_cast<ttnn::GetDeviceOp>(op)) {

--- a/test/ttmlir/EmitC/TTNN/models/llama_prefill.mlir
+++ b/test/ttmlir/EmitC/TTNN/models/llama_prefill.mlir
@@ -1,0 +1,2667 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
+// RUN: ttmlir-opt --ttnn-modify-signatures-for-dylib --convert-ttnn-to-emitc %t.mlir > %t2.mlir
+// RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
+
+// https://huggingface.co/meta-llama/Llama-3.2-1B
+module @LLama_3.2_1B attributes {} {
+  func.func @forward(%arg0: tensor<1x11xi32> {ttir.name = "input_1"}, %arg1: tensor<1xf32> {ttir.name = "input_1_add_152"}, %arg2: tensor<1x11x32xf32> {ttir.name = "input_0_unsqueeze_162"}, %arg3: tensor<1x32x32x64xf32> {ttir.name = "dc.input_tensor.index_172.2"}, %arg4: tensor<1xf32> {ttir.name = "input_1_multiply_173"}, %arg5: tensor<1x32x32x64xf32> {ttir.name = "dc.input_tensor.index_174.2"}, %arg6: tensor<1x8x32x64xf32> {ttir.name = "dc.input_tensor.index_186.2"}, %arg7: tensor<1xf32> {ttir.name = "input_1_multiply_187"}, %arg8: tensor<1x8x32x64xf32> {ttir.name = "dc.input_tensor.index_188.2"}, %arg9: tensor<1xf32> {ttir.name = "input_1_multiply_199"}, %arg10: tensor<1x1x11x11xf32> {ttir.name = "input_1_add_200"}, %arg11: tensor<1xf32> {ttir.name = "input_1_add_225"}, %arg12: tensor<1xf32> {ttir.name = "input_1_add_245"}, %arg13: tensor<1x32x32x64xf32> {ttir.name = "dc.input_tensor.index_256.2"}, %arg14: tensor<1xf32> {ttir.name = "input_1_multiply_257"}, %arg15: tensor<1x32x32x64xf32> {ttir.name = "dc.input_tensor.index_258.2"}, %arg16: tensor<1x8x32x64xf32> {ttir.name = "dc.input_tensor.index_268.2"}, %arg17: tensor<1xf32> {ttir.name = "input_1_multiply_269"}, %arg18: tensor<1x8x32x64xf32> {ttir.name = "dc.input_tensor.index_270.2"}, %arg19: tensor<1xf32> {ttir.name = "input_1_multiply_281"}, %arg20: tensor<1x1x11x11xf32> {ttir.name = "input_1_add_282"}, %arg21: tensor<1xf32> {ttir.name = "input_1_add_307"}, %arg22: tensor<1xf32> {ttir.name = "input_1_add_327"}, %arg23: tensor<1x32x32x64xf32> {ttir.name = "dc.input_tensor.index_338.2"}, %arg24: tensor<1xf32> {ttir.name = "input_1_multiply_339"}, %arg25: tensor<1x32x32x64xf32> {ttir.name = "dc.input_tensor.index_340.2"}, %arg26: tensor<1x8x32x64xf32> {ttir.name = "dc.input_tensor.index_350.2"}, %arg27: tensor<1xf32> {ttir.name = "input_1_multiply_351"}, %arg28: tensor<1x8x32x64xf32> {ttir.name = "dc.input_tensor.index_352.2"}, %arg29: tensor<1xf32> {ttir.name = "input_1_multiply_363"}, %arg30: tensor<1x1x11x11xf32> {ttir.name = "input_1_add_364"}, %arg31: tensor<1xf32> {ttir.name = "input_1_add_389"}, %arg32: tensor<1xf32> {ttir.name = "input_1_add_409"}, %arg33: tensor<1x32x32x64xf32> {ttir.name = "dc.input_tensor.index_420.2"}, %arg34: tensor<1xf32> {ttir.name = "input_1_multiply_421"}, %arg35: tensor<1x32x32x64xf32> {ttir.name = "dc.input_tensor.index_422.2"}, %arg36: tensor<1x8x32x64xf32> {ttir.name = "dc.input_tensor.index_432.2"}, %arg37: tensor<1xf32> {ttir.name = "input_1_multiply_433"}, %arg38: tensor<1x8x32x64xf32> {ttir.name = "dc.input_tensor.index_434.2"}, %arg39: tensor<1xf32> {ttir.name = "input_1_multiply_445"}, %arg40: tensor<1x1x11x11xf32> {ttir.name = "input_1_add_446"}, %arg41: tensor<1xf32> {ttir.name = "input_1_add_471"}, %arg42: tensor<1xf32> {ttir.name = "input_1_add_491"}, %arg43: tensor<1x32x32x64xf32> {ttir.name = "dc.input_tensor.index_502.2"}, %arg44: tensor<1xf32> {ttir.name = "input_1_multiply_503"}, %arg45: tensor<1x32x32x64xf32> {ttir.name = "dc.input_tensor.index_504.2"}, %arg46: tensor<1x8x32x64xf32> {ttir.name = "dc.input_tensor.index_514.2"}, %arg47: tensor<1xf32> {ttir.name = "input_1_multiply_515"}, %arg48: tensor<1x8x32x64xf32> {ttir.name = "dc.input_tensor.index_516.2"}, %arg49: tensor<1xf32> {ttir.name = "input_1_multiply_527"}, %arg50: tensor<1x1x11x11xf32> {ttir.name = "input_1_add_528"}, %arg51: tensor<1xf32> {ttir.name = "input_1_add_553"}, %arg52: tensor<1xf32> {ttir.name = "input_1_add_573"}, %arg53: tensor<1x32x32x64xf32> {ttir.name = "dc.input_tensor.index_584.2"}, %arg54: tensor<1xf32> {ttir.name = "input_1_multiply_585"}, %arg55: tensor<1x32x32x64xf32> {ttir.name = "dc.input_tensor.index_586.2"}, %arg56: tensor<1x8x32x64xf32> {ttir.name = "dc.input_tensor.index_596.2"}, %arg57: tensor<1xf32> {ttir.name = "input_1_multiply_597"}, %arg58: tensor<1x8x32x64xf32> {ttir.name = "dc.input_tensor.index_598.2"}, %arg59: tensor<1xf32> {ttir.name = "input_1_multiply_609"}, %arg60: tensor<1x1x11x11xf32> {ttir.name = "input_1_add_610"}, %arg61: tensor<1xf32> {ttir.name = "input_1_add_635"}, %arg62: tensor<1xf32> {ttir.name = "input_1_add_655"}, %arg63: tensor<1x32x32x64xf32> {ttir.name = "dc.input_tensor.index_666.2"}, %arg64: tensor<1xf32> {ttir.name = "input_1_multiply_667"}, %arg65: tensor<1x32x32x64xf32> {ttir.name = "dc.input_tensor.index_668.2"}, %arg66: tensor<1x8x32x64xf32> {ttir.name = "dc.input_tensor.index_678.2"}, %arg67: tensor<1xf32> {ttir.name = "input_1_multiply_679"}, %arg68: tensor<1x8x32x64xf32> {ttir.name = "dc.input_tensor.index_680.2"}, %arg69: tensor<1xf32> {ttir.name = "input_1_multiply_691"}, %arg70: tensor<1x1x11x11xf32> {ttir.name = "input_1_add_692"}, %arg71: tensor<1xf32> {ttir.name = "input_1_add_717"}, %arg72: tensor<1xf32> {ttir.name = "input_1_add_737"}, %arg73: tensor<1x32x32x64xf32> {ttir.name = "dc.input_tensor.index_748.2"}, %arg74: tensor<1xf32> {ttir.name = "input_1_multiply_749"}, %arg75: tensor<1x32x32x64xf32> {ttir.name = "dc.input_tensor.index_750.2"}, %arg76: tensor<1x8x32x64xf32> {ttir.name = "dc.input_tensor.index_760.2"}, %arg77: tensor<1xf32> {ttir.name = "input_1_multiply_761"}, %arg78: tensor<1x8x32x64xf32> {ttir.name = "dc.input_tensor.index_762.2"}, %arg79: tensor<1xf32> {ttir.name = "input_1_multiply_773"}, %arg80: tensor<1x1x11x11xf32> {ttir.name = "input_1_add_774"}, %arg81: tensor<1xf32> {ttir.name = "input_1_add_799"}, %arg82: tensor<1xf32> {ttir.name = "input_1_add_819"}, %arg83: tensor<1x32x32x64xf32> {ttir.name = "dc.input_tensor.index_830.2"}, %arg84: tensor<1xf32> {ttir.name = "input_1_multiply_831"}, %arg85: tensor<1x32x32x64xf32> {ttir.name = "dc.input_tensor.index_832.2"}, %arg86: tensor<1x8x32x64xf32> {ttir.name = "dc.input_tensor.index_842.2"}, %arg87: tensor<1xf32> {ttir.name = "input_1_multiply_843"}, %arg88: tensor<1x8x32x64xf32> {ttir.name = "dc.input_tensor.index_844.2"}, %arg89: tensor<1xf32> {ttir.name = "input_1_multiply_855"}, %arg90: tensor<1x1x11x11xf32> {ttir.name = "input_1_add_856"}, %arg91: tensor<1xf32> {ttir.name = "input_1_add_881"}, %arg92: tensor<1xf32> {ttir.name = "input_1_add_901"}, %arg93: tensor<1x32x32x64xf32> {ttir.name = "dc.input_tensor.index_912.2"}, %arg94: tensor<1xf32> {ttir.name = "input_1_multiply_913"}, %arg95: tensor<1x32x32x64xf32> {ttir.name = "dc.input_tensor.index_914.2"}, %arg96: tensor<1x8x32x64xf32> {ttir.name = "dc.input_tensor.index_924.2"}, %arg97: tensor<1xf32> {ttir.name = "input_1_multiply_925"}, %arg98: tensor<1x8x32x64xf32> {ttir.name = "dc.input_tensor.index_926.2"}, %arg99: tensor<1xf32> {ttir.name = "input_1_multiply_937"}, %arg100: tensor<1x1x11x11xf32> {ttir.name = "input_1_add_938"}, %arg101: tensor<1xf32> {ttir.name = "input_1_add_963"}, %arg102: tensor<1xf32> {ttir.name = "input_1_add_983"}, %arg103: tensor<1x32x32x64xf32> {ttir.name = "dc.input_tensor.index_994.2"}, %arg104: tensor<1xf32> {ttir.name = "input_1_multiply_995"}, %arg105: tensor<1x32x32x64xf32> {ttir.name = "dc.input_tensor.index_996.2"}, %arg106: tensor<1x8x32x64xf32> {ttir.name = "dc.input_tensor.index_1006.2"}, %arg107: tensor<1xf32> {ttir.name = "input_1_multiply_1007"}, %arg108: tensor<1x8x32x64xf32> {ttir.name = "dc.input_tensor.index_1008.2"}, %arg109: tensor<1xf32> {ttir.name = "input_1_multiply_1019"}, %arg110: tensor<1x1x11x11xf32> {ttir.name = "input_1_add_1020"}, %arg111: tensor<1xf32> {ttir.name = "input_1_add_1045"}, %arg112: tensor<1xf32> {ttir.name = "input_1_add_1065"}, %arg113: tensor<1x32x32x64xf32> {ttir.name = "dc.input_tensor.index_1076.2"}, %arg114: tensor<1xf32> {ttir.name = "input_1_multiply_1077"}, %arg115: tensor<1x32x32x64xf32> {ttir.name = "dc.input_tensor.index_1078.2"}, %arg116: tensor<1x8x32x64xf32> {ttir.name = "dc.input_tensor.index_1088.2"}, %arg117: tensor<1xf32> {ttir.name = "input_1_multiply_1089"}, %arg118: tensor<1x8x32x64xf32> {ttir.name = "dc.input_tensor.index_1090.2"}, %arg119: tensor<1xf32> {ttir.name = "input_1_multiply_1101"}, %arg120: tensor<1x1x11x11xf32> {ttir.name = "input_1_add_1102"}, %arg121: tensor<1xf32> {ttir.name = "input_1_add_1127"}, %arg122: tensor<1xf32> {ttir.name = "input_1_add_1147"}, %arg123: tensor<1x32x32x64xf32> {ttir.name = "dc.input_tensor.index_1158.2"}, %arg124: tensor<1xf32> {ttir.name = "input_1_multiply_1159"}, %arg125: tensor<1x32x32x64xf32> {ttir.name = "dc.input_tensor.index_1160.2"}, %arg126: tensor<1x8x32x64xf32> {ttir.name = "dc.input_tensor.index_1170.2"}, %arg127: tensor<1xf32> {ttir.name = "input_1_multiply_1171"}, %arg128: tensor<1x8x32x64xf32> {ttir.name = "dc.input_tensor.index_1172.2"}, %arg129: tensor<1xf32> {ttir.name = "input_1_multiply_1183"}, %arg130: tensor<1x1x11x11xf32> {ttir.name = "input_1_add_1184"}, %arg131: tensor<1xf32> {ttir.name = "input_1_add_1209"}, %arg132: tensor<1xf32> {ttir.name = "input_1_add_1229"}, %arg133: tensor<1x32x32x64xf32> {ttir.name = "dc.input_tensor.index_1240.2"}, %arg134: tensor<1xf32> {ttir.name = "input_1_multiply_1241"}, %arg135: tensor<1x32x32x64xf32> {ttir.name = "dc.input_tensor.index_1242.2"}, %arg136: tensor<1x8x32x64xf32> {ttir.name = "dc.input_tensor.index_1252.2"}, %arg137: tensor<1xf32> {ttir.name = "input_1_multiply_1253"}, %arg138: tensor<1x8x32x64xf32> {ttir.name = "dc.input_tensor.index_1254.2"}, %arg139: tensor<1xf32> {ttir.name = "input_1_multiply_1265"}, %arg140: tensor<1x1x11x11xf32> {ttir.name = "input_1_add_1266"}, %arg141: tensor<1xf32> {ttir.name = "input_1_add_1291"}, %arg142: tensor<1xf32> {ttir.name = "input_1_add_1311"}, %arg143: tensor<1x32x32x64xf32> {ttir.name = "dc.input_tensor.index_1322.2"}, %arg144: tensor<1xf32> {ttir.name = "input_1_multiply_1323"}, %arg145: tensor<1x32x32x64xf32> {ttir.name = "dc.input_tensor.index_1324.2"}, %arg146: tensor<1x8x32x64xf32> {ttir.name = "dc.input_tensor.index_1334.2"}, %arg147: tensor<1xf32> {ttir.name = "input_1_multiply_1335"}, %arg148: tensor<1x8x32x64xf32> {ttir.name = "dc.input_tensor.index_1336.2"}, %arg149: tensor<1xf32> {ttir.name = "input_1_multiply_1347"}, %arg150: tensor<1x1x11x11xf32> {ttir.name = "input_1_add_1348"}, %arg151: tensor<1xf32> {ttir.name = "input_1_add_1373"}, %arg152: tensor<1xf32> {ttir.name = "input_1_add_1393"}, %arg153: tensor<1x32x32x64xf32> {ttir.name = "dc.input_tensor.index_1404.2"}, %arg154: tensor<1xf32> {ttir.name = "input_1_multiply_1405"}, %arg155: tensor<1x32x32x64xf32> {ttir.name = "dc.input_tensor.index_1406.2"}, %arg156: tensor<1x8x32x64xf32> {ttir.name = "dc.input_tensor.index_1416.2"}, %arg157: tensor<1xf32> {ttir.name = "input_1_multiply_1417"}, %arg158: tensor<1x8x32x64xf32> {ttir.name = "dc.input_tensor.index_1418.2"}, %arg159: tensor<1xf32> {ttir.name = "input_1_multiply_1429"}, %arg160: tensor<1x1x11x11xf32> {ttir.name = "input_1_add_1430"}, %arg161: tensor<1xf32> {ttir.name = "input_1_add_1455"}, %arg162: tensor<1xf32> {ttir.name = "input_1_add_1475"}, %arg163: tensor<2048xf32> {ttir.name = "norm.weight"}, %arg164: tensor<128256x2048xbf16> {ttir.name = "embed_tokens.weight"}, %arg165: tensor<2048xf32> {ttir.name = "layers.0.input_layernorm.weight"}, %arg166: tensor<2048x2048xf32> {ttir.name = "layers.0.self_attn.q_proj.weight"}, %arg167: tensor<2048x512xf32> {ttir.name = "layers.0.self_attn.k_proj.weight"}, %arg168: tensor<2048x512xf32> {ttir.name = "layers.0.self_attn.v_proj.weight"}, %arg169: tensor<2048x2048xf32> {ttir.name = "layers.0.self_attn.o_proj.weight"}, %arg170: tensor<2048xf32> {ttir.name = "layers.0.post_attention_layernorm.weight"}, %arg171: tensor<2048x8192xf32> {ttir.name = "layers.0.mlp.gate_proj.weight"}, %arg172: tensor<2048x8192xf32> {ttir.name = "layers.0.mlp.up_proj.weight"}, %arg173: tensor<8192x2048xf32> {ttir.name = "layers.0.mlp.down_proj.weight"}, %arg174: tensor<2048xf32> {ttir.name = "layers.1.input_layernorm.weight"}, %arg175: tensor<2048x2048xf32> {ttir.name = "layers.1.self_attn.q_proj.weight"}, %arg176: tensor<2048x512xf32> {ttir.name = "layers.1.self_attn.k_proj.weight"}, %arg177: tensor<2048x512xf32> {ttir.name = "layers.1.self_attn.v_proj.weight"}, %arg178: tensor<2048x2048xf32> {ttir.name = "layers.1.self_attn.o_proj.weight"}, %arg179: tensor<2048xf32> {ttir.name = "layers.1.post_attention_layernorm.weight"}, %arg180: tensor<2048x8192xf32> {ttir.name = "layers.1.mlp.gate_proj.weight"}, %arg181: tensor<2048x8192xf32> {ttir.name = "layers.1.mlp.up_proj.weight"}, %arg182: tensor<8192x2048xf32> {ttir.name = "layers.1.mlp.down_proj.weight"}, %arg183: tensor<2048xf32> {ttir.name = "layers.2.input_layernorm.weight"}, %arg184: tensor<2048x2048xf32> {ttir.name = "layers.2.self_attn.q_proj.weight"}, %arg185: tensor<2048x512xf32> {ttir.name = "layers.2.self_attn.k_proj.weight"}, %arg186: tensor<2048x512xf32> {ttir.name = "layers.2.self_attn.v_proj.weight"}, %arg187: tensor<2048x2048xf32> {ttir.name = "layers.2.self_attn.o_proj.weight"}, %arg188: tensor<2048xf32> {ttir.name = "layers.2.post_attention_layernorm.weight"}, %arg189: tensor<2048x8192xf32> {ttir.name = "layers.2.mlp.gate_proj.weight"}, %arg190: tensor<2048x8192xf32> {ttir.name = "layers.2.mlp.up_proj.weight"}, %arg191: tensor<8192x2048xf32> {ttir.name = "layers.2.mlp.down_proj.weight"}, %arg192: tensor<2048xf32> {ttir.name = "layers.3.input_layernorm.weight"}, %arg193: tensor<2048x2048xf32> {ttir.name = "layers.3.self_attn.q_proj.weight"}, %arg194: tensor<2048x512xf32> {ttir.name = "layers.3.self_attn.k_proj.weight"}, %arg195: tensor<2048x512xf32> {ttir.name = "layers.3.self_attn.v_proj.weight"}, %arg196: tensor<2048x2048xf32> {ttir.name = "layers.3.self_attn.o_proj.weight"}, %arg197: tensor<2048xf32> {ttir.name = "layers.3.post_attention_layernorm.weight"}, %arg198: tensor<2048x8192xf32> {ttir.name = "layers.3.mlp.gate_proj.weight"}, %arg199: tensor<2048x8192xf32> {ttir.name = "layers.3.mlp.up_proj.weight"}, %arg200: tensor<8192x2048xf32> {ttir.name = "layers.3.mlp.down_proj.weight"}, %arg201: tensor<2048xf32> {ttir.name = "layers.4.input_layernorm.weight"}, %arg202: tensor<2048x2048xf32> {ttir.name = "layers.4.self_attn.q_proj.weight"}, %arg203: tensor<2048x512xf32> {ttir.name = "layers.4.self_attn.k_proj.weight"}, %arg204: tensor<2048x512xf32> {ttir.name = "layers.4.self_attn.v_proj.weight"}, %arg205: tensor<2048x2048xf32> {ttir.name = "layers.4.self_attn.o_proj.weight"}, %arg206: tensor<2048xf32> {ttir.name = "layers.4.post_attention_layernorm.weight"}, %arg207: tensor<2048x8192xf32> {ttir.name = "layers.4.mlp.gate_proj.weight"}, %arg208: tensor<2048x8192xf32> {ttir.name = "layers.4.mlp.up_proj.weight"}, %arg209: tensor<8192x2048xf32> {ttir.name = "layers.4.mlp.down_proj.weight"}, %arg210: tensor<2048xf32> {ttir.name = "layers.5.input_layernorm.weight"}, %arg211: tensor<2048x2048xf32> {ttir.name = "layers.5.self_attn.q_proj.weight"}, %arg212: tensor<2048x512xf32> {ttir.name = "layers.5.self_attn.k_proj.weight"}, %arg213: tensor<2048x512xf32> {ttir.name = "layers.5.self_attn.v_proj.weight"}, %arg214: tensor<2048x2048xf32> {ttir.name = "layers.5.self_attn.o_proj.weight"}, %arg215: tensor<2048xf32> {ttir.name = "layers.5.post_attention_layernorm.weight"}, %arg216: tensor<2048x8192xf32> {ttir.name = "layers.5.mlp.gate_proj.weight"}, %arg217: tensor<2048x8192xf32> {ttir.name = "layers.5.mlp.up_proj.weight"}, %arg218: tensor<8192x2048xf32> {ttir.name = "layers.5.mlp.down_proj.weight"}, %arg219: tensor<2048xf32> {ttir.name = "layers.6.input_layernorm.weight"}, %arg220: tensor<2048x2048xf32> {ttir.name = "layers.6.self_attn.q_proj.weight"}, %arg221: tensor<2048x512xf32> {ttir.name = "layers.6.self_attn.k_proj.weight"}, %arg222: tensor<2048x512xf32> {ttir.name = "layers.6.self_attn.v_proj.weight"}, %arg223: tensor<2048x2048xf32> {ttir.name = "layers.6.self_attn.o_proj.weight"}, %arg224: tensor<2048xf32> {ttir.name = "layers.6.post_attention_layernorm.weight"}, %arg225: tensor<2048x8192xf32> {ttir.name = "layers.6.mlp.gate_proj.weight"}, %arg226: tensor<2048x8192xf32> {ttir.name = "layers.6.mlp.up_proj.weight"}, %arg227: tensor<8192x2048xf32> {ttir.name = "layers.6.mlp.down_proj.weight"}, %arg228: tensor<2048xf32> {ttir.name = "layers.7.input_layernorm.weight"}, %arg229: tensor<2048x2048xf32> {ttir.name = "layers.7.self_attn.q_proj.weight"}, %arg230: tensor<2048x512xf32> {ttir.name = "layers.7.self_attn.k_proj.weight"}, %arg231: tensor<2048x512xf32> {ttir.name = "layers.7.self_attn.v_proj.weight"}, %arg232: tensor<2048x2048xf32> {ttir.name = "layers.7.self_attn.o_proj.weight"}, %arg233: tensor<2048xf32> {ttir.name = "layers.7.post_attention_layernorm.weight"}, %arg234: tensor<2048x8192xf32> {ttir.name = "layers.7.mlp.gate_proj.weight"}, %arg235: tensor<2048x8192xf32> {ttir.name = "layers.7.mlp.up_proj.weight"}, %arg236: tensor<8192x2048xf32> {ttir.name = "layers.7.mlp.down_proj.weight"}, %arg237: tensor<2048xf32> {ttir.name = "layers.8.input_layernorm.weight"}, %arg238: tensor<2048x2048xf32> {ttir.name = "layers.8.self_attn.q_proj.weight"}, %arg239: tensor<2048x512xf32> {ttir.name = "layers.8.self_attn.k_proj.weight"}, %arg240: tensor<2048x512xf32> {ttir.name = "layers.8.self_attn.v_proj.weight"}, %arg241: tensor<2048x2048xf32> {ttir.name = "layers.8.self_attn.o_proj.weight"}, %arg242: tensor<2048xf32> {ttir.name = "layers.8.post_attention_layernorm.weight"}, %arg243: tensor<2048x8192xf32> {ttir.name = "layers.8.mlp.gate_proj.weight"}, %arg244: tensor<2048x8192xf32> {ttir.name = "layers.8.mlp.up_proj.weight"}, %arg245: tensor<8192x2048xf32> {ttir.name = "layers.8.mlp.down_proj.weight"}, %arg246: tensor<2048xf32> {ttir.name = "layers.9.input_layernorm.weight"}, %arg247: tensor<2048x2048xf32> {ttir.name = "layers.9.self_attn.q_proj.weight"}, %arg248: tensor<2048x512xf32> {ttir.name = "layers.9.self_attn.k_proj.weight"}, %arg249: tensor<2048x512xf32> {ttir.name = "layers.9.self_attn.v_proj.weight"}, %arg250: tensor<2048x2048xf32> {ttir.name = "layers.9.self_attn.o_proj.weight"}, %arg251: tensor<2048xf32> {ttir.name = "layers.9.post_attention_layernorm.weight"}, %arg252: tensor<2048x8192xf32> {ttir.name = "layers.9.mlp.gate_proj.weight"}, %arg253: tensor<2048x8192xf32> {ttir.name = "layers.9.mlp.up_proj.weight"}, %arg254: tensor<8192x2048xf32> {ttir.name = "layers.9.mlp.down_proj.weight"}, %arg255: tensor<2048xf32> {ttir.name = "layers.10.input_layernorm.weight"}, %arg256: tensor<2048x2048xf32> {ttir.name = "layers.10.self_attn.q_proj.weight"}, %arg257: tensor<2048x512xf32> {ttir.name = "layers.10.self_attn.k_proj.weight"}, %arg258: tensor<2048x512xf32> {ttir.name = "layers.10.self_attn.v_proj.weight"}, %arg259: tensor<2048x2048xf32> {ttir.name = "layers.10.self_attn.o_proj.weight"}, %arg260: tensor<2048xf32> {ttir.name = "layers.10.post_attention_layernorm.weight"}, %arg261: tensor<2048x8192xf32> {ttir.name = "layers.10.mlp.gate_proj.weight"}, %arg262: tensor<2048x8192xf32> {ttir.name = "layers.10.mlp.up_proj.weight"}, %arg263: tensor<8192x2048xf32> {ttir.name = "layers.10.mlp.down_proj.weight"}, %arg264: tensor<2048xf32> {ttir.name = "layers.11.input_layernorm.weight"}, %arg265: tensor<2048x2048xf32> {ttir.name = "layers.11.self_attn.q_proj.weight"}, %arg266: tensor<2048x512xf32> {ttir.name = "layers.11.self_attn.k_proj.weight"}, %arg267: tensor<2048x512xf32> {ttir.name = "layers.11.self_attn.v_proj.weight"}, %arg268: tensor<2048x2048xf32> {ttir.name = "layers.11.self_attn.o_proj.weight"}, %arg269: tensor<2048xf32> {ttir.name = "layers.11.post_attention_layernorm.weight"}, %arg270: tensor<2048x8192xf32> {ttir.name = "layers.11.mlp.gate_proj.weight"}, %arg271: tensor<2048x8192xf32> {ttir.name = "layers.11.mlp.up_proj.weight"}, %arg272: tensor<8192x2048xf32> {ttir.name = "layers.11.mlp.down_proj.weight"}, %arg273: tensor<2048xf32> {ttir.name = "layers.12.input_layernorm.weight"}, %arg274: tensor<2048x2048xf32> {ttir.name = "layers.12.self_attn.q_proj.weight"}, %arg275: tensor<2048x512xf32> {ttir.name = "layers.12.self_attn.k_proj.weight"}, %arg276: tensor<2048x512xf32> {ttir.name = "layers.12.self_attn.v_proj.weight"}, %arg277: tensor<2048x2048xf32> {ttir.name = "layers.12.self_attn.o_proj.weight"}, %arg278: tensor<2048xf32> {ttir.name = "layers.12.post_attention_layernorm.weight"}, %arg279: tensor<2048x8192xf32> {ttir.name = "layers.12.mlp.gate_proj.weight"}, %arg280: tensor<2048x8192xf32> {ttir.name = "layers.12.mlp.up_proj.weight"}, %arg281: tensor<8192x2048xf32> {ttir.name = "layers.12.mlp.down_proj.weight"}, %arg282: tensor<2048xf32> {ttir.name = "layers.13.input_layernorm.weight"}, %arg283: tensor<2048x2048xf32> {ttir.name = "layers.13.self_attn.q_proj.weight"}, %arg284: tensor<2048x512xf32> {ttir.name = "layers.13.self_attn.k_proj.weight"}, %arg285: tensor<2048x512xf32> {ttir.name = "layers.13.self_attn.v_proj.weight"}, %arg286: tensor<2048x2048xf32> {ttir.name = "layers.13.self_attn.o_proj.weight"}, %arg287: tensor<2048xf32> {ttir.name = "layers.13.post_attention_layernorm.weight"}, %arg288: tensor<2048x8192xf32> {ttir.name = "layers.13.mlp.gate_proj.weight"}, %arg289: tensor<2048x8192xf32> {ttir.name = "layers.13.mlp.up_proj.weight"}, %arg290: tensor<8192x2048xf32> {ttir.name = "layers.13.mlp.down_proj.weight"}, %arg291: tensor<2048xf32> {ttir.name = "layers.14.input_layernorm.weight"}, %arg292: tensor<2048x2048xf32> {ttir.name = "layers.14.self_attn.q_proj.weight"}, %arg293: tensor<2048x512xf32> {ttir.name = "layers.14.self_attn.k_proj.weight"}, %arg294: tensor<2048x512xf32> {ttir.name = "layers.14.self_attn.v_proj.weight"}, %arg295: tensor<2048x2048xf32> {ttir.name = "layers.14.self_attn.o_proj.weight"}, %arg296: tensor<2048xf32> {ttir.name = "layers.14.post_attention_layernorm.weight"}, %arg297: tensor<2048x8192xf32> {ttir.name = "layers.14.mlp.gate_proj.weight"}, %arg298: tensor<2048x8192xf32> {ttir.name = "layers.14.mlp.up_proj.weight"}, %arg299: tensor<8192x2048xf32> {ttir.name = "layers.14.mlp.down_proj.weight"}, %arg300: tensor<2048xf32> {ttir.name = "layers.15.input_layernorm.weight"}, %arg301: tensor<2048x2048xf32> {ttir.name = "layers.15.self_attn.q_proj.weight"}, %arg302: tensor<2048x512xf32> {ttir.name = "layers.15.self_attn.k_proj.weight"}, %arg303: tensor<2048x512xf32> {ttir.name = "layers.15.self_attn.v_proj.weight"}, %arg304: tensor<2048x2048xf32> {ttir.name = "layers.15.self_attn.o_proj.weight"}, %arg305: tensor<2048xf32> {ttir.name = "layers.15.post_attention_layernorm.weight"}, %arg306: tensor<2048x8192xf32> {ttir.name = "layers.15.mlp.gate_proj.weight"}, %arg307: tensor<2048x8192xf32> {ttir.name = "layers.15.mlp.up_proj.weight"}, %arg308: tensor<8192x2048xf32> {ttir.name = "layers.15.mlp.down_proj.weight"}) -> (tensor<1x11x2048xf32> {ttir.name = "LlamaModel.output_multiply_1479"}) {
+    %0 = tensor.empty() : tensor<1x11x2048xbf16>
+    %1 = "ttir.embedding"(%arg0, %arg164, %0) : (tensor<1x11xi32>, tensor<128256x2048xbf16>, tensor<1x11x2048xbf16>) -> tensor<1x11x2048xbf16>
+    %2 = tensor.empty() : tensor<1x11x2048xf32>
+    %3 = "ttir.typecast"(%1, %2) <{operandSegmentSizes = array<i32: 1, 1>}> {dtype = "Float32"} : (tensor<1x11x2048xbf16>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %4 = tensor.empty() : tensor<1x11x2048xf32>
+    %5 = "ttir.typecast"(%1, %4) <{operandSegmentSizes = array<i32: 1, 1>}> {dtype = "Float32"} : (tensor<1x11x2048xbf16>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %6 = tensor.empty() : tensor<1x11x2048xf32>
+    %7 = "ttir.typecast"(%1, %6) <{operandSegmentSizes = array<i32: 1, 1>}> {dtype = "Float32"} : (tensor<1x11x2048xbf16>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %8 = tensor.empty() : tensor<1x11x2048xf32>
+    %9 = "ttir.multiply"(%7, %7, %8) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %10 = tensor.empty() : tensor<1x11x1xf32>
+    %11 = "ttir.mean"(%9, %10) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %12 = tensor.empty() : tensor<1x11x1xf32>
+    %13 = "ttir.add"(%11, %arg1, %12) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %14 = tensor.empty() : tensor<1x11x1xf32>
+    %15 = "ttir.sqrt"(%13, %14) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %16 = tensor.empty() : tensor<1x11x1xf32>
+    %17 = "ttir.reciprocal"(%15, %16) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %18 = tensor.empty() : tensor<1x11x2048xf32>
+    %19 = "ttir.multiply"(%5, %17, %18) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %20 = tensor.empty() : tensor<1x11x2048xf32>
+    %21 = "ttir.multiply"(%arg165, %19, %20) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %22 = tensor.empty() : tensor<11x2048xf32>
+    %23 = "ttir.squeeze"(%21, %22) <{dim = 0 : si32}> : (tensor<1x11x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %24 = tensor.empty() : tensor<11x2048xf32>
+    %25 = "ttir.matmul"(%23, %arg166, %24) : (tensor<11x2048xf32>, tensor<2048x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %26 = tensor.empty() : tensor<1x11x32x64xf32>
+    %27 = "ttir.reshape"(%25, %26) <{shape = [1 : i32, 11 : i32, 32 : i32, 64 : i32]}> : (tensor<11x2048xf32>, tensor<1x11x32x64xf32>) -> tensor<1x11x32x64xf32>
+    %28 = tensor.empty() : tensor<1x32x11x64xf32>
+    %29 = "ttir.transpose"(%27, %28) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x32x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %30 = tensor.empty() : tensor<1x11x64xf32>
+    %31 = "ttir.concat"(%arg2, %arg2, %30) <{dim = -1 : si32}> : (tensor<1x11x32xf32>, tensor<1x11x32xf32>, tensor<1x11x64xf32>) -> tensor<1x11x64xf32>
+    %32 = tensor.empty() : tensor<1x11x64xf32>
+    %33 = "ttir.cos"(%31, %32) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x64xf32>, tensor<1x11x64xf32>) -> tensor<1x11x64xf32>
+    %34 = tensor.empty() : tensor<1x1x11x64xf32>
+    %35 = "ttir.unsqueeze"(%33, %34) <{dim = 1 : si32}> : (tensor<1x11x64xf32>, tensor<1x1x11x64xf32>) -> tensor<1x1x11x64xf32>
+    %36 = tensor.empty() : tensor<1x32x11x64xf32>
+    %37 = "ttir.multiply"(%29, %35, %36) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %38 = tensor.empty() : tensor<1x32x64x11xf32>
+    %39 = "ttir.transpose"(%29, %38) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %40 = tensor.empty() : tensor<1x32x32x11xf32>
+    %41 = "ttir.matmul"(%arg3, %39, %40) : (tensor<1x32x32x64xf32>, tensor<1x32x64x11xf32>, tensor<1x32x32x11xf32>) -> tensor<1x32x32x11xf32>
+    %42 = tensor.empty() : tensor<1x32x11x32xf32>
+    %43 = "ttir.transpose"(%41, %42) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x32x11xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %44 = tensor.empty() : tensor<1x32x11x32xf32>
+    %45 = "ttir.multiply"(%43, %arg4, %44) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x32xf32>, tensor<1xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %46 = tensor.empty() : tensor<1x32x64x11xf32>
+    %47 = "ttir.transpose"(%29, %46) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %48 = tensor.empty() : tensor<1x32x32x11xf32>
+    %49 = "ttir.matmul"(%arg5, %47, %48) : (tensor<1x32x32x64xf32>, tensor<1x32x64x11xf32>, tensor<1x32x32x11xf32>) -> tensor<1x32x32x11xf32>
+    %50 = tensor.empty() : tensor<1x32x11x32xf32>
+    %51 = "ttir.transpose"(%49, %50) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x32x11xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %52 = tensor.empty() : tensor<1x32x11x64xf32>
+    %53 = "ttir.concat"(%45, %51, %52) <{dim = -1 : si32}> : (tensor<1x32x11x32xf32>, tensor<1x32x11x32xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %54 = tensor.empty() : tensor<1x11x64xf32>
+    %55 = "ttir.sin"(%31, %54) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x64xf32>, tensor<1x11x64xf32>) -> tensor<1x11x64xf32>
+    %56 = tensor.empty() : tensor<1x1x11x64xf32>
+    %57 = "ttir.unsqueeze"(%55, %56) <{dim = 1 : si32}> : (tensor<1x11x64xf32>, tensor<1x1x11x64xf32>) -> tensor<1x1x11x64xf32>
+    %58 = tensor.empty() : tensor<1x32x11x64xf32>
+    %59 = "ttir.multiply"(%53, %57, %58) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %60 = tensor.empty() : tensor<1x32x11x64xf32>
+    %61 = "ttir.add"(%37, %59, %60) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x32x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %62 = tensor.empty() : tensor<32x11x64xf32>
+    %63 = "ttir.squeeze"(%61, %62) <{dim = 0 : si32}> : (tensor<1x32x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %64 = tensor.empty() : tensor<11x512xf32>
+    %65 = "ttir.matmul"(%23, %arg167, %64) : (tensor<11x2048xf32>, tensor<2048x512xf32>, tensor<11x512xf32>) -> tensor<11x512xf32>
+    %66 = tensor.empty() : tensor<1x11x8x64xf32>
+    %67 = "ttir.reshape"(%65, %66) <{shape = [1 : i32, 11 : i32, 8 : i32, 64 : i32]}> : (tensor<11x512xf32>, tensor<1x11x8x64xf32>) -> tensor<1x11x8x64xf32>
+    %68 = tensor.empty() : tensor<1x8x11x64xf32>
+    %69 = "ttir.transpose"(%67, %68) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x8x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %70 = tensor.empty() : tensor<1x8x11x64xf32>
+    %71 = "ttir.multiply"(%69, %35, %70) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %72 = tensor.empty() : tensor<1x8x64x11xf32>
+    %73 = "ttir.transpose"(%69, %72) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x64x11xf32>) -> tensor<1x8x64x11xf32>
+    %74 = tensor.empty() : tensor<1x8x32x11xf32>
+    %75 = "ttir.matmul"(%arg6, %73, %74) : (tensor<1x8x32x64xf32>, tensor<1x8x64x11xf32>, tensor<1x8x32x11xf32>) -> tensor<1x8x32x11xf32>
+    %76 = tensor.empty() : tensor<1x8x11x32xf32>
+    %77 = "ttir.transpose"(%75, %76) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x32x11xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %78 = tensor.empty() : tensor<1x8x11x32xf32>
+    %79 = "ttir.multiply"(%77, %arg7, %78) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x32xf32>, tensor<1xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %80 = tensor.empty() : tensor<1x8x64x11xf32>
+    %81 = "ttir.transpose"(%69, %80) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x64x11xf32>) -> tensor<1x8x64x11xf32>
+    %82 = tensor.empty() : tensor<1x8x32x11xf32>
+    %83 = "ttir.matmul"(%arg8, %81, %82) : (tensor<1x8x32x64xf32>, tensor<1x8x64x11xf32>, tensor<1x8x32x11xf32>) -> tensor<1x8x32x11xf32>
+    %84 = tensor.empty() : tensor<1x8x11x32xf32>
+    %85 = "ttir.transpose"(%83, %84) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x32x11xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %86 = tensor.empty() : tensor<1x8x11x64xf32>
+    %87 = "ttir.concat"(%79, %85, %86) <{dim = -1 : si32}> : (tensor<1x8x11x32xf32>, tensor<1x8x11x32xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %88 = tensor.empty() : tensor<1x8x11x64xf32>
+    %89 = "ttir.multiply"(%87, %57, %88) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %90 = tensor.empty() : tensor<1x8x11x64xf32>
+    %91 = "ttir.add"(%71, %89, %90) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x8x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %92 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %93 = "ttir.unsqueeze"(%91, %92) <{dim = 2 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %94 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %95 = "ttir.repeat_interleave"(%93, %94) <{dim = 0 : si32, repeats = 1 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %96 = tensor.empty() : tensor<1x8x4x11x64xf32>
+    %97 = "ttir.repeat_interleave"(%95, %96) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x4x11x64xf32>) -> tensor<1x8x4x11x64xf32>
+    %98 = tensor.empty() : tensor<32x11x64xf32>
+    %99 = "ttir.reshape"(%97, %98) <{shape = [32 : i32, 11 : i32, 64 : i32]}> : (tensor<1x8x4x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %100 = tensor.empty() : tensor<32x64x11xf32>
+    %101 = "ttir.transpose"(%99, %100) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x11x64xf32>, tensor<32x64x11xf32>) -> tensor<32x64x11xf32>
+    %102 = tensor.empty() : tensor<32x11x11xf32>
+    %103 = "ttir.matmul"(%63, %101, %102) : (tensor<32x11x64xf32>, tensor<32x64x11xf32>, tensor<32x11x11xf32>) -> tensor<32x11x11xf32>
+    %104 = tensor.empty() : tensor<1x32x11x11xf32>
+    %105 = "ttir.unsqueeze"(%103, %104) <{dim = 0 : si32}> : (tensor<32x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %106 = tensor.empty() : tensor<1x32x11x11xf32>
+    %107 = "ttir.multiply"(%105, %arg9, %106) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x11xf32>, tensor<1xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %108 = tensor.empty() : tensor<1x32x11x11xf32>
+    %109 = "ttir.add"(%107, %arg10, %108) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x11xf32>, tensor<1x1x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %110 = tensor.empty() : tensor<1x32x11x11xf32>
+    %111 = "ttir.softmax"(%109, %110) <{dimension = -1 : si32}> : (tensor<1x32x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %112 = tensor.empty() : tensor<32x11x11xf32>
+    %113 = "ttir.squeeze"(%111, %112) <{dim = 0 : si32}> : (tensor<1x32x11x11xf32>, tensor<32x11x11xf32>) -> tensor<32x11x11xf32>
+    %114 = tensor.empty() : tensor<11x512xf32>
+    %115 = "ttir.matmul"(%23, %arg168, %114) : (tensor<11x2048xf32>, tensor<2048x512xf32>, tensor<11x512xf32>) -> tensor<11x512xf32>
+    %116 = tensor.empty() : tensor<1x11x8x64xf32>
+    %117 = "ttir.reshape"(%115, %116) <{shape = [1 : i32, 11 : i32, 8 : i32, 64 : i32]}> : (tensor<11x512xf32>, tensor<1x11x8x64xf32>) -> tensor<1x11x8x64xf32>
+    %118 = tensor.empty() : tensor<1x8x11x64xf32>
+    %119 = "ttir.transpose"(%117, %118) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x8x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %120 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %121 = "ttir.unsqueeze"(%119, %120) <{dim = 2 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %122 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %123 = "ttir.repeat_interleave"(%121, %122) <{dim = 0 : si32, repeats = 1 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %124 = tensor.empty() : tensor<1x8x4x11x64xf32>
+    %125 = "ttir.repeat_interleave"(%123, %124) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x4x11x64xf32>) -> tensor<1x8x4x11x64xf32>
+    %126 = tensor.empty() : tensor<1x32x11x64xf32>
+    %127 = "ttir.reshape"(%125, %126) <{shape = [1 : i32, 32 : i32, 11 : i32, 64 : i32]}> : (tensor<1x8x4x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %128 = tensor.empty() : tensor<1x32x64x11xf32>
+    %129 = "ttir.transpose"(%127, %128) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %130 = tensor.empty() : tensor<32x64x11xf32>
+    %131 = "ttir.squeeze"(%129, %130) <{dim = 0 : si32}> : (tensor<1x32x64x11xf32>, tensor<32x64x11xf32>) -> tensor<32x64x11xf32>
+    %132 = tensor.empty() : tensor<32x11x64xf32>
+    %133 = "ttir.transpose"(%131, %132) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x64x11xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %134 = tensor.empty() : tensor<32x11x64xf32>
+    %135 = "ttir.matmul"(%113, %133, %134) : (tensor<32x11x11xf32>, tensor<32x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %136 = tensor.empty() : tensor<1x32x11x64xf32>
+    %137 = "ttir.unsqueeze"(%135, %136) <{dim = 0 : si32}> : (tensor<32x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %138 = tensor.empty() : tensor<1x11x32x64xf32>
+    %139 = "ttir.transpose"(%137, %138) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x11x32x64xf32>) -> tensor<1x11x32x64xf32>
+    %140 = tensor.empty() : tensor<11x2048xf32>
+    %141 = "ttir.reshape"(%139, %140) <{shape = [11 : i32, 2048 : i32]}> : (tensor<1x11x32x64xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %142 = tensor.empty() : tensor<11x2048xf32>
+    %143 = "ttir.matmul"(%141, %arg169, %142) : (tensor<11x2048xf32>, tensor<2048x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %144 = tensor.empty() : tensor<1x11x2048xf32>
+    %145 = "ttir.unsqueeze"(%143, %144) <{dim = 0 : si32}> : (tensor<11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %146 = tensor.empty() : tensor<1x11x2048xf32>
+    %147 = "ttir.add"(%3, %145, %146) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %148 = tensor.empty() : tensor<1x11x2048xf32>
+    %149 = "ttir.multiply"(%147, %147, %148) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %150 = tensor.empty() : tensor<1x11x1xf32>
+    %151 = "ttir.mean"(%149, %150) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %152 = tensor.empty() : tensor<1x11x1xf32>
+    %153 = "ttir.add"(%151, %arg11, %152) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %154 = tensor.empty() : tensor<1x11x1xf32>
+    %155 = "ttir.sqrt"(%153, %154) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %156 = tensor.empty() : tensor<1x11x1xf32>
+    %157 = "ttir.reciprocal"(%155, %156) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %158 = tensor.empty() : tensor<1x11x2048xf32>
+    %159 = "ttir.multiply"(%147, %157, %158) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %160 = tensor.empty() : tensor<1x11x2048xf32>
+    %161 = "ttir.multiply"(%arg170, %159, %160) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %162 = tensor.empty() : tensor<11x2048xf32>
+    %163 = "ttir.squeeze"(%161, %162) <{dim = 0 : si32}> : (tensor<1x11x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %164 = tensor.empty() : tensor<11x8192xf32>
+    %165 = "ttir.matmul"(%163, %arg171, %164) : (tensor<11x2048xf32>, tensor<2048x8192xf32>, tensor<11x8192xf32>) -> tensor<11x8192xf32>
+    %166 = tensor.empty() : tensor<1x11x8192xf32>
+    %167 = "ttir.unsqueeze"(%165, %166) <{dim = 0 : si32}> : (tensor<11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %168 = tensor.empty() : tensor<1x11x8192xf32>
+    %169 = "ttir.sigmoid"(%167, %168) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %170 = tensor.empty() : tensor<1x11x8192xf32>
+    %171 = "ttir.multiply"(%167, %169, %170) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %172 = tensor.empty() : tensor<11x8192xf32>
+    %173 = "ttir.matmul"(%163, %arg172, %172) : (tensor<11x2048xf32>, tensor<2048x8192xf32>, tensor<11x8192xf32>) -> tensor<11x8192xf32>
+    %174 = tensor.empty() : tensor<1x11x8192xf32>
+    %175 = "ttir.unsqueeze"(%173, %174) <{dim = 0 : si32}> : (tensor<11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %176 = tensor.empty() : tensor<1x11x8192xf32>
+    %177 = "ttir.multiply"(%171, %175, %176) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %178 = tensor.empty() : tensor<1x11x2048xf32>
+    %179 = "ttir.matmul"(%177, %arg173, %178) : (tensor<1x11x8192xf32>, tensor<8192x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %180 = tensor.empty() : tensor<1x11x2048xf32>
+    %181 = "ttir.add"(%147, %179, %180) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %182 = tensor.empty() : tensor<1x11x2048xf32>
+    %183 = "ttir.multiply"(%181, %181, %182) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %184 = tensor.empty() : tensor<1x11x1xf32>
+    %185 = "ttir.mean"(%183, %184) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %186 = tensor.empty() : tensor<1x11x1xf32>
+    %187 = "ttir.add"(%185, %arg12, %186) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %188 = tensor.empty() : tensor<1x11x1xf32>
+    %189 = "ttir.sqrt"(%187, %188) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %190 = tensor.empty() : tensor<1x11x1xf32>
+    %191 = "ttir.reciprocal"(%189, %190) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %192 = tensor.empty() : tensor<1x11x2048xf32>
+    %193 = "ttir.multiply"(%181, %191, %192) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %194 = tensor.empty() : tensor<1x11x2048xf32>
+    %195 = "ttir.multiply"(%arg174, %193, %194) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %196 = tensor.empty() : tensor<11x2048xf32>
+    %197 = "ttir.squeeze"(%195, %196) <{dim = 0 : si32}> : (tensor<1x11x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %198 = tensor.empty() : tensor<11x2048xf32>
+    %199 = "ttir.matmul"(%197, %arg175, %198) : (tensor<11x2048xf32>, tensor<2048x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %200 = tensor.empty() : tensor<1x11x32x64xf32>
+    %201 = "ttir.reshape"(%199, %200) <{shape = [1 : i32, 11 : i32, 32 : i32, 64 : i32]}> : (tensor<11x2048xf32>, tensor<1x11x32x64xf32>) -> tensor<1x11x32x64xf32>
+    %202 = tensor.empty() : tensor<1x32x11x64xf32>
+    %203 = "ttir.transpose"(%201, %202) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x32x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %204 = tensor.empty() : tensor<1x32x11x64xf32>
+    %205 = "ttir.multiply"(%203, %35, %204) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %206 = tensor.empty() : tensor<1x32x64x11xf32>
+    %207 = "ttir.transpose"(%203, %206) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %208 = tensor.empty() : tensor<1x32x32x11xf32>
+    %209 = "ttir.matmul"(%arg13, %207, %208) : (tensor<1x32x32x64xf32>, tensor<1x32x64x11xf32>, tensor<1x32x32x11xf32>) -> tensor<1x32x32x11xf32>
+    %210 = tensor.empty() : tensor<1x32x11x32xf32>
+    %211 = "ttir.transpose"(%209, %210) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x32x11xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %212 = tensor.empty() : tensor<1x32x11x32xf32>
+    %213 = "ttir.multiply"(%211, %arg14, %212) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x32xf32>, tensor<1xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %214 = tensor.empty() : tensor<1x32x64x11xf32>
+    %215 = "ttir.transpose"(%203, %214) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %216 = tensor.empty() : tensor<1x32x32x11xf32>
+    %217 = "ttir.matmul"(%arg15, %215, %216) : (tensor<1x32x32x64xf32>, tensor<1x32x64x11xf32>, tensor<1x32x32x11xf32>) -> tensor<1x32x32x11xf32>
+    %218 = tensor.empty() : tensor<1x32x11x32xf32>
+    %219 = "ttir.transpose"(%217, %218) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x32x11xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %220 = tensor.empty() : tensor<1x32x11x64xf32>
+    %221 = "ttir.concat"(%213, %219, %220) <{dim = -1 : si32}> : (tensor<1x32x11x32xf32>, tensor<1x32x11x32xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %222 = tensor.empty() : tensor<1x32x11x64xf32>
+    %223 = "ttir.multiply"(%221, %57, %222) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %224 = tensor.empty() : tensor<1x32x11x64xf32>
+    %225 = "ttir.add"(%205, %223, %224) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x32x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %226 = tensor.empty() : tensor<32x11x64xf32>
+    %227 = "ttir.squeeze"(%225, %226) <{dim = 0 : si32}> : (tensor<1x32x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %228 = tensor.empty() : tensor<11x512xf32>
+    %229 = "ttir.matmul"(%197, %arg176, %228) : (tensor<11x2048xf32>, tensor<2048x512xf32>, tensor<11x512xf32>) -> tensor<11x512xf32>
+    %230 = tensor.empty() : tensor<1x11x8x64xf32>
+    %231 = "ttir.reshape"(%229, %230) <{shape = [1 : i32, 11 : i32, 8 : i32, 64 : i32]}> : (tensor<11x512xf32>, tensor<1x11x8x64xf32>) -> tensor<1x11x8x64xf32>
+    %232 = tensor.empty() : tensor<1x8x11x64xf32>
+    %233 = "ttir.transpose"(%231, %232) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x8x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %234 = tensor.empty() : tensor<1x8x11x64xf32>
+    %235 = "ttir.multiply"(%233, %35, %234) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %236 = tensor.empty() : tensor<1x8x64x11xf32>
+    %237 = "ttir.transpose"(%233, %236) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x64x11xf32>) -> tensor<1x8x64x11xf32>
+    %238 = tensor.empty() : tensor<1x8x32x11xf32>
+    %239 = "ttir.matmul"(%arg16, %237, %238) : (tensor<1x8x32x64xf32>, tensor<1x8x64x11xf32>, tensor<1x8x32x11xf32>) -> tensor<1x8x32x11xf32>
+    %240 = tensor.empty() : tensor<1x8x11x32xf32>
+    %241 = "ttir.transpose"(%239, %240) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x32x11xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %242 = tensor.empty() : tensor<1x8x11x32xf32>
+    %243 = "ttir.multiply"(%241, %arg17, %242) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x32xf32>, tensor<1xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %244 = tensor.empty() : tensor<1x8x64x11xf32>
+    %245 = "ttir.transpose"(%233, %244) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x64x11xf32>) -> tensor<1x8x64x11xf32>
+    %246 = tensor.empty() : tensor<1x8x32x11xf32>
+    %247 = "ttir.matmul"(%arg18, %245, %246) : (tensor<1x8x32x64xf32>, tensor<1x8x64x11xf32>, tensor<1x8x32x11xf32>) -> tensor<1x8x32x11xf32>
+    %248 = tensor.empty() : tensor<1x8x11x32xf32>
+    %249 = "ttir.transpose"(%247, %248) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x32x11xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %250 = tensor.empty() : tensor<1x8x11x64xf32>
+    %251 = "ttir.concat"(%243, %249, %250) <{dim = -1 : si32}> : (tensor<1x8x11x32xf32>, tensor<1x8x11x32xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %252 = tensor.empty() : tensor<1x8x11x64xf32>
+    %253 = "ttir.multiply"(%251, %57, %252) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %254 = tensor.empty() : tensor<1x8x11x64xf32>
+    %255 = "ttir.add"(%235, %253, %254) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x8x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %256 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %257 = "ttir.unsqueeze"(%255, %256) <{dim = 2 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %258 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %259 = "ttir.repeat_interleave"(%257, %258) <{dim = 0 : si32, repeats = 1 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %260 = tensor.empty() : tensor<1x8x4x11x64xf32>
+    %261 = "ttir.repeat_interleave"(%259, %260) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x4x11x64xf32>) -> tensor<1x8x4x11x64xf32>
+    %262 = tensor.empty() : tensor<32x11x64xf32>
+    %263 = "ttir.reshape"(%261, %262) <{shape = [32 : i32, 11 : i32, 64 : i32]}> : (tensor<1x8x4x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %264 = tensor.empty() : tensor<32x64x11xf32>
+    %265 = "ttir.transpose"(%263, %264) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x11x64xf32>, tensor<32x64x11xf32>) -> tensor<32x64x11xf32>
+    %266 = tensor.empty() : tensor<32x11x11xf32>
+    %267 = "ttir.matmul"(%227, %265, %266) : (tensor<32x11x64xf32>, tensor<32x64x11xf32>, tensor<32x11x11xf32>) -> tensor<32x11x11xf32>
+    %268 = tensor.empty() : tensor<1x32x11x11xf32>
+    %269 = "ttir.unsqueeze"(%267, %268) <{dim = 0 : si32}> : (tensor<32x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %270 = tensor.empty() : tensor<1x32x11x11xf32>
+    %271 = "ttir.multiply"(%269, %arg19, %270) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x11xf32>, tensor<1xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %272 = tensor.empty() : tensor<1x32x11x11xf32>
+    %273 = "ttir.add"(%271, %arg20, %272) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x11xf32>, tensor<1x1x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %274 = tensor.empty() : tensor<1x32x11x11xf32>
+    %275 = "ttir.softmax"(%273, %274) <{dimension = -1 : si32}> : (tensor<1x32x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %276 = tensor.empty() : tensor<32x11x11xf32>
+    %277 = "ttir.squeeze"(%275, %276) <{dim = 0 : si32}> : (tensor<1x32x11x11xf32>, tensor<32x11x11xf32>) -> tensor<32x11x11xf32>
+    %278 = tensor.empty() : tensor<11x512xf32>
+    %279 = "ttir.matmul"(%197, %arg177, %278) : (tensor<11x2048xf32>, tensor<2048x512xf32>, tensor<11x512xf32>) -> tensor<11x512xf32>
+    %280 = tensor.empty() : tensor<1x11x8x64xf32>
+    %281 = "ttir.reshape"(%279, %280) <{shape = [1 : i32, 11 : i32, 8 : i32, 64 : i32]}> : (tensor<11x512xf32>, tensor<1x11x8x64xf32>) -> tensor<1x11x8x64xf32>
+    %282 = tensor.empty() : tensor<1x8x11x64xf32>
+    %283 = "ttir.transpose"(%281, %282) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x8x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %284 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %285 = "ttir.unsqueeze"(%283, %284) <{dim = 2 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %286 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %287 = "ttir.repeat_interleave"(%285, %286) <{dim = 0 : si32, repeats = 1 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %288 = tensor.empty() : tensor<1x8x4x11x64xf32>
+    %289 = "ttir.repeat_interleave"(%287, %288) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x4x11x64xf32>) -> tensor<1x8x4x11x64xf32>
+    %290 = tensor.empty() : tensor<1x32x11x64xf32>
+    %291 = "ttir.reshape"(%289, %290) <{shape = [1 : i32, 32 : i32, 11 : i32, 64 : i32]}> : (tensor<1x8x4x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %292 = tensor.empty() : tensor<1x32x64x11xf32>
+    %293 = "ttir.transpose"(%291, %292) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %294 = tensor.empty() : tensor<32x64x11xf32>
+    %295 = "ttir.squeeze"(%293, %294) <{dim = 0 : si32}> : (tensor<1x32x64x11xf32>, tensor<32x64x11xf32>) -> tensor<32x64x11xf32>
+    %296 = tensor.empty() : tensor<32x11x64xf32>
+    %297 = "ttir.transpose"(%295, %296) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x64x11xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %298 = tensor.empty() : tensor<32x11x64xf32>
+    %299 = "ttir.matmul"(%277, %297, %298) : (tensor<32x11x11xf32>, tensor<32x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %300 = tensor.empty() : tensor<1x32x11x64xf32>
+    %301 = "ttir.unsqueeze"(%299, %300) <{dim = 0 : si32}> : (tensor<32x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %302 = tensor.empty() : tensor<1x11x32x64xf32>
+    %303 = "ttir.transpose"(%301, %302) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x11x32x64xf32>) -> tensor<1x11x32x64xf32>
+    %304 = tensor.empty() : tensor<11x2048xf32>
+    %305 = "ttir.reshape"(%303, %304) <{shape = [11 : i32, 2048 : i32]}> : (tensor<1x11x32x64xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %306 = tensor.empty() : tensor<11x2048xf32>
+    %307 = "ttir.matmul"(%305, %arg178, %306) : (tensor<11x2048xf32>, tensor<2048x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %308 = tensor.empty() : tensor<1x11x2048xf32>
+    %309 = "ttir.unsqueeze"(%307, %308) <{dim = 0 : si32}> : (tensor<11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %310 = tensor.empty() : tensor<1x11x2048xf32>
+    %311 = "ttir.add"(%181, %309, %310) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %312 = tensor.empty() : tensor<1x11x2048xf32>
+    %313 = "ttir.multiply"(%311, %311, %312) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %314 = tensor.empty() : tensor<1x11x1xf32>
+    %315 = "ttir.mean"(%313, %314) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %316 = tensor.empty() : tensor<1x11x1xf32>
+    %317 = "ttir.add"(%315, %arg21, %316) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %318 = tensor.empty() : tensor<1x11x1xf32>
+    %319 = "ttir.sqrt"(%317, %318) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %320 = tensor.empty() : tensor<1x11x1xf32>
+    %321 = "ttir.reciprocal"(%319, %320) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %322 = tensor.empty() : tensor<1x11x2048xf32>
+    %323 = "ttir.multiply"(%311, %321, %322) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %324 = tensor.empty() : tensor<1x11x2048xf32>
+    %325 = "ttir.multiply"(%arg179, %323, %324) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %326 = tensor.empty() : tensor<11x2048xf32>
+    %327 = "ttir.squeeze"(%325, %326) <{dim = 0 : si32}> : (tensor<1x11x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %328 = tensor.empty() : tensor<11x8192xf32>
+    %329 = "ttir.matmul"(%327, %arg180, %328) : (tensor<11x2048xf32>, tensor<2048x8192xf32>, tensor<11x8192xf32>) -> tensor<11x8192xf32>
+    %330 = tensor.empty() : tensor<1x11x8192xf32>
+    %331 = "ttir.unsqueeze"(%329, %330) <{dim = 0 : si32}> : (tensor<11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %332 = tensor.empty() : tensor<1x11x8192xf32>
+    %333 = "ttir.sigmoid"(%331, %332) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %334 = tensor.empty() : tensor<1x11x8192xf32>
+    %335 = "ttir.multiply"(%331, %333, %334) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %336 = tensor.empty() : tensor<11x8192xf32>
+    %337 = "ttir.matmul"(%327, %arg181, %336) : (tensor<11x2048xf32>, tensor<2048x8192xf32>, tensor<11x8192xf32>) -> tensor<11x8192xf32>
+    %338 = tensor.empty() : tensor<1x11x8192xf32>
+    %339 = "ttir.unsqueeze"(%337, %338) <{dim = 0 : si32}> : (tensor<11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %340 = tensor.empty() : tensor<1x11x8192xf32>
+    %341 = "ttir.multiply"(%335, %339, %340) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %342 = tensor.empty() : tensor<1x11x2048xf32>
+    %343 = "ttir.matmul"(%341, %arg182, %342) : (tensor<1x11x8192xf32>, tensor<8192x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %344 = tensor.empty() : tensor<1x11x2048xf32>
+    %345 = "ttir.add"(%311, %343, %344) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %346 = tensor.empty() : tensor<1x11x2048xf32>
+    %347 = "ttir.multiply"(%345, %345, %346) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %348 = tensor.empty() : tensor<1x11x1xf32>
+    %349 = "ttir.mean"(%347, %348) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %350 = tensor.empty() : tensor<1x11x1xf32>
+    %351 = "ttir.add"(%349, %arg22, %350) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %352 = tensor.empty() : tensor<1x11x1xf32>
+    %353 = "ttir.sqrt"(%351, %352) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %354 = tensor.empty() : tensor<1x11x1xf32>
+    %355 = "ttir.reciprocal"(%353, %354) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %356 = tensor.empty() : tensor<1x11x2048xf32>
+    %357 = "ttir.multiply"(%345, %355, %356) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %358 = tensor.empty() : tensor<1x11x2048xf32>
+    %359 = "ttir.multiply"(%arg183, %357, %358) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %360 = tensor.empty() : tensor<11x2048xf32>
+    %361 = "ttir.squeeze"(%359, %360) <{dim = 0 : si32}> : (tensor<1x11x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %362 = tensor.empty() : tensor<11x2048xf32>
+    %363 = "ttir.matmul"(%361, %arg184, %362) : (tensor<11x2048xf32>, tensor<2048x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %364 = tensor.empty() : tensor<1x11x32x64xf32>
+    %365 = "ttir.reshape"(%363, %364) <{shape = [1 : i32, 11 : i32, 32 : i32, 64 : i32]}> : (tensor<11x2048xf32>, tensor<1x11x32x64xf32>) -> tensor<1x11x32x64xf32>
+    %366 = tensor.empty() : tensor<1x32x11x64xf32>
+    %367 = "ttir.transpose"(%365, %366) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x32x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %368 = tensor.empty() : tensor<1x32x11x64xf32>
+    %369 = "ttir.multiply"(%367, %35, %368) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %370 = tensor.empty() : tensor<1x32x64x11xf32>
+    %371 = "ttir.transpose"(%367, %370) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %372 = tensor.empty() : tensor<1x32x32x11xf32>
+    %373 = "ttir.matmul"(%arg23, %371, %372) : (tensor<1x32x32x64xf32>, tensor<1x32x64x11xf32>, tensor<1x32x32x11xf32>) -> tensor<1x32x32x11xf32>
+    %374 = tensor.empty() : tensor<1x32x11x32xf32>
+    %375 = "ttir.transpose"(%373, %374) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x32x11xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %376 = tensor.empty() : tensor<1x32x11x32xf32>
+    %377 = "ttir.multiply"(%375, %arg24, %376) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x32xf32>, tensor<1xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %378 = tensor.empty() : tensor<1x32x64x11xf32>
+    %379 = "ttir.transpose"(%367, %378) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %380 = tensor.empty() : tensor<1x32x32x11xf32>
+    %381 = "ttir.matmul"(%arg25, %379, %380) : (tensor<1x32x32x64xf32>, tensor<1x32x64x11xf32>, tensor<1x32x32x11xf32>) -> tensor<1x32x32x11xf32>
+    %382 = tensor.empty() : tensor<1x32x11x32xf32>
+    %383 = "ttir.transpose"(%381, %382) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x32x11xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %384 = tensor.empty() : tensor<1x32x11x64xf32>
+    %385 = "ttir.concat"(%377, %383, %384) <{dim = -1 : si32}> : (tensor<1x32x11x32xf32>, tensor<1x32x11x32xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %386 = tensor.empty() : tensor<1x32x11x64xf32>
+    %387 = "ttir.multiply"(%385, %57, %386) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %388 = tensor.empty() : tensor<1x32x11x64xf32>
+    %389 = "ttir.add"(%369, %387, %388) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x32x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %390 = tensor.empty() : tensor<32x11x64xf32>
+    %391 = "ttir.squeeze"(%389, %390) <{dim = 0 : si32}> : (tensor<1x32x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %392 = tensor.empty() : tensor<11x512xf32>
+    %393 = "ttir.matmul"(%361, %arg185, %392) : (tensor<11x2048xf32>, tensor<2048x512xf32>, tensor<11x512xf32>) -> tensor<11x512xf32>
+    %394 = tensor.empty() : tensor<1x11x8x64xf32>
+    %395 = "ttir.reshape"(%393, %394) <{shape = [1 : i32, 11 : i32, 8 : i32, 64 : i32]}> : (tensor<11x512xf32>, tensor<1x11x8x64xf32>) -> tensor<1x11x8x64xf32>
+    %396 = tensor.empty() : tensor<1x8x11x64xf32>
+    %397 = "ttir.transpose"(%395, %396) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x8x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %398 = tensor.empty() : tensor<1x8x11x64xf32>
+    %399 = "ttir.multiply"(%397, %35, %398) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %400 = tensor.empty() : tensor<1x8x64x11xf32>
+    %401 = "ttir.transpose"(%397, %400) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x64x11xf32>) -> tensor<1x8x64x11xf32>
+    %402 = tensor.empty() : tensor<1x8x32x11xf32>
+    %403 = "ttir.matmul"(%arg26, %401, %402) : (tensor<1x8x32x64xf32>, tensor<1x8x64x11xf32>, tensor<1x8x32x11xf32>) -> tensor<1x8x32x11xf32>
+    %404 = tensor.empty() : tensor<1x8x11x32xf32>
+    %405 = "ttir.transpose"(%403, %404) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x32x11xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %406 = tensor.empty() : tensor<1x8x11x32xf32>
+    %407 = "ttir.multiply"(%405, %arg27, %406) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x32xf32>, tensor<1xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %408 = tensor.empty() : tensor<1x8x64x11xf32>
+    %409 = "ttir.transpose"(%397, %408) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x64x11xf32>) -> tensor<1x8x64x11xf32>
+    %410 = tensor.empty() : tensor<1x8x32x11xf32>
+    %411 = "ttir.matmul"(%arg28, %409, %410) : (tensor<1x8x32x64xf32>, tensor<1x8x64x11xf32>, tensor<1x8x32x11xf32>) -> tensor<1x8x32x11xf32>
+    %412 = tensor.empty() : tensor<1x8x11x32xf32>
+    %413 = "ttir.transpose"(%411, %412) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x32x11xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %414 = tensor.empty() : tensor<1x8x11x64xf32>
+    %415 = "ttir.concat"(%407, %413, %414) <{dim = -1 : si32}> : (tensor<1x8x11x32xf32>, tensor<1x8x11x32xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %416 = tensor.empty() : tensor<1x8x11x64xf32>
+    %417 = "ttir.multiply"(%415, %57, %416) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %418 = tensor.empty() : tensor<1x8x11x64xf32>
+    %419 = "ttir.add"(%399, %417, %418) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x8x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %420 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %421 = "ttir.unsqueeze"(%419, %420) <{dim = 2 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %422 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %423 = "ttir.repeat_interleave"(%421, %422) <{dim = 0 : si32, repeats = 1 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %424 = tensor.empty() : tensor<1x8x4x11x64xf32>
+    %425 = "ttir.repeat_interleave"(%423, %424) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x4x11x64xf32>) -> tensor<1x8x4x11x64xf32>
+    %426 = tensor.empty() : tensor<32x11x64xf32>
+    %427 = "ttir.reshape"(%425, %426) <{shape = [32 : i32, 11 : i32, 64 : i32]}> : (tensor<1x8x4x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %428 = tensor.empty() : tensor<32x64x11xf32>
+    %429 = "ttir.transpose"(%427, %428) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x11x64xf32>, tensor<32x64x11xf32>) -> tensor<32x64x11xf32>
+    %430 = tensor.empty() : tensor<32x11x11xf32>
+    %431 = "ttir.matmul"(%391, %429, %430) : (tensor<32x11x64xf32>, tensor<32x64x11xf32>, tensor<32x11x11xf32>) -> tensor<32x11x11xf32>
+    %432 = tensor.empty() : tensor<1x32x11x11xf32>
+    %433 = "ttir.unsqueeze"(%431, %432) <{dim = 0 : si32}> : (tensor<32x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %434 = tensor.empty() : tensor<1x32x11x11xf32>
+    %435 = "ttir.multiply"(%433, %arg29, %434) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x11xf32>, tensor<1xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %436 = tensor.empty() : tensor<1x32x11x11xf32>
+    %437 = "ttir.add"(%435, %arg30, %436) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x11xf32>, tensor<1x1x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %438 = tensor.empty() : tensor<1x32x11x11xf32>
+    %439 = "ttir.softmax"(%437, %438) <{dimension = -1 : si32}> : (tensor<1x32x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %440 = tensor.empty() : tensor<32x11x11xf32>
+    %441 = "ttir.squeeze"(%439, %440) <{dim = 0 : si32}> : (tensor<1x32x11x11xf32>, tensor<32x11x11xf32>) -> tensor<32x11x11xf32>
+    %442 = tensor.empty() : tensor<11x512xf32>
+    %443 = "ttir.matmul"(%361, %arg186, %442) : (tensor<11x2048xf32>, tensor<2048x512xf32>, tensor<11x512xf32>) -> tensor<11x512xf32>
+    %444 = tensor.empty() : tensor<1x11x8x64xf32>
+    %445 = "ttir.reshape"(%443, %444) <{shape = [1 : i32, 11 : i32, 8 : i32, 64 : i32]}> : (tensor<11x512xf32>, tensor<1x11x8x64xf32>) -> tensor<1x11x8x64xf32>
+    %446 = tensor.empty() : tensor<1x8x11x64xf32>
+    %447 = "ttir.transpose"(%445, %446) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x8x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %448 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %449 = "ttir.unsqueeze"(%447, %448) <{dim = 2 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %450 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %451 = "ttir.repeat_interleave"(%449, %450) <{dim = 0 : si32, repeats = 1 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %452 = tensor.empty() : tensor<1x8x4x11x64xf32>
+    %453 = "ttir.repeat_interleave"(%451, %452) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x4x11x64xf32>) -> tensor<1x8x4x11x64xf32>
+    %454 = tensor.empty() : tensor<1x32x11x64xf32>
+    %455 = "ttir.reshape"(%453, %454) <{shape = [1 : i32, 32 : i32, 11 : i32, 64 : i32]}> : (tensor<1x8x4x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %456 = tensor.empty() : tensor<1x32x64x11xf32>
+    %457 = "ttir.transpose"(%455, %456) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %458 = tensor.empty() : tensor<32x64x11xf32>
+    %459 = "ttir.squeeze"(%457, %458) <{dim = 0 : si32}> : (tensor<1x32x64x11xf32>, tensor<32x64x11xf32>) -> tensor<32x64x11xf32>
+    %460 = tensor.empty() : tensor<32x11x64xf32>
+    %461 = "ttir.transpose"(%459, %460) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x64x11xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %462 = tensor.empty() : tensor<32x11x64xf32>
+    %463 = "ttir.matmul"(%441, %461, %462) : (tensor<32x11x11xf32>, tensor<32x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %464 = tensor.empty() : tensor<1x32x11x64xf32>
+    %465 = "ttir.unsqueeze"(%463, %464) <{dim = 0 : si32}> : (tensor<32x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %466 = tensor.empty() : tensor<1x11x32x64xf32>
+    %467 = "ttir.transpose"(%465, %466) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x11x32x64xf32>) -> tensor<1x11x32x64xf32>
+    %468 = tensor.empty() : tensor<11x2048xf32>
+    %469 = "ttir.reshape"(%467, %468) <{shape = [11 : i32, 2048 : i32]}> : (tensor<1x11x32x64xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %470 = tensor.empty() : tensor<11x2048xf32>
+    %471 = "ttir.matmul"(%469, %arg187, %470) : (tensor<11x2048xf32>, tensor<2048x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %472 = tensor.empty() : tensor<1x11x2048xf32>
+    %473 = "ttir.unsqueeze"(%471, %472) <{dim = 0 : si32}> : (tensor<11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %474 = tensor.empty() : tensor<1x11x2048xf32>
+    %475 = "ttir.add"(%345, %473, %474) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %476 = tensor.empty() : tensor<1x11x2048xf32>
+    %477 = "ttir.multiply"(%475, %475, %476) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %478 = tensor.empty() : tensor<1x11x1xf32>
+    %479 = "ttir.mean"(%477, %478) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %480 = tensor.empty() : tensor<1x11x1xf32>
+    %481 = "ttir.add"(%479, %arg31, %480) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %482 = tensor.empty() : tensor<1x11x1xf32>
+    %483 = "ttir.sqrt"(%481, %482) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %484 = tensor.empty() : tensor<1x11x1xf32>
+    %485 = "ttir.reciprocal"(%483, %484) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %486 = tensor.empty() : tensor<1x11x2048xf32>
+    %487 = "ttir.multiply"(%475, %485, %486) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %488 = tensor.empty() : tensor<1x11x2048xf32>
+    %489 = "ttir.multiply"(%arg188, %487, %488) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %490 = tensor.empty() : tensor<11x2048xf32>
+    %491 = "ttir.squeeze"(%489, %490) <{dim = 0 : si32}> : (tensor<1x11x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %492 = tensor.empty() : tensor<11x8192xf32>
+    %493 = "ttir.matmul"(%491, %arg189, %492) : (tensor<11x2048xf32>, tensor<2048x8192xf32>, tensor<11x8192xf32>) -> tensor<11x8192xf32>
+    %494 = tensor.empty() : tensor<1x11x8192xf32>
+    %495 = "ttir.unsqueeze"(%493, %494) <{dim = 0 : si32}> : (tensor<11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %496 = tensor.empty() : tensor<1x11x8192xf32>
+    %497 = "ttir.sigmoid"(%495, %496) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %498 = tensor.empty() : tensor<1x11x8192xf32>
+    %499 = "ttir.multiply"(%495, %497, %498) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %500 = tensor.empty() : tensor<11x8192xf32>
+    %501 = "ttir.matmul"(%491, %arg190, %500) : (tensor<11x2048xf32>, tensor<2048x8192xf32>, tensor<11x8192xf32>) -> tensor<11x8192xf32>
+    %502 = tensor.empty() : tensor<1x11x8192xf32>
+    %503 = "ttir.unsqueeze"(%501, %502) <{dim = 0 : si32}> : (tensor<11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %504 = tensor.empty() : tensor<1x11x8192xf32>
+    %505 = "ttir.multiply"(%499, %503, %504) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %506 = tensor.empty() : tensor<1x11x2048xf32>
+    %507 = "ttir.matmul"(%505, %arg191, %506) : (tensor<1x11x8192xf32>, tensor<8192x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %508 = tensor.empty() : tensor<1x11x2048xf32>
+    %509 = "ttir.add"(%475, %507, %508) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %510 = tensor.empty() : tensor<1x11x2048xf32>
+    %511 = "ttir.multiply"(%509, %509, %510) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %512 = tensor.empty() : tensor<1x11x1xf32>
+    %513 = "ttir.mean"(%511, %512) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %514 = tensor.empty() : tensor<1x11x1xf32>
+    %515 = "ttir.add"(%513, %arg32, %514) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %516 = tensor.empty() : tensor<1x11x1xf32>
+    %517 = "ttir.sqrt"(%515, %516) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %518 = tensor.empty() : tensor<1x11x1xf32>
+    %519 = "ttir.reciprocal"(%517, %518) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %520 = tensor.empty() : tensor<1x11x2048xf32>
+    %521 = "ttir.multiply"(%509, %519, %520) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %522 = tensor.empty() : tensor<1x11x2048xf32>
+    %523 = "ttir.multiply"(%arg192, %521, %522) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %524 = tensor.empty() : tensor<11x2048xf32>
+    %525 = "ttir.squeeze"(%523, %524) <{dim = 0 : si32}> : (tensor<1x11x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %526 = tensor.empty() : tensor<11x2048xf32>
+    %527 = "ttir.matmul"(%525, %arg193, %526) : (tensor<11x2048xf32>, tensor<2048x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %528 = tensor.empty() : tensor<1x11x32x64xf32>
+    %529 = "ttir.reshape"(%527, %528) <{shape = [1 : i32, 11 : i32, 32 : i32, 64 : i32]}> : (tensor<11x2048xf32>, tensor<1x11x32x64xf32>) -> tensor<1x11x32x64xf32>
+    %530 = tensor.empty() : tensor<1x32x11x64xf32>
+    %531 = "ttir.transpose"(%529, %530) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x32x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %532 = tensor.empty() : tensor<1x32x11x64xf32>
+    %533 = "ttir.multiply"(%531, %35, %532) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %534 = tensor.empty() : tensor<1x32x64x11xf32>
+    %535 = "ttir.transpose"(%531, %534) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %536 = tensor.empty() : tensor<1x32x32x11xf32>
+    %537 = "ttir.matmul"(%arg33, %535, %536) : (tensor<1x32x32x64xf32>, tensor<1x32x64x11xf32>, tensor<1x32x32x11xf32>) -> tensor<1x32x32x11xf32>
+    %538 = tensor.empty() : tensor<1x32x11x32xf32>
+    %539 = "ttir.transpose"(%537, %538) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x32x11xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %540 = tensor.empty() : tensor<1x32x11x32xf32>
+    %541 = "ttir.multiply"(%539, %arg34, %540) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x32xf32>, tensor<1xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %542 = tensor.empty() : tensor<1x32x64x11xf32>
+    %543 = "ttir.transpose"(%531, %542) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %544 = tensor.empty() : tensor<1x32x32x11xf32>
+    %545 = "ttir.matmul"(%arg35, %543, %544) : (tensor<1x32x32x64xf32>, tensor<1x32x64x11xf32>, tensor<1x32x32x11xf32>) -> tensor<1x32x32x11xf32>
+    %546 = tensor.empty() : tensor<1x32x11x32xf32>
+    %547 = "ttir.transpose"(%545, %546) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x32x11xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %548 = tensor.empty() : tensor<1x32x11x64xf32>
+    %549 = "ttir.concat"(%541, %547, %548) <{dim = -1 : si32}> : (tensor<1x32x11x32xf32>, tensor<1x32x11x32xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %550 = tensor.empty() : tensor<1x32x11x64xf32>
+    %551 = "ttir.multiply"(%549, %57, %550) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %552 = tensor.empty() : tensor<1x32x11x64xf32>
+    %553 = "ttir.add"(%533, %551, %552) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x32x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %554 = tensor.empty() : tensor<32x11x64xf32>
+    %555 = "ttir.squeeze"(%553, %554) <{dim = 0 : si32}> : (tensor<1x32x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %556 = tensor.empty() : tensor<11x512xf32>
+    %557 = "ttir.matmul"(%525, %arg194, %556) : (tensor<11x2048xf32>, tensor<2048x512xf32>, tensor<11x512xf32>) -> tensor<11x512xf32>
+    %558 = tensor.empty() : tensor<1x11x8x64xf32>
+    %559 = "ttir.reshape"(%557, %558) <{shape = [1 : i32, 11 : i32, 8 : i32, 64 : i32]}> : (tensor<11x512xf32>, tensor<1x11x8x64xf32>) -> tensor<1x11x8x64xf32>
+    %560 = tensor.empty() : tensor<1x8x11x64xf32>
+    %561 = "ttir.transpose"(%559, %560) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x8x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %562 = tensor.empty() : tensor<1x8x11x64xf32>
+    %563 = "ttir.multiply"(%561, %35, %562) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %564 = tensor.empty() : tensor<1x8x64x11xf32>
+    %565 = "ttir.transpose"(%561, %564) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x64x11xf32>) -> tensor<1x8x64x11xf32>
+    %566 = tensor.empty() : tensor<1x8x32x11xf32>
+    %567 = "ttir.matmul"(%arg36, %565, %566) : (tensor<1x8x32x64xf32>, tensor<1x8x64x11xf32>, tensor<1x8x32x11xf32>) -> tensor<1x8x32x11xf32>
+    %568 = tensor.empty() : tensor<1x8x11x32xf32>
+    %569 = "ttir.transpose"(%567, %568) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x32x11xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %570 = tensor.empty() : tensor<1x8x11x32xf32>
+    %571 = "ttir.multiply"(%569, %arg37, %570) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x32xf32>, tensor<1xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %572 = tensor.empty() : tensor<1x8x64x11xf32>
+    %573 = "ttir.transpose"(%561, %572) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x64x11xf32>) -> tensor<1x8x64x11xf32>
+    %574 = tensor.empty() : tensor<1x8x32x11xf32>
+    %575 = "ttir.matmul"(%arg38, %573, %574) : (tensor<1x8x32x64xf32>, tensor<1x8x64x11xf32>, tensor<1x8x32x11xf32>) -> tensor<1x8x32x11xf32>
+    %576 = tensor.empty() : tensor<1x8x11x32xf32>
+    %577 = "ttir.transpose"(%575, %576) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x32x11xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %578 = tensor.empty() : tensor<1x8x11x64xf32>
+    %579 = "ttir.concat"(%571, %577, %578) <{dim = -1 : si32}> : (tensor<1x8x11x32xf32>, tensor<1x8x11x32xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %580 = tensor.empty() : tensor<1x8x11x64xf32>
+    %581 = "ttir.multiply"(%579, %57, %580) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %582 = tensor.empty() : tensor<1x8x11x64xf32>
+    %583 = "ttir.add"(%563, %581, %582) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x8x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %584 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %585 = "ttir.unsqueeze"(%583, %584) <{dim = 2 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %586 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %587 = "ttir.repeat_interleave"(%585, %586) <{dim = 0 : si32, repeats = 1 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %588 = tensor.empty() : tensor<1x8x4x11x64xf32>
+    %589 = "ttir.repeat_interleave"(%587, %588) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x4x11x64xf32>) -> tensor<1x8x4x11x64xf32>
+    %590 = tensor.empty() : tensor<32x11x64xf32>
+    %591 = "ttir.reshape"(%589, %590) <{shape = [32 : i32, 11 : i32, 64 : i32]}> : (tensor<1x8x4x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %592 = tensor.empty() : tensor<32x64x11xf32>
+    %593 = "ttir.transpose"(%591, %592) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x11x64xf32>, tensor<32x64x11xf32>) -> tensor<32x64x11xf32>
+    %594 = tensor.empty() : tensor<32x11x11xf32>
+    %595 = "ttir.matmul"(%555, %593, %594) : (tensor<32x11x64xf32>, tensor<32x64x11xf32>, tensor<32x11x11xf32>) -> tensor<32x11x11xf32>
+    %596 = tensor.empty() : tensor<1x32x11x11xf32>
+    %597 = "ttir.unsqueeze"(%595, %596) <{dim = 0 : si32}> : (tensor<32x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %598 = tensor.empty() : tensor<1x32x11x11xf32>
+    %599 = "ttir.multiply"(%597, %arg39, %598) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x11xf32>, tensor<1xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %600 = tensor.empty() : tensor<1x32x11x11xf32>
+    %601 = "ttir.add"(%599, %arg40, %600) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x11xf32>, tensor<1x1x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %602 = tensor.empty() : tensor<1x32x11x11xf32>
+    %603 = "ttir.softmax"(%601, %602) <{dimension = -1 : si32}> : (tensor<1x32x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %604 = tensor.empty() : tensor<32x11x11xf32>
+    %605 = "ttir.squeeze"(%603, %604) <{dim = 0 : si32}> : (tensor<1x32x11x11xf32>, tensor<32x11x11xf32>) -> tensor<32x11x11xf32>
+    %606 = tensor.empty() : tensor<11x512xf32>
+    %607 = "ttir.matmul"(%525, %arg195, %606) : (tensor<11x2048xf32>, tensor<2048x512xf32>, tensor<11x512xf32>) -> tensor<11x512xf32>
+    %608 = tensor.empty() : tensor<1x11x8x64xf32>
+    %609 = "ttir.reshape"(%607, %608) <{shape = [1 : i32, 11 : i32, 8 : i32, 64 : i32]}> : (tensor<11x512xf32>, tensor<1x11x8x64xf32>) -> tensor<1x11x8x64xf32>
+    %610 = tensor.empty() : tensor<1x8x11x64xf32>
+    %611 = "ttir.transpose"(%609, %610) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x8x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %612 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %613 = "ttir.unsqueeze"(%611, %612) <{dim = 2 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %614 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %615 = "ttir.repeat_interleave"(%613, %614) <{dim = 0 : si32, repeats = 1 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %616 = tensor.empty() : tensor<1x8x4x11x64xf32>
+    %617 = "ttir.repeat_interleave"(%615, %616) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x4x11x64xf32>) -> tensor<1x8x4x11x64xf32>
+    %618 = tensor.empty() : tensor<1x32x11x64xf32>
+    %619 = "ttir.reshape"(%617, %618) <{shape = [1 : i32, 32 : i32, 11 : i32, 64 : i32]}> : (tensor<1x8x4x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %620 = tensor.empty() : tensor<1x32x64x11xf32>
+    %621 = "ttir.transpose"(%619, %620) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %622 = tensor.empty() : tensor<32x64x11xf32>
+    %623 = "ttir.squeeze"(%621, %622) <{dim = 0 : si32}> : (tensor<1x32x64x11xf32>, tensor<32x64x11xf32>) -> tensor<32x64x11xf32>
+    %624 = tensor.empty() : tensor<32x11x64xf32>
+    %625 = "ttir.transpose"(%623, %624) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x64x11xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %626 = tensor.empty() : tensor<32x11x64xf32>
+    %627 = "ttir.matmul"(%605, %625, %626) : (tensor<32x11x11xf32>, tensor<32x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %628 = tensor.empty() : tensor<1x32x11x64xf32>
+    %629 = "ttir.unsqueeze"(%627, %628) <{dim = 0 : si32}> : (tensor<32x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %630 = tensor.empty() : tensor<1x11x32x64xf32>
+    %631 = "ttir.transpose"(%629, %630) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x11x32x64xf32>) -> tensor<1x11x32x64xf32>
+    %632 = tensor.empty() : tensor<11x2048xf32>
+    %633 = "ttir.reshape"(%631, %632) <{shape = [11 : i32, 2048 : i32]}> : (tensor<1x11x32x64xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %634 = tensor.empty() : tensor<11x2048xf32>
+    %635 = "ttir.matmul"(%633, %arg196, %634) : (tensor<11x2048xf32>, tensor<2048x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %636 = tensor.empty() : tensor<1x11x2048xf32>
+    %637 = "ttir.unsqueeze"(%635, %636) <{dim = 0 : si32}> : (tensor<11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %638 = tensor.empty() : tensor<1x11x2048xf32>
+    %639 = "ttir.add"(%509, %637, %638) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %640 = tensor.empty() : tensor<1x11x2048xf32>
+    %641 = "ttir.multiply"(%639, %639, %640) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %642 = tensor.empty() : tensor<1x11x1xf32>
+    %643 = "ttir.mean"(%641, %642) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %644 = tensor.empty() : tensor<1x11x1xf32>
+    %645 = "ttir.add"(%643, %arg41, %644) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %646 = tensor.empty() : tensor<1x11x1xf32>
+    %647 = "ttir.sqrt"(%645, %646) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %648 = tensor.empty() : tensor<1x11x1xf32>
+    %649 = "ttir.reciprocal"(%647, %648) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %650 = tensor.empty() : tensor<1x11x2048xf32>
+    %651 = "ttir.multiply"(%639, %649, %650) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %652 = tensor.empty() : tensor<1x11x2048xf32>
+    %653 = "ttir.multiply"(%arg197, %651, %652) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %654 = tensor.empty() : tensor<11x2048xf32>
+    %655 = "ttir.squeeze"(%653, %654) <{dim = 0 : si32}> : (tensor<1x11x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %656 = tensor.empty() : tensor<11x8192xf32>
+    %657 = "ttir.matmul"(%655, %arg198, %656) : (tensor<11x2048xf32>, tensor<2048x8192xf32>, tensor<11x8192xf32>) -> tensor<11x8192xf32>
+    %658 = tensor.empty() : tensor<1x11x8192xf32>
+    %659 = "ttir.unsqueeze"(%657, %658) <{dim = 0 : si32}> : (tensor<11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %660 = tensor.empty() : tensor<1x11x8192xf32>
+    %661 = "ttir.sigmoid"(%659, %660) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %662 = tensor.empty() : tensor<1x11x8192xf32>
+    %663 = "ttir.multiply"(%659, %661, %662) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %664 = tensor.empty() : tensor<11x8192xf32>
+    %665 = "ttir.matmul"(%655, %arg199, %664) : (tensor<11x2048xf32>, tensor<2048x8192xf32>, tensor<11x8192xf32>) -> tensor<11x8192xf32>
+    %666 = tensor.empty() : tensor<1x11x8192xf32>
+    %667 = "ttir.unsqueeze"(%665, %666) <{dim = 0 : si32}> : (tensor<11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %668 = tensor.empty() : tensor<1x11x8192xf32>
+    %669 = "ttir.multiply"(%663, %667, %668) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %670 = tensor.empty() : tensor<1x11x2048xf32>
+    %671 = "ttir.matmul"(%669, %arg200, %670) : (tensor<1x11x8192xf32>, tensor<8192x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %672 = tensor.empty() : tensor<1x11x2048xf32>
+    %673 = "ttir.add"(%639, %671, %672) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %674 = tensor.empty() : tensor<1x11x2048xf32>
+    %675 = "ttir.multiply"(%673, %673, %674) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %676 = tensor.empty() : tensor<1x11x1xf32>
+    %677 = "ttir.mean"(%675, %676) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %678 = tensor.empty() : tensor<1x11x1xf32>
+    %679 = "ttir.add"(%677, %arg42, %678) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %680 = tensor.empty() : tensor<1x11x1xf32>
+    %681 = "ttir.sqrt"(%679, %680) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %682 = tensor.empty() : tensor<1x11x1xf32>
+    %683 = "ttir.reciprocal"(%681, %682) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %684 = tensor.empty() : tensor<1x11x2048xf32>
+    %685 = "ttir.multiply"(%673, %683, %684) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %686 = tensor.empty() : tensor<1x11x2048xf32>
+    %687 = "ttir.multiply"(%arg201, %685, %686) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %688 = tensor.empty() : tensor<11x2048xf32>
+    %689 = "ttir.squeeze"(%687, %688) <{dim = 0 : si32}> : (tensor<1x11x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %690 = tensor.empty() : tensor<11x2048xf32>
+    %691 = "ttir.matmul"(%689, %arg202, %690) : (tensor<11x2048xf32>, tensor<2048x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %692 = tensor.empty() : tensor<1x11x32x64xf32>
+    %693 = "ttir.reshape"(%691, %692) <{shape = [1 : i32, 11 : i32, 32 : i32, 64 : i32]}> : (tensor<11x2048xf32>, tensor<1x11x32x64xf32>) -> tensor<1x11x32x64xf32>
+    %694 = tensor.empty() : tensor<1x32x11x64xf32>
+    %695 = "ttir.transpose"(%693, %694) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x32x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %696 = tensor.empty() : tensor<1x32x11x64xf32>
+    %697 = "ttir.multiply"(%695, %35, %696) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %698 = tensor.empty() : tensor<1x32x64x11xf32>
+    %699 = "ttir.transpose"(%695, %698) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %700 = tensor.empty() : tensor<1x32x32x11xf32>
+    %701 = "ttir.matmul"(%arg43, %699, %700) : (tensor<1x32x32x64xf32>, tensor<1x32x64x11xf32>, tensor<1x32x32x11xf32>) -> tensor<1x32x32x11xf32>
+    %702 = tensor.empty() : tensor<1x32x11x32xf32>
+    %703 = "ttir.transpose"(%701, %702) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x32x11xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %704 = tensor.empty() : tensor<1x32x11x32xf32>
+    %705 = "ttir.multiply"(%703, %arg44, %704) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x32xf32>, tensor<1xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %706 = tensor.empty() : tensor<1x32x64x11xf32>
+    %707 = "ttir.transpose"(%695, %706) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %708 = tensor.empty() : tensor<1x32x32x11xf32>
+    %709 = "ttir.matmul"(%arg45, %707, %708) : (tensor<1x32x32x64xf32>, tensor<1x32x64x11xf32>, tensor<1x32x32x11xf32>) -> tensor<1x32x32x11xf32>
+    %710 = tensor.empty() : tensor<1x32x11x32xf32>
+    %711 = "ttir.transpose"(%709, %710) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x32x11xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %712 = tensor.empty() : tensor<1x32x11x64xf32>
+    %713 = "ttir.concat"(%705, %711, %712) <{dim = -1 : si32}> : (tensor<1x32x11x32xf32>, tensor<1x32x11x32xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %714 = tensor.empty() : tensor<1x32x11x64xf32>
+    %715 = "ttir.multiply"(%713, %57, %714) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %716 = tensor.empty() : tensor<1x32x11x64xf32>
+    %717 = "ttir.add"(%697, %715, %716) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x32x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %718 = tensor.empty() : tensor<32x11x64xf32>
+    %719 = "ttir.squeeze"(%717, %718) <{dim = 0 : si32}> : (tensor<1x32x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %720 = tensor.empty() : tensor<11x512xf32>
+    %721 = "ttir.matmul"(%689, %arg203, %720) : (tensor<11x2048xf32>, tensor<2048x512xf32>, tensor<11x512xf32>) -> tensor<11x512xf32>
+    %722 = tensor.empty() : tensor<1x11x8x64xf32>
+    %723 = "ttir.reshape"(%721, %722) <{shape = [1 : i32, 11 : i32, 8 : i32, 64 : i32]}> : (tensor<11x512xf32>, tensor<1x11x8x64xf32>) -> tensor<1x11x8x64xf32>
+    %724 = tensor.empty() : tensor<1x8x11x64xf32>
+    %725 = "ttir.transpose"(%723, %724) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x8x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %726 = tensor.empty() : tensor<1x8x11x64xf32>
+    %727 = "ttir.multiply"(%725, %35, %726) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %728 = tensor.empty() : tensor<1x8x64x11xf32>
+    %729 = "ttir.transpose"(%725, %728) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x64x11xf32>) -> tensor<1x8x64x11xf32>
+    %730 = tensor.empty() : tensor<1x8x32x11xf32>
+    %731 = "ttir.matmul"(%arg46, %729, %730) : (tensor<1x8x32x64xf32>, tensor<1x8x64x11xf32>, tensor<1x8x32x11xf32>) -> tensor<1x8x32x11xf32>
+    %732 = tensor.empty() : tensor<1x8x11x32xf32>
+    %733 = "ttir.transpose"(%731, %732) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x32x11xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %734 = tensor.empty() : tensor<1x8x11x32xf32>
+    %735 = "ttir.multiply"(%733, %arg47, %734) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x32xf32>, tensor<1xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %736 = tensor.empty() : tensor<1x8x64x11xf32>
+    %737 = "ttir.transpose"(%725, %736) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x64x11xf32>) -> tensor<1x8x64x11xf32>
+    %738 = tensor.empty() : tensor<1x8x32x11xf32>
+    %739 = "ttir.matmul"(%arg48, %737, %738) : (tensor<1x8x32x64xf32>, tensor<1x8x64x11xf32>, tensor<1x8x32x11xf32>) -> tensor<1x8x32x11xf32>
+    %740 = tensor.empty() : tensor<1x8x11x32xf32>
+    %741 = "ttir.transpose"(%739, %740) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x32x11xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %742 = tensor.empty() : tensor<1x8x11x64xf32>
+    %743 = "ttir.concat"(%735, %741, %742) <{dim = -1 : si32}> : (tensor<1x8x11x32xf32>, tensor<1x8x11x32xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %744 = tensor.empty() : tensor<1x8x11x64xf32>
+    %745 = "ttir.multiply"(%743, %57, %744) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %746 = tensor.empty() : tensor<1x8x11x64xf32>
+    %747 = "ttir.add"(%727, %745, %746) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x8x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %748 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %749 = "ttir.unsqueeze"(%747, %748) <{dim = 2 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %750 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %751 = "ttir.repeat_interleave"(%749, %750) <{dim = 0 : si32, repeats = 1 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %752 = tensor.empty() : tensor<1x8x4x11x64xf32>
+    %753 = "ttir.repeat_interleave"(%751, %752) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x4x11x64xf32>) -> tensor<1x8x4x11x64xf32>
+    %754 = tensor.empty() : tensor<32x11x64xf32>
+    %755 = "ttir.reshape"(%753, %754) <{shape = [32 : i32, 11 : i32, 64 : i32]}> : (tensor<1x8x4x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %756 = tensor.empty() : tensor<32x64x11xf32>
+    %757 = "ttir.transpose"(%755, %756) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x11x64xf32>, tensor<32x64x11xf32>) -> tensor<32x64x11xf32>
+    %758 = tensor.empty() : tensor<32x11x11xf32>
+    %759 = "ttir.matmul"(%719, %757, %758) : (tensor<32x11x64xf32>, tensor<32x64x11xf32>, tensor<32x11x11xf32>) -> tensor<32x11x11xf32>
+    %760 = tensor.empty() : tensor<1x32x11x11xf32>
+    %761 = "ttir.unsqueeze"(%759, %760) <{dim = 0 : si32}> : (tensor<32x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %762 = tensor.empty() : tensor<1x32x11x11xf32>
+    %763 = "ttir.multiply"(%761, %arg49, %762) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x11xf32>, tensor<1xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %764 = tensor.empty() : tensor<1x32x11x11xf32>
+    %765 = "ttir.add"(%763, %arg50, %764) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x11xf32>, tensor<1x1x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %766 = tensor.empty() : tensor<1x32x11x11xf32>
+    %767 = "ttir.softmax"(%765, %766) <{dimension = -1 : si32}> : (tensor<1x32x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %768 = tensor.empty() : tensor<32x11x11xf32>
+    %769 = "ttir.squeeze"(%767, %768) <{dim = 0 : si32}> : (tensor<1x32x11x11xf32>, tensor<32x11x11xf32>) -> tensor<32x11x11xf32>
+    %770 = tensor.empty() : tensor<11x512xf32>
+    %771 = "ttir.matmul"(%689, %arg204, %770) : (tensor<11x2048xf32>, tensor<2048x512xf32>, tensor<11x512xf32>) -> tensor<11x512xf32>
+    %772 = tensor.empty() : tensor<1x11x8x64xf32>
+    %773 = "ttir.reshape"(%771, %772) <{shape = [1 : i32, 11 : i32, 8 : i32, 64 : i32]}> : (tensor<11x512xf32>, tensor<1x11x8x64xf32>) -> tensor<1x11x8x64xf32>
+    %774 = tensor.empty() : tensor<1x8x11x64xf32>
+    %775 = "ttir.transpose"(%773, %774) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x8x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %776 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %777 = "ttir.unsqueeze"(%775, %776) <{dim = 2 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %778 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %779 = "ttir.repeat_interleave"(%777, %778) <{dim = 0 : si32, repeats = 1 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %780 = tensor.empty() : tensor<1x8x4x11x64xf32>
+    %781 = "ttir.repeat_interleave"(%779, %780) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x4x11x64xf32>) -> tensor<1x8x4x11x64xf32>
+    %782 = tensor.empty() : tensor<1x32x11x64xf32>
+    %783 = "ttir.reshape"(%781, %782) <{shape = [1 : i32, 32 : i32, 11 : i32, 64 : i32]}> : (tensor<1x8x4x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %784 = tensor.empty() : tensor<1x32x64x11xf32>
+    %785 = "ttir.transpose"(%783, %784) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %786 = tensor.empty() : tensor<32x64x11xf32>
+    %787 = "ttir.squeeze"(%785, %786) <{dim = 0 : si32}> : (tensor<1x32x64x11xf32>, tensor<32x64x11xf32>) -> tensor<32x64x11xf32>
+    %788 = tensor.empty() : tensor<32x11x64xf32>
+    %789 = "ttir.transpose"(%787, %788) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x64x11xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %790 = tensor.empty() : tensor<32x11x64xf32>
+    %791 = "ttir.matmul"(%769, %789, %790) : (tensor<32x11x11xf32>, tensor<32x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %792 = tensor.empty() : tensor<1x32x11x64xf32>
+    %793 = "ttir.unsqueeze"(%791, %792) <{dim = 0 : si32}> : (tensor<32x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %794 = tensor.empty() : tensor<1x11x32x64xf32>
+    %795 = "ttir.transpose"(%793, %794) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x11x32x64xf32>) -> tensor<1x11x32x64xf32>
+    %796 = tensor.empty() : tensor<11x2048xf32>
+    %797 = "ttir.reshape"(%795, %796) <{shape = [11 : i32, 2048 : i32]}> : (tensor<1x11x32x64xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %798 = tensor.empty() : tensor<11x2048xf32>
+    %799 = "ttir.matmul"(%797, %arg205, %798) : (tensor<11x2048xf32>, tensor<2048x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %800 = tensor.empty() : tensor<1x11x2048xf32>
+    %801 = "ttir.unsqueeze"(%799, %800) <{dim = 0 : si32}> : (tensor<11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %802 = tensor.empty() : tensor<1x11x2048xf32>
+    %803 = "ttir.add"(%673, %801, %802) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %804 = tensor.empty() : tensor<1x11x2048xf32>
+    %805 = "ttir.multiply"(%803, %803, %804) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %806 = tensor.empty() : tensor<1x11x1xf32>
+    %807 = "ttir.mean"(%805, %806) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %808 = tensor.empty() : tensor<1x11x1xf32>
+    %809 = "ttir.add"(%807, %arg51, %808) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %810 = tensor.empty() : tensor<1x11x1xf32>
+    %811 = "ttir.sqrt"(%809, %810) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %812 = tensor.empty() : tensor<1x11x1xf32>
+    %813 = "ttir.reciprocal"(%811, %812) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %814 = tensor.empty() : tensor<1x11x2048xf32>
+    %815 = "ttir.multiply"(%803, %813, %814) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %816 = tensor.empty() : tensor<1x11x2048xf32>
+    %817 = "ttir.multiply"(%arg206, %815, %816) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %818 = tensor.empty() : tensor<11x2048xf32>
+    %819 = "ttir.squeeze"(%817, %818) <{dim = 0 : si32}> : (tensor<1x11x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %820 = tensor.empty() : tensor<11x8192xf32>
+    %821 = "ttir.matmul"(%819, %arg207, %820) : (tensor<11x2048xf32>, tensor<2048x8192xf32>, tensor<11x8192xf32>) -> tensor<11x8192xf32>
+    %822 = tensor.empty() : tensor<1x11x8192xf32>
+    %823 = "ttir.unsqueeze"(%821, %822) <{dim = 0 : si32}> : (tensor<11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %824 = tensor.empty() : tensor<1x11x8192xf32>
+    %825 = "ttir.sigmoid"(%823, %824) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %826 = tensor.empty() : tensor<1x11x8192xf32>
+    %827 = "ttir.multiply"(%823, %825, %826) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %828 = tensor.empty() : tensor<11x8192xf32>
+    %829 = "ttir.matmul"(%819, %arg208, %828) : (tensor<11x2048xf32>, tensor<2048x8192xf32>, tensor<11x8192xf32>) -> tensor<11x8192xf32>
+    %830 = tensor.empty() : tensor<1x11x8192xf32>
+    %831 = "ttir.unsqueeze"(%829, %830) <{dim = 0 : si32}> : (tensor<11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %832 = tensor.empty() : tensor<1x11x8192xf32>
+    %833 = "ttir.multiply"(%827, %831, %832) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %834 = tensor.empty() : tensor<1x11x2048xf32>
+    %835 = "ttir.matmul"(%833, %arg209, %834) : (tensor<1x11x8192xf32>, tensor<8192x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %836 = tensor.empty() : tensor<1x11x2048xf32>
+    %837 = "ttir.add"(%803, %835, %836) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %838 = tensor.empty() : tensor<1x11x2048xf32>
+    %839 = "ttir.multiply"(%837, %837, %838) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %840 = tensor.empty() : tensor<1x11x1xf32>
+    %841 = "ttir.mean"(%839, %840) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %842 = tensor.empty() : tensor<1x11x1xf32>
+    %843 = "ttir.add"(%841, %arg52, %842) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %844 = tensor.empty() : tensor<1x11x1xf32>
+    %845 = "ttir.sqrt"(%843, %844) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %846 = tensor.empty() : tensor<1x11x1xf32>
+    %847 = "ttir.reciprocal"(%845, %846) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %848 = tensor.empty() : tensor<1x11x2048xf32>
+    %849 = "ttir.multiply"(%837, %847, %848) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %850 = tensor.empty() : tensor<1x11x2048xf32>
+    %851 = "ttir.multiply"(%arg210, %849, %850) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %852 = tensor.empty() : tensor<11x2048xf32>
+    %853 = "ttir.squeeze"(%851, %852) <{dim = 0 : si32}> : (tensor<1x11x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %854 = tensor.empty() : tensor<11x2048xf32>
+    %855 = "ttir.matmul"(%853, %arg211, %854) : (tensor<11x2048xf32>, tensor<2048x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %856 = tensor.empty() : tensor<1x11x32x64xf32>
+    %857 = "ttir.reshape"(%855, %856) <{shape = [1 : i32, 11 : i32, 32 : i32, 64 : i32]}> : (tensor<11x2048xf32>, tensor<1x11x32x64xf32>) -> tensor<1x11x32x64xf32>
+    %858 = tensor.empty() : tensor<1x32x11x64xf32>
+    %859 = "ttir.transpose"(%857, %858) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x32x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %860 = tensor.empty() : tensor<1x32x11x64xf32>
+    %861 = "ttir.multiply"(%859, %35, %860) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %862 = tensor.empty() : tensor<1x32x64x11xf32>
+    %863 = "ttir.transpose"(%859, %862) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %864 = tensor.empty() : tensor<1x32x32x11xf32>
+    %865 = "ttir.matmul"(%arg53, %863, %864) : (tensor<1x32x32x64xf32>, tensor<1x32x64x11xf32>, tensor<1x32x32x11xf32>) -> tensor<1x32x32x11xf32>
+    %866 = tensor.empty() : tensor<1x32x11x32xf32>
+    %867 = "ttir.transpose"(%865, %866) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x32x11xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %868 = tensor.empty() : tensor<1x32x11x32xf32>
+    %869 = "ttir.multiply"(%867, %arg54, %868) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x32xf32>, tensor<1xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %870 = tensor.empty() : tensor<1x32x64x11xf32>
+    %871 = "ttir.transpose"(%859, %870) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %872 = tensor.empty() : tensor<1x32x32x11xf32>
+    %873 = "ttir.matmul"(%arg55, %871, %872) : (tensor<1x32x32x64xf32>, tensor<1x32x64x11xf32>, tensor<1x32x32x11xf32>) -> tensor<1x32x32x11xf32>
+    %874 = tensor.empty() : tensor<1x32x11x32xf32>
+    %875 = "ttir.transpose"(%873, %874) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x32x11xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %876 = tensor.empty() : tensor<1x32x11x64xf32>
+    %877 = "ttir.concat"(%869, %875, %876) <{dim = -1 : si32}> : (tensor<1x32x11x32xf32>, tensor<1x32x11x32xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %878 = tensor.empty() : tensor<1x32x11x64xf32>
+    %879 = "ttir.multiply"(%877, %57, %878) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %880 = tensor.empty() : tensor<1x32x11x64xf32>
+    %881 = "ttir.add"(%861, %879, %880) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x32x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %882 = tensor.empty() : tensor<32x11x64xf32>
+    %883 = "ttir.squeeze"(%881, %882) <{dim = 0 : si32}> : (tensor<1x32x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %884 = tensor.empty() : tensor<11x512xf32>
+    %885 = "ttir.matmul"(%853, %arg212, %884) : (tensor<11x2048xf32>, tensor<2048x512xf32>, tensor<11x512xf32>) -> tensor<11x512xf32>
+    %886 = tensor.empty() : tensor<1x11x8x64xf32>
+    %887 = "ttir.reshape"(%885, %886) <{shape = [1 : i32, 11 : i32, 8 : i32, 64 : i32]}> : (tensor<11x512xf32>, tensor<1x11x8x64xf32>) -> tensor<1x11x8x64xf32>
+    %888 = tensor.empty() : tensor<1x8x11x64xf32>
+    %889 = "ttir.transpose"(%887, %888) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x8x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %890 = tensor.empty() : tensor<1x8x11x64xf32>
+    %891 = "ttir.multiply"(%889, %35, %890) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %892 = tensor.empty() : tensor<1x8x64x11xf32>
+    %893 = "ttir.transpose"(%889, %892) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x64x11xf32>) -> tensor<1x8x64x11xf32>
+    %894 = tensor.empty() : tensor<1x8x32x11xf32>
+    %895 = "ttir.matmul"(%arg56, %893, %894) : (tensor<1x8x32x64xf32>, tensor<1x8x64x11xf32>, tensor<1x8x32x11xf32>) -> tensor<1x8x32x11xf32>
+    %896 = tensor.empty() : tensor<1x8x11x32xf32>
+    %897 = "ttir.transpose"(%895, %896) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x32x11xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %898 = tensor.empty() : tensor<1x8x11x32xf32>
+    %899 = "ttir.multiply"(%897, %arg57, %898) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x32xf32>, tensor<1xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %900 = tensor.empty() : tensor<1x8x64x11xf32>
+    %901 = "ttir.transpose"(%889, %900) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x64x11xf32>) -> tensor<1x8x64x11xf32>
+    %902 = tensor.empty() : tensor<1x8x32x11xf32>
+    %903 = "ttir.matmul"(%arg58, %901, %902) : (tensor<1x8x32x64xf32>, tensor<1x8x64x11xf32>, tensor<1x8x32x11xf32>) -> tensor<1x8x32x11xf32>
+    %904 = tensor.empty() : tensor<1x8x11x32xf32>
+    %905 = "ttir.transpose"(%903, %904) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x32x11xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %906 = tensor.empty() : tensor<1x8x11x64xf32>
+    %907 = "ttir.concat"(%899, %905, %906) <{dim = -1 : si32}> : (tensor<1x8x11x32xf32>, tensor<1x8x11x32xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %908 = tensor.empty() : tensor<1x8x11x64xf32>
+    %909 = "ttir.multiply"(%907, %57, %908) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %910 = tensor.empty() : tensor<1x8x11x64xf32>
+    %911 = "ttir.add"(%891, %909, %910) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x8x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %912 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %913 = "ttir.unsqueeze"(%911, %912) <{dim = 2 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %914 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %915 = "ttir.repeat_interleave"(%913, %914) <{dim = 0 : si32, repeats = 1 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %916 = tensor.empty() : tensor<1x8x4x11x64xf32>
+    %917 = "ttir.repeat_interleave"(%915, %916) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x4x11x64xf32>) -> tensor<1x8x4x11x64xf32>
+    %918 = tensor.empty() : tensor<32x11x64xf32>
+    %919 = "ttir.reshape"(%917, %918) <{shape = [32 : i32, 11 : i32, 64 : i32]}> : (tensor<1x8x4x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %920 = tensor.empty() : tensor<32x64x11xf32>
+    %921 = "ttir.transpose"(%919, %920) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x11x64xf32>, tensor<32x64x11xf32>) -> tensor<32x64x11xf32>
+    %922 = tensor.empty() : tensor<32x11x11xf32>
+    %923 = "ttir.matmul"(%883, %921, %922) : (tensor<32x11x64xf32>, tensor<32x64x11xf32>, tensor<32x11x11xf32>) -> tensor<32x11x11xf32>
+    %924 = tensor.empty() : tensor<1x32x11x11xf32>
+    %925 = "ttir.unsqueeze"(%923, %924) <{dim = 0 : si32}> : (tensor<32x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %926 = tensor.empty() : tensor<1x32x11x11xf32>
+    %927 = "ttir.multiply"(%925, %arg59, %926) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x11xf32>, tensor<1xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %928 = tensor.empty() : tensor<1x32x11x11xf32>
+    %929 = "ttir.add"(%927, %arg60, %928) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x11xf32>, tensor<1x1x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %930 = tensor.empty() : tensor<1x32x11x11xf32>
+    %931 = "ttir.softmax"(%929, %930) <{dimension = -1 : si32}> : (tensor<1x32x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %932 = tensor.empty() : tensor<32x11x11xf32>
+    %933 = "ttir.squeeze"(%931, %932) <{dim = 0 : si32}> : (tensor<1x32x11x11xf32>, tensor<32x11x11xf32>) -> tensor<32x11x11xf32>
+    %934 = tensor.empty() : tensor<11x512xf32>
+    %935 = "ttir.matmul"(%853, %arg213, %934) : (tensor<11x2048xf32>, tensor<2048x512xf32>, tensor<11x512xf32>) -> tensor<11x512xf32>
+    %936 = tensor.empty() : tensor<1x11x8x64xf32>
+    %937 = "ttir.reshape"(%935, %936) <{shape = [1 : i32, 11 : i32, 8 : i32, 64 : i32]}> : (tensor<11x512xf32>, tensor<1x11x8x64xf32>) -> tensor<1x11x8x64xf32>
+    %938 = tensor.empty() : tensor<1x8x11x64xf32>
+    %939 = "ttir.transpose"(%937, %938) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x8x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %940 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %941 = "ttir.unsqueeze"(%939, %940) <{dim = 2 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %942 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %943 = "ttir.repeat_interleave"(%941, %942) <{dim = 0 : si32, repeats = 1 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %944 = tensor.empty() : tensor<1x8x4x11x64xf32>
+    %945 = "ttir.repeat_interleave"(%943, %944) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x4x11x64xf32>) -> tensor<1x8x4x11x64xf32>
+    %946 = tensor.empty() : tensor<1x32x11x64xf32>
+    %947 = "ttir.reshape"(%945, %946) <{shape = [1 : i32, 32 : i32, 11 : i32, 64 : i32]}> : (tensor<1x8x4x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %948 = tensor.empty() : tensor<1x32x64x11xf32>
+    %949 = "ttir.transpose"(%947, %948) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %950 = tensor.empty() : tensor<32x64x11xf32>
+    %951 = "ttir.squeeze"(%949, %950) <{dim = 0 : si32}> : (tensor<1x32x64x11xf32>, tensor<32x64x11xf32>) -> tensor<32x64x11xf32>
+    %952 = tensor.empty() : tensor<32x11x64xf32>
+    %953 = "ttir.transpose"(%951, %952) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x64x11xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %954 = tensor.empty() : tensor<32x11x64xf32>
+    %955 = "ttir.matmul"(%933, %953, %954) : (tensor<32x11x11xf32>, tensor<32x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %956 = tensor.empty() : tensor<1x32x11x64xf32>
+    %957 = "ttir.unsqueeze"(%955, %956) <{dim = 0 : si32}> : (tensor<32x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %958 = tensor.empty() : tensor<1x11x32x64xf32>
+    %959 = "ttir.transpose"(%957, %958) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x11x32x64xf32>) -> tensor<1x11x32x64xf32>
+    %960 = tensor.empty() : tensor<11x2048xf32>
+    %961 = "ttir.reshape"(%959, %960) <{shape = [11 : i32, 2048 : i32]}> : (tensor<1x11x32x64xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %962 = tensor.empty() : tensor<11x2048xf32>
+    %963 = "ttir.matmul"(%961, %arg214, %962) : (tensor<11x2048xf32>, tensor<2048x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %964 = tensor.empty() : tensor<1x11x2048xf32>
+    %965 = "ttir.unsqueeze"(%963, %964) <{dim = 0 : si32}> : (tensor<11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %966 = tensor.empty() : tensor<1x11x2048xf32>
+    %967 = "ttir.add"(%837, %965, %966) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %968 = tensor.empty() : tensor<1x11x2048xf32>
+    %969 = "ttir.multiply"(%967, %967, %968) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %970 = tensor.empty() : tensor<1x11x1xf32>
+    %971 = "ttir.mean"(%969, %970) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %972 = tensor.empty() : tensor<1x11x1xf32>
+    %973 = "ttir.add"(%971, %arg61, %972) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %974 = tensor.empty() : tensor<1x11x1xf32>
+    %975 = "ttir.sqrt"(%973, %974) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %976 = tensor.empty() : tensor<1x11x1xf32>
+    %977 = "ttir.reciprocal"(%975, %976) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %978 = tensor.empty() : tensor<1x11x2048xf32>
+    %979 = "ttir.multiply"(%967, %977, %978) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %980 = tensor.empty() : tensor<1x11x2048xf32>
+    %981 = "ttir.multiply"(%arg215, %979, %980) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %982 = tensor.empty() : tensor<11x2048xf32>
+    %983 = "ttir.squeeze"(%981, %982) <{dim = 0 : si32}> : (tensor<1x11x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %984 = tensor.empty() : tensor<11x8192xf32>
+    %985 = "ttir.matmul"(%983, %arg216, %984) : (tensor<11x2048xf32>, tensor<2048x8192xf32>, tensor<11x8192xf32>) -> tensor<11x8192xf32>
+    %986 = tensor.empty() : tensor<1x11x8192xf32>
+    %987 = "ttir.unsqueeze"(%985, %986) <{dim = 0 : si32}> : (tensor<11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %988 = tensor.empty() : tensor<1x11x8192xf32>
+    %989 = "ttir.sigmoid"(%987, %988) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %990 = tensor.empty() : tensor<1x11x8192xf32>
+    %991 = "ttir.multiply"(%987, %989, %990) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %992 = tensor.empty() : tensor<11x8192xf32>
+    %993 = "ttir.matmul"(%983, %arg217, %992) : (tensor<11x2048xf32>, tensor<2048x8192xf32>, tensor<11x8192xf32>) -> tensor<11x8192xf32>
+    %994 = tensor.empty() : tensor<1x11x8192xf32>
+    %995 = "ttir.unsqueeze"(%993, %994) <{dim = 0 : si32}> : (tensor<11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %996 = tensor.empty() : tensor<1x11x8192xf32>
+    %997 = "ttir.multiply"(%991, %995, %996) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %998 = tensor.empty() : tensor<1x11x2048xf32>
+    %999 = "ttir.matmul"(%997, %arg218, %998) : (tensor<1x11x8192xf32>, tensor<8192x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1000 = tensor.empty() : tensor<1x11x2048xf32>
+    %1001 = "ttir.add"(%967, %999, %1000) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1002 = tensor.empty() : tensor<1x11x2048xf32>
+    %1003 = "ttir.multiply"(%1001, %1001, %1002) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1004 = tensor.empty() : tensor<1x11x1xf32>
+    %1005 = "ttir.mean"(%1003, %1004) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1006 = tensor.empty() : tensor<1x11x1xf32>
+    %1007 = "ttir.add"(%1005, %arg62, %1006) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1008 = tensor.empty() : tensor<1x11x1xf32>
+    %1009 = "ttir.sqrt"(%1007, %1008) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1010 = tensor.empty() : tensor<1x11x1xf32>
+    %1011 = "ttir.reciprocal"(%1009, %1010) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1012 = tensor.empty() : tensor<1x11x2048xf32>
+    %1013 = "ttir.multiply"(%1001, %1011, %1012) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1014 = tensor.empty() : tensor<1x11x2048xf32>
+    %1015 = "ttir.multiply"(%arg219, %1013, %1014) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1016 = tensor.empty() : tensor<11x2048xf32>
+    %1017 = "ttir.squeeze"(%1015, %1016) <{dim = 0 : si32}> : (tensor<1x11x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %1018 = tensor.empty() : tensor<11x2048xf32>
+    %1019 = "ttir.matmul"(%1017, %arg220, %1018) : (tensor<11x2048xf32>, tensor<2048x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %1020 = tensor.empty() : tensor<1x11x32x64xf32>
+    %1021 = "ttir.reshape"(%1019, %1020) <{shape = [1 : i32, 11 : i32, 32 : i32, 64 : i32]}> : (tensor<11x2048xf32>, tensor<1x11x32x64xf32>) -> tensor<1x11x32x64xf32>
+    %1022 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1023 = "ttir.transpose"(%1021, %1022) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x32x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1024 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1025 = "ttir.multiply"(%1023, %35, %1024) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1026 = tensor.empty() : tensor<1x32x64x11xf32>
+    %1027 = "ttir.transpose"(%1023, %1026) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %1028 = tensor.empty() : tensor<1x32x32x11xf32>
+    %1029 = "ttir.matmul"(%arg63, %1027, %1028) : (tensor<1x32x32x64xf32>, tensor<1x32x64x11xf32>, tensor<1x32x32x11xf32>) -> tensor<1x32x32x11xf32>
+    %1030 = tensor.empty() : tensor<1x32x11x32xf32>
+    %1031 = "ttir.transpose"(%1029, %1030) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x32x11xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %1032 = tensor.empty() : tensor<1x32x11x32xf32>
+    %1033 = "ttir.multiply"(%1031, %arg64, %1032) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x32xf32>, tensor<1xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %1034 = tensor.empty() : tensor<1x32x64x11xf32>
+    %1035 = "ttir.transpose"(%1023, %1034) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %1036 = tensor.empty() : tensor<1x32x32x11xf32>
+    %1037 = "ttir.matmul"(%arg65, %1035, %1036) : (tensor<1x32x32x64xf32>, tensor<1x32x64x11xf32>, tensor<1x32x32x11xf32>) -> tensor<1x32x32x11xf32>
+    %1038 = tensor.empty() : tensor<1x32x11x32xf32>
+    %1039 = "ttir.transpose"(%1037, %1038) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x32x11xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %1040 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1041 = "ttir.concat"(%1033, %1039, %1040) <{dim = -1 : si32}> : (tensor<1x32x11x32xf32>, tensor<1x32x11x32xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1042 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1043 = "ttir.multiply"(%1041, %57, %1042) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1044 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1045 = "ttir.add"(%1025, %1043, %1044) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x32x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1046 = tensor.empty() : tensor<32x11x64xf32>
+    %1047 = "ttir.squeeze"(%1045, %1046) <{dim = 0 : si32}> : (tensor<1x32x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %1048 = tensor.empty() : tensor<11x512xf32>
+    %1049 = "ttir.matmul"(%1017, %arg221, %1048) : (tensor<11x2048xf32>, tensor<2048x512xf32>, tensor<11x512xf32>) -> tensor<11x512xf32>
+    %1050 = tensor.empty() : tensor<1x11x8x64xf32>
+    %1051 = "ttir.reshape"(%1049, %1050) <{shape = [1 : i32, 11 : i32, 8 : i32, 64 : i32]}> : (tensor<11x512xf32>, tensor<1x11x8x64xf32>) -> tensor<1x11x8x64xf32>
+    %1052 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1053 = "ttir.transpose"(%1051, %1052) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x8x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1054 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1055 = "ttir.multiply"(%1053, %35, %1054) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1056 = tensor.empty() : tensor<1x8x64x11xf32>
+    %1057 = "ttir.transpose"(%1053, %1056) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x64x11xf32>) -> tensor<1x8x64x11xf32>
+    %1058 = tensor.empty() : tensor<1x8x32x11xf32>
+    %1059 = "ttir.matmul"(%arg66, %1057, %1058) : (tensor<1x8x32x64xf32>, tensor<1x8x64x11xf32>, tensor<1x8x32x11xf32>) -> tensor<1x8x32x11xf32>
+    %1060 = tensor.empty() : tensor<1x8x11x32xf32>
+    %1061 = "ttir.transpose"(%1059, %1060) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x32x11xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %1062 = tensor.empty() : tensor<1x8x11x32xf32>
+    %1063 = "ttir.multiply"(%1061, %arg67, %1062) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x32xf32>, tensor<1xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %1064 = tensor.empty() : tensor<1x8x64x11xf32>
+    %1065 = "ttir.transpose"(%1053, %1064) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x64x11xf32>) -> tensor<1x8x64x11xf32>
+    %1066 = tensor.empty() : tensor<1x8x32x11xf32>
+    %1067 = "ttir.matmul"(%arg68, %1065, %1066) : (tensor<1x8x32x64xf32>, tensor<1x8x64x11xf32>, tensor<1x8x32x11xf32>) -> tensor<1x8x32x11xf32>
+    %1068 = tensor.empty() : tensor<1x8x11x32xf32>
+    %1069 = "ttir.transpose"(%1067, %1068) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x32x11xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %1070 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1071 = "ttir.concat"(%1063, %1069, %1070) <{dim = -1 : si32}> : (tensor<1x8x11x32xf32>, tensor<1x8x11x32xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1072 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1073 = "ttir.multiply"(%1071, %57, %1072) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1074 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1075 = "ttir.add"(%1055, %1073, %1074) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x8x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1076 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %1077 = "ttir.unsqueeze"(%1075, %1076) <{dim = 2 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %1078 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %1079 = "ttir.repeat_interleave"(%1077, %1078) <{dim = 0 : si32, repeats = 1 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %1080 = tensor.empty() : tensor<1x8x4x11x64xf32>
+    %1081 = "ttir.repeat_interleave"(%1079, %1080) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x4x11x64xf32>) -> tensor<1x8x4x11x64xf32>
+    %1082 = tensor.empty() : tensor<32x11x64xf32>
+    %1083 = "ttir.reshape"(%1081, %1082) <{shape = [32 : i32, 11 : i32, 64 : i32]}> : (tensor<1x8x4x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %1084 = tensor.empty() : tensor<32x64x11xf32>
+    %1085 = "ttir.transpose"(%1083, %1084) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x11x64xf32>, tensor<32x64x11xf32>) -> tensor<32x64x11xf32>
+    %1086 = tensor.empty() : tensor<32x11x11xf32>
+    %1087 = "ttir.matmul"(%1047, %1085, %1086) : (tensor<32x11x64xf32>, tensor<32x64x11xf32>, tensor<32x11x11xf32>) -> tensor<32x11x11xf32>
+    %1088 = tensor.empty() : tensor<1x32x11x11xf32>
+    %1089 = "ttir.unsqueeze"(%1087, %1088) <{dim = 0 : si32}> : (tensor<32x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %1090 = tensor.empty() : tensor<1x32x11x11xf32>
+    %1091 = "ttir.multiply"(%1089, %arg69, %1090) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x11xf32>, tensor<1xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %1092 = tensor.empty() : tensor<1x32x11x11xf32>
+    %1093 = "ttir.add"(%1091, %arg70, %1092) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x11xf32>, tensor<1x1x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %1094 = tensor.empty() : tensor<1x32x11x11xf32>
+    %1095 = "ttir.softmax"(%1093, %1094) <{dimension = -1 : si32}> : (tensor<1x32x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %1096 = tensor.empty() : tensor<32x11x11xf32>
+    %1097 = "ttir.squeeze"(%1095, %1096) <{dim = 0 : si32}> : (tensor<1x32x11x11xf32>, tensor<32x11x11xf32>) -> tensor<32x11x11xf32>
+    %1098 = tensor.empty() : tensor<11x512xf32>
+    %1099 = "ttir.matmul"(%1017, %arg222, %1098) : (tensor<11x2048xf32>, tensor<2048x512xf32>, tensor<11x512xf32>) -> tensor<11x512xf32>
+    %1100 = tensor.empty() : tensor<1x11x8x64xf32>
+    %1101 = "ttir.reshape"(%1099, %1100) <{shape = [1 : i32, 11 : i32, 8 : i32, 64 : i32]}> : (tensor<11x512xf32>, tensor<1x11x8x64xf32>) -> tensor<1x11x8x64xf32>
+    %1102 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1103 = "ttir.transpose"(%1101, %1102) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x8x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1104 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %1105 = "ttir.unsqueeze"(%1103, %1104) <{dim = 2 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %1106 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %1107 = "ttir.repeat_interleave"(%1105, %1106) <{dim = 0 : si32, repeats = 1 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %1108 = tensor.empty() : tensor<1x8x4x11x64xf32>
+    %1109 = "ttir.repeat_interleave"(%1107, %1108) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x4x11x64xf32>) -> tensor<1x8x4x11x64xf32>
+    %1110 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1111 = "ttir.reshape"(%1109, %1110) <{shape = [1 : i32, 32 : i32, 11 : i32, 64 : i32]}> : (tensor<1x8x4x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1112 = tensor.empty() : tensor<1x32x64x11xf32>
+    %1113 = "ttir.transpose"(%1111, %1112) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %1114 = tensor.empty() : tensor<32x64x11xf32>
+    %1115 = "ttir.squeeze"(%1113, %1114) <{dim = 0 : si32}> : (tensor<1x32x64x11xf32>, tensor<32x64x11xf32>) -> tensor<32x64x11xf32>
+    %1116 = tensor.empty() : tensor<32x11x64xf32>
+    %1117 = "ttir.transpose"(%1115, %1116) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x64x11xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %1118 = tensor.empty() : tensor<32x11x64xf32>
+    %1119 = "ttir.matmul"(%1097, %1117, %1118) : (tensor<32x11x11xf32>, tensor<32x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %1120 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1121 = "ttir.unsqueeze"(%1119, %1120) <{dim = 0 : si32}> : (tensor<32x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1122 = tensor.empty() : tensor<1x11x32x64xf32>
+    %1123 = "ttir.transpose"(%1121, %1122) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x11x32x64xf32>) -> tensor<1x11x32x64xf32>
+    %1124 = tensor.empty() : tensor<11x2048xf32>
+    %1125 = "ttir.reshape"(%1123, %1124) <{shape = [11 : i32, 2048 : i32]}> : (tensor<1x11x32x64xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %1126 = tensor.empty() : tensor<11x2048xf32>
+    %1127 = "ttir.matmul"(%1125, %arg223, %1126) : (tensor<11x2048xf32>, tensor<2048x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %1128 = tensor.empty() : tensor<1x11x2048xf32>
+    %1129 = "ttir.unsqueeze"(%1127, %1128) <{dim = 0 : si32}> : (tensor<11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1130 = tensor.empty() : tensor<1x11x2048xf32>
+    %1131 = "ttir.add"(%1001, %1129, %1130) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1132 = tensor.empty() : tensor<1x11x2048xf32>
+    %1133 = "ttir.multiply"(%1131, %1131, %1132) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1134 = tensor.empty() : tensor<1x11x1xf32>
+    %1135 = "ttir.mean"(%1133, %1134) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1136 = tensor.empty() : tensor<1x11x1xf32>
+    %1137 = "ttir.add"(%1135, %arg71, %1136) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1138 = tensor.empty() : tensor<1x11x1xf32>
+    %1139 = "ttir.sqrt"(%1137, %1138) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1140 = tensor.empty() : tensor<1x11x1xf32>
+    %1141 = "ttir.reciprocal"(%1139, %1140) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1142 = tensor.empty() : tensor<1x11x2048xf32>
+    %1143 = "ttir.multiply"(%1131, %1141, %1142) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1144 = tensor.empty() : tensor<1x11x2048xf32>
+    %1145 = "ttir.multiply"(%arg224, %1143, %1144) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1146 = tensor.empty() : tensor<11x2048xf32>
+    %1147 = "ttir.squeeze"(%1145, %1146) <{dim = 0 : si32}> : (tensor<1x11x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %1148 = tensor.empty() : tensor<11x8192xf32>
+    %1149 = "ttir.matmul"(%1147, %arg225, %1148) : (tensor<11x2048xf32>, tensor<2048x8192xf32>, tensor<11x8192xf32>) -> tensor<11x8192xf32>
+    %1150 = tensor.empty() : tensor<1x11x8192xf32>
+    %1151 = "ttir.unsqueeze"(%1149, %1150) <{dim = 0 : si32}> : (tensor<11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %1152 = tensor.empty() : tensor<1x11x8192xf32>
+    %1153 = "ttir.sigmoid"(%1151, %1152) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %1154 = tensor.empty() : tensor<1x11x8192xf32>
+    %1155 = "ttir.multiply"(%1151, %1153, %1154) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %1156 = tensor.empty() : tensor<11x8192xf32>
+    %1157 = "ttir.matmul"(%1147, %arg226, %1156) : (tensor<11x2048xf32>, tensor<2048x8192xf32>, tensor<11x8192xf32>) -> tensor<11x8192xf32>
+    %1158 = tensor.empty() : tensor<1x11x8192xf32>
+    %1159 = "ttir.unsqueeze"(%1157, %1158) <{dim = 0 : si32}> : (tensor<11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %1160 = tensor.empty() : tensor<1x11x8192xf32>
+    %1161 = "ttir.multiply"(%1155, %1159, %1160) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %1162 = tensor.empty() : tensor<1x11x2048xf32>
+    %1163 = "ttir.matmul"(%1161, %arg227, %1162) : (tensor<1x11x8192xf32>, tensor<8192x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1164 = tensor.empty() : tensor<1x11x2048xf32>
+    %1165 = "ttir.add"(%1131, %1163, %1164) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1166 = tensor.empty() : tensor<1x11x2048xf32>
+    %1167 = "ttir.multiply"(%1165, %1165, %1166) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1168 = tensor.empty() : tensor<1x11x1xf32>
+    %1169 = "ttir.mean"(%1167, %1168) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1170 = tensor.empty() : tensor<1x11x1xf32>
+    %1171 = "ttir.add"(%1169, %arg72, %1170) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1172 = tensor.empty() : tensor<1x11x1xf32>
+    %1173 = "ttir.sqrt"(%1171, %1172) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1174 = tensor.empty() : tensor<1x11x1xf32>
+    %1175 = "ttir.reciprocal"(%1173, %1174) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1176 = tensor.empty() : tensor<1x11x2048xf32>
+    %1177 = "ttir.multiply"(%1165, %1175, %1176) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1178 = tensor.empty() : tensor<1x11x2048xf32>
+    %1179 = "ttir.multiply"(%arg228, %1177, %1178) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1180 = tensor.empty() : tensor<11x2048xf32>
+    %1181 = "ttir.squeeze"(%1179, %1180) <{dim = 0 : si32}> : (tensor<1x11x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %1182 = tensor.empty() : tensor<11x2048xf32>
+    %1183 = "ttir.matmul"(%1181, %arg229, %1182) : (tensor<11x2048xf32>, tensor<2048x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %1184 = tensor.empty() : tensor<1x11x32x64xf32>
+    %1185 = "ttir.reshape"(%1183, %1184) <{shape = [1 : i32, 11 : i32, 32 : i32, 64 : i32]}> : (tensor<11x2048xf32>, tensor<1x11x32x64xf32>) -> tensor<1x11x32x64xf32>
+    %1186 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1187 = "ttir.transpose"(%1185, %1186) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x32x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1188 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1189 = "ttir.multiply"(%1187, %35, %1188) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1190 = tensor.empty() : tensor<1x32x64x11xf32>
+    %1191 = "ttir.transpose"(%1187, %1190) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %1192 = tensor.empty() : tensor<1x32x32x11xf32>
+    %1193 = "ttir.matmul"(%arg73, %1191, %1192) : (tensor<1x32x32x64xf32>, tensor<1x32x64x11xf32>, tensor<1x32x32x11xf32>) -> tensor<1x32x32x11xf32>
+    %1194 = tensor.empty() : tensor<1x32x11x32xf32>
+    %1195 = "ttir.transpose"(%1193, %1194) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x32x11xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %1196 = tensor.empty() : tensor<1x32x11x32xf32>
+    %1197 = "ttir.multiply"(%1195, %arg74, %1196) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x32xf32>, tensor<1xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %1198 = tensor.empty() : tensor<1x32x64x11xf32>
+    %1199 = "ttir.transpose"(%1187, %1198) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %1200 = tensor.empty() : tensor<1x32x32x11xf32>
+    %1201 = "ttir.matmul"(%arg75, %1199, %1200) : (tensor<1x32x32x64xf32>, tensor<1x32x64x11xf32>, tensor<1x32x32x11xf32>) -> tensor<1x32x32x11xf32>
+    %1202 = tensor.empty() : tensor<1x32x11x32xf32>
+    %1203 = "ttir.transpose"(%1201, %1202) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x32x11xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %1204 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1205 = "ttir.concat"(%1197, %1203, %1204) <{dim = -1 : si32}> : (tensor<1x32x11x32xf32>, tensor<1x32x11x32xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1206 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1207 = "ttir.multiply"(%1205, %57, %1206) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1208 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1209 = "ttir.add"(%1189, %1207, %1208) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x32x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1210 = tensor.empty() : tensor<32x11x64xf32>
+    %1211 = "ttir.squeeze"(%1209, %1210) <{dim = 0 : si32}> : (tensor<1x32x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %1212 = tensor.empty() : tensor<11x512xf32>
+    %1213 = "ttir.matmul"(%1181, %arg230, %1212) : (tensor<11x2048xf32>, tensor<2048x512xf32>, tensor<11x512xf32>) -> tensor<11x512xf32>
+    %1214 = tensor.empty() : tensor<1x11x8x64xf32>
+    %1215 = "ttir.reshape"(%1213, %1214) <{shape = [1 : i32, 11 : i32, 8 : i32, 64 : i32]}> : (tensor<11x512xf32>, tensor<1x11x8x64xf32>) -> tensor<1x11x8x64xf32>
+    %1216 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1217 = "ttir.transpose"(%1215, %1216) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x8x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1218 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1219 = "ttir.multiply"(%1217, %35, %1218) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1220 = tensor.empty() : tensor<1x8x64x11xf32>
+    %1221 = "ttir.transpose"(%1217, %1220) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x64x11xf32>) -> tensor<1x8x64x11xf32>
+    %1222 = tensor.empty() : tensor<1x8x32x11xf32>
+    %1223 = "ttir.matmul"(%arg76, %1221, %1222) : (tensor<1x8x32x64xf32>, tensor<1x8x64x11xf32>, tensor<1x8x32x11xf32>) -> tensor<1x8x32x11xf32>
+    %1224 = tensor.empty() : tensor<1x8x11x32xf32>
+    %1225 = "ttir.transpose"(%1223, %1224) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x32x11xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %1226 = tensor.empty() : tensor<1x8x11x32xf32>
+    %1227 = "ttir.multiply"(%1225, %arg77, %1226) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x32xf32>, tensor<1xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %1228 = tensor.empty() : tensor<1x8x64x11xf32>
+    %1229 = "ttir.transpose"(%1217, %1228) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x64x11xf32>) -> tensor<1x8x64x11xf32>
+    %1230 = tensor.empty() : tensor<1x8x32x11xf32>
+    %1231 = "ttir.matmul"(%arg78, %1229, %1230) : (tensor<1x8x32x64xf32>, tensor<1x8x64x11xf32>, tensor<1x8x32x11xf32>) -> tensor<1x8x32x11xf32>
+    %1232 = tensor.empty() : tensor<1x8x11x32xf32>
+    %1233 = "ttir.transpose"(%1231, %1232) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x32x11xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %1234 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1235 = "ttir.concat"(%1227, %1233, %1234) <{dim = -1 : si32}> : (tensor<1x8x11x32xf32>, tensor<1x8x11x32xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1236 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1237 = "ttir.multiply"(%1235, %57, %1236) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1238 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1239 = "ttir.add"(%1219, %1237, %1238) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x8x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1240 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %1241 = "ttir.unsqueeze"(%1239, %1240) <{dim = 2 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %1242 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %1243 = "ttir.repeat_interleave"(%1241, %1242) <{dim = 0 : si32, repeats = 1 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %1244 = tensor.empty() : tensor<1x8x4x11x64xf32>
+    %1245 = "ttir.repeat_interleave"(%1243, %1244) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x4x11x64xf32>) -> tensor<1x8x4x11x64xf32>
+    %1246 = tensor.empty() : tensor<32x11x64xf32>
+    %1247 = "ttir.reshape"(%1245, %1246) <{shape = [32 : i32, 11 : i32, 64 : i32]}> : (tensor<1x8x4x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %1248 = tensor.empty() : tensor<32x64x11xf32>
+    %1249 = "ttir.transpose"(%1247, %1248) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x11x64xf32>, tensor<32x64x11xf32>) -> tensor<32x64x11xf32>
+    %1250 = tensor.empty() : tensor<32x11x11xf32>
+    %1251 = "ttir.matmul"(%1211, %1249, %1250) : (tensor<32x11x64xf32>, tensor<32x64x11xf32>, tensor<32x11x11xf32>) -> tensor<32x11x11xf32>
+    %1252 = tensor.empty() : tensor<1x32x11x11xf32>
+    %1253 = "ttir.unsqueeze"(%1251, %1252) <{dim = 0 : si32}> : (tensor<32x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %1254 = tensor.empty() : tensor<1x32x11x11xf32>
+    %1255 = "ttir.multiply"(%1253, %arg79, %1254) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x11xf32>, tensor<1xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %1256 = tensor.empty() : tensor<1x32x11x11xf32>
+    %1257 = "ttir.add"(%1255, %arg80, %1256) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x11xf32>, tensor<1x1x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %1258 = tensor.empty() : tensor<1x32x11x11xf32>
+    %1259 = "ttir.softmax"(%1257, %1258) <{dimension = -1 : si32}> : (tensor<1x32x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %1260 = tensor.empty() : tensor<32x11x11xf32>
+    %1261 = "ttir.squeeze"(%1259, %1260) <{dim = 0 : si32}> : (tensor<1x32x11x11xf32>, tensor<32x11x11xf32>) -> tensor<32x11x11xf32>
+    %1262 = tensor.empty() : tensor<11x512xf32>
+    %1263 = "ttir.matmul"(%1181, %arg231, %1262) : (tensor<11x2048xf32>, tensor<2048x512xf32>, tensor<11x512xf32>) -> tensor<11x512xf32>
+    %1264 = tensor.empty() : tensor<1x11x8x64xf32>
+    %1265 = "ttir.reshape"(%1263, %1264) <{shape = [1 : i32, 11 : i32, 8 : i32, 64 : i32]}> : (tensor<11x512xf32>, tensor<1x11x8x64xf32>) -> tensor<1x11x8x64xf32>
+    %1266 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1267 = "ttir.transpose"(%1265, %1266) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x8x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1268 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %1269 = "ttir.unsqueeze"(%1267, %1268) <{dim = 2 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %1270 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %1271 = "ttir.repeat_interleave"(%1269, %1270) <{dim = 0 : si32, repeats = 1 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %1272 = tensor.empty() : tensor<1x8x4x11x64xf32>
+    %1273 = "ttir.repeat_interleave"(%1271, %1272) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x4x11x64xf32>) -> tensor<1x8x4x11x64xf32>
+    %1274 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1275 = "ttir.reshape"(%1273, %1274) <{shape = [1 : i32, 32 : i32, 11 : i32, 64 : i32]}> : (tensor<1x8x4x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1276 = tensor.empty() : tensor<1x32x64x11xf32>
+    %1277 = "ttir.transpose"(%1275, %1276) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %1278 = tensor.empty() : tensor<32x64x11xf32>
+    %1279 = "ttir.squeeze"(%1277, %1278) <{dim = 0 : si32}> : (tensor<1x32x64x11xf32>, tensor<32x64x11xf32>) -> tensor<32x64x11xf32>
+    %1280 = tensor.empty() : tensor<32x11x64xf32>
+    %1281 = "ttir.transpose"(%1279, %1280) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x64x11xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %1282 = tensor.empty() : tensor<32x11x64xf32>
+    %1283 = "ttir.matmul"(%1261, %1281, %1282) : (tensor<32x11x11xf32>, tensor<32x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %1284 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1285 = "ttir.unsqueeze"(%1283, %1284) <{dim = 0 : si32}> : (tensor<32x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1286 = tensor.empty() : tensor<1x11x32x64xf32>
+    %1287 = "ttir.transpose"(%1285, %1286) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x11x32x64xf32>) -> tensor<1x11x32x64xf32>
+    %1288 = tensor.empty() : tensor<11x2048xf32>
+    %1289 = "ttir.reshape"(%1287, %1288) <{shape = [11 : i32, 2048 : i32]}> : (tensor<1x11x32x64xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %1290 = tensor.empty() : tensor<11x2048xf32>
+    %1291 = "ttir.matmul"(%1289, %arg232, %1290) : (tensor<11x2048xf32>, tensor<2048x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %1292 = tensor.empty() : tensor<1x11x2048xf32>
+    %1293 = "ttir.unsqueeze"(%1291, %1292) <{dim = 0 : si32}> : (tensor<11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1294 = tensor.empty() : tensor<1x11x2048xf32>
+    %1295 = "ttir.add"(%1165, %1293, %1294) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1296 = tensor.empty() : tensor<1x11x2048xf32>
+    %1297 = "ttir.multiply"(%1295, %1295, %1296) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1298 = tensor.empty() : tensor<1x11x1xf32>
+    %1299 = "ttir.mean"(%1297, %1298) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1300 = tensor.empty() : tensor<1x11x1xf32>
+    %1301 = "ttir.add"(%1299, %arg81, %1300) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1302 = tensor.empty() : tensor<1x11x1xf32>
+    %1303 = "ttir.sqrt"(%1301, %1302) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1304 = tensor.empty() : tensor<1x11x1xf32>
+    %1305 = "ttir.reciprocal"(%1303, %1304) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1306 = tensor.empty() : tensor<1x11x2048xf32>
+    %1307 = "ttir.multiply"(%1295, %1305, %1306) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1308 = tensor.empty() : tensor<1x11x2048xf32>
+    %1309 = "ttir.multiply"(%arg233, %1307, %1308) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1310 = tensor.empty() : tensor<11x2048xf32>
+    %1311 = "ttir.squeeze"(%1309, %1310) <{dim = 0 : si32}> : (tensor<1x11x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %1312 = tensor.empty() : tensor<11x8192xf32>
+    %1313 = "ttir.matmul"(%1311, %arg234, %1312) : (tensor<11x2048xf32>, tensor<2048x8192xf32>, tensor<11x8192xf32>) -> tensor<11x8192xf32>
+    %1314 = tensor.empty() : tensor<1x11x8192xf32>
+    %1315 = "ttir.unsqueeze"(%1313, %1314) <{dim = 0 : si32}> : (tensor<11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %1316 = tensor.empty() : tensor<1x11x8192xf32>
+    %1317 = "ttir.sigmoid"(%1315, %1316) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %1318 = tensor.empty() : tensor<1x11x8192xf32>
+    %1319 = "ttir.multiply"(%1315, %1317, %1318) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %1320 = tensor.empty() : tensor<11x8192xf32>
+    %1321 = "ttir.matmul"(%1311, %arg235, %1320) : (tensor<11x2048xf32>, tensor<2048x8192xf32>, tensor<11x8192xf32>) -> tensor<11x8192xf32>
+    %1322 = tensor.empty() : tensor<1x11x8192xf32>
+    %1323 = "ttir.unsqueeze"(%1321, %1322) <{dim = 0 : si32}> : (tensor<11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %1324 = tensor.empty() : tensor<1x11x8192xf32>
+    %1325 = "ttir.multiply"(%1319, %1323, %1324) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %1326 = tensor.empty() : tensor<1x11x2048xf32>
+    %1327 = "ttir.matmul"(%1325, %arg236, %1326) : (tensor<1x11x8192xf32>, tensor<8192x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1328 = tensor.empty() : tensor<1x11x2048xf32>
+    %1329 = "ttir.add"(%1295, %1327, %1328) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1330 = tensor.empty() : tensor<1x11x2048xf32>
+    %1331 = "ttir.multiply"(%1329, %1329, %1330) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1332 = tensor.empty() : tensor<1x11x1xf32>
+    %1333 = "ttir.mean"(%1331, %1332) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1334 = tensor.empty() : tensor<1x11x1xf32>
+    %1335 = "ttir.add"(%1333, %arg82, %1334) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1336 = tensor.empty() : tensor<1x11x1xf32>
+    %1337 = "ttir.sqrt"(%1335, %1336) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1338 = tensor.empty() : tensor<1x11x1xf32>
+    %1339 = "ttir.reciprocal"(%1337, %1338) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1340 = tensor.empty() : tensor<1x11x2048xf32>
+    %1341 = "ttir.multiply"(%1329, %1339, %1340) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1342 = tensor.empty() : tensor<1x11x2048xf32>
+    %1343 = "ttir.multiply"(%arg237, %1341, %1342) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1344 = tensor.empty() : tensor<11x2048xf32>
+    %1345 = "ttir.squeeze"(%1343, %1344) <{dim = 0 : si32}> : (tensor<1x11x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %1346 = tensor.empty() : tensor<11x2048xf32>
+    %1347 = "ttir.matmul"(%1345, %arg238, %1346) : (tensor<11x2048xf32>, tensor<2048x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %1348 = tensor.empty() : tensor<1x11x32x64xf32>
+    %1349 = "ttir.reshape"(%1347, %1348) <{shape = [1 : i32, 11 : i32, 32 : i32, 64 : i32]}> : (tensor<11x2048xf32>, tensor<1x11x32x64xf32>) -> tensor<1x11x32x64xf32>
+    %1350 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1351 = "ttir.transpose"(%1349, %1350) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x32x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1352 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1353 = "ttir.multiply"(%1351, %35, %1352) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1354 = tensor.empty() : tensor<1x32x64x11xf32>
+    %1355 = "ttir.transpose"(%1351, %1354) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %1356 = tensor.empty() : tensor<1x32x32x11xf32>
+    %1357 = "ttir.matmul"(%arg83, %1355, %1356) : (tensor<1x32x32x64xf32>, tensor<1x32x64x11xf32>, tensor<1x32x32x11xf32>) -> tensor<1x32x32x11xf32>
+    %1358 = tensor.empty() : tensor<1x32x11x32xf32>
+    %1359 = "ttir.transpose"(%1357, %1358) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x32x11xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %1360 = tensor.empty() : tensor<1x32x11x32xf32>
+    %1361 = "ttir.multiply"(%1359, %arg84, %1360) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x32xf32>, tensor<1xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %1362 = tensor.empty() : tensor<1x32x64x11xf32>
+    %1363 = "ttir.transpose"(%1351, %1362) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %1364 = tensor.empty() : tensor<1x32x32x11xf32>
+    %1365 = "ttir.matmul"(%arg85, %1363, %1364) : (tensor<1x32x32x64xf32>, tensor<1x32x64x11xf32>, tensor<1x32x32x11xf32>) -> tensor<1x32x32x11xf32>
+    %1366 = tensor.empty() : tensor<1x32x11x32xf32>
+    %1367 = "ttir.transpose"(%1365, %1366) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x32x11xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %1368 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1369 = "ttir.concat"(%1361, %1367, %1368) <{dim = -1 : si32}> : (tensor<1x32x11x32xf32>, tensor<1x32x11x32xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1370 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1371 = "ttir.multiply"(%1369, %57, %1370) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1372 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1373 = "ttir.add"(%1353, %1371, %1372) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x32x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1374 = tensor.empty() : tensor<32x11x64xf32>
+    %1375 = "ttir.squeeze"(%1373, %1374) <{dim = 0 : si32}> : (tensor<1x32x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %1376 = tensor.empty() : tensor<11x512xf32>
+    %1377 = "ttir.matmul"(%1345, %arg239, %1376) : (tensor<11x2048xf32>, tensor<2048x512xf32>, tensor<11x512xf32>) -> tensor<11x512xf32>
+    %1378 = tensor.empty() : tensor<1x11x8x64xf32>
+    %1379 = "ttir.reshape"(%1377, %1378) <{shape = [1 : i32, 11 : i32, 8 : i32, 64 : i32]}> : (tensor<11x512xf32>, tensor<1x11x8x64xf32>) -> tensor<1x11x8x64xf32>
+    %1380 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1381 = "ttir.transpose"(%1379, %1380) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x8x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1382 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1383 = "ttir.multiply"(%1381, %35, %1382) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1384 = tensor.empty() : tensor<1x8x64x11xf32>
+    %1385 = "ttir.transpose"(%1381, %1384) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x64x11xf32>) -> tensor<1x8x64x11xf32>
+    %1386 = tensor.empty() : tensor<1x8x32x11xf32>
+    %1387 = "ttir.matmul"(%arg86, %1385, %1386) : (tensor<1x8x32x64xf32>, tensor<1x8x64x11xf32>, tensor<1x8x32x11xf32>) -> tensor<1x8x32x11xf32>
+    %1388 = tensor.empty() : tensor<1x8x11x32xf32>
+    %1389 = "ttir.transpose"(%1387, %1388) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x32x11xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %1390 = tensor.empty() : tensor<1x8x11x32xf32>
+    %1391 = "ttir.multiply"(%1389, %arg87, %1390) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x32xf32>, tensor<1xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %1392 = tensor.empty() : tensor<1x8x64x11xf32>
+    %1393 = "ttir.transpose"(%1381, %1392) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x64x11xf32>) -> tensor<1x8x64x11xf32>
+    %1394 = tensor.empty() : tensor<1x8x32x11xf32>
+    %1395 = "ttir.matmul"(%arg88, %1393, %1394) : (tensor<1x8x32x64xf32>, tensor<1x8x64x11xf32>, tensor<1x8x32x11xf32>) -> tensor<1x8x32x11xf32>
+    %1396 = tensor.empty() : tensor<1x8x11x32xf32>
+    %1397 = "ttir.transpose"(%1395, %1396) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x32x11xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %1398 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1399 = "ttir.concat"(%1391, %1397, %1398) <{dim = -1 : si32}> : (tensor<1x8x11x32xf32>, tensor<1x8x11x32xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1400 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1401 = "ttir.multiply"(%1399, %57, %1400) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1402 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1403 = "ttir.add"(%1383, %1401, %1402) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x8x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1404 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %1405 = "ttir.unsqueeze"(%1403, %1404) <{dim = 2 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %1406 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %1407 = "ttir.repeat_interleave"(%1405, %1406) <{dim = 0 : si32, repeats = 1 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %1408 = tensor.empty() : tensor<1x8x4x11x64xf32>
+    %1409 = "ttir.repeat_interleave"(%1407, %1408) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x4x11x64xf32>) -> tensor<1x8x4x11x64xf32>
+    %1410 = tensor.empty() : tensor<32x11x64xf32>
+    %1411 = "ttir.reshape"(%1409, %1410) <{shape = [32 : i32, 11 : i32, 64 : i32]}> : (tensor<1x8x4x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %1412 = tensor.empty() : tensor<32x64x11xf32>
+    %1413 = "ttir.transpose"(%1411, %1412) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x11x64xf32>, tensor<32x64x11xf32>) -> tensor<32x64x11xf32>
+    %1414 = tensor.empty() : tensor<32x11x11xf32>
+    %1415 = "ttir.matmul"(%1375, %1413, %1414) : (tensor<32x11x64xf32>, tensor<32x64x11xf32>, tensor<32x11x11xf32>) -> tensor<32x11x11xf32>
+    %1416 = tensor.empty() : tensor<1x32x11x11xf32>
+    %1417 = "ttir.unsqueeze"(%1415, %1416) <{dim = 0 : si32}> : (tensor<32x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %1418 = tensor.empty() : tensor<1x32x11x11xf32>
+    %1419 = "ttir.multiply"(%1417, %arg89, %1418) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x11xf32>, tensor<1xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %1420 = tensor.empty() : tensor<1x32x11x11xf32>
+    %1421 = "ttir.add"(%1419, %arg90, %1420) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x11xf32>, tensor<1x1x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %1422 = tensor.empty() : tensor<1x32x11x11xf32>
+    %1423 = "ttir.softmax"(%1421, %1422) <{dimension = -1 : si32}> : (tensor<1x32x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %1424 = tensor.empty() : tensor<32x11x11xf32>
+    %1425 = "ttir.squeeze"(%1423, %1424) <{dim = 0 : si32}> : (tensor<1x32x11x11xf32>, tensor<32x11x11xf32>) -> tensor<32x11x11xf32>
+    %1426 = tensor.empty() : tensor<11x512xf32>
+    %1427 = "ttir.matmul"(%1345, %arg240, %1426) : (tensor<11x2048xf32>, tensor<2048x512xf32>, tensor<11x512xf32>) -> tensor<11x512xf32>
+    %1428 = tensor.empty() : tensor<1x11x8x64xf32>
+    %1429 = "ttir.reshape"(%1427, %1428) <{shape = [1 : i32, 11 : i32, 8 : i32, 64 : i32]}> : (tensor<11x512xf32>, tensor<1x11x8x64xf32>) -> tensor<1x11x8x64xf32>
+    %1430 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1431 = "ttir.transpose"(%1429, %1430) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x8x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1432 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %1433 = "ttir.unsqueeze"(%1431, %1432) <{dim = 2 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %1434 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %1435 = "ttir.repeat_interleave"(%1433, %1434) <{dim = 0 : si32, repeats = 1 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %1436 = tensor.empty() : tensor<1x8x4x11x64xf32>
+    %1437 = "ttir.repeat_interleave"(%1435, %1436) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x4x11x64xf32>) -> tensor<1x8x4x11x64xf32>
+    %1438 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1439 = "ttir.reshape"(%1437, %1438) <{shape = [1 : i32, 32 : i32, 11 : i32, 64 : i32]}> : (tensor<1x8x4x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1440 = tensor.empty() : tensor<1x32x64x11xf32>
+    %1441 = "ttir.transpose"(%1439, %1440) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %1442 = tensor.empty() : tensor<32x64x11xf32>
+    %1443 = "ttir.squeeze"(%1441, %1442) <{dim = 0 : si32}> : (tensor<1x32x64x11xf32>, tensor<32x64x11xf32>) -> tensor<32x64x11xf32>
+    %1444 = tensor.empty() : tensor<32x11x64xf32>
+    %1445 = "ttir.transpose"(%1443, %1444) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x64x11xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %1446 = tensor.empty() : tensor<32x11x64xf32>
+    %1447 = "ttir.matmul"(%1425, %1445, %1446) : (tensor<32x11x11xf32>, tensor<32x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %1448 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1449 = "ttir.unsqueeze"(%1447, %1448) <{dim = 0 : si32}> : (tensor<32x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1450 = tensor.empty() : tensor<1x11x32x64xf32>
+    %1451 = "ttir.transpose"(%1449, %1450) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x11x32x64xf32>) -> tensor<1x11x32x64xf32>
+    %1452 = tensor.empty() : tensor<11x2048xf32>
+    %1453 = "ttir.reshape"(%1451, %1452) <{shape = [11 : i32, 2048 : i32]}> : (tensor<1x11x32x64xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %1454 = tensor.empty() : tensor<11x2048xf32>
+    %1455 = "ttir.matmul"(%1453, %arg241, %1454) : (tensor<11x2048xf32>, tensor<2048x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %1456 = tensor.empty() : tensor<1x11x2048xf32>
+    %1457 = "ttir.unsqueeze"(%1455, %1456) <{dim = 0 : si32}> : (tensor<11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1458 = tensor.empty() : tensor<1x11x2048xf32>
+    %1459 = "ttir.add"(%1329, %1457, %1458) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1460 = tensor.empty() : tensor<1x11x2048xf32>
+    %1461 = "ttir.multiply"(%1459, %1459, %1460) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1462 = tensor.empty() : tensor<1x11x1xf32>
+    %1463 = "ttir.mean"(%1461, %1462) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1464 = tensor.empty() : tensor<1x11x1xf32>
+    %1465 = "ttir.add"(%1463, %arg91, %1464) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1466 = tensor.empty() : tensor<1x11x1xf32>
+    %1467 = "ttir.sqrt"(%1465, %1466) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1468 = tensor.empty() : tensor<1x11x1xf32>
+    %1469 = "ttir.reciprocal"(%1467, %1468) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1470 = tensor.empty() : tensor<1x11x2048xf32>
+    %1471 = "ttir.multiply"(%1459, %1469, %1470) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1472 = tensor.empty() : tensor<1x11x2048xf32>
+    %1473 = "ttir.multiply"(%arg242, %1471, %1472) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1474 = tensor.empty() : tensor<11x2048xf32>
+    %1475 = "ttir.squeeze"(%1473, %1474) <{dim = 0 : si32}> : (tensor<1x11x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %1476 = tensor.empty() : tensor<11x8192xf32>
+    %1477 = "ttir.matmul"(%1475, %arg243, %1476) : (tensor<11x2048xf32>, tensor<2048x8192xf32>, tensor<11x8192xf32>) -> tensor<11x8192xf32>
+    %1478 = tensor.empty() : tensor<1x11x8192xf32>
+    %1479 = "ttir.unsqueeze"(%1477, %1478) <{dim = 0 : si32}> : (tensor<11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %1480 = tensor.empty() : tensor<1x11x8192xf32>
+    %1481 = "ttir.sigmoid"(%1479, %1480) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %1482 = tensor.empty() : tensor<1x11x8192xf32>
+    %1483 = "ttir.multiply"(%1479, %1481, %1482) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %1484 = tensor.empty() : tensor<11x8192xf32>
+    %1485 = "ttir.matmul"(%1475, %arg244, %1484) : (tensor<11x2048xf32>, tensor<2048x8192xf32>, tensor<11x8192xf32>) -> tensor<11x8192xf32>
+    %1486 = tensor.empty() : tensor<1x11x8192xf32>
+    %1487 = "ttir.unsqueeze"(%1485, %1486) <{dim = 0 : si32}> : (tensor<11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %1488 = tensor.empty() : tensor<1x11x8192xf32>
+    %1489 = "ttir.multiply"(%1483, %1487, %1488) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %1490 = tensor.empty() : tensor<1x11x2048xf32>
+    %1491 = "ttir.matmul"(%1489, %arg245, %1490) : (tensor<1x11x8192xf32>, tensor<8192x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1492 = tensor.empty() : tensor<1x11x2048xf32>
+    %1493 = "ttir.add"(%1459, %1491, %1492) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1494 = tensor.empty() : tensor<1x11x2048xf32>
+    %1495 = "ttir.multiply"(%1493, %1493, %1494) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1496 = tensor.empty() : tensor<1x11x1xf32>
+    %1497 = "ttir.mean"(%1495, %1496) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1498 = tensor.empty() : tensor<1x11x1xf32>
+    %1499 = "ttir.add"(%1497, %arg92, %1498) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1500 = tensor.empty() : tensor<1x11x1xf32>
+    %1501 = "ttir.sqrt"(%1499, %1500) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1502 = tensor.empty() : tensor<1x11x1xf32>
+    %1503 = "ttir.reciprocal"(%1501, %1502) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1504 = tensor.empty() : tensor<1x11x2048xf32>
+    %1505 = "ttir.multiply"(%1493, %1503, %1504) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1506 = tensor.empty() : tensor<1x11x2048xf32>
+    %1507 = "ttir.multiply"(%arg246, %1505, %1506) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1508 = tensor.empty() : tensor<11x2048xf32>
+    %1509 = "ttir.squeeze"(%1507, %1508) <{dim = 0 : si32}> : (tensor<1x11x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %1510 = tensor.empty() : tensor<11x2048xf32>
+    %1511 = "ttir.matmul"(%1509, %arg247, %1510) : (tensor<11x2048xf32>, tensor<2048x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %1512 = tensor.empty() : tensor<1x11x32x64xf32>
+    %1513 = "ttir.reshape"(%1511, %1512) <{shape = [1 : i32, 11 : i32, 32 : i32, 64 : i32]}> : (tensor<11x2048xf32>, tensor<1x11x32x64xf32>) -> tensor<1x11x32x64xf32>
+    %1514 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1515 = "ttir.transpose"(%1513, %1514) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x32x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1516 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1517 = "ttir.multiply"(%1515, %35, %1516) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1518 = tensor.empty() : tensor<1x32x64x11xf32>
+    %1519 = "ttir.transpose"(%1515, %1518) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %1520 = tensor.empty() : tensor<1x32x32x11xf32>
+    %1521 = "ttir.matmul"(%arg93, %1519, %1520) : (tensor<1x32x32x64xf32>, tensor<1x32x64x11xf32>, tensor<1x32x32x11xf32>) -> tensor<1x32x32x11xf32>
+    %1522 = tensor.empty() : tensor<1x32x11x32xf32>
+    %1523 = "ttir.transpose"(%1521, %1522) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x32x11xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %1524 = tensor.empty() : tensor<1x32x11x32xf32>
+    %1525 = "ttir.multiply"(%1523, %arg94, %1524) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x32xf32>, tensor<1xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %1526 = tensor.empty() : tensor<1x32x64x11xf32>
+    %1527 = "ttir.transpose"(%1515, %1526) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %1528 = tensor.empty() : tensor<1x32x32x11xf32>
+    %1529 = "ttir.matmul"(%arg95, %1527, %1528) : (tensor<1x32x32x64xf32>, tensor<1x32x64x11xf32>, tensor<1x32x32x11xf32>) -> tensor<1x32x32x11xf32>
+    %1530 = tensor.empty() : tensor<1x32x11x32xf32>
+    %1531 = "ttir.transpose"(%1529, %1530) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x32x11xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %1532 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1533 = "ttir.concat"(%1525, %1531, %1532) <{dim = -1 : si32}> : (tensor<1x32x11x32xf32>, tensor<1x32x11x32xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1534 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1535 = "ttir.multiply"(%1533, %57, %1534) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1536 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1537 = "ttir.add"(%1517, %1535, %1536) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x32x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1538 = tensor.empty() : tensor<32x11x64xf32>
+    %1539 = "ttir.squeeze"(%1537, %1538) <{dim = 0 : si32}> : (tensor<1x32x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %1540 = tensor.empty() : tensor<11x512xf32>
+    %1541 = "ttir.matmul"(%1509, %arg248, %1540) : (tensor<11x2048xf32>, tensor<2048x512xf32>, tensor<11x512xf32>) -> tensor<11x512xf32>
+    %1542 = tensor.empty() : tensor<1x11x8x64xf32>
+    %1543 = "ttir.reshape"(%1541, %1542) <{shape = [1 : i32, 11 : i32, 8 : i32, 64 : i32]}> : (tensor<11x512xf32>, tensor<1x11x8x64xf32>) -> tensor<1x11x8x64xf32>
+    %1544 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1545 = "ttir.transpose"(%1543, %1544) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x8x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1546 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1547 = "ttir.multiply"(%1545, %35, %1546) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1548 = tensor.empty() : tensor<1x8x64x11xf32>
+    %1549 = "ttir.transpose"(%1545, %1548) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x64x11xf32>) -> tensor<1x8x64x11xf32>
+    %1550 = tensor.empty() : tensor<1x8x32x11xf32>
+    %1551 = "ttir.matmul"(%arg96, %1549, %1550) : (tensor<1x8x32x64xf32>, tensor<1x8x64x11xf32>, tensor<1x8x32x11xf32>) -> tensor<1x8x32x11xf32>
+    %1552 = tensor.empty() : tensor<1x8x11x32xf32>
+    %1553 = "ttir.transpose"(%1551, %1552) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x32x11xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %1554 = tensor.empty() : tensor<1x8x11x32xf32>
+    %1555 = "ttir.multiply"(%1553, %arg97, %1554) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x32xf32>, tensor<1xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %1556 = tensor.empty() : tensor<1x8x64x11xf32>
+    %1557 = "ttir.transpose"(%1545, %1556) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x64x11xf32>) -> tensor<1x8x64x11xf32>
+    %1558 = tensor.empty() : tensor<1x8x32x11xf32>
+    %1559 = "ttir.matmul"(%arg98, %1557, %1558) : (tensor<1x8x32x64xf32>, tensor<1x8x64x11xf32>, tensor<1x8x32x11xf32>) -> tensor<1x8x32x11xf32>
+    %1560 = tensor.empty() : tensor<1x8x11x32xf32>
+    %1561 = "ttir.transpose"(%1559, %1560) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x32x11xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %1562 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1563 = "ttir.concat"(%1555, %1561, %1562) <{dim = -1 : si32}> : (tensor<1x8x11x32xf32>, tensor<1x8x11x32xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1564 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1565 = "ttir.multiply"(%1563, %57, %1564) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1566 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1567 = "ttir.add"(%1547, %1565, %1566) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x8x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1568 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %1569 = "ttir.unsqueeze"(%1567, %1568) <{dim = 2 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %1570 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %1571 = "ttir.repeat_interleave"(%1569, %1570) <{dim = 0 : si32, repeats = 1 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %1572 = tensor.empty() : tensor<1x8x4x11x64xf32>
+    %1573 = "ttir.repeat_interleave"(%1571, %1572) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x4x11x64xf32>) -> tensor<1x8x4x11x64xf32>
+    %1574 = tensor.empty() : tensor<32x11x64xf32>
+    %1575 = "ttir.reshape"(%1573, %1574) <{shape = [32 : i32, 11 : i32, 64 : i32]}> : (tensor<1x8x4x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %1576 = tensor.empty() : tensor<32x64x11xf32>
+    %1577 = "ttir.transpose"(%1575, %1576) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x11x64xf32>, tensor<32x64x11xf32>) -> tensor<32x64x11xf32>
+    %1578 = tensor.empty() : tensor<32x11x11xf32>
+    %1579 = "ttir.matmul"(%1539, %1577, %1578) : (tensor<32x11x64xf32>, tensor<32x64x11xf32>, tensor<32x11x11xf32>) -> tensor<32x11x11xf32>
+    %1580 = tensor.empty() : tensor<1x32x11x11xf32>
+    %1581 = "ttir.unsqueeze"(%1579, %1580) <{dim = 0 : si32}> : (tensor<32x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %1582 = tensor.empty() : tensor<1x32x11x11xf32>
+    %1583 = "ttir.multiply"(%1581, %arg99, %1582) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x11xf32>, tensor<1xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %1584 = tensor.empty() : tensor<1x32x11x11xf32>
+    %1585 = "ttir.add"(%1583, %arg100, %1584) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x11xf32>, tensor<1x1x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %1586 = tensor.empty() : tensor<1x32x11x11xf32>
+    %1587 = "ttir.softmax"(%1585, %1586) <{dimension = -1 : si32}> : (tensor<1x32x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %1588 = tensor.empty() : tensor<32x11x11xf32>
+    %1589 = "ttir.squeeze"(%1587, %1588) <{dim = 0 : si32}> : (tensor<1x32x11x11xf32>, tensor<32x11x11xf32>) -> tensor<32x11x11xf32>
+    %1590 = tensor.empty() : tensor<11x512xf32>
+    %1591 = "ttir.matmul"(%1509, %arg249, %1590) : (tensor<11x2048xf32>, tensor<2048x512xf32>, tensor<11x512xf32>) -> tensor<11x512xf32>
+    %1592 = tensor.empty() : tensor<1x11x8x64xf32>
+    %1593 = "ttir.reshape"(%1591, %1592) <{shape = [1 : i32, 11 : i32, 8 : i32, 64 : i32]}> : (tensor<11x512xf32>, tensor<1x11x8x64xf32>) -> tensor<1x11x8x64xf32>
+    %1594 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1595 = "ttir.transpose"(%1593, %1594) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x8x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1596 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %1597 = "ttir.unsqueeze"(%1595, %1596) <{dim = 2 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %1598 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %1599 = "ttir.repeat_interleave"(%1597, %1598) <{dim = 0 : si32, repeats = 1 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %1600 = tensor.empty() : tensor<1x8x4x11x64xf32>
+    %1601 = "ttir.repeat_interleave"(%1599, %1600) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x4x11x64xf32>) -> tensor<1x8x4x11x64xf32>
+    %1602 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1603 = "ttir.reshape"(%1601, %1602) <{shape = [1 : i32, 32 : i32, 11 : i32, 64 : i32]}> : (tensor<1x8x4x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1604 = tensor.empty() : tensor<1x32x64x11xf32>
+    %1605 = "ttir.transpose"(%1603, %1604) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %1606 = tensor.empty() : tensor<32x64x11xf32>
+    %1607 = "ttir.squeeze"(%1605, %1606) <{dim = 0 : si32}> : (tensor<1x32x64x11xf32>, tensor<32x64x11xf32>) -> tensor<32x64x11xf32>
+    %1608 = tensor.empty() : tensor<32x11x64xf32>
+    %1609 = "ttir.transpose"(%1607, %1608) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x64x11xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %1610 = tensor.empty() : tensor<32x11x64xf32>
+    %1611 = "ttir.matmul"(%1589, %1609, %1610) : (tensor<32x11x11xf32>, tensor<32x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %1612 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1613 = "ttir.unsqueeze"(%1611, %1612) <{dim = 0 : si32}> : (tensor<32x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1614 = tensor.empty() : tensor<1x11x32x64xf32>
+    %1615 = "ttir.transpose"(%1613, %1614) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x11x32x64xf32>) -> tensor<1x11x32x64xf32>
+    %1616 = tensor.empty() : tensor<11x2048xf32>
+    %1617 = "ttir.reshape"(%1615, %1616) <{shape = [11 : i32, 2048 : i32]}> : (tensor<1x11x32x64xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %1618 = tensor.empty() : tensor<11x2048xf32>
+    %1619 = "ttir.matmul"(%1617, %arg250, %1618) : (tensor<11x2048xf32>, tensor<2048x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %1620 = tensor.empty() : tensor<1x11x2048xf32>
+    %1621 = "ttir.unsqueeze"(%1619, %1620) <{dim = 0 : si32}> : (tensor<11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1622 = tensor.empty() : tensor<1x11x2048xf32>
+    %1623 = "ttir.add"(%1493, %1621, %1622) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1624 = tensor.empty() : tensor<1x11x2048xf32>
+    %1625 = "ttir.multiply"(%1623, %1623, %1624) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1626 = tensor.empty() : tensor<1x11x1xf32>
+    %1627 = "ttir.mean"(%1625, %1626) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1628 = tensor.empty() : tensor<1x11x1xf32>
+    %1629 = "ttir.add"(%1627, %arg101, %1628) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1630 = tensor.empty() : tensor<1x11x1xf32>
+    %1631 = "ttir.sqrt"(%1629, %1630) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1632 = tensor.empty() : tensor<1x11x1xf32>
+    %1633 = "ttir.reciprocal"(%1631, %1632) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1634 = tensor.empty() : tensor<1x11x2048xf32>
+    %1635 = "ttir.multiply"(%1623, %1633, %1634) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1636 = tensor.empty() : tensor<1x11x2048xf32>
+    %1637 = "ttir.multiply"(%arg251, %1635, %1636) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1638 = tensor.empty() : tensor<11x2048xf32>
+    %1639 = "ttir.squeeze"(%1637, %1638) <{dim = 0 : si32}> : (tensor<1x11x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %1640 = tensor.empty() : tensor<11x8192xf32>
+    %1641 = "ttir.matmul"(%1639, %arg252, %1640) : (tensor<11x2048xf32>, tensor<2048x8192xf32>, tensor<11x8192xf32>) -> tensor<11x8192xf32>
+    %1642 = tensor.empty() : tensor<1x11x8192xf32>
+    %1643 = "ttir.unsqueeze"(%1641, %1642) <{dim = 0 : si32}> : (tensor<11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %1644 = tensor.empty() : tensor<1x11x8192xf32>
+    %1645 = "ttir.sigmoid"(%1643, %1644) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %1646 = tensor.empty() : tensor<1x11x8192xf32>
+    %1647 = "ttir.multiply"(%1643, %1645, %1646) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %1648 = tensor.empty() : tensor<11x8192xf32>
+    %1649 = "ttir.matmul"(%1639, %arg253, %1648) : (tensor<11x2048xf32>, tensor<2048x8192xf32>, tensor<11x8192xf32>) -> tensor<11x8192xf32>
+    %1650 = tensor.empty() : tensor<1x11x8192xf32>
+    %1651 = "ttir.unsqueeze"(%1649, %1650) <{dim = 0 : si32}> : (tensor<11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %1652 = tensor.empty() : tensor<1x11x8192xf32>
+    %1653 = "ttir.multiply"(%1647, %1651, %1652) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %1654 = tensor.empty() : tensor<1x11x2048xf32>
+    %1655 = "ttir.matmul"(%1653, %arg254, %1654) : (tensor<1x11x8192xf32>, tensor<8192x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1656 = tensor.empty() : tensor<1x11x2048xf32>
+    %1657 = "ttir.add"(%1623, %1655, %1656) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1658 = tensor.empty() : tensor<1x11x2048xf32>
+    %1659 = "ttir.multiply"(%1657, %1657, %1658) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1660 = tensor.empty() : tensor<1x11x1xf32>
+    %1661 = "ttir.mean"(%1659, %1660) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1662 = tensor.empty() : tensor<1x11x1xf32>
+    %1663 = "ttir.add"(%1661, %arg102, %1662) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1664 = tensor.empty() : tensor<1x11x1xf32>
+    %1665 = "ttir.sqrt"(%1663, %1664) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1666 = tensor.empty() : tensor<1x11x1xf32>
+    %1667 = "ttir.reciprocal"(%1665, %1666) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1668 = tensor.empty() : tensor<1x11x2048xf32>
+    %1669 = "ttir.multiply"(%1657, %1667, %1668) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1670 = tensor.empty() : tensor<1x11x2048xf32>
+    %1671 = "ttir.multiply"(%arg255, %1669, %1670) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1672 = tensor.empty() : tensor<11x2048xf32>
+    %1673 = "ttir.squeeze"(%1671, %1672) <{dim = 0 : si32}> : (tensor<1x11x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %1674 = tensor.empty() : tensor<11x2048xf32>
+    %1675 = "ttir.matmul"(%1673, %arg256, %1674) : (tensor<11x2048xf32>, tensor<2048x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %1676 = tensor.empty() : tensor<1x11x32x64xf32>
+    %1677 = "ttir.reshape"(%1675, %1676) <{shape = [1 : i32, 11 : i32, 32 : i32, 64 : i32]}> : (tensor<11x2048xf32>, tensor<1x11x32x64xf32>) -> tensor<1x11x32x64xf32>
+    %1678 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1679 = "ttir.transpose"(%1677, %1678) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x32x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1680 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1681 = "ttir.multiply"(%1679, %35, %1680) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1682 = tensor.empty() : tensor<1x32x64x11xf32>
+    %1683 = "ttir.transpose"(%1679, %1682) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %1684 = tensor.empty() : tensor<1x32x32x11xf32>
+    %1685 = "ttir.matmul"(%arg103, %1683, %1684) : (tensor<1x32x32x64xf32>, tensor<1x32x64x11xf32>, tensor<1x32x32x11xf32>) -> tensor<1x32x32x11xf32>
+    %1686 = tensor.empty() : tensor<1x32x11x32xf32>
+    %1687 = "ttir.transpose"(%1685, %1686) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x32x11xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %1688 = tensor.empty() : tensor<1x32x11x32xf32>
+    %1689 = "ttir.multiply"(%1687, %arg104, %1688) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x32xf32>, tensor<1xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %1690 = tensor.empty() : tensor<1x32x64x11xf32>
+    %1691 = "ttir.transpose"(%1679, %1690) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %1692 = tensor.empty() : tensor<1x32x32x11xf32>
+    %1693 = "ttir.matmul"(%arg105, %1691, %1692) : (tensor<1x32x32x64xf32>, tensor<1x32x64x11xf32>, tensor<1x32x32x11xf32>) -> tensor<1x32x32x11xf32>
+    %1694 = tensor.empty() : tensor<1x32x11x32xf32>
+    %1695 = "ttir.transpose"(%1693, %1694) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x32x11xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %1696 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1697 = "ttir.concat"(%1689, %1695, %1696) <{dim = -1 : si32}> : (tensor<1x32x11x32xf32>, tensor<1x32x11x32xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1698 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1699 = "ttir.multiply"(%1697, %57, %1698) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1700 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1701 = "ttir.add"(%1681, %1699, %1700) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x32x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1702 = tensor.empty() : tensor<32x11x64xf32>
+    %1703 = "ttir.squeeze"(%1701, %1702) <{dim = 0 : si32}> : (tensor<1x32x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %1704 = tensor.empty() : tensor<11x512xf32>
+    %1705 = "ttir.matmul"(%1673, %arg257, %1704) : (tensor<11x2048xf32>, tensor<2048x512xf32>, tensor<11x512xf32>) -> tensor<11x512xf32>
+    %1706 = tensor.empty() : tensor<1x11x8x64xf32>
+    %1707 = "ttir.reshape"(%1705, %1706) <{shape = [1 : i32, 11 : i32, 8 : i32, 64 : i32]}> : (tensor<11x512xf32>, tensor<1x11x8x64xf32>) -> tensor<1x11x8x64xf32>
+    %1708 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1709 = "ttir.transpose"(%1707, %1708) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x8x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1710 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1711 = "ttir.multiply"(%1709, %35, %1710) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1712 = tensor.empty() : tensor<1x8x64x11xf32>
+    %1713 = "ttir.transpose"(%1709, %1712) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x64x11xf32>) -> tensor<1x8x64x11xf32>
+    %1714 = tensor.empty() : tensor<1x8x32x11xf32>
+    %1715 = "ttir.matmul"(%arg106, %1713, %1714) : (tensor<1x8x32x64xf32>, tensor<1x8x64x11xf32>, tensor<1x8x32x11xf32>) -> tensor<1x8x32x11xf32>
+    %1716 = tensor.empty() : tensor<1x8x11x32xf32>
+    %1717 = "ttir.transpose"(%1715, %1716) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x32x11xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %1718 = tensor.empty() : tensor<1x8x11x32xf32>
+    %1719 = "ttir.multiply"(%1717, %arg107, %1718) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x32xf32>, tensor<1xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %1720 = tensor.empty() : tensor<1x8x64x11xf32>
+    %1721 = "ttir.transpose"(%1709, %1720) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x64x11xf32>) -> tensor<1x8x64x11xf32>
+    %1722 = tensor.empty() : tensor<1x8x32x11xf32>
+    %1723 = "ttir.matmul"(%arg108, %1721, %1722) : (tensor<1x8x32x64xf32>, tensor<1x8x64x11xf32>, tensor<1x8x32x11xf32>) -> tensor<1x8x32x11xf32>
+    %1724 = tensor.empty() : tensor<1x8x11x32xf32>
+    %1725 = "ttir.transpose"(%1723, %1724) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x32x11xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %1726 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1727 = "ttir.concat"(%1719, %1725, %1726) <{dim = -1 : si32}> : (tensor<1x8x11x32xf32>, tensor<1x8x11x32xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1728 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1729 = "ttir.multiply"(%1727, %57, %1728) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1730 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1731 = "ttir.add"(%1711, %1729, %1730) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x8x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1732 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %1733 = "ttir.unsqueeze"(%1731, %1732) <{dim = 2 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %1734 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %1735 = "ttir.repeat_interleave"(%1733, %1734) <{dim = 0 : si32, repeats = 1 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %1736 = tensor.empty() : tensor<1x8x4x11x64xf32>
+    %1737 = "ttir.repeat_interleave"(%1735, %1736) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x4x11x64xf32>) -> tensor<1x8x4x11x64xf32>
+    %1738 = tensor.empty() : tensor<32x11x64xf32>
+    %1739 = "ttir.reshape"(%1737, %1738) <{shape = [32 : i32, 11 : i32, 64 : i32]}> : (tensor<1x8x4x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %1740 = tensor.empty() : tensor<32x64x11xf32>
+    %1741 = "ttir.transpose"(%1739, %1740) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x11x64xf32>, tensor<32x64x11xf32>) -> tensor<32x64x11xf32>
+    %1742 = tensor.empty() : tensor<32x11x11xf32>
+    %1743 = "ttir.matmul"(%1703, %1741, %1742) : (tensor<32x11x64xf32>, tensor<32x64x11xf32>, tensor<32x11x11xf32>) -> tensor<32x11x11xf32>
+    %1744 = tensor.empty() : tensor<1x32x11x11xf32>
+    %1745 = "ttir.unsqueeze"(%1743, %1744) <{dim = 0 : si32}> : (tensor<32x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %1746 = tensor.empty() : tensor<1x32x11x11xf32>
+    %1747 = "ttir.multiply"(%1745, %arg109, %1746) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x11xf32>, tensor<1xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %1748 = tensor.empty() : tensor<1x32x11x11xf32>
+    %1749 = "ttir.add"(%1747, %arg110, %1748) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x11xf32>, tensor<1x1x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %1750 = tensor.empty() : tensor<1x32x11x11xf32>
+    %1751 = "ttir.softmax"(%1749, %1750) <{dimension = -1 : si32}> : (tensor<1x32x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %1752 = tensor.empty() : tensor<32x11x11xf32>
+    %1753 = "ttir.squeeze"(%1751, %1752) <{dim = 0 : si32}> : (tensor<1x32x11x11xf32>, tensor<32x11x11xf32>) -> tensor<32x11x11xf32>
+    %1754 = tensor.empty() : tensor<11x512xf32>
+    %1755 = "ttir.matmul"(%1673, %arg258, %1754) : (tensor<11x2048xf32>, tensor<2048x512xf32>, tensor<11x512xf32>) -> tensor<11x512xf32>
+    %1756 = tensor.empty() : tensor<1x11x8x64xf32>
+    %1757 = "ttir.reshape"(%1755, %1756) <{shape = [1 : i32, 11 : i32, 8 : i32, 64 : i32]}> : (tensor<11x512xf32>, tensor<1x11x8x64xf32>) -> tensor<1x11x8x64xf32>
+    %1758 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1759 = "ttir.transpose"(%1757, %1758) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x8x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1760 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %1761 = "ttir.unsqueeze"(%1759, %1760) <{dim = 2 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %1762 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %1763 = "ttir.repeat_interleave"(%1761, %1762) <{dim = 0 : si32, repeats = 1 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %1764 = tensor.empty() : tensor<1x8x4x11x64xf32>
+    %1765 = "ttir.repeat_interleave"(%1763, %1764) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x4x11x64xf32>) -> tensor<1x8x4x11x64xf32>
+    %1766 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1767 = "ttir.reshape"(%1765, %1766) <{shape = [1 : i32, 32 : i32, 11 : i32, 64 : i32]}> : (tensor<1x8x4x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1768 = tensor.empty() : tensor<1x32x64x11xf32>
+    %1769 = "ttir.transpose"(%1767, %1768) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %1770 = tensor.empty() : tensor<32x64x11xf32>
+    %1771 = "ttir.squeeze"(%1769, %1770) <{dim = 0 : si32}> : (tensor<1x32x64x11xf32>, tensor<32x64x11xf32>) -> tensor<32x64x11xf32>
+    %1772 = tensor.empty() : tensor<32x11x64xf32>
+    %1773 = "ttir.transpose"(%1771, %1772) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x64x11xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %1774 = tensor.empty() : tensor<32x11x64xf32>
+    %1775 = "ttir.matmul"(%1753, %1773, %1774) : (tensor<32x11x11xf32>, tensor<32x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %1776 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1777 = "ttir.unsqueeze"(%1775, %1776) <{dim = 0 : si32}> : (tensor<32x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1778 = tensor.empty() : tensor<1x11x32x64xf32>
+    %1779 = "ttir.transpose"(%1777, %1778) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x11x32x64xf32>) -> tensor<1x11x32x64xf32>
+    %1780 = tensor.empty() : tensor<11x2048xf32>
+    %1781 = "ttir.reshape"(%1779, %1780) <{shape = [11 : i32, 2048 : i32]}> : (tensor<1x11x32x64xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %1782 = tensor.empty() : tensor<11x2048xf32>
+    %1783 = "ttir.matmul"(%1781, %arg259, %1782) : (tensor<11x2048xf32>, tensor<2048x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %1784 = tensor.empty() : tensor<1x11x2048xf32>
+    %1785 = "ttir.unsqueeze"(%1783, %1784) <{dim = 0 : si32}> : (tensor<11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1786 = tensor.empty() : tensor<1x11x2048xf32>
+    %1787 = "ttir.add"(%1657, %1785, %1786) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1788 = tensor.empty() : tensor<1x11x2048xf32>
+    %1789 = "ttir.multiply"(%1787, %1787, %1788) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1790 = tensor.empty() : tensor<1x11x1xf32>
+    %1791 = "ttir.mean"(%1789, %1790) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1792 = tensor.empty() : tensor<1x11x1xf32>
+    %1793 = "ttir.add"(%1791, %arg111, %1792) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1794 = tensor.empty() : tensor<1x11x1xf32>
+    %1795 = "ttir.sqrt"(%1793, %1794) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1796 = tensor.empty() : tensor<1x11x1xf32>
+    %1797 = "ttir.reciprocal"(%1795, %1796) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1798 = tensor.empty() : tensor<1x11x2048xf32>
+    %1799 = "ttir.multiply"(%1787, %1797, %1798) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1800 = tensor.empty() : tensor<1x11x2048xf32>
+    %1801 = "ttir.multiply"(%arg260, %1799, %1800) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1802 = tensor.empty() : tensor<11x2048xf32>
+    %1803 = "ttir.squeeze"(%1801, %1802) <{dim = 0 : si32}> : (tensor<1x11x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %1804 = tensor.empty() : tensor<11x8192xf32>
+    %1805 = "ttir.matmul"(%1803, %arg261, %1804) : (tensor<11x2048xf32>, tensor<2048x8192xf32>, tensor<11x8192xf32>) -> tensor<11x8192xf32>
+    %1806 = tensor.empty() : tensor<1x11x8192xf32>
+    %1807 = "ttir.unsqueeze"(%1805, %1806) <{dim = 0 : si32}> : (tensor<11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %1808 = tensor.empty() : tensor<1x11x8192xf32>
+    %1809 = "ttir.sigmoid"(%1807, %1808) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %1810 = tensor.empty() : tensor<1x11x8192xf32>
+    %1811 = "ttir.multiply"(%1807, %1809, %1810) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %1812 = tensor.empty() : tensor<11x8192xf32>
+    %1813 = "ttir.matmul"(%1803, %arg262, %1812) : (tensor<11x2048xf32>, tensor<2048x8192xf32>, tensor<11x8192xf32>) -> tensor<11x8192xf32>
+    %1814 = tensor.empty() : tensor<1x11x8192xf32>
+    %1815 = "ttir.unsqueeze"(%1813, %1814) <{dim = 0 : si32}> : (tensor<11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %1816 = tensor.empty() : tensor<1x11x8192xf32>
+    %1817 = "ttir.multiply"(%1811, %1815, %1816) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %1818 = tensor.empty() : tensor<1x11x2048xf32>
+    %1819 = "ttir.matmul"(%1817, %arg263, %1818) : (tensor<1x11x8192xf32>, tensor<8192x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1820 = tensor.empty() : tensor<1x11x2048xf32>
+    %1821 = "ttir.add"(%1787, %1819, %1820) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1822 = tensor.empty() : tensor<1x11x2048xf32>
+    %1823 = "ttir.multiply"(%1821, %1821, %1822) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1824 = tensor.empty() : tensor<1x11x1xf32>
+    %1825 = "ttir.mean"(%1823, %1824) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1826 = tensor.empty() : tensor<1x11x1xf32>
+    %1827 = "ttir.add"(%1825, %arg112, %1826) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1828 = tensor.empty() : tensor<1x11x1xf32>
+    %1829 = "ttir.sqrt"(%1827, %1828) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1830 = tensor.empty() : tensor<1x11x1xf32>
+    %1831 = "ttir.reciprocal"(%1829, %1830) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1832 = tensor.empty() : tensor<1x11x2048xf32>
+    %1833 = "ttir.multiply"(%1821, %1831, %1832) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1834 = tensor.empty() : tensor<1x11x2048xf32>
+    %1835 = "ttir.multiply"(%arg264, %1833, %1834) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1836 = tensor.empty() : tensor<11x2048xf32>
+    %1837 = "ttir.squeeze"(%1835, %1836) <{dim = 0 : si32}> : (tensor<1x11x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %1838 = tensor.empty() : tensor<11x2048xf32>
+    %1839 = "ttir.matmul"(%1837, %arg265, %1838) : (tensor<11x2048xf32>, tensor<2048x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %1840 = tensor.empty() : tensor<1x11x32x64xf32>
+    %1841 = "ttir.reshape"(%1839, %1840) <{shape = [1 : i32, 11 : i32, 32 : i32, 64 : i32]}> : (tensor<11x2048xf32>, tensor<1x11x32x64xf32>) -> tensor<1x11x32x64xf32>
+    %1842 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1843 = "ttir.transpose"(%1841, %1842) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x32x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1844 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1845 = "ttir.multiply"(%1843, %35, %1844) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1846 = tensor.empty() : tensor<1x32x64x11xf32>
+    %1847 = "ttir.transpose"(%1843, %1846) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %1848 = tensor.empty() : tensor<1x32x32x11xf32>
+    %1849 = "ttir.matmul"(%arg113, %1847, %1848) : (tensor<1x32x32x64xf32>, tensor<1x32x64x11xf32>, tensor<1x32x32x11xf32>) -> tensor<1x32x32x11xf32>
+    %1850 = tensor.empty() : tensor<1x32x11x32xf32>
+    %1851 = "ttir.transpose"(%1849, %1850) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x32x11xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %1852 = tensor.empty() : tensor<1x32x11x32xf32>
+    %1853 = "ttir.multiply"(%1851, %arg114, %1852) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x32xf32>, tensor<1xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %1854 = tensor.empty() : tensor<1x32x64x11xf32>
+    %1855 = "ttir.transpose"(%1843, %1854) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %1856 = tensor.empty() : tensor<1x32x32x11xf32>
+    %1857 = "ttir.matmul"(%arg115, %1855, %1856) : (tensor<1x32x32x64xf32>, tensor<1x32x64x11xf32>, tensor<1x32x32x11xf32>) -> tensor<1x32x32x11xf32>
+    %1858 = tensor.empty() : tensor<1x32x11x32xf32>
+    %1859 = "ttir.transpose"(%1857, %1858) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x32x11xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %1860 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1861 = "ttir.concat"(%1853, %1859, %1860) <{dim = -1 : si32}> : (tensor<1x32x11x32xf32>, tensor<1x32x11x32xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1862 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1863 = "ttir.multiply"(%1861, %57, %1862) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1864 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1865 = "ttir.add"(%1845, %1863, %1864) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x32x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1866 = tensor.empty() : tensor<32x11x64xf32>
+    %1867 = "ttir.squeeze"(%1865, %1866) <{dim = 0 : si32}> : (tensor<1x32x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %1868 = tensor.empty() : tensor<11x512xf32>
+    %1869 = "ttir.matmul"(%1837, %arg266, %1868) : (tensor<11x2048xf32>, tensor<2048x512xf32>, tensor<11x512xf32>) -> tensor<11x512xf32>
+    %1870 = tensor.empty() : tensor<1x11x8x64xf32>
+    %1871 = "ttir.reshape"(%1869, %1870) <{shape = [1 : i32, 11 : i32, 8 : i32, 64 : i32]}> : (tensor<11x512xf32>, tensor<1x11x8x64xf32>) -> tensor<1x11x8x64xf32>
+    %1872 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1873 = "ttir.transpose"(%1871, %1872) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x8x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1874 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1875 = "ttir.multiply"(%1873, %35, %1874) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1876 = tensor.empty() : tensor<1x8x64x11xf32>
+    %1877 = "ttir.transpose"(%1873, %1876) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x64x11xf32>) -> tensor<1x8x64x11xf32>
+    %1878 = tensor.empty() : tensor<1x8x32x11xf32>
+    %1879 = "ttir.matmul"(%arg116, %1877, %1878) : (tensor<1x8x32x64xf32>, tensor<1x8x64x11xf32>, tensor<1x8x32x11xf32>) -> tensor<1x8x32x11xf32>
+    %1880 = tensor.empty() : tensor<1x8x11x32xf32>
+    %1881 = "ttir.transpose"(%1879, %1880) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x32x11xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %1882 = tensor.empty() : tensor<1x8x11x32xf32>
+    %1883 = "ttir.multiply"(%1881, %arg117, %1882) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x32xf32>, tensor<1xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %1884 = tensor.empty() : tensor<1x8x64x11xf32>
+    %1885 = "ttir.transpose"(%1873, %1884) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x64x11xf32>) -> tensor<1x8x64x11xf32>
+    %1886 = tensor.empty() : tensor<1x8x32x11xf32>
+    %1887 = "ttir.matmul"(%arg118, %1885, %1886) : (tensor<1x8x32x64xf32>, tensor<1x8x64x11xf32>, tensor<1x8x32x11xf32>) -> tensor<1x8x32x11xf32>
+    %1888 = tensor.empty() : tensor<1x8x11x32xf32>
+    %1889 = "ttir.transpose"(%1887, %1888) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x32x11xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %1890 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1891 = "ttir.concat"(%1883, %1889, %1890) <{dim = -1 : si32}> : (tensor<1x8x11x32xf32>, tensor<1x8x11x32xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1892 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1893 = "ttir.multiply"(%1891, %57, %1892) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1894 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1895 = "ttir.add"(%1875, %1893, %1894) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x8x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1896 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %1897 = "ttir.unsqueeze"(%1895, %1896) <{dim = 2 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %1898 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %1899 = "ttir.repeat_interleave"(%1897, %1898) <{dim = 0 : si32, repeats = 1 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %1900 = tensor.empty() : tensor<1x8x4x11x64xf32>
+    %1901 = "ttir.repeat_interleave"(%1899, %1900) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x4x11x64xf32>) -> tensor<1x8x4x11x64xf32>
+    %1902 = tensor.empty() : tensor<32x11x64xf32>
+    %1903 = "ttir.reshape"(%1901, %1902) <{shape = [32 : i32, 11 : i32, 64 : i32]}> : (tensor<1x8x4x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %1904 = tensor.empty() : tensor<32x64x11xf32>
+    %1905 = "ttir.transpose"(%1903, %1904) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x11x64xf32>, tensor<32x64x11xf32>) -> tensor<32x64x11xf32>
+    %1906 = tensor.empty() : tensor<32x11x11xf32>
+    %1907 = "ttir.matmul"(%1867, %1905, %1906) : (tensor<32x11x64xf32>, tensor<32x64x11xf32>, tensor<32x11x11xf32>) -> tensor<32x11x11xf32>
+    %1908 = tensor.empty() : tensor<1x32x11x11xf32>
+    %1909 = "ttir.unsqueeze"(%1907, %1908) <{dim = 0 : si32}> : (tensor<32x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %1910 = tensor.empty() : tensor<1x32x11x11xf32>
+    %1911 = "ttir.multiply"(%1909, %arg119, %1910) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x11xf32>, tensor<1xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %1912 = tensor.empty() : tensor<1x32x11x11xf32>
+    %1913 = "ttir.add"(%1911, %arg120, %1912) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x11xf32>, tensor<1x1x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %1914 = tensor.empty() : tensor<1x32x11x11xf32>
+    %1915 = "ttir.softmax"(%1913, %1914) <{dimension = -1 : si32}> : (tensor<1x32x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %1916 = tensor.empty() : tensor<32x11x11xf32>
+    %1917 = "ttir.squeeze"(%1915, %1916) <{dim = 0 : si32}> : (tensor<1x32x11x11xf32>, tensor<32x11x11xf32>) -> tensor<32x11x11xf32>
+    %1918 = tensor.empty() : tensor<11x512xf32>
+    %1919 = "ttir.matmul"(%1837, %arg267, %1918) : (tensor<11x2048xf32>, tensor<2048x512xf32>, tensor<11x512xf32>) -> tensor<11x512xf32>
+    %1920 = tensor.empty() : tensor<1x11x8x64xf32>
+    %1921 = "ttir.reshape"(%1919, %1920) <{shape = [1 : i32, 11 : i32, 8 : i32, 64 : i32]}> : (tensor<11x512xf32>, tensor<1x11x8x64xf32>) -> tensor<1x11x8x64xf32>
+    %1922 = tensor.empty() : tensor<1x8x11x64xf32>
+    %1923 = "ttir.transpose"(%1921, %1922) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x8x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %1924 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %1925 = "ttir.unsqueeze"(%1923, %1924) <{dim = 2 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %1926 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %1927 = "ttir.repeat_interleave"(%1925, %1926) <{dim = 0 : si32, repeats = 1 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %1928 = tensor.empty() : tensor<1x8x4x11x64xf32>
+    %1929 = "ttir.repeat_interleave"(%1927, %1928) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x4x11x64xf32>) -> tensor<1x8x4x11x64xf32>
+    %1930 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1931 = "ttir.reshape"(%1929, %1930) <{shape = [1 : i32, 32 : i32, 11 : i32, 64 : i32]}> : (tensor<1x8x4x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1932 = tensor.empty() : tensor<1x32x64x11xf32>
+    %1933 = "ttir.transpose"(%1931, %1932) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %1934 = tensor.empty() : tensor<32x64x11xf32>
+    %1935 = "ttir.squeeze"(%1933, %1934) <{dim = 0 : si32}> : (tensor<1x32x64x11xf32>, tensor<32x64x11xf32>) -> tensor<32x64x11xf32>
+    %1936 = tensor.empty() : tensor<32x11x64xf32>
+    %1937 = "ttir.transpose"(%1935, %1936) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x64x11xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %1938 = tensor.empty() : tensor<32x11x64xf32>
+    %1939 = "ttir.matmul"(%1917, %1937, %1938) : (tensor<32x11x11xf32>, tensor<32x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %1940 = tensor.empty() : tensor<1x32x11x64xf32>
+    %1941 = "ttir.unsqueeze"(%1939, %1940) <{dim = 0 : si32}> : (tensor<32x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %1942 = tensor.empty() : tensor<1x11x32x64xf32>
+    %1943 = "ttir.transpose"(%1941, %1942) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x11x32x64xf32>) -> tensor<1x11x32x64xf32>
+    %1944 = tensor.empty() : tensor<11x2048xf32>
+    %1945 = "ttir.reshape"(%1943, %1944) <{shape = [11 : i32, 2048 : i32]}> : (tensor<1x11x32x64xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %1946 = tensor.empty() : tensor<11x2048xf32>
+    %1947 = "ttir.matmul"(%1945, %arg268, %1946) : (tensor<11x2048xf32>, tensor<2048x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %1948 = tensor.empty() : tensor<1x11x2048xf32>
+    %1949 = "ttir.unsqueeze"(%1947, %1948) <{dim = 0 : si32}> : (tensor<11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1950 = tensor.empty() : tensor<1x11x2048xf32>
+    %1951 = "ttir.add"(%1821, %1949, %1950) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1952 = tensor.empty() : tensor<1x11x2048xf32>
+    %1953 = "ttir.multiply"(%1951, %1951, %1952) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1954 = tensor.empty() : tensor<1x11x1xf32>
+    %1955 = "ttir.mean"(%1953, %1954) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1956 = tensor.empty() : tensor<1x11x1xf32>
+    %1957 = "ttir.add"(%1955, %arg121, %1956) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1958 = tensor.empty() : tensor<1x11x1xf32>
+    %1959 = "ttir.sqrt"(%1957, %1958) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1960 = tensor.empty() : tensor<1x11x1xf32>
+    %1961 = "ttir.reciprocal"(%1959, %1960) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1962 = tensor.empty() : tensor<1x11x2048xf32>
+    %1963 = "ttir.multiply"(%1951, %1961, %1962) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1964 = tensor.empty() : tensor<1x11x2048xf32>
+    %1965 = "ttir.multiply"(%arg269, %1963, %1964) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1966 = tensor.empty() : tensor<11x2048xf32>
+    %1967 = "ttir.squeeze"(%1965, %1966) <{dim = 0 : si32}> : (tensor<1x11x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %1968 = tensor.empty() : tensor<11x8192xf32>
+    %1969 = "ttir.matmul"(%1967, %arg270, %1968) : (tensor<11x2048xf32>, tensor<2048x8192xf32>, tensor<11x8192xf32>) -> tensor<11x8192xf32>
+    %1970 = tensor.empty() : tensor<1x11x8192xf32>
+    %1971 = "ttir.unsqueeze"(%1969, %1970) <{dim = 0 : si32}> : (tensor<11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %1972 = tensor.empty() : tensor<1x11x8192xf32>
+    %1973 = "ttir.sigmoid"(%1971, %1972) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %1974 = tensor.empty() : tensor<1x11x8192xf32>
+    %1975 = "ttir.multiply"(%1971, %1973, %1974) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %1976 = tensor.empty() : tensor<11x8192xf32>
+    %1977 = "ttir.matmul"(%1967, %arg271, %1976) : (tensor<11x2048xf32>, tensor<2048x8192xf32>, tensor<11x8192xf32>) -> tensor<11x8192xf32>
+    %1978 = tensor.empty() : tensor<1x11x8192xf32>
+    %1979 = "ttir.unsqueeze"(%1977, %1978) <{dim = 0 : si32}> : (tensor<11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %1980 = tensor.empty() : tensor<1x11x8192xf32>
+    %1981 = "ttir.multiply"(%1975, %1979, %1980) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %1982 = tensor.empty() : tensor<1x11x2048xf32>
+    %1983 = "ttir.matmul"(%1981, %arg272, %1982) : (tensor<1x11x8192xf32>, tensor<8192x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1984 = tensor.empty() : tensor<1x11x2048xf32>
+    %1985 = "ttir.add"(%1951, %1983, %1984) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1986 = tensor.empty() : tensor<1x11x2048xf32>
+    %1987 = "ttir.multiply"(%1985, %1985, %1986) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1988 = tensor.empty() : tensor<1x11x1xf32>
+    %1989 = "ttir.mean"(%1987, %1988) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1990 = tensor.empty() : tensor<1x11x1xf32>
+    %1991 = "ttir.add"(%1989, %arg122, %1990) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1992 = tensor.empty() : tensor<1x11x1xf32>
+    %1993 = "ttir.sqrt"(%1991, %1992) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1994 = tensor.empty() : tensor<1x11x1xf32>
+    %1995 = "ttir.reciprocal"(%1993, %1994) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %1996 = tensor.empty() : tensor<1x11x2048xf32>
+    %1997 = "ttir.multiply"(%1985, %1995, %1996) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %1998 = tensor.empty() : tensor<1x11x2048xf32>
+    %1999 = "ttir.multiply"(%arg273, %1997, %1998) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2000 = tensor.empty() : tensor<11x2048xf32>
+    %2001 = "ttir.squeeze"(%1999, %2000) <{dim = 0 : si32}> : (tensor<1x11x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %2002 = tensor.empty() : tensor<11x2048xf32>
+    %2003 = "ttir.matmul"(%2001, %arg274, %2002) : (tensor<11x2048xf32>, tensor<2048x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %2004 = tensor.empty() : tensor<1x11x32x64xf32>
+    %2005 = "ttir.reshape"(%2003, %2004) <{shape = [1 : i32, 11 : i32, 32 : i32, 64 : i32]}> : (tensor<11x2048xf32>, tensor<1x11x32x64xf32>) -> tensor<1x11x32x64xf32>
+    %2006 = tensor.empty() : tensor<1x32x11x64xf32>
+    %2007 = "ttir.transpose"(%2005, %2006) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x32x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %2008 = tensor.empty() : tensor<1x32x11x64xf32>
+    %2009 = "ttir.multiply"(%2007, %35, %2008) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %2010 = tensor.empty() : tensor<1x32x64x11xf32>
+    %2011 = "ttir.transpose"(%2007, %2010) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %2012 = tensor.empty() : tensor<1x32x32x11xf32>
+    %2013 = "ttir.matmul"(%arg123, %2011, %2012) : (tensor<1x32x32x64xf32>, tensor<1x32x64x11xf32>, tensor<1x32x32x11xf32>) -> tensor<1x32x32x11xf32>
+    %2014 = tensor.empty() : tensor<1x32x11x32xf32>
+    %2015 = "ttir.transpose"(%2013, %2014) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x32x11xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %2016 = tensor.empty() : tensor<1x32x11x32xf32>
+    %2017 = "ttir.multiply"(%2015, %arg124, %2016) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x32xf32>, tensor<1xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %2018 = tensor.empty() : tensor<1x32x64x11xf32>
+    %2019 = "ttir.transpose"(%2007, %2018) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %2020 = tensor.empty() : tensor<1x32x32x11xf32>
+    %2021 = "ttir.matmul"(%arg125, %2019, %2020) : (tensor<1x32x32x64xf32>, tensor<1x32x64x11xf32>, tensor<1x32x32x11xf32>) -> tensor<1x32x32x11xf32>
+    %2022 = tensor.empty() : tensor<1x32x11x32xf32>
+    %2023 = "ttir.transpose"(%2021, %2022) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x32x11xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %2024 = tensor.empty() : tensor<1x32x11x64xf32>
+    %2025 = "ttir.concat"(%2017, %2023, %2024) <{dim = -1 : si32}> : (tensor<1x32x11x32xf32>, tensor<1x32x11x32xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %2026 = tensor.empty() : tensor<1x32x11x64xf32>
+    %2027 = "ttir.multiply"(%2025, %57, %2026) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %2028 = tensor.empty() : tensor<1x32x11x64xf32>
+    %2029 = "ttir.add"(%2009, %2027, %2028) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x32x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %2030 = tensor.empty() : tensor<32x11x64xf32>
+    %2031 = "ttir.squeeze"(%2029, %2030) <{dim = 0 : si32}> : (tensor<1x32x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %2032 = tensor.empty() : tensor<11x512xf32>
+    %2033 = "ttir.matmul"(%2001, %arg275, %2032) : (tensor<11x2048xf32>, tensor<2048x512xf32>, tensor<11x512xf32>) -> tensor<11x512xf32>
+    %2034 = tensor.empty() : tensor<1x11x8x64xf32>
+    %2035 = "ttir.reshape"(%2033, %2034) <{shape = [1 : i32, 11 : i32, 8 : i32, 64 : i32]}> : (tensor<11x512xf32>, tensor<1x11x8x64xf32>) -> tensor<1x11x8x64xf32>
+    %2036 = tensor.empty() : tensor<1x8x11x64xf32>
+    %2037 = "ttir.transpose"(%2035, %2036) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x8x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %2038 = tensor.empty() : tensor<1x8x11x64xf32>
+    %2039 = "ttir.multiply"(%2037, %35, %2038) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %2040 = tensor.empty() : tensor<1x8x64x11xf32>
+    %2041 = "ttir.transpose"(%2037, %2040) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x64x11xf32>) -> tensor<1x8x64x11xf32>
+    %2042 = tensor.empty() : tensor<1x8x32x11xf32>
+    %2043 = "ttir.matmul"(%arg126, %2041, %2042) : (tensor<1x8x32x64xf32>, tensor<1x8x64x11xf32>, tensor<1x8x32x11xf32>) -> tensor<1x8x32x11xf32>
+    %2044 = tensor.empty() : tensor<1x8x11x32xf32>
+    %2045 = "ttir.transpose"(%2043, %2044) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x32x11xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %2046 = tensor.empty() : tensor<1x8x11x32xf32>
+    %2047 = "ttir.multiply"(%2045, %arg127, %2046) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x32xf32>, tensor<1xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %2048 = tensor.empty() : tensor<1x8x64x11xf32>
+    %2049 = "ttir.transpose"(%2037, %2048) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x64x11xf32>) -> tensor<1x8x64x11xf32>
+    %2050 = tensor.empty() : tensor<1x8x32x11xf32>
+    %2051 = "ttir.matmul"(%arg128, %2049, %2050) : (tensor<1x8x32x64xf32>, tensor<1x8x64x11xf32>, tensor<1x8x32x11xf32>) -> tensor<1x8x32x11xf32>
+    %2052 = tensor.empty() : tensor<1x8x11x32xf32>
+    %2053 = "ttir.transpose"(%2051, %2052) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x32x11xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %2054 = tensor.empty() : tensor<1x8x11x64xf32>
+    %2055 = "ttir.concat"(%2047, %2053, %2054) <{dim = -1 : si32}> : (tensor<1x8x11x32xf32>, tensor<1x8x11x32xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %2056 = tensor.empty() : tensor<1x8x11x64xf32>
+    %2057 = "ttir.multiply"(%2055, %57, %2056) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %2058 = tensor.empty() : tensor<1x8x11x64xf32>
+    %2059 = "ttir.add"(%2039, %2057, %2058) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x8x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %2060 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %2061 = "ttir.unsqueeze"(%2059, %2060) <{dim = 2 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %2062 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %2063 = "ttir.repeat_interleave"(%2061, %2062) <{dim = 0 : si32, repeats = 1 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %2064 = tensor.empty() : tensor<1x8x4x11x64xf32>
+    %2065 = "ttir.repeat_interleave"(%2063, %2064) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x4x11x64xf32>) -> tensor<1x8x4x11x64xf32>
+    %2066 = tensor.empty() : tensor<32x11x64xf32>
+    %2067 = "ttir.reshape"(%2065, %2066) <{shape = [32 : i32, 11 : i32, 64 : i32]}> : (tensor<1x8x4x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %2068 = tensor.empty() : tensor<32x64x11xf32>
+    %2069 = "ttir.transpose"(%2067, %2068) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x11x64xf32>, tensor<32x64x11xf32>) -> tensor<32x64x11xf32>
+    %2070 = tensor.empty() : tensor<32x11x11xf32>
+    %2071 = "ttir.matmul"(%2031, %2069, %2070) : (tensor<32x11x64xf32>, tensor<32x64x11xf32>, tensor<32x11x11xf32>) -> tensor<32x11x11xf32>
+    %2072 = tensor.empty() : tensor<1x32x11x11xf32>
+    %2073 = "ttir.unsqueeze"(%2071, %2072) <{dim = 0 : si32}> : (tensor<32x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %2074 = tensor.empty() : tensor<1x32x11x11xf32>
+    %2075 = "ttir.multiply"(%2073, %arg129, %2074) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x11xf32>, tensor<1xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %2076 = tensor.empty() : tensor<1x32x11x11xf32>
+    %2077 = "ttir.add"(%2075, %arg130, %2076) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x11xf32>, tensor<1x1x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %2078 = tensor.empty() : tensor<1x32x11x11xf32>
+    %2079 = "ttir.softmax"(%2077, %2078) <{dimension = -1 : si32}> : (tensor<1x32x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %2080 = tensor.empty() : tensor<32x11x11xf32>
+    %2081 = "ttir.squeeze"(%2079, %2080) <{dim = 0 : si32}> : (tensor<1x32x11x11xf32>, tensor<32x11x11xf32>) -> tensor<32x11x11xf32>
+    %2082 = tensor.empty() : tensor<11x512xf32>
+    %2083 = "ttir.matmul"(%2001, %arg276, %2082) : (tensor<11x2048xf32>, tensor<2048x512xf32>, tensor<11x512xf32>) -> tensor<11x512xf32>
+    %2084 = tensor.empty() : tensor<1x11x8x64xf32>
+    %2085 = "ttir.reshape"(%2083, %2084) <{shape = [1 : i32, 11 : i32, 8 : i32, 64 : i32]}> : (tensor<11x512xf32>, tensor<1x11x8x64xf32>) -> tensor<1x11x8x64xf32>
+    %2086 = tensor.empty() : tensor<1x8x11x64xf32>
+    %2087 = "ttir.transpose"(%2085, %2086) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x8x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %2088 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %2089 = "ttir.unsqueeze"(%2087, %2088) <{dim = 2 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %2090 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %2091 = "ttir.repeat_interleave"(%2089, %2090) <{dim = 0 : si32, repeats = 1 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %2092 = tensor.empty() : tensor<1x8x4x11x64xf32>
+    %2093 = "ttir.repeat_interleave"(%2091, %2092) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x4x11x64xf32>) -> tensor<1x8x4x11x64xf32>
+    %2094 = tensor.empty() : tensor<1x32x11x64xf32>
+    %2095 = "ttir.reshape"(%2093, %2094) <{shape = [1 : i32, 32 : i32, 11 : i32, 64 : i32]}> : (tensor<1x8x4x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %2096 = tensor.empty() : tensor<1x32x64x11xf32>
+    %2097 = "ttir.transpose"(%2095, %2096) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %2098 = tensor.empty() : tensor<32x64x11xf32>
+    %2099 = "ttir.squeeze"(%2097, %2098) <{dim = 0 : si32}> : (tensor<1x32x64x11xf32>, tensor<32x64x11xf32>) -> tensor<32x64x11xf32>
+    %2100 = tensor.empty() : tensor<32x11x64xf32>
+    %2101 = "ttir.transpose"(%2099, %2100) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x64x11xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %2102 = tensor.empty() : tensor<32x11x64xf32>
+    %2103 = "ttir.matmul"(%2081, %2101, %2102) : (tensor<32x11x11xf32>, tensor<32x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %2104 = tensor.empty() : tensor<1x32x11x64xf32>
+    %2105 = "ttir.unsqueeze"(%2103, %2104) <{dim = 0 : si32}> : (tensor<32x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %2106 = tensor.empty() : tensor<1x11x32x64xf32>
+    %2107 = "ttir.transpose"(%2105, %2106) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x11x32x64xf32>) -> tensor<1x11x32x64xf32>
+    %2108 = tensor.empty() : tensor<11x2048xf32>
+    %2109 = "ttir.reshape"(%2107, %2108) <{shape = [11 : i32, 2048 : i32]}> : (tensor<1x11x32x64xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %2110 = tensor.empty() : tensor<11x2048xf32>
+    %2111 = "ttir.matmul"(%2109, %arg277, %2110) : (tensor<11x2048xf32>, tensor<2048x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %2112 = tensor.empty() : tensor<1x11x2048xf32>
+    %2113 = "ttir.unsqueeze"(%2111, %2112) <{dim = 0 : si32}> : (tensor<11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2114 = tensor.empty() : tensor<1x11x2048xf32>
+    %2115 = "ttir.add"(%1985, %2113, %2114) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2116 = tensor.empty() : tensor<1x11x2048xf32>
+    %2117 = "ttir.multiply"(%2115, %2115, %2116) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2118 = tensor.empty() : tensor<1x11x1xf32>
+    %2119 = "ttir.mean"(%2117, %2118) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %2120 = tensor.empty() : tensor<1x11x1xf32>
+    %2121 = "ttir.add"(%2119, %arg131, %2120) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %2122 = tensor.empty() : tensor<1x11x1xf32>
+    %2123 = "ttir.sqrt"(%2121, %2122) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %2124 = tensor.empty() : tensor<1x11x1xf32>
+    %2125 = "ttir.reciprocal"(%2123, %2124) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %2126 = tensor.empty() : tensor<1x11x2048xf32>
+    %2127 = "ttir.multiply"(%2115, %2125, %2126) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2128 = tensor.empty() : tensor<1x11x2048xf32>
+    %2129 = "ttir.multiply"(%arg278, %2127, %2128) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2130 = tensor.empty() : tensor<11x2048xf32>
+    %2131 = "ttir.squeeze"(%2129, %2130) <{dim = 0 : si32}> : (tensor<1x11x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %2132 = tensor.empty() : tensor<11x8192xf32>
+    %2133 = "ttir.matmul"(%2131, %arg279, %2132) : (tensor<11x2048xf32>, tensor<2048x8192xf32>, tensor<11x8192xf32>) -> tensor<11x8192xf32>
+    %2134 = tensor.empty() : tensor<1x11x8192xf32>
+    %2135 = "ttir.unsqueeze"(%2133, %2134) <{dim = 0 : si32}> : (tensor<11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %2136 = tensor.empty() : tensor<1x11x8192xf32>
+    %2137 = "ttir.sigmoid"(%2135, %2136) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %2138 = tensor.empty() : tensor<1x11x8192xf32>
+    %2139 = "ttir.multiply"(%2135, %2137, %2138) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %2140 = tensor.empty() : tensor<11x8192xf32>
+    %2141 = "ttir.matmul"(%2131, %arg280, %2140) : (tensor<11x2048xf32>, tensor<2048x8192xf32>, tensor<11x8192xf32>) -> tensor<11x8192xf32>
+    %2142 = tensor.empty() : tensor<1x11x8192xf32>
+    %2143 = "ttir.unsqueeze"(%2141, %2142) <{dim = 0 : si32}> : (tensor<11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %2144 = tensor.empty() : tensor<1x11x8192xf32>
+    %2145 = "ttir.multiply"(%2139, %2143, %2144) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %2146 = tensor.empty() : tensor<1x11x2048xf32>
+    %2147 = "ttir.matmul"(%2145, %arg281, %2146) : (tensor<1x11x8192xf32>, tensor<8192x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2148 = tensor.empty() : tensor<1x11x2048xf32>
+    %2149 = "ttir.add"(%2115, %2147, %2148) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2150 = tensor.empty() : tensor<1x11x2048xf32>
+    %2151 = "ttir.multiply"(%2149, %2149, %2150) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2152 = tensor.empty() : tensor<1x11x1xf32>
+    %2153 = "ttir.mean"(%2151, %2152) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %2154 = tensor.empty() : tensor<1x11x1xf32>
+    %2155 = "ttir.add"(%2153, %arg132, %2154) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %2156 = tensor.empty() : tensor<1x11x1xf32>
+    %2157 = "ttir.sqrt"(%2155, %2156) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %2158 = tensor.empty() : tensor<1x11x1xf32>
+    %2159 = "ttir.reciprocal"(%2157, %2158) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %2160 = tensor.empty() : tensor<1x11x2048xf32>
+    %2161 = "ttir.multiply"(%2149, %2159, %2160) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2162 = tensor.empty() : tensor<1x11x2048xf32>
+    %2163 = "ttir.multiply"(%arg282, %2161, %2162) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2164 = tensor.empty() : tensor<11x2048xf32>
+    %2165 = "ttir.squeeze"(%2163, %2164) <{dim = 0 : si32}> : (tensor<1x11x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %2166 = tensor.empty() : tensor<11x2048xf32>
+    %2167 = "ttir.matmul"(%2165, %arg283, %2166) : (tensor<11x2048xf32>, tensor<2048x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %2168 = tensor.empty() : tensor<1x11x32x64xf32>
+    %2169 = "ttir.reshape"(%2167, %2168) <{shape = [1 : i32, 11 : i32, 32 : i32, 64 : i32]}> : (tensor<11x2048xf32>, tensor<1x11x32x64xf32>) -> tensor<1x11x32x64xf32>
+    %2170 = tensor.empty() : tensor<1x32x11x64xf32>
+    %2171 = "ttir.transpose"(%2169, %2170) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x32x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %2172 = tensor.empty() : tensor<1x32x11x64xf32>
+    %2173 = "ttir.multiply"(%2171, %35, %2172) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %2174 = tensor.empty() : tensor<1x32x64x11xf32>
+    %2175 = "ttir.transpose"(%2171, %2174) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %2176 = tensor.empty() : tensor<1x32x32x11xf32>
+    %2177 = "ttir.matmul"(%arg133, %2175, %2176) : (tensor<1x32x32x64xf32>, tensor<1x32x64x11xf32>, tensor<1x32x32x11xf32>) -> tensor<1x32x32x11xf32>
+    %2178 = tensor.empty() : tensor<1x32x11x32xf32>
+    %2179 = "ttir.transpose"(%2177, %2178) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x32x11xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %2180 = tensor.empty() : tensor<1x32x11x32xf32>
+    %2181 = "ttir.multiply"(%2179, %arg134, %2180) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x32xf32>, tensor<1xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %2182 = tensor.empty() : tensor<1x32x64x11xf32>
+    %2183 = "ttir.transpose"(%2171, %2182) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %2184 = tensor.empty() : tensor<1x32x32x11xf32>
+    %2185 = "ttir.matmul"(%arg135, %2183, %2184) : (tensor<1x32x32x64xf32>, tensor<1x32x64x11xf32>, tensor<1x32x32x11xf32>) -> tensor<1x32x32x11xf32>
+    %2186 = tensor.empty() : tensor<1x32x11x32xf32>
+    %2187 = "ttir.transpose"(%2185, %2186) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x32x11xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %2188 = tensor.empty() : tensor<1x32x11x64xf32>
+    %2189 = "ttir.concat"(%2181, %2187, %2188) <{dim = -1 : si32}> : (tensor<1x32x11x32xf32>, tensor<1x32x11x32xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %2190 = tensor.empty() : tensor<1x32x11x64xf32>
+    %2191 = "ttir.multiply"(%2189, %57, %2190) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %2192 = tensor.empty() : tensor<1x32x11x64xf32>
+    %2193 = "ttir.add"(%2173, %2191, %2192) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x32x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %2194 = tensor.empty() : tensor<32x11x64xf32>
+    %2195 = "ttir.squeeze"(%2193, %2194) <{dim = 0 : si32}> : (tensor<1x32x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %2196 = tensor.empty() : tensor<11x512xf32>
+    %2197 = "ttir.matmul"(%2165, %arg284, %2196) : (tensor<11x2048xf32>, tensor<2048x512xf32>, tensor<11x512xf32>) -> tensor<11x512xf32>
+    %2198 = tensor.empty() : tensor<1x11x8x64xf32>
+    %2199 = "ttir.reshape"(%2197, %2198) <{shape = [1 : i32, 11 : i32, 8 : i32, 64 : i32]}> : (tensor<11x512xf32>, tensor<1x11x8x64xf32>) -> tensor<1x11x8x64xf32>
+    %2200 = tensor.empty() : tensor<1x8x11x64xf32>
+    %2201 = "ttir.transpose"(%2199, %2200) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x8x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %2202 = tensor.empty() : tensor<1x8x11x64xf32>
+    %2203 = "ttir.multiply"(%2201, %35, %2202) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %2204 = tensor.empty() : tensor<1x8x64x11xf32>
+    %2205 = "ttir.transpose"(%2201, %2204) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x64x11xf32>) -> tensor<1x8x64x11xf32>
+    %2206 = tensor.empty() : tensor<1x8x32x11xf32>
+    %2207 = "ttir.matmul"(%arg136, %2205, %2206) : (tensor<1x8x32x64xf32>, tensor<1x8x64x11xf32>, tensor<1x8x32x11xf32>) -> tensor<1x8x32x11xf32>
+    %2208 = tensor.empty() : tensor<1x8x11x32xf32>
+    %2209 = "ttir.transpose"(%2207, %2208) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x32x11xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %2210 = tensor.empty() : tensor<1x8x11x32xf32>
+    %2211 = "ttir.multiply"(%2209, %arg137, %2210) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x32xf32>, tensor<1xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %2212 = tensor.empty() : tensor<1x8x64x11xf32>
+    %2213 = "ttir.transpose"(%2201, %2212) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x64x11xf32>) -> tensor<1x8x64x11xf32>
+    %2214 = tensor.empty() : tensor<1x8x32x11xf32>
+    %2215 = "ttir.matmul"(%arg138, %2213, %2214) : (tensor<1x8x32x64xf32>, tensor<1x8x64x11xf32>, tensor<1x8x32x11xf32>) -> tensor<1x8x32x11xf32>
+    %2216 = tensor.empty() : tensor<1x8x11x32xf32>
+    %2217 = "ttir.transpose"(%2215, %2216) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x32x11xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %2218 = tensor.empty() : tensor<1x8x11x64xf32>
+    %2219 = "ttir.concat"(%2211, %2217, %2218) <{dim = -1 : si32}> : (tensor<1x8x11x32xf32>, tensor<1x8x11x32xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %2220 = tensor.empty() : tensor<1x8x11x64xf32>
+    %2221 = "ttir.multiply"(%2219, %57, %2220) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %2222 = tensor.empty() : tensor<1x8x11x64xf32>
+    %2223 = "ttir.add"(%2203, %2221, %2222) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x8x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %2224 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %2225 = "ttir.unsqueeze"(%2223, %2224) <{dim = 2 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %2226 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %2227 = "ttir.repeat_interleave"(%2225, %2226) <{dim = 0 : si32, repeats = 1 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %2228 = tensor.empty() : tensor<1x8x4x11x64xf32>
+    %2229 = "ttir.repeat_interleave"(%2227, %2228) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x4x11x64xf32>) -> tensor<1x8x4x11x64xf32>
+    %2230 = tensor.empty() : tensor<32x11x64xf32>
+    %2231 = "ttir.reshape"(%2229, %2230) <{shape = [32 : i32, 11 : i32, 64 : i32]}> : (tensor<1x8x4x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %2232 = tensor.empty() : tensor<32x64x11xf32>
+    %2233 = "ttir.transpose"(%2231, %2232) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x11x64xf32>, tensor<32x64x11xf32>) -> tensor<32x64x11xf32>
+    %2234 = tensor.empty() : tensor<32x11x11xf32>
+    %2235 = "ttir.matmul"(%2195, %2233, %2234) : (tensor<32x11x64xf32>, tensor<32x64x11xf32>, tensor<32x11x11xf32>) -> tensor<32x11x11xf32>
+    %2236 = tensor.empty() : tensor<1x32x11x11xf32>
+    %2237 = "ttir.unsqueeze"(%2235, %2236) <{dim = 0 : si32}> : (tensor<32x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %2238 = tensor.empty() : tensor<1x32x11x11xf32>
+    %2239 = "ttir.multiply"(%2237, %arg139, %2238) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x11xf32>, tensor<1xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %2240 = tensor.empty() : tensor<1x32x11x11xf32>
+    %2241 = "ttir.add"(%2239, %arg140, %2240) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x11xf32>, tensor<1x1x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %2242 = tensor.empty() : tensor<1x32x11x11xf32>
+    %2243 = "ttir.softmax"(%2241, %2242) <{dimension = -1 : si32}> : (tensor<1x32x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %2244 = tensor.empty() : tensor<32x11x11xf32>
+    %2245 = "ttir.squeeze"(%2243, %2244) <{dim = 0 : si32}> : (tensor<1x32x11x11xf32>, tensor<32x11x11xf32>) -> tensor<32x11x11xf32>
+    %2246 = tensor.empty() : tensor<11x512xf32>
+    %2247 = "ttir.matmul"(%2165, %arg285, %2246) : (tensor<11x2048xf32>, tensor<2048x512xf32>, tensor<11x512xf32>) -> tensor<11x512xf32>
+    %2248 = tensor.empty() : tensor<1x11x8x64xf32>
+    %2249 = "ttir.reshape"(%2247, %2248) <{shape = [1 : i32, 11 : i32, 8 : i32, 64 : i32]}> : (tensor<11x512xf32>, tensor<1x11x8x64xf32>) -> tensor<1x11x8x64xf32>
+    %2250 = tensor.empty() : tensor<1x8x11x64xf32>
+    %2251 = "ttir.transpose"(%2249, %2250) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x8x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %2252 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %2253 = "ttir.unsqueeze"(%2251, %2252) <{dim = 2 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %2254 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %2255 = "ttir.repeat_interleave"(%2253, %2254) <{dim = 0 : si32, repeats = 1 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %2256 = tensor.empty() : tensor<1x8x4x11x64xf32>
+    %2257 = "ttir.repeat_interleave"(%2255, %2256) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x4x11x64xf32>) -> tensor<1x8x4x11x64xf32>
+    %2258 = tensor.empty() : tensor<1x32x11x64xf32>
+    %2259 = "ttir.reshape"(%2257, %2258) <{shape = [1 : i32, 32 : i32, 11 : i32, 64 : i32]}> : (tensor<1x8x4x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %2260 = tensor.empty() : tensor<1x32x64x11xf32>
+    %2261 = "ttir.transpose"(%2259, %2260) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %2262 = tensor.empty() : tensor<32x64x11xf32>
+    %2263 = "ttir.squeeze"(%2261, %2262) <{dim = 0 : si32}> : (tensor<1x32x64x11xf32>, tensor<32x64x11xf32>) -> tensor<32x64x11xf32>
+    %2264 = tensor.empty() : tensor<32x11x64xf32>
+    %2265 = "ttir.transpose"(%2263, %2264) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x64x11xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %2266 = tensor.empty() : tensor<32x11x64xf32>
+    %2267 = "ttir.matmul"(%2245, %2265, %2266) : (tensor<32x11x11xf32>, tensor<32x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %2268 = tensor.empty() : tensor<1x32x11x64xf32>
+    %2269 = "ttir.unsqueeze"(%2267, %2268) <{dim = 0 : si32}> : (tensor<32x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %2270 = tensor.empty() : tensor<1x11x32x64xf32>
+    %2271 = "ttir.transpose"(%2269, %2270) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x11x32x64xf32>) -> tensor<1x11x32x64xf32>
+    %2272 = tensor.empty() : tensor<11x2048xf32>
+    %2273 = "ttir.reshape"(%2271, %2272) <{shape = [11 : i32, 2048 : i32]}> : (tensor<1x11x32x64xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %2274 = tensor.empty() : tensor<11x2048xf32>
+    %2275 = "ttir.matmul"(%2273, %arg286, %2274) : (tensor<11x2048xf32>, tensor<2048x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %2276 = tensor.empty() : tensor<1x11x2048xf32>
+    %2277 = "ttir.unsqueeze"(%2275, %2276) <{dim = 0 : si32}> : (tensor<11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2278 = tensor.empty() : tensor<1x11x2048xf32>
+    %2279 = "ttir.add"(%2149, %2277, %2278) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2280 = tensor.empty() : tensor<1x11x2048xf32>
+    %2281 = "ttir.multiply"(%2279, %2279, %2280) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2282 = tensor.empty() : tensor<1x11x1xf32>
+    %2283 = "ttir.mean"(%2281, %2282) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %2284 = tensor.empty() : tensor<1x11x1xf32>
+    %2285 = "ttir.add"(%2283, %arg141, %2284) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %2286 = tensor.empty() : tensor<1x11x1xf32>
+    %2287 = "ttir.sqrt"(%2285, %2286) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %2288 = tensor.empty() : tensor<1x11x1xf32>
+    %2289 = "ttir.reciprocal"(%2287, %2288) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %2290 = tensor.empty() : tensor<1x11x2048xf32>
+    %2291 = "ttir.multiply"(%2279, %2289, %2290) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2292 = tensor.empty() : tensor<1x11x2048xf32>
+    %2293 = "ttir.multiply"(%arg287, %2291, %2292) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2294 = tensor.empty() : tensor<11x2048xf32>
+    %2295 = "ttir.squeeze"(%2293, %2294) <{dim = 0 : si32}> : (tensor<1x11x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %2296 = tensor.empty() : tensor<11x8192xf32>
+    %2297 = "ttir.matmul"(%2295, %arg288, %2296) : (tensor<11x2048xf32>, tensor<2048x8192xf32>, tensor<11x8192xf32>) -> tensor<11x8192xf32>
+    %2298 = tensor.empty() : tensor<1x11x8192xf32>
+    %2299 = "ttir.unsqueeze"(%2297, %2298) <{dim = 0 : si32}> : (tensor<11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %2300 = tensor.empty() : tensor<1x11x8192xf32>
+    %2301 = "ttir.sigmoid"(%2299, %2300) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %2302 = tensor.empty() : tensor<1x11x8192xf32>
+    %2303 = "ttir.multiply"(%2299, %2301, %2302) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %2304 = tensor.empty() : tensor<11x8192xf32>
+    %2305 = "ttir.matmul"(%2295, %arg289, %2304) : (tensor<11x2048xf32>, tensor<2048x8192xf32>, tensor<11x8192xf32>) -> tensor<11x8192xf32>
+    %2306 = tensor.empty() : tensor<1x11x8192xf32>
+    %2307 = "ttir.unsqueeze"(%2305, %2306) <{dim = 0 : si32}> : (tensor<11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %2308 = tensor.empty() : tensor<1x11x8192xf32>
+    %2309 = "ttir.multiply"(%2303, %2307, %2308) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %2310 = tensor.empty() : tensor<1x11x2048xf32>
+    %2311 = "ttir.matmul"(%2309, %arg290, %2310) : (tensor<1x11x8192xf32>, tensor<8192x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2312 = tensor.empty() : tensor<1x11x2048xf32>
+    %2313 = "ttir.add"(%2279, %2311, %2312) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2314 = tensor.empty() : tensor<1x11x2048xf32>
+    %2315 = "ttir.multiply"(%2313, %2313, %2314) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2316 = tensor.empty() : tensor<1x11x1xf32>
+    %2317 = "ttir.mean"(%2315, %2316) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %2318 = tensor.empty() : tensor<1x11x1xf32>
+    %2319 = "ttir.add"(%2317, %arg142, %2318) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %2320 = tensor.empty() : tensor<1x11x1xf32>
+    %2321 = "ttir.sqrt"(%2319, %2320) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %2322 = tensor.empty() : tensor<1x11x1xf32>
+    %2323 = "ttir.reciprocal"(%2321, %2322) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %2324 = tensor.empty() : tensor<1x11x2048xf32>
+    %2325 = "ttir.multiply"(%2313, %2323, %2324) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2326 = tensor.empty() : tensor<1x11x2048xf32>
+    %2327 = "ttir.multiply"(%arg291, %2325, %2326) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2328 = tensor.empty() : tensor<11x2048xf32>
+    %2329 = "ttir.squeeze"(%2327, %2328) <{dim = 0 : si32}> : (tensor<1x11x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %2330 = tensor.empty() : tensor<11x2048xf32>
+    %2331 = "ttir.matmul"(%2329, %arg292, %2330) : (tensor<11x2048xf32>, tensor<2048x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %2332 = tensor.empty() : tensor<1x11x32x64xf32>
+    %2333 = "ttir.reshape"(%2331, %2332) <{shape = [1 : i32, 11 : i32, 32 : i32, 64 : i32]}> : (tensor<11x2048xf32>, tensor<1x11x32x64xf32>) -> tensor<1x11x32x64xf32>
+    %2334 = tensor.empty() : tensor<1x32x11x64xf32>
+    %2335 = "ttir.transpose"(%2333, %2334) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x32x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %2336 = tensor.empty() : tensor<1x32x11x64xf32>
+    %2337 = "ttir.multiply"(%2335, %35, %2336) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %2338 = tensor.empty() : tensor<1x32x64x11xf32>
+    %2339 = "ttir.transpose"(%2335, %2338) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %2340 = tensor.empty() : tensor<1x32x32x11xf32>
+    %2341 = "ttir.matmul"(%arg143, %2339, %2340) : (tensor<1x32x32x64xf32>, tensor<1x32x64x11xf32>, tensor<1x32x32x11xf32>) -> tensor<1x32x32x11xf32>
+    %2342 = tensor.empty() : tensor<1x32x11x32xf32>
+    %2343 = "ttir.transpose"(%2341, %2342) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x32x11xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %2344 = tensor.empty() : tensor<1x32x11x32xf32>
+    %2345 = "ttir.multiply"(%2343, %arg144, %2344) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x32xf32>, tensor<1xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %2346 = tensor.empty() : tensor<1x32x64x11xf32>
+    %2347 = "ttir.transpose"(%2335, %2346) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %2348 = tensor.empty() : tensor<1x32x32x11xf32>
+    %2349 = "ttir.matmul"(%arg145, %2347, %2348) : (tensor<1x32x32x64xf32>, tensor<1x32x64x11xf32>, tensor<1x32x32x11xf32>) -> tensor<1x32x32x11xf32>
+    %2350 = tensor.empty() : tensor<1x32x11x32xf32>
+    %2351 = "ttir.transpose"(%2349, %2350) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x32x11xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %2352 = tensor.empty() : tensor<1x32x11x64xf32>
+    %2353 = "ttir.concat"(%2345, %2351, %2352) <{dim = -1 : si32}> : (tensor<1x32x11x32xf32>, tensor<1x32x11x32xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %2354 = tensor.empty() : tensor<1x32x11x64xf32>
+    %2355 = "ttir.multiply"(%2353, %57, %2354) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %2356 = tensor.empty() : tensor<1x32x11x64xf32>
+    %2357 = "ttir.add"(%2337, %2355, %2356) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x32x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %2358 = tensor.empty() : tensor<32x11x64xf32>
+    %2359 = "ttir.squeeze"(%2357, %2358) <{dim = 0 : si32}> : (tensor<1x32x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %2360 = tensor.empty() : tensor<11x512xf32>
+    %2361 = "ttir.matmul"(%2329, %arg293, %2360) : (tensor<11x2048xf32>, tensor<2048x512xf32>, tensor<11x512xf32>) -> tensor<11x512xf32>
+    %2362 = tensor.empty() : tensor<1x11x8x64xf32>
+    %2363 = "ttir.reshape"(%2361, %2362) <{shape = [1 : i32, 11 : i32, 8 : i32, 64 : i32]}> : (tensor<11x512xf32>, tensor<1x11x8x64xf32>) -> tensor<1x11x8x64xf32>
+    %2364 = tensor.empty() : tensor<1x8x11x64xf32>
+    %2365 = "ttir.transpose"(%2363, %2364) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x8x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %2366 = tensor.empty() : tensor<1x8x11x64xf32>
+    %2367 = "ttir.multiply"(%2365, %35, %2366) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %2368 = tensor.empty() : tensor<1x8x64x11xf32>
+    %2369 = "ttir.transpose"(%2365, %2368) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x64x11xf32>) -> tensor<1x8x64x11xf32>
+    %2370 = tensor.empty() : tensor<1x8x32x11xf32>
+    %2371 = "ttir.matmul"(%arg146, %2369, %2370) : (tensor<1x8x32x64xf32>, tensor<1x8x64x11xf32>, tensor<1x8x32x11xf32>) -> tensor<1x8x32x11xf32>
+    %2372 = tensor.empty() : tensor<1x8x11x32xf32>
+    %2373 = "ttir.transpose"(%2371, %2372) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x32x11xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %2374 = tensor.empty() : tensor<1x8x11x32xf32>
+    %2375 = "ttir.multiply"(%2373, %arg147, %2374) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x32xf32>, tensor<1xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %2376 = tensor.empty() : tensor<1x8x64x11xf32>
+    %2377 = "ttir.transpose"(%2365, %2376) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x64x11xf32>) -> tensor<1x8x64x11xf32>
+    %2378 = tensor.empty() : tensor<1x8x32x11xf32>
+    %2379 = "ttir.matmul"(%arg148, %2377, %2378) : (tensor<1x8x32x64xf32>, tensor<1x8x64x11xf32>, tensor<1x8x32x11xf32>) -> tensor<1x8x32x11xf32>
+    %2380 = tensor.empty() : tensor<1x8x11x32xf32>
+    %2381 = "ttir.transpose"(%2379, %2380) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x32x11xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %2382 = tensor.empty() : tensor<1x8x11x64xf32>
+    %2383 = "ttir.concat"(%2375, %2381, %2382) <{dim = -1 : si32}> : (tensor<1x8x11x32xf32>, tensor<1x8x11x32xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %2384 = tensor.empty() : tensor<1x8x11x64xf32>
+    %2385 = "ttir.multiply"(%2383, %57, %2384) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %2386 = tensor.empty() : tensor<1x8x11x64xf32>
+    %2387 = "ttir.add"(%2367, %2385, %2386) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x8x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %2388 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %2389 = "ttir.unsqueeze"(%2387, %2388) <{dim = 2 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %2390 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %2391 = "ttir.repeat_interleave"(%2389, %2390) <{dim = 0 : si32, repeats = 1 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %2392 = tensor.empty() : tensor<1x8x4x11x64xf32>
+    %2393 = "ttir.repeat_interleave"(%2391, %2392) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x4x11x64xf32>) -> tensor<1x8x4x11x64xf32>
+    %2394 = tensor.empty() : tensor<32x11x64xf32>
+    %2395 = "ttir.reshape"(%2393, %2394) <{shape = [32 : i32, 11 : i32, 64 : i32]}> : (tensor<1x8x4x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %2396 = tensor.empty() : tensor<32x64x11xf32>
+    %2397 = "ttir.transpose"(%2395, %2396) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x11x64xf32>, tensor<32x64x11xf32>) -> tensor<32x64x11xf32>
+    %2398 = tensor.empty() : tensor<32x11x11xf32>
+    %2399 = "ttir.matmul"(%2359, %2397, %2398) : (tensor<32x11x64xf32>, tensor<32x64x11xf32>, tensor<32x11x11xf32>) -> tensor<32x11x11xf32>
+    %2400 = tensor.empty() : tensor<1x32x11x11xf32>
+    %2401 = "ttir.unsqueeze"(%2399, %2400) <{dim = 0 : si32}> : (tensor<32x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %2402 = tensor.empty() : tensor<1x32x11x11xf32>
+    %2403 = "ttir.multiply"(%2401, %arg149, %2402) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x11xf32>, tensor<1xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %2404 = tensor.empty() : tensor<1x32x11x11xf32>
+    %2405 = "ttir.add"(%2403, %arg150, %2404) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x11xf32>, tensor<1x1x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %2406 = tensor.empty() : tensor<1x32x11x11xf32>
+    %2407 = "ttir.softmax"(%2405, %2406) <{dimension = -1 : si32}> : (tensor<1x32x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %2408 = tensor.empty() : tensor<32x11x11xf32>
+    %2409 = "ttir.squeeze"(%2407, %2408) <{dim = 0 : si32}> : (tensor<1x32x11x11xf32>, tensor<32x11x11xf32>) -> tensor<32x11x11xf32>
+    %2410 = tensor.empty() : tensor<11x512xf32>
+    %2411 = "ttir.matmul"(%2329, %arg294, %2410) : (tensor<11x2048xf32>, tensor<2048x512xf32>, tensor<11x512xf32>) -> tensor<11x512xf32>
+    %2412 = tensor.empty() : tensor<1x11x8x64xf32>
+    %2413 = "ttir.reshape"(%2411, %2412) <{shape = [1 : i32, 11 : i32, 8 : i32, 64 : i32]}> : (tensor<11x512xf32>, tensor<1x11x8x64xf32>) -> tensor<1x11x8x64xf32>
+    %2414 = tensor.empty() : tensor<1x8x11x64xf32>
+    %2415 = "ttir.transpose"(%2413, %2414) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x8x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %2416 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %2417 = "ttir.unsqueeze"(%2415, %2416) <{dim = 2 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %2418 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %2419 = "ttir.repeat_interleave"(%2417, %2418) <{dim = 0 : si32, repeats = 1 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %2420 = tensor.empty() : tensor<1x8x4x11x64xf32>
+    %2421 = "ttir.repeat_interleave"(%2419, %2420) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x4x11x64xf32>) -> tensor<1x8x4x11x64xf32>
+    %2422 = tensor.empty() : tensor<1x32x11x64xf32>
+    %2423 = "ttir.reshape"(%2421, %2422) <{shape = [1 : i32, 32 : i32, 11 : i32, 64 : i32]}> : (tensor<1x8x4x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %2424 = tensor.empty() : tensor<1x32x64x11xf32>
+    %2425 = "ttir.transpose"(%2423, %2424) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %2426 = tensor.empty() : tensor<32x64x11xf32>
+    %2427 = "ttir.squeeze"(%2425, %2426) <{dim = 0 : si32}> : (tensor<1x32x64x11xf32>, tensor<32x64x11xf32>) -> tensor<32x64x11xf32>
+    %2428 = tensor.empty() : tensor<32x11x64xf32>
+    %2429 = "ttir.transpose"(%2427, %2428) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x64x11xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %2430 = tensor.empty() : tensor<32x11x64xf32>
+    %2431 = "ttir.matmul"(%2409, %2429, %2430) : (tensor<32x11x11xf32>, tensor<32x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %2432 = tensor.empty() : tensor<1x32x11x64xf32>
+    %2433 = "ttir.unsqueeze"(%2431, %2432) <{dim = 0 : si32}> : (tensor<32x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %2434 = tensor.empty() : tensor<1x11x32x64xf32>
+    %2435 = "ttir.transpose"(%2433, %2434) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x11x32x64xf32>) -> tensor<1x11x32x64xf32>
+    %2436 = tensor.empty() : tensor<11x2048xf32>
+    %2437 = "ttir.reshape"(%2435, %2436) <{shape = [11 : i32, 2048 : i32]}> : (tensor<1x11x32x64xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %2438 = tensor.empty() : tensor<11x2048xf32>
+    %2439 = "ttir.matmul"(%2437, %arg295, %2438) : (tensor<11x2048xf32>, tensor<2048x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %2440 = tensor.empty() : tensor<1x11x2048xf32>
+    %2441 = "ttir.unsqueeze"(%2439, %2440) <{dim = 0 : si32}> : (tensor<11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2442 = tensor.empty() : tensor<1x11x2048xf32>
+    %2443 = "ttir.add"(%2313, %2441, %2442) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2444 = tensor.empty() : tensor<1x11x2048xf32>
+    %2445 = "ttir.multiply"(%2443, %2443, %2444) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2446 = tensor.empty() : tensor<1x11x1xf32>
+    %2447 = "ttir.mean"(%2445, %2446) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %2448 = tensor.empty() : tensor<1x11x1xf32>
+    %2449 = "ttir.add"(%2447, %arg151, %2448) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %2450 = tensor.empty() : tensor<1x11x1xf32>
+    %2451 = "ttir.sqrt"(%2449, %2450) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %2452 = tensor.empty() : tensor<1x11x1xf32>
+    %2453 = "ttir.reciprocal"(%2451, %2452) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %2454 = tensor.empty() : tensor<1x11x2048xf32>
+    %2455 = "ttir.multiply"(%2443, %2453, %2454) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2456 = tensor.empty() : tensor<1x11x2048xf32>
+    %2457 = "ttir.multiply"(%arg296, %2455, %2456) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2458 = tensor.empty() : tensor<11x2048xf32>
+    %2459 = "ttir.squeeze"(%2457, %2458) <{dim = 0 : si32}> : (tensor<1x11x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %2460 = tensor.empty() : tensor<11x8192xf32>
+    %2461 = "ttir.matmul"(%2459, %arg297, %2460) : (tensor<11x2048xf32>, tensor<2048x8192xf32>, tensor<11x8192xf32>) -> tensor<11x8192xf32>
+    %2462 = tensor.empty() : tensor<1x11x8192xf32>
+    %2463 = "ttir.unsqueeze"(%2461, %2462) <{dim = 0 : si32}> : (tensor<11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %2464 = tensor.empty() : tensor<1x11x8192xf32>
+    %2465 = "ttir.sigmoid"(%2463, %2464) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %2466 = tensor.empty() : tensor<1x11x8192xf32>
+    %2467 = "ttir.multiply"(%2463, %2465, %2466) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %2468 = tensor.empty() : tensor<11x8192xf32>
+    %2469 = "ttir.matmul"(%2459, %arg298, %2468) : (tensor<11x2048xf32>, tensor<2048x8192xf32>, tensor<11x8192xf32>) -> tensor<11x8192xf32>
+    %2470 = tensor.empty() : tensor<1x11x8192xf32>
+    %2471 = "ttir.unsqueeze"(%2469, %2470) <{dim = 0 : si32}> : (tensor<11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %2472 = tensor.empty() : tensor<1x11x8192xf32>
+    %2473 = "ttir.multiply"(%2467, %2471, %2472) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %2474 = tensor.empty() : tensor<1x11x2048xf32>
+    %2475 = "ttir.matmul"(%2473, %arg299, %2474) : (tensor<1x11x8192xf32>, tensor<8192x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2476 = tensor.empty() : tensor<1x11x2048xf32>
+    %2477 = "ttir.add"(%2443, %2475, %2476) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2478 = tensor.empty() : tensor<1x11x2048xf32>
+    %2479 = "ttir.multiply"(%2477, %2477, %2478) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2480 = tensor.empty() : tensor<1x11x1xf32>
+    %2481 = "ttir.mean"(%2479, %2480) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %2482 = tensor.empty() : tensor<1x11x1xf32>
+    %2483 = "ttir.add"(%2481, %arg152, %2482) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %2484 = tensor.empty() : tensor<1x11x1xf32>
+    %2485 = "ttir.sqrt"(%2483, %2484) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %2486 = tensor.empty() : tensor<1x11x1xf32>
+    %2487 = "ttir.reciprocal"(%2485, %2486) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %2488 = tensor.empty() : tensor<1x11x2048xf32>
+    %2489 = "ttir.multiply"(%2477, %2487, %2488) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2490 = tensor.empty() : tensor<1x11x2048xf32>
+    %2491 = "ttir.multiply"(%arg300, %2489, %2490) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2492 = tensor.empty() : tensor<11x2048xf32>
+    %2493 = "ttir.squeeze"(%2491, %2492) <{dim = 0 : si32}> : (tensor<1x11x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %2494 = tensor.empty() : tensor<11x2048xf32>
+    %2495 = "ttir.matmul"(%2493, %arg301, %2494) : (tensor<11x2048xf32>, tensor<2048x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %2496 = tensor.empty() : tensor<1x11x32x64xf32>
+    %2497 = "ttir.reshape"(%2495, %2496) <{shape = [1 : i32, 11 : i32, 32 : i32, 64 : i32]}> : (tensor<11x2048xf32>, tensor<1x11x32x64xf32>) -> tensor<1x11x32x64xf32>
+    %2498 = tensor.empty() : tensor<1x32x11x64xf32>
+    %2499 = "ttir.transpose"(%2497, %2498) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x32x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %2500 = tensor.empty() : tensor<1x32x11x64xf32>
+    %2501 = "ttir.multiply"(%2499, %35, %2500) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %2502 = tensor.empty() : tensor<1x32x64x11xf32>
+    %2503 = "ttir.transpose"(%2499, %2502) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %2504 = tensor.empty() : tensor<1x32x32x11xf32>
+    %2505 = "ttir.matmul"(%arg153, %2503, %2504) : (tensor<1x32x32x64xf32>, tensor<1x32x64x11xf32>, tensor<1x32x32x11xf32>) -> tensor<1x32x32x11xf32>
+    %2506 = tensor.empty() : tensor<1x32x11x32xf32>
+    %2507 = "ttir.transpose"(%2505, %2506) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x32x11xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %2508 = tensor.empty() : tensor<1x32x11x32xf32>
+    %2509 = "ttir.multiply"(%2507, %arg154, %2508) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x32xf32>, tensor<1xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %2510 = tensor.empty() : tensor<1x32x64x11xf32>
+    %2511 = "ttir.transpose"(%2499, %2510) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %2512 = tensor.empty() : tensor<1x32x32x11xf32>
+    %2513 = "ttir.matmul"(%arg155, %2511, %2512) : (tensor<1x32x32x64xf32>, tensor<1x32x64x11xf32>, tensor<1x32x32x11xf32>) -> tensor<1x32x32x11xf32>
+    %2514 = tensor.empty() : tensor<1x32x11x32xf32>
+    %2515 = "ttir.transpose"(%2513, %2514) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x32x11xf32>, tensor<1x32x11x32xf32>) -> tensor<1x32x11x32xf32>
+    %2516 = tensor.empty() : tensor<1x32x11x64xf32>
+    %2517 = "ttir.concat"(%2509, %2515, %2516) <{dim = -1 : si32}> : (tensor<1x32x11x32xf32>, tensor<1x32x11x32xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %2518 = tensor.empty() : tensor<1x32x11x64xf32>
+    %2519 = "ttir.multiply"(%2517, %57, %2518) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %2520 = tensor.empty() : tensor<1x32x11x64xf32>
+    %2521 = "ttir.add"(%2501, %2519, %2520) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x64xf32>, tensor<1x32x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %2522 = tensor.empty() : tensor<32x11x64xf32>
+    %2523 = "ttir.squeeze"(%2521, %2522) <{dim = 0 : si32}> : (tensor<1x32x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %2524 = tensor.empty() : tensor<11x512xf32>
+    %2525 = "ttir.matmul"(%2493, %arg302, %2524) : (tensor<11x2048xf32>, tensor<2048x512xf32>, tensor<11x512xf32>) -> tensor<11x512xf32>
+    %2526 = tensor.empty() : tensor<1x11x8x64xf32>
+    %2527 = "ttir.reshape"(%2525, %2526) <{shape = [1 : i32, 11 : i32, 8 : i32, 64 : i32]}> : (tensor<11x512xf32>, tensor<1x11x8x64xf32>) -> tensor<1x11x8x64xf32>
+    %2528 = tensor.empty() : tensor<1x8x11x64xf32>
+    %2529 = "ttir.transpose"(%2527, %2528) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x8x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %2530 = tensor.empty() : tensor<1x8x11x64xf32>
+    %2531 = "ttir.multiply"(%2529, %35, %2530) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %2532 = tensor.empty() : tensor<1x8x64x11xf32>
+    %2533 = "ttir.transpose"(%2529, %2532) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x64x11xf32>) -> tensor<1x8x64x11xf32>
+    %2534 = tensor.empty() : tensor<1x8x32x11xf32>
+    %2535 = "ttir.matmul"(%arg156, %2533, %2534) : (tensor<1x8x32x64xf32>, tensor<1x8x64x11xf32>, tensor<1x8x32x11xf32>) -> tensor<1x8x32x11xf32>
+    %2536 = tensor.empty() : tensor<1x8x11x32xf32>
+    %2537 = "ttir.transpose"(%2535, %2536) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x32x11xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %2538 = tensor.empty() : tensor<1x8x11x32xf32>
+    %2539 = "ttir.multiply"(%2537, %arg157, %2538) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x32xf32>, tensor<1xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %2540 = tensor.empty() : tensor<1x8x64x11xf32>
+    %2541 = "ttir.transpose"(%2529, %2540) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x64x11xf32>) -> tensor<1x8x64x11xf32>
+    %2542 = tensor.empty() : tensor<1x8x32x11xf32>
+    %2543 = "ttir.matmul"(%arg158, %2541, %2542) : (tensor<1x8x32x64xf32>, tensor<1x8x64x11xf32>, tensor<1x8x32x11xf32>) -> tensor<1x8x32x11xf32>
+    %2544 = tensor.empty() : tensor<1x8x11x32xf32>
+    %2545 = "ttir.transpose"(%2543, %2544) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x8x32x11xf32>, tensor<1x8x11x32xf32>) -> tensor<1x8x11x32xf32>
+    %2546 = tensor.empty() : tensor<1x8x11x64xf32>
+    %2547 = "ttir.concat"(%2539, %2545, %2546) <{dim = -1 : si32}> : (tensor<1x8x11x32xf32>, tensor<1x8x11x32xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %2548 = tensor.empty() : tensor<1x8x11x64xf32>
+    %2549 = "ttir.multiply"(%2547, %57, %2548) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x1x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %2550 = tensor.empty() : tensor<1x8x11x64xf32>
+    %2551 = "ttir.add"(%2531, %2549, %2550) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x8x11x64xf32>, tensor<1x8x11x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %2552 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %2553 = "ttir.unsqueeze"(%2551, %2552) <{dim = 2 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %2554 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %2555 = "ttir.repeat_interleave"(%2553, %2554) <{dim = 0 : si32, repeats = 1 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %2556 = tensor.empty() : tensor<1x8x4x11x64xf32>
+    %2557 = "ttir.repeat_interleave"(%2555, %2556) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x4x11x64xf32>) -> tensor<1x8x4x11x64xf32>
+    %2558 = tensor.empty() : tensor<32x11x64xf32>
+    %2559 = "ttir.reshape"(%2557, %2558) <{shape = [32 : i32, 11 : i32, 64 : i32]}> : (tensor<1x8x4x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %2560 = tensor.empty() : tensor<32x64x11xf32>
+    %2561 = "ttir.transpose"(%2559, %2560) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x11x64xf32>, tensor<32x64x11xf32>) -> tensor<32x64x11xf32>
+    %2562 = tensor.empty() : tensor<32x11x11xf32>
+    %2563 = "ttir.matmul"(%2523, %2561, %2562) : (tensor<32x11x64xf32>, tensor<32x64x11xf32>, tensor<32x11x11xf32>) -> tensor<32x11x11xf32>
+    %2564 = tensor.empty() : tensor<1x32x11x11xf32>
+    %2565 = "ttir.unsqueeze"(%2563, %2564) <{dim = 0 : si32}> : (tensor<32x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %2566 = tensor.empty() : tensor<1x32x11x11xf32>
+    %2567 = "ttir.multiply"(%2565, %arg159, %2566) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x11xf32>, tensor<1xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %2568 = tensor.empty() : tensor<1x32x11x11xf32>
+    %2569 = "ttir.add"(%2567, %arg160, %2568) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x11x11xf32>, tensor<1x1x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %2570 = tensor.empty() : tensor<1x32x11x11xf32>
+    %2571 = "ttir.softmax"(%2569, %2570) <{dimension = -1 : si32}> : (tensor<1x32x11x11xf32>, tensor<1x32x11x11xf32>) -> tensor<1x32x11x11xf32>
+    %2572 = tensor.empty() : tensor<32x11x11xf32>
+    %2573 = "ttir.squeeze"(%2571, %2572) <{dim = 0 : si32}> : (tensor<1x32x11x11xf32>, tensor<32x11x11xf32>) -> tensor<32x11x11xf32>
+    %2574 = tensor.empty() : tensor<11x512xf32>
+    %2575 = "ttir.matmul"(%2493, %arg303, %2574) : (tensor<11x2048xf32>, tensor<2048x512xf32>, tensor<11x512xf32>) -> tensor<11x512xf32>
+    %2576 = tensor.empty() : tensor<1x11x8x64xf32>
+    %2577 = "ttir.reshape"(%2575, %2576) <{shape = [1 : i32, 11 : i32, 8 : i32, 64 : i32]}> : (tensor<11x512xf32>, tensor<1x11x8x64xf32>) -> tensor<1x11x8x64xf32>
+    %2578 = tensor.empty() : tensor<1x8x11x64xf32>
+    %2579 = "ttir.transpose"(%2577, %2578) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x11x8x64xf32>, tensor<1x8x11x64xf32>) -> tensor<1x8x11x64xf32>
+    %2580 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %2581 = "ttir.unsqueeze"(%2579, %2580) <{dim = 2 : si32}> : (tensor<1x8x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %2582 = tensor.empty() : tensor<1x8x1x11x64xf32>
+    %2583 = "ttir.repeat_interleave"(%2581, %2582) <{dim = 0 : si32, repeats = 1 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x1x11x64xf32>) -> tensor<1x8x1x11x64xf32>
+    %2584 = tensor.empty() : tensor<1x8x4x11x64xf32>
+    %2585 = "ttir.repeat_interleave"(%2583, %2584) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x1x11x64xf32>, tensor<1x8x4x11x64xf32>) -> tensor<1x8x4x11x64xf32>
+    %2586 = tensor.empty() : tensor<1x32x11x64xf32>
+    %2587 = "ttir.reshape"(%2585, %2586) <{shape = [1 : i32, 32 : i32, 11 : i32, 64 : i32]}> : (tensor<1x8x4x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %2588 = tensor.empty() : tensor<1x32x64x11xf32>
+    %2589 = "ttir.transpose"(%2587, %2588) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x32x64x11xf32>) -> tensor<1x32x64x11xf32>
+    %2590 = tensor.empty() : tensor<32x64x11xf32>
+    %2591 = "ttir.squeeze"(%2589, %2590) <{dim = 0 : si32}> : (tensor<1x32x64x11xf32>, tensor<32x64x11xf32>) -> tensor<32x64x11xf32>
+    %2592 = tensor.empty() : tensor<32x11x64xf32>
+    %2593 = "ttir.transpose"(%2591, %2592) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x64x11xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %2594 = tensor.empty() : tensor<32x11x64xf32>
+    %2595 = "ttir.matmul"(%2573, %2593, %2594) : (tensor<32x11x11xf32>, tensor<32x11x64xf32>, tensor<32x11x64xf32>) -> tensor<32x11x64xf32>
+    %2596 = tensor.empty() : tensor<1x32x11x64xf32>
+    %2597 = "ttir.unsqueeze"(%2595, %2596) <{dim = 0 : si32}> : (tensor<32x11x64xf32>, tensor<1x32x11x64xf32>) -> tensor<1x32x11x64xf32>
+    %2598 = tensor.empty() : tensor<1x11x32x64xf32>
+    %2599 = "ttir.transpose"(%2597, %2598) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x32x11x64xf32>, tensor<1x11x32x64xf32>) -> tensor<1x11x32x64xf32>
+    %2600 = tensor.empty() : tensor<11x2048xf32>
+    %2601 = "ttir.reshape"(%2599, %2600) <{shape = [11 : i32, 2048 : i32]}> : (tensor<1x11x32x64xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %2602 = tensor.empty() : tensor<11x2048xf32>
+    %2603 = "ttir.matmul"(%2601, %arg304, %2602) : (tensor<11x2048xf32>, tensor<2048x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %2604 = tensor.empty() : tensor<1x11x2048xf32>
+    %2605 = "ttir.unsqueeze"(%2603, %2604) <{dim = 0 : si32}> : (tensor<11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2606 = tensor.empty() : tensor<1x11x2048xf32>
+    %2607 = "ttir.add"(%2477, %2605, %2606) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2608 = tensor.empty() : tensor<1x11x2048xf32>
+    %2609 = "ttir.multiply"(%2607, %2607, %2608) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2610 = tensor.empty() : tensor<1x11x1xf32>
+    %2611 = "ttir.mean"(%2609, %2610) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %2612 = tensor.empty() : tensor<1x11x1xf32>
+    %2613 = "ttir.add"(%2611, %arg161, %2612) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %2614 = tensor.empty() : tensor<1x11x1xf32>
+    %2615 = "ttir.sqrt"(%2613, %2614) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %2616 = tensor.empty() : tensor<1x11x1xf32>
+    %2617 = "ttir.reciprocal"(%2615, %2616) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %2618 = tensor.empty() : tensor<1x11x2048xf32>
+    %2619 = "ttir.multiply"(%2607, %2617, %2618) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2620 = tensor.empty() : tensor<1x11x2048xf32>
+    %2621 = "ttir.multiply"(%arg305, %2619, %2620) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2622 = tensor.empty() : tensor<11x2048xf32>
+    %2623 = "ttir.squeeze"(%2621, %2622) <{dim = 0 : si32}> : (tensor<1x11x2048xf32>, tensor<11x2048xf32>) -> tensor<11x2048xf32>
+    %2624 = tensor.empty() : tensor<11x8192xf32>
+    %2625 = "ttir.matmul"(%2623, %arg306, %2624) : (tensor<11x2048xf32>, tensor<2048x8192xf32>, tensor<11x8192xf32>) -> tensor<11x8192xf32>
+    %2626 = tensor.empty() : tensor<1x11x8192xf32>
+    %2627 = "ttir.unsqueeze"(%2625, %2626) <{dim = 0 : si32}> : (tensor<11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %2628 = tensor.empty() : tensor<1x11x8192xf32>
+    %2629 = "ttir.sigmoid"(%2627, %2628) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %2630 = tensor.empty() : tensor<1x11x8192xf32>
+    %2631 = "ttir.multiply"(%2627, %2629, %2630) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %2632 = tensor.empty() : tensor<11x8192xf32>
+    %2633 = "ttir.matmul"(%2623, %arg307, %2632) : (tensor<11x2048xf32>, tensor<2048x8192xf32>, tensor<11x8192xf32>) -> tensor<11x8192xf32>
+    %2634 = tensor.empty() : tensor<1x11x8192xf32>
+    %2635 = "ttir.unsqueeze"(%2633, %2634) <{dim = 0 : si32}> : (tensor<11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %2636 = tensor.empty() : tensor<1x11x8192xf32>
+    %2637 = "ttir.multiply"(%2631, %2635, %2636) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x8192xf32>, tensor<1x11x8192xf32>, tensor<1x11x8192xf32>) -> tensor<1x11x8192xf32>
+    %2638 = tensor.empty() : tensor<1x11x2048xf32>
+    %2639 = "ttir.matmul"(%2637, %arg308, %2638) : (tensor<1x11x8192xf32>, tensor<8192x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2640 = tensor.empty() : tensor<1x11x2048xf32>
+    %2641 = "ttir.add"(%2607, %2639, %2640) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2642 = tensor.empty() : tensor<1x11x2048xf32>
+    %2643 = "ttir.multiply"(%2641, %2641, %2642) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2644 = tensor.empty() : tensor<1x11x1xf32>
+    %2645 = "ttir.mean"(%2643, %2644) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %2646 = tensor.empty() : tensor<1x11x1xf32>
+    %2647 = "ttir.add"(%2645, %arg162, %2646) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x1xf32>, tensor<1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %2648 = tensor.empty() : tensor<1x11x1xf32>
+    %2649 = "ttir.sqrt"(%2647, %2648) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %2650 = tensor.empty() : tensor<1x11x1xf32>
+    %2651 = "ttir.reciprocal"(%2649, %2650) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x11x1xf32>, tensor<1x11x1xf32>) -> tensor<1x11x1xf32>
+    %2652 = tensor.empty() : tensor<1x11x2048xf32>
+    %2653 = "ttir.multiply"(%2641, %2651, %2652) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x11x2048xf32>, tensor<1x11x1xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    %2654 = tensor.empty() : tensor<1x11x2048xf32>
+    %2655 = "ttir.multiply"(%arg163, %2653, %2654) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<2048xf32>, tensor<1x11x2048xf32>, tensor<1x11x2048xf32>) -> tensor<1x11x2048xf32>
+    return %2655 : tensor<1x11x2048xf32>
+  }
+}

--- a/test/ttmlir/EmitC/TTNN/models/resnet.mlir
+++ b/test/ttmlir/EmitC/TTNN/models/resnet.mlir
@@ -1,0 +1,508 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
+// RUN: ttmlir-opt --ttnn-modify-signatures-for-dylib --convert-ttnn-to-emitc %t.mlir > %t2.mlir
+// RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
+//
+// UNSUPPORTED: true
+// Not supported as several ops don't have proper emitc conversions yet
+
+// https://huggingface.co/microsoft/resnet-50
+module @ResNetForImageClassification attributes {} {
+  func.func @forward(%arg0: tensor<1x3x224x224xf32> {ttir.name = "pixel_values"}, %arg1: tensor<1x1x1x64xf32> {ttir.name = "input_1_add_2"}, %arg2: tensor<1x1x1x64xf32> {ttir.name = "input_1_add_2_fork_clone1229"}, %arg3: tensor<1x1x1x64xf32> {ttir.name = "input_1_add_19"}, %arg4: tensor<1x1x1x64xf32> {ttir.name = "input_1_add_19_fork_clone1271"}, %arg5: tensor<1x1x1x64xf32> {ttir.name = "input_1_add_35"}, %arg6: tensor<1x1x1x64xf32> {ttir.name = "input_1_add_35_fork_clone1204"}, %arg7: tensor<1x1x1x256xf32> {ttir.name = "input_1_add_51"}, %arg8: tensor<1x1x1x256xf32> {ttir.name = "input_1_add_51_fork_clone1108"}, %arg9: tensor<1x1x1x256xf32> {ttir.name = "input_1_add_66"}, %arg10: tensor<1x1x1x256xf32> {ttir.name = "input_1_add_66_fork_clone1112"}, %arg11: tensor<1x1x1x64xf32> {ttir.name = "input_1_add_83"}, %arg12: tensor<1x1x1x64xf32> {ttir.name = "input_1_add_83_fork_clone1238"}, %arg13: tensor<1x1x1x64xf32> {ttir.name = "input_1_add_99"}, %arg14: tensor<1x1x1x64xf32> {ttir.name = "input_1_add_99_fork_clone1152"}, %arg15: tensor<1x1x1x256xf32> {ttir.name = "input_1_add_115"}, %arg16: tensor<1x1x1x256xf32> {ttir.name = "input_1_add_115_fork_clone1051"}, %arg17: tensor<1x1x1x64xf32> {ttir.name = "input_1_add_132"}, %arg18: tensor<1x1x1x64xf32> {ttir.name = "input_1_add_132_fork_clone1192"}, %arg19: tensor<1x1x1x64xf32> {ttir.name = "input_1_add_148"}, %arg20: tensor<1x1x1x64xf32> {ttir.name = "input_1_add_148_fork_clone1096"}, %arg21: tensor<1x1x1x256xf32> {ttir.name = "input_1_add_164"}, %arg22: tensor<1x1x1x256xf32> {ttir.name = "input_1_add_164_fork_clone992"}, %arg23: tensor<1x1x1x128xf32> {ttir.name = "input_1_add_181"}, %arg24: tensor<1x1x1x128xf32> {ttir.name = "input_1_add_181_fork_clone1065"}, %arg25: tensor<1x1x1x128xf32> {ttir.name = "input_1_add_197"}, %arg26: tensor<1x1x1x128xf32> {ttir.name = "input_1_add_197_fork_clone962"}, %arg27: tensor<1x1x1x512xf32> {ttir.name = "input_1_add_213"}, %arg28: tensor<1x1x1x512xf32> {ttir.name = "input_1_add_213_fork_clone853"}, %arg29: tensor<1x1x1x512xf32> {ttir.name = "input_1_add_228"}, %arg30: tensor<1x1x1x512xf32> {ttir.name = "input_1_add_228_fork_clone857"}, %arg31: tensor<1x1x1x128xf32> {ttir.name = "input_1_add_245"}, %arg32: tensor<1x1x1x128xf32> {ttir.name = "input_1_add_245_fork_clone1007"}, %arg33: tensor<1x1x1x128xf32> {ttir.name = "input_1_add_261"}, %arg34: tensor<1x1x1x128xf32> {ttir.name = "input_1_add_261_fork_clone901"}, %arg35: tensor<1x1x1x512xf32> {ttir.name = "input_1_add_277"}, %arg36: tensor<1x1x1x512xf32> {ttir.name = "input_1_add_277_fork_clone791"}, %arg37: tensor<1x1x1x128xf32> {ttir.name = "input_1_add_294"}, %arg38: tensor<1x1x1x128xf32> {ttir.name = "input_1_add_294_fork_clone950"}, %arg39: tensor<1x1x1x128xf32> {ttir.name = "input_1_add_310"}, %arg40: tensor<1x1x1x128xf32> {ttir.name = "input_1_add_310_fork_clone841"}, %arg41: tensor<1x1x1x512xf32> {ttir.name = "input_1_add_326"}, %arg42: tensor<1x1x1x512xf32> {ttir.name = "input_1_add_326_fork_clone735"}, %arg43: tensor<1x1x1x128xf32> {ttir.name = "input_1_add_343"}, %arg44: tensor<1x1x1x128xf32> {ttir.name = "input_1_add_343_fork_clone889"}, %arg45: tensor<1x1x1x128xf32> {ttir.name = "input_1_add_359"}, %arg46: tensor<1x1x1x128xf32> {ttir.name = "input_1_add_359_fork_clone779"}, %arg47: tensor<1x1x1x512xf32> {ttir.name = "input_1_add_375"}, %arg48: tensor<1x1x1x512xf32> {ttir.name = "input_1_add_375_fork_clone677"}, %arg49: tensor<1x1x1x256xf32> {ttir.name = "input_1_add_392"}, %arg50: tensor<1x1x1x256xf32> {ttir.name = "input_1_add_392_fork_clone748"}, %arg51: tensor<1x1x1x256xf32> {ttir.name = "input_1_add_408"}, %arg52: tensor<1x1x1x256xf32> {ttir.name = "input_1_add_408_fork_clone645"}, %arg53: tensor<1x1x1x1024xf32> {ttir.name = "input_1_add_424"}, %arg54: tensor<1x1x1x1024xf32> {ttir.name = "input_1_add_424_fork_clone524"}, %arg55: tensor<1x1x1x1024xf32> {ttir.name = "input_1_add_439"}, %arg56: tensor<1x1x1x1024xf32> {ttir.name = "input_1_add_439_fork_clone528"}, %arg57: tensor<1x1x1x256xf32> {ttir.name = "input_1_add_456"}, %arg58: tensor<1x1x1x256xf32> {ttir.name = "input_1_add_456_fork_clone692"}, %arg59: tensor<1x1x1x256xf32> {ttir.name = "input_1_add_472"}, %arg60: tensor<1x1x1x256xf32> {ttir.name = "input_1_add_472_fork_clone580"}, %arg61: tensor<1x1x1x1024xf32> {ttir.name = "input_1_add_488"}, %arg62: tensor<1x1x1x1024xf32> {ttir.name = "input_1_add_488_fork_clone453"}, %arg63: tensor<1x1x1x256xf32> {ttir.name = "input_1_add_505"}, %arg64: tensor<1x1x1x256xf32> {ttir.name = "input_1_add_505_fork_clone633"}, %arg65: tensor<1x1x1x256xf32> {ttir.name = "input_1_add_521"}, %arg66: tensor<1x1x1x256xf32> {ttir.name = "input_1_add_521_fork_clone512"}, %arg67: tensor<1x1x1x1024xf32> {ttir.name = "input_1_add_537"}, %arg68: tensor<1x1x1x1024xf32> {ttir.name = "input_1_add_537_fork_clone389"}, %arg69: tensor<1x1x1x256xf32> {ttir.name = "input_1_add_554"}, %arg70: tensor<1x1x1x256xf32> {ttir.name = "input_1_add_554_fork_clone568"}, %arg71: tensor<1x1x1x256xf32> {ttir.name = "input_1_add_570"}, %arg72: tensor<1x1x1x256xf32> {ttir.name = "input_1_add_570_fork_clone441"}, %arg73: tensor<1x1x1x1024xf32> {ttir.name = "input_1_add_586"}, %arg74: tensor<1x1x1x1024xf32> {ttir.name = "input_1_add_586_fork_clone329"}, %arg75: tensor<1x1x1x256xf32> {ttir.name = "input_1_add_603"}, %arg76: tensor<1x1x1x256xf32> {ttir.name = "input_1_add_603_fork_clone500"}, %arg77: tensor<1x1x1x256xf32> {ttir.name = "input_1_add_619"}, %arg78: tensor<1x1x1x256xf32> {ttir.name = "input_1_add_619_fork_clone377"}, %arg79: tensor<1x1x1x1024xf32> {ttir.name = "input_1_add_635"}, %arg80: tensor<1x1x1x1024xf32> {ttir.name = "input_1_add_635_fork_clone274"}, %arg81: tensor<1x1x1x256xf32> {ttir.name = "input_1_add_652"}, %arg82: tensor<1x1x1x256xf32> {ttir.name = "input_1_add_652_fork_clone429"}, %arg83: tensor<1x1x1x256xf32> {ttir.name = "input_1_add_668"}, %arg84: tensor<1x1x1x256xf32> {ttir.name = "input_1_add_668_fork_clone317"}, %arg85: tensor<1x1x1x1024xf32> {ttir.name = "input_1_add_684"}, %arg86: tensor<1x1x1x1024xf32> {ttir.name = "input_1_add_684_fork_clone219"}, %arg87: tensor<1x1x1x512xf32> {ttir.name = "input_1_add_701"}, %arg88: tensor<1x1x1x512xf32> {ttir.name = "input_1_add_701_fork_clone287"}, %arg89: tensor<1x1x1x512xf32> {ttir.name = "input_1_add_717"}, %arg90: tensor<1x1x1x512xf32> {ttir.name = "input_1_add_717_fork_clone190"}, %arg91: tensor<1x2048x1x1xf32> {ttir.name = "input_1_add_733"}, %arg92: tensor<1x2048x1x1xf32> {ttir.name = "input_1_add_733_fork_clone101"}, %arg93: tensor<1x2048x1x1xf32> {ttir.name = "input_1_add_748"}, %arg94: tensor<1x2048x1x1xf32> {ttir.name = "input_1_add_748_fork_clone105"}, %arg95: tensor<1x1x1x512xf32> {ttir.name = "input_1_add_765"}, %arg96: tensor<1x1x1x512xf32> {ttir.name = "input_1_add_765_fork_clone233"}, %arg97: tensor<1x1x1x512xf32> {ttir.name = "input_1_add_781"}, %arg98: tensor<1x1x1x512xf32> {ttir.name = "input_1_add_781_fork_clone138"}, %arg99: tensor<1x2048x1x1xf32> {ttir.name = "input_1_add_797"}, %arg100: tensor<1x2048x1x1xf32> {ttir.name = "input_1_add_797_fork_clone61"}, %arg101: tensor<1x1x1x512xf32> {ttir.name = "input_1_add_814"}, %arg102: tensor<1x1x1x512xf32> {ttir.name = "input_1_add_814_fork_clone178"}, %arg103: tensor<1x1x1x512xf32> {ttir.name = "input_1_add_830"}, %arg104: tensor<1x1x1x512xf32> {ttir.name = "input_1_add_830_fork_clone89"}, %arg105: tensor<1x2048x1x1xf32> {ttir.name = "input_1_add_846"}, %arg106: tensor<1x2048x1x1xf32> {ttir.name = "input_1_add_846_fork_clone32"}, %arg107: tensor<64x3x7x7xf32> {ttir.name = "resnet.embedder.embedder.convolution.weight"}, %arg108: tensor<64x64x1x1xf32> {ttir.name = "resnet.encoder.stages.0.layers.0.layer.0.convolution.weight"}, %arg109: tensor<64x64x3x3xf32> {ttir.name = "resnet.encoder.stages.0.layers.0.layer.1.convolution.weight"}, %arg110: tensor<256x64x1x1xf32> {ttir.name = "resnet.encoder.stages.0.layers.0.layer.2.convolution.weight"}, %arg111: tensor<256x64x1x1xf32> {ttir.name = "resnet.encoder.stages.0.layers.0.shortcut.convolution.weight"}, %arg112: tensor<64x256x1x1xf32> {ttir.name = "resnet.encoder.stages.0.layers.1.layer.0.convolution.weight"}, %arg113: tensor<64x64x3x3xf32> {ttir.name = "resnet.encoder.stages.0.layers.1.layer.1.convolution.weight"}, %arg114: tensor<256x64x1x1xf32> {ttir.name = "resnet.encoder.stages.0.layers.1.layer.2.convolution.weight"}, %arg115: tensor<64x256x1x1xf32> {ttir.name = "resnet.encoder.stages.0.layers.2.layer.0.convolution.weight"}, %arg116: tensor<64x64x3x3xf32> {ttir.name = "resnet.encoder.stages.0.layers.2.layer.1.convolution.weight"}, %arg117: tensor<256x64x1x1xf32> {ttir.name = "resnet.encoder.stages.0.layers.2.layer.2.convolution.weight"}, %arg118: tensor<128x256x1x1xf32> {ttir.name = "resnet.encoder.stages.1.layers.0.layer.0.convolution.weight"}, %arg119: tensor<128x128x3x3xf32> {ttir.name = "resnet.encoder.stages.1.layers.0.layer.1.convolution.weight"}, %arg120: tensor<512x128x1x1xf32> {ttir.name = "resnet.encoder.stages.1.layers.0.layer.2.convolution.weight"}, %arg121: tensor<512x256x1x1xf32> {ttir.name = "resnet.encoder.stages.1.layers.0.shortcut.convolution.weight"}, %arg122: tensor<128x512x1x1xf32> {ttir.name = "resnet.encoder.stages.1.layers.1.layer.0.convolution.weight"}, %arg123: tensor<128x128x3x3xf32> {ttir.name = "resnet.encoder.stages.1.layers.1.layer.1.convolution.weight"}, %arg124: tensor<512x128x1x1xf32> {ttir.name = "resnet.encoder.stages.1.layers.1.layer.2.convolution.weight"}, %arg125: tensor<128x512x1x1xf32> {ttir.name = "resnet.encoder.stages.1.layers.2.layer.0.convolution.weight"}, %arg126: tensor<128x128x3x3xf32> {ttir.name = "resnet.encoder.stages.1.layers.2.layer.1.convolution.weight"}, %arg127: tensor<512x128x1x1xf32> {ttir.name = "resnet.encoder.stages.1.layers.2.layer.2.convolution.weight"}, %arg128: tensor<128x512x1x1xf32> {ttir.name = "resnet.encoder.stages.1.layers.3.layer.0.convolution.weight"}, %arg129: tensor<128x128x3x3xf32> {ttir.name = "resnet.encoder.stages.1.layers.3.layer.1.convolution.weight"}, %arg130: tensor<512x128x1x1xf32> {ttir.name = "resnet.encoder.stages.1.layers.3.layer.2.convolution.weight"}, %arg131: tensor<256x512x1x1xf32> {ttir.name = "resnet.encoder.stages.2.layers.0.layer.0.convolution.weight"}, %arg132: tensor<256x256x3x3xf32> {ttir.name = "resnet.encoder.stages.2.layers.0.layer.1.convolution.weight"}, %arg133: tensor<1024x256x1x1xf32> {ttir.name = "resnet.encoder.stages.2.layers.0.layer.2.convolution.weight"}, %arg134: tensor<1024x512x1x1xf32> {ttir.name = "resnet.encoder.stages.2.layers.0.shortcut.convolution.weight"}, %arg135: tensor<256x1024x1x1xf32> {ttir.name = "resnet.encoder.stages.2.layers.1.layer.0.convolution.weight"}, %arg136: tensor<256x256x3x3xf32> {ttir.name = "resnet.encoder.stages.2.layers.1.layer.1.convolution.weight"}, %arg137: tensor<1024x256x1x1xf32> {ttir.name = "resnet.encoder.stages.2.layers.1.layer.2.convolution.weight"}, %arg138: tensor<256x1024x1x1xf32> {ttir.name = "resnet.encoder.stages.2.layers.2.layer.0.convolution.weight"}, %arg139: tensor<256x256x3x3xf32> {ttir.name = "resnet.encoder.stages.2.layers.2.layer.1.convolution.weight"}, %arg140: tensor<1024x256x1x1xf32> {ttir.name = "resnet.encoder.stages.2.layers.2.layer.2.convolution.weight"}, %arg141: tensor<256x1024x1x1xf32> {ttir.name = "resnet.encoder.stages.2.layers.3.layer.0.convolution.weight"}, %arg142: tensor<256x256x3x3xf32> {ttir.name = "resnet.encoder.stages.2.layers.3.layer.1.convolution.weight"}, %arg143: tensor<1024x256x1x1xf32> {ttir.name = "resnet.encoder.stages.2.layers.3.layer.2.convolution.weight"}, %arg144: tensor<256x1024x1x1xf32> {ttir.name = "resnet.encoder.stages.2.layers.4.layer.0.convolution.weight"}, %arg145: tensor<256x256x3x3xf32> {ttir.name = "resnet.encoder.stages.2.layers.4.layer.1.convolution.weight"}, %arg146: tensor<1024x256x1x1xf32> {ttir.name = "resnet.encoder.stages.2.layers.4.layer.2.convolution.weight"}, %arg147: tensor<256x1024x1x1xf32> {ttir.name = "resnet.encoder.stages.2.layers.5.layer.0.convolution.weight"}, %arg148: tensor<256x256x3x3xf32> {ttir.name = "resnet.encoder.stages.2.layers.5.layer.1.convolution.weight"}, %arg149: tensor<1024x256x1x1xf32> {ttir.name = "resnet.encoder.stages.2.layers.5.layer.2.convolution.weight"}, %arg150: tensor<512x1024x1x1xf32> {ttir.name = "resnet.encoder.stages.3.layers.0.layer.0.convolution.weight"}, %arg151: tensor<512x512x3x3xf32> {ttir.name = "resnet.encoder.stages.3.layers.0.layer.1.convolution.weight"}, %arg152: tensor<2048x512x1x1xf32> {ttir.name = "resnet.encoder.stages.3.layers.0.layer.2.convolution.weight"}, %arg153: tensor<2048x1024x1x1xf32> {ttir.name = "resnet.encoder.stages.3.layers.0.shortcut.convolution.weight"}, %arg154: tensor<512x2048x1x1xf32> {ttir.name = "resnet.encoder.stages.3.layers.1.layer.0.convolution.weight"}, %arg155: tensor<512x512x3x3xf32> {ttir.name = "resnet.encoder.stages.3.layers.1.layer.1.convolution.weight"}, %arg156: tensor<2048x512x1x1xf32> {ttir.name = "resnet.encoder.stages.3.layers.1.layer.2.convolution.weight"}, %arg157: tensor<512x2048x1x1xf32> {ttir.name = "resnet.encoder.stages.3.layers.2.layer.0.convolution.weight"}, %arg158: tensor<512x512x3x3xf32> {ttir.name = "resnet.encoder.stages.3.layers.2.layer.1.convolution.weight"}, %arg159: tensor<2048x512x1x1xf32> {ttir.name = "resnet.encoder.stages.3.layers.2.layer.2.convolution.weight"}, %arg160: tensor<2048x1000xf32> {ttir.name = "classifier.1.weight"}, %arg161: tensor<1000xf32> {ttir.name = "classifier.1.bias"}) -> (tensor<1x1000xf32> {ttir.name = "ResNetForImageClassification.output_add_868"}) {
+    %0 = tensor.empty() : tensor<1x224x3x224xf32>
+    %1 = "ttir.transpose"(%arg0, %0) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x3x224x224xf32>, tensor<1x224x3x224xf32>) -> tensor<1x224x3x224xf32>
+    %2 = tensor.empty() : tensor<1x224x224x3xf32>
+    %3 = "ttir.transpose"(%1, %2) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x224x3x224xf32>, tensor<1x224x224x3xf32>) -> tensor<1x224x224x3xf32>
+    %4 = tensor.empty() : tensor<1x112x112x64xf32>
+    %5 = "ttir.conv2d"(%3, %arg107, %4) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 3 : si32, padding_left = 3 : si32, padding_right = 3 : si32, padding_top = 3 : si32, stride_height = 2 : si32, stride_width = 2 : si32}> {channel_last = 1 : si32} : (tensor<1x224x224x3xf32>, tensor<64x3x7x7xf32>, tensor<1x112x112x64xf32>) -> tensor<1x112x112x64xf32>
+    %6 = tensor.empty() : tensor<1x112x112x64xf32>
+    %7 = "ttir.multiply"(%5, %arg1, %6) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x112x112x64xf32>, tensor<1x1x1x64xf32>, tensor<1x112x112x64xf32>) -> tensor<1x112x112x64xf32>
+    %8 = tensor.empty() : tensor<1x112x112x64xf32>
+    %9 = "ttir.add"(%7, %arg2, %8) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x112x112x64xf32>, tensor<1x1x1x64xf32>, tensor<1x112x112x64xf32>) -> tensor<1x112x112x64xf32>
+    %10 = tensor.empty() : tensor<1x112x112x64xf32>
+    %11 = "ttir.relu"(%9, %10) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x112x112x64xf32>, tensor<1x112x112x64xf32>) -> tensor<1x112x112x64xf32>
+    %12 = tensor.empty() : tensor<1x56x56x64xf32>
+    %13 = "ttir.max_pool2d"(%11, %12) <{ceil_mode = false, dilation_height = 1 : si32, dilation_width = 1 : si32, kernel_height = 3 : si32, kernel_width = 3 : si32, padding_bottom = 1 : si32, padding_left = 1 : si32, padding_right = 1 : si32, padding_top = 1 : si32, stride_height = 2 : si32, stride_width = 2 : si32}> {channel_last = true} : (tensor<1x112x112x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %14 = tensor.empty() : tensor<1x56x56x64xf32>
+    %15 = "ttir.conv2d"(%13, %arg108, %14) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x56x56x64xf32>, tensor<64x64x1x1xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %16 = tensor.empty() : tensor<1x56x56x64xf32>
+    %17 = "ttir.multiply"(%15, %arg3, %16) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x56x56x64xf32>, tensor<1x1x1x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %18 = tensor.empty() : tensor<1x56x56x64xf32>
+    %19 = "ttir.add"(%17, %arg4, %18) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x56x56x64xf32>, tensor<1x1x1x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %20 = tensor.empty() : tensor<1x56x56x64xf32>
+    %21 = "ttir.relu"(%19, %20) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x56x56x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %22 = tensor.empty() : tensor<1x56x56x64xf32>
+    %23 = "ttir.conv2d"(%21, %arg109, %22) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 1 : si32, padding_left = 1 : si32, padding_right = 1 : si32, padding_top = 1 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x56x56x64xf32>, tensor<64x64x3x3xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %24 = tensor.empty() : tensor<1x56x56x64xf32>
+    %25 = "ttir.multiply"(%23, %arg5, %24) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x56x56x64xf32>, tensor<1x1x1x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %26 = tensor.empty() : tensor<1x56x56x64xf32>
+    %27 = "ttir.add"(%25, %arg6, %26) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x56x56x64xf32>, tensor<1x1x1x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %28 = tensor.empty() : tensor<1x56x56x64xf32>
+    %29 = "ttir.relu"(%27, %28) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x56x56x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %30 = tensor.empty() : tensor<1x56x56x256xf32>
+    %31 = "ttir.conv2d"(%29, %arg110, %30) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x56x56x64xf32>, tensor<256x64x1x1xf32>, tensor<1x56x56x256xf32>) -> tensor<1x56x56x256xf32>
+    %32 = tensor.empty() : tensor<1x56x56x256xf32>
+    %33 = "ttir.multiply"(%31, %arg7, %32) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x56x56x256xf32>, tensor<1x1x1x256xf32>, tensor<1x56x56x256xf32>) -> tensor<1x56x56x256xf32>
+    %34 = tensor.empty() : tensor<1x56x56x256xf32>
+    %35 = "ttir.add"(%33, %arg8, %34) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x56x56x256xf32>, tensor<1x1x1x256xf32>, tensor<1x56x56x256xf32>) -> tensor<1x56x56x256xf32>
+    %36 = tensor.empty() : tensor<1x56x56x256xf32>
+    %37 = "ttir.conv2d"(%13, %arg111, %36) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x56x56x64xf32>, tensor<256x64x1x1xf32>, tensor<1x56x56x256xf32>) -> tensor<1x56x56x256xf32>
+    %38 = tensor.empty() : tensor<1x56x56x256xf32>
+    %39 = "ttir.multiply"(%37, %arg9, %38) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x56x56x256xf32>, tensor<1x1x1x256xf32>, tensor<1x56x56x256xf32>) -> tensor<1x56x56x256xf32>
+    %40 = tensor.empty() : tensor<1x56x56x256xf32>
+    %41 = "ttir.add"(%39, %arg10, %40) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x56x56x256xf32>, tensor<1x1x1x256xf32>, tensor<1x56x56x256xf32>) -> tensor<1x56x56x256xf32>
+    %42 = tensor.empty() : tensor<1x56x56x256xf32>
+    %43 = "ttir.add"(%35, %41, %42) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x56x56x256xf32>, tensor<1x56x56x256xf32>, tensor<1x56x56x256xf32>) -> tensor<1x56x56x256xf32>
+    %44 = tensor.empty() : tensor<1x56x56x256xf32>
+    %45 = "ttir.relu"(%43, %44) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x56x56x256xf32>, tensor<1x56x56x256xf32>) -> tensor<1x56x56x256xf32>
+    %46 = tensor.empty() : tensor<1x56x56x64xf32>
+    %47 = "ttir.conv2d"(%45, %arg112, %46) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x56x56x256xf32>, tensor<64x256x1x1xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %48 = tensor.empty() : tensor<1x56x56x64xf32>
+    %49 = "ttir.multiply"(%47, %arg11, %48) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x56x56x64xf32>, tensor<1x1x1x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %50 = tensor.empty() : tensor<1x56x56x64xf32>
+    %51 = "ttir.add"(%49, %arg12, %50) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x56x56x64xf32>, tensor<1x1x1x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %52 = tensor.empty() : tensor<1x56x56x64xf32>
+    %53 = "ttir.relu"(%51, %52) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x56x56x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %54 = tensor.empty() : tensor<1x56x56x64xf32>
+    %55 = "ttir.conv2d"(%53, %arg113, %54) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 1 : si32, padding_left = 1 : si32, padding_right = 1 : si32, padding_top = 1 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x56x56x64xf32>, tensor<64x64x3x3xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %56 = tensor.empty() : tensor<1x56x56x64xf32>
+    %57 = "ttir.multiply"(%55, %arg13, %56) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x56x56x64xf32>, tensor<1x1x1x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %58 = tensor.empty() : tensor<1x56x56x64xf32>
+    %59 = "ttir.add"(%57, %arg14, %58) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x56x56x64xf32>, tensor<1x1x1x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %60 = tensor.empty() : tensor<1x56x56x64xf32>
+    %61 = "ttir.relu"(%59, %60) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x56x56x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %62 = tensor.empty() : tensor<1x56x56x256xf32>
+    %63 = "ttir.conv2d"(%61, %arg114, %62) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x56x56x64xf32>, tensor<256x64x1x1xf32>, tensor<1x56x56x256xf32>) -> tensor<1x56x56x256xf32>
+    %64 = tensor.empty() : tensor<1x56x56x256xf32>
+    %65 = "ttir.multiply"(%63, %arg15, %64) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x56x56x256xf32>, tensor<1x1x1x256xf32>, tensor<1x56x56x256xf32>) -> tensor<1x56x56x256xf32>
+    %66 = tensor.empty() : tensor<1x56x56x256xf32>
+    %67 = "ttir.add"(%65, %arg16, %66) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x56x56x256xf32>, tensor<1x1x1x256xf32>, tensor<1x56x56x256xf32>) -> tensor<1x56x56x256xf32>
+    %68 = tensor.empty() : tensor<1x56x56x256xf32>
+    %69 = "ttir.add"(%67, %45, %68) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x56x56x256xf32>, tensor<1x56x56x256xf32>, tensor<1x56x56x256xf32>) -> tensor<1x56x56x256xf32>
+    %70 = tensor.empty() : tensor<1x56x56x256xf32>
+    %71 = "ttir.relu"(%69, %70) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x56x56x256xf32>, tensor<1x56x56x256xf32>) -> tensor<1x56x56x256xf32>
+    %72 = tensor.empty() : tensor<1x56x56x64xf32>
+    %73 = "ttir.conv2d"(%71, %arg115, %72) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x56x56x256xf32>, tensor<64x256x1x1xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %74 = tensor.empty() : tensor<1x56x56x64xf32>
+    %75 = "ttir.multiply"(%73, %arg17, %74) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x56x56x64xf32>, tensor<1x1x1x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %76 = tensor.empty() : tensor<1x56x56x64xf32>
+    %77 = "ttir.add"(%75, %arg18, %76) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x56x56x64xf32>, tensor<1x1x1x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %78 = tensor.empty() : tensor<1x56x56x64xf32>
+    %79 = "ttir.relu"(%77, %78) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x56x56x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %80 = tensor.empty() : tensor<1x56x56x64xf32>
+    %81 = "ttir.conv2d"(%79, %arg116, %80) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 1 : si32, padding_left = 1 : si32, padding_right = 1 : si32, padding_top = 1 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x56x56x64xf32>, tensor<64x64x3x3xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %82 = tensor.empty() : tensor<1x56x56x64xf32>
+    %83 = "ttir.multiply"(%81, %arg19, %82) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x56x56x64xf32>, tensor<1x1x1x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %84 = tensor.empty() : tensor<1x56x56x64xf32>
+    %85 = "ttir.add"(%83, %arg20, %84) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x56x56x64xf32>, tensor<1x1x1x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %86 = tensor.empty() : tensor<1x56x56x64xf32>
+    %87 = "ttir.relu"(%85, %86) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x56x56x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %88 = tensor.empty() : tensor<1x56x56x256xf32>
+    %89 = "ttir.conv2d"(%87, %arg117, %88) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x56x56x64xf32>, tensor<256x64x1x1xf32>, tensor<1x56x56x256xf32>) -> tensor<1x56x56x256xf32>
+    %90 = tensor.empty() : tensor<1x56x56x256xf32>
+    %91 = "ttir.multiply"(%89, %arg21, %90) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x56x56x256xf32>, tensor<1x1x1x256xf32>, tensor<1x56x56x256xf32>) -> tensor<1x56x56x256xf32>
+    %92 = tensor.empty() : tensor<1x56x56x256xf32>
+    %93 = "ttir.add"(%91, %arg22, %92) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x56x56x256xf32>, tensor<1x1x1x256xf32>, tensor<1x56x56x256xf32>) -> tensor<1x56x56x256xf32>
+    %94 = tensor.empty() : tensor<1x56x56x256xf32>
+    %95 = "ttir.add"(%93, %71, %94) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x56x56x256xf32>, tensor<1x56x56x256xf32>, tensor<1x56x56x256xf32>) -> tensor<1x56x56x256xf32>
+    %96 = tensor.empty() : tensor<1x56x56x256xf32>
+    %97 = "ttir.relu"(%95, %96) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x56x56x256xf32>, tensor<1x56x56x256xf32>) -> tensor<1x56x56x256xf32>
+    %98 = tensor.empty() : tensor<1x56x56x128xf32>
+    %99 = "ttir.conv2d"(%97, %arg118, %98) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x56x56x256xf32>, tensor<128x256x1x1xf32>, tensor<1x56x56x128xf32>) -> tensor<1x56x56x128xf32>
+    %100 = tensor.empty() : tensor<1x56x56x128xf32>
+    %101 = "ttir.multiply"(%99, %arg23, %100) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x56x56x128xf32>, tensor<1x1x1x128xf32>, tensor<1x56x56x128xf32>) -> tensor<1x56x56x128xf32>
+    %102 = tensor.empty() : tensor<1x56x56x128xf32>
+    %103 = "ttir.add"(%101, %arg24, %102) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x56x56x128xf32>, tensor<1x1x1x128xf32>, tensor<1x56x56x128xf32>) -> tensor<1x56x56x128xf32>
+    %104 = tensor.empty() : tensor<1x56x56x128xf32>
+    %105 = "ttir.relu"(%103, %104) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x56x56x128xf32>, tensor<1x56x56x128xf32>) -> tensor<1x56x56x128xf32>
+    %106 = tensor.empty() : tensor<1x28x28x128xf32>
+    %107 = "ttir.conv2d"(%105, %arg119, %106) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 1 : si32, padding_left = 1 : si32, padding_right = 1 : si32, padding_top = 1 : si32, stride_height = 2 : si32, stride_width = 2 : si32}> {channel_last = 1 : si32} : (tensor<1x56x56x128xf32>, tensor<128x128x3x3xf32>, tensor<1x28x28x128xf32>) -> tensor<1x28x28x128xf32>
+    %108 = tensor.empty() : tensor<1x28x28x128xf32>
+    %109 = "ttir.multiply"(%107, %arg25, %108) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x28x28x128xf32>, tensor<1x1x1x128xf32>, tensor<1x28x28x128xf32>) -> tensor<1x28x28x128xf32>
+    %110 = tensor.empty() : tensor<1x28x28x128xf32>
+    %111 = "ttir.add"(%109, %arg26, %110) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x28x28x128xf32>, tensor<1x1x1x128xf32>, tensor<1x28x28x128xf32>) -> tensor<1x28x28x128xf32>
+    %112 = tensor.empty() : tensor<1x28x28x128xf32>
+    %113 = "ttir.relu"(%111, %112) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x28x28x128xf32>, tensor<1x28x28x128xf32>) -> tensor<1x28x28x128xf32>
+    %114 = tensor.empty() : tensor<1x28x28x512xf32>
+    %115 = "ttir.conv2d"(%113, %arg120, %114) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x28x28x128xf32>, tensor<512x128x1x1xf32>, tensor<1x28x28x512xf32>) -> tensor<1x28x28x512xf32>
+    %116 = tensor.empty() : tensor<1x28x28x512xf32>
+    %117 = "ttir.multiply"(%115, %arg27, %116) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x28x28x512xf32>, tensor<1x1x1x512xf32>, tensor<1x28x28x512xf32>) -> tensor<1x28x28x512xf32>
+    %118 = tensor.empty() : tensor<1x28x28x512xf32>
+    %119 = "ttir.add"(%117, %arg28, %118) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x28x28x512xf32>, tensor<1x1x1x512xf32>, tensor<1x28x28x512xf32>) -> tensor<1x28x28x512xf32>
+    %120 = tensor.empty() : tensor<1x28x28x512xf32>
+    %121 = "ttir.conv2d"(%97, %arg121, %120) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 2 : si32, stride_width = 2 : si32}> {channel_last = 1 : si32} : (tensor<1x56x56x256xf32>, tensor<512x256x1x1xf32>, tensor<1x28x28x512xf32>) -> tensor<1x28x28x512xf32>
+    %122 = tensor.empty() : tensor<1x28x28x512xf32>
+    %123 = "ttir.multiply"(%121, %arg29, %122) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x28x28x512xf32>, tensor<1x1x1x512xf32>, tensor<1x28x28x512xf32>) -> tensor<1x28x28x512xf32>
+    %124 = tensor.empty() : tensor<1x28x28x512xf32>
+    %125 = "ttir.add"(%123, %arg30, %124) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x28x28x512xf32>, tensor<1x1x1x512xf32>, tensor<1x28x28x512xf32>) -> tensor<1x28x28x512xf32>
+    %126 = tensor.empty() : tensor<1x28x28x512xf32>
+    %127 = "ttir.add"(%119, %125, %126) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x28x28x512xf32>, tensor<1x28x28x512xf32>, tensor<1x28x28x512xf32>) -> tensor<1x28x28x512xf32>
+    %128 = tensor.empty() : tensor<1x28x28x512xf32>
+    %129 = "ttir.relu"(%127, %128) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x28x28x512xf32>, tensor<1x28x28x512xf32>) -> tensor<1x28x28x512xf32>
+    %130 = tensor.empty() : tensor<1x28x28x128xf32>
+    %131 = "ttir.conv2d"(%129, %arg122, %130) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x28x28x512xf32>, tensor<128x512x1x1xf32>, tensor<1x28x28x128xf32>) -> tensor<1x28x28x128xf32>
+    %132 = tensor.empty() : tensor<1x28x28x128xf32>
+    %133 = "ttir.multiply"(%131, %arg31, %132) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x28x28x128xf32>, tensor<1x1x1x128xf32>, tensor<1x28x28x128xf32>) -> tensor<1x28x28x128xf32>
+    %134 = tensor.empty() : tensor<1x28x28x128xf32>
+    %135 = "ttir.add"(%133, %arg32, %134) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x28x28x128xf32>, tensor<1x1x1x128xf32>, tensor<1x28x28x128xf32>) -> tensor<1x28x28x128xf32>
+    %136 = tensor.empty() : tensor<1x28x28x128xf32>
+    %137 = "ttir.relu"(%135, %136) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x28x28x128xf32>, tensor<1x28x28x128xf32>) -> tensor<1x28x28x128xf32>
+    %138 = tensor.empty() : tensor<1x28x28x128xf32>
+    %139 = "ttir.conv2d"(%137, %arg123, %138) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 1 : si32, padding_left = 1 : si32, padding_right = 1 : si32, padding_top = 1 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x28x28x128xf32>, tensor<128x128x3x3xf32>, tensor<1x28x28x128xf32>) -> tensor<1x28x28x128xf32>
+    %140 = tensor.empty() : tensor<1x28x28x128xf32>
+    %141 = "ttir.multiply"(%139, %arg33, %140) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x28x28x128xf32>, tensor<1x1x1x128xf32>, tensor<1x28x28x128xf32>) -> tensor<1x28x28x128xf32>
+    %142 = tensor.empty() : tensor<1x28x28x128xf32>
+    %143 = "ttir.add"(%141, %arg34, %142) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x28x28x128xf32>, tensor<1x1x1x128xf32>, tensor<1x28x28x128xf32>) -> tensor<1x28x28x128xf32>
+    %144 = tensor.empty() : tensor<1x28x28x128xf32>
+    %145 = "ttir.relu"(%143, %144) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x28x28x128xf32>, tensor<1x28x28x128xf32>) -> tensor<1x28x28x128xf32>
+    %146 = tensor.empty() : tensor<1x28x28x512xf32>
+    %147 = "ttir.conv2d"(%145, %arg124, %146) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x28x28x128xf32>, tensor<512x128x1x1xf32>, tensor<1x28x28x512xf32>) -> tensor<1x28x28x512xf32>
+    %148 = tensor.empty() : tensor<1x28x28x512xf32>
+    %149 = "ttir.multiply"(%147, %arg35, %148) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x28x28x512xf32>, tensor<1x1x1x512xf32>, tensor<1x28x28x512xf32>) -> tensor<1x28x28x512xf32>
+    %150 = tensor.empty() : tensor<1x28x28x512xf32>
+    %151 = "ttir.add"(%149, %arg36, %150) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x28x28x512xf32>, tensor<1x1x1x512xf32>, tensor<1x28x28x512xf32>) -> tensor<1x28x28x512xf32>
+    %152 = tensor.empty() : tensor<1x28x28x512xf32>
+    %153 = "ttir.add"(%151, %129, %152) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x28x28x512xf32>, tensor<1x28x28x512xf32>, tensor<1x28x28x512xf32>) -> tensor<1x28x28x512xf32>
+    %154 = tensor.empty() : tensor<1x28x28x512xf32>
+    %155 = "ttir.relu"(%153, %154) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x28x28x512xf32>, tensor<1x28x28x512xf32>) -> tensor<1x28x28x512xf32>
+    %156 = tensor.empty() : tensor<1x28x28x128xf32>
+    %157 = "ttir.conv2d"(%155, %arg125, %156) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x28x28x512xf32>, tensor<128x512x1x1xf32>, tensor<1x28x28x128xf32>) -> tensor<1x28x28x128xf32>
+    %158 = tensor.empty() : tensor<1x28x28x128xf32>
+    %159 = "ttir.multiply"(%157, %arg37, %158) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x28x28x128xf32>, tensor<1x1x1x128xf32>, tensor<1x28x28x128xf32>) -> tensor<1x28x28x128xf32>
+    %160 = tensor.empty() : tensor<1x28x28x128xf32>
+    %161 = "ttir.add"(%159, %arg38, %160) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x28x28x128xf32>, tensor<1x1x1x128xf32>, tensor<1x28x28x128xf32>) -> tensor<1x28x28x128xf32>
+    %162 = tensor.empty() : tensor<1x28x28x128xf32>
+    %163 = "ttir.relu"(%161, %162) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x28x28x128xf32>, tensor<1x28x28x128xf32>) -> tensor<1x28x28x128xf32>
+    %164 = tensor.empty() : tensor<1x28x28x128xf32>
+    %165 = "ttir.conv2d"(%163, %arg126, %164) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 1 : si32, padding_left = 1 : si32, padding_right = 1 : si32, padding_top = 1 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x28x28x128xf32>, tensor<128x128x3x3xf32>, tensor<1x28x28x128xf32>) -> tensor<1x28x28x128xf32>
+    %166 = tensor.empty() : tensor<1x28x28x128xf32>
+    %167 = "ttir.multiply"(%165, %arg39, %166) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x28x28x128xf32>, tensor<1x1x1x128xf32>, tensor<1x28x28x128xf32>) -> tensor<1x28x28x128xf32>
+    %168 = tensor.empty() : tensor<1x28x28x128xf32>
+    %169 = "ttir.add"(%167, %arg40, %168) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x28x28x128xf32>, tensor<1x1x1x128xf32>, tensor<1x28x28x128xf32>) -> tensor<1x28x28x128xf32>
+    %170 = tensor.empty() : tensor<1x28x28x128xf32>
+    %171 = "ttir.relu"(%169, %170) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x28x28x128xf32>, tensor<1x28x28x128xf32>) -> tensor<1x28x28x128xf32>
+    %172 = tensor.empty() : tensor<1x28x28x512xf32>
+    %173 = "ttir.conv2d"(%171, %arg127, %172) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x28x28x128xf32>, tensor<512x128x1x1xf32>, tensor<1x28x28x512xf32>) -> tensor<1x28x28x512xf32>
+    %174 = tensor.empty() : tensor<1x28x28x512xf32>
+    %175 = "ttir.multiply"(%173, %arg41, %174) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x28x28x512xf32>, tensor<1x1x1x512xf32>, tensor<1x28x28x512xf32>) -> tensor<1x28x28x512xf32>
+    %176 = tensor.empty() : tensor<1x28x28x512xf32>
+    %177 = "ttir.add"(%175, %arg42, %176) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x28x28x512xf32>, tensor<1x1x1x512xf32>, tensor<1x28x28x512xf32>) -> tensor<1x28x28x512xf32>
+    %178 = tensor.empty() : tensor<1x28x28x512xf32>
+    %179 = "ttir.add"(%177, %155, %178) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x28x28x512xf32>, tensor<1x28x28x512xf32>, tensor<1x28x28x512xf32>) -> tensor<1x28x28x512xf32>
+    %180 = tensor.empty() : tensor<1x28x28x512xf32>
+    %181 = "ttir.relu"(%179, %180) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x28x28x512xf32>, tensor<1x28x28x512xf32>) -> tensor<1x28x28x512xf32>
+    %182 = tensor.empty() : tensor<1x28x28x128xf32>
+    %183 = "ttir.conv2d"(%181, %arg128, %182) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x28x28x512xf32>, tensor<128x512x1x1xf32>, tensor<1x28x28x128xf32>) -> tensor<1x28x28x128xf32>
+    %184 = tensor.empty() : tensor<1x28x28x128xf32>
+    %185 = "ttir.multiply"(%183, %arg43, %184) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x28x28x128xf32>, tensor<1x1x1x128xf32>, tensor<1x28x28x128xf32>) -> tensor<1x28x28x128xf32>
+    %186 = tensor.empty() : tensor<1x28x28x128xf32>
+    %187 = "ttir.add"(%185, %arg44, %186) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x28x28x128xf32>, tensor<1x1x1x128xf32>, tensor<1x28x28x128xf32>) -> tensor<1x28x28x128xf32>
+    %188 = tensor.empty() : tensor<1x28x28x128xf32>
+    %189 = "ttir.relu"(%187, %188) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x28x28x128xf32>, tensor<1x28x28x128xf32>) -> tensor<1x28x28x128xf32>
+    %190 = tensor.empty() : tensor<1x28x28x128xf32>
+    %191 = "ttir.conv2d"(%189, %arg129, %190) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 1 : si32, padding_left = 1 : si32, padding_right = 1 : si32, padding_top = 1 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x28x28x128xf32>, tensor<128x128x3x3xf32>, tensor<1x28x28x128xf32>) -> tensor<1x28x28x128xf32>
+    %192 = tensor.empty() : tensor<1x28x28x128xf32>
+    %193 = "ttir.multiply"(%191, %arg45, %192) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x28x28x128xf32>, tensor<1x1x1x128xf32>, tensor<1x28x28x128xf32>) -> tensor<1x28x28x128xf32>
+    %194 = tensor.empty() : tensor<1x28x28x128xf32>
+    %195 = "ttir.add"(%193, %arg46, %194) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x28x28x128xf32>, tensor<1x1x1x128xf32>, tensor<1x28x28x128xf32>) -> tensor<1x28x28x128xf32>
+    %196 = tensor.empty() : tensor<1x28x28x128xf32>
+    %197 = "ttir.relu"(%195, %196) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x28x28x128xf32>, tensor<1x28x28x128xf32>) -> tensor<1x28x28x128xf32>
+    %198 = tensor.empty() : tensor<1x28x28x512xf32>
+    %199 = "ttir.conv2d"(%197, %arg130, %198) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x28x28x128xf32>, tensor<512x128x1x1xf32>, tensor<1x28x28x512xf32>) -> tensor<1x28x28x512xf32>
+    %200 = tensor.empty() : tensor<1x28x28x512xf32>
+    %201 = "ttir.multiply"(%199, %arg47, %200) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x28x28x512xf32>, tensor<1x1x1x512xf32>, tensor<1x28x28x512xf32>) -> tensor<1x28x28x512xf32>
+    %202 = tensor.empty() : tensor<1x28x28x512xf32>
+    %203 = "ttir.add"(%201, %arg48, %202) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x28x28x512xf32>, tensor<1x1x1x512xf32>, tensor<1x28x28x512xf32>) -> tensor<1x28x28x512xf32>
+    %204 = tensor.empty() : tensor<1x28x28x512xf32>
+    %205 = "ttir.add"(%203, %181, %204) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x28x28x512xf32>, tensor<1x28x28x512xf32>, tensor<1x28x28x512xf32>) -> tensor<1x28x28x512xf32>
+    %206 = tensor.empty() : tensor<1x28x28x512xf32>
+    %207 = "ttir.relu"(%205, %206) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x28x28x512xf32>, tensor<1x28x28x512xf32>) -> tensor<1x28x28x512xf32>
+    %208 = tensor.empty() : tensor<1x28x28x256xf32>
+    %209 = "ttir.conv2d"(%207, %arg131, %208) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x28x28x512xf32>, tensor<256x512x1x1xf32>, tensor<1x28x28x256xf32>) -> tensor<1x28x28x256xf32>
+    %210 = tensor.empty() : tensor<1x28x28x256xf32>
+    %211 = "ttir.multiply"(%209, %arg49, %210) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x28x28x256xf32>, tensor<1x1x1x256xf32>, tensor<1x28x28x256xf32>) -> tensor<1x28x28x256xf32>
+    %212 = tensor.empty() : tensor<1x28x28x256xf32>
+    %213 = "ttir.add"(%211, %arg50, %212) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x28x28x256xf32>, tensor<1x1x1x256xf32>, tensor<1x28x28x256xf32>) -> tensor<1x28x28x256xf32>
+    %214 = tensor.empty() : tensor<1x28x28x256xf32>
+    %215 = "ttir.relu"(%213, %214) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x28x28x256xf32>, tensor<1x28x28x256xf32>) -> tensor<1x28x28x256xf32>
+    %216 = tensor.empty() : tensor<1x14x14x256xf32>
+    %217 = "ttir.conv2d"(%215, %arg132, %216) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 1 : si32, padding_left = 1 : si32, padding_right = 1 : si32, padding_top = 1 : si32, stride_height = 2 : si32, stride_width = 2 : si32}> {channel_last = 1 : si32} : (tensor<1x28x28x256xf32>, tensor<256x256x3x3xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %218 = tensor.empty() : tensor<1x14x14x256xf32>
+    %219 = "ttir.multiply"(%217, %arg51, %218) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x1x1x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %220 = tensor.empty() : tensor<1x14x14x256xf32>
+    %221 = "ttir.add"(%219, %arg52, %220) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x1x1x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %222 = tensor.empty() : tensor<1x14x14x256xf32>
+    %223 = "ttir.relu"(%221, %222) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %224 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %225 = "ttir.conv2d"(%223, %arg133, %224) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x14x14x256xf32>, tensor<1024x256x1x1xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %226 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %227 = "ttir.multiply"(%225, %arg53, %226) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x1024xf32>, tensor<1x1x1x1024xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %228 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %229 = "ttir.add"(%227, %arg54, %228) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x1024xf32>, tensor<1x1x1x1024xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %230 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %231 = "ttir.conv2d"(%207, %arg134, %230) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 2 : si32, stride_width = 2 : si32}> {channel_last = 1 : si32} : (tensor<1x28x28x512xf32>, tensor<1024x512x1x1xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %232 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %233 = "ttir.multiply"(%231, %arg55, %232) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x1024xf32>, tensor<1x1x1x1024xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %234 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %235 = "ttir.add"(%233, %arg56, %234) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x1024xf32>, tensor<1x1x1x1024xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %236 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %237 = "ttir.add"(%229, %235, %236) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x1024xf32>, tensor<1x14x14x1024xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %238 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %239 = "ttir.relu"(%237, %238) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x14x14x1024xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %240 = tensor.empty() : tensor<1x14x14x256xf32>
+    %241 = "ttir.conv2d"(%239, %arg135, %240) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x14x14x1024xf32>, tensor<256x1024x1x1xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %242 = tensor.empty() : tensor<1x14x14x256xf32>
+    %243 = "ttir.multiply"(%241, %arg57, %242) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x1x1x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %244 = tensor.empty() : tensor<1x14x14x256xf32>
+    %245 = "ttir.add"(%243, %arg58, %244) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x1x1x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %246 = tensor.empty() : tensor<1x14x14x256xf32>
+    %247 = "ttir.relu"(%245, %246) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %248 = tensor.empty() : tensor<1x14x14x256xf32>
+    %249 = "ttir.conv2d"(%247, %arg136, %248) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 1 : si32, padding_left = 1 : si32, padding_right = 1 : si32, padding_top = 1 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x14x14x256xf32>, tensor<256x256x3x3xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %250 = tensor.empty() : tensor<1x14x14x256xf32>
+    %251 = "ttir.multiply"(%249, %arg59, %250) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x1x1x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %252 = tensor.empty() : tensor<1x14x14x256xf32>
+    %253 = "ttir.add"(%251, %arg60, %252) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x1x1x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %254 = tensor.empty() : tensor<1x14x14x256xf32>
+    %255 = "ttir.relu"(%253, %254) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %256 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %257 = "ttir.conv2d"(%255, %arg137, %256) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x14x14x256xf32>, tensor<1024x256x1x1xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %258 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %259 = "ttir.multiply"(%257, %arg61, %258) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x1024xf32>, tensor<1x1x1x1024xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %260 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %261 = "ttir.add"(%259, %arg62, %260) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x1024xf32>, tensor<1x1x1x1024xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %262 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %263 = "ttir.add"(%261, %239, %262) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x1024xf32>, tensor<1x14x14x1024xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %264 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %265 = "ttir.relu"(%263, %264) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x14x14x1024xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %266 = tensor.empty() : tensor<1x14x14x256xf32>
+    %267 = "ttir.conv2d"(%265, %arg138, %266) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x14x14x1024xf32>, tensor<256x1024x1x1xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %268 = tensor.empty() : tensor<1x14x14x256xf32>
+    %269 = "ttir.multiply"(%267, %arg63, %268) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x1x1x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %270 = tensor.empty() : tensor<1x14x14x256xf32>
+    %271 = "ttir.add"(%269, %arg64, %270) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x1x1x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %272 = tensor.empty() : tensor<1x14x14x256xf32>
+    %273 = "ttir.relu"(%271, %272) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %274 = tensor.empty() : tensor<1x14x14x256xf32>
+    %275 = "ttir.conv2d"(%273, %arg139, %274) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 1 : si32, padding_left = 1 : si32, padding_right = 1 : si32, padding_top = 1 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x14x14x256xf32>, tensor<256x256x3x3xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %276 = tensor.empty() : tensor<1x14x14x256xf32>
+    %277 = "ttir.multiply"(%275, %arg65, %276) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x1x1x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %278 = tensor.empty() : tensor<1x14x14x256xf32>
+    %279 = "ttir.add"(%277, %arg66, %278) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x1x1x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %280 = tensor.empty() : tensor<1x14x14x256xf32>
+    %281 = "ttir.relu"(%279, %280) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %282 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %283 = "ttir.conv2d"(%281, %arg140, %282) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x14x14x256xf32>, tensor<1024x256x1x1xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %284 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %285 = "ttir.multiply"(%283, %arg67, %284) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x1024xf32>, tensor<1x1x1x1024xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %286 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %287 = "ttir.add"(%285, %arg68, %286) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x1024xf32>, tensor<1x1x1x1024xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %288 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %289 = "ttir.add"(%287, %265, %288) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x1024xf32>, tensor<1x14x14x1024xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %290 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %291 = "ttir.relu"(%289, %290) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x14x14x1024xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %292 = tensor.empty() : tensor<1x14x14x256xf32>
+    %293 = "ttir.conv2d"(%291, %arg141, %292) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x14x14x1024xf32>, tensor<256x1024x1x1xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %294 = tensor.empty() : tensor<1x14x14x256xf32>
+    %295 = "ttir.multiply"(%293, %arg69, %294) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x1x1x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %296 = tensor.empty() : tensor<1x14x14x256xf32>
+    %297 = "ttir.add"(%295, %arg70, %296) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x1x1x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %298 = tensor.empty() : tensor<1x14x14x256xf32>
+    %299 = "ttir.relu"(%297, %298) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %300 = tensor.empty() : tensor<1x14x14x256xf32>
+    %301 = "ttir.conv2d"(%299, %arg142, %300) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 1 : si32, padding_left = 1 : si32, padding_right = 1 : si32, padding_top = 1 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x14x14x256xf32>, tensor<256x256x3x3xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %302 = tensor.empty() : tensor<1x14x14x256xf32>
+    %303 = "ttir.multiply"(%301, %arg71, %302) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x1x1x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %304 = tensor.empty() : tensor<1x14x14x256xf32>
+    %305 = "ttir.add"(%303, %arg72, %304) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x1x1x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %306 = tensor.empty() : tensor<1x14x14x256xf32>
+    %307 = "ttir.relu"(%305, %306) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %308 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %309 = "ttir.conv2d"(%307, %arg143, %308) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x14x14x256xf32>, tensor<1024x256x1x1xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %310 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %311 = "ttir.multiply"(%309, %arg73, %310) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x1024xf32>, tensor<1x1x1x1024xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %312 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %313 = "ttir.add"(%311, %arg74, %312) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x1024xf32>, tensor<1x1x1x1024xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %314 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %315 = "ttir.add"(%313, %291, %314) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x1024xf32>, tensor<1x14x14x1024xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %316 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %317 = "ttir.relu"(%315, %316) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x14x14x1024xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %318 = tensor.empty() : tensor<1x14x14x256xf32>
+    %319 = "ttir.conv2d"(%317, %arg144, %318) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x14x14x1024xf32>, tensor<256x1024x1x1xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %320 = tensor.empty() : tensor<1x14x14x256xf32>
+    %321 = "ttir.multiply"(%319, %arg75, %320) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x1x1x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %322 = tensor.empty() : tensor<1x14x14x256xf32>
+    %323 = "ttir.add"(%321, %arg76, %322) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x1x1x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %324 = tensor.empty() : tensor<1x14x14x256xf32>
+    %325 = "ttir.relu"(%323, %324) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %326 = tensor.empty() : tensor<1x14x14x256xf32>
+    %327 = "ttir.conv2d"(%325, %arg145, %326) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 1 : si32, padding_left = 1 : si32, padding_right = 1 : si32, padding_top = 1 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x14x14x256xf32>, tensor<256x256x3x3xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %328 = tensor.empty() : tensor<1x14x14x256xf32>
+    %329 = "ttir.multiply"(%327, %arg77, %328) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x1x1x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %330 = tensor.empty() : tensor<1x14x14x256xf32>
+    %331 = "ttir.add"(%329, %arg78, %330) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x1x1x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %332 = tensor.empty() : tensor<1x14x14x256xf32>
+    %333 = "ttir.relu"(%331, %332) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %334 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %335 = "ttir.conv2d"(%333, %arg146, %334) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x14x14x256xf32>, tensor<1024x256x1x1xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %336 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %337 = "ttir.multiply"(%335, %arg79, %336) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x1024xf32>, tensor<1x1x1x1024xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %338 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %339 = "ttir.add"(%337, %arg80, %338) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x1024xf32>, tensor<1x1x1x1024xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %340 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %341 = "ttir.add"(%339, %317, %340) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x1024xf32>, tensor<1x14x14x1024xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %342 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %343 = "ttir.relu"(%341, %342) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x14x14x1024xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %344 = tensor.empty() : tensor<1x14x14x256xf32>
+    %345 = "ttir.conv2d"(%343, %arg147, %344) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x14x14x1024xf32>, tensor<256x1024x1x1xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %346 = tensor.empty() : tensor<1x14x14x256xf32>
+    %347 = "ttir.multiply"(%345, %arg81, %346) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x1x1x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %348 = tensor.empty() : tensor<1x14x14x256xf32>
+    %349 = "ttir.add"(%347, %arg82, %348) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x1x1x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %350 = tensor.empty() : tensor<1x14x14x256xf32>
+    %351 = "ttir.relu"(%349, %350) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %352 = tensor.empty() : tensor<1x14x14x256xf32>
+    %353 = "ttir.conv2d"(%351, %arg148, %352) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 1 : si32, padding_left = 1 : si32, padding_right = 1 : si32, padding_top = 1 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x14x14x256xf32>, tensor<256x256x3x3xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %354 = tensor.empty() : tensor<1x14x14x256xf32>
+    %355 = "ttir.multiply"(%353, %arg83, %354) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x1x1x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %356 = tensor.empty() : tensor<1x14x14x256xf32>
+    %357 = "ttir.add"(%355, %arg84, %356) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x1x1x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %358 = tensor.empty() : tensor<1x14x14x256xf32>
+    %359 = "ttir.relu"(%357, %358) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x14x14x256xf32>, tensor<1x14x14x256xf32>) -> tensor<1x14x14x256xf32>
+    %360 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %361 = "ttir.conv2d"(%359, %arg149, %360) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x14x14x256xf32>, tensor<1024x256x1x1xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %362 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %363 = "ttir.multiply"(%361, %arg85, %362) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x1024xf32>, tensor<1x1x1x1024xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %364 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %365 = "ttir.add"(%363, %arg86, %364) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x1024xf32>, tensor<1x1x1x1024xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %366 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %367 = "ttir.add"(%365, %343, %366) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x1024xf32>, tensor<1x14x14x1024xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %368 = tensor.empty() : tensor<1x14x14x1024xf32>
+    %369 = "ttir.relu"(%367, %368) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x14x14x1024xf32>, tensor<1x14x14x1024xf32>) -> tensor<1x14x14x1024xf32>
+    %370 = tensor.empty() : tensor<1x14x14x512xf32>
+    %371 = "ttir.conv2d"(%369, %arg150, %370) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x14x14x1024xf32>, tensor<512x1024x1x1xf32>, tensor<1x14x14x512xf32>) -> tensor<1x14x14x512xf32>
+    %372 = tensor.empty() : tensor<1x14x14x512xf32>
+    %373 = "ttir.multiply"(%371, %arg87, %372) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x512xf32>, tensor<1x1x1x512xf32>, tensor<1x14x14x512xf32>) -> tensor<1x14x14x512xf32>
+    %374 = tensor.empty() : tensor<1x14x14x512xf32>
+    %375 = "ttir.add"(%373, %arg88, %374) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x14x14x512xf32>, tensor<1x1x1x512xf32>, tensor<1x14x14x512xf32>) -> tensor<1x14x14x512xf32>
+    %376 = tensor.empty() : tensor<1x14x14x512xf32>
+    %377 = "ttir.relu"(%375, %376) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x14x14x512xf32>, tensor<1x14x14x512xf32>) -> tensor<1x14x14x512xf32>
+    %378 = tensor.empty() : tensor<1x7x7x512xf32>
+    %379 = "ttir.conv2d"(%377, %arg151, %378) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 1 : si32, padding_left = 1 : si32, padding_right = 1 : si32, padding_top = 1 : si32, stride_height = 2 : si32, stride_width = 2 : si32}> {channel_last = 1 : si32} : (tensor<1x14x14x512xf32>, tensor<512x512x3x3xf32>, tensor<1x7x7x512xf32>) -> tensor<1x7x7x512xf32>
+    %380 = tensor.empty() : tensor<1x7x7x512xf32>
+    %381 = "ttir.multiply"(%379, %arg89, %380) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x7x7x512xf32>, tensor<1x1x1x512xf32>, tensor<1x7x7x512xf32>) -> tensor<1x7x7x512xf32>
+    %382 = tensor.empty() : tensor<1x7x7x512xf32>
+    %383 = "ttir.add"(%381, %arg90, %382) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x7x7x512xf32>, tensor<1x1x1x512xf32>, tensor<1x7x7x512xf32>) -> tensor<1x7x7x512xf32>
+    %384 = tensor.empty() : tensor<1x7x7x512xf32>
+    %385 = "ttir.relu"(%383, %384) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x7x7x512xf32>, tensor<1x7x7x512xf32>) -> tensor<1x7x7x512xf32>
+    %386 = tensor.empty() : tensor<1x7x7x2048xf32>
+    %387 = "ttir.conv2d"(%385, %arg152, %386) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x7x7x512xf32>, tensor<2048x512x1x1xf32>, tensor<1x7x7x2048xf32>) -> tensor<1x7x7x2048xf32>
+    %388 = tensor.empty() : tensor<1x7x2048x7xf32>
+    %389 = "ttir.transpose"(%387, %388) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x7x7x2048xf32>, tensor<1x7x2048x7xf32>) -> tensor<1x7x2048x7xf32>
+    %390 = tensor.empty() : tensor<1x2048x7x7xf32>
+    %391 = "ttir.transpose"(%389, %390) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x7x2048x7xf32>, tensor<1x2048x7x7xf32>) -> tensor<1x2048x7x7xf32>
+    %392 = tensor.empty() : tensor<1x2048x7x7xf32>
+    %393 = "ttir.multiply"(%391, %arg91, %392) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x2048x7x7xf32>, tensor<1x2048x1x1xf32>, tensor<1x2048x7x7xf32>) -> tensor<1x2048x7x7xf32>
+    %394 = tensor.empty() : tensor<1x2048x7x7xf32>
+    %395 = "ttir.add"(%393, %arg92, %394) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x2048x7x7xf32>, tensor<1x2048x1x1xf32>, tensor<1x2048x7x7xf32>) -> tensor<1x2048x7x7xf32>
+    %396 = tensor.empty() : tensor<1x7x7x2048xf32>
+    %397 = "ttir.conv2d"(%369, %arg153, %396) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 2 : si32, stride_width = 2 : si32}> {channel_last = 1 : si32} : (tensor<1x14x14x1024xf32>, tensor<2048x1024x1x1xf32>, tensor<1x7x7x2048xf32>) -> tensor<1x7x7x2048xf32>
+    %398 = tensor.empty() : tensor<1x7x2048x7xf32>
+    %399 = "ttir.transpose"(%397, %398) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x7x7x2048xf32>, tensor<1x7x2048x7xf32>) -> tensor<1x7x2048x7xf32>
+    %400 = tensor.empty() : tensor<1x2048x7x7xf32>
+    %401 = "ttir.transpose"(%399, %400) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x7x2048x7xf32>, tensor<1x2048x7x7xf32>) -> tensor<1x2048x7x7xf32>
+    %402 = tensor.empty() : tensor<1x2048x7x7xf32>
+    %403 = "ttir.multiply"(%401, %arg93, %402) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x2048x7x7xf32>, tensor<1x2048x1x1xf32>, tensor<1x2048x7x7xf32>) -> tensor<1x2048x7x7xf32>
+    %404 = tensor.empty() : tensor<1x2048x7x7xf32>
+    %405 = "ttir.add"(%403, %arg94, %404) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x2048x7x7xf32>, tensor<1x2048x1x1xf32>, tensor<1x2048x7x7xf32>) -> tensor<1x2048x7x7xf32>
+    %406 = tensor.empty() : tensor<1x2048x7x7xf32>
+    %407 = "ttir.add"(%395, %405, %406) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x2048x7x7xf32>, tensor<1x2048x7x7xf32>, tensor<1x2048x7x7xf32>) -> tensor<1x2048x7x7xf32>
+    %408 = tensor.empty() : tensor<1x2048x7x7xf32>
+    %409 = "ttir.relu"(%407, %408) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x2048x7x7xf32>, tensor<1x2048x7x7xf32>) -> tensor<1x2048x7x7xf32>
+    %410 = tensor.empty() : tensor<1x7x2048x7xf32>
+    %411 = "ttir.transpose"(%409, %410) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x2048x7x7xf32>, tensor<1x7x2048x7xf32>) -> tensor<1x7x2048x7xf32>
+    %412 = tensor.empty() : tensor<1x7x7x2048xf32>
+    %413 = "ttir.transpose"(%411, %412) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x7x2048x7xf32>, tensor<1x7x7x2048xf32>) -> tensor<1x7x7x2048xf32>
+    %414 = tensor.empty() : tensor<1x7x7x512xf32>
+    %415 = "ttir.conv2d"(%413, %arg154, %414) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x7x7x2048xf32>, tensor<512x2048x1x1xf32>, tensor<1x7x7x512xf32>) -> tensor<1x7x7x512xf32>
+    %416 = tensor.empty() : tensor<1x7x7x512xf32>
+    %417 = "ttir.multiply"(%415, %arg95, %416) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x7x7x512xf32>, tensor<1x1x1x512xf32>, tensor<1x7x7x512xf32>) -> tensor<1x7x7x512xf32>
+    %418 = tensor.empty() : tensor<1x7x7x512xf32>
+    %419 = "ttir.add"(%417, %arg96, %418) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x7x7x512xf32>, tensor<1x1x1x512xf32>, tensor<1x7x7x512xf32>) -> tensor<1x7x7x512xf32>
+    %420 = tensor.empty() : tensor<1x7x7x512xf32>
+    %421 = "ttir.relu"(%419, %420) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x7x7x512xf32>, tensor<1x7x7x512xf32>) -> tensor<1x7x7x512xf32>
+    %422 = tensor.empty() : tensor<1x7x7x512xf32>
+    %423 = "ttir.conv2d"(%421, %arg155, %422) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 1 : si32, padding_left = 1 : si32, padding_right = 1 : si32, padding_top = 1 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x7x7x512xf32>, tensor<512x512x3x3xf32>, tensor<1x7x7x512xf32>) -> tensor<1x7x7x512xf32>
+    %424 = tensor.empty() : tensor<1x7x7x512xf32>
+    %425 = "ttir.multiply"(%423, %arg97, %424) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x7x7x512xf32>, tensor<1x1x1x512xf32>, tensor<1x7x7x512xf32>) -> tensor<1x7x7x512xf32>
+    %426 = tensor.empty() : tensor<1x7x7x512xf32>
+    %427 = "ttir.add"(%425, %arg98, %426) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x7x7x512xf32>, tensor<1x1x1x512xf32>, tensor<1x7x7x512xf32>) -> tensor<1x7x7x512xf32>
+    %428 = tensor.empty() : tensor<1x7x7x512xf32>
+    %429 = "ttir.relu"(%427, %428) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x7x7x512xf32>, tensor<1x7x7x512xf32>) -> tensor<1x7x7x512xf32>
+    %430 = tensor.empty() : tensor<1x7x7x2048xf32>
+    %431 = "ttir.conv2d"(%429, %arg156, %430) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x7x7x512xf32>, tensor<2048x512x1x1xf32>, tensor<1x7x7x2048xf32>) -> tensor<1x7x7x2048xf32>
+    %432 = tensor.empty() : tensor<1x7x2048x7xf32>
+    %433 = "ttir.transpose"(%431, %432) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x7x7x2048xf32>, tensor<1x7x2048x7xf32>) -> tensor<1x7x2048x7xf32>
+    %434 = tensor.empty() : tensor<1x2048x7x7xf32>
+    %435 = "ttir.transpose"(%433, %434) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x7x2048x7xf32>, tensor<1x2048x7x7xf32>) -> tensor<1x2048x7x7xf32>
+    %436 = tensor.empty() : tensor<1x2048x7x7xf32>
+    %437 = "ttir.multiply"(%435, %arg99, %436) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x2048x7x7xf32>, tensor<1x2048x1x1xf32>, tensor<1x2048x7x7xf32>) -> tensor<1x2048x7x7xf32>
+    %438 = tensor.empty() : tensor<1x2048x7x7xf32>
+    %439 = "ttir.add"(%437, %arg100, %438) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x2048x7x7xf32>, tensor<1x2048x1x1xf32>, tensor<1x2048x7x7xf32>) -> tensor<1x2048x7x7xf32>
+    %440 = tensor.empty() : tensor<1x2048x7x7xf32>
+    %441 = "ttir.add"(%439, %409, %440) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x2048x7x7xf32>, tensor<1x2048x7x7xf32>, tensor<1x2048x7x7xf32>) -> tensor<1x2048x7x7xf32>
+    %442 = tensor.empty() : tensor<1x2048x7x7xf32>
+    %443 = "ttir.relu"(%441, %442) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x2048x7x7xf32>, tensor<1x2048x7x7xf32>) -> tensor<1x2048x7x7xf32>
+    %444 = tensor.empty() : tensor<1x7x2048x7xf32>
+    %445 = "ttir.transpose"(%443, %444) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x2048x7x7xf32>, tensor<1x7x2048x7xf32>) -> tensor<1x7x2048x7xf32>
+    %446 = tensor.empty() : tensor<1x7x7x2048xf32>
+    %447 = "ttir.transpose"(%445, %446) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x7x2048x7xf32>, tensor<1x7x7x2048xf32>) -> tensor<1x7x7x2048xf32>
+    %448 = tensor.empty() : tensor<1x7x7x512xf32>
+    %449 = "ttir.conv2d"(%447, %arg157, %448) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x7x7x2048xf32>, tensor<512x2048x1x1xf32>, tensor<1x7x7x512xf32>) -> tensor<1x7x7x512xf32>
+    %450 = tensor.empty() : tensor<1x7x7x512xf32>
+    %451 = "ttir.multiply"(%449, %arg101, %450) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x7x7x512xf32>, tensor<1x1x1x512xf32>, tensor<1x7x7x512xf32>) -> tensor<1x7x7x512xf32>
+    %452 = tensor.empty() : tensor<1x7x7x512xf32>
+    %453 = "ttir.add"(%451, %arg102, %452) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x7x7x512xf32>, tensor<1x1x1x512xf32>, tensor<1x7x7x512xf32>) -> tensor<1x7x7x512xf32>
+    %454 = tensor.empty() : tensor<1x7x7x512xf32>
+    %455 = "ttir.relu"(%453, %454) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x7x7x512xf32>, tensor<1x7x7x512xf32>) -> tensor<1x7x7x512xf32>
+    %456 = tensor.empty() : tensor<1x7x7x512xf32>
+    %457 = "ttir.conv2d"(%455, %arg158, %456) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 1 : si32, padding_left = 1 : si32, padding_right = 1 : si32, padding_top = 1 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x7x7x512xf32>, tensor<512x512x3x3xf32>, tensor<1x7x7x512xf32>) -> tensor<1x7x7x512xf32>
+    %458 = tensor.empty() : tensor<1x7x7x512xf32>
+    %459 = "ttir.multiply"(%457, %arg103, %458) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x7x7x512xf32>, tensor<1x1x1x512xf32>, tensor<1x7x7x512xf32>) -> tensor<1x7x7x512xf32>
+    %460 = tensor.empty() : tensor<1x7x7x512xf32>
+    %461 = "ttir.add"(%459, %arg104, %460) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x7x7x512xf32>, tensor<1x1x1x512xf32>, tensor<1x7x7x512xf32>) -> tensor<1x7x7x512xf32>
+    %462 = tensor.empty() : tensor<1x7x7x512xf32>
+    %463 = "ttir.relu"(%461, %462) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x7x7x512xf32>, tensor<1x7x7x512xf32>) -> tensor<1x7x7x512xf32>
+    %464 = tensor.empty() : tensor<1x7x7x2048xf32>
+    %465 = "ttir.conv2d"(%463, %arg159, %464) <{dilation_height = 1 : si32, dilation_width = 1 : si32, groups = 1 : si32, padding_bottom = 0 : si32, padding_left = 0 : si32, padding_right = 0 : si32, padding_top = 0 : si32, stride_height = 1 : si32, stride_width = 1 : si32}> {channel_last = 1 : si32} : (tensor<1x7x7x512xf32>, tensor<2048x512x1x1xf32>, tensor<1x7x7x2048xf32>) -> tensor<1x7x7x2048xf32>
+    %466 = tensor.empty() : tensor<1x7x2048x7xf32>
+    %467 = "ttir.transpose"(%465, %466) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x7x7x2048xf32>, tensor<1x7x2048x7xf32>) -> tensor<1x7x2048x7xf32>
+    %468 = tensor.empty() : tensor<1x2048x7x7xf32>
+    %469 = "ttir.transpose"(%467, %468) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x7x2048x7xf32>, tensor<1x2048x7x7xf32>) -> tensor<1x2048x7x7xf32>
+    %470 = tensor.empty() : tensor<1x2048x7x7xf32>
+    %471 = "ttir.multiply"(%469, %arg105, %470) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x2048x7x7xf32>, tensor<1x2048x1x1xf32>, tensor<1x2048x7x7xf32>) -> tensor<1x2048x7x7xf32>
+    %472 = tensor.empty() : tensor<1x2048x7x7xf32>
+    %473 = "ttir.add"(%471, %arg106, %472) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x2048x7x7xf32>, tensor<1x2048x1x1xf32>, tensor<1x2048x7x7xf32>) -> tensor<1x2048x7x7xf32>
+    %474 = tensor.empty() : tensor<1x2048x7x7xf32>
+    %475 = "ttir.add"(%473, %443, %474) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x2048x7x7xf32>, tensor<1x2048x7x7xf32>, tensor<1x2048x7x7xf32>) -> tensor<1x2048x7x7xf32>
+    %476 = tensor.empty() : tensor<1x2048x7x7xf32>
+    %477 = "ttir.relu"(%475, %476) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x2048x7x7xf32>, tensor<1x2048x7x7xf32>) -> tensor<1x2048x7x7xf32>
+    %478 = tensor.empty() : tensor<1x1x2048x49xf32>
+    %479 = "ttir.reshape"(%477, %478) <{shape = [1 : i32, 1 : i32, 2048 : i32, 49 : i32]}> : (tensor<1x2048x7x7xf32>, tensor<1x1x2048x49xf32>) -> tensor<1x1x2048x49xf32>
+    %480 = tensor.empty() : tensor<1x1x49x2048xf32>
+    %481 = "ttir.transpose"(%479, %480) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x1x2048x49xf32>, tensor<1x1x49x2048xf32>) -> tensor<1x1x49x2048xf32>
+    %482 = tensor.empty() : tensor<1x1x1x2048xf32>
+    %483 = "ttir.mean"(%481, %482) <{dim_arg = [-2 : i32], keep_dim = true}> : (tensor<1x1x49x2048xf32>, tensor<1x1x1x2048xf32>) -> tensor<1x1x1x2048xf32>
+    %484 = tensor.empty() : tensor<1x1x2048x1xf32>
+    %485 = "ttir.transpose"(%483, %484) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x1x1x2048xf32>, tensor<1x1x2048x1xf32>) -> tensor<1x1x2048x1xf32>
+    %486 = tensor.empty() : tensor<1x2048x1xf32>
+    %487 = "ttir.squeeze"(%485, %486) <{dim = 0 : si32}> : (tensor<1x1x2048x1xf32>, tensor<1x2048x1xf32>) -> tensor<1x2048x1xf32>
+    %488 = tensor.empty() : tensor<1x2048xf32>
+    %489 = "ttir.squeeze"(%487, %488) <{dim = -1 : si32}> : (tensor<1x2048x1xf32>, tensor<1x2048xf32>) -> tensor<1x2048xf32>
+    %490 = tensor.empty() : tensor<1x1000xf32>
+    %491 = "ttir.matmul"(%489, %arg160, %490) : (tensor<1x2048xf32>, tensor<2048x1000xf32>, tensor<1x1000xf32>) -> tensor<1x1000xf32>
+    %492 = tensor.empty() : tensor<1x1000xf32>
+    %493 = "ttir.add"(%491, %arg161, %492) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x1000xf32>, tensor<1000xf32>, tensor<1x1000xf32>) -> tensor<1x1000xf32>
+    return %493 : tensor<1x1000xf32>
+  }
+}

--- a/test/ttmlir/EmitC/TTNN/tensor/repeat_interleave.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/repeat_interleave.mlir
@@ -1,0 +1,10 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
+// RUN: ttmlir-opt --ttnn-modify-signatures-for-dylib --convert-ttnn-to-emitc %t.mlir > %t2.mlir
+// RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
+
+func.func @repeat_interleave(%arg0: tensor<4x6xf32>) -> tensor<4x24xf32> {
+  %0 = tensor.empty() : tensor<4x24xf32>
+  %1 = "ttir.repeat_interleave"(%arg0, %0) {repeats = 4 : ui32, dim = 1 : si32} : (tensor<4x6xf32>, tensor<4x24xf32>) -> tensor<4x24xf32>
+  return %1 : tensor<4x24xf32>
+}

--- a/tools/ttnn-standalone/ci_compile_dylib.py
+++ b/tools/ttnn-standalone/ci_compile_dylib.py
@@ -145,7 +145,6 @@ def compile_shared_object(cpp_file_path, output_dir):
         destination_path = os.path.join(output_dir, output_file_name)
         shutil.copy2(compiled_so_path, destination_path)
         print(f"  Successfully copied compiled file to {destination_path}.")
-        os.remove(source_cpp_path)
     except subprocess.CalledProcessError as e:
         print(f"  Error during build process: {e}")
         print(e.stderr)

--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -13,6 +13,7 @@
 #include "operations/creation.hpp"
 #include "operations/data_movement/concat/concat.hpp"
 #include "operations/data_movement/repeat/repeat.hpp"
+#include "operations/data_movement/repeat_interleave/repeat_interleave.hpp"
 #include "operations/data_movement/transpose/transpose.hpp"
 #include "operations/eltwise/binary/binary.hpp"
 #include "operations/eltwise/binary/binary_composite.hpp"


### PR DESCRIPTION
### Ticket
Closes #2143

### Problem description
Add llama and resnet tests for emitc path.

### What's changed
- For llama, it was needed to tackle several issues:
  - `ttnn::repeat_interleave` support added thru emitc
  - Pass `--ttnn-create-input-gens` wasn't putting tensors on device when they were assumed on device by their layout desc, fixed that
- Added resnet test, currently unsupported, awaiting further op support
- Change the dylib compilation script `ci_compile_dylib.py` to not remove `ttnn-dylib.cpp` as it is useful for debugging - this is okay as the file is gitignored already

