### PR TITLE
Uplift third_party/tt-metal to 38578b33849c41ad70f5375856d736bc77239b8c 2025-02-10

### DIFF
--- a/runtime/lib/ttnn/operations/data_movement/pad.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/pad.cpp
@@ -33,8 +33,8 @@ void run(const ::tt::target::ttnn::PadOp *op, ProgramContext &context) {
                    : std::nullopt;
 
   if (workaround::Env::get().usePaddingPairSignatureWithQueueId) {
-    out = ::ttnn::pad(0, in, padding, padValue, op->use_multicore(),
-                      outputMemoryConfig);
+    out = ::ttnn::pad(::ttnn::DefaultQueueId, in, padding, padValue,
+                      op->use_multicore(), outputMemoryConfig);
   } else {
     LOG_FATAL("Currently, the only ::ttnn::pad signature which supports "
               "padding pairs as input has queue_id in its signature. The only "

--- a/runtime/lib/ttnn/operations/pool/maxpool2d.cpp
+++ b/runtime/lib/ttnn/operations/pool/maxpool2d.cpp
@@ -64,13 +64,14 @@ void run(const ::tt::target::ttnn::MaxPool2dOp *op, ProgramContext &context) {
   }
   ::ttnn::MemoryConfig outMemConfig =
       ::tt::runtime::ttnn::utils::createMemoryConfig(op->out());
-  ::ttnn::Tensor out = operation.invoke(
-      0, input, op->batch_size(), op->input_height(), op->input_width(),
-      op->channels(), {op->kernel_height(), op->kernel_width()},
-      {op->stride_height(), op->stride_width()},
-      {op->padding_height(), op->padding_width()},
-      {op->dilation_height(), op->dilation_width()}, outMemConfig,
-      std::nullopt);
+  ::ttnn::Tensor out =
+      operation.invoke(::ttnn::DefaultQueueId, input, op->batch_size(),
+                       op->input_height(), op->input_width(), op->channels(),
+                       {op->kernel_height(), op->kernel_width()},
+                       {op->stride_height(), op->stride_width()},
+                       {op->padding_height(), op->padding_width()},
+                       {op->dilation_height(), op->dilation_width()},
+                       outMemConfig, std::nullopt);
 
   tensorPool.insert_or_assign(op->out()->global_id(), out);
 }

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "b552fb8ae14236777983e3521a312dd78432f0e1")
+set(TT_METAL_VERSION "38578b33849c41ad70f5375856d736bc77239b8c")
 
 if ("$ENV{ARCH_NAME}" STREQUAL "grayskull")
   set(ARCH_NAME "grayskull")

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -32,6 +32,7 @@ set(TTMETAL_INCLUDE_DIRS
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/umd/src/firmware/riscv/${ARCH_NAME}
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/tracy/public
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/taskflow
+  ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/tt_stl
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_eager
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal-build/include
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/reflect/e75434c4c5f669e4a74e4d84e0a30d7249c1e66f

--- a/tools/ttnn-standalone/CMakeLists.txt
+++ b/tools/ttnn-standalone/CMakeLists.txt
@@ -71,6 +71,7 @@ set(INCLUDE_DIRS
     $ENV{TT_METAL_HOME}/tt_metal/hw/inc/${ARCH_EXTRA_DIR}
     $ENV{TT_METAL_HOME}/tt_metal/hw/inc/${ARCH_NAME}
     $ENV{TT_METAL_HOME}/tt_metal/include
+    $ENV{TT_METAL_HOME}/tt_metal/tt_stl
     $ENV{TT_METAL_HOME}/tt_metal/third_party/fmt
     $ENV{TT_METAL_HOME}/tt_metal/third_party/magic_enum
     $ENV{TT_METAL_HOME}/tt_metal/third_party/taskflow


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 38578b33849c41ad70f5375856d736bc77239b8c

- Use strongly typed QueueID after metal commit 14f9739