### PR TITLE
Fix asm parser bug in loading TensorMeshShardingAttr

### DIFF
--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -494,14 +494,14 @@ def TT_TensorMeshShardingAttr : TT_Attr<"TensorMeshSharding", "mesh_sharding", [
 
       (ii) multi-device tensor with tensor mesh shard axis indicate all devices in "mesh"
           have sharded tensor defined by the TensorMeshShardingAxisAttr. e.g., 192x16384 for
-            tensor<784x16384xf32, #tt.mesh_sharding<"mesh" : [ 4(1),  1]>>.
+            tensor<784x16384xf32, #tt.mesh_sharding<"mesh", [ 4(1),  1]>>.
           Here, 4(1) indicates shard_shape(shard_dim), so 784 should be sharded by 4
           at "mesh"'s second hardware dimension. 1 indicates no sharding, so 16384 is not
           being sharded.
   }];
   let parameters = (ins "StringAttr":$name,
                         OptionalArrayRefParameter<"TensorMeshShardingAxisAttr">:$tensor_mesh_sharding_axis);
-  let assemblyFormat = "`<` $name (`:` `[`$tensor_mesh_sharding_axis^`]`)? `>`";
+  let assemblyFormat = "`<` $name (`,` `[` $tensor_mesh_sharding_axis^ `]` )? `>`";
 
   let extraClassDeclaration = [{
       static TensorMeshShardingAttr get(::mlir::MLIRContext *context, StringRef name) {

--- a/test/ttmlir/Conversion/StableHLOToTTIR/ccl/ccl_ops_shardy.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/ccl/ccl_ops_shardy.mlir
@@ -331,8 +331,8 @@ module @jit_matmul_shardy_automatic_test1 attributes {mhlo.num_partitions = 8 : 
   }
 }
 // CHECK-LABEL @main
-// CHECK: %arg{{[0-9]+}}: tensor<8192x784xf32, #tt.mesh_sharding<"mesh" : [ 2(0),  4(1)]>>
-// CHECK-SAME: %arg{{[0-9]+}}: tensor<784x16384xf32, #tt.mesh_sharding<"mesh" : [ 4(1),  1]>>
+// CHECK: %arg{{[0-9]+}}: tensor<8192x784xf32, #tt.mesh_sharding<"mesh", [ 2(0),  4(1)]>>
+// CHECK-SAME: %arg{{[0-9]+}}: tensor<784x16384xf32, #tt.mesh_sharding<"mesh", [ 4(1),  1]>>
 // CHECK-NOT: tensor<8192x16384xf32, #tt.mesh_sharding<"mesh">>
 // CHECK-SAME: tensor<8192x16384xf32>
 
@@ -341,7 +341,7 @@ module @jit_matmul_shardy_automatic_test1 attributes {mhlo.num_partitions = 8 : 
 // CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
 // CHECK-SAME: shard_shape = array<i64: 2, 4>
 // CHECK-SAME: shard_type = #tt.shard_type<identity>
-// CHECK-SAME: tensor<8192x784xf32, #tt.mesh_sharding<"mesh" : [ 2(0),  4(1)]>>
+// CHECK-SAME: tensor<8192x784xf32, #tt.mesh_sharding<"mesh", [ 2(0),  4(1)]>>
 // CHECK-SAME: tensor<4096x196xf32, #tt.mesh_sharding<"mesh">>
 // CHECK-SAME: tensor<4096x196xf32, #tt.mesh_sharding<"mesh">>
 
@@ -350,7 +350,7 @@ module @jit_matmul_shardy_automatic_test1 attributes {mhlo.num_partitions = 8 : 
 // CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
 // CHECK-SAME: shard_shape = array<i64: 4, 1>
 // CHECK-SAME: shard_type = #tt.shard_type<identity>
-// CHECK-SAME: tensor<784x16384xf32, #tt.mesh_sharding<"mesh" : [ 4(1),  1]>>
+// CHECK-SAME: tensor<784x16384xf32, #tt.mesh_sharding<"mesh", [ 4(1),  1]>>
 // CHECK-SAME: tensor<196x16384xf32, #tt.mesh_sharding<"mesh">>
 // CHECK-SAME: tensor<196x16384xf32, #tt.mesh_sharding<"mesh">>
 
@@ -389,16 +389,16 @@ module @jit_matmul_shardy_automatic_test2 attributes {mhlo.num_partitions = 8 : 
   }
 }
 // CHECK-LABEL @main
-// CHECK: %arg{{[0-9]+}}: tensor<8192x784xf32, #tt.mesh_sharding<"mesh" : [ 2(0),  4(1)]>>
-// CHECK-SAME: %arg{{[0-9]+}}: tensor<784x16384xf32, #tt.mesh_sharding<"mesh" : [ 4(1),  1]>>
-// CHECK-SAME: tensor<8192x16384xf32, #tt.mesh_sharding<"mesh" : [ 2(0),  1]>>
+// CHECK: %arg{{[0-9]+}}: tensor<8192x784xf32, #tt.mesh_sharding<"mesh", [ 2(0),  4(1)]>>
+// CHECK-SAME: %arg{{[0-9]+}}: tensor<784x16384xf32, #tt.mesh_sharding<"mesh", [ 4(1),  1]>>
+// CHECK-SAME: tensor<8192x16384xf32, #tt.mesh_sharding<"mesh", [ 2(0),  1]>>
 
 // CHECK: "ttir.mesh_shard"
 // CHECK-SAME: shard_dims = array<i64: 0, 1>
 // CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
 // CHECK-SAME: shard_shape = array<i64: 2, 4>
 // CHECK-SAME: shard_type = #tt.shard_type<identity>
-// CHECK-SAME: tensor<8192x784xf32, #tt.mesh_sharding<"mesh" : [ 2(0),  4(1)]>>
+// CHECK-SAME: tensor<8192x784xf32, #tt.mesh_sharding<"mesh", [ 2(0),  4(1)]>>
 // CHECK-SAME: tensor<4096x196xf32, #tt.mesh_sharding<"mesh">>
 // CHECK-SAME: tensor<4096x196xf32, #tt.mesh_sharding<"mesh">>
 
@@ -407,7 +407,7 @@ module @jit_matmul_shardy_automatic_test2 attributes {mhlo.num_partitions = 8 : 
 // CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
 // CHECK-SAME: shard_shape = array<i64: 4, 1>
 // CHECK-SAME: shard_type = #tt.shard_type<identity>
-// CHECK-SAME: tensor<784x16384xf32, #tt.mesh_sharding<"mesh" : [ 4(1),  1]>>
+// CHECK-SAME: tensor<784x16384xf32, #tt.mesh_sharding<"mesh", [ 4(1),  1]>>
 // CHECK-SAME: tensor<196x16384xf32, #tt.mesh_sharding<"mesh">>
 // CHECK-SAME: tensor<196x16384xf32, #tt.mesh_sharding<"mesh">>
 
@@ -422,5 +422,5 @@ module @jit_matmul_shardy_automatic_test2 attributes {mhlo.num_partitions = 8 : 
 // CHECK-SAME: shard_shape = array<i64: 2, 1>
 // CHECK-SAME: shard_type = #tt.shard_type<identity>
 // CHECK-SAME: tensor<4096x16384xf32, #tt.mesh_sharding<"mesh">>
-// CHECK-SAME: tensor<8192x16384xf32, #tt.mesh_sharding<"mesh" : [ 2(0),  1]>>
-// CHECK-SAME: tensor<8192x16384xf32, #tt.mesh_sharding<"mesh" : [ 2(0),  1]>>
+// CHECK-SAME: tensor<8192x16384xf32, #tt.mesh_sharding<"mesh", [ 2(0),  1]>>
+// CHECK-SAME: tensor<8192x16384xf32, #tt.mesh_sharding<"mesh", [ 2(0),  1]>>

--- a/test/ttmlir/Dialect/TTNN/ccl/mesh_shard.mlir
+++ b/test/ttmlir/Dialect/TTNN/ccl/mesh_shard.mlir
@@ -17,10 +17,10 @@ module @mesh_shard_test attributes {tt.meshes = #tt.meshes<[<"mesh" = 1x1>]>} {
 // -----
 
 module @mesh_shard_test attributes {tt.meshes = #tt.meshes<[<"mesh" = 1x1>]>} {
-  func.func @forward(%arg0: tensor<8192x784xf32>) -> tensor<8192x392xf32> {
-    %0 = ttir.empty() : tensor<8192x392xf32>
-    %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: 0, 1>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 2>, shard_type = #tt.shard_type<identity>}> : (tensor<8192x784xf32>, tensor<8192x392xf32>) -> tensor<8192x392xf32>
-    return %1 : tensor<8192x392xf32>
+  func.func @forward(%arg0: tensor<8192x784xf32, #tt.mesh_sharding<"mesh">>) -> tensor<8192x392xf32, #tt.mesh_sharding<"mesh", [ 2(0),  1]>> {
+    %0 = ttir.empty() : tensor<8192x392xf32, #tt.mesh_sharding<"mesh", [ 2(0),  1]>>
+    %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: 0, 1>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 2>, shard_type = #tt.shard_type<identity>}> : (tensor<8192x784xf32, #tt.mesh_sharding<"mesh">>, tensor<8192x392xf32, #tt.mesh_sharding<"mesh", [ 2(0),  1]>>) -> tensor<8192x392xf32, #tt.mesh_sharding<"mesh", [ 2(0),  1]>>
+    return %1 : tensor<8192x392xf32, #tt.mesh_sharding<"mesh", [ 2(0),  1]>>
   }
 }
 // CHECK: [[DEVICE:%[0-9]+]] = "ttnn.get_device"()


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/2786

### Problem description
When loading ttir mlir file with tensor annotation info, it leads to some failure in parsing the TensorMeshShardingAttr.

### What's changed
Updated asm format that has no issue.

### Checklist
- [X] New/Existing tests provide coverage for changes
