### PR TITLE
On community PR send message to slack

### DIFF
--- a/.github/workflows/on-community-issue.yml
+++ b/.github/workflows/on-community-issue.yml
@@ -3,11 +3,12 @@ name: "Issue Notification"
 on:
   issues:
     types: [opened]
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 jobs:
   gh-slack-bridge:
+    if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -17,28 +18,26 @@ jobs:
         id: set-variables
         run: |
           if [ "${{ github.event_name }}" = "issues" ]; then
-            echo "USERNAME=${{ github.event.issue.user.login }}" >> $GITHUB_ENV
-            echo "NUMBER=${{ github.event.issue.number }}" >> $GITHUB_ENV
-            echo "EVENT_URL=${{ github.event.issue.html_url }}" >> $GITHUB_ENV
-            echo "EVENT_TYPE=issue" >> $GITHUB_ENV
-            echo "GH_COMMAND=issue" >> $GITHUB_ENV
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "USERNAME=${{ github.event.pull_request.user.login }}" >> $GITHUB_ENV
-            echo "NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
-            echo "EVENT_URL=${{ github.event.pull_request.html_url }}" >> $GITHUB_ENV
-            echo "EVENT_TYPE=PR" >> $GITHUB_ENV
-            echo "GH_COMMAND=pr" >> $GITHUB_ENV
+            echo "USERNAME=${{ github.event.issue.user.login }}" >> $GITHUB_OUTPUT
+            echo "NUMBER=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
+            echo "EVENT_URL=${{ github.event.issue.html_url }}" >> $GITHUB_OUTPUT
+            echo "EVENT_TYPE=issue" >> $GITHUB_OUTPUT
+            echo "GH_COMMAND=issue" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" = "pull_request_target" ]; then
+            echo "USERNAME=${{ github.event.pull_request.user.login }}" >> $GITHUB_OUTPUT
+            echo "NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+            echo "EVENT_URL=${{ github.event.pull_request.html_url }}" >> $GITHUB_OUTPUT
+            echo "EVENT_TYPE=PR" >> $GITHUB_OUTPUT
+            echo "GH_COMMAND=pr" >> $GITHUB_OUTPUT
           elif [ "${{ github.event_name }}" = "push" ]; then
-            echo "USERNAME=${{ github.actor }}" >> $GITHUB_ENV
-            echo "EVENT_URL=https://github.com/${{ github.repository }}/commit/${{ github.sha }}" >> $GITHUB_ENV
-            echo "EVENT_TYPE=push" >> $GITHUB_ENV
+            echo "USERNAME=${{ github.actor }}" >> $GITHUB_OUTPUT
+            echo "EVENT_URL=https://github.com/${{ github.repository }}/commit/${{ github.sha }}" >> $GITHUB_OUTPUT
+            echo "EVENT_TYPE=push" >> $GITHUB_OUTPUT
           fi
       - name: Check if organization member
         id: is_organization_member
-        env:
-          GITHUB_ORG: tenstorrent
         run: |
-          http_status=$(curl -o /dev/null -s -w '%{http_code}' -H "Authorization: Bearer ${{ secrets.ORG_READ_GITHUB_TOKEN }}" https://api.github.com/orgs/${{ env.GITHUB_ORG }}/members/${{ env.USERNAME }})
+          http_status=$(curl -o /dev/null -s -w '%{http_code}' -H "Authorization: Bearer ${{ secrets.ORG_READ_GITHUB_TOKEN }}" https://api.github.com/orgs/tenstorrent/members/${{ steps.set-variables.outputs.USERNAME }})
           if [ "$http_status" -eq 204 ]; then
             echo "Detected org member"
             echo "is_member=true" >> $GITHUB_OUTPUT
@@ -47,9 +46,9 @@ jobs:
             echo "is_member=false" >> $GITHUB_OUTPUT
           fi
       - name: Add community label
-        if: ${{ steps.is_organization_member.outputs.is_member == 'false' && env.GH_COMMAND && env.NUMBER }}
+        if: ${{ steps.is_organization_member.outputs.is_member == 'false' && steps.set-variables.outputs.GH_COMMAND && steps.set-variables.outputs.NUMBER }}
         run: |
-          gh ${{env.GH_COMMAND}} edit ${{ env.NUMBER }} --add-label ${{ env.LABELS }}
+          gh ${{steps.set-variables.outputs.GH_COMMAND}} edit ${{ steps.set-variables.outputs.NUMBER }} --add-label ${{ env.LABELS }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
@@ -60,7 +59,7 @@ jobs:
         with:
           payload: |
             {
-              "text": "A new ${{ env.EVENT_TYPE }} has been created by a non-org member `${{ env.USERNAME }}`: ${{ env.EVENT_URL }}",
+              "text": "A new ${{ steps.set-variables.outputs.EVENT_TYPE }} has been created by a non-org member `${{ steps.set-variables.outputs.USERNAME }}`: ${{ steps.set-variables.outputs.EVENT_URL }}",
               "channel": "C07R5GYEW8J"
             }
         env:


### PR DESCRIPTION
### Ticket
slack issue "External PR notification not working"

### Problem description
When PR is opened, it can't run workflows and doesn't send notifications to slack.

### What's changed
used pull_request_target which runs in PR's context and thus can run.
