### PR TITLE
Added folders for ttir.transpose, ttir.reshape, and ttir.permute

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -1065,6 +1065,8 @@ def TTIR_TransposeOp : TTIR_NamedOp<"transpose"> {
     let hasVerifier = 1;
 
     let hasCanonicalizer = 1;
+
+    let hasFolder = 1;
 }
 
 def TTIR_ConcatOp : TTIR_NamedOp<"concat"> {
@@ -1810,6 +1812,8 @@ def TTIR_PermuteOp : TTIR_NamedOp<"permute"> {
     let hasVerifier = 1;
 
     let hasCanonicalizer = 1;
+
+    let hasFolder = 1;
 }
 
 def TTIR_Upsample2dOp : TTIR_NamedOp<"upsample2d"> {

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -26,9 +26,6 @@
 #include "llvm/Support/LogicalResult.h"
 
 #include <cstdint>
-#include <llvm/Support/Casting.h>
-#include <llvm/Support/raw_ostream.h>
-#include <mlir/IR/BuiltinAttributeInterfaces.h>
 #include <numeric>
 #include <string>
 
@@ -756,16 +753,22 @@ mlir::LogicalResult mlir::tt::ttir::ConvTranspose2dOp::verify() {
 
 // ReshapeOp folder
 ::mlir::OpFoldResult mlir::tt::ttir::ReshapeOp::fold(FoldAdaptor adaptor) {
+
   if (getType() == getOperand(0).getType()) {
     return getOperand(0);
   }
+
+  ElementsAttr foldedAttr;
   if (auto value = dyn_cast_or_null<DenseElementsAttr>(adaptor.getInput())) {
-    return value.reshape(getType());
+    foldedAttr = value.reshape(getType());
   } else if (auto value = dyn_cast_or_null<DenseResourceElementsAttr>(
                  adaptor.getInput())) {
-    return DenseResourceElementsAttr::get(getType(), value.getRawHandle());
+    foldedAttr =
+        DenseResourceElementsAttr::get(getType(), value.getRawHandle());
+  } else {
+    return nullptr;
   }
-  return nullptr;
+  return foldedAttr;
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/ttmlir/Dialect/TTNN/constant/positive/simple_constant_fold.mlir
+++ b/test/ttmlir/Dialect/TTNN/constant/positive/simple_constant_fold.mlir
@@ -1,0 +1,12 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
+module attributes {} {
+  func.func @test_empty_int8() -> tensor<12xi32> {
+    %0 = "ttir.constant"() <{value = dense<[[[0, 1], [2, 3], [4, 5]], [[6, 7], [8, 9], [10, 11]]]> : tensor<2x3x2xi32>}> : () -> tensor<2x3x2xi32>
+    // CHECK: "ttnn.constant"() <{value = dense<[0, 2, 4, 6, 8, 10, 1, 3, 5, 7, 9, 11]> : tensor<12xi32>}>
+    %1 = tensor.empty() : tensor<2x2x3xi32>
+    %2 = "ttir.permute"(%0, %1) <{permutation = array<i64: 2, 0, 1>}> : (tensor<2x3x2xi32>, tensor<2x2x3xi32>) -> tensor<2x2x3xi32>
+    %3 = tensor.empty() : tensor<12xi32>
+    %4 = "ttir.reshape"(%2, %3) <{shape = [12: i32]}> : (tensor<2x2x3xi32>, tensor<12xi32>) -> tensor<12xi32>
+    return %4 : tensor<12xi32>
+  }
+}


### PR DESCRIPTION
### What's changed
Implemented folding of `ttir.constant` ops if they are operands to `ReshapeOp`, `TransposeOp`, or `PermuteOp`

### Checklist
- [x] New/Existing tests provide coverage for changes
