### PR TITLE
Disable RemoveDeadValues pass by default

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -162,6 +162,13 @@ struct TTIRToTTNNBackendPipelineOptions
           "\"argument-types=forward=input,parameter,parameter,constant\""
           "\n\n"),
       llvm::cl::init(TTArgumentTypeMap())};
+
+  // TODO (azecevic): This pass is causing a lot of memory consumption and is
+  // disabled by default (https://github.com/tenstorrent/tt-mlir/issues/2512).
+  Option<bool> removeDeadValuesEnabled{
+      *this, "enable-remove-dead-values",
+      llvm::cl::desc("Enable --remove-dead-values optimization pass."),
+      llvm::cl::init(false)};
 };
 
 // TTIR to EmitC pipeline options.

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -66,7 +66,9 @@ void createTTNNPipelineLoweringPasses(
   // Add pass to convert TTIR to TTNN.
   pm.addPass(createConvertTTIRToTTNNPass());
   // Add pass to remove unused values.
-  pm.addPass(mlir::createRemoveDeadValuesPass());
+  if (options.removeDeadValuesEnabled) {
+    pm.addPass(mlir::createRemoveDeadValuesPass());
+  }
 }
 
 // Create a pass to workaround issues in the TTNN dialect.


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/2512

### Problem description
This pass has very high memory consumption, with a very little (if any) benefit.

### What's changed
Added an option to enable it if we find some use-case for it, but it's disabled by default.

### Checklist
- CI runs:
- [forge-fe](https://github.com/tenstorrent/tt-forge-fe/actions/runs/13948345509)
- [tt-torch](https://github.com/tenstorrent/tt-torch/actions/runs/13948354212)
- [tt-xla](https://github.com/tenstorrent/tt-xla/actions/runs/13948359539)