### PR TITLE
TTIR Generic datamovement pass and dma ops

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/CMakeLists.txt
+++ b/include/ttmlir/Dialect/TTIR/IR/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mlir_dialect(TTIROps ttir)
 add_mlir_doc(TTIRBase TTIRDialect src/autogen/md/Dialect/ -gen-dialect-doc)
 add_mlir_doc(TTIROps TTIROp src/autogen/md/Dialect/ -gen-op-doc)
+add_mlir_doc(TTIROpsTypes TTIROpsTypes src/autogen/md/Dialect/ -gen-typedef-doc)
 add_mlir_doc(TTIRGenericRegionOps TTIRGenericRegionOps src/autogen/md/Dialect/ -gen-op-doc)
 
 set(LLVM_TARGET_DEFINITIONS TTIROpsAttrs.td)
@@ -8,6 +9,12 @@ mlir_tablegen(TTIROpsAttrs.h.inc -gen-attrdef-decls)
 mlir_tablegen(TTIROpsAttrs.cpp.inc -gen-attrdef-defs)
 add_public_tablegen_target(TTIROpsAttrsIncGen)
 add_dependencies(mlir-headers TTIROpsAttrsIncGen)
+
+set(LLVM_TARGET_DEFINITIONS TTIROpsTypes.td)
+mlir_tablegen(TTIROpsTypeDefs.h.inc -gen-typedef-decls)
+mlir_tablegen(TTIROpsTypeDefs.cpp.inc -gen-typedef-defs)
+add_public_tablegen_target(MLIRTTIROpsTypesIncGen)
+add_dependencies(mlir-headers MLIRTTIROpsTypesIncGen)
 
 set(LLVM_TARGET_DEFINITIONS TTIROpsEnums.td)
 mlir_tablegen(TTIROpsEnums.h.inc -gen-enum-decls)

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRBase.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRBase.td
@@ -23,6 +23,7 @@ def TTIR_Dialect : Dialect {
         or dialects that are actually supported by a consuming backend.
     }];
     let cppNamespace = "::mlir::tt::ttir";
+    let useDefaultTypePrinterParser = 1;
     let useDefaultAttributePrinterParser = 1;
     let dependentDialects = [
       "::mlir::arith::ArithDialect",
@@ -35,6 +36,10 @@ def TTIR_Dialect : Dialect {
     ];
 
     let hasConstantMaterializer = 1;
+
+    let extraClassDeclaration = [{
+        void registerTypes();
+    }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
@@ -55,16 +55,6 @@ def TTIR_TileMulOp : TTIR_GenericRegionOp<"tile_mul">{
     let results = (outs TT_Tile:$result);
 }
 
-def TTIR_TileMaximumOp : TTIR_GenericRegionOp<"tile_maximum">{
-    let summary = "TTIR Tile Maximum Op";
-    let description = [{
-        The `tile_maximum` operation calculates the maximum of two tensors element-wise.
-    }];
-
-    let arguments = (ins TT_Tile:$lhs, TT_Tile:$rhs);
-    let results = (outs TT_Tile:$result);
-}
-
 def TTIR_TileRecipOp : TTIR_GenericRegionOp<"tile_recip">{
     let summary = "TTIR Tile Recip Op";
     let description = [{

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
@@ -260,7 +260,7 @@ _tx
       bool isFullyIndexed() {
         return static_cast<int64_t>(getSrcIndices().size()) == getSrcMemRefType().getRank() &&
                static_cast<int64_t>(getDstIndices().size()) == getDstMemRefType().getRank() &&
-               getOptNumElems();;
+               getOptNumElems();
       }
     }];
 }
@@ -408,7 +408,7 @@ def TTIR_IterIndexOp : TTIR_IndexOp<"iter_index"> {
 def TTIR_CoreIndexOp : TTIR_IndexOp<"core_index"> {
     let summary = "Core Index op.";
     let description = [{
-      Return the index of the this core's coordinate inside the generic op's grid dimension.
+      Return the index of this core's coordinate inside the generic op's grid dimension.
     }];
 }
 

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
@@ -6,10 +6,12 @@
 #define TTMLIR_TTMLIR_DIALECT_TTIR_TTIRGENERICREGIONOPS_TD
 
 include "ttmlir/Dialect/TT/IR/TTOpsTypes.td"
+include "ttmlir/Dialect/TTIR/IR/TTIROpsTypes.td"
 include "ttmlir/Dialect/TTIR/IR/TTIRBase.td"
 include "ttmlir/Dialect/TTIR/IR/TTIROpsAttrs.td"
 include "ttmlir/Dialect/TTIR/IR/TTIROpsInterfaces.td"
 
+include "mlir/IR/OpAsmInterface.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 
 class TTIR_GenericRegionOp<string mnemonic, list<Trait> traits = [TTIR_GenericRegionOpTrait, TTIR_GenericParent]> :
@@ -17,17 +19,8 @@ class TTIR_GenericRegionOp<string mnemonic, list<Trait> traits = [TTIR_GenericRe
 }
 
 //===----------------------------------------------------------------------===//
-// TTIR Generic Region Ops (Used in TTMetal Lowering)
+// TTIR Generic Region Math Ops (Used in TTMetal Lowering)
 //===----------------------------------------------------------------------===//
-
-def TTIR_YieldOp : TTIR_Op<"yield", [Pure, ReturnLike, Terminator, TTIR_GenericRegionOpTrait]> {
-    let summary = "Yield op.";
-    let description = [{
-      Yield operation, this is required by MLIR to mark the end of a dispatch region.
-    }];
-
-    let arguments = (ins Variadic<AnyRankedTensorOrMemRef>:$values);
-}
 
 def TTIR_TileAddOp : TTIR_GenericRegionOp<"tile_add">{
     let summary = "TTIR Tile Add Op";
@@ -59,6 +52,16 @@ def TTIR_TileMulOp : TTIR_GenericRegionOp<"tile_mul">{
 
     let arguments = (ins TT_Tile:$lhs,
                          TT_Tile:$rhs);
+    let results = (outs TT_Tile:$result);
+}
+
+def TTIR_TileMaximumOp : TTIR_GenericRegionOp<"tile_maximum">{
+    let summary = "TTIR Tile Maximum Op";
+    let description = [{
+        The `tile_maximum` operation calculates the maximum of two tensors element-wise.
+    }];
+
+    let arguments = (ins TT_Tile:$lhs, TT_Tile:$rhs);
     let results = (outs TT_Tile:$result);
 }
 
@@ -117,7 +120,7 @@ def TTIR_TileReduceMaxOp : TTIR_GenericRegionOp<"tile_reduce_max">{
 }
 
 def TTIR_TileMatmulBlockOp : TTIR_GenericRegionOp<"tile_matmul_block",
-  [DestinationStyleOpInterface, MemoryEffects<[MemRead, MemWrite]>]> {
+  [DestinationStyleOpInterface, DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
     let summary = "TTIR Tile Matmul Block Op";
     let description = [{
         The `tile_matmul_block` operation computes the matrix multiplication of two input blocks.
@@ -166,6 +169,257 @@ def TTIR_TileUntilizeBlockOp : TTIR_GenericRegionOp<"tile_untilize_block",
     }];
 
     let hasVerifier = 1;
+}
+
+
+//===----------------------------------------------------------------------===//
+// TTIR Generic Region Datamovement Ops (Used in TTMetal Lowering)
+//===----------------------------------------------------------------------===//
+
+def TTIR_DMAOp : TTIR_GenericRegionOp<"dma",
+  [ AttrSizedOperandSegments
+  , DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
+  , DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
+  ]> {
+    let summary = "TTIR DMA Op";
+    let description = [{
+      DMA operation, moves data from src to dst where src and dst are memrefs that may or may not belong to
+      different memory spaces. This op comes in a few flavors and is capable of roughly expressing everything
+      that underlying Noc hardware can do. The op can be used to express a wide range of data movement operations:
+
+      - Local to local
+      ```mlir
+      %tx = ttir.dma %src, %dst : (memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+      ```
+
+      - Local to remote dram
+      ```mlir
+      %tx = ttir.dma %src, %dst : (memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #dram>) -> !ttir.mem_tx
+      ```
+
+      - Remote dram to local
+      ```mlir
+      %tx = ttir.dma %src, %dst : (memref<6x8x!tt.tile<32x32, f32>, #dram>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+      ```
+
+      - Local to remote L1, e.g. core[1, 2]
+      ```mlir
+      %tx = ttir.dma %src, %dst, core[%c1, %c2] : (memref<6x8x!tt.tile<32x32, f32>, #dram>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+      ```
+
+      - Local to mcast, e.g. starting at offset core[1, 2] with mcast shape [4, 4] (src and dst have the same SSA value, implies NoC doesn't loopback)
+      ```mlir
+      %tx = ttir.dma %foo, %foo, core[%c1, %c2] mcast[%c4, %c4] : (memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+      ```
+
+      - Local to mcast w/ loopback (same as above but src and dst are different SSA values)
+      ```mlir
+      %tx = ttir.dma %src, %dst, core[%c1, %c2] mcast[%c4, %c4] : (memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+      ```
+
+      - A lower level form, is "fully indexed" DMA, where the src and dst memrefs have thier ranks fully indexed the additional numElems argument
+        is used to specify the number of elements to transfer. As opposed to the forms above that are not fully indexed which implicitly means to
+        transfer the leftover block.  That is given memref<2x2x3x4x!tt.tile<>>, if we indexed by [i, j], since we only indexed a rank of 2, the remaining
+        3x4 block is transferred.  In the fully indexed form, to express the same thing we would need to specify the number of elements to transfer:
+      ```mlir
+      %tx = ttir.dma %src[%i, %j, %k, %l], %dst[%i, %j, %k, %l], 12 : (memref<2x2x3x4x!tt.tile<32x32, f32>, #dram>, memref<2x2x3x4x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+      ```
+
+      - Conversely, a higher level form is affine form, where the src and dst indices are implied by an affine map shared with the parent generic op.
+        Given some affine map, as demonstrated below, the dma op will be evaluated at each point in the affine map's iteration space.
+      ```mlir
+      #map1 = affine_map<(d0, d1, d2) -> (d0, d2)>
+      %tx = ttir.dma %stream #map1, %cb0 : (memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem
+      ```
+_tx
+
+      Some constraints:
+      - src and dst must have the same element type.
+      - src and dst cannot both be remote
+    }];
+
+    let arguments = (ins AnyNon0RankedMemRef:$src, OptionalAttr<AffineMapAttr>:$srcAffineMap, Variadic<Index>:$srcIndices,
+                         AnyNon0RankedMemRef:$dst, OptionalAttr<AffineMapAttr>:$dstAffineMap, Variadic<Index>:$dstIndices,
+                         OptionalAttr<I64Attr>:$optNumElems, Variadic<Index>:$dstCoreIndex, Variadic<Index>:$mcastShape);
+    let results = (outs TTIR_MemTx:$result);
+
+    let assemblyFormat = [{ $src ($srcAffineMap^)? (`[` $srcIndices^ `]`)? `,` $dst ($dstAffineMap^)? (`[` $dstIndices^ `]`)? (`,` $optNumElems^)? (`,` `core` `[` $dstCoreIndex^ `]`)? (`mcast` `[` $mcastShape^ `]`)? attr-dict `:` `(` type($src) `,` type($dst) `)` `->` type($result)}];
+
+    let hasVerifier = 1;
+
+    let extraClassDeclaration = [{
+      MemRefType getSrcMemRefType() { return cast<MemRefType>(getSrc().getType()); }
+      MemRefType getDstMemRefType() { return cast<MemRefType>(getDst().getType()); }
+      int64_t getNumElems();
+      bool isSrcLocal() {
+        Block *block = getSrc().getParentBlock();
+        Block::BlockArgListType blockArgs = block->getArguments();
+        return std::find(blockArgs.begin(), blockArgs.end(), getSrc()) !=
+               blockArgs.end();
+      }
+      bool isSrcRemote() { return !isSrcLocal(); }
+      bool isDstLocal() {
+        Block *block = getDst().getParentBlock();
+        Block::BlockArgListType blockArgs = block->getArguments();
+        return std::find(blockArgs.begin(), blockArgs.end(), getDst()) !=
+               blockArgs.end();
+      }
+      bool isDstRemote() { return !isDstLocal(); }
+      bool isMcast() { return !getMcastShape().empty(); }
+      bool isAffine() { return getSrcAffineMap() || getDstAffineMap(); }
+      bool isFullyIndexed() {
+        return static_cast<int64_t>(getSrcIndices().size()) == getSrcMemRefType().getRank() &&
+               static_cast<int64_t>(getDstIndices().size()) == getDstMemRefType().getRank() &&
+               getOptNumElems();;
+      }
+    }];
+}
+
+def TTIR_DMAWaitOp : TTIR_GenericRegionOp<"dma_wait", [MemoryEffects<[MemRead, MemWrite]>]> {
+    let summary = "TTIR DMA wait Op";
+    let description = [{
+      Waits for the producer DMA memory transaction to complete.
+    }];
+
+    let arguments = (ins TTIR_MemTx:$mem_tx);
+
+    let assemblyFormat = [{ $mem_tx attr-dict }];
+}
+
+//===----------------------------------------------------------------------===//
+// TTIR Generic Region Semaphore Ops (Used in TTMetal Lowering)
+//===----------------------------------------------------------------------===//
+
+class TTIR_SemaphoreUpdateOp<string mnemonic> : TTIR_GenericRegionOp<mnemonic,
+  [ AttrSizedOperandSegments
+  , MemoryEffects<[MemRead, MemWrite]>
+  ]> {
+    let summary = "TTIR Semaphore Set or Inc Op";
+    let description = [{
+      Set or increment the semaphore value atomically. This op comes in a few flavors:
+
+      - Set or increment this local core's semaphore value
+      ```mlir
+      ttir.semaphore_set %sem0, %c1
+      ttir.semaphore_inc %sem0, %c1
+      ```
+
+      - Update a remote core's semaphore value
+      ```mlir
+      ttir.semaphore_set %sem0, %c1 core[%c2, %c2]
+      ttir.semaphore_inc %sem0, %c1 core[%c2, %c2]
+      ```
+
+      - Update a remote mcast region of cores' semaphore value
+      ```mlir
+      ttir.semaphore_set %sem0, %c1 core[%c2, %c2] mcast[%c4, %c4]
+      ttir.semaphore_inc %sem0, %c1 core[%c2, %c2] mcast[%c4, %c4]
+      ```
+    }];
+
+    let arguments = (ins TTIR_Semaphore:$semaphore, Index:$value,
+                         Variadic<Index>:$dstCoreIndex, Variadic<Index>:$mcastShape);
+
+    let assemblyFormat = [{ $semaphore `,` $value (`,` `core` `[` $dstCoreIndex^ `]`)? (`mcast` `[` $mcastShape^ `]`)? attr-dict }];
+
+    let builders =
+    [
+      OpBuilder<(ins "Value":$semaphore, "Value":$value),
+      [{
+        build($_builder, $_state, semaphore, value, ValueRange(), ValueRange());
+      }]>,
+      OpBuilder<(ins "Value":$semaphore, "Value":$value, "ValueRange":$dstCoreIndex),
+      [{
+        build($_builder, $_state, semaphore, value, dstCoreIndex, ValueRange());
+      }]>,
+    ];
+}
+
+def TTIR_SemaphoreSetOp : TTIR_SemaphoreUpdateOp<"semaphore_set"> {}
+
+def TTIR_SemaphoreIncOp : TTIR_SemaphoreUpdateOp<"semaphore_inc"> {}
+
+def TTIR_SemaphoreWaitOp : TTIR_GenericRegionOp<"semaphore_wait", [MemoryEffects<[MemRead, MemWrite]>]> {
+    let summary = "TTIR Semaphore Set Op.";
+    let description = [{
+      Wait for the semaphore value to reach the specified value. Optionall supply a reset value as a shorthand syntax.
+
+      ```mlir
+      ttir.semaphore_wait %sem1, %c1 reset %c0
+      // is equivalent to
+      ttir.semaphore_wait %sem1, %c1
+      ttir.semaphore_set %sem1, %c0
+      ```
+    }];
+
+    let arguments = (ins TTIR_Semaphore:$semaphore, Index:$value, Optional<Index>:$resetValue);
+
+    let assemblyFormat = [{ $semaphore `,` $value (`reset` $resetValue^)? attr-dict }];
+
+    let builders =
+    [
+      OpBuilder<(ins "Value":$semaphore, "Value":$value),
+      [{
+        build($_builder, $_state, semaphore, value, nullptr);
+      }]>,
+    ];
+}
+
+//===----------------------------------------------------------------------===//
+// TTIR Generic Region Control Ops (Used in TTMetal Lowering)
+//===----------------------------------------------------------------------===//
+
+def TTIR_YieldOp : TTIR_GenericRegionOp<"yield", [MemoryEffects<[MemRead, MemWrite]>, ReturnLike, Terminator]> {
+    let summary = "Yield op.";
+    let description = [{
+      Yield operation, return control flow to another thread. Corresponds to a circular buffer push.
+    }];
+
+    let arguments = (ins Variadic<AnyRankedTensorOrMemRef>:$values);
+
+    let assemblyFormat = [{ $values attr-dict `:` `(` type($values) `)` }];
+
+    let hasVerifier = 1;
+}
+
+def TTIR_AwaitOp : TTIR_GenericRegionOp<"await", [MemoryEffects<[MemRead, MemWrite]>]> {
+    let summary = "Await op.";
+    let description = [{
+      Await operation, await control flow from another thread. Corresponds to a circular buffer wait.
+    }];
+
+    let arguments = (ins Variadic<AnyNon0RankedMemRef>:$values);
+
+    let assemblyFormat = [{ $values attr-dict `:` `(` type($values) `)` }];
+
+    let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// TTIR Generic Region Indexing Ops (Used in TTMetal Lowering)
+//===----------------------------------------------------------------------===//
+
+class TTIR_IndexOp<string mnemonic> : TTIR_GenericRegionOp<mnemonic,
+  [ Pure
+  , DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
+  ]> {
+    let arguments = (ins ConfinedAttr<I64Attr, [IntMinValue<0>]>:$dim);
+    let results = (outs Index:$result);
+    let assemblyFormat = [{ `(` $dim `)` attr-dict `:` type($result) }];
+}
+
+def TTIR_IterIndexOp : TTIR_IndexOp<"iter_index"> {
+    let summary = "Iter Index op.";
+    let description = [{
+      Return the index of the current element in the iteration for the given generic op dimension.
+    }];
+}
+
+def TTIR_CoreIndexOp : TTIR_IndexOp<"core_index"> {
+    let summary = "Core Index op.";
+    let description = [{
+      Return the index of the this core's coordinate inside the generic op's grid dimension.
+    }];
 }
 
 #endif // TTMLIR_TTMLIR_DIALECT_TTIR_TTIRGENERICREGIONOPS_TD

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.h
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.h
@@ -7,6 +7,7 @@
 
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIROpsInterfaces.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIROpsTypes.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIRTraits.h"
 #include "ttmlir/Dialect/TTIR/IR/Utils.h"
 

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -78,7 +78,11 @@ class TTIR_BufferizableOp<string mnemonic, list<Trait> traits = []> :
     }];
 }
 
-def TTIR_GenericOp : TTIR_BufferizableOp<"generic", [AttrSizedOperandSegments, NoTerminator]> {
+def TTIR_GenericOp : TTIR_BufferizableOp<"generic",
+  [ AttrSizedOperandSegments
+  , NoTerminator
+  , DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmBlockArgumentNames", "getAsmBlockNames"]>
+  ]> {
     let summary = "Generically dispatch work to a grid of cores.";
     let description = [{
       This generic op carries a region that represents the work each core does. The region is

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROpsTypes.h
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROpsTypes.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROpsTypes.h
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROpsTypes.h
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTIR_IR_TTIROPSTYPES_H
+#define TTMLIR_DIALECT_TTIR_IR_TTIROPSTYPES_H
+
+#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+
+#define GET_TYPEDEF_CLASSES
+#include "ttmlir/Dialect/TTIR/IR/TTIROpsTypeDefs.h.inc"
+
+#endif // TTMLIR_DIALECT_TTIR_IR_TTIROPSTYPES_H

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROpsTypes.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROpsTypes.td
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROpsTypes.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROpsTypes.td
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef TTMLIR_TTMLIR_DIALECT_TTIR_TTIROPSTYPES_TD
-#define TTMLIR_TTMLIR_DIALECT_TTIR_TTIROPSTYPES_TD
+#ifndef TTMLIR_TTMLIR_DIALECT_TTIR_IR_TTIROPSTYPES_TD
+#define TTMLIR_TTMLIR_DIALECT_TTIR_IR_TTIROPSTYPES_TD
 
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/BuiltinTypeInterfaces.td"
@@ -29,4 +29,4 @@ def TTIR_Semaphore : TTIR_Type<"Semaphore", "semaphore"> {
     let description = "Semaphore primitive type used in combination with semaphore ops to synchronize cores.";
 }
 
-#endif  // TTMLIR_TTMLIR_DIALECT_TTIR_TTIROPSTYPES_TD
+#endif  // TTMLIR_TTMLIR_DIALECT_TTIR_IR_TTIROPSTYPES_TD

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROpsTypes.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROpsTypes.td
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_TTMLIR_DIALECT_TTIR_TTIROPSTYPES_TD
+#define TTMLIR_TTMLIR_DIALECT_TTIR_TTIROPSTYPES_TD
+
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/BuiltinTypeInterfaces.td"
+include "mlir/IR/CommonTypeConstraints.td"
+include "ttmlir/Dialect/TTIR/IR/TTIRBase.td"
+
+//===----------------------------------------------------------------------===//
+// TTIR type definitions
+//===----------------------------------------------------------------------===//
+
+class TTIR_Type<string name, string typeMnemonic, list<Trait> traits = []>
+    : TypeDef<TTIR_Dialect, name, traits> {
+  let mnemonic = typeMnemonic;
+}
+
+def TTIR_MemTx : TTIR_Type<"MemTx", "mem_tx"> {
+    let summary = "TTIR memory transaction type.";
+    let description = "Memory transaction returned by dma op, used to wait for completion.";
+}
+
+def TTIR_Semaphore : TTIR_Type<"Semaphore", "semaphore"> {
+    let summary = "TTIR semaphore type.";
+    let description = "Semaphore primitive type used in combination with semaphore ops to synchronize cores.";
+}
+
+#endif  // TTMLIR_TTMLIR_DIALECT_TTIR_TTIROPSTYPES_TD

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -84,7 +84,7 @@ def TTIROptimizeTensorLayout: Pass<"ttir-optimize-tensor-layout", "::mlir::Modul
   }];
 }
 
-def TTIRGenericDatamovement: Pass<"ttir-generic-datamovement", "::mlir::ModuleOp"> {
+def TTIRGenericGenerateDatamovement: Pass<"ttir-generic-generate-datamovement", "::mlir::ModuleOp"> {
   let summary = "Generate generic data movement threads.";
   let description = [{
     This pass makes the following transformation, given a generic compute region:

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -84,6 +84,55 @@ def TTIROptimizeTensorLayout: Pass<"ttir-optimize-tensor-layout", "::mlir::Modul
   }];
 }
 
+def TTIRGenericDatamovement: Pass<"ttir-generic-datamovement", "::mlir::ModuleOp"> {
+  let summary = "Generate generic data movement threads.";
+  let description = [{
+    This pass makes the following transformation, given a generic compute region:
+    ```mlir
+    #map = affine_map<(d0, d1) -> (d0, d1)>
+    #parallel = #tt.iterator_type<parallel>
+
+    "ttir.generic"(%arg0, %arg1, %alloc) <{indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel]}> ({
+    ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg3: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
+      affine.for %arg5 = 0 to 2 {
+        affine.for %arg6 = 0 to 4 {
+          %0 = affine.load %arg2[%arg5, %arg6] : memref<2x4x!tt.tile<32x32, f32>, #l1_>
+          %1 = affine.load %arg3[%arg5, %arg6] : memref<2x4x!tt.tile<32x32, f32>, #l1_>
+          %2 = "ttir.tile_add"(%0, %1) : (!tt.tile<32x32, f32>, !tt.tile<32x32, f32>) -> !tt.tile<32x32, f32>
+          affine.store %2, %arg4[%arg5, %arg6] : memref<2x4x!tt.tile<32x32, f32>, #l1_>
+        }
+      }
+    })
+    ```
+
+    We generate additional (prepended) regions that correspond to the data movement
+    for each operand respectively:
+    ```mlir
+    "ttir.generic"(%arg0, %arg1, %alloc) <{indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel]}> ({
+    ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg3: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
+      ttir.yield %arg2 : (memref<2x4x!tt.tile<32x32, f32>, #l1_>)
+    }, {
+    ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg3: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
+      ttir.yield %arg3 : (memref<2x4x!tt.tile<32x32, f32>, #l1_>)
+    }, {
+    ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg3: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
+      ttir.await %arg4 : (memref<2x4x!tt.tile<32x32, f32>, #l1_>)
+    }, {
+    ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg3: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
+      ttir.await %arg2, %arg3 : (memref<2x4x!tt.tile<32x32, f32>, #l1_>, memref<2x4x!tt.tile<32x32, f32>, #l1_>)
+      affine.for %arg5 = 0 to 2 {
+        affine.for %arg6 = 0 to 4 {
+          %0 = affine.load %arg2[%arg5, %arg6] : memref<2x4x!tt.tile<32x32, f32>, #l1_>
+          %1 = affine.load %arg3[%arg5, %arg6] : memref<2x4x!tt.tile<32x32, f32>, #l1_>
+          %2 = "ttir.tile_add"(%0, %1) : (!tt.tile<32x32, f32>, !tt.tile<32x32, f32>) -> !tt.tile<32x32, f32>
+          affine.store %2, %arg4[%arg5, %arg6] : memref<2x4x!tt.tile<32x32, f32>, #l1_>
+        }
+      }
+      ttir.yield %arg4 : (memref<2x4x!tt.tile<32x32, f32>, #l1_>)
+    })
+    ```
+  }];
+}
 
 def TTIRLayout: Pass<"ttir-layout", "::mlir::ModuleOp"> {
   let summary = "Tensor tilize all generic ops.";

--- a/lib/Dialect/TTIR/IR/CMakeLists.txt
+++ b/lib/Dialect/TTIR/IR/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mlir_dialect_library(MLIRTTIRDialect
         TTIRDialect.cpp
         TTIROps.cpp
+        TTIROpsTypes.cpp
         TTIROpsInterfaces.cpp
         TTIRTraits.cpp
         TTIRGenericRegionOps.cpp

--- a/lib/Dialect/TTIR/IR/TTIRDialect.cpp
+++ b/lib/Dialect/TTIR/IR/TTIRDialect.cpp
@@ -104,6 +104,7 @@ void TTIRDialect::initialize() {
 #define GET_ATTRDEF_LIST
 #include "ttmlir/Dialect/TTIR/IR/TTIROpsAttrs.cpp.inc"
       >();
+  registerTypes();
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTIR/IR/TTIRGenericRegionOps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIRGenericRegionOps.cpp
@@ -4,6 +4,8 @@
 
 #include "ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.h"
 
+#include "ttmlir/Utils.h"
+
 #define GET_OP_CLASSES
 #include "ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.cpp.inc"
 
@@ -55,4 +57,103 @@
   }
 
   return success();
+}
+
+void mlir::tt::ttir::TileMatmulBlockOp::getEffects(
+    mlir::SmallVectorImpl<
+        mlir::SideEffects::EffectInstance<mlir::MemoryEffects::Effect>>
+        &effects) {
+  return mlir::tt::ttir::getDpsEffects(*this, effects);
+}
+
+//===----------------------------------------------------------------------===//
+// DMAOp
+//===----------------------------------------------------------------------===//
+::mlir::LogicalResult mlir::tt::ttir::DMAOp::verify() {
+  MemRefType srcType = getSrc().getType();
+  MemRefType dstType = getDst().getType();
+  if (srcType.getElementType() != dstType.getElementType()) {
+    return emitOpError(
+        "MemRef operands to DMA must have the same element type");
+  }
+
+  if (isSrcRemote() && isDstRemote()) {
+    return emitOpError("DMA cannot have both src and dst remote");
+  }
+
+  if (getSrcAffineMap() && getSrcIndices().size()) {
+    return emitOpError("DMA cannot have both src affine map and indices");
+  }
+
+  if (getDstAffineMap() && getDstIndices().size()) {
+    return emitOpError("DMA cannot have both dst affine map and indices");
+  }
+
+  int64_t srcIndices = getSrcAffineMap() ? getSrcAffineMap()->getNumResults()
+                                         : getSrcIndices().size();
+  int64_t dstIndices = getDstAffineMap() ? getDstAffineMap()->getNumResults()
+                                         : getDstIndices().size();
+
+  if (srcIndices > srcType.getRank()) {
+    return emitOpError("Invalid number of src indices, expected less than ")
+           << srcType.getRank();
+  }
+
+  if (dstIndices > dstType.getRank()) {
+    return emitOpError("Invalid number of dst indices, expected less than ")
+           << dstType.getRank();
+  }
+
+  if ((srcType.getRank() - srcIndices) != (dstType.getRank() - dstIndices)) {
+    return emitOpError(
+        "MemRef operands to DMA must have the same post-index rank");
+  }
+
+  if (!std::equal(srcType.getShape().begin() + srcIndices,
+                  srcType.getShape().end(),
+                  dstType.getShape().begin() + dstIndices)) {
+    return emitOpError(
+        "MemRef operands to DMA must have the same post-index shape");
+  }
+
+  return success();
+}
+
+int64_t mlir::tt::ttir::DMAOp::getNumElems() {
+  if (getOptNumElems()) {
+    return *getOptNumElems();
+  }
+
+  ArrayRef<int64_t> txShape =
+      getSrcMemRefType().getShape().drop_front(getSrcIndices().size());
+  return ttmlir::utils::volume(txShape);
+}
+
+void mlir::tt::ttir::DMAOp::getAsmResultNames(
+    function_ref<void(Value, StringRef)> setNameFn) {
+  setNameFn(getResult(), "tx");
+}
+
+void mlir::tt::ttir::DMAOp::getEffects(
+    mlir::SmallVectorImpl<
+        mlir::SideEffects::EffectInstance<mlir::MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(mlir::MemoryEffects::Read::get(), &getSrcMutable(),
+                       0 /*stage*/, true /*effectOnFullRegion*/,
+                       mlir::SideEffects::DefaultResource::get());
+  effects.emplace_back(mlir::MemoryEffects::Write::get(), &getDstMutable(),
+                       0 /*stage*/, true /*effectOnFullRegion*/,
+                       mlir::SideEffects::DefaultResource::get());
+}
+
+void mlir::tt::ttir::IterIndexOp::getAsmResultNames(
+    function_ref<void(Value, StringRef)> setNameFn) {
+  int64_t dim = getDim();
+  setNameFn(getResult(), "iter" + std::to_string(dim));
+}
+
+void mlir::tt::ttir::CoreIndexOp::getAsmResultNames(
+    function_ref<void(Value, StringRef)> setNameFn) {
+  int64_t dim = getDim();
+  setNameFn(getResult(), "core" + std::to_string(dim));
 }

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -1650,8 +1650,11 @@ mlir::LogicalResult mlir::tt::ttir::StreamLayoutOp::verify() {
     return storageResultVerification;
   }
 
-  if (mlir::cast<MemRefType>(getInput().getType()).getMemorySpace() !=
-      mlir::cast<MemRefType>(getResult().getType()).getMemorySpace()) {
+  MemRefType inputMemrefType = mlir::dyn_cast<MemRefType>(getInput().getType());
+  MemRefType resultMemrefType =
+      mlir::dyn_cast<MemRefType>(getResult().getType());
+  if (inputMemrefType && resultMemrefType &&
+      (inputMemrefType.getMemorySpace() != resultMemrefType.getMemorySpace())) {
     return this->emitOpError(
         "Input and result memref memory spaces must be the same");
   }

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -1632,7 +1632,8 @@ mlir::LogicalResult mlir::tt::ttir::StreamLayoutOp::verify() {
                      /*allowMemorySpaceChange*/ true,
                      /*checkMemrefRank*/ true,
                      /*checkMemrefGridShardForm */ true,
-                     /*checkMemrefGridShape*/ false);
+                     /*checkMemrefGridShape*/ false,
+                     /*checkMemrefShardShape*/ false);
   if (failed(inputStorageVerification)) {
     return inputStorageVerification;
   }
@@ -1643,7 +1644,8 @@ mlir::LogicalResult mlir::tt::ttir::StreamLayoutOp::verify() {
                      /*allowMemorySpaceChange*/ false,
                      /*checkMemrefRank*/ true,
                      /*checkMemrefGridShardForm */ true,
-                     /*checkMemrefGridShape*/ true);
+                     /*checkMemrefGridShape*/ false,
+                     /*checkMemrefShardShape*/ true);
   if (failed(storageResultVerification)) {
     return storageResultVerification;
   }
@@ -2818,6 +2820,17 @@ void mlir::tt::ttir::PermuteOp::getCanonicalizationPatterns(
 
 // GenericOp verification
 ::mlir::LogicalResult mlir::tt::ttir::GenericOp::verify() {
+  if (!getGrid().getMapping().isEmpty()) {
+    return emitOpError("GenericOp grid mapping is not supported");
+  }
+
+  auto [outputOperandsIndex, outputOperandsLength] =
+      getODSOperandIndexAndLength(1);
+  if (outputOperandsLength != 1) {
+    return emitOpError(
+        "GenericOp must currently have exactly one output operand");
+  }
+
   // Output grid shape must equal the GenericOp grid shape.
   auto opGridShape = getGrid().getShape();
   for (auto output : getOutputs()) {
@@ -2898,9 +2911,46 @@ void mlir::tt::ttir::PermuteOp::getCanonicalizationPatterns(
                            "shape of the corresponding operand");
       }
     }
+
+    auto additionalArguments =
+        region.getArguments().drop_front(operandTypes.size());
+    for (BlockArgument arg : additionalArguments) {
+      bool supportedType = mlir::isa<SemaphoreType>(arg.getType());
+      if (!supportedType) {
+        return emitOpError(
+            "Additional GenericOp region arguments must be of SemaphoreType");
+      }
+    }
   }
 
   return success();
+}
+
+void mlir::tt::ttir::GenericOp::getAsmBlockArgumentNames(
+    Region &region, function_ref<void(Value, StringRef)> setNameFn) {
+  int cbIndex = 0;
+  int semIndex = 0;
+  for (BlockArgument arg : region.getArguments()) {
+    if (mlir::isa<MemRefType>(arg.getType())) {
+      setNameFn(arg, "cb" + std::to_string(cbIndex++));
+    } else {
+      setNameFn(arg, "sem" + std::to_string(semIndex++));
+    }
+  }
+}
+
+void mlir::tt::ttir::GenericOp::getAsmBlockNames(
+    function_ref<void(Block *, StringRef)> setNameFn) {
+  size_t numRegions = getNumRegions();
+  for (Region &region : getRegions()) {
+    // Right now the last region is implicitly the compute region.
+    if (region.getRegionNumber() < (numRegions - 1)) {
+      setNameFn(&region.front(),
+                "datamovement" + std::to_string(region.getRegionNumber()));
+    } else {
+      setNameFn(&region.front(), "compute");
+    }
+  }
 }
 
 mlir::LogicalResult mlir::tt::ttir::GenericOp::bufferize(
@@ -3241,4 +3291,43 @@ void mlir::tt::ttir::ArgMaxOp::buildGenericRegion(::mlir::OpBuilder &opBuilder,
   }
 
   return success();
+}
+
+//===----------------------------------------------------------------------===//
+// YieldOp / AwaitOp
+//===----------------------------------------------------------------------===//
+
+static bool valueInBlockArguments(mlir::Value value, mlir::Block *block) {
+  return llvm::any_of(block->getArguments(),
+                      [&](const mlir::BlockArgument &blockArgument) {
+                        return blockArgument == value;
+                      });
+}
+
+static mlir::Value recurseThroughMemrefCollapse(mlir::Value value) {
+  while (auto memrefCastOp =
+             value.getDefiningOp<::mlir::memref::CollapseShapeOp>()) {
+    value = memrefCastOp.getOperand();
+  }
+  return value;
+}
+
+static ::mlir::LogicalResult operandsInBlockArguments(mlir::Operation *op,
+                                                      mlir::Block *block) {
+  for (mlir::OpOperand &operand : op->getOpOperands()) {
+    mlir::Value value = recurseThroughMemrefCollapse(operand.get());
+    if (!valueInBlockArguments(value, block)) {
+      return op->emitOpError() << "operand[" << operand.getOperandNumber()
+                               << "] not in block arguments";
+    }
+  }
+  return ::mlir::success();
+}
+
+::mlir::LogicalResult mlir::tt::ttir::YieldOp::verify() {
+  return operandsInBlockArguments(getOperation(), getOperation()->getBlock());
+}
+
+::mlir::LogicalResult mlir::tt::ttir::AwaitOp::verify() {
+  return operandsInBlockArguments(getOperation(), getOperation()->getBlock());
 }

--- a/lib/Dialect/TTIR/IR/TTIROpsTypes.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROpsTypes.cpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTIR/IR/TTIROpsTypes.h"
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIR.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace mlir::tt::ttir;
+
+#define GET_TYPEDEF_CLASSES
+#include "ttmlir/Dialect/TTIR/IR/TTIROpsTypeDefs.cpp.inc"
+
+void TTIRDialect::registerTypes() {
+  // NOLINTNEXTLINE
+  addTypes<
+#define GET_TYPEDEF_LIST
+#include "ttmlir/Dialect/TTIR/IR/TTIROpsTypeDefs.cpp.inc"
+      >();
+}

--- a/lib/Dialect/TTIR/IR/TTIROpsTypes.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROpsTypes.cpp
@@ -4,9 +4,10 @@
 
 #include "ttmlir/Dialect/TTIR/IR/TTIROpsTypes.h"
 
+#include "ttmlir/Dialect/TTIR/IR/TTIR.h"
+
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/DialectImplementation.h"
-#include "ttmlir/Dialect/TTIR/IR/TTIR.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
 

--- a/lib/Dialect/TTIR/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTIR/Transforms/CMakeLists.txt
@@ -3,7 +3,7 @@ add_mlir_dialect_library(MLIRTTIRTransforms
         Broadcast.cpp
         Constant.cpp
         GenericLinearizeMemref.cpp
-        GenericDatamovement.cpp
+        GenericGenerateDatamovement.cpp
         HoistCPUOps.cpp
         Layout.cpp
         Transforms.cpp

--- a/lib/Dialect/TTIR/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTIR/Transforms/CMakeLists.txt
@@ -3,6 +3,7 @@ add_mlir_dialect_library(MLIRTTIRTransforms
         Broadcast.cpp
         Constant.cpp
         GenericLinearizeMemref.cpp
+        GenericDatamovement.cpp
         HoistCPUOps.cpp
         Layout.cpp
         Transforms.cpp

--- a/lib/Dialect/TTIR/Transforms/GenericDatamovement.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericDatamovement.cpp
@@ -114,9 +114,9 @@ public:
     mcastShape.reserve(grid.getShape().size());
 
     for (auto [dim, iteratorType] : llvm::enumerate(mcastIterators)) {
-      Value gridDimMinusOne = blockBuilder.create<arith::ConstantOp>(
+      Value gridDim = blockBuilder.create<arith::ConstantOp>(
           loc, blockBuilder.getIndexType(),
-          blockBuilder.getIndexAttr(grid.getShape()[dim] - 1));
+          blockBuilder.getIndexAttr(grid.getShape()[dim]));
       Value core =
           blockBuilder.create<CoreIndexOp>(loc, blockBuilder.getIndexType(),
                                            blockBuilder.getI64IntegerAttr(dim));
@@ -125,8 +125,8 @@ public:
         mcastShape.push_back(Value(one));
       } else {
         assert(iteratorType == IteratorType::Reduction);
-        coreIndex.push_back(one);
-        mcastShape.push_back(gridDimMinusOne);
+        coreIndex.push_back(zero);
+        mcastShape.push_back(gridDim);
         mcastVolume *= grid.getShape()[dim];
 
         Value condition = blockBuilder.create<arith::CmpIOp>(

--- a/lib/Dialect/TTIR/Transforms/GenericDatamovement.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericDatamovement.cpp
@@ -1,0 +1,323 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TT/IR/TT.h"
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
+
+#include <mlir/Dialect/Affine/IR/AffineOps.h>
+#include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/Linalg/IR/Linalg.h>
+#include <mlir/Dialect/MemRef/IR/MemRef.h>
+#include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/Dialect/Tensor/IR/Tensor.h>
+#include <mlir/Rewrite/FrozenRewritePatternSet.h>
+#include <mlir/Transforms/DialectConversion.h>
+#include <mlir/Transforms/GreedyPatternRewriteDriver.h>
+
+namespace mlir::tt::ttir {
+#define GEN_PASS_DEF_TTIRGENERICDATAMOVEMENT
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h.inc"
+
+namespace {
+class TTIRGenericDatamovementRewriter : public OpRewritePattern<GenericOp> {
+public:
+  using OpRewritePattern<GenericOp>::OpRewritePattern;
+
+  static bool isStream(Type ty) {
+    return mlir::isa<StreamLayoutAttr>(mlir::cast<MemRefType>(ty).getLayout());
+  }
+
+  static bool compatibleDeviceGrid(DeviceAttr device, GridAttr grid) {
+    if (grid.getShape().size() != device.getWorkerGrid().getShape().size()) {
+      return false;
+    }
+    return true;
+  }
+
+  static BlockArgument createSemaphore(OpBuilder &builder, Location loc) {
+    Block *thisBlock = builder.getBlock();
+    Operation *op = thisBlock->getParentOp();
+    BlockArgument semaphore = nullptr;
+    for (Region &region : op->getRegions()) {
+      for (Block &block : region) {
+        BlockArgument blockSemaphore =
+            block.addArgument(builder.getType<SemaphoreType>(), loc);
+        if (thisBlock == &block) {
+          semaphore = blockSemaphore;
+        }
+      }
+    }
+    assert(semaphore);
+    return semaphore;
+  }
+
+  static SmallVector<IteratorType>
+  calculateMcastIterators(GridAttr grid, DeviceAttr device,
+                          AffineMap operandIndexingMap,
+                          ArrayAttr iteratorTypes) {
+    assert(grid.getShape().size() == 2 && "Currently only support 2D grid");
+    assert(grid.getShape().size() == operandIndexingMap.getNumResults());
+    assert(compatibleDeviceGrid(device, grid));
+
+    bool allParallel = true;
+    SmallVector<IteratorType> mcastIterators;
+    mcastIterators.reserve(grid.getShape().size());
+    for (unsigned dim = 0; dim < grid.getShape().size(); dim++) {
+      unsigned dimPosition = operandIndexingMap.getDimPosition(dim);
+
+      IteratorType iteratorType =
+          mlir::cast<IteratorTypeAttr>(iteratorTypes[dimPosition]).getValue();
+      mcastIterators.push_back(iteratorType);
+
+      // If the grid dimension is 1, we can special case it and always safely
+      // fallback to mode parallel.  Reduction implies multicast, and while
+      // it'll be functionally correct, a multicast with a single core to itself
+      // is a redundant copy and more complicated than necessary.
+      bool singleCore = grid.getShape()[dim] == 1;
+      allParallel &= (iteratorType == IteratorType::Parallel) || singleCore;
+    }
+
+    return allParallel ? SmallVector<IteratorType>() : mcastIterators;
+  }
+
+  static Value createDMA(OpBuilder &builder, Location loc, Value src, Value dst,
+                         std::optional<AffineMap> operandIndexingMap,
+                         SmallVector<Value> coreIndex = {},
+                         SmallVector<Value> mcastShape = {}) {
+    return builder
+        .create<ttir::DMAOp>(loc, builder.getType<MemTxType>(), src,
+                             operandIndexingMap
+                                 ? AffineMapAttr::get(*operandIndexingMap)
+                                 : nullptr,
+                             ValueRange(), dst, nullptr, ValueRange(), nullptr,
+                             coreIndex, mcastShape)
+        .getResult();
+  }
+
+  static std::tuple<SmallVector<Value>, SmallVector<Value>, unsigned,
+                    SmallVector<Value>>
+  calculateGatherMcastArguments(OpBuilder &blockBuilder, Location loc,
+                                GridAttr grid,
+                                ArrayRef<IteratorType> mcastIterators) {
+    Value zero = blockBuilder.create<arith::ConstantOp>(
+        loc, blockBuilder.getIndexType(), blockBuilder.getIndexAttr(0));
+    Value one = blockBuilder.create<arith::ConstantOp>(
+        loc, blockBuilder.getIndexType(), blockBuilder.getIndexAttr(1));
+
+    SmallVector<Value> coreIndex;
+    SmallVector<Value> mcastShape;
+    unsigned mcastVolume = 1;
+    SmallVector<Value> conditions;
+    coreIndex.reserve(grid.getShape().size());
+    mcastShape.reserve(grid.getShape().size());
+
+    for (auto [dim, iteratorType] : llvm::enumerate(mcastIterators)) {
+      Value gridDimMinusOne = blockBuilder.create<arith::ConstantOp>(
+          loc, blockBuilder.getIndexType(),
+          blockBuilder.getIndexAttr(grid.getShape()[dim] - 1));
+      Value core =
+          blockBuilder.create<CoreIndexOp>(loc, blockBuilder.getIndexType(),
+                                           blockBuilder.getI64IntegerAttr(dim));
+      if (iteratorType == IteratorType::Parallel) {
+        coreIndex.push_back(Value(core));
+        mcastShape.push_back(Value(one));
+      } else {
+        assert(iteratorType == IteratorType::Reduction);
+        coreIndex.push_back(one);
+        mcastShape.push_back(gridDimMinusOne);
+        mcastVolume *= grid.getShape()[dim];
+
+        Value condition = blockBuilder.create<arith::CmpIOp>(
+            loc, blockBuilder.getI1Type(), mlir::arith::CmpIPredicate::eq, core,
+            zero);
+        conditions.push_back(condition);
+      }
+    }
+
+    return std::make_tuple(coreIndex, mcastShape, mcastVolume, conditions);
+  }
+
+  // One implementation of mcast by which one core (the 0th core for the
+  // respective dim) takes on the role of (the sender) gathering and sending the
+  // data to all other cores (the receivers) via mcast along the same dimension.
+  static void createGatherMcastDMA(OpBuilder &builder, Location loc, Value src,
+                                   Value dst, AffineMap operandIndexingMap,
+                                   GridAttr grid,
+                                   ArrayRef<IteratorType> mcastIterators) {
+    SmallVector<Value> coreIndex, mcastShape, conditions;
+    unsigned mcastVolume;
+    std::tie(coreIndex, mcastShape, mcastVolume, conditions) =
+        calculateGatherMcastArguments(builder, loc, grid, mcastIterators);
+    Value zero = builder.create<arith::ConstantOp>(loc, builder.getIndexType(),
+                                                   builder.getIndexAttr(0));
+    Value one = builder.create<arith::ConstantOp>(loc, builder.getIndexType(),
+                                                  builder.getIndexAttr(1));
+    assert(mcastVolume > 0);
+    Value mcastVolumeMinusOne = builder.create<arith::ConstantOp>(
+        loc, builder.getIndexType(), builder.getIndexAttr(mcastVolume - 1));
+    Value receiversReadySemaphore = createSemaphore(builder, loc);
+    Value senderFinishedSemaphore = createSemaphore(builder, loc);
+    assert(coreIndex.size() == mcastShape.size());
+    assert(conditions.size() == 1 && "Exactly one condition supported");
+    builder.create<scf::IfOp>(
+        loc, conditions[0],
+        [&](OpBuilder &builder, Location loc) {
+          Value gatherMemTx =
+              createDMA(builder, loc, src, dst, operandIndexingMap);
+          builder.create<ttir::DMAWaitOp>(loc, gatherMemTx);
+          builder.create<ttir::SemaphoreWaitOp>(loc, receiversReadySemaphore,
+                                                mcastVolumeMinusOne, zero);
+          Value mcastMemTx = createDMA(builder, loc, dst, dst, std::nullopt,
+                                       coreIndex, mcastShape);
+          builder.create<ttir::DMAWaitOp>(loc, mcastMemTx);
+          builder.create<ttir::SemaphoreSetOp>(loc, senderFinishedSemaphore,
+                                               one, coreIndex, mcastShape);
+          builder.create<scf::YieldOp>(loc);
+        },
+        [&](OpBuilder &builder, Location loc) {
+          builder.create<ttir::SemaphoreIncOp>(loc, receiversReadySemaphore,
+                                               one, coreIndex);
+          builder.create<ttir::SemaphoreWaitOp>(loc, senderFinishedSemaphore,
+                                                one, zero);
+          builder.create<scf::YieldOp>(loc);
+        });
+  }
+
+  static LogicalResult
+  buildDatamovementBlock(OpBuilder &builder, Location loc, Value genericOperand,
+                         Value blockOperand, GridAttr grid, DeviceAttr device,
+                         AffineMap operandIndexingMap,
+                         AffineMap gridIndexingMap, ArrayAttr iteratorTypes,
+                         bool isOutput) {
+    if (isOutput) {
+      // Wait for compute
+      builder.create<ttir::AwaitOp>(loc, ValueRange(blockOperand));
+    }
+
+    if (isStream(genericOperand.getType())) {
+      assert(!isOutput && "Output streaming is not currently supported");
+      Value src = isOutput ? blockOperand : genericOperand;
+      Value dst = isOutput ? genericOperand : blockOperand;
+      SmallVector<IteratorType> mcastIterators = calculateMcastIterators(
+          grid, device, operandIndexingMap, iteratorTypes);
+      bool isMcast = !mcastIterators.empty();
+      if (isMcast) {
+        createGatherMcastDMA(builder, loc, src, dst, operandIndexingMap, grid,
+                             mcastIterators);
+      } else {
+        Value memTx = createDMA(builder, loc, src, dst, operandIndexingMap);
+        builder.create<ttir::DMAWaitOp>(loc, memTx);
+      }
+    }
+
+    if (!isOutput) {
+      // Push input to compute
+      builder.create<ttir::YieldOp>(loc, ValueRange(blockOperand));
+    }
+
+    return success();
+  }
+
+  LogicalResult matchAndRewrite(GenericOp generic,
+                                PatternRewriter &rewriter) const final {
+    if (generic.getNumRegions() > 1) {
+      // Already inserted, skip.
+      return failure();
+    }
+
+    // One per operand
+    auto numDataMovementRegions = generic.getNumOperands();
+    auto newGeneric = rewriter.create<GenericOp>(
+        generic->getLoc(), generic.getResultTypes(), generic.getInputs(),
+        generic.getOutputs(), generic.getGrid(), generic.getIndexingMaps(),
+        generic.getIteratorTypes(),
+        generic.getNumRegions() + numDataMovementRegions);
+
+    // Insert the new data movement regions.
+    auto [outputOperandsIndex, outputOperandsLength] =
+        generic.getODSOperandIndexAndLength(1);
+    // The output and the grid indexing must always be aligned.
+    AffineMap gridIndexingMap =
+        mlir::cast<AffineMapAttr>(
+            generic.getIndexingMaps()[outputOperandsIndex])
+            .getValue();
+    auto device = getCurrentScopeDevice(generic);
+    for (OpOperand &operand : generic->getOpOperands()) {
+      Block *datamovementBlock =
+          &newGeneric.getRegion(operand.getOperandNumber()).emplaceBlock();
+      datamovementBlock->addArguments(
+          generic.getRegion(0).getArgumentTypes(),
+          SmallVector<mlir::Location>(
+              generic.getRegion(0).getArgumentTypes().size(),
+              generic.getLoc()));
+
+      OpBuilder blockBuilder = OpBuilder::atBlockEnd(datamovementBlock);
+      bool isOutput = operand.getOperandNumber() >= outputOperandsIndex;
+      AffineMap operandIndexingMap =
+          mlir::cast<AffineMapAttr>(
+              generic.getIndexingMaps()[operand.getOperandNumber()])
+              .getValue();
+      auto result = buildDatamovementBlock(
+          blockBuilder, generic->getLoc(),
+          generic->getOperand(operand.getOperandNumber()),
+          datamovementBlock->getArgument(operand.getOperandNumber()),
+          generic.getGrid(), device, operandIndexingMap, gridIndexingMap,
+          generic.getIteratorTypes(), isOutput);
+      if (failed(result)) {
+        return result;
+      }
+    }
+
+    // Copy over the original compute region.
+    unsigned computeRegionIndex = numDataMovementRegions;
+    auto &newRegion = newGeneric.getRegion(computeRegionIndex);
+    auto &oldRegion = generic.getRegion(0);
+    newRegion.takeBody(oldRegion);
+
+    // Await / Yield insertion to compute region.
+    {
+      Block *computeBlock = &newGeneric.getRegion(computeRegionIndex).front();
+      OpBuilder blockBuilder = OpBuilder::atBlockBegin(computeBlock);
+      auto [inputOperandsIndex, inputOperandsLength] =
+          generic.getODSOperandIndexAndLength(0);
+
+      // Await the inputs
+      blockBuilder.create<ttir::AwaitOp>(
+          generic->getLoc(), ValueRange(computeBlock->getArguments().take_front(
+                                 inputOperandsLength)));
+
+      blockBuilder.setInsertionPointToEnd(computeBlock);
+
+      // Yield the outputs
+      blockBuilder.create<ttir::YieldOp>(
+          generic->getLoc(), ValueRange(computeBlock->getArguments().take_back(
+                                 outputOperandsLength)));
+    }
+
+    rewriter.replaceOp(generic, newGeneric);
+    return success();
+  }
+};
+} // namespace
+
+namespace {
+class TTIRGenericDatamovement
+    : public impl::TTIRGenericDatamovementBase<TTIRGenericDatamovement> {
+public:
+  using impl::TTIRGenericDatamovementBase<
+      TTIRGenericDatamovement>::TTIRGenericDatamovementBase;
+
+  void runOnOperation() final {
+    RewritePatternSet patterns(&getContext());
+    patterns.add<TTIRGenericDatamovementRewriter>(&getContext());
+    FrozenRewritePatternSet patternSet(std::move(patterns));
+    if (failed(applyPatternsGreedily(getOperation(), patternSet))) {
+      signalPassFailure();
+    }
+  }
+};
+} // namespace
+
+} // namespace mlir::tt::ttir

--- a/lib/Dialect/TTIR/Transforms/GenericGenerateDatamovement.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericGenerateDatamovement.cpp
@@ -17,11 +17,11 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir::tt::ttir {
-#define GEN_PASS_DEF_TTIRGENERICDATAMOVEMENT
+#define GEN_PASS_DEF_TTIRGENERICGENERATEDATAMOVEMENT
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h.inc"
 
 namespace {
-class TTIRGenericDatamovementRewriter : public OpRewritePattern<GenericOp> {
+class TTIRGenericGenerateDatamovementRewriter : public OpRewritePattern<GenericOp> {
 public:
   using OpRewritePattern<GenericOp>::OpRewritePattern;
 
@@ -296,15 +296,15 @@ public:
 } // namespace
 
 namespace {
-class TTIRGenericDatamovement
-    : public impl::TTIRGenericDatamovementBase<TTIRGenericDatamovement> {
+class TTIRGenericGenerateDatamovement
+    : public impl::TTIRGenericGenerateDatamovementBase<TTIRGenericGenerateDatamovement> {
 public:
-  using impl::TTIRGenericDatamovementBase<
-      TTIRGenericDatamovement>::TTIRGenericDatamovementBase;
+  using impl::TTIRGenericGenerateDatamovementBase<
+      TTIRGenericGenerateDatamovement>::TTIRGenericGenerateDatamovementBase;
 
   void runOnOperation() final {
     RewritePatternSet patterns(&getContext());
-    patterns.add<TTIRGenericDatamovementRewriter>(&getContext());
+    patterns.add<TTIRGenericGenerateDatamovementRewriter>(&getContext());
     FrozenRewritePatternSet patternSet(std::move(patterns));
     if (failed(applyPatternsGreedily(getOperation(), patternSet))) {
       signalPassFailure();

--- a/lib/Dialect/TTIR/Transforms/GenericGenerateDatamovement.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericGenerateDatamovement.cpp
@@ -21,7 +21,8 @@ namespace mlir::tt::ttir {
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h.inc"
 
 namespace {
-class TTIRGenericGenerateDatamovementRewriter : public OpRewritePattern<GenericOp> {
+class TTIRGenericGenerateDatamovementRewriter
+    : public OpRewritePattern<GenericOp> {
 public:
   using OpRewritePattern<GenericOp>::OpRewritePattern;
 
@@ -297,7 +298,8 @@ public:
 
 namespace {
 class TTIRGenericGenerateDatamovement
-    : public impl::TTIRGenericGenerateDatamovementBase<TTIRGenericGenerateDatamovement> {
+    : public impl::TTIRGenericGenerateDatamovementBase<
+          TTIRGenericGenerateDatamovement> {
 public:
   using impl::TTIRGenericGenerateDatamovementBase<
       TTIRGenericGenerateDatamovement>::TTIRGenericGenerateDatamovementBase;

--- a/lib/Dialect/TTIR/Transforms/GenericGenerateDatamovement.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericGenerateDatamovement.cpp
@@ -307,8 +307,7 @@ public:
   void runOnOperation() final {
     RewritePatternSet patterns(&getContext());
     patterns.add<TTIRGenericGenerateDatamovementRewriter>(&getContext());
-    FrozenRewritePatternSet patternSet(std::move(patterns));
-    if (failed(applyPatternsGreedily(getOperation(), patternSet))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       signalPassFailure();
     }
   }

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -10,6 +10,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/Passes.h"
 #include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/Passes.h"
 
 #include "ttmlir/Conversion/Passes.h"
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
@@ -92,6 +93,7 @@ void createTTIRToTTMetalBackendPipeline(
     pm.addPass(mlir::createConvertLinalgToAffineLoopsPass());
     pm.addPass(mlir::tt::ttir::createTTIRGenericLinearizeMemref());
     pm.addPass(mlir::createLowerAffinePass());
+    pm.addPass(mlir::tt::ttir::createTTIRGenericDatamovement());
   } else {
     mlir::tt::ttir::TTIRLayoutOptions layoutOptions;
     {

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -93,7 +93,7 @@ void createTTIRToTTMetalBackendPipeline(
     pm.addPass(mlir::createConvertLinalgToAffineLoopsPass());
     pm.addPass(mlir::tt::ttir::createTTIRGenericLinearizeMemref());
     pm.addPass(mlir::createLowerAffinePass());
-    pm.addPass(mlir::tt::ttir::createTTIRGenericDatamovement());
+    pm.addPass(mlir::tt::ttir::createTTIRGenericGenerateDatamovement());
   } else {
     mlir::tt::ttir::TTIRLayoutOptions layoutOptions;
     {

--- a/test/ttmlir/Dialect/TTIR/generic/generic_datamovement.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/generic_datamovement.mlir
@@ -1,0 +1,185 @@
+// RUN: ttmlir-opt --ttir-load-system-desc --ttir-implicit-device --ttir-generic-datamovement %s | FileCheck %s
+
+#l1_ = #tt.memory_space<l1>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #tt.iterator_type<parallel>
+
+func.func @add(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 2, 1>, operand_cb_mapping = array<i64>}> ({
+  // Look for 4 regions, one for each operand and one for the compute
+  // Operand 0 (input)
+  // CHECK: ^datamovement0
+  // CHECK-NEXT: ttir.yield
+  // Operand 1 (input)
+  // CHECK: ^datamovement1
+  // CHECK-NEXT: ttir.yield
+  // Operand 2 (output)
+  // CHECK: ^datamovement2
+  // CHECK-NEXT: ttir.await
+  // Compute
+  // CHECK: ^compute
+  // CHECK: ttir.await
+  // CHECK: ttir.tile_add
+  // CHECK: ttir.yield
+  ^bb0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
+    affine.for %arg5 = 0 to 2 {
+      affine.for %arg6 = 0 to 4 {
+        %0 = affine.load %cb0[%arg5, %arg6] : memref<2x4x!tt.tile<32x32, f32>, #l1_>
+        %1 = affine.load %cb1[%arg5, %arg6] : memref<2x4x!tt.tile<32x32, f32>, #l1_>
+        %2 = "ttir.tile_add"(%0, %1) : (!tt.tile<32x32, f32>, !tt.tile<32x32, f32>) -> !tt.tile<32x32, f32>
+        affine.store %2, %cb2[%arg5, %arg6] : memref<2x4x!tt.tile<32x32, f32>, #l1_>
+      }
+    }
+  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+}
+
+#mapL = affine_map<(d0, d1, d2) -> (d0, d2)>
+#mapR = affine_map<(d0, d1, d2) -> (d2, d1)>
+#mapO = affine_map<(d0, d1, d2) -> (d0, d1)>
+#reduction = #tt.iterator_type<reduction>
+
+func.func @matmul_single_core(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x4x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>, operand_cb_mapping = array<i64>}> ({
+  // Look for 4 regions, one for each operand and one for the compute
+  // Operand 0 (input)
+  // CHECK: ^datamovement0
+  // CHECK-NEXT: ttir.yield
+  // Operand 1 (input)
+  // CHECK: ^datamovement1
+  // CHECK-NEXT: ttir.yield
+  // Operand 2 (output)
+  // CHECK: ^datamovement2
+  // CHECK-NEXT: ttir.await
+  // Compute
+  // CHECK: ^compute
+  // CHECK: ttir.await
+  // CHECK: ttir.tile_matmul_block
+  // CHECK: ttir.yield
+  ^bb0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<4x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
+    "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<2x4x!tt.tile<32x32, f32>, #l1_>, memref<4x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
+  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x4x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+}
+
+func.func @matmul_single_core_stream(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  %cb0_alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  %cb1_alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  %0 = "ttir.stream_layout"(%arg0, %cb0_alloc) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 2 * 4096 + d3 * 4096)>, #l1_>
+  %1 = "ttir.stream_layout"(%arg1, %cb1_alloc) : (memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 2 * 4096 + d3 * 4096)>, #l1_>
+  // CHECK: "ttir.generic"([[lhs:%[a-z0-9_]+]], [[rhs:%[a-z0-9_]+]], [[out:%[a-z0-9_]+]])
+  "ttir.generic"(%0, %1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>, operand_cb_mapping = array<i64>}> ({
+  // Look for 4 regions, one for each operand and one for the compute
+  // Operand 0 (input)
+  // CHECK: ^datamovement0
+  // CHECK-NEXT: ttir.dma [[lhs]] #map1, %cb0
+  // CHECK-NEXT: ttir.dma_wait
+  // CHECK-NEXT: ttir.yield %cb0
+  // Operand 1 (input)
+  // CHECK: ^datamovement1
+  // CHECK-NEXT: ttir.dma [[rhs]] #map2, %cb1
+  // CHECK-NEXT: ttir.dma_wait
+  // CHECK-NEXT: ttir.yield %cb1
+  // Operand 2 (output)
+  // CHECK: ^datamovement2
+  // CHECK-NEXT: ttir.await
+  // Compute
+  // CHECK: ^compute
+  // CHECK: ttir.await
+  // CHECK: ttir.tile_matmul_block
+  // CHECK: ttir.yield
+  ^bb0(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
+    "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
+  }) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 2 * 4096 + d3 * 4096)>, #l1_>, memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 2 * 4096 + d3 * 4096)>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+}
+
+func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
+  %cb0_alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
+  %cb1_alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>
+  %0 = "ttir.stream_layout"(%arg0, %cb0_alloc) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 6 * 4096 + d3 * 4096)>, #l1_>
+  %1 = "ttir.stream_layout"(%arg1, %cb1_alloc) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>, memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8 * 4096 + d3 * 4096)>, #l1_>
+  // CHECK: "ttir.generic"([[lhs:%[a-z0-9_]+]], [[rhs:%[a-z0-9_]+]], [[out:%[a-z0-9_]+]])
+  "ttir.generic"(%0, %1, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>, operand_cb_mapping = array<i64>}> ({
+  // Look for 4 regions, one for each operand and one for the compute
+  // Operand 0 (input)
+  // CHECK: ^datamovement0
+  // CHECK: ttir.dma [[lhs]] #map1, %cb0
+  // CHECK-NEXT: ttir.dma_wait
+  // CHECK-NEXT: ttir.semaphore_wait [[reader_ready_lhs:%[a-z0-9]+]]
+  // CHECK-NEXT: ttir.dma %cb0, %cb0
+  // CHECK-NEXT: ttir.dma_wait
+  // CHECK-NEXT: ttir.semaphore_set [[writer_done_lhs:%[a-z0-9]+]]
+  // CHECK-NEXT: else
+  // CHECK-NEXT: ttir.semaphore_inc [[reader_ready_lhs]]
+  // CHECK-NEXT: ttir.semaphore_wait [[writer_done_lhs]]
+  // Operand 1 (input)
+  // CHECK: ^datamovement1
+  // CHECK: ttir.dma [[rhs]] #map2, %cb1
+  // CHECK-NEXT: ttir.dma_wait
+  // CHECK-NEXT: ttir.semaphore_wait [[reader_ready_rhs:%[a-z0-9]+]]
+  // CHECK-NEXT: ttir.dma %cb1, %cb1
+  // CHECK-NEXT: ttir.dma_wait
+  // CHECK-NEXT: ttir.semaphore_set [[writer_done_rhs:%[a-z0-9]+]]
+  // CHECK-NEXT: else
+  // CHECK-NEXT: ttir.semaphore_inc [[reader_ready_rhs]]
+  // CHECK-NEXT: ttir.semaphore_wait [[writer_done_rhs]]
+  // Operand 2 (output)
+  // CHECK: ^datamovement2
+  // CHECK-NEXT: ttir.await
+  // Compute
+  // CHECK: ^compute
+  // CHECK: ttir.await
+  // CHECK: ttir.tile_matmul_block
+  // CHECK: ttir.yield
+  ^bb0(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>):
+    "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
+  }) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 6 * 4096 + d3 * 4096)>, #l1_>, memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8 * 4096 + d3 * 4096)>, #l1_>, memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
+  return %alloc : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
+}
+
+func.func @tilize(%arg0: memref<2x4x128x192xf32, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>, operand_cb_mapping = array<i64>}> ({
+  // Look for 4 regions, one for each operand and one for the compute
+  // Operand 0 (input)
+  // CHECK: ^datamovement0
+  // CHECK-NEXT: ttir.yield
+  // Operand 1 (output)
+  // CHECK: ^datamovement1
+  // CHECK-NEXT: ttir.await
+  // Compute
+  // CHECK: ^compute
+  // CHECK: ttir.await
+  // CHECK: ttir.tile_tilize_block
+  // CHECK: ttir.yield
+  ^compute(%cb0: memref<128x192xf32, #l1_>, %cb1: memref<4x6x!tt.tile<32x32, f32>, #l1_>):
+    "ttir.tile_tilize_block"(%cb0, %cb1) : (memref<128x192xf32, #l1_>, memref<4x6x!tt.tile<32x32, f32>, #l1_>) -> ()
+  }) : (memref<2x4x128x192xf32, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> ()
+  return %alloc : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
+}
+
+func.func @untilize(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x128x192xf32, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x128x192xf32, #l1_>
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>, operand_cb_mapping = array<i64>}> ({
+  // Look for 4 regions, one for each operand and one for the compute
+  // Operand 0 (input)
+  // CHECK: ^datamovement0
+  // CHECK-NEXT: ttir.yield
+  // Operand 1 (output)
+  // CHECK: ^datamovement1
+  // CHECK-NEXT: ttir.await
+  // Compute
+  // CHECK: ^compute
+  // CHECK: ttir.await
+  // CHECK: ttir.tile_untilize_block
+  // CHECK: ttir.yield
+  ^compute(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<128x192xf32, #l1_>):
+    "ttir.tile_untilize_block"(%cb0, %cb1) : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<128x192xf32, #l1_>) -> ()
+  }) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<2x4x128x192xf32, #l1_>) -> ()
+  return %alloc : memref<2x4x128x192xf32, #l1_>
+}

--- a/test/ttmlir/Dialect/TTIR/generic/generic_datamovement.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/generic_datamovement.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttir-load-system-desc --ttir-implicit-device --ttir-generic-datamovement %s | FileCheck %s
+// RUN: ttmlir-opt --ttir-load-system-desc --ttir-implicit-device --ttir-generic-generate-datamovement %s | FileCheck %s
 
 #l1_ = #tt.memory_space<l1>
 #dram = #tt.memory_space<dram>

--- a/test/ttmlir/Dialect/TTIR/loops/linearize_memref.mlir
+++ b/test/ttmlir/Dialect/TTIR/loops/linearize_memref.mlir
@@ -7,20 +7,22 @@
 func.func @add(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
   "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 2, 1>}> ({
-  ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg3: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
-    // CHECK: = memref.collapse_shape %arg3
-    // CHECK: = memref.collapse_shape %arg4
-    affine.for %arg5 = 0 to 2 {
-      affine.for %arg6 = 0 to 4 {
-        // CHECK: = affine.load %collapse_shape[%arg5 * 4 + %arg6]
-        // CHECK: = affine.load %collapse_shape_0[%arg5 * 4 + %arg6]
-        %0 = affine.load %arg2[%arg5, %arg6] : memref<2x4x!tt.tile<32x32, f32>, #l1_>
-        %1 = affine.load %arg3[%arg5, %arg6] : memref<2x4x!tt.tile<32x32, f32>, #l1_>
+  ^bb0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
+    // CHECK: [[cshape0:%[a-z0-9_]+]] = memref.collapse_shape %cb0
+    // CHECK-NEXT: [[cshape1:%[a-z0-9_]+]] = memref.collapse_shape %cb1
+    // CHECK-NEXT: [[cshape2:%[a-z0-9_]+]] = memref.collapse_shape %cb2
+    affine.for %arg2 = 0 to 2 {
+      affine.for %arg3 = 0 to 4 {
+        // CHECK: = affine.load [[cshape0]][%arg2 * 4 + %arg3]
+        // CHECK: = affine.load [[cshape1]][%arg2 * 4 + %arg3]
+        %0 = affine.load %cb0[%arg2, %arg3] : memref<2x4x!tt.tile<32x32, f32>, #l1_>
+        %1 = affine.load %cb1[%arg2, %arg3] : memref<2x4x!tt.tile<32x32, f32>, #l1_>
         %2 = "ttir.tile_add"(%0, %1) : (!tt.tile<32x32, f32>, !tt.tile<32x32, f32>) -> !tt.tile<32x32, f32>
-        // CHECK: affine.store %2, %collapse_shape_1[%{{.*}} * 4 + %{{.*}}]
-        affine.store %2, %arg4[%arg5, %arg6] : memref<2x4x!tt.tile<32x32, f32>, #l1_>
+        // CHECK: affine.store %2, [[cshape2]][%{{.*}} * 4 + %{{.*}}]
+        affine.store %2, %cb2[%arg2, %arg3] : memref<2x4x!tt.tile<32x32, f32>, #l1_>
       }
     }
+    ttir.yield %cb2 : (memref<2x4x!tt.tile<32x32, f32>, #l1_>)
   }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
   return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
 }
@@ -28,20 +30,22 @@ func.func @add(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<
 func.func @addT(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1T: memref<1x1x4x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
   "ttir.generic"(%arg0, %arg1T, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 2, 1>}> ({
-  ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg3: memref<4x2x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
-    // CHECK: = memref.collapse_shape %arg3
-    // CHECK: = memref.collapse_shape %arg4
-    affine.for %arg5 = 0 to 2 {
-      affine.for %arg6 = 0 to 4 {
-        // CHECK: = affine.load %collapse_shape[%arg5 * 4 + %arg6]
-        // CHECK: = affine.load %collapse_shape_0[%arg6 * 2 + %arg5]
-        %0 = affine.load %arg2[%arg5, %arg6] : memref<2x4x!tt.tile<32x32, f32>, #l1_>
-        %1 = affine.load %arg3[%arg6, %arg5] : memref<4x2x!tt.tile<32x32, f32>, #l1_>
+  ^bb0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<4x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
+    // CHECK: [[cshape0:%[a-z0-9_]+]] = memref.collapse_shape %cb0
+    // CHECK-NEXT: [[cshape1:%[a-z0-9_]+]] = memref.collapse_shape %cb1
+    // CHECK-NEXT: [[cshape2:%[a-z0-9_]+]] = memref.collapse_shape %cb2
+    affine.for %arg2 = 0 to 2 {
+      affine.for %arg3 = 0 to 4 {
+        // CHECK: = affine.load [[cshape0]][%arg2 * 4 + %arg3]
+        // CHECK: = affine.load [[cshape1]][%arg3 * 2 + %arg2]
+        %0 = affine.load %cb0[%arg2, %arg3] : memref<2x4x!tt.tile<32x32, f32>, #l1_>
+        %1 = affine.load %cb1[%arg3, %arg2] : memref<4x2x!tt.tile<32x32, f32>, #l1_>
         %2 = "ttir.tile_add"(%0, %1) : (!tt.tile<32x32, f32>, !tt.tile<32x32, f32>) -> !tt.tile<32x32, f32>
-        // CHECK: affine.store %2, %collapse_shape_1[%{{.*}} * 4 + %{{.*}}]
-        affine.store %2, %arg4[%arg5, %arg6] : memref<2x4x!tt.tile<32x32, f32>, #l1_>
+        // CHECK: affine.store %2, [[cshape2]][%{{.*}} * 4 + %{{.*}}]
+        affine.store %2, %cb2[%arg2, %arg3] : memref<2x4x!tt.tile<32x32, f32>, #l1_>
       }
     }
+    ttir.yield %cb2 : (memref<2x4x!tt.tile<32x32, f32>, #l1_>)
   }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x4x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
   return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
 }

--- a/test/ttmlir/Dialect/TTIR/optimize_tensor_layout/optimize_tensor_layout.mlir
+++ b/test/ttmlir/Dialect/TTIR/optimize_tensor_layout/optimize_tensor_layout.mlir
@@ -19,9 +19,9 @@ func.func @reduce_large_grid(%arg0: tensor<256x384xf32, #layout1>, %arg1: tensor
         iterator_types = [#parallel, #reduction],
         operandSegmentSizes = array<i32: 2, 1>
         }> ({
-        // CHECK: ^bb0(%arg2: memref<1x2x!tt.tile<32x32, f32>, #l1_>,
-        // CHECK-SAME: %arg3: memref<1x2x!tt.tile<32x32, f32>, #l1_>,
-        // CHECK-SAME: %arg4: memref<1x1x!tt.tile<32x32, f32>, #l1_>):
+        // CHECK: ^compute(%cb0: memref<1x2x!tt.tile<32x32, f32>, #l1_>,
+        // CHECK-SAME: %cb1: memref<1x2x!tt.tile<32x32, f32>, #l1_>,
+        // CHECK-SAME: %cb2: memref<1x1x!tt.tile<32x32, f32>, #l1_>):
         ^bb0(%arg2: memref<8x12x!tt.tile<32x32, f32>, #l1_>,
             %arg3: memref<8x12x!tt.tile<32x32, f32>, #l1_>,
             %arg4: memref<8x1x!tt.tile<32x32, f32>, #l1_>):
@@ -59,9 +59,9 @@ func.func @reduce_prime(%arg0: tensor<32x608xf32, #layout1>, %arg1: tensor<32x60
         iterator_types = [#parallel, #reduction],
         operandSegmentSizes = array<i32: 2, 1>
         }> ({
-        // CHECK: ^bb0(%arg2: memref<1x19x!tt.tile<32x32, f32>, #l1_>,
-        // CHECK-SAME: %arg3: memref<1x19x!tt.tile<32x32, f32>, #l1_>,
-        // CHECK-SAME: %arg4: memref<1x1x!tt.tile<32x32, f32>, #l1_>):
+        // CHECK: ^compute(%cb0: memref<1x19x!tt.tile<32x32, f32>, #l1_>,
+        // CHECK-SAME: %cb1: memref<1x19x!tt.tile<32x32, f32>, #l1_>,
+        // CHECK-SAME: %cb2: memref<1x1x!tt.tile<32x32, f32>, #l1_>):
         ^bb0(%arg2: memref<1x19x!tt.tile<32x32, f32>, #l1_>,
             %arg3: memref<1x19x!tt.tile<32x32, f32>, #l1_>,
             %arg4: memref<1x1x!tt.tile<32x32, f32>, #l1_>):


### PR DESCRIPTION
This commit adds support for generic op to have multiple regions and also autogenerating generic datamovement threads.

This pass makes the following transformation, given a generic compute region:
```mlir
#map = affine_map<(d0, d1) -> (d0, d1)>
#parallel = #tt.iterator_type<parallel>

^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg3: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
  affine.for %arg5 = 0 to 2 {
    affine.for %arg6 = 0 to 4 {
      %0 = affine.load %arg2[%arg5, %arg6] : memref<2x4x!tt.tile<32x32, f32>, #l1_>
      %1 = affine.load %arg3[%arg5, %arg6] : memref<2x4x!tt.tile<32x32, f32>, #l1_>
      %2 = "ttir.tile_add"(%0, %1) : (!tt.tile<32x32, f32>, !tt.tile<32x32, f32>) -> !tt.tile<32x32, f32>
      affine.store %2, %arg4[%arg5, %arg6] : memref<2x4x!tt.tile<32x32, f32>, #l1_>
    }
  }
})
```

We generate additional (prepended) regions that correspond to the data movement for each operand respectively:
```mlir
^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg3: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
  ttir.yield %arg2 : (memref<2x4x!tt.tile<32x32, f32>, #l1_>)
}, {
^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg3: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
  ttir.yield %arg3 : (memref<2x4x!tt.tile<32x32, f32>, #l1_>)
}, {
^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg3: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
  ttir.await %arg4 : (memref<2x4x!tt.tile<32x32, f32>, #l1_>)
}, {
^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg3: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
  ttir.await %arg2, %arg3 : (memref<2x4x!tt.tile<32x32, f32>, #l1_>, memref<2x4x!tt.tile<32x32, f32>, #l1_>)
  affine.for %arg5 = 0 to 2 {
    affine.for %arg6 = 0 to 4 {
      %0 = affine.load %arg2[%arg5, %arg6] : memref<2x4x!tt.tile<32x32, f32>, #l1_>
      %1 = affine.load %arg3[%arg5, %arg6] : memref<2x4x!tt.tile<32x32, f32>, #l1_>
      %2 = "ttir.tile_add"(%0, %1) : (!tt.tile<32x32, f32>, !tt.tile<32x32, f32>) -> !tt.tile<32x32, f32>
      affine.store %2, %arg4[%arg5, %arg6] : memref<2x4x!tt.tile<32x32, f32>, #l1_>
    }
  }
  ttir.yield %arg4 : (memref<2x4x!tt.tile<32x32, f32>, #l1_>)
})
```
