### PR TITLE
Add constraints and runtime API for Conv2d

### DIFF
--- a/include/Constants.h
+++ b/include/Constants.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/include/Constants.h
+++ b/include/Constants.h
@@ -7,12 +7,12 @@
 
 #include <cstddef>
 
-namespace mlir::tt::ttnn::constants {
+namespace tt::constants {
 
 // Default L1 small size to use for the ttnn runtime (32kb).
 // This reserves a region of L1 memory for L1_SMALL buffers used by convs.
 constexpr static std::size_t L1_SMALL_SIZE = 1 << 15;
 
-} // namespace mlir::tt::ttnn::constants
+} // namespace tt::constants
 
 #endif // TTMLIR_DIALECT_TTNN_UTILS_CONSTANTS_H

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1117,7 +1117,9 @@ def TTNN_MatmulOp : TTNN_Op<"matmul",
 }
 // ANCHOR_END: adding_an_op_matmul_ttnn
 
-def TTNN_Conv2dOp : TTNN_Op<"conv2d"> {
+def TTNN_Conv2dOp : TTNN_Op<"conv2d",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
     let summary = "Conv2d operation.";
     let description = [{
       Applies a 2D convolution over an input image composed of several input planes.

--- a/include/ttmlir/Dialect/TTNN/Utils/Constants.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/Constants.h
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_UTILS_CONSTANTS_H
+#define TTMLIR_DIALECT_TTNN_UTILS_CONSTANTS_H
+
+#include <cstddef>
+
+namespace mlir::tt::ttnn::constants {
+
+// Default L1 small size to use for the ttnn runtime (32kb).
+// This reserves a region of L1 memory for L1_SMALL buffers used by convs.
+constexpr static std::size_t L1_SMALL_SIZE = 1 << 15;
+
+} // namespace mlir::tt::ttnn::constants
+
+#endif // TTMLIR_DIALECT_TTNN_UTILS_CONSTANTS_H

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -223,5 +223,45 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
 
 }; // namespace MultiplyOpInterface
 
+//===----------------------------------------------------------------------===//
+// Conv2dOp
+//===----------------------------------------------------------------------===//
+
+namespace Conv2dOpInterface {
+llvm::Expected<std::tuple<size_t, size_t, size_t>>
+getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+                 llvm::ArrayRef<int64_t> weightShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr weightLayout,
+                 std::optional<llvm::ArrayRef<int64_t>> biasShape,
+                 std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
+                 int32_t in_channels, int32_t out_channels, int32_t batch_size,
+                 int32_t input_height, int32_t input_width,
+                 llvm::ArrayRef<int32_t> kernel_size,
+                 llvm::ArrayRef<int32_t> stride,
+                 llvm::ArrayRef<int32_t> padding,
+                 llvm::ArrayRef<int32_t> dilation, int32_t groups,
+                 std::optional<mlir::tt::ttnn::Conv2dConfigAttr> conv2dConfig,
+                 llvm::ArrayRef<int64_t> outputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+
+llvm::Expected<size_t>
+getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+             llvm::ArrayRef<int64_t> weightShape,
+             mlir::tt::ttnn::TTNNLayoutAttr weightLayout,
+             std::optional<llvm::ArrayRef<int64_t>> biasShape,
+             std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
+             int32_t in_channels, int32_t out_channels, int32_t batch_size,
+             int32_t input_height, int32_t input_width,
+             llvm::ArrayRef<int32_t> kernel_size,
+             llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+             llvm::ArrayRef<int32_t> dilation, int32_t groups,
+             std::optional<mlir::tt::ttnn::Conv2dConfigAttr> conv2dConfig,
+             llvm::ArrayRef<int64_t> outputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+
+}; // namespace Conv2dOpInterface
+
 } // namespace mlir::tt::op_model::ttnn
 #endif // TTMLIR_OPMODEL_TTNN_TTNNOPMODEL_H

--- a/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
+++ b/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
@@ -702,8 +702,8 @@ llvm::Expected<bool> ShardSolver::checkShardCompatible(
       if (DEBUG) {
         llvm::errs() << "OpModel constraints failed: ";
         llvm::errs() << producerOperand.getLoc() << "->"
-                     << consumerOp->getName()
-                     << " :: " << llvm::toString(l1UsageExp.takeError())
+                     << consumerOp->getName() << " :: "
+                     << llvm::toStringWithoutConsuming(l1UsageExp.takeError())
                      << "\n";
         producerLayout.dump();
         consumerLayout.dump();

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -417,4 +417,69 @@ MultiplyOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
       inputShapeA, inputs[0], inputShapeB, inputs[1], outputShape, output);
 }
 
+//===----------------------------------------------------------------------===//
+// Conv2dOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<std::tuple<size_t, size_t, size_t>>
+Conv2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                           const TTNNLayoutAttr &output) {
+  assert(inputs.size() == 2 || inputs.size() == 3);
+
+  const auto inputShape =
+      mlir::cast<RankedTensorType>(getOperand(0).getType()).getShape();
+  const auto weightShape =
+      mlir::cast<RankedTensorType>(getOperand(1).getType()).getShape();
+  std::optional<llvm::ArrayRef<int64_t>> biasShape;
+  std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout;
+
+  if (inputs.size() == 3) {
+    biasShape =
+        mlir::cast<RankedTensorType>(getOperand(2).getType()).getShape();
+    biasLayout = inputs[2];
+  }
+
+  const auto outputShape =
+      mlir::cast<RankedTensorType>(getResult().getType()).getShape();
+
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+
+  return op_model::ttnn::Conv2dOpInterface::getOpConstraints(
+      inputShape, inputs[0], weightShape, inputs[1], biasShape, biasLayout,
+      getInChannels(), getOutChannels(), getBatchSize(), getInputHeight(),
+      getInputWidth(), getKernelSize(), getStride(), getPadding(),
+      getDilation(), getGroups(), getConv2dConfig(), outputShape, output);
+}
+
+llvm::Expected<size_t>
+Conv2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                       const TTNNLayoutAttr &output) {
+  assert(inputs.size() == 2 || inputs.size() == 3);
+
+  const auto inputShape =
+      mlir::cast<RankedTensorType>(getOperand(0).getType()).getShape();
+  const auto weightShape =
+      mlir::cast<RankedTensorType>(getOperand(1).getType()).getShape();
+  std::optional<llvm::ArrayRef<int64_t>> biasShape;
+  std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout;
+
+  if (inputs.size() == 3) {
+    biasShape =
+        mlir::cast<RankedTensorType>(getOperand(2).getType()).getShape();
+    biasLayout = inputs[2];
+  }
+
+  const auto outputShape =
+      mlir::cast<RankedTensorType>(getResult().getType()).getShape();
+
+  return op_model::ttnn::Conv2dOpInterface::getOpRuntime(
+      inputShape, inputs[0], weightShape, inputs[1], biasShape, biasLayout,
+      getInChannels(), getOutChannels(), getBatchSize(), getInputHeight(),
+      getInputWidth(), getKernelSize(), getStride(), getPadding(),
+      getDilation(), getGroups(), getConv2dConfig(), outputShape, output);
+}
+
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -426,21 +426,17 @@ Conv2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                            const TTNNLayoutAttr &output) {
   assert(inputs.size() == 2 || inputs.size() == 3);
 
-  const auto inputShape =
-      mlir::cast<RankedTensorType>(getOperand(0).getType()).getShape();
-  const auto weightShape =
-      mlir::cast<RankedTensorType>(getOperand(1).getType()).getShape();
+  const auto inputShape = getInput().getType().getShape();
+  const auto weightShape = getWeight().getType().getShape();
   std::optional<llvm::ArrayRef<int64_t>> biasShape;
   std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout;
 
   if (inputs.size() == 3) {
-    biasShape =
-        mlir::cast<RankedTensorType>(getOperand(2).getType()).getShape();
+    biasShape = getBias().getType().getShape();
     biasLayout = inputs[2];
   }
 
-  const auto outputShape =
-      mlir::cast<RankedTensorType>(getResult().getType()).getShape();
+  const auto outputShape = getResult().getType().getShape();
 
   llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
   if (!check) {
@@ -459,21 +455,17 @@ Conv2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                        const TTNNLayoutAttr &output) {
   assert(inputs.size() == 2 || inputs.size() == 3);
 
-  const auto inputShape =
-      mlir::cast<RankedTensorType>(getOperand(0).getType()).getShape();
-  const auto weightShape =
-      mlir::cast<RankedTensorType>(getOperand(1).getType()).getShape();
+  const auto inputShape = getInput().getType().getShape();
+  const auto weightShape = getWeight().getType().getShape();
   std::optional<llvm::ArrayRef<int64_t>> biasShape;
   std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout;
 
   if (inputs.size() == 3) {
-    biasShape =
-        mlir::cast<RankedTensorType>(getOperand(2).getType()).getShape();
+    biasShape = getBias().getType().getShape();
     biasLayout = inputs[2];
   }
 
-  const auto outputShape =
-      mlir::cast<RankedTensorType>(getResult().getType()).getShape();
+  const auto outputShape = getResult().getType().getShape();
 
   return op_model::ttnn::Conv2dOpInterface::getOpRuntime(
       inputShape, inputs[0], weightShape, inputs[1], biasShape, biasLayout,

--- a/lib/OpModel/TTNN/Conversion.hpp
+++ b/lib/OpModel/TTNN/Conversion.hpp
@@ -11,8 +11,7 @@
 
 namespace mlir::tt::op_model::ttnn {
 namespace conversion {
-::tt::tt_metal::DataType
-getDataType(const mlir::tt::ttnn::TTNNLayoutAttr layout);
+::tt::tt_metal::DataType getDataType(const DataType dataType);
 
 ::tt::tt_metal::DataType getDataType(mlir::tt::DataType dtype);
 
@@ -35,8 +34,8 @@ getShardSpec(const mlir::tt::ttnn::TTNNLayoutAttr &layout);
 ::tt::tt_metal::BufferType
 getBufferType(const mlir::tt::ttnn::TTNNLayoutAttr &layout);
 
-::tt::tt_metal::TensorMemoryLayout
-getTensorMemoryLayout(const mlir::tt::ttnn::TTNNLayoutAttr &layout);
+::tt::tt_metal::TensorMemoryLayout getTensorMemoryLayout(
+    const mlir::tt::ttnn::TensorMemoryLayoutAttr memLayoutAttr);
 
 ::tt::tt_metal::MemoryConfig
 getMemoryConfig(const mlir::tt::ttnn::TTNNLayoutAttr &layout);
@@ -49,6 +48,12 @@ getTensorLayout(const mlir::tt::ttnn::TTNNLayoutAttr &layout);
 
 ::ttnn::SmallVector<int>
 convertLLVMSmallVecToTTNNSmallVec(const ::llvm::ArrayRef<int64_t> vec);
+
+std::array<uint32_t, 2>
+convertArrayRefToArray(const llvm::ArrayRef<int32_t> array);
+
+std::optional<::ttnn::operations::conv::conv2d::Conv2dConfig> getConv2dConfig(
+    const std::optional<mlir::tt::ttnn::Conv2dConfigAttr> &conv2dConfig);
 
 } // namespace conversion
 } // namespace mlir::tt::op_model::ttnn

--- a/lib/OpModel/TTNN/MetalHeaders.h
+++ b/lib/OpModel/TTNN/MetalHeaders.h
@@ -64,6 +64,7 @@ using IDevice = ::tt::tt_metal::IDevice;
 #include "ttnn/graph/graph_query_op_constraints.hpp"
 #include "ttnn/graph/graph_query_op_runtime.hpp"
 #include "ttnn/graph/graph_trace_utils.hpp"
+#include "ttnn/operations/conv/conv2d/conv2d.hpp"
 #include "ttnn/operations/copy.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/data_movement/reshape_view/reshape.hpp"

--- a/lib/OpModel/TTNN/SingletonDeviceContext.cpp
+++ b/lib/OpModel/TTNN/SingletonDeviceContext.cpp
@@ -7,6 +7,7 @@
 
 #include "MetalHeaders.h"
 
+#include "ttmlir/Dialect/TTNN/Utils/Constants.h"
 namespace mlir::tt::op_model::ttnn {
 
 // todo(arminaleTT): look into dynamically adjusting this
@@ -16,17 +17,7 @@ namespace mlir::tt::op_model::ttnn {
 static constexpr size_t opModelDefaultTraceRegionSize = 200000;
 
 SingletonDeviceContext::SingletonDeviceContext(const size_t traceRegionSize) {
-
-  // todo: this replicates logic in runtime/include/tt/runtime/detail/common.h,
-  // move to shared location
-  size_t numDevices = ::tt::tt_metal::GetNumAvailableDevices();
-  size_t numPCIeDevices = ::tt::tt_metal::GetNumPCIeDevices();
-  ::tt::tt_metal::DispatchCoreType dispatchCoreType =
-      numDevices == numPCIeDevices ? ::tt::tt_metal::DispatchCoreType::WORKER
-                                   : ::tt::tt_metal::DispatchCoreType::ETH;
-  m_device = ::tt::tt_metal::CreateDevice(
-      0, /* num_hw_cqs = */ 1, /* l1_small_size = */ DEFAULT_L1_SMALL_SIZE,
-      /* trace_region_size = */ traceRegionSize, dispatchCoreType);
+  resetDevice(traceRegionSize);
 }
 
 SingletonDeviceContext::~SingletonDeviceContext() {
@@ -37,6 +28,29 @@ SingletonDeviceContext &SingletonDeviceContext::getInstance() {
   static SingletonDeviceContext instance =
       SingletonDeviceContext(opModelDefaultTraceRegionSize);
   return instance;
+}
+
+void SingletonDeviceContext::resetInstance() {
+  SingletonDeviceContext &instance = getInstance();
+  instance.resetDevice(opModelDefaultTraceRegionSize);
+}
+
+void SingletonDeviceContext::resetDevice(const size_t traceRegionSize) {
+  if (m_device) {
+    ::tt::tt_metal::CloseDevice(m_device);
+  }
+
+  // todo: this replicates logic in runtime/include/tt/runtime/detail/common.h,
+  // move to shared location
+  size_t numDevices = ::tt::tt_metal::GetNumAvailableDevices();
+  size_t numPCIeDevices = ::tt::tt_metal::GetNumPCIeDevices();
+  ::tt::tt_metal::DispatchCoreType dispatchCoreType =
+      numDevices == numPCIeDevices ? ::tt::tt_metal::DispatchCoreType::WORKER
+                                   : ::tt::tt_metal::DispatchCoreType::ETH;
+  m_device = ::tt::tt_metal::CreateDevice(
+      0, /* num_hw_cqs = */ 1,
+      /* l1_small_size = */ mlir::tt::ttnn::constants::L1_SMALL_SIZE,
+      /* trace_region_size = */ traceRegionSize, dispatchCoreType);
 }
 
 } // namespace mlir::tt::op_model::ttnn

--- a/lib/OpModel/TTNN/SingletonDeviceContext.cpp
+++ b/lib/OpModel/TTNN/SingletonDeviceContext.cpp
@@ -49,7 +49,7 @@ void SingletonDeviceContext::resetDevice(const size_t traceRegionSize) {
                                    : ::tt::tt_metal::DispatchCoreType::ETH;
   m_device = ::tt::tt_metal::CreateDevice(
       0, /* num_hw_cqs = */ 1,
-      /* l1_small_size = */ mlir::tt::ttnn::constants::L1_SMALL_SIZE,
+      /* l1_small_size = */ ::tt::constants::L1_SMALL_SIZE,
       /* trace_region_size = */ traceRegionSize, dispatchCoreType);
 }
 

--- a/lib/OpModel/TTNN/SingletonDeviceContext.cpp
+++ b/lib/OpModel/TTNN/SingletonDeviceContext.cpp
@@ -5,9 +5,9 @@
 #ifdef TTMLIR_ENABLE_OPMODEL
 #include "SingletonDeviceContext.h"
 
+#include "Constants.h"
 #include "MetalHeaders.h"
 
-#include "ttmlir/Dialect/TTNN/Utils/Constants.h"
 namespace mlir::tt::op_model::ttnn {
 
 // todo(arminaleTT): look into dynamically adjusting this

--- a/lib/OpModel/TTNN/SingletonDeviceContext.h
+++ b/lib/OpModel/TTNN/SingletonDeviceContext.h
@@ -29,6 +29,7 @@ namespace mlir::tt::op_model::ttnn {
 class SingletonDeviceContext {
 public:
   static SingletonDeviceContext &getInstance();
+  static void resetInstance();
 
   ::tt::tt_metal::v0::IDevice *getDevice() { return m_device; }
 
@@ -41,6 +42,8 @@ private:
   SingletonDeviceContext &operator=(const SingletonDeviceContext &) = delete;
 
   ::tt::tt_metal::IDevice *m_device;
+
+  void resetDevice(const size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE);
 };
 } // namespace mlir::tt::op_model::ttnn
 

--- a/lib/OpModel/TTNN/TTNNOpModelLib.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModelLib.cpp
@@ -977,7 +977,6 @@ Conv2dOpInterface::getOpConstraints(
          llvm::ArrayRef<int64_t> outputShape,
          mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
         // open device device, will close it at the end of function
-
         ::tt::tt_metal::v0::IDevice *device =
             SingletonDeviceContext::getInstance().getDevice();
 

--- a/lib/OpModel/TTNN/TTNNOpModelLib.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModelLib.cpp
@@ -941,4 +941,153 @@ MultiplyOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
+//===----------------------------------------------------------------------===//
+// Conv2dOp
+//===----------------------------------------------------------------------===//
+llvm::Expected<std::tuple<size_t, size_t, size_t>>
+Conv2dOpInterface::getOpConstraints(
+    llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> weightShape,
+    mlir::tt::ttnn::TTNNLayoutAttr weightLayout,
+    std::optional<llvm::ArrayRef<int64_t>> biasShape,
+    std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
+    int32_t in_channels, int32_t out_channels, int32_t batch_size,
+    int32_t input_height, int32_t input_width,
+    llvm::ArrayRef<int32_t> kernel_size, llvm::ArrayRef<int32_t> stride,
+    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
+    int32_t groups,
+    std::optional<mlir::tt::ttnn::Conv2dConfigAttr> conv2dConfig,
+    llvm::ArrayRef<int64_t> outputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  auto conv2dOpQuery =
+      [](llvm::ArrayRef<int64_t> inputShape,
+         mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+         llvm::ArrayRef<int64_t> weightShape,
+         mlir::tt::ttnn::TTNNLayoutAttr weightLayout,
+         std::optional<llvm::ArrayRef<int64_t>> biasShape,
+         std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
+         int32_t in_channels, int32_t out_channels, int32_t batch_size,
+         int32_t input_height, int32_t input_width,
+         llvm::ArrayRef<int32_t> kernel_size, llvm::ArrayRef<int32_t> stride,
+         llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
+         int32_t groups,
+         std::optional<mlir::tt::ttnn::Conv2dConfigAttr> conv2dConfig,
+         llvm::ArrayRef<int64_t> outputShape,
+         mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+        // open device device, will close it at the end of function
+
+        ::tt::tt_metal::v0::IDevice *device =
+            SingletonDeviceContext::getInstance().getDevice();
+
+        // prepare io specs
+        const auto [inputSpec, weightSpec, outputSpec] =
+            detail::convertToTensorSpec(
+                device, std::make_tuple(inputShape, inputLayout),
+                std::make_tuple(weightShape, weightLayout),
+                std::make_tuple(outputShape, outputLayout));
+
+        std::optional<::tt::tt_metal::Tensor> biasTensor;
+        if (biasShape && biasLayout) {
+          ::ttnn::TensorSpec biasSpec =
+              conversion::getTensorSpec(biasShape.value(), biasLayout.value());
+          biasTensor = ::tt::tt_metal::create_device_tensor(biasSpec, device);
+        }
+
+        auto conv2dConfigConverted = conversion::getConv2dConfig(conv2dConfig);
+
+        return ::ttnn::graph::query_op_constraints(
+            ::ttnn::conv2d, device, inputSpec, weightSpec, device, in_channels,
+            out_channels, batch_size, input_height, input_width,
+            conversion::convertArrayRefToArray(kernel_size),
+            conversion::convertArrayRefToArray(stride),
+            conversion::convertArrayRefToArray(padding),
+            conversion::convertArrayRefToArray(dilation), groups, biasTensor,
+            conv2dConfigConverted, std::nullopt,
+            outputSpec.tensor_layout().get_memory_config());
+      };
+
+  return operation::getOpConstraints(
+      "Conv2dOpInterface", conv2dOpQuery, inputShape, inputLayout, weightShape,
+      weightLayout, biasShape, biasLayout, in_channels, out_channels,
+      batch_size, input_height, input_width, kernel_size, stride, padding,
+      dilation, groups, conv2dConfig, outputShape, outputLayout);
+#else
+  return std::make_tuple(0, 0, 0);
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t> Conv2dOpInterface::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> weightShape,
+    mlir::tt::ttnn::TTNNLayoutAttr weightLayout,
+    std::optional<llvm::ArrayRef<int64_t>> biasShape,
+    std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
+    int32_t in_channels, int32_t out_channels, int32_t batch_size,
+    int32_t input_height, int32_t input_width,
+    llvm::ArrayRef<int32_t> kernel_size, llvm::ArrayRef<int32_t> stride,
+    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
+    int32_t groups,
+    std::optional<mlir::tt::ttnn::Conv2dConfigAttr> conv2dConfig,
+    llvm::ArrayRef<int64_t> outputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  auto conv2dOpQuery =
+      [](llvm::ArrayRef<int64_t> inputShape,
+         mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+         llvm::ArrayRef<int64_t> weightShape,
+         mlir::tt::ttnn::TTNNLayoutAttr weightLayout,
+         std::optional<llvm::ArrayRef<int64_t>> biasShape,
+         std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
+         int32_t in_channels, int32_t out_channels, int32_t batch_size,
+         int32_t input_height, int32_t input_width,
+         llvm::ArrayRef<int32_t> kernel_size, llvm::ArrayRef<int32_t> stride,
+         llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
+         int32_t groups,
+         std::optional<mlir::tt::ttnn::Conv2dConfigAttr> conv2dConfig,
+         llvm::ArrayRef<int64_t> outputShape,
+         mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+        // open device device, will close it at the end of function
+        ::tt::tt_metal::v0::IDevice *device =
+            SingletonDeviceContext::getInstance().getDevice();
+
+        // prepare io specs
+        const auto [inputSpec, weightSpec, outputSpec] =
+            detail::convertToTensorSpec(
+                device, std::make_tuple(inputShape, inputLayout),
+                std::make_tuple(weightShape, weightLayout),
+                std::make_tuple(outputShape, outputLayout));
+
+        std::optional<::tt::tt_metal::Tensor> biasTensor;
+        if (biasShape && biasLayout) {
+          ::ttnn::TensorSpec biasSpec =
+              conversion::getTensorSpec(biasShape.value(), biasLayout.value());
+          biasTensor = ::tt::tt_metal::create_device_tensor(biasSpec, device);
+        }
+
+        auto conv2dConfigConverted = conversion::getConv2dConfig(conv2dConfig);
+
+        return ::ttnn::graph::query_op_runtime(
+            ::ttnn::conv2d, device, inputSpec, weightSpec, device, in_channels,
+            out_channels, batch_size, input_height, input_width,
+            conversion::convertArrayRefToArray(kernel_size),
+            conversion::convertArrayRefToArray(stride),
+            conversion::convertArrayRefToArray(padding),
+            conversion::convertArrayRefToArray(dilation), groups, biasTensor,
+            conv2dConfigConverted, std::nullopt,
+            outputSpec.tensor_layout().get_memory_config());
+      };
+
+  return operation::getOpRuntime(
+      "Conv2dOpInterface", conv2dOpQuery, inputShape, inputLayout, weightShape,
+      weightLayout, biasShape, biasLayout, in_channels, out_channels,
+      batch_size, input_height, input_width, kernel_size, stride, padding,
+      dilation, groups, conv2dConfig, outputShape, outputLayout);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
 } // namespace mlir::tt::op_model::ttnn

--- a/runtime/include/tt/runtime/detail/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn.h
@@ -48,9 +48,6 @@
 
 namespace tt::runtime::ttnn {
 
-// Default L1 small size to use for the ttnn runtime (32kb).
-constexpr std::size_t kL1SmallSize = 1 << 15;
-
 Tensor createOwnedTensor(std::shared_ptr<void> data,
                          std::vector<std::uint32_t> const &shape,
                          std::vector<std::uint32_t> const &stride,

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "Constants.h"
 #include "tt-metalium/small_vector.hpp"
 #include "tt/runtime/detail/common.h"
 #include "tt/runtime/detail/debug.h"
@@ -11,7 +12,6 @@
 #include "tt/runtime/ttnn/types.h"
 #include "tt/runtime/ttnn/utils.h"
 #include "tt/runtime/utils.h"
-#include "ttmlir/Dialect/TTNN/Utils/Constants.h"
 #include "ttmlir/Target/TTNN/Target.h"
 #include "ttmlir/Version.h"
 #include "ttnn/tensor/types.hpp"

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -215,8 +215,7 @@ Device openDevice(DeviceIds const &deviceIds, size_t numHWCQs,
   LOG_ASSERT(deviceIds.size(), "No devices specified");
   ::tt::tt_metal::distributed::MeshShape grid{
       1, static_cast<uint32_t>(deviceIds.size())};
-  size_t l1SmallSizeValue =
-      l1SmallSize.value_or(mlir::tt::ttnn::constants::L1_SMALL_SIZE);
+  size_t l1SmallSizeValue = l1SmallSize.value_or(tt::constants::L1_SMALL_SIZE);
   std::shared_ptr<::ttnn::MeshDevice> meshDevice = ::ttnn::MeshDevice::create(
       ::tt::tt_metal::distributed::MeshDeviceConfig{.mesh_shape = grid,
                                                     .offset = {}},

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -11,6 +11,7 @@
 #include "tt/runtime/ttnn/types.h"
 #include "tt/runtime/ttnn/utils.h"
 #include "tt/runtime/utils.h"
+#include "ttmlir/Dialect/TTNN/Utils/Constants.h"
 #include "ttmlir/Target/TTNN/Target.h"
 #include "ttmlir/Version.h"
 #include "ttnn/tensor/types.hpp"
@@ -214,7 +215,8 @@ Device openDevice(DeviceIds const &deviceIds, size_t numHWCQs,
   LOG_ASSERT(deviceIds.size(), "No devices specified");
   ::tt::tt_metal::distributed::MeshShape grid{
       1, static_cast<uint32_t>(deviceIds.size())};
-  size_t l1SmallSizeValue = l1SmallSize.value_or(kL1SmallSize);
+  size_t l1SmallSizeValue =
+      l1SmallSize.value_or(mlir::tt::ttnn::constants::L1_SMALL_SIZE);
   std::shared_ptr<::ttnn::MeshDevice> meshDevice = ::ttnn::MeshDevice::create(
       ::tt::tt_metal::distributed::MeshDeviceConfig{.mesh_shape = grid,
                                                     .offset = {}},

--- a/test/unittests/OpModel/TTNN/Conversion/TestConversion.cpp
+++ b/test/unittests/OpModel/TTNN/Conversion/TestConversion.cpp
@@ -55,7 +55,7 @@ TEST_P(MlirToTtnnConversionDataType, DataType) {
           &context, mlir::tt::ttnn::TensorMemoryLayout::Interleaved));
 
   auto convertedDataType =
-      mlir::tt::op_model::ttnn::conversion::getDataType(layout);
+      mlir::tt::op_model::ttnn::conversion::getDataType(layout.getDataType());
   EXPECT_EQ(convertedDataType, expectedDataType);
 }
 
@@ -405,7 +405,8 @@ TEST_P(MlirToTnnConversionTensorMemoryLayout, MemoryConfig) {
                                   mlirTensorMemoryLayout);
 
   const auto tensorMemoryLayout =
-      mlir::tt::op_model::ttnn::conversion::getTensorMemoryLayout(layout);
+      mlir::tt::op_model::ttnn::conversion::getTensorMemoryLayout(
+          layout.getMemLayout());
   EXPECT_EQ(tensorMemoryLayout, expectedTensorMemoryLayout);
 }
 

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -4,6 +4,7 @@
 
 #include "OpModelFixture.h"
 
+#include "../lib/OpModel/TTNN/SingletonDeviceContext.h"
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/OpModel/TTNN/TTNNOpModel.h"
@@ -11,7 +12,6 @@
 #include "llvm/ADT/SmallVector.h"
 #include "gtest/gtest.h"
 #include <cstdint>
-#include <functional>
 #include <optional>
 #include <tuple>
 
@@ -981,4 +981,116 @@ INSTANTIATE_TEST_SUITE_P(
                 llvm::SmallVector<int64_t>{56, 1}},
             llvm::SmallVector<int64_t>{7, 8},
             detail::ExpectedResult{true, 114688, 114688, 114688})));
+
+class OpModelConv2dParam
+    : public OpModelTest,
+      public testing::WithParamInterface<
+          std::tuple<detail::TestTensor,         // input
+                     detail::TestTensor,         // weight
+                     detail::TestTensor,         // output
+                     uint32_t,                   // in_channels
+                     uint32_t,                   // out_channels
+                     uint32_t,                   // batch_size
+                     uint32_t,                   // input_height
+                     uint32_t,                   // input_width
+                     llvm::SmallVector<int32_t>, // kernel_size
+                     llvm::SmallVector<int32_t>, // stride
+                     llvm::SmallVector<int32_t>, // padding
+                     llvm::SmallVector<int32_t>, // dilation
+                     uint32_t,                   // groups
+                     bool, bool>> {};
+
+TEST_P(OpModelConv2dParam, Conv2d) {
+  auto params = GetParam();
+  const auto [inputShape, inputTensorLayout, inputBufferType,
+              inputVirtualGrid] = std::get<0>(params);
+  const auto [weightShape, weightTensorLayout, weightBufferType,
+              weightVirtualGrid] = std::get<1>(params);
+  const auto [outputShape, outputTensorLayout, outputBufferType,
+              outputVirtualGrid] = std::get<2>(params);
+  const auto in_channels = std::get<3>(params);
+  const auto out_channels = std::get<4>(params);
+  const auto batch_size = std::get<5>(params);
+  const auto input_height = std::get<6>(params);
+  const auto input_width = std::get<7>(params);
+  const auto kernel_size = std::get<8>(params);
+  const auto stride = std::get<9>(params);
+  const auto padding = std::get<10>(params);
+  const auto dilation = std::get<11>(params);
+  const auto groups = std::get<12>(params);
+  const auto constraintsLegal = std::get<13>(params);
+  const auto runtimeLegal = std::get<14>(params);
+
+  const mlir::tt::ttnn::TTNNLayoutAttr inputLayout = CreateTiledLayout(
+      inputShape, inputBufferType, inputTensorLayout, inputVirtualGrid);
+  const mlir::tt::ttnn::TTNNLayoutAttr weightLayout = CreateTiledLayout(
+      weightShape, weightBufferType, weightTensorLayout, weightVirtualGrid);
+  const mlir::tt::ttnn::TTNNLayoutAttr outputLayout = CreateTiledLayout(
+      outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
+
+  // Device hangs otherwise.
+  SingletonDeviceContext::resetInstance();
+
+  auto constraintsExp = Conv2dOpInterface::getOpConstraints(
+      inputShape, inputLayout, weightShape, weightLayout, std::nullopt,
+      std::nullopt, in_channels, out_channels, batch_size, input_height,
+      input_width, kernel_size, stride, padding, dilation, groups, std::nullopt,
+      outputShape, outputLayout);
+  // Manually cast to bool because EXPECT_TRUE requires a const bool operator
+  // which llvm::Expected<T> does not have
+  EXPECT_EQ(static_cast<bool>(constraintsExp), constraintsLegal);
+  if (constraintsExp) {
+    const auto [cbSize, peakSize, outputSize] = constraintsExp.get();
+    EXPECT_GT(cbSize, 0);
+    EXPECT_GT(peakSize, 0);
+    EXPECT_GT(outputSize, 0);
+  } else {
+    // Must clean up the error
+    llvm::consumeError(constraintsExp.takeError());
+  }
+
+  // Device hangs otherwise.
+  SingletonDeviceContext::resetInstance();
+
+  auto runtimeExp = Conv2dOpInterface::getOpRuntime(
+      inputShape, inputLayout, weightShape, weightLayout, std::nullopt,
+      std::nullopt, in_channels, out_channels, batch_size, input_height,
+      input_width, kernel_size, stride, padding, dilation, groups, std::nullopt,
+      outputShape, outputLayout);
+  // Manually cast to bool because EXPECT_TRUE requires a const bool operator
+  // which llvm::Expected<T> does not have
+  EXPECT_EQ(static_cast<bool>(runtimeExp), runtimeLegal);
+  if (runtimeExp) {
+    const auto runtime = runtimeExp.get();
+    EXPECT_GT(runtime, 0);
+  } else {
+    // Must clean up the error
+    llvm::consumeError(runtimeExp.takeError());
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Conv2dTests, OpModelConv2dParam,
+    ::testing::Values(
+        std::make_tuple(
+            detail::TestTensor{{1, 1, 50176, 3},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::TestTensor{{1, 1, 1568, 64},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM},
+            detail::TestTensor{{1, 1, 12544, 64},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM},
+            3, 64, 1, 224, 224, llvm::SmallVector<int32_t>{7, 7},
+            llvm::SmallVector<int32_t>{2, 2}, llvm::SmallVector<int32_t>{3, 3},
+            llvm::SmallVector<int32_t>{1, 1}, 1, false, true),
+        std::make_tuple(detail::interleavedN300X1024Dram,
+                        detail::interleavedN300X1024Dram,
+                        detail::interleavedN300X1024L1, 3, 64, 32, 224, 224,
+                        llvm::SmallVector<int32_t>{7, 7},
+                        llvm::SmallVector<int32_t>{2, 2},
+                        llvm::SmallVector<int32_t>{3, 3},
+                        llvm::SmallVector<int32_t>{1, 1}, 1, false, false)));
+
 } // namespace mlir::tt::op_model::ttnn

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -487,7 +487,8 @@ TEST_F(OpModelBase, Conv2dInterface) {
   EXPECT_FALSE(static_cast<bool>(constraintsExp));
   if (!constraintsExp) {
     std::string error = llvm::toString(constraintsExp.takeError());
-    EXPECT_TRUE(error.find("Mismatch!! L1 Allocation Pre Op"));
+    EXPECT_TRUE(error.find("Mismatch!! L1 Allocation Pre Op") !=
+                std::string::npos);
   }
 
   // Device hangs otherwise.

--- a/test/unittests/OpModel/TTNN/OpModelFixture.h
+++ b/test/unittests/OpModel/TTNN/OpModelFixture.h
@@ -32,8 +32,11 @@ public:
   // helper function
   llvm::SmallVector<int64_t>
   GetTensorShapeInTiles(const llvm::ArrayRef<int64_t> &tensorShape) {
-    return {ttmlir::utils::alignUp(tensorShape[0], 32L),
-            ttmlir::utils::alignUp(tensorShape[1], 32L)};
+    llvm::SmallVector<int64_t> shapeInTiles;
+    for (const auto &dim : tensorShape) {
+      shapeInTiles.push_back(ttmlir::utils::alignUp(dim, 32L));
+    }
+    return shapeInTiles;
   }
 
   static llvm::SmallVector<int64_t> GetPhysicalGridSize() {
@@ -51,16 +54,18 @@ public:
     llvm::SmallVector<int64_t> tensorShapeTiles =
         GetTensorShapeInTiles(tensorShape);
 
-    assert(tensorShape.size() == 2);
+    int64_t tensorTiles = 1;
+    for (const auto &dim : tensorShapeTiles) {
+      tensorTiles *= dim;
+    }
+
     switch (tensorMemoryLayout) {
     case mlir::tt::ttnn::TensorMemoryLayout::WidthSharded:
-      return {1, std::min(tensorShapeTiles[0] * tensorShapeTiles[1],
-                          gridPhyCores[0] * gridPhyCores[1])};
+      return {1, std::min(tensorTiles, gridPhyCores[0] * gridPhyCores[1])};
     case mlir::tt::ttnn::TensorMemoryLayout::HeightSharded:
-      return {std::min(tensorShapeTiles[0] * tensorShapeTiles[1],
-                       gridPhyCores[0] * gridPhyCores[1]),
-              1};
+      return {std::min(tensorTiles, gridPhyCores[0] * gridPhyCores[1]), 1};
     case mlir::tt::ttnn::TensorMemoryLayout::BlockSharded:
+      assert(tensorShapeTiles.size() == 2);
       return {std::min(gridPhyCores[0], tensorShapeTiles[0]),
               std::min(gridPhyCores[1], tensorShapeTiles[1])};
     default:


### PR DESCRIPTION
### Problem description
Optimizer needs more ops with constraints and runtime support to be able to ingest real models. Conv is used in resnet :) (https://github.com/tenstorrent/tt-mlir/issues/2277)

### What's changed
* Added constraints and runtime API support for Conv2d. Added unit tests for the new APIs.
* Set L1_SMALL_SIZE for opmodellib device

### Notes
* There is a bug with Conv2D and graph capture in NO_DISPATCH mode so we always get that the op failed until this is solved: https://github.com/tenstorrent/tt-metal/issues/18886
* For some reason device needs to be reopened before executing conv multiple times. This will be solved with: https://github.com/tenstorrent/tt-metal/issues/14000 but is not planned in the near future.

### Checklist
- [x] New/Existing tests provide coverage for changes
