### PR TITLE
Runtime and EmitC tensor mismatch error reporting

### DIFF
--- a/runtime/test/ttnn/dylib.cpp
+++ b/runtime/test/ttnn/dylib.cpp
@@ -168,9 +168,6 @@ bool compareOuts(std::vector<Tensor> &lhs, std::vector<Tensor> &rhs) {
     LOG_ASSERT(lhsTensor->get_logical_shape() == rhsTensor->get_logical_shape(),
                "Logical shape: ", lhsTensor->get_logical_shape(), ", ",
                rhsTensor->get_logical_shape());
-    LOG_ASSERT(lhsTensor->element_size() == rhsTensor->element_size(),
-               "Element size in bytes: ", lhsTensor->element_size(), ", ",
-               rhsTensor->element_size());
 
     // Compare tensor data
     //

--- a/runtime/test/ttnn/dylib.cpp
+++ b/runtime/test/ttnn/dylib.cpp
@@ -143,7 +143,7 @@ static std::string toString(SupportedTypes &v) {
 // Compare two values of the same type for equality. We compare byte by byte, so
 // that even special values are compared correctly.
 //
-bool areEqual(const SupportedTypes &lhs, const SupportedTypes &rhs) {
+static bool areEqual(const SupportedTypes &lhs, const SupportedTypes &rhs) {
   size_t size = std::visit(
       [&](const auto &val) {
         using T = std::decay_t<decltype(val)>;
@@ -159,11 +159,11 @@ bool areEqual(const SupportedTypes &lhs, const SupportedTypes &rhs) {
   return true;
 }
 
-bool operator==(const SupportedTypes &lhs, const SupportedTypes &rhs) {
+static bool operator==(const SupportedTypes &lhs, const SupportedTypes &rhs) {
   return areEqual(lhs, rhs);
 }
 
-bool operator!=(const SupportedTypes &lhs, const SupportedTypes &rhs) {
+static bool operator!=(const SupportedTypes &lhs, const SupportedTypes &rhs) {
   return !(lhs == rhs);
 }
 
@@ -184,7 +184,7 @@ IndexTy getIndex(const ::ttnn::Shape &shape, size_t idx) {
   return result;
 }
 
-std::string toString(const IndexTy &v) {
+static std::string toString(const IndexTy &v) {
   std::string result = "[";
   for (size_t i = 0; i < v.size(); i++) {
     result += std::to_string(v[i]);
@@ -216,10 +216,8 @@ bool compareOuts(std::vector<Tensor> &lhs, std::vector<Tensor> &rhs) {
 
     // Compare various tensor properties
     //
-    // NOLINTBEGIN
     LOG_ASSERT(lhsTensor->get_dtype() == rhsTensor->get_dtype(),
                "DType: ", lhsTensor->get_dtype(), ", ", rhsTensor->get_dtype());
-    // NOLINTEND
     LOG_ASSERT(lhsTensor->get_layout() == rhsTensor->get_layout(),
                "Layout: ", static_cast<int>(lhsTensor->get_layout()), ", ",
                static_cast<int>(rhsTensor->get_layout()));

--- a/runtime/test/ttnn/dylib.cpp
+++ b/runtime/test/ttnn/dylib.cpp
@@ -169,10 +169,10 @@ bool operator!=(const SupportedTypes &lhs, const SupportedTypes &rhs) {
 
 using IndexTy = std::vector<size_t>;
 
-IndexTy getIndex(const ::ttnn::Shape &shape, size_t index) {
+IndexTy getIndex(const ::ttnn::Shape &shape, size_t idx) {
   IndexTy result(shape.size());
 
-  size_t remaining = index;
+  size_t remaining = idx;
   size_t stride = 1;
 
   assert(shape.size() > 0 && "Shape must have at least one dimension");

--- a/runtime/test/ttnn/dylib.cpp
+++ b/runtime/test/ttnn/dylib.cpp
@@ -168,8 +168,6 @@ bool compareOuts(std::vector<Tensor> &lhs, std::vector<Tensor> &rhs) {
     LOG_ASSERT(lhsTensor->get_logical_shape() == rhsTensor->get_logical_shape(),
                "Logical shape: ", lhsTensor->get_logical_shape(), ", ",
                rhsTensor->get_logical_shape());
-    LOG_ASSERT(lhsTensor->volume() == rhsTensor->volume(),
-               "Volume: ", lhsTensor->volume(), ", ", rhsTensor->volume());
     LOG_ASSERT(lhsTensor->element_size() == rhsTensor->element_size(),
                "Element size in bytes: ", lhsTensor->element_size(), ", ",
                rhsTensor->element_size());

--- a/runtime/test/ttnn/dylib.cpp
+++ b/runtime/test/ttnn/dylib.cpp
@@ -163,9 +163,6 @@ bool compareOuts(std::vector<Tensor> &lhs, std::vector<Tensor> &rhs) {
     LOG_ASSERT(lhsTensor->get_dtype() == rhsTensor->get_dtype(),
                "DType: ", static_cast<int>(lhsTensor->get_dtype()), ", ",
                static_cast<int>(rhsTensor->get_dtype()));
-    LOG_ASSERT(lhsTensor->get_logical_shape() == rhsTensor->get_logical_shape(),
-               "Shape: ", lhsTensor->get_logical_shape(), ", ",
-               rhsTensor->get_logical_shape());
     LOG_ASSERT(lhsTensor->get_layout() == rhsTensor->get_layout(),
                "Layout: ", static_cast<int>(lhsTensor->get_layout()), ", ",
                static_cast<int>(rhsTensor->get_layout()));

--- a/runtime/test/ttnn/dylib.cpp
+++ b/runtime/test/ttnn/dylib.cpp
@@ -10,7 +10,6 @@
 #include "tt/runtime/ttnn/utils.h"
 #include "tt/runtime/types.h"
 
-#include <cstddef>
 #include <dlfcn.h>
 
 namespace tt::runtime::ttnn::test {
@@ -217,8 +216,10 @@ bool compareOuts(std::vector<Tensor> &lhs, std::vector<Tensor> &rhs) {
 
     // Compare various tensor properties
     //
+    // NOLINTBEGIN
     LOG_ASSERT(lhsTensor->get_dtype() == rhsTensor->get_dtype(),
                "DType: ", lhsTensor->get_dtype(), ", ", rhsTensor->get_dtype());
+    // NOLINTEND
     LOG_ASSERT(lhsTensor->get_layout() == rhsTensor->get_layout(),
                "Layout: ", static_cast<int>(lhsTensor->get_layout()), ", ",
                static_cast<int>(rhsTensor->get_layout()));

--- a/runtime/test/ttnn/dylib.cpp
+++ b/runtime/test/ttnn/dylib.cpp
@@ -161,8 +161,7 @@ bool compareOuts(std::vector<Tensor> &lhs, std::vector<Tensor> &rhs) {
     // Compare various tensor properties
     //
     LOG_ASSERT(lhsTensor->get_dtype() == rhsTensor->get_dtype(),
-               "DType: ", static_cast<int>(lhsTensor->get_dtype()), ", ",
-               static_cast<int>(rhsTensor->get_dtype()));
+               "DType: ", lhsTensor->get_dtype(), ", ", rhsTensor->get_dtype());
     LOG_ASSERT(lhsTensor->get_layout() == rhsTensor->get_layout(),
                "Layout: ", static_cast<int>(lhsTensor->get_layout()), ", ",
                static_cast<int>(rhsTensor->get_layout()));


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/2483

### Problem description
- Tensor data in runtime and EmitC path were compared byte by byte. In case of mismatch, the value of mismatched byte were reported, which wasn't very helpful.

### What's changed
- Values are now compared element by element (with an appropriate type), and in the case of mismatch, the typed value is reported. To handle special values like NaN, Inf etc. we still compare individual elements byte by byte.
- Some redundant checks were removed.

### Checklist
- [ ] New/Existing tests provide coverage for changes
