### PR TITLE
Remove TT_TensorMemoryLayout

### DIFF
--- a/include/ttmlir-c/TTAttrs.h
+++ b/include/ttmlir-c/TTAttrs.h
@@ -61,9 +61,6 @@ MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTOOBValAttrGet(MlirContext ctx,
                                                        uint32_t oobVal);
 
 MLIR_CAPI_EXPORTED MlirAttribute
-ttmlirTTTensorMemoryLayoutAttrGet(MlirContext ctx, uint32_t memLayout);
-
-MLIR_CAPI_EXPORTED MlirAttribute
 ttmlirTTIteratorTypeAttrGet(MlirContext ctx, uint32_t iteratorType);
 
 MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTIteratorTypeArrayAttrGet(

--- a/include/ttmlir/Dialect/TT/IR/TTOpsEnums.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsEnums.td
@@ -72,26 +72,6 @@ def TT_MemorySpace : I32EnumAttr<"MemorySpace", "TT MemorySpace",
   let cppNamespace = "::mlir::tt";
 }
 
-def TT_TensorMemoryLayoutNone : I32EnumAttrCase<"None", 0, "none">;
-def TT_TensorMemoryLayoutInterleaved : I32EnumAttrCase<"Interleaved", 1, "interleaved">;
-def TT_TensorMemoryLayoutSingleBank : I32EnumAttrCase<"SingleBank", 2, "single_bank">;
-def TT_TensorMemoryLayoutHeightSharded : I32EnumAttrCase<"HeightSharded", 3, "height_sharded">;
-def TT_TensorMemoryLayoutWidthSharded : I32EnumAttrCase<"WidthSharded", 4, "width_sharded">;
-def TT_TensorMemoryLayoutBlockSharded : I32EnumAttrCase<"BlockSharded", 5, "block_sharded">;
-
-def TT_TensorMemoryLayout : I32EnumAttr<"TensorMemoryLayout", "TT TensorMemoryLayout",
-                           [
-                            TT_TensorMemoryLayoutNone,
-                            TT_TensorMemoryLayoutInterleaved,
-                            TT_TensorMemoryLayoutSingleBank,
-                            TT_TensorMemoryLayoutHeightSharded,
-                            TT_TensorMemoryLayoutWidthSharded,
-                            TT_TensorMemoryLayoutBlockSharded,
-                           ]> {
-  let genSpecializedAttr = 0;
-  let cppNamespace = "::mlir::tt";
-}
-
 def TT_Parallel : I32EnumAttrCase<"Parallel", 0, "parallel">;
 def TT_Systolic : I32EnumAttrCase<"Systolic", 1, "systolic">;
 def TT_Broadcast : I32EnumAttrCase<"Broadcast", 2, "broadcast">;

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.h
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.h
@@ -45,12 +45,6 @@ inline bool isL1MemorySpace(MemorySpace memorySpace) {
   return memorySpace == MemorySpace::DeviceL1;
 }
 
-inline bool isShardedMemoryLayout(TensorMemoryLayout layout) {
-  return layout == TensorMemoryLayout::HeightSharded ||
-         layout == TensorMemoryLayout::WidthSharded ||
-         layout == TensorMemoryLayout::BlockSharded;
-}
-
 inline void printDimensionList(::mlir::AsmPrinter &printer,
                                ::llvm::ArrayRef<int64_t> shape) {
   printer.printDimensionList(shape);

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -320,9 +320,8 @@ def TT_MetalLayoutAttr : TT_Attr<"MetalLayout", "metal_layout"> {
   let parameters = (ins AttrParameter<"AffineMap", "An affine map that defines how the logical tensor dimensions map to a grid shape.">:$linear,
                         AttrParameter<"OOBVal", "A tracked out of bounds value that fills padding space.">:$oob_val,
                         AttrParameter<"GridAttr", "The grid shape that this tensor is divided onto.">:$grid,
-                        AttrParameter<"MemRefType", "A memref that describes the physical footprint allocation of the shard. It must also have a shape with rank equal to grid.">:$memref,
-                        DefaultValuedParameter<"TensorMemoryLayout", "TensorMemoryLayout::None", "The layout of the tensor in memory.">:$mem_layout);
-  let assemblyFormat = "`<` $linear`,` $oob_val`,` $grid`,` $memref (`,` $mem_layout^)? `>`";
+                        AttrParameter<"MemRefType", "A memref that describes the physical footprint allocation of the shard. It must also have a shape with rank equal to grid.">:$memref);
+  let assemblyFormat = "`<` $linear`,` $oob_val`,` $grid`,` $memref `>`";
 
   let extraClassDeclaration = [{
       static MetalLayoutAttr get(::mlir::MLIRContext *context,
@@ -331,21 +330,18 @@ def TT_MetalLayoutAttr : TT_Attr<"MetalLayout", "metal_layout"> {
                             MemorySpace memorySpace = MemorySpace::System,
                             GridAttr grid = {},
                             ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}},
-                            OOBVal oobVal = OOBVal::Undef,
-                            TensorMemoryLayout memLayout = TensorMemoryLayout::None);
+                            OOBVal oobVal = OOBVal::Undef);
       static MetalLayoutAttr get(::mlir::MLIRContext *context,
                             RankedTensorType ty,
                             MemorySpace memorySpace = MemorySpace::System,
                             GridAttr grid = {},
                             ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}},
-                            OOBVal oobVal = OOBVal::Undef,
-                            TensorMemoryLayout memLayout = TensorMemoryLayout::None);
+                            OOBVal oobVal = OOBVal::Undef);
       static MetalLayoutAttr get(::mlir::MLIRContext *context,
                             RankedTensorType ty,
                             MemorySpace memorySpace,
                             GridAttr grid,
-                            Type elementType,
-                            TensorMemoryLayout memLayout = TensorMemoryLayout::None);
+                            Type elementType);
       MetalLayoutAttr withGrid(::mlir::MLIRContext *context, ArrayRef<int64_t> tensorShape, GridAttr grid, ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}});
       MetalLayoutAttr withGrid(::mlir::MLIRContext *context,
                           RankedTensorType ty,
@@ -353,7 +349,6 @@ def TT_MetalLayoutAttr : TT_Attr<"MetalLayout", "metal_layout"> {
                           ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}});
       MetalLayoutAttr withElementType(::mlir::MLIRContext *context, Type elementType);
       MetalLayoutAttr withMemorySpace(::mlir::MLIRContext *context, MemorySpace memorySpace);
-      MetalLayoutAttr withMemoryLayout(::mlir::MLIRContext *context, TensorMemoryLayout memLayout);
       MetalLayoutAttr withShardShape(::mlir::MLIRContext *context, llvm::SmallVector<int64_t> shardShape);
       MetalLayoutAttr withStreamLayout(::mlir::MLIRContext *context, StreamLayoutAttr stream);
       MetalLayoutAttr withOuterScale(::mlir::MLIRContext *context,
@@ -365,10 +360,6 @@ def TT_MetalLayoutAttr : TT_Attr<"MetalLayout", "metal_layout"> {
       MemorySpace getMemorySpace() const;
       bool isSystemMemorySpace() const { return ::mlir::tt::isSystemMemorySpace(getMemorySpace()); }
       bool isDeviceMemorySpace() const { return ::mlir::tt::isDeviceMemorySpace(getMemorySpace()); }
-      bool hasShardedTensorMemoryLayout() const;
-      bool hasInterleavedTensorMemoryLayout() const;
-      bool hasShardedL1TensorMemoryLayout() const;
-      bool hasInterleavedL1TensorMemoryLayout() const;
       bool isTiled() const;
       Type getElementType() const;
       Type getScalarElementType() const;
@@ -434,10 +425,6 @@ def TT_DeviceAttr : TT_Attr<"Device", "device", []> {
 }
 
 def TT_MemorySpaceAttr : EnumAttr<TT_Dialect, TT_MemorySpace, "memory_space"> {
-  let assemblyFormat = "`<` $value `>`";
-}
-
-def TT_TensorMemoryLayoutAttr : EnumAttr<TT_Dialect, TT_TensorMemoryLayout, "tensor_memory_layout"> {
   let assemblyFormat = "`<` $value `>`";
 }
 

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -133,7 +133,6 @@ def TTIR_ToLayoutOp : TTIR_Op<"to_layout", [DestinationStyleOpInterface, TTIROpI
         bool isGridChange;
         bool isFormatChange;
         bool isMemorySpaceChange;
-        bool isMemoryLayoutChange;
       };
 
       // Returns booleans indicating if the op changes layout, grid, format, memory space or memory layout.

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -53,10 +53,6 @@ def TTIRLayout: Pass<"ttir-layout", "::mlir::ModuleOp"> {
           "::mlir::tt::MemorySpace",
           /*default=*/"::mlir::tt::MemorySpace::DeviceDRAM",
            "Set the default memory space for layout pass to prefer for operation operands, if not constrained">,
-    Option<"defaultDeviceMemoryLayout", "default-device-memory-layout",
-          "::mlir::tt::TensorMemoryLayout",
-          /*default=*/"::mlir::tt::TensorMemoryLayout::Interleaved",
-          "Set the default memory layout for layout pass to prefer for operation operands that are on device, if not constrained">
   ];
 }
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsEnums.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsEnums.td
@@ -21,11 +21,11 @@ def TTNN_Layout : I32EnumAttr<"Layout", "TTNN Layout",
   let cppNamespace = "::mlir::tt::ttnn";
 }
 
-def TTNN_TensorMemoryLayout_Interleaved : I32EnumAttrCase<"Interleaved", 1, "interleaved">;
-def TTNN_TensorMemoryLayout_SingleBank : I32EnumAttrCase<"SingleBank", 2, "single_bank">;
-def TTNN_TensorMemoryLayout_HeightSharded : I32EnumAttrCase<"HeightSharded", 3, "height_sharded">;
-def TTNN_TensorMemoryLayout_WidthSharded : I32EnumAttrCase<"WidthSharded", 4, "width_sharded">;
-def TTNN_TensorMemoryLayout_BlockSharded : I32EnumAttrCase<"BlockSharded", 5, "block_sharded">;
+def TTNN_TensorMemoryLayout_Interleaved : I32EnumAttrCase<"Interleaved", 0, "interleaved">;
+def TTNN_TensorMemoryLayout_SingleBank : I32EnumAttrCase<"SingleBank", 1, "single_bank">;
+def TTNN_TensorMemoryLayout_HeightSharded : I32EnumAttrCase<"HeightSharded", 2, "height_sharded">;
+def TTNN_TensorMemoryLayout_WidthSharded : I32EnumAttrCase<"WidthSharded", 3, "width_sharded">;
+def TTNN_TensorMemoryLayout_BlockSharded : I32EnumAttrCase<"BlockSharded", 4, "block_sharded">;
 
 def TTNN_TensorMemoryLayout : I32EnumAttr<"TensorMemoryLayout", "TTNN Tensor Memory Layout",
                            [

--- a/include/ttmlir/Dialect/TTNN/Utils/Utils.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/Utils.h
@@ -21,16 +21,6 @@ namespace mlir::tt::ttnn::utils {
 mlir::tt::ttnn::BufferType
 toTTNNBufferType(const mlir::tt::MemorySpace memorySpace);
 
-// Map tt::TensorMemoryLayout to ttnn::TensorMemoryLayout
-//
-ttnn::TensorMemoryLayout
-toTTNNTensorMemoryLayout(const tt::TensorMemoryLayout ttTensorMemoryLayout);
-
-// Map ttnn::BufferType to tt::MemorySpace
-//
-mlir::tt::TensorMemoryLayout toTTTensorMemoryLayout(
-    const ::mlir::tt::ttnn::TensorMemoryLayout ttnnTensorMemoryLayout);
-
 // Map ttnn::BufferType to tt::MemorySpace
 //
 mlir::tt::MemorySpace

--- a/lib/CAPI/TTAttrs.cpp
+++ b/lib/CAPI/TTAttrs.cpp
@@ -121,13 +121,12 @@ MlirAttribute ttmlirTTSystemDescAttrGet(
 
 MlirAttribute ttmlirTTMetalLayoutAttrGet(MlirContext ctx, MlirAffineMap linear,
                                          unsigned oobVal, MlirAttribute grid,
-                                         MlirType memref, unsigned memLayout) {
+                                         MlirType memref) {
   mlir::AffineMap affineMap = mlir::AffineMap::getFromOpaquePointer(linear.ptr);
   return wrap(MetalLayoutAttr::get(unwrap(ctx), affineMap,
                                    static_cast<OOBVal>(oobVal),
                                    mlir::cast<GridAttr>(unwrap(grid)),
-                                   mlir::cast<MemRefType>(unwrap(memref)),
-                                   static_cast<TensorMemoryLayout>(memLayout)));
+                                   mlir::cast<MemRefType>(unwrap(memref))));
 }
 
 MlirAttribute ttmlirTTMemorySpaceAttrGet(MlirContext ctx,
@@ -138,12 +137,6 @@ MlirAttribute ttmlirTTMemorySpaceAttrGet(MlirContext ctx,
 
 MlirAttribute ttmlirTTOOBValAttrGet(MlirContext ctx, uint32_t oobVal) {
   return wrap(OOBValAttr::get(unwrap(ctx), static_cast<tt::OOBVal>(oobVal)));
-}
-
-MlirAttribute ttmlirTTTensorMemoryLayoutAttrGet(MlirContext ctx,
-                                                uint32_t memLayout) {
-  return wrap(TensorMemoryLayoutAttr::get(
-      unwrap(ctx), static_cast<tt::TensorMemoryLayout>(memLayout)));
 }
 
 MlirAttribute ttmlirTTIteratorTypeAttrGet(MlirContext ctx,

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
@@ -519,13 +519,9 @@ public:
                        static_cast<int>(components.isGridChange ||
                                         components.isMemorySpaceChange) +
                        static_cast<int>(components.isFormatChange)) > 1;
-    assert(!components.isMemoryLayoutChange &&
-           "Memory layout is not used in direct to metal path");
     assert(!isCompound && "Only one change is allowed");
 
     assert(!isCompound && "Only one change is allowed");
-    assert(!components.isMemoryLayoutChange &&
-           "Tensor memory layout shouldn't change in metal backend");
     if (components.isMemorySpaceChange) {
       if (inputLayout.isSystemMemorySpace()) {
         assert(outputLayout.isDeviceMemorySpace());

--- a/lib/Dialect/TT/IR/TTOpsTypes.cpp
+++ b/lib/Dialect/TT/IR/TTOpsTypes.cpp
@@ -486,7 +486,7 @@ MetalLayoutAttr MetalLayoutAttr::get(
     ::mlir::MLIRContext *context, ArrayRef<int64_t> tensorShape,
     Type elementType, MemorySpace memorySpace, GridAttr grid,
     ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals,
-    OOBVal oobVal, TensorMemoryLayout memLayout) {
+    OOBVal oobVal) {
   if (not grid) {
     grid = GridAttr::get(context, tensorShape.size());
   }
@@ -496,28 +496,27 @@ MetalLayoutAttr MetalLayoutAttr::get(
   auto shardShape = calculateLogicalShardShape(tensorShape, linear, grid);
   auto memref = buildMemRef<MemorySpace, MemorySpaceAttr>(
       context, shardShape, elementType, memorySpace);
-  return get(context, linear, oobVal, grid, memref, memLayout);
+  return get(context, linear, oobVal, grid, memref);
 }
 
 MetalLayoutAttr MetalLayoutAttr::get(
     ::mlir::MLIRContext *context, RankedTensorType ty, MemorySpace memorySpace,
     GridAttr grid,
     ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals,
-    OOBVal oobVal, TensorMemoryLayout memLayout) {
+    OOBVal oobVal) {
   assert(ty);
   return get(context, ty.getShape(), ty.getElementType(), memorySpace, grid,
-             collapseIntervals, oobVal, memLayout);
+             collapseIntervals, oobVal);
 }
 
 MetalLayoutAttr MetalLayoutAttr::get(::mlir::MLIRContext *context,
                                      RankedTensorType ty,
                                      MemorySpace memorySpace, GridAttr grid,
-                                     Type elementType,
-                                     TensorMemoryLayout memLayout) {
+                                     Type elementType) {
   assert(ty);
   assert(grid);
   return get(context, ty.getShape(), elementType, memorySpace, grid, {{0, -1}},
-             OOBVal::Undef, memLayout);
+             OOBVal::Undef);
 }
 
 // From the logical shape of the tensor and the affine map of the layout,
@@ -620,28 +619,6 @@ mlir::Type MetalLayoutAttr::getScalarElementType() const {
   return elementType;
 }
 
-bool MetalLayoutAttr::hasShardedTensorMemoryLayout() const {
-  return (getMemLayout() == TensorMemoryLayout::HeightSharded or
-          getMemLayout() == TensorMemoryLayout::WidthSharded or
-          getMemLayout() == TensorMemoryLayout::BlockSharded);
-}
-
-bool MetalLayoutAttr::hasInterleavedTensorMemoryLayout() const {
-  return (getMemLayout() == TensorMemoryLayout::Interleaved);
-}
-
-bool MetalLayoutAttr::hasShardedL1TensorMemoryLayout() const {
-  return ::mlir::tt::isL1MemorySpace(getMemorySpace()) and
-         (getMemLayout() == TensorMemoryLayout::HeightSharded or
-          getMemLayout() == TensorMemoryLayout::WidthSharded or
-          getMemLayout() == TensorMemoryLayout::BlockSharded);
-}
-
-bool MetalLayoutAttr::hasInterleavedL1TensorMemoryLayout() const {
-  return ::mlir::tt::isL1MemorySpace(getMemorySpace()) and
-         (getMemLayout() == TensorMemoryLayout::Interleaved);
-}
-
 bool MetalLayoutAttr::isTiled() const {
   return ::mlir::isa<::mlir::tt::TileType>(getElementType());
 }
@@ -667,7 +644,7 @@ MetalLayoutAttr MetalLayoutAttr::withGrid(
     ::mlir::MLIRContext *context, ArrayRef<int64_t> tensorShape, GridAttr grid,
     ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals) {
   return get(context, tensorShape, getElementType(), getMemorySpace(), grid,
-             collapseIntervals, getOobVal(), getMemLayout());
+             collapseIntervals, getOobVal());
 }
 
 MetalLayoutAttr MetalLayoutAttr::withGrid(
@@ -683,8 +660,7 @@ MetalLayoutAttr MetalLayoutAttr::withElementType(::mlir::MLIRContext *context,
   return MetalLayoutAttr::get(
       context, getLinear(), getOobVal(), getGrid(),
       buildMemRef<MemorySpace, MemorySpaceAttr>(context, getShardShape(),
-                                                elementType, getMemorySpace()),
-      getMemLayout());
+                                                elementType, getMemorySpace()));
 }
 
 MetalLayoutAttr MetalLayoutAttr::withMemorySpace(::mlir::MLIRContext *context,
@@ -692,18 +668,7 @@ MetalLayoutAttr MetalLayoutAttr::withMemorySpace(::mlir::MLIRContext *context,
   return MetalLayoutAttr::get(
       context, getLinear(), getOobVal(), getGrid(),
       buildMemRef<MemorySpace, MemorySpaceAttr>(context, getShardShape(),
-                                                getElementType(), memorySpace),
-      getMemLayout());
-}
-
-MetalLayoutAttr
-MetalLayoutAttr::withMemoryLayout(::mlir::MLIRContext *context,
-                                  TensorMemoryLayout memLayout) {
-  return MetalLayoutAttr::get(
-      context, getLinear(), getOobVal(), getGrid(),
-      buildMemRef<MemorySpace, MemorySpaceAttr>(
-          context, getShardShape(), getElementType(), getMemorySpace()),
-      memLayout);
+                                                getElementType(), memorySpace));
 }
 
 MetalLayoutAttr
@@ -712,18 +677,16 @@ MetalLayoutAttr::withShardShape(::mlir::MLIRContext *context,
   return MetalLayoutAttr::get(
       context, getLinear(), getOobVal(), getGrid(),
       buildMemRef<MemorySpace, MemorySpaceAttr>(
-          context, shardShape, getElementType(), getMemorySpace()),
-      getMemLayout());
+          context, shardShape, getElementType(), getMemorySpace()));
 }
 
 // TODO(vroubtsovTT): remove this, it's difficult/unsafe to use
 MetalLayoutAttr MetalLayoutAttr::withStreamLayout(::mlir::MLIRContext *context,
                                                   StreamLayoutAttr layout) {
-  return MetalLayoutAttr::get(
-      context, getLinear(), getOobVal(), getGrid(),
-      buildMemRef<MemorySpace, MemorySpaceAttr>(
-          context, getShardShape(), getElementType(), getMemorySpace(), layout),
-      getMemLayout());
+  return MetalLayoutAttr::get(context, getLinear(), getOobVal(), getGrid(),
+                              buildMemRef<MemorySpace, MemorySpaceAttr>(
+                                  context, getShardShape(), getElementType(),
+                                  getMemorySpace(), layout));
 }
 
 MetalLayoutAttr MetalLayoutAttr::withOuterScale(
@@ -747,7 +710,7 @@ MetalLayoutAttr MetalLayoutAttr::withOuterScale(
       context, fullShape, getElementType(), getMemorySpace(), fullLayout);
 
   return MetalLayoutAttr::get(context, getLinear(), getOobVal(), getGrid(),
-                              fullMemRef, getMemLayout());
+                              fullMemRef);
 }
 
 MemorySpace MetalLayoutAttr::getMemorySpace() const {

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -1316,10 +1316,7 @@ mlir::tt::ttir::ToLayoutOp::compoundComponents() {
       inputLayout.getElementType() != outputLayout.getElementType();
   bool isMemorySpaceChange =
       inputLayout.getMemorySpace() != outputLayout.getMemorySpace();
-  bool isMemoryLayoutChange =
-      inputLayout.getMemLayout() != outputLayout.getMemLayout();
-  return {isLayoutChange, isGridChange, isFormatChange, isMemorySpaceChange,
-          isMemoryLayoutChange};
+  return {isLayoutChange, isGridChange, isFormatChange, isMemorySpaceChange};
 }
 
 ::mlir::LogicalResult

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -43,8 +43,6 @@ void createTTIRToTTMetalBackendPipeline(
     {
       layoutOptions.initMemorySpace = mlir::tt::MemorySpace::DeviceL1;
       layoutOptions.defaultMemorySpace = mlir::tt::MemorySpace::DeviceL1;
-      layoutOptions.defaultDeviceMemoryLayout =
-          mlir::tt::TensorMemoryLayout::None;
     }
     pm.addPass(mlir::tt::ttir::createTTIRLayout(layoutOptions));
     pm.addPass(mlir::tt::ttir::createTTIRAllocate());

--- a/lib/Dialect/TTNN/Utils/Utils.cpp
+++ b/lib/Dialect/TTNN/Utils/Utils.cpp
@@ -25,46 +25,6 @@ toTTNNBufferType(const mlir::tt::MemorySpace memorySpace) {
   llvm_unreachable("Unknown MemorySpace");
 }
 
-// Map TT::TensorMemoryLayout to TTNN::TensorMemoryLayout
-//
-mlir::tt::ttnn::TensorMemoryLayout toTTNNTensorMemoryLayout(
-    const ::mlir::tt::TensorMemoryLayout ttTensorMemoryLayout) {
-
-  switch (ttTensorMemoryLayout) {
-  case ::mlir::tt::TensorMemoryLayout::HeightSharded:
-    return ttnn::TensorMemoryLayout::HeightSharded;
-  case ::mlir::tt::TensorMemoryLayout::Interleaved:
-    return ttnn::TensorMemoryLayout::Interleaved;
-  case ::mlir::tt::TensorMemoryLayout::WidthSharded:
-    return ttnn::TensorMemoryLayout::WidthSharded;
-  case ::mlir::tt::TensorMemoryLayout::BlockSharded:
-    return ttnn::TensorMemoryLayout::BlockSharded;
-  case ::mlir::tt::TensorMemoryLayout::SingleBank:
-    return ttnn::TensorMemoryLayout::SingleBank;
-  default:
-    llvm_unreachable("Unknown TensorMemoryLayout");
-  }
-}
-
-mlir::tt::TensorMemoryLayout toTTTensorMemoryLayout(
-    const ::mlir::tt::ttnn::TensorMemoryLayout ttnnTensorMemoryLayout) {
-
-  switch (ttnnTensorMemoryLayout) {
-  case ttnn::TensorMemoryLayout::HeightSharded:
-    return ::mlir::tt::TensorMemoryLayout::HeightSharded;
-  case ttnn::TensorMemoryLayout::Interleaved:
-    return ::mlir::tt::TensorMemoryLayout::Interleaved;
-  case ttnn::TensorMemoryLayout::WidthSharded:
-    return ::mlir::tt::TensorMemoryLayout::WidthSharded;
-  case ttnn::TensorMemoryLayout::BlockSharded:
-    return ::mlir::tt::TensorMemoryLayout::BlockSharded;
-  case ttnn::TensorMemoryLayout::SingleBank:
-    return ::mlir::tt::TensorMemoryLayout::SingleBank;
-  }
-
-  llvm_unreachable("Unknown TensorMemoryLayout");
-}
-
 mlir::tt::MemorySpace
 toTTMemorySpace(const mlir::tt::ttnn::BufferType bufferType) {
   switch (bufferType) {

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -50,25 +50,6 @@ static OpType findOpAtTopLevel(mlir::ModuleOp module) {
 
 ::tt::target::ttnn::TensorMemoryLayout
 toFlatbuffer(FlatbufferObjectCache &,
-             ::mlir::tt::TensorMemoryLayout memLayout) {
-  switch (memLayout) {
-  case TensorMemoryLayout::Interleaved:
-    return ::tt::target::ttnn::TensorMemoryLayout::Interleaved;
-  case TensorMemoryLayout::SingleBank:
-    return ::tt::target::ttnn::TensorMemoryLayout::SingleBank;
-  case TensorMemoryLayout::HeightSharded:
-    return ::tt::target::ttnn::TensorMemoryLayout::HeightSharded;
-  case TensorMemoryLayout::WidthSharded:
-    return ::tt::target::ttnn::TensorMemoryLayout::WidthSharded;
-  case TensorMemoryLayout::BlockSharded:
-    return ::tt::target::ttnn::TensorMemoryLayout::BlockSharded;
-  default:
-    llvm_unreachable("unhandled TensorMemoryLayout");
-  }
-}
-
-::tt::target::ttnn::TensorMemoryLayout
-toFlatbuffer(FlatbufferObjectCache &,
              ttnn::TensorMemoryLayoutAttr memLayoutAttr) {
   switch (memLayoutAttr.getValue()) {
   case ttnn::TensorMemoryLayout::SingleBank:

--- a/python/TTModule.cpp
+++ b/python/TTModule.cpp
@@ -22,14 +22,14 @@ void populateTTModule(py::module &m) {
                      uint32_t memorySpaceValue, MlirAttribute grid,
                      std::vector<std::pair<std::int64_t, std::int64_t>>
                          collapseIntervals,
-                     uint32_t oobValValue, uint32_t memLayoutValue) {
+                     uint32_t oobValValue) {
                     return wrap(tt::MetalLayoutAttr::get(
                         unwrap(ctx),
                         mlir::cast<RankedTensorType>(unwrap(rankedTensorType)),
                         static_cast<tt::MemorySpace>(memorySpaceValue),
                         mlir::cast<tt::GridAttr>(unwrap(grid)),
-                        collapseIntervals, static_cast<tt::OOBVal>(oobValValue),
-                        static_cast<tt::TensorMemoryLayout>(memLayoutValue)));
+                        collapseIntervals,
+                        static_cast<tt::OOBVal>(oobValValue)));
                   })
       .def_static("with_grid",
                   [](MlirContext ctx, MlirAttribute self,
@@ -106,15 +106,9 @@ void populateTTModule(py::module &m) {
                                    la.getMemorySpace());
                              })
       .def_property_readonly("shard_shape", &tt::MetalLayoutAttr::getShardShape)
-      .def_property_readonly("memory_layout",
-                             &tt::MetalLayoutAttr::getMemLayout)
-      .def_property_readonly(
-          "linear",
-          [](tt::MetalLayoutAttr self) { return wrap(self.getLinear()); })
-      .def_property_readonly("memory_layout_as_int",
-                             [](tt::MetalLayoutAttr la) {
-                               return static_cast<uint32_t>(la.getMemLayout());
-                             });
+      .def_property_readonly("linear", [](tt::MetalLayoutAttr self) {
+        return wrap(self.getLinear());
+      });
 
   tt_attribute_class<tt::GridAttr>(m, "GridAttr")
       .def_static("get",
@@ -372,18 +366,6 @@ void populateTTModule(py::module &m) {
       .def_property_readonly("oob_val_as_int", [](tt::OOBValAttr self) {
         return static_cast<uint32_t>(self.getValue());
       });
-
-  tt_attribute_class<tt::TensorMemoryLayoutAttr>(m, "TensorMemoryLayoutAttr")
-      .def_static(
-          "get",
-          [](MlirContext ctx, uint32_t memLayout) {
-            return wrap(tt::TensorMemoryLayoutAttr::get(
-                unwrap(ctx), static_cast<tt::TensorMemoryLayout>(memLayout)));
-          })
-      .def_property_readonly("mem_layout_as_int",
-                             [](tt::TensorMemoryLayoutAttr self) {
-                               return static_cast<uint32_t>(self.getValue());
-                             });
 
   tt_attribute_class<tt::IteratorTypeAttr>(m, "IteratorTypeAttr")
       .def_static(

--- a/test/python/tensor_layout.py
+++ b/test/python/tensor_layout.py
@@ -11,16 +11,6 @@ ctx = Context()
 tt.register_dialect(ctx)
 
 
-def getTensorMemoryLayout(memorySpace):
-    if (
-        memorySpace == tt.MemorySpace.DeviceL1
-        or memorySpace == tt.MemorySpace.DeviceDRAM
-    ):
-        return tt.TensorMemoryLayout.Interleaved
-    else:
-        return tt.TensorMemoryLayout.None_
-
-
 def createTensorLayout(
     shape,
     grid,
@@ -33,9 +23,8 @@ def createTensorLayout(
     tensorTy = RankedTensorType.get(
         shape, F32Type.get(ctx), None, Location.unknown(ctx)
     )
-    memoryLayout = getTensorMemoryLayout(memorySpace)
     layout = tt.ir.MetalLayoutAttr.get(
-        ctx, tensorTy, memorySpace, grid, collapseIntervals, oobVal, memoryLayout
+        ctx, tensorTy, memorySpace, grid, collapseIntervals, oobVal
     )
     return RankedTensorType.get(shape, F32Type.get(ctx), layout, Location.unknown(ctx))
 
@@ -58,9 +47,9 @@ def parallelize(tensor, grid, collapseIntervals=[(0, -1)]):
 
 
 t0 = createTensorLayout([2, 3, 64, 128], [2, 4])
-# CHECK: tensor<2x3x64x128xf32, #tt.metal_layout<(d0, d1, d2, d3) -> (d0 * 192 + d1 * 64 + d2, d3), undef, <2x4>, memref<192x32xf32, #tt.memory_space<l1>>, interleaved>>
+# CHECK: tensor<2x3x64x128xf32, #tt.metal_layout<(d0, d1, d2, d3) -> (d0 * 192 + d1 * 64 + d2, d3), undef, <2x4>, memref<192x32xf32, #tt.memory_space<l1>>>>
 print(t0)
-# CHECK: #tt.metal_layout<(d0, d1, d2, d3) -> (d0 * 192 + d1 * 64 + d2, d3), undef, <2x4>, memref<6x1x!tt.tile<32x32, bfp_bf8>, #tt.memory_space<l1>>, interleaved>
+# CHECK: #tt.metal_layout<(d0, d1, d2, d3) -> (d0 * 192 + d1 * 64 + d2, d3), undef, <2x4>, memref<6x1x!tt.tile<32x32, bfp_bf8>, #tt.memory_space<l1>>>
 print(tilize(t0, tt.DataType.BFP_BFloat8).wrapped())
 print(parallelize(t0, [3, 2]).wrapped())
 
@@ -69,24 +58,24 @@ print(tilize(t1, tt.DataType.BFP_BFloat8).wrapped())
 print(parallelize(t1, [3, 2]).wrapped())
 
 t2 = createTensorLayout([128], [4], collapseIntervals=[(0, -1)])
-# CHECK: tensor<128xf32, #tt.metal_layout<(d0) -> (d0), undef, <4>, memref<32xf32, #tt.memory_space<l1>>, interleaved>>
+# CHECK: tensor<128xf32, #tt.metal_layout<(d0) -> (d0), undef, <4>, memref<32xf32, #tt.memory_space<l1>>>>
 print(t2)
-# CHECK: #tt.metal_layout<(d0) -> (d0), undef, <2>, memref<64xf32, #tt.memory_space<l1>>, interleaved>
+# CHECK: #tt.metal_layout<(d0) -> (d0), undef, <2>, memref<64xf32, #tt.memory_space<l1>>>
 print(parallelize(t2, [2]).wrapped())
-# CHECK: #tt.metal_layout<(d0) -> (0, d0), undef, <1x2>, memref<1x64xf32, #tt.memory_space<l1>>, interleaved>
+# CHECK: #tt.metal_layout<(d0) -> (0, d0), undef, <1x2>, memref<1x64xf32, #tt.memory_space<l1>>>
 print(parallelize(t2, [1, 2]).wrapped())
 
 t3 = createTensorLayout([128], [1, 4], collapseIntervals=[(0, -1)])
-# CHECK: tensor<128xf32, #tt.metal_layout<(d0) -> (0, d0), undef, <1x4>, memref<1x32xf32, #tt.memory_space<l1>>, interleaved>>
+# CHECK: tensor<128xf32, #tt.metal_layout<(d0) -> (0, d0), undef, <1x4>, memref<1x32xf32, #tt.memory_space<l1>>>>
 print(t3)
-# CHECK: #tt.metal_layout<(d0) -> (0, d0), undef, <1x4>, memref<1x1x!tt.tile<32x32, bfp_bf8>, #tt.memory_space<l1>>, interleaved>
+# CHECK: #tt.metal_layout<(d0) -> (0, d0), undef, <1x4>, memref<1x1x!tt.tile<32x32, bfp_bf8>, #tt.memory_space<l1>>>
 print(tilize(t3, tt.DataType.BFP_BFloat8).wrapped())
 
 t4 = createTensorLayout([128], [1, 2, 4], collapseIntervals=[(0, -1)])
-# CHECK: tensor<128xf32, #tt.metal_layout<(d0) -> (0, 0, d0), undef, <1x2x4>, memref<1x1x32xf32, #tt.memory_space<l1>>, interleaved>>
+# CHECK: tensor<128xf32, #tt.metal_layout<(d0) -> (0, 0, d0), undef, <1x2x4>, memref<1x1x32xf32, #tt.memory_space<l1>>>>
 print(t4)
 
-# CHECK: #tt.metal_layout<(d0) -> (0, 0, d0), undef, <1x2x4>, memref<1x1x1x!tt.tile<32x32, bfp_bf8>, #tt.memory_space<l1>>, interleaved>
+# CHECK: #tt.metal_layout<(d0) -> (0, 0, d0), undef, <1x2x4>, memref<1x1x1x!tt.tile<32x32, bfp_bf8>, #tt.memory_space<l1>>>
 print(tilize(t4, tt.DataType.BFP_BFloat8).wrapped())
-# CHECK: #tt.metal_layout<(d0) -> (0, d0), undef, <1x2>, memref<1x64xf32, #tt.memory_space<l1>>, interleaved>
+# CHECK: #tt.metal_layout<(d0) -> (0, d0), undef, <1x2>, memref<1x64xf32, #tt.memory_space<l1>>>
 print(parallelize(t4, [1, 2]).wrapped())

--- a/test/ttmlir/Dialect/TTIR/split_compound_layout.mlir
+++ b/test/ttmlir/Dialect/TTIR/split_compound_layout.mlir
@@ -3,21 +3,21 @@
 #dram = #tt.memory_space<dram>
 #l1_ = #tt.memory_space<l1>
 
-// CHECK-DAG: #[[row_major1x1:.*]] = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<64x128xf32, #l1_>, interleaved>
-// CHECK-DAG: #[[row_major1x1_T:.*]] = #tt.metal_layout<(d0, d1) -> (d1, d0), undef, <1x1>, memref<64x128xf32, #l1_>, interleaved>
-// CHECK-DAG: #[[row_major2x2:.*]] = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <2x2>, memref<32x64xf32, #l1_>, interleaved>
-// CHECK-DAG: #[[tile1x1_f32:.*]] = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<2x4x!tt.tile<32x32, f32>, #l1_>, interleaved>
-// CHECK-DAG: #[[tile1x1_bf16:.*]] = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<2x4x!tt.tile<32x32, bf16>, #l1_>, interleaved>
-// CHECK-DAG: #[[tile1x1_f32_dram:.*]] = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<2x4x!tt.tile<32x32, f32>, #dram>, interleaved>
-// CHECK-DAG: #[[tile2x2_f32:.*]] = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <2x2>, memref<1x2x!tt.tile<32x32, f32>, #l1_>, interleaved>
+// CHECK-DAG: #[[row_major1x1:.*]] = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<64x128xf32, #l1_>>
+// CHECK-DAG: #[[row_major1x1_T:.*]] = #tt.metal_layout<(d0, d1) -> (d1, d0), undef, <1x1>, memref<64x128xf32, #l1_>>
+// CHECK-DAG: #[[row_major2x2:.*]] = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <2x2>, memref<32x64xf32, #l1_>>
+// CHECK-DAG: #[[tile1x1_f32:.*]] = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<2x4x!tt.tile<32x32, f32>, #l1_>>
+// CHECK-DAG: #[[tile1x1_bf16:.*]] = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<2x4x!tt.tile<32x32, bf16>, #l1_>>
+// CHECK-DAG: #[[tile1x1_f32_dram:.*]] = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<2x4x!tt.tile<32x32, f32>, #dram>>
+// CHECK-DAG: #[[tile2x2_f32:.*]] = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <2x2>, memref<1x2x!tt.tile<32x32, f32>, #l1_>>
 
-#row_major1x1 = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<64x128xf32, #l1_>, interleaved>
-#row_major1x1_T = #tt.metal_layout<(d0, d1) -> (d1, d0), undef, <1x1>, memref<64x128xf32, #l1_>, interleaved>
-#row_major2x2 = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <2x2>, memref<32x64xf32, #l1_>, interleaved>
-#tile1x1_f32 = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<2x4x!tt.tile<32x32, f32>, #l1_>, interleaved>
-#tile1x1_bf16 = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<2x4x!tt.tile<32x32, bf16>, #l1_>, interleaved>
-#tile1x1_f32_dram = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<2x4x!tt.tile<32x32, f32>, #dram>, interleaved>
-#tile2x2_f32 = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <2x2>, memref<1x2x!tt.tile<32x32, f32>, #l1_>, interleaved>
+#row_major1x1 = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<64x128xf32, #l1_>>
+#row_major1x1_T = #tt.metal_layout<(d0, d1) -> (d1, d0), undef, <1x1>, memref<64x128xf32, #l1_>>
+#row_major2x2 = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <2x2>, memref<32x64xf32, #l1_>>
+#tile1x1_f32 = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<2x4x!tt.tile<32x32, f32>, #l1_>>
+#tile1x1_bf16 = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<2x4x!tt.tile<32x32, bf16>, #l1_>>
+#tile1x1_f32_dram = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<2x4x!tt.tile<32x32, f32>, #dram>>
+#tile2x2_f32 = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <2x2>, memref<1x2x!tt.tile<32x32, f32>, #l1_>>
 
 func.func @noncompound_linear(%in: tensor<64x128xf32, #row_major1x1>) -> tensor<64x128xf32, #row_major1x1_T> {
     %out = tensor.empty() : tensor<64x128xf32, #row_major1x1_T>

--- a/test/ttmlir/Dialect/TTIR/test_allocate.mlir
+++ b/test/ttmlir/Dialect/TTIR/test_allocate.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-load-system-desc --ttir-implicit-device --ttir-allocate %s | FileCheck %s
 #l1_ = #tt.memory_space<l1>
-#layout = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<64x128xf32, #l1_>, interleaved>
+#layout = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <1x1>, memref<64x128xf32, #l1_>>
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xf32, #layout>, %arg1: tensor<64x128xf32, #layout>) -> tensor<64x128xf32, #layout> {
     // CHECK: %[[C:.*]] = "ttir.alloc"[[C:.*]]

--- a/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
@@ -364,12 +364,6 @@ def parse_tt_layout(attr):
     )
     result.append(
         graph_builder.KeyValue(
-            key="memory_layout",
-            value=str(tt.TensorMemoryLayout(layout.memory_layout_as_int)),
-        )
-    )
-    result.append(
-        graph_builder.KeyValue(
             key="grid_shape", value="x".join(map(str, layout.grid_attr.shape))
         )
     )


### PR DESCRIPTION
### Ticket
closes #596 

### Problem description
TT_TensorMemoryLayout is unneeded since metal backend doesn't use it. 

### What's changed
Since I just merged #2217 which removes TensorMemoryLayout from metal flatbuffer as well as TensorMemoryLayout::None from ttnn flatbuffer, I thought I would do the same for the compiler as well. 

This PR removes TT_TensorMemoryLayout. With this, TensorMemoryLayout should be unified end to end.

