### PR TITLE
Pass mesh_shape to backend pipeline to support CCL ops in TTIRBuilder

### DIFF
--- a/python/test_infra/test_utils.py
+++ b/python/test_infra/test_utils.py
@@ -199,16 +199,16 @@ def ttir_to_ttnn(
     if system_desc_path is None:
         system_desc_path = os.getenv("SYSTEM_DESC_PATH", "")
 
-    # Generate override string
-    overridings = []
+    # Generate option string
+    options = []
     if system_desc_path:
-        overridings.append(f"system-desc-path={system_desc_path}")
+        options.append(f"system-desc-path={system_desc_path}")
     if mesh_shape and len(mesh_shape) == 2:
-        overridings.append(f"mesh-shape={mesh_shape[0]},{mesh_shape[1]}")
+        options.append(f"mesh-shape={mesh_shape[0]},{mesh_shape[1]}")
 
     # Now, pass it through the TTIR to TTNN pipeline. Module gets
     # modified in place.
-    ttir_to_ttnn_backend_pipeline(module, " ".join(overridings))
+    ttir_to_ttnn_backend_pipeline(module, " ".join(options))
 
     print("`ttir_to_ttnn_backend_pipeline` passed successfully.")
 

--- a/python/test_infra/test_utils.py
+++ b/python/test_infra/test_utils.py
@@ -59,6 +59,7 @@ def compile_as_mlir_module(
     test_fn: Callable,
     inputs_shapes: List[Shape],
     inputs_types: Optional[List[torch.dtype]] = None,
+    mesh_shape: Optional[Tuple[int, int]] = None,
     module_dump: bool = False,
 ):
     """
@@ -130,6 +131,11 @@ def compile_as_mlir_module(
     # Instantiate builder which is passed as the last argument to
     # `test_fn` so the user can use it to build ops.
     builder = TTIRBuilder(ctx, loc)
+
+    # deliver mesh_shape to TTIRBuilder
+    # TTIR itself does not require mesh_shape information; however, it is needed to generate the golden tensor.
+    if mesh_shape is not None:
+        builder.set_mesh_shape(mesh_shape)
 
     # Default to all f32s
     if inputs_types is None:
@@ -389,7 +395,7 @@ def compile_to_flatbuffer(
 
             if "ttnn" in targets:
                 module, builder = compile_as_mlir_module(
-                    test_fn, inputs_shapes, inputs_types
+                    test_fn, inputs_shapes, inputs_types, mesh_shape
                 )
 
                 if module_dump:

--- a/python/test_infra/ttir_builder.py
+++ b/python/test_infra/ttir_builder.py
@@ -112,6 +112,9 @@ class TTIRBuilder:
         # id to golden map
         self.id_golden_map = {}
 
+        # mesh_shape for multi-device
+        self.mesh_shape = ()
+
     # ----- Public helpers -----
 
     @property
@@ -182,6 +185,10 @@ class TTIRBuilder:
                 golden_tensor.tensor.numel() * golden_tensor.tensor.dtype.itemsize,
             )
         return golden_info
+
+    # set mesh_shape for multi-device environment
+    def set_mesh_shape(self, mesh_shape: Tuple[int, int]):
+        self.mesh_shape = mesh_shape
 
     # ----- Private helpers -----
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/2539
Closes #2539 

### Problem description
The mesh_shape information is required during MLIR module generation when using CCL (Collective Communication Library) ops such as all_gather, all_reduce, reduce_scatter, and mesh_shard.
Currently, this information is not passed into the compile_as_mlir_module flow, which prevents the backend pipeline from correctly configuring the module for these ops.

### What's changed
Added mesh_shape as an optional argument to compile_as_mlir_module.
mesh_shape is now passed through to the ttir_to_ttnn_backend_pipeline, enabling correct lowering and compilation for CCL ops.

### Checklist
- [ ] New/Existing tests provide coverage for changes
