### PR TITLE
Add Constraints and Runtime API for ToLayoutOp

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -48,7 +48,9 @@ def TTNN_ToMemoryConfigOp : TTNN_Op<"to_memory_config", [HasMemoryConfigTrait]> 
     let hasVerifier = 1;
 }
 
-def TTNN_ToLayoutOp : TTNN_Op<"to_layout"> {
+def TTNN_ToLayoutOp : TTNN_Op<"to_layout",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
     let summary = "ToLayout op.";
     let description = [{
       This op wraps all layout information gathered from ttir.toLayout. It is used/updated by the optimizer

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -148,7 +148,6 @@ namespace ToLayoutOpInterface {
 llvm::Expected<std::tuple<size_t, size_t, size_t>>
 getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-                 mlir::tt::ttnn::Layout outputPageLayout,
                  std::optional<mlir::tt::DataType> outputDtype,
                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
                  bool passDevicePtr);
@@ -156,7 +155,6 @@ getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
 llvm::Expected<size_t>
 getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
              mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-             mlir::tt::ttnn::Layout outputPageLayout,
              std::optional<mlir::tt::DataType> outputDtype,
              mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool passDevicePtr);
 

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -149,7 +149,7 @@ llvm::Expected<std::tuple<size_t, size_t, size_t>>
 getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
                  mlir::tt::ttnn::Layout outputPageLayout,
-                 std::optional<mlir::tt::DataTypeAttr> outputDtype,
+                 std::optional<mlir::tt::DataType> outputDtype,
                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
                  bool passDevicePtr);
 
@@ -157,7 +157,7 @@ llvm::Expected<size_t>
 getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
              mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
              mlir::tt::ttnn::Layout outputPageLayout,
-             std::optional<mlir::tt::DataTypeAttr> outputDtype,
+             std::optional<mlir::tt::DataType> outputDtype,
              mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool passDevicePtr);
 
 }; // namespace ToLayoutOpInterface

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -141,6 +141,28 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 }; // namespace TypecastOpInterface
 
 //===----------------------------------------------------------------------===//
+// ToLayoutOp
+//===----------------------------------------------------------------------===//
+
+namespace ToLayoutOpInterface {
+llvm::Expected<std::tuple<size_t, size_t, size_t>>
+getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+                 mlir::tt::ttnn::LayoutAttr outputPageLayout,
+                 std::optional<mlir::tt::DataTypeAttr> outputDtype,
+                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
+                 bool passDevicePtr);
+
+llvm::Expected<size_t>
+getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+             mlir::tt::ttnn::LayoutAttr outputPageLayout,
+             std::optional<mlir::tt::DataTypeAttr> outputDtype,
+             mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool passDevicePtr);
+
+}; // namespace ToLayoutOpInterface
+
+//===----------------------------------------------------------------------===//
 // TransposeOp
 //===----------------------------------------------------------------------===//
 

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -148,7 +148,7 @@ namespace ToLayoutOpInterface {
 llvm::Expected<std::tuple<size_t, size_t, size_t>>
 getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-                 mlir::tt::ttnn::LayoutAttr outputPageLayout,
+                 mlir::tt::ttnn::Layout outputPageLayout,
                  std::optional<mlir::tt::DataTypeAttr> outputDtype,
                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
                  bool passDevicePtr);
@@ -156,7 +156,7 @@ getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
 llvm::Expected<size_t>
 getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
              mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-             mlir::tt::ttnn::LayoutAttr outputPageLayout,
+             mlir::tt::ttnn::Layout outputPageLayout,
              std::optional<mlir::tt::DataTypeAttr> outputDtype,
              mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool passDevicePtr);
 

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -276,10 +276,10 @@ ToLayoutOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   if (!check) {
     return check.takeError();
   }
+  const bool passDevicePtr = !getODSOperands(1).empty();
   assert(output.getLayout() == getLayoutAttr().getValue());
   return op_model::ttnn::ToLayoutOpInterface::getOpConstraints(
-      inputShape, inputs[0], getLayoutAttr().getValue(), getDtype(), output,
-      !getODSOperands(1).empty());
+      inputShape, inputs[0], getDtype(), output, passDevicePtr);
 }
 
 llvm::Expected<size_t>
@@ -288,10 +288,9 @@ ToLayoutOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   assert(inputs.size() == 1);
 
   const auto inputShape = getInput().getType().getShape();
-
+  const bool passDevicePtr = !getODSOperands(1).empty();
   return op_model::ttnn::ToLayoutOpInterface::getOpRuntime(
-      inputShape, inputs[0], getLayoutAttr().getValue(), getDtype(), output,
-      !getODSOperands(1).empty());
+      inputShape, inputs[0], getDtype(), output, passDevicePtr);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -269,6 +269,7 @@ llvm::Expected<std::tuple<size_t, size_t, size_t>>
 ToLayoutOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                              const TTNNLayoutAttr &output) {
   assert(inputs.size() == 1);
+  assert(output.getLayout() == getLayoutAttr().getValue());
 
   const auto inputShape = getInput().getType().getShape();
 
@@ -276,8 +277,10 @@ ToLayoutOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   if (!check) {
     return check.takeError();
   }
-  const bool passDevicePtr = !getODSOperands(1).empty();
-  assert(output.getLayout() == getLayoutAttr().getValue());
+
+  auto deviceOperand = getODSOperands(1);
+  const bool passDevicePtr = !deviceOperand.empty();
+
   return op_model::ttnn::ToLayoutOpInterface::getOpConstraints(
       inputShape, inputs[0], getDtype(), output, passDevicePtr);
 }
@@ -286,9 +289,13 @@ llvm::Expected<size_t>
 ToLayoutOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                          const TTNNLayoutAttr &output) {
   assert(inputs.size() == 1);
+  assert(output.getLayout() == getLayoutAttr().getValue());
 
   const auto inputShape = getInput().getType().getShape();
-  const bool passDevicePtr = !getODSOperands(1).empty();
+
+  auto deviceOperand = getODSOperands(1);
+  const bool passDevicePtr = !deviceOperand.empty();
+
   return op_model::ttnn::ToLayoutOpInterface::getOpRuntime(
       inputShape, inputs[0], getDtype(), output, passDevicePtr);
 }

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -278,7 +278,7 @@ ToLayoutOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   }
   assert(output.getLayout() == getLayoutAttr().getValue());
   return op_model::ttnn::ToLayoutOpInterface::getOpConstraints(
-      inputShape, inputs[0], getLayoutAttr().getValue(), getDtypeAttr(), output,
+      inputShape, inputs[0], getLayoutAttr().getValue(), getDtype(), output,
       !getODSOperands(1).empty());
 }
 
@@ -290,7 +290,7 @@ ToLayoutOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShape = getInput().getType().getShape();
 
   return op_model::ttnn::ToLayoutOpInterface::getOpRuntime(
-      inputShape, inputs[0], getLayoutAttr().getValue(), getDtypeAttr(), output,
+      inputShape, inputs[0], getLayoutAttr().getValue(), getDtype(), output,
       !getODSOperands(1).empty());
 }
 

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -276,9 +276,9 @@ ToLayoutOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   if (!check) {
     return check.takeError();
   }
-
+  assert(output.getLayout() == getLayoutAttr().getValue());
   return op_model::ttnn::ToLayoutOpInterface::getOpConstraints(
-      inputShape, inputs[0], getLayoutAttr(), getDtypeAttr(), output,
+      inputShape, inputs[0], getLayoutAttr().getValue(), getDtypeAttr(), output,
       !getODSOperands(1).empty());
 }
 
@@ -290,7 +290,7 @@ ToLayoutOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   const auto inputShape = getInput().getType().getShape();
 
   return op_model::ttnn::ToLayoutOpInterface::getOpRuntime(
-      inputShape, inputs[0], getLayoutAttr(), getDtypeAttr(), output,
+      inputShape, inputs[0], getLayoutAttr().getValue(), getDtypeAttr(), output,
       !getODSOperands(1).empty());
 }
 

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -269,7 +269,7 @@ llvm::Expected<std::tuple<size_t, size_t, size_t>>
 ToLayoutOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                              const TTNNLayoutAttr &output) {
   assert(inputs.size() == 1);
-  assert(output.getLayout() == getLayoutAttr().getValue());
+  assert(output.getLayout() == getLayout());
 
   const auto inputShape = getInput().getType().getShape();
 
@@ -278,8 +278,8 @@ ToLayoutOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
     return check.takeError();
   }
 
-  auto deviceOperand = getODSOperands(1);
-  const bool passDevicePtr = !deviceOperand.empty();
+  auto deviceOperand = getDevice();
+  const bool passDevicePtr = !deviceOperand;
 
   return op_model::ttnn::ToLayoutOpInterface::getOpConstraints(
       inputShape, inputs[0], getDtype(), output, passDevicePtr);
@@ -289,12 +289,12 @@ llvm::Expected<size_t>
 ToLayoutOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                          const TTNNLayoutAttr &output) {
   assert(inputs.size() == 1);
-  assert(output.getLayout() == getLayoutAttr().getValue());
+  assert(output.getLayout() == getLayout());
 
   const auto inputShape = getInput().getType().getShape();
 
-  auto deviceOperand = getODSOperands(1);
-  const bool passDevicePtr = !deviceOperand.empty();
+  auto deviceOperand = getDevice();
+  const bool passDevicePtr = !deviceOperand;
 
   return op_model::ttnn::ToLayoutOpInterface::getOpRuntime(
       inputShape, inputs[0], getDtype(), output, passDevicePtr);

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -262,6 +262,39 @@ TypecastOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// ToLayoutOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<std::tuple<size_t, size_t, size_t>>
+ToLayoutOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                             const TTNNLayoutAttr &output) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+
+  return op_model::ttnn::ToLayoutOpInterface::getOpConstraints(
+      inputShape, inputs[0], getLayoutAttr(), getDtypeAttr(), output,
+      !getODSOperands(1).empty());
+}
+
+llvm::Expected<size_t>
+ToLayoutOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                         const TTNNLayoutAttr &output) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  return op_model::ttnn::ToLayoutOpInterface::getOpRuntime(
+      inputShape, inputs[0], getLayoutAttr(), getDtypeAttr(), output,
+      !getODSOperands(1).empty());
+}
+
+//===----------------------------------------------------------------------===//
 // TransposeOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 

--- a/lib/OpModel/TTNN/Conversion.cpp
+++ b/lib/OpModel/TTNN/Conversion.cpp
@@ -45,10 +45,6 @@ getDataType(const mlir::tt::ttnn::TTNNLayoutAttr layout) {
   }
 }
 
-::tt::tt_metal::DataType getDataType(mlir::tt::DataTypeAttr dtype) {
-  return getDataType(dtype.getValue());
-}
-
 ::ttnn::Shape getShape(const ::llvm::ArrayRef<int64_t> shape) {
   ::tt::stl::SmallVector<uint32_t> small_vector_shape;
   for (const auto &dim : shape) {

--- a/lib/OpModel/TTNN/Conversion.cpp
+++ b/lib/OpModel/TTNN/Conversion.cpp
@@ -45,6 +45,10 @@ getDataType(const mlir::tt::ttnn::TTNNLayoutAttr layout) {
   }
 }
 
+::tt::tt_metal::DataType getDataType(mlir::tt::DataTypeAttr dtype) {
+  return getDataType(dtype.getValue());
+}
+
 ::ttnn::Shape getShape(const ::llvm::ArrayRef<int64_t> shape) {
   ::tt::stl::SmallVector<uint32_t> small_vector_shape;
   for (const auto &dim : shape) {
@@ -73,6 +77,17 @@ getShardShape(const mlir::tt::ttnn::TTNNLayoutAttr &layout) {
 getPageLayout(const mlir::tt::ttnn::TTNNLayoutAttr &layout) {
   return layout.isTiled() ? ::tt::tt_metal::Layout::TILE
                           : ::tt::tt_metal::Layout::ROW_MAJOR;
+}
+
+::tt::tt_metal::Layout getPageLayout(mlir::tt::ttnn::LayoutAttr layout) {
+  switch (layout.getValue()) {
+  case ::mlir::tt::ttnn::Layout::RowMajor:
+    return ::tt::tt_metal::Layout::ROW_MAJOR;
+  case ::mlir::tt::ttnn::Layout::Tile:
+    return ::tt::tt_metal::Layout::TILE;
+  case ::mlir::tt::ttnn::Layout::Invalid:
+    return ::tt::tt_metal::Layout::INVALID;
+  }
 }
 
 ::tt::tt_metal::CoreRangeSet

--- a/lib/OpModel/TTNN/Conversion.cpp
+++ b/lib/OpModel/TTNN/Conversion.cpp
@@ -79,8 +79,8 @@ getPageLayout(const mlir::tt::ttnn::TTNNLayoutAttr &layout) {
                           : ::tt::tt_metal::Layout::ROW_MAJOR;
 }
 
-::tt::tt_metal::Layout getPageLayout(mlir::tt::ttnn::LayoutAttr layout) {
-  switch (layout.getValue()) {
+::tt::tt_metal::Layout getPageLayout(mlir::tt::ttnn::Layout layout) {
+  switch (layout) {
   case ::mlir::tt::ttnn::Layout::RowMajor:
     return ::tt::tt_metal::Layout::ROW_MAJOR;
   case ::mlir::tt::ttnn::Layout::Tile:

--- a/lib/OpModel/TTNN/Conversion.hpp
+++ b/lib/OpModel/TTNN/Conversion.hpp
@@ -24,7 +24,7 @@ getShardShape(const mlir::tt::ttnn::TTNNLayoutAttr &layout);
 ::tt::tt_metal::Layout
 getPageLayout(const mlir::tt::ttnn::TTNNLayoutAttr &layout);
 
-::tt::tt_metal::Layout getPageLayout(mlir::tt::ttnn::LayoutAttr layout);
+::tt::tt_metal::Layout getPageLayout(mlir::tt::ttnn::Layout layout);
 
 ::tt::tt_metal::CoreRangeSet
 getCoreRangeSet(const mlir::tt::ttnn::TTNNLayoutAttr &layout);

--- a/lib/OpModel/TTNN/Conversion.hpp
+++ b/lib/OpModel/TTNN/Conversion.hpp
@@ -24,6 +24,8 @@ getShardShape(const mlir::tt::ttnn::TTNNLayoutAttr &layout);
 ::tt::tt_metal::Layout
 getPageLayout(const mlir::tt::ttnn::TTNNLayoutAttr &layout);
 
+::tt::tt_metal::Layout getPageLayout(mlir::tt::ttnn::LayoutAttr layout);
+
 ::tt::tt_metal::CoreRangeSet
 getCoreRangeSet(const mlir::tt::ttnn::TTNNLayoutAttr &layout);
 

--- a/lib/OpModel/TTNN/MetalHeaders.h
+++ b/lib/OpModel/TTNN/MetalHeaders.h
@@ -66,7 +66,6 @@ using IDevice = ::tt::tt_metal::IDevice;
 #include "ttnn/graph/graph_trace_utils.hpp"
 #include "ttnn/operations/copy.hpp"
 #include "ttnn/operations/core/core.hpp"
-#include "ttnn/operations/core/to_layout/to_layout_op.hpp"
 #include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
 #include "ttnn/operations/data_movement/transpose/transpose.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"

--- a/lib/OpModel/TTNN/MetalHeaders.h
+++ b/lib/OpModel/TTNN/MetalHeaders.h
@@ -65,6 +65,8 @@ using IDevice = ::tt::tt_metal::IDevice;
 #include "ttnn/graph/graph_query_op_runtime.hpp"
 #include "ttnn/graph/graph_trace_utils.hpp"
 #include "ttnn/operations/copy.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/core/to_layout/to_layout_op.hpp"
 #include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
 #include "ttnn/operations/data_movement/transpose/transpose.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"

--- a/lib/OpModel/TTNN/TTNNOpModelLib.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModelLib.cpp
@@ -674,13 +674,13 @@ ToLayoutOpInterface::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
     mlir::tt::ttnn::Layout outputPageLayout,
-    std::optional<mlir::tt::DataTypeAttr> outputDtype,
+    std::optional<mlir::tt::DataType> outputDtype,
     mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool passDevicePtr) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   auto toLayoutOpQuery = [](llvm::ArrayRef<int64_t> inputShape,
                             mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
                             mlir::tt::ttnn::Layout outputPageLayout,
-                            std::optional<mlir::tt::DataTypeAttr> outputDtype,
+                            std::optional<mlir::tt::DataType> outputDtype,
                             mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
                             bool passDevicePtr) {
     // open device device, will close it at the end of function
@@ -701,7 +701,6 @@ ToLayoutOpInterface::getOpConstraints(
     std::optional<::tt::tt_metal::MemoryConfig> memoryConfig =
         std::make_optional(conversion::getMemoryConfig(outputLayout));
 
-    // run op constraint query
     return ::ttnn::graph::query_op_constraints(
         ::ttnn::to_layout, device, inputSpec,
         conversion::getPageLayout(outputPageLayout), dtype, memoryConfig,
@@ -716,17 +715,18 @@ ToLayoutOpInterface::getOpConstraints(
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
-llvm::Expected<size_t> ToLayoutOpInterface::getOpRuntime(
-    llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-    mlir::tt::ttnn::Layout outputPageLayout,
-    std::optional<mlir::tt::DataTypeAttr> outputDtype,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool passDevicePtr) {
+llvm::Expected<size_t>
+ToLayoutOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+                                  mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+                                  mlir::tt::ttnn::Layout outputPageLayout,
+                                  std::optional<mlir::tt::DataType> outputDtype,
+                                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
+                                  bool passDevicePtr) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   auto toLayoutOpQuery = [](llvm::ArrayRef<int64_t> inputShape,
                             mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
                             mlir::tt::ttnn::Layout outputPageLayout,
-                            std::optional<mlir::tt::DataTypeAttr> outputDtype,
+                            std::optional<mlir::tt::DataType> outputDtype,
                             mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
                             bool passDevicePtr) {
     // open device device, will close it at the end of function

--- a/lib/OpModel/TTNN/TTNNOpModelLib.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModelLib.cpp
@@ -673,13 +673,11 @@ llvm::Expected<std::tuple<size_t, size_t, size_t>>
 ToLayoutOpInterface::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-    mlir::tt::ttnn::Layout outputPageLayout,
     std::optional<mlir::tt::DataType> outputDtype,
     mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool passDevicePtr) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   auto toLayoutOpQuery = [](llvm::ArrayRef<int64_t> inputShape,
                             mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-                            mlir::tt::ttnn::Layout outputPageLayout,
                             std::optional<mlir::tt::DataType> outputDtype,
                             mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
                             bool passDevicePtr) {
@@ -703,13 +701,13 @@ ToLayoutOpInterface::getOpConstraints(
 
     return ::ttnn::graph::query_op_constraints(
         ::ttnn::to_layout, device, inputSpec,
-        conversion::getPageLayout(outputPageLayout), dtype, memoryConfig,
-        passDevicePtr ? device : nullptr);
+        conversion::getPageLayout(outputLayout.getLayout()), dtype,
+        memoryConfig, passDevicePtr ? device : nullptr);
   };
 
   return operation::getOpConstraints("ToLayoutOpInterface", toLayoutOpQuery,
-                                     inputShape, inputLayout, outputPageLayout,
-                                     outputDtype, outputLayout, passDevicePtr);
+                                     inputShape, inputLayout, outputDtype,
+                                     outputLayout, passDevicePtr);
 #else
   return std::make_tuple(0, 0, 0);
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -718,14 +716,12 @@ ToLayoutOpInterface::getOpConstraints(
 llvm::Expected<size_t>
 ToLayoutOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                   mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-                                  mlir::tt::ttnn::Layout outputPageLayout,
                                   std::optional<mlir::tt::DataType> outputDtype,
                                   mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
                                   bool passDevicePtr) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   auto toLayoutOpQuery = [](llvm::ArrayRef<int64_t> inputShape,
                             mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-                            mlir::tt::ttnn::Layout outputPageLayout,
                             std::optional<mlir::tt::DataType> outputDtype,
                             mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
                             bool passDevicePtr) {
@@ -749,13 +745,13 @@ ToLayoutOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 
     return ::ttnn::graph::query_op_runtime(
         ::ttnn::to_layout, device, inputSpec,
-        conversion::getPageLayout(outputPageLayout), dtype, memoryConfig,
-        passDevicePtr ? device : nullptr);
+        conversion::getPageLayout(outputLayout.getLayout()), dtype,
+        memoryConfig, passDevicePtr ? device : nullptr);
   };
 
   return operation::getOpRuntime("ToLayoutOpInterface", toLayoutOpQuery,
-                                 inputShape, inputLayout, outputPageLayout,
-                                 outputDtype, outputLayout, passDevicePtr);
+                                 inputShape, inputLayout, outputDtype,
+                                 outputLayout, passDevicePtr);
 #else
   return llvm::createStringError("Not Implemented");
 #endif // TTMLIR_ENABLE_OPMODEL

--- a/lib/OpModel/TTNN/TTNNOpModelLib.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModelLib.cpp
@@ -667,6 +667,101 @@ TypecastOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 }
 
 //===----------------------------------------------------------------------===//
+// ToLayoutOp
+//===----------------------------------------------------------------------===//
+llvm::Expected<std::tuple<size_t, size_t, size_t>>
+ToLayoutOpInterface::getOpConstraints(
+    llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+    mlir::tt::ttnn::LayoutAttr outputPageLayout,
+    std::optional<mlir::tt::DataTypeAttr> outputDtype,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool passDevicePtr) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  auto toLayoutOpQuery = [](llvm::ArrayRef<int64_t> inputShape,
+                            mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+                            mlir::tt::ttnn::LayoutAttr outputPageLayout,
+                            std::optional<mlir::tt::DataTypeAttr> outputDtype,
+                            mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
+                            bool passDevicePtr) {
+    // open device device, will close it at the end of function
+    ::tt::tt_metal::v0::IDevice *device =
+        SingletonDeviceContext::getInstance().getDevice();
+
+    // prepare io specs
+    auto [inputSpec] = detail::convertToTensorSpec(
+        device, std::make_tuple(inputShape, inputLayout));
+
+    std::optional<::tt::tt_metal::DataType> dtype;
+    if (outputDtype) {
+      dtype = conversion::getDataType(outputDtype.value());
+    } else {
+      dtype = std::nullopt;
+    }
+
+    std::optional<::tt::tt_metal::MemoryConfig> memoryConfig =
+        std::make_optional(conversion::getMemoryConfig(outputLayout));
+
+    // run op constraint query
+    return ::ttnn::graph::query_op_constraints(
+        ::ttnn::to_layout, device, inputSpec,
+        conversion::getPageLayout(outputPageLayout), dtype, memoryConfig,
+        passDevicePtr ? device : nullptr);
+  };
+
+  return operation::getOpConstraints("ToLayoutOpInterface", toLayoutOpQuery,
+                                     inputShape, inputLayout, outputPageLayout,
+                                     outputDtype, outputLayout, passDevicePtr);
+#else
+  return std::make_tuple(0, 0, 0);
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t> ToLayoutOpInterface::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+    mlir::tt::ttnn::LayoutAttr outputPageLayout,
+    std::optional<mlir::tt::DataTypeAttr> outputDtype,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool passDevicePtr) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  auto toLayoutOpQuery = [](llvm::ArrayRef<int64_t> inputShape,
+                            mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+                            mlir::tt::ttnn::LayoutAttr outputPageLayout,
+                            std::optional<mlir::tt::DataTypeAttr> outputDtype,
+                            mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
+                            bool passDevicePtr) {
+    // open device device, will close it at the end of function
+    ::tt::tt_metal::v0::IDevice *device =
+        SingletonDeviceContext::getInstance().getDevice();
+
+    // prepare io specs
+    auto [inputSpec] = detail::convertToTensorSpec(
+        device, std::make_tuple(inputShape, inputLayout));
+
+    std::optional<::tt::tt_metal::DataType> dtype;
+    if (outputDtype) {
+      dtype = conversion::getDataType(outputDtype.value());
+    } else {
+      dtype = std::nullopt;
+    }
+
+    std::optional<::tt::tt_metal::MemoryConfig> memoryConfig =
+        std::make_optional(conversion::getMemoryConfig(outputLayout));
+
+    return ::ttnn::graph::query_op_runtime(
+        ::ttnn::to_layout, device, inputSpec,
+        conversion::getPageLayout(outputPageLayout), dtype, memoryConfig,
+        passDevicePtr ? device : nullptr);
+  };
+
+  return operation::getOpRuntime("ToLayoutOpInterface", toLayoutOpQuery,
+                                 inputShape, inputLayout, outputPageLayout,
+                                 outputDtype, outputLayout, passDevicePtr);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
 // TransposeOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<std::tuple<size_t, size_t, size_t>>

--- a/lib/OpModel/TTNN/TTNNOpModelLib.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModelLib.cpp
@@ -673,13 +673,13 @@ llvm::Expected<std::tuple<size_t, size_t, size_t>>
 ToLayoutOpInterface::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-    mlir::tt::ttnn::LayoutAttr outputPageLayout,
+    mlir::tt::ttnn::Layout outputPageLayout,
     std::optional<mlir::tt::DataTypeAttr> outputDtype,
     mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool passDevicePtr) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   auto toLayoutOpQuery = [](llvm::ArrayRef<int64_t> inputShape,
                             mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-                            mlir::tt::ttnn::LayoutAttr outputPageLayout,
+                            mlir::tt::ttnn::Layout outputPageLayout,
                             std::optional<mlir::tt::DataTypeAttr> outputDtype,
                             mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
                             bool passDevicePtr) {
@@ -719,13 +719,13 @@ ToLayoutOpInterface::getOpConstraints(
 llvm::Expected<size_t> ToLayoutOpInterface::getOpRuntime(
     llvm::ArrayRef<int64_t> inputShape,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-    mlir::tt::ttnn::LayoutAttr outputPageLayout,
+    mlir::tt::ttnn::Layout outputPageLayout,
     std::optional<mlir::tt::DataTypeAttr> outputDtype,
     mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool passDevicePtr) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   auto toLayoutOpQuery = [](llvm::ArrayRef<int64_t> inputShape,
                             mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-                            mlir::tt::ttnn::LayoutAttr outputPageLayout,
+                            mlir::tt::ttnn::Layout outputPageLayout,
                             std::optional<mlir::tt::DataTypeAttr> outputDtype,
                             mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
                             bool passDevicePtr) {

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -363,6 +363,19 @@ TEST_F(OpModelTest, ToLayout) {
       tensorShape, layoutDRAMTiled, std::nullopt, layoutL1RowMajorHS, true);
   EXPECT_FALSE(static_cast<bool>(runtimeExp));
   llvm::consumeError(runtimeExp.takeError());
+
+  constraintsExp = ToLayoutOpInterface::getOpConstraints(
+      tensorShape, layoutDRAMTiled, std::nullopt, layoutDRAMRowMajor, false);
+  EXPECT_TRUE(static_cast<bool>(constraintsExp));
+  std::tie(cb_size, peak_size, output_size) = constraintsExp.get();
+  EXPECT_EQ(cb_size, 262144);
+  EXPECT_EQ(output_size, 0);
+  EXPECT_EQ(peak_size, 0);
+
+  runtimeExp = ToLayoutOpInterface::getOpRuntime(
+      tensorShape, layoutDRAMTiled, std::nullopt, layoutDRAMRowMajor, false);
+  EXPECT_TRUE(static_cast<bool>(runtimeExp));
+  EXPECT_TRUE(runtimeExp.get() > 0);
 }
 
 TEST_F(OpModelTest, Transpose) {

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -326,6 +326,34 @@ TEST_F(OpModelTest, Reshape) {
   EXPECT_TRUE(runtimeExp.get() > 0);
 }
 
+TEST_F(OpModelTest, ToLayout) {
+  const llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
+  const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
+  const mlir::tt::ttnn::TTNNLayoutAttr layoutDRAMTiled =
+      CreateTiledLayout(tensorShape, mlir::tt::ttnn::BufferType::DRAM,
+                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
+  const mlir::tt::ttnn::TTNNLayoutAttr layoutDRAMRowMajor =
+      CreateRowMajorLayout(tensorShape, mlir::tt::ttnn::BufferType::DRAM,
+                           mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
+  auto legalExp = Device::getDeviceConstraints(workerGrid);
+  EXPECT_TRUE(static_cast<bool>(legalExp));
+
+  auto constraintsExp = ToLayoutOpInterface::getOpConstraints(
+      tensorShape, layoutDRAMTiled, layoutDRAMRowMajor.getLayout(),
+      std::nullopt, layoutDRAMRowMajor, true);
+  EXPECT_TRUE(static_cast<bool>(constraintsExp));
+  auto [cb_size, peak_size, output_size] = constraintsExp.get();
+  EXPECT_EQ(cb_size, 262144);
+  EXPECT_EQ(output_size, 0);
+  EXPECT_EQ(peak_size, 0);
+
+  auto runtimeExp = ToLayoutOpInterface::getOpRuntime(
+      tensorShape, layoutDRAMTiled, layoutDRAMRowMajor.getLayout(),
+      std::nullopt, layoutDRAMRowMajor, true);
+  EXPECT_TRUE(static_cast<bool>(runtimeExp));
+  EXPECT_TRUE(runtimeExp.get() > 0);
+}
+
 TEST_F(OpModelTest, Transpose) {
   const llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
   const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -339,8 +339,7 @@ TEST_F(OpModelTest, ToLayout) {
   EXPECT_TRUE(static_cast<bool>(legalExp));
 
   auto constraintsExp = ToLayoutOpInterface::getOpConstraints(
-      tensorShape, layoutDRAMTiled, layoutDRAMRowMajor.getLayout(),
-      std::nullopt, layoutDRAMRowMajor, true);
+      tensorShape, layoutDRAMTiled, std::nullopt, layoutDRAMRowMajor, true);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   auto [cb_size, peak_size, output_size] = constraintsExp.get();
   EXPECT_EQ(cb_size, 262144);
@@ -348,8 +347,7 @@ TEST_F(OpModelTest, ToLayout) {
   EXPECT_EQ(peak_size, 0);
 
   auto runtimeExp = ToLayoutOpInterface::getOpRuntime(
-      tensorShape, layoutDRAMTiled, layoutDRAMRowMajor.getLayout(),
-      std::nullopt, layoutDRAMRowMajor, true);
+      tensorShape, layoutDRAMTiled, std::nullopt, layoutDRAMRowMajor, true);
   EXPECT_TRUE(static_cast<bool>(runtimeExp));
   EXPECT_TRUE(runtimeExp.get() > 0);
 }

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -335,6 +335,9 @@ TEST_F(OpModelTest, ToLayout) {
   const mlir::tt::ttnn::TTNNLayoutAttr layoutDRAMRowMajor =
       CreateRowMajorLayout(tensorShape, mlir::tt::ttnn::BufferType::DRAM,
                            mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
+  const mlir::tt::ttnn::TTNNLayoutAttr layoutL1RowMajorHS =
+      CreateRowMajorLayout(tensorShape, mlir::tt::ttnn::BufferType::L1,
+                           mlir::tt::ttnn::TensorMemoryLayout::HeightSharded);
   auto legalExp = Device::getDeviceConstraints(workerGrid);
   EXPECT_TRUE(static_cast<bool>(legalExp));
 
@@ -350,6 +353,16 @@ TEST_F(OpModelTest, ToLayout) {
       tensorShape, layoutDRAMTiled, std::nullopt, layoutDRAMRowMajor, true);
   EXPECT_TRUE(static_cast<bool>(runtimeExp));
   EXPECT_TRUE(runtimeExp.get() > 0);
+
+  constraintsExp = ToLayoutOpInterface::getOpConstraints(
+      tensorShape, layoutDRAMTiled, std::nullopt, layoutL1RowMajorHS, true);
+  EXPECT_FALSE(static_cast<bool>(constraintsExp));
+  llvm::consumeError(constraintsExp.takeError());
+
+  runtimeExp = ToLayoutOpInterface::getOpRuntime(
+      tensorShape, layoutDRAMTiled, std::nullopt, layoutL1RowMajorHS, true);
+  EXPECT_FALSE(static_cast<bool>(runtimeExp));
+  llvm::consumeError(runtimeExp.takeError());
 }
 
 TEST_F(OpModelTest, Transpose) {


### PR DESCRIPTION
### Ticket
#2316

### Problem description
The optimizer needs more ops to have runtime/constraints APIs to be able to ingest real models. ToLayout is used in resent (#2277)

### What's changed
Added runtime and constraints API to ToLayout. Added unit tests to exercise the new API. Closes #2316 

### Checklist
- [X] New/Existing tests provide coverage for changes
