### PR TITLE
Use `AsmState` instead of `PrintFlags` in `getOpDebugString` 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,12 +11,7 @@ option(TTMLIR_ENABLE_PYKERNEL "Enable python kernels" OFF)
 option(TTMLIR_ENABLE_STABLEHLO "Enable StableHLO support" OFF)
 option(TTMLIR_ENABLE_OPMODEL "Enable OpModel support" OFF)
 option(TTMLIR_ENABLE_SHARED_LIB "Enable Shared lib building" ON)
-option(TTMLIR_ENABLE_DEBUG_STRINGS "Enable debug strings in flatbuffer" ON)
 option(TTMLIR_ENABLE_EXPLORER "Enable cloning and building the explorer tool" ON)
-
-if (TTMLIR_ENABLE_DEBUG_STRINGS)
-  add_compile_definitions(TTMLIR_ENABLE_DEBUG_STRINGS)
-endif()
 
 if (TTMLIR_ENABLE_STABLEHLO)
   add_compile_definitions(TTMLIR_ENABLE_STABLEHLO)


### PR DESCRIPTION
### Ticket

https://github.com/tenstorrent/tt-mlir/issues/2159

### Problem description
Described in https://github.com/tenstorrent/tt-mlir/pull/2157 and https://github.com/tenstorrent/tt-mlir/pull/1782.

### What's changed
This should fix the issue with debug string execution time for good. I have removed the workaround introduced in https://github.com/tenstorrent/tt-mlir/pull/1782, since debug string execution time is now negligible even for larger models. 

All credits to @nsmithtt for discovering this.

### Checklist
- [ ] New/Existing tests provide coverage for changes
