### PR TITLE
Uplift third_party/tt-metal to bec3eced688f5b154520abed9357aa6440c498db 2025-03-05

### DIFF
--- a/lib/OpModel/TTNN/Conversion.cpp
+++ b/lib/OpModel/TTNN/Conversion.cpp
@@ -91,9 +91,9 @@ getShardSpec(const mlir::tt::ttnn::TTNNLayoutAttr &layout) {
   // tt_ShardOrientation is not part of ttnn::TTNNLayoutAttr;
   // defaulting to ROW_MAJOR. TODO(jserbedzija): with issue #620
   return isShardedMemoryLayout(layout.getMemLayout().getValue())
-             ? std::make_optional(ShardSpec(getCoreRangeSet(layout),
-                                            getShardShape(layout),
-                                            ShardOrientation::ROW_MAJOR))
+             ? std::make_optional(::tt::tt_metal::ShardSpec(
+                   getCoreRangeSet(layout), getShardShape(layout),
+                   ::tt::tt_metal::ShardOrientation::ROW_MAJOR))
              : std::nullopt;
 }
 

--- a/lib/OpModel/TTNN/MetalHeaders.h
+++ b/lib/OpModel/TTNN/MetalHeaders.h
@@ -58,6 +58,9 @@
 #include "tt-metalium/host_api.hpp"
 #include "tt-metalium/small_vector.hpp"
 #include "ttnn/graph/graph_processor.hpp"
+// using namespace removed in metal
+// but IDevice cannot be resolved by "ttnn/graph/graph_query_op_constraints.hpp"
+using IDevice = ::tt::tt_metal::IDevice;
 #include "ttnn/graph/graph_query_op_constraints.hpp"
 #include "ttnn/graph/graph_query_op_runtime.hpp"
 #include "ttnn/graph/graph_trace_utils.hpp"

--- a/runtime/include/tt/runtime/detail/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal.h
@@ -114,7 +114,7 @@ createBufferFromTensorRef(::tt::tt_metal::IDevice *device,
   for (unsigned i = 0; i < shardRank - 1; ++i) {
     shardShape[0] *= layout->memory_desc()->shape()->Get(i);
   }
-  ShardSpec shardSpec(coreRangeSet, shardShape);
+  ::tt::tt_metal::ShardSpec shardSpec(coreRangeSet, shardShape);
   std::array<uint32_t, 2> pageShape = {static_cast<uint32_t>(tile_shape->y()),
                                        shardShape[1]};
 
@@ -135,25 +135,26 @@ createBufferFromTensorRef(::tt::tt_metal::IDevice *device,
       innerDim / pageShape[1],
   };
 
-  ShardSpecBuffer shardSpecBuffer(shardSpec, pageShape, tensorShape);
+  ::tt::tt_metal::ShardSpecBuffer shardSpecBuffer(shardSpec, pageShape,
+                                                  tensorShape);
   assert(memoryDesc->memory_space() == ::tt::target::MemorySpace::DeviceDRAM ||
          memoryDesc->memory_space() == ::tt::target::MemorySpace::DeviceL1);
-  BufferType bufferType =
+  ::tt::tt_metal::BufferType bufferType =
       memoryDesc->memory_space() == ::tt::target::MemorySpace::DeviceDRAM
-          ? BufferType::DRAM
-          : BufferType::L1;
+          ? ::tt::tt_metal::BufferType::DRAM
+          : ::tt::tt_metal::BufferType::L1;
 
   tt::target::DataType dataType = memoryDesc->data_type();
   uint64_t itemSize = ::tt::runtime::utils::dataTypeElementSize(dataType);
   uint64_t pageSize = pageShape[0] * pageShape[1] * itemSize;
   uint64_t size = tensorShape[0] * tensorShape[1] * pageSize;
-  auto shardedBufferConfig =
-      ShardedBufferConfig{.device = device,
-                          .size = size,
-                          .page_size = pageSize,
-                          .buffer_type = bufferType,
-                          .buffer_layout = TensorMemoryLayout::BLOCK_SHARDED,
-                          .shard_parameters = shardSpecBuffer};
+  auto shardedBufferConfig = ::tt::tt_metal::ShardedBufferConfig{
+      .device = device,
+      .size = size,
+      .page_size = pageSize,
+      .buffer_type = bufferType,
+      .buffer_layout = ::tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED,
+      .shard_parameters = shardSpecBuffer};
 
   assert(tensorRef->address());
   std::shared_ptr<::tt::tt_metal::Buffer> buffer =

--- a/runtime/lib/ttmetal/command_queue.cpp
+++ b/runtime/lib/ttmetal/command_queue.cpp
@@ -238,7 +238,9 @@ static void writeFile(std::string const &fileName, char const *data,
   file.close();
 }
 
-static std::variant<DataMovementConfig, ComputeConfig, EthernetConfig>
+static std::variant<::tt::tt_metal::DataMovementConfig,
+                    ::tt::tt_metal::ComputeConfig,
+                    ::tt::tt_metal::EthernetConfig>
 createKernelConfig(::tt::target::metal::KernelSource const *kernelSource) {
   switch (kernelSource->config_type()) {
   case ::tt::target::metal::KernelConfig::NocConfig: {
@@ -255,22 +257,22 @@ createKernelConfig(::tt::target::metal::KernelSource const *kernelSource) {
     ::tt::tt_metal::EthernetConfig ethernetConfig;
     switch (kernelSource->config_as_EthernetConfig()->eth_type()) {
     case tt::target::metal::EthType::Sender: {
-      ethernetConfig.eth_mode = Eth::SENDER;
+      ethernetConfig.eth_mode = ::tt::tt_metal::Eth::SENDER;
       break;
     }
     case tt::target::metal::EthType::Receiver: {
-      ethernetConfig.eth_mode = Eth::RECEIVER;
+      ethernetConfig.eth_mode = ::tt::tt_metal::Eth::RECEIVER;
       break;
     }
     }
 
     switch (kernelSource->config_as_EthernetConfig()->noc_index()) {
     case tt::target::metal::NocIndex::Noc0: {
-      ethernetConfig.noc = NOC::NOC_0;
+      ethernetConfig.noc = ::tt::tt_metal::NOC::NOC_0;
       break;
     }
     case tt::target::metal::NocIndex::Noc1: {
-      ethernetConfig.noc = NOC::NOC_1;
+      ethernetConfig.noc = ::tt::tt_metal::NOC::NOC_1;
       break;
     }
     }
@@ -374,13 +376,14 @@ static ::tt::tt_metal::CircularBufferConfig createCircularBufferConfig(
       toDataFormat(cbRef->desc()->memory_desc()->data_type());
 
   if (!cbRef->tensor_ref()) {
-    return CircularBufferConfig(totalSize,
-                                {{cbRef->desc()->port(), dataFormat}})
+    return ::tt::tt_metal::CircularBufferConfig(
+               totalSize, {{cbRef->desc()->port(), dataFormat}})
         .set_page_size(cbRef->desc()->port(), cbRef->desc()->page_size());
   }
 
-  return CircularBufferConfig(totalSize, {{cbRef->desc()->port(), dataFormat}},
-                              *buffers.at(cbRef->tensor_ref()->global_id()))
+  return ::tt::tt_metal::CircularBufferConfig(
+             totalSize, {{cbRef->desc()->port(), dataFormat}},
+             *buffers.at(cbRef->tensor_ref()->global_id()))
       .set_page_size(cbRef->desc()->port(), cbRef->desc()->page_size());
 }
 
@@ -456,8 +459,9 @@ void CQExecutor::execute(
                                                 coreRangeSet, kernelSource);
     writeFile(fileName, kernelSource->source()->c_str(),
               kernelSource->source()->size());
-    std::variant<DataMovementConfig, ComputeConfig, EthernetConfig> config =
-        createKernelConfig(kernelSource);
+    std::variant<::tt::tt_metal::DataMovementConfig,
+                 ::tt::tt_metal::ComputeConfig, ::tt::tt_metal::EthernetConfig>
+        config = createKernelConfig(kernelSource);
 
     ::tt::tt_metal::KernelHandle handle =
         ::tt::tt_metal::CreateKernel(program, fileName, coreRangeSet, config);
@@ -469,13 +473,13 @@ void CQExecutor::execute(
       }
       ::tt::tt_metal::CircularBufferConfig config =
           createCircularBufferConfig(cbRef, buffers);
-      CBHandle cbHandle =
+      ::tt::tt_metal::CBHandle cbHandle =
           ::tt::tt_metal::CreateCircularBuffer(program, coreRangeSet, config);
 
       if (!cbRef->tensor_ref()) {
         // Internally allocated CBs are not associated with any tensor ref. We
         // need to set the address of the CB manually.
-        std::shared_ptr<CircularBuffer> cbPtr =
+        std::shared_ptr<::tt::tt_metal::CircularBuffer> cbPtr =
             tt_metal::detail::GetCircularBuffer(program, cbHandle);
         assert(!cbPtr->globally_allocated() &&
                "CB should not be globally allocated");

--- a/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/utils.cpp
+++ b/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/utils.cpp
@@ -46,7 +46,7 @@ bool isTilized(const ::tt::target::ttnn::TensorRef *tensorRef) {
 
 ::ttnn::operations::conv::conv2d::Conv2dConfig
 createConv2dConfig(const ::tt::target::ttnn::Conv2dConfig *memcfg) {
-  std::optional<TensorMemoryLayout> shardLayout = std::nullopt;
+  std::optional<::tt::tt_metal::TensorMemoryLayout> shardLayout = std::nullopt;
   if (memcfg->shard_layout()) {
     shardLayout = ::tt::runtime::ttnn::utils::toTTNNTensorMemoryLayout(
         memcfg->shard_layout().value());

--- a/runtime/lib/ttnn/operations/reduction/argmax.cpp
+++ b/runtime/lib/ttnn/operations/reduction/argmax.cpp
@@ -18,9 +18,10 @@ runReductionArgMaxOp(::tt::target::ttnn::ReductionArgMaxOp const *op,
   std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
       ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
 
-  ::ttnn::Tensor out = ::ttnn::argmax(in, op->dim(), op->use_multicore(),
-                                      /*memory_config_arg=*/outputMemoryConfig,
-                                      /*optional_output_tensor=*/std::nullopt);
+  ::ttnn::Tensor out =
+      ::ttnn::argmax(in, op->dim(), std::nullopt, op->use_multicore(),
+                     /*memory_config_arg=*/outputMemoryConfig,
+                     /*optional_output_tensor=*/std::nullopt);
 
   tensorPool.insertAndValidate(op->out(), out);
 }

--- a/test/unittests/OpModel/TTNN/Conversion/TestConversion.cpp
+++ b/test/unittests/OpModel/TTNN/Conversion/TestConversion.cpp
@@ -295,8 +295,9 @@ TEST_P(ShardSpecFixture, ShardSpec) {
   // side, we are setting them to default values.
   // Purpose of testing them is to update the test
   // if the compiler side changes.
-  EXPECT_EQ(shardSpec->orientation, ShardOrientation::ROW_MAJOR);
-  EXPECT_EQ(shardSpec->mode, ShardMode::PHYSICAL);
+  EXPECT_EQ(shardSpec->orientation,
+            ::tt::tt_metal::ShardOrientation::ROW_MAJOR);
+  EXPECT_EQ(shardSpec->mode, ::tt::tt_metal::ShardMode::PHYSICAL);
   EXPECT_EQ(shardSpec->physical_shard_shape.has_value(), false);
 }
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "23791beeccca6323d0aa49d7d531c124ceb69e46")
+set(TT_METAL_VERSION "bec3eced688f5b154520abed9357aa6440c498db")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "f05457a1eb5b45fddbd60b35835439994e06ae9d")
+set(TT_METAL_VERSION "23791beeccca6323d0aa49d7d531c124ceb69e46")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the bec3eced688f5b154520abed9357aa6440c498db

- Use fully qualified tt_metal types after using namespace directive removed in metal commit 3b28664
- Point tt-metal to commit bec3ece for tilize_wh kernel fix after metal commit 6c77212
- Update argmax params after metal commit 5f6a7b1