### PR TITLE
Fix Debug build when -DTTMLIR_ENABLE_OPMODEL=ON

### DIFF
--- a/test/unittests/OpModel/TTNN/Lib/CMakeLists.txt
+++ b/test/unittests/OpModel/TTNN/Lib/CMakeLists.txt
@@ -8,6 +8,7 @@ TestOpModelLib.cpp
 
 target_compile_options(TestOpModelLib
     PRIVATE
+    -fno-rtti
 )
 
 target_include_directories(TestOpModelLib

--- a/test/unittests/OpModel/TTNN/Op/CMakeLists.txt
+++ b/test/unittests/OpModel/TTNN/Op/CMakeLists.txt
@@ -8,6 +8,7 @@ TestOpModelInterface.cpp
 
 target_compile_options(TestOpModelInterface
     PRIVATE
+    -fno-rtti
 )
 
 target_include_directories(TestOpModelInterface


### PR DESCRIPTION
We had a Debug build breakage when -DTTMLIR_ENABLE_OPMODEL=ON on main, so I am bringing back `fno-rtti` compile option to fix it.