### PR TITLE
Added AugAssign to PyKernel

### DIFF
--- a/python/pykernel/pykernel_ast.py
+++ b/python/pykernel/pykernel_ast.py
@@ -423,12 +423,44 @@ class TTKernelCompiler(ast.NodeVisitor):
             var = memref.alloca(memref_type, [], [])
             sym_table[var_name] = var
         else:
-            assert isinstance(var, MemRefType), "Can not AugAssign to non-memref types"
+            assert isinstance(var, MemRefType), "Can not AnnAssign to non-memref types"
 
         memref.StoreOp(value, var, [arith.ConstantOp(IndexType.get(self.ctx), 0)])
 
     def visit_AugAssign(self, node):
-        raise NotImplementedError("AugAssign not supported yet")
+        target = self.visit(node.target)
+
+        # Target must already be defined in the scope of the symbol table
+        if not target:
+            raise ValueError(
+                "AugAssign can only Assign to values that have been defined"
+            )
+
+        value = self.visit(node.value)
+        sym_table = self.symbol_tables[-1]
+
+        if not isinstance(target.type, memref.MemRefType):
+            raise ValueError("Can not AugAssign to non-memref types")
+
+        _target = memref.LoadOp(
+            target, arith.ConstantOp(IndexType.get(self.ctx), 0)
+        ).result
+
+        # Determine the operation based on the type of AugAssign
+        match node.op:
+            case ast.Add():
+                result = arith.AddIOp(_target, value)
+            case ast.Sub():
+                result = arith.SubIOp(_target, value)
+            case ast.Mult():
+                result = arith.MulIOp(_target, value)
+            case _:
+                raise NotImplementedError(
+                    f"AugAssign operation {type(node.op).__name__} not supported"
+                )
+
+        # Store the result back to the target
+        memref.StoreOp(result, target, [arith.ConstantOp(IndexType.get(self.ctx), 0)])
 
     # Function calls
     def visit_Call(self, node):
@@ -590,7 +622,9 @@ class TTKernelCompiler(ast.NodeVisitor):
         if any(
             isinstance(node, supported_node) for supported_node in self.supported_nodes
         ):
-            if self.verbose and isinstance(node, (ast.Assign, ast.AnnAssign)):
+            if self.verbose and isinstance(
+                node, (ast.Assign, ast.AnnAssign, ast.AugAssign)
+            ):
                 # Create a verbatim Op here to store the comment
                 source_code = self.get_source_comment(node)
                 emitc.verbatim(source_code)

--- a/test/pykernel/eltwise_sfpu/reader_unary.py
+++ b/test/pykernel/eltwise_sfpu/reader_unary.py
@@ -49,11 +49,11 @@ def reader_unary(cb_in: CircularBuffer, cb_out: CircularBuffer, rt_args):
         # CHECK: "ttkernel.cb_push_back"{{.*}}
         cb_push_back(cb_in, ublock_size_tiles)
 
-        # CHECK: emitc.verbatim "// src_addr = src_addr + ublock_size_bytes"
+        # CHECK: emitc.verbatim "// src_addr += ublock_size_bytes"
         # CHECK: {{.*}}memref.load %[[SRC_ADDR]]{{.*}}
         # CHECK: {{.*}}arith.addi{{.*}}
         # CHECK: memref.store {{.*}} %[[SRC_ADDR]]{{.*}}
-        src_addr = src_addr + ublock_size_bytes
+        src_addr += ublock_size_bytes
 
     return
 

--- a/test/pykernel/eltwise_sfpu/writer_unary.py
+++ b/test/pykernel/eltwise_sfpu/writer_unary.py
@@ -41,11 +41,10 @@ def writer_unary(cb_in: CircularBuffer, cb_out: CircularBuffer, rt_args):
 
         # CHECK: "ttkernel.cb_pop_front"{{.*}}
         cb_pop_front(cb_out, ublock_size_tiles)
-
         # CHECK: {{.*}}memref.load %[[DST_ADDR]]{{.*}}
         # CHECK: {{.*}}arith.addi{{.*}}
         # CHECK: memref.store {{.*}} %[[DST_ADDR]]{{.*}}
-        dst_addr = dst_addr + ublock_size_bytes
+        dst_addr += ublock_size_bytes
 
     return
 

--- a/test/pykernel/matmul_common/reader_bmm_8bank.py
+++ b/test/pykernel/matmul_common/reader_bmm_8bank.py
@@ -48,7 +48,7 @@ def reader_bmm_8bank(cb_id_in0: CircularBuffer, cb_id_in1: CircularBuffer, rt_ar
     for nb in range(0, batch, 1):
         itileA: int = itileA_batch + 0
         for mt in range(0, Mt, 1):
-            itileB = itileB_batch + 0
+            itileB: int = itileB_batch + 0
             for nt in range(0, Nt, 1):
                 for kt in range(0, Kt, 1):
                     cb_reserve_back(cb_id_in0, onetile)
@@ -63,15 +63,15 @@ def reader_bmm_8bank(cb_id_in0: CircularBuffer, cb_id_in1: CircularBuffer, rt_ar
                     noc_async_read_barrier()
                     cb_push_back(cb_id_in1, onetile)
 
-                    itileA = itileA + 1
-                    itileB = itileB + Nt
+                    itileA += 1
+                    itileB += Nt
 
-                itileB = itileB - KtNt + 1
-                itileA = itileA - Kt
-            itileA = itileA + Kt
-        itileA_batch = itileA_batch + MtKt
+                itileB -= KtNt + 1
+                itileA -= Kt
+            itileA += Kt
+        itileA_batch += MtKt
         if bcast_B == 0:
-            itileB_batch = itileB_batch + KtNt
+            itileB_batch += KtNt
 
     return
 

--- a/test/pykernel/matmul_common/writer_bmm_8bank.py
+++ b/test/pykernel/matmul_common/writer_bmm_8bank.py
@@ -33,7 +33,7 @@ def writer_bmm_8bank(cb_id_out0: CircularBuffer):
                 noc_async_write_tile(itileC, s, l1_read_addr)
                 noc_async_write_barrier()
                 cb_pop_front(cb_id_out0, onetile)
-                itileC = itileC + 1
+                itileC += 1
 
     return
 

--- a/test/pykernel/unit_tests.py
+++ b/test/pykernel/unit_tests.py
@@ -19,7 +19,7 @@ def test_assign():
     a = 1
     a = 2
 
-    # TEST: AugAssign with memref
+    # TEST: AnnAssign with memref
     # CHECK: %[[CONST:.*]] = arith.constant{{.*}} : i32
     # CHECK: %[[ALLOCA:.*]] = memref.alloca() : memref<1xi32>
     # CHECK: memref.store %[[CONST]], %[[ALLOCA]]{{.*}} : memref<1xi32>
@@ -28,7 +28,7 @@ def test_assign():
     # CHECK: memref.store %[[CONST]], %[[ALLOCA]]{{.*}} : memref<1xi32>
     b = 2
 
-    # TEST: AnnAssign with memref
+    # TEST: AugAssign with memref
     # CHECK: {{.*}}memref.load %[[ALLOCA]]{{.*}}
     # CHECK: {{.*}}arith.addi{{.*}}
     # CHECK: memref.store {{.*}} %[[ALLOCA]]{{.*}}

--- a/test/pykernel/unit_tests.py
+++ b/test/pykernel/unit_tests.py
@@ -28,6 +28,22 @@ def test_assign():
     # CHECK: memref.store %[[CONST]], %[[ALLOCA]]{{.*}} : memref<1xi32>
     b = 2
 
+    # TEST: AnnAssign with memref
+    # CHECK: {{.*}}memref.load %[[ALLOCA]]{{.*}}
+    # CHECK: {{.*}}arith.addi{{.*}}
+    # CHECK: memref.store {{.*}} %[[ALLOCA]]{{.*}}
+    b += 2
+
+    # CHECK: {{.*}}memref.load %[[ALLOCA]]{{.*}}
+    # CHECK: {{.*}}arith.subi{{.*}}
+    # CHECK: memref.store {{.*}} %[[ALLOCA]]{{.*}}
+    b -= 2
+
+    # CHECK: {{.*}}memref.load %[[ALLOCA]]{{.*}}
+    # CHECK: {{.*}}arith.muli{{.*}}
+    # CHECK: memref.store {{.*}} %[[ALLOCA]]{{.*}}
+    b *= 2
+
     return
 
 


### PR DESCRIPTION
### Ticket
- PR closes #1844 

### Problem description
- Previously AugAssign wasn't supported

### What's changed
- Added `AugAssign` for `Add`, `Mul`, `Sub` into PyKernel AST
- Only operates on MemRefTypes already defined in Symbol table.

### Checklist
- [x] Updated Tests with `AugAssign` calls.
