### PR TITLE
Pykernel - matmul common reader/writer kernels

### DIFF
--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -634,7 +634,7 @@ def TTKernel_StoreToL1Op : TTKernel_Op<"store_to_l1"> {
     let arguments = (ins I32:$value, TTKernel_L1AddrPtr:$l1_ptr, I32:$offset);
 }
 
-def TTKernel_GetInterleavedAddrGenFastConfigOp : TTKernel_Op<"get_interleaved_addr_gen_fast"> {
+def TTKernel_GetInterleavedAddrGenFastOp : TTKernel_Op<"get_interleaved_addr_gen_fast"> {
     let summary = "GetAddrGenFastConfig";
     let description = [{
       Returns an InterleavedAddrGenFast type.

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -640,7 +640,7 @@ def TTKernel_GetInterleavedAddrGenFastOp : TTKernel_Op<"get_interleaved_addr_gen
       Returns an InterleavedAddrGenFast type.
     }];
 
-    let arguments = (ins I1:$DRAM, I32:$bank_base_address, I32:$page_size, I32:$data_format);
+    let arguments = (ins I1:$DRAM, I32:$bank_base_address, I32:$page_size, TTKernel_DataFormat:$data_format);
     let results = (outs TTKernel_InterleavedAddrGenFast:$result);
 }
 
@@ -773,5 +773,13 @@ def TTKernel_GetTileSizeOp : TTKernel_Op<"get_tile_size"> {
     let results = (outs I32:$tileSizeBytes);
 }
 
+def TTKernel_GetDataFormatOp: TTKernel_Op<"get_dataformat"> {
+    let summary = "Get the data format of a given CB";
+    let description = [{
+      get_dataformat operation
+    }];
+    let arguments = (ins TTKernel_CB:$cb);
+    let results = (outs TTKernel_DataFormat:$dataFormat);
+}
 
 #endif

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -418,6 +418,15 @@ def TTKernel_NocAsyncReadOp : TTKernel_Op<"noc_async_read"> {
     let arguments = (ins TTKernel_NocAddr:$srcNocAddr, I32:$dstLocalL1Addr, I32:$size);
 }
 
+def TTKernel_NocAsyncReadTileOp : TTKernel_Op<"noc_async_read_tile"> {
+    let summary = "NocAsyncReadTile";
+    let description = [{
+      NocAsyncReadTile
+    }];
+
+    let arguments = (ins I32:$id, TTKernel_InterleavedAddrGenFast:$s, I32:$dstLocalL1Addr);
+}
+
 def TTKernel_NocAsyncReadOnePacketSetStateOp : TTKernel_Op<"noc_async_read_one_packet_set_state"> {
     let summary = "NocAsyncReadOnePacketSetState";
     let description = [{

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -634,6 +634,16 @@ def TTKernel_StoreToL1Op : TTKernel_Op<"store_to_l1"> {
     let arguments = (ins I32:$value, TTKernel_L1AddrPtr:$l1_ptr, I32:$offset);
 }
 
+def TTKernel_GetInterleavedAddrGenFastConfigOp : TTKernel_Op<"get_interleaved_addr_gen_fast"> {
+    let summary = "GetAddrGenFastConfig";
+    let description = [{
+      Returns an InterleavedAddrGenFast type.
+    }];
+
+    let arguments = (ins I1:$DRAM, I32:$bank_base_address, I32:$page_size, I32:$data_format);
+    let results = (outs TTKernel_InterleavedAddrGenFast:$result);
+}
+
 //===----------------------------------------------------------------------===//
 // TTKernel Multicast NoC operations
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -424,7 +424,7 @@ def TTKernel_NocAsyncReadTileOp : TTKernel_Op<"noc_async_read_tile"> {
       NocAsyncReadTile
     }];
 
-    let arguments = (ins I32:$id, TTKernel_InterleavedAddrGenFast:$s, I32:$dstLocalL1Addr);
+    let arguments = (ins I32:$id, TTKernel_InterleavedAddrGenFast:$addrGenStruct, I32:$dstLocalL1Addr);
 }
 
 def TTKernel_NocAsyncReadOnePacketSetStateOp : TTKernel_Op<"noc_async_read_one_packet_set_state"> {
@@ -467,7 +467,7 @@ def TTKernel_NocAsyncWriteTileOp : TTKernel_Op<"noc_async_write_tile"> {
       NocAsyncWriteTilie
     }];
 
-    let arguments = (ins I32:$id, TTKernel_InterleavedAddrGenFast:$s, I32:$srcLocalL1Addr);
+    let arguments = (ins I32:$id, TTKernel_InterleavedAddrGenFast:$addrGenStruct, I32:$srcLocalL1Addr);
 }
 
 def TTKernel_NocAsyncWriteBarrierOp : TTKernel_Op<"noc_async_write_barrier"> {
@@ -653,7 +653,7 @@ def TTKernel_StoreToL1Op : TTKernel_Op<"store_to_l1"> {
 }
 
 def TTKernel_GetInterleavedAddrGenFastOp : TTKernel_Op<"get_interleaved_addr_gen_fast"> {
-    let summary = "GetAddrGenFastConfig";
+    let summary = "GetInterleavedAddrGenFastOp";
     let description = [{
       Returns an InterleavedAddrGenFast type.
     }];

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -461,6 +461,15 @@ def TTKernel_NocAsyncWriteOp : TTKernel_Op<"noc_async_write"> {
     let arguments = (ins I32:$srcLocalL1Addr, TTKernel_NocAddr:$dstNocAddr, I32:$size);
 }
 
+def TTKernel_NocAsyncWriteTileOp : TTKernel_Op<"noc_async_write_tile"> {
+    let summary = "NocAsyncWriteTile";
+    let description = [{
+      NocAsyncWriteTilie
+    }];
+
+    let arguments = (ins I32:$id, TTKernel_InterleavedAddrGenFast:$s, I32:$srcLocalL1Addr);
+}
+
 def TTKernel_NocAsyncWriteBarrierOp : TTKernel_Op<"noc_async_write_barrier"> {
     let summary = "NocAsyncWriteBarrier";
     let description = [{

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsEnums.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsEnums.td
@@ -174,4 +174,48 @@ def TTKernel_ReduceDim : I32EnumAttr<"ReduceDim", "TTKernel Reduce Dimensions",
   let cppNamespace = "::mlir::tt::ttkernel";
 }
 
+def TTKernel_DataFormatFloat32    : I32EnumAttrCase<"Float32", 0, "Float32">;
+def TTKernel_DataFormatFloat16    : I32EnumAttrCase<"Float16", 1, "Float16">;
+def TTKernel_DataFormatBfp8       : I32EnumAttrCase<"Bfp8", 2, "Bfp8">;
+def TTKernel_DataFormatBfp4       : I32EnumAttrCase<"Bfp4", 3, "Bfp4">;
+def TTKernel_DataFormatBfp2       : I32EnumAttrCase<"Bfp2", 11, "Bfp2">;
+def TTKernel_DataFormatFloat16_b  : I32EnumAttrCase<"Float16_b", 5, "Float16_b">;
+def TTKernel_DataFormatBfp8_b     : I32EnumAttrCase<"Bfp8_b", 6, "Bfp8_b">;
+def TTKernel_DataFormatBfp4_b     : I32EnumAttrCase<"Bfp4_b", 7, "Bfp4_b">;
+def TTKernel_DataFormatBfp2_b     : I32EnumAttrCase<"Bfp2_b", 15, "Bfp2_b">;
+def TTKernel_DataFormatLf8        : I32EnumAttrCase<"Lf8", 10, "Lf8">;
+def TTKernel_DataFormatFp8_e4m3   : I32EnumAttrCase<"Fp8_e4m3", 0x1A, "Fp8_e4m3">;
+def TTKernel_DataFormatInt8       : I32EnumAttrCase<"Int8", 14, "Int8">;
+def TTKernel_DataFormatTf32       : I32EnumAttrCase<"Tf32", 4, "Tf32">;
+def TTKernel_DataFormatUInt8      : I32EnumAttrCase<"UInt8", 30, "UInt8">;
+def TTKernel_DataFormatUInt16     : I32EnumAttrCase<"UInt16", 9, "uint16">;
+def TTKernel_DataFormatInt32      : I32EnumAttrCase<"Int32", 8, "Int32">;
+def TTKernel_DataFormatUInt32     : I32EnumAttrCase<"UInt32", 24, "UInt32">;
+def TTKernel_DataFormatInvalid    : I32EnumAttrCase<"Invalid", 0xff, "Invalid">;
+
+def TTKernel_DataFormat : I32EnumAttr<"DataFormat", "TTKernel Tensix Dataformat">,
+                         [
+                           TTKernel_DataFormatFloat32,
+                           TTKernel_DataFormatFloat16,
+                           TTKernel_DataFormatBfp8,
+                           TTKernel_DataFormatBfp4,
+                           TTKernel_DataFormatBfp2,
+                           TTKernel_DataFormatFloat16_b,
+                           TTKernel_DataFormatBfp8_b,
+                           TTKernel_DataFormatBfp4_b,
+                           TTKernel_DataFormatBfp2_b,
+                           TTKernel_DataFormatLf8,
+                           TTKernel_DataFormatFp8_e4m3,
+                           TTKernel_DataFormatInt8,
+                           TTKernel_DataFormatTf32,
+                           TTKernel_DataFormatUInt8,
+                           TTKernel_DataFormatUInt16,
+                           TTKernel_DataFormatInt32,
+                           TTKernel_DataFormatUInt32,
+                           TTKernel_DataFormatInvalid
+                         ]> {
+  let genSpecializedAttr = 0;
+  let cppNamespace = "::mlir::tt::ttkernel";
+}
+
 #endif

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsEnums.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsEnums.td
@@ -193,7 +193,7 @@ def TTKernel_DataFormatInt32      : I32EnumAttrCase<"Int32", 8, "Int32">;
 def TTKernel_DataFormatUInt32     : I32EnumAttrCase<"UInt32", 24, "UInt32">;
 def TTKernel_DataFormatInvalid    : I32EnumAttrCase<"Invalid", 0xff, "Invalid">;
 
-def TTKernel_DataFormat : I32EnumAttr<"DataFormat", "TTKernel Tensix Dataformat">,
+def TTKernel_DataFormat : I32EnumAttr<"DataFormat", "TTKernel Tensix Dataformat",
                          [
                            TTKernel_DataFormatFloat32,
                            TTKernel_DataFormatFloat16,
@@ -212,7 +212,7 @@ def TTKernel_DataFormat : I32EnumAttr<"DataFormat", "TTKernel Tensix Dataformat"
                            TTKernel_DataFormatUInt16,
                            TTKernel_DataFormatInt32,
                            TTKernel_DataFormatUInt32,
-                           TTKernel_DataFormatInvalid
+                           TTKernel_DataFormatInvalid,
                          ]> {
   let genSpecializedAttr = 0;
   let cppNamespace = "::mlir::tt::ttkernel";

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsEnums.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsEnums.td
@@ -174,48 +174,4 @@ def TTKernel_ReduceDim : I32EnumAttr<"ReduceDim", "TTKernel Reduce Dimensions",
   let cppNamespace = "::mlir::tt::ttkernel";
 }
 
-def TTKernel_DataFormatFloat32    : I32EnumAttrCase<"Float32", 0, "Float32">;
-def TTKernel_DataFormatFloat16    : I32EnumAttrCase<"Float16", 1, "Float16">;
-def TTKernel_DataFormatBfp8       : I32EnumAttrCase<"Bfp8", 2, "Bfp8">;
-def TTKernel_DataFormatBfp4       : I32EnumAttrCase<"Bfp4", 3, "Bfp4">;
-def TTKernel_DataFormatBfp2       : I32EnumAttrCase<"Bfp2", 11, "Bfp2">;
-def TTKernel_DataFormatFloat16_b  : I32EnumAttrCase<"Float16_b", 5, "Float16_b">;
-def TTKernel_DataFormatBfp8_b     : I32EnumAttrCase<"Bfp8_b", 6, "Bfp8_b">;
-def TTKernel_DataFormatBfp4_b     : I32EnumAttrCase<"Bfp4_b", 7, "Bfp4_b">;
-def TTKernel_DataFormatBfp2_b     : I32EnumAttrCase<"Bfp2_b", 15, "Bfp2_b">;
-def TTKernel_DataFormatLf8        : I32EnumAttrCase<"Lf8", 10, "Lf8">;
-def TTKernel_DataFormatFp8_e4m3   : I32EnumAttrCase<"Fp8_e4m3", 0x1A, "Fp8_e4m3">;
-def TTKernel_DataFormatInt8       : I32EnumAttrCase<"Int8", 14, "Int8">;
-def TTKernel_DataFormatTf32       : I32EnumAttrCase<"Tf32", 4, "Tf32">;
-def TTKernel_DataFormatUInt8      : I32EnumAttrCase<"UInt8", 30, "UInt8">;
-def TTKernel_DataFormatUInt16     : I32EnumAttrCase<"UInt16", 9, "uint16">;
-def TTKernel_DataFormatInt32      : I32EnumAttrCase<"Int32", 8, "Int32">;
-def TTKernel_DataFormatUInt32     : I32EnumAttrCase<"UInt32", 24, "UInt32">;
-def TTKernel_DataFormatInvalid    : I32EnumAttrCase<"Invalid", 0xff, "Invalid">;
-
-def TTKernel_DataFormat : I32EnumAttr<"DataFormat", "TTKernel Tensix Dataformat",
-                         [
-                           TTKernel_DataFormatFloat32,
-                           TTKernel_DataFormatFloat16,
-                           TTKernel_DataFormatBfp8,
-                           TTKernel_DataFormatBfp4,
-                           TTKernel_DataFormatBfp2,
-                           TTKernel_DataFormatFloat16_b,
-                           TTKernel_DataFormatBfp8_b,
-                           TTKernel_DataFormatBfp4_b,
-                           TTKernel_DataFormatBfp2_b,
-                           TTKernel_DataFormatLf8,
-                           TTKernel_DataFormatFp8_e4m3,
-                           TTKernel_DataFormatInt8,
-                           TTKernel_DataFormatTf32,
-                           TTKernel_DataFormatUInt8,
-                           TTKernel_DataFormatUInt16,
-                           TTKernel_DataFormatInt32,
-                           TTKernel_DataFormatUInt32,
-                           TTKernel_DataFormatInvalid,
-                         ]> {
-  let genSpecializedAttr = 0;
-  let cppNamespace = "::mlir::tt::ttkernel";
-}
-
 #endif

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
@@ -141,4 +141,14 @@ def TTKernel_L1AddrPtr : TTKernel_Type<"L1AddrPtr", "l1_addr_ptr"> {
     let description = "L1 pointer address type in TTKernel dialect";
 }
 
+// consider using a class for templated types?
+def TTKernel_InterleavedAddrGenFast : TTKernel_Type<"InterleavedAddrGenFast", "interleaved_addr_gen_fast"> {
+    let summary = "TTKernel InterleavedAddrGenFast type";
+    let description = "InterleavedAddrGenFast type in TTKernel dialect";
+    let parameters = (ins "uint32_t":$bank_base_address,
+                          "uint32_t":$page_size,
+                          "DataFormat":$data_format);
+    let assemblyFormat =  "`<` $bank_base_address`,` $page_size`,` $data_format `>`";
+}
+
 #endif

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
@@ -147,8 +147,11 @@ def TTKernel_InterleavedAddrGenFast : TTKernel_Type<"InterleavedAddrGenFast", "i
     let description = "InterleavedAddrGenFast type in TTKernel dialect";
     let parameters = (ins "uint32_t":$bank_base_address,
                           "uint32_t":$page_size,
-                          "DataFormat":$data_format);
-    let assemblyFormat =  "`<` $bank_base_address`,` $page_size`,` $data_format `>`";
+                          // "DataFormat":$data_format,
+                          DefaultValuedParameter<"bool", "true">:$DRAM,
+                          DefaultValuedParameter<"uint32_t", "1024">:$tile_hw);
+    // let assemblyFormat =  "`<` $bank_base_address `,` $page_size `,` $data_format `,` $DRAM `,` $tile_hw `>`";
+    let assemblyFormat =  "`<` $bank_base_address `,` $page_size `,` $DRAM `,` $tile_hw `>`";
 }
 
 #endif

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
@@ -145,13 +145,11 @@ def TTKernel_L1AddrPtr : TTKernel_Type<"L1AddrPtr", "l1_addr_ptr"> {
 def TTKernel_InterleavedAddrGenFast : TTKernel_Type<"InterleavedAddrGenFast", "interleaved_addr_gen_fast"> {
     let summary = "TTKernel InterleavedAddrGenFast type";
     let description = "InterleavedAddrGenFast type in TTKernel dialect";
-    let parameters = (ins "uint32_t":$bank_base_address,
-                          "uint32_t":$page_size,
-                          // "DataFormat":$data_format,
-                          DefaultValuedParameter<"bool", "true">:$DRAM,
-                          DefaultValuedParameter<"uint32_t", "1024">:$tile_hw);
-    // let assemblyFormat =  "`<` $bank_base_address `,` $page_size `,` $data_format `,` $DRAM `,` $tile_hw `>`";
-    let assemblyFormat =  "`<` $bank_base_address `,` $page_size `,` $DRAM `,` $tile_hw `>`";
+    // let parameters = (ins DefaultValuedParameter<"bool", "true">:$DRAM,
+    //                       "uint32_t":$bank_base_address,
+    //                       "uint32_t":$page_size,
+    //                       "DataFormat":$data_format);
+    // let assemblyFormat =  "`<` $DRAM `,` $bank_base_address `,` $page_size `,` $data_format `>`";
 }
 
 #endif

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
@@ -141,15 +141,14 @@ def TTKernel_L1AddrPtr : TTKernel_Type<"L1AddrPtr", "l1_addr_ptr"> {
     let description = "L1 pointer address type in TTKernel dialect";
 }
 
-// consider using a class for templated types?
 def TTKernel_InterleavedAddrGenFast : TTKernel_Type<"InterleavedAddrGenFast", "interleaved_addr_gen_fast"> {
     let summary = "TTKernel InterleavedAddrGenFast type";
     let description = "InterleavedAddrGenFast type in TTKernel dialect";
-    // let parameters = (ins DefaultValuedParameter<"bool", "true">:$DRAM,
-    //                       "uint32_t":$bank_base_address,
-    //                       "uint32_t":$page_size,
-    //                       "DataFormat":$data_format);
-    // let assemblyFormat =  "`<` $DRAM `,` $bank_base_address `,` $page_size `,` $data_format `>`";
+}
+
+def TTKernel_DataFormat : TTKernel_Type<"DataFormat", "DataFormat"> {
+    let summary = "TTKernel tensix data format type";
+    let description = "Data format type in TTKernel dialect";
 }
 
 #endif

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -33,9 +33,9 @@
 #include <mlir/Transforms/DialectConversion.h>
 
 #include <cctype>
+#include <iostream>
 #include <string>
 #include <unordered_map>
-
 using namespace mlir;
 using namespace tt;
 
@@ -135,6 +135,7 @@ namespace {
 class TTKernelToEmitCTypeConverter : public NullTypeConverter {
 public:
   TTKernelToEmitCTypeConverter(MLIRContext *ctx) {
+    std::cout << " Hello from TTKernelToEmitCTypeConverter" << std::endl;
     addConversion([](Type type) { return type; });
     addConversion([ctx](mlir::tt::ttkernel::NocAddrType type) -> Type {
       return Builder(ctx).getI64Type();
@@ -150,6 +151,14 @@ public:
         [ctx](mlir::tt::ttkernel::L1AddrPtrType type) -> emitc::PointerType {
           return emitc::PointerType::get(
               emitc::OpaqueType::get(ctx, "volatile tt_l1_ptr uint32_t"));
+        });
+    addConversion(
+        [ctx](mlir::tt::ttkernel::InterleavedAddrGenFastType type) -> Type {
+          std::cout << " Hello from type converter" << std::endl;
+          std::string opaque_name = "InterleavedAddrGenFast<";
+          opaque_name += type.getDRAM() ? "true" : "false";
+          opaque_name += ", " + std::to_string(type.getTileHw()) + ">";
+          return emitc::OpaqueType::get(ctx, opaque_name);
         });
   }
 };

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -490,10 +490,10 @@ public:
       // Create an lvalue for all struct field accesses
       auto lvalueBankBaseAddr = rewriter.create<emitc::MemberOp>(
           op->getLoc(),
-          emitc::LValueType::get(op.getBankBaseAddress().getType()),
+          emitc::LValueType::get(adaptor.getBankBaseAddress().getType()),
           "bank_base_address", varOp);
       auto lvaluePageSize = rewriter.create<emitc::MemberOp>(
-          op->getLoc(), emitc::LValueType::get(op.getPageSize().getType()),
+          op->getLoc(), emitc::LValueType::get(adaptor.getPageSize().getType()),
           "page_size", varOp);
       auto lvalueDataFormat = rewriter.create<emitc::MemberOp>(
           op->getLoc(),
@@ -502,10 +502,10 @@ public:
 
       // Assign corresponding values to the struct members
       rewriter.create<emitc::AssignOp>(op->getLoc(), lvalueBankBaseAddr,
-                                       op.getBankBaseAddress());
+                                       adaptor.getBankBaseAddress());
       rewriter.create<emitc::AssignOp>(op->getLoc(), lvaluePageSize,
-                                       op.getPageSize());
-      rewriter.create<emitc::AssignOp>(op.getLoc(), lvalueDataFormat,
+                                       adaptor.getPageSize());
+      rewriter.create<emitc::AssignOp>(op->getLoc(), lvalueDataFormat,
                                        adaptor.getDataFormat());
 
       // Load the value from the lvalue variable
@@ -513,7 +513,6 @@ public:
           rewriter.create<emitc::LoadOp>(op->getLoc(), opaqueStructType, varOp);
 
       // Replace the original operation with the loaded value so it can be used.
-      op.replaceAllUsesWith(loadOp.getResult());
       rewriter.replaceOp(op, loadOp.getResult());
     }
     return success();
@@ -624,7 +623,6 @@ public:
         return op.getNumArguments() == 0;
       });
       target.addLegalOp<func::ReturnOp>();
-      target.addIllegalOp<ttkernel::GetInterleavedAddrGenFastOp>();
       target.addIllegalDialect<ttkernel::TTKernelDialect>();
 
       patterns.add<

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -672,6 +672,7 @@ public:
               ttkernel::NocAsyncReadOnePacketWithStateOp>,
           TTMetalToEmitCOpaqueRewriter<ttkernel::NocAsyncReadBarrierOp>,
           TTMetalToEmitCOpaqueRewriter<ttkernel::NocAsyncWriteOp>,
+          TTMetalToEmitCOpaqueRewriter<ttkernel::NocAsyncWriteTileOp>,
           TTMetalToEmitCOpaqueRewriter<ttkernel::NocAsyncWriteBarrierOp>,
           TTMetalToEmitCOpaqueRewriter<ttkernel::GetNocMulticastAddrOp>,
           TTMetalToEmitCOpaqueRewriter<

--- a/python/pykernel/pykernel_ast.py
+++ b/python/pykernel/pykernel_ast.py
@@ -101,6 +101,7 @@ class TTKernelCompiler(ast.NodeVisitor):
         "get_dataformat": ttkernel.get_dataformat,
         "get_noc_addr_from_bank_id": ttkernel.get_noc_addr_from_bank_id,
         "noc_async_read": ttkernel.noc_async_read,
+        "noc_async_read_tile": ttkernel.noc_async_read_tile,
         "noc_async_write": ttkernel.noc_async_write,
         "noc_async_read_barrier": ttkernel.noc_async_read_barrier,
         "noc_async_write_barrier": ttkernel.noc_async_write_barrier,

--- a/python/pykernel/pykernel_ast.py
+++ b/python/pykernel/pykernel_ast.py
@@ -92,7 +92,6 @@ class TTKernelCompiler(ast.NodeVisitor):
         "tile_regs_wait": ttkernel.tile_regs_wait,
         "pack_tile": ttkernel.pack_tile,
         "copy_tile": ttkernel.copy_tile,
-        "add": ttkernel.add,
         "add_tiles": ttkernel.add_tiles,
         "get_compile_time_arg_val": ttkernel.get_compile_time_arg_val,
         "get_write_ptr": ttkernel.get_write_ptr,
@@ -359,10 +358,13 @@ class TTKernelCompiler(ast.NodeVisitor):
 
         # load variable if needed
         if isinstance(lhs.type, memref.MemRefType):
-            lhs = memref.LoadOp(lhs, arith.ConstantOp(IndexType.get(self.ctx), 0))
+            lhs = memref.LoadOp(
+                lhs, arith.ConstantOp(IndexType.get(self.ctx), 0)
+            ).result
         if isinstance(rhs.type, memref.MemRefType):
-            rhs = memref.LoadOp(rhs, arith.ConstantOp(IndexType.get(self.ctx), 0))
-
+            rhs = memref.LoadOp(
+                rhs, arith.ConstantOp(IndexType.get(self.ctx), 0)
+            ).result
         match (node.op):
             case ast.Add():
                 return arith.addi(lhs, rhs)
@@ -458,7 +460,7 @@ def ttkernel_compile(kernel_type=None):
         def _wrapper(*args, **kwargs):
             m = ast.parse(inspect.getsource(f))
             b = TTKernelCompiler(f.__name__, args)
-            # print(ast.dump(m, indent=4) + "\n")
+            print(ast.dump(m, indent=4) + "\n")
             b.visit(m)
 
             # Check if generated IR is valid

--- a/python/pykernel/pykernel_ast.py
+++ b/python/pykernel/pykernel_ast.py
@@ -103,6 +103,7 @@ class TTKernelCompiler(ast.NodeVisitor):
         "noc_async_write": ttkernel.noc_async_write,
         "noc_async_read_barrier": ttkernel.noc_async_read_barrier,
         "noc_async_write_barrier": ttkernel.noc_async_write_barrier,
+        "get_interleaved_addr_gen_fast": ttkernel.get_interleaved_addr_gen_fast,
     }
 
     def __init__(self, name, args):
@@ -425,7 +426,11 @@ class TTKernelCompiler(ast.NodeVisitor):
 
     # Literals
     def visit_Constant(self, node):
-        if isinstance(node.value, int):
+        # print(node.value)
+        # print(isinstance(node.value, bool))
+        if isinstance(node.value, bool):
+            return arith.ConstantOp(IntegerType.get_signless(1, self.ctx), node.value)
+        elif isinstance(node.value, int):
             return arith.ConstantOp(IntegerType.get_signless(32, self.ctx), node.value)
         else:
             raise NotImplementedError(

--- a/python/pykernel/pykernel_ast.py
+++ b/python/pykernel/pykernel_ast.py
@@ -98,6 +98,7 @@ class TTKernelCompiler(ast.NodeVisitor):
         "get_write_ptr": ttkernel.get_write_ptr,
         "get_read_ptr": ttkernel.get_read_ptr,
         "get_tile_size": ttkernel.get_tile_size,
+        "get_dataformat": ttkernel.get_dataformat,
         "get_noc_addr_from_bank_id": ttkernel.get_noc_addr_from_bank_id,
         "noc_async_read": ttkernel.noc_async_read,
         "noc_async_write": ttkernel.noc_async_write,

--- a/python/pykernel/pykernel_ast.py
+++ b/python/pykernel/pykernel_ast.py
@@ -302,6 +302,11 @@ class TTKernelCompiler(ast.NodeVisitor):
         sym_table = self.symbol_tables[-1]
         var_name = node.target.id
 
+        if hasattr(value, "type") and isinstance(value.type, MemRefType):
+            raise ValueError(
+                "Not allowed to AnnAssign to another AnnAssign'ed variable. Temporary fix is to just add 0 to the variable."
+            )
+
         if not var:
             var_type = value.type
             memref_type = MemRefType.get([1], var_type)

--- a/python/pykernel/pykernel_ast.py
+++ b/python/pykernel/pykernel_ast.py
@@ -434,8 +434,6 @@ class TTKernelCompiler(ast.NodeVisitor):
 
     # Literals
     def visit_Constant(self, node):
-        # print(node.value)
-        # print(isinstance(node.value, bool))
         if isinstance(node.value, bool):
             return arith.ConstantOp(IntegerType.get_signless(1, self.ctx), node.value)
         elif isinstance(node.value, int):

--- a/python/pykernel/pykernel_ast.py
+++ b/python/pykernel/pykernel_ast.py
@@ -103,6 +103,7 @@ class TTKernelCompiler(ast.NodeVisitor):
         "noc_async_read": ttkernel.noc_async_read,
         "noc_async_read_tile": ttkernel.noc_async_read_tile,
         "noc_async_write": ttkernel.noc_async_write,
+        "noc_async_write_tile": ttkernel.noc_async_write_tile,
         "noc_async_read_barrier": ttkernel.noc_async_read_barrier,
         "noc_async_write_barrier": ttkernel.noc_async_write_barrier,
         "get_interleaved_addr_gen_fast": ttkernel.get_interleaved_addr_gen_fast,

--- a/test/pykernel/matmul_common/reader_bmm_8bank.py
+++ b/test/pykernel/matmul_common/reader_bmm_8bank.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from pykernel.pykernel_ast import *
+from pykernel.types import *
+
+
+@ttkernel_noc_compile()
+def reader_bmm_8bank(cb_id_in0: CircularBuffer, cb_id_in1: CircularBuffer):
+    src0_addr = get_arg_val(int, 0)
+    src1_addr = get_arg_val(int, 1)
+    Mt = get_arg_val(int, 2)
+    Kt = get_arg_val(int, 3)
+    Nt = get_arg_val(int, 4)
+    MtKt = get_arg_val(int, 5)
+    KtNt = get_arg_val(int, 6)
+    batch = get_arg_val(int, 7)
+    bcast_B = get_arg_val(int, 8)
+
+    src0_is_dram = get_compile_time_arg_val(int, 0) == 1
+    src1_is_dram = get_compile_time_arg_val(int, 1) == 1
+
+    onetile = 1
+    src0_tile_bytes = get_tile_size(cb_id_in0)
+    src0_data_format = get_dataformat(cb_id_in0)
+    src1_tile_bytes = get_tile_size(cb_id_in1)
+    src1_data_format = get_dataformat(cb_id_in1)
+
+    itileA_batch: int = 0
+    itileB_batch: int = 0
+
+    s0 = get_interleaved_addr_gen_fast(
+        src0_is_dram, src0_addr, src0_tile_bytes, src0_data_format
+    )
+    s1 = get_interleaved_addr_gen_fast(
+        src1_is_dram, src1_addr, src1_tile_bytes, src1_data_format
+    )
+
+    for nb in range(0, batch, 1):
+        itileA: int = itileA_batch + 0
+        for mt in range(0, Mt, 1):
+            itileB = itileB_batch + 0
+            for nt in range(0, Nt, 1):
+                for kt in range(0, Kt, 1):
+                    cb_reserve_back(cb_id_in0, onetile)
+                    l1_write_addr_in0 = get_write_ptr(cb_id_in0)
+                    noc_async_read_tile(itileA, s0, l1_write_addr_in0)
+                    noc_async_read_barrier()
+                    cb_push_back(cb_id_in0, onetile)
+
+                    cb_reserve_back(cb_id_in1, onetile)
+                    l1_write_addr_in1 = get_write_ptr(cb_id_in1)
+                    noc_async_read_tile(itileB, s1, l1_write_addr_in1)
+                    noc_async_read_barrier()
+                    cb_push_back(cb_id_in1, onetile)
+
+                    itileA = itileA + 1
+                    itileB = itileB + Nt
+
+                itileB = itileB - KtNt + 1
+                itileA = itileA - Kt
+            itileA = itileA + Kt
+        itileA_batch = itileA_batch + MtKt
+        if bcast_B == 0:
+            itileB_batch = itileB_batch + KtNt
+
+    return
+
+
+cb_in0 = CircularBuffer(0)
+cb_in1 = CircularBuffer(1)
+kernel_string = reader_bmm_8bank(cb_in0, cb_in1)
+py_kernel = Kernel("reader_bmm_8bank", kernel_string)
+py_kernel.dump()

--- a/test/pykernel/matmul_common/reader_bmm_8bank.py
+++ b/test/pykernel/matmul_common/reader_bmm_8bank.py
@@ -2,6 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# RUN: %python %s
+# REQUIRES: pykernel
+
 from pykernel.pykernel_ast import *
 from pykernel.types import *
 

--- a/test/pykernel/matmul_common/reader_bmm_8bank_output_tiles_partitioned.py
+++ b/test/pykernel/matmul_common/reader_bmm_8bank_output_tiles_partitioned.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from pykernel.pykernel_ast import *
+from pykernel.types import *
+
+
+@ttkernel_noc_compile()
+def reader_bmm_8bank_output_tiles_partitioned(
+    cb_id_in0: CircularBuffer, cb_id_in1: CircularBuffer
+):
+    src0_addr = get_arg_val(int, 0)
+    src1_addr = get_arg_val(int, 1)
+    Mt = get_arg_val(int, 2)
+    Kt = get_arg_val(int, 3)
+    Nt = get_arg_val(int, 4)
+    MtKt = get_arg_val(int, 5)
+    KtNt = get_arg_val(int, 6)
+    batch = get_arg_val(int, 7)
+    bcast_B = get_arg_val(int, 8)
+    output_tile_start_id = get_arg_val(int, 9)
+    num_output_tiles = get_arg_val(int, 10)
+    MtNt = get_arg_val(int, 11)
+
+    src0_is_dram = get_compile_time_arg_val(0) == 1
+    src1_is_dram = get_compile_time_arg_val(1) == 1
+
+    itileA = output_tile_start_id / Nt * Kt
+
+    onetile = 1
+    in0_tile_bytes = get_tile_size(cb_id_in0)
+    in0_data_format = get_dataformat(cb_id_in0)
+    in1_tile_bytes = get_tile_size(cb_id_in1)
+    in1_data_format = get_dataformat(cb_id_in1)
+
+    # outbatch = output_tile_start_id % MtNt
+    # itileB_batch = output_tile_start_id % Nt
+    # itileB = itileB_batch
+
+    s0 = get_interleaved_addr_gen_fast(
+        src0_is_dram, src0_addr, in0_tile_bytes, in0_data_format
+    )
+    s1 = get_interleaved_addr_gen_fast(
+        src1_is_dram, src1_addr, in1_tile_bytes, in1_data_format
+    )
+
+    l1_write_addr_in0 = get_write_ptr(cb_id_in0)
+    noc_async_read_tile(itileA, s0, l1_write_addr_in0)

--- a/test/pykernel/matmul_common/reader_bmm_8bank_output_tiles_partitioned.py
+++ b/test/pykernel/matmul_common/reader_bmm_8bank_output_tiles_partitioned.py
@@ -23,10 +23,10 @@ def reader_bmm_8bank_output_tiles_partitioned(
     num_output_tiles = get_arg_val(int, 10)
     MtNt = get_arg_val(int, 11)
 
-    src0_is_dram = get_compile_time_arg_val(0) == 1
-    src1_is_dram = get_compile_time_arg_val(1) == 1
+    src0_is_dram = get_compile_time_arg_val(int, 0) == 1
+    src1_is_dram = get_compile_time_arg_val(int, 1) == 1
 
-    itileA = output_tile_start_id / Nt * Kt
+    itileA: int = output_tile_start_id  # should be: output_tile_start_id / Nt * Kt
 
     onetile = 1
     in0_tile_bytes = get_tile_size(cb_id_in0)
@@ -34,9 +34,13 @@ def reader_bmm_8bank_output_tiles_partitioned(
     in1_tile_bytes = get_tile_size(cb_id_in1)
     in1_data_format = get_dataformat(cb_id_in1)
 
-    # outbatch = output_tile_start_id % MtNt
-    # itileB_batch = output_tile_start_id % Nt
-    # itileB = itileB_batch
+    outbatch: int = (
+        output_tile_start_id * MtNt
+    )  # should be: output_tile_start_id % MtNt
+    itileB_batch: int = (
+        output_tile_start_id * Nt
+    )  # should be: output_tile_start_id % Nt
+    itileB: int = itileB_batch + 0
 
     s0 = get_interleaved_addr_gen_fast(
         src0_is_dram, src0_addr, in0_tile_bytes, in0_data_format
@@ -45,5 +49,43 @@ def reader_bmm_8bank_output_tiles_partitioned(
         src1_is_dram, src1_addr, in1_tile_bytes, in1_data_format
     )
 
-    l1_write_addr_in0 = get_write_ptr(cb_id_in0)
-    noc_async_read_tile(itileA, s0, l1_write_addr_in0)
+    for n in range(0, num_output_tiles, 1):
+        for kt in range(0, Kt, 1):
+            cb_reserve_back(cb_id_in0, onetile)
+            l1_write_addr_in0 = get_write_ptr(cb_id_in0)
+            noc_async_read_tile(itileA, s0, l1_write_addr_in0)
+            noc_async_read_barrier()
+            cb_push_back(cb_id_in0, onetile)
+
+            cb_reserve_back(cb_id_in1, onetile)
+            l1_write_addr_in1 = get_write_ptr(cb_id_in1)
+            noc_async_read_tile(itileB, s1, l1_write_addr_in1)
+            noc_async_read_barrier()
+            cb_push_back(cb_id_in1, onetile)
+
+            itileA = itileA + 1
+            itileB = itileB + Nt
+
+        outbatch = outbatch + 1
+        itileB_batch = itileB_batch + 1
+        itileB = itileB - KtNt
+        itileB = itileB + 1
+
+        if itileB_batch == Nt:
+            itileB_batch = 0
+            itileB = itileB - Nt
+            if outbatch == MtNt:
+                if bcast_B == 0:
+                    itileB = itileB + KtNt
+                outbatch = 0
+        else:
+            itileA = itileA - Kt
+
+    return
+
+
+cb_in0 = CircularBuffer(0)
+cb_in1 = CircularBuffer(1)
+kernel_string = reader_bmm_8bank_output_tiles_partitioned(cb_in0, cb_in1)
+py_kernel = Kernel("reader_bmm_8bank_output_tiles_partitioned", kernel_string)
+py_kernel.dump()

--- a/test/pykernel/matmul_common/reader_bmm_8bank_output_tiles_partitioned.py
+++ b/test/pykernel/matmul_common/reader_bmm_8bank_output_tiles_partitioned.py
@@ -2,6 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# RUN: %python %s
+# REQUIRES: pykernel
+
 from pykernel.pykernel_ast import *
 from pykernel.types import *
 

--- a/test/pykernel/matmul_common/writer_bmm_8bank.py
+++ b/test/pykernel/matmul_common/writer_bmm_8bank.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from pykernel.pykernel_ast import *
+from pykernel.types import *
+
+
+@ttkernel_noc_compile()
+def writer_bmm_8bank(cb_id_out0: CircularBuffer):
+    dst_addr = get_arg_val(int, 0)
+    Mt = get_arg_val(int, 2)
+    Nt = get_arg_val(int, 4)
+    batch = get_arg_val(int, 7)
+
+    dst_is_dram = get_compile_time_arg_val(int, 0) == 1
+
+    onetile = 1
+    tile_bytes = get_tile_size(cb_id_out0)
+    data_format = get_dataformat(cb_id_out0)
+    itileC: int = 0
+
+    s = get_interleaved_addr_gen_fast(dst_is_dram, dst_addr, tile_bytes, data_format)
+
+    for nb in range(0, batch, 1):
+        for mt_C in range(0, Mt, 1):
+            for nt_C in range(0, Nt, 1):
+                cb_wait_front(cb_id_out0, onetile)
+                l1_read_addr = get_read_ptr(cb_id_out0)
+                noc_async_write_tile(itileC, s, l1_read_addr)
+                noc_async_write_barrier()
+                cb_pop_front(cb_id_out0, onetile)
+                itileC = itileC + 1
+
+    return
+
+
+cb_in0 = CircularBuffer(0)
+cb_in1 = CircularBuffer(1)
+kernel_string = writer_bmm_8bank(cb_in0, cb_in1)
+py_kernel = Kernel("writer_bmm_8bank", kernel_string)
+py_kernel.dump()

--- a/test/pykernel/matmul_common/writer_bmm_8bank.py
+++ b/test/pykernel/matmul_common/writer_bmm_8bank.py
@@ -2,6 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# RUN: %python %s
+# REQUIRES: pykernel
+
 from pykernel.pykernel_ast import *
 from pykernel.types import *
 

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -571,6 +571,30 @@ module {
       return
     }
 
+    // CHECK-LABEL: func @interleaved_addr_gen_fast_funcs
+    func.func @interleaved_addr_gen_fast_funcs(%cb: !cb0_tiles) -> () {
+      // CHECK: = emitc.call_opaque "get_dataformat"{{.*}}
+      %data_format = "ttkernel.get_dataformat"(%cb) : (!cb0_tiles) -> !ttkernel.DataFormat
+      // CHECK: %[[VAR:.*]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.opaque<"InterleavedAddrGenFast<true>">>
+      // CHECK: "emitc.member"(%[[VAR]]) <{member = "bank_base_address"}>{{.*}}
+      // CHECK: "emitc.member"(%[[VAR]]) <{member = "page_size"}>{{.*}}
+      // CHECK: "emitc.member"(%[[VAR]]) <{member = "data_format"}>{{.*}}
+      // CHECK: emitc.assign {{.*}}
+      // CHECK: emitc.assign {{.*}}
+      // CHECK: emitc.assign {{.*}}
+      // CHECK: = emitc.load %[[VAR]] : <!emitc.opaque<"InterleavedAddrGenFast<true>">>
+      %is_dram = arith.constant 1 : i1
+      %temp1 = arith.constant 262400 : i32
+      %temp2 = arith.constant 32 : i32
+      %s = "ttkernel.get_interleaved_addr_gen_fast"(%is_dram, %temp1, %temp2, %data_format) : (i1, i32, i32, !ttkernel.DataFormat) -> !ttkernel.interleaved_addr_gen_fast
+      // CHECK: emitc.call_opaque "noc_async_write_tile"{{.*}}
+      "ttkernel.noc_async_write_tile"(%temp2, %s, %temp1) : (i32, !ttkernel.interleaved_addr_gen_fast, i32) -> ()
+      // CHECK: emitc.call_opaque "noc_async_read_tile"{{.*}}
+      "ttkernel.noc_async_read_tile"(%temp2, %s, %temp1) : (i32, !ttkernel.interleaved_addr_gen_fast, i32) -> ()
+      // CHECK-NEXT: return
+      return
+    }
+
   } // module
 
 } // module

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -573,7 +573,7 @@ module {
 
     // CHECK-LABEL: func @interleaved_addr_gen_fast_funcs
     func.func @interleaved_addr_gen_fast_funcs(%cb: !cb0_tiles) -> () {
-      // CHECK: %[[DATA_FORMAT:.*]]= emitc.call_opaque "get_dataformat"{{.*}}
+      // CHECK: %[[DATA_FORMAT:.*]]= emitc.call_opaque "get_dataformat"
       %data_format = "ttkernel.get_dataformat"(%cb) : (!cb0_tiles) -> !ttkernel.DataFormat
       // CHECK: = "emitc.constant"() <{value = true}>
       // CHECK: %[[TEMP_ADDR:.*]] = "emitc.constant"()
@@ -584,9 +584,9 @@ module {
       %tile_size = arith.constant 8 : i32
       %tile = arith.constant 1 : i32
       // CHECK: %[[VAR:.*]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.opaque<"InterleavedAddrGenFast<true>">>
-      // CHECK: "emitc.member"(%[[VAR]]) <{member = "bank_base_address"}>{{.*}}
-      // CHECK: "emitc.member"(%[[VAR]]) <{member = "page_size"}>{{.*}}
-      // CHECK: "emitc.member"(%[[VAR]]) <{member = "data_format"}>{{.*}}
+      // CHECK: "emitc.member"(%[[VAR]]) <{member = "bank_base_address"}>
+      // CHECK: "emitc.member"(%[[VAR]]) <{member = "page_size"}>
+      // CHECK: "emitc.member"(%[[VAR]]) <{member = "data_format"}>
       // CHECK: emitc.assign %[[TEMP_ADDR]]
       // CHECK: emitc.assign %[[TILE_SIZE]]
       // CHECK: emitc.assign %[[DATA_FORMAT]]


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/2254

More specifically: 
https://github.com/tenstorrent/tt-mlir/issues/2178
https://github.com/tenstorrent/tt-mlir/issues/2247
https://github.com/tenstorrent/tt-mlir/issues/2249

### Problem description
Want to be able to write reader and writer kernels used in matmul programming examples.

### What's changed
`InterleavedAddrGenFast` cpp struct mapping:
- struct itself is exposed to python through TTKernelOp `get_interleaved_addr_gen_fast`
- conversionpatternrewriter for said Op that will do the following:
```
%6 = "ttkernel.get_interleaved_addr_gen_fast"(%3, %0, %4, %5) : (i1, i32, i32, !ttkernel.DataFormat) -> !ttkernel.interleaved_addr_gen_fast

-> to emitc

%14 = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.opaque<"InterleavedAddrGenFast<true>">>
%15 = "emitc.member"(%14) <{member = "bank_base_address"}> : (!emitc.lvalue<!emitc.opaque<"InterleavedAddrGenFast<true>">>) -> !emitc.lvalue<i32>
%16 = "emitc.member"(%14) <{member = "page_size"}> : (!emitc.lvalue<!emitc.opaque<"InterleavedAddrGenFast<true>">>) -> !emitc.lvalue<i32>
%17 = "emitc.member"(%14) <{member = "data_format"}> : (!emitc.lvalue<!emitc.opaque<"InterleavedAddrGenFast<true>">>) -> !emitc.lvalue<!emitc.opaque<"DataFormat">>
emitc.assign %5 : i32 to %15 : <i32>
emitc.assign %12 : i32 to %16 : <i32>
emitc.assign %13 : !emitc.opaque<"DataFormat"> to %17 : <!emitc.opaque<"DataFormat">>
%18 = emitc.load %14 : <!emitc.opaque<"InterleavedAddrGenFast<true>">>

-> to cpp

InterleavedAddrGenFast<true> v15;
v15.bank_base_address = v6;
v15.page_size = v13;
v15.data_format = v14;
InterleavedAddrGenFast<true> v16 = v15;
```

- added `noc_async_read_tile` ttkernel op
- added `noc_async_write_tile` ttkernel op

### Checklist
- [x] TTKernelToEmitC unit tests for all added ops
