### PR TITLE
Add type conversion pattern for empty op

### DIFF
--- a/include/ttmlir/Conversion/StableHLOToTTIR/EmptyOpTypeConversion.h
+++ b/include/ttmlir/Conversion/StableHLOToTTIR/EmptyOpTypeConversion.h
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_CONVERSION_STABLEHLOTOTTIR_EMPTYOPTYPECONVERSION_H
+#define TTMLIR_CONVERSION_STABLEHLOTOTTIR_EMPTYOPTYPECONVERSION_H
+
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir::tt {
+
+#ifdef TTMLIR_ENABLE_STABLEHLO
+void addEmptyOpTypeConversionPattern(MLIRContext *ctx,
+                                     RewritePatternSet &patterns,
+                                     TypeConverter &typeConverter);
+#endif
+
+} // namespace mlir::tt
+
+#endif // TTMLIR_CONVERSION_STABLEHLOTOTTIR_EMPTYOPTYPECONVERSION_H

--- a/lib/Conversion/StableHLOToTTIR/CMakeLists.txt
+++ b/lib/Conversion/StableHLOToTTIR/CMakeLists.txt
@@ -6,10 +6,11 @@ include_directories(${TTMLIR_SOURCE_DIR}/include)
 include_directories(${PROJECT_SOURCE_DIR}/include)
 
 add_mlir_library(TTMLIRStableHLOToTTIR
+  ArithToStableHLOPass.cpp
+  EmptyOpTypeConversion.cpp
+  ShardingUtils.cpp
   StableHLOToTTIRPatterns.cpp
   StableHLOToTTIRPass.cpp
-  ArithToStableHLOPass.cpp
-  ShardingUtils.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${PROJECT_SOURCE_DIR}/include/ttmlir/Conversion/StableHLOToTTIR

--- a/lib/Conversion/StableHLOToTTIR/EmptyOpTypeConversion.cpp
+++ b/lib/Conversion/StableHLOToTTIR/EmptyOpTypeConversion.cpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Conversion/StableHLOToTTIR/EmptyOpTypeConversion.h"
+
+#include <mlir/Dialect/Tensor/IR/Tensor.h>
+
+using namespace mlir;
+using namespace mlir::tt;
+
+namespace {
+class EmptyOpTypeConversionPattern
+    : public OpConversionPattern<mlir::tensor::EmptyOp> {
+
+  using OpConversionPattern<mlir::tensor::EmptyOp>::OpConversionPattern;
+
+public:
+  LogicalResult
+  matchAndRewrite(mlir::tensor::EmptyOp srcOp,
+                  mlir::tensor::EmptyOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    RankedTensorType inputType = mlir::cast<RankedTensorType>(
+        getTypeConverter()->convertType(srcOp.getType()));
+    rewriter.replaceOpWithNewOp<mlir::tensor::EmptyOp>(
+        srcOp, inputType.getShape(), inputType.getElementType(),
+        inputType.getEncoding());
+
+    return success();
+  }
+};
+} // namespace
+
+namespace mlir::tt {
+void addEmptyOpTypeConversionPattern(MLIRContext *ctx,
+                                     RewritePatternSet &patterns,
+                                     TypeConverter &typeConverter) {
+  patterns.add<EmptyOpTypeConversionPattern>(typeConverter, ctx);
+}
+} // namespace mlir::tt

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPass.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPass.cpp
@@ -19,6 +19,7 @@
 #include <shardy/dialect/sdy/ir/dialect.h>
 #include <stablehlo/dialect/StablehloOps.h>
 
+#include "ttmlir/Conversion/StableHLOToTTIR/EmptyOpTypeConversion.h"
 #include "ttmlir/Dialect/TT/IR/TT.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIR.h"
 
@@ -120,6 +121,10 @@ struct ConvertStableHLOToTTIRPass
     populateCallOpTypeConversionPattern(patterns, typeConverter);
     target.addDynamicallyLegalOp<func::CallOp>(
         [&](func::CallOp op) { return typeConverter.isLegal(op); });
+
+    addEmptyOpTypeConversionPattern(&getContext(), patterns, typeConverter);
+    target.addDynamicallyLegalOp<tensor::EmptyOp>(
+        [&](tensor::EmptyOp op) { return typeConverter.isLegal(op); });
 
     populateStableHLOToTTIRPatterns(&getContext(), patterns, typeConverter);
     // Apply conversion.

--- a/test/ttmlir/Conversion/StableHLOToTTIR/empty_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/empty_op.mlir
@@ -1,0 +1,10 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s | FileCheck %s
+module @module_empty {
+  func.func @test_empty_boolean() -> tensor<1xi1> {
+    // CHECK: %[[EMPTY:[0-9]+]] = tensor.empty() : tensor<1xbf16>
+    %0 = tensor.empty() : tensor<1xi1>
+    // CHECK:     return %[[EMPTY]] : tensor<1xbf16>
+    return %0 : tensor<1xi1>
+  }
+}


### PR DESCRIPTION
Stablehlo to TTIR conversion uses a customized type convertor. Use the same type convertor for tensor::empty op as well to ensure consistency.

closes #2161 

### Ticket
#2161 

### Problem description
Stablehlo to TTIR conversion pass apply custom pass to convert unsupported data types to supported data types. which is not applied to tensor::emptyop. This causes stablehlo to TTIR conversion to fail for empty op with unsupported data types.

### What's changed
Add a conversion pattern for tensor::emptyop to apply custom type convertor and match the output with stablehlo to TTIR conversion pass.

### Checklist
- [X] New tests provide coverage for changes
