### PR TITLE
Add a new pass that checks the match of input and output of tensor

### DIFF
--- a/include/ttmlir/Conversion/Passes.h
+++ b/include/ttmlir/Conversion/Passes.h
@@ -7,6 +7,7 @@
 
 #ifdef TTMLIR_ENABLE_STABLEHLO
 #include "ttmlir/Conversion/ArithToStableHLO/ArithToStableHLO.h"
+#include "ttmlir/Conversion/StableHLOToTTIR/ShardyToTTIR.h"
 #include "ttmlir/Conversion/StableHLOToTTIR/StableHLOToTTIR.h"
 #endif
 #include "ttmlir/Conversion/TTIRToLinalg/TTIRToLinalg.h"

--- a/include/ttmlir/Conversion/StableHLOToTTIR/ShardingUtils.h
+++ b/include/ttmlir/Conversion/StableHLOToTTIR/ShardingUtils.h
@@ -71,6 +71,12 @@ public:
   mlir::tt::TensorMeshShardingAttr
   getTensorMeshShardingAttr(mlir::PatternRewriter &rewriter);
 
+  // Given TensorMeshShardingAttr, extract MeshSharding info.
+  void extractMeshShardingFromTensorMeshShardingAttr(
+      mlir::tt::MeshAttr mesh,
+      mlir::tt::TensorMeshShardingAttr tensorMeshShardingAttr,
+      mlir::tt::MeshShardDirection direction);
+
   // Getter functions.
   mlir::tt::MeshShardDirection getShardDirection() const {
     return shardDirection;

--- a/include/ttmlir/Conversion/StableHLOToTTIR/ShardyToTTIR.h
+++ b/include/ttmlir/Conversion/StableHLOToTTIR/ShardyToTTIR.h
@@ -15,6 +15,8 @@ namespace mlir::tt {
 void populateShardyToTTIRPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
                                   TypeConverter &typeConverter);
 
+std::unique_ptr<mlir::Pass> createTTIRTensorAnnotationCleanupPass();
+
 #endif
 
 } // namespace mlir::tt

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -529,6 +529,16 @@ def TT_MeshesAttr : TT_Attr<"Meshes", "meshes"> {
   }];
   let parameters = (ins ArrayRefParameter<"MeshAttr">:$meshes);
   let assemblyFormat = "`<` `[` $meshes `]` `>`";
+  let extraClassDeclaration = [{
+      MeshAttr getMesh(StringRef name) {
+        for( auto mesh : getMeshes() ) {
+          if( mesh.getName() == name ) {
+            return mesh;
+          }
+        }
+        return nullptr;
+      }
+  }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/StableHLOToTTIR/ShardingUtils.cpp
+++ b/lib/Conversion/StableHLOToTTIR/ShardingUtils.cpp
@@ -431,6 +431,29 @@ MeshSharding::getTensorMeshShardingAttr(mlir::PatternRewriter &rewriter) {
                                                tensorMeshShardingAxisAttr);
 }
 
+// Get MeshSharding given MeshAttr, TensorMeshShardingAttr, and
+// MeshShardDirection.
+void MeshSharding::extractMeshShardingFromTensorMeshShardingAttr(
+    mlir::tt::MeshAttr meshAttr,
+    mlir::tt::TensorMeshShardingAttr tensorMeshShardingAttr,
+    mlir::tt::MeshShardDirection direction) {
+  meshName = meshAttr.getName().str();
+  meshShape = llvm::SmallVector<int64_t>(meshAttr.getShape());
+  shardDirection = direction;
+
+  auto axes = tensorMeshShardingAttr.getTensorMeshShardingAxis();
+  shardShape.resize(axes.size());
+  shardDims.resize(axes.size(), -1);
+  for (auto [dim, axis] : llvm::enumerate(axes)) {
+    shardShape[dim] = axis.getShardShape();
+    for (auto deviceDim : axis.getAxes()) {
+      shardDims[deviceDim] = dim;
+    }
+  }
+
+  shardType = mlir::tt::MeshShardType::Devices;
+}
+
 FailureOr<std::unordered_map<std::string, std::string>>
 MeshSharding::fillStrategyMapFromSharding(
     const mlir::tt::sharding_utils::MeshSharding &meshSharding,

--- a/lib/Conversion/StableHLOToTTIR/ShardyToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/ShardyToTTIRPatterns.cpp
@@ -19,6 +19,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
+#include "mlir/IR/Iterators.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/PatternMatch.h"
@@ -358,9 +359,10 @@ public:
                                               meshShape);
 
     // Before erasing MeshOp, visit public functions and properly handle
-    // argument sharding attributes that are not used by ManualComputationOp or
-    // MeshShardOp. Ones that are refered by ManualComputationOp are properly
-    // handled by ShardyToTTIRManualComputationOpConversionPattern.
+    // argument and return sharding attributes that are not used or defined by
+    // ManualComputationOp, respectively. Ones that are refered by
+    // ManualComputationOp are properly handled by
+    // ShardyToTTIRManualComputationOpConversionPattern.
     module->walk([&](mlir::func::FuncOp funcOp) {
       if (!funcOp.isPublic()) {
         return mlir::WalkResult::skip();
@@ -375,16 +377,10 @@ public:
           continue;
         }
         if (llvm::any_of(arg.getUsers(), [&](mlir::Operation *user) {
-              return mlir::isa<mlir::sdy::ManualComputationOp,
-                               mlir::tt::ttir::MeshShardOp>(*user);
+              return mlir::isa<mlir::sdy::ManualComputationOp>(*user);
             })) {
           continue;
         }
-
-        auto *firstUserOp = *arg.user_begin();
-        rewriter.setInsertionPoint(firstUserOp);
-        auto outputType = mlir::cast<mlir::RankedTensorType>(
-            getTypeConverter()->convertType(arg.getType()));
 
         mlir::tt::sharding_utils::MeshSharding meshSharding;
         auto error = meshSharding.convertSdyShardingToMeshSharding(
@@ -394,20 +390,39 @@ public:
           llvm_unreachable(llvm::toString(std::move(e)).c_str());
         }
 
-        rewriter.modifyOpInPlace(funcOp, [&]() {
-          funcOp.removeArgAttr(argIdx, mlir::sdy::kShardingAttr);
-          mlir::tt::sharding_utils::addTensorMeshShardingAttrToFunctionArg(
-              funcOp, argIdx, meshSharding.getTensorMeshShardingAttr(rewriter));
-        });
+        mlir::tt::sharding_utils::checkAndRemoveFuncArgSharding<
+            mlir::sdy::TensorShardingAttr>(
+            rewriter, funcOp, argIdx, argShardingAttr,
+            meshSharding.getTensorMeshShardingAttr(rewriter),
+            mlir::sdy::kShardingAttr);
+      }
 
-        auto meshShardOp =
-            ttmlir::utils::createDPSOp<mlir::tt::ttir::MeshShardOp>(
-                rewriter, firstUserOp->getLoc(), outputType, arg,
-                meshSharding.getShardType(), meshSharding.getShardDirection(),
-                meshSharding.getShardShape(), meshSharding.getShardDims());
+      mlir::Operation *funcReturnOp = funcOp.getBody().front().getTerminator();
+      for (auto [retIdx, ret] : llvm::enumerate(funcReturnOp->getOperands())) {
+        // Check arguments with sdy sharding attribute.
+        auto retShardingAttr =
+            funcOp.getResultAttrOfType<mlir::sdy::TensorShardingAttr>(
+                retIdx, mlir::sdy::kShardingAttr);
+        if (!retShardingAttr) {
+          continue;
+        }
+        if (mlir::isa<mlir::sdy::ManualComputationOp>(ret.getDefiningOp())) {
+          continue;
+        }
 
-        rewriter.replaceAllUsesExcept(arg, meshShardOp.getResult(),
-                                      meshShardOp);
+        mlir::tt::sharding_utils::MeshSharding meshSharding;
+        auto error = meshSharding.convertSdyShardingToMeshSharding(
+            retShardingAttr, sdyMesh,
+            mlir::tt::MeshShardDirection::FullToShard);
+        if (auto e = error.takeError()) {
+          llvm_unreachable(llvm::toString(std::move(e)).c_str());
+        }
+
+        mlir::tt::sharding_utils::checkAndRemoveFuncReturnSharding<
+            mlir::sdy::TensorShardingAttr>(
+            rewriter, funcOp, retIdx, retShardingAttr,
+            meshSharding.getTensorMeshShardingAttr(rewriter),
+            mlir::sdy::kShardingAttr);
       }
       return mlir::WalkResult::advance();
     });
@@ -427,6 +442,156 @@ void populateShardyToTTIRPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
   patterns.add<ShardyToTTIRManualComputationOpConversionPattern>(typeConverter,
                                                                  ctx);
   patterns.add<ShardyToTTIRMeshOpConversionPattern>(typeConverter, ctx);
+}
+
+} // namespace mlir::tt
+
+namespace mlir::tt {
+
+// Check matching of input and result tensor annotations and fix if there is any
+// issue.
+llvm::LogicalResult
+analyzeSingleOpAndFixWrongTensorAnnotation(mlir::tt::MeshesAttr meshes,
+                                           mlir::Operation *srcOp,
+                                           mlir::OpBuilder &builder) {
+  if (srcOp->getNumResults() == 0 || srcOp->getNumOperands() == 0) {
+    return llvm::success();
+  }
+
+  auto resultType =
+      mlir::cast<mlir::RankedTensorType>(srcOp->getResult(0).getType());
+  if (auto tensorMeshShardingAttr =
+          mlir::dyn_cast_if_present<mlir::tt::TensorMeshShardingAttr>(
+              resultType.getEncoding())) {
+    // Result is multi device tensor and thus expects args to be multi device
+    // tensors. If args are not multi device tensor, propagate the missing
+    // TensorMeshShardingAttr to args.
+    for (auto arg : srcOp->getOperands()) {
+      auto argType = mlir::cast<mlir::RankedTensorType>(arg.getType());
+      if (auto argTensorMeshShardingAttr =
+              mlir::dyn_cast_if_present<mlir::tt::TensorMeshShardingAttr>(
+                  argType.getEncoding())) {
+        // If pre-existing TensorMeshShardingAttr is different from the
+        // expected one, then fail.
+        if (argTensorMeshShardingAttr != tensorMeshShardingAttr) {
+          srcOp->emitError()
+              << "Inconsistency found in TensorMeshShardingAttr : expected ("
+              << tensorMeshShardingAttr << ") and current ("
+              << argTensorMeshShardingAttr << ") are different.";
+        }
+        continue;
+      }
+      mlir::Type elementType = argType.getElementType();
+      llvm::ArrayRef<int64_t> shape = argType.getShape();
+      arg.setType(mlir::RankedTensorType::get(shape, elementType,
+                                              tensorMeshShardingAttr));
+    }
+  } else {
+    // Result is single device tensor and thus expects args to be single
+    // device tensors. If we find inconsistency due to one of the args with
+    // multi-device tensor, insert MeshShardOp before the op and change the
+    // tensor to single device tensor.
+    for (auto arg : srcOp->getOperands()) {
+      auto argType = mlir::cast<mlir::RankedTensorType>(arg.getType());
+      if (auto argTensorMeshShardingAttr =
+              mlir::dyn_cast_if_present<mlir::tt::TensorMeshShardingAttr>(
+                  argType.getEncoding())) {
+        mlir::tt::sharding_utils::MeshSharding meshSharding;
+        meshSharding.extractMeshShardingFromTensorMeshShardingAttr(
+            meshes.getMesh(argTensorMeshShardingAttr.getName().str()),
+            argTensorMeshShardingAttr,
+            mlir::tt::MeshShardDirection::ShardToFull);
+
+        mlir::Type elementType = argType.getElementType();
+        llvm::ArrayRef<int64_t> shape = argType.getShape();
+
+        builder.setInsertionPoint(srcOp);
+
+        // TODO(wooseoklee): update code to use createDPSOp API with OpBuilder
+        // once it is ready. https://github.com/tenstorrent/tt-mlir/issues/2767
+        auto emptyOp = builder.create<mlir::tt::ttir::EmptyOp>(
+            srcOp->getLoc(), shape, elementType);
+        auto meshShardOp = builder.create<mlir::tt::ttir::MeshShardOp>(
+            srcOp->getLoc(), mlir::RankedTensorType::get(shape, elementType),
+            arg, emptyOp, meshSharding.getShardType(),
+            meshSharding.getShardDirection(), meshSharding.getShardShape(),
+            meshSharding.getShardDims());
+
+        srcOp->replaceUsesOfWith(arg, meshShardOp.getResult());
+      }
+    }
+  }
+  return llvm::success();
+}
+
+// This pass is to clean up the tensor annotations in the module.
+// In particular, we find two use cases:
+// 1. Single device tensor op has multi device tensor argument in a single op.
+// In this case, we need to insert MeshShardOp before the op and change the
+// tensor to single device tensor.
+// 2. Multi device tensor ops have missing multi device tensor annotation in
+// case of automatic parallelism with pre-sharded inputs and outputs. In this
+// case, we need to add missing TensorMeshShardingAttr.
+class TTIRTensorAnnotationCleanupPass
+    : public mlir::PassWrapper<TTIRTensorAnnotationCleanupPass,
+                               mlir::OperationPass<mlir::ModuleOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TTIRTensorAnnotationCleanupPass)
+
+  void runOnOperation() final {
+    mlir::ModuleOp moduleOp = getOperation();
+    mlir::MLIRContext *context = moduleOp.getContext();
+    auto builder = mlir::OpBuilder(context);
+    auto meshes = moduleOp->getAttrOfType<mlir::tt::MeshesAttr>(
+        mlir::tt::MeshesAttr::name);
+
+    // We regard a module without meshes as a module only containing single
+    // device tensors. Thus, skip this pass.
+    if (!meshes) {
+      return;
+    }
+
+    // Visit all functions and analyze each op from backward in order to
+    // determine either single or multidevcie computation context.
+    for (auto funcOp : moduleOp.getOps<mlir::func::FuncOp>()) {
+      llvm::SmallVector<mlir::Operation *> orderedOps;
+      funcOp->walk<mlir::WalkOrder::PostOrder, mlir::ReverseIterator>(
+          [&](mlir::Operation *op) {
+            // ReturnOp is the root of this analysis and thus shouldn't be
+            // touched. MeshShardOps are ones that convert single to multi
+            // device tensor or vice versa, so do not need to be analyzed.
+            if (mlir::isa<mlir::func::ReturnOp, mlir::tt::ttir::MeshShardOp>(
+                    op)) {
+              return mlir::WalkResult::skip();
+            }
+            orderedOps.push_back(op);
+            return mlir::WalkResult::advance();
+          });
+
+      for (mlir::Operation *op : orderedOps) {
+        if (failed(analyzeSingleOpAndFixWrongTensorAnnotation(meshes, op,
+                                                              builder))) {
+          signalPassFailure();
+        }
+      }
+    }
+  }
+
+  llvm::StringRef getArgument() const override {
+    return "shardy-tensor-annotation-cleanup";
+  }
+
+  llvm::StringRef getDescription() const override {
+    return "Cleanup pass that fixes the multi-device tensor annotations.";
+  }
+
+  void getDependentDialects(mlir::DialectRegistry &registry) const final {
+    registry.insert<mlir::tt::ttir::TTIRDialect>();
+  }
+};
+
+std::unique_ptr<Pass> createTTIRTensorAnnotationCleanupPass() {
+  return std::make_unique<TTIRTensorAnnotationCleanupPass>();
 }
 
 } // namespace mlir::tt

--- a/lib/Dialect/TTIR/Pipelines/TTIRPipelines.cpp
+++ b/lib/Dialect/TTIR/Pipelines/TTIRPipelines.cpp
@@ -41,6 +41,7 @@ void createStableHLOToTTIRPipeline(
     pm.addPass(stablehlo::createStablehloLegalizeCompositeToCallPass());
   }
   pm.addPass(createConvertStableHLOToTTIRPass());
+  pm.addPass(createTTIRTensorAnnotationCleanupPass());
 }
 #endif
 

--- a/test/ttmlir/Conversion/StableHLOToTTIR/ccl/ccl_ops_shardy.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/ccl/ccl_ops_shardy.mlir
@@ -315,7 +315,7 @@ module @jit_neg_shardy7 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_repl
 // -----
 
 // jax/pjrt sharding target 2x4 for t3k - Shardy all_reduce with automatic input sharding
-module @jit_matmul_shardy_automatic attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas = 1 : i32} {
+module @jit_matmul_shardy_automatic_test1 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas = 1 : i32} {
   sdy.mesh @mesh = <["x"=2, "y"=4]>
   func.func public @main(%arg0: tensor<8192x784xf32> {sdy.sharding = #sdy.sharding<@mesh, [{"x"}, {"y"}]>}, %arg1: tensor<784x16384xf32> {sdy.sharding = #sdy.sharding<@mesh, [{"y"}, {}]>}) -> (tensor<8192x16384xf32> {jax.result_info = ""}) {
     %0 = sdy.manual_computation(%arg0, %arg1) in_shardings=[<@mesh, [{"x"}, {"y"}]>, <@mesh, [{"y"}, {}]>] out_shardings=[<@mesh, [{"x"}, {}]>] manual_axes={"x", "y"} (%arg2: tensor<4096x196xf32>, %arg3: tensor<196x16384xf32>) {
@@ -373,7 +373,7 @@ module @jit_matmul_shardy_automatic attributes {mhlo.num_partitions = 8 : i32, m
 // -----
 
 // jax/pjrt automatic input/output sharding tests
-module @jit_matmul_shardy1 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas = 1 : i32} {
+module @jit_matmul_shardy_automatic_test2 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas = 1 : i32} {
   sdy.mesh @mesh = <["x"=2, "y"=4]>
   func.func public @main(%arg0: tensor<8192x784xf32> {sdy.sharding = #sdy.sharding<@mesh, [{"x"}, {"y"}]>}, %arg1: tensor<784x16384xf32> {sdy.sharding = #sdy.sharding<@mesh, [{"y"}, {}]>}) -> (tensor<8192x16384xf32> {jax.result_info = "", sdy.sharding = #sdy.sharding<@mesh, [{"x"}, {}]>}) {
     %0 = sdy.manual_computation(%arg0, %arg1) in_shardings=[<@mesh, [{"x"}, {"y"}]>, <@mesh, [{"y"}, {}]>] out_shardings=[<@mesh, [{"x"}, {}]>] manual_axes={"x", "y"} (%arg2: tensor<4096x196xf32>, %arg3: tensor<196x16384xf32>) {


### PR DESCRIPTION
annotations and fix if there is any issue.

### Ticket
https://github.com/tenstorrent/tt-mlir/issues/2645

### Problem description
Found cases where stablehlo from JAX may not fully follow sharding rules for automatic parallelism with sharded inputs/outputs.

### What's changed
Instead of fixing the issue with case by case, the new pass is introduced that allows us to manage tensor annotations in a more general manner. In particular, this pass address following two cases.
1. Single device tensor op has multi device tensor argument in a single op.
 In this case, we need to insert MeshShardOp before the op and change the
 tensor to single device tensor.
2. Multi device tensor ops have missing multi device tensor annotation in
 case of automatic parallelism with pre-sharded inputs and outputs. In this
 case, we need to add missing TensorMeshShardingAttr.

### Checklist
- [X] New/Existing tests provide coverage for changes
