### PR TITLE
Add support for negative constant

### DIFF
--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -883,9 +883,11 @@ public:
 
       mlir::APFloat fillValue(mlir::APFloat::IEEEsingle());
       if (valueAttr.getElementType().isInteger()) {
+        // Both signed and signless integer can have negative values.
+        bool isSigned = valueAttr.getElementType().isSignedInteger() ||
+                        valueAttr.getElementType().isSignlessInteger();
         fillValue.convertFromAPInt(valueAttr.getSplatValue<llvm::APInt>(),
-                                   valueAttr.getElementType().isSignedInteger(),
-                                   llvm::RoundingMode::TowardZero);
+                                   isSigned, llvm::RoundingMode::TowardZero);
       } else {
         fillValue = valueAttr.getSplatValue<mlir::APFloat>();
       }

--- a/test/ttmlir/Conversion/StableHLOToTTIR/constant_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/constant_op.mlir
@@ -306,4 +306,37 @@ module @jit_constant attributes {} {
     // CHECK: return %{{[0-9]+}} : tensor<2x2xui32>
     return %0 : tensor<2x2xui64>
   }
+
+  func.func public @test_int8_negative_scalar() -> tensor<i8> {
+    // CHECK-LABEL: func.func public @test_int8_negative_scalar
+    // CHECK: %[[CONSTANT:[0-9]+]] = "ttir.constant"() <{value = dense<-3> : tensor<1xi8>}> : () -> tensor<1xi8>
+    %0 = stablehlo.constant dense<-3> : tensor<i8>
+    // CHECK: return %[[CONSTANT]] : tensor<1xi8>
+    return %0 : tensor<i8>
+  }
+
+  func.func public @test_int16_negative_splat() -> tensor<64xi16> {
+    // CHECK-LABEL: func.func public @test_int16_negative_splat
+    // CHECK: %[[CONSTANT:[0-9]+]] = "ttir.constant"() <{value = dense<-3> : tensor<64xi16>}> : () -> tensor<64xi16>
+    %0 = stablehlo.constant dense<-3> : tensor<64xi16>
+    // CHECK: return %[[CONSTANT]] : tensor<64xi16>
+    return %0 : tensor<64xi16>
+  }
+
+  func.func public @test_int32_negative_multiple() -> tensor<2x2xi32> {
+    // The ugly regex after `dense` is necessary because double square opening
+    // brackets indicate substitution block in FileCheck syntax.
+    // CHECK: %[[CONSTANT:[0-9]+]] = "ttir.constant"() <{value = dense<{{([[])}}[0, -1], [-2, 3]]> : tensor<2x2xi32>}> : () -> tensor<2x2xi32>
+    %0 = stablehlo.constant dense<[[0, -1], [-2, 3]]> : tensor<2x2xi32>
+    // CHECK: return %[[CONSTANT]] : tensor<2x2xi32>
+    return %0 : tensor<2x2xi32>
+  }
+
+  func.func public @test_int64_negative_min_scalar() -> tensor<i64> {
+    // CHECK-LABEL: func.func public @test_int64_negative_min_scalar
+    // CHECK: %[[CONSTANT:[0-9]+]] = "ttir.constant"() <{value = dense<-2147483648> : tensor<1xi32>}> : () -> tensor<1xi32>
+    %0 = stablehlo.constant dense<9223372036854775808> : tensor<i64>
+    // CHECK: return %[[CONSTANT]] : tensor<1xi32>
+    return %0 : tensor<i64>
+  }
 }

--- a/test/ttmlir/Dialect/TTNN/simple_constant.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_constant.mlir
@@ -127,4 +127,12 @@ module attributes {} {
     %0 = "ttir.constant"() <{value = dense<[[1], [2], [3]]> : tensor<3x1xui8>}> : () -> tensor<3x1xui8>
     return %0 : tensor<3x1xui8>
   }
+
+  func.func @test_constant_i32_negative() -> tensor<1x1x3xi32> {
+    // CHECK: "ttnn.constant"
+    // CHECK-SAME: value = dense
+    // CHECK-SAME: -1, 2, 3
+    %0 = "ttir.constant"() <{value = dense<[[[-1, 2, 3]]]> : tensor<1x1x3xi32>}> : () -> tensor<1x1x3xi32>
+    return %0 : tensor<1x1x3xi32>
+  }
 }


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-mlir/issues/2287

### Problem description
LLVM disabled `implicitTruncate` as default option for APInt constructor which triggered assertion for negative constant. It also caused failure for 64 bit constant as 64 bit constants are converted to 32 bit implicitly (64 bit integer is unsupported hardware type).

### What's changed
- Use APInt object to extract constant values instead of basic data types (int16_t, 
uint16_t, int32_t, uint32_t, etc.) which covers both positive and negative values.
- Use APInt::truncSSat() (truncation with sign saturation) instead of implicit truncation. 
This will convert `-INT64_MIN` to `-INT32_MIN` instead of converting it to `0`.
- TTIR->TTNN conversion for `ttir.constant` is also updated to consider signless integer
as signed value as they can also store negative values. 

### Checklist
- [X] New/Existing tests provide coverage for changes
