### PR TITLE
Add `transpose` to `ttir_builder`

### DIFF
--- a/python/test_infra/ttir_builder.py
+++ b/python/test_infra/ttir_builder.py
@@ -683,6 +683,17 @@ class TTIRBuilder:
             organize_ttir_args=lambda i, o, shape: (self._get_type(o), i[0], i[1], o),
         )
 
+    def transpose(self, in0: Operand, dim0: int = 0, dim1: int = 1) -> OpView:
+        kwargs = {"dim0": dim0, "dim1": dim1}
+        return self.op_proxy(
+            torch.transpose,
+            ttir.TransposeOp,
+            [in0],
+            golden_kwargs=kwargs,
+            ttir_kwargs=kwargs,
+            organize_ttir_args=lambda i, o, _: (self._get_type(o), i[0], o),
+        )
+
     def softmax(self, in0: Operand, dimension: int = 1) -> OpView:
         return self.op_proxy(
             torch.softmax,

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -409,6 +409,16 @@ def test_reshape(in0: Operand, builder: TTIRBuilder):
     return builder.reshape(in0, [2048])
 
 
+@compile_to_flatbuffer(
+    [
+        (32, 64),
+    ],
+    targets=["ttnn"],
+)
+def test_transpose(in0: Operand, builder: TTIRBuilder):
+    return builder.transpose(in0)
+
+
 # @compile_to_flatbuffer(
 #   [
 #       (64, 64),


### PR DESCRIPTION
Closes #1961
Closes #1759

### Problem description
`transpose` wasn't exposed to `ttir_builder`, preventing llama attention layer modelling

### Special Thanks
To @vprajapati-tt for inadvertently fixing a blocking memory issue that was exposed by this bug (See #2136 )