### PR TITLE
Determine indirectly defined constant for clamp op

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -1571,6 +1571,28 @@ def TTIR_ClampOp : TTIR_NamedOp<"clamp"> {
     let hasVerifier = 1;
 }
 
+def TTIR_ClampTensorOp : TTIR_NamedOp<"clamp_tensor"> {
+  let summary = "Clamp op.";
+  let description = [{
+    Clamp tensor values to a specified range using min/max as tensor.
+
+    Example:
+      min: [[2, 2, 2, 3, 3, 3, 0, 0]]
+      input: [[0, 1, 2, 3, 4, 5, 6, 7]]
+      max: [[5, 5, 5, 9, 9, 9, 6, 6]]
+
+      "ttir.clamp_tensor"(%input, %min, %max)
+      -> %out = [[2, 2, 2, 3, 4, 5, 6, 6]]
+  }];
+
+  let arguments = (ins AnyRankedTensor:$input,
+                       AnyRankedTensor:$min,
+                       AnyRankedTensor:$max,
+                       AnyRankedTensor:$output);
+
+  let results = (outs AnyRankedTensor:$result);
+}
+
 def TTIR_ArangeOp : TTIR_Op<"arange"> {
   let summary = "Arange operation.";
   let description = [{

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -1547,7 +1547,7 @@ def TTIR_UnsqueezeOp : TTIR_NamedOp<"unsqueeze"> {
     let hasVerifier = 1;
 }
 
-def TTIR_ClampOp : TTIR_NamedOp<"clamp"> {
+def TTIR_ClampScalarOp : TTIR_NamedOp<"clamp_scalar"> {
     let summary = "Clamp op.";
     let description = [{
       Clamp tensor values to a specified range.
@@ -1557,7 +1557,7 @@ def TTIR_ClampOp : TTIR_NamedOp<"clamp"> {
         input: [[0, 1, 2, 3, 4, 5, 6, 7]]
         max: 5.000000+00
 
-        "ttir.clamp"(%arg0) <{max = 2.000000e+00 : f32, min = 5.000000e+00 : f32}>
+        "ttir.clamp_scalar"(%arg0) <{max = 2.000000e+00 : f32, min = 5.000000e+00 : f32}>
         -> %out = [[2, 2, 2, 3, 4, 5, 5, 5]]
     }];
 
@@ -1577,12 +1577,12 @@ def TTIR_ClampTensorOp : TTIR_NamedOp<"clamp_tensor"> {
     Clamp tensor values to a specified range using min/max as tensor.
 
     Example:
-      min: [[2, 2, 2, 3, 3, 3, 0, 0]]
+      min:   [[2, 2, 2, 3, 3, 3, 0, 0]]
       input: [[0, 1, 2, 3, 4, 5, 6, 7]]
-      max: [[5, 5, 5, 9, 9, 9, 6, 6]]
+      max:   [[5, 5, 5, 9, 9, 9, 6, 6]]
 
       "ttir.clamp_tensor"(%input, %min, %max)
-      -> %out = [[2, 2, 2, 3, 4, 5, 6, 6]]
+      %out:  [[2, 2, 2, 3, 4, 5, 6, 6]]
   }];
 
   let arguments = (ins AnyRankedTensor:$input,

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1339,6 +1339,27 @@ def TTNN_ClampOp : TTNN_Op<"clamp"> {
     let hasVerifier = 1;
 }
 
+def TTNN_ClampTensorOp : TTNN_Op<"clamp_tensor"> {
+  let summary = "Clamp op.";
+  let description = [{
+    Clamp tensor values to a specified range using min/max as tensor.
+
+    Example:
+      min: [[2, 2, 2, 3, 3, 3, 0, 0]]
+      input: [[0, 1, 2, 3, 4, 5, 6, 7]]
+      max: [[5, 5, 5, 9, 9, 9, 6, 6]]
+
+      "ttnn.clamp_tensor"(%input, %min, %max)
+      -> %out = [[2, 2, 2, 3, 4, 5, 6, 6]]
+  }];
+
+  let arguments = (ins Variadic<AnyRankedTensor>:$inputs,
+                       AnyRankedTensor:$min,
+                       AnyRankedTensor:$max);
+
+  let results = (outs Variadic<AnyRankedTensor>:$result);
+}
+
 def TTNN_EmptyOp : TTNN_Op<"empty"> {
     let summary = "Empty op.";
     let description = [{

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1316,7 +1316,7 @@ def TTNN_MaxPool2dOp : TTNN_Op<"max_pool2d",
     let hasVerifier = 1;
 }
 
-def TTNN_ClampOp : TTNN_Op<"clamp"> {
+def TTNN_ClampScalarOp : TTNN_Op<"clamp_scalar"> {
     let summary = "Clamp op.";
     let description = [{
       Clamp tensor values to a specified range.
@@ -1326,7 +1326,7 @@ def TTNN_ClampOp : TTNN_Op<"clamp"> {
         input: [[0, 1, 2, 3, 4, 5, 6, 7]]
         max: 5.000000+00
 
-        "ttnn.clamp"(%arg0) <{max = 2.000000e+00 : f32, min = 5.000000e+00 : f32}>
+        "ttnn.clamp_scalar"(%arg0) <{max = 2.000000e+00 : f32, min = 5.000000e+00 : f32}>
         -> %out = [[2, 2, 2, 3, 4, 5, 5, 5]]
     }];
 
@@ -1345,12 +1345,12 @@ def TTNN_ClampTensorOp : TTNN_Op<"clamp_tensor"> {
     Clamp tensor values to a specified range using min/max as tensor.
 
     Example:
-      min: [[2, 2, 2, 3, 3, 3, 0, 0]]
+      min:   [[2, 2, 2, 3, 3, 3, 0, 0]]
       input: [[0, 1, 2, 3, 4, 5, 6, 7]]
-      max: [[5, 5, 5, 9, 9, 9, 6, 6]]
+      max:   [[5, 5, 5, 9, 9, 9, 6, 6]]
 
       "ttnn.clamp_tensor"(%input, %min, %max)
-      -> %out = [[2, 2, 2, 3, 4, 5, 6, 6]]
+      %out:  [[2, 2, 2, 3, 4, 5, 6, 6]]
   }];
 
   let arguments = (ins Variadic<AnyRankedTensor>:$inputs,

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -160,6 +160,7 @@ enum EltwiseOpType: uint32 {
   Where,
   Gelu,
   Clamp,
+  ClampTensor,
   LeakyRelu,
   Scatter,
   Tan,
@@ -173,12 +174,18 @@ table ClampOpParams {
   max: float;
 }
 
+table ClampTensorOpParams {
+  min: tt.target.ttnn.TensorRef;
+  max: tt.target.ttnn.TensorRef;
+}
+
 table EltwiseOpWithFloatParams {
   parameter: float;
 }
 
 union EltwiseOpParams {
   ClampOpParams,
+  ClampTensorOpParams,
   EltwiseOpWithFloatParams,
 }
 

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -159,7 +159,7 @@ enum EltwiseOpType: uint32 {
   Floor,
   Where,
   Gelu,
-  Clamp,
+  ClampScalar,
   ClampTensor,
   LeakyRelu,
   Scatter,
@@ -169,7 +169,7 @@ enum EltwiseOpType: uint32 {
   Atan
 }
 
-table ClampOpParams {
+table ClampScalarOpParams {
   min: float;
   max: float;
 }
@@ -184,7 +184,7 @@ table EltwiseOpWithFloatParams {
 }
 
 union EltwiseOpParams {
-  ClampOpParams,
+  ClampScalarOpParams,
   ClampTensorOpParams,
   EltwiseOpWithFloatParams,
 }

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -542,14 +542,16 @@ public:
 } // namespace
 
 namespace {
-class ClampOpConversionPattern : public OpConversionPattern<ttir::ClampOp> {
+template <typename TTIROpTy, typename TTNNOpTy,
+          typename OpAdaptor = typename TTIROpTy::Adaptor>
+class ClampOpConversionPattern : public OpConversionPattern<TTIROpTy> {
 public:
-  using OpConversionPattern<ttir::ClampOp>::OpConversionPattern;
+  using OpConversionPattern<TTIROpTy>::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(ttir::ClampOp op, OpAdaptor adaptor,
+  matchAndRewrite(TTIROpTy op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<ttnn::ClampOp>(
+    rewriter.replaceOpWithNewOp<TTNNOpTy>(
         op, this->getTypeConverter()->convertType(op.getType()),
         adaptor.getInput(), adaptor.getMin(), adaptor.getMax());
     return success();
@@ -1623,7 +1625,8 @@ void populateTTIRToTTNNPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
            SoftmaxOpConversionPattern,
            TransposeOpConversionPattern,
            TypecastOpConversionPattern,
-           ClampOpConversionPattern,
+           ClampOpConversionPattern<ttir::ClampOp, ttnn::ClampOp>,
+           ClampOpConversionPattern<ttir::ClampTensorOp, ttnn::ClampTensorOp>,
            ConcatOpConversionPattern,
            ReshapeOpConversionPattern,
            SliceOpConversionPattern,

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -542,11 +542,11 @@ public:
 } // namespace
 
 namespace {
-template <typename TTIROpTy, typename TTNNOpTy,
-          typename OpAdaptor = typename TTIROpTy::Adaptor>
+template <typename TTIROpTy, typename TTNNOpTy>
 class ClampOpConversionPattern : public OpConversionPattern<TTIROpTy> {
 public:
   using OpConversionPattern<TTIROpTy>::OpConversionPattern;
+  using OpAdaptor = typename TTIROpTy::Adaptor;
 
   LogicalResult
   matchAndRewrite(TTIROpTy op, OpAdaptor adaptor,
@@ -1625,7 +1625,7 @@ void populateTTIRToTTNNPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
            SoftmaxOpConversionPattern,
            TransposeOpConversionPattern,
            TypecastOpConversionPattern,
-           ClampOpConversionPattern<ttir::ClampOp, ttnn::ClampOp>,
+           ClampOpConversionPattern<ttir::ClampScalarOp, ttnn::ClampScalarOp>,
            ClampOpConversionPattern<ttir::ClampTensorOp, ttnn::ClampTensorOp>,
            ConcatOpConversionPattern,
            ReshapeOpConversionPattern,

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -7,6 +7,7 @@
 #include "ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h"
 #include "ttmlir/Conversion/TTNNToEmitC/Utils.h"
 #include "ttmlir/Dialect/TT/IR/TTOps.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNN.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
@@ -259,15 +260,16 @@ public:
 // modelled in the dialect (memcfg).
 //
 namespace {
+template <typename SourceOp>
 class ClampOpConversionPattern
-    : public TTNNToEmitCBaseOpConversionPattern<tt::ttnn::ClampOp> {
+    : public TTNNToEmitCBaseOpConversionPattern<SourceOp> {
 public:
   using TTNNToEmitCBaseOpConversionPattern<
-      tt::ttnn::ClampOp>::TTNNToEmitCBaseOpConversionPattern;
-  using Adaptor = typename tt::ttnn::ClampOp::Adaptor;
+      SourceOp>::TTNNToEmitCBaseOpConversionPattern;
+  using Adaptor = typename SourceOp::Adaptor;
 
   LogicalResult
-  matchAndRewrite(tt::ttnn::ClampOp srcOp, Adaptor adaptor,
+  matchAndRewrite(SourceOp srcOp, Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
     ttnn_to_emitc::EmitCTTNNEmitter<tt::ttnn::ClampOp> emitter(srcOp, adaptor,
@@ -1710,7 +1712,8 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
   //
   patterns.add<EltwiseUnaryOpConversionPattern<tt::ttnn::AbsOp>,
                EltwiseUnaryCompositeOpConversionPattern<tt::ttnn::CbrtOp>,
-               ClampOpConversionPattern,
+               ClampOpConversionPattern<tt::ttir::ClampOp>,
+               ClampOpConversionPattern<tt::ttir::ClampTensorOp>,
                EltwiseUnaryOpConversionPattern<tt::ttnn::FloorOp>,
                EltwiseUnaryOpConversionPattern<tt::ttnn::IsFiniteOp>,
                EltwiseUnaryOpConversionPattern<tt::ttnn::LogicalNotOp>,

--- a/lib/Conversion/TosaToTTIR/TosaToTTIRPatterns.cpp
+++ b/lib/Conversion/TosaToTTIR/TosaToTTIRPatterns.cpp
@@ -92,7 +92,7 @@ public:
     auto outputType = mlir::cast<RankedTensorType>(
         this->getTypeConverter()->convertType(srcOp.getResult().getType()));
 
-    ttmlir::utils::replaceOpWithNewDPSOp<ttir::ClampOp>(
+    ttmlir::utils::replaceOpWithNewDPSOp<ttir::ClampScalarOp>(
         rewriter, srcOp, outputType, adaptor.getInput(), adaptor.getMinFp(),
         adaptor.getMaxFp());
 

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -84,7 +84,7 @@ void mlir::tt::ttir::BitwiseXorOp::getCanonicalizationPatterns(
 // ClampOp
 //===----------------------------------------------------------------------===//
 
-::mlir::LogicalResult mlir::tt::ttir::ClampOp::verify() {
+::mlir::LogicalResult mlir::tt::ttir::ClampScalarOp::verify() {
   const RankedTensorType inputTensorType =
       mlir::cast<RankedTensorType>(getInput().getType());
 

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -40,7 +40,7 @@ namespace mlir::tt::ttnn {
 // ClampOp
 //===----------------------------------------------------------------------===//
 
-::mlir::LogicalResult mlir::tt::ttnn::ClampOp::verify() {
+::mlir::LogicalResult mlir::tt::ttnn::ClampScalarOp::verify() {
   ::mlir::Operation::operand_range inputs = getInputs();
   ::mlir::Operation::result_range outputs = getResults();
 

--- a/python/test_infra/ttir_builder.py
+++ b/python/test_infra/ttir_builder.py
@@ -1200,7 +1200,7 @@ class TTIRBuilder:
         kwargs = {"min": min_arg, "max": max_arg}
         return self.op_proxy(
             torch.clamp,
-            ttir.ClampOp,
+            ttir.ClampScalarOp,
             [in0],
             ttir_kwargs=kwargs,
             golden_kwargs=kwargs,

--- a/runtime/lib/ttnn/operations/eltwise/unary/unary_composite.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/unary/unary_composite.cpp
@@ -34,17 +34,15 @@ static void runEltwiseUnaryCompositeOp(
   tensorPool.insertAndValidate(op->out(), out);
 }
 
-static void runEltwiseUnaryCompositeClampOp(
-    const ::tt::target::ttnn::EltwiseOp *op, ProgramTensorPool &tensorPool,
-    const std::function<
-        ::ttnn::Tensor(const ::ttnn::Tensor &, float, float,
-                       const std::optional<::ttnn::MemoryConfig> &)> &ttnnOp) {
+static void
+runEltwiseUnaryCompositeClampScalarOp(const ::tt::target::ttnn::EltwiseOp *op,
+                                      ProgramTensorPool &tensorPool) {
   ::ttnn::Tensor *in = nullptr;
 
   getEltwiseUnaryOpInputTensor(op, tensorPool, &in);
 
-  float min = op->params_as_ClampOpParams()->min();
-  float max = op->params_as_ClampOpParams()->max();
+  float min = op->params_as_ClampScalarOpParams()->min();
+  float max = op->params_as_ClampScalarOpParams()->max();
 
   std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
       ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
@@ -53,7 +51,7 @@ static void runEltwiseUnaryCompositeClampOp(
                  outputMemoryConfig.has_value(),
              "Memory config must exist for device tensors");
 
-  ::ttnn::Tensor out = ttnnOp(*in, min, max, outputMemoryConfig);
+  ::ttnn::Tensor out = ::ttnn::clamp(*in, min, max, outputMemoryConfig);
 
   tensorPool.insertAndValidate(op->out(), out);
 }
@@ -89,8 +87,8 @@ void run(const ::tt::target::ttnn::EltwiseOp *op, ProgramContext &context) {
     runEltwiseUnaryCompositeOp(op, tensorPool, ::ttnn::cbrt);
     break;
   }
-  case ::tt::target::ttnn::EltwiseOpType::Clamp: {
-    runEltwiseUnaryCompositeClampOp(op, tensorPool, ::ttnn::clamp);
+  case ::tt::target::ttnn::EltwiseOpType::ClampScalar: {
+    runEltwiseUnaryCompositeClampScalarOp(op, tensorPool);
     break;
   }
   case ::tt::target::ttnn::EltwiseOpType::ClampTensor: {

--- a/runtime/lib/ttnn/operations/eltwise/unary/unary_composite.h
+++ b/runtime/lib/ttnn/operations/eltwise/unary/unary_composite.h
@@ -13,7 +13,7 @@ namespace tt::runtime::ttnn::operations::unary::composite {
 inline bool isUnaryCompositeOp(const ::tt::target::ttnn::EltwiseOp *op) {
   switch (op->type()) {
   case ::tt::target::ttnn::EltwiseOpType::Cbrt:
-  case ::tt::target::ttnn::EltwiseOpType::Clamp:
+  case ::tt::target::ttnn::EltwiseOpType::ClampScalar:
   case ::tt::target::ttnn::EltwiseOpType::ClampTensor:
   case ::tt::target::ttnn::EltwiseOpType::Log1p:
     return true;

--- a/runtime/lib/ttnn/operations/eltwise/unary/unary_composite.h
+++ b/runtime/lib/ttnn/operations/eltwise/unary/unary_composite.h
@@ -14,6 +14,7 @@ inline bool isUnaryCompositeOp(const ::tt::target::ttnn::EltwiseOp *op) {
   switch (op->type()) {
   case ::tt::target::ttnn::EltwiseOpType::Cbrt:
   case ::tt::target::ttnn::EltwiseOpType::Clamp:
+  case ::tt::target::ttnn::EltwiseOpType::ClampTensor:
   case ::tt::target::ttnn::EltwiseOpType::Log1p:
     return true;
   default:

--- a/test/ttmlir/Conversion/StableHLOToTTIR/clamp_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/clamp_op.mlir
@@ -6,7 +6,7 @@ module @jit_clamp attributes {} {
     %cst = stablehlo.constant dense<2.000000e+00> : tensor<4xf32>
     %cst_0 = stablehlo.constant dense<3.000000e+00> : tensor<4xf32>
     // CHECK: %[[EMPTY:.*]] = ttir.empty() : [[TENSOR:tensor<4xf32>]]
-    // CHECK: "ttir.clamp"(%arg0, %[[EMPTY]])
+    // CHECK: "ttir.clamp_scalar"(%arg0, %[[EMPTY]])
     // CHECK-SAME: max = 3.000000e+00 : f32, min = 2.000000e+00 : f32
     // CHECK-SAME: ([[TENSOR]], [[TENSOR]]) -> [[TENSOR]]
     %0 = stablehlo.clamp %cst, %arg0, %cst_0 : tensor<4xf32>
@@ -22,7 +22,7 @@ module @jit_clamp attributes {} {
     %2 = stablehlo.convert %cst_0 : (tensor<1xi64>) -> tensor<1xbf16>
     %3 = stablehlo.reshape %2 : (tensor<1xbf16>) -> tensor<bf16>
     // CHECK: %[[EMPTY:[0-9]+]] = ttir.empty() : [[TENSOR:tensor<1x16xbf16>]]
-    // CHECK: "ttir.clamp"(%arg0, %[[EMPTY]])
+    // CHECK: "ttir.clamp_scalar"(%arg0, %[[EMPTY]])
     // CHECK-SAME: max = 6.000000e+00 : f32, min = 3.000000e+00 : f32
     // CHECK-SAME: ([[TENSOR]], [[TENSOR]]) -> [[TENSOR]]
     %4 = stablehlo.clamp %1, %arg0, %3 : (tensor<bf16>, tensor<1x16xbf16>, tensor<bf16>) -> tensor<1x16xbf16>
@@ -35,10 +35,9 @@ module @jit_clamp attributes {} {
     %cst_0 = stablehlo.constant dense<5.000000e+00> : tensor<bf16>
     %0 = stablehlo.broadcast_in_dim %cst, dims = [] : (tensor<bf16>) -> tensor<1x32xbf16>
     %1 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<bf16>) -> tensor<1x32xbf16>
-    // CHECK: %[[EMPTY:[0-9]+]] = ttir.empty() : [[TENSOR:tensor<1x32xbf16>]]
-    // CHECK: "ttir.clamp"(%arg0, %[[EMPTY]])
+    // CHECK: "ttir.clamp_scalar"(%arg0, %{{[0-9]+}}
     // CHECK-SAME: max = 5.000000e+00 : f32, min = 2.000000e+00 : f32
-    // CHECK-SAME: ([[TENSOR]], [[TENSOR]]) -> [[TENSOR]]
+    // CHECK-SAME: (tensor<1x32xbf16>, tensor<1x32xbf16>) -> tensor<1x32xbf16>
     %2 = stablehlo.clamp %0, %arg0, %1 : tensor<1x32xbf16>
     return %2 : tensor<1x32xbf16>
   }

--- a/test/ttmlir/Conversion/StableHLOToTTIR/clamp_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/clamp_op.mlir
@@ -42,47 +42,4 @@ module @jit_clamp attributes {} {
     %2 = stablehlo.clamp %0, %arg0, %1 : tensor<1x32xbf16>
     return %2 : tensor<1x32xbf16>
   }
-
-  func.func public @test_clamp_tensor(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>, %arg2: tensor<4xf32>) -> tensor<4xf32> {
-    // CHECK: %[[EMPTY0:.*]] = ttir.empty() : [[TENSOR:tensor<4xf32>]]
-    // CHECK: %[[MAX:.*]] = "ttir.maximum"(%arg1, %arg0, %[[EMPTY0]])
-    // CHECK-SAME: ([[TENSOR]], [[TENSOR]], [[TENSOR]]) -> [[TENSOR]]
-    // CHECK: %[[EMPTY1:.*]] = ttir.empty() : [[TENSOR]]
-    // CHECK: %[[MIN:.*]] = "ttir.minimum"(%[[MAX]], %arg2, %[[EMPTY1]])
-    // CHECK-SAME: ([[TENSOR]], [[TENSOR]], [[TENSOR]]) -> [[TENSOR]]
-    %0 = stablehlo.clamp %arg1, %arg0, %arg2 : tensor<4xf32>
-    // CHECK: return %[[MIN]] : [[TENSOR]]
-    return %0 : tensor<4xf32>
-  }
-
-  func.func public @test_clamp_tensor_constant(%arg0: tensor<1x16xbf16>, %arg1: tensor<bf16>) -> tensor<1x16xbf16> {
-    // CHECK-LABEL: func.func public @test_clamp_tensor_constant(
-    // CHECK: %[[CONSTANT:[0-9]+]] = "ttir.constant"() <{value = dense<3.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
-    %cst = arith.constant dense<3.0> : tensor<1xf64>
-    // CHECK: %[[CAST:[0-9]+]] = "ttir.typecast"(%[[CONSTANT]],
-    // CHECK-SAME: (tensor<1xf32>, tensor<1xbf16>) -> tensor<1xbf16>
-    %0 = stablehlo.convert %cst : (tensor<1xf64>) -> tensor<1xbf16>
-    // CHECK: %[[RESHAPE0:[0-9]+]] = "ttir.reshape"(%[[CAST]],
-    // CHECK-SAME: shape = [1 : i32]
-    // CHECK-SAME: (tensor<1xbf16>, tensor<1xbf16>) -> tensor<1xbf16>
-    %1 = stablehlo.reshape %0 : (tensor<1xbf16>) -> tensor<bf16>
-    // CHECK: %[[RESHAPE1:[0-9]+]] = "ttir.reshape"(%[[RESHAPE0]],
-    // CHECK-SAME: shape = [1 : i32, 1 : i32]
-    // CHECK-SAME: (tensor<1xbf16>, tensor<1x1xbf16>) -> tensor<1x1xbf16>
-    // CHECK: %[[MIN:[0-9]+]] = "ttir.broadcast"(%[[RESHAPE1]]
-    // CHECK-SAME: {broadcast_dimensions = array<i64: 1, 16>}
-    // CHECK-SAME:  (tensor<1x1xbf16>, tensor<1x16xbf16>) -> tensor<1x16xbf16>
-    // CHECK: %[[RESHAPE2:[0-9]+]] = "ttir.reshape"(%arg1,
-    // CHECK-SAME: <{shape = [1 : i32, 1 : i32]}>
-    // CHECK-SAME:  (tensor<1xbf16>, tensor<1x1xbf16>) -> tensor<1x1xbf16>
-    // CHECK: %[[MAX:[0-9]+]] = "ttir.broadcast"(%[[RESHAPE2]],
-    // CHECK-SAME: <{broadcast_dimensions = array<i64: 1, 16>}>
-    // CHECK-SAME: (tensor<1x1xbf16>, tensor<1x16xbf16>) -> tensor<1x16xbf16>
-    // CHECK: %[[ARG:[0-9]+]] = "ttir.maximum"(%[[MIN]], %arg0,
-    // CHECK-SAME: (tensor<1x16xbf16>, tensor<1x16xbf16>, tensor<1x16xbf16>) -> tensor<1x16xbf16>
-    // CHECK: "ttir.minimum"(%[[ARG]], %[[MAX]],
-    // CHECK-SAME: (tensor<1x16xbf16>, tensor<1x16xbf16>, tensor<1x16xbf16>) -> tensor<1x16xbf16>
-    %2 = stablehlo.clamp %1, %arg0, %arg1 : (tensor<bf16>, tensor<1x16xbf16>, tensor<bf16>) -> tensor<1x16xbf16>
-    return %2 : tensor<1x16xbf16>
-  }
 }

--- a/test/ttmlir/Conversion/StableHLOToTTIR/clamp_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/clamp_op.mlir
@@ -1,7 +1,8 @@
 // REQUIRES: stablehlo
 // RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s | FileCheck %s
-module @jit_transpose attributes {} {
+module @jit_clamp attributes {} {
   func.func public @test_clamp_constant(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+    // CHECK-LABEL: func.func public @test_clamp_constant
     %cst = stablehlo.constant dense<2.000000e+00> : tensor<4xf32>
     %cst_0 = stablehlo.constant dense<3.000000e+00> : tensor<4xf32>
     // CHECK: %[[EMPTY:.*]] = ttir.empty() : [[TENSOR:tensor<4xf32>]]
@@ -10,6 +11,36 @@ module @jit_transpose attributes {} {
     // CHECK-SAME: ([[TENSOR]], [[TENSOR]]) -> [[TENSOR]]
     %0 = stablehlo.clamp %cst, %arg0, %cst_0 : tensor<4xf32>
     return %0 : tensor<4xf32>
+  }
+
+  func.func public @test_clamp_indirect_constant_reshape(%arg0: tensor<1x16xbf16>) -> tensor<1x16xbf16> {
+    // CHECK-LABEL: func.func public @test_clamp_indirect_constant_reshape
+    %cst = arith.constant dense<3.0> : tensor<1xf64>
+    %cst_0 = arith.constant dense<6> : tensor<1xi64>
+    %0 = stablehlo.convert %cst : (tensor<1xf64>) -> tensor<1xbf16>
+    %1 = stablehlo.reshape %0 : (tensor<1xbf16>) -> tensor<bf16>
+    %2 = stablehlo.convert %cst_0 : (tensor<1xi64>) -> tensor<1xbf16>
+    %3 = stablehlo.reshape %2 : (tensor<1xbf16>) -> tensor<bf16>
+    // CHECK: %[[EMPTY:[0-9]+]] = ttir.empty() : [[TENSOR:tensor<1x16xbf16>]]
+    // CHECK: "ttir.clamp"(%arg0, %[[EMPTY]])
+    // CHECK-SAME: max = 6.000000e+00 : f32, min = 3.000000e+00 : f32
+    // CHECK-SAME: ([[TENSOR]], [[TENSOR]]) -> [[TENSOR]]
+    %4 = stablehlo.clamp %1, %arg0, %3 : (tensor<bf16>, tensor<1x16xbf16>, tensor<bf16>) -> tensor<1x16xbf16>
+    return %4 : tensor<1x16xbf16>
+  }
+
+  func.func public @test_clamp_indirect_constant_broadcast(%arg0: tensor<1x32xbf16>) -> (tensor<1x32xbf16>) {
+    // CHECK-LABEL: func.func public @test_clamp_indirect_constant_broadcast
+    %cst = stablehlo.constant dense<2.000000e+00> : tensor<bf16>
+    %cst_0 = stablehlo.constant dense<5.000000e+00> : tensor<bf16>
+    %0 = stablehlo.broadcast_in_dim %cst, dims = [] : (tensor<bf16>) -> tensor<1x32xbf16>
+    %1 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<bf16>) -> tensor<1x32xbf16>
+    // CHECK: %[[EMPTY:[0-9]+]] = ttir.empty() : [[TENSOR:tensor<1x32xbf16>]]
+    // CHECK: "ttir.clamp"(%arg0, %[[EMPTY]])
+    // CHECK-SAME: max = 5.000000e+00 : f32, min = 2.000000e+00 : f32
+    // CHECK-SAME: ([[TENSOR]], [[TENSOR]]) -> [[TENSOR]]
+    %2 = stablehlo.clamp %0, %arg0, %1 : tensor<1x32xbf16>
+    return %2 : tensor<1x32xbf16>
   }
 
   func.func public @test_clamp_tensor(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>, %arg2: tensor<4xf32>) -> tensor<4xf32> {
@@ -22,5 +53,36 @@ module @jit_transpose attributes {} {
     %0 = stablehlo.clamp %arg1, %arg0, %arg2 : tensor<4xf32>
     // CHECK: return %[[MIN]] : [[TENSOR]]
     return %0 : tensor<4xf32>
+  }
+
+  func.func public @test_clamp_tensor_constant(%arg0: tensor<1x16xbf16>, %arg1: tensor<bf16>) -> tensor<1x16xbf16> {
+    // CHECK-LABEL: func.func public @test_clamp_tensor_constant(
+    // CHECK: %[[CONSTANT:[0-9]+]] = "ttir.constant"() <{value = dense<3.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
+    %cst = arith.constant dense<3.0> : tensor<1xf64>
+    // CHECK: %[[CAST:[0-9]+]] = "ttir.typecast"(%[[CONSTANT]],
+    // CHECK-SAME: (tensor<1xf32>, tensor<1xbf16>) -> tensor<1xbf16>
+    %0 = stablehlo.convert %cst : (tensor<1xf64>) -> tensor<1xbf16>
+    // CHECK: %[[RESHAPE0:[0-9]+]] = "ttir.reshape"(%[[CAST]],
+    // CHECK-SAME: shape = [1 : i32]
+    // CHECK-SAME: (tensor<1xbf16>, tensor<1xbf16>) -> tensor<1xbf16>
+    %1 = stablehlo.reshape %0 : (tensor<1xbf16>) -> tensor<bf16>
+    // CHECK: %[[RESHAPE1:[0-9]+]] = "ttir.reshape"(%[[RESHAPE0]],
+    // CHECK-SAME: shape = [1 : i32, 1 : i32]
+    // CHECK-SAME: (tensor<1xbf16>, tensor<1x1xbf16>) -> tensor<1x1xbf16>
+    // CHECK: %[[MIN:[0-9]+]] = "ttir.broadcast"(%[[RESHAPE1]]
+    // CHECK-SAME: {broadcast_dimensions = array<i64: 1, 16>}
+    // CHECK-SAME:  (tensor<1x1xbf16>, tensor<1x16xbf16>) -> tensor<1x16xbf16>
+    // CHECK: %[[RESHAPE2:[0-9]+]] = "ttir.reshape"(%arg1,
+    // CHECK-SAME: <{shape = [1 : i32, 1 : i32]}>
+    // CHECK-SAME:  (tensor<1xbf16>, tensor<1x1xbf16>) -> tensor<1x1xbf16>
+    // CHECK: %[[MAX:[0-9]+]] = "ttir.broadcast"(%[[RESHAPE2]],
+    // CHECK-SAME: <{broadcast_dimensions = array<i64: 1, 16>}>
+    // CHECK-SAME: (tensor<1x1xbf16>, tensor<1x16xbf16>) -> tensor<1x16xbf16>
+    // CHECK: %[[ARG:[0-9]+]] = "ttir.maximum"(%[[MIN]], %arg0,
+    // CHECK-SAME: (tensor<1x16xbf16>, tensor<1x16xbf16>, tensor<1x16xbf16>) -> tensor<1x16xbf16>
+    // CHECK: "ttir.minimum"(%[[ARG]], %[[MAX]],
+    // CHECK-SAME: (tensor<1x16xbf16>, tensor<1x16xbf16>, tensor<1x16xbf16>) -> tensor<1x16xbf16>
+    %2 = stablehlo.clamp %1, %arg0, %arg1 : (tensor<bf16>, tensor<1x16xbf16>, tensor<bf16>) -> tensor<1x16xbf16>
+    return %2 : tensor<1x16xbf16>
   }
 }

--- a/test/ttmlir/Conversion/StableHLOToTTIR/clamp_tensor_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/clamp_tensor_op.mlir
@@ -1,0 +1,42 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s | FileCheck %s
+module @test_clamp_tensor attributes {} {
+  func.func public @test_clamp_tensor(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>, %arg2: tensor<4xf32>) -> tensor<4xf32> {
+    // CHECK-LABEL: func.func public @test_clamp_tensor
+    // CHECK: %[[EMPTY0:.*]] = tensor.empty() : [[TENSOR:tensor<4xf32>]]
+    // CHECK: %[[CLAMP:.*]] = "ttir.clamp_tensor"(%arg0, %arg1, %arg2, %[[EMPTY0]])
+    // CHECK-SAME: ([[TENSOR]], [[TENSOR]], [[TENSOR]], [[TENSOR]]) -> [[TENSOR]]
+    %0 = stablehlo.clamp %arg1, %arg0, %arg2 : tensor<4xf32>
+    // CHECK: return %[[CLAMP]] : [[TENSOR]]
+    return %0 : tensor<4xf32>
+  }
+
+  func.func public @test_clamp_tensor_constant(%arg0: tensor<1x16xbf16>, %arg1: tensor<bf16>) -> tensor<1x16xbf16> {
+    // CHECK-LABEL: func.func public @test_clamp_tensor_constant(
+    // CHECK: %[[CONSTANT:[0-9]+]] = "ttir.constant"() <{value = dense<3.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
+    %cst = arith.constant dense<3.0> : tensor<1xf64>
+    // CHECK: %[[CAST:[0-9]+]] = "ttir.typecast"(%[[CONSTANT]],
+    // CHECK-SAME: (tensor<1xf32>, tensor<1xbf16>) -> tensor<1xbf16>
+    %0 = stablehlo.convert %cst : (tensor<1xf64>) -> tensor<1xbf16>
+    // CHECK: %[[RESHAPE0:[0-9]+]] = "ttir.reshape"(%[[CAST]],
+    // CHECK-SAME: shape = [1 : i32]
+    // CHECK-SAME: (tensor<1xbf16>, tensor<1xbf16>) -> tensor<1xbf16>
+    %1 = stablehlo.reshape %0 : (tensor<1xbf16>) -> tensor<bf16>
+    // CHECK: %[[RESHAPE1:[0-9]+]] = "ttir.reshape"(%[[RESHAPE0]],
+    // CHECK-SAME: shape = [1 : i32, 1 : i32]
+    // CHECK-SAME: (tensor<1xbf16>, tensor<1x1xbf16>) -> tensor<1x1xbf16>
+    // CHECK: %[[MIN:[0-9]+]] = "ttir.broadcast"(%[[RESHAPE1]]
+    // CHECK-SAME: {broadcast_dimensions = array<i64: 1, 16>}
+    // CHECK-SAME:  (tensor<1x1xbf16>, tensor<1x16xbf16>) -> tensor<1x16xbf16>
+    // CHECK: %[[RESHAPE2:[0-9]+]] = "ttir.reshape"(%arg1,
+    // CHECK-SAME: <{shape = [1 : i32, 1 : i32]}>
+    // CHECK-SAME:  (tensor<1xbf16>, tensor<1x1xbf16>) -> tensor<1x1xbf16>
+    // CHECK: %[[MAX:[0-9]+]] = "ttir.broadcast"(%[[RESHAPE2]],
+    // CHECK-SAME: <{broadcast_dimensions = array<i64: 1, 16>}>
+    // CHECK-SAME: (tensor<1x1xbf16>, tensor<1x16xbf16>) -> tensor<1x16xbf16>
+    // CHECK: = "ttir.clamp_tensor"(%arg0, %[[MIN]], %[[MAX]],
+    // CHECK-SAME: (tensor<1x16xbf16>, tensor<1x16xbf16>, tensor<1x16xbf16>, tensor<1x16xbf16>) -> tensor<1x16xbf16>
+    %2 = stablehlo.clamp %1, %arg0, %arg1 : (tensor<bf16>, tensor<1x16xbf16>, tensor<bf16>) -> tensor<1x16xbf16>
+    return %2 : tensor<1x16xbf16>
+  }
+}

--- a/test/ttmlir/Conversion/StableHLOToTTIR/clamp_tensor_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/clamp_tensor_op.mlir
@@ -3,7 +3,7 @@
 module @test_clamp_tensor attributes {} {
   func.func public @test_clamp_tensor(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>, %arg2: tensor<4xf32>) -> tensor<4xf32> {
     // CHECK-LABEL: func.func public @test_clamp_tensor
-    // CHECK: %[[EMPTY0:.*]] = tensor.empty() : [[TENSOR:tensor<4xf32>]]
+    // CHECK: %[[EMPTY0:.*]] = ttir.empty() : [[TENSOR:tensor<4xf32>]]
     // CHECK: %[[CLAMP:.*]] = "ttir.clamp_tensor"(%arg0, %arg1, %arg2, %[[EMPTY0]])
     // CHECK-SAME: ([[TENSOR]], [[TENSOR]], [[TENSOR]], [[TENSOR]]) -> [[TENSOR]]
     %0 = stablehlo.clamp %arg1, %arg0, %arg2 : tensor<4xf32>

--- a/test/ttmlir/Conversion/TosaToTTIR/clamp.mlir
+++ b/test/ttmlir/Conversion/TosaToTTIR/clamp.mlir
@@ -3,7 +3,7 @@ module attributes {} {
   func.func @test_clamp(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
     %0 = tosa.clamp %arg0 { min_int = 2 : i64, max_int = 3 : i64, min_fp = 2.0 : f32, max_fp = 3.0 : f32 } : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
     // CHECK: %[[OP_OUT:[0-9]+]] = ttir.empty() : [[TENSOR_SIZE:tensor<[0-9]+x[0-9]+x[0-9]+xf[0-9]+>]]
-    // CHECK: %[[VAL:[0-9]+]] = "ttir.clamp"(%arg{{[0-9]+}}, %[[OP_OUT]])
+    // CHECK: %[[VAL:[0-9]+]] = "ttir.clamp_scalar"(%arg{{[0-9]+}}, %[[OP_OUT]])
     // CHECK-SAME: max = 3.000000e+00 : f32, min = 2.000000e+00 : f32{{.+}}: ([[TENSOR_SIZE]], [[TENSOR_SIZE]]) -> [[TENSOR_SIZE]]
     return %0 : tensor<13x21x3xf32>
     // CHECK: return %[[VAL]] : [[TENSOR_SIZE]]

--- a/test/ttmlir/Dialect/TTIR/clamp/clamp_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/clamp/clamp_tests_negative.mlir
@@ -5,8 +5,8 @@
 module attributes {} {
   func.func @clamp(%arg0: tensor<64x64xbf16>) -> tensor<64x128xbf16> {
     %0 = ttir.empty() : tensor<64x128xbf16>
-    // CHECK: error: 'ttir.clamp' op input and output must have same shape.
-    %1 = "ttir.clamp"(%arg0, %0) <{max = 3.000000e+00 : f32, min = 2.000000e+00 : f32}> : (tensor<64x64xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+    // CHECK: error: 'ttir.clamp_scalar' op input and output must have same shape.
+    %1 = "ttir.clamp_scalar"(%arg0, %0) <{max = 3.000000e+00 : f32, min = 2.000000e+00 : f32}> : (tensor<64x64xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/clamp/clamp_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/clamp/clamp_tests_negative.mlir
@@ -4,9 +4,9 @@
 // Verify that the parsing fails if input and output shapes do not match.
 module attributes {} {
   func.func @clamp(%arg0: tensor<64x64xbf16>) -> tensor<64x128xbf16> {
-    // CHECK: error: 'ttnn.clamp' op input and output must have same shape.
+    // CHECK: error: 'ttnn.clamp_scalar' op input and output must have same shape.
     %0 = ttir.empty() : tensor<64x128xbf16>
-    %1 = "ttnn.clamp"(%arg0) <{max = 3.000000e+00 : f32, min = 2.000000e+00 : f32}> : (tensor<64x64xbf16>) -> tensor<64x128xbf16>
+    %1 = "ttnn.clamp_scalar"(%arg0) <{max = 3.000000e+00 : f32, min = 2.000000e+00 : f32}> : (tensor<64x64xbf16>) -> tensor<64x128xbf16>
     return %1 : tensor<64x128xbf16>
   }
 }
@@ -15,9 +15,9 @@ module attributes {} {
 // -----
 module attributes {} {
   func.func @clamp2(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
-    // CHECK: error: 'ttnn.clamp' op expects one tensor as input.
+    // CHECK: error: 'ttnn.clamp_scalar' op expects one tensor as input.
     %0 = ttir.empty() : tensor<64x128xbf16>
-    %1 = "ttnn.clamp"(%arg0, %arg1) <{max = 3.000000e+00 : f32, min = 2.000000e+00 : f32}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+    %1 = "ttnn.clamp_scalar"(%arg0, %arg1) <{max = 3.000000e+00 : f32, min = 2.000000e+00 : f32}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/simple_clamp.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_clamp.mlir
@@ -2,9 +2,9 @@
 module attributes {} {
   func.func @clamp(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
     %0 = ttir.empty() : tensor<64x128xbf16>
-    // CHECK: "ttnn.clamp"(%arg0)
+    // CHECK: "ttnn.clamp_scalar"(%arg0)
     // CHECK-SAME: {max = 3.000000e+00 : f32, min = 2.000000e+00 : f32}
-    %1 = "ttir.clamp"(%arg0, %0) <{max = 3.000000e+00 : f32, min = 2.000000e+00 : f32}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+    %1 = "ttir.clamp_scalar"(%arg0, %0) <{max = 3.000000e+00 : f32, min = 2.000000e+00 : f32}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/simple_clamp_tensor.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_clamp_tensor.mlir
@@ -1,0 +1,13 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
+module attributes {} {
+  func.func public @test_clamp_tensor(%arg0: tensor<32x64xf32>, %arg1: tensor<32x64xf32>, %arg2: tensor<32x64xf32>) -> tensor<32x64xf32> {
+    %0 = tensor.empty() : tensor<32x64xf32>
+    // CHECK: %{{[0-9]+}} = "ttnn.clamp_tensor"(%arg0, %arg1, %arg2)
+    // CHECK-SAME: tensor<32x64xf32,
+    // CHECK-SAME: tensor<32x64xf32,
+    // CHECK-SAME: tensor<32x64xf32,
+    // CHECK-SAME: -> tensor<32x64xf32,
+    %1 = "ttir.clamp_tensor"(%arg0, %arg1, %arg2, %0) : (tensor<32x64xf32>, tensor<32x64xf32>, tensor<32x64xf32>, tensor<32x64xf32>) -> tensor<32x64xf32>
+    return %1 : tensor<32x64xf32>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/simple_clamp_tensor.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_clamp_tensor.mlir
@@ -1,7 +1,7 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
   func.func public @test_clamp_tensor(%arg0: tensor<32x64xf32>, %arg1: tensor<32x64xf32>, %arg2: tensor<32x64xf32>) -> tensor<32x64xf32> {
-    %0 = tensor.empty() : tensor<32x64xf32>
+    %0 = ttir.empty() : tensor<32x64xf32>
     // CHECK: %{{[0-9]+}} = "ttnn.clamp_tensor"(%arg0, %arg1, %arg2)
     // CHECK-SAME: tensor<32x64xf32,
     // CHECK-SAME: tensor<32x64xf32,

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/clamp.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/clamp.mlir
@@ -5,6 +5,6 @@
 
 func.func @clamp(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
   %0 = ttir.empty() : tensor<64x128xbf16>
-  %1 = "ttir.clamp"(%arg0, %0) <{max = 3.000000e+00 : f32, min = 2.000000e+00 : f32}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+  %1 = "ttir.clamp_scalar"(%arg0, %0) <{max = 3.000000e+00 : f32, min = 2.000000e+00 : f32}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/Unary/clamp_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Unary/clamp_op.mlir
@@ -6,7 +6,7 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 // RUN: FileCheck --input-file=%t.mlir %s
 
-module @jit_transpose attributes {} {
+module @test_clamp attributes {} {
   func.func public @test_clamp_constant(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
     // CHECK-LABEL: func.func public @test_clamp_constant(
     // CHECK: ttnn.clamp
@@ -47,36 +47,5 @@ module @jit_transpose attributes {} {
     // CHECK-SAME: -> tensor<1x32xbf16,
     %2 = stablehlo.clamp %0, %arg0, %1 : tensor<1x32xbf16>
     return %2 : tensor<1x32xbf16>
-  }
-
-  func.func public @test_clamp_tensor(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>, %arg2: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    // CHECK-LABEL: func.func public @test_clamp_tensor(
-    // CHECK: %[[MAX:.*]] = "ttnn.maximum"
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: -> tensor<64x128xf32,
-    // CHECK: "ttnn.minimum"(%[[MAX]]
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: -> tensor<64x128xf32,
-    %0 = stablehlo.clamp %arg1, %arg0, %arg2 : tensor<64x128xf32>
-    return %0 : tensor<64x128xf32>
-  }
-
-  func.func public @test_clamp_tensor_constant(%arg0: tensor<32x32xbf16>, %arg1: tensor<bf16>) -> tensor<32x32xbf16> {
-    // CHECK-LABEL: func.func public @test_clamp_tensor_constant(
-    %cst = arith.constant dense<3.0> : tensor<1xf64>
-    %0 = stablehlo.convert %cst : (tensor<1xf64>) -> tensor<1xbf16>
-    %1 = stablehlo.reshape %0 : (tensor<1xbf16>) -> tensor<bf16>
-    // CHECK: %[[MAX:.*]] = "ttnn.maximum"
-    // CHECK-SAME: tensor<32x32xbf16,
-    // CHECK-SAME: tensor<32x32xbf16,
-    // CHECK-SAME: -> tensor<32x32xbf16,
-    // CHECK: "ttnn.minimum"(%[[MAX]]
-    // CHECK-SAME: tensor<32x32xbf16,
-    // CHECK-SAME: tensor<32x32xbf16,
-    // CHECK-SAME: -> tensor<32x32xbf16,
-    %2 = stablehlo.clamp %1, %arg0, %arg1 : (tensor<bf16>, tensor<32x32xbf16>, tensor<bf16>) -> tensor<32x32xbf16>
-    return %2 : tensor<32x32xbf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/Unary/clamp_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Unary/clamp_op.mlir
@@ -9,7 +9,7 @@
 module @test_clamp attributes {} {
   func.func public @test_clamp_constant(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
     // CHECK-LABEL: func.func public @test_clamp_constant(
-    // CHECK: ttnn.clamp
+    // CHECK: ttnn.clamp_scalar
     // CHECK-SAME: {max = 3.000000e+00 : f32, min = 2.000000e+00 : f32}
     // CHECK-SAME: tensor<64x128xf32,
     // CHECK-SAME: -> tensor<64x128xf32,
@@ -27,7 +27,7 @@ module @test_clamp attributes {} {
     %1 = stablehlo.reshape %0 : (tensor<1xbf16>) -> tensor<bf16>
     %2 = stablehlo.convert %cst_0 : (tensor<1xi64>) -> tensor<1xbf16>
     %3 = stablehlo.reshape %2 : (tensor<1xbf16>) -> tensor<bf16>
-    // CHECK: ttnn.clamp
+    // CHECK: ttnn.clamp_scalar
     // CHECK-SAME: {max = 6.000000e+00 : f32, min = 3.000000e+00 : f32}
     // CHECK-SAME: tensor<1x16xbf16,
     // CHECK-SAME: -> tensor<1x16xbf16,
@@ -41,7 +41,7 @@ module @test_clamp attributes {} {
     %cst_0 = stablehlo.constant dense<5.000000e+00> : tensor<bf16>
     %0 = stablehlo.broadcast_in_dim %cst, dims = [] : (tensor<bf16>) -> tensor<1x32xbf16>
     %1 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<bf16>) -> tensor<1x32xbf16>
-    // CHECK: ttnn.clamp
+    // CHECK: ttnn.clamp_scalar
     // CHECK-SAME: {max = 5.000000e+00 : f32, min = 2.000000e+00 : f32}
     // CHECK-SAME: tensor<1x32xbf16,
     // CHECK-SAME: -> tensor<1x32xbf16,

--- a/test/ttmlir/Silicon/StableHLO/n150/Unary/clamp_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Unary/clamp_op.mlir
@@ -1,14 +1,14 @@
 // REQUIRES: stablehlo
 // RUN: rm -rf %t.ttnn
 // RUN: rm -rf %t.mlir
-// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s | \
-// RUN:     ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" > %t.mlir
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s \
+// RUN:     --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" > %t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module @jit_transpose attributes {} {
   func.func public @test_clamp_constant(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    // CHECK-LABEL: func.func public @test_clamp_constant
+    // CHECK-LABEL: func.func public @test_clamp_constant(
     // CHECK: ttnn.clamp
     // CHECK-SAME: {max = 3.000000e+00 : f32, min = 2.000000e+00 : f32}
     // CHECK-SAME: tensor<64x128xf32,
@@ -19,8 +19,38 @@ module @jit_transpose attributes {} {
     return %0 : tensor<64x128xf32>
   }
 
+  func.func public @test_clamp_indirect_constant_reshape(%arg0: tensor<1x16xbf16>) -> tensor<1x16xbf16> {
+    // CHECK-LABEL: func.func public @test_clamp_indirect_constant_reshape
+    %cst = arith.constant dense<3.0> : tensor<1xf64>
+    %cst_0 = arith.constant dense<6> : tensor<1xi64>
+    %0 = stablehlo.convert %cst : (tensor<1xf64>) -> tensor<1xbf16>
+    %1 = stablehlo.reshape %0 : (tensor<1xbf16>) -> tensor<bf16>
+    %2 = stablehlo.convert %cst_0 : (tensor<1xi64>) -> tensor<1xbf16>
+    %3 = stablehlo.reshape %2 : (tensor<1xbf16>) -> tensor<bf16>
+    // CHECK: ttnn.clamp
+    // CHECK-SAME: {max = 6.000000e+00 : f32, min = 3.000000e+00 : f32}
+    // CHECK-SAME: tensor<1x16xbf16,
+    // CHECK-SAME: -> tensor<1x16xbf16,
+    %4 = stablehlo.clamp %1, %arg0, %3 : (tensor<bf16>, tensor<1x16xbf16>, tensor<bf16>) -> tensor<1x16xbf16>
+    return %4 : tensor<1x16xbf16>
+  }
+
+  func.func public @test_clamp_indirect_constant_broadcast(%arg0: tensor<1x32xbf16>) -> (tensor<1x32xbf16>) {
+    // CHECK-LABEL: func.func public @test_clamp_indirect_constant_broadcast
+    %cst = stablehlo.constant dense<2.000000e+00> : tensor<bf16>
+    %cst_0 = stablehlo.constant dense<5.000000e+00> : tensor<bf16>
+    %0 = stablehlo.broadcast_in_dim %cst, dims = [] : (tensor<bf16>) -> tensor<1x32xbf16>
+    %1 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<bf16>) -> tensor<1x32xbf16>
+    // CHECK: ttnn.clamp
+    // CHECK-SAME: {max = 5.000000e+00 : f32, min = 2.000000e+00 : f32}
+    // CHECK-SAME: tensor<1x32xbf16,
+    // CHECK-SAME: -> tensor<1x32xbf16,
+    %2 = stablehlo.clamp %0, %arg0, %1 : tensor<1x32xbf16>
+    return %2 : tensor<1x32xbf16>
+  }
+
   func.func public @test_clamp_tensor(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>, %arg2: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    // CHECK-LABEL: func.func public @test_clamp_tensor
+    // CHECK-LABEL: func.func public @test_clamp_tensor(
     // CHECK: %[[MAX:.*]] = "ttnn.maximum"
     // CHECK-SAME: tensor<64x128xf32,
     // CHECK-SAME: tensor<64x128xf32,
@@ -31,5 +61,22 @@ module @jit_transpose attributes {} {
     // CHECK-SAME: -> tensor<64x128xf32,
     %0 = stablehlo.clamp %arg1, %arg0, %arg2 : tensor<64x128xf32>
     return %0 : tensor<64x128xf32>
+  }
+
+  func.func public @test_clamp_tensor_constant(%arg0: tensor<32x32xbf16>, %arg1: tensor<bf16>) -> tensor<32x32xbf16> {
+    // CHECK-LABEL: func.func public @test_clamp_tensor_constant(
+    %cst = arith.constant dense<3.0> : tensor<1xf64>
+    %0 = stablehlo.convert %cst : (tensor<1xf64>) -> tensor<1xbf16>
+    %1 = stablehlo.reshape %0 : (tensor<1xbf16>) -> tensor<bf16>
+    // CHECK: %[[MAX:.*]] = "ttnn.maximum"
+    // CHECK-SAME: tensor<32x32xbf16,
+    // CHECK-SAME: tensor<32x32xbf16,
+    // CHECK-SAME: -> tensor<32x32xbf16,
+    // CHECK: "ttnn.minimum"(%[[MAX]]
+    // CHECK-SAME: tensor<32x32xbf16,
+    // CHECK-SAME: tensor<32x32xbf16,
+    // CHECK-SAME: -> tensor<32x32xbf16,
+    %2 = stablehlo.clamp %1, %arg0, %arg1 : (tensor<bf16>, tensor<32x32xbf16>, tensor<bf16>) -> tensor<32x32xbf16>
+    return %2 : tensor<32x32xbf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/Unary/clamp_tensor_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Unary/clamp_tensor_op.mlir
@@ -1,0 +1,34 @@
+// REQUIRES: stablehlo
+// RUN: rm -rf %t.ttnn
+// RUN: rm -rf %t.mlir
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s \
+// RUN:     --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" > %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+// RUN: FileCheck --input-file=%t.mlir %s
+
+module @test_clamp_tensor attributes {} {
+  func.func public @test_clamp_tensor(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>, %arg2: tensor<64x128xf32>) -> tensor<64x128xf32> {
+    // CHECK-LABEL: func.func public @test_clamp_tensor(
+    // CHECK: %{{[0-9]+}} = "ttnn.clamp_tensor"(%arg0, %arg1, %arg2)
+    // CHECK-SAME: tensor<64x128xf32,
+    // CHECK-SAME: tensor<64x128xf32,
+    // CHECK-SAME: tensor<64x128xf32,
+    // CHECK-SAME: -> tensor<64x128xf32,
+    %0 = stablehlo.clamp %arg1, %arg0, %arg2 : tensor<64x128xf32>
+    return %0 : tensor<64x128xf32>
+  }
+
+  func.func public @test_clamp_tensor_constant(%arg0: tensor<32x32xbf16>, %arg1: tensor<bf16>) -> tensor<32x32xbf16> {
+    // CHECK-LABEL: func.func public @test_clamp_tensor_constant(
+    %cst = arith.constant dense<3.0> : tensor<1xf64>
+    %0 = stablehlo.convert %cst : (tensor<1xf64>) -> tensor<1xbf16>
+    %1 = stablehlo.reshape %0 : (tensor<1xbf16>) -> tensor<bf16>
+    // CHECK: %{{[0-9]+}} = "ttnn.clamp_tensor"(%arg0, %{{[0-9]+}}, %{{[0-9]+}})
+    // CHECK-SAME: tensor<32x32xbf16,
+    // CHECK-SAME: tensor<32x32xbf16,
+    // CHECK-SAME: tensor<32x32xbf16,
+    // CHECK-SAME: -> tensor<32x32xbf16,
+    %2 = stablehlo.clamp %1, %arg0, %arg1 : (tensor<bf16>, tensor<32x32xbf16>, tensor<bf16>) -> tensor<32x32xbf16>
+    return %2 : tensor<32x32xbf16>
+  }
+}

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/clamp/clamp.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/clamp/clamp.mlir
@@ -4,8 +4,8 @@
 
 func.func @clamp(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
   %0 = ttir.empty() : tensor<64x128xbf16>
-  %1 = "ttir.clamp"(%arg0, %0) <{max = 3.000000e+00 : f32, min = 2.000000e+00 : f32}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
-  // CHECK: "ttnn.clamp"
+  %1 = "ttir.clamp_scalar"(%arg0, %0) <{max = 3.000000e+00 : f32, min = 2.000000e+00 : f32}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+  // CHECK: "ttnn.clamp_scalar"
   // CHECK-SAME: {max = 3.000000e+00 : f32, min = 2.000000e+00 : f32}
   // CHECK-SAME: tensor<64x128xbf16
   // CHECK-SAME: -> tensor<64x128xbf16

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/clamp/clamp_tensor.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/clamp/clamp_tensor.mlir
@@ -4,7 +4,7 @@
 
 func.func public @test_clamp_tensor(%arg0: tensor<32x64xf32>, %arg1: tensor<32x64xf32>, %arg2: tensor<32x64xf32>) -> tensor<32x64xf32> {
   // CHECK-LABEL: func.func public @test_clamp_tensor(
-  %0 = tensor.empty() : tensor<32x64xf32>
+  %0 = ttir.empty() : tensor<32x64xf32>
   // CHECK: %{{[0-9]+}} = "ttnn.clamp_tensor"(%arg0, %arg1, %arg2)
   // CHECK-SAME: tensor<32x64xf32,
   // CHECK-SAME: tensor<32x64xf32,

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/clamp/clamp_tensor.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/clamp/clamp_tensor.mlir
@@ -1,0 +1,15 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+
+func.func public @test_clamp_tensor(%arg0: tensor<32x64xf32>, %arg1: tensor<32x64xf32>, %arg2: tensor<32x64xf32>) -> tensor<32x64xf32> {
+  // CHECK-LABEL: func.func public @test_clamp_tensor(
+  %0 = tensor.empty() : tensor<32x64xf32>
+  // CHECK: %{{[0-9]+}} = "ttnn.clamp_tensor"(%arg0, %arg1, %arg2)
+  // CHECK-SAME: tensor<32x64xf32,
+  // CHECK-SAME: tensor<32x64xf32,
+  // CHECK-SAME: tensor<32x64xf32,
+  // CHECK-SAME: -> tensor<32x64xf32,
+  %1 = "ttir.clamp_tensor"(%arg0, %arg1, %arg2, %0) : (tensor<32x64xf32>, tensor<32x64xf32>, tensor<32x64xf32>, tensor<32x64xf32>) -> tensor<32x64xf32>
+  return %1 : tensor<32x64xf32>
+}

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_clamp.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_clamp.mlir
@@ -4,8 +4,8 @@
 
 func.func @clamp(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
   %0 = ttir.empty() : tensor<64x128xbf16>
-  // CHECK: "ttnn.clamp"(%arg0)
+  // CHECK: "ttnn.clamp_scalar"(%arg0)
   // CHECK-SAME: {max = 3.000000e+00 : f32, min = 2.000000e+00 : f32}
-  %1 = "ttir.clamp"(%arg0, %0) <{max = 3.000000e+00 : f32, min = 2.000000e+00 : f32}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+  %1 = "ttir.clamp_scalar"(%arg0, %0) <{max = 3.000000e+00 : f32, min = 2.000000e+00 : f32}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   return %1 : tensor<64x128xbf16>
 }


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-mlir/issues/2185

### Problem description
stablehlo.clamp is lowered to either 1) ttir.clamp or 2) ttir.maximum followed by ttir.minimum op.
However, tt-metal does not support implicit broadcast for maximum and minimum ops. These two
ops fail if the operand shapes does not match and broadcast is required. 

### What's changed
1. Broadcast min/max value(s) if the shape of min/max does not match with input operand.
2. If a constant op is indirectly used in the stablehlo.clamp op (e.g. constant is converted/reshaped and then used in clamp op), then determine the constant value of min/max and use it in ttir.clamp conversion.

### Checklist
- [X] New/Existing tests provide coverage for changes
