### PR TITLE
Fix macos build

### DIFF
--- a/include/ttmlir/Utils.h
+++ b/include/ttmlir/Utils.h
@@ -577,6 +577,9 @@ inline std::string firstNLines(std::string str, int n) {
   return result;
 }
 
+template <typename...>
+struct False : std::bool_constant<false> {};
+
 } // namespace ttmlir::utils
 
 #endif // TTMLIR_UTILS_H

--- a/include/ttmlir/Utils.h
+++ b/include/ttmlir/Utils.h
@@ -578,7 +578,9 @@ inline std::string firstNLines(std::string str, int n) {
 }
 
 template <typename...>
-struct False : std::bool_constant<false> {};
+constexpr bool always_false() {
+  return false;
+}
 
 } // namespace ttmlir::utils
 

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -626,7 +626,7 @@ createNamedFullOp(FlatbufferObjectCache &cache, OpTy op) {
   } else if constexpr (std::is_same_v<OpTy, ttnn::OnesOp>) {
     type = ::tt::target::ttnn::NamedFullOpType::Ones;
   } else {
-    static_assert(ttmlir::utils::False<OpTy>::value,
+    static_assert(ttmlir::utils::always_false<OpTy>(),
                   "Unsupported NamedFullOp type");
   }
 

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -626,7 +626,8 @@ createNamedFullOp(FlatbufferObjectCache &cache, OpTy op) {
   } else if constexpr (std::is_same_v<OpTy, ttnn::OnesOp>) {
     type = ::tt::target::ttnn::NamedFullOpType::Ones;
   } else {
-    static_assert(false, "Unsupported NamedFullOp type");
+    static_assert(ttmlir::utils::False<OpTy>::value,
+                  "Unsupported NamedFullOp type");
   }
 
   ::flatbuffers::Offset<::flatbuffers::Vector<int64_t>> shape =


### PR DESCRIPTION
Using `static_assert(false);` only came into the standard as part of c++23. In order to support some older compilers, as a workaround the same objective can be accomplished by introducing a dependent type.

https://cplusplus.github.io/CWG/issues/2518.html