### PR TITLE
TTIRBuilder: Support skipping golden generation when provided_golden is given

### DIFF
--- a/python/test_infra/ttir_builder.py
+++ b/python/test_infra/ttir_builder.py
@@ -1279,3 +1279,112 @@ class TTIRBuilder:
 
     def maximum(self, in0: Operand, in1: Operand) -> OpView:
         return self.eltwise_proxy(torch.maximum, ttir.MaximumOp, [in0, in1])
+
+    # CCL ops
+    def all_gather(
+        self,
+        input: Operand,
+        all_gather_dim: int = None,
+        cluster_axis: int = None,
+        output_shape=None,
+        provided_golden=None,
+    ) -> OpView:
+        kwargs = {"all_gather_dim": all_gather_dim, "cluster_axis": cluster_axis}
+        return self.op_proxy(
+            None,
+            ttir.AllGatherOp,
+            [input],
+            ttir_kwargs=kwargs,
+            organize_ttir_args=lambda i, o, shape: (
+                self._get_type(o),
+                i[0],
+                o,
+            ),
+            output_shape=output_shape,
+            provided_golden=provided_golden,
+        )
+
+    def all_reduce(
+        self,
+        input: Operand,
+        reduce_type: str,
+        cluster_axis: int = None,
+        output_shape=None,
+        provided_golden=None,
+    ) -> OpView:
+        _reduce_type = Attribute.parse(reduce_type)
+        kwargs = {"reduce_type": _reduce_type, "cluster_axis": cluster_axis}
+        return self.op_proxy(
+            None,
+            ttir.AllReduceOp,
+            [input],
+            ttir_kwargs=kwargs,
+            organize_ttir_args=lambda i, o, shape: (
+                self._get_type(o),
+                i[0],
+                o,
+            ),
+            output_shape=output_shape,
+            provided_golden=provided_golden,
+        )
+
+    def reduce_scatter(
+        self,
+        input: Operand,
+        reduce_type: str,
+        scatter_dim=3,
+        cluster_axis: int = None,
+        output_shape=None,
+        provided_golden=None,
+    ) -> OpView:
+        _reduce_type = Attribute.parse(reduce_type)
+        kwargs = {
+            "reduce_type": _reduce_type,
+            "scatter_dim": scatter_dim,
+            "cluster_axis": cluster_axis,
+        }
+        return self.op_proxy(
+            None,
+            ttir.ReduceScatterOp,
+            [input],
+            ttir_kwargs=kwargs,
+            organize_ttir_args=lambda i, o, shape: (
+                self._get_type(o),
+                i[0],
+                o,
+            ),
+            output_shape=output_shape,
+            provided_golden=provided_golden,
+        )
+
+    def mesh_shard(
+        self,
+        in0: Operand,
+        shard_type: str,
+        shard_direction: str,
+        shard_shape: Tuple[int, ...],
+        shard_dims: Tuple[int, ...],
+        output_shape=None,
+        provided_golden=None,
+    ) -> OpView:
+        _shard_type = Attribute.parse(shard_type)
+        _shard_direction = Attribute.parse(shard_direction)
+        kwargs = {
+            "shard_type": _shard_type,
+            "shard_direction": _shard_direction,
+            "shard_shape": shard_shape,
+            "shard_dims": shard_dims,
+        }
+        return self.op_proxy(
+            None,
+            ttir.MeshShardOp,
+            [in0],
+            organize_ttir_args=lambda i, o, shape: (
+                self._get_type(o),
+                i[0],
+                o,
+            ),
+            ttir_kwargs=kwargs,
+            output_shape=output_shape,
+            provided_golden=provided_golden,
+        )

--- a/test/python/golden/ccl_golden/lit.local.cfg
+++ b/test/python/golden/ccl_golden/lit.local.cfg
@@ -1,0 +1,4 @@
+config.suffixes.add(".py")
+
+if not "n300" in config.targets:
+    config.unsupported = True

--- a/test/python/golden/ccl_golden/test_ttir_ccl_ops.py
+++ b/test/python/golden/ccl_golden/test_ttir_ccl_ops.py
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# RUN: SYSTEM_DESC_PATH=%system_desc_path% %python %s
+
+import inspect
+import torch
+
+from ttmlir.test_utils import compile_to_flatbuffer, set_output_path
+from ttmlir.ttir_builder import Operand, TTIRBuilder
+
+
+@compile_to_flatbuffer(
+    [
+        (1, 32, 128, 128),
+    ],
+    targets=["ttnn"],
+    mesh_shape=[1, 2],
+)
+def test_all_gather(in0: Operand, builder: TTIRBuilder):
+    def pseudo_golden_all_gather(in0):
+        input_tensor = builder._get_golden_tensor(in0)
+        output_tensor = input_tensor.clone()
+        return output_tensor
+
+    input_shape = builder._get_golden_tensor(in0).shape
+    half_shape = input_shape[:-1] + (input_shape[-1] // 2,)
+    sharded = builder.mesh_shard(
+        in0,
+        shard_direction="#tt.shard_direction<full_to_shard>",
+        shard_type="#tt.shard_type<devices>",
+        shard_shape=[1, 1, 1, 2],
+        shard_dims=[-1, 3],
+        output_shape=half_shape,
+    )
+    result = builder.all_gather(
+        sharded,
+        all_gather_dim=3,
+        cluster_axis=1,
+        output_shape=half_shape,
+    )
+    return builder.mesh_shard(
+        result,
+        shard_direction="#tt.shard_direction<shard_to_full>",
+        shard_type="#tt.shard_type<replicate>",
+        shard_shape=[1],
+        shard_dims=[-1],
+        provided_golden=pseudo_golden_all_gather(in0),
+    )
+
+
+@compile_to_flatbuffer(
+    [
+        (1, 64, 512, 1024),
+    ],
+    targets=["ttnn"],
+    mesh_shape=[1, 2],
+)
+def test_all_reduce(in0: Operand, builder: TTIRBuilder):
+    def pseudo_golden_all_reduce(in0):
+        input_tensor = builder._get_golden_tensor(in0)
+        shard_1, shard_2 = torch.chunk(input_tensor, 2, dim=3)
+        output_tensor = shard_1 + shard_2
+        return output_tensor
+
+    input_shape = builder._get_golden_tensor(in0).shape
+    half_shape = input_shape[:-1] + (input_shape[-1] // 2,)
+
+    sharded = builder.mesh_shard(
+        in0,
+        shard_direction="#tt.shard_direction<full_to_shard>",
+        shard_type="#tt.shard_type<devices>",
+        shard_shape=[1, 1, 1, 2],
+        shard_dims=[-1, 3],
+        output_shape=half_shape,
+    )
+    result = builder.all_reduce(
+        sharded,
+        reduce_type="#tt.reduce_type<sum>",
+        cluster_axis=1,
+        output_shape=half_shape,
+    )
+    return builder.mesh_shard(
+        result,
+        shard_direction="#tt.shard_direction<shard_to_full>",
+        shard_type="#tt.shard_type<replicate>",
+        shard_shape=[1],
+        shard_dims=[-1],
+        provided_golden=pseudo_golden_all_reduce(in0),
+    )
+
+
+@compile_to_flatbuffer(
+    [
+        (1, 1, 32, 1024),
+    ],
+    targets=["ttnn"],
+    mesh_shape=[1, 2],
+)
+def test_reduce_scatter(in0: Operand, builder: TTIRBuilder):
+    def pseudo_golden_reduce_scatter(in0):
+        input_tensor = builder._get_golden_tensor(in0)
+        shard_1, shard_2 = torch.chunk(input_tensor, 2, dim=3)
+        output_tensor = shard_1 + shard_2
+        # reduce with sum
+        # scatter -> 'shard to full' is not needed
+        return output_tensor
+
+    input_shape = builder._get_golden_tensor(in0).shape
+    input_shape = builder._get_golden_tensor(in0).shape
+    half_shape = input_shape[:-1] + (input_shape[-1] // 2,)
+    quarter_shape = input_shape[:-1] + (half_shape[-1] // 2,)
+    sharded = builder.mesh_shard(
+        in0,
+        shard_direction="#tt.shard_direction<full_to_shard>",
+        shard_type="#tt.shard_type<devices>",
+        shard_shape=[1, 1, 1, 2],
+        shard_dims=[-1, 3],
+        output_shape=half_shape,
+    )
+    result = builder.reduce_scatter(
+        sharded,
+        reduce_type="#tt.reduce_type<sum>",
+        scatter_dim=3,
+        cluster_axis=1,
+        output_shape=quarter_shape,
+    )
+    return builder.mesh_shard(
+        result,
+        shard_direction="#tt.shard_direction<shard_to_full>",
+        shard_type="#tt.shard_type<devices>",
+        shard_shape=[1, 1, 1, 2],
+        shard_dims=[-1, 3],
+        provided_golden=pseudo_golden_reduce_scatter(in0),
+    )
+
+
+if __name__ == "__main__":
+    import argparse, os
+
+    parser = argparse.ArgumentParser(description="Run TTIR Builder Op tests")
+    parser.add_argument(
+        "--path",
+        type=str,
+        help="Optional output path for the flatbuffer. Creates path if supplied path doesn't exist",
+    )
+    args = parser.parse_args()
+
+    if args.path and os.path.exists(args.path):
+        if not os.path.exists(args.path):
+            os.makedirs(args.path)
+        set_output_path(args.path)
+
+    test_functions = inspect.getmembers(
+        inspect.getmodule(inspect.currentframe()), inspect.isfunction
+    )
+
+    for function_name, func in test_functions:
+        if function_name.startswith("test_"):
+            func()


### PR DESCRIPTION
### Ticket
Close #2568 
Partly related to #2020

### Problem description
Op-by-op golden comparison is not possible with CCL Ops. Because the output tensors of CCL Ops are placed on the device side, so we cannot access them under the current implementation.
However, we can access the output tensors of a multi-device subgraph, allowing users to skip op-by-op golden comparisons selectively.
As Phase 0 of #2020, users can provide their own golden tensors instead of generating them using a golden op (e.g., torch or another framework).

### What's changed
 - If `provided_golden` is specified, `op_golden_function` is skipped and the provided tensor is used directly.
 - If no golden is produced by any means, it is not stored and not included in flatbuffer generation, effectively disabling golden comparison at runtime.
 - When `output_shape` is provided, it is used to create the output tensor needed for `op_ttir_function` invocation.
 - Implemented TTIRBuilder wrapper functions for CCL ops: mesh_shard, all_gather, all_reduce, and reduce_scatter.
 - Golden generation is skipped for now by relying on `provided_golden`.
 - Add basic testcases for CCL ops with TTIRBuilder

### Checklist
- [ ] New/Existing tests provide coverage for changes
