### PR TITLE
TTRT incremental build fix

### DIFF
--- a/runtime/tools/python/CMakeLists.txt
+++ b/runtime/tools/python/CMakeLists.txt
@@ -6,8 +6,22 @@ foreach (filename ${TTRT_FILES})
     list(APPEND TTRT_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/${relative_filename}")
 endforeach (filename)
 
+function(get_all_deps target deps)
+    get_target_property(libs ${target} LINK_LIBRARIES)
+    if (libs)
+        foreach(lib IN LISTS libs)
+            list(APPEND ${deps} ${lib})
+            get_all_deps(${lib} ${deps})
+        endforeach()
+    endif()
+    set(${deps} ${${deps}} PARENT_SCOPE)
+endfunction()
+
+set(TTRuntime_DEPS TTRuntime)
+get_all_deps(TTRuntime TTRuntime_DEPS)
+
 add_custom_command(
-  COMMAND rm -f build/*.whl
+  COMMAND rm -rf build
   COMMAND python -m pip install -r "${CMAKE_CURRENT_BINARY_DIR}/requirements.txt"
   COMMAND TTMLIR_ENABLE_RUNTIME=${TTMLIR_ENABLE_RUNTIME}
           TT_RUNTIME_ENABLE_TTNN=${TT_RUNTIME_ENABLE_TTNN}
@@ -25,7 +39,7 @@ add_custom_command(
   COMMAND python -m pip install build/*.whl --force-reinstall
   COMMAND touch ${CMAKE_CURRENT_BINARY_DIR}/build/.installed
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
-  DEPENDS ${TTRT_SOURCES}
+  DEPENDS ${TTRT_SOURCES} ${TTRuntime_DEPS}
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/build/.installed
 )
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/2187

### Problem description
The incremental build of TTRT is not working properly.  As I understand the root cause is that `python -m pip wheel` will run only when one of the files in `runtime/tools/python` is touched, but it should also run in case `TTRuntime` or some of its dependencies have changed because we need to rebuild `ttrt.runtime._C` and `ttrt.binary._C` shared libraries.

### What's changed
Added new dependencies. This is a somewhat hacky solution, so I'm very open to suggestions on how to improve this, or even take a different approach.

### Checklist
- [ ] New/Existing tests provide coverage for changes
