### PR TITLE
Add signed int32 data type support end to end

### DIFF
--- a/include/ttmlir/Dialect/TT/IR/TTOpsEnums.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsEnums.td
@@ -19,6 +19,7 @@ def TT_BFP_BFloat2 : I32EnumAttrCase<"BFP_BFloat2", 8, "bfp_bf2">;
 def TT_UInt32 : I32EnumAttrCase<"UInt32", 9, "u32">;
 def TT_UInt16 : I32EnumAttrCase<"UInt16", 10, "u16">;
 def TT_UInt8 : I32EnumAttrCase<"UInt8", 11, "u8">;
+def TT_Int32: I32EnumAttrCase<"Int32", 12, "si32">;
 
 def TT_DataType : I32EnumAttr<"DataType", "TT DataTypes",
                            [
@@ -33,7 +34,8 @@ def TT_DataType : I32EnumAttr<"DataType", "TT DataTypes",
                             TT_BFP_BFloat2,
                             TT_UInt32,
                             TT_UInt16,
-                            TT_UInt8
+                            TT_UInt8,
+                            TT_Int32
                            ]> {
   let genSpecializedAttr = 0;
   let cppNamespace = "::mlir::tt";

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.h
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.h
@@ -93,7 +93,10 @@ inline DataType elementTypeToDataType(Type elementType) {
   } else if (isa<IntegerType>(elementType)) {
     auto intType = mlir::cast<IntegerType>(elementType);
     if (intType.getWidth() == 32) {
-      dtype = DataType::UInt32;
+      // We interpret signed ints (si32) and signless ints (i32) as signed
+      // integers
+      dtype = (intType.isSigned() || intType.isSignless()) ? DataType::Int32
+                                                           : DataType::UInt32;
     } else if (intType.getWidth() == 16) {
       dtype = DataType::UInt16;
     } else if (intType.getWidth() == 8) {
@@ -135,6 +138,9 @@ inline Type dataTypeToElementType(::mlir::MLIRContext *context,
   case DataType::UInt8:
     return IntegerType::get(context, 8,
                             IntegerType::SignednessSemantics::Unsigned);
+  case DataType::Int32:
+    return IntegerType::get(context, 32,
+                            IntegerType::SignednessSemantics::Signed);
   }
 }
 } // namespace mlir::tt

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -786,6 +786,13 @@ def TTNN_UpdateCacheOp : TTNN_InplaceOp<"update_cache"> {
                        AnyRankedTensor:$update_index,
                        I32Attr:$batch_offset);
 
+    let extraClassDeclaration = [{
+      wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
+        RankedTensorType updateIndexType = getUpdateIndex().getType();
+        return wa::TTNNOperandsWorkaroundsFactory::createUpdateCacheOpOperandsWorkarounds(updateIndexType);
+      }
+    }];
+
   let hasVerifier = 1;
 }
 
@@ -958,6 +965,13 @@ def TTNN_ReshapeOp : TTNN_Op<"reshape",
                          I32ArrayAttr:$shape);
 
     let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
+        RankedTensorType inputType = getInput().getType();
+        return wa::TTNNOperandsWorkaroundsFactory::createReshapeOpOperandsWorkarounds(inputType);
+      }
+    }];
 
     let hasVerifier = 1;
 }
@@ -1356,12 +1370,7 @@ def TTNN_FullOp : TTNN_Op<"full"> {
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         mlir::tt::ttnn::FullOp op = mlir::cast<mlir::tt::ttnn::FullOp>(this->getOperation());
         auto outputType = mlir::cast<RankedTensorType>(op.getType());
-        ttnn::TTNNLayoutAttr layoutAttr =
-            mlir::cast<ttnn::TTNNLayoutAttr>(outputType.getEncoding());
-        if (outputType.getRank() > 1 || !layoutAttr.isTiled()) {
-          return wa::TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds(this->getOperation());
-        }
-        return wa::TTNNOperandsWorkaroundsFactory::createFullOpOperandsWorkarounds();
+        return wa::TTNNOperandsWorkaroundsFactory::createFullOpOperandsWorkarounds(outputType);
       }
     }];
 }

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkarounds.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkarounds.h
@@ -231,7 +231,8 @@ public:
   createCumSumOpOperandsWorkarounds(RankedTensorType inputType);
 
   // Create workarounds for full op operands.
-  static TTNNOperandsWorkarounds createFullOpOperandsWorkarounds();
+  static TTNNOperandsWorkarounds
+  createFullOpOperandsWorkarounds(RankedTensorType outputType);
 
   // Create workarounds for mesh shard op operands.
   static TTNNOperandsWorkarounds createMeshShardOpOperandsWorkarounds();
@@ -254,6 +255,12 @@ public:
   // Create workarounds for concat op operands.
   static TTNNOperandsWorkarounds
   createWhereOpOperandsWorkarounds(mlir::Operation::operand_range inputs);
+
+  static TTNNOperandsWorkarounds
+  createReshapeOpOperandsWorkarounds(RankedTensorType inputType);
+
+  static TTNNOperandsWorkarounds
+  createUpdateCacheOpOperandsWorkarounds(RankedTensorType updateIndex);
 };
 
 } // namespace mlir::tt::ttnn::wa

--- a/include/ttmlir/Target/Common/types.fbs
+++ b/include/ttmlir/Target/Common/types.fbs
@@ -29,6 +29,7 @@ enum DataType: uint16 {
   UInt32,
   UInt16,
   UInt8,
+  Int32,
 }
 
 enum OOBVal: ushort {

--- a/include/ttmlir/Target/TTNN/utils.h
+++ b/include/ttmlir/Target/TTNN/utils.h
@@ -66,12 +66,10 @@ toTargetTensorLayout(::mlir::tt::ttnn::Layout layout) {
 
 ::tt::target::DataType toTargetDataType(::mlir::tt::DataType dataType) {
   switch (dataType) {
-  case ::mlir::tt::DataType::BFloat16:
-    return ::tt::target::DataType::BFloat16;
   case ::mlir::tt::DataType::Float32:
     return ::tt::target::DataType::Float32;
-  case ::mlir::tt::DataType::UInt32:
-    return ::tt::target::DataType::UInt32;
+  case ::mlir::tt::DataType::BFloat16:
+    return ::tt::target::DataType::BFloat16;
   case ::mlir::tt::DataType::BFP_BFloat8:
     return ::tt::target::DataType::BFP_BFloat8;
   case ::mlir::tt::DataType::BFP_BFloat4:
@@ -80,6 +78,10 @@ toTargetTensorLayout(::mlir::tt::ttnn::Layout layout) {
     return ::tt::target::DataType::UInt8;
   case ::mlir::tt::DataType::UInt16:
     return ::tt::target::DataType::UInt16;
+  case ::mlir::tt::DataType::UInt32:
+    return ::tt::target::DataType::UInt32;
+  case ::mlir::tt::DataType::Int32:
+    return ::tt::target::DataType::Int32;
   case ::mlir::tt::DataType::Float16:
   case ::mlir::tt::DataType::BFP_Float2:
   case ::mlir::tt::DataType::BFP_Float4:

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -58,6 +58,7 @@ inline std::uint64_t getElementSizeBytes(DataType dtype) {
   case DataType::BFloat16:
     return 2;
   case DataType::UInt32:
+  case DataType::Int32:
     return 4;
   case DataType::UInt16:
     return 2;
@@ -98,6 +99,8 @@ inline ::tt::target::DataType toFlatbuffer(FlatbufferObjectCache &,
     return ::tt::target::DataType::UInt16;
   case DataType::UInt8:
     return ::tt::target::DataType::UInt8;
+  case DataType::Int32:
+    return ::tt::target::DataType::Int32;
   }
 }
 

--- a/lib/Conversion/TTNNToEmitC/Utils.cpp
+++ b/lib/Conversion/TTNNToEmitC/Utils.cpp
@@ -147,11 +147,8 @@ emitc::OpaqueAttr convertDType(Builder &builder, tt::DataTypeAttr attr) {
     return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::UINT8");
   case tt::DataType::UInt16:
     return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::UINT16");
-  // TODO(svuckovic):
-  // Add support for INT32
-  //
-  // case tt::DataType::Int32:
-  //   return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::INT32");
+  case tt::DataType::Int32:
+    return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::INT32");
   case tt::DataType::Float16:
   case tt::DataType::BFP_Float2:
   case tt::DataType::BFP_Float4:

--- a/lib/Dialect/TT/IR/TTOpsTypes.cpp
+++ b/lib/Dialect/TT/IR/TTOpsTypes.cpp
@@ -70,6 +70,8 @@ mlir::tt::SystemDescAttr::getDefault(MLIRContext *context) {
       tt::DataTypeAttr::get(context, tt::DataType::UInt16));
   supported_data_types.push_back(
       tt::DataTypeAttr::get(context, tt::DataType::UInt8));
+  supported_data_types.push_back(
+      tt::DataTypeAttr::get(context, tt::DataType::Int32));
 
   // populate a placeholder for supported tile sizes
   SmallVector<tt::TileSizeAttr> supported_tile_sizes;
@@ -262,6 +264,10 @@ mlir::tt::SystemDescAttr::getFromPath(MLIRContext *context, std::string &path) {
       case ::tt::target::DataType::UInt8:
         supported_data_types_attr.push_back(
             tt::DataTypeAttr::get(context, tt::DataType::UInt8));
+        break;
+      case ::tt::target::DataType::Int32:
+        supported_data_types_attr.push_back(
+            tt::DataTypeAttr::get(context, tt::DataType::Int32));
         break;
       }
     }
@@ -1174,6 +1180,7 @@ uint64_t TileType::getSizeBytes() const {
     assert(getHeight() == 32 && getWidth() == 32);
     return 256;
   case DataType::UInt32:
+  case DataType::Int32:
     return getHeight() * getWidth() * 4;
   case DataType::UInt16:
     return getHeight() * getWidth() * 2;

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -158,9 +158,9 @@ void mlir::tt::ttir::BitwiseXorOp::getCanonicalizationPatterns(
 mlir::tt::ttir::GetDimensionSizeOp::fold(FoldAdaptor adaptor) {
   RankedTensorType inputTensorType = getOperand().getType();
   uint32_t dimensionIndex = getDimension();
-  int32_t dimSize = inputTensorType.getShape()[dimensionIndex];
+  uint32_t dimSize = inputTensorType.getShape()[dimensionIndex];
 
-  return mlir::DenseElementsAttr::get<int32_t>(getType(), dimSize);
+  return mlir::DenseElementsAttr::get<uint32_t>(getType(), dimSize);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/IR/TTNNWorkarounds.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkarounds.cpp
@@ -199,12 +199,25 @@ TTNNOperandsWorkaroundsFactory::createCumSumOpOperandsWorkarounds(
 // ttnn::FullOp does not support 1D tilized tensors
 // If the output of full is a 1D tensor and is tiled
 // we need to convert it to row major layout then tilize separately
+// ttnn::full does not support output dtype int32. If the output data type of
+// full is int32, we override to uint32 and typecast separately.
 TTNNOperandsWorkarounds
-TTNNOperandsWorkaroundsFactory::createFullOpOperandsWorkarounds() {
-  wa::TTNNOperandWorkarounds rowMajorLayoutWorkaround;
-  rowMajorLayoutWorkaround.tensorLayoutWorkaround = Layout::RowMajor;
+TTNNOperandsWorkaroundsFactory::createFullOpOperandsWorkarounds(
+    RankedTensorType outputType) {
+  wa::TTNNOperandWorkarounds fullOpOutputWorkarounds;
+  ttnn::TTNNLayoutAttr layoutAttr =
+      mlir::cast<ttnn::TTNNLayoutAttr>(outputType.getEncoding());
+  if (outputType.getRank() == 1 && layoutAttr.isTiled()) {
+    fullOpOutputWorkarounds.tensorLayoutWorkaround = Layout::RowMajor;
+  }
+  mlir::tt::DataType dataType =
+      elementTypeToDataType(outputType.getElementType());
+  if (dataType == mlir::tt::DataType::Int32) {
+    fullOpOutputWorkarounds.tensorDataTypeWorkaround =
+        mlir::tt::DataType::UInt32;
+  }
   return wa::TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
-      .addOutputOperandWorkaround(rowMajorLayoutWorkaround);
+      .addOutputOperandWorkaround(fullOpOutputWorkarounds);
 }
 
 // Factory method to create a set of workarounds for mesh shard op input
@@ -356,5 +369,40 @@ TTNNOperandsWorkaroundsFactory::createWhereOpOperandsWorkarounds(
       .addInputOperandWorkaround(typeWorkaround)
       .addInputOperandWorkaround(typeWorkaround)
       .addOutputOperandWorkaround(typeWorkaround);
+}
+
+// Factory method to create a set of workarounds for reshape operation operands.
+// Reshape op only does not work with int32 - force to uint32 then typecast
+// separately.
+TTNNOperandsWorkarounds
+TTNNOperandsWorkaroundsFactory::createReshapeOpOperandsWorkarounds(
+    RankedTensorType inputType) {
+  mlir::Type inputElementType = inputType.getElementType();
+  TTNNOperandWorkarounds typeWorkarounds;
+  mlir::tt::DataType dataType = elementTypeToDataType(inputElementType);
+  if (dataType == mlir::tt::DataType::Int32) {
+    typeWorkarounds.tensorDataTypeWorkaround = mlir::tt::DataType::UInt32;
+  }
+  return TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
+      .addInputOperandWorkaround(typeWorkarounds)
+      .addOutputOperandWorkaround(typeWorkarounds);
+}
+
+// Factory method to create a set of workarounds for UpdateCache operation
+// operands. Update index of UpdateCacheOp must be unsigned
+TTNNOperandsWorkarounds
+TTNNOperandsWorkaroundsFactory::createUpdateCacheOpOperandsWorkarounds(
+    RankedTensorType updateIndex) {
+  mlir::Type updateIndexElementType = updateIndex.getElementType();
+  TTNNOperandWorkarounds nullWorkarounds;
+  TTNNOperandWorkarounds typeWorkarounds;
+  mlir::tt::DataType dataType = elementTypeToDataType(updateIndexElementType);
+  if (dataType == mlir::tt::DataType::Int32) {
+    typeWorkarounds.tensorDataTypeWorkaround = mlir::tt::DataType::UInt32;
+  }
+  return TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
+      .addInputOperandWorkaround(nullWorkarounds)
+      .addInputOperandWorkaround(nullWorkarounds)
+      .addInputOperandWorkaround(typeWorkarounds);
 }
 } // namespace mlir::tt::ttnn::wa

--- a/lib/OpModel/TTNN/Conversion.cpp
+++ b/lib/OpModel/TTNN/Conversion.cpp
@@ -36,6 +36,8 @@ getDataType(const mlir::tt::ttnn::TTNNLayoutAttr layout) {
     return ::tt::tt_metal::DataType::UINT16;
   case tt::DataType::UInt8:
     return ::tt::tt_metal::DataType::UINT8;
+  case tt::DataType::Int32:
+    return ::tt::tt_metal::DataType::INT32;
   default:
     throw std::runtime_error("Invalid element type");
   }

--- a/python/OptimizerOverrides.cpp
+++ b/python/OptimizerOverrides.cpp
@@ -108,7 +108,8 @@ void populateOptimizerOverridesModule(py::module &m) {
       .value("BFP_BFloat2", mlir::tt::DataType::BFP_BFloat2)
       .value("UInt32", mlir::tt::DataType::UInt32)
       .value("UInt16", mlir::tt::DataType::UInt16)
-      .value("UInt8", mlir::tt::DataType::UInt8);
+      .value("UInt8", mlir::tt::DataType::UInt8)
+      .value("Int32", mlir::tt::DataType::Int32);
 
   py::class_<mlir::tt::ttnn::InputLayoutOverrideParams>(
       m, "InputLayoutOverrideParams")

--- a/runtime/include/tt/runtime/utils.h
+++ b/runtime/include/tt/runtime/utils.h
@@ -32,6 +32,7 @@ inline std::uint32_t dataTypeElementSize(::tt::target::DataType dataType) {
   case ::tt::target::DataType::BFloat16:
     return 2;
   case ::tt::target::DataType::UInt32:
+  case ::tt::target::DataType::Int32:
     return 4;
   case ::tt::target::DataType::UInt16:
     return 2;

--- a/runtime/lib/common/system_desc.cpp
+++ b/runtime/lib/common/system_desc.cpp
@@ -195,7 +195,8 @@ static std::unique_ptr<::tt::runtime::SystemDesc> getCurrentSystemDescImpl(
         ::tt::target::DataType::BFP_BFloat8, ::tt::target::DataType::BFP_Float4,
         ::tt::target::DataType::BFP_BFloat4, ::tt::target::DataType::BFP_Float2,
         ::tt::target::DataType::BFP_BFloat2, ::tt::target::DataType::UInt32,
-        ::tt::target::DataType::UInt16,      ::tt::target::DataType::UInt8};
+        ::tt::target::DataType::UInt16,      ::tt::target::DataType::UInt8,
+        ::tt::target::DataType::Int32};
 
     auto supportedDataTypes = fbb.CreateVector(supportedDataTypesVector);
 

--- a/runtime/lib/ttmetal/command_queue.cpp
+++ b/runtime/lib/ttmetal/command_queue.cpp
@@ -345,6 +345,8 @@ static ::tt::DataFormat toDataFormat(::tt::target::DataType dataType) {
     return ::tt::DataFormat::UInt16;
   case ::tt::target::DataType::UInt8:
     return ::tt::DataFormat::UInt8;
+  case ::tt::target::DataType::Int32:
+    return ::tt::DataFormat::Int32;
   default:
     LOG_FATAL("Unsupported data type");
   }

--- a/runtime/lib/ttnn/include/tt/runtime/ttnn/utils.h
+++ b/runtime/lib/ttnn/include/tt/runtime/ttnn/utils.h
@@ -78,6 +78,11 @@ struct NativeDType<::tt::target::DataType::UInt8> {
   using type = uint8_t;
 };
 
+template <>
+struct NativeDType<::tt::target::DataType::Int32> {
+  using type = int32_t;
+};
+
 template <::tt::target::DataType DataType>
 using NativeDTypeT = typename NativeDType<DataType>::type;
 

--- a/runtime/lib/ttnn/operations/eltwise/binary/binary_composite.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/binary/binary_composite.cpp
@@ -16,18 +16,10 @@ static void runEltwiseBinaryCompositeOp(
         ::ttnn::Tensor(const ::ttnn::Tensor &, const ::ttnn::Tensor &,
                        const std::optional<::ttnn::MemoryConfig> &)> &ttnnOp) {
 
-  ::ttnn::Tensor lhs, rhs;
-  getEltwiseBinaryOpInputTensors(op, tensorPool, lhs, rhs);
+  ::ttnn::Tensor *lhs = nullptr;
+  ::ttnn::Tensor *rhs = nullptr;
 
-  // TODO (#2272): Support for int32 is added in #2272
-  // However to_layout ops are not cannonicalized properly, blocking #2272
-  // This is a hack to unblock metal uplifts for now until #2272 is merged
-  if (lhs.get_dtype() == ::ttnn::DataType::UINT32) {
-    lhs = ::ttnn::typecast(lhs, ::ttnn::DataType::INT32);
-  }
-  if (rhs.get_dtype() == ::ttnn::DataType::UINT32) {
-    rhs = ::ttnn::typecast(rhs, ::ttnn::DataType::INT32);
-  }
+  getEltwiseBinaryOpInputTensors(op, tensorPool, &lhs, &rhs);
 
   std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
       ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
@@ -36,16 +28,7 @@ static void runEltwiseBinaryCompositeOp(
                  outputMemoryConfig.has_value(),
              "Memory config must exist for device tensors");
 
-  ::ttnn::Tensor out = ttnnOp(lhs, rhs, outputMemoryConfig);
-
-  // TODO (#2272): Support for int32 is added in #2272
-  // However to_layout ops are not cannonicalized properly, blocking #2272
-  // This is a hack to unblock metal uplifts for now until #2272 is merged
-  ::ttnn::DataType outputDataType = utils::getDataType(op->out());
-  if (out.get_dtype() == ::ttnn::DataType::INT32 &&
-      outputDataType == ::ttnn::DataType::UINT32) {
-    out = ::ttnn::typecast(out, ::ttnn::DataType::UINT32);
-  }
+  ::ttnn::Tensor out = ttnnOp(*lhs, *rhs, outputMemoryConfig);
 
   tensorPool.insert_or_assign(op->out()->global_id(), out);
 }

--- a/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/eltwise/binary/utils.cpp
+++ b/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/eltwise/binary/utils.cpp
@@ -8,30 +8,31 @@
 namespace tt::runtime::ttnn::operations::binary {
 
 bool shouldSwapBinaryOperands(const ::tt::target::ttnn::EltwiseOp *op,
-                              const ::ttnn::Tensor &lhs, ::ttnn::Tensor &rhs) {
+                              const ::ttnn::Tensor *lhs, ::ttnn::Tensor *rhs) {
   // For scatter, we expect the left-hand side operator to be lesser or equal in
   // volume to the right hand side, so we omit the swap.
   return (op->type() != ::tt::target::ttnn::EltwiseOpType::Scatter &&
           workaround::Env::get().swapBinaryOperands &&
-          lhs.volume() < rhs.volume());
+          lhs->volume() < rhs->volume());
 }
 
 void getEltwiseBinaryOpInputTensors(const ::tt::target::ttnn::EltwiseOp *op,
                                     ProgramTensorPool &tensorPool,
-                                    ::ttnn::Tensor &lhs, ::ttnn::Tensor &rhs) {
+                                    ::ttnn::Tensor **lhs,
+                                    ::ttnn::Tensor **rhs) {
 
   LOG_ASSERT(op->ins()->size() == 2, "Expected 2 inputs");
-  lhs = tensorPool.at(op->ins()->Get(0)->global_id());
-  rhs = tensorPool.at(op->ins()->Get(1)->global_id());
-  DEBUG_ASSERT(lhs.is_allocated());
-  DEBUG_ASSERT(rhs.is_allocated());
+  *lhs = &(tensorPool.at(op->ins()->Get(0)->global_id()));
+  *rhs = &(tensorPool.at(op->ins()->Get(1)->global_id()));
+  DEBUG_ASSERT((*lhs)->is_allocated());
+  DEBUG_ASSERT((*rhs)->is_allocated());
 
   // Switch the order of operands if the second operand requires broadcast
   // TODO(bug #1124): We're currently swapping the operands for binary ops
   // in runtime if the lhs operand is smaller (and requires broadcast onto the
   // rhs operand). We should add this check in the compiler.
-  if (shouldSwapBinaryOperands(op, lhs, rhs)) {
-    std::swap(lhs, rhs);
+  if (shouldSwapBinaryOperands(op, *lhs, *rhs)) {
+    std::swap(*lhs, *rhs);
   }
 }
 

--- a/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/eltwise/binary/utils.h
+++ b/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/eltwise/binary/utils.h
@@ -13,7 +13,7 @@ namespace tt::runtime::ttnn::operations::binary {
 
 void getEltwiseBinaryOpInputTensors(const ::tt::target::ttnn::EltwiseOp *op,
                                     ProgramTensorPool &tensorPool,
-                                    ::ttnn::Tensor &lhs, ::ttnn::Tensor &rhs);
+                                    ::ttnn::Tensor **lhs, ::ttnn::Tensor **rhs);
 
 } // namespace tt::runtime::ttnn::operations::binary
 

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -67,6 +67,8 @@ static StorageType createStorage(void *ptr, std::uint32_t numElements,
                                       numElements);
   case ::tt::target::DataType::UInt8:
     return createStorage<StorageType>(static_cast<uint8_t *>(ptr), numElements);
+  case ::tt::target::DataType::Int32:
+    return createStorage<StorageType>(static_cast<int32_t *>(ptr), numElements);
   default:
     LOG_FATAL("Unsupported data type");
   }

--- a/runtime/lib/ttnn/utils/utils.cpp
+++ b/runtime/lib/ttnn/utils/utils.cpp
@@ -64,6 +64,8 @@ bool isSharded(
     return ::ttnn::DataType::UINT16;
   case ::tt::target::DataType::UInt8:
     return ::ttnn::DataType::UINT8;
+  case ::tt::target::DataType::Int32:
+    return ::ttnn::DataType::INT32;
 
   default:
     LOG_FATAL("Unsupported data type");
@@ -86,6 +88,8 @@ bool isSharded(
     return ::tt::target::DataType::UInt16;
   case ::ttnn::DataType::UINT8:
     return ::tt::target::DataType::UInt8;
+  case ::ttnn::DataType::INT32:
+    return ::tt::target::DataType::Int32;
 
   default:
     LOG_FATAL("Unsupported data type");

--- a/runtime/tools/python/ttrt/binary/module.cpp
+++ b/runtime/tools/python/ttrt/binary/module.cpp
@@ -103,6 +103,11 @@ PYBIND11_MODULE(_C, m) {
           size = sizeof(uint32_t);
           break;
 
+        case tt::target::DataType::Int32:
+          format = py::format_descriptor<int32_t>::format();
+          size = sizeof(int32_t);
+          break;
+
         case tt::target::DataType::Float32:
           format = py::format_descriptor<float>::format();
           size = sizeof(float);

--- a/runtime/tools/python/ttrt/common/run.py
+++ b/runtime/tools/python/ttrt/common/run.py
@@ -836,7 +836,7 @@ class Run:
         def randn(shape, dtype):
             import torch
 
-            if dtype in (torch.uint8, torch.uint16, torch.uint32):
+            if dtype in (torch.uint8, torch.uint16, torch.uint32, torch.int32):
                 high = torch.iinfo(dtype).max + 1
                 return torch.randint(0, high, shape, dtype=dtype)
 

--- a/runtime/tools/python/ttrt/common/util.py
+++ b/runtime/tools/python/ttrt/common/util.py
@@ -663,6 +663,8 @@ class Binary(Flatbuffer):
                 return ttrt.runtime.DataType.UInt16
             if dtype == torch.uint8:
                 return ttrt.runtime.DataType.UInt8
+            if dtype == torch.int32:
+                return ttrt.runtime.DataType.Int32
             raise ValueError(f"unsupported dtype: {dtype}")
 
         @staticmethod
@@ -681,6 +683,8 @@ class Binary(Flatbuffer):
                 return torch.uint16
             if dtype == "UInt8":
                 return torch.uint8
+            if dtype == "Int32":
+                return torch.int32
             raise ValueError(f"unsupported dtype: {dtype}")
 
 

--- a/runtime/tools/python/ttrt/runtime/module.cpp
+++ b/runtime/tools/python/ttrt/runtime/module.cpp
@@ -60,7 +60,8 @@ PYBIND11_MODULE(_C, m) {
       .value("BFP_BFloat2", ::tt::target::DataType::BFP_BFloat2)
       .value("UInt32", ::tt::target::DataType::UInt32)
       .value("UInt16", ::tt::target::DataType::UInt16)
-      .value("UInt8", ::tt::target::DataType::UInt8);
+      .value("UInt8", ::tt::target::DataType::UInt8)
+      .value("Int32", ::tt::target::DataType::Int32);
   py::enum_<::tt::runtime::DeviceRuntime>(m, "DeviceRuntime")
       .value("Disabled", ::tt::runtime::DeviceRuntime::Disabled)
       .value("TTNN", ::tt::runtime::DeviceRuntime::TTNN)

--- a/test/ttmlir/Dialect/TTNN/data_movement/repeat/repeat_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/data_movement/repeat/repeat_workaround.mlir
@@ -3,7 +3,7 @@ module {
   func.func @main(%arg0: tensor<1x16x32xf32>, %arg1: tensor<1x1x32xf32>) -> tensor<1x16x32xf32> {
     // CHECK: %[[VAL0:[0-9]+]] = "ttnn.full"
     // CHECK-SAME: fillValue = 0.000000e+00 : f32
-    // CHECK: %{{[0-9]+}} = "ttnn.add"(%arg1, %[[VAL0]])
+    // CHECK: %{{[0-9]+}} = "ttnn.add"(%arg1, %{{[0-9]+}})
     // CHECK-NOT: "ttnn.repeat"
     %0 = tensor.empty() : tensor<1x16x32xf32>
     %1 = "ttir.broadcast"(%arg1, %0) <{broadcast_dimensions = array<i64: 1, 16, 1>}> : (tensor<1x1x32xf32>, tensor<1x16x32xf32>) -> tensor<1x16x32xf32>

--- a/test/ttmlir/Dialect/TTNN/data_movement/reshape/reshape_folding_test.mlir
+++ b/test/ttmlir/Dialect/TTNN/data_movement/reshape/reshape_folding_test.mlir
@@ -5,7 +5,7 @@ module @reshape_test {
     %0 = tensor.empty() : tensor<1xi32>
     %1 = "ttir.reshape"(%arg0, %0) <{shape = [1 : i32]}> : (tensor<1xi32>, tensor<1xi32>) -> tensor<1xi32>
     // CHECK-NOT: = "ttnn.reshape"[C:.*]]
-    // CHECK: return %arg0 : tensor<1xui32, #{{.*}}>
+    // CHECK: return %arg0 : tensor<1xsi32, #{{.*}}>
     return %1 : tensor<1xi32>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/binary/bitwise_and/simple_bitwise_and.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/binary/bitwise_and/simple_bitwise_and.mlir
@@ -5,9 +5,9 @@ module attributes {} {
     %0 = tensor.empty() : tensor<64x128xi32>
     %1 = "ttir.bitwise_and"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xi32>, tensor<64x128xi32>, tensor<64x128xi32>) -> tensor<64x128xi32>
     // CHECK: "ttnn.bitwise_and"
-    // CHECK-SAME: tensor<64x128xui32
-    // CHECK-SAME: tensor<64x128xui32
-    // CHECK-SAME: -> tensor<64x128xui32
+    // CHECK-SAME: tensor<64x128xsi32
+    // CHECK-SAME: tensor<64x128xsi32
+    // CHECK-SAME: -> tensor<64x128xsi32
     return %1 : tensor<64x128xi32>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/binary/bitwise_or/simple_bitwise_or.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/binary/bitwise_or/simple_bitwise_or.mlir
@@ -5,9 +5,9 @@ module attributes {} {
     %0 = tensor.empty() : tensor<64x128xi32>
     %1 = "ttir.bitwise_or"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xi32>, tensor<64x128xi32>, tensor<64x128xi32>) -> tensor<64x128xi32>
     // CHECK: "ttnn.bitwise_or"
-    // CHECK-SAME: tensor<64x128xui32
-    // CHECK-SAME: tensor<64x128xui32
-    // CHECK-SAME: -> tensor<64x128xui32
+    // CHECK-SAME: tensor<64x128xsi32
+    // CHECK-SAME: tensor<64x128xsi32
+    // CHECK-SAME: -> tensor<64x128xsi32
     return %1 : tensor<64x128xi32>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/binary/bitwise_xor/simple_bitwise_xor.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/binary/bitwise_xor/simple_bitwise_xor.mlir
@@ -5,9 +5,9 @@ module attributes {} {
     %0 = tensor.empty() : tensor<64x128xi32>
     %1 = "ttir.bitwise_xor"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xi32>, tensor<64x128xi32>, tensor<64x128xi32>) -> tensor<64x128xi32>
     // CHECK: "ttnn.bitwise_xor"
-    // CHECK-SAME: tensor<64x128xui32
-    // CHECK-SAME: tensor<64x128xui32
-    // CHECK-SAME: -> tensor<64x128xui32
+    // CHECK-SAME: tensor<64x128xsi32
+    // CHECK-SAME: tensor<64x128xsi32
+    // CHECK-SAME: -> tensor<64x128xsi32
     return %1 : tensor<64x128xi32>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/unary/bitwise_not/simple_bitwise_not.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/unary/bitwise_not/simple_bitwise_not.mlir
@@ -5,8 +5,8 @@ module attributes {} {
     %0 = tensor.empty() : tensor<64x128xi32>
     %1 = "ttir.bitwise_not"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xi32>, tensor<64x128xi32>) -> tensor<64x128xi32>
     // CHECK: "ttnn.bitwise_not"
-    // CHECK-SAME: tensor<64x128xui32
-    // CHECK-SAME: -> tensor<64x128xui32
+    // CHECK-SAME: tensor<64x128xsi32
+    // CHECK-SAME: -> tensor<64x128xsi32
     return %1 : tensor<64x128xi32>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/reduction/simple_argmax.mlir
+++ b/test/ttmlir/Dialect/TTNN/reduction/simple_argmax.mlir
@@ -7,8 +7,8 @@ module attributes {} {
     // CHECK: "ttnn.argmax"
     // CHECK-SAME: {dim = 1 : i32, use_multicore = false}>
     // CHECK-SAME: tensor<64x64xf32
-    // CHECK-SAME: tensor<64x1xui32
-    // CHECK-SAME: -> tensor<64x1xui32
+    // CHECK-SAME: tensor<64x1xsi32
+    // CHECK-SAME: -> tensor<64x1xsi32
     %1 = "ttir.argmax"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<64x64xf32>, tensor<64x1xi32>) -> tensor<64x1xi32>
     return %1 : tensor<64x1xi32>
   }
@@ -19,12 +19,13 @@ module attributes {} {
     // CHECK: %[[ARGMAX:[0-9]+]] = "ttnn.argmax"
     // CHECK-SAME: {dim = 2 : i32, use_multicore = false}>
     // CHECK-SAME: tensor<128x28x28xf32
-    // CHECK-SAME: tensor<128x28x1xui32
+    // CHECK: %[[TYPECAST:[0-9]+]] = "ttnn.typecast"(%[[ARGMAX]])
     // CHECK-SAME: -> tensor<128x28x1xui32
-    // CHECK: "ttnn.reshape"(%[[ARGMAX]])
+    // CHECK: %[[RESHAPE:[0-9]+]] = "ttnn.reshape"(%[[TYPECAST]])
     // CHECK-SAME: <{shape = [128 : i32, 28 : i32]}>
-    // CHECK-SAME: tensor<128x28x1xui32
     // CHECK-SAME: -> tensor<128x28xui32
+    // CHECK: "ttnn.typecast"(%[[RESHAPE]])
+    // CHECK-SAME: -> tensor<128x28xsi32
     %1 = "ttir.argmax"(%arg0, %0) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<128x28x28xf32>, tensor<128x28xi32>) -> tensor<128x28xi32>
     return %1 : tensor<128x28xi32>
   }
@@ -35,12 +36,13 @@ module attributes {} {
     // CHECK: %[[ARGMAX:[0-9]+]] = "ttnn.argmax"
     // CHECK-SAME: {dim = 3 : i32, use_multicore = false}>
     // CHECK-SAME: tensor<4x8x128x64xf32
-    // CHECK-SAME: tensor<4x8x128x1xui32
+    // CHECK: %[[TYPECAST:[0-9]+]] = "ttnn.typecast"(%[[ARGMAX]])
     // CHECK-SAME: -> tensor<4x8x128x1xui32
-    // CHECK: "ttnn.reshape"(%[[ARGMAX]])
+    // CHECK: %[[RESHAPE:[0-9]+]] = "ttnn.reshape"(%[[TYPECAST]])
     // CHECK-SAME: <{shape = [4 : i32, 8 : i32, 128 : i32]}>
-    // CHECK-SAME: tensor<4x8x128x1xui32
     // CHECK-SAME: -> tensor<4x8x128xui32
+    // CHECK: "ttnn.typecast"(%[[RESHAPE]])
+    // CHECK-SAME: -> tensor<4x8x128xsi32
     %1 = "ttir.argmax"(%arg0, %0) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<4x8x128x64xf32>, tensor<4x8x128xi32>) -> tensor<4x8x128xi32>
     return %1 : tensor<4x8x128xi32>
   }

--- a/test/ttmlir/Dialect/TTNN/simple_constant.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_constant.mlir
@@ -56,6 +56,8 @@ module attributes {} {
     // CHECK: %{{[0-9]+}} = "ttnn.full"
     // CHECK-SAME: fillValue = 1.000000e+00 : f32
     // CHECK-SAME: tensor<64x128xui32
+    // CHECK: %{{[0-9]+}} = "ttnn.typecast"
+    // CHECK-SAME: tensor<64x128xsi32
     %0 = "ttir.constant"() <{value = dense<1> : tensor<64x128xi32>}> : () -> tensor<64x128xi32>
     return %0 : tensor<64x128xi32>
   }

--- a/test/ttmlir/Dialect/TTNN/typecast.mlir
+++ b/test/ttmlir/Dialect/TTNN/typecast.mlir
@@ -58,7 +58,7 @@ module {
   }
   func.func public @main9(%arg0: tensor<32x32xi32>) -> tensor<32x32xui32> {
     %0 = tensor.empty() : tensor<32x32xui32>
-    // CHECK-NOT: "ttnn.typecast"
+    // CHECK: "ttnn.typecast"
     %1 = "ttir.typecast"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xi32>, tensor<32x32xui32>) -> tensor<32x32xui32>
     // CHECK: return {{.*}} : tensor<32x32xui32
     return %1 : tensor<32x32xui32>

--- a/test/ttmlir/Silicon/StableHLO/n150/Binary/concat_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Binary/concat_op.mlir
@@ -87,15 +87,15 @@ module @jit_concat attributes {} {
     // CHECK-LABEL: func.func public @test_concat_5
     // CHECK: %[[ARG0:[0-9]+]] = "ttnn.typecast"
     // CHECK-SAME: dtype = #tt.supportedDataTypes<bf16>
-    // CHECK-SAME: tensor<1x53xui32
+    // CHECK-SAME: tensor<1x53xsi32
     // CHECK-SAME: -> tensor<1x53xbf16
     // CHECK: %[[ARG1:[0-9]+]] = "ttnn.typecast"
     // CHECK-SAME: dtype = #tt.supportedDataTypes<bf16>
-    // CHECK-SAME: tensor<1x1xui32
+    // CHECK-SAME: tensor<1x1xsi32
     // CHECK-SAME: -> tensor<1x1xbf16
     // CHECK: %[[ARG2:[0-9]+]] = "ttnn.typecast"
     // CHECK-SAME: dtype = #tt.supportedDataTypes<bf16>
-    // CHECK-SAME: tensor<1x54xui32
+    // CHECK-SAME: tensor<1x54xsi32
     // CHECK-SAME: -> tensor<1x54xbf16
     // CHECK: %[[CONCAT:[0-9]+]] = "ttnn.concat"(%[[ARG0]], %[[ARG1]], %[[ARG2]])
     // CHECK-SAME: dim = 1 : si32
@@ -105,9 +105,9 @@ module @jit_concat attributes {} {
     // CHECK-SAME: -> tensor<1x54xbf16
     %0 = stablehlo.concatenate %arg0, %arg1, dim = 1 : (tensor<1x53xi64>, tensor<1x1xi64>) -> tensor<1x54xi64>
     // CHECK: "ttnn.typecast"(%[[CONCAT]])
-    // CHECK-SAME: dtype = #tt.supportedDataTypes<u32>
+    // CHECK-SAME: dtype = #tt.supportedDataTypes<si32>
     // CHECK-SAME: tensor<1x54xbf16
-    // CHECK-SAME: -> tensor<1x54xui32
+    // CHECK-SAME: -> tensor<1x54xsi32
     return %0 : tensor<1x54xi64>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/Constant/constant_i32.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Constant/constant_i32.mlir
@@ -12,6 +12,8 @@ module @jit_constant attributes {} {
     // CHECK: ttnn.full
     // CHECK-SAME: fillValue = 3.000000e+00 : f32
     // CHECK-SAME: -> tensor<1xui32
+    // CHECK: ttnn.typecast
+    // CHECK-SAME: -> tensor<1xsi32
     %0 = stablehlo.constant dense<3> : tensor<i32>
     return %0 : tensor<i32>
   }
@@ -20,6 +22,8 @@ module @jit_constant attributes {} {
     // CHECK-LABEL: func.func public @test_int32_scalar_empty
     // CHECK: ttnn.full
     // CHECK-SAME: -> tensor<1xui32
+    // CHECK: ttnn.typecast
+    // CHECK-SAME: -> tensor<1xsi32
     %0 = stablehlo.constant dense<0> : tensor<i32>
     return %0 : tensor<i32>
   }
@@ -28,6 +32,8 @@ module @jit_constant attributes {} {
     // CHECK-LABEL: func.func public @test_int32_empty
     // CHECK: ttnn.full
     // CHECK-SAME: -> tensor<64x128xui32
+    // CHECK: ttnn.typecast
+    // CHECK-SAME: -> tensor<64x128xsi32
     %0 = stablehlo.constant dense<0> : tensor<64x128xi32>
     return %0 : tensor<64x128xi32>
   }
@@ -37,6 +43,8 @@ module @jit_constant attributes {} {
     // CHECK: ttnn.full
     // CHECK-SAME: fillValue = 3.000000e+00 : f32
     // CHECK-SAME: -> tensor<64x128xui32
+    // CHECK: ttnn.typecast
+    // CHECK-SAME: -> tensor<64x128xsi32
     %0 = stablehlo.constant dense<3> : tensor<64x128xi32>
     return %0 : tensor<64x128xi32>
   }

--- a/test/ttmlir/Silicon/StableHLO/n150/Constant/constant_i64.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Constant/constant_i64.mlir
@@ -12,6 +12,8 @@ module @jit_constant attributes {} {
     // CHECK: ttnn.full
     // CHECK-SAME: fillValue = 3.000000e+00 : f32
     // CHECK-SAME: -> tensor<1xui32
+    // CHECK: ttnn.typecast
+    // CHECK-SAME: -> tensor<1xsi32
     %0 = stablehlo.constant dense<3> : tensor<i64>
     return %0 : tensor<i64>
   }
@@ -20,6 +22,8 @@ module @jit_constant attributes {} {
     // CHECK-LABEL: func.func public @test_int64_scalar_empty
     // CHECK: ttnn.full
     // CHECK-SAME: -> tensor<1xui32
+    // CHECK: ttnn.typecast
+    // CHECK-SAME: -> tensor<1xsi32
     %0 = stablehlo.constant dense<0> : tensor<i64>
     return %0 : tensor<i64>
   }
@@ -28,6 +32,8 @@ module @jit_constant attributes {} {
     // CHECK-LABEL: func.func public @test_int64_empty
     // CHECK: ttnn.full
     // CHECK-SAME: -> tensor<64x128xui32
+    // CHECK: ttnn.typecast
+    // CHECK-SAME: -> tensor<64x128xsi32
     %0 = stablehlo.constant dense<0> : tensor<64x128xi64>
     return %0 : tensor<64x128xi64>
   }
@@ -37,6 +43,8 @@ module @jit_constant attributes {} {
     // CHECK: ttnn.full
     // CHECK-SAME: fillValue = 3.000000e+00 : f32
     // CHECK-SAME: -> tensor<64x128xui32
+    // CHECK: ttnn.typecast
+    // CHECK-SAME: -> tensor<64x128xsi32
     %0 = stablehlo.constant dense<3> : tensor<64x128xi64>
     return %0 : tensor<64x128xi64>
   }

--- a/test/ttmlir/Silicon/StableHLO/n150/moreh_cumsum_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/moreh_cumsum_op.mlir
@@ -79,15 +79,15 @@ module @moreh_cumsum attributes {} {
     // CHECK-SAME: tensor<1x10xui32
     // CHECK-SAME: -> tensor<1x10x1x1xui32
     // CHECK: %[[EMPTY:[0-9]+]] = "ttnn.empty"
-    // CHECK-SAME: {dtype = #tt.supportedDataTypes<u32>
-    // CHECK-SAME: -> tensor<1x10x1x1xui32
+    // CHECK-SAME: {dtype = #tt.supportedDataTypes<si32>
+    // CHECK-SAME: -> tensor<1x10x1x1xsi32
     // CHECK: %[[ARG0:[0-9]+]] = "ttnn.typecast"(%[[RESHAPE]])
     // CHECK-SAME: {dtype = #tt.supportedDataTypes<f32>}
     // CHECK-SAME: tensor<1x10x1x1xui32
     // CHECK-SAME: -> tensor<1x10x1x1xf32
     // CHECK: %[[ARG1:[0-9]+]] = "ttnn.typecast"(%[[EMPTY]])
     // CHECK-SAME: {dtype = #tt.supportedDataTypes<f32>}
-    // CHECK-SAME: tensor<1x10x1x1xui32
+    // CHECK-SAME: tensor<1x10x1x1xsi32
     // CHECK-SAME: -> tensor<1x10x1x1xf32
     // CHECK: %[[CUMSUM:[0-9]+]] = "ttnn.moreh_cumsum"(%[[ARG0]], %[[ARG1]])
     // CHECK-SAME: <{dim = 1 : i64}>
@@ -96,12 +96,15 @@ module @moreh_cumsum attributes {} {
     // CHECK-SAME: -> tensor<1x10x1x1xf32
     // CHECK: %[[TYPECAST:[0-9]+]] = "ttnn.typecast"(%[[CUMSUM]])
     // CHECK-SAME: {dtype = #tt.supportedDataTypes<u32>}
-    // CHECK-SMAE: tensor<1x10x1x1xf32
+    // CHECK-SAME: tensor<1x10x1x1xf32
     // CHECK-SAME: -> tensor<1x10x1x1xui32
-    // CHECK: "ttnn.reshape"(%[[TYPECAST]])
+    // CHECK: %[[RESHAPE_FINAL:[0-9]+]] = "ttnn.reshape"(%[[TYPECAST]])
     // CHECK-SAME: <{shape = [1 : i32, 10 : i32]}>
     // CHECK-SAME: tensor<1x10x1x1xui32
     // CHECK-SAME: -> tensor<1x10xui32
+    // CHECK: "ttnn.typecast"(%[[RESHAPE_FINAL]])
+    // CHECK-SAME: {dtype = #tt.supportedDataTypes<si32>}
+    // CHECK-SAME: tensor<1x10xsi32
     %0 = "stablehlo.reduce_window"(%arg0, %c) <{padding = dense<[[0, 0], [9, 0]]> : tensor<2x2xi64>, window_dilations = array<i64: 1, 1>, window_dimensions = array<i64: 1, 10>, window_strides = array<i64: 1, 1>}> ({
     ^bb0(%arg1: tensor<i64>, %arg2: tensor<i64>):
       %1 = stablehlo.add %arg1, %arg2 : tensor<i64>

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/binary/add/add_int32.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/binary/add/add_int32.mlir
@@ -6,8 +6,8 @@ func.func @addint32(%arg0: tensor<64x128xi32>, %arg1: tensor<64x128xi32>) -> ten
   %0 = tensor.empty() : tensor<64x128xi32>
   %1 = "ttir.add"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xi32>, tensor<64x128xi32>, tensor<64x128xi32>) -> tensor<64x128xi32>
   // CHECK: "ttnn.add"
-  // CHECK-SAME: tensor<64x128xui32
-  // CHECK-SAME: tensor<64x128xui32
-  // CHECK-SAME: -> tensor<64x128xui32
+  // CHECK-SAME: tensor<64x128xsi32
+  // CHECK-SAME: tensor<64x128xsi32
+  // CHECK-SAME: -> tensor<64x128xsi32
   return %1 : tensor<64x128xi32>
 }

--- a/test/unittests/OpModel/TTNN/Conversion/TestConversion.cpp
+++ b/test/unittests/OpModel/TTNN/Conversion/TestConversion.cpp
@@ -74,7 +74,9 @@ INSTANTIATE_TEST_SUITE_P(
                       std::make_tuple(mlir::tt::DataType::UInt16,
                                       ::tt::tt_metal::DataType::UINT16),
                       std::make_tuple(mlir::tt::DataType::UInt8,
-                                      ::tt::tt_metal::DataType::UINT8)));
+                                      ::tt::tt_metal::DataType::UINT8),
+                      std::make_tuple(mlir::tt::DataType::Int32,
+                                      ::tt::tt_metal::DataType::INT32)));
 
 //================================================================================
 // getShardShape


### PR DESCRIPTION
### Problem description
We don't support signed integers in tt-mlir, and we've been shifting to uint32 when encountering signed/signless integers. With newest metal uplift, binary ops will assert on uint32 (they used to run with uint32 but produce garbage data), therefore we need to add int32 support in our stack.

### What's changed
* Added int32 data type end to end
* Convert signed and signless integers to `TT_Int32`
* Added workarounds for full op and reshape op to typecast to uint32 if input/output datatypes are int32.

### Checklist
- [X] New/Existing tests provide coverage for changes
- [x] Remove TODO 2272 workaround in ops to force INT32

FYI @brataTT @kmabeeTT please try the uplift on top of my branch and see if the asserts go away. If needed we might want to merge this branch before the 24 hour limit to support the uplift.
