### PR TITLE
Augment dma lowering pass

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
@@ -185,17 +185,12 @@ def TTIR_DMAOp : TTIR_GenericRegionOp<"dma",
 
       - Local to remote dram
       ```mlir
-      %tx = ttir.dma %src, %dst : (memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #dram>) -> !ttir.mem_tx
+      %tx = ttir.dma %src, %dst : (memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<1x1x6x8x!tt.tile<32x32, f32>, $tt.shard<...>, #dram>) -> !ttir.mem_tx
       ```
 
       - Remote dram to local
       ```mlir
-      %tx = ttir.dma %src, %dst : (memref<6x8x!tt.tile<32x32, f32>, #dram>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
-      ```
-
-      - Local to remote L1, e.g. core[1, 2]
-      ```mlir
-      %tx = ttir.dma %src, %dst, core[%c1, %c2] : (memref<6x8x!tt.tile<32x32, f32>, #dram>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+      %tx = ttir.dma %src, %dst : (memref<1x1x6x8x!tt.tile<32x32, f32>, #tt.shard<...>, #dram>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
       ```
 
       - Local to mcast, e.g. starting at offset core[1, 2] with mcast shape [4, 4] (src and dst have the same SSA value, implies NoC doesn't loopback)
@@ -231,10 +226,69 @@ _tx
 
     let arguments = (ins AnyNon0RankedMemRef:$src, OptionalAttr<AffineMapAttr>:$srcAffineMap, Variadic<Index>:$srcIndices,
                          AnyNon0RankedMemRef:$dst, OptionalAttr<AffineMapAttr>:$dstAffineMap, Variadic<Index>:$dstIndices,
-                         OptionalAttr<I64Attr>:$optNumElems, Variadic<Index>:$dstCoreIndex, Variadic<Index>:$mcastShape);
+                         OptionalAttr<I64Attr>:$optNumElems, Variadic<Index>:$mcastStartIndex, Variadic<Index>:$mcastShape);
     let results = (outs TTIR_MemTx:$result);
 
-    let assemblyFormat = [{ $src (`<` $srcAffineMap^ `>`)? (`[` $srcIndices^ `]`)? `,` $dst (`<` $dstAffineMap^ `>`)? (`[` $dstIndices^ `]`)? (`,` `core` `[` $dstCoreIndex^ `]`)? (`mcast` `[` $mcastShape^ `]`)? (`,` `<` $optNumElems^ `>`)? attr-dict `:` `(` type($src) `,` type($dst) `)` `->` type($result)}];
+    let builders =
+    [
+      // %tx = ttir.dma %src, %dst
+      OpBuilder<(ins "Value": $src, "Value": $dst),
+      [{
+        build($_builder, $_state, src, nullptr, dst);
+      }]>,
+      // %tx = ttir.dma %src<#map>, %dst
+      OpBuilder<(ins "Value": $src, "AffineMapAttr": $srcAffineMap, "Value": $dst),
+      [{
+        build($_builder, $_state, src, srcAffineMap, dst, ValueRange(), ValueRange());
+      }]>,
+      // %tx = ttir.dma %src<#map>, %dst core[%c0, %c1] mcast[%c2, %c3]
+      OpBuilder<(ins "Value": $src, "AffineMapAttr": $srcAffineMap, "Value": $dst, "ValueRange": $mcastStartIndex, "ValueRange": $mcastShape),
+      [{
+        build($_builder, $_state, $_builder.getType<MemTxType>(), src, srcAffineMap, ValueRange(), dst, nullptr, ValueRange(), nullptr, mcastStartIndex, mcastShape);
+      }]>,
+      // %tx = ttir.dma %src, %dst<#map>
+      OpBuilder<(ins "Value": $src, "Value": $dst, "AffineMapAttr": $dstAffineMap),
+      [{
+        build($_builder, $_state, $_builder.getType<MemTxType>(), src, nullptr, ValueRange(), dst, dstAffineMap, ValueRange(), nullptr, ValueRange(), ValueRange());
+      }]>,
+      // %tx = ttir.dma %src[%c0, %c1], %dst
+      OpBuilder<(ins "Value": $src, "ValueRange": $srcIndices, "Value": $dst),
+      [{
+        build($_builder, $_state, src, srcIndices, dst, ValueRange());
+      }]>,
+      // %tx = ttir.dma %src[%c0, %c1], %dst core[%c2, %c3] mcast[%c4, %c5]
+      OpBuilder<(ins "Value": $src, "ValueRange": $srcIndices, "Value": $dst, "ValueRange": $mcastStartIndex, "ValueRange": $mcastShape),
+      [{
+        build($_builder, $_state, $_builder.getType<MemTxType>(), src, nullptr, srcIndices, dst, nullptr, ValueRange(), nullptr, mcastStartIndex, mcastShape);
+      }]>,
+      // %tx = ttir.dma %src, %dst[%c0, %c1]
+      OpBuilder<(ins "Value": $src, "Value": $dst, "ValueRange": $dstIndices),
+      [{
+        build($_builder, $_state, src, ValueRange(), dst, dstIndices);
+      }]>,
+      // %tx = ttir.dma %src[%c0, %c1], %dst[%c2, %c3]
+      OpBuilder<(ins "Value": $src, "ValueRange": $srcIndices, "Value": $dst, "ValueRange": $dstIndices),
+      [{
+        build($_builder, $_state, src, srcIndices, dst, dstIndices, ValueRange(), ValueRange());
+      }]>,
+      // %tx = ttir.dma %src[%c0, %c1], %dst[%c2, %c3] core[%c4, %c5] mcast[%c6, %c7]
+      OpBuilder<(ins "Value": $src, "ValueRange": $srcIndices, "Value": $dst, "ValueRange": $dstIndices, "ValueRange": $mcastStartIndex, "ValueRange": $mcastShape),
+      [{
+        build($_builder, $_state, $_builder.getType<MemTxType>(), src, nullptr, srcIndices, dst, nullptr, dstIndices, nullptr, mcastStartIndex, mcastShape);
+      }]>,
+      // %tx = ttir.dma %src[%c0, %c1], %dst[%c2, %c3], <4>
+      OpBuilder<(ins "Value": $src, "ValueRange": $srcIndices, "Value": $dst, "ValueRange": $dstIndices, "size_t": $numElems),
+      [{
+        build($_builder, $_state, src, srcIndices, dst, dstIndices, ValueRange(), ValueRange(), numElems);
+      }]>,
+      // %tx = ttir.dma %src[%c0, %c1], %dst[%c2, %c3] core[%c4, %c5] mcast[%c6, %c7], <4>
+      OpBuilder<(ins "Value": $src, "ValueRange": $srcIndices, "Value": $dst, "ValueRange": $dstIndices, "ValueRange": $mcastStartIndex, "ValueRange": $mcastShape, "size_t": $numElems),
+      [{
+        build($_builder, $_state, $_builder.getType<MemTxType>(), src, nullptr, srcIndices, dst, nullptr, dstIndices, $_builder.getI64IntegerAttr(numElems), mcastStartIndex, mcastShape);
+      }]>,
+    ];
+
+    let assemblyFormat = [{ $src (`<` $srcAffineMap^ `>`)? (`[` $srcIndices^ `]`)? `,` $dst (`<` $dstAffineMap^ `>`)? (`[` $dstIndices^ `]`)? (`,` `core` `[` $mcastStartIndex^ `]` `mcast` `[` $mcastShape `]`)? (`,` `<` $optNumElems^ `>`)? attr-dict `:` `(` type($src) `,` type($dst) `)` `->` type($result)}];
 
     let hasVerifier = 1;
 

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -261,10 +261,12 @@ def TTIRGenericGenerateLoops : Pass<"ttir-generic-generate-loops", "::mlir::Modu
   }];
 }
 
-def TTIRGenericLowerAffineDMAs : Pass<"ttir-generic-lower-affine-dmas", "::mlir::ModuleOp"> {
-  let summary = "Lower DMA ops from their affine form to indexed form.";
+def TTIRGenericLowerDMAs : Pass<"ttir-generic-lower-dmas", "::mlir::ModuleOp"> {
+  let summary = "Lower DMA ops from their high level form to fully indexed form.";
   let description = [{
-    This pass lowers DMA ops from their affine form to indexed form. This is useful for doing analysis on the DMA
+    This pass lowers DMA ops from their high level forms to fully indexed form.
+
+    One important pattern is rewriting their affine form to indexed form. This is useful for doing analysis on the DMA
     ops and lowering them to an optimal loop nest of coalesced transactions.  This is acheived by sampling the affine
     map over the entire parent generic op iterator space. Note that the affine map provided to the DMA op must be
     one of the indexing maps of the parent generic op.

--- a/lib/Dialect/TTIR/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTIR/Transforms/CMakeLists.txt
@@ -7,7 +7,7 @@ add_mlir_dialect_library(MLIRTTIRTransforms
         GenericGenerateDatamovement.cpp
         GenericGenerateLoops.cpp
         GenericHWThreadSelection.cpp
-        GenericLowerAffineDMAs.cpp
+        GenericLowerDMAs.cpp
         AttachMetalLayout.cpp
         OptimizeTensorLayout.cpp
         HoistCPUOps.cpp

--- a/lib/Dialect/TTIR/Transforms/GenericGenerateDatamovement.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericGenerateDatamovement.cpp
@@ -85,12 +85,11 @@ public:
                          SmallVector<Value> coreIndex = {},
                          SmallVector<Value> mcastShape = {}) {
     return builder
-        .create<ttir::DMAOp>(loc, builder.getType<MemTxType>(), src,
+        .create<ttir::DMAOp>(loc, src,
                              operandIndexingMap
                                  ? AffineMapAttr::get(*operandIndexingMap)
                                  : nullptr,
-                             ValueRange(), dst, nullptr, ValueRange(), nullptr,
-                             coreIndex, mcastShape)
+                             dst, coreIndex, mcastShape)
         .getResult();
   }
 

--- a/lib/Dialect/TTIR/Transforms/GenericLowerDMAs.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericLowerDMAs.cpp
@@ -256,7 +256,7 @@ public:
     SmallVector<Value> dstIndices(dma.getDstIndices());
     Value zero = rewriter.create<arith::ConstantOp>(
         dma.getLoc(), rewriter.getIndexType(), rewriter.getIndexAttr(0));
-    while (srcIndices.size() < (size_t)dma.getSrcMemRefType().getRank()) {
+    while (srcIndices.size() < static_cast<size_t>(dma.getSrcMemRefType().getRank())) {
       srcIndices.push_back(zero);
     }
     while (dstIndices.size() < static_cast<size_t>(dma.getDstMemRefType().getRank())) {

--- a/lib/Dialect/TTIR/Transforms/GenericLowerDMAs.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericLowerDMAs.cpp
@@ -256,10 +256,12 @@ public:
     SmallVector<Value> dstIndices(dma.getDstIndices());
     Value zero = rewriter.create<arith::ConstantOp>(
         dma.getLoc(), rewriter.getIndexType(), rewriter.getIndexAttr(0));
-    while (srcIndices.size() < static_cast<size_t>(dma.getSrcMemRefType().getRank())) {
+    while (srcIndices.size() <
+           static_cast<size_t>(dma.getSrcMemRefType().getRank())) {
       srcIndices.push_back(zero);
     }
-    while (dstIndices.size() < static_cast<size_t>(dma.getDstMemRefType().getRank())) {
+    while (dstIndices.size() <
+           static_cast<size_t>(dma.getDstMemRefType().getRank())) {
       dstIndices.push_back(zero);
     }
     rewriter.replaceOpWithNewOp<ttir::DMAOp>(

--- a/lib/Dialect/TTIR/Transforms/GenericLowerDMAs.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericLowerDMAs.cpp
@@ -259,7 +259,7 @@ public:
     while (srcIndices.size() < (size_t)dma.getSrcMemRefType().getRank()) {
       srcIndices.push_back(zero);
     }
-    while (dstIndices.size() < (size_t)dma.getDstMemRefType().getRank()) {
+    while (dstIndices.size() < static_cast<size_t>(dma.getDstMemRefType().getRank())) {
       dstIndices.push_back(zero);
     }
     rewriter.replaceOpWithNewOp<ttir::DMAOp>(

--- a/lib/Dialect/TTIR/Transforms/GenericLowerDMAs.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericLowerDMAs.cpp
@@ -15,7 +15,7 @@
 #include <numeric>
 
 namespace mlir::tt::ttir {
-#define GEN_PASS_DEF_TTIRGENERICLOWERAFFINEDMAS
+#define GEN_PASS_DEF_TTIRGENERICLOWERDMAS
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h.inc"
 
 namespace {
@@ -169,9 +169,8 @@ public:
           SmallVector<Value> srcIndex =
               llvm::to_vector(llvm::concat<Value>(streamIndex, iters));
           return SmallVector<Value>{builder.create<ttir::DMAOp>(
-              dma.getLoc(), builder.getType<MemTxType>(), dma.getSrc(), nullptr,
-              srcIndex, dma.getDst(), nullptr, iters, nullptr,
-              dma.getDstCoreIndex(), dma.getMcastShape())};
+              dma.getLoc(), dma.getSrc(), srcIndex, dma.getDst(), iters,
+              dma.getMcastStartIndex(), dma.getMcastShape())};
         });
     return loopNest;
   }
@@ -222,9 +221,8 @@ public:
         static_cast<size_t>(ttmlir::utils::volume(memrefShardShape))) {
       // Fully coalesced, we can trivially lower.
       newDma = rewriter.create<ttir::DMAOp>(
-          dma.getLoc(), rewriter.getType<MemTxType>(), dma.getSrc(), nullptr,
-          streamIndex, dma.getDst(), nullptr, ValueRange(), nullptr,
-          dma.getDstCoreIndex(), dma.getMcastShape());
+          dma.getLoc(), dma.getSrc(), streamIndex, dma.getDst(),
+          dma.getMcastStartIndex(), dma.getMcastShape());
     } else {
       // Fallback to single tile gather for now, in the future we can chage this
       // to support more sophisticated gathering.
@@ -241,15 +239,52 @@ public:
 } // namespace
 
 namespace {
-class TTIRGenericLowerAffineDMAs
-    : public impl::TTIRGenericLowerAffineDMAsBase<TTIRGenericLowerAffineDMAs> {
+class TTIRGenericLowerToFullyIndexedDMARewritePattern
+    : public OpRewritePattern<DMAOp> {
 public:
-  using impl::TTIRGenericLowerAffineDMAsBase<
-      TTIRGenericLowerAffineDMAs>::TTIRGenericLowerAffineDMAsBase;
+  using OpRewritePattern<DMAOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(DMAOp dma,
+                                PatternRewriter &rewriter) const final {
+    if (dma.isAffine() || dma.isFullyIndexed()) {
+      // Lower to affine first.
+      // Or if it's already fully indexed, nothing to do.
+      return failure();
+    }
+
+    SmallVector<Value> srcIndices(dma.getSrcIndices());
+    SmallVector<Value> dstIndices(dma.getDstIndices());
+    Value zero = rewriter.create<arith::ConstantOp>(
+        dma.getLoc(), rewriter.getIndexType(), rewriter.getIndexAttr(0));
+    while (srcIndices.size() < (size_t)dma.getSrcMemRefType().getRank()) {
+      srcIndices.push_back(zero);
+    }
+    while (dstIndices.size() < (size_t)dma.getDstMemRefType().getRank()) {
+      dstIndices.push_back(zero);
+    }
+    rewriter.replaceOpWithNewOp<ttir::DMAOp>(
+        dma, dma.getResult().getType(), dma.getSrc(), nullptr, srcIndices,
+        dma.getDst(), nullptr, dstIndices,
+        rewriter.getI64IntegerAttr(dma.getNumElems()), dma.getMcastStartIndex(),
+        dma.getMcastShape());
+
+    return success();
+  }
+};
+} // namespace
+
+namespace {
+class TTIRGenericLowerDMAs
+    : public impl::TTIRGenericLowerDMAsBase<TTIRGenericLowerDMAs> {
+public:
+  using impl::TTIRGenericLowerDMAsBase<
+      TTIRGenericLowerDMAs>::TTIRGenericLowerDMAsBase;
 
   void runOnOperation() final {
     RewritePatternSet patterns(&getContext());
-    patterns.add<TTIRGenericLowerAffineDMAsRewritePattern>(&getContext());
+    patterns.add<TTIRGenericLowerAffineDMAsRewritePattern,
+                 TTIRGenericLowerToFullyIndexedDMARewritePattern>(
+        &getContext());
     if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       signalPassFailure();
     }

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -70,7 +70,7 @@ void createTTIRToTTMetalBackendPipeline(
   pm.addPass(mlir::tt::ttir::createTTIRGenericLinearizeMemref());
   pm.addPass(mlir::createLowerAffinePass());
   pm.addPass(mlir::tt::ttir::createTTIRGenericGenerateDatamovement());
-  pm.addPass(mlir::tt::ttir::createTTIRGenericLowerAffineDMAs());
+  pm.addPass(mlir::tt::ttir::createTTIRGenericLowerDMAs());
   pm.addPass(mlir::tt::ttir::createTTIRGenericHWThreadSelection());
   pm.addPass(mlir::tt::ttir::createTTIRGenericGenerateLoops());
   createOptimizationPasses(pm);

--- a/test/ttmlir/Dialect/TTIR/generic/affine_dma.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/affine_dma.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --tt-register-device --ttir-generic-lower-affine-dmas %s | FileCheck %s
+// RUN: ttmlir-opt --tt-register-device --ttir-generic-lower-dmas %s | FileCheck %s
 
 #dram = #tt.memory_space<dram>
 #l1_ = #tt.memory_space<l1>
@@ -21,7 +21,7 @@ func.func @matmul_single_core_stream(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>,
     // CHECK-DAG: [[core0:%.*]] = ttir.core_index(0)
     // CHECK-DAG: arith.muli
     // CHECK-DAG: arith.addi
-    // CHECK: ttir.dma %stream{{[_0-9]*}} [%{{.*}}, [[iter2]]]
+    // CHECK: ttir.dma %stream{{[_0-9]*}} [%{{.*}}, [[iter2]], %c0, %c0]
     %tx = ttir.dma %stream<#map1>, %cb0 : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
     ttir.dma_wait %tx
     ttir.yield %cb0 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
@@ -32,7 +32,7 @@ func.func @matmul_single_core_stream(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>,
     // CHECK-DAG: [[core1:%.*]] = ttir.core_index(1)
     // CHECK-DAG: arith.muli
     // CHECK-DAG: arith.addi
-    // CHECK: ttir.dma %stream{{[_0-9]*}} [[[iter2]], %{{.*}}]
+    // CHECK: ttir.dma %stream{{[_0-9]*}} [[[iter2]], %{{.*}}, %c0, %c0]
     %tx = ttir.dma %stream_2<#map2>, %cb1 : (memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
     ttir.dma_wait %tx
     ttir.yield %cb1 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
@@ -61,7 +61,7 @@ func.func @matmul_single_core_transpose(%arg0: memref<1x2x2x2x!tt.tile<32x32, f3
     // CHECK-DAG: [[core0:%.*]] = ttir.core_index(0)
     // CHECK-DAG: arith.muli
     // CHECK-DAG: arith.addi
-    // CHECK: ttir.dma %stream{{[_0-9]*}} [%{{.*}}, [[iter2]]]
+    // CHECK: ttir.dma %stream{{[_0-9]*}} [%{{.*}}, [[iter2]], %c0, %c0]
     %tx = ttir.dma %stream<#map1>, %cb0 : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
     ttir.dma_wait %tx
     ttir.yield %cb0 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
@@ -73,9 +73,9 @@ func.func @matmul_single_core_transpose(%arg0: memref<1x2x2x2x!tt.tile<32x32, f3
     // CHECK-DAG: arith.muli
     // CHECK-DAG: arith.addi
     // CHECK: ttir.null_tx
-    // CHECK-NEXT: scf.for
-    // CHECK-NEXT: scf.for
-    // CHECK-NEXT: ttir.dma %stream{{[_0-9]*}} [[[iter2]], %{{.*}}]
+    // CHECK-NEXT: scf.for [[for_iter_i:%[a-zA-Z0-9]*]] =
+    // CHECK-NEXT: scf.for [[for_iter_j:%[a-zA-Z0-9]*]] =
+    // CHECK-NEXT: ttir.dma %stream{{[_0-9]*}} [[[iter2]], %{{.*}}, [[for_iter_i]], [[for_iter_j]]]
     // CHECK: scf.yield
     // CHECK: scf.yield
     %tx = ttir.dma %stream_2<#map2>, %cb1 : (memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d1, d0, d3, d2) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
@@ -114,7 +114,7 @@ func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, 
       // CHECK-DAG: [[core0:%.*]] = ttir.core_index(0)
       // CHECK-DAG: arith.muli
       // CHECK-DAG: arith.addi
-      // CHECK: ttir.dma %stream{{[_0-9]*}} [%{{.*}}, [[iter2]]]
+      // CHECK: ttir.dma %stream{{[_0-9]*}} [%{{.*}}, [[iter2]], %c0, %c0]
       %tx = ttir.dma %stream<#map1>, %cb0 : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 24576 + d3 * 4096)>, #l1_>, memref<4x6x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
       ttir.dma_wait %tx
       ttir.semaphore_wait %sem0, %c3 reset %c0
@@ -140,7 +140,7 @@ func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, 
       // CHECK-DAG: [[core1:%.*]] = ttir.core_index(1)
       // CHECK-DAG: arith.muli
       // CHECK-DAG: arith.addi
-      // CHECK: ttir.dma %stream{{[_0-9]*}} [[[iter2]], %{{.*}}]
+      // CHECK: ttir.dma %stream{{[_0-9]*}} [[[iter2]], %{{.*}}, %c0, %c0]
       %tx = ttir.dma %stream_2<#map2>, %cb1 : (memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
       ttir.dma_wait %tx
       ttir.semaphore_wait %sem2, %c1 reset %c0
@@ -185,7 +185,7 @@ func.func @matmul_multi_core_dram_params(%arg0: memref<2x4x4x6x!tt.tile<32x32, f
       // CHECK-DAG: [[core0:%.*]] = ttir.core_index(0)
       // CHECK-DAG: arith.muli
       // CHECK-DAG: arith.addi
-      // CHECK: ttir.dma %stream{{[_0-9]*}} [%{{.*}}, [[iter2]]]
+      // CHECK: ttir.dma %stream{{[_0-9]*}} [%{{.*}}, [[iter2]], %c0, %c0]
       %tx = ttir.dma %stream<#map1>, %cb0 : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 24576 + d3 * 4096)>, #l1_>, memref<4x6x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
       ttir.dma_wait %tx
       ttir.semaphore_wait %sem0, %c3 reset %c0
@@ -211,7 +211,7 @@ func.func @matmul_multi_core_dram_params(%arg0: memref<2x4x4x6x!tt.tile<32x32, f
       // CHECK-DAG: [[core1:%.*]] = ttir.core_index(1)
       // CHECK-DAG: arith.muli
       // CHECK-DAG: arith.addi
-      // CHECK: ttir.dma %stream{{[_0-9]*}} [[[iter2]], %{{.*}}]
+      // CHECK: ttir.dma %stream{{[_0-9]*}} [[[iter2]], %{{.*}}, %c0, %c0]
       %tx = ttir.dma %stream_2<#map2>, %cb1 : (memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #dram>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
       ttir.dma_wait %tx
       ttir.semaphore_wait %sem2, %c1 reset %c0


### PR DESCRIPTION
Augment the existing lower affine dma pass to also lower to fully indexed form.  This simplifies backend conversion because now there is only 1 form of dma style to lower.

Additionally remove one of the supported dma forms that is redundant with another, preferred, way to represent the same thing. Add new and clean up verification messages and add builders for all DMA variants.