### PR TITLE
Update build-requirements.txt

### DIFF
--- a/env/build-requirements.txt
+++ b/env/build-requirements.txt
@@ -6,5 +6,3 @@ wheel
 setuptools
 black
 pre-commit
-pybind11
-nanobind

--- a/env/build-requirements.txt
+++ b/env/build-requirements.txt
@@ -6,3 +6,5 @@ wheel
 setuptools
 black
 pre-commit
+pybind11
+nanobind

--- a/env/build_venv.sh
+++ b/env/build_venv.sh
@@ -10,5 +10,6 @@ TTMLIR_PYTHON_VERSION="${TTMLIR_PYTHON_VERSION:-python3.10}"
 $TTMLIR_PYTHON_VERSION -m venv $TTMLIR_VENV
 source $CURRENT_SOURCE_DIR/activate
 python -m pip install --upgrade pip
+# Requirements for third party projects are installed during their build in `CMakeLists.txt`
 pip install -r $CURRENT_SOURCE_DIR/build-requirements.txt
 pip install -r $CURRENT_SOURCE_DIR/../test/python/requirements.txt


### PR DESCRIPTION
### Ticket
Fixes #2224

### Problem description
Currently `pybind11` and `nanobind` are required to build tt-mlir, but they are not explicitly stated in tt-mlir `env/build-requirements.txt`. They get transiently installed during env build (during llvm project build). This makes Frontends oblivious to those unspecified tt-mlir dependencies, which causes problems because FEs don't use the same venv as tt-mlir.

### What's changed
Added a comment in `tt-mlir/env/build_venv.sh` referencing that there are more requirements installed during llvm project build in `tt-mlir/env/CMakeLists.txt`, to make it more obvious.

Opened issues for all FEs to consume tt-mlir dependencies:
- tt-xla: https://github.com/tenstorrent/tt-xla/issues/269
- tt-torch: https://github.com/tenstorrent/tt-torch/issues/322
- tt-forge: https://github.com/tenstorrent/tt-forge-fe/issues/1263

### Checklist
- [x] New/Existing tests provide coverage for changes
