### PR TITLE
Uplift third_party/tt-metal to 4acdb8b52797aa34b6c4bba1f8212deeefa0f68c 2025-04-02

### DIFF
--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -1738,7 +1738,8 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
                EltwiseUnaryWithFastAndApproximateModeOpConversionPattern<
                    tt::ttnn::RsqrtOp>,
                EltwiseUnaryOpConversionPattern<tt::ttnn::SignOp>,
-               EltwiseUnaryOpConversionPattern<tt::ttnn::SigmoidOp>,
+               EltwiseUnaryWithFastAndApproximateModeOpConversionPattern<
+                   tt::ttnn::SigmoidOp>,
                EltwiseUnaryCompositeOpConversionPattern<tt::ttnn::Log1pOp>,
                EltwiseUnaryOpConversionPattern<tt::ttnn::ReciprocalOp>,
                EltwiseUnaryWithFastAndApproximateModeOpConversionPattern<

--- a/runtime/lib/ttnn/operations/eltwise/unary/unary.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/unary/unary.cpp
@@ -130,7 +130,8 @@ void run(const ::tt::target::ttnn::EltwiseOp *op, ProgramContext &context) {
     break;
   }
   case ::tt::target::ttnn::EltwiseOpType::Sigmoid: {
-    runEltwiseUnaryOp(op, tensorPool, ::ttnn::sigmoid);
+    runEltwiseUnaryWithFastAndApproximateModeOp(op, tensorPool,
+                                                ::ttnn::sigmoid);
     break;
   }
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "7598b7ecd1426ae6fe1f54eb532a1dca00efcbf0")
+set(TT_METAL_VERSION "4acdb8b52797aa34b6c4bba1f8212deeefa0f68c")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 4acdb8b52797aa34b6c4bba1f8212deeefa0f68c

Also added:
- change in tt-metal #19768 changed sigmoid template causing build to fail
- update ::tt::sigmoid run function
- update sigmoid's TTNtoEmitC consversion pattern