### PR TITLE
Fix pad op issues on output tensor

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -1515,6 +1515,7 @@ def TTIR_PadOp: TTIR_Op<"pad"> {
     }];
 
     let arguments = (ins AnyRankedTensor:$input,
+                         AnyRankedTensor:$output,
                          DenseI32ArrayAttr:$padding,
                          F32Attr:$value);
 

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -1488,7 +1488,7 @@ def TTIR_ReshapeOp: TTIR_NamedOp<"reshape"> {
     let hasFolder = 1;
 }
 
-def TTIR_PadOp: TTIR_Op<"pad"> {
+def TTIR_PadOp: TTIR_NamedOp<"pad"> {
     let summary = "Pad op.";
     let description = [{
       Pad input tensor with tuple of padding values.

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -2194,7 +2194,7 @@ public:
         outputType,                            // result type
         adaptor.getOperand(),                  // input
         rewriter.getDenseI32ArrayAttr(padDim), // padding dimensions
-        rewriter.getF32FloatAttr(value)        // padding value
+        rewriter.getF32FloatAttr(value)        // padding f32 value
     );
 
     return success();

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -2189,12 +2189,12 @@ public:
       value = paddingValueAttr.getSplatValue<APFloat>().convertToDouble();
     }
 
-    rewriter.replaceOpWithNewOp<mlir::tt::ttir::PadOp>(
-        srcOp,
+    ttmlir::utils::replaceOpWithNewDPSOp<mlir::tt::ttir::PadOp>(
+        rewriter, srcOp,
         outputType,                            // result type
         adaptor.getOperand(),                  // input
         rewriter.getDenseI32ArrayAttr(padDim), // padding dimensions
-        rewriter.getF32FloatAttr(value)        // padding f32 value
+        rewriter.getF32FloatAttr(value)        // padding value
     );
 
     return success();

--- a/python/test_infra/ttir_builder.py
+++ b/python/test_infra/ttir_builder.py
@@ -1287,10 +1287,19 @@ class TTIRBuilder:
         return self.op_proxy(
             torch.nn.functional.pad,
             ttir.PadOp,
-            [in0],
-            golden_kwargs={"pad": golden_padding, "mode": "constant", "value": value},
+            [in0, in1],
+            golden_kwargs={
+                "pad": tuple(golden_padding),
+                "mode": "constant",
+                "value": value,
+            },
             ttir_kwargs={"padding": padding, "value": value},
-            organize_ttir_args=lambda i, o, _: (self._get_type(o), i[0]),
+            organize_golden_args=lambda i: [self._get_golden_tensor(i[0])],
+            organize_ttir_args=lambda i, o, _: (
+                self._get_type(o),
+                i[0],
+                i[1],
+            ),
         )
 
     def select(

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -649,6 +649,7 @@ def test_max_pool2d(in0: Operand, in1: Operand, builder: TTIRBuilder):
 
 
 @compile_to_flatbuffer(
+<<<<<<< HEAD
     [
         (1, 1, 5, 5),
     ],
@@ -657,6 +658,13 @@ def test_max_pool2d(in0: Operand, in1: Operand, builder: TTIRBuilder):
 )
 def test_pad(in0: Operand, builder: TTIRBuilder):
     return builder.pad(in0, padding=[0, 0, 0, 0, 1, 1, 1, 1], value=0)
+=======
+    [(32, 32), (34, 33)],
+    targets=["ttnn"],
+)
+def test_pad(in0: Operand, in1: Operand, builder: TTIRBuilder):
+    return builder.pad(in0, in1, padding=[0, 2, 1, 0], value=0)
+>>>>>>> a8b3aef8 (pad op fix mlir)
 
 
 @compile_to_flatbuffer([(32, 64)], targets=["ttnn"])

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -649,22 +649,11 @@ def test_max_pool2d(in0: Operand, in1: Operand, builder: TTIRBuilder):
 
 
 @compile_to_flatbuffer(
-<<<<<<< HEAD
-    [
-        (1, 1, 5, 5),
-    ],
-    inputs_types=[torch.bfloat16],
-    targets=["ttnn"],
-)
-def test_pad(in0: Operand, builder: TTIRBuilder):
-    return builder.pad(in0, padding=[0, 0, 0, 0, 1, 1, 1, 1], value=0)
-=======
     [(32, 32), (34, 33)],
     targets=["ttnn"],
 )
 def test_pad(in0: Operand, in1: Operand, builder: TTIRBuilder):
     return builder.pad(in0, in1, padding=[0, 2, 1, 0], value=0)
->>>>>>> a8b3aef8 (pad op fix mlir)
 
 
 @compile_to_flatbuffer([(32, 64)], targets=["ttnn"])

--- a/test/ttmlir/Conversion/StableHLOToTTIR/pad_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/pad_op.mlir
@@ -5,7 +5,6 @@ module {
     // CHECK: ttir.pad
     // CHECK-SAME: padding = array<i32: 0, 0, 0, 4, 0, 4, 0, 0>
     // CHECK-SAME: value = 0.000000e+00 : f32
-    // CHECK-SAME: (tensor<1x128x128x384xf32>) -> tensor<1x132x132x384xf32>
     %cst = arith.constant dense<0.000000e+00> : tensor<1xf64>
     %0 = stablehlo.convert %cst : (tensor<1xf64>) -> tensor<1xf32>
     %1 = stablehlo.reshape %0 : (tensor<1xf32>) -> tensor<f32>
@@ -19,7 +18,6 @@ module {
     // CHECK: ttir.pad
     // CHECK-SAME: padding = array<i32: 0, 0, 0, 8, 0, 8, 0, 0>
     // CHECK-SAME: value = 0.000000e+00 : f32
-    // CHECK-SAME: (tensor<1x64x64x384xf32>) -> tensor<1x72x72x384xf32>
     %cst = arith.constant dense<0.000000e+00> : tensor<1xf64>
     %0 = stablehlo.convert %cst : (tensor<1xf64>) -> tensor<1xf32>
     %1 = stablehlo.reshape %0 : (tensor<1xf32>) -> tensor<f32>
@@ -47,28 +45,10 @@ module {
     // CHECK: ttir.pad
     // CHECK-SAME: padding = array<i32: 0, 0, 0, 8, 0, 8, 0, 0>
     // CHECK-SAME: value = 0.000000e+00 : f32
-    // CHECK-SAME: (tensor<1x64x64x768xi32>) -> tensor<1x72x72x768xi32>
-    %cst = arith.constant dense<0> : tensor<1xi32>
-    %0 = stablehlo.convert %cst : (tensor<1xi32>) -> tensor<1xi32>
-    %1 = stablehlo.reshape %0 : (tensor<1xi32>) -> tensor<i32>
-    %2 = stablehlo.pad %arg0, %1, low = [0, 0, 0, 0], high = [0, 8, 8, 0], interior = [0, 0, 0, 0] : (tensor<1x64x64x768xi32>, tensor<i32>) -> tensor<1x72x72x768xi32>
-    return %2 : tensor<1x72x72x768xi32>
-  }
-}
-
-module {
-  func.func public @main(%arg0: tensor<4x54x54x64xbf16> ) -> (tensor<4x54x54x68xbf16>) {
-    // CHECK: ttir.pad
-    // CHECK-SAME: padding = array<i32: 0, 0, 0, 0, 0, 0, 2, 2>
-    // CHECK-SAME: value = 0.000000e+00 : f32
-    // CHECK-SAME: (tensor<4x54x54x64xbf16>) -> tensor<4x54x54x68xbf16>
-    %cst = stablehlo.constant dense<0> : tensor<i32>
-    %0 = call @_pad(%arg0, %cst) : (tensor<4x54x54x64xbf16>, tensor<i32>) -> tensor<4x54x54x68xbf16>
-    return %0 : tensor<4x54x54x68xbf16>
-  }
-  func.func private @_pad(%arg0: tensor<4x54x54x64xbf16>, %arg1: tensor<i32>) -> tensor<4x54x54x68xbf16> {
-    %0 = stablehlo.convert %arg1 : (tensor<i32>) -> tensor<bf16>
-    %1 = stablehlo.pad %arg0, %0, low = [0, 0, 0, 2], high = [0, 0, 0, 2], interior = [0, 0, 0, 0] : (tensor<4x54x54x64xbf16>, tensor<bf16>) -> tensor<4x54x54x68xbf16>
-    return %1 : tensor<4x54x54x68xbf16>
+    %cst = arith.constant dense<0.000000e+00> : tensor<1xf64>
+    %0 = stablehlo.convert %cst : (tensor<1xf64>) -> tensor<1xf32>
+    %1 = stablehlo.reshape %0 : (tensor<1xf32>) -> tensor<f32>
+    %2 = stablehlo.pad %arg0, %1, low = [0, 0, 0, 0], high = [0, 8, 8, 0], interior = [0, 0, 0, 0] : (tensor<1x64x64x768xf32>, tensor<f32>) -> tensor<1x72x72x768xf32>
+    return %2 : tensor<1x72x72x768xf32>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/simple_pad.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_pad.mlir
@@ -4,7 +4,8 @@ module {
   func.func @main(%arg0: tensor<1x1x5x5xbf16>) -> tensor<1x1x7x7xbf16> {
     // CHECK: ttnn.pad
     // CHECK: padding = array<i32: 0, 0, 0, 0, 1, 1, 1, 1>
-    %1 = "ttir.pad"(%arg0) <{padding = array<i32: 0, 0, 0, 0, 1, 1, 1, 1>, value = 0.000000e+00 : f32}> : (tensor<1x1x5x5xbf16>) -> tensor<1x1x7x7xbf16>
+    %0 = tensor.empty() : tensor<1x1x7x7xbf16>
+    %1 = "ttir.pad"(%arg0,%0) <{padding = array<i32: 0, 0, 0, 0, 1, 1, 1, 1>, value = 0.000000e+00 : f32}> : (tensor<1x1x5x5xbf16>,tensor<1x1x7x7xbf16>) -> tensor<1x1x7x7xbf16>
     return %1 : tensor<1x1x7x7xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/simple_pad.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_pad.mlir
@@ -4,7 +4,7 @@ module {
   func.func @main(%arg0: tensor<1x1x5x5xbf16>) -> tensor<1x1x7x7xbf16> {
     // CHECK: ttnn.pad
     // CHECK: padding = array<i32: 0, 0, 0, 0, 1, 1, 1, 1>
-    %0 = tensor.empty() : tensor<1x1x7x7xbf16>
+    %0 = ttir.empty() : tensor<1x1x7x7xbf16>
     %1 = "ttir.pad"(%arg0,%0) <{padding = array<i32: 0, 0, 0, 0, 1, 1, 1, 1>, value = 0.000000e+00 : f32}> : (tensor<1x1x5x5xbf16>,tensor<1x1x7x7xbf16>) -> tensor<1x1x7x7xbf16>
     return %1 : tensor<1x1x7x7xbf16>
   }

--- a/test/ttmlir/Silicon/TTNN/n150/simple_pad.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_pad.mlir
@@ -4,7 +4,8 @@ module {
   func.func @main(%arg0: tensor<1x128x128x384xf32>) -> tensor<1x132x132x384xf32> {
     // CHECK: ttnn.pad
     // CHECK-SAME: padding = array<i32: 0, 0, 2, 2, 2, 2, 0, 0>
-    %1 = "ttir.pad"(%arg0) <{padding = array<i32: 0, 0, 2, 2, 2, 2, 0, 0>, value = 0.000000e+00 : f32}> : (tensor<1x128x128x384xf32>) -> tensor<1x132x132x384xf32>
+    %0 = tensor.empty() : tensor<1x132x132x384xf32>
+    %1 = "ttir.pad"(%arg0,%0) <{padding = array<i32: 0, 0, 2, 2, 2, 2, 0, 0>, value = 0.000000e+00 : f32}> : (tensor<1x128x128x384xf32>,tensor<1x132x132x384xf32>) -> tensor<1x132x132x384xf32>
     return %1 : tensor<1x132x132x384xf32>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/simple_pad.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_pad.mlir
@@ -4,7 +4,7 @@ module {
   func.func @main(%arg0: tensor<1x128x128x384xf32>) -> tensor<1x132x132x384xf32> {
     // CHECK: ttnn.pad
     // CHECK-SAME: padding = array<i32: 0, 0, 2, 2, 2, 2, 0, 0>
-    %0 = tensor.empty() : tensor<1x132x132x384xf32>
+    %0 = ttir.empty() : tensor<1x132x132x384xf32>
     %1 = "ttir.pad"(%arg0,%0) <{padding = array<i32: 0, 0, 2, 2, 2, 2, 0, 0>, value = 0.000000e+00 : f32}> : (tensor<1x128x128x384xf32>,tensor<1x132x132x384xf32>) -> tensor<1x132x132x384xf32>
     return %1 : tensor<1x132x132x384xf32>
   }


### PR DESCRIPTION
### Issue:
```
Assertion `operands.size() == 1u && "mismatched number of parameters
```
### Description

This PR includes the updated  tablegen for the tensor manipulation PadOp as the dps op and the respective mlir lit test and stablehlotottir pattern and the python ttir pad op test case.



