### PR TITLE
Add LLama Attention Block To `TTBuilder` & Test

### DIFF
--- a/test/python/golden/test_ttir_models.py
+++ b/test/python/golden/test_ttir_models.py
@@ -55,6 +55,7 @@ def test_mnist(
         (3200, 3200),  # arg14
     ],
     targets=["ttnn"],
+    module_dump=True,
 )
 def test_llama_attention(
     arg0: Operand,

--- a/test/python/golden/test_ttir_models.py
+++ b/test/python/golden/test_ttir_models.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# RUN: SYSTEM_DESC_PATH=%system_desc_path% %python %s
+
+import inspect
+
+from ttmlir.test_utils import compile_to_flatbuffer
+from ttmlir.ttir_builder import Operand, TTIRBuilder
+
+
+@compile_to_flatbuffer(
+    [
+        (1, 784),
+        (784, 256),
+        (1, 256),
+        (256, 10),
+        (1, 10),
+    ],
+    targets=["ttnn"],
+)
+def test_mnist(
+    in0: Operand,  # Input 28x28 image
+    in1: Operand,  # Weight 1
+    in2: Operand,  # Bias 1
+    in3: Operand,  # Weight 2
+    in4: Operand,  # Bias 2
+    builder: TTIRBuilder,
+):
+    matmul_1 = builder.matmul(in0, in1)
+    add_2 = builder.add(matmul_1, in2)
+    relu_3 = builder.relu(add_2)
+    matmul_5 = builder.matmul(relu_3, in3)
+    add_6 = builder.add(matmul_5, in4)
+    return builder.softmax(add_6, dimension=1)
+
+
+@compile_to_flatbuffer(
+    [
+        (1, 12, 3200),  # arg0
+        (1, 1, 12, 12),  # arg1
+        (1, 12),  # arg2
+        (1, 50, 1),  # arg3
+        (1, 32, 50, 100),  # arg4
+        (1, 1),  # arg5
+        (1, 32, 50, 100),  # arg6
+        (1, 32, 50, 100),  # arg7
+        (1, 1),  # arg8
+        (1, 32, 50, 100),  # arg9
+        (1, 1),  # arg10
+        (3200, 3200),  # arg11
+        (3200, 3200),  # arg12
+        (3200, 3200),  # arg13
+        (3200, 3200),  # arg14
+    ],
+    targets=["ttnn"],
+)
+def test_llama_attention(
+    arg0: Operand,
+    arg1: Operand,
+    arg2: Operand,
+    arg3: Operand,
+    arg4: Operand,
+    arg5: Operand,
+    arg6: Operand,
+    arg7: Operand,
+    arg8: Operand,
+    arg9: Operand,
+    arg10: Operand,
+    arg11: Operand,
+    arg12: Operand,
+    arg13: Operand,
+    arg14: Operand,
+    builder: TTIRBuilder,
+):
+
+    output1 = builder.squeeze(arg0, 0)
+    output3 = builder.matmul(output1, arg11)
+    output5 = builder.reshape(output3, (1, 12, 32, 100))
+    output7 = builder.transpose(output5, -3, -2)
+    output9 = builder.unsqueeze(arg2, 1)
+    output11 = builder.matmul(arg3, output9)
+    output13 = builder.transpose(output11, -2, -1)
+    output15 = builder.concat([output13, output13], -1)
+    output17 = builder.cos(output15)
+    output19 = builder.unsqueeze(output17, 1)
+    output21 = builder.multiply(output7, output19)
+    output23 = builder.transpose(output7, -2, -1)
+    output25 = builder.matmul(arg4, output23)
+    output27 = builder.transpose(output25, -2, -1)
+    output29 = builder.multiply(output27, arg5)
+    output31 = builder.transpose(output7, -2, -1)
+    output33 = builder.matmul(arg6, output31)
+    output35 = builder.transpose(output33, -2, -1)
+    output37 = builder.concat([output29, output35], -1)
+    output39 = builder.sin(output15)
+    output41 = builder.unsqueeze(output39, 1)
+    output43 = builder.multiply(output37, output41)
+    output45 = builder.add(output21, output43)
+    output47 = builder.squeeze(output45, 0)
+    output49 = builder.matmul(output1, arg12)
+    output51 = builder.reshape(output49, (1, 12, 32, 100))
+    output53 = builder.transpose(output51, -3, -2)
+    output55 = builder.multiply(output53, output19)
+    output57 = builder.transpose(output53, -2, -1)
+    output59 = builder.matmul(arg7, output57)
+    output61 = builder.transpose(output59, -2, -1)
+    output63 = builder.multiply(output61, arg8)
+    output65 = builder.transpose(output53, -2, -1)
+    output67 = builder.matmul(arg9, output65)
+    output69 = builder.transpose(output67, -2, -1)
+    output71 = builder.concat([output63, output69], -1)
+    output73 = builder.multiply(output71, output41)
+    output75 = builder.add(output55, output73)
+    output77 = builder.squeeze(output75, 0)
+    output79 = builder.transpose(output77, -2, -1)
+    output81 = builder.matmul(output47, output79)
+    output83 = builder.unsqueeze(output81, 0)
+    output85 = builder.multiply(output83, arg10)
+    output87 = builder.add(output85, arg1)
+    output89 = builder.softmax(output87, -1)
+    output91 = builder.squeeze(output89, 0)
+    output93 = builder.matmul(output1, arg13)
+    output95 = builder.reshape(output93, (1, 12, 32, 100))
+    output97 = builder.transpose(output95, -3, -2)
+    output99 = builder.transpose(output97, -2, -1)
+    output101 = builder.squeeze(output99, 0)
+    output103 = builder.transpose(output101, -2, -1)
+    output105 = builder.matmul(output91, output103)
+    output107 = builder.unsqueeze(output105, 0)
+    output109 = builder.transpose(output107, -3, -2)
+    output111 = builder.reshape(output109, (12, 3200))
+    output113 = builder.matmul(output111, arg14)
+    output115 = builder.unsqueeze(output113, 0)
+
+    return output115
+
+
+if __name__ == "__main__":
+    test_functions = inspect.getmembers(
+        inspect.getmodule(inspect.currentframe()), inspect.isfunction
+    )
+
+    for function_name, func in test_functions:
+        if function_name.startswith("test_"):
+            func()

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -449,32 +449,6 @@ def test_arbitrary_op_chain(
     return builder.multiply(add, exp)
 
 
-@compile_to_flatbuffer(
-    [
-        (1, 784),
-        (784, 256),
-        (1, 256),
-        (256, 10),
-        (1, 10),
-    ],
-    targets=["ttnn"],
-)
-def test_mnist(
-    in0: Operand,  # Input 28x28 image
-    in1: Operand,  # Weight 1
-    in2: Operand,  # Bias 1
-    in3: Operand,  # Weight 2
-    in4: Operand,  # Bias 2
-    builder: TTIRBuilder,
-):
-    matmul_1 = builder.matmul(in0, in1)
-    add_2 = builder.add(matmul_1, in2)
-    relu_3 = builder.relu(add_2)
-    matmul_5 = builder.matmul(relu_3, in3)
-    add_6 = builder.add(matmul_5, in4)
-    return builder.softmax(add_6, dimension=1)
-
-
 if __name__ == "__main__":
     test_functions = inspect.getmembers(
         inspect.getmodule(inspect.currentframe()), inspect.isfunction

--- a/test/ttmlir/Silicon/TTNN/n150/models/llama_attention.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/models/llama_attention.mlir
@@ -1,0 +1,123 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+module {
+  func.func @test_llama_attention(%arg0: tensor<1x12x3200xf32>, %arg1: tensor<1x1x12x12xf32>, %arg2: tensor<1x12xf32>, %arg3: tensor<1x50x1xf32>, %arg4: tensor<1x32x50x100xf32>, %arg5: tensor<1x1xf32>, %arg6: tensor<1x32x50x100xf32>, %arg7: tensor<1x32x50x100xf32>, %arg8: tensor<1x1xf32>, %arg9: tensor<1x32x50x100xf32>, %arg10: tensor<1x1xf32>, %arg11: tensor<3200x3200xf32>, %arg12: tensor<3200x3200xf32>, %arg13: tensor<3200x3200xf32>, %arg14: tensor<3200x3200xf32>) -> tensor<1x12x3200xf32> {
+    %0 = tensor.empty() : tensor<12x3200xf32>
+    %1 = "ttir.squeeze"(%arg0, %0) <{dim = 0 : si32}> : (tensor<1x12x3200xf32>, tensor<12x3200xf32>) -> tensor<12x3200xf32>
+    %2 = tensor.empty() : tensor<12x3200xf32>
+    %3 = "ttir.matmul"(%1, %arg11, %2) : (tensor<12x3200xf32>, tensor<3200x3200xf32>, tensor<12x3200xf32>) -> tensor<12x3200xf32>
+    %4 = tensor.empty() : tensor<1x12x32x100xf32>
+    %5 = "ttir.reshape"(%3, %4) <{shape = [1 : i32, 12 : i32, 32 : i32, 100 : i32]}> : (tensor<12x3200xf32>, tensor<1x12x32x100xf32>) -> tensor<1x12x32x100xf32>
+    %6 = tensor.empty() : tensor<1x32x12x100xf32>
+    %7 = "ttir.transpose"(%5, %6) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x12x32x100xf32>, tensor<1x32x12x100xf32>) -> tensor<1x32x12x100xf32>
+    %8 = tensor.empty() : tensor<1x1x12xf32>
+    %9 = "ttir.unsqueeze"(%arg2, %8) <{dim = 1 : si32}> : (tensor<1x12xf32>, tensor<1x1x12xf32>) -> tensor<1x1x12xf32>
+    %10 = tensor.empty() : tensor<1x50x12xf32>
+    %11 = "ttir.matmul"(%arg3, %9, %10) : (tensor<1x50x1xf32>, tensor<1x1x12xf32>, tensor<1x50x12xf32>) -> tensor<1x50x12xf32>
+    %12 = tensor.empty() : tensor<1x12x50xf32>
+    %13 = "ttir.transpose"(%11, %12) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x50x12xf32>, tensor<1x12x50xf32>) -> tensor<1x12x50xf32>
+    %14 = tensor.empty() : tensor<1x12x100xf32>
+    %15 = "ttir.concat"(%13, %13, %14) <{dim = -1 : si32}> : (tensor<1x12x50xf32>, tensor<1x12x50xf32>, tensor<1x12x100xf32>) -> tensor<1x12x100xf32>
+    %16 = tensor.empty() : tensor<1x12x100xf32>
+    %17 = "ttir.cos"(%15, %16) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x12x100xf32>, tensor<1x12x100xf32>) -> tensor<1x12x100xf32>
+    %18 = tensor.empty() : tensor<1x1x12x100xf32>
+    %19 = "ttir.unsqueeze"(%17, %18) <{dim = 1 : si32}> : (tensor<1x12x100xf32>, tensor<1x1x12x100xf32>) -> tensor<1x1x12x100xf32>
+    %20 = tensor.empty() : tensor<1x32x12x100xf32>
+    %21 = "ttir.multiply"(%7, %19, %20) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x12x100xf32>, tensor<1x1x12x100xf32>, tensor<1x32x12x100xf32>) -> tensor<1x32x12x100xf32>
+    %22 = tensor.empty() : tensor<1x32x100x12xf32>
+    %23 = "ttir.transpose"(%7, %22) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x12x100xf32>, tensor<1x32x100x12xf32>) -> tensor<1x32x100x12xf32>
+    %24 = tensor.empty() : tensor<1x32x50x12xf32>
+    %25 = "ttir.matmul"(%arg4, %23, %24) : (tensor<1x32x50x100xf32>, tensor<1x32x100x12xf32>, tensor<1x32x50x12xf32>) -> tensor<1x32x50x12xf32>
+    %26 = tensor.empty() : tensor<1x32x12x50xf32>
+    %27 = "ttir.transpose"(%25, %26) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x50x12xf32>, tensor<1x32x12x50xf32>) -> tensor<1x32x12x50xf32>
+    %28 = tensor.empty() : tensor<1x32x12x50xf32>
+    %29 = "ttir.multiply"(%27, %arg5, %28) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x12x50xf32>, tensor<1x1xf32>, tensor<1x32x12x50xf32>) -> tensor<1x32x12x50xf32>
+    %30 = tensor.empty() : tensor<1x32x100x12xf32>
+    %31 = "ttir.transpose"(%7, %30) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x12x100xf32>, tensor<1x32x100x12xf32>) -> tensor<1x32x100x12xf32>
+    %32 = tensor.empty() : tensor<1x32x50x12xf32>
+    %33 = "ttir.matmul"(%arg6, %31, %32) : (tensor<1x32x50x100xf32>, tensor<1x32x100x12xf32>, tensor<1x32x50x12xf32>) -> tensor<1x32x50x12xf32>
+    %34 = tensor.empty() : tensor<1x32x12x50xf32>
+    %35 = "ttir.transpose"(%33, %34) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x50x12xf32>, tensor<1x32x12x50xf32>) -> tensor<1x32x12x50xf32>
+    %36 = tensor.empty() : tensor<1x32x12x100xf32>
+    %37 = "ttir.concat"(%29, %35, %36) <{dim = -1 : si32}> : (tensor<1x32x12x50xf32>, tensor<1x32x12x50xf32>, tensor<1x32x12x100xf32>) -> tensor<1x32x12x100xf32>
+    %38 = tensor.empty() : tensor<1x12x100xf32>
+    %39 = "ttir.sin"(%15, %38) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x12x100xf32>, tensor<1x12x100xf32>) -> tensor<1x12x100xf32>
+    %40 = tensor.empty() : tensor<1x1x12x100xf32>
+    %41 = "ttir.unsqueeze"(%39, %40) <{dim = 1 : si32}> : (tensor<1x12x100xf32>, tensor<1x1x12x100xf32>) -> tensor<1x1x12x100xf32>
+    %42 = tensor.empty() : tensor<1x32x12x100xf32>
+    %43 = "ttir.multiply"(%37, %41, %42) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x12x100xf32>, tensor<1x1x12x100xf32>, tensor<1x32x12x100xf32>) -> tensor<1x32x12x100xf32>
+    %44 = tensor.empty() : tensor<1x32x12x100xf32>
+    %45 = "ttir.add"(%21, %43, %44) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x12x100xf32>, tensor<1x32x12x100xf32>, tensor<1x32x12x100xf32>) -> tensor<1x32x12x100xf32>
+    %46 = tensor.empty() : tensor<32x12x100xf32>
+    %47 = "ttir.squeeze"(%45, %46) <{dim = 0 : si32}> : (tensor<1x32x12x100xf32>, tensor<32x12x100xf32>) -> tensor<32x12x100xf32>
+    %48 = tensor.empty() : tensor<12x3200xf32>
+    %49 = "ttir.matmul"(%1, %arg12, %48) : (tensor<12x3200xf32>, tensor<3200x3200xf32>, tensor<12x3200xf32>) -> tensor<12x3200xf32>
+    %50 = tensor.empty() : tensor<1x12x32x100xf32>
+    %51 = "ttir.reshape"(%49, %50) <{shape = [1 : i32, 12 : i32, 32 : i32, 100 : i32]}> : (tensor<12x3200xf32>, tensor<1x12x32x100xf32>) -> tensor<1x12x32x100xf32>
+    %52 = tensor.empty() : tensor<1x32x12x100xf32>
+    %53 = "ttir.transpose"(%51, %52) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x12x32x100xf32>, tensor<1x32x12x100xf32>) -> tensor<1x32x12x100xf32>
+    %54 = tensor.empty() : tensor<1x32x12x100xf32>
+    %55 = "ttir.multiply"(%53, %19, %54) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x12x100xf32>, tensor<1x1x12x100xf32>, tensor<1x32x12x100xf32>) -> tensor<1x32x12x100xf32>
+    %56 = tensor.empty() : tensor<1x32x100x12xf32>
+    %57 = "ttir.transpose"(%53, %56) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x12x100xf32>, tensor<1x32x100x12xf32>) -> tensor<1x32x100x12xf32>
+    %58 = tensor.empty() : tensor<1x32x50x12xf32>
+    %59 = "ttir.matmul"(%arg7, %57, %58) : (tensor<1x32x50x100xf32>, tensor<1x32x100x12xf32>, tensor<1x32x50x12xf32>) -> tensor<1x32x50x12xf32>
+    %60 = tensor.empty() : tensor<1x32x12x50xf32>
+    %61 = "ttir.transpose"(%59, %60) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x50x12xf32>, tensor<1x32x12x50xf32>) -> tensor<1x32x12x50xf32>
+    %62 = tensor.empty() : tensor<1x32x12x50xf32>
+    %63 = "ttir.multiply"(%61, %arg8, %62) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x12x50xf32>, tensor<1x1xf32>, tensor<1x32x12x50xf32>) -> tensor<1x32x12x50xf32>
+    %64 = tensor.empty() : tensor<1x32x100x12xf32>
+    %65 = "ttir.transpose"(%53, %64) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x12x100xf32>, tensor<1x32x100x12xf32>) -> tensor<1x32x100x12xf32>
+    %66 = tensor.empty() : tensor<1x32x50x12xf32>
+    %67 = "ttir.matmul"(%arg9, %65, %66) : (tensor<1x32x50x100xf32>, tensor<1x32x100x12xf32>, tensor<1x32x50x12xf32>) -> tensor<1x32x50x12xf32>
+    %68 = tensor.empty() : tensor<1x32x12x50xf32>
+    %69 = "ttir.transpose"(%67, %68) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x50x12xf32>, tensor<1x32x12x50xf32>) -> tensor<1x32x12x50xf32>
+    %70 = tensor.empty() : tensor<1x32x12x100xf32>
+    %71 = "ttir.concat"(%63, %69, %70) <{dim = -1 : si32}> : (tensor<1x32x12x50xf32>, tensor<1x32x12x50xf32>, tensor<1x32x12x100xf32>) -> tensor<1x32x12x100xf32>
+    %72 = tensor.empty() : tensor<1x32x12x100xf32>
+    %73 = "ttir.multiply"(%71, %41, %72) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x12x100xf32>, tensor<1x1x12x100xf32>, tensor<1x32x12x100xf32>) -> tensor<1x32x12x100xf32>
+    %74 = tensor.empty() : tensor<1x32x12x100xf32>
+    %75 = "ttir.add"(%55, %73, %74) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x12x100xf32>, tensor<1x32x12x100xf32>, tensor<1x32x12x100xf32>) -> tensor<1x32x12x100xf32>
+    %76 = tensor.empty() : tensor<32x12x100xf32>
+    %77 = "ttir.squeeze"(%75, %76) <{dim = 0 : si32}> : (tensor<1x32x12x100xf32>, tensor<32x12x100xf32>) -> tensor<32x12x100xf32>
+    %78 = tensor.empty() : tensor<32x100x12xf32>
+    %79 = "ttir.transpose"(%77, %78) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x12x100xf32>, tensor<32x100x12xf32>) -> tensor<32x100x12xf32>
+    %80 = tensor.empty() : tensor<32x12x12xf32>
+    %81 = "ttir.matmul"(%47, %79, %80) : (tensor<32x12x100xf32>, tensor<32x100x12xf32>, tensor<32x12x12xf32>) -> tensor<32x12x12xf32>
+    %82 = tensor.empty() : tensor<1x32x12x12xf32>
+    %83 = "ttir.unsqueeze"(%81, %82) <{dim = 0 : si32}> : (tensor<32x12x12xf32>, tensor<1x32x12x12xf32>) -> tensor<1x32x12x12xf32>
+    %84 = tensor.empty() : tensor<1x32x12x12xf32>
+    %85 = "ttir.multiply"(%83, %arg10, %84) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x12x12xf32>, tensor<1x1xf32>, tensor<1x32x12x12xf32>) -> tensor<1x32x12x12xf32>
+    %86 = tensor.empty() : tensor<1x32x12x12xf32>
+    %87 = "ttir.add"(%85, %arg1, %86) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x12x12xf32>, tensor<1x1x12x12xf32>, tensor<1x32x12x12xf32>) -> tensor<1x32x12x12xf32>
+    %88 = tensor.empty() : tensor<1x32x12x12xf32>
+    %89 = "ttir.softmax"(%87, %88) <{dimension = -1 : si32}> : (tensor<1x32x12x12xf32>, tensor<1x32x12x12xf32>) -> tensor<1x32x12x12xf32>
+    %90 = tensor.empty() : tensor<32x12x12xf32>
+    %91 = "ttir.squeeze"(%89, %90) <{dim = 0 : si32}> : (tensor<1x32x12x12xf32>, tensor<32x12x12xf32>) -> tensor<32x12x12xf32>
+    %92 = tensor.empty() : tensor<12x3200xf32>
+    %93 = "ttir.matmul"(%1, %arg13, %92) : (tensor<12x3200xf32>, tensor<3200x3200xf32>, tensor<12x3200xf32>) -> tensor<12x3200xf32>
+    %94 = tensor.empty() : tensor<1x12x32x100xf32>
+    %95 = "ttir.reshape"(%93, %94) <{shape = [1 : i32, 12 : i32, 32 : i32, 100 : i32]}> : (tensor<12x3200xf32>, tensor<1x12x32x100xf32>) -> tensor<1x12x32x100xf32>
+    %96 = tensor.empty() : tensor<1x32x12x100xf32>
+    %97 = "ttir.transpose"(%95, %96) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x12x32x100xf32>, tensor<1x32x12x100xf32>) -> tensor<1x32x12x100xf32>
+    %98 = tensor.empty() : tensor<1x32x100x12xf32>
+    %99 = "ttir.transpose"(%97, %98) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<1x32x12x100xf32>, tensor<1x32x100x12xf32>) -> tensor<1x32x100x12xf32>
+    %100 = tensor.empty() : tensor<32x100x12xf32>
+    %101 = "ttir.squeeze"(%99, %100) <{dim = 0 : si32}> : (tensor<1x32x100x12xf32>, tensor<32x100x12xf32>) -> tensor<32x100x12xf32>
+    %102 = tensor.empty() : tensor<32x12x100xf32>
+    %103 = "ttir.transpose"(%101, %102) <{dim0 = -2 : si32, dim1 = -1 : si32}> : (tensor<32x100x12xf32>, tensor<32x12x100xf32>) -> tensor<32x12x100xf32>
+    %104 = tensor.empty() : tensor<32x12x100xf32>
+    %105 = "ttir.matmul"(%91, %103, %104) : (tensor<32x12x12xf32>, tensor<32x12x100xf32>, tensor<32x12x100xf32>) -> tensor<32x12x100xf32>
+    %106 = tensor.empty() : tensor<1x32x12x100xf32>
+    %107 = "ttir.unsqueeze"(%105, %106) <{dim = 0 : si32}> : (tensor<32x12x100xf32>, tensor<1x32x12x100xf32>) -> tensor<1x32x12x100xf32>
+    %108 = tensor.empty() : tensor<1x12x32x100xf32>
+    %109 = "ttir.transpose"(%107, %108) <{dim0 = -3 : si32, dim1 = -2 : si32}> : (tensor<1x32x12x100xf32>, tensor<1x12x32x100xf32>) -> tensor<1x12x32x100xf32>
+    %110 = tensor.empty() : tensor<12x3200xf32>
+    %111 = "ttir.reshape"(%109, %110) <{shape = [12 : i32, 3200 : i32]}> : (tensor<1x12x32x100xf32>, tensor<12x3200xf32>) -> tensor<12x3200xf32>
+    %112 = tensor.empty() : tensor<12x3200xf32>
+    %113 = "ttir.matmul"(%111, %arg14, %112) : (tensor<12x3200xf32>, tensor<3200x3200xf32>, tensor<12x3200xf32>) -> tensor<12x3200xf32>
+    %114 = tensor.empty() : tensor<1x12x3200xf32>
+    %115 = "ttir.unsqueeze"(%113, %114) <{dim = 0 : si32}> : (tensor<12x3200xf32>, tensor<1x12x3200xf32>) -> tensor<1x12x3200xf32>
+    return %115 : tensor<1x12x3200xf32>
+  }
+}


### PR DESCRIPTION
### Ticket
Closes #1768 

### What's changed
PoC for large real world model chunks through `TTBuilder`. Also demonstrates a golden check for said model.

### Notes:
The Silicon test of the generated `ttir` `mlir` Llama attention block is _not_ filechecked. If requested we could use [this script](https://github.com/llvm/llvm-project/blob/main/mlir/utils/generate-test-checks.py) to generate them, but our canonical and atomic checks for ops and common patterns should be robust enough to guarantee correctness here. I attempted to manually do it and got about halfway before thoughts of sunken cost fallacy started entering my head. We should set up a set of standards for FileCheck in the future. 
