### PR TITLE
Omit duplicate operands in graph

### DIFF
--- a/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
@@ -30,7 +30,7 @@ class AttrHandler:
 
     @staticmethod
     def default_parser(attr):
-        return [graph_builder.KeyValue(key=str(attr.name), value=str(attr.attr))]
+        return [graph_builder.KeyValue(key=attr.name, value=str(attr.attr))]
 
     @staticmethod
     def parse_attr(attr):
@@ -591,6 +591,8 @@ def build_graph(module, perf_trace=None):
     graph = graph_builder.Graph(id="tt-graph")
 
     op_to_graph_node = {}
+    # Track operands already added to graph to avoid duplicates
+    operands_in_graph = set()
 
     # Prepare perf data for color overlay
     perf_node_data = {}
@@ -639,12 +641,14 @@ def build_graph(module, perf_trace=None):
                         ):
                             # If the owner is not an op, then it is a constant provided from the toplevel FuncOp.
 
-                            # This is a constant and we need to create a node for it.
-                            operand_node = operation.make_constant_node(
-                                operand.get_name()
-                            )
-                            graph.nodes.append(operand_node)
-                            op_to_graph_node[operand] = operand_node
+                            if operand not in operands_in_graph:
+                                # This is a constant and we need to create a node for it.
+                                operand_node = operation.make_constant_node(
+                                    operand.get_name()
+                                )
+                                graph.nodes.append(operand_node)
+                                op_to_graph_node[operand] = operand_node
+                                operands_in_graph.add(operand)
 
                 # This puts the node at the far right when viewing which is a bit more consistant with it being the last operand.
                 for node in append_later:


### PR DESCRIPTION
### Ticket
Closes #2154 

### Problem description
Multiple occurrences of the same operand were being added to the graph. 

### What's changed
Now adding only one node to the graph for each operand.
