### PR TITLE
Fix a segfault in ReduceWindowOp conversion

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -1038,11 +1038,11 @@ private:
       return false;
     }
 
-    auto padding_elems = padding.asArrayRef();
-    auto first = padding_elems[0];
+    auto paddingElems = padding.asArrayRef();
+    auto first = paddingElems[0];
 
     // Check for splat padding (all zeroes expected).
-    if (llvm::all_of(padding_elems,
+    if (llvm::all_of(paddingElems,
                      [first](int value) { return value == first; })) {
       if (first != 0) {
         return false;

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -1039,7 +1039,7 @@ private:
     }
 
     // Check for splat padding (all zeroes expected).
-    if (llvm::all_equal(padding)) {
+    if (llvm::all_equal(padding.asArrayRef())) {
       if (padding[0] != 0) {
         return false;
       }

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -5,7 +5,6 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
-#include <llvm/ADT/STLExtras.h>
 #include <vector>
 
 #include "mlir/Dialect/Traits.h"
@@ -27,6 +26,7 @@
 #include "ttmlir/Utils.h"
 
 #include <llvm/ADT/APFloat.h>
+#include <llvm/ADT/STLExtras.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/Func/Transforms/FuncConversions.h>
 #include <mlir/Dialect/Tensor/IR/Tensor.h>
@@ -1038,13 +1038,9 @@ private:
       return false;
     }
 
-    auto paddingElems = padding.asArrayRef();
-    auto first = paddingElems[0];
-
     // Check for splat padding (all zeroes expected).
-    if (llvm::all_of(paddingElems,
-                     [first](int value) { return value == first; })) {
-      if (first != 0) {
+    if (llvm::all_equal(padding)) {
+      if (padding[0] != 0) {
         return false;
       }
       if (!llvm::all_of(windowDimensions,
@@ -1081,7 +1077,6 @@ private:
                                int64_t &dimension) const {
     int64_t dimArgValue = -1;
     int64_t idx = -1;
-    auto paddingValues = padding.asArrayRef();
 
     // Determine dimension attribute.
     for (int64_t windowDim : windowDimensions) {
@@ -1103,10 +1098,10 @@ private:
 
     for (int64_t i = 0; i < padding.size(); ++i) {
       if (i == (dimension * 2)) {
-        if (paddingValues[i] != (dimArgValue - 1)) {
+        if (padding[i] != (dimArgValue - 1)) {
           return false;
         }
-      } else if (paddingValues[i] != 0) {
+      } else if (padding[i] != 0) {
         return false;
       }
     }

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <llvm/ADT/STLExtras.h>
 #include <vector>
 
 #include "mlir/Dialect/Traits.h"
@@ -1041,13 +1042,13 @@ private:
     auto first = padding_elems[0];
 
     // Check for splat padding (all zeroes expected).
-    if (std::all_of(padding_elems.begin(), padding_elems.end(),
-                    [first](int value) { return value == first; })) {
+    if (llvm::all_of(padding_elems,
+                     [first](int value) { return value == first; })) {
       if (first != 0) {
         return false;
       }
-      if (!std::all_of(windowDimensions.begin(), windowDimensions.end(),
-                       [](int value) { return value == 1; })) {
+      if (!llvm::all_of(windowDimensions,
+                        [](int value) { return value == 1; })) {
         return false;
       }
       // Determine the dimension using input tensor shape.
@@ -1080,7 +1081,7 @@ private:
                                int64_t &dimension) const {
     int64_t dimArgValue = -1;
     int64_t idx = -1;
-    auto padding_values = padding.asArrayRef();
+    auto paddingValues = padding.asArrayRef();
 
     // Determine dimension attribute.
     for (int64_t windowDim : windowDimensions) {
@@ -1102,10 +1103,10 @@ private:
 
     for (int64_t i = 0; i < padding.size(); ++i) {
       if (i == (dimension * 2)) {
-        if (padding_values[i] != (dimArgValue - 1)) {
+        if (paddingValues[i] != (dimArgValue - 1)) {
           return false;
         }
-      } else if (padding_values[i] != 0) {
+      } else if (paddingValues[i] != 0) {
         return false;
       }
     }

--- a/test/ttmlir/Conversion/StableHLOToTTIR/cumsum_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/cumsum_op.mlir
@@ -100,4 +100,20 @@ module @moreh_cumsum attributes {} {
     // CHECK: return %[[RET]] : [[TENSOR]]
     return %0 : tensor<8x2x4x1xbf16>
   }
+
+  func.func @test_no_padding(%arg0: tensor<1x1xi32>) -> tensor<1x1xi32> {
+    // CHECK-LABEL: func.func @test_no_padding
+    // CHECK: %[[EMPTY:[0-9]+]] = tensor.empty() : [[TENSOR:tensor<1x1xi32>]]
+    // CHECK: %[[RET:[0-9]+]] = "ttir.cumsum"(%arg0, %[[EMPTY]])
+    // CHECK-SAME: <{dim = 0 : i64}>
+    // CHECK-SAME: ([[TENSOR]], [[TENSOR]]) -> [[TENSOR]]
+    %c = stablehlo.constant dense<0> : tensor<i32>
+    %0 = stablehlo.broadcast_in_dim %c, dims = [] : (tensor<i32>) -> tensor<i32>
+    %1 = "stablehlo.reduce_window"(%arg0, %0) <{window_dimensions = array<i64: 1, 1>}> ({
+    ^bb0(%arg1: tensor<i32>, %arg2: tensor<i32>):
+      %2 = stablehlo.add %arg1, %arg2 : tensor<i32>
+      stablehlo.return %2 : tensor<i32>
+    }) : (tensor<1x1xi32>, tensor<i32>) -> tensor<1x1xi32>
+    return %1 : tensor<1x1xi32>
+  }
 }


### PR DESCRIPTION
### Ticket
fixes #2401 

### Problem description
We retrieve the padding attribute in two places but only guard against it not existing in one place.

### What's changed
Now we read the padding attribute only once and pass it down trough arguments to where it's needed. 

### Checklist
- [X] New/Existing tests provide coverage for changes
