### PR TITLE
Fix preprocessor stableHLO definition

### DIFF
--- a/include/ttmlir/Conversion/StableHLOToTTIR/ShardingUtils.h
+++ b/include/ttmlir/Conversion/StableHLOToTTIR/ShardingUtils.h
@@ -17,7 +17,7 @@
 
 namespace mlir::tt::sharding_utils {
 
-#if defined(TTMLIR_ENABLE_STABLEHLO) && (TTMLIR_ENABLE_STABLEHLO != 0)
+#ifdef TTMLIR_ENABLE_STABLEHLO
 
 class MeshSharding {
 public:


### PR DESCRIPTION
The definitions in `include/ttmlir/Conversion/StableHLOToTTIR/ShardingUtils.h` are guarded by checking the `TTMLIR_ENABLE_STABLEHLO` preprocessor directive. Changing how the directive is checked, as the previous definition had problems during `tt-xla`, and was not in line with other checks.
