### PR TITLE
Add ttnn runtime layout comparisons in debug mode, minor runtime build cleanup

### DIFF
--- a/lib/Dialect/TTNN/IR/TTNNWorkarounds.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkarounds.cpp
@@ -478,8 +478,13 @@ TTNNOperandsWorkaroundsFactory::createArgMaxOpOperandsWorkarounds() {
   wa::TTNNOperandWorkarounds rowMajorLayoutBF16Workaround;
   rowMajorLayoutBF16Workaround.tensorLayoutWorkaround = Layout::RowMajor;
   rowMajorLayoutBF16Workaround.tensorDataTypeWorkaround = DataType::BFloat16;
+
+  wa::TTNNOperandWorkarounds rowMajorLayoutUint32Workaround;
+  rowMajorLayoutUint32Workaround.tensorLayoutWorkaround = Layout::RowMajor;
+  rowMajorLayoutUint32Workaround.tensorDataTypeWorkaround = DataType::UInt32;
+
   return wa::TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
       .addInputOperandWorkaround(rowMajorLayoutBF16Workaround)
-      .addOutputOperandWorkaround(rowMajorLayoutWorkaround);
+      .addOutputOperandWorkaround(rowMajorLayoutUint32Workaround);
 }
 } // namespace mlir::tt::ttnn::wa

--- a/lib/Dialect/TTNN/Transforms/TTNNDecomposeLayouts.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNDecomposeLayouts.cpp
@@ -652,13 +652,13 @@ private:
     if (info.shouldUntilize() && !opsToCreate.createFromDeviceOp) {
       // Force-create a FromDeviceOp
       currentInput = this->createFromDeviceOpIfNeeded(
-          op, rewriter, currentInput, info, true /* forceCreate */);
+          op, rewriter, currentInput, info, /*forceCreate=*/true);
       // untilize on host
       currentInput =
           this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
       // move back to device and convert memory config if needed
       currentInput = createToDeviceOpIfNeeded(op, rewriter, currentInput, info,
-                                              true /* forceCreate */);
+                                              /*forceCreate=*/true);
       op.getResult().replaceAllUsesWith(currentInput);
       return;
     }
@@ -694,13 +694,13 @@ private:
         !opsToCreate.createFromDeviceOp) {
       // Force-create a FromDeviceOp
       currentInput = this->createFromDeviceOpIfNeeded(
-          op, rewriter, currentInput, info, true /* forceCreate */);
+          op, rewriter, currentInput, info, /*forceCreate=*/true);
       // tilize on host
       currentInput =
           this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
       // move back to device and convert memory config if needed
-      currentInput = this->createToDeviceOpIfNeeded(
-          op, rewriter, currentInput, info, true /* forceCreate */);
+      currentInput = this->createToDeviceOpIfNeeded(op, rewriter, currentInput,
+                                                    info, /*forceCreate=*/true);
       currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
                                                           currentInput, info);
       op.getResult().replaceAllUsesWith(currentInput);
@@ -745,15 +745,14 @@ private:
     /* Device to device untilized typecast, need to move to host first */
     if (!output.isTilized() && !opsToCreate.createFromDeviceOp) {
       // Force-create a FromDeviceOp
-      currentInput =
-          this->createOp<ttnn::FromDeviceOp>(op, rewriter, currentInput);
+      currentInput = this->createFromDeviceOpIfNeeded(
+          op, rewriter, currentInput, info, /*forceCreate=*/true);
       // typecast on host
       currentInput = this->createDataTypeCastingOpIfNeeded(op, rewriter,
                                                            currentInput, info);
       // move back to device and convert memory config if needed
-      currentInput = this->createOp<ttnn::ToDeviceOp>(
-          op, rewriter, currentInput, info.device,
-          /* optional MemConfigAttr */ nullptr);
+      currentInput = this->createToDeviceOpIfNeeded(op, rewriter, currentInput,
+                                                    info, /*forceCreate=*/true);
       currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,
                                                           currentInput, info);
       op.getResult().replaceAllUsesWith(currentInput);
@@ -790,13 +789,13 @@ private:
                                                            currentInput, info);
       // Force-create a FromDeviceOp
       currentInput = this->createFromDeviceOpIfNeeded(
-          op, rewriter, currentInput, info, true /* forceCreate */);
+          op, rewriter, currentInput, info, /*forceCreate=*/true);
       // untilize on host
       currentInput =
           this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
       // move back to device and convert memory config if needed
-      currentInput = this->createToDeviceOpIfNeeded(
-          op, rewriter, currentInput, info, true /* forceCreate */);
+      currentInput = this->createToDeviceOpIfNeeded(op, rewriter, currentInput,
+                                                    info, /*forceCreate=*/true);
       op.getResult().replaceAllUsesWith(currentInput);
       return;
     }
@@ -836,15 +835,14 @@ private:
     if (info.shouldTilize() && input.dataType != DataType::BFloat16 &&
         !opsToCreate.createFromDeviceOp) {
       // Force-create a FromDeviceOp
-      currentInput =
-          this->createOp<ttnn::FromDeviceOp>(op, rewriter, currentInput);
+      currentInput = this->createFromDeviceOpIfNeeded(
+          op, rewriter, currentInput, info, /*forceCreate=*/true);
       // tilize on host
       currentInput =
           this->createToLayoutOpIfNeeded(op, rewriter, currentInput, info);
       // move back to device and convert data type/memory config if needed
-      currentInput = this->createOp<ttnn::ToDeviceOp>(
-          op, rewriter, currentInput, info.device,
-          /* optional MemConfigAttr */ nullptr);
+      currentInput = this->createToDeviceOpIfNeeded(op, rewriter, currentInput,
+                                                    info, /*forceCreate=*/true);
       currentInput = this->createDataTypeCastingOpIfNeeded(op, rewriter,
                                                            currentInput, info);
       currentInput = this->createToMemoryConfigOpIfNeeded(op, rewriter,

--- a/runtime/lib/CMakeLists.txt
+++ b/runtime/lib/CMakeLists.txt
@@ -1,22 +1,8 @@
-if (TTMLIR_ENABLE_RUNTIME)
-  if (TT_RUNTIME_ENABLE_TTNN)
-    add_subdirectory(ttnn)
-  else()
-    add_library(TTRuntimeTTNN INTERFACE)
-  endif()
-  if (TT_RUNTIME_ENABLE_TTMETAL)
-    add_subdirectory(ttmetal)
-  else()
-    add_library(TTRuntimeTTMetal INTERFACE)
-  endif()
-else()
-  add_library(TTRuntimeTTNN INTERFACE)
-  add_library(TTRuntimeTTNNTypes INTERFACE)
-  add_library(TTRuntimeTTNNUtils INTERFACE)
-  add_library(TTRuntimeTTMetal INTERFACE)
-endif()
-
 message(STATUS "Runtimes Enabled: TTNN[${TT_RUNTIME_ENABLE_TTNN}] TTMETAL[${TT_RUNTIME_ENABLE_TTMETAL}]")
+
+add_subdirectory(common)
+add_subdirectory(ttnn)
+add_subdirectory(ttmetal)
 
 add_library(TTBinary STATIC binary.cpp)
 set_property(TARGET TTBinary PROPERTY CXX_STANDARD 20)
@@ -26,14 +12,6 @@ target_include_directories(TTBinary
     ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common
 )
 add_dependencies(TTBinary FBS_GENERATION)
-
-if (TTMLIR_ENABLE_RUNTIME AND (TT_RUNTIME_ENABLE_TTNN OR TT_RUNTIME_ENABLE_TTMETAL))
-  add_subdirectory(common)
-else()
-  add_library(TTRuntimeSysDesc INTERFACE)
-  add_library(TTRuntimeDebug INTERFACE)
-  add_library(TTRuntimeWorkarounds INTERFACE)
-endif()
 
 add_library(TTMLIRRuntime SHARED runtime.cpp)
 set_property(TARGET TTMLIRRuntime PROPERTY CXX_STANDARD 20)
@@ -72,7 +50,7 @@ target_link_libraries(TTMLIRRuntime
 set_target_properties(TTMLIRRuntime PROPERTIES INSTALL_RPATH "$ORIGIN")
 set_target_properties(TTMLIRRuntime PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE)
 
-add_dependencies(TTMLIRRuntime TTBinary TTRuntimeSysDesc TTRuntimeDebug TTRuntimeWorkarounds FBS_GENERATION)
+add_dependencies(TTMLIRRuntime TTBinary TTRuntimeSysDesc TTRuntimeDebug TTRuntimeWorkarounds TTRuntimeTTNN TTRuntimeTTMetal FBS_GENERATION)
 
 if (TTMLIR_ENABLE_RUNTIME)
   set_target_properties(TTMLIRRuntime PROPERTIES PUBLIC_HEADER "../include/tt/runtime/runtime.h;../include/tt/runtime/types.h;../include/tt/runtime/utils.h")

--- a/runtime/lib/common/CMakeLists.txt
+++ b/runtime/lib/common/CMakeLists.txt
@@ -25,6 +25,19 @@ message(STATUS "Target triple: ${triple}")
 
 add_definitions(-DTARGET_TRIPLE="${triple}")
 
+if (TTMLIR_ENABLE_RUNTIME AND (TT_RUNTIME_ENABLE_TTNN OR TT_RUNTIME_ENABLE_TTMETAL))
+    set(ANY_RUNTIME_ENABLED ON)
+else()
+    set(ANY_RUNTIME_ENABLED OFF)
+endif()
+
+if (NOT ANY_RUNTIME_ENABLED)
+  add_library(TTRuntimeSysDesc INTERFACE)
+  add_library(TTRuntimeDebug INTERFACE)
+  add_library(TTRuntimeWorkarounds INTERFACE)
+  return()
+endif()
+
 add_library(TTRuntimeSysDesc STATIC system_desc.cpp)
 set_property(TARGET TTRuntimeSysDesc PROPERTY CXX_STANDARD 20)
 target_include_directories(TTRuntimeSysDesc

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -10,7 +10,6 @@
 
 #if defined(TT_RUNTIME_ENABLE_TTNN)
 #include "tt/runtime/detail/ttnn.h"
-#include "tt/runtime/ttnn/types.h"
 #endif
 
 #if defined(TT_RUNTIME_ENABLE_TTMETAL)

--- a/runtime/lib/ttmetal/CMakeLists.txt
+++ b/runtime/lib/ttmetal/CMakeLists.txt
@@ -1,3 +1,14 @@
+if (TTMLIR_ENABLE_RUNTIME AND TT_RUNTIME_ENABLE_TTMETAL)
+  set(TTMETAL_RUNTIME_ENABLED ON)
+else()
+  set(TTMETAL_RUNTIME_ENABLED OFF)
+endif()
+
+if (NOT TTMETAL_RUNTIME_ENABLED)
+  add_library(TTRuntimeTTMetal INTERFACE)
+  return()
+endif()
+
 add_library(TTRuntimeTTMetal
   STATIC
   runtime.cpp

--- a/runtime/lib/ttnn/CMakeLists.txt
+++ b/runtime/lib/ttnn/CMakeLists.txt
@@ -1,6 +1,18 @@
-add_subdirectory(types)
+if (TTMLIR_ENABLE_RUNTIME AND TT_RUNTIME_ENABLE_TTNN)
+    set(TTNN_RUNTIME_ENABLED ON)
+else()
+    set(TTNN_RUNTIME_ENABLED OFF)
+endif()
+
 add_subdirectory(utils)
+add_subdirectory(debug)
+add_subdirectory(types)
 add_subdirectory(operations)
+
+if (NOT TTNN_RUNTIME_ENABLED)
+  add_library(TTRuntimeTTNN INTERFACE)
+  return()
+endif()
 
 add_library(TTRuntimeTTNN
   STATIC

--- a/runtime/lib/ttnn/debug/CMakeLists.txt
+++ b/runtime/lib/ttnn/debug/CMakeLists.txt
@@ -1,0 +1,19 @@
+if (NOT TTNN_RUNTIME_ENABLED OR NOT TT_RUNTIME_DEBUG)
+  add_library(TTRuntimeTTNNDebug INTERFACE)
+  return()
+endif()
+
+add_library(TTRuntimeTTNNDebug
+  STATIC
+  debug_apis.cpp
+)
+set_property(TARGET TTRuntimeTTNNDebug PROPERTY CXX_STANDARD 20)
+target_compile_options(TTRuntimeTTNNDebug PUBLIC -mavx -mavx2)
+target_include_directories(TTRuntimeTTNNDebug PUBLIC
+  ${PROJECT_SOURCE_DIR}/runtime/include
+  ${PROJECT_SOURCE_DIR}/runtime/lib/ttnn/include
+  ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common
+)
+target_include_directories(TTRuntimeTTNNDebug SYSTEM PUBLIC "$<BUILD_INTERFACE:${TTMETAL_INCLUDE_DIRS}>")
+add_dependencies(TTRuntimeTTNNDebug TTRuntimeTTNNUtils)
+target_link_libraries(TTRuntimeTTNNDebug PUBLIC TTRuntimeTTNNUtils)

--- a/runtime/lib/ttnn/debug/debug_apis.cpp
+++ b/runtime/lib/ttnn/debug/debug_apis.cpp
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#if !defined(TT_RUNTIME_DEBUG) || !TT_RUNTIME_DEBUG
+#error "TT_RUNTIME_DEBUG must be defined and set"
+#endif
+
+#include "tt/runtime/ttnn/debug_apis.h"
+#include "tt/runtime/detail/logger.h"
+#include "tt/runtime/ttnn/utils.h"
+
+namespace tt::runtime::ttnn::debug {
+
+static std::string toString(::ttnn::Layout layout) {
+  switch (layout) {
+  case ::ttnn::Layout::ROW_MAJOR:
+    return "ROW_MAJOR";
+  case ::ttnn::Layout::TILE:
+    return "TILE";
+  case ::ttnn::Layout::INVALID:
+    return "INVALID";
+  }
+}
+
+static std::string toString(::ttnn::DataType dtype) {
+  switch (dtype) {
+  case ::ttnn::DataType::FLOAT32:
+    return "FLOAT32";
+  case ::ttnn::DataType::BFLOAT16:
+    return "BFLOAT16";
+  case ::ttnn::DataType::BFLOAT8_B:
+    return "BFLOAT8_B";
+  case ::ttnn::DataType::BFLOAT4_B:
+    return "BFLOAT4_B";
+  case ::ttnn::DataType::UINT32:
+    return "UINT32";
+  case ::ttnn::DataType::UINT16:
+    return "UINT16";
+  case ::ttnn::DataType::UINT8:
+    return "UINT8";
+  case ::ttnn::DataType::INT32:
+    return "INT32";
+  case ::ttnn::DataType::INVALID:
+    return "INVALID";
+  }
+}
+
+void checkTensorRefMatchesTTNNTensor(
+    const ::tt::target::ttnn::TensorRef *tensorRef,
+    const ::ttnn::Tensor &ttnnTensor) {
+  ::ttnn::Layout expectedLayout =
+      ::tt::runtime::ttnn::utils::inferLayoutFromTileShape(tensorRef);
+  ::ttnn::Layout actualLayout = ttnnTensor.get_layout();
+  DEBUG_ASSERT(expectedLayout == actualLayout, "Layout mismatch, expected ",
+               toString(expectedLayout), ", got ", toString(actualLayout));
+
+  ::ttnn::DataType expectedDataType =
+      ::tt::runtime::ttnn::utils::toTTNNDataType(
+          tensorRef->desc()->layout()->memory_desc()->data_type());
+  ::ttnn::DataType actualDataType = ttnnTensor.get_dtype();
+  DEBUG_ASSERT(expectedDataType == actualDataType,
+               "DataType mismatch, expected ", toString(expectedDataType),
+               ", got ", toString(actualDataType));
+
+  // TODO (jnie): Compare storage once we correctly determine it in the
+  // flatbuffer. This requires compiler support which is missing.
+  //
+  // ::ttnn::StorageType expectedStorageType =
+  //     ::tt::runtime::ttnn::utils::toTTNNStorageType(
+  //         tensorRef->desc()->layout()->memory_desc()->storage_type());
+  // ::ttnn::StorageType actualStorageType =
+  //     ttnnTensor.storage_type();
+  // DEBUG_ASSERT(expectedStorageType == actualStorageType, "Storage type
+  // mismatch, expected ", static_cast<int>(expectedStorageType), ", got ",
+  // static_cast<int>(actualStorageType));
+
+  if (!::tt::runtime::ttnn::utils::inSystemMemory(tensorRef)) {
+    const ::tt::target::ttnn::MemoryConfig *memcfg =
+        ::tt::runtime::ttnn::utils::getTensorRefMemoryConfig(tensorRef);
+    DEBUG_ASSERT(memcfg, "Device tensor must have memory config");
+    ::ttnn::MemoryConfig expectedMemoryConfig =
+        ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(memcfg).value();
+    ::ttnn::MemoryConfig actualMemoryConfig = ttnnTensor.memory_config();
+    DEBUG_ASSERT(expectedMemoryConfig == actualMemoryConfig,
+                 "Memory config mismatch, expected ", expectedMemoryConfig,
+                 ", got ", actualMemoryConfig);
+  }
+}
+} // namespace tt::runtime::ttnn::debug

--- a/runtime/lib/ttnn/include/tt/runtime/ttnn/debug_apis.h
+++ b/runtime/lib/ttnn/include/tt/runtime/ttnn/debug_apis.h
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TT_RUNTIME_TTNN_DEBUG_APIS_H
+#define TT_RUNTIME_TTNN_DEBUG_APIS_H
+
+#include "tt/runtime/detail/ttnn.h"
+#include "ttmlir/Target/TTNN/Target.h"
+
+#if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
+#define RUNTIME_DEBUG_MAYBE_CONST_INLINE
+#else
+#define RUNTIME_DEBUG_MAYBE_CONST_INLINE                                       \
+  inline __attribute__((always_inline, const))
+#endif
+
+namespace tt::runtime::ttnn::debug {
+
+RUNTIME_DEBUG_MAYBE_CONST_INLINE void
+checkTensorRefMatchesTTNNTensor(const ::tt::target::ttnn::TensorRef *tensorRef,
+                                const ::ttnn::Tensor &ttnnTensor)
+#if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
+    ;
+#else
+{
+}
+#endif
+
+#undef RUNTIME_DEBUG_MAYBE_CONST_INLINE
+
+} // namespace tt::runtime::ttnn::debug
+
+#endif // TT_RUNTIME_TTNN_DEBUG_APIS_H

--- a/runtime/lib/ttnn/include/tt/runtime/ttnn/types.h
+++ b/runtime/lib/ttnn/include/tt/runtime/ttnn/types.h
@@ -88,44 +88,43 @@ class ProgramTensorPool {
 public:
   ProgramTensorPool(
       const std::unordered_map<uint32_t, ::ttnn::Tensor *> &liveTensors,
-      const std::vector<uint32_t> &programInputs,
-      const std::vector<uint32_t> &programOutputs)
-      : programInputs(programInputs), programOutputs(programOutputs),
+      const std::vector<uint32_t> &programInputIds,
+      const std::vector<uint32_t> &programOutputIds)
+      : programInputIds(programInputIds), programOutputIds(programOutputIds),
         liveTensors(liveTensors) {}
   ProgramTensorPool(const ProgramTensorPool &) = delete;
   ProgramTensorPool &operator=(const ProgramTensorPool &) = delete;
   ProgramTensorPool(ProgramTensorPool &&) = default;
   ProgramTensorPool &operator=(ProgramTensorPool &&) = default;
 
-  std::pair<std::unordered_map<std::uint32_t, ::ttnn::Tensor *>::iterator, bool>
-  try_emplace(std::uint32_t globalId, const ::ttnn::Tensor &tensor);
+  const ::ttnn::Tensor &
+  getAndValidate(const ::tt::target::ttnn::TensorRef *tensorRef) const;
+  ::ttnn::Tensor &
+  getAndValidate(const ::tt::target::ttnn::TensorRef *tensorRef);
 
   std::pair<std::unordered_map<std::uint32_t, ::ttnn::Tensor *>::iterator, bool>
-  insert_or_assign(std::uint32_t globalId, const ::ttnn::Tensor &tensor);
+  insertAndValidate(const ::tt::target::ttnn::TensorRef *tensorRef,
+                    const ::ttnn::Tensor &ttnnTensor);
 
-  ::ttnn::Tensor &at(std::uint32_t globalId);
-
-  const ::ttnn::Tensor &at(std::uint32_t globalId) const;
-
-  size_t erase(std::uint32_t globalId);
+  size_t erase(const ::tt::target::ttnn::TensorRef *tensorRef);
 
   std::vector<Tensor> gatherOutputTensors();
 
-  bool contains(std::uint32_t globalId) const {
-    return liveTensors.contains(globalId);
+  bool contains(const ::tt::target::ttnn::TensorRef *tensorRef) const {
+    return liveTensors.contains(tensorRef->global_id());
   }
 
-  const std::vector<std::uint32_t> &getProgramInputs() const {
-    return programInputs;
+  const std::vector<std::uint32_t> &getProgramInputIds() const {
+    return programInputIds;
   }
 
-  const std::vector<std::uint32_t> &getProgramOutputs() const {
-    return programOutputs;
+  const std::vector<std::uint32_t> &getProgramOutputIds() const {
+    return programOutputIds;
   }
 
 private:
-  std::vector<std::uint32_t> programInputs;
-  std::vector<std::uint32_t> programOutputs;
+  std::vector<std::uint32_t> programInputIds;
+  std::vector<std::uint32_t> programOutputIds;
   // A superset of intermedTensors, containing pointers to all tensors created
   // by the program and the input tensors passed in by the user
   std::unordered_map<uint32_t, ::ttnn::Tensor *> liveTensors;
@@ -139,8 +138,8 @@ class ProgramContext {
 public:
   ProgramContext(
       const std::unordered_map<uint32_t, ::ttnn::Tensor *> &liveTensors,
-      const std::vector<uint32_t> &programInputs,
-      const std::vector<uint32_t> &programOutputs,
+      const std::vector<uint32_t> &programInputIds,
+      const std::vector<uint32_t> &programOutputIds,
       ::ttnn::MeshDevice *parentMesh);
   ProgramContext(const ProgramContext &) = delete;
   ProgramContext &operator=(const ProgramContext &) = delete;

--- a/runtime/lib/ttnn/operations/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/CMakeLists.txt
@@ -1,3 +1,8 @@
+if (NOT TTNN_RUNTIME_ENABLED)
+  add_library(TTRuntimeTTNNOps INTERFACE)
+  return()
+endif()
+
 set(TTNN_OPS_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/include/tt/runtime/ttnn/operations/utils.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/include/tt/runtime/ttnn/operations/eltwise/binary/utils.cpp
@@ -69,11 +74,11 @@ target_include_directories(TTRuntimeTTNNOps PUBLIC
 )
 
 target_include_directories(TTRuntimeTTNNOps SYSTEM PUBLIC "$<BUILD_INTERFACE:${TTMETAL_INCLUDE_DIRS}>")
-target_link_libraries(TTRuntimeTTNNOps PUBLIC TTNN_LIBRARY TTRuntimeTTNNTypes TTRuntimeTTNNUtils)
+target_link_libraries(TTRuntimeTTNNOps PUBLIC TTNN_LIBRARY TTRuntimeTTNNDebug TTRuntimeTTNNTypes TTRuntimeTTNNUtils)
 
 if (TT_RUNTIME_ENABLE_PERF_TRACE)
   target_link_libraries(TTRuntimeTTNNOps PUBLIC TRACY_LIBRARY)
 endif()
 
 
-add_dependencies(TTRuntimeTTNNOps TTNN_LIBRARY tt-metal FBS_GENERATION TTRuntimeTTNNTypes TTRuntimeTTNNUtils)
+add_dependencies(TTRuntimeTTNNOps TTNN_LIBRARY tt-metal FBS_GENERATION TTRuntimeTTNNTypes TTRuntimeTTNNDebug)

--- a/runtime/lib/ttnn/operations/ccl/all_gather.cpp
+++ b/runtime/lib/ttnn/operations/ccl/all_gather.cpp
@@ -5,6 +5,7 @@
 #include "operations/ccl/all_gather.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
 #include "ttnn/operations/ccl/ccl_host_types.hpp"
@@ -12,7 +13,9 @@
 namespace tt::runtime::ttnn::operations::ccl {
 void run(const ::tt::target::ttnn::AllGatherOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  const ::ttnn::Tensor &input = tensorPool.at(op->in()->global_id());
+
+  const ::ttnn::Tensor &input = tensorPool.getAndValidate(op->in());
+
   int32_t allGatherDim = op->all_gather_dim();
   uint32_t clusterAxis = op->cluster_axis();
   uint32_t numLinks = op->num_links();
@@ -32,6 +35,7 @@ void run(const ::tt::target::ttnn::AllGatherOp *op, ProgramContext &context) {
       ::ttnn::all_gather(input, allGatherDim, clusterAxis, meshDevice, numLinks,
                          outputMemoryConfig, std::nullopt, std::nullopt,
                          ::ttnn::ccl::Topology::Linear);
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+
+  tensorPool.insertAndValidate(op->out(), out);
 }
 } // namespace tt::runtime::ttnn::operations::ccl

--- a/runtime/lib/ttnn/operations/ccl/reduce_scatter.cpp
+++ b/runtime/lib/ttnn/operations/ccl/reduce_scatter.cpp
@@ -5,6 +5,7 @@
 #include "operations/ccl/reduce_scatter.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
 #include "ttnn/operations/ccl/ccl_host_types.hpp"
@@ -14,7 +15,9 @@ namespace tt::runtime::ttnn::operations::ccl {
 void run(const ::tt::target::ttnn::ReduceScatterOp *op,
          ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  const ::ttnn::Tensor &input = tensorPool.at(op->in()->global_id());
+
+  const ::ttnn::Tensor &input = tensorPool.getAndValidate(op->in());
+
   int32_t scatterDimension = op->scatter_dim();
   uint32_t clusterAxis = op->cluster_axis();
   uint32_t numLinks = op->num_links();
@@ -36,6 +39,7 @@ void run(const ::tt::target::ttnn::ReduceScatterOp *op,
   ::ttnn::Tensor out = ::ttnn::reduce_scatter(
       input, scatterDimension, clusterAxis, meshDevice, reduceType, numLinks,
       outputMemoryConfig, ::ttnn::ccl::Topology::Linear);
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+
+  tensorPool.insertAndValidate(op->out(), out);
 }
 } // namespace tt::runtime::ttnn::operations::ccl

--- a/runtime/lib/ttnn/operations/conv/conv2d.cpp
+++ b/runtime/lib/ttnn/operations/conv/conv2d.cpp
@@ -5,6 +5,7 @@
 #include "operations/conv/conv2d.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
 #include "ttmlir/Target/TTNN/program_generated.h"
@@ -13,13 +14,11 @@
 namespace tt::runtime::ttnn::operations::conv {
 void run(const ::tt::target::ttnn::Conv2dOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  const ::ttnn::Tensor &input = tensorPool.at(op->input()->global_id());
-  const ::ttnn::Tensor &weight = tensorPool.at(op->weight()->global_id());
-  DEBUG_ASSERT(input.is_allocated());
-  DEBUG_ASSERT(weight.is_allocated());
+  const ::ttnn::Tensor &input = tensorPool.getAndValidate(op->input());
+  const ::ttnn::Tensor &weight = tensorPool.getAndValidate(op->weight());
 
   std::optional<::ttnn::Tensor> bias =
-      op->bias() ? std::make_optional(tensorPool.at(op->bias()->global_id()))
+      op->bias() ? std::make_optional(tensorPool.getAndValidate(op->bias()))
                  : std::nullopt;
 
   LOG_ASSERT(op->kernel_size()->size() == 2,
@@ -65,6 +64,6 @@ void run(const ::tt::target::ttnn::Conv2dOp *op, ProgramContext &context) {
       },
       targetDevice);
 
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+  tensorPool.insertAndValidate(op->out(), out);
 }
 } // namespace tt::runtime::ttnn::operations::conv

--- a/runtime/lib/ttnn/operations/conv/conv_transpose2d.cpp
+++ b/runtime/lib/ttnn/operations/conv/conv_transpose2d.cpp
@@ -5,6 +5,7 @@
 #include "operations/conv/conv_transpose2d.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
 #include "ttmlir/Target/TTNN/program_generated.h"
@@ -15,13 +16,11 @@ namespace tt::runtime::ttnn::operations::conv {
 void run(const ::tt::target::ttnn::ConvTranspose2dOp *op,
          ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  const ::ttnn::Tensor &input = tensorPool.at(op->input()->global_id());
-  const ::ttnn::Tensor &weight = tensorPool.at(op->weight()->global_id());
-  DEBUG_ASSERT(input.is_allocated());
-  DEBUG_ASSERT(weight.is_allocated());
+  const ::ttnn::Tensor &input = tensorPool.getAndValidate(op->input());
+  const ::ttnn::Tensor &weight = tensorPool.getAndValidate(op->weight());
 
   std::optional<::ttnn::Tensor> bias =
-      op->bias() ? std::make_optional(tensorPool.at(op->bias()->global_id()))
+      op->bias() ? std::make_optional(tensorPool.getAndValidate(op->bias()))
                  : std::nullopt;
 
   LOG_ASSERT(op->kernel_size()->size() == 2,
@@ -57,7 +56,7 @@ void run(const ::tt::target::ttnn::ConvTranspose2dOp *op,
       },
       targetDevice);
 
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+  tensorPool.insertAndValidate(op->out(), out);
 }
 
 } // namespace tt::runtime::ttnn::operations::conv

--- a/runtime/lib/ttnn/operations/creation/arange.cpp
+++ b/runtime/lib/ttnn/operations/creation/arange.cpp
@@ -4,6 +4,7 @@
 
 #include "operations/creation/arange.h"
 #include "tt/runtime/detail/logger.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
 #include "ttnn/types.hpp"
@@ -44,6 +45,6 @@ void run(const ::tt::target::ttnn::ArangeOp *op, ProgramContext &context) {
   ::ttnn::Tensor out = ::ttnn::arange(op->start(), op->end(), op->step(), dtype,
                                       device, memoryConfig);
 
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+  tensorPool.insertAndValidate(op->out(), out);
 }
 } // namespace tt::runtime::ttnn::operations::creation

--- a/runtime/lib/ttnn/operations/creation/constant.cpp
+++ b/runtime/lib/ttnn/operations/creation/constant.cpp
@@ -5,6 +5,7 @@
 #include "operations/creation/constant.h"
 
 #include "tt/runtime/detail/logger.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
 
@@ -80,7 +81,7 @@ void run(const ::tt::target::ttnn::ConstantOp *op, ProgramContext &context) {
   ::ttnn::Tensor out(::tt::tt_metal::OwnedStorage(ownedBuffer), shape, dtype,
                      ::ttnn::Layout::ROW_MAJOR);
 
-  context.getTensorPool().insert_or_assign(op->out()->global_id(), out);
+  context.getTensorPool().insertAndValidate(op->out(), out);
 }
 
 } // namespace tt::runtime::ttnn::operations::creation

--- a/runtime/lib/ttnn/operations/creation/empty.cpp
+++ b/runtime/lib/ttnn/operations/creation/empty.cpp
@@ -6,6 +6,7 @@
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
 #include "tt/runtime/detail/workarounds.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
 
@@ -94,6 +95,6 @@ void run(const ::tt::target::ttnn::EmptyOp *op, ProgramContext &context) {
   } else {
     LOG_FATAL("Unsupported num shards");
   }
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+  tensorPool.insertAndValidate(op->out(), out);
 }
 } // namespace tt::runtime::ttnn::operations::creation

--- a/runtime/lib/ttnn/operations/creation/full.cpp
+++ b/runtime/lib/ttnn/operations/creation/full.cpp
@@ -6,6 +6,7 @@
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
 #include "tt/runtime/detail/workarounds.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
 
@@ -106,6 +107,7 @@ void run(const ::tt::target::ttnn::FullOp *op, ProgramContext &context) {
   } else {
     LOG_FATAL("Unsupported num shards");
   }
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+
+  tensorPool.insertAndValidate(op->out(), out);
 }
 } // namespace tt::runtime::ttnn::operations::creation

--- a/runtime/lib/ttnn/operations/creation/ones.cpp
+++ b/runtime/lib/ttnn/operations/creation/ones.cpp
@@ -5,6 +5,7 @@
 #include "operations/creation/ones.h"
 
 #include "tt/runtime/detail/logger.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
 #include "ttmlir/Target/TTNN/program_generated.h"
@@ -46,6 +47,6 @@ void run(const ::tt::target::ttnn::OnesOp *op, ProgramContext &context) {
 
   ::ttnn::Tensor out = ::ttnn::ones(shape, dtype, layout, device, memoryConfig);
 
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+  tensorPool.insertAndValidate(op->out(), out);
 }
 } // namespace tt::runtime::ttnn::operations::creation

--- a/runtime/lib/ttnn/operations/creation/zeros.cpp
+++ b/runtime/lib/ttnn/operations/creation/zeros.cpp
@@ -5,6 +5,7 @@
 #include "operations/creation/zeros.h"
 
 #include "tt/runtime/detail/logger.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
 #include "ttmlir/Target/TTNN/program_generated.h"
@@ -46,6 +47,6 @@ void run(const ::tt::target::ttnn::ZerosOp *op, ProgramContext &context) {
   ::ttnn::Tensor out =
       ::ttnn::zeros(shape, dtype, layout, device, memoryConfig);
 
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+  tensorPool.insertAndValidate(op->out(), out);
 }
 } // namespace tt::runtime::ttnn::operations::creation

--- a/runtime/lib/ttnn/operations/data_movement/concat.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/concat.cpp
@@ -5,6 +5,7 @@
 #include "operations/data_movement/concat.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
 
@@ -13,8 +14,7 @@ void run(const ::tt::target::ttnn::ConcatOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
   std::vector<::ttnn::Tensor> inputs;
   for (const auto &input : *op->inputs()) {
-    const ::ttnn::Tensor &in = tensorPool.at(input->global_id());
-    DEBUG_ASSERT(in.is_allocated());
+    const ::ttnn::Tensor &in = tensorPool.getAndValidate(input);
     inputs.push_back(in);
   }
   int32_t dim = op->dim();
@@ -25,6 +25,7 @@ void run(const ::tt::target::ttnn::ConcatOp *op, ProgramContext &context) {
           : ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
                 op->memory_config());
   ::ttnn::Tensor out = ::ttnn::concat(inputs, dim, memoryConfig);
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+
+  tensorPool.insertAndValidate(op->out(), out);
 }
 } // namespace tt::runtime::ttnn::operations::data_movement

--- a/runtime/lib/ttnn/operations/data_movement/pad.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/pad.cpp
@@ -6,6 +6,7 @@
 #include "tt-metalium/span.hpp"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/workarounds.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
 
@@ -15,8 +16,7 @@ namespace tt::runtime::ttnn::operations::data_movement {
 void run(const ::tt::target::ttnn::PadOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
 
-  const ::ttnn::Tensor &in = tensorPool.at(op->in()->global_id());
-  DEBUG_ASSERT(in.is_allocated());
+  const ::ttnn::Tensor &in = tensorPool.getAndValidate(op->in());
 
   float padValue = op->value();
 
@@ -33,6 +33,6 @@ void run(const ::tt::target::ttnn::PadOp *op, ProgramContext &context) {
   out = ::ttnn::pad(in, padding, padValue, op->use_multicore(),
                     outputMemoryConfig);
 
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+  tensorPool.insertAndValidate(op->out(), out);
 }
 } // namespace tt::runtime::ttnn::operations::data_movement

--- a/runtime/lib/ttnn/operations/data_movement/permute.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/permute.cpp
@@ -5,17 +5,16 @@
 #include "operations/data_movement/permute.h"
 
 #include "tt/runtime/detail/logger.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
-
 #include <vector>
 
 namespace tt::runtime::ttnn::operations::data_movement {
 void run(const ::tt::target::ttnn::PermuteOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
 
-  const ::ttnn::Tensor &in = tensorPool.at(op->in()->global_id());
-  DEBUG_ASSERT(in.is_allocated());
+  const ::ttnn::Tensor &in = tensorPool.getAndValidate(op->in());
 
   ::ttnn::SmallVector<int64_t> permutation(op->permutation()->begin(),
                                            op->permutation()->end());
@@ -25,6 +24,7 @@ void run(const ::tt::target::ttnn::PermuteOp *op, ProgramContext &context) {
   float padValue = op->pad_value();
 
   ::ttnn::Tensor out = ::ttnn::permute(in, permutation, memoryConfig, padValue);
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+
+  tensorPool.insertAndValidate(op->out(), out);
 }
 } // namespace tt::runtime::ttnn::operations::data_movement

--- a/runtime/lib/ttnn/operations/data_movement/repeat.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/repeat.cpp
@@ -5,16 +5,19 @@
 #include "operations/data_movement/repeat.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 
 namespace tt::runtime::ttnn::operations::data_movement {
 void run(const ::tt::target::ttnn::RepeatOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  const ::ttnn::Tensor &in = tensorPool.at(op->in()->global_id());
-  DEBUG_ASSERT(in.is_allocated());
+
+  const ::ttnn::Tensor &in = tensorPool.getAndValidate(op->in());
+
   const auto *fbShape = op->repeat_dims();
   const std::vector<uint32_t> repeatDims(fbShape->begin(), fbShape->end());
   ::ttnn::Shape repeatDimsShape(repeatDims);
   ::ttnn::Tensor out = ::ttnn::repeat(in, repeatDimsShape);
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+
+  tensorPool.insertAndValidate(op->out(), out);
 }
 } // namespace tt::runtime::ttnn::operations::data_movement

--- a/runtime/lib/ttnn/operations/data_movement/repeat_interleave.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/repeat_interleave.cpp
@@ -5,6 +5,7 @@
 #include "operations/data_movement/repeat_interleave.h"
 
 #include "tt/runtime/detail/logger.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
 
@@ -13,8 +14,7 @@ void run(const ::tt::target::ttnn::RepeatInterleaveOp *op,
          ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
 
-  const ::ttnn::Tensor &input = tensorPool.at(op->input()->global_id());
-  DEBUG_ASSERT(input.is_allocated());
+  const ::ttnn::Tensor &input = tensorPool.getAndValidate(op->input());
 
   uint32_t repeats = op->repeats();
   int32_t dim = op->dim();
@@ -24,6 +24,7 @@ void run(const ::tt::target::ttnn::RepeatInterleaveOp *op,
 
   ::ttnn::Tensor out =
       ::ttnn::repeat_interleave(input, repeats, dim, memoryConfig);
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+
+  tensorPool.insertAndValidate(op->out(), out);
 }
 } // namespace tt::runtime::ttnn::operations::data_movement

--- a/runtime/lib/ttnn/operations/data_movement/reshape.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/reshape.cpp
@@ -5,13 +5,15 @@
 #include "operations/data_movement/reshape.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/utils.h"
 
 namespace tt::runtime::ttnn::operations::data_movement {
 void run(const ::tt::target::ttnn::ReshapeOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  const ::ttnn::Tensor &in = tensorPool.at(op->in()->global_id());
-  DEBUG_ASSERT(in.is_allocated());
+
+  const ::ttnn::Tensor &in = tensorPool.getAndValidate(op->in());
+
   const auto *fbShape = op->shape();
   std::vector<int32_t> shape(fbShape->begin(), fbShape->end());
   std::optional<::ttnn::MemoryConfig> memoryConfig =
@@ -21,6 +23,6 @@ void run(const ::tt::target::ttnn::ReshapeOp *op, ProgramContext &context) {
           : ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
                 op->memory_config());
   ::ttnn::Tensor out = ::ttnn::reshape(in, shape, memoryConfig);
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+  tensorPool.insertAndValidate(op->out(), out);
 }
 } // namespace tt::runtime::ttnn::operations::data_movement

--- a/runtime/lib/ttnn/operations/data_movement/slice.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/slice.cpp
@@ -5,6 +5,7 @@
 #include "operations/data_movement/slice.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "ttmlir/Target/TTNN/program_generated.h"
 #include "ttnn/operations/data_movement/slice/slice.hpp"
 #include <cstdint>
@@ -12,14 +13,15 @@
 namespace tt::runtime::ttnn::operations::data_movement {
 void run(const ::tt::target::ttnn::SliceOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  const ::ttnn::Tensor &in = tensorPool.at(op->in()->global_id());
-  DEBUG_ASSERT(in.is_allocated());
+  const ::ttnn::Tensor &in = tensorPool.getAndValidate(op->in());
+
   ::ttnn::SmallVector<int32_t> begins(op->begins()->begin(),
                                       op->begins()->end());
   ::ttnn::SmallVector<int32_t> ends(op->ends()->begin(), op->ends()->end());
   ::ttnn::SmallVector<int32_t> step(op->step()->begin(), op->step()->end());
 
   ::ttnn::Tensor out = ::ttnn::slice(in, begins, ends, step);
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+
+  tensorPool.insertAndValidate(op->out(), out);
 }
 } // namespace tt::runtime::ttnn::operations::data_movement

--- a/runtime/lib/ttnn/operations/data_movement/transpose.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/transpose.cpp
@@ -5,14 +5,15 @@
 #include "operations/data_movement/transpose.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
 
 namespace tt::runtime::ttnn::operations::data_movement {
 void run(const ::tt::target::ttnn::TransposeOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  const ::ttnn::Tensor &in = tensorPool.at(op->in()->global_id());
-  DEBUG_ASSERT(in.is_allocated());
+  const ::ttnn::Tensor &in = tensorPool.getAndValidate(op->in());
+
   int32_t dim0 = op->dim0();
   int32_t dim1 = op->dim1();
 
@@ -24,6 +25,7 @@ void run(const ::tt::target::ttnn::TransposeOp *op, ProgramContext &context) {
              "Memory config must exist for device tensors");
 
   ::ttnn::Tensor out = ::ttnn::transpose(in, dim0, dim1, outputMemoryConfig);
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+
+  tensorPool.insertAndValidate(op->out(), out);
 }
 } // namespace tt::runtime::ttnn::operations::data_movement

--- a/runtime/lib/ttnn/operations/deletion/deallocate.cpp
+++ b/runtime/lib/ttnn/operations/deletion/deallocate.cpp
@@ -4,13 +4,13 @@
 #include "operations/deletion/deallocate.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 
 namespace tt::runtime::ttnn::operations::deletion {
 void run(const ::tt::target::ttnn::DeallocateOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  ::ttnn::Tensor &tensor = tensorPool.at(op->in()->global_id());
-  DEBUG_ASSERT(tensor.is_allocated());
+  ::ttnn::Tensor &tensor = tensorPool.getAndValidate(op->in());
   ::ttnn::deallocate(tensor, op->force());
-  tensorPool.erase(op->in()->global_id());
+  tensorPool.erase(op->in());
 }
 } // namespace tt::runtime::ttnn::operations::deletion

--- a/runtime/lib/ttnn/operations/eltwise/binary/binary.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/binary/binary.cpp
@@ -4,6 +4,7 @@
 #include "operations/eltwise/binary/binary.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/eltwise/binary/utils.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
@@ -23,6 +24,7 @@ static void runEltwiseBinaryOp(
 
   ::ttnn::Tensor *lhs = nullptr;
   ::ttnn::Tensor *rhs = nullptr;
+
   getEltwiseBinaryOpInputTensors(op, tensorPool, &lhs, &rhs);
 
   ::ttnn::DataType outputDataType = utils::getDataType(op->out());
@@ -37,7 +39,7 @@ static void runEltwiseBinaryOp(
   ::ttnn::Tensor out = ttnnOp(*lhs, *rhs, outputDataType, outputMemoryConfig,
                               std::nullopt, std::nullopt, std::nullopt);
 
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+  tensorPool.insertAndValidate(op->out(), out);
 }
 
 void run(const ::tt::target::ttnn::EltwiseOp *op, ProgramContext &context) {

--- a/runtime/lib/ttnn/operations/eltwise/binary/binary_composite.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/binary/binary_composite.cpp
@@ -4,6 +4,7 @@
 #include "operations/eltwise/binary/binary_composite.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/eltwise/binary/utils.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
@@ -30,7 +31,7 @@ static void runEltwiseBinaryCompositeOp(
 
   ::ttnn::Tensor out = ttnnOp(*lhs, *rhs, outputMemoryConfig);
 
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+  tensorPool.insertAndValidate(op->out(), out);
 }
 
 void run(const ::tt::target::ttnn::EltwiseOp *op, ProgramContext &context) {

--- a/runtime/lib/ttnn/operations/eltwise/ternary/ternary.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/ternary/ternary.cpp
@@ -5,6 +5,7 @@
 #include "operations/eltwise/ternary/ternary.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/eltwise/ternary/utils.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
@@ -19,6 +20,7 @@ static void runEltwiseTernaryWhereOp(
   ::ttnn::Tensor *first = nullptr;
   ::ttnn::Tensor *second = nullptr;
   ::ttnn::Tensor *third = nullptr;
+
   getEltwiseTernaryOpInputTensors(op, tensorPool, &first, &second, &third);
 
   std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
@@ -29,7 +31,8 @@ static void runEltwiseTernaryWhereOp(
              "Memory config must exist for device tensors");
 
   ::ttnn::Tensor out = ttnnOp(*first, *second, *third, outputMemoryConfig);
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+
+  tensorPool.insertAndValidate(op->out(), out);
 }
 
 void run(const ::tt::target::ttnn::EltwiseOp *op, ProgramContext &context) {

--- a/runtime/lib/ttnn/operations/eltwise/unary/unary.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/unary/unary.cpp
@@ -4,6 +4,7 @@
 #include "operations/eltwise/unary/unary.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/eltwise/unary/utils.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
@@ -19,6 +20,7 @@ static void runEltwiseUnaryOp(
         const std::optional<::ttnn::Tensor> &)> &ttnnOp) {
 
   ::ttnn::Tensor *in = nullptr;
+
   getEltwiseUnaryOpInputTensor(op, tensorPool, &in);
 
   std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
@@ -29,7 +31,8 @@ static void runEltwiseUnaryOp(
              "Memory config must exist for device tensors");
 
   ::ttnn::Tensor out = ttnnOp(*in, outputMemoryConfig, std::nullopt);
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+
+  tensorPool.insertAndValidate(op->out(), out);
 }
 
 static void runEltwiseUnaryWithFastAndApproximateModeOp(
@@ -40,6 +43,7 @@ static void runEltwiseUnaryWithFastAndApproximateModeOp(
                        const std::optional<::ttnn::Tensor> &)> &ttnnOp) {
 
   ::ttnn::Tensor *in = nullptr;
+
   getEltwiseUnaryOpInputTensor(op, tensorPool, &in);
 
   std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
@@ -51,7 +55,8 @@ static void runEltwiseUnaryWithFastAndApproximateModeOp(
 
   ::ttnn::Tensor out =
       ttnnOp(*in, false /* parameter */, outputMemoryConfig, std::nullopt);
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+
+  tensorPool.insertAndValidate(op->out(), out);
 }
 
 static void runEltwiseUnaryWithFloatParameterOp(
@@ -60,6 +65,7 @@ static void runEltwiseUnaryWithFloatParameterOp(
         ::ttnn::Tensor(const ::ttnn::Tensor &, float,
                        const std::optional<::ttnn::MemoryConfig> &)> &ttnnOp) {
   ::ttnn::Tensor *in = nullptr;
+
   getEltwiseUnaryOpInputTensor(op, tensorPool, &in);
 
   float parameter = op->params_as_EltwiseOpWithFloatParams()->parameter();
@@ -72,7 +78,8 @@ static void runEltwiseUnaryWithFloatParameterOp(
              "Memory config must exist for device tensors");
 
   ::ttnn::Tensor out = ttnnOp(*in, parameter, outputMemoryConfig);
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+
+  tensorPool.insertAndValidate(op->out(), out);
 }
 
 void run(const ::tt::target::ttnn::EltwiseOp *op, ProgramContext &context) {

--- a/runtime/lib/ttnn/operations/eltwise/unary/unary_composite.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/unary/unary_composite.cpp
@@ -4,6 +4,7 @@
 #include "operations/eltwise/unary/unary_composite.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/eltwise/unary/utils.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
@@ -18,6 +19,7 @@ static void runEltwiseUnaryCompositeOp(
         &ttnnOp) {
 
   ::ttnn::Tensor *in = nullptr;
+
   getEltwiseUnaryOpInputTensor(op, tensorPool, &in);
 
   std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
@@ -28,7 +30,8 @@ static void runEltwiseUnaryCompositeOp(
              "Memory config must exist for device tensors");
 
   ::ttnn::Tensor out = ttnnOp(*in, outputMemoryConfig);
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+
+  tensorPool.insertAndValidate(op->out(), out);
 }
 
 static void runEltwiseUnaryCompositeClampOp(
@@ -37,6 +40,7 @@ static void runEltwiseUnaryCompositeClampOp(
         ::ttnn::Tensor(const ::ttnn::Tensor &, float, float,
                        const std::optional<::ttnn::MemoryConfig> &)> &ttnnOp) {
   ::ttnn::Tensor *in = nullptr;
+
   getEltwiseUnaryOpInputTensor(op, tensorPool, &in);
 
   float min = op->params_as_ClampOpParams()->min();
@@ -50,7 +54,8 @@ static void runEltwiseUnaryCompositeClampOp(
              "Memory config must exist for device tensors");
 
   ::ttnn::Tensor out = ttnnOp(*in, min, max, outputMemoryConfig);
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+
+  tensorPool.insertAndValidate(op->out(), out);
 }
 
 void run(const ::tt::target::ttnn::EltwiseOp *op, ProgramContext &context) {

--- a/runtime/lib/ttnn/operations/embedding/embedding.cpp
+++ b/runtime/lib/ttnn/operations/embedding/embedding.cpp
@@ -5,6 +5,7 @@
 #include "operations/embedding/embedding.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
 
@@ -12,10 +13,8 @@ namespace tt::runtime::ttnn::operations::embedding {
 void run(const ::tt::target::ttnn::EmbeddingOp *op, ProgramContext &context) {
 
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  const ::ttnn::Tensor &input = tensorPool.at(op->input()->global_id());
-  const ::ttnn::Tensor &weight = tensorPool.at(op->weight()->global_id());
-  DEBUG_ASSERT(input.is_allocated());
-  DEBUG_ASSERT(weight.is_allocated());
+  const ::ttnn::Tensor &input = tensorPool.getAndValidate(op->input());
+  const ::ttnn::Tensor &weight = tensorPool.getAndValidate(op->weight());
 
   // default params for embedding op
   std::optional<int> padToken = std::nullopt;
@@ -35,6 +34,7 @@ void run(const ::tt::target::ttnn::EmbeddingOp *op, ProgramContext &context) {
   ::ttnn::Tensor out =
       ::ttnn::embedding(input, weight, padToken, layout, embeddingsType,
                         outputDataType, outputMemoryConfig);
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+
+  tensorPool.insertAndValidate(op->out(), out);
 }
 } // namespace tt::runtime::ttnn::operations::embedding

--- a/runtime/lib/ttnn/operations/embedding/embedding_backward.cpp
+++ b/runtime/lib/ttnn/operations/embedding/embedding_backward.cpp
@@ -5,6 +5,7 @@
 #include "operations/embedding/embedding_backward.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
 #include "ttmlir/Target/TTNN/program_generated.h"
@@ -16,12 +17,9 @@ void run(const ::tt::target::ttnn::EmbeddingBackwardOp *op,
          ProgramContext &context) {
 
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  const ::ttnn::Tensor &input = tensorPool.at(op->input()->global_id());
-  const ::ttnn::Tensor &weight = tensorPool.at(op->weight()->global_id());
-  const ::ttnn::Tensor &inGrad = tensorPool.at(op->in_grad()->global_id());
-  DEBUG_ASSERT(input.is_allocated());
-  DEBUG_ASSERT(weight.is_allocated());
-  DEBUG_ASSERT(inGrad.is_allocated());
+  const ::ttnn::Tensor &input = tensorPool.getAndValidate(op->input());
+  const ::ttnn::Tensor &weight = tensorPool.getAndValidate(op->weight());
+  const ::ttnn::Tensor &inGrad = tensorPool.getAndValidate(op->in_grad());
 
   std::optional<::ttnn::MemoryConfig> memoryConfig =
       ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
@@ -33,6 +31,6 @@ void run(const ::tt::target::ttnn::EmbeddingBackwardOp *op,
   ::ttnn::Tensor out =
       ::ttnn::embedding_bw(input, weight, inGrad, dtype, memoryConfig);
 
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+  tensorPool.insertAndValidate(op->out(), out);
 }
 } // namespace tt::runtime::ttnn::operations::embedding_backward

--- a/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/eltwise/binary/utils.cpp
+++ b/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/eltwise/binary/utils.cpp
@@ -22,10 +22,8 @@ void getEltwiseBinaryOpInputTensors(const ::tt::target::ttnn::EltwiseOp *op,
                                     ::ttnn::Tensor **rhs) {
 
   LOG_ASSERT(op->ins()->size() == 2, "Expected 2 inputs");
-  *lhs = &(tensorPool.at(op->ins()->Get(0)->global_id()));
-  *rhs = &(tensorPool.at(op->ins()->Get(1)->global_id()));
-  DEBUG_ASSERT((*lhs)->is_allocated());
-  DEBUG_ASSERT((*rhs)->is_allocated());
+  *lhs = &(tensorPool.getAndValidate(op->ins()->Get(0)));
+  *rhs = &(tensorPool.getAndValidate(op->ins()->Get(1)));
 
   // Switch the order of operands if the second operand requires broadcast
   // TODO(bug #1124): We're currently swapping the operands for binary ops

--- a/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/eltwise/ternary/utils.cpp
+++ b/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/eltwise/ternary/utils.cpp
@@ -13,12 +13,9 @@ void getEltwiseTernaryOpInputTensors(const ::tt::target::ttnn::EltwiseOp *op,
                                      ::ttnn::Tensor **second,
                                      ::ttnn::Tensor **third) {
   LOG_ASSERT(op->ins()->size() == 3, "Expected 3 inputs");
-  *first = &(tensorPool.at(op->ins()->Get(0)->global_id()));
-  *second = &(tensorPool.at(op->ins()->Get(1)->global_id()));
-  *third = &(tensorPool.at(op->ins()->Get(2)->global_id()));
-  DEBUG_ASSERT((*first)->is_allocated());
-  DEBUG_ASSERT((*second)->is_allocated());
-  DEBUG_ASSERT((*third)->is_allocated());
+  *first = &(tensorPool.getAndValidate(op->ins()->Get(0)));
+  *second = &(tensorPool.getAndValidate(op->ins()->Get(1)));
+  *third = &(tensorPool.getAndValidate(op->ins()->Get(2)));
 }
 
 } // namespace tt::runtime::ttnn::operations::ternary

--- a/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/eltwise/unary/utils.cpp
+++ b/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/eltwise/unary/utils.cpp
@@ -11,8 +11,7 @@ void getEltwiseUnaryOpInputTensor(const ::tt::target::ttnn::EltwiseOp *op,
                                   ::ttnn::Tensor **in) {
   LOG_ASSERT(op->ins()->size() == 1, "Expected 1 input, got ",
              op->ins()->size());
-  *in = &(tensorPool.at(op->ins()->Get(0)->global_id()));
-  DEBUG_ASSERT((*in)->is_allocated());
+  *in = &(tensorPool.getAndValidate(op->ins()->Get(0)));
 }
 
 } // namespace tt::runtime::ttnn::operations::unary

--- a/runtime/lib/ttnn/operations/kv_cache/fill_cache.cpp
+++ b/runtime/lib/ttnn/operations/kv_cache/fill_cache.cpp
@@ -3,13 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "operations/kv_cache/fill_cache.h"
-
+#include "tt/runtime/detail/logger.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 namespace tt::runtime::ttnn::operations::kv_cache {
 void run(const ::tt::target::ttnn::FillCacheOp *op, ProgramContext &context) {
 
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  const ::ttnn::Tensor &cache = tensorPool.at(op->cache()->global_id());
-  const ::ttnn::Tensor &input = tensorPool.at(op->input()->global_id());
+  const ::ttnn::Tensor &cache = tensorPool.getAndValidate(op->cache());
+  const ::ttnn::Tensor &input = tensorPool.getAndValidate(op->input());
 
   ::ttnn::fill_cache(cache, input, op->batch_offset());
 }

--- a/runtime/lib/ttnn/operations/kv_cache/update_cache.cpp
+++ b/runtime/lib/ttnn/operations/kv_cache/update_cache.cpp
@@ -6,16 +6,18 @@
 
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/workarounds.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 
 namespace tt::runtime::ttnn::operations::kv_cache {
 void run(const ::tt::target::ttnn::UpdateCacheOp *op, ProgramContext &context) {
 
   ProgramTensorPool &tensorPool = context.getTensorPool();
 
-  const ::ttnn::Tensor &cache = tensorPool.at(op->cache()->global_id());
-  const ::ttnn::Tensor &input = tensorPool.at(op->input()->global_id());
+  const ::ttnn::Tensor &cache = tensorPool.getAndValidate(op->cache());
+  const ::ttnn::Tensor &input = tensorPool.getAndValidate(op->input());
   const ::ttnn::Tensor &updateIndex =
-      tensorPool.at(op->update_index()->global_id());
+      tensorPool.getAndValidate(op->update_index());
+
   if (workaround::Env::get().readUpdateIndexFromDeviceForKVCache) {
 
     const ::ttnn::Tensor indexOnHost = ::ttnn::from_device(updateIndex);

--- a/runtime/lib/ttnn/operations/layout/from_device.cpp
+++ b/runtime/lib/ttnn/operations/layout/from_device.cpp
@@ -5,18 +5,18 @@
 #include "operations/layout/from_device.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
 namespace tt::runtime::ttnn::operations::layout {
 void run(const ::tt::target::ttnn::FromDeviceOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  const ::ttnn::Tensor &inputTensor = tensorPool.at(op->in()->global_id());
-  DEBUG_ASSERT(inputTensor.is_allocated());
-  DEBUG_ASSERT(
-      ::tt::runtime::ttnn::utils::isOnDevice(inputTensor.storage_type()),
-      "Calling ttnn::from_device on a host tensor");
+  const ::ttnn::Tensor &inputTensor = tensorPool.getAndValidate(op->in());
+  DEBUG_ASSERT(!::tt::runtime::ttnn::utils::inSystemMemory(op->in()),
+               "Calling ttnn::from_device on a host tensor");
 
   ::ttnn::Tensor out = ::ttnn::from_device(inputTensor);
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+
+  tensorPool.insertAndValidate(op->out(), out);
 }
 } // namespace tt::runtime::ttnn::operations::layout

--- a/runtime/lib/ttnn/operations/layout/to_dtype.cpp
+++ b/runtime/lib/ttnn/operations/layout/to_dtype.cpp
@@ -3,19 +3,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "operations/layout/to_dtype.h"
+#include "tt/runtime/detail/logger.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/utils.h"
 
 namespace tt::runtime::ttnn::operations::layout {
-
 void run(const ::tt::target::ttnn::ToDTypeOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  const ::ttnn::Tensor &inputTensor = tensorPool.at(op->in()->global_id());
+  const ::ttnn::Tensor &inputTensor = tensorPool.getAndValidate(op->in());
 
   ::ttnn::DataType targetDataType =
       ::tt::runtime::ttnn::utils::toTTNNDataType(op->dtype());
 
   ::ttnn::Tensor out = ::ttnn::to_dtype(inputTensor, targetDataType);
 
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+  tensorPool.insertAndValidate(op->out(), out);
 }
 } // namespace tt::runtime::ttnn::operations::layout

--- a/runtime/lib/ttnn/operations/layout/to_memory_config.cpp
+++ b/runtime/lib/ttnn/operations/layout/to_memory_config.cpp
@@ -5,27 +5,26 @@
 #include "operations/layout/to_memory_config.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
 
 namespace tt::runtime::ttnn::operations::layout {
-
-// TODO(bug #272): right now hardcoding tilize/untilize, should determine with
-// tile shape blocked by issue #272
 void run(const ::tt::target::ttnn::ToMemoryConfigOp *op,
          ProgramContext &context) {
 
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  const ::ttnn::Tensor &inputTensor = tensorPool.at(op->in0()->global_id());
-  DEBUG_ASSERT(inputTensor.is_allocated());
+  const ::ttnn::Tensor &inputTensor = tensorPool.getAndValidate(op->in0());
   LOG_ASSERT(!::tt::runtime::ttnn::utils::inSystemMemory(op->out()),
              "Should not be converting memory config for host tensor");
   LOG_ASSERT(op->memcfg(), "ToMemoryConfigOp must have memory config");
+
   std::optional<::ttnn::MemoryConfig> memoryConfig =
       ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
 
   ::ttnn::Tensor out =
       ::ttnn::to_memory_config(inputTensor, memoryConfig.value(), std::nullopt);
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+
+  tensorPool.insertAndValidate(op->out(), out);
 }
 } // namespace tt::runtime::ttnn::operations::layout

--- a/runtime/lib/ttnn/operations/layout/typecast.cpp
+++ b/runtime/lib/ttnn/operations/layout/typecast.cpp
@@ -3,24 +3,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "operations/layout/typecast.h"
+#include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
 #include "tt/runtime/detail/workarounds.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
 #include "ttnn/operations/core/core.hpp"
 
 namespace tt::runtime::ttnn::operations::layout {
-
 void run(const ::tt::target::ttnn::TypecastOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  const ::ttnn::Tensor &inputTensor = tensorPool.at(op->in()->global_id());
+  const ::ttnn::Tensor &inputTensor = tensorPool.getAndValidate(op->in());
 
   ::ttnn::DataType targetDataType =
       ::tt::runtime::ttnn::utils::toTTNNDataType(op->dtype());
 
   ::ttnn::Tensor out = ::ttnn::typecast(inputTensor, targetDataType);
 
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+  tensorPool.insertAndValidate(op->out(), out);
 }
 
 } // namespace tt::runtime::ttnn::operations::layout

--- a/runtime/lib/ttnn/operations/moreh/moreh_cumsum.cpp
+++ b/runtime/lib/ttnn/operations/moreh/moreh_cumsum.cpp
@@ -6,6 +6,7 @@
 
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
 #include "ttmlir/Target/TTNN/program_generated.h"
@@ -16,8 +17,7 @@
 namespace tt::runtime::ttnn::operations::moreh {
 void run(const ::tt::target::ttnn::MorehCumSumOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  const ::ttnn::Tensor &in = tensorPool.at(op->in()->global_id());
-  DEBUG_ASSERT(in.is_allocated());
+  const ::ttnn::Tensor &in = tensorPool.getAndValidate(op->in());
 
   std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
       ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
@@ -26,6 +26,6 @@ void run(const ::tt::target::ttnn::MorehCumSumOp *op, ProgramContext &context) {
       ::ttnn::moreh_cumsum(in, op->dim(), std::nullopt, outputMemoryConfig,
                            /*computeKernelConfig*/ std::nullopt);
 
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+  tensorPool.insertAndValidate(op->out(), out);
 }
 } // namespace tt::runtime::ttnn::operations::moreh

--- a/runtime/lib/ttnn/operations/normalization/softmax.cpp
+++ b/runtime/lib/ttnn/operations/normalization/softmax.cpp
@@ -5,16 +5,16 @@
 #include "operations/normalization/softmax.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
 
 namespace tt::runtime::ttnn::operations::normalization {
 void run(const ::tt::target::ttnn::SoftmaxOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
-  const ::ttnn::Tensor &in = tensorPool.at(op->in()->global_id());
-  DEBUG_ASSERT(in.is_allocated());
-  int32_t dimension = op->dimension();
+  const ::ttnn::Tensor &in = tensorPool.getAndValidate(op->in());
 
+  int32_t dimension = op->dimension();
   std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
       ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
           ::tt::runtime::ttnn::utils::getTensorRefMemoryConfig(op->out()));
@@ -23,6 +23,7 @@ void run(const ::tt::target::ttnn::SoftmaxOp *op, ProgramContext &context) {
              "Memory config must exist for device tensors");
 
   ::ttnn::Tensor out = ::ttnn::softmax(in, dimension, outputMemoryConfig);
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+
+  tensorPool.insertAndValidate(op->out(), out);
 }
 } // namespace tt::runtime::ttnn::operations::normalization

--- a/runtime/lib/ttnn/operations/pool/maxpool2d.cpp
+++ b/runtime/lib/ttnn/operations/pool/maxpool2d.cpp
@@ -5,6 +5,7 @@
 #include "operations/pool/maxpool2d.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
 #include "ttnn/types.hpp"
@@ -15,8 +16,7 @@ namespace tt::runtime::ttnn::operations::pool {
 void run(const ::tt::target::ttnn::MaxPool2dOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
 
-  ::ttnn::Tensor input = tensorPool.at(op->in()->global_id());
-  DEBUG_ASSERT(input.is_allocated());
+  ::ttnn::Tensor input = tensorPool.getAndValidate(op->in());
 
   std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
       ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
@@ -33,6 +33,6 @@ void run(const ::tt::target::ttnn::MaxPool2dOp *op, ProgramContext &context) {
       std::array{op->dilation_height(), op->dilation_width()},
       outputMemoryConfig, std::nullopt);
 
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+  tensorPool.insertAndValidate(op->out(), out);
 }
 } // namespace tt::runtime::ttnn::operations::pool

--- a/runtime/lib/ttnn/operations/pool/upsample.cpp
+++ b/runtime/lib/ttnn/operations/pool/upsample.cpp
@@ -5,6 +5,7 @@
 #include "operations/pool/upsample.h"
 
 #include "tt/runtime/detail/logger.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
 
@@ -12,8 +13,7 @@ namespace tt::runtime::ttnn::operations::pool {
 void run(const ::tt::target::ttnn::UpsampleOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
 
-  ::ttnn::Tensor &input = tensorPool.at(op->in()->global_id());
-  DEBUG_ASSERT(input.is_allocated());
+  ::ttnn::Tensor &input = tensorPool.getAndValidate(op->in());
 
   std::variant<int32_t, std::array<uint32_t, 2>> scaleFactor;
   if (op->scale_factor_type() == ::tt::target::ttnn::Scale2D::UniformScale2D) {
@@ -37,6 +37,6 @@ void run(const ::tt::target::ttnn::UpsampleOp *op, ProgramContext &context) {
   ::ttnn::Tensor output =
       ::ttnn::upsample(input, scaleFactor, mode, memoryConfig);
 
-  tensorPool.insert_or_assign(op->out()->global_id(), output);
+  tensorPool.insertAndValidate(op->out(), output);
 }
 } // namespace tt::runtime::ttnn::operations::pool

--- a/runtime/lib/ttnn/operations/reduction/argmax.cpp
+++ b/runtime/lib/ttnn/operations/reduction/argmax.cpp
@@ -4,17 +4,16 @@
 
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
-
 #include <optional>
 
 namespace tt::runtime::ttnn::operations::reduction {
 static void
 runReductionArgMaxOp(::tt::target::ttnn::ReductionArgMaxOp const *op,
                      ProgramTensorPool &tensorPool) {
-  const ::ttnn::Tensor &in = tensorPool.at(op->in()->global_id());
-  DEBUG_ASSERT(in.is_allocated());
+  const ::ttnn::Tensor &in = tensorPool.getAndValidate(op->in());
 
   std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
       ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
@@ -23,7 +22,7 @@ runReductionArgMaxOp(::tt::target::ttnn::ReductionArgMaxOp const *op,
                                       /*memory_config_arg=*/outputMemoryConfig,
                                       /*optional_output_tensor=*/std::nullopt);
 
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+  tensorPool.insertAndValidate(op->out(), out);
 }
 
 void run(const ::tt::target::ttnn::ReductionArgMaxOp *op,

--- a/runtime/lib/ttnn/operations/reduction/prod.cpp
+++ b/runtime/lib/ttnn/operations/reduction/prod.cpp
@@ -5,6 +5,7 @@
 #include "operations/reduction/prod.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
 
@@ -15,14 +16,13 @@ static void runReductionProdOp(::tt::target::ttnn::ReductionProdOp const *op,
   std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
       ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
 
-  const ::ttnn::Tensor &in = tensorPool.at(op->in()->global_id());
-  DEBUG_ASSERT(in.is_allocated());
+  const ::ttnn::Tensor &in = tensorPool.getAndValidate(op->in());
 
   ::ttnn::Tensor out =
       ::ttnn::prod(in, op->all_dimensions(), op->dim_arg(), op->keep_dim(),
                    outputMemoryConfig /* memory_config_arg */);
 
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+  tensorPool.insertAndValidate(op->out(), out);
 }
 
 void run(const ::tt::target::ttnn::ReductionProdOp *op,

--- a/runtime/lib/ttnn/operations/reduction/reduction.cpp
+++ b/runtime/lib/ttnn/operations/reduction/reduction.cpp
@@ -5,6 +5,7 @@
 #include "operations/reduction/reduction.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
 
@@ -25,8 +26,7 @@ static void runReductionOp(
                  outputMemoryConfig.has_value(),
              "Memory config must exist for device tensors");
 
-  const ::ttnn::Tensor &in = tensorPool.at(op->in()->global_id());
-  DEBUG_ASSERT(in.is_allocated());
+  const ::ttnn::Tensor &in = tensorPool.getAndValidate(op->in());
 
   const auto *fbDimArg = op->dim_arg();
   std::optional<::ttnn::SmallVector<int>> dimArg =
@@ -38,7 +38,7 @@ static void runReductionOp(
       in, dimArg, op->keep_dim(), outputMemoryConfig /* memory_config_arg */,
       std::nullopt /* compute_kernel_config */, 1.0f /* scalar */);
 
-  tensorPool.insert_or_assign(op->out()->global_id(), out);
+  tensorPool.insertAndValidate(op->out(), out);
 }
 
 void run(const ::tt::target::ttnn::ReductionOp *op, ProgramContext &context) {

--- a/runtime/lib/ttnn/types/CMakeLists.txt
+++ b/runtime/lib/ttnn/types/CMakeLists.txt
@@ -1,3 +1,8 @@
+if (NOT TTNN_RUNTIME_ENABLED)
+  add_library(TTRuntimeTTNNTypes INTERFACE)
+  return()
+endif()
+
 add_library(TTRuntimeTTNNTypes
   STATIC
   types.cpp
@@ -10,5 +15,5 @@ target_include_directories(TTRuntimeTTNNTypes PUBLIC
   ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common
 )
 target_include_directories(TTRuntimeTTNNTypes SYSTEM PUBLIC "$<BUILD_INTERFACE:${TTMETAL_INCLUDE_DIRS}>")
-add_dependencies(TTRuntimeTTNNTypes TTNN_LIBRARY tt-metal FBS_GENERATION)
-target_link_libraries(TTRuntimeTTNNTypes PUBLIC TTNN_LIBRARY)
+add_dependencies(TTRuntimeTTNNTypes TTNN_LIBRARY tt-metal FBS_GENERATION TTRuntimeTTNNDebug)
+target_link_libraries(TTRuntimeTTNNTypes PUBLIC TTNN_LIBRARY TTRuntimeTTNNDebug)

--- a/runtime/lib/ttnn/types/types.cpp
+++ b/runtime/lib/ttnn/types/types.cpp
@@ -4,6 +4,7 @@
 
 #include "tt/runtime/ttnn/types.h"
 #include "tt/runtime/detail/logger.h"
+#include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/utils.h"
 
 namespace tt::runtime::ttnn {
@@ -339,36 +340,40 @@ LayoutConverter::convertDeviceTensorLayout(const ::ttnn::Tensor &input) {
 //
 // ProgramTensorPool APIs
 //
-std::pair<std::unordered_map<std::uint32_t, ::ttnn::Tensor *>::iterator, bool>
-ProgramTensorPool::try_emplace(std::uint32_t globalId,
-                               const ::ttnn::Tensor &tensor) {
-  auto it = liveTensors.find(globalId);
-  if (it != liveTensors.end()) {
-    return std::make_pair(it, false);
-  }
-  LOG_ASSERT(!intermedTensors.contains(globalId));
-  intermedTensors.try_emplace(globalId, tensor);
-  return liveTensors.try_emplace(globalId, &intermedTensors.at(globalId));
-}
-
-std::pair<std::unordered_map<std::uint32_t, ::ttnn::Tensor *>::iterator, bool>
-ProgramTensorPool::insert_or_assign(std::uint32_t globalId,
-                                    const ::ttnn::Tensor &tensor) {
-  intermedTensors.insert_or_assign(globalId, tensor);
-  return liveTensors.insert_or_assign(globalId, &intermedTensors.at(globalId));
-}
-
-::ttnn::Tensor &ProgramTensorPool::at(std::uint32_t globalId) {
+const ::ttnn::Tensor &ProgramTensorPool::getAndValidate(
+    const ::tt::target::ttnn::TensorRef *tensorRef) const {
+  LOG_ASSERT(tensorRef != nullptr, "tensorRef should not be null");
+  std::uint32_t globalId = tensorRef->global_id();
   LOG_ASSERT(liveTensors.contains(globalId));
-  return *liveTensors.at(globalId);
+  const ::ttnn::Tensor &ttnnTensor = *liveTensors.at(globalId);
+  DEBUG_ASSERT(ttnnTensor.is_allocated());
+  debug::checkTensorRefMatchesTTNNTensor(tensorRef, ttnnTensor);
+  return ttnnTensor;
 }
 
-const ::ttnn::Tensor &ProgramTensorPool::at(std::uint32_t globalId) const {
-  LOG_ASSERT(liveTensors.contains(globalId));
-  return *liveTensors.at(globalId);
+::ttnn::Tensor &ProgramTensorPool::getAndValidate(
+    const ::tt::target::ttnn::TensorRef *tensorRef) {
+  return const_cast<::ttnn::Tensor &>(
+      static_cast<const ProgramTensorPool &>(*this).getAndValidate(tensorRef));
 }
 
-size_t ProgramTensorPool::erase(std::uint32_t globalId) {
+std::pair<std::unordered_map<std::uint32_t, ::ttnn::Tensor *>::iterator, bool>
+ProgramTensorPool::insertAndValidate(
+    const ::tt::target::ttnn::TensorRef *tensorRef,
+    const ::ttnn::Tensor &ttnnTensor) {
+  LOG_ASSERT(tensorRef != nullptr, "tensorRef should not be null");
+  std::uint32_t globalId = tensorRef->global_id();
+  DEBUG_ASSERT(ttnnTensor.is_allocated());
+  debug::checkTensorRefMatchesTTNNTensor(tensorRef, ttnnTensor);
+  auto [iter, inserted] =
+      intermedTensors.insert_or_assign(globalId, ttnnTensor);
+  return liveTensors.insert_or_assign(globalId, &(iter->second));
+}
+
+size_t
+ProgramTensorPool::erase(const ::tt::target::ttnn::TensorRef *tensorRef) {
+  LOG_ASSERT(tensorRef != nullptr, "tensorRef should not be null");
+  std::uint32_t globalId = tensorRef->global_id();
   LOG_ASSERT(liveTensors.contains(globalId) &&
              intermedTensors.contains(globalId));
   intermedTensors.erase(globalId);
@@ -377,11 +382,14 @@ size_t ProgramTensorPool::erase(std::uint32_t globalId) {
 
 std::vector<Tensor> ProgramTensorPool::gatherOutputTensors() {
   std::vector<Tensor> outputTensors;
-  outputTensors.reserve(programOutputs.size());
+  outputTensors.reserve(programOutputIds.size());
   std::transform(
-      programOutputs.begin(), programOutputs.end(),
+      programOutputIds.begin(), programOutputIds.end(),
       std::back_inserter(outputTensors), [this](uint32_t outputGlobalId) {
-        return utils::createRuntimeTensorFromTTNN(this->at(outputGlobalId));
+        LOG_ASSERT(liveTensors.contains(outputGlobalId));
+        const ::ttnn::Tensor &ttnnTensor = *liveTensors.at(outputGlobalId);
+        DEBUG_ASSERT(ttnnTensor.is_allocated());
+        return utils::createRuntimeTensorFromTTNN(ttnnTensor);
       });
   return outputTensors;
 }
@@ -391,9 +399,11 @@ std::vector<Tensor> ProgramTensorPool::gatherOutputTensors() {
 //
 ProgramContext::ProgramContext(
     const std::unordered_map<uint32_t, ::ttnn::Tensor *> &liveTensors,
-    const std::vector<uint32_t> &programInputs,
-    const std::vector<uint32_t> &programOutputs, ::ttnn::MeshDevice *parentMesh)
-    : tensorPool(ProgramTensorPool(liveTensors, programInputs, programOutputs)),
+    const std::vector<uint32_t> &programInputIds,
+    const std::vector<uint32_t> &programOutputIds,
+    ::ttnn::MeshDevice *parentMesh)
+    : tensorPool(
+          ProgramTensorPool(liveTensors, programInputIds, programOutputIds)),
       parentMesh(parentMesh) {
   LOG_ASSERT(parentMesh, "Parent mesh cannot be null");
 }

--- a/runtime/lib/ttnn/utils/CMakeLists.txt
+++ b/runtime/lib/ttnn/utils/CMakeLists.txt
@@ -1,3 +1,8 @@
+if (NOT TTNN_RUNTIME_ENABLED)
+  add_library(TTRuntimeTTNNUtils INTERFACE)
+  return()
+endif()
+
 add_library(TTRuntimeTTNNUtils
   STATIC
   utils.cpp

--- a/runtime/tools/python/setup.py
+++ b/runtime/tools/python/setup.py
@@ -234,15 +234,11 @@ if enable_runtime:
             ],
             libraries=[
                 "TTMLIRRuntime",
-                "TTRuntimeTTNNTypes",
-                "TTRuntimeTTNNUtils",
                 "flatbuffers",
             ]
             + (["TTRuntimeTTNNTestLib"] if enable_runtime_tests else []),
             library_dirs=[
                 f"{ttmlir_build_dir}/runtime/lib",
-                f"{ttmlir_build_dir}/runtime/lib/ttnn/types",
-                f"{ttmlir_build_dir}/runtime/lib/ttnn/utils",
                 f"{ttmlir_build_dir}/runtime/test/ttnn",
                 f"{toolchain}/lib",
             ],

--- a/test/ttmlir/Dialect/TTNN/reduction/simple_argmax.mlir
+++ b/test/ttmlir/Dialect/TTNN/reduction/simple_argmax.mlir
@@ -7,7 +7,7 @@ module attributes {} {
     // CHECK: "ttnn.argmax"
     // CHECK-SAME: {dim = 3 : i32, use_multicore = false}>
     // CHECK-SAME: tensor<1x1x64x64xbf16
-    // CHECK-SAME: -> tensor<1x1x64x1xsi32
+    // CHECK-SAME: -> tensor<1x1x64x1xui32
     %1 = "ttir.argmax"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<64x64xf32>, tensor<64x1xi32>) -> tensor<64x1xi32>
     return %1 : tensor<64x1xi32>
   }
@@ -18,7 +18,7 @@ module attributes {} {
     // CHECK: %[[ARGMAX:[0-9]+]] = "ttnn.argmax"
     // CHECK-SAME: {dim = 3 : i32, use_multicore = false}>
     // CHECK-SAME: tensor<1x128x28x28xbf16
-    // CHECK-SAME: -> tensor<1x128x28x1xsi32
+    // CHECK-SAME: -> tensor<1x128x28x1xui32
     %1 = "ttir.argmax"(%arg0, %0) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<128x28x28xf32>, tensor<128x28xi32>) -> tensor<128x28xi32>
     return %1 : tensor<128x28xi32>
   }
@@ -29,7 +29,7 @@ module attributes {} {
     // CHECK: %[[ARGMAX:[0-9]+]] = "ttnn.argmax"
     // CHECK-SAME: {dim = 3 : i32, use_multicore = false}>
     // CHECK-SAME: tensor<4x8x128x64xbf16
-    // CHECK-SAME: -> tensor<4x8x128x1xsi32
+    // CHECK-SAME: -> tensor<4x8x128x1xui32
     %1 = "ttir.argmax"(%arg0, %0) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<4x8x128x64xf32>, tensor<4x8x128xi32>) -> tensor<4x8x128xi32>
     return %1 : tensor<4x8x128xi32>
   }

--- a/test/ttmlir/Silicon/StableHLO/n150/reduction/argmax_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/reduction/argmax_op.mlir
@@ -11,7 +11,7 @@ module @module_argmax attributes {} {
     // CHECK: "ttnn.argmax"
     // CHECK-SAME: {dim = 3 : i32, use_multicore = false}>
     // CHECK-SAME: tensor<1x1x1x32128xbf16
-    // CHECK-SAME: -> tensor<1x1x1x1xsi32
+    // CHECK-SAME: -> tensor<1x1x1x1xui32
     %cst = stablehlo.constant dense<0xFF800000> : tensor<f32>
     %c = stablehlo.constant dense<0> : tensor<i64>
     %0 = stablehlo.iota dim = 1 : tensor<1x32128xi64>
@@ -33,7 +33,7 @@ module @module_argmax attributes {} {
     // CHECK: "ttnn.argmax"
     // CHECK-SAME: {dim = 3 : i32, use_multicore = false}>
     // CHECK-SAME: tensor<1x1x32x32xbf16
-    // CHECK-SAME: -> tensor<1x1x32x1xsi32
+    // CHECK-SAME: -> tensor<1x1x32x1xui32
     %0 = stablehlo.iota dim = 2 : tensor<1x32x32xi32>
     %cst = stablehlo.constant dense<0xFF800000> : tensor<f32>
     %c = stablehlo.constant dense<0> : tensor<i32>
@@ -58,7 +58,7 @@ module @module_argmax attributes {} {
     // CHECK: "ttnn.argmax"
     // CHECK-SAME: {dim = 3 : i32, use_multicore = false}>
     // CHECK-SAME: tensor<1x1x128x64xbf16
-    // CHECK-SAME: -> tensor<1x1x128x1xsi32
+    // CHECK-SAME: -> tensor<1x1x128x1xui32
     %cst = stablehlo.constant dense<0xFF800000> : tensor<f32>
     %c = stablehlo.constant dense<0> : tensor<i64>
     %0 = stablehlo.iota dim = 3 : tensor<1x1x128x64xi64>

--- a/test/ttmlir/Silicon/TTNN/n150/simple_argmax.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_argmax.mlir
@@ -11,7 +11,7 @@ module attributes {} {
     // CHECK: "ttnn.argmax"
     // CHECK-SAME: {dim = 3 : i32, use_multicore = false}>
     // CHECK-SAME: tensor<1x1x64x64xbf16
-    // CHECK-SAME: -> tensor<1x1x64x1xsi32
+    // CHECK-SAME: -> tensor<1x1x64x1xui32
     %1 = "ttir.argmax"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<64x64xf32>, tensor<64xi32>) -> tensor<64xi32>
     return %1 : tensor<64xi32>
   }
@@ -22,7 +22,7 @@ module attributes {} {
     // CHECK: "ttnn.argmax"
     // CHECK-SAME: {dim = 3 : i32, use_multicore = false}>
     // CHECK-SAME: tensor<1x1x28x28xbf16
-    // CHECK-SAME: -> tensor<1x1x28x1xsi32
+    // CHECK-SAME: -> tensor<1x1x28x1xui32
     %1 = "ttir.argmax"(%arg0, %0) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<1x28x28xf32>, tensor<1x28xi32>) -> tensor<1x28xi32>
     return %1 : tensor<1x28xi32>
   }
@@ -33,7 +33,7 @@ module attributes {} {
     // CHECK: "ttnn.argmax"
     // CHECK-SAME: {dim = 3 : i32, use_multicore = false}>
     // CHECK-SAME: tensor<1x1x128x64xbf16
-    // CHECK-SAME: -> tensor<1x1x128x1xsi32
+    // CHECK-SAME: -> tensor<1x1x128x1xui32
     %1 = "ttir.argmax"(%arg0, %0) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<1x1x128x64xf32>, tensor<1x1x128xi32>) -> tensor<1x1x128xi32>
     return %1 : tensor<1x1x128xi32>
   }


### PR DESCRIPTION
### Ticket
closes #1313 
Part of #2125 

### Problem description
Currently we have don't have a consistency checker that verifies runtime intermediates are aligned with compiler generated descriptors. 

### What's changed
This PR adds a debug API (only enabled with `-DTT_RUNTIME_DEBUG=ON`) that compares every runtime tensor with its corresponding flatbuffer descriptor, checking that layouts, memory configs, data types match. 

Couple mismatches were found, needed to update the following to fix the mismatches:

* In `TTNNDecomposeLayouts`, remove all direct calls to createOp, use the dedicated op creation API instead so that the intermediate layouts are correct
* For conv2d, since we currently don't populate the conv2dconfig, the output layout at runtime will be tilized by default. Thus in `TTNNLayouts`, set the default layout of the dps operand of conv2d op to tilized instead of forcing to row major.

Also added some minor updates in the cmake files under runtime
 
### Checklist
- [X] New/Existing tests provide coverage for changes
