### PR TITLE
Restore default truncation in APInt constructor

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -737,7 +737,7 @@ private:
     // Create data structure for other types.
     std::vector<mlir::APInt> IntegerValue = {};
     for (ElementType value : valueAttr.getValues<ElementType>()) {
-      mlir::APInt input(bitWidth, value);
+      mlir::APInt input(bitWidth, value, false, true);
       IntegerValue.emplace_back(input);
     }
     return mlir::DenseElementsAttr::get(valueType, IntegerValue);


### PR DESCRIPTION
### Ticket
Torch failing nightly tests for only vilt model.
Credit for this goes to @LPanosTT 

### Problem description
Recent LLVM uplift captured a change in the APInt constructor:
https://github.com/llvm/llvm-project/pull/114539/files

The previous code relied on that default implicit truncation behavior,
that default changed from implicitTruncate=true to implicitTruncate=false.

### What's changed
Explicitly set implicitTrunc=True instead of relying on default behavior.

### Checklist
- [x] New/Existing tests provide coverage for changes
