### PR TITLE
Annotate multi-device tensors with TensorMeshShardingAttr

### DIFF
--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -464,6 +464,28 @@ def TT_MeshShardTypeAttr : EnumAttr<TT_Dialect, TT_MeshShardType, "shard_type"> 
   let assemblyFormat = "`<` $value `>`";
 }
 
+def TT_TensorMeshShardingAttr : TT_Attr<"TensorMeshSharding", "mesh_sharding", []> {
+  let summary = "Tensor MeshSharding attribute in TT dialect.";
+  let description = [{
+    Describes how a tensor is sharded including name and axes. With mesh name 'mesh',
+    a tensor with TensorMeshShardingAttr can be represented as
+      tensor<1x1024x128x128xf32, #tt.mesh_sharding<"mesh">> if axes info is not available,
+      or
+      tensor<1x1024x128x128xf32, #tt.mesh_sharding<"mesh" : [-1, -1, 0, 1]>> with some axes info.
+  }];
+  let parameters = (ins "StringAttr":$name,
+                        OptionalArrayRefParameter<"int64_t">:$axes);
+  let assemblyFormat = "`<` $name (`:` `[` $axes^ `]`)? `>`";
+
+  let extraClassDeclaration = [{
+      static TensorMeshShardingAttr get(::mlir::MLIRContext *context, StringRef name) {
+        auto meshNameStrAttr = mlir::StringAttr::get(context, name);
+        ::llvm::ArrayRef<int64_t> axes;
+        return TensorMeshShardingAttr::get(context, meshNameStrAttr, axes);
+      }
+  }];
+}
+
 def TT_MeshAttr : TT_Attr<"Mesh", "mesh", []> {
   let summary = "Mesh reference attribute in TT dialect.";
   let description = [{
@@ -475,9 +497,9 @@ def TT_MeshAttr : TT_Attr<"Mesh", "mesh", []> {
 }
 
 def TT_MeshesAttr : TT_Attr<"Meshes", "meshes"> {
-  let summary = "TT system meshes attribute";
+  let summary = "TT system meshes attribute.";
   let description = [{
-    TT system meshes attribute that can include multiple mesh configs used for networks.
+    TT system meshes attribute includes one or more mesh configs used for networks.
   }];
   let parameters = (ins ArrayRefParameter<"MeshAttr">:$meshes);
   let assemblyFormat = "`<` `[` $meshes `]` `>`";

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h
@@ -37,6 +37,10 @@ inline bool isShardedMemoryLayout(TensorMemoryLayout layout) {
          layout == TensorMemoryLayout::BlockSharded;
 }
 
+inline bool isMeshDeviceTensor(TensorMeshShardingAttr tensorMeshSharding) {
+  return tensorMeshSharding != nullptr;
+}
+
 } // namespace mlir::tt::ttnn
 
 #define GET_ATTRDEF_CLASSES

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
@@ -164,13 +164,15 @@ def TTNN_TTNNLayoutAttr: TTNN_Attr<"TTNNLayout", "ttnn_layout"> {
     - memref: A memref is used to describe shard size and memory space. Shard size is calculated by dividing the tensor size by grid size.
     - mem_layout: The layout of the tensor in memory. For tensor on host it should be None. For tensor on device
     it can be interleaved or sharded.
+    - mesh_sharding: The mesh of the tensor in multi-devices.
   }];
 
   let parameters = (ins AttrParameter<"AffineMap", "An affine map that defines how the logical tensor dimensions map to a grid shape.">:$linear,
                         AttrParameter<"GridAttr", "The grid shape that this tensor is divided onto.">:$grid,
                         AttrParameter<"MemRefType", "A memref that describes the physical footprint allocation of the shard. It must also have a shape with rank equal to grid.">:$memref,
-                        OptionalParameter<"TensorMemoryLayoutAttr", "TTNN tensor memory layout">:$mem_layout);
-  let assemblyFormat = "`<` $linear`,` $grid`,` $memref (`,` $mem_layout^)? `>`";
+                        OptionalParameter<"TensorMemoryLayoutAttr", "TTNN tensor memory layout">:$mem_layout,
+                        OptionalParameter<"TensorMeshShardingAttr", "TT mesh sharding attr">:$tensor_mesh_sharding);
+  let assemblyFormat = "`<` $linear`,` $grid`,` (`mesh` `=` $tensor_mesh_sharding^ `,`)? $memref (`,` $mem_layout^)? `>`";
   let extraClassDeclaration = [{
     static TTNNLayoutAttr get(::mlir::MLIRContext *context,
                         ArrayRef<int64_t> tensorShape,
@@ -178,6 +180,7 @@ def TTNN_TTNNLayoutAttr: TTNN_Attr<"TTNNLayout", "ttnn_layout"> {
                         BufferType bufferType,
                         GridAttr grid,
                         TensorMemoryLayoutAttr memoryLayoutAttr = nullptr,
+                        TensorMeshShardingAttr tensorMeshShardingAttr = nullptr,
                         ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}});
 
     TTNNLayoutAttr withGrid(::mlir::MLIRContext *context, ArrayRef<int64_t> tensorShape, GridAttr grid, ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}});
@@ -194,6 +197,7 @@ def TTNN_TTNNLayoutAttr: TTNN_Attr<"TTNNLayout", "ttnn_layout"> {
 
     bool isSystemBufferType() const { return ::mlir::tt::ttnn::isSystemBufferType(getBufferType()); }
     bool isDeviceBufferType() const { return ::mlir::tt::ttnn::isDeviceBufferType(getBufferType()); }
+    bool isMeshDeviceTensor() const { return ::mlir::tt::ttnn::isMeshDeviceTensor(getTensorMeshSharding()); }
     bool isTiled() const;
     bool hasShardedTensorMemoryLayout() const;
     bool hasShardedL1TensorMemoryLayout() const;

--- a/lib/CAPI/TTNNAttrs.cpp
+++ b/lib/CAPI/TTNNAttrs.cpp
@@ -84,9 +84,12 @@ MlirAttribute ttmlirTTNNTTNNLayoutAttrGet(MlirContext ctx, MlirAffineMap linear,
     memLayoutAttr = TensorMemoryLayoutAttr::get(
         unwrap(ctx), static_cast<TensorMemoryLayout>(*memLayout));
   }
-  return wrap(TTNNLayoutAttr::get(
-      unwrap(ctx), affineMap, mlir::cast<GridAttr>(unwrap(grid)),
-      mlir::cast<MemRefType>(unwrap(memref)), memLayoutAttr));
+
+  TensorMeshShardingAttr tensorMeshShardingAttr;
+  return wrap(TTNNLayoutAttr::get(unwrap(ctx), affineMap,
+                                  mlir::cast<GridAttr>(unwrap(grid)),
+                                  mlir::cast<MemRefType>(unwrap(memref)),
+                                  memLayoutAttr, tensorMeshShardingAttr));
 }
 
 } // namespace mlir::tt::ttnn

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPass.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPass.cpp
@@ -69,6 +69,7 @@ public:
       Type elementType = type.getElementType();
       llvm::ArrayRef<int64_t> shape = type.getShape();
       size_t bitWidth = type.getElementTypeBitWidth();
+      mlir::Attribute encoding = type.getEncoding();
       MLIRContext *context = elementType.getContext();
       // Convert the element type to bfloat16 if the input is boolean.
       if (bitWidth == 1) {
@@ -98,7 +99,8 @@ public:
         shape = RankedTensorType::get({1}, elementType).getShape();
         changed = true;
       }
-      return changed ? RankedTensorType::get(shape, elementType) : type;
+      return changed ? RankedTensorType::get(shape, elementType, encoding)
+                     : type;
     });
   }
 };

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -1715,18 +1715,6 @@ mlir::tt::ttnn::ReduceScatterOp::fold(FoldAdaptor adaptor) {
   }
 
   if (shardType == ::mlir::tt::MeshShardType::Devices) {
-    // Check if input rank is equal to or greater than two.
-    if (inputShape.size() < 2) {
-      return emitOpError(
-          "Invalid input rank (<2) for mesh_shard op with devices partition.");
-    }
-
-    // Check if shardShape is eqaul to or greater than two.
-    if (shardShape.size() < 2) {
-      return emitOpError(
-          "Invalid shard_shape (<2) for mesh_shard op with devices partition.");
-    }
-
     // Check if rank(shardShape) is eqaul to rank(input).
     if (shardShape.size() != inputShape.size()) {
       return emitOpError("Invalid rank(shard_shape) != rank(input) for "

--- a/test/ttmlir/Conversion/StableHLOToTTIR/ccl/ccl_ops_shardy.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/ccl/ccl_ops_shardy.mlir
@@ -285,16 +285,32 @@ module @jit_neg_shardy7 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_repl
     return %0 : tensor<1x1024x128x1024xf32>
   }
 }
+// CHECK-LABEL @main
+// CHECK: %arg{{[0-9]+}}: tensor<1x1024x128x1024xf32>
+// CHECK-NOT: tensor<1x1024x128x1024xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: tensor<1x1024x128x1024xf32>
+
 // CHECK: "ttir.mesh_shard"
 // CHECK-SAME: shard_dims = array<i64: -1, 1>
 // CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
 // CHECK-SAME: shard_shape = array<i64: 1, 8, 1, 1>
 // CHECK-SAME: shard_type = #tt.shard_type<devices>
+// CHECK-NOT: tensor<1x1024x128x1024xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: tensor<1x1024x128x1024xf32>
+// CHECK-SAME: tensor<1x128x128x1024xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: tensor<1x128x128x1024xf32, #tt.mesh_sharding<"mesh">>
+
 // CHECK: "ttir.mesh_shard"
 // CHECK-SAME: shard_dims = array<i64: -1, 1>
 // CHECK-SAME: shard_direction = #tt.shard_direction<shard_to_full>
 // CHECK-SAME: shard_shape = array<i64: 1, 8, 1, 1>
 // CHECK-SAME: shard_type = #tt.shard_type<devices>
+// CHECK-NOT: tensor<1x128x128x1024xf32>
+// CHECK-SAME: tensor<1x128x128x1024xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-NOT: tensor<1x1024x128x1024xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: tensor<1x1024x128x1024xf32>
+// CHECK-NOT: tensor<1x1024x128x1024xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: tensor<1x1024x128x1024xf32>
 
 // -----
 
@@ -314,22 +330,45 @@ module @jit_matmul_shardy_automatic attributes {mhlo.num_partitions = 8 : i32, m
     return %0 : tensor<8192x16384xf32>
   }
 }
+// CHECK-LABEL @main
+// CHECK: %arg{{[0-9]+}}: tensor<8192x784xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: %arg{{[0-9]+}}: tensor<784x16384xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-NOT: tensor<8192x16384xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: tensor<8192x16384xf32>
+
 // CHECK: "ttir.mesh_shard"
 // CHECK-SAME: shard_dims = array<i64: 0, 1>
 // CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
 // CHECK-SAME: shard_shape = array<i64: 2, 4>
 // CHECK-SAME: shard_type = #tt.shard_type<identity>
+// CHECK-SAME: tensor<8192x784xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: tensor<4096x196xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: tensor<4096x196xf32, #tt.mesh_sharding<"mesh">>
+
 // CHECK: "ttir.mesh_shard"
 // CHECK-SAME: shard_dims = array<i64: -1, 0>
 // CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
 // CHECK-SAME: shard_shape = array<i64: 4, 1>
 // CHECK-SAME: shard_type = #tt.shard_type<identity>
+// CHECK-SAME: tensor<784x16384xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: tensor<196x16384xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: tensor<196x16384xf32, #tt.mesh_sharding<"mesh">>
+
 // CHECK: = "ttir.all_reduce"
+// CHECK-SAME: tensor<4096x16384xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: tensor<4096x16384xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: tensor<4096x16384xf32, #tt.mesh_sharding<"mesh">>
+
 // CHECK: "ttir.mesh_shard"
 // CHECK-SAME: shard_dims = array<i64: 0, -1>
 // CHECK-SAME: shard_direction = #tt.shard_direction<shard_to_full>
 // CHECK-SAME: shard_shape = array<i64: 2, 1>
 // CHECK-SAME: shard_type = #tt.shard_type<devices>
+// CHECK-SAME: tensor<4096x16384xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-NOT: tensor<8192x16384xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: tensor<8192x16384xf32>
+// CHECK-NOT: tensor<8192x16384xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: tensor<8192x16384xf32>
 
 // -----
 
@@ -349,19 +388,39 @@ module @jit_matmul_shardy1 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_r
     return %0 : tensor<8192x16384xf32>
   }
 }
+// CHECK-LABEL @main
+// CHECK: %arg{{[0-9]+}}: tensor<8192x784xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: %arg{{[0-9]+}}: tensor<784x16384xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: tensor<8192x16384xf32, #tt.mesh_sharding<"mesh">>
+
 // CHECK: "ttir.mesh_shard"
 // CHECK-SAME: shard_dims = array<i64: 0, 1>
 // CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
 // CHECK-SAME: shard_shape = array<i64: 2, 4>
 // CHECK-SAME: shard_type = #tt.shard_type<identity>
+// CHECK-SAME: tensor<8192x784xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: tensor<4096x196xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: tensor<4096x196xf32, #tt.mesh_sharding<"mesh">>
+
 // CHECK: "ttir.mesh_shard"
 // CHECK-SAME: shard_dims = array<i64: -1, 0>
 // CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
 // CHECK-SAME: shard_shape = array<i64: 4, 1>
 // CHECK-SAME: shard_type = #tt.shard_type<identity>
+// CHECK-SAME: tensor<784x16384xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: tensor<196x16384xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: tensor<196x16384xf32, #tt.mesh_sharding<"mesh">>
+
 // CHECK: = "ttir.all_reduce"
+// CHECK-SAME: tensor<4096x16384xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: tensor<4096x16384xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: tensor<4096x16384xf32, #tt.mesh_sharding<"mesh">>
+
 // CHECK: "ttir.mesh_shard"
 // CHECK-SAME: shard_dims = array<i64: 0, -1>
 // CHECK-SAME: shard_direction = #tt.shard_direction<shard_to_full>
 // CHECK-SAME: shard_shape = array<i64: 2, 1>
 // CHECK-SAME: shard_type = #tt.shard_type<identity>
+// CHECK-SAME: tensor<4096x16384xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: tensor<8192x16384xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: tensor<8192x16384xf32, #tt.mesh_sharding<"mesh">>

--- a/test/ttmlir/Conversion/StableHLOToTTIR/ccl/e2e_fsdp_shardy.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/ccl/e2e_fsdp_shardy.mlir
@@ -173,3 +173,17 @@ module @jit_loss_fsdp attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replic
 // CHECK-SAME: shard_direction = #tt.shard_direction<shard_to_full>
 // CHECK-SAME: shard_shape = array<i64: 1>
 // CHECK-SAME: shard_type = #tt.shard_type<replicate>
+
+// CHECK-LABEL @relu
+// CHECK: %arg{{[0-9]+}}: tensor<4x128xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: tensor<4x128xf32, #tt.mesh_sharding<"mesh">>
+// CHECK: "ttir.constant"
+// CHECK-SAME: -> tensor<1xf32, #tt.mesh_sharding<"mesh">>
+// CHECK: tensor.empty()
+// CHECK-SAME: tensor<1x1xf32, #tt.mesh_sharding<"mesh">>
+// CHECK: "ttir.reshape"
+// CHECK-SAME: tensor<1xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: tensor<1x1xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: -> tensor<1x1xf32, #tt.mesh_sharding<"mesh">>
+// CHECK: return
+// CHECK-SAME: tensor<4x128xf32, #tt.mesh_sharding<"mesh">>


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/2429


### Problem description
In order to handle single device and multi-device tensors in a graph, we need to know each tensor belongs to single device or multi-device (mesh).

### What's changed
Propagate mesh_sharding attribute including associated "mesh" information to multi-device tensors. Currently, we include associated "mesh" information that the tensor belongs to. We can add detailed sharding info with the following PRs.

No impact on single-device tensors.

Muti-device tensors:
  Given mesh info in module attribute, tt.meshes = #tt.meshes<[<"mesh" = 2x4>]> 
  TTIR tensors looks like tensor<4096x16384xf32, #tt<mesh_sharding["mesh"]>.
  TTNN layout looks like 
     #ttnn_layout3 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, mesh = ["mesh"], memref<4096x196xf32, #system_memory>>

### Checklist
- [X] New/Existing tests provide coverage for changes
