### PR TITLE
Fix tensor.empty op conversion

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/ArithToStableHLOPass.cpp
+++ b/lib/Conversion/StableHLOToTTIR/ArithToStableHLOPass.cpp
@@ -56,7 +56,7 @@ struct ConvertArithToStableHLOPass
     target.addIllegalDialect<mlir::arith::ArithDialect>();
     target.addLegalDialect<mlir::stablehlo::StablehloDialect>();
     target.addLegalDialect<mlir::sdy::SdyDialect>();
-    target.addLegalOp<mlir::tt::ttir::EmptyOp>();
+    target.addLegalOp<mlir::tensor::EmptyOp>();
     target.addLegalOp<mlir::ModuleOp>();
     target.addLegalOp<mlir::func::FuncOp>();
     target.addLegalOp<mlir::func::ReturnOp>();

--- a/lib/Conversion/StableHLOToTTIR/EmptyOpTypeConversion.cpp
+++ b/lib/Conversion/StableHLOToTTIR/EmptyOpTypeConversion.cpp
@@ -13,14 +13,14 @@ using namespace mlir::tt;
 
 namespace {
 class EmptyOpTypeConversionPattern
-    : public OpConversionPattern<mlir::tt::ttir::EmptyOp> {
+    : public OpConversionPattern<mlir::tensor::EmptyOp> {
 
-  using OpConversionPattern<mlir::tt::ttir::EmptyOp>::OpConversionPattern;
+  using OpConversionPattern<mlir::tensor::EmptyOp>::OpConversionPattern;
 
 public:
   LogicalResult
-  matchAndRewrite(mlir::tt::ttir::EmptyOp srcOp,
-                  mlir::tt::ttir::EmptyOp::Adaptor adaptor,
+  matchAndRewrite(mlir::tensor::EmptyOp srcOp,
+                  mlir::tensor::EmptyOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     RankedTensorType inputType = mlir::cast<RankedTensorType>(
         getTypeConverter()->convertType(srcOp.getType()));

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPass.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPass.cpp
@@ -99,6 +99,7 @@ struct ConvertStableHLOToTTIRPass
 
     target.addIllegalDialect<mlir::stablehlo::StablehloDialect>();
     target.addIllegalDialect<mlir::sdy::SdyDialect>();
+    target.addIllegalOp<mlir::tensor::EmptyOp>();
 
     target.addLegalDialect<ttir::TTIRDialect>();
     target.addLegalOp<mlir::tt::ttir::EmptyOp>();
@@ -127,8 +128,6 @@ struct ConvertStableHLOToTTIRPass
         [&](func::CallOp op) { return typeConverter.isLegal(op); });
 
     addEmptyOpTypeConversionPattern(&getContext(), patterns, typeConverter);
-    target.addDynamicallyLegalOp<ttir::EmptyOp>(
-        [&](ttir::EmptyOp op) { return typeConverter.isLegal(op); });
 
     populateStableHLOToTTIRPatterns(&getContext(), patterns, typeConverter);
     populateShardyToTTIRPatterns(&getContext(), patterns, typeConverter);

--- a/test/ttmlir/Conversion/StableHLOToTTIR/empty_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/empty_op.mlir
@@ -2,9 +2,18 @@
 // RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s | FileCheck %s
 module @module_empty {
   func.func @test_empty_boolean() -> tensor<1xi1> {
+    // CHECK-LABEL: @test_empty_boolean
     // CHECK: %[[EMPTY:[0-9]+]] = ttir.empty() : tensor<1xbf16>
-    %0 = ttir.empty() : tensor<1xi1>
-    // CHECK:     return %[[EMPTY]] : tensor<1xbf16>
+    %0 = tensor.empty() : tensor<1xi1>
+    // CHECK: return %[[EMPTY]] : tensor<1xbf16>
     return %0 : tensor<1xi1>
+  }
+
+  func.func @test_empty_float() -> tensor<4x64xf32> {
+    // CHECK-LABEL: @test_empty_float
+    // CHECK: %[[EMPTY:[0-9]+]] = ttir.empty() : tensor<4x64xf32>
+    %0 = tensor.empty() : tensor<4x64xf32>
+    // CHECK: return %[[EMPTY]] : tensor<4x64xf32>
+    return %0 : tensor<4x64xf32>
   }
 }


### PR DESCRIPTION
### Ticket
closes #2659 

### Problem description
Stablehlo graph can contain `tensor.empty` op which didn't require any conversion (except type conversion). 
This conversion is affected after introducing `ttir.empty` op.

### What's changed
Convert tensor.empty op to ttir.empty op during Stablehlo to TTIR conversion.

### Checklist
- [x] New/Existing tests provide coverage for changes
