### PR TITLE
Details TensorMeshShardingAttr with extra info and fix bug in

### DIFF
--- a/include/ttmlir/Conversion/StableHLOToTTIR/ShardingUtils.h
+++ b/include/ttmlir/Conversion/StableHLOToTTIR/ShardingUtils.h
@@ -52,15 +52,24 @@ public:
   // mesh_shard op needs to be created or not.
   bool checkAndUpdateShardyArgSharding(
       mlir::PatternRewriter &rewriter, mlir::func::FuncOp funcOp,
-      mlir::Value argOperand, mlir::sdy::TensorShardingAttr shardingAttr,
-      mlir::tt::TensorMeshShardingAttr tensorMeshShardingAttr);
+      mlir::Value argOperand, mlir::sdy::TensorShardingAttr shardingAttr);
 
   // Check and update ret sharding attribute and determine if mesh_shard op
   // needs to be created or not.
-  bool checkAndUpdateShardyRetSharding(
-      mlir::PatternRewriter &rewriter, mlir::func::FuncOp funcOp,
-      uint64_t retIdx, mlir::sdy::TensorShardingAttr shardingAttr,
-      mlir::tt::TensorMeshShardingAttr tensorMeshShardingAttr);
+  bool
+  checkAndUpdateShardyRetSharding(mlir::PatternRewriter &rewriter,
+                                  mlir::func::FuncOp funcOp, uint64_t retIdx,
+                                  mlir::sdy::TensorShardingAttr shardingAttr);
+
+  // Parse Shardy sharing attribuite. Make this as public for
+  // potential frontend use.
+  llvm::Expected<bool>
+  parseSdySharding(mlir::sdy::TensorShardingAttr sdySharding,
+                   mlir::sdy::MeshAttr meshAttr);
+
+  // Given parsed MeshSharding info, get TensorMeshShardingAttr.
+  mlir::tt::TensorMeshShardingAttr
+  getTensorMeshShardingAttr(mlir::PatternRewriter &rewriter);
 
   // Getter functions.
   mlir::tt::MeshShardDirection getShardDirection() const {
@@ -93,8 +102,8 @@ private:
   // op will be ignored at runtime by simply copying input tensor to output.
   void setDummyShardingOp() { shardType = mlir::tt::MeshShardType::Identity; }
 
-  // Decide wheter to create mesh_shard op and shard_type. Detailed description
-  // can be found in function body.
+  // Decide wheter to create mesh_shard op and shard_type. Detailed
+  // description can be found in function body.
   bool determineMeshShardOpCreationAndShardType(bool foundArgSharding);
 
 private:
@@ -105,6 +114,7 @@ private:
   llvm::SmallVector<int64_t> shardDims{-1};
   llvm::SmallVector<int64_t> meshShape{-1};
   llvm::SmallVector<int64_t> deviceIds{-1};
+  std::string meshName;
   bool lastTileDimReplicate = false;
 };
 

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -464,24 +464,46 @@ def TT_MeshShardTypeAttr : EnumAttr<TT_Dialect, TT_MeshShardType, "shard_type"> 
   let assemblyFormat = "`<` $value `>`";
 }
 
-def TT_TensorMeshShardingAttr : TT_Attr<"TensorMeshSharding", "mesh_sharding", []> {
-  let summary = "Tensor MeshSharding attribute in TT dialect.";
+def TT_TensorMeshShardingAxisAttr : TT_Attr<"TensorMeshShardingAxis", "tensor_sharding", []> {
+  let summary = "Tensor mesh sharding axis info attribute in TT dialect.";
   let description = [{
-    Describes how a tensor is sharded including name and axes. With mesh name 'mesh',
-    a tensor with TensorMeshShardingAttr can be represented as
-      tensor<1x1024x128x128xf32, #tt.mesh_sharding<"mesh">> if axes info is not available,
-      or
-      tensor<1x1024x128x128xf32, #tt.mesh_sharding<"mesh" : [-1, -1, 0, 1]>> with some axes info.
+    Details per tensor dimension sharding and axes info.
+    - shard_shape: shard shape at a tensor dimension.
+    - (optional) axes: mesh shard dimensions. Axes may be empty if it is not being sharded.
+  }];
+  let parameters = (ins "int64_t":$shard_shape,
+                        OptionalArrayRefParameter<"int64_t">:$axes);
+  let assemblyFormat = "$shard_shape (`(`$axes^`)`)?";
+}
+
+def TT_TensorMeshShardingAttr : TT_Attr<"TensorMeshSharding", "mesh_sharding", []> {
+  let summary = "Tensor mesh sharding attribute in TT dialect.";
+  let description = [{
+    Describes a tensor's multi-device status.
+    - Single device tensor has no TensorMeshShardingAttr.
+        tensor<784x16384xf32>
+
+    - Multi-device tensors have TensorMeshShardingAttr.
+      (i) multi-device tensor without tensor mesh shard axis indicates all devices in "mesh"
+          have full size tensors e.g., 784x16384 for
+            tensor<784x16384xf32, #tt.mesh_sharding<"mesh">>
+
+      (ii) multi-device tensor with tensor mesh shard axis indicate all devices in "mesh"
+          have sharded tensor defined by the TensorMeshShardingAxisAttr. e.g., 192x16384 for
+            tensor<784x16384xf32, #tt.mesh_sharding<"mesh" : [ 4(1),  1]>>.
+          Here, 4(1) indicates shard_shape(shard_dim), so 784 should be sharded by 4
+          at "mesh"'s second hardware dimension. 1 indicates no sharding, so 16384 is not
+          being sharded.
   }];
   let parameters = (ins "StringAttr":$name,
-                        OptionalArrayRefParameter<"int64_t">:$axes);
-  let assemblyFormat = "`<` $name (`:` `[` $axes^ `]`)? `>`";
+                        OptionalArrayRefParameter<"TensorMeshShardingAxisAttr">:$tensor_mesh_sharding_axis);
+  let assemblyFormat = "`<` $name (`:` `[`$tensor_mesh_sharding_axis^`]`)? `>`";
 
   let extraClassDeclaration = [{
       static TensorMeshShardingAttr get(::mlir::MLIRContext *context, StringRef name) {
         auto meshNameStrAttr = mlir::StringAttr::get(context, name);
-        ::llvm::ArrayRef<int64_t> axes;
-        return TensorMeshShardingAttr::get(context, meshNameStrAttr, axes);
+        ::llvm::SmallVector<TensorMeshShardingAxisAttr> tensor_mesh_sharding_axis;
+        return TensorMeshShardingAttr::get(context, meshNameStrAttr, tensor_mesh_sharding_axis);
       }
   }];
 }

--- a/test/ttmlir/Conversion/StableHLOToTTIR/ccl/ccl_ops_shardy.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/ccl/ccl_ops_shardy.mlir
@@ -331,8 +331,8 @@ module @jit_matmul_shardy_automatic attributes {mhlo.num_partitions = 8 : i32, m
   }
 }
 // CHECK-LABEL @main
-// CHECK: %arg{{[0-9]+}}: tensor<8192x784xf32, #tt.mesh_sharding<"mesh">>
-// CHECK-SAME: %arg{{[0-9]+}}: tensor<784x16384xf32, #tt.mesh_sharding<"mesh">>
+// CHECK: %arg{{[0-9]+}}: tensor<8192x784xf32, #tt.mesh_sharding<"mesh" : [ 2(0),  4(1)]>>
+// CHECK-SAME: %arg{{[0-9]+}}: tensor<784x16384xf32, #tt.mesh_sharding<"mesh" : [ 4(1),  1]>>
 // CHECK-NOT: tensor<8192x16384xf32, #tt.mesh_sharding<"mesh">>
 // CHECK-SAME: tensor<8192x16384xf32>
 
@@ -341,7 +341,7 @@ module @jit_matmul_shardy_automatic attributes {mhlo.num_partitions = 8 : i32, m
 // CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
 // CHECK-SAME: shard_shape = array<i64: 2, 4>
 // CHECK-SAME: shard_type = #tt.shard_type<identity>
-// CHECK-SAME: tensor<8192x784xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: tensor<8192x784xf32, #tt.mesh_sharding<"mesh" : [ 2(0),  4(1)]>>
 // CHECK-SAME: tensor<4096x196xf32, #tt.mesh_sharding<"mesh">>
 // CHECK-SAME: tensor<4096x196xf32, #tt.mesh_sharding<"mesh">>
 
@@ -350,7 +350,7 @@ module @jit_matmul_shardy_automatic attributes {mhlo.num_partitions = 8 : i32, m
 // CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
 // CHECK-SAME: shard_shape = array<i64: 4, 1>
 // CHECK-SAME: shard_type = #tt.shard_type<identity>
-// CHECK-SAME: tensor<784x16384xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: tensor<784x16384xf32, #tt.mesh_sharding<"mesh" : [ 4(1),  1]>>
 // CHECK-SAME: tensor<196x16384xf32, #tt.mesh_sharding<"mesh">>
 // CHECK-SAME: tensor<196x16384xf32, #tt.mesh_sharding<"mesh">>
 
@@ -389,16 +389,16 @@ module @jit_matmul_shardy1 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_r
   }
 }
 // CHECK-LABEL @main
-// CHECK: %arg{{[0-9]+}}: tensor<8192x784xf32, #tt.mesh_sharding<"mesh">>
-// CHECK-SAME: %arg{{[0-9]+}}: tensor<784x16384xf32, #tt.mesh_sharding<"mesh">>
-// CHECK-SAME: tensor<8192x16384xf32, #tt.mesh_sharding<"mesh">>
+// CHECK: %arg{{[0-9]+}}: tensor<8192x784xf32, #tt.mesh_sharding<"mesh" : [ 2(0),  4(1)]>>
+// CHECK-SAME: %arg{{[0-9]+}}: tensor<784x16384xf32, #tt.mesh_sharding<"mesh" : [ 4(1),  1]>>
+// CHECK-SAME: tensor<8192x16384xf32, #tt.mesh_sharding<"mesh" : [ 2(0),  1]>>
 
 // CHECK: "ttir.mesh_shard"
 // CHECK-SAME: shard_dims = array<i64: 0, 1>
 // CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
 // CHECK-SAME: shard_shape = array<i64: 2, 4>
 // CHECK-SAME: shard_type = #tt.shard_type<identity>
-// CHECK-SAME: tensor<8192x784xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: tensor<8192x784xf32, #tt.mesh_sharding<"mesh" : [ 2(0),  4(1)]>>
 // CHECK-SAME: tensor<4096x196xf32, #tt.mesh_sharding<"mesh">>
 // CHECK-SAME: tensor<4096x196xf32, #tt.mesh_sharding<"mesh">>
 
@@ -407,7 +407,7 @@ module @jit_matmul_shardy1 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_r
 // CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
 // CHECK-SAME: shard_shape = array<i64: 4, 1>
 // CHECK-SAME: shard_type = #tt.shard_type<identity>
-// CHECK-SAME: tensor<784x16384xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: tensor<784x16384xf32, #tt.mesh_sharding<"mesh" : [ 4(1),  1]>>
 // CHECK-SAME: tensor<196x16384xf32, #tt.mesh_sharding<"mesh">>
 // CHECK-SAME: tensor<196x16384xf32, #tt.mesh_sharding<"mesh">>
 
@@ -422,5 +422,5 @@ module @jit_matmul_shardy1 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_r
 // CHECK-SAME: shard_shape = array<i64: 2, 1>
 // CHECK-SAME: shard_type = #tt.shard_type<identity>
 // CHECK-SAME: tensor<4096x16384xf32, #tt.mesh_sharding<"mesh">>
-// CHECK-SAME: tensor<8192x16384xf32, #tt.mesh_sharding<"mesh">>
-// CHECK-SAME: tensor<8192x16384xf32, #tt.mesh_sharding<"mesh">>
+// CHECK-SAME: tensor<8192x16384xf32, #tt.mesh_sharding<"mesh" : [ 2(0),  1]>>
+// CHECK-SAME: tensor<8192x16384xf32, #tt.mesh_sharding<"mesh" : [ 2(0),  1]>>

--- a/test/ttmlir/Conversion/StableHLOToTTIR/ccl/e2e_tp_shardy.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/ccl/e2e_tp_shardy.mlir
@@ -150,6 +150,7 @@ module @jit_loss_tp attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas
 // CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
 // CHECK-SAME: shard_shape = array<i64: 8, 1>
 // CHECK-SAME: shard_type = #tt.shard_type<identity>
+
 // CHECK: "ttir.mesh_shard"
 // CHECK-SAME: shard_dims = array<i64: -1, 0>
 // CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
@@ -195,6 +196,32 @@ module @jit_loss_tp attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas
 // CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
 // CHECK-SAME: shard_shape = array<i64: 8>
 // CHECK-SAME: shard_type = #tt.shard_type<identity>
+// CHECK: "ttir.mesh_shard"
+// CHECK-SAME: shard_dims = array<i64: -1, 1>
+// CHECK-SAME: shard_direction = #tt.shard_direction<shard_to_full>
+// CHECK-SAME: shard_shape = array<i64: 1, 8>
+// CHECK-SAME: shard_type = #tt.shard_type<devices>
+
+// CHECK: "ttir.mesh_shard"
+// CHECK-SAME: shard_dims = array<i64: -1, 1>
+// CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
+// CHECK-SAME: shard_shape = array<i64: 1, 8>
+// CHECK-SAME: shard_type = #tt.shard_type<devices>
+// CHECK: "ttir.mesh_shard"
+// CHECK-SAME: shard_dims = array<i64: -1, 0>
+// CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
+// CHECK-SAME: shard_shape = array<i64: 8, 1>
+// CHECK-SAME: shard_type = #tt.shard_type<identity>
+// CHECK: "ttir.mesh_shard"
+// CHECK-SAME: shard_dims = array<i64: -1, 0>
+// CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
+// CHECK-SAME: shard_shape = array<i64: 8>
+// CHECK-SAME: shard_type = #tt.shard_type<identity>
+// CHECK: "ttir.mesh_shard"
+// CHECK-SAME: shard_dims = array<i64: -1, 1>
+// CHECK-SAME: shard_direction = #tt.shard_direction<shard_to_full>
+// CHECK-SAME: shard_shape = array<i64: 1, 8>
+// CHECK-SAME: shard_type = #tt.shard_type<devices>
 // CHECK: "ttir.mesh_shard"
 // CHECK-SAME: shard_dims = array<i64: -1, 1>
 // CHECK-SAME: shard_direction = #tt.shard_direction<shard_to_full>


### PR DESCRIPTION
maintaining multi-device tensors with pre-sharded inputs.

### Ticket
https://github.com/tenstorrent/tt-mlir/issues/2429

### Problem description
1. Some multi-device tensors need extra information to understand the actual shape of tensors across devices.
2. Some ops with pre-sharded input tensors try to compute single-device tensor with multi-device tensor. 

### What's changed
1. Elaborate multi-device tensors with extra sharding info if tensor shape is full shape.
    - Single device tensor has no TensorMeshShardingAttr.
        tensor<784x16384xf32>

    - Multi-device tensors have TensorMeshShardingAttr.
      (i) multi-device tensor without tensor mesh shard axis indicates all devices in "mesh"
          have tensors with the given shape. e.g., 784x16384 for
            tensor<784x16384xf32, #tt.mesh_sharding<"mesh">>

      (ii) multi-device tensor with tensor mesh shard axis indicate all devices in "mesh"
          have sharded tensor shape defined by the TensorMeshShardingAxisAttr. e.g., 196x16384 for
            tensor<784x16384xf32, #tt.mesh_sharding<"mesh" : [ 4(1),  1]>>.
          Here, 4(1) indicates shard_shape(shard_dim), so 784 should be sharded by 4
          at "mesh"'s second hardware dimension. 1 indicates no sharding, so 16384 is not
          being sharded.

2. Insert extra mesh_shard op for pre-sharded tensors that are computing with single-device tensors.

### Checklist
- [X] New/Existing tests provide coverage for changes
