### PR TITLE
#2506: Fixed bug where flatbuffer dependencies were not getting regenerated in incremental build

### DIFF
--- a/cmake/modules/BuildFlatbuffers.cmake
+++ b/cmake/modules/BuildFlatbuffers.cmake
@@ -1,7 +1,17 @@
 find_program(FLATBUFFERS_COMPILER flatc)
 
 function(build_flatbuffers sources target)
+# Query deps if they exist
+set(deps)
+if(ARGC GREATER 2)
+  foreach(target_dep IN LISTS ARGV2)
+    get_property(target_sources TARGET ${target_dep} PROPERTY SOURCES)
+    list(APPEND deps ${target_sources})
+  endforeach()
+endif()
+
 set(FBS_GEN_OUTPUTS)
+
 foreach(FILE ${sources})
   get_filename_component(BASE_NAME ${FILE} NAME_WE)
   add_custom_command(OUTPUT
@@ -13,10 +23,10 @@ foreach(FILE ${sources})
     ARGS --cpp --cpp-std c++17
     ARGS --scoped-enums --warnings-as-errors
     ARGS -o "${CMAKE_CURRENT_BINARY_DIR}/" "${FILE}"
-    DEPENDS ${FILE}
+    DEPENDS ${FILE} ${deps} ${sources}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
   list(APPEND FBS_GEN_OUTPUTS ${CMAKE_CURRENT_BINARY_DIR}/${BASE_NAME}_generated.h)
   list(APPEND FBS_GEN_OUTPUTS ${CMAKE_CURRENT_BINARY_DIR}/${BASE_NAME}_bfbs_generated.h)
 endforeach()
-add_custom_target(${target} DEPENDS ${FBS_GEN_OUTPUTS})
+add_library(${target} INTERFACE ${FBS_GEN_OUTPUTS})
 endfunction()

--- a/include/ttmlir/Target/TTMetal/CMakeLists.txt
+++ b/include/ttmlir/Target/TTMetal/CMakeLists.txt
@@ -7,4 +7,4 @@ set(TTMETAL_FBS_GEN_SOURCES
   binary.fbs
 )
 
-build_flatbuffers("${TTMETAL_FBS_GEN_SOURCES}" TTMETAL_FBS)
+build_flatbuffers("${TTMETAL_FBS_GEN_SOURCES}" TTMETAL_FBS COMMON_FBS)

--- a/include/ttmlir/Target/TTNN/CMakeLists.txt
+++ b/include/ttmlir/Target/TTNN/CMakeLists.txt
@@ -6,4 +6,4 @@ set(TTNN_FBS_GEN_SOURCES
   program.fbs
 )
 
-build_flatbuffers("${TTNN_FBS_GEN_SOURCES}" TTNN_FBS)
+build_flatbuffers("${TTNN_FBS_GEN_SOURCES}" TTNN_FBS COMMON_FBS)


### PR DESCRIPTION
When trying to do incremental builds, there was a bug where flatc compiler did not regenerate the correct dependencies for a root flatbuffer schema if any of the dependencies were changed. This lead to seg faults when trying to read the flatbuffer in ttrt (since the runtime was using the serialized schema bytes from an old build and not the latest).