### PR TITLE
Generic op loop generation

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
@@ -233,7 +233,7 @@ _tx
                          OptionalAttr<I64Attr>:$optNumElems, Variadic<Index>:$dstCoreIndex, Variadic<Index>:$mcastShape);
     let results = (outs TTIR_MemTx:$result);
 
-    let assemblyFormat = [{ $src ($srcAffineMap^)? (`[` $srcIndices^ `]`)? `,` $dst ($dstAffineMap^)? (`[` $dstIndices^ `]`)? (`,` $optNumElems^)? (`,` `core` `[` $dstCoreIndex^ `]`)? (`mcast` `[` $mcastShape^ `]`)? attr-dict `:` `(` type($src) `,` type($dst) `)` `->` type($result)}];
+    let assemblyFormat = [{ $src (`[` $srcIndices^ `]`)? (`[` $srcAffineMap^ `]`)? `,` $dst (`[` $dstIndices^ `]`)? (`[` $dstAffineMap^ `]`)? (`,` $optNumElems^)? (`,` `core` `[` $dstCoreIndex^ `]`)? (`mcast` `[` $mcastShape^ `]`)? attr-dict `:` `(` type($src) `,` type($dst) `)` `->` type($result)}];
 
     let hasVerifier = 1;
 
@@ -389,7 +389,8 @@ def TTIR_AwaitOp : TTIR_GenericRegionOp<"await", [MemoryEffects<[MemRead, MemWri
 // TTIR Generic Region Indexing Ops (Used in TTMetal Lowering)
 //===----------------------------------------------------------------------===//
 
-class TTIR_IndexOp<string mnemonic> : TTIR_GenericRegionOp<mnemonic,
+class TTIR_IndexOp<string mnemonic, list<Trait> traits = []> : TTIR_GenericRegionOp<mnemonic,
+  traits #
   [ Pure
   , DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
   ]> {
@@ -405,11 +406,12 @@ def TTIR_IterIndexOp : TTIR_IndexOp<"iter_index"> {
     }];
 }
 
-def TTIR_CoreIndexOp : TTIR_IndexOp<"core_index"> {
+def TTIR_CoreIndexOp : TTIR_IndexOp<"core_index", [ConstantLike]> {
     let summary = "Core Index op.";
     let description = [{
       Return the index of this core's coordinate inside the generic op's grid dimension.
     }];
+    let hasFolder = true;
 }
 
 #endif // TTMLIR_TTMLIR_DIALECT_TTIR_TTIRGENERICREGIONOPS_TD

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -123,7 +123,6 @@ def TTIR_GenericOp : TTIR_BufferizableOp<"generic",
       SmallVector<int64_t> getLoopBounds();
       SmallVector<AffineMap> getIndexingMapsValue();
       SmallVector<IteratorType> getIteratorTypesValue();
-      SmallVector<SmallVector<int64_t>> getOperandShardShapes();
       SmallVector<SmallVector<int64_t>> getOperandGridShapes();
     }];
 }

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -115,6 +115,17 @@ def TTIR_GenericOp : TTIR_BufferizableOp<"generic",
     let results = (outs Variadic<AnyRankedTensor>:$results);
     let regions = (region VariadicRegion<AnyRegion>:$regions);
     let hasVerifier = 1;
+
+    let extraClassDeclaration = [{
+      MutableOperandRange getDpsInitsMutable() { return ttir::getDpsOutputs(this); }
+      unsigned getNumLoops();
+      unsigned getNumDims();
+      SmallVector<int64_t> getLoopBounds();
+      SmallVector<AffineMap> getIndexingMapsValue();
+      SmallVector<IteratorType> getIteratorTypesValue();
+      SmallVector<SmallVector<int64_t>> getOperandShardShapes();
+      SmallVector<SmallVector<int64_t>> getOperandGridShapes();
+    }];
 }
 
 def TTIR_ToLayoutOp : TTIR_BufferizableOp<"to_layout"> {

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -221,6 +221,46 @@ def TTIRGenericHWThreadSelection : Pass<"ttir-generic-hw-thread-selection", "::m
   }];
 }
 
+def TTIRGenericGenerateLoops : Pass<"ttir-generic-generate-loops", "::mlir::ModuleOp"> {
+  let summary = "Generate generic loops.";
+  let description = [{
+    One of the final lowering forms of ttir generic op. This pass converts the affine declarative
+    loops into imperative loops and the affine maps are erased. For example a generic region
+    might transform as follows:
+
+    ```mlir
+    #lhs = affine_map<(d0, d1, d2) -> (d0, d2)>
+    #rhs = affine_map<(d0, d1, d2) -> (d2, d1)>
+    #out = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+    grid = #tt.grid<2x4>
+    operands : (memref<2x4x4x6x!tt.tile<32x32, f32>>, memref<4x4x6x8x!tt.tile<32x32, f32>>, memref<2x4x4x8x!tt.tile<32x32, f32>>)
+
+    ^compute(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>):
+      ttir.await %cb0, %cb1
+      "ttir.tile_matmul_block"(%cb0, %cb1, %cb2)
+      ttir.yield %cb2
+    ```
+
+    Into:
+    ```mlir
+    ^compute(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>):
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c4 = arith.constant 4 : index
+      scf.for %arg2 = %c0 to %c1 step %c1 {
+        scf.for %arg3 = %c0 to %c1 step %c1 {
+          scf.for %arg4 = %c0 to %c4 step %c1 {
+            ttir.await %cb0, %cb1
+            "ttir.tile_matmul_block"(%cb0, %cb1, %cb2)
+            ttir.yield %cb2
+          }
+        }
+      }
+    ```
+  }];
+}
+
 def TTIRLayout: Pass<"ttir-layout", "::mlir::ModuleOp"> {
   let summary = "Tensor tilize all generic ops.";
   let description = [{

--- a/lib/Dialect/TTIR/IR/TTIRGenericRegionOps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIRGenericRegionOps.cpp
@@ -157,3 +157,11 @@ void mlir::tt::ttir::CoreIndexOp::getAsmResultNames(
   int64_t dim = getDim();
   setNameFn(getResult(), "core" + std::to_string(dim));
 }
+
+//===----------------------------------------------------------------------===//
+// CoreIndexOp
+//===----------------------------------------------------------------------===//
+
+mlir::OpFoldResult mlir::tt::ttir::CoreIndexOp::fold(FoldAdaptor adaptor) {
+  return getDimAttr();
+}

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -3030,26 +3030,6 @@ mlir::tt::ttir::GenericOp::getIteratorTypesValue() {
 }
 
 mlir::SmallVector<mlir::SmallVector<int64_t>>
-mlir::tt::ttir::GenericOp::getOperandShardShapes() {
-  SmallVector<SmallVector<int64_t>> gridShapes;
-  gridShapes.reserve(getOperands().size());
-  for (auto operand : this->getOperands()) {
-    auto memrefType = mlir::dyn_cast<MemRefType>(operand.getType());
-    if (memrefType) {
-      assert(memrefType.getRank() % 2 == 0);
-      gridShapes.emplace_back(
-          memrefType.getShape().drop_front(memrefType.getRank() / 2));
-    } else {
-      auto tensorType = mlir::cast<RankedTensorType>(operand.getType());
-      MetalLayoutAttr layout =
-          mlir::cast<MetalLayoutAttr>(tensorType.getEncoding());
-      gridShapes.emplace_back(layout.getMemref().getShape());
-    }
-  }
-  return gridShapes;
-}
-
-mlir::SmallVector<mlir::SmallVector<int64_t>>
 mlir::tt::ttir::GenericOp::getOperandGridShapes() {
   SmallVector<SmallVector<int64_t>> gridShapes;
   gridShapes.reserve(getOperands().size());

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -3009,7 +3009,9 @@ unsigned mlir::tt::ttir::GenericOp::getNumLoops() { return getNumDims(); }
 unsigned mlir::tt::ttir::GenericOp::getNumDims() {
   assert(!getIndexingMaps().empty() && "GenericOp must be pre-loop generated "
                                        "with indexing maps to use this method");
-  return getIndexingMapsValue()[0].getNumDims();
+  return mlir::cast<mlir::AffineMapAttr>(getIndexingMapsAttr()[0])
+      .getAffineMap()
+      .getNumDims();
 }
 
 mlir::SmallVector<mlir::AffineMap>

--- a/lib/Dialect/TTIR/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTIR/Transforms/CMakeLists.txt
@@ -5,6 +5,7 @@ add_mlir_dialect_library(MLIRTTIRTransforms
         GeneralizeNamedOps.cpp
         GenericLinearizeMemref.cpp
         GenericGenerateDatamovement.cpp
+        GenericGenerateLoops.cpp
         GenericHWThreadSelection.cpp
         AttachMetalLayout.cpp
         OptimizeTensorLayout.cpp

--- a/lib/Dialect/TTIR/Transforms/GenericGenerateLoops.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericGenerateLoops.cpp
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
+
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Rewrite/FrozenRewritePatternSet.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir::tt::ttir {
+#define GEN_PASS_DEF_TTIRGENERICGENERATELOOPS
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h.inc"
+
+namespace {
+class TTIRGenericGenerateLoopsRewriter : public OpRewritePattern<GenericOp> {
+public:
+  using OpRewritePattern<GenericOp>::OpRewritePattern;
+
+  static std::tuple<SmallVector<Value>, SmallVector<Value>, SmallVector<Value>>
+  buildLoopBounds(OpBuilder &builder, Location loc,
+                  ArrayRef<int64_t> loopBounds) {
+    Value zero = builder.create<arith::ConstantOp>(loc, builder.getIndexType(),
+                                                   builder.getIndexAttr(0));
+    Value one = builder.create<arith::ConstantOp>(loc, builder.getIndexType(),
+                                                  builder.getIndexAttr(1));
+    SmallVector<Value> lbs(loopBounds.size(), zero);
+    SmallVector<Value> ubs(llvm::map_range(loopBounds, [&](int64_t dim) {
+      return builder.create<arith::ConstantOp>(loc, builder.getIndexType(),
+                                               builder.getIndexAttr(dim));
+    }));
+    SmallVector<Value> step(loopBounds.size(), one);
+    return std::make_tuple(lbs, ubs, step);
+  }
+
+  static scf::LoopNest buildLoopNest(PatternRewriter &rewriter, Location loc,
+                                     ArrayRef<int64_t> loopBounds,
+                                     Block *regionBlock, Block *loopedBlock) {
+    auto [lbs, ubs, steps] = buildLoopBounds(rewriter, loc, loopBounds);
+
+    return scf::buildLoopNest(
+        rewriter, loc, lbs, ubs, steps,
+        [&](OpBuilder &bodyBuilder, Location loc, ValueRange iters) {
+          rewriter.setInsertionPointToStart(bodyBuilder.getInsertionBlock());
+          Block *innerLoopBlock = bodyBuilder.getInsertionBlock();
+          rewriter.mergeBlocks(regionBlock, innerLoopBlock,
+                               loopedBlock->getArguments());
+        });
+  }
+
+  static void replaceIterIndexUses(PatternRewriter &rewriter, Location loc,
+                                   scf::LoopNest &loopNest) {
+    loopNest.loops.back().walk([&](IterIndexOp index) {
+      uint64_t loopDepth = index.getDim();
+      assert(loopDepth < loopNest.loops.size());
+      scf::ForOp loop = loopNest.loops[loopDepth];
+      rewriter.replaceOp(index, loop.getInductionVar());
+    });
+  }
+
+  LogicalResult matchAndRewrite(GenericOp generic,
+                                PatternRewriter &rewriter) const final {
+    if (generic.getIndexingMaps().empty()) {
+      return failure();
+    }
+
+    auto loopedGeneric = rewriter.create<GenericOp>(
+        generic->getLoc(), generic.getResultTypes(), generic.getInputs(),
+        generic.getOutputs(), generic.getGrid(), rewriter.getArrayAttr({}),
+        rewriter.getArrayAttr({}), generic.getNumRegions());
+
+    SmallVector<int64_t> loopBounds = generic.getLoopBounds();
+    for (Region &region : generic.getRegions()) {
+      Block *regionBlock = &region.front();
+      Block *loopedBlock =
+          &loopedGeneric.getRegion(region.getRegionNumber()).emplaceBlock();
+      loopedBlock->addArguments(
+          region.getArgumentTypes(),
+          SmallVector<mlir::Location>(region.getArgumentTypes().size(),
+                                      generic.getLoc()));
+      rewriter.setInsertionPointToStart(loopedBlock);
+      scf::LoopNest loopNest = buildLoopNest(
+          rewriter, generic.getLoc(), loopBounds, regionBlock, loopedBlock);
+      replaceIterIndexUses(rewriter, generic.getLoc(), loopNest);
+    }
+
+    rewriter.replaceOp(generic, loopedGeneric.getResults());
+
+    return success();
+  }
+};
+} // namespace
+
+namespace {
+class TTIRGenericGenerateLoops
+    : public impl::TTIRGenericGenerateLoopsBase<TTIRGenericGenerateLoops> {
+public:
+  using impl::TTIRGenericGenerateLoopsBase<
+      TTIRGenericGenerateLoops>::TTIRGenericGenerateLoopsBase;
+
+  void runOnOperation() final {
+    RewritePatternSet patterns(&getContext());
+    patterns.add<TTIRGenericGenerateLoopsRewriter>(&getContext());
+    FrozenRewritePatternSet patternSet(std::move(patterns));
+    if (failed(applyPatternsGreedily(getOperation(), patternSet))) {
+      signalPassFailure();
+    }
+  }
+};
+} // namespace
+
+} // namespace mlir::tt::ttir

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -61,6 +61,8 @@ void createTTIRToTTMetalBackendPipeline(
   pm.addPass(mlir::tt::ttir::createTTIRGenericLinearizeMemref());
   pm.addPass(mlir::createLowerAffinePass());
   pm.addPass(mlir::tt::ttir::createTTIRGenericGenerateDatamovement());
+  pm.addPass(mlir::tt::ttir::createTTIRGenericHWThreadSelection());
+  pm.addPass(mlir::tt::ttir::createTTIRGenericGenerateLoops());
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/ttmlir/Dialect/TTIR/bufferization/prepare_tensors.mlir
+++ b/test/ttmlir/Dialect/TTIR/bufferization/prepare_tensors.mlir
@@ -35,21 +35,21 @@ func.func @main(%arg0: tensor<256x384xf32, #layout1>, %arg1: tensor<256x384xf32,
 #parallel = #tt.iterator_type<parallel>
 #reduction = #tt.iterator_type<reduction>
 #l1_ = #tt.memory_space<l1>
-#layout1 = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <2x3>, memref<4x4x!tt.tile<32x32, f32>, #l1_>>
+#layout1 = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <4x3>, memref<2x4x!tt.tile<32x32, f32>, #l1_>>
 #layout2 = #tt.metal_layout<(d0, d1) -> (d0, d1), undef, <4x1>, memref<2x1x!tt.tile<32x32, f32>, #l1_>>
 
 func.func @main(%arg0: tensor<256x384xf32, #layout1>, %arg1: tensor<256x384xf32, #layout1>) -> tensor<256x32xf32, #layout2> {
   // CHECK: tensor.empty() : tensor<4x1x2x1x!tt.tile<32x32, f32>, #layout1>
   %0 = tensor.empty() : tensor<256x32xf32, #layout2>
-  // CHECK: : (tensor<2x3x4x4x!tt.tile<32x32, f32>, #layout>, tensor<2x3x4x4x!tt.tile<32x32, f32>, #layout>, tensor<4x1x2x1x!tt.tile<32x32, f32>, #layout1>) -> tensor<4x1x2x1x!tt.tile<32x32, f32>, #layout1>
+  // CHECK: : (tensor<4x3x2x4x!tt.tile<32x32, f32>, #layout>, tensor<4x3x2x4x!tt.tile<32x32, f32>, #layout>, tensor<4x1x2x1x!tt.tile<32x32, f32>, #layout1>) -> tensor<4x1x2x1x!tt.tile<32x32, f32>, #layout1>
   %1 = "ttir.generic"(%arg0, %arg1, %0) <{
         grid = #tt.grid<4x1>,
         indexing_maps = [#map1, #map1, #map2],
         iterator_types = [#parallel, #reduction],
         operandSegmentSizes = array<i32: 2, 1>
         }> ({
-        ^bb0(%arg2: memref<4x4x!tt.tile<32x32, f32>, #l1_>,
-            %arg3: memref<4x4x!tt.tile<32x32, f32>, #l1_>,
+        ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>,
+            %arg3: memref<2x4x!tt.tile<32x32, f32>, #l1_>,
             %arg4: memref<2x1x!tt.tile<32x32, f32>, #l1_>):
         "ttir.yield"() : () -> ()
         }) : (tensor<256x384xf32, #layout1>, tensor<256x384xf32, #layout1>, tensor<256x32xf32, #layout2>) -> tensor<256x32xf32, #layout2>

--- a/test/ttmlir/Dialect/TTIR/generic/generic_datamovement.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/generic_datamovement.mlir
@@ -76,12 +76,12 @@ func.func @matmul_single_core_stream(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>,
   // Look for 4 regions, one for each operand and one for the compute
   // Operand 0 (input)
   // CHECK: ^datamovement0
-  // CHECK-NEXT: ttir.dma [[lhs]] #map1, %cb0
+  // CHECK-NEXT: ttir.dma [[lhs]] [#map1], %cb0
   // CHECK-NEXT: ttir.dma_wait
   // CHECK-NEXT: ttir.yield %cb0
   // Operand 1 (input)
   // CHECK: ^datamovement1
-  // CHECK-NEXT: ttir.dma [[rhs]] #map2, %cb1
+  // CHECK-NEXT: ttir.dma [[rhs]] [#map2], %cb1
   // CHECK-NEXT: ttir.dma_wait
   // CHECK-NEXT: ttir.yield %cb1
   // Operand 2 (output)
@@ -109,7 +109,7 @@ func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, 
   // Look for 4 regions, one for each operand and one for the compute
   // Operand 0 (input)
   // CHECK: ^datamovement0
-  // CHECK: ttir.dma [[lhs]] #map1, %cb0
+  // CHECK: ttir.dma [[lhs]] [#map1], %cb0
   // CHECK-NEXT: ttir.dma_wait
   // CHECK-NEXT: ttir.semaphore_wait [[reader_ready_lhs:%[a-z0-9]+]]
   // CHECK-NEXT: ttir.dma %cb0, %cb0
@@ -120,7 +120,7 @@ func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, 
   // CHECK-NEXT: ttir.semaphore_wait [[writer_done_lhs]]
   // Operand 1 (input)
   // CHECK: ^datamovement1
-  // CHECK: ttir.dma [[rhs]] #map2, %cb1
+  // CHECK: ttir.dma [[rhs]] [#map2], %cb1
   // CHECK-NEXT: ttir.dma_wait
   // CHECK-NEXT: ttir.semaphore_wait [[reader_ready_rhs:%[a-z0-9]+]]
   // CHECK-NEXT: ttir.dma %cb1, %cb1
@@ -154,7 +154,7 @@ func.func @matmul_multi_core_dram_params(%arg0: memref<2x4x4x6x!tt.tile<32x32, f
   // Look for 4 regions, one for each operand and one for the compute
   // Operand 0 (input)
   // CHECK: ^datamovement0
-  // CHECK: ttir.dma [[lhs]] #map1, %cb0
+  // CHECK: ttir.dma [[lhs]] [#map1], %cb0
   // CHECK-NEXT: ttir.dma_wait
   // CHECK-NEXT: ttir.semaphore_wait [[reader_ready_lhs:%[a-z0-9]+]]
   // CHECK-NEXT: ttir.dma %cb0, %cb0
@@ -165,7 +165,7 @@ func.func @matmul_multi_core_dram_params(%arg0: memref<2x4x4x6x!tt.tile<32x32, f
   // CHECK-NEXT: ttir.semaphore_wait [[writer_done_lhs]]
   // Operand 1 (input)
   // CHECK: ^datamovement1
-  // CHECK: ttir.dma [[rhs]] #map2, %cb1
+  // CHECK: ttir.dma [[rhs]] [#map2], %cb1
   // CHECK-NEXT: ttir.dma_wait
   // CHECK-NEXT: ttir.semaphore_wait [[reader_ready_rhs:%[a-z0-9]+]]
   // CHECK-NEXT: ttir.dma %cb1, %cb1

--- a/test/ttmlir/Dialect/TTIR/generic/generic_loops.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/generic_loops.mlir
@@ -1,0 +1,182 @@
+// RUN: ttmlir-opt --tt-register-device --ttir-generic-generate-loops %s | FileCheck %s
+
+#dram = #tt.memory_space<dram>
+#l1_ = #tt.memory_space<l1>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#map1 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map2 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map3 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#parallel = #tt.iterator_type<parallel>
+#reduction = #tt.iterator_type<reduction>
+
+func.func @unary2x4(%arg0: memref<2x4x128x192xf32, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>}> ({
+  ^datamovement0(%cb0: memref<128x192xf32, #l1_>, %cb1: memref<4x6x!tt.tile<32x32, f32>, #l1_>):
+    // CHECK: scf.for %{{.*}} = %c0 to %c1
+    // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1
+    ttir.yield %cb0 : (memref<128x192xf32, #l1_>)
+  }, {
+  ^datamovement1(%cb0: memref<128x192xf32, #l1_>, %cb1: memref<4x6x!tt.tile<32x32, f32>, #l1_>):
+    // CHECK: scf.for %{{.*}} = %c0 to %c1
+    // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1
+    ttir.await %cb1 : (memref<4x6x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^compute(%cb0: memref<128x192xf32, #l1_>, %cb1: memref<4x6x!tt.tile<32x32, f32>, #l1_>):
+    // CHECK: scf.for %{{.*}} = %c0 to %c1
+    // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1
+    ttir.await %cb0 : (memref<128x192xf32, #l1_>)
+    "ttir.tile_tilize_block"(%cb0, %cb1) : (memref<128x192xf32, #l1_>, memref<4x6x!tt.tile<32x32, f32>, #l1_>) -> ()
+    ttir.yield %cb1 : (memref<4x6x!tt.tile<32x32, f32>, #l1_>)
+  }) : (memref<2x4x128x192xf32, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> ()
+  return %alloc : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
+}
+
+func.func @binary1x1(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 2, 1>}> ({
+  ^datamovement0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
+    // CHECK: scf.for %{{.*}} = %c0 to %c1
+    // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1
+    ttir.yield %cb0 : (memref<2x4x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^datamovement1(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
+    // CHECK: scf.for %{{.*}} = %c0 to %c1
+    // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1
+    ttir.yield %cb1 : (memref<2x4x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^datamovement2(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
+    // CHECK: scf.for %{{.*}} = %c0 to %c1
+    // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1
+    ttir.await %cb2 : (memref<2x4x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^compute(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
+    // CHECK: scf.for %{{.*}} = %c0 to %c1
+    // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1
+    ttir.await %cb0, %cb1 : (memref<2x4x!tt.tile<32x32, f32>, #l1_>, memref<2x4x!tt.tile<32x32, f32>, #l1_>)
+    affine.for %arg2 = 0 to 2 {
+      affine.for %arg3 = 0 to 4 {
+        %0 = affine.load %cb0[%arg2, %arg3] : memref<2x4x!tt.tile<32x32, f32>, #l1_>
+        %1 = affine.load %cb1[%arg2, %arg3] : memref<2x4x!tt.tile<32x32, f32>, #l1_>
+        %2 = "ttir.tile_add"(%0, %1) : (!tt.tile<32x32, f32>, !tt.tile<32x32, f32>) -> !tt.tile<32x32, f32>
+        affine.store %2, %cb2[%arg2, %arg3] : memref<2x4x!tt.tile<32x32, f32>, #l1_>
+      }
+    }
+    ttir.yield %cb2 : (memref<2x4x!tt.tile<32x32, f32>, #l1_>)
+  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+}
+
+func.func @matmul1x1(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x4x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  ^datamovement0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<4x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
+    // CHECK: scf.for %{{.*}} = %c0 to %c1
+    // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1
+    // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1
+    ttir.yield %cb0 : (memref<2x4x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^datamovement1(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<4x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
+    // CHECK: scf.for %{{.*}} = %c0 to %c1
+    // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1
+    // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1
+    ttir.yield %cb1 : (memref<4x2x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^datamovement2(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<4x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
+    // CHECK: scf.for %{{.*}} = %c0 to %c1
+    // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1
+    // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1
+    ttir.await %cb2 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^compute(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<4x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
+    // CHECK: scf.for %{{.*}} = %c0 to %c1
+    // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1
+    // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1
+    ttir.await %cb0, %cb1 : (memref<2x4x!tt.tile<32x32, f32>, #l1_>, memref<4x2x!tt.tile<32x32, f32>, #l1_>)
+    "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<2x4x!tt.tile<32x32, f32>, #l1_>, memref<4x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
+    ttir.yield %cb2 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
+  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x4x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+}
+
+func.func @matmul_outer_k(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>
+  %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>
+  "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  ^datamovement0(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
+    // CHECK: scf.for %{{.*}} = %c0 to %c1
+    // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1
+    // CHECK-NEXT: scf.for %[[I:.*]] = %c0 to %c2
+    // CHECK-NEXT: ttir.dma %{{.*}}[%c0, %[[I]]]
+    %c0 = arith.constant 0 : index
+    %k = ttir.iter_index(2) : index
+    %tx = ttir.dma %stream[%c0, %k], %cb0 : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+    ttir.dma_wait %tx
+    ttir.yield %cb0 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^datamovement1(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
+    // CHECK: scf.for %{{.*}} = %c0 to %c1
+    // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1
+    // CHECK-NEXT: scf.for %[[I:.*]] = %c0 to %c2
+    // CHECK-NEXT: ttir.dma %{{.*}}[%[[I]], %c0]
+    %c0 = arith.constant 0 : index
+    %k = ttir.iter_index(2) : index
+    %tx = ttir.dma %stream_2[%k, %c0], %cb1 : (memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+    ttir.dma_wait %tx
+    ttir.yield %cb1 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^datamovement2(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
+    // CHECK: scf.for %{{.*}} = %c0 to %c1
+    // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1
+    // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c2
+    ttir.await %cb2 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^compute(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
+    // CHECK: scf.for %{{.*}} = %c0 to %c1
+    // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1
+    // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c2
+    ttir.await %cb0, %cb1 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>)
+    "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
+    ttir.yield %cb2 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
+  }) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+}
+
+func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
+  %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
+  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>
+  %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 24576 + d3 * 4096)>, #l1_>
+  %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>, memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #l1_>
+  "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  ^datamovement0(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>, %sem0: !ttir.semaphore, %sem1: !ttir.semaphore, %sem2: !ttir.semaphore, %sem3: !ttir.semaphore):
+    // CHECK: scf.for %{{.*}} = %c0 to %c1
+    // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1
+    // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c4
+    ttir.yield %cb0 : (memref<4x6x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^datamovement1(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>, %sem0: !ttir.semaphore, %sem1: !ttir.semaphore, %sem2: !ttir.semaphore, %sem3: !ttir.semaphore):
+    // CHECK: scf.for %{{.*}} = %c0 to %c1
+    // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1
+    // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c4
+    ttir.yield %cb1 : (memref<6x8x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^datamovement2(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>, %sem0: !ttir.semaphore, %sem1: !ttir.semaphore, %sem2: !ttir.semaphore, %sem3: !ttir.semaphore):
+    // CHECK: scf.for %{{.*}} = %c0 to %c1
+    // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1
+    // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c4
+    ttir.await %cb2 : (memref<4x8x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^compute(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>, %sem0: !ttir.semaphore, %sem1: !ttir.semaphore, %sem2: !ttir.semaphore, %sem3: !ttir.semaphore):
+    // CHECK: scf.for %{{.*}} = %c0 to %c1
+    // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1
+    // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c4
+    ttir.await %cb0, %cb1 : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>)
+    "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
+    ttir.yield %cb2 : (memref<4x8x!tt.tile<32x32, f32>, #l1_>)
+  }) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 24576 + d3 * 4096)>, #l1_>, memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #l1_>, memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
+  return %alloc : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
+}


### PR DESCRIPTION
This commit implements one of the final lowering forms of ttir generic op. This pass converts the affine declarative loops into imperative loops and the affine maps are erased. For example a generic region might transform as follows:

```mlir
#lhs = affine_map<(d0, d1, d2) -> (d0, d2)>
#rhs = affine_map<(d0, d1, d2) -> (d2, d1)>
#out = affine_map<(d0, d1, d2) -> (d0, d1)>

grid = #tt.grid<2x4>
operands : (memref<2x4x4x6x!tt.tile<32x32, f32>>, memref<4x4x6x8x!tt.tile<32x32, f32>>, memref<2x4x4x8x!tt.tile<32x32, f32>>)

^compute(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>):
  ttir.await %cb0, %cb1
  ttir.tile_matmul_block (%cb0, %cb1, %cb2)
  ttir.yield %cb2
```

Into:
```mlir
^compute(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>):
  %c0 = arith.constant 0 : index
  %c1 = arith.constant 1 : index
  %c4 = arith.constant 4 : index
  scf.for %arg2 = %c0 to %c1 step %c1 {
    scf.for %arg3 = %c0 to %c1 step %c1 {
      scf.for %arg4 = %c0 to %c4 step %c1 {
        ttir.await %cb0, %cb1
        ttir.tile_matmul_block (%cb0, %cb1, %cb2)
        ttir.yield %cb2
      }
    }
  }
```