### PR TITLE
Hacky workaround for a decode error when using ttrt on specific graphs

### DIFF
--- a/runtime/tools/python/ttrt/binary/__init__.py
+++ b/runtime/tools/python/ttrt/binary/__init__.py
@@ -16,4 +16,9 @@ import json
 
 
 def as_dict(bin):
-    return json.loads(bin.as_json())
+    tmp = bin.as_json()
+    # Flatbuffers emits 'nan' and 'inf'
+    # But Python's JSON accepts only 'NaN' and 'Infinity' and nothing else
+    tmp = tmp.replace('nan', 'NaN')
+    tmp = tmp.replace('inf', 'Infinity')
+    return json.loads(tmp)

--- a/runtime/tools/python/ttrt/binary/__init__.py
+++ b/runtime/tools/python/ttrt/binary/__init__.py
@@ -19,6 +19,6 @@ def as_dict(bin):
     tmp = bin.as_json()
     # Flatbuffers emits 'nan' and 'inf'
     # But Python's JSON accepts only 'NaN' and 'Infinity' and nothing else
-    tmp = tmp.replace('nan', 'NaN')
-    tmp = tmp.replace('inf', 'Infinity')
+    tmp = tmp.replace("nan", "NaN")
+    tmp = tmp.replace("inf", "Infinity")
     return json.loads(tmp)

--- a/runtime/tools/python/ttrt/binary/__init__.py
+++ b/runtime/tools/python/ttrt/binary/__init__.py
@@ -19,6 +19,7 @@ def as_dict(bin):
     tmp = bin.as_json()
     # Flatbuffers emits 'nan' and 'inf'
     # But Python's JSON accepts only 'NaN' and 'Infinity' and nothing else
-    tmp = tmp.replace("nan", "NaN")
-    tmp = tmp.replace("inf", "Infinity")
+    # We include the comma to avoid replacing 'inf' in contexts like 'info'
+    tmp = tmp.replace("nan,", "NaN,")
+    tmp = tmp.replace("inf,", "Infinity,")
     return json.loads(tmp)

--- a/test/ttmlir/Silicon/TTNN/n150/simple_constant.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_constant.mlir
@@ -26,6 +26,11 @@ module @sysmem_creation attributes {} {
     return %0 : tensor<1x1xf32>
   }
 
+  func.func @test_neginf_float() -> tensor<1xf32> {
+    %0 = "ttir.constant"() <{value = dense<0xFF800000> : tensor<1xf32>}> : () -> tensor<1xf32>
+    return %0 : tensor<1xf32>
+  }
+
   func.func @test_full_int() -> tensor<64x128xi32> {
     %0 = "ttir.constant"() <{value = dense<1> : tensor<64x128xi32>}> : () -> tensor<64x128xi32>
     // CHECK: = "ttnn.full"


### PR DESCRIPTION
### Ticket
fixes #838 

### Problem description
ttrt would error out with a JsonDecodeError if a constant op contained infinity or a NaN value. This is because the way flatbuffer emits those values and what Python's json library expect do not match up(fb happily emits `inf` and `nan`, meanwhile Python refuses to accept anything else but `Infinity` and `NaN`)

### What's changed
Now we manually replace flatbuffer's textual representation with what Python expects. Very hacky in my opinion, but I don't have a better fix in mind.

### Checklist
- [X] New/Existing tests provide coverage for changes
