### PR TITLE
update path for `simple_multiply.mlir`

### DIFF
--- a/docs/src/ttmlir-translate.md
+++ b/docs/src/ttmlir-translate.md
@@ -5,7 +5,7 @@ The `ttmlir-translate` translation utility. Unlike `ttmlir-opt` tool which is us
 
 ```bash
 # First, let's run `ttmlir-opt` to convert to proper dialect
-./build/bin/ttmlir-opt --ttir-to-emitc-pipeline test/ttmlir/Dialect/TTNN/simple_multiply.mlir -o c.mlir
+./build/bin/ttmlir-opt --ttir-to-emitc-pipeline test/ttmlir/Dialect/TTNN/eltwise/binary/multiply/simple_multiply.mlir -o c.mlir
 
 # Now run `ttmlir-translate` to produce C++ code
 ./build/bin/ttmlir-translate --mlir-to-cpp c.mlir
@@ -13,13 +13,13 @@ The `ttmlir-translate` translation utility. Unlike `ttmlir-opt` tool which is us
 
 Bonus: These two commands can be piped, to avoid writing a `mlir` file to disk, like so:
 ```bash
-./build/bin/ttmlir-opt --ttir-to-emitc-pipeline test/ttmlir/Dialect/TTNN/simple_multiply.mlir | ./build/bin/ttmlir-translate -mlir-to-cpp
+./build/bin/ttmlir-opt --ttir-to-emitc-pipeline test/ttmlir/Dialect/TTNN/eltwise/binary/multiply/simple_multiply.mlir | ./build/bin/ttmlir-translate -mlir-to-cpp
 ```
 
 ## Generate flatbuffer file from MLIR
 ```bash
 # First run `ttmlir-opt` to convert to proper dialect
-./build/bin/ttmlir-opt --ttir-to-ttnn-backend-pipeline test/ttmlir/Dialect/TTNN/simple_multiply.mlir -o ttnn.mlir
+./build/bin/ttmlir-opt --ttir-to-ttnn-backend-pipeline test/ttmlir/Dialect/TTNN/eltwise/binary/multiply/simple_multiply.mlir -o ttnn.mlir
 
 # Now run `ttmlir-translate` to produce flatbuffer file
 ./build/bin/ttmlir-translate --ttnn-to-flatbuffer ttnn.mlir -o out.ttnn


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The previous path was out-of-date 

`test/ttmlir/Dialect/TTNN/simple_multiply.mlir`

to

`test/ttmlir/Dialect/TTNN/eltwise/binary/multiply/simple_multiply.mlir `

### What's changed
Update the path so the command works out of box
