### PR TITLE
[TTNN] Add E2E MatmulProgramConfig support

### DIFF
--- a/include/ttmlir-c/TTNNAttrs.h
+++ b/include/ttmlir-c/TTNNAttrs.h
@@ -12,11 +12,8 @@
 extern "C" {
 #endif
 
-MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTNNCoreRangeAttrGet(MlirContext ctx,
-                                                            int64_t *offset,
-                                                            size_t offsetSize,
-                                                            int64_t *size,
-                                                            size_t sizeSize);
+MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTNNCoreRangeAttrGet(
+    MlirContext ctx, MlirAttribute startCoord, MlirAttribute endCoord);
 
 MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTNNCoreRangeArrayAttrGet(
     MlirContext ctx, MlirAttribute *coreRangeAttrs, size_t coreRangeAttrsSize);

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1138,7 +1138,13 @@ def TTNN_MatmulOp : TTNN_Op<"matmul",
     let arguments = (ins AnyRankedTensor:$a,
                          AnyRankedTensor:$b,
                          DefaultValuedAttr<BoolAttr, "false">:$transpose_a,
-                         DefaultValuedAttr<BoolAttr, "false">:$transpose_b);
+                         DefaultValuedAttr<BoolAttr, "false">:$transpose_b,
+                         OptionalAttr<AnyAttrOf<[
+                            TTNN_MatmulMultiCoreReuseProgramConfigAttr,
+                            TTNN_MatmulMultiCoreReuseMultiCastProgramConfigAttr,
+                            TTNN_MatmulMultiCoreReuseMultiCast1DProgramConfigAttr,
+                            TTNN_MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr
+                         ]>>:$matmul_program_config);
 
     let results = (outs AnyRankedTensor:$result);
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h
@@ -46,4 +46,25 @@ inline bool isMeshDeviceTensor(TensorMeshShardingAttr tensorMeshSharding) {
 #define GET_ATTRDEF_CLASSES
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrDefs.h.inc"
 
+namespace mlir::tt::ttnn {
+inline void printCoordBracketStyle(::mlir::AsmPrinter &printer,
+                                   CoreCoordAttr coreCoordAttr) {
+  printer << "(" << coreCoordAttr.getX() << "," << coreCoordAttr.getY() << ")";
+}
+
+inline ::mlir::ParseResult
+parseCoordBracketStyle(::mlir::AsmParser &parser,
+                       CoreCoordAttr &coreCoordAttr) {
+  int64_t x, y;
+
+  if (parser.parseLParen() || parser.parseInteger(x) || parser.parseComma() ||
+      parser.parseInteger(y) || parser.parseRParen()) {
+    return ::mlir::failure();
+  }
+
+  coreCoordAttr = CoreCoordAttr::get(parser.getContext(), x, y);
+  return ::mlir::success();
+}
+} // namespace mlir::tt::ttnn
+
 #endif // TTMLIR_DIALECT_TTNN_IR_TTNNOPSATTRS_H

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
@@ -23,23 +23,89 @@ class TTNN_Attr<string name, string attrMnemonic, list<Trait> traits = [],
   let attrName = "ttnn." # attrMnemonic;
 }
 
-def TTNN_CoreRangeAttr : TTNN_Attr<"CoreRange", "core_range"> {
-  let summary = "TTNN grid attribute";
+def TTNN_CoreCoordAttr : TTNN_Attr<"CoreCoord", "core_coord"> {
+  let summary = "A 2D coordinate of a core in the core grid";
   let description = [{
-    TTNN grid attribute
+    Specifies a coordinate representing a specific core
+
+    Parameters:
+    - `x`: The x-coordinate in the core grid
+    - `y`: The y-coordinate in the core grid
+
+    Example:
+
+    ```mlir
+    #core = #ttnn.core_coord<3, 4>
+    ```
   }];
 
-  let parameters = (ins ArrayRefParameter<"int64_t">:$offset,
-                        ArrayRefParameter<"int64_t">:$size);
-  let assemblyFormat = "`<` custom<DimensionList>($offset) `,` custom<DimensionList>($size) `>`";
+  let parameters = (ins "uint64_t":$x, "uint64_t":$y);
+  let assemblyFormat = "`<` params `>`";
+}
+
+def TTNN_CoreRangeAttr: TTNN_Attr<"CoreRange", "core_range"> {
+  let summary = "A range of cores in the core grid";
+  let description = [{
+    Defines a range of cores in the core grid.
+
+    Parameters:
+    - `start_coord`: Lower-left corner of the core range
+    - `end_coord`: Upper-right corner of the core range
+
+    Constraints:
+    - The condition `start_coord` <= `end_coord` must be satisfied
+
+    Example:
+
+    ```mlir
+    // Define a core range spanning from (1,1) to (3,4)
+    // This represents a 3x4 rectangular grid of cores
+    #core_range = #ttnn.core_range<(1, 1), (3, 4)>
+    ```
+  }];
+
+  let parameters = (ins "CoreCoordAttr":$start_coord, "CoreCoordAttr":$end_coord);
+  let assemblyFormat = "`<` custom<CoordBracketStyle>($start_coord) `,` custom<CoordBracketStyle>($end_coord) `>`";
 
   let extraClassDeclaration = [{
-      static CoreRangeAttr get(::mlir::MLIRContext *context, ::mlir::tt::GridAttr grid, SmallVector<int64_t> offset = {0, 0})
-      {
-        assert(grid.getShape().size() == 2 && "Grid shape must be 2D for now");
-        return CoreRangeAttr::get(context, {0, 0}, grid.getShape());
-      }
+    bool intersects(CoreRangeAttr other) const;
   }];
+
+  let genVerifyDecl = 1;
+}
+
+def TTNN_CoreRangeSetAttr: TTNN_Attr<"CoreRangeSet", "core_range_set"> {
+  let summary = "Represents a set of core ranges in the core grid";
+  let description = [{
+    Defines a collection of core ranges within the core grid.
+    No two core ranges in the set should intersect.
+
+    Parameters:
+    - `core_ranges`: An array of core ranges
+
+    Constraints:
+    - The set must contain non-intersecting core ranges
+    - Can be empty (no ranges)
+
+    Example:
+
+    ```mlir
+    // Define empty core range set
+    #empty_core_range_set = #ttnn.core_range_set<>
+
+    // Define three non-intersecting core ranges
+    #core_range_set = #ttnn.core_range_set<[
+      #ttnn.core_range<(0, 0), (2, 2)>,
+      #ttnn.core_range<(3, 3), (5, 5)>,
+      #ttnn.core_range<(6, 0), (7, 4)>
+    ]>
+    ```
+  }];
+
+  let parameters = (ins OptionalArrayRefParameter<"CoreRangeAttr">:$core_ranges);
+  let assemblyFormat = "`<` (`[` qualified($core_ranges)^ `]`)? `>`";
+
+  let genVerifyDecl = 1;
 }
 
 def TTNN_LayoutAttr : EnumAttr<TTNN_Dialect, TTNN_Layout, "layout"> {
@@ -94,6 +160,211 @@ def TTNN_MemoryConfigAttr : TTNN_Attr<"MemoryConfig", "memory_config"> {
   }];
 
   let genVerifyDecl = 1;
+}
+
+def UnaryWithParamAttr : TTNN_Attr<"UnaryWithParam", "unary_with_param"> {
+  let summary = "A unary operation with parameters";
+  let description = [{
+    Defines a unary operation with additional parameters, used
+    for fused activations.
+
+    Parameters:
+    - `op_type`: Type of unary operation
+    - `params`: Optional parameters
+
+    Example:
+
+    ```mlir
+    // Unary operation with no parameters
+    #unary_witout_params = #ttnn.unary_with_param<op_type = relu>
+
+    // Unary operation with parameters
+    #unary_with_params = #ttnn.unary_with_param<op_type = add_unary_sfpu, params = [1.0 : f32]>
+    ```
+  }];
+
+  let parameters = (ins "UnaryOpType":$op_type,
+                        OptionalArrayRefParameter<"FloatAttr">:$params);
+
+  let assemblyFormat = "`<` `op_type` `=` qualified($op_type) (`,` `params` `=` `[` $params^ `]`)? `>`";
+}
+
+def TTNN_MatmulMultiCoreReuseProgramConfigAttr : TTNN_Attr<"MatmulMultiCoreReuseProgramConfig", "matmul_multi_core_reuse_program_config"> {
+  let summary = "TTNN MatmulMultiCoreReuseProgramConfig";
+  let description = [{
+    TTNN MatmulMultiCoreReuseProgramConfig
+
+    Example:
+
+    ```mlir
+    #matmul_program_config = #ttnn.matmul_multi_core_reuse_program_config<
+      compute_with_storage_grid_size = #ttnn.core_coord<7, 9>,
+      in0_block_w = 8,
+      out_subblock_h = 1,
+      out_subblock_w = 8,
+      per_core_m = 8,
+      per_core_n = 8
+    >
+    ```
+  }];
+
+  let parameters = (ins "CoreCoordAttr":$compute_with_storage_grid_size,
+                        "uint64_t":$in0_block_w,
+                        "uint64_t":$out_subblock_h,
+                        "uint64_t":$out_subblock_w,
+                        "uint64_t":$per_core_m,
+                        "uint64_t":$per_core_n);
+
+  let assemblyFormat = [{
+    `<` struct(
+      qualified($compute_with_storage_grid_size),
+      $in0_block_w,
+      $out_subblock_h,
+      $out_subblock_w,
+      $per_core_m,
+      $per_core_n
+    ) `>`
+  }];
+}
+
+def TTNN_MatmulMultiCoreReuseMultiCastProgramConfigAttr : TTNN_Attr<"MatmulMultiCoreReuseMultiCastProgramConfig", "matmul_multi_core_reuse_multi_cast_program_config"> {
+  let summary = "TTNN MatmulMultiCoreReuseMultiCastProgramConfig";
+  let description = [{
+    TTNN MatmulMultiCoreReuseMultiCastProgramConfig
+
+    Example:
+
+    ```mlir
+    #matmul_program_config = #ttnn.matmul_multi_core_reuse_multi_cast_program_config<
+      compute_with_storage_grid_size = #ttnn.core_coord<8, 8>,
+      in0_block_w = 16,
+      out_subblock_h = 2,
+      out_subblock_w = 4,
+      out_block_h = 2,
+      out_block_w = 4,
+      per_core_m = 2,
+      per_core_n = 4,
+      transpose_mcast = true,
+      fused_activation = #ttnn.unary_with_param<op_type = relu>,
+      fuse_batch = true
+    >
+    ```
+  }];
+
+  let parameters = (ins "CoreCoordAttr":$compute_with_storage_grid_size,
+                        "uint64_t":$in0_block_w,
+                        "uint64_t":$out_subblock_h,
+                        "uint64_t":$out_subblock_w,
+                        "uint64_t":$out_block_h,
+                        "uint64_t":$out_block_w,
+                        "uint64_t":$per_core_m,
+                        "uint64_t":$per_core_n,
+                        "bool":$transpose_mcast,
+                        OptionalParameter<"UnaryWithParamAttr">:$fused_activation,
+                        "bool":$fuse_batch);
+
+  let assemblyFormat = [{
+    `<` struct(
+      qualified($compute_with_storage_grid_size),
+      $in0_block_w,
+      $out_subblock_h,
+      $out_subblock_w,
+      $out_block_h,
+      $out_block_w,
+      $per_core_m,
+      $per_core_n,
+      $transpose_mcast,
+      qualified($fused_activation),
+      $fuse_batch
+    ) `>`
+  }];
+}
+
+def TTNN_MatmulMultiCoreReuseMultiCast1DProgramConfigAttr : TTNN_Attr<"MatmulMultiCoreReuseMultiCast1DProgramConfig", "matmul_multi_core_reuse_multi_cast_1d_program_config"> {
+  let summary = "TTNN MatmulMultiCoreReuseMultiCast1DProgramConfig";
+  let description = [{
+    TTNN MatmulMultiCoreReuseMultiCast1DProgramConfig
+
+    Example:
+
+    ```mlir
+    #matmul_program_config = #ttnn.matmul_multi_core_reuse_multi_cast_1d_program_config<
+      compute_with_storage_grid_size = #ttnn.core_coord<8, 2>,
+      in0_block_w = 32,
+      out_subblock_h = 1,
+      out_subblock_w = 2,
+      out_block_h = 8,
+      out_block_w = 6,
+      per_core_m = 8,
+      per_core_n = 6,
+      fuse_batch = true,
+      fused_activation = #ttnn.unary_with_param<op_type = add_unary_sfpu, params = [1.0 : f32]>,
+      mcast_in0 = true,
+      gather_in0 = false,
+      hop_cores = #ttnn.core_range_set<>,
+      num_global_cb_receivers = 0
+    >
+    ```
+  }];
+
+  let parameters = (ins "CoreCoordAttr":$compute_with_storage_grid_size,
+                        "uint64_t":$in0_block_w,
+                        "uint64_t":$out_subblock_h,
+                        "uint64_t":$out_subblock_w,
+                        "uint64_t":$out_block_h,
+                        "uint64_t":$out_block_w,
+                        "uint64_t":$per_core_m,
+                        "uint64_t":$per_core_n,
+                        "bool":$fuse_batch,
+                        OptionalParameter<"UnaryWithParamAttr">:$fused_activation,
+                        "bool":$mcast_in0,
+                        "bool":$gather_in0,
+                        "CoreRangeSetAttr":$hop_cores,
+                        "uint64_t":$num_global_cb_receivers);
+
+  let assemblyFormat = [{
+    `<` struct(
+      qualified($compute_with_storage_grid_size),
+      $in0_block_w,
+      $out_subblock_h,
+      $out_subblock_w,
+      $out_block_h,
+      $out_block_w,
+      $per_core_m,
+      $per_core_n,
+      $fuse_batch,
+      qualified($fused_activation),
+      $mcast_in0,
+      $gather_in0,
+      qualified($hop_cores),
+      $num_global_cb_receivers
+    ) `>`
+  }];
+}
+
+def TTNN_MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr : TTNN_Attr<"MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig", "matmul_multi_core_reuse_multi_cast_dram_sharded_program_config"> {
+  let summary = "TTNN MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig";
+  let description = [{
+    TTNN MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig
+
+    Example:
+
+    ```mlir
+    #matmul_program_config = #ttnn.matmul_multi_core_reuse_multi_cast_dram_sharded_program_config<
+      in0_block_w = 1,
+      per_core_m = 1,
+      per_core_n = 5,
+      fused_activation = #ttnn.unary_with_param<op_type = relu>
+    >
+    ```
+  }];
+
+  let parameters = (ins "uint64_t":$in0_block_w,
+                        "uint64_t":$per_core_m,
+                        "uint64_t":$per_core_n,
+                        OptionalParameter<"UnaryWithParamAttr">:$fused_activation);
+
+  let assemblyFormat = "`<` struct($in0_block_w, $per_core_m, $per_core_n, qualified($fused_activation)) `>`";
 }
 
 def TTNN_Conv2dConfigAttr : TTNN_Attr<"Conv2dConfig", "conv2d_config"> {

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsEnums.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsEnums.td
@@ -77,4 +77,172 @@ def TTNN_ReduceType: I32EnumAttr<"ReduceType", "TTNN Reduce Operation Type",
   let cppNamespace = "::mlir::tt::ttnn::operations::reduction";
 }
 
+def TTNN_UnaryOpType_Exp  : I32EnumAttrCase<"Exp", 0, "exp">;
+def TTNN_UnaryOpType_Recip  : I32EnumAttrCase<"Recip", 1, "recip">;
+def TTNN_UnaryOpType_Gelu  : I32EnumAttrCase<"Gelu", 2, "gelu">;
+def TTNN_UnaryOpType_Relu  : I32EnumAttrCase<"Relu", 3, "relu">;
+def TTNN_UnaryOpType_Sqrt  : I32EnumAttrCase<"Sqrt", 4, "sqrt">;
+def TTNN_UnaryOpType_Sigmoid  : I32EnumAttrCase<"Sigmoid", 5, "sigmoid">;
+def TTNN_UnaryOpType_Log  : I32EnumAttrCase<"Log", 6, "log">;
+def TTNN_UnaryOpType_Tanh  : I32EnumAttrCase<"Tanh", 7, "tanh">;
+def TTNN_UnaryOpType_Log2  : I32EnumAttrCase<"Log2", 8, "log2">;
+def TTNN_UnaryOpType_Log10  : I32EnumAttrCase<"Log10", 9, "log10">;
+def TTNN_UnaryOpType_Sin  : I32EnumAttrCase<"Sin", 10, "sin">;
+def TTNN_UnaryOpType_Cos  : I32EnumAttrCase<"Cos", 11, "cos">;
+def TTNN_UnaryOpType_Abs  : I32EnumAttrCase<"Abs", 12, "abs">;
+def TTNN_UnaryOpType_AbsInt32  : I32EnumAttrCase<"AbsInt32", 13, "abs_int32">;
+def TTNN_UnaryOpType_Sign  : I32EnumAttrCase<"Sign", 14, "sign">;
+def TTNN_UnaryOpType_Square  : I32EnumAttrCase<"Square", 15, "square">;
+def TTNN_UnaryOpType_Eqz  : I32EnumAttrCase<"Eqz", 16, "eqz">;
+def TTNN_UnaryOpType_Nez  : I32EnumAttrCase<"Nez", 17, "nez">;
+def TTNN_UnaryOpType_Gtz  : I32EnumAttrCase<"Gtz", 18, "gtz">;
+def TTNN_UnaryOpType_Ltz  : I32EnumAttrCase<"Ltz", 19, "ltz">;
+def TTNN_UnaryOpType_Gez  : I32EnumAttrCase<"Gez", 20, "gez">;
+def TTNN_UnaryOpType_Lez  : I32EnumAttrCase<"Lez", 21, "Lez">;
+def TTNN_UnaryOpType_ReluMax  : I32EnumAttrCase<"ReluMax", 22, "relu_max">;
+def TTNN_UnaryOpType_ReluMin  : I32EnumAttrCase<"ReluMin", 23, "relu_min">;
+def TTNN_UnaryOpType_Power  : I32EnumAttrCase<"Power", 24, "power">;
+def TTNN_UnaryOpType_LeakyRelu  : I32EnumAttrCase<"LeakyRelu", 25, "leaky_relu">;
+def TTNN_UnaryOpType_Elu  : I32EnumAttrCase<"Elu", 26, "elu">;
+def TTNN_UnaryOpType_Exp2  : I32EnumAttrCase<"Exp2", 27, "exp2">;
+def TTNN_UnaryOpType_Heaviside  : I32EnumAttrCase<"Heaviside", 28, "heaviside">;
+def TTNN_UnaryOpType_Expm1  : I32EnumAttrCase<"Expm1", 29, "expm1">;
+def TTNN_UnaryOpType_Signbit  : I32EnumAttrCase<"Signbit", 30, "signbit">;
+def TTNN_UnaryOpType_Asin  : I32EnumAttrCase<"Asin", 31, "asin">;
+def TTNN_UnaryOpType_Acos  : I32EnumAttrCase<"Acos", 32, "acos">;
+def TTNN_UnaryOpType_Rsqrt  : I32EnumAttrCase<"Rsqrt", 33, "rsqrt">;
+def TTNN_UnaryOpType_Relu6  : I32EnumAttrCase<"Relu6", 34, "relu6">;
+def TTNN_UnaryOpType_Atan  : I32EnumAttrCase<"Atan", 35, "atan">;
+def TTNN_UnaryOpType_Erf  : I32EnumAttrCase<"Erf", 36, "erf">;
+def TTNN_UnaryOpType_Erfc  : I32EnumAttrCase<"Erfc", 37, "erfc">;
+def TTNN_UnaryOpType_IsInf  : I32EnumAttrCase<"IsInf", 38, "is_inf">;
+def TTNN_UnaryOpType_IsPosInf  : I32EnumAttrCase<"IsPosInf", 39, "is_pos_inf">;
+def TTNN_UnaryOpType_IsNegInf  : I32EnumAttrCase<"IsNegInf", 40, "is_neg_inf">;
+def TTNN_UnaryOpType_IsNan  : I32EnumAttrCase<"IsNan", 41, "is_nan">;
+def TTNN_UnaryOpType_LogicalNotUnary  : I32EnumAttrCase<"LogicalNotUnary", 42, "logical_not_unary">;
+def TTNN_UnaryOpType_IsFinite  : I32EnumAttrCase<"IsFinite", 43, "is_finite">;
+def TTNN_UnaryOpType_Erfinv  : I32EnumAttrCase<"Erfinv", 44, "erfinv">;
+def TTNN_UnaryOpType_I0  : I32EnumAttrCase<"I0", 45, "i0">;
+def TTNN_UnaryOpType_I1  : I32EnumAttrCase<"I1", 46, "i1">;
+def TTNN_UnaryOpType_Tan  : I32EnumAttrCase<"Tan", 47, "tan">;
+def TTNN_UnaryOpType_Rsub  : I32EnumAttrCase<"Rsub", 48, "rsub">;
+def TTNN_UnaryOpType_Rdiv  : I32EnumAttrCase<"Rdiv", 49, "rdiv">;
+def TTNN_UnaryOpType_Silu  : I32EnumAttrCase<"Silu", 50, "silu">;
+def TTNN_UnaryOpType_SoftPlus  : I32EnumAttrCase<"SoftPlus", 51, "soft_plus">;
+def TTNN_UnaryOpType_Identity  : I32EnumAttrCase<"Identity", 52, "identity">;
+def TTNN_UnaryOpType_Neg  : I32EnumAttrCase<"Neg", 53, "neg">;
+def TTNN_UnaryOpType_AddUnarySfpu  : I32EnumAttrCase<"AddUnarySfpu", 54, "add_unary_sfpu">;
+def TTNN_UnaryOpType_SubUnarySfpu  : I32EnumAttrCase<"SubUnarySfpu", 55, "sub_unary_sfpu">;
+def TTNN_UnaryOpType_MulUnarySfpu  : I32EnumAttrCase<"MulUnarySfpu", 56, "mul_unary_sfpu">;
+def TTNN_UnaryOpType_DivUnarySfpu  : I32EnumAttrCase<"DivUnarySfpu", 57, "div_unary_sfpu">;
+def TTNN_UnaryOpType_IdentityUint32  : I32EnumAttrCase<"IdentityUint32", 58, "identity_uint32">;
+def TTNN_UnaryOpType_UnaryNe  : I32EnumAttrCase<"UnaryNe", 59, "unary_ne">;
+def TTNN_UnaryOpType_UnaryGt  : I32EnumAttrCase<"UnaryGt", 60, "unary_gt">;
+def TTNN_UnaryOpType_UnaryLt  : I32EnumAttrCase<"UnaryLt", 61, "unary_lt">;
+def TTNN_UnaryOpType_TiledProd  : I32EnumAttrCase<"TiledProd", 62, "tiled_prod">;
+def TTNN_UnaryOpType_Typecast  : I32EnumAttrCase<"Typecast", 63, "typecast">;
+def TTNN_UnaryOpType_BitwiseXor  : I32EnumAttrCase<"BitwiseXor", 64, "bitwise_xor">;
+def TTNN_UnaryOpType_BitwiseNot  : I32EnumAttrCase<"BitwiseNot", 65, "bitwise_not">;
+def TTNN_UnaryOpType_BitwiseAnd  : I32EnumAttrCase<"BitwiseAnd", 66, "bitwise_and">;
+def TTNN_UnaryOpType_BitwiseOr  : I32EnumAttrCase<"BitwiseOr", 67, "bitwise_or">;
+def TTNN_UnaryOpType_RightShift  : I32EnumAttrCase<"RightShift", 68, "right_shift">;
+def TTNN_UnaryOpType_Floor  : I32EnumAttrCase<"Floor", 69, "floor">;
+def TTNN_UnaryOpType_FloorFloat32  : I32EnumAttrCase<"FloorFloat32", 70, "floor_float32">;
+def TTNN_UnaryOpType_Ceil  : I32EnumAttrCase<"Ceil", 71, "ceil">;
+def TTNN_UnaryOpType_CeilFloat32  : I32EnumAttrCase<"CeilFloat32", 72, "ceil_float32">;
+def TTNN_UnaryOpType_LeftShift  : I32EnumAttrCase<"LeftShift", 73, "left_shift">;
+def TTNN_UnaryOpType_Remainder  : I32EnumAttrCase<"Remainder", 74, "remainder">;
+def TTNN_UnaryOpType_Fmod  : I32EnumAttrCase<"Fmod", 75, "fmod">;
+def TTNN_UnaryOpType_Dropout  : I32EnumAttrCase<"Dropout", 76, "dropout">;
+def TTNN_UnaryOpType_Fill  : I32EnumAttrCase<"Fill", 77, "fill">;
+def TTNN_UnaryOpType_PreluSfpu  : I32EnumAttrCase<"PreluSfpu", 78, "prelu_sfpu">;
+def TTNN_UnaryOpType_ZeroPoint  : I32EnumAttrCase<"ZeroPoint", 79, "zero_point">;
+
+def TTNN_UnaryOpType : I32EnumAttr<"UnaryOpType", "TTNN Unary Operation Type",
+                          [
+                            TTNN_UnaryOpType_Exp,
+                            TTNN_UnaryOpType_Recip,
+                            TTNN_UnaryOpType_Gelu,
+                            TTNN_UnaryOpType_Relu,
+                            TTNN_UnaryOpType_Sqrt,
+                            TTNN_UnaryOpType_Sigmoid,
+                            TTNN_UnaryOpType_Log,
+                            TTNN_UnaryOpType_Tanh,
+                            TTNN_UnaryOpType_Log2,
+                            TTNN_UnaryOpType_Log10,
+                            TTNN_UnaryOpType_Sin,
+                            TTNN_UnaryOpType_Cos,
+                            TTNN_UnaryOpType_Abs,
+                            TTNN_UnaryOpType_AbsInt32,
+                            TTNN_UnaryOpType_Sign,
+                            TTNN_UnaryOpType_Square,
+                            TTNN_UnaryOpType_Eqz,
+                            TTNN_UnaryOpType_Nez,
+                            TTNN_UnaryOpType_Gtz,
+                            TTNN_UnaryOpType_Ltz,
+                            TTNN_UnaryOpType_Gez,
+                            TTNN_UnaryOpType_Lez,
+                            TTNN_UnaryOpType_ReluMax,
+                            TTNN_UnaryOpType_ReluMin,
+                            TTNN_UnaryOpType_Power,
+                            TTNN_UnaryOpType_LeakyRelu,
+                            TTNN_UnaryOpType_Elu,
+                            TTNN_UnaryOpType_Exp2,
+                            TTNN_UnaryOpType_Heaviside,
+                            TTNN_UnaryOpType_Expm1,
+                            TTNN_UnaryOpType_Signbit,
+                            TTNN_UnaryOpType_Asin,
+                            TTNN_UnaryOpType_Acos,
+                            TTNN_UnaryOpType_Rsqrt,
+                            TTNN_UnaryOpType_Relu6,
+                            TTNN_UnaryOpType_Atan,
+                            TTNN_UnaryOpType_Erf,
+                            TTNN_UnaryOpType_Erfc,
+                            TTNN_UnaryOpType_IsInf,
+                            TTNN_UnaryOpType_IsPosInf,
+                            TTNN_UnaryOpType_IsNegInf,
+                            TTNN_UnaryOpType_IsNan,
+                            TTNN_UnaryOpType_LogicalNotUnary,
+                            TTNN_UnaryOpType_IsFinite,
+                            TTNN_UnaryOpType_Erfinv,
+                            TTNN_UnaryOpType_I0,
+                            TTNN_UnaryOpType_I1,
+                            TTNN_UnaryOpType_Tan,
+                            TTNN_UnaryOpType_Rsub,
+                            TTNN_UnaryOpType_Rdiv,
+                            TTNN_UnaryOpType_Silu,
+                            TTNN_UnaryOpType_SoftPlus,
+                            TTNN_UnaryOpType_Identity,
+                            TTNN_UnaryOpType_Neg,
+                            TTNN_UnaryOpType_AddUnarySfpu,
+                            TTNN_UnaryOpType_SubUnarySfpu,
+                            TTNN_UnaryOpType_MulUnarySfpu,
+                            TTNN_UnaryOpType_DivUnarySfpu,
+                            TTNN_UnaryOpType_IdentityUint32,
+                            TTNN_UnaryOpType_UnaryNe,
+                            TTNN_UnaryOpType_UnaryGt,
+                            TTNN_UnaryOpType_UnaryLt,
+                            TTNN_UnaryOpType_TiledProd,
+                            TTNN_UnaryOpType_Typecast,
+                            TTNN_UnaryOpType_BitwiseXor,
+                            TTNN_UnaryOpType_BitwiseNot,
+                            TTNN_UnaryOpType_BitwiseAnd,
+                            TTNN_UnaryOpType_BitwiseOr,
+                            TTNN_UnaryOpType_RightShift,
+                            TTNN_UnaryOpType_Floor,
+                            TTNN_UnaryOpType_FloorFloat32,
+                            TTNN_UnaryOpType_Ceil,
+                            TTNN_UnaryOpType_CeilFloat32,
+                            TTNN_UnaryOpType_LeftShift,
+                            TTNN_UnaryOpType_Remainder,
+                            TTNN_UnaryOpType_Fmod,
+                            TTNN_UnaryOpType_Dropout,
+                            TTNN_UnaryOpType_Fill,
+                            TTNN_UnaryOpType_PreluSfpu,
+                            TTNN_UnaryOpType_ZeroPoint
+                          ]> {
+  let genSpecializedAttr = 0;
+  let cppNamespace = "::mlir::tt::ttnn";
+}
+
 #endif

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -322,6 +322,7 @@ table MatmulOp {
   out: tt.target.ttnn.TensorRef;
   transpose_a: bool;
   transpose_b: bool;
+  matmul_program_config: tt.target.ttnn.MatmulProgramConfig;
 }
 // ANCHOR_END: adding_an_op_matmul_fbs
 

--- a/include/ttmlir/Target/TTNN/types.fbs
+++ b/include/ttmlir/Target/TTNN/types.fbs
@@ -30,6 +30,20 @@ enum MeshShardType: uint32 {
   Devices,
 }
 
+struct CoreCoord {
+  x: uint64;
+  y: uint64;
+}
+
+struct CoreRange {
+  start_coord: CoreCoord;
+  end_coord: CoreCoord;
+}
+
+table CoreRangeSet {
+  core_ranges: [CoreRange];
+}
+
 table ReplicateTensor {
   replication_factor: uint32;
 }
@@ -87,6 +101,148 @@ table Conv2dConfig {
   enable_weights_double_buffer: bool;
   enable_split_reader: bool;
   enable_subblock_padding: bool;
+}
+
+enum UnaryOpType: uint32 {
+  Exp,
+  Recip,
+  Gelu,
+  Relu,
+  Sqrt,
+  Sigmoid,
+  Log,
+  Tanh,
+  Log2,
+  Log10,
+  Sin,
+  Cos,
+  Abs,
+  AbsInt32,
+  Sign,
+  Square,
+  Eqz,
+  Nez,
+  Gtz,
+  Ltz,
+  Gez,
+  Lez,
+  ReluMax,
+  ReluMin,
+  Power,
+  LeakyRelu,
+  Elu,
+  Exp2,
+  Heaviside,
+  Expm1,
+  Signbit,
+  Asin,
+  Acos,
+  Rsqrt,
+  Relu6,
+  Atan,
+  Erf,
+  Erfc,
+  Isinf,
+  Isposinf,
+  Isneginf,
+  Isnan,
+  LogicalNotUnary,
+  Isfinite,
+  Erfinv,
+  I0,
+  I1,
+  Tan,
+  Rsub,
+  Rdiv,
+  Silu,
+  Softplus,
+  Identity,
+  Neg,
+  AddUnarySfpu,
+  SubUnarySfpu,
+  MulUnarySfpu,
+  DivUnarySfpu,
+  IdentityUint32,
+  UnaryNe,
+  UnaryGt,
+  UnaryLt,
+  TiledProd,
+  Typecast,
+  BitwiseXor,
+  BitwiseNot,
+  BitwiseAnd,
+  BitwiseOr,
+  RightShift,
+  Floor,
+  FloorFloat32,
+  Ceil,
+  CeilFloat32,
+  LeftShift,
+  Remainder,
+  Fmod,
+  Dropout,
+  Fill,
+  PreluSfpu,
+  ZeroPoint
+}
+
+table UnaryWithParam {
+  op_type: UnaryOpType;
+  params: [double];
+}
+
+table MatmulMultiCoreReuseProgramConfig {
+  compute_with_storage_grid_size: CoreCoord;
+  in0_block_w: uint64;
+  out_subblock_h: uint64;
+  out_subblock_w: uint64;
+  per_core_m: uint64;
+  per_core_n: uint64;
+}
+
+table MatmulMultiCoreReuseMultiCastProgramConfig {
+  compute_with_storage_grid_size: CoreCoord;
+  in0_block_w: uint64;
+  out_subblock_h: uint64;
+  out_subblock_w: uint64;
+  out_block_h: uint64;
+  out_block_w: uint64;
+  per_core_m: uint64;
+  per_core_n: uint64;
+  transpose_mcast: bool;
+  fused_activation: UnaryWithParam;
+  fuse_batch: bool;
+}
+
+table MatmulMultiCoreReuseMultiCast1DProgramConfig {
+  compute_with_storage_grid_size: CoreCoord;
+  in0_block_w: uint64;
+  out_subblock_h: uint64;
+  out_subblock_w: uint64;
+  out_block_h: uint64;
+  out_block_w: uint64;
+  per_core_m: uint64;
+  per_core_n: uint64;
+  fuse_batch: bool;
+  fused_activation: UnaryWithParam;
+  mcast_in0: bool;
+  gather_in0: bool;
+  hop_cores: CoreRangeSet;
+  num_global_cb_receivers: uint64;
+}
+
+table MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig {
+  in0_block_w: uint64;
+  per_core_m: uint64;
+  per_core_n: uint64;
+  fused_activation: UnaryWithParam;
+}
+
+union MatmulProgramConfig {
+  MatmulMultiCoreReuseProgramConfig,
+  MatmulMultiCoreReuseMultiCastProgramConfig,
+  MatmulMultiCoreReuseMultiCast1DProgramConfig,
+  MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig
 }
 
 table MemoryDesc {

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -426,6 +426,207 @@ toDebugInfo(::flatbuffers::FlatBufferBuilder &fbb, std::string const &name,
 
   return ::tt::target::CreateMLIRDirect(fbb, name.c_str(), source.c_str());
 }
+
+inline double toFlatbuffer(FlatbufferObjectCache &, mlir::FloatAttr attr) {
+  return attr.getValueAsDouble();
+}
+
+inline ::tt::target::ttnn::CoreCoord
+toFlatbuffer(FlatbufferObjectCache &cache, ttnn::CoreCoordAttr coreCoordAttr) {
+  return ::tt::target::ttnn::CoreCoord(coreCoordAttr.getX(),
+                                       coreCoordAttr.getY());
+}
+
+inline ::tt::target::ttnn::CoreRange
+toFlatbuffer(FlatbufferObjectCache &cache, ttnn::CoreRangeAttr coreRangeAttr) {
+  return ::tt::target::ttnn::CoreRange(
+      toFlatbuffer(cache, coreRangeAttr.getStartCoord()),
+      toFlatbuffer(cache, coreRangeAttr.getEndCoord()));
+}
+
+inline ::flatbuffers::Offset<::tt::target::ttnn::CoreRangeSet>
+toFlatbuffer(FlatbufferObjectCache &cache,
+             ttnn::CoreRangeSetAttr coreRangeSetAttr) {
+  return ::tt::target::ttnn::CreateCoreRangeSet(
+      *cache.fbb, toFlatbuffer(cache, coreRangeSetAttr.getCoreRanges()));
+}
+
+inline ::tt::target::ttnn::UnaryOpType
+toFlatbuffer(FlatbufferObjectCache &, ttnn::UnaryOpType unaryOpType) {
+  using MlirUnaryOpType = ::mlir::tt::ttnn::UnaryOpType;
+  using FbUnaryOpType = ::tt::target::ttnn::UnaryOpType;
+
+  static const std::unordered_map<MlirUnaryOpType, FbUnaryOpType> opTypeMap = {
+      {MlirUnaryOpType::Exp, FbUnaryOpType::Exp},
+      {MlirUnaryOpType::Recip, FbUnaryOpType::Recip},
+      {MlirUnaryOpType::Gelu, FbUnaryOpType::Gelu},
+      {MlirUnaryOpType::Relu, FbUnaryOpType::Relu},
+      {MlirUnaryOpType::Sqrt, FbUnaryOpType::Sqrt},
+      {MlirUnaryOpType::Sigmoid, FbUnaryOpType::Sigmoid},
+      {MlirUnaryOpType::Log, FbUnaryOpType::Log},
+      {MlirUnaryOpType::Tanh, FbUnaryOpType::Tanh},
+      {MlirUnaryOpType::Log2, FbUnaryOpType::Log2},
+      {MlirUnaryOpType::Log10, FbUnaryOpType::Log10},
+      {MlirUnaryOpType::Sin, FbUnaryOpType::Sin},
+      {MlirUnaryOpType::Cos, FbUnaryOpType::Cos},
+      {MlirUnaryOpType::Abs, FbUnaryOpType::Abs},
+      {MlirUnaryOpType::AbsInt32, FbUnaryOpType::AbsInt32},
+      {MlirUnaryOpType::Sign, FbUnaryOpType::Sign},
+      {MlirUnaryOpType::Square, FbUnaryOpType::Square},
+      {MlirUnaryOpType::Eqz, FbUnaryOpType::Eqz},
+      {MlirUnaryOpType::Nez, FbUnaryOpType::Nez},
+      {MlirUnaryOpType::Gtz, FbUnaryOpType::Gtz},
+      {MlirUnaryOpType::Ltz, FbUnaryOpType::Ltz},
+      {MlirUnaryOpType::Gez, FbUnaryOpType::Gez},
+      {MlirUnaryOpType::Lez, FbUnaryOpType::Lez},
+      {MlirUnaryOpType::ReluMax, FbUnaryOpType::ReluMax},
+      {MlirUnaryOpType::ReluMin, FbUnaryOpType::ReluMin},
+      {MlirUnaryOpType::Power, FbUnaryOpType::Power},
+      {MlirUnaryOpType::LeakyRelu, FbUnaryOpType::LeakyRelu},
+      {MlirUnaryOpType::Elu, FbUnaryOpType::Elu},
+      {MlirUnaryOpType::Exp2, FbUnaryOpType::Exp2},
+      {MlirUnaryOpType::Heaviside, FbUnaryOpType::Heaviside},
+      {MlirUnaryOpType::Expm1, FbUnaryOpType::Expm1},
+      {MlirUnaryOpType::Signbit, FbUnaryOpType::Signbit},
+      {MlirUnaryOpType::Asin, FbUnaryOpType::Asin},
+      {MlirUnaryOpType::Acos, FbUnaryOpType::Acos},
+      {MlirUnaryOpType::Rsqrt, FbUnaryOpType::Rsqrt},
+      {MlirUnaryOpType::Relu6, FbUnaryOpType::Relu6},
+      {MlirUnaryOpType::Atan, FbUnaryOpType::Atan},
+      {MlirUnaryOpType::Erf, FbUnaryOpType::Erf},
+      {MlirUnaryOpType::Erfc, FbUnaryOpType::Erfc},
+      {MlirUnaryOpType::IsInf, FbUnaryOpType::Isinf},
+      {MlirUnaryOpType::IsPosInf, FbUnaryOpType::Isposinf},
+      {MlirUnaryOpType::IsNegInf, FbUnaryOpType::Isneginf},
+      {MlirUnaryOpType::IsNan, FbUnaryOpType::Isnan},
+      {MlirUnaryOpType::LogicalNotUnary, FbUnaryOpType::LogicalNotUnary},
+      {MlirUnaryOpType::IsFinite, FbUnaryOpType::Isfinite},
+      {MlirUnaryOpType::Erfinv, FbUnaryOpType::Erfinv},
+      {MlirUnaryOpType::I0, FbUnaryOpType::I0},
+      {MlirUnaryOpType::I1, FbUnaryOpType::I1},
+      {MlirUnaryOpType::Tan, FbUnaryOpType::Tan},
+      {MlirUnaryOpType::Rsub, FbUnaryOpType::Rsub},
+      {MlirUnaryOpType::Rdiv, FbUnaryOpType::Rdiv},
+      {MlirUnaryOpType::Silu, FbUnaryOpType::Silu},
+      {MlirUnaryOpType::SoftPlus, FbUnaryOpType::Softplus},
+      {MlirUnaryOpType::Identity, FbUnaryOpType::Identity},
+      {MlirUnaryOpType::Neg, FbUnaryOpType::Neg},
+      {MlirUnaryOpType::AddUnarySfpu, FbUnaryOpType::AddUnarySfpu},
+      {MlirUnaryOpType::SubUnarySfpu, FbUnaryOpType::SubUnarySfpu},
+      {MlirUnaryOpType::MulUnarySfpu, FbUnaryOpType::MulUnarySfpu},
+      {MlirUnaryOpType::DivUnarySfpu, FbUnaryOpType::DivUnarySfpu},
+      {MlirUnaryOpType::IdentityUint32, FbUnaryOpType::IdentityUint32},
+      {MlirUnaryOpType::UnaryNe, FbUnaryOpType::UnaryNe},
+      {MlirUnaryOpType::UnaryGt, FbUnaryOpType::UnaryGt},
+      {MlirUnaryOpType::UnaryLt, FbUnaryOpType::UnaryLt},
+      {MlirUnaryOpType::TiledProd, FbUnaryOpType::TiledProd},
+      {MlirUnaryOpType::Typecast, FbUnaryOpType::Typecast},
+      {MlirUnaryOpType::BitwiseXor, FbUnaryOpType::BitwiseXor},
+      {MlirUnaryOpType::BitwiseNot, FbUnaryOpType::BitwiseNot},
+      {MlirUnaryOpType::BitwiseAnd, FbUnaryOpType::BitwiseAnd},
+      {MlirUnaryOpType::BitwiseOr, FbUnaryOpType::BitwiseOr},
+      {MlirUnaryOpType::RightShift, FbUnaryOpType::RightShift},
+      {MlirUnaryOpType::Floor, FbUnaryOpType::Floor},
+      {MlirUnaryOpType::FloorFloat32, FbUnaryOpType::FloorFloat32},
+      {MlirUnaryOpType::Ceil, FbUnaryOpType::Ceil},
+      {MlirUnaryOpType::CeilFloat32, FbUnaryOpType::CeilFloat32},
+      {MlirUnaryOpType::LeftShift, FbUnaryOpType::LeftShift},
+      {MlirUnaryOpType::Remainder, FbUnaryOpType::Remainder},
+      {MlirUnaryOpType::Fmod, FbUnaryOpType::Fmod},
+      {MlirUnaryOpType::Dropout, FbUnaryOpType::Dropout},
+      {MlirUnaryOpType::Fill, FbUnaryOpType::Fill},
+      {MlirUnaryOpType::PreluSfpu, FbUnaryOpType::PreluSfpu},
+      {MlirUnaryOpType::ZeroPoint, FbUnaryOpType::ZeroPoint}};
+
+  auto it = opTypeMap.find(unaryOpType);
+  if (it != opTypeMap.end()) {
+    return it->second;
+  }
+
+  llvm_unreachable("Unsupported unary op type");
+}
+
+inline ::flatbuffers::Offset<
+    ::tt::target::ttnn::MatmulMultiCoreReuseProgramConfig>
+toFlatbuffer(FlatbufferObjectCache &cache,
+             ttnn::MatmulMultiCoreReuseProgramConfigAttr matmulConfigAttr) {
+  ::tt::target::ttnn::CoreCoord computeWithStorageGridSize =
+      toFlatbuffer(cache, matmulConfigAttr.getComputeWithStorageGridSize());
+  return ::tt::target::ttnn::CreateMatmulMultiCoreReuseProgramConfig(
+      *cache.fbb, &computeWithStorageGridSize, matmulConfigAttr.getIn0BlockW(),
+      matmulConfigAttr.getOutSubblockH(), matmulConfigAttr.getOutSubblockW(),
+      matmulConfigAttr.getPerCoreM(), matmulConfigAttr.getPerCoreN());
+}
+
+inline ::flatbuffers::Offset<::tt::target::ttnn::UnaryWithParam>
+toFlatbuffer(FlatbufferObjectCache &cache,
+             ttnn::UnaryWithParamAttr unaryWithParam) {
+  return ::tt::target::ttnn::CreateUnaryWithParam(
+      *cache.fbb, toFlatbuffer(cache, unaryWithParam.getOpType()),
+      toFlatbuffer(cache, unaryWithParam.getParams()));
+}
+
+inline ::flatbuffers::Offset<
+    ::tt::target::ttnn::MatmulMultiCoreReuseMultiCastProgramConfig>
+toFlatbuffer(
+    FlatbufferObjectCache &cache,
+    ttnn::MatmulMultiCoreReuseMultiCastProgramConfigAttr matmulConfigAttr) {
+  ::tt::target::ttnn::CoreCoord computeWithStorageGridSize =
+      toFlatbuffer(cache, matmulConfigAttr.getComputeWithStorageGridSize());
+  ::flatbuffers::Offset<::tt::target::ttnn::UnaryWithParam> fusedActivation;
+  if (matmulConfigAttr.getFusedActivation()) {
+    fusedActivation =
+        toFlatbuffer(cache, matmulConfigAttr.getFusedActivation());
+  }
+  return ::tt::target::ttnn::CreateMatmulMultiCoreReuseMultiCastProgramConfig(
+      *cache.fbb, &computeWithStorageGridSize, matmulConfigAttr.getIn0BlockW(),
+      matmulConfigAttr.getOutSubblockH(), matmulConfigAttr.getOutSubblockW(),
+      matmulConfigAttr.getOutBlockH(), matmulConfigAttr.getOutBlockW(),
+      matmulConfigAttr.getPerCoreM(), matmulConfigAttr.getPerCoreN(),
+      matmulConfigAttr.getTransposeMcast(), fusedActivation,
+      matmulConfigAttr.getFuseBatch());
+}
+
+inline ::flatbuffers::Offset<
+    ::tt::target::ttnn::MatmulMultiCoreReuseMultiCast1DProgramConfig>
+toFlatbuffer(
+    FlatbufferObjectCache &cache,
+    ttnn::MatmulMultiCoreReuseMultiCast1DProgramConfigAttr matmulConfigAttr) {
+  ::tt::target::ttnn::CoreCoord computeWithStorageGridSize =
+      toFlatbuffer(cache, matmulConfigAttr.getComputeWithStorageGridSize());
+  ::flatbuffers::Offset<::tt::target::ttnn::UnaryWithParam> fusedActivation;
+  if (matmulConfigAttr.getFusedActivation()) {
+    fusedActivation =
+        toFlatbuffer(cache, matmulConfigAttr.getFusedActivation());
+  }
+  return ::tt::target::ttnn::CreateMatmulMultiCoreReuseMultiCast1DProgramConfig(
+      *cache.fbb, &computeWithStorageGridSize, matmulConfigAttr.getIn0BlockW(),
+      matmulConfigAttr.getOutSubblockH(), matmulConfigAttr.getOutSubblockW(),
+      matmulConfigAttr.getOutBlockH(), matmulConfigAttr.getOutBlockW(),
+      matmulConfigAttr.getPerCoreM(), matmulConfigAttr.getPerCoreN(),
+      matmulConfigAttr.getFuseBatch(), fusedActivation,
+      matmulConfigAttr.getMcastIn0(), matmulConfigAttr.getGatherIn0(),
+      toFlatbuffer(cache, matmulConfigAttr.getHopCores()),
+      matmulConfigAttr.getNumGlobalCbReceivers());
+}
+
+inline ::flatbuffers::Offset<
+    ::tt::target::ttnn::MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig>
+toFlatbuffer(FlatbufferObjectCache &cache,
+             ttnn::MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr
+                 matmulConfigAttr) {
+  ::flatbuffers::Offset<::tt::target::ttnn::UnaryWithParam> fusedActivation;
+  if (matmulConfigAttr.getFusedActivation()) {
+    fusedActivation =
+        toFlatbuffer(cache, matmulConfigAttr.getFusedActivation());
+  }
+  return ::tt::target::ttnn::
+      CreateMatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
+          *cache.fbb, matmulConfigAttr.getIn0BlockW(),
+          matmulConfigAttr.getPerCoreM(), matmulConfigAttr.getPerCoreN(),
+          fusedActivation);
+}
+
 } // namespace mlir::tt
 
 #endif

--- a/lib/CAPI/TTNNAttrs.cpp
+++ b/lib/CAPI/TTNNAttrs.cpp
@@ -6,15 +6,17 @@
 #include "mlir/CAPI/IR.h"
 #include "mlir/CAPI/Support.h"
 
+#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 
 namespace mlir::tt::ttnn {
 
-MlirAttribute ttmlirTTNNCoreRangeAttrGet(MlirContext ctx, int64_t *offset,
-                                         size_t offsetSize, int64_t *size,
-                                         size_t sizeSize) {
-  return wrap(CoreRangeAttr::get(unwrap(ctx), {offset, offset + offsetSize},
-                                 {size, size + sizeSize}));
+MlirAttribute ttmlirTTNNCoreRangeAttrGet(MlirContext ctx,
+                                         MlirAttribute startCoord,
+                                         MlirAttribute endCoord) {
+  return wrap(CoreRangeAttr::get(unwrap(ctx),
+                                 mlir::cast<CoreCoordAttr>(unwrap(startCoord)),
+                                 mlir::cast<CoreCoordAttr>(unwrap(endCoord))));
 }
 
 MlirAttribute ttmlirTTNNCoreRangeArrayAttrGet(MlirContext ctx,

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -901,7 +901,8 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     rewriter.replaceOpWithNewOp<ttnn::MatmulOp>(
         op, this->getTypeConverter()->convertType(op.getType()), adaptor.getA(),
-        adaptor.getB(), adaptor.getTransposeA(), adaptor.getTransposeB());
+        adaptor.getB(), adaptor.getTransposeA(), adaptor.getTransposeB(),
+        nullptr);
     return success();
   }
 };

--- a/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp
@@ -557,3 +557,53 @@ MemoryConfigAttr::withMemoryLayout(::mlir::MLIRContext *context,
   // TODO(#2140): Once we complete #1628, we should add a verifier for
   // ShardSpecAttr. ShardSpecAttr is only valid if the buffer type is L1.
 }
+
+bool CoreRangeAttr::intersects(CoreRangeAttr other) const {
+  bool thisEndsBeforeOtherStarts =
+      this->getEndCoord().getX() < other.getStartCoord().getX();
+  bool thisStartsAfterOtherEnds =
+      this->getStartCoord().getX() > other.getEndCoord().getX();
+  bool thisEndsBelowOtherStarts =
+      this->getEndCoord().getY() < other.getStartCoord().getY();
+  bool thisStartsAboveOtherEnds =
+      this->getStartCoord().getY() > other.getEndCoord().getY();
+
+  return !(thisEndsBeforeOtherStarts || thisStartsAfterOtherEnds ||
+           thisEndsBelowOtherStarts || thisStartsAboveOtherEnds);
+}
+
+::llvm::LogicalResult CoreRangeAttr::verify(
+    ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
+    mlir::tt::ttnn::CoreCoordAttr startCoord,
+    mlir::tt::ttnn::CoreCoordAttr endCoord) {
+  if (startCoord.getX() > endCoord.getX() ||
+      startCoord.getY() > endCoord.getY()) {
+    return emitError() << "Start coordinates " << startCoord
+                       << " must be less than or equal to end coordinates "
+                       << endCoord;
+  }
+
+  return ::llvm::success();
+}
+
+::llvm::LogicalResult CoreRangeSetAttr::verify(
+    ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
+    llvm::ArrayRef<mlir::tt::ttnn::CoreRangeAttr> coreRanges) {
+  if (coreRanges.size() < 2) {
+    return ::llvm::success();
+  }
+
+  // Check each pair of core ranges for intersections
+  for (size_t i = 0; i < coreRanges.size() - 1; ++i) {
+    for (size_t j = i + 1; j < coreRanges.size(); ++j) {
+      CoreRangeAttr firstCoreRange = coreRanges[i];
+      CoreRangeAttr secondCoreRange = coreRanges[j];
+      if (firstCoreRange.intersects(secondCoreRange)) {
+        return emitError() << "Core ranges overlap: " << firstCoreRange
+                           << " and " << secondCoreRange;
+      }
+    }
+  }
+
+  return ::llvm::success();
+}

--- a/python/TTNNModule.cpp
+++ b/python/TTNNModule.cpp
@@ -9,34 +9,6 @@
 namespace mlir::ttmlir::python {
 void populateTTNNModule(nb::module_ &m) {
 
-  tt_attribute_class<tt::ttnn::CoreRangeAttr>(m, "CoreRangeAttr")
-      .def_static("get",
-                  [](MlirContext ctx, std::vector<int64_t> offset,
-                     std::vector<int64_t> size) {
-                    return wrap(tt::ttnn::CoreRangeAttr::get(unwrap(ctx),
-                                                             offset, size));
-                  })
-      .def_static(
-          "get_with_grid",
-          [](MlirContext ctx, MlirAttribute grid, std::vector<int64_t> offset) {
-            llvm::SmallVector<int64_t> offsetVec{0, 0};
-            if (offset.size() == 2 && not(offset[0] == 0 && offset[1] == 0)) {
-              offsetVec[0] = offset[0];
-              offsetVec[1] = offset[1];
-            }
-            return wrap(tt::ttnn::CoreRangeAttr::get(
-                unwrap(ctx), mlir::cast<tt::GridAttr>(unwrap(grid)),
-                offsetVec));
-          },
-          nb::arg("ctx"), nb::arg("grid"),
-          nb::arg("offset") = std::vector<int64_t>{0, 0})
-      .def_prop_ro(
-          "offset",
-          [](tt::ttnn::CoreRangeAttr self) { return self.getOffset().vec(); })
-      .def_prop_ro("size", [](tt::ttnn::CoreRangeAttr self) {
-        return self.getSize().vec();
-      });
-
   tt_attribute_class<tt::ttnn::LayoutAttr>(m, "LayoutAttr")
       .def_static("get",
                   [](MlirContext ctx, uint32_t layout) {

--- a/runtime/lib/ttnn/include/tt/runtime/ttnn/utils.h
+++ b/runtime/lib/ttnn/include/tt/runtime/ttnn/utils.h
@@ -46,6 +46,13 @@ CoreRangeSet
 toCoreRangeSet(const ::flatbuffers::Vector<const ::tt::target::Dim2dRange *>
                    *coreRangeSet);
 
+CoreCoord toTTNNCoreCoord(const ::tt::target::ttnn::CoreCoord &coreCoord);
+
+CoreRange toTTNNCoreRange(const tt::target::ttnn::CoreRange &coreRange);
+
+CoreRangeSet
+toTTNNCoreRangeSet(const tt::target::ttnn::CoreRangeSet &coreRangeSet);
+
 const ::tt::target::ttnn::MemoryConfig *
 getTensorRefMemoryConfig(const ::tt::target::ttnn::TensorRef *tensorRef);
 

--- a/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/utils.cpp
+++ b/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/utils.cpp
@@ -44,6 +44,205 @@ bool isTilized(const ::tt::target::ttnn::TensorRef *tensorRef) {
   }
 }
 
+::ttnn::operations::unary::UnaryOpType
+toTTNNUnaryOpType(::tt::target::ttnn::UnaryOpType unaryOpType) {
+  using FbUnaryOpType = ::tt::target::ttnn::UnaryOpType;
+  using TTNNUnaryOpType = ::ttnn::operations::unary::UnaryOpType;
+
+  static const std::unordered_map<FbUnaryOpType, TTNNUnaryOpType> opTypeMap = {
+      {FbUnaryOpType::Exp, TTNNUnaryOpType::EXP},
+      {FbUnaryOpType::Recip, TTNNUnaryOpType::RECIP},
+      {FbUnaryOpType::Gelu, TTNNUnaryOpType::GELU},
+      {FbUnaryOpType::Relu, TTNNUnaryOpType::RELU},
+      {FbUnaryOpType::Sqrt, TTNNUnaryOpType::SQRT},
+      {FbUnaryOpType::Sigmoid, TTNNUnaryOpType::SIGMOID},
+      {FbUnaryOpType::Log, TTNNUnaryOpType::LOG},
+      {FbUnaryOpType::Tanh, TTNNUnaryOpType::TANH},
+      {FbUnaryOpType::Log2, TTNNUnaryOpType::LOG2},
+      {FbUnaryOpType::Log10, TTNNUnaryOpType::LOG10},
+      {FbUnaryOpType::Sin, TTNNUnaryOpType::SIN},
+      {FbUnaryOpType::Cos, TTNNUnaryOpType::COS},
+      {FbUnaryOpType::Abs, TTNNUnaryOpType::ABS},
+      {FbUnaryOpType::AbsInt32, TTNNUnaryOpType::ABS_INT32},
+      {FbUnaryOpType::Sign, TTNNUnaryOpType::SIGN},
+      {FbUnaryOpType::Square, TTNNUnaryOpType::SQUARE},
+      {FbUnaryOpType::Eqz, TTNNUnaryOpType::EQZ},
+      {FbUnaryOpType::Nez, TTNNUnaryOpType::NEZ},
+      {FbUnaryOpType::Gtz, TTNNUnaryOpType::GTZ},
+      {FbUnaryOpType::Ltz, TTNNUnaryOpType::LTZ},
+      {FbUnaryOpType::Gez, TTNNUnaryOpType::GEZ},
+      {FbUnaryOpType::Lez, TTNNUnaryOpType::LEZ},
+      {FbUnaryOpType::ReluMax, TTNNUnaryOpType::RELU_MAX},
+      {FbUnaryOpType::ReluMin, TTNNUnaryOpType::RELU_MIN},
+      {FbUnaryOpType::Power, TTNNUnaryOpType::POWER},
+      {FbUnaryOpType::LeakyRelu, TTNNUnaryOpType::LEAKY_RELU},
+      {FbUnaryOpType::Elu, TTNNUnaryOpType::ELU},
+      {FbUnaryOpType::Exp2, TTNNUnaryOpType::EXP2},
+      {FbUnaryOpType::Heaviside, TTNNUnaryOpType::HEAVISIDE},
+      {FbUnaryOpType::Expm1, TTNNUnaryOpType::EXPM1},
+      {FbUnaryOpType::Signbit, TTNNUnaryOpType::SIGNBIT},
+      {FbUnaryOpType::Asin, TTNNUnaryOpType::ASIN},
+      {FbUnaryOpType::Acos, TTNNUnaryOpType::ACOS},
+      {FbUnaryOpType::Rsqrt, TTNNUnaryOpType::RSQRT},
+      {FbUnaryOpType::Relu6, TTNNUnaryOpType::RELU6},
+      {FbUnaryOpType::Atan, TTNNUnaryOpType::ATAN},
+      {FbUnaryOpType::Erf, TTNNUnaryOpType::ERF},
+      {FbUnaryOpType::Erfc, TTNNUnaryOpType::ERFC},
+      {FbUnaryOpType::Isinf, TTNNUnaryOpType::ISINF},
+      {FbUnaryOpType::Isposinf, TTNNUnaryOpType::ISPOSINF},
+      {FbUnaryOpType::Isneginf, TTNNUnaryOpType::ISNEGINF},
+      {FbUnaryOpType::Isnan, TTNNUnaryOpType::ISNAN},
+      {FbUnaryOpType::LogicalNotUnary, TTNNUnaryOpType::LOGICAL_NOT_UNARY},
+      {FbUnaryOpType::Isfinite, TTNNUnaryOpType::ISFINITE},
+      {FbUnaryOpType::Erfinv, TTNNUnaryOpType::ERFINV},
+      {FbUnaryOpType::I0, TTNNUnaryOpType::I0},
+      {FbUnaryOpType::I1, TTNNUnaryOpType::I1},
+      {FbUnaryOpType::Tan, TTNNUnaryOpType::TAN},
+      {FbUnaryOpType::Rsub, TTNNUnaryOpType::RSUB},
+      {FbUnaryOpType::Rdiv, TTNNUnaryOpType::RDIV},
+      {FbUnaryOpType::Silu, TTNNUnaryOpType::SILU},
+      {FbUnaryOpType::Softplus, TTNNUnaryOpType::SOFTPLUS},
+      {FbUnaryOpType::Identity, TTNNUnaryOpType::IDENTITY},
+      {FbUnaryOpType::Neg, TTNNUnaryOpType::NEG},
+      {FbUnaryOpType::AddUnarySfpu, TTNNUnaryOpType::ADD_UNARY_SFPU},
+      {FbUnaryOpType::SubUnarySfpu, TTNNUnaryOpType::SUB_UNARY_SFPU},
+      {FbUnaryOpType::MulUnarySfpu, TTNNUnaryOpType::MUL_UNARY_SFPU},
+      {FbUnaryOpType::DivUnarySfpu, TTNNUnaryOpType::DIV_UNARY_SFPU},
+      {FbUnaryOpType::IdentityUint32, TTNNUnaryOpType::IDENTITY_UINT32},
+      {FbUnaryOpType::UnaryNe, TTNNUnaryOpType::UNARY_NE},
+      {FbUnaryOpType::UnaryGt, TTNNUnaryOpType::UNARY_GT},
+      {FbUnaryOpType::UnaryLt, TTNNUnaryOpType::UNARY_LT},
+      {FbUnaryOpType::TiledProd, TTNNUnaryOpType::TILED_PROD},
+      {FbUnaryOpType::Typecast, TTNNUnaryOpType::TYPECAST},
+      {FbUnaryOpType::BitwiseXor, TTNNUnaryOpType::BITWISE_XOR},
+      {FbUnaryOpType::BitwiseNot, TTNNUnaryOpType::BITWISE_NOT},
+      {FbUnaryOpType::BitwiseAnd, TTNNUnaryOpType::BITWISE_AND},
+      {FbUnaryOpType::BitwiseOr, TTNNUnaryOpType::BITWISE_OR},
+      {FbUnaryOpType::RightShift, TTNNUnaryOpType::RIGHT_SHIFT},
+      {FbUnaryOpType::Floor, TTNNUnaryOpType::FLOOR},
+      {FbUnaryOpType::FloorFloat32, TTNNUnaryOpType::FLOOR_FLOAT32},
+      {FbUnaryOpType::Ceil, TTNNUnaryOpType::CEIL},
+      {FbUnaryOpType::CeilFloat32, TTNNUnaryOpType::CEIL_FLOAT32},
+      {FbUnaryOpType::LeftShift, TTNNUnaryOpType::LEFT_SHIFT},
+      {FbUnaryOpType::Remainder, TTNNUnaryOpType::REMAINDER},
+      {FbUnaryOpType::Fmod, TTNNUnaryOpType::FMOD},
+      {FbUnaryOpType::Dropout, TTNNUnaryOpType::DROPOUT},
+      {FbUnaryOpType::Fill, TTNNUnaryOpType::FILL},
+      {FbUnaryOpType::PreluSfpu, TTNNUnaryOpType::PRELU_SFPU},
+      {FbUnaryOpType::ZeroPoint, TTNNUnaryOpType::ZERO_POINT},
+  };
+
+  auto it = opTypeMap.find(unaryOpType);
+  if (it != opTypeMap.end()) {
+    return it->second;
+  }
+
+  LOG_FATAL("Unsupported UnaryOpType");
+}
+
+::ttnn::operations::unary::UnaryWithParam
+toTTNNUnaryWithParam(const ::tt::target::ttnn::UnaryWithParam &unaryWithParam) {
+  return ::ttnn::operations::unary::UnaryWithParam(
+      toTTNNUnaryOpType(unaryWithParam.op_type()),
+      std::vector<float>(unaryWithParam.params()->begin(),
+                         unaryWithParam.params()->end()));
+}
+
+std::optional<::ttnn::operations::matmul::MatmulProgramConfig>
+createMatmulProgramConfigIfNeeded(const ::tt::target::ttnn::MatmulOp *op) {
+  if (!op->matmul_program_config()) {
+    return std::nullopt;
+  }
+
+  ::ttnn::operations::matmul::MatmulProgramConfig matmulProgramConfig;
+  switch (op->matmul_program_config_type()) {
+  case ::tt::target::ttnn::MatmulProgramConfig::
+      MatmulMultiCoreReuseProgramConfig: {
+    auto *config =
+        op->matmul_program_config_as_MatmulMultiCoreReuseProgramConfig();
+    return ::ttnn::operations::matmul::MatmulMultiCoreReuseProgramConfig{
+        .compute_with_storage_grid_size =
+            ::tt::runtime::ttnn::utils::toTTNNCoreCoord(
+                *config->compute_with_storage_grid_size()),
+        .in0_block_w = config->in0_block_w(),
+        .out_subblock_h = config->out_subblock_h(),
+        .out_subblock_w = config->out_subblock_w(),
+        .per_core_M = config->per_core_m(),
+        .per_core_N = config->per_core_n()};
+  }
+  case ::tt::target::ttnn::MatmulProgramConfig::
+      MatmulMultiCoreReuseMultiCastProgramConfig: {
+    auto *config =
+        op->matmul_program_config_as_MatmulMultiCoreReuseMultiCastProgramConfig();
+    return ::ttnn::operations::matmul::
+        MatmulMultiCoreReuseMultiCastProgramConfig{
+            .compute_with_storage_grid_size =
+                ::tt::runtime::ttnn::utils::toTTNNCoreCoord(
+                    *config->compute_with_storage_grid_size()),
+            .in0_block_w = config->in0_block_w(),
+            .out_subblock_h = config->out_subblock_h(),
+            .out_subblock_w = config->out_subblock_w(),
+            .out_block_h = config->out_block_h(),
+            .out_block_w = config->out_block_w(),
+            .per_core_M = config->per_core_m(),
+            .per_core_N = config->per_core_n(),
+            .transpose_mcast = config->transpose_mcast(),
+            .fused_activation =
+                config->fused_activation()
+                    ? std::optional<::ttnn::operations::unary::UnaryWithParam>(
+                          toTTNNUnaryWithParam(*config->fused_activation()))
+                    : std::nullopt,
+            .fuse_batch = config->fuse_batch()};
+  }
+  case ::tt::target::ttnn::MatmulProgramConfig::
+      MatmulMultiCoreReuseMultiCast1DProgramConfig: {
+    auto *config =
+        op->matmul_program_config_as_MatmulMultiCoreReuseMultiCast1DProgramConfig();
+    return ::ttnn::operations::matmul::
+        MatmulMultiCoreReuseMultiCast1DProgramConfig{
+            .compute_with_storage_grid_size =
+                ::tt::runtime::ttnn::utils::toTTNNCoreCoord(
+                    *config->compute_with_storage_grid_size()),
+            .in0_block_w = config->in0_block_w(),
+            .out_subblock_h = config->out_subblock_h(),
+            .out_subblock_w = config->out_subblock_w(),
+            .out_block_h = config->out_block_h(),
+            .out_block_w = config->out_block_w(),
+            .per_core_M = config->per_core_m(),
+            .per_core_N = config->per_core_n(),
+            .fuse_batch = config->fuse_batch(),
+            .fused_activation =
+                config->fused_activation()
+                    ? std::optional<::ttnn::operations::unary::UnaryWithParam>(
+                          toTTNNUnaryWithParam(*config->fused_activation()))
+                    : std::nullopt,
+            .mcast_in0 = config->mcast_in0(),
+            .gather_in0 = config->gather_in0(),
+            .hop_cores = ::tt::runtime::ttnn::utils::toTTNNCoreRangeSet(
+                *config->hop_cores()),
+            .num_global_cb_receivers = config->num_global_cb_receivers()};
+  }
+  case ::tt::target::ttnn::MatmulProgramConfig::
+      MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig: {
+    auto *config =
+        op->matmul_program_config_as_MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig();
+    return ::ttnn::operations::matmul::
+        MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig{
+            .in0_block_w = config->in0_block_w(),
+            .per_core_M = config->per_core_m(),
+            .per_core_N = config->per_core_n(),
+            .fused_activation =
+                config->fused_activation()
+                    ? std::optional<::ttnn::operations::unary::UnaryWithParam>(
+                          toTTNNUnaryWithParam(*config->fused_activation()))
+                    : std::nullopt,
+        };
+  }
+  default:
+    LOG_FATAL("Unsupported MatmulProgramConfig type");
+  }
+}
+
 ::ttnn::operations::conv::conv2d::Conv2dConfig
 createConv2dConfig(const ::tt::target::ttnn::Conv2dConfig *memcfg) {
   std::optional<::ttnn::TensorMemoryLayout> shardLayout = std::nullopt;
@@ -73,4 +272,5 @@ createConv2dConfig(const ::tt::target::ttnn::Conv2dConfig *memcfg) {
 
   return conv2dConfig;
 }
+
 } // namespace tt::runtime::ttnn::operations::utils

--- a/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/utils.h
+++ b/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/utils.h
@@ -32,6 +32,15 @@ inline ::ttnn::Shape toTTNNShape(const flatbuffers::Vector<T> &vec) {
   return ::ttnn::Shape(rawShape);
 }
 
+::ttnn::operations::unary::UnaryOpType
+toTTNNUnaryOpType(::tt::target::ttnn::UnaryOpType unaryOpType);
+
+::ttnn::operations::unary::UnaryWithParam
+toTTNNUnaryWithParam(const ::tt::target::ttnn::UnaryWithParam &unaryWithParam);
+
+std::optional<::ttnn::operations::matmul::MatmulProgramConfig>
+createMatmulProgramConfigIfNeeded(const ::tt::target::ttnn::MatmulOp *op);
+
 ::ttnn::operations::conv::conv2d::Conv2dConfig
 createConv2dConfig(const ::tt::target::ttnn::Conv2dConfig *memcfg);
 

--- a/runtime/lib/ttnn/operations/matmul/matmul.cpp
+++ b/runtime/lib/ttnn/operations/matmul/matmul.cpp
@@ -13,6 +13,7 @@
 #include <optional>
 
 namespace tt::runtime::ttnn::operations::matmul {
+
 // ANCHOR: adding_an_op_matmul_runtime_operations
 void run(const ::tt::target::ttnn::MatmulOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
@@ -28,9 +29,12 @@ void run(const ::tt::target::ttnn::MatmulOp *op, ProgramContext &context) {
 
   ::ttnn::DataType outputDataType = utils::getDataType(op->out());
 
+  std::optional<::ttnn::operations::matmul::MatmulProgramConfig>
+      matmulProgramConfig = utils::createMatmulProgramConfigIfNeeded(op);
+
   ::ttnn::Tensor output = ::ttnn::matmul(
       lhs, rhs, op->transpose_a(), op->transpose_b(), outputMemoryConfig,
-      outputDataType, /*program_config=*/std::nullopt,
+      outputDataType, matmulProgramConfig,
       /*activation=*/std::nullopt, /*compute_kernel_config=*/std::nullopt,
       /*core_grid=*/std::nullopt, /*output_tile=*/std::nullopt,
       /* optional_output_tensor=*/std::nullopt);

--- a/runtime/lib/ttnn/utils/utils.cpp
+++ b/runtime/lib/ttnn/utils/utils.cpp
@@ -201,6 +201,26 @@ toCoreRangeSet(const ::flatbuffers::Vector<const ::tt::target::Dim2dRange *>
   return CoreRangeSet(coreRanges);
 }
 
+CoreCoord toTTNNCoreCoord(const ::tt::target::ttnn::CoreCoord &coreCoord) {
+  return CoreCoord(coreCoord.x(), coreCoord.y());
+}
+
+CoreRange toTTNNCoreRange(const tt::target::ttnn::CoreRange &coreRange) {
+  CoreCoord start = toTTNNCoreCoord(coreRange.start_coord());
+  CoreCoord end = toTTNNCoreCoord(coreRange.end_coord());
+  return CoreRange(start, end);
+}
+
+CoreRangeSet
+toTTNNCoreRangeSet(const tt::target::ttnn::CoreRangeSet &coreRangeSet) {
+  std::set<CoreRange> coreRanges;
+  for (const tt::target::ttnn::CoreRange *coreRange :
+       *coreRangeSet.core_ranges()) {
+    coreRanges.emplace(toTTNNCoreRange(*coreRange));
+  }
+  return CoreRangeSet(coreRanges);
+}
+
 const ::tt::target::ttnn::MemoryConfig *
 getTensorRefMemoryConfig(const ::tt::target::ttnn::TensorRef *tensorRef) {
   return tensorRef->desc()->layout()->memory_desc()->memory_config();

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_matmul_multi_core_reuse_multi_cast_1d_program_config.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_matmul_multi_core_reuse_multi_cast_1d_program_config.mlir
@@ -1,0 +1,36 @@
+// RUN: ttmlir-opt --tt-register-device="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<8x32x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
+#ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<32x64x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
+#ttnn_layout2 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<8x64x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
+
+#matmul_program_config = #ttnn.matmul_multi_core_reuse_multi_cast_1d_program_config<
+  compute_with_storage_grid_size = #ttnn.core_coord<8, 2>,
+  in0_block_w = 32,
+  out_subblock_h = 1,
+  out_subblock_w = 2,
+  out_block_h = 8,
+  out_block_w = 6,
+  per_core_m = 8,
+  per_core_n = 6,
+  fuse_batch = true,
+  fused_activation = #ttnn.unary_with_param<op_type = add_unary_sfpu, params = [1.0 : f32]>,
+  mcast_in0 = true,
+  gather_in0 = false,
+  hop_cores = #ttnn.core_range_set<>,
+  num_global_cb_receivers = 0
+>
+
+module attributes {} {
+  func.func @forward(%arg0: tensor<256x1024xbf16, #ttnn_layout>, %arg1: tensor<1024x2048xbf16, #ttnn_layout1>) -> tensor<256x2048xbf16, #ttnn_layout2> {
+    %0 = "ttnn.matmul"(%arg0, %arg1)
+      <{
+        transpose_a = false,
+        transpose_b = false,
+        matmul_program_config = #matmul_program_config
+      }> : (tensor<256x1024xbf16, #ttnn_layout>, tensor<1024x2048xbf16, #ttnn_layout1>) -> tensor<256x2048xbf16, #ttnn_layout2>
+    return %0 : tensor<256x2048xbf16, #ttnn_layout2>
+  }
+}

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_matmul_multi_core_reuse_multi_cast_dram_sharded_program_config.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_matmul_multi_core_reuse_multi_cast_dram_sharded_program_config.mlir
@@ -1,0 +1,33 @@
+// RUN: ttmlir-opt --tt-register-device="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+
+#l1 = #ttnn.buffer_type<l1>
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x32x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
+#ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<32x40x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
+#ttnn_layout2 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x40x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
+
+#sharded_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <8x1>, memref<1x4x!tt.tile<32x32, bf16>, #l1>, <width_sharded>>
+#sharded_layout1 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <8x1>, memref<32x5x!tt.tile<32x32, bf16>, #l1>, <width_sharded>>
+#sharded_layout2 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <8x1>, memref<1x5x!tt.tile<32x32, bf16>, #l1>, <width_sharded>>
+
+#matmul_program_config = #ttnn.matmul_multi_core_reuse_multi_cast_dram_sharded_program_config<
+  in0_block_w = 1,
+  per_core_m = 1,
+  per_core_n = 5,
+  fused_activation = #ttnn.unary_with_param<op_type = relu>
+>
+
+module attributes {} {
+  func.func @forward(%arg0: tensor<32x1024xbf16, #ttnn_layout>, %arg1: tensor<1024x1280xbf16, #ttnn_layout1>) -> tensor<32x1280xbf16, #sharded_layout2> {
+    %0 = "ttnn.to_memory_config"(%arg0) <{memory_config = #ttnn.memory_config<#l1, <<1x4>>, <width_sharded>>}> : (tensor<32x1024xbf16, #ttnn_layout>) -> tensor<32x1024xbf16, #sharded_layout>
+    %1 = "ttnn.to_memory_config"(%arg1) <{memory_config = #ttnn.memory_config<#l1, <<32x5>>, <width_sharded>>}> : (tensor<1024x1280xbf16, #ttnn_layout1>) -> tensor<1024x1280xbf16, #sharded_layout1>
+    %2 = "ttnn.matmul"(%0, %1)
+      <{
+        transpose_a = false,
+        transpose_b = false,
+        matmul_program_config = #matmul_program_config
+      }> : (tensor<32x1024xbf16, #sharded_layout>, tensor<1024x1280xbf16, #sharded_layout1>) -> tensor<32x1280xbf16, #sharded_layout2>
+    return %2 : tensor<32x1280xbf16, #sharded_layout2>
+  }
+}

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_matmul_multi_core_reuse_multi_cast_program_config.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_matmul_multi_core_reuse_multi_cast_program_config.mlir
@@ -1,0 +1,31 @@
+// RUN: ttmlir-opt --tt-register-device="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<16x16x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
+#ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<16x32x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
+
+#matmul_program_config = #ttnn.matmul_multi_core_reuse_multi_cast_program_config<
+  compute_with_storage_grid_size = #ttnn.core_coord<8, 8>,
+  in0_block_w = 16,
+  out_subblock_h = 2,
+  out_subblock_w = 4,
+  out_block_h = 2,
+  out_block_w = 4,
+  per_core_m = 2,
+  per_core_n = 4,
+  transpose_mcast = true,
+  fused_activation = #ttnn.unary_with_param<op_type = relu>,
+  fuse_batch = true
+>
+
+module attributes {} {
+  func.func @forward(%arg0: tensor<512x512xbf16, #ttnn_layout>, %arg1: tensor<512x1024xbf16, #ttnn_layout1>) -> tensor<512x1024xbf16, #ttnn_layout1> {
+    %0 = "ttnn.matmul"(%arg0, %arg1) <{
+      transpose_a = false,
+      transpose_b = false,
+      matmul_program_config = #matmul_program_config
+    }> : (tensor<512x512xbf16, #ttnn_layout>, tensor<512x1024xbf16, #ttnn_layout1>) -> tensor<512x1024xbf16, #ttnn_layout1>
+    return %0 : tensor<512x1024xbf16, #ttnn_layout1>
+  }
+}

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_matmul_multi_core_reuse_program_config.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_matmul_multi_core_reuse_program_config.mlir
@@ -1,0 +1,25 @@
+// RUN: ttmlir-opt --tt-register-device="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 2304 + d1 * 256 + d2, d3), <1x1>, memref<504x8x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
+
+#matmul_program_config = #ttnn.matmul_multi_core_reuse_program_config<
+  compute_with_storage_grid_size = #ttnn.core_coord<7, 9>,
+  in0_block_w = 8,
+  out_subblock_h = 1,
+  out_subblock_w = 8,
+  per_core_m = 8,
+  per_core_n = 8
+>
+
+module attributes {} {
+  func.func @forward(%arg0: tensor<7x9x256x256xbf16, #ttnn_layout>, %arg1: tensor<7x9x256x256xbf16, #ttnn_layout>) -> tensor<7x9x256x256xbf16, #ttnn_layout> {
+    %0 = "ttnn.matmul"(%arg0, %arg1) <{
+      transpose_a = false,
+      transpose_b = false,
+      matmul_program_config = #matmul_program_config}
+    > : (tensor<7x9x256x256xbf16, #ttnn_layout>, tensor<7x9x256x256xbf16, #ttnn_layout>) -> tensor<7x9x256x256xbf16, #ttnn_layout>
+    return %0 : tensor<7x9x256x256xbf16, #ttnn_layout>
+  }
+}


### PR DESCRIPTION
### Problem description
Add E2E `MatmulProgramConfig` support

### What's changed
- Since `MatmulProgramConfig` in the TTNN library is of type `std::variant`, I had to model each variant as a separate attribute in the TTNN dialect (`TTNN_MatmulMultiCoreReuseProgramConfigAttr`, `TTNN_MatmulMultiCoreReuseMultiCastProgramConfigAttr`, …). I also added other attributes that model dependencies of `MatmulProgramConfig` (`TTNN_CoreCoordAttr`, `TTNN_CoreRangeAttr`, …).
- ~~The added silicon tests are marked UNSUPPORTED since the values passed to the matmul config in them are just placeholder values.~~ The added silicon tests are passing now.
