### PR TITLE
Add workaround for pad op

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1027,25 +1027,36 @@ def TTNN_RepeatOp : TTNN_Op<"repeat"> {
 }
 
 def TTNN_PadOp: TTNN_Op<"pad"> {
-    let summary = "Pad op.";
-    let description = [{
-      Pad input tensor by padding the input_shape to output_shape using the provided value.
+  let summary = "Pad op.";
+  let description = [{
+    Pad input tensor by padding the input_shape to output_shape using the provided value.
 
-      The `padding` attribute must be a sequence of integers that is twice the size as the rank of the input.
-      Each pair of integers in the padding attribute represents the amount of padding to add to the low and high of that dimension.
-      I.e: an input tensor of shape <1x30x30x64xf32> with padding attribute <0, 0, 1, 1, 1, 1, 0, 0> will return a tensor of shape <1x32x32x64xf32>,
-      and so will a padding attribute of <0, 0, 0, 2, 0, 2, 0, 0>.
-    }];
+    The `padding` attribute must be a sequence of integers that is twice the size as the rank of the input.
+    Each pair of integers in the padding attribute represents the amount of padding to add to the low and high of that dimension.
+    I.e: an input tensor of shape <1x30x30x64xf32> with padding attribute <0, 0, 1, 1, 1, 1, 0, 0> will return a tensor of shape <1x32x32x64xf32>,
+    and so will a padding attribute of <0, 0, 0, 2, 0, 2, 0, 0>.
+  }];
 
-    let arguments = (ins AnyRankedTensor:$input,
-                         DenseI32ArrayAttr:$padding,
-                         F32Attr:$value,
-                         BoolAttr:$use_multicore,
-                         OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
+  let arguments = (ins AnyRankedTensor:$input,
+                        DenseI32ArrayAttr:$padding,
+                        F32Attr:$value,
+                        BoolAttr:$use_multicore,
+                        OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
 
-    let results = (outs AnyRankedTensor:$result);
+  let results = (outs AnyRankedTensor:$result);
 
-    let hasVerifier = 1;
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
+      mlir::TypedValue<mlir::RankedTensorType> input = getInput();
+      ttnn::TTNNLayoutAttr layoutAttr = mlir::cast<ttnn::TTNNLayoutAttr>(
+            getResult().getType().getEncoding());
+      return
+        wa::TTNNOperandsWorkaroundsFactory::createPadOpOperandsWorkarounds(
+                                                             input, layoutAttr);
+    }
+  }];
 }
 
 def TTNN_SliceOp: TTNN_Op<"slice"> {

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkarounds.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkarounds.h
@@ -270,6 +270,11 @@ public:
 
   // Create workarounds for ArgMax op operands.
   static TTNNOperandsWorkarounds createArgMaxOpOperandsWorkarounds();
+
+  // Create workarounds for pad op operands.
+  static TTNNOperandsWorkarounds
+  createPadOpOperandsWorkarounds(mlir::TypedValue<mlir::RankedTensorType> input,
+                                 ttnn::TTNNLayoutAttr layoutAttr);
 };
 
 } // namespace mlir::tt::ttnn::wa

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/pad_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/pad_workaround.mlir
@@ -1,0 +1,25 @@
+// RUN: ttmlir-opt --tt-register-device="system-desc-path=%system_desc_path%" --ttnn-workaround  %s | FileCheck %s
+
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 30 + d1, d2), <1x1>, memref<1x1x!tt.tile<32x32, si32>, #dram>, <interleaved>>
+#ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<1x1x!tt.tile<32x32, si32>, #dram>, <interleaved>>
+module attributes {} {
+  func.func @test_pad_workaround(%arg0: tensor<1x30x30xsi32, #ttnn_layout>) -> tensor<1x32x32xsi32, #ttnn_layout1> {
+    // CHECK-LABEL: @test_pad_workaround
+    // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0,
+    // CHECK-SAME: <{dtype = #tt.supportedDataTypes<bf16>,
+    // CHECK-SAME: layout = #ttnn.layout<row_major>,
+    // CHECK-SAME: tensor<1x30x30xsi32,
+    // CHECK-SAME: -> tensor<1x30x30xbf16,
+    // CHECK: %[[PAD:[0-9]+]] = "ttnn.pad"(%[[ARG0]])
+    // CHECK-SAME: tensor<1x30x30xbf16
+    // CHECK-SAME: -> tensor<1x32x32xbf16,
+    %0 = "ttnn.pad"(%arg0) <{memory_config = #ttnn.memory_config<<dram>, <<1x1>>, <interleaved>>, padding = array<i32: 0, 0, 1, 1, 1, 1>, use_multicore = true, value = 0.000000e+00 : f32}> : (tensor<1x30x30xsi32, #ttnn_layout>) -> tensor<1x32x32xsi32, #ttnn_layout1>
+    // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[PAD]],
+    // CHECK-SAME: <{dtype = #tt.supportedDataTypes<si32>,
+    // CHECK-SAME: layout = #ttnn.layout<tile>
+    // CHECK-SAME: tensor<1x32x32xbf16,
+    // CHECK-SAME: -> tensor<1x32x32xsi32,
+    return %0 : tensor<1x32x32xsi32, #ttnn_layout1>
+  }
+}


### PR DESCRIPTION
### Ticket
closes #2642 

### Problem description
* tt-metal does not support integer type inputs
* tt-metal produces incorrect result for tile layout

### What's changed
* Add layout workaround
* Add data type workaround

### Checklist
- [X] New/Existing tests provide coverage for changes
