### PR TITLE
Add data type workaround for concat op

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -873,6 +873,15 @@ def TTNN_ConcatOp : TTNN_NamedDPSOp<"concat"> {
 
     let extraClassDeclaration = [{
       MutableOperandRange getDpsInitsMutable() { return getOutputMutable(); }
+
+      wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
+        ::mlir::Operation::operand_range inputs = getInputs();
+        int64_t numOperands = getOperands().size();
+        int32_t dim = getDim();
+        return
+          wa::TTNNOperandsWorkaroundsFactory::createConcatOpOperandsWorkarounds(
+                                                        inputs, numOperands, dim);
+      }
     }];
 
     let hasVerifier = 1;

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkarounds.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkarounds.h
@@ -234,6 +234,11 @@ public:
 
   // Create workarounds for mesh shard op operands.
   static TTNNOperandsWorkarounds createMeshShardOpOperandsWorkarounds();
+
+  // Create workarounds for concat op operands.
+  static TTNNOperandsWorkarounds
+  createConcatOpOperandsWorkarounds(mlir::Operation::operand_range inputs,
+                                    int64_t numOperands, int32_t dim);
 };
 
 } // namespace mlir::tt::ttnn::wa

--- a/lib/Dialect/TTNN/IR/TTNNWorkarounds.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkarounds.cpp
@@ -6,8 +6,8 @@
 
 #include "ttmlir/Utils.h"
 
+#include "mlir/IR/BuiltinTypes.h"
 #include "llvm/ADT/SmallVector.h"
-#include <mlir/IR/BuiltinTypes.h>
 
 namespace mlir::tt::ttnn::wa {
 
@@ -214,5 +214,52 @@ TTNNOperandsWorkaroundsFactory::createMeshShardOpOperandsWorkarounds() {
   return wa::TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
       .addInputOperandWorkaround(sysMemWorkaround)
       .addOutputOperandWorkaround(sysMemWorkaround);
+}
+
+// Factory method to create a set of workaround for concat operation operands.
+// tt-metal applies padding (before concatenation) to the input tensors if the
+// layout is tile and the shape is not divisible by tile size along concatenated
+// dimension for any input tensor. Padding can only be applied for float or
+// bfloat16 tensors.
+TTNNOperandsWorkarounds
+TTNNOperandsWorkaroundsFactory::createConcatOpOperandsWorkarounds(
+    mlir::Operation::operand_range inputs, int64_t numOperands, int32_t dim) {
+  mlir::RankedTensorType inputType =
+      mlir::cast<RankedTensorType>(inputs.front().getType());
+  ttnn::TTNNLayoutAttr layoutAttr =
+      mlir::cast<ttnn::TTNNLayoutAttr>(inputType.getEncoding());
+  mlir::Type elementType = inputType.getElementType();
+
+  // Check if the op is using tile layout.
+  bool isDataTypeWARequired = layoutAttr.isTiled();
+  // Check if the tensor data type is neither float32 nor bfloat16.
+  isDataTypeWARequired &= (!elementType.isF32() && !elementType.isBF16());
+  // Check if shape (for any input tensor) along concatenated dimension is not
+  // divisible by tileHeight (Assuming TileWidth and TileHeigh are same).
+  int32_t tileWidth = 1;
+  int32_t tileHeight = 1;
+  if (isDataTypeWARequired) {
+    TileType tile =
+        mlir::cast<TileType>(layoutAttr.getMemref().getElementType());
+    tileWidth = tile.getWidth();
+    tileHeight = tile.getHeight();
+  }
+  assert(tileHeight == tileWidth);
+  isDataTypeWARequired &= llvm::any_of(inputs, [&](mlir::Value value) {
+    RankedTensorType inputTensor =
+        mlir::dyn_cast<RankedTensorType>(value.getType());
+    return inputTensor.getShape()[dim] % tileHeight != 0;
+  });
+
+  TTNNOperandWorkarounds bf16Workaround;
+  if (isDataTypeWARequired) {
+    bf16Workaround.tensorDataTypeWorkaround = DataType::BFloat16;
+  }
+  auto workaround =
+      TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds();
+  for (int64_t count = 0; count < numOperands; ++count) {
+    workaround.addInputOperandWorkaround(bf16Workaround);
+  }
+  return workaround.addOutputOperandWorkaround(bf16Workaround);
 }
 } // namespace mlir::tt::ttnn::wa

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/concat_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/concat_workaround.mlir
@@ -1,0 +1,37 @@
+// RUN: ttmlir-opt --ttnn-workaround --canonicalize %s | FileCheck %s
+
+#device = #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, d0 floordiv s0, d1 floordiv s1, (d0 mod s0) * s1 + d1 mod s1), dramMap = (d0, d1)[s0, s1] -> (0, 0, ((((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 8192) mod 12, (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 98304 + (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) mod 8192), meshShape = , chipIds = [0]>
+#dram = #ttnn.buffer_type<dram>
+#system_desc = #tt.system_desc<[{role = host, target_triple = "x86_64-pc-linux-gnu"}], [{arch = <wormhole_b0>, grid = 8x8, l1_size = 1499136, num_dram_channels = 12, dram_channel_size = 1073741824, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32, l1_unreserved_base = 1024, erisc_l1_unreserved_base = 1024, dram_unreserved_base = 1024, dram_unreserved_end = 1073741824, physical_cores = {worker = [ 0x0,  0x1,  0x2,  0x3,  0x4,  0x5,  0x6,  0x7,  1x0,  1x1,  1x2,  1x3,  1x4,  1x5,  1x6,  1x7,  2x0,  2x1,  2x2,  2x3,  2x4,  2x5,  2x6,  2x7,  3x0,  3x1,  3x2,  3x3,  3x4,  3x5,  3x6,  3x7,  4x0,  4x1,  4x2,  4x3,  4x4,  4x5,  4x6,  4x7,  5x0,  5x1,  5x2,  5x3,  5x4,  5x5,  5x6,  5x7,  6x0,  6x1,  6x2,  6x3,  6x4,  6x5,  6x6,  6x7,  7x0,  7x1,  7x2,  7x3,  7x4,  7x5,  7x6,  7x7] dram = [ 8x0,  9x0,  10x0,  8x1,  9x1,  10x1,  8x2,  9x2,  10x2,  8x3,  9x3,  10x3]}, supported_data_types = [<f32>, <f16>, <bf16>, <bfp_f8>, <bfp_bf8>, <bfp_f4>, <bfp_bf4>, <bfp_f2>, <bfp_bf2>, <u32>, <u16>, <u8>], supported_tile_sizes = [ 4x16,  16x16,  32x16,  4x32,  16x32,  32x32], num_cbs = 32}], [0], [3 : i32], [ 0x0x0x0]>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x2x!tt.tile<32x32, u32>, #dram>, <interleaved>>
+#ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!tt.tile<32x32, u32>, #dram>, <interleaved>>
+module attributes {tt.device = #device, tt.system_desc = #system_desc} {
+  func.func @test_concat_workaround(%arg0: tensor<1x53xui32, #ttnn_layout>, %arg1: tensor<1x1xui32, #ttnn_layout1>) -> tensor<1x54xui32, #ttnn_layout> {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
+    %1 = "ttnn.empty"(%0) <{dtype = #tt.supportedDataTypes<u32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <<1x2>>, <interleaved>>, shape = #ttnn.shape<1x54>}> : (!tt.device<#device>) -> tensor<1x54xui32, #ttnn_layout>
+    // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"
+    // CHECK-SAME: dtype = #tt.supportedDataTypes<bf16>
+    // CHECK-SAME: tensor<1x53xui32
+    // CHECK-SAME: -> tensor<1x53xbf16
+    // CHECK: %[[ARG1:[0-9]+]] = "ttnn.to_layout"
+    // CHECK-SAME: dtype = #tt.supportedDataTypes<bf16>
+    // CHECK-SAME: tensor<1x1xui32
+    // CHECK-SAME: -> tensor<1x1xbf16
+    // CHECK: %[[ARG2:[0-9]+]] = "ttnn.to_layout"
+    // CHECK-SAME: dtype = #tt.supportedDataTypes<bf16>
+    // CHECK-SAME: tensor<1x54xui32
+    // CHECK-SAME: -> tensor<1x54xbf16
+    // CHECK: %[[CONCAT:[0-9]+]] = "ttnn.concat"(%[[ARG0]], %[[ARG1]], %[[ARG2]])
+    // CHECK-SAME: dim = 1 : si32
+    // CHECK-SAME: tensor<1x53xbf16
+    // CHECK-SAME: tensor<1x1xbf16
+    // CHECK-SAME: tensor<1x54xbf16
+    // CHECK-SAME: -> tensor<1x54xbf16
+    %2 = "ttnn.concat"(%arg0, %arg1, %1) <{dim = 1 : si32}> : (tensor<1x53xui32, #ttnn_layout>, tensor<1x1xui32, #ttnn_layout1>, tensor<1x54xui32, #ttnn_layout>) -> tensor<1x54xui32, #ttnn_layout>
+    // CHECK: %6 = "ttnn.to_layout"(%[[CONCAT]]
+    // CHECK-SAME: dtype = #tt.supportedDataTypes<u32>
+    // CHECK-SAME: tensor<1x54xbf16
+    // CHECK-SAME: -> tensor<1x54xui32
+    return %2 : tensor<1x54xui32, #ttnn_layout>
+  }
+}

--- a/test/ttmlir/Silicon/StableHLO/n150/Binary/concat_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Binary/concat_op.mlir
@@ -82,4 +82,32 @@ module @jit_concat attributes {} {
     } : (tensor<32x32x32x32xf32>, tensor<32x32x32x64xf32>) -> tensor<32x32x32x96xf32>
     return %0 : tensor<32x32x32x96xf32>
   }
+
+  func.func public @test_concat_5(%arg0: tensor<1x53xi64>, %arg1: tensor<1x1xi64>) -> tensor<1x54xi64> {
+    // CHECK-LABEL: func.func public @test_concat_5
+    // CHECK: %[[ARG0:[0-9]+]] = "ttnn.typecast"
+    // CHECK-SAME: dtype = #tt.supportedDataTypes<bf16>
+    // CHECK-SAME: tensor<1x53xui32
+    // CHECK-SAME: -> tensor<1x53xbf16
+    // CHECK: %[[ARG1:[0-9]+]] = "ttnn.typecast"
+    // CHECK-SAME: dtype = #tt.supportedDataTypes<bf16>
+    // CHECK-SAME: tensor<1x1xui32
+    // CHECK-SAME: -> tensor<1x1xbf16
+    // CHECK: %[[ARG2:[0-9]+]] = "ttnn.typecast"
+    // CHECK-SAME: dtype = #tt.supportedDataTypes<bf16>
+    // CHECK-SAME: tensor<1x54xui32
+    // CHECK-SAME: -> tensor<1x54xbf16
+    // CHECK: %[[CONCAT:[0-9]+]] = "ttnn.concat"(%[[ARG0]], %[[ARG1]], %[[ARG2]])
+    // CHECK-SAME: dim = 1 : si32
+    // CHECK-SAME: tensor<1x53xbf16
+    // CHECK-SAME: tensor<1x1xbf16
+    // CHECK-SAME: tensor<1x54xbf16
+    // CHECK-SAME: -> tensor<1x54xbf16
+    %0 = stablehlo.concatenate %arg0, %arg1, dim = 1 : (tensor<1x53xi64>, tensor<1x1xi64>) -> tensor<1x54xi64>
+    // CHECK: "ttnn.typecast"(%[[CONCAT]])
+    // CHECK-SAME: dtype = #tt.supportedDataTypes<u32>
+    // CHECK-SAME: tensor<1x54xbf16
+    // CHECK-SAME: -> tensor<1x54xui32
+    return %0 : tensor<1x54xi64>
+  }
 }


### PR DESCRIPTION
closes #2181 

### Ticket
[#2181 ](https://github.com/tenstorrent/tt-mlir/issues/2181)

### Problem description
tt-metal applies padding (before concatenation) to the input tensors if the
layout is tile and the shape is not divisible by tile size along concatenated
dimension for any input tensor. Padding can only be applied for float or
bfloat16 tensors.


### What's changed
Add layout workaround for data types other than float32 or bfloat16

### Checklist
- [X] New tests provide coverage for changes
