### PR TITLE
Add Ignore Version flag for TTRT to ignore patch differences.

### DIFF
--- a/runtime/tools/python/ttrt/common/perf.py
+++ b/runtime/tools/python/ttrt/common/perf.py
@@ -106,6 +106,13 @@ class Perf:
             help="disable putting dispatch on ethernet cores - place it on worker cores instead",
         )
         Perf.register_arg(
+            name="--ignore-version",
+            type=bool,
+            default=False,
+            choices=[True, False],
+            help="Ignore check for Major/Minor/Patch between flatbuffer and TTRT, use at your own risk.",
+        )
+        Perf.register_arg(
             name="binary",
             type=str,
             default="",
@@ -212,7 +219,7 @@ class Perf:
             for path in ttnn_binary_paths:
                 bin = Binary(self.logger, self.file_manager, path)
                 try:
-                    bin.check_version()
+                    bin.check_version(ignore=self["--ignore-version"])
                 except Exception as e:
                     test_result = {
                         "file_path": path,
@@ -270,7 +277,7 @@ class Perf:
             for path in ttmetal_binary_paths:
                 bin = Binary(self.logger, self.file_manager, path)
                 try:
-                    bin.check_version()
+                    bin.check_version(ignore=self["--ignore-version"])
                 except Exception as e:
                     test_result = {
                         "file_path": path,

--- a/runtime/tools/python/ttrt/common/read.py
+++ b/runtime/tools/python/ttrt/common/read.py
@@ -78,6 +78,13 @@ class Read:
             help="test file to save results to",
         )
         Read.register_arg(
+            name="--ignore-version",
+            type=bool,
+            default=False,
+            choices=[True, False],
+            help="Ignore check for Major/Minor/Patch between flatbuffer and TTRT, use at your own risk.",
+        )
+        Read.register_arg(
             name="binary",
             type=str,
             default="",
@@ -150,7 +157,7 @@ class Read:
         for path in ttsys_binary_paths:
             try:
                 bin = SystemDesc(self.logger, self.file_manager, path)
-                if bin.check_version():
+                if bin.check_version(ignore=self["--ignore-version"]):
                     self.system_desc_binaries.append(bin)
             except Exception as e:
                 test_result = {
@@ -168,7 +175,7 @@ class Read:
         for path in ttnn_binary_paths:
             try:
                 bin = Binary(self.logger, self.file_manager, path)
-                if bin.check_version():
+                if bin.check_version(ignore=self["--ignore-version"]):
                     self.ttnn_binaries.append(bin)
             except Exception as e:
                 test_result = {
@@ -186,7 +193,7 @@ class Read:
         for path in ttmetal_binary_paths:
             try:
                 bin = Binary(self.logger, self.file_manager, path)
-                if bin.check_version():
+                if bin.check_version(ignore=self["--ignore-version"]):
                     self.ttmetal_binaries.append(bin)
             except Exception as e:
                 test_result = {

--- a/runtime/tools/python/ttrt/common/run.py
+++ b/runtime/tools/python/ttrt/common/run.py
@@ -204,6 +204,13 @@ class Run:
             help="disable putting dispatch on ethernet cores - place it on worker cores instead",
         )
         Run.register_arg(
+            name="--ignore-version",
+            type=bool,
+            default=False,
+            choices=[True, False],
+            help="Ignore check for Major/Minor/Patch between flatbuffer and TTRT, use at your own risk.",
+        )
+        Run.register_arg(
             name="binary",
             type=str,
             default="",
@@ -274,7 +281,7 @@ class Run:
         for path in ttnn_binary_paths:
             bin = Binary(self.logger, self.file_manager, path)
             try:
-                bin.check_version()
+                bin.check_version(ignore=self["--ignore-version"])
             except Exception as e:
                 test_result = {
                     "file_path": path,
@@ -330,7 +337,7 @@ class Run:
         for path in ttmetal_binary_paths:
             bin = Binary(self.logger, self.file_manager, path)
             try:
-                bin.check_version()
+                bin.check_version(ignore=self["--ignore-version"])
             except Exception as e:
                 test_result = {
                     "file_path": path,

--- a/runtime/tools/python/ttrt/common/util.py
+++ b/runtime/tools/python/ttrt/common/util.py
@@ -524,7 +524,7 @@ class Flatbuffer:
         # temporary state value to check if test failed
         self.test_result = "pass"
 
-    def check_version(self):
+    def check_version(self, ignore: bool = False):
         package_name = "ttrt"
 
         try:
@@ -532,7 +532,7 @@ class Flatbuffer:
         except Exception as e:
             raise Exception(f"error retrieving version: {e} for {package_name}")
 
-        if package_version != self.version:
+        if package_version != self.version and not ignore:
             raise Exception(
                 f"{package_name}: v{package_version} does not match flatbuffer: v{self.version} for flatbuffer: {self.file_path} - skipping this test"
             )


### PR DESCRIPTION
### Problem description
- `ttrt` will error out if a binary is provided that was compiled with a different in ttrt version. This changes _on commit_, so if I commit some unrelated issue and test it will error out.

### What's changed
- Added a `--ignore-version` flag to `read`, `perf`, and `run`. Flag is always defaulted to False unless explicitly set.
- Flag is run at user's own risk. They should not run the flag if changes are made to ttrt or the FB schema.
