### PR TITLE
Placeholder allocate pass

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -157,7 +157,7 @@ def TTIR_ToLayoutOp : TTIR_BufferizableOp<"to_layout"> {
 
     let hasVerifier = 1;
 
-    let hasCanonicalizeMethod = 1;
+    let hasFolder = 1;
 }
 
 def TTIR_StreamLayoutOp : TTIR_BufferizableOp<"stream_layout",
@@ -192,6 +192,7 @@ def TTIR_StreamLayoutOp : TTIR_BufferizableOp<"stream_layout",
     }];
 
     let hasVerifier = 1;
+    let hasCanonicalizer = 1;
 }
 
 def TTIR_ViewLayoutOp : TTIR_Op<"view_layout",

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -171,6 +171,36 @@ def TTIRAllocate: Pass<"ttir-allocate", "::mlir::ModuleOp"> {
   }];
 }
 
+def TTIRPlaceholderAllocate : Pass<"ttir-placeholder-allocate", "::mlir::ModuleOp"> {
+  let summary = "Placeholder for the eventual full allocate pass.";
+  let description = [{
+    Currently this pass only does some simple heuristics for forming stream_layout ops
+    for the situations that require it for correctness.  In the future, this pass will
+    be replaced with a full allocate pass that has to do more sophisticated analysis
+    for inserting streams on top of actually allocating.
+
+    Converts generic arguments that require a stream (i.e. local storage
+    buffer for circular buffer):
+
+    ```mlir
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
+    %0 = "ttir.view_layout"(%arg0) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
+    %1 = "ttir.view_layout"(%arg1) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>
+    "ttir.generic"(%0, %1, %alloc)
+    ```
+
+    Into:
+    ```mlir
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
+    %storage_0 = memref.alloc() : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
+    %stream = "ttir.stream_layout"(%arg0, %storage_0) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, #l1_>
+    %storage_1 = memref.alloc() : memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>
+    %stream_2 = "ttir.stream_layout"(%arg1, %storage_1) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>, memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, #l1_>
+    "ttir.generic"(%stream, %stream_2, %alloc)
+    ```
+  }];
+}
+
 def TTIRImplicitBroadcastFold: Pass<"ttir-implicit-broadcast-fold", "::mlir::ModuleOp"> {
   let summary = "Broadcast operation is folded to all the consumers.";
   let description = [{

--- a/lib/Dialect/TTIR/Transforms/Allocate.cpp
+++ b/lib/Dialect/TTIR/Transforms/Allocate.cpp
@@ -2,16 +2,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "ttmlir/Dialect/TT/IR/TT.h"
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
 #include "ttmlir/Utils.h"
 
 #include "mlir/Analysis/Liveness.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir::tt::ttir {
 #define GEN_PASS_DEF_TTIRALLOCATE
+#define GEN_PASS_DEF_TTIRPLACEHOLDERALLOCATE
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h.inc"
 
 //===----------------------------------------------------------------------===//
@@ -36,6 +40,7 @@ inline MemorySpace getMemorySpace(RankedTensorType ty) {
 // Allocate pass
 //===----------------------------------------------------------------------===//
 
+namespace {
 class TTIRAllocate : public impl::TTIRAllocateBase<TTIRAllocate> {
   struct SimpleAllocator {
     struct MemorySpaceInfo {
@@ -180,4 +185,103 @@ public:
     });
   }
 };
+} // namespace
+
+namespace {
+struct TTIRGenericFormStreams : public OpRewritePattern<ttir::GenericOp> {
+  using OpRewritePattern<ttir::GenericOp>::OpRewritePattern;
+
+  static bool needsStream(AffineMap operandIndexingMap, ArrayAttr iteratorTypes,
+                          Value operand, bool isOutput) {
+    auto *definingOp = operand.getDefiningOp();
+    if (mlir::isa_and_nonnull<ttir::StreamLayoutOp, memref::AllocOp>(
+            definingOp)) {
+      return false;
+    }
+
+    if (mlir::isa_and_nonnull<ttir::ViewLayoutOp>(definingOp)) {
+      return true;
+    }
+
+    if (isOutput) {
+      return false;
+    }
+
+    bool operandNeedsReduction = llvm::any_of(
+        llvm::seq(operandIndexingMap.getNumResults()),
+        [&](unsigned resultIndex) {
+          unsigned dimPosition = operandIndexingMap.getDimPosition(resultIndex);
+          IteratorType iteratorType =
+              mlir::cast<IteratorTypeAttr>(iteratorTypes[dimPosition])
+                  .getValue();
+          return iteratorType == IteratorType::Reduction;
+        });
+    return operandNeedsReduction;
+  }
+
+  static void insertStream(PatternRewriter &rewriter, OpOperand &operand,
+                           ttir::GenericOp op) {
+    auto memref = mlir::cast<MemRefType>(operand.get().getType());
+    auto streamAttr = rewriter.getAttr<StreamLayoutAttr>(
+        rewriter.getMultiDimIdentityMap(memref.getRank()));
+    auto streamMemref =
+        MemRefType::get(memref.getShape(), memref.getElementType(), streamAttr,
+                        memref.getMemorySpace());
+    auto storage = rewriter.create<memref::AllocOp>(op.getLoc(), memref);
+    auto streamLayout = rewriter.create<ttir::StreamLayoutOp>(
+        op.getLoc(), streamMemref, operand.get(), storage);
+    rewriter.modifyOpInPlace(
+        op, [&]() { operand.assign(streamLayout.getResult()); });
+  }
+
+  LogicalResult matchAndRewrite(ttir::GenericOp op,
+                                PatternRewriter &rewriter) const final {
+    bool modified = false;
+    unsigned outputOperandsIndex = op.getOutputs().getBeginOperandIndex();
+    ArrayAttr iteratorTypes = op.getIteratorTypes();
+    for (OpOperand &operand : op->getOpOperands()) {
+      bool isOutput = operand.getOperandNumber() >= outputOperandsIndex;
+      AffineMap operandIndexingMap =
+          mlir::cast<AffineMapAttr>(
+              op.getIndexingMaps()[operand.getOperandNumber()])
+              .getValue();
+
+      if (!needsStream(operandIndexingMap, iteratorTypes, operand.get(),
+                       isOutput)) {
+        continue;
+      }
+
+      insertStream(rewriter, operand, op);
+
+      modified = true;
+    }
+
+    return modified ? success() : failure();
+  }
+};
+} // namespace
+
+namespace {
+class TTIRPlaceholderAllocate
+    : public impl::TTIRPlaceholderAllocateBase<TTIRPlaceholderAllocate> {
+
+  using impl::TTIRPlaceholderAllocateBase<
+      TTIRPlaceholderAllocate>::TTIRPlaceholderAllocateBase;
+
+  void runOnOperation() final {
+    RewritePatternSet patterns(&getContext());
+    patterns.add<TTIRGenericFormStreams>(&getContext());
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+      signalPassFailure();
+      return;
+    }
+  }
+
+  void getDependentDialects(mlir::DialectRegistry &registry) const override {
+    registry.insert<mlir::tt::ttir::TTIRDialect>();
+    registry.insert<mlir::tt::TTDialect>();
+  }
+};
+} // namespace
+
 } // namespace mlir::tt::ttir

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -90,6 +90,8 @@ void createTTIRToTTMetalBackendPipeline(
     pm.addPass(mlir::tt::ttir::createTTIROptimizeTensorLayout(
         optimizeTensorLayoutOptions));
     createTTIRBufferizationPipeline(pm);
+    pm.addPass(ttir::createTTIRPlaceholderAllocate());
+    pm.addPass(mlir::createCanonicalizerPass());
     pm.addPass(mlir::createConvertLinalgToAffineLoopsPass());
     pm.addPass(mlir::tt::ttir::createTTIRGenericLinearizeMemref());
     pm.addPass(mlir::createLowerAffinePass());

--- a/test/ttmlir/Dialect/TTIR/allocate/generic_form_streams.mlir
+++ b/test/ttmlir/Dialect/TTIR/allocate/generic_form_streams.mlir
@@ -1,0 +1,56 @@
+// RUN: ttmlir-opt --tt-register-device --ttir-placeholder-allocate --canonicalize %s | FileCheck %s
+
+#l1_ = #tt.memory_space<l1>
+#parallel = #tt.iterator_type<parallel>
+#reduction = #tt.iterator_type<reduction>
+#mapL = affine_map<(d0, d1, d2) -> (d0, d2)>
+#mapR = affine_map<(d0, d1, d2) -> (d2, d1)>
+#mapO = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+func.func @matmul_single_core_stream(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  // CHECK-NOT: "ttir.view_layout"
+  // CHECK: [[lhs:%[a-z0-9_]+]] = "ttir.stream_layout"(%arg0,
+  %0 = "ttir.view_layout"(%arg0) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>
+  // CHECK-NOT: "ttir.view_layout"
+  // CHECK: [[rhs:%[a-z0-9_]+]] = "ttir.stream_layout"(%arg1,
+  %1 = "ttir.view_layout"(%arg1) : (memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  // CHECK: "ttir.generic"([[lhs]], [[rhs]], [[out:%[a-z0-9_]+]])
+  "ttir.generic"(%0, %1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>, operand_cb_mapping = array<i64>}> ({
+  ^bb0(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
+    "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
+  }) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+}
+
+func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
+  // CHECK-NOT: "ttir.view_layout"
+  // CHECK: [[lhs:%[a-z0-9_]+]] = "ttir.stream_layout"(%arg0,
+  %0 = "ttir.view_layout"(%arg0) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
+  // CHECK-NOT: "ttir.view_layout"
+  // CHECK: [[rhs:%[a-z0-9_]+]] = "ttir.stream_layout"(%arg1,
+  %1 = "ttir.view_layout"(%arg1) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>
+  // CHECK: "ttir.generic"([[lhs]], [[rhs]], [[out:%[a-z0-9_]+]])
+  "ttir.generic"(%0, %1, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>, operand_cb_mapping = array<i64>}> ({
+  ^bb0(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>):
+    "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
+  }) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>, memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
+  return %alloc : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
+}
+
+func.func @matmul_multi_core_transpose(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<4x4x8x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
+  // CHECK-NOT: "ttir.view_layout"
+  // CHECK: [[lhs:%[a-z0-9_]+]] = "ttir.stream_layout"(%arg0,
+  %0 = "ttir.view_layout"(%arg0) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
+  // CHECK-NOT: "ttir.view_layout"
+  // CHECK: [[rhs:%[a-z0-9_]+]] = "ttir.stream_layout"(%arg1, {{.*}}, #tt.stream<(d0, d1, d2, d3) -> (d1, d0, d3, d2)>,
+  %1 = "ttir.view_layout"(%arg1) : (memref<4x4x8x6x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, affine_map<(d0, d1, d2, d3) -> (d1, d0, d3, d2)>, #l1_>
+  // CHECK: "ttir.generic"([[lhs]], [[rhs]], [[out:%[a-z0-9_]+]])
+  "ttir.generic"(%0, %1, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>, operand_cb_mapping = array<i64>}> ({
+  ^bb0(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>):
+    "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
+  }) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<4x4x6x8x!tt.tile<32x32, f32>, affine_map<(d0, d1, d2, d3) -> (d1, d0, d3, d2)>, #l1_>, memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
+  return %alloc : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
+}


### PR DESCRIPTION
Currently this pass only does some simple heuristics for forming stream_layout ops for the situations that require it for correctness.  In the future, this pass will be replaced with a full allocate pass that has to do more sophisticated analysis for inserting streams on top of actually allocating.

Converts generic arguments that require a stream (i.e. local storage buffer for circular buffer):

```mlir
%alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
%0 = "ttir.view_layout"(%arg0) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
%1 = "ttir.view_layout"(%arg1) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>
ttir.generic (%0, %1, %alloc)
```

Into:
```mlir
%alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
%storage_0 = memref.alloc() : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
%stream = "ttir.stream_layout"(%arg0, %storage_0) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, #l1_>
%storage_1 = memref.alloc() : memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>
%stream_2 = "ttir.stream_layout"(%arg1, %storage_1) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>, memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, #l1_>
ttir.generic (%stream, %stream_2, %alloc)
```