### PR TITLE
1D Convolution where input spatial dimension isn't 2

### DIFF
--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -213,11 +213,6 @@ public:
       return failure();
     }
 
-    // Not currently supporting spatial dims other than 2 for the 1D case.
-    if (op.getConvolutionLayout().getInputSpatialDimensions()[0] != 2) {
-      return failure();
-    }
-
     // The shapes that the convolution currently operates with have are 3D, and
     // we need to add another dimension for it to match the conv2d signature, so
     // adding a dimension of size 1 to the end of input and output shapes.

--- a/test/ttmlir/Dialect/TTNN/convolution/simple_conv1d.mlir
+++ b/test/ttmlir/Dialect/TTNN/convolution/simple_conv1d.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module {
-  func.func @main(%arg0: tensor<1x256x512xf32>, %arg1: tensor<1024x256x1xf32>, %arg2: tensor<1024xf32>) -> tensor<1x1024x512xf32> {
+  func.func @conv1d_test1(%arg0: tensor<1x256x512xf32>, %arg1: tensor<1024x256x1xf32>, %arg2: tensor<1024xf32>) -> tensor<1x1024x512xf32> {
     %0 = tensor.empty() : tensor<1x1024x512xf32>
     // CHECK: "ttnn.reshape"
     // CHECK-SAME: shape = [1 : i32, 256 : i32, 512 : i32, 1 : i32]
@@ -16,5 +16,25 @@ module {
     %1 = "ttir.convolution"(%arg0, %arg1, %0) <{batch_group_count = 1 : i64, convolution_layout = #ttir<convolution_layout input_batch = 0, input_feature = 1, input_spatial_dimensions = 2, kernel_output_feature = 0, kernel_input_feature = 1, kernel_spatial_dimensions = 2, output_batch = 0, output_feature = 1, output_spatial_dimensions = 2>, feature_group_count = 1 : i64, input_dilation = array<i64: 1>, padding = array<i64: 0, 0>, weight_dilation = array<i64: 1>, window_reversal = array<i1: false>, window_strides = array<i64: 1>}> : (tensor<1x256x512xf32>, tensor<1024x256x1xf32>, tensor<1x1024x512xf32>) -> tensor<1x1024x512xf32>
     // CHECK: return %{{.*}} : tensor<1x1024x512xf32, #ttnn_layout3>
     return %1 : tensor<1x1024x512xf32>
+  }
+
+  func.func public @conv1d_test2(%arg0: tensor<1x7x768xbf16>, %arg1: tensor<1x192x768xbf16>) -> (tensor<1x7x768xbf16>) {
+    %0 = tensor.empty() : tensor<1x7x768xbf16>
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: shape = [1 : i32, 7 : i32, 768 : i32, 1 : i32]
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: shape = [1 : i32, 192 : i32, 768 : i32, 1 : i32]
+    // CHECK: "ttnn.permute"
+    // CHECK-SAME: permutation = array<i64: 0, 1, 3, 2>
+    // CHECK: "ttnn.permute"
+    // CHECK-SAME: permutation = array<i64: 2, 1, 0, 3>
+    // CHECK: "ttnn.conv2d"
+    // CHECK: "ttnn.permute"
+    // CHECK-SAME: permutation = array<i64: 0, 1, 3, 2>
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: shape = [1 : i32, 7 : i32, 768 : i32]
+    %1 = "ttir.convolution"(%arg0, %arg1, %0) <{batch_group_count = 1 : i64, convolution_layout = #ttir<convolution_layout input_batch = 0, input_feature = 2, input_spatial_dimensions = 1, kernel_output_feature = 2, kernel_input_feature = 1, kernel_spatial_dimensions = 0, output_batch = 0, output_feature = 2, output_spatial_dimensions = 1>, feature_group_count = 4 : i64, input_dilation = array<i64: 1>, padding = array<i64: 0, 0>, weight_dilation = array<i64: 1>, window_reversal = array<i1: false>, window_strides = array<i64: 1>}> : (tensor<1x7x768xbf16>, tensor<1x192x768xbf16>, tensor<1x7x768xbf16>) -> tensor<1x7x768xbf16>
+    // CHECK: return %{{.*}} : tensor<1x7x768xbf16, #ttnn_layout{{.*}}>
+    return %1 : tensor<1x7x768xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/convolution/simple_conv1d.mlir
+++ b/test/ttmlir/Dialect/TTNN/convolution/simple_conv1d.mlir
@@ -18,6 +18,7 @@ module {
     return %1 : tensor<1x1024x512xf32>
   }
 
+  // Test a different ordering of dimensions
   func.func public @conv1d_test2(%arg0: tensor<1x7x768xbf16>, %arg1: tensor<1x192x768xbf16>) -> (tensor<1x7x768xbf16>) {
     %0 = tensor.empty() : tensor<1x7x768xbf16>
     // CHECK: "ttnn.reshape"


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/2357

### Problem description
In TTIR to TTIR decomposition, `Legalize1DConvolutionPattern` is not currently supporting spatial dimensions other than 2.

### What's changed
This case is already supported and the check isn't necessary. After reshaping input and output to match 2D `ttir.convolution` op and the new `ttir.convolution` op is picked up by the `ConvolutionToConv2dPattern`, the dimensions are permuted and handled correctly.
Added a test for this case.

### Checklist
- [x] New/Existing tests provide coverage for changes
