### PR TITLE
Remove reduce op workaround for full tensor reduction

### DIFF
--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkarounds.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkarounds.cpp
@@ -433,14 +433,6 @@ public:
                        ttnn::MeanOp, /*keepDimUnsupported*/ false>,
                    workarounds::decomposition::ReduceOpsKeepDimRewritePattern<
                        ttnn::MinOp, /*keepDimUnsupported*/ false>,
-                   workarounds::decomposition::ReduceOpsAllDimsRewritePattern<
-                       ttnn::SumOp>,
-                   workarounds::decomposition::ReduceOpsAllDimsRewritePattern<
-                       ttnn::MaxOp>,
-                   workarounds::decomposition::ReduceOpsAllDimsRewritePattern<
-                       ttnn::MeanOp>,
-                   workarounds::decomposition::ReduceOpsAllDimsRewritePattern<
-                       ttnn::MinOp>,
                    workarounds::decomposition::CumSumOpRewritePattern>(
           &getContext());
 

--- a/test/ttmlir/Silicon/StableHLO/n150/reduction/reduce_add_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/reduction/reduce_add_op.mlir
@@ -8,7 +8,7 @@
 module @jit_reduce_add attributes {} {
   func.func public @test_reduce_add_4to0dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: "ttnn.sum"
-    // CHECK-NOT: dim_arg
+    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32, 3 : i32]
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128x10x32x4xf32,
     // CHECK-SAME: -> tensor<1x1x1x1xf32,
@@ -41,7 +41,7 @@ module @jit_reduce_add attributes {} {
 
   func.func public @test_reduce_add_3to0dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: "ttnn.sum"
-    // CHECK-NOT: dim_arg
+    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32]
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128x10x4xf32,
     // CHECK-SAME: -> tensor<1x1x1xf32,
@@ -64,7 +64,7 @@ module @jit_reduce_add attributes {} {
 
   func.func public @test_reduce_add_2to0dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: "ttnn.sum"
-    // CHECK-NOT: dim_arg
+    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32]
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128x10xf32,
     // CHECK-SAME: -> tensor<1x1xf32,
@@ -77,7 +77,7 @@ module @jit_reduce_add attributes {} {
 
   func.func public @test_reduce_add_1to0dim(%arg0: tensor<128xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: "ttnn.sum"
-    // CHECK-NOT: dim_arg
+    // CHECK-SAME: dim_arg = [0 : i32]
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128xf32,
     // CHECK-SAME: -> tensor<1xf32,

--- a/test/ttmlir/Silicon/StableHLO/n150/reduction/reduce_maximum_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/reduction/reduce_maximum_op.mlir
@@ -8,7 +8,7 @@
 module @jit_reduce_maximum attributes {} {
   func.func public @test_reduce_maximum_4to0dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: "ttnn.max"
-    // CHECK-NOT: dim_arg
+    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32, 3 : i32]
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128x10x32x4xf32,
     // CHECK-SAME: -> tensor<1x1x1x1xf32,
@@ -41,7 +41,7 @@ module @jit_reduce_maximum attributes {} {
 
   func.func public @test_reduce_maximum_3to0dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: "ttnn.max"
-    // CHECK-NOT: dim_arg
+    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32]
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128x10x4xf32,
     // CHECK-SAME: -> tensor<1x1x1xf32,
@@ -64,7 +64,7 @@ module @jit_reduce_maximum attributes {} {
 
   func.func public @test_reduce_maximum_2to0dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: "ttnn.max"
-    // CHECK-NOT: dim_arg
+    // CHECK-SAME: dim_arg = [0 : i32, 1 : i32]
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128x10xf32,
     // CHECK-SAME: -> tensor<1x1xf32,
@@ -77,7 +77,7 @@ module @jit_reduce_maximum attributes {} {
 
   func.func public @test_reduce_maximum_1to0dim(%arg0: tensor<128xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: "ttnn.max"
-    // CHECK-NOT: dim_arg
+    // CHECK-SAME: dim_arg = [0 : i32]
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128xf32,
     // CHECK-SAME: -> tensor<1xf32,

--- a/test/ttmlir/Silicon/StableHLO/n150/reduction/reduce_min_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/reduction/reduce_min_op.mlir
@@ -9,7 +9,7 @@
 module @jit_reduce_minimum attributes {} {
   func.func public @test_reduce_minimum_4to0dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: "ttnn.min"
-    // CHECK-NOT: dim_arg
+    // CEHCK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32, 3 : i32]
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128x10x32x4xf32,
     // CHECK-SAME: -> tensor<1x1x1x1xf32,
@@ -43,7 +43,7 @@ module @jit_reduce_minimum attributes {} {
 
   func.func public @test_reduce_minimum_3to0dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: "ttnn.min"
-    // CHECK-NOT: dim_arg
+    // CEHCK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32]
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128x10x4xf32,
     // CHECK-SAME: -> tensor<1x1x1xf32,
@@ -67,7 +67,7 @@ module @jit_reduce_minimum attributes {} {
 
   func.func public @test_reduce_minimum_2to0dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: "ttnn.min"
-    // CHECK-NOT: dim_arg
+    // CEHCK-SAME: dim_arg = [0 : i32, 1 : i32]
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128x10xf32,
     // CHECK-SAME: -> tensor<1x1xf32,
@@ -81,7 +81,7 @@ module @jit_reduce_minimum attributes {} {
 
   func.func public @test_reduce_minimum_1to0dim(%arg0: tensor<128xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: "ttnn.min"
-    // CHECK-NOT: dim_arg
+    // CEHCK-SAME: dim_arg = [0 : i32]
     // CHECK-SAME: keep_dim = true
     // CHECK-SAME: tensor<128xf32,
     // CHECK-SAME: -> tensor<1xf32,

--- a/test/ttmlir/Silicon/TTNN/n150/simple_sum.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_sum.mlir
@@ -3,10 +3,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-// These tests are currently failing until a fix for this issue is uplifted
-// with new version of Metal: https://github.com/tenstorrent/tt-metal/issues/16104
-// TODO(mrakita): Enable and edit these tests after the Metal issue is fixed.
-// Tracked by: https://github.com/tenstorrent/tt-mlir/issues/1640
 
 module {
   func.func public @reduce_not_keep_dim(%arg0: tensor<128x10xf32>) -> tensor<128xf32> {


### PR DESCRIPTION
closes #1624 

### Ticket
#1624 

### Problem description
TTNN workaround was added to handle tt-metal issue (https://github.com/tenstorrent/tt-metal/issues/16118). This issue is resolved now.

### What's changed
TTNN workaround removed.

### Checklist
- [X] Existing tests provide coverage for changes
