### PR TITLE
Introduce new workaround for all_reduce op.

### DIFF
--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -368,7 +368,7 @@ public:
       const int64_t sizeLimit = 200000;
       int64_t tensorSize = inputType.getNumElements();
       if (tensorSize < sizeLimit) {
-        return rewriteAsAllGatherLocalReduce(op, rewriter, meshShape);
+        return rewriteAsAllGatherLocalReduce(op, meshShape, rewriter);
       }
     }
 
@@ -462,8 +462,9 @@ public:
 
 private:
   LogicalResult
-  rewriteAsAllGatherLocalReduce(ttnn::AllReduceOp op, PatternRewriter &rewriter,
-                                ::llvm::ArrayRef<int64_t> meshShape) const {
+  rewriteAsAllGatherLocalReduce(ttnn::AllReduceOp op,
+                                ::llvm::ArrayRef<int64_t> meshShape,
+                                PatternRewriter &rewriter) const {
     RankedTensorType inputType =
         mlir::cast<RankedTensorType>(op.getInput().getType());
     Location loc = op.getLoc();
@@ -478,7 +479,7 @@ private:
     ArrayAttr reshapedInputShapeAttr =
         rewriter.getI32ArrayAttr(llvm::SmallVector<int32_t>(
             expandedInputShape.begin(), expandedInputShape.end()));
-    auto reshapedInputType =
+    RankedTensorType reshapedInputType =
         RankedTensorType::Builder(inputType).setShape(expandedInputShape);
 
     ttnn::ReshapeOp leadingReshapeOp = rewriter.create<ttnn::ReshapeOp>(

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -368,7 +368,7 @@ public:
       // blowup, enforce a size constraint based on DRAM capacity.
       if (exceedsAllGatherReduceMemLimit(getCurrentScopeSystemDesc(op),
                                          inputType, meshShape[clusterAxis],
-                                         0.1)) {
+                                         0.05)) {
         return rewriteAsAllGatherLocalReduce(op, meshShape, rewriter);
       }
     }

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -524,7 +524,7 @@ private:
   bool exceedsAllGatherReduceMemLimit(tt::SystemDescAttr systemDesc,
                                       RankedTensorType inputType,
                                       int64_t numOfDevicesInCluster,
-                                      float memoryLimitFactor = 0.1) const {
+                                      float memoryLimitFactor = 0.05) const {
     // Estimate additional memory required when using AllGather + LocalReduce,
     // compared to the baseline ReduceScatter + AllGather breakdown.
     //
@@ -561,13 +561,13 @@ private:
         inputTensorSize;
 
     // Additional memory required
-    double delta = static_cast<double>(memAllgatherLocalReduce) -
-                   memReduceScatterAllGather;
+    double overhead = static_cast<double>(memAllgatherLocalReduce) -
+                      memReduceScatterAllGather;
 
     // Compare against memory limit threshold
     double threshold = static_cast<double>(dramCapacity) * memoryLimitFactor;
 
-    return delta <= threshold;
+    return overhead <= threshold;
   }
 };
 

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -465,8 +465,7 @@ private:
   rewriteAsAllGatherLocalReduce(ttnn::AllReduceOp op,
                                 ::llvm::ArrayRef<int64_t> meshShape,
                                 PatternRewriter &rewriter) const {
-    RankedTensorType inputType =
-        mlir::cast<RankedTensorType>(op.getInput().getType());
+    RankedTensorType inputType = op.getInput().getType();
     Location loc = op.getLoc();
     uint32_t clusterAxis = op.getClusterAxis();
     Value deviceValue = op.getDevice();
@@ -483,7 +482,7 @@ private:
         RankedTensorType::Builder(inputType).setShape(expandedInputShape);
 
     ttnn::ReshapeOp leadingReshapeOp = rewriter.create<ttnn::ReshapeOp>(
-        loc, Type(reshapedInputType), op.getInput(), reshapedInputShapeAttr,
+        loc, reshapedInputType, op.getInput(), reshapedInputShapeAttr,
         /* memory_config */ nullptr);
 
     // Create a new all gather op.
@@ -492,8 +491,8 @@ private:
         RankedTensorType::Builder(reshapedInputType)
             .setShape(expandedInputShape);
     ttnn::AllGatherOp allGatherOp = rewriter.create<ttnn::AllGatherOp>(
-        loc, Type(allGatherOutputType), leadingReshapeOp.getResult(),
-        deviceValue, 0, clusterAxis);
+        loc, allGatherOutputType, leadingReshapeOp.getResult(), deviceValue, 0,
+        clusterAxis);
     // Create a new reduce op.
     ArrayAttr reduceDimAttr =
         rewriter.getI32ArrayAttr(llvm::ArrayRef<int32_t>{0});

--- a/test/ttmlir/Dialect/TTNN/ccl/all_reduce/all_reduce_positive.mlir
+++ b/test/ttmlir/Dialect/TTNN/ccl/all_reduce/all_reduce_positive.mlir
@@ -118,17 +118,17 @@ module attributes {} {
 
 // Verify breakdown of all_reduce into all_gather and local reduce memory limit
 // Reduce_Scatter + All_Gather breakdown need to be used for this case due to memory limitation
-// 1x38x256x515xf32 tensor needs additional 1292559360 bytes of memory when we use all_gather + local reduce breakdown
-// It exceedes 10% of DRAM capacity limit : 1288488960 bytes with default system descriptor
+// 1x38x128x515xf32 tensor needs additional 646279680 bytes of memory when we use all_gather + local reduce breakdown
+// It exceedes 5% of DRAM capacity limit : 644244480 bytes with default system descriptor
 
 module attributes {} {
   // CHECK-LABEL: all_reduce_positive_with_non_divisible_dimensions_over_memory_limit
-  func.func @all_reduce_positive_with_non_divisible_dimensions_over_memory_limit(%arg0: tensor<1x38x256x515xf32>) -> tensor<1x38x256x515xf32> {
-    %0 = ttir.empty() : tensor<1x38x256x515xf32>
-    %1 = "ttir.all_reduce"(%arg0, %0) <{cluster_axis = 1 : ui32, reduce_type = #tt.reduce_type<sum>}> : (tensor<1x38x256x515xf32>, tensor<1x38x256x515xf32>) -> tensor<1x38x256x515xf32>
+  func.func @all_reduce_positive_with_non_divisible_dimensions_over_memory_limit(%arg0: tensor<1x38x128x515xf32>) -> tensor<1x38x128x515xf32> {
+    %0 = ttir.empty() : tensor<1x38x128x515xf32>
+    %1 = "ttir.all_reduce"(%arg0, %0) <{cluster_axis = 1 : ui32, reduce_type = #tt.reduce_type<sum>}> : (tensor<1x38x128x515xf32>, tensor<1x38x128x515xf32>) -> tensor<1x38x128x515xf32>
     // CHECK: "ttnn.reduce_scatter"
     // CHECK: "ttnn.all_gather"
     // CHECK-NOT: "ttnn.sum"
-    return %1 : tensor<1x38x256x515xf32>
+    return %1 : tensor<1x38x128x515xf32>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/ccl/all_reduce/all_reduce_positive.mlir
+++ b/test/ttmlir/Dialect/TTNN/ccl/all_reduce/all_reduce_positive.mlir
@@ -118,33 +118,16 @@ module attributes {} {
 
 // Verify breakdown of all_reduce into all_gather and local reduce memory limit
 // Reduce_Scatter + All_Gather breakdown need to be used for this case due to memory limitation
-// 1x50x64x63x == 201600  (limit: 200000)
+// 1x32x256x1229xf32 needs 1288699904 bytes (limit: 1288488960 with default system descriptor)
+
 module attributes {} {
   // CHECK-LABEL: all_reduce_positive_with_non_divisible_dimensions_over_memory_limit
-  func.func @all_reduce_positive_with_non_divisible_dimensions_over_memory_limit(%arg0: tensor<1x50x64x63xf32>) -> tensor<1x50x64x63xf32> {
-    %0 = ttir.empty() : tensor<1x50x64x63xf32>
-    %1 = "ttir.all_reduce"(%arg0, %0) <{cluster_axis = 1 : ui32, reduce_type = #tt.reduce_type<sum>}> : (tensor<1x50x64x63xf32>, tensor<1x50x64x63xf32>) -> tensor<1x50x64x63xf32>
+  func.func @all_reduce_positive_with_non_divisible_dimensions_over_memory_limit(%arg0: tensor<1x32x256x1229xf32>) -> tensor<1x32x256x1229xf32> {
+    %0 = ttir.empty() : tensor<1x32x256x1229xf32>
+    %1 = "ttir.all_reduce"(%arg0, %0) <{cluster_axis = 1 : ui32, reduce_type = #tt.reduce_type<sum>}> : (tensor<1x32x256x1229xf32>, tensor<1x32x256x1229xf32>) -> tensor<1x32x256x1229xf32>
     // CHECK: "ttnn.reduce_scatter"
     // CHECK: "ttnn.all_gather"
     // CHECK-NOT: "ttnn.sum"
-    return %1 : tensor<1x50x64x63xf32>
-  }
-}
-
-
-// -----
-
-// Verify breakdown of all_reduce into all_gather and local reduce memory limit
-// All_Gather + Local_Reduce breakdown need to be used for this case
-// 1x48x64x63x == 193536  (limit: 200000)
-module attributes {} {
-  // CHECK-LABEL: all_reduce_positive_with_non_divisible_dimensions_under_memory_limit
-  func.func @all_reduce_positive_with_non_divisible_dimensions_under_memory_limit(%arg0: tensor<1x48x64x63xf32>) -> tensor<1x48x64x63xf32> {
-    %0 = ttir.empty() : tensor<1x48x64x63xf32>
-    %1 = "ttir.all_reduce"(%arg0, %0) <{cluster_axis = 1 : ui32, reduce_type = #tt.reduce_type<sum>}> : (tensor<1x48x64x63xf32>, tensor<1x48x64x63xf32>) -> tensor<1x48x64x63xf32>
-    // CHECK-NOT: "ttnn.reduce_scatter"
-    // CHECK: "ttnn.all_gather"
-    // CHECK: "ttnn.sum"
-    return %1 : tensor<1x48x64x63xf32>
+    return %1 : tensor<1x32x256x1229xf32>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/ccl/all_reduce/all_reduce_positive.mlir
+++ b/test/ttmlir/Dialect/TTNN/ccl/all_reduce/all_reduce_positive.mlir
@@ -118,16 +118,17 @@ module attributes {} {
 
 // Verify breakdown of all_reduce into all_gather and local reduce memory limit
 // Reduce_Scatter + All_Gather breakdown need to be used for this case due to memory limitation
-// 1x32x256x1229xf32 needs 1288699904 bytes (limit: 1288488960 with default system descriptor)
+// 1x38x256x515xf32 tensor needs additional 1292559360 bytes of memory when we use all_gather + local reduce breakdown
+// It exceedes 10% of DRAM capacity limit : 1288488960 bytes with default system descriptor
 
 module attributes {} {
   // CHECK-LABEL: all_reduce_positive_with_non_divisible_dimensions_over_memory_limit
-  func.func @all_reduce_positive_with_non_divisible_dimensions_over_memory_limit(%arg0: tensor<1x32x256x1229xf32>) -> tensor<1x32x256x1229xf32> {
-    %0 = ttir.empty() : tensor<1x32x256x1229xf32>
-    %1 = "ttir.all_reduce"(%arg0, %0) <{cluster_axis = 1 : ui32, reduce_type = #tt.reduce_type<sum>}> : (tensor<1x32x256x1229xf32>, tensor<1x32x256x1229xf32>) -> tensor<1x32x256x1229xf32>
+  func.func @all_reduce_positive_with_non_divisible_dimensions_over_memory_limit(%arg0: tensor<1x38x256x515xf32>) -> tensor<1x38x256x515xf32> {
+    %0 = ttir.empty() : tensor<1x38x256x515xf32>
+    %1 = "ttir.all_reduce"(%arg0, %0) <{cluster_axis = 1 : ui32, reduce_type = #tt.reduce_type<sum>}> : (tensor<1x38x256x515xf32>, tensor<1x38x256x515xf32>) -> tensor<1x38x256x515xf32>
     // CHECK: "ttnn.reduce_scatter"
     // CHECK: "ttnn.all_gather"
     // CHECK-NOT: "ttnn.sum"
-    return %1 : tensor<1x32x256x1229xf32>
+    return %1 : tensor<1x38x256x515xf32>
   }
 }


### PR DESCRIPTION
### Ticket
Closes #2675 

### Problem description
We decompose all_reduce into reduce_scatter and all_gather as a workaround. However, reduce_scatter requires that the size along scatter_dim be divisible by the number of devices. This constraint propagates back to all_reduce, limiting our ability to compile certain models. In cases where this divisibility requirement is not met, compilation can fail.

### What's changed
Added a new decomposition path for the AllReduce TTIR op using AllGather + local Reduce.
This serves as an alternative to the existing ReduceScatter + AllGather workaround.
The new decomposition is applied when:
 - The tensor shape along the scatter_dim is not divisible by the number of devices, or
 - The input tensor is smaller than heuristically found size_limit

### Checklist
- [x] New/Existing tests provide coverage for changes
