### PR TITLE
#2426: Add support for all_gather and reduce_scater ttnn to emitc path. Add runtime assert for mesh_shard operation.

### DIFF
--- a/include/ttmlir/Conversion/TTNNToEmitC/Utils.h
+++ b/include/ttmlir/Conversion/TTNNToEmitC/Utils.h
@@ -49,6 +49,10 @@ emitc::OpaqueAttr convertBoolAttr(Builder &builder, BoolAttr attr);
 //
 emitc::OpaqueAttr convertDType(Builder &builder, tt::DataTypeAttr attr);
 
+// Create emitc::OpaqueAttr for ttnn::operations::reduction::ReduceType
+emitc::OpaqueAttr convertReduceType(ConversionPatternRewriter &rewriter,
+                                    tt::ReduceType reduceType);
+
 // Create emitc::OpaqueAttr for ttnn::SmallVector used in Reduction ops
 //
 emitc::OpaqueAttr convertArrayAttrToTTNNSmallVector(Builder &builder,

--- a/lib/Conversion/TTNNToEmitC/Utils.cpp
+++ b/lib/Conversion/TTNNToEmitC/Utils.cpp
@@ -160,6 +160,32 @@ emitc::OpaqueAttr convertDType(Builder &builder, tt::DataTypeAttr attr) {
   llvm_unreachable("Unkonwn tt::DataType");
 }
 
+emitc::OpaqueAttr convertReduceType(ConversionPatternRewriter &rewriter,
+                                    tt::ReduceType reduceType) {
+  switch (reduceType) {
+  case tt::ReduceType::Sum:
+    return rewriter.getType<emitc::OpaqueAttr>(
+        "::ttnn::operations::reduction::ReduceType::Sum");
+  case tt::ReduceType::Mean:
+    return rewriter.getType<emitc::OpaqueAttr>(
+        "::ttnn::operations::reduction::ReduceType::Mean");
+  case tt::ReduceType::Max:
+    return rewriter.getType<emitc::OpaqueAttr>(
+        "::ttnn::operations::reduction::ReduceType::Max");
+  case tt::ReduceType::Min:
+    return rewriter.getType<emitc::OpaqueAttr>(
+        "::ttnn::operations::reduction::ReduceType::Min");
+  case tt::ReduceType::Std:
+    return rewriter.getType<emitc::OpaqueAttr>(
+        "::ttnn::operations::reduction::ReduceType::Std");
+  case tt::ReduceType::Var:
+    return rewriter.getType<emitc::OpaqueAttr>(
+        "::ttnn::operations::reduction::ReduceType::Var");
+  }
+
+  llvm_unreachable("Unknown ttnn::operations::reduction::ReduceType");
+}
+
 emitc::OpaqueAttr convertArrayAttrToTTNNSmallVector(Builder &builder,
                                                     ArrayAttr attr) {
   std::string buf;

--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -8,6 +8,9 @@
 // ANCHOR: standalone_includes
 #include "core.hpp"
 #include "device.hpp"
+#include "operations/ccl/all_gather/all_gather.hpp"
+#include "operations/ccl/ccl_host_types.hpp"
+#include "operations/ccl/reduce_scatter/reduce_scatter.hpp"
 #include "operations/conv/conv2d/conv2d.hpp"
 #include "operations/copy.hpp"
 #include "operations/core/core.hpp"
@@ -33,6 +36,7 @@
 #include "types.hpp"
 // ANCHOR_END: standalone_includes
 
+#include <cassert>
 #include <cstddef>
 #include <iostream>
 #include <vector>


### PR DESCRIPTION
Currently, if emitC is run on the following operations (all_gather, reduce_scatter, mesh_shard) it produces incorrect C++ codegen. This PR adds in proper support for all_gather and reduce_scatter to emitC conversion. It adds in an assert for mesh_shard operation until that can be supported.

example
```
ttnn::Tensor v3 = v1[0];
assert(0 && "Mesh shard operation is not supported in emitc yet.");
ttnn::Tensor v4 = ttnn::mesh_shard(v3);
```