### PR TITLE
Added Unary Ops Not, Invert, USub, UAdd to PyKernel

### DIFF
--- a/test/pykernel/unit_tests.py
+++ b/test/pykernel/unit_tests.py
@@ -145,8 +145,39 @@ def test_compare_expr():
     return
 
 
+@ttkernel_compile()
+def test_unary_ops():
+    # CHECK: module {
+    # CHECK: func.func @
+
+    a = 1
+
+    # CHECK: %{{.*}} = emitc.expression : i1 {{.*}}
+    # CHECK: %{{.*}} = logical_not {{.*}}
+    # CHECK: yield %{{.*}}
+    not a
+
+    # CHECK: %{{.*}} = emitc.expression {{.*}}
+    # CHECK: %{{.*}} = bitwise_not {{.*}}
+    # CHECK: yield %{{.*}}
+    ~a
+
+    # CHECK: %{{.*}} = emitc.expression {{.*}}
+    # CHECK: %{{.*}} = unary_minus {{.*}}
+    # CHECK: yield %{{.*}}
+    -a
+
+    # CHECK: %{{.*}} = emitc.expression {{.*}}
+    # CHECK: %{{.*}} = unary_plus {{.*}}
+    # CHECK: yield %{{.*}}
+    +a
+
+    return
+
+
 test_assign()
 test_ifstmt()
 test_for()
 test_binops()
 test_compare_expr()
+test_unary_ops()


### PR DESCRIPTION
### Ticket
- PR closes #1814 
- PR closes #1815 
- PR closes #1816 
- PR closes #1817 
- PR closes #1818  

### Problem description
- PyKernel didn't support Unary Ops before

### What's changed
- Use `emitc` calls directly to support Unary Ops, relying on the `emitc.expression` to update the value and have it pass through the compiler.
- Results now look a lot better than forcing `arith` ops to emulate the same behaviour.
- Updated Unit tests.
