### PR TITLE
Fix clang-tidy version to 19.1.0

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -386,7 +386,7 @@ jobs:
       shell: bash
       run: |
         source env/activate
-        cmake --build ${{ steps.strings.outputs.build-output-dir }} -- COMMON_FBS TTMETAL_FBS TTNN_FBS mlir-headers mlir-generic-headers
+        cmake --build ${{ steps.strings.outputs.build-output-dir }} -- FBS_GENERATION mlir-headers mlir-generic-headers
         python3 tools/scripts/filter-compile-commands.py --diff ${{ steps.strings.outputs.build-output-dir }}/compile_commands.json
         cmake --build ${{ steps.strings.outputs.build-output-dir }} -- clang-tidy
 

--- a/env/build-requirements.txt
+++ b/env/build-requirements.txt
@@ -1,7 +1,7 @@
 cmake
 ninja
 clang-format
-clang-tidy
+clang-tidy==19.1.0
 wheel
 setuptools
 black


### PR DESCRIPTION
Recently clang-tidy bumped to version 20 on pypi which broke CI.