### PR TITLE
Add workaround that prevents permute from operating on integers

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1647,6 +1647,15 @@ def TTNN_PermuteOp : TTNN_Op<"permute"> {
     let results = (outs AnyRankedTensor:$result);
 
     let hasVerifier = 1;
+
+    let extraClassDeclaration = [{
+      wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
+        return
+          wa::TTNNOperandsWorkaroundsFactory::createPermuteOpOperandWorkaround(
+            getInput().getType()
+          );
+      }
+    }];
 }
 
 def TTNN_UpsampleOp : TTNN_Op<"upsample"> {

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkarounds.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkarounds.h
@@ -275,6 +275,10 @@ public:
   static TTNNOperandsWorkarounds
   createPadOpOperandsWorkarounds(mlir::TypedValue<mlir::RankedTensorType> input,
                                  ttnn::TTNNLayoutAttr layoutAttr);
+
+  // Create workaround for permute op operands.
+  static TTNNOperandsWorkarounds
+  createPermuteOpOperandWorkaround(mlir::RankedTensorType inputType);
 };
 
 } // namespace mlir::tt::ttnn::wa

--- a/lib/Dialect/TTNN/IR/TTNNWorkarounds.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkarounds.cpp
@@ -511,4 +511,22 @@ TTNNOperandsWorkaroundsFactory::createPadOpOperandsWorkarounds(
       .addOutputOperandWorkaround(operandWorkaround);
 }
 
+// ttnn.permute will not work correctly on 32-bit integers. This workaround will
+// typecast the 32-bit integers to 32-bit floats before the ttnn.permute op and
+// typecast the output back.
+// tt-metal issue: https://github.com/tenstorrent/tt-metal/issues/19950
+TTNNOperandsWorkarounds
+TTNNOperandsWorkaroundsFactory::createPermuteOpOperandWorkaround(
+    mlir::RankedTensorType inputType) {
+  TTNNOperandWorkarounds operandWorkaround;
+  if (auto elementType = dyn_cast<IntegerType>(inputType.getElementType());
+      elementType && elementType.getWidth() == 32) {
+    operandWorkaround.tensorDataTypeWorkaround = DataType::Float32;
+  }
+
+  return wa::TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
+      .addInputOperandWorkaround(operandWorkaround)
+      .addOutputOperandWorkaround(operandWorkaround);
+}
+
 } // namespace mlir::tt::ttnn::wa

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/permute_dtype_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/permute_dtype_workaround.mlir
@@ -1,0 +1,17 @@
+// RUN: ttmlir-opt --tt-register-device="system-desc-path=%system_desc_path%" --ttnn-workaround %s | FileCheck %s
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 64 + d1, d2), <1x1>, memref<64x4x!tt.tile<32x32, si32>, #dram>, <interleaved>>
+#ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 128 + d1, d2), <1x1>, memref<256x1x!tt.tile<32x32, si32>, #dram>, <interleaved>>
+module attributes {} {
+  func.func @permute_general(%arg0: tensor<32x64x128xsi32, #ttnn_layout>) -> tensor<64x128x32xsi32, #ttnn_layout1> {
+    // CHECK: %[[LAYOUT_TYPE_CAST0:[0-9]+]] = "ttnn.to_layout"(%arg0
+    // CHECK-SAME: dtype = #tt.supportedDataTypes<f32>
+    // CHECK-SAME: -> tensor<32x64x128xf32
+    // CHECK: %[[PERMUTE:[0-9]+]] = "ttnn.permute"(%[[LAYOUT_TYPE_CAST0]])
+    %0 = "ttnn.permute"(%arg0) <{permutation = array<i64: 1, 2, 0>}> : (tensor<32x64x128xsi32, #ttnn_layout>) -> tensor<64x128x32xsi32, #ttnn_layout1>
+    // CHECK: %[[LAYOUT_TYPE_CAST1:[0-9]+]] = "ttnn.to_layout"(%[[PERMUTE]]
+    // CHECK-SAME: dtype = #tt.supportedDataTypes<si32>
+    // CHECK-SAME: -> tensor<64x128x32xsi32
+    return %0 : tensor<64x128x32xsi32, #ttnn_layout1>
+  }
+}


### PR DESCRIPTION
### Ticket
tt-metal issue: https://github.com/tenstorrent/tt-metal/issues/19950

### Problem description
ttnn.permute is not supported for 32-bit signed/unsigned integers, however the op will execute without error if you do pass an input in this data type.

### What's changed
Added a workaround to cast 32-bit integer permute inputs to float32, then back to integer.

### Checklist
- [X] New/Existing tests provide coverage for changes
