### PR TITLE
Element type normalization pass

### DIFF
--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -413,4 +413,22 @@ def TTIRHoistTransform: Pass<"ttir-cpu-hoist-transform", "::mlir::ModuleOp">
   let dependentDialects = ["::mlir::tt::TTDialect"];
 }
 
+def ElementTypeNormalization: Pass<"ttir-element-type-normalization", "::mlir::ModuleOp">
+{
+  let summary = "Normalize element types into list of supported types.";
+  let description = [{
+    "This pass walks through the graph and normalizes the element types into a list of supported types. This is useful for lowering
+        to a target that only supports a subset of the element types.
+  }];
+
+  let options = [
+    Option<"enableFP32", "enable-fp32",
+          "bool",
+          /*default=*/"true",
+          "Enables fp32 type.">
+  ];
+
+  let dependentDialects = ["::mlir::tt::TTDialect",  "::mlir::tt::ttir::TTIRDialect", "::mlir::func::FuncDialect"];
+}
+
 #endif

--- a/include/ttmlir/Dialect/TTIR/Utils/UniformTypeRewriter.h
+++ b/include/ttmlir/Dialect/TTIR/Utils/UniformTypeRewriter.h
@@ -36,7 +36,7 @@ public:
 
   bool convertFuncType(Operation *op, PatternRewriter &rewriter) const {
     auto funcOp = dyn_cast<func::FuncOp>(op);
-    if (not funcOp) {
+    if (!funcOp) {
       return false;
     }
     SmallVector<Type> inputTypes(funcOp.getArgumentTypes());
@@ -52,6 +52,10 @@ public:
       return false;
     }
     funcOp.setFunctionType(newType);
+
+    if (funcOp.isDeclaration()) {
+      return true;
+    }
 
     Block &entryBlock = funcOp.getBody().front();
     for (unsigned i = 0; i < entryBlock.getNumArguments(); ++i) {

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1467,6 +1467,8 @@ class TTNN_NamedFullOp<string mnemonic, list<Trait> traits = []> :
                        OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
 
   let results = (outs AnyRankedTensor:$result);
+
+  let hasVerifier = 1;
 }
 
 def TTNN_ZerosOp : TTNN_NamedFullOp<"zeros"> {

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -169,6 +169,10 @@ struct TTIRToTTNNBackendPipelineOptions
       *this, "enable-remove-dead-values",
       llvm::cl::desc("Enable --remove-dead-values optimization pass."),
       llvm::cl::init(false)};
+
+  Option<bool> enableFP32{*this, "enable-fp32",
+                          llvm::cl::desc("Enable fp32 type."),
+                          llvm::cl::init(true)};
 };
 
 // TTIR to EmitC pipeline options.

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -211,7 +211,10 @@ mlir::tt::ttir::GetDimensionSizeOp::fold(FoldAdaptor adaptor) {
   uint32_t dimensionIndex = getDimension();
   uint32_t dimSize = inputTensorType.getShape()[dimensionIndex];
 
-  return mlir::DenseElementsAttr::get<uint32_t>(getType(), dimSize);
+  auto resultElType = IntegerType::get(
+      getContext(), 32, IntegerType::SignednessSemantics::Unsigned);
+  auto resultType = RankedTensorType::get(/*shape=*/{1}, resultElType);
+  return mlir::DenseElementsAttr::get<uint32_t>(resultType, dimSize);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTIR/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTIR/Transforms/CMakeLists.txt
@@ -13,6 +13,7 @@ add_mlir_dialect_library(MLIRTTIRTransforms
         HoistCPUOps.cpp
         Bufferization.cpp
         Layout.cpp
+        ElementTypeNormalization.cpp
         Transforms.cpp
 
         ADDITIONAL_HEADER_DIRS

--- a/lib/Dialect/TTIR/Transforms/ElementTypeNormalization.cpp
+++ b/lib/Dialect/TTIR/Transforms/ElementTypeNormalization.cpp
@@ -8,7 +8,7 @@
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Rewrite/FrozenRewritePatternSet.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/WalkPatternRewriteDriver.h"
 
 namespace mlir::tt::ttir {
 #define GEN_PASS_DEF_ELEMENTTYPENORMALIZATION
@@ -54,10 +54,7 @@ struct ElementTypeNormalization
     RewritePatternSet patterns(&getContext());
     ElementTypeConverter converter(enableFP32);
     patterns.add<UniformTypeRewriter>(converter, &getContext());
-    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
-      signalPassFailure();
-      return;
-    }
+    walkAndApplyPatterns(getOperation(), std::move(patterns));
   }
 };
 } // namespace

--- a/lib/Dialect/TTIR/Transforms/ElementTypeNormalization.cpp
+++ b/lib/Dialect/TTIR/Transforms/ElementTypeNormalization.cpp
@@ -28,8 +28,12 @@ public:
       // support uint8.
       if (bitWidth == 1) {
         elementType = BFloat16Type::get(context);
-      } else if (enableFP32 && isa<FloatType>(elementType) && bitWidth >= 32) {
-        elementType = Float32Type::get(context);
+      } else if (isa<FloatType>(elementType) && bitWidth >= 32) {
+        if (enableFP32) {
+          elementType = Float32Type::get(context);
+        } else {
+          elementType = BFloat16Type::get(context);
+        }
       } else {
         elementType =
             dataTypeToElementType(context, elementTypeToDataType(elementType));

--- a/lib/Dialect/TTIR/Transforms/ElementTypeNormalization.cpp
+++ b/lib/Dialect/TTIR/Transforms/ElementTypeNormalization.cpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TT/IR/TT.h"
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
+#include "ttmlir/Dialect/TTIR/Utils/UniformTypeRewriter.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Rewrite/FrozenRewritePatternSet.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir::tt::ttir {
+#define GEN_PASS_DEF_ELEMENTTYPENORMALIZATION
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h.inc"
+
+namespace {
+class ElementTypeConverter : public TypeConverter {
+public:
+  ElementTypeConverter(bool enableFP32) {
+    addConversion([](Type type) -> Type { return type; });
+    addConversion([enableFP32](RankedTensorType type) -> RankedTensorType {
+      Type elementType = type.getElementType();
+      size_t bitWidth = type.getElementTypeBitWidth();
+      MLIRContext *context = elementType.getContext();
+
+      // Convert bools to bf16, since not all ttnn ops
+      // support uint8.
+      if (bitWidth == 1) {
+        elementType = BFloat16Type::get(context);
+      } else if (enableFP32 && isa<FloatType>(elementType) && bitWidth >= 32) {
+        elementType = Float32Type::get(context);
+      } else {
+        elementType =
+            dataTypeToElementType(context, elementTypeToDataType(elementType));
+      }
+
+      SmallVector<int64_t> shape(type.getShape());
+      if (shape.empty()) {
+        shape = {1};
+      }
+
+      return RankedTensorType::get(shape, elementType);
+    });
+  }
+};
+
+struct ElementTypeNormalization
+    : public impl::ElementTypeNormalizationBase<ElementTypeNormalization> {
+  using impl::ElementTypeNormalizationBase<
+      ElementTypeNormalization>::ElementTypeNormalizationBase;
+
+  void runOnOperation() final {
+    RewritePatternSet patterns(&getContext());
+    ElementTypeConverter converter(enableFP32);
+    patterns.add<UniformTypeRewriter>(converter, &getContext());
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+      signalPassFailure();
+      return;
+    }
+  }
+};
+} // namespace
+
+} // namespace mlir::tt::ttir

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -545,10 +545,6 @@ static ::mlir::LogicalResult namedOpVerify(Op op) {
   return namedOpVerify(*this);
 }
 
-//===----------------------------------------------------------------------===//
-// OnesOp
-//===----------------------------------------------------------------------===//
-
 ::mlir::LogicalResult mlir::tt::ttnn::OnesOp::verify() {
   return namedOpVerify(*this);
 }

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -518,6 +518,42 @@ namespace mlir::tt::ttnn {
 }
 
 //===----------------------------------------------------------------------===//
+// NamedFullOp
+//===----------------------------------------------------------------------===//
+
+template <typename Op>
+static ::mlir::LogicalResult namedOpVerify(Op op) {
+  RankedTensorType output = op.getResult().getType();
+  if (op.getDtype()) {
+    if (op.getDtype() != elementTypeToDataType(output.getElementType())) {
+      return op.emitOpError("Data type mismatch between op and output tensor.");
+    }
+  }
+
+  ArrayRef<int64_t> shape = op.getShape().getShape();
+  ArrayRef<int64_t> outputShape = output.getShape();
+
+  if (shape != outputShape) {
+    return op.emitOpError("Output tensor shape must be ")
+           << shape << ", but got " << outputShape;
+  }
+
+  return success();
+}
+
+::mlir::LogicalResult mlir::tt::ttnn::ZerosOp::verify() {
+  return namedOpVerify(*this);
+}
+
+//===----------------------------------------------------------------------===//
+// OnesOp
+//===----------------------------------------------------------------------===//
+
+::mlir::LogicalResult mlir::tt::ttnn::OnesOp::verify() {
+  return namedOpVerify(*this);
+}
+
+//===----------------------------------------------------------------------===//
 // EmptyOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -144,6 +144,9 @@ void createTTIRToTTNNBackendPipeline(
     OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options) {
   // Create DeviceModule to wrap all ops.
   pm.addPass(tt::createTTWrapDeviceModulePass());
+  ttir::ElementTypeNormalizationOptions normalizationOptions{
+      options.enableFP32};
+  pm.addPass(ttir::createElementTypeNormalization(normalizationOptions));
   // Create CPUModuleOp to wrap hoisted ops (if any).
   pm.addPass(ttir::createTTIRHoistTransform());
 

--- a/test/ttmlir/Dialect/TTIR/Decomposition/get_dimension_size_decomposition.mlir
+++ b/test/ttmlir/Dialect/TTIR/Decomposition/get_dimension_size_decomposition.mlir
@@ -2,7 +2,7 @@
 module  {
   func.func @get_dimension_size_decomposition(%arg0: tensor<32x64x128xf32>) -> tensor<1xi32> {
     // CHECK: [[VAL:%.+]] = "ttir.constant"
-    // CHECK-SAME: value = dense<128> : tensor<1xi32>
+    // CHECK-SAME: value = dense<128> : tensor<1xui32>
     // CHECK: return [[VAL]] : tensor<1xi32>
     %0 = "ttir.get_dimension_size"(%arg0) <{dimension = 2 : i32}> : (tensor<32x64x128xf32>) -> tensor<1xi32>
     return %0 : tensor<1xi32>


### PR DESCRIPTION
* Adding pass which will be common place for canonicalization of all input mlir types into compiler
* Adding override flag for enabling f32 type - we plan to use bf16 for all float types since is more TT hardware friendly. Until I fix all tests to use bf16 I will leave this override to on
* Fixed `GetDimensionSizeOp::fold` - Currently, this folder creates a DenseElementsAttr with C++ type uint32_t and uses the result type of GetDimensionSizeOp (obtained via getType()) as the MLIR type for constructing the attribute. However, if that type happens to be a signed integer (e.g., si32), MLIR’s verification logic asserts, since it expects the C++ element type and the MLIR type to be consistent.
Because our pass converts si32 to i32 (signless), this mismatch causes a verification error during constant folding.

To do in next PR:
* Fixup all tests - majority of tests rely on f32 types in their checks
* Remove type conversion from shlo
