### PR TITLE
Add View/StreamLayout Operation

### DIFF
--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -373,6 +373,7 @@ def TT_MetalLayoutAttr : TT_Attr<"MetalLayout", "metal_layout"> {
       AffineMap projectOnto(AffineMap linearMap, AffineMap physicalMemoryMap) const;
       AffineMap getIdentityTileLinearMap() const;
       llvm::SmallVector<int64_t> getTiledShape(ArrayRef<int64_t> logicalTensorShape) const;
+      MemRefType getBufferType() const;
   }];
 }
 

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -373,6 +373,10 @@ def TT_MetalLayoutAttr : TT_Attr<"MetalLayout", "metal_layout"> {
       AffineMap projectOnto(AffineMap linearMap, AffineMap physicalMemoryMap) const;
       AffineMap getIdentityTileLinearMap() const;
       llvm::SmallVector<int64_t> getTiledShape(ArrayRef<int64_t> logicalTensorShape) const;
+      // Concatenates the grid shape with the memref shape to form an all in one memref shape,
+      // used as the buffer type for bufferization, e.g.:
+      //   metal_layout<..., <2x3>, memref<4x5xtt.tile<32x32, f32>>>
+      //     -> memref<2x3x4x5xtt.tile<32x32, f32>>
       MemRefType getBufferType() const;
   }];
 }

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.h
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.h
@@ -19,14 +19,6 @@
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
-#include "ttmlir/Dialect/TTIR/IR/TTIROpsEnums.h.inc"
-
-#define GET_ATTRDEF_CLASSES
-#include "ttmlir/Dialect/TTIR/IR/TTIROpsAttrs.h.inc"
-
-#define GET_OP_CLASSES
-#include "ttmlir/Dialect/TTIR/IR/TTIROps.h.inc"
-
 namespace mlir::tt::ttir {
 
 inline void getDpsEffects(
@@ -50,5 +42,13 @@ inline void getDpsEffects(
 }
 
 } // namespace mlir::tt::ttir
+
+#include "ttmlir/Dialect/TTIR/IR/TTIROpsEnums.h.inc"
+
+#define GET_ATTRDEF_CLASSES
+#include "ttmlir/Dialect/TTIR/IR/TTIROpsAttrs.h.inc"
+
+#define GET_OP_CLASSES
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h.inc"
 
 #endif // TTMLIR_DIALECT_TTIR_IR_TTIROPS_H

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.h
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.h
@@ -27,4 +27,28 @@
 #define GET_OP_CLASSES
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h.inc"
 
+namespace mlir::tt::ttir {
+
+inline void getDpsEffects(
+    DestinationStyleOpInterface op,
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  for (OpOperand &operand : op->getOpOperands()) {
+    if (!llvm::isa<MemRefType>(operand.get().getType())) {
+      continue;
+    }
+    if (op.isDpsInput(&operand)) {
+      effects.emplace_back(MemoryEffects::Read::get(), &operand, 0 /*stage*/,
+                           true /*effectOnFullRegion*/,
+                           SideEffects::DefaultResource::get());
+    } else {
+      effects.emplace_back(MemoryEffects::Write::get(), &operand, 0 /*stage*/,
+                           true /*effectOnFullRegion*/,
+                           SideEffects::DefaultResource::get());
+    }
+  }
+}
+
+} // namespace mlir::tt::ttir
+
 #endif // TTMLIR_DIALECT_TTIR_IR_TTIROPS_H

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.h
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.h
@@ -38,12 +38,12 @@ inline void getDpsEffects(
       continue;
     }
     if (op.isDpsInput(&operand)) {
-      effects.emplace_back(MemoryEffects::Read::get(), &operand, 0 /*stage*/,
-                           true /*effectOnFullRegion*/,
+      effects.emplace_back(MemoryEffects::Read::get(), &operand, /*stage*/ 0,
+                           /*effectOnFullRegion*/ true,
                            SideEffects::DefaultResource::get());
     } else {
-      effects.emplace_back(MemoryEffects::Write::get(), &operand, 0 /*stage*/,
-                           true /*effectOnFullRegion*/,
+      effects.emplace_back(MemoryEffects::Write::get(), &operand, /*stage*/ 0,
+                           /*effectOnFullRegion*/ true,
                            SideEffects::DefaultResource::get());
     }
   }

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -41,6 +41,40 @@ class TTIR_BufferizableOp<string mnemonic, list<Trait> traits = []> :
                                                            ]>
       , DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
       ], traits)> {
+
+    let extraClassDefinition = [{
+      bool $cppClass::bufferizesToMemoryRead(
+          mlir::OpOperand &operand, const mlir::bufferization::AnalysisState &) {
+        // If the operand is an input, it is a bufferized to a memory read.
+        return isDpsInput(&operand);
+      }
+
+      bool $cppClass::bufferizesToMemoryWrite(
+          mlir::OpOperand &operand, const mlir::bufferization::AnalysisState &) {
+        // If the operand is an output, it is a bufferized to a memory write.
+        return isDpsInit(&operand);
+      }
+
+      bufferization::AliasingValueList $cppClass::getAliasingValues(
+          OpOperand &operand, const bufferization::AnalysisState &) {
+        bufferization::AliasingValueList result;
+        return result;
+      }
+
+      FailureOr<mlir::BaseMemRefType> $cppClass::getBufferType(
+          Value value, const bufferization::BufferizationOptions &,
+          SmallVector<mlir::Value> &) {
+        auto rankedTensorType = mlir::cast<mlir::RankedTensorType>(value.getType());
+        return mlir::cast<tt::MetalLayoutAttr>(rankedTensorType.getEncoding())
+            .getBufferType();
+      }
+
+      void $cppClass::getEffects(
+          SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+              &effects) {
+        getDpsEffects(*this, effects);
+      }
+    }];
 }
 
 def TTIR_GenericOp : TTIR_BufferizableOp<"generic", [AttrSizedOperandSegments, NoTerminator]> {
@@ -78,7 +112,7 @@ def TTIR_GenericOp : TTIR_BufferizableOp<"generic", [AttrSizedOperandSegments, N
                          TT_IteratorTypeArrayAttr:$iterator_types,
                          DefaultValuedOptionalAttr<DenseI64ArrayAttr, "{}">:$operand_cb_mapping); // index of input operand and index of cb go together
     let results = (outs Variadic<AnyRankedTensor>:$results);
-    let regions = (region AnyRegion:$region);
+    let regions = (region VariadicRegion<AnyRegion>:$regions);
     let hasVerifier = 1;
 
     let extraClassDeclaration = [{
@@ -135,6 +169,76 @@ def TTIR_ToLayoutOp : TTIR_BufferizableOp<"to_layout"> {
     let hasVerifier = 1;
 
     let hasCanonicalizeMethod = 1;
+}
+
+def TTIR_StreamLayoutOp : TTIR_BufferizableOp<"stream_layout",
+  [DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {
+    let summary = "Stream Layout op.";
+    let description = [{
+      StreamLayout operation, similar to the ToLayout operation, but with the difference that this op is not
+      eagerly evaluated and is instead used as a means for defining a stream. The primary usecases include,
+      to enable streaming a large tensor out of dram via a small L1 buffer and also as a means for forming
+      reduce or gather multicast operations. A stream definition includes:
+
+      - The tensor to be streamed.
+      - The storage buffer to be used for streaming.
+      - Backing memory for a list of DMA transactions to be filled in by the backend.
+      - A result, which is also able to take a view over the input, i.e. same semantics as the ViewLayout op.
+
+      Additional constraints:
+      - It is not capable of changing the data type nor the memory space of the tensor.
+
+      ```llvm
+      %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
+      %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<2x4x1x1x!tt.tile<32x32, f32>, #l1_>
+      %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<2x4x1x1x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3)
+      ```
+    }];
+
+    let arguments = (ins AnyRankedTensorOrMemRef:$input,
+                         AnyRankedTensorOrMemRef:$storage,
+                         Optional<AnyNon0RankedMemRef>:$dmaList);
+    let results = (outs AnyRankedTensorOrMemRef:$result);
+
+    let extraClassDeclaration = [{
+      MutableOperandRange getDpsInitsMutable() { return getStorageMutable(); }
+    }];
+
+    let hasVerifier = 1;
+}
+
+def TTIR_ViewLayoutOp : TTIR_Op<"view_layout",
+  [ Pure
+  , TTIROpInterface
+  , DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
+  , DeclareOpInterfaceMethods<BufferizableOpInterface, [ "bufferizesToMemoryRead"
+                                                       , "bufferizesToMemoryWrite"
+                                                       , "bufferize"
+                                                       , "getAliasingValues"
+                                                       , "getBufferType"
+                                                       ]>
+  ]> {
+    let summary = "View Layout op.";
+    let description = [{
+      ViewLayout operation, nearly identical to ToLayout operation, but with the difference that this op is not
+      eagerly evaluated. Its primary usecase is to allow reinterpreting the layout of a tensor without actually
+      moving the data.
+
+      Additional notes/constraints:
+      - It is not capable of changing the data type nor the memory space of the tensor.
+      - All ViewLayout ops can trivially be converted to ToLayout ops.
+
+      ```llvm
+      #layout = #tt.metal_layout<8192x128x1, undef, <1x1>, memref<64x128xf32, #system>>
+      #layout1 = #tt.metal_layout<8192x128x1, undef, <1x1>, memref<64x128xf32, #l1_>>
+      %1 = "ttir.view_layout"(%arg0, %0) : (tensor<64x128xf32, #layout>, tensor<64x128xf32, #layout1>) -> tensor<64x128xf32, #layout1>
+      ```
+    }];
+
+    let arguments = (ins AnyRankedTensorOrMemRef:$input);
+    let results = (outs AnyRankedTensorOrMemRef:$result);
+
+    let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -56,7 +56,7 @@ class TTIR_BufferizableOp<string mnemonic, list<Trait> traits = []> :
       }
 
       bufferization::AliasingValueList $cppClass::getAliasingValues(
-          OpOperand &operand, const bufferization::AnalysisState &) {
+          OpOperand &, const bufferization::AnalysisState &) {
         bufferization::AliasingValueList result;
         return result;
       }
@@ -72,7 +72,7 @@ class TTIR_BufferizableOp<string mnemonic, list<Trait> traits = []> :
       void $cppClass::getEffects(
           SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
               &effects) {
-        getDpsEffects(*this, effects);
+        ttir::getDpsEffects(*this, effects);
       }
     }];
 }

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -175,14 +175,13 @@ def TTIR_StreamLayoutOp : TTIR_BufferizableOp<"stream_layout",
   [DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {
     let summary = "Stream Layout op.";
     let description = [{
-      StreamLayout operation, similar to the ToLayout operation, but with the difference that this op is not
-      eagerly evaluated and is instead used as a means for defining a stream. The primary use cases include,
-      to enable streaming a large tensor out of dram via a small L1 buffer and also as a means for forming
-      reduce or gather multicast operations. A stream definition includes:
+      StreamLayout operation used to form a stream between remote and local memory spaces. Note that this op has
+      no side-effects, it's purely representational. The primary use cases include, to enable streaming a large
+      tensor out of dram via a small L1 buffer and also as a means for forming reduce or gather multicast
+      operations. A stream definition includes:
 
       - The tensor to be streamed.
       - The storage buffer to be used for streaming.
-      - Backing memory for a list of DMA transactions to be filled in by the backend.
       - A result, which is also able to take a view over the input, i.e. same semantics as the ViewLayout op.
 
       Additional constraints:
@@ -219,9 +218,9 @@ def TTIR_ViewLayoutOp : TTIR_Op<"view_layout",
   ]> {
     let summary = "View Layout op.";
     let description = [{
-      ViewLayout operation, nearly identical to ToLayout operation, but with the difference that this op is not
-      eagerly evaluated. Its primary usecase is to allow reinterpreting the layout of a tensor without actually
-      moving the data.
+      ViewLayout operation, used to take a view of one layout into another.  Note that this op is purely representational
+      and doesn't have any side-effects. Its primary usecase is to allow reinterpreting the layout of a tensor without actually
+      moving the data. Consumers of this op are expected to compose the layout with the underlying backing layout.
 
       Additional notes/constraints:
       - It is not capable of changing the data type nor the memory space of the tensor.

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -176,7 +176,7 @@ def TTIR_StreamLayoutOp : TTIR_BufferizableOp<"stream_layout",
     let summary = "Stream Layout op.";
     let description = [{
       StreamLayout operation, similar to the ToLayout operation, but with the difference that this op is not
-      eagerly evaluated and is instead used as a means for defining a stream. The primary usecases include,
+      eagerly evaluated and is instead used as a means for defining a stream. The primary use cases include,
       to enable streaming a large tensor out of dram via a small L1 buffer and also as a means for forming
       reduce or gather multicast operations. A stream definition includes:
 
@@ -189,15 +189,14 @@ def TTIR_StreamLayoutOp : TTIR_BufferizableOp<"stream_layout",
       - It is not capable of changing the data type nor the memory space of the tensor.
 
       ```llvm
-      %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
-      %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<2x4x1x1x!tt.tile<32x32, f32>, #l1_>
-      %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<2x4x1x1x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3)
+      %input = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
+      %storage = memref.alloc() {alignment = 64 : i64} : memref<2x4x1x1x!tt.tile<32x32, f32>, #l1_>
+      %stream = "ttir.stream_layout"(%input, %storage) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<2x4x1x1x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3), stream>, #l1_>
       ```
     }];
 
     let arguments = (ins AnyRankedTensorOrMemRef:$input,
-                         AnyRankedTensorOrMemRef:$storage,
-                         Optional<AnyNon0RankedMemRef>:$dmaList);
+                         AnyRankedTensorOrMemRef:$storage);
     let results = (outs AnyRankedTensorOrMemRef:$result);
 
     let extraClassDeclaration = [{

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
@@ -1481,7 +1481,7 @@ public:
   }
 
   static bool needScaler(ttir::GenericOp op) {
-    Block &block = op.getRegion().front();
+    Block &block = op.getRegion(0).front();
     Operation &firstOp = block.getOperations().front();
     if (!mlir::isa<ttir::KernelOp>(firstOp)) {
       return false;
@@ -1498,7 +1498,7 @@ public:
   static Type addReduceScaler(ttir::GenericOp op, Block *dmBlock,
                               ArrayRef<Type> rewrittenBlockArgumentTypes,
                               PatternRewriter &rewriter) {
-    Block &block = op.getRegion().front();
+    Block &block = op.getRegion(0).front();
     Operation &firstOp = block.getOperations().front();
     if (!mlir::isa<ttir::KernelOp>(firstOp)) {
       return nullptr;

--- a/lib/Dialect/TT/IR/TTOpsTypes.cpp
+++ b/lib/Dialect/TT/IR/TTOpsTypes.cpp
@@ -819,6 +819,16 @@ MetalLayoutAttr::projectOnto(mlir::AffineMap linearMap,
       .compose(linearMap);
 }
 
+mlir::MemRefType MetalLayoutAttr::getBufferType() const {
+  SmallVector<int64_t> fullMemrefShape;
+  auto gridShape = getGrid().getShape();
+  auto shardShape = getShardShape(true /*convertTileToScalar*/);
+  fullMemrefShape.append(gridShape.begin(), gridShape.end());
+  fullMemrefShape.append(shardShape.begin(), shardShape.end());
+  return buildMemRef<MemorySpace, MemorySpaceAttr>(
+      getContext(), fullMemrefShape, getElementType(), getMemorySpace());
+}
+
 //
 // This function creates an affine map that represents mapping the tensor's
 // linear layout onto the 2d physical device grid. A typical example will look

--- a/lib/Dialect/TT/IR/TTOpsTypes.cpp
+++ b/lib/Dialect/TT/IR/TTOpsTypes.cpp
@@ -822,7 +822,7 @@ MetalLayoutAttr::projectOnto(mlir::AffineMap linearMap,
 mlir::MemRefType MetalLayoutAttr::getBufferType() const {
   SmallVector<int64_t> fullMemrefShape;
   auto gridShape = getGrid().getShape();
-  auto shardShape = getShardShape(true /*convertTileToScalar*/);
+  auto shardShape = getShardShape(/*convertTileToScalar*/ true);
   fullMemrefShape.append(gridShape.begin(), gridShape.end());
   fullMemrefShape.append(shardShape.begin(), shardShape.end());
   return buildMemRef<MemorySpace, MemorySpaceAttr>(

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -2766,10 +2766,10 @@ void mlir::tt::ttir::PermuteOp::getCanonicalizationPatterns(
   for (auto output : getOutputs()) {
     Type operandType = output.getType();
     ArrayRef<int64_t> outputGridShape;
-    if (mlir::isa<RankedTensorType>(operandType)) {
-      RankedTensorType tensorType = mlir::cast<RankedTensorType>(operandType);
+    if (RankedTensorType tensorType =
+            mlir::dyn_cast<RankedTensorType>(operandType)) {
       if (!tensorType.getEncoding()) {
-        // Skip layout checks if the tensor type does not have a layout yet
+        // Skip layout checks if the tensor type does not have a layout yet.
         continue;
       }
       MetalLayoutAttr layout =
@@ -2803,16 +2803,16 @@ void mlir::tt::ttir::PermuteOp::getCanonicalizationPatterns(
     auto memrefArguments =
         region.getArguments().take_front(operandTypes.size());
     for (BlockArgument arg : memrefArguments) {
-      if (!mlir::isa<MemRefType>(arg.getType())) {
+      auto blockMemref = mlir::dyn_cast<MemRefType>(arg.getType());
+      if (!blockMemref) {
         return emitOpError("GenericOp region arguments must be of MemRefType");
       }
-      auto blockMemref = mlir::cast<MemRefType>(arg.getType());
 
       Type operandType = operandTypes[arg.getArgNumber()];
       Attribute expectedMemorySpace;
       ArrayRef<int64_t> expectedShardShape;
-      if (mlir::isa<RankedTensorType>(operandType)) {
-        RankedTensorType tensorType = mlir::cast<RankedTensorType>(operandType);
+      if (RankedTensorType tensorType =
+              mlir::dyn_cast<RankedTensorType>(operandType)) {
         if (!tensorType.getEncoding()) {
           // Skip layout checks if the tensor type does not have a layout yet
           continue;

--- a/lib/Dialect/TTIR/Transforms/GenericLinearizeMemref.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericLinearizeMemref.cpp
@@ -59,7 +59,9 @@ public:
 
   LogicalResult matchAndRewrite(GenericOp op,
                                 PatternRewriter &rewriter) const final {
-    Block *entry = &op.getRegion().front();
+    assert(op.getNumRegions() == 1 &&
+           "expected single compute region at this stage");
+    Block *entry = &op.getRegion(0).front();
     rewriter.setInsertionPointToStart(entry);
     auto args = entry->getArguments();
     if (llvm::all_of(args, isLinearizedMemref)) {

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -34,7 +34,7 @@ void createTTIRBufferizationPipeline(OpPassManager &pm) {
             tensorType, memorySpace);
       }
       return mlir::cast<tt::MetalLayoutAttr>(rankedTensorType.getEncoding())
-          .getMemref();
+          .getBufferType();
     };
     bufferizationOptions.defaultMemorySpaceFn =
         [](mlir::TensorType tensorType) -> std::optional<mlir::Attribute> {

--- a/test/ttmlir/Dialect/TTIR/bufferization/bufferization.mlir
+++ b/test/ttmlir/Dialect/TTIR/bufferization/bufferization.mlir
@@ -7,21 +7,35 @@
 #parallel = #tt.iterator_type<parallel>
 #reduction = #tt.iterator_type<reduction>
 
-func.func @matmul(%arg0: tensor<2x4x!tt.tile<32x32, f32>>, %arg1: tensor<4x2x!tt.tile<32x32, f32>>) -> tensor<2x2x!tt.tile<32x32, f32>> {
-  // CHECK: = memref.alloc() {{.*}} : memref<2x2x!tt.tile<32x32, f32>, #l1_>
-  %0 = tensor.empty() : tensor<2x2x!tt.tile<32x32, f32>>
+func.func @matmul(%arg0: tensor<1x1x2x4x!tt.tile<32x32, f32>>, %arg1: tensor<1x1x4x2x!tt.tile<32x32, f32>>) -> tensor<1x1x2x2x!tt.tile<32x32, f32>> {
+  // CHECK: = memref.alloc() {{.*}} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  %0 = tensor.empty() : tensor<1x1x2x2x!tt.tile<32x32, f32>>
   // CHECK: {{^  "ttir.generic".*}}
   %3 = "ttir.generic"(%arg0, %arg1, %0) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map1, #map2], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 0, 1>, operand_cb_mapping = array<i64>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg3: memref<4x2x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
     "ttir.tile_matmul_block"(%arg2, %arg3, %arg4) : (memref<2x4x!tt.tile<32x32, f32>, #l1_>, memref<4x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
-  }) : (tensor<2x4x!tt.tile<32x32, f32>>, tensor<4x2x!tt.tile<32x32, f32>>, tensor<2x2x!tt.tile<32x32, f32>>) -> tensor<2x2x!tt.tile<32x32, f32>>
-  return %3 : tensor<2x2x!tt.tile<32x32, f32>>
+  }) : (tensor<1x1x2x4x!tt.tile<32x32, f32>>, tensor<1x1x4x2x!tt.tile<32x32, f32>>, tensor<1x1x2x2x!tt.tile<32x32, f32>>) -> tensor<1x1x2x2x!tt.tile<32x32, f32>>
+  return %3 : tensor<1x1x2x2x!tt.tile<32x32, f32>>
 }
 
-func.func @to_layout(%arg0: tensor<2x4x!tt.tile<32x32, f32>>) -> tensor<2x4x!tt.tile<32x32, f32>> {
-  // CHECK: = memref.alloc() {{.*}} : memref<2x4x!tt.tile<32x32, f32>, #l1_>
-  %0 = tensor.empty() : tensor<2x4x!tt.tile<32x32, f32>>
+func.func @to_layout(%arg0: tensor<1x1x2x4x!tt.tile<32x32, f32>>) -> tensor<1x1x2x4x!tt.tile<32x32, f32>> {
+  // CHECK: = memref.alloc() {{.*}} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+  %0 = tensor.empty() : tensor<1x1x2x4x!tt.tile<32x32, f32>>
   // CHECK: {{^  "ttir.to_layout".*}}
-  %3 = "ttir.to_layout"(%arg0, %0) : (tensor<2x4x!tt.tile<32x32, f32>>, tensor<2x4x!tt.tile<32x32, f32>>) -> tensor<2x4x!tt.tile<32x32, f32>>
-  return %3 : tensor<2x4x!tt.tile<32x32, f32>>
+  %3 = "ttir.to_layout"(%arg0, %0) : (tensor<1x1x2x4x!tt.tile<32x32, f32>>, tensor<1x1x2x4x!tt.tile<32x32, f32>>) -> tensor<1x1x2x4x!tt.tile<32x32, f32>>
+  return %3 : tensor<1x1x2x4x!tt.tile<32x32, f32>>
+}
+
+func.func @stream_layout(%arg0: tensor<1x1x2x4x!tt.tile<32x32, f32>>) -> tensor<1x1x2x4x!tt.tile<32x32, f32>> {
+  // CHECK: = memref.alloc() {{.*}} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+  %0 = tensor.empty() : tensor<1x1x2x4x!tt.tile<32x32, f32>>
+  // CHECK: = "ttir.stream_layout"
+  %3 = "ttir.stream_layout"(%arg0, %0) : (tensor<1x1x2x4x!tt.tile<32x32, f32>>, tensor<1x1x2x4x!tt.tile<32x32, f32>>) -> tensor<1x1x2x4x!tt.tile<32x32, f32>>
+  return %3 : tensor<1x1x2x4x!tt.tile<32x32, f32>>
+}
+
+func.func @view_layout(%arg0: tensor<1x1x2x4x!tt.tile<32x32, f32>>) -> tensor<1x1x2x4x!tt.tile<32x32, f32>> {
+  // CHECK: = "ttir.view_layout"
+  %3 = "ttir.view_layout"(%arg0) : (tensor<1x1x2x4x!tt.tile<32x32, f32>>) -> tensor<1x1x2x4x!tt.tile<32x32, f32>>
+  return %3 : tensor<1x1x2x4x!tt.tile<32x32, f32>>
 }

--- a/test/ttmlir/Dialect/TTIR/bufferization/memory_effects.mlir
+++ b/test/ttmlir/Dialect/TTIR/bufferization/memory_effects.mlir
@@ -26,21 +26,21 @@ func.func @to_layout_pure_tensors(%arg0: tensor<2x4x!tt.tile<32x32, f32>>) -> te
   return %0 : tensor<2x4x!tt.tile<32x32, f32>>
 }
 
-func.func @matmul_memref(%arg0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<4x2x!tt.tile<32x32, f32>, #l1_>) -> memref<2x2x!tt.tile<32x32, f32>, #l1_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x2x!tt.tile<32x32, f32>, #l1_>
+func.func @matmul_memref(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x4x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
   // Ensure that the generic op is not removed.
   // CHECK: "ttir.generic"
   "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map1, #map2], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 0, 1>, operand_cb_mapping = array<i64>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg3: memref<4x2x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
     "ttir.tile_matmul_block"(%arg2, %arg3, %arg4) : (memref<2x4x!tt.tile<32x32, f32>, #l1_>, memref<4x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
-  }) : (memref<2x4x!tt.tile<32x32, f32>, #l1_>, memref<4x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
-  return %alloc : memref<2x2x!tt.tile<32x32, f32>, #l1_>
+  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x4x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
 }
 
-func.func @to_layout_memref(%arg0: memref<2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x!tt.tile<32x32, f32>, #l1_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x!tt.tile<32x32, f32>, #l1_>
+func.func @to_layout_memref(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
   // Ensure that the layout op is not removed.
   // CHECK: "ttir.to_layout"
-  "ttir.to_layout"(%arg0, %alloc) : (memref<2x4x!tt.tile<32x32, f32>, #l1_>, memref<2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
-  return %alloc : memref<2x4x!tt.tile<32x32, f32>, #l1_>
+  "ttir.to_layout"(%arg0, %alloc) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
 }

--- a/test/ttmlir/Dialect/TTIR/generic/generic_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/generic_negative.mlir
@@ -1,0 +1,81 @@
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+// Negative tests for generic operation.
+
+#l1_ = #tt.memory_space<l1>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #tt.iterator_type<parallel>
+
+// CHECK: error: 'ttir.generic' op Output grid shape must match the GenericOp grid shape
+
+func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<2x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 0, 1>, operand_cb_mapping = array<i64>}> ({
+  ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
+  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+}
+
+// -----
+
+#l1_ = #tt.memory_space<l1>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #tt.iterator_type<parallel>
+
+// CHECK: error: 'ttir.generic' op GenericOp region must have at least as many arguments as the number of top-level operands
+
+func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 0, 1>, operand_cb_mapping = array<i64>}> ({
+  ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
+  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+}
+
+// -----
+
+#l1_ = #tt.memory_space<l1>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #tt.iterator_type<parallel>
+
+// CHECK: error: 'ttir.generic' op GenericOp region arguments must be of MemRefType
+
+func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 0, 1>, operand_cb_mapping = array<i64>}> ({
+  ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: tensor<2x4x!tt.tile<32x32, f32>, #l1_>):
+  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+}
+
+// -----
+
+#l1_ = #tt.memory_space<l1>
+#dram_ = #tt.memory_space<dram>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #tt.iterator_type<parallel>
+
+// CHECK: error: 'ttir.generic' op GenericOp region argument memory space must match the memory space of the corresponding operand
+
+func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #dram_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #dram_>
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 0, 1>, operand_cb_mapping = array<i64>}> ({
+  ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
+  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #dram_>) -> ()
+  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #dram_>
+}
+
+// -----
+
+#l1_ = #tt.memory_space<l1>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #tt.iterator_type<parallel>
+
+// CHECK: error: 'ttir.generic' op GenericOp region argument shape must match the shape of the corresponding operand
+
+func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 0, 1>, operand_cb_mapping = array<i64>}> ({
+  ^bb0(%arg2: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
+  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+}

--- a/test/ttmlir/Dialect/TTIR/ttir_generic_hoist.mlir
+++ b/test/ttmlir/Dialect/TTIR/ttir_generic_hoist.mlir
@@ -9,14 +9,14 @@ func.func @forward(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tens
     iterator_types = [#parallel, #parallel],
     operandSegmentSizes = array<i32: 2, 0, 1>,
     operand_cb_mapping = array<i64>}> ({
-  ^bb0(%arg2: memref<64x128xf32>, %arg3: tensor<64x128xf32>, %arg4: tensor<64x128xf32>):
+  ^bb0(%arg2: memref<64x128xf32>, %arg3: memref<64x128xf32>, %arg4: memref<64x128xf32>):
     // lit CHECK to make sure this constant stays inside the generic region
     // CHECK: ttir.generic
     // CHECK: arith.constant 0 : index
     %i = arith.constant 0 : index
     %2 = arith.constant 0.000000e+00 : f32
     memref.store %2, %arg2[%i, %i] : memref<64x128xf32>
-    "ttir.yield"(%arg3) : (tensor<64x128xf32>) -> ()
+    "ttir.yield"(%arg3) : (memref<64x128xf32>) -> ()
   }) : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
   return %1 : tensor<64x128xf32>
 }


### PR DESCRIPTION
This change adds 2 new TTIR layout related ops and makes a few refactors to better share common interface and verifier code between them.  The verifiers are also significantly improved and check for many more illegal cases.

## StreamLayout Operation

StreamLayout operation, similar to the ToLayout operation, but with the difference that this op is not eagerly evaluated and is instead used as a means for defining a stream. The primary usecases include, to enable streaming a large tensor out of dram via a small L1 buffer and also as a means for forming reduce or gather multicast operations. A stream definition includes:

- The tensor to be streamed.
- The storage buffer to be used for streaming.
- Backing memory for a list of DMA transactions to be filled in by the backend.
- A result, which is also able to take a view over the input, i.e. same semantics as the ViewLayout op.

Additional constraints:
- It is not capable of changing the data type nor the memory space of the tensor.

```llvm
%alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
%alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<2x4x1x1x!tt.tile<32x32, f32>, #l1_>
%stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<2x4x1x1x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3)
```

## ViewLayout Operation

ViewLayout operation, nearly identical to ToLayout operation, but with the difference that this op is not eagerly evaluated. Its primary usecase is to allow reinterpreting the layout of a tensor without actually moving the data.

Additional notes/constraints:
- It is not capable of changing the data type nor the memory space of the tensor.
- All ViewLayout ops can trivially be converted to ToLayout ops.

```llvm
#layout = #tt.metal_layout<8192x128x1, undef, <1x1>, memref<64x128xf32, #system>>
#layout1 = #tt.metal_layout<8192x128x1, undef, <1x1>, memref<64x128xf32, #l1_>>
%1 = "ttir.view_layout"(%arg0, %0) : (tensor<64x128xf32, #layout>, tensor<64x128xf32, #layout1>) -> tensor<64x128xf32, #layout1>
```

Closes #587