### PR TITLE
Fix scatter_dim/gather_dim to 3 during all_reduce lowering

### DIFF
--- a/test/ttmlir/Silicon/TTNN/llmbox/ccl/ccl_1x8.mlir
+++ b/test/ttmlir/Silicon/TTNN/llmbox/ccl/ccl_1x8.mlir
@@ -15,18 +15,18 @@ func.func @all_gather_cluster1(%arg0: tensor<1x1x32x128xf32>) -> tensor<1x1x32x1
   return %5 : tensor<1x1x32x128xf32>
 }
 
-func.func @all_reduce_cluster1(%arg0: tensor<1x1x8192x512xf32>) -> (tensor<1x1x8192x64xf32> {jax.result_info = ""}) {
-  %0 = tensor.empty() : tensor<1x1x8192x64xf32>
-  %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: -1, 3>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 1, 8>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x8192x512xf32>, tensor<1x1x8192x64xf32>) -> tensor<1x1x8192x64xf32>
+func.func @all_reduce_cluster1(%arg0: tensor<1x1x8192x2048xf32>) -> (tensor<1x1x8192x256xf32> {jax.result_info = ""}) {
+  %0 = tensor.empty() : tensor<1x1x8192x256xf32>
+  %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: -1, 3>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 1, 8>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x8192x2048xf32>, tensor<1x1x8192x256xf32>) -> tensor<1x1x8192x256xf32>
   // CHECK: "ttnn.mesh_shard"
-  %2 = tensor.empty() : tensor<1x1x8192x64xf32>
-  %3 = "ttir.all_reduce"(%1, %2) <{cluster_axis = 1 : ui32, reduce_type = #tt.reduce_type<sum>}> : (tensor<1x1x8192x64xf32>, tensor<1x1x8192x64xf32>) -> tensor<1x1x8192x64xf32>
+  %2 = tensor.empty() : tensor<1x1x8192x256xf32>
+  %3 = "ttir.all_reduce"(%1, %2) <{cluster_axis = 1 : ui32, reduce_type = #tt.reduce_type<sum>}> : (tensor<1x1x8192x256xf32>, tensor<1x1x8192x256xf32>) -> tensor<1x1x8192x256xf32>
   // CHECK: "ttnn.reduce_scatter"
   // CHECK: "ttnn.all_gather"
-  %4 = tensor.empty() : tensor<1x1x8192x64xf32>
-  %5 = "ttir.mesh_shard"(%3, %4) <{shard_dims = array<i64: -1>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1>, shard_type = #tt.shard_type<replicate>}> : (tensor<1x1x8192x64xf32>, tensor<1x1x8192x64xf32>) -> tensor<1x1x8192x64xf32>
+  %4 = tensor.empty() : tensor<1x1x8192x256xf32>
+  %5 = "ttir.mesh_shard"(%3, %4) <{shard_dims = array<i64: -1>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1>, shard_type = #tt.shard_type<replicate>}> : (tensor<1x1x8192x256xf32>, tensor<1x1x8192x256xf32>) -> tensor<1x1x8192x256xf32>
   // CHECK: "ttnn.mesh_shard"
-  return %5 : tensor<1x1x8192x64xf32>
+  return %5 : tensor<1x1x8192x256xf32>
 }
 
 func.func @reduce_scatter_cluster1(%arg0: tensor<1x1x8192x2048xf32>) -> (tensor<1x1x8192x256xf32> {jax.result_info = ""}) {


### PR DESCRIPTION

### Ticket
https://github.com/tenstorrent/tt-mlir/issues/2626
closes #2626 

### Problem description
Using any dimension other than 3 generates incorrect output. 
Refer to the issue tenstorrent/tt-metal#19433

### What's changed
Fix dimension to 3 for broken down ops while lowering all_reduce. 
Raise a failure if dimension 3 of the input shape is not divisible by sizeOfDevices.


### Checklist
- [ ] New/Existing tests provide coverage for changes
