### PR TITLE
Remove TTNN layout methods that reference device memory maps

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
@@ -209,10 +209,8 @@ def TTNN_TTNNLayoutAttr: TTNN_Attr<"TTNNLayout", "ttnn_layout"> {
     BufferType getBufferType() const;
     DataType getDataType() const;
     uint64_t getElementSizeBytes() const;
-    int64_t getTensorSizeInBytes(ArrayRef<int64_t> tensorShape, ::mlir::tt::DeviceAttr device) const;
     static llvm::SmallVector<int64_t> calculateLogicalShardShapeForSharding(ArrayRef<int64_t> tensorShape, mlir::AffineMap linear, GridAttr grid);
     static llvm::SmallVector<int64_t> calculateLogicalShardShapeForL1Interleaved(ArrayRef<int64_t> tensorShape, Type elementType, mlir::AffineMap linear, GridAttr grid);
-    llvm::SmallVector<int64_t> getStride(ArrayRef<int64_t> logicalShape) const;
     llvm::SmallVector<int64_t> getShardShape() const;
     llvm::SmallVector<int64_t> getScalarShardShape() const;
     AffineMap getIdentityTileLinearMap() const;

--- a/lib/Dialect/TTNN/Analysis/DFShardingPolicy.cpp
+++ b/lib/Dialect/TTNN/Analysis/DFShardingPolicy.cpp
@@ -120,20 +120,12 @@ void DFShardingPolicy::run() {
             TTNNLayoutAttr currentOpLayout =
                 legalLayouts.lookup(currentOp).front();
             assert(currentOpLayout.hasShardedL1TensorMemoryLayout());
-            llvm::ArrayRef<int64_t> currentOpOutputTensorShape =
-                mlir::cast<RankedTensorType>(currentOp->getResult(0).getType())
-                    .getShape();
             uint64_t currentOpL1OutputUsage =
-                currentOpLayout.getTensorSizeInBytes(currentOpOutputTensorShape,
-                                                     deviceAttr);
+                currentOpLayout.getShardSizeInBytes();
 
             TTNNLayoutAttr nextOpLayout = legalLayouts.lookup(nextOp).front();
             assert(nextOpLayout.hasShardedL1TensorMemoryLayout());
-            llvm::ArrayRef<int64_t> nextOpOutputTensorShape =
-                mlir::cast<RankedTensorType>(nextOp->getResult(0).getType())
-                    .getShape();
-            uint64_t nextOpL1OutputUsage = nextOpLayout.getTensorSizeInBytes(
-                nextOpOutputTensorShape, deviceAttr);
+            uint64_t nextOpL1OutputUsage = nextOpLayout.getShardSizeInBytes();
 
             // Figure out this const based on exec data, but will be replaced
             // with API.
@@ -174,8 +166,7 @@ void DFShardingPolicy::run() {
                                   currentOpLayout.getGrid());
 
                 uint64_t firstInputL1Usage =
-                    firstOpInputShardedLayout.getTensorSizeInBytes(
-                        firstOpInputTensorType.getShape(), deviceAttr);
+                    firstOpInputShardedLayout.getShardSizeInBytes();
 
                 firstInputL1UsageValid =
                     (firstInputL1Usage + currentOpL1OutputUsage) <

--- a/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
+++ b/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
@@ -277,12 +277,9 @@ bool ShardSolver::preprocessFirstOp() {
             .withGrid(firstOp->getContext(), firstOpInputTensorType,
                       firstOpLayout.getGrid());
 
-    uint64_t firstInputL1Usage = firstOpInputShardedLayout.getTensorSizeInBytes(
-        firstOpInputTensorType.getShape(), deviceAttr);
-    uint64_t firstOpL1OutputUsage = firstOpLayout.getTensorSizeInBytes(
-        mlir::cast<RankedTensorType>(firstOp->getResult(0).getType())
-            .getShape(),
-        deviceAttr);
+    uint64_t firstInputL1Usage =
+        firstOpInputShardedLayout.getShardSizeInBytes();
+    uint64_t firstOpL1OutputUsage = firstOpLayout.getShardSizeInBytes();
 
     if ((firstInputL1Usage + firstOpL1OutputUsage) >=
         tensorL1UsageCap * usableL1CacheSize) {
@@ -726,10 +723,7 @@ llvm::Expected<bool> ShardSolver::checkShardCompatible(
                    << outputTensorUsage << "\n";
     }
 
-    RankedTensorType producerTensorType =
-        mlir::cast<RankedTensorType>(producerOperand.getType());
-    uint64_t producerL1OutputUsage = producerLayout.getTensorSizeInBytes(
-        producerTensorType.getShape(), deviceAttr);
+    uint64_t producerL1OutputUsage = producerLayout.getShardSizeInBytes();
 
     bool l1UsageValid = (producerL1OutputUsage + outputTensorUsage +
                          cBUsagePeak) < tensorL1UsageCap * usableL1CacheSize;
@@ -751,18 +745,12 @@ llvm::Expected<bool> ShardSolver::checkShardCompatible(
 
     uint64_t producerL1OutputUsage = 0;
     if (producerLayout.hasL1BufferType()) {
-      RankedTensorType producerTensorType =
-          mlir::cast<RankedTensorType>(producerOperand.getType());
-      producerL1OutputUsage = producerLayout.getTensorSizeInBytes(
-          producerTensorType.getShape(), deviceAttr);
+      producerL1OutputUsage = producerLayout.getShardSizeInBytes();
     }
 
     uint64_t consumerL1OutputUsage = 0;
     if (consumerLayout.hasL1BufferType()) {
-      RankedTensorType consumerTensorType =
-          mlir::cast<RankedTensorType>(consumerOp->getResult(0).getType());
-      consumerL1OutputUsage = consumerLayout.getTensorSizeInBytes(
-          consumerTensorType.getShape(), deviceAttr);
+      consumerL1OutputUsage = consumerLayout.getShardSizeInBytes();
     }
 
     bool l1UsageValid = (producerL1OutputUsage + consumerL1OutputUsage) <


### PR DESCRIPTION
There were a couple methods on TTNN layout that make reference to the device l1/dram memory maps.  These maps are not intended for use in the TTNN dialect and do not model TTNN behavior, they are intended for metal backend only.

I noticed failures because we're trying to change the way these maps work for metal path refactor.
