### PR TITLE
Tag hoisted calls with special attr

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROpsAttrs.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROpsAttrs.td
@@ -45,4 +45,13 @@ def TTIR_ConvolutionLayoutAttr : AttrDef<TTIR_Dialect, "ConvolutionLayout", [], 
   }];
 }
 
+def TTIR_HoistedCallAttr : AttrDef<TTIR_Dialect, "HoistedCall", [], "::mlir::Attribute"> {
+  let mnemonic = "hoisted_call";
+  let summary = "Indicates that this call operation has been hoisted";
+  let description = [{
+    This attribute marks call operations that have been hoisted during optimization.
+    It is used as a marker and doesn't carry any additional data.
+  }];
+}
+
 #endif // TTMLIR_TTIR_ATTRS_TD

--- a/lib/Dialect/TTIR/Transforms/HoistCPUOps.cpp
+++ b/lib/Dialect/TTIR/Transforms/HoistCPUOps.cpp
@@ -153,7 +153,8 @@ static void hoistOperationToFunction(mlir::Operation *opToHoist,
       opToHoist->getLoc(), localFunc, opToHoist->getOperands());
 
   // Add the hoisted_call attribute
-  callOp->setAttr("ttir.hoisted_call", UnitAttr::get(opToHoist->getContext()));
+  callOp->setAttr(HoistedCallAttr::name,
+                  UnitAttr::get(opToHoist->getContext()));
 
   // Replace all results of the original operation with the call results.
   opToHoist->replaceAllUsesWith(callOp);

--- a/lib/Dialect/TTIR/Transforms/HoistCPUOps.cpp
+++ b/lib/Dialect/TTIR/Transforms/HoistCPUOps.cpp
@@ -152,6 +152,9 @@ static void hoistOperationToFunction(mlir::Operation *opToHoist,
   auto callOp = opBuilder.create<mlir::func::CallOp>(
       opToHoist->getLoc(), localFunc, opToHoist->getOperands());
 
+  // Add the hoisted_call attribute
+  callOp->setAttr("ttir.hoisted_call", UnitAttr::get(opToHoist->getContext()));
+
   // Replace all results of the original operation with the call results.
   opToHoist->replaceAllUsesWith(callOp);
 

--- a/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
@@ -442,7 +442,7 @@ public:
   // Match and rewrite the CallOp.
   LogicalResult matchAndRewrite(func::CallOp callOp,
                                 PatternRewriter &rewriter) const override {
-    if (!callOp->hasAttr("hoisted_call")) {
+    if (!callOp->hasAttr("ttir.hoisted_call")) {
       return failure();
     }
 

--- a/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
@@ -442,7 +442,7 @@ public:
   // Match and rewrite the CallOp.
   LogicalResult matchAndRewrite(func::CallOp callOp,
                                 PatternRewriter &rewriter) const override {
-    if (!callOp->hasAttr("ttir.hoisted_call")) {
+    if (!callOp->hasAttr(ttir::HoistedCallAttr::name)) {
       return failure();
     }
 

--- a/test/ttmlir/Dialect/TTNN/ttir_to_ttnn_pipeline_hoist_call.mlir
+++ b/test/ttmlir/Dialect/TTNN/ttir_to_ttnn_pipeline_hoist_call.mlir
@@ -11,10 +11,10 @@ module attributes {} {
     %2 = "ttir.ones"() <{shape = array<i32:64, 128>}> : () -> tensor<64x128xf32>
     // CHECK: %{{.*}} = "ttnn.from_device"(%{{.*}}) : (tensor<[[DIMS:.*]], #{{.*}}>) -> tensor<[[DIMS]], #{{.*}}>
     // CHECK: %{{.*}} = call @hoisted_func_decl(%{{.*}}, %{{.*}}, %{{.*}})
-    %3 = call @hoisted_func_decl(%arg0, %1, %2) {hoisted_call} : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+    %3 = call @hoisted_func_decl(%arg0, %1, %2) {ttir.hoisted_call} : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
     // CHECK: %{{.*}} = "ttnn.zeros"
     %4 = "ttir.zeros"() <{shape = array<i32:64, 128>}> : () -> tensor<64x128xf32>
-    %5 = call @hoisted_func_decl(%arg0, %3, %4) {hoisted_call} : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+    %5 = call @hoisted_func_decl(%arg0, %3, %4) {ttir.hoisted_call} : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
     // CHECK: %{{.*}} = "ttnn.empty"(%{{.*}})
     %6 = tensor.empty() : tensor<64x128xf32>
     // CHECK: %{{.*}} = "ttnn.to_layout"(%{{.*}}) <{layout = #ttnn.layout<{{.*}}>}> : (tensor<[[DIMS:.*]], #{{.*}}>) -> tensor<[[DIMS]], #{{.*}}>


### PR DESCRIPTION
### Problem description
In earlier TTNNLayout PR, I missed a change to HoistCPUOps.cpp which tags hoisted calls with special attr.  This PR adds in this change + makes it a ttir dialect attr instead of an anonymous one.
### What's changed
Small change to hoisting logic to tag resulting calls with `ttir.hoisted_call` attr, used by TTNNLayout.cpp.  Change testcase to reflect this.

### Checklist
- [x] New/Existing tests provide coverage for changes
