### PR TITLE
Add TTIR pass that lowers DMA ops from affine to index form

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.h
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.h
@@ -7,6 +7,8 @@
 
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
 
+#include "mlir/Interfaces/InferIntRangeInterface.h"
+
 #define GET_OP_CLASSES
 #include "ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.h.inc"
 

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
@@ -13,6 +13,7 @@ include "ttmlir/Dialect/TTIR/IR/TTIROpsInterfaces.td"
 
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
+include "mlir/Interfaces/InferIntRangeInterface.td"
 
 class TTIR_GenericRegionOp<string mnemonic, list<Trait> traits = [TTIR_GenericRegionOpTrait, TTIR_GenericParent]> :
     TTIR_Op<mnemonic, traits> {
@@ -219,7 +220,7 @@ def TTIR_DMAOp : TTIR_GenericRegionOp<"dma",
         Given some affine map, as demonstrated below, the dma op will be evaluated at each point in the affine map's iteration space.
       ```mlir
       #map1 = affine_map<(d0, d1, d2) -> (d0, d2)>
-      %tx = ttir.dma %stream #map1, %cb0 : (memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem
+      %tx = ttir.dma %stream<#map1>, %cb0 : (memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem
       ```
 _tx
 
@@ -233,7 +234,7 @@ _tx
                          OptionalAttr<I64Attr>:$optNumElems, Variadic<Index>:$dstCoreIndex, Variadic<Index>:$mcastShape);
     let results = (outs TTIR_MemTx:$result);
 
-    let assemblyFormat = [{ $src (`[` $srcIndices^ `]`)? (`[` $srcAffineMap^ `]`)? `,` $dst (`[` $dstIndices^ `]`)? (`[` $dstAffineMap^ `]`)? (`,` $optNumElems^)? (`,` `core` `[` $dstCoreIndex^ `]`)? (`mcast` `[` $mcastShape^ `]`)? attr-dict `:` `(` type($src) `,` type($dst) `)` `->` type($result)}];
+    let assemblyFormat = [{ $src (`<` $srcAffineMap^ `>`)? (`[` $srcIndices^ `]`)? `,` $dst (`<` $dstAffineMap^ `>`)? (`[` $dstIndices^ `]`)? (`,` `core` `[` $dstCoreIndex^ `]`)? (`mcast` `[` $mcastShape^ `]`)? (`,` `<` $optNumElems^ `>`)? attr-dict `:` `(` type($src) `,` type($dst) `)` `->` type($result)}];
 
     let hasVerifier = 1;
 
@@ -263,6 +264,18 @@ _tx
                getOptNumElems();
       }
     }];
+}
+
+def TTIR_NullTxOp : TTIR_GenericRegionOp<"null_tx", [Pure]> {
+    let summary = "Create a null transaction.";
+    let description = [{
+      Utility op to create a null transaction.  This is required for creating a sentinel
+      starting transaction for a DMA nested inside of a loop nest.
+    }];
+
+    let results = (outs TTIR_MemTx:$result);
+
+    let assemblyFormat = [{ attr-dict }];
 }
 
 def TTIR_DMAWaitOp : TTIR_GenericRegionOp<"dma_wait", [MemoryEffects<[MemRead, MemWrite]>]> {
@@ -393,6 +406,7 @@ class TTIR_IndexOp<string mnemonic, list<Trait> traits = []> : TTIR_GenericRegio
   traits #
   [ Pure
   , DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
+  , DeclareOpInterfaceMethods<InferIntRangeInterface, ["inferResultRanges"]>
   ]> {
     let arguments = (ins ConfinedAttr<I64Attr, [IntMinValue<0>]>:$dim);
     let results = (outs Index:$result);

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -261,6 +261,32 @@ def TTIRGenericGenerateLoops : Pass<"ttir-generic-generate-loops", "::mlir::Modu
   }];
 }
 
+def TTIRGenericLowerAffineDMAs : Pass<"ttir-generic-lower-affine-dmas", "::mlir::ModuleOp"> {
+  let summary = "Lower DMA ops from their affine form to indexed form.";
+  let description = [{
+    This pass lowers DMA ops from their affine form to indexed form. This is useful for doing analysis on the DMA
+    ops and lowering them to an optimal loop nest of coalesced transactions.  This is acheived by sampling the affine
+    map over the entire parent generic op iterator space. Note that the affine map provided to the DMA op must be
+    one of the indexing maps of the parent generic op.
+
+    e.g.
+    ```mlir
+    %tx = ttir.dma %stream<#map1>, %cb0
+    ```
+
+    Might become:
+    ```mlir
+    %c2 = arith.constant 2
+    %iter0 = ttir.iter_index(0)
+    %core0 = ttir.core_index(0)
+    %0 = arith.muli %core0, %c2
+    %1 = arith.addi %0, %iter0
+    %iter2 = ttir.iter_index(2)
+    %tx = ttir.dma %stream [%1, %iter2], %cb0
+    ```
+  }];
+}
+
 def TTIRLayout: Pass<"ttir-layout", "::mlir::ModuleOp"> {
   let summary = "Tensor tilize all generic ops.";
   let description = [{

--- a/lib/Dialect/TTIR/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTIR/Transforms/CMakeLists.txt
@@ -7,6 +7,7 @@ add_mlir_dialect_library(MLIRTTIRTransforms
         GenericGenerateDatamovement.cpp
         GenericGenerateLoops.cpp
         GenericHWThreadSelection.cpp
+        GenericLowerAffineDMAs.cpp
         AttachMetalLayout.cpp
         OptimizeTensorLayout.cpp
         HoistCPUOps.cpp

--- a/lib/Dialect/TTIR/Transforms/GenericGenerateDatamovement.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericGenerateDatamovement.cpp
@@ -183,11 +183,12 @@ public:
         });
   }
 
-  static LogicalResult buildDatamovementBlock(
-      PatternRewriter &builder, Location loc, Value genericOperand,
-      Value blockOperand, GridAttr grid, DeviceAttr device,
-      AffineMap operandIndexingMap, AffineMap gridIndexingMap,
-      ArrayAttr iteratorTypes, bool isOutput, MutableArrayRef<Region> regions) {
+  static LogicalResult
+  buildDatamovementBlock(PatternRewriter &builder, Location loc,
+                         Value genericOperand, Value blockOperand,
+                         GridAttr grid, DeviceAttr device,
+                         AffineMap operandIndexingMap, ArrayAttr iteratorTypes,
+                         bool isOutput, MutableArrayRef<Region> regions) {
     if (isOutput) {
       // Wait for compute.
       builder.create<ttir::AwaitOp>(loc, blockOperand);
@@ -247,11 +248,6 @@ public:
     // Insert the new data movement regions.
     unsigned outputOperandsIndex = generic.getOutputs().getBeginOperandIndex();
     unsigned outputOperandsLength = generic.getOutputs().size();
-    // The output and the grid indexing must always be aligned.
-    AffineMap gridIndexingMap =
-        mlir::cast<AffineMapAttr>(
-            generic.getIndexingMaps()[outputOperandsIndex])
-            .getValue();
     auto device = lookupDevice(generic);
     for (OpOperand &operand : generic->getOpOperands()) {
       Block *datamovementBlock =
@@ -267,7 +263,7 @@ public:
           rewriter, generic->getLoc(),
           generic->getOperand(operand.getOperandNumber()),
           datamovementBlock->getArgument(operand.getOperandNumber()),
-          generic.getGrid(), device, operandIndexingMap, gridIndexingMap,
+          generic.getGrid(), device, operandIndexingMap,
           generic.getIteratorTypes(), isOutput, newGeneric.getRegions());
       if (failed(result)) {
         return result;

--- a/lib/Dialect/TTIR/Transforms/GenericLowerAffineDMAs.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericLowerAffineDMAs.cpp
@@ -1,0 +1,260 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TT/IR/TT.h"
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
+#include "ttmlir/Utils.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include <numeric>
+
+namespace mlir::tt::ttir {
+#define GEN_PASS_DEF_TTIRGENERICLOWERAFFINEDMAS
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h.inc"
+
+namespace {
+class TTIRGenericLowerAffineDMAsRewritePattern
+    : public OpRewritePattern<DMAOp> {
+public:
+  using OpRewritePattern<DMAOp>::OpRewritePattern;
+
+  // Returns a tuple of the stream index and the index bounds. The stream index
+  // represents the position in the stream that the DMA will is currently on,
+  // and is relative per core. The index bounds represent the index upper
+  // bounds.
+  static std::tuple<SmallVector<Value>, SmallVector<int64_t>>
+  buildStreamIndex(OpBuilder &builder, Location loc,
+                   ArrayRef<int64_t> gridShape, ArrayRef<int64_t> shardShape,
+                   AffineMap dmaIndexingMap, AffineMap gridIndexingMap) {
+    assert(dmaIndexingMap.getNumDims() == gridIndexingMap.getNumDims());
+    assert(dmaIndexingMap.getNumResults() == gridIndexingMap.getNumResults());
+    assert(dmaIndexingMap.getNumResults() == shardShape.size());
+    assert(gridIndexingMap.isProjectedPermutation() &&
+           "Grid indexing map must be a permutation");
+
+    SmallVector<Value> streamIndex;
+    SmallVector<int64_t> indexBounds;
+    streamIndex.reserve(dmaIndexingMap.getNumResults());
+    indexBounds.reserve(dmaIndexingMap.getNumResults());
+    for (unsigned result = 0; result < dmaIndexingMap.getNumResults();
+         result++) {
+      unsigned dim = dmaIndexingMap.getDimPosition(result);
+      std::optional<unsigned> gridResult =
+          gridIndexingMap.getResultPosition(dmaIndexingMap.getResult(result));
+      //
+      // The following assert is pretty subtle. If this operand dimension
+      // participates in the grid, for now we must assert that the relative grid
+      // result is the same as the operand result. This protects against
+      // permutations of the grid, ie. transposes.  For example, let's consider
+      // a matmul case:
+      //   dmaIndexingMap:  (m, n, k) -> (m, k)
+      //   dmaIndexingMap:  (m, n, k) -> (k, n)
+      //   gridIndexingMap: (m, n, k) -> (m, n)
+      //                                     ^
+      // This assert ensures that the m's line up. A counter example would be:
+      //   dmaIndexingMap:  (m, n, k) -> (m, k)
+      //   gridIndexingMap: (m, n, k) -> (n, m)
+      //
+      // Not currently supported.
+      //
+      assert(!gridResult || *gridResult == result);
+      bool isGridDim = gridResult.has_value();
+      Value iterIndex = builder.create<IterIndexOp>(
+          loc, builder.getIndexType(), builder.getI64IntegerAttr(dim));
+      Value index;
+      if (isGridDim) {
+        // gridI * dimI + iterI
+        Value dimConstant = builder.create<arith::ConstantOp>(
+            loc, builder.getIndexType(),
+            builder.getIndexAttr(shardShape[result]));
+        index = builder.create<CoreIndexOp>(loc, builder.getIndexType(),
+                                            builder.getI64IntegerAttr(dim));
+        index = builder.create<arith::MulIOp>(loc, builder.getIndexType(),
+                                              index, dimConstant);
+        index = builder.create<arith::AddIOp>(loc, builder.getIndexType(),
+                                              index, iterIndex);
+      } else {
+        index = iterIndex;
+      }
+      streamIndex.push_back(index);
+      indexBounds.push_back(gridShape[result]);
+    }
+    return std::make_tuple(streamIndex, indexBounds);
+  }
+
+  static size_t getElementSizeBytes(MemRefType memref) {
+    mlir::Type elementType = memref.getElementType();
+    auto tileType = mlir::dyn_cast<TileType>(elementType);
+    return tileType ? tileType.getSizeBytes()
+                    : elementType.getIntOrFloatBitWidth() / 8;
+  }
+
+  static size_t getMemRefShardSizeBytes(MemRefType memref) {
+    ArrayRef<int64_t> memrefShardShape =
+        memref.getShape().drop_front(memref.getRank() / 2);
+    return std::accumulate(memrefShardShape.begin(), memrefShardShape.end(),
+                           getElementSizeBytes(memref),
+                           std::multiplies<int64_t>());
+  }
+
+  // For now we'll do just a simple brute force check and sample the entire map
+  // to calculate the coalescing factor. In the future there are some simple
+  // checks we could do for the common case that would be much faster.
+  static size_t calculateCoalescingFactor(AffineMap memoryMap,
+                                          ArrayRef<int64_t> gridShape,
+                                          ArrayRef<int64_t> shardShape,
+                                          size_t elemSizeBytes,
+                                          ArrayRef<int64_t> indexBounds) {
+    size_t coalescingFactor = ttmlir::utils::volume(shardShape);
+    SmallVector<int64_t> memoryIndex;
+    memoryIndex.resize(gridShape.size() + shardShape.size());
+    ttmlir::utils::sample(gridShape, [&](ArrayRef<int64_t> gridIndex) {
+      size_t currentCoalescingFactor = 0;
+      SmallVector<int64_t, 4> nextAddress;
+      ttmlir::utils::sample(shardShape, [&](ArrayRef<int64_t> shardIndex) {
+        for (unsigned i = 0; i < gridIndex.size(); i++) {
+          memoryIndex[i] = gridIndex[i];
+        }
+        for (unsigned i = 0; i < shardIndex.size(); i++) {
+          memoryIndex[gridIndex.size() + i] = shardIndex[i];
+        }
+        SmallVector<int64_t, 4> address = memoryMap.compose(memoryIndex);
+        if (nextAddress.empty() || nextAddress == address) {
+          ++currentCoalescingFactor;
+        } else {
+          coalescingFactor =
+              std::gcd(coalescingFactor, currentCoalescingFactor);
+        }
+        nextAddress = address;
+        nextAddress.back() += elemSizeBytes;
+      });
+    });
+    return coalescingFactor;
+  }
+
+  static std::tuple<SmallVector<Value>, SmallVector<Value>, SmallVector<Value>>
+  getLoopBounds(OpBuilder &builder, Location loc,
+                ArrayRef<int64_t> shardShape) {
+    Value zero = builder.create<arith::ConstantOp>(loc, builder.getIndexType(),
+                                                   builder.getIndexAttr(0));
+    Value one = builder.create<arith::ConstantOp>(loc, builder.getIndexType(),
+                                                  builder.getIndexAttr(1));
+    SmallVector<Value> lbs(shardShape.size(), zero);
+    SmallVector<Value> ubs(llvm::map_range(shardShape, [&](int64_t dim) {
+      return builder.create<arith::ConstantOp>(loc, builder.getIndexType(),
+                                               builder.getIndexAttr(dim));
+    }));
+    SmallVector<Value> step(shardShape.size(), one);
+    return std::make_tuple(lbs, ubs, step);
+  }
+
+  static scf::LoopNest
+  fallbackSingleTileGatherLoop(OpBuilder &builder, Location loc, DMAOp dma,
+                               ArrayRef<Value> streamIndex,
+                               ArrayRef<int64_t> shardShape) {
+    auto [lbs, ubs, steps] = getLoopBounds(builder, loc, shardShape);
+
+    auto initTx = builder.create<ttir::NullTxOp>(dma.getLoc(),
+                                                 builder.getType<MemTxType>());
+    scf::LoopNest loopNest = scf::buildLoopNest(
+        builder, loc, lbs, ubs, steps, ValueRange(initTx),
+        [&](OpBuilder &builder, Location loc, ValueRange iters,
+            ValueRange /*args*/) {
+          SmallVector<Value> srcIndex =
+              llvm::to_vector(llvm::concat<Value>(streamIndex, iters));
+          return SmallVector<Value>{builder.create<ttir::DMAOp>(
+              dma.getLoc(), builder.getType<MemTxType>(), dma.getSrc(), nullptr,
+              srcIndex, dma.getDst(), nullptr, iters, nullptr,
+              dma.getDstCoreIndex(), dma.getMcastShape())};
+        });
+    return loopNest;
+  }
+
+  LogicalResult matchAndRewrite(DMAOp dma,
+                                PatternRewriter &rewriter) const final {
+    if (!dma.isAffine()) {
+      // Already lowered, skip.
+      return failure();
+    }
+    assert(!dma.getDstAffineMap() && "DMA dst affine map not supported yet");
+    assert(dma.getSrcAffineMap() && "DMA src affine map expected");
+
+    AffineMap dmaIndexingMap = *dma.getSrcAffineMap();
+    MemRefType memref = dma.getSrcMemRefType();
+    assert(memref.getRank() % 2 == 0 && "Only even rank memrefs are supported");
+    ArrayRef<int64_t> memrefShape = memref.getShape();
+    ArrayRef<int64_t> memrefGridShape =
+        memrefShape.take_front(memrefShape.size() / 2);
+    ArrayRef<int64_t> memrefShardShape =
+        memrefShape.drop_front(memrefShape.size() / 2);
+
+    GenericOp genericParent = dma->getParentOfType<ttir::GenericOp>();
+    unsigned outputOperandsIndex =
+        genericParent.getOutputs().getBeginOperandIndex();
+    // The output and the grid indexing must always be aligned.
+    AffineMap gridIndexingMap =
+        mlir::cast<AffineMapAttr>(
+            genericParent.getIndexingMaps()[outputOperandsIndex])
+            .getValue();
+
+    auto [streamIndex, indexBounds] =
+        buildStreamIndex(rewriter, dma.getLoc(), memrefGridShape,
+                         memrefShardShape, dmaIndexingMap, gridIndexingMap);
+
+    DeviceAttr device = genericParent.getDevice();
+    // TODO(#1909) Once we have an allocation pass, we need to lookup the page
+    // size instead of calculating it here.
+    size_t pageSize = getMemRefShardSizeBytes(memref);
+    AffineMap memoryMap = device.getMemoryMap(memref, pageSize);
+    size_t elemSizeBytes = getElementSizeBytes(memref);
+    size_t coalescingFactor =
+        calculateCoalescingFactor(memoryMap, memrefGridShape, memrefShardShape,
+                                  elemSizeBytes, indexBounds);
+
+    Operation *newDma;
+    if (coalescingFactor ==
+        static_cast<size_t>(ttmlir::utils::volume(memrefShardShape))) {
+      // Fully coalesced, we can trivially lower.
+      newDma = rewriter.create<ttir::DMAOp>(
+          dma.getLoc(), rewriter.getType<MemTxType>(), dma.getSrc(), nullptr,
+          streamIndex, dma.getDst(), nullptr, ValueRange(), nullptr,
+          dma.getDstCoreIndex(), dma.getMcastShape());
+    } else {
+      // Fallback to single tile gather for now, in the future we can chage this
+      // to support more sophisticated gathering.
+      scf::LoopNest loopNest = fallbackSingleTileGatherLoop(
+          rewriter, dma.getLoc(), dma, streamIndex, memrefShardShape);
+      assert(loopNest.loops.size() == memrefShardShape.size());
+      newDma = loopNest.loops.front();
+    }
+
+    rewriter.replaceOp(dma, newDma);
+    return success();
+  }
+};
+} // namespace
+
+namespace {
+class TTIRGenericLowerAffineDMAs
+    : public impl::TTIRGenericLowerAffineDMAsBase<TTIRGenericLowerAffineDMAs> {
+public:
+  using impl::TTIRGenericLowerAffineDMAsBase<
+      TTIRGenericLowerAffineDMAs>::TTIRGenericLowerAffineDMAsBase;
+
+  void runOnOperation() final {
+    RewritePatternSet patterns(&getContext());
+    patterns.add<TTIRGenericLowerAffineDMAsRewritePattern>(&getContext());
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+} // namespace
+
+} // namespace mlir::tt::ttir

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -9,6 +9,7 @@
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
 
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
+#include "mlir/Dialect/Arith/Transforms/Passes.h"
 #include "mlir/Dialect/Bufferization/Transforms/OneShotAnalysis.h"
 #include "mlir/Dialect/Bufferization/Transforms/Passes.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -32,6 +33,14 @@ void createTTIRBufferizationPipeline(OpPassManager &pm) {
   // bufferDeallocationOptions;
   // mlir::bufferization::buildBufferDeallocationPipeline(
   //    pm, bufferDeallocationOptions);
+}
+
+void createOptimizationPasses(OpPassManager &pm) {
+  pm.addPass(mlir::createCanonicalizerPass());
+  pm.addPass(mlir::createLoopInvariantCodeMotionPass());
+  pm.addPass(mlir::createSCCPPass());
+  pm.addPass(mlir::createCSEPass());
+  pm.addPass(mlir::arith::createIntRangeOptimizationsPass());
 }
 
 void createTTIRToTTMetalBackendPipeline(
@@ -61,8 +70,10 @@ void createTTIRToTTMetalBackendPipeline(
   pm.addPass(mlir::tt::ttir::createTTIRGenericLinearizeMemref());
   pm.addPass(mlir::createLowerAffinePass());
   pm.addPass(mlir::tt::ttir::createTTIRGenericGenerateDatamovement());
+  pm.addPass(mlir::tt::ttir::createTTIRGenericLowerAffineDMAs());
   pm.addPass(mlir::tt::ttir::createTTIRGenericHWThreadSelection());
   pm.addPass(mlir::tt::ttir::createTTIRGenericGenerateLoops());
+  createOptimizationPasses(pm);
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/ttmlir/Dialect/TTIR/generic/affine_dma.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/affine_dma.mlir
@@ -1,0 +1,236 @@
+// RUN: ttmlir-opt --tt-register-device --ttir-generic-lower-affine-dmas %s | FileCheck %s
+
+#dram = #tt.memory_space<dram>
+#l1_ = #tt.memory_space<l1>
+#map1 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map2 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map3 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#parallel = #tt.iterator_type<parallel>
+#reduction = #tt.iterator_type<reduction>
+
+func.func @matmul_single_core_stream(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>
+  %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>
+  "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  ^datamovement0(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
+    // CHECK-DAG: [[iter0:%.*]] = ttir.iter_index(0)
+    // CHECK-DAG: [[iter2:%.*]] = ttir.iter_index(2)
+    // CHECK-DAG: [[core0:%.*]] = ttir.core_index(0)
+    // CHECK-DAG: arith.muli
+    // CHECK-DAG: arith.addi
+    // CHECK: ttir.dma %stream{{[_0-9]*}} [%{{.*}}, [[iter2]]]
+    %tx = ttir.dma %stream<#map1>, %cb0 : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+    ttir.dma_wait %tx
+    ttir.yield %cb0 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^datamovement1(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
+    // CHECK-DAG: [[iter1:%.*]] = ttir.iter_index(1)
+    // CHECK-DAG: [[iter2:%.*]] = ttir.iter_index(2)
+    // CHECK-DAG: [[core1:%.*]] = ttir.core_index(1)
+    // CHECK-DAG: arith.muli
+    // CHECK-DAG: arith.addi
+    // CHECK: ttir.dma %stream{{[_0-9]*}} [[[iter2]], %{{.*}}]
+    %tx = ttir.dma %stream_2<#map2>, %cb1 : (memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+    ttir.dma_wait %tx
+    ttir.yield %cb1 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^datamovement2(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
+    ttir.await %cb2 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^compute(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
+    ttir.await %cb0, %cb1 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>)
+    "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
+    ttir.yield %cb2 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
+  }) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+}
+
+func.func @matmul_single_core_transpose(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>
+  %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d1, d0, d3, d2) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>
+  "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  ^datamovement0(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
+    // CHECK-DAG: [[iter0:%.*]] = ttir.iter_index(0)
+    // CHECK-DAG: [[iter2:%.*]] = ttir.iter_index(2)
+    // CHECK-DAG: [[core0:%.*]] = ttir.core_index(0)
+    // CHECK-DAG: arith.muli
+    // CHECK-DAG: arith.addi
+    // CHECK: ttir.dma %stream{{[_0-9]*}} [%{{.*}}, [[iter2]]]
+    %tx = ttir.dma %stream<#map1>, %cb0 : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+    ttir.dma_wait %tx
+    ttir.yield %cb0 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^datamovement1(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
+    // CHECK-DAG: [[iter2:%.*]] = ttir.iter_index(2)
+    // CHECK-DAG: [[iter1:%.*]] = ttir.iter_index(1)
+    // CHECK-DAG: [[core1:%.*]] = ttir.core_index(1)
+    // CHECK-DAG: arith.muli
+    // CHECK-DAG: arith.addi
+    // CHECK: ttir.null_tx
+    // CHECK-NEXT: scf.for
+    // CHECK-NEXT: scf.for
+    // CHECK-NEXT: ttir.dma %stream{{[_0-9]*}} [[[iter2]], %{{.*}}]
+    // CHECK: scf.yield
+    // CHECK: scf.yield
+    %tx = ttir.dma %stream_2<#map2>, %cb1 : (memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d1, d0, d3, d2) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+    ttir.dma_wait %tx
+    ttir.yield %cb1 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^datamovement2(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
+    ttir.await %cb2 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^compute(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
+    ttir.await %cb0, %cb1 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>)
+    "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
+    ttir.yield %cb2 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
+  }) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d1, d0, d3, d2) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+}
+
+func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
+  %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
+  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>
+  %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 24576 + d3 * 4096)>, #l1_>
+  %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>, memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #l1_>
+  "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  ^datamovement0(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>, %sem0: !ttir.semaphore, %sem1: !ttir.semaphore, %sem2: !ttir.semaphore, %sem3: !ttir.semaphore):
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %core0 = ttir.core_index(0) : index
+    %core1 = ttir.core_index(1) : index
+    %0 = arith.cmpi eq, %core1, %c0 : index
+    scf.if %0 {
+      // CHECK-DAG: [[iter0:%.*]] = ttir.iter_index(0)
+      // CHECK-DAG: [[iter2:%.*]] = ttir.iter_index(2)
+      // CHECK-DAG: [[core0:%.*]] = ttir.core_index(0)
+      // CHECK-DAG: arith.muli
+      // CHECK-DAG: arith.addi
+      // CHECK: ttir.dma %stream{{[_0-9]*}} [%{{.*}}, [[iter2]]]
+      %tx = ttir.dma %stream<#map1>, %cb0 : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 24576 + d3 * 4096)>, #l1_>, memref<4x6x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+      ttir.dma_wait %tx
+      ttir.semaphore_wait %sem0, %c3 reset %c0
+      %tx_3 = ttir.dma %cb0, %cb0, core[%core0, %c0] mcast[%c1, %c4] : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<4x6x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+      ttir.dma_wait %tx_3
+      ttir.semaphore_set %sem1, %c1, core[%core0, %c0] mcast[%c1, %c4]
+    } else {
+      ttir.semaphore_inc %sem0, %c1, core[%core0, %c0]
+      ttir.semaphore_wait %sem1, %c1 reset %c0
+    }
+    ttir.yield %cb0 : (memref<4x6x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^datamovement1(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>, %sem0: !ttir.semaphore, %sem1: !ttir.semaphore, %sem2: !ttir.semaphore, %sem3: !ttir.semaphore):
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %core0 = ttir.core_index(0) : index
+    %0 = arith.cmpi eq, %core0, %c0 : index
+    %core1 = ttir.core_index(1) : index
+    scf.if %0 {
+      // CHECK-DAG: [[iter1:%.*]] = ttir.iter_index(1)
+      // CHECK-DAG: [[iter2:%.*]] = ttir.iter_index(2)
+      // CHECK-DAG: [[core1:%.*]] = ttir.core_index(1)
+      // CHECK-DAG: arith.muli
+      // CHECK-DAG: arith.addi
+      // CHECK: ttir.dma %stream{{[_0-9]*}} [[[iter2]], %{{.*}}]
+      %tx = ttir.dma %stream_2<#map2>, %cb1 : (memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+      ttir.dma_wait %tx
+      ttir.semaphore_wait %sem2, %c1 reset %c0
+      %tx_3 = ttir.dma %cb1, %cb1, core[%c0, %core1] mcast[%c2, %c1] : (memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+      ttir.dma_wait %tx_3
+      ttir.semaphore_set %sem3, %c1, core[%c0, %core1] mcast[%c2, %c1]
+    } else {
+      ttir.semaphore_inc %sem2, %c1, core[%c0, %core1]
+      ttir.semaphore_wait %sem3, %c1 reset %c0
+    }
+    ttir.yield %cb1 : (memref<6x8x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^datamovement2(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>, %sem0: !ttir.semaphore, %sem1: !ttir.semaphore, %sem2: !ttir.semaphore, %sem3: !ttir.semaphore):
+    ttir.await %cb2 : (memref<4x8x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^compute(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>, %sem0: !ttir.semaphore, %sem1: !ttir.semaphore, %sem2: !ttir.semaphore, %sem3: !ttir.semaphore):
+    ttir.await %cb0, %cb1 : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>)
+    "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
+    ttir.yield %cb2 : (memref<4x8x!tt.tile<32x32, f32>, #l1_>)
+  }) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 24576 + d3 * 4096)>, #l1_>, memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #l1_>, memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
+  return %alloc : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
+}
+
+func.func @matmul_multi_core_dram_params(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<4x4x6x8x!tt.tile<32x32, f32>, #dram>) -> memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
+  %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
+  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>
+  %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 24576 + d3 * 4096)>, #l1_>
+  %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #dram>, memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #dram>
+  "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  ^datamovement0(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>, %sem0: !ttir.semaphore, %sem1: !ttir.semaphore, %sem2: !ttir.semaphore, %sem3: !ttir.semaphore):
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %core0 = ttir.core_index(0) : index
+    %core1 = ttir.core_index(1) : index
+    %0 = arith.cmpi eq, %core1, %c0 : index
+    scf.if %0 {
+      // CHECK-DAG: [[iter0:%.*]] = ttir.iter_index(0)
+      // CHECK-DAG: [[iter2:%.*]] = ttir.iter_index(2)
+      // CHECK-DAG: [[core0:%.*]] = ttir.core_index(0)
+      // CHECK-DAG: arith.muli
+      // CHECK-DAG: arith.addi
+      // CHECK: ttir.dma %stream{{[_0-9]*}} [%{{.*}}, [[iter2]]]
+      %tx = ttir.dma %stream<#map1>, %cb0 : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 24576 + d3 * 4096)>, #l1_>, memref<4x6x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+      ttir.dma_wait %tx
+      ttir.semaphore_wait %sem0, %c3 reset %c0
+      %tx_3 = ttir.dma %cb0, %cb0, core[%core0, %c0] mcast[%c1, %c4] : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<4x6x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+      ttir.dma_wait %tx_3
+      ttir.semaphore_set %sem1, %c1, core[%core0, %c0] mcast[%c1, %c4]
+    } else {
+      ttir.semaphore_inc %sem0, %c1, core[%core0, %c0]
+      ttir.semaphore_wait %sem1, %c1 reset %c0
+    }
+    ttir.yield %cb0 : (memref<4x6x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^datamovement1(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>, %sem0: !ttir.semaphore, %sem1: !ttir.semaphore, %sem2: !ttir.semaphore, %sem3: !ttir.semaphore):
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %core0 = ttir.core_index(0) : index
+    %0 = arith.cmpi eq, %core0, %c0 : index
+    %core1 = ttir.core_index(1) : index
+    scf.if %0 {
+      // CHECK-DAG: [[iter1:%.*]] = ttir.iter_index(1)
+      // CHECK-DAG: [[iter2:%.*]] = ttir.iter_index(2)
+      // CHECK-DAG: [[core1:%.*]] = ttir.core_index(1)
+      // CHECK-DAG: arith.muli
+      // CHECK-DAG: arith.addi
+      // CHECK: ttir.dma %stream{{[_0-9]*}} [[[iter2]], %{{.*}}]
+      %tx = ttir.dma %stream_2<#map2>, %cb1 : (memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #dram>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+      ttir.dma_wait %tx
+      ttir.semaphore_wait %sem2, %c1 reset %c0
+      %tx_3 = ttir.dma %cb1, %cb1, core[%c0, %core1] mcast[%c2, %c1] : (memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+      ttir.dma_wait %tx_3
+      ttir.semaphore_set %sem3, %c1, core[%c0, %core1] mcast[%c2, %c1]
+    } else {
+      ttir.semaphore_inc %sem2, %c1, core[%c0, %core1]
+      ttir.semaphore_wait %sem3, %c1 reset %c0
+    }
+    ttir.yield %cb1 : (memref<6x8x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^datamovement2(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>, %sem0: !ttir.semaphore, %sem1: !ttir.semaphore, %sem2: !ttir.semaphore, %sem3: !ttir.semaphore):
+    ttir.await %cb2 : (memref<4x8x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^compute(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>, %sem0: !ttir.semaphore, %sem1: !ttir.semaphore, %sem2: !ttir.semaphore, %sem3: !ttir.semaphore):
+    ttir.await %cb0, %cb1 : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>)
+    "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
+    ttir.yield %cb2 : (memref<4x8x!tt.tile<32x32, f32>, #l1_>)
+  }) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 24576 + d3 * 4096)>, #l1_>, memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #dram>, memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
+  return %alloc : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
+}

--- a/test/ttmlir/Dialect/TTIR/generic/generic_datamovement.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/generic_datamovement.mlir
@@ -76,12 +76,12 @@ func.func @matmul_single_core_stream(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>,
   // Look for 4 regions, one for each operand and one for the compute
   // Operand 0 (input)
   // CHECK: ^datamovement0
-  // CHECK-NEXT: ttir.dma [[lhs]] [#map1], %cb0
+  // CHECK-NEXT: ttir.dma [[lhs]]<#map1>, %cb0
   // CHECK-NEXT: ttir.dma_wait
   // CHECK-NEXT: ttir.yield %cb0
   // Operand 1 (input)
   // CHECK: ^datamovement1
-  // CHECK-NEXT: ttir.dma [[rhs]] [#map2], %cb1
+  // CHECK-NEXT: ttir.dma [[rhs]]<#map2>, %cb1
   // CHECK-NEXT: ttir.dma_wait
   // CHECK-NEXT: ttir.yield %cb1
   // Operand 2 (output)
@@ -109,7 +109,7 @@ func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, 
   // Look for 4 regions, one for each operand and one for the compute
   // Operand 0 (input)
   // CHECK: ^datamovement0
-  // CHECK: ttir.dma [[lhs]] [#map1], %cb0
+  // CHECK: ttir.dma [[lhs]]<#map1>, %cb0
   // CHECK-NEXT: ttir.dma_wait
   // CHECK-NEXT: ttir.semaphore_wait [[reader_ready_lhs:%[a-z0-9]+]]
   // CHECK-NEXT: ttir.dma %cb0, %cb0
@@ -120,7 +120,7 @@ func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, 
   // CHECK-NEXT: ttir.semaphore_wait [[writer_done_lhs]]
   // Operand 1 (input)
   // CHECK: ^datamovement1
-  // CHECK: ttir.dma [[rhs]] [#map2], %cb1
+  // CHECK: ttir.dma [[rhs]]<#map2>, %cb1
   // CHECK-NEXT: ttir.dma_wait
   // CHECK-NEXT: ttir.semaphore_wait [[reader_ready_rhs:%[a-z0-9]+]]
   // CHECK-NEXT: ttir.dma %cb1, %cb1
@@ -154,7 +154,7 @@ func.func @matmul_multi_core_dram_params(%arg0: memref<2x4x4x6x!tt.tile<32x32, f
   // Look for 4 regions, one for each operand and one for the compute
   // Operand 0 (input)
   // CHECK: ^datamovement0
-  // CHECK: ttir.dma [[lhs]] [#map1], %cb0
+  // CHECK: ttir.dma [[lhs]]<#map1>, %cb0
   // CHECK-NEXT: ttir.dma_wait
   // CHECK-NEXT: ttir.semaphore_wait [[reader_ready_lhs:%[a-z0-9]+]]
   // CHECK-NEXT: ttir.dma %cb0, %cb0
@@ -165,7 +165,7 @@ func.func @matmul_multi_core_dram_params(%arg0: memref<2x4x4x6x!tt.tile<32x32, f
   // CHECK-NEXT: ttir.semaphore_wait [[writer_done_lhs]]
   // Operand 1 (input)
   // CHECK: ^datamovement1
-  // CHECK: ttir.dma [[rhs]] [#map2], %cb1
+  // CHECK: ttir.dma [[rhs]]<#map2>, %cb1
   // CHECK-NEXT: ttir.dma_wait
   // CHECK-NEXT: ttir.semaphore_wait [[reader_ready_rhs:%[a-z0-9]+]]
   // CHECK-NEXT: ttir.dma %cb1, %cb1


### PR DESCRIPTION
This pass lowers DMA ops from their affine form to indexed form. This is useful for doing analysis on the DMA ops and lowering them to an optimal loop nest of coalesced transactions.  This is acheived by sampling the affine map over the entire parent generic op iterator space. Note that the affine map provided to the DMA op must be one of the indexing maps of the parent generic op.

e.g.
```mlir
%tx = ttir.dma %stream<#map1>, %cb0
```

Might become:
```mlir
%c2 = arith.constant 2
%iter0 = ttir.iter_index(0)
%core0 = ttir.core_index(0)
%0 = arith.muli %core0, %c2
%1 = arith.addi %0, %iter0
%iter2 = ttir.iter_index(2)
%tx = ttir.dma %stream [%1, %iter2], %cb0
```