### PR TITLE
Add constraints and runtime API to transpose 

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -889,7 +889,9 @@ def TTNN_SoftmaxOp : TTNN_Op<"softmax",
     let hasVerifier = 1;
 }
 
-def TTNN_TransposeOp : TTNN_Op<"transpose"> {
+def TTNN_TransposeOp : TTNN_Op<"transpose",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
     let summary = "Transpose op.";
     let description = [{
       Transpose tensor along two given dimensions.

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -121,6 +121,23 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 }; // namespace ReshapeOpInterface
 
 //===----------------------------------------------------------------------===//
+// TransposeOp
+//===----------------------------------------------------------------------===//
+
+namespace TransposeOpInterface {
+llvm::Expected<std::tuple<size_t, size_t, size_t>>
+getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayout, const int dim0,
+                 const int dim1, mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+
+llvm::Expected<size_t>
+getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayout, const int dim0,
+             const int dim1, mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+
+}; // namespace TransposeOpInterface
+
+//===----------------------------------------------------------------------===//
 // MatmulOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -135,8 +135,7 @@ SoftmaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                             const TTNNLayoutAttr &output) {
   assert(inputs.size() == 1);
 
-  const auto inputShape =
-      mlir::cast<RankedTensorType>(getOperand().getType()).getShape();
+  const auto inputShape = getInput().getType().getShape();
 
   const auto outputShape =
       mlir::cast<RankedTensorType>(getResult().getType()).getShape();
@@ -155,8 +154,7 @@ SoftmaxOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                         const TTNNLayoutAttr &output) {
   assert(inputs.size() == 1);
 
-  const auto inputShape =
-      mlir::cast<RankedTensorType>(getOperand().getType()).getShape();
+  const auto inputShape = getInput().getType().getShape();
 
   const auto outputShape =
       mlir::cast<RankedTensorType>(getResult().getType()).getShape();
@@ -174,8 +172,7 @@ MeanOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                          const TTNNLayoutAttr &output) {
   assert(inputs.size() == 1);
 
-  const auto inputShape =
-      mlir::cast<RankedTensorType>(getOperand().getType()).getShape();
+  const auto inputShape = getInput().getType().getShape();
 
   llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
   if (!check) {
@@ -192,8 +189,7 @@ MeanOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                      const TTNNLayoutAttr &output) {
   assert(inputs.size() == 1);
 
-  const auto inputShape =
-      mlir::cast<RankedTensorType>(getOperand().getType()).getShape();
+  const auto inputShape = getInput().getType().getShape();
 
   return op_model::ttnn::MeanOpInterface::getOpRuntime(
       inputShape, inputs[0], detail::convertReductionArg(getDimArg()),
@@ -209,8 +205,7 @@ ReshapeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                             const TTNNLayoutAttr &output) {
   assert(inputs.size() == 1);
 
-  const auto inputShape =
-      mlir::cast<RankedTensorType>(getOperand().getType()).getShape();
+  const auto inputShape = getInput().getType().getShape();
 
   const auto outputShape =
       mlir::cast<RankedTensorType>(getResult().getType()).getShape();
@@ -229,8 +224,7 @@ ReshapeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                         const TTNNLayoutAttr &output) {
   assert(inputs.size() == 1);
 
-  const auto inputShape =
-      mlir::cast<RankedTensorType>(getOperand().getType()).getShape();
+  const auto inputShape = getInput().getType().getShape();
   const auto outputShape =
       mlir::cast<RankedTensorType>(getResult().getType()).getShape();
 
@@ -247,8 +241,7 @@ TransposeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                               const TTNNLayoutAttr &output) {
   assert(inputs.size() == 1);
 
-  const auto inputShape =
-      mlir::cast<RankedTensorType>(getOperand().getType()).getShape();
+  const auto inputShape = getInput().getType().getShape();
 
   llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
   if (!check) {
@@ -264,8 +257,7 @@ TransposeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                           const TTNNLayoutAttr &output) {
   assert(inputs.size() == 1);
 
-  const auto inputShape =
-      mlir::cast<RankedTensorType>(getOperand().getType()).getShape();
+  const auto inputShape = getInput().getType().getShape();
 
   return op_model::ttnn::TransposeOpInterface::getOpRuntime(
       inputShape, inputs[0], getDim0(), getDim1(), output);

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -239,6 +239,39 @@ ReshapeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// TransposeOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<std::tuple<size_t, size_t, size_t>>
+TransposeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                              const TTNNLayoutAttr &output) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape =
+      mlir::cast<RankedTensorType>(getOperand().getType()).getShape();
+
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+
+  return op_model::ttnn::TransposeOpInterface::getOpConstraints(
+      inputShape, inputs[0], getDim0(), getDim1(), output);
+}
+
+llvm::Expected<size_t>
+TransposeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                          const TTNNLayoutAttr &output) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape =
+      mlir::cast<RankedTensorType>(getOperand().getType()).getShape();
+
+  return op_model::ttnn::TransposeOpInterface::getOpRuntime(
+      inputShape, inputs[0], getDim0(), getDim1(), output);
+}
+
+//===----------------------------------------------------------------------===//
 // MatmulOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 

--- a/lib/OpModel/TTNN/MetalHeaders.h
+++ b/lib/OpModel/TTNN/MetalHeaders.h
@@ -62,6 +62,7 @@
 #include "ttnn/graph/graph_query_op_runtime.hpp"
 #include "ttnn/graph/graph_trace_utils.hpp"
 #include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
+#include "ttnn/operations/data_movement/transpose/transpose.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"
 #include "ttnn/operations/matmul/matmul.hpp"


### PR DESCRIPTION
### Ticket
#2314 

### Problem description
The optimizer needs more ops with constraints and runtime support to be able to ingest real models. Transpose is useful for both rennet (#2277) and llama (#2084)

### What's changed
Added constraints and runtime APIs to the `transposeOp`. Added unit tests to exercise the new API

Closes #2314 

### Checklist
- [X] New/Existing tests provide coverage for changes
