### PR TITLE
Enable Tensor MeshShape info in TensorDesc

### DIFF
--- a/include/ttmlir/Target/TTNN/types.fbs
+++ b/include/ttmlir/Target/TTNN/types.fbs
@@ -105,6 +105,7 @@ table LayoutDesc {
 
 table TensorDesc {
   shape: [int];
+  mesh_shape: [int32];
   layout: LayoutDesc;
 }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/2685

### Problem description
For the proper handling of multi-device tensors, runtime needs to know the specific mesh shape for each tensor.

### What's changed
This change allows TensorDesc to have associated meshShape info if it is multi-device tensor. 
If single-device tensor, the meshShape will be 1x1.

