### PR TITLE
Add cmake support for code coverage build type

### DIFF
--- a/cmake/modules/TTMLIRBuildTypes.cmake
+++ b/cmake/modules/TTMLIRBuildTypes.cmake
@@ -12,6 +12,20 @@ set(CMAKE_SHARED_LINKER_FLAGS_ASAN
     "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -fsanitize=address -shared-libasan" CACHE STRING
     "Linker lags to be used to create shared libraries for Asan build type." FORCE)
 
+# Code coverage build type
+set(CMAKE_C_FLAGS_COVERAGE
+    "${CMAKE_C_FLAGS_DEBUG} --coverage" CACHE STRING
+    "Flags used by the C compiler for code coverage build type or configuration." FORCE)
+set(CMAKE_CXX_FLAGS_COVERAGE
+    "${CMAKE_CXX_FLAGS_DEBUG} --coverage" CACHE STRING
+    "Flags used by the C++ compiler for code coverage build type or configuration." FORCE)
+set(CMAKE_EXE_LINKER_FLAGS_COVERAGE
+    "${CMAKE_EXE_LINKER_FLAGS_DEBUG} --coverage" CACHE STRING
+    "Linker flags to be used to create executables for code coverage build type." FORCE)
+set(CMAKE_SHARED_LINKER_FLAGS_COVERAGE
+    "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} --coverage" CACHE STRING
+    "Linker lags to be used to create shared libraries for code coverage build type." FORCE)
+
   # Assert build type
 set(CMAKE_C_FLAGS_ASSERT
   "${CMAKE_C_FLAGS_RELEASE}" CACHE STRING

--- a/test/ttmlir/Translate/LLVM/dylib.mlir
+++ b/test/ttmlir/Translate/LLVM/dylib.mlir
@@ -1,4 +1,5 @@
 // RUN: ttmlir-translate --llvm-to-dylib %s | llvm-nm -g - | FileCheck %s
+// UNSUPPORTED: system-darwin
 
 module attributes {ttir.cpu_module} {
   llvm.func @memrefCopy(i64, !llvm.ptr, !llvm.ptr)


### PR DESCRIPTION
Generate a coverage report with:

```bash
lcov --ignore-errors inconsistent,format --include $(pwd) --exclude $BUILD_DIR --directory $BUILD_DIR --capture --output-file $BUILD_DIR/coverage.info
genhtml --ignore-errors inconsistent,format,category $BUILD_DIR/coverage.info -o $BUILD_DIR/coverage-site
echo "Coverage report is available at $BUILD_DIR/coverage-site/index.html"
```
