### PR TITLE
Add Conv2dOp and Test

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -1215,13 +1215,13 @@ def TTIR_Conv2dOp : TTIR_NamedOp<"conv2d"> {
         - H_in is the height of the input planes
         - W_in is the width of the input planes
         - C is the number of channels
-      - `weight` (AnyRankedTensor): expected in the following format (O, C/G, K_H, K_W).
-      - `bias` Optional<AnyRankedTensor>: expected in the following format (1, 1, 1, O) where:
+      - `weight` (AnyRankedTensor): expected in the following format (O, C/G, K_H, K_W) where:
         - C is the number of input channels
         - O is the number of output channels
         - G is the number of groups
         - K_H is the height of the kernel
         - K_W is the width of the kernel
+      - `bias` Optional<AnyRankedTensor>: expected in the following format (1, 1, 1, O).
       - `output` AnyRankedTensor()): expected in the following format (N, H_out, W_out, O) where:
         - `H_out = (H_in + pT + pB - dH * (K_H - 1) - 1) / sH + 1`
         - `W_out = (W_in + pL + pR - dW * (K_W - 1) - 1) / sW + 1`
@@ -1283,13 +1283,13 @@ def TTIR_ConvTranspose2dOp : TTIR_NamedOp<"conv_transpose2d"> {
           - W_in is the width of the input planes
           - C is the number of channels
 
-        - `weight` AnyRankedTensor: expected in the following format (C, O/G, K_H, K_W).
-        - `bias` Optional<AnyRankedTensor>: expected in the following format (1, 1, 1, O) where:
-          - C is the number of input channels
-          - O is the number of output channels
-          - G is the number of groups
-          - K_H is the height of the kernel
-          - K_W is the width of the kernel
+      - `weight` (AnyRankedTensor): expected in the following format (O, C/G, K_H, K_W) where:
+        - C is the number of input channels
+        - O is the number of output channels
+        - G is the number of groups
+        - K_H is the height of the kernel
+        - K_W is the width of the kernel
+      - `bias` Optional<AnyRankedTensor>: expected in the following format (1, 1, 1, O).
 
         - `output` AnyRankedTensor: expected in the following format (N, H_out, W_out, O) where:
           - H_out = (H_in - 1) * stride[0] - (padding_top + padding_bottom) + dilation[0] * (K_H - 1) + output_padding[0] + 1

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -1277,12 +1277,11 @@ def TTIR_ConvTranspose2dOp : TTIR_NamedOp<"conv_transpose2d"> {
       Applies a 2D transposed convolution operator over an input image composed of several input planes.
 
       Inputs:
-        - `input` AnyRankedTensor: expected in the following format (N, H_in, W_in, C) where:
-          - N is the batch size
-          - H_in is the height of the input planes
-          - W_in is the width of the input planes
-          - C is the number of channels
-
+      - `input` AnyRankedTensor: expected in the following format (N, H_in, W_in, C) where:
+        - N is the batch size
+        - H_in is the height of the input planes
+        - W_in is the width of the input planes
+        - C is the number of channels
       - `weight` (AnyRankedTensor): expected in the following format (O, C/G, K_H, K_W) where:
         - C is the number of input channels
         - O is the number of output channels
@@ -1290,17 +1289,16 @@ def TTIR_ConvTranspose2dOp : TTIR_NamedOp<"conv_transpose2d"> {
         - K_H is the height of the kernel
         - K_W is the width of the kernel
       - `bias` Optional<AnyRankedTensor>: expected in the following format (1, 1, 1, O).
-
-        - `output` AnyRankedTensor: expected in the following format (N, H_out, W_out, O) where:
-          - H_out = (H_in - 1) * stride[0] - (padding_top + padding_bottom) + dilation[0] * (K_H - 1) + output_padding[0] + 1
-          - W_out = (W_in - 1) * stride[1] - (padding_left + padding_right) + dilation[1] * (K_W - 1) + output_padding[1] + 1
+      - `output` AnyRankedTensor: expected in the following format (N, H_out, W_out, O) where:
+        - H_out = (H_in - 1) * stride[0] - (padding_top + padding_bottom) + dilation[0] * (K_H - 1) + output_padding[0] + 1
+        - W_out = (W_in - 1) * stride[1] - (padding_left + padding_right) + dilation[1] * (K_W - 1) + output_padding[1] + 1
 
       Attributes:
-        - `stride` (i32 | array<2xi32>): Controls the stride for the cross-correlation.
-        - `padding` (i32 | array<2xi32> | array<4xi32>): Controls the amount of implicit zero padding on both sides for dilation * (kernel_size - 1) - padding number of points.
-        - `output_padding` (i32 | array<2xi32>): Controls the additional size added to one side of the output shape.
-        - `dilation` (i32 | array<2xi32>): Controls the spacing between the kernel points
-        - `groups` i32: Controls the connections between inputs and outputs. Must be divisible by input and output channels.
+      - `stride` (i32 | array<2xi32>): Controls the stride for the cross-correlation.
+      - `padding` (i32 | array<2xi32> | array<4xi32>): Controls the amount of implicit zero padding on both sides for dilation * (kernel_size - 1) - padding number of points.
+      - `output_padding` (i32 | array<2xi32>): Controls the additional size added to one side of the output shape.
+      - `dilation` (i32 | array<2xi32>): Controls the spacing between the kernel points
+      - `groups` i32: Controls the connections between inputs and outputs. Must be divisible by input and output channels.
 
       Example:
         %input = tensor.empty() : () -> tensor<3x8x8x256xbf16>

--- a/python/test_infra/ttir_builder.py
+++ b/python/test_infra/ttir_builder.py
@@ -841,6 +841,78 @@ class TTIRBuilder:
             organize_ttir_args=lambda i, o, _: (self._get_type(o), i[0], o),
         )
 
+    def conv2d(
+        self,
+        in0: Operand,
+        weight: Operand,
+        bias: Optional[Operand],
+        in1: Operand,
+        stride: Union[IntegerAttr, DenseI32ArrayAttr],
+        padding: Union[IntegerAttr, DenseI32ArrayAttr],
+        dilation: Union[IntegerAttr, DenseI32ArrayAttr],
+        groups: IntegerAttr,
+    ) -> OpView:
+        output_type = self.get_type_from_torch_dtype(self._get_golden_tensor(in1).dtype)
+        if not bias:
+            bias = None
+        return self.op_proxy(
+            self.conv2d_golden_function,
+            ttir.Conv2dOp,
+            [in0, weight],
+            golden_kwargs={
+                "stride": stride,
+                "padding": padding,
+                "dilation": dilation,
+                "groups": int(groups),
+            },
+            ttir_kwargs={
+                "stride": stride,
+                "padding": padding,
+                "dilation": dilation,
+                "groups": groups,
+                "bias": bias,
+            },
+            organize_ttir_args=lambda i, o, _: (self._get_type(o), i[0], i[1], o),
+            output_type=output_type,
+        )
+
+    def conv2d_golden_function(
+        self,
+        in0: Operand,
+        weight: Operand,
+        stride: Union[IntegerAttr, DenseI32ArrayAttr],
+        padding: Union[IntegerAttr, DenseI32ArrayAttr],
+        dilation: Union[IntegerAttr, DenseI32ArrayAttr],
+        groups: int,
+    ) -> Operand:
+        # reorganize ttir_kwargs into golden_kwargs
+        golden_stride = (
+            tuple(stride) if not isinstance(stride, IntegerAttr) else int(stride)
+        )
+        golden_padding = (
+            tuple(padding) if not isinstance(padding, IntegerAttr) else int(padding)
+        )
+        golden_dilation = (
+            tuple(dilation) if not isinstance(dilation, IntegerAttr) else int(dilation)
+        )
+        golden_bias = torch.rand((weight.size()[0]), dtype=in0.dtype)
+
+        # reorganize input and output tensors, golden and ttir functions have different expected tensor shapes
+        n, h_out, w_out, c_out = list(in0.size())
+        input_tensor = torch.rand((n, c_out, h_out, w_out), dtype=in0.dtype)
+        output_unorganized = torch.nn.functional.conv2d(
+            input_tensor,
+            weight,
+            bias=golden_bias,
+            stride=golden_stride,
+            padding=golden_padding,
+            dilation=golden_dilation,
+            groups=groups,
+        )
+        n, c_out, h_out, w_out = list(output_unorganized.size())
+        output_tensor = torch.rand((n, h_out, w_out, c_out), dtype=in0.dtype)
+        return output_tensor
+
     def max_pool2d(
         self,
         in0: Operand,

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -11,7 +11,13 @@ import numpy as np
 from ttmlir.test_utils import compile_to_flatbuffer, set_output_path
 from ttmlir.ttir_builder import Operand, TTIRBuilder, Attribute, UnitAttr
 from ttmlir.dialects import ttir
-from ttmlir.ir import DenseI64ArrayAttr, DenseElementsAttr
+from ttmlir.ir import (
+    DenseI64ArrayAttr,
+    DenseElementsAttr,
+    DenseI32ArrayAttr,
+    IntegerAttr,
+    IntegerType,
+)
 
 
 # NOTE: This test is not valid for TTRT Perf due to weird issues with perf collection. Issue #2371
@@ -529,6 +535,35 @@ def test_repeat_interleave(in0: Operand, builder: TTIRBuilder):
 )
 def test_broadcast(in0: Operand, in1: Operand, builder: TTIRBuilder):
     return builder.broadcast(in0, in1, [1, 16, 1])
+
+
+@compile_to_flatbuffer(
+    [
+        (1, 32, 32, 64),
+        (64, 32, 3, 3),
+        (1, 1, 1, 64),
+        (1, 16, 28, 64),
+    ],
+    inputs_types=[torch.bfloat16, torch.bfloat16, torch.bfloat16, torch.bfloat16],
+    targets=["ttnn"],
+)
+def test_conv2d(
+    in0: Operand, weight: Operand, bias: Operand, in1: Operand, builder: TTIRBuilder
+):
+    stride = DenseI32ArrayAttr.get([2, 1])
+    padding = DenseI32ArrayAttr.get([2, 1])
+    dilation = DenseI32ArrayAttr.get([2, 1])
+    groups = IntegerAttr.get(IntegerType.get_signless(32), 2)
+    return builder.conv2d(
+        in0,
+        weight,
+        bias,
+        in1,
+        stride=stride,
+        padding=padding,
+        dilation=dilation,
+        groups=groups,
+    )
 
 
 @compile_to_flatbuffer(


### PR DESCRIPTION
### Ticket
[Issue #2529 ](https://github.com/tenstorrent/tt-mlir/issues/2529)

### Problem description
Conv2dOp was not supported in TTIR builder

### What's changed
Added support in ttir_builder.py for Conv2dOp
Added test in test_ttir_ops.py.

### Checklist
- [x] New/Existing tests provide coverage for changes
