### PR TITLE
Add boilerplate for op configs in optimizer

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/BFInterleavedPolicy.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/BFInterleavedPolicy.h
@@ -7,6 +7,7 @@
 
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
 #include "ttmlir/Dialect/TTNN/Analysis/MemoryLayoutAnalysisPolicy.h"
+#include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
 
 namespace mlir::tt::ttnn {
 
@@ -32,18 +33,17 @@ public:
 public:
   BFInterleavedPolicy(
       Operation *rootOp, std::vector<L1ChainConfig> &l1ChainConfigs,
-      const llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>>
-          &legalLayouts,
+      const llvm::DenseMap<Operation *, std::vector<OpConfig>> &legalConfigs,
       llvm::DenseMap<func::FuncOp, llvm::SmallVector<Operation *>> &schedule,
       unsigned usableL1CacheSize)
-      : MemoryLayoutAnalysisPolicy(rootOp, l1ChainConfigs, legalLayouts,
+      : MemoryLayoutAnalysisPolicy(rootOp, l1ChainConfigs, legalConfigs,
                                    schedule, usableL1CacheSize) {}
 
   void run() final;
 
 private:
   // Check if the op is analyzable. Op is analyzable if it has at least one
-  // legal layout.
+  // legal config.
   bool isAnalyzable(Operation *op);
 
   // Iterate over all operands of the op that satisfy the analyzability
@@ -53,11 +53,11 @@ private:
   void walkOnAnalyzableOperands(Operation *op,
                                 function_ref<void(Operation *)> callback);
 
-  // Fetch op's DRAM layout from legalLayouts.
+  // Fetch op's DRAM layout from legalConfigs.
   bool hasDRAMBufferType(Operation *op);
   TTNNLayoutAttr getDRAMLayout(Operation *op);
 
-  // Fetch op's L1 Interleaved layout from legalLayouts.
+  // Fetch op's L1 Interleaved layout from legalConfigs.
   bool hasL1BufferType(Operation *op);
   TTNNLayoutAttr getL1InterleavedLayout(Operation *op);
 

--- a/include/ttmlir/Dialect/TTNN/Analysis/DFShardingPolicy.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/DFShardingPolicy.h
@@ -5,10 +5,12 @@
 #ifndef TTMLIR_DIALECT_TTNN_ANALYSIS_DFSHARDINGPOLICY_H
 #define TTMLIR_DIALECT_TTNN_ANALYSIS_DFSHARDINGPOLICY_H
 
-#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "ttmlir/Dialect/TTNN/Analysis/L1ChainConfig.h"
 #include "ttmlir/Dialect/TTNN/Analysis/MemoryLayoutAnalysisPolicy.h"
+#include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 
 namespace mlir::tt::ttnn {
 
@@ -18,17 +20,16 @@ namespace mlir::tt::ttnn {
 class DFShardingPolicy : public MemoryLayoutAnalysisPolicy {
 private:
   std::unordered_set<Edge> overrideReshardEdges;
-  void pickOpShardLayouts(ShardSolver &shardSolver,
+  void pickOpShardConfigs(ShardSolver &shardSolver,
                           const L1ChainConfig &l1ChainConfig);
 
 public:
   DFShardingPolicy(
       Operation *rootOp, std::vector<L1ChainConfig> &l1ChainConfigs,
-      const llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>>
-          &legalLayouts,
+      const llvm::DenseMap<Operation *, std::vector<OpConfig>> &legalConfigs,
       llvm::DenseMap<func::FuncOp, llvm::SmallVector<Operation *>> &schedule,
       unsigned usableL1CacheSize)
-      : MemoryLayoutAnalysisPolicy(rootOp, l1ChainConfigs, legalLayouts,
+      : MemoryLayoutAnalysisPolicy(rootOp, l1ChainConfigs, legalConfigs,
                                    schedule, usableL1CacheSize),
         overrideReshardEdges() {}
 

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1ChainConfig.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1ChainConfig.h
@@ -5,6 +5,7 @@
 #ifndef TTMLIR_DIALECT_TTNN_ANALYSIS_L1CHAINCONFIG_H
 #define TTMLIR_DIALECT_TTNN_ANALYSIS_L1CHAINCONFIG_H
 
+#include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
 #include "ttmlir/Dialect/TTNN/Analysis/ShardSolver.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 
@@ -22,18 +23,18 @@ struct OpL1MemSpec {
   //
   uint tensorSplitFactor = 1;
 
-  // Layout of the output tensor of the op.
+  // Op specific configuration.
   //
-  TTNNLayoutAttr layout;
+  OpConfig config;
 };
 
 // Enum to track the state of the L1 chain.
 // InBuild: L1 chain is being built. OpL1MemSpecs can be added.
 // Built: L1 chain is built, but not resolved yet. ShardSolver can be run.
 // Resolved: L1 chain is resolved. Reshards are computed. We can pick legal
-// layouts for each op.
+// configs for each op.
 // Completed: L1 chain is completed. OpL1MemSpecs are
-// resolved to a single layout.
+// resolved to a single config.
 //
 enum class L1ChainState { InBuild, Built, Resolved, Completed, Failed };
 
@@ -48,15 +49,13 @@ public:
   L1ChainConfig() : opL1MemSpecs(), state() {}
 
   ShardSolver resolveWithSolver(
-      const llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>>
-          &legalLayouts,
+      const llvm::DenseMap<Operation *, std::vector<OpConfig>> &legalConfigs,
       unsigned usableL1CacheSize,
       const std::unordered_set<Edge> &overrideReshardEdges);
   void resolve();
   void build();
-  void
-  complete(const llvm::DenseMap<Operation *, TTNNLayoutAttr> &selectedOpLayout,
-           std::unordered_set<Edge> &memReconfigEdges);
+  void complete(const llvm::DenseMap<Operation *, OpConfig> &selectedOpConfig,
+                std::unordered_set<Edge> &memReconfigEdges);
   void complete();
 
   bool isEmpty() { return opL1MemSpecs.empty(); }

--- a/include/ttmlir/Dialect/TTNN/Analysis/LegalLayoutAnalysis.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/LegalLayoutAnalysis.h
@@ -6,8 +6,10 @@
 #define TTMLIR_DIALECT_TTNN_ANALYSIS_LEGALLAYOUTANALYSIS_H
 
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
+#include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
 #include "ttmlir/Dialect/TTNN/Analysis/TTNNAnalysis.h"
 #include "ttmlir/Dialect/TTNN/Utils/OptimizerOverrides.h"
+
 #include "llvm/ADT/StringMap.h"
 
 namespace mlir::tt::ttnn {
@@ -16,7 +18,7 @@ struct LegalLayoutAnalysisInput {
   ChipDescAttr chipDesc;
   GridAttr maxGrid;
   RankedTensorType tensorType;
-  int64_t maxShardedLayouts;
+  int64_t maxShardedConfigs;
   llvm::StringMap<OutputLayoutOverrideParams> *outputLayoutOverrides;
   bool rowMajorEnabled;
 
@@ -26,11 +28,11 @@ struct LegalLayoutAnalysisInput {
 
   LegalLayoutAnalysisInput(
       ChipDescAttr chipDesc, GridAttr maxGrid, RankedTensorType tensorType,
-      int64_t maxShardedLayouts,
+      int64_t maxShardedConfigs,
       llvm::StringMap<OutputLayoutOverrideParams> *outputLayoutOverrides,
       bool rowMajorEnabled)
       : chipDesc(chipDesc), maxGrid(maxGrid), tensorType(tensorType),
-        maxShardedLayouts(maxShardedLayouts),
+        maxShardedConfigs(maxShardedConfigs),
         outputLayoutOverrides(outputLayoutOverrides),
         rowMajorEnabled(rowMajorEnabled) {}
 
@@ -45,8 +47,8 @@ struct LegalLayoutAnalysisInput {
   }
 };
 
-class LegalLayoutAnalysis : public TTNNAnalysis<LegalLayoutAnalysisInput,
-                                                std::vector<TTNNLayoutAttr>> {
+class LegalLayoutAnalysis
+    : public TTNNAnalysis<LegalLayoutAnalysisInput, std::vector<OpConfig>> {
 private:
   void analysisImplementation() override;
   bool applyOverrides() override;

--- a/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutAnalysis.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutAnalysis.h
@@ -7,6 +7,7 @@
 
 #include "ttmlir/Dialect/TTNN/Analysis/Edge.h"
 #include "ttmlir/Dialect/TTNN/Analysis/L1ChainConfig.h"
+#include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
 #include "ttmlir/Dialect/TTNN/Analysis/TTNNAnalysis.h"
 #include "ttmlir/Dialect/TTNN/Utils/MemoryLayoutAnalysisParams.h"
 
@@ -17,24 +18,23 @@
 namespace mlir::tt::ttnn {
 
 struct MemoryLayoutAnalysisInput {
-  llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>> legalLayouts;
+  llvm::DenseMap<Operation *, std::vector<OpConfig>> legalConfigs;
   unsigned usableL1CacheSize = 0;
   std::unordered_set<Edge> overrideReshardEdges;
   MemoryLayoutAnalysisPolicyType policy;
 
-  MemoryLayoutAnalysisInput() : legalLayouts() {}
+  MemoryLayoutAnalysisInput() : legalConfigs() {}
 
   MemoryLayoutAnalysisInput(
-      const llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>>
-          &legalLayouts,
+      const llvm::DenseMap<Operation *, std::vector<OpConfig>> &legalConfigs,
       unsigned usableL1CacheSize,
       const std::unordered_set<Edge> &overrideReshardEdges,
       MemoryLayoutAnalysisPolicyType policy)
-      : legalLayouts(legalLayouts), usableL1CacheSize(usableL1CacheSize),
+      : legalConfigs(legalConfigs), usableL1CacheSize(usableL1CacheSize),
         overrideReshardEdges(overrideReshardEdges), policy(policy) {}
 
   bool operator==(const MemoryLayoutAnalysisInput &rhs) const {
-    return legalLayouts == rhs.legalLayouts;
+    return legalConfigs == rhs.legalConfigs;
   }
 
   bool operator!=(const MemoryLayoutAnalysisInput &rhs) const {
@@ -43,20 +43,19 @@ struct MemoryLayoutAnalysisInput {
 };
 
 struct MemoryLayoutAnalysisResult {
-  llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>> legalLayouts;
+  llvm::DenseMap<Operation *, std::vector<OpConfig>> legalConfigs;
   std::unordered_set<Edge> memReconfigEdges;
   std::vector<Operation *> spillToDramOps;
   llvm::DenseMap<func::FuncOp, llvm::SmallVector<Operation *>> schedule;
 
   MemoryLayoutAnalysisResult()
-      : legalLayouts(), memReconfigEdges(), spillToDramOps(), schedule() {}
+      : legalConfigs(), memReconfigEdges(), spillToDramOps(), schedule() {}
 
   MemoryLayoutAnalysisResult(
-      const llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>>
-          &legalLayouts,
+      const llvm::DenseMap<Operation *, std::vector<OpConfig>> &legalConfigs,
       const std::unordered_set<Edge> &memReconfigEdges,
       const std::vector<Operation *> &spillToDramOps)
-      : legalLayouts(legalLayouts), memReconfigEdges(memReconfigEdges),
+      : legalConfigs(legalConfigs), memReconfigEdges(memReconfigEdges),
         spillToDramOps(spillToDramOps) {}
 };
 

--- a/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutAnalysisPolicy.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutAnalysisPolicy.h
@@ -5,8 +5,10 @@
 #ifndef TTMLIR_DIALECT_TTNN_ANALYSIS_MEMORYLAYOUTANALYSISPOLICY_H
 #define TTMLIR_DIALECT_TTNN_ANALYSIS_MEMORYLAYOUTANALYSISPOLICY_H
 
-#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "ttmlir/Dialect/TTNN/Analysis/L1ChainConfig.h"
+#include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 
 namespace mlir::tt::ttnn {
 
@@ -14,7 +16,7 @@ class MemoryLayoutAnalysisPolicy {
 protected:
   Operation *rootOp;
   std::vector<L1ChainConfig> *l1ChainConfigs;
-  llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>> legalLayouts;
+  llvm::DenseMap<Operation *, std::vector<OpConfig>> legalConfigs;
   llvm::DenseMap<func::FuncOp, llvm::SmallVector<Operation *>> *schedule;
   unsigned usableL1CacheSize = 0;
   DeviceAttr deviceAttr;
@@ -24,12 +26,11 @@ public:
 
   MemoryLayoutAnalysisPolicy(
       Operation *rootOp, std::vector<L1ChainConfig> &l1ChainConfigs,
-      const llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>>
-          &legalLayouts,
+      const llvm::DenseMap<Operation *, std::vector<OpConfig>> &legalConfigs,
       llvm::DenseMap<func::FuncOp, llvm::SmallVector<Operation *>> &schedule,
       unsigned usableL1CacheSize)
       : rootOp(rootOp), l1ChainConfigs(&l1ChainConfigs),
-        legalLayouts(legalLayouts), schedule(&schedule),
+        legalConfigs(legalConfigs), schedule(&schedule),
         usableL1CacheSize(usableL1CacheSize) {}
 
   virtual void run() = 0;

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpConfig.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpConfig.h
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_ANALYSIS_OPCONFIG_H
+#define TTMLIR_DIALECT_TTNN_ANALYSIS_OPCONFIG_H
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+
+namespace mlir::tt::ttnn {
+
+struct OpConfig {
+  // Desired output layout for the op.
+  //
+  TTNNLayoutAttr outputLayout;
+
+  // Op specific configuration. E.g. Conv2dConfigAttr for Conv2dOp.
+  //
+  Attribute config;
+
+  OpConfig() : outputLayout(), config() {}
+  OpConfig(TTNNLayoutAttr outputLayout)
+      : outputLayout(outputLayout), config() {}
+
+  bool operator==(const OpConfig &other) const {
+    return outputLayout == other.outputLayout && config == other.config;
+  }
+
+  void dump() const {
+    outputLayout.dump();
+    if (config) {
+      config.dump();
+    }
+  }
+};
+
+} // namespace mlir::tt::ttnn
+
+#endif // TTMLIR_DIALECT_TTNN_ANALYSIS_OPCONFIG_H

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpConfig.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpConfig.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -18,16 +18,17 @@ struct OpConfig {
   //
   Attribute config;
 
-  OpConfig() : outputLayout(), config() {}
-  OpConfig(TTNNLayoutAttr outputLayout)
-      : outputLayout(outputLayout), config() {}
+  OpConfig() = default;
+  OpConfig(TTNNLayoutAttr outputLayout) : outputLayout(outputLayout) {}
 
   bool operator==(const OpConfig &other) const {
     return outputLayout == other.outputLayout && config == other.config;
   }
 
   void dump() const {
-    outputLayout.dump();
+    if (outputLayout) {
+      outputLayout.dump();
+    }
     if (config) {
       config.dump();
     }

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpConfigAnalysis.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpConfigAnalysis.h
@@ -5,28 +5,27 @@
 #ifndef TTMLIR_DIALECT_TTNN_ANALYSIS_OPCONFIGANALYSIS_H
 #define TTMLIR_DIALECT_TTNN_ANALYSIS_OPCONFIGANALYSIS_H
 
+#include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
 #include "ttmlir/Dialect/TTNN/Analysis/TTNNAnalysis.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 
 namespace mlir::tt::ttnn {
 
 struct OpConfigAnalysisInput {
-  llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>> legalLayouts;
+  llvm::DenseMap<Operation *, std::vector<OpConfig>> legalConfigs;
 
-  OpConfigAnalysisInput() : legalLayouts() {}
-
-  OpConfigAnalysisInput(
-      const llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>>
-          &&legalLayouts)
-      : legalLayouts(std::move(legalLayouts)) {}
+  OpConfigAnalysisInput() : legalConfigs() {}
 
   OpConfigAnalysisInput(
-      const llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>>
-          &legalLayouts)
-      : legalLayouts(legalLayouts) {}
+      const llvm::DenseMap<Operation *, std::vector<OpConfig>> &&legalConfigs)
+      : legalConfigs(std::move(legalConfigs)) {}
+
+  OpConfigAnalysisInput(
+      const llvm::DenseMap<Operation *, std::vector<OpConfig>> &legalConfigs)
+      : legalConfigs(legalConfigs) {}
 
   bool operator==(const OpConfigAnalysisInput &rhs) const {
-    return legalLayouts == rhs.legalLayouts;
+    return legalConfigs == rhs.legalConfigs;
   }
 
   bool operator!=(const OpConfigAnalysisInput &rhs) const {
@@ -38,7 +37,7 @@ struct OpConfigAnalysisInput {
 //
 class OpConfigAnalysis
     : public TTNNAnalysis<OpConfigAnalysisInput,
-                          llvm::DenseMap<Operation *, TTNNLayoutAttr>> {
+                          llvm::DenseMap<Operation *, OpConfig>> {
 
 private:
   void analysisImplementation() override;

--- a/lib/Dialect/TTNN/Analysis/DFShardingPolicy.cpp
+++ b/lib/Dialect/TTNN/Analysis/DFShardingPolicy.cpp
@@ -4,6 +4,7 @@
 
 #include "ttmlir/Dialect/TTNN/Analysis/DFShardingPolicy.h"
 
+#include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
 #include "ttmlir/Dialect/TTNN/Analysis/ShardSolver.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Scheduler/Scheduler.h"
@@ -81,8 +82,8 @@ void DFShardingPolicy::run() {
           // fork/join op.
           //
           bool validForSharding = currentOp->hasOneUse() &&
-                                  legalLayouts.lookup(currentOp).size() > 0 &&
-                                  legalLayouts.lookup(nextOp).size() > 0;
+                                  legalConfigs.lookup(currentOp).size() > 0 &&
+                                  legalConfigs.lookup(nextOp).size() > 0;
 
           // TODO(odjuricic): Skip all ops that don't support sharding due to
           // bugs and incomplete implementation. This needs to be addressed in
@@ -117,15 +118,16 @@ void DFShardingPolicy::run() {
             // currentOp output tensor shard spec, nextOp exec and nextOp output
             // tensor.
             //
-            TTNNLayoutAttr currentOpLayout =
-                legalLayouts.lookup(currentOp).front();
-            assert(currentOpLayout.hasShardedL1TensorMemoryLayout());
+            OpConfig currentOpConfig = legalConfigs.lookup(currentOp).front();
+            assert(
+                currentOpConfig.outputLayout.hasShardedL1TensorMemoryLayout());
             uint64_t currentOpL1OutputUsage =
-                currentOpLayout.getShardSizeInBytes();
+                currentOpConfig.outputLayout.getShardSizeInBytes();
 
-            TTNNLayoutAttr nextOpLayout = legalLayouts.lookup(nextOp).front();
-            assert(nextOpLayout.hasShardedL1TensorMemoryLayout());
-            uint64_t nextOpL1OutputUsage = nextOpLayout.getShardSizeInBytes();
+            OpConfig nextOpConfig = legalConfigs.lookup(nextOp).front();
+            assert(nextOpConfig.outputLayout.hasShardedL1TensorMemoryLayout());
+            uint64_t nextOpL1OutputUsage =
+                nextOpConfig.outputLayout.getShardSizeInBytes();
 
             // Figure out this const based on exec data, but will be replaced
             // with API.
@@ -157,13 +159,15 @@ void DFShardingPolicy::run() {
 
                 TTNNLayoutAttr firstOpInputShardedLayout =
                     firstOpInputLayout
-                        .withBufferType(currentOp->getContext(),
-                                        currentOpLayout.getBufferType())
-                        .withMemoryLayout(currentOp->getContext(),
-                                          currentOpLayout.getMemLayout())
+                        .withBufferType(
+                            currentOp->getContext(),
+                            currentOpConfig.outputLayout.getBufferType())
+                        .withMemoryLayout(
+                            currentOp->getContext(),
+                            currentOpConfig.outputLayout.getMemLayout())
                         .withGrid(currentOp->getContext(),
                                   firstOpInputTensorType,
-                                  currentOpLayout.getGrid());
+                                  currentOpConfig.outputLayout.getGrid());
 
                 uint64_t firstInputL1Usage =
                     firstOpInputShardedLayout.getShardSizeInBytes();
@@ -211,7 +215,7 @@ void DFShardingPolicy::run() {
   //
   for (auto &l1ChainConfig : *l1ChainConfigs) {
     ShardSolver shardSolver = l1ChainConfig.resolveWithSolver(
-        legalLayouts, usableL1CacheSize, overrideReshardEdges);
+        legalConfigs, usableL1CacheSize, overrideReshardEdges);
 
     if (l1ChainConfig.getState() == L1ChainState::Failed) {
       mlir::emitWarning(l1ChainConfig.getOpL1MemSpecs().front().op->getLoc(),
@@ -223,48 +227,48 @@ void DFShardingPolicy::run() {
       continue;
     }
 
-    pickOpShardLayouts(shardSolver, l1ChainConfig);
+    pickOpShardConfigs(shardSolver, l1ChainConfig);
 
     ShardSolverSolution resolvedShardSolution = shardSolver.finish();
-    l1ChainConfig.complete(resolvedShardSolution.selectedOpLayout,
+    l1ChainConfig.complete(resolvedShardSolution.selectedOpConfig,
                            resolvedShardSolution.memReconfigEdges);
 
     // TODO(odjuricic): Add constraint check if op can write to dram.
-    if (not resolvedShardSolution.selectedOpLayout[l1ChainConfig.getLastOp()]
-                .hasDRAMBufferType()) {
+    if (not resolvedShardSolution.selectedOpConfig[l1ChainConfig.getLastOp()]
+                .outputLayout.hasDRAMBufferType()) {
       l1ChainConfig.spillEndToDRAM = true;
     }
   }
 }
 
-void DFShardingPolicy::pickOpShardLayouts(ShardSolver &shardSolver,
+void DFShardingPolicy::pickOpShardConfigs(ShardSolver &shardSolver,
                                           const L1ChainConfig &l1ChainConfig) {
   assert(l1ChainConfig.getState() == L1ChainState::Resolved);
   llvm::DenseMap<Operation *, SmallVector<float, 64>> accMaxCoreUsage =
       shardSolver.produceMaxCoreUsage();
   for (const auto &shardSpec : l1ChainConfig.getOpL1MemSpecs()) {
     Operation *op = shardSpec.op;
-    ShardSolver::RemainingLayoutAttrs validLayouts = shardSolver.at(op);
-    const TTNNLayoutAttr *selectedLayout = validLayouts.begin().get();
+    ShardSolver::RemainingConfigAttrs validConfigs = shardSolver.at(op);
+    const OpConfig *selectedConfig = validConfigs.begin().get();
     float maxCoreUsage = 0;
-    for (auto layoutIterator = validLayouts.begin();
-         layoutIterator != validLayouts.end(); ++layoutIterator) {
-      if (accMaxCoreUsage[op][layoutIterator.index()] > maxCoreUsage) {
-        maxCoreUsage = accMaxCoreUsage[op][layoutIterator.index()];
-        selectedLayout = layoutIterator.get();
-      } else if (accMaxCoreUsage[op][layoutIterator.index()] == maxCoreUsage) {
-        assert(layoutIterator->getMemLayout() &&
+    for (auto configIterator = validConfigs.begin();
+         configIterator != validConfigs.end(); ++configIterator) {
+      if (accMaxCoreUsage[op][configIterator.index()] > maxCoreUsage) {
+        maxCoreUsage = accMaxCoreUsage[op][configIterator.index()];
+        selectedConfig = configIterator.get();
+      } else if (accMaxCoreUsage[op][configIterator.index()] == maxCoreUsage) {
+        assert(configIterator->outputLayout.getMemLayout() &&
                "TensorMemoryLayout is not set");
         // If we have a tie, prefer layout that is not BlockSharded.
         //
-        if (layoutIterator->getMemLayout().getValue() !=
+        if (configIterator->outputLayout.getMemLayout().getValue() !=
             ttnn::TensorMemoryLayout::BlockSharded) {
-          selectedLayout = layoutIterator.get();
+          selectedConfig = configIterator.get();
         }
       }
     }
 
-    shardSolver.set(op, *selectedLayout);
+    shardSolver.set(op, *selectedConfig);
   }
 }
 

--- a/lib/Dialect/TTNN/Analysis/GreedyL1InterleavedPolicy.cpp
+++ b/lib/Dialect/TTNN/Analysis/GreedyL1InterleavedPolicy.cpp
@@ -3,17 +3,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Dialect/TTNN/Analysis/GreedyL1InterleavedPolicy.h"
+
 #include "ttmlir/Dialect/TTNN/Analysis/L1ChainConfig.h"
+#include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 #include "ttmlir/Scheduler/Scheduler.h"
 
 namespace mlir::tt::ttnn {
 
-GreedyL1InterleavedPolicy::OpConfig GreedyL1InterleavedPolicy::getGreedyConfig(
+GreedyL1InterleavedPolicy::GreedyPolicyChoice
+GreedyL1InterleavedPolicy::getGreedyConfig(
     Operation *baseOp, llvm::DenseMap<Operation *, L1Usage> &opsL1Usage) {
   uint64_t numOfOps, bitIndex, currentMask;
   uint64_t currentL1Usage, optimalL1Usage;
-  llvm::DenseMap<Operation *, TTNNLayoutAttr> optimalLayouts;
+  llvm::DenseMap<Operation *, OpConfig> optimalConfigs;
+  llvm::DenseMap<Operation *, OpConfig> currentConfigs;
   llvm::SmallVector<Operation *> optimalPrecedence;
 
   constexpr uint64_t maxNumOfOps = sizeof(numOfOps) * 8;
@@ -23,7 +27,7 @@ GreedyL1InterleavedPolicy::OpConfig GreedyL1InterleavedPolicy::getGreedyConfig(
   optimalL1Usage = 0;
   for (currentMask = 0; currentMask < (1 << numOfOps); currentMask++) {
     std::bitset<maxNumOfOps> bitset(currentMask);
-    llvm::DenseMap<Operation *, TTNNLayoutAttr> currentLayouts;
+    llvm::DenseMap<Operation *, OpConfig> currentConfigs;
     llvm::SmallVector<Operation *> currentPrecedence, optimalL1Precedence,
         L1Precedence;
 
@@ -40,7 +44,7 @@ GreedyL1InterleavedPolicy::OpConfig GreedyL1InterleavedPolicy::getGreedyConfig(
         // currentPrecedence.
         //
         currentL1Usage += l1Usage.outputL1Usage;
-        currentLayouts[op] = getL1InterleavedLayout(op);
+        currentConfigs[op] = OpConfig(getL1InterleavedLayout(op));
 
         // Skip the baseOp.
         //
@@ -52,7 +56,7 @@ GreedyL1InterleavedPolicy::OpConfig GreedyL1InterleavedPolicy::getGreedyConfig(
         // Therefore, we can directly insert them into the
         // currentOptimalPrecedence.
         //
-        currentLayouts[op] = getDRAMLayout(op);
+        currentConfigs[op] = OpConfig(getDRAMLayout(op));
 
         // Skip the baseOp.
         //
@@ -112,16 +116,16 @@ GreedyL1InterleavedPolicy::OpConfig GreedyL1InterleavedPolicy::getGreedyConfig(
       // Update the optimal configuration.
       //
       optimalL1Usage = currentL1Usage;
-      optimalLayouts = std::move(currentLayouts);
+      optimalConfigs = std::move(currentConfigs);
       optimalPrecedence = std::move(currentPrecedence);
     }
   }
 
   // Create the optimal config.
   //
-  OpConfig optimalConfig;
+  GreedyPolicyChoice optimalConfig;
   optimalConfig.baseOp = baseOp;
-  optimalConfig.layouts = std::move(optimalLayouts);
+  optimalConfig.configs = std::move(optimalConfigs);
   optimalConfig.precedence = std::move(optimalPrecedence);
 
   return optimalConfig;
@@ -151,7 +155,7 @@ void GreedyL1InterleavedPolicy::run() {
         llvm::SmallVector<Operation *> opsPrecedence;
 
         // Generate optimal configuration for the current op based on the
-        // outputs of its operands and its legal output layouts.
+        // outputs of its operands and its legal configs.
         //
         if (isAnalyzable(op)) {
 
@@ -159,7 +163,7 @@ void GreedyL1InterleavedPolicy::run() {
           //
           OpMemSpec OpMemSpec;
           assert(hasDRAMBufferType(op));
-          OpMemSpec.layout = getDRAMLayout(op);
+          OpMemSpec.config = OpConfig(getDRAMLayout(op));
           OpMemSpec.requiredL1Usage = 0;
           OpMemSpecMap[op] = OpMemSpec;
 
@@ -184,15 +188,16 @@ void GreedyL1InterleavedPolicy::run() {
           // Skip non-analyzable operands.
           //
           if (isAnalyzable(operandOp)) {
-            TTNNLayoutAttr operandOpLayout = OpMemSpecMap[operandOp].layout;
+            OpConfig operandOpConfig = OpMemSpecMap[operandOp].config;
 
             // Take into consideration only the operands with L1 interleaved
             // memory space.
             //
-            if (operandOpLayout.hasInterleavedL1TensorMemoryLayout()) {
+            if (operandOpConfig.outputLayout
+                    .hasInterleavedL1TensorMemoryLayout()) {
               L1Usage l1Usage;
               l1Usage.outputL1Usage =
-                  utils::getOpOutputL1Usage(operandOpLayout);
+                  utils::getOpOutputL1Usage(operandOpConfig.outputLayout);
               l1Usage.requiredL1Usage = OpMemSpecMap[operandOp].requiredL1Usage;
               opsL1Usage[operandOp] = l1Usage;
             }
@@ -205,7 +210,7 @@ void GreedyL1InterleavedPolicy::run() {
             }
           }
           // In case the operand is not analyzable, i.e. there are no legal
-          // layouts for this operand, we can insert it into the precedence
+          // configs for this operand, we can insert it into the precedence
           // directly if it is schedulable since it does not use DRAM nor L1
           // memory.
           //
@@ -218,9 +223,9 @@ void GreedyL1InterleavedPolicy::run() {
 
         // Greedily find the optimal configuration.
         //
-        OpConfig optimalConfig = getGreedyConfig(op, opsL1Usage);
-        for (const auto &[op, layout] : optimalConfig.layouts) {
-          OpMemSpecMap[op].layout = layout;
+        GreedyPolicyChoice optimalConfig = getGreedyConfig(op, opsL1Usage);
+        for (const auto &[innerOp, cfg] : optimalConfig.configs) {
+          OpMemSpecMap[innerOp].config = cfg;
         }
 
         // Override op's precedence.
@@ -251,14 +256,14 @@ void GreedyL1InterleavedPolicy::run() {
                   std::max(intermediateRequiredL1Usage,
                            intermediateL1Usage +
                                OpMemSpecMap[operandOp].requiredL1Usage);
-              intermediateL1Usage +=
-                  utils::getOpOutputL1Usage(OpMemSpecMap[operandOp].layout);
+              intermediateL1Usage += utils::getOpOutputL1Usage(
+                  OpMemSpecMap[operandOp].config.outputLayout);
             }
           }
-          OpMemSpecMap[op].requiredL1Usage =
-              std::max(intermediateRequiredL1Usage,
-                       intermediateL1Usage +
-                           utils::getOpOutputL1Usage(OpMemSpecMap[op].layout));
+          OpMemSpecMap[op].requiredL1Usage = std::max(
+              intermediateRequiredL1Usage,
+              intermediateL1Usage + utils::getOpOutputL1Usage(
+                                        OpMemSpecMap[op].config.outputLayout));
         }
       }
     }
@@ -273,63 +278,63 @@ void GreedyL1InterleavedPolicy::run() {
     // TODO(fbajraktari): Fix this hack.
     //
     l1ChainConfigs->push_back(L1ChainConfig());
-    llvm::DenseMap<Operation *, TTNNLayoutAttr> selectedOpLayout;
+    llvm::DenseMap<Operation *, OpConfig> selectedOpConfig;
     for (auto &OpMemSpec : OpMemSpecMap) {
       OpL1MemSpec opL1MemSpec;
       opL1MemSpec.op = OpMemSpec.first;
       opL1MemSpec.tensorSplitFactor = 1;
-      selectedOpLayout[OpMemSpec.first] = OpMemSpec.second.layout;
+      selectedOpConfig[OpMemSpec.first] = OpMemSpec.second.config.outputLayout;
       l1ChainConfigs->back().addOpL1MemSpec(opL1MemSpec);
     }
     l1ChainConfigs->back().build();
     l1ChainConfigs->back().resolve();
     std::unordered_set<Edge> memReconfigEdges;
-    l1ChainConfigs->back().complete(selectedOpLayout, memReconfigEdges);
+    l1ChainConfigs->back().complete(selectedOpConfig, memReconfigEdges);
   }
 }
 
 bool GreedyL1InterleavedPolicy::isAnalyzable(Operation *op) {
-  // Skip operations that are not analyzed by the LegalGridAnalysis.
+  // Skip operations that are not analyzed by the LegalLayoutAnalysis.
   //
-  if (legalLayouts.count(op) > 0) {
+  if (legalConfigs.count(op) > 0) {
     // Skip operations that are filterd out by the MemoryLayoutAnalysis.
     //
-    return legalLayouts[op].size() > 0;
+    return legalConfigs[op].size() > 0;
   }
   return false;
 }
 
 bool GreedyL1InterleavedPolicy::hasDRAMBufferType(Operation *op) {
-  return std::find_if(legalLayouts[op].begin(), legalLayouts[op].end(),
-                      [](TTNNLayoutAttr layout) {
-                        return layout.hasDRAMBufferType();
-                      }) != legalLayouts[op].end();
+  return std::find_if(legalConfigs[op].begin(), legalConfigs[op].end(),
+                      [](OpConfig config) {
+                        return config.outputLayout.hasDRAMBufferType();
+                      }) != legalConfigs[op].end();
 }
 
 TTNNLayoutAttr GreedyL1InterleavedPolicy::getDRAMLayout(Operation *op) {
   assert(hasDRAMBufferType(op));
-  auto dramLayoutIter = std::find_if(
-      legalLayouts[op].begin(), legalLayouts[op].end(),
-      [](TTNNLayoutAttr layout) { return layout.hasDRAMBufferType(); });
-  return *dramLayoutIter;
+  auto configIter = std::find_if(
+      legalConfigs[op].begin(), legalConfigs[op].end(),
+      [](OpConfig config) { return config.outputLayout.hasDRAMBufferType(); });
+  return configIter->outputLayout;
 }
 
 bool GreedyL1InterleavedPolicy::hasL1BufferType(Operation *op) {
-  return std::find_if(legalLayouts[op].begin(), legalLayouts[op].end(),
-                      [](TTNNLayoutAttr layout) {
-                        return layout.hasInterleavedL1TensorMemoryLayout();
-                      }) != legalLayouts[op].end();
+  return std::find_if(
+             legalConfigs[op].begin(), legalConfigs[op].end(),
+             [](OpConfig config) {
+               return config.outputLayout.hasInterleavedL1TensorMemoryLayout();
+             }) != legalConfigs[op].end();
 }
 
 TTNNLayoutAttr
 GreedyL1InterleavedPolicy::getL1InterleavedLayout(Operation *op) {
   assert(hasL1BufferType(op));
-  auto l1InterleaveLayoutIter =
-      std::find_if(legalLayouts[op].begin(), legalLayouts[op].end(),
-                   [](TTNNLayoutAttr layout) {
-                     return layout.hasInterleavedL1TensorMemoryLayout();
-                   });
-  return *l1InterleaveLayoutIter;
+  auto l1InterleaveLayoutIter = std::find_if(
+      legalConfigs[op].begin(), legalConfigs[op].end(), [](OpConfig config) {
+        return config.outputLayout.hasInterleavedL1TensorMemoryLayout();
+      });
+  return l1InterleaveLayoutIter->outputLayout;
 }
 
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Analysis/L1ChainConfig.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1ChainConfig.cpp
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Dialect/TTNN/Analysis/L1ChainConfig.h"
+
 #include "ttmlir/Dialect/TTNN/Analysis/Edge.h"
+#include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
 #include "ttmlir/Dialect/TTNN/Analysis/ShardSolver.h"
 
 namespace mlir::tt::ttnn {
@@ -19,8 +21,7 @@ void L1ChainConfig::resolve() {
 }
 
 ShardSolver L1ChainConfig::resolveWithSolver(
-    const llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>>
-        &legalLayouts,
+    const llvm::DenseMap<Operation *, std::vector<OpConfig>> &legalConfigs,
     unsigned usableL1CacheSize,
     const std::unordered_set<Edge> &overrideReshardEdges) {
   assert(state == L1ChainState::Built);
@@ -28,7 +29,7 @@ ShardSolver L1ChainConfig::resolveWithSolver(
   // Reconcile adjacent shard specs.
   // Generate reshard specs where needed.
   //
-  ShardSolver shardSolver(legalLayouts, opL1MemSpecs, l1ChainedOps,
+  ShardSolver shardSolver(legalConfigs, opL1MemSpecs, l1ChainedOps,
                           usableL1CacheSize, overrideReshardEdges);
 
   state = shardSolver.resolve() ? L1ChainState::Resolved : L1ChainState::Failed;
@@ -37,14 +38,14 @@ ShardSolver L1ChainConfig::resolveWithSolver(
 }
 
 void L1ChainConfig::complete(
-    const llvm::DenseMap<Operation *, TTNNLayoutAttr> &selectedOpLayout,
+    const llvm::DenseMap<Operation *, OpConfig> &selectedOpConfig,
     std::unordered_set<Edge> &memReconfigEdges) {
   assert(state == L1ChainState::Resolved);
   for (auto &opL1MemSpec : opL1MemSpecs) {
-    auto legalLayoutsIter = selectedOpLayout.find(opL1MemSpec.op);
-    assert(legalLayoutsIter != selectedOpLayout.end());
+    auto legalConfigsIter = selectedOpConfig.find(opL1MemSpec.op);
+    assert(legalConfigsIter != selectedOpConfig.end());
 
-    opL1MemSpec.layout = legalLayoutsIter->second;
+    opL1MemSpec.config = legalConfigsIter->second;
   }
 
   this->memReconfigEdges.swap(memReconfigEdges);

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutAnalysis.cpp
@@ -3,9 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Dialect/TTNN/Analysis/MemoryLayoutAnalysis.h"
+
 #include "ttmlir/Dialect/TTNN/Analysis/BFInterleavedPolicy.h"
 #include "ttmlir/Dialect/TTNN/Analysis/DFShardingPolicy.h"
 #include "ttmlir/Dialect/TTNN/Analysis/GreedyL1InterleavedPolicy.h"
+#include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 
 namespace mlir::tt::ttnn {
@@ -18,42 +20,39 @@ bool MemoryLayoutAnalysis::applyOverrides() {
   return false;
 }
 
-llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>>
-filterShardedOnly(const llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>>
-                      &legalLayouts) {
-  llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>> shardedLayouts;
-  for (const auto &opLayouts : legalLayouts) {
-    std::vector<TTNNLayoutAttr> opShardedLayouts;
-    for (const auto &layout : opLayouts.second) {
-      if (layout.hasShardedL1TensorMemoryLayout()) {
-        opShardedLayouts.push_back(layout);
+llvm::DenseMap<Operation *, std::vector<OpConfig>> filterShardedOnly(
+    const llvm::DenseMap<Operation *, std::vector<OpConfig>> &legalConfigs) {
+  llvm::DenseMap<Operation *, std::vector<OpConfig>> shardedConfigs;
+  for (const auto &configs : legalConfigs) {
+    std::vector<OpConfig> opShardedConfigs;
+    for (const OpConfig &config : configs.second) {
+      if (config.outputLayout.hasShardedL1TensorMemoryLayout()) {
+        opShardedConfigs.push_back(config);
       }
     }
 
-    shardedLayouts[opLayouts.first] = opShardedLayouts;
+    shardedConfigs[configs.first] = opShardedConfigs;
   }
 
-  return shardedLayouts;
+  return shardedConfigs;
 }
 
-llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>>
-filterDRAMAndL1Interleaved(
-    const llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>>
-        &legalLayouts) {
-  llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>> l1InterleavedLayouts;
-  for (const auto &opLayouts : legalLayouts) {
-    std::vector<TTNNLayoutAttr> opL1InterleavedLayouts;
-    for (const auto &layout : opLayouts.second) {
-      if (layout.hasDRAMBufferType() ||
-          layout.hasInterleavedL1TensorMemoryLayout()) {
-        opL1InterleavedLayouts.push_back(layout);
+llvm::DenseMap<Operation *, std::vector<OpConfig>> filterDRAMAndL1Interleaved(
+    const llvm::DenseMap<Operation *, std::vector<OpConfig>> &legalConfigs) {
+  llvm::DenseMap<Operation *, std::vector<OpConfig>> l1InterleavedConfigs;
+  for (const auto &configs : legalConfigs) {
+    std::vector<OpConfig> opL1InterleavedConfigs;
+    for (const auto &config : configs.second) {
+      if (config.outputLayout.hasDRAMBufferType() ||
+          config.outputLayout.hasInterleavedL1TensorMemoryLayout()) {
+        opL1InterleavedConfigs.push_back(config);
       }
     }
 
-    l1InterleavedLayouts[opLayouts.first] = opL1InterleavedLayouts;
+    l1InterleavedConfigs[configs.first] = opL1InterleavedConfigs;
   }
 
-  return l1InterleavedLayouts;
+  return l1InterleavedConfigs;
 }
 
 void MemoryLayoutAnalysis::analysisImplementation() {
@@ -62,7 +61,7 @@ void MemoryLayoutAnalysis::analysisImplementation() {
   switch (analysisInput.policy) {
   case MemoryLayoutAnalysisPolicyType::DFSharding: {
     DFShardingPolicy dfShardingPolicy(
-        op, l1ChainConfigs, filterShardedOnly(analysisInput.legalLayouts),
+        op, l1ChainConfigs, filterShardedOnly(analysisInput.legalConfigs),
         analysisResult.schedule, analysisInput.usableL1CacheSize);
     dfShardingPolicy.setOverrideReshardEdges(
         analysisInput.overrideReshardEdges);
@@ -72,7 +71,7 @@ void MemoryLayoutAnalysis::analysisImplementation() {
   case MemoryLayoutAnalysisPolicyType::GreedyL1Interleaved: {
     GreedyL1InterleavedPolicy l1InterleavedPolicy(
         op, l1ChainConfigs,
-        filterDRAMAndL1Interleaved(analysisInput.legalLayouts),
+        filterDRAMAndL1Interleaved(analysisInput.legalConfigs),
         analysisResult.schedule, analysisInput.usableL1CacheSize);
     l1InterleavedPolicy.run();
     break;
@@ -80,16 +79,16 @@ void MemoryLayoutAnalysis::analysisImplementation() {
   case MemoryLayoutAnalysisPolicyType::BFInterleaved: {
     BFInterleavedPolicy bfInterleavedPolicy(
         op, l1ChainConfigs,
-        filterDRAMAndL1Interleaved(analysisInput.legalLayouts),
+        filterDRAMAndL1Interleaved(analysisInput.legalConfigs),
         analysisResult.schedule, analysisInput.usableL1CacheSize);
     bfInterleavedPolicy.run();
     break;
   }
   }
 
-  // Copy over default legal layouts.
+  // Copy over default legal configs.
   //
-  analysisResult.legalLayouts = analysisInput.legalLayouts;
+  analysisResult.legalConfigs = analysisInput.legalConfigs;
 
   // Override with L1 chain configs where applicable.
   //
@@ -100,8 +99,8 @@ void MemoryLayoutAnalysis::analysisImplementation() {
 
     assert(l1ChainConfig.getState() == L1ChainState::Completed);
     for (const auto &opL1MemSpec : l1ChainConfig.getOpL1MemSpecs()) {
-      analysisResult.legalLayouts[opL1MemSpec.op] =
-          std::vector<TTNNLayoutAttr>{opL1MemSpec.layout};
+      analysisResult.legalConfigs[opL1MemSpec.op] =
+          std::vector<OpConfig>{opL1MemSpec.config};
     }
 
     analysisResult.memReconfigEdges.insert(

--- a/lib/Dialect/TTNN/Analysis/OpConfigAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpConfigAnalysis.cpp
@@ -16,10 +16,10 @@ bool OpConfigAnalysis::applyOverrides() {
 void OpConfigAnalysis::analysisImplementation() {
 
   // Future entrypoint for picking optimal op config.
-  // Placeholder: pick the first legal layout.
+  // Placeholder: pick the first legal config.
   //
-  for (auto opLayouts : analysisInput.legalLayouts) {
-    analysisResult[opLayouts.first] = opLayouts.second[0];
+  for (auto opConfigs : analysisInput.legalConfigs) {
+    analysisResult[opConfigs.first] = opConfigs.second[0];
   }
 }
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
+++ b/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
@@ -5,6 +5,7 @@
 #include "ttmlir/Dialect/TTNN/Analysis/ShardSolver.h"
 
 #include "ttmlir/Dialect/TTNN/Analysis/L1ChainConfig.h"
+#include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 
@@ -24,15 +25,14 @@ ShardSolver::Bitset ShardSolver::kBitsetAll = ~kBitsetNone;
 constexpr bool DEBUG = false;
 
 ShardSolver::ShardSolver(
-    const llvm::DenseMap<Operation *, std::vector<TTNNLayoutAttr>>
-        &legalLayouts,
+    const llvm::DenseMap<Operation *, std::vector<OpConfig>> &legalConfigs,
     const std::vector<OpL1MemSpec> &shardSpecs,
     const llvm::DenseSet<Operation *> &shardedOps,
     const unsigned usableL1CacheSize,
     const std::unordered_set<Edge> &overrideReshardEdges,
-    std::function<bool(Value, TTNNLayoutAttr, Operation *, TTNNLayoutAttr)>
+    std::function<bool(Value, TTNNLayoutAttr, Operation *, OpConfig)>
         customCheckShardCompatible)
-    : legalLayouts(&legalLayouts), shardSpecs(&shardSpecs),
+    : legalConfigs(&legalConfigs), shardSpecs(&shardSpecs),
       shardedOps(&shardedOps), usableL1CacheSize(usableL1CacheSize),
       memReconfigEdges(overrideReshardEdges),
       customCheckShardCompatible(customCheckShardCompatible) {
@@ -72,7 +72,7 @@ bool ShardSolver::resolveStep() {
   OperationPathsProcessor opProcessor;
   bitsets.reserve(shardedOps->size());
   bitsetIds.reserve(shardedOps->size());
-  selectedOpLayout.reserve(shardedOps->size());
+  selectedOpConfig.reserve(shardedOps->size());
   bool reshardInserted = false;
 
   // We need special handling for the first op in the chain.
@@ -84,8 +84,7 @@ bool ShardSolver::resolveStep() {
   for (const auto shardSpec : *shardSpecs) {
     Operation *consumerOp = shardSpec.op;
     Bitset *consumerBitset = getOrInsertBitset(consumerOp, kBitsetAll);
-    std::vector<TTNNLayoutAttr> const &consumerLayouts =
-        getLegalLayouts(consumerOp);
+    std::vector<OpConfig> const &consumerConfigs = getLegalConfigs(consumerOp);
 
     for (Edge edge : operandOpEdges[consumerOp]) {
 
@@ -93,23 +92,23 @@ bool ShardSolver::resolveStep() {
 
       Operation *producerOp = edge.producerOp;
       Bitset *producerBitset = getOrInsertBitset(producerOp, kBitsetAll);
-      std::vector<TTNNLayoutAttr> const &producerLayouts =
-          getLegalLayouts(producerOp);
+      std::vector<OpConfig> const &producerConfigs =
+          getLegalConfigs(producerOp);
 
-      assert(not(consumerLayouts.empty() && producerLayouts.empty()));
+      assert(not(consumerConfigs.empty() && producerConfigs.empty()));
 
       PathSet::Paths paths;
       std::unordered_map<std::string, int> errorCount;
       Bitset edgeProducerBitset = kBitsetNone;
       Bitset edgeConsumerBitset = kBitsetNone;
       std::uint64_t producer_count =
-          std::min(kNumBitsetBits, std::max(1lu, producerLayouts.size()));
+          std::min(kNumBitsetBits, std::max(1lu, producerConfigs.size()));
       std::uint64_t consumer_count =
-          std::min(kNumBitsetBits, std::max(1lu, consumerLayouts.size()));
+          std::min(kNumBitsetBits, std::max(1lu, consumerConfigs.size()));
       for (std::uint64_t producerId = 0; producerId < producer_count;
            ++producerId) {
         // If the producer cannot accomodate this path, continue.
-        // Also if this is not the TTNNLayoutAttr we selected, continue.
+        // Also if this is not the OpConfig we selected, continue.
         //
         if (!producerBitset->test(producerId)) {
           continue;
@@ -142,9 +141,10 @@ bool ShardSolver::resolveStep() {
             continue;
           }
 
-          llvm::Expected<bool> shardCompatible = checkShardCompatible(
-              producerOp->getResult(0), producerLayouts[producerId], consumerOp,
-              consumerLayouts[consumerId]);
+          llvm::Expected<bool> shardCompatible =
+              checkShardCompatible(producerOp->getResult(0),
+                                   producerConfigs[producerId].outputLayout,
+                                   consumerOp, consumerConfigs[consumerId]);
 
           if (shardCompatible && shardCompatible.get()) {
             assert(producerId <=
@@ -218,8 +218,8 @@ bool ShardSolver::resolveStep() {
   return true;
 }
 
-bool ShardSolver::supportsInterleavedInputShardedOutput(
-    Operation *op, TTNNLayoutAttr outputLayout) {
+bool ShardSolver::supportsInterleavedInputShardedOutput(Operation *op,
+                                                        OpConfig outputConfig) {
   TTNNLayoutAttr inputLayout = mlir::cast<TTNNLayoutAttr>(
       mlir::cast<RankedTensorType>(op->getOperand(0).getType()).getEncoding());
 
@@ -228,7 +228,7 @@ bool ShardSolver::supportsInterleavedInputShardedOutput(
           .withMemoryLayout(op->getContext(), TensorMemoryLayout::Interleaved);
 
   llvm::Expected<bool> shardCompatible =
-      checkShardCompatible(op->getOperand(0), inputLayout, op, outputLayout);
+      checkShardCompatible(op->getOperand(0), inputLayout, op, outputConfig);
 
   if (!shardCompatible) {
     llvm::consumeError(shardCompatible.takeError());
@@ -250,7 +250,7 @@ bool ShardSolver::preprocessFirstOp() {
   }
 
   Bitset *firstOpBitset = getOrInsertBitset(firstOp, kBitsetAll);
-  std::vector<TTNNLayoutAttr> const &firstOpLayouts = getLegalLayouts(firstOp);
+  std::vector<OpConfig> const &firstOpConfigs = getLegalConfigs(firstOp);
 
   RankedTensorType firstOpInputTensorType =
       mlir::cast<RankedTensorType>(firstOp->getOperand(0).getType());
@@ -258,14 +258,14 @@ bool ShardSolver::preprocessFirstOp() {
       mlir::cast<TTNNLayoutAttr>(firstOpInputTensorType.getEncoding());
   constexpr float tensorL1UsageCap = 0.8;
 
-  bool hasValidLayout = false;
+  bool hasValidConfig = false;
 
-  for (size_t i = 0; i < firstOpLayouts.size(); ++i) {
+  for (size_t i = 0; i < firstOpConfigs.size(); ++i) {
     if (!firstOpBitset->test(i)) {
       continue;
     }
 
-    TTNNLayoutAttr firstOpLayout = firstOpLayouts[i];
+    TTNNLayoutAttr firstOpLayout = firstOpConfigs[i].outputLayout;
     assert(firstOpLayout.hasShardedL1TensorMemoryLayout());
 
     TTNNLayoutAttr firstOpInputShardedLayout =
@@ -285,14 +285,14 @@ bool ShardSolver::preprocessFirstOp() {
         tensorL1UsageCap * usableL1CacheSize) {
       firstOpBitset->reset(i);
     } else if (not supportsInterleavedInputShardedOutput(firstOp,
-                                                         firstOpLayouts[i])) {
+                                                         firstOpConfigs[i])) {
       firstOpBitset->reset(i);
     } else {
-      hasValidLayout = true;
+      hasValidConfig = true;
     }
   }
 
-  if (!hasValidLayout) {
+  if (!hasValidConfig) {
     // Insert reshard edge for the first op to start the chain.
     Edge shardChainInputEdge = Edge(firstOp->getOperand(0).getDefiningOp(),
                                     firstOp, 0 /*operandIndex*/);
@@ -312,37 +312,36 @@ bool ShardSolver::insertReshard(const Edge &edge) {
   Bitset *consumerBitset = getOrInsertBitset(consumerOp, kBitsetAll);
   *consumerBitset = kBitsetNone;
 
-  std::vector<TTNNLayoutAttr> const &consumerLayouts =
-      getLegalLayouts(consumerOp);
-  // TODO(odjuricic): This needs to be raplaced with all possible layouts for
+  std::vector<OpConfig> const &consumerConfigs = getLegalConfigs(consumerOp);
+  // TODO(odjuricic): This needs to be replaced with all possible layouts for
   // the input tensor instead of the producer op, as these are not always the
   // same. Related: #2219
-  std::vector<TTNNLayoutAttr> const &producerLayouts =
-      getLegalLayouts(edge.producerOp);
+  std::vector<OpConfig> const &producerConfigs =
+      getLegalConfigs(edge.producerOp);
 
   // For all legal outputs, check if there is at least one valid input.
   //
-  bool validLayoutExists = false;
-  for (size_t i = 0; i < consumerLayouts.size(); ++i) {
-    TTNNLayoutAttr outputLayout = consumerLayouts[i];
+  bool validConfigExists = false;
+  for (size_t i = 0; i < consumerConfigs.size(); ++i) {
+    OpConfig outputConfig = consumerConfigs[i];
 
-    for (TTNNLayoutAttr producerLayout : producerLayouts) {
-      llvm::Expected<bool> shardCompatible =
-          checkShardCompatible(consumerOp->getOperand(edge.operandIndex),
-                               producerLayout, consumerOp, outputLayout);
+    for (OpConfig producerConfig : producerConfigs) {
+      llvm::Expected<bool> shardCompatible = checkShardCompatible(
+          consumerOp->getOperand(edge.operandIndex),
+          producerConfig.outputLayout, consumerOp, outputConfig);
 
       if (shardCompatible && shardCompatible.get()) {
         consumerBitset->set(i);
-        validLayoutExists = true;
+        validConfigExists = true;
         break;
       }
       llvm::consumeError(shardCompatible.takeError());
     }
   }
 
-  if (not validLayoutExists) {
+  if (not validConfigExists) {
     consumerOp->emitWarning()
-        << "No valid output layout found for resharded input!";
+        << "No valid output config found for resharded input!";
 
     if (DEBUG) {
       llvm::errs() << "Op location" << consumerOp->getLoc() << "\n";
@@ -353,13 +352,13 @@ bool ShardSolver::insertReshard(const Edge &edge) {
         llvm::errs() << "Producer op is null\n";
       }
 
-      llvm::errs() << "Producer layouts: " << producerLayouts.size() << "\n";
-      for (auto layout : producerLayouts) {
-        llvm::errs() << "\t" << layout << "\n";
+      llvm::errs() << "Producer layouts: " << producerConfigs.size() << "\n";
+      for (auto config : producerConfigs) {
+        llvm::errs() << "\t" << config.outputLayout << "\n";
       }
-      llvm::errs() << "Consumer layouts: " << consumerLayouts.size() << "\n";
-      for (auto layout : consumerLayouts) {
-        llvm::errs() << "\t" << layout << "\n";
+      llvm::errs() << "Consumer layouts: " << consumerConfigs.size() << "\n";
+      for (auto config : consumerConfigs) {
+        llvm::errs() << "\t" << config.outputLayout << "\n";
       }
     }
 
@@ -481,7 +480,7 @@ bool ShardSolver::updateSolver(Operation *root, bool expand_root,
       path_set->update(bitsets);
     }
 
-    // When op bitsets are updated(set of valid op layouts), we need to update
+    // When op bitsets are updated(set of valid op configs), we need to update
     // paths for all operands and users.
     //
     addOperandsAndUsers(root, needsUpdate);
@@ -579,37 +578,36 @@ ShardSolver::Bitset *ShardSolver::getOrInsertBitset(Operation *op,
   return &bitsets[match->second];
 }
 
-// Returns vector of legal LayoutAttrs for passed in op.
+// Returns vector of legal OpConfigs for passed in op.
 //
-const std::vector<TTNNLayoutAttr> &
-ShardSolver::getLegalLayouts(Operation *op) const {
-  static std::vector<TTNNLayoutAttr> nullLayouts;
+const std::vector<OpConfig> &ShardSolver::getLegalConfigs(Operation *op) const {
+  static std::vector<OpConfig> nullConfigs;
 
-  const auto legalIt = legalLayouts->find(op);
+  const auto legalIt = legalConfigs->find(op);
 
-  if (legalIt != legalLayouts->end()) {
+  if (legalIt != legalConfigs->end()) {
     return legalIt->second;
   }
 
-  return nullLayouts;
+  return nullConfigs;
 }
 
-ShardSolver::RemainingLayoutAttrs ShardSolver::at(Operation *op) const {
-  auto layouts = RemainingLayoutAttrs(getLegalLayouts(op), *getBitset(op));
-  assert(layouts.begin() != layouts.end());
-  return layouts;
+ShardSolver::RemainingConfigAttrs ShardSolver::at(Operation *op) const {
+  auto configs = RemainingConfigAttrs(getLegalConfigs(op), *getBitset(op));
+  assert(configs.begin() != configs.end());
+  return configs;
 }
 
-void ShardSolver::set(Operation *op, TTNNLayoutAttr const &layout) {
-  assert(selectedOpLayout.count(op) == 0);
+void ShardSolver::set(Operation *op, OpConfig const &config) {
+  assert(selectedOpConfig.count(op) == 0);
 
-  selectedOpLayout[op] = layout;
+  selectedOpConfig[op] = config;
 
-  auto const &layouts = getLegalLayouts(op);
-  assert(!layouts.empty());
-  size_t selection = layouts.size();
-  for (size_t i = 0; i < layouts.size(); ++i) {
-    if (layouts[i] == layout) {
+  const std::vector<OpConfig> &configs = getLegalConfigs(op);
+  assert(!configs.empty());
+  size_t selection = configs.size();
+  for (size_t i = 0; i < configs.size(); ++i) {
+    if (configs[i] == config) {
       selection = i;
       break;
     }
@@ -617,7 +615,7 @@ void ShardSolver::set(Operation *op, TTNNLayoutAttr const &layout) {
 
   Bitset *op_bitset = getBitset(op);
 
-  assert(selection != layouts.size());
+  assert(selection != configs.size());
   assert((*op_bitset)[selection]);
 
   op_bitset->reset();
@@ -625,18 +623,18 @@ void ShardSolver::set(Operation *op, TTNNLayoutAttr const &layout) {
 
   bool updateSuccessful =
       updateSolver(op, true /*expand_root*/, true /*invokedBySet*/);
-  assert(updateSuccessful && "Failed to update solver after setting layout");
+  assert(updateSuccessful && "Failed to update solver after setting config");
 }
 
 llvm::Expected<bool> ShardSolver::checkShardCompatible(
     Value producerOperand, TTNNLayoutAttr const &producerLayout,
-    Operation *consumerOp, TTNNLayoutAttr const &consumerLayout) const {
+    Operation *consumerOp, OpConfig const &consumerConfig) const {
 
   // Custom(test) hook for shard compatibility check.
   //
   if (customCheckShardCompatible) {
     return customCheckShardCompatible(producerOperand, producerLayout,
-                                      consumerOp, consumerLayout);
+                                      consumerOp, consumerConfig);
   }
   // Figure out this const based on exec data, but will be replaced
   // with API.
@@ -694,8 +692,10 @@ llvm::Expected<bool> ShardSolver::checkShardCompatible(
 
     assert(inputUnderCheckFound && "Input under check not found");
 
+    // TODO(odjuricic): This needs to change to pass full consumer config once #
+    // is completed.
     llvm::Expected<std::tuple<size_t, size_t, size_t>> l1UsageExp =
-        backend.getOpConstraints(inputLayouts, consumerLayout);
+        backend.getOpConstraints(inputLayouts, consumerConfig.outputLayout);
 
     if (!l1UsageExp) {
       // early exit
@@ -706,7 +706,7 @@ llvm::Expected<bool> ShardSolver::checkShardCompatible(
                      << " :: " << llvm::toString(l1UsageExp.takeError())
                      << "\n";
         producerLayout.dump();
-        consumerLayout.dump();
+        consumerConfig.dump();
       }
 
       return l1UsageExp.takeError();
@@ -718,7 +718,7 @@ llvm::Expected<bool> ShardSolver::checkShardCompatible(
       llvm::errs() << producerOperand.getLoc() << "->" << consumerOp->getName()
                    << "\n";
       producerLayout.dump();
-      consumerLayout.dump();
+      consumerConfig.dump();
       llvm::errs() << "L1 usage: " << cBUsagePeak << ", " << tensorUsage << ", "
                    << outputTensorUsage << "\n";
     }
@@ -739,7 +739,8 @@ llvm::Expected<bool> ShardSolver::checkShardCompatible(
 
     // TODO(odjurcic,#2265) Put this fallback under a flag.
 
-    if (producerLayout.getMemLayout() != consumerLayout.getMemLayout()) {
+    if (producerLayout.getMemLayout() !=
+        consumerConfig.outputLayout.getMemLayout()) {
       return llvm::createStringError("FALLBACK: tensor memory layout mismatch");
     }
 
@@ -749,8 +750,8 @@ llvm::Expected<bool> ShardSolver::checkShardCompatible(
     }
 
     uint64_t consumerL1OutputUsage = 0;
-    if (consumerLayout.hasL1BufferType()) {
-      consumerL1OutputUsage = consumerLayout.getShardSizeInBytes();
+    if (consumerConfig.outputLayout.hasL1BufferType()) {
+      consumerL1OutputUsage = consumerConfig.outputLayout.getShardSizeInBytes();
     }
 
     bool l1UsageValid = (producerL1OutputUsage + consumerL1OutputUsage) <
@@ -764,11 +765,11 @@ llvm::Expected<bool> ShardSolver::checkShardCompatible(
 }
 
 // Preprocess ShardSolver search space to make a helper structure which links op
-// layout choices to global max core usage.
+// config choices to global max core usage.
 // Example:
-// Lets assume simple case where layouts at same index are compatible for input
-// graph provided below. Tupples represent layout core
-// usage (Layout0GridVolume, Layout1GridVolume, Layout2GridVolume).
+// Lets assume simple case where configs at same index are compatible for input
+// graph provided below. Tupples represent grid core
+// usage (Config0GridVolume, Config1GridVolume, Config2GridVolume).
 //
 //    Op0 ----- (4, 8, 2)
 //     |
@@ -796,9 +797,9 @@ llvm::Expected<bool> ShardSolver::checkShardCompatible(
 //     |
 //    Op5 ----- (2, 1, 1)
 //
-// Global max of 24 core usage is achieved by selecting layout[0] for each Op.
+// Global max of 24 core usage is achieved by selecting config[0] for each Op.
 //
-// Returns map of op to vector of max core usage for each layout.
+// Returns map of op to vector of max core usage for each config.
 llvm::DenseMap<Operation *, SmallVector<float, 64>>
 ShardSolver::produceMaxCoreUsage() {
   using Paths = llvm::SmallVector<Path, 16>;
@@ -811,15 +812,15 @@ ShardSolver::produceMaxCoreUsage() {
   for (auto shardSpec = shardSpecs->rbegin(); shardSpec != shardSpecs->rend();
        ++shardSpec) {
     Operation *op = shardSpec->op;
-    std::vector<TTNNLayoutAttr> const &layouts = getLegalLayouts(op);
-    assert(!layouts.empty());
+    std::vector<OpConfig> const &configs = getLegalConfigs(op);
+    assert(!configs.empty());
 
-    // Find the layout that leads to the max core usage.
+    // Find the config that leads to the max core usage.
     // Start with grid volume of current op.
     //
-    for (size_t i = 0; i < layouts.size(); ++i) {
-      TTNNLayoutAttr const &layout = layouts[i];
-      uint64_t coreUsage = layout.getGrid().getGridVolume();
+    for (size_t i = 0; i < configs.size(); ++i) {
+      OpConfig const &config = configs[i];
+      uint64_t coreUsage = config.outputLayout.getGrid().getGridVolume();
       accCoreUsage[op].push_back(coreUsage);
     }
 
@@ -829,7 +830,7 @@ ShardSolver::produceMaxCoreUsage() {
     for (size_t i = 0; i < userPathSets.size(); ++i) {
       ShardSolver::PathSet *pathSet = userPathSets[i];
       const Paths &paths = pathSet->getPaths();
-      SmallVector<uint64_t, 64> maxCoreUsage(layouts.size(), 0);
+      SmallVector<uint64_t, 64> maxCoreUsage(configs.size(), 0);
       Operation *consumerOp = pathSet->getConsumerOp();
       size_t consumerInChainOperandSize =
           getOperandPathSetsPts(consumerOp).size();
@@ -843,8 +844,8 @@ ShardSolver::produceMaxCoreUsage() {
         }
       }
 
-      for (size_t i = 0; i < layouts.size(); ++i) {
-        // Add max core usage of consumer ops to current op layout.
+      for (size_t i = 0; i < configs.size(); ++i) {
+        // Add max core usage of consumer ops to current op config.
         // We divide by consumerInChainOperandSize to normalize the core usage
         // based on forking factor(so that cores are not counted more than
         // once).
@@ -853,7 +854,7 @@ ShardSolver::produceMaxCoreUsage() {
         // without previous forks, ie - chain having multiple input ops. In that
         // case total sum of used cores would be a sum of maxCoreUsage generated
         // by all input ops. This is currently not needed for making a
-        // decision on layout choice for maximizing core usage.
+        // decision on config choice for maximizing core usage.
         //
         accCoreUsage[op][i] += static_cast<float>(maxCoreUsage[i]) /
                                static_cast<float>(consumerInChainOperandSize);
@@ -867,7 +868,7 @@ ShardSolver::produceMaxCoreUsage() {
 // Returns ShardSolverSolution.
 //
 ShardSolverSolution ShardSolver::finish() const {
-  assert(selectedOpLayout.size() == shardedOps->size());
-  return ShardSolverSolution(selectedOpLayout, memReconfigEdges);
+  assert(selectedOpConfig.size() == shardedOps->size());
+  return ShardSolverSolution(selectedOpConfig, memReconfigEdges);
 }
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
+++ b/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
@@ -339,7 +339,7 @@ bool ShardSolver::insertReshard(const Edge &edge) {
     }
   }
 
-  if (not validConfigExists) {
+  if (!validConfigExists) {
     consumerOp->emitWarning()
         << "No valid output config found for resharded input!";
 

--- a/test/unittests/Optimizer/TestShardSolver.cpp
+++ b/test/unittests/Optimizer/TestShardSolver.cpp
@@ -13,6 +13,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"
 
+#include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNN.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 
@@ -94,21 +95,20 @@ public:
     l1ChainedOps.insert(op);
   }
 
-  void
-  addLayoutForOp(mlir::Operation *op,
-                 llvm::DenseMap<mlir::Operation *, std::vector<TTNNLayoutAttr>>
-                     &legalLayouts,
-                 BufferType memorySpace, TensorMemoryLayout tensorMemoryLayout,
-                 int gridWidth, int gridHeight) {
-    if (legalLayouts.find(op) == legalLayouts.end()) {
-      legalLayouts[op] = std::vector<TTNNLayoutAttr>{TTNNLayoutAttr::get(
+  void addConfigForOp(
+      mlir::Operation *op,
+      llvm::DenseMap<mlir::Operation *, std::vector<OpConfig>> &legalConfigs,
+      BufferType memorySpace, TensorMemoryLayout tensorMemoryLayout,
+      int gridWidth, int gridHeight) {
+    if (legalConfigs.find(op) == legalConfigs.end()) {
+      legalConfigs[op] = std::vector<OpConfig>{TTNNLayoutAttr::get(
           &context, getTensorRankedType().getShape(), builder.getF32Type(),
           memorySpace,
           mlir::tt::GridAttr::get(&context, {gridWidth, gridHeight}),
           mlir::tt::ttnn::TensorMemoryLayoutAttr::get(&context,
                                                       tensorMemoryLayout))};
     } else {
-      legalLayouts[op].push_back(TTNNLayoutAttr::get(
+      legalConfigs[op].push_back(TTNNLayoutAttr::get(
           &context, getTensorRankedType().getShape(), builder.getF32Type(),
           memorySpace,
           mlir::tt::GridAttr::get(&context, {gridWidth, gridHeight}),
@@ -150,7 +150,7 @@ public:
 //    Op5 ----- (2, 1, 1)
 //
 TEST_F(ShardSolverBase, VerifyProduceMaxCoreUsage) {
-  llvm::DenseMap<mlir::Operation *, std::vector<TTNNLayoutAttr>> legalLayouts;
+  llvm::DenseMap<mlir::Operation *, std::vector<OpConfig>> legalConfigs;
   std::vector<OpL1MemSpec> opL1MemSpecs;
   llvm::DenseSet<mlir::Operation *> l1ChainedOps;
   constexpr unsigned usableL1CacheSize = 1024 * 1024;
@@ -163,21 +163,21 @@ TEST_F(ShardSolverBase, VerifyProduceMaxCoreUsage) {
   mlir::Operation *firstOp = op;
 
   prepareOpForShardSolver(op, opL1MemSpecs, l1ChainedOps);
-  addLayoutForOp(op, legalLayouts, BufferType::L1,
+  addConfigForOp(op, legalConfigs, BufferType::L1,
                  TensorMemoryLayout::WidthSharded, 1, 4);
-  addLayoutForOp(op, legalLayouts, BufferType::L1,
+  addConfigForOp(op, legalConfigs, BufferType::L1,
                  TensorMemoryLayout::HeightSharded, 8, 1);
-  addLayoutForOp(op, legalLayouts, BufferType::L1,
+  addConfigForOp(op, legalConfigs, BufferType::L1,
                  TensorMemoryLayout::BlockSharded, 2, 2);
 
   rhs = op->getResult(0);
   op = builder.create<ReluOp>(builder.getUnknownLoc(), rhs);
   prepareOpForShardSolver(op, opL1MemSpecs, l1ChainedOps);
-  addLayoutForOp(op, legalLayouts, BufferType::L1,
+  addConfigForOp(op, legalConfigs, BufferType::L1,
                  TensorMemoryLayout::WidthSharded, 1, 8);
-  addLayoutForOp(op, legalLayouts, BufferType::L1,
+  addConfigForOp(op, legalConfigs, BufferType::L1,
                  TensorMemoryLayout::HeightSharded, 4, 1);
-  addLayoutForOp(op, legalLayouts, BufferType::L1,
+  addConfigForOp(op, legalConfigs, BufferType::L1,
                  TensorMemoryLayout::BlockSharded, 2, 2);
 
   lhs = func.getBody().getBlocks().front().getArgument(0);
@@ -185,67 +185,67 @@ TEST_F(ShardSolverBase, VerifyProduceMaxCoreUsage) {
 
   op = builder.create<AddOp>(builder.getUnknownLoc(), lhs, rhs, lhs.getType());
   prepareOpForShardSolver(op, opL1MemSpecs, l1ChainedOps);
-  addLayoutForOp(op, legalLayouts, BufferType::L1,
+  addConfigForOp(op, legalConfigs, BufferType::L1,
                  TensorMemoryLayout::WidthSharded, 1, 4);
-  addLayoutForOp(op, legalLayouts, BufferType::L1,
+  addConfigForOp(op, legalConfigs, BufferType::L1,
                  TensorMemoryLayout::HeightSharded, 4, 1);
-  addLayoutForOp(op, legalLayouts, BufferType::L1,
+  addConfigForOp(op, legalConfigs, BufferType::L1,
                  TensorMemoryLayout::BlockSharded, 1, 1);
 
   op = builder.create<AddOp>(builder.getUnknownLoc(), lhs, rhs, lhs.getType());
   prepareOpForShardSolver(op, opL1MemSpecs, l1ChainedOps);
-  addLayoutForOp(op, legalLayouts, BufferType::L1,
+  addConfigForOp(op, legalConfigs, BufferType::L1,
                  TensorMemoryLayout::WidthSharded, 1, 4);
-  addLayoutForOp(op, legalLayouts, BufferType::L1,
+  addConfigForOp(op, legalConfigs, BufferType::L1,
                  TensorMemoryLayout::HeightSharded, 4, 1);
-  addLayoutForOp(op, legalLayouts, BufferType::L1,
+  addConfigForOp(op, legalConfigs, BufferType::L1,
                  TensorMemoryLayout::BlockSharded, 1, 1);
 
   lhs = opL1MemSpecs[opL1MemSpecs.size() - 2].op->getResult(0);
   rhs = opL1MemSpecs[opL1MemSpecs.size() - 1].op->getResult(0);
   op = builder.create<AddOp>(builder.getUnknownLoc(), lhs, rhs, lhs.getType());
   prepareOpForShardSolver(op, opL1MemSpecs, l1ChainedOps);
-  addLayoutForOp(op, legalLayouts, BufferType::L1,
+  addConfigForOp(op, legalConfigs, BufferType::L1,
                  TensorMemoryLayout::WidthSharded, 1, 2);
-  addLayoutForOp(op, legalLayouts, BufferType::L1,
+  addConfigForOp(op, legalConfigs, BufferType::L1,
                  TensorMemoryLayout::HeightSharded, 1, 1);
-  addLayoutForOp(op, legalLayouts, BufferType::L1,
+  addConfigForOp(op, legalConfigs, BufferType::L1,
                  TensorMemoryLayout::BlockSharded, 1, 1);
 
   rhs = op->getResult(0);
   op = builder.create<ReluOp>(builder.getUnknownLoc(), rhs);
   prepareOpForShardSolver(op, opL1MemSpecs, l1ChainedOps);
-  addLayoutForOp(op, legalLayouts, BufferType::L1,
+  addConfigForOp(op, legalConfigs, BufferType::L1,
                  TensorMemoryLayout::WidthSharded, 1, 2);
-  addLayoutForOp(op, legalLayouts, BufferType::L1,
+  addConfigForOp(op, legalConfigs, BufferType::L1,
                  TensorMemoryLayout::HeightSharded, 1, 1);
-  addLayoutForOp(op, legalLayouts, BufferType::L1,
+  addConfigForOp(op, legalConfigs, BufferType::L1,
                  TensorMemoryLayout::BlockSharded, 1, 1);
 
   // Create custom checkShardCompatible function.
   //
   std::function<bool(mlir::Value, TTNNLayoutAttr const &, mlir::Operation *,
-                     TTNNLayoutAttr const &)>
-      checkShardCompatible = [](mlir::Value producerOperand,
-                                TTNNLayoutAttr const &producerLayout,
-                                mlir::Operation *consumerOp,
-                                TTNNLayoutAttr const &consumerLayout) {
-        // Interleaved to sharded is always supported.
-        //
-        if (producerLayout.hasInterleavedDRAMTensorMemoryLayout()) {
-          return true;
-        }
+                     OpConfig const &)>
+      checkShardCompatible =
+          [](mlir::Value producerOperand, TTNNLayoutAttr const &producerLayout,
+             mlir::Operation *consumerOp, OpConfig const &consumerConfig) {
+            // Interleaved to sharded is always supported.
+            //
+            if (producerLayout.hasInterleavedDRAMTensorMemoryLayout()) {
+              return true;
+            }
 
-        // Simple shard compat assumption. Try to keep same shard layout.
-        //
-        if (producerLayout.getMemLayout() != consumerLayout.getMemLayout()) {
-          return false;
-        }
+            // Simple shard compat assumption. Try to keep same shard layout.
+            //
+            if (producerLayout.getMemLayout() !=
+                consumerConfig.outputLayout.getMemLayout()) {
+              return false;
+            }
 
-        return true;
-      };
+            return true;
+          };
 
-  ShardSolver shardSolver(legalLayouts, opL1MemSpecs, l1ChainedOps,
+  ShardSolver shardSolver(legalConfigs, opL1MemSpecs, l1ChainedOps,
                           usableL1CacheSize, overrideReshardEdges,
                           checkShardCompatible);
 
@@ -263,17 +263,17 @@ TEST_F(ShardSolverBase, VerifyProduceMaxCoreUsage) {
   // ops should lead to accMaxCoreUsage[firstOp][0] total core usage.
   //
   for (auto &opL1MemSpec : opL1MemSpecs) {
-    ShardSolver::RemainingLayoutAttrs validLayouts =
+    ShardSolver::RemainingConfigAttrs validLayouts =
         shardSolver.at(opL1MemSpec.op);
-    const TTNNLayoutAttr *selectedLayout = validLayouts.begin().get();
-    shardSolver.set(opL1MemSpec.op, *selectedLayout);
+    const OpConfig *selectedConfig = validLayouts.begin().get();
+    shardSolver.set(opL1MemSpec.op, *selectedConfig);
   }
 
-  llvm::DenseMap<mlir::Operation *, TTNNLayoutAttr> selectedOpLayout =
-      shardSolver.finish().selectedOpLayout;
+  llvm::DenseMap<mlir::Operation *, OpConfig> selectedOpConfig =
+      shardSolver.finish().selectedOpConfig;
   float totalCoreUsage = 0;
-  for (const auto &opLayout : selectedOpLayout) {
-    totalCoreUsage += opLayout.second.getGrid().getGridVolume();
+  for (const auto &opLayout : selectedOpConfig) {
+    totalCoreUsage += opLayout.second.outputLayout.getGrid().getGridVolume();
   }
 
   ASSERT_EQ(totalCoreUsage, accMaxCoreUsage[firstOp][0]);


### PR DESCRIPTION
### Problem description
Up to now optimizer only changes op output layout. In order to get max performance out of an op we need to control it's "config" as well (e.g. Conv2dConfig, MatmulProgramConfig...)

### What's changed
Provide boilerplate needed to start using op configs in Optimizer (for overrides and automatic config picking).
* Add OpConfig as struct that covers both output layout and op specific configurations
* Change all optimizer analysis to use OpConfig instead of just output layout
* All configs are still null

### Checklist
- [x] New/Existing tests provide coverage for changes
