### PR TITLE
Remove `QueueId` from ops in runtime

### DIFF
--- a/runtime/include/tt/runtime/detail/workarounds.h
+++ b/runtime/include/tt/runtime/detail/workarounds.h
@@ -17,13 +17,12 @@ struct Env {
 #endif
   get(bool swapBinaryOperands = true,
       bool readUpdateIndexFromDeviceForKVCache = true,
-      bool toLayoutAPIAssumeSingleChip = true,
-      bool usePaddingPairSignatureWithQueueId = true)
+      bool toLayoutAPIAssumeSingleChip = true)
 #if defined(TT_RUNTIME_WORKAROUNDS) && TT_RUNTIME_WORKAROUNDS == 1
       ;
 #else
   {
-    return Env(true, true, true, true);
+    return Env(true, true, true);
   }
 #endif
   // TODO(bug #1124): We're currently swapping the operands for binary ops
@@ -46,26 +45,14 @@ struct Env {
   // grid information to the tensorDesc.
   bool toLayoutAPIAssumeSingleChip;
 
-  // TODO(tt-metal issue #17388): We're currently using the signature of
-  // ttnn::pad which takes a sequence of padding pairs as input. We want to do
-  // this as it is more intuitive and matches stablehlo and even pytorch.
-  // However, we do not want to expose metal-specific details like queue_id in
-  // the runtime. The issue above is requesting they provide a signature for
-  // ttnn::padd which accepts padding pairs to define the padding, but does not
-  // require us to pass queue_id.
-  bool usePaddingPairSignatureWithQueueId;
-
 private:
   constexpr Env(bool swapBinaryOperands,
                 bool readUpdateIndexFromDeviceForKVCache,
-                bool toLayoutAPIAssumeSingleChip,
-                bool usePaddingPairSignatureWithQueueId)
+                bool toLayoutAPIAssumeSingleChip)
       : swapBinaryOperands(swapBinaryOperands),
         readUpdateIndexFromDeviceForKVCache(
             readUpdateIndexFromDeviceForKVCache),
-        toLayoutAPIAssumeSingleChip(toLayoutAPIAssumeSingleChip),
-        usePaddingPairSignatureWithQueueId(usePaddingPairSignatureWithQueueId) {
-  }
+        toLayoutAPIAssumeSingleChip(toLayoutAPIAssumeSingleChip) {}
 };
 
 inline std::ostream &operator<<(std::ostream &os, const Env &env) {
@@ -78,9 +65,6 @@ inline std::ostream &operator<<(std::ostream &os, const Env &env) {
   os << "\t"
      << "toLayoutAPIAssumeSingleChip: " << env.toLayoutAPIAssumeSingleChip
      << "\n";
-  os << "\t"
-     << "usePaddingPairSignatureWithQueueId: "
-     << env.usePaddingPairSignatureWithQueueId << "\n";
   os << "}";
   return os;
 }

--- a/runtime/lib/common/workarounds.cpp
+++ b/runtime/lib/common/workarounds.cpp
@@ -8,11 +8,10 @@ namespace tt::runtime::workaround {
 #if defined(TT_RUNTIME_WORKAROUNDS) && TT_RUNTIME_WORKAROUNDS == 1
 const Env &Env::get(bool swapBinaryOperands,
                     bool readUpdateIndexFromDeviceForKVCache,
-                    bool toLayoutAPIAssumeSingleChip,
-                    bool usePaddingPairSignatureWithQueueId) {
-  static const Env config(
-      swapBinaryOperands, readUpdateIndexFromDeviceForKVCache,
-      toLayoutAPIAssumeSingleChip, usePaddingPairSignatureWithQueueId);
+                    bool toLayoutAPIAssumeSingleChip) {
+  static const Env config(swapBinaryOperands,
+                          readUpdateIndexFromDeviceForKVCache,
+                          toLayoutAPIAssumeSingleChip);
   return config;
 }
 #endif

--- a/runtime/lib/ttnn/operations/conv/conv_transpose2d.cpp
+++ b/runtime/lib/ttnn/operations/conv/conv_transpose2d.cpp
@@ -52,10 +52,10 @@ void run(const ::tt::target::ttnn::ConvTranspose2dOp *op,
   ::ttnn::Tensor out = std::visit(
       [&](auto &&targetDevice) -> ::ttnn::Tensor {
         return std::get<0>(::ttnn::conv_transpose2d(
-            ::ttnn::DefaultQueueId, input, weight, &(targetDevice.get()),
-            op->in_channels(), op->out_channels(), op->batch_size(),
-            op->input_height(), op->input_width(), kernelSize, stride, padding,
-            outputPadding, dilation, op->groups(), bias, config));
+            input, weight, &targetDevice.get(), op->in_channels(),
+            op->out_channels(), op->batch_size(), op->input_height(),
+            op->input_width(), kernelSize, stride, padding, outputPadding,
+            dilation, op->groups(), bias, config));
       },
       targetDevice);
 

--- a/runtime/lib/ttnn/operations/pool/maxpool2d.cpp
+++ b/runtime/lib/ttnn/operations/pool/maxpool2d.cpp
@@ -14,24 +14,19 @@ namespace tt::runtime::ttnn::operations::pool {
 
 void run(const ::tt::target::ttnn::MaxPool2dOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  const ::ttnn::operations::pool::Pool2DOp<
-      ::ttnn::operations::pool::Pool2DType::MAX_POOL2D>
-      operation = ::ttnn::operations::pool::Pool2DOp<
-          ::ttnn::operations::pool::Pool2DType::MAX_POOL2D>();
 
   ::ttnn::Tensor input = tensorPool.at(op->in()->global_id());
   DEBUG_ASSERT(input.is_allocated());
 
   ::ttnn::MemoryConfig outMemConfig =
       ::tt::runtime::ttnn::utils::createMemoryConfig(op->out());
-  ::ttnn::Tensor out =
-      operation.invoke(::ttnn::DefaultQueueId, input, op->batch_size(),
-                       op->input_height(), op->input_width(), op->channels(),
-                       {op->kernel_height(), op->kernel_width()},
-                       {op->stride_height(), op->stride_width()},
-                       {op->padding_height(), op->padding_width()},
-                       {op->dilation_height(), op->dilation_width()},
-                       outMemConfig, std::nullopt);
+  ::ttnn::Tensor out = ::ttnn::max_pool2d(
+      input, op->batch_size(), op->input_height(), op->input_width(),
+      op->channels(), std::array{op->kernel_height(), op->kernel_width()},
+      std::array{op->stride_height(), op->stride_width()},
+      std::array{op->padding_height(), op->padding_width()},
+      std::array{op->dilation_height(), op->dilation_width()}, outMemConfig,
+      std::nullopt);
 
   tensorPool.insert_or_assign(op->out()->global_id(), out);
 }

--- a/runtime/tools/python/ttrt/common/run.py
+++ b/runtime/tools/python/ttrt/common/run.py
@@ -141,13 +141,6 @@ class Run:
             help="disable runtime to_layout api assume single chip workaround",
         )
         Run.register_arg(
-            name="--disable-pad-op-padding-pairs-signature",
-            type=bool,
-            default=False,
-            choices=[True, False],
-            help="disable pad op padding pairs signature workaround",
-        )
-        Run.register_arg(
             name="--result-file",
             type=str,
             default="run_results.json",
@@ -417,7 +410,6 @@ class Run:
                 not self["--disable-swap-binary-operands"],
                 not self["--disable-read-update-index-for-kv-cache"],
                 not self["--disable-to-layout-api-assume-single-chip"],
-                not self["--disable-pad-op-padding-pairs-signature"],
             )
             self.logging.debug(f"setting tt runtime workaround env={workaround_env}")
             self.logging.debug(f"setting torch manual seed={self['--seed']}")


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/2167

### Problem description
With https://github.com/tenstorrent/tt-metal/pull/17640 `QueueId` is now optional in all calls. There were 3 cases where we couldn't use signature without `QueueId`, that restriction is now removed.

### What's changed
Removed `QueueId` and stuff related to it from `conv_transpose2d`, `pad` and `max_pool2d`.

### Checklist
- [ ] New/Existing tests provide coverage for changes
