### PR TITLE
Add workaround for ttnn.where

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -187,6 +187,17 @@ def TTNN_WhereOp : TTNN_ElementwiseTernaryOp<"where"> {
     let description = [{
       Eltwise where operation.
     }];
+
+    let extraClassDeclaration = [{
+      MutableOperandRange getDpsInitsMutable() { return getOutputsMutable(); }
+
+      wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
+        ::mlir::Operation::operand_range inputs = getInputs();
+        return
+          wa::TTNNOperandsWorkaroundsFactory::createWhereOpOperandsWorkarounds(
+                                                                        inputs);
+      }
+    }];
 }
 
 def TTNN_AbsOp : TTNN_ElementwiseUnaryOp<"abs"> {

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkarounds.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkarounds.h
@@ -226,6 +226,7 @@ public:
   // Create workarounds for upsample op operands.
   static TTNNOperandsWorkarounds createUpsampleOpOperandsWorkarounds();
 
+  // Create workarounds for cumulative sum op operands.
   static TTNNOperandsWorkarounds
   createCumSumOpOperandsWorkarounds(RankedTensorType inputType);
 
@@ -249,6 +250,10 @@ public:
   // Workaround for tensor creation that is modeled as ConstantOp in TTNN
   // dialect.
   static TTNNOperandsWorkarounds createConstantOpOperandsWorkarounds();
+
+  // Create workarounds for concat op operands.
+  static TTNNOperandsWorkarounds
+  createWhereOpOperandsWorkarounds(mlir::Operation::operand_range inputs);
 };
 
 } // namespace mlir::tt::ttnn::wa

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/where_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/where_workaround.mlir
@@ -1,0 +1,29 @@
+// RUN: ttmlir-opt --ttnn-workaround --canonicalize %s | FileCheck %s
+
+#device = #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, d0 floordiv s0, d1 floordiv s1, (d0 mod s0) * s1 + d1 mod s1), dramMap = (d0, d1)[s0, s1] -> (0, 0, ((((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 8192) mod 12, (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 98304 + (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) mod 8192), meshShape = , chipIds = [0]>
+#dram = #ttnn.buffer_type<dram>
+#system_desc = #tt.system_desc<[{role = host, target_triple = "x86_64-pc-linux-gnu"}], [{arch = <wormhole_b0>, grid = 8x8, l1_size = 1499136, num_dram_channels = 12, dram_channel_size = 1073741824, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32, l1_unreserved_base = 1024, erisc_l1_unreserved_base = 1024, dram_unreserved_base = 1024, dram_unreserved_end = 1073741824, physical_cores = {worker = [ 0x0,  0x1,  0x2,  0x3,  0x4,  0x5,  0x6,  0x7,  1x0,  1x1,  1x2,  1x3,  1x4,  1x5,  1x6,  1x7,  2x0,  2x1,  2x2,  2x3,  2x4,  2x5,  2x6,  2x7,  3x0,  3x1,  3x2,  3x3,  3x4,  3x5,  3x6,  3x7,  4x0,  4x1,  4x2,  4x3,  4x4,  4x5,  4x6,  4x7,  5x0,  5x1,  5x2,  5x3,  5x4,  5x5,  5x6,  5x7,  6x0,  6x1,  6x2,  6x3,  6x4,  6x5,  6x6,  6x7,  7x0,  7x1,  7x2,  7x3,  7x4,  7x5,  7x6,  7x7] dram = [ 8x0,  9x0,  10x0,  8x1,  9x1,  10x1,  8x2,  9x2,  10x2,  8x3,  9x3,  10x3]}, supported_data_types = [<f32>, <f16>, <bf16>, <bfp_f8>, <bfp_bf8>, <bfp_f4>, <bfp_bf4>, <bfp_f2>, <bfp_bf2>, <u32>, <u16>, <u8>], supported_tile_sizes = [ 4x16,  16x16,  32x16,  4x32,  16x32,  32x32], num_cbs = 32}], [0], [3 : i32], [ 0x0x0x0]>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 + d1 + d2, d3), <1x1>, memref<1x2x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
+#ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 12 + d1 + d2, d3), <1x1>, memref<1x2x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+#ttnn_layout2 = #ttnn.ttnn_layout<(d0) -> (0, d0), <1x1>, memref<1x1x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+#ttnn_layout3 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 + d1 + d2, d3), <1x1>, memref<1x1x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+module @moreh_cumsum attributes {tt.device = #device, tt.system_desc = #system_desc} {
+  func.func @main(%arg0: tensor<1x1x1x46xbf16, #ttnn_layout>, %arg1: tensor<1x12x1x46xf32, #ttnn_layout1>, %arg2: tensor<1xf32, #ttnn_layout2>) -> tensor<1x12x1x46xf32, #ttnn_layout1> {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
+    %1 = "ttnn.reshape"(%arg2) <{shape = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<1xf32, #ttnn_layout2>) -> tensor<1x1x1x1xf32, #ttnn_layout3>
+    %2 = "ttnn.repeat"(%1) <{repeat_dims = #ttnn.shape<1x12x1x46>}> : (tensor<1x1x1x1xf32, #ttnn_layout3>) -> tensor<1x12x1x46xf32, #ttnn_layout1>
+    %3 = "ttnn.empty"(%0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <<1x2>>, <interleaved>>, shape = #ttnn.shape<1x12x1x46>}> : (!tt.device<#device>) -> tensor<1x12x1x46xf32, #ttnn_layout1>
+    // CHECK: %[[ARG0:[0-9]+]] = {{.*}}(%arg0,
+    // CHECK-SAME: dtype = #tt.supportedDataTypes<f32>
+    // CHECK-SAME: tensor<1x1x1x46xbf16
+    // CHECK-SAME: -> tensor<1x1x1x46xf32
+    // CHECK: "ttnn.where"(%[[ARG0]]
+    // CHECK-SAME: tensor<1x1x1x46xf32
+    // CHECK-SAME: tensor<1x12x1x46xf32
+    // CHECK-SAME: tensor<1x12x1x46xf32
+    // CHECK-SAME: tensor<1x12x1x46xf32
+    // CHECK-SAME: -> tensor<1x12x1x46xf32
+    %4 = "ttnn.where"(%arg0, %arg1, %2, %3) <{operandSegmentSizes = array<i32: 3, 1>}> : (tensor<1x1x1x46xbf16, #ttnn_layout>, tensor<1x12x1x46xf32, #ttnn_layout1>, tensor<1x12x1x46xf32, #ttnn_layout1>, tensor<1x12x1x46xf32, #ttnn_layout1>) -> tensor<1x12x1x46xf32, #ttnn_layout1>
+    return %4 : tensor<1x12x1x46xf32, #ttnn_layout1>
+  }
+}

--- a/test/ttmlir/Silicon/StableHLO/n150/select_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/select_op.mlir
@@ -25,4 +25,33 @@ module @jit_eltwise_select attributes {} {
     %1 = stablehlo.select %0, %arg0, %arg1 : (tensor<64x128xi1>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     return %1 : tensor<64x128xbf16>
   }
+
+  func.func public @test_select_bf16(%arg0: tensor<1x1x1x50xi1>, %arg1: tensor<1x12x1x50xbf16>, %arg2: tensor<bf16>) -> tensor<1x12x1x50xbf16> {
+    // CHECK-LABEL: func.func public @test_select_bf16(
+    %0 = stablehlo.broadcast_in_dim %arg0, dims = [0, 1, 2, 3] : (tensor<1x1x1x50xi1>) -> tensor<1x12x1x50xi1>
+    %1 = stablehlo.broadcast_in_dim %arg1, dims = [0, 1, 2, 3] : (tensor<1x12x1x50xbf16>) -> tensor<1x12x1x50xbf16>
+    %2 = stablehlo.broadcast_in_dim %arg2, dims = [] : (tensor<bf16>) -> tensor<1x12x1x50xbf16>
+    // CHECK: "ttnn.where"(%arg0, %arg1,
+    // CHECK-SAME: tensor<1x1x1x50xbf16
+    // CHECK-SAME: tensor<1x1x1x50xbf16
+    // CHECK-SAME: tensor<1x1x1x50xbf16
+    // CHECK-SAME: -> tensor<1x1x1x50xbf16
+    %3 = stablehlo.select %0, %1, %2 : tensor<1x12x1x50xi1>, tensor<1x12x1x50xbf16>
+    return %3 : tensor<1x12x1x50xbf16>
+  }
+
+  func.func public @test_select_f32(%arg0: tensor<1x12x1x51xi1>, %arg1: tensor<1x12x1x51xf32>, %arg2: tensor<1x12x1x51xf32>) -> tensor<1x12x1x51xf32> {
+    // CHECK-LABEL: func.func public @test_select_bf16(
+    // CHECK: %[[ARGO[0-9]+]] = {{.*}}(%arg0)
+    // CHECK-SAME: dtype = #tt.supportedDataTypes<f32>
+    // CHECK-SAME: tensor<1x12x1x51xbf16
+    // CHECK-SAME: -> tensor<1x12x1x51xf32
+    // CHECK: "ttnn.where"(%[[ARG0]], %arg1, %arg2
+    // CHECK-SAME: tensor<1x12x1x51xf32
+    // CHECK-SAME: tensor<1x12x1x51xf32
+    // CHECK-SAME: tensor<1x12x1x51xf32
+    // CHECK-SAME: -> tensor<1x12x1x51xf32
+    %0 = stablehlo.select %arg0, %arg1, %arg2 : tensor<1x12x1x51xi1>, tensor<1x12x1x51xf32>
+    return %0 : tensor<1x12x1x51xf32>
+  }
 }


### PR DESCRIPTION
closes #2195 

### Ticket
#2195 

### Problem description
tt-metal uses data type of predicate for implementation of ttnn.where op. If the predicate and inputs/output have different data type; then ttnn.where can generate incorrect results or may cause other failures.

### What's changed
Add a data type workaround to apply the input data type to `predicate` if `input` data type is not same as of `predicate`

### Checklist
- [X] New tests provide coverage for changes
