### PR TITLE
Uplift third_party/tt-metal to f05457a1eb5b45fddbd60b35835439994e06ae9d 2025-02-28

### DIFF
--- a/lib/OpModel/TTNN/CMakeLists.txt
+++ b/lib/OpModel/TTNN/CMakeLists.txt
@@ -22,7 +22,11 @@ if (TTMLIR_ENABLE_OPMODEL)
 
     # Link to tt-metal libs and include directories
     target_include_directories(${LIB_NAME} PUBLIC "$<BUILD_INTERFACE:${TTMETAL_INCLUDE_DIRS}>")
-    target_link_libraries(${LIB_NAME} PUBLIC TTNN_LIBRARY TTMETAL_LIBRARY DEVICE_LIBRARY)
+    set(TTNN_LIBS TTMETAL_LIBRARY DEVICE_LIBRARY TTNN_LIBRARY)
+    if (TT_RUNTIME_ENABLE_PERF_TRACE)
+        list(APPEND TTNN_LIBS TRACY_LIBRARY)
+    endif()
+    target_link_libraries(${LIB_NAME} PUBLIC ${TTNN_LIBS})
     target_compile_definitions(${LIB_NAME} PUBLIC TTMLIR_ENABLE_OPMODEL)
 else()
     # link stubs implementation when op model library is disabled

--- a/runtime/lib/ttmetal/CMakeLists.txt
+++ b/runtime/lib/ttmetal/CMakeLists.txt
@@ -12,5 +12,3 @@ target_include_directories(TTRuntimeTTMetal PUBLIC
 target_include_directories(TTRuntimeTTMetal SYSTEM PUBLIC "$<BUILD_INTERFACE:${TTMETAL_INCLUDE_DIRS}>")
 target_link_libraries(TTRuntimeTTMetal PUBLIC TTMETAL_LIBRARY DEVICE_LIBRARY)
 add_dependencies(TTRuntimeTTMetal TTMETAL_LIBRARY DEVICE_LIBRARY tt-metal FBS_GENERATION)
-
-# Optionally compile profiling code and link tracy client for perf profiling.

--- a/test/unittests/OpModel/TTNN/Conversion/CMakeLists.txt
+++ b/test/unittests/OpModel/TTNN/Conversion/CMakeLists.txt
@@ -9,7 +9,6 @@ add_executable(TestConversion
 
 target_compile_options(TestConversion
     PRIVATE
-    -fno-rtti
 )
 
 target_include_directories(TestConversion

--- a/test/unittests/OpModel/TTNN/Lib/CMakeLists.txt
+++ b/test/unittests/OpModel/TTNN/Lib/CMakeLists.txt
@@ -8,7 +8,6 @@ TestOpModelLib.cpp
 
 target_compile_options(TestOpModelLib
     PRIVATE
-    -fno-rtti
 )
 
 target_include_directories(TestOpModelLib

--- a/test/unittests/OpModel/TTNN/Op/CMakeLists.txt
+++ b/test/unittests/OpModel/TTNN/Op/CMakeLists.txt
@@ -8,7 +8,6 @@ TestOpModelInterface.cpp
 
 target_compile_options(TestOpModelInterface
     PRIVATE
-    -fno-rtti
 )
 
 target_include_directories(TestOpModelInterface

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "9b3d8557734bba9b5c7e91e178b85e4e019022cf")
+set(TT_METAL_VERSION "07cee7ca1c0ad97526fc99c171dbdce3a50a5d50")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "07cee7ca1c0ad97526fc99c171dbdce3a50a5d50")
+set(TT_METAL_VERSION "f05457a1eb5b45fddbd60b35835439994e06ae9d")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 

--- a/tools/ttnn-standalone/CMakeLists.txt
+++ b/tools/ttnn-standalone/CMakeLists.txt
@@ -65,6 +65,7 @@ set(INCLUDE_DIRS
 
     # Metalium
     $ENV{TT_METAL_HOME}
+    $ENV{TT_METAL_HOME}/tt_metal
     $ENV{TT_METAL_HOME}/tt_metal/api
     $ENV{TT_METAL_HOME}/tt_metal/hostdevcommon/api
     $ENV{TT_METAL_HOME}/tt_metal/hw/inc


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the f05457a1eb5b45fddbd60b35835439994e06ae9d

- Include tt_metal/ header path in ttnn-standalone after metal commit 8b2d814
- Get rid of no-rtti to support dynamic_cast
- Pick this tt-metal commit f05457a1eb5b45 intentionally since commit right after gives error "Kernel file tests/tt_metal/tt_metal/test_kernels/compute/tilize_wh.cpp doesn't exist"
