### PR TITLE
TTNN->EmitC transition existing ops to new converter

### DIFF
--- a/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
+++ b/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
@@ -699,12 +699,13 @@ public:
   template <typename OpConversionPatternTy>
   emitc::CallOpaqueOp replaceOp(OpConversionPatternTy &&opConversionPattern,
                                 llvm::ArrayRef<mlir::Attribute> args) {
+    auto resultTypes = llvm::to_vector(
+        llvm::map_range(op->getResultTypes(), [&](Type type) -> Type {
+          return opConversionPattern.getTypeConverter()->convertType(type);
+        }));
     return rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
-        op,
-        opConversionPattern.getTypeConverter()->convertType(
-            op->getResult(0).getType()),
-        opConversionPattern.convertOpName(op), rewriter.getArrayAttr(args),
-        nullptr, adaptor.getOperands());
+        op, resultTypes, opConversionPattern.convertOpName(op),
+        rewriter.getArrayAttr(args), nullptr, adaptor.getOperands());
   }
 
 private:

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -359,8 +359,6 @@ public:
     ttnn_to_emitc::EmitCTTNNEmitter<tt::ttnn::EmbeddingOp> emitter(
         embeddingOp, adaptor, rewriter);
 
-    // TODO (azecevic): Potentially problematic. Has to model `EmbeddingsType`
-    // to be able to emit memory config.
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(embeddingOp.getInput()),
         emitter.emit(embeddingOp.getWeight()),
@@ -402,7 +400,6 @@ public:
   }
 };
 
-// TODO (azecevic): This is a reduction ops class pattern.
 // MeanOp conversion pattern
 //
 class MeanOpConversionPattern
@@ -478,9 +475,9 @@ public:
                                                                  rewriter);
 
     llvm::SmallVector<mlir::Attribute> args{
-      emitter.emit(srcOp.getInput()),
-      emitter.emit<std::vector<int32_t>>(srcOp.getShape()),
-      emitter.emit(srcOp.getMemoryConfig()),
+        emitter.emit(srcOp.getInput()),
+        emitter.emit<std::vector<int32_t>>(srcOp.getShape()),
+        emitter.emit(srcOp.getMemoryConfig()),
     };
 
     emitter.replaceOp(*this, args);
@@ -565,7 +562,7 @@ public:
         emitter.emit(srcOp.getInput()),
         emitter.emit(srcOp.getRepeatDims()),
     };
-    srcOp->getNumOperands();
+
     emitter.replaceOp(*this, args);
 
     return success();
@@ -796,12 +793,6 @@ public:
     ttnn_to_emitc::EmitCTTNNEmitter<tt::ttnn::ToLayoutOp> emitter(
         srcOp, adaptor, rewriter);
 
-    // TODO (azecevic): This is unbelievably bad design. There are two overloads
-    // with a tons of default valued paramaters, but they are all useless
-    // because every call will be ambiguous due to the fact that every parameter
-    // except the last one is the same (and the last one is pointer type, so
-    // even `nullptr` is not enough to disambiguate). This is a design flaw in
-    // the TTNN that needs to be fixed.
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()), emitter.emit(srcOp.getLayout()),
         emitter.emit(srcOp.getDtype()), emitter.emit(srcOp.getMemoryConfig()),
@@ -890,7 +881,6 @@ public:
     ttnn_to_emitc::EmitCTTNNEmitter<tt::ttnn::OnesOp> emitter(srcOp, adaptor,
                                                               rewriter);
 
-    // TODO (azecevic): Same as the `ZerosOp` conversion pattern.
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getShape()),        emitter.emit(srcOp.getDtype()),
         emitter.emit(srcOp.getLayout()),       emitter.emit(srcOp.getDevice()),

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -133,15 +133,16 @@ public:
   LogicalResult
   matchAndRewrite(SourceOp srcOp, Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    // emitc::CallOpaqueOp needs to know positions of operands vs attributes, so
-    // an ArrayAttr object holding IndexTypes is created to denote this.
-    //
+
     ttnn_to_emitc::EmitCTTNNEmitter<SourceOp> emitter(srcOp, adaptor, rewriter);
+
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInputs()[0]),
         emitter.emit(std::nullopt),
     };
+
     emitter.replaceOp(*this, args);
+
     return success();
   }
 };
@@ -164,18 +165,16 @@ public:
   LogicalResult
   matchAndRewrite(SourceOp srcOp, Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    // emitc::CallOpaqueOp needs to know positions of operands vs attributes, so
-    // an ArrayAttr object holding IndexTypes is created to denote this.
-    //
-    ArrayAttr arrayAttrs = rewriter.getArrayAttr(
-        {mlir::IntegerAttr::get(rewriter.getIndexType(), 0),
-         tt::ttnn_to_emitc::utils::convertBoolAttr(
-             rewriter, BoolAttr::get(rewriter.getContext(), false)),
-         ttnn_to_emitc::utils::createStdNullopt(rewriter)});
 
-    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
-        srcOp, this->getTypeConverter()->convertType(srcOp.getType(0)),
-        this->convertOpName(srcOp), arrayAttrs, nullptr, adaptor.getOperands());
+    ttnn_to_emitc::EmitCTTNNEmitter<SourceOp> emitter(srcOp, adaptor, rewriter);
+
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getInputs()[0]),
+        /*paramter=*/emitter.emit(false),
+        /*memory_config=*/emitter.emit(std::nullopt),
+    };
+
+    emitter.replaceOp(*this, args);
 
     return success();
   }
@@ -198,16 +197,15 @@ public:
   LogicalResult
   matchAndRewrite(SourceOp srcOp, Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    // emitc::CallOpaqueOp needs to know positions of operands vs attributes, so
-    // an ArrayAttr object holding IndexTypes is created to denote this.
-    //
-    ArrayAttr arrayAttrs = rewriter.getArrayAttr(
-        {mlir::IntegerAttr::get(rewriter.getIndexType(), 0),
-         tt::ttnn_to_emitc::utils::createStdNullopt(rewriter)});
 
-    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
-        srcOp, this->getTypeConverter()->convertType(srcOp.getType(0)),
-        this->convertOpName(srcOp), arrayAttrs, nullptr, adaptor.getOperands());
+    ttnn_to_emitc::EmitCTTNNEmitter<SourceOp> emitter(srcOp, adaptor, rewriter);
+
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getInputs()[0]),
+        /*memory_config=*/emitter.emit(std::nullopt),
+    };
+
+    emitter.replaceOp(*this, args);
 
     return success();
   }
@@ -232,20 +230,16 @@ public:
   matchAndRewrite(SourceOp srcOp, Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    // emitc::CallOpaqueOp needs to know positions of operands vs attributes, so
-    // an ArrayAttr object holding IndexTypes is created to denote this
-    //
-    llvm::SmallVector<Attribute, 5> attrs;
-    attrs.push_back(mlir::IntegerAttr::get(rewriter.getIndexType(), 0));
-    attrs.push_back(mlir::IntegerAttr::get(rewriter.getIndexType(), 1));
-    attrs.push_back(ttnn_to_emitc::utils::createStdNullopt(rewriter));
-    attrs.push_back(ttnn_to_emitc::utils::createStdNullopt(rewriter));
+    ttnn_to_emitc::EmitCTTNNEmitter<SourceOp> emitter(srcOp, adaptor, rewriter);
 
-    ArrayAttr arrayAttrs = ArrayAttr::get(srcOp->getContext(), attrs);
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getInputs()[0]),
+        emitter.emit(srcOp.getInputs()[1]),
+        /*dtype=*/emitter.emit(std::nullopt),
+        /*memory_config=*/emitter.emit(std::nullopt),
+    };
 
-    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
-        srcOp, this->getTypeConverter()->convertType(srcOp.getType(0)),
-        this->convertOpName(srcOp), arrayAttrs, nullptr, adaptor.getOperands());
+    emitter.replaceOp(*this, args);
 
     return success();
   }
@@ -262,34 +256,22 @@ public:
       tt::ttnn::LinearOp>::TTNNToEmitCBaseOpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(tt::ttnn::LinearOp linearOp,
-                  tt::ttnn::LinearOp::Adaptor adaptor,
+  matchAndRewrite(tt::ttnn::LinearOp srcOp, tt::ttnn::LinearOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    // emitc::CallOpaqueOp needs to know positions of operands vs attributes, so
-    // an ArrayAttr object holding IndexTypes is created to denote this.
-    //
-    ArrayAttr arrayAttrs = rewriter.getArrayAttr(
-        {rewriter.getIndexAttr(0), rewriter.getIndexAttr(1),
-         rewriter.getIndexAttr(2),
-         tt::ttnn_to_emitc::utils::convertBoolAttr(
-             rewriter, linearOp.getTransposeAAttr()),
-         tt::ttnn_to_emitc::utils::convertBoolAttr(
-             rewriter, linearOp.getTransposeBAttr()),
-         /*memory_config=*/tt::ttnn_to_emitc::utils::createStdNullopt(rewriter),
-         /*dtype=*/tt::ttnn_to_emitc::utils::createStdNullopt(rewriter),
-         /*program_config=*/
-         tt::ttnn_to_emitc::utils::createStdNullopt(rewriter),
-         /*activation=*/tt::ttnn_to_emitc::utils::createStdNullopt(rewriter),
-         /*compute_kernel_config=*/
-         ttnn_to_emitc::utils::createStdNullopt(rewriter),
-         /*core_grid=*/ttnn_to_emitc::utils::createStdNullopt(rewriter),
-         /*output_tile=*/ttnn_to_emitc::utils::createStdNullopt(rewriter)});
+    ttnn_to_emitc::EmitCTTNNEmitter<tt::ttnn::LinearOp> emitter(srcOp, adaptor,
+                                                                rewriter);
 
-    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
-        linearOp, this->getTypeConverter()->convertType(linearOp.getType()),
-        this->convertOpName(linearOp), arrayAttrs, nullptr,
-        adaptor.getOperands());
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getA()),
+        emitter.emit(srcOp.getB()),
+        emitter.emit(srcOp.getBias()),
+        emitter.emit(srcOp.getTransposeA()),
+        emitter.emit(srcOp.getTransposeB()),
+        /*memory_config=*/emitter.emit(std::nullopt),
+    };
+
+    emitter.replaceOp(*this, args);
 
     return success();
   }
@@ -307,35 +289,23 @@ public:
       tt::ttnn::MatmulOp>::TTNNToEmitCBaseOpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(tt::ttnn::MatmulOp matmulOp,
-                  tt::ttnn::MatmulOp::Adaptor adaptor,
+  matchAndRewrite(tt::ttnn::MatmulOp srcOp, tt::ttnn::MatmulOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    // ANCHOR: adding_an_op_matmul_ttnn_to_emitc_array_attrs
-    // emitc::CallOpaqueOp needs to know positions of operands vs attributes, so
-    // an ArrayAttr object holding IndexTypes is created to denote this.
-    //
-    ArrayAttr arrayAttrs = rewriter.getArrayAttr(
-        {rewriter.getIndexAttr(0), rewriter.getIndexAttr(1),
-         tt::ttnn_to_emitc::utils::convertBoolAttr(
-             rewriter, matmulOp.getTransposeAAttr()),
-         tt::ttnn_to_emitc::utils::convertBoolAttr(
-             rewriter, matmulOp.getTransposeBAttr()),
-         /*memory_config=*/tt::ttnn_to_emitc::utils::createStdNullopt(rewriter),
-         /*dtype=*/tt::ttnn_to_emitc::utils::createStdNullopt(rewriter),
-         /*program_config=*/
-         tt::ttnn_to_emitc::utils::createStdNullopt(rewriter),
-         /*activation=*/tt::ttnn_to_emitc::utils::createStdNullopt(rewriter),
-         /*compute_kernel_config=*/
-         ttnn_to_emitc::utils::createStdNullopt(rewriter),
-         /*core_grid=*/ttnn_to_emitc::utils::createStdNullopt(rewriter),
-         /*output_tile=*/ttnn_to_emitc::utils::createStdNullopt(rewriter)});
-    // ANCHOR_END: adding_an_op_matmul_ttnn_to_emitc_array_attrs
+    ttnn_to_emitc::EmitCTTNNEmitter<tt::ttnn::MatmulOp> emitter(srcOp, adaptor,
+                                                                rewriter);
 
-    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
-        matmulOp, this->getTypeConverter()->convertType(matmulOp.getType()),
-        this->convertOpName(matmulOp), arrayAttrs, nullptr,
-        adaptor.getOperands());
+    // ANCHOR: adding_an_op_matmul_tt::ttnn_to_emitc_array_attrs
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getA()),
+        emitter.emit(srcOp.getB()),
+        emitter.emit(srcOp.getTransposeA()),
+        emitter.emit(srcOp.getTransposeB()),
+        /*memory_config=*/emitter.emit(std::nullopt),
+    };
+    // ANCHOR_END: adding_an_op_matmul_tt::ttnn_to_emitc_array_attrs
+
+    emitter.replaceOp(*this, args);
 
     return success();
   }
@@ -353,22 +323,20 @@ public:
       tt::ttnn::SoftmaxOp>::TTNNToEmitCBaseOpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(tt::ttnn::SoftmaxOp softmaxOp,
+  matchAndRewrite(tt::ttnn::SoftmaxOp srcOp,
                   tt::ttnn::SoftmaxOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    // emitc::CallOpaqueOp needs to know positions of operands vs attributes, so
-    // an ArrayAttr object holding IndexTypes is created to denote this.
-    //
-    ArrayAttr arrayAttrs = rewriter.getArrayAttr({
-        mlir::IntegerAttr::get(rewriter.getIndexType(), 0),
-        softmaxOp.getDimensionAttr(),
-    });
+    ttnn_to_emitc::EmitCTTNNEmitter<tt::ttnn::SoftmaxOp> emitter(srcOp, adaptor,
+                                                                 rewriter);
 
-    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
-        softmaxOp, this->getTypeConverter()->convertType(softmaxOp.getType()),
-        this->convertOpName(softmaxOp), arrayAttrs, nullptr,
-        adaptor.getOperands());
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getInput()),
+        emitter.emit(srcOp.getDimension()),
+        /*memory_config=*/emitter.emit(std::nullopt),
+    };
+
+    emitter.replaceOp(*this, args);
 
     return success();
   }
@@ -388,19 +356,17 @@ public:
                   tt::ttnn::EmbeddingOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    // emitc::CallOpaqueOp needs to know positions of operands vs attributes, so
-    // an ArrayAttr object holding IndexTypes is created to denote this.
-    //
-    ArrayAttr arrayAttrs = rewriter.getArrayAttr({
-        mlir::IntegerAttr::get(rewriter.getIndexType(), 0),
-        mlir::IntegerAttr::get(rewriter.getIndexType(), 1),
-    });
+    ttnn_to_emitc::EmitCTTNNEmitter<tt::ttnn::EmbeddingOp> emitter(
+        embeddingOp, adaptor, rewriter);
 
-    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
-        embeddingOp,
-        this->getTypeConverter()->convertType(embeddingOp.getType()),
-        this->convertOpName(embeddingOp), arrayAttrs, nullptr,
-        adaptor.getOperands());
+    // TODO (azecevic): Potentially problematic. Has to model `EmbeddingsType`
+    // to be able to emit memory config.
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(embeddingOp.getInput()),
+        emitter.emit(embeddingOp.getWeight()),
+    };
+
+    emitter.replaceOp(*this, args);
 
     return success();
   }
@@ -420,25 +386,23 @@ public:
                   tt::ttnn::MorehCumSumOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    // emitc::CallOpaqueOp needs to know positions of operands vs attributes, so
-    // an ArrayAttr object holding IndexTypes is created to denote this.
-    //
-    ArrayAttr arrayAttrs = rewriter.getArrayAttr({
-        mlir::IntegerAttr::get(rewriter.getIndexType(), 0),
-        srcOp.getDimAttr(),
-        tt::ttnn_to_emitc::utils::createStdNullopt(rewriter),
-        tt::ttnn_to_emitc::utils::createStdNullopt(rewriter),
-        tt::ttnn_to_emitc::utils::createStdNullopt(rewriter),
-    });
+    ttnn_to_emitc::EmitCTTNNEmitter<tt::ttnn::MorehCumSumOp> emitter(
+        srcOp, adaptor, rewriter);
 
-    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
-        srcOp, this->getTypeConverter()->convertType(srcOp.getType()),
-        this->convertOpName(srcOp), arrayAttrs, nullptr, adaptor.getOperands());
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getInput()),
+        emitter.emit(srcOp.getDim()),
+        /*output=*/emitter.emit(std::nullopt),
+        emitter.emit(srcOp.getMemoryConfig()),
+        /*compute_kernel_config=*/emitter.emit(std::nullopt),
+    };
 
+    emitter.replaceOp(*this, args);
     return success();
   }
 };
 
+// TODO (azecevic): This is a reduction ops class pattern.
 // MeanOp conversion pattern
 //
 class MeanOpConversionPattern
@@ -459,6 +423,7 @@ public:
         emitter.emit(srcOp.getInput()),
         emitter.emit<::ttnn::SmallVector<int32_t>>(srcOp.getDimArg()),
         emitter.emit(srcOp.getKeepDim()),
+        /*memory_config=*/emitter.emit(std::nullopt),
     };
 
     emitter.replaceOp(*this, args);
@@ -480,20 +445,17 @@ public:
   matchAndRewrite(tt::ttnn::ArgMaxOp srcOp, tt::ttnn::ArgMaxOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    // emitc::CallOpaqueOp needs to know positions of operands vs attributes, so
-    // an ArrayAttr object holding IndexTypes is created to denote this.
-    //
-    ArrayAttr arrayAttrs = rewriter.getArrayAttr({
-        rewriter.getIndexAttr(0),
-        srcOp.getDimAttr(),
-        tt::ttnn_to_emitc::utils::convertBoolAttr(rewriter,
-                                                  srcOp.getUseMulticoreAttr()),
-        tt::ttnn_to_emitc::utils::createStdNullopt(rewriter),
-    });
+    ttnn_to_emitc::EmitCTTNNEmitter<tt::ttnn::ArgMaxOp> emitter(srcOp, adaptor,
+                                                                rewriter);
 
-    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
-        srcOp, this->getTypeConverter()->convertType(srcOp.getType()),
-        this->convertOpName(srcOp), arrayAttrs, nullptr, adaptor.getOperands());
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getInput()),
+        emitter.emit(srcOp.getDim()),
+        emitter.emit(srcOp.getUseMulticore()),
+        emitter.emit(srcOp.getMemoryConfig()),
+    };
+
+    emitter.replaceOp(*this, args);
 
     return success();
   }
@@ -516,9 +478,10 @@ public:
                                                                  rewriter);
 
     llvm::SmallVector<mlir::Attribute> args{
-        emitter.emit(srcOp.getInput()),
-        emitter.emit<std::vector<int32_t>>(srcOp.getShape()),
-        emitter.emit(srcOp.getMemoryConfig())};
+      emitter.emit(srcOp.getInput()),
+      emitter.emit<std::vector<int32_t>>(srcOp.getShape()),
+      emitter.emit(srcOp.getMemoryConfig()),
+    };
 
     emitter.replaceOp(*this, args);
 
@@ -539,15 +502,16 @@ public:
   matchAndRewrite(tt::ttnn::TransposeOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    // emitc::CallOpaqueOp needs to know positions of operands vs attributes, so
-    // an ArrayAttr object holding IndexTypes is created to denote this.
-    //
-    ArrayAttr arrayAttrs = rewriter.getArrayAttr(
-        {rewriter.getIndexAttr(0), srcOp.getDim0Attr(), srcOp.getDim1Attr()});
+    ttnn_to_emitc::EmitCTTNNEmitter<tt::ttnn::TransposeOp> emitter(
+        srcOp, adaptor, rewriter);
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getInput()),
+        emitter.emit(srcOp.getDim0()),
+        emitter.emit(srcOp.getDim1()),
+        /*memory_config=*/emitter.emit(std::nullopt),
+    };
 
-    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
-        srcOp, this->getTypeConverter()->convertType(srcOp.getType()),
-        this->convertOpName(srcOp), arrayAttrs, nullptr, adaptor.getOperands());
+    emitter.replaceOp(*this, args);
 
     return success();
   }
@@ -621,16 +585,15 @@ public:
       tt::ttnn::RepeatOp>::TTNNToEmitCBaseOpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(tt::ttnn::RepeatOp repeatOp,
-                  tt::ttnn::RepeatOp::Adaptor adaptor,
+  matchAndRewrite(tt::ttnn::RepeatOp srcOp, tt::ttnn::RepeatOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    ttnn_to_emitc::EmitCTTNNEmitter<tt::ttnn::RepeatOp> emitter(
-        repeatOp, adaptor, rewriter);
+    ttnn_to_emitc::EmitCTTNNEmitter<tt::ttnn::RepeatOp> emitter(srcOp, adaptor,
+                                                                rewriter);
 
     llvm::SmallVector<mlir::Attribute> args{
-        emitter.emit(repeatOp.getInput()),
-        emitter.emit(repeatOp.getRepeatDims()),
+        emitter.emit(srcOp.getInput()),
+        emitter.emit(srcOp.getRepeatDims()),
     };
 
     emitter.replaceOp(*this, args);
@@ -690,9 +653,10 @@ public:
   matchAndRewrite(tt::ttnn::GetDeviceOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
-        srcOp, this->getTypeConverter()->convertType(srcOp.getType()),
-        this->convertOpName(srcOp), nullptr, nullptr, adaptor.getOperands());
+    ttnn_to_emitc::EmitCTTNNEmitter<tt::ttnn::GetDeviceOp> emitter(
+        srcOp, adaptor, rewriter);
+
+    emitter.replaceOp(*this, {});
 
     return success();
   }
@@ -713,43 +677,16 @@ public:
   matchAndRewrite(tt::ttnn::ToDeviceOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    llvm::SmallVector<Attribute, 2> attrs;
-    attrs.push_back(mlir::IntegerAttr::get(rewriter.getIndexType(), 0));
-    attrs.push_back(mlir::IntegerAttr::get(rewriter.getIndexType(), 1));
-    llvm::SmallVector<Value, 2> operands(adaptor.getOperands());
+    ttnn_to_emitc::EmitCTTNNEmitter<tt::ttnn::ToDeviceOp> emitter(
+        srcOp, adaptor, rewriter);
 
-    if (srcOp.getMemoryConfig()) {
-      // Create ArrayAttr object holding MemoryConfig attributes.
-      //
-      ArrayAttr arrayAttrs = rewriter.getArrayAttr(
-          {tt::ttnn_to_emitc::utils::convertTensorMemoryLayout(
-               rewriter, srcOp.getMemoryConfig()->getTensorMemoryLayout()),
-           tt::ttnn_to_emitc::utils::convertBufferType(
-               rewriter, srcOp.getMemoryConfig()->getBufferType())});
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getInput()),
+        emitter.emit(srcOp.getDevice()),
+        emitter.emit(srcOp.getMemoryConfig()),
+    };
 
-      // Create MemoryConfig object first, then pass it to the op.
-      //
-      emitc::CallOpaqueOp memCfgOp = rewriter.create<emitc::CallOpaqueOp>(
-          srcOp->getLoc(),
-          emitc::OpaqueType::get(rewriter.getContext(), "ttnn::MemoryConfig"),
-          "ttnn::MemoryConfig", arrayAttrs, nullptr, ValueRange());
-
-      // Concat operands and MemoryConfig object.
-      //
-      operands.append(1, memCfgOp.getResult(0));
-
-      attrs.push_back(mlir::IntegerAttr::get(rewriter.getIndexType(), 2));
-    } else {
-      attrs.push_back(tt::ttnn_to_emitc::utils::createStdNullopt(rewriter));
-    }
-
-    ArrayAttr finalAttrs = ArrayAttr::get(srcOp->getContext(), attrs);
-
-    // Convert ToDeviceOp
-    //
-    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
-        srcOp, this->getTypeConverter()->convertType(srcOp.getType()),
-        this->convertOpName(srcOp), finalAttrs, nullptr, operands);
+    emitter.replaceOp(*this, args);
 
     return success();
   }
@@ -770,9 +707,14 @@ public:
   matchAndRewrite(tt::ttnn::FromDeviceOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
-        srcOp, this->getTypeConverter()->convertType(srcOp.getType()),
-        this->convertOpName(srcOp), nullptr, nullptr, adaptor.getOperands());
+    ttnn_to_emitc::EmitCTTNNEmitter<tt::ttnn::FromDeviceOp> emitter(
+        srcOp, adaptor, rewriter);
+
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getInput()),
+    };
+
+    emitter.replaceOp(*this, args);
 
     return success();
   }
@@ -793,14 +735,16 @@ public:
   matchAndRewrite(tt::ttnn::TypecastOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    ArrayAttr arrayAttrs = rewriter.getArrayAttr(
-        {mlir::IntegerAttr::get(rewriter.getIndexType(), 0),
-         tt::ttnn_to_emitc::utils::convertDType(rewriter,
-                                                srcOp.getDtypeAttr())});
+    ttnn_to_emitc::EmitCTTNNEmitter<tt::ttnn::TypecastOp> emitter(
+        srcOp, adaptor, rewriter);
 
-    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
-        srcOp, this->getTypeConverter()->convertType(srcOp.getType()),
-        this->convertOpName(srcOp), arrayAttrs, nullptr, adaptor.getOperands());
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getInput()),
+        emitter.emit(srcOp.getDtype()),
+        /*memory_config=*/emitter.emit(std::nullopt),
+    };
+
+    emitter.replaceOp(*this, args);
 
     return success();
   }
@@ -821,14 +765,15 @@ public:
   matchAndRewrite(tt::ttnn::ToDTypeOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    ArrayAttr arrayAttrs = rewriter.getArrayAttr(
-        {mlir::IntegerAttr::get(rewriter.getIndexType(), 0),
-         tt::ttnn_to_emitc::utils::convertDType(rewriter,
-                                                srcOp.getDtypeAttr())});
+    ttnn_to_emitc::EmitCTTNNEmitter<tt::ttnn::ToDTypeOp> emitter(srcOp, adaptor,
+                                                                 rewriter);
 
-    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
-        srcOp, this->getTypeConverter()->convertType(srcOp.getType()),
-        this->convertOpName(srcOp), arrayAttrs, nullptr, adaptor.getOperands());
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getInput()),
+        emitter.emit(srcOp.getDtype()),
+    };
+
+    emitter.replaceOp(*this, args);
 
     return success();
   }
@@ -848,36 +793,16 @@ public:
   LogicalResult
   matchAndRewrite(tt::ttnn::ToMemoryConfigOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    // Create ArrayAttr object holding MemoryConfig attributes.
-    //
-    ArrayAttr arrayAttrs = rewriter.getArrayAttr(
-        {tt::ttnn_to_emitc::utils::convertTensorMemoryLayout(
-             rewriter, srcOp.getMemoryConfig().getTensorMemoryLayout()),
-         tt::ttnn_to_emitc::utils::convertBufferType(
-             rewriter, srcOp.getMemoryConfig().getBufferType())});
 
-    // Create MemoryConfig object first, then pass it to the op.
-    //
-    emitc::CallOpaqueOp memCfgOp = rewriter.create<emitc::CallOpaqueOp>(
-        srcOp->getLoc(),
-        emitc::OpaqueType::get(rewriter.getContext(), "ttnn::MemoryConfig"),
-        "ttnn::MemoryConfig", arrayAttrs, nullptr, ValueRange());
+    ttnn_to_emitc::EmitCTTNNEmitter<tt::ttnn::ToMemoryConfigOp> emitter(
+        srcOp, adaptor, rewriter);
 
-    // Concat operands and MemoryConfig object.
-    //
-    llvm::SmallVector<Value, 2> operands(adaptor.getOperands());
-    operands.append(1, memCfgOp.getResult(0));
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getInput()),
+        emitter.emit(srcOp.getMemoryConfig()),
+    };
 
-    llvm::SmallVector<Attribute, 3> attrs;
-    attrs.push_back(mlir::IntegerAttr::get(rewriter.getIndexType(), 0));
-    attrs.push_back(mlir::IntegerAttr::get(rewriter.getIndexType(), 1));
-    attrs.push_back(tt::ttnn_to_emitc::utils::createStdNullopt(rewriter));
-
-    ArrayAttr finalAttrs = ArrayAttr::get(srcOp->getContext(), attrs);
-
-    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
-        srcOp, this->getTypeConverter()->convertType(srcOp.getType()),
-        this->convertOpName(srcOp), finalAttrs, nullptr, operands);
+    emitter.replaceOp(*this, args);
 
     return success();
   }
@@ -898,19 +823,22 @@ public:
   matchAndRewrite(tt::ttnn::ToLayoutOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    llvm::SmallVector<Attribute, 5> attrs;
-    attrs.push_back(mlir::IntegerAttr::get(rewriter.getIndexType(), 0));
-    attrs.push_back(tt::ttnn_to_emitc::utils::convertLayoutAttr(
-        rewriter, srcOp.getLayoutAttr()));
-    attrs.push_back(tt::ttnn_to_emitc::utils::createStdNullopt(rewriter));
-    attrs.push_back(tt::ttnn_to_emitc::utils::createStdNullopt(rewriter));
-    attrs.push_back(createNullDevicePointer(rewriter));
+    ttnn_to_emitc::EmitCTTNNEmitter<tt::ttnn::ToLayoutOp> emitter(
+        srcOp, adaptor, rewriter);
 
-    ArrayAttr arrayAttrs = ArrayAttr::get(srcOp->getContext(), attrs);
+    // TODO (azecevic): This is unbelievably bad design. There are two overloads
+    // with a tons of default valued paramaters, but they are all useless
+    // because every call will be ambiguous due to the fact that every parameter
+    // except the last one is the same (and the last one is pointer type, so
+    // even `nullptr` is not enough to disambiguate). This is a design flaw in
+    // the TTNN that needs to be fixed.
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getInput()), emitter.emit(srcOp.getLayout()),
+        emitter.emit(srcOp.getDtype()), emitter.emit(srcOp.getMemoryConfig()),
+        emitter.emit(srcOp.getDevice()) |
+            emitter.emit<::ttnn::IDevice>(nullptr)};
 
-    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
-        srcOp, this->getTypeConverter()->convertType(srcOp.getType()),
-        this->convertOpName(srcOp), arrayAttrs, nullptr, adaptor.getOperands());
+    emitter.replaceOp(*this, args);
 
     return success();
   }
@@ -960,73 +888,16 @@ public:
   matchAndRewrite(tt::ttnn::ZerosOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    // tt::ttnn:ZerosOp has 5 input params:
-    //
-    // let arguments = (ins TTNN_ShapeAttr:$shape,
-    //                      OptionalAttr<TT_DataTypeAttr>:$dtype,
-    //                      OptionalAttr<TTNN_LayoutAttr>:$layout,
-    //                      Optional<TT_Device>:$device,
-    //                      OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
-    //
-    // Some of them are Attrs, some are Values. ShapeAttr is required, while
-    // others are optional. Additionally, in the context of C++, some of the
-    // Attrs (like shape) need to be instantiated into objects before being
-    // passed to the op. Therefore:
-    //
-    // We first create a tt::ttnn::SimpleShape object (SSA) by calling
-    // createShapeOp() and add it to the operands vector, but also add an
-    // IndexAttr in ArrayAttr to reference it (this is an EmitC mechanism that
-    // allows for combining Attrs and Values when calling an OpaqueOp). All the
-    // other input params are optional, so we create them on-the-fly into the
-    // ArrayAttr, whether they are an actual Attr, or a Value pointed to by
-    // IndexAttr. If they are present, we create the object and pass it to the
-    // op. If not, we pass std::nullopt.
+    ttnn_to_emitc::EmitCTTNNEmitter<tt::ttnn::ZerosOp> emitter(srcOp, adaptor,
+                                                               rewriter);
 
-    // Create tt::ttnn::SimpleShape() call
-    //
-    emitc::CallOpaqueOp shapeOp = tt::ttnn_to_emitc::utils::createShapeOp(
-        rewriter, srcOp.getShapeAttr(), srcOp.getLoc());
-
-    llvm::SmallVector<Value, 3> operands{
-        shapeOp->getResult(0),
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getShape()),        emitter.emit(srcOp.getDtype()),
+        emitter.emit(srcOp.getLayout()),       emitter.emit(srcOp.getDevice()),
+        emitter.emit(srcOp.getMemoryConfig()),
     };
 
-    // Create ArrayAttr object holding attributes and pointers to operands
-    //
-    // Params that are Values are added to the operands vector on-the-fly, and
-    // a corresponding IndexAttr is added to the ArrayAttr to reference them.
-    //
-    size_t operandIndex = 0;
-    ArrayAttr arrayAttr = rewriter.getArrayAttr({
-        rewriter.getIndexAttr(operandIndex++), // tt::ttnn::SimpleShape
-        srcOp.getDtype().has_value()
-            ? tt::ttnn_to_emitc::utils::convertDType(rewriter,
-                                                     srcOp.getDtypeAttr())
-            : tt::ttnn_to_emitc::utils::createStdNullopt(
-                  rewriter), // tt::ttnn::DataType
-        srcOp.getLayout().has_value()
-            ? tt::ttnn_to_emitc::utils::convertLayoutAttr(rewriter,
-                                                          srcOp.getLayoutAttr())
-            : tt::ttnn_to_emitc::utils::createStdNullopt(
-                  rewriter), // tt::ttnn::Layout
-        adaptor.getDevice()
-            ? (operands.append(1, adaptor.getDevice()),
-               mlir::cast<Attribute>(rewriter.getIndexAttr(operandIndex++)))
-            : tt::ttnn_to_emitc::utils::createStdNullopt(
-                  rewriter), // tt::ttnn::Device
-        srcOp.getMemoryConfig().has_value()
-            ? (operands.append(
-                   1, tt::ttnn_to_emitc::utils::createMemoryConfigOp(
-                          rewriter, srcOp.getMemoryConfigAttr(), srcOp.getLoc())
-                          ->getResult(0)),
-               mlir::cast<Attribute>(rewriter.getIndexAttr(operandIndex++)))
-            : tt::ttnn_to_emitc::utils::createStdNullopt(
-                  rewriter), // tt::ttnn::MemoryConfig
-    });
-
-    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
-        srcOp, this->getTypeConverter()->convertType(srcOp.getType()),
-        this->convertOpName(srcOp), arrayAttr, nullptr, operands);
+    emitter.replaceOp(*this, args);
 
     return success();
   }
@@ -1046,73 +917,17 @@ public:
   matchAndRewrite(tt::ttnn::OnesOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    // tt::ttnn:OnesOp has 5 input params:
-    //
-    // let arguments = (ins TTNN_ShapeAttr:$shape,
-    //                      OptionalAttr<TT_DataTypeAttr>:$dtype,
-    //                      OptionalAttr<TTNN_LayoutAttr>:$layout,
-    //                      Optional<TT_Device>:$device,
-    //                      OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
-    //
-    // Some of them are Attrs, some are Values. ShapeAttr is required, while
-    // others are optional. Additionally, in the context of C++, some of the
-    // Attrs (like shape) need to be instantiated into objects before being
-    // passed to the op. Therefore:
-    //
-    // We first create a tt::ttnn::Shape object (SA) by calling
-    // createShapeOp() and add it to the operands vector, but also add an
-    // IndexAttr in ArrayAttr to reference it (this is an EmitC mechanism that
-    // allows for combining Attrs and Values when calling an OpaqueOp). All the
-    // other input params are optional, so we create them on-the-fly into the
-    // ArrayAttr, whether they are an actual Attr, or a Value pointed to by
-    // IndexAttr. If they are present, we create the object and pass it to the
-    // op. If not, we pass std::nullopt.
+    ttnn_to_emitc::EmitCTTNNEmitter<tt::ttnn::OnesOp> emitter(srcOp, adaptor,
+                                                              rewriter);
 
-    // Create tt::ttnn::Shape() call
-    //
-    emitc::CallOpaqueOp shapeOp = tt::ttnn_to_emitc::utils::createShapeOp(
-        rewriter, srcOp.getShapeAttr(), srcOp.getLoc());
-
-    llvm::SmallVector<Value, 3> operands{
-        shapeOp->getResult(0),
+    // TODO (azecevic): Same as the `ZerosOp` conversion pattern.
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getShape()),        emitter.emit(srcOp.getDtype()),
+        emitter.emit(srcOp.getLayout()),       emitter.emit(srcOp.getDevice()),
+        emitter.emit(srcOp.getMemoryConfig()),
     };
 
-    // Create ArrayAttr object holding attributes and pointers to operands
-    //
-    // Params that are Values are added to the operands vector on-the-fly, and
-    // a corresponding IndexAttr is added to the ArrayAttr to reference them.
-    //
-    size_t operandIndex = 0;
-    ArrayAttr arrayAttr = rewriter.getArrayAttr({
-        rewriter.getIndexAttr(operandIndex++), // tt::ttnn::Shape
-        srcOp.getDtype().has_value()
-            ? tt::ttnn_to_emitc::utils::convertDType(rewriter,
-                                                     srcOp.getDtypeAttr())
-            : tt::ttnn_to_emitc::utils::createStdNullopt(
-                  rewriter), // tt::ttnn::DataType
-        srcOp.getLayout().has_value()
-            ? tt::ttnn_to_emitc::utils::convertLayoutAttr(rewriter,
-                                                          srcOp.getLayoutAttr())
-            : tt::ttnn_to_emitc::utils::createStdNullopt(
-                  rewriter), // tt::ttnn::Layout
-        adaptor.getDevice()
-            ? (operands.append(1, adaptor.getDevice()),
-               mlir::cast<Attribute>(rewriter.getIndexAttr(operandIndex++)))
-            : tt::ttnn_to_emitc::utils::createStdNullopt(
-                  rewriter), // tt::ttnn::Device
-        srcOp.getMemoryConfig().has_value()
-            ? (operands.append(
-                   1, tt::ttnn_to_emitc::utils::createMemoryConfigOp(
-                          rewriter, srcOp.getMemoryConfigAttr(), srcOp.getLoc())
-                          ->getResult(0)),
-               mlir::cast<Attribute>(rewriter.getIndexAttr(operandIndex++)))
-            : tt::ttnn_to_emitc::utils::createStdNullopt(
-                  rewriter), // tt::ttnn::MemoryConfig
-    });
-
-    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
-        srcOp, this->getTypeConverter()->convertType(srcOp.getType()),
-        this->convertOpName(srcOp), arrayAttr, nullptr, operands);
+    emitter.replaceOp(*this, args);
 
     return success();
   }
@@ -1133,15 +948,15 @@ public:
   matchAndRewrite(tt::ttnn::DeallocateOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    ArrayAttr arrayAttr = rewriter.getArrayAttr({
-        rewriter.getIndexAttr(0),
-        tt::ttnn_to_emitc::utils::convertBoolAttr(rewriter,
-                                                  srcOp.getForceAttr()),
-    });
+    ttnn_to_emitc::EmitCTTNNEmitter<tt::ttnn::DeallocateOp> emitter(
+        srcOp, adaptor, rewriter);
 
-    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
-        srcOp, srcOp->getResultTypes(), this->convertOpName(srcOp), arrayAttr,
-        nullptr, adaptor.getOperands());
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getInput()),
+        emitter.emit(srcOp.getForce()),
+    };
+
+    emitter.replaceOp(*this, args);
 
     return success();
   }

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -295,7 +295,7 @@ public:
     ttnn_to_emitc::EmitCTTNNEmitter<tt::ttnn::MatmulOp> emitter(srcOp, adaptor,
                                                                 rewriter);
 
-    // ANCHOR: adding_an_op_matmul_tt::ttnn_to_emitc_array_attrs
+    // ANCHOR: adding_an_op_matmul_ttnn_to_emitc_array_attrs
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getA()),
         emitter.emit(srcOp.getB()),
@@ -303,7 +303,7 @@ public:
         emitter.emit(srcOp.getTransposeB()),
         /*memory_config=*/emitter.emit(std::nullopt),
     };
-    // ANCHOR_END: adding_an_op_matmul_tt::ttnn_to_emitc_array_attrs
+    // ANCHOR_END: adding_an_op_matmul_ttnn_to_emitc_array_attrs
 
     emitter.replaceOp(*this, args);
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/2343

### Problem description
Part of the effort to onboard all TTNN ops to conversion infrastructure introduced in https://github.com/tenstorrent/tt-mlir/pull/2331

### What's changed
Transitioned ops with existing conversion to conversion with the new converter. Few changes in the Emitter class, mainly in the way how operands are treated, to accommodate more complex cases like `Variadic` of tensors that maps to `std::vector<ttnn::Tensor>`.
