### PR TITLE
Implement runtime tensor desc API

### DIFF
--- a/runtime/include/tt/runtime/detail/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal.h
@@ -35,7 +35,6 @@ std::vector<std::uint32_t> getShape(::tt::runtime::Tensor tensor);
 std::vector<std::uint32_t> getStride(::tt::runtime::Tensor tensor);
 std::uint32_t getElementSize(::tt::runtime::Tensor tensor);
 std::uint32_t getVolume(::tt::runtime::Tensor tensor);
-target::DataType getDtype(::tt::runtime::Tensor tensor);
 
 size_t getNumAvailableDevices();
 

--- a/runtime/include/tt/runtime/detail/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal.h
@@ -35,6 +35,7 @@ std::vector<std::uint32_t> getShape(::tt::runtime::Tensor tensor);
 std::vector<std::uint32_t> getStride(::tt::runtime::Tensor tensor);
 std::uint32_t getElementSize(::tt::runtime::Tensor tensor);
 std::uint32_t getVolume(::tt::runtime::Tensor tensor);
+TensorDesc getTensorDesc(::tt::runtime::Tensor tensor);
 
 size_t getNumAvailableDevices();
 

--- a/runtime/include/tt/runtime/detail/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal.h
@@ -71,8 +71,6 @@ std::string getOpLocInfo(OpContext opContextHandle);
 Tensor getOpOutputTensor(OpContext opContextHandle,
                          CallbackContext programContextHandle);
 
-std::vector<float> getTensorData(Tensor tensor);
-
 using InputBuffer =
     std::tuple<std::uint32_t, std::shared_ptr<::tt::tt_metal::Buffer>,
                std::shared_ptr<::tt::tt_metal::Event>>;

--- a/runtime/include/tt/runtime/detail/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal.h
@@ -30,11 +30,11 @@ inline Tensor createTensor(std::shared_ptr<void> data, TensorDesc const &desc) {
 }
 
 tt::target::DataType getTensorDataType(Tensor tensor);
-std::vector<std::byte> getDataBuffer(::tt::runtime::Tensor tensor);
-std::vector<std::uint32_t> getShape(::tt::runtime::Tensor tensor);
-std::vector<std::uint32_t> getStride(::tt::runtime::Tensor tensor);
-std::uint32_t getElementSize(::tt::runtime::Tensor tensor);
-std::uint32_t getVolume(::tt::runtime::Tensor tensor);
+std::vector<std::byte> getTensorDataBuffer(::tt::runtime::Tensor tensor);
+std::vector<std::uint32_t> getTensorShape(::tt::runtime::Tensor tensor);
+std::vector<std::uint32_t> getTensorStride(::tt::runtime::Tensor tensor);
+std::uint32_t getTensorElementSize(::tt::runtime::Tensor tensor);
+std::uint32_t getTensorVolume(::tt::runtime::Tensor tensor);
 TensorDesc getTensorDesc(::tt::runtime::Tensor tensor);
 
 size_t getNumAvailableDevices();

--- a/runtime/include/tt/runtime/detail/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal.h
@@ -30,6 +30,12 @@ inline Tensor createTensor(std::shared_ptr<void> data, TensorDesc const &desc) {
 }
 
 tt::target::DataType getTensorDataType(Tensor tensor);
+std::vector<std::byte> getDataBuffer(::tt::runtime::Tensor tensor);
+std::vector<std::uint32_t> getShape(::tt::runtime::Tensor tensor);
+std::vector<std::uint32_t> getStride(::tt::runtime::Tensor tensor);
+std::uint32_t getElementSize(::tt::runtime::Tensor tensor);
+std::uint32_t getVolume(::tt::runtime::Tensor tensor);
+target::DataType getDtype(::tt::runtime::Tensor tensor);
 
 size_t getNumAvailableDevices();
 

--- a/runtime/include/tt/runtime/detail/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn.h
@@ -99,6 +99,7 @@ std::vector<std::uint32_t> getShape(::tt::runtime::Tensor tensor);
 std::vector<std::uint32_t> getStride(::tt::runtime::Tensor tensor);
 std::uint32_t getElementSize(::tt::runtime::Tensor tensor);
 std::uint32_t getVolume(::tt::runtime::Tensor tensor);
+TensorDesc getTensorDesc(::tt::runtime::Tensor tensor);
 
 size_t getNumAvailableDevices();
 

--- a/runtime/include/tt/runtime/detail/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn.h
@@ -94,11 +94,11 @@ inline Tensor createTensor(Device device, Layout layout,
 
 tt::target::DataType getTensorDataType(Tensor tensor);
 
-std::vector<std::byte> getDataBuffer(::tt::runtime::Tensor tensor);
-std::vector<std::uint32_t> getShape(::tt::runtime::Tensor tensor);
-std::vector<std::uint32_t> getStride(::tt::runtime::Tensor tensor);
-std::uint32_t getElementSize(::tt::runtime::Tensor tensor);
-std::uint32_t getVolume(::tt::runtime::Tensor tensor);
+std::vector<std::byte> getTensorDataBuffer(::tt::runtime::Tensor tensor);
+std::vector<std::uint32_t> getTensorShape(::tt::runtime::Tensor tensor);
+std::vector<std::uint32_t> getTensorStride(::tt::runtime::Tensor tensor);
+std::uint32_t getTensorElementSize(::tt::runtime::Tensor tensor);
+std::uint32_t getTensorVolume(::tt::runtime::Tensor tensor);
 TensorDesc getTensorDesc(::tt::runtime::Tensor tensor);
 
 size_t getNumAvailableDevices();

--- a/runtime/include/tt/runtime/detail/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn.h
@@ -144,8 +144,6 @@ std::string getOpLocInfo(OpContext opContextHandle);
 Tensor getOpOutputTensor(OpContext opContextHandle,
                          CallbackContext programContextHandle);
 
-std::vector<float> getTensorData(Tensor tensor);
-
 std::vector<Tensor> submit(Device deviceHandle, Binary executableHandle,
                            std::uint32_t programIndex,
                            std::vector<Tensor> const &inputs);

--- a/runtime/include/tt/runtime/detail/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn.h
@@ -99,7 +99,6 @@ std::vector<std::uint32_t> getShape(::tt::runtime::Tensor tensor);
 std::vector<std::uint32_t> getStride(::tt::runtime::Tensor tensor);
 std::uint32_t getElementSize(::tt::runtime::Tensor tensor);
 std::uint32_t getVolume(::tt::runtime::Tensor tensor);
-target::DataType getDtype(::tt::runtime::Tensor tensor);
 
 size_t getNumAvailableDevices();
 

--- a/runtime/include/tt/runtime/detail/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn.h
@@ -94,6 +94,13 @@ inline Tensor createTensor(Device device, Layout layout,
 
 tt::target::DataType getTensorDataType(Tensor tensor);
 
+std::vector<std::byte> getDataBuffer(::tt::runtime::Tensor tensor);
+std::vector<std::uint32_t> getShape(::tt::runtime::Tensor tensor);
+std::vector<std::uint32_t> getStride(::tt::runtime::Tensor tensor);
+std::uint32_t getElementSize(::tt::runtime::Tensor tensor);
+std::uint32_t getVolume(::tt::runtime::Tensor tensor);
+target::DataType getDtype(::tt::runtime::Tensor tensor);
+
 size_t getNumAvailableDevices();
 
 Device

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -89,6 +89,12 @@ inline Tensor createTensor(Device device, Layout layout,
 }
 
 tt::target::DataType getTensorDataType(Tensor tensor);
+std::vector<std::byte> getDataBuffer(Tensor tensor);
+std::uint32_t getElementSize(Tensor tensor);
+std::uint32_t getVolume(Tensor tensor);
+std::vector<std::uint32_t> getShape(Tensor tensor);
+std::vector<std::uint32_t> getStride(Tensor tensor);
+TensorDesc getTensorDesc(Tensor tensor);
 
 size_t getNumAvailableDevices();
 

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -89,11 +89,11 @@ inline Tensor createTensor(Device device, Layout layout,
 }
 
 tt::target::DataType getTensorDataType(Tensor tensor);
-std::vector<std::byte> getDataBuffer(Tensor tensor);
-std::uint32_t getElementSize(Tensor tensor);
-std::uint32_t getVolume(Tensor tensor);
-std::vector<std::uint32_t> getShape(Tensor tensor);
-std::vector<std::uint32_t> getStride(Tensor tensor);
+std::vector<std::byte> getTensorDataBuffer(Tensor tensor);
+std::uint32_t getTensorElementSize(Tensor tensor);
+std::uint32_t getTensorVolume(Tensor tensor);
+std::vector<std::uint32_t> getTensorShape(Tensor tensor);
+std::vector<std::uint32_t> getTensorStride(Tensor tensor);
 TensorDesc getTensorDesc(Tensor tensor);
 
 size_t getNumAvailableDevices();

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -126,8 +126,6 @@ std::string getOpLocInfo(OpContext opContextHandle);
 Tensor getOpOutputTensor(OpContext opContextHandle,
                          CallbackContext programContextHandle);
 
-std::vector<float> getTensorData(Tensor tensor);
-
 std::vector<Tensor> submit(Device deviceHandle, Binary executableHandle,
                            std::uint32_t programIndex,
                            std::vector<Tensor> const &inputs);

--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -158,6 +158,7 @@ struct Tensor : public detail::RuntimeCheckedObjectImpl {
   std::vector<std::uint32_t> getShape();
   std::vector<std::uint32_t> getStride();
   target::DataType getDtype();
+  TensorDesc getTensorDesc();
 };
 
 struct Layout : public detail::RuntimeCheckedObjectImpl {

--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -151,6 +151,13 @@ struct Tensor : public detail::RuntimeCheckedObjectImpl {
          std::shared_ptr<void> eventHandle, DeviceRuntime runtime)
       : detail::RuntimeCheckedObjectImpl(handle, runtime), data(data),
         event(eventHandle, runtime) {}
+
+  std::vector<std::byte> getDataBuffer();
+  std::uint32_t getElementSize();
+  std::uint32_t getVolume();
+  std::vector<std::uint32_t> getShape();
+  std::vector<std::uint32_t> getStride();
+  target::DataType getDtype();
 };
 
 struct Layout : public detail::RuntimeCheckedObjectImpl {

--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -151,14 +151,6 @@ struct Tensor : public detail::RuntimeCheckedObjectImpl {
          std::shared_ptr<void> eventHandle, DeviceRuntime runtime)
       : detail::RuntimeCheckedObjectImpl(handle, runtime), data(data),
         event(eventHandle, runtime) {}
-
-  std::vector<std::byte> getDataBuffer();
-  std::uint32_t getElementSize();
-  std::uint32_t getVolume();
-  std::vector<std::uint32_t> getShape();
-  std::vector<std::uint32_t> getStride();
-  target::DataType getDtype();
-  TensorDesc getTensorDesc();
 };
 
 struct Layout : public detail::RuntimeCheckedObjectImpl {

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -621,4 +621,19 @@ std::uint32_t Tensor::getVolume() {
   LOG_FATAL("runtime is not enabled");
 }
 
+TensorDesc Tensor::getTensorDesc() {
+#if defined(TT_RUNTIME_ENABLE_TTNN)
+  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
+    return ::tt::runtime::ttnn::getTensorDesc(*this);
+  }
+#endif
+
+#if defined(TT_RUNTIME_ENABLE_TTMETAL)
+  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
+    return ::tt::runtime::ttmetal::getTensorDesc(*this);
+  }
+#endif
+  LOG_FATAL("runtime is not enabled");
+}
+
 } // namespace tt::runtime

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -515,106 +515,106 @@ Event submit(Device deviceHandle, Binary executableHandle,
 #endif
   LOG_FATAL("runtime is not enabled");
 }
-std::vector<std::byte> Tensor::getDataBuffer() {
+std::vector<std::byte> getDataBuffer(::tt::runtime::Tensor t) {
 #if defined(TT_RUNTIME_ENABLE_TTNN)
   if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::getDataBuffer(*this);
+    return ::tt::runtime::ttnn::getDataBuffer(t);
   }
 #endif
 
 #if defined(TT_RUNTIME_ENABLE_TTMETAL)
   if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::getDataBuffer(*this);
+    return ::tt::runtime::ttmetal::getDataBuffer(t);
   }
 #endif
   LOG_FATAL("runtime is not enabled");
 }
 
-std::vector<std::uint32_t> Tensor::getShape() {
+std::vector<std::uint32_t> getShape(::tt::runtime::Tensor t) {
 #if defined(TT_RUNTIME_ENABLE_TTNN)
   if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::getShape(*this);
+    return ::tt::runtime::ttnn::getShape(t);
   }
 #endif
 
 #if defined(TT_RUNTIME_ENABLE_TTMETAL)
   if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::getShape(*this);
+    return ::tt::runtime::ttmetal::getShape(t);
   }
 #endif
   LOG_FATAL("runtime is not enabled");
 }
 
-std::vector<std::uint32_t> Tensor::getStride() {
+std::vector<std::uint32_t> getStride(::tt::runtime::Tensor t) {
 #if defined(TT_RUNTIME_ENABLE_TTNN)
   if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::getStride(*this);
+    return ::tt::runtime::ttnn::getStride(t);
   }
 #endif
 
 #if defined(TT_RUNTIME_ENABLE_TTMETAL)
   if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::getStride(*this);
+    return ::tt::runtime::ttmetal::getStride(t);
   }
 #endif
   LOG_FATAL("runtime is not enabled");
 }
 
-target::DataType Tensor::getDtype() {
+target::DataType getDtype(::tt::runtime::Tensor t) {
 #if defined(TT_RUNTIME_ENABLE_TTNN)
   if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::getTensorDataType(*this);
+    return ::tt::runtime::ttnn::getTensorDataType(t);
   }
 #endif
 
 #if defined(TT_RUNTIME_ENABLE_TTMETAL)
   if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::getTensorDataType(*this);
+    return ::tt::runtime::ttmetal::getTensorDataType(t);
   }
 #endif
   LOG_FATAL("runtime is not enabled");
 }
 
-std::uint32_t Tensor::getElementSize() {
+std::uint32_t getElementSize(::tt::runtime::Tensor t) {
 #if defined(TT_RUNTIME_ENABLE_TTNN)
   if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::getElementSize(*this);
+    return ::tt::runtime::ttnn::getElementSize(t);
   }
 #endif
 
 #if defined(TT_RUNTIME_ENABLE_TTMETAL)
   if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::getElementSize(*this);
+    return ::tt::runtime::ttmetal::getElementSize(t);
   }
 #endif
   LOG_FATAL("runtime is not enabled");
 }
 
-std::uint32_t Tensor::getVolume() {
+std::uint32_t getVolume(::tt::runtime::Tensor t) {
 #if defined(TT_RUNTIME_ENABLE_TTNN)
   if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::getVolume(*this);
+    return ::tt::runtime::ttnn::getVolume(t);
   }
 #endif
 
 #if defined(TT_RUNTIME_ENABLE_TTMETAL)
   if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::getVolume(*this);
+    return ::tt::runtime::ttmetal::getVolume(t);
   }
 #endif
   LOG_FATAL("runtime is not enabled");
 }
 
-TensorDesc Tensor::getTensorDesc() {
+TensorDesc getTensorDesc(::tt::runtime::Tensor t) {
 #if defined(TT_RUNTIME_ENABLE_TTNN)
   if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::getTensorDesc(*this);
+    return ::tt::runtime::ttnn::getTensorDesc(t);
   }
 #endif
 
 #if defined(TT_RUNTIME_ENABLE_TTMETAL)
   if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::getTensorDesc(*this);
+    return ::tt::runtime::ttmetal::getTensorDesc(t);
   }
 #endif
   LOG_FATAL("runtime is not enabled");

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -579,13 +579,13 @@ std::vector<std::uint32_t> Tensor::getStride() {
 target::DataType Tensor::getDtype() {
 #if defined(TT_RUNTIME_ENABLE_TTNN)
   if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::getDtype(*this);
+    return ::tt::runtime::ttnn::getTensorDataType(*this);
   }
 #endif
 
 #if defined(TT_RUNTIME_ENABLE_TTMETAL)
   if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::getDtype(*this);
+    return ::tt::runtime::ttmetal::getTensorDataType(*this);
   }
 #endif
   LOG_FATAL("runtime is not enabled");

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -531,4 +531,94 @@ Event submit(Device deviceHandle, Binary executableHandle,
 #endif
   LOG_FATAL("runtime is not enabled");
 }
+std::vector<std::byte> Tensor::getDataBuffer() {
+#if defined(TT_RUNTIME_ENABLE_TTNN)
+  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
+    return ::tt::runtime::ttnn::getDataBuffer(*this);
+  }
+#endif
+
+#if defined(TT_RUNTIME_ENABLE_TTMETAL)
+  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
+    return ::tt::runtime::ttmetal::getDataBuffer(*this);
+  }
+#endif
+  LOG_FATAL("runtime is not enabled");
+}
+
+std::vector<std::uint32_t> Tensor::getShape() {
+#if defined(TT_RUNTIME_ENABLE_TTNN)
+  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
+    return ::tt::runtime::ttnn::getShape(*this);
+  }
+#endif
+
+#if defined(TT_RUNTIME_ENABLE_TTMETAL)
+  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
+    return ::tt::runtime::ttmetal::getShape(*this);
+  }
+#endif
+  LOG_FATAL("runtime is not enabled");
+}
+
+std::vector<std::uint32_t> Tensor::getStride() {
+#if defined(TT_RUNTIME_ENABLE_TTNN)
+  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
+    return ::tt::runtime::ttnn::getStride(*this);
+  }
+#endif
+
+#if defined(TT_RUNTIME_ENABLE_TTMETAL)
+  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
+    return ::tt::runtime::ttmetal::getStride(*this);
+  }
+#endif
+  LOG_FATAL("runtime is not enabled");
+}
+
+target::DataType Tensor::getDtype() {
+#if defined(TT_RUNTIME_ENABLE_TTNN)
+  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
+    return ::tt::runtime::ttnn::getDtype(*this);
+  }
+#endif
+
+#if defined(TT_RUNTIME_ENABLE_TTMETAL)
+  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
+    return ::tt::runtime::ttmetal::getDtype(*this);
+  }
+#endif
+  LOG_FATAL("runtime is not enabled");
+}
+
+std::uint32_t Tensor::getElementSize() {
+#if defined(TT_RUNTIME_ENABLE_TTNN)
+  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
+    return ::tt::runtime::ttnn::getElementSize(*this);
+  }
+#endif
+
+#if defined(TT_RUNTIME_ENABLE_TTMETAL)
+  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
+    return ::tt::runtime::ttmetal::getElementSize(*this);
+  }
+#endif
+  LOG_FATAL("runtime is not enabled");
+}
+
+std::uint32_t Tensor::getVolume() {
+#if defined(TT_RUNTIME_ENABLE_TTNN)
+  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
+    return ::tt::runtime::ttnn::getVolume(*this);
+  }
+#endif
+
+#if defined(TT_RUNTIME_ENABLE_TTMETAL)
+  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
+    return ::tt::runtime::ttmetal::getVolume(*this);
+  }
+#endif
+  LOG_FATAL("runtime is not enabled");
+}
+
 } // namespace tt::runtime

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -515,46 +515,46 @@ Event submit(Device deviceHandle, Binary executableHandle,
 #endif
   LOG_FATAL("runtime is not enabled");
 }
-std::vector<std::byte> getDataBuffer(::tt::runtime::Tensor t) {
+std::vector<std::byte> getTensorDataBuffer(::tt::runtime::Tensor t) {
 #if defined(TT_RUNTIME_ENABLE_TTNN)
   if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::getDataBuffer(t);
+    return ::tt::runtime::ttnn::getTensorDataBuffer(t);
   }
 #endif
 
 #if defined(TT_RUNTIME_ENABLE_TTMETAL)
   if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::getDataBuffer(t);
+    return ::tt::runtime::ttmetal::getTensorDataBuffer(t);
   }
 #endif
   LOG_FATAL("runtime is not enabled");
 }
 
-std::vector<std::uint32_t> getShape(::tt::runtime::Tensor t) {
+std::vector<std::uint32_t> getTensorShape(::tt::runtime::Tensor t) {
 #if defined(TT_RUNTIME_ENABLE_TTNN)
   if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::getShape(t);
+    return ::tt::runtime::ttnn::getTensorShape(t);
   }
 #endif
 
 #if defined(TT_RUNTIME_ENABLE_TTMETAL)
   if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::getShape(t);
+    return ::tt::runtime::ttmetal::getTensorShape(t);
   }
 #endif
   LOG_FATAL("runtime is not enabled");
 }
 
-std::vector<std::uint32_t> getStride(::tt::runtime::Tensor t) {
+std::vector<std::uint32_t> getTensorStride(::tt::runtime::Tensor t) {
 #if defined(TT_RUNTIME_ENABLE_TTNN)
   if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::getStride(t);
+    return ::tt::runtime::ttnn::getTensorStride(t);
   }
 #endif
 
 #if defined(TT_RUNTIME_ENABLE_TTMETAL)
   if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::getStride(t);
+    return ::tt::runtime::ttmetal::getTensorStride(t);
   }
 #endif
   LOG_FATAL("runtime is not enabled");
@@ -575,31 +575,31 @@ target::DataType getDtype(::tt::runtime::Tensor t) {
   LOG_FATAL("runtime is not enabled");
 }
 
-std::uint32_t getElementSize(::tt::runtime::Tensor t) {
+std::uint32_t getTensorElementSize(::tt::runtime::Tensor t) {
 #if defined(TT_RUNTIME_ENABLE_TTNN)
   if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::getElementSize(t);
+    return ::tt::runtime::ttnn::getTensorElementSize(t);
   }
 #endif
 
 #if defined(TT_RUNTIME_ENABLE_TTMETAL)
   if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::getElementSize(t);
+    return ::tt::runtime::ttmetal::getTensorElementSize(t);
   }
 #endif
   LOG_FATAL("runtime is not enabled");
 }
 
-std::uint32_t getVolume(::tt::runtime::Tensor t) {
+std::uint32_t getTensorVolume(::tt::runtime::Tensor t) {
 #if defined(TT_RUNTIME_ENABLE_TTNN)
   if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::getVolume(t);
+    return ::tt::runtime::ttnn::getTensorVolume(t);
   }
 #endif
 
 #if defined(TT_RUNTIME_ENABLE_TTMETAL)
   if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::getVolume(t);
+    return ::tt::runtime::ttmetal::getTensorVolume(t);
   }
 #endif
   LOG_FATAL("runtime is not enabled");

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -477,22 +477,6 @@ Tensor getOpOutputTensor(OpContext opContextHandle,
   LOG_FATAL("runtime is not enabled");
 }
 
-std::vector<float> getTensorData(Tensor tensor) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::getTensorData(tensor);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::getTensorData(tensor);
-  }
-#endif
-
-  LOG_FATAL("runtime is not enabled");
-}
-
 std::vector<Tensor> submit(Device deviceHandle, Binary executableHandle,
                            std::uint32_t programIndex,
                            std::vector<Tensor> const &inputHandles) {

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -357,27 +357,27 @@ Tensor getOpOutputTensor(OpContext opContextHandle,
   return createNullTensor();
 }
 
-std::vector<std::byte> getDataBuffer(::tt::runtime::Tensor tensor) {
+std::vector<std::byte> getTensorDataBuffer(::tt::runtime::Tensor tensor) {
   LOG_WARNING("getDataBuffer not implemented for metal runtime");
   return {};
 }
 
-std::vector<std::uint32_t> getShape(::tt::runtime::Tensor tensor) {
+std::vector<std::uint32_t> getTensorShape(::tt::runtime::Tensor tensor) {
   LOG_WARNING("getShape not implemented for metal runtime");
   return {};
 }
 
-std::vector<std::uint32_t> getStride(::tt::runtime::Tensor tensor) {
+std::vector<std::uint32_t> getTensorStride(::tt::runtime::Tensor tensor) {
   LOG_WARNING("getStride not implemented for metal runtime");
   return {};
 }
 
-std::uint32_t getElementSize(::tt::runtime::Tensor tensor) {
+std::uint32_t getTensorElementSize(::tt::runtime::Tensor tensor) {
   LOG_WARNING("getElementSize not implemented for metal runtime");
   return 0;
 }
 
-std::uint32_t getVolume(::tt::runtime::Tensor tensor) {
+std::uint32_t getTensorVolume(::tt::runtime::Tensor tensor) {
   LOG_WARNING("getVolume not implemented for metal runtime");
   return 0;
 }

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -388,4 +388,9 @@ std::uint32_t getVolume(::tt::runtime::Tensor tensor) {
   return 0;
 }
 
+TensorDesc getTensorDesc(::tt::runtime::Tensor tensor) {
+  LOG_WARNING("getTensorDesc not implemented for metal runtime");
+  return {};
+}
+
 } // namespace tt::runtime::ttmetal

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -357,12 +357,6 @@ Tensor getOpOutputTensor(OpContext opContextHandle,
   return createNullTensor();
 }
 
-std::vector<float> getTensorData(Tensor tensor) {
-  // Not implemented
-  LOG_WARNING("obtaining tensor data for metal runtime not implemented");
-  return {};
-}
-
 std::vector<std::byte> getDataBuffer(::tt::runtime::Tensor tensor) {
   LOG_WARNING("getDataBuffer not implemented for metal runtime");
   return {};

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -363,4 +363,33 @@ std::vector<float> getTensorData(Tensor tensor) {
   return {};
 }
 
+std::vector<std::byte> getDataBuffer(::tt::runtime::Tensor tensor) {
+  LOG_WARNING("getDataBuffer not implemented for metal runtime");
+  return {};
+}
+
+std::vector<std::uint32_t> getShape(::tt::runtime::Tensor tensor) {
+  LOG_WARNING("getShape not implemented for metal runtime");
+  return {};
+}
+
+std::vector<std::uint32_t> getStride(::tt::runtime::Tensor tensor) {
+  LOG_WARNING("getStride not implemented for metal runtime");
+  return {};
+}
+
+std::uint32_t getElementSize(::tt::runtime::Tensor tensor) {
+  LOG_WARNING("getElementSize not implemented for metal runtime");
+  return 0;
+}
+
+std::uint32_t getVolume(::tt::runtime::Tensor tensor) {
+  LOG_WARNING("getVolume not implemented for metal runtime");
+  return 0;
+}
+target::DataType getDtype(::tt::runtime::Tensor tensor) {
+  LOG_WARNING("getDtype not implemented for metal runtime");
+  return {};
+}
+
 } // namespace tt::runtime::ttmetal

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -387,9 +387,5 @@ std::uint32_t getVolume(::tt::runtime::Tensor tensor) {
   LOG_WARNING("getVolume not implemented for metal runtime");
   return 0;
 }
-target::DataType getDtype(::tt::runtime::Tensor tensor) {
-  LOG_WARNING("getDtype not implemented for metal runtime");
-  return {};
-}
 
 } // namespace tt::runtime::ttmetal

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -555,17 +555,18 @@ Tensor getOpOutputTensor(OpContext opContextHandle,
                 DeviceRuntime::TTNN);
 }
 
-std::vector<std::byte> getDataBuffer(::tt::runtime::Tensor tensor) {
+std::vector<std::byte> getTensorDataBuffer(::tt::runtime::Tensor tensor) {
   const ::ttnn::Tensor &ttnnTensor =
       tensor.as<::ttnn::Tensor>(DeviceRuntime::TTNN);
   void *dataPtr = nullptr;
-  std::vector<std::byte> dataVec(getElementSize(tensor) * getVolume(tensor));
+  std::vector<std::byte> dataVec(getTensorElementSize(tensor) *
+                                 getTensorVolume(tensor));
 
   // Need to `memcpy` in each case because the vector will go out of scope if we
   // wait until after the switch case
   switch (getTensorDataType(tensor)) {
   case target::DataType::BFP_BFloat4: {
-    dataVec.resize(sizeof(float) * getVolume(tensor));
+    dataVec.resize(sizeof(float) * getTensorVolume(tensor));
     auto vec = ttnnTensor.to_vector<float>();
     dataPtr = vec.data();
     LOG_ASSERT(dataPtr != nullptr);
@@ -573,7 +574,7 @@ std::vector<std::byte> getDataBuffer(::tt::runtime::Tensor tensor) {
     return dataVec;
   }
   case target::DataType::BFP_BFloat8: {
-    dataVec.resize(sizeof(float) * getVolume(tensor));
+    dataVec.resize(sizeof(float) * getTensorVolume(tensor));
     auto vec = ttnnTensor.to_vector<float>();
     dataPtr = vec.data();
     LOG_ASSERT(dataPtr != nullptr);
@@ -629,7 +630,7 @@ std::vector<std::byte> getDataBuffer(::tt::runtime::Tensor tensor) {
   }
 }
 
-std::vector<std::uint32_t> getShape(::tt::runtime::Tensor tensor) {
+std::vector<std::uint32_t> getTensorShape(::tt::runtime::Tensor tensor) {
   const ::ttnn::Tensor &ttnnTensor =
       tensor.as<::ttnn::Tensor>(DeviceRuntime::TTNN);
   std::vector<std::uint32_t> shape;
@@ -639,7 +640,7 @@ std::vector<std::uint32_t> getShape(::tt::runtime::Tensor tensor) {
   return shape;
 }
 
-std::vector<std::uint32_t> getStride(::tt::runtime::Tensor tensor) {
+std::vector<std::uint32_t> getTensorStride(::tt::runtime::Tensor tensor) {
   const ::ttnn::Tensor &ttnnTensor =
       tensor.as<::ttnn::Tensor>(DeviceRuntime::TTNN);
   std::vector<std::uint32_t> stride;
@@ -649,13 +650,13 @@ std::vector<std::uint32_t> getStride(::tt::runtime::Tensor tensor) {
   return stride;
 }
 
-std::uint32_t getElementSize(::tt::runtime::Tensor tensor) {
+std::uint32_t getTensorElementSize(::tt::runtime::Tensor tensor) {
   const ::ttnn::Tensor &ttnnTensor =
       tensor.as<::ttnn::Tensor>(DeviceRuntime::TTNN);
   return ttnnTensor.element_size();
 }
 
-std::uint32_t getVolume(::tt::runtime::Tensor tensor) {
+std::uint32_t getTensorVolume(::tt::runtime::Tensor tensor) {
   const ::ttnn::Tensor &ttnnTensor =
       tensor.as<::ttnn::Tensor>(DeviceRuntime::TTNN);
   return ttnnTensor.volume();
@@ -664,9 +665,9 @@ std::uint32_t getVolume(::tt::runtime::Tensor tensor) {
 TensorDesc getTensorDesc(::tt::runtime::Tensor tensor) {
   TensorDesc desc;
   desc.dataType = getTensorDataType(tensor);
-  desc.itemsize = getElementSize(tensor);
-  desc.stride = getStride(tensor);
-  desc.shape = getShape(tensor);
+  desc.itemsize = getTensorElementSize(tensor);
+  desc.stride = getTensorStride(tensor);
+  desc.shape = getTensorShape(tensor);
   return desc;
 }
 

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -559,8 +559,7 @@ std::vector<std::byte> getDataBuffer(::tt::runtime::Tensor tensor) {
   const ::ttnn::Tensor &ttnnTensor =
       tensor.as<::ttnn::Tensor>(DeviceRuntime::TTNN);
   void *dataPtr = nullptr;
-  size_t numBytes = getElementSize(tensor) * getVolume(tensor);
-  std::vector<std::byte> dataVec(numBytes);
+  std::vector<std::byte> dataVec(getElementSize(tensor) * getVolume(tensor));
 
   // Need to `memcpy` in each case because the vector will go out of scope if we
   // wait until after the switch case
@@ -570,7 +569,7 @@ std::vector<std::byte> getDataBuffer(::tt::runtime::Tensor tensor) {
     auto vec = ttnnTensor.to_vector<float>();
     dataPtr = vec.data();
     LOG_ASSERT(dataPtr != nullptr);
-    std::memcpy(dataVec.data(), dataPtr, numBytes);
+    std::memcpy(dataVec.data(), dataPtr, dataVec.size());
     return dataVec;
   }
   case target::DataType::BFP_BFloat8: {
@@ -578,49 +577,49 @@ std::vector<std::byte> getDataBuffer(::tt::runtime::Tensor tensor) {
     auto vec = ttnnTensor.to_vector<float>();
     dataPtr = vec.data();
     LOG_ASSERT(dataPtr != nullptr);
-    std::memcpy(dataVec.data(), dataPtr, numBytes);
+    std::memcpy(dataVec.data(), dataPtr, dataVec.size());
     return dataVec;
   }
   case target::DataType::Float32: {
     auto vec = ttnnTensor.to_vector<float>();
     dataPtr = vec.data();
     LOG_ASSERT(dataPtr != nullptr);
-    std::memcpy(dataVec.data(), dataPtr, numBytes);
+    std::memcpy(dataVec.data(), dataPtr, dataVec.size());
     return dataVec;
   }
   case target::DataType::BFloat16: {
     auto vec = ttnnTensor.to_vector<bfloat16>();
     dataPtr = vec.data();
     LOG_ASSERT(dataPtr != nullptr);
-    std::memcpy(dataVec.data(), dataPtr, numBytes);
+    std::memcpy(dataVec.data(), dataPtr, dataVec.size());
     return dataVec;
   }
   case target::DataType::Int32: {
     auto vec = ttnnTensor.to_vector<std::int32_t>();
     dataPtr = vec.data();
     LOG_ASSERT(dataPtr != nullptr);
-    std::memcpy(dataVec.data(), dataPtr, numBytes);
+    std::memcpy(dataVec.data(), dataPtr, dataVec.size());
     return dataVec;
   }
   case target::DataType::UInt32: {
     auto vec = ttnnTensor.to_vector<std::uint32_t>();
     dataPtr = vec.data();
     LOG_ASSERT(dataPtr != nullptr);
-    std::memcpy(dataVec.data(), dataPtr, numBytes);
+    std::memcpy(dataVec.data(), dataPtr, dataVec.size());
     return dataVec;
   }
   case target::DataType::UInt16: {
     auto vec = ttnnTensor.to_vector<std::uint16_t>();
     dataPtr = vec.data();
     LOG_ASSERT(dataPtr != nullptr);
-    std::memcpy(dataVec.data(), dataPtr, numBytes);
+    std::memcpy(dataVec.data(), dataPtr, dataVec.size());
     return dataVec;
   }
   case target::DataType::UInt8: {
     auto vec = ttnnTensor.to_vector<std::uint8_t>();
     dataPtr = vec.data();
     LOG_ASSERT(dataPtr != nullptr);
-    std::memcpy(dataVec.data(), dataPtr, numBytes);
+    std::memcpy(dataVec.data(), dataPtr, dataVec.size());
     return dataVec;
   }
   default:

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -567,6 +567,83 @@ std::vector<float> getTensorData(Tensor tensor) {
                             static_cast<float *>(dataPtr) + nnTensor->volume());
 }
 
+std::vector<std::byte> getDataBuffer(::tt::runtime::Tensor tensor) {
+  auto ttnnTensor = static_cast<::ttnn::Tensor *>(tensor.handle.get());
+  void *dataPtr = nullptr;
+  size_t numBytes = getElementSize(tensor) * getVolume(tensor);
+  std::vector<std::byte> dataVec(numBytes);
+
+  // Need to `memcpy` in each case because the vector will go out of scope if we
+  // wait until after the switch case
+  switch (getDtype(tensor)) {
+  case target::DataType::BFP_BFloat4:
+  case target::DataType::BFP_BFloat8:
+  case target::DataType::Float32:
+    dataPtr = ttnnTensor->to_vector<float>().data();
+    assert(dataPtr != nullptr);
+    std::memcpy(dataVec.data(), dataPtr, numBytes);
+    return dataVec;
+  case target::DataType::BFloat16:
+    dataPtr = ttnnTensor->to_vector<bfloat16>().data();
+    assert(dataPtr != nullptr);
+    std::memcpy(dataVec.data(), dataPtr, numBytes);
+    return dataVec;
+  case target::DataType::Int32:
+    dataPtr = ttnnTensor->to_vector<std::int32_t>().data();
+    assert(dataPtr != nullptr);
+    std::memcpy(dataVec.data(), dataPtr, numBytes);
+    return dataVec;
+  case target::DataType::UInt32:
+    dataPtr = ttnnTensor->to_vector<std::uint32_t>().data();
+    assert(dataPtr != nullptr);
+    std::memcpy(dataVec.data(), dataPtr, numBytes);
+    return dataVec;
+  case target::DataType::UInt16:
+    dataPtr = ttnnTensor->to_vector<std::uint16_t>().data();
+    assert(dataPtr != nullptr);
+    std::memcpy(dataVec.data(), dataPtr, numBytes);
+    return dataVec;
+  case target::DataType::UInt8:
+    dataPtr = ttnnTensor->to_vector<std::uint8_t>().data();
+    assert(dataPtr != nullptr);
+    std::memcpy(dataVec.data(), dataPtr, numBytes);
+    return dataVec;
+  default:
+    LOG_ERROR("Unsupported datatype for underlying TTNN tensor, returning "
+              "empty data vector");
+    return {};
+  }
+}
+
+std::vector<std::uint32_t> getShape(::tt::runtime::Tensor tensor) {
+  auto ttnnTensor = static_cast<::ttnn::Tensor *>(tensor.handle.get());
+  std::vector<std::uint32_t> shape(ttnnTensor->logical_shape().cbegin(),
+                                   ttnnTensor->logical_shape().cend());
+  return shape;
+}
+
+std::vector<std::uint32_t> getStride(::tt::runtime::Tensor tensor) {
+  auto ttnnTensor = static_cast<::ttnn::Tensor *>(tensor.handle.get());
+  std::vector<std::uint32_t> stride(ttnnTensor->strides().cbegin(),
+                                    ttnnTensor->strides().cend());
+  return stride;
+}
+
+std::uint32_t getElementSize(::tt::runtime::Tensor tensor) {
+  auto ttnnTensor = static_cast<::ttnn::Tensor *>(tensor.handle.get());
+  return ttnnTensor->element_size();
+}
+
+std::uint32_t getVolume(::tt::runtime::Tensor tensor) {
+  auto ttnnTensor = static_cast<::ttnn::Tensor *>(tensor.handle.get());
+  return ttnnTensor->volume();
+}
+
+target::DataType getDtype(::tt::runtime::Tensor tensor) {
+  auto ttnnTensor = static_cast<::ttnn::Tensor *>(tensor.handle.get());
+  return utils::fromTTNNDataType(ttnnTensor->dtype());
+}
+
 std::vector<Tensor> submit(Device deviceHandle, Binary executableHandle,
                            std::uint32_t programIndex,
                            std::vector<Tensor> const &inputHandles) {

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -619,16 +619,20 @@ std::vector<std::byte> getDataBuffer(::tt::runtime::Tensor tensor) {
 std::vector<std::uint32_t> getShape(::tt::runtime::Tensor tensor) {
   const ::ttnn::Tensor &ttnnTensor =
       tensor.as<::ttnn::Tensor>(DeviceRuntime::TTNN);
-  std::vector<std::uint32_t> shape(ttnnTensor.logical_shape().cbegin(),
-                                   ttnnTensor.logical_shape().cend());
+  std::vector<std::uint32_t> shape;
+  for (size_t i = 0; i < ttnnTensor.logical_shape().size(); ++i) {
+    shape.push_back(ttnnTensor.logical_shape()[i]);
+  }
   return shape;
 }
 
 std::vector<std::uint32_t> getStride(::tt::runtime::Tensor tensor) {
   const ::ttnn::Tensor &ttnnTensor =
       tensor.as<::ttnn::Tensor>(DeviceRuntime::TTNN);
-  std::vector<std::uint32_t> stride(ttnnTensor.strides().cbegin(),
-                                    ttnnTensor.strides().cend());
+  std::vector<std::uint32_t> stride;
+  for (size_t i = 0; i < ttnnTensor.strides().size(); ++i) {
+    stride.push_back(ttnnTensor.strides()[i]);
+  }
   return stride;
 }
 
@@ -642,6 +646,15 @@ std::uint32_t getVolume(::tt::runtime::Tensor tensor) {
   const ::ttnn::Tensor &ttnnTensor =
       tensor.as<::ttnn::Tensor>(DeviceRuntime::TTNN);
   return ttnnTensor.volume();
+}
+
+TensorDesc getTensorDesc(::tt::runtime::Tensor tensor) {
+  TensorDesc desc;
+  desc.dataType = getTensorDataType(tensor);
+  desc.itemsize = getElementSize(tensor);
+  desc.stride = getStride(tensor);
+  desc.shape = getShape(tensor);
+  return desc;
 }
 
 std::vector<Tensor> submit(Device deviceHandle, Binary executableHandle,

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -568,44 +568,45 @@ std::vector<float> getTensorData(Tensor tensor) {
 }
 
 std::vector<std::byte> getDataBuffer(::tt::runtime::Tensor tensor) {
-  auto ttnnTensor = static_cast<::ttnn::Tensor *>(tensor.handle.get());
+  const ::ttnn::Tensor &ttnnTensor =
+      tensor.as<::ttnn::Tensor>(DeviceRuntime::TTNN);
   void *dataPtr = nullptr;
   size_t numBytes = getElementSize(tensor) * getVolume(tensor);
   std::vector<std::byte> dataVec(numBytes);
 
   // Need to `memcpy` in each case because the vector will go out of scope if we
   // wait until after the switch case
-  switch (getDtype(tensor)) {
+  switch (getTensorDataType(tensor)) {
   case target::DataType::BFP_BFloat4:
   case target::DataType::BFP_BFloat8:
   case target::DataType::Float32:
-    dataPtr = ttnnTensor->to_vector<float>().data();
-    assert(dataPtr != nullptr);
+    dataPtr = ttnnTensor.to_vector<float>().data();
+    LOG_ASSERT(dataPtr != nullptr);
     std::memcpy(dataVec.data(), dataPtr, numBytes);
     return dataVec;
   case target::DataType::BFloat16:
-    dataPtr = ttnnTensor->to_vector<bfloat16>().data();
-    assert(dataPtr != nullptr);
+    dataPtr = ttnnTensor.to_vector<bfloat16>().data();
+    LOG_ASSERT(dataPtr != nullptr);
     std::memcpy(dataVec.data(), dataPtr, numBytes);
     return dataVec;
   case target::DataType::Int32:
-    dataPtr = ttnnTensor->to_vector<std::int32_t>().data();
-    assert(dataPtr != nullptr);
+    dataPtr = ttnnTensor.to_vector<std::int32_t>().data();
+    LOG_ASSERT(dataPtr != nullptr);
     std::memcpy(dataVec.data(), dataPtr, numBytes);
     return dataVec;
   case target::DataType::UInt32:
-    dataPtr = ttnnTensor->to_vector<std::uint32_t>().data();
-    assert(dataPtr != nullptr);
+    dataPtr = ttnnTensor.to_vector<std::uint32_t>().data();
+    LOG_ASSERT(dataPtr != nullptr);
     std::memcpy(dataVec.data(), dataPtr, numBytes);
     return dataVec;
   case target::DataType::UInt16:
-    dataPtr = ttnnTensor->to_vector<std::uint16_t>().data();
-    assert(dataPtr != nullptr);
+    dataPtr = ttnnTensor.to_vector<std::uint16_t>().data();
+    LOG_ASSERT(dataPtr != nullptr);
     std::memcpy(dataVec.data(), dataPtr, numBytes);
     return dataVec;
   case target::DataType::UInt8:
-    dataPtr = ttnnTensor->to_vector<std::uint8_t>().data();
-    assert(dataPtr != nullptr);
+    dataPtr = ttnnTensor.to_vector<std::uint8_t>().data();
+    LOG_ASSERT(dataPtr != nullptr);
     std::memcpy(dataVec.data(), dataPtr, numBytes);
     return dataVec;
   default:
@@ -616,32 +617,31 @@ std::vector<std::byte> getDataBuffer(::tt::runtime::Tensor tensor) {
 }
 
 std::vector<std::uint32_t> getShape(::tt::runtime::Tensor tensor) {
-  auto ttnnTensor = static_cast<::ttnn::Tensor *>(tensor.handle.get());
-  std::vector<std::uint32_t> shape(ttnnTensor->logical_shape().cbegin(),
-                                   ttnnTensor->logical_shape().cend());
+  const ::ttnn::Tensor &ttnnTensor =
+      tensor.as<::ttnn::Tensor>(DeviceRuntime::TTNN);
+  std::vector<std::uint32_t> shape(ttnnTensor.logical_shape().cbegin(),
+                                   ttnnTensor.logical_shape().cend());
   return shape;
 }
 
 std::vector<std::uint32_t> getStride(::tt::runtime::Tensor tensor) {
-  auto ttnnTensor = static_cast<::ttnn::Tensor *>(tensor.handle.get());
-  std::vector<std::uint32_t> stride(ttnnTensor->strides().cbegin(),
-                                    ttnnTensor->strides().cend());
+  const ::ttnn::Tensor &ttnnTensor =
+      tensor.as<::ttnn::Tensor>(DeviceRuntime::TTNN);
+  std::vector<std::uint32_t> stride(ttnnTensor.strides().cbegin(),
+                                    ttnnTensor.strides().cend());
   return stride;
 }
 
 std::uint32_t getElementSize(::tt::runtime::Tensor tensor) {
-  auto ttnnTensor = static_cast<::ttnn::Tensor *>(tensor.handle.get());
-  return ttnnTensor->element_size();
+  const ::ttnn::Tensor &ttnnTensor =
+      tensor.as<::ttnn::Tensor>(DeviceRuntime::TTNN);
+  return ttnnTensor.element_size();
 }
 
 std::uint32_t getVolume(::tt::runtime::Tensor tensor) {
-  auto ttnnTensor = static_cast<::ttnn::Tensor *>(tensor.handle.get());
-  return ttnnTensor->volume();
-}
-
-target::DataType getDtype(::tt::runtime::Tensor tensor) {
-  auto ttnnTensor = static_cast<::ttnn::Tensor *>(tensor.handle.get());
-  return utils::fromTTNNDataType(ttnnTensor->dtype());
+  const ::ttnn::Tensor &ttnnTensor =
+      tensor.as<::ttnn::Tensor>(DeviceRuntime::TTNN);
+  return ttnnTensor.volume();
 }
 
 std::vector<Tensor> submit(Device deviceHandle, Binary executableHandle,

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -555,18 +555,6 @@ Tensor getOpOutputTensor(OpContext opContextHandle,
                 DeviceRuntime::TTNN);
 }
 
-std::vector<float> getTensorData(Tensor tensor) {
-  const ::ttnn::Tensor *nnTensor =
-      static_cast<::ttnn::Tensor *>(tensor.handle.get());
-  if (nnTensor == nullptr) {
-    return {};
-  }
-
-  void *dataPtr = ::tt::tt_metal::get_raw_host_data_ptr(*nnTensor);
-  return std::vector<float>(static_cast<float *>(dataPtr),
-                            static_cast<float *>(dataPtr) + nnTensor->volume());
-}
-
 std::vector<std::byte> getDataBuffer(::tt::runtime::Tensor tensor) {
   const ::ttnn::Tensor &ttnnTensor =
       tensor.as<::ttnn::Tensor>(DeviceRuntime::TTNN);

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -577,38 +577,64 @@ std::vector<std::byte> getDataBuffer(::tt::runtime::Tensor tensor) {
   // Need to `memcpy` in each case because the vector will go out of scope if we
   // wait until after the switch case
   switch (getTensorDataType(tensor)) {
-  case target::DataType::BFP_BFloat4:
-  case target::DataType::BFP_BFloat8:
-  case target::DataType::Float32:
-    dataPtr = ttnnTensor.to_vector<float>().data();
+  case target::DataType::BFP_BFloat4: {
+    dataVec.resize(sizeof(float) * getVolume(tensor));
+    auto vec = ttnnTensor.to_vector<float>();
+    dataPtr = vec.data();
     LOG_ASSERT(dataPtr != nullptr);
     std::memcpy(dataVec.data(), dataPtr, numBytes);
     return dataVec;
-  case target::DataType::BFloat16:
-    dataPtr = ttnnTensor.to_vector<bfloat16>().data();
+  }
+  case target::DataType::BFP_BFloat8: {
+    dataVec.resize(sizeof(float) * getVolume(tensor));
+    auto vec = ttnnTensor.to_vector<float>();
+    dataPtr = vec.data();
     LOG_ASSERT(dataPtr != nullptr);
     std::memcpy(dataVec.data(), dataPtr, numBytes);
     return dataVec;
-  case target::DataType::Int32:
-    dataPtr = ttnnTensor.to_vector<std::int32_t>().data();
+  }
+  case target::DataType::Float32: {
+    auto vec = ttnnTensor.to_vector<float>();
+    dataPtr = vec.data();
     LOG_ASSERT(dataPtr != nullptr);
     std::memcpy(dataVec.data(), dataPtr, numBytes);
     return dataVec;
-  case target::DataType::UInt32:
-    dataPtr = ttnnTensor.to_vector<std::uint32_t>().data();
+  }
+  case target::DataType::BFloat16: {
+    auto vec = ttnnTensor.to_vector<bfloat16>();
+    dataPtr = vec.data();
     LOG_ASSERT(dataPtr != nullptr);
     std::memcpy(dataVec.data(), dataPtr, numBytes);
     return dataVec;
-  case target::DataType::UInt16:
-    dataPtr = ttnnTensor.to_vector<std::uint16_t>().data();
+  }
+  case target::DataType::Int32: {
+    auto vec = ttnnTensor.to_vector<std::int32_t>();
+    dataPtr = vec.data();
     LOG_ASSERT(dataPtr != nullptr);
     std::memcpy(dataVec.data(), dataPtr, numBytes);
     return dataVec;
-  case target::DataType::UInt8:
-    dataPtr = ttnnTensor.to_vector<std::uint8_t>().data();
+  }
+  case target::DataType::UInt32: {
+    auto vec = ttnnTensor.to_vector<std::uint32_t>();
+    dataPtr = vec.data();
     LOG_ASSERT(dataPtr != nullptr);
     std::memcpy(dataVec.data(), dataPtr, numBytes);
     return dataVec;
+  }
+  case target::DataType::UInt16: {
+    auto vec = ttnnTensor.to_vector<std::uint16_t>();
+    dataPtr = vec.data();
+    LOG_ASSERT(dataPtr != nullptr);
+    std::memcpy(dataVec.data(), dataPtr, numBytes);
+    return dataVec;
+  }
+  case target::DataType::UInt8: {
+    auto vec = ttnnTensor.to_vector<std::uint8_t>();
+    dataPtr = vec.data();
+    LOG_ASSERT(dataPtr != nullptr);
+    std::memcpy(dataVec.data(), dataPtr, numBytes);
+    return dataVec;
+  }
   default:
     LOG_ERROR("Unsupported datatype for underlying TTNN tensor, returning "
               "empty data vector");

--- a/runtime/test/python/ttnn/test_runtime_api.py
+++ b/runtime/test/python/ttnn/test_runtime_api.py
@@ -23,13 +23,22 @@ def test_tensor_buffer_api(shape, dtype):
         runtime_dtype,
     )
     rt_shape = rt_tensor.get_shape()
+    rt_stride = rt_tensor.get_stride()
     rt_elem_size = rt_tensor.get_element_size()
     rt_vol = rt_tensor.get_volume()
     rt_dtype = ttrt_datatype_to_torch_dtype(rt_tensor.get_dtype())
     rt_bytes = rt_tensor.get_data_buffer()
+    rt_desc = rt_tensor.get_tensor_desc()
+
+    # Tests to make sure the binding of `TensorDesc` works. Might belong in its own test?
+    assert rt_desc.shape == rt_shape
+    assert rt_desc.stride == rt_stride
+    assert ttrt_datatype_to_torch_dtype(rt_desc.dtype) == rt_dtype
+    assert rt_desc.item_size == rt_elem_size
 
     # Various tests that the no underlying stuff has changed over the pybind boundary
     assert list(rt_shape) == list(shape)
+    assert list(rt_stride) == list(torch_tensor.stride())
     assert rt_elem_size == torch_tensor.element_size()
     assert rt_vol == torch_tensor.numel()
     assert rt_dtype == torch_tensor.dtype

--- a/runtime/tools/python/ttrt/common/callback.py
+++ b/runtime/tools/python/ttrt/common/callback.py
@@ -212,15 +212,17 @@ def golden(callback_runtime_config, binary, program_context, op_context):
 
     op_output_tensor = ttrt.runtime.get_op_output_tensor(op_context, program_context)
 
-    if len(op_output_tensor) == 0:
+    if op_output_tensor is None:
         logging.debug("Output tensor is empty - skipping golden comparison")
         return
 
+    rt_buffer = op_output_tensor.get_data_buffer()
     dtype = ttrt_datatype_to_torch_dtype(op_golden_tensor.dtype)
+    assert ttrt_datatype_to_torch_dtype(op_output_tensor.get_dtype()) == dtype
 
     golden_tensor_torch = torch.frombuffer(op_golden_tensor, dtype=dtype).flatten()
 
-    output_tensor_torch = torch.tensor(op_output_tensor, dtype=dtype).flatten()
+    output_tensor_torch = torch.frombuffer(rt_buffer, dtype=dtype).flatten()
 
     if callback_runtime_config.save_golden_tensors:
         torch.save(

--- a/runtime/tools/python/ttrt/common/util.py
+++ b/runtime/tools/python/ttrt/common/util.py
@@ -53,8 +53,12 @@ def ttrt_datatype_to_torch_dtype(dtype) -> torch.dtype:
         return torch.uint16
     elif dtype == DataType.UInt8:
         return torch.uint8
+    elif dtype == DataType.BFloat16:
+        return torch.bfloat16
     else:
-        raise ValueError("Only F32 and unsigned integers are supported in the runtime")
+        raise ValueError(
+            "Only F32, BF16, and unsigned integers are supported in the runtime"
+        )
 
 
 def get_ttrt_metal_home_path():

--- a/runtime/tools/python/ttrt/runtime/__init__.py
+++ b/runtime/tools/python/ttrt/runtime/__init__.py
@@ -7,6 +7,7 @@ try:
         Device,
         Event,
         Tensor,
+        TensorDesc,
         MemoryBufferType,
         DataType,
         DeviceRuntime,

--- a/runtime/tools/python/ttrt/runtime/module.cpp
+++ b/runtime/tools/python/ttrt/runtime/module.cpp
@@ -196,9 +196,11 @@ PYBIND11_MODULE(_C, m) {
          tt::runtime::CallbackContext &programContextHandle) {
         tt::runtime::Tensor tensor = tt::runtime::getOpOutputTensor(
             opContextHandle, programContextHandle);
-        return tt::runtime::getTensorData(tensor);
+        return tensor.handle.get() == nullptr
+                   ? std::nullopt
+                   : std::optional<tt::runtime::Tensor>(tensor);
       },
-      "Get the input tensor of the op");
+      "Get the output tensor of the op");
   m.def("get_op_debug_str", &tt::runtime::getOpDebugString,
         "Get the debug string of the op");
   m.def("get_op_loc_info", &tt::runtime::getOpLocInfo,

--- a/runtime/tools/python/ttrt/runtime/module.cpp
+++ b/runtime/tools/python/ttrt/runtime/module.cpp
@@ -39,7 +39,17 @@ PYBIND11_MODULE(_C, m) {
       .def("get_memory_view", &tt::runtime::detail::getMemoryView,
            py::arg("device_id") = 0);
   py::class_<tt::runtime::Event>(m, "Event");
-  py::class_<tt::runtime::Tensor>(m, "Tensor");
+  py::class_<tt::runtime::Tensor>(m, "Tensor")
+      .def("get_shape", &tt::runtime::Tensor::getShape)
+      .def("get_stride", &tt::runtime::Tensor::getStride)
+      .def("get_volume", &tt::runtime::Tensor::getVolume)
+      .def("get_dtype", &tt::runtime::Tensor::getDtype)
+      .def("get_element_size", &tt::runtime::Tensor::getElementSize)
+      .def("get_data_buffer", [](tt::runtime::Tensor self) {
+        std::vector<std::byte> vec = self.getDataBuffer();
+        return py::bytes(reinterpret_cast<const char *>(vec.data()),
+                         vec.size());
+      });
   py::class_<tt::runtime::Layout>(m, "Layout");
   py::class_<tt::runtime::OpContext>(m, "OpContext");
   py::class_<tt::runtime::CallbackContext>(m, "CallbackContext");

--- a/runtime/tools/python/ttrt/runtime/module.cpp
+++ b/runtime/tools/python/ttrt/runtime/module.cpp
@@ -45,16 +45,30 @@ PYBIND11_MODULE(_C, m) {
       .def_readonly("item_size", &tt::runtime::TensorDesc::itemsize)
       .def_readonly("dtype", &tt::runtime::TensorDesc::dataType);
   py::class_<tt::runtime::Tensor>(m, "Tensor")
-      .def("get_shape", &tt::runtime::Tensor::getShape)
-      .def("get_stride", &tt::runtime::Tensor::getStride)
-      .def("get_volume", &tt::runtime::Tensor::getVolume)
-      .def("get_dtype", &tt::runtime::Tensor::getDtype)
-      .def("get_element_size", &tt::runtime::Tensor::getElementSize)
-      .def("get_tensor_desc", &tt::runtime::Tensor::getTensorDesc)
+      .def("get_shape",
+           [](tt::runtime::Tensor self) { return tt::runtime::getShape(self); })
+      .def(
+          "get_stride",
+          [](tt::runtime::Tensor self) { return tt::runtime::getStride(self); })
+      .def(
+          "get_volume",
+          [](tt::runtime::Tensor self) { return tt::runtime::getVolume(self); })
+      .def("get_dtype",
+           [](tt::runtime::Tensor self) {
+             return tt::runtime::getTensorDataType(self);
+           })
+      .def("get_element_size",
+           [](tt::runtime::Tensor self) {
+             return tt::runtime::getElementSize(self);
+           })
+      .def("get_tensor_desc",
+           [](tt::runtime::Tensor self) {
+             return tt::runtime::getTensorDesc(self);
+           })
       .def(
           "get_data_buffer",
           [](tt::runtime::Tensor self) {
-            std::vector<std::byte> vec = self.getDataBuffer();
+            std::vector<std::byte> vec = tt::runtime::getDataBuffer(self);
             return py::bytes(reinterpret_cast<const char *>(vec.data()),
                              vec.size());
           },

--- a/runtime/tools/python/ttrt/runtime/module.cpp
+++ b/runtime/tools/python/ttrt/runtime/module.cpp
@@ -39,17 +39,26 @@ PYBIND11_MODULE(_C, m) {
       .def("get_memory_view", &tt::runtime::detail::getMemoryView,
            py::arg("device_id") = 0);
   py::class_<tt::runtime::Event>(m, "Event");
+  py::class_<tt::runtime::TensorDesc>(m, "TensorDesc")
+      .def_readonly("shape", &tt::runtime::TensorDesc::shape)
+      .def_readonly("stride", &tt::runtime::TensorDesc::stride)
+      .def_readonly("item_size", &tt::runtime::TensorDesc::itemsize)
+      .def_readonly("dtype", &tt::runtime::TensorDesc::dataType);
   py::class_<tt::runtime::Tensor>(m, "Tensor")
       .def("get_shape", &tt::runtime::Tensor::getShape)
       .def("get_stride", &tt::runtime::Tensor::getStride)
       .def("get_volume", &tt::runtime::Tensor::getVolume)
       .def("get_dtype", &tt::runtime::Tensor::getDtype)
       .def("get_element_size", &tt::runtime::Tensor::getElementSize)
-      .def("get_data_buffer", [](tt::runtime::Tensor self) {
-        std::vector<std::byte> vec = self.getDataBuffer();
-        return py::bytes(reinterpret_cast<const char *>(vec.data()),
-                         vec.size());
-      });
+      .def("get_tensor_desc", &tt::runtime::Tensor::getTensorDesc)
+      .def(
+          "get_data_buffer",
+          [](tt::runtime::Tensor self) {
+            std::vector<std::byte> vec = self.getDataBuffer();
+            return py::bytes(reinterpret_cast<const char *>(vec.data()),
+                             vec.size());
+          },
+          py::return_value_policy::take_ownership);
   py::class_<tt::runtime::Layout>(m, "Layout");
   py::class_<tt::runtime::OpContext>(m, "OpContext");
   py::class_<tt::runtime::CallbackContext>(m, "CallbackContext");

--- a/runtime/tools/python/ttrt/runtime/module.cpp
+++ b/runtime/tools/python/ttrt/runtime/module.cpp
@@ -46,20 +46,24 @@ PYBIND11_MODULE(_C, m) {
       .def_readonly("dtype", &tt::runtime::TensorDesc::dataType);
   py::class_<tt::runtime::Tensor>(m, "Tensor")
       .def("get_shape",
-           [](tt::runtime::Tensor self) { return tt::runtime::getShape(self); })
-      .def(
-          "get_stride",
-          [](tt::runtime::Tensor self) { return tt::runtime::getStride(self); })
-      .def(
-          "get_volume",
-          [](tt::runtime::Tensor self) { return tt::runtime::getVolume(self); })
+           [](tt::runtime::Tensor self) {
+             return tt::runtime::getTensorShape(self);
+           })
+      .def("get_stride",
+           [](tt::runtime::Tensor self) {
+             return tt::runtime::getTensorStride(self);
+           })
+      .def("get_volume",
+           [](tt::runtime::Tensor self) {
+             return tt::runtime::getTensorVolume(self);
+           })
       .def("get_dtype",
            [](tt::runtime::Tensor self) {
              return tt::runtime::getTensorDataType(self);
            })
       .def("get_element_size",
            [](tt::runtime::Tensor self) {
-             return tt::runtime::getElementSize(self);
+             return tt::runtime::getTensorElementSize(self);
            })
       .def("get_tensor_desc",
            [](tt::runtime::Tensor self) {
@@ -68,7 +72,7 @@ PYBIND11_MODULE(_C, m) {
       .def(
           "get_data_buffer",
           [](tt::runtime::Tensor self) {
-            std::vector<std::byte> vec = tt::runtime::getDataBuffer(self);
+            std::vector<std::byte> vec = tt::runtime::getTensorDataBuffer(self);
             return py::bytes(reinterpret_cast<const char *>(vec.data()),
                              vec.size());
           },


### PR DESCRIPTION
This change implements an API on runtime tensors to reflect tensor metadata and contents reflecting the underlying TTNN tensor. This functionality is pybound as well, allowing for easy casting to torch tensors. Please see `runtime/test/python/ttnn/test_runtime_api.py` for an example.

NOTE: This is not the most efficient implementation possible, as there is effectively a double copy to get the data in a pybindable row major format. There is probably some trickery that can be done later to avoid this, but I would like to get this functionality out ASAP and avoid premature optimization

Big thanks to @tapspatel for helping me figure out the namespace dispatch intricacies here!

### Ticket
Closes #1957 

### Checklist
- [x] New/Existing tests provide coverage for changes
