### PR TITLE
Exposed the createOwnedTensor API in the runtime to the frontends

### DIFF
--- a/runtime/include/tt/runtime/detail/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn.h
@@ -53,11 +53,11 @@ constexpr std::size_t kL1SmallSize = 1 << 15;
 std::pair<SystemDesc, DeviceIds> getCurrentSystemDesc(
     std::optional<DispatchCoreType> dispatchCoreType = std::nullopt);
 
-::ttnn::Tensor createOwnedTensor(std::shared_ptr<void> data,
-                                 std::vector<std::uint32_t> const &shape,
-                                 std::vector<std::uint32_t> const &stride,
-                                 std::uint32_t itemsize,
-                                 ::tt::target::DataType dataType);
+Tensor createOwnedTensor(std::shared_ptr<void> data,
+                         std::vector<std::uint32_t> const &shape,
+                         std::vector<std::uint32_t> const &stride,
+                         std::uint32_t itemsize,
+                         ::tt::target::DataType dataType);
 
 Tensor createTensor(std::shared_ptr<void> data,
                     std::vector<std::uint32_t> const &shape,

--- a/runtime/include/tt/runtime/detail/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn.h
@@ -53,6 +53,12 @@ constexpr std::size_t kL1SmallSize = 1 << 15;
 std::pair<SystemDesc, DeviceIds> getCurrentSystemDesc(
     std::optional<DispatchCoreType> dispatchCoreType = std::nullopt);
 
+::ttnn::Tensor createOwnedTensor(std::shared_ptr<void> data,
+                                 std::vector<std::uint32_t> const &shape,
+                                 std::vector<std::uint32_t> const &stride,
+                                 std::uint32_t itemsize,
+                                 ::tt::target::DataType dataType);
+
 Tensor createTensor(std::shared_ptr<void> data,
                     std::vector<std::uint32_t> const &shape,
                     std::vector<std::uint32_t> const &stride,

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -47,11 +47,11 @@ void setCompatibleRuntime(const Binary &binary);
 std::pair<SystemDesc, DeviceIds> getCurrentSystemDesc(
     std::optional<DispatchCoreType> dispatchCoreType = std::nullopt);
 
-Tensor createOwnedRuntimeTensor(std::shared_ptr<void> data,
-                                std::vector<std::uint32_t> const &shape,
-                                std::vector<std::uint32_t> const &stride,
-                                std::uint32_t itemsize,
-                                ::tt::target::DataType dataType);
+Tensor createOwnedTensor(std::shared_ptr<void> data,
+                         std::vector<std::uint32_t> const &shape,
+                         std::vector<std::uint32_t> const &stride,
+                         std::uint32_t itemsize,
+                         ::tt::target::DataType dataType);
 
 Tensor createTensor(std::shared_ptr<void> data,
                     std::vector<std::uint32_t> const &shape,

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -47,6 +47,12 @@ void setCompatibleRuntime(const Binary &binary);
 std::pair<SystemDesc, DeviceIds> getCurrentSystemDesc(
     std::optional<DispatchCoreType> dispatchCoreType = std::nullopt);
 
+Tensor createOwnedRuntimeTensor(std::shared_ptr<void> data,
+                                std::vector<std::uint32_t> const &shape,
+                                std::vector<std::uint32_t> const &stride,
+                                std::uint32_t itemsize,
+                                ::tt::target::DataType dataType);
+
 Tensor createTensor(std::shared_ptr<void> data,
                     std::vector<std::uint32_t> const &shape,
                     std::vector<std::uint32_t> const &stride,

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -146,14 +146,15 @@ Tensor createOwnedRuntimeTensor(std::shared_ptr<void> data,
   LOG_ASSERT(itemsize > 0);
 #if defined(TT_RUNTIME_ENABLE_TTNN)
   if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ttnn::utils::createRuntimeTensorFromTTNN(
-        ::tt::runtime::ttnn::createOwnedTensor(data, shape, stride, itemsize,
-                                               dataType));
+    return ::tt::runtime::ttnn::createOwnedTensor(data, shape, stride, itemsize,
+                                                  dataType);
   }
 #endif
 
 #if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  LOG_FATAL("TT Metal runtime does not support creating owned tensors");
+  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
+    LOG_FATAL("TT Metal runtime does not support creating owned tensors");
+  }
 #endif
   LOG_FATAL("runtime is not enabled");
 }

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -11,7 +11,6 @@
 #if defined(TT_RUNTIME_ENABLE_TTNN)
 #include "tt/runtime/detail/ttnn.h"
 #include "tt/runtime/ttnn/types.h"
-#include "tt/runtime/ttnn/utils.h"
 #endif
 
 #if defined(TT_RUNTIME_ENABLE_TTMETAL)
@@ -136,11 +135,11 @@ getCurrentSystemDesc(std::optional<DispatchCoreType> dispatchCoreType) {
   LOG_FATAL("runtime is not enabled");
 }
 
-Tensor createOwnedRuntimeTensor(std::shared_ptr<void> data,
-                                std::vector<std::uint32_t> const &shape,
-                                std::vector<std::uint32_t> const &stride,
-                                std::uint32_t itemsize,
-                                ::tt::target::DataType dataType) {
+Tensor createOwnedTensor(std::shared_ptr<void> data,
+                         std::vector<std::uint32_t> const &shape,
+                         std::vector<std::uint32_t> const &stride,
+                         std::uint32_t itemsize,
+                         ::tt::target::DataType dataType) {
   LOG_ASSERT(not shape.empty());
   LOG_ASSERT(not stride.empty());
   LOG_ASSERT(itemsize > 0);

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -70,11 +70,11 @@ static StorageType createStorage(void *ptr, std::uint32_t numElements,
   }
 }
 
-static ::ttnn::Tensor
-createOwnedTensor(std::shared_ptr<void> data,
-                  std::vector<std::uint32_t> const &shape,
-                  std::vector<std::uint32_t> const &stride,
-                  std::uint32_t itemsize, ::tt::target::DataType dataType) {
+::ttnn::Tensor createOwnedTensor(std::shared_ptr<void> data,
+                                 std::vector<std::uint32_t> const &shape,
+                                 std::vector<std::uint32_t> const &stride,
+                                 std::uint32_t itemsize,
+                                 ::tt::target::DataType dataType) {
   std::uint32_t numElements = shape[0] * stride[0];
 
   return ::ttnn::Tensor(

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -70,17 +70,27 @@ static StorageType createStorage(void *ptr, std::uint32_t numElements,
   }
 }
 
-::ttnn::Tensor createOwnedTensor(std::shared_ptr<void> data,
-                                 std::vector<std::uint32_t> const &shape,
-                                 std::vector<std::uint32_t> const &stride,
-                                 std::uint32_t itemsize,
-                                 ::tt::target::DataType dataType) {
+static ::ttnn::Tensor
+createOwnedTTNNTensor(std::shared_ptr<void> data,
+                      std::vector<std::uint32_t> const &shape,
+                      std::vector<std::uint32_t> const &stride,
+                      std::uint32_t itemsize, ::tt::target::DataType dataType) {
   std::uint32_t numElements = shape[0] * stride[0];
 
   return ::ttnn::Tensor(
       createStorage<OwnedStorage>(data.get(), numElements, dataType),
       ::ttnn::Shape(shape), utils::toTTNNDataType(dataType),
       ::ttnn::Layout::ROW_MAJOR);
+}
+
+Tensor createOwnedTensor(std::shared_ptr<void> data,
+                         std::vector<std::uint32_t> const &shape,
+                         std::vector<std::uint32_t> const &stride,
+                         std::uint32_t itemsize,
+                         ::tt::target::DataType dataType) {
+
+  return utils::createRuntimeTensorFromTTNN(
+      createOwnedTTNNTensor(data, shape, stride, itemsize, dataType));
 }
 
 static Tensor createNullTensor() {
@@ -140,8 +150,8 @@ createTensor(std::vector<std::shared_ptr<void>> &data,
   tensorShards.reserve(data.size());
   std::transform(data.begin(), data.end(), std::back_inserter(tensorShards),
                  [&](std::shared_ptr<void> &dataShard) -> ::ttnn::Tensor {
-                   return createOwnedTensor(dataShard, shape, stride, itemsize,
-                                            dataType);
+                   return createOwnedTTNNTensor(dataShard, shape, stride,
+                                                itemsize, dataType);
                  });
   DistributedTensorConfig distributionStrategy =
       ::tt::tt_metal::get_distributed_tensor_config(strategy);
@@ -161,8 +171,8 @@ Tensor createTensor(Device device, Layout layout,
   const LayoutDesc &layoutDesc = layout.as<LayoutDesc>(DeviceRuntime::TTNN);
   if (layoutDesc.isOnHost()) {
     ::ttnn::Tensor tensor =
-        createOwnedTensor(nullptr, shape, stride, itemsize,
-                          utils::fromTTNNDataType(layoutDesc.dataType));
+        createOwnedTTNNTensor(nullptr, shape, stride, itemsize,
+                              utils::fromTTNNDataType(layoutDesc.dataType));
     Tensor out = utils::createRuntimeTensorFromTTNN(tensor);
     return ::tt::runtime::ttnn::toLayout(out, device, layout);
   }


### PR DESCRIPTION
As outlined in issue https://github.com/tenstorrent/tt-mlir/issues/2203, the fact that there is no way to create an owned tensor has posed a significant problem to the tt-xla frontend and the multichip effort. This PR exposes that functionality, allowing creating of tensors in which the ttnn runtime owns the tensor data.

Fixes https://github.com/tenstorrent/tt-mlir/issues/2203