### PR TITLE
Added strict rt_args parameter + tuple assignment

### DIFF
--- a/test/pykernel/add_2_integers_in_compute/reader_binary_1_tile.py
+++ b/test/pykernel/add_2_integers_in_compute/reader_binary_1_tile.py
@@ -10,11 +10,8 @@ from pykernel.types import *
 
 
 @ttkernel_noc_compile()
-def reader_binary_1_tile(cb_in0: CircularBuffer, cb_in1: CircularBuffer):
-    src0_addr = get_arg_val(int, 0)
-    src1_addr = get_arg_val(int, 1)
-    src0_bank_id = get_arg_val(int, 2)
-    src1_bank_id = get_arg_val(int, 3)
+def reader_binary_1_tile(cb_in0: CircularBuffer, cb_in1: CircularBuffer, rt_args):
+    src0_addr, src1_addr, src0_bank_id, src1_bank_id = rt_args[:4]
 
     src0_noc_addr = get_noc_addr_from_bank_id(src0_bank_id, src0_addr)
     src1_noc_addr = get_noc_addr_from_bank_id(src1_bank_id, src1_addr)

--- a/test/pykernel/add_2_integers_in_compute/writer_1_tile.py
+++ b/test/pykernel/add_2_integers_in_compute/writer_1_tile.py
@@ -10,9 +10,9 @@ from pykernel.types import *
 
 
 @ttkernel_noc_compile()
-def write_1_tile(cb_out: CircularBuffer):
-    dst_addr = get_arg_val(int, 0)
-    dst_bank_id = get_arg_val(int, 1)
+def write_1_tile(cb_out: CircularBuffer, rt_args):
+    dst_addr = rt_args[0]
+    dst_bank_id = rt_args[1]
 
     dst_noc_addr = get_noc_addr_from_bank_id(dst_bank_id, dst_addr)
 

--- a/test/pykernel/eltwise_sfpu/reader_unary.py
+++ b/test/pykernel/eltwise_sfpu/reader_unary.py
@@ -10,16 +10,15 @@ from pykernel.types import *
 
 
 @ttkernel_noc_compile()
-def reader_unary(cb_in: CircularBuffer, cb_out: CircularBuffer):
+def reader_unary(cb_in: CircularBuffer, cb_out: CircularBuffer, rt_args):
     # CHECK: module {
     # CHECK: func.func @{{.*}}(%arg0: !ttkernel.cb<{{.*}}>, %arg1: !ttkernel.cb<{{.*}}>) {
     # CHECK: {{.*}}"ttkernel.get_arg_val"{{.*}}
     # CHECK: %[[SRC_ADDR:.*]] = memref.alloca(){{.*}}
     # CHECK: {{.*}}"ttkernel.get_arg_val"{{.*}}
     # CHECK: {{.*}}"ttkernel.get_arg_val"{{.*}}
-    src_addr: int = get_arg_val(int, 0)
-    bank_id = get_arg_val(int, 1)
-    num_tiles = get_arg_val(int, 2)
+    src_addr: int = rt_args[0]
+    bank_id, num_tiles = rt_args[1:3]
 
     # CHECK: {{.*}}"ttkernel.get_tile_size"{{.*}}
     ublock_size_tiles = 1

--- a/test/pykernel/eltwise_sfpu/writer_unary.py
+++ b/test/pykernel/eltwise_sfpu/writer_unary.py
@@ -10,16 +10,16 @@ from pykernel.types import *
 
 
 @ttkernel_noc_compile()
-def writer_unary(cb_in: CircularBuffer, cb_out: CircularBuffer):
+def writer_unary(cb_in: CircularBuffer, cb_out: CircularBuffer, rt_args):
     # CHECK: module {
     # CHECK: func.func @{{.*}}(%arg0: !ttkernel.cb<{{.*}}>, %arg1: !ttkernel.cb<{{.*}}>) {
     # CHECK: {{.*}}"ttkernel.get_arg_val"{{.*}}
     # CHECK: %[[DST_ADDR:.*]] = memref.alloca(){{.*}}
     # CHECK: %[[BANK_ID:.*]] = "ttkernel.get_arg_val"{{.*}}
     # CHECK: {{.*}}"ttkernel.get_arg_val"{{.*}}
-    dst_addr: int = get_arg_val(int, 0)
-    bank_id = get_arg_val(int, 1)
-    num_tiles = get_arg_val(int, 2)
+    dst_addr: int = rt_args[0]
+    bank_id = rt_args[1]
+    num_tiles = rt_args[2]
 
     # CHECK: {{.*}}"ttkernel.get_tile_size"{{.*}}
     ublock_size_bytes = get_tile_size(cb_out)

--- a/test/pykernel/matmul_common/reader_bmm_8bank.py
+++ b/test/pykernel/matmul_common/reader_bmm_8bank.py
@@ -10,14 +10,9 @@ from pykernel.types import *
 
 
 @ttkernel_noc_compile()
-def reader_bmm_8bank(cb_id_in0: CircularBuffer, cb_id_in1: CircularBuffer):
-    src0_addr = get_arg_val(int, 0)
-    src1_addr = get_arg_val(int, 1)
-    Mt = get_arg_val(int, 2)
-    Kt = get_arg_val(int, 3)
-    Nt = get_arg_val(int, 4)
-    MtKt = get_arg_val(int, 5)
-    KtNt = get_arg_val(int, 6)
+def reader_bmm_8bank(cb_id_in0: CircularBuffer, cb_id_in1: CircularBuffer, rt_args):
+    src0_addr, src1_addr = rt_args[:2]
+    Mt, Kt, Nt, MtKt, KtNt = rt_args[2:7]
     batch = get_arg_val(int, 7)
     bcast_B = get_arg_val(int, 8)
 

--- a/test/pykernel/matmul_common/reader_bmm_8bank_output_tiles_partitioned.py
+++ b/test/pykernel/matmul_common/reader_bmm_8bank_output_tiles_partitioned.py
@@ -11,15 +11,10 @@ from pykernel.types import *
 
 @ttkernel_noc_compile()
 def reader_bmm_8bank_output_tiles_partitioned(
-    cb_id_in0: CircularBuffer, cb_id_in1: CircularBuffer
+    cb_id_in0: CircularBuffer, cb_id_in1: CircularBuffer, rt_args
 ):
-    src0_addr = get_arg_val(int, 0)
-    src1_addr = get_arg_val(int, 1)
-    Mt = get_arg_val(int, 2)
-    Kt = get_arg_val(int, 3)
-    Nt = get_arg_val(int, 4)
-    MtKt = get_arg_val(int, 5)
-    KtNt = get_arg_val(int, 6)
+    src0_addr, src1_addr = rt_args[:2]
+    Mt, Kt, Nt, MtKt, KtNt = rt_args[2:7]
     batch = get_arg_val(int, 7)
     bcast_B = get_arg_val(int, 8)
     output_tile_start_id = get_arg_val(int, 9)


### PR DESCRIPTION
### Ticket
- PR closes #2474 

### Problem description
- Used `get_arg_val` calls which may seem out of place / unpythonic.

### What's changed
- Added strict `rt_args` parameter, if added into FunctionDef you can use it to access `get_arg_val` calls.
- Supports tuple assignment (ex: `a, b = rt_args[:2]`). More pythonic invocation methods.
- Modified tests to include a combination of `rt_arg`/`get_arg_val` calls to demonstrate that it gets lowered to the same thing.
- Added some comments on logical assumptions made for this functionality.
