### PR TITLE
make release tag discovery more robust

### DIFF
--- a/.github/actions/build-tt-mlir-action/action.yaml
+++ b/.github/actions/build-tt-mlir-action/action.yaml
@@ -151,7 +151,7 @@ runs:
     - name: Get Latest Tag and Version
       shell: bash
       run: |
-        latest_tag=$(git describe --tags --abbrev=0)
+        latest_tag= $(git tag --merged main --sort=-taggerdate | egrep '^v([0-9]+)\.([0-9]+)$' | head -1)
         latest_tag=${latest_tag#v}
         echo "latest_tag=$latest_tag" >> $GITHUB_ENV
         commit_count=$(git rev-list ${{ env.latest_tag }}..HEAD --count)

--- a/.github/actions/build-tt-mlir-action/action.yaml
+++ b/.github/actions/build-tt-mlir-action/action.yaml
@@ -151,7 +151,7 @@ runs:
     - name: Get Latest Tag and Version
       shell: bash
       run: |
-        latest_tag= $(git tag --merged main --sort=-taggerdate | egrep '^v([0-9]+)\.([0-9]+)$' | head -1)
+        latest_tag= $(git describe --tags --match 'v[0-9]*.[0-9]*' --abbrev=0)
         latest_tag=${latest_tag#v}
         echo "latest_tag=$latest_tag" >> $GITHUB_ENV
         commit_count=$(git rev-list ${{ env.latest_tag }}..HEAD --count)

--- a/.github/actions/build-tt-mlir-action/action.yaml
+++ b/.github/actions/build-tt-mlir-action/action.yaml
@@ -151,7 +151,7 @@ runs:
     - name: Get Latest Tag and Version
       shell: bash
       run: |
-        latest_tag= $(git describe --tags --match 'v[0-9]*.[0-9]*' --abbrev=0)
+        latest_tag=$(git describe --tags --match 'v[0-9]*.[0-9]*' --abbrev=0)
         latest_tag=${latest_tag#v}
         echo "latest_tag=$latest_tag" >> $GITHUB_ENV
         commit_count=$(git rev-list ${{ env.latest_tag }}..HEAD --count)

--- a/cmake/modules/TTMLIRVersion.cmake
+++ b/cmake/modules/TTMLIRVersion.cmake
@@ -7,7 +7,7 @@ execute_process(
 )
 
 execute_process(
-  COMMAND bash "-c" "git tag --merged main --sort=-taggerdate"
+  COMMAND bash "-c" "git status"
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
   OUTPUT_VARIABLE VLAD_TRACE
   OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/cmake/modules/TTMLIRVersion.cmake
+++ b/cmake/modules/TTMLIRVersion.cmake
@@ -13,6 +13,7 @@ execute_process(
   OUTPUT_VARIABLE GIT_TAG
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
+message(TODO_remove_this_GIT_TAG_is "[${GIT_TAG}]")
 
 # get the number of commits since the latest tag
 execute_process(

--- a/cmake/modules/TTMLIRVersion.cmake
+++ b/cmake/modules/TTMLIRVersion.cmake
@@ -9,7 +9,7 @@ execute_process(
 # get the latest tag from git matching 'v<major>.<minor>' format
 # (note: matching a glob(7) pattern, not a regex)
 execute_process(
-  COMMAND git describe --tags --abbrev=0
+  COMMAND git describe --tags --match v[0-9]*.[0-9]* --abbrev=0
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
   OUTPUT_VARIABLE GIT_TAG
   OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/cmake/modules/TTMLIRVersion.cmake
+++ b/cmake/modules/TTMLIRVersion.cmake
@@ -6,22 +6,14 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
+# get the latest tag from git matching 'v<major>.<minor>' format
+# (note: matching a glob(7) pattern, not a regex)
 execute_process(
-  COMMAND bash "-c" "git tag"
-  WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-  OUTPUT_VARIABLE VLAD_TRACE
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-message(TODO_remove_this_VLAD_TRACE_is "[${VLAD_TRACE}]")
-
-# get the latest tag from git, reachable from 'main' branch and matching 'v<major>.<minor>' format
-execute_process(
-  COMMAND bash "-c" "git tag --merged main --sort=-taggerdate | egrep '^v([0-9]+)\.([0-9]+)$' | head -1"
+  COMMAND git describe --tags --match 'v[0-9]*.[0-9]*' --abbrev=0
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
   OUTPUT_VARIABLE GIT_TAG
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
-message(TODO_remove_this_GIT_TAG_is "[${GIT_TAG}]")
 
 # get the number of commits since the latest tag
 execute_process(

--- a/cmake/modules/TTMLIRVersion.cmake
+++ b/cmake/modules/TTMLIRVersion.cmake
@@ -8,7 +8,7 @@ execute_process(
 
 # get the latest tag from git, reachable from 'main' branch and matching 'v<major>.<minor>' format
 execute_process(
-  COMMAND bash "-c" "git tag --merged main --sort=-taggerdate | egrep '^v([0-9]+)\\.([0-9]+)$' | head -1"
+  COMMAND bash "-c" "git tag --merged main --sort=-taggerdate | egrep '^v([0-9]+)\.([0-9]+)$' | head -1"
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
   OUTPUT_VARIABLE GIT_TAG
   OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/cmake/modules/TTMLIRVersion.cmake
+++ b/cmake/modules/TTMLIRVersion.cmake
@@ -7,7 +7,7 @@ execute_process(
 )
 
 execute_process(
-  COMMAND bash "-c" "git status"
+  COMMAND bash "-c" "git tag"
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
   OUTPUT_VARIABLE VLAD_TRACE
   OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/cmake/modules/TTMLIRVersion.cmake
+++ b/cmake/modules/TTMLIRVersion.cmake
@@ -6,6 +6,14 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
+execute_process(
+  COMMAND bash "-c" "git tag --merged main --sort=-taggerdate"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+  OUTPUT_VARIABLE VLAD_TRACE
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+message(TODO_remove_this_VLAD_TRACE_is "[${VLAD_TRACE}]")
+
 # get the latest tag from git, reachable from 'main' branch and matching 'v<major>.<minor>' format
 execute_process(
   COMMAND bash "-c" "git tag --merged main --sort=-taggerdate | egrep '^v([0-9]+)\.([0-9]+)$' | head -1"

--- a/cmake/modules/TTMLIRVersion.cmake
+++ b/cmake/modules/TTMLIRVersion.cmake
@@ -6,9 +6,9 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
-# get the latest tag from Git
+# get the latest tag from git, reachable from 'main' branch and matching 'v<major>.<minor>' format
 execute_process(
-  COMMAND git describe --tags --abbrev=0
+  COMMAND bash "-c" "git tag --merged main --sort=-taggerdate | egrep '^v([0-9]+)\\.([0-9]+)$' | head -1"
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
   OUTPUT_VARIABLE GIT_TAG
   OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/cmake/modules/TTMLIRVersion.cmake
+++ b/cmake/modules/TTMLIRVersion.cmake
@@ -9,7 +9,7 @@ execute_process(
 # get the latest tag from git matching 'v<major>.<minor>' format
 # (note: matching a glob(7) pattern, not a regex)
 execute_process(
-  COMMAND git describe --tags --match 'v[0-9]*.[0-9]*' --abbrev=0
+  COMMAND git describe --tags --abbrev=0
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
   OUTPUT_VARIABLE GIT_TAG
   OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
### Ticket
closes #2169

### Problem description
Current git stansa `git describe --tags --abbrev=0` can pick up tags from personal dev branches, which will results in empty  TTMLIR_VERSION_MAJOR/TTMLIR_VERSION_MINOR defs and a broken build.

### What's changed
Final change is to add a glob filter that will select the latest tag matching `v<digit>*.<digit>*`, which is compatible with our current release tag format but should also reduce the probability that a personal dev tag gets picked up.

Note that using `git tag --merged main ...` was promising in local builds but seems problematic in CI which uses detached head clones. 

### Checklist
Tested against multiple tags in a dev branch and observed a CI run succeed with the latest changes.
