### PR TITLE
Implement op constraints & runtime API for MaxPool2D

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1275,14 +1275,15 @@ def TTNN_ConvTranspose2dOp : TTNN_Op<"conv_transpose2d"> {
     let hasVerifier = 1;
 }
 
-def TTNN_MaxPool2dOp : TTNN_Op<"max_pool2d"> {
+def TTNN_MaxPool2dOp : TTNN_Op<"max_pool2d",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
     let summary = "Applies a 2D max pooling over an input signal composed of several input planes.";
     let description = [{
       Applies a 2D max pooling over an input signal composed of several input planes.
     }];
 
     let arguments = (ins AnyRankedTensor:$input,
-                         TTNN_Device:$device,
                          SI32Attr:$batch_size,
                          SI32Attr:$input_height,
                          SI32Attr:$input_width,

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -9,6 +9,7 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/Error.h"
 
 #include <tuple>
 
@@ -262,6 +263,30 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
              mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
 
 }; // namespace Conv2dOpInterface
+
+//===----------------------------------------------------------------------===//
+// MaxPool2D
+//===----------------------------------------------------------------------===//
+namespace MaxPool2DInterface {
+llvm::Expected<std::tuple<size_t, size_t, size_t>> getOpConstraints(
+    llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayout, int32_t batchSize,
+    int32_t inputHeight, int32_t inputWidth, int32_t inputChannels,
+    llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
+    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
+    bool ceilMode, llvm::ArrayRef<int64_t> outputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+
+llvm::Expected<size_t>
+getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayout, int32_t batchSize,
+             int32_t inputHeight, int32_t inputWidth, int32_t inputChannels,
+             llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
+             llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
+             bool ceilMode, llvm::ArrayRef<int64_t> outputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+
+}; // namespace MaxPool2DInterface
 
 } // namespace mlir::tt::op_model::ttnn
 #endif // TTMLIR_OPMODEL_TTNN_TTNNOPMODEL_H

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -361,7 +361,6 @@ table ConvTranspose2dOp {
 table MaxPool2dOp {
   in: tt.target.ttnn.TensorRef;
   out: tt.target.ttnn.TensorRef;
-  device: tt.target.DeviceRef;
   batch_size: uint32;
   input_height: uint32;
   input_width: uint32;

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -1229,7 +1229,6 @@ public:
            "TTNN max_pool2d does not support padding top/bottom/left/right "
            "separately");
 
-    auto device = mlir::tt::ttnn::utils::getOrInsertDevice(rewriter, op);
     auto inputType = mlir::cast<RankedTensorType>(adaptor.getInput().getType());
     llvm::ArrayRef<std::int64_t> inputShape = inputType.getShape();
 
@@ -1266,7 +1265,7 @@ public:
 
     auto newPool = rewriter.create<ttnn::MaxPool2dOp>(
         op.getLoc(), this->getTypeConverter()->convertType(outputType),
-        flattenedInput, device, batchSize,
+        flattenedInput, batchSize,
         static_cast<int32_t>(inputShape[inputShape.size() - 3]),
         static_cast<int32_t>(inputShape[inputShape.size() - 2]), channels,
         kernelSizeAttr, strideAttr, paddingAttr, dilationAttr,

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -475,4 +475,44 @@ Conv2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
       getDilation(), getGroups(), getConv2dConfig(), outputShape, output);
 }
 
+//===----------------------------------------------------------------------===//
+// MaxPool2dOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<std::tuple<size_t, size_t, size_t>>
+MaxPool2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                              const TTNNLayoutAttr &output) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  const auto outputShape =
+      mlir::cast<RankedTensorType>(getResult().getType()).getShape();
+
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  return op_model::ttnn::MaxPool2DInterface::getOpConstraints(
+      inputShape, inputs[0], getBatchSize(), getInputHeight(), getInputWidth(),
+      getChannels(), getKernelSize(), getStride(), getPadding(), getDilation(),
+      getCeilMode(), outputShape, output);
+}
+
+llvm::Expected<size_t>
+MaxPool2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                          const TTNNLayoutAttr &output) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  const auto outputShape =
+      mlir::cast<RankedTensorType>(getResult().getType()).getShape();
+
+  return op_model::ttnn::MaxPool2DInterface::getOpRuntime(
+      inputShape, inputs[0], getBatchSize(), getInputHeight(), getInputWidth(),
+      getChannels(), getKernelSize(), getStride(), getPadding(), getDilation(),
+      getCeilMode(), outputShape, output);
+}
+
 } // namespace mlir::tt::ttnn

--- a/lib/OpModel/TTNN/Conversion.cpp
+++ b/lib/OpModel/TTNN/Conversion.cpp
@@ -168,16 +168,6 @@ convertLLVMSmallVecToTTNNSmallVec(const ::llvm::ArrayRef<int64_t> vec) {
   return ::ttnn::SmallVector<int>(vec.begin(), vec.end());
 }
 
-std::array<uint32_t, 2>
-convertArrayRefToArray(const llvm::ArrayRef<int32_t> array) {
-  assert(array.size() == 2);
-  std::array<uint32_t, 2> result;
-  for (size_t i = 0; i < 2; ++i) {
-    result[i] = static_cast<uint32_t>(array[i]);
-  }
-  return result;
-}
-
 std::optional<::ttnn::operations::conv::conv2d::Conv2dConfig> getConv2dConfig(
     const std::optional<mlir::tt::ttnn::Conv2dConfigAttr> &conv2dConfig) {
   if (!conv2dConfig) {

--- a/lib/OpModel/TTNN/MetalHeaders.h
+++ b/lib/OpModel/TTNN/MetalHeaders.h
@@ -76,6 +76,7 @@ using IDevice = ::tt::tt_metal::IDevice;
 #include "ttnn/operations/eltwise/unary/unary.hpp"
 #include "ttnn/operations/matmul/matmul.hpp"
 #include "ttnn/operations/normalization/softmax/softmax.hpp"
+#include "ttnn/operations/pool/generic/generic_pools.hpp"
 #include "ttnn/operations/reduction/generic/generic_reductions.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/tensor_spec.hpp"

--- a/lib/OpModel/TTNN/TTNNOpModelLib.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModelLib.cpp
@@ -3,13 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "TTNNOpModel.h"
-#include <type_traits>
 
 #ifdef TTMLIR_ENABLE_OPMODEL
+
 #include "Conversion.hpp"
 #include "MetalHeaders.h"
 #include "SingletonDeviceContext.h"
-
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
@@ -19,9 +18,13 @@
 #include "mlir/IR/Types.h"
 #include "llvm/Support/Casting.h"
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <stdexcept>
+#include <type_traits>
+
 #endif // TTMLIR_ENABLE_OPMODEL
 
 namespace mlir::tt::op_model::ttnn {
@@ -999,11 +1002,11 @@ Conv2dOpInterface::getOpConstraints(
         return ::ttnn::graph::query_op_constraints(
             ::ttnn::conv2d, device, inputSpec, weightSpec, device, in_channels,
             out_channels, batch_size, input_height, input_width,
-            conversion::convertArrayRefToArray(kernel_size),
-            conversion::convertArrayRefToArray(stride),
-            conversion::convertArrayRefToArray(padding),
-            conversion::convertArrayRefToArray(dilation), groups, biasTensor,
-            conv2dConfigConverted, std::nullopt,
+            conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(kernel_size),
+            conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(stride),
+            conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(padding),
+            conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(dilation),
+            groups, biasTensor, conv2dConfigConverted, std::nullopt,
             outputSpec.tensor_layout().get_memory_config());
       };
 
@@ -1012,6 +1015,65 @@ Conv2dOpInterface::getOpConstraints(
       weightLayout, biasShape, biasLayout, in_channels, out_channels,
       batch_size, input_height, input_width, kernel_size, stride, padding,
       dilation, groups, conv2dConfig, outputShape, outputLayout);
+#else
+  return std::make_tuple(0, 0, 0);
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
+// MaxPool2D
+//===----------------------------------------------------------------------===//
+llvm::Expected<std::tuple<size_t, size_t, size_t>>
+MaxPool2DInterface::getOpConstraints(
+    llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayout, int32_t batchSize,
+    int32_t inputHeight, int32_t inputWidth, int32_t inputChannels,
+    llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
+    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
+    bool ceilMode, llvm::ArrayRef<int64_t> outputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+
+#ifdef TTMLIR_ENABLE_OPMODEL
+  auto maxPool2DQuery =
+      [](llvm::ArrayRef<int64_t> inputShape,
+         mlir::tt::ttnn::TTNNLayoutAttr inputLayout, int32_t batchSize,
+         int32_t inputHeight, int32_t inputWidth, int32_t inputChannels,
+         llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
+         llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
+         bool ceilMode, llvm::ArrayRef<int64_t> outputShape,
+         mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+        // open device device, will close it at the end of function
+        ::tt::tt_metal::IDevice *device =
+            SingletonDeviceContext::getInstance().getDevice();
+
+        // convert all signed integers to unsigned integers
+        uint32_t batchSizeU = static_cast<uint32_t>(batchSize);
+        uint32_t inputHeightU = static_cast<uint32_t>(inputHeight);
+
+        uint32_t inputWidthU = static_cast<uint32_t>(inputWidth);
+
+        uint32_t inputChannelsU = static_cast<uint32_t>(inputChannels);
+
+        // prepare io specs
+        const auto [inputSpec, outputSpec] = detail::convertToTensorSpec(
+            device, std::make_tuple(inputShape, inputLayout),
+            std::make_tuple(outputShape, outputLayout));
+
+        return ::ttnn::graph::query_op_constraints(
+            ::ttnn::max_pool2d, device, inputSpec, batchSizeU, inputHeightU,
+            inputWidthU, inputChannelsU,
+            conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(kernelSize),
+            conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(stride),
+            conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(padding),
+            conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(dilation),
+            outputSpec.tensor_layout().get_memory_config(),
+            std::nullopt /* applied_shard_scheme */, ceilMode);
+      };
+
+  return operation::getOpConstraints(
+      "MaxPool2DInterface", maxPool2DQuery, inputShape, inputLayout, batchSize,
+      inputHeight, inputWidth, inputChannels, kernelSize, stride, padding,
+      dilation, ceilMode, outputShape, outputLayout);
 #else
   return std::make_tuple(0, 0, 0);
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1071,11 +1133,11 @@ llvm::Expected<size_t> Conv2dOpInterface::getOpRuntime(
         return ::ttnn::graph::query_op_runtime(
             ::ttnn::conv2d, device, inputSpec, weightSpec, device, in_channels,
             out_channels, batch_size, input_height, input_width,
-            conversion::convertArrayRefToArray(kernel_size),
-            conversion::convertArrayRefToArray(stride),
-            conversion::convertArrayRefToArray(padding),
-            conversion::convertArrayRefToArray(dilation), groups, biasTensor,
-            conv2dConfigConverted, std::nullopt,
+            conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(kernel_size),
+            conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(stride),
+            conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(padding),
+            conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(dilation),
+            groups, biasTensor, conv2dConfigConverted, std::nullopt,
             outputSpec.tensor_layout().get_memory_config());
       };
 
@@ -1084,6 +1146,60 @@ llvm::Expected<size_t> Conv2dOpInterface::getOpRuntime(
       weightLayout, biasShape, biasLayout, in_channels, out_channels,
       batch_size, input_height, input_width, kernel_size, stride, padding,
       dilation, groups, conv2dConfig, outputShape, outputLayout);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t> MaxPool2DInterface::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayout, int32_t batchSize,
+    int32_t inputHeight, int32_t inputWidth, int32_t inputChannels,
+    llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
+    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
+    bool ceilMode, llvm::ArrayRef<int64_t> outputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  auto maxPool2DQuery =
+      [](llvm::ArrayRef<int64_t> inputShape,
+         mlir::tt::ttnn::TTNNLayoutAttr inputLayout, int32_t batchSize,
+         int32_t inputHeight, int32_t inputWidth, int32_t inputChannels,
+         llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
+         llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
+         bool ceilMode, llvm::ArrayRef<int64_t> outputShape,
+         mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+        // open device device, will close it at the end of function
+        ::tt::tt_metal::IDevice *device =
+            SingletonDeviceContext::getInstance().getDevice();
+
+        // convert all signed integers to unsigned integers
+        uint32_t batchSizeU = static_cast<uint32_t>(batchSize);
+        uint32_t inputHeightU = static_cast<uint32_t>(inputHeight);
+
+        uint32_t inputWidthU = static_cast<uint32_t>(inputWidth);
+
+        uint32_t inputChannelsU = static_cast<uint32_t>(inputChannels);
+
+        // prepare io specs
+        const auto [inputSpec, outputSpec] = detail::convertToTensorSpec(
+            device, std::make_tuple(inputShape, inputLayout),
+            std::make_tuple(outputShape, outputLayout));
+
+        return ::ttnn::graph::query_op_runtime(
+            ::ttnn::max_pool2d, device, inputSpec, batchSizeU, inputHeightU,
+            inputWidthU, inputChannelsU,
+            conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(kernelSize),
+            conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(stride),
+            conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(padding),
+            conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(dilation),
+            outputSpec.tensor_layout().get_memory_config(),
+            std::nullopt /* applied_shard_scheme */, ceilMode);
+      };
+
+  return operation::getOpRuntime(
+      "MaxPool2DInterface", maxPool2DQuery, inputShape, inputLayout, batchSize,
+      inputHeight, inputWidth, inputChannels, kernelSize, stride, padding,
+      dilation, ceilMode, outputShape, outputLayout);
 #else
   return llvm::createStringError("Not Implemented");
 #endif // TTMLIR_ENABLE_OPMODEL

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -1386,12 +1386,10 @@ createMaxPool2dOp(FlatbufferObjectCache &cache, MaxPool2dOp op) {
   ::flatbuffers::Offset<::flatbuffers::Vector<int32_t>> dilation =
       toFlatbuffer(cache, op.getDilation());
 
-  auto device = getOperandThroughDPSOps(op.getDevice());
   return ::tt::target::ttnn::CreateMaxPool2dOp(
-      *cache.fbb, in, out, cache.at<::tt::target::DeviceRef>(device),
-      op.getBatchSize(), op.getInputHeight(), op.getInputWidth(),
-      op.getChannels(), kernelSize, stride, padding, dilation,
-      op.getCeilMode());
+      *cache.fbb, in, out, op.getBatchSize(), op.getInputHeight(),
+      op.getInputWidth(), op.getChannels(), kernelSize, stride, padding,
+      dilation, op.getCeilMode());
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::RepeatInterleaveOp>

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/max_pool2d_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/max_pool2d_workaround.mlir
@@ -18,9 +18,9 @@ module attributes {} {
     // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: memory_config = #ttnn.memory_config<#dram, <<16384x32>>, <interleaved>>
     // CHECK-SAME: -> tensor<1x1x16384x32xbf16,
-    // %3 = "ttnn.max_pool2d"(%2, %0) <{batch_size = 1 : si32, ceil_mode = false, channels = 32 : si32, dilation_height = 1 : si32, dilation_width = 1 : si32, input_height = 128 : si32, input_width = 128 : si32, kernel_height = 2 : si32, kernel_width = 2 : si32, padding_height = 0 : si32, padding_width = 0 : si32, stride_height = 2 : si32, stride_width = 2 : si32}> : (tensor<1x1x16384x32xf32, #ttnn_layout2>, !ttnn.device) -> tensor<1x1x4096x32xf32, #ttnn_layout3>
-    %3 = "ttnn.max_pool2d"(%2, %0) <{batch_size = 1 : si32, ceil_mode = false, channels = 32 : si32, input_height = 128 : si32, input_width = 128 : si32, kernel_size = array<i32: 2, 2>, stride = array<i32: 2, 2>, dilation = array<i32: 1, 1>, padding = array<i32: 0, 0>}> : (tensor<1x1x16384x32xf32, #ttnn_layout2>, !ttnn.device) -> tensor<1x1x4096x32xf32, #ttnn_layout3>
-    // CHECK-NEXT: %[[MAX_POOL_2D_OP:.*]] = "ttnn.max_pool2d"(%[[TO_LAYOUT_INPUT]], %[[DEVICE_OP]])
+    // %3 = "ttnn.max_pool2d"(%2, %0) <{batch_size = 1 : si32, ceil_mode = false, channels = 32 : si32, dilation_height = 1 : si32, dilation_width = 1 : si32, input_height = 128 : si32, input_width = 128 : si32, kernel_height = 2 : si32, kernel_width = 2 : si32, padding_height = 0 : si32, padding_width = 0 : si32, stride_height = 2 : si32, stride_width = 2 : si32}> : (tensor<1x1x16384x32xf32, #ttnn_layout2>, !tt.device<#device>) -> tensor<1x1x4096x32xf32, #ttnn_layout3>
+    %3 = "ttnn.max_pool2d"(%2) <{batch_size = 1 : si32, ceil_mode = false, channels = 32 : si32, input_height = 128 : si32, input_width = 128 : si32, kernel_size = array<i32: 2, 2>, stride = array<i32: 2, 2>, dilation = array<i32: 1, 1>, padding = array<i32: 0, 0>}> : (tensor<1x1x16384x32xf32, #ttnn_layout2>) -> tensor<1x1x4096x32xf32, #ttnn_layout3>
+    // CHECK-NEXT: %[[MAX_POOL_2D_OP:.*]] = "ttnn.max_pool2d"(%[[TO_LAYOUT_INPUT]])
     // Check that the output operand is transformed back into the tile and f32 data type.
     // CHECK-NEXT: %[[TO_LAYOUT_OUTPUT:.*]] = "ttnn.to_layout"(%[[MAX_POOL_2D_OP]], %[[DEVICE_OP]])
     // CHECK-SAME: dtype = #tt.supportedDataTypes<f32>

--- a/test/unittests/OpModel/TTNN/OpModelFixture.h
+++ b/test/unittests/OpModel/TTNN/OpModelFixture.h
@@ -62,8 +62,18 @@ public:
       const mlir::tt::ttnn::TensorMemoryLayout &tensorMemoryLayout,
       const llvm::ArrayRef<int64_t> &gridPhyCores = GetPhysicalGridSize()) {
 
+    // Usually tensors are of rank 2, but in case of MaxPool2D or Conv2D ops, it
+    // is 4. Anyway this tensor will be flattened to {1, 1, Y, X} shape.
+    assert(tensorShape.size() >= 2);
+    for (size_t i = 0; i < tensorShape.size() - 2; i++) {
+      assert(tensorShape[i] == 1);
+    }
+    int32_t tensorRank = tensorShape.size();
+    int64_t tensorSizeX = tensorShape[tensorRank - 1];
+    int64_t tensorSizeY = tensorShape[tensorRank - 2];
+
     llvm::SmallVector<int64_t> tensorShapeTiles =
-        GetTensorShapeInTiles(tensorShape);
+        GetTensorShapeInTiles({tensorSizeY, tensorSizeX});
 
     int64_t tensorTiles = 1;
     for (const auto &dim : tensorShapeTiles) {


### PR DESCRIPTION
### Ticket

Related to https://github.com/tenstorrent/tt-mlir/issues/2277

### Problem description

Optimizer needs constraints and runtime model for every op in order to shard them properly. This commit adds support for MaxPool 2D op in that regard.

### What's changed

Implementation for GetOpConstraints & GetOpRuntime for MaxPool2D.
Unit tests for MaxPool2D API.

### Checklist

- [x]  New/Existing tests provide coverage for changes
