### PR TITLE
#2502: Added additional constraint checks to ccl operations for replica group device ids

### DIFF
--- a/include/ttmlir-c/TTAttrs.h
+++ b/include/ttmlir-c/TTAttrs.h
@@ -78,6 +78,14 @@ MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTChipPhysicalCoresAttrGet(
 MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTCoreCoordAttrGet(MlirContext ctx,
                                                           int64_t y, int64_t x);
 
+MlirAttribute ttmlirTTMeshAttrGet(MlirContext ctx, MlirAttribute *meshName,
+                                  MlirAttribute *shape, size_t shapeSize,
+                                  MlirAttribute *chipIds, size_t chipIdsSize);
+
+MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTMeshesAttrGet(MlirContext ctx,
+                                                       MlirAttribute *meshes,
+                                                       size_t meshesSize);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -105,6 +105,37 @@ def TT_ChipPhysicalCoresAttr : TT_Attr<"ChipPhysicalCores", "chip_physical_cores
   let assemblyFormat = "`{` `worker` `=` `[` $worker `]` `dram` `=` `[` $dram `]` (`eth` `=` `[` $eth^ `]`)? (`eth_inactive` `=` `[` $eth_inactive^ `]`)? `}`";
 }
 
+def TT_MeshAttr : TT_Attr<"Mesh", "mesh", []> {
+  let summary = "Mesh reference attribute in TT dialect.";
+  let description = [{
+    Describes a mesh config including name and shape.
+  }];
+  let parameters = (ins "StringAttr":$name,
+                        ArrayRefParameter<"int64_t">:$shape,
+                        ArrayRefParameter<"unsigned">:$chipIds);
+  let assemblyFormat = "`<` `name` `=` $name `,` `shape` `=` custom<DimensionList>($shape) `,` `chipIds` `=` `[` $chipIds `]` `>`";
+  let genVerifyDecl = 1;
+
+  let extraClassDeclaration = [{
+    static MeshAttr getDefault(::mlir::MLIRContext *context) {
+      auto meshName = mlir::StringAttr::get(context, "mesh");
+      ::llvm::SmallVector<int64_t> shape = {1, 1};
+      ::llvm::SmallVector<unsigned> chipIds = {0};
+      return MeshAttr::get(context, meshName, shape, chipIds);
+    };
+    static MeshAttr get(::mlir::MLIRContext *context, StringRef meshName, ::llvm::ArrayRef<int64_t> meshShape);
+  }];
+}
+
+def TT_MeshesAttr : TT_Attr<"Meshes", "meshes"> {
+  let summary = "TT system meshes attribute.";
+  let description = [{
+    TT system meshes attribute includes one or more mesh configs used for networks.
+  }];
+  let parameters = (ins ArrayRefParameter<"MeshAttr">:$meshes);
+  let assemblyFormat = "`<` `[` $meshes `]` `>`";
+}
+
 def TT_ChipDescAttr : TT_Attr<"ChipDesc", "chip_desc"> {
   let summary = "TT chip_desc attribute";
   let description = [{
@@ -210,8 +241,8 @@ def TT_SystemDescAttr : TT_Attr<"SystemDesc", "system_desc"> {
   let assemblyFormat = "`<` `[` $cpuDescs `]` `,` `[` $chipDescs `]` `,` `[` $chipDescIndices `]` `,` `[` $chipCapabilities `]` `,` `[` $chipCoords `]` (`,` `[` $chipChannels^ `]`)? `>`";
 
   let extraClassDeclaration = [{
-    static tt::SystemDescAttr getDefault(MLIRContext *context, const llvm::SmallVector<int64_t> &meshShape = {1});
-    static tt::SystemDescAttr getFromPath(MLIRContext *context, std::string& path);
+    static tt::SystemDescAttr getDefault(MLIRContext *context, const MeshAttr &meshAttr);
+    static tt::SystemDescAttr getFromPath(MLIRContext *context, std::string &path);
     unsigned getAddressAlignBytes(unsigned chipIndex = 0) const;
     unsigned getAddressAlignBytes(MemorySpace memorySpace, unsigned chipIndex = 0) const;
     unsigned getNocL1AddressAlignBytes(unsigned chipIndex = 0) const;
@@ -398,13 +429,11 @@ def TT_DeviceAttr : TT_Attr<"Device", "device", []> {
   let parameters = (ins TT_GridAttr:$workerGrid,
                         "AffineMap":$l1Map,
                         "AffineMap":$dramMap,
-                        ArrayRefParameter<"int64_t">:$meshShape,
-                        ArrayRefParameter<"unsigned">:$chipIds);
-  let assemblyFormat = "`<` `workerGrid` `=` qualified($workerGrid) `,` `l1Map` `=` qualified($l1Map) `,` `dramMap` `=` qualified($dramMap) `,` `meshShape` `=` custom<DimensionList>($meshShape) `,` `chipIds` `=` `[` $chipIds `]` `>`";
+                        TT_MeshAttr:$mesh);
+  let assemblyFormat = "`<` `workerGrid` `=` qualified($workerGrid) `,` `l1Map` `=` qualified($l1Map) `,` `dramMap` `=` qualified($dramMap) `,` `mesh` `=` qualified($mesh) `>`";
 
   let extraClassDeclaration = [{
-      static DeviceAttr get(::mlir::MLIRContext *context, SystemDescAttr systemDesc, ArrayRef<int64_t> meshShape, ArrayRef<unsigned> chipIds);
-      static DeviceAttr get(::mlir::MLIRContext *context, SystemDescAttr systemDesc, ArrayRef<int64_t> meshShape = {});
+      static DeviceAttr get(::mlir::MLIRContext *context, SystemDescAttr systemDesc, MeshAttr meshAttr);
       AffineMap getMemoryMap(MemRefType memrefType, size_t pageSize, size_t baseOffset = 0) const;
       size_t getMemrefSizeBytes(MemRefType memrefType, size_t pageSize) const;
 
@@ -510,25 +539,6 @@ def TT_TensorMeshShardingAttr : TT_Attr<"TensorMeshSharding", "mesh_sharding", [
         return TensorMeshShardingAttr::get(context, meshNameStrAttr, tensor_mesh_sharding_axis);
       }
   }];
-}
-
-def TT_MeshAttr : TT_Attr<"Mesh", "mesh", []> {
-  let summary = "Mesh reference attribute in TT dialect.";
-  let description = [{
-    Describes a mesh config including name and shape.
-  }];
-  let parameters = (ins "StringAttr":$name,
-                        ArrayRefParameter<"int64_t">:$shape);
-  let assemblyFormat = "`<` $name `=` custom<DimensionList>($shape) `>`";
-}
-
-def TT_MeshesAttr : TT_Attr<"Meshes", "meshes"> {
-  let summary = "TT system meshes attribute.";
-  let description = [{
-    TT system meshes attribute includes one or more mesh configs used for networks.
-  }];
-  let parameters = (ins ArrayRefParameter<"MeshAttr">:$meshes);
-  let assemblyFormat = "`<` `[` $meshes `]` `>`";
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Dialect/TT/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TT/Transforms/Passes.td
@@ -60,6 +60,7 @@ def TTRegisterDevicePass : Pass<"tt-register-device", "::mlir::ModuleOp"> {
   list<Option> options = [
         Option<"systemDescPath", "system-desc-path", "std::string", "", "System desc path">,
         ListOption<"meshShape", "mesh-shape", "int64_t", "Set the mesh shape">,
+        Option<"meshName", "mesh-name", "std::string", "", "Set the mesh name.">,
     ];
 }
 

--- a/include/ttmlir/Dialect/TT/Transforms/Transforms.h
+++ b/include/ttmlir/Dialect/TT/Transforms/Transforms.h
@@ -12,7 +12,8 @@
 namespace mlir::tt {
 
 void registerDevice(ModuleOp module, std::string path = {},
-                    ArrayRef<int64_t> meshShape = {});
+                    ArrayRef<int64_t> meshShape = {1, 1},
+                    StringRef meshName = "mesh");
 
 } // namespace mlir::tt
 

--- a/include/ttmlir/Dialect/TTMetal/Pipelines/TTMetalPipelines.h
+++ b/include/ttmlir/Dialect/TTMetal/Pipelines/TTMetalPipelines.h
@@ -12,6 +12,10 @@ namespace mlir::tt::ttmetal {
 //
 struct TTIRToTTMetalBackendPipelineOptions
     : public PassPipelineOptions<TTIRToTTMetalBackendPipelineOptions> {
+  Option<std::string> meshName{*this, "mesh-name",
+                               llvm::cl::desc("Set a mesh name."),
+                               llvm::cl::init("mesh")};
+
   ListOption<int64_t> meshShape{
       *this, "mesh-shape", llvm::cl::desc("Set the multi-device mesh shape.")};
 

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -116,6 +116,10 @@ struct TTIRToTTNNBackendPipelineOptions
                      "layout analysis."),
       llvm::cl::init(64)};
 
+  Option<std::string> meshName{*this, OptionNames::meshName,
+                               llvm::cl::desc("Set a mesh name."),
+                               llvm::cl::init("mesh")};
+
   ListOption<int64_t> meshShape{
       *this, OptionNames::meshShape,
       llvm::cl::desc("Set the multi-device mesh shape.")};

--- a/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
@@ -25,6 +25,7 @@ struct OptionNames {
   static constexpr StringRef systemDescPath = "system-desc-path";
   static constexpr StringRef maxLegalLayouts = "max-legal-layouts";
   static constexpr StringRef meshShape = "mesh-shape";
+  static constexpr StringRef meshName = "mesh-name";
 };
 
 struct OutputLayoutOverrideParams {

--- a/lib/CAPI/TTAttrs.cpp
+++ b/lib/CAPI/TTAttrs.cpp
@@ -196,4 +196,36 @@ MlirAttribute ttmlirTTCoreCoordAttrGet(MlirContext ctx, int64_t y, int64_t x) {
   return wrap(CoreCoordAttr::get(unwrap(ctx), y, x));
 }
 
+MlirAttribute ttmlirTTMeshAttrGet(MlirContext ctx, const char *meshName,
+                                  size_t meshNameSize, int64_t *shape,
+                                  size_t shapeSize, unsigned *chipIds,
+                                  size_t chipIdsSize) {
+  std::string meshNameStr;
+  meshNameStr.assign(meshName, meshNameSize);
+  mlir::StringAttr meshNameAttr = StringAttr::get(unwrap(ctx), meshNameStr);
+
+  std::vector<int64_t> shapeVec;
+  for (size_t i = 0; i < shapeSize; i++) {
+    shapeVec.push_back(shape[i]);
+  }
+
+  std::vector<unsigned> chipIdsVec;
+  for (size_t i = 0; i < chipIdsSize; i++) {
+    chipIdsVec.push_back(chipIds[i]);
+  }
+
+  return wrap(
+      tt::MeshAttr::get(unwrap(ctx), meshNameAttr, shapeVec, chipIdsVec));
+}
+
+MlirAttribute ttmlirTTMeshesAttrGet(MlirContext ctx, MlirAttribute *meshes,
+                                    size_t meshesSize) {
+  std::vector<MeshAttr> meshesVec;
+  for (size_t i = 0; i < meshesSize; i++) {
+    meshesVec.push_back(mlir::cast<MeshAttr>(unwrap(meshes[i])));
+  }
+
+  return wrap(tt::MeshesAttr::get(unwrap(ctx), meshesVec));
+}
+
 } // namespace mlir::tt

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
@@ -237,7 +237,7 @@ public:
 
     PhysicalCoreCoordMapping physicalCoordMapping =
         PhysicalCoreCoordMapping::getMemorySpaceMapping(
-            device.getChipIds(), systemDesc.getChipDescs(),
+            device.getMesh().getChipIds(), systemDesc.getChipDescs(),
             dataMovementType == NocTx::Type::Read
                 ? inputLayout.getMemorySpace()
                 : outputLayout.getMemorySpace());

--- a/lib/Dialect/TT/IR/TTOpsTypes.cpp
+++ b/lib/Dialect/TT/IR/TTOpsTypes.cpp
@@ -39,8 +39,9 @@ unsigned mlir::tt::ChipDescAttr::getScratchL1RegionAddress() const {
   return getL1Size() - getScratchL1RegionSize();
 }
 
-mlir::tt::SystemDescAttr mlir::tt::SystemDescAttr::getDefault(
-    MLIRContext *context, const ::llvm::SmallVector<int64_t> &meshShape) {
+mlir::tt::SystemDescAttr
+mlir::tt::SystemDescAttr::getDefault(MLIRContext *context,
+                                     const mlir::tt::MeshAttr &meshAttr) {
   // Set default values
   constexpr auto l1Size = 1499136;
   constexpr auto numDramChannels = 12;
@@ -55,11 +56,7 @@ mlir::tt::SystemDescAttr mlir::tt::SystemDescAttr::getDefault(
   constexpr auto numCBs = 32;
   constexpr auto numComputeThreads = 1;
   constexpr auto numDatamovementThreads = 2;
-
-  // Get number of chips in mesh.
-  int64_t numberOfChips =
-      std::accumulate(meshShape.begin(), meshShape.end(), int64_t{1},
-                      std::multiplies<int64_t>());
+  auto numberOfChips = meshAttr.getChipIds().size();
 
   // Populate dummy values for single chip or multi chip config.
   llvm::SmallVector<std::int64_t> gridShape = {8, 8};
@@ -111,7 +108,7 @@ mlir::tt::SystemDescAttr mlir::tt::SystemDescAttr::getDefault(
   llvm::SmallVector<tt::ChipDescAttr> chipDescs;
   chipDescs.reserve(numberOfChips);
 
-  for (auto i = 0; i < numberOfChips; i++) {
+  for (unsigned i = 0; i < numberOfChips; i++) {
     chipDescs.push_back(ChipDescAttr::get(
         context, ArchAttr::get(context, Arch::WormholeB0), gridShape, l1Size,
         numDramChannels, dramChannelSize, nocL1AddressAlignBytes,
@@ -126,7 +123,7 @@ mlir::tt::SystemDescAttr mlir::tt::SystemDescAttr::getDefault(
   llvm::SmallVector<tt::ChipCapabilityAttr> chipCapabilities;
   chipCapabilities.reserve(numberOfChips);
 
-  for (auto i = 0; i < numberOfChips; i++) {
+  for (unsigned i = 0; i < numberOfChips; i++) {
     chipCapabilities.push_back(tt::ChipCapabilityAttr::get(
         context,
         // NOLINTNEXTLINE
@@ -138,7 +135,7 @@ mlir::tt::SystemDescAttr mlir::tt::SystemDescAttr::getDefault(
   chipChannelList.reserve(numberOfChips);
 
   if (numberOfChips != 1) {
-    for (auto i = 0; i < numberOfChips; i++) {
+    for (unsigned i = 0; i < numberOfChips; i++) {
       // Assume a default ring topology where final chip connects with initial
       // chip.
       chipChannelList.push_back(tt::ChipChannelAttr::get(
@@ -189,7 +186,7 @@ mlir::tt::SystemDescAttr::getFromPath(MLIRContext *context, std::string &path) {
   auto const *chip_channel_connections = binary_system_desc->chip_channels();
 
   // Acquire cpu descs
-  std::vector<tt::CPUDescAttr> cpu_desc_list;
+  llvm::SmallVector<tt::CPUDescAttr> cpu_desc_list;
   for (auto const *element : *binary_cpu_desc) {
     static_assert(static_cast<std::underlying_type_t<::tt::target::CPURole>>(
                       ::mlir::tt::CPURole::Device) ==
@@ -208,13 +205,13 @@ mlir::tt::SystemDescAttr::getFromPath(MLIRContext *context, std::string &path) {
   }
 
   // Acquire chip descs
-  std::vector<tt::ChipDescAttr> chip_desc_list;
+  llvm::SmallVector<tt::ChipDescAttr> chip_desc_list;
   for (auto const *element : *binary_chip_desc) {
-    std::vector<tt::CoreCoordAttr> worker_cores, dram_cores, eth_cores,
+    llvm::SmallVector<tt::CoreCoordAttr> worker_cores, dram_cores, eth_cores,
         eth_inactive_cores;
     auto const *physical_cores = element->physical_cores();
 
-    // Populate all vecrors with CoreCoordAttr instances
+    // Populate all vectors with CoreCoordAttr instances
     for (auto const &core : *physical_cores->worker()) {
       worker_cores.emplace_back(
           tt::CoreCoordAttr::get(context, core->y(), core->x()));
@@ -249,7 +246,7 @@ mlir::tt::SystemDescAttr::getFromPath(MLIRContext *context, std::string &path) {
       break;
     }
 
-    std::vector<tt::DataTypeAttr> supported_data_types_attr;
+    llvm::SmallVector<tt::DataTypeAttr> supported_data_types_attr;
 
     for (auto it : *(element->supported_data_types())) {
       switch (it) {
@@ -331,13 +328,13 @@ mlir::tt::SystemDescAttr::getFromPath(MLIRContext *context, std::string &path) {
   }
 
   // Acquire chip indices
-  std::vector<uint32_t> chip_indices_list;
+  llvm::SmallVector<uint32_t> chip_indices_list;
   for (auto element : *binary_chip_desc_indices) {
     chip_indices_list.push_back(element);
   }
 
   // Acquire chip capabilities
-  std::vector<tt::ChipCapabilityAttr> chip_capabilities_list;
+  llvm::SmallVector<tt::ChipCapabilityAttr> chip_capabilities_list;
   for (auto element : *chip_capabilities) {
     static_assert(
         static_cast<std::underlying_type_t<::tt::target::ChipCapability>>(
@@ -356,20 +353,20 @@ mlir::tt::SystemDescAttr::getFromPath(MLIRContext *context, std::string &path) {
   }
 
   // Acquire chip coordinates
-  std::vector<tt::ChipCoordAttr> chip_coordinate_list;
+  llvm::SmallVector<tt::ChipCoordAttr> chip_coordinate_list;
   for (auto const *element : *binary_chip_coords) {
     auto chip_coordinate_attr = tt::ChipCoordAttr::get(
         context, element->rack(), element->shelf(), element->y(), element->x());
     chip_coordinate_list.push_back(chip_coordinate_attr);
   }
 
-  std::vector<tt::ChipChannelAttr> chip_channel_list;
+  llvm::SmallVector<tt::ChipChannelAttr> chip_channel_list;
   for (auto const *element : *chip_channel_connections) {
-    std::vector<int64_t> ethernet_core_coord0_vec = {
+    llvm::SmallVector<int64_t> ethernet_core_coord0_vec = {
         element->ethernet_core_coord0().y(),
         element->ethernet_core_coord0().x()};
 
-    std::vector<int64_t> ethernet_core_coord1_vec = {
+    llvm::SmallVector<int64_t> ethernet_core_coord1_vec = {
         element->ethernet_core_coord1().y(),
         element->ethernet_core_coord1().x()};
 
@@ -870,16 +867,10 @@ static mlir::AffineMap createL1Map(mlir::MLIRContext *context,
 
 static GridAttr createWorkerGrid(::mlir::MLIRContext *context,
                                  mlir::ArrayRef<int64_t> chipGrid,
-                                 mlir::ArrayRef<int64_t> meshShapeRef) {
-  assert(chipGrid.size() == 2 && "expected 2D grid");
-  mlir::SmallVector<int64_t> meshShape(meshShapeRef);
-
-  // Fill in missing dimensions with 1 so that the mesh shape is at least 2D.
-  while (meshShape.size() < chipGrid.size()) {
-    meshShape.push_back(1);
-  }
-
+                                 const mlir::tt::MeshAttr &meshAttr) {
   mlir::SmallVector<int64_t> virtualGrid(chipGrid);
+  const auto meshShape = meshAttr.getShape();
+
   // Fill in missing dimensions with 1 so that the virtual grid is at has
   // meshShape dimensions.
   while (virtualGrid.size() < meshShape.size()) {
@@ -1015,43 +1006,38 @@ static mlir::AffineMap createDramMap(::mlir::MLIRContext *context,
 
 DeviceAttr DeviceAttr::get(::mlir::MLIRContext *context,
                            SystemDescAttr systemDesc,
-                           ArrayRef<int64_t> meshShape,
-                           ArrayRef<unsigned> chipIds) {
-  assert(not chipIds.empty() && "expected at least one chip");
-  ChipDescAttr chipDesc = systemDesc.getChipDescs()[chipIds.front()];
-  SmallVector<int64_t> chipGrid(chipDesc.getGrid());
-  assert(chipGrid.size() == 2 && "expected 2D grid");
+                           mlir::tt::MeshAttr meshAttr) {
+  // Check if the chipIds found in meshAttr actually exist in systemDesc.
+  // A deviceAttr can be a subset of all the chips available on the system.
+  auto chipDescIndices = systemDesc.getChipDescIndices();
+  auto chipIds = meshAttr.getChipIds();
+  for (auto chipId : chipIds) {
+    assert(llvm::find(chipDescIndices, chipId) != chipDescIndices.end() &&
+           "chip id in mesh does not exist in system descriptor");
+  }
 
   // Take the min grid shape across all chips, this can happen if 1 chip has
   // more harvested rows than another.  We take the min because we want to
   // ensure that the logical grid is the same across all chips and this vastly
   // simplifies the grid /memory mappings across the board.
+  auto chipDescs = systemDesc.getChipDescs();
+  ChipDescAttr chipDesc = chipDescs[chipIds.front()];
+  SmallVector<int64_t> chipGrid(chipDesc.getGrid());
+  assert(chipGrid.size() == 2 && "expected 2D grid");
   for (unsigned chipId : chipIds) {
-    ChipDescAttr chip = systemDesc.getChipDescs()[chipId];
+    ChipDescAttr chip = chipDescs[chipId];
     ArrayRef<int64_t> iChipGrid = chip.getGrid();
     assert(iChipGrid.size() == 2 && "expected 2D grid");
     chipGrid[0] = std::min(chipGrid[0], iChipGrid[0]);
     chipGrid[1] = std::min(chipGrid[1], iChipGrid[1]);
   }
 
-  auto workerGrid = createWorkerGrid(context, chipGrid, meshShape);
+  auto workerGrid = createWorkerGrid(context, chipGrid, meshAttr);
   auto l1Map = createL1Map(context, workerGrid);
   constexpr unsigned dramPageSize = 8192;
   auto dramMap =
       createDramMap(context, workerGrid, systemDesc, chipIds, dramPageSize);
-  return get(context, workerGrid, l1Map, dramMap, meshShape, chipIds);
-}
-
-DeviceAttr DeviceAttr::get(::mlir::MLIRContext *context,
-                           SystemDescAttr systemDesc,
-                           ArrayRef<int64_t> meshShape) {
-  int64_t numChips = ttmlir::utils::volume(meshShape);
-  assert(systemDesc.getChipDescIndices().size() >=
-             static_cast<size_t>(numChips) &&
-         "expected at least one chip");
-  SmallVector<unsigned> chipIds(numChips);
-  std::iota(chipIds.begin(), chipIds.end(), 0);
-  return get(context, systemDesc, meshShape, chipIds);
+  return get(context, workerGrid, l1Map, dramMap, meshAttr);
 }
 
 mlir::AffineMap DeviceAttr::getMemoryMap(MemRefType memrefType, size_t pageSize,
@@ -1119,20 +1105,7 @@ uint64_t DeviceAttr::getTensorSizeBytes(RankedTensorType tensorType,
 ::mlir::LogicalResult
 DeviceAttr::verify(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
                    ::mlir::tt::GridAttr workerGrid, ::mlir::AffineMap l1Map,
-                   ::mlir::AffineMap dramMap,
-                   ::llvm::ArrayRef<int64_t> meshShape,
-                   ::llvm::ArrayRef<unsigned> chipIds) {
-  if (chipIds.empty()) {
-    emitError() << "expected at least one chip";
-    return ::mlir::failure();
-  }
-
-  std::int64_t meshVolume = ttmlir::utils::volume(meshShape);
-  if (chipIds.size() != static_cast<size_t>(meshVolume)) {
-    emitError() << "expected chipIds size to match the volume of meshShape";
-    return ::mlir::failure();
-  }
-
+                   ::mlir::AffineMap dramMap, mlir::tt::MeshAttr meshAttr) {
   auto workerGridShape = workerGrid.getShape();
   for (auto dim : workerGridShape) {
     if (dim <= 0) {
@@ -1234,6 +1207,39 @@ uint64_t TileType::getSizeBytes() const {
 
 mlir::Type TileType::getElementType() const {
   return dataTypeToElementType(getContext(), getDataType());
+}
+
+::mlir::LogicalResult
+MeshAttr::verify(::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
+                 StringAttr name, ::llvm::ArrayRef<int64_t> shape,
+                 ::llvm::ArrayRef<unsigned> chipIds) {
+  if (static_cast<int64_t>(chipIds.size()) != ttmlir::utils::volume(shape)) {
+    emitError() << "number of chips does not equal shape of mesh";
+    return ::mlir::failure();
+  }
+
+  return ::mlir::success();
+}
+
+MeshAttr MeshAttr::get(::mlir::MLIRContext *context, llvm::StringRef meshName,
+                       ::llvm::ArrayRef<int64_t> meshShape) {
+  // Set mesh name to default 'mesh'
+  std::string name = "mesh";
+  if (!meshName.empty()) {
+    name = meshName;
+  }
+  auto nameAttr = mlir::StringAttr::get(context, meshName);
+
+  // Set mesh shape size to (1, 1) if not set
+  llvm::SmallVector<int64_t> shape = {1, 1};
+  if (!meshShape.empty()) {
+    shape.assign(meshShape.begin(), meshShape.end());
+  }
+
+  auto numberOfChips = ttmlir::utils::volume(llvm::ArrayRef<int64_t>(shape));
+  llvm::SmallVector<unsigned> chipIds =
+      llvm::to_vector(llvm::seq<unsigned>(numberOfChips));
+  return MeshAttr::get(context, nameAttr, shape, chipIds);
 }
 
 void TTDialect::registerTypes() {

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -40,6 +40,7 @@ void createTTIRToTTMetalBackendPipeline(
   {
     registerDeviceOptions.systemDescPath = options.systemDescPath;
     registerDeviceOptions.meshShape = llvm::to_vector(options.meshShape);
+    registerDeviceOptions.meshName = options.meshName;
   }
   pm.addPass(mlir::tt::createTTRegisterDevicePass(registerDeviceOptions));
   pm.addPass(mlir::tt::ttir::createTTIRConstantAsFill());

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -1598,7 +1598,7 @@ void mlir::tt::ttnn::ToLayoutOp::getCanonicalizationPatterns(
 
 ::mlir::OpFoldResult mlir::tt::ttnn::AllGatherOp::fold(FoldAdaptor adaptor) {
   tt::DeviceAttr device = lookupDevice(*this);
-  llvm::SmallVector<int64_t> meshShape{device.getMeshShape()};
+  llvm::SmallVector<int64_t> meshShape{device.getMesh().getShape()};
   // AllGather Op is semantically meaningless when gathering across a single
   // mesh device.
   if (meshShape.empty() || meshShape[getClusterAxis()] != 1) {
@@ -1648,7 +1648,7 @@ void mlir::tt::ttnn::ToLayoutOp::getCanonicalizationPatterns(
 ::mlir::OpFoldResult
 mlir::tt::ttnn::ReduceScatterOp::fold(FoldAdaptor adaptor) {
   tt::DeviceAttr device = lookupDevice(*this);
-  llvm::SmallVector<int64_t> meshShape{device.getMeshShape()};
+  llvm::SmallVector<int64_t> meshShape{device.getMesh().getShape()};
   // ReduceScatter Op is semantically meaningless when gathering across a single
   // mesh device.
   if (meshShape.empty() || meshShape[getClusterAxis()] != 1) {
@@ -1685,7 +1685,7 @@ mlir::tt::ttnn::ReduceScatterOp::fold(FoldAdaptor adaptor) {
 
 ::mlir::OpFoldResult mlir::tt::ttnn::AllReduceOp::fold(FoldAdaptor adaptor) {
   tt::DeviceAttr device = lookupDevice(*this);
-  llvm::SmallVector<int64_t> meshShape{device.getMeshShape()};
+  llvm::SmallVector<int64_t> meshShape{device.getMesh().getShape()};
   // AllReduce Op is semantically meaningless when gathering across a single
   // mesh device.
   if (meshShape.empty() || meshShape[getClusterAxis()] != 1) {

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -29,6 +29,7 @@ void createTTNNPipelineTTIRPasses(
   {
     registerDeviceOptions.systemDescPath = options.systemDescPath;
     registerDeviceOptions.meshShape = llvm::to_vector(options.meshShape);
+    registerDeviceOptions.meshName = options.meshName;
   }
   pm.addPass(mlir::tt::createTTRegisterDevicePass(registerDeviceOptions));
 

--- a/lib/Dialect/TTNN/Transforms/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/Optimizer.cpp
@@ -429,7 +429,7 @@ private:
     DeviceAttr deviceAttr = lookupDevice(contextOp);
     auto currentInsertionPoint = builder.saveInsertionPoint();
     builder.setInsertionPoint(block, block->begin());
-    llvm::SmallVector<int64_t> meshShape{deviceAttr.getMeshShape()};
+    llvm::SmallVector<int64_t> meshShape{deviceAttr.getMesh().getShape()};
     if (meshShape.empty()) {
       meshShape = llvm::SmallVector<int64_t, 2>{1, 1};
     }

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkarounds.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkarounds.cpp
@@ -351,7 +351,7 @@ public:
     uint32_t clusterAxis = op.getClusterAxis();
     Value deviceValue = op.getDevice();
     auto deviceDesc = lookupDevice(op);
-    ::llvm::ArrayRef<int64_t> meshShape = deviceDesc.getMeshShape();
+    ::llvm::ArrayRef<int64_t> meshShape = deviceDesc.getMesh().getShape();
 
     // TODO(hongseok): Restore dynamic dimension selection once the issue
     // (https://github.com/tenstorrent/tt-metal/issues/19433) is resolved.

--- a/lib/Dialect/TTNN/Utils/TransformUtils.cpp
+++ b/lib/Dialect/TTNN/Utils/TransformUtils.cpp
@@ -23,13 +23,11 @@ GetDeviceOp getOrInsertDevice(RewriterBase &rewriter, Operation *op) {
   DeviceAttr deviceAttr = lookupDevice(op);
   auto currentInsertionPoint = rewriter.saveInsertionPoint();
   rewriter.setInsertionPoint(block, block->begin());
-  llvm::SmallVector<int64_t> meshShape{deviceAttr.getMeshShape()};
-  if (meshShape.empty()) {
-    meshShape = llvm::SmallVector<int64_t, 2>{1, 1};
-  }
   auto deviceOp = rewriter.create<ttnn::GetDeviceOp>(
       op->getLoc(), rewriter.getType<DeviceType>(),
-      ttnn::MeshShapeAttr::get(op->getContext(), meshShape[0], meshShape[1]));
+      ttnn::MeshShapeAttr::get(op->getContext(),
+                               deviceAttr.getMesh().getShape()[0],
+                               deviceAttr.getMesh().getShape()[1]));
   rewriter.restoreInsertionPoint(currentInsertionPoint);
   return deviceOp;
 }

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -122,7 +122,7 @@ getTensorValueCoreRangeSet(FlatbufferObjectCache &cache, Value value) {
 ::flatbuffers::Offset<::tt::target::DeviceRef>
 createDeviceRef(FlatbufferObjectCache &cache, Value device) {
   auto desc = lookupDevice(device.getParentBlock()->getParentOp());
-  auto chipIds = desc.getChipIds();
+  auto chipIds = desc.getMesh().getChipIds();
   return ::tt::target::CreateDeviceRef(*cache.fbb, chipIds[0]);
 }
 
@@ -330,7 +330,7 @@ createOperation(FlatbufferObjectCache &cache, ::flatbuffers::Offset<OpT> op,
 createOp(FlatbufferObjectCache &cache, GetDeviceOp op) {
   auto result = op.getResult();
   auto desc = lookupDevice(op);
-  auto meshShape = desc.getMeshShape();
+  auto meshShape = desc.getMesh().getShape();
   auto meshVolume = ttmlir::utils::volume(meshShape);
   ::tt::target::Dim2d mesh;
   if (meshVolume > 1) {
@@ -339,7 +339,7 @@ createOp(FlatbufferObjectCache &cache, GetDeviceOp op) {
     mesh = ::tt::target::Dim2d(1, 1);
   }
 
-  auto chipIds = toFlatbuffer(cache, desc.getChipIds());
+  auto chipIds = toFlatbuffer(cache, desc.getMesh().getChipIds());
   auto out = cache.getOrCreate(result, createDeviceRef);
   return ::tt::target::ttnn::CreateGetDeviceOp(*cache.fbb, &mesh, chipIds, out);
 }
@@ -495,7 +495,7 @@ createDistributionStrategy(FlatbufferObjectCache &cache,
   auto deviceOp = mlir::cast<GetDeviceOp>(
       getOperandThroughDPSOps(deviceValue).getDefiningOp());
   auto desc = lookupDevice(deviceOp);
-  ::llvm::ArrayRef<int64_t> meshShape = desc.getMeshShape();
+  ::llvm::ArrayRef<int64_t> meshShape = desc.getMesh().getShape();
   numShards = ttmlir::utils::volume(meshShape);
 
   if (numShards == 1) {

--- a/test/python/device_attr.py
+++ b/test/python/device_attr.py
@@ -66,7 +66,7 @@ def createDeviceAttr(
     deviceStartIdx=0,
     workerGridMap=None,
     system_desc=None,
-    mesh_shape=[1],
+    mesh_shape=[1, 1],
 ):
     if system_desc is not None:
         return tt.ir.DeviceAttr.from_system_desc(ctx, system_desc, mesh_shape)
@@ -100,50 +100,50 @@ d1 = d(1)
 d2 = d(2)
 
 print("=== From SystemDesc ===")
-# CHECK: tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 1, chipIds = [0]>
+# CHECK: #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5] -> (0, 0, (((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) floordiv s4) mod 12, ((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) floordiv (s4 * 12) + ((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) mod s4 + s5), mesh = #tt.mesh<name = "mesh", shape = 1x1, chipIds = [0]>>
 print("", createDeviceAttr([8, 8], system_desc=tt.ir.SystemDescAttr.get_default(ctx)))
 
 # ------------------------------------------------------------------------------
 
 print("=== Simple single device ===")
-# CHECK: tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 1, chipIds = [0]>
+# CHECK: #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, 0, d0, d1), dramMap = (d0, d1)[s0, s1] -> (0, 0, d0, d1), mesh = #tt.mesh<name = "mesh", shape = 1x1, chipIds = [0]>>
 print("", createDeviceAttr([8, 8]))
 
 # ------------------------------------------------------------------------------
 
 print("\n=== Data parallel over batch ===")
-# CHECK: tt.device<workerGrid = #tt.grid<2x8x8, (d0, d1, d2) -> (d0, d1, d2)>, l1Map = [[M:.*]], dramMap = [[M:.*]], meshShape = 2x1x1, chipIds = [0, 1]>
+# CHECK: #tt.device<workerGrid = #tt.grid<2x8x8, (d0, d1, d2) -> (d0, d1, d2)>, l1Map = (d0, d1, d2)[s0, s1, s2] -> (0, d0, d1, d2), dramMap = (d0, d1, d2)[s0, s1, s2] -> (0, d0, d1, d2), mesh = #tt.mesh<name = "mesh", shape = 2x1x1, chipIds = [0, 1]>>
 print("divide batch by 2\n", createDeviceAttr([2, 8, 8], mesh_shape=[2, 1, 1]))
-# CHECK: tt.device<workerGrid = #tt.grid<4x8x8, (d0, d1, d2) -> (d0, d1, d2)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 4x1x1, chipIds = [0, 1, 2, 3]>
+# CHECK: tt.device<workerGrid = #tt.grid<4x8x8, (d0, d1, d2) -> (d0, d1, d2)>, l1Map = (d0, d1, d2)[s0, s1, s2] -> (0, d0, d1, d2), dramMap = (d0, d1, d2)[s0, s1, s2] -> (0, d0, d1, d2), mesh = #tt.mesh<name = "mesh", shape = 4x1x1, chipIds = [0, 1, 2, 3]>>
 print("divide batch by 4\n", createDeviceAttr([4, 8, 8], mesh_shape=[4, 1, 1]))
 
 # ------------------------------------------------------------------------------
 
 print("\n=== Data parallel over 2d ===")
-# CHECK: tt.device<workerGrid = #tt.grid<8x16, (d0, d1) -> (d1 floordiv 8, d0, d1 mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 1x2, chipIds = [0, 1]>
+# CHECK: #tt.device<workerGrid = #tt.grid<8x16, (d0, d1) -> (d1 floordiv 8, d0, d1 mod 8)>, l1Map = (d0, d1)[s0, s1] -> (0, 0, d0, d1), dramMap = (d0, d1)[s0, s1] -> (0, 0, d0, d1), mesh = #tt.mesh<name = "mesh", shape = 1x2, chipIds = [0, 1]>>
 print(
     "Reinterpret 2 devices as grid side by side, 1x2 mesh\n",
     createDeviceAttr([8, 16], mesh_shape=[1, 2]),
 )
-# CHECK: tt.device<workerGrid = #tt.grid<16x8, (d0, d1) -> (d0 floordiv 8, d0 mod 8, d1)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 2x1, chipIds = [0, 1]>
+# CHECK: #tt.device<workerGrid = #tt.grid<16x8, (d0, d1) -> (d0 floordiv 8, d0 mod 8, d1)>, l1Map = (d0, d1)[s0, s1] -> (0, 0, d0, d1), dramMap = (d0, d1)[s0, s1] -> (0, 0, d0, d1), mesh = #tt.mesh<name = "mesh", shape = 2x1, chipIds = [0, 1]>>
 print(
     "Reinterpret 2 devices as grid top to bottom, 2x1 mesh\n",
     createDeviceAttr([16, 8], mesh_shape=[2, 1]),
 )
-# CHECK: tt.device<workerGrid = #tt.grid<16x32, (d0, d1) -> (d1 floordiv 8 + (d0 floordiv 8) * 4, d0 mod 8, d1 mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 2x4, chipIds = [0, 1, 2, 3, 4, 5, 6, 7]>
+# CHECK: #tt.device<workerGrid = #tt.grid<16x32, (d0, d1) -> (d1 floordiv 8 + (d0 floordiv 8) * 4, d0 mod 8, d1 mod 8)>, l1Map = (d0, d1)[s0, s1] -> (0, 0, d0, d1), dramMap = (d0, d1)[s0, s1] -> (0, 0, d0, d1), mesh = #tt.mesh<name = "mesh", shape = 2x4, chipIds = [0, 1, 2, 3, 4, 5, 6, 7]>>
 print("8 devices 2x4 mesh\n", createDeviceAttr([16, 32], mesh_shape=[2, 4]))
-# CHECK: tt.device<workerGrid = #tt.grid<32x16, (d0, d1) -> (d1 floordiv 8 + (d0 floordiv 8) * 2, d0 mod 8, d1 mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 4x2, chipIds = [0, 1, 2, 3, 4, 5, 6, 7]>
+# CHECK: #tt.device<workerGrid = #tt.grid<32x16, (d0, d1) -> (d1 floordiv 8 + (d0 floordiv 8) * 2, d0 mod 8, d1 mod 8)>, l1Map = (d0, d1)[s0, s1] -> (0, 0, d0, d1), dramMap = (d0, d1)[s0, s1] -> (0, 0, d0, d1), mesh = #tt.mesh<name = "mesh", shape = 4x2, chipIds = [0, 1, 2, 3, 4, 5, 6, 7]>>
 print("8 devices 4x2 mesh\n", createDeviceAttr([32, 16], mesh_shape=[4, 2]))
 
 # ------------------------------------------------------------------------------
 
 print("\n=== Data parallel over 2d and batch (3d) ===")
-# CHECK: tt.device<workerGrid = #tt.grid<2x8x16, (d0, d1, d2) -> (d0 * 2 + d2 floordiv 8, d1, d2 mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 2x1x2, chipIds = [0, 1, 2, 3]>
+# CHECK: #tt.device<workerGrid = #tt.grid<2x8x16, (d0, d1, d2) -> (d0 * 2 + d2 floordiv 8, d1, d2 mod 8)>, l1Map = (d0, d1, d2)[s0, s1, s2] -> (0, d0, d1, d2), dramMap = (d0, d1, d2)[s0, s1, s2] -> (0, d0, d1, d2), mesh = #tt.mesh<name = "mesh", shape = 2x1x2, chipIds = [0, 1, 2, 3]>>
 print(
     "divide batch by 2, 2x1x2 mesh\n",
     createDeviceAttr([2, 8, 16], mesh_shape=[2, 1, 2]),
 )
-# CHECK: tt.device<workerGrid = #tt.grid<3x24x8, (d0, d1, d2) -> (d0 * 3 + d1 floordiv 8, d1 mod 8, d2)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 3x3x1, chipIds = [0, 1, 2, 3, 4, 5, 6, 7, 8]>
+# CHECK: #tt.device<workerGrid = #tt.grid<3x24x8, (d0, d1, d2) -> (d0 * 3 + d1 floordiv 8, d1 mod 8, d2)>, l1Map = (d0, d1, d2)[s0, s1, s2] -> (0, d0, d1, d2), dramMap = (d0, d1, d2)[s0, s1, s2] -> (0, d0, d1, d2), mesh = #tt.mesh<name = "mesh", shape = 3x3x1, chipIds = [0, 1, 2, 3, 4, 5, 6, 7, 8]>>
 print(
     "divide batch by 3, 3x3x1 mesh\n",
     createDeviceAttr([3, 24, 8], mesh_shape=[3, 3, 1]),
@@ -152,13 +152,13 @@ print(
 # ------------------------------------------------------------------------------
 
 print("\n=== nD ===")
-# CHECK: tt.device<workerGrid = #tt.grid<3x2x8x8, (d0, d1, d2, d3) -> (d0 * 2 + d1, d2, d3)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 3x2x1x1, chipIds = [0, 1, 2, 3, 4, 5]>
+# CHECK: #tt.device<workerGrid = #tt.grid<3x2x8x8, (d0, d1, d2, d3) -> (d0 * 2 + d1, d2, d3)>, l1Map = (d0, d1, d2, d3)[s0, s1, s2, s3] -> (d0, d1, d2, d3), dramMap = (d0, d1, d2, d3)[s0, s1, s2, s3] -> (d0, d1, d2, d3), mesh = #tt.mesh<name = "mesh", shape = 3x2x1x1, chipIds = [0, 1, 2, 3, 4, 5]>>
 print("", createDeviceAttr([3, 2, 8, 8], mesh_shape=[3, 2, 1, 1]))
 
 # ------------------------------------------------------------------------------
 
 print("\n=== Data parallel batch on single device ===")
-# CHECK: tt.device<workerGrid = #tt.grid<2x4x8, (d0, d1, d2) -> (0, d0 * 4 + d1, d2)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 1, chipIds = [0]>
+# CHECK: #tt.device<workerGrid = #tt.grid<2x4x8, (d0, d1, d2) -> (0, d0 * 4 + d1, d2)>, l1Map = (d0, d1, d2)[s0, s1, s2] -> (0, d0, d1, d2), dramMap = (d0, d1, d2)[s0, s1, s2] -> (0, d0, d1, d2), mesh = #tt.mesh<name = "mesh", shape = 1x1, chipIds = [0]>>
 print(
     "divide batch by 2, top 4 rows get batch 0, bottom 4 rows get batch 1\n",
     createDeviceAttr([2, 4, 8], workerGridMap=amap(3, [c0, d0 * 4 + d1, d2])),
@@ -167,12 +167,12 @@ print(
 # ------------------------------------------------------------------------------
 
 print("\n=== Pipeline parallel ===")
-# CHECK: tt.device<workerGrid = #tt.grid<2x8x16, (d0, d1, d2) -> (d0 * 2 + d2 floordiv 8, d1, d2 mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 2x1x2, chipIds = [0, 1, 2, 3]>
+# CHECK: #tt.device<workerGrid = #tt.grid<2x8x16, (d0, d1, d2) -> (d0 * 2 + d2 floordiv 8, d1, d2 mod 8)>, l1Map = (d0, d1, d2)[s0, s1, s2] -> (0, d0, d1, d2), dramMap = (d0, d1, d2)[s0, s1, s2] -> (0, d0, d1, d2), mesh = #tt.mesh<name = "mesh", shape = 2x1x2, chipIds = [0, 1, 2, 3]>>
 print(
     "view devices 0-3 in one way\n",
     createDeviceAttr([2, 8, 16], deviceStartIdx=0, mesh_shape=[2, 1, 2]),
 )
-# CHECK: tt.device<workerGrid = #tt.grid<16x16, (d0, d1) -> (d1 floordiv 8 + (d0 floordiv 8) * 2, d0 mod 8, d1 mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 2x2, chipIds = [4, 5, 6, 7]>
+# CHECK: #tt.device<workerGrid = #tt.grid<16x16, (d0, d1) -> (d1 floordiv 8 + (d0 floordiv 8) * 2, d0 mod 8, d1 mod 8)>, l1Map = (d0, d1)[s0, s1] -> (0, 0, d0, d1), dramMap = (d0, d1)[s0, s1] -> (0, 0, d0, d1), mesh = #tt.mesh<name = "mesh", shape = 2x2, chipIds = [0, 1, 2, 3]>>
 print(
     "view devices 4-7 in another way\n",
     createDeviceAttr([16, 16], deviceStartIdx=4, mesh_shape=[2, 2]),
@@ -181,16 +181,16 @@ print(
 # ------------------------------------------------------------------------------
 
 print("\n=== Reinterpreted Grids ===")
-# CHECK: tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d1, d0)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 1, chipIds = [0]>
+# CHECK: #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d1, d0)>, l1Map = (d0, d1)[s0, s1] -> (0, 0, d0, d1), dramMap = (d0, d1)[s0, s1] -> (0, 0, d0, d1), mesh = #tt.mesh<name = "mesh", shape = 1x1, chipIds = [0]>>
 print("transposed\n", createDeviceAttr([8, 8], workerGridMap=amap(2, [c0, d1, d0])))
-# CHECK: tt.device<workerGrid = #tt.grid<1x64, (d0, d1) -> (0, d0 * 8 + d1 floordiv 8, d1 mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 1, chipIds = [0]>
+# CHECK: #tt.device<workerGrid = #tt.grid<1x64, (d0, d1) -> (0, d0 * 8 + d1 floordiv 8, d1 mod 8)>, l1Map = (d0, d1)[s0, s1] -> (0, 0, d0, d1), dramMap = (d0, d1)[s0, s1] -> (0, 0, d0, d1), mesh = #tt.mesh<name = "mesh", shape = 1x1, chipIds = [0]>>
 print(
     "extra wide\n",
     createDeviceAttr(
         [1, 64], workerGridMap=amap(2, [c0, d0 * 8 + floordiv(d1, c(8)), d1 % 8])
     ),
 )
-# CHECK: tt.device<workerGrid = #tt.grid<64x1, (d0, d1) -> (0, d1 * 8 + d0 floordiv 8, d0 mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 1, chipIds = [0]>
+# CHECK: #tt.device<workerGrid = #tt.grid<64x1, (d0, d1) -> (0, d1 * 8 + d0 floordiv 8, d0 mod 8)>, l1Map = (d0, d1)[s0, s1] -> (0, 0, d0, d1), dramMap = (d0, d1)[s0, s1] -> (0, 0, d0, d1), mesh = #tt.mesh<name = "mesh", shape = 1x1, chipIds = [0]>>
 print(
     "extra tall transposed\n",
     createDeviceAttr(
@@ -198,7 +198,7 @@ print(
         workerGridMap=amap(2, [c0, d1 * 8 + floordiv(d0, c(8)), d0 % 8]),
     ),
 )
-# CHECK: tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, (d0 + d1) mod 8)>, l1Map = [[L1:.*]], dramMap = [[DRAM:.*]], meshShape = 1, chipIds = [0]>
+# CHECK: #tt.device<workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, (d0 + d1) mod 8)>, l1Map = (d0, d1)[s0, s1] -> (0, 0, d0, d1), dramMap = (d0, d1)[s0, s1] -> (0, 0, d0, d1), mesh = #tt.mesh<name = "mesh", shape = 1x1, chipIds = [0]>>
 print(
     "staircase systolic\n",
     createDeviceAttr([8, 8], workerGridMap=amap(2, [c0, d0, (d0 + d1) % 8])),

--- a/test/ttmlir/Conversion/StableHLOToTTIR/ccl/all_reduce.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/ccl/all_reduce.mlir
@@ -1,7 +1,7 @@
 // REQUIRES: stablehlo
 // RUN: ttmlir-opt -split-input-file --stablehlo-to-ttir-pipeline %s | FileCheck %s
 
-module {
+module attributes {mhlo.num_partitions = 2 : i32, mhlo.num_replicas = 1 : i32, tt.meshes = #tt.meshes<[<name = "mesh_gspmd", shape = 1x2, chipIds = [0, 1]>]>} {
   func.func @all_reduce_variadic(%arg0: tensor<f32>, %arg1: tensor<f32>) -> (tensor<f32>, tensor<f32>) {
     %cst_0 = stablehlo.constant dense<1.600000e+01> : tensor<f32>
     %cst_1 = stablehlo.constant dense<0.000000e+00> : tensor<f32>

--- a/test/ttmlir/Dialect/TTNN/ccl/all_gather/all_gather_positive.mlir
+++ b/test/ttmlir/Dialect/TTNN/ccl/all_gather/all_gather_positive.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --split-input-file --ttir-to-ttnn-backend-pipeline="mesh-shape=1,4" %s | FileCheck %s
+// RUN: ttmlir-opt --split-input-file --ttir-to-ttnn-backend-pipeline="mesh-shape=1,2" %s | FileCheck %s
 // Unit tests for ttnn all_gather op
 
 // -----

--- a/test/ttmlir/Dialect/TTNN/ccl/mesh_shard.mlir
+++ b/test/ttmlir/Dialect/TTNN/ccl/mesh_shard.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt -split-input-file --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 
-module @mesh_shard_test attributes {tt.meshes = #tt.meshes<[<"mesh" = 1x1>]>} {
+module @mesh_shard_test attributes {tt.meshes = #tt.meshes<[#tt.mesh<name="mesh", shape=1x1, chipIds = [0]>]>} {
   func.func @forward(%arg0: tensor<8192x784xf32>) -> tensor<8192x392xf32> {
     %0 = ttir.empty() : tensor<8192x392xf32>
     %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: 0, 1>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 2>, shard_type = #tt.shard_type<devices>}> : (tensor<8192x784xf32>, tensor<8192x392xf32>) -> tensor<8192x392xf32>
@@ -16,7 +16,7 @@ module @mesh_shard_test attributes {tt.meshes = #tt.meshes<[<"mesh" = 1x1>]>} {
 
 // -----
 
-module @mesh_shard_test attributes {tt.meshes = #tt.meshes<[<"mesh" = 1x1>]>} {
+module @mesh_shard_test attributes {tt.meshes = #tt.meshes<[#tt.mesh<name="mesh", shape=1x1, chipIds = [0]>]>} {
   func.func @forward(%arg0: tensor<8192x784xf32>) -> tensor<8192x392xf32> {
     %0 = ttir.empty() : tensor<8192x392xf32>
     %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: 0, 1>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 2>, shard_type = #tt.shard_type<identity>}> : (tensor<8192x784xf32>, tensor<8192x392xf32>) -> tensor<8192x392xf32>

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -75,8 +75,9 @@ public:
         /*dimCount=*/2, /*symbolCount=*/0, {deviceIdx, d0, d1, shardOffset},
         &context);
     auto workerGrid = GridAttr::get(&context, gridShapeHwN300, map3);
+    auto mesh = MeshAttr::get(&context, "mesh", {0});
 
-    return DeviceAttr::get(&context, workerGrid, map4, map4, {1}, {0});
+    return DeviceAttr::get(&context, workerGrid, map4, map4, mesh);
   }
 
   mlir::RankedTensorType createRankedTensorType(llvm::ArrayRef<int64_t> shape) {


### PR DESCRIPTION
This PR checks if a device is found in replica groups for all ccl operations that does not exist in the mesh that the ccl is operating on, then it should fail conversion. 

For example
if my mesh is the following
```
#tt.meshes<[<name = "mesh_gspmd", numberOfChips = 2, shape = 1x2, chipIds = [0, 1]>]
```

and my reduce_scatter has this signature
```
%0 = "stablehlo.reduce_scatter"(%arg0) <{channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>, replica_groups = dense<[[0], [1], [2]]> : tensor<3x1xi64>, scatter_dimension = 3 : i64, use_global_device_ids}> ({
```

this should fail. In SHLO gspmd, they don't propagate the mesh shape down the graph. We manually calculate and insert it back in during SHLO -> TTIR conversion, so we have the ability to check for valid graphs.