### PR TITLE
Uplift third_party/tt-metal to 95e4842659459bdf01c7b961706d0c943f2d5e4d 2025-03-14

### DIFF
--- a/runtime/lib/ttmetal/command_queue.cpp
+++ b/runtime/lib/ttmetal/command_queue.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <unordered_map>
 
+#include "tracy/Tracy.hpp"
 #include "tt/runtime/detail/debug.h"
 #include "tt/runtime/detail/ttmetal.h"
 #include "tt/runtime/runtime.h"

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -4,6 +4,7 @@
 
 #include <variant>
 
+#include "tracy/Tracy.hpp"
 #include "tt/runtime/detail/common.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttmetal.h"

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "bf1298a3e4a3b92dfeae7842f4769826ffa87194")
+set(TT_METAL_VERSION "95e4842659459bdf01c7b961706d0c943f2d5e4d")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 95e4842659459bdf01c7b961706d0c943f2d5e4d

- Include tracy header after transitive include from metal removed in commit 2725392