### PR TITLE
Refactor TTNN verification and add tests for conv2d op

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1119,7 +1119,7 @@ def TTNN_Conv2dOp : TTNN_Op<"conv2d"> {
       Applies a 2D convolution over an input image composed of several input planes.
 
       Inputs:
-      - `input` (AnyRankedTensor): expected in the following format (N, H_in, W_in, C) where:
+      - `input` (AnyRankedTensor): expected in the following flattened format (1, 1, N * H_in * W_in, C) where:
         - N is the batch size
         - H_in is the height of the input planes
         - W_in is the width of the input planes
@@ -1131,9 +1131,6 @@ def TTNN_Conv2dOp : TTNN_Op<"conv2d"> {
         - G is the number of groups
         - K_H is the height of the kernel
         - K_W is the width of the kernel
-      - `output` (AnyRankedTensor): expected in the following format (N, H_out, W_out, O) where:
-        - `H_out = (H_in + 2 * pH - dH * (K_H - 1) - 1) / sH + 1`
-        - `W_out = (W_in + 2 * pW - dW * (K_W - 1) - 1) / sW + 1`
 
       Attributes:
       - `in_channels` (i32): The number of input channels.
@@ -1141,29 +1138,35 @@ def TTNN_Conv2dOp : TTNN_Op<"conv2d"> {
       - `batch_size` (i32): The batch size.
       - `input_height` (i32): The input height.
       - `input_width` (i32): The input width.
-      - `stride` (i32 | array<2xi32>):
-        - i32: Same stride for height and width dimensions (sH = sW = value).
-        - array<2xi32>: [sH, sW] where sH is stride for height and sW is stride for width.
-      - `padding` (i32 | array<2xi32>):
-        - i32: Same padding for all sides (pH = pW = value).
-        - array<2xi32>: [pH, pW] where pH is padding for height (top/bottom) and pW is padding for width (left/right).
-      - `dilation` (i32 | array<2xi32>): Spacing between kernel elements.
-        - i32: Same dilation for height and width dimensions (dH = dW = value).
-        - array<2xi32>: [dH, dW] where dH is dilation for height and dW is dilation for width.
+      - `kernel_size` (array<2xi32>): [K_H, K_W] where K_H is the kernel height and K_W is the kernel width.
+      - `stride` (array<2xi32>): [sH, sW] where sH is stride for height and sW is stride for width.
+      - `padding` (array<2xi32>): [pH, pW] where pH is padding for height (top/bottom) and pW is padding for width (left/right).
+      - `dilation` (array<2xi32>): [dH, dW] where dH is dilation for height and dW is dilation for width.
       - `groups` (i32): Number of blocked connections from input channels to output channels. Input and output channels must both be divisible by groups.
 
+      Outputs:
+      - `result` (AnyRankedTensor): returned in the following flattened format (1, 1, N * H_out * W_out, O) where:
+        - `H_out = (H_in + 2 * pH - dH * (K_H - 1) - 1) / sH + 1`
+        - `W_out = (W_in + 2 * pW - dW * (K_W - 1) - 1) / sW + 1`
+
       Example:
-        %input = tensor.empty() : () -> tensor<1x32x32x64xbf16>
+        %input = tensor.empty() : () -> tensor<1x1x1024x64xbf16>
         %weight = tensor.empty() : () -> tensor<64x64x3x3xbf16>
         %bias = tensor.empty() : () -> tensor<1x1x1x64xbf16>
-        %output = tensor.empty() : () -> tensor<1x30x30x64xbf16>
-        %0 = "ttnn.conv2d"(%input, %weight, %bias, %output)
+        %device = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
+        %0 = "ttnn.conv2d"(%input, %weight, %bias, %device)
           <{
-            stride = 1: i32,
-            padding = 0: i32,
-            dilation = 1: i32,
+            in_channels = 64: i32,
+            out_channels = 64: i32,
+            batch_size = 1: i32,
+            input_height = 32: i32,
+            input_width = 32: i32,
+            kernel_size = array<i32: 3, 3>,
+            stride = array<i32: 1, 1>,
+            padding = array<i32: 0, 0>,
+            dilation = array<i32: 1, 1>,
             groups = 1: i32
-          > : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+          }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !tt.device<#device>) -> tensor<1x1x900x64xbf16>
     }];
 
     let arguments = (ins AnyRankedTensor:$input,

--- a/test/ttmlir/Dialect/TTIR/conv2d/conv2d_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/conv2d/conv2d_tests_negative.mlir
@@ -2,7 +2,7 @@
 // Negative tests for conv2d operation
 
 // Verify that the parsing fails if tensors don't have four dimensions
-module attributes {} {
+module {
   func.func @conv2d_invalid_input_shape(%arg0: tensor<32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x64xbf16> {
     %0 = tensor.empty() : tensor<1x30x30x64xbf16>
     // CHECK: error: 'ttir.conv2d' op Input must be a 4D tensor
@@ -18,7 +18,7 @@ module attributes {} {
 }
 
 // -----
-module attributes {} {
+module {
   func.func @conv2d_invalid_weight_shape(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x64xbf16> {
     %0 = tensor.empty() : tensor<1x30x30x64xbf16>
     // CHECK: error: 'ttir.conv2d' op Weight must be a 4D tensor
@@ -34,7 +34,7 @@ module attributes {} {
 }
 
 // -----
-module attributes {} {
+module {
   func.func @conv2d_invalid_bias_shape(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x64xbf16>) -> tensor<1x30x30x64xbf16> {
     %0 = tensor.empty() : tensor<1x30x30x64xbf16>
     // CHECK: error: 'ttir.conv2d' op Bias must be a 4D tensor
@@ -50,7 +50,7 @@ module attributes {} {
 }
 
 // -----
-module attributes {} {
+module {
   func.func @conv2d_invalid_output_shape(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<30x30x64xbf16> {
     %0 = tensor.empty() : tensor<30x30x64xbf16>
     // CHECK: error: 'ttir.conv2d' op Output must be a 4D tensor
@@ -67,7 +67,7 @@ module attributes {} {
 
 // Verify that the parsing fails if attributes are not integers or pair of integers
 // -----
-module attributes {} {
+module {
   func.func @conv2d_invalid_stride_shape(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x64xbf16> {
     %0 = tensor.empty() : tensor<1x30x30x64xbf16>
     // CHECK: error: 'ttir.conv2d' op Expected integer or pair of integers, got tuple of size 3 for stride
@@ -83,7 +83,7 @@ module attributes {} {
 }
 
 // -----
-module attributes {} {
+module {
   func.func @conv2d_invalid_padding_shape(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x64xbf16> {
     %0 = tensor.empty() : tensor<1x30x30x64xbf16>
     // CHECK: error: 'ttir.conv2d' op Expected integer, pair, or tuple of size 4, but got tuple of size 3 for padding
@@ -99,7 +99,7 @@ module attributes {} {
 }
 
 // -----
-module attributes {} {
+module {
   func.func @conv2d_invalid_dilation_shape(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x64xbf16> {
     %0 = tensor.empty() : tensor<1x30x30x64xbf16>
     // CHECK: error: 'ttir.conv2d' op Expected integer or pair of integers, got tuple of size 3 for dilation
@@ -116,10 +116,10 @@ module attributes {} {
 
 // Verify that the parsing fails if attributes have invalid values
 // -----
-module attributes {} {
+module {
   func.func @conv2d_invalid_stride_values(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x64xbf16> {
     %0 = tensor.empty() : tensor<1x30x30x64xbf16>
-    // CHECK: error: 'ttir.conv2d' op Stride values must be greater than 0
+    // CHECK: error: 'ttir.conv2d' op Stride attribute values must be greater than 0
     %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
             <{
               stride = array<i32: 2, -2>,
@@ -132,10 +132,10 @@ module attributes {} {
 }
 
 // -----
-module attributes {} {
+module {
   func.func @conv2d_invalid_padding_values(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x64xbf16> {
     %0 = tensor.empty() : tensor<1x30x30x64xbf16>
-    // CHECK: error: 'ttir.conv2d' op Padding values must be greater or equal than 0
+    // CHECK: error: 'ttir.conv2d' op Padding attribute values must be greater than or equal to 0
     %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
             <{
               stride = 1: i32,
@@ -148,10 +148,10 @@ module attributes {} {
 }
 
 // -----
-module attributes {} {
+module {
   func.func @conv2d_invalid_dilation_values(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x64xbf16> {
     %0 = tensor.empty() : tensor<1x30x30x64xbf16>
-    // CHECK: error: 'ttir.conv2d' op Dilation values must be greater than 0
+    // CHECK: error: 'ttir.conv2d' op Dilation attribute values must be greater than 0
     %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
             <{
               stride = 1: i32,
@@ -165,7 +165,7 @@ module attributes {} {
 
 // Verify the parsing fails if number of channels are incorrect
 // -----
-module attributes {} {
+module {
   func.func @conv2d_input_channels_not_divisible_by_groups(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<100x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x100xbf16> {
     %0 = tensor.empty() : tensor<1x30x30x100xbf16>
     // CHECK: error: 'ttir.conv2d' op Number of input channels from input tensor must be divisible by the number of groups. Got 64 input channels and 10 groups
@@ -181,7 +181,7 @@ module attributes {} {
 }
 
 // -----
-module attributes {} {
+module {
   func.func @conv2d_output_channels_not_divisible_by_groups(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<128x64x3x3xbf16>, %arg2: tensor<1x1x1x102xbf16>) -> tensor<1x30x30x102xbf16> {
     %0 = tensor.empty() : tensor<1x30x30x102xbf16>
     // CHECK: error: 'ttir.conv2d' op Number of output channels from output tensor must be divisible by the number of groups. Got 102 output channels and 8 groups
@@ -197,7 +197,7 @@ module attributes {} {
 }
 
 // -----
-module attributes {} {
+module {
   func.func @conv2d_input_channels_missmatch_with_weight(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x128x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x64xbf16> {
     %0 = tensor.empty() : tensor<1x30x30x64xbf16>
     // CHECK: error: 'ttir.conv2d' op Number of input channels per group must match the second dimension of the weight tensor. Got 64 input channels per group and 128 in the weight tensor
@@ -213,7 +213,7 @@ module attributes {} {
 }
 
 // -----
-module attributes {} {
+module {
   func.func @conv2d_output_channels_missmatch_with_weight(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<128x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x64xbf16> {
     %0 = tensor.empty() : tensor<1x30x30x64xbf16>
     // CHECK:  error: 'ttir.conv2d' op Number of output channels from output tensor must match the first dimension of the weight tensor. Got 64 output channels and 128 in the weight tensor
@@ -229,7 +229,7 @@ module attributes {} {
 }
 
 // -----
-module attributes {} {
+module {
   func.func @conv2d_output_channels_missmatch_with_bias(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x128xbf16>) -> tensor<1x30x30x64xbf16> {
     %0 = tensor.empty() : tensor<1x30x30x64xbf16>
     // CHECK: error: 'ttir.conv2d' op Mismatch in bias tensor dimensions. Bias tensor has 128 channels, but the output tensor has 64 channels
@@ -245,7 +245,7 @@ module attributes {} {
 }
 
 // -----
-module attributes {} {
+module {
   func.func @conv2d_input_size_smaller_than_kernel_size(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x64xbf16> {
     %0 = tensor.empty() : tensor<1x30x30x64xbf16>
     // CHECK: error: 'ttir.conv2d' op Calculated padded input size per channel: (56 x 56). Kernel size: (65 x 65). Kernel size can't be greater than actual input size
@@ -261,7 +261,7 @@ module attributes {} {
 }
 
 // -----
-module attributes {} {
+module {
   func.func @conv2d_calculated_output_size_per_channel_missmatch_with_output_tensor(%arg0: tensor<1x128x256x36xbf16>, %arg1: tensor<72x6x16x32xbf16>, %arg2: tensor<1x1x1x72xbf16>) -> tensor<1x32x32x72xbf16> {
     %0 = tensor.empty() : tensor<1x32x32x72xbf16>
     // CHECK: error: 'ttir.conv2d' op  Mismatch between calculated and got output height and width. Calculated: (9 x 9). Got output tensor height and width: (32 x 32)

--- a/test/ttmlir/Dialect/TTNN/conv2d/conv2d_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/conv2d/conv2d_tests_negative.mlir
@@ -1,0 +1,487 @@
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+// Negative tests for conv2d operation
+
+// Verify that the parsing fails if tensors don't have four dimensions
+#device = #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, d0 floordiv s0, d1 floordiv s1, (d0 mod s0) * s1 + d1 mod s1), dramMap = (d0, d1)[s0, s1] -> (0, 0, ((((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 8192) mod 12, (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 98304 + (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) mod 8192), meshShape = , chipIds = [0]>
+module {
+  func.func @conv2d_invalid_input_shape(%arg0: tensor<32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
+    // CHECK: error: 'ttnn.conv2d' op Input must be a 4D tensor
+    %1 = "ttnn.conv2d"(%arg0, %arg1, %arg2, %0)
+            <{
+              in_channels = 64: i32,
+              out_channels = 64: i32,
+              batch_size = 1: i32,
+              input_height = 32: i32,
+              input_width = 32: i32,
+              kernel_size = array<i32: 3, 3>,
+              stride = array<i32: 1, 1>,
+              padding = array<i32: 0, 0>,
+              dilation = array<i32: 1, 1>,
+              groups = 1: i32
+            }> : (tensor<32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !tt.device<#device>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+#device = #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, d0 floordiv s0, d1 floordiv s1, (d0 mod s0) * s1 + d1 mod s1), dramMap = (d0, d1)[s0, s1] -> (0, 0, ((((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 8192) mod 12, (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 98304 + (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) mod 8192), meshShape = , chipIds = [0]>
+module {
+  func.func @conv2d_invalid_weight_shape(%arg0: tensor<1x1x1024x64xbf16>, %arg1: tensor<64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
+    // CHECK: error: 'ttnn.conv2d' op Weight must be a 4D tensor
+    %1 = "ttnn.conv2d"(%arg0, %arg1, %arg2, %0)
+            <{
+              in_channels = 64: i32,
+              out_channels = 64: i32,
+              batch_size = 1: i32,
+              input_height = 32: i32,
+              input_width = 32: i32,
+              kernel_size = array<i32: 3, 3>,
+              stride = array<i32: 1, 1>,
+              padding = array<i32: 0, 0>,
+              dilation = array<i32: 1, 1>,
+              groups = 1: i32
+            }> : (tensor<1x1x1024x64xbf16>, tensor<64x3x3xbf16>, tensor<1x1x1x64xbf16>, !tt.device<#device>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+#device = #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, d0 floordiv s0, d1 floordiv s1, (d0 mod s0) * s1 + d1 mod s1), dramMap = (d0, d1)[s0, s1] -> (0, 0, ((((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 8192) mod 12, (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 98304 + (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) mod 8192), meshShape = , chipIds = [0]>
+module {
+  func.func @conv2d_invalid_bias_shape(%arg0: tensor<1x1x1024x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
+    // CHECK: error: 'ttnn.conv2d' op Bias must be a 4D tensor
+    %1 = "ttnn.conv2d"(%arg0, %arg1, %arg2, %0)
+            <{
+              in_channels = 64: i32,
+              out_channels = 64: i32,
+              batch_size = 1: i32,
+              input_height = 32: i32,
+              input_width = 32: i32,
+              kernel_size = array<i32: 3, 3>,
+              stride = array<i32: 1, 1>,
+              padding = array<i32: 0, 0>,
+              dilation = array<i32: 1, 1>,
+              groups = 1: i32
+            }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x64xbf16>, !tt.device<#device>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+#device = #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, d0 floordiv s0, d1 floordiv s1, (d0 mod s0) * s1 + d1 mod s1), dramMap = (d0, d1)[s0, s1] -> (0, 0, ((((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 8192) mod 12, (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 98304 + (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) mod 8192), meshShape = , chipIds = [0]>
+module {
+  func.func @conv2d_invalid_output_shape(%arg0: tensor<1x1x1024x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x900x64xbf16> {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
+    // CHECK: error: 'ttnn.conv2d' op Output must be a 4D tensor
+    %1 = "ttnn.conv2d"(%arg0, %arg1, %arg2, %0)
+            <{
+              in_channels = 64: i32,
+              out_channels = 64: i32,
+              batch_size = 1: i32,
+              input_height = 32: i32,
+              input_width = 32: i32,
+              kernel_size = array<i32: 3, 3>,
+              stride = array<i32: 1, 1>,
+              padding = array<i32: 0, 0>,
+              dilation = array<i32: 1, 1>,
+              groups = 1: i32
+            }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !tt.device<#device>) -> tensor<1x900x64xbf16>
+    return %1 : tensor<1x900x64xbf16>
+  }
+}
+
+// Verify that the parsing fails if attributes are not pair of integers
+// -----
+#device = #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, d0 floordiv s0, d1 floordiv s1, (d0 mod s0) * s1 + d1 mod s1), dramMap = (d0, d1)[s0, s1] -> (0, 0, ((((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 8192) mod 12, (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 98304 + (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) mod 8192), meshShape = , chipIds = [0]>
+module {
+  func.func @conv2d_invalid_kernel_size_shape(%arg0: tensor<1x1x1024x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
+    // CHECK: error: 'ttnn.conv2d' op Kernel size attribute must have two values, got: 1
+    %1 = "ttnn.conv2d"(%arg0, %arg1, %arg2, %0)
+            <{
+              in_channels = 64: i32,
+              out_channels = 64: i32,
+              batch_size = 1: i32,
+              input_height = 32: i32,
+              input_width = 32: i32,
+              kernel_size = array<i32: 3>,
+              stride = array<i32: 1, 1>,
+              padding = array<i32: 0, 0>,
+              dilation = array<i32: 1, 1>,
+              groups = 1: i32
+            }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !tt.device<#device>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+#device = #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, d0 floordiv s0, d1 floordiv s1, (d0 mod s0) * s1 + d1 mod s1), dramMap = (d0, d1)[s0, s1] -> (0, 0, ((((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 8192) mod 12, (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 98304 + (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) mod 8192), meshShape = , chipIds = [0]>
+module {
+  func.func @conv2d_invalid_stride_shape(%arg0: tensor<1x1x1024x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
+    // CHECK: error: 'ttnn.conv2d' op Stride attribute must have two values, got: 3
+    %1 = "ttnn.conv2d"(%arg0, %arg1, %arg2, %0)
+            <{
+              in_channels = 64: i32,
+              out_channels = 64: i32,
+              batch_size = 1: i32,
+              input_height = 32: i32,
+              input_width = 32: i32,
+              kernel_size = array<i32: 3, 3>,
+              stride = array<i32: 1, 1, 3>,
+              padding = array<i32: 0, 0>,
+              dilation = array<i32: 1, 1>,
+              groups = 1: i32
+            }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !tt.device<#device>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+#device = #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, d0 floordiv s0, d1 floordiv s1, (d0 mod s0) * s1 + d1 mod s1), dramMap = (d0, d1)[s0, s1] -> (0, 0, ((((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 8192) mod 12, (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 98304 + (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) mod 8192), meshShape = , chipIds = [0]>
+module {
+  func.func @conv2d_invalid_padding_shape(%arg0: tensor<1x1x1024x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
+    // CHECK: error: 'ttnn.conv2d' op Padding attribute must have two values, got: 4
+    %1 = "ttnn.conv2d"(%arg0, %arg1, %arg2, %0)
+            <{
+              in_channels = 64: i32,
+              out_channels = 64: i32,
+              batch_size = 1: i32,
+              input_height = 32: i32,
+              input_width = 32: i32,
+              kernel_size = array<i32: 3, 3>,
+              stride = array<i32: 1, 1>,
+              padding = array<i32: 0, 0, 0, 0>,
+              dilation = array<i32: 1, 1>,
+              groups = 1: i32
+            }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !tt.device<#device>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+#device = #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, d0 floordiv s0, d1 floordiv s1, (d0 mod s0) * s1 + d1 mod s1), dramMap = (d0, d1)[s0, s1] -> (0, 0, ((((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 8192) mod 12, (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 98304 + (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) mod 8192), meshShape = , chipIds = [0]>
+module {
+  func.func @conv2d_invalid_dilation_shape(%arg0: tensor<1x1x1024x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
+    // CHECK: error: 'ttnn.conv2d' op Dilation attribute must have two values, got: 3
+    %1 = "ttnn.conv2d"(%arg0, %arg1, %arg2, %0)
+            <{
+              in_channels = 64: i32,
+              out_channels = 64: i32,
+              batch_size = 1: i32,
+              input_height = 32: i32,
+              input_width = 32: i32,
+              kernel_size = array<i32: 3, 3>,
+              stride = array<i32: 1, 1>,
+              padding = array<i32: 0, 0>,
+              dilation = array<i32: 1, 1, 1>,
+              groups = 1: i32
+            }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !tt.device<#device>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// Verify that the parsing fails if attributes have invalid values
+// -----
+#device = #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, d0 floordiv s0, d1 floordiv s1, (d0 mod s0) * s1 + d1 mod s1), dramMap = (d0, d1)[s0, s1] -> (0, 0, ((((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 8192) mod 12, (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 98304 + (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) mod 8192), meshShape = , chipIds = [0]>
+module {
+  func.func @conv2d_invalid_stride_values(%arg0: tensor<1x1x1024x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
+    // CHECK: error: 'ttnn.conv2d' op Stride attribute (2, -2) must be greater than 0
+    %1 = "ttnn.conv2d"(%arg0, %arg1, %arg2, %0)
+            <{
+              in_channels = 64: i32,
+              out_channels = 64: i32,
+              batch_size = 1: i32,
+              input_height = 32: i32,
+              input_width = 32: i32,
+              kernel_size = array<i32: 3, 3>,
+              stride = array<i32: 2, -2>,
+              padding = array<i32: 0, 0>,
+              dilation = array<i32: 1, 1>,
+              groups = 1: i32
+            }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !tt.device<#device>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+#device = #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, d0 floordiv s0, d1 floordiv s1, (d0 mod s0) * s1 + d1 mod s1), dramMap = (d0, d1)[s0, s1] -> (0, 0, ((((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 8192) mod 12, (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 98304 + (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) mod 8192), meshShape = , chipIds = [0]>
+module {
+  func.func @conv2d_invalid_padding_values(%arg0: tensor<1x1x1024x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
+    // CHECK: error: 'ttnn.conv2d' op Padding attribute (-1, 0) must be greater than or equal to 0
+    %1 = "ttnn.conv2d"(%arg0, %arg1, %arg2, %0)
+            <{
+              in_channels = 64: i32,
+              out_channels = 64: i32,
+              batch_size = 1: i32,
+              input_height = 32: i32,
+              input_width = 32: i32,
+              kernel_size = array<i32: 3, 3>,
+              stride = array<i32: 1, 1>,
+              padding = array<i32: -1, 0>,
+              dilation = array<i32: 1, 1>,
+              groups = 1: i32
+            }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !tt.device<#device>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+#device = #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, d0 floordiv s0, d1 floordiv s1, (d0 mod s0) * s1 + d1 mod s1), dramMap = (d0, d1)[s0, s1] -> (0, 0, ((((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 8192) mod 12, (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 98304 + (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) mod 8192), meshShape = , chipIds = [0]>
+module {
+  func.func @conv2d_invalid_dilation_values(%arg0: tensor<1x1x1024x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
+    // CHECK: error: 'ttnn.conv2d' op Dilation attribute (-2, -2) must be greater than 0
+    %1 = "ttnn.conv2d"(%arg0, %arg1, %arg2, %0)
+            <{
+              in_channels = 64: i32,
+              out_channels = 64: i32,
+              batch_size = 1: i32,
+              input_height = 32: i32,
+              input_width = 32: i32,
+              kernel_size = array<i32: 3, 3>,
+              stride = array<i32: 1, 1>,
+              padding = array<i32: 0, 0>,
+              dilation = array<i32: -2, -2>,
+              groups = 1: i32
+            }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !tt.device<#device>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+#device = #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, d0 floordiv s0, d1 floordiv s1, (d0 mod s0) * s1 + d1 mod s1), dramMap = (d0, d1)[s0, s1] -> (0, 0, ((((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 8192) mod 12, (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 98304 + (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) mod 8192), meshShape = , chipIds = [0]>
+module {
+  func.func @conv2d_kernel_size_missmatch_with_weight_tensor(%arg0: tensor<1x1x1024x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
+    // CHECK: error: 'ttnn.conv2d' op Kernel size attribute (3, 5) must match the last two dimensions of the weight tensor (3, 3)
+    %1 = "ttnn.conv2d"(%arg0, %arg1, %arg2, %0)
+            <{
+              in_channels = 64: i32,
+              out_channels = 64: i32,
+              batch_size = 1: i32,
+              input_height = 32: i32,
+              input_width = 32: i32,
+              kernel_size = array<i32: 3, 5>,
+              stride = array<i32: 1, 1>,
+              padding = array<i32: 0, 0>,
+              dilation = array<i32: 1, 1>,
+              groups = 1: i32
+            }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !tt.device<#device>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+#device = #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, d0 floordiv s0, d1 floordiv s1, (d0 mod s0) * s1 + d1 mod s1), dramMap = (d0, d1)[s0, s1] -> (0, 0, ((((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 8192) mod 12, (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 98304 + (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) mod 8192), meshShape = , chipIds = [0]>
+module {
+  func.func @conv2d_input_channels_missmatch_with_input_tensor(%arg0: tensor<1x1x1024x64xbf16>, %arg1: tensor<64x32x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
+    // CHECK: error: 'ttnn.conv2d' op Expected input channels attribute (32) to match the last dimension of the input tensor (64)
+    %1 = "ttnn.conv2d"(%arg0, %arg1, %arg2, %0)
+            <{
+              in_channels = 32: i32,
+              out_channels = 64: i32,
+              batch_size = 1: i32,
+              input_height = 32: i32,
+              input_width = 32: i32,
+              kernel_size = array<i32: 3, 3>,
+              stride = array<i32: 1, 1>,
+              padding = array<i32: 0, 0>,
+              dilation = array<i32: 1, 1>,
+              groups = 1: i32
+            }> : (tensor<1x1x1024x64xbf16>, tensor<64x32x3x3xbf16>, tensor<1x1x1x64xbf16>, !tt.device<#device>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+#device = #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, d0 floordiv s0, d1 floordiv s1, (d0 mod s0) * s1 + d1 mod s1), dramMap = (d0, d1)[s0, s1] -> (0, 0, ((((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 8192) mod 12, (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 98304 + (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) mod 8192), meshShape = , chipIds = [0]>
+module {
+  func.func @conv2d_input_channels_missmatch_with_bias_tensor(%arg0: tensor<1x1x1024x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x1x900x32xbf16> {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
+    // CHECK: error: 'ttnn.conv2d' op Expected output channels attribute (32) to match the last dimension of the bias tensor (64)
+    %1 = "ttnn.conv2d"(%arg0, %arg1, %arg2, %0)
+            <{
+              in_channels = 64: i32,
+              out_channels = 32: i32,
+              batch_size = 1: i32,
+              input_height = 32: i32,
+              input_width = 32: i32,
+              kernel_size = array<i32: 3, 3>,
+              stride = array<i32: 1, 1>,
+              padding = array<i32: 0, 0>,
+              dilation = array<i32: 1, 1>,
+              groups = 1: i32
+            }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !tt.device<#device>) -> tensor<1x1x900x32xbf16>
+    return %1 : tensor<1x1x900x32xbf16>
+  }
+}
+
+// -----
+#device = #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, d0 floordiv s0, d1 floordiv s1, (d0 mod s0) * s1 + d1 mod s1), dramMap = (d0, d1)[s0, s1] -> (0, 0, ((((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 8192) mod 12, (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 98304 + (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) mod 8192), meshShape = , chipIds = [0]>
+module {
+  func.func @conv2d_input_channels_missmatch_with_output_tensor(%arg0: tensor<1x1x1024x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x32xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
+    // CHECK: error: 'ttnn.conv2d' op Expected output channels attribute (32) to match the last dimension of the output tensor (64)
+    %1 = "ttnn.conv2d"(%arg0, %arg1, %arg2, %0)
+            <{
+              in_channels = 64: i32,
+              out_channels = 32: i32,
+              batch_size = 1: i32,
+              input_height = 32: i32,
+              input_width = 32: i32,
+              kernel_size = array<i32: 3, 3>,
+              stride = array<i32: 1, 1>,
+              padding = array<i32: 0, 0>,
+              dilation = array<i32: 1, 1>,
+              groups = 1: i32
+            }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x32xbf16>, !tt.device<#device>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+#device = #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, d0 floordiv s0, d1 floordiv s1, (d0 mod s0) * s1 + d1 mod s1), dramMap = (d0, d1)[s0, s1] -> (0, 0, ((((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 8192) mod 12, (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 98304 + (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) mod 8192), meshShape = , chipIds = [0]>
+module {
+  func.func @conv2d_flattened_input_missmatch(%arg0: tensor<1x1x1024x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
+    // CHECK: error: 'ttnn.conv2d' op Input is flattened, so batch_size * input_height * input_width (2048) must match the third dimension of the input tensor (1024). Got batch_size = 2, input_height = 32, input_width = 32
+    %1 = "ttnn.conv2d"(%arg0, %arg1, %arg2, %0)
+            <{
+              in_channels = 64: i32,
+              out_channels = 64: i32,
+              batch_size = 2: i32,
+              input_height = 32: i32,
+              input_width = 32: i32,
+              kernel_size = array<i32: 3, 3>,
+              stride = array<i32: 1, 1>,
+              padding = array<i32: 0, 0>,
+              dilation = array<i32: 1, 1>,
+              groups = 1: i32
+            }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !tt.device<#device>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+#device = #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, d0 floordiv s0, d1 floordiv s1, (d0 mod s0) * s1 + d1 mod s1), dramMap = (d0, d1)[s0, s1] -> (0, 0, ((((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 8192) mod 12, (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 98304 + (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) mod 8192), meshShape = , chipIds = [0]>
+module {
+  func.func @conv2d_flattened_output_missmatch(%arg0: tensor<1x1x1024x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
+    // CHECK: error: 'ttnn.conv2d' op Output is flattened, so batch_size * output_height * output_width (840) must match the third dimension of the output tensor (900). Got batch_size = 2, output_height = 14, output_width = 30
+    %1 = "ttnn.conv2d"(%arg0, %arg1, %arg2, %0)
+            <{
+              in_channels = 64: i32,
+              out_channels = 64: i32,
+              batch_size = 2: i32,
+              input_height = 16: i32,
+              input_width = 32: i32,
+              kernel_size = array<i32: 3, 3>,
+              stride = array<i32: 1, 1>,
+              padding = array<i32: 0, 0>,
+              dilation = array<i32: 1, 1>,
+              groups = 1: i32
+            }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !tt.device<#device>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+#device = #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, d0 floordiv s0, d1 floordiv s1, (d0 mod s0) * s1 + d1 mod s1), dramMap = (d0, d1)[s0, s1] -> (0, 0, ((((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 8192) mod 12, (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 98304 + (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) mod 8192), meshShape = , chipIds = [0]>
+module {
+  func.func @conv2d_input_channels_not_divisible_by_group(%arg0: tensor<1x1x1024x64xbf16>, %arg1: tensor<96x64x3x3xbf16>, %arg2: tensor<1x1x1x96xbf16>) -> tensor<1x1x900x96xbf16> {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
+    // CHECK: error: 'ttnn.conv2d' op Number of input channels (64) must be divisible by the number of groups (3)
+    %1 = "ttnn.conv2d"(%arg0, %arg1, %arg2, %0)
+            <{
+              in_channels = 64: i32,
+              out_channels = 96: i32,
+              batch_size = 1: i32,
+              input_height = 32: i32,
+              input_width = 32: i32,
+              kernel_size = array<i32: 3, 3>,
+              stride = array<i32: 1, 1>,
+              padding = array<i32: 0, 0>,
+              dilation = array<i32: 1, 1>,
+              groups = 3: i32
+            }> : (tensor<1x1x1024x64xbf16>, tensor<96x64x3x3xbf16>, tensor<1x1x1x96xbf16>, !tt.device<#device>) -> tensor<1x1x900x96xbf16>
+    return %1 : tensor<1x1x900x96xbf16>
+  }
+}
+
+// -----
+#device = #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, d0 floordiv s0, d1 floordiv s1, (d0 mod s0) * s1 + d1 mod s1), dramMap = (d0, d1)[s0, s1] -> (0, 0, ((((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 8192) mod 12, (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 98304 + (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) mod 8192), meshShape = , chipIds = [0]>
+module {
+  func.func @conv2d_output_channels_missmatch_with_weight_tensor(%arg0: tensor<1x1x1024x64xbf16>, %arg1: tensor<32x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
+    // CHECK: error: 'ttnn.conv2d' op Number of output channels (64) must match the first dimension of the weight tensor (32)
+    %1 = "ttnn.conv2d"(%arg0, %arg1, %arg2, %0)
+            <{
+              in_channels = 64: i32,
+              out_channels = 64: i32,
+              batch_size = 1: i32,
+              input_height = 32: i32,
+              input_width = 32: i32,
+              kernel_size = array<i32: 3, 3>,
+              stride = array<i32: 1, 1>,
+              padding = array<i32: 0, 0>,
+              dilation = array<i32: 1, 1>,
+              groups = 1: i32
+            }> : (tensor<1x1x1024x64xbf16>, tensor<32x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !tt.device<#device>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+#device = #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, d0 floordiv s0, d1 floordiv s1, (d0 mod s0) * s1 + d1 mod s1), dramMap = (d0, d1)[s0, s1] -> (0, 0, ((((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 8192) mod 12, (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 98304 + (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) mod 8192), meshShape = , chipIds = [0]>
+module {
+  func.func @conv2d_input_channels_per_group_missmatch_with_weight_tensor(%arg0: tensor<1x1x1024x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x1x900x64xbf16> {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
+    // CHECK: error: 'ttnn.conv2d' op Number of input channels per group (32) must match the second dimension of the weight tensor (64)
+    %1 = "ttnn.conv2d"(%arg0, %arg1, %arg2, %0)
+            <{
+              in_channels = 64: i32,
+              out_channels = 64: i32,
+              batch_size = 1: i32,
+              input_height = 32: i32,
+              input_width = 32: i32,
+              kernel_size = array<i32: 3, 3>,
+              stride = array<i32: 1, 1>,
+              padding = array<i32: 0, 0>,
+              dilation = array<i32: 1, 1>,
+              groups = 2: i32
+            }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !tt.device<#device>) -> tensor<1x1x900x64xbf16>
+    return %1 : tensor<1x1x900x64xbf16>
+  }
+}
+
+// -----
+#device = #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, d0 floordiv s0, d1 floordiv s1, (d0 mod s0) * s1 + d1 mod s1), dramMap = (d0, d1)[s0, s1] -> (0, 0, ((((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 8192) mod 12, (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) floordiv 98304 + (((d0 floordiv s0) * 8 + d1 floordiv s1) * (s1 * s0) + (d0 mod s0) * s1 + d1 mod s1) mod 8192), meshShape = , chipIds = [0]>
+module {
+  func.func @conv2d_kernel_size_bigger_than_input_size(%arg0: tensor<4x1x1024x64xbf16>, %arg1: tensor<64x32x12x12xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<4x1x900x64xbf16> {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
+    // CHECK: error: 'ttnn.conv2d' op Calculated padded input size per channel: (36, 40). Kernel size: (67, 133). Kernel size can't be greater than actual input size
+    %1 = "ttnn.conv2d"(%arg0, %arg1, %arg2, %0)
+            <{
+              in_channels = 64: i32,
+              out_channels = 64: i32,
+              batch_size = 1: i32,
+              input_height = 32: i32,
+              input_width = 32: i32,
+              kernel_size = array<i32: 12, 12>,
+              stride = array<i32: 1, 1>,
+              padding = array<i32: 2, 4>,
+              dilation = array<i32: 6, 12>,
+              groups = 2: i32
+            }> : (tensor<4x1x1024x64xbf16>, tensor<64x32x12x12xbf16>, tensor<1x1x1x64xbf16>, !tt.device<#device>) -> tensor<4x1x900x64xbf16>
+    return %1 : tensor<4x1x900x64xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/conv2d/conv2d_tests_negative_padding.mlir
+++ b/test/ttmlir/Dialect/TTNN/conv2d/conv2d_tests_negative_padding.mlir
@@ -1,0 +1,17 @@
+// RUN: not ttmlir-opt --ttir-to-ttnn-backend-pipeline %s 2>&1 | FileCheck %s
+
+// TTNN does not support asymmetric padding
+module {
+  func.func @conv2d_padding_no_support_for_asymmteric_padding_ttnn(%arg0: tensor<8x32x32x64xbf16>, %arg1: tensor<256x64x3x3xbf16>, %arg2: tensor<1x1x1x256xbf16>) -> tensor<8x48x42x256xbf16> {
+    %0 = tensor.empty() : tensor<8x48x42x256xbf16>
+    // CHECK: error: failed to legalize operation 'ttir.conv2d'
+    %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
+            <{
+              stride = 1: i32,
+              padding = array<i32: 12, 8, 6, 4>,
+              dilation = 1: i32,
+              groups = 1: i32
+            }> : (tensor<8x32x32x64xbf16>, tensor<256x64x3x3xbf16>, tensor<1x1x1x256xbf16>, tensor<8x48x42x256xbf16>) -> tensor<8x48x42x256xbf16>
+    return %1 : tensor<8x48x42x256xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/conv2d/conv2d_tests_positive.mlir
+++ b/test/ttmlir/Dialect/TTNN/conv2d/conv2d_tests_positive.mlir
@@ -1,9 +1,8 @@
-// RUN: ttmlir-opt %s | FileCheck %s
-
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module {
   func.func @conv2d_simple(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x64xbf16> {
     %0 = tensor.empty() : tensor<1x30x30x64xbf16>
-    // CHECK: %[[C:.*]] = "ttir.conv2d"[[C:.*]]
+    // CHECK: "ttnn.conv2d"
     %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
             <{
               stride = 1: i32,
@@ -16,7 +15,7 @@ module {
 
   func.func @conv2d_stride_1(%arg0: tensor<3x32x32x8xbf16>, %arg1: tensor<16x8x3x3xbf16>, %arg2: tensor<1x1x1x16xbf16>) -> tensor<3x15x15x16xbf16> {
     %0 = tensor.empty() : tensor<3x15x15x16xbf16>
-    // CHECK: %[[C:.*]] = "ttir.conv2d"[[C:.*]]
+    // CHECK: "ttnn.conv2d"
     %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
             <{
               stride = 2: i32,
@@ -29,7 +28,7 @@ module {
 
   func.func @conv2d_stride_2(%arg0: tensor<4x32x32x16xbf16>, %arg1: tensor<8x16x3x3xbf16>, %arg2: tensor<1x1x1x8xbf16>) -> tensor<4x8x5x8xbf16> {
     %0 = tensor.empty() : tensor<4x8x5x8xbf16>
-    // CHECK: %[[C:.*]] = "ttir.conv2d"[[C:.*]]
+    // CHECK: "ttnn.conv2d"
     %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
             <{
               stride = array<i32: 4, 6>,
@@ -42,7 +41,7 @@ module {
 
   func.func @conv2d_padding_1(%arg0: tensor<32x32x32x4xbf16>, %arg1: tensor<8x4x3x3xbf16>, %arg2: tensor<1x1x1x8xbf16>) -> tensor<32x38x38x8xbf16> {
     %0 = tensor.empty() : tensor<32x38x38x8xbf16>
-    // CHECK: %[[C:.*]] = "ttir.conv2d"[[C:.*]]
+    // CHECK: "ttnn.conv2d"
     %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
             <{
               stride = 1: i32,
@@ -55,7 +54,7 @@ module {
 
   func.func @conv2d_padding_2(%arg0: tensor<16x32x32x32xbf16>, %arg1: tensor<128x32x3x3xbf16>, %arg2: tensor<1x1x1x128xbf16>) -> tensor<16x54x46x128xbf16> {
     %0 = tensor.empty() : tensor<16x54x46x128xbf16>
-    // CHECK: %[[C:.*]] = "ttir.conv2d"[[C:.*]]
+    // CHECK: "ttnn.conv2d"
     %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
             <{
               stride = 1: i32,
@@ -66,22 +65,9 @@ module {
     return %1 : tensor<16x54x46x128xbf16>
   }
 
-  func.func @conv2d_padding_3(%arg0: tensor<8x32x32x64xbf16>, %arg1: tensor<256x64x3x3xbf16>, %arg2: tensor<1x1x1x256xbf16>) -> tensor<8x48x42x256xbf16> {
-    %0 = tensor.empty() : tensor<8x48x42x256xbf16>
-    // CHECK: %[[C:.*]] = "ttir.conv2d"[[C:.*]]
-    %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
-            <{
-              stride = 1: i32,
-              padding = array<i32: 12, 8, 6, 4>,
-              dilation = 1: i32,
-              groups = 1: i32
-            }> : (tensor<8x32x32x64xbf16>, tensor<256x64x3x3xbf16>, tensor<1x1x1x256xbf16>, tensor<8x48x42x256xbf16>) -> tensor<8x48x42x256xbf16>
-    return %1 : tensor<8x48x42x256xbf16>
-  }
-
   func.func @conv2d_dilation_1(%arg0: tensor<16x32x32x128xbf16>, %arg1: tensor<64x128x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<16x24x24x64xbf16> {
     %0 = tensor.empty() : tensor<16x24x24x64xbf16>
-    // CHECK: %[[C:.*]] = "ttir.conv2d"[[C:.*]]
+    // CHECK: "ttnn.conv2d"
     %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
             <{
               stride = 1: i32,
@@ -94,7 +80,7 @@ module {
 
   func.func @conv2d_dilation_2(%arg0: tensor<32x32x32x16xbf16>, %arg1: tensor<64x16x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<32x20x28x64xbf16> {
     %0 = tensor.empty() : tensor<32x20x28x64xbf16>
-    // CHECK: %[[C:.*]] = "ttir.conv2d"[[C:.*]]
+    // CHECK: "ttnn.conv2d"
     %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
             <{
               stride = 1: i32,
@@ -107,7 +93,7 @@ module {
 
   func.func @conv2d_groups(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<128x16x3x3xbf16>, %arg2: tensor<1x1x1x128xbf16>) -> tensor<1x30x30x128xbf16> {
     %0 = tensor.empty() : tensor<1x30x30x128xbf16>
-    // CHECK: %[[C:.*]] = "ttir.conv2d"[[C:.*]]
+    // CHECK: "ttnn.conv2d"
     %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
             <{
               stride = 1: i32,
@@ -118,16 +104,16 @@ module {
     return %1 : tensor<1x30x30x128xbf16>
   }
 
-  func.func @conv2d_complex(%arg0: tensor<1x128x256x36xbf16>, %arg1: tensor<72x6x16x32xbf16>, %arg2: tensor<1x1x1x72xbf16>) -> tensor<1x9x9x72xbf16> {
-    %0 = tensor.empty() : tensor<1x9x9x72xbf16>
-    // CHECK: %[[C:.*]] = "ttir.conv2d"[[C:.*]]
+  func.func @conv2d_complex(%arg0: tensor<1x128x256x36xbf16>, %arg1: tensor<72x6x16x32xbf16>, %arg2: tensor<1x1x1x72xbf16>) -> tensor<1x9x10x72xbf16> {
+    %0 = tensor.empty() : tensor<1x9x10x72xbf16>
+    // CHECK: "ttnn.conv2d"
     %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
             <{
               stride = 10: i32,
-              padding = array<i32: 10, 12, 6, 8>,
+              padding = array<i32: 10, 12>,
               dilation = array<i32: 4, 6>,
               groups = 6: i32
-            }> : (tensor<1x128x256x36xbf16>, tensor<72x6x16x32xbf16>, tensor<1x1x1x72xbf16>, tensor<1x9x9x72xbf16>) -> tensor<1x9x9x72xbf16>
-    return %1 : tensor<1x9x9x72xbf16>
+            }> : (tensor<1x128x256x36xbf16>, tensor<72x6x16x32xbf16>, tensor<1x1x1x72xbf16>, tensor<1x9x10x72xbf16>) -> tensor<1x9x10x72xbf16>
+    return %1 : tensor<1x9x10x72xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/convolution/simple_conv2d.mlir
+++ b/test/ttmlir/Dialect/TTNN/convolution/simple_conv2d.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 
-module attributes {} {
+module {
   func.func @forward(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x32x32x64xbf16> {
     %0 = tensor.empty() : tensor<1x32x32x64xbf16>
     // CHECK: %[[C:.*]] = "ttnn.conv2d"[[C:.*]]

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_conv2d_config.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_conv2d_config.mlir
@@ -33,9 +33,22 @@
 >
 
 module attributes {tt.device = #device, tt.system_desc = #system_desc} {
-  func.func @forward(%arg0: tensor<1x32x32x64xbf16, #ttnn_layout>, %arg1: tensor<64x64x3x3xbf16, #ttnn_layout1>, %arg2: tensor<1x1x1x64xbf16, #ttnn_layout2>) -> tensor<1x30x30x64xbf16, #ttnn_layout3> {
+  func.func @forward(%arg0: tensor<1x1x1024x64xbf16, #ttnn_layout>, %arg1: tensor<64x64x3x3xbf16, #ttnn_layout1>, %arg2: tensor<1x1x1x64xbf16, #ttnn_layout2>) -> tensor<1x30x30x64xbf16, #ttnn_layout3> {
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !tt.device<#device>
-    %1 = "ttnn.conv2d"(%arg0, %arg1, %arg2, %0) <{batch_size = 1 : i32, conv2d_config = #conv2d_config, dilation = array<i32: 1, 1>, groups = 1 : i32, in_channels = 64 : i32, input_height = 32 : i32, input_width = 32 : i32, kernel_size = array<i32: 3, 3>, out_channels = 64 : i32, padding = array<i32: 0, 0>, stride = array<i32: 1, 1>}> : (tensor<1x32x32x64xbf16, #ttnn_layout>, tensor<64x64x3x3xbf16, #ttnn_layout1>, tensor<1x1x1x64xbf16, #ttnn_layout2>, !tt.device<#device>) -> tensor<1x1x900x64xbf16, #ttnn_layout4>
+    %1 = "ttnn.conv2d"(%arg0, %arg1, %arg2, %0)
+            <{
+              in_channels = 64 : i32,
+              out_channels = 64 : i32,
+              batch_size = 1 : i32,
+              input_height = 32 : i32,
+              input_width = 32 : i32,
+              kernel_size = array<i32: 3, 3>,
+              stride = array<i32: 1, 1>,
+              padding = array<i32: 0, 0>,
+              dilation = array<i32: 1, 1>,
+              groups = 1 : i32,
+              conv2d_config = #conv2d_config
+            }> : (tensor<1x1x1024x64xbf16, #ttnn_layout>, tensor<64x64x3x3xbf16, #ttnn_layout1>, tensor<1x1x1x64xbf16, #ttnn_layout2>, !tt.device<#device>) -> tensor<1x1x900x64xbf16, #ttnn_layout4>
     %2 = "ttnn.reshape"(%1) <{shape = [1 : i32, 30 : i32, 30 : i32, 64 : i32]}> : (tensor<1x1x900x64xbf16, #ttnn_layout4>) -> tensor<1x30x30x64xbf16, #ttnn_layout4>
     "ttnn.deallocate"(%1) <{force = false}> : (tensor<1x1x900x64xbf16, #ttnn_layout4>) -> ()
     %3 = "ttnn.from_device"(%2) : (tensor<1x30x30x64xbf16, #ttnn_layout4>) -> tensor<1x30x30x64xbf16, #ttnn_layout5>

--- a/test/ttmlir/Silicon/TTNN/n150/simple_conv2d.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_conv2d.mlir
@@ -2,7 +2,7 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-module attributes {} {
+module {
   func.func @forward(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x64xbf16> {
     %0 = tensor.empty() : tensor<1x30x30x64xbf16>
     // CHECK: %[[C:.*]] = "ttnn.conv2d"[[C:.*]]


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/1854)

### Problem description
The TTNN verification was previously reverted in [this commit](https://github.com/tenstorrent/tt-mlir/commit/cc6f36d02687d60a40b0e8712d81c4792becd1f0) to unblock the uplift of frontends. This PR restores the verification while improving test coverage.

### What's changed
- Reintroduce the reverted TTNN verification
- Add positive and negative tests for Conv2D TTNN verification
- Update the description for conv2d in tablegen files
