### PR TITLE
Added a `fillStrategyMapFromSharding` function to the SharingUtils class

### DIFF
--- a/include/ttmlir/Conversion/StableHLOToTTIR/ShardingUtils.h
+++ b/include/ttmlir/Conversion/StableHLOToTTIR/ShardingUtils.h
@@ -76,10 +76,13 @@ public:
     return shardDirection;
   }
 
-  static LogicalResult fillStrategyMapFromSharding(
+  // Needed by the frontend (tt-xla) to create a 'strategy' map for creating
+  // multiDevice tensors based on the MeshSharding object attached to it. This
+  // is needed fren the frontend generates a multiDevice tensor as input.
+  static FailureOr<std::unordered_map<std::string, std::string>>
+  fillStrategyMapFromSharding(
       const mlir::tt::sharding_utils::MeshSharding &meshSharding,
-      size_t num_devices,
-      std::unordered_map<std::string, std::string> &strategy);
+      size_t num_devices);
 
   mlir::tt::MeshShardType getShardType() const { return shardType; }
   llvm::ArrayRef<int64_t> getShardShape() const { return shardShape; }

--- a/include/ttmlir/Conversion/StableHLOToTTIR/ShardingUtils.h
+++ b/include/ttmlir/Conversion/StableHLOToTTIR/ShardingUtils.h
@@ -75,6 +75,12 @@ public:
   mlir::tt::MeshShardDirection getShardDirection() const {
     return shardDirection;
   }
+
+  static LogicalResult fillStrategyMapFromSharding(
+      const mlir::tt::sharding_utils::MeshSharding &meshSharding,
+      size_t num_devices,
+      std::unordered_map<std::string, std::string> &strategy);
+
   mlir::tt::MeshShardType getShardType() const { return shardType; }
   llvm::ArrayRef<int64_t> getShardShape() const { return shardShape; }
   llvm::ArrayRef<int64_t> getShardDims() const { return shardDims; }

--- a/lib/Conversion/StableHLOToTTIR/ShardingUtils.cpp
+++ b/lib/Conversion/StableHLOToTTIR/ShardingUtils.cpp
@@ -431,10 +431,11 @@ MeshSharding::getTensorMeshShardingAttr(mlir::PatternRewriter &rewriter) {
                                                tensorMeshShardingAxisAttr);
 }
 
-LogicalResult MeshSharding::fillStrategyMapFromSharding(
+FailureOr<std::unordered_map<std::string, std::string>>
+MeshSharding::fillStrategyMapFromSharding(
     const mlir::tt::sharding_utils::MeshSharding &meshSharding,
-    size_t num_devices,
-    std::unordered_map<std::string, std::string> &strategy) {
+    size_t num_devices) {
+  std::unordered_map<std::string, std::string> strategy;
   mlir::tt::MeshShardType meshType = meshSharding.getShardType();
   if (meshType == mlir::tt::MeshShardType::Replicate) {
     // If there is only one device, the output will be replicated, but there is
@@ -464,7 +465,7 @@ LogicalResult MeshSharding::fillStrategyMapFromSharding(
   } else {
     return mlir::failure();
   }
-  return mlir::success();
+  return strategy;
 }
 
 } // namespace sharding_utils


### PR DESCRIPTION
In `tt-xla`, we need a function that will translate an object `mlir::tt::sharding_utils::MeshSharding` into a std::map of strings needed to call `CreateTensor()` on a multichip Tensor. Currently, this functionality is in `tt-xla`, this moves it to `tt-mlir`.