### PR TITLE
[Everywhere] Replace `dyn_cast_or_null` with `dyn_cast_if_present`

### DIFF
--- a/include/ttmlir/Target/Utils/FuncOpToProgram.h
+++ b/include/ttmlir/Target/Utils/FuncOpToProgram.h
@@ -77,7 +77,7 @@ Program<OpT> funcOpToProgram(FlatbufferObjectCache &cache, func::FuncOp entry,
 
   mlir::AsmState printState(entry, printFlags);
   entry.getBody().walk([&](mlir::Operation *op) {
-    if (auto returnOp = dyn_cast_or_null<func::ReturnOp>(op); returnOp) {
+    if (auto returnOp = dyn_cast_if_present<func::ReturnOp>(op); returnOp) {
       for (auto output : returnOp.getOperands()) {
         program.outputs.push_back(cache.at<::tt::target::ttnn::TensorRef>(
             getOperandThroughDPSOps(output)));

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -2192,7 +2192,7 @@ private:
             valueDef)) {
       valueDef = valueDef->getOperand(0).getDefiningOp();
     }
-    return mlir::dyn_cast_or_null<ttir::ConstantOp>(valueDef);
+    return mlir::dyn_cast_if_present<ttir::ConstantOp>(valueDef);
   }
 
   LogicalResult checkBasicLegality(mlir::stablehlo::PadOp &srcOp,

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -788,7 +788,7 @@ public:
 
     ttnn::MemoryConfigAttr memcfg = nullptr;
     if (ttnn::TTNNLayoutAttr layoutAttr =
-            mlir::dyn_cast_or_null<ttnn::TTNNLayoutAttr>(
+            mlir::dyn_cast_if_present<ttnn::TTNNLayoutAttr>(
                 op.getResult().getType().getEncoding());
         layoutAttr.getBufferType() != ttnn::BufferType::SystemMemory) {
       memcfg = ttnn::MemoryConfigAttr::get(

--- a/lib/Dialect/TT/Transforms/TTModuleWrap.cpp
+++ b/lib/Dialect/TT/Transforms/TTModuleWrap.cpp
@@ -73,7 +73,8 @@ public:
       (*cpuOpsList.begin())->erase();
     }
 
-    auto innerModule = dyn_cast_or_null<ModuleOp>(deviceOp.getBody()->front());
+    auto innerModule =
+        dyn_cast_if_present<ModuleOp>(deviceOp.getBody()->front());
     assert(innerModule &&
            "tt.device_module must always contain single builtin.module!");
 

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -1787,7 +1787,7 @@ void mlir::tt::ttir::MatmulOp::getCanonicalizationPatterns(
 
 // AllocOp verification
 ::mlir::LogicalResult mlir::tt::ttir::AllocOp::verify() {
-  auto layout = mlir::dyn_cast_or_null<mlir::tt::MetalLayoutAttr>(
+  auto layout = mlir::dyn_cast_if_present<mlir::tt::MetalLayoutAttr>(
       getResult().getType().getEncoding());
   if (not layout) {
     return emitOpError("Result type missing layout attribute");

--- a/lib/Dialect/TTIR/Transforms/HoistCPUOps.cpp
+++ b/lib/Dialect/TTIR/Transforms/HoistCPUOps.cpp
@@ -125,7 +125,7 @@ static void hoistOperationToFunction(mlir::Operation *opToHoist,
   llvm::SmallString<16> localFunctionName = functionName;
   localFunctionName.append("_decl");
 
-  auto localFunc = llvm::dyn_cast_or_null<func::FuncOp>(
+  auto localFunc = llvm::dyn_cast_if_present<func::FuncOp>(
       sourceModule.lookupSymbol(localFunctionName.str()));
 
   // Create a new hoisted function only if an equivalent one does not exist.
@@ -274,7 +274,7 @@ public:
     assert(deviceModule &&
            "must run tt::WrapDeviceModulePass on IR before hoisting!");
 
-    ModuleOp deviceInnerModule = dyn_cast_or_null<mlir::ModuleOp>(
+    ModuleOp deviceInnerModule = dyn_cast_if_present<mlir::ModuleOp>(
         deviceModule.getBodyRegion().front().front());
     assert(deviceInnerModule &&
            "tt::DeviceModuleOp must have single ModuleOp child!");
@@ -297,7 +297,7 @@ public:
     for (auto &op : rootModule.getBody()->getOperations()) {
       if (auto module = llvm::dyn_cast<tt::CPUModuleOp>(op)) {
         cpuModule = module;
-        cpuInnerModule = dyn_cast_or_null<mlir::ModuleOp>(
+        cpuInnerModule = dyn_cast_if_present<mlir::ModuleOp>(
             cpuModule.getBodyRegion().front().front());
         assert(cpuInnerModule && "CPUModuleOp must contain 1 ModuleOp!");
         break;

--- a/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
@@ -23,12 +23,12 @@ static bool insideEnqueueProgramOpRegion(mlir::Operation *op) {
     return false;
   }
 
-  if (dyn_cast_or_null<ttmetal::EnqueueProgramOp>(parentOp)) {
+  if (dyn_cast_if_present<ttmetal::EnqueueProgramOp>(parentOp)) {
     return true;
   }
 
-  if (dyn_cast_or_null<func::FuncOp>(parentOp) &&
-      dyn_cast_or_null<mlir::ModuleOp>(parentOp->getParentOp())) {
+  if (dyn_cast_if_present<func::FuncOp>(parentOp) &&
+      dyn_cast_if_present<mlir::ModuleOp>(parentOp->getParentOp())) {
     return true;
   }
   return insideEnqueueProgramOpRegion(parentOp);

--- a/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
+++ b/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
@@ -16,8 +16,8 @@ namespace mlir::tt::ttmetal {
 
 ::mlir::LogicalResult EnqueueWriteBufferOp::verify() {
   ::mlir::RankedTensorType outputTy = getOutput().getType();
-  auto outputLayout =
-      mlir::dyn_cast_or_null<mlir::tt::MetalLayoutAttr>(outputTy.getEncoding());
+  auto outputLayout = mlir::dyn_cast_if_present<mlir::tt::MetalLayoutAttr>(
+      outputTy.getEncoding());
   if (not outputLayout) {
     return emitOpError("Input tensor missing layout attribute");
   }
@@ -29,8 +29,8 @@ namespace mlir::tt::ttmetal {
 
 ::mlir::LogicalResult EnqueueReadBufferOp::verify() {
   ::mlir::RankedTensorType outputTy = getOutput().getType();
-  auto outputLayout =
-      mlir::dyn_cast_or_null<mlir::tt::MetalLayoutAttr>(outputTy.getEncoding());
+  auto outputLayout = mlir::dyn_cast_if_present<mlir::tt::MetalLayoutAttr>(
+      outputTy.getEncoding());
   if (not outputLayout) {
     return emitOpError("Input tensor missing layout attribute");
   }
@@ -41,7 +41,7 @@ namespace mlir::tt::ttmetal {
 }
 
 ::mlir::LogicalResult CreateBufferOp::verify() {
-  auto layout = mlir::dyn_cast_or_null<mlir::tt::MetalLayoutAttr>(
+  auto layout = mlir::dyn_cast_if_present<mlir::tt::MetalLayoutAttr>(
       getResult().getType().getEncoding());
   if (not layout) {
     return emitOpError("Result type missing layout attribute");
@@ -76,7 +76,7 @@ namespace mlir::tt::ttmetal {
 ::mlir::LogicalResult EnqueueProgramOp::verify() {
   // Assert inputs/outputs device memspace
   for (auto operand : getOperands()) {
-    auto layout = mlir::dyn_cast_or_null<mlir::tt::MetalLayoutAttr>(
+    auto layout = mlir::dyn_cast_if_present<mlir::tt::MetalLayoutAttr>(
         mlir::cast<mlir::RankedTensorType>(operand.getType()).getEncoding());
     if (not layout) {
       return emitOpError("Input tensor missing layout attribute");

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -834,9 +834,9 @@ static bool isValidDeviceLayout(TensorMemoryLayoutAttr memLayoutAttr) {
   ::mlir::RankedTensorType inputTy = getInput().getType();
   ::mlir::RankedTensorType outputTy = getResult().getType();
   auto inputLayout =
-      mlir::dyn_cast_or_null<TTNNLayoutAttr>(inputTy.getEncoding());
+      mlir::dyn_cast_if_present<TTNNLayoutAttr>(inputTy.getEncoding());
   auto outputLayout =
-      mlir::dyn_cast_or_null<TTNNLayoutAttr>(outputTy.getEncoding());
+      mlir::dyn_cast_if_present<TTNNLayoutAttr>(outputTy.getEncoding());
   if (not inputLayout) {
     return emitOpError("Input tensor type missing layout attribute");
   }
@@ -1226,7 +1226,7 @@ mlir::tt::ttnn::ToLayoutOp::canonicalize(ToLayoutOp toLayoutOp,
 
 // AllocOp verification
 ::mlir::LogicalResult AllocOp::verify() {
-  auto layout = mlir::dyn_cast_or_null<TTNNLayoutAttr>(
+  auto layout = mlir::dyn_cast_if_present<TTNNLayoutAttr>(
       getResult().getType().getEncoding());
   if (not layout) {
     return emitOpError("Result type missing layout attribute");

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -329,7 +329,7 @@ static std::shared_ptr<void> translateModuleToFlatbuffer(
 
     entry->walk([&](mlir::Operation *op) {
       if (auto enqueueProgramOp =
-              dyn_cast_or_null<tt::ttmetal::EnqueueProgramOp>(op);
+              dyn_cast_if_present<tt::ttmetal::EnqueueProgramOp>(op);
           enqueueProgramOp) {
         std::vector<::flatbuffers::Offset<::tt::target::metal::TensorRef>>
             operands;
@@ -401,7 +401,7 @@ static std::shared_ptr<void> translateModuleToFlatbuffer(
                 fbb, &operands, program),
             op);
       } else if (auto createBufferOp =
-                     dyn_cast_or_null<tt::ttmetal::CreateBufferOp>(op);
+                     dyn_cast_if_present<tt::ttmetal::CreateBufferOp>(op);
                  createBufferOp) {
         cqBuilder.appendCommand(
             ::tt::target::metal::CreateCreateBufferCommand(
@@ -411,7 +411,7 @@ static std::shared_ptr<void> translateModuleToFlatbuffer(
                                        createBufferOp.getSize())),
             op);
       } else if (auto deallocateBufferOp =
-                     dyn_cast_or_null<tt::ttmetal::DeallocateBufferOp>(op);
+                     dyn_cast_if_present<tt::ttmetal::DeallocateBufferOp>(op);
                  deallocateBufferOp) {
         cqBuilder.appendCommand(
             ::tt::target::metal::CreateDeallocateBufferCommand(
@@ -420,7 +420,7 @@ static std::shared_ptr<void> translateModuleToFlatbuffer(
                     getOperandThroughDPSOps(deallocateBufferOp.getInput()))),
             op);
       } else if (auto enqueueReadBufferOp =
-                     dyn_cast_or_null<tt::ttmetal::EnqueueReadBufferOp>(op);
+                     dyn_cast_if_present<tt::ttmetal::EnqueueReadBufferOp>(op);
                  enqueueReadBufferOp) {
         cqBuilder.appendCommand(
             ::tt::target::metal::CreateEnqueueReadBufferCommand(
@@ -431,7 +431,7 @@ static std::shared_ptr<void> translateModuleToFlatbuffer(
                     getOperandThroughDPSOps(enqueueReadBufferOp.getOutput()))),
             op);
       } else if (auto enqueueWriteBufferOp =
-                     dyn_cast_or_null<tt::ttmetal::EnqueueWriteBufferOp>(op);
+                     dyn_cast_if_present<tt::ttmetal::EnqueueWriteBufferOp>(op);
                  enqueueWriteBufferOp) {
         auto [hostBufferType, hostBuffer] =
             hostBufferToFlatbuffer(cache, enqueueWriteBufferOp.getValue());
@@ -441,7 +441,7 @@ static std::shared_ptr<void> translateModuleToFlatbuffer(
                 cache.at<::tt::target::metal::TensorRef>(
                     getOperandThroughDPSOps(enqueueWriteBufferOp.getOutput()))),
             op);
-      } else if (auto returnOp = dyn_cast_or_null<func::ReturnOp>(op);
+      } else if (auto returnOp = dyn_cast_if_present<func::ReturnOp>(op);
                  returnOp) {
         for (auto output : returnOp.getOperands()) {
           cqBuilder.outputs.push_back(cache.at<::tt::target::metal::TensorRef>(

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -1719,7 +1719,7 @@ std::shared_ptr<void> ttnnToFlatbuffer(
   // DeviceModule for most conversions.
   ModuleOp module = rootModule;
   if (auto deviceModule = findOpAtTopLevel<tt::DeviceModuleOp>(module)) {
-    module = dyn_cast_or_null<mlir::ModuleOp>(
+    module = dyn_cast_if_present<mlir::ModuleOp>(
         deviceModule.getBodyRegion().front().front());
     assert(module && "Found tt::DeviceModuleOp but it didn't contain a single "
                      "mlir::ModuleOp!");
@@ -1749,7 +1749,7 @@ std::shared_ptr<void> ttnnToFlatbuffer(
   std::vector<::flatbuffers::Offset<::tt::target::DynamicLib>> dylibs;
   if (auto cpuModule = findOpAtTopLevel<tt::CPUModuleOp>(rootModule);
       cpuModule != nullptr) {
-    mlir::ModuleOp cpuNestedModule = dyn_cast_or_null<mlir::ModuleOp>(
+    mlir::ModuleOp cpuNestedModule = dyn_cast_if_present<mlir::ModuleOp>(
         cpuModule.getBodyRegion().front().front());
     llvm::SmallVector<char, 2048> binaryBuffer;
     llvm::raw_svector_ostream dylibStream(binaryBuffer);


### PR DESCRIPTION
`dyn_cast_or_null` is getting replaced with `dyn_cast_if_present` in future llvm releases. Currently `dyn_cast_or_null` implementation just forwards to `dyn_cast_if_present`.
