### PR TITLE
Remove workaround for to layout in decompose layouts

### DIFF
--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.h
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.h
@@ -110,6 +110,39 @@ inline DataType elementTypeToDataType(Type elementType) {
   }
   return dtype;
 }
+
+inline Type dataTypeToElementType(::mlir::MLIRContext *context,
+                                  DataType dtype) {
+  switch (dtype) {
+  case DataType::Float32:
+    return FloatType::getF32(context);
+  case DataType::Float16:
+    return FloatType::getF16(context);
+  case DataType::BFloat16:
+    return FloatType::getBF16(context);
+  case DataType::BFP_Float8:
+    return FloatType::getF16(context);
+  case DataType::BFP_BFloat8:
+    return FloatType::getBF16(context);
+  case DataType::BFP_Float4:
+    return FloatType::getF16(context);
+  case DataType::BFP_BFloat4:
+    return FloatType::getBF16(context);
+  case DataType::BFP_Float2:
+    return FloatType::getF16(context);
+  case DataType::BFP_BFloat2:
+    return FloatType::getBF16(context);
+  case DataType::UInt32:
+    return IntegerType::get(context, 32,
+                            IntegerType::SignednessSemantics::Unsigned);
+  case DataType::UInt16:
+    return IntegerType::get(context, 16,
+                            IntegerType::SignednessSemantics::Unsigned);
+  case DataType::UInt8:
+    return IntegerType::get(context, 8,
+                            IntegerType::SignednessSemantics::Unsigned);
+  }
+}
 } // namespace mlir::tt
 
 #define GET_ATTRDEF_CLASSES

--- a/include/ttmlir/Dialect/TTNN/Utils/Utils.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/Utils.h
@@ -36,8 +36,6 @@ mlir::tt::TensorMemoryLayout toTTTensorMemoryLayout(
 mlir::tt::MemorySpace
 toTTMemorySpace(const mlir::tt::ttnn::BufferType bufferType);
 
-mlir::Type dataTypeToElementType(::mlir::MLIRContext *context, DataType dtype);
-
 // Helper method to create a RankedTensorType with the given encoding.
 RankedTensorType
 createRankedTensorTypeWithEncoding(RankedTensorType tensorType,

--- a/lib/Dialect/TT/IR/TTOpsTypes.cpp
+++ b/lib/Dialect/TT/IR/TTOpsTypes.cpp
@@ -1205,35 +1205,7 @@ uint64_t TileType::getSizeBytes() const {
 }
 
 mlir::Type TileType::getElementType() const {
-  switch (getDataType()) {
-  case DataType::Float32:
-    return FloatType::getF32(getContext());
-  case DataType::Float16:
-    return FloatType::getF16(getContext());
-  case DataType::BFloat16:
-    return FloatType::getBF16(getContext());
-  case DataType::BFP_Float8:
-    return FloatType::getF16(getContext());
-  case DataType::BFP_BFloat8:
-    return FloatType::getBF16(getContext());
-  case DataType::BFP_Float4:
-    return FloatType::getF16(getContext());
-  case DataType::BFP_BFloat4:
-    return FloatType::getBF16(getContext());
-  case DataType::BFP_Float2:
-    return FloatType::getF16(getContext());
-  case DataType::BFP_BFloat2:
-    return FloatType::getBF16(getContext());
-  case DataType::UInt32:
-    return IntegerType::get(getContext(), 32,
-                            IntegerType::SignednessSemantics::Unsigned);
-  case DataType::UInt16:
-    return IntegerType::get(getContext(), 16,
-                            IntegerType::SignednessSemantics::Unsigned);
-  case DataType::UInt8:
-    return IntegerType::get(getContext(), 8,
-                            IntegerType::SignednessSemantics::Unsigned);
-  }
+  return dataTypeToElementType(getContext(), getDataType());
 }
 
 SystemDescAttr mlir::tt::getCurrentScopeSystemDesc(mlir::Operation *op) {

--- a/lib/Dialect/TTNN/Analysis/LegalLayoutAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/LegalLayoutAnalysis.cpp
@@ -117,8 +117,8 @@ bool LegalLayoutAnalysis::applyOverrides() {
   // Create element type for the new layout.
   Type elementType = layout.getScalarElementType();
   if (layoutOverride.dataType.has_value()) {
-    elementType = utils::dataTypeToElementType(op->getContext(),
-                                               layoutOverride.dataType.value());
+    elementType = mlir::tt::dataTypeToElementType(
+        op->getContext(), layoutOverride.dataType.value());
   }
 
   if (layoutOverride.memoryLayout == Layout::Tile) {
@@ -201,7 +201,7 @@ void LegalLayoutAnalysis::analysisImplementation() {
         overrideIt != analysisInput.outputLayoutOverrides->end()) {
       override = overrideIt->getValue();
       if (override->dataType.has_value()) {
-        scalarElementType = {utils::dataTypeToElementType(
+        scalarElementType = {mlir::tt::dataTypeToElementType(
             op->getContext(), override->dataType.value())};
       }
     }

--- a/lib/Dialect/TTNN/Transforms/TTNNDecomposeLayouts.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNDecomposeLayouts.cpp
@@ -294,13 +294,10 @@ private:
         ttnn::LayoutAttr::get(op.getContext(), info.output.layoutEnum);
     RankedTensorType currentInputType =
         mlir::cast<RankedTensorType>(currentInput.getType());
-    // Remove this once we have type conversion pass in TTIR.
-    // Issue for tracking: https://github.com/tenstorrent/tt-mlir/issues/1277.
-    Type memrefElementType =
-        info.output.layoutEnum == ttnn::Layout::RowMajor
-            ? currentInputType.getElementType()
-            : utils::getElementType(op.getContext(), info.output.layoutEnum,
-                                    info.output.dataType);
+    DataType currentInputDataType =
+        mlir::tt::elementTypeToDataType(currentInputType.getElementType());
+    Type memrefElementType = utils::getElementType(
+        op.getContext(), info.output.layoutEnum, currentInputDataType);
     RankedTensorType newResultType =
         utils::createRankedTensorTypeWithElementType(currentInputType,
                                                      memrefElementType);

--- a/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
@@ -92,7 +92,7 @@ public:
 
       TTNNLayoutAttr newLayout = createLayoutAttr(ctx, deviceGrid, type);
       // Convert mlir data types to tt data types
-      Type elementType = mlir::tt::ttnn::utils::dataTypeToElementType(
+      Type elementType = mlir::tt::dataTypeToElementType(
           ctx, elementTypeToDataType(type.getElementType()));
       return RankedTensorType::get(type.getShape(), elementType, newLayout);
     });
@@ -119,7 +119,7 @@ public:
       TTNNLayoutAttr newLayout = createLayoutAttr(
           ctx, deviceGrid, type, BufferType::SystemMemory, std::nullopt, false);
       // Convert mlir data types to tt data types
-      Type elementType = mlir::tt::ttnn::utils::dataTypeToElementType(
+      Type elementType = mlir::tt::dataTypeToElementType(
           ctx, elementTypeToDataType(type.getElementType()));
       return RankedTensorType::get(type.getShape(), elementType, newLayout);
     });

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkarounds.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkarounds.cpp
@@ -173,7 +173,7 @@ workaroundOutputOperand(mlir::TypedValue<RankedTensorType> opResult,
       ttnn::utils::createRankedTensorTypeWithEncoding(
           ttnn::utils::createRankedTensorTypeWithElementType(
               opResultType,
-              ttnn::utils::dataTypeToElementType(
+              mlir::tt::dataTypeToElementType(
                   rewriter.getContext(),
                   outputWorkaroundResults.tensorDataTypeResult.targetValue)),
           newOutputLayoutAttr);

--- a/lib/Dialect/TTNN/Utils/TransformUtils.cpp
+++ b/lib/Dialect/TTNN/Utils/TransformUtils.cpp
@@ -71,8 +71,8 @@ createToLayoutOp(Operation *op, mlir::TypedValue<RankedTensorType> inputValue,
       ttnn::utils::createRankedTensorTypeWithEncoding(
           ttnn::utils::createRankedTensorTypeWithElementType(
               inputToLayoutOpType,
-              utils::dataTypeToElementType(rewriter.getContext(),
-                                           targetTensorDataType)),
+              mlir::tt::dataTypeToElementType(rewriter.getContext(),
+                                              targetTensorDataType)),
           toLayoutOpResultEncoding);
 
   // Create the output memory config attribute.

--- a/lib/Dialect/TTNN/Utils/Utils.cpp
+++ b/lib/Dialect/TTNN/Utils/Utils.cpp
@@ -83,38 +83,6 @@ toTTMemorySpace(const mlir::tt::ttnn::BufferType bufferType) {
   llvm_unreachable("Unknown MemorySpace");
 }
 
-Type dataTypeToElementType(::mlir::MLIRContext *context, DataType dtype) {
-  switch (dtype) {
-  case DataType::Float32:
-    return FloatType::getF32(context);
-  case DataType::Float16:
-    return FloatType::getF16(context);
-  case DataType::BFloat16:
-    return FloatType::getBF16(context);
-  case DataType::BFP_Float8:
-    return FloatType::getF16(context);
-  case DataType::BFP_BFloat8:
-    return FloatType::getBF16(context);
-  case DataType::BFP_Float4:
-    return FloatType::getF16(context);
-  case DataType::BFP_BFloat4:
-    return FloatType::getBF16(context);
-  case DataType::BFP_Float2:
-    return FloatType::getF16(context);
-  case DataType::BFP_BFloat2:
-    return FloatType::getBF16(context);
-  case DataType::UInt32:
-    return IntegerType::get(context, 32,
-                            IntegerType::SignednessSemantics::Unsigned);
-  case DataType::UInt16:
-    return IntegerType::get(context, 16,
-                            IntegerType::SignednessSemantics::Unsigned);
-  case DataType::UInt8:
-    return IntegerType::get(context, 8,
-                            IntegerType::SignednessSemantics::Unsigned);
-  }
-}
-
 // Helper method to create a RankedTensorType with the given encoding.
 RankedTensorType
 createRankedTensorTypeWithEncoding(RankedTensorType tensorType,
@@ -182,7 +150,7 @@ Type getElementType(MLIRContext *context, Layout tensorLayout,
   return tensorLayout == Layout::Tile
              ? TileType::get(context, {ttnn::TILE_HEIGHT, ttnn::TILE_WIDTH},
                              dataType)
-             : ttnn::utils::dataTypeToElementType(context, dataType);
+             : mlir::tt::dataTypeToElementType(context, dataType);
 }
 
 } // namespace mlir::tt::ttnn::utils

--- a/test/ttmlir/Dialect/TTNN/typecast.mlir
+++ b/test/ttmlir/Dialect/TTNN/typecast.mlir
@@ -4,102 +4,105 @@ module {
     %0 = tensor.empty() : tensor<32x32xui16>
     // CHECK: "ttnn.typecast"
     %1 = "ttir.typecast"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xui32>, tensor<32x32xui16>) -> tensor<32x32xui16>
+    // CHECK: return {{.*}} : tensor<32x32xui16
     return %1 : tensor<32x32xui16>
   }
   func.func public @main1(%arg0: tensor<32x32xui32>) -> tensor<32x32xui16> {
     %0 = tensor.empty() : tensor<32x32xui16>
     // CHECK: "ttnn.typecast"
     %1 = "ttir.typecast"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xui32>, tensor<32x32xui16>) -> tensor<32x32xui16>
-    return %1 : tensor<32x32xui16>
-  }
-  func.func public @main2(%arg0: tensor<32x32xi16>) -> tensor<32x32xui16> {
-    %0 = tensor.empty() : tensor<32x32xui16>
-    // CHECK: "ttnn.typecast"
-    %1 = "ttir.typecast"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xi16>, tensor<32x32xui16>) -> tensor<32x32xui16>
+    // CHECK: return {{.*}} : tensor<32x32xui16
     return %1 : tensor<32x32xui16>
   }
   func.func public @main3(%arg0: tensor<32x32xi32>) -> tensor<32x32xui16> {
     %0 = tensor.empty() : tensor<32x32xui16>
     // CHECK: "ttnn.typecast"
     %1 = "ttir.typecast"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xi32>, tensor<32x32xui16>) -> tensor<32x32xui16>
+    // CHECK: return {{.*}} : tensor<32x32xui16
     return %1 : tensor<32x32xui16>
   }
   func.func public @main4(%arg0: tensor<32x32xi32>) -> tensor<32x32xui16> {
     %0 = tensor.empty() : tensor<32x32xui16>
     // CHECK: "ttnn.typecast"
     %1 = "ttir.typecast"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xi32>, tensor<32x32xui16>) -> tensor<32x32xui16>
+    // CHECK: return {{.*}} : tensor<32x32xui16
     return %1 : tensor<32x32xui16>
   }
   func.func public @main5(%arg0: tensor<32x32xf32>) -> tensor<32x32xui16> {
     %0 = tensor.empty() : tensor<32x32xui16>
     // CHECK: "ttnn.typecast"
     %1 = "ttir.typecast"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xf32>, tensor<32x32xui16>) -> tensor<32x32xui16>
+    // CHECK: return {{.*}} : tensor<32x32xui16
     return %1 : tensor<32x32xui16>
   }
   func.func public @main6(%arg0: tensor<32x32xbf16>) -> tensor<32x32xui16> {
     %0 = tensor.empty() : tensor<32x32xui16>
     // CHECK: "ttnn.typecast"
     %1 = "ttir.typecast"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xbf16>, tensor<32x32xui16>) -> tensor<32x32xui16>
+    // CHECK: return {{.*}} : tensor<32x32xui16
     return %1 : tensor<32x32xui16>
   }
   func.func public @main7(%arg0: tensor<32x32xui16>) -> tensor<32x32xui32> {
     %0 = tensor.empty() : tensor<32x32xui32>
     // CHECK: "ttnn.typecast"
     %1 = "ttir.typecast"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xui16>, tensor<32x32xui32>) -> tensor<32x32xui32>
+    // CHECK: return {{.*}} : tensor<32x32xui32
     return %1 : tensor<32x32xui32>
   }
   func.func public @main8(%arg0: tensor<32x32xi16>) -> tensor<32x32xui32> {
     %0 = tensor.empty() : tensor<32x32xui32>
     // CHECK: "ttnn.typecast"
     %1 = "ttir.typecast"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xi16>, tensor<32x32xui32>) -> tensor<32x32xui32>
+    // CHECK: return {{.*}} : tensor<32x32xui32
     return %1 : tensor<32x32xui32>
   }
   func.func public @main9(%arg0: tensor<32x32xi32>) -> tensor<32x32xui32> {
     %0 = tensor.empty() : tensor<32x32xui32>
     // CHECK-NOT: "ttnn.typecast"
     %1 = "ttir.typecast"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xi32>, tensor<32x32xui32>) -> tensor<32x32xui32>
-    return %1 : tensor<32x32xui32>
-  }
-  func.func public @main10(%arg0: tensor<32x32xi32>) -> tensor<32x32xui32> {
-    %0 = tensor.empty() : tensor<32x32xui32>
-    // CHECK: "ttnn.typecast"
-    %1 = "ttir.typecast"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xi32>, tensor<32x32xui32>) -> tensor<32x32xui32>
+    // CHECK: return {{.*}} : tensor<32x32xui32
     return %1 : tensor<32x32xui32>
   }
   func.func public @main11(%arg0: tensor<32x32xf32>) -> tensor<32x32xui32> {
     %0 = tensor.empty() : tensor<32x32xui32>
     // CHECK: "ttnn.typecast"
     %1 = "ttir.typecast"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xf32>, tensor<32x32xui32>) -> tensor<32x32xui32>
+    // CHECK: return {{.*}} : tensor<32x32xui32
     return %1 : tensor<32x32xui32>
   }
   func.func public @main12(%arg0: tensor<32x32xbf16>) -> tensor<32x32xui32> {
     %0 = tensor.empty() : tensor<32x32xui32>
     // CHECK: "ttnn.typecast"
     %1 = "ttir.typecast"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xbf16>, tensor<32x32xui32>) -> tensor<32x32xui32>
+    // CHECK: return {{.*}} : tensor<32x32xui32
     return %1 : tensor<32x32xui32>
   }
   func.func public @main13(%arg0: tensor<32x32xui16>) -> tensor<32x32xui32> {
     %0 = tensor.empty() : tensor<32x32xui32>
     // CHECK: "ttnn.typecast"
     %1 = "ttir.typecast"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xui16>, tensor<32x32xui32>) -> tensor<32x32xui32>
+    // CHECK: return {{.*}} : tensor<32x32xui32
     return %1 : tensor<32x32xui32>
   }
   func.func public @main14(%arg0: tensor<32x32xi16>) -> tensor<32x32xui32> {
     %0 = tensor.empty() : tensor<32x32xui32>
     // CHECK: "ttnn.typecast"
     %1 = "ttir.typecast"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xi16>, tensor<32x32xui32>) -> tensor<32x32xui32>
+    // CHECK: return {{.*}} : tensor<32x32xui32
     return %1 : tensor<32x32xui32>
   }
   func.func public @main15(%arg0: tensor<32x32xf32>) -> tensor<32x32xui32> {
     %0 = tensor.empty() : tensor<32x32xui32>
-    // CHECK-EXISTS: "ttnn.typecast"
+    // CHECK: "ttnn.typecast"
     %1 = "ttir.typecast"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xf32>, tensor<32x32xui32>) -> tensor<32x32xui32>
+    // CHECK: return {{.*}} : tensor<32x32xui32
     return %1 : tensor<32x32xui32>
   }
   func.func public @main16(%arg0: tensor<32x32xbf16>) -> tensor<32x32xui32> {
     %0 = tensor.empty() : tensor<32x32xui32>
-    // CHECK-EXISTS: "ttnn.typecast"
+    // CHECK: "ttnn.typecast"
     %1 = "ttir.typecast"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xbf16>, tensor<32x32xui32>) -> tensor<32x32xui32>
+    // CHECK: return {{.*}} : tensor<32x32xui32
     return %1 : tensor<32x32xui32>
   }
 }


### PR DESCRIPTION
Before we used to perform conversion from mlir type to tt type in different places in the code. #1744 added type conversion in TTNNLayout which converts all types to tt supported types which makes this workaround redundant.
