### PR TITLE
Decouple ttmetal and ttnn flatbuffer types

### DIFF
--- a/include/ttmlir/Target/Common/types.fbs
+++ b/include/ttmlir/Target/Common/types.fbs
@@ -51,15 +51,6 @@ enum ChipCapability: uint32 (bit_flags) {
   HostMMIO,
 }
 
-enum TensorMemoryLayout: ushort {
-  None,
-  Interleaved,
-  SingleBank,
-  HeightSharded,
-  WidthSharded,
-  BlockSharded,
-}
-
 enum TensorLayout: ushort {
   RowMajor,
   Tile,
@@ -72,98 +63,6 @@ enum BufferType: ushort {
   SystemMemory,
   L1Small,
   Trace,
-}
-
-enum MeshShardDirection: uint32 {
-  FullToShardShape,
-  ShardToFullShape,
-}
-
-enum MeshShardType: uint32 {
-  Manual,
-  Replicate,
-  Maximal,
-  Devices,
-}
-
-// TODO (#620): Add other fields like core_ranges, shard orientation etc.
-table ShardSpec {
-  shard_shape: [int64];
-}
-
-table MemoryConfigDesc {
-  tensor_memory_layout: TensorMemoryLayout;
-  buffer_type: BufferType;
-  shard_spec: ShardSpec;
-}
-
-table ReplicateTensor {
-  replication_factor: uint32;
-}
-
-table ShardTensor {
-  shard_dim: uint32;
-}
-
-table ShardTensor2D {
-  shard_mesh: Dim2d;
-}
-
-table AllGatherTensor {
-
-}
-
-union DistributedTensorConfig {
-  ReplicateTensor,
-  ShardTensor,
-  ShardTensor2D,
-  AllGatherTensor
-}
-
-table DistributionStrategy {
-  strategy: DistributedTensorConfig;
-}
-
-table MemoryDesc {
-  shape: [int];
-  tile_shape: Dim2d;
-  data_type: DataType;
-  memory_space: MemorySpace;
-  memory_layout: TensorMemoryLayout;
-  size: uint64;
-}
-
-table LayoutDesc {
-  oob_val: OOBVal;
-  core_range_set: [Dim2dRange];
-  memory_desc: MemoryDesc;
-  strategy: DistributionStrategy;
-}
-
-table TensorDesc {
-  shape: [int];
-  layout: LayoutDesc;
-}
-
-table CBDesc {
-  port: uint32;
-  memory_desc: MemoryDesc;
-  page_size: uint64;
-  num_buffers: uint64;
-}
-
-table TensorRef {
-  global_id: uint32;
-  address: uint64;
-  size: uint64;
-  desc: TensorDesc;
-}
-
-table CBRef {
-  global_id: uint32;
-  tensor_ref: TensorRef;
-  address: uint64;
-  desc: CBDesc;
 }
 
 table ChipDesc {
@@ -206,8 +105,7 @@ table ChipPhysicalCores {
   eth_inactive: [Dim2d];
 }
 
-enum CPURole: uint8
-{
+enum CPURole: uint8 {
   Host,
   Device,
 }

--- a/include/ttmlir/Target/TTMetal/CMakeLists.txt
+++ b/include/ttmlir/Target/TTMetal/CMakeLists.txt
@@ -1,6 +1,7 @@
 include(BuildFlatbuffers)
 
 set(TTMETAL_FBS_GEN_SOURCES
+  types.fbs
   command.fbs
   program.fbs
   binary.fbs

--- a/include/ttmlir/Target/TTMetal/Target.h
+++ b/include/ttmlir/Target/TTMetal/Target.h
@@ -14,6 +14,7 @@
 #include "ttmlir/Target/TTMetal/binary_generated.h"
 #include "ttmlir/Target/TTMetal/command_generated.h"
 #include "ttmlir/Target/TTMetal/program_generated.h"
+#include "ttmlir/Target/TTMetal/types_generated.h"
 
 #pragma clang diagnostic pop
 

--- a/include/ttmlir/Target/TTMetal/binary.fbs
+++ b/include/ttmlir/Target/TTMetal/binary.fbs
@@ -2,6 +2,7 @@ include "Common/types.fbs";
 include "Common/version.fbs";
 include "Common/debug_info.fbs";
 include "command.fbs";
+include "types.fbs";
 
 namespace tt.target.metal;
 

--- a/include/ttmlir/Target/TTMetal/command.fbs
+++ b/include/ttmlir/Target/TTMetal/command.fbs
@@ -1,4 +1,5 @@
 include "program.fbs";
+include "types.fbs";
 
 namespace tt.target.metal;
 

--- a/include/ttmlir/Target/TTMetal/program.fbs
+++ b/include/ttmlir/Target/TTMetal/program.fbs
@@ -1,4 +1,5 @@
 include "Common/types.fbs";
+include "types.fbs";
 
 namespace tt.target.metal;
 

--- a/include/ttmlir/Target/TTMetal/types.fbs
+++ b/include/ttmlir/Target/TTMetal/types.fbs
@@ -1,0 +1,43 @@
+include "Common/types.fbs";
+
+namespace tt.target.metal;
+
+table MemoryDesc {
+  shape: [int];
+  tile_shape: Dim2d;
+  data_type: DataType;
+  memory_space: MemorySpace;
+  size: uint64;
+}
+
+table LayoutDesc {
+  oob_val: OOBVal;
+  core_range_set: [Dim2dRange];
+  memory_desc: MemoryDesc;
+}
+
+table TensorDesc {
+  shape: [int];
+  layout: LayoutDesc;
+}
+
+table CBDesc {
+  port: uint32;
+  memory_desc: MemoryDesc;
+  page_size: uint64;
+  num_buffers: uint64;
+}
+
+table TensorRef {
+  global_id: uint32;
+  address: uint64;
+  size: uint64;
+  desc: TensorDesc;
+}
+
+table CBRef {
+  global_id: uint32;
+  tensor_ref: TensorRef;
+  address: uint64;
+  desc: CBDesc;
+}

--- a/include/ttmlir/Target/TTNN/CMakeLists.txt
+++ b/include/ttmlir/Target/TTNN/CMakeLists.txt
@@ -1,6 +1,7 @@
 include(BuildFlatbuffers)
 
 set(TTNN_FBS_GEN_SOURCES
+  types.fbs
   binary.fbs
   program.fbs
 )

--- a/include/ttmlir/Target/TTNN/Target.h
+++ b/include/ttmlir/Target/TTNN/Target.h
@@ -13,6 +13,7 @@
 #include "ttmlir/Target/Common/types_generated.h"
 #include "ttmlir/Target/Common/version_generated.h"
 #include "ttmlir/Target/TTNN/binary_generated.h"
+#include "ttmlir/Target/TTNN/types_generated.h"
 
 #pragma clang diagnostic pop
 

--- a/include/ttmlir/Target/TTNN/binary.fbs
+++ b/include/ttmlir/Target/TTNN/binary.fbs
@@ -1,6 +1,7 @@
 include "Common/types.fbs";
 include "Common/version.fbs";
 include "program.fbs";
+include "types.fbs";
 
 namespace tt.target.ttnn;
 

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -1,5 +1,6 @@
 include "Common/types.fbs";
 include "Common/debug_info.fbs";
+include "types.fbs";
 
 namespace tt.target.ttnn;
 
@@ -10,55 +11,55 @@ table GetDeviceOp {
 }
 
 table ToMemoryConfigOp {
-  in0: tt.target.TensorRef;
-  memcfg: MemoryConfigDesc;
-  out: tt.target.TensorRef;
+  in0: tt.target.ttnn.TensorRef;
+  memcfg: tt.target.ttnn.MemoryConfig;
+  out: tt.target.ttnn.TensorRef;
 }
 
 table ToLayoutOp {
-  in: tt.target.TensorRef;
+  in: tt.target.ttnn.TensorRef;
   layout: tt.target.TensorLayout;
   dtype: tt.target.DataType = null;
-  memcfg: tt.target.MemoryConfigDesc;
+  memcfg: tt.target.ttnn.MemoryConfig;
   device: tt.target.DeviceRef;
-  out: tt.target.TensorRef;
+  out: tt.target.ttnn.TensorRef;
 }
 
 table ToDTypeOp {
-  in: tt.target.TensorRef;
+  in: tt.target.ttnn.TensorRef;
   dtype: tt.target.DataType;
-  out: tt.target.TensorRef;
+  out: tt.target.ttnn.TensorRef;
 }
 
 table TypecastOp {
-  in: tt.target.TensorRef;
+  in: tt.target.ttnn.TensorRef;
   dtype: tt.target.DataType;
-  out: tt.target.TensorRef;
+  out: tt.target.ttnn.TensorRef;
 }
 
 table ToDeviceOp {
-  in: tt.target.TensorRef;
+  in: tt.target.ttnn.TensorRef;
   device: tt.target.DeviceRef;
-  memcfg: tt.target.MemoryConfigDesc;
-  out: tt.target.TensorRef;
+  memcfg: tt.target.ttnn.MemoryConfig;
+  out: tt.target.ttnn.TensorRef;
 }
 
 table UpdateCacheOp {
-  cache: tt.target.TensorRef;
-  input: tt.target.TensorRef;
-  update_index: tt.target.TensorRef;
+  cache: tt.target.ttnn.TensorRef;
+  input: tt.target.ttnn.TensorRef;
+  update_index: tt.target.ttnn.TensorRef;
   batch_offset: uint32;
 }
 
 table FillCacheOp {
-  cache: tt.target.TensorRef;
-  input: tt.target.TensorRef;
+  cache: tt.target.ttnn.TensorRef;
+  input: tt.target.ttnn.TensorRef;
   batch_offset: uint32;
 }
 
 table FromDeviceOp {
-  in: tt.target.TensorRef;
-  out: tt.target.TensorRef;
+  in: tt.target.ttnn.TensorRef;
+  out: tt.target.ttnn.TensorRef;
 }
 
 table EmptyOp {
@@ -67,9 +68,9 @@ table EmptyOp {
   layout: TensorLayout;
   num_shards: uint32;
   device: tt.target.DeviceRef;
-  memcfg: tt.target.MemoryConfigDesc;
-  strategy: tt.target.DistributionStrategy;
-  out: tt.target.TensorRef;
+  memcfg: tt.target.ttnn.MemoryConfig;
+  strategy: tt.target.ttnn.DistributionStrategy;
+  out: tt.target.ttnn.TensorRef;
 }
 
 table ZerosOp {
@@ -77,8 +78,8 @@ table ZerosOp {
   dtype: DataType = null;
   layout: TensorLayout = null;
   device: tt.target.DeviceRef;
-  memcfg: tt.target.MemoryConfigDesc;
-  out: tt.target.TensorRef;
+  memcfg: tt.target.ttnn.MemoryConfig;
+  out: tt.target.ttnn.TensorRef;
 }
 
 table OnesOp {
@@ -86,16 +87,16 @@ table OnesOp {
   dtype: DataType = null;
   layout: TensorLayout = null;
   device: tt.target.DeviceRef;
-  memcfg: tt.target.MemoryConfigDesc;
-  out: tt.target.TensorRef;
+  memcfg: tt.target.ttnn.MemoryConfig;
+  out: tt.target.ttnn.TensorRef;
 }
 
 table FullOp {
   device: tt.target.DeviceRef;
   fill_value: float;
   num_shards: uint32;
-  strategy: tt.target.DistributionStrategy;
-  out: tt.target.TensorRef;
+  strategy: tt.target.ttnn.DistributionStrategy;
+  out: tt.target.ttnn.TensorRef;
 }
 
 table ArangeOp {
@@ -104,8 +105,8 @@ table ArangeOp {
   step: float;
   dtype: tt.target.DataType = null;
   device: tt.target.DeviceRef;
-  memcfg: tt.target.MemoryConfigDesc;
-  out: tt.target.TensorRef;
+  memcfg: tt.target.ttnn.MemoryConfig;
+  out: tt.target.ttnn.TensorRef;
 }
 
 enum EltwiseOpType: uint32 {
@@ -175,16 +176,16 @@ union EltwiseOpParams {
 
 table EltwiseOp {
   type: EltwiseOpType;
-  ins: [tt.target.TensorRef];
-  out: tt.target.TensorRef;
+  ins: [tt.target.ttnn.TensorRef];
+  out: tt.target.ttnn.TensorRef;
   params: EltwiseOpParams;
 }
 
 table MorehCumSumOp {
-  in: tt.target.TensorRef;
-  out: tt.target.TensorRef;
+  in: tt.target.ttnn.TensorRef;
+  out: tt.target.ttnn.TensorRef;
   dim: int64;
-  memcfg: tt.target.MemoryConfigDesc;
+  memcfg: tt.target.ttnn.MemoryConfig;
 }
 
 enum ReductionOpType: uint32 {
@@ -196,121 +197,121 @@ enum ReductionOpType: uint32 {
 
 table ReductionOp {
   type: ReductionOpType;
-  in: tt.target.TensorRef;
-  out: tt.target.TensorRef;
+  in: tt.target.ttnn.TensorRef;
+  out: tt.target.ttnn.TensorRef;
   dim_arg: [int32];
   keep_dim: bool;
 }
 
 table ReductionArgMaxOp {
-  in: tt.target.TensorRef;
-  out: tt.target.TensorRef;
+  in: tt.target.ttnn.TensorRef;
+  out: tt.target.ttnn.TensorRef;
   dim: int32 = null;
   use_multicore: bool;
-  memcfg: tt.target.MemoryConfigDesc;
+  memcfg: tt.target.ttnn.MemoryConfig;
 }
 
 table ReductionProdOp {
-  in: tt.target.TensorRef;
-  out: tt.target.TensorRef;
+  in: tt.target.ttnn.TensorRef;
+  out: tt.target.ttnn.TensorRef;
   all_dimensions: bool;
   dim_arg: int64;
   keep_dim: bool;
-  memcfg: tt.target.MemoryConfigDesc;
+  memcfg: tt.target.ttnn.MemoryConfig;
 }
 
 table EmbeddingOp {
-  input: tt.target.TensorRef;
-  weight: tt.target.TensorRef;
-  out: tt.target.TensorRef;
+  input: tt.target.ttnn.TensorRef;
+  weight: tt.target.ttnn.TensorRef;
+  out: tt.target.ttnn.TensorRef;
 }
 
 table EmbeddingBackwardOp {
-  input: tt.target.TensorRef;
-  weight: tt.target.TensorRef;
-  in_grad: tt.target.TensorRef;
+  input: tt.target.ttnn.TensorRef;
+  weight: tt.target.ttnn.TensorRef;
+  in_grad: tt.target.ttnn.TensorRef;
   dtype: tt.target.DataType = null;
-  memcfg: tt.target.MemoryConfigDesc;
-  out: tt.target.TensorRef;
+  memcfg: tt.target.ttnn.MemoryConfig;
+  out: tt.target.ttnn.TensorRef;
 }
 
 table RepeatInterleaveOp {
-  input: tt.target.TensorRef;
-  out: tt.target.TensorRef;
+  input: tt.target.ttnn.TensorRef;
+  out: tt.target.ttnn.TensorRef;
   repeats: uint32;
   dim: int32;
-  memory_config: MemoryConfigDesc;
+  memory_config: tt.target.ttnn.MemoryConfig;
 }
 
 table SoftmaxOp {
-  in: tt.target.TensorRef;
-  out: tt.target.TensorRef;
+  in: tt.target.ttnn.TensorRef;
+  out: tt.target.ttnn.TensorRef;
   dimension: int32;
 }
 
 table TransposeOp {
-  in: tt.target.TensorRef;
-  out: tt.target.TensorRef;
+  in: tt.target.ttnn.TensorRef;
+  out: tt.target.ttnn.TensorRef;
   dim0: int32;
   dim1: int32;
 }
 
 table ConcatOp {
- inputs: [tt.target.TensorRef];
- out: tt.target.TensorRef;
+ inputs: [tt.target.ttnn.TensorRef];
+ out: tt.target.ttnn.TensorRef;
  dim: int32;
- memory_config: MemoryConfigDesc;
+ memory_config: tt.target.ttnn.MemoryConfig;
 }
 
 table ReshapeOp {
-  in: tt.target.TensorRef;
-  out: tt.target.TensorRef;
+  in: tt.target.ttnn.TensorRef;
+  out: tt.target.ttnn.TensorRef;
   shape: [int32];
 }
 
 table RepeatOp {
-  in: tt.target.TensorRef;
-  out: tt.target.TensorRef;
+  in: tt.target.ttnn.TensorRef;
+  out: tt.target.ttnn.TensorRef;
   repeat_dims: [int64];
 }
 
 table PadOp {
-  in: tt.target.TensorRef;
-  out: tt.target.TensorRef;
+  in: tt.target.ttnn.TensorRef;
+  out: tt.target.ttnn.TensorRef;
   padding: [uint32];
   value: float;
   use_multicore: bool;
-  memcfg: MemoryConfigDesc;
+  memcfg: tt.target.ttnn.MemoryConfig;
 }
 
 table SliceOp {
-  in: tt.target.TensorRef;
-  out: tt.target.TensorRef;
+  in: tt.target.ttnn.TensorRef;
+  out: tt.target.ttnn.TensorRef;
   begins: [int64];
   ends: [int64];
   step: [int64];
 }
 
 table LinearOp {
-  in0: tt.target.TensorRef;
-  in1: tt.target.TensorRef;
-  bias: tt.target.TensorRef;
-  out: tt.target.TensorRef;
+  in0: tt.target.ttnn.TensorRef;
+  in1: tt.target.ttnn.TensorRef;
+  bias: tt.target.ttnn.TensorRef;
+  out: tt.target.ttnn.TensorRef;
 }
 
 // ANCHOR: adding_an_op_matmul_fbs
 table MatmulOp {
-  in0: tt.target.TensorRef;
-  in1: tt.target.TensorRef;
-  out: tt.target.TensorRef;
+  in0: tt.target.ttnn.TensorRef;
+  in1: tt.target.ttnn.TensorRef;
+  out: tt.target.ttnn.TensorRef;
 }
 // ANCHOR_END: adding_an_op_matmul_fbs
 
 table Conv2dOp {
-  input: tt.target.TensorRef;
-  weight: tt.target.TensorRef;
-  bias: tt.target.TensorRef;
-  out: tt.target.TensorRef;
+  input: tt.target.ttnn.TensorRef;
+  weight: tt.target.ttnn.TensorRef;
+  bias: tt.target.ttnn.TensorRef;
+  out: tt.target.ttnn.TensorRef;
   device: tt.target.DeviceRef;
   in_channels: uint32;
   out_channels: uint32;
@@ -329,10 +330,10 @@ table Conv2dOp {
 }
 
 table ConvTranspose2dOp {
-  input: tt.target.TensorRef;
-  weight: tt.target.TensorRef;
-  bias: tt.target.TensorRef;
-  out: tt.target.TensorRef;
+  input: tt.target.ttnn.TensorRef;
+  weight: tt.target.ttnn.TensorRef;
+  bias: tt.target.ttnn.TensorRef;
+  out: tt.target.ttnn.TensorRef;
   device: tt.target.DeviceRef;
   in_channels: uint32;
   out_channels: uint32;
@@ -348,8 +349,8 @@ table ConvTranspose2dOp {
 }
 
 table MaxPool2dOp {
-  in: tt.target.TensorRef;
-  out: tt.target.TensorRef;
+  in: tt.target.ttnn.TensorRef;
+  out: tt.target.ttnn.TensorRef;
   device: tt.target.DeviceRef;
   batch_size: uint32;
   input_height: uint32;
@@ -367,13 +368,13 @@ table MaxPool2dOp {
 }
 
 table DeallocateOp {
-  in: tt.target.TensorRef;
+  in: tt.target.ttnn.TensorRef;
   force: bool;
 }
 
 table AllGatherOp {
-  in: tt.target.TensorRef;
-  out: tt.target.TensorRef;
+  in: tt.target.ttnn.TensorRef;
+  out: tt.target.ttnn.TensorRef;
   device: tt.target.DeviceRef;
   all_gather_dim: int32;
   cluster_axis: uint32;
@@ -381,16 +382,16 @@ table AllGatherOp {
 }
 
 table PermuteOp {
-  in: tt.target.TensorRef;
+  in: tt.target.ttnn.TensorRef;
   permutation: [int64];
-  memory_config: MemoryConfigDesc;
+  memory_config: tt.target.ttnn.MemoryConfig;
   pad_value: float;
-  out: tt.target.TensorRef;
+  out: tt.target.ttnn.TensorRef;
 }
 
 table ReduceScatterOp {
-  in: tt.target.TensorRef;
-  out: tt.target.TensorRef;
+  in: tt.target.ttnn.TensorRef;
+  out: tt.target.ttnn.TensorRef;
   device: tt.target.DeviceRef;
   scatter_split_dim: uint32;
   math_op: uint32;
@@ -398,11 +399,11 @@ table ReduceScatterOp {
 }
 
 table MeshShardOp {
-  in: tt.target.TensorRef;
-  out: tt.target.TensorRef;
+  in: tt.target.ttnn.TensorRef;
+  out: tt.target.ttnn.TensorRef;
   device: tt.target.DeviceRef;
-  shard_direction: tt.target.MeshShardDirection;
-  shard_type: tt.target.MeshShardType;
+  shard_direction: tt.target.ttnn.MeshShardDirection;
+  shard_type: tt.target.ttnn.MeshShardType;
   shard_shape: [int64];
   shard_dims: [int64];
 }
@@ -421,22 +422,22 @@ union Scale2D {
 }
 
 table UpsampleOp {
-  in: tt.target.TensorRef;
+  in: tt.target.ttnn.TensorRef;
   scale_factor: Scale2D;
   mode: string;
-  memory_config: MemoryConfigDesc;
-  out: tt.target.TensorRef;
+  memory_config: tt.target.ttnn.MemoryConfig;
+  out: tt.target.ttnn.TensorRef;
 }
 
 table CpuOp {
-  ins: [tt.target.TensorRef];
-  out: tt.target.TensorRef;
+  ins: [tt.target.ttnn.TensorRef];
+  out: tt.target.ttnn.TensorRef;
   func_name: string;
   dylib_id: uint32;
 }
 
 table ConstantOp {
-  out: tt.target.TensorRef;
+  out: tt.target.ttnn.TensorRef;
   data: [ubyte];
 }
 

--- a/include/ttmlir/Target/TTNN/types.fbs
+++ b/include/ttmlir/Target/TTNN/types.fbs
@@ -1,0 +1,94 @@
+include "Common/types.fbs";
+
+namespace tt.target.ttnn;
+
+enum TensorMemoryLayout: ushort {
+  Interleaved,
+  SingleBank,
+  HeightSharded,
+  WidthSharded,
+  BlockSharded,
+}
+
+enum StorageType: ushort {
+    Owned,
+    Device,
+    Borrowed,
+    MultiDevice,
+    MultiDeviceHost,
+}
+
+enum MeshShardDirection: uint32 {
+  FullToShardShape,
+  ShardToFullShape,
+}
+
+enum MeshShardType: uint32 {
+  Manual,
+  Replicate,
+  Maximal,
+  Devices,
+}
+
+table ReplicateTensor {
+  replication_factor: uint32;
+}
+
+table ShardTensor {
+  shard_dim: uint32;
+}
+
+table ShardTensor2D {
+  shard_mesh: Dim2d;
+}
+
+table AllGatherTensor {
+
+}
+
+union DistributedTensorConfig {
+  ReplicateTensor,
+  ShardTensor,
+  ShardTensor2D,
+  AllGatherTensor
+}
+
+table DistributionStrategy {
+  strategy: DistributedTensorConfig;
+}
+
+table ShardSpec {
+  grid: [Dim2dRange];
+  shard_shape: [int32];
+}
+
+table MemoryConfig {
+  tensor_memory_layout: TensorMemoryLayout;
+  buffer_type: BufferType;
+  shard_spec: ShardSpec;
+}
+
+table MemoryDesc {
+  storage_type: StorageType;
+  tile_shape: Dim2d;
+  data_type: DataType;
+  memory_config: MemoryConfig;
+  size: uint64;
+}
+
+table LayoutDesc {
+  oob_val: OOBVal;
+  memory_desc: MemoryDesc;
+  strategy: DistributionStrategy;
+}
+
+table TensorDesc {
+  shape: [int];
+  layout: LayoutDesc;
+}
+
+table TensorRef {
+  global_id: uint32;
+  size: uint64;
+  desc: TensorDesc;
+}

--- a/include/ttmlir/Target/TTNN/utils.h
+++ b/include/ttmlir/Target/TTNN/utils.h
@@ -12,20 +12,20 @@
 
 namespace tt::mlir::ttnn::utils {
 
-::tt::target::TensorMemoryLayout toTargetTensorMemoryLayout(
+::tt::target::ttnn::TensorMemoryLayout toTargetTensorMemoryLayout(
     ::mlir::tt::ttnn::TensorMemoryLayout tensorMemoryLayout) {
 
   switch (tensorMemoryLayout) {
   case ::mlir::tt::ttnn::TensorMemoryLayout::Interleaved:
-    return ::tt::target::TensorMemoryLayout::Interleaved;
+    return ::tt::target::ttnn::TensorMemoryLayout::Interleaved;
   case ::mlir::tt::ttnn::TensorMemoryLayout::SingleBank:
-    return ::tt::target::TensorMemoryLayout::SingleBank;
+    return ::tt::target::ttnn::TensorMemoryLayout::SingleBank;
   case ::mlir::tt::ttnn::TensorMemoryLayout::HeightSharded:
-    return ::tt::target::TensorMemoryLayout::HeightSharded;
+    return ::tt::target::ttnn::TensorMemoryLayout::HeightSharded;
   case ::mlir::tt::ttnn::TensorMemoryLayout::WidthSharded:
-    return ::tt::target::TensorMemoryLayout::WidthSharded;
+    return ::tt::target::ttnn::TensorMemoryLayout::WidthSharded;
   case ::mlir::tt::ttnn::TensorMemoryLayout::BlockSharded:
-    return ::tt::target::TensorMemoryLayout::BlockSharded;
+    return ::tt::target::ttnn::TensorMemoryLayout::BlockSharded;
   }
 
   llvm_unreachable("Unsupported TensorMemoryLayout");

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -19,15 +19,6 @@
 
 namespace mlir::tt {
 
-flatbuffers::Offset<::tt::target::LayoutDesc>
-metalLayoutAttrToFlatbuffer(FlatbufferObjectCache &cache, MetalLayoutAttr attr,
-                            ArrayRef<int64_t> logicalShape,
-                            DeviceAttr deviceAttr);
-
-flatbuffers::Offset<::tt::target::LayoutDesc> ttnnLayoutAttrToFlatbuffer(
-    FlatbufferObjectCache &cache, ttnn::TTNNLayoutAttr attr,
-    ArrayRef<int64_t> logicalShape, DeviceAttr deviceAttr);
-
 struct GoldenTensor {
   std::string name;
   std::vector<int64_t> shape;
@@ -55,24 +46,6 @@ inline ::tt::target::OOBVal toFlatbuffer(FlatbufferObjectCache &,
     return ::tt::target::OOBVal::Inf;
   case OOBVal::NegInf:
     return ::tt::target::OOBVal::NegInf;
-  }
-}
-
-inline ::tt::target::TensorMemoryLayout
-toFlatbuffer(FlatbufferObjectCache &, TensorMemoryLayout memLayout) {
-  switch (memLayout) {
-  case TensorMemoryLayout::None:
-    return ::tt::target::TensorMemoryLayout::None;
-  case TensorMemoryLayout::Interleaved:
-    return ::tt::target::TensorMemoryLayout::Interleaved;
-  case TensorMemoryLayout::SingleBank:
-    return ::tt::target::TensorMemoryLayout::SingleBank;
-  case TensorMemoryLayout::HeightSharded:
-    return ::tt::target::TensorMemoryLayout::HeightSharded;
-  case TensorMemoryLayout::WidthSharded:
-    return ::tt::target::TensorMemoryLayout::WidthSharded;
-  case TensorMemoryLayout::BlockSharded:
-    return ::tt::target::TensorMemoryLayout::BlockSharded;
   }
 }
 
@@ -431,44 +404,6 @@ toFlatbuffer(FlatbufferObjectCache &cache, ElementsAttr elementsAttr) {
   }
   SmallVector<uint32_t> data({value});
   return toFlatbuffer(cache, ArrayRef<uint32_t>(data));
-}
-
-inline flatbuffers::Offset<::tt::target::LayoutDesc>
-encodingToFlatbuffer(FlatbufferObjectCache &cache, Attribute attr,
-                     ArrayRef<int64_t> logicalShape, DeviceAttr deviceAttr) {
-  if (isa<MetalLayoutAttr>(attr)) {
-    return metalLayoutAttrToFlatbuffer(cache, cast<MetalLayoutAttr>(attr),
-                                       logicalShape, deviceAttr);
-  }
-
-  assert(isa<ttnn::TTNNLayoutAttr>(attr) && "unsupported layout attr");
-  return ttnnLayoutAttrToFlatbuffer(cache, cast<ttnn::TTNNLayoutAttr>(attr),
-                                    logicalShape, deviceAttr);
-}
-
-inline flatbuffers::Offset<::tt::target::TensorDesc>
-tensorTypeToFlatbuffer(FlatbufferObjectCache &cache, Type type,
-                       DeviceAttr deviceAttr) {
-  auto tensorType = mlir::cast<RankedTensorType>(type);
-  auto shapeInt64 = tensorType.getShape();
-  std::vector<int32_t> shape(shapeInt64.begin(), shapeInt64.end());
-  return ::tt::target::CreateTensorDescDirect(
-      *cache.fbb, &shape,
-      cache.getOrCreate(tensorType.getEncoding(), encodingToFlatbuffer,
-                        shapeInt64, deviceAttr));
-}
-
-inline flatbuffers::Offset<::tt::target::TensorRef>
-tensorValueToFlatbuffer(FlatbufferObjectCache &cache, Value value,
-                        uint64_t address, uint64_t size) {
-  auto deviceAttr =
-      getCurrentScopeDevice(value.getParentBlock()->getParentOp());
-  assert(deviceAttr);
-  auto tensorType = mlir::cast<RankedTensorType>(value.getType());
-  auto tensorDesc =
-      cache.getOrCreate(tensorType, tensorTypeToFlatbuffer, deviceAttr);
-  return ::tt::target::CreateTensorRef(*cache.fbb, cache.global_id++, address,
-                                       size, tensorDesc);
 }
 
 inline flatbuffers::Offset<::tt::target::MLIR>

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -16,6 +16,7 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsTypes.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTNN/Transforms/TTNNToCpp.h"
+#include "ttmlir/Dialect/TTNN/Types/Types.h"
 #include "ttmlir/Target/Common/Target.h"
 #include "ttmlir/Target/Common/types_generated.h"
 #include "ttmlir/Target/LLVM/LLVMToDynamicLib.h"
@@ -47,24 +48,39 @@ static OpType findOpAtTopLevel(mlir::ModuleOp module) {
   return nullptr;
 }
 
-::tt::target::TensorMemoryLayout
+::tt::target::ttnn::TensorMemoryLayout
+toFlatbuffer(FlatbufferObjectCache &,
+             ::mlir::tt::TensorMemoryLayout memLayout) {
+  switch (memLayout) {
+  case TensorMemoryLayout::Interleaved:
+    return ::tt::target::ttnn::TensorMemoryLayout::Interleaved;
+  case TensorMemoryLayout::SingleBank:
+    return ::tt::target::ttnn::TensorMemoryLayout::SingleBank;
+  case TensorMemoryLayout::HeightSharded:
+    return ::tt::target::ttnn::TensorMemoryLayout::HeightSharded;
+  case TensorMemoryLayout::WidthSharded:
+    return ::tt::target::ttnn::TensorMemoryLayout::WidthSharded;
+  case TensorMemoryLayout::BlockSharded:
+    return ::tt::target::ttnn::TensorMemoryLayout::BlockSharded;
+  default:
+    llvm_unreachable("unhandled TensorMemoryLayout");
+  }
+}
+
+::tt::target::ttnn::TensorMemoryLayout
 toFlatbuffer(FlatbufferObjectCache &,
              ttnn::TensorMemoryLayoutAttr memLayoutAttr) {
-  if (!memLayoutAttr) {
-    return ::tt::target::TensorMemoryLayout::None;
-  }
-
   switch (memLayoutAttr.getValue()) {
   case ttnn::TensorMemoryLayout::SingleBank:
-    return ::tt::target::TensorMemoryLayout::SingleBank;
+    return ::tt::target::ttnn::TensorMemoryLayout::SingleBank;
   case ttnn::TensorMemoryLayout::Interleaved:
-    return ::tt::target::TensorMemoryLayout::Interleaved;
+    return ::tt::target::ttnn::TensorMemoryLayout::Interleaved;
   case ttnn::TensorMemoryLayout::HeightSharded:
-    return ::tt::target::TensorMemoryLayout::HeightSharded;
+    return ::tt::target::ttnn::TensorMemoryLayout::HeightSharded;
   case ttnn::TensorMemoryLayout::WidthSharded:
-    return ::tt::target::TensorMemoryLayout::WidthSharded;
+    return ::tt::target::ttnn::TensorMemoryLayout::WidthSharded;
   case ttnn::TensorMemoryLayout::BlockSharded:
-    return ::tt::target::TensorMemoryLayout::BlockSharded;
+    return ::tt::target::ttnn::TensorMemoryLayout::BlockSharded;
   }
 }
 
@@ -82,9 +98,103 @@ toFlatbuffer(FlatbufferObjectCache &,
   }
 }
 
-flatbuffers::Offset<::tt::target::MemoryDesc>
+} // namespace mlir::tt
+
+namespace mlir::tt::ttnn {
+
+constexpr uint64_t kHostAllocatedSize = 0;
+
+#define GEN_PASS_DEF_TTNNSERIALIZETOBINARY
+#include "ttmlir/Dialect/TTNN/Transforms/Passes.h.inc"
+
+static bool
+isShardedMemoryLayout(::tt::target::ttnn::TensorMemoryLayout layout) {
+  return layout == ::tt::target::ttnn::TensorMemoryLayout::HeightSharded ||
+         layout == ::tt::target::ttnn::TensorMemoryLayout::WidthSharded ||
+         layout == ::tt::target::ttnn::TensorMemoryLayout::BlockSharded;
+}
+static ::tt::target::Dim2d getTensorValueTileShape(Value value) {
+  auto tensorType = mlir::cast<RankedTensorType>(value.getType());
+  auto layoutAttr = mlir::cast<ttnn::TTNNLayoutAttr>(tensorType.getEncoding());
+  ::mlir::MemRefType memref = layoutAttr.getMemref();
+  ::mlir::Type elementType = memref.getElementType();
+
+  if (mlir::isa<TileType>(elementType)) {
+    auto tileType = mlir::cast<TileType>(elementType);
+    return ::tt::target::Dim2d(tileType.getHeight(), tileType.getWidth());
+  }
+  return ::tt::target::Dim2d(1, 1);
+}
+
+static std::vector<::tt::target::Dim2dRange>
+getTensorValueCoreRangeSet(FlatbufferObjectCache &cache, Value value) {
+  DeviceAttr deviceAttr =
+      getCurrentScopeDevice(value.getParentBlock()->getParentOp());
+  assert(deviceAttr);
+  RankedTensorType tensorType = mlir::cast<RankedTensorType>(value.getType());
+  ttnn::TTNNLayoutAttr layoutAttr =
+      mlir::cast<ttnn::TTNNLayoutAttr>(tensorType.getEncoding());
+  std::vector<::tt::target::Dim2dRange> coreRangeSet =
+      toFlatbuffer(cache, layoutAttr.getGrid(), deviceAttr.getWorkerGrid());
+  return coreRangeSet;
+}
+
+::flatbuffers::Offset<::tt::target::DeviceRef>
+createDeviceRef(FlatbufferObjectCache &cache, Value device) {
+  auto deviceType = mlir::cast<DeviceType>(device.getType());
+  auto chipIds = deviceType.getDesc().getChipIds();
+  return ::tt::target::CreateDeviceRef(*cache.fbb, chipIds[0]);
+}
+
+::flatbuffers::Offset<::tt::target::ttnn::ShardSpec>
+shardSpecToFlatbuffer(FlatbufferObjectCache &cache,
+                      ::mlir::tt::ttnn::ShardSpecAttr shardSpec,
+                      ::tt::target::Dim2d tileShape,
+                      std::vector<::tt::target::Dim2dRange> coreRangeSet) {
+  assert(tileShape.y() == 1 || tileShape.y() == TILE_HEIGHT);
+  assert(tileShape.x() == 1 || tileShape.x() == TILE_WIDTH);
+  llvm::ArrayRef<int64_t> shardShapeArr = shardSpec.getShardShape().getShape();
+  assert(shardShapeArr.size() == 2);
+  std::vector<int32_t> shardShape;
+  shardShape.reserve(shardShapeArr.size());
+  std::transform(shardShapeArr.begin(), shardShapeArr.end(),
+                 std::back_inserter(shardShape), [](int64_t val) -> int32_t {
+                   return static_cast<int32_t>(val);
+                 });
+  shardShape[0] *= tileShape.y();
+  shardShape[1] *= tileShape.x();
+
+  return ::tt::target::ttnn::CreateShardSpecDirect(*cache.fbb, &coreRangeSet,
+                                                   &shardShape);
+}
+
+::flatbuffers::Offset<::tt::target::ttnn::MemoryConfig>
+memoryConfigToFlatbuffer(FlatbufferObjectCache &cache,
+                         ::mlir::tt::ttnn::MemoryConfigAttr memoryConfigAttr,
+                         ::tt::target::Dim2d tileShape,
+                         std::vector<::tt::target::Dim2dRange> coreRangeSet) {
+  ::tt::target::ttnn::TensorMemoryLayout tensorMemoryLayout =
+      toFlatbuffer(cache, memoryConfigAttr.getTensorMemoryLayout());
+  ::tt::target::BufferType bufferType =
+      ::tt::mlir::ttnn::utils::toTargetBufferType(
+          memoryConfigAttr.getBufferType().getValue());
+
+  ::flatbuffers::Offset<::tt::target::ttnn::ShardSpec> shardSpec = 0;
+  if (isShardedMemoryLayout(tensorMemoryLayout)) {
+    shardSpec = shardSpecToFlatbuffer(cache, memoryConfigAttr.getShardSpec(),
+                                      tileShape, coreRangeSet);
+  }
+  ::flatbuffers::Offset<::tt::target::ttnn::MemoryConfig> memoryConfig =
+      ::tt::target::ttnn::CreateMemoryConfig(*cache.fbb, tensorMemoryLayout,
+                                             bufferType, shardSpec);
+  return memoryConfig;
+}
+
+flatbuffers::Offset<::tt::target::ttnn::MemoryDesc>
 memrefAttrToFlatbuffer(FlatbufferObjectCache &cache, mlir::MemRefType memref,
-                       ttnn::TensorMemoryLayoutAttr memLayoutAttr) {
+                       BufferType bufferType,
+                       ttnn::TensorMemoryLayoutAttr memLayoutAttr,
+                       std::vector<::tt::target::Dim2dRange> coreRangeSet) {
   auto shapeInt64 = memref.getShape();
   std::vector<int32_t> shape(shapeInt64.begin(), shapeInt64.end());
   DataType dtype = DataType::Float32;
@@ -106,66 +216,83 @@ memrefAttrToFlatbuffer(FlatbufferObjectCache &cache, mlir::MemRefType memref,
     size *= dim;
   }
 
-  return ::tt::target::CreateMemoryDescDirect(
-      *cache.fbb, &shape, &tileShape, toFlatbuffer(cache, dtype),
-      toFlatbuffer(
-          cache,
-          mlir::cast<ttnn::BufferTypeAttr>(memref.getMemorySpace()).getValue()),
-      toFlatbuffer(cache, memLayoutAttr), size);
+  // TODO (jnie): Currently we hardcode to owned or single-device storage
+  // Will need compiler support to correctly/dynamically determine this
+  ::tt::target::ttnn::StorageType storageType =
+      bufferType == ttnn::BufferType::SystemMemory
+          ? ::tt::target::ttnn::StorageType::Owned
+          : ::tt::target::ttnn::StorageType::Device;
+
+  ::flatbuffers::Offset<::tt::target::ttnn::MemoryConfig> memoryConfig = 0;
+
+  // Only device tensors should have a memory config
+  if (bufferType != ttnn::BufferType::SystemMemory) {
+    ::mlir::MLIRContext *ctx = memref.getContext();
+    auto bufferTypeAttr = BufferTypeAttr::get(ctx, bufferType);
+    auto memoryConfigAttr = ::mlir::tt::ttnn::MemoryConfigAttr::get(
+        ctx, bufferTypeAttr,
+        ttnn::ShardSpecAttr::get(ctx,
+                                 ttnn::ShapeAttr::get(ctx, memref.getShape())),
+        memLayoutAttr);
+
+    memoryConfig = memoryConfigToFlatbuffer(cache, memoryConfigAttr, tileShape,
+                                            coreRangeSet);
+  }
+
+  return ::tt::target::ttnn::CreateMemoryDesc(
+      *cache.fbb, storageType, &tileShape, toFlatbuffer(cache, dtype),
+      memoryConfig, size);
 }
 
-flatbuffers::Offset<::tt::target::LayoutDesc> ttnnLayoutAttrToFlatbuffer(
-    FlatbufferObjectCache &cache, ttnn::TTNNLayoutAttr layoutAttr,
-    mlir::ArrayRef<int64_t> logicalShape, DeviceAttr deviceAttr) {
-  auto coreRangeSet =
+flatbuffers::Offset<::tt::target::ttnn::LayoutDesc>
+ttnnLayoutAttrToFlatbuffer(FlatbufferObjectCache &cache,
+                           ttnn::TTNNLayoutAttr layoutAttr,
+                           DeviceAttr deviceAttr) {
+  std::vector<::tt::target::Dim2dRange> coreRangeSet =
       toFlatbuffer(cache, layoutAttr.getGrid(), deviceAttr.getWorkerGrid());
-  return ::tt::target::CreateLayoutDescDirect(
-      *cache.fbb, toFlatbuffer(cache, OOBVal::Undef), &coreRangeSet,
-      cache.getOrCreate(layoutAttr.getMemref(), memrefAttrToFlatbuffer,
-                        layoutAttr.getMemLayout()));
-}
-} // namespace mlir::tt
 
-namespace mlir::tt::ttnn {
-
-constexpr uint64_t kHostAllocatedSize = 0;
-constexpr uint64_t kHostAllocatedAddress = 0;
-
-#define GEN_PASS_DEF_TTNNSERIALIZETOBINARY
-#include "ttmlir/Dialect/TTNN/Transforms/Passes.h.inc"
-
-::flatbuffers::Offset<::tt::target::ShardSpec>
-shardSpecToFlatbuffer(FlatbufferObjectCache &cache,
-                      ::mlir::tt::ttnn::ShardSpecAttr shardSpec) {
-  llvm::ArrayRef<int64_t> shardShapeArr = shardSpec.getShardShape().getShape();
-  std::vector<int64_t> shardShapeVec(shardShapeArr.begin(),
-                                     shardShapeArr.end());
-  auto shardShape = cache.fbb->CreateVector<int64_t>(shardShapeVec);
-  return ::tt::target::CreateShardSpec(*cache.fbb, shardShape);
+  // TODO (jnie): Memory reference alone is insufficient to determine LayoutDesc
+  // uniquely. Using `cache.getOrCreate()` is unsafe because identical memory
+  // references can produce different LayoutDesc objects.
+  // Current state: Removed cache.getOrCreate() to prevent inconsistencies
+  // Ideally, we establish one-to-one mapping between MLIR and FlatBuffer
+  // that guarantees identical memrefs will always produce identical
+  // flatbuffer LayoutDescs.
+  return ::tt::target::ttnn::CreateLayoutDesc(
+      *cache.fbb, toFlatbuffer(cache, OOBVal::Undef),
+      memrefAttrToFlatbuffer(cache, layoutAttr.getMemref(),
+                             layoutAttr.getBufferType(),
+                             layoutAttr.getMemLayout(), coreRangeSet));
 }
 
-::flatbuffers::Offset<::tt::target::MemoryConfigDesc>
-memoryConfigToFlatbuffer(FlatbufferObjectCache &cache,
-                         ::mlir::tt::ttnn::MemoryConfigAttr memoryConfig) {
-  ::tt::target::TensorMemoryLayout tensorMemoryLayout =
-      ::tt::mlir::ttnn::utils::toTargetTensorMemoryLayout(
-          memoryConfig.getTensorMemoryLayout().getValue());
-  ::tt::target::BufferType bufferType =
-      ::tt::mlir::ttnn::utils::toTargetBufferType(
-          memoryConfig.getBufferType().getValue());
-  auto shardSpec =
-      cache.getOrCreate(memoryConfig.getShardSpec(), shardSpecToFlatbuffer);
-  ::flatbuffers::Offset<::tt::target::MemoryConfigDesc> memoryConfigDesc =
-      ::tt::target::CreateMemoryConfigDesc(*cache.fbb, tensorMemoryLayout,
-                                           bufferType, shardSpec);
-  return memoryConfigDesc;
+flatbuffers::Offset<::tt::target::ttnn::TensorDesc>
+tensorTypeToFlatbuffer(FlatbufferObjectCache &cache, Type type,
+                       DeviceAttr deviceAttr) {
+  auto tensorType = mlir::cast<RankedTensorType>(type);
+  auto shapeInt64 = tensorType.getShape();
+  std::vector<int32_t> shape;
+  shape.reserve(shapeInt64.size());
+  std::transform(
+      shapeInt64.begin(), shapeInt64.end(), std::back_inserter(shape),
+      [](int64_t val) -> int32_t { return static_cast<int32_t>(val); });
+  return ::tt::target::ttnn::CreateTensorDescDirect(
+      *cache.fbb, &shape,
+      cache.getOrCreate(
+          mlir::cast<ttnn::TTNNLayoutAttr>(tensorType.getEncoding()),
+          ttnnLayoutAttrToFlatbuffer, deviceAttr));
 }
 
-::flatbuffers::Offset<::tt::target::DeviceRef>
-createDeviceRef(FlatbufferObjectCache &cache, Value device) {
-  auto deviceType = mlir::cast<DeviceType>(device.getType());
-  auto chipIds = deviceType.getDesc().getChipIds();
-  return ::tt::target::CreateDeviceRef(*cache.fbb, chipIds[0]);
+flatbuffers::Offset<::tt::target::ttnn::TensorRef>
+tensorValueToFlatbuffer(FlatbufferObjectCache &cache, Value value,
+                        uint64_t size) {
+  auto deviceAttr =
+      getCurrentScopeDevice(value.getParentBlock()->getParentOp());
+  assert(deviceAttr);
+  auto tensorType = mlir::cast<RankedTensorType>(value.getType());
+  auto tensorDesc =
+      cache.getOrCreate(tensorType, tensorTypeToFlatbuffer, deviceAttr);
+  return ::tt::target::ttnn::CreateTensorRef(*cache.fbb, cache.global_id++,
+                                             size, tensorDesc);
 }
 
 template <typename OpT>
@@ -197,26 +324,32 @@ createOp(FlatbufferObjectCache &cache, GetDeviceOp op) {
 
 ::flatbuffers::Offset<::tt::target::ttnn::ToMemoryConfigOp>
 createOp(FlatbufferObjectCache &cache, ToMemoryConfigOp op) {
-  auto input =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
+  auto input = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
 
-  auto memoryConfigDesc =
-      cache.getOrCreate(op.getMemoryConfig(), memoryConfigToFlatbuffer);
+  auto tileShape = getTensorValueTileShape(op.getResult());
+  auto coreRangeSet = getTensorValueCoreRangeSet(cache, op.getResult());
+
+  // TODO (jnie): Disabled `cache.getOrCreate` because identical MLIR memory
+  // configs may produce different flatbuffer memory configs. One-to-one mapping
+  // needed.
+  auto memoryConfig = memoryConfigToFlatbuffer(cache, op.getMemoryConfig(),
+                                               tileShape, coreRangeSet);
 
   auto output = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
-                                  kHostAllocatedAddress, kHostAllocatedSize);
+                                  kHostAllocatedSize);
   return ::tt::target::ttnn::CreateToMemoryConfigOp(*cache.fbb, input,
-                                                    memoryConfigDesc, output);
+                                                    memoryConfig, output);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::ToLayoutOp>
 createOp(FlatbufferObjectCache &cache, ToLayoutOp op) {
-  auto input =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
+  auto input = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
   ::tt::target::TensorLayout layout =
       ::tt::mlir::ttnn::utils::toTargetTensorLayout(op.getLayout());
   auto output = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
-                                  kHostAllocatedAddress, kHostAllocatedSize);
+                                  kHostAllocatedSize);
 
   std::optional<::mlir::tt::DataType> dtype = op.getDtype();
   std::optional<::mlir::tt::ttnn::MemoryConfigAttr> memoryConfig =
@@ -225,88 +358,91 @@ createOp(FlatbufferObjectCache &cache, ToLayoutOp op) {
   if (device) {
     device = getOperandThroughDPSOps(device);
   }
+  auto tileShape = getTensorValueTileShape(op.getResult());
   return ::tt::target::ttnn::CreateToLayoutOp(
       *cache.fbb, input, layout,
       dtype.has_value()
           ? ::flatbuffers::Optional<::tt::target::DataType>(
                 ::tt::mlir::ttnn::utils::toTargetDataType(dtype.value()))
           : ::flatbuffers::nullopt,
-      memoryConfig ? cache.getOrCreate(*memoryConfig, memoryConfigToFlatbuffer)
+      memoryConfig ? memoryConfigToFlatbuffer(
+                         cache, *memoryConfig, tileShape,
+                         getTensorValueCoreRangeSet(cache, op.getResult()))
                    : 0,
       device ? cache.at<::tt::target::DeviceRef>(device) : 0, output);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::ToDTypeOp>
 createOp(FlatbufferObjectCache &cache, ToDTypeOp op) {
-  auto input =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
+  auto input = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
   ::tt::target::DataType dtype =
       ::tt::mlir::ttnn::utils::toTargetDataType(op.getDtype());
   auto output = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
-                                  kHostAllocatedAddress, kHostAllocatedSize);
+                                  kHostAllocatedSize);
 
   return ::tt::target::ttnn::CreateToDTypeOp(*cache.fbb, input, dtype, output);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::TypecastOp>
 createOp(FlatbufferObjectCache &cache, TypecastOp op) {
-  auto input =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
+  auto input = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
   ::tt::target::DataType dtype =
       ::tt::mlir::ttnn::utils::toTargetDataType(op.getDtype());
   auto output = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
-                                  kHostAllocatedAddress, kHostAllocatedSize);
+                                  kHostAllocatedSize);
 
   return ::tt::target::ttnn::CreateTypecastOp(*cache.fbb, input, dtype, output);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::ToDeviceOp>
 createOp(FlatbufferObjectCache &cache, ToDeviceOp op) {
-  auto input =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
+  auto input = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
   auto device = getOperandThroughDPSOps(op.getDevice());
 
   auto output = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
-                                  kHostAllocatedAddress, kHostAllocatedSize);
+                                  kHostAllocatedSize);
 
   if (!op.getMemoryConfig()) {
     return ::tt::target::ttnn::CreateToDeviceOp(
         *cache.fbb, input, cache.at<::tt::target::DeviceRef>(device),
-        /* memoryConfigDesc */ 0, output);
+        /* memoryConfig */ 0, output);
   }
-
-  auto memoryConfigDesc =
-      cache.getOrCreate(op.getMemoryConfig().value(), memoryConfigToFlatbuffer);
+  auto tileShape = getTensorValueTileShape(op.getResult());
+  auto coreRangeSet = getTensorValueCoreRangeSet(cache, op.getResult());
+  auto memoryConfig = memoryConfigToFlatbuffer(
+      cache, op.getMemoryConfig().value(), tileShape, coreRangeSet);
 
   return ::tt::target::ttnn::CreateToDeviceOp(
       *cache.fbb, input, cache.at<::tt::target::DeviceRef>(device),
-      memoryConfigDesc, output);
+      memoryConfig, output);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::FromDeviceOp>
 createOp(FlatbufferObjectCache &cache, FromDeviceOp op) {
-  auto input =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
+  auto input = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
 
   auto output = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
-                                  kHostAllocatedAddress, kHostAllocatedSize);
+                                  kHostAllocatedSize);
 
   return ::tt::target::ttnn::CreateFromDeviceOp(*cache.fbb, input, output);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::CpuOp>
 createCpuOp(FlatbufferObjectCache &cache, func::CallOp op, uint32_t dylib_id) {
-  std::vector<::flatbuffers::Offset<::tt::target::TensorRef>> ins;
+  std::vector<::flatbuffers::Offset<::tt::target::ttnn::TensorRef>> ins;
   for (auto input : op.getOperands()) {
-    ins.push_back(
-        cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(input)));
+    ins.push_back(cache.at<::tt::target::ttnn::TensorRef>(
+        getOperandThroughDPSOps(input)));
   }
 
   // For now, assume we will get exactly 1 result tensor from our call -- this
   // is hardcoded assumption for all ops AFAICT.
-  auto output =
-      cache.getOrCreate(*op.getResults().begin(), tensorValueToFlatbuffer,
-                        kHostAllocatedAddress, kHostAllocatedSize);
+  auto output = cache.getOrCreate(*op.getResults().begin(),
+                                  tensorValueToFlatbuffer, kHostAllocatedSize);
 
   std::string oldName = op.getCallee().str();
   // Remove the "_decl" suffix and add the "_helper" suffix.
@@ -317,14 +453,15 @@ createCpuOp(FlatbufferObjectCache &cache, func::CallOp op, uint32_t dylib_id) {
       cache.fbb->CreateString(funcName), dylib_id);
 }
 
-::flatbuffers::Offset<::tt::target::DistributionStrategy>
+::flatbuffers::Offset<::tt::target::ttnn::DistributionStrategy>
 createDistributionStrategy(FlatbufferObjectCache &cache,
                            const Value &deviceValue,
                            const RankedTensorType &type, uint32_t &numShards) {
   auto noneDistributionStrategy = [&cache]() {
     ::flatbuffers::Offset<void> distribution = 0;
-    return ::tt::target::CreateDistributionStrategy(
-        *cache.fbb, ::tt::target::DistributedTensorConfig::NONE, distribution);
+    return ::tt::target::ttnn::CreateDistributionStrategy(
+        *cache.fbb, ::tt::target::ttnn::DistributedTensorConfig::NONE,
+        distribution);
   };
 
   if (!deviceValue) {
@@ -349,16 +486,18 @@ createDistributionStrategy(FlatbufferObjectCache &cache,
   if (meshShape[0] == 1 || meshShape[1] == 1) {
     assert(type.getShape().size() > 0 && "expected non-zero tensor shape");
     uint32_t target_dim = type.getShape().size() - 1;
-    auto strategy = ::tt::target::CreateShardTensor(*cache.fbb, target_dim);
-    return ::tt::target::CreateDistributionStrategy(
-        *cache.fbb, ::tt::target::DistributedTensorConfig::ShardTensor,
+    auto strategy =
+        ::tt::target::ttnn::CreateShardTensor(*cache.fbb, target_dim);
+    return ::tt::target::ttnn::CreateDistributionStrategy(
+        *cache.fbb, ::tt::target::ttnn::DistributedTensorConfig::ShardTensor,
         strategy.Union());
   }
 
   const ::tt::target::Dim2d shard_mesh(meshShape[0], meshShape[1]);
-  auto strategy = ::tt::target::CreateShardTensor2D(*cache.fbb, &shard_mesh);
-  return ::tt::target::CreateDistributionStrategy(
-      *cache.fbb, ::tt::target::DistributedTensorConfig::ShardTensor2D,
+  auto strategy =
+      ::tt::target::ttnn::CreateShardTensor2D(*cache.fbb, &shard_mesh);
+  return ::tt::target::ttnn::CreateDistributionStrategy(
+      *cache.fbb, ::tt::target::ttnn::DistributedTensorConfig::ShardTensor2D,
       strategy.Union());
 }
 
@@ -378,15 +517,16 @@ createOp(FlatbufferObjectCache &cache, EmptyOp op) {
 
   auto device = getOperandThroughDPSOps(op.getDevice());
 
-  auto memoryConfigDesc =
-      cache.getOrCreate(op.getMemoryConfig(), memoryConfigToFlatbuffer);
+  auto tileShape = getTensorValueTileShape(output);
+  auto coreRangeSet = getTensorValueCoreRangeSet(cache, output);
+  auto memoryConfig = memoryConfigToFlatbuffer(cache, op.getMemoryConfig(),
+                                               tileShape, coreRangeSet);
 
   return ::tt::target::ttnn::CreateEmptyOp(
       *cache.fbb, cache.fbb->CreateVector<int64_t>(shape), dtype, layout,
-      numShards, cache.at<::tt::target::DeviceRef>(device), memoryConfigDesc,
+      numShards, cache.at<::tt::target::DeviceRef>(device), memoryConfig,
       strategy,
-      cache.getOrCreate(output, tensorValueToFlatbuffer, kHostAllocatedAddress,
-                        kHostAllocatedSize));
+      cache.getOrCreate(output, tensorValueToFlatbuffer, kHostAllocatedSize));
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::FullOp>
@@ -401,8 +541,7 @@ createOp(FlatbufferObjectCache &cache, FullOp op) {
   return ::tt::target::ttnn::CreateFullOp(
       *cache.fbb, cache.at<::tt::target::DeviceRef>(device), fillValue,
       numShards, strategy,
-      cache.getOrCreate(output, tensorValueToFlatbuffer, kHostAllocatedAddress,
-                        kHostAllocatedSize));
+      cache.getOrCreate(output, tensorValueToFlatbuffer, kHostAllocatedSize));
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::ArangeOp>
@@ -415,19 +554,22 @@ createOp(FlatbufferObjectCache &cache, ArangeOp op) {
   auto device =
       op.getDevice() ? cache.at<::tt::target::DeviceRef>(op.getDevice()) : 0;
 
-  auto memoryConfigDesc = op.getMemoryConfig().has_value()
-                              ? cache.getOrCreate(op.getMemoryConfig().value(),
-                                                  memoryConfigToFlatbuffer)
-                              : 0;
+  auto tileShape = getTensorValueTileShape(op.getResult());
+  auto coreRangeSet = getTensorValueCoreRangeSet(cache, op.getResult());
+  auto memoryConfig =
+      op.getMemoryConfig().has_value()
+          ? memoryConfigToFlatbuffer(cache, op.getMemoryConfig().value(),
+                                     tileShape, coreRangeSet)
+          : 0;
 
   auto output = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
-                                  kHostAllocatedAddress, kHostAllocatedSize);
+                                  kHostAllocatedSize);
 
   return ::tt::target::ttnn::CreateArangeOp(
       *cache.fbb, static_cast<float>(op.getStart()),
       static_cast<float>(op.getEnd()), static_cast<float>(op.getStep()),
-      dtype /* optional */, device /* optional */,
-      memoryConfigDesc /* optional */, output);
+      dtype /* optional */, device /* optional */, memoryConfig /* optional */,
+      output);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::ZerosOp>
@@ -444,16 +586,19 @@ createOp(FlatbufferObjectCache &cache, ZerosOp op) {
   flatbuffers::Offset<::tt::target::DeviceRef> device =
       op.getDevice() ? cache.at<::tt::target::DeviceRef>(op.getDevice()) : 0;
 
-  auto memoryConfigDesc = op.getMemoryConfig().has_value()
-                              ? cache.getOrCreate(op.getMemoryConfig().value(),
-                                                  memoryConfigToFlatbuffer)
-                              : 0;
+  auto tileShape = getTensorValueTileShape(op.getResult());
+  auto coreRangeSet = getTensorValueCoreRangeSet(cache, op.getResult());
+  auto memoryConfig =
+      op.getMemoryConfig().has_value()
+          ? memoryConfigToFlatbuffer(cache, op.getMemoryConfig().value(),
+                                     tileShape, coreRangeSet)
+          : 0;
 
   auto output = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
-                                  kHostAllocatedAddress, kHostAllocatedSize);
+                                  kHostAllocatedSize);
 
   return ::tt::target::ttnn::CreateZerosOp(*cache.fbb, shape, dtype, layout,
-                                           device, memoryConfigDesc, output);
+                                           device, memoryConfig, output);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::OnesOp>
@@ -470,29 +615,32 @@ createOp(FlatbufferObjectCache &cache, OnesOp op) {
   flatbuffers::Offset<::tt::target::DeviceRef> device =
       op.getDevice() ? cache.at<::tt::target::DeviceRef>(op.getDevice()) : 0;
 
-  auto memoryConfigDesc = op.getMemoryConfig().has_value()
-                              ? cache.getOrCreate(op.getMemoryConfig().value(),
-                                                  memoryConfigToFlatbuffer)
-                              : 0;
+  auto tileShape = getTensorValueTileShape(op.getResult());
+  auto coreRangeSet = getTensorValueCoreRangeSet(cache, op.getResult());
+  auto memoryConfig =
+      op.getMemoryConfig().has_value()
+          ? memoryConfigToFlatbuffer(cache, op.getMemoryConfig().value(),
+                                     tileShape, coreRangeSet)
+          : 0;
 
   auto output = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
-                                  kHostAllocatedAddress, kHostAllocatedSize);
+                                  kHostAllocatedSize);
 
   return ::tt::target::ttnn::CreateOnesOp(*cache.fbb, shape, dtype, layout,
-                                          device, memoryConfigDesc, output);
+                                          device, memoryConfig, output);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::LinearOp>
 createOp(FlatbufferObjectCache &cache, LinearOp op) {
-  auto in0 =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getA()));
-  auto in1 =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getB()));
+  auto in0 = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getA()));
+  auto in1 = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getB()));
   auto bias = op.getODSOperands(2).empty()
-                  ? flatbuffers::Offset<::tt::target::TensorRef>()
-                  : cache.at<::tt::target::TensorRef>(
+                  ? flatbuffers::Offset<::tt::target::ttnn::TensorRef>()
+                  : cache.at<::tt::target::ttnn::TensorRef>(
                         getOperandThroughDPSOps(op.getBias()));
-  auto output = cache.at<::tt::target::TensorRef>(
+  auto output = cache.at<::tt::target::ttnn::TensorRef>(
       getOperandThroughDPSOps(op.getResult()));
   return ::tt::target::ttnn::CreateLinearOp(*cache.fbb, in0, in1, bias, output);
 }
@@ -500,11 +648,11 @@ createOp(FlatbufferObjectCache &cache, LinearOp op) {
 // ANCHOR: adding_an_op_matmul_serialize_to_binary
 ::flatbuffers::Offset<::tt::target::ttnn::MatmulOp>
 createOp(FlatbufferObjectCache &cache, MatmulOp op) {
-  auto in0 =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getA()));
-  auto in1 =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getB()));
-  auto output = cache.at<::tt::target::TensorRef>(
+  auto in0 = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getA()));
+  auto in1 = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getB()));
+  auto output = cache.at<::tt::target::ttnn::TensorRef>(
       getOperandThroughDPSOps(op.getResult()));
   return ::tt::target::ttnn::CreateMatmulOp(*cache.fbb, in0, in1, output);
 }
@@ -512,30 +660,34 @@ createOp(FlatbufferObjectCache &cache, MatmulOp op) {
 
 ::flatbuffers::Offset<::tt::target::ttnn::MorehCumSumOp>
 createOp(FlatbufferObjectCache &cache, MorehCumSumOp op) {
-  auto in =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
-  auto output = cache.at<::tt::target::TensorRef>(
-      getOperandThroughDPSOps(op.getResult()));
-  auto memoryConfigDesc =
+  auto in = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
+  auto dpsOutput = getOperandThroughDPSOps(op.getResult());
+  auto output = cache.at<::tt::target::ttnn::TensorRef>(dpsOutput);
+
+  auto tileShape = getTensorValueTileShape(dpsOutput);
+  auto coreRangeSet = getTensorValueCoreRangeSet(cache, dpsOutput);
+  auto memoryConfig =
       op.getMemoryConfig()
-          ? cache.getOrCreate(*op.getMemoryConfig(), memoryConfigToFlatbuffer)
+          ? memoryConfigToFlatbuffer(cache, op.getMemoryConfig().value(),
+                                     tileShape, coreRangeSet)
           : 0;
 
   return ::tt::target::ttnn::CreateMorehCumSumOp(*cache.fbb, in, output,
-                                                 op.getDim(), memoryConfigDesc);
+                                                 op.getDim(), memoryConfig);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::Conv2dOp>
 createOp(FlatbufferObjectCache &cache, Conv2dOp op) {
-  auto in0 =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
-  auto in1 = cache.at<::tt::target::TensorRef>(
+  auto in0 = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
+  auto in1 = cache.at<::tt::target::ttnn::TensorRef>(
       getOperandThroughDPSOps(op.getWeight()));
   auto in2 = op.getODSOperands(2).empty()
-                 ? flatbuffers::Offset<::tt::target::TensorRef>()
-                 : cache.at<::tt::target::TensorRef>(
+                 ? flatbuffers::Offset<::tt::target::ttnn::TensorRef>()
+                 : cache.at<::tt::target::ttnn::TensorRef>(
                        getOperandThroughDPSOps(op.getBias()));
-  auto output = cache.at<::tt::target::TensorRef>(
+  auto output = cache.at<::tt::target::ttnn::TensorRef>(
       getOperandThroughDPSOps(op.getResult()));
 
   auto device = getOperandThroughDPSOps(op.getDevice());
@@ -551,15 +703,15 @@ createOp(FlatbufferObjectCache &cache, Conv2dOp op) {
 
 ::flatbuffers::Offset<::tt::target::ttnn::ConvTranspose2dOp>
 createOp(FlatbufferObjectCache &cache, ConvTranspose2dOp op) {
-  auto in0 =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
-  auto in1 = cache.at<::tt::target::TensorRef>(
+  auto in0 = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
+  auto in1 = cache.at<::tt::target::ttnn::TensorRef>(
       getOperandThroughDPSOps(op.getWeight()));
   auto in2 = op.getODSOperands(2).empty()
-                 ? flatbuffers::Offset<::tt::target::TensorRef>()
-                 : cache.at<::tt::target::TensorRef>(
+                 ? flatbuffers::Offset<::tt::target::ttnn::TensorRef>()
+                 : cache.at<::tt::target::ttnn::TensorRef>(
                        getOperandThroughDPSOps(op.getBias()));
-  auto output = cache.at<::tt::target::TensorRef>(
+  auto output = cache.at<::tt::target::ttnn::TensorRef>(
       getOperandThroughDPSOps(op.getResult()));
 
   auto device = getOperandThroughDPSOps(op.getDevice());
@@ -585,10 +737,10 @@ createOp(FlatbufferObjectCache &cache, ConvTranspose2dOp op) {
 
 ::flatbuffers::Offset<::tt::target::ttnn::AllGatherOp>
 createOp(FlatbufferObjectCache &cache, AllGatherOp op) {
-  auto input =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
+  auto input = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
   auto output = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
-                                  kHostAllocatedAddress, kHostAllocatedSize);
+                                  kHostAllocatedSize);
   auto device = getOperandThroughDPSOps(op.getDevice());
   return ::tt::target::ttnn::CreateAllGatherOp(
       *cache.fbb, input, output, cache.at<::tt::target::DeviceRef>(device),
@@ -597,10 +749,10 @@ createOp(FlatbufferObjectCache &cache, AllGatherOp op) {
 
 ::flatbuffers::Offset<::tt::target::ttnn::ReduceScatterOp>
 createOp(FlatbufferObjectCache &cache, ReduceScatterOp op) {
-  auto input =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
+  auto input = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
   auto output = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
-                                  kHostAllocatedAddress, kHostAllocatedSize);
+                                  kHostAllocatedSize);
   auto device = getOperandThroughDPSOps(op.getDevice());
   return ::tt::target::ttnn::CreateReduceScatterOp(
       *cache.fbb, input, output, cache.at<::tt::target::DeviceRef>(device),
@@ -610,30 +762,32 @@ createOp(FlatbufferObjectCache &cache, ReduceScatterOp op) {
 
 ::flatbuffers::Offset<::tt::target::ttnn::MeshShardOp>
 createOp(FlatbufferObjectCache &cache, MeshShardOp op) {
-  auto input =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
+  auto input = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
   auto output = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
-                                  kHostAllocatedAddress, kHostAllocatedSize);
+                                  kHostAllocatedSize);
   auto device = getOperandThroughDPSOps(op.getDevice());
   const mlir::tt::MeshShardDirection shardDirection = op.getShardDirection();
   const mlir::tt::MeshShardType shardType = op.getShardType();
   llvm::ArrayRef<int64_t> shardShape = op.getShardShape();
   llvm::ArrayRef<int64_t> shardDims = op.getShardDims();
 
-  ::tt::target::MeshShardDirection meshShardDirection;
+  ::tt::target::ttnn::MeshShardDirection meshShardDirection;
   if (shardDirection == mlir::tt::MeshShardDirection::FullToShard) {
-    meshShardDirection = ::tt::target::MeshShardDirection::FullToShardShape;
+    meshShardDirection =
+        ::tt::target::ttnn::MeshShardDirection::FullToShardShape;
   } else if (shardDirection == mlir::tt::MeshShardDirection::ShardToFull) {
-    meshShardDirection = ::tt::target::MeshShardDirection::ShardToFullShape;
+    meshShardDirection =
+        ::tt::target::ttnn::MeshShardDirection::ShardToFullShape;
   } else {
     llvm_unreachable("unhandled mesh_shard direction");
   }
 
-  ::tt::target::MeshShardType meshShardType;
+  ::tt::target::ttnn::MeshShardType meshShardType;
   if (shardType == mlir::tt::MeshShardType::Replicate) {
-    meshShardType = ::tt::target::MeshShardType::Replicate;
+    meshShardType = ::tt::target::ttnn::MeshShardType::Replicate;
   } else if (shardType == mlir::tt::MeshShardType::Devices) {
-    meshShardType = ::tt::target::MeshShardType::Devices;
+    meshShardType = ::tt::target::ttnn::MeshShardType::Devices;
   } else {
     llvm_unreachable("unhandled mesh_shard type");
   }
@@ -647,35 +801,44 @@ createOp(FlatbufferObjectCache &cache, MeshShardOp op) {
 
 ::flatbuffers::Offset<::tt::target::ttnn::PermuteOp>
 createOp(FlatbufferObjectCache &cache, PermuteOp op) {
-  flatbuffers::Offset<::tt::target::TensorRef> input =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
+  flatbuffers::Offset<::tt::target::ttnn::TensorRef> input =
+      cache.at<::tt::target::ttnn::TensorRef>(
+          getOperandThroughDPSOps(op.getInput()));
   flatbuffers::Offset<flatbuffers::Vector<int64_t>> permutation =
       toFlatbuffer(cache, op.getPermutation());
   std::optional<mlir::tt::ttnn::MemoryConfigAttr> memoryConfig =
       op.getMemoryConfig();
   float padValue = op.getPadValue().convertToFloat();
   auto output = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
-                                  kHostAllocatedAddress, kHostAllocatedSize);
+                                  kHostAllocatedSize);
+
+  auto tileShape = getTensorValueTileShape(op.getResult());
+  auto coreRangeSet = getTensorValueCoreRangeSet(cache, op.getResult());
   return ::tt::target::ttnn::CreatePermuteOp(
       *cache.fbb, input, permutation,
-      memoryConfig ? cache.getOrCreate(*memoryConfig, memoryConfigToFlatbuffer)
+      memoryConfig ? memoryConfigToFlatbuffer(cache, memoryConfig.value(),
+                                              tileShape, coreRangeSet)
                    : 0,
       padValue, output);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::UpsampleOp>
 createOp(FlatbufferObjectCache &cache, UpsampleOp op) {
-  flatbuffers::Offset<::tt::target::TensorRef> input =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
+  flatbuffers::Offset<::tt::target::ttnn::TensorRef> input =
+      cache.at<::tt::target::ttnn::TensorRef>(
+          getOperandThroughDPSOps(op.getInput()));
   flatbuffers::Offset<flatbuffers::String> mode =
       toFlatbuffer(cache, op.getMode());
-  flatbuffers::Offset<::tt::target::MemoryConfigDesc> memoryConfig =
+
+  auto tileShape = getTensorValueTileShape(op.getResult());
+  auto coreRangeSet = getTensorValueCoreRangeSet(cache, op.getResult());
+  flatbuffers::Offset<::tt::target::ttnn::MemoryConfig> memoryConfig =
       op.getMemoryConfig()
-          ? cache.getOrCreate(*op.getMemoryConfig(), memoryConfigToFlatbuffer)
+          ? memoryConfigToFlatbuffer(cache, op.getMemoryConfig().value(),
+                                     tileShape, coreRangeSet)
           : 0;
-  flatbuffers::Offset<::tt::target::TensorRef> output =
-      cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
-                        kHostAllocatedAddress, kHostAllocatedSize);
+  flatbuffers::Offset<::tt::target::ttnn::TensorRef> output = cache.getOrCreate(
+      op.getResult(), tensorValueToFlatbuffer, kHostAllocatedSize);
 
   ::tt::target::ttnn::Scale2D scaleType;
   ::flatbuffers::Offset<void> scaleFactor;
@@ -717,11 +880,11 @@ createEltwiseOpParams(FlatbufferObjectCache &cache, EltwiseOp op) {
 
 ::flatbuffers::Offset<::tt::target::ttnn::UpdateCacheOp>
 createOp(FlatbufferObjectCache &cache, UpdateCacheOp op) {
-  auto cacheOperand =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getCache()));
-  auto input =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
-  auto updateIndex = cache.at<::tt::target::TensorRef>(
+  auto cacheOperand = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getCache()));
+  auto input = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
+  auto updateIndex = cache.at<::tt::target::ttnn::TensorRef>(
       getOperandThroughDPSOps(op.getUpdateIndex()));
 
   return ::tt::target::ttnn::CreateUpdateCacheOp(
@@ -730,10 +893,10 @@ createOp(FlatbufferObjectCache &cache, UpdateCacheOp op) {
 
 ::flatbuffers::Offset<::tt::target::ttnn::FillCacheOp>
 createOp(FlatbufferObjectCache &cache, FillCacheOp op) {
-  auto cacheOperand =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getCache()));
-  auto input =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
+  auto cacheOperand = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getCache()));
+  auto input = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
 
   return ::tt::target::ttnn::CreateFillCacheOp(*cache.fbb, cacheOperand, input,
                                                op.getBatchOffset());
@@ -742,7 +905,7 @@ createOp(FlatbufferObjectCache &cache, FillCacheOp op) {
 ::flatbuffers::Offset<::tt::target::ttnn::ConstantOp>
 createOp(FlatbufferObjectCache &cache, ttnn::ConstantOp op) {
   auto output = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
-                                  kHostAllocatedAddress, kHostAllocatedSize);
+                                  kHostAllocatedSize);
 
   auto rawData =
       mlir::dyn_cast<mlir::DenseElementsAttr>(op.getValue()).getRawData();
@@ -768,14 +931,14 @@ createNonDPSEltwiseOp(FlatbufferObjectCache &cache, EltwiseOp op) {
     llvm_unreachable("unhandled non-DPS EltwiseOp");
   }
 
-  std::vector<::flatbuffers::Offset<::tt::target::TensorRef>> ins;
+  std::vector<::flatbuffers::Offset<::tt::target::ttnn::TensorRef>> ins;
   for (auto input : op.getInputs()) {
-    ins.push_back(
-        cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(input)));
+    ins.push_back(cache.at<::tt::target::ttnn::TensorRef>(
+        getOperandThroughDPSOps(input)));
   }
   assert(op.getResults().size() == 1);
   auto out = cache.getOrCreate(op.getResults().front(), tensorValueToFlatbuffer,
-                               kHostAllocatedAddress, kHostAllocatedSize);
+                               kHostAllocatedSize);
   return ::tt::target::ttnn::CreateEltwiseOpDirect(*cache.fbb, type, &ins, out,
                                                    paramsType, params);
 }
@@ -888,15 +1051,15 @@ createEltwiseOp(FlatbufferObjectCache &cache, EltwiseOp op) {
   } else {
     llvm_unreachable("unhandled EltwiseOp");
   }
-  std::vector<::flatbuffers::Offset<::tt::target::TensorRef>> ins;
+  std::vector<::flatbuffers::Offset<::tt::target::ttnn::TensorRef>> ins;
   for (auto input : op.getInputs()) {
-    ins.push_back(
-        cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(input)));
+    ins.push_back(cache.at<::tt::target::ttnn::TensorRef>(
+        getOperandThroughDPSOps(input)));
   }
   assert(op.getOutputs().size() == 1);
   return ::tt::target::ttnn::CreateEltwiseOpDirect(
       *cache.fbb, type, &ins,
-      cache.at<::tt::target::TensorRef>(
+      cache.at<::tt::target::ttnn::TensorRef>(
           getOperandThroughDPSOps(op.getOutputs().front())),
       paramsType, params);
 }
@@ -917,10 +1080,10 @@ createReductionOp(FlatbufferObjectCache &cache, ReductionOp op) {
     llvm_unreachable("unhandled ReductionOp");
   }
 
-  auto in =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
+  auto in = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
   auto output = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
-                                  kHostAllocatedAddress, kHostAllocatedSize);
+                                  kHostAllocatedSize);
   auto dimArg =
       arrayAttrToFlatbuffer<mlir::IntegerAttr, int>(cache, op.getDimArg());
 
@@ -931,45 +1094,53 @@ createReductionOp(FlatbufferObjectCache &cache, ReductionOp op) {
 template <typename ReductionOp>
 ::flatbuffers::Offset<::tt::target::ttnn::ReductionArgMaxOp>
 createReductionArgMaxOp(FlatbufferObjectCache &cache, ReductionOp op) {
-  auto in =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
+  auto in = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
   auto output = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
-                                  kHostAllocatedAddress, kHostAllocatedSize);
-  auto memoryConfigDesc =
+                                  kHostAllocatedSize);
+
+  auto tileShape = getTensorValueTileShape(op.getResult());
+  auto coreRangeSet = getTensorValueCoreRangeSet(cache, op.getResult());
+  auto memoryConfig =
       op.getMemoryConfig()
-          ? cache.getOrCreate(*op.getMemoryConfig(), memoryConfigToFlatbuffer)
+          ? memoryConfigToFlatbuffer(cache, op.getMemoryConfig().value(),
+                                     tileShape, coreRangeSet)
           : 0;
 
   ::flatbuffers::Optional<int32_t> dim =
       op.getDim() ? std::make_optional(*op.getDim()) : ::flatbuffers::nullopt;
 
   return ::tt::target::ttnn::CreateReductionArgMaxOp(
-      *cache.fbb, in, output, dim, op.getUseMulticore(), memoryConfigDesc);
+      *cache.fbb, in, output, dim, op.getUseMulticore(), memoryConfig);
 }
 
 template <typename ReductionOp>
 ::flatbuffers::Offset<::tt::target::ttnn::ReductionProdOp>
 createReductionProdOp(FlatbufferObjectCache &cache, ReductionOp op) {
-  auto in =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
+  auto in = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
   auto output = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
-                                  kHostAllocatedAddress, kHostAllocatedSize);
-  auto memoryConfigDesc =
+                                  kHostAllocatedSize);
+
+  auto tileShape = getTensorValueTileShape(op.getResult());
+  auto coreRangeSet = getTensorValueCoreRangeSet(cache, op.getResult());
+  auto memoryConfig =
       op.getMemoryConfig()
-          ? cache.getOrCreate(*op.getMemoryConfig(), memoryConfigToFlatbuffer)
+          ? memoryConfigToFlatbuffer(cache, op.getMemoryConfig().value(),
+                                     tileShape, coreRangeSet)
           : 0;
 
   return ::tt::target::ttnn::CreateReductionProdOp(
       *cache.fbb, in, output, op.getAllDimensions(), op.getDimArg(),
-      op.getKeepDim(), memoryConfigDesc);
+      op.getKeepDim(), memoryConfig);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::TransposeOp>
 createTransposeOp(FlatbufferObjectCache &cache, TransposeOp op) {
-  auto in =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
+  auto in = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
   auto out = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
-                               kHostAllocatedAddress, kHostAllocatedSize);
+                               kHostAllocatedSize);
   int32_t dim0 = op.getDim0();
   int32_t dim1 = op.getDim1();
 
@@ -978,31 +1149,35 @@ createTransposeOp(FlatbufferObjectCache &cache, TransposeOp op) {
 
 ::flatbuffers::Offset<::tt::target::ttnn::ConcatOp>
 createConcatOp(FlatbufferObjectCache &cache, ConcatOp op) {
-  std::vector<::flatbuffers::Offset<::tt::target::TensorRef>> ins;
+  std::vector<::flatbuffers::Offset<::tt::target::ttnn::TensorRef>> ins;
   for (auto input : op.getInputs()) {
-    ins.push_back(
-        cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(input)));
+    ins.push_back(cache.at<::tt::target::ttnn::TensorRef>(
+        getOperandThroughDPSOps(input)));
   }
-  auto out = cache.at<::tt::target::TensorRef>(
-      getOperandThroughDPSOps(op.getResult()));
+
+  auto dpsOutput = getOperandThroughDPSOps(op.getResult());
+  auto out = cache.at<::tt::target::ttnn::TensorRef>(dpsOutput);
   int32_t dim = op.getDim();
 
   std::optional<mlir::tt::ttnn::MemoryConfigAttr> memoryConfig =
       op.getMemoryConfig();
 
+  auto tileShape = getTensorValueTileShape(dpsOutput);
+  auto coreRangeSet = getTensorValueCoreRangeSet(cache, dpsOutput);
   return ::tt::target::ttnn::CreateConcatOpDirect(
       *cache.fbb, &ins, out, dim,
-      memoryConfig ? cache.getOrCreate(*memoryConfig, memoryConfigToFlatbuffer)
+      memoryConfig ? memoryConfigToFlatbuffer(cache, memoryConfig.value(),
+                                              tileShape, coreRangeSet)
                    : 0);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::EmbeddingOp>
 createEmbeddingOp(FlatbufferObjectCache &cache, EmbeddingOp op) {
-  auto in0 =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
-  auto in1 = cache.at<::tt::target::TensorRef>(
+  auto in0 = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
+  auto in1 = cache.at<::tt::target::ttnn::TensorRef>(
       getOperandThroughDPSOps(op.getWeight()));
-  auto out = cache.at<::tt::target::TensorRef>(
+  auto out = cache.at<::tt::target::ttnn::TensorRef>(
       getOperandThroughDPSOps(op.getResult()));
   return ::tt::target::ttnn::CreateEmbeddingOp(*cache.fbb, in0, in1, out);
 }
@@ -1011,37 +1186,41 @@ template <typename EmbeddingBackwardOp>
 ::flatbuffers::Offset<::tt::target::ttnn::EmbeddingBackwardOp>
 createEmbeddingBackwardOp(FlatbufferObjectCache &cache,
                           EmbeddingBackwardOp op) {
-  auto in0 =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
-  auto in1 = cache.at<::tt::target::TensorRef>(
+  auto in0 = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
+  auto in1 = cache.at<::tt::target::ttnn::TensorRef>(
       getOperandThroughDPSOps(op.getWeight()));
-  auto in2 = cache.at<::tt::target::TensorRef>(
+  auto in2 = cache.at<::tt::target::ttnn::TensorRef>(
       getOperandThroughDPSOps(op.getInGradient()));
   std::optional<::mlir::tt::DataType> dtype = op.getDtype();
   std::optional<::mlir::tt::ttnn::MemoryConfigAttr> memoryConfig =
       op.getMemoryConfig();
 
-  auto out = cache.at<::tt::target::TensorRef>(
-      getOperandThroughDPSOps(op.getResult()));
+  auto dpsOutput = getOperandThroughDPSOps(op.getResult());
+  auto out = cache.at<::tt::target::ttnn::TensorRef>(dpsOutput);
+
+  auto tileShape = getTensorValueTileShape(dpsOutput);
+  auto coreRangeSet = getTensorValueCoreRangeSet(cache, dpsOutput);
   return ::tt::target::ttnn::CreateEmbeddingBackwardOp(
       *cache.fbb, in0, in1, in2,
       dtype.has_value()
           ? ::flatbuffers::Optional<::tt::target::DataType>(
                 ::tt::mlir::ttnn::utils::toTargetDataType(dtype.value()))
           : ::flatbuffers::nullopt,
-      memoryConfig ? cache.getOrCreate(*memoryConfig, memoryConfigToFlatbuffer)
+      memoryConfig ? memoryConfigToFlatbuffer(cache, memoryConfig.value(),
+                                              tileShape, coreRangeSet)
                    : 0,
       out);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::ReshapeOp>
 createReshapeOp(FlatbufferObjectCache &cache, ReshapeOp op) {
-  auto in =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
+  auto in = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
   auto shape =
       arrayAttrToFlatbuffer<mlir::IntegerAttr, int32_t>(cache, op.getShape());
   auto out = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
-                               kHostAllocatedAddress, kHostAllocatedSize);
+                               kHostAllocatedSize);
 
   return ::tt::target::ttnn::CreateReshapeOp(*cache.fbb, in, out, shape);
 }
@@ -1049,11 +1228,11 @@ createReshapeOp(FlatbufferObjectCache &cache, ReshapeOp op) {
 template <typename RepeatOp>
 ::flatbuffers::Offset<::tt::target::ttnn::RepeatOp>
 createRepeatOp(FlatbufferObjectCache &cache, RepeatOp op) {
-  auto in =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
+  auto in = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
   ::llvm::ArrayRef<int64_t> repeatDims = op.getRepeatDims().getShape();
   auto out = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
-                               kHostAllocatedAddress, kHostAllocatedSize);
+                               kHostAllocatedSize);
 
   return ::tt::target::ttnn::CreateRepeatOp(
       *cache.fbb, in, out, cache.fbb->CreateVector<int64_t>(repeatDims));
@@ -1061,28 +1240,31 @@ createRepeatOp(FlatbufferObjectCache &cache, RepeatOp op) {
 
 ::flatbuffers::Offset<::tt::target::ttnn::PadOp>
 createPadOp(FlatbufferObjectCache &cache, PadOp op) {
-  flatbuffers::Offset<::tt::target::TensorRef> in =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
+  flatbuffers::Offset<::tt::target::ttnn::TensorRef> in =
+      cache.at<::tt::target::ttnn::TensorRef>(
+          getOperandThroughDPSOps(op.getInput()));
   std::vector<uint32_t> padding(op.getPadding().begin(), op.getPadding().end());
   float value = op.getValue().convertToFloat();
-  flatbuffers::Offset<::tt::target::TensorRef> out =
-      cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
-                        kHostAllocatedAddress, kHostAllocatedSize);
+  flatbuffers::Offset<::tt::target::ttnn::TensorRef> out = cache.getOrCreate(
+      op.getResult(), tensorValueToFlatbuffer, kHostAllocatedSize);
 
-  flatbuffers::Offset<::tt::target::MemoryConfigDesc> memoryConfigDesc =
+  auto tileShape = getTensorValueTileShape(op.getResult());
+  auto coreRangeSet = getTensorValueCoreRangeSet(cache, op.getResult());
+  flatbuffers::Offset<::tt::target::ttnn::MemoryConfig> memoryConfig =
       op.getMemoryConfig()
-          ? cache.getOrCreate(*op.getMemoryConfig(), memoryConfigToFlatbuffer)
+          ? memoryConfigToFlatbuffer(cache, op.getMemoryConfig().value(),
+                                     tileShape, coreRangeSet)
           : 0;
   return ::tt::target::ttnn::CreatePadOp(
       *cache.fbb, in, out, cache.fbb->CreateVector<uint32_t>(padding), value,
-      op.getUseMulticore(), memoryConfigDesc);
+      op.getUseMulticore(), memoryConfig);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::SliceOp>
 createSliceOp(FlatbufferObjectCache &cache, SliceOp op) {
-  auto in =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
-  auto out = cache.at<::tt::target::TensorRef>(
+  auto in = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
+  auto out = cache.at<::tt::target::ttnn::TensorRef>(
       getOperandThroughDPSOps(op.getResult()));
   auto begins =
       arrayAttrToFlatbuffer<mlir::IntegerAttr, int64_t>(cache, op.getBegins());
@@ -1097,9 +1279,9 @@ createSliceOp(FlatbufferObjectCache &cache, SliceOp op) {
 
 ::flatbuffers::Offset<::tt::target::ttnn::MaxPool2dOp>
 createMaxPool2dOp(FlatbufferObjectCache &cache, MaxPool2dOp op) {
-  auto in =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
-  auto out = cache.at<::tt::target::TensorRef>(
+  auto in = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
+  auto out = cache.at<::tt::target::ttnn::TensorRef>(
       getOperandThroughDPSOps(op.getResult()));
 
   auto device = getOperandThroughDPSOps(op.getDevice());
@@ -1114,26 +1296,30 @@ createMaxPool2dOp(FlatbufferObjectCache &cache, MaxPool2dOp op) {
 
 ::flatbuffers::Offset<::tt::target::ttnn::RepeatInterleaveOp>
 createRepeatInterleaveOp(FlatbufferObjectCache &cache, RepeatInterleaveOp op) {
-  auto input =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
+  auto input = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
   auto out = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
-                               kHostAllocatedAddress, kHostAllocatedSize);
+                               kHostAllocatedSize);
   std::optional<mlir::tt::ttnn::MemoryConfigAttr> memoryConfig =
       op.getMemoryConfig();
   uint32_t repeats = op.getRepeats();
   int32_t dim = op.getDim();
+
+  auto tileShape = getTensorValueTileShape(op.getResult());
+  auto coreRangeSet = getTensorValueCoreRangeSet(cache, op.getResult());
   return ::tt::target::ttnn::CreateRepeatInterleaveOp(
       *cache.fbb, input, out, repeats, dim,
-      memoryConfig ? cache.getOrCreate(*memoryConfig, memoryConfigToFlatbuffer)
+      memoryConfig ? memoryConfigToFlatbuffer(cache, memoryConfig.value(),
+                                              tileShape, coreRangeSet)
                    : 0);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::SoftmaxOp>
 createSoftmaxOp(FlatbufferObjectCache &cache, SoftmaxOp op) {
-  auto in =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
+  auto in = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
   auto out = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
-                               kHostAllocatedAddress, kHostAllocatedSize);
+                               kHostAllocatedSize);
   int32_t dimension = op.getDimension();
 
   return ::tt::target::ttnn::CreateSoftmaxOp(*cache.fbb, in, out, dimension);
@@ -1141,8 +1327,8 @@ createSoftmaxOp(FlatbufferObjectCache &cache, SoftmaxOp op) {
 
 ::flatbuffers::Offset<::tt::target::ttnn::DeallocateOp>
 createDeallocateOp(FlatbufferObjectCache &cache, DeallocateOp op) {
-  auto in =
-      cache.at<::tt::target::TensorRef>(getOperandThroughDPSOps(op.getInput()));
+  auto in = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
   auto force = op.getForceAttr().getValue();
   return ::tt::target::ttnn::CreateDeallocateOp(*cache.fbb, in, force);
 }
@@ -1606,8 +1792,8 @@ std::shared_ptr<void> ttnnToFlatbuffer(
   std::vector<::flatbuffers::Offset<::tt::target::ttnn::Program>> programs;
   module->walk([&](func::FuncOp func) {
     Program<::tt::target::ttnn::Operation> program =
-        funcOpToProgram<::tt::target::ttnn::Operation>(cache, func,
-                                                       emitTTNNOperation);
+        funcOpToProgram<::tt::target::ttnn::Operation>(
+            cache, func, emitTTNNOperation, tensorValueToFlatbuffer);
     programs.push_back(::tt::target::ttnn::CreateProgramDirect(
         fbb, program.name, &program.inputs, &program.outputs, &program.ops,
         &dylibs, debugInfo));

--- a/runtime/include/tt/runtime/detail/logger.h
+++ b/runtime/include/tt/runtime/detail/logger.h
@@ -61,7 +61,7 @@ inline std::vector<std::string> backtrace(int size = 64, int skip = 1) {
   std::unique_ptr<char *, decltype(&free)> strings(
       backtrace_symbols(array.data(), s), free);
 
-  if (not strings) {
+  if (!strings) {
     std::cout << "backtrace_symbols error." << std::endl;
     return bt;
   }

--- a/runtime/include/tt/runtime/detail/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal.h
@@ -19,9 +19,6 @@
 
 namespace tt::runtime::ttmetal {
 
-std::pair<SystemDesc, DeviceIds> getCurrentSystemDesc(
-    std::optional<DispatchCoreType> dispatchCoreType = std::nullopt);
-
 Tensor createTensor(std::shared_ptr<void> data,
                     std::vector<std::uint32_t> const &shape,
                     std::vector<std::uint32_t> const &stride,
@@ -104,10 +101,10 @@ inline CoreRangeSet toCoreRangeSet(
 
 inline std::shared_ptr<::tt::tt_metal::Buffer>
 createBufferFromTensorRef(::tt::tt_metal::IDevice *device,
-                          ::tt::target::TensorRef const *tensorRef) {
-  ::tt::target::TensorDesc const *tensorDesc = tensorRef->desc();
-  ::tt::target::LayoutDesc const *layout = tensorDesc->layout();
-  ::tt::target::MemoryDesc const *memoryDesc = layout->memory_desc();
+                          ::tt::target::metal::TensorRef const *tensorRef) {
+  ::tt::target::metal::TensorDesc const *tensorDesc = tensorRef->desc();
+  ::tt::target::metal::LayoutDesc const *layout = tensorDesc->layout();
+  ::tt::target::metal::MemoryDesc const *memoryDesc = layout->memory_desc();
   CoreRangeSet coreRangeSet = toCoreRangeSet(layout->core_range_set());
   auto shardRank = memoryDesc->shape()->size();
   ::tt::target::Dim2d const *tile_shape = memoryDesc->tile_shape();

--- a/runtime/include/tt/runtime/detail/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn.h
@@ -51,9 +51,6 @@ namespace tt::runtime::ttnn {
 // Default L1 small size to use for the ttnn runtime (32kb).
 constexpr std::size_t kL1SmallSize = 1 << 15;
 
-std::pair<SystemDesc, DeviceIds> getCurrentSystemDesc(
-    std::optional<DispatchCoreType> dispatchCoreType = std::nullopt);
-
 Tensor createOwnedTensor(std::shared_ptr<void> data,
                          std::vector<std::uint32_t> const &shape,
                          std::vector<std::uint32_t> const &stride,

--- a/runtime/lib/binary.cpp
+++ b/runtime/lib/binary.cpp
@@ -26,13 +26,13 @@ static std::string asJson(void const *fbb, uint8_t const *binarySchema,
   opts.output_default_scalars_in_json = true;
   flatbuffers::Parser parser(opts);
 
-  if (not parser.Deserialize(binarySchema, schemaSize)) {
+  if (!parser.Deserialize(binarySchema, schemaSize)) {
     LOG_FATAL("Failed to deserialize schema");
   }
 
   std::string text;
   const char *err = ::flatbuffers::GenerateText(parser, fbb, &text);
-  LOG_ASSERT(not err, "Failed to generate JSON: ", err);
+  LOG_ASSERT(!err, "Failed to generate JSON: ", err);
   return text;
 }
 

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -140,8 +140,8 @@ Tensor createOwnedTensor(std::shared_ptr<void> data,
                          std::vector<std::uint32_t> const &stride,
                          std::uint32_t itemsize,
                          ::tt::target::DataType dataType) {
-  LOG_ASSERT(not shape.empty());
-  LOG_ASSERT(not stride.empty());
+  LOG_ASSERT(!shape.empty());
+  LOG_ASSERT(!stride.empty());
   LOG_ASSERT(itemsize > 0);
 #if defined(TT_RUNTIME_ENABLE_TTNN)
   if (getCurrentRuntime() == DeviceRuntime::TTNN) {
@@ -162,8 +162,8 @@ Tensor createTensor(std::shared_ptr<void> data,
                     std::vector<std::uint32_t> const &shape,
                     std::vector<std::uint32_t> const &stride,
                     std::uint32_t itemsize, ::tt::target::DataType dataType) {
-  LOG_ASSERT(not shape.empty());
-  LOG_ASSERT(not stride.empty());
+  LOG_ASSERT(!shape.empty());
+  LOG_ASSERT(!stride.empty());
   LOG_ASSERT(itemsize > 0);
 #if defined(TT_RUNTIME_ENABLE_TTNN)
   if (getCurrentRuntime() == DeviceRuntime::TTNN) {
@@ -187,8 +187,8 @@ createTensor(std::vector<std::shared_ptr<void>> &data,
              std::vector<std::uint32_t> const &stride, std::uint32_t itemsize,
              ::tt::target::DataType dataType,
              std::unordered_map<std::string, std::string> const &strategy) {
-  LOG_ASSERT(not shape.empty());
-  LOG_ASSERT(not stride.empty());
+  LOG_ASSERT(!shape.empty());
+  LOG_ASSERT(!stride.empty());
   LOG_ASSERT(itemsize > 0);
 #if defined(TT_RUNTIME_ENABLE_TTNN)
   if (getCurrentRuntime() == DeviceRuntime::TTNN) {
@@ -209,8 +209,8 @@ Tensor createTensor(Device device, Layout layout,
                     std::vector<std::uint32_t> const &shape,
                     std::vector<std::uint32_t> const &stride,
                     std::uint32_t itemsize) {
-  LOG_ASSERT(not shape.empty());
-  LOG_ASSERT(not stride.empty());
+  LOG_ASSERT(!shape.empty());
+  LOG_ASSERT(!stride.empty());
   LOG_ASSERT(itemsize > 0);
 #if defined(TT_RUNTIME_ENABLE_TTNN)
   if (getCurrentRuntime() == DeviceRuntime::TTNN) {

--- a/runtime/lib/ttmetal/command_queue.cpp
+++ b/runtime/lib/ttmetal/command_queue.cpp
@@ -362,7 +362,7 @@ static CoreType toCoreType(::tt::target::metal::CoreType coreType) {
 }
 
 static ::tt::tt_metal::CircularBufferConfig createCircularBufferConfig(
-    ::tt::target::CBRef const *cbRef,
+    ::tt::target::metal::CBRef const *cbRef,
     std::unordered_map<std::uint32_t,
                        std::shared_ptr<::tt::tt_metal::Buffer>> const
         &buffers) {
@@ -387,8 +387,8 @@ static void processRuntimeArgs(
     ::tt::tt_metal::Program &program,
     ::tt::target::metal::KernelDesc const *kernelDesc,
     ::tt::tt_metal::KernelHandle &handle, CoreRangeSet &coreRange,
-    const ::flatbuffers::Vector<::flatbuffers::Offset<tt::target::TensorRef>>
-        *operands,
+    const ::flatbuffers::Vector<
+        ::flatbuffers::Offset<tt::target::metal::TensorRef>> *operands,
     std::unordered_map<std::uint32_t,
                        std::shared_ptr<::tt::tt_metal::Buffer>> const
         &buffers) {
@@ -460,7 +460,7 @@ void CQExecutor::execute(
     ::tt::tt_metal::KernelHandle handle =
         ::tt::tt_metal::CreateKernel(program, fileName, coreRangeSet, config);
 
-    for (::tt::target::CBRef const *cbRef : *kernelDesc->cbs()) {
+    for (::tt::target::metal::CBRef const *cbRef : *kernelDesc->cbs()) {
       if (createdCBs.count(cbRef->desc()->port())) {
         // Since kernels may share the same CB, we only need to create it once.
         continue;
@@ -549,7 +549,7 @@ void CQExecutor::execute(
 void CQExecutor::execute(
     ::tt::target::metal::CreateEventCommand const *command) {
   ZoneScopedN("CreateEventCommand");
-  LOG_ASSERT(not events.contains(command->ref()->global_id()));
+  LOG_ASSERT(!events.contains(command->ref()->global_id()));
   events[command->ref()->global_id()] =
       std::make_shared<::tt::tt_metal::Event>();
 }

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -24,7 +24,7 @@ static ::tt::target::metal::TTMetalBinary const *getBinary(Flatbuffer binary) {
   bool isTTMetal =
       ::tt::target::metal::SizePrefixedTTMetalBinaryBufferHasIdentifier(
           binary.handle.get());
-  if (not isTTMetal) {
+  if (!isTTMetal) {
     LOG_FATAL("Unsupported binary format");
   }
   return ::tt::target::metal::GetSizePrefixedTTMetalBinary(binary.handle.get());
@@ -186,7 +186,7 @@ void wait(std::vector<Tensor> const &tensors) {
 static std::pair<std::shared_ptr<::tt::tt_metal::Buffer>,
                  std::shared_ptr<::tt::tt_metal::Event>>
 prepareInput(::tt::tt_metal::IDevice *device, MetalTensor const &metalTensor,
-             void *data, ::tt::target::TensorRef const *tensorRef) {
+             void *data, ::tt::target::metal::TensorRef const *tensorRef) {
   if (std::holds_alternative<TensorDesc>(metalTensor)) {
     // todo assert that tensorDesc matches hostTensorDesc
     std::shared_ptr<::tt::tt_metal::Buffer> buffer =
@@ -212,7 +212,7 @@ prepareInput(::tt::tt_metal::IDevice *device, MetalTensor const &metalTensor,
 
 static std::shared_ptr<::tt::tt_metal::Buffer>
 prepareOutput(::tt::tt_metal::IDevice *device, MetalTensor const *metalTensor,
-              ::tt::target::TensorRef const *tensorRef) {
+              ::tt::target::metal::TensorRef const *tensorRef) {
   LOG_ASSERT(metalTensor != nullptr);
   if (TensorDesc const *hostTensorDesc = std::get_if<TensorDesc>(metalTensor);
       hostTensorDesc) {
@@ -291,7 +291,7 @@ Event submit(Device deviceHandle, Binary executableHandle,
     LOG_ASSERT(inputHandles.size() == deviceProgram->inputs()->size(),
                "Input size mismatch");
     for (unsigned i = 0; i < inputHandles.size(); ++i) {
-      ::tt::target::TensorRef const *tensorRef =
+      ::tt::target::metal::TensorRef const *tensorRef =
           deviceProgram->inputs()->Get(i);
       auto [buffer, event] = prepareInput(
           device, inputHandles[i].as<MetalTensor>(DeviceRuntime::TTMetal),
@@ -305,7 +305,7 @@ Event submit(Device deviceHandle, Binary executableHandle,
     LOG_ASSERT(outputHandles.size() == deviceProgram->outputs()->size(),
                "Output size mismatch");
     for (unsigned i = 0; i < outputHandles.size(); ++i) {
-      ::tt::target::TensorRef const *tensorRef =
+      ::tt::target::metal::TensorRef const *tensorRef =
           deviceProgram->outputs()->Get(i);
       std::shared_ptr<::tt::tt_metal::Buffer> buffer = prepareOutput(
           device, &outputHandles[i].as<MetalTensor>(DeviceRuntime::TTMetal),
@@ -326,7 +326,7 @@ Event submit(Device deviceHandle, Binary executableHandle,
 
     Events copyEvents =
         maybeCopyHostOutputs(device, outputHandles, outputs, deviceEvents);
-    if (not copyEvents.empty()) {
+    if (!copyEvents.empty()) {
       std::swap(deviceEvents, copyEvents);
     }
 

--- a/runtime/lib/ttnn/include/tt/runtime/ttnn/types.h
+++ b/runtime/lib/ttnn/include/tt/runtime/ttnn/types.h
@@ -15,19 +15,21 @@ using DeviceVariant = std::variant<std::reference_wrapper<::ttnn::IDevice>,
                                    std::reference_wrapper<::ttnn::MeshDevice>>;
 
 struct LayoutDesc {
-  ::ttnn::BufferType bufferType;
+  ::ttnn::StorageType storageType;
   ::ttnn::Layout layout;
   ::ttnn::DataType dataType;
   std::optional<::ttnn::MemoryConfig> memoryConfig;
 
-  LayoutDesc(const ::ttnn::BufferType &bufferType, const ::ttnn::Layout &layout,
-             const ::ttnn::DataType &dataType,
+  LayoutDesc(const ::ttnn::StorageType &storageType,
+             const ::ttnn::Layout &layout, const ::ttnn::DataType &dataType,
              const std::optional<::ttnn::MemoryConfig> &memoryConfig)
-      : bufferType(bufferType), layout(layout), dataType(dataType),
+      : storageType(storageType), layout(layout), dataType(dataType),
         memoryConfig(memoryConfig) {}
 
   bool isOnHost() const {
-    return bufferType == ::ttnn::BufferType::SYSTEM_MEMORY;
+    return (storageType == ::ttnn::StorageType::OWNED) ||
+           (storageType == ::ttnn::StorageType::BORROWED) ||
+           (storageType == ::ttnn::StorageType::MULTI_DEVICE_HOST);
   }
   bool isOnDevice() const { return !isOnHost(); }
 

--- a/runtime/lib/ttnn/include/tt/runtime/ttnn/utils.h
+++ b/runtime/lib/ttnn/include/tt/runtime/ttnn/utils.h
@@ -14,9 +14,14 @@ namespace tt::runtime::ttnn::utils {
 
 bool isOnHost(const ::ttnn::StorageType &storageType);
 
+bool inSystemMemory(const ::tt::target::ttnn::TensorRef *tensorRef);
+
 bool isOnDevice(const ::ttnn::StorageType &storageType);
 
 bool isValidTileShape(const ::tt::target::Dim2d *shape);
+
+bool isSharded(
+    const ::tt::target::ttnn::TensorMemoryLayout &tensorMemoryLayout);
 
 ::ttnn::DataType toTTNNDataType(::tt::target::DataType dataType);
 
@@ -24,36 +29,28 @@ bool isValidTileShape(const ::tt::target::Dim2d *shape);
 
 ::ttnn::Layout toTTNNLayout(::tt::target::TensorLayout layout);
 
-::ttnn::TensorMemoryLayout
-toTTNNTensorMemoryLayout(::tt::target::TensorMemoryLayout tensorMemoryLayout);
+::ttnn::TensorMemoryLayout toTTNNTensorMemoryLayout(
+    ::tt::target::ttnn::TensorMemoryLayout tensorMemoryLayout);
 
-// This method will be deprecated in favor of method below
-//
-::tt::tt_metal::BufferType
-toTTNNBufferType(::tt::target::MemorySpace memorySpace);
-
-// Prefer to use this method
-//
 ::ttnn::BufferType toTTNNBufferType(::tt::target::BufferType bufferType);
 
+::ttnn::StorageType
+toTTNNStorageType(::tt::target::ttnn::StorageType storageType);
+
 ::ttnn::Layout
-inferLayoutFromTileShape(const ::tt::target::TensorRef *tensorRef);
+inferLayoutFromTileShape(const ::tt::target::ttnn::TensorRef *tensorRef);
 
 CoreRangeSet
 toCoreRangeSet(const ::flatbuffers::Vector<const ::tt::target::Dim2dRange *>
                    *coreRangeSet);
 
-::tt::tt_metal::MemoryConfig
-createMemoryConfig(const ::tt::target::TensorRef *tensorRef);
+const ::tt::target::ttnn::MemoryConfig *
+getTensorRefMemoryConfig(const ::tt::target::ttnn::TensorRef *tensorRef);
+
+std::optional<::ttnn::MemoryConfig>
+createMemoryConfigIfNeeded(const ::tt::target::ttnn::MemoryConfig *memcfg);
 
 Tensor createRuntimeTensorFromTTNN(const ::ttnn::Tensor &tensor);
-
-// TODO: (#1435): Fix int types across shapes
-//
-inline std::vector<uint32_t>
-toShapeFromFBShape(const flatbuffers::Vector<int32_t> &vec) {
-  return std::vector<uint32_t>(vec.begin(), vec.end());
-}
 
 // Translates a flatbuffer DataType to the native (C++) type.
 template <::tt::target::DataType DataType>

--- a/runtime/lib/ttnn/operations/ccl/all_gather.cpp
+++ b/runtime/lib/ttnn/operations/ccl/all_gather.cpp
@@ -17,10 +17,15 @@ void run(const ::tt::target::ttnn::AllGatherOp *op, ProgramContext &context) {
   uint32_t clusterAxis = op->cluster_axis();
   uint32_t numLinks = op->num_links();
   LOG_ASSERT(
-      input.storage_type() == ::tt::tt_metal::StorageType::MULTI_DEVICE,
+      input.storage_type() == ::ttnn::StorageType::MULTI_DEVICE,
       "Input of all_gather must be MULTIDEVICE. id:", op->in()->global_id());
-  ::tt::tt_metal::MemoryConfig outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfig(op->out());
+
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
+          ::tt::runtime::ttnn::utils::getTensorRefMemoryConfig(op->out()));
+  LOG_ASSERT(outputMemoryConfig.has_value(),
+             "Memory config must exist for device tensors");
+
   ::ttnn::MeshDevice &meshDevice =
       context.getSubMesh(op->device()->global_id());
   ::ttnn::Tensor out =

--- a/runtime/lib/ttnn/operations/ccl/mesh_shard.cpp
+++ b/runtime/lib/ttnn/operations/ccl/mesh_shard.cpp
@@ -13,10 +13,10 @@
 namespace tt::runtime::ttnn::operations::ccl {
 void FullToShardShape(const ::ttnn::Tensor &input, ::ttnn::Tensor &out,
                       ::ttnn::MeshDevice &meshDevice,
-                      const ::tt::target::MeshShardType &shardType,
+                      const ::tt::target::ttnn::MeshShardType &shardType,
                       const std::vector<int64_t> &shardShape,
                       const std::vector<int64_t> &shardDims) {
-  if (shardType == ::tt::target::MeshShardType::Replicate) {
+  if (shardType == ::tt::target::ttnn::MeshShardType::Replicate) {
     out = ::ttnn::distributed::distribute_tensor(
         input,
         *::ttnn::distributed::replicate_tensor_to_mesh_mapper(meshDevice));
@@ -41,12 +41,12 @@ void FullToShardShape(const ::ttnn::Tensor &input, ::ttnn::Tensor &out,
 
 void ShardToFullShape(const ::ttnn::Tensor &input, ::ttnn::Tensor &out,
                       ::ttnn::MeshDevice &meshDevice,
-                      const ::tt::target::MeshShardType &shardType,
+                      const ::tt::target::ttnn::MeshShardType &shardType,
                       const std::vector<int64_t> &shardShape,
                       const std::vector<int64_t> &shardDims) {
   std::vector<::ttnn::Tensor> input_tensors =
       ::ttnn::distributed::get_tensors_from_multi_device_storage(input);
-  if (shardType == ::tt::target::MeshShardType::Replicate) {
+  if (shardType == ::tt::target::ttnn::MeshShardType::Replicate) {
     out = input_tensors[0];
   } else {
     bool bFullConcat = std::all_of(shardDims.begin(), shardDims.end(),
@@ -86,8 +86,9 @@ void ShardToFullShape(const ::ttnn::Tensor &input, ::ttnn::Tensor &out,
 void run(const ::tt::target::ttnn::MeshShardOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
   const ::ttnn::Tensor &input = tensorPool.at(op->in()->global_id());
-  const ::tt::target::MeshShardDirection shardDirection = op->shard_direction();
-  const ::tt::target::MeshShardType shardType = op->shard_type();
+  const ::tt::target::ttnn::MeshShardDirection shardDirection =
+      op->shard_direction();
+  const ::tt::target::ttnn::MeshShardType shardType = op->shard_type();
   const auto *fbShardShape = op->shard_shape();
   const auto *fbShardDims = op->shard_dims();
   std::vector<int64_t> shardShape(fbShardShape->begin(), fbShardShape->end());
@@ -95,13 +96,15 @@ void run(const ::tt::target::ttnn::MeshShardOp *op, ProgramContext &context) {
   DEBUG_ASSERT(::tt::runtime::ttnn::utils::isOnHost(input.storage_type()),
                "Input of ttnn::mesh_shard should be host tensor");
 
-  if (shardDirection != ::tt::target::MeshShardDirection::FullToShardShape &&
-      shardDirection != ::tt::target::MeshShardDirection::ShardToFullShape) {
+  if (shardDirection !=
+          ::tt::target::ttnn::MeshShardDirection::FullToShardShape &&
+      shardDirection !=
+          ::tt::target::ttnn::MeshShardDirection::ShardToFullShape) {
     throw std::runtime_error("Unsupported shard direction");
   }
 
-  if (shardType != ::tt::target::MeshShardType::Replicate &&
-      shardType != ::tt::target::MeshShardType::Devices) {
+  if (shardType != ::tt::target::ttnn::MeshShardType::Replicate &&
+      shardType != ::tt::target::ttnn::MeshShardType::Devices) {
     throw std::runtime_error("Unsupported shard type");
   }
 
@@ -109,7 +112,8 @@ void run(const ::tt::target::ttnn::MeshShardOp *op, ProgramContext &context) {
       context.getSubMesh(op->device()->global_id());
 
   ::ttnn::Tensor out;
-  if (shardDirection == ::tt::target::MeshShardDirection::FullToShardShape) {
+  if (shardDirection ==
+      ::tt::target::ttnn::MeshShardDirection::FullToShardShape) {
     FullToShardShape(input, out, meshDevice, shardType, shardShape, shardDims);
   } else {
     ShardToFullShape(input, out, meshDevice, shardType, shardShape, shardDims);

--- a/runtime/lib/ttnn/operations/ccl/reduce_scatter.cpp
+++ b/runtime/lib/ttnn/operations/ccl/reduce_scatter.cpp
@@ -23,11 +23,16 @@ void run(const ::tt::target::ttnn::ReduceScatterOp *op,
   // config: e.g., For 2x4 mesh, clusterAxis (1) means reduction in horizontal
   // direction such as 0,1,2,3 and 4,5,6,7.
   int32_t clusterAxis = 1;
-  LOG_ASSERT(input.storage_type() == ::tt::tt_metal::StorageType::MULTI_DEVICE,
+  LOG_ASSERT(input.storage_type() == ::ttnn::StorageType::MULTI_DEVICE,
              "Input of reduce_scatter must be MULTIDEVICE. id:",
              op->in()->global_id());
-  ::tt::tt_metal::MemoryConfig outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfig(op->out());
+
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
+          ::tt::runtime::ttnn::utils::getTensorRefMemoryConfig(op->out()));
+  LOG_ASSERT(outputMemoryConfig.has_value(),
+             "Memory config must be exist for device tensors");
+
   ::ttnn::MeshDevice &meshDevice =
       context.getSubMesh(op->device()->global_id());
   ::ttnn::Tensor out = ::ttnn::reduce_scatter(

--- a/runtime/lib/ttnn/operations/conv/conv_transpose2d.cpp
+++ b/runtime/lib/ttnn/operations/conv/conv_transpose2d.cpp
@@ -44,8 +44,6 @@ void run(const ::tt::target::ttnn::ConvTranspose2dOp *op,
   config.dtype = utils::getDataType(op->input());
   config.weights_dtype = utils::getDataType(op->weight());
   config.shard_layout = ::ttnn::TensorMemoryLayout::WIDTH_SHARDED;
-  ::ttnn::MemoryConfig outMemConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfig(op->out());
 
   DeviceVariant targetDevice =
       context.getTargetDevice(op->device()->global_id());

--- a/runtime/lib/ttnn/operations/creation/arange.cpp
+++ b/runtime/lib/ttnn/operations/creation/arange.cpp
@@ -25,7 +25,9 @@ void run(const ::tt::target::ttnn::ArangeOp *op, ProgramContext &context) {
   }
 
   if (op->memcfg()) {
-    memoryConfig = utils::createMemoryConfig(op->memcfg(), op->out());
+    memoryConfig =
+        ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg())
+            .value();
   }
 
   if (op->device()) {

--- a/runtime/lib/ttnn/operations/creation/constant.cpp
+++ b/runtime/lib/ttnn/operations/creation/constant.cpp
@@ -64,8 +64,7 @@ makeTypedBuffer(::tt::target::DataType dtype,
 }
 
 void run(const ::tt::target::ttnn::ConstantOp *op, ProgramContext &context) {
-  ::ttnn::Shape shape(::tt::runtime::ttnn::utils::toShapeFromFBShape(
-      *op->out()->desc()->shape()));
+  ::ttnn::Shape shape = utils::toTTNNShape(*op->out()->desc()->shape());
 
   ::tt::tt_metal::OwnedBuffer ownedBuffer = makeTypedBuffer(
       op->out()->desc()->layout()->memory_desc()->data_type(), op->data());
@@ -73,7 +72,7 @@ void run(const ::tt::target::ttnn::ConstantOp *op, ProgramContext &context) {
   ::ttnn::DataType dtype =
       ::tt::runtime::ttnn::operations::utils::getDataType(op->out());
 
-  LOG_ASSERT(::tt::runtime::ttnn::operations::utils::inSystemMemory(op->out()),
+  LOG_ASSERT(::tt::runtime::ttnn::utils::inSystemMemory(op->out()),
              "Output tensor is expected to be in system memory");
   LOG_ASSERT(!::tt::runtime::ttnn::operations::utils::isTilized(op->out()),
              "Output tensor is expected to be in ROW_MAJOR layout");

--- a/runtime/lib/ttnn/operations/creation/ones.cpp
+++ b/runtime/lib/ttnn/operations/creation/ones.cpp
@@ -25,7 +25,7 @@ void run(const ::tt::target::ttnn::OnesOp *op, ProgramContext &context) {
   std::optional<::ttnn::Layout> layout = std::optional<::ttnn::Layout>();
   std::optional<std::reference_wrapper<::ttnn::IDevice>> device = std::nullopt;
   std::optional<::ttnn::MemoryConfig> memoryConfig =
-      std::optional<::ttnn::MemoryConfig>();
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
 
   if (op->dtype()) {
     dtype = ::tt::runtime::ttnn::utils::toTTNNDataType(*(op->dtype()));
@@ -42,10 +42,6 @@ void run(const ::tt::target::ttnn::OnesOp *op, ProgramContext &context) {
                    targetDevice),
                "ttnn::ones does not support MeshDevice.");
     device = std::get<std::reference_wrapper<::ttnn::IDevice>>(targetDevice);
-  }
-
-  if (op->memcfg()) {
-    memoryConfig = utils::createMemoryConfig(op->memcfg(), op->out());
   }
 
   ::ttnn::Tensor out = ::ttnn::ones(shape, dtype, layout, device, memoryConfig);

--- a/runtime/lib/ttnn/operations/creation/zeros.cpp
+++ b/runtime/lib/ttnn/operations/creation/zeros.cpp
@@ -24,7 +24,7 @@ void run(const ::tt::target::ttnn::ZerosOp *op, ProgramContext &context) {
   std::optional<::ttnn::Layout> layout = std::optional<::ttnn::Layout>();
   std::optional<std::reference_wrapper<::ttnn::IDevice>> device = std::nullopt;
   std::optional<::ttnn::MemoryConfig> memoryConfig =
-      std::optional<::ttnn::MemoryConfig>();
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
 
   if (op->dtype()) {
     dtype = ::tt::runtime::ttnn::utils::toTTNNDataType(*(op->dtype()));
@@ -41,10 +41,6 @@ void run(const ::tt::target::ttnn::ZerosOp *op, ProgramContext &context) {
                    targetDevice),
                "ttnn::zeros does not support MeshDevice.");
     device = std::get<std::reference_wrapper<::ttnn::IDevice>>(targetDevice);
-  }
-
-  if (op->memcfg()) {
-    memoryConfig = utils::createMemoryConfig(op->memcfg(), op->out());
   }
 
   ::ttnn::Tensor out =

--- a/runtime/lib/ttnn/operations/data_movement/concat.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/concat.cpp
@@ -6,6 +6,7 @@
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
 #include "tt/runtime/ttnn/operations/utils.h"
+#include "tt/runtime/ttnn/utils.h"
 
 namespace tt::runtime::ttnn::operations::data_movement {
 void run(const ::tt::target::ttnn::ConcatOp *op, ProgramContext &context) {
@@ -17,10 +18,9 @@ void run(const ::tt::target::ttnn::ConcatOp *op, ProgramContext &context) {
     inputs.push_back(in);
   }
   int32_t dim = op->dim();
-  std::optional<tt::tt_metal::MemoryConfig> memoryConfig =
-      op->memory_config() ? std::make_optional(utils::createMemoryConfig(
-                                op->memory_config(), op->out()))
-                          : std::nullopt;
+  std::optional<::ttnn::MemoryConfig> memoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
+          op->memory_config());
   ::ttnn::Tensor out = ::ttnn::concat(inputs, dim, memoryConfig);
   tensorPool.insert_or_assign(op->out()->global_id(), out);
 }

--- a/runtime/lib/ttnn/operations/data_movement/pad.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/pad.cpp
@@ -7,6 +7,7 @@
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/workarounds.h"
 #include "tt/runtime/ttnn/operations/utils.h"
+#include "tt/runtime/ttnn/utils.h"
 
 #include <optional>
 
@@ -26,10 +27,8 @@ void run(const ::tt::target::ttnn::PadOp *op, ProgramContext &context) {
     padding.emplace_back(op->padding()->Get(i), op->padding()->Get(i + 1));
   }
 
-  std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
-      op->memcfg() ? std::make_optional(
-                         utils::createMemoryConfig(op->memcfg(), op->out()))
-                   : std::nullopt;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
 
   out = ::ttnn::pad(in, padding, padValue, op->use_multicore(),
                     outputMemoryConfig);

--- a/runtime/lib/ttnn/operations/data_movement/permute.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/permute.cpp
@@ -6,6 +6,7 @@
 
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/ttnn/operations/utils.h"
+#include "tt/runtime/ttnn/utils.h"
 
 #include <vector>
 
@@ -18,10 +19,9 @@ void run(const ::tt::target::ttnn::PermuteOp *op, ProgramContext &context) {
 
   ::ttnn::SmallVector<int64_t> permutation(op->permutation()->begin(),
                                            op->permutation()->end());
-  std::optional<tt::tt_metal::MemoryConfig> memoryConfig =
-      op->memory_config() ? std::make_optional(utils::createMemoryConfig(
-                                op->memory_config(), op->out()))
-                          : std::nullopt;
+  std::optional<::ttnn::MemoryConfig> memoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
+          op->memory_config());
   float padValue = op->pad_value();
 
   ::ttnn::Tensor out = ::ttnn::permute(in, permutation, memoryConfig, padValue);

--- a/runtime/lib/ttnn/operations/data_movement/repeat_interleave.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/repeat_interleave.cpp
@@ -6,6 +6,7 @@
 
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/ttnn/operations/utils.h"
+#include "tt/runtime/ttnn/utils.h"
 
 namespace tt::runtime::ttnn::operations::data_movement {
 void run(const ::tt::target::ttnn::RepeatInterleaveOp *op,
@@ -17,10 +18,9 @@ void run(const ::tt::target::ttnn::RepeatInterleaveOp *op,
 
   uint32_t repeats = op->repeats();
   int32_t dim = op->dim();
-  std::optional<tt::tt_metal::MemoryConfig> memoryConfig =
-      op->memory_config() ? std::make_optional(utils::createMemoryConfig(
-                                op->memory_config(), op->out()))
-                          : std::nullopt;
+  std::optional<::ttnn::MemoryConfig> memoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
+          op->memory_config());
 
   ::ttnn::Tensor out =
       ::ttnn::repeat_interleave(input, repeats, dim, memoryConfig);

--- a/runtime/lib/ttnn/operations/data_movement/transpose.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/transpose.cpp
@@ -15,8 +15,14 @@ void run(const ::tt::target::ttnn::TransposeOp *op, ProgramContext &context) {
   DEBUG_ASSERT(in.is_allocated());
   int32_t dim0 = op->dim0();
   int32_t dim1 = op->dim1();
-  ::tt::tt_metal::MemoryConfig outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfig(op->out());
+
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
+          ::tt::runtime::ttnn::utils::getTensorRefMemoryConfig(op->out()));
+  LOG_ASSERT(::tt::runtime::ttnn::utils::inSystemMemory(op->out()) ||
+                 outputMemoryConfig.has_value(),
+             "Memory config must exist for device tensors");
+
   ::ttnn::Tensor out = ::ttnn::transpose(in, dim0, dim1, outputMemoryConfig);
   tensorPool.insert_or_assign(op->out()->global_id(), out);
 }

--- a/runtime/lib/ttnn/operations/eltwise/ternary/ternary.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/ternary/ternary.cpp
@@ -15,14 +15,18 @@ static void runEltwiseTernaryWhereOp(
     const ::tt::target::ttnn::EltwiseOp *op, ProgramTensorPool &tensorPool,
     const std::function<::ttnn::Tensor(
         const ::ttnn::Tensor &, const ::ttnn::Tensor &, const ::ttnn::Tensor &,
-        const std::optional<::tt::tt_metal::MemoryConfig> &)> &ttnnOp) {
+        const std::optional<::ttnn::MemoryConfig> &)> &ttnnOp) {
   ::ttnn::Tensor *first = nullptr;
   ::ttnn::Tensor *second = nullptr;
   ::ttnn::Tensor *third = nullptr;
   getEltwiseTernaryOpInputTensors(op, tensorPool, &first, &second, &third);
 
-  ::tt::tt_metal::MemoryConfig outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfig(op->out());
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
+          ::tt::runtime::ttnn::utils::getTensorRefMemoryConfig(op->out()));
+  LOG_ASSERT(::tt::runtime::ttnn::utils::inSystemMemory(op->out()) ||
+                 outputMemoryConfig.has_value(),
+             "Memory config must exist for device tensors");
 
   ::ttnn::Tensor out = ttnnOp(*first, *second, *third, outputMemoryConfig);
   tensorPool.insert_or_assign(op->out()->global_id(), out);

--- a/runtime/lib/ttnn/operations/embedding/embedding_backward.cpp
+++ b/runtime/lib/ttnn/operations/embedding/embedding_backward.cpp
@@ -23,15 +23,12 @@ void run(const ::tt::target::ttnn::EmbeddingBackwardOp *op,
   DEBUG_ASSERT(weight.is_allocated());
   DEBUG_ASSERT(inGrad.is_allocated());
 
-  std::optional<::ttnn::DataType> dtype = std::nullopt;
-  std::optional<::ttnn::MemoryConfig> memoryConfig = std::nullopt;
+  std::optional<::ttnn::MemoryConfig> memoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
 
+  std::optional<::ttnn::DataType> dtype = std::nullopt;
   if (op->dtype()) {
     dtype = ::tt::runtime::ttnn::utils::toTTNNDataType(*(op->dtype()));
-  }
-  if (op->memcfg()) {
-    memoryConfig =
-        std::make_optional(utils::createMemoryConfig(op->memcfg(), op->out()));
   }
   ::ttnn::Tensor out =
       ::ttnn::embedding_bw(input, weight, inGrad, dtype, memoryConfig);

--- a/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/utils.cpp
+++ b/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/utils.cpp
@@ -7,97 +7,38 @@
 
 namespace tt::runtime::ttnn::operations::utils {
 
-bool isTilized(const ::tt::target::TensorRef *tensorRef) {
+bool isTilized(const ::tt::target::ttnn::TensorRef *tensorRef) {
   const ::tt::target::Dim2d *tileShape =
       tensorRef->desc()->layout()->memory_desc()->tile_shape();
-  return tileShape->x() == 32 and tileShape->y() == 32;
+  return tileShape->x() == 32 && tileShape->y() == 32;
 }
 
-::tt::target::MemorySpace
-getMemorySpace(const ::tt::target::TensorRef *tensorRef) {
-  return tensorRef->desc()->layout()->memory_desc()->memory_space();
-}
-
-bool inSystemMemory(const ::tt::target::TensorRef *tensorRef) {
-  const ::tt::target::MemorySpace targetMemorySpace = getMemorySpace(tensorRef);
-  return targetMemorySpace == ::tt::target::MemorySpace::System or
-         targetMemorySpace == ::tt::target::MemorySpace::SystemMMIO;
-}
-
-::ttnn::DataType getDataType(const ::tt::target::TensorRef *tensorRef) {
+::ttnn::DataType getDataType(const ::tt::target::ttnn::TensorRef *tensorRef) {
   return ::tt::runtime::ttnn::utils::toTTNNDataType(
       tensorRef->desc()->layout()->memory_desc()->data_type());
 }
 
-::tt::tt_metal::MemoryConfig
-createMemoryConfig(const ::tt::target::MemoryConfigDesc *memcfg,
-                   const ::tt::target::TensorRef *tensorRef) {
-
-  ::ttnn::TensorMemoryLayout tensorMemoryLayout =
-      ::tt::runtime::ttnn::utils::toTTNNTensorMemoryLayout(
-          memcfg->tensor_memory_layout());
-
-  ::ttnn::BufferType bufferType =
-      ::tt::runtime::ttnn::utils::toTTNNBufferType(memcfg->buffer_type());
-
-  const ::tt::target::LayoutDesc *layout = tensorRef->desc()->layout();
-  const ::flatbuffers::Vector<const tt::target::Dim2dRange *>
-      *targetCoreRangeSet = layout->core_range_set();
-  CoreRangeSet ttnnCoreRangeSet =
-      ::tt::runtime::ttnn::utils::toCoreRangeSet(targetCoreRangeSet);
-  const ::flatbuffers::Vector<int64_t> *shardShape =
-      memcfg->shard_spec()->shard_shape();
-  const ::tt::target::Dim2d *tileShape = layout->memory_desc()->tile_shape();
-
-  LOG_ASSERT(targetCoreRangeSet->size() == 1,
-             "Currently only single core range/grid is supported");
-
-  LOG_ASSERT(shardShape->size() == 2,
-             "Only 2D shard shape is supported in TTNN backend");
-
-  LOG_ASSERT(::tt::runtime::ttnn::utils::isValidTileShape(tileShape),
-             "Invalid tile shape");
-
-  std::array<uint32_t, 2> ttnnShardShape = {
-      static_cast<uint32_t>(shardShape->Get(0)),
-      static_cast<uint32_t>(shardShape->Get(1))};
-
-  ttnnShardShape[0] *= tileShape->y();
-  ttnnShardShape[1] *= tileShape->x();
-
-  ::tt::tt_metal::ShardSpec shardSpec(
-      ttnnCoreRangeSet, ttnnShardShape,
-      ::tt::tt_metal::ShardOrientation::ROW_MAJOR);
-
-  ::ttnn::MemoryConfig memoryConfig = {
-      tensorMemoryLayout, bufferType,
-      tensorMemoryLayout == tt_metal::TensorMemoryLayout::INTERLEAVED
-          ? std::nullopt
-          : std::make_optional(shardSpec)};
-  return memoryConfig;
-}
-
 ::tt::tt_metal::DistributedTensorConfig distributedTensorConfigFromFlatbuffer(
-    const ::tt::target::DistributionStrategy *strategy) {
+    const ::tt::target::ttnn::DistributionStrategy *strategy) {
   switch (strategy->strategy_type()) {
-  case ::tt::target::DistributedTensorConfig::ReplicateTensor: {
+  case ::tt::target::ttnn::DistributedTensorConfig::ReplicateTensor: {
     return ::tt::tt_metal::ReplicateTensor(
         strategy->strategy_as_ReplicateTensor()->replication_factor());
   }
-  case ::tt::target::DistributedTensorConfig::ShardTensor: {
+  case ::tt::target::ttnn::DistributedTensorConfig::ShardTensor: {
     return ::tt::tt_metal::ShardTensor(
         strategy->strategy_as_ShardTensor()->shard_dim());
   }
-  case ::tt::target::DistributedTensorConfig::ShardTensor2D: {
+  case ::tt::target::ttnn::DistributedTensorConfig::ShardTensor2D: {
     uint32_t y = strategy->strategy_as_ShardTensor2D()->shard_mesh()->y();
     uint32_t x = strategy->strategy_as_ShardTensor2D()->shard_mesh()->x();
     ::tt::tt_metal::ShardMesh mesh(y, x);
     return ::tt::tt_metal::ShardTensor2D(mesh);
   }
-  case ::tt::target::DistributedTensorConfig::AllGatherTensor: {
+  case ::tt::target::ttnn::DistributedTensorConfig::AllGatherTensor: {
     return ::tt::tt_metal::AllGatherTensor();
   }
-  case ::tt::target::DistributedTensorConfig::NONE: {
+  case ::tt::target::ttnn::DistributedTensorConfig::NONE: {
     LOG_FATAL("Unsupported distributed tensor config");
   }
   }

--- a/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/utils.h
+++ b/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/utils.h
@@ -14,21 +14,12 @@
 
 namespace tt::runtime::ttnn::operations::utils {
 
-bool isTilized(const ::tt::target::TensorRef *tensorRef);
+bool isTilized(const ::tt::target::ttnn::TensorRef *tensorRef);
 
-bool inSystemMemory(const ::tt::target::TensorRef *tensorRef);
-
-::tt::target::MemorySpace
-getMemorySpace(const ::tt::target::TensorRef *tensorRef);
-
-::ttnn::DataType getDataType(const ::tt::target::TensorRef *tensorRef);
-
-::tt::tt_metal::MemoryConfig
-createMemoryConfig(const ::tt::target::MemoryConfigDesc *memcfg,
-                   const ::tt::target::TensorRef *tensorRef);
+::ttnn::DataType getDataType(const ::tt::target::ttnn::TensorRef *tensorRef);
 
 ::tt::tt_metal::DistributedTensorConfig distributedTensorConfigFromFlatbuffer(
-    const ::tt::target::DistributionStrategy *strategy);
+    const ::tt::target::ttnn::DistributionStrategy *strategy);
 
 template <std::integral T>
 inline ::ttnn::Shape toTTNNShape(const flatbuffers::Vector<T> &vec) {

--- a/runtime/lib/ttnn/operations/layout/to_device.cpp
+++ b/runtime/lib/ttnn/operations/layout/to_device.cpp
@@ -16,12 +16,10 @@ void run(const ::tt::target::ttnn::ToDeviceOp *op, ProgramContext &context) {
   DEBUG_ASSERT(inputTensor.is_allocated());
   DEBUG_ASSERT(::tt::runtime::ttnn::utils::isOnHost(inputTensor.storage_type()),
                "Calling ttnn::to_device on a device tensor");
-  std::optional<::ttnn::MemoryConfig> memoryConfig = std::nullopt;
 
-  if (op->memcfg()) {
-    memoryConfig =
-        std::make_optional(utils::createMemoryConfig(op->memcfg(), op->out()));
-  }
+  std::optional<::ttnn::MemoryConfig> memoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
+
   DeviceVariant targetDevice =
       context.getTargetDevice(op->device()->global_id());
   ::ttnn::Tensor out = std::visit(

--- a/runtime/lib/ttnn/operations/layout/to_layout.cpp
+++ b/runtime/lib/ttnn/operations/layout/to_layout.cpp
@@ -31,16 +31,12 @@ void run(const ::tt::target::ttnn::ToLayoutOp *op, ProgramContext &context) {
              "Invalid tile shape");
 
   ::ttnn::Layout layout = toTTNNLayout(op->layout());
+  std::optional<::ttnn::MemoryConfig> memoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
   std::optional<::ttnn::DataType> dtype = std::nullopt;
-  std::optional<::ttnn::MemoryConfig> memoryConfig = std::nullopt;
 
   if (op->dtype()) {
     dtype = ::tt::runtime::ttnn::utils::toTTNNDataType(*(op->dtype()));
-  }
-
-  if (op->memcfg()) {
-    memoryConfig =
-        std::make_optional(utils::createMemoryConfig(op->memcfg(), op->out()));
   }
 
   ::ttnn::Tensor out;

--- a/runtime/lib/ttnn/operations/layout/to_memory_config.cpp
+++ b/runtime/lib/ttnn/operations/layout/to_memory_config.cpp
@@ -18,13 +18,14 @@ void run(const ::tt::target::ttnn::ToMemoryConfigOp *op,
   ProgramTensorPool &tensorPool = context.getTensorPool();
   const ::ttnn::Tensor &inputTensor = tensorPool.at(op->in0()->global_id());
   DEBUG_ASSERT(inputTensor.is_allocated());
-  LOG_ASSERT(not utils::inSystemMemory(op->out()),
+  LOG_ASSERT(!::tt::runtime::ttnn::utils::inSystemMemory(op->out()),
              "Should not be converting memory config for host tensor");
+  LOG_ASSERT(op->memcfg(), "ToMemoryConfigOp must have memory config");
+  std::optional<::ttnn::MemoryConfig> memoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
 
-  ::ttnn::MemoryConfig memoryConfig =
-      utils::createMemoryConfig(op->memcfg(), op->out());
   ::ttnn::Tensor out =
-      ::ttnn::to_memory_config(inputTensor, memoryConfig, std::nullopt);
+      ::ttnn::to_memory_config(inputTensor, memoryConfig.value(), std::nullopt);
   tensorPool.insert_or_assign(op->out()->global_id(), out);
 }
 } // namespace tt::runtime::ttnn::operations::layout

--- a/runtime/lib/ttnn/operations/moreh/moreh_cumsum.cpp
+++ b/runtime/lib/ttnn/operations/moreh/moreh_cumsum.cpp
@@ -19,10 +19,8 @@ void run(const ::tt::target::ttnn::MorehCumSumOp *op, ProgramContext &context) {
   const ::ttnn::Tensor &in = tensorPool.at(op->in()->global_id());
   DEBUG_ASSERT(in.is_allocated());
 
-  std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
-      op->memcfg() ? std::make_optional(
-                         utils::createMemoryConfig(op->memcfg(), op->out()))
-                   : std::nullopt;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
 
   ::ttnn::Tensor out =
       ::ttnn::moreh_cumsum(in, op->dim(), std::nullopt, outputMemoryConfig,

--- a/runtime/lib/ttnn/operations/pool/maxpool2d.cpp
+++ b/runtime/lib/ttnn/operations/pool/maxpool2d.cpp
@@ -18,15 +18,20 @@ void run(const ::tt::target::ttnn::MaxPool2dOp *op, ProgramContext &context) {
   ::ttnn::Tensor input = tensorPool.at(op->in()->global_id());
   DEBUG_ASSERT(input.is_allocated());
 
-  ::ttnn::MemoryConfig outMemConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfig(op->out());
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
+          ::tt::runtime::ttnn::utils::getTensorRefMemoryConfig(op->out()));
+  LOG_ASSERT(::tt::runtime::ttnn::utils::inSystemMemory(op->out()) ||
+                 outputMemoryConfig.has_value(),
+             "Memory config must exist for device tensors");
+
   ::ttnn::Tensor out = ::ttnn::max_pool2d(
       input, op->batch_size(), op->input_height(), op->input_width(),
       op->channels(), std::array{op->kernel_height(), op->kernel_width()},
       std::array{op->stride_height(), op->stride_width()},
       std::array{op->padding_height(), op->padding_width()},
-      std::array{op->dilation_height(), op->dilation_width()}, outMemConfig,
-      std::nullopt);
+      std::array{op->dilation_height(), op->dilation_width()},
+      outputMemoryConfig, std::nullopt);
 
   tensorPool.insert_or_assign(op->out()->global_id(), out);
 }

--- a/runtime/lib/ttnn/operations/pool/upsample.cpp
+++ b/runtime/lib/ttnn/operations/pool/upsample.cpp
@@ -6,6 +6,7 @@
 
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/ttnn/operations/utils.h"
+#include "tt/runtime/ttnn/utils.h"
 
 namespace tt::runtime::ttnn::operations::pool {
 void run(const ::tt::target::ttnn::UpsampleOp *op, ProgramContext &context) {
@@ -29,10 +30,9 @@ void run(const ::tt::target::ttnn::UpsampleOp *op, ProgramContext &context) {
   }
 
   std::string mode = op->mode()->str();
-  std::optional<tt::tt_metal::MemoryConfig> memoryConfig =
-      op->memory_config() ? std::make_optional(utils::createMemoryConfig(
-                                op->memory_config(), op->out()))
-                          : std::nullopt;
+  std::optional<::ttnn::MemoryConfig> memoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
+          op->memory_config());
 
   ::ttnn::Tensor output =
       ::ttnn::upsample(input, scaleFactor, mode, memoryConfig);

--- a/runtime/lib/ttnn/operations/reduction/argmax.cpp
+++ b/runtime/lib/ttnn/operations/reduction/argmax.cpp
@@ -18,10 +18,8 @@ runReductionArgMaxOp(::tt::target::ttnn::ReductionArgMaxOp const *op,
   const ::ttnn::Tensor &in = tensorPool.at(op->in()->global_id());
   DEBUG_ASSERT(in.is_allocated());
 
-  std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
-      op->memcfg() ? std::make_optional(
-                         utils::createMemoryConfig(op->memcfg(), op->out()))
-                   : std::nullopt;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
 
   ::ttnn::Tensor out =
       ::ttnn::argmax(in, op->dim(), op->use_multicore(),

--- a/runtime/lib/ttnn/operations/reduction/prod.cpp
+++ b/runtime/lib/ttnn/operations/reduction/prod.cpp
@@ -12,10 +12,8 @@ namespace tt::runtime::ttnn::operations::reduction {
 static void runReductionProdOp(::tt::target::ttnn::ReductionProdOp const *op,
                                ProgramTensorPool &tensorPool) {
 
-  std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
-      op->memcfg() ? std::make_optional(
-                         utils::createMemoryConfig(op->memcfg(), op->out()))
-                   : std::nullopt;
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
 
   const ::ttnn::Tensor &in = tensorPool.at(op->in()->global_id());
   DEBUG_ASSERT(in.is_allocated());

--- a/runtime/lib/ttnn/operations/reduction/reduction.cpp
+++ b/runtime/lib/ttnn/operations/reduction/reduction.cpp
@@ -14,11 +14,17 @@ static void runReductionOp(
     const std::function<::ttnn::Tensor(
         const ::ttnn::Tensor &,
         const std::optional<std::variant<int, ::ttnn::SmallVector<int>>> &,
-        const bool, const std::optional<::tt::tt_metal::MemoryConfig> &,
+        const bool, const std::optional<::ttnn::MemoryConfig> &,
         const std::optional<::ttnn::DeviceComputeKernelConfig> &, float)>
         &ttnnOp) {
-  ::tt::tt_metal::MemoryConfig outputMemoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfig(op->out());
+
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
+          ::tt::runtime::ttnn::utils::getTensorRefMemoryConfig(op->out()));
+  LOG_ASSERT(::tt::runtime::ttnn::utils::inSystemMemory(op->out()) ||
+                 outputMemoryConfig.has_value(),
+             "Memory config must exist for device tensors");
+
   const ::ttnn::Tensor &in = tensorPool.at(op->in()->global_id());
   DEBUG_ASSERT(in.is_allocated());
 

--- a/runtime/lib/ttnn/program.cpp
+++ b/runtime/lib/ttnn/program.cpp
@@ -305,14 +305,14 @@ std::vector<Tensor> runProgram(::ttnn::MeshDevice &meshDevice,
   LOG_ASSERT(program->inputs()->size() == inputs.size(),
              "Program input size mismatch: ", program->inputs()->size(),
              " != ", inputs.size());
-  for (::tt::target::TensorRef const *input : *program->inputs()) {
+  for (::tt::target::ttnn::TensorRef const *input : *program->inputs()) {
     auto [iter, inserted] =
         liveTensors.try_emplace(input->global_id(), inputs[inputIndex++]);
     LOG_ASSERT(inserted, "Duplicate input tensor");
     programInputs.push_back(input->global_id());
   }
   std::vector<uint32_t> programOutputs;
-  for (::tt::target::TensorRef const *output : *program->outputs()) {
+  for (::tt::target::ttnn::TensorRef const *output : *program->outputs()) {
     programOutputs.push_back(output->global_id());
   }
   ProgramExecutor executor(executableHandle, liveTensors, programInputs,

--- a/runtime/lib/ttnn/types/types.cpp
+++ b/runtime/lib/ttnn/types/types.cpp
@@ -14,15 +14,15 @@ namespace tt::runtime::ttnn {
 LayoutConverter::LayoutConverter(const LayoutDesc &inputDesc,
                                  const LayoutDesc &outputDesc)
     : inputDesc(inputDesc), outputDesc(outputDesc) {
-  shouldTilize = (inputDesc.layout == ::ttnn::Layout::ROW_MAJOR and
+  shouldTilize = (inputDesc.layout == ::ttnn::Layout::ROW_MAJOR &&
                   outputDesc.layout == ::ttnn::Layout::TILE);
-  shouldUntilize = (inputDesc.layout == ::ttnn::Layout::TILE and
+  shouldUntilize = (inputDesc.layout == ::ttnn::Layout::TILE &&
                     outputDesc.layout == ::ttnn::Layout::ROW_MAJOR);
   shouldTypecast = (inputDesc.dataType != outputDesc.dataType);
-  shouldToDevice = (inputDesc.isOnHost() and outputDesc.isOnDevice());
-  shouldToMemoryConfig = (not shouldToDevice and outputDesc.isOnDevice() and
+  shouldToDevice = (inputDesc.isOnHost() && outputDesc.isOnDevice());
+  shouldToMemoryConfig = (!shouldToDevice && outputDesc.isOnDevice() &&
                           (inputDesc.memoryConfig != outputDesc.memoryConfig));
-  shouldFromDevice = (inputDesc.isOnDevice() and outputDesc.isOnHost());
+  shouldFromDevice = (inputDesc.isOnDevice() && outputDesc.isOnHost());
 }
 
 ::ttnn::Tensor LayoutConverter::convertTensorLayout(
@@ -48,7 +48,7 @@ LayoutConverter::LayoutConverter(const LayoutDesc &inputDesc,
 }
 
 ::ttnn::Tensor LayoutConverter::typecastIfNeeded(const ::ttnn::Tensor &input) {
-  if (not shouldTypecast) {
+  if (!shouldTypecast) {
     return input;
   }
   if (utils::isOnHost(input.storage_type())) {
@@ -61,7 +61,7 @@ LayoutConverter::LayoutConverter(const LayoutDesc &inputDesc,
 LayoutConverter::toDeviceIfNeeded(const ::ttnn::Tensor &input,
                                   std::optional<DeviceVariant> targetDevice,
                                   bool force) {
-  if (shouldToDevice or force) {
+  if (shouldToDevice || force) {
     LOG_ASSERT(targetDevice.has_value());
     return std::visit(
         [&](auto &&targetDevice) -> ::ttnn::Tensor {
@@ -106,14 +106,14 @@ LayoutConverter::fromDeviceIfNeeded(const ::ttnn::Tensor &input) {
     return out;
   }
 
-  if (shouldTilize and outputDesc.dataType == ::ttnn::DataType::BFLOAT16) {
+  if (shouldTilize && outputDesc.dataType == ::ttnn::DataType::BFLOAT16) {
     ::ttnn::Tensor out = toDeviceIfNeeded(input, targetDevice);
     out = toLayoutIfNeeded(out);
     out = toMemoryConfigIfNeeded(out);
     return out;
   }
 
-  if (shouldTilize and outputDesc.dataType != ::ttnn::DataType::BFLOAT16) {
+  if (shouldTilize && outputDesc.dataType != ::ttnn::DataType::BFLOAT16) {
     ::ttnn::Tensor out = toLayoutIfNeeded(input);
     out = toDeviceIfNeeded(out, targetDevice);
     out = toMemoryConfigIfNeeded(out);
@@ -150,7 +150,7 @@ LayoutConverter::fromDeviceIfNeeded(const ::ttnn::Tensor &input) {
     return out;
   }
 
-  if (shouldTilize and inputDesc.dataType == ::ttnn::DataType::BFLOAT16) {
+  if (shouldTilize && inputDesc.dataType == ::ttnn::DataType::BFLOAT16) {
     ::ttnn::Tensor out = toDeviceIfNeeded(input, targetDevice);
     out = toLayoutIfNeeded(out);
     out = typecastIfNeeded(out);
@@ -158,7 +158,7 @@ LayoutConverter::fromDeviceIfNeeded(const ::ttnn::Tensor &input) {
     return out;
   }
 
-  if (shouldTilize and outputDesc.dataType == ::ttnn::DataType::BFLOAT16) {
+  if (shouldTilize && outputDesc.dataType == ::ttnn::DataType::BFLOAT16) {
     ::ttnn::Tensor out = typecastIfNeeded(input);
     out = toDeviceIfNeeded(out, targetDevice);
     out = toLayoutIfNeeded(input);
@@ -166,7 +166,7 @@ LayoutConverter::fromDeviceIfNeeded(const ::ttnn::Tensor &input) {
     return out;
   }
 
-  if (shouldTilize and inputDesc.dataType != ::ttnn::DataType::BFLOAT16 and
+  if (shouldTilize && inputDesc.dataType != ::ttnn::DataType::BFLOAT16 &&
       outputDesc.dataType != ::ttnn::DataType::BFLOAT16) {
     ::ttnn::Tensor out = typecastIfNeeded(input);
     out = toLayoutIfNeeded(out);
@@ -180,19 +180,19 @@ LayoutConverter::fromDeviceIfNeeded(const ::ttnn::Tensor &input) {
 
 ::ttnn::Tensor LayoutConverter::convertHostTensorLayout(
     const ::ttnn::Tensor &input, std::optional<DeviceVariant> targetDevice) {
-  bool shouldToLayout = (shouldTilize or shouldUntilize);
-  LOG_ASSERT(not shouldToDevice or targetDevice.has_value(),
+  bool shouldToLayout = (shouldTilize || shouldUntilize);
+  LOG_ASSERT(!shouldToDevice || targetDevice.has_value(),
              "Target device must be provided for ToDevice");
-  if (not shouldToLayout and not shouldTypecast) {
+  if (!shouldToLayout && !shouldTypecast) {
     return handleHostInputNoLayoutNoTypecast(input, targetDevice);
   }
-  if (shouldToLayout and not shouldTypecast) {
+  if (shouldToLayout && !shouldTypecast) {
     return handleHostInputLayoutNoTypecast(input, targetDevice);
   }
-  if (not shouldToLayout and shouldTypecast) {
+  if (!shouldToLayout && shouldTypecast) {
     return handleHostInputNoLayoutTypecast(input, targetDevice);
   }
-  if (shouldToLayout and shouldTypecast) {
+  if (shouldToLayout && shouldTypecast) {
     return handleHostInputLayoutTypecast(input, targetDevice);
   }
   LOG_FATAL("Unreachable code path");
@@ -207,13 +207,13 @@ LayoutConverter::fromDeviceIfNeeded(const ::ttnn::Tensor &input) {
 
 ::ttnn::Tensor LayoutConverter::handleDeviceInputLayoutNoTypecast(
     const ::ttnn::Tensor &input) {
-  if (shouldUntilize and shouldFromDevice) {
+  if (shouldUntilize && shouldFromDevice) {
     ::ttnn::Tensor out = fromDeviceIfNeeded(input);
     out = toLayoutIfNeeded(out);
     return out;
   }
 
-  if (shouldUntilize and not shouldFromDevice) {
+  if (shouldUntilize && !shouldFromDevice) {
     LOG_WARNING("Currently no constraint checking for on-device untilize.");
     ::ttnn::Tensor out = toLayoutIfNeeded(input);
     out = toMemoryConfigIfNeeded(out);
@@ -222,7 +222,7 @@ LayoutConverter::fromDeviceIfNeeded(const ::ttnn::Tensor &input) {
 
   /* If we should tilize and the input data type is bfloat16, tilize on device
    */
-  if (shouldTilize and inputDesc.dataType == ::ttnn::DataType::BFLOAT16) {
+  if (shouldTilize && inputDesc.dataType == ::ttnn::DataType::BFLOAT16) {
     ::ttnn::Tensor out = toLayoutIfNeeded(input);
     out = toMemoryConfigIfNeeded(out);
     out = fromDeviceIfNeeded(out);
@@ -231,15 +231,15 @@ LayoutConverter::fromDeviceIfNeeded(const ::ttnn::Tensor &input) {
 
   /* If we should tilize and the input data type is not bfloat16, tilize on
    * host */
-  if (shouldTilize and inputDesc.dataType != ::ttnn::DataType::BFLOAT16 and
+  if (shouldTilize && inputDesc.dataType != ::ttnn::DataType::BFLOAT16 &&
       shouldFromDevice) {
     ::ttnn::Tensor out = fromDeviceIfNeeded(input);
     out = toLayoutIfNeeded(out);
     return out;
   }
 
-  if (shouldTilize and inputDesc.dataType != ::ttnn::DataType::BFLOAT16 and
-      not shouldFromDevice) {
+  if (shouldTilize && inputDesc.dataType != ::ttnn::DataType::BFLOAT16 &&
+      !shouldFromDevice) {
     LOG_WARNING("Currently no constraint checking for on-device tilize.");
     ::ttnn::Tensor out = toLayoutIfNeeded(input);
     out = toMemoryConfigIfNeeded(out);
@@ -258,13 +258,13 @@ LayoutConverter::fromDeviceIfNeeded(const ::ttnn::Tensor &input) {
     return out;
   }
 
-  if (not inputDesc.isTilized() and shouldFromDevice) {
+  if (!inputDesc.isTilized() && shouldFromDevice) {
     ::ttnn::Tensor out = fromDeviceIfNeeded(input);
     out = typecastIfNeeded(out);
     return out;
   }
 
-  if (not inputDesc.isTilized() and not shouldFromDevice) {
+  if (!inputDesc.isTilized() && !shouldFromDevice) {
     LOG_WARNING("Currently no constraint checking for on-device typecast.");
     ::ttnn::Tensor out = typecastIfNeeded(input);
     out = toMemoryConfigIfNeeded(out);
@@ -275,14 +275,14 @@ LayoutConverter::fromDeviceIfNeeded(const ::ttnn::Tensor &input) {
 
 ::ttnn::Tensor
 LayoutConverter::handleDeviceInputLayoutTypecast(const ::ttnn::Tensor &input) {
-  if (shouldUntilize and shouldFromDevice) {
+  if (shouldUntilize && shouldFromDevice) {
     ::ttnn::Tensor out = typecastIfNeeded(input);
     out = fromDeviceIfNeeded(input);
     out = toLayoutIfNeeded(out);
     return out;
   }
 
-  if (shouldUntilize and not shouldFromDevice) {
+  if (shouldUntilize && !shouldFromDevice) {
     LOG_WARNING("Currently no constraint checking for on-device untilize.");
     ::ttnn::Tensor out = typecastIfNeeded(input);
     out = toLayoutIfNeeded(input);
@@ -290,7 +290,7 @@ LayoutConverter::handleDeviceInputLayoutTypecast(const ::ttnn::Tensor &input) {
     return out;
   }
 
-  if (shouldTilize and inputDesc.dataType == ::ttnn::DataType::BFLOAT16) {
+  if (shouldTilize && inputDesc.dataType == ::ttnn::DataType::BFLOAT16) {
     ::ttnn::Tensor out = toLayoutIfNeeded(input);
     out = typecastIfNeeded(out);
     out = toMemoryConfigIfNeeded(out);
@@ -298,7 +298,7 @@ LayoutConverter::handleDeviceInputLayoutTypecast(const ::ttnn::Tensor &input) {
     return out;
   }
 
-  if (shouldTilize and inputDesc.dataType != ::ttnn::DataType::BFLOAT16 and
+  if (shouldTilize && inputDesc.dataType != ::ttnn::DataType::BFLOAT16 &&
       shouldFromDevice) {
     ::ttnn::Tensor out = fromDeviceIfNeeded(input);
     out = toLayoutIfNeeded(out);
@@ -306,8 +306,8 @@ LayoutConverter::handleDeviceInputLayoutTypecast(const ::ttnn::Tensor &input) {
     return out;
   }
 
-  if (shouldTilize and inputDesc.dataType != ::ttnn::DataType::BFLOAT16 and
-      not shouldFromDevice) {
+  if (shouldTilize && inputDesc.dataType != ::ttnn::DataType::BFLOAT16 &&
+      !shouldFromDevice) {
     LOG_WARNING("Currently no constraint checking for on-device tilize.");
     ::ttnn::Tensor out = toLayoutIfNeeded(input);
     out = typecastIfNeeded(out);
@@ -320,17 +320,17 @@ LayoutConverter::handleDeviceInputLayoutTypecast(const ::ttnn::Tensor &input) {
 
 ::ttnn::Tensor
 LayoutConverter::convertDeviceTensorLayout(const ::ttnn::Tensor &input) {
-  bool shouldToLayout = (shouldTilize or shouldUntilize);
-  if (not shouldToLayout and not shouldTypecast) {
+  bool shouldToLayout = (shouldTilize || shouldUntilize);
+  if (!shouldToLayout && !shouldTypecast) {
     return handleDeviceInputNoLayoutNoTypecast(input);
   }
-  if (shouldToLayout and not shouldTypecast) {
+  if (shouldToLayout && !shouldTypecast) {
     return handleDeviceInputLayoutNoTypecast(input);
   }
-  if (not shouldToLayout and shouldTypecast) {
+  if (!shouldToLayout && shouldTypecast) {
     return handleDeviceInputNoLayoutTypecast(input);
   }
-  if (shouldToLayout and shouldTypecast) {
+  if (shouldToLayout && shouldTypecast) {
     return handleDeviceInputLayoutTypecast(input);
   }
   LOG_FATAL("Unreachable code path");

--- a/runtime/test/ttnn/utils.cpp
+++ b/runtime/test/ttnn/utils.cpp
@@ -15,9 +15,9 @@ Layout getDramInterleavedTileLayout(::tt::target::DataType dataType) {
   LOG_ASSERT(getCurrentRuntime() == DeviceRuntime::TTNN);
   ::ttnn::DataType ttnnDataType =
       ::tt::runtime::ttnn::utils::toTTNNDataType(dataType);
-  ::tt::runtime::ttnn::LayoutDesc layoutDesc(::ttnn::BufferType::DRAM,
+  ::tt::runtime::ttnn::LayoutDesc layoutDesc(::ttnn::StorageType::DEVICE,
                                              ::ttnn::Layout::TILE, ttnnDataType,
-                                             std::nullopt);
+                                             ::ttnn::DRAM_MEMORY_CONFIG);
   return Layout(
       std::static_pointer_cast<void>(
           std::make_shared<::tt::runtime::ttnn::LayoutDesc>(layoutDesc)),
@@ -27,9 +27,9 @@ Layout getDramInterleavedRowMajorLayout(::tt::target::DataType dataType) {
   LOG_ASSERT(getCurrentRuntime() == DeviceRuntime::TTNN);
   ::ttnn::DataType ttnnDataType =
       ::tt::runtime::ttnn::utils::toTTNNDataType(dataType);
-  ::tt::runtime::ttnn::LayoutDesc layoutDesc(::ttnn::BufferType::DRAM,
-                                             ::ttnn::Layout::ROW_MAJOR,
-                                             ttnnDataType, std::nullopt);
+  ::tt::runtime::ttnn::LayoutDesc layoutDesc(
+      ::ttnn::StorageType::DEVICE, ::ttnn::Layout::ROW_MAJOR, ttnnDataType,
+      ::ttnn::DRAM_MEMORY_CONFIG);
   return Layout(
       std::static_pointer_cast<void>(
           std::make_shared<::tt::runtime::ttnn::LayoutDesc>(layoutDesc)),
@@ -39,7 +39,7 @@ Layout getDramInterleavedRowMajorLayout(::tt::target::DataType dataType) {
   LOG_ASSERT(getCurrentRuntime() == DeviceRuntime::TTNN);
   ::ttnn::DataType ttnnDataType =
       ::tt::runtime::ttnn::utils::toTTNNDataType(dataType);
-  ::tt::runtime::ttnn::LayoutDesc layoutDesc(::ttnn::BufferType::SYSTEM_MEMORY,
+  ::tt::runtime::ttnn::LayoutDesc layoutDesc(::ttnn::StorageType::OWNED,
                                              ::ttnn::Layout::ROW_MAJOR,
                                              ttnnDataType, std::nullopt);
   return Layout(


### PR DESCRIPTION
### Problem description
We have been using a shared types.fbs file as an interface between mlir and runtime types. This caused ttmetal types and ttnn types to be coupled and it makes it hard to model backend-specific constructs. We also needed to add workarounds (e.g. TensorMemoryLayout::NONE) for compatibility between both backends. As we start expanding work on direct to metal as well as multichip work on ttnn, it would be desirable to separate backend-specific types.

### What's changed
This PR is a refactors the mlir to flatbuffer interface as well as runtime. Specific changes include:

* Moved backend-specific types out of `Common/types.fbs` into `ttmetal/types.fbs` and `ttnn/types.fbs`. 
* Refactored ttnn `TensorDesc` to contain `StorageType` and `MemoryConfig`. Also moved core range into `ShardSpec` to match the modelling in ttnn. 
* Removed `TensorMemoryLayout`, `DistributionStrategy` from ttmetal TensorDesc.
* Removed `TensorMemoryLayout::NONE` from flatbuffer entirely.
* Canonicalized `createMemoryConfig` API in ttnn backend, now the API just needs a `::tt::target::ttnn::MemoryConfig` parameter.
* Updated runtime code to follow established coding guidelines, specifically changing `not` to `!`, `and` to `&&` etc.
* Update ttnn backend to use ttnn type aliases when possible, instead of a mixture of say `::ttnn::MemoryConfig` and `::tt::tt_metal::MemoryConfig`.

### Future Improvements
* This PR supports 1-to-1 mapping between flatbuffer and runtime. It would also be desirable to have a 1-to-1 mapping between compiler and flatbuffer (FYI @odjuricicTT). Currently many types/attributes are still coupled on the compiler end, and it would be nice to separate them and start adding backend-specific attributes to support 1-to-1 mapping and consistency throughout the stack across different backends.
  
* Currently tensor `storageType` is hardcoded to either owned (for host tensors) or device (for device tensors). Ideally we should have compiler support for this to dynamically program the storage type. We could add a storage type to the layout attributes in ttnn dialect such that when a tensor is an output of say a mesh_shard op, it'll change its storage to multi_device_host or back to owned (if it's a shard to full). 

