### PR TITLE
Maximize build space on Github runners

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -128,10 +128,16 @@ jobs:
     steps:
 
     - name: Maximize build space
-      uses: easimon/maximize-build-space@v10
-      with:
-        remove-dotnet: 'true'
-        remove-android: 'true'
+      shell: bash
+      run: |
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          sudo docker builder prune -a
+          df -h
         
     - uses: actions/checkout@v4
       with:
@@ -201,10 +207,16 @@ jobs:
     steps:
 
     - name: Maximize build space
-      uses: easimon/maximize-build-space@v10
-      with:
-        remove-dotnet: 'true'
-        remove-android: 'true'
+      shell: bash
+      run: |
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          sudo docker builder prune -a
+          df -h
 
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -126,6 +126,13 @@ jobs:
       image: ${{ needs.build-image.outputs.docker-image }}
 
     steps:
+
+    - name: Maximize build space
+      uses: easimon/maximize-build-space@v10
+      with:
+        remove-dotnet: 'true'
+        remove-android: 'true'
+        
     - uses: actions/checkout@v4
       with:
           fetch-depth: 0
@@ -192,6 +199,12 @@ jobs:
       image: ${{ needs.build-image.outputs.docker-image }}
 
     steps:
+
+    - name: Maximize build space
+      uses: easimon/maximize-build-space@v10
+      with:
+        remove-dotnet: 'true'
+        remove-android: 'true'
 
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -128,17 +128,11 @@ jobs:
     steps:
 
     - name: Maximize build space
-      shell: bash
-      run: |
-          df -h
-          sudo rm -rf /usr/share/dotnet || true
-          sudo rm -rf /usr/local/lib/android || true
-          sudo rm -rf /opt/ghc || true
-          sudo rm -rf /opt/hostedtoolcache/CodeQL || true
-          # sudo docker image prune --all --force || true
-          # sudo docker builder prune -a || true
-          df -h
-
+      uses: easimon/maximize-build-space@master
+      with:
+        remove-dotnet: 'true'
+        remove-android: 'true'
+        
     - uses: actions/checkout@v4
       with:
           fetch-depth: 0
@@ -207,16 +201,10 @@ jobs:
     steps:
 
     - name: Maximize build space
-      shell: bash
-      run: |
-          df -h
-          sudo rm -rf /usr/share/dotnet || true
-          sudo rm -rf /usr/local/lib/android || true
-          sudo rm -rf /opt/ghc || true
-          sudo rm -rf /opt/hostedtoolcache/CodeQL || true
-          # sudo docker image prune --all --force || true
-          # sudo docker builder prune -a || true
-          df -h
+      uses: easimon/maximize-build-space@master
+      with:
+        remove-dotnet: 'true'
+        remove-android: 'true'
 
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -121,17 +121,11 @@ jobs:
     strategy:
       fail-fast: false
     name: Debug Build
-    runs-on: ubuntu-latest
+    runs-on: runner
     container:
       image: ${{ needs.build-image.outputs.docker-image }}
 
     steps:
-
-    - name: Maximize build space
-      uses: easimon/maximize-build-space@master
-      with:
-        remove-dotnet: 'true'
-        remove-android: 'true'
         
     - uses: actions/checkout@v4
       with:
@@ -185,11 +179,11 @@ jobs:
       fail-fast: false
       matrix:
         build: [
-          {runs-on: ubuntu-latest, enable_perf: OFF, enable_op_model: OFF, enable_emitc: OFF, enable_async: OFF, enable_runtime_debug: OFF, name: "run", ttrt_flags: ""},
-          {runs-on: ubuntu-latest, enable_perf: ON, enable_op_model: OFF, enable_emitc: OFF, enable_async: OFF, enable_runtime_debug: OFF, name: "perf", ttrt_flags: ""},
-          {runs-on: ubuntu-latest, enable_perf: OFF, enable_op_model: OFF, enable_emitc: ON, enable_async: OFF, enable_runtime_debug: OFF, name: "emitc", ttrt_flags: ""},
-          {runs-on: ubuntu-latest, enable_perf: OFF, enable_op_model: OFF, enable_emitc: OFF, enable_async: ON, enable_runtime_debug: OFF, name: "async", ttrt_flags: ""},
-          {runs-on: ubuntu-latest, enable_perf: OFF, enable_op_model: OFF, enable_emitc: OFF, enable_async: OFF, enable_runtime_debug: ON, name: "runtime_debug", ttrt_flags: ""},
+          {runs-on: runner, enable_perf: OFF, enable_op_model: OFF, enable_emitc: OFF, enable_async: OFF, enable_runtime_debug: OFF, name: "run", ttrt_flags: ""},
+          {runs-on: runner, enable_perf: ON, enable_op_model: OFF, enable_emitc: OFF, enable_async: OFF, enable_runtime_debug: OFF, name: "perf", ttrt_flags: ""},
+          {runs-on: runner, enable_perf: OFF, enable_op_model: OFF, enable_emitc: ON, enable_async: OFF, enable_runtime_debug: OFF, name: "emitc", ttrt_flags: ""},
+          {runs-on: runner, enable_perf: OFF, enable_op_model: OFF, enable_emitc: OFF, enable_async: ON, enable_runtime_debug: OFF, name: "async", ttrt_flags: ""},
+          {runs-on: runner, enable_perf: OFF, enable_op_model: OFF, enable_emitc: OFF, enable_async: OFF, enable_runtime_debug: ON, name: "runtime_debug", ttrt_flags: ""},
         ]
 
     name: Build and test tt-mlir (compute machine)
@@ -199,12 +193,6 @@ jobs:
       image: ${{ needs.build-image.outputs.docker-image }}
 
     steps:
-
-    - name: Maximize build space
-      uses: easimon/maximize-build-space@master
-      with:
-        remove-dotnet: 'true'
-        remove-android: 'true'
 
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -129,7 +129,7 @@ jobs:
 
     - name: Maximize space
       uses: tenstorrent/tt-github-actions/.github/actions/maximize_space@main
-        
+
     - uses: actions/checkout@v4
       with:
           fetch-depth: 0

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -131,14 +131,14 @@ jobs:
       shell: bash
       run: |
           df -h
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force
-          sudo docker builder prune -a
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /opt/ghc || true
+          sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+          # sudo docker image prune --all --force || true
+          # sudo docker builder prune -a || true
           df -h
-        
+
     - uses: actions/checkout@v4
       with:
           fetch-depth: 0
@@ -210,12 +210,12 @@ jobs:
       shell: bash
       run: |
           df -h
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force
-          sudo docker builder prune -a
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /opt/ghc || true
+          sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+          # sudo docker image prune --all --force || true
+          # sudo docker builder prune -a || true
           df -h
 
     - uses: actions/checkout@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -121,11 +121,14 @@ jobs:
     strategy:
       fail-fast: false
     name: Debug Build
-    runs-on: runner
+    runs-on: ubuntu-latest
     container:
       image: ${{ needs.build-image.outputs.docker-image }}
 
     steps:
+
+    - name: Maximize space
+      uses: tenstorrent/tt-github-actions/.github/actions/maximize_space@main
         
     - uses: actions/checkout@v4
       with:
@@ -179,11 +182,11 @@ jobs:
       fail-fast: false
       matrix:
         build: [
-          {runs-on: runner, enable_perf: OFF, enable_op_model: OFF, enable_emitc: OFF, enable_async: OFF, enable_runtime_debug: OFF, name: "run", ttrt_flags: ""},
-          {runs-on: runner, enable_perf: ON, enable_op_model: OFF, enable_emitc: OFF, enable_async: OFF, enable_runtime_debug: OFF, name: "perf", ttrt_flags: ""},
-          {runs-on: runner, enable_perf: OFF, enable_op_model: OFF, enable_emitc: ON, enable_async: OFF, enable_runtime_debug: OFF, name: "emitc", ttrt_flags: ""},
-          {runs-on: runner, enable_perf: OFF, enable_op_model: OFF, enable_emitc: OFF, enable_async: ON, enable_runtime_debug: OFF, name: "async", ttrt_flags: ""},
-          {runs-on: runner, enable_perf: OFF, enable_op_model: OFF, enable_emitc: OFF, enable_async: OFF, enable_runtime_debug: ON, name: "runtime_debug", ttrt_flags: ""},
+          {runs-on: ubuntu-latest, enable_perf: OFF, enable_op_model: OFF, enable_emitc: OFF, enable_async: OFF, enable_runtime_debug: OFF, name: "run", ttrt_flags: ""},
+          {runs-on: ubuntu-latest, enable_perf: ON, enable_op_model: OFF, enable_emitc: OFF, enable_async: OFF, enable_runtime_debug: OFF, name: "perf", ttrt_flags: ""},
+          {runs-on: ubuntu-latest, enable_perf: OFF, enable_op_model: OFF, enable_emitc: ON, enable_async: OFF, enable_runtime_debug: OFF, name: "emitc", ttrt_flags: ""},
+          {runs-on: ubuntu-latest, enable_perf: OFF, enable_op_model: OFF, enable_emitc: OFF, enable_async: ON, enable_runtime_debug: OFF, name: "async", ttrt_flags: ""},
+          {runs-on: ubuntu-latest, enable_perf: OFF, enable_op_model: OFF, enable_emitc: OFF, enable_async: OFF, enable_runtime_debug: ON, name: "runtime_debug", ttrt_flags: ""},
         ]
 
     name: Build and test tt-mlir (compute machine)
@@ -193,6 +196,9 @@ jobs:
       image: ${{ needs.build-image.outputs.docker-image }}
 
     steps:
+
+    - name: Maximize space
+      uses: tenstorrent/tt-github-actions/.github/actions/maximize_space@main
 
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
### Ticket
N/A

### Problem description
We started running out of space when building on Github runners.

### What's changed
~Free up space on runners by removing unneeded packages using https://github.com/easimon/maximize-build-space action~
Free up space on runners by using custom action that removes unused software packages from Github runner

### Checklist
- [x] New/Existing tests provide coverage for changes
