### PR TITLE
Adding ToLayout op folding

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -63,7 +63,7 @@ def TTNN_ToLayoutOp : TTNN_Op<"to_layout"> {
                          Optional<TT_Device>:$device);
     let results = (outs AnyRankedTensor:$result);
 
-    let hasCanonicalizeMethod = 1;
+    let hasCanonicalizer = 1;
 }
 
 def TTNN_TypecastOp : TTNN_Op<"typecast"> {

--- a/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
@@ -374,10 +374,10 @@ public:
       }
 
       // TTNN mesh shard expects host input and output
-      // TODO(#2102): This can be removed once the workaround pass can correctly
-      // handle cannonicalization of toLayout ops. Currently the workaround pass
-      // cannot detect redundant toLayout ops as a result of forcing the output
-      // layout and removing them.
+      // TODO(#2291): This can be removed once the workaround pass can correctly
+      // handle canonicalization of toLayout ops (#2102). Currently the
+      // workaround pass cannot detect redundant toLayout ops as a result of
+      // forcing the output layout and removing them.
       if (mlir::isa<ttir::MeshShardOp>(op.getOperation())) {
         modified = changeLayoutToHost(op, operand, rewriter, isDPSResult);
         continue;

--- a/test/ttmlir/Dialect/TTNN/Canonicalizer/simple_to_layout_op_canonicalizer.mlir
+++ b/test/ttmlir/Dialect/TTNN/Canonicalizer/simple_to_layout_op_canonicalizer.mlir
@@ -66,7 +66,7 @@ module attributes {tt.device = #device, tt.system_desc = #system_desc} {
     return %2 : tensor<32x32xf32, #ttnn_layout5>
   }
 
-    func.func @merge_to_layout_op_4x(%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xf32, #ttnn_layout5> {
+  func.func @merge_to_layout_op_4x(%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xf32, #ttnn_layout5> {
     // Verify that the to_layout op is canonicalized to a single to_layout op and the attributes are merged.
     // CHECK: "ttnn.to_layout"(%arg0, %0)
     // CHECK-SAME: dtype = #tt.supportedDataTypes<f32>
@@ -80,5 +80,13 @@ module attributes {tt.device = #device, tt.system_desc = #system_desc} {
     %3 = "ttnn.to_layout"(%2, %0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <<1x1>>, <interleaved>>}> : (tensor<32x32xf32, #ttnn_layout5>, !tt.device<#device>) -> tensor<32x32xf32, #ttnn_layout3>
     %4 = "ttnn.to_layout"(%3, %0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory, <<32x32>>>}> : (tensor<32x32xf32, #ttnn_layout3>, !tt.device<#device>) -> tensor<32x32xf32, #ttnn_layout5>
     return %4 : tensor<32x32xf32, #ttnn_layout5>
+  }
+
+  func.func @fold_to_layout_op(%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout> {
+    // Verify folding of to_layout_op.
+    %0 = "ttnn.to_layout"(%arg0) <{dtype = #tt.supportedDataTypes<bf16>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory, <<32x32>>>}> : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout>
+    // CHECK-NOT: "ttnn.to_layout"
+    return %0 : tensor<32x32xbf16, #ttnn_layout>
+    // CHECK: return %arg0 : tensor<32x32xbf16
   }
 }


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/2102

### Problem description
In certain passes, we add multiple TTNN ToLayoutOps and have an assertion check in LayoutDecomposition to identify redundant ToLayoutOps.

### What's changed
A new folder has been created for TTNN ToLayoutOps that folds them when a redundant ToLayoutOp is detected.

### Checklist
- [x] New/Existing tests provide coverage for changes
