### PR TITLE
Adding memory config to a reshape op

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -953,8 +953,8 @@ def TTNN_ConcatOp : TTNN_Op<"concat", [HasMemoryConfigTrait]> {
     let hasVerifier = 1;
 }
 
-def TTNN_ReshapeOp : TTNN_Op<"reshape",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+def TTNN_ReshapeOp : TTNN_Op<"reshape", [HasMemoryConfigTrait,
+      DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
       > {
     let summary = "Reshape op.";
     let description = [{
@@ -962,7 +962,8 @@ def TTNN_ReshapeOp : TTNN_Op<"reshape",
     }];
 
     let arguments = (ins AnyRankedTensor:$input,
-                         I32ArrayAttr:$shape);
+                         I32ArrayAttr:$shape,
+                         OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
 
     let results = (outs AnyRankedTensor:$result);
 

--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceOpsRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceOpsRewritePattern.h
@@ -95,7 +95,7 @@ private:
         llvm::SmallVector<int32_t>(outputType.getShape()));
 
     rewriter.replaceOpWithNewOp<mlir::tt::ttnn::ReshapeOp>(
-        srcOp, outputType, newReduceOp, shapeAttr);
+        srcOp, outputType, newReduceOp, shapeAttr, /* memory_config */ nullptr);
   }
 
   // Determine if the workaround is required.

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -267,6 +267,7 @@ table ReshapeOp {
   in: tt.target.ttnn.TensorRef;
   out: tt.target.ttnn.TensorRef;
   shape: [int32];
+  memory_config: tt.target.ttnn.MemoryConfig;
 }
 
 table RepeatOp {

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -671,7 +671,7 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     rewriter.replaceOpWithNewOp<ttnn::ReshapeOp>(
         op, this->getTypeConverter()->convertType(op.getType()),
-        adaptor.getInput(), adaptor.getShape());
+        adaptor.getInput(), adaptor.getShape(), /* memory_config */ nullptr);
     return success();
   }
 };
@@ -731,7 +731,7 @@ public:
     // Replace the SqueezeOp with a ReshapeOp
     rewriter.replaceOpWithNewOp<ttnn::ReshapeOp>(
         op, this->getTypeConverter()->convertType(op.getType()),
-        adaptor.getInput(), shapeAttr);
+        adaptor.getInput(), shapeAttr, /* memory_config */ nullptr);
 
     return success();
   }
@@ -854,7 +854,7 @@ public:
     // Replace the UnsqueezeOp with a ReshapeOp
     rewriter.replaceOpWithNewOp<ttnn::ReshapeOp>(
         op, this->getTypeConverter()->convertType(op.getType()),
-        adaptor.getInput(), shapeAttr);
+        adaptor.getInput(), shapeAttr, /* memory_config */ nullptr);
 
     return success();
   }

--- a/lib/Conversion/TTIRToTTNN/Utils.cpp
+++ b/lib/Conversion/TTIRToTTNN/Utils.cpp
@@ -27,8 +27,9 @@ ttnn::ReshapeOp generateReshape(mlir::TypedValue<mlir::RankedTensorType> input,
       newShape, inputType.getElementType(), outputLayoutAttr);
 
   llvm::SmallVector<int32_t> newShapeI32(newShape.begin(), newShape.end());
-  return rewriter.create<ttnn::ReshapeOp>(
-      input.getLoc(), outputType, input, rewriter.getI32ArrayAttr(newShapeI32));
+  return rewriter.create<ttnn::ReshapeOp>(input.getLoc(), outputType, input,
+                                          rewriter.getI32ArrayAttr(newShapeI32),
+                                          /* memory_config */ nullptr);
 }
 
 ttnn::ReshapeOp

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -691,59 +691,56 @@ mlir::LogicalResult mlir::tt::ttir::ConvTranspose2dOp::verify() {
   ::mlir::RankedTensorType inputType = getInput().getType();
   ::mlir::RankedTensorType outputType = getOutput().getType();
   auto shape = getShape();
-  int64_t shape_size = static_cast<int64_t>(shape.size());
+  int64_t shapeSize = static_cast<int64_t>(shape.size());
 
-  // Check that the shape size matches the rank of the output tensor
-  if (shape_size != static_cast<int64_t>(outputType.getRank())) {
-    return emitOpError("Shape attribute size must match output tensor rank");
-  }
-
-  // Check that the shape attribute is non-empty
-  if (shape_size == 0) {
+  // Check that the shape attribute is non-empty.
+  if (shapeSize == 0) {
     return emitOpError("Shape attribute must be non-empty");
   }
 
-  // Cardinality of the input and output tensors must be the same
-  if (inputType.getNumElements() != outputType.getNumElements()) {
-    return emitOpError(
-        "Input and output tensors must have the same number of elements");
+  // Check that the shape size matches the rank of the output tensor.
+  if (shapeSize != static_cast<int64_t>(outputType.getRank())) {
+    return emitOpError() << "Shape attribute size " << shapeSize
+                         << " must match output tensor rank "
+                         << outputType.getRank();
   }
 
-  bool has_negative = false;
-  int64_t known_dim_product = 1;
+  // Cardinality of the input and output tensors must be the same.
+  if (inputType.getNumElements() != outputType.getNumElements()) {
+    return emitOpError() << "Input tensor number of elements "
+                         << inputType.getNumElements()
+                         << " and output tensor number of elements "
+                         << outputType.getNumElements() << " must be the same";
+  }
+
+  bool hasNegative = false;
   auto outputShape = outputType.getShape();
 
-  // Check that all dimensions are positive except for at most one -1
-  // Check that the non-negative dimensions match the output tensor shape
-  // Calculate the product of the known dimensions
-  for (int64_t i = 0; i < shape_size; i++) {
-    int64_t dim_value = mlir::cast<IntegerAttr>(shape[i]).getInt();
+  // Check that all dimensions are positive except for at most one -1.
+  // Check that the non-negative dimensions match the output tensor shape.
+  // Calculate the product of the known dimensions.
+  for (int64_t i = 0; i < shapeSize; i++) {
+    int64_t dimValue = mlir::cast<IntegerAttr>(shape[i]).getInt();
 
-    if (dim_value == -1) {
-      if (has_negative) {
+    if (dimValue == -1) {
+      if (hasNegative) {
         return emitOpError("Shape attribute must have at most one -1 element");
       }
-      has_negative = true;
+      hasNegative = true;
     } else {
-      if (dim_value <= 0) {
+      if (dimValue <= 0) {
         return emitOpError(
             "All dimensions must be positive except the one with -1");
       }
 
-      // Ensure that the non-negative dimensions match the output tensor shape
-      if (dim_value != outputShape[i]) {
-        return emitOpError("Shape attribute must match the output tensor shape "
-                           "for dimensions that are not -1");
+      // Ensure that the non-negative dimensions match the output tensor shape.
+      if (dimValue != outputShape[i]) {
+        return emitOpError()
+               << "Shape attribute " << dimValue
+               << " must match the output tensor shape " << outputShape[i]
+               << " at index " << i << " for dimension that is not -1";
       }
-
-      known_dim_product *= dim_value;
     }
-  }
-
-  // If there's a -1, ensure that it can be inferred correctly
-  if (has_negative && inputType.getNumElements() % known_dim_product != 0) {
-    return emitOpError("Invalid shape: the dimensions do not multiply to the "
-                       "total number of elements in the tensor");
   }
 
   return success();

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkarounds.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkarounds.cpp
@@ -386,7 +386,8 @@ public:
 
       // Create a new reshape op.
       ttnn::ReshapeOp preReshapeOp = rewriter.create<ttnn::ReshapeOp>(
-          loc, Type(reshapedInputType), op.getInput(), reshapedInputShapeAttr);
+          loc, Type(reshapedInputType), op.getInput(), reshapedInputShapeAttr,
+          /* memory_config */ nullptr);
 
       // Determine new dimension since entire tensor shape got shifted.
       dimension = dimension + requiredOnesInput;
@@ -424,9 +425,9 @@ public:
           loc, Type(reshapedOutputType), reduceScatterOp.getResult(),
           deviceValue, dimension, clusterAxis);
 
-      rewriter.replaceOpWithNewOp<ttnn::ReshapeOp>(op, Type(outputType),
-                                                   allGatherOp.getResult(),
-                                                   reshapedOutputShapeAttr);
+      rewriter.replaceOpWithNewOp<ttnn::ReshapeOp>(
+          op, Type(outputType), allGatherOp.getResult(),
+          reshapedOutputShapeAttr, /* memory_config */ nullptr);
     } else {
       // TODO(wooseoklee): Once ttnn supports all_reduce op
       // (https://github.com/tenstorrent/tt-metal/issues/13835), we can convert

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -1262,7 +1262,16 @@ createReshapeOp(FlatbufferObjectCache &cache, ReshapeOp op) {
   auto out = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
                                kHostAllocatedSize);
 
-  return ::tt::target::ttnn::CreateReshapeOp(*cache.fbb, in, out, shape);
+  std::optional<mlir::tt::ttnn::MemoryConfigAttr> memoryConfig =
+      op.getMemoryConfig();
+  auto tileShape = getTensorValueTileShape(op.getResult());
+  auto coreRangeSet = getTensorValueCoreRangeSet(cache, op.getResult());
+
+  return ::tt::target::ttnn::CreateReshapeOp(
+      *cache.fbb, in, out, shape,
+      memoryConfig ? memoryConfigToFlatbuffer(cache, memoryConfig.value(),
+                                              tileShape, coreRangeSet)
+                   : 0);
 }
 
 template <typename RepeatOp>

--- a/runtime/lib/ttnn/operations/data_movement/concat.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/concat.cpp
@@ -19,8 +19,11 @@ void run(const ::tt::target::ttnn::ConcatOp *op, ProgramContext &context) {
   }
   int32_t dim = op->dim();
   std::optional<::ttnn::MemoryConfig> memoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          op->memory_config());
+      op->memory_config() == 0
+          ? ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
+                ::tt::runtime::ttnn::utils::getTensorRefMemoryConfig(op->out()))
+          : ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
+                op->memory_config());
   ::ttnn::Tensor out = ::ttnn::concat(inputs, dim, memoryConfig);
   tensorPool.insert_or_assign(op->out()->global_id(), out);
 }

--- a/runtime/lib/ttnn/operations/data_movement/reshape.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/reshape.cpp
@@ -5,6 +5,7 @@
 #include "operations/data_movement/reshape.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
+#include "tt/runtime/ttnn/utils.h"
 
 namespace tt::runtime::ttnn::operations::data_movement {
 void run(const ::tt::target::ttnn::ReshapeOp *op, ProgramContext &context) {
@@ -13,7 +14,10 @@ void run(const ::tt::target::ttnn::ReshapeOp *op, ProgramContext &context) {
   DEBUG_ASSERT(in.is_allocated());
   const auto *fbShape = op->shape();
   std::vector<int32_t> shape(fbShape->begin(), fbShape->end());
-  ::ttnn::Tensor out = ::ttnn::reshape(in, shape);
+  std::optional<::ttnn::MemoryConfig> memoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
+          op->memory_config());
+  ::ttnn::Tensor out = ::ttnn::reshape(in, shape, memoryConfig);
   tensorPool.insert_or_assign(op->out()->global_id(), out);
 }
 } // namespace tt::runtime::ttnn::operations::data_movement

--- a/runtime/lib/ttnn/operations/data_movement/reshape.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/reshape.cpp
@@ -15,8 +15,11 @@ void run(const ::tt::target::ttnn::ReshapeOp *op, ProgramContext &context) {
   const auto *fbShape = op->shape();
   std::vector<int32_t> shape(fbShape->begin(), fbShape->end());
   std::optional<::ttnn::MemoryConfig> memoryConfig =
-      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
-          op->memory_config());
+      op->memory_config() == 0
+          ? ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
+                ::tt::runtime::ttnn::utils::getTensorRefMemoryConfig(op->out()))
+          : ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
+                op->memory_config());
   ::ttnn::Tensor out = ::ttnn::reshape(in, shape, memoryConfig);
   tensorPool.insert_or_assign(op->out()->global_id(), out);
 }

--- a/test/ttmlir/Dialect/TTIR/data_movement/reshape/reshape_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/data_movement/reshape/reshape_tests_negative.mlir
@@ -1,0 +1,67 @@
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+// Negative tests for reshape operation
+
+// Verify that verification fails when shape attribute is empty.
+module {
+  func.func @reshape_shape_attribute_empty(%arg0: tensor<2x32x32xbf16>) -> tensor<32x2x32xbf16> {
+    %0 = tensor.empty() : tensor<32x2x32xbf16>
+    %1 = "ttir.reshape"(%arg0, %0) <{shape = []}> : (tensor<2x32x32xbf16>, tensor<32x2x32xbf16>) -> tensor<32x2x32xbf16>
+    // CHECK: error: 'ttir.reshape' op Shape attribute must be non-empty
+    return %1 : tensor<32x2x32xbf16>
+  }
+}
+
+// -----
+// Verify that verification fails when shape size doesn't matches the rank of the output tensor
+module {
+  func.func @reshape_shape_size_different_from_the_output_rank(%arg0: tensor<2x32x32xbf16>) -> tensor<1x32x2x32xbf16> {
+    %0 = tensor.empty() : tensor<1x32x2x32xbf16>
+    %1 = "ttir.reshape"(%arg0, %0) <{shape = [32: i32, 2: i32, 32: i32]}> : (tensor<2x32x32xbf16>, tensor<1x32x2x32xbf16>) -> tensor<1x32x2x32xbf16>
+    // CHECK: error: 'ttir.reshape' op Shape attribute size 3 must match output tensor rank 4
+    return %1 : tensor<1x32x2x32xbf16>
+  }
+}
+
+// -----
+// Verify that verification fails when input and output tensor have different number of elements.
+module {
+  func.func @reshape_input_output_elements_mismatch(%arg0: tensor<2x32x32xbf16>) -> tensor<32x3x32xbf16> {
+    %0 = tensor.empty() : tensor<32x3x32xbf16>
+    %1 = "ttir.reshape"(%arg0, %0) <{shape = [32: i32, 3: i32, 32: i32]}> : (tensor<2x32x32xbf16>, tensor<32x3x32xbf16>) -> tensor<32x3x32xbf16>
+    // CHECK: error: 'ttir.reshape' op Input tensor number of elements 2048 and output tensor number of elements 3072 must be the same
+    return %1 : tensor<32x3x32xbf16>
+  }
+}
+
+// -----
+// Verify that verification fails when shape attribute has more than one -1(infer) element.
+module {
+  func.func @reshape_infer_dim_negative(%arg0: tensor<2x32x32xbf16>) -> tensor<32x2x32xbf16> {
+    %0 = tensor.empty() : tensor<32x2x32xbf16>
+    %1 = "ttir.reshape"(%arg0, %0) <{shape = [32: i32, -1: i32, -1: i32]}> : (tensor<2x32x32xbf16>, tensor<32x2x32xbf16>) -> tensor<32x2x32xbf16>
+    // CHECK: error: 'ttir.reshape' op Shape attribute must have at most one -1 element
+    return %1 : tensor<32x2x32xbf16>
+  }
+}
+
+// -----
+// Verify that verification fails if the shape attribute has negative dimension which is not -1.
+module {
+  func.func @reshape_infer_dim_negative(%arg0: tensor<2x32x32xbf16>) -> tensor<32x2x32xbf16> {
+    %0 = tensor.empty() : tensor<32x2x32xbf16>
+    %1 = "ttir.reshape"(%arg0, %0) <{shape = [32: i32, -1: i32, -32: i32]}> : (tensor<2x32x32xbf16>, tensor<32x2x32xbf16>) -> tensor<32x2x32xbf16>
+    // CHECK: error: 'ttir.reshape' op All dimensions must be positive except the one with -1
+    return %1 : tensor<32x2x32xbf16>
+  }
+}
+
+// -----
+// Verify that verification fails if the shape attribute is different from the output tensor shape.
+module {
+  func.func @reshape_shape_mismatch(%arg0: tensor<2x32x32xbf16>) -> tensor<32x2x32xbf16> {
+    %0 = tensor.empty() : tensor<32x2x32xbf16>
+    %1 = "ttir.reshape"(%arg0, %0) <{shape = [32: i32, 3: i32, 32: i32]}> : (tensor<2x32x32xbf16>, tensor<32x2x32xbf16>) -> tensor<32x2x32xbf16>
+    // CHECK: error: 'ttir.reshape' op Shape attribute 3 must match the output tensor shape 2 at index 1 for dimension that is not -1
+    return %1 : tensor<32x2x32xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/data_movement/reshape/reshape_folding_test.mlir
+++ b/test/ttmlir/Dialect/TTNN/data_movement/reshape/reshape_folding_test.mlir
@@ -1,11 +1,12 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s| FileCheck %s
-// Tests if we fold when translating from "ttir.reshape" which is called on the two same shapes.
+
 module @reshape_test {
+  // Test folding of "ttir.reshape" when called with identical shapes.
   func.func @main(%arg0: tensor<1xi32>) -> (tensor<1xi32> {jax.result_info = ""}) {
     %0 = tensor.empty() : tensor<1xi32>
     %1 = "ttir.reshape"(%arg0, %0) <{shape = [1 : i32]}> : (tensor<1xi32>, tensor<1xi32>) -> tensor<1xi32>
-    // CHECK-NOT: = "ttnn.reshape"[C:.*]]
-    // CHECK: return %arg0 : tensor<1xsi32, #{{.*}}>
+    // CHECK-NOT: = "ttnn.reshape"
     return %1 : tensor<1xi32>
+    // CHECK: return %arg0 : tensor<1xsi32, #{{.*}}>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/data_movement/reshape/reshape_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/data_movement/reshape/reshape_tests_negative.mlir
@@ -1,0 +1,61 @@
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+// Negative tests for reshape operation
+
+// Verify that verification fails when shape attribute is empty.
+module {
+  func.func @reshape_shape_attribute_empty(%arg0: tensor<2x32x32xbf16>) -> tensor<32x2x32xbf16> {
+    %0 = "ttnn.reshape"(%arg0) <{shape = []}> : (tensor<2x32x32xbf16>) -> tensor<32x2x32xbf16>
+    // CHECK: error: 'ttnn.reshape' op Shape attribute must be non-empty
+    return %0 : tensor<32x2x32xbf16>
+  }
+}
+
+// -----
+// Verify that verification fails when shape size doesn't matches the rank of the output tensor
+module {
+  func.func @reshape_shape_size_different_from_the_output_rank(%arg0: tensor<2x32x32xbf16>) -> tensor<1x32x2x32xbf16> {
+    %1 = "ttnn.reshape"(%arg0) <{shape = [32: i32, 2: i32, 32: i32]}> : (tensor<2x32x32xbf16>) -> tensor<1x32x2x32xbf16>
+    // CHECK: error: 'ttnn.reshape' op Shape attribute size 3 must match output tensor rank 4
+    return %1 : tensor<1x32x2x32xbf16>
+  }
+}
+
+// -----
+// Verify that verification fails when input and output tensor have different number of elements.
+module {
+  func.func @reshape_input_output_elements_mismatch(%arg0: tensor<2x32x32xbf16>) -> tensor<32x3x32xbf16> {
+    %1 = "ttnn.reshape"(%arg0) <{shape = [32: i32, 3: i32, 32: i32]}> : (tensor<2x32x32xbf16>) -> tensor<32x3x32xbf16>
+    // CHECK: error: 'ttnn.reshape' op Input tensor number of elements 2048 and output tensor number of elements 3072 must be the same
+    return %1 : tensor<32x3x32xbf16>
+  }
+}
+
+// -----
+// Verify that verification fails when shape attribute has more than one -1(infer) element.
+module {
+  func.func @reshape_infer_dim_negative(%arg0: tensor<2x32x32xbf16>) -> tensor<32x2x32xbf16> {
+    %1 = "ttnn.reshape"(%arg0) <{shape = [32: i32, -1: i32, -1: i32]}> : (tensor<2x32x32xbf16>) -> tensor<32x2x32xbf16>
+    // CHECK: error: 'ttnn.reshape' op Shape attribute must have at most one -1 element
+    return %1 : tensor<32x2x32xbf16>
+  }
+}
+
+// -----
+// Verify that verification fails if the shape attribute has negative dimension which is not -1.
+module {
+  func.func @reshape_infer_dim_negative(%arg0: tensor<2x32x32xbf16>) -> tensor<32x2x32xbf16> {
+    %1 = "ttnn.reshape"(%arg0) <{shape = [32: i32, -1: i32, -32: i32]}> : (tensor<2x32x32xbf16>) -> tensor<32x2x32xbf16>
+    // CHECK: error: 'ttnn.reshape' op All dimensions must be positive except the one with -1
+    return %1 : tensor<32x2x32xbf16>
+  }
+}
+
+// -----
+// Verify that verification fails if the shape attribute is different from the output tensor shape.
+module {
+  func.func @reshape_shape_mismatch(%arg0: tensor<2x32x32xbf16>) -> tensor<32x2x32xbf16> {
+    %1 = "ttnn.reshape"(%arg0) <{shape = [32: i32, 3: i32, 32: i32]}> : (tensor<2x32x32xbf16>) -> tensor<32x2x32xbf16>
+    // CHECK: error: 'ttnn.reshape' op Shape attribute 3 must match the output tensor shape 2 at index 1 for dimension that is not -1
+    return %1 : tensor<32x2x32xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/data_movement/reshape/reshape_tests_positive.mlir
+++ b/test/ttmlir/Dialect/TTNN/data_movement/reshape/reshape_tests_positive.mlir
@@ -1,0 +1,22 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s| FileCheck %s
+module attributes {} {
+  func.func @reshape_positive(%arg0: tensor<4x2x32x32xbf16>) -> tensor<2x4x32x32xbf16> {
+    %0 = tensor.empty() : tensor<2x4x32x32xbf16>
+    %1 = "ttir.reshape"(%arg0, %0) <{shape = [2: i32, 4: i32, 32: i32, 32: i32]}> : (tensor<4x2x32x32xbf16>, tensor<2x4x32x32xbf16>) -> tensor<2x4x32x32xbf16>
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: <{shape = [2 : i32, 4 : i32, 32 : i32, 32 : i32]}>
+    // CHECK-SAME: tensor<4x2x32x32xbf16
+    // CHECK-SAME: -> tensor<2x4x32x32xbf16
+    return %1 : tensor<2x4x32x32xbf16>
+  }
+
+  func.func @reshape_with_minus_one(%arg0: tensor<4x2x32x32xbf16>) -> tensor<2x4x32x32xbf16> {
+    %0 = tensor.empty() : tensor<2x4x32x32xbf16>
+    %1 = "ttir.reshape"(%arg0, %0) <{shape = [2: i32, -1: i32, 32: i32, 32: i32]}> : (tensor<4x2x32x32xbf16>, tensor<2x4x32x32xbf16>) -> tensor<2x4x32x32xbf16>
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: <{shape = [2 : i32, -1 : i32, 32 : i32, 32 : i32]}>
+    // CHECK-SAME: tensor<4x2x32x32xbf16
+    // CHECK-SAME: -> tensor<2x4x32x32xbf16
+    return %1 : tensor<2x4x32x32xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/simple_reshape.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_reshape.mlir
@@ -1,9 +1,0 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s| FileCheck %s
-module attributes {} {
-  func.func @forward(%arg0: tensor<4x2x32x32xbf16>) -> tensor<2x4x32x32xbf16> {
-    %0 = tensor.empty() : tensor<2x4x32x32xbf16>
-    // CHECK: = "ttnn.reshape"
-    %1 = "ttir.reshape"(%arg0, %0) <{shape = [2: i32, 4: i32, 32: i32, 32: i32]}> : (tensor<4x2x32x32xbf16>, tensor<2x4x32x32xbf16>) -> tensor<2x4x32x32xbf16>
-    return %1 : tensor<2x4x32x32xbf16>
-  }
-}

--- a/test/ttmlir/Silicon/TTNN/n150/data_movement/reshape/reshape.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/data_movement/reshape/reshape.mlir
@@ -4,7 +4,7 @@
 
 func.func @reshape(%arg0: tensor<4x2x32x32xbf16>) -> tensor<2x4x32x32xbf16> {
   %0 = tensor.empty() : tensor<2x4x32x32xbf16>
-  // CHECK: = "ttnn.reshape"
   %1 = "ttir.reshape"(%arg0, %0) <{shape = [2: i32, 4: i32, 32: i32, 32: i32]}> : (tensor<4x2x32x32xbf16>, tensor<2x4x32x32xbf16>) -> tensor<2x4x32x32xbf16>
+  // CHECK: "ttnn.reshape"
   return %1 : tensor<2x4x32x32xbf16>
 }


### PR DESCRIPTION
### Ticket
The following GH issue contains all the ops that require memory_config:
https://github.com/tenstorrent/tt-mlir/issues/1637

Reshape op is one on the list.

### Problem description
TTNN Reshape op requires a memory config attribute.

### What's changed
I added the memory config trait to a reshape op and implemented the memory config e2e.

### Checklist
- [x] New/Existing tests provide coverage for changes
