### PR TITLE
Pass golden tensor data type to flatbuffer in ir_builder

### DIFF
--- a/docs/src/build.md
+++ b/docs/src/build.md
@@ -183,6 +183,28 @@ CMake Error at CMakeLists.txt:2 (project):
 
 If you get the following error, it means you need to install clang which you can do with `sudo apt install clang` on Ubuntu.
 
+### tt-metal Update Failures
+
+```
+Failed to unstash changes in: '/path/to/tt-metal/src/tt-metal'
+You will have to resolve the conflicts manually
+```
+
+This error occurs during CMake's ExternalProject update of tt-metal. The build system tries to apply changes using Git's stash mechanism, but fails due to conflicts. This can happen even if you haven't manually modified any files, as the build process itself may leave behind artifacts or partial changes from previous builds.
+
+To resolve, clean up the tt-metal directory:
+
+```bash
+cd third_party/tt-metal/src/tt-metal
+git reset --hard HEAD  # Reset any tracked file modifications
+git clean -fd         # Remove all untracked files and directories
+```
+
+Then retry your build command. If the error persists, you may also need to:
+1. Remove the build directory: `rm -rf build`
+2. Run CMake commands again.
+3. Run the above.
+
 ## Common Runtime Errors
 
 ### Debugging python on macOS

--- a/docs/src/ttrt.md
+++ b/docs/src/ttrt.md
@@ -416,12 +416,13 @@ The `ttrt` toolchain verifies whether the current system configuration matches t
 To resolve issues stemming from these synchronization problems, follow this workflow:
 
 1. **Incremental build**
-'''<make some changes>
-commit
-cmake --build build
-cmake --build build -- ttrt
-(note you need to generate system_desc and flatbuffer again once you do this)
-'''
+```bash
+  # make some changes
+  # commit
+  cmake --build build
+  cmake --build build -- ttrt
+  # note you need to generate system_desc and flatbuffer again once you do this
+```
 
 This incremental build should be sufficient. If it does not resolve the error, please file an issue and proceed with the following steps for now.
 
@@ -433,7 +434,7 @@ This incremental build should be sufficient. If it does not resolve the error, p
 This ensures that all previous build artifacts and dependencies are removed, preventing conflicts or stale files from affecting the new build.
 
 3. **Rebuild from scratch:**
-Once the build directories are cleared, rebuild the project from the ground up. This ensures that the build process incorporates all the necessary components without any remnants of previous builds. [Build Instructions](./build.md#build)
+After clearing the build directories, rebuild the project from the ground up. This ensures that the build process incorporates all the necessary components without any remnants of previous builds. [Build Instructions](./build.md#build)
 
 4. **Switch build configurations:**
 If switching from a Debug to a Release build (or vice versa), ensure that you clean the build environment before transitioning. This avoids inconsistencies between build configurations and potential issues with optimization levels or debugging symbols.

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -120,6 +120,8 @@ declare_mlir_python_extension(TTMLIRPythonExtensions.Main
   PYTHON_BINDINGS_LIBRARY nanobind
 )
 
+set(MLIR_BINDINGS_PYTHON_NB_DOMAIN "ttmlir")
+
 set(TTMLIR_PYTHON_SOURCES
   MLIRPythonSources.Core
   MLIRPythonSources.Dialects.affine
@@ -132,6 +134,7 @@ set(TTMLIR_PYTHON_SOURCES
   MLIRPythonSources.Dialects.tosa
   MLIRPythonSources.Dialects.memref
   MLIRPythonSources.Dialects.emitc
+  MLIRPythonSources.Dialects.quant
   TTMLIRPythonSources
   TTMLIRPythonExtensions
   TTMLIRPythonTestInfra

--- a/python/Passes.cpp
+++ b/python/Passes.cpp
@@ -267,7 +267,9 @@ void populatePassesModule(nb::module_ &m) {
 
   nb::enum_<::tt::target::DataType>(m, "DataType")
       .value("Float32", ::tt::target::DataType::Float32)
-      .value("Float16", ::tt::target::DataType::Float16);
+      .value("Float16", ::tt::target::DataType::Float16)
+      .value("BFloat16", ::tt::target::DataType::BFloat16)
+      .value("Int32", ::tt::target::DataType::Int32);
 
   m.def("lookup_dtype", [](std::string enumName) {
     // Function to return the enum value based on the name.

--- a/python/test_infra/test_utils.py
+++ b/python/test_infra/test_utils.py
@@ -5,7 +5,7 @@
 import os
 import inspect
 import torch
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple, Union
 
 from ttmlir.dialects import func
 from ttmlir.ir import *
@@ -18,7 +18,7 @@ from ttmlir.passes import (
     ModuleLog,
 )
 
-from .ttir_builder import Golden, Operand, Shape, TTIRBuilder, DataType
+from .ttir_builder import Golden, Operand, Shape, TTIRBuilder, DataType, TypeInfo
 
 TT_MLIR_HOME = os.environ.get("TT_MLIR_HOME", "")
 
@@ -58,7 +58,7 @@ def get_ttmetal_path(filename):
 def compile_as_mlir_module(
     test_fn: Callable,
     inputs_shapes: List[Shape],
-    inputs_types: Optional[List[torch.dtype]] = None,
+    inputs_types: Optional[List[Union[torch.dtype, TypeInfo]]] = None,
     mesh_shape: Optional[Tuple[int, int]] = None,
     module_dump: bool = False,
 ):
@@ -145,13 +145,17 @@ def compile_as_mlir_module(
 
     with ctx, loc:
         test_fn_input_types = [
-            builder.ranked_tensor_type(shape, builder.get_type_from_torch_dtype(dtype))
+            builder.ranked_tensor_type(
+                shape,
+                builder.get_type_from_torch_dtype(
+                    dtype if isinstance(dtype, torch.dtype) else dtype
+                ),
+            )
             for (shape, dtype) in zip(inputs_shapes, inputs_types)
         ]
 
         # Wrap everything in a mlir module.
         module = Module.create()
-
         with InsertionPoint(module.body):
             # Wrap everything in a mlir function.
             @func.func(*test_fn_input_types, name=test_fn.__name__)
@@ -159,14 +163,12 @@ def compile_as_mlir_module(
                 # Randomly generate golden tensors for function inputs.
                 for index, (operand, dtype) in enumerate(zip(inputs, inputs_types)):
                     builder.generate_input_golden(operand, dtype, index)
-
                 return test_fn(*inputs, builder=builder)
 
         print(f"`{test_fn.__name__}` sucessfully transformed into a MLIR module.")
 
         if module_dump:
             _dump_module(module)
-
         return module, builder
 
 
@@ -311,7 +313,7 @@ def ttmetal_to_flatbuffer(
 
 def compile_to_flatbuffer(
     inputs_shapes: List[Shape],
-    inputs_types: Optional[List[torch.dtype]] = None,
+    inputs_types: Optional[List[Union[torch.dtype, TypeInfo]]] = None,
     test_name: Optional[str] = None,
     targets: List[str] = ["ttmetal", "ttnn"],
     mesh_shape: Tuple[int, int] = None,

--- a/python/test_infra/ttir_builder.py
+++ b/python/test_infra/ttir_builder.py
@@ -8,7 +8,7 @@ import inspect
 from dataclasses import dataclass
 from typing import List, Optional, Union, Tuple, Callable, Dict, Any
 from ttmlir.ir import *
-from ttmlir.dialects import ttir, tt, tensor
+from ttmlir.dialects import ttir, tt, tensor, quant
 from ttmlir.passes import GoldenTensor, DataType
 import torch
 import array
@@ -89,6 +89,24 @@ class Golden:
 
     def contiguous(self) -> Golden:
         return Golden(self.tensor.contiguous())
+
+
+@dataclass
+class TypeInfo:
+    """Encapsulates type information for quantized tensors.
+
+    Contains both the base data type and quantization parameters (scale and zero point)
+    required for quantized operations.
+
+    Attributes:
+        dtype: Base PyTorch data type (e.g. torch.float32, torch.qint32).
+        scale: Scaling factor for quantization. Required for quantized types.
+        zero_point: Zero point offset for quantization. Required for quantized types.
+    """
+
+    dtype: torch.dtype
+    scale: Optional[float] = None
+    zero_point: Optional[int] = None
 
 
 class TTIRBuilder:
@@ -176,11 +194,12 @@ class TTIRBuilder:
         golden_info = {}
         for name, golden_tensor in self.id_golden_map.items():
             golden_tensor = golden_tensor.contiguous()
+            data_type = self.get_datatype_from_torch_dtype(golden_tensor.tensor.dtype)
             golden_info[name] = GoldenTensor(
                 name,
                 list(golden_tensor.tensor.shape),
                 list(golden_tensor.tensor.stride()),
-                DataType.Float32,
+                data_type if data_type is not None else DataType.Float32,
                 golden_tensor.tensor.data_ptr(),
                 golden_tensor.tensor.numel() * golden_tensor.tensor.dtype.itemsize,
             )
@@ -226,7 +245,6 @@ class TTIRBuilder:
         Generates random tensor of shape `shape`, with type `dtype`, using `seed` to seed torch
         random generator.
         """
-
         if dtype.is_floating_point:
             return torch.randn(shape, generator=torch.manual_seed(seed), dtype=dtype)
         else:
@@ -294,11 +312,41 @@ class TTIRBuilder:
 
     # ----- Utility Conversion ----
 
-    def get_type_from_torch_dtype(self, dtype: torch.dtype) -> Type:
+    def get_datatype_from_torch_dtype(self, dtype: torch.dtype) -> DataType:
         """
-        Returns a MLIR `Type` obj corresponding to `dtype`
+        Returns a MLIR `DataType` obj corresponding to `dtype`.
         """
         match dtype:
+            case torch.float16:
+                return DataType.Float16
+            case torch.bfloat16:
+                return DataType.BFloat16
+            case torch.float32:
+                return DataType.Float32
+            case torch.int32:
+                return DataType.Int32
+            case None:
+                return DataType.Float32
+
+    def get_type_from_torch_dtype(self, dtype: Union[torch.dtype, TypeInfo]) -> Type:
+        """Converts PyTorch dtype or TypeInfo to corresponding MLIR Type.
+
+        For quantized types (e.g. qint32), scale and zero_point must be provided via TypeInfo.
+        For non-quantized types, a plain torch.dtype can be used.
+
+        Args:
+            dtype: Either a torch.dtype or TypeInfo containing dtype and quantization params.
+
+        Returns:
+            MLIR Type corresponding to the input dtype.
+
+        Raises:
+            ValueError: If quantization parameters are missing for quantized types.
+            TypeError: If the dtype is not supported.
+        """
+        base_dtype = dtype.dtype if isinstance(dtype, TypeInfo) else dtype
+
+        match base_dtype:
             case torch.bfloat16:
                 return BF16Type.get(self._ctx)
             case torch.float16:
@@ -323,8 +371,22 @@ class TTIRBuilder:
                 return IntegerType.get_unsigned(32, self._ctx)
             case torch.uint64:
                 return IntegerType.get_unsigned(64, self._ctx)
+            case torch.qint32:
+                if not isinstance(dtype, TypeInfo):
+                    raise ValueError("TypeInfo required for qint32")
+                if dtype.scale is None or dtype.zero_point is None:
+                    raise ValueError("scale and zero_point required for qint32")
+                return quant.UniformQuantizedType.get(
+                    quant.UniformQuantizedType.FLAG_SIGNED,
+                    IntegerType.get_signless(32, self._ctx),
+                    F32Type.get(self._ctx),
+                    dtype.scale,
+                    dtype.zero_point,
+                    torch.iinfo(torch.qint32).min,
+                    torch.iinfo(torch.qint32).max,
+                )
             case _:
-                raise TypeError(f"Invalid Type {type}")
+                raise TypeError(f"Invalid Type {dtype}")
 
     # ----- Utility factories -----
 
@@ -398,6 +460,7 @@ class TTIRBuilder:
 
                 The list/tuple will then be unpacked as the positional arugments for the op_golden_function
         - output_shape (Optional[Shape]): An optional argument specifying the shape of the output of the OP.
+        - output_type (Optional[Type]): An optional argument specifying the type of the output of the OP.
         - golden_kwargs (dict): Additional keyword arguments for the `op_golden_function`.
         - ttir_kwargs (dict): Additional keyword arguments for the `op_ttir_function`.
 
@@ -444,8 +507,7 @@ class TTIRBuilder:
                 if not isinstance(golden_output, torch.Tensor)
                 else Golden(golden_output)
             )
-
-            # Use the golden output to determine proper output shape and type unless otherwise specified
+            # Use the golden output to determine proper output shape and type unless otherwise specified.
             output_shape = golden.tensor.shape if not output_shape else output_shape
             if not output_type and inputs:
                 output_type = self.get_type_from_torch_dtype(
@@ -485,7 +547,6 @@ class TTIRBuilder:
             self.id_golden_map[str(loc)] = golden
             self._store_golden(op, golden)
             self._override_golden(output, golden)
-
             return op
 
     def eltwise_proxy(

--- a/runtime/tools/python/ttrt/common/callback.py
+++ b/runtime/tools/python/ttrt/common/callback.py
@@ -219,11 +219,9 @@ def golden(callback_runtime_config, binary, program_context, op_context):
     rt_buffer = op_output_tensor.get_data_buffer()
     dtype = ttrt_datatype_to_torch_dtype(op_golden_tensor.dtype)
     assert ttrt_datatype_to_torch_dtype(op_output_tensor.get_dtype()) == dtype
-
     golden_tensor_torch = torch.frombuffer(op_golden_tensor, dtype=dtype).flatten()
 
     output_tensor_torch = torch.frombuffer(rt_buffer, dtype=dtype).flatten()
-
     if callback_runtime_config.save_golden_tensors:
         torch.save(
             golden_tensor_torch,

--- a/runtime/tools/python/ttrt/common/util.py
+++ b/runtime/tools/python/ttrt/common/util.py
@@ -55,6 +55,8 @@ def ttrt_datatype_to_torch_dtype(dtype) -> torch.dtype:
         return torch.uint8
     elif dtype == DataType.BFloat16:
         return torch.bfloat16
+    elif dtype == DataType.Int32:
+        return torch.int32
     else:
         raise ValueError(
             "Only F32, BF16, and unsigned integers are supported in the runtime"


### PR DESCRIPTION
### Ticket
Required for #2448. Separate PR for adding quantize/dequantize/requantize support in ir_builder will be filed after E2E support is merged. The fix in this PR can be merged first and apply to all ops.

### What's changed
The data type of the golden tensor in ir_builder is passed back to the flatbuffer.

`get_type_from_torch_dtype` now handles quantized types, with the first incremental change to translate the `torch.int32` -> `quant.uniform` int32 data type for TTIR/TTNN modules. 

Also includes some minor edits to the documentation. 