### PR TITLE
Add constraints and runtime API to typecast

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -67,7 +67,9 @@ def TTNN_ToLayoutOp : TTNN_Op<"to_layout"> {
     let hasCanonicalizer = 1;
 }
 
-def TTNN_TypecastOp : TTNN_Op<"typecast"> {
+def TTNN_TypecastOp : TTNN_Op<"typecast",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
     let summary = "Typecast op.";
     let description = [{
       This op converts the data type of the input tensor based on the given data type.

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -121,6 +121,26 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 }; // namespace ReshapeOpInterface
 
 //===----------------------------------------------------------------------===//
+// TypecastOp
+//===----------------------------------------------------------------------===//
+
+namespace TypecastOpInterface {
+llvm::Expected<std::tuple<size_t, size_t, size_t>>
+getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+                 mlir::tt::DataTypeAttr dtype,
+                 llvm::ArrayRef<int64_t> outputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+
+llvm::Expected<size_t>
+getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+             mlir::tt::DataTypeAttr dtype, llvm::ArrayRef<int64_t> outputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+
+}; // namespace TypecastOpInterface
+
+//===----------------------------------------------------------------------===//
 // TransposeOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -233,6 +233,42 @@ ReshapeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// TypecastOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<std::tuple<size_t, size_t, size_t>>
+TypecastOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                             const TTNNLayoutAttr &output) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  const auto outputShape =
+      mlir::cast<RankedTensorType>(getResult().getType()).getShape();
+
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+
+  return op_model::ttnn::TypecastOpInterface::getOpConstraints(
+      inputShape, inputs[0], getDtypeAttr(), outputShape, output);
+}
+
+llvm::Expected<size_t>
+TypecastOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                         const TTNNLayoutAttr &output) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+  const auto outputShape =
+      mlir::cast<RankedTensorType>(getResult().getType()).getShape();
+
+  return op_model::ttnn::TypecastOpInterface::getOpRuntime(
+      inputShape, inputs[0], getDtypeAttr(), outputShape, output);
+}
+
+//===----------------------------------------------------------------------===//
 // TransposeOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -242,7 +242,6 @@ TypecastOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   assert(inputs.size() == 1);
 
   const auto inputShape = getInput().getType().getShape();
-
   const auto outputShape =
       mlir::cast<RankedTensorType>(getResult().getType()).getShape();
 

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -137,8 +137,7 @@ SoftmaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  const auto outputShape =
-      mlir::cast<RankedTensorType>(getResult().getType()).getShape();
+  const auto outputShape = getResult().getType().getShape();
 
   llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
   if (!check) {
@@ -156,8 +155,7 @@ SoftmaxOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  const auto outputShape =
-      mlir::cast<RankedTensorType>(getResult().getType()).getShape();
+  const auto outputShape = getResult().getType().getShape();
 
   return op_model::ttnn::SoftmaxOpInterface::getOpRuntime(
       inputShape, inputs[0], getDimension(), outputShape, output);
@@ -207,8 +205,7 @@ ReshapeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  const auto outputShape =
-      mlir::cast<RankedTensorType>(getResult().getType()).getShape();
+  const auto outputShape = getResult().getType().getShape();
 
   llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
   if (!check) {
@@ -225,8 +222,7 @@ ReshapeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   assert(inputs.size() == 1);
 
   const auto inputShape = getInput().getType().getShape();
-  const auto outputShape =
-      mlir::cast<RankedTensorType>(getResult().getType()).getShape();
+  const auto outputShape = getResult().getType().getShape();
 
   return op_model::ttnn::ReshapeOpInterface::getOpRuntime(inputShape, inputs[0],
                                                           outputShape, output);
@@ -242,8 +238,7 @@ TypecastOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   assert(inputs.size() == 1);
 
   const auto inputShape = getInput().getType().getShape();
-  const auto outputShape =
-      mlir::cast<RankedTensorType>(getResult().getType()).getShape();
+  const auto outputShape = getResult().getType().getShape();
 
   llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
   if (!check) {
@@ -260,8 +255,7 @@ TypecastOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   assert(inputs.size() == 1);
 
   const auto inputShape = getInput().getType().getShape();
-  const auto outputShape =
-      mlir::cast<RankedTensorType>(getResult().getType()).getShape();
+  const auto outputShape = getResult().getType().getShape();
 
   return op_model::ttnn::TypecastOpInterface::getOpRuntime(
       inputShape, inputs[0], getDtypeAttr(), outputShape, output);
@@ -312,8 +306,7 @@ MatmulOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShapeB =
       mlir::cast<RankedTensorType>(getOperand(1).getType()).getShape();
 
-  const auto outputShape =
-      mlir::cast<RankedTensorType>(getResult().getType()).getShape();
+  const auto outputShape = getResult().getType().getShape();
 
   llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
   if (!check) {
@@ -335,8 +328,7 @@ MatmulOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShapeB =
       mlir::cast<RankedTensorType>(getOperand(1).getType()).getShape();
 
-  const auto outputShape =
-      mlir::cast<RankedTensorType>(getResult().getType()).getShape();
+  const auto outputShape = getResult().getType().getShape();
 
   return op_model::ttnn::MatmulOpInterface::getOpRuntime(
       inputShapeA, inputs[0], inputShapeB, inputs[1], outputShape, output,

--- a/lib/OpModel/TTNN/Conversion.cpp
+++ b/lib/OpModel/TTNN/Conversion.cpp
@@ -22,10 +22,6 @@ getDataType(const mlir::tt::ttnn::TTNNLayoutAttr layout) {
   return getDataType(layout.getDataType());
 }
 
-::tt::tt_metal::DataType getDataType(mlir::tt::DataTypeAttr dtype) {
-  return getDataType(dtype.getValue());
-}
-
 ::tt::tt_metal::DataType getDataType(mlir::tt::DataType dtype) {
   switch (dtype) {
   case tt::DataType::Float32:

--- a/lib/OpModel/TTNN/Conversion.cpp
+++ b/lib/OpModel/TTNN/Conversion.cpp
@@ -19,9 +19,15 @@ namespace conversion {
 
 ::tt::tt_metal::DataType
 getDataType(const mlir::tt::ttnn::TTNNLayoutAttr layout) {
-  auto dataType = layout.getDataType();
+  return getDataType(layout.getDataType());
+}
 
-  switch (dataType) {
+::tt::tt_metal::DataType getDataType(mlir::tt::DataTypeAttr dtype) {
+  return getDataType(dtype.getValue());
+}
+
+::tt::tt_metal::DataType getDataType(mlir::tt::DataType dtype) {
+  switch (dtype) {
   case tt::DataType::Float32:
     return ::tt::tt_metal::DataType::FLOAT32;
   case tt::DataType::BFloat16:

--- a/lib/OpModel/TTNN/Conversion.hpp
+++ b/lib/OpModel/TTNN/Conversion.hpp
@@ -14,6 +14,10 @@ namespace conversion {
 ::tt::tt_metal::DataType
 getDataType(const mlir::tt::ttnn::TTNNLayoutAttr layout);
 
+::tt::tt_metal::DataType getDataType(mlir::tt::DataTypeAttr dtype);
+
+::tt::tt_metal::DataType getDataType(mlir::tt::DataType dtype);
+
 ::ttnn::Shape getShape(const ::llvm::ArrayRef<int64_t> shape);
 
 const std::array<uint32_t, 2>

--- a/lib/OpModel/TTNN/Conversion.hpp
+++ b/lib/OpModel/TTNN/Conversion.hpp
@@ -14,8 +14,6 @@ namespace conversion {
 ::tt::tt_metal::DataType
 getDataType(const mlir::tt::ttnn::TTNNLayoutAttr layout);
 
-::tt::tt_metal::DataType getDataType(mlir::tt::DataTypeAttr dtype);
-
 ::tt::tt_metal::DataType getDataType(mlir::tt::DataType dtype);
 
 ::ttnn::Shape getShape(const ::llvm::ArrayRef<int64_t> shape);

--- a/lib/OpModel/TTNN/MetalHeaders.h
+++ b/lib/OpModel/TTNN/MetalHeaders.h
@@ -64,6 +64,7 @@ using IDevice = ::tt::tt_metal::IDevice;
 #include "ttnn/graph/graph_query_op_constraints.hpp"
 #include "ttnn/graph/graph_query_op_runtime.hpp"
 #include "ttnn/graph/graph_trace_utils.hpp"
+#include "ttnn/operations/copy.hpp"
 #include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
 #include "ttnn/operations/data_movement/transpose/transpose.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -370,12 +370,12 @@ TEST_F(OpModelTest, Transpose) {
 
   constraintsExp = TransposeOpInterface::getOpConstraints(
       tensorShape, layoutL1Interleaved, 0, 1, layoutL1WSharded);
-  EXPECT_TRUE(!static_cast<bool>(constraintsExp));
+  EXPECT_FALSE(static_cast<bool>(constraintsExp));
   llvm::consumeError(constraintsExp.takeError());
 
   runtimeExp = TransposeOpInterface::getOpRuntime(
       tensorShape, layoutL1Interleaved, 0, 1, layoutL1WSharded);
-  EXPECT_TRUE(!static_cast<bool>(runtimeExp));
+  EXPECT_FALSE(static_cast<bool>(runtimeExp));
   llvm::consumeError(runtimeExp.takeError());
 }
 
@@ -461,13 +461,13 @@ TEST_F(OpModelTest, Typecast) {
       tensorShape, inputLayoutDRAMIBF16,
       DataTypeAttr::get(&context, DataType::Float32), tensorShape,
       inputLayoutL1HSBF16);
-  EXPECT_TRUE(!static_cast<bool>(constraintsExp));
+  EXPECT_FALSE(static_cast<bool>(constraintsExp));
   llvm::consumeError(constraintsExp.takeError());
   runtimeExp = TypecastOpInterface::getOpRuntime(
       tensorShape, inputLayoutDRAMIBF16,
       DataTypeAttr::get(&context, DataType::Float32), tensorShape,
       inputLayoutL1HSBF16);
-  EXPECT_TRUE(!static_cast<bool>(runtimeExp));
+  EXPECT_FALSE(static_cast<bool>(runtimeExp));
   llvm::consumeError(runtimeExp.takeError());
 }
 

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -378,7 +378,6 @@ TEST_F(OpModelBase, typecastOp) {
       builder.getUnknownLoc(), rankedTensorTypeF32, input, DataType::Float32);
   typecast->setAttr(DeviceAttr::name, getFakeDeviceAttr());
 
-  // test transpose Op interface
   auto constraintsExp = getOpConstraints(typecast.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -359,4 +359,44 @@ TEST_F(OpModelBase, transposeOp) {
   }
 }
 
+TEST_F(OpModelBase, typecastOp) {
+  // create TransposeOp
+  llvm::SmallVector<int64_t> tensorShape = {64, 1024};
+
+  RankedTensorType rankedTensorTypeBF16 =
+      RankedTensorType::get(tensorShape, builder.getBF16Type());
+
+  auto input =
+      builder.create<OnesOp>(builder.getUnknownLoc(), rankedTensorTypeBF16,
+                             ShapeAttr::get(&context, tensorShape),
+                             DataTypeAttr::get(&context, DataType::BFloat16),
+                             nullptr, nullptr, nullptr);
+  RankedTensorType rankedTensorTypeF32 =
+      RankedTensorType::get(tensorShape, builder.getF32Type());
+
+  auto typecast = builder.create<TypecastOp>(
+      builder.getUnknownLoc(), rankedTensorTypeF32, input, DataType::Float32);
+  typecast->setAttr(DeviceAttr::name, getFakeDeviceAttr());
+
+  // test transpose Op interface
+  auto constraintsExp = getOpConstraints(typecast.getOperation());
+  if (constraintsExp) {
+    auto l1 = constraintsExp.get();
+    const auto &[cb_size, peak_size, output_size] = l1;
+    EXPECT_EQ(cb_size, 12288);
+    EXPECT_EQ(peak_size, 4096);
+    EXPECT_EQ(output_size, 4096);
+  } else {
+    FAIL() << "Missing L1 constraints; Error="
+           << llvm::toString(constraintsExp.takeError()) << std::endl;
+  }
+
+  auto runtimeExp = getOpRuntime(typecast.getOperation());
+  if (runtimeExp) {
+    EXPECT_TRUE(runtimeExp.get() > 0);
+  } else {
+    FAIL() << llvm::toString(runtimeExp.takeError());
+  }
+}
+
 } // namespace mlir::tt::ttnn

--- a/test/unittests/OpModel/TTNN/OpModelFixture.h
+++ b/test/unittests/OpModel/TTNN/OpModelFixture.h
@@ -74,7 +74,8 @@ public:
       const mlir::tt::ttnn::TensorMemoryLayout &tensorMemoryLayout,
       const std::optional<llvm::SmallVector<int64_t>> &virtualGrid =
           std::nullopt,
-      const llvm::SmallVector<int64_t> physicalGrid = GetPhysicalGridSize()) {
+      const llvm::SmallVector<int64_t> physicalGrid = GetPhysicalGridSize(),
+      const std::optional<mlir::FloatType> dtype = std::nullopt) {
     const auto &virtualGridSelected =
         virtualGrid.has_value()
             ? virtualGrid.value()
@@ -84,10 +85,11 @@ public:
                              ? mlir::tt::ttnn::TensorMemoryLayoutAttr{}
                              : mlir::tt::ttnn::TensorMemoryLayoutAttr::get(
                                    &context, tensorMemoryLayout);
-
+    const auto dtypeSelected =
+        dtype.has_value() ? dtype.value() : builder.getBF16Type();
     return mlir::tt::ttnn::TTNNLayoutAttr::get(
-        &context, tensorShape,
-        mlir::tt::TileType::get(&context, builder.getBF16Type()), bufferType,
+        &context, tensorShape, mlir::tt::TileType::get(&context, dtypeSelected),
+        bufferType,
         CreateGrid(&context, tensorMemoryLayout, virtualGridSelected,
                    physicalGrid),
         memLayoutAttr);


### PR DESCRIPTION
### Ticket
#2315 

### Problem description
The optimizer needs more ops with constraints and runtime support to be able to ingest real models. Typecast is used in resnet  (#2277)

### What's changed
Added constraints and runtime API support for typecast. Added unit tests for the new APIs

Closes #2315

### Checklist
- [X] New/Existing tests provide coverage for changes
