### PR TITLE
Improve flatbuffer header generation logic

### DIFF
--- a/cmake/modules/BuildFlatbuffers.cmake
+++ b/cmake/modules/BuildFlatbuffers.cmake
@@ -18,10 +18,11 @@ foreach(FILE ${sources})
     "${CMAKE_CURRENT_BINARY_DIR}/${BASE_NAME}_generated.h"
     "${CMAKE_CURRENT_BINARY_DIR}/${BASE_NAME}_bfbs_generated.h"
     COMMAND ${FLATBUFFERS_COMPILER}
-    ARGS -I ${PROJECT_SOURCE_DIR}/include/ttmlir/Target
+    ARGS -I ${PROJECT_SOURCE_DIR}/include/
     ARGS --bfbs-gen-embed
     ARGS --cpp --cpp-std c++17
     ARGS --scoped-enums --warnings-as-errors
+    ARGS --keep-prefix
     ARGS -o "${CMAKE_CURRENT_BINARY_DIR}/" "${FILE}"
     DEPENDS ${FILE} ${deps} ${sources}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/include/ttmlir/Target/Common/debug_info.fbs
+++ b/include/ttmlir/Target/Common/debug_info.fbs
@@ -1,4 +1,4 @@
-include "Common/types.fbs";
+include "ttmlir/Target/Common/types.fbs";
 
 namespace tt.target;
 

--- a/include/ttmlir/Target/Common/system_desc.fbs
+++ b/include/ttmlir/Target/Common/system_desc.fbs
@@ -1,5 +1,5 @@
-include "types.fbs";
-include "version.fbs";
+include "ttmlir/Target/Common/types.fbs";
+include "ttmlir/Target/Common/version.fbs";
 
 namespace tt.target;
 

--- a/include/ttmlir/Target/TTMetal/binary.fbs
+++ b/include/ttmlir/Target/TTMetal/binary.fbs
@@ -1,8 +1,8 @@
-include "Common/types.fbs";
-include "Common/version.fbs";
-include "Common/debug_info.fbs";
-include "command.fbs";
-include "types.fbs";
+include "ttmlir/Target/Common/types.fbs";
+include "ttmlir/Target/Common/version.fbs";
+include "ttmlir/Target/Common/debug_info.fbs";
+include "ttmlir/Target/TTMetal/command.fbs";
+include "ttmlir/Target/TTMetal/types.fbs";
 
 namespace tt.target.metal;
 

--- a/include/ttmlir/Target/TTMetal/command.fbs
+++ b/include/ttmlir/Target/TTMetal/command.fbs
@@ -1,5 +1,5 @@
-include "program.fbs";
-include "types.fbs";
+include "ttmlir/Target/TTMetal/program.fbs";
+include "ttmlir/Target/TTMetal/types.fbs";
 
 namespace tt.target.metal;
 

--- a/include/ttmlir/Target/TTMetal/program.fbs
+++ b/include/ttmlir/Target/TTMetal/program.fbs
@@ -1,5 +1,5 @@
-include "Common/types.fbs";
-include "types.fbs";
+include "ttmlir/Target/Common/types.fbs";
+include "ttmlir/Target/TTMetal/types.fbs";
 
 namespace tt.target.metal;
 

--- a/include/ttmlir/Target/TTMetal/types.fbs
+++ b/include/ttmlir/Target/TTMetal/types.fbs
@@ -1,4 +1,4 @@
-include "Common/types.fbs";
+include "ttmlir/Target/Common/types.fbs";
 
 namespace tt.target.metal;
 

--- a/include/ttmlir/Target/TTNN/binary.fbs
+++ b/include/ttmlir/Target/TTNN/binary.fbs
@@ -1,7 +1,7 @@
-include "Common/types.fbs";
-include "Common/version.fbs";
-include "program.fbs";
-include "types.fbs";
+include "ttmlir/Target/Common/types.fbs";
+include "ttmlir/Target/Common/version.fbs";
+include "ttmlir/Target/TTNN/program.fbs";
+include "ttmlir/Target/TTNN/types.fbs";
 
 namespace tt.target.ttnn;
 

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -1,6 +1,6 @@
-include "Common/types.fbs";
-include "Common/debug_info.fbs";
-include "types.fbs";
+include "ttmlir/Target/Common/types.fbs";
+include "ttmlir/Target/Common/debug_info.fbs";
+include "ttmlir/Target/TTNN/types.fbs";
 
 namespace tt.target.ttnn;
 

--- a/include/ttmlir/Target/TTNN/types.fbs
+++ b/include/ttmlir/Target/TTNN/types.fbs
@@ -1,4 +1,4 @@
-include "Common/types.fbs";
+include "ttmlir/Target/Common/types.fbs";
 
 namespace tt.target.ttnn;
 

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -9,6 +9,7 @@
 #include "ttmlir/Dialect/TT/Utils/CoreRangeSet.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/Target/Common/Target.h"
+#include "ttmlir/Target/TTNN/Target.h"
 #include "ttmlir/Target/Utils/FlatbufferObjectCache.h"
 #include "ttmlir/Utils.h"
 

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -23,5 +23,3 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         MLIRTTNNAnalysis
         MLIRTTDialect
         )
-
-target_include_directories(MLIRTTNNTransforms PUBLIC ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common)

--- a/lib/Target/TTKernel/CMakeLists.txt
+++ b/lib/Target/TTKernel/CMakeLists.txt
@@ -12,5 +12,3 @@ add_mlir_translation_library(TTKernelTargetCpp
     MLIRSCFToEmitC
     MLIRArithToEmitC
 )
-
-target_include_directories(TTKernelTargetCpp PUBLIC ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common)

--- a/lib/Target/TTMetal/CMakeLists.txt
+++ b/lib/Target/TTMetal/CMakeLists.txt
@@ -12,5 +12,3 @@ add_mlir_translation_library(TTMetalTargetFlatbuffer
     MLIRTTDialect
     TTMLIRTTKernelToEmitC
 )
-
-target_include_directories(TTMetalTargetFlatbuffer PUBLIC ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common)

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -28,7 +28,6 @@
 #include "ttmlir/Target/Utils/FlatbufferObjectCache.h"
 #include "ttmlir/Target/Utils/MLIRToFlatbuffer.h"
 #include "ttmlir/Version.h"
-#include "types_generated.h"
 
 namespace mlir::tt {
 flatbuffers::Offset<::tt::target::metal::MemoryDesc>

--- a/lib/Target/TTNN/CMakeLists.txt
+++ b/lib/Target/TTNN/CMakeLists.txt
@@ -13,5 +13,3 @@ add_mlir_translation_library(TTNNTargetFlatbuffer
     MLIRTTNNTransforms
     TTMLIRTTNNToEmitC
 )
-
-target_include_directories(TTNNTargetFlatbuffer PUBLIC ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common)


### PR DESCRIPTION
### Problem description
Currently, when including other FlatBuffers schemas in a FlatBuffers schema, such as in `include/ttmlir/Target/TTNN/types.fbs`, it looks like this:
```
include "Common/types.fbs";
```
The generated header for `include/ttmlir/Target/TTNN/types.fbs`, located at `build/include/ttmlir/Target/TTNN/types_generated.h`, will include the generated header for `include/ttmlir/Target/Common/types.fbs`, located at `build/include/ttmlir/Target/Common/types_generated.h`, as follows:
```
#include "types_generated.h";
```
This is problematic because they do not reside in the same folder. As a workaround, we have to configure CMake in multiple places to avoid build issues:
```
target_include_directories(TTMetalTargetFlatbuffer PUBLIC ${PROJECT_BINARY_DIR}/include/ttmlir/Target/Common)
```

### What's changed
Added the `--keep-prefix` flag when calling the FlatBuffers compiler:
```
--keep-prefix: Keep original prefix of schema include statement.
```
Now, in the example, the include statement in `include/ttmlir/Target/TTNN/types.fbs` should look like this:
```
include "ttmlir/Target/Common/types.fbs";
```
In the generated header, the #include directive will include the prepended prefix `ttmlir/Target/Common` and it will in line with the way we do C++ headers.
```
#include "ttmlir/Target/Common/types_generated.h"
```

