### PR TITLE
Adding EmitC conversion for slice op

### DIFF
--- a/test/ttmlir/EmitC/TTNN/tensor/slice.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/slice.mlir
@@ -1,0 +1,10 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
+// RUN: ttmlir-opt --ttnn-modify-signatures-for-dylib --convert-ttnn-to-emitc %t.mlir > %t2.mlir
+// RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
+
+func.func @slice(%arg0: tensor<4x32x32xbf16>) -> tensor<2x16x16xbf16> {
+    %0 = tensor.empty() : tensor<2x16x16xbf16>
+    %1 = "ttir.slice"(%arg0, %0) <{begins = [0: i32, 0: i32, 0: i32], ends = [2: i32, 16: i32, 16: i32], step = [1: i32, 1: i32, 1: i32]}> : (tensor<4x32x32xbf16>, tensor<2x16x16xbf16>) -> tensor<2x16x16xbf16>
+    return %1 : tensor<2x16x16xbf16>
+}

--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -18,6 +18,7 @@
 #include "operations/data_movement/concat/concat.hpp"
 #include "operations/data_movement/repeat/repeat.hpp"
 #include "operations/data_movement/repeat_interleave/repeat_interleave.hpp"
+#include "operations/data_movement/slice/slice.hpp"
 #include "operations/data_movement/transpose/transpose.hpp"
 #include "operations/eltwise/binary/binary.hpp"
 #include "operations/eltwise/binary/binary_composite.hpp"


### PR DESCRIPTION
### Ticket
Part of the following issues:
https://github.com/tenstorrent/tt-mlir/issues/1877

### Problem description
Currently, we lack an emitC conversion for slice op.

### What's changed
This PR adds a missing emitC conversion for slice op.

### Checklist
- [x] New/Existing tests provide coverage for changes
