### PR TITLE
#2403: Updated default system descriptor attributes in compiler to handle multi-device meshes

### DIFF
--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -206,7 +206,7 @@ def TT_SystemDescAttr : TT_Attr<"SystemDesc", "system_desc"> {
   let assemblyFormat = "`<` `[` $cpuDescs `]` `,` `[` $chipDescs `]` `,` `[` $chipDescIndices `]` `,` `[` $chipCapabilities `]` `,` `[` $chipCoords `]` (`,` `[` $chipChannels^ `]`)? `>`";
 
   let extraClassDeclaration = [{
-    static tt::SystemDescAttr getDefault(MLIRContext *context);
+    static tt::SystemDescAttr getDefault(MLIRContext *context, const llvm::SmallVector<int64_t> &meshShape = {1});
     static tt::SystemDescAttr getFromPath(MLIRContext *context, std::string& path);
     unsigned getAddressAlignBytes(unsigned chipIndex = 0) const;
     unsigned getAddressAlignBytes(MemorySpace memorySpace, unsigned chipIndex = 0) const;

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -134,6 +134,7 @@ def TTIRLoadSystemDesc: Pass<"ttir-load-system-desc", "::mlir::ModuleOp"> {
 
   list<Option> options = [
         Option<"path", "path", "std::string", "", "System desc path">,
+        ListOption<"meshShape", "mesh-shape", "int64_t", "Set the mesh shape.">,
     ];
 }
 

--- a/lib/Dialect/TTIR/Transforms/Utility.cpp
+++ b/lib/Dialect/TTIR/Transforms/Utility.cpp
@@ -60,7 +60,8 @@ public:
                       tt::SystemDescAttr::getFromPath(&getContext(), path));
     } else if (not module->hasAttr(tt::SystemDescAttr::name)) {
       module->setAttr(tt::SystemDescAttr::name,
-                      tt::SystemDescAttr::getDefault(&getContext()));
+                      tt::SystemDescAttr::getDefault(
+                          &getContext(), llvm::to_vector(meshShape)));
     }
   }
 };

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -60,8 +60,13 @@ void createTTIRBufferizationPipeline(OpPassManager &pm) {
 void createTTIRToTTMetalBackendPipeline(
     OpPassManager &pm, const TTIRToTTMetalBackendPipelineOptions &options) {
   ttir::TTIRLoadSystemDescOptions systemDescOptions;
-  { systemDescOptions.path = options.systemDescPath; }
+  {
+    systemDescOptions.path = options.systemDescPath;
+    systemDescOptions.meshShape = ::llvm::SmallVector<int64_t>(
+        options.meshShape.begin(), options.meshShape.end());
+  }
   pm.addPass(mlir::tt::ttir::createTTIRLoadSystemDesc(systemDescOptions));
+
   ttir::TTIRImplicitDeviceOptions implicitDeviceOptions;
   {
     implicitDeviceOptions.meshShape = ::llvm::SmallVector<int64_t>(

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -24,8 +24,12 @@ namespace mlir::tt::ttnn {
 
 void createTTNNPipelineTTIRPasses(
     OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options) {
+
   ttir::TTIRLoadSystemDescOptions systemDescOptions;
   systemDescOptions.path = options.systemDescPath;
+  systemDescOptions.meshShape = ::llvm::SmallVector<int64_t>(
+      options.meshShape.begin(), options.meshShape.end());
+  pm.addPass(mlir::tt::ttir::createTTIRLoadSystemDesc(systemDescOptions));
 
   pm.addPass(mlir::tt::createTTPopulateArgumentTypes(options.argumentTypeMap));
   pm.addPass(mlir::createCanonicalizerPass());
@@ -35,8 +39,6 @@ void createTTNNPipelineTTIRPasses(
   // Inlines all private functions. I.e flattens the program into the main
   // function. Removes all private functions.
   pm.addPass(mlir::createInlinerPass());
-
-  pm.addPass(mlir::tt::ttir::createTTIRLoadSystemDesc(systemDescOptions));
 
   ttir::TTIRImplicitDeviceOptions implicitDeviceOptions;
   implicitDeviceOptions.meshShape = ::llvm::SmallVector<int64_t>(


### PR DESCRIPTION
This change adds support for multi-device default values for the system descriptor in the compiler. It assumes a linear mesh connected in ring topology connections. This does not map to a physical layout but allows the user to run compiler passes on a multi-device configuration without having to provide a multi-device system descriptor. 

With change, you can now do this
```
ttmlir-opt --ttir-to-ttnn-backend-pipeline="mesh-shape=2,4" test.mlir
```