### PR TITLE
Add support for stablehlo.reduce op for logical or operator

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -806,6 +806,28 @@ def TTIR_ReduceAndOp : TTIR_ReductionOp<"reduce_and"> {
     }];
 }
 
+def TTIR_ReduceOrOp : TTIR_ReductionOp<"reduce_or"> {
+    let summary = "Or reduction op.";
+    let description = [{
+      Reduces a given tensor using logical or operator along the given dimension(s).
+
+      Example:
+        input: [[True,  False, False, False],
+                [True,  True,  False, True],
+                [False, False, False, True],
+                [False, False, False, False]]
+
+        // Reduction along dim 0
+        output: [True, True, False, True]
+
+        // Reduction along dim 1
+        output: [True, True, True, False]
+
+        // Reduction for both dimensions (entire tensor)
+        output: [True]
+    }];
+}
+
 def TTIR_ProdOp : TTIR_ReductionOp<"prod"> {
   let summary = "Product reduction op.";
   let description = [{

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecompositionPass.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecompositionPass.cpp
@@ -54,6 +54,7 @@ struct TTIRToTTIRDecompositionPass
     target.addIllegalOp<ttir::SelectOp>();
     target.addIllegalOp<ttir::DotGeneralOp>();
     target.addIllegalOp<ttir::ReduceAndOp>();
+    target.addIllegalOp<ttir::ReduceOrOp>();
 
     // These are the ops that must satisfy some conditions after this pass
     target.addDynamicallyLegalOp<ttir::ArangeOp>([&](ttir::ArangeOp op) {

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -2564,6 +2564,22 @@ void mlir::tt::ttir::ReduceAndOp::buildGenericRegion(
 }
 
 //===----------------------------------------------------------------------===//
+// ReduceOrOp
+//===----------------------------------------------------------------------===//
+
+// ReduceOrOp kernel builder.
+void mlir::tt::ttir::ReduceOrOp::buildGenericRegion(
+    ::mlir::OpBuilder &opBuilder, ::mlir::Block *block) {
+  // NOLINTNEXTLINE
+  createReduceOp(opBuilder, block, getLoc(), "or");
+}
+
+// ReduceOrOp verification.
+::mlir::LogicalResult mlir::tt::ttir::ReduceOrOp::verify() {
+  return verifyReduceOp(getOperation(), getInput().getType(), getDimArg());
+}
+
+//===----------------------------------------------------------------------===//
 // Reduce ArgMaxOp
 //===----------------------------------------------------------------------===//
 

--- a/test/ttmlir/Conversion/StableHLOToTTIR/reduction/reduce_or_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/reduction/reduce_or_op.mlir
@@ -1,0 +1,39 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s | FileCheck %s
+module @jit_reduce_or attributes {} {
+  func.func public @test_reduce_or_4to3dim(%arg0: tensor<128x10x32x4xi1>, %cst_0: tensor<i1>) -> tensor<128x10x32xi1> {
+    // CHECK-LABEL: func.func public @test_reduce_or_4to3dim
+    // CHECK: tensor.empty
+    // CHECK: "ttir.reduce_or"
+    // CHECK-SAME: dim_arg = [3 : i32]
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x32x4xbf16>
+    // CHECK-SAME: -> tensor<128x10x32xbf16>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.or across dimensions = [3] : (tensor<128x10x32x4xi1>, tensor<i1>) -> tensor<128x10x32xi1>
+    return %0 : tensor<128x10x32xi1>
+  }
+
+  func.func public @test_reduce_or_3to2dim(%arg0: tensor<128x10x4xi1>, %cst_0: tensor<i1>) -> tensor<128x4xi1> {
+    // CHECK-LABEL: func.func public @test_reduce_or_3to2dim
+    // CHECK: tensor.empty
+    // CHECK: "ttir.reduce_or"
+    // CHECK-SAME: dim_arg = [1 : i32]
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x4xbf16>
+    // CHECK-SAME: -> tensor<128x4xbf16>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.or across dimensions = [1] : (tensor<128x10x4xi1>, tensor<i1>) -> tensor<128x4xi1>
+    return %0 : tensor<128x4xi1>
+  }
+
+  func.func public @test_reduce_or_2to1dim(%arg0: tensor<128x10xi1>, %cst_0: tensor<i1>) -> tensor<10xi1> {
+    // CHECK-LABEL: func.func public @test_reduce_or_2to1dim
+    // CHECK: tensor.empty
+    // CHECK: "ttir.reduce_or"
+    // CHECK-SAME: dim_arg = [0 : i32]
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10xbf16>
+    // CHECK-SAME: -> tensor<10xbf16>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.or across dimensions = [0] : (tensor<128x10xi1>, tensor<i1>) -> tensor<10xi1>
+    return %0 : tensor<10xi1>
+  }
+}

--- a/test/ttmlir/Decomposition/TTIR/reduction/reduce_or.mlir
+++ b/test/ttmlir/Decomposition/TTIR/reduction/reduce_or.mlir
@@ -1,0 +1,41 @@
+// RUN: ttmlir-opt --ttir-to-ttir-decomposition %s | FileCheck %s
+module attributes {} {
+  func.func public @test_reduce_or_4to3dim(%arg0: tensor<128x10x32x4xbf16>, %arg1: tensor<1xbf16>) -> tensor<128x10x32xbf16> {
+    // CHECK-LABEL: func.func public @test_reduce_or_4to3dim
+    // CHECK: %[[SUM:[0-9]+]] = "ttir.sum"
+    // CHECK-SAME: dim_arg = [3 : i32]
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x32x4xbf16>
+    // CHECK-SAME: -> tensor<128x10x32xbf16>
+    // CHECK: return %[[SUM]]
+    %0 = tensor.empty() : tensor<128x10x32xbf16>
+    %1 = "ttir.reduce_or"(%arg0, %0) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<128x10x32x4xbf16>, tensor<128x10x32xbf16>) -> tensor<128x10x32xbf16>
+    return %1 : tensor<128x10x32xbf16>
+  }
+
+  func.func public @test_reduce_or_3to2dim(%arg0: tensor<128x10x4xbf16>, %arg1: tensor<1xbf16>) -> tensor<128x4xbf16> {
+    // CHECK-LABEL: func.func public @test_reduce_or_3to2dim
+    // CHECK: %[[SUM:[0-9]+]] = "ttir.sum"
+    // CHECK-SAME: dim_arg = [1 : i32]
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x4xbf16>
+    // CHECK-SAME: -> tensor<128x4xbf16>
+    // CHECK: return %[[SUM]]
+    %0 = tensor.empty() : tensor<128x4xbf16>
+    %1 = "ttir.reduce_or"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x10x4xbf16>, tensor<128x4xbf16>) -> tensor<128x4xbf16>
+    return %1 : tensor<128x4xbf16>
+  }
+
+  func.func public @test_reduce_or_2to1dim(%arg0: tensor<128x10xbf16>, %arg1: tensor<1xbf16>) -> tensor<10xbf16> {
+    // CHECK-LABEL: func.func public @test_reduce_or_2to1dim
+    // CHECK: %[[SUM:[0-9]+]] = "ttir.sum"
+    // CHECK-SAME: dim_arg = [0 : i32]
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10xbf16>
+    // CHECK-SAME: -> tensor<10xbf16>
+    // CHECK: return %[[SUM]]
+    %0 = tensor.empty() : tensor<10xbf16>
+    %1 = "ttir.reduce_or"(%arg0, %0) <{dim_arg = [0 : i32], keep_dim = false}> : (tensor<128x10xbf16>, tensor<10xbf16>) -> tensor<10xbf16>
+    return %1 : tensor<10xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/reduction/simple_reduce_or.mlir
+++ b/test/ttmlir/Dialect/TTNN/reduction/simple_reduce_or.mlir
@@ -1,0 +1,39 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
+
+module attributes {} {
+  func.func public @test_reduce_or_4to3dim(%arg0: tensor<128x10x32x4xbf16>, %arg1: tensor<1xbf16>) -> tensor<128x10x32xbf16> {
+    // CHECK-LABEL: func.func public @test_reduce_or_4to3dim
+    // CHECK: %[[SUM:[0-9]+]] = "ttnn.sum"
+    // CHECK-SAME: dim_arg = [3 : i32]
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x32x4xbf16,
+    // CHECK-SAME: -> tensor<128x10x32xbf16,
+    %0 = tensor.empty() : tensor<128x10x32xbf16>
+    %1 = "ttir.reduce_or"(%arg0, %0) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<128x10x32x4xbf16>, tensor<128x10x32xbf16>) -> tensor<128x10x32xbf16>
+    return %1 : tensor<128x10x32xbf16>
+  }
+
+  func.func public @test_reduce_or_3to2dim(%arg0: tensor<128x10x4xbf16>, %arg1: tensor<1xbf16>) -> tensor<128x4xbf16> {
+    // CHECK-LABEL: func.func public @test_reduce_or_3to2dim
+    // CHECK: %[[SUM:[0-9]+]] = "ttnn.sum"
+    // CHECK-SAME: dim_arg = [1 : i32]
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x4xbf16,
+    // CHECK-SAME: -> tensor<128x4xbf16,
+    %0 = tensor.empty() : tensor<128x4xbf16>
+    %1 = "ttir.reduce_or"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x10x4xbf16>, tensor<128x4xbf16>) -> tensor<128x4xbf16>
+    return %1 : tensor<128x4xbf16>
+  }
+
+  func.func public @test_reduce_or_2to1dim(%arg0: tensor<128x10xbf16>, %arg1: tensor<1xbf16>) -> tensor<10xbf16> {
+    // CHECK-LABEL: func.func public @test_reduce_or_2to1dim
+    // CHECK: %[[SUM:[0-9]+]] = "ttnn.sum"
+    // CHECK-SAME: dim_arg = [0 : i32]
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10xbf16,
+    // CHECK-SAME: -> tensor<10xbf16,
+    %0 = tensor.empty() : tensor<10xbf16>
+    %1 = "ttir.reduce_or"(%arg0, %0) <{dim_arg = [0 : i32], keep_dim = false}> : (tensor<128x10xbf16>, tensor<10xbf16>) -> tensor<10xbf16>
+    return %1 : tensor<10xbf16>
+  }
+}

--- a/test/ttmlir/Silicon/StableHLO/n150/reduction/reduce_or_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/reduction/reduce_or_op.mlir
@@ -1,0 +1,19 @@
+// REQUIRES: stablehlo
+// RUN: rm -rf %t.ttnn
+// RUN: rm -rf %t.mlir
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline \
+// RUN:     --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+// RUN: FileCheck --input-file=%t.mlir %s
+
+module @jit_reduce_add attributes {} {
+  func.func public @test_reduce_or_4to3dim(%arg0: tensor<128x10x32x4xi1>, %cst_0: tensor<i1>) -> tensor<128x10x32xi1> {
+    // CHECK-LABEL: func.func public @test_reduce_or_4to3dim
+    // CHECK: "ttnn.sum"
+    // CHECK-SAME: dim_arg = [3 : i32]
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: -> tensor<128x10x32xbf16,
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.or across dimensions = [3] : (tensor<128x10x32x4xi1>, tensor<i1>) -> tensor<128x10x32xi1>
+    return %0 : tensor<128x10x32xi1>
+  }
+}

--- a/test/ttmlir/Silicon/TTNN/n150/simple_reduce_or.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_reduce_or.mlir
@@ -1,0 +1,43 @@
+// RUN: rm -rf %t.ttnn
+// RUN: rm -rf %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+
+module attributes {} {
+  func.func public @test_reduce_or_4to2dim(%arg0: tensor<128x10x32x4xbf16>, %arg1: tensor<1xbf16>) -> tensor<128x32xbf16> {
+    // CHECK-LABEL: func.func public @test_reduce_or_4to2dim
+    // CHECK: %[[SUM:[0-9]+]] = "ttnn.sum"
+    // CHECK-SAME: dim_arg = [1 : i32, 3 : i32]
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x32x4xbf16,
+    // CHECK-SAME: -> tensor<128x32xbf16,
+    %0 = tensor.empty() : tensor<128x32xbf16>
+    %1 = "ttir.reduce_or"(%arg0, %0) <{dim_arg = [1: i32, 3 : i32], keep_dim = false}> : (tensor<128x10x32x4xbf16>, tensor<128x32xbf16>) -> tensor<128x32xbf16>
+    return %1 : tensor<128x32xbf16>
+  }
+
+  func.func public @test_reduce_or_3to2dim(%arg0: tensor<128x10x4xbf16>, %arg1: tensor<1xbf16>) -> tensor<128x4xbf16> {
+    // CHECK-LABEL: func.func public @test_reduce_or_3to2dim
+    // CHECK: %[[SUM:[0-9]+]] = "ttnn.sum"
+    // CHECK-SAME: dim_arg = [1 : i32]
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10x4xbf16,
+    // CHECK-SAME: -> tensor<128x4xbf16,
+    %0 = tensor.empty() : tensor<128x4xbf16>
+    %1 = "ttir.reduce_or"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x10x4xbf16>, tensor<128x4xbf16>) -> tensor<128x4xbf16>
+    return %1 : tensor<128x4xbf16>
+  }
+
+  func.func public @test_reduce_or_2to1dim(%arg0: tensor<128x10xbf16>, %arg1: tensor<1xbf16>) -> tensor<10xbf16> {
+    // CHECK-LABEL: func.func public @test_reduce_or_2to1dim
+    // CHECK: %[[SUM:[0-9]+]] = "ttnn.sum"
+    // CHECK-SAME: dim_arg = [0 : i32]
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x10xbf16,
+    // CHECK-SAME: -> tensor<10xbf16,
+    %0 = tensor.empty() : tensor<10xbf16>
+    %1 = "ttir.reduce_or"(%arg0, %0) <{dim_arg = [0 : i32], keep_dim = false}> : (tensor<128x10xbf16>, tensor<10xbf16>) -> tensor<10xbf16>
+    return %1 : tensor<10xbf16>
+  }
+}


### PR DESCRIPTION
TTNN does not support reduction for logical or operator. So stablehlo.reduce for stablehlo.or operator is decomposed into reduction sum op along give dimension. If ttnn.sum output is zero then reduce_or output is false; otherwise the output is true.

closes #1143 

### Ticket
#1143 

### Problem description
Add support for reduction operation for logical or operator

### What's changed
- `ttir.reduce_or` op is added in TTIR dialect
- `ttir.reduce_or` op is decomposed/converted to `ttir.sum` op as tt-metal does not support reduction or operation.
- Stablehlo conversion for reduce or op.

### Checklist
- [X] New tests provide coverage for changes
