### PR TITLE
Added PyKernel Compile Pipeline

### DIFF
--- a/include/ttmlir/Dialect/TTKernel/Pipelines/TTKernelPipelines.h
+++ b/include/ttmlir/Dialect/TTKernel/Pipelines/TTKernelPipelines.h
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTKERNEL_PIPELINES_TTKERNELPIPELINES_H
+#define TTMLIR_DIALECT_TTKERNEL_PIPELINES_TTKERNELPIPELINES_H
+
+#include "mlir/Pass/PassOptions.h"
+
+namespace mlir::tt::ttkernel {
+// Define the PyKernelCompilePipelineOptions
+struct PyKernelCompilePipelineOptions
+    : public PassPipelineOptions<PyKernelCompilePipelineOptions> {
+  Option<bool> enableSROA{
+      *this, "sroa",
+      llvm::cl::desc("Enables Scalar Replacement of Aggregates Optimization "
+                     "(Default: true)"),
+      llvm::cl::init(true)};
+
+  Option<bool> enableFormExpressions{
+      *this, "form-expressions",
+      llvm::cl::desc(
+          "Enables EmitC Form Expressions Optimization (Default: true)"),
+      llvm::cl::init(true)};
+};
+
+void createPyKernelCompilePipeline(
+    OpPassManager &pm, const PyKernelCompilePipelineOptions &options);
+
+void registerTTKernelPipelines();
+} // namespace mlir::tt::ttkernel
+
+#endif

--- a/include/ttmlir/Dialect/TTKernel/Pipelines/TTKernelPipelines.h
+++ b/include/ttmlir/Dialect/TTKernel/Pipelines/TTKernelPipelines.h
@@ -11,10 +11,9 @@ namespace mlir::tt::ttkernel {
 // Define the PyKernelCompilePipelineOptions
 struct PyKernelCompilePipelineOptions
     : public PassPipelineOptions<PyKernelCompilePipelineOptions> {
-  Option<bool> enableSROA{
-      *this, "sroa",
-      llvm::cl::desc("Enables Scalar Replacement of Aggregates Optimization "
-                     "(Default: true)"),
+  Option<bool> enableCanonicalizer{
+      *this, "canonicalizer",
+      llvm::cl::desc("Enables Canonicalizer Pass (Default: true)"),
       llvm::cl::init(true)};
 
   Option<bool> enableFormExpressions{

--- a/lib/Dialect/TTKernel/CMakeLists.txt
+++ b/lib/Dialect/TTKernel/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(IR)
+add_subdirectory(Pipelines)

--- a/lib/Dialect/TTKernel/Pipelines/CMakeLists.txt
+++ b/lib/Dialect/TTKernel/Pipelines/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_mlir_dialect_library(MLIRTTKernelPipelines
+  TTKernelPipelines.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${PROJECT_SOURCE_DIR}/include/ttmlir
+
+  LINK_LIBS PUBLIC
+  MLIRTTKernelDialect
+  MLIREmitCDialect
+  MLIREmitCTransforms
+  MLIRPass
+  MLIRTransforms
+)

--- a/lib/Dialect/TTKernel/Pipelines/TTKernelPipelines.cpp
+++ b/lib/Dialect/TTKernel/Pipelines/TTKernelPipelines.cpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTKernel/Pipelines/TTKernelPipelines.h"
+
+#include "mlir/Dialect/EmitC/Transforms/Passes.h"
+
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/Passes.h"
+#include "ttmlir/Conversion/Passes.h"
+
+namespace mlir::tt::ttkernel {
+//===----------------------------------------------------------------------===//
+// Pipeline implementation.
+//===----------------------------------------------------------------------===//
+
+void createPyKernelCompilePipeline(
+    OpPassManager &pm, const PyKernelCompilePipelineOptions &options) {
+  // Use Options to Enable/Disable certain Optimizations
+  if (options.enableSROA) {
+    pm.addPass(mlir::createSROA());
+  }
+
+  if (options.enableFormExpressions) {
+    pm.addPass(mlir::emitc::createFormExpressionsPass());
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Pipeline registration.
+//===----------------------------------------------------------------------===//
+
+void registerTTKernelPipelines() {
+  mlir::PassPipelineRegistration<
+      mlir::tt::ttkernel::PyKernelCompilePipelineOptions>(
+      "pykernel-compile-pipeline",
+      "Pipeline applying optimizations to MLIR Module from PyKernel",
+      mlir::tt::ttkernel::createPyKernelCompilePipeline);
+}
+} // namespace mlir::tt::ttkernel

--- a/lib/Dialect/TTKernel/Pipelines/TTKernelPipelines.cpp
+++ b/lib/Dialect/TTKernel/Pipelines/TTKernelPipelines.cpp
@@ -5,6 +5,7 @@
 #include "ttmlir/Dialect/TTKernel/Pipelines/TTKernelPipelines.h"
 
 #include "mlir/Dialect/EmitC/Transforms/Passes.h"
+#include "mlir/Dialect/SCF/Transforms/Passes.h"
 
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
@@ -18,8 +19,8 @@ namespace mlir::tt::ttkernel {
 void createPyKernelCompilePipeline(
     OpPassManager &pm, const PyKernelCompilePipelineOptions &options) {
   // Use Options to Enable/Disable certain Optimizations
-  if (options.enableSROA) {
-    pm.addPass(mlir::createSROA());
+  if (options.enableCanonicalizer) {
+    pm.addPass(mlir::createCanonicalizerPass());
   }
 
   if (options.enableFormExpressions) {

--- a/lib/Dialect/TTKernel/Pipelines/TTKernelPipelines.cpp
+++ b/lib/Dialect/TTKernel/Pipelines/TTKernelPipelines.cpp
@@ -4,12 +4,12 @@
 
 #include "ttmlir/Dialect/TTKernel/Pipelines/TTKernelPipelines.h"
 
+#include "ttmlir/Conversion/Passes.h"
+
 #include "mlir/Dialect/EmitC/Transforms/Passes.h"
 #include "mlir/Dialect/SCF/Transforms/Passes.h"
-
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
-#include "ttmlir/Conversion/Passes.h"
 
 namespace mlir::tt::ttkernel {
 //===----------------------------------------------------------------------===//

--- a/lib/RegisterAll.cpp
+++ b/lib/RegisterAll.cpp
@@ -13,6 +13,7 @@
 #include "ttmlir/Dialect/TTIR/Pipelines/TTIRPipelines.h"
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTKernel/IR/TTKernel.h"
+#include "ttmlir/Dialect/TTKernel/Pipelines/TTKernelPipelines.h"
 #include "ttmlir/Dialect/TTMetal/Pipelines/TTMetalPipelines.h"
 #include "ttmlir/Dialect/TTMetal/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNN.h"
@@ -91,6 +92,7 @@ void mlir::tt::registerAllPasses() {
   mlir::tt::ttir::registerTTIRPipelines();
   mlir::tt::ttnn::registerTTNNPipelines();
   mlir::tt::ttmetal::registerTTMetalPipelines();
+  mlir::tt::ttkernel::registerTTKernelPipelines();
 }
 
 void mlir::tt::MLIRModuleLogger::attachContext(

--- a/python/Passes.cpp
+++ b/python/Passes.cpp
@@ -237,6 +237,34 @@ void populatePassesModule(nb::module_ &m) {
       },
       nb::arg("module"), nb::arg("isTensixKernel"));
 
+  m.def(
+      "pykernel_compile_pipeline",
+      [](MlirModule module, std::string options = "") {
+        mlir::Operation *moduleOp = unwrap(mlirModuleGetOperation(module));
+        mlir::PassManager pm(moduleOp->getName());
+
+        mlir::DialectRegistry registry;
+        mlir::tt::registerAllDialects(registry);
+        mlir::tt::registerAllExtensions(registry);
+        mlir::MLIRContext *ctx = unwrap(mlirModuleGetContext(module));
+        ctx->appendDialectRegistry(registry);
+
+        const auto *pipeline =
+            mlir::PassPipelineInfo::lookup("pykernel-compile-pipeline");
+
+        std::function<mlir::LogicalResult(const llvm::Twine &)> err_handler =
+            [](const llvm::Twine &) { return mlir::failure(); };
+
+        if (mlir::failed(pipeline->addToPipeline(pm, options, err_handler))) {
+          throw std::runtime_error("Failed to add pipeline to pass manager");
+        }
+
+        if (mlir::failed(pm.run(moduleOp))) {
+          throw std::runtime_error("Failed to run pass manager");
+        }
+      },
+      nb::arg("module"), nb::arg("options") = "");
+
   nb::enum_<::tt::target::DataType>(m, "DataType")
       .value("Float32", ::tt::target::DataType::Float32)
       .value("Float16", ::tt::target::DataType::Float16);

--- a/python/pykernel/pykernel_ast.py
+++ b/python/pykernel/pykernel_ast.py
@@ -617,7 +617,7 @@ def ttkernel_compile(kernel_type=None, verbose: bool = False):
             print(b.module)
             b.module.operation.verify()
 
-            # Run the PyKernel Compile Pipeline to fit model for Trnaslation
+            # Run the PyKernel Compile Pipeline to fit model for Translation
             pykernel_compile_pipeline(b.module)
             print("---- Optimized PyKernel Module ----", b.module, sep="\n\n")
 

--- a/python/pykernel/pykernel_ast.py
+++ b/python/pykernel/pykernel_ast.py
@@ -8,7 +8,7 @@ import functools
 import os
 from ttmlir.ir import *
 from ttmlir.dialects import tt, ttkernel, func, scf, arith, memref, emitc
-from ttmlir.passes import ttkernel_to_cpp
+from ttmlir.passes import ttkernel_to_cpp, pykernel_compile_pipeline
 
 # ttmlir-translate --ttkernel-to-cpp-noc
 
@@ -616,6 +616,10 @@ def ttkernel_compile(kernel_type=None, verbose: bool = False):
             # Check if generated IR is valid
             print(b.module)
             b.module.operation.verify()
+
+            # Run the PyKernel Compile Pipeline to fit model for Trnaslation
+            pykernel_compile_pipeline(b.module)
+            print("---- Optimized PyKernel Module ----", b.module, sep="\n\n")
 
             if kernel_type:
                 assert kernel_type in ["noc", "tensix"], "Invalid kernel type"


### PR DESCRIPTION
### Ticket
- PR closes #2562 

### Problem description
- It would be best to leverage some of MLIR's existing passes (+ the ones we have defined) before translation in PyKernel
- The pipeline provides a sufficient platform to hold those passes + define the compilation flow.

### What's changed
- Added a PyKernel Compile Pipeline to run passes before translation to C++.
- Pybound pipeline.
- Added SROA and EmitC's form-expressions passes to the pipeline (w/ Options)
