### PR TITLE
Uplift third_party/tt-metal to 02fb2125f3fe1f05afd38bcea7993ccb7df87313 2025-02-11

### DIFF
--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_conv_transpose2d.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_conv_transpose2d.mlir
@@ -1,6 +1,7 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+// UNSUPPORTED: true
 
 module attributes {} {
   func.func @forward(%arg0: tensor<3x8x8x256xbf16>, %arg1: tensor<256x256x3x3xbf16>, %arg2: tensor<1x1x1x256xbf16>) -> tensor<3x10x10x256xbf16> {

--- a/test/ttmlir/Silicon/TTNN/n150/simple_conv_transpose2d.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_conv_transpose2d.mlir
@@ -1,6 +1,7 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+// UNSUPPORTED: true
 
 module attributes {} {
   func.func @forward(%arg0: tensor<3x8x8x256xbf16>, %arg1: tensor<256x256x3x3xbf16>, %arg2: tensor<1x1x1x256xbf16>) -> tensor<3x10x10x256xbf16> {

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "38578b33849c41ad70f5375856d736bc77239b8c")
+set(TT_METAL_VERSION "02fb2125f3fe1f05afd38bcea7993ccb7df87313")
 
 if ("$ENV{ARCH_NAME}" STREQUAL "grayskull")
   set(ARCH_NAME "grayskull")


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 02fb2125f3fe1f05afd38bcea7993ccb7df87313

- Mark ttnn.conv_transpose2d tests as unsupported after metal change 9b459f0