### PR TITLE
Fix ttnn-standalone.cpp; auto create ttnn-dylib.cpp so that the build script doesn't fail

### DIFF
--- a/tools/ttnn-standalone/CMakeLists.txt
+++ b/tools/ttnn-standalone/CMakeLists.txt
@@ -135,6 +135,9 @@ target_precompile_headers(ttnn-standalone PRIVATE ttnn-precompiled.hpp)
 #  \__,_| \__, ||_||_||_.__/
 #         |___/
 
+if(NOT EXISTS "ttnn-dylib.cpp")
+    file(TOUCH "ttnn-dylib.cpp")
+endif()
 add_library(ttnn-dylib SHARED ttnn-dylib.cpp)
 set_property(TARGET ttnn-dylib PROPERTY CXX_STANDARD 20)
 

--- a/tools/ttnn-standalone/ttnn-standalone.cpp
+++ b/tools/ttnn-standalone/ttnn-standalone.cpp
@@ -13,7 +13,7 @@ ttnn::Tensor add(ttnn::Tensor v1, ttnn::Tensor v2) {
   ttnn::Tensor v8 = ttnn::to_device(v2, v3, v7);
   ttnn::Tensor v9 = ttnn::to_layout(v8, ttnn::Layout::TILE, std::nullopt, std::nullopt, static_cast<::ttnn::IDevice *>(nullptr));
   ttnn::deallocate(v8, false);
-  ttnn::Shape v10 = ttnn::Shape(tt::tt_metal::LegacyShape({32, 32, }));
+  ttnn::Shape v10 = ttnn::Shape({32, 32});
   ttnn::MemoryConfig v11 = ttnn::MemoryConfig(ttnn::TensorMemoryLayout::INTERLEAVED, ttnn::BufferType::DRAM);
   ttnn::Tensor v12 = ttnn::empty(v10, ttnn::DataType::BFLOAT16, ttnn::Layout::TILE, v3, v11);
   ttnn::Tensor v13 = ttnn::add(v6, v9, std::nullopt, std::nullopt, v12);
@@ -27,9 +27,9 @@ ttnn::Tensor add(ttnn::Tensor v1, ttnn::Tensor v2) {
 }
 
 std::tuple<ttnn::Tensor, ttnn::Tensor> createInputsFor_add() {
-  ttnn::Shape v1 = ttnn::Shape(tt::tt_metal::LegacyShape({32, 32, }));
+  ttnn::Shape v1 = ttnn::Shape({32, 32});
   ttnn::Tensor v2 = ttnn::ones(v1, ttnn::DataType::BFLOAT16, ttnn::Layout::ROW_MAJOR, std::nullopt, std::nullopt);
-  ttnn::Shape v3 = ttnn::Shape(tt::tt_metal::LegacyShape({32, 32, }));
+  ttnn::Shape v3 = ttnn::Shape({32, 32});
   ttnn::Tensor v4 = ttnn::ones(v3, ttnn::DataType::BFLOAT16, ttnn::Layout::ROW_MAJOR, std::nullopt, std::nullopt);
   return std::make_tuple(v2, v4);
 }


### PR DESCRIPTION
### Ticket
#2301

### Problem description
TTNN Standalone fails on main due to 2 errors:
- stale LegacyShape used
- ttnn-dylib.cpp doesn't exist so the build script fails

### What's changed
Removed stale LegacyShape; added few lines to CMake script to create file if not already there.
