### PR TITLE
Generic regions to top level functions pass

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIRBase.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRBase.td
@@ -39,10 +39,6 @@ def TTIR_Dialect : Dialect {
 
     let extraClassDeclaration = [{
         void registerTypes();
-
-        static StringRef getThreadTypeAttrName() {
-          return "ttir.thread_type";
-        }
     }];
 }
 

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRBase.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRBase.td
@@ -58,7 +58,7 @@ def ThreeOperands : ParamNativeOpTrait<"NOperands", "3">;
 def FourOperands : ParamNativeOpTrait<"NOperands", "4">;
 
 class TTIR_Trait<string name, list<Trait> traits = []> : NativeOpTrait<name, traits> {
-  let cppNamespace = "::mlir::OpTrait::tt::ttir";
+  let cppNamespace = "::mlir::tt::ttir";
 }
 
 // Involution is property of an operation where applying the operation twice results in the original value.

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRBase.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRBase.td
@@ -39,6 +39,10 @@ def TTIR_Dialect : Dialect {
 
     let extraClassDeclaration = [{
         void registerTypes();
+
+        static StringRef getThreadTypeAttrName() {
+          return "ttir.thread_type";
+        }
     }];
 }
 
@@ -58,7 +62,7 @@ def ThreeOperands : ParamNativeOpTrait<"NOperands", "3">;
 def FourOperands : ParamNativeOpTrait<"NOperands", "4">;
 
 class TTIR_Trait<string name, list<Trait> traits = []> : NativeOpTrait<name, traits> {
-  let cppNamespace = "::mlir::tt::ttir::OpTrait";
+  let cppNamespace = "::mlir::OpTrait::tt::ttir";
 }
 
 // Involution is property of an operation where applying the operation twice results in the original value.
@@ -70,8 +74,10 @@ def TTIR_Idempotence : TTIR_Trait<"TTIRIdempotence", [DestinationStyleOpInterfac
 // BinaryIdempotence is property of a binary operation where applying the operation on the same value results in the same value.
 // Example: and(x, x) == x
 def TTIR_BinaryIdempotence : TTIR_Trait<"TTIRBinaryIdempotence", [DestinationStyleOpInterface, ThreeOperands, NoMemoryEffect]>;
-// GenericRegionOpTrait is a trait that acts as a label for all generic region operations.
-def TTIR_GenericRegionOpTrait : TTIR_Trait<"TTIRGenericRegionOpTrait", []>;
+// GenericRegionComputeOpTrait is a trait that verifies that the operation is inside a compute thread.
+def TTIR_GenericRegionComputeOpTrait : TTIR_Trait<"TTIRGenericRegionComputeOpTrait">;
+// GenericRegionDatamovementOpTrait is a trait that verifies that the operation is inside a datamovement thread.
+def TTIR_GenericRegionDatamovementOpTrait : TTIR_Trait<"TTIRGenericRegionDatamovementOpTrait">;
 
 //===----------------------------------------------------------------------===//
 // TTIR common types.

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
@@ -15,15 +15,20 @@ include "mlir/IR/OpAsmInterface.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/InferIntRangeInterface.td"
 
-class TTIR_GenericRegionOp<string mnemonic, list<Trait> traits = [TTIR_GenericRegionOpTrait, TTIR_GenericParent]> :
-    TTIR_Op<mnemonic, traits> {
-}
+class TTIR_GenericRegionOp<string mnemonic, list<Trait> traits = []> :
+    TTIR_Op<mnemonic, [TTIR_GenericParent] # traits> {}
+
+class TTIR_GenericRegionComputeOp<string mnemonic, list<Trait> traits = []> :
+    TTIR_GenericRegionOp<mnemonic, [TTIR_GenericRegionComputeOpTrait] # traits> {}
+
+class TTIR_GenericRegionDatamovementOp<string mnemonic, list<Trait> traits = []> :
+    TTIR_GenericRegionOp<mnemonic, [TTIR_GenericRegionDatamovementOpTrait] # traits> {}
 
 //===----------------------------------------------------------------------===//
 // TTIR Generic Region Math Ops (Used in TTMetal Lowering)
 //===----------------------------------------------------------------------===//
 
-def TTIR_TileAddOp : TTIR_GenericRegionOp<"tile_add">{
+def TTIR_TileAddOp : TTIR_GenericRegionComputeOp<"tile_add"> {
     let summary = "TTIR Tile Add Op";
     let description = [{
         The `tile_add` operation adds two tiles element-wise.
@@ -34,7 +39,7 @@ def TTIR_TileAddOp : TTIR_GenericRegionOp<"tile_add">{
     let results = (outs TT_Tile:$result);
 }
 
-def TTIR_TileSubOp : TTIR_GenericRegionOp<"tile_sub">{
+def TTIR_TileSubOp : TTIR_GenericRegionComputeOp<"tile_sub"> {
     let summary = "TTIR Tile Sub Op";
     let description = [{
         The `tile_sub` operation subtracts two tiles element-wise.
@@ -45,7 +50,7 @@ def TTIR_TileSubOp : TTIR_GenericRegionOp<"tile_sub">{
     let results = (outs TT_Tile:$result);
 }
 
-def TTIR_TileMulOp : TTIR_GenericRegionOp<"tile_mul">{
+def TTIR_TileMulOp : TTIR_GenericRegionComputeOp<"tile_mul"> {
     let summary = "TTIR Tile Mul Op";
     let description = [{
         The `tile_mul` operation multiplies two tiles element-wise.
@@ -56,7 +61,7 @@ def TTIR_TileMulOp : TTIR_GenericRegionOp<"tile_mul">{
     let results = (outs TT_Tile:$result);
 }
 
-def TTIR_TileRecipOp : TTIR_GenericRegionOp<"tile_recip">{
+def TTIR_TileRecipOp : TTIR_GenericRegionComputeOp<"tile_recip"> {
     let summary = "TTIR Tile Recip Op";
     let description = [{
         The `tile_recip` operation computes the reciprocal of each element in the input tile.
@@ -66,7 +71,7 @@ def TTIR_TileRecipOp : TTIR_GenericRegionOp<"tile_recip">{
     let results = (outs TT_Tile:$result);
 }
 
-def TTIR_TileExpOp : TTIR_GenericRegionOp<"tile_exp">{
+def TTIR_TileExpOp : TTIR_GenericRegionComputeOp<"tile_exp"> {
     let summary = "TTIR Tile Exp Op";
     let description = [{
         The `tile_exp` operation computes the exponential of each element in the input tile.
@@ -76,7 +81,7 @@ def TTIR_TileExpOp : TTIR_GenericRegionOp<"tile_exp">{
     let results = (outs TT_Tile:$result);
 }
 
-def TTIR_TileLogOp : TTIR_GenericRegionOp<"tile_log">{
+def TTIR_TileLogOp : TTIR_GenericRegionComputeOp<"tile_log"> {
     let summary = "TTIR Tile Log Op";
     let description = [{
         The `tile_log` operation computes the natural logarithm of each element in the input tile.
@@ -86,7 +91,7 @@ def TTIR_TileLogOp : TTIR_GenericRegionOp<"tile_log">{
     let results = (outs TT_Tile:$result);
 }
 
-def TTIR_TileReduceSumOp : TTIR_GenericRegionOp<"tile_reduce_sum">{
+def TTIR_TileReduceSumOp : TTIR_GenericRegionComputeOp<"tile_reduce_sum"> {
     let summary = "TTIR Tile Reduce Sum Op";
     let description = [{
         The `tile_reduce_sum` operation computes the weighted sum of all elements in the input tile over the specified reduction dim(s).
@@ -98,7 +103,7 @@ def TTIR_TileReduceSumOp : TTIR_GenericRegionOp<"tile_reduce_sum">{
     let results = (outs TT_Tile:$result);
 }
 
-def TTIR_TileReduceMaxOp : TTIR_GenericRegionOp<"tile_reduce_max">{
+def TTIR_TileReduceMaxOp : TTIR_GenericRegionComputeOp<"tile_reduce_max"> {
     let summary = "TTIR Tile Reduce Max Op";
     let description = [{
         The `tile_reduce_max` operation computes the max of all elements in the input tile over the specified reduction dim(s).
@@ -110,7 +115,7 @@ def TTIR_TileReduceMaxOp : TTIR_GenericRegionOp<"tile_reduce_max">{
     let results = (outs TT_Tile:$result);
 }
 
-def TTIR_TileMatmulBlockOp : TTIR_GenericRegionOp<"tile_matmul_block",
+def TTIR_TileMatmulBlockOp : TTIR_GenericRegionComputeOp<"tile_matmul_block",
   [DestinationStyleOpInterface, DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
     let summary = "TTIR Tile Matmul Block Op";
     let description = [{
@@ -128,7 +133,7 @@ def TTIR_TileMatmulBlockOp : TTIR_GenericRegionOp<"tile_matmul_block",
     let hasVerifier = 1;
 }
 
-def TTIR_TileTilizeBlockOp : TTIR_GenericRegionOp<"tile_tilize_block",
+def TTIR_TileTilizeBlockOp : TTIR_GenericRegionComputeOp<"tile_tilize_block",
   [DestinationStyleOpInterface, MemoryEffects<[MemRead, MemWrite]>]> {
     let summary = "TTIR Tile Tilize Block Op";
     let description = [{
@@ -145,7 +150,7 @@ def TTIR_TileTilizeBlockOp : TTIR_GenericRegionOp<"tile_tilize_block",
     let hasVerifier = 1;
 }
 
-def TTIR_TileUntilizeBlockOp : TTIR_GenericRegionOp<"tile_untilize_block",
+def TTIR_TileUntilizeBlockOp : TTIR_GenericRegionComputeOp<"tile_untilize_block",
   [DestinationStyleOpInterface, MemoryEffects<[MemRead, MemWrite]>]> {
     let summary = "TTIR Tile Untilize Block Op";
     let description = [{
@@ -167,7 +172,7 @@ def TTIR_TileUntilizeBlockOp : TTIR_GenericRegionOp<"tile_untilize_block",
 // TTIR Generic Region Datamovement Ops (Used in TTMetal Lowering)
 //===----------------------------------------------------------------------===//
 
-def TTIR_DMAOp : TTIR_GenericRegionOp<"dma",
+def TTIR_DMAOp : TTIR_GenericRegionDatamovementOp<"dma",
   [ AttrSizedOperandSegments
   , DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
   , DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
@@ -320,7 +325,7 @@ _tx
     }];
 }
 
-def TTIR_NullTxOp : TTIR_GenericRegionOp<"null_tx", [Pure]> {
+def TTIR_NullTxOp : TTIR_GenericRegionDatamovementOp<"null_tx", [Pure]> {
     let summary = "Create a null transaction.";
     let description = [{
       Utility op to create a null transaction.  This is required for creating a sentinel
@@ -332,7 +337,7 @@ def TTIR_NullTxOp : TTIR_GenericRegionOp<"null_tx", [Pure]> {
     let assemblyFormat = [{ attr-dict }];
 }
 
-def TTIR_DMAWaitOp : TTIR_GenericRegionOp<"dma_wait", [MemoryEffects<[MemRead, MemWrite]>]> {
+def TTIR_DMAWaitOp : TTIR_GenericRegionDatamovementOp<"dma_wait", [MemoryEffects<[MemRead, MemWrite]>]> {
     let summary = "TTIR DMA wait Op";
     let description = [{
       Waits for the producer DMA memory transaction to complete.
@@ -480,6 +485,52 @@ def TTIR_CoreIndexOp : TTIR_IndexOp<"core_index", [ConstantLike]> {
       Return the index of this core's coordinate inside the generic op's grid dimension.
     }];
     let hasFolder = true;
+}
+
+//===----------------------------------------------------------------------===//
+// TTIR Remote Access ops (Used in TTMetal Lowering)
+//===----------------------------------------------------------------------===//
+
+def TTIR_GetGlobalOperandOp : TTIR_GenericRegionOp<"get_global_operand", [Pure]> {
+    let summary = "Get global operand op.";
+    let description = [{
+      Access the global, aka parent generic op, operand at the specified index.
+
+      The following forms are all equivalent, but the latter forms are required
+      when moving generic regions to top level func ops in the module.
+      ```mlir
+      ttir.generic (%arg0, %arg1, %arg2) {
+        ^datamovement(%cb0, %cb1, %cb2)
+          ttir.dma %arg1, %cb1 // Capture %arg1 from parent scope
+      }
+      ```
+
+      And:
+      ```mlir
+      ttir.generic (%arg0, %arg1, %arg2) {
+        ^datamovement(%cb0, %cb1, %cb2)
+          %operand_arg1 = ttir.get_global_operand 1
+          ttir.dma %operand_arg1, %cb0
+      }
+      ```
+
+      And:
+      ```mlir
+      func.func @main(...) {
+        ttir.generic (%arg0, %arg1, %arg2) { kernel_symbols = [@dm0] }
+      }
+
+      func.func private @dm0(%cb0, %cb1, %cb2) {
+        %operand_arg1 = ttir.get_global_operand 1
+        ttir.dma %operand_arg1, %cb0
+      }
+      ```
+    }];
+
+    let arguments = (ins ConfinedAttr<I64Attr, [IntMinValue<0>]>:$operand_index);
+    let results = (outs AnyNon0RankedMemRef:$result);
+
+    let assemblyFormat = [{ `(` $operand_index `)` attr-dict `:` type($result) }];
 }
 
 #endif // TTMLIR_TTMLIR_DIALECT_TTIR_TTIRGENERICREGIONOPS_TD

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -143,11 +143,9 @@ def TTIR_GenericOp : TTIR_BufferizableOp<"generic",
                      "llvm::function_ref<void(OpBuilder&, Location, ValueRange)>": $computeRegionBuilder),
       [{
         build($_builder, $_state, inputs, outputs, indexingMaps, iteratorTypes);
-        llvm::SmallVector<Type> blockTypes = llvm::map_to_vector(TypeRange($_state.operands), [&](Type t) {
+        llvm::SmallVector<Type> blockTypes = llvm::map_to_vector(TypeRange($_state.operands), [&](Type t) -> Type {
           mlir::RankedTensorType tensorType = mlir::cast<RankedTensorType>(t);
-          tt::MetalLayoutAttr layout =
-              mlir::cast<tt::MetalLayoutAttr>(tensorType.getEncoding());
-          return mlir::cast<Type>(layout.getMemref());
+          return mlir::cast<tt::MetalLayoutAttr>(tensorType.getEncoding()).getMemref();
         });
         Region& region = *$_state.regions.front().get();
         llvm::SmallVector<mlir::Location> locs($_state.operands.size(), $_state.location);

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -97,6 +97,7 @@ def TTIR_GenericOp : TTIR_BufferizableOp<"generic",
         grid = #tt.grid<1x1>,                        // The grid range of cores to dispatch work to.
         indexing_maps = [#map, #map, #map],          // Affine maps for indexing into the input/output tensors. See linalg.generic
         iterator_types = [#parallel, #parallel],     // Iterator types for the input/output tensors. See linalg.generic
+        threads = [#ttir.thread<compute>],           // Thread types for the regions.
         operandSegmentSizes = array<i32: 2, 1>       // Sizes of the operand segments, i.e. 2 inputs and 1 output.
       ({
       ^bb0(%arg2: memref<64x128xf32, #l1_>,
@@ -111,10 +112,50 @@ def TTIR_GenericOp : TTIR_BufferizableOp<"generic",
                          Variadic<AnyRankedTensorOrMemRef>:$outputs,
                          TT_GridAttr:$grid,
                          AffineMapArrayAttr:$indexing_maps,
-                         TT_IteratorTypeArrayAttr:$iterator_types);
+                         TT_IteratorTypeArrayAttr:$iterator_types,
+                         TTIR_ThreadArrayAttr:$threads);
     let results = (outs Variadic<AnyRankedTensor>:$results);
     let regions = (region VariadicRegion<AnyRegion>:$regions);
     let hasVerifier = 1;
+
+    let assemblyFormat = [{ attr-dict `\n`
+    ` ` ` ` ` ` ` ` `ins` `(` $inputs `:` type($inputs) `)` `\n`
+    ` ` ` ` ` ` ` ` `outs` `(` $outputs  `:` type($outputs) `)` ` `  $regions (`:`  type($results)^ )?
+    }];
+
+    let builders =
+    [
+      OpBuilder<(ins "ValueRange": $inputs,
+                     "ValueRange": $outputs,
+                     "ArrayAttr": $indexingMaps,
+                     "ArrayAttr": $iteratorTypes),
+      [{
+        assert(!indexingMaps.empty() && "expected non-empty indexing maps");
+        auto firstIndexingMap = mlir::cast<AffineMapAttr>(indexingMaps[0]).getValue();
+        auto grid = $_builder.getAttr<tt::GridAttr>(SmallVector<int64_t>(firstIndexingMap.getNumResults(), 1));
+        auto threads = $_builder.getArrayAttr($_builder.getAttr<ThreadAttr>(ThreadType::Compute));
+        build($_builder, $_state, TypeRange(outputs), inputs, outputs, grid, indexingMaps, iteratorTypes, threads, 1);
+      }]>,
+      OpBuilder<(ins "ValueRange": $inputs,
+                     "ValueRange": $outputs,
+                     "ArrayAttr": $indexingMaps,
+                     "ArrayAttr": $iteratorTypes,
+                     "llvm::function_ref<void(OpBuilder&, Location, ValueRange)>": $computeRegionBuilder),
+      [{
+        build($_builder, $_state, inputs, outputs, indexingMaps, iteratorTypes);
+        llvm::SmallVector<Type> blockTypes = llvm::map_to_vector(TypeRange($_state.operands), [&](Type t) {
+          mlir::RankedTensorType tensorType = mlir::cast<RankedTensorType>(t);
+          tt::MetalLayoutAttr layout =
+              mlir::cast<tt::MetalLayoutAttr>(tensorType.getEncoding());
+          return mlir::cast<Type>(layout.getMemref());
+        });
+        Region& region = *$_state.regions.front().get();
+        llvm::SmallVector<mlir::Location> locs($_state.operands.size(), $_state.location);
+        OpBuilder::InsertionGuard guard($_builder);
+        Block* block = $_builder.createBlock(&region, region.end(), blockTypes, locs);
+        computeRegionBuilder($_builder, $_state.location, block->getArguments());
+      }]>,
+    ];
 
     let extraClassDeclaration = [{
       MutableOperandRange getDpsInitsMutable() { return ttir::getDpsOutputs(this); }
@@ -124,6 +165,12 @@ def TTIR_GenericOp : TTIR_BufferizableOp<"generic",
       SmallVector<AffineMap> getIndexingMapsValue();
       SmallVector<IteratorType> getIteratorTypesValue();
       SmallVector<SmallVector<int64_t>> getOperandGridShapes();
+      ThreadType getRegionThreadType(unsigned regionIndex) {
+        return mlir::cast<ThreadAttr>(getThreads()[regionIndex]).getThreadType();
+      }
+      bool isAffineMapForm() { return !getIndexingMaps().empty(); }
+      bool isLoweredLoopForm() { return !isAffineMapForm(); }
+      bool isExternalSymbolForm() { return getRegions().empty(); }
     }];
 }
 

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROpsAttrs.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROpsAttrs.td
@@ -56,4 +56,26 @@ def TTIR_HoistedCallAttr : AttrDef<TTIR_Dialect, "HoistedCall", [], "::mlir::Att
   }];
 }
 
+def TTIR_ThreadAttr : AttrDef<TTIR_Dialect, "Thread", [], "::mlir::Attribute"> {
+  let mnemonic = "thread";
+  let summary = "Thread information for a generic op.";
+  let description = [{
+    Holds the thread information corresponding to a single generic op region.
+  }];
+  let parameters = (ins
+    "ThreadType":$threadType,
+    OptionalParameter<"SymbolRefAttr">:$kernelSymbol
+  );
+
+  let assemblyFormat = [{ `<` $threadType (`,` $kernelSymbol^)? `>` }];
+
+  let extraClassDeclaration = [{
+      static ThreadAttr get(::mlir::MLIRContext *context, ThreadType threadType) {
+        return get(context, threadType, nullptr);
+      }
+  }];
+}
+
+def TTIR_ThreadArrayAttr : TypedArrayAttrBase<TTIR_ThreadAttr, "">;
+
 #endif // TTMLIR_TTIR_ATTRS_TD

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROpsEnums.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROpsEnums.td
@@ -31,4 +31,15 @@ def TTIR_ReduceDim : I32EnumAttr<"ReduceDim", "TTIR ReduceDim", [
   let cppNamespace = "::mlir::tt::ttir";
 }
 
+def TTIR_ThreadTypeCompute : I32EnumAttrCase<"Compute", 0, "compute">;
+def TTIR_ThreadTypeDatamovement : I32EnumAttrCase<"Datamovement", 1, "datamovement">;
+
+def TTIR_ThreadType : I32EnumAttr<"ThreadType", "TTIR ThreadType", [
+                                  TTIR_ThreadTypeCompute,
+                                  TTIR_ThreadTypeDatamovement,
+                                ]> {
+  let genSpecializedAttr = 1;
+  let cppNamespace = "::mlir::tt::ttir";
+}
+
 #endif

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRTraits.h
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRTraits.h
@@ -9,7 +9,6 @@
 #include "mlir/Support/LLVM.h"
 
 namespace mlir {
-namespace OpTrait {
 namespace tt {
 namespace ttir {
 namespace impl {
@@ -70,7 +69,7 @@ public:
 
 template <typename ConcreteType>
 struct TTIRGenericRegionComputeOpTrait
-    : public TraitBase<ConcreteType, TTIRGenericRegionComputeOpTrait> {
+    : public OpTrait::TraitBase<ConcreteType, TTIRGenericRegionComputeOpTrait> {
   static mlir::LogicalResult verifyTrait(mlir::Operation *op) {
     return impl::verifyGenericRegionComputeOp(op);
   }
@@ -78,7 +77,8 @@ struct TTIRGenericRegionComputeOpTrait
 
 template <typename ConcreteType>
 struct TTIRGenericRegionDatamovementOpTrait
-    : public TraitBase<ConcreteType, TTIRGenericRegionDatamovementOpTrait> {
+    : public OpTrait::TraitBase<ConcreteType,
+                                TTIRGenericRegionDatamovementOpTrait> {
   static mlir::LogicalResult verifyTrait(mlir::Operation *op) {
     return impl::verifyGenericRegionDatamovementOp(op);
   }
@@ -86,7 +86,6 @@ struct TTIRGenericRegionDatamovementOpTrait
 
 } // namespace ttir
 } // namespace tt
-} // namespace OpTrait
 } // namespace mlir
 
 #endif // TTMLIR_DIALECT_TTIR_IR_TTIRTRAITS_H

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRTraits.h
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRTraits.h
@@ -9,14 +9,15 @@
 #include "mlir/Support/LLVM.h"
 
 namespace mlir {
+namespace OpTrait {
 namespace tt {
 namespace ttir {
-namespace OpTrait {
-
 namespace impl {
 bool verifyInvolution(mlir::Operation *op);
 bool verifyIdempotence(mlir::Operation *op);
 bool verifyBinaryIdempotence(mlir::Operation *op);
+mlir::LogicalResult verifyGenericRegionComputeOp(mlir::Operation *op);
+mlir::LogicalResult verifyGenericRegionDatamovementOp(mlir::Operation *op);
 mlir::OpFoldResult foldInvolution(mlir::Operation *op);
 mlir::OpFoldResult foldIdempotence(mlir::Operation *op);
 mlir::OpFoldResult foldBinaryIdempotence(mlir::Operation *op);
@@ -68,13 +69,24 @@ public:
 };
 
 template <typename ConcreteType>
-class TTIRGenericRegionOpTrait
-    : public mlir::OpTrait::TraitBase<ConcreteType, TTIRGenericRegionOpTrait> {
+struct TTIRGenericRegionComputeOpTrait
+    : public TraitBase<ConcreteType, TTIRGenericRegionComputeOpTrait> {
+  static mlir::LogicalResult verifyTrait(mlir::Operation *op) {
+    return impl::verifyGenericRegionComputeOp(op);
+  }
 };
 
-} // namespace OpTrait
+template <typename ConcreteType>
+struct TTIRGenericRegionDatamovementOpTrait
+    : public TraitBase<ConcreteType, TTIRGenericRegionDatamovementOpTrait> {
+  static mlir::LogicalResult verifyTrait(mlir::Operation *op) {
+    return impl::verifyGenericRegionDatamovementOp(op);
+  }
+};
+
 } // namespace ttir
 } // namespace tt
+} // namespace OpTrait
 } // namespace mlir
 
 #endif // TTMLIR_DIALECT_TTIR_IR_TTIRTRAITS_H

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -230,6 +230,40 @@ def TTIRGenericLowerDMAs : Pass<"ttir-generic-lower-dmas", "::mlir::ModuleOp"> {
   }];
 }
 
+def TTIRGenericRegionsToFuncs : Pass<"ttir-generic-regions-to-funcs", "::mlir::ModuleOp"> {
+  let summary = "Move generic regions to top level functions.";
+  let description = [{
+    This pass moves the generic regions to top level functions. This is a useful prerequisite
+    step before lowering because it enables us to better separate kernel program lowering from
+    host program lowering.
+
+    ```mlir
+    func.func @main(/*...*/) {
+      ttir.generic {grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute>]}
+          ins(%arg0, %arg1 : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>)
+          outs(%alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>)  {
+      ^compute0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
+        // ...compute body...
+      }
+    }
+    ```
+
+    Into (note the new compute function / symbol @compute_kernel0):
+    ```mlir
+    func.func @main(/*...*/) {
+      ttir.generic {grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute, @compute_kernel0>]}
+          ins(%arg0, %arg1 : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>)
+          outs(%alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>)
+    }
+
+    func.func private @compute_kernel0(%arg0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>) attributes {ttir.thread_type = 0 : i32} {
+      // ...compute body...
+      return
+    }
+    ```
+  }];
+}
+
 def TTIRLayout: Pass<"ttir-layout", "::mlir::ModuleOp"> {
   let summary = "Tensor tilize all generic ops.";
   let description = [{

--- a/include/ttmlir/Utils.h
+++ b/include/ttmlir/Utils.h
@@ -582,6 +582,20 @@ constexpr bool always_false() {
   return false;
 }
 
+template <typename... Args>
+static mlir::Region *getRegionWithParentOfType(mlir::Operation *op) {
+  mlir::Region *region = op->getParentRegion();
+  mlir::Operation *parentOp = region->getParentOp();
+  while (!mlir::isa<Args...>(parentOp)) {
+    region = parentOp->getParentRegion();
+    if (!region) {
+      break;
+    }
+    parentOp = region->getParentOp();
+  }
+  return region;
+}
+
 } // namespace ttmlir::utils
 
 #endif // TTMLIR_UTILS_H

--- a/include/ttmlir/Utils.h
+++ b/include/ttmlir/Utils.h
@@ -582,11 +582,11 @@ constexpr bool always_false() {
   return false;
 }
 
-template <typename... Args>
+template <typename... ParentOps>
 static mlir::Region *getRegionWithParentOfType(mlir::Operation *op) {
   mlir::Region *region = op->getParentRegion();
   mlir::Operation *parentOp = region->getParentOp();
-  while (!mlir::isa<Args...>(parentOp)) {
+  while (!mlir::isa<ParentOps...>(parentOp)) {
     region = parentOp->getParentRegion();
     if (!region) {
       break;

--- a/lib/Conversion/TTIRToTTIRGeneric/TTIRToTTIRGeneric.cpp
+++ b/lib/Conversion/TTIRToTTIRGeneric/TTIRToTTIRGeneric.cpp
@@ -133,9 +133,8 @@ private:
 
     // Create 'ttir.generic' accepting 'op's operands.
     auto generic = rewriter.create<ttir::GenericOp>(
-        loc, mlir::TypeRange(outputs), inputs, outputs, grid,
-        rewriter.getAffineMapArrayAttr(indexingMaps),
-        rewriter.getArrayAttr(iteratorTypes), /* regionsCount */ 1);
+        loc, inputs, outputs, rewriter.getAffineMapArrayAttr(indexingMaps),
+        rewriter.getArrayAttr(iteratorTypes));
 
     // Create one bb in 'generic''s region and set its arguments.
     rewriter.startOpModification(generic);
@@ -268,9 +267,8 @@ private:
 
     // Create 'ttir.generic' accepting extended operands.
     auto generic = rewriter.create<ttir::GenericOp>(
-        loc, mlir::TypeRange(outputs), newInputs, outputs, grid,
-        rewriter.getAffineMapArrayAttr(indexingMaps),
-        rewriter.getArrayAttr(iteratorTypes), /* regionsCount */ 1);
+        loc, newInputs, outputs, rewriter.getAffineMapArrayAttr(indexingMaps),
+        rewriter.getArrayAttr(iteratorTypes));
 
     // Create one bb in 'generic''s region and set its arguments.
     rewriter.startOpModification(generic);
@@ -507,9 +505,8 @@ private:
 
     // Create 'ttir.generic' accepting 'op's operands.
     auto generic = rewriter.create<ttir::GenericOp>(
-        loc, mlir::TypeRange(outputs), inputs, outputs, grid,
-        rewriter.getAffineMapArrayAttr(indexingMaps),
-        rewriter.getArrayAttr(iteratorTypes), /* regionsCount */ 1);
+        loc, inputs, outputs, rewriter.getAffineMapArrayAttr(indexingMaps),
+        rewriter.getArrayAttr(iteratorTypes));
 
     // Create one bb in 'generic''s region and set its arguments.
     rewriter.startOpModification(generic);

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -10,6 +10,7 @@
 #include "ttmlir/Utils.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Traits.h"
@@ -2911,12 +2912,19 @@ verifyAffineShapes(llvm::function_ref<mlir::InFlightDiagnostic()> diagFn,
 // GenericOp verification
 ::mlir::LogicalResult mlir::tt::ttir::GenericOp::verify() {
   if (!getGrid().getMapping().isEmpty()) {
-    return emitOpError("GenericOp grid mapping is not supported");
+    return emitOpError("grid mapping is not supported");
   }
 
   if (getOutputs().size() != 1) {
-    return emitOpError(
-        "GenericOp must currently have exactly one output operand");
+    return emitOpError("must currently have exactly one output operand");
+  }
+
+  if (getThreads().empty()) {
+    return emitOpError("must have at least one thread");
+  }
+
+  if (!getRegions().empty() && getRegions().size() != getThreads().size()) {
+    return emitOpError("number of regions must match the number of threads");
   }
 
   // Output grid shape must equal the GenericOp grid shape.
@@ -2943,7 +2951,7 @@ verifyAffineShapes(llvm::function_ref<mlir::InFlightDiagnostic()> diagFn,
     }
     if (opGridShape != outputGridShape) {
       return emitOpError(
-          "Output grid shape must match the GenericOp grid shape");
+          "output grid shape must match the generic op's grid shape");
     }
   }
 
@@ -2973,11 +2981,11 @@ verifyAffineShapes(llvm::function_ref<mlir::InFlightDiagnostic()> diagFn,
   auto *firstRegion = getRegions().begin();
   for (Region &region : getRegions()) {
     if (!region.hasOneBlock()) {
-      return emitOpError("GenericOp region must have a single block");
+      return emitOpError("region must have a single block");
     }
 
     if (region.getNumArguments() < this->getNumOperands()) {
-      return emitOpError("GenericOp region must have at least as many "
+      return emitOpError("region must have at least as many "
                          "arguments as the number of top-level operands");
     }
 
@@ -2998,7 +3006,7 @@ verifyAffineShapes(llvm::function_ref<mlir::InFlightDiagnostic()> diagFn,
     for (BlockArgument arg : memrefArguments) {
       auto blockMemref = mlir::dyn_cast<MemRefType>(arg.getType());
       if (!blockMemref) {
-        return emitOpError("GenericOp region arguments must be of MemRefType");
+        return emitOpError("region arguments must be of MemRefType");
       }
 
       Type operandType = operandTypes[arg.getArgNumber()];
@@ -3027,12 +3035,12 @@ verifyAffineShapes(llvm::function_ref<mlir::InFlightDiagnostic()> diagFn,
       }
 
       if (!isStream && expectedMemorySpace != blockMemref.getMemorySpace()) {
-        return emitOpError("GenericOp region argument memory space must match "
+        return emitOpError("region argument memory space must match "
                            "the memory space of the corresponding operand");
       }
 
       if (expectedShardShape != blockMemref.getShape()) {
-        return emitOpError("GenericOp region argument shape must match the "
+        return emitOpError("region argument shape must match the "
                            "shape of the corresponding operand");
       }
     }
@@ -3043,7 +3051,16 @@ verifyAffineShapes(llvm::function_ref<mlir::InFlightDiagnostic()> diagFn,
       bool supportedType = mlir::isa<SemaphoreType>(arg.getType());
       if (!supportedType) {
         return emitOpError(
-            "Additional GenericOp region arguments must be of SemaphoreType");
+            "additional region arguments must be of 'semaphore' type");
+      }
+    }
+  }
+
+  if (isExternalSymbolForm()) {
+    for (auto &thread : getThreads()) {
+      if (!mlir::cast<ThreadAttr>(thread).getKernelSymbol()) {
+        return emitOpError("threads must have a kernel symbol in external "
+                           "symbol form (i.e. without regions)");
       }
     }
   }
@@ -3156,15 +3173,14 @@ void mlir::tt::ttir::GenericOp::getAsmBlockArgumentNames(
 
 void mlir::tt::ttir::GenericOp::getAsmBlockNames(
     function_ref<void(Block *, StringRef)> setNameFn) {
-  size_t numRegions = getNumRegions();
+  std::array<int, getMaxEnumValForThreadType() + 1> threadTypeCounts{};
   for (Region &region : getRegions()) {
-    // Right now the last region is implicitly the compute region.
-    if (region.getRegionNumber() < (numRegions - 1)) {
-      setNameFn(&region.front(),
-                "datamovement" + std::to_string(region.getRegionNumber()));
-    } else {
-      setNameFn(&region.front(), "compute");
-    }
+    auto type = getRegionThreadType(region.getRegionNumber());
+    setNameFn(&region.front(),
+              stringifyEnum(type).str() +
+                  Twine(threadTypeCounts[static_cast<
+                            std::underlying_type_t<ThreadType>>(type)]++)
+                      .str());
   }
 }
 
@@ -3202,7 +3218,7 @@ mlir::LogicalResult mlir::tt::ttir::GenericOp::bufferize(
   }
   auto bufferGeneric = rewriter.create<mlir::tt::ttir::GenericOp>(
       getLoc(), ValueRange(), bufferInputs, bufferOutputs, getGrid(),
-      getIndexingMaps(), getIteratorTypes(), getNumRegions());
+      getIndexingMaps(), getIteratorTypes(), getThreads(), getNumRegions());
   for (mlir::Region &region : bufferGeneric.getRegions()) {
     region.takeBody(getRegion(region.getRegionNumber()));
   }
@@ -3415,10 +3431,14 @@ static mlir::Region *getParentRegionOfType(mlir::Operation *op) {
 
 ::mlir::LogicalResult mlir::tt::ttir::YieldOp::verify() {
   return operandsInRegionArguments(
-      getOperation(), getParentRegionOfType<GenericOp>(getOperation()));
+      getOperation(),
+      ttmlir::utils::getRegionWithParentOfType<GenericOp, func::FuncOp>(
+          getOperation()));
 }
 
 ::mlir::LogicalResult mlir::tt::ttir::AwaitOp::verify() {
   return operandsInRegionArguments(
-      getOperation(), getParentRegionOfType<GenericOp>(getOperation()));
+      getOperation(),
+      ttmlir::utils::getRegionWithParentOfType<GenericOp, func::FuncOp>(
+          getOperation()));
 }

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -3057,11 +3057,11 @@ verifyAffineShapes(llvm::function_ref<mlir::InFlightDiagnostic()> diagFn,
   }
 
   if (isExternalSymbolForm()) {
-    for (auto &thread : getThreads()) {
-      if (!mlir::cast<ThreadAttr>(thread).getKernelSymbol()) {
-        return emitOpError("threads must have a kernel symbol in external "
-                           "symbol form (i.e. without regions)");
-      }
+    if (llvm::any_of(getThreads(), [](Attribute thread) {
+          return !mlir::cast<ThreadAttr>(thread).getKernelSymbol();
+        })) {
+      return emitOpError("threads must have a kernel symbol in external symbol "
+                         "form (i.e. without regions)");
     }
   }
 

--- a/lib/Dialect/TTIR/IR/TTIROpsInterfaces.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROpsInterfaces.cpp
@@ -11,6 +11,7 @@
 #include <llvm/ADT/ArrayRef.h>
 #include <mlir/IR/ValueRange.h>
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Traits.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Operation.h"
@@ -51,7 +52,8 @@ mlir::tt::ttir::detail::verifyBroadcastable(mlir::Operation *op) {
 
 mlir::LogicalResult
 mlir::tt::ttir::detail::verifyGenericParent(mlir::Operation *op) {
-  return op->getParentOfType<ttir::GenericOp>()
+  return (op->getParentOfType<ttir::GenericOp>() ||
+          op->getParentOfType<func::FuncOp>())
              ? success()
              : op->emitOpError(
                    "TTIR Generic Ops must be inside a generic region");

--- a/lib/Dialect/TTIR/IR/TTIRTraits.cpp
+++ b/lib/Dialect/TTIR/IR/TTIRTraits.cpp
@@ -19,7 +19,7 @@ static bool operandAndResultSameType(mlir::Operation *op) {
 // 2. Argument is defined by the same op.
 // 3. 1) is true for the producing op of the argument.
 // op(op(T a, T r0), T r1)
-bool mlir::OpTrait::tt::ttir::impl::verifyInvolution(mlir::Operation *op) {
+bool mlir::tt::ttir::impl::verifyInvolution(mlir::Operation *op) {
   if (!operandAndResultSameType(op)) {
     return false;
   }
@@ -35,7 +35,7 @@ bool mlir::OpTrait::tt::ttir::impl::verifyInvolution(mlir::Operation *op) {
 // 2. Argument is defined by the same op.
 // 3. 1) is true for the producing op of the argument.
 // op(op(T a, T r0), T r1)
-bool mlir::OpTrait::tt::ttir::impl::verifyIdempotence(mlir::Operation *op) {
+bool mlir::tt::ttir::impl::verifyIdempotence(mlir::Operation *op) {
   if (!operandAndResultSameType(op)) {
     return false;
   }
@@ -49,8 +49,7 @@ bool mlir::OpTrait::tt::ttir::impl::verifyIdempotence(mlir::Operation *op) {
 // If Op has TTIRBinaryIdempotence trait, then it's foldable if:
 // 1. Both inputs are the same.
 // 2. Inputs and result types are the same.
-bool mlir::OpTrait::tt::ttir::impl::verifyBinaryIdempotence(
-    mlir::Operation *op) {
+bool mlir::tt::ttir::impl::verifyBinaryIdempotence(mlir::Operation *op) {
   if (op->getOperand(0) != op->getOperand(1)) {
     return false;
   }
@@ -58,18 +57,16 @@ bool mlir::OpTrait::tt::ttir::impl::verifyBinaryIdempotence(
   return op->getResult(0).getType() == op->getOperand(0).getType();
 }
 
-mlir::OpFoldResult
-mlir::OpTrait::tt::ttir::impl::foldInvolution(mlir::Operation *op) {
+mlir::OpFoldResult mlir::tt::ttir::impl::foldInvolution(mlir::Operation *op) {
   return op->getOperand(0).getDefiningOp()->getOperand(0);
 }
 
-mlir::OpFoldResult
-mlir::OpTrait::tt::ttir::impl::foldIdempotence(mlir::Operation *op) {
+mlir::OpFoldResult mlir::tt::ttir::impl::foldIdempotence(mlir::Operation *op) {
   return op->getOperand(0);
 }
 
 mlir::OpFoldResult
-mlir::OpTrait::tt::ttir::impl::foldBinaryIdempotence(mlir::Operation *op) {
+mlir::tt::ttir::impl::foldBinaryIdempotence(mlir::Operation *op) {
   return op->getOperand(0);
 }
 
@@ -91,15 +88,14 @@ verifyGenericRegionOpThreadType(mlir::Operation *op,
   return mlir::success();
 }
 
-mlir::LogicalResult mlir::OpTrait::tt::ttir::impl::verifyGenericRegionComputeOp(
-    mlir::Operation *op) {
+mlir::LogicalResult
+mlir::tt::ttir::impl::verifyGenericRegionComputeOp(mlir::Operation *op) {
   return verifyGenericRegionOpThreadType(op,
                                          ::mlir::tt::ttir::ThreadType::Compute);
 }
 
 mlir::LogicalResult
-mlir::OpTrait::tt::ttir::impl::verifyGenericRegionDatamovementOp(
-    mlir::Operation *op) {
+mlir::tt::ttir::impl::verifyGenericRegionDatamovementOp(mlir::Operation *op) {
   return verifyGenericRegionOpThreadType(
       op, ::mlir::tt::ttir::ThreadType::Datamovement);
 }

--- a/lib/Dialect/TTIR/IR/TTIRTraits.cpp
+++ b/lib/Dialect/TTIR/IR/TTIRTraits.cpp
@@ -4,6 +4,9 @@
 
 #include "ttmlir/Dialect/TTIR/IR/TTIRTraits.h"
 
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+#include "ttmlir/Utils.h"
+
 // Check if all operands and result have the same type. Function assumes op has
 // at least one operand and exactly one result.
 static bool operandAndResultSameType(mlir::Operation *op) {
@@ -16,7 +19,7 @@ static bool operandAndResultSameType(mlir::Operation *op) {
 // 2. Argument is defined by the same op.
 // 3. 1) is true for the producing op of the argument.
 // op(op(T a, T r0), T r1)
-bool mlir::tt::ttir::OpTrait::impl::verifyInvolution(mlir::Operation *op) {
+bool mlir::OpTrait::tt::ttir::impl::verifyInvolution(mlir::Operation *op) {
   if (!operandAndResultSameType(op)) {
     return false;
   }
@@ -32,7 +35,7 @@ bool mlir::tt::ttir::OpTrait::impl::verifyInvolution(mlir::Operation *op) {
 // 2. Argument is defined by the same op.
 // 3. 1) is true for the producing op of the argument.
 // op(op(T a, T r0), T r1)
-bool mlir::tt::ttir::OpTrait::impl::verifyIdempotence(mlir::Operation *op) {
+bool mlir::OpTrait::tt::ttir::impl::verifyIdempotence(mlir::Operation *op) {
   if (!operandAndResultSameType(op)) {
     return false;
   }
@@ -46,7 +49,7 @@ bool mlir::tt::ttir::OpTrait::impl::verifyIdempotence(mlir::Operation *op) {
 // If Op has TTIRBinaryIdempotence trait, then it's foldable if:
 // 1. Both inputs are the same.
 // 2. Inputs and result types are the same.
-bool mlir::tt::ttir::OpTrait::impl::verifyBinaryIdempotence(
+bool mlir::OpTrait::tt::ttir::impl::verifyBinaryIdempotence(
     mlir::Operation *op) {
   if (op->getOperand(0) != op->getOperand(1)) {
     return false;
@@ -56,16 +59,47 @@ bool mlir::tt::ttir::OpTrait::impl::verifyBinaryIdempotence(
 }
 
 mlir::OpFoldResult
-mlir::tt::ttir::OpTrait::impl::foldInvolution(mlir::Operation *op) {
+mlir::OpTrait::tt::ttir::impl::foldInvolution(mlir::Operation *op) {
   return op->getOperand(0).getDefiningOp()->getOperand(0);
 }
 
 mlir::OpFoldResult
-mlir::tt::ttir::OpTrait::impl::foldIdempotence(mlir::Operation *op) {
+mlir::OpTrait::tt::ttir::impl::foldIdempotence(mlir::Operation *op) {
   return op->getOperand(0);
 }
 
 mlir::OpFoldResult
-mlir::tt::ttir::OpTrait::impl::foldBinaryIdempotence(mlir::Operation *op) {
+mlir::OpTrait::tt::ttir::impl::foldBinaryIdempotence(mlir::Operation *op) {
   return op->getOperand(0);
+}
+
+static mlir::LogicalResult
+verifyGenericRegionOpThreadType(mlir::Operation *op,
+                                mlir::tt::ttir::ThreadType threadType) {
+  mlir::Region *region =
+      ttmlir::utils::getRegionWithParentOfType<mlir::tt::ttir::GenericOp>(op);
+  if (!region) {
+    // If not enclosed in a generic op then we forgo verification.
+    return mlir::success();
+  }
+  mlir::tt::ttir::GenericOp genericOp =
+      mlir::cast<mlir::tt::ttir::GenericOp>(region->getParentOp());
+  if (genericOp.getRegionThreadType(region->getRegionNumber()) != threadType) {
+    return op->emitOpError("expected to be in a ")
+           << stringifyEnum(threadType) << " region";
+  }
+  return mlir::success();
+}
+
+mlir::LogicalResult mlir::OpTrait::tt::ttir::impl::verifyGenericRegionComputeOp(
+    mlir::Operation *op) {
+  return verifyGenericRegionOpThreadType(op,
+                                         ::mlir::tt::ttir::ThreadType::Compute);
+}
+
+mlir::LogicalResult
+mlir::OpTrait::tt::ttir::impl::verifyGenericRegionDatamovementOp(
+    mlir::Operation *op) {
+  return verifyGenericRegionOpThreadType(
+      op, ::mlir::tt::ttir::ThreadType::Datamovement);
 }

--- a/lib/Dialect/TTIR/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTIR/Transforms/CMakeLists.txt
@@ -7,6 +7,7 @@ add_mlir_dialect_library(MLIRTTIRTransforms
         GenericGenerateLoops.cpp
         GenericHWThreadSelection.cpp
         GenericLowerDMAs.cpp
+        GenericRegionsToFuncs.cpp
         AttachMetalLayout.cpp
         OptimizeTensorLayout.cpp
         HoistCPUOps.cpp

--- a/lib/Dialect/TTIR/Transforms/GenericGenerateDatamovement.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericGenerateDatamovement.cpp
@@ -227,10 +227,15 @@ public:
     // One per operand.
     auto numDataMovementRegions = generic.getNumOperands();
     auto numTotalRegions = generic.getNumRegions() + numDataMovementRegions;
+    SmallVector<Attribute> threads(
+        numDataMovementRegions,
+        rewriter.getAttr<ThreadAttr>(ThreadType::Datamovement));
+    threads.append(generic.getThreads().begin(), generic.getThreads().end());
     auto newGeneric = rewriter.create<GenericOp>(
         generic->getLoc(), generic.getResultTypes(), generic.getInputs(),
         generic.getOutputs(), generic.getGrid(), generic.getIndexingMaps(),
-        generic.getIteratorTypes(), numTotalRegions);
+        generic.getIteratorTypes(), rewriter.getArrayAttr(threads),
+        numTotalRegions);
 
     // Preinitialize all regions so that we can modify their signatures on the
     // fly. i.e. adding semaphore arguments.

--- a/lib/Dialect/TTIR/Transforms/GenericGenerateLoops.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericGenerateLoops.cpp
@@ -68,7 +68,7 @@ public:
         generic->getLoc(), generic.getResultTypes(), generic.getInputs(),
         generic.getOutputs(), generic.getGrid(),
         /* indexing_maps */ rewriter.getArrayAttr({}),
-        /* iterator_types */ rewriter.getArrayAttr({}),
+        /* iterator_types */ rewriter.getArrayAttr({}), generic.getThreads(),
         generic.getNumRegions());
 
     SmallVector<int64_t> loopBounds = generic.getLoopBounds();

--- a/lib/Dialect/TTIR/Transforms/GenericHWThreadSelection.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericHWThreadSelection.cpp
@@ -57,10 +57,14 @@ public:
       return failure();
     }
 
+    SmallVector<Attribute> threads(op.getThreads().getValue());
+    // Skip the output operands block
+    threads.erase(threads.begin() + outputOperandsIndex);
     auto newGeneric = rewriter.create<GenericOp>(
         op.getLoc(), op.getResults().getTypes(), op.getInputs(),
         op.getOutputs(), op.getGrid(), op.getIndexingMaps(),
-        op.getIteratorTypes(), op.getNumRegions() - 1);
+        op.getIteratorTypes(), rewriter.getArrayAttr(threads),
+        op.getNumRegions() - 1);
 
     unsigned regionIndex = 0;
     for (mlir::Region &region : op.getRegions()) {

--- a/lib/Dialect/TTIR/Transforms/GenericRegionsToFuncs.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericRegionsToFuncs.cpp
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Rewrite/FrozenRewritePatternSet.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir::tt::ttir {
+#define GEN_PASS_DEF_TTIRGENERICREGIONSTOFUNCS
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h.inc"
+
+static std::optional<unsigned> getCapturedOperandIndex(GenericOp op,
+                                                       Value operand) {
+  for (OpOperand &opOperand : op->getOpOperands()) {
+    if (opOperand.get() == operand) {
+      return opOperand.getOperandNumber();
+    }
+  }
+  return std::nullopt;
+}
+
+static void rewriteOperand(OpBuilder &builder, DMAOp dma, OpOperand &dmaOperand,
+                           unsigned operandIndex) {
+  auto globalOperand = builder.create<GetGlobalOperandOp>(
+      dma.getLoc(), dmaOperand.get().getType(), operandIndex);
+  dmaOperand.set(globalOperand.getResult());
+}
+
+static void rewriteCapturedDMAOperands(OpBuilder &builder, GenericOp generic,
+                                       DMAOp dma) {
+  auto srcIndex = getCapturedOperandIndex(generic, dma.getSrc());
+  auto dstIndex = getCapturedOperandIndex(generic, dma.getDst());
+
+  builder.setInsertionPoint(dma);
+  if (srcIndex) {
+    rewriteOperand(builder, dma, dma.getSrcMutable(), *srcIndex);
+  }
+
+  if (dstIndex) {
+    rewriteOperand(builder, dma, dma.getDstMutable(), *dstIndex);
+  }
+}
+
+namespace {
+class TTIRGenericRegionsToFuncs
+    : public impl::TTIRGenericRegionsToFuncsBase<TTIRGenericRegionsToFuncs> {
+public:
+  using impl::TTIRGenericRegionsToFuncsBase<
+      TTIRGenericRegionsToFuncs>::TTIRGenericRegionsToFuncsBase;
+
+  void runOnOperation() final {
+    ModuleOp moduleOp = getOperation();
+    OpBuilder builder(&getContext());
+    static int unique = 0;
+    moduleOp->walk([&](GenericOp generic) {
+      generic.walk([&](DMAOp dma) {
+        rewriteCapturedDMAOperands(builder, generic, dma);
+      });
+
+      SmallVector<Attribute> threads;
+      for (Region &region : generic.getRegions()) {
+        builder.setInsertionPoint(moduleOp.getBody(),
+                                  moduleOp.getBody()->end());
+        ThreadType threadType =
+            generic.getRegionThreadType(region.getRegionNumber());
+        std::string symbolName =
+            stringifyEnum(generic.getRegionThreadType(region.getRegionNumber()))
+                .str() +
+            "_kernel" + Twine(unique++).str();
+        auto func = builder.create<func::FuncOp>(
+            generic.getLoc(), symbolName,
+            FunctionType::get(builder.getContext(), region.getArgumentTypes(),
+                              {}));
+        func.setPrivate();
+        func->setAttr(TTIRDialect::getThreadTypeAttrName(),
+                      builder.getAttr<ThreadTypeAttr>(threadType));
+        func.getBody().takeBody(region);
+        builder.setInsertionPointToEnd(&func.getBody().front());
+        builder.create<func::ReturnOp>(generic.getLoc());
+
+        threads.push_back(builder.getAttr<ThreadAttr>(
+            threadType, builder.getAttr<SymbolRefAttr>(symbolName)));
+      }
+
+      builder.setInsertionPoint(generic);
+      auto symbolicGeneric = builder.create<GenericOp>(
+          generic->getLoc(), generic.getResultTypes(), generic.getInputs(),
+          generic.getOutputs(), generic.getGrid(), generic.getIndexingMaps(),
+          generic.getIteratorTypes(), builder.getArrayAttr(threads),
+          /*numRegions*/ 0);
+
+      generic.replaceAllUsesWith(symbolicGeneric);
+      generic.erase();
+    });
+  }
+};
+} // namespace
+
+} // namespace mlir::tt::ttir

--- a/lib/Dialect/TTIR/Transforms/GenericRegionsToFuncs.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericRegionsToFuncs.cpp
@@ -58,7 +58,7 @@ public:
   void runOnOperation() final {
     ModuleOp moduleOp = getOperation();
     OpBuilder builder(&getContext());
-    static int unique = 0;
+    int unique = 0;
     moduleOp->walk([&](GenericOp generic) {
       generic.walk([&](DMAOp dma) {
         rewriteCapturedDMAOperands(builder, generic, dma);

--- a/lib/Dialect/TTIR/Transforms/GenericRegionsToFuncs.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericRegionsToFuncs.cpp
@@ -74,19 +74,20 @@ public:
             stringifyEnum(generic.getRegionThreadType(region.getRegionNumber()))
                 .str() +
             "_kernel" + Twine(unique++).str();
+        auto threadAttrWithSym = builder.getAttr<ThreadAttr>(
+            threadType, builder.getAttr<SymbolRefAttr>(symbolName));
+        auto threadAttrWithoutSym =
+            builder.getAttr<ThreadAttr>(threadType, nullptr);
         auto func = builder.create<func::FuncOp>(
             generic.getLoc(), symbolName,
             FunctionType::get(builder.getContext(), region.getArgumentTypes(),
                               {}));
         func.setPrivate();
-        func->setAttr(TTIRDialect::getThreadTypeAttrName(),
-                      builder.getAttr<ThreadTypeAttr>(threadType));
+        func->setAttr(ttir::ThreadAttr::name, threadAttrWithoutSym);
         func.getBody().takeBody(region);
         builder.setInsertionPointToEnd(&func.getBody().front());
         builder.create<func::ReturnOp>(generic.getLoc());
-
-        threads.push_back(builder.getAttr<ThreadAttr>(
-            threadType, builder.getAttr<SymbolRefAttr>(symbolName)));
+        threads.push_back(threadAttrWithSym);
       }
 
       builder.setInsertionPoint(generic);

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -71,6 +71,7 @@ void createTTIRToTTMetalBackendPipeline(
   pm.addPass(ttir::createTTIRGenericHWThreadSelection());
   pm.addPass(ttir::createTTIRGenericGenerateLoops());
   createOptimizationPasses(pm);
+  pm.addPass(ttir::createTTIRGenericRegionsToFuncs());
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/ttmlir/Conversion/TTIRToTTIRGeneric/named_to_generic.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTIRGeneric/named_to_generic.mlir
@@ -68,7 +68,7 @@ module {
 
   // CHECK-LABEL: func @named_contractions
   func.func @named_contractions(%lhs: !lhs, %rhs: !rhs, %out: !matmul_result) -> (!matmul_result) {
-    // CHECK: "ttir.generic"{{.+}}iterator_types = [#parallel, #parallel, #reduction]
+    // CHECK: ttir.generic{{.+}}iterator_types = [#parallel, #parallel, #reduction]
     // CHECK-NOT: linalg.generic
     // CHECK: ttir.tile_matmul_block
     %r = "ttir.matmul"(%lhs, %rhs, %out) : (!lhs, !rhs, !matmul_result) -> (!matmul_result)

--- a/test/ttmlir/Dialect/TTIR/allocate/generic_form_streams.mlir
+++ b/test/ttmlir/Dialect/TTIR/allocate/generic_form_streams.mlir
@@ -15,8 +15,10 @@ func.func @matmul_single_core_stream(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>,
   // CHECK-NOT: "ttir.view_layout"
   // CHECK: [[rhs:%[a-z0-9_]+]] = "ttir.stream_layout"(%arg1,
   %1 = "ttir.view_layout"(%arg1) : (memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>
-  // CHECK: "ttir.generic"([[lhs]], [[rhs]], [[out:%[a-z0-9_]+]])
-  "ttir.generic"(%0, %1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>, operand_cb_mapping = array<i64>}> ({
+  // CHECK: ttir.generic{{.*}}
+  // CHECK-NEXT: ins([[lhs]], [[rhs]] : {{.*}})
+  // CHECK-NEXT: outs([[out:%[a-z0-9_]+]] : {{.*}})
+  "ttir.generic"(%0, %1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^bb0(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
     "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
   }) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
@@ -31,8 +33,10 @@ func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, 
   // CHECK-NOT: "ttir.view_layout"
   // CHECK: [[rhs:%[a-z0-9_]+]] = "ttir.stream_layout"(%arg1,
   %1 = "ttir.view_layout"(%arg1) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>
-  // CHECK: "ttir.generic"([[lhs]], [[rhs]], [[out:%[a-z0-9_]+]])
-  "ttir.generic"(%0, %1, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>, operand_cb_mapping = array<i64>}> ({
+  // CHECK: ttir.generic{{.*}}
+  // CHECK-NEXT: ins([[lhs]], [[rhs]] : {{.*}})
+  // CHECK-NEXT: outs([[out:%[a-z0-9_]+]] : {{.*}})
+  "ttir.generic"(%0, %1, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^bb0(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>):
     "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
   }) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>, memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
@@ -47,8 +51,10 @@ func.func @matmul_multi_core_transpose(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32
   // CHECK-NOT: "ttir.view_layout"
   // CHECK: [[rhs:%[a-z0-9_]+]] = "ttir.stream_layout"(%arg1, {{.*}}, #tt.stream<(d0, d1, d2, d3) -> (d1, d0, d3, d2)>,
   %1 = "ttir.view_layout"(%arg1) : (memref<4x4x8x6x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, affine_map<(d0, d1, d2, d3) -> (d1, d0, d3, d2)>, #l1_>
-  // CHECK: "ttir.generic"([[lhs]], [[rhs]], [[out:%[a-z0-9_]+]])
-  "ttir.generic"(%0, %1, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>, operand_cb_mapping = array<i64>}> ({
+  // CHECK: ttir.generic{{.*}}
+  // CHECK-NEXT: ins([[lhs]], [[rhs]] : {{.*}})
+  // CHECK-NEXT: outs([[out:%[a-z0-9_]+]] : {{.*}})
+  "ttir.generic"(%0, %1, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^bb0(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>):
     "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
   }) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<4x4x6x8x!tt.tile<32x32, f32>, affine_map<(d0, d1, d2, d3) -> (d1, d0, d3, d2)>, #l1_>, memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>) -> ()

--- a/test/ttmlir/Dialect/TTIR/bufferization/bufferization.mlir
+++ b/test/ttmlir/Dialect/TTIR/bufferization/bufferization.mlir
@@ -10,8 +10,8 @@
 func.func @matmul(%arg0: tensor<1x1x2x4x!tt.tile<32x32, f32>>, %arg1: tensor<1x1x4x2x!tt.tile<32x32, f32>>) -> tensor<1x1x2x2x!tt.tile<32x32, f32>> {
   // CHECK: = memref.alloc(){{.*}}: memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>
   %0 = ttir.empty() : tensor<1x1x2x2x!tt.tile<32x32, f32>>
-  // CHECK: {{^  "ttir.generic".*}}
-  %3 = "ttir.generic"(%arg0, %arg1, %0) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map1, #map2], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  // CHECK: {{^  ttir.generic.*}}
+  %3 = "ttir.generic"(%arg0, %arg1, %0) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map1, #map2], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg3: memref<4x2x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
     "ttir.tile_matmul_block"(%arg2, %arg3, %arg4) : (memref<2x4x!tt.tile<32x32, f32>, #l1_>, memref<4x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
   }) : (tensor<1x1x2x4x!tt.tile<32x32, f32>>, tensor<1x1x4x2x!tt.tile<32x32, f32>>, tensor<1x1x2x2x!tt.tile<32x32, f32>>) -> tensor<1x1x2x2x!tt.tile<32x32, f32>>

--- a/test/ttmlir/Dialect/TTIR/bufferization/memory_effects.mlir
+++ b/test/ttmlir/Dialect/TTIR/bufferization/memory_effects.mlir
@@ -10,8 +10,8 @@
 func.func @matmul_pure_tensors(%arg0: tensor<2x4x!tt.tile<32x32, f32>>, %arg1: tensor<4x2x!tt.tile<32x32, f32>>) -> tensor<2x2x!tt.tile<32x32, f32>> {
   %0 = ttir.empty() : tensor<2x2x!tt.tile<32x32, f32>>
   // No uses of %3, so it should be removed.
-  // CHECK-NOT: "ttir.generic"
-  %3 = "ttir.generic"(%arg0, %arg1, %0) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map1, #map2], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  // CHECK-NOT: ttir.generic
+  %3 = "ttir.generic"(%arg0, %arg1, %0) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map1, #map2], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg3: memref<4x2x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
     "ttir.tile_matmul_block"(%arg2, %arg3, %arg4) : (memref<2x4x!tt.tile<32x32, f32>, #l1_>, memref<4x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
   }) : (tensor<2x4x!tt.tile<32x32, f32>>, tensor<4x2x!tt.tile<32x32, f32>>, tensor<2x2x!tt.tile<32x32, f32>>) -> tensor<2x2x!tt.tile<32x32, f32>>
@@ -29,8 +29,8 @@ func.func @to_layout_pure_tensors(%arg0: tensor<2x4x!tt.tile<32x32, f32>>) -> te
 func.func @matmul_memref(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x4x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
   // Ensure that the generic op is not removed.
-  // CHECK: "ttir.generic"
-  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map1, #map2], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  // CHECK: ttir.generic
+  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map1, #map2], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg3: memref<4x2x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
     "ttir.tile_matmul_block"(%arg2, %arg3, %arg4) : (memref<2x4x!tt.tile<32x32, f32>, #l1_>, memref<4x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
   }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x4x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()

--- a/test/ttmlir/Dialect/TTIR/bufferization/prepare_tensors.mlir
+++ b/test/ttmlir/Dialect/TTIR/bufferization/prepare_tensors.mlir
@@ -12,11 +12,13 @@
 func.func @main(%arg0: tensor<256x384xf32, #layout1>, %arg1: tensor<256x384xf32, #layout1>) -> tensor<256x32xf32, #layout2> {
   // CHECK: ttir.empty() : tensor<1x1x8x1x!tt.tile<32x32, f32>, #layout1>
   %0 = ttir.empty() : tensor<256x32xf32, #layout2>
-  // CHECK: : (tensor<1x1x8x12x!tt.tile<32x32, f32>, #layout>, tensor<1x1x8x12x!tt.tile<32x32, f32>, #layout>, tensor<1x1x8x1x!tt.tile<32x32, f32>, #layout1>) -> tensor<1x1x8x1x!tt.tile<32x32, f32>, #layout1>
+  // CHECK: ins({{.*}} : tensor<1x1x8x12x!tt.tile<32x32, f32>, #layout>, tensor<1x1x8x12x!tt.tile<32x32, f32>, #layout>)
+  // CHECK-NEXT: outs({{.*}} : tensor<1x1x8x1x!tt.tile<32x32, f32>, #layout1>)
   %1 = "ttir.generic"(%arg0, %arg1, %0) <{
         grid = #tt.grid<1x1>,
         indexing_maps = [#map1, #map1, #map2],
         iterator_types = [#parallel, #reduction],
+        threads = [#ttir.thread<compute>],
         operandSegmentSizes = array<i32: 2, 1>
         }> ({
         ^bb0(%arg2: memref<8x12x!tt.tile<32x32, f32>, #l1_>,
@@ -41,11 +43,13 @@ func.func @main(%arg0: tensor<256x384xf32, #layout1>, %arg1: tensor<256x384xf32,
 func.func @main(%arg0: tensor<256x384xf32, #layout1>, %arg1: tensor<256x384xf32, #layout1>) -> tensor<256x32xf32, #layout2> {
   // CHECK: ttir.empty() : tensor<4x1x2x1x!tt.tile<32x32, f32>, #layout1>
   %0 = ttir.empty() : tensor<256x32xf32, #layout2>
-  // CHECK: : (tensor<4x3x2x4x!tt.tile<32x32, f32>, #layout>, tensor<4x3x2x4x!tt.tile<32x32, f32>, #layout>, tensor<4x1x2x1x!tt.tile<32x32, f32>, #layout1>) -> tensor<4x1x2x1x!tt.tile<32x32, f32>, #layout1>
+  // CHECK: ins({{.*}} : tensor<4x3x2x4x!tt.tile<32x32, f32>, #layout>, tensor<4x3x2x4x!tt.tile<32x32, f32>, #layout>)
+  // CHECK-NEXT: outs({{.*}} : tensor<4x1x2x1x!tt.tile<32x32, f32>, #layout1>)
   %1 = "ttir.generic"(%arg0, %arg1, %0) <{
         grid = #tt.grid<4x1>,
         indexing_maps = [#map1, #map1, #map2],
         iterator_types = [#parallel, #reduction],
+        threads = [#ttir.thread<compute>],
         operandSegmentSizes = array<i32: 2, 1>
         }> ({
         ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>,

--- a/test/ttmlir/Dialect/TTIR/generic/affine_dma.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/affine_dma.mlir
@@ -14,7 +14,7 @@ func.func @matmul_single_core_stream(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>,
   %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
   %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>
   %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>
-  "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^datamovement0(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
     // CHECK-DAG: [[iter0:%.*]] = ttir.iter_index(0)
     // CHECK-DAG: [[iter2:%.*]] = ttir.iter_index(2)
@@ -54,7 +54,7 @@ func.func @matmul_single_core_transpose(%arg0: memref<1x2x2x2x!tt.tile<32x32, f3
   %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
   %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>
   %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d1, d0, d3, d2) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>
-  "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^datamovement0(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
     // CHECK-DAG: [[iter0:%.*]] = ttir.iter_index(0)
     // CHECK-DAG: [[iter2:%.*]] = ttir.iter_index(2)
@@ -99,7 +99,7 @@ func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, 
   %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>
   %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 24576 + d3 * 4096)>, #l1_>
   %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>, memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #l1_>
-  "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^datamovement0(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>, %sem0: !ttir.semaphore, %sem1: !ttir.semaphore, %sem2: !ttir.semaphore, %sem3: !ttir.semaphore):
     %c3 = arith.constant 3 : index
     %c4 = arith.constant 4 : index
@@ -170,7 +170,7 @@ func.func @matmul_multi_core_dram_params(%arg0: memref<2x4x4x6x!tt.tile<32x32, f
   %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>
   %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 24576 + d3 * 4096)>, #l1_>
   %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #dram>, memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #dram>
-  "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^datamovement0(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>, %sem0: !ttir.semaphore, %sem1: !ttir.semaphore, %sem2: !ttir.semaphore, %sem3: !ttir.semaphore):
     %c3 = arith.constant 3 : index
     %c4 = arith.constant 4 : index

--- a/test/ttmlir/Dialect/TTIR/generic/generic_datamovement.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/generic_datamovement.mlir
@@ -7,7 +7,7 @@
 
 func.func @add(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 2, 1>, operand_cb_mapping = array<i64>}> ({
+  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   // Look for 4 regions, one for each operand and one for the compute
   // Operand 0 (input)
   // CHECK: ^datamovement0
@@ -43,7 +43,7 @@ func.func @add(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<
 
 func.func @matmul_single_core(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x4x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>, operand_cb_mapping = array<i64>}> ({
+  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   // Look for 4 regions, one for each operand and one for the compute
   // Operand 0 (input)
   // CHECK: ^datamovement0
@@ -71,8 +71,10 @@ func.func @matmul_single_core_stream(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>,
   %cb1_alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
   %0 = "ttir.stream_layout"(%arg0, %cb0_alloc) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 2 * 4096 + d3 * 4096)>, #l1_>
   %1 = "ttir.stream_layout"(%arg1, %cb1_alloc) : (memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 2 * 4096 + d3 * 4096)>, #l1_>
-  // CHECK: "ttir.generic"([[lhs:%[a-z0-9_]+]], [[rhs:%[a-z0-9_]+]], [[out:%[a-z0-9_]+]])
-  "ttir.generic"(%0, %1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>, operand_cb_mapping = array<i64>}> ({
+  // CHECK: ttir.generic
+  // CHECK-NEXT: ins([[lhs:%[a-z0-9_]+]], [[rhs:%[a-z0-9_]+]] : {{.*}})
+  // CHECK-NEXT: outs([[out:%[a-z0-9_]+]] : {{.*}})
+  "ttir.generic"(%0, %1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   // Look for 4 regions, one for each operand and one for the compute
   // Operand 0 (input)
   // CHECK: ^datamovement0
@@ -104,8 +106,10 @@ func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, 
   %cb1_alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>
   %0 = "ttir.stream_layout"(%arg0, %cb0_alloc) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 6 * 4096 + d3 * 4096)>, #l1_>
   %1 = "ttir.stream_layout"(%arg1, %cb1_alloc) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>, memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8 * 4096 + d3 * 4096)>, #l1_>
-  // CHECK: "ttir.generic"([[lhs:%[a-z0-9_]+]], [[rhs:%[a-z0-9_]+]], [[out:%[a-z0-9_]+]])
-  "ttir.generic"(%0, %1, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>, operand_cb_mapping = array<i64>}> ({
+  // CHECK: ttir.generic
+  // CHECK-NEXT: ins([[lhs:%[a-z0-9_]+]], [[rhs:%[a-z0-9_]+]] : {{.*}})
+  // CHECK-NEXT: outs([[out:%[a-z0-9_]+]] : {{.*}})
+  "ttir.generic"(%0, %1, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   // Look for 4 regions, one for each operand and one for the compute
   // Operand 0 (input)
   // CHECK: ^datamovement0
@@ -149,8 +153,10 @@ func.func @matmul_multi_core_dram_params(%arg0: memref<2x4x4x6x!tt.tile<32x32, f
   %cb1_alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>
   %0 = "ttir.stream_layout"(%arg0, %cb0_alloc) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 6 * 4096 + d3 * 4096)>, #l1_>
   %1 = "ttir.stream_layout"(%arg1, %cb1_alloc) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #dram>, memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8 * 4096 + d3 * 4096)>, #dram>
-  // CHECK: "ttir.generic"([[lhs:%[a-z0-9_]+]], [[rhs:%[a-z0-9_]+]], [[out:%[a-z0-9_]+]])
-  "ttir.generic"(%0, %1, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>, operand_cb_mapping = array<i64>}> ({
+  // CHECK: ttir.generic
+  // CHECK-NEXT: ins([[lhs:%[a-z0-9_]+]], [[rhs:%[a-z0-9_]+]] : {{.*}})
+  // CHECK-NEXT: outs([[out:%[a-z0-9_]+]] : {{.*}})
+  "ttir.generic"(%0, %1, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   // Look for 4 regions, one for each operand and one for the compute
   // Operand 0 (input)
   // CHECK: ^datamovement0
@@ -190,7 +196,7 @@ func.func @matmul_multi_core_dram_params(%arg0: memref<2x4x4x6x!tt.tile<32x32, f
 
 func.func @tilize(%arg0: memref<2x4x128x192xf32, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>, operand_cb_mapping = array<i64>}> ({
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 1, 1>}> ({
   // Look for 4 regions, one for each operand and one for the compute
   // Operand 0 (input)
   // CHECK: ^datamovement0
@@ -211,7 +217,7 @@ func.func @tilize(%arg0: memref<2x4x128x192xf32, #l1_>) -> memref<2x4x4x6x!tt.ti
 
 func.func @untilize(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x128x192xf32, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x128x192xf32, #l1_>
-  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>, operand_cb_mapping = array<i64>}> ({
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 1, 1>}> ({
   // Look for 4 regions, one for each operand and one for the compute
   // Operand 0 (input)
   // CHECK: ^datamovement0

--- a/test/ttmlir/Dialect/TTIR/generic/generic_hw_thread_selection.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/generic_hw_thread_selection.mlir
@@ -11,7 +11,7 @@
 
 func.func @add(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 2, 1>}> ({
+  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^datamovement0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
     ttir.yield %cb0 : (memref<2x4x!tt.tile<32x32, f32>, #l1_>)
   }, {
@@ -41,7 +41,7 @@ func.func @add(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<
 
 func.func @matmul_single_core(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x4x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^datamovement0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<4x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
     ttir.yield %cb0 : (memref<2x4x!tt.tile<32x32, f32>, #l1_>)
   }, {
@@ -64,7 +64,7 @@ func.func @matmul_single_core(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>,
 
 func.func @tilize(%arg0: memref<2x4x128x192xf32, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>}> ({
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 1, 1>}> ({
   ^datamovement0(%cb0: memref<128x192xf32, #l1_>, %cb1: memref<4x6x!tt.tile<32x32, f32>, #l1_>):
     ttir.yield %cb0 : (memref<128x192xf32, #l1_>)
   }, {

--- a/test/ttmlir/Dialect/TTIR/generic/generic_loops.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/generic_loops.mlir
@@ -11,7 +11,7 @@
 
 func.func @unary2x4(%arg0: memref<2x4x128x192xf32, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>}> ({
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 1, 1>}> ({
   ^datamovement0(%cb0: memref<128x192xf32, #l1_>, %cb1: memref<4x6x!tt.tile<32x32, f32>, #l1_>):
     // CHECK: scf.for %{{.*}} = %c0 to %c1
     // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1
@@ -34,7 +34,7 @@ func.func @unary2x4(%arg0: memref<2x4x128x192xf32, #l1_>) -> memref<2x4x4x6x!tt.
 
 func.func @binary1x1(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 2, 1>}> ({
+  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^datamovement0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
     // CHECK: scf.for %{{.*}} = %c0 to %c1
     // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1
@@ -69,7 +69,7 @@ func.func @binary1x1(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: m
 
 func.func @matmul1x1(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x4x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^datamovement0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<4x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
     // CHECK: scf.for %{{.*}} = %c0 to %c1
     // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1
@@ -105,7 +105,7 @@ func.func @matmul_outer_k(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, %ar
   %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
   %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>
   %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>
-  "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^datamovement0(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
     // CHECK: scf.for %{{.*}} = %c0 to %c1
     // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1
@@ -151,7 +151,7 @@ func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, 
   %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>
   %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 24576 + d3 * 4096)>, #l1_>
   %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>, memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #l1_>
-  "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^datamovement0(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>, %sem0: !ttir.semaphore, %sem1: !ttir.semaphore, %sem2: !ttir.semaphore, %sem3: !ttir.semaphore):
     // CHECK: scf.for %{{.*}} = %c0 to %c1
     // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1

--- a/test/ttmlir/Dialect/TTIR/generic/generic_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/generic_negative.mlir
@@ -5,11 +5,11 @@
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #parallel = #tt.iterator_type<parallel>
 
-// CHECK: error: 'ttir.generic' op Output grid shape must match the GenericOp grid shape
+// CHECK: error: 'ttir.generic' op output grid shape must match the generic op's grid shape
 
 func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<2x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>}> ({
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<2x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 1, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
   }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
   return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
@@ -21,11 +21,11 @@ func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #parallel = #tt.iterator_type<parallel>
 
-// CHECK: error: 'ttir.generic' op GenericOp region must have at least as many arguments as the number of top-level operands
+// CHECK: error: 'ttir.generic' op region must have at least as many arguments as the number of top-level operands
 
 func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>}> ({
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 1, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
   }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
   return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
@@ -37,11 +37,11 @@ func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #parallel = #tt.iterator_type<parallel>
 
-// CHECK: error: 'ttir.generic' op GenericOp region arguments must be of MemRefType
+// CHECK: error: 'ttir.generic' op region arguments must be of MemRefType
 
 func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>}> ({
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 1, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: tensor<2x4x!tt.tile<32x32, f32>, #l1_>):
   }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
   return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
@@ -54,11 +54,11 @@ func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #parallel = #tt.iterator_type<parallel>
 
-// CHECK: error: 'ttir.generic' op GenericOp region argument memory space must match the memory space of the corresponding operand
+// CHECK: error: 'ttir.generic' op region argument memory space must match the memory space of the corresponding operand
 
 func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #dram_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #dram_>
-  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>}> ({
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 1, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
   }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #dram_>) -> ()
   return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #dram_>
@@ -70,11 +70,11 @@ func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #parallel = #tt.iterator_type<parallel>
 
-// CHECK: error: 'ttir.generic' op GenericOp region argument shape must match the shape of the corresponding operand
+// CHECK: error: 'ttir.generic' op region argument shape must match the shape of the corresponding operand
 
 func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>}> ({
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>, threads = [#ttir.thread<compute>]}> ({
   ^bb0(%arg2: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
   }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
   return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
@@ -90,7 +90,7 @@ func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1
 
 func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>}> ({
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 1, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
   }, {
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg5: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
@@ -109,7 +109,7 @@ func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1
 
 func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map1], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>}> ({
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map1], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 1, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
   }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
   return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
@@ -125,7 +125,7 @@ func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1
 
 func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>}> ({
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 1, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg5: !ttir.semaphore):
   }, {
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg5: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
@@ -146,7 +146,7 @@ func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1
 
 func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#lhs, #rhs, #out], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#lhs, #rhs, #out], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg3: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
   }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
   return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
@@ -165,8 +165,25 @@ func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memr
 
 func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#lhs, #rhs, #out], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#lhs, #rhs, #out], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg3: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
   }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+}
+
+// -----
+
+#l1_ = #tt.memory_space<l1>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #tt.iterator_type<parallel>
+
+// CHECK: error: 'ttir.tile_matmul_block' op expected to be in a compute region
+
+func.func @matmul(%arg0: memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>, threads = [#ttir.thread<datamovement>]}> ({
+  ^bb0(%arg2: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
+  "ttir.tile_matmul_block"(%arg2, %arg4, %arg4) : (memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
+  }) : (memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
   return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
 }

--- a/test/ttmlir/Dialect/TTIR/generic/generic_region_ops.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/generic_region_ops.mlir
@@ -11,6 +11,7 @@ func.func @reduce_max(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> t
         grid = #tt.grid<1x1>,
         indexing_maps = [#map, #map, #map],
         iterator_types = [#parallel, #parallel],
+        threads = [#ttir.thread<compute>],
         operandSegmentSizes = array<i32: 2, 1>
         }> ({
         ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_alias>,

--- a/test/ttmlir/Dialect/TTIR/generic/generic_region_ops_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/generic_region_ops_negative.mlir
@@ -10,6 +10,7 @@ func.func @reduce_dim_arg(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) 
       grid = #tt.grid<1x1>,
       indexing_maps = [#map, #map, #map],
       iterator_types = [#parallel, #parallel],
+      threads = [#ttir.thread<compute>],
       operandSegmentSizes = array<i32: 2, 1>
       }> ({
       ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_alias>,
@@ -29,12 +30,4 @@ func.func @reduce_dim_arg(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) 
       "ttir.yield"() : () -> ()
       }) : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
   return %1 : tensor<64x128xf32>
-}
-
-// -----
-
-func.func @not_in_generic_region(%a: !tt.tile<32x32, f32>, %b: !tt.tile<32x32, f32>) -> !tt.tile<32x32, f32> {
-    // CHECK: error: 'ttir.tile_reduce_max' op TTIR Generic Ops must be inside a generic region
-  %1 = "ttir.tile_reduce_max" (%a, %b) {reduce_dim = #ttir<reduce_dim R>} : (!tt.tile<32x32, f32>, !tt.tile<32x32, f32>) -> !tt.tile<32x32, f32>
-  return %1 : !tt.tile<32x32, f32>
 }

--- a/test/ttmlir/Dialect/TTIR/generic/generic_regions_to_funcs.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/generic_regions_to_funcs.mlir
@@ -21,6 +21,6 @@ func.func @add(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<
   }
   return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
 }
-// CHECK: func.func private @datamovement_kernel0{{.*}} attributes {ttir.thread_type = 1 : i32}
+// CHECK: func.func private @datamovement_kernel0{{.*}} attributes {ttir.thread = #ttir.thread<datamovement>}
 // CHECK: ttir.get_global_operand(0)
-// CHECK: func.func private @compute_kernel1{{.*}} attributes {ttir.thread_type = 0 : i32}
+// CHECK: func.func private @compute_kernel1{{.*}} attributes {ttir.thread = #ttir.thread<compute>}

--- a/test/ttmlir/Dialect/TTIR/generic/generic_regions_to_funcs.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/generic_regions_to_funcs.mlir
@@ -1,0 +1,26 @@
+// RUN: ttmlir-opt --tt-register-device --ttir-generic-regions-to-funcs %s | FileCheck %s
+
+#l1_ = #tt.memory_space<l1>
+#dram = #tt.memory_space<dram>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #tt.iterator_type<parallel>
+
+func.func @add(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+  // CHECK: [#ttir.thread<datamovement, @datamovement_kernel0>, #ttir.thread<compute, @compute_kernel1>]
+  ttir.generic {grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<datamovement>, #ttir.thread<compute>]}
+               ins(%arg0, %arg1 : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>)
+               outs(%alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) {
+  ^datamovement0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
+    %c0 = arith.constant 0 : index
+    %tx = ttir.dma %arg0[%c0, %c0], %cb0 : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<2x4x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+    "ttir.yield"() : () -> ()
+  }, {
+  ^compute0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
+    "ttir.yield"() : () -> ()
+  }
+  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+}
+// CHECK: func.func private @datamovement_kernel0{{.*}} attributes {ttir.thread_type = 1 : i32}
+// CHECK: ttir.get_global_operand(0)
+// CHECK: func.func private @compute_kernel1{{.*}} attributes {ttir.thread_type = 0 : i32}

--- a/test/ttmlir/Dialect/TTIR/loops/linearize_memref.mlir
+++ b/test/ttmlir/Dialect/TTIR/loops/linearize_memref.mlir
@@ -6,7 +6,7 @@
 
 func.func @add(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 2, 1>}> ({
+  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^bb0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
     // CHECK: [[cshape0:%[a-z0-9_]+]] = memref.collapse_shape %cb0
     // CHECK-NEXT: [[cshape1:%[a-z0-9_]+]] = memref.collapse_shape %cb1
@@ -29,7 +29,7 @@ func.func @add(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<
 
 func.func @addT(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1T: memref<1x1x4x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %arg1T, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 2, 1>}> ({
+  "ttir.generic"(%arg0, %arg1T, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^bb0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<4x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
     // CHECK: [[cshape0:%[a-z0-9_]+]] = memref.collapse_shape %cb0
     // CHECK-NEXT: [[cshape1:%[a-z0-9_]+]] = memref.collapse_shape %cb1

--- a/test/ttmlir/Dialect/TTIR/optimize_tensor_layout/optimize_tensor_layout.mlir
+++ b/test/ttmlir/Dialect/TTIR/optimize_tensor_layout/optimize_tensor_layout.mlir
@@ -17,9 +17,10 @@ func.func @reduce_large_grid(%arg0: tensor<256x384xf32, #layout1>, %arg1: tensor
         grid = #tt.grid<1x1>,
         indexing_maps = [#map1, #map1, #map2],
         iterator_types = [#parallel, #reduction],
+        threads = [#ttir.thread<compute>],
         operandSegmentSizes = array<i32: 2, 1>
         }> ({
-        // CHECK: ^compute(%cb0: memref<1x2x!tt.tile<32x32, f32>, #l1_>,
+        // CHECK: ^compute0(%cb0: memref<1x2x!tt.tile<32x32, f32>, #l1_>,
         // CHECK-SAME: %cb1: memref<1x2x!tt.tile<32x32, f32>, #l1_>,
         // CHECK-SAME: %cb2: memref<1x1x!tt.tile<32x32, f32>, #l1_>):
         ^bb0(%arg2: memref<8x12x!tt.tile<32x32, f32>, #l1_>,
@@ -57,9 +58,10 @@ func.func @reduce_prime(%arg0: tensor<32x608xf32, #layout1>, %arg1: tensor<32x60
         grid = #tt.grid<1x1>,
         indexing_maps = [#map1, #map1, #map2],
         iterator_types = [#parallel, #reduction],
+        threads = [#ttir.thread<compute>],
         operandSegmentSizes = array<i32: 2, 1>
         }> ({
-        // CHECK: ^compute(%cb0: memref<1x19x!tt.tile<32x32, f32>, #l1_>,
+        // CHECK: ^compute0(%cb0: memref<1x19x!tt.tile<32x32, f32>, #l1_>,
         // CHECK-SAME: %cb1: memref<1x19x!tt.tile<32x32, f32>, #l1_>,
         // CHECK-SAME: %cb2: memref<1x1x!tt.tile<32x32, f32>, #l1_>):
         ^bb0(%arg2: memref<1x19x!tt.tile<32x32, f32>, #l1_>,

--- a/test/ttmlir/Dialect/TTIR/ttir_generic_hoist.mlir
+++ b/test/ttmlir/Dialect/TTIR/ttir_generic_hoist.mlir
@@ -7,6 +7,7 @@ func.func @forward(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tens
     grid = #tt.grid<1x1>,
     indexing_maps = [#map, #map, #map],
     iterator_types = [#parallel, #parallel],
+    threads = [#ttir.thread<compute>],
     operandSegmentSizes = array<i32: 2, 1>}> ({
   ^bb0(%arg2: memref<64x128xf32>, %arg3: memref<64x128xf32>, %arg4: memref<64x128xf32>):
     // lit CHECK to make sure this constant stays inside the generic region


### PR DESCRIPTION
This pass moves the generic regions to top level functions. This is a useful prerequisite step before lowering because it enables us to better separate kernel program lowering from host program lowering.

```mlir
func.func @main(/*...*/) {
  ttir.generic {grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute>]}
      ins(%arg0, %arg1 : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>)
      outs(%alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>)  {
  ^compute0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
    // ...compute body...
  }
}
```

Into (note the new compute function / symbol @compute_kernel0):
```mlir
func.func @main(/*...*/) {
  ttir.generic {grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute, @compute_kernel0>]}
      ins(%arg0, %arg1 : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>)
      outs(%alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>)
}

func.func private @compute_kernel0(%arg0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>) attributes {ttir.thread_type = 0 : i32} {
  // ...compute body...
  return
}
```

Closes #2607