### PR TITLE
Add workaround for strided slice operation

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -960,6 +960,15 @@ def TTNN_SliceOp: TTNN_NamedDPSOp<"slice"> {
 
     let extraClassDeclaration = [{
       MutableOperandRange getDpsInitsMutable() { return getOutputMutable(); }
+
+      wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
+        ttnn::TTNNLayoutAttr layoutAttr = mlir::cast<ttnn::TTNNLayoutAttr>(
+            getOutput().getType().getEncoding());
+        ::mlir::ArrayAttr begins = getBegins();
+        ::mlir::ArrayAttr step = getStep();
+        return wa::TTNNOperandsWorkaroundsFactory::
+            createSliceOpOperandsWorkarounds(layoutAttr, begins, step);
+      }
     }];
 
     let hasVerifier = 1;

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkarounds.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkarounds.h
@@ -239,6 +239,12 @@ public:
   static TTNNOperandsWorkarounds
   createConcatOpOperandsWorkarounds(mlir::Operation::operand_range inputs,
                                     int64_t numOperands, int32_t dim);
+
+  // Create workarounds for slice op operands.
+  static TTNNOperandsWorkarounds
+  createSliceOpOperandsWorkarounds(ttnn::TTNNLayoutAttr layoutAttr,
+                                   mlir::ArrayAttr begins,
+                                   mlir::ArrayAttr step);
 };
 
 } // namespace mlir::tt::ttnn::wa

--- a/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
@@ -424,8 +424,7 @@ private:
     }
 
     // These ops constrain to ROW_MAJOR on their operands
-    if (mlir::isa<ttir::Conv2dOp>(operation) ||
-        mlir::isa<ttir::SliceOp>(operation)) {
+    if (mlir::isa<ttir::Conv2dOp>(operation)) {
       return false;
     }
     return true;

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/slice_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/slice_workaround.mlir
@@ -1,0 +1,37 @@
+// RUN: ttmlir-opt --ttnn-workaround  %s | FileCheck %s
+
+#device = #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, d0 floordiv s0, d1 floordiv s1, (d0 mod s0) * s1 + d1 mod s1), dramMap = (d0, d1)[s0, s1] -> (0, 0, ((((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 8192) mod 12, (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 98304 + (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) mod 8192), meshShape = , chipIds = [0]>
+#dram = #ttnn.buffer_type<dram>
+#system_desc = #tt.system_desc<[{role = host, target_triple = "x86_64-pc-linux-gnu"}], [{arch = <wormhole_b0>, grid = 8x8, l1_size = 1499136, num_dram_channels = 12, dram_channel_size = 1073741824, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32, l1_unreserved_base = 1024, erisc_l1_unreserved_base = 1024, dram_unreserved_base = 1024, dram_unreserved_end = 1073741824, physical_cores = {worker = [ 0x0,  0x1,  0x2,  0x3,  0x4,  0x5,  0x6,  0x7,  1x0,  1x1,  1x2,  1x3,  1x4,  1x5,  1x6,  1x7,  2x0,  2x1,  2x2,  2x3,  2x4,  2x5,  2x6,  2x7,  3x0,  3x1,  3x2,  3x3,  3x4,  3x5,  3x6,  3x7,  4x0,  4x1,  4x2,  4x3,  4x4,  4x5,  4x6,  4x7,  5x0,  5x1,  5x2,  5x3,  5x4,  5x5,  5x6,  5x7,  6x0,  6x1,  6x2,  6x3,  6x4,  6x5,  6x6,  6x7,  7x0,  7x1,  7x2,  7x3,  7x4,  7x5,  7x6,  7x7] dram = [ 8x0,  9x0,  10x0,  8x1,  9x1,  10x1,  8x2,  9x2,  10x2,  8x3,  9x3,  10x3]}, supported_data_types = [<f32>, <f16>, <f32>, <bfp_f8>, <bfp_bf8>, <bfp_f4>, <bfp_bf4>, <bfp_f2>, <bfp_bf2>, <u32>, <u16>, <u8>], supported_tile_sizes = [ 4x16,  16x16,  32x16,  4x32,  16x32,  32x32], num_cbs = 32}], [0], [3 : i32], [ 0x0x0x0]>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<4x1x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+#ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 16 + d1, d2), <1x1>, memref<1x1x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+module attributes {tt.device = #device, tt.system_desc = #system_desc} {
+  func.func @test_strided_slice_workaround(%arg0: tensor<4x32x32xf32, #ttnn_layout>) -> tensor<2x16x8xf32, #ttnn_layout1> {
+    // CHECK-LABEL: @test_strided_slice_workaround(
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
+    // CHECK: %[[EMPTY:[0-9]+]] = "ttnn.empty"
+    // CHECK-SAME: layout = #ttnn.layout<tile>
+    %1 = "ttnn.empty"(%0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <<1x1>>, <interleaved>>, shape = #ttnn.shape<2x16x8>}> : (!tt.device<#device>) -> tensor<2x16x8xf32, #ttnn_layout1>
+    // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0,
+    // CHECK-SAME: dtype = #tt.supportedDataTypes<bf16>
+    // CHECK-SAME: tensor<4x32x32xf32
+    // CHECK-SAME: -> tensor<4x32x32xbf16
+    // CHECK: %[[ARG1:[0-9]+]] = "ttnn.to_layout"(%[[EMPTY]],
+    // CHECK-SAME: dtype = #tt.supportedDataTypes<bf16>
+    // CHECK-SAME: tensor<2x16x8xf32
+    // CHECK-SAME: -> tensor<2x16x8xbf16
+    // CHECK: %[[SLICE:[0-9]+]] = "ttnn.slice"(%[[ARG0]], %[[ARG1]])
+    // CHECK-SAME: begins = [0 : i32, 0 : i32, 0 : i32]
+    // CHECK-SAME: ends = [2 : i32, 16 : i32, 16 : i32]
+    // CHECK-SAME: step = [1 : i32, 1 : i32, 2 : i32]}
+    // CHECK-SAME: tensor<4x32x32xbf16
+    // CHECK-SAME: tensor<2x16x8xbf16
+    // CHECK-SAME: -> tensor<2x16x8xbf16
+    %2 = "ttnn.slice"(%arg0, %1) <{begins = [0 : i32, 0 : i32, 0 : i32], ends = [2 : i32, 16 : i32, 16 : i32], step = [1 : i32, 1 : i32, 2 : i32]}> : (tensor<4x32x32xf32, #ttnn_layout>, tensor<2x16x8xf32, #ttnn_layout1>) -> tensor<2x16x8xf32, #ttnn_layout1>
+    // CHECK: "ttnn.to_layout"(%[[SLICE]]
+    // CHECK-SAME: dtype = #tt.supportedDataTypes<f32>
+    // CHECK-SAME: tensor<2x16x8xbf16
+    // CHECK-SAME: -> tensor<2x16x8xf32
+    return %2 : tensor<2x16x8xf32, #ttnn_layout1>
+  }
+}

--- a/test/ttmlir/Silicon/StableHLO/n150/slice_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/slice_op.mlir
@@ -1,12 +1,12 @@
 // REQUIRES: stablehlo
 // RUN: rm -rf %t.ttnn
 // RUN: rm -rf %t.mlir
-// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s | \
-// RUN:     ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" > %t.mlir
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s \
+// RUN:     --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" > %t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 // RUN: FileCheck --input-file=%t.mlir %s
 
-module @jit_eltwise_subtract attributes {} {
+module @mod_slice attributes {} {
   func.func public @test_slice(%arg0: tensor<32x64xbf16>) -> tensor<8x8xbf16> {
     // CHECK-LABEL: func.func public @test_slice
     // CHECK: ttnn.empty
@@ -23,5 +23,73 @@ module @jit_eltwise_subtract attributes {} {
       strides = array<i64: 2, 2>
     } : (tensor<32x64xbf16>) -> tensor<8x8xbf16>
     return %result : tensor<8x8xbf16>
+  }
+
+  func.func public @test_slice_f32(%arg0: tensor<32x64xf32>) -> (tensor<16x16xf32>) {
+    // CHECK-LABEL: @test_slice_f32(
+    // CHECK: ttnn.empty
+    // CHECK: ttnn.slice
+    // CHECK-SAME: begins = [0 : i32, 16 : i32],
+    // CHECK-SAME: ends = [16 : i32, 32 : i32],
+    // CHECK-SAME: step = [1 : i32, 1 : i32]
+    // CHECK-SAME: tensor<32x64xf32
+    // CHECK-SAME: tensor<16x16xf32
+    // CHECK-SAME: -> tensor<16x16xf32
+    %0 = stablehlo.slice %arg0 [0:16, 16:32] : (tensor<32x64xf32>) -> tensor<16x16xf32>
+    return %0 : tensor<16x16xf32>
+  }
+
+  func.func public @test_slice_non_tilize(%arg0: tensor<32x64xf32>) -> (tensor<14x14xf32>) {
+    // CHECK-LABEL: @test_slice_non_tilize(
+    // CHECK: ttnn.empty
+    // CHECK: ttnn.slice
+    // CHECK-SAME: begins = [0 : i32, 16 : i32],
+    // CHECK-SAME: ends = [14 : i32, 30 : i32],
+    // CHECK-SAME: step = [1 : i32, 1 : i32]
+    // CHECK-SAME: tensor<32x64xf32
+    // CHECK-SAME: tensor<14x14xf32
+    // CHECK-SAME: -> tensor<14x14xf32
+    %0 = stablehlo.slice %arg0 [0:14, 16:30] : (tensor<32x64xf32>) -> tensor<14x14xf32>
+    return %0 : tensor<14x14xf32>
+  }
+
+  func.func public @test_slice_strided(%arg0: tensor<32x64xf32>) -> (tensor<8x8xf32>) {
+    // CHECK-LABEL: @test_slice_strided(
+    // CHECK: ttnn.empty
+    // CHECK: ttnn.slice
+    // CHECK-SAME: begins = [0 : i32, 16 : i32],
+    // CHECK-SAME: ends = [16 : i32, 32 : i32],
+    // CHECK-SAME: step = [2 : i32, 2 : i32]
+    // CHECK-SAME: tensor<32x64xbf16
+    // CHECK-SAME: tensor<8x8xbf16
+    // CHECK-SAME: -> tensor<8x8xbf16
+    %0 = stablehlo.slice %arg0 [0:16:2, 16:32:2] : (tensor<32x64xf32>) -> tensor<8x8xf32>
+    return %0 : tensor<8x8xf32>
+  }
+
+  func.func @test_slice_strided_f32(%arg0: tensor<1x128x128x192xf32>) -> tensor<1x64x128x192xf32> {
+    // CHECK-LABEL: @test_slice_strided_f32(
+    // CHECK: ttnn.empty
+    // CHECK: ttnn.typecast
+    // CHECK-SAME: dtype = #tt.supportedDataTypes<bf16>
+    // CHECK-SAME: tensor<1x128x128x192xf32
+    // CHECK-SAME:-> tensor<1x128x128x192xbf16
+    // CHECK: ttnn.typecast
+    // CHECK-SAME: dtype = #tt.supportedDataTypes<bf16>
+    // CHECK-SAME: tensor<1x64x128x192xf32
+    // CHECK-SAME: -> tensor<1x64x128x192xbf16
+    // CHECK: ttnn.slice
+    // CHECK-SAME: begins = [0 : i32, 0 : i32, 0 : i32, 0 : i32],
+    // CHECK-SAME: ends = [1 : i32, 128 : i32, 128 : i32, 192 : i32],
+    // CHECK-SAME: step = [1 : i32, 2 : i32, 1 : i32, 1 : i32]
+    // CHECK-SAME: tensor<1x128x128x192xbf16
+    // CHECK-SAME: tensor<1x64x128x192xbf16
+    // CHECK-SAME: -> tensor<1x64x128x192xbf16
+    %0 = stablehlo.slice %arg0 [0:1, 0:128:2, 0:128, 0:192] : (tensor<1x128x128x192xf32>) -> tensor<1x64x128x192xf32>
+    // CHECK: ttnn.typecast
+    // CHECK-SAME: dtype = #tt.supportedDataTypes<f32>
+    // CHECK-SAME: tensor<1x64x128x192xbf16
+    // CHECK-SAME: -> tensor<1x64x128x192xf32
+    return %0 : tensor<1x64x128x192xf32>
   }
 }


### PR DESCRIPTION
* Strided slice can only work with bfloat16 tensor
closes #1453 
closes #2150 

### Ticket
#1453 
#2150 

### Problem description
tt-metal supports strided slice operation for bfloat16 data type

### What's changed
Added a layout workaround for converting data type to bfloat16 in case of strided slice operation.

### Checklist
- [X] New tests provide coverage for changes
