### PR TITLE
set CMAKE_INSTALL_MESSAGE to LAZY for third_party build

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -2,6 +2,8 @@ include(ExternalProject)
 
 set(TT_METAL_VERSION "45186bcf465d6bad3d5e8efaf3ef5afb9e2de2d9")
 
+set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
+
 if ("$ENV{ARCH_NAME}" STREQUAL "grayskull")
   set(ARCH_NAME "grayskull")
   set(ARCH_EXTRA_DIR "grayskull")


### PR DESCRIPTION
### Problem description
Current build can generate a long list of messages like
```
build] -- Install configuration: "Debug"
[build] -- Up-to-date: /localdev/vroubtsov/PRJ/tt-mlir/third_party/tt-metal/src/tt-metal-build/lib/libnng.a
[build] -- Up-to-date: /localdev/vroubtsov/PRJ/tt-mlir/third_party/tt-metal/src/tt-metal-build/lib/cmake/nng/nng-targets.cmake
[build] -- Up-to-date: /localdev/vroubtsov/PRJ/tt-mlir/third_party/tt-metal/src/tt-metal-build/lib/cmake/nng/nng-targets-debug.cmake
[build] -- Up-to-date: /localdev/vroubtsov/PRJ/tt-mlir/third_party/tt-metal/src/tt-metal-build/include/nng
[build] -- Up-to-date: /localdev/vroubtsov/PRJ/tt-mlir/third_party/tt-metal/src/tt-metal-build/include/nng/nng.h
...
```
which is unhelpful noise when the build output is captured and parsed by an IDE.

### What's changed

This is a quality-of-life improvement. `third_party/CMakeList.txt` adds a setting `set(CMAKE_INSTALL_MESSAGE LAZY)` which will [make cmake show the initial "Installing" messages but not "Up-to-date" on repeated/incremental builds](https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_MESSAGE.html).
