### PR TITLE
Uplift third_party/tt-metal to bf1298a3e4a3b92dfeae7842f4769826ffa87194 2025-03-13

### DIFF
--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecompositionPass.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecompositionPass.cpp
@@ -59,9 +59,8 @@ struct TTIRToTTIRDecompositionPass
     // These are the ops that must satisfy some conditions after this pass
     target.addDynamicallyLegalOp<ttir::ArangeOp>([&](ttir::ArangeOp op) {
       auto shape = op.getResult().getType().getShape();
-      return (static_cast<int64_t>(op.getArangeDimension()) == 3 &&
-              shape.size() == 4 && shape[0] == 1 && shape[1] == 1 &&
-              shape[2] == 1);
+      return (static_cast<int64_t>(op.getArangeDimension()) == 0 &&
+              shape.size() == 1);
     });
 
     target.addDynamicallyLegalOp<ttir::ArgMaxOp>(

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -507,7 +507,7 @@ namespace mlir::tt::ttnn {
            << getStart() << ", end=" << getEnd() << ", step=" << getStep();
   }
 
-  std::vector<int64_t> expectedShape = {1, 1, 1, numValues};
+  std::vector<int64_t> expectedShape = {numValues};
   if (getType().getShape().vec() != expectedShape) {
     return emitOpError() << "Output tensor shape must be " << expectedShape
                          << ", but got " << getType().getShape();

--- a/lib/OpModel/TTNN/MetalHeaders.h
+++ b/lib/OpModel/TTNN/MetalHeaders.h
@@ -61,6 +61,9 @@
 // using namespace removed in metal
 // but IDevice cannot be resolved by "ttnn/graph/graph_query_op_constraints.hpp"
 using IDevice = ::tt::tt_metal::IDevice;
+// allocator header include required by
+// "ttnn/graph/graph_query_op_constraints.hpp"
+#include "tt-metalium/allocator.hpp"
 #include "ttnn/graph/graph_query_op_constraints.hpp"
 #include "ttnn/graph/graph_query_op_runtime.hpp"
 #include "ttnn/graph/graph_trace_utils.hpp"

--- a/lib/OpModel/TTNN/SingletonDeviceContext.h
+++ b/lib/OpModel/TTNN/SingletonDeviceContext.h
@@ -11,9 +11,7 @@
 
 namespace tt {
 namespace tt_metal {
-inline namespace v0 {
 class IDevice;
-} // namespace v0
 } // namespace tt_metal
 } // namespace tt
 
@@ -30,7 +28,7 @@ class SingletonDeviceContext {
 public:
   static SingletonDeviceContext &getInstance();
 
-  ::tt::tt_metal::v0::IDevice *getDevice() { return m_device; }
+  ::tt::tt_metal::IDevice *getDevice() { return m_device; }
 
 private:
   SingletonDeviceContext(

--- a/lib/OpModel/TTNN/TTNNOpModelLib.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModelLib.cpp
@@ -162,7 +162,7 @@ template <typename... Args,
                               std::tuple<::llvm::ArrayRef<int64_t>,
                                          ::mlir::tt::ttnn::TTNNLayoutAttr>> &&
                ...)>>
-auto convertToTensorSpec(::tt::tt_metal::v0::IDevice *device, Args... args) {
+auto convertToTensorSpec(::tt::tt_metal::IDevice *device, Args... args) {
   auto transformArg = [device](auto &&arg) {
     const ::ttnn::TensorSpec spec =
         conversion::getTensorSpec(std::get<0>(arg), std::get<1>(arg));
@@ -215,7 +215,7 @@ getEltwiseBinaryOpConstraints(std::string_view opName, OpSymbol opSymbol,
                    mlir::tt::ttnn::TTNNLayoutAttr bLayout,
                    llvm::ArrayRef<int64_t> outShape,
                    mlir::tt::ttnn::TTNNLayoutAttr outLayout) {
-    ::tt::tt_metal::v0::IDevice *device =
+    ::tt::tt_metal::IDevice *device =
         SingletonDeviceContext::getInstance().getDevice();
     const auto [inputSpecA, inputSpecB, outputSpec] =
         detail::convertToTensorSpec(device, std::make_tuple(aShape, aLayout),
@@ -247,7 +247,7 @@ getEltwiseBinaryOpRuntime(std::string_view opName, OpSymbol opSymbol,
                    mlir::tt::ttnn::TTNNLayoutAttr bLayout,
                    llvm::ArrayRef<int64_t> outShape,
                    mlir::tt::ttnn::TTNNLayoutAttr outLayout) {
-    ::tt::tt_metal::v0::IDevice *device =
+    ::tt::tt_metal::IDevice *device =
         SingletonDeviceContext::getInstance().getDevice();
     const auto [inputSpecA, inputSpecB, outputSpec] =
         detail::convertToTensorSpec(device, std::make_tuple(aShape, aLayout),
@@ -279,7 +279,7 @@ ReluOpInterface::getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                         llvm::ArrayRef<int64_t> outputShape,
                         mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
     // open device device, will close it at the end of function
-    ::tt::tt_metal::v0::IDevice *device =
+    ::tt::tt_metal::IDevice *device =
         SingletonDeviceContext::getInstance().getDevice();
 
     // prepare io specs
@@ -311,7 +311,7 @@ ReluOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                         llvm::ArrayRef<int64_t> outputShape,
                         mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
     // open device device, will close it at the end of function
-    ::tt::tt_metal::v0::IDevice *device =
+    ::tt::tt_metal::IDevice *device =
         SingletonDeviceContext::getInstance().getDevice();
 
     // prepare io specs
@@ -382,7 +382,7 @@ SoftmaxOpInterface::getOpConstraints(
                            llvm::ArrayRef<int64_t> outputShape,
                            mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
     // open device device, will close it at the end of function
-    ::tt::tt_metal::v0::IDevice *device =
+    ::tt::tt_metal::IDevice *device =
         SingletonDeviceContext::getInstance().getDevice();
 
     // prepare io specs
@@ -417,7 +417,7 @@ SoftmaxOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                            llvm::ArrayRef<int64_t> outputShape,
                            mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
     // open device device, will close it at the end of function
-    ::tt::tt_metal::v0::IDevice *device =
+    ::tt::tt_metal::IDevice *device =
         SingletonDeviceContext::getInstance().getDevice();
 
     // prepare io specs
@@ -454,7 +454,7 @@ MeanOpInterface::getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                         bool keepDim,
                         mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
     // open device device, will close it at the end of function
-    ::tt::tt_metal::v0::IDevice *device =
+    ::tt::tt_metal::IDevice *device =
         SingletonDeviceContext::getInstance().getDevice();
 
     // prepare io specs
@@ -495,7 +495,7 @@ MeanOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                         bool keepDim,
                         mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
     // open device device, will close it at the end of function
-    ::tt::tt_metal::v0::IDevice *device =
+    ::tt::tt_metal::IDevice *device =
         SingletonDeviceContext::getInstance().getDevice();
 
     // prepare io specs
@@ -538,7 +538,7 @@ ReshapeOpInterface::getOpConstraints(
                            llvm::ArrayRef<int64_t> outputShape,
                            mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
     // open device device, will close it at the end of function
-    ::tt::tt_metal::v0::IDevice *device =
+    ::tt::tt_metal::IDevice *device =
         SingletonDeviceContext::getInstance().getDevice();
 
     // prepare io specs
@@ -571,7 +571,7 @@ ReshapeOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                            llvm::ArrayRef<int64_t> outputShape,
                            mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
     // open device device, will close it at the end of function
-    ::tt::tt_metal::v0::IDevice *device =
+    ::tt::tt_metal::IDevice *device =
         SingletonDeviceContext::getInstance().getDevice();
 
     // prepare io specs
@@ -608,7 +608,7 @@ TypecastOpInterface::getOpConstraints(
                             llvm::ArrayRef<int64_t> outputShape,
                             mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
     // open device device, will close it at the end of function
-    ::tt::tt_metal::v0::IDevice *device =
+    ::tt::tt_metal::IDevice *device =
         SingletonDeviceContext::getInstance().getDevice();
 
     // prepare io specs
@@ -644,7 +644,7 @@ TypecastOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                             llvm::ArrayRef<int64_t> outputShape,
                             mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
     // open device device, will close it at the end of function
-    ::tt::tt_metal::v0::IDevice *device =
+    ::tt::tt_metal::IDevice *device =
         SingletonDeviceContext::getInstance().getDevice();
 
     // prepare io specs
@@ -682,7 +682,7 @@ ToLayoutOpInterface::getOpConstraints(
                             mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
                             bool passDevicePtr) {
     // open device device, will close it at the end of function
-    ::tt::tt_metal::v0::IDevice *device =
+    ::tt::tt_metal::IDevice *device =
         SingletonDeviceContext::getInstance().getDevice();
 
     // prepare io specs
@@ -726,7 +726,7 @@ ToLayoutOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                             mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
                             bool passDevicePtr) {
     // open device device, will close it at the end of function
-    ::tt::tt_metal::v0::IDevice *device =
+    ::tt::tt_metal::IDevice *device =
         SingletonDeviceContext::getInstance().getDevice();
 
     // prepare io specs
@@ -771,7 +771,7 @@ TransposeOpInterface::getOpConstraints(
                              const int dim0, const int dim1,
                              mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
     // open device device, will close it at the end of function
-    ::tt::tt_metal::v0::IDevice *device =
+    ::tt::tt_metal::IDevice *device =
         SingletonDeviceContext::getInstance().getDevice();
 
     // prepare io specs
@@ -802,7 +802,7 @@ llvm::Expected<size_t> TransposeOpInterface::getOpRuntime(
                              const int dim0, const int dim1,
                              mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
     // open device device, will close it at the end of function
-    ::tt::tt_metal::v0::IDevice *device =
+    ::tt::tt_metal::IDevice *device =
         SingletonDeviceContext::getInstance().getDevice();
 
     // prepare io specs
@@ -842,7 +842,7 @@ MatmulOpInterface::getOpConstraints(llvm::ArrayRef<int64_t> inputShapeA,
                           mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
                           bool transposeA, bool transposeB) {
     // open device device, will close it at the end of function
-    ::tt::tt_metal::v0::IDevice *device =
+    ::tt::tt_metal::IDevice *device =
         SingletonDeviceContext::getInstance().getDevice();
 
     // prepare io specs
@@ -884,7 +884,7 @@ MatmulOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
                           mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
                           bool transposeA, bool transposeB) {
     // open device device, will close it at the end of function
-    ::tt::tt_metal::v0::IDevice *device =
+    ::tt::tt_metal::IDevice *device =
         SingletonDeviceContext::getInstance().getDevice();
 
     // prepare io specs

--- a/runtime/lib/common/system_desc.cpp
+++ b/runtime/lib/common/system_desc.cpp
@@ -15,6 +15,7 @@
 #include "eth_l1_address_map.h"
 #include "hostdevcommon/common_values.hpp"
 #include "noc/noc_parameters.h"
+#include "tt-metalium/allocator.hpp"
 #include "tt-metalium/host_api.hpp"
 #include "tt-metalium/mesh_device.hpp"
 

--- a/runtime/lib/ttnn/operations/data_movement/pad.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/pad.cpp
@@ -3,12 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "operations/data_movement/pad.h"
-#include "tt-metalium/span.hpp"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/ttnn/debug_apis.h"
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/ttnn/utils.h"
 #include "tt/runtime/workarounds.h"
+#include "tt_stl/span.hpp"
 
 #include <optional>
 

--- a/runtime/test/ttnn/dylib.cpp
+++ b/runtime/test/ttnn/dylib.cpp
@@ -16,7 +16,7 @@ namespace tt::runtime::ttnn::test {
 
 static constexpr const char *POTENTIAL_MANGLING_ADDITIONS[] = {
     "",
-    "PNS1_2v07IDeviceE",
+    "PNS1_7IDeviceE",
 };
 
 void *openSo(std::string path) {

--- a/test/ttmlir/Decomposition/TTIR/arange/arange_tests_positive.mlir
+++ b/test/ttmlir/Decomposition/TTIR/arange/arange_tests_positive.mlir
@@ -2,12 +2,11 @@
 module attributes {} {
   func.func @forward(%arg0: tensor<1x32x128x128xf32>) -> tensor<1x32x128x128xf32> {
     // CHECK: %[[ARANGE:[0-9]+]] = "ttir.arange"
-    // CHECK-SAME: {arange_dimension = 3 : i64, end = 32 : si64, start = 0 : si64, step = 1 : si64}
-    // CHECK-SAME: -> tensor<1x1x1x32xf32>
-    // CHECK: %[[TRANSPOSE:[0-9]+]] = "ttir.transpose"(%[[ARANGE]],
-    // CHECK-SAME: {dim0 = 1 : si32, dim1 = 3 : si32}>
-    // CHECK-SAME: (tensor<1x1x1x32xf32>, tensor<1x32x1x1xf32>) -> tensor<1x32x1x1xf32>
-    // CHECK: %[[BROADCAST:[0-9]+]] = "ttir.broadcast"(%[[TRANSPOSE]],
+    // CHECK-SAME: {arange_dimension = 0 : i64, end = 32 : si64, start = 0 : si64, step = 1 : si64}
+    // CHECK-SAME: -> tensor<32xf32>
+    // CHECK: %[[RESHAPE:[0-9]+]] = "ttir.reshape"(%[[ARANGE]],
+    // CHECK-SAME: (tensor<32xf32>, tensor<1x32x1x1xf32>) -> tensor<1x32x1x1xf32>
+    // CHECK: %[[BROADCAST:[0-9]+]] = "ttir.broadcast"(%[[RESHAPE]],
     // CHECK-SAME: broadcast_dimensions = array<i64: 1, 1, 128, 128>
     // CHECK-SAME: (tensor<1x32x1x1xf32>, tensor<1x32x128x128xf32>) -> tensor<1x32x128x128xf32>
     %1 = "ttir.arange"() <{start = 0: si64, end = 32: si64, step = 1: si64, arange_dimension = 1: i64}> : () -> tensor<1x32x128x128xf32>

--- a/test/ttmlir/Dialect/TTIR/Decomposition/arange_decomposition.mlir
+++ b/test/ttmlir/Dialect/TTIR/Decomposition/arange_decomposition.mlir
@@ -2,7 +2,6 @@
 module attributes {} {
   func.func @forward(%arg0: tensor<1x32x128x128xf32>) -> tensor<1x32x128x128xf32> {
     // CHECK: = "ttir.arange"
-    // CHECK: = "ttir.transpose"
     // CHECK: = "ttir.broadcast"
     %1 = "ttir.arange"() <{start = 0: si64, end = 32: si64, step = 1: si64, arange_dimension = 1: i64}> : () -> tensor<1x32x128x128xf32>
     return %1 : tensor<1x32x128x128xf32>

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "cd5cf40ccce9dd9e13fa00bc412df22566816edb")
+set(TT_METAL_VERSION "bf1298a3e4a3b92dfeae7842f4769826ffa87194")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -34,7 +34,7 @@ set(TTMETAL_INCLUDE_DIRS
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/umd/src/firmware/riscv/${ARCH_NAME}
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/tracy/public
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/taskflow
-  ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/tt_stl
+  ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_stl
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_eager
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal-build/include
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/reflect/e75434c4c5f669e4a74e4d84e0a30d7249c1e66f

--- a/tools/ttnn-standalone/CMakeLists.txt
+++ b/tools/ttnn-standalone/CMakeLists.txt
@@ -72,7 +72,7 @@ set(INCLUDE_DIRS
     $ENV{TT_METAL_HOME}/tt_metal/hw/inc/${ARCH_EXTRA_DIR}
     $ENV{TT_METAL_HOME}/tt_metal/hw/inc/${ARCH_NAME}
     $ENV{TT_METAL_HOME}/tt_metal/include
-    $ENV{TT_METAL_HOME}/tt_metal/tt_stl
+    $ENV{TT_METAL_HOME}/tt_stl
     $ENV{TT_METAL_HOME}/tt_metal/third_party/fmt
     $ENV{TT_METAL_HOME}/tt_metal/third_party/magic_enum
     $ENV{TT_METAL_HOME}/tt_metal/third_party/taskflow


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the bf1298a3e4a3b92dfeae7842f4769826ffa87194

- Update path of tt_stl after metal commit c9dec81
- Include allocator header after transitive includes removed in metal commit c913e48
- Remove reference to v0 namespace after namespace removed in metal commit a9328e6
- Modify ArangeForceLastDimensionPattern to ensure that the output shape is 1D after metal commit 43047b1b26
- Ignore IDevice mangled name