### PR TITLE
Create `ttnn.neg` as non-DPS op

### DIFF
--- a/include/ttmlir/Utils.h
+++ b/include/ttmlir/Utils.h
@@ -15,7 +15,6 @@
 #include "llvm/Support/Error.h"
 
 #include <cstdint>
-#include <mlir/Interfaces/DestinationStyleOpInterface.h>
 #include <type_traits>
 
 namespace ttmlir::utils {

--- a/include/ttmlir/Utils.h
+++ b/include/ttmlir/Utils.h
@@ -15,6 +15,7 @@
 #include "llvm/Support/Error.h"
 
 #include <cstdint>
+#include <mlir/Interfaces/DestinationStyleOpInterface.h>
 #include <type_traits>
 
 namespace ttmlir::utils {
@@ -366,6 +367,9 @@ auto splitAndCall(mlir::PatternRewriter &rewriter, mlir::Location loc,
 template <typename OpTy, typename... ArgsTy>
 OpTy createDPSOp(mlir::PatternRewriter &rewriter, mlir::Location loc,
                  mlir::RankedTensorType outputType, ArgsTy &&...args) {
+  static_assert(
+      OpTy::template hasTrait<mlir::DestinationStyleOpInterface::Trait>());
+
   auto output = rewriter.create<mlir::tensor::EmptyOp>(
       loc, outputType.getShape(), outputType.getElementType(),
       outputType.getEncoding());
@@ -393,6 +397,9 @@ OpTy createDPSOp(mlir::PatternRewriter &rewriter, mlir::Location loc,
                  llvm::ArrayRef<int64_t> outputShape,
                  mlir::Type outputElementType, mlir::Attribute outputEncoding,
                  ArgsTy &&...args) {
+  static_assert(
+      OpTy::template hasTrait<mlir::DestinationStyleOpInterface::Trait>());
+
   auto outputType = mlir::RankedTensorType::get(outputShape, outputElementType,
                                                 outputEncoding);
   return createDPSOp<OpTy>(rewriter, loc, outputType,
@@ -414,6 +421,9 @@ template <typename OpTy, typename... ArgsTy>
 OpTy replaceOpWithNewDPSOp(mlir::PatternRewriter &rewriter, mlir::Operation *op,
                            mlir::RankedTensorType outputType,
                            ArgsTy &&...args) {
+  static_assert(
+      OpTy::template hasTrait<mlir::DestinationStyleOpInterface::Trait>());
+
   auto newOp = createDPSOp<OpTy>(rewriter, op->getLoc(), outputType,
                                  std::forward<ArgsTy>(args)...);
   rewriter.replaceOp(op, newOp.getOperation());
@@ -440,6 +450,9 @@ OpTy replaceOpWithNewDPSOp(mlir::PatternRewriter &rewriter, mlir::Operation *op,
                            llvm::ArrayRef<int64_t> outputShape,
                            mlir::Type outputElementType,
                            mlir::Attribute outputEncoding, ArgsTy &&...args) {
+  static_assert(
+      OpTy::template hasTrait<mlir::DestinationStyleOpInterface::Trait>());
+
   auto newOp =
       createDPSOp<OpTy>(rewriter, op->getLoc(), outputShape, outputElementType,
                         outputEncoding, std::forward<ArgsTy>(args)...);

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -1309,6 +1309,7 @@ public:
         mlir::cast<RankedTensorType>(adaptor.getInputs().front().getType());
     RankedTensorType rhsType =
         mlir::cast<RankedTensorType>(adaptor.getInputs().back().getType());
+
     if (lhsType.getShape() == rhsType.getShape()) {
       rewriter.replaceOpWithNewOp<ttnn::SubtractOp>(
           srcOp, adaptor.getInputs().front(), adaptor.getInputs().back());

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -29,7 +29,6 @@
 #include "llvm/Support/Casting.h"
 
 #include <cstdint>
-#include <mlir/Interfaces/DestinationStyleOpInterface.h>
 #include <optional>
 
 using namespace mlir;

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -29,6 +29,7 @@
 #include "llvm/Support/Casting.h"
 
 #include <cstdint>
+#include <mlir/Interfaces/DestinationStyleOpInterface.h>
 #include <optional>
 
 using namespace mlir;
@@ -1308,7 +1309,6 @@ public:
         mlir::cast<RankedTensorType>(adaptor.getInputs().front().getType());
     RankedTensorType rhsType =
         mlir::cast<RankedTensorType>(adaptor.getInputs().back().getType());
-
     if (lhsType.getShape() == rhsType.getShape()) {
       rewriter.replaceOpWithNewOp<ttnn::SubtractOp>(
           srcOp, adaptor.getInputs().front(), adaptor.getInputs().back());
@@ -1319,8 +1319,8 @@ public:
       // addOp(lhs, negOp(rhs))
 
     } else {
-      ttnn::NegOp negOp = ttmlir::utils::createDPSOp<ttnn::NegOp>(
-          rewriter, srcOp.getLoc(), rhsType);
+      ttnn::NegOp negOp = rewriter.create<ttnn::NegOp>(
+          srcOp.getLoc(), adaptor.getInputs().back());
 
       rewriter.replaceOpWithNewOp<ttnn::AddOp>(
           srcOp, adaptor.getInputs().front(), negOp.getResults().front());

--- a/test/ttmlir/Dialect/TTNN/simple_subtract_to_add.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_subtract_to_add.mlir
@@ -1,7 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xf32>, %arg1: tensor<1x128xf32>) -> tensor<64x128xf32> {
-    // CHECK: = "ttnn.empty"
     %0 = tensor.empty() : tensor<64x128xf32>
     // CHECK: = "ttnn.neg"
     // CHECK: = "ttnn.add"


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/2283

### Problem description
In one place in TTIR->TTNN conversion, `NegOp` is created as DPS op, even though it isn't.

### What's changed
Since `NegOp` is elementwise op and they were recently changed from DPS to non DPS op it was an error to create it like a DPS op, because it took empty tensor as an input. Added `static_assert`s in DPSOp creation functions to check if target op is actually a DPS op.

### Checklist
- [ ] New/Existing tests provide coverage for changes
