### PR TITLE
#2501: Migrated all mesh functionality into MeshAttr which gets propogated. Cleaned up verification logic and tests

### DIFF
--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -105,6 +105,39 @@ def TT_ChipPhysicalCoresAttr : TT_Attr<"ChipPhysicalCores", "chip_physical_cores
   let assemblyFormat = "`{` `worker` `=` `[` $worker `]` `dram` `=` `[` $dram `]` (`eth` `=` `[` $eth^ `]`)? (`eth_inactive` `=` `[` $eth_inactive^ `]`)? `}`";
 }
 
+def TT_MeshAttr : TT_Attr<"Mesh", "mesh", []> {
+  let summary = "Mesh reference attribute in TT dialect.";
+  let description = [{
+    Describes a mesh config including name and shape.
+  }];
+  let parameters = (ins "StringAttr":$name,
+                        "unsigned":$numberOfChips,
+                        ArrayRefParameter<"int64_t">:$shape,
+                        ArrayRefParameter<"unsigned">:$chipIds);
+  let assemblyFormat = "`<` `name` `=` $name `,` `numberOfChips` `=` $numberOfChips `,` `shape` `=` custom<DimensionList>($shape) `,` `chipIds` `=` `[` $chipIds `]` `>`";
+  let genVerifyDecl = 1;
+
+  let extraClassDeclaration = [{
+    static MeshAttr getDefault(::mlir::MLIRContext *context) {
+      auto meshName = mlir::StringAttr::get(context, "mesh");
+      auto numberOfChips = 1;
+      ::llvm::SmallVector<int64_t> shape = {1, 1};
+      ::llvm::SmallVector<unsigned> chipIds = {0};
+      return MeshAttr::get(context, meshName, numberOfChips, shape, chipIds);
+    };
+    static MeshAttr get(::mlir::MLIRContext *context, StringRef meshName, ::llvm::ArrayRef<int64_t> meshShape);
+  }];
+}
+
+def TT_MeshesAttr : TT_Attr<"Meshes", "meshes"> {
+  let summary = "TT system meshes attribute.";
+  let description = [{
+    TT system meshes attribute includes one or more mesh configs used for networks.
+  }];
+  let parameters = (ins ArrayRefParameter<"MeshAttr">:$meshes);
+  let assemblyFormat = "`<` `[` $meshes `]` `>`";
+}
+
 def TT_ChipDescAttr : TT_Attr<"ChipDesc", "chip_desc"> {
   let summary = "TT chip_desc attribute";
   let description = [{
@@ -206,8 +239,8 @@ def TT_SystemDescAttr : TT_Attr<"SystemDesc", "system_desc"> {
   let assemblyFormat = "`<` `[` $cpuDescs `]` `,` `[` $chipDescs `]` `,` `[` $chipDescIndices `]` `,` `[` $chipCapabilities `]` `,` `[` $chipCoords `]` (`,` `[` $chipChannels^ `]`)? `>`";
 
   let extraClassDeclaration = [{
-    static tt::SystemDescAttr getDefault(MLIRContext *context, const llvm::SmallVector<int64_t> &meshShape = {1});
-    static tt::SystemDescAttr getFromPath(MLIRContext *context, std::string& path);
+    static tt::SystemDescAttr getDefault(MLIRContext *context, const MeshAttr &meshAttr);
+    static tt::SystemDescAttr getFromPath(MLIRContext *context, std::string &path);
     unsigned getAddressAlignBytes(unsigned chipIndex = 0) const;
     unsigned getAddressAlignBytes(MemorySpace memorySpace, unsigned chipIndex = 0) const;
     unsigned getNocL1AddressAlignBytes(unsigned chipIndex = 0) const;
@@ -394,13 +427,11 @@ def TT_DeviceAttr : TT_Attr<"Device", "device", []> {
   let parameters = (ins TT_GridAttr:$workerGrid,
                         "AffineMap":$l1Map,
                         "AffineMap":$dramMap,
-                        ArrayRefParameter<"int64_t">:$meshShape,
-                        ArrayRefParameter<"unsigned">:$chipIds);
-  let assemblyFormat = "`<` `workerGrid` `=` qualified($workerGrid) `,` `l1Map` `=` qualified($l1Map) `,` `dramMap` `=` qualified($dramMap) `,` `meshShape` `=` custom<DimensionList>($meshShape) `,` `chipIds` `=` `[` $chipIds `]` `>`";
+                        TT_MeshAttr:$mesh);
+  let assemblyFormat = "`<` `workerGrid` `=` qualified($workerGrid) `,` `l1Map` `=` qualified($l1Map) `,` `dramMap` `=` qualified($dramMap) `,` `mesh` `=` qualified($mesh) `>`";
 
   let extraClassDeclaration = [{
-      static DeviceAttr get(::mlir::MLIRContext *context, SystemDescAttr systemDesc, ArrayRef<int64_t> meshShape, ArrayRef<unsigned> chipIds);
-      static DeviceAttr get(::mlir::MLIRContext *context, SystemDescAttr systemDesc, ArrayRef<int64_t> meshShape = {});
+      static DeviceAttr get(::mlir::MLIRContext *context, SystemDescAttr systemDesc, MeshAttr meshAttr);
       AffineMap getMemoryMap(MemRefType memrefType, size_t pageSize, size_t baseOffset = 0) const;
       size_t getMemrefSizeBytes(MemRefType memrefType, size_t pageSize) const;
 
@@ -484,25 +515,6 @@ def TT_TensorMeshShardingAttr : TT_Attr<"TensorMeshSharding", "mesh_sharding", [
         return TensorMeshShardingAttr::get(context, meshNameStrAttr, axes);
       }
   }];
-}
-
-def TT_MeshAttr : TT_Attr<"Mesh", "mesh", []> {
-  let summary = "Mesh reference attribute in TT dialect.";
-  let description = [{
-    Describes a mesh config including name and shape.
-  }];
-  let parameters = (ins "StringAttr":$name,
-                        ArrayRefParameter<"int64_t">:$shape);
-  let assemblyFormat = "`<` $name `=` custom<DimensionList>($shape) `>`";
-}
-
-def TT_MeshesAttr : TT_Attr<"Meshes", "meshes"> {
-  let summary = "TT system meshes attribute.";
-  let description = [{
-    TT system meshes attribute includes one or more mesh configs used for networks.
-  }];
-  let parameters = (ins ArrayRefParameter<"MeshAttr">:$meshes);
-  let assemblyFormat = "`<` `[` $meshes `]` `>`";
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Dialect/TT/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TT/Transforms/Passes.td
@@ -60,6 +60,7 @@ def TTRegisterDevicePass : Pass<"tt-register-device", "::mlir::ModuleOp"> {
   list<Option> options = [
         Option<"systemDescPath", "system-desc-path", "std::string", "", "System desc path">,
         ListOption<"meshShape", "mesh-shape", "int64_t", "Set the mesh shape">,
+        Option<"meshName", "mesh-name", "std::string", "", "Set the mesh name.">,
     ];
 }
 

--- a/include/ttmlir/Dialect/TT/Transforms/Transforms.h
+++ b/include/ttmlir/Dialect/TT/Transforms/Transforms.h
@@ -12,7 +12,8 @@
 namespace mlir::tt {
 
 void registerDevice(ModuleOp module, std::string path = {},
-                    ArrayRef<int64_t> meshShape = {});
+                    ArrayRef<int64_t> meshShape = {1, 1},
+                    StringRef meshName = "mesh");
 
 } // namespace mlir::tt
 

--- a/include/ttmlir/Dialect/TTMetal/Pipelines/TTMetalPipelines.h
+++ b/include/ttmlir/Dialect/TTMetal/Pipelines/TTMetalPipelines.h
@@ -12,6 +12,10 @@ namespace mlir::tt::ttmetal {
 //
 struct TTIRToTTMetalBackendPipelineOptions
     : public PassPipelineOptions<TTIRToTTMetalBackendPipelineOptions> {
+  Option<std::string> meshName{*this, "mesh-name",
+                               llvm::cl::desc("Set a mesh name."),
+                               llvm::cl::init("mesh")};
+
   ListOption<int64_t> meshShape{
       *this, "mesh-shape", llvm::cl::desc("Set the multi-device mesh shape.")};
 

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -116,6 +116,10 @@ struct TTIRToTTNNBackendPipelineOptions
                      "layout analysis."),
       llvm::cl::init(64)};
 
+  Option<std::string> meshName{*this, OptionNames::meshName,
+                               llvm::cl::desc("Set a mesh name."),
+                               llvm::cl::init("mesh")};
+
   ListOption<int64_t> meshShape{
       *this, OptionNames::meshShape,
       llvm::cl::desc("Set the multi-device mesh shape.")};

--- a/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
@@ -25,6 +25,7 @@ struct OptionNames {
   static constexpr StringRef systemDescPath = "system-desc-path";
   static constexpr StringRef maxLegalLayouts = "max-legal-layouts";
   static constexpr StringRef meshShape = "mesh-shape";
+  static constexpr StringRef meshName = "mesh-name";
 };
 
 struct OutputLayoutOverrideParams {

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
@@ -237,7 +237,7 @@ public:
 
     PhysicalCoreCoordMapping physicalCoordMapping =
         PhysicalCoreCoordMapping::getMemorySpaceMapping(
-            device.getChipIds(), systemDesc.getChipDescs(),
+            device.getMesh().getChipIds(), systemDesc.getChipDescs(),
             dataMovementType == NocTx::Type::Read
                 ? inputLayout.getMemorySpace()
                 : outputLayout.getMemorySpace());

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -40,6 +40,7 @@ void createTTIRToTTMetalBackendPipeline(
   {
     registerDeviceOptions.systemDescPath = options.systemDescPath;
     registerDeviceOptions.meshShape = llvm::to_vector(options.meshShape);
+    registerDeviceOptions.meshName = options.meshName;
   }
   pm.addPass(mlir::tt::createTTRegisterDevicePass(registerDeviceOptions));
   pm.addPass(mlir::tt::ttir::createTTIRConstantAsFill());

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -1598,7 +1598,7 @@ void mlir::tt::ttnn::ToLayoutOp::getCanonicalizationPatterns(
 
 ::mlir::OpFoldResult mlir::tt::ttnn::AllGatherOp::fold(FoldAdaptor adaptor) {
   tt::DeviceAttr device = lookupDevice(*this);
-  llvm::SmallVector<int64_t> meshShape{device.getMeshShape()};
+  llvm::SmallVector<int64_t> meshShape{device.getMesh().getShape()};
   // AllGather Op is semantically meaningless when gathering across a single
   // mesh device.
   if (meshShape.empty() || meshShape[getClusterAxis()] != 1) {
@@ -1648,7 +1648,7 @@ void mlir::tt::ttnn::ToLayoutOp::getCanonicalizationPatterns(
 ::mlir::OpFoldResult
 mlir::tt::ttnn::ReduceScatterOp::fold(FoldAdaptor adaptor) {
   tt::DeviceAttr device = lookupDevice(*this);
-  llvm::SmallVector<int64_t> meshShape{device.getMeshShape()};
+  llvm::SmallVector<int64_t> meshShape{device.getMesh().getShape()};
   // ReduceScatter Op is semantically meaningless when gathering across a single
   // mesh device.
   if (meshShape.empty() || meshShape[getClusterAxis()] != 1) {
@@ -1685,7 +1685,7 @@ mlir::tt::ttnn::ReduceScatterOp::fold(FoldAdaptor adaptor) {
 
 ::mlir::OpFoldResult mlir::tt::ttnn::AllReduceOp::fold(FoldAdaptor adaptor) {
   tt::DeviceAttr device = lookupDevice(*this);
-  llvm::SmallVector<int64_t> meshShape{device.getMeshShape()};
+  llvm::SmallVector<int64_t> meshShape{device.getMesh().getShape()};
   // AllReduce Op is semantically meaningless when gathering across a single
   // mesh device.
   if (meshShape.empty() || meshShape[getClusterAxis()] != 1) {

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -29,6 +29,7 @@ void createTTNNPipelineTTIRPasses(
   {
     registerDeviceOptions.systemDescPath = options.systemDescPath;
     registerDeviceOptions.meshShape = llvm::to_vector(options.meshShape);
+    registerDeviceOptions.meshName = options.meshName;
   }
   pm.addPass(mlir::tt::createTTRegisterDevicePass(registerDeviceOptions));
 

--- a/lib/Dialect/TTNN/Transforms/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/Optimizer.cpp
@@ -429,7 +429,7 @@ private:
     DeviceAttr deviceAttr = lookupDevice(contextOp);
     auto currentInsertionPoint = builder.saveInsertionPoint();
     builder.setInsertionPoint(block, block->begin());
-    llvm::SmallVector<int64_t> meshShape{deviceAttr.getMeshShape()};
+    llvm::SmallVector<int64_t> meshShape{deviceAttr.getMesh().getShape()};
     if (meshShape.empty()) {
       meshShape = llvm::SmallVector<int64_t, 2>{1, 1};
     }

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkarounds.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkarounds.cpp
@@ -349,7 +349,7 @@ public:
     uint32_t clusterAxis = op.getClusterAxis();
     Value deviceValue = op.getDevice();
     auto deviceDesc = lookupDevice(op);
-    ::llvm::ArrayRef<int64_t> meshShape = deviceDesc.getMeshShape();
+    ::llvm::ArrayRef<int64_t> meshShape = deviceDesc.getMesh().getShape();
 
     // Algorithm: iterate through all tensor dimension values and select first
     // tensor dimension which is divisible by number of devices along the

--- a/lib/Dialect/TTNN/Utils/TransformUtils.cpp
+++ b/lib/Dialect/TTNN/Utils/TransformUtils.cpp
@@ -23,13 +23,11 @@ GetDeviceOp getOrInsertDevice(RewriterBase &rewriter, Operation *op) {
   DeviceAttr deviceAttr = lookupDevice(op);
   auto currentInsertionPoint = rewriter.saveInsertionPoint();
   rewriter.setInsertionPoint(block, block->begin());
-  llvm::SmallVector<int64_t> meshShape{deviceAttr.getMeshShape()};
-  if (meshShape.empty()) {
-    meshShape = llvm::SmallVector<int64_t, 2>{1, 1};
-  }
   auto deviceOp = rewriter.create<ttnn::GetDeviceOp>(
       op->getLoc(), rewriter.getType<DeviceType>(),
-      ttnn::MeshShapeAttr::get(op->getContext(), meshShape[0], meshShape[1]));
+      ttnn::MeshShapeAttr::get(op->getContext(),
+                               deviceAttr.getMesh().getShape()[0],
+                               deviceAttr.getMesh().getShape()[1]));
   rewriter.restoreInsertionPoint(currentInsertionPoint);
   return deviceOp;
 }

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -122,7 +122,7 @@ getTensorValueCoreRangeSet(FlatbufferObjectCache &cache, Value value) {
 ::flatbuffers::Offset<::tt::target::DeviceRef>
 createDeviceRef(FlatbufferObjectCache &cache, Value device) {
   auto desc = lookupDevice(device.getParentBlock()->getParentOp());
-  auto chipIds = desc.getChipIds();
+  auto chipIds = desc.getMesh().getChipIds();
   return ::tt::target::CreateDeviceRef(*cache.fbb, chipIds[0]);
 }
 
@@ -330,7 +330,7 @@ createOperation(FlatbufferObjectCache &cache, ::flatbuffers::Offset<OpT> op,
 createOp(FlatbufferObjectCache &cache, GetDeviceOp op) {
   auto result = op.getResult();
   auto desc = lookupDevice(op);
-  auto meshShape = desc.getMeshShape();
+  auto meshShape = desc.getMesh().getShape();
   auto meshVolume = ttmlir::utils::volume(meshShape);
   ::tt::target::Dim2d mesh;
   if (meshVolume > 1) {
@@ -339,7 +339,7 @@ createOp(FlatbufferObjectCache &cache, GetDeviceOp op) {
     mesh = ::tt::target::Dim2d(1, 1);
   }
 
-  auto chipIds = toFlatbuffer(cache, desc.getChipIds());
+  auto chipIds = toFlatbuffer(cache, desc.getMesh().getChipIds());
   auto out = cache.getOrCreate(result, createDeviceRef);
   return ::tt::target::ttnn::CreateGetDeviceOp(*cache.fbb, &mesh, chipIds, out);
 }
@@ -495,7 +495,7 @@ createDistributionStrategy(FlatbufferObjectCache &cache,
   auto deviceOp = mlir::cast<GetDeviceOp>(
       getOperandThroughDPSOps(deviceValue).getDefiningOp());
   auto desc = lookupDevice(deviceOp);
-  ::llvm::ArrayRef<int64_t> meshShape = desc.getMeshShape();
+  ::llvm::ArrayRef<int64_t> meshShape = desc.getMesh().getShape();
   numShards = ttmlir::utils::volume(meshShape);
 
   if (numShards == 1) {

--- a/python/TTModule.cpp
+++ b/python/TTModule.cpp
@@ -278,7 +278,8 @@ void populateTTModule(nb::module_ &m) {
   tt_attribute_class<tt::SystemDescAttr>(m, "SystemDescAttr")
       .def_static("get_default",
                   [](MlirContext ctx) {
-                    return wrap(tt::SystemDescAttr::getDefault(unwrap(ctx)));
+                    return wrap(tt::SystemDescAttr::getDefault(
+                        unwrap(ctx), tt::MeshAttr::getDefault(unwrap(ctx))));
                   })
       .def_static(
           "get",
@@ -375,7 +376,7 @@ void populateTTModule(nb::module_ &m) {
                     return wrap(tt::DeviceAttr::get(
                         unwrap(ctx),
                         mlir::cast<tt::SystemDescAttr>(unwrap(systemDesc)),
-                        meshShape));
+                        tt::MeshAttr::get(unwrap(ctx), "mesh", meshShape)));
                   })
       .def_static("get",
                   [](MlirContext ctx, std::vector<int64_t> gridShape,
@@ -386,7 +387,8 @@ void populateTTModule(nb::module_ &m) {
                         unwrap(ctx),
                         tt::GridAttr::get(unwrap(ctx), gridShape,
                                           unwrap(workerGridMapping)),
-                        unwrap(l1Map), unwrap(dramMap), meshShape, chipIds));
+                        unwrap(l1Map), unwrap(dramMap),
+                        tt::MeshAttr::get(unwrap(ctx), "mesh", meshShape)));
                   })
       .def("unwrap",
            [](MlirAttribute const &self) {
@@ -397,11 +399,12 @@ void populateTTModule(nb::module_ &m) {
                    [](tt::DeviceAttr self) { return wrap(self.getL1Map()); })
       .def_prop_ro("dram_map",
                    [](tt::DeviceAttr self) { return wrap(self.getDramMap()); })
-      .def_prop_ro(
-          "mesh_shape",
-          [](tt::DeviceAttr const &self) { return self.getMeshShape().vec(); })
+      .def_prop_ro("mesh_shape",
+                   [](tt::DeviceAttr const &self) {
+                     return self.getMesh().getShape().vec();
+                   })
       .def_prop_ro("chip_ids", [](tt::DeviceAttr const &self) {
-        return self.getChipIds().vec();
+        return self.getMesh().getChipIds().vec();
       });
 
   tt_type_class<tt::TileType>(m, "TileType")

--- a/test/python/device_attr.py
+++ b/test/python/device_attr.py
@@ -66,7 +66,7 @@ def createDeviceAttr(
     deviceStartIdx=0,
     workerGridMap=None,
     system_desc=None,
-    mesh_shape=[1],
+    mesh_shape=[1, 1],
 ):
     if system_desc is not None:
         return tt.ir.DeviceAttr.from_system_desc(ctx, system_desc, mesh_shape)
@@ -100,50 +100,50 @@ d1 = d(1)
 d2 = d(2)
 
 print("=== From SystemDesc ===")
-# CHECK: tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 1, chipIds = [0]>
+# CHECK: #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5] -> (0, 0, (((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) floordiv s4) mod 12, ((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) floordiv (s4 * 12) + ((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) mod s4 + s5), mesh = #tt.mesh<name = "mesh", numberOfChips = 1, shape = 1x1, chipIds = [0]>>
 print("", createDeviceAttr([8, 8], system_desc=tt.ir.SystemDescAttr.get_default(ctx)))
 
 # ------------------------------------------------------------------------------
 
 print("=== Simple single device ===")
-# CHECK: tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 1, chipIds = [0]>
+# CHECK: #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, 0, d0, d1), dramMap = (d0, d1)[s0, s1] -> (0, 0, d0, d1), mesh = #tt.mesh<name = "mesh", numberOfChips = 1, shape = 1x1, chipIds = [0]>>
 print("", createDeviceAttr([8, 8]))
 
 # ------------------------------------------------------------------------------
 
 print("\n=== Data parallel over batch ===")
-# CHECK: tt.device<workerGrid = #tt.grid<2x8x8, (d0, d1, d2) -> (d0, d1, d2)>, l1Map = [[M:.*]], dramMap = [[M:.*]], meshShape = 2x1x1, chipIds = [0, 1]>
+# CHECK: #tt.device<workerGrid = #tt.grid<2x8x8, (d0, d1, d2) -> (d0, d1, d2)>, l1Map = (d0, d1, d2)[s0, s1, s2] -> (0, d0, d1, d2), dramMap = (d0, d1, d2)[s0, s1, s2] -> (0, d0, d1, d2), mesh = #tt.mesh<name = "mesh", numberOfChips = 2, shape = 2x1x1, chipIds = [0, 1]>>
 print("divide batch by 2\n", createDeviceAttr([2, 8, 8], mesh_shape=[2, 1, 1]))
-# CHECK: tt.device<workerGrid = #tt.grid<4x8x8, (d0, d1, d2) -> (d0, d1, d2)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 4x1x1, chipIds = [0, 1, 2, 3]>
+# CHECK: tt.device<workerGrid = #tt.grid<4x8x8, (d0, d1, d2) -> (d0, d1, d2)>, l1Map = (d0, d1, d2)[s0, s1, s2] -> (0, d0, d1, d2), dramMap = (d0, d1, d2)[s0, s1, s2] -> (0, d0, d1, d2), mesh = #tt.mesh<name = "mesh", numberOfChips = 4, shape = 4x1x1, chipIds = [0, 1, 2, 3]>>
 print("divide batch by 4\n", createDeviceAttr([4, 8, 8], mesh_shape=[4, 1, 1]))
 
 # ------------------------------------------------------------------------------
 
 print("\n=== Data parallel over 2d ===")
-# CHECK: tt.device<workerGrid = #tt.grid<8x16, (d0, d1) -> (d1 floordiv 8, d0, d1 mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 1x2, chipIds = [0, 1]>
+# CHECK: #tt.device<workerGrid = #tt.grid<8x16, (d0, d1) -> (d1 floordiv 8, d0, d1 mod 8)>, l1Map = (d0, d1)[s0, s1] -> (0, 0, d0, d1), dramMap = (d0, d1)[s0, s1] -> (0, 0, d0, d1), mesh = #tt.mesh<name = "mesh", numberOfChips = 2, shape = 1x2, chipIds = [0, 1]>>
 print(
     "Reinterpret 2 devices as grid side by side, 1x2 mesh\n",
     createDeviceAttr([8, 16], mesh_shape=[1, 2]),
 )
-# CHECK: tt.device<workerGrid = #tt.grid<16x8, (d0, d1) -> (d0 floordiv 8, d0 mod 8, d1)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 2x1, chipIds = [0, 1]>
+# CHECK: #tt.device<workerGrid = #tt.grid<16x8, (d0, d1) -> (d0 floordiv 8, d0 mod 8, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, 0, d0, d1), dramMap = (d0, d1)[s0, s1] -> (0, 0, d0, d1), mesh = #tt.mesh<name = "mesh", numberOfChips = 2, shape = 2x1, chipIds = [0, 1]>>
 print(
     "Reinterpret 2 devices as grid top to bottom, 2x1 mesh\n",
     createDeviceAttr([16, 8], mesh_shape=[2, 1]),
 )
-# CHECK: tt.device<workerGrid = #tt.grid<16x32, (d0, d1) -> (d1 floordiv 8 + (d0 floordiv 8) * 4, d0 mod 8, d1 mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 2x4, chipIds = [0, 1, 2, 3, 4, 5, 6, 7]>
+# CHECK: #tt.device<workerGrid = #tt.grid<16x32, (d0, d1) -> (d1 floordiv 8 + (d0 floordiv 8) * 4, d0 mod 8, d1 mod 8)>, l1Map = (d0, d1)[s0, s1] -> (0, 0, d0, d1), dramMap = (d0, d1)[s0, s1] -> (0, 0, d0, d1), mesh = #tt.mesh<name = "mesh", numberOfChips = 8, shape = 2x4, chipIds = [0, 1, 2, 3, 4, 5, 6, 7]>>
 print("8 devices 2x4 mesh\n", createDeviceAttr([16, 32], mesh_shape=[2, 4]))
-# CHECK: tt.device<workerGrid = #tt.grid<32x16, (d0, d1) -> (d1 floordiv 8 + (d0 floordiv 8) * 2, d0 mod 8, d1 mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 4x2, chipIds = [0, 1, 2, 3, 4, 5, 6, 7]>
+# CHECK: #tt.device<workerGrid = #tt.grid<32x16, (d0, d1) -> (d1 floordiv 8 + (d0 floordiv 8) * 2, d0 mod 8, d1 mod 8)>, l1Map = (d0, d1)[s0, s1] -> (0, 0, d0, d1), dramMap = (d0, d1)[s0, s1] -> (0, 0, d0, d1), mesh = #tt.mesh<name = "mesh", numberOfChips = 8, shape = 4x2, chipIds = [0, 1, 2, 3, 4, 5, 6, 7]>>
 print("8 devices 4x2 mesh\n", createDeviceAttr([32, 16], mesh_shape=[4, 2]))
 
 # ------------------------------------------------------------------------------
 
 print("\n=== Data parallel over 2d and batch (3d) ===")
-# CHECK: tt.device<workerGrid = #tt.grid<2x8x16, (d0, d1, d2) -> (d0 * 2 + d2 floordiv 8, d1, d2 mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 2x1x2, chipIds = [0, 1, 2, 3]>
+# CHECK: #tt.device<workerGrid = #tt.grid<2x8x16, (d0, d1, d2) -> (d0 * 2 + d2 floordiv 8, d1, d2 mod 8)>, l1Map = (d0, d1, d2)[s0, s1, s2] -> (0, d0, d1, d2), dramMap = (d0, d1, d2)[s0, s1, s2] -> (0, d0, d1, d2), mesh = #tt.mesh<name = "mesh", numberOfChips = 4, shape = 2x1x2, chipIds = [0, 1, 2, 3]>>
 print(
     "divide batch by 2, 2x1x2 mesh\n",
     createDeviceAttr([2, 8, 16], mesh_shape=[2, 1, 2]),
 )
-# CHECK: tt.device<workerGrid = #tt.grid<3x24x8, (d0, d1, d2) -> (d0 * 3 + d1 floordiv 8, d1 mod 8, d2)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 3x3x1, chipIds = [0, 1, 2, 3, 4, 5, 6, 7, 8]>
+# CHECK: #tt.device<workerGrid = #tt.grid<3x24x8, (d0, d1, d2) -> (d0 * 3 + d1 floordiv 8, d1 mod 8, d2)>, l1Map = (d0, d1, d2)[s0, s1, s2] -> (0, d0, d1, d2), dramMap = (d0, d1, d2)[s0, s1, s2] -> (0, d0, d1, d2), mesh = #tt.mesh<name = "mesh", numberOfChips = 9, shape = 3x3x1, chipIds = [0, 1, 2, 3, 4, 5, 6, 7, 8]>>
 print(
     "divide batch by 3, 3x3x1 mesh\n",
     createDeviceAttr([3, 24, 8], mesh_shape=[3, 3, 1]),
@@ -152,13 +152,13 @@ print(
 # ------------------------------------------------------------------------------
 
 print("\n=== nD ===")
-# CHECK: tt.device<workerGrid = #tt.grid<3x2x8x8, (d0, d1, d2, d3) -> (d0 * 2 + d1, d2, d3)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 3x2x1x1, chipIds = [0, 1, 2, 3, 4, 5]>
+# CHECK: #tt.device<workerGrid = #tt.grid<3x2x8x8, (d0, d1, d2, d3) -> (d0 * 2 + d1, d2, d3)>, l1Map = (d0, d1, d2, d3)[s0, s1, s2, s3] -> (d0, d1, d2, d3), dramMap = (d0, d1, d2, d3)[s0, s1, s2, s3] -> (d0, d1, d2, d3), mesh = #tt.mesh<name = "mesh", numberOfChips = 6, shape = 3x2x1x1, chipIds = [0, 1, 2, 3, 4, 5]>>
 print("", createDeviceAttr([3, 2, 8, 8], mesh_shape=[3, 2, 1, 1]))
 
 # ------------------------------------------------------------------------------
 
 print("\n=== Data parallel batch on single device ===")
-# CHECK: tt.device<workerGrid = #tt.grid<2x4x8, (d0, d1, d2) -> (0, d0 * 4 + d1, d2)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 1, chipIds = [0]>
+# CHECK: #tt.device<workerGrid = #tt.grid<2x4x8, (d0, d1, d2) -> (0, d0 * 4 + d1, d2)>, l1Map = (d0, d1, d2)[s0, s1, s2] -> (0, d0, d1, d2), dramMap = (d0, d1, d2)[s0, s1, s2] -> (0, d0, d1, d2), mesh = #tt.mesh<name = "mesh", numberOfChips = 1, shape = 1x1, chipIds = [0]>>
 print(
     "divide batch by 2, top 4 rows get batch 0, bottom 4 rows get batch 1\n",
     createDeviceAttr([2, 4, 8], workerGridMap=amap(3, [c0, d0 * 4 + d1, d2])),
@@ -167,12 +167,12 @@ print(
 # ------------------------------------------------------------------------------
 
 print("\n=== Pipeline parallel ===")
-# CHECK: tt.device<workerGrid = #tt.grid<2x8x16, (d0, d1, d2) -> (d0 * 2 + d2 floordiv 8, d1, d2 mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 2x1x2, chipIds = [0, 1, 2, 3]>
+# CHECK: #tt.device<workerGrid = #tt.grid<2x8x16, (d0, d1, d2) -> (d0 * 2 + d2 floordiv 8, d1, d2 mod 8)>, l1Map = (d0, d1, d2)[s0, s1, s2] -> (0, d0, d1, d2), dramMap = (d0, d1, d2)[s0, s1, s2] -> (0, d0, d1, d2), mesh = #tt.mesh<name = "mesh", numberOfChips = 4, shape = 2x1x2, chipIds = [0, 1, 2, 3]>>
 print(
     "view devices 0-3 in one way\n",
     createDeviceAttr([2, 8, 16], deviceStartIdx=0, mesh_shape=[2, 1, 2]),
 )
-# CHECK: tt.device<workerGrid = #tt.grid<16x16, (d0, d1) -> (d1 floordiv 8 + (d0 floordiv 8) * 2, d0 mod 8, d1 mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 2x2, chipIds = [4, 5, 6, 7]>
+# CHECK: #tt.device<workerGrid = #tt.grid<16x16, (d0, d1) -> (d1 floordiv 8 + (d0 floordiv 8) * 2, d0 mod 8, d1 mod 8)>, l1Map = (d0, d1)[s0, s1] -> (0, 0, d0, d1), dramMap = (d0, d1)[s0, s1] -> (0, 0, d0, d1), mesh = #tt.mesh<name = "mesh", numberOfChips = 4, shape = 2x2, chipIds = [0, 1, 2, 3]>>
 print(
     "view devices 4-7 in another way\n",
     createDeviceAttr([16, 16], deviceStartIdx=4, mesh_shape=[2, 2]),
@@ -181,16 +181,16 @@ print(
 # ------------------------------------------------------------------------------
 
 print("\n=== Reinterpreted Grids ===")
-# CHECK: tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d1, d0)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 1, chipIds = [0]>
+# CHECK: #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d1, d0)>, l1Map = (d0, d1)[s0, s1] -> (0, 0, d0, d1), dramMap = (d0, d1)[s0, s1] -> (0, 0, d0, d1), mesh = #tt.mesh<name = "mesh", numberOfChips = 1, shape = 1x1, chipIds = [0]>>
 print("transposed\n", createDeviceAttr([8, 8], workerGridMap=amap(2, [c0, d1, d0])))
-# CHECK: tt.device<workerGrid = #tt.grid<1x64, (d0, d1) -> (0, d0 * 8 + d1 floordiv 8, d1 mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 1, chipIds = [0]>
+# CHECK: #tt.device<workerGrid = #tt.grid<1x64, (d0, d1) -> (0, d0 * 8 + d1 floordiv 8, d1 mod 8)>, l1Map = (d0, d1)[s0, s1] -> (0, 0, d0, d1), dramMap = (d0, d1)[s0, s1] -> (0, 0, d0, d1), mesh = #tt.mesh<name = "mesh", numberOfChips = 1, shape = 1x1, chipIds = [0]>>
 print(
     "extra wide\n",
     createDeviceAttr(
         [1, 64], workerGridMap=amap(2, [c0, d0 * 8 + floordiv(d1, c(8)), d1 % 8])
     ),
 )
-# CHECK: tt.device<workerGrid = #tt.grid<64x1, (d0, d1) -> (0, d1 * 8 + d0 floordiv 8, d0 mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 1, chipIds = [0]>
+# CHECK: #tt.device<workerGrid = #tt.grid<64x1, (d0, d1) -> (0, d1 * 8 + d0 floordiv 8, d0 mod 8)>, l1Map = (d0, d1)[s0, s1] -> (0, 0, d0, d1), dramMap = (d0, d1)[s0, s1] -> (0, 0, d0, d1), mesh = #tt.mesh<name = "mesh", numberOfChips = 1, shape = 1x1, chipIds = [0]>>
 print(
     "extra tall transposed\n",
     createDeviceAttr(
@@ -198,7 +198,7 @@ print(
         workerGridMap=amap(2, [c0, d1 * 8 + floordiv(d0, c(8)), d0 % 8]),
     ),
 )
-# CHECK: tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, (d0 + d1) mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 1, chipIds = [0]>
+# CHECK: #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, (d0 + d1) mod 8)>, l1Map = (d0, d1)[s0, s1] -> (0, 0, d0, d1), dramMap = (d0, d1)[s0, s1] -> (0, 0, d0, d1), mesh = #tt.mesh<name = "mesh", numberOfChips = 1, shape = 1x1, chipIds = [0]>>
 print(
     "staircase systolic\n",
     createDeviceAttr([8, 8], workerGridMap=amap(2, [c0, d0, (d0 + d1) % 8])),

--- a/test/ttmlir/Dialect/TTNN/ccl/all_gather/all_gather_positive.mlir
+++ b/test/ttmlir/Dialect/TTNN/ccl/all_gather/all_gather_positive.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --split-input-file --ttir-to-ttnn-backend-pipeline="mesh-shape=1,4" %s | FileCheck %s
+// RUN: ttmlir-opt --split-input-file --ttir-to-ttnn-backend-pipeline="mesh-shape=1,2" %s | FileCheck %s
 // Unit tests for ttnn all_gather op
 
 // -----

--- a/test/ttmlir/Dialect/TTNN/ccl/mesh_shard.mlir
+++ b/test/ttmlir/Dialect/TTNN/ccl/mesh_shard.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt -split-input-file --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 
-module @mesh_shard_test attributes {tt.meshes = #tt.meshes<[<"mesh" = 1x1>]>} {
+module @mesh_shard_test attributes {tt.meshes = #tt.meshes<[#tt.mesh<name="mesh", numberOfChips = 1, shape=1x1, chipIds = [0]>]>} {
   func.func @forward(%arg0: tensor<8192x784xf32>) -> tensor<8192x392xf32> {
     %0 = tensor.empty() : tensor<8192x392xf32>
     %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: 0, 1>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 2>, shard_type = #tt.shard_type<devices>}> : (tensor<8192x784xf32>, tensor<8192x392xf32>) -> tensor<8192x392xf32>
@@ -16,7 +16,7 @@ module @mesh_shard_test attributes {tt.meshes = #tt.meshes<[<"mesh" = 1x1>]>} {
 
 // -----
 
-module @mesh_shard_test attributes {tt.meshes = #tt.meshes<[<"mesh" = 1x1>]>} {
+module @mesh_shard_test attributes {tt.meshes = #tt.meshes<[#tt.mesh<name="mesh", numberOfChips = 1, shape=1x1, chipIds = [0]>]>} {
   func.func @forward(%arg0: tensor<8192x784xf32>) -> tensor<8192x392xf32> {
     %0 = tensor.empty() : tensor<8192x392xf32>
     %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: 0, 1>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 2>, shard_type = #tt.shard_type<identity>}> : (tensor<8192x784xf32>, tensor<8192x392xf32>) -> tensor<8192x392xf32>


### PR DESCRIPTION
This change wraps all chipIds and mesh shapes under a MeshAttr. This MeshAttr is attached to DeviceAttr. This will allow us to create multiple DeviceAttrs with sub meshes and keep track of them throughout compiler.