### PR TITLE
Add Conv2dConfig overrides

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/LegalLayoutAnalysis.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/LegalLayoutAnalysis.h
@@ -9,6 +9,7 @@
 #include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
 #include "ttmlir/Dialect/TTNN/Analysis/TTNNAnalysis.h"
 #include "ttmlir/Dialect/TTNN/Utils/OptimizerOverrides.h"
+#include "ttmlir/Dialect/TTNN/Utils/PassOverrides.h"
 
 #include "llvm/ADT/StringMap.h"
 
@@ -20,26 +21,30 @@ struct LegalLayoutAnalysisInput {
   RankedTensorType tensorType;
   int64_t maxShardedConfigs;
   llvm::StringMap<OutputLayoutOverrideParams> *outputLayoutOverrides;
+  llvm::StringMap<Conv2dConfigOverrideParams> *conv2dConfigOverrides;
   bool rowMajorEnabled;
 
   LegalLayoutAnalysisInput()
       : chipDesc(nullptr), maxGrid(nullptr), tensorType(nullptr),
-        outputLayoutOverrides(nullptr) {}
+        outputLayoutOverrides(nullptr), conv2dConfigOverrides(nullptr) {}
 
   LegalLayoutAnalysisInput(
       ChipDescAttr chipDesc, GridAttr maxGrid, RankedTensorType tensorType,
       int64_t maxShardedConfigs,
       llvm::StringMap<OutputLayoutOverrideParams> *outputLayoutOverrides,
+      llvm::StringMap<Conv2dConfigOverrideParams> *conv2dConfigOverrides,
       bool rowMajorEnabled)
       : chipDesc(chipDesc), maxGrid(maxGrid), tensorType(tensorType),
         maxShardedConfigs(maxShardedConfigs),
         outputLayoutOverrides(outputLayoutOverrides),
+        conv2dConfigOverrides(conv2dConfigOverrides),
         rowMajorEnabled(rowMajorEnabled) {}
 
   bool operator==(const LegalLayoutAnalysisInput &rhs) const {
     return chipDesc == rhs.chipDesc && maxGrid == rhs.maxGrid &&
            tensorType == rhs.tensorType &&
-           outputLayoutOverrides == rhs.outputLayoutOverrides;
+           outputLayoutOverrides == rhs.outputLayoutOverrides &&
+           conv2dConfigOverrides == rhs.conv2dConfigOverrides;
   }
 
   bool operator!=(const LegalLayoutAnalysisInput &rhs) const {

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -76,7 +76,7 @@ struct TTIRToTTNNBackendPipelineOptions
           llvm::cl::desc("Override output tensor layout for specific ops."),
           llvm::cl::init(llvm::StringMap<OutputLayoutOverrideParams>())};
 
-  //Conv2dConfig Overrides
+  // Conv2dConfig Overrides
   Option<llvm::StringMap<Conv2dConfigOverrideParams>,
          Conv2dConfigOverrideParser>
       overrideConv2dConfig{

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -76,6 +76,14 @@ struct TTIRToTTNNBackendPipelineOptions
           llvm::cl::desc("Override output tensor layout for specific ops."),
           llvm::cl::init(llvm::StringMap<OutputLayoutOverrideParams>())};
 
+  //Conv2dConfig Overrides
+  Option<llvm::StringMap<Conv2dConfigOverrideParams>,
+         Conv2dConfigOverrideParser>
+      overrideConv2dConfig{
+          *this, OptionNames::overrideConv2dConfig,
+          llvm::cl::desc("Override Conv2d configuration for specific ops."),
+          llvm::cl::init(llvm::StringMap<Conv2dConfigOverrideParams>())};
+
   // If this option is true, run memory layout analysis.
   //
   Option<bool> memoryLayoutAnalysisEnabled{

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -84,7 +84,7 @@ struct TTIRToTTNNBackendPipelineOptions
   // optimizerPassEnabled (enable-optimizer) is true.
   //
   // Full Example:
-  // override-conv2d-config=conv2d_1=dtype#bf16:weights_dtype#bf16:activation#relu:input_channels_alignment#32:deallocate_activation#false:reallocate_halo_output#true:act_block_h_override#0:act_block_w_div#1:reshard_if_not_optimal#false:override_sharding_config#false:shard_layout#block_sharded:core_grid#0:transpose_shards#true:output_layout#row_major:enable_act_double_buffer#false:enable_weights_double_buffer#false:enable_split_reader#false:enable_subblock_padding#false
+  // override-conv2d-config=conv2d_1=dtype#bf16:weights_dtype#bf16:activation#relu:input_channels_alignment#32:deallocate_activation#false:reallocate_halo_output#true:act_block_h_override#0:act_block_w_div#1:reshard_if_not_optimal#false:override_sharding_config#false:shard_layout#block_sharded:core_grid#0:transpose_shards#true:output_layout#row_major:preprocess_weights_on_device#false:always_preprocess_weights#false:enable_act_double_buffer#false:enable_weights_double_buffer#false:enable_split_reader#false:enable_subblock_padding#false
   // Partial Example:
   // "conv2d_1=enable_weights_double_buffer#true:activation#none,conv2d_2=dtype#bf16"
   //
@@ -104,6 +104,8 @@ struct TTIRToTTNNBackendPipelineOptions
   // width_sharded]
   // * core_grid:
   // * transpose_shards: [true, false]
+  // * preprocess_weights_on_device: [true, false]
+  // * always_preprocess_weights: [true, false]
   // * output_layout: [row_major, tile]
   // * enable_act_double_buffer: [true, false]
   // * enable_weights_double_buffer: [true, false]

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -76,7 +76,42 @@ struct TTIRToTTNNBackendPipelineOptions
           llvm::cl::desc("Override output tensor layout for specific ops."),
           llvm::cl::init(llvm::StringMap<OutputLayoutOverrideParams>())};
 
-  // Conv2dConfig Overrides
+  // Option to override Conv2d configuration for specific operations.
+  // If not all parameters are overridden, the remaining ones will be set to
+  // default (see in tt-metal). The format is a comma-separated list of
+  // operation names followed by the conv2d config parameters as
+  // `param_name#param_value`, separated by :. This option is only valid if
+  // optimizerPassEnabled (enable-optimizer) is true.
+  //
+  // Full Example:
+  // override-conv2d-config=conv2d_1=dtype#bf16:weights_dtype#bf16:activation#relu:input_channels_alignment#32:deallocate_activation#false:reallocate_halo_output#true:act_block_h_override#0:act_block_w_div#1:reshard_if_not_optimal#false:override_sharding_config#false:shard_layout#block_sharded:core_grid#0:transpose_shards#true:output_layout#row_major:enable_act_double_buffer#false:enable_weights_double_buffer#false:enable_split_reader#false:enable_subblock_padding#false
+  // Partial Example:
+  // "conv2d_1=enable_weights_double_buffer#true:activation#none,conv2d_2=dtype#bf16"
+  //
+  // * dtype: [bf16, f32, f16, bfp_f8, bfp_bf8, bfp_f4, bfp_bf4, bfp_f2,
+  // bfp_bf2, u32, u16, u8]
+  // * weights_dtype: [bf16, f32, f16, bfp_f8, bfp_bf8, bfp_f4, bfp_bf4, bfp_f2,
+  // bfp_bf2, u32, u16, u8]
+  // * activation: [none, relu]
+  // * input_channels_alignment: uint32_t (multiple of 8)
+  // * deallocate_activation: [true, false]
+  // * reallocate_halo_output: [true, false]
+  // * act_block_h_override: uint32_t (multiple of 32)
+  // * act_block_w_div: uint32_t
+  // * reshard_if_not_optimal: [true, false]
+  // * override_sharding_config: [true, false]
+  // * shard_layout: [block_sharded, interleaved, single_bank, height_sharded,
+  // width_sharded]
+  // * core_grid:
+  // * transpose_shards: [true, false]
+  // * output_layout: [row_major, tile]
+  // * enable_act_double_buffer: [true, false]
+  // * enable_weights_double_buffer: [true, false]
+  // * enable_split_reader: [true, false]
+  // * enable_subblock_padding: [true, false]
+  //
+  // For more details on parameter values see conv2d_op.hpp in tt-metal.
+  //
   Option<llvm::StringMap<Conv2dConfigOverrideParams>,
          Conv2dConfigOverrideParser>
       overrideConv2dConfig{

--- a/include/ttmlir/Dialect/TTNN/Transforms/Optimizer.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Optimizer.h
@@ -18,6 +18,8 @@ struct TTNNOptimizerOptions {
       llvm::StringMap<InputLayoutOverrideParams>();
   llvm::StringMap<OutputLayoutOverrideParams> overrideOutputLayout =
       llvm::StringMap<OutputLayoutOverrideParams>();
+  llvm::StringMap<Conv2dConfigOverrideParams> overrideConv2dConfig =
+      llvm::StringMap<Conv2dConfigOverrideParams>();
   bool memoryLayoutAnalysisEnabled = false;
   MemoryLayoutAnalysisPolicyType memoryLayoutAnalysisPolicy =
       MemoryLayoutAnalysisPolicyType::DFSharding;

--- a/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
@@ -30,7 +30,6 @@ struct OptionNames {
 };
 
 struct Conv2dConfigOverrideParams {
-  // change metal to ttnn types
   std::optional<tt::DataType> dtype = std::nullopt;
   std::optional<tt::DataType> weightsDtype = std::nullopt;
   std::optional<std::string> activation = std::nullopt;
@@ -157,9 +156,12 @@ public:
   Conv2dConfigOverrideParser(llvm::cl::Option &opt)
       : llvm::cl::parser<llvm::StringMap<Conv2dConfigOverrideParams>>(opt) {}
 
+  // Parse override-conv2d-config string. If string format is invalid, return
+  // true, else return false.
   bool parse(llvm::cl::Option &opt, StringRef argName, StringRef arg,
              llvm::StringMap<Conv2dConfigOverrideParams> &value);
 
+  // Return override-conv2d-config string represenation.
   static std::string
   toString(const llvm::StringMap<Conv2dConfigOverrideParams> &);
 

--- a/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
@@ -5,12 +5,12 @@
 #ifndef TTMLIR_DIALECT_TTNN_UTILS_PASSOVERRIDES_H
 #define TTMLIR_DIALECT_TTNN_UTILS_PASSOVERRIDES_H
 
-#include <llvm/Support/CommandLine.h>
-#include <optional>
-
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 
+#include <llvm/Support/CommandLine.h>
+
+#include <optional>
 namespace mlir::tt::ttnn {
 
 struct OptionNames {
@@ -41,9 +41,11 @@ struct Conv2dConfigOverrideParams {
   std::optional<bool> reshardIfNotOptimal = std::nullopt;
   std::optional<bool> overrideShardingConfig = std::nullopt;
   std::optional<TensorMemoryLayout> shardLayout = std::nullopt;
-  std::optional<Attribute> coreGrid = std::nullopt;
+  std::optional<CoreRangeSetAttr> coreGrid = std::nullopt;
   std::optional<bool> transposeShards = std::nullopt;
   std::optional<Layout> outputLayout = std::nullopt;
+  std::optional<bool> preprocessWeightsOnDevice = std::nullopt;
+  std::optional<bool> alwaysPreprocessWeights = std::nullopt;
   std::optional<bool> enableActDoubleBuffer = std::nullopt;
   std::optional<bool> enableWeightsDoubleBuffer = std::nullopt;
   std::optional<bool> enableSplitReader = std::nullopt;

--- a/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
@@ -6,6 +6,7 @@
 #define TTMLIR_DIALECT_TTNN_UTILS_PASSOVERRIDES_H
 
 #include <llvm/Support/CommandLine.h>
+#include <optional>
 
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
@@ -17,6 +18,7 @@ struct OptionNames {
   static constexpr StringRef optimizerPassEnabled = "enable-optimizer";
   static constexpr StringRef overrideInputLayout = "insert-memreconfig";
   static constexpr StringRef overrideOutputLayout = "override-output-layout";
+  static constexpr StringRef overrideConv2dConfig = "override-conv2d-config";
   static constexpr StringRef memoryLayoutAnalysisEnabled =
       "memory-layout-analysis-enabled";
   static constexpr StringRef memReconfigEnabled = "memreconfig-enabled";
@@ -25,6 +27,32 @@ struct OptionNames {
   static constexpr StringRef systemDescPath = "system-desc-path";
   static constexpr StringRef maxLegalLayouts = "max-legal-layouts";
   static constexpr StringRef meshShape = "mesh-shape";
+};
+
+struct Conv2dConfigOverrideParams {
+  // change metal to ttnn types
+  std::optional<tt::DataType> dtype = std::nullopt;
+  std::optional<tt::DataType> weightsDtype = std::nullopt;
+  std::optional<std::string> activation = std::nullopt;
+  std::optional<uint32_t> inputChannelsAlignment = std::nullopt;
+  std::optional<bool> deallocateActivation = std::nullopt;
+  std::optional<bool> reallocateHaloOutput = std::nullopt;
+  std::optional<uint32_t> actBlockHOverride = std::nullopt;
+  std::optional<uint32_t> actBlockWDiv = std::nullopt;
+  std::optional<bool> reshardIfNotOptimal = std::nullopt;
+  std::optional<bool> overrideShardingConfig = std::nullopt;
+  std::optional<TensorMemoryLayout> shardLayout = std::nullopt;
+  std::optional<Attribute> coreGrid = std::nullopt;
+  std::optional<bool> transposeShards = std::nullopt;
+  std::optional<Layout> outputLayout = std::nullopt;
+  std::optional<bool> enableActDoubleBuffer = std::nullopt;
+  std::optional<bool> enableWeightsDoubleBuffer = std::nullopt;
+  std::optional<bool> enableSplitReader = std::nullopt;
+  std::optional<bool> enableSubblockPadding = std::nullopt;
+
+  //TODO: Implement for testing.
+  bool operator==(const Conv2dConfigOverrideParams &rhs) const;
+  bool operator!=(const Conv2dConfigOverrideParams &rhs) const;
 };
 
 struct OutputLayoutOverrideParams {
@@ -125,6 +153,22 @@ struct InputLayoutOverrideParams {
   bool operator!=(const InputLayoutOverrideParams &rhs) const {
     return !(*this == rhs);
   }
+};
+
+struct Conv2dConfigOverrideParser
+    : public llvm::cl::parser<llvm::StringMap<Conv2dConfigOverrideParams>> {
+public:
+  Conv2dConfigOverrideParser(llvm::cl::Option &opt)
+      : llvm::cl::parser<llvm::StringMap<Conv2dConfigOverrideParams>>(opt) {}
+
+  bool parse(llvm::cl::Option &opt, StringRef argName, StringRef arg,
+             llvm::StringMap<Conv2dConfigOverrideParams> &value);
+
+  static std::string
+  toString(const llvm::StringMap<Conv2dConfigOverrideParams> &);
+
+  static void print(llvm::raw_ostream &os,
+                    const llvm::StringMap<Conv2dConfigOverrideParams> &value);
 };
 
 struct OutputLayoutOverrideParser

--- a/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
@@ -49,22 +49,6 @@ struct Conv2dConfigOverrideParams {
   std::optional<bool> enableWeightsDoubleBuffer = std::nullopt;
   std::optional<bool> enableSplitReader = std::nullopt;
   std::optional<bool> enableSubblockPadding = std::nullopt;
-
-  bool fullConv2dConfigOverride() const {
-    return dtype.has_value() && weightsDtype.has_value() &&
-           activation.has_value() && inputChannelsAlignment.has_value() &&
-           deallocateActivation.has_value() && reallocateHaloOutput.has_value() &&
-           actBlockHOverride.has_value() && actBlockWDiv.has_value() &&
-           reshardIfNotOptimal.has_value() && overrideShardingConfig.has_value() &&
-           shardLayout.has_value() && coreGrid.has_value() &&
-           transposeShards.has_value() && outputLayout.has_value() &&
-           enableActDoubleBuffer.has_value() && enableWeightsDoubleBuffer.has_value() &&
-           enableSplitReader.has_value() && enableSubblockPadding.has_value();
-  }
-
-  //TODO: Implement for testing.
-  bool operator==(const Conv2dConfigOverrideParams &rhs) const;
-  bool operator!=(const Conv2dConfigOverrideParams &rhs) const;
 };
 
 struct OutputLayoutOverrideParams {

--- a/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
@@ -50,6 +50,18 @@ struct Conv2dConfigOverrideParams {
   std::optional<bool> enableSplitReader = std::nullopt;
   std::optional<bool> enableSubblockPadding = std::nullopt;
 
+  bool fullConv2dConfigOverride() const {
+    return dtype.has_value() && weightsDtype.has_value() &&
+           activation.has_value() && inputChannelsAlignment.has_value() &&
+           deallocateActivation.has_value() && reallocateHaloOutput.has_value() &&
+           actBlockHOverride.has_value() && actBlockWDiv.has_value() &&
+           reshardIfNotOptimal.has_value() && overrideShardingConfig.has_value() &&
+           shardLayout.has_value() && coreGrid.has_value() &&
+           transposeShards.has_value() && outputLayout.has_value() &&
+           enableActDoubleBuffer.has_value() && enableWeightsDoubleBuffer.has_value() &&
+           enableSplitReader.has_value() && enableSubblockPadding.has_value();
+  }
+
   //TODO: Implement for testing.
   bool operator==(const Conv2dConfigOverrideParams &rhs) const;
   bool operator!=(const Conv2dConfigOverrideParams &rhs) const;

--- a/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
@@ -8,9 +8,10 @@
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 
-#include <llvm/Support/CommandLine.h>
+#include "llvm/Support/CommandLine.h"
 
 #include <optional>
+
 namespace mlir::tt::ttnn {
 
 struct OptionNames {

--- a/include/ttmlir/Dialect/TTNN/Utils/TransformUtils.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/TransformUtils.h
@@ -24,7 +24,7 @@ createToLayoutOp(mlir::Operation *op,
                  PatternRewriter &rewriter, Layout targetTensorLayout,
                  BufferType targetTensorBufferType,
                  std::optional<TensorMemoryLayout> targetTensorMemoryLayout,
-                 DataType targetTensorDataType);
+                 DataType targetTensorDataType, llvm::StringRef locSuffix = "");
 } // namespace mlir::tt::ttnn::utils
 
 #endif

--- a/lib/Dialect/TTNN/Analysis/LegalLayoutAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/LegalLayoutAnalysis.cpp
@@ -86,8 +86,8 @@ bool cantChangeOutputLayout(Operation *op) {
   return false;
 }
 
-bool applyConv2dConfigOverrides(
-    Operation *op, Conv2dConfigOverrideParams &conv2dConfigOverrides,
+void applyConv2dConfigOverrides(
+    Operation *op, const Conv2dConfigOverrideParams &conv2dConfigOverrides,
     std::vector<OpConfig> &analysisResult) {
   // Apply conv2d config overrides to all legal (layout) configurations of
   // current op.
@@ -122,10 +122,8 @@ bool applyConv2dConfigOverrides(
       context, conv2dConfigOverrides.overrideShardingConfig.value_or(false));
   ttnn::TensorMemoryLayoutAttr newShardLayout;
   if (conv2dConfigOverrides.shardLayout.has_value()) {
-    TensorMemoryLayoutAttr::get(context,
-                                conv2dConfigOverrides.shardLayout.value());
-  } else {
-    newShardLayout = TensorMemoryLayoutAttr();
+    newShardLayout = TensorMemoryLayoutAttr::get(
+        context, conv2dConfigOverrides.shardLayout.value());
   }
   Attribute newCoreGrid = conv2dConfigOverrides.coreGrid.value_or(Attribute());
   BoolAttr newTransposeShards = BoolAttr::get(
@@ -153,8 +151,6 @@ bool applyConv2dConfigOverrides(
         newEnableActDoubleBuffer, newEnableWeightsDoubleBuffer,
         newEnableSplitReader, newEnableSubblockPadding);
   }
-
-  return false;
 }
 
 bool LegalLayoutAnalysis::applyOverrides() {

--- a/lib/Dialect/TTNN/Analysis/LegalLayoutAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/LegalLayoutAnalysis.cpp
@@ -142,6 +142,8 @@ bool applyConv2dConfigOverrides(
       context, conv2dConfigOverrides.enableSubblockPadding.value_or(false));
 
   for (auto &opConfig : analysisResult) {
+    assert(!opConfig.config &&
+           "OpConfig should not have a config set before applying overrides");
     opConfig.config = Conv2dConfigAttr::get(
         context, newDtype, newWeightsDtype, newActivation,
         newInputChannelsAlignment, newDeallocateActivation,
@@ -210,14 +212,12 @@ bool LegalLayoutAnalysis::applyOverrides() {
                                   layoutOverride.tensorMemoryLayout.value())));
 
   // Apply conv2d config overrides if they exist and op is Conv2d.
-  if (analysisInput.conv2dConfigOverrides) {
-    if (isa<ttnn::Conv2dOp>(op)) {
-      auto overrideConv2dIt =
-          analysisInput.conv2dConfigOverrides->find(opLocName);
-      if (overrideConv2dIt != analysisInput.conv2dConfigOverrides->end()) {
-        applyConv2dConfigOverrides(op, overrideConv2dIt->getValue(),
-                                   analysisResult);
-      }
+  if (analysisInput.conv2dConfigOverrides && isa<ttnn::Conv2dOp>(op)) {
+    auto overrideConv2dIt =
+        analysisInput.conv2dConfigOverrides->find(opLocName);
+    if (overrideConv2dIt != analysisInput.conv2dConfigOverrides->end()) {
+      applyConv2dConfigOverrides(op, overrideConv2dIt->getValue(),
+                                 analysisResult);
     }
   }
   return true;
@@ -429,14 +429,12 @@ void LegalLayoutAnalysis::analysisImplementation() {
   // Apply conv2d config overrides if they exist and op is Conv2d.
   if (isa<NameLoc>(op->getLoc())) {
     StringRef opLocName = mlir::cast<NameLoc>(op->getLoc()).getName();
-    if (analysisInput.conv2dConfigOverrides) {
-      if (isa<ttnn::Conv2dOp>(op)) {
-        auto overrideConv2dIt =
-            analysisInput.conv2dConfigOverrides->find(opLocName);
-        if (overrideConv2dIt != analysisInput.conv2dConfigOverrides->end()) {
-          applyConv2dConfigOverrides(op, overrideConv2dIt->getValue(),
-                                     analysisResult);
-        }
+    if (analysisInput.conv2dConfigOverrides && isa<ttnn::Conv2dOp>(op)) {
+      auto overrideConv2dIt =
+          analysisInput.conv2dConfigOverrides->find(opLocName);
+      if (overrideConv2dIt != analysisInput.conv2dConfigOverrides->end()) {
+        applyConv2dConfigOverrides(op, overrideConv2dIt->getValue(),
+                                   analysisResult);
       }
     }
   }

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -49,6 +49,7 @@ void createTTNNPipelineAnalysisPasses(
     ttnn::TTNNOptimizerOptions optimizerOptions;
     optimizerOptions.overrideInputLayout = options.overrideInputLayout;
     optimizerOptions.overrideOutputLayout = options.overrideOutputLayout;
+    optimizerOptions.overrideConv2dConfig = options.overrideConv2dConfig;
     optimizerOptions.memoryLayoutAnalysisEnabled =
         options.memoryLayoutAnalysisEnabled;
     optimizerOptions.memReconfigEnabled = options.memReconfigEnabled;

--- a/lib/Dialect/TTNN/Transforms/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/Optimizer.cpp
@@ -377,15 +377,15 @@ private:
     //
     llvm::StringMap<bool> overridenOpExists;
     llvm::StringMap<bool> overrideConv2dOp;
-    for (auto &opOverride : overrideOutputLayout) {
-      overridenOpExists[opOverride.first()] = false;
+    for (const auto &[opLoc, _] : overrideOutputLayout) {
+      overridenOpExists[opLoc] = false;
     }
-    for (auto &opOverride : overrideInputLayout) {
-      overridenOpExists[opOverride.first()] = false;
+    for (const auto &[opLoc, _] : overrideInputLayout) {
+      overridenOpExists[opLoc] = false;
     }
-    for (auto &opOverride : overrideConv2dConfig) {
-      overridenOpExists[opOverride.first()] = false;
-      overrideConv2dOp[opOverride.first()] = false;
+    for (const auto &[opLoc, _] : overrideConv2dConfig) {
+      overridenOpExists[opLoc] = false;
+      overrideConv2dOp[opLoc] = false;
     }
 
     ModuleOp moduleOp = getOperation();
@@ -399,16 +399,14 @@ private:
         overridenOpExists[opLocName] = true;
       }
       if (!isa<ttnn::Conv2dOp>(op) && overrideConv2dOp.contains(opLocName)) {
-        llvm::errs() << "Trying to override conv2d config on non-conv2d op: "
-                     << op->getName() << "\n";
-        assert(false && "Trying to override conv2d config on non-conv2d op: ");
+        op->emitOpError("Trying to override conv2d config on non-conv2d op.");
+        assert(false && "Trying to override conv2d config on non-conv2d op.");
       }
     });
 
-    for (auto &opOverride : overridenOpExists) {
-      if (!opOverride.second) {
-        llvm::errs() << "Trying to override non-existing op: "
-                     << opOverride.first() << "\n";
+    for (const auto &[opLoc, opOverridenAndExists] : overridenOpExists) {
+      if (!opOverridenAndExists) {
+        llvm::errs() << "Trying to override non-existing op: " << opLoc << "\n";
         assert(false && "Trying to override non-existing op");
       }
     }

--- a/lib/Dialect/TTNN/Transforms/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/Optimizer.cpp
@@ -21,12 +21,12 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Value.h"
 #include "mlir/IR/Visitors.h"
-#include <cstddef>
 #include <llvm/ADT/APInt.h>
 #include <llvm/Support/Casting.h>
 #include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/BuiltinTypes.h>
 #include <mlir/IR/MLIRContext.h>
+#include <mlir/Support/LLVM.h>
 
 namespace mlir::tt::ttnn {
 
@@ -349,7 +349,10 @@ public:
         }
         // Set Conv2d Config
         //
-        StringRef opLocName = mlir::cast<NameLoc>(op->getLoc()).getName();
+        StringRef opLocName = "";
+        if(isa<NameLoc>(op->getLoc())) {
+          opLocName = mlir::cast<NameLoc>(op->getLoc()).getName();
+        }
         if(isa<ttnn::Conv2dOp>(op)) {
           if(overrideConv2dConfig.contains(opLocName)) {
             Conv2dConfigOverrideParams conv2dConfigOverrideParams = overrideConv2dConfig[opLocName];
@@ -368,13 +371,11 @@ public:
             ttnn::TensorMemoryLayoutAttr newShardLayout;
             Attribute newCoreGrid;
             BoolAttr newTransposeShards;  
-            // TODO: Change to 'Layout'
             LayoutAttr newOutputLayout;
             BoolAttr newEnableActDoubleBuffer;
             BoolAttr newEnableWeightsDoubleBuffer;
             BoolAttr newEnableSplitReader;
             BoolAttr newEnableSubblockPadding;
-            //TODO: Keep Conv2dConfig values if present
             if(conv2dConfigOverrideParams.dtype.has_value()) {
               newDtype = conv2dConfigOverrideParams.dtype.value();
             } else {
@@ -430,15 +431,13 @@ public:
             if(conv2dConfigOverrideParams.shardLayout.has_value()) {
               newShardLayout = TensorMemoryLayoutAttr::get(context, conv2dConfigOverrideParams.shardLayout.value());
             } else {
-              // TODO: see default value
-              newShardLayout = TensorMemoryLayoutAttr::get(context, TensorMemoryLayout::Interleaved);
+              //newShardLayout = TensorMemoryLayoutAttr::get(context, TensorMemoryLayout::Interleaved);
+              newShardLayout = TensorMemoryLayoutAttr();
             }
             if(conv2dConfigOverrideParams.coreGrid.has_value()) {
               newCoreGrid = conv2dConfigOverrideParams.coreGrid.value();
             } else {
-              // TODO: see default value
-              // Why can't I access ::tt::tt_metal::CoreRangeSet?
-              newCoreGrid = 0;
+              newCoreGrid = Attribute();
             } 
             if(conv2dConfigOverrideParams.transposeShards.has_value()) {
               newTransposeShards = BoolAttr::get(context, conv2dConfigOverrideParams.transposeShards.value());

--- a/lib/Dialect/TTNN/Transforms/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/Optimizer.cpp
@@ -350,14 +350,15 @@ public:
         // Set Conv2d Config
         //
         StringRef opLocName = "";
-        if(isa<NameLoc>(op->getLoc())) {
+        if (isa<NameLoc>(op->getLoc())) {
           opLocName = mlir::cast<NameLoc>(op->getLoc()).getName();
         }
-        if(isa<ttnn::Conv2dOp>(op)) {
-          if(overrideConv2dConfig.contains(opLocName)) {
-            Conv2dConfigOverrideParams conv2dConfigOverrideParams = overrideConv2dConfig[opLocName];
+        if (isa<ttnn::Conv2dOp>(op)) {
+          if (overrideConv2dConfig.contains(opLocName)) {
+            Conv2dConfigOverrideParams conv2dConfigOverrideParams =
+                overrideConv2dConfig[opLocName];
             ttnn::Conv2dOp conv2dOp = mlir::cast<ttnn::Conv2dOp>(op);
-            MLIRContext* context = op->getContext();
+            MLIRContext *context = op->getContext();
             DataType newDtype;
             DataType newWeightsDtype;
             StringAttr newActivation;
@@ -370,111 +371,145 @@ public:
             BoolAttr newOverrideShardingConfig;
             ttnn::TensorMemoryLayoutAttr newShardLayout;
             Attribute newCoreGrid;
-            BoolAttr newTransposeShards;  
+            BoolAttr newTransposeShards;
             LayoutAttr newOutputLayout;
             BoolAttr newEnableActDoubleBuffer;
             BoolAttr newEnableWeightsDoubleBuffer;
             BoolAttr newEnableSplitReader;
             BoolAttr newEnableSubblockPadding;
-            if(conv2dConfigOverrideParams.dtype.has_value()) {
+            if (conv2dConfigOverrideParams.dtype.has_value()) {
               newDtype = conv2dConfigOverrideParams.dtype.value();
             } else {
-              newDtype = DataType::BFloat16; 
+              newDtype = DataType::BFloat16;
             }
-            if(conv2dConfigOverrideParams.weightsDtype.has_value()) {
+            if (conv2dConfigOverrideParams.weightsDtype.has_value()) {
               newWeightsDtype = conv2dConfigOverrideParams.weightsDtype.value();
             } else {
-              newWeightsDtype = DataType::BFloat16; 
-            } if(conv2dConfigOverrideParams.activation.has_value()) {
-              newActivation = StringAttr::get(context, conv2dConfigOverrideParams.activation.value());
+              newWeightsDtype = DataType::BFloat16;
+            }
+            if (conv2dConfigOverrideParams.activation.has_value()) {
+              newActivation = StringAttr::get(
+                  context, conv2dConfigOverrideParams.activation.value());
             } else {
               newActivation = StringAttr::get(context, "");
-            } 
-            if(conv2dConfigOverrideParams.inputChannelsAlignment.has_value()) {
-              uint32_t value = conv2dConfigOverrideParams.inputChannelsAlignment.value();
-              newInputChannelsAlignment = IntegerAttr::get(IntegerType::get(context, value),value);
-            } else {
-              newInputChannelsAlignment = IntegerAttr::get(IntegerType::get(context, 32), 32);
             }
-            if(conv2dConfigOverrideParams.deallocateActivation.has_value()) {
-              newDeallocateActivation = BoolAttr::get(context, conv2dConfigOverrideParams.deallocateActivation.value());
+            if (conv2dConfigOverrideParams.inputChannelsAlignment.has_value()) {
+              uint32_t value =
+                  conv2dConfigOverrideParams.inputChannelsAlignment.value();
+              newInputChannelsAlignment =
+                  IntegerAttr::get(IntegerType::get(context, value), value);
+            } else {
+              newInputChannelsAlignment =
+                  IntegerAttr::get(IntegerType::get(context, 32), 32);
+            }
+            if (conv2dConfigOverrideParams.deallocateActivation.has_value()) {
+              newDeallocateActivation = BoolAttr::get(
+                  context,
+                  conv2dConfigOverrideParams.deallocateActivation.value());
             } else {
               newDeallocateActivation = BoolAttr::get(context, false);
             }
-            if(conv2dConfigOverrideParams.reallocateHaloOutput.has_value()) {
-              newReallocateHaloOutput = BoolAttr::get(context, conv2dConfigOverrideParams.reallocateHaloOutput.value());
+            if (conv2dConfigOverrideParams.reallocateHaloOutput.has_value()) {
+              newReallocateHaloOutput = BoolAttr::get(
+                  context,
+                  conv2dConfigOverrideParams.reallocateHaloOutput.value());
             } else {
               newReallocateHaloOutput = BoolAttr::get(context, true);
             }
-            if(conv2dConfigOverrideParams.actBlockHOverride.has_value()) {
-              uint32_t value = conv2dConfigOverrideParams.actBlockHOverride.value();
-              newActBlockHOverride = IntegerAttr::get(IntegerType::get(context, value), value);
+            if (conv2dConfigOverrideParams.actBlockHOverride.has_value()) {
+              uint32_t value =
+                  conv2dConfigOverrideParams.actBlockHOverride.value();
+              newActBlockHOverride =
+                  IntegerAttr::get(IntegerType::get(context, value), value);
             } else {
-              newActBlockHOverride = IntegerAttr::get(IntegerType::get(context, 0), 0);
+              newActBlockHOverride =
+                  IntegerAttr::get(IntegerType::get(context, 0), 0);
             }
-            if(conv2dConfigOverrideParams.actBlockWDiv.has_value()) {
+            if (conv2dConfigOverrideParams.actBlockWDiv.has_value()) {
               uint32_t value = conv2dConfigOverrideParams.actBlockWDiv.value();
-              newActBlockWDiv = IntegerAttr::get(IntegerType::get(context, value), value);
+              newActBlockWDiv =
+                  IntegerAttr::get(IntegerType::get(context, value), value);
             } else {
-              newActBlockWDiv = IntegerAttr::get(IntegerType::get(context, 1), 1);
+              newActBlockWDiv =
+                  IntegerAttr::get(IntegerType::get(context, 1), 1);
             }
-            if(conv2dConfigOverrideParams.reshardIfNotOptimal.has_value()) {
-              newReshardIfNotOptimal = BoolAttr::get(context, conv2dConfigOverrideParams.reshardIfNotOptimal.value());
+            if (conv2dConfigOverrideParams.reshardIfNotOptimal.has_value()) {
+              newReshardIfNotOptimal = BoolAttr::get(
+                  context,
+                  conv2dConfigOverrideParams.reshardIfNotOptimal.value());
             } else {
               newReshardIfNotOptimal = BoolAttr::get(context, false);
             }
-            if(conv2dConfigOverrideParams.overrideShardingConfig.has_value()) {
-              newOverrideShardingConfig = BoolAttr::get(context, conv2dConfigOverrideParams.overrideShardingConfig.value());
+            if (conv2dConfigOverrideParams.overrideShardingConfig.has_value()) {
+              newOverrideShardingConfig = BoolAttr::get(
+                  context,
+                  conv2dConfigOverrideParams.overrideShardingConfig.value());
             } else {
               newOverrideShardingConfig = BoolAttr::get(context, false);
             }
-            if(conv2dConfigOverrideParams.shardLayout.has_value()) {
-              newShardLayout = TensorMemoryLayoutAttr::get(context, conv2dConfigOverrideParams.shardLayout.value());
+            if (conv2dConfigOverrideParams.shardLayout.has_value()) {
+              newShardLayout = TensorMemoryLayoutAttr::get(
+                  context, conv2dConfigOverrideParams.shardLayout.value());
             } else {
-              //newShardLayout = TensorMemoryLayoutAttr::get(context, TensorMemoryLayout::Interleaved);
+              // newShardLayout = TensorMemoryLayoutAttr::get(context,
+              // TensorMemoryLayout::Interleaved);
               newShardLayout = TensorMemoryLayoutAttr();
             }
-            if(conv2dConfigOverrideParams.coreGrid.has_value()) {
+            if (conv2dConfigOverrideParams.coreGrid.has_value()) {
               newCoreGrid = conv2dConfigOverrideParams.coreGrid.value();
             } else {
               newCoreGrid = Attribute();
-            } 
-            if(conv2dConfigOverrideParams.transposeShards.has_value()) {
-              newTransposeShards = BoolAttr::get(context, conv2dConfigOverrideParams.transposeShards.value());
+            }
+            if (conv2dConfigOverrideParams.transposeShards.has_value()) {
+              newTransposeShards = BoolAttr::get(
+                  context, conv2dConfigOverrideParams.transposeShards.value());
             } else {
               newTransposeShards = BoolAttr::get(context, false);
             }
-            if(conv2dConfigOverrideParams.outputLayout.has_value()) {
-              newOutputLayout = LayoutAttr::get(context, conv2dConfigOverrideParams.outputLayout.value());
+            if (conv2dConfigOverrideParams.outputLayout.has_value()) {
+              newOutputLayout = LayoutAttr::get(
+                  context, conv2dConfigOverrideParams.outputLayout.value());
             } else {
               newOutputLayout = LayoutAttr::get(context, Layout::Tile);
             }
-            if(conv2dConfigOverrideParams.enableActDoubleBuffer.has_value()) {
-              newEnableActDoubleBuffer = BoolAttr::get(context, conv2dConfigOverrideParams.enableActDoubleBuffer.value());
+            if (conv2dConfigOverrideParams.enableActDoubleBuffer.has_value()) {
+              newEnableActDoubleBuffer = BoolAttr::get(
+                  context,
+                  conv2dConfigOverrideParams.enableActDoubleBuffer.value());
             } else {
               newEnableActDoubleBuffer = BoolAttr::get(context, false);
             }
-            if(conv2dConfigOverrideParams.enableWeightsDoubleBuffer.has_value()) {
-              newEnableWeightsDoubleBuffer = BoolAttr::get(context, conv2dConfigOverrideParams.enableWeightsDoubleBuffer.value());
+            if (conv2dConfigOverrideParams.enableWeightsDoubleBuffer
+                    .has_value()) {
+              newEnableWeightsDoubleBuffer = BoolAttr::get(
+                  context,
+                  conv2dConfigOverrideParams.enableWeightsDoubleBuffer.value());
             } else {
               newEnableWeightsDoubleBuffer = BoolAttr::get(context, false);
             }
-            if(conv2dConfigOverrideParams.enableSplitReader.has_value()) {
-              newEnableSplitReader = BoolAttr::get(context, conv2dConfigOverrideParams.enableSplitReader.value());
+            if (conv2dConfigOverrideParams.enableSplitReader.has_value()) {
+              newEnableSplitReader = BoolAttr::get(
+                  context,
+                  conv2dConfigOverrideParams.enableSplitReader.value());
             } else {
               newEnableSplitReader = BoolAttr::get(context, false);
             }
-            if(conv2dConfigOverrideParams.enableSubblockPadding.has_value()) {
-              newEnableSubblockPadding = BoolAttr::get(context, conv2dConfigOverrideParams.enableSubblockPadding.value());
+            if (conv2dConfigOverrideParams.enableSubblockPadding.has_value()) {
+              newEnableSubblockPadding = BoolAttr::get(
+                  context,
+                  conv2dConfigOverrideParams.enableSubblockPadding.value());
             } else {
               newEnableSubblockPadding = BoolAttr::get(context, false);
             }
-            conv2dOp.setConv2dConfigAttr(Conv2dConfigAttr::get(context, newDtype, 
-              newWeightsDtype, newActivation, newInputChannelsAlignment, 
-              newDeallocateActivation, newReallocateHaloOutput, newActBlockHOverride, 
-              newActBlockWDiv, newReshardIfNotOptimal, newOverrideShardingConfig, 
-              newShardLayout, newCoreGrid, newTransposeShards, newOutputLayout.getValue(),
-              newEnableActDoubleBuffer, newEnableWeightsDoubleBuffer, newEnableSplitReader, newEnableSubblockPadding));
+            conv2dOp.setConv2dConfigAttr(Conv2dConfigAttr::get(
+                context, newDtype, newWeightsDtype, newActivation,
+                newInputChannelsAlignment, newDeallocateActivation,
+                newReallocateHaloOutput, newActBlockHOverride, newActBlockWDiv,
+                newReshardIfNotOptimal, newOverrideShardingConfig,
+                newShardLayout, newCoreGrid, newTransposeShards,
+                newOutputLayout.getValue(), newEnableActDoubleBuffer,
+                newEnableWeightsDoubleBuffer, newEnableSplitReader,
+                newEnableSubblockPadding));
           }
         }
       });

--- a/lib/Dialect/TTNN/Transforms/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/Optimizer.cpp
@@ -343,11 +343,13 @@ public:
 
           // Set specific Conv2d Op configuration.
           if (isa<ttnn::Conv2dOp>(op)) {
-            Attribute config = opConfigAnalysis.getResult().at(op).config;
-            if (isa<ttnn::Conv2dConfigAttr>(config)) {
-              ttnn::Conv2dOp conv2dOp = mlir::cast<ttnn::Conv2dOp>(op);
-              conv2dOp.setConv2dConfigAttr(
-                  mlir::cast<ttnn::Conv2dConfigAttr>(config));
+            if (opConfigAnalysis.getResult().at(op).config) {
+              Attribute config = opConfigAnalysis.getResult().at(op).config;
+              if (mlir::isa<ttnn::Conv2dConfigAttr>(config)) {
+                ttnn::Conv2dOp conv2dOp = mlir::cast<ttnn::Conv2dOp>(op);
+                conv2dOp.setConv2dConfigAttr(
+                    mlir::cast<ttnn::Conv2dConfigAttr>(config));
+              }
             }
           }
         }

--- a/lib/Dialect/TTNN/Transforms/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/Optimizer.cpp
@@ -15,13 +15,13 @@
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTNN/Utils/PassOverrides.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+#include "ttmlir/Utils.h"
 
 #include "mlir/Analysis/Liveness.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Value.h"
 #include "mlir/IR/Visitors.h"
-#include "ttmlir/Utils.h"
 
 namespace mlir::tt::ttnn {
 
@@ -342,15 +342,13 @@ public:
                 tensorMemoryLayoutAttr));
           }
 
-          // Set specific Conv2d Op configuration.
-          if (isa<ttnn::Conv2dOp>(op)) {
-            if (opConfigAnalysis.getResult().at(op).config) {
-              Attribute config = opConfigAnalysis.getResult().at(op).config;
-              if (isa<ttnn::Conv2dConfigAttr>(config)) {
-                ttnn::Conv2dOp conv2dOp = mlir::cast<ttnn::Conv2dOp>(op);
-                conv2dOp.setConv2dConfigAttr(
-                    mlir::cast<ttnn::Conv2dConfigAttr>(config));
-              }
+          // Set specific Conv2d Op configuration if it is exists.
+          //
+          if (auto conv2dOp = mlir::dyn_cast<ttnn::Conv2dOp>(op)) {
+            if (auto conv2dConfig =
+                    mlir::dyn_cast_if_present<ttnn::Conv2dConfigAttr>(
+                        opConfigAnalysis.getResult().at(op).config)) {
+              conv2dOp.setConv2dConfigAttr(conv2dConfig);
             }
           }
         }

--- a/lib/Dialect/TTNN/Transforms/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/Optimizer.cpp
@@ -21,6 +21,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Value.h"
 #include "mlir/IR/Visitors.h"
+#include <cstddef>
 #include <llvm/ADT/APInt.h>
 #include <llvm/Support/Casting.h>
 #include <mlir/IR/BuiltinAttributes.h>
@@ -354,102 +355,127 @@ public:
             Conv2dConfigOverrideParams conv2dConfigOverrideParams = overrideConv2dConfig[opLocName];
             ttnn::Conv2dOp conv2dOp = mlir::cast<ttnn::Conv2dOp>(op);
             MLIRContext* context = op->getContext();
+            DataType newDtype;
+            DataType newWeightsDtype;
+            StringAttr newActivation;
+            IntegerAttr newInputChannelsAlignment;
+            BoolAttr newDeallocateActivation;
+            BoolAttr newReallocateHaloOutput;
+            IntegerAttr newActBlockHOverride;
+            IntegerAttr newActBlockWDiv;
+            BoolAttr newReshardIfNotOptimal;
+            BoolAttr newOverrideShardingConfig;
+            ttnn::TensorMemoryLayoutAttr newShardLayout;
+            Attribute newCoreGrid;
+            BoolAttr newTransposeShards;  
+            // TODO: Change to 'Layout'
+            LayoutAttr newOutputLayout;
+            BoolAttr newEnableActDoubleBuffer;
+            BoolAttr newEnableWeightsDoubleBuffer;
+            BoolAttr newEnableSplitReader;
+            BoolAttr newEnableSubblockPadding;
+            //TODO: Keep Conv2dConfig values if present
             if(conv2dConfigOverrideParams.dtype.has_value()) {
-              DataType newDtype = conv2dConfigOverrideParams.dtype.value();
+              newDtype = conv2dConfigOverrideParams.dtype.value();
             } else {
-              DataType newDtype = DataType::BFloat16; 
+              newDtype = DataType::BFloat16; 
             }
             if(conv2dConfigOverrideParams.weightsDtype.has_value()) {
-              DataType newWeightsDtype = conv2dConfigOverrideParams.weightsDtype.value();
+              newWeightsDtype = conv2dConfigOverrideParams.weightsDtype.value();
             } else {
-              DataType newWeightsDtype = DataType::BFloat16; 
+              newWeightsDtype = DataType::BFloat16; 
             } if(conv2dConfigOverrideParams.activation.has_value()) {
-              StringAttr newActivation = StringAttr::get(context, conv2dConfigOverrideParams.activation.value());
+              newActivation = StringAttr::get(context, conv2dConfigOverrideParams.activation.value());
             } else {
-              StringAttr newActivation = StringAttr::get(context, "");
+              newActivation = StringAttr::get(context, "");
             } 
             if(conv2dConfigOverrideParams.inputChannelsAlignment.has_value()) {
               uint32_t value = conv2dConfigOverrideParams.inputChannelsAlignment.value();
-              IntegerAttr newInputChannelsAlignment = IntegerAttr::get(IntegerType::get(context, value),value);
+              newInputChannelsAlignment = IntegerAttr::get(IntegerType::get(context, value),value);
             } else {
-              IntegerType::get(context, 32);
-              IntegerAttr newInputChannelsAlignment = IntegerAttr::get(IntegerType::get(context, 32), 32);
+              newInputChannelsAlignment = IntegerAttr::get(IntegerType::get(context, 32), 32);
             }
             if(conv2dConfigOverrideParams.deallocateActivation.has_value()) {
-              BoolAttr newDeallocateActivation = BoolAttr::get(context, conv2dConfigOverrideParams.deallocateActivation.value());
+              newDeallocateActivation = BoolAttr::get(context, conv2dConfigOverrideParams.deallocateActivation.value());
             } else {
-              BoolAttr newDeallocateActivation = BoolAttr::get(context, false);
+              newDeallocateActivation = BoolAttr::get(context, false);
             }
             if(conv2dConfigOverrideParams.reallocateHaloOutput.has_value()) {
-              BoolAttr newReallocateHaloOutput = BoolAttr::get(context, conv2dConfigOverrideParams.reallocateHaloOutput.value());
+              newReallocateHaloOutput = BoolAttr::get(context, conv2dConfigOverrideParams.reallocateHaloOutput.value());
             } else {
-              BoolAttr newReallocateHaloOutput = BoolAttr::get(context, true);
+              newReallocateHaloOutput = BoolAttr::get(context, true);
             }
             if(conv2dConfigOverrideParams.actBlockHOverride.has_value()) {
               uint32_t value = conv2dConfigOverrideParams.actBlockHOverride.value();
-              IntegerAttr newActBlockHOverride = IntegerAttr::get(IntegerType::get(context, value), value);
+              newActBlockHOverride = IntegerAttr::get(IntegerType::get(context, value), value);
             } else {
-              IntegerAttr newActBlockHOverride = IntegerAttr::get(IntegerType::get(context, 0), 0);
+              newActBlockHOverride = IntegerAttr::get(IntegerType::get(context, 0), 0);
             }
             if(conv2dConfigOverrideParams.actBlockWDiv.has_value()) {
               uint32_t value = conv2dConfigOverrideParams.actBlockWDiv.value();
-              IntegerAttr newActBlockWDiv = IntegerAttr::get(IntegerType::get(context, value), value);
+              newActBlockWDiv = IntegerAttr::get(IntegerType::get(context, value), value);
             } else {
-              IntegerAttr newActBlockWDiv = IntegerAttr::get(IntegerType::get(context, 1), 1);
+              newActBlockWDiv = IntegerAttr::get(IntegerType::get(context, 1), 1);
             }
             if(conv2dConfigOverrideParams.reshardIfNotOptimal.has_value()) {
-              BoolAttr newReshardIfNotOptimal = BoolAttr::get(context, conv2dConfigOverrideParams.reshardIfNotOptimal.value());
+              newReshardIfNotOptimal = BoolAttr::get(context, conv2dConfigOverrideParams.reshardIfNotOptimal.value());
             } else {
-              BoolAttr newReshardIfNotOptimal = BoolAttr::get(context, false);
+              newReshardIfNotOptimal = BoolAttr::get(context, false);
             }
             if(conv2dConfigOverrideParams.overrideShardingConfig.has_value()) {
-              BoolAttr newOverrideShardingConfig = BoolAttr::get(context, conv2dConfigOverrideParams.overrideShardingConfig.value());
+              newOverrideShardingConfig = BoolAttr::get(context, conv2dConfigOverrideParams.overrideShardingConfig.value());
             } else {
-              BoolAttr newOverrideShardingConfig = BoolAttr::get(context, false);
+              newOverrideShardingConfig = BoolAttr::get(context, false);
             }
-            // TODO
-            // if(conv2dConfigOverrideParams.shardLayout.has_value()) {
-            //  ttnn::TensorMemoryLayoutAttr newShardLayout = TensorMemoryLayoutAttr::get(context, conv2dConfigOverrideParams.shardLayout.value());
-            // } 
-            // if(conv2dConfigOverrideParams.coreGrid.has_value()) {
-            //  Attribute newCoreGrid = conv2dConfigOverrideParams.coreGrid.value();
-            //} 
-            if(conv2dConfigOverrideParams.transposeShards.has_value()) {
-              BoolAttr newTransposeShards = BoolAttr::get(context, conv2dConfigOverrideParams.transposeShards.value());
+            if(conv2dConfigOverrideParams.shardLayout.has_value()) {
+              newShardLayout = TensorMemoryLayoutAttr::get(context, conv2dConfigOverrideParams.shardLayout.value());
             } else {
-              BoolAttr newTransposeShards = BoolAttr::get(context, false);
+              // TODO: see default value
+              newShardLayout = TensorMemoryLayoutAttr::get(context, TensorMemoryLayout::Interleaved);
+            }
+            if(conv2dConfigOverrideParams.coreGrid.has_value()) {
+              newCoreGrid = conv2dConfigOverrideParams.coreGrid.value();
+            } else {
+              // TODO: see default value
+              // Why can't I access ::tt::tt_metal::CoreRangeSet?
+              newCoreGrid = 0;
+            } 
+            if(conv2dConfigOverrideParams.transposeShards.has_value()) {
+              newTransposeShards = BoolAttr::get(context, conv2dConfigOverrideParams.transposeShards.value());
+            } else {
+              newTransposeShards = BoolAttr::get(context, false);
             }
             if(conv2dConfigOverrideParams.outputLayout.has_value()) {
-              LayoutAttr newOutputLayout = LayoutAttr::get(context, conv2dConfigOverrideParams.outputLayout.value());
+              newOutputLayout = LayoutAttr::get(context, conv2dConfigOverrideParams.outputLayout.value());
             } else {
-              LayoutAttr newOutputLayout = LayoutAttr::get(context, Layout::Tile);
+              newOutputLayout = LayoutAttr::get(context, Layout::Tile);
             }
             if(conv2dConfigOverrideParams.enableActDoubleBuffer.has_value()) {
-              BoolAttr newEnableActDoubleBuffer = BoolAttr::get(context, conv2dConfigOverrideParams.enableActDoubleBuffer.value());
+              newEnableActDoubleBuffer = BoolAttr::get(context, conv2dConfigOverrideParams.enableActDoubleBuffer.value());
             } else {
-              BoolAttr newEnableActDoubleBuffer = BoolAttr::get(context, false);
+              newEnableActDoubleBuffer = BoolAttr::get(context, false);
             }
             if(conv2dConfigOverrideParams.enableWeightsDoubleBuffer.has_value()) {
-              BoolAttr newEnableWeightsDoubleBuffer = BoolAttr::get(context, conv2dConfigOverrideParams.enableWeightsDoubleBuffer.value());
+              newEnableWeightsDoubleBuffer = BoolAttr::get(context, conv2dConfigOverrideParams.enableWeightsDoubleBuffer.value());
             } else {
-              BoolAttr newEnableWeightsDoubleBuffer = BoolAttr::get(context, false);
+              newEnableWeightsDoubleBuffer = BoolAttr::get(context, false);
             }
             if(conv2dConfigOverrideParams.enableSplitReader.has_value()) {
-              BoolAttr newEnableSplitReader = BoolAttr::get(context, conv2dConfigOverrideParams.enableSplitReader.value());
+              newEnableSplitReader = BoolAttr::get(context, conv2dConfigOverrideParams.enableSplitReader.value());
             } else {
-              BoolAttr newEnableSplitReader = BoolAttr::get(context, false);
+              newEnableSplitReader = BoolAttr::get(context, false);
             }
             if(conv2dConfigOverrideParams.enableSubblockPadding.has_value()) {
-              BoolAttr newEnableSubblockPadding = BoolAttr::get(context, conv2dConfigOverrideParams.enableSubblockPadding.value());
+              newEnableSubblockPadding = BoolAttr::get(context, conv2dConfigOverrideParams.enableSubblockPadding.value());
             } else {
-              BoolAttr newEnableSubblockPadding = BoolAttr::get(context, false);
+              newEnableSubblockPadding = BoolAttr::get(context, false);
             }
             conv2dOp.setConv2dConfigAttr(Conv2dConfigAttr::get(context, newDtype, 
               newWeightsDtype, newActivation, newInputChannelsAlignment, 
               newDeallocateActivation, newReallocateHaloOutput, newActBlockHOverride, 
               newActBlockWDiv, newReshardIfNotOptimal, newOverrideShardingConfig, 
-              newTransposeShards, newOutputLayout, newEnableActDoubleBuffer, 
-              newEnableWeightsDoubleBuffer, newEnableSplitReader, newEnableSubblockPadding));
+              newShardLayout, newCoreGrid, newTransposeShards, newOutputLayout.getValue(),
+              newEnableActDoubleBuffer, newEnableWeightsDoubleBuffer, newEnableSplitReader, newEnableSubblockPadding));
           }
         }
       });

--- a/lib/Dialect/TTNN/Transforms/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/Optimizer.cpp
@@ -3,12 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Dialect/TT/IR/Utils.h"
+#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
 #include "ttmlir/Dialect/TTNN/Analysis/Edge.h"
 #include "ttmlir/Dialect/TTNN/Analysis/LegalLayoutAnalysis.h"
 #include "ttmlir/Dialect/TTNN/Analysis/MemoryLayoutAnalysis.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpConfigAnalysis.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsTypes.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTNN/Utils/PassOverrides.h"
@@ -19,6 +21,11 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Value.h"
 #include "mlir/IR/Visitors.h"
+#include <llvm/ADT/APInt.h>
+#include <llvm/Support/Casting.h>
+#include <mlir/IR/BuiltinAttributes.h>
+#include <mlir/IR/BuiltinTypes.h>
+#include <mlir/IR/MLIRContext.h>
 
 namespace mlir::tt::ttnn {
 
@@ -339,6 +346,112 @@ public:
                 tensorMemoryLayoutAttr));
           }
         }
+        // Set Conv2d Config
+        //
+        StringRef opLocName = mlir::cast<NameLoc>(op->getLoc()).getName();
+        if(isa<ttnn::Conv2dOp>(op)) {
+          if(overrideConv2dConfig.contains(opLocName)) {
+            Conv2dConfigOverrideParams conv2dConfigOverrideParams = overrideConv2dConfig[opLocName];
+            ttnn::Conv2dOp conv2dOp = mlir::cast<ttnn::Conv2dOp>(op);
+            MLIRContext* context = op->getContext();
+            if(conv2dConfigOverrideParams.dtype.has_value()) {
+              DataType newDtype = conv2dConfigOverrideParams.dtype.value();
+            } else {
+              DataType newDtype = DataType::BFloat16; 
+            }
+            if(conv2dConfigOverrideParams.weightsDtype.has_value()) {
+              DataType newWeightsDtype = conv2dConfigOverrideParams.weightsDtype.value();
+            } else {
+              DataType newWeightsDtype = DataType::BFloat16; 
+            } if(conv2dConfigOverrideParams.activation.has_value()) {
+              StringAttr newActivation = StringAttr::get(context, conv2dConfigOverrideParams.activation.value());
+            } else {
+              StringAttr newActivation = StringAttr::get(context, "");
+            } 
+            if(conv2dConfigOverrideParams.inputChannelsAlignment.has_value()) {
+              uint32_t value = conv2dConfigOverrideParams.inputChannelsAlignment.value();
+              IntegerAttr newInputChannelsAlignment = IntegerAttr::get(IntegerType::get(context, value),value);
+            } else {
+              IntegerType::get(context, 32);
+              IntegerAttr newInputChannelsAlignment = IntegerAttr::get(IntegerType::get(context, 32), 32);
+            }
+            if(conv2dConfigOverrideParams.deallocateActivation.has_value()) {
+              BoolAttr newDeallocateActivation = BoolAttr::get(context, conv2dConfigOverrideParams.deallocateActivation.value());
+            } else {
+              BoolAttr newDeallocateActivation = BoolAttr::get(context, false);
+            }
+            if(conv2dConfigOverrideParams.reallocateHaloOutput.has_value()) {
+              BoolAttr newReallocateHaloOutput = BoolAttr::get(context, conv2dConfigOverrideParams.reallocateHaloOutput.value());
+            } else {
+              BoolAttr newReallocateHaloOutput = BoolAttr::get(context, true);
+            }
+            if(conv2dConfigOverrideParams.actBlockHOverride.has_value()) {
+              uint32_t value = conv2dConfigOverrideParams.actBlockHOverride.value();
+              IntegerAttr newActBlockHOverride = IntegerAttr::get(IntegerType::get(context, value), value);
+            } else {
+              IntegerAttr newActBlockHOverride = IntegerAttr::get(IntegerType::get(context, 0), 0);
+            }
+            if(conv2dConfigOverrideParams.actBlockWDiv.has_value()) {
+              uint32_t value = conv2dConfigOverrideParams.actBlockWDiv.value();
+              IntegerAttr newActBlockWDiv = IntegerAttr::get(IntegerType::get(context, value), value);
+            } else {
+              IntegerAttr newActBlockWDiv = IntegerAttr::get(IntegerType::get(context, 1), 1);
+            }
+            if(conv2dConfigOverrideParams.reshardIfNotOptimal.has_value()) {
+              BoolAttr newReshardIfNotOptimal = BoolAttr::get(context, conv2dConfigOverrideParams.reshardIfNotOptimal.value());
+            } else {
+              BoolAttr newReshardIfNotOptimal = BoolAttr::get(context, false);
+            }
+            if(conv2dConfigOverrideParams.overrideShardingConfig.has_value()) {
+              BoolAttr newOverrideShardingConfig = BoolAttr::get(context, conv2dConfigOverrideParams.overrideShardingConfig.value());
+            } else {
+              BoolAttr newOverrideShardingConfig = BoolAttr::get(context, false);
+            }
+            // TODO
+            // if(conv2dConfigOverrideParams.shardLayout.has_value()) {
+            //  ttnn::TensorMemoryLayoutAttr newShardLayout = TensorMemoryLayoutAttr::get(context, conv2dConfigOverrideParams.shardLayout.value());
+            // } 
+            // if(conv2dConfigOverrideParams.coreGrid.has_value()) {
+            //  Attribute newCoreGrid = conv2dConfigOverrideParams.coreGrid.value();
+            //} 
+            if(conv2dConfigOverrideParams.transposeShards.has_value()) {
+              BoolAttr newTransposeShards = BoolAttr::get(context, conv2dConfigOverrideParams.transposeShards.value());
+            } else {
+              BoolAttr newTransposeShards = BoolAttr::get(context, false);
+            }
+            if(conv2dConfigOverrideParams.outputLayout.has_value()) {
+              LayoutAttr newOutputLayout = LayoutAttr::get(context, conv2dConfigOverrideParams.outputLayout.value());
+            } else {
+              LayoutAttr newOutputLayout = LayoutAttr::get(context, Layout::Tile);
+            }
+            if(conv2dConfigOverrideParams.enableActDoubleBuffer.has_value()) {
+              BoolAttr newEnableActDoubleBuffer = BoolAttr::get(context, conv2dConfigOverrideParams.enableActDoubleBuffer.value());
+            } else {
+              BoolAttr newEnableActDoubleBuffer = BoolAttr::get(context, false);
+            }
+            if(conv2dConfigOverrideParams.enableWeightsDoubleBuffer.has_value()) {
+              BoolAttr newEnableWeightsDoubleBuffer = BoolAttr::get(context, conv2dConfigOverrideParams.enableWeightsDoubleBuffer.value());
+            } else {
+              BoolAttr newEnableWeightsDoubleBuffer = BoolAttr::get(context, false);
+            }
+            if(conv2dConfigOverrideParams.enableSplitReader.has_value()) {
+              BoolAttr newEnableSplitReader = BoolAttr::get(context, conv2dConfigOverrideParams.enableSplitReader.value());
+            } else {
+              BoolAttr newEnableSplitReader = BoolAttr::get(context, false);
+            }
+            if(conv2dConfigOverrideParams.enableSubblockPadding.has_value()) {
+              BoolAttr newEnableSubblockPadding = BoolAttr::get(context, conv2dConfigOverrideParams.enableSubblockPadding.value());
+            } else {
+              BoolAttr newEnableSubblockPadding = BoolAttr::get(context, false);
+            }
+            conv2dOp.setConv2dConfigAttr(Conv2dConfigAttr::get(context, newDtype, 
+              newWeightsDtype, newActivation, newInputChannelsAlignment, 
+              newDeallocateActivation, newReallocateHaloOutput, newActBlockHOverride, 
+              newActBlockWDiv, newReshardIfNotOptimal, newOverrideShardingConfig, 
+              newTransposeShards, newOutputLayout, newEnableActDoubleBuffer, 
+              newEnableWeightsDoubleBuffer, newEnableSplitReader, newEnableSubblockPadding));
+          }
+        }
       });
 
       if (memReconfigEnabled) {
@@ -366,6 +479,9 @@ private:
       overridenOpExists[override.first()] = false;
     }
     for (auto &override : overrideInputLayout) {
+      overridenOpExists[override.first()] = false;
+    }
+    for (auto &override : overrideConv2dConfig) {
       overridenOpExists[override.first()] = false;
     }
 

--- a/lib/Dialect/TTNN/Transforms/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/Optimizer.cpp
@@ -11,6 +11,7 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsTypes.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
+#include "ttmlir/Dialect/TTNN/Utils/PassOverrides.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 
 #include "mlir/Analysis/Liveness.h"
@@ -81,6 +82,7 @@ public:
   TTNNOptimizerBase(TTNNOptimizerOptions options) : TTNNOptimizerBase() {
     overrideInputLayout = std::move(options.overrideInputLayout);
     overrideOutputLayout = std::move(options.overrideOutputLayout);
+    overrideConv2dConfig = std::move(options.overrideConv2dConfig);
     memoryLayoutAnalysisEnabled =
         std::move(options.memoryLayoutAnalysisEnabled);
     memReconfigEnabled = std::move(options.memReconfigEnabled);
@@ -103,6 +105,12 @@ protected:
           *this, "override-output-layout",
           ::llvm::cl::desc("Override output tensor layout for specific ops."),
           ::llvm::cl::init(llvm::StringMap<OutputLayoutOverrideParams>())};
+  ::mlir::Pass::Option<llvm::StringMap<Conv2dConfigOverrideParams>,
+                       mlir::tt::ttnn::Conv2dConfigOverrideParser>
+      overrideConv2dConfig{
+          *this, "override-conv2d-config",
+          ::llvm::cl::desc("Override Conv2d configuration for specific ops."),
+          ::llvm::cl::init(llvm::StringMap<Conv2dConfigOverrideParams>())};
   ::mlir::Pass::Option<bool> memoryLayoutAnalysisEnabled{
       *this, "memory-layout-analysis-enabled",
       ::llvm::cl::desc("Enable memory layout optimization."),

--- a/lib/Dialect/TTNN/Transforms/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/Optimizer.cpp
@@ -400,13 +400,10 @@ private:
       if (overridenOpExists.contains(opLocName)) {
         overridenOpExists[opLocName] = true;
       }
-      if (!isa<ttnn::Conv2dOp>(op)) {
-        if (overrideConv2dOp.contains(opLocName)) {
-          llvm::errs() << "Trying to override conv2d config on non-conv2d op: "
-                       << op->getName() << "\n";
-          assert(false &&
-                 "Trying to override conv2d config on non-conv2d op: ");
-        }
+      if (!isa<ttnn::Conv2dOp>(op) && overrideConv2dOp.contains(opLocName)) {
+        llvm::errs() << "Trying to override conv2d config on non-conv2d op: "
+                     << op->getName() << "\n";
+        assert(false && "Trying to override conv2d config on non-conv2d op: ");
       }
     });
 

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkarounds.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkarounds.cpp
@@ -62,7 +62,7 @@ static void revertOutputLayout(wa::TTNNWorkaroundInterface &op,
       workaroundResults.tensorLayoutResult.previousValue,
       workaroundResults.tensorBufferTypeResult.previousValue,
       workaroundResults.tensorMemoryLayoutResult.previousValue,
-      workaroundResults.tensorDataTypeResult.previousValue);
+      workaroundResults.tensorDataTypeResult.previousValue, "_workaround");
 
   // Replace the new output result with the casted output result.
   rewriter.replaceUsesWithIf(
@@ -100,7 +100,7 @@ static bool workaroundInputOperand(
       inputWorkaroundResults.tensorLayoutResult.targetValue,
       inputWorkaroundResults.tensorBufferTypeResult.targetValue,
       inputWorkaroundResults.tensorMemoryLayoutResult.targetValue,
-      inputWorkaroundResults.tensorDataTypeResult.targetValue);
+      inputWorkaroundResults.tensorDataTypeResult.targetValue, "_workaround");
 
   // Insert to layout op between the current op and the input operand
   // to convert the input operand to the desired tensor layout, buffer type.

--- a/lib/Dialect/TTNN/Utils/PassOverrides.cpp
+++ b/lib/Dialect/TTNN/Utils/PassOverrides.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Dialect/TTNN/Utils/PassOverrides.h"
+#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
+#include <llvm/ADT/SmallVector.h>
+#include <mlir/Support/LLVM.h>
 #include <numeric>
 
 namespace mlir::tt::ttnn {
@@ -24,6 +27,352 @@ parseGrid(StringRef param, char gridSeparator, llvm::cl::Option &opt) {
   return std::nullopt;
 }
 } // namespace
+
+// ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true override-output-layout=add_0=1x1,add_1=l1,add_2=block_sharded,add_3=bf16,add_4=l1:interleaved,add_5=width_sharded:tile,add_6=4x4:dram:interleaved:row_major:bf16,add_7=4x4:l1:interleaved:tile:f32"
+// override-conv2d-config=op_0=dtype#bf16:weights_dtype#bf16:activation#relu:input_channels_alignment#8:deallocate_activation#true:reallocate_halo_output#true:act_block_h_override#4:act_block_w_div#4:reshard_if_not_optimal#true:override_sharding_config#true:shard_layout#interleaved:core_grid#4x4:transpose_shards#true:output_layout#row_major:enable_act_double_buffer#true:enable_weights_double_buffer#true:enable_split_reader#true
+bool Conv2dConfigOverrideParser::parse(
+    llvm::cl::Option &opt, StringRef argName, StringRef arg, 
+    llvm::StringMap<Conv2dConfigOverrideParams> &value) {
+  SmallVector<StringRef> opOverrideList;
+  constexpr size_t kvPairSize = 2;
+  constexpr size_t iOpName = 0;
+  constexpr size_t iConv2dConfigOverrideParams = 1;
+  constexpr size_t iConv2dConfigParamName = 0;
+  constexpr size_t iConv2dConfigParamValue = 1;
+  constexpr char opSeparator = ',';
+  constexpr char opNameSeparator = '=';
+  constexpr char paramSeparator = ':';
+  constexpr char paramKVSeparator = '#';
+
+  arg.split(opOverrideList, opSeparator);
+  for(const StringRef override : opOverrideList) {
+    SmallVector<StringRef, kvPairSize> opOverrideParts;
+    override.split(opOverrideParts, opNameSeparator);
+    if(opOverrideParts.size() != kvPairSize) {
+      //                                         Why grid??
+      opt.error("Invalid format for override grid sizes: " + override);
+      return true;  
+    }
+
+    SmallVector<StringRef> conv2dParamParts;
+    opOverrideParts[iConv2dConfigOverrideParams].split(conv2dParamParts,
+                                                 paramSeparator);
+
+    Conv2dConfigOverrideParams params;
+
+    for(const StringRef &param : conv2dParamParts) {
+      SmallVector<StringRef> param_kv;
+      param.split(param_kv, paramKVSeparator);
+      StringRef param_name = param_kv[iConv2dConfigParamName];
+      StringRef param_value = param_kv[iConv2dConfigParamValue];
+
+      if(param_name == "dtype") {
+        auto dtype = mlir::tt::DataTypeStringToEnum(param_value);
+        if (!dtype) {
+          opt.error("Invalid dtype: " + param_value);
+          return true;
+        } 
+        if(params.dtype.has_value()) {
+            opt.error("Duplicate dtype: " + param_value);
+            return true;
+        }
+        params.dtype = dtype;
+      } 
+      else if(param_name == "weights_dtype") {
+        auto weightsDtype = mlir::tt::DataTypeStringToEnum(param_value);
+        if (!weightsDtype) {
+          opt.error("Invalid weights_dtype: " + param_value);
+          return true;
+        } 
+        if(params.weightsDtype.has_value()) {
+            opt.error("Duplicate weights_dtype: " + param_value);
+            return true;
+        }
+        params.weightsDtype = weightsDtype;
+      }
+      //TODO: Check activation type. When to use StringRef and StringAttr.
+      else if(param_name == "activation") {
+        auto activation = param_value;
+        if(activation.empty()) {
+          opt.error("Invalid activation: " + param_value);
+          return true;
+        }
+        if (!activation.equals_insensitive(StringRef("relu")) &&
+              !activation.equals_insensitive(("none"))) {
+          opt.error("Invalid activation: " + param_value);
+          return true;
+        } 
+        if(params.activation.has_value()) {
+            opt.error("Duplicate activation: " + param_value);
+            return true;
+        }
+        params.activation = std::optional<std::string>(activation.str());
+      }
+      else if(param_name == "input_channels_alignment") {
+        uint32_t inputChannelsAlignment; 
+        if(!param_value.getAsInteger<uint32_t>(10, inputChannelsAlignment)) {
+          opt.error("Invalid input_channels_alignment: " + param_value);
+          return true;
+        }
+        if(params.inputChannelsAlignment.has_value()) {
+          opt.error("Duplicate input_channels_alignment: " + param_value);
+          return true;
+        }
+        params.inputChannelsAlignment = inputChannelsAlignment;
+      }  
+      //TODO: 1/0 or true/false for attribute value?
+      else if(param_name == "deallocate_activation") {
+        bool deallocateActivation;
+        // Is it safe (getAsInteger<bool>) ?
+        if(!param_value.getAsInteger<bool>(10, deallocateActivation)) {
+          opt.error("Invalid deallocate_activation: " + param_value);
+          return true;
+        }
+        if(params.deallocateActivation.has_value()) {
+          opt.error("Duplicate deallocate_activation: " + param_value);
+          return true;
+        }
+        params.deallocateActivation = deallocateActivation;
+      }
+      else if(param_name == "reallocate_halo_output") {
+        bool reallocateHaloOutput;
+        if(!param_value.getAsInteger<bool>(10, reallocateHaloOutput)) {
+          opt.error("Invalid reallocateHaloOutput: " + param_value);
+          return true;
+        }
+        if(params.reallocateHaloOutput.has_value()) {
+          opt.error("Duplicate reallocateHaloOutput: " + param_value);
+          return true;
+        }
+        params.reallocateHaloOutput = reallocateHaloOutput;
+      }
+      else if(param_name == "act_block_h_override") {
+        uint32_t actBlockHOverride;
+        if(!param_value.getAsInteger<uint32_t>(10, actBlockHOverride)) {
+          opt.error("Invalid actBlockHOverride: " + param_value);
+          return true;
+        }
+        if(params.actBlockHOverride.has_value()) {
+          opt.error("Duplicate actBlockHOverride: " + param_value);
+          return true;
+        }
+        params.actBlockHOverride = actBlockHOverride;
+      }
+      else if(param_name == "act_block_w_div") {
+        uint32_t actBlockWDiv;
+        if(!param_value.getAsInteger<uint32_t>(10, actBlockWDiv)) {
+          opt.error("Invalid actBlockWDiv: " + param_value);
+          return true;
+        }
+        if(params.actBlockWDiv.has_value()) {
+          opt.error("Duplicate actBlockWDiv: " + param_value);
+          return true;
+        }
+        params.actBlockWDiv = actBlockWDiv;
+      }
+      else if(param_name == "reshard_if_not_optimal") {
+        bool reshardIfNotOptimal;
+        if(!param_value.getAsInteger<bool>(10, reshardIfNotOptimal)) {
+          opt.error("Invalid reshardIfNotOptimal: " + param_value);
+          return true;
+        }
+        if(params.reshardIfNotOptimal.has_value()) {
+          opt.error("Duplicate reshardIfNotOptimal: " + param_value);
+          return true;
+        }
+        params.reshardIfNotOptimal = reshardIfNotOptimal;
+      }
+      else if(param_name == "override_sharding_config") {
+        bool overrideShardingConfig;
+        if(!param_value.getAsInteger<bool>(10, overrideShardingConfig)) {
+          opt.error("Invalid overrideShardingConfig: " + param_value);
+          return true;
+        }
+        if(params.overrideShardingConfig.has_value()) {
+          opt.error("Duplicate overrideShardingConfig: " + param_value);
+          return true;
+        }
+        params.overrideShardingConfig = overrideShardingConfig;
+      }
+      else if(param_name == "shard_layout") {
+        auto shardLayout = symbolizeTensorMemoryLayout(param_value);
+        if (!shardLayout) {
+          opt.error("Invalid shardLayout: " + param_value);
+          return true;
+        } 
+        if(params.shardLayout.has_value()) {
+            opt.error("Duplicate shardLayout: " + param_value);
+            return true;
+        }
+        params.shardLayout = shardLayout;
+      }
+      //TODO: Check coreGrid
+      else if(param_name == "coreGrid") 
+        continue;
+      else if(param_name == "transpose_shards") {
+        bool transposeShards;
+        if(!param_value.getAsInteger<bool>(10, transposeShards)) {
+          opt.error("Invalid transposeShards: " + param_value);
+          return true;
+        }
+        if(params.transposeShards.has_value()) {
+          opt.error("Duplicate transposeShards: " + param_value);
+          return true;
+        }
+        params.transposeShards = transposeShards;
+      }
+      else if(param_name == "output_layout") {
+        auto outputLayout = symbolizeLayout(param_value);
+        if (!outputLayout) {
+          opt.error("Invalid outputLayout: " + param_value);
+          return true;
+        } 
+        if(params.outputLayout.has_value()) {
+            opt.error("Duplicate outputLayout: " + param_value);
+            return true;
+        }
+        params.outputLayout = outputLayout;
+      }
+      else if(param_name == "enable_act_double_buffer") {
+        bool enableActDoubleBuffer;
+        if(!param_value.getAsInteger<bool>(10, enableActDoubleBuffer)) {
+          opt.error("Invalid enableActDoubleBuffer: " + param_value);
+          return true;
+        }
+        if(params.enableActDoubleBuffer.has_value()) {
+          opt.error("Duplicate enableActDoubleBuffer: " + param_value);
+          return true;
+        }
+        params.enableActDoubleBuffer = enableActDoubleBuffer;
+      }
+      else if(param_name == "enable_weights_double_buffer") {
+        bool enableWeightsDoubleBuffer;
+        if(!param_value.getAsInteger<bool>(10, enableWeightsDoubleBuffer)) {
+          opt.error("Invalid enableWeightsDoubleBuffer: " + param_value);
+          return true;
+        }
+        if(params.enableWeightsDoubleBuffer.has_value()) {
+          opt.error("Duplicate enableWeightsDoubleBuffer: " + param_value);
+          return true;
+        }
+        params.enableWeightsDoubleBuffer = enableWeightsDoubleBuffer;
+      }
+      else if(param_name == "enable_split_reader") {
+        bool enableSplitReader;
+        if(!param_value.getAsInteger<bool>(10, enableSplitReader)) {
+          opt.error("Invalid enableSplitReader: " + param_value);
+          return true;
+        }
+        if(params.enableSplitReader.has_value()) {
+          opt.error("Duplicate enableSplitReader: " + param_value);
+          return true;
+        }
+        params.enableSplitReader = enableSplitReader;
+      }
+      else if(param_name == "enable_subblock_padding") {
+        bool enableSubblockPadding;
+        if(!param_value.getAsInteger<bool>(10, enableSubblockPadding)) {
+          opt.error("Invalid enableSubblockPadding: " + param_value);
+          return true;
+        }
+        if(params.enableSubblockPadding.has_value()) {
+          opt.error("Duplicate enableSubblockPadding: " + param_value);
+          return true;
+        }
+        params.enableSubblockPadding = enableSubblockPadding;
+      }
+      else {
+        opt.error("Invalid Conv2dConfig parameter: " + param);
+        return true;
+      }
+    }
+
+    value[opOverrideParts[iOpName]] = params;
+  }
+  return false;
+}
+
+std::string Conv2dConfigOverrideParser::toString(
+    const llvm::StringMap<Conv2dConfigOverrideParams> &value) {
+  std::string res;
+  size_t count = 0;
+  for (const auto &entry : value) {
+    res += std::string(entry.getKey()) + "=";
+    const Conv2dConfigOverrideParams &params = entry.getValue();
+
+    std::vector<std::string> parts;
+
+    if(params.dtype.has_value()) {
+      parts.push_back("dtype#" + DataTypeEnumToString(params.dtype.value()).str());
+    }
+    if(params.weightsDtype.has_value()) {
+      parts.push_back("weights_dtype#" + DataTypeEnumToString(params.weightsDtype.value()).str());
+    }
+    if(params.activation.has_value()) {
+      parts.push_back("activation#" + params.activation.value());
+    }
+    if(params.inputChannelsAlignment.has_value()) {
+      parts.push_back("input_channels_alignment#" + std::to_string(params.inputChannelsAlignment.value()));
+    }
+    if(params.deallocateActivation.has_value()) {
+      parts.push_back("deallocate_activation#" + std::to_string(params.deallocateActivation.value()));
+    }
+    if(params.reallocateHaloOutput.has_value()) {
+      parts.push_back("reallocate_halo_output#" + std::to_string(params.reallocateHaloOutput.value()));
+    }
+    if(params.actBlockHOverride.has_value()) {
+      parts.push_back("act_block_h_override#" + std::to_string(params.actBlockHOverride.value()));
+    }
+    if(params.actBlockWDiv.has_value()) {
+      parts.push_back("act_block_w_div#" + std::to_string(params.actBlockWDiv.value()));
+    }
+    if(params.reshardIfNotOptimal.has_value()) {
+      parts.push_back("reshard_if_not_optimal#" + std::to_string(params.reshardIfNotOptimal.value()));
+    }
+    if(params.overrideShardingConfig.has_value()) {
+      parts.push_back("override_sharding_config#" + std::to_string(params.overrideShardingConfig.value()));
+    }
+    if(params.shardLayout.has_value()) {
+      parts.push_back("shard_layout#" + stringifyTensorMemoryLayout(params.shardLayout.value()).str());
+    }
+    if(params.transposeShards.has_value()) {
+      parts.push_back("transpose_shards#" + std::to_string(params.transposeShards.value()));
+    }
+    if(params.outputLayout.has_value()) {
+      parts.push_back("output_layout#" + stringifyLayout(params.outputLayout.value()).str());
+    }
+    if(params.enableActDoubleBuffer.has_value()) {
+      parts.push_back("enable_act_double_buffer#" + std::to_string(params.enableActDoubleBuffer.value()));
+    }
+    if(params.enableWeightsDoubleBuffer.has_value()) {
+      parts.push_back("enable_weights_double_buffer#" + std::to_string(params.enableWeightsDoubleBuffer.value()));
+    }
+    if(params.enableSplitReader.has_value()) {
+      parts.push_back("enable_split_reader#" + std::to_string(params.enableSplitReader.value()));
+    }
+    if(params.enableSubblockPadding.has_value()) {
+      parts.push_back("enable_subblock_padding#" + std::to_string(params.enableSubblockPadding.value()));
+    }
+
+    res += std::accumulate(parts.begin(), parts.end(), std::string(),
+                           [](const std::string &a, const std::string &b) {
+                             return a.empty() ? b : a + ":" + b;
+                           });
+
+    if(++count < value.size()) {
+      res += ",";
+    }
+  }
+  return res;
+}
+
+void Conv2dConfigOverrideParser::print(
+    llvm::raw_ostream &os,
+    const llvm::StringMap<Conv2dConfigOverrideParams> &value) {
+  os << "override-conv2d-config=";
+  os << Conv2dConfigOverrideParser::toString(value);
+  os << "\n";
+}
 
 bool OutputLayoutOverrideParser::parse(
     llvm::cl::Option &opt, StringRef argName, StringRef arg,

--- a/lib/Dialect/TTNN/Utils/PassOverrides.cpp
+++ b/lib/Dialect/TTNN/Utils/PassOverrides.cpp
@@ -5,8 +5,10 @@
 #include "ttmlir/Dialect/TTNN/Utils/PassOverrides.h"
 
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/raw_ostream.h"
 
 #include <numeric>
 
@@ -309,109 +311,91 @@ std::string Conv2dConfigOverrideParser::toString(
     const llvm::StringMap<Conv2dConfigOverrideParams> &value) {
   std::string res;
   size_t count = 0;
-  for (const auto &entry : value) {
-    res += std::string(entry.getKey()) + "=";
-    const Conv2dConfigOverrideParams &params = entry.getValue();
-
-    std::vector<std::string> parts;
+  for (const auto &[opLoc, params] : value) {
+    std::string opConv2dConfigString;
+    llvm::raw_string_ostream rso(opConv2dConfigString);
 
     if (params.dtype.has_value()) {
-      parts.push_back("dtype#" +
-                      DataTypeEnumToString(params.dtype.value()).str());
+      rso << "dtype#" << DataTypeEnumToString(params.dtype.value()) << ":";
     }
     if (params.weightsDtype.has_value()) {
-      parts.push_back("weights_dtype#" +
-                      DataTypeEnumToString(params.weightsDtype.value()).str());
+      rso << "weights_dtype#"
+          << DataTypeEnumToString(params.weightsDtype.value()) << ":";
     }
     if (params.activation.has_value()) {
-      parts.push_back("activation#" + params.activation.value());
+      rso << "activation#" << params.activation.value() << ":";
     }
     if (params.inputChannelsAlignment.has_value()) {
-      parts.push_back("input_channels_alignment#" +
-                      std::to_string(params.inputChannelsAlignment.value()));
+      rso << "input_channels_alignment#"
+          << params.inputChannelsAlignment.value() << ":";
     }
     if (params.deallocateActivation.has_value()) {
-      parts.push_back(
-          "deallocate_activation#" +
-          std::string(params.deallocateActivation.value() ? "true" : "false"));
+      rso << "deallocate_activation#"
+          << (params.deallocateActivation.value() ? "true" : "false") << ":";
     }
     if (params.reallocateHaloOutput.has_value()) {
-      parts.push_back(
-          "reallocate_halo_output#" +
-          std::string(params.reallocateHaloOutput.value() ? "true" : "false"));
+      rso << "reallocate_halo_output#"
+          << (params.reallocateHaloOutput.value() ? "true" : "false") << ":";
     }
     if (params.actBlockHOverride.has_value()) {
-      parts.push_back("act_block_h_override#" +
-                      std::to_string(params.actBlockHOverride.value()));
+      rso << "act_block_h_override#" << params.actBlockHOverride.value() << ":";
     }
     if (params.actBlockWDiv.has_value()) {
-      parts.push_back("act_block_w_div#" +
-                      std::to_string(params.actBlockWDiv.value()));
+      rso << "act_block_w_div#" << params.actBlockWDiv.value() << ":";
     }
     if (params.reshardIfNotOptimal.has_value()) {
-      parts.push_back(
-          "reshard_if_not_optimal#" +
-          std::string(params.reshardIfNotOptimal.value() ? "true" : "false"));
+      rso << "reshard_if_not_optimal#"
+          << (params.reshardIfNotOptimal.value() ? "true" : "false") << ":";
     }
     if (params.overrideShardingConfig.has_value()) {
-      parts.push_back("override_sharding_config#" +
-                      std::string(params.overrideShardingConfig.value()
-                                      ? "true"
-                                      : "false"));
+      rso << "override_sharding_config#"
+          << (params.overrideShardingConfig.value() ? "true" : "false") << ":";
     }
     if (params.shardLayout.has_value()) {
-      parts.push_back(
-          "shard_layout#" +
-          stringifyTensorMemoryLayout(params.shardLayout.value()).str());
+      rso << "shard_layout#"
+          << stringifyTensorMemoryLayout(params.shardLayout.value()) << ":";
     }
     if (params.transposeShards.has_value()) {
-      parts.push_back(
-          "transpose_shards#" +
-          std::string(params.transposeShards.value() ? "true" : "false"));
+      rso << "transpose_shards#"
+          << (params.transposeShards.value() ? "true" : "false") << ":";
     }
     if (params.outputLayout.has_value()) {
-      parts.push_back("output_layout#" +
-                      stringifyLayout(params.outputLayout.value()).str());
+      rso << "output_layout#" << stringifyLayout(params.outputLayout.value())
+          << ":";
     }
     if (params.preprocessWeightsOnDevice.has_value()) {
-      parts.push_back("preprocess_weights_on_device#" +
-                      std::string(params.preprocessWeightsOnDevice.value()
-                                      ? "true"
-                                      : "false"));
+      rso << "preprocess_weights_on_device#"
+          << (params.preprocessWeightsOnDevice.value() ? "true" : "false")
+          << ":";
     }
     if (params.alwaysPreprocessWeights.has_value()) {
-      parts.push_back("always_preprocess_weights#" +
-                      std::string(params.alwaysPreprocessWeights.value()
-                                      ? "true"
-                                      : "false"));
+      rso << "always_preprocess_weights#"
+          << (params.alwaysPreprocessWeights.value() ? "true" : "false") << ":";
     }
     if (params.enableActDoubleBuffer.has_value()) {
-      parts.push_back(
-          "enable_act_double_buffer#" +
-          std::string(params.enableActDoubleBuffer.value() ? "true" : "false"));
+      rso << "enable_act_double_buffer#"
+          << (params.enableActDoubleBuffer.value() ? "true" : "false") << ":";
     }
     if (params.enableWeightsDoubleBuffer.has_value()) {
-      parts.push_back("enable_weights_double_buffer#" +
-                      std::string(params.enableWeightsDoubleBuffer.value()
-                                      ? "true"
-                                      : "false"));
+      rso << "enable_weights_double_buffer#"
+          << (params.enableWeightsDoubleBuffer.value() ? "true" : "false")
+          << ":";
     }
     if (params.enableSplitReader.has_value()) {
-      parts.push_back(
-          "enable_split_reader#" +
-          std::string(params.enableSplitReader.value() ? "true" : "false"));
+      rso << "enable_split_reader#"
+          << (params.enableSplitReader.value() ? "true" : "false") << ":";
     }
     if (params.enableSubblockPadding.has_value()) {
-      parts.push_back(
-          "enable_subblock_padding#" +
-          std::string(params.enableSubblockPadding.value() ? "true" : "false"));
+      rso << "enable_subblock_padding#"
+          << (params.enableSubblockPadding.value() ? "true" : "false") << ":";
+    }
+    rso.flush();
+    // Remove the last ':' if there are parameters
+    if (!opConv2dConfigString.empty()) {
+      opConv2dConfigString.pop_back();
     }
 
-    res += std::accumulate(parts.begin(), parts.end(), std::string(),
-                           [](const std::string &a, const std::string &b) {
-                             return a.empty() ? b : a + ":" + b;
-                           });
-
+    res += (opLoc.str() + "=" + opConv2dConfigString);
     if (++count < value.size()) {
       res += ",";
     }

--- a/lib/Dialect/TTNN/Utils/PassOverrides.cpp
+++ b/lib/Dialect/TTNN/Utils/PassOverrides.cpp
@@ -194,6 +194,7 @@ bool Conv2dConfigOverrideParser::parse(
       }
       // TODO(vkovacevic): Parse core_grid
       else if (paramName == "core_grid") {
+        assert(false && "overriding core_grid is not supported yet");
         continue;
       } else if (paramName == "transpose_shards") {
         if (auto transposeShards = parseBool(paramValue, opt)) {

--- a/lib/Dialect/TTNN/Utils/PassOverrides.cpp
+++ b/lib/Dialect/TTNN/Utils/PassOverrides.cpp
@@ -60,6 +60,7 @@ bool Conv2dConfigOverrideParser::parse(
 
     Conv2dConfigOverrideParams params;
 
+    // TODO: change BoolAtrr format from 1/0 to true/false
     for(const StringRef &param : conv2dParamParts) {
       SmallVector<StringRef> param_kv;
       param.split(param_kv, paramKVSeparator);
@@ -110,7 +111,7 @@ bool Conv2dConfigOverrideParser::parse(
       }
       else if(param_name == "input_channels_alignment") {
         uint32_t inputChannelsAlignment; 
-        if(!param_value.getAsInteger<uint32_t>(10, inputChannelsAlignment)) {
+        if(param_value.getAsInteger<uint32_t>(10, inputChannelsAlignment)) {
           opt.error("Invalid input_channels_alignment: " + param_value);
           return true;
         }
@@ -124,7 +125,7 @@ bool Conv2dConfigOverrideParser::parse(
       else if(param_name == "deallocate_activation") {
         bool deallocateActivation;
         // Is it safe (getAsInteger<bool>) ?
-        if(!param_value.getAsInteger<bool>(10, deallocateActivation)) {
+        if(param_value.getAsInteger<bool>(10, deallocateActivation)) {
           opt.error("Invalid deallocate_activation: " + param_value);
           return true;
         }
@@ -136,7 +137,7 @@ bool Conv2dConfigOverrideParser::parse(
       }
       else if(param_name == "reallocate_halo_output") {
         bool reallocateHaloOutput;
-        if(!param_value.getAsInteger<bool>(10, reallocateHaloOutput)) {
+        if(param_value.getAsInteger<bool>(10, reallocateHaloOutput)) {
           opt.error("Invalid reallocateHaloOutput: " + param_value);
           return true;
         }
@@ -148,7 +149,7 @@ bool Conv2dConfigOverrideParser::parse(
       }
       else if(param_name == "act_block_h_override") {
         uint32_t actBlockHOverride;
-        if(!param_value.getAsInteger<uint32_t>(10, actBlockHOverride)) {
+        if(param_value.getAsInteger<uint32_t>(10, actBlockHOverride)) {
           opt.error("Invalid actBlockHOverride: " + param_value);
           return true;
         }
@@ -160,7 +161,7 @@ bool Conv2dConfigOverrideParser::parse(
       }
       else if(param_name == "act_block_w_div") {
         uint32_t actBlockWDiv;
-        if(!param_value.getAsInteger<uint32_t>(10, actBlockWDiv)) {
+        if(param_value.getAsInteger<uint32_t>(10, actBlockWDiv)) {
           opt.error("Invalid actBlockWDiv: " + param_value);
           return true;
         }
@@ -172,7 +173,7 @@ bool Conv2dConfigOverrideParser::parse(
       }
       else if(param_name == "reshard_if_not_optimal") {
         bool reshardIfNotOptimal;
-        if(!param_value.getAsInteger<bool>(10, reshardIfNotOptimal)) {
+        if(param_value.getAsInteger<bool>(10, reshardIfNotOptimal)) {
           opt.error("Invalid reshardIfNotOptimal: " + param_value);
           return true;
         }
@@ -184,7 +185,7 @@ bool Conv2dConfigOverrideParser::parse(
       }
       else if(param_name == "override_sharding_config") {
         bool overrideShardingConfig;
-        if(!param_value.getAsInteger<bool>(10, overrideShardingConfig)) {
+        if(param_value.getAsInteger<bool>(10, overrideShardingConfig)) {
           opt.error("Invalid overrideShardingConfig: " + param_value);
           return true;
         }
@@ -207,11 +208,11 @@ bool Conv2dConfigOverrideParser::parse(
         params.shardLayout = shardLayout;
       }
       //TODO: Check coreGrid
-      else if(param_name == "coreGrid") 
+      else if(param_name == "core_grid") 
         continue;
       else if(param_name == "transpose_shards") {
         bool transposeShards;
-        if(!param_value.getAsInteger<bool>(10, transposeShards)) {
+        if(param_value.getAsInteger<bool>(10, transposeShards)) {
           opt.error("Invalid transposeShards: " + param_value);
           return true;
         }
@@ -235,7 +236,7 @@ bool Conv2dConfigOverrideParser::parse(
       }
       else if(param_name == "enable_act_double_buffer") {
         bool enableActDoubleBuffer;
-        if(!param_value.getAsInteger<bool>(10, enableActDoubleBuffer)) {
+        if(param_value.getAsInteger<bool>(10, enableActDoubleBuffer)) {
           opt.error("Invalid enableActDoubleBuffer: " + param_value);
           return true;
         }
@@ -247,7 +248,7 @@ bool Conv2dConfigOverrideParser::parse(
       }
       else if(param_name == "enable_weights_double_buffer") {
         bool enableWeightsDoubleBuffer;
-        if(!param_value.getAsInteger<bool>(10, enableWeightsDoubleBuffer)) {
+        if(param_value.getAsInteger<bool>(10, enableWeightsDoubleBuffer)) {
           opt.error("Invalid enableWeightsDoubleBuffer: " + param_value);
           return true;
         }
@@ -259,7 +260,7 @@ bool Conv2dConfigOverrideParser::parse(
       }
       else if(param_name == "enable_split_reader") {
         bool enableSplitReader;
-        if(!param_value.getAsInteger<bool>(10, enableSplitReader)) {
+        if(param_value.getAsInteger<bool>(10, enableSplitReader)) {
           opt.error("Invalid enableSplitReader: " + param_value);
           return true;
         }
@@ -271,7 +272,7 @@ bool Conv2dConfigOverrideParser::parse(
       }
       else if(param_name == "enable_subblock_padding") {
         bool enableSubblockPadding;
-        if(!param_value.getAsInteger<bool>(10, enableSubblockPadding)) {
+        if(param_value.getAsInteger<bool>(10, enableSubblockPadding)) {
           opt.error("Invalid enableSubblockPadding: " + param_value);
           return true;
         }

--- a/lib/Dialect/TTNN/Utils/PassOverrides.cpp
+++ b/lib/Dialect/TTNN/Utils/PassOverrides.cpp
@@ -29,7 +29,7 @@ parseGrid(StringRef param, char gridSeparator, llvm::cl::Option &opt) {
 } // namespace
 
 bool Conv2dConfigOverrideParser::parse(
-    llvm::cl::Option &opt, StringRef argName, StringRef arg, 
+    llvm::cl::Option &opt, StringRef argName, StringRef arg,
     llvm::StringMap<Conv2dConfigOverrideParams> &value) {
   SmallVector<StringRef> opOverrideList;
   constexpr size_t kvPairSize = 2;
@@ -43,270 +43,237 @@ bool Conv2dConfigOverrideParser::parse(
   constexpr char paramNameValueSeparator = '#';
 
   arg.split(opOverrideList, opSeparator);
-  for(const StringRef override : opOverrideList) {
+  for (const StringRef override : opOverrideList) {
     SmallVector<StringRef, kvPairSize> opOverrideParts;
     override.split(opOverrideParts, opNameSeparator);
-    if(opOverrideParts.size() != kvPairSize) {
+    if (opOverrideParts.size() != kvPairSize) {
       opt.error("Invalid format for overriding op " + override);
-      return true;  
+      return true;
     }
 
     SmallVector<StringRef> conv2dParamParts;
     opOverrideParts[iConv2dConfigOverrideParams].split(conv2dParamParts,
-                                                 paramSeparator);
+                                                       paramSeparator);
 
     Conv2dConfigOverrideParams params;
 
-    for(const StringRef &param : conv2dParamParts) {
+    for (const StringRef &param : conv2dParamParts) {
       SmallVector<StringRef> param_kv;
       param.split(param_kv, paramNameValueSeparator);
       StringRef param_name = param_kv[iConv2dConfigParamName];
       StringRef param_value = param_kv[iConv2dConfigParamValue];
 
-      if(param_name == "dtype") {
+      if (param_name == "dtype") {
         auto dtype = mlir::tt::DataTypeStringToEnum(param_value);
         if (!dtype) {
           opt.error("Invalid dtype: " + param_value);
           return true;
-        } 
-        if(params.dtype.has_value()) {
-            opt.error("Duplicate dtype: " + param_value);
-            return true;
+        }
+        if (params.dtype.has_value()) {
+          opt.error("Duplicate dtype: " + param_value);
+          return true;
         }
         params.dtype = dtype;
-      } 
-      else if(param_name == "weights_dtype") {
+      } else if (param_name == "weights_dtype") {
         auto weightsDtype = mlir::tt::DataTypeStringToEnum(param_value);
         if (!weightsDtype) {
           opt.error("Invalid weights_dtype: " + param_value);
           return true;
-        } 
-        if(params.weightsDtype.has_value()) {
-            opt.error("Duplicate weights_dtype: " + param_value);
-            return true;
+        }
+        if (params.weightsDtype.has_value()) {
+          opt.error("Duplicate weights_dtype: " + param_value);
+          return true;
         }
         params.weightsDtype = weightsDtype;
-      }
-      else if(param_name == "activation") {
+      } else if (param_name == "activation") {
         auto activation = param_value;
-        if(activation.empty()) {
+        if (activation.empty()) {
           opt.error("Invalid activation: " + param_value);
           return true;
         }
         if (!activation.equals_insensitive(StringRef("relu")) &&
-              !activation.equals_insensitive(("none"))) {
+            !activation.equals_insensitive(("none"))) {
           opt.error("Invalid activation: " + param_value);
           return true;
-        } 
-        if(params.activation.has_value()) {
-            opt.error("Duplicate activation: " + param_value);
-            return true;
+        }
+        if (params.activation.has_value()) {
+          opt.error("Duplicate activation: " + param_value);
+          return true;
         }
         params.activation = activation.str();
-      }
-      else if(param_name == "input_channels_alignment") {
-        uint32_t inputChannelsAlignment; 
-        if(param_value.getAsInteger<uint32_t>(10, inputChannelsAlignment)) {
+      } else if (param_name == "input_channels_alignment") {
+        uint32_t inputChannelsAlignment;
+        if (param_value.getAsInteger<uint32_t>(10, inputChannelsAlignment)) {
           opt.error("Invalid input_channels_alignment: " + param_value);
           return true;
         }
-        if(params.inputChannelsAlignment.has_value()) {
+        if (params.inputChannelsAlignment.has_value()) {
           opt.error("Duplicate input_channels_alignment: " + param_value);
           return true;
         }
         params.inputChannelsAlignment = inputChannelsAlignment;
-      }  
-      else if(param_name == "deallocate_activation") {
-        if(params.deallocateActivation.has_value()) {
+      } else if (param_name == "deallocate_activation") {
+        if (params.deallocateActivation.has_value()) {
           opt.error("Duplicate deallocate_activation: " + param_value);
           return true;
         }
-        if(param_value.equals_insensitive("true")) {
+        if (param_value.equals_insensitive("true")) {
           params.deallocateActivation = true;
-        }
-        else if(param_value.equals_insensitive("false")) {
+        } else if (param_value.equals_insensitive("false")) {
           params.deallocateActivation = false;
-        }
-        else {
+        } else {
           opt.error("Invalid deallocate_activation: " + param_value);
           return true;
         }
-      }
-      else if(param_name == "reallocate_halo_output") {
-        if(params.reallocateHaloOutput.has_value()) {
+      } else if (param_name == "reallocate_halo_output") {
+        if (params.reallocateHaloOutput.has_value()) {
           opt.error("Duplicate reallocate_halo_output: " + param_value);
           return true;
         }
-        if(param_value.equals_insensitive("true")) {
+        if (param_value.equals_insensitive("true")) {
           params.reallocateHaloOutput = true;
-        }
-        else if(param_value.equals_insensitive("false")) {
+        } else if (param_value.equals_insensitive("false")) {
           params.reallocateHaloOutput = false;
-        }
-        else {
+        } else {
           opt.error("Invalid reallocate_halo_output: " + param_value);
           return true;
         }
-      }
-      else if(param_name == "act_block_h_override") {
+      } else if (param_name == "act_block_h_override") {
         uint32_t actBlockHOverride;
-        if(param_value.getAsInteger<uint32_t>(10, actBlockHOverride)) {
+        if (param_value.getAsInteger<uint32_t>(10, actBlockHOverride)) {
           opt.error("Invalid actBlockHOverride: " + param_value);
           return true;
         }
-        if(params.actBlockHOverride.has_value()) {
+        if (params.actBlockHOverride.has_value()) {
           opt.error("Duplicate actBlockHOverride: " + param_value);
           return true;
         }
         params.actBlockHOverride = actBlockHOverride;
-      }
-      else if(param_name == "act_block_w_div") {
+      } else if (param_name == "act_block_w_div") {
         uint32_t actBlockWDiv;
-        if(param_value.getAsInteger<uint32_t>(10, actBlockWDiv)) {
+        if (param_value.getAsInteger<uint32_t>(10, actBlockWDiv)) {
           opt.error("Invalid actBlockWDiv: " + param_value);
           return true;
         }
-        if(params.actBlockWDiv.has_value()) {
+        if (params.actBlockWDiv.has_value()) {
           opt.error("Duplicate actBlockWDiv: " + param_value);
           return true;
         }
         params.actBlockWDiv = actBlockWDiv;
-      }
-      else if(param_name == "reshard_if_not_optimal") {
-        if(params.reshardIfNotOptimal.has_value()) {
+      } else if (param_name == "reshard_if_not_optimal") {
+        if (params.reshardIfNotOptimal.has_value()) {
           opt.error("Duplicate reshard_if_not_optimal: " + param_value);
           return true;
         }
-        if(param_value.equals_insensitive("true")) {
+        if (param_value.equals_insensitive("true")) {
           params.reshardIfNotOptimal = true;
-        }
-        else if(param_value.equals_insensitive("false")) {
+        } else if (param_value.equals_insensitive("false")) {
           params.reshardIfNotOptimal = false;
-        }
-        else {
+        } else {
           opt.error("Invalid reshard_if_not_optimal: " + param_value);
           return true;
         }
-      }
-      else if(param_name == "override_sharding_config") {
-        if(params.overrideShardingConfig.has_value()) {
+      } else if (param_name == "override_sharding_config") {
+        if (params.overrideShardingConfig.has_value()) {
           opt.error("Duplicate override_sharding_config: " + param_value);
           return true;
         }
-        if(param_value.equals_insensitive("true")) {
+        if (param_value.equals_insensitive("true")) {
           params.overrideShardingConfig = true;
-        }
-        else if(param_value.equals_insensitive("false")) {
+        } else if (param_value.equals_insensitive("false")) {
           params.overrideShardingConfig = false;
-        }
-        else {
+        } else {
           opt.error("Invalid override_sharding_config: " + param_value);
           return true;
         }
-      }
-      else if(param_name == "shard_layout") {
+      } else if (param_name == "shard_layout") {
         auto shardLayout = symbolizeTensorMemoryLayout(param_value);
         if (!shardLayout) {
           opt.error("Invalid shardLayout: " + param_value);
           return true;
-        } 
-        if(params.shardLayout.has_value()) {
-            opt.error("Duplicate shardLayout: " + param_value);
-            return true;
+        }
+        if (params.shardLayout.has_value()) {
+          opt.error("Duplicate shardLayout: " + param_value);
+          return true;
         }
         params.shardLayout = shardLayout;
       }
-      //TODO(vkovacevic): Parse core_grid
-      else if(param_name == "core_grid") 
+      // TODO(vkovacevic): Parse core_grid
+      else if (param_name == "core_grid") {
         continue;
-      else if(param_name == "transpose_shards") {
-          if(params.transposeShards.has_value()) {
-            opt.error("Duplicate transpose_shards: " + param_value);
-            return true;
-          }
-          if(param_value.equals_insensitive("true")) {
-            params.transposeShards = true;
-          }
-          else if(param_value.equals_insensitive("false")) {
-            params.transposeShards = false;
-          }
-          else {
-            opt.error("Invalid transpose_shards: " + param_value);
-            return true;
-          }
-      }
-      else if(param_name == "output_layout") {
+      } else if (param_name == "transpose_shards") {
+        if (params.transposeShards.has_value()) {
+          opt.error("Duplicate transpose_shards: " + param_value);
+          return true;
+        }
+        if (param_value.equals_insensitive("true")) {
+          params.transposeShards = true;
+        } else if (param_value.equals_insensitive("false")) {
+          params.transposeShards = false;
+        } else {
+          opt.error("Invalid transpose_shards: " + param_value);
+          return true;
+        }
+      } else if (param_name == "output_layout") {
         auto outputLayout = symbolizeLayout(param_value);
         if (!outputLayout) {
           opt.error("Invalid outputLayout: " + param_value);
           return true;
-        } 
-        if(params.outputLayout.has_value()) {
-            opt.error("Duplicate outputLayout: " + param_value);
-            return true;
+        }
+        if (params.outputLayout.has_value()) {
+          opt.error("Duplicate outputLayout: " + param_value);
+          return true;
         }
         params.outputLayout = outputLayout;
-      }
-      else if(param_name == "enable_act_double_buffer") {
-        if(params.enableActDoubleBuffer.has_value()) {
+      } else if (param_name == "enable_act_double_buffer") {
+        if (params.enableActDoubleBuffer.has_value()) {
           opt.error("Duplicate enable_act_double_buffer: " + param_value);
           return true;
         }
-        if(param_value.equals_insensitive("true")) {
+        if (param_value.equals_insensitive("true")) {
           params.enableActDoubleBuffer = true;
-        }
-        else if(param_value.equals_insensitive("false")) {
+        } else if (param_value.equals_insensitive("false")) {
           params.enableActDoubleBuffer = false;
-        }
-        else {
+        } else {
           opt.error("Invalid enable_act_double_buffer: " + param_value);
           return true;
         }
-      }
-      else if(param_name == "enable_weights_double_buffer") {
-        if(params.enableWeightsDoubleBuffer.has_value()) {
+      } else if (param_name == "enable_weights_double_buffer") {
+        if (params.enableWeightsDoubleBuffer.has_value()) {
           opt.error("Duplicate enable_weights_double_buffer: " + param_value);
           return true;
         }
-        if(param_value.equals_insensitive("true")) {
+        if (param_value.equals_insensitive("true")) {
           params.enableWeightsDoubleBuffer = true;
-        }
-        else if(param_value.equals_insensitive("false")) {
+        } else if (param_value.equals_insensitive("false")) {
           params.enableWeightsDoubleBuffer = false;
-        }
-        else {
+        } else {
           opt.error("Invalid enable_weights_double_buffer: " + param_value);
           return true;
         }
-      }
-      else if(param_name == "enable_split_reader") {
-        if(params.enableSplitReader.has_value()) {
+      } else if (param_name == "enable_split_reader") {
+        if (params.enableSplitReader.has_value()) {
           opt.error("Duplicate enable_split_reader: " + param_value);
           return true;
         }
-        if(param_value.equals_insensitive("true")) {
+        if (param_value.equals_insensitive("true")) {
           params.enableSplitReader = true;
-        }
-        else if(param_value.equals_insensitive("false")) {
+        } else if (param_value.equals_insensitive("false")) {
           params.enableSplitReader = false;
-        }
-        else {
+        } else {
           opt.error("Invalid enable_split_reader: " + param_value);
           return true;
         }
-      }
-      else if(param_name == "enable_subblock_padding") {
-        if(params.enableSubblockPadding.has_value()) {
+      } else if (param_name == "enable_subblock_padding") {
+        if (params.enableSubblockPadding.has_value()) {
           opt.error("Duplicate enable_subblock_padding: " + param_value);
           return true;
         }
-        if(param_value.equals_insensitive("true")) {
+        if (param_value.equals_insensitive("true")) {
           params.enableSubblockPadding = true;
-        }
-        else if(param_value.equals_insensitive("false")) {
+        } else if (param_value.equals_insensitive("false")) {
           params.enableSubblockPadding = false;
-        }
-        else {
+        } else {
           opt.error("Invalid enable_subblock_padding: " + param_value);
           return true;
         }
@@ -328,56 +295,73 @@ std::string Conv2dConfigOverrideParser::toString(
 
     std::vector<std::string> parts;
 
-    if(params.dtype.has_value()) {
-      parts.push_back("dtype#" + DataTypeEnumToString(params.dtype.value()).str());
+    if (params.dtype.has_value()) {
+      parts.push_back("dtype#" +
+                      DataTypeEnumToString(params.dtype.value()).str());
     }
-    if(params.weightsDtype.has_value()) {
-      parts.push_back("weights_dtype#" + DataTypeEnumToString(params.weightsDtype.value()).str());
+    if (params.weightsDtype.has_value()) {
+      parts.push_back("weights_dtype#" +
+                      DataTypeEnumToString(params.weightsDtype.value()).str());
     }
-    if(params.activation.has_value()) {
+    if (params.activation.has_value()) {
       parts.push_back("activation#" + params.activation.value());
     }
-    if(params.inputChannelsAlignment.has_value()) {
-      parts.push_back("input_channels_alignment#" + std::to_string(params.inputChannelsAlignment.value()));
+    if (params.inputChannelsAlignment.has_value()) {
+      parts.push_back("input_channels_alignment#" +
+                      std::to_string(params.inputChannelsAlignment.value()));
     }
-    if(params.deallocateActivation.has_value()) {
-      parts.push_back("deallocate_activation#" + std::to_string(params.deallocateActivation.value()));
+    if (params.deallocateActivation.has_value()) {
+      parts.push_back("deallocate_activation#" +
+                      std::to_string(params.deallocateActivation.value()));
     }
-    if(params.reallocateHaloOutput.has_value()) {
-      parts.push_back("reallocate_halo_output#" + std::to_string(params.reallocateHaloOutput.value()));
+    if (params.reallocateHaloOutput.has_value()) {
+      parts.push_back("reallocate_halo_output#" +
+                      std::to_string(params.reallocateHaloOutput.value()));
     }
-    if(params.actBlockHOverride.has_value()) {
-      parts.push_back("act_block_h_override#" + std::to_string(params.actBlockHOverride.value()));
+    if (params.actBlockHOverride.has_value()) {
+      parts.push_back("act_block_h_override#" +
+                      std::to_string(params.actBlockHOverride.value()));
     }
-    if(params.actBlockWDiv.has_value()) {
-      parts.push_back("act_block_w_div#" + std::to_string(params.actBlockWDiv.value()));
+    if (params.actBlockWDiv.has_value()) {
+      parts.push_back("act_block_w_div#" +
+                      std::to_string(params.actBlockWDiv.value()));
     }
-    if(params.reshardIfNotOptimal.has_value()) {
-      parts.push_back("reshard_if_not_optimal#" + std::to_string(params.reshardIfNotOptimal.value()));
+    if (params.reshardIfNotOptimal.has_value()) {
+      parts.push_back("reshard_if_not_optimal#" +
+                      std::to_string(params.reshardIfNotOptimal.value()));
     }
-    if(params.overrideShardingConfig.has_value()) {
-      parts.push_back("override_sharding_config#" + std::to_string(params.overrideShardingConfig.value()));
+    if (params.overrideShardingConfig.has_value()) {
+      parts.push_back("override_sharding_config#" +
+                      std::to_string(params.overrideShardingConfig.value()));
     }
-    if(params.shardLayout.has_value()) {
-      parts.push_back("shard_layout#" + stringifyTensorMemoryLayout(params.shardLayout.value()).str());
+    if (params.shardLayout.has_value()) {
+      parts.push_back(
+          "shard_layout#" +
+          stringifyTensorMemoryLayout(params.shardLayout.value()).str());
     }
-    if(params.transposeShards.has_value()) {
-      parts.push_back("transpose_shards#" + std::to_string(params.transposeShards.value()));
+    if (params.transposeShards.has_value()) {
+      parts.push_back("transpose_shards#" +
+                      std::to_string(params.transposeShards.value()));
     }
-    if(params.outputLayout.has_value()) {
-      parts.push_back("output_layout#" + stringifyLayout(params.outputLayout.value()).str());
+    if (params.outputLayout.has_value()) {
+      parts.push_back("output_layout#" +
+                      stringifyLayout(params.outputLayout.value()).str());
     }
-    if(params.enableActDoubleBuffer.has_value()) {
-      parts.push_back("enable_act_double_buffer#" + std::to_string(params.enableActDoubleBuffer.value()));
+    if (params.enableActDoubleBuffer.has_value()) {
+      parts.push_back("enable_act_double_buffer#" +
+                      std::to_string(params.enableActDoubleBuffer.value()));
     }
-    if(params.enableWeightsDoubleBuffer.has_value()) {
-      parts.push_back("enable_weights_double_buffer#" + std::to_string(params.enableWeightsDoubleBuffer.value()));
+    if (params.enableWeightsDoubleBuffer.has_value()) {
+      parts.push_back("enable_weights_double_buffer#" +
+                      std::to_string(params.enableWeightsDoubleBuffer.value()));
     }
-    if(params.enableSplitReader.has_value()) {
-      parts.push_back("enable_split_reader#" + std::to_string(params.enableSplitReader.value()));
+    if (params.enableSplitReader.has_value()) {
+      parts.push_back("enable_split_reader#" +
+                      std::to_string(params.enableSplitReader.value()));
     }
-    if(params.enableSubblockPadding.has_value()) {
-      parts.push_back("enable_subblock_padding#" + std::to_string(params.enableSubblockPadding.value()));
+    if (params.enableSubblockPadding.has_value()) {
+      parts.push_back("enable_subblock_padding#" +
+                      std::to_string(params.enableSubblockPadding.value()));
     }
 
     res += std::accumulate(parts.begin(), parts.end(), std::string(),
@@ -385,7 +369,7 @@ std::string Conv2dConfigOverrideParser::toString(
                              return a.empty() ? b : a + ":" + b;
                            });
 
-    if(++count < value.size()) {
+    if (++count < value.size()) {
       res += ",";
     }
   }

--- a/lib/Dialect/TTNN/Utils/TransformUtils.cpp
+++ b/lib/Dialect/TTNN/Utils/TransformUtils.cpp
@@ -8,6 +8,7 @@
 #include "ttmlir/Dialect/TT/IR/Utils.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+#include "ttmlir/Utils.h"
 
 namespace mlir::tt::ttnn::utils {
 // Gets or inserts a GetDeviceOp at the top of the current block of the given
@@ -41,7 +42,7 @@ createToLayoutOp(Operation *op, mlir::TypedValue<RankedTensorType> inputValue,
                  PatternRewriter &rewriter, Layout targetTensorLayout,
                  BufferType targetTensorBufferType,
                  std::optional<TensorMemoryLayout> targetTensorMemoryLayout,
-                 DataType targetTensorDataType) {
+                 DataType targetTensorDataType, llvm::StringRef locSuffix) {
   TTNNLayoutAttr inputLayoutAttr =
       getLayoutAttrFromTensor(inputValue.getType());
 
@@ -91,10 +92,11 @@ createToLayoutOp(Operation *op, mlir::TypedValue<RankedTensorType> inputValue,
                          ? nullptr
                          : Value(utils::getOrInsertDevice(rewriter, op));
 
+  Location loc = ttmlir::utils::appendLocationSuffix(op->getLoc(), locSuffix);
   // Create a ToLayoutOp to convert the input operand to the desired
-  // tensor layout, buffer type and memory layout.
+  // tensor layout, buffer type and memory layout.o
   return rewriter.create<ttnn::ToLayoutOp>(
-      op->getLoc(), toLayoutOpResultType, inputValue,
+      loc, toLayoutOpResultType, inputValue,
       LayoutAttr::get(rewriter.getContext(), targetTensorLayout),
       DataTypeAttr::get(rewriter.getContext(), targetTensorDataType),
       outputMemConfigAttr, deviceValue);

--- a/test/ttmlir/Dialect/TTNN/optimizer/conv2d_config_override.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/conv2d_config_override.mlir
@@ -1,0 +1,16 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true override-conv2d-config=conv2d_1=dtype#bf16:weights_dtype#bf16:activation#relu:input_channels_alignment#32:deallocate_activation#false:reallocate_halo_output#true:act_block_h_override#0:act_block_w_div#1:reshard_if_not_optimal#false:override_sharding_config#false:transpose_shards#true:output_layout#row_major:enable_act_double_buffer#false:enable_weights_double_buffer#false:enable_split_reader#false:enable_subblock_padding#false" %s | FileCheck %s
+module {
+  func.func @forward(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x32x32x64xbf16> {
+    %0 = tensor.empty() : tensor<1x32x32x64xbf16> 
+    // CHECK: %{{.*}} = "ttnn.conv2d"{{.*}} conv2d_config = #ttnn.conv2d_config<dtype = bf16, weightsDtype = bf16, activation = "relu", inputChannelsAlignment = 32 : i32, deallocateActivation = false, reallocateHaloOutput = true, actBlockHOverride = 0 : i0, actBlockWDiv = true, reshardIfNotOptimal = false, overrideShardingConfig = false, transposeShards = true, outputLayout = row_major, enableActDoubleBuffer = false, enableWeightsDoubleBuffer = false, enableSplitReader = false, enableSubblockPadding = false>{{.*}}
+    %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0) 
+            <{
+              stride = array<i32: 1, 1>,
+              padding = array<i32: 1, 1>,
+              dilation = 1: i32,
+              groups = 1: i32
+            }> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, tensor<1x32x32x64xbf16>) -> tensor<1x32x32x64xbf16> loc(#loc2)
+    return %1 : tensor<1x32x32x64xbf16>
+  }
+}
+#loc2 = loc("conv2d_1")

--- a/test/ttmlir/Dialect/TTNN/optimizer/conv2d_config_override.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/conv2d_config_override.mlir
@@ -2,7 +2,7 @@
 module {
   func.func @forward(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x32x32x64xbf16> {
     %0 = ttir.empty() : tensor<1x32x32x64xbf16>
-    // CHECK: %{{.*}} = "ttnn.conv2d"{{.*}} conv2d_config = #ttnn.conv2d_config<dtype = bf16, weightsDtype = bf16, activation = "relu", inputChannelsAlignment = 32 : i32, deallocateActivation = false, reallocateHaloOutput = true, actBlockHOverride = 0 : i0, actBlockWDiv = true, reshardIfNotOptimal = false, overrideShardingConfig = false, transposeShards = true, outputLayout = row_major, enableActDoubleBuffer = false, enableWeightsDoubleBuffer = false, enableSplitReader = false, enableSubblockPadding = false>{{.*}}
+    // CHECK: %{{.*}} = "ttnn.conv2d"{{.*}} conv2d_config = #ttnn.conv2d_config<dtype = bf16, weights_dtype = bf16, activation = "relu", input_channels_alignment = 32, deallocate_activation = false, reallocate_halo_output = true, act_block_h_override = 0, act_block_w_div = 1, reshard_if_not_optimal = false, override_sharding_config = false, transpose_shards = true, output_layout = row_major, preprocess_weights_on_device = false, always_preprocess_weights = false, enable_act_double_buffer = false, enable_weights_double_buffer = false, enable_split_reader = false, enable_subblock_padding = false>{{.*}}
     %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
             <{
               stride = array<i32: 1, 1>,

--- a/test/ttmlir/Dialect/TTNN/optimizer/conv2d_config_override.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/conv2d_config_override.mlir
@@ -1,9 +1,9 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true override-conv2d-config=conv2d_1=dtype#bf16:weights_dtype#bf16:activation#relu:input_channels_alignment#32:deallocate_activation#false:reallocate_halo_output#true:act_block_h_override#0:act_block_w_div#1:reshard_if_not_optimal#false:override_sharding_config#false:transpose_shards#true:output_layout#row_major:enable_act_double_buffer#false:enable_weights_double_buffer#false:enable_split_reader#false:enable_subblock_padding#false" %s | FileCheck %s
 module {
   func.func @forward(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x32x32x64xbf16> {
-    %0 = tensor.empty() : tensor<1x32x32x64xbf16> 
+    %0 = tensor.empty() : tensor<1x32x32x64xbf16>
     // CHECK: %{{.*}} = "ttnn.conv2d"{{.*}} conv2d_config = #ttnn.conv2d_config<dtype = bf16, weightsDtype = bf16, activation = "relu", inputChannelsAlignment = 32 : i32, deallocateActivation = false, reallocateHaloOutput = true, actBlockHOverride = 0 : i0, actBlockWDiv = true, reshardIfNotOptimal = false, overrideShardingConfig = false, transposeShards = true, outputLayout = row_major, enableActDoubleBuffer = false, enableWeightsDoubleBuffer = false, enableSplitReader = false, enableSubblockPadding = false>{{.*}}
-    %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0) 
+    %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
             <{
               stride = array<i32: 1, 1>,
               padding = array<i32: 1, 1>,

--- a/test/ttmlir/Dialect/TTNN/optimizer/conv2d_config_override.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/conv2d_config_override.mlir
@@ -1,7 +1,7 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true override-conv2d-config=conv2d_1=dtype#bf16:weights_dtype#bf16:activation#relu:input_channels_alignment#32:deallocate_activation#false:reallocate_halo_output#true:act_block_h_override#0:act_block_w_div#1:reshard_if_not_optimal#false:override_sharding_config#false:transpose_shards#true:output_layout#row_major:enable_act_double_buffer#false:enable_weights_double_buffer#false:enable_split_reader#false:enable_subblock_padding#false" %s | FileCheck %s
 module {
   func.func @forward(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x32x32x64xbf16> {
-    %0 = tensor.empty() : tensor<1x32x32x64xbf16>
+    %0 = ttir.empty() : tensor<1x32x32x64xbf16>
     // CHECK: %{{.*}} = "ttnn.conv2d"{{.*}} conv2d_config = #ttnn.conv2d_config<dtype = bf16, weightsDtype = bf16, activation = "relu", inputChannelsAlignment = 32 : i32, deallocateActivation = false, reallocateHaloOutput = true, actBlockHOverride = 0 : i0, actBlockWDiv = true, reshardIfNotOptimal = false, overrideShardingConfig = false, transposeShards = true, outputLayout = row_major, enableActDoubleBuffer = false, enableWeightsDoubleBuffer = false, enableSplitReader = false, enableSubblockPadding = false>{{.*}}
     %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
             <{

--- a/test/unittests/Optimizer/TestOptimizerOverrides.cpp
+++ b/test/unittests/Optimizer/TestOptimizerOverrides.cpp
@@ -43,7 +43,6 @@ TEST_F(Conv2dConfigOverrideTest, ParseFullConv2dConfigOverride) {
                     "reshard_if_not_optimal#false:"
                     "override_sharding_config#false:"
                     "shard_layout#block_sharded:"
-                    "core_grid#0:"
                     "transpose_shards#true:"
                     "output_layout#row_major:"
                     "enable_act_double_buffer#false:"

--- a/test/unittests/Optimizer/TestOptimizerOverrides.cpp
+++ b/test/unittests/Optimizer/TestOptimizerOverrides.cpp
@@ -45,6 +45,8 @@ TEST_F(Conv2dConfigOverrideTest, ParseFullConv2dConfigOverride) {
                     "shard_layout#block_sharded:"
                     "transpose_shards#true:"
                     "output_layout#row_major:"
+                    "preprocess_weights_on_device#false:"
+                    "always_preprocess_weights#false:"
                     "enable_act_double_buffer#false:"
                     "enable_weights_double_buffer#false:"
                     "enable_split_reader#false:"
@@ -83,6 +85,10 @@ TEST_F(Conv2dConfigOverrideTest, ParseFullConv2dConfigOverride) {
   ASSERT_TRUE(params.transposeShards.value());
   ASSERT_TRUE(params.outputLayout.has_value());
   ASSERT_EQ(params.outputLayout.value(), Layout::RowMajor);
+  ASSERT_TRUE(params.preprocessWeightsOnDevice.has_value());
+  ASSERT_FALSE(params.preprocessWeightsOnDevice.value());
+  ASSERT_TRUE(params.alwaysPreprocessWeights.has_value());
+  ASSERT_FALSE(params.alwaysPreprocessWeights.value());
   ASSERT_TRUE(params.enableActDoubleBuffer.has_value());
   ASSERT_FALSE(params.enableActDoubleBuffer.value());
   ASSERT_TRUE(params.enableWeightsDoubleBuffer.has_value());

--- a/test/unittests/Optimizer/TestOptimizerOverrides.cpp
+++ b/test/unittests/Optimizer/TestOptimizerOverrides.cpp
@@ -11,6 +11,12 @@
 
 using namespace mlir::tt::ttnn;
 
+class Conv2dConfigOverrideTest : public ::testing::Test {
+protected:
+  static llvm::cl::opt<std::string> OverrideConv2dConfigOption;
+  Conv2dConfigOverrideParser parser{OverrideConv2dConfigOption};
+  llvm::StringMap<Conv2dConfigOverrideParams> parsedOverride;
+};
 class OutputLayoutOverrideTest : public ::testing::Test {
 protected:
   static llvm::cl::opt<std::string> OverrideOutputLayoutOption;
@@ -18,8 +24,158 @@ protected:
   llvm::StringMap<OutputLayoutOverrideParams> parsedOverride;
 };
 
+llvm::cl::opt<std::string> Conv2dConfigOverrideTest::OverrideConv2dConfigOption{
+    "override-conv2d-config"};
+
 llvm::cl::opt<std::string> OutputLayoutOverrideTest::OverrideOutputLayoutOption{
     "override-output-layout"};
+
+TEST_F(Conv2dConfigOverrideTest, ParseFullConv2dConfigOverride) {
+  std::string arg = "op0="
+                    "dtype#bf16:"
+                    "weights_dtype#bf16:"
+                    "activation#relu:"
+                    "input_channels_alignment#32:"
+                    "deallocate_activation#0:"
+                    "reallocate_halo_output#1:"
+                    "act_block_h_override#0:"
+                    "act_block_w_div#1:"
+                    "reshard_if_not_optimal#0:"
+                    "override_sharding_config#0:"
+                    "shard_layout#block_sharded:"
+                    "core_grid#0:"
+                    "transpose_shards#1:"
+                    "output_layout#row_major:"
+                    "enable_act_double_buffer#0:"
+                    "enable_weights_double_buffer#0:"
+                    "enable_split_reader#0:"
+                    "enable_subblock_padding#0";
+
+  bool result = parser.parse(OverrideConv2dConfigOption,
+                             "override-conv2d-config", arg, parsedOverride);
+  ASSERT_FALSE(result);
+  ASSERT_EQ(parsedOverride.size(), 1);
+  ASSERT_TRUE(parsedOverride.count("op0"));
+
+  const auto &params = parsedOverride["op0"];
+  ASSERT_TRUE(params.dtype.has_value());
+  ASSERT_EQ(params.dtype.value(), mlir::tt::DataType::BFloat16);
+  ASSERT_TRUE(params.weightsDtype.has_value());
+  ASSERT_EQ(params.weightsDtype.value(), mlir::tt::DataType::BFloat16);
+  ASSERT_TRUE(params.activation.has_value());
+  ASSERT_EQ(params.activation.value(), "relu");
+  ASSERT_TRUE(params.inputChannelsAlignment.has_value());
+  ASSERT_EQ(params.inputChannelsAlignment.value(), 32);
+  ASSERT_TRUE(params.deallocateActivation.has_value());
+  ASSERT_FALSE(params.deallocateActivation.value());
+  ASSERT_TRUE(params.reallocateHaloOutput.has_value());
+  ASSERT_TRUE(params.reallocateHaloOutput.value());
+  ASSERT_TRUE(params.actBlockHOverride.has_value());
+  ASSERT_EQ(params.actBlockHOverride.value(), 0);
+  ASSERT_TRUE(params.actBlockWDiv.has_value());
+  ASSERT_EQ(params.actBlockWDiv.value(), 1);
+  ASSERT_TRUE(params.reshardIfNotOptimal.has_value());
+  ASSERT_FALSE(params.reshardIfNotOptimal.value());
+  ASSERT_TRUE(params.overrideShardingConfig.has_value());
+  ASSERT_FALSE(params.overrideShardingConfig.value());
+  ASSERT_TRUE(params.shardLayout.has_value());
+  ASSERT_EQ(params.shardLayout.value(), TensorMemoryLayout::BlockSharded);
+  ASSERT_TRUE(params.transposeShards.has_value());
+  ASSERT_TRUE(params.transposeShards.value());
+  ASSERT_TRUE(params.outputLayout.has_value());
+  ASSERT_EQ(params.outputLayout.value(), Layout::RowMajor);
+  ASSERT_TRUE(params.enableActDoubleBuffer.has_value());
+  ASSERT_FALSE(params.enableActDoubleBuffer.value());
+  ASSERT_TRUE(params.enableWeightsDoubleBuffer.has_value());
+  ASSERT_FALSE(params.enableWeightsDoubleBuffer.value());
+  ASSERT_TRUE(params.enableSplitReader.has_value());
+  ASSERT_FALSE(params.enableSplitReader.value());
+  ASSERT_TRUE(params.enableSubblockPadding.has_value());
+  ASSERT_FALSE(params.enableSubblockPadding.value());
+}
+
+TEST_F(Conv2dConfigOverrideTest, ParsePartialConv2dConfigOverride) {
+  std::string arg = "op0="
+                    "dtype#f32:"
+                    "activation#none";
+
+  bool result = parser.parse(OverrideConv2dConfigOption,
+                             "override-conv2d-config", arg, parsedOverride);
+  ASSERT_FALSE(result);
+  ASSERT_EQ(parsedOverride.size(), 1);
+  ASSERT_TRUE(parsedOverride.count("op0"));
+
+  const auto &params = parsedOverride["op0"];
+  ASSERT_TRUE(params.dtype.has_value());
+  ASSERT_EQ(params.dtype.value(), mlir::tt::DataType::Float32);
+  ASSERT_TRUE(params.activation.has_value());
+  ASSERT_EQ(params.activation.value(), "none");
+  ASSERT_FALSE(params.weightsDtype.has_value());
+  ASSERT_FALSE(params.inputChannelsAlignment.has_value());
+  ASSERT_FALSE(params.deallocateActivation.has_value());
+  ASSERT_FALSE(params.reallocateHaloOutput.has_value());
+  ASSERT_FALSE(params.actBlockHOverride.has_value());
+  ASSERT_FALSE(params.actBlockWDiv.has_value());
+  ASSERT_FALSE(params.reshardIfNotOptimal.has_value());
+  ASSERT_FALSE(params.overrideShardingConfig.has_value());
+  ASSERT_FALSE(params.shardLayout.has_value());
+  ASSERT_FALSE(params.transposeShards.has_value());
+  ASSERT_FALSE(params.outputLayout.has_value());
+  ASSERT_FALSE(params.enableActDoubleBuffer.has_value());
+  ASSERT_FALSE(params.enableWeightsDoubleBuffer.has_value());
+  ASSERT_FALSE(params.enableSplitReader.has_value());
+  ASSERT_FALSE(params.enableSubblockPadding.has_value());
+}
+
+TEST_F(Conv2dConfigOverrideTest, ParseMultipleOps) {
+  std::string arg = "op0="
+                    "dtype#f32:"
+                    "activation#none"
+                    ","
+                    "op1=dtype#bf16:"
+                    "weights_dtype#bf16:"
+                    "activation#relu:"
+                    "input_channels_alignment#32";
+
+  bool result = parser.parse(OverrideConv2dConfigOption,
+                             "override-conv2d-config", arg, parsedOverride);
+  ASSERT_FALSE(result);
+  ASSERT_EQ(parsedOverride.size(), 2);
+  ASSERT_TRUE(parsedOverride.count("op0"));
+  ASSERT_TRUE(parsedOverride.count("op1"));
+
+  const auto &params0 = parsedOverride["op0"];
+  ASSERT_TRUE(params0.dtype.has_value());
+  ASSERT_EQ(params0.dtype.value(), mlir::tt::DataType::Float32);
+  ASSERT_TRUE(params0.activation.has_value());
+  ASSERT_EQ(params0.activation.value(), "none");
+
+  const auto &params1 = parsedOverride["op1"];
+  ASSERT_TRUE(params1.dtype.has_value());
+  ASSERT_EQ(params1.dtype.value(), mlir::tt::DataType::BFloat16);
+  ASSERT_TRUE(params1.weightsDtype.has_value());
+  ASSERT_EQ(params1.weightsDtype.value(), mlir::tt::DataType::BFloat16);
+  ASSERT_TRUE(params1.activation.has_value());
+  ASSERT_EQ(params1.activation.value(), "relu");
+  ASSERT_TRUE(params1.inputChannelsAlignment.has_value());
+  ASSERT_EQ(params1.inputChannelsAlignment.value(), 32);
+}
+
+TEST_F(Conv2dConfigOverrideTest, ParseInvalidActivation) {
+  std::string arg = "op0=activation#invalid_activation";
+
+  bool result = parser.parse(OverrideConv2dConfigOption,
+                             "override-conv2d-config", arg, parsedOverride);
+  ASSERT_TRUE(result);
+}
+
+TEST_F(Conv2dConfigOverrideTest, ParseInvalidShardLayout) {
+  std::string arg = "op0=shard_layout#invalid";
+
+  bool result = parser.parse(OverrideConv2dConfigOption,
+                             "override-conv2d-config", arg, parsedOverride);
+  ASSERT_TRUE(result);
+}
 
 TEST_F(OutputLayoutOverrideTest, ParseFullOutputLayoutOverride) {
   std::string arg = "op1=2x2:dram:interleaved:tile:f32";

--- a/test/unittests/Optimizer/TestOptimizerOverrides.cpp
+++ b/test/unittests/Optimizer/TestOptimizerOverrides.cpp
@@ -36,20 +36,20 @@ TEST_F(Conv2dConfigOverrideTest, ParseFullConv2dConfigOverride) {
                     "weights_dtype#bf16:"
                     "activation#relu:"
                     "input_channels_alignment#32:"
-                    "deallocate_activation#0:"
-                    "reallocate_halo_output#1:"
-                    "act_block_h_override#0:"
+                    "deallocate_activation#false:"
+                    "reallocate_halo_output#true:"
+                    "act_block_h_override#32:"
                     "act_block_w_div#1:"
-                    "reshard_if_not_optimal#0:"
-                    "override_sharding_config#0:"
+                    "reshard_if_not_optimal#false:"
+                    "override_sharding_config#false:"
                     "shard_layout#block_sharded:"
                     "core_grid#0:"
-                    "transpose_shards#1:"
+                    "transpose_shards#true:"
                     "output_layout#row_major:"
-                    "enable_act_double_buffer#0:"
-                    "enable_weights_double_buffer#0:"
-                    "enable_split_reader#0:"
-                    "enable_subblock_padding#0";
+                    "enable_act_double_buffer#false:"
+                    "enable_weights_double_buffer#false:"
+                    "enable_split_reader#false:"
+                    "enable_subblock_padding#false";
 
   bool result = parser.parse(OverrideConv2dConfigOption,
                              "override-conv2d-config", arg, parsedOverride);
@@ -71,7 +71,7 @@ TEST_F(Conv2dConfigOverrideTest, ParseFullConv2dConfigOverride) {
   ASSERT_TRUE(params.reallocateHaloOutput.has_value());
   ASSERT_TRUE(params.reallocateHaloOutput.value());
   ASSERT_TRUE(params.actBlockHOverride.has_value());
-  ASSERT_EQ(params.actBlockHOverride.value(), 0);
+  ASSERT_EQ(params.actBlockHOverride.value(), 32);
   ASSERT_TRUE(params.actBlockWDiv.has_value());
   ASSERT_EQ(params.actBlockWDiv.value(), 1);
   ASSERT_TRUE(params.reshardIfNotOptimal.has_value());


### PR DESCRIPTION
### Ticket
Closes #2712

### Problem description
Overrides for Conv2d Config Attribute should be added to the Optimizer.

### What's changed
- Option to override Conv2d Config has been added to ttir-to-ttnn-backend-pipeline
- CLI string format and a parser for Conv2d Config overrides have been defined
- Conv2d Config overrides are applied in LegalLayoutAnalysis
- Suffix to loc of toLayout op that is created in the pass has been added so that ttnn.conv2d op can have a unique loc 