### PR TITLE
Parsing conv2d_config as editable attributes in explorer

### DIFF
--- a/python/TTNNModule.cpp
+++ b/python/TTNNModule.cpp
@@ -168,5 +168,98 @@ void populateTTNNModule(nb::module_ &m) {
       .def_prop_ro("data_type_as_int", [](tt::ttnn::TTNNLayoutAttr self) {
         return static_cast<uint32_t>(self.getDataType());
       });
+  tt_attribute_class<tt::ttnn::Conv2dConfigAttr>(m, "Conv2dConfigAttr")
+      .def_static(
+          "get",
+          [](MlirContext ctx, tt::DataType dtype, tt::DataType weightsDtype,
+             StringAttr activation, IntegerAttr inputChannelsAlignment,
+             BoolAttr deallocateActivation, BoolAttr reallocateHaloOutput,
+             IntegerAttr actBlockHOverride, IntegerAttr actBlockWDiv,
+             BoolAttr reshardIfNotOptimal, BoolAttr overrideShardingConfig,
+             tt::ttnn::TensorMemoryLayoutAttr shardLayout, Attribute coreGrid,
+             BoolAttr transposeShards, tt::ttnn::Layout outputLayout,
+             BoolAttr enableActDoubleBuffer, BoolAttr enableWeightsDoubleBuffer,
+             BoolAttr enableSplitReader, BoolAttr enableSubblockPadding) {
+            return wrap(tt::ttnn::Conv2dConfigAttr::get(
+                unwrap(ctx), dtype, weightsDtype, activation,
+                inputChannelsAlignment, deallocateActivation,
+                reallocateHaloOutput, actBlockHOverride, actBlockWDiv,
+                reshardIfNotOptimal, overrideShardingConfig, shardLayout,
+                coreGrid, transposeShards, outputLayout, enableActDoubleBuffer,
+                enableWeightsDoubleBuffer, enableSplitReader,
+                enableSubblockPadding));
+          })
+      .def_prop_ro("dtype",
+                   [](tt::ttnn::Conv2dConfigAttr self) {
+                     return static_cast<uint32_t>(self.getDtype());
+                   })
+      .def_prop_ro("weights_dtype",
+                   [](tt::ttnn::Conv2dConfigAttr self) {
+                     return static_cast<uint32_t>(self.getDtype());
+                   })
+      .def_prop_ro("activation",
+                   [](tt::ttnn::Conv2dConfigAttr self) {
+                     return self.getActivation().str();
+                   })
+      .def_prop_ro("input_channels_alignment",
+                   [](tt::ttnn::Conv2dConfigAttr self) {
+                     return self.getInputChannelsAlignment().getInt();
+                   })
+      .def_prop_ro("deallocate_activation",
+                   [](tt::ttnn::Conv2dConfigAttr self) {
+                     return self.getDeallocateActivation().getValue();
+                   })
+      .def_prop_ro("reallocate_halo_output",
+                   [](tt::ttnn::Conv2dConfigAttr self) {
+                     return self.getReallocateHaloOutput().getValue();
+                   })
+      .def_prop_ro("act_block_h_override",
+                   [](tt::ttnn::Conv2dConfigAttr self) {
+                     return self.getActBlockHOverride().getInt();
+                   })
+      .def_prop_ro("act_block_w_div",
+                   [](tt::ttnn::Conv2dConfigAttr self) {
+                     return self.getActBlockWDiv().getInt();
+                   })
+      .def_prop_ro("reshard_if_not_optimal",
+                   [](tt::ttnn::Conv2dConfigAttr self) {
+                     return self.getReshardIfNotOptimal().getValue();
+                   })
+      .def_prop_ro("override_sharding_config",
+                   [](tt::ttnn::Conv2dConfigAttr self) {
+                     return self.getOverrideShardingConfig().getValue();
+                   })
+      .def_prop_ro("shard_layout",
+                   [](tt::ttnn::Conv2dConfigAttr self) {
+                     return static_cast<uint32_t>(
+                         self.getShardLayout().getValue());
+                   })
+      // TODO(vkovacevic): parse core_grid
+      .def_prop_ro("core_grid",
+                   [](tt::ttnn::Conv2dConfigAttr self) { return nb::none(); })
+      .def_prop_ro("transpose_shards",
+                   [](tt::ttnn::Conv2dConfigAttr self) {
+                     return self.getTransposeShards().getValue();
+                   })
+      .def_prop_ro("output_layout",
+                   [](tt::ttnn::Conv2dConfigAttr self) {
+                     return static_cast<uint32_t>(self.getOutputLayout());
+                   })
+      .def_prop_ro("enable_act_double_buffer",
+                   [](tt::ttnn::Conv2dConfigAttr self) {
+                     return self.getEnableActDoubleBuffer().getValue();
+                   })
+      .def_prop_ro("enable_weights_double_buffer",
+                   [](tt::ttnn::Conv2dConfigAttr self) {
+                     return self.getEnableWeightsDoubleBuffer().getValue();
+                   })
+      .def_prop_ro("enable_split_reader",
+                   [](tt::ttnn::Conv2dConfigAttr self) {
+                     return self.getEnableSplitReader().getValue();
+                   })
+      .def_prop_ro("enable_subblock_padding",
+                   [](tt::ttnn::Conv2dConfigAttr self) {
+                     return self.getEnableSubblockPadding().getValue();
+                   });
 }
 } // namespace mlir::ttmlir::python

--- a/tools/explorer/CMakeLists.txt
+++ b/tools/explorer/CMakeLists.txt
@@ -3,7 +3,7 @@ include(ExternalProject)
 set(TT_EXPLORER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/run.py)
 set(TTMLIR_BUILD_BIN_DIR ${TTMLIR_BINARY_DIR}/bin)
 
-set(MODEL_EXPLORER_VERSION "5be0dda742f81a7dcc8aeec90afd40198cc686a2")
+set(MODEL_EXPLORER_VERSION "main")
 ExternalProject_Add(
   model-explorer
   PREFIX ${CMAKE_CURRENT_SOURCE_DIR}/model-explorer
@@ -17,9 +17,9 @@ ExternalProject_Add(
 
 set(PIP_EDITABLE_FLAG "")
 
-if (TT_EXPLORER_EDITABLE)
+#if (TT_EXPLORER_EDITABLE)
   set(PIP_EDITABLE_FLAG "-e")
-endif()
+#endif()
 
 add_custom_target(explorer
   COMMENT "Building tt-explorer... ${TTMLIR_BIN_DIR}"

--- a/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
@@ -464,6 +464,218 @@ def parse_ttnn_ttnn_layout(attr):
             },
         )
     )
+
+    return result
+
+
+@AttrHandler.register_handler("conv2d_config")
+def parse_conv2d_config(attr):
+    conv2d_config = ttnn.ir.Conv2dConfigAttr.maybe_downcast(attr)
+    result = []
+    result.append(
+        utils.make_editable_kv(
+            graph_builder.KeyValue(
+                key="dtype",
+                value=str(tt.DataType(conv2d_config.dtype)),
+            ),
+            editable={
+                "input_type": "value_list",
+                "options": [str(o) for o in tt.DataType],
+            },
+        )
+    )
+    result.append(
+        utils.make_editable_kv(
+            graph_builder.KeyValue(
+                key="weights_dtype",
+                value=str(tt.DataType(conv2d_config.weights_dtype)),
+            ),
+            editable={
+                "input_type": "value_list",
+                "options": [str(o) for o in tt.DataType],
+            },
+        )
+    )
+    result.append(
+        utils.make_editable_kv(
+            graph_builder.KeyValue(
+                key="activation",
+                value=conv2d_config.activation,
+            ),
+            editable={
+                "input_type": "value_list",
+                "options": ["relu"],
+            },
+        )
+    )
+    result.append(
+        utils.make_editable_kv(
+            graph_builder.KeyValue(
+                key="input_channels_alignment",
+                value=str(conv2d_config.input_channels_alignment),
+            ),
+            editable={
+                "input_type": "value_list",
+                "options": ["32", "16"],
+            },
+        )
+    )
+    result.append(
+        utils.make_editable_kv(
+            graph_builder.KeyValue(
+                key="deallocate_activation",
+                value=str(conv2d_config.deallocate_activation),
+            ),
+            editable={
+                "input_type": "value_list",
+                "options": ["True", "False"],
+            },
+        )
+    )
+    result.append(
+        utils.make_editable_kv(
+            graph_builder.KeyValue(
+                key="reallocate_halo_output",
+                value=str(conv2d_config.reallocate_halo_output),
+            ),
+            editable={
+                "input_type": "value_list",
+                "options": ["True", "False"],
+            },
+        )
+    )
+    result.append(
+        utils.make_editable_kv(
+            graph_builder.KeyValue(
+                key="act_block_h_override",
+                value=str(conv2d_config.act_block_h_override),
+            ),
+            editable={
+                "input_type": "int_list",
+                "min_value": 0,
+                "max_value": 100 * 32,
+                "step": 32,
+            },
+        )
+    )
+    result.append(
+        utils.make_editable_kv(
+            graph_builder.KeyValue(
+                key="act_block_w_div",
+                value=str(conv2d_config.act_block_w_div),
+            ),
+            editable={"input_type": "int_list", "min_value": 0, "step": 1},
+        )
+    )
+    result.append(
+        utils.make_editable_kv(
+            graph_builder.KeyValue(
+                key="reshard_if_not_optimal",
+                value=str(conv2d_config.reshard_if_not_optimal),
+            ),
+            editable={
+                "input_type": "value_list",
+                "options": ["True", "False"],
+            },
+        )
+    )
+    result.append(
+        utils.make_editable_kv(
+            graph_builder.KeyValue(
+                key="override_sharding_config",
+                value=str(conv2d_config.override_sharding_config),
+            ),
+            editable={
+                "input_type": "value_list",
+                "options": ["True", "False"],
+            },
+        )
+    )
+    result.append(
+        utils.make_editable_kv(
+            graph_builder.KeyValue(
+                key="shard_layout",
+                value=str(ttnn.TensorMemoryLayout(conv2d_config.shard_layout)),
+            ),
+            editable={
+                "input_type": "value_list",
+                "options": [str(o) for o in ttnn.TensorMemoryLayout],
+            },
+        )
+    )
+    result.append(
+        utils.make_editable_kv(
+            graph_builder.KeyValue(
+                key="transpose_shards",
+                value=str(conv2d_config.transpose_shards),
+            ),
+            editable={
+                "input_type": "value_list",
+                "options": ["True", "False"],
+            },
+        )
+    )
+    result.append(
+        utils.make_editable_kv(
+            graph_builder.KeyValue(
+                key="output_layout",
+                value=str(ttnn.Layout(conv2d_config.output_layout)),
+            ),
+            editable={
+                "input_type": "value_list",
+                "options": [str(o) for o in ttnn.Layout],
+            },
+        )
+    )
+    result.append(
+        utils.make_editable_kv(
+            graph_builder.KeyValue(
+                key="enable_act_double_buffer",
+                value=str(conv2d_config.enable_act_double_buffer),
+            ),
+            editable={
+                "input_type": "value_list",
+                "options": ["True", "False"],
+            },
+        )
+    )
+    result.append(
+        utils.make_editable_kv(
+            graph_builder.KeyValue(
+                key="enable_weights_double_buffer",
+                value=str(conv2d_config.enable_weights_double_buffer),
+            ),
+            editable={
+                "input_type": "value_list",
+                "options": ["True", "False"],
+            },
+        )
+    )
+    result.append(
+        utils.make_editable_kv(
+            graph_builder.KeyValue(
+                key="enable_split_reader",
+                value=str(conv2d_config.enable_split_reader),
+            ),
+            editable={
+                "input_type": "value_list",
+                "options": ["True", "False"],
+            },
+        )
+    )
+    result.append(
+        utils.make_editable_kv(
+            graph_builder.KeyValue(
+                key="enable_subblock_padding",
+                value=str(conv2d_config.enable_subblock_padding),
+            ),
+            editable={
+                "input_type": "value_list",
+                "options": ["True", "False"],
+            },
+        )
+    )
+
     return result
 
 

--- a/tools/explorer/tt_adapter/src/tt_adapter/runner.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/runner.py
@@ -7,6 +7,7 @@ import logging
 
 # TODO(odjuricic) Cleaner to implement ttrt --quiet flag.
 # os.environ["TTRT_LOGGER_LEVEL"] = "ERROR"
+logging.basicConfig(level=logging.DEBUG)
 from ttrt import API as ttrt
 from ttmlir import passes
 from . import utils, mlir


### PR DESCRIPTION
### Ticket
Closes #2209 

### What's changed
Added python bindings for parsing conv2d_config.
Made conv2d_config attributes editable in tt-explorer.
Although editable, changed attributes won't be used in execution (todo).

