### PR TITLE
Support bufferization interface for ttir.empty op

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -1679,7 +1679,15 @@ def TTIR_ReverseOp : TTIR_NamedOp<"reverse", [AllShapesMatch<["input", "result"]
     let hasCanonicalizer = 1;
 }
 
-def TTIR_EmptyOp : TTIR_Op<"empty", [Pure]> {
+def TTIR_EmptyOp : TTIR_Op<"empty",
+  [ Pure
+  , DeclareOpInterfaceMethods<BufferizableOpInterface, [ "bufferizesToMemoryRead"
+                                                       , "bufferizesToMemoryWrite"
+                                                       , "bufferize"
+                                                       , "getAliasingValues"
+                                                       , "getBufferType"
+                                                       ]>
+  ]> {
     let summary = "Empty op.";
     let description = [{
       Tensor empty operation

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -134,13 +134,13 @@ void mlir::tt::ttir::BitwiseXorOp::getCanonicalizationPatterns(
 //===----------------------------------------------------------------------===//
 
 bool mlir::tt::ttir::EmptyOp::bufferizesToMemoryRead(
-    mlir::OpOperand &operand, const mlir::bufferization::AnalysisState &) {
+    mlir::OpOperand &, const mlir::bufferization::AnalysisState &) {
   // If the operand is an input, it is a bufferized to a memory read.
   return false;
 }
 
 bool mlir::tt::ttir::EmptyOp::bufferizesToMemoryWrite(
-    mlir::OpOperand &operand, const mlir::bufferization::AnalysisState &) {
+    mlir::OpOperand &, const mlir::bufferization::AnalysisState &) {
   // If the operand is an output, it is a bufferized to a memory write.
   return false;
 }

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -130,6 +130,53 @@ void mlir::tt::ttir::BitwiseXorOp::getCanonicalizationPatterns(
 }
 
 //===----------------------------------------------------------------------===//
+// EmptyOp
+//===----------------------------------------------------------------------===//
+
+bool mlir::tt::ttir::EmptyOp::bufferizesToMemoryRead(
+    mlir::OpOperand &operand, const mlir::bufferization::AnalysisState &) {
+  // If the operand is an input, it is a bufferized to a memory read.
+  return false;
+}
+
+bool mlir::tt::ttir::EmptyOp::bufferizesToMemoryWrite(
+    mlir::OpOperand &operand, const mlir::bufferization::AnalysisState &) {
+  // If the operand is an output, it is a bufferized to a memory write.
+  return false;
+}
+
+mlir::LogicalResult mlir::tt::ttir::EmptyOp::bufferize(
+    mlir::RewriterBase &rewriter,
+    const mlir::bufferization::BufferizationOptions &options) {
+  if (getOperation()->getUses().empty()) {
+    rewriter.eraseOp(*this);
+    return success();
+  }
+
+  ::llvm::SmallVector<mlir::Value> invocationStack;
+  mlir::bufferization::replaceOpWithNewBufferizedOp<memref::AllocOp>(
+      rewriter, *this,
+      mlir::cast<MemRefType>(
+          *getBufferType(getResult(), options, invocationStack)));
+  return mlir::success();
+}
+
+mlir::bufferization::AliasingValueList
+mlir::tt::ttir::EmptyOp::getAliasingValues(
+    mlir::OpOperand &, const mlir::bufferization::AnalysisState &) {
+  bufferization::AliasingValueList result;
+  return result;
+}
+
+mlir::FailureOr<mlir::BaseMemRefType> mlir::tt::ttir::EmptyOp::getBufferType(
+    mlir::Value value, const mlir::bufferization::BufferizationOptions &,
+    ::llvm::SmallVector<mlir::Value> &) {
+  auto rankedTensorType = mlir::cast<mlir::RankedTensorType>(value.getType());
+  return mlir::cast<tt::MetalLayoutAttr>(rankedTensorType.getEncoding())
+      .getBufferType();
+}
+
+//===----------------------------------------------------------------------===//
 // ConstantOp
 //===----------------------------------------------------------------------===//
 

--- a/test/ttmlir/Dialect/TTIR/bufferization/bufferization.mlir
+++ b/test/ttmlir/Dialect/TTIR/bufferization/bufferization.mlir
@@ -8,7 +8,7 @@
 #reduction = #tt.iterator_type<reduction>
 
 func.func @matmul(%arg0: tensor<1x1x2x4x!tt.tile<32x32, f32>>, %arg1: tensor<1x1x4x2x!tt.tile<32x32, f32>>) -> tensor<1x1x2x2x!tt.tile<32x32, f32>> {
-  // CHECK: = memref.alloc() {{.*}} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  // CHECK: = memref.alloc(){{.*}}: memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>
   %0 = ttir.empty() : tensor<1x1x2x2x!tt.tile<32x32, f32>>
   // CHECK: {{^  "ttir.generic".*}}
   %3 = "ttir.generic"(%arg0, %arg1, %0) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map1, #map2], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
@@ -19,7 +19,7 @@ func.func @matmul(%arg0: tensor<1x1x2x4x!tt.tile<32x32, f32>>, %arg1: tensor<1x1
 }
 
 func.func @to_layout(%arg0: tensor<1x1x2x4x!tt.tile<32x32, f32>>) -> tensor<1x1x2x4x!tt.tile<32x32, f32>> {
-  // CHECK: = memref.alloc() {{.*}} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+  // CHECK: = memref.alloc(){{.*}}: memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
   %0 = ttir.empty() : tensor<1x1x2x4x!tt.tile<32x32, f32>>
   // CHECK: {{^  "ttir.to_layout".*}}
   %3 = "ttir.to_layout"(%arg0, %0) : (tensor<1x1x2x4x!tt.tile<32x32, f32>>, tensor<1x1x2x4x!tt.tile<32x32, f32>>) -> tensor<1x1x2x4x!tt.tile<32x32, f32>>
@@ -27,7 +27,7 @@ func.func @to_layout(%arg0: tensor<1x1x2x4x!tt.tile<32x32, f32>>) -> tensor<1x1x
 }
 
 func.func @stream_layout(%arg0: tensor<1x1x2x4x!tt.tile<32x32, f32>>) -> tensor<1x1x2x4x!tt.tile<32x32, f32>> {
-  // CHECK: = memref.alloc() {{.*}} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+  // CHECK: = memref.alloc(){{.*}}: memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
   %0 = ttir.empty() : tensor<1x1x2x4x!tt.tile<32x32, f32>>
   // CHECK: = "ttir.stream_layout"
   %3 = "ttir.stream_layout"(%arg0, %0) : (tensor<1x1x2x4x!tt.tile<32x32, f32>>, tensor<1x1x2x4x!tt.tile<32x32, f32>>) -> tensor<1x1x2x4x!tt.tile<32x32, f32>>


### PR DESCRIPTION
Previously we were just using upstream `tensor.empty` bufferization which results in an alloc that looks like this:

```mlir
memref.alloc() : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
```

Note that it's missing the shard layout attribute which is required for allocating device tensors in the d2m flow. This commit implements the bufferization interface for `ttir.empty` with a correctly annotated allocation:

```mlir
memref.alloc() : memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>
```