### PR TITLE
Changing TTIRBuilder PadOp and RepeatOp and tests to pass e2e run

### DIFF
--- a/python/test_infra/ttir_builder.py
+++ b/python/test_infra/ttir_builder.py
@@ -348,7 +348,7 @@ class TTIRBuilder:
         """Convenience wrapper constructing `ttir.EmptyOp`."""
         dtype = data_type if data_type is not None else self._default_dtype
         with self._ctx, self._loc:
-            op = ttir.EmptyOp(shape, dtype)
+            op = ttir.EmptyOp(RankedTensorType.get(shape, dtype))
 
             self.generate_and_store_random_golden(op)
 

--- a/python/test_infra/ttir_builder.py
+++ b/python/test_infra/ttir_builder.py
@@ -348,7 +348,7 @@ class TTIRBuilder:
         """Convenience wrapper constructing `ttir.EmptyOp`."""
         dtype = data_type if data_type is not None else self._default_dtype
         with self._ctx, self._loc:
-            op = ttir.EmptyOp(RankedTensorType.get(shape, dtype))
+            op = ttir.EmptyOp(shape, dtype)
 
             self.generate_and_store_random_golden(op)
 
@@ -1115,16 +1115,8 @@ class TTIRBuilder:
         )
 
     def pad(self, in0: Operand, padding: List[int], value: int) -> OpView:
-        golden_padding = []
-        # Reformatting padding dimensions for golden tensor:
-        if len(padding) == 4:
-            golden_padding = padding.copy()
-            golden_padding.reverse()
-        if len(padding) > 4:
-            for i in range(int(len(padding) / 2) - 4):
-                i = i + 4
-                golden_padding.append(padding[(2 * i) + 1])
-                golden_padding.append(padding[2 * i])
+        golden_padding = padding.copy()
+        golden_padding.reverse()
         return self.op_proxy(
             torch.nn.functional.pad,
             ttir.PadOp,

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -502,12 +502,12 @@ def test_transpose(in0: Operand, builder: TTIRBuilder):
 
 @compile_to_flatbuffer(
     [
-        (2, 3),
+        (1, 32, 32),
     ],
     targets=["ttnn"],
 )
 def test_repeat(in0: Operand, builder: TTIRBuilder):
-    return builder.repeat(in0, [2, 2])
+    return builder.repeat(in0, [32, 1, 1])
 
 
 @compile_to_flatbuffer(
@@ -618,12 +618,13 @@ def test_max_pool2d(in0: Operand, in1: Operand, builder: TTIRBuilder):
 
 @compile_to_flatbuffer(
     [
-        (32, 32),
+        (1, 1, 5, 5),
     ],
+    inputs_types=[torch.bfloat16],
     targets=["ttnn"],
 )
 def test_pad(in0: Operand, builder: TTIRBuilder):
-    return builder.pad(in0, padding=[0, 2, 1, 0], value=0)
+    return builder.pad(in0, padding=[0, 0, 0, 0, 1, 1, 1, 1], value=0)
 
 
 @compile_to_flatbuffer([(32, 64)], targets=["ttnn"])


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/2665)

### Problem description
PadOp and RepeatOp tests are failing e2e run

### What's changed
Cleaned up PadOp
Corrected PadOp and RepeatOp tests

### Checklist
- [ ] New/Existing tests provide coverage for changes
