### PR TITLE
Skip op verification in opDebugString

### DIFF
--- a/include/ttmlir/Target/Utils/FuncOpToProgram.h
+++ b/include/ttmlir/Target/Utils/FuncOpToProgram.h
@@ -68,7 +68,8 @@ Program<OpT> funcOpToProgram(FlatbufferObjectCache &cache, func::FuncOp entry,
   printFlags = printFlags.elideLargeElementsAttrs()
                    .elideLargeResourceString()
                    .skipRegions()
-                   .enableDebugInfo();
+                   .enableDebugInfo()
+                   .assumeVerified();
 
   Program<OpT> program;
   program.name = entry.getSymName().data();


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/2156

### Problem description
As described here https://github.com/tenstorrent/tt-mlir/pull/1782 `getOpDebugString` was taking more than 99% of the time of `ttmlir-translate -ttnn-to-flatbuffer` execution. From that time, 99% was spent on op verification.

### What's changed
- added `assumeVefied()` to `printFlags` that are used for printing ops (the way we are running our pipelines I believe this is a safe assumption)
- greatly lowers TTNN->Flatbuffer compile time (on LlamaPrefill example from https://github.com/tenstorrent/tt-mlir/pull/2144) compile time was lowered from ~70s -> ~1.5s (around 0.8s was spent on op printing)

### Checklist
- [ ] New/Existing tests provide coverage for changes
