### PR TITLE
Fixing ones op conversion

### DIFF
--- a/test/ttmlir/EmitC/TTNN/tensor/ones.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/ones.mlir
@@ -2,9 +2,6 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
 // RUN: ttmlir-opt --ttnn-modify-signatures-for-dylib --convert-ttnn-to-emitc %t.mlir > %t2.mlir
 // RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
-//
-// UNSUPPORTED: true
-// Outstanding bug: https://github.com/tenstorrent/tt-mlir/issues/2072
 
 func.func @ones() -> tensor<13x24x56x42xbf16> {
   %0 = "ttir.ones"() <{shape = array<i32:13, 24, 56, 42>}> : () -> tensor<13x24x56x42xbf16>


### PR DESCRIPTION
### Ticket
Part of the following issue:
https://github.com/tenstorrent/tt-mlir/issues/2072

### Problem description
One's op emitted IDevice instead of OptionalAnyDevice.

### What's changed
Emition changed from IDevice to OptionalAnyDevice.

### Checklist
- [x] New/Existing tests provide coverage for changes
