### PR TITLE
Remove debug print when running tests

### DIFF
--- a/test/unittests/lit.cfg.py
+++ b/test/unittests/lit.cfg.py
@@ -42,19 +42,16 @@ if "HOME" in os.environ:
 
 
 if "TT_MLIR_HOME" in os.environ:
-    print(f"{os.environ['TT_MLIR_HOME']}")
     config.environment["TT_MLIR_HOME"] = os.environ["TT_MLIR_HOME"]
 else:
     raise OSError("TT_MLIR_HOME environment variable is not set")
 
 if "TT_METAL_HOME" in os.environ:
-    print(f"{os.environ['TT_METAL_HOME']}")
     config.environment["TT_METAL_HOME"] = os.environ["TT_METAL_HOME"]
 else:
     raise OSError("TT_METAL_HOME environment variable is not set")
 
 if "ARCH_NAME" in os.environ:
-    print(f"ARCH_NAME={os.environ['ARCH_NAME']}")
     config.environment["ARCH_NAME"] = os.environ["ARCH_NAME"]
 else:
     raise OSError("ARCH_NAME environment variable is not set")


### PR DESCRIPTION
I assume this was added during development for debug purposes, it would print something like
```
[0/1] Running the ttmlir regression tests
/localdev/azecevic/tt-mlir
/opt/ttmlir-toolchain/venv/lib/python3.10/site-packages/ttrt/runtime
ARCH_NAME=wormhole_b0
```
every time you run `check-ttmlir`.