### PR TITLE
Bug fix, generate semaphores for all generic regions in lockstep

### DIFF
--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -2857,7 +2857,7 @@ void mlir::tt::ttir::PermuteOp::getCanonicalizationPatterns(
   }
 
   ValueTypeRange<OperandRange> operandTypes = getOperation()->getOperandTypes();
-  auto firstRegion = getRegions().begin();
+  auto *firstRegion = getRegions().begin();
   for (Region &region : getRegions()) {
     if (!region.hasOneBlock()) {
       return emitOpError("GenericOp region must have a single block");

--- a/lib/Dialect/TTIR/Transforms/GenericGenerateDatamovement.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericGenerateDatamovement.cpp
@@ -236,10 +236,12 @@ public:
     // fly. i.e. adding semaphore arguments.
     for (unsigned regionIdx = 0; regionIdx < numTotalRegions; ++regionIdx) {
       Block &block = newGeneric.getRegion(regionIdx).emplaceBlock();
-      block.addArguments(generic.getRegion(0).getArgumentTypes(),
-                         SmallVector<mlir::Location>(
-                             generic.getRegion(0).getArgumentTypes().size(),
-                             generic.getLoc()));
+      rewriter.modifyOpInPlace(newGeneric, [&] {
+        block.addArguments(generic.getRegion(0).getArgumentTypes(),
+                           SmallVector<mlir::Location>(
+                               generic.getRegion(0).getArgumentTypes().size(),
+                               generic.getLoc()));
+      });
     }
 
     // Insert the new data movement regions.

--- a/test/ttmlir/Dialect/TTIR/generic/generic_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/generic_negative.mlir
@@ -79,3 +79,39 @@ func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1
   }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
   return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
 }
+
+// -----
+
+#l1_ = #tt.memory_space<l1>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #tt.iterator_type<parallel>
+
+// CHECK: error: 'ttir.generic' op all regions must have the same number of arguments
+
+func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>}> ({
+  ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
+  }, {
+  ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg5: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
+  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+}
+
+// -----
+
+#l1_ = #tt.memory_space<l1>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #tt.iterator_type<parallel>
+
+// CHECK: error: 'ttir.generic' op all regions must have the same argument types
+
+func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>}> ({
+  ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg5: !ttir.semaphore):
+  }, {
+  ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg5: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
+  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+}


### PR DESCRIPTION
This commit actually fixes a couple of issues in the semaphore generation part of the datamovement generation pass.  These include:

- Pregenerating all of the region function signatures for the new generic op, up front.  This is the core bug, previously we were just creating new regions on the fly, but this meant that they would miss out on previous region's semaphore additions.
- Compute region should also inherit semaphores.
- Modify only the newly created regions instead of the old op in place.
- Additional generic op verification and testing to enforce that all regions have the same number of arguments and the same type for each respective argument.

Closes #2526