### PR TITLE
ci_compile_dylib script improvements

### DIFF
--- a/docs/src/emitc-testing.md
+++ b/docs/src/emitc-testing.md
@@ -1,14 +1,39 @@
 # EmitC testing
 
-To locally run EmitC tests:
+## Prerequisites
 
-```bash
-# Generate flatbuffers and .cpp files
-llvm-lit -sv test/ttmlir/EmitC/TTNN
+* [Built ttmlir](https://docs.tenstorrent.com/tt-mlir/build.html#build)
+* [Built ttrt](https://docs.tenstorrent.com/tt-mlir/ttrt.html#building)
+* Saved system descriptor file:
 
-# Compile .cpp files to shared objects
-tools/ttnn-standalone/ci_compile_dylib.py
+  ```bash
+  ttrt query --save-artifacts
+  ```
 
-# Run flatbuffers + shared objects and compare results
-ttrt run --emitc build/test/ttmlir/EmitC/TTNN
-```
+## Generate EmitC tests and run it
+
+1. Generate flatbuffers and .cpp files for EmitC tests
+
+    If you don't have SYSTEM_DESC_PATH environment variable exported, you can run:
+
+    ```bash
+    SYSTEM_DESC_PATH=/path/to/system_desc.ttsys llvm-lit -sv test/ttmlir/EmitC/TTNN
+    ```
+
+    Or if you have SYSTEM_DESC_PATH exported, you can omit it:
+
+    ```bash
+    llvm-lit -sv test/ttmlir/EmitC/TTNN
+    ```
+
+2. Compile generated .ccp files to shared objects
+
+    ```python
+    python tools/ttnn-standalone/ci_compile_dylib.py
+    ```
+
+3. Run flatbuffers + shared objects and compare results
+
+    ```bash
+    ttrt run --emitc build/test/ttmlir/EmitC/TTNN
+    ```

--- a/docs/src/emitc-testing.md
+++ b/docs/src/emitc-testing.md
@@ -9,6 +9,11 @@
   ```bash
   ttrt query --save-artifacts
   ```
+* Activated virtual environment:
+
+  ```bash
+  source env/activate
+  ```
 
 ## Generate EmitC tests and run it
 
@@ -26,10 +31,10 @@
     llvm-lit -sv test/ttmlir/EmitC/TTNN
     ```
 
-2. Compile generated .ccp files to shared objects
+2. Compile generated .cpp files to shared objects
 
     ```python
-    python tools/ttnn-standalone/ci_compile_dylib.py
+    tools/ttnn-standalone/ci_compile_dylib.py
     ```
 
 3. Run flatbuffers + shared objects and compare results


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/2095

### Problem description
There are a couple of problems in the ci_compile_dylib.py script described in the above issue.

### What's changed
This PR adds the ability to specify a different build directory and provides an option to compile a single C++ file instead of a whole group. It also polishes the MD file on how to run the emitC tests locally.

### Checklist
- [ ] New/Existing tests provide coverage for changes
