### PR TITLE
Allow shardy include files in install directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,14 @@ if (TTMLIR_ENABLE_STABLEHLO)
   add_subdirectory(${TTMLIR_TOOLCHAIN_DIR}/src/stablehlo ${CMAKE_CURRENT_BINARY_DIR}/stablehlo EXCLUDE_FROM_ALL)
   include_directories(${CMAKE_CURRENT_BINARY_DIR}/stablehlo)
   include_directories(${TTMLIR_TOOLCHAIN_DIR}/src/stablehlo)
+  install(DIRECTORY shardy ${CMAKE_CURRENT_BINARY_DIR}/shardy/shardy
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+    COMPONENT SharedLib
+    FILES_MATCHING
+    PATTERN "*.h"
+    PATTERN "*.inc"
+    PATTERN "*.td"
+  )
   install(DIRECTORY stablehlo ${CMAKE_CURRENT_BINARY_DIR}/stablehlo/stablehlo
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
     COMPONENT SharedLib


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/2270

### Problem description
Currently, Shardy include files are not available to frontend SW stack since we are not installing them to install directory.

### What's changed
This patch allows include files after building Shardy and install files in install directory.

### Checklist
- [V] Locally confirmed that files are copied to install directory.
