### PR TITLE
Re-enable ttnn::zeros emitc test

### DIFF
--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -1174,7 +1174,8 @@ public:
         emitter.emit(srcOp.getShape()),
         emitter.emit(srcOp.getDtype()),
         emitter.emit(srcOp.getLayout()),
-        emitter.emit(srcOp.getDevice()),
+        emitter.emit<::ttnn::operations::creation::detail::OptionalAnyDevice>(
+            srcOp.getDevice()),
         emitter.emit(srcOp.getMemoryConfig()) |
             emitter.getMemoryConfig(srcOp.getResult()),
     };

--- a/test/ttmlir/EmitC/TTNN/tensor/zeros.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/zeros.mlir
@@ -2,9 +2,6 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
 // RUN: ttmlir-opt --ttnn-modify-signatures-for-dylib --convert-ttnn-to-emitc %t.mlir > %t2.mlir
 // RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
-//
-// UNSUPPORTED: true
-// Outstanding bug: https://github.com/tenstorrent/tt-mlir/issues/2072
 
 func.func @zeros() -> tensor<13x24x56x42xbf16> {
   %0 = "ttir.zeros"() <{shape = array<i32:13, 24, 56, 42>}> : () -> tensor<13x24x56x42xbf16>


### PR DESCRIPTION
### Ticket
#2558 

### Problem description
Zeros op isn't working in EmitC path because the device piped to `ttnn::zeros` is `ttnn::IDevice*` instead of `::ttnn::operations::creation::detail::OptionalAnyDevice`.

### What's changed
Convert `ttnn::IDevice` to `::ttnn::operations::creation::detail::OptionalAnyDevice`.

### Checklist
- [x] New/Existing tests provide coverage for changes
