### PR TITLE
mark failing v0 tests UNSUPPORTED

### DIFF
--- a/include/ttmlir/Dialect/TTMetal/Pipelines/TTMetalPipelines.h
+++ b/include/ttmlir/Dialect/TTMetal/Pipelines/TTMetalPipelines.h
@@ -29,7 +29,7 @@ struct TTIRToTTMetalBackendPipelineOptions
   Option<std::size_t> version{
       *this, "version",
       llvm::cl::desc("Select pipeline implementation version (default: 0)."),
-      llvm::cl::init(0)};
+      llvm::cl::init(1)};
 };
 
 void createTTIRToTTMetalBackendPipeline(

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -21,7 +21,7 @@ def test_unsqueeze(in0: Operand, builder: TTIRBuilder):
     return builder.unsqueeze(in0, 0)
 
 
-@compile_to_flatbuffer([(128, 128)])
+@compile_to_flatbuffer([(128, 128)], targets=["ttnn"])
 def test_exp(in0: Operand, builder: TTIRBuilder):
     return builder.exp(in0)
 
@@ -165,6 +165,7 @@ def test_concat(in0: Operand, in1: Operand, in2: Operand, builder: TTIRBuilder):
         (64, 128),
         (64, 128),
     ],
+    targets=["ttnn"]
 )
 def test_add(in0: Operand, in1: Operand, builder: TTIRBuilder):
     return builder.add(in0, in1)
@@ -175,6 +176,7 @@ def test_add(in0: Operand, in1: Operand, builder: TTIRBuilder):
         (64, 64),
         (64, 64),
     ],
+    targets=["ttnn"]
 )
 def test_multiply(in0: Operand, in1: Operand, builder: TTIRBuilder):
     return builder.multiply(in0, in1)
@@ -427,6 +429,7 @@ def test_reshape(in0: Operand, builder: TTIRBuilder):
         (32, 32),
         (32, 32),
     ],
+    targets=["ttnn"]
 )
 def test_arbitrary_op_chain(
     in0: Operand, in1: Operand, in2: Operand, builder: TTIRBuilder

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -165,7 +165,7 @@ def test_concat(in0: Operand, in1: Operand, in2: Operand, builder: TTIRBuilder):
         (64, 128),
         (64, 128),
     ],
-    targets=["ttnn"]
+    targets=["ttnn"],
 )
 def test_add(in0: Operand, in1: Operand, builder: TTIRBuilder):
     return builder.add(in0, in1)
@@ -176,7 +176,7 @@ def test_add(in0: Operand, in1: Operand, builder: TTIRBuilder):
         (64, 64),
         (64, 64),
     ],
-    targets=["ttnn"]
+    targets=["ttnn"],
 )
 def test_multiply(in0: Operand, in1: Operand, builder: TTIRBuilder):
     return builder.multiply(in0, in1)
@@ -429,7 +429,7 @@ def test_reshape(in0: Operand, builder: TTIRBuilder):
         (32, 32),
         (32, 32),
     ],
-    targets=["ttnn"]
+    targets=["ttnn"],
 )
 def test_arbitrary_op_chain(
     in0: Operand, in1: Operand, in2: Operand, builder: TTIRBuilder

--- a/test/ttmlir/Silicon/TTMetal/n150/perf/test_perf_add.mlir
+++ b/test/ttmlir/Silicon/TTMetal/n150/perf/test_perf_add.mlir
@@ -1,3 +1,4 @@
+// UNSUPPORTED: true
 // RUN: ttmlir-opt --ttir-to-ttmetal-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttmetal-to-flatbuffer %t.mlir > %t.ttm

--- a/test/ttmlir/Silicon/TTMetal/n150/perf/test_perf_div.mlir
+++ b/test/ttmlir/Silicon/TTMetal/n150/perf/test_perf_div.mlir
@@ -1,3 +1,4 @@
+// UNSUPPORTED: true
 // RUN: ttmlir-opt --ttir-to-ttmetal-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttmetal-to-flatbuffer %t.mlir > %t.ttm

--- a/test/ttmlir/Silicon/TTMetal/n150/perf/test_perf_exp.mlir
+++ b/test/ttmlir/Silicon/TTMetal/n150/perf/test_perf_exp.mlir
@@ -1,3 +1,4 @@
+// UNSUPPORTED: true
 // RUN: ttmlir-opt --ttir-to-ttmetal-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttmetal-to-flatbuffer %t.mlir > %t.ttm

--- a/test/ttmlir/Silicon/TTMetal/n150/perf/test_perf_max.mlir
+++ b/test/ttmlir/Silicon/TTMetal/n150/perf/test_perf_max.mlir
@@ -1,3 +1,4 @@
+// UNSUPPORTED: true
 // RUN: ttmlir-opt --ttir-to-ttmetal-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttmetal-to-flatbuffer %t.mlir > %t.ttm

--- a/test/ttmlir/Silicon/TTMetal/n150/perf/test_perf_multiply.mlir
+++ b/test/ttmlir/Silicon/TTMetal/n150/perf/test_perf_multiply.mlir
@@ -1,3 +1,4 @@
+// UNSUPPORTED: true
 // RUN: ttmlir-opt --ttir-to-ttmetal-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttmetal-to-flatbuffer %t.mlir > %t.ttm

--- a/test/ttmlir/Silicon/TTMetal/n150/simple_constant.mlir
+++ b/test/ttmlir/Silicon/TTMetal/n150/simple_constant.mlir
@@ -1,3 +1,4 @@
+// UNSUPPORTED: true
 // RUN: ttmlir-opt --ttir-to-ttmetal-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttmetal-to-flatbuffer %t.mlir > %t.ttm

--- a/test/ttmlir/Silicon/TTMetal/n150/simple_eltwise.mlir
+++ b/test/ttmlir/Silicon/TTMetal/n150/simple_eltwise.mlir
@@ -1,3 +1,4 @@
+// UNSUPPORTED: true
 // RUN: ttmlir-opt --ttir-to-ttmetal-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttmetal-to-flatbuffer %t.mlir > %t.ttm

--- a/test/ttmlir/Silicon/TTMetal/n150/simple_max.mlir
+++ b/test/ttmlir/Silicon/TTMetal/n150/simple_max.mlir
@@ -1,3 +1,4 @@
+// UNSUPPORTED: true
 // RUN: ttmlir-opt --ttir-to-ttmetal-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttmetal-to-flatbuffer %t.mlir > %t.ttm

--- a/test/ttmlir/Silicon/TTMetal/n150/simple_reduce_1x1.mlir
+++ b/test/ttmlir/Silicon/TTMetal/n150/simple_reduce_1x1.mlir
@@ -1,3 +1,4 @@
+// UNSUPPORTED: true
 // RUN: ttmlir-opt --ttir-to-ttmetal-backend-pipeline="system-desc-path=%system_desc_path%"  %s | FileCheck %s
 #l1_ = #tt.memory_space<l1>
 


### PR DESCRIPTION
### Ticket
This closes #2131

### Problem description
Existing ttmetal tests get broken when the new stream/alias encoding is enabled, this disables the failing tests until v1 pipeline is ready.

### What's changed

- TTMetalPipelines.h: set 'version' default to be 1
- test/ttmlir/Silicon/TTMetal/n150/* mlir tests marked with `// UNSUPPORTED: true`
- test/python/golden/test_ttir_ops.py all tests marked with `targets=["ttnn"]`

### Checklist
- looking for CI to remain green on n150 arch
