### PR TITLE
Lowering of softmax op from TTIR to the Linalg dialect

### DIFF
--- a/lib/Conversion/TTIRToLinalg/TTIRToLinalg.cpp
+++ b/lib/Conversion/TTIRToLinalg/TTIRToLinalg.cpp
@@ -252,8 +252,7 @@ void populateTTIRToLinalgPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
       ElementwiseOpConversionPattern<ttir::FloorOp, linalg::FloorOp>,
       ElementwiseOpConversionPattern<ttir::TanhOp, linalg::TanhOp>,
       ElementwiseOpConversionPattern<ttir::ReciprocalOp, linalg::ReciprocalOp>,
-      SoftmaxOpConversionPattern>(
-      typeConverter, ctx);
+      SoftmaxOpConversionPattern>(typeConverter, ctx);
 }
 
 } // namespace mlir::tt

--- a/lib/Conversion/TTIRToLinalg/TTIRToLinalg.cpp
+++ b/lib/Conversion/TTIRToLinalg/TTIRToLinalg.cpp
@@ -252,7 +252,7 @@ void populateTTIRToLinalgPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
       ElementwiseOpConversionPattern<ttir::FloorOp, linalg::FloorOp>,
       ElementwiseOpConversionPattern<ttir::TanhOp, linalg::TanhOp>,
       ElementwiseOpConversionPattern<ttir::ReciprocalOp, linalg::ReciprocalOp>,
-      SoftmaxOpConversionPattern>>(
+      SoftmaxOpConversionPattern>(
       typeConverter, ctx);
 }
 

--- a/lib/Conversion/TTIRToLinalg/TTIRToLinalg.cpp
+++ b/lib/Conversion/TTIRToLinalg/TTIRToLinalg.cpp
@@ -182,9 +182,9 @@ public:
     return success();
   }
 };
-
 } // namespace
 
+namespace {
 // General elementwise conversion pattern, without implicit broadcasting etc.
 // Appropriate for unary ops, or other ops without broadcasting.
 template <typename TTIROpTy, typename LinAlgOpTy,

--- a/lib/Conversion/TTIRToLinalg/TTIRToLinalg.cpp
+++ b/lib/Conversion/TTIRToLinalg/TTIRToLinalg.cpp
@@ -197,9 +197,9 @@ public:
     Value input = adaptor.getInput();
     const size_t inputSize =
         dyn_cast<RankedTensorType>(input.getType()).getShape().size();
-    int32_t dimension = op.getDimension();
-    if (dimension < 0)
-      dimension += inputSize;
+    const int32_t dimension = (op.getDimension() < 0)
+                                  ? op.getDimension() + inputSize
+                                  : op.getDimension();
 
     rewriter.replaceOpWithNewOp<linalg::SoftmaxOp>(
         op, this->getTypeConverter()->convertType(op.getType()), input,

--- a/test/ttmlir/Conversion/TTIRToLinalg/softmax.mlir
+++ b/test/ttmlir/Conversion/TTIRToLinalg/softmax.mlir
@@ -1,0 +1,22 @@
+// RUN: ttmlir-opt --convert-ttir-to-linalg %s | FileCheck %s
+
+module {
+  func.func @softmax_simple(%arg0: tensor<512x1024xbf16>) -> tensor<512x1024xbf16> {
+    %0 = tensor.empty() : tensor<512x1024xbf16>
+    // CHECK: %{{.*}} = linalg.softmax dimension(0) ins(%arg0 : tensor<512x1024xbf16>) outs(%0 : tensor<512x1024xbf16>) -> tensor<512x1024xbf16>
+    %1 = "ttir.softmax"(%arg0, %0) <{dimension = 0 : si32}> : (tensor<512x1024xbf16>, tensor<512x1024xbf16>) -> tensor<512x1024xbf16>
+    return %1 : tensor<512x1024xbf16>
+  }
+
+  func.func @softmax(%arg0: tensor<512x1024xbf16>) -> tensor<512x1024xbf16> {
+    %0 = tensor.empty() : tensor<512x1024xbf16>
+    // Check for positive dimension attribute
+    // CHECK: %{{.*}} = linalg.softmax dimension(1) ins(%arg0 : tensor<512x1024xbf16>) outs(%0 : tensor<512x1024xbf16>) -> tensor<512x1024xbf16>
+    %1 = "ttir.softmax"(%arg0, %0) <{dimension = 1 : si32}> : (tensor<512x1024xbf16>, tensor<512x1024xbf16>) -> tensor<512x1024xbf16>
+    %2 = tensor.empty() : tensor<512x1024xbf16>
+    // Check for negative dimension attribute
+    // CHECK: %{{.*}} = linalg.softmax dimension(1) ins(%1 : tensor<512x1024xbf16>) outs(%2 : tensor<512x1024xbf16>) -> tensor<512x1024xbf16>
+    %3 = "ttir.softmax"(%1, %2) <{dimension = -1 : si32}> : (tensor<512x1024xbf16>, tensor<512x1024xbf16>) -> tensor<512x1024xbf16>
+    return %3 : tensor<512x1024xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket
Closes #2580 

### Problem description
Currently, the TTIR dialect doesn't support lowering the `softmax` operation to the Linalg dialect. Since Linalg provides `linalg.softmax` opeartion, it should be possible to implement this lowering.

### What's changed
Implemented a basic lowering of `softmax` operation to the Linalg dialect. While lowering we distinguish between two cases for dimension attribute:
    
1) Negative dimension: we treated it as an index from the end, so we subtract it from the tensor's shape size.
2) Positive dimension: we just passed it through
    
If dimension is bigger than shape size, then `ttmlir-opt` reports an error before conversion.


### Checklist
- [x] New/Existing tests provide coverage for changes
