### PR TITLE
Move Python Bindings from being defined with Pybind -> Nanobind

### DIFF
--- a/include/ttmlir/Bindings/Python/TTMLIRModule.h
+++ b/include/ttmlir/Bindings/Python/TTMLIRModule.h
@@ -22,6 +22,7 @@
 #include "ttmlir/RegisterAll.h"
 #include "llvm/Support/CommandLine.h"
 
+#include <nanobind/stl/variant.h>
 #include <variant>
 
 namespace nb = nanobind;

--- a/include/ttmlir/Bindings/Python/TTMLIRModule.h
+++ b/include/ttmlir/Bindings/Python/TTMLIRModule.h
@@ -6,7 +6,8 @@
 #define TTMLIR_BINDINGS_PYTHON_TTMLIRMODULE_H
 
 #include "mlir-c/Bindings/Python/Interop.h"
-#include "mlir/Bindings/Python/PybindAdaptors.h"
+#include "mlir/Bindings/Python/Nanobind.h"
+#include "mlir/Bindings/Python/NanobindAdaptors.h"
 #include "mlir/CAPI/IR.h"
 #include "mlir/InitAllDialects.h"
 #include "mlir/InitAllPasses.h"
@@ -23,46 +24,46 @@
 
 #include <variant>
 
-namespace py = pybind11;
+namespace nb = nanobind;
 
 namespace mlir::ttmlir::python {
 
 template <typename T>
-py::class_<T> tt_attribute_class(py::module &m, const char *class_name) {
-  py::class_<T> cls(m, class_name);
+nb::class_<T> tt_attribute_class(nb::module_ &m, const char *class_name) {
+  nb::class_<T> cls(m, class_name);
   cls.def_static("maybe_downcast",
-                 [](MlirAttribute attr) -> std::variant<T, py::object> {
+                 [](MlirAttribute attr) -> std::variant<T, nb::object> {
                    auto res = mlir::dyn_cast<T>(unwrap(attr));
                    if (res) {
                      return res;
                    }
-                   return py::none();
+                   return nb::none();
                  });
   return cls;
 }
 
 template <typename T>
-py::class_<T> tt_type_class(py::module &m, const char *class_name) {
-  py::class_<T> cls(m, class_name);
+nb::class_<T> tt_type_class(nb::module_ &m, const char *class_name) {
+  nb::class_<T> cls(m, class_name);
   cls.def_static("maybe_downcast",
-                 [](MlirType type) -> std::variant<T, py::object> {
+                 [](MlirType type) -> std::variant<T, nb::object> {
                    auto res = mlir::dyn_cast<T>(unwrap(type));
                    if (res) {
                      return res;
                    }
-                   return py::none();
+                   return nb::none();
                  });
   return cls;
 }
 
-void populateTTModule(py::module &m);
-void populateTTIRModule(py::module &m);
-void populateTTKernelModule(py::module &m);
-void populateTTNNModule(py::module &m);
-void populateOverridesModule(py::module &m);
-void populateOptimizerOverridesModule(py::module &m);
-void populatePassesModule(py::module &m);
-void populateUtilModule(py::module &m);
+void populateTTModule(nb::module_ &m);
+void populateTTIRModule(nb::module_ &m);
+void populateTTKernelModule(nb::module_ &m);
+void populateTTNNModule(nb::module_ &m);
+void populateOverridesModule(nb::module_ &m);
+void populateOptimizerOverridesModule(nb::module_ &m);
+void populatePassesModule(nb::module_ &m);
+void populateUtilModule(nb::module_ &m);
 } // namespace mlir::ttmlir::python
 
 #endif // TTMLIR_BINDINGS_PYTHON_TTMLIRMODULE_H

--- a/include/ttmlir/Dialect/TTNN/Utils/OptimizerOverrides.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/OptimizerOverrides.h
@@ -70,14 +70,15 @@ public:
 
   // Wrapper methods we use to expose the adders to the python bindings
   std::unordered_map<std::string, InputLayoutOverrideParams>
-  getInputLayoutOverridesPybindWrapper() const;
+  getInputLayoutOverridesNanobindWrapper() const;
   std::unordered_map<std::string, OutputLayoutOverrideParams>
-  getOutputLayoutOverridesPybindWrapper() const;
+  getOutputLayoutOverridesNanobindWrapper() const;
 
   // Wrapper methods we use to expose the adders to the python bindings
-  void addInputLayoutOverridePybindWrapper(std::string, std::vector<int64_t> &);
-  void addOutputLayoutOverridePybindWrapper(std::string,
-                                            OutputLayoutOverrideParams);
+  void addInputLayoutOverrideNanobindWrapper(std::string,
+                                             std::vector<int64_t> &);
+  void addOutputLayoutOverrideNanobindWrapper(std::string,
+                                              OutputLayoutOverrideParams);
 
 private:
   // Flags for enabling/disabling the optimizer passes

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -31,6 +31,9 @@ struct GoldenTensor {
                std::vector<std::uint8_t> &&_data)
       : name(name), shape(shape), strides(strides), dtype(dtype),
         data(std::move(_data)) {}
+
+  // Create an explicit empty constructor
+  GoldenTensor() {}
 };
 
 inline ::tt::target::OOBVal toFlatbuffer(FlatbufferObjectCache &,

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -33,7 +33,7 @@ struct GoldenTensor {
         data(std::move(_data)) {}
 
   // Create an explicit empty constructor
-  GoldenTensor() {}
+  GoldenTensor() = default;
 };
 
 inline ::tt::target::OOBVal toFlatbuffer(FlatbufferObjectCache &,

--- a/lib/Dialect/TTNN/Utils/OptimizerOverrides.cpp
+++ b/lib/Dialect/TTNN/Utils/OptimizerOverrides.cpp
@@ -83,7 +83,7 @@ OptimizerOverridesHandler::getOutputLayoutOverrides() const {
 }
 
 std::unordered_map<std::string, InputLayoutOverrideParams>
-OptimizerOverridesHandler::getInputLayoutOverridesPybindWrapper() const {
+OptimizerOverridesHandler::getInputLayoutOverridesNanobindWrapper() const {
   std::unordered_map<std::string, InputLayoutOverrideParams>
       inputLayoutOverridesWrapper;
   for (auto &entry : inputLayoutOverrides) {
@@ -93,7 +93,7 @@ OptimizerOverridesHandler::getInputLayoutOverridesPybindWrapper() const {
 }
 
 std::unordered_map<std::string, OutputLayoutOverrideParams>
-OptimizerOverridesHandler::getOutputLayoutOverridesPybindWrapper() const {
+OptimizerOverridesHandler::getOutputLayoutOverridesNanobindWrapper() const {
   std::unordered_map<std::string, OutputLayoutOverrideParams>
       outputLayoutOverridesWrapper;
   for (auto &entry : outputLayoutOverrides) {
@@ -190,7 +190,7 @@ void OptimizerOverridesHandler::addOutputLayoutOverride(
       std::move(grid), bufferType, tensorMemoryLayout, memoryLayout, dataType};
 }
 
-void OptimizerOverridesHandler::addInputLayoutOverridePybindWrapper(
+void OptimizerOverridesHandler::addInputLayoutOverrideNanobindWrapper(
     std::string opName, std::vector<int64_t> &operandIdxes) {
   StringRef opNameStringRef(opName);
   SmallVector<int64_t> operandIdxesSmallVector(operandIdxes.begin(),
@@ -198,7 +198,7 @@ void OptimizerOverridesHandler::addInputLayoutOverridePybindWrapper(
   addInputLayoutOverride(opNameStringRef, operandIdxesSmallVector);
 }
 
-void OptimizerOverridesHandler::addOutputLayoutOverridePybindWrapper(
+void OptimizerOverridesHandler::addOutputLayoutOverrideNanobindWrapper(
     std::string opName, OutputLayoutOverrideParams overrideParams) {
   StringRef opNameStringRef(opName);
   addOutputLayoutOverride(opNameStringRef, overrideParams);

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -117,6 +117,7 @@ declare_mlir_python_extension(TTMLIRPythonExtensions.Main
     MLIRTestToLLVMIRTranslation
     MLIRVCIXToLLVMIRTranslation
     MLIRX86VectorToLLVMIRTranslation
+  PYTHON_BINDINGS_LIBRARY nanobind
 )
 
 set(TTMLIR_PYTHON_SOURCES

--- a/python/OptimizerOverrides.cpp
+++ b/python/OptimizerOverrides.cpp
@@ -8,11 +8,11 @@
 
 namespace mlir::ttmlir::python {
 
-void populateOptimizerOverridesModule(py::module &m) {
+void populateOptimizerOverridesModule(nb::module_ &m) {
 
-  py::class_<tt::ttnn::OptimizerOverridesHandler>(m,
+  nb::class_<tt::ttnn::OptimizerOverridesHandler>(m,
                                                   "OptimizerOverridesHandler")
-      .def(py::init<>())
+      .def(nb::init<>())
 
       .def("set_enable_optimizer",
            &tt::ttnn::OptimizerOverridesHandler::setEnableOptimizer)
@@ -56,20 +56,21 @@ void populateOptimizerOverridesModule(py::module &m) {
 
       .def("get_input_layout_overrides",
            &tt::ttnn::OptimizerOverridesHandler::
-               getInputLayoutOverridesPybindWrapper)
+               getInputLayoutOverridesNanobindWrapper)
       .def("get_output_layout_overrides",
            &tt::ttnn::OptimizerOverridesHandler::
-               getOutputLayoutOverridesPybindWrapper)
+               getOutputLayoutOverridesNanobindWrapper)
 
-      .def("add_input_layout_override", &tt::ttnn::OptimizerOverridesHandler::
-                                            addInputLayoutOverridePybindWrapper)
+      .def("add_input_layout_override",
+           &tt::ttnn::OptimizerOverridesHandler::
+               addInputLayoutOverrideNanobindWrapper)
       .def("add_output_layout_override",
            &tt::ttnn::OptimizerOverridesHandler::
-               addOutputLayoutOverridePybindWrapper)
+               addOutputLayoutOverrideNanobindWrapper)
 
       .def("to_string", &tt::ttnn::OptimizerOverridesHandler::toString);
 
-  py::enum_<mlir::tt::MemoryLayoutAnalysisPolicyType>(
+  nb::enum_<mlir::tt::MemoryLayoutAnalysisPolicyType>(
       m, "MemoryLayoutAnalysisPolicyType")
       .value("DFSharding", mlir::tt::MemoryLayoutAnalysisPolicyType::DFSharding)
       .value("GreedyL1Interleaved",
@@ -77,26 +78,26 @@ void populateOptimizerOverridesModule(py::module &m) {
       .value("BFInterleaved",
              mlir::tt::MemoryLayoutAnalysisPolicyType::BFInterleaved);
 
-  py::enum_<mlir::tt::ttnn::BufferType>(m, "BufferType")
+  nb::enum_<mlir::tt::ttnn::BufferType>(m, "BufferType")
       .value("DRAM", mlir::tt::ttnn::BufferType::DRAM)
       .value("L1", mlir::tt::ttnn::BufferType::L1)
       .value("SystemMemory", mlir::tt::ttnn::BufferType::SystemMemory)
       .value("L1Small", mlir::tt::ttnn::BufferType::L1Small)
       .value("Trace", mlir::tt::ttnn::BufferType::Trace);
 
-  py::enum_<mlir::tt::ttnn::Layout>(m, "Layout")
+  nb::enum_<mlir::tt::ttnn::Layout>(m, "Layout")
       .value("RowMajor", mlir::tt::ttnn::Layout::RowMajor)
       .value("Tile", mlir::tt::ttnn::Layout::Tile)
       .value("Invalid", mlir::tt::ttnn::Layout::Invalid);
 
-  py::enum_<mlir::tt::ttnn::TensorMemoryLayout>(m, "TensorMemoryLayout")
+  nb::enum_<mlir::tt::ttnn::TensorMemoryLayout>(m, "TensorMemoryLayout")
       .value("Interleaved", mlir::tt::ttnn::TensorMemoryLayout::Interleaved)
       .value("SingleBank", mlir::tt::ttnn::TensorMemoryLayout::SingleBank)
       .value("HeightSharded", mlir::tt::ttnn::TensorMemoryLayout::HeightSharded)
       .value("WidthSharded", mlir::tt::ttnn::TensorMemoryLayout::WidthSharded)
       .value("BlockSharded", mlir::tt::ttnn::TensorMemoryLayout::BlockSharded);
 
-  py::enum_<mlir::tt::DataType>(m, "DataType")
+  nb::enum_<mlir::tt::DataType>(m, "DataType")
       .value("Float32", mlir::tt::DataType::Float32)
       .value("Float16", mlir::tt::DataType::Float16)
       .value("BFloat16", mlir::tt::DataType::BFloat16)
@@ -111,10 +112,10 @@ void populateOptimizerOverridesModule(py::module &m) {
       .value("UInt8", mlir::tt::DataType::UInt8)
       .value("Int32", mlir::tt::DataType::Int32);
 
-  py::class_<mlir::tt::ttnn::InputLayoutOverrideParams>(
+  nb::class_<mlir::tt::ttnn::InputLayoutOverrideParams>(
       m, "InputLayoutOverrideParams")
-      .def(py::init<>())
-      .def_property(
+      .def(nb::init<>())
+      .def_prop_rw(
           "operand_idxes",
           [](const mlir::tt::ttnn::InputLayoutOverrideParams &obj) {
             // Getter: Convert SmallVector to std::vector
@@ -128,10 +129,10 @@ void populateOptimizerOverridesModule(py::module &m) {
             obj.operandIdxes.append(input.begin(), input.end());
           });
 
-  py::class_<mlir::tt::ttnn::OutputLayoutOverrideParams>(
+  nb::class_<mlir::tt::ttnn::OutputLayoutOverrideParams>(
       m, "OutputLayoutOverrideParams")
-      .def(py::init<>())
-      .def_property(
+      .def(nb::init<>())
+      .def_prop_rw(
           "grid",
           [](const mlir::tt::ttnn::OutputLayoutOverrideParams &obj) {
             // Getter: Convert SmallVector to std::vector
@@ -151,20 +152,20 @@ void populateOptimizerOverridesModule(py::module &m) {
             }
             obj.grid->append(input.begin(), input.end());
           })
-      .def_readwrite("buffer_type",
-                     &mlir::tt::ttnn::OutputLayoutOverrideParams::bufferType)
-      .def_readwrite(
-          "tensor_memory_layout",
-          &mlir::tt::ttnn::OutputLayoutOverrideParams::tensorMemoryLayout)
-      .def_readwrite("memory_layout",
-                     &mlir::tt::ttnn::OutputLayoutOverrideParams::memoryLayout)
-      .def_readwrite("data_type",
-                     &mlir::tt::ttnn::OutputLayoutOverrideParams::dataType)
+      .def_rw("buffer_type",
+              &mlir::tt::ttnn::OutputLayoutOverrideParams::bufferType)
+      .def_rw("tensor_memory_layout",
+              &mlir::tt::ttnn::OutputLayoutOverrideParams::tensorMemoryLayout)
+      .def_rw("memory_layout",
+              &mlir::tt::ttnn::OutputLayoutOverrideParams::memoryLayout)
+      .def_rw("data_type",
+              &mlir::tt::ttnn::OutputLayoutOverrideParams::dataType)
       .def("set_buffer_type_from_str",
            [](mlir::tt::ttnn::OutputLayoutOverrideParams &obj,
               const std::string &value) {
-             if (auto bufferType = mlir::tt::ttnn::symbolizeBufferType(value)) {
-               obj.bufferType = bufferType;
+             if (auto bufferType_ =
+                     mlir::tt::ttnn::symbolizeBufferType(value)) {
+               obj.bufferType = bufferType_;
              } else {
                throw std::invalid_argument("Invalid buffer type: " + value);
              }
@@ -183,8 +184,8 @@ void populateOptimizerOverridesModule(py::module &m) {
       .def("set_memory_layout_from_str",
            [](mlir::tt::ttnn::OutputLayoutOverrideParams &obj,
               const std::string &value) {
-             if (auto memoryLayout = mlir::tt::ttnn::symbolizeLayout(value)) {
-               obj.memoryLayout = memoryLayout;
+             if (auto memoryLayout_ = mlir::tt::ttnn::symbolizeLayout(value)) {
+               obj.memoryLayout = memoryLayout_;
              } else {
                throw std::invalid_argument("Invalid memory layout: " + value);
              }
@@ -192,8 +193,8 @@ void populateOptimizerOverridesModule(py::module &m) {
       .def("set_data_type_from_str",
            [](mlir::tt::ttnn::OutputLayoutOverrideParams &obj,
               const std::string &value) {
-             if (auto dataType = mlir::tt::DataTypeStringToEnum(value)) {
-               obj.dataType = dataType;
+             if (auto dataType_ = mlir::tt::DataTypeStringToEnum(value)) {
+               obj.dataType = dataType_;
              } else {
                throw std::invalid_argument("Invalid data type: " + value);
              }

--- a/python/Overrides.cpp
+++ b/python/Overrides.cpp
@@ -6,11 +6,11 @@
 
 namespace mlir::ttmlir::python {
 
-void populateOverridesModule(py::module &m) {
+void populateOverridesModule(nb::module_ &m) {
 
   m.def(
       "get_ptr", [](void *op) { return reinterpret_cast<uintptr_t>(op); },
-      py::arg("op").noconvert());
+      nb::arg("op").noconvert());
 }
 
 } // namespace mlir::ttmlir::python

--- a/python/Passes.cpp
+++ b/python/Passes.cpp
@@ -10,11 +10,11 @@
 #include "ttmlir/Target/TTMetal/TTMetalToFlatbuffer.h"
 #include "ttmlir/Target/TTNN/TTNNToFlatbuffer.h"
 #include <cstdint>
-#include <pybind11/stl_bind.h>
+#include <nanobind/stl/bind_vector.h>
+#include <nanobind/stl/shared_ptr.h>
 
 // Make Opaque so Casts & Copies don't occur
-PYBIND11_MAKE_OPAQUE(std::shared_ptr<void>);
-PYBIND11_MAKE_OPAQUE(std::vector<std::pair<std::string, std::string>>);
+NB_MAKE_OPAQUE(std::vector<std::pair<std::string, std::string>>);
 
 namespace mlir::tt::ttnn {
 void registerTTNNToFlatbuffer();
@@ -22,7 +22,7 @@ void registerTTNNToFlatbuffer();
 
 namespace mlir::ttmlir::python {
 
-void populatePassesModule(py::module &m) {
+void populatePassesModule(nb::module_ &m) {
   // When populating passes, need to first register them
 
   mlir::tt::registerAllPasses();
@@ -40,7 +40,7 @@ void populatePassesModule(py::module &m) {
           throw std::runtime_error("Failed to run pass manager");
         }
       },
-      py::arg("module"), py::arg("options") = "");
+      nb::arg("module"), nb::arg("options") = "");
 
   m.def(
       "ttnn_pipeline_analysis_passes",
@@ -54,7 +54,7 @@ void populatePassesModule(py::module &m) {
           throw std::runtime_error("Failed to run pass manager");
         }
       },
-      py::arg("module"), py::arg("options") = "");
+      nb::arg("module"), nb::arg("options") = "");
 
   m.def(
       "ttnn_pipeline_lowering_passes",
@@ -68,7 +68,7 @@ void populatePassesModule(py::module &m) {
           throw std::runtime_error("Failed to run pass manager");
         }
       },
-      py::arg("module"), py::arg("options") = "");
+      nb::arg("module"), nb::arg("options") = "");
 
   m.def(
       "ttnn_pipeline_layout_decomposition_pass",
@@ -83,7 +83,7 @@ void populatePassesModule(py::module &m) {
           throw std::runtime_error("Failed to run pass manager");
         }
       },
-      py::arg("module"), py::arg("options") = "");
+      nb::arg("module"), nb::arg("options") = "");
 
   m.def(
       "ttnn_pipeline_dealloc_pass",
@@ -97,7 +97,7 @@ void populatePassesModule(py::module &m) {
           throw std::runtime_error("Failed to run pass manager");
         }
       },
-      py::arg("module"), py::arg("options") = "");
+      nb::arg("module"), nb::arg("options") = "");
 
   m.def(
       "ttir_to_ttnn_backend_pipeline",
@@ -125,7 +125,7 @@ void populatePassesModule(py::module &m) {
           throw std::runtime_error("Failed to run pass manager");
         }
       },
-      py::arg("module"), py::arg("options") = "");
+      nb::arg("module"), nb::arg("options") = "");
 
   m.def(
       "ttir_to_ttmetal_backend_pipeline",
@@ -148,30 +148,11 @@ void populatePassesModule(py::module &m) {
           throw std::runtime_error("Failed to run pass manager");
         }
       },
-      py::arg("module"), py::arg("options") = "");
-
-  py::class_<std::shared_ptr<void>>(m, "SharedVoidPtr")
-      .def(py::init<>())
-      .def("from_ttnn", [](std::shared_ptr<void> data, MlirModule module) {
-        mlir::Operation *moduleOp = unwrap(mlirModuleGetOperation(module));
-        data = mlir::tt::ttnn::ttnnToFlatbuffer(moduleOp);
-      });
-
-  m.def("ttnn_to_flatbuffer_binary", [](MlirModule module) {
-    // NOLINTBEGIN
-    mlir::Operation *moduleOp = unwrap(mlirModuleGetOperation(module));
-    std::shared_ptr<void> *binary = new std::shared_ptr<void>();
-    *binary = mlir::tt::ttnn::ttnnToFlatbuffer(moduleOp);
-    return py::capsule((void *)binary, [](void *data) {
-      std::shared_ptr<void> *bin = static_cast<std::shared_ptr<void> *>(data);
-      delete bin;
-    });
-    // NOLINTEND
-  });
+      nb::arg("module"), nb::arg("options") = "");
 
   // This binds the vector into an interfaceable object in python and also an
   // opaquely passed one into other functions.
-  py::bind_vector<std::vector<std::pair<std::string, std::string>>>(
+  nb::bind_vector<std::vector<std::pair<std::string, std::string>>>(
       m, "ModuleLog");
 
   m.def(
@@ -197,8 +178,8 @@ void populatePassesModule(py::module &m) {
                                    filepath);
         }
       },
-      py::arg("module"), py::arg("filepath"), py::arg("goldenMap") = py::dict(),
-      py::arg("moduleCache") =
+      nb::arg("module"), nb::arg("filepath"), nb::arg("goldenMap") = nb::dict(),
+      nb::arg("moduleCache") =
           std::vector<std::pair<std::string, std::string>>());
 
   m.def("ttmetal_to_flatbuffer_file",
@@ -234,9 +215,9 @@ void populatePassesModule(py::module &m) {
         output_stream.flush();
         return output;
       },
-      py::arg("module"), py::arg("isTensixKernel"));
+      nb::arg("module"), nb::arg("isTensixKernel"));
 
-  py::enum_<::tt::target::DataType>(m, "DataType")
+  nb::enum_<::tt::target::DataType>(m, "DataType")
       .value("Float32", ::tt::target::DataType::Float32)
       .value("Float16", ::tt::target::DataType::Float16);
 
@@ -255,39 +236,37 @@ void populatePassesModule(py::module &m) {
     return ::tt::target::DataType::MIN;
   });
 
-  // Preserve the Data by holding it in a SharedPtr.
-  py::class_<mlir::tt::GoldenTensor, std::shared_ptr<mlir::tt::GoldenTensor>>(
-      m, "GoldenTensor")
-      .def(py::init([](std::string name, std::vector<int64_t> shape,
-                       std::vector<int64_t> strides,
-                       ::tt::target::DataType dtype, std::uintptr_t ptr,
-                       std::size_t dataSize) {
-        // Create Golden Tensor and move ownership to GoldenTensor
-        auto *dataPtr = reinterpret_cast<std::uint8_t *>(ptr);
+  nb::class_<mlir::tt::GoldenTensor>(m, "GoldenTensor")
+      .def("__init__",
+           [](mlir::tt::GoldenTensor *self, std::string name,
+              std::vector<int64_t> shape, std::vector<int64_t> strides,
+              ::tt::target::DataType dtype, std::uintptr_t ptr,
+              std::size_t dataSize) {
+             new (self) mlir::tt::GoldenTensor(
+                 name, shape, strides, dtype,
+                 std::vector<std::uint8_t>(
+                     reinterpret_cast<std::uint8_t *>(ptr),
+                     reinterpret_cast<std::uint8_t *>(ptr) + dataSize));
+           })
+      .def_rw("name", &mlir::tt::GoldenTensor::name)
+      .def_rw("shape", &mlir::tt::GoldenTensor::shape)
+      .def_rw("strides", &mlir::tt::GoldenTensor::strides)
+      .def_rw("dtype", &mlir::tt::GoldenTensor::dtype)
+      .def_rw("data", &mlir::tt::GoldenTensor::data);
 
-        return std::make_shared<mlir::tt::GoldenTensor>(
-            name, shape, strides, dtype,
-            std::vector<std::uint8_t>(dataPtr, dataPtr + dataSize));
-      }))
-      .def_readwrite("name", &mlir::tt::GoldenTensor::name)
-      .def_readwrite("shape", &mlir::tt::GoldenTensor::shape)
-      .def_readwrite("strides", &mlir::tt::GoldenTensor::strides)
-      .def_readwrite("dtype", &mlir::tt::GoldenTensor::dtype)
-      .def_readwrite("data", &mlir::tt::GoldenTensor::data);
-
-  py::class_<mlir::tt::MLIRModuleLogger,
-             std::shared_ptr<mlir::tt::MLIRModuleLogger>>(m, "MLIRModuleLogger")
-      .def(py::init<>())
+  // Supposedly no need for shared_ptr holder types anymore, have python take
+  // ownership of ModuleLog
+  nb::class_<mlir::tt::MLIRModuleLogger>(m, "MLIRModuleLogger")
+      .def(nb::init<>(), nb::rv_policy::take_ownership)
       .def(
           "attach_context",
-          [](std::shared_ptr<mlir::tt::MLIRModuleLogger> &self, MlirContext ctx,
+          [](mlir::tt::MLIRModuleLogger *self, MlirContext ctx,
              std::vector<std::string> &passnames_to_cache) {
             self->attachContext(unwrap(ctx), passnames_to_cache);
           },
-          py::arg("ctx"), py::arg("passnames_to_cache") = py::list())
-      .def_property_readonly(
-          "module_log", [](std::shared_ptr<mlir::tt::MLIRModuleLogger> &self) {
-            return self->moduleCache;
-          });
+          nb::arg("ctx"), nb::arg("passnames_to_cache") = nb::list())
+      .def_prop_ro("module_log", [](mlir::tt::MLIRModuleLogger *self) {
+        return self->moduleCache;
+      });
 }
 } // namespace mlir::ttmlir::python

--- a/python/Passes.cpp
+++ b/python/Passes.cpp
@@ -10,11 +10,14 @@
 #include "ttmlir/Target/TTMetal/TTMetalToFlatbuffer.h"
 #include "ttmlir/Target/TTNN/TTNNToFlatbuffer.h"
 #include <cstdint>
+#include <nanobind/stl/bind_map.h>
 #include <nanobind/stl/bind_vector.h>
 #include <nanobind/stl/shared_ptr.h>
 
 // Make Opaque so Casts & Copies don't occur
 NB_MAKE_OPAQUE(std::vector<std::pair<std::string, std::string>>);
+NB_MAKE_OPAQUE(mlir::tt::GoldenTensor);
+NB_MAKE_OPAQUE(std::unordered_map<std::string, mlir::tt::GoldenTensor>);
 
 namespace mlir::tt::ttnn {
 void registerTTNNToFlatbuffer();
@@ -155,6 +158,9 @@ void populatePassesModule(nb::module_ &m) {
   nb::bind_vector<std::vector<std::pair<std::string, std::string>>>(
       m, "ModuleLog");
 
+  nb::bind_map<std::unordered_map<std::string, mlir::tt::GoldenTensor>>(
+      m, "GoldenMap");
+
   m.def(
       "ttnn_to_flatbuffer_file",
       [](MlirModule module, std::string &filepath,
@@ -178,7 +184,9 @@ void populatePassesModule(nb::module_ &m) {
                                    filepath);
         }
       },
-      nb::arg("module"), nb::arg("filepath"), nb::arg("goldenMap") = nb::dict(),
+      nb::arg("module"), nb::arg("filepath"),
+      nb::arg("goldenMap") =
+          std::unordered_map<std::string, mlir::tt::GoldenTensor>(),
       nb::arg("moduleCache") =
           std::vector<std::pair<std::string, std::string>>());
 

--- a/python/TTIRModule.cpp
+++ b/python/TTIRModule.cpp
@@ -7,7 +7,7 @@
 #include "mlir/CAPI/IR.h"
 
 namespace mlir::ttmlir::python {
-void populateTTIRModule(py::module &m) {
+void populateTTIRModule(nb::module_ &m) {
   m.def("is_dps", [](MlirOperation op) {
     return mlir::isa<DestinationStyleOpInterface>(unwrap(op));
   });

--- a/python/TTKernelModule.cpp
+++ b/python/TTKernelModule.cpp
@@ -12,8 +12,8 @@
 #include "ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.h"
 
 namespace mlir::ttmlir::python {
-void populateTTKernelModule(py::module &m) {
-  py::class_<tt::ttkernel::CBType>(m, "CBType")
+void populateTTKernelModule(nb::module_ &m) {
+  tt_type_class<tt::ttkernel::CBType>(m, "CBType")
       .def_static("get",
                   [](MlirContext ctx, uint64_t address, uint64_t port,
                      MlirType memrefType) {
@@ -24,10 +24,10 @@ void populateTTKernelModule(py::module &m) {
                   [](MlirType &ty) {
                     return mlir::cast<tt::ttkernel::CBType>(unwrap(ty));
                   })
-      .def_property_readonly("shape",
-                             [](tt::ttkernel::CBType &cb) {
-                               return std::vector<int64_t>(cb.getShape());
-                             })
-      .def_property_readonly("memref", &tt::ttkernel::CBType::getMemref);
+      .def_prop_ro("shape",
+                   [](tt::ttkernel::CBType &cb) {
+                     return std::vector<int64_t>(cb.getShape());
+                   })
+      .def_prop_ro("memref", &tt::ttkernel::CBType::getMemref);
 }
 } // namespace mlir::ttmlir::python

--- a/python/TTMLIRModule.cpp
+++ b/python/TTMLIRModule.cpp
@@ -4,7 +4,7 @@
 
 #include "ttmlir/Bindings/Python/TTMLIRModule.h"
 
-PYBIND11_MODULE(_ttmlir, m) {
+NB_MODULE(_ttmlir, m) {
   m.doc() = "ttmlir main python extension";
 
   m.def(
@@ -25,7 +25,7 @@ PYBIND11_MODULE(_ttmlir, m) {
           mlirDialectHandleLoadDialect(ttnn_handle, context);
         }
       },
-      py::arg("context"), py::arg("load") = true);
+      nb::arg("context"), nb::arg("load") = true);
 
   auto tt_ir = m.def_submodule("tt_ir", "TT IR Bindings");
   mlir::ttmlir::python::populateTTModule(tt_ir);

--- a/python/TTNNModule.cpp
+++ b/python/TTNNModule.cpp
@@ -6,7 +6,7 @@
 #include "ttmlir/Bindings/Python/TTMLIRModule.h"
 
 namespace mlir::ttmlir::python {
-void populateTTNNModule(py::module &m) {
+void populateTTNNModule(nb::module_ &m) {
 
   tt_attribute_class<tt::ttnn::CoreRangeAttr>(m, "CoreRangeAttr")
       .def_static("get",
@@ -27,12 +27,12 @@ void populateTTNNModule(py::module &m) {
                 unwrap(ctx), mlir::cast<tt::GridAttr>(unwrap(grid)),
                 offsetVec));
           },
-          py::arg("ctx"), py::arg("grid"),
-          py::arg("offset") = std::vector<int64_t>{0, 0})
-      .def_property_readonly(
+          nb::arg("ctx"), nb::arg("grid"),
+          nb::arg("offset") = std::vector<int64_t>{0, 0})
+      .def_prop_ro(
           "offset",
           [](tt::ttnn::CoreRangeAttr self) { return self.getOffset().vec(); })
-      .def_property_readonly("size", [](tt::ttnn::CoreRangeAttr self) {
+      .def_prop_ro("size", [](tt::ttnn::CoreRangeAttr self) {
         return self.getSize().vec();
       });
 
@@ -42,7 +42,7 @@ void populateTTNNModule(py::module &m) {
                     return wrap(tt::ttnn::LayoutAttr::get(
                         unwrap(ctx), static_cast<tt::ttnn::Layout>(layout)));
                   })
-      .def_property_readonly("value", [](tt::ttnn::LayoutAttr self) {
+      .def_prop_ro("value", [](tt::ttnn::LayoutAttr self) {
         return static_cast<uint32_t>(self.getValue());
       });
 
@@ -54,10 +54,9 @@ void populateTTNNModule(py::module &m) {
                         unwrap(ctx), static_cast<tt::ttnn::TensorMemoryLayout>(
                                          tensorMemoryLayout)));
                   })
-      .def_property_readonly("value",
-                             [](tt::ttnn::TensorMemoryLayoutAttr self) {
-                               return static_cast<uint32_t>(self.getValue());
-                             });
+      .def_prop_ro("value", [](tt::ttnn::TensorMemoryLayoutAttr self) {
+        return static_cast<uint32_t>(self.getValue());
+      });
   tt_attribute_class<tt::ttnn::BufferTypeAttr>(m, "BufferTypeAttr")
       .def_static(
           "get",
@@ -65,7 +64,7 @@ void populateTTNNModule(py::module &m) {
             return wrap(tt::ttnn::BufferTypeAttr::get(
                 unwrap(ctx), static_cast<tt::ttnn::BufferType>(bufferType)));
           })
-      .def_property_readonly("value", [](tt::ttnn::BufferTypeAttr self) {
+      .def_prop_ro("value", [](tt::ttnn::BufferTypeAttr self) {
         return static_cast<uint32_t>(self.getValue());
       });
 
@@ -75,8 +74,7 @@ void populateTTNNModule(py::module &m) {
                     return wrap(
                         tt::ttnn::ShardSpecAttr::get(unwrap(ctx), shardShape));
                   })
-      .def_property_readonly("shard_shape",
-                             &tt::ttnn::ShardSpecAttr::getShardShape);
+      .def_prop_ro("shard_shape", &tt::ttnn::ShardSpecAttr::getShardShape);
 
   tt_attribute_class<tt::ttnn::MemoryConfigAttr>(m, "MemoryConfigAttr")
       .def_static("get",
@@ -106,19 +104,17 @@ void populateTTNNModule(py::module &m) {
                     tt::ttnn::ShapeAttr::get(unwrap(ctx), shardShape)),
                 layoutAttr));
           })
-      .def_property_readonly("tensor_memory_layout",
-                             &tt::ttnn::MemoryConfigAttr::getTensorMemoryLayout)
-      .def_property_readonly("buffer_type",
-                             &tt::ttnn::MemoryConfigAttr::getBufferType)
-      .def_property_readonly("shard_spec",
-                             &tt::ttnn::MemoryConfigAttr::getShardSpec);
+      .def_prop_ro("tensor_memory_layout",
+                   &tt::ttnn::MemoryConfigAttr::getTensorMemoryLayout)
+      .def_prop_ro("buffer_type", &tt::ttnn::MemoryConfigAttr::getBufferType)
+      .def_prop_ro("shard_spec", &tt::ttnn::MemoryConfigAttr::getShardSpec);
 
   tt_attribute_class<tt::ttnn::ShapeAttr>(m, "ShapeAttr")
       .def_static("get",
                   [](MlirContext ctx, std::vector<int64_t> shape) {
                     return wrap(tt::ttnn::ShapeAttr::get(unwrap(ctx), shape));
                   })
-      .def_property_readonly("shape", [](tt::ttnn::ShapeAttr self) {
+      .def_prop_ro("shape", [](tt::ttnn::ShapeAttr self) {
         return std::vector<int64_t>(self.getShape().begin(),
                                     self.getShape().end());
       });
@@ -129,8 +125,8 @@ void populateTTNNModule(py::module &m) {
                     return wrap(
                         tt::ttnn::MeshShapeAttr::get(unwrap(ctx), y, x));
                   })
-      .def_property_readonly("y", &tt::ttnn::MeshShapeAttr::getY)
-      .def_property_readonly("x", &tt::ttnn::MeshShapeAttr::getX);
+      .def_prop_ro("y", &tt::ttnn::MeshShapeAttr::getY)
+      .def_prop_ro("x", &tt::ttnn::MeshShapeAttr::getX);
 
   tt_attribute_class<tt::ttnn::TTNNLayoutAttr>(m, "TTNNLayoutAttr")
       .def_static(
@@ -149,29 +145,28 @@ void populateTTNNModule(py::module &m) {
                 mlir::cast<tt::GridAttr>(unwrap(grid)),
                 mlir::cast<MemRefType>(unwrap(memref)), memLayoutAttr));
           })
-      .def_property_readonly(
+      .def_prop_ro(
           "linear",
           [](tt::ttnn::TTNNLayoutAttr self) { return wrap(self.getLinear()); })
-      .def_property_readonly("grid_attr", &tt::ttnn::TTNNLayoutAttr::getGrid)
-      .def_property_readonly(
+      .def_prop_ro("grid_attr", &tt::ttnn::TTNNLayoutAttr::getGrid)
+      .def_prop_ro(
           "memref",
           [](tt::ttnn::TTNNLayoutAttr self) { return wrap(self.getMemref()); })
-      .def_property_readonly("tensor_memory_layout_as_int",
-                             [](tt::ttnn::TTNNLayoutAttr self)
-                                 -> std::variant<uint32_t, py::object> {
-                               if (!self.getMemLayout()) {
-                                 return py::none();
-                               }
-                               return static_cast<uint32_t>(
-                                   self.getMemLayout().getValue());
-                             })
-      .def_property_readonly("memory_layout_as_int",
-                             [](tt::ttnn::TTNNLayoutAttr self) {
-                               return static_cast<uint32_t>(self.getLayout());
-                             })
-      .def_property_readonly("data_type_as_int",
-                             [](tt::ttnn::TTNNLayoutAttr self) {
-                               return static_cast<uint32_t>(self.getDataType());
-                             });
+      .def_prop_ro("tensor_memory_layout_as_int",
+                   [](tt::ttnn::TTNNLayoutAttr self)
+                       -> std::variant<uint32_t, nb::object> {
+                     if (!self.getMemLayout()) {
+                       return nb::none();
+                     }
+                     return static_cast<uint32_t>(
+                         self.getMemLayout().getValue());
+                   })
+      .def_prop_ro("memory_layout_as_int",
+                   [](tt::ttnn::TTNNLayoutAttr self) {
+                     return static_cast<uint32_t>(self.getLayout());
+                   })
+      .def_prop_ro("data_type_as_int", [](tt::ttnn::TTNNLayoutAttr self) {
+        return static_cast<uint32_t>(self.getDataType());
+      });
 }
 } // namespace mlir::ttmlir::python

--- a/python/Util.cpp
+++ b/python/Util.cpp
@@ -18,26 +18,25 @@ void populateUtilModule(nb::module_ &m) {
     return source;
   });
 
-  m.def("get_loc_name",
-        [](MlirLocation _loc) -> std::variant<std::string, nb::object> {
-          mlir::Location loc = unwrap(_loc);
-          if (mlir::isa<mlir::NameLoc>(loc)) {
-            mlir::NameLoc nameLoc = mlir::cast<mlir::NameLoc>(loc);
-            return nameLoc.getName().str();
-          }
-          return nb::none();
-        });
+  m.def("get_loc_name", [](MlirLocation _loc) -> nb::object {
+    mlir::Location loc = unwrap(_loc);
+    if (mlir::isa<mlir::NameLoc>(loc)) {
+      mlir::NameLoc nameLoc = mlir::cast<mlir::NameLoc>(loc);
+      return nb::str(nameLoc.getName().str().c_str());
+    }
+    return nb::none();
+  });
 
-  m.def("get_loc_full",
-        [](MlirLocation _loc) -> std::variant<std::string, nb::object> {
-          mlir::Location loc = unwrap(_loc);
+  m.def("get_loc_full", [](MlirLocation _loc) {
+    mlir::Location loc = unwrap(_loc);
 
-          std::string locationStr;
-          llvm::raw_string_ostream output(locationStr);
-          loc.print(output);
+    std::string locationStr;
+    llvm::raw_string_ostream output(locationStr);
+    loc.print(output);
+    output.flush();
 
-          return locationStr;
-        });
+    return locationStr;
+  });
 }
 
 } // namespace mlir::ttmlir::python

--- a/python/Util.cpp
+++ b/python/Util.cpp
@@ -3,12 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Bindings/Python/TTMLIRModule.h"
-#include <pybind11/pytypes.h>
 #include <variant>
 
 namespace mlir::ttmlir::python {
 
-void populateUtilModule(py::module &m) {
+void populateUtilModule(nb::module_ &m) {
   m.def("debug_print_module", [](MlirModule module) {
     std::string source;
     llvm::raw_string_ostream os(source);
@@ -20,17 +19,17 @@ void populateUtilModule(py::module &m) {
   });
 
   m.def("get_loc_name",
-        [](MlirLocation _loc) -> std::variant<std::string, py::object> {
+        [](MlirLocation _loc) -> std::variant<std::string, nb::object> {
           mlir::Location loc = unwrap(_loc);
           if (mlir::isa<mlir::NameLoc>(loc)) {
             mlir::NameLoc nameLoc = mlir::cast<mlir::NameLoc>(loc);
             return nameLoc.getName().str();
           }
-          return py::none();
+          return nb::none();
         });
 
   m.def("get_loc_full",
-        [](MlirLocation _loc) -> std::variant<std::string, py::object> {
+        [](MlirLocation _loc) -> std::variant<std::string, nb::object> {
           mlir::Location loc = unwrap(_loc);
 
           std::string locationStr;


### PR DESCRIPTION
### Ticket
- PR closes #1774 

### Problem description
- `nanobind` is now supported through MLIR. It's hopefully leaner, faster, and better supported.
- We should switch our Python bindings over to `nanobind` ASAP to prevent further complications

### What's changed
- Few functional changes to nanobind to support new python object storage methods.
- Switched all of the bindings and build system from `pybind11` -> `nanobind`.
