### PR TITLE
Implement OpModel interface for TTNN.MultiplyOp

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -573,7 +573,10 @@ def TTNN_MinimumOp :  TTNN_ElementwiseBinaryOp<"minimum"> {
     }];
 }
 
-def TTNN_MultiplyOp : TTNN_ElementwiseBinaryOp<"multiply"> {
+def TTNN_MultiplyOp : TTNN_ElementwiseBinaryOp<"multiply",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
+
     let summary = "Eltwise multiply.";
     let description = [{
       Eltwise multiply operation.

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -143,5 +143,28 @@ llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
                                     bool transposeA, bool transposeB);
 }; // namespace MatmulOpInterface
 
+//===----------------------------------------------------------------------===//
+// MultiplyOp
+//===----------------------------------------------------------------------===//
+
+namespace MultiplyOpInterface {
+llvm::Expected<std::tuple<size_t, size_t, size_t>>
+getOpConstraints(llvm::ArrayRef<int64_t> inputShapeA,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                 llvm::ArrayRef<int64_t> inputShapeB,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                 llvm::ArrayRef<int64_t> outputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+
+llvm::Expected<size_t>
+getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+             llvm::ArrayRef<int64_t> inputShapeB,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+             llvm::ArrayRef<int64_t> outputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+
+}; // namespace MultiplyOpInterface
+
 } // namespace mlir::tt::op_model::ttnn
 #endif // TTMLIR_OPMODEL_TTNN_TTNNOPMODEL_H

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -283,4 +283,47 @@ MatmulOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
       false, false);
 }
 
+//===----------------------------------------------------------------------===//
+// MultiplyOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<std::tuple<size_t, size_t, size_t>>
+MultiplyOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                             const TTNNLayoutAttr &output) {
+  assert(inputs.size() == 2);
+
+  const auto inputShapeA =
+      mlir::cast<RankedTensorType>(getOperand(0).getType()).getShape();
+  const auto inputShapeB =
+      mlir::cast<RankedTensorType>(getOperand(1).getType()).getShape();
+
+  const auto outputShape =
+      mlir::cast<RankedTensorType>(getResult(0).getType()).getShape();
+
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+
+  return op_model::ttnn::MultiplyOpInterface::getOpConstraints(
+      inputShapeA, inputs[0], inputShapeB, inputs[1], outputShape, output);
+}
+
+llvm::Expected<size_t>
+MultiplyOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                         const TTNNLayoutAttr &output) {
+  assert(inputs.size() == 2);
+
+  const auto inputShapeA =
+      mlir::cast<RankedTensorType>(getOperand(0).getType()).getShape();
+  const auto inputShapeB =
+      mlir::cast<RankedTensorType>(getOperand(1).getType()).getShape();
+
+  const auto outputShape =
+      mlir::cast<RankedTensorType>(getResult(0).getType()).getShape();
+
+  return op_model::ttnn::MultiplyOpInterface::getOpRuntime(
+      inputShapeA, inputs[0], inputShapeB, inputs[1], outputShape, output);
+}
+
 } // namespace mlir::tt::ttnn

--- a/lib/OpModel/TTNN/TTNNOpModelLib.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModelLib.cpp
@@ -196,6 +196,74 @@ Device::getDeviceConstraints(mlir::tt::GridAttr workerGrid) {
 }
 
 //===----------------------------------------------------------------------===//
+// Template functions for binary elementwise operations.
+//===----------------------------------------------------------------------===//
+
+template <typename OpSymbol>
+llvm::Expected<std::tuple<size_t, size_t, size_t>>
+getEltwiseBinaryOpConstraints(std::string_view opName, OpSymbol opSymbol,
+                              llvm::ArrayRef<int64_t> inputShapeA,
+                              mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                              llvm::ArrayRef<int64_t> inputShapeB,
+                              mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                              llvm::ArrayRef<int64_t> outputShape,
+                              mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+  auto query = [&](llvm::ArrayRef<int64_t> aShape,
+                   mlir::tt::ttnn::TTNNLayoutAttr aLayout,
+                   llvm::ArrayRef<int64_t> bShape,
+                   mlir::tt::ttnn::TTNNLayoutAttr bLayout,
+                   llvm::ArrayRef<int64_t> outShape,
+                   mlir::tt::ttnn::TTNNLayoutAttr outLayout) {
+    ::tt::tt_metal::v0::IDevice *device =
+        SingletonDeviceContext::getInstance().getDevice();
+    const auto [inputSpecA, inputSpecB, outputSpec] =
+        detail::convertToTensorSpec(device, std::make_tuple(aShape, aLayout),
+                                    std::make_tuple(bShape, bLayout),
+                                    std::make_tuple(outShape, outLayout));
+
+    return ::ttnn::graph::query_op_constraints(
+        opSymbol, device, inputSpecA, inputSpecB, outputSpec.data_type(),
+        outputSpec.tensor_layout().get_memory_config());
+  };
+
+  return operation::getOpConstraints(opName, query, inputShapeA, inputLayoutA,
+                                     inputShapeB, inputLayoutB, outputShape,
+                                     outputLayout);
+}
+
+template <typename OpSymbol>
+llvm::Expected<size_t>
+getEltwiseBinaryOpRuntime(std::string_view opName, OpSymbol opSymbol,
+                          llvm::ArrayRef<int64_t> inputShapeA,
+                          mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                          llvm::ArrayRef<int64_t> inputShapeB,
+                          mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                          llvm::ArrayRef<int64_t> outputShape,
+                          mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+  auto query = [&](llvm::ArrayRef<int64_t> aShape,
+                   mlir::tt::ttnn::TTNNLayoutAttr aLayout,
+                   llvm::ArrayRef<int64_t> bShape,
+                   mlir::tt::ttnn::TTNNLayoutAttr bLayout,
+                   llvm::ArrayRef<int64_t> outShape,
+                   mlir::tt::ttnn::TTNNLayoutAttr outLayout) {
+    ::tt::tt_metal::v0::IDevice *device =
+        SingletonDeviceContext::getInstance().getDevice();
+    const auto [inputSpecA, inputSpecB, outputSpec] =
+        detail::convertToTensorSpec(device, std::make_tuple(aShape, aLayout),
+                                    std::make_tuple(bShape, bLayout),
+                                    std::make_tuple(outShape, outLayout));
+
+    return ::ttnn::graph::query_op_runtime(
+        opSymbol, device, inputSpecA, inputSpecB, outputSpec.data_type(),
+        outputSpec.tensor_layout().get_memory_config());
+  };
+
+  return operation::getOpRuntime(opName, query, inputShapeA, inputLayoutA,
+                                 inputShapeB, inputLayoutB, outputShape,
+                                 outputLayout);
+}
+
+//===----------------------------------------------------------------------===//
 // ReluOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<std::tuple<size_t, size_t, size_t>>
@@ -272,31 +340,9 @@ AddOpInterface::getOpConstraints(llvm::ArrayRef<int64_t> inputShapeA,
                                  llvm::ArrayRef<int64_t> outputShape,
                                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  auto addOpQuery = [](llvm::ArrayRef<int64_t> inputShapeA,
-                       mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
-                       llvm::ArrayRef<int64_t> inputShapeB,
-                       mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
-                       llvm::ArrayRef<int64_t> outputShape,
-                       mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
-    // open device device, will close it at the end of function
-    ::tt::tt_metal::v0::IDevice *device =
-        SingletonDeviceContext::getInstance().getDevice();
-
-    // prepare io specs
-    const auto [inputSpecA, inputSpecB, outputSpec] =
-        detail::convertToTensorSpec(device,
-                                    std::make_tuple(inputShapeA, inputLayoutA),
-                                    std::make_tuple(inputShapeB, inputLayoutB),
-                                    std::make_tuple(outputShape, outputLayout));
-
-    return ::ttnn::graph::query_op_constraints(
-        ::ttnn::add, device, inputSpecA, inputSpecB, outputSpec.data_type(),
-        outputSpec.tensor_layout().get_memory_config());
-  };
-
-  return operation::getOpConstraints("AddOpInterface", addOpQuery, inputShapeA,
-                                     inputLayoutA, inputShapeB, inputLayoutB,
-                                     outputShape, outputLayout);
+  return getEltwiseBinaryOpConstraints("AddOpInterface", ::ttnn::add,
+                                       inputShapeA, inputLayoutA, inputShapeB,
+                                       inputLayoutB, outputShape, outputLayout);
 #else
   return std::make_tuple(0, 0, 0);
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -310,31 +356,9 @@ AddOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
                              llvm::ArrayRef<int64_t> outputShape,
                              mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  auto addOpQuery = [](llvm::ArrayRef<int64_t> inputShapeA,
-                       mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
-                       llvm::ArrayRef<int64_t> inputShapeB,
-                       mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
-                       llvm::ArrayRef<int64_t> outputShape,
-                       mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
-    // open device device, will close it at the end of function
-    ::tt::tt_metal::v0::IDevice *device =
-        SingletonDeviceContext::getInstance().getDevice();
-
-    // prepare io specs
-    const auto [inputSpecA, inputSpecB, outputSpec] =
-        detail::convertToTensorSpec(device,
-                                    std::make_tuple(inputShapeA, inputLayoutA),
-                                    std::make_tuple(inputShapeB, inputLayoutB),
-                                    std::make_tuple(outputShape, outputLayout));
-
-    return ::ttnn::graph::query_op_runtime(
-        ::ttnn::add, device, inputSpecA, inputSpecB, outputSpec.data_type(),
-        outputSpec.tensor_layout().get_memory_config());
-  };
-
-  return operation::getOpRuntime("AddOpInterface", addOpQuery, inputShapeA,
-                                 inputLayoutA, inputShapeB, inputLayoutB,
-                                 outputShape, outputLayout);
+  return getEltwiseBinaryOpRuntime("AddOpInterface", ::ttnn::add, inputShapeA,
+                                   inputLayoutA, inputShapeB, inputLayoutB,
+                                   outputShape, outputLayout);
 #else
   return llvm::createStringError("Not Implemented");
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -647,6 +671,39 @@ MatmulOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
                                  inputShapeA, inputLayoutA, inputShapeB,
                                  inputLayoutB, outputShape, outputLayout,
                                  transposeA, transposeB);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<std::tuple<size_t, size_t, size_t>>
+MultiplyOpInterface::getOpConstraints(
+    llvm::ArrayRef<int64_t> inputShapeA,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+    llvm::ArrayRef<int64_t> outputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  return getEltwiseBinaryOpConstraints("MultiplyOpInterface", ::ttnn::multiply,
+                                       inputShapeA, inputLayoutA, inputShapeB,
+                                       inputLayoutB, outputShape, outputLayout);
+#else
+  return std::make_tuple(0, 0, 0);
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t>
+MultiplyOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
+                                  mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                                  llvm::ArrayRef<int64_t> inputShapeB,
+                                  mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                                  llvm::ArrayRef<int64_t> outputShape,
+                                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  return getEltwiseBinaryOpRuntime("MultiplyOpInterface", ::ttnn::multiply,
+                                   inputShapeA, inputLayoutA, inputShapeB,
+                                   inputLayoutB, outputShape, outputLayout);
 #else
   return llvm::createStringError("Not Implemented");
 #endif // TTMLIR_ENABLE_OPMODEL

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -11,7 +11,9 @@
 #include "llvm/ADT/SmallVector.h"
 #include "gtest/gtest.h"
 #include <cstdint>
+#include <functional>
 #include <optional>
+#include <tuple>
 
 namespace mlir::tt::op_model::ttnn {
 
@@ -368,109 +370,142 @@ TEST_F(OpModelTest, SoftmaxSharded) {
   EXPECT_TRUE(runtimeExp.get() > 0);
 }
 
+enum class OpType { Add, Mul };
 class OpModelBinaryEltwiseParam : public OpModelTest,
                                   public testing::WithParamInterface<
-                                      std::tuple<detail::TestTensor, // inputA
+                                      std::tuple<OpType,
+                                                 detail::TestTensor, // inputA
                                                  detail::TestTensor, // inputB
                                                  detail::TestTensor, // output
-                                                 detail::ExpectedResult>> {};
+                                                 detail::ExpectedResult>> {
 
-TEST_P(OpModelBinaryEltwiseParam, Add) {
-  auto params = GetParam();
-  const auto [inputShapeA, inputTensorLayoutA, inputBufferTypeA,
-              inputVirtualGridA] = std::get<0>(params);
-  const auto [inputShapeB, inputTensorLayoutB, inputBufferTypeB,
-              inputVirtualGridB] = std::get<1>(params);
-  const auto [outputShape, outputTensorLayout, outputBufferType,
-              outputVirtualGrid] = std::get<2>(params);
-  const auto [expectedLegal, expectedCbSize, expectedPeakSize,
-              expectedOutputSize] = std::get<3>(params);
+protected:
+  std::map<OpType,
+           std::function<llvm::Expected<size_t>(
+               llvm::ArrayRef<int64_t>, mlir::tt::ttnn::TTNNLayoutAttr,
+               llvm::ArrayRef<int64_t>, mlir::tt::ttnn::TTNNLayoutAttr,
+               llvm::ArrayRef<int64_t>, mlir::tt::ttnn::TTNNLayoutAttr)>>
+      runtimeMap = {
+          {OpType::Add, AddOpInterface::getOpRuntime},
+          {OpType::Mul, MultiplyOpInterface::getOpRuntime},
+      };
 
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA = CreateTiledLayout(
-      inputShapeA, inputBufferTypeA, inputTensorLayoutA, inputVirtualGridA);
-  const mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB = CreateTiledLayout(
-      inputShapeB, inputBufferTypeB, inputTensorLayoutB, inputVirtualGridB);
-  const mlir::tt::ttnn::TTNNLayoutAttr outputLayout = CreateTiledLayout(
-      outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
+  std::map<OpType,
+           std::function<llvm::Expected<std::tuple<size_t, size_t, size_t>>(
+               llvm::ArrayRef<int64_t>, mlir::tt::ttnn::TTNNLayoutAttr,
+               llvm::ArrayRef<int64_t>, mlir::tt::ttnn::TTNNLayoutAttr,
+               llvm::ArrayRef<int64_t>, mlir::tt::ttnn::TTNNLayoutAttr)>>
+      constraintsMap = {
+          {OpType::Add, AddOpInterface::getOpConstraints},
+          {OpType::Mul, MultiplyOpInterface::getOpConstraints},
+      };
 
-  auto constraintsExp =
-      AddOpInterface::getOpConstraints(inputShapeA, inputLayoutA, inputShapeB,
-                                       inputLayoutB, outputShape, outputLayout);
-  // Manually cast to bool because EXPECT_TRUE requires a const bool operator
-  // which llvm::Expected<T> does not have
-  EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
-  if (expectedLegal) {
-    const auto [cbSize, peakSize, outputSize] = constraintsExp.get();
-    EXPECT_EQ(cbSize, expectedCbSize);
-    EXPECT_EQ(peakSize, expectedPeakSize);
-    EXPECT_EQ(outputSize, expectedOutputSize);
-  } else {
-    // Must clean up the error
-    llvm::consumeError(constraintsExp.takeError());
+  void RunTest() {
+    const auto opType = get<0>(GetParam());
+    const auto [inputShapeA, inputTensorLayoutA, inputBufferTypeA,
+                inputVirtualGridA] = std::get<1>(GetParam());
+    const auto [inputShapeB, inputTensorLayoutB, inputBufferTypeB,
+                inputVirtualGridB] = std::get<2>(GetParam());
+    const auto [outputShape, outputTensorLayout, outputBufferType,
+                outputVirtualGrid] = std::get<3>(GetParam());
+    const auto [expectedLegal, expectedCbSize, expectedPeakSize,
+                expectedOutputSize] = std::get<4>(GetParam());
+
+    const mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA = CreateTiledLayout(
+        inputShapeA, inputBufferTypeA, inputTensorLayoutA, inputVirtualGridA);
+    const mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB = CreateTiledLayout(
+        inputShapeB, inputBufferTypeB, inputTensorLayoutB, inputVirtualGridB);
+    const mlir::tt::ttnn::TTNNLayoutAttr outputLayout = CreateTiledLayout(
+        outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
+
+    auto constraintsExp =
+        constraintsMap[opType](inputShapeA, inputLayoutA, inputShapeB,
+                               inputLayoutB, outputShape, outputLayout);
+    // Manually cast to bool because EXPECT_TRUE requires a const bool operator
+    // which llvm::Expected<T> does not have
+    EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
+    if (expectedLegal) {
+      const auto [cbSize, peakSize, outputSize] = constraintsExp.get();
+      EXPECT_EQ(cbSize, expectedCbSize);
+      EXPECT_EQ(peakSize, expectedPeakSize);
+      EXPECT_EQ(outputSize, expectedOutputSize);
+    } else {
+      // Must clean up the error
+      llvm::consumeError(constraintsExp.takeError());
+    }
+
+    llvm::Expected<size_t> runtimeExp =
+        runtimeMap[opType](inputShapeA, inputLayoutA, inputShapeB, inputLayoutB,
+                           outputShape, outputLayout);
+    EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
+    if (expectedLegal) {
+      EXPECT_TRUE(runtimeExp.get() > 0);
+    } else {
+      llvm::consumeError(runtimeExp.takeError());
+    }
   }
+};
 
-  auto runtimeExp =
-      AddOpInterface::getOpRuntime(inputShapeA, inputLayoutA, inputShapeB,
-                                   inputLayoutB, outputShape, outputLayout);
-  EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
-  if (expectedLegal) {
-    EXPECT_TRUE(runtimeExp.get() > 0);
-  } else {
-    llvm::consumeError(runtimeExp.takeError());
-  }
-}
+TEST_P(OpModelBinaryEltwiseParam, BinaryOp) { RunTest(); }
 
 INSTANTIATE_TEST_SUITE_P(
     AddTests, OpModelBinaryEltwiseParam,
     ::testing::Values(
-        std::make_tuple(detail::interleavedN300X1024Dram,
+        std::make_tuple(OpType::Add, detail::interleavedN300X1024Dram,
                         detail::interleavedN300X1024Dram,
                         detail::interleavedN300X1024Dram,
                         detail::ExpectedResult{true, 12288, 0, 0}),
-        std::make_tuple(detail::interleavedN300X1024Dram,
-                        detail::interleavedN300X1024L1,
-                        detail::interleavedN300X1024Dram,
-                        detail::ExpectedResult{true, 12288, 0, 0}),
-        std::make_tuple(detail::interleavedN300X1024L1,
-                        detail::interleavedN300X1024Dram,
-                        detail::interleavedN300X1024Dram,
-                        detail::ExpectedResult{true, 12288, 0, 0}),
-        std::make_tuple(detail::interleavedN300X1024L1,
-                        detail::interleavedN300X1024L1,
-                        detail::interleavedN300X1024Dram,
-                        detail::ExpectedResult{true, 12288, 0, 0}),
-        std::make_tuple(detail::interleavedN300X1024L1,
-                        detail::interleavedN300X1024L1,
-                        detail::interleavedN300X1024L1,
-                        detail::ExpectedResult{true, 12288, 2048, 2048}),
-        std::make_tuple(detail::interleavedN300X1024Dram,
-                        detail::interleavedN300X1024L1,
-                        detail::interleavedN300X1024L1,
-                        detail::ExpectedResult{true, 12288, 2048, 2048}),
-        std::make_tuple(detail::interleavedN300X1024L1,
-                        detail::interleavedN300X1024Dram,
-                        detail::interleavedN300X1024L1,
-                        detail::ExpectedResult{true, 12288, 2048, 2048}),
-        std::make_tuple(detail::interleavedN300X1024Dram,
-                        detail::interleavedN300X1024Dram,
-                        detail::interleavedN300X1024L1,
-                        detail::ExpectedResult{true, 12288, 2048, 2048}),
         std::make_tuple(
-            detail::TestTensor{
-                {16 * OpModelFixture::workerCoresN300 * 32, 32},
-                mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
-                mlir::tt::ttnn::BufferType::L1,
-                llvm::SmallVector<int64_t>{8, 1}},
-            detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM},
-            detail::TestTensor{
-                {16 * OpModelFixture::workerCoresN300 * 32, 32},
-                mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
-                mlir::tt::ttnn::BufferType::L1,
-                llvm::SmallVector<int64_t>{8, 1}},
-            detail::ExpectedResult{true, 32768, 262144, 262144}),
+            OpType::Add, detail::interleavedN300X1024Dram,
+            detail::interleaved2048X2048Dram, detail::interleaved2048X2048Dram,
+            detail::ExpectedResult{false, 0, 0,
+                                   0}), // incompatible dimensions at the input
+        std::make_tuple(OpType::Add, detail::interleavedN300X1024Dram,
+                        detail::interleavedN300X1024L1,
+                        detail::interleavedN300X1024Dram,
+                        detail::ExpectedResult{true, 12288, 0, 0}),
+        std::make_tuple(OpType::Add, detail::interleavedN300X1024L1,
+                        detail::interleavedN300X1024Dram,
+                        detail::interleavedN300X1024Dram,
+                        detail::ExpectedResult{true, 12288, 0, 0}),
+        std::make_tuple(OpType::Add, detail::interleavedN300X1024L1,
+                        detail::interleavedN300X1024L1,
+                        detail::interleavedN300X1024Dram,
+                        detail::ExpectedResult{true, 12288, 0, 0}),
+        std::make_tuple(OpType::Add, detail::interleavedN300X1024L1,
+                        detail::interleavedN300X1024L1,
+                        detail::interleavedN300X1024L1,
+                        detail::ExpectedResult{true, 12288, 2048, 2048}),
+        std::make_tuple(OpType::Add, detail::interleavedN300X1024Dram,
+                        detail::interleavedN300X1024L1,
+                        detail::interleavedN300X1024L1,
+                        detail::ExpectedResult{true, 12288, 2048, 2048}),
+        std::make_tuple(OpType::Add, detail::interleavedN300X1024L1,
+                        detail::interleavedN300X1024Dram,
+                        detail::interleavedN300X1024L1,
+                        detail::ExpectedResult{true, 12288, 2048, 2048}),
+        std::make_tuple(OpType::Add, detail::interleavedN300X1024Dram,
+                        detail::interleavedN300X1024Dram,
+                        detail::interleavedN300X1024L1,
+                        detail::ExpectedResult{true, 12288, 2048, 2048}),
+        std::make_tuple(OpType::Add,
+                        detail::TestTensor{
+                            {16 * OpModelFixture::workerCoresN300 * 32, 32},
+                            mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
+                            mlir::tt::ttnn::BufferType::L1,
+                            llvm::SmallVector<int64_t>{8, 1}},
+                        detail::TestTensor{
+                            {16 * OpModelFixture::workerCoresN300 * 32, 32},
+                            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                            mlir::tt::ttnn::BufferType::DRAM},
+                        detail::TestTensor{
+                            {16 * OpModelFixture::workerCoresN300 * 32, 32},
+                            mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
+                            mlir::tt::ttnn::BufferType::L1,
+                            llvm::SmallVector<int64_t>{8, 1}},
+                        detail::ExpectedResult{true, 32768, 262144, 262144}),
         std::make_tuple(
+            OpType::Add,
             detail::TestTensor{
                 {16 * OpModelFixture::workerCoresN300 * 32, 32},
                 mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
@@ -484,6 +519,92 @@ INSTANTIATE_TEST_SUITE_P(
                                mlir::tt::ttnn::BufferType::DRAM},
             detail::ExpectedResult{true, 65536, 0, 0}),
         std::make_tuple(
+            OpType::Add,
+            detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::TestTensor{
+                {16 * OpModelFixture::workerCoresN300 * 32, 32},
+                mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
+                mlir::tt::ttnn::BufferType::L1,
+                llvm::SmallVector<int64_t>{8, 1}},
+            detail::ExpectedResult{true, 65536, 262144, 262144})));
+
+INSTANTIATE_TEST_SUITE_P(
+    MulTests, OpModelBinaryEltwiseParam,
+    ::testing::Values(
+        std::make_tuple(OpType::Mul, detail::interleavedN300X1024Dram,
+                        detail::interleavedN300X1024Dram,
+                        detail::interleavedN300X1024Dram,
+                        detail::ExpectedResult{true, 12288, 0, 0}),
+        std::make_tuple(
+            OpType::Mul, detail::interleavedN300X1024Dram,
+            detail::interleaved2048X2048Dram, detail::interleaved2048X2048Dram,
+            detail::ExpectedResult{false, 0, 0,
+                                   0}), // incompatible dimensions at the input
+        std::make_tuple(OpType::Mul, detail::interleavedN300X1024Dram,
+                        detail::interleavedN300X1024L1,
+                        detail::interleavedN300X1024Dram,
+                        detail::ExpectedResult{true, 12288, 0, 0}),
+        std::make_tuple(OpType::Mul, detail::interleavedN300X1024L1,
+                        detail::interleavedN300X1024Dram,
+                        detail::interleavedN300X1024Dram,
+                        detail::ExpectedResult{true, 12288, 0, 0}),
+        std::make_tuple(OpType::Mul, detail::interleavedN300X1024L1,
+                        detail::interleavedN300X1024L1,
+                        detail::interleavedN300X1024Dram,
+                        detail::ExpectedResult{true, 12288, 0, 0}),
+        std::make_tuple(OpType::Mul, detail::interleavedN300X1024L1,
+                        detail::interleavedN300X1024L1,
+                        detail::interleavedN300X1024L1,
+                        detail::ExpectedResult{true, 12288, 2048, 2048}),
+        std::make_tuple(OpType::Mul, detail::interleavedN300X1024Dram,
+                        detail::interleavedN300X1024L1,
+                        detail::interleavedN300X1024L1,
+                        detail::ExpectedResult{true, 12288, 2048, 2048}),
+        std::make_tuple(OpType::Mul, detail::interleavedN300X1024L1,
+                        detail::interleavedN300X1024Dram,
+                        detail::interleavedN300X1024L1,
+                        detail::ExpectedResult{true, 12288, 2048, 2048}),
+        std::make_tuple(OpType::Mul, detail::interleavedN300X1024Dram,
+                        detail::interleavedN300X1024Dram,
+                        detail::interleavedN300X1024L1,
+                        detail::ExpectedResult{true, 12288, 2048, 2048}),
+        std::make_tuple(OpType::Mul,
+                        detail::TestTensor{
+                            {16 * OpModelFixture::workerCoresN300 * 32, 32},
+                            mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
+                            mlir::tt::ttnn::BufferType::L1,
+                            llvm::SmallVector<int64_t>{8, 1}},
+                        detail::TestTensor{
+                            {16 * OpModelFixture::workerCoresN300 * 32, 32},
+                            mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                            mlir::tt::ttnn::BufferType::DRAM},
+                        detail::TestTensor{
+                            {16 * OpModelFixture::workerCoresN300 * 32, 32},
+                            mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
+                            mlir::tt::ttnn::BufferType::L1,
+                            llvm::SmallVector<int64_t>{8, 1}},
+                        detail::ExpectedResult{true, 32768, 262144, 262144}),
+        std::make_tuple(
+            OpType::Mul,
+            detail::TestTensor{
+                {16 * OpModelFixture::workerCoresN300 * 32, 32},
+                mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
+                mlir::tt::ttnn::BufferType::L1,
+                llvm::SmallVector<int64_t>{8, 1}},
+            detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::ExpectedResult{true, 65536, 0, 0}),
+        std::make_tuple(
+            OpType::Mul,
             detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
                                mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
                                mlir::tt::ttnn::BufferType::DRAM},

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -84,7 +84,7 @@ public:
   }
 };
 
-TEST_F(OpModelBase, ReluInterface) {
+TEST_F(OpModelBase, ReluOpInterface) {
   // create ReluOp
   llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
 
@@ -115,7 +115,7 @@ TEST_F(OpModelBase, ReluInterface) {
     FAIL() << llvm::toString(runtimeExp.takeError());
   }
 }
-TEST_F(OpModelBase, SoftmaxInterface) {
+TEST_F(OpModelBase, SoftmaxOpInterface) {
   // create SoftmaxOp
   llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
 
@@ -147,7 +147,7 @@ TEST_F(OpModelBase, SoftmaxInterface) {
   }
 }
 
-TEST_F(OpModelBase, AddInterface) {
+TEST_F(OpModelBase, AddOpInterface) {
   // create AddOp
   llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
 
@@ -180,7 +180,41 @@ TEST_F(OpModelBase, AddInterface) {
   }
 }
 
-TEST_F(OpModelBase, MatmulInterface) {
+TEST_F(OpModelBase, MultiplyOpInterface) {
+  // create MultiplyOp
+  llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
+
+  auto input1 = createEmptyTensor(tensorShape);
+  auto input2 = createEmptyTensor(tensorShape);
+  auto output = createEmptyTensor(tensorShape);
+
+  auto multiply =
+      builder.create<MultiplyOp>(builder.getUnknownLoc(), output.getType(),
+                                 ::mlir::ValueRange{input1, input2, output});
+  multiply->setAttr(DeviceAttr::name, getFakeDeviceAttr());
+
+  // test MultiplyOp interface
+  auto constraintsExp = getOpConstraints(multiply.getOperation());
+  if (constraintsExp) {
+    auto l1 = constraintsExp.get();
+    const auto [cb_size, peak_size, output_size] = l1;
+    EXPECT_EQ(cb_size, 12288);
+    EXPECT_EQ(peak_size, 2048);
+    EXPECT_EQ(output_size, 2048);
+  } else {
+    FAIL() << "Missing L1 constraints; Error="
+           << llvm::toString(constraintsExp.takeError()) << std::endl;
+  }
+
+  auto runtimeExp = getOpRuntime(multiply.getOperation());
+  if (runtimeExp) {
+    EXPECT_TRUE(runtimeExp.get() > 0);
+  } else {
+    FAIL() << llvm::toString(runtimeExp.takeError());
+  }
+}
+
+TEST_F(OpModelBase, MatmulOpInterface) {
   // create MatmulOp
   llvm::SmallVector<int64_t> tensorShapeA = {2048, 1024};
   llvm::SmallVector<int64_t> tensorShapeB = {1024, 2048};
@@ -216,7 +250,7 @@ TEST_F(OpModelBase, MatmulInterface) {
   }
 }
 
-TEST_F(OpModelBase, MeanInterface) {
+TEST_F(OpModelBase, MeanOpInterface) {
   // create MeanOp
   llvm::SmallVector<int64_t> tensorShapeA = {2048, 1024};
   llvm::SmallVector<int64_t> tensorShapeO = {2048, 1024};
@@ -252,7 +286,7 @@ TEST_F(OpModelBase, MeanInterface) {
   }
 }
 
-TEST_F(OpModelBase, reshapeOp) {
+TEST_F(OpModelBase, ReshapeOpInterface) {
   // create ReshapeOp
   llvm::SmallVector<int64_t> tensorShapeA = {64, 1024};
   llvm::SmallVector<int64_t> tensorShapeO = {64 * 4, 1024 / 4};


### PR DESCRIPTION


### Ticket
Related to #2277 

### Problem description
Optimizer needs constraints and runtime model for every op in order to shard them properly. This commit adds support for multiply op in that regard.

### What's changed
Implementation for GetOpConstraints & GetOpRuntime for MultiplyOp.   
Unit tests for MultiplyOp API, unified with existing AddOp tests.

Checklist

- [x]  New/Existing tests provide coverage for changes
