### PR TITLE
Remove DPS interface for ttnn.argmax

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -688,7 +688,7 @@ def TTNN_MinOp : TTNN_ReductionOp<"min"> {
   }];
 }
 
-def TTNN_ArgMaxOp : TTNN_NamedDPSOp<"argmax"> {
+def TTNN_ArgMaxOp : TTNN_Op<"argmax"> {
   let summary = "Argmax reduction op.";
   let description = [{
     Determine the indices of the maximum values along a specified dimension of a tensor or over all elements in a tensor.
@@ -722,12 +722,7 @@ def TTNN_ArgMaxOp : TTNN_NamedDPSOp<"argmax"> {
   let arguments = (ins AnyRankedTensor:$input,
                        OptionalAttr<I32Attr>:$dim,
                        BoolAttr:$use_multicore,
-                       OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config,
-                       AnyRankedTensor:$output);
-
-  let extraClassDeclaration = [{
-      MutableOperandRange getDpsInitsMutable() { return getOutputMutable(); }
-    }];
+                       OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
 
   let results = (outs AnyRankedTensor:$result);
 }

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -382,7 +382,7 @@ public:
             ? mlir::cast<mlir::IntegerAttr>(dimArg->getValue().front())
             : nullptr,
         /*use_multicore*/ false, // Default tt-metal value.
-        /*memoryConfig*/ nullptr, adaptor.getOutput());
+        /*memoryConfig*/ nullptr);
     return success();
   }
 };

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -489,7 +489,6 @@ public:
         tt::ttnn_to_emitc::utils::convertBoolAttr(rewriter,
                                                   srcOp.getUseMulticoreAttr()),
         tt::ttnn_to_emitc::utils::createStdNullopt(rewriter),
-        tt::ttnn_to_emitc::utils::createStdNullopt(rewriter),
     });
 
     rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(

--- a/runtime/lib/ttnn/operations/reduction/argmax.cpp
+++ b/runtime/lib/ttnn/operations/reduction/argmax.cpp
@@ -21,9 +21,9 @@ runReductionArgMaxOp(::tt::target::ttnn::ReductionArgMaxOp const *op,
   std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
       ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
 
-  ::ttnn::Tensor out =
-      ::ttnn::argmax(in, op->dim(), op->use_multicore(),
-                     outputMemoryConfig /* memory_config_arg */, std::nullopt);
+  ::ttnn::Tensor out = ::ttnn::argmax(in, op->dim(), op->use_multicore(),
+                                      /*memory_config_arg=*/outputMemoryConfig,
+                                      /* optional_output_tensor=*/std::nullopt);
 
   tensorPool.insert_or_assign(op->out()->global_id(), out);
 }

--- a/test/ttmlir/Dialect/TTNN/reduction/simple_argmax.mlir
+++ b/test/ttmlir/Dialect/TTNN/reduction/simple_argmax.mlir
@@ -7,7 +7,6 @@ module attributes {} {
     // CHECK: "ttnn.argmax"
     // CHECK-SAME: {dim = 1 : i32, use_multicore = false}>
     // CHECK-SAME: tensor<64x64xf32
-    // CHECK-SAME: tensor<64x1xsi32
     // CHECK-SAME: -> tensor<64x1xsi32
     %1 = "ttir.argmax"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<64x64xf32>, tensor<64x1xi32>) -> tensor<64x1xi32>
     return %1 : tensor<64x1xi32>


### PR DESCRIPTION
### Ticket
closes #2360 

### Problem description
TTNN dialect is not using DPS interface anymore for non-element wise ops. 
However, ttnn.argmax is still using DPS interface probably due to timing of both PRs

### What's changed
Remove DPS interface for ttnn.argmax op

### Checklist
- [X] Existing tests provide coverage for changes
