### PR TITLE
Add folding code for CollectivePermuteOp

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1553,6 +1553,8 @@ def TTNN_CollectivePermuteOp: TTNN_Op<"collective_permute"> {
     let results = (outs AnyRankedTensor:$result);
 
     let hasVerifier = 1;
+
+    let hasFolder = 1;
 }
 
 def TTNN_MeshShardOp: TTNN_Op<"mesh_shard"> {

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -1763,13 +1763,11 @@ mlir::tt::ttnn::CollectivePermuteOp::fold(FoldAdaptor adaptor) {
     filteredPairs.push_back(target);
   }
 
-  // No permute exist
-  if (filteredPairs.size() == 0) {
-    return getInput();
-  } else {
-    // Update source_target_pairs if there were self-mapping pairs.
+  if (filteredPairs.size() != 0) {
+    // There are effective permutations left.
     if (srcTargetPairs.getNumElements() !=
         static_cast<int64_t>(filteredPairs.size())) {
+      // Update source_target_pairs if changed.
       std::array<int64_t, 2> shape = {
           static_cast<int64_t>(filteredPairs.size() / 2), 2};
       auto newShape = llvm::ArrayRef<int64_t>(shape);
@@ -1778,6 +1776,9 @@ mlir::tt::ttnn::CollectivePermuteOp::fold(FoldAdaptor adaptor) {
       setSourceTargetPairsAttr(
           DenseIntElementsAttr::get(newType, filteredPairs));
     }
+  } else {
+    // No permutations left. Exclude this op.
+    return getInput();
   }
   return {};
 }

--- a/test/ttmlir/Dialect/TTNN/ccl/collective_permute/collective_permute_positive.mlir
+++ b/test/ttmlir/Dialect/TTNN/ccl/collective_permute/collective_permute_positive.mlir
@@ -8,6 +8,7 @@ module attributes {} {
     %0 = tensor.empty() : tensor<1x1x8192x512xf32>
     %1 = "ttir.collective_permute"(%arg0, %0) <{source_target_pairs = dense<[[0, 1], [1, 0]]> : tensor<2x2xi64>}> : (tensor<1x1x8192x512xf32>, tensor<1x1x8192x512xf32>) -> tensor<1x1x8192x512xf32>
     // CHECK: "ttnn.collective_permute"
+    // CHECK-SAME: source_target_pairs = dense<{{([[])}}[0, 1], [1, 0]]> : tensor<2x2xi64>
     return %1 : tensor<1x1x8192x512xf32>
   }
 }
@@ -35,7 +36,6 @@ module attributes {} {
     %1 = "ttir.collective_permute"(%arg0, %0) <{source_target_pairs = dense<[[0, 0], [1, 2]]> : tensor<2x2xi64>}> : (tensor<1x1x8192x512xf32>, tensor<1x1x8192x512xf32>) -> tensor<1x1x8192x512xf32>
     // CHECK: "ttnn.collective_permute"
     // CHECK-SAME: source_target_pairs = dense<{{([[])}}[1, 2]]> : tensor<1x2xi64>
-    // CHECK-NOT: [0, 0]
     return %1 : tensor<1x1x8192x512xf32>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/ccl/collective_permute/collective_permute_positive.mlir
+++ b/test/ttmlir/Dialect/TTNN/ccl/collective_permute/collective_permute_positive.mlir
@@ -1,14 +1,54 @@
-// RUN: ttmlir-opt --split-input-file --ttir-to-ttnn-backend-pipeline="mesh-shape=1,1" %s | FileCheck %s
+// RUN: ttmlir-opt --split-input-file --ttir-to-ttnn-backend-pipeline="mesh-shape=1,2" %s | FileCheck %s
 // Unit tests for ttnn collective_permute op
-
-// -----
 
 // Verify lowering of ttir collective_permute to ttnn ops
 module attributes {} {
-  func.func public @collective_permute_invalid_duplicate_sources(%arg0: tensor<1x1x8192x512xf32>) -> (tensor<1x1x8192x512xf32> {jax.result_info = ""}) {
+  // CHECK-LABEL: collective_permute_valid_case
+  func.func public @collective_permute_valid_case(%arg0: tensor<1x1x8192x512xf32>) -> (tensor<1x1x8192x512xf32> {jax.result_info = ""}) {
     %0 = tensor.empty() : tensor<1x1x8192x512xf32>
     %1 = "ttir.collective_permute"(%arg0, %0) <{source_target_pairs = dense<[[0, 1], [1, 0]]> : tensor<2x2xi64>}> : (tensor<1x1x8192x512xf32>, tensor<1x1x8192x512xf32>) -> tensor<1x1x8192x512xf32>
+    // CHECK: "ttnn.collective_permute"
     return %1 : tensor<1x1x8192x512xf32>
   }
 }
-// CHECK: "ttnn.collective_permute"
+
+// -----
+
+// Verify op folding for zero sized source-target pair
+module attributes {} {
+  // CHECK-LABEL: collective_permute_zero_sized_pair
+  func.func public @collective_permute_zero_sized_pair(%arg0: tensor<1x1x8192x512xf32>) -> (tensor<1x1x8192x512xf32> {jax.result_info = ""}) {
+    %0 = tensor.empty() : tensor<1x1x8192x512xf32>
+    %1 = "ttir.collective_permute"(%arg0, %0) <{source_target_pairs = dense<> : tensor<0x2xi64>}> : (tensor<1x1x8192x512xf32>, tensor<1x1x8192x512xf32>) -> tensor<1x1x8192x512xf32>
+    // CHECK-NOT: "ttnn.collective_permute"
+    return %1 : tensor<1x1x8192x512xf32>
+  }
+}
+
+// -----
+
+// Verify op folding for self-mapped pairs
+module attributes {} {
+  // CHECK-LABEL: collective_permute_self_mapped_pair
+  func.func public @collective_permute_self_mapped_pair(%arg0: tensor<1x1x8192x512xf32>) -> (tensor<1x1x8192x512xf32> {jax.result_info = ""}) {
+    %0 = tensor.empty() : tensor<1x1x8192x512xf32>
+    %1 = "ttir.collective_permute"(%arg0, %0) <{source_target_pairs = dense<[[0, 0], [1, 2]]> : tensor<2x2xi64>}> : (tensor<1x1x8192x512xf32>, tensor<1x1x8192x512xf32>) -> tensor<1x1x8192x512xf32>
+    // CHECK: "ttnn.collective_permute"
+    // CHECK-SAME: source_target_pairs = dense<{{([[])}}[1, 2]]> : tensor<1x2xi64>
+    // CHECK-NOT: [0, 0]
+    return %1 : tensor<1x1x8192x512xf32>
+  }
+}
+
+// -----
+
+// Verify op folding for self-mapped pairs
+module attributes {} {
+  // CHECK-LABEL: collective_permute_all_self_mapped_pair
+  func.func public @collective_permute_all_self_mapped_pair(%arg0: tensor<1x1x8192x512xf32>) -> (tensor<1x1x8192x512xf32> {jax.result_info = ""}) {
+    %0 = tensor.empty() : tensor<1x1x8192x512xf32>
+    %1 = "ttir.collective_permute"(%arg0, %0) <{source_target_pairs = dense<[[0, 0], [1, 1]]> : tensor<2x2xi64>}> : (tensor<1x1x8192x512xf32>, tensor<1x1x8192x512xf32>) -> tensor<1x1x8192x512xf32>
+    // CHECK-NOT: "ttnn.collective_permute"
+    return %1 : tensor<1x1x8192x512xf32>
+  }
+}


### PR DESCRIPTION


### Ticket
https://github.com/tenstorrent/tt-mlir/issues/2406
closes #2406 

### Problem description
CollectivePermute Op is semantically meaningless when there is no tensor data movement from any device.
source_target_pair attribute describes where Tensor data moving from and to. There will be no data movement If source and target are same. Also if we don't have any effective movement description, we don't need to execute this op.

### What's changed
- Remove entries in the permute attribute where 'src' and 'target' are identical.
- Exclude the CollectivePermuteOp if the source_target_pair array becomes empty after cleanup.
- Added unit tests to verify folding

### Checklist
- [x] New/Existing tests provide coverage for changes
