### PR TITLE
Added More BinOps + BoolOp Support in PyKernel

### DIFF
--- a/python/pykernel/pykernel_ast.py
+++ b/python/pykernel/pykernel_ast.py
@@ -263,9 +263,9 @@ class TTKernelCompiler(ast.NodeVisitor):
         # NOTE: else-if blocks are not supported in SCF dialect
         # NOTE: Only handling Compare for if statements right now
         # TODO: if cond can be: Name, Expr, Compare, Call, UnaryOp, BoolOp
-        assert isinstance(
-            node.test, ast.Compare
-        ), "Only Compare supported in if statements"
+        # assert isinstance(
+        #     node.test, ast.Compare
+        # ), "Only Compare supported in if statements"
         if_cond = self.visit(node.test)
         # if not if_cond.result.type.width == 1 or not if_cond.result.type.is_signless:
         # if_cond = arith.TruncIOp(IntegerType.get_signless(1), if_cond) # temporary since expr not implemented yet
@@ -458,6 +458,59 @@ class TTKernelCompiler(ast.NodeVisitor):
         # NOTE: will catch function calls and expressions where return values not used.
         return self.visit(node.value)
 
+    def visit_BoolOp(self, node):
+        values = [self.visit(arg) for arg in node.values]
+
+        # Make sure that each of the values are booleans
+        for i in range(len(values)):
+            value = values[i]
+            value_type = None
+            if hasattr(value, "type") and isinstance(value.type, memref.MemRefType):
+                value = memref.LoadOp(
+                    value, arith.ConstantOp(IndexType.get(self.ctx), 0)
+                ).result
+                value_type = value.type
+            elif hasattr(value, "type") and isinstance(value.type, IntegerType):
+                value_type = value.type
+            elif isinstance(value, arith.ConstantOp):
+                value_type = value.type
+
+            if value_type is None:
+                raise ValueError(
+                    "BoolOp values must be MemRef, ConstantOp, or IntegerType"
+                )
+
+            if not isinstance(value_type, IntegerType):
+                raise ValueError(
+                    "BoolOp values must be MemRef or ConstantOp of IntegerType"
+                )
+
+            if value_type.width != 1:
+                # Set the value to 1 if not equal to 0, otherwise 0. This is the C-style way
+                values[i] = arith.cmpi(
+                    arith.CmpIPredicate.ne, value, arith.ConstantOp(value_type, 0)
+                )
+
+        # Chain all of the comparisons together
+        def _match_bool_op(lhs, rhs):
+            # We will know and assume LHS and RHS are booleans
+            match (node.op):
+                case ast.And():
+                    return arith.andi(lhs, rhs)
+                case ast.Or():
+                    return arith.ori(lhs, rhs)
+                case _:
+                    raise NotImplementedError(f"BoolOp {node.op} not supported")
+
+        # Atleast 2 Ops must exist in BoolOp
+        chained_op = _match_bool_op(values[0], values[1])
+
+        # Chain all of the remaining values
+        for i in range(2, len(values)):
+            chained_op = _match_bool_op(chained_op, values[i])
+
+        return chained_op
+
     def visit_BinOp(self, node):
         # TODO: need to load MemRef types when using variables
         # TODO: need to handle float, unsigned, and signed operations
@@ -482,6 +535,20 @@ class TTKernelCompiler(ast.NodeVisitor):
                 return arith.subi(lhs, rhs)
             case ast.Mult():
                 return arith.muli(lhs, rhs)
+            case ast.FloorDiv():
+                return arith.floordivsi(lhs, rhs)
+            case ast.Mod():
+                return arith.remsi(lhs, rhs)
+            case ast.LShift():
+                return arith.shli(lhs, rhs)
+            case ast.RShift():
+                return arith.shrsi(lhs, rhs)
+            case ast.BitOr():
+                return arith.ori(lhs, rhs)
+            case ast.BitAnd():
+                return arith.andi(lhs, rhs)
+            case ast.BitXor():
+                return arith.xori(lhs, rhs)
             # case ast.Div(): # only worried about integers right now
             # return arith.divf(lhs, rhs)
             case _:
@@ -601,7 +668,7 @@ class TTKernelCompiler(ast.NodeVisitor):
             raise NotImplementedError(f"visit {type(node).__name__} not supported")
 
 
-def ttkernel_compile(kernel_type=None, verbose: bool = False):
+def ttkernel_compile(kernel_type=None, verbose: bool = False, optimize: bool = True):
     def _decorator(f):
         @functools.wraps(f)
         def _wrapper(*args, **kwargs):
@@ -620,8 +687,9 @@ def ttkernel_compile(kernel_type=None, verbose: bool = False):
             b.module.operation.verify()
 
             # Run the PyKernel Compile Pipeline to fit model for Translation
-            pykernel_compile_pipeline(b.module)
-            print("---- Optimized PyKernel Module ----", b.module, sep="\n\n")
+            if optimize:
+                pykernel_compile_pipeline(b.module)
+                print("---- Optimized PyKernel Module ----", b.module, sep="\n\n")
 
             if kernel_type:
                 assert kernel_type in ["noc", "tensix"], "Invalid kernel type"
@@ -634,9 +702,9 @@ def ttkernel_compile(kernel_type=None, verbose: bool = False):
     return _decorator
 
 
-def ttkernel_tensix_compile(verbose: bool = False):
-    return ttkernel_compile(kernel_type="tensix", verbose=verbose)
+def ttkernel_tensix_compile(verbose: bool = False, optimize: bool = True):
+    return ttkernel_compile(kernel_type="tensix", verbose=verbose, optimize=optimize)
 
 
-def ttkernel_noc_compile(verbose: bool = False):
-    return ttkernel_compile(kernel_type="noc", verbose=verbose)
+def ttkernel_noc_compile(verbose: bool = False, optimize: bool = True):
+    return ttkernel_compile(kernel_type="noc", verbose=verbose, optimize=optimize)

--- a/test/pykernel/unit_tests.py
+++ b/test/pykernel/unit_tests.py
@@ -121,10 +121,32 @@ def test_binops():
     # CHECK: %{{.*}} = arith.muli{{.*}}
     # CHECK: %{{.*}} = arith.subi{{.*}}
     a + b - a * b
+
+    # CHECK: %{{.*}} = arith.floordivsi{{.*}}
+    a // b
+
+    # CHECK: %{{.*}} = arith.remsi{{.*}}
+    a % b
+
+    # CHECK: %{{.*}} = arith.shrsi{{.*}}
+    a >> b
+
+    # CHECK: %{{.*}} = arith.shli{{.*}}
+    a << b
+
+    # CHECK: %{{.*}} = arith.andi{{.*}}
+    a & b
+
+    # CHECK: %{{.*}} = arith.ori{{.*}}
+    a | b
+
+    # CHECK: %{{.*}} = arith.xori{{.*}}
+    a ^ b
+
     return
 
 
-@ttkernel_compile()
+@ttkernel_compile(optimize=False)
 def test_compare_expr():
     # CHECK: module {
     # CHECK: func.func @
@@ -142,6 +164,34 @@ def test_compare_expr():
     a > b
     # CHECK: %{{.*}} = arith.cmpi sge{{.*}}
     a >= b
+    return
+
+
+@ttkernel_compile(optimize=False)
+def test_bool_ops():
+    # CHECK: module {
+    # CHECK: func.func @
+    a = 1
+    b = 2
+    # CHECK: %{{.*}} = arith.cmpi sge{{.*}}
+    # CHECK: %{{.*}} = arith.cmpi sle{{.*}}
+    # CHECK: %{{.*}} = arith.andi {{.*}}
+    a >= b and b <= a
+
+    # CHECK: %{{.*}} = arith.cmpi sgt{{.*}}
+    # CHECK: %{{.*}} = arith.cmpi ne{{.*}}
+    # CHECK: %{{.*}} = arith.andi {{.*}}
+    # CHECK: %{{.*}} = arith.cmpi ne{{.*}}
+    # CHECK: %{{.*}} = arith.ori {{.*}}
+    a or b and a > b
+
+    # CHECK: %{{.*}} = arith.cmpi slt{{.*}}
+    # CHECK: %{{.*}} = arith.andi {{.*}}
+    # CHECK: %{{.*}} = arith.ori {{.*}}
+    # CHECK: %{{.*}} = arith.ori {{.*}}
+    # CHECK: %{{.*}} = arith.andi {{.*}}
+    # CHECK: %{{.*}} = arith.ori {{.*}}
+    False and (a < b) or False and (True or False or False)
     return
 
 
@@ -180,4 +230,5 @@ test_ifstmt()
 test_for()
 test_binops()
 test_compare_expr()
+test_bool_ops()
 test_unary_ops()

--- a/test/pykernel/unit_tests.py
+++ b/test/pykernel/unit_tests.py
@@ -31,7 +31,7 @@ def test_assign():
     return
 
 
-@ttkernel_compile()
+@ttkernel_compile(optimize=False)
 def test_ifstmt():
     # CHECK: module {
     # CHECK: func.func @
@@ -68,6 +68,19 @@ def test_ifstmt():
     a = 1
     b = 2
     c = 3
+
+    # CHECK: %[[COND2:.*]] = arith.cmpi ne{{.*}}
+    # CHECK: scf.if %[[COND2]]{{.*}}
+    if a:
+        # CHECK: memref.store {{.*}}
+        a = 2
+
+    # CHECK: %{{.*}} = arith.cmpi sgt{{.*}}
+    # CHECK: %[[COND3:.*]] = arith.andi {{.*}}
+    # CHECK: scf.if %[[COND3]]{{.*}}
+    if True and a > 10:
+        # CHECK: memref.store {{.*}}
+        a = 2
     return
 
 


### PR DESCRIPTION
### Ticket
- PR closes #1823 
- PR closes #1825 
- PR closes #1826 
- PR closes #1827 
- PR closes #1828 
- PR closes #1829 
- PR closes #1830 
- PR closes #1831 
- PR closes #1832 

### Problem description
- Certain niche BinOps + all BoolOps weren't supported before. They are needed to increase support for defining conditionals in if and while blocks.

### What's changed
- Added Support in PyKernel AST + Unit Tests for New BinOps + BoolOps.
