### PR TITLE
Erase Inverse Ops pass

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,7 @@
 /env/ @nsmithtt @vwellsTT
 *.fbs @jnie-TT @nsmithtt
 /.github/CODEOWNERS @vmilosevic @tapspatel @nsmithtt @sdjordjevicTT @tt-mpantic
+LICENSE @nsmithtt
 
 # CI
 /.github/ @vmilosevic @jmcgrathTT @nsumrakTT
@@ -35,9 +36,9 @@
 /test/ttmlir/Conversion/TTIRToLinalg/ @vwellsTT @ctodTT @nsmithTT
 
 # Tosa Conversion
-/include/ttmlir/Conversion/TosaToTTIR/ @mrakitaTT
-/lib/Conversion/TosaToTTIR/ @mrakitaTT
-/test/ttmlir/Conversion/TosaToTTIR/ @mrakitaTT
+/include/ttmlir/Conversion/TosaToTTIR/ @mrakitaTT @sgligorijevicTT @sdjukicTT
+/lib/Conversion/TosaToTTIR/ @mrakitaTT @sgligorijevicTT @sdjukicTT
+/test/ttmlir/Conversion/TosaToTTIR/ @mrakitaTT @sgligorijevicTT @sdjukicTT
 
 # TTNN Conversions
 /include/ttmlir/Conversion/TTIRToTTIRDecomposition/ @svuckovicTT @sdjordjevicTT @mtopalovicTT @jserbedzijaTT @azecevicTT
@@ -75,6 +76,11 @@
 /include/ttmlir/Dialect/TTIR/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @mrakitaTT @jserbedzijaTT @azecevicTT
 /lib/Dialect/TTIR/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @mrakitaTT @jserbedzijaTT @azecevicTT
 /test/ttmlir/Dialect/TTIR/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @mrakitaTT @jserbedzijaTT @azecevicTT
+
+# TTIR Erase Inverse Ops Optimization Pass
+/include/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps @LPanosTT @azecevicTT
+/lib/Dialect/TTIR/Transforms/EraseInverseOps @LPanosTT @azecevicTT
+/test/ttmlir/Dialect/TTIR/erase_inverse_ops @LPanosTT @azecevicTT
 
 # Metal Dialects
 /include/ttmlir/Dialect/TTIR/IR/TTIRGeneric* @nsmithtt @vroubtsovTT

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -399,7 +399,7 @@ def TTIR_WhereOp: TTIR_ElementwiseTernaryOp<"where", [TTIR_PartiallyBroadcastabl
 }
 
 class TTIR_ElementwiseUnaryOp<string mnemonic, list<Trait> traits = []> :
-    TTIR_ElementwiseOp<mnemonic, [TwoOperands] # traits> {
+    TTIR_ElementwiseOp<mnemonic, [TwoOperands, TTIR_ElementwiseUnary] # traits> {
     let summary = "Eltwise unary op.";
     let description = [{
       Eltwise unary op.
@@ -671,7 +671,7 @@ def TTIR_LeakyReluOp : TTIR_ElementwiseUnaryWithFloatParameterOp<"leaky_relu"> {
 }
 
 class TTIR_ElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
-    TTIR_ElementwiseOp<mnemonic, [ThreeOperands] # traits> {
+    TTIR_ElementwiseOp<mnemonic, [ThreeOperands, TTIR_ElementwiseBinary] #  traits> {
     let summary = "Eltwise binary op.";
     let description = [{
       Eltwise binary op.
@@ -1138,7 +1138,7 @@ def TTIR_SoftmaxOp : TTIR_NamedOp<"softmax"> {
     let hasVerifier = 1;
 }
 
-def TTIR_TransposeOp : TTIR_NamedOp<"transpose"> {
+def TTIR_TransposeOp : TTIR_NamedOp<"transpose", [TTIR_TensorManipulation]> {
     let summary = "Transpose op.";
     let description = [{
       Transpose tensor along two given dimensions.
@@ -1153,7 +1153,7 @@ def TTIR_TransposeOp : TTIR_NamedOp<"transpose"> {
 
     let hasVerifier = 1;
 
-    let hasCanonicalizer = 1;
+    let hasFolder = 1;
 }
 
 def TTIR_ConcatOp : TTIR_NamedOp<"concat"> {
@@ -1349,7 +1349,8 @@ def TTIR_Conv2dOp : TTIR_NamedOp<"conv2d"> {
                          AnyAttrOf<[I32Attr, DenseI32ArrayAttr]>:$stride,
                          AnyAttrOf<[I32Attr, DenseI32ArrayAttr]>:$padding,
                          AnyAttrOf<[I32Attr, DenseI32ArrayAttr]>:$dilation,
-                         I32Attr:$groups);
+                         I32Attr:$groups,
+                         DefaultValuedAttr<TTIR_FlattenedCompatInfoAttr, "nullptr">:$flattened_compat_info);
 
     let results = (outs AnyRankedTensor:$result);
 
@@ -1504,14 +1505,15 @@ def TTIR_MaxPool2dOp : TTIR_NamedOp<"max_pool2d"> {
                          SI32Attr:$padding_left,
                          SI32Attr:$padding_right,
                          SI32Attr:$padding_top,
-                         SI32Attr:$padding_bottom);
+                         SI32Attr:$padding_bottom,
+                         DefaultValuedAttr<TTIR_FlattenedCompatInfoAttr, "nullptr">:$flattened_compat_info);
 
     let results = (outs AnyRankedTensor:$result);
 
     let hasVerifier = 1;
 }
 
-def TTIR_ReshapeOp: TTIR_NamedOp<"reshape"> {
+def TTIR_ReshapeOp: TTIR_NamedOp<"reshape", [TTIR_TensorManipulation]> {
     let summary = "Reshape op.";
     let description = [{
       Reshape tensor.
@@ -1805,7 +1807,7 @@ def TTIR_MatmulOp : TTIR_NamedOp<"matmul"> {
 }
 // ANCHOR_END: adding_an_op_matmul_ttir
 
-def TTIR_PermuteOp : TTIR_NamedOp<"permute"> {
+def TTIR_PermuteOp : TTIR_NamedOp<"permute", [TTIR_TensorManipulation]> {
     let summary = "Permute operation.";
     let description = [{
       Permute input tensor dimensions.
@@ -1827,7 +1829,7 @@ def TTIR_PermuteOp : TTIR_NamedOp<"permute"> {
 
     let hasVerifier = 1;
 
-    let hasCanonicalizer = 1;
+    let hasFolder = 1;
 }
 
 def TTIR_Upsample2dOp : TTIR_NamedOp<"upsample2d"> {

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROpsAttrs.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROpsAttrs.td
@@ -47,6 +47,30 @@ def TTIR_ConvolutionLayoutAttr : AttrDef<TTIR_Dialect, "ConvolutionLayout", [], 
   }];
 }
 
+def TTIR_FlattenedCompatInfoAttr : AttrDef<TTIR_Dialect, "FlattenedCompatInfo", [], "::mlir::Attribute"> {
+  let mnemonic = "flattened_compat";
+  let summary = "Information for sliding window operations with tensors flattened to (1, 1, N*H*W, C)";
+  let description = [{
+    This attribute marks operations that are compatible with flattened tensors.
+    It is used as a marker and doesn't carry any additional data.
+  }];
+
+
+  let parameters = (ins
+    "int64_t":$batchSize,
+    "int64_t":$inputHeight,
+    "int64_t":$inputWidth
+  );
+
+  let assemblyFormat = [{
+        `batch_size` `=` $batchSize `,`
+        `input_height` `=` $inputHeight `,`
+        `input_width` `=` $inputWidth
+  }];
+
+  let constBuilderCall = "$0";
+}
+
 def TTIR_HoistedCallAttr : AttrDef<TTIR_Dialect, "HoistedCall", [], "::mlir::Attribute"> {
   let mnemonic = "hoisted_call";
   let summary = "Indicates that this call operation has been hoisted";

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROpsInterfaces.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROpsInterfaces.td
@@ -82,4 +82,16 @@ def TTIR_GenericParent : OpInterface<"GenericParent"> {
   }];
 }
 
+def TTIR_ElementwiseUnary : OpInterface<"ElementwiseUnary"> {
+  let cppNamespace = "::mlir::tt::ttir";
+}
+
+def TTIR_ElementwiseBinary : OpInterface<"ElementwiseBinary"> {
+  let cppNamespace = "::mlir::tt::ttir";
+}
+
+def TTIR_TensorManipulation : OpInterface<"TensorManipulation"> {
+  let cppNamespace = "::mlir::tt::ttir";
+}
+
 #endif

--- a/include/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/EraseInverseOps.h
+++ b/include/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/EraseInverseOps.h
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTIR_TRANSFORMS_ERASEINVERSEOPS_ERASEINVERSEOPS_H
+#define TTMLIR_DIALECT_TTIR_TRANSFORMS_ERASEINVERSEOPS_ERASEINVERSEOPS_H
+
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIROpsInterfaces.h"
+
+namespace mlir::tt::ttir {
+
+template <typename TMOpType, typename CommutableOpOrInterface>
+class TTIRCommuteRewritePatternBase {
+public:
+  virtual ~TTIRCommuteRewritePatternBase() noexcept = default;
+
+protected:
+  LogicalResult matchAndRewriteImpl(CommutableOpOrInterface op,
+                                    PatternRewriter &rewriter) const {
+    // This operation cannot have a TM below it if it has no users.
+    if (op->getUsers().empty()) {
+      return failure();
+    }
+
+    // Try to find a user which is a `TMOpType`.
+    // If found, verify that it can be commuted above `op`.
+    // If it can, verify that it SHOULD be commuted above `op`.
+    // If it should commute, perform the commute.
+    TMOpType userToCommute = nullptr;
+    for (Operation *user : op->getUsers()) {
+      auto tmUser = dyn_cast<TMOpType>(user);
+      if (!tmUser) {
+        continue;
+      }
+
+      if (!isCommuteViable(op, tmUser)) {
+        continue;
+      }
+
+      if (!isCommuteFavorable(op, tmUser)) {
+        continue;
+      }
+      userToCommute = tmUser;
+      break;
+    }
+
+    if (!userToCommute) {
+      return failure();
+    }
+
+    // We have found a user that we can and should commute above `op`.
+    performCommuteRewrite(op, userToCommute, rewriter);
+    return success();
+  }
+
+private:
+  // This should return `success()` if `tmUser` can be commuted above `op`.
+  virtual bool isCommuteViable(CommutableOpOrInterface op,
+                               TMOpType tmUser) const = 0;
+
+  // This should return `success()` if there is a user of `op` that we should
+  // commute above `op`. Note that the difference between this method and
+  // `isCommuteViable` is that this function should be used to determine if
+  // commuting is favourable, while `isCommuteViable` should be used to
+  // determine if commuting is possible.
+  //
+  // An example of when a commute is viable AND favourable is as follows:
+  //
+  // We have an elementwise op with one user which is a TM, and one operand. TMs
+  // can always be commuted through an elementwise op, so this is viable. This
+  // commute would add no new ops and the computation cost of the TM will not
+  // change. If we perform this commute, the worse case scenario is that
+  // performance stays the same. In the best case, this commute brings the TM
+  // closer to its inverse(s). If there is more than one TM user, and all of
+  // them are an identical TM, commuting is favourable because you can replace
+  // all the TM users with one operand TM.
+  //
+  // An example of when a commute is viable but NOT favourable is as follows:
+  //
+  // We have an elementwise op with 10 users, one of which is a TM, and one
+  // operand. TMs can always be commuted through an elementwise op, so this is
+  // viable. This commute would have to add an inverse of the TM to each of the
+  // other 9 users to keep the graph valid if it commutes. Lets say there are no
+  // inverses below those 9 users, and there is no inverses above the
+  // elementwise too. This means the commute does not cause any ops to be erased
+  // in the future and adds 9 ops.
+  //
+  virtual bool isCommuteFavorable(CommutableOpOrInterface op,
+                                  TMOpType tmUser) const = 0;
+
+  virtual void performCommuteRewrite(CommutableOpOrInterface op,
+                                     TMOpType tmUser,
+                                     PatternRewriter &rewriter) const = 0;
+};
+
+// Using this class will allow you to match against any operation that
+// implements a given interface. This is useful for implementing the elementwise
+// patterns. This way we do not have to create a separate pattern for each
+// elementwise operation.
+template <typename TMOpType, typename CommutableOpInterface>
+class TTIRCommuteOpInterfaceRewritePattern
+    : public OpInterfaceRewritePattern<CommutableOpInterface>,
+      public TTIRCommuteRewritePatternBase<TMOpType, CommutableOpInterface> {
+public:
+  using OpInterfaceRewritePattern<
+      CommutableOpInterface>::OpInterfaceRewritePattern;
+
+  LogicalResult matchAndRewrite(CommutableOpInterface op,
+                                PatternRewriter &rewriter) const override {
+    return this->matchAndRewriteImpl(op, rewriter);
+  }
+};
+
+// Using this class will allow you to match against a specific operation type:
+// `CommutableOp`.
+template <typename TMOpType, typename CommutableOp>
+class TTIRCommuteOpRewritePattern
+    : public OpRewritePattern<CommutableOp>,
+      public TTIRCommuteRewritePatternBase<TMOpType, CommutableOp> {
+public:
+  using OpRewritePattern<CommutableOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(CommutableOp op,
+                                PatternRewriter &rewriter) const override {
+    return this->matchAndRewriteImpl(op, rewriter);
+  }
+};
+
+inline bool checkIdenticalTransposes(Operation *op1, Operation *op2) {
+  auto transposeOp1 = dyn_cast<ttir::TransposeOp>(op1);
+  auto transposeOp2 = dyn_cast<ttir::TransposeOp>(op2);
+  if (transposeOp1 && transposeOp2) {
+    return transposeOp1.getDim0() == transposeOp2.getDim0() &&
+           transposeOp1.getDim1() == transposeOp2.getDim1();
+  }
+
+  return false;
+}
+
+inline bool checkIdenticalPermutes(Operation *op1, Operation *op2) {
+  auto permuteOp1 = dyn_cast<ttir::PermuteOp>(op1);
+  auto permuteOp2 = dyn_cast<ttir::PermuteOp>(op2);
+  if (permuteOp1 && permuteOp2) {
+    return permuteOp1.getPermutation() == permuteOp2.getPermutation();
+  }
+
+  return false;
+}
+
+inline bool checkIdenticalReshapes(Operation *op1, Operation *op2) {
+  auto reshapeOp1 = dyn_cast<ttir::ReshapeOp>(op1);
+  auto reshapeOp2 = dyn_cast<ttir::ReshapeOp>(op2);
+  if (reshapeOp1 && reshapeOp2) {
+    return reshapeOp1.getShape() == reshapeOp2.getShape();
+  }
+
+  return false;
+}
+
+inline bool checkIdenticalTms(Operation *op1, Operation *op2) {
+  return checkIdenticalTransposes(op1, op2) ||
+         checkIdenticalPermutes(op1, op2) || checkIdenticalReshapes(op1, op2);
+}
+
+inline bool checkAllUsersAreIdenticalTms(ArrayRef<Operation *> users) {
+  return llvm::all_of(users, [users](Operation *user) {
+    return checkIdenticalTms(users[0], user);
+  });
+}
+
+void populateElementwiseCommutePatterns(MLIRContext *ctx,
+                                        RewritePatternSet &patterns);
+void populateBroadcastCommutePatterns(MLIRContext *ctx,
+                                      RewritePatternSet &patterns);
+
+} // namespace mlir::tt::ttir
+
+#endif

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -417,4 +417,55 @@ def ElementTypeNormalization: Pass<"ttir-element-type-normalization", "::mlir::M
   let dependentDialects = ["::mlir::tt::TTDialect",  "::mlir::tt::ttir::TTIRDialect", "::mlir::func::FuncDialect"];
 }
 
+def TTIRFlattenSlidingWindow: Pass<"ttir-flatten-sliding-window", "::mlir::ModuleOp">
+{
+  let summary = "Flatten sliding window ops.";
+  let description = [{
+    This is a compatibility pass for converting to the TTNN dialect.
+    This pass walks through the graph and flattens sliding window ops (ttir.conv2d, ttir.max_pool2d).
+
+    Example:
+      Before:
+         %dps = ttir.empty() : tensor<3x15x31x16xbf16>
+         %1 = "ttir.conv2d"(%input, %weight, %bias, %dps)
+            <{
+              stride = 2: i32,
+              padding = 0: i32,
+              dilation = 1: i32,
+              groups = 1: i32
+            }> : (tensor<3x32x64x8xbf16>, tensor<16x8x3x3xbf16>, tensor<1x1x1x16xbf16>, tensor<3x15x31x16xbf16>) -> tensor<3x15x31x16xbf16>
+
+      After:
+        %reshape_dps = ttir.empty() : tensor<1x1x6144x8xbf16>
+        %0 = "ttir.reshape"(%input, %reshape_dps) <{[i32: 1, i32: 1, i32: 6144, i32: 8]}> : (tensor<3x32x64x8xbf16>, tensor<1x1x6144x8xbf16>) -> tensor<1x1x6144x8xbf16>
+        %new_conv_dps = ttir.empty() : tensor<1x1x1395x16xbf16>
+        %1 = "ttir.conv2d"(%0, %weight, %bias, %new_conv_dps)
+            <{
+              stride = 2: i32,
+              padding = 0: i32,
+              dilation = 1: i32,
+              groups = 1: i32,
+              flattened_compat_info = #ttir<flattened_compat in_channels = 8, out_channels = 16, batch_size = 3, input_height = 32, input_width = 64,>
+            }> : (tensor<1x1x6144x8xbf16>, tensor<16x8x3x3xbf16>, tensor<1x1x1x16xbf16>, tensor<1x1x1395x16xbf16>) -> tensor<1x1x1395x16xbf16>
+          %output_reshape_dps = ttir.empty() : tensor<3x15x30x16xbf16>
+          %2 = "ttir.reshape"(%1, %output_reshape_dps) <{[i32: 3, i32: 15, i32: 31, i32: 16]}> : (tensor<1x1x1395x16xbf16>, tensor<3x15x31x16xbf16>) -> tensor<3x15x31x16xbf16>
+  }];
+}
+
+def TTIREraseInverseOps: Pass<"ttir-erase-inverse-ops", "::mlir::ModuleOp">
+{
+  let summary = "Erase inverse ops.";
+  let description = [{
+    This pass walks through the graph and erases inverse operations.
+
+    For example:
+      ttir.permute(0, 1, 3, 2) -> ttir.exp -> ttir.permute(0, 1, 3, 2)
+
+    The above sequence can be reduced to simply: "ttir.exp" as the permutations
+    on either end are inverses.
+  }];
+
+  let dependentDialects = ["mlir::tt::TTDialect", "mlir::tt::ttir::TTIRDialect"];
+}
+
 #endif

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -192,6 +192,10 @@ struct TTIRToTTNNBackendPipelineOptions
       llvm::cl::desc("Enable implicit broadcast folding pass."),
       llvm::cl::init(true)};
 
+  Option<bool> eraseInverseOpsEnabled{
+      *this, "enable-erase-inverse-ops-pass",
+      llvm::cl::desc("Enable erase inverse ops pass."), llvm::cl::init(true)};
+
   Option<tt::TTArgumentTypeMap, tt::ArgumentTypeMapParser> argumentTypeMap{
       *this, tt::OptionNames::argumentTypes,
       llvm::cl::desc(

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -419,7 +419,8 @@ public:
 
     ttir::Conv2dOp newConv = ttmlir::utils::createDPSOp<ttir::Conv2dOp>(
         rewriter, op.getLoc(), outputType, Value(input), Value(weight),
-        adaptor.getBias(), strideAttr, paddingAttr, dilationAttr, groupsAttr);
+        adaptor.getBias(), strideAttr, paddingAttr, dilationAttr, groupsAttr,
+        /*flattenedCompatInfo=*/nullptr);
 
     // Applying the inverse of permutation to the output will restore the
     // tensor to the original layout.

--- a/lib/Conversion/TosaToTTIR/TosaToTTIRPatterns.cpp
+++ b/lib/Conversion/TosaToTTIR/TosaToTTIRPatterns.cpp
@@ -184,7 +184,8 @@ public:
     // TODO (azecevic) Add comment about the parameters.
     ttmlir::utils::replaceOpWithNewDPSOp<ttir::MaxPool2dOp>(
         rewriter, srcOp, outputType, adaptor.getInput(), dims[0], dims[1],
-        strides[0], strides[1], 1, 1, false, pad[2], pad[3], pad[0], pad[1]);
+        strides[0], strides[1], 1, 1, false, pad[2], pad[3], pad[0], pad[1],
+        /*flattened_compat_info=*/nullptr);
 
     return success();
   }

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -414,21 +414,37 @@ mlir::tt::ttir::GetDimensionSizeOp::fold(FoldAdaptor adaptor) {
       return emitOpError("Bias must only have data on the final dimenstion");
     }
   }
-
+  // FLATTEN_DIM corresponds to the second last dimension as it is where N, H, W
+  // are flattened to by FlattenSlidingWindow.
   constexpr unsigned int BATCH_DIM = 0, HEIGHT_DIM = 1, WIDTH_DIM = 2,
-                         CHANNEL_DIM = 3;
-  uint32_t batchSize = inputType.getDimSize(BATCH_DIM);
-  if (batchSize != outputType.getDimSize(BATCH_DIM)) {
+                         CHANNEL_DIM = 3, FLATTEN_DIM = 2;
+  if (!getFlattenedCompatInfo() &&
+      inputType.getDimSize(BATCH_DIM) != outputType.getDimSize(BATCH_DIM)) {
     return emitOpError()
-           << "Batch size from the input tensor (" << batchSize
+           << "Batch size from the input tensor ("
+           << inputType.getDimSize(BATCH_DIM)
            << ") must match the first dimension of the output tensor ("
            << outputType.getDimSize(BATCH_DIM) << ")";
   }
 
+  uint32_t batchSize = inputType.getDimSize(BATCH_DIM);
   uint32_t inputHeight = inputType.getDimSize(HEIGHT_DIM);
   uint32_t inputWidth = inputType.getDimSize(WIDTH_DIM);
   uint32_t inChannels = inputType.getDimSize(CHANNEL_DIM);
   uint32_t outChannels = outputType.getDimSize(CHANNEL_DIM);
+
+  if (getFlattenedCompatInfo()) {
+    batchSize = getFlattenedCompatInfo().getBatchSize();
+    inputHeight = getFlattenedCompatInfo().getInputHeight();
+    inputWidth = getFlattenedCompatInfo().getInputWidth();
+
+    if (inputType.getDimSize(FLATTEN_DIM) !=
+        batchSize * inputHeight * inputWidth) {
+      return emitOpError() << "Expected dim 2 of the input tensor to have size "
+                           << batchSize * inputHeight * inputWidth
+                           << " but got " << inputType.getDimSize(FLATTEN_DIM);
+    }
+  }
 
   auto stride = ttmlir::utils::getPairOfInteger<int32_t>(getStride());
   if (auto error = stride.takeError()) {
@@ -463,9 +479,9 @@ mlir::tt::ttir::GetDimensionSizeOp::fold(FoldAdaptor adaptor) {
   constexpr unsigned int WEIGHT_OUT_CHANNEL_DIM = 0, WEIGHT_IN_CHANNEL_DIM = 1;
   constexpr unsigned int WEIGHT_KERNEL_HEIGHT_DIM = 2,
                          WEIGHT_KERNEL_WIDTH_DIM = 3;
-  llvm::SmallVector<int32_t, 2> kernelSize{
-      static_cast<int32_t>(weightType.getDimSize(WEIGHT_KERNEL_HEIGHT_DIM)),
-      static_cast<int32_t>(weightType.getDimSize(WEIGHT_KERNEL_WIDTH_DIM))};
+  llvm::SmallVector<int64_t> kernelSize{
+      weightType.getDimSize(WEIGHT_KERNEL_HEIGHT_DIM),
+      weightType.getDimSize(WEIGHT_KERNEL_WIDTH_DIM)};
 
   llvm::SmallVector<uint32_t, 2> paddedInputSize{
       inputHeight + verticalPadding, inputWidth + horizontalPadding};
@@ -533,17 +549,26 @@ mlir::tt::ttir::GetDimensionSizeOp::fold(FoldAdaptor adaptor) {
                             dilation->second * (kernelSize[1] - 1) - 1) /
                                stride->second +
                            1;
-  if (calculatedHOut != outputType.getDimSize(HEIGHT_DIM) ||
-      calculatedWOut != outputType.getDimSize(WIDTH_DIM)) {
-    return emitOpError()
-           << "Mismatch between calculated and got output height and width. "
-           << "Calculated: (" << calculatedHOut << " x " << calculatedWOut
-           << "). "
-           << "Got output tensor height and width: ("
-           << outputType.getDimSize(HEIGHT_DIM) << " x "
-           << outputType.getDimSize(WIDTH_DIM) << ")";
+  if (!getFlattenedCompatInfo()) {
+    if (calculatedHOut != outputType.getDimSize(HEIGHT_DIM) ||
+        calculatedWOut != outputType.getDimSize(WIDTH_DIM)) {
+      return emitOpError()
+             << "Mismatch between calculated and got output height and width. "
+             << "Calculated: (" << calculatedHOut << " x " << calculatedWOut
+             << "). "
+             << "Got output tensor height and width: ("
+             << outputType.getDimSize(HEIGHT_DIM) << " x "
+             << outputType.getDimSize(WIDTH_DIM) << ")";
+    }
+  } else if (calculatedHOut * calculatedWOut * batchSize !=
+             outputType.getDimSize(FLATTEN_DIM)) {
+    return emitOpError() << "Mismatch between calculated flatten dimension "
+                            "and output type. "
+                         << "Calculated: "
+                         << calculatedHOut * calculatedWOut * batchSize << ". "
+                         << "Got output tensor flatten dimension: "
+                         << outputType.getDimSize(FLATTEN_DIM);
   }
-
   return success();
 }
 
@@ -887,7 +912,9 @@ mlir::LogicalResult mlir::tt::ttir::ConvTranspose2dOp::verify() {
 // MaxPool2dOp verification
 ::mlir::LogicalResult mlir::tt::ttir::MaxPool2dOp::verify() {
   ::mlir::RankedTensorType inputType = getInput().getType();
-  std::vector<int64_t> inputShape = getInput().getType().getShape().vec();
+  ArrayRef<int64_t> inputShape = inputType.getShape();
+  ::mlir::RankedTensorType outputType = getOutput().getType();
+  ArrayRef<int64_t> outputShape = outputType.getShape();
 
   if (inputType.getRank() != 4) {
     return emitOpError()
@@ -895,15 +922,75 @@ mlir::LogicalResult mlir::tt::ttir::ConvTranspose2dOp::verify() {
            << inputType.getRank() << ". Shape: (" << inputShape << ").";
   }
 
-  if (getKernelHeight() > inputShape[1]) {
+  if (outputType.getRank() != 4) {
+    return emitOpError()
+           << "Output tensor rank must be 4. Recieved output with rank "
+           << outputType.getRank() << ". Shape: (" << outputShape << ").";
+  }
+
+  // FLATTEN_DIM corresponds to the second last dimension as it is where N, H, W
+  // are flattened to by FlattenSlidingWindow.
+  constexpr unsigned int BATCH_DIM = 0, HEIGHT_DIM = 1, WIDTH_DIM = 2,
+                         CHANNEL_DIM = 3, FLATTEN_DIM = 2;
+
+  int64_t inputHeight = inputType.getDimSize(HEIGHT_DIM);
+  int64_t inputWidth = inputType.getDimSize(WIDTH_DIM);
+  int64_t inChannels = inputType.getDimSize(CHANNEL_DIM);
+  int64_t outChannels = outputType.getDimSize(CHANNEL_DIM);
+  if (getFlattenedCompatInfo()) {
+    auto batchSize = getFlattenedCompatInfo().getBatchSize();
+    inputHeight = getFlattenedCompatInfo().getInputHeight();
+    inputWidth = getFlattenedCompatInfo().getInputWidth();
+
+    if (inputType.getDimSize(2) != batchSize * inputHeight * inputWidth) {
+      return emitOpError() << "Expected dim 2 of the input tensor to have size "
+                           << batchSize * inputHeight * inputWidth
+                           << " but got " << inputType.getDimSize(FLATTEN_DIM);
+    }
+  }
+
+  if (!getFlattenedCompatInfo() &&
+      inputType.getDimSize(BATCH_DIM) != outputType.getDimSize(BATCH_DIM)) {
+    return emitOpError()
+           << "Batch size from the input tensor ("
+           << inputType.getDimSize(BATCH_DIM)
+           << ") must match the first dimension of the output tensor ("
+           << outputType.getDimSize(BATCH_DIM) << ")";
+  }
+
+  if (outChannels != outputType.getDimSize(CHANNEL_DIM)) {
+    return emitOpError() << "Expected dim 3 of the output tensor to have size "
+                         << outChannels << " but got "
+                         << outputType.getDimSize(CHANNEL_DIM);
+  }
+
+  if (inChannels != inputType.getDimSize(CHANNEL_DIM)) {
+    return emitOpError() << "Expected dim 3 of the input tensor to have size "
+                         << inChannels << " but got "
+                         << inputType.getDimSize(CHANNEL_DIM);
+  }
+
+  if (outChannels != inChannels) {
+    return emitOpError() << "Output tensor channels (" << outChannels
+                         << ") must match input tensor channels (" << inChannels
+                         << ").";
+  }
+
+  if (getKernelHeight() > inputHeight) {
     return emitOpError() << "Kernel height " << getKernelHeight()
-                         << " is greater than input height " << inputShape[1]
+                         << " is greater than input height " << inputHeight
+                         << (getFlattenedCompatInfo()
+                                 ? " (as defined in flattened_compat_info)"
+                                 : "")
                          << ". This MaxPool2d configuration is invalid.";
   }
 
-  if (getKernelWidth() > inputShape[2]) {
+  if (getKernelWidth() > inputWidth) {
     return emitOpError() << "Kernel width " << getKernelWidth()
-                         << " is greater than input width " << inputShape[2]
+                         << " is greater than input width " << inputWidth
+                         << (getFlattenedCompatInfo()
+                                 ? " (as defined in flattened_compat_info)"
+                                 : "")
                          << ". This MaxPool2d configuration is invalid.";
   }
 
@@ -1056,11 +1143,34 @@ mlir::LogicalResult mlir::tt::ttir::ConvTranspose2dOp::verify() {
   return success();
 }
 
+// Fold the operation if the type of the input and output types are the same.
+static mlir::OpFoldResult foldIdentityReshape(mlir::tt::ttir::ReshapeOp op) {
+  if (op.getType() == op.getInput().getType()) {
+    return op.getInput();
+  }
+  return nullptr;
+}
+
+// Back to back reshapes can be replaced with the final reshape.
+static mlir::OpFoldResult foldConsecutiveReshape(mlir::tt::ttir::ReshapeOp op) {
+  if (auto reshapeOperand =
+          op.getInput().getDefiningOp<mlir::tt::ttir::ReshapeOp>()) {
+    op.setOperand(0, reshapeOperand.getInput());
+    return op.getResult();
+  }
+  return nullptr;
+}
+
 // ReshapeOp folder
 ::mlir::OpFoldResult mlir::tt::ttir::ReshapeOp::fold(FoldAdaptor adaptor) {
-  if (getType() == getOperand(0).getType()) {
-    return getOperand(0);
+  if (auto foldResult = foldIdentityReshape(*this)) {
+    return foldResult;
   }
+
+  if (auto foldResult = foldConsecutiveReshape(*this)) {
+    return foldResult;
+  }
+
   return nullptr;
 }
 
@@ -1540,75 +1650,78 @@ mlir::LogicalResult mlir::tt::ttir::ConvTranspose2dOp::verify() {
   return success();
 }
 
-// TransposeOp canonicalization
-void mlir::tt::ttir::TransposeOp::getCanonicalizationPatterns(
-    mlir::RewritePatternSet &patterns, mlir::MLIRContext *context) {
-  // NOLINTBEGIN(clang-analyzer-core.StackAddressEscape)
-  // TransposeOp can be removed if the both 'dim0' and 'dim1' are the same.
-  patterns.add(
-      +[](mlir::tt::ttir::TransposeOp op, mlir::PatternRewriter &rewriter) {
-        if (op.getDim0() != op.getDim1()) {
-          return mlir::failure();
-        }
+// TransposeOp can be removed if the both 'dim0' and 'dim1' are the same.
+static mlir::OpFoldResult
+foldIdentityTranspose(mlir::tt::ttir::TransposeOp op) {
+  if (op.getDim0() == op.getDim1()) {
+    return op.getInput();
+  }
+  return nullptr;
+}
 
-        rewriter.replaceAllOpUsesWith(op, op.getInput());
-        return success();
-      });
+// Rewrite a transpose op to a canonical form where the 'dim0' is less than
+// 'dim1'.
+static mlir::OpFoldResult sortTansposeDims(mlir::tt::ttir::TransposeOp op) {
+  if (op.getDim0() < op.getDim1()) {
+    return nullptr;
+  }
 
-  // Rewrite a transpose of to a canonical form where the 'dim0' is less than
-  // 'dim1'.
-  patterns.add(
-      +[](mlir::tt::ttir::TransposeOp op, mlir::PatternRewriter &rewriter) {
-        if (op.getDim0() <= op.getDim1()) {
-          return mlir::failure();
-        }
+  auto oldDim0 = op.getDim0();
+  op.setDim0(op.getDim1());
+  op.setDim1(oldDim0);
+  return op.getResult();
+}
 
-        rewriter.replaceOpWithNewOp<mlir::tt::ttir::TransposeOp>(
-            op, op.getType(), op.getInput(), op.getOutput(), op.getDim1(),
-            op.getDim0());
-        return mlir::success();
-      });
+// Rewrite tranpose dims to a canonical form where the 'dim0' and 'dim1' are
+// in range [0, N), where N is a rank of input tensor.
+static mlir::OpFoldResult
+forcePositiveTransposeDims(mlir::tt::ttir::TransposeOp op) {
+  if (op.getDim0() >= 0 && op.getDim1() >= 0) {
+    return nullptr;
+  }
 
-  // Rewrite a tranpose dims to a canonical form where the 'dim0' and 'dim1' are
-  // in range [0, N), where N is a rank of input tensor.
-  patterns.add(+[](mlir::tt::ttir::TransposeOp op,
-                   mlir::PatternRewriter &rewriter) {
-    int64_t rank = op.getInput().getType().getRank();
-    int32_t dim0 = op.getDim0();
-    int32_t dim1 = op.getDim1();
+  if (op.getDim0() < 0) {
+    op.setDim0(op.getDim0() + op.getInput().getType().getRank());
+  } else if (op.getDim1() < 0) {
+    op.setDim1(op.getDim1() + op.getInput().getType().getRank());
+  }
 
-    if (dim0 >= 0 && dim1 >= 0) {
-      return mlir::failure();
+  return op.getResult();
+}
+
+// Transposing twice in the row over the same dimensions results in identity,
+// hence y = T(T(x)) can be replaced with y = x.
+static mlir::OpFoldResult
+foldInverseTransposeOperand(mlir::tt::ttir::TransposeOp op) {
+  if (auto producerOp =
+          op.getInput().getDefiningOp<mlir::tt::ttir::TransposeOp>()) {
+    if (op.getDim0() == producerOp.getDim0() &&
+        op.getDim1() == producerOp.getDim1()) {
+      return producerOp.getInput();
     }
+  }
+  return nullptr;
+}
 
-    if (dim0 < 0) {
-      rewriter.modifyOpInPlace(op, [&]() -> void { op.setDim0(dim0 + rank); });
-    }
-    if (dim1 < 0) {
-      rewriter.modifyOpInPlace(op, [&]() -> void { op.setDim1(dim1 + rank); });
-    }
-    return mlir::success();
-  });
+// TransposeOp folder
+mlir::OpFoldResult mlir::tt::ttir::TransposeOp::fold(FoldAdaptor adaptor) {
+  if (auto foldResult = foldIdentityTranspose(*this)) {
+    return foldResult;
+  }
 
-  // Transposing twice in the row over the same dimensions results in identity,
-  // hence y = T(T(x)) can be replaced with y = x.
-  patterns.add(
-      +[](mlir::tt::ttir::TransposeOp op, mlir::PatternRewriter &rewriter) {
-        auto producerOp =
-            op.getInput().getDefiningOp<mlir::tt::ttir::TransposeOp>();
-        if (!producerOp || op->getName() != producerOp->getName()) {
-          return mlir::failure();
-        }
+  if (auto foldResult = sortTansposeDims(*this)) {
+    return foldResult;
+  }
 
-        if (op.getDim0() != producerOp.getDim0() ||
-            op.getDim1() != producerOp.getDim1()) {
-          return mlir::failure();
-        }
+  if (auto foldResult = forcePositiveTransposeDims(*this)) {
+    return foldResult;
+  }
 
-        rewriter.replaceAllOpUsesWith(op, producerOp.getInput());
-        return mlir::success();
-      });
-  // NOLINTEND(clang-analyzer-core.StackAddressEscape)
+  if (auto foldResult = foldInverseTransposeOperand(*this)) {
+    return foldResult;
+  }
+
+  return nullptr;
 }
 
 //===----------------------------------------------------------------------===//
@@ -3102,45 +3215,42 @@ void mlir::tt::ttir::ReverseOp::getCanonicalizationPatterns(
   return success();
 }
 
-// PermuteOp canonicalization
-void mlir::tt::ttir::PermuteOp::getCanonicalizationPatterns(
-    mlir::RewritePatternSet &patterns, mlir::MLIRContext *context) {
-  // NOLINTBEGIN(clang-analyzer-core.StackAddressEscape)
-  // Permute dimensions of two consecutive PermuteOps can be folded into a
-  // single PermuteOp where the permutation is the composition of the two
-  // permutations.
-  patterns.add(
-      +[](mlir::tt::ttir::PermuteOp op, mlir::PatternRewriter &rewriter) {
-        auto producerOp = op.getInput().getDefiningOp<ttir::PermuteOp>();
-        if (!producerOp) {
-          return mlir::failure();
-        }
+// PermuteOp with identity permutation is a no-op.
+// The input can be used directly as the output.
+static mlir::OpFoldResult foldIdentityPermute(mlir::tt::ttir::PermuteOp op) {
+  if (llvm::is_sorted(op.getPermutation())) {
+    return op.getInput();
+  }
+  return nullptr;
+}
 
-        // I: identity permutation
-        // P1: permutation of producerOp
-        // P2: permutation of op
-        // P: permutation of the composed PermuteOp
-        // P = applyPermutation(applyPermutation(I, P1), P2) =
-        // applyPermutation(P1, P2)
-        llvm::SmallVector<int64_t> composedPermutation =
-            ttmlir::utils::applyPermutation(producerOp.getPermutation(),
-                                            op.getPermutation());
-        rewriter.replaceOpWithNewOp<ttir::PermuteOp>(
-            op, op.getType(), producerOp.getInput(), op.getOutput(),
-            composedPermutation);
-        return mlir::success();
-      });
+// If the producer is a PermuteOp we can compose the permutation attributes
+// into `op`, and set the input to the producers input.
+static mlir::OpFoldResult foldConsecutivePermute(mlir::tt::ttir::PermuteOp op) {
+  if (auto producerOp =
+          op.getInput().getDefiningOp<mlir::tt::ttir::PermuteOp>()) {
+    llvm::SmallVector<int64_t> composedPermutation =
+        ttmlir::utils::applyPermutation(producerOp.getPermutation(),
+                                        op.getPermutation());
+    op.setPermutation(composedPermutation);
+    op->setOperand(0, producerOp.getInput());
+    return op.getResult();
+  }
+  return nullptr;
+}
 
-  // PermuteOp with identity permutation is a no-op.
-  patterns.add(
-      +[](mlir::tt::ttir::PermuteOp op, mlir::PatternRewriter &rewriter) {
-        if (llvm::is_sorted(op.getPermutation())) {
-          rewriter.replaceAllOpUsesWith(op, op.getInput());
-          return mlir::success();
-        }
-        return mlir::failure();
-      });
-  // NOLINTEND(clang-analyzer-core.StackAddressEscape)
+// PermuteOp folder
+mlir::OpFoldResult mlir::tt::ttir::PermuteOp::fold(FoldAdaptor adaptor) {
+
+  if (auto foldResult = foldIdentityPermute(*this)) {
+    return foldResult;
+  }
+
+  if (auto foldResult = foldConsecutivePermute(*this)) {
+    return foldResult;
+  }
+
+  return nullptr;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTIR/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTIR/Transforms/CMakeLists.txt
@@ -1,7 +1,9 @@
+add_subdirectory(EraseInverseOps)
 add_mlir_dialect_library(MLIRTTIRTransforms
         Allocate.cpp
         Broadcast.cpp
         Constant.cpp
+        FlattenSlidingWindow.cpp
         GenericLinearizeMemref.cpp
         GenericGenerateDatamovement.cpp
         GenericGenerateLoops.cpp
@@ -22,4 +24,7 @@ add_mlir_dialect_library(MLIRTTIRTransforms
         MLIRTTIROpsIncGen
         MLIRTTIRPassesIncGen
         MLIRTTOpsIncGen
+
+        LINK_LIBS PUBLIC
+        MLIRTTIREraseInverseOps
         )

--- a/lib/Dialect/TTIR/Transforms/EraseInverseOps/BroadcastCommutePatterns.cpp
+++ b/lib/Dialect/TTIR/Transforms/EraseInverseOps/BroadcastCommutePatterns.cpp
@@ -1,0 +1,393 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/EraseInverseOps.h"
+
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+#include "ttmlir/Utils.h"
+
+namespace mlir::tt::ttir {
+
+namespace {
+class TTIRCommuteTransposesAboveBroadcast
+    : public TTIRCommuteOpRewritePattern<ttir::TransposeOp, ttir::BroadcastOp> {
+public:
+  using TTIRCommuteOpRewritePattern<
+      ttir::TransposeOp, ttir::BroadcastOp>::TTIRCommuteOpRewritePattern;
+
+  void performCommuteRewrite(ttir::BroadcastOp op,
+                             ttir::TransposeOp transposeUser,
+                             PatternRewriter &rewriter) const override {
+
+    auto operand = op.getInput();
+    auto tmResultType = transposeUser.getResult().getType();
+
+    SmallVector<int64_t> newShape(operand.getType().getShape());
+    std::swap(newShape[transposeUser.getDim0()],
+              newShape[transposeUser.getDim1()]);
+
+    // Commuting a transpose above a broadcast requires us to swap the broadcast
+    // dimensions according to the transpose dimensions.
+    SmallVector<int64_t> newBroadcastDimensions(op.getBroadcastDimensions());
+    std::swap(newBroadcastDimensions[transposeUser.getDim0()],
+              newBroadcastDimensions[transposeUser.getDim1()]);
+
+    auto newTranspose = ttmlir::utils::createDPSOp<ttir::TransposeOp>(
+        rewriter, op->getLoc(), newShape, tmResultType.getElementType(),
+        tmResultType.getEncoding(), operand, transposeUser.getDim0(),
+        transposeUser.getDim1());
+
+    assert(newBroadcastDimensions.size() ==
+           static_cast<size_t>(tmResultType.getRank()));
+
+    auto newBroadcast = ttmlir::utils::createDPSOp<ttir::BroadcastOp>(
+        rewriter, op->getLoc(), tmResultType, newTranspose,
+        newBroadcastDimensions);
+
+    SmallVector<Operation *> users(op->getUsers());
+    for (auto *user : users) {
+      assert(checkIdenticalTms(transposeUser, user) &&
+             "shouldCommute should have ensured this is true");
+      rewriter.replaceOp(user, newBroadcast);
+    }
+  }
+
+private:
+  bool isCommuteViable(ttir::BroadcastOp op, ttir::TransposeOp) const override {
+    // We can always commute a transpose above a broadcast.
+    return true;
+  }
+
+  bool isCommuteFavorable(ttir::BroadcastOp op,
+                          ttir::TransposeOp) const override {
+    // We should always commute a transpose above a broadcast if all users are
+    // an identical transpose. This includes the case where there is one user.
+    SmallVector<Operation *> users(op->getUsers());
+    return !users.empty() && checkAllUsersAreIdenticalTms(users);
+  }
+};
+} // namespace
+
+// This function will return std::nullopt if the reshape places broadcasted
+// data along the same axes as the original data. If this is the case for
+// a particular broadcast -> reshape sequence, the reshape cannot be commuted
+// above the broadcast.
+//
+// Otherwise, it will return the shape of the commuted reshape and the new
+// broadcast dimensions.
+static std::optional<std::tuple<SmallVector<int64_t>, SmallVector<int64_t>>>
+getNewReshapeAndBroadcastDims(ArrayRef<int64_t> originalShape,
+                              ArrayRef<int64_t> finalShape,
+                              ArrayRef<int64_t> broadcastDims) {
+
+  // This is meant to represent some volume of data in a tensor, and whether or
+  // not it is original, or broadcasted data.
+  struct VolumePartition {
+    int64_t size;
+    bool isOriginalData;
+  };
+
+  // A tensor after a broadcast can have its volume separated into chunks of
+  // contiguous "original" and "broadcasted" data. For example, if we broadcast
+  // a tensor with shape (2, 1, 1, 64) to (2, 32, 32, 64). We its volume
+  // partitions will be:
+  //  [{size: 2, isOriginalData: true}, {size: 1024, isOriginalData: false},
+  //   {size: 64, isOriginalData: true}].
+  SmallVector<VolumePartition> volumePartitions;
+
+  // The current partition we are working on. We cannot correctly initialize
+  // this before the loop because we do not know where the first partition
+  // starts and whether or not is broadcasted or real data.
+  VolumePartition currentPartition = {-1, false};
+  for (uint64_t i = 0; i < originalShape.size(); i++) {
+    assert(originalShape[i] > 1 && broadcastDims[i] == 1 ||
+           originalShape[i] == 1 && broadcastDims[i] >= 1 &&
+               "Broadcast dimensions should always be 1 when the input shape "
+               "is > 1");
+
+    // Create new "original" partiton OR fuse volume of this dimension with
+    // current "original" partition.
+    if (broadcastDims[i] == 1 && originalShape[i] > 1) {
+      if (currentPartition.size == -1) {
+        currentPartition = {1, true};
+      }
+      if (currentPartition.isOriginalData) {
+        currentPartition.size *= originalShape[i];
+      } else {
+        volumePartitions.push_back(currentPartition);
+        currentPartition = {originalShape[i], true};
+      }
+    }
+    // Create new "broadcasted" partiton OR fuse volume of this dimension with
+    // current "broadcasted" partition.
+    else if (broadcastDims[i] > 1) {
+      if (currentPartition.size == -1) {
+        currentPartition = {1, false};
+      }
+      if (!currentPartition.isOriginalData) {
+        currentPartition.size *= broadcastDims[i];
+      } else {
+        volumePartitions.push_back(currentPartition);
+        currentPartition = {broadcastDims[i], false};
+      }
+    }
+    // Otherwise, both broadcast dim and original shape are 1 and whether it is
+    // broadcasted or not is both undefined and irrevlevant.
+  }
+  volumePartitions.push_back(currentPartition);
+
+  // Consider the example from the comment above: Original tensor: (2, 1, 1,
+  // 64). Broadcasted tensor: (2, 32, 32, 64). Consider the following reshape to
+  // output a tensor of shape (2, 8, 4, 2, 16, 8, 8). Remember, our volume
+  // partitions from above are:
+  //    [{size: 2, isOriginalData: true}, {size: 1024, isOriginalData: false},
+  //     {size: 64, isOriginalData: true}].
+  //
+  // We are going to iterate over this final shape from back-to-front. We will
+  // start drawing volume from the partition at the back of the list, and move
+  // to the next partition towards the front when we "run out" of volume in the
+  // current partition.
+  //
+  // Starting with finalShape[6] = 8:
+  //  We can draw 8 from the current partition. Now we must divide the volume
+  //  left in the partition by 8.
+  //  After:
+  //    volumePartitions = [{size: 2, isOriginalData: true},
+  //      {size: 1024, isOriginalData: false}, {size: 8, isOriginalData: true}]
+  //
+  // finalShape[5] = 8:
+  //  We can draw 8 from the current partition. Now we must divide the volume
+  //  left in the partition by 8.
+  //  After:
+  //    volumePartitions = [{size: 2, isOriginalData: true},
+  //      {size: 1024, isOriginalData: false}, {size: 1, isOriginalData: true}]
+  //    We now focus on the partition at index 1.
+  //
+  //
+  // finalShape[4] = 16:
+  //  We can draw 16 from the current partition. Now we must divide the volume
+  //  left in the partition by 16.
+  //  After:
+  //    volumePartitions = [{size: 2, isOriginalData: true},
+  //      {size: 64, isOriginalData: false}, ...]
+  //    We are drawing from broadcasted data, the new broadcast dimension at
+  //    dim 4 should be 16. And the new reshape size at dim 4 should be 1.
+  //
+  // finalShape[3] = 2:
+  //  We can draw 2 from the current partition. Now we must divide the volume
+  //  left in the partition by 2. After:
+  //    volumePartitions = [{size: 2, isOriginalData: true},
+  //      {size: 32, isOriginalData: false}, ...]
+  //    We are drawing from broadcasted data, the new broadcast dimension at
+  //    dim 3 should be 2. And the new reshape size at dim 3 should be 1.
+  //
+  // finalShape[2] = 4:
+  //  We can draw 4 from the current partition. Now we must divide the volume
+  //  left in the partition by 4. After:
+  //    volumePartitions = [{size: 2, isOriginalData: true},
+  //      {size: 8, isOriginalData: false}, ...]
+  //    We are drawing from broadcasted data, the new broadcast dimension at
+  //    dim 2 should be 8. And the new reshape size at dim 2 should be 1.
+  //
+  // finalShape[1] = 8:
+  //  We can draw 8 from the current partition. Now we must divide the volume
+  //  left in the partition by 8. After:
+  //    volumePartitions = [{size: 2, isOriginalData: true},
+  //      {size: 1, isOriginalData: false}, ...]
+  //   We are drawing from broadcasted data, the new broadcast dimension at
+  //   dim 1 should be 8. And the new reshape size at dim 1 should be 1.
+  //   We can now focus on the partition at index 0.
+  //
+  // finalShape[0] = 2:
+  //  We can draw 2 from the current partition. Now we must divide the volume
+  //  left in the partition by 2. After:
+  //    volumePartitions = [{size: 1, isOriginalData: true}, ...]
+  //
+  // And so we can commute the reshape above.
+  //
+  // IMPORTANT: If at any point the size of finalShape at some index i is
+  // greater than the size of the current partition, this would imply that
+  //            the reshape has placed broacasted and original data along the
+  //            same axis. And so, the reshape cannot commute through the
+  //            broadcast.
+
+  int64_t partitionIndex = volumePartitions.size() - 1;
+
+  // Initialize the broadcast dims to all 1s and populate them as we go.
+  // The new reshape shape will be the same as the final shape. And we will
+  // drop the size of a dimension to 1 if we know it is broadcasted data.
+  SmallVector<int64_t> newBroadcastDims(finalShape.size(), 1);
+  SmallVector<int64_t> newReshapeShape(finalShape);
+  for (int64_t i = static_cast<int64_t>(finalShape.size()) - 1; i >= 0; i--) {
+    if (partitionIndex < 0 && finalShape[i] != 1) {
+      return std::nullopt;
+    }
+    if (finalShape[i] == 1) {
+      continue;
+    }
+    if (volumePartitions[partitionIndex].isOriginalData) {
+      if (finalShape[i] > volumePartitions[partitionIndex].size) {
+        return std::nullopt;
+      }
+      volumePartitions[partitionIndex].size /= finalShape[i];
+    } else {
+      if (finalShape[i] > volumePartitions[partitionIndex].size) {
+        return std::nullopt;
+      }
+      volumePartitions[partitionIndex].size /= finalShape[i];
+
+      newBroadcastDims[i] = finalShape[i];
+      newReshapeShape[i] = 1;
+    }
+
+    if (volumePartitions[partitionIndex].size == 1) {
+      partitionIndex--;
+    }
+  }
+  assert(partitionIndex == -1 && "All data should have been accounted for.");
+
+  return std::make_tuple(newReshapeShape, newBroadcastDims);
+}
+
+namespace {
+class TTIRCommuteReshapeAboveBroadcast
+    : public TTIRCommuteOpRewritePattern<ttir::ReshapeOp, ttir::BroadcastOp> {
+public:
+  using TTIRCommuteOpRewritePattern<
+      ttir::ReshapeOp, ttir::BroadcastOp>::TTIRCommuteOpRewritePattern;
+  void performCommuteRewrite(ttir::BroadcastOp op, ttir::ReshapeOp reshapeUser,
+                             PatternRewriter &rewriter) const override {
+
+    auto originalShape = op.getInput().getType().getShape();
+    // auto broadcastShape = op.getResult().getType().getShape();
+    auto tmResultType = reshapeUser.getResult().getType();
+    auto finalShape = tmResultType.getShape();
+
+    // This must return something, since we know that the commute is viable.
+    // If this returns std::nullopt, then there is a bug in isCommuteViable or
+    // within getNewReshapeAndBroadcastDims.
+    auto [newReshapeShape, newBroadcastDimensions] =
+        *getNewReshapeAndBroadcastDims(originalShape, finalShape,
+                                       op.getBroadcastDimensions());
+
+    // Now that we know which shape the reshape should have and which broadcast
+    // dimensions the broadcast should have, we can generate the new ops.
+    auto newTMResultType =
+        RankedTensorType::get(newReshapeShape, tmResultType.getElementType(),
+                              tmResultType.getEncoding());
+
+    auto newReshape = ttmlir::utils::createDPSOp<ttir::ReshapeOp>(
+        rewriter, op->getLoc(), newTMResultType, op.getInput(),
+        rewriter.getI32ArrayAttr(SmallVector<int32_t>(newReshapeShape.begin(),
+                                                      newReshapeShape.end())));
+
+    assert(newBroadcastDimensions.size() ==
+           static_cast<size_t>(tmResultType.getRank()));
+    auto newBroadcast = ttmlir::utils::createDPSOp<ttir::BroadcastOp>(
+        rewriter, op->getLoc(), tmResultType, newReshape,
+        newBroadcastDimensions);
+
+    SmallVector<Operation *> users(op->getUsers());
+    for (auto *user : users) {
+      assert(checkIdenticalTms(reshapeUser, user) &&
+             "shouldCommute should have ensured this is true");
+      rewriter.replaceOp(user, newBroadcast);
+    }
+  }
+
+private:
+  bool isCommuteViable(ttir::BroadcastOp op,
+                       ttir::ReshapeOp reshapeUser) const override {
+
+    // If we have a broadcast -> reshape sequence, where the reshape places
+    // broadcasted data along one or more of the same axes as real data. The
+    // reshape cannot be commuted above the broadcast. This is because there is
+    // no way to achieve the same result tensor with a reshape -> broadcast
+    // sequence as the broadcast operation cannot result in real data along the
+    // same axes as broadcasted data.
+
+    auto originalShape = op.getInput().getType().getShape();
+    auto finalShape = reshapeUser.getResult().getType().getShape();
+    auto broadcastDims = op.getBroadcastDimensions();
+
+    return getNewReshapeAndBroadcastDims(originalShape, finalShape,
+                                         broadcastDims)
+        .has_value();
+  }
+
+  bool isCommuteFavorable(ttir::BroadcastOp op,
+                          ttir::ReshapeOp) const override {
+    // We should always commute a reshape above a broadcast if all users are an
+    // identical reshape. This includes the case where there is one user.
+    SmallVector<Operation *> users(op->getUsers());
+    return !users.empty() && checkAllUsersAreIdenticalTms(users);
+  }
+};
+} // namespace
+
+namespace {
+class TTIRCommutePermuteAboveBroadcast
+    : public TTIRCommuteOpRewritePattern<ttir::PermuteOp, ttir::BroadcastOp> {
+public:
+  using TTIRCommuteOpRewritePattern<
+      ttir::PermuteOp, ttir::BroadcastOp>::TTIRCommuteOpRewritePattern;
+
+  void performCommuteRewrite(ttir::BroadcastOp op, ttir::PermuteOp permuteUser,
+                             PatternRewriter &rewriter) const override {
+    auto operand = op.getInput();
+    auto operandShape = operand.getType().getShape();
+    auto tmResultType = permuteUser.getResult().getType();
+
+    // Commuting a permute above a broadcast requires us to permute which dims
+    // are broadcasted.
+    auto permutation = permuteUser.getPermutation();
+    SmallVector<int64_t> newShape =
+        ttmlir::utils::applyPermutation(operandShape, permutation);
+    SmallVector<int64_t> newBroadcastDimensions =
+        ttmlir::utils::applyPermutation(op.getBroadcastDimensions(),
+                                        permutation);
+
+    auto newPermute = ttmlir::utils::createDPSOp<ttir::PermuteOp>(
+        rewriter, op->getLoc(), newShape, tmResultType.getElementType(),
+        tmResultType.getEncoding(), operand, permutation);
+
+    assert(newBroadcastDimensions.size() ==
+           static_cast<size_t>(tmResultType.getRank()));
+    auto newBroadcast = ttmlir::utils::createDPSOp<ttir::BroadcastOp>(
+        rewriter, op->getLoc(), tmResultType, newPermute,
+        newBroadcastDimensions);
+
+    SmallVector<Operation *> users(op->getUsers());
+    for (auto *user : users) {
+      assert(checkIdenticalTms(permuteUser, user) &&
+             "shouldCommute should have ensured this is true");
+      rewriter.replaceOp(user, newBroadcast);
+    }
+  }
+
+private:
+  bool isCommuteViable(ttir::BroadcastOp op, ttir::PermuteOp) const override {
+    // We can always commute a permute above a broadcast.
+    return true;
+  }
+
+  bool isCommuteFavorable(ttir::BroadcastOp op,
+                          ttir::PermuteOp) const override {
+    // We should always commute a permute above a broadcast if all users are an
+    // identical permutation. This includes the case where there is one user.
+    SmallVector<Operation *> users(op->getUsers());
+    return !users.empty() && checkAllUsersAreIdenticalTms(users);
+  }
+};
+} // namespace
+
+void populateBroadcastCommutePatterns(MLIRContext *ctx,
+                                      RewritePatternSet &patterns) {
+  patterns
+      .add<TTIRCommuteTransposesAboveBroadcast,
+           TTIRCommuteReshapeAboveBroadcast, TTIRCommutePermuteAboveBroadcast>(
+          ctx);
+}
+
+} // namespace mlir::tt::ttir

--- a/lib/Dialect/TTIR/Transforms/EraseInverseOps/CMakeLists.txt
+++ b/lib/Dialect/TTIR/Transforms/EraseInverseOps/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_mlir_dialect_library(MLIRTTIREraseInverseOps
+        EraseInverseOps.cpp
+        BroadcastCommutePatterns.cpp
+        ElementwiseCommutePatterns.cpp
+
+        ADDITIONAL_HEADER_DIRS
+        ${PROJECT_SOURCE_DIR}/include/ttmlir
+
+        DEPENDS
+        MLIRTTIROpsIncGen
+        MLIRTTIRPassesIncGen
+        MLIRTTOpsIncGen
+)

--- a/lib/Dialect/TTIR/Transforms/EraseInverseOps/ElementwiseCommutePatterns.cpp
+++ b/lib/Dialect/TTIR/Transforms/EraseInverseOps/ElementwiseCommutePatterns.cpp
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIROpsInterfaces.h"
+#include "ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/EraseInverseOps.h"
+
+namespace mlir::tt::ttir {
+
+namespace {
+template <typename TMOpType, typename ElementwiseInterfaceType>
+class TTIRCommuteTmsAboveElementwiseRewriter
+    : public TTIRCommuteOpInterfaceRewritePattern<TMOpType,
+                                                  ElementwiseInterfaceType> {
+public:
+  using TTIRCommuteOpInterfaceRewritePattern<
+      TMOpType, ElementwiseInterfaceType>::TTIRCommuteOpInterfaceRewritePattern;
+
+  void performCommuteRewrite(ElementwiseInterfaceType op, TMOpType tmUser,
+                             PatternRewriter &rewriter) const override {
+
+    llvm::SmallVector<Operation *> users(op->getUsers());
+    auto oldEltwiseType = cast<RankedTensorType>(op->getResult(0).getType());
+    auto oldTMResultType = tmUser.getResult().getType();
+
+    auto newEltwiseType = RankedTensorType::get(oldTMResultType.getShape(),
+                                                oldEltwiseType.getElementType(),
+                                                oldTMResultType.getEncoding());
+
+    SmallVector<ttir::EmptyOp> newTMDPSOperands;
+    SmallVector<Value> newEltwiseOperands;
+    SmallVector<RankedTensorType> newTMResultTypes;
+    for (uint32_t operandIdx = 0; operandIdx < op->getNumOperands() - 1;
+         operandIdx++) {
+
+      // The new TM will have the same shape as before, but if the eltwise op
+      // was a typecast, it will have the element type of the original operand
+      // of the eltwise. So we need to generate a new type for the TM keeping
+      // this in mind.
+      auto operandType =
+          cast<RankedTensorType>(op->getOperand(operandIdx).getType());
+
+      newTMResultTypes.push_back(
+          oldTMResultType.clone(operandType.getElementType()));
+
+      auto dpsOperand = rewriter.create<ttir::EmptyOp>(
+          op->getLoc(), newEltwiseType.getShape(),
+          operandType.getElementType());
+      newTMDPSOperands.push_back(dpsOperand);
+
+      auto newTM = rewriter.create<TMOpType>(
+          op->getLoc(), newTMResultTypes[operandIdx],
+          ValueRange({op->getOperand(operandIdx), dpsOperand}),
+          tmUser->getAttrs());
+
+      newEltwiseOperands.push_back(newTM);
+    }
+
+    newEltwiseOperands.push_back(
+        rewriter.create<ttir::EmptyOp>(op->getLoc(), newEltwiseType.getShape(),
+                                       newEltwiseType.getElementType()));
+
+    Operation *newEltwise = rewriter.create(
+        op->getLoc(), rewriter.getStringAttr(op->getName().getStringRef()),
+        newEltwiseOperands, newEltwiseType, op->getAttrs());
+
+    // This only works when all the users are an identical TM
+    // In the future this function may be called when this is not
+    // the case, and we'll need to insert user clones on the
+    // user edges that do not have an inverse on them.
+    for (auto *user : users) {
+      assert(checkIdenticalTms(tmUser, user) &&
+             "shouldCommute should have ensured this is true");
+      rewriter.replaceOp(user, newEltwise);
+    }
+  }
+};
+} // namespace
+
+namespace {
+template <typename TMOpType>
+class TTIRCommuteTmsAboveElementwiseUnaryRewriter
+    : public TTIRCommuteTmsAboveElementwiseRewriter<TMOpType,
+                                                    ElementwiseUnary> {
+public:
+  using TTIRCommuteTmsAboveElementwiseRewriter<
+      TMOpType, ElementwiseUnary>::TTIRCommuteTmsAboveElementwiseRewriter;
+
+private:
+  bool isCommuteViable(ElementwiseUnary op, TMOpType tmUser) const override {
+    // We can always commute a TM above an elementwise op.
+    return true;
+  }
+
+  bool isCommuteFavorable(ElementwiseUnary op, TMOpType) const override {
+    // If all users of an elementwise unary op are identical tms, then it is
+    // always favorable to commute them above it.
+    SmallVector<Operation *> users(op->getUsers());
+    return !users.empty() && checkAllUsersAreIdenticalTms(users);
+  }
+};
+} // namespace
+
+namespace {
+template <typename TMOpType>
+class TTIRCommuteTmsAboveElementwiseBinaryRewriter
+    : public TTIRCommuteTmsAboveElementwiseRewriter<TMOpType,
+                                                    ElementwiseBinary> {
+public:
+  using TTIRCommuteTmsAboveElementwiseRewriter<
+      TMOpType, ElementwiseBinary>::TTIRCommuteTmsAboveElementwiseRewriter;
+
+private:
+  bool isCommuteViable(ElementwiseBinary op, TMOpType tmUser) const override {
+    // We can always commute a TM above an elementwise op
+    return true;
+  }
+
+  bool isCommuteFavorable(ElementwiseBinary op, TMOpType) const override {
+    // In some cases there may be an implicit broadcast on one of the operands.
+    // That is there is no broadcast op on one of the operands but a broadcast
+    // is required to execute the op nonetheless. We do not handle this yet. So
+    // we will make sure the operand types are identical.
+    auto firstOperandType = cast<RankedTensorType>(op->getOperand(0).getType());
+    auto secondOperandType =
+        cast<RankedTensorType>(op->getOperand(1).getType());
+
+    // If all users of an elementwise binary op are identical tms, then it is
+    // typically favorable to commute them above it. In some cases we may not
+    // be able to erase/consteval one or both of the commuted operand TMs.
+    SmallVector<Operation *> users(op->getUsers());
+    return !users.empty() && checkAllUsersAreIdenticalTms(users) &&
+           firstOperandType == secondOperandType;
+  }
+};
+} // namespace
+
+void populateElementwiseCommutePatterns(MLIRContext *ctx,
+                                        RewritePatternSet &patterns) {
+  patterns.add<TTIRCommuteTmsAboveElementwiseUnaryRewriter<TransposeOp>,
+               TTIRCommuteTmsAboveElementwiseUnaryRewriter<PermuteOp>,
+               TTIRCommuteTmsAboveElementwiseUnaryRewriter<ReshapeOp>,
+               TTIRCommuteTmsAboveElementwiseBinaryRewriter<TransposeOp>,
+               TTIRCommuteTmsAboveElementwiseBinaryRewriter<PermuteOp>,
+               TTIRCommuteTmsAboveElementwiseBinaryRewriter<ReshapeOp>>(ctx);
+}
+
+} // namespace mlir::tt::ttir

--- a/lib/Dialect/TTIR/Transforms/EraseInverseOps/EraseInverseOps.cpp
+++ b/lib/Dialect/TTIR/Transforms/EraseInverseOps/EraseInverseOps.cpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/EraseInverseOps.h"
+
+#include "ttmlir/Dialect/TT/IR/TT.h"
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
+
+#include "mlir/IR/OperationSupport.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir::tt::ttir {
+#define GEN_PASS_DEF_TTIRERASEINVERSEOPS
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h.inc"
+
+class TTIREraseInverseOps
+    : public impl::TTIREraseInverseOpsBase<TTIREraseInverseOps> {
+public:
+  using impl::TTIREraseInverseOpsBase<
+      TTIREraseInverseOps>::TTIREraseInverseOpsBase;
+  void runOnOperation() final {
+    RewritePatternSet commutePatterns(&getContext());
+    populateElementwiseCommutePatterns(&getContext(), commutePatterns);
+    populateBroadcastCommutePatterns(&getContext(), commutePatterns);
+
+    if (failed(applyPatternsGreedily(getOperation(),
+                                     std::move(commutePatterns)))) {
+      signalPassFailure();
+      return;
+    }
+  }
+};
+} // namespace mlir::tt::ttir

--- a/lib/Dialect/TTIR/Transforms/FlattenSlidingWindow.cpp
+++ b/lib/Dialect/TTIR/Transforms/FlattenSlidingWindow.cpp
@@ -1,0 +1,154 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TT/IR/TT.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
+#include "ttmlir/Utils.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/OperationSupport.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+#include <cstdint>
+
+namespace mlir::tt::ttir {
+#define GEN_PASS_DEF_TTIRFLATTENSLIDINGWINDOW
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h.inc"
+
+namespace {
+
+RankedTensorType getNHWFlattenedType(RankedTensorType unflattenedOutputType) {
+  llvm::ArrayRef<int64_t> outputShape = unflattenedOutputType.getShape();
+  assert(outputShape.size() == 4 && "Expecting 4D tensor");
+  llvm::SmallVector<int64_t, 4> flattenedOutputShape = {
+      1, 1, outputShape[0] * outputShape[1] * outputShape[2], outputShape[3]};
+
+  return RankedTensorType::get(flattenedOutputShape,
+                               unflattenedOutputType.getElementType());
+}
+
+ttir::ReshapeOp generateReshape(mlir::TypedValue<mlir::RankedTensorType> input,
+                                RankedTensorType outputType,
+                                PatternRewriter &rewriter) {
+  // We cannot pass the shape directly as the attribute as ttir::ReshapeOp
+  // requires that the shape attribute is a 32-bit integer array attribute.
+  // Construction the SmallVector allows us to cast it.
+  return ttmlir::utils::createDPSOp<ttir::ReshapeOp>(
+      rewriter, input.getLoc(), outputType, input,
+      rewriter.getI32ArrayAttr(SmallVector<int32_t>(
+          outputType.getShape().begin(), outputType.getShape().end())));
+}
+
+class ConvertToFlattenedConv2dPattern
+    : public OpConversionPattern<ttir::Conv2dOp> {
+public:
+  using OpConversionPattern<ttir::Conv2dOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttir::Conv2dOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    auto inputType = op.getInput().getType();
+    auto outputType = op.getResult().getType();
+
+    Value flattenedInput = generateReshape(
+        op.getInput(), getNHWFlattenedType(inputType), rewriter);
+
+    auto flattenedCompatInfoAttr = ttir::FlattenedCompatInfoAttr::get(
+        getContext(), inputType.getDimSize(0), inputType.getDimSize(1),
+        inputType.getDimSize(2));
+
+    auto newConv = ttmlir::utils::createDPSOp<ttir::Conv2dOp>(
+        rewriter, op.getLoc(), getNHWFlattenedType(outputType), flattenedInput,
+        adaptor.getWeight(), adaptor.getBias(), adaptor.getStride(),
+        adaptor.getPadding(), adaptor.getDilation(), adaptor.getGroups(),
+        flattenedCompatInfoAttr);
+
+    Value output = generateReshape(newConv, outputType, rewriter);
+
+    rewriter.replaceOp(op, output);
+    return success();
+  }
+};
+} // namespace
+
+namespace {
+class ConvertToMaxPool2dFlattenedCompatOpConversionPattern
+    : public OpConversionPattern<ttir::MaxPool2dOp> {
+public:
+  using OpConversionPattern<ttir::MaxPool2dOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttir::MaxPool2dOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto inputType = op.getInput().getType();
+    auto outputType = op.getResult().getType();
+
+    Value flattenedInput = generateReshape(
+        op.getInput(), getNHWFlattenedType(inputType), rewriter);
+
+    auto flattenedCompatInfoAttr = ttir::FlattenedCompatInfoAttr::get(
+        getContext(), inputType.getDimSize(0), inputType.getDimSize(1),
+        inputType.getDimSize(2));
+
+    auto newPool = ttmlir::utils::createDPSOp<ttir::MaxPool2dOp>(
+        rewriter, op.getLoc(), getNHWFlattenedType(outputType), flattenedInput,
+        adaptor.getKernelHeight(), adaptor.getKernelWidth(),
+        adaptor.getStrideHeight(), adaptor.getStrideWidth(),
+        adaptor.getDilationHeight(), adaptor.getDilationWidth(),
+        adaptor.getCeilMode(), adaptor.getPaddingLeft(),
+        adaptor.getPaddingRight(), adaptor.getPaddingTop(),
+        adaptor.getPaddingBottom(), flattenedCompatInfoAttr);
+
+    Value output = generateReshape(newPool, outputType, rewriter);
+
+    rewriter.replaceOp(op, output);
+    return success();
+  }
+};
+} // namespace
+
+class TTIRFlattenSlidingWindow
+    : public impl::TTIRFlattenSlidingWindowBase<TTIRFlattenSlidingWindow> {
+public:
+  using impl::TTIRFlattenSlidingWindowBase<
+      TTIRFlattenSlidingWindow>::TTIRFlattenSlidingWindowBase;
+
+  void runOnOperation() final {
+    RewritePatternSet conversionPatterns(&getContext());
+    TypeConverter typeConverter;
+    // All types map 1:1.
+    typeConverter.addConversion([](Type type) { return type; });
+    conversionPatterns
+        .add<ConvertToFlattenedConv2dPattern,
+             ConvertToMaxPool2dFlattenedCompatOpConversionPattern>(
+            typeConverter, &getContext());
+    FrozenRewritePatternSet conversionPatternSet(std::move(conversionPatterns));
+
+    mlir::ConversionTarget target(getContext());
+    target.addLegalDialect<ttir::TTIRDialect>();
+    target.addLegalDialect<mlir::func::FuncDialect>();
+
+    target.addDynamicallyLegalOp<ttir::Conv2dOp>([&](ttir::Conv2dOp op) {
+      return op.getFlattenedCompatInfo() != nullptr;
+    });
+    target.addDynamicallyLegalOp<ttir::MaxPool2dOp>([&](ttir::MaxPool2dOp op) {
+      return op.getFlattenedCompatInfo() != nullptr;
+    });
+
+    if (failed(applyPartialConversion(getOperation(), target,
+                                      std::move(conversionPatternSet)))) {
+      signalPassFailure();
+      return;
+    }
+  }
+};
+
+} // namespace mlir::tt::ttir

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -41,6 +41,15 @@ void createTTNNPipelineTTIRPasses(
   // Inlines all private functions. I.e flattens the program into the main
   // function. Removes all private functions.
   pm.addPass(mlir::createInlinerPass());
+
+  // Flattening sliding window ops for compatibility with conversion to TTNN
+  pm.addPass(mlir::tt::ttir::createTTIRFlattenSlidingWindow());
+
+  // Add pass to erase inverse ops. This is disabled by default
+  // while the pass is experimental.
+  if (options.eraseInverseOpsEnabled) {
+    pm.addPass(mlir::tt::ttir::createTTIREraseInverseOps());
+  }
 }
 
 void createTTNNPipelineAnalysisPasses(

--- a/lib/Dialect/TTNN/Transforms/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/Optimizer.cpp
@@ -399,8 +399,10 @@ private:
         overridenOpExists[opLocName] = true;
       }
       if (!isa<ttnn::Conv2dOp>(op) && overrideConv2dOp.contains(opLocName)) {
-        op->emitOpError("Trying to override conv2d config on non-conv2d op.");
-        assert(false && "Trying to override conv2d config on non-conv2d op.");
+        op->emitRemark() << "Trying to override non-conv2d op: '"
+                         << op->getName()
+                         << "' with conv2d config. Skipping...";
+        return;
       }
     });
 

--- a/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
@@ -265,9 +265,8 @@ public:
 
       // TTNN Conv2d moves input, weight, and bias from host to device
       // itself. Inserting the ToLayoutOp on these operands is thus problematic.
-      if (!isDPSResult &&
-          (mlir::isa<ttir::Conv2dOp>(op.getOperation()) ||
-           mlir::isa<ttir::ConvTranspose2dOp>(op.getOperation()))) {
+      if (!isDPSResult && (mlir::isa<ttir::Conv2dOp, ttir::ConvTranspose2dOp>(
+                              op.getOperation()))) {
         // For the weight input of the conv2d op, it specifically needs to be on
         // host, so we create a host to layout op (issue
         // https://github.com/tenstorrent/tt-mlir/issues/1528).
@@ -549,8 +548,7 @@ private:
       }
       // For the weight input of the conv2d op, it specifically needs to be on
       // host (issue https://github.com/tenstorrent/tt-mlir/issues/1528).
-      if ((mlir::isa<ttir::Conv2dOp>(user) ||
-           mlir::isa<ttir::ConvTranspose2dOp>(user)) &&
+      if ((mlir::isa<ttir::Conv2dOp, ttir::ConvTranspose2dOp>(user)) &&
           user->getOperand(1) == arg) {
         return true;
       }

--- a/python/test_infra/ttir_builder.py
+++ b/python/test_infra/ttir_builder.py
@@ -1131,7 +1131,7 @@ class TTIRBuilder:
         return self.op_proxy(
             self.conv2d_golden_function,
             ttir.Conv2dOp,
-            [in0, weight],
+            [in0, weight, bias],
             golden_kwargs={
                 "stride": stride,
                 "padding": padding,
@@ -1143,7 +1143,6 @@ class TTIRBuilder:
                 "padding": padding,
                 "dilation": dilation,
                 "groups": groups,
-                "bias": bias,
             },
             organize_ttir_args=lambda i, o, _: (self._get_type(o), i[0], i[1], o),
         )
@@ -1152,6 +1151,7 @@ class TTIRBuilder:
         self,
         input_tensor: Operand,
         weight: Operand,
+        bias: Optional[Operand],
         stride: Union[IntegerAttr, DenseI32ArrayAttr],
         padding: Union[IntegerAttr, DenseI32ArrayAttr],
         dilation: Union[IntegerAttr, DenseI32ArrayAttr],
@@ -1165,19 +1165,23 @@ class TTIRBuilder:
         dilation = (
             tuple(dilation) if not isinstance(dilation, IntegerAttr) else int(dilation)
         )
-        golden_bias = torch.rand((weight.size()[0]), dtype=input_tensor.dtype)
+
+        # ttir can handle a broadcastable bias in the shape [1, 1, 1, C_out], but PyTorch requires the bias is rank 1: [C_out]
+        bias = bias.squeeze()  # Removes all dims of size 1
 
         # Reorganize input and output tensors, golden and ttir functions have different expected tensor shapes
         input_tensor = input_tensor.transpose(-2, -1).transpose(-3, -2)
         result = torch.nn.functional.conv2d(
             input_tensor,
             weight,
-            bias=golden_bias,
+            bias=bias,
             stride=stride,
             padding=padding,
             dilation=dilation,
             groups=groups,
         )
+        result = result.transpose(-3, -2).transpose(-2, -1)
+        return result
         result = result.transpose(-3, -2).transpose(-2, -1)
         return result
 
@@ -1309,6 +1313,9 @@ class TTIRBuilder:
         dilation: tuple[int],
         ceil_mode: bool,
     ):
+        # TTIR  max_pool2d is channels last. PyTorch max_pool2d is channels first.
+        # We need to transpose the input tensor to channels first before applying max_pool2d,
+        # and transpose back to channels last afterward to properly calculate the golden tensor.
         # TTIR  max_pool2d is channels last. PyTorch max_pool2d is channels first.
         # We need to transpose the input tensor to channels first before applying max_pool2d,
         # and transpose back to channels last afterward to properly calculate the golden tensor.

--- a/test/ttmlir/Dialect/TTIR/erase_inverse_ops/basic_eltwise_binary_commute.mlir
+++ b/test/ttmlir/Dialect/TTIR/erase_inverse_ops/basic_eltwise_binary_commute.mlir
@@ -1,0 +1,15 @@
+// RUN: ttmlir-opt --ttir-erase-inverse-ops %s | FileCheck %s
+
+module {
+    func.func @test_commute_permute(%arg0: tensor<1x3x224x224xbf16>, %arg1: tensor<1x3x224x224xbf16>) -> tensor<1x224x224x3xbf16> {
+        // CHECK: %[[PERMUTE1:[0-9]+]] = "ttir.permute"
+        // CHECK: %[[PERMUTE2:[0-9]+]] = "ttir.permute"
+        // CHECK: %[[ADD:[0-9]+]] = "ttir.add"(%[[PERMUTE1]], %[[PERMUTE2]]
+        // CHECK: return %[[ADD]]
+        %0 = tensor.empty() : tensor<1x3x224x224xbf16>
+        %1 = "ttir.add"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x3x224x224xbf16>, tensor<1x3x224x224xbf16>, tensor<1x3x224x224xbf16>) -> tensor<1x3x224x224xbf16>
+        %2 = tensor.empty() : tensor<1x224x224x3xbf16>
+        %3 = "ttir.permute"(%1, %2) <{permutation = array<i64: 0, 2, 3, 1>}> : (tensor<1x3x224x224xbf16>, tensor<1x224x224x3xbf16>) -> tensor<1x224x224x3xbf16>
+        return %3: tensor<1x224x224x3xbf16>
+    }
+}

--- a/test/ttmlir/Dialect/TTIR/erase_inverse_ops/basic_eltwise_unary_commute.mlir
+++ b/test/ttmlir/Dialect/TTIR/erase_inverse_ops/basic_eltwise_unary_commute.mlir
@@ -1,0 +1,70 @@
+// RUN: ttmlir-opt --ttir-erase-inverse-ops %s | FileCheck %s
+module {
+    func.func @test_commute_one_user(%arg0: tensor<32x64xbf16>) -> tensor<64x32xbf16> {
+        // CHECK: %[[TRANSPOSE:[0-9]+]] = "ttir.transpose"
+        // CHECK: %[[EXP:[0-9]+]] = "ttir.exp"(%[[TRANSPOSE]]
+        // CHECK: return %[[EXP]]
+        %0 = tensor.empty() : tensor<32x64xbf16>
+        %1 = "ttir.exp"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x64xbf16>, tensor<32x64xbf16>) -> tensor<32x64xbf16>
+        %2 = tensor.empty() : tensor<64x32xbf16>
+        %3 = "ttir.transpose"(%1, %2) <{dim0 = 0 : si32, dim1 = 1 : si32}> : (tensor<32x64xbf16>, tensor<64x32xbf16>) -> tensor<64x32xbf16>
+        return %3: tensor<64x32xbf16>
+    }
+}
+
+module {
+    func.func @test_commute_identical_users(%arg0: tensor<32x64xbf16>) -> (tensor<64x32xbf16>, tensor<64x32xbf16>) {
+        // CHECK: %[[TRANSPOSE:[0-9]+]] = "ttir.transpose"
+        // CHECK: %[[EXP:[0-9]+]] = "ttir.exp"(%[[TRANSPOSE]]
+        // CHECK: return %[[EXP]], %[[EXP]]
+        %0 = tensor.empty() : tensor<32x64xbf16>
+        %1 = "ttir.exp"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x64xbf16>, tensor<32x64xbf16>) -> tensor<32x64xbf16>
+        %2 = tensor.empty() : tensor<64x32xbf16>
+        %3 = "ttir.transpose"(%1, %2) <{dim0 = 0 : si32, dim1 = 1 : si32}> : (tensor<32x64xbf16>, tensor<64x32xbf16>) -> tensor<64x32xbf16>
+        %4 = tensor.empty() : tensor<64x32xbf16>
+        %5 = "ttir.transpose"(%1, %4) <{dim0 = 0 : si32, dim1 = 1 : si32}> : (tensor<32x64xbf16>, tensor<64x32xbf16>) -> tensor<64x32xbf16>
+        return %3, %5 : tensor<64x32xbf16>, tensor<64x32xbf16>
+    }
+}
+
+module {
+    func.func @test_dont_commute_different_users(%arg0: tensor<32x64xbf16>) -> (tensor<64x32xbf16>, tensor<1x2048xbf16>) {
+        // CHECK: %[[EXP:[0-9]+]] = "ttir.exp"(
+        // CHECK: %[[TRANSPOSE:[0-9]+]] = "ttir.transpose"(%[[EXP]]
+        // CHECK: %[[RESHAPE:[0-9]+]] = "ttir.reshape"(%[[EXP]]
+        // CHECK: return %[[TRANSPOSE]], %[[RESHAPE]]
+        %0 = tensor.empty() : tensor<32x64xbf16>
+        %1 = "ttir.exp"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x64xbf16>, tensor<32x64xbf16>) -> tensor<32x64xbf16>
+        %2 = tensor.empty() : tensor<64x32xbf16>
+        %3 = "ttir.transpose"(%1, %2) <{dim0 = 0 : si32, dim1 = 1 : si32}> : (tensor<32x64xbf16>, tensor<64x32xbf16>) -> tensor<64x32xbf16>
+        %4 = tensor.empty() : tensor<1x2048xbf16>
+        %5 = "ttir.reshape"(%1, %4) <{shape = [1: i32, 2048: i32]}> : (tensor<32x64xbf16>, tensor<1x2048xbf16>) -> tensor<1x2048xbf16>
+        return %3, %5 : tensor<64x32xbf16>, tensor<1x2048xbf16>
+    }
+}
+
+module {
+    func.func @test_commute_reshape(%arg0: tensor<32x64xbf16>) -> tensor<1x2048xbf16> {
+        // CHECK: %[[RESHAPE:[0-9]+]] = "ttir.reshape"
+        // CHECK: %[[EXP:[0-9]+]] = "ttir.exp"(%[[RESHAPE]]
+        // CHECK: return %[[EXP]]
+        %0 = tensor.empty() : tensor<32x64xbf16>
+        %1 = "ttir.exp"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x64xbf16>, tensor<32x64xbf16>) -> tensor<32x64xbf16>
+        %2 = tensor.empty() : tensor<1x2048xbf16>
+        %3 = "ttir.reshape"(%1, %2) <{shape = [1: i32, 2048: i32]}> : (tensor<32x64xbf16>, tensor<1x2048xbf16>) -> tensor<1x2048xbf16>
+        return %3: tensor<1x2048xbf16>
+    }
+}
+
+module {
+    func.func @test_commute_permute(%arg0: tensor<1x3x224x224xbf16>) -> tensor<1x224x224x3xbf16> {
+        // CHECK: %[[PERMUTE:[0-9]+]] = "ttir.permute"
+        // CHECK: %[[EXP:[0-9]+]] = "ttir.exp"(%[[PERMUTE]]
+        // CHECK: return %[[EXP]]
+        %0 = tensor.empty() : tensor<1x3x224x224xbf16>
+        %1 = "ttir.exp"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x3x224x224xbf16>, tensor<1x3x224x224xbf16>) -> tensor<1x3x224x224xbf16>
+        %2 = tensor.empty() : tensor<1x224x224x3xbf16>
+        %3 = "ttir.permute"(%1, %2) <{permutation = array<i64: 0, 2, 3, 1>}> : (tensor<1x3x224x224xbf16>, tensor<1x224x224x3xbf16>) -> tensor<1x224x224x3xbf16>
+        return %3: tensor<1x224x224x3xbf16>
+    }
+}

--- a/test/ttmlir/Dialect/TTIR/erase_inverse_ops/commute_reshape_broadcast.mlir
+++ b/test/ttmlir/Dialect/TTIR/erase_inverse_ops/commute_reshape_broadcast.mlir
@@ -1,0 +1,13 @@
+// RUN: ttmlir-opt --ttir-erase-inverse-ops %s | FileCheck %s
+
+module {
+    func.func @test_commute_reshape_through_broadcast(%arg0: tensor<2048x1x1xbf16>) -> tensor<2048x32x1x64xbf16> {
+        // CHECK: %[[RESHAPE:[0-9]+]] = "ttir.reshape"(%arg0,
+        // CHECK: %[[BROADCAST:[0-9]+]] = "ttir.broadcast"(%[[RESHAPE]]
+        %0 = tensor.empty() : tensor<2048x2048x1xbf16>
+        %1 = "ttir.broadcast"(%arg0, %0) <{broadcast_dimensions = array<i64: 1, 2048, 1>}> : (tensor<2048x1x1xbf16>, tensor<2048x2048x1xbf16>) -> tensor<2048x2048x1xbf16>
+        %2 = tensor.empty() : tensor<2048x32x1x64xbf16>
+        %3 = "ttir.reshape"(%1, %2) <{shape = [2048:i32, 32: i32, 1: i32, 64: i32]}> : (tensor<2048x2048x1xbf16>, tensor<2048x32x1x64xbf16>) -> tensor<2048x32x1x64xbf16>
+        return %3: tensor<2048x32x1x64xbf16>
+    }
+}

--- a/test/ttmlir/Dialect/TTIR/erase_inverse_ops/erase_permute_between_conv2d.mlir
+++ b/test/ttmlir/Dialect/TTIR/erase_inverse_ops/erase_permute_between_conv2d.mlir
@@ -1,0 +1,31 @@
+// RUN: ttmlir-opt --ttir-erase-inverse-ops %s | FileCheck %s
+module {
+  func.func @main(%arg0: tensor<64x3x7x7xf32>, %arg1: tensor<1x3x256x256xf32>, %arg2: tensor<1x64x128x128xf32>, %arg3: tensor<512x64x7x7xf32>) -> tensor<1x512x64x64xf32> {
+    // This module tests whether the permute on the output of the first conv2d is erased along with the permute on the input of the second conv2d.
+    // CHECK: %[[CONV0:[0-9]+]] = "ttir.conv2d"
+    // CHECK: %[[ADD:[0-9]+]] = "ttir.add"(%{{.+}}, %[[CONV0]],
+    // CHECK: %[[EXP:[0-9]+]] = "ttir.exp"(%[[ADD]],
+    // CHECK: %[[CONV1:[0-9]+]] = "ttir.conv2d"(%[[EXP]],
+    %0 = tensor.empty() : tensor<1x64x128x128xf32>
+    %1 = tensor.empty() : tensor<1x256x256x3xf32>
+    %2 = "ttir.permute"(%arg1, %1) <{permutation = array<i64: 0, 2, 3, 1>}> : (tensor<1x3x256x256xf32>, tensor<1x256x256x3xf32>) -> tensor<1x256x256x3xf32>
+    %3 = tensor.empty() : tensor<64x3x7x7xf32>
+    %4 = "ttir.permute"(%arg0, %3) <{permutation = array<i64: 0, 1, 2, 3>}> : (tensor<64x3x7x7xf32>, tensor<64x3x7x7xf32>) -> tensor<64x3x7x7xf32>
+    %5 = tensor.empty() : tensor<1x128x128x64xf32>
+    %6 = "ttir.conv2d"(%2, %4, %5) <{dilation = array<i32: 1, 1>, groups = 1 : i32, padding = array<i32: 3, 3, 3, 3>, stride = array<i32: 2, 2>}> : (tensor<1x256x256x3xf32>, tensor<64x3x7x7xf32>, tensor<1x128x128x64xf32>) -> tensor<1x128x128x64xf32>
+    %7 = "ttir.permute"(%6, %0) <{permutation = array<i64: 0, 3, 1, 2>}> : (tensor<1x128x128x64xf32>, tensor<1x64x128x128xf32>) -> tensor<1x64x128x128xf32>
+    %8 = tensor.empty() : tensor<1x64x128x128xf32>
+    %9 = "ttir.add"(%arg2, %7, %8) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x64x128x128xf32>, tensor<1x64x128x128xf32>, tensor<1x64x128x128xf32>) -> tensor<1x64x128x128xf32>
+    %10 = tensor.empty() : tensor<1x64x128x128xf32>
+    %11 = "ttir.exp"(%9, %10) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x64x128x128xf32>, tensor<1x64x128x128xf32>) -> tensor<1x64x128x128xf32>
+    %12 = tensor.empty() : tensor<1x512x64x64xf32>
+    %13 = tensor.empty() : tensor<1x128x128x64xf32>
+    %14 = "ttir.permute"(%11, %13) <{permutation = array<i64: 0, 2, 3, 1>}> : (tensor<1x64x128x128xf32>, tensor<1x128x128x64xf32>) -> tensor<1x128x128x64xf32>
+    %15 = tensor.empty() : tensor<512x64x7x7xf32>
+    %16 = "ttir.permute"(%arg3, %15) <{permutation = array<i64: 0, 1, 2, 3>}> : (tensor<512x64x7x7xf32>, tensor<512x64x7x7xf32>) -> tensor<512x64x7x7xf32>
+    %17 = tensor.empty() : tensor<1x64x64x512xf32>
+    %18 = "ttir.conv2d"(%14, %16, %17) <{dilation = array<i32: 1, 1>, groups = 1 : i32, padding = array<i32: 3, 3, 3, 3>, stride = array<i32: 2, 2>}> : (tensor<1x128x128x64xf32>, tensor<512x64x7x7xf32>, tensor<1x64x64x512xf32>) -> tensor<1x64x64x512xf32>
+    %19 = "ttir.permute"(%18, %12) <{permutation = array<i64: 0, 3, 1, 2>}> : (tensor<1x64x64x512xf32>, tensor<1x512x64x64xf32>) -> tensor<1x512x64x64xf32>
+    return %19 : tensor<1x512x64x64xf32>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/erase_inverse_ops/no_tms_between_convs.mlir
+++ b/test/ttmlir/Dialect/TTIR/erase_inverse_ops/no_tms_between_convs.mlir
@@ -1,0 +1,48 @@
+// RUN: ttmlir-opt --ttir-erase-inverse-ops %s | FileCheck %s
+module {
+  func.func @main(%arg0: tensor<128x128x3x3xbf16>, %arg1: tensor<1x128x1x1xbf16>, %arg2: tensor<1x128x28x28xbf16>, %arg3: tensor<1x128x1x1xbf16>, %arg4: tensor<1x128x1x1xbf16>, %arg5: tensor<128x128x3x3xbf16>, %arg6: tensor<128xbf16>) -> tensor<1x128x28x28xbf16> {
+    // CHECK: %[[CONV0:[0-9]+]] = "ttir.conv2d"
+    // CHECK: %[[MUL:[0-9]+]] = "ttir.multiply"(%[[CONV0]],
+    // CHECK: %[[ADD:[0-9]+]] = "ttir.add"(%[[MUL]],
+    // CHECK: %[[MAXIMUM:[0-9]+]] = "ttir.maximum"(%[[ADD]],
+    // CHECK: %[[CONV1:[0-9]+]] = "ttir.conv2d"(%[[MAXIMUM]],
+    %0 = "ttir.constant"() <{value = dense<0.000000e+00> : tensor<1x128x28x28xbf16>}> : () -> tensor<1x128x28x28xbf16>
+    %1 = tensor.empty() : tensor<1x128x28x28xbf16>
+    %2 = tensor.empty() : tensor<1x28x28x128xbf16>
+    %3 = "ttir.permute"(%arg2, %2) <{permutation = array<i64: 0, 2, 3, 1>}> : (tensor<1x128x28x28xbf16>, tensor<1x28x28x128xbf16>) -> tensor<1x28x28x128xbf16>
+    %4 = tensor.empty() : tensor<1x1x784x128xbf16>
+    %5 = "ttir.reshape"(%3, %4) <{shape = [1 : i32, 1 : i32, 784 : i32, 128 : i32]}> : (tensor<1x28x28x128xbf16>, tensor<1x1x784x128xbf16>) -> tensor<1x1x784x128xbf16>
+    %6 = tensor.empty() : tensor<1x1x784x128xbf16>
+    %7 = "ttir.conv2d"(%5, %arg0, %6) <{dilation = array<i32: 1, 1>, flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 28, input_width = 28,>, groups = 1 : i32, padding = array<i32: 1, 1, 1, 1>, stride = array<i32: 1, 1>}> : (tensor<1x1x784x128xbf16>, tensor<128x128x3x3xbf16>, tensor<1x1x784x128xbf16>) -> tensor<1x1x784x128xbf16>
+    %8 = tensor.empty() : tensor<1x28x28x128xbf16>
+    %9 = "ttir.reshape"(%7, %8) <{shape = [1 : i32, 28 : i32, 28 : i32, 128 : i32]}> : (tensor<1x1x784x128xbf16>, tensor<1x28x28x128xbf16>) -> tensor<1x28x28x128xbf16>
+    %10 = "ttir.permute"(%9, %1) <{permutation = array<i64: 0, 3, 1, 2>}> : (tensor<1x28x28x128xbf16>, tensor<1x128x28x28xbf16>) -> tensor<1x128x28x28xbf16>
+    %11 = tensor.empty() : tensor<1x128x28x28xbf16>
+    %12 = "ttir.broadcast"(%arg3, %11) <{broadcast_dimensions = array<i64: 1, 1, 28, 28>}> : (tensor<1x128x1x1xbf16>, tensor<1x128x28x28xbf16>) -> tensor<1x128x28x28xbf16>
+    %13 = tensor.empty() : tensor<1x128x28x28xbf16>
+    %14 = "ttir.multiply"(%10, %12, %13) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x128x28x28xbf16>, tensor<1x128x28x28xbf16>, tensor<1x128x28x28xbf16>) -> tensor<1x128x28x28xbf16>
+    %15 = tensor.empty() : tensor<1x128x28x28xbf16>
+    %16 = "ttir.broadcast"(%arg4, %15) <{broadcast_dimensions = array<i64: 1, 1, 28, 28>}> : (tensor<1x128x1x1xbf16>, tensor<1x128x28x28xbf16>) -> tensor<1x128x28x28xbf16>
+    %17 = tensor.empty() : tensor<1x128x28x28xbf16>
+    %18 = "ttir.add"(%14, %16, %17) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x128x28x28xbf16>, tensor<1x128x28x28xbf16>, tensor<1x128x28x28xbf16>) -> tensor<1x128x28x28xbf16>
+    %19 = tensor.empty() : tensor<1x128x28x28xbf16>
+    %20 = "ttir.maximum"(%18, %0, %19) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x128x28x28xbf16>, tensor<1x128x28x28xbf16>, tensor<1x128x28x28xbf16>) -> tensor<1x128x28x28xbf16>
+    %21 = tensor.empty() : tensor<1x128x28x28xbf16>
+    %22 = tensor.empty() : tensor<1x28x28x128xbf16>
+    %23 = "ttir.permute"(%20, %22) <{permutation = array<i64: 0, 2, 3, 1>}> : (tensor<1x128x28x28xbf16>, tensor<1x28x28x128xbf16>) -> tensor<1x28x28x128xbf16>
+    %24 = tensor.empty() : tensor<1x1x784x128xbf16>
+    %25 = "ttir.reshape"(%23, %24) <{shape = [1 : i32, 1 : i32, 784 : i32, 128 : i32]}> : (tensor<1x28x28x128xbf16>, tensor<1x1x784x128xbf16>) -> tensor<1x1x784x128xbf16>
+    %26 = tensor.empty() : tensor<1x1x784x128xbf16>
+    %27 = "ttir.conv2d"(%25, %arg5, %26) <{dilation = array<i32: 1, 1>, flattened_compat_info = #ttir<flattened_compat batch_size = 1, input_height = 28, input_width = 28,>, groups = 1 : i32, padding = array<i32: 1, 1, 1, 1>, stride = array<i32: 1, 1>}> : (tensor<1x1x784x128xbf16>, tensor<128x128x3x3xbf16>, tensor<1x1x784x128xbf16>) -> tensor<1x1x784x128xbf16>
+    %28 = tensor.empty() : tensor<1x28x28x128xbf16>
+    %29 = "ttir.reshape"(%27, %28) <{shape = [1 : i32, 28 : i32, 28 : i32, 128 : i32]}> : (tensor<1x1x784x128xbf16>, tensor<1x28x28x128xbf16>) -> tensor<1x28x28x128xbf16>
+    %30 = "ttir.permute"(%29, %21) <{permutation = array<i64: 0, 3, 1, 2>}> : (tensor<1x28x28x128xbf16>, tensor<1x128x28x28xbf16>) -> tensor<1x128x28x28xbf16>
+    %31 = tensor.empty() : tensor<1x128x1x1xbf16>
+    %32 = "ttir.reshape"(%arg6, %31) <{shape = [1 : i32, 128 : i32, 1 : i32, 1 : i32]}> : (tensor<128xbf16>, tensor<1x128x1x1xbf16>) -> tensor<1x128x1x1xbf16>
+    %33 = tensor.empty() : tensor<1x128x28x28xbf16>
+    %34 = "ttir.broadcast"(%32, %33) <{broadcast_dimensions = array<i64: 1, 1, 28, 28>}> : (tensor<1x128x1x1xbf16>, tensor<1x128x28x28xbf16>) -> tensor<1x128x28x28xbf16>
+    %35 = tensor.empty() : tensor<1x128x28x28xbf16>
+    %36 = "ttir.add"(%30, %34, %35) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x128x28x28xbf16>, tensor<1x128x28x28xbf16>, tensor<1x128x28x28xbf16>) -> tensor<1x128x28x28xbf16>
+    return %36 : tensor<1x128x28x28xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/flatten_sliding_window.mlir
+++ b/test/ttmlir/Dialect/TTIR/flatten_sliding_window.mlir
@@ -1,0 +1,44 @@
+// RUN: ttmlir-opt --ttir-flatten-sliding-window %s | FileCheck %s
+
+module {
+  func.func @conv2d_simple(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x64xbf16> {
+    %0 = tensor.empty() : tensor<1x30x30x64xbf16>
+    // CHECK: %[[RESHAPE1:[0-9]+]] = "ttir.reshape"
+    // CHECK: %[[CONV:[0-9]+]] = "ttir.conv2d"(%[[RESHAPE1]]
+    // CHECK: #ttir<flattened_compat batch_size = 1, input_height = 32, input_width = 32>
+    // CHECK: %[[RESHAPE2:[0-9]+]] = "ttir.reshape"(%[[CONV]]
+    %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
+            <{
+              stride = 1: i32,
+              padding = 0: i32,
+              dilation = 1: i32,
+              groups = 1: i32
+            }> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    return %1 : tensor<1x30x30x64xbf16>
+  }
+}
+
+module {
+  func.func @max_pool2d_simple(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x64xbf16> {
+    %0 = tensor.empty() : tensor<1x30x30x64xbf16>
+    // CHECK: %[[RESHAPE1:[0-9]+]] = "ttir.reshape"
+    // CHECK: %[[POOL:[0-9]+]] = "ttir.max_pool2d"(%[[RESHAPE1]]
+    // CHECK: #ttir<flattened_compat batch_size = 1, input_height = 32, input_width = 32>
+    // CHECK: %[[RESHAPE2:[0-9]+]] = "ttir.reshape"(%[[POOL]]
+    %1 = "ttir.max_pool2d"(%arg0, %0)
+            <{
+              stride_height = 1: si32,
+              stride_width = 1: si32,
+              padding_top = 0: si32,
+              padding_bottom = 0: si32,
+              padding_left = 0: si32,
+              padding_right = 0: si32,
+              dilation_height = 1: si32,
+              dilation_width = 1: si32,
+              kernel_height = 3: si32,
+              kernel_width = 3: si32,
+              ceil_mode = false
+            }> : (tensor<1x32x32x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    return %1 : tensor<1x30x30x64xbf16>
+  }
+}


### PR DESCRIPTION
### Problem description
This pass aims to purge the graph of TMs which are the inverses of each other when separated by a sequence of other ops.

### What's changed
- Added `EraseInverseOps` pass
    - This pass applies _commute patterns_ to ops in the graph. That is the pattern will match some op, followed by a TM and move the TM to the producer of the op
    - Patterns have been implemented to commute transposes, reshapes, and permutations through eltwise unary, eltwise binary, and broadcast ops.

- Added/replaced TM canonicalization patterns using `fold`
    - This is because folding patterns run **during** passes automatically, whilst canonicalization must be explicitly called.
    - These patterns are responsible for erasing back-to-back inverse TMs. The folding patterns are:
        - Replace identity TM with its operand
        - For back-to-back permutations, fuse the permutation attribute into the consumer permutation, and set its operand to the input of the first permutation
        - For back-to-back inverse transposes, replace the consumer with the producer transpose's input
        - Replace back-to-back reshape with just the consumer reshape
   - While these patterns do not explicitly remove inverses, they do after multiple calls to `fold`. I.e, back to back permutation will become just one permutation, that permutation ends up being the identity permutation, then that permutation is removed.


- Added TTIRToTTNNBackendPipeline option to enable/disable the pass `enable-erase-inverse-ops-pass` (`true` by default)
- Added `FlattenSlidingWindow` pass and `FlattenedCompatInfoAttr`
    - Since ttnn sliding window ops require their inputs (and outputs) be in the format `(1, 1, N*H*W, C)` we need to insert reshapes on the input/output of these ops at some point during lowering.
    - Currently this is done when converting TTIR to TTNN
    - `EraseInverseOps` has the capability of removing inverse reshapes. Since it operates on the TTIR dialect we would like to expose these reshapes before this pass
    - `FlattenedCompatInfoAttr` is an optional attribute for `ttir.conv2d` and `ttir.max_pool2d` and it contains any information that is lost when flattening the input and output
        - Input height
        - input width
        - batch size
    - The `FlattenSlidingWindow` pass inserts the required reshapes on the input and output of `ttir.conv2d` and `ttir.max_pool2d` and populates the `FlattenedCompatInfoAttr`
- Lowering `ttir.conv2d` and `ttir.max_pool2d` now requires that `FlattenedCompatInfoAttr` is populated. That is, `FlattenSlidingWindow` must be run on the TTIR graph before dialect conversion

- The EraseInverseOps pass has been written for the TTIR dialect. This is because:
  - This is a high level optimization. That is, this is hardware agnostic - it solely removes high level operations from the program
  - We want to do this before memory modelling as it will change the shapes and attributes of some ops, and in some cases move TMs elsewhere in the graph (if they are not erased)
  - There is also the direct to metal backend which would likely want to use this pass during lowering too
 
Transposes/Permutes/Reshapes can conditionally commute through ops like Reduce, Select, and Concat. The commute logic for those has not been implemented. We can add this logic at any time by defining new a `CommuteRewritePattern`.
- The `CommuteRewritePattern` classes for eltwise unary and binary ops are currently identical. However I've separated them as we may wish to implement different logic in `isCommuteFavorable` given that eltwise binary ops have two operands.

There is room for a more rigorous analysis on whether we should commute. Currently we only commute if all users of an eltwise op are an identical TM, however there can be cases where you want to commute anyway. The `isCommuteFavorable` functions can be as detailed as we like.

### Checklist
- [X] New/Existing tests provide coverage for changes
