### PR TITLE
Adding DotGeneralOp to TTIR builder

### DIFF
--- a/python/test_infra/ttir_builder.py
+++ b/python/test_infra/ttir_builder.py
@@ -501,6 +501,35 @@ class TTIRBuilder:
     ) -> torch.Tensor:
         return torch.tensor([in0.size(dimension)])
 
+    def dot_general(
+        self,
+        in0: Operand,
+        in1: Operand,
+        batch_dims_lhs=List[int],
+        contract_dims_lhs=List[int],
+        batch_dims_rhs=List[int],
+        contract_dims_rhs=List[int],
+    ) -> OpView:
+        lhs = contract_dims_lhs + batch_dims_lhs
+        rhs = contract_dims_rhs + batch_dims_rhs
+        return self.op_proxy(
+            torch.tensordot,
+            ttir.DotGeneralOp,
+            [in0, in1],
+            golden_kwargs={"dims": (lhs, rhs)},
+            ttir_kwargs={
+                "batch_dims_lhs": batch_dims_lhs,
+                "contract_dims_lhs": contract_dims_lhs,
+                "batch_dims_rhs": batch_dims_rhs,
+                "contract_dims_rhs": contract_dims_rhs,
+            },
+            organize_ttir_args=lambda i, o, _: (self._get_type(o), i[0], i[1]),
+            output_shape=[4, 10, 3, 7, 10, 7, 3],
+            output_type=self.get_type_from_torch_dtype(
+                self._get_golden_tensor(in0).dtype
+            ),
+        )
+
     # TTIR top level named ops
     # class TTIR_ElementwiseTernaryOp
 

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -177,6 +177,17 @@ def test_get_dimension_size(in0: Operand, builder: TTIRBuilder):
 
 @compile_to_flatbuffer(
     [
+        (4, 10, 3, 5, 7),
+        (4, 10, 5, 7, 3),
+    ],
+    targets=["ttnn"],
+)
+def test_dot_general(in0: Operand, in1: Operand, builder: TTIRBuilder):
+    return builder.dot_general(in0, in1, [0], [3], [0], [2])
+
+
+@compile_to_flatbuffer(
+    [
         (64, 128),
         (32, 128),
         (16, 128),


### PR DESCRIPTION
### Ticket
[Issue #2574](https://github.com/tenstorrent/tt-mlir/issues/2574)

### Problem description
TTIR builder had no support for DotGeneralOp

### What's changed
Added DotGeneralOp and test

### Checklist
- [ ] New/Existing tests provide coverage for changes
