### PR TITLE
Output shape verification for reduce ops

### DIFF
--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -1702,7 +1702,8 @@ void mlir::tt::ttnn::ToLayoutOp::getCanonicalizationPatterns(
 
 // Common verifier for all Reduction ops.
 static mlir::LogicalResult
-verifyReduceOp(mlir::Operation *reduceOp, mlir::RankedTensorType inputType,
+verifyReduceOp(llvm::function_ref<mlir::InFlightDiagnostic()> emitOpError,
+               mlir::RankedTensorType inputType,
                const std::optional<mlir::ArrayAttr> &reduceDims, bool keepDim,
                ::llvm::ArrayRef<int64_t> specifiedOutputShape) {
 
@@ -1738,10 +1739,11 @@ verifyReduceOp(mlir::Operation *reduceOp, mlir::RankedTensorType inputType,
 
   // Finally, compare shapes.
   if (!llvm::equal(specifiedOutputShape, expectedOutputShape)) {
-    return reduceOp->emitOpError(
-        "Expected output shape (" +
-        ttmlir::utils::join(expectedOutputShape, ", ") + "), got (" +
-        ttmlir::utils::join(specifiedOutputShape, ", ") + ")");
+    return emitOpError() << "Expected output shape ("
+                         << ttmlir::utils::join(expectedOutputShape, ", ")
+                         << "), got ("
+                         << ttmlir::utils::join(specifiedOutputShape, ", ")
+                         << ")";
   }
 
   return mlir::success();
@@ -1775,8 +1777,9 @@ static mlir::LogicalResult verifyReduceProdOp(mlir::Operation *reduceOp,
 
 // MaxOp verification.
 ::mlir::LogicalResult MaxOp::verify() {
-  return verifyReduceOp(getOperation(), getInput().getType(), getDimArg(),
-                        getKeepDim(), getResult().getType().getShape());
+  return verifyReduceOp([&]() { return emitOpError(); }, getInput().getType(),
+                        getDimArg(), getKeepDim(),
+                        getResult().getType().getShape());
 }
 
 //===----------------------------------------------------------------------===//
@@ -1785,8 +1788,9 @@ static mlir::LogicalResult verifyReduceProdOp(mlir::Operation *reduceOp,
 
 // MeanOp verification.
 ::mlir::LogicalResult MeanOp::verify() {
-  return verifyReduceOp(getOperation(), getInput().getType(), getDimArg(),
-                        getKeepDim(), getResult().getType().getShape());
+  return verifyReduceOp([&]() { return emitOpError(); }, getInput().getType(),
+                        getDimArg(), getKeepDim(),
+                        getResult().getType().getShape());
 }
 
 //===----------------------------------------------------------------------===//
@@ -1795,8 +1799,9 @@ static mlir::LogicalResult verifyReduceProdOp(mlir::Operation *reduceOp,
 
 // SumOp verification.
 ::mlir::LogicalResult SumOp::verify() {
-  return verifyReduceOp(getOperation(), getInput().getType(), getDimArg(),
-                        getKeepDim(), getResult().getType().getShape());
+  return verifyReduceOp([&]() { return emitOpError(); }, getInput().getType(),
+                        getDimArg(), getKeepDim(),
+                        getResult().getType().getShape());
 }
 
 //===----------------------------------------------------------------------===//
@@ -1805,8 +1810,9 @@ static mlir::LogicalResult verifyReduceProdOp(mlir::Operation *reduceOp,
 
 // MinOp verification.
 ::mlir::LogicalResult MinOp::verify() {
-  return verifyReduceOp(getOperation(), getInput().getType(), getDimArg(),
-                        getKeepDim(), getResult().getType().getShape());
+  return verifyReduceOp([&]() { return emitOpError(); }, getInput().getType(),
+                        getDimArg(), getKeepDim(),
+                        getResult().getType().getShape());
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/ttmlir/Dialect/TTIR/reduction/negative_invalid_dim_high.mlir
+++ b/test/ttmlir/Dialect/TTIR/reduction/negative_invalid_dim_high.mlir
@@ -1,7 +1,7 @@
 // RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
 // Negative tests for reduce ops
 
-// CHECK: error: 'ttir.sum' op Reduce dimensions are out of range
+// CHECK: error: 'ttir.sum' op Reduce dimension 2 is out of range for input tensor of rank 2
 func.func public @test_reduce_add_invalid_dim_high(%arg0: tensor<128x10xf32>, %arg1: tensor<1xf32>) -> tensor<128xf32> {
   %0 = tensor.empty() : tensor<128xf32>
   %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<128x10xf32>, tensor<128xf32>) -> tensor<128xf32>

--- a/test/ttmlir/Dialect/TTIR/reduction/negative_invalid_dim_low.mlir
+++ b/test/ttmlir/Dialect/TTIR/reduction/negative_invalid_dim_low.mlir
@@ -1,7 +1,7 @@
 // RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
 // Negative tests for reduce ops
 
-// CHECK: error: 'ttir.sum' op Reduce dimensions are out of range
+// CHECK: error: 'ttir.sum' op Reduce dimension -3 is out of range for input tensor of rank 2
 func.func public @test_reduce_add_invalid_dim_low(%arg0: tensor<128x10xf32>, %arg1: tensor<1xf32>) -> tensor<128xf32> {
   %0 = tensor.empty() : tensor<128xf32>
   %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [-3 : i32], keep_dim = false}> : (tensor<128x10xf32>, tensor<128xf32>) -> tensor<128xf32>

--- a/test/ttmlir/Dialect/TTIR/reduction/negative_shape_mismatch.mlir
+++ b/test/ttmlir/Dialect/TTIR/reduction/negative_shape_mismatch.mlir
@@ -1,0 +1,41 @@
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+// Negative tests for reduce ops expected shape mismatch.
+
+module {
+  // CHECK: error: 'ttir.sum' op Expected output shape (128, 16), got (128, 16, 1)
+  func.func public @shape_mismatch_0(%arg0: tensor<128x16x32xf32>) -> tensor<128x16x1xf32> {
+    %0 = tensor.empty() : tensor<128x16x1xf32>
+    %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [2 : i32], keep_dim = false}> : (tensor<128x16x32xf32>, tensor<128x16x1xf32>) -> tensor<128x16x1xf32>
+    return %1 : tensor<128x16x1xf32>
+  }
+}
+
+// -----
+module {
+  // CHECK: error: 'ttir.sum' op Expected output shape (128, 16, 1), got (128, 16)
+  func.func public @shape_mismatch_1(%arg0: tensor<128x16x32xf32>) -> tensor<128x16xf32> {
+    %0 = tensor.empty() : tensor<128x16xf32>
+    %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [2 : i32], keep_dim = true}> : (tensor<128x16x32xf32>, tensor<128x16xf32>) -> tensor<128x16xf32>
+    return %1 : tensor<128x16xf32>
+  }
+}
+
+// -----
+module {
+  // CHECK: error: 'ttir.sum' op Expected output shape (1, 1, 1), got (128, 16, 1)
+  func.func public @shape_mismatch_2(%arg0: tensor<128x16x32xf32>) -> tensor<128x16x1xf32> {
+    %0 = tensor.empty() : tensor<128x16x1xf32>
+    %1 = "ttir.sum"(%arg0, %0) <{keep_dim = true}> : (tensor<128x16x32xf32>, tensor<128x16x1xf32>) -> tensor<128x16x1xf32>
+    return %1 : tensor<128x16x1xf32>
+  }
+}
+
+// -----
+module {
+  // CHECK: error: 'ttir.sum' op Expected output shape (1), got (128, 16, 1)
+  func.func public @shape_mismatch_3(%arg0: tensor<128x16x32xf32>) -> tensor<128x16x1xf32> {
+    %0 = tensor.empty() : tensor<128x16x1xf32>
+    %1 = "ttir.sum"(%arg0, %0) <{keep_dim = false}> : (tensor<128x16x32xf32>, tensor<128x16x1xf32>) -> tensor<128x16x1xf32>
+    return %1 : tensor<128x16x1xf32>
+  }
+}

--- a/test/ttmlir/Dialect/TTMetal/simple_attach_metal_layout.mlir
+++ b/test/ttmlir/Dialect/TTMetal/simple_attach_metal_layout.mlir
@@ -17,15 +17,15 @@ func.func @maximum(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tens
 #layout2 = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <4x1>, memref<64x32xf32, #l1_>>
 // CHECK-LABEL: func.func @reduceW(
 // CHECK-SAME: %arg0: tensor<256x384xf32, #[[LAYOUT1:layout1]]>
-// CHECK-SAME: ) -> tensor<256x32xf32, #[[LAYOUT2:layout2]]>
-func.func @reduceW(%arg0: tensor<256x384xf32, #layout1>) -> tensor<256x32xf32, #layout2> {
-  // CHECK: %[[C0:.*]] = tensor.empty() : tensor<256x32xf32, #[[LAYOUT2]]>
-  // CHECK: %[[C1:.*]] = "ttir.sum"(%arg0, %0) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<256x384xf32, #[[LAYOUT1]]>, tensor<256x32xf32, #[[LAYOUT2]]>) -> tensor<256x32xf32, #[[LAYOUT2]]>
-  %0 = tensor.empty() : tensor<256x32xf32, #layout2>
+// CHECK-SAME: ) -> tensor<256x1xf32, #[[LAYOUT2:layout2]]>
+func.func @reduceW(%arg0: tensor<256x384xf32, #layout1>) -> tensor<256x1xf32, #layout2> {
+  // CHECK: %[[C0:.*]] = tensor.empty() : tensor<256x1xf32, #[[LAYOUT2]]>
+  // CHECK: %[[C1:.*]] = "ttir.sum"(%arg0, %0) <{dim_arg = [-1 : i32], keep_dim = true}> : (tensor<256x384xf32, #[[LAYOUT1]]>, tensor<256x1xf32, #[[LAYOUT2]]>) -> tensor<256x1xf32, #[[LAYOUT2]]>
+  %0 = tensor.empty() : tensor<256x1xf32, #layout2>
   %1 = "ttir.sum"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>,
                                dim_arg = [-1: i32],
                                keep_dim = true}> :
-    (tensor<256x384xf32, #layout1>, tensor<256x32xf32, #layout2>) -> tensor<256x32xf32, #layout2>
-  // CHECK: return %[[C1]] : tensor<256x32xf32, #[[LAYOUT2]]>
-  return %1 : tensor<256x32xf32, #layout2>
+    (tensor<256x384xf32, #layout1>, tensor<256x1xf32, #layout2>) -> tensor<256x1xf32, #layout2>
+  // CHECK: return %[[C1]] : tensor<256x1xf32, #[[LAYOUT2]]>
+  return %1 : tensor<256x1xf32, #layout2>
 }


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/2369

### Problem description
Some erroneous shapes would pass verification and only fail in the runtime due to wrong interpretation of `dim_arg` when its value is `nullopt`. There is an example in the linked issue.

### What's changed
- Added verification when `dim_arg` is nullopt in TTNN
- Added a shape verification in TTIR
- Added negative tests

### Checklist
- [x] New/Existing tests provide coverage for changes
