### PR TITLE
Adding emitC conversion for Where op

### DIFF
--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -358,6 +358,42 @@ public:
 };
 } // namespace
 
+// Eltwise Ternary op conversion pattern
+//
+// Currently, it has to insert nullopts for some parameters that are not
+// modelled in the dialect (memcfg).
+//
+namespace {
+template <typename SourceOp>
+class EltwiseTernaryOpConversionPattern
+    : public TTNNToEmitCBaseOpConversionPattern<SourceOp> {
+
+public:
+  using TTNNToEmitCBaseOpConversionPattern<
+      SourceOp>::TTNNToEmitCBaseOpConversionPattern;
+  using Adaptor = typename SourceOp::Adaptor;
+
+  LogicalResult
+  matchAndRewrite(SourceOp srcOp, Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    ttnn_to_emitc::EmitCTTNNEmitter<SourceOp> emitter(srcOp, adaptor, rewriter);
+
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getInputs()[0]),
+        emitter.emit(srcOp.getInputs()[1]),
+        emitter.emit(srcOp.getInputs()[2]),
+        emitter.emit(std::nullopt) |
+            emitter.getMemoryConfig(srcOp->getResult(0)),
+    };
+
+    emitter.replaceOp(*this, args);
+
+    return success();
+  }
+};
+} // namespace
+
 // Linear op conversion pattern
 //
 namespace {
@@ -1592,6 +1628,11 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
            EltwiseBinaryOpConversionPattern<tt::ttnn::PowerOp>>(typeConverter,
                                                                 ctx);
 
+  // Eltwise ternary ops
+  //
+  patterns.add<EltwiseTernaryOpConversionPattern<tt::ttnn::WhereOp>>(
+      typeConverter, ctx);
+
   // Tensor manipulation ops
   //
   patterns.add<TransposeOpConversionPattern, ConcatOpConversionPattern,
@@ -1630,7 +1671,6 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
   //
   patterns.add<SoftmaxOpConversionPattern, EmbeddingOpConversionPattern,
                DefaultOpConversionPattern<tt::ttnn::EmbeddingBackwardOp>,
-               DefaultOpConversionPattern<tt::ttnn::WhereOp>,
                MorehCumSumOpConversionPattern>(typeConverter, ctx);
 
   // CCL ops

--- a/test/ttmlir/EmitC/TTNN/eltwise_ternary/where.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_ternary/where.mlir
@@ -1,0 +1,12 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
+// RUN: ttmlir-opt --ttnn-modify-signatures-for-dylib --convert-ttnn-to-emitc %t.mlir > %t2.mlir
+// RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
+
+func.func @test_where(%arg0: tensor<13x37xbf16>, %arg1: tensor<13x37xbf16>) -> tensor<13x37xbf16> {
+  %0 = tensor.empty() : tensor<13x37xbf16>
+  %1 = "ttir.eq"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x37xbf16>, tensor<13x37xbf16>, tensor<13x37xbf16>) -> tensor<13x37xbf16>
+  %2 = tensor.empty() : tensor<13x37xbf16>
+  %3 = "ttir.where"(%1, %arg0, %arg1, %2) <{operandSegmentSizes = array<i32: 3, 1>}> : (tensor<13x37xbf16>, tensor<13x37xbf16>, tensor<13x37xbf16>, tensor<13x37xbf16>) -> tensor<13x37xbf16>
+  return %3 : tensor<13x37xbf16>
+}


### PR DESCRIPTION
### Ticket
Part of the following issues:
https://github.com/tenstorrent/tt-mlir/issues/1877

### Problem description
Currently we lack an emitC conversion for all where op.

### What's changed
This PR adds a missing emitC conversion for where op.
### Checklist
- [x] New/Existing tests provide coverage for changes
