### PR TITLE
D2M Backend Lowering Phase 1

### DIFF
--- a/include/ttmlir/Conversion/Passes.td
+++ b/include/ttmlir/Conversion/Passes.td
@@ -44,6 +44,12 @@ def ConvertTTIRToTTMetal: Pass<"convert-ttir-to-ttmetal", "::mlir::ModuleOp"> {
   let dependentDialects = ["mlir::tt::ttir::TTIRDialect", "mlir::tt::ttmetal::TTMetalDialect", "mlir::tt::ttkernel::TTKernelDialect"];
 }
 
+def ConvertTTIRToTTKernel: Pass<"convert-ttir-to-ttkernel", "::mlir::ModuleOp"> {
+  let summary = "Convert TTIR dialect to TTKernel dialect.";
+  let constructor = "createConvertTTIRToTTKernelPass()";
+  let dependentDialects = ["mlir::tt::ttir::TTIRDialect", "mlir::tt::ttmetal::TTMetalDialect", "mlir::tt::ttkernel::TTKernelDialect"];
+}
+
 def ConvertTTNNToEmitC : Pass<"convert-ttnn-to-emitc", "::mlir::ModuleOp"> {
   let summary = "Convert TTNN dialect to EmitC dialect.";
   let constructor = "createConvertTTNNToEmitCPass()";

--- a/include/ttmlir/Conversion/TTIRToTTKernel/TTIRToTTKernel.h
+++ b/include/ttmlir/Conversion/TTIRToTTKernel/TTIRToTTKernel.h
@@ -10,17 +10,13 @@
 
 namespace mlir::tt {
 
-void populateTTIRToTTKernelPatternsPhase1(MLIRContext *ctx,
-                                          RewritePatternSet &patterns,
-                                          TypeConverter &typeConverter);
+void populateTTIRToTTKernelInnerRegionPatterns(MLIRContext *ctx,
+                                               RewritePatternSet &patterns,
+                                               TypeConverter &typeConverter);
 
-void populateTTIRToTTKernelPatternsPhase2(MLIRContext *ctx,
-                                          RewritePatternSet &patterns,
-                                          TypeConverter &typeConverter);
-
-void populateTTIRToTTKernelPatternsPhase3(MLIRContext *ctx,
-                                          RewritePatternSet &patterns,
-                                          TypeConverter & /*typeConverter*/);
+void populateTTIRToTTKernelTopLevelPatterns(MLIRContext *ctx,
+                                            RewritePatternSet &patterns,
+                                            TypeConverter & /*typeConverter*/);
 
 std::unique_ptr<OperationPass<ModuleOp>> createConvertTTIRToTTKernelPass();
 

--- a/include/ttmlir/Conversion/TTIRToTTKernel/TTIRToTTKernel.h
+++ b/include/ttmlir/Conversion/TTIRToTTKernel/TTIRToTTKernel.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_CONVERSION_TTIRTOTTKERNEL_TTIRTOTTKERNEL_H
+#define TTMLIR_CONVERSION_TTIRTOTTKERNEL_TTIRTOTTKERNEL_H
+
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir::tt {
+
+void populateTTIRToTTKernelPatternsPhase1(MLIRContext *ctx,
+                                          RewritePatternSet &patterns,
+                                          TypeConverter &typeConverter);
+
+void populateTTIRToTTKernelPatternsPhase2(MLIRContext *ctx,
+                                          RewritePatternSet &patterns,
+                                          TypeConverter &typeConverter);
+
+void populateTTIRToTTKernelPatternsPhase3(MLIRContext *ctx,
+                                          RewritePatternSet &patterns,
+                                          TypeConverter & /*typeConverter*/);
+
+std::unique_ptr<OperationPass<ModuleOp>> createConvertTTIRToTTKernelPass();
+
+} // namespace mlir::tt
+
+#endif // TTMLIR_CONVERSION_TTIRTOTTKERNEL_TTIRTOTTKERNEL_H

--- a/include/ttmlir/Conversion/TTIRToTTMetal/TTIRToTTKernel.h
+++ b/include/ttmlir/Conversion/TTIRToTTMetal/TTIRToTTKernel.h
@@ -10,13 +10,9 @@
 
 namespace mlir::tt {
 
-void populateTTIRToTTKernelInnerRegionPatterns(MLIRContext *ctx,
-                                               RewritePatternSet &patterns,
-                                               TypeConverter &typeConverter);
-
-void populateTTIRToTTKernelTopLevelPatterns(MLIRContext *ctx,
-                                            RewritePatternSet &patterns,
-                                            TypeConverter & /*typeConverter*/);
+void populateTTIRToTTKernelPatterns(MLIRContext *ctx,
+                                    RewritePatternSet &patterns,
+                                    TypeConverter &typeConverter);
 
 std::unique_ptr<OperationPass<ModuleOp>> createConvertTTIRToTTKernelPass();
 

--- a/include/ttmlir/Conversion/TTIRToTTMetal/TTIRToTTMetal.h
+++ b/include/ttmlir/Conversion/TTIRToTTMetal/TTIRToTTMetal.h
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "ttmlir/Conversion/TTIRToTTMetal/TTIRToTTKernel.h"
+
 #ifndef TTMLIR_CONVERSION_TTIRTOTTMETAL_TTIRTOTTMETAL_H
 #define TTMLIR_CONVERSION_TTIRTOTTMETAL_TTIRTOTTMETAL_H
 
@@ -15,7 +17,6 @@ void populateTTIRToTTMetalPatterns(MLIRContext *ctx,
                                    TypeConverter &typeConverter);
 
 std::unique_ptr<OperationPass<ModuleOp>> createConvertTTIRToTTMetalPass();
-std::unique_ptr<OperationPass<ModuleOp>> createConvertTTIRToTTKernelPass();
 
 } // namespace mlir::tt
 

--- a/include/ttmlir/Conversion/TTIRToTTMetal/TTIRToTTMetal.h
+++ b/include/ttmlir/Conversion/TTIRToTTMetal/TTIRToTTMetal.h
@@ -15,6 +15,7 @@ void populateTTIRToTTMetalPatterns(MLIRContext *ctx,
                                    TypeConverter &typeConverter);
 
 std::unique_ptr<OperationPass<ModuleOp>> createConvertTTIRToTTMetalPass();
+std::unique_ptr<OperationPass<ModuleOp>> createConvertTTIRToTTKernelPass();
 
 } // namespace mlir::tt
 

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRBase.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRBase.td
@@ -39,6 +39,10 @@ def TTIR_Dialect : Dialect {
 
     let extraClassDeclaration = [{
         void registerTypes();
+
+        static StringRef getThreadTypeAttrName() {
+          return "ttir.thread_type";
+        }
     }];
 }
 
@@ -58,7 +62,7 @@ def ThreeOperands : ParamNativeOpTrait<"NOperands", "3">;
 def FourOperands : ParamNativeOpTrait<"NOperands", "4">;
 
 class TTIR_Trait<string name, list<Trait> traits = []> : NativeOpTrait<name, traits> {
-  let cppNamespace = "::mlir::tt::ttir::OpTrait";
+  let cppNamespace = "::mlir::OpTrait::tt::ttir";
 }
 
 // Involution is property of an operation where applying the operation twice results in the original value.
@@ -70,8 +74,10 @@ def TTIR_Idempotence : TTIR_Trait<"TTIRIdempotence", [DestinationStyleOpInterfac
 // BinaryIdempotence is property of a binary operation where applying the operation on the same value results in the same value.
 // Example: and(x, x) == x
 def TTIR_BinaryIdempotence : TTIR_Trait<"TTIRBinaryIdempotence", [DestinationStyleOpInterface, ThreeOperands, NoMemoryEffect]>;
-// GenericRegionOpTrait is a trait that acts as a label for all generic region operations.
-def TTIR_GenericRegionOpTrait : TTIR_Trait<"TTIRGenericRegionOpTrait", []>;
+// GenericRegionComputeOpTrait is a trait that verifies that the operation is inside a compute thread.
+def TTIR_GenericRegionComputeOpTrait : TTIR_Trait<"TTIRGenericRegionComputeOpTrait">;
+// GenericRegionDatamovementOpTrait is a trait that verifies that the operation is inside a datamovement thread.
+def TTIR_GenericRegionDatamovementOpTrait : TTIR_Trait<"TTIRGenericRegionDatamovementOpTrait">;
 
 //===----------------------------------------------------------------------===//
 // TTIR common types.

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.h
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.h
@@ -7,6 +7,8 @@
 
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
 
+#include "mlir/Interfaces/InferIntRangeInterface.h"
+
 #define GET_OP_CLASSES
 #include "ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.h.inc"
 

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
@@ -13,6 +13,7 @@ include "ttmlir/Dialect/TTIR/IR/TTIROpsInterfaces.td"
 
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
+include "mlir/Interfaces/InferIntRangeInterface.td"
 
 class TTIR_GenericRegionOp<string mnemonic, list<Trait> traits = [TTIR_GenericRegionOpTrait, TTIR_GenericParent]> :
     TTIR_Op<mnemonic, traits> {
@@ -219,7 +220,7 @@ def TTIR_DMAOp : TTIR_GenericRegionOp<"dma",
         Given some affine map, as demonstrated below, the dma op will be evaluated at each point in the affine map's iteration space.
       ```mlir
       #map1 = affine_map<(d0, d1, d2) -> (d0, d2)>
-      %tx = ttir.dma %stream #map1, %cb0 : (memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem
+      %tx = ttir.dma %stream<#map1>, %cb0 : (memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem
       ```
 _tx
 
@@ -233,7 +234,7 @@ _tx
                          OptionalAttr<I64Attr>:$optNumElems, Variadic<Index>:$dstCoreIndex, Variadic<Index>:$mcastShape);
     let results = (outs TTIR_MemTx:$result);
 
-    let assemblyFormat = [{ $src (`[` $srcIndices^ `]`)? (`[` $srcAffineMap^ `]`)? `,` $dst (`[` $dstIndices^ `]`)? (`[` $dstAffineMap^ `]`)? (`,` $optNumElems^)? (`,` `core` `[` $dstCoreIndex^ `]`)? (`mcast` `[` $mcastShape^ `]`)? attr-dict `:` `(` type($src) `,` type($dst) `)` `->` type($result)}];
+    let assemblyFormat = [{ $src (`<` $srcAffineMap^ `>`)? (`[` $srcIndices^ `]`)? `,` $dst (`<` $dstAffineMap^ `>`)? (`[` $dstIndices^ `]`)? (`,` `core` `[` $dstCoreIndex^ `]`)? (`mcast` `[` $mcastShape^ `]`)? (`,` `<` $optNumElems^ `>`)? attr-dict `:` `(` type($src) `,` type($dst) `)` `->` type($result)}];
 
     let hasVerifier = 1;
 
@@ -263,6 +264,18 @@ _tx
                getOptNumElems();
       }
     }];
+}
+
+def TTIR_NullTxOp : TTIR_GenericRegionOp<"null_tx", [Pure]> {
+    let summary = "Create a null transaction.";
+    let description = [{
+      Utility op to create a null transaction.  This is required for creating a sentinel
+      starting transaction for a DMA nested inside of a loop nest.
+    }];
+
+    let results = (outs TTIR_MemTx:$result);
+
+    let assemblyFormat = [{ attr-dict }];
 }
 
 def TTIR_DMAWaitOp : TTIR_GenericRegionOp<"dma_wait", [MemoryEffects<[MemRead, MemWrite]>]> {
@@ -393,6 +406,7 @@ class TTIR_IndexOp<string mnemonic, list<Trait> traits = []> : TTIR_GenericRegio
   traits #
   [ Pure
   , DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
+  , DeclareOpInterfaceMethods<InferIntRangeInterface, ["inferResultRanges"]>
   ]> {
     let arguments = (ins ConfinedAttr<I64Attr, [IntMinValue<0>]>:$dim);
     let results = (outs Index:$result);

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
@@ -15,15 +15,20 @@ include "mlir/IR/OpAsmInterface.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/InferIntRangeInterface.td"
 
-class TTIR_GenericRegionOp<string mnemonic, list<Trait> traits = [TTIR_GenericRegionOpTrait, TTIR_GenericParent]> :
-    TTIR_Op<mnemonic, traits> {
-}
+class TTIR_GenericRegionOp<string mnemonic, list<Trait> traits = []> :
+    TTIR_Op<mnemonic, [TTIR_GenericParent] # traits> {}
+
+class TTIR_GenericRegionComputeOp<string mnemonic, list<Trait> traits = []> :
+    TTIR_GenericRegionOp<mnemonic, [TTIR_GenericRegionComputeOpTrait] # traits> {}
+
+class TTIR_GenericRegionDatamovementOp<string mnemonic, list<Trait> traits = []> :
+    TTIR_GenericRegionOp<mnemonic, [TTIR_GenericRegionDatamovementOpTrait] # traits> {}
 
 //===----------------------------------------------------------------------===//
 // TTIR Generic Region Math Ops (Used in TTMetal Lowering)
 //===----------------------------------------------------------------------===//
 
-def TTIR_TileAddOp : TTIR_GenericRegionOp<"tile_add">{
+def TTIR_TileAddOp : TTIR_GenericRegionComputeOp<"tile_add"> {
     let summary = "TTIR Tile Add Op";
     let description = [{
         The `tile_add` operation adds two tiles element-wise.
@@ -34,7 +39,7 @@ def TTIR_TileAddOp : TTIR_GenericRegionOp<"tile_add">{
     let results = (outs TT_Tile:$result);
 }
 
-def TTIR_TileSubOp : TTIR_GenericRegionOp<"tile_sub">{
+def TTIR_TileSubOp : TTIR_GenericRegionComputeOp<"tile_sub"> {
     let summary = "TTIR Tile Sub Op";
     let description = [{
         The `tile_sub` operation subtracts two tiles element-wise.
@@ -45,7 +50,7 @@ def TTIR_TileSubOp : TTIR_GenericRegionOp<"tile_sub">{
     let results = (outs TT_Tile:$result);
 }
 
-def TTIR_TileMulOp : TTIR_GenericRegionOp<"tile_mul">{
+def TTIR_TileMulOp : TTIR_GenericRegionComputeOp<"tile_mul"> {
     let summary = "TTIR Tile Mul Op";
     let description = [{
         The `tile_mul` operation multiplies two tiles element-wise.
@@ -56,7 +61,7 @@ def TTIR_TileMulOp : TTIR_GenericRegionOp<"tile_mul">{
     let results = (outs TT_Tile:$result);
 }
 
-def TTIR_TileRecipOp : TTIR_GenericRegionOp<"tile_recip">{
+def TTIR_TileRecipOp : TTIR_GenericRegionComputeOp<"tile_recip"> {
     let summary = "TTIR Tile Recip Op";
     let description = [{
         The `tile_recip` operation computes the reciprocal of each element in the input tile.
@@ -66,7 +71,7 @@ def TTIR_TileRecipOp : TTIR_GenericRegionOp<"tile_recip">{
     let results = (outs TT_Tile:$result);
 }
 
-def TTIR_TileExpOp : TTIR_GenericRegionOp<"tile_exp">{
+def TTIR_TileExpOp : TTIR_GenericRegionComputeOp<"tile_exp"> {
     let summary = "TTIR Tile Exp Op";
     let description = [{
         The `tile_exp` operation computes the exponential of each element in the input tile.
@@ -76,7 +81,7 @@ def TTIR_TileExpOp : TTIR_GenericRegionOp<"tile_exp">{
     let results = (outs TT_Tile:$result);
 }
 
-def TTIR_TileLogOp : TTIR_GenericRegionOp<"tile_log">{
+def TTIR_TileLogOp : TTIR_GenericRegionComputeOp<"tile_log"> {
     let summary = "TTIR Tile Log Op";
     let description = [{
         The `tile_log` operation computes the natural logarithm of each element in the input tile.
@@ -86,7 +91,7 @@ def TTIR_TileLogOp : TTIR_GenericRegionOp<"tile_log">{
     let results = (outs TT_Tile:$result);
 }
 
-def TTIR_TileReduceSumOp : TTIR_GenericRegionOp<"tile_reduce_sum">{
+def TTIR_TileReduceSumOp : TTIR_GenericRegionComputeOp<"tile_reduce_sum"> {
     let summary = "TTIR Tile Reduce Sum Op";
     let description = [{
         The `tile_reduce_sum` operation computes the weighted sum of all elements in the input tile over the specified reduction dim(s).
@@ -98,7 +103,7 @@ def TTIR_TileReduceSumOp : TTIR_GenericRegionOp<"tile_reduce_sum">{
     let results = (outs TT_Tile:$result);
 }
 
-def TTIR_TileReduceMaxOp : TTIR_GenericRegionOp<"tile_reduce_max">{
+def TTIR_TileReduceMaxOp : TTIR_GenericRegionComputeOp<"tile_reduce_max"> {
     let summary = "TTIR Tile Reduce Max Op";
     let description = [{
         The `tile_reduce_max` operation computes the max of all elements in the input tile over the specified reduction dim(s).
@@ -110,7 +115,7 @@ def TTIR_TileReduceMaxOp : TTIR_GenericRegionOp<"tile_reduce_max">{
     let results = (outs TT_Tile:$result);
 }
 
-def TTIR_TileMatmulBlockOp : TTIR_GenericRegionOp<"tile_matmul_block",
+def TTIR_TileMatmulBlockOp : TTIR_GenericRegionComputeOp<"tile_matmul_block",
   [DestinationStyleOpInterface, DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
     let summary = "TTIR Tile Matmul Block Op";
     let description = [{
@@ -128,7 +133,7 @@ def TTIR_TileMatmulBlockOp : TTIR_GenericRegionOp<"tile_matmul_block",
     let hasVerifier = 1;
 }
 
-def TTIR_TileTilizeBlockOp : TTIR_GenericRegionOp<"tile_tilize_block",
+def TTIR_TileTilizeBlockOp : TTIR_GenericRegionComputeOp<"tile_tilize_block",
   [DestinationStyleOpInterface, MemoryEffects<[MemRead, MemWrite]>]> {
     let summary = "TTIR Tile Tilize Block Op";
     let description = [{
@@ -145,7 +150,7 @@ def TTIR_TileTilizeBlockOp : TTIR_GenericRegionOp<"tile_tilize_block",
     let hasVerifier = 1;
 }
 
-def TTIR_TileUntilizeBlockOp : TTIR_GenericRegionOp<"tile_untilize_block",
+def TTIR_TileUntilizeBlockOp : TTIR_GenericRegionComputeOp<"tile_untilize_block",
   [DestinationStyleOpInterface, MemoryEffects<[MemRead, MemWrite]>]> {
     let summary = "TTIR Tile Untilize Block Op";
     let description = [{
@@ -167,7 +172,7 @@ def TTIR_TileUntilizeBlockOp : TTIR_GenericRegionOp<"tile_untilize_block",
 // TTIR Generic Region Datamovement Ops (Used in TTMetal Lowering)
 //===----------------------------------------------------------------------===//
 
-def TTIR_DMAOp : TTIR_GenericRegionOp<"dma",
+def TTIR_DMAOp : TTIR_GenericRegionDatamovementOp<"dma",
   [ AttrSizedOperandSegments
   , DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
   , DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
@@ -278,7 +283,7 @@ def TTIR_NullTxOp : TTIR_GenericRegionOp<"null_tx", [Pure]> {
     let assemblyFormat = [{ attr-dict }];
 }
 
-def TTIR_DMAWaitOp : TTIR_GenericRegionOp<"dma_wait", [MemoryEffects<[MemRead, MemWrite]>]> {
+def TTIR_DMAWaitOp : TTIR_GenericRegionDatamovementOp<"dma_wait", [MemoryEffects<[MemRead, MemWrite]>]> {
     let summary = "TTIR DMA wait Op";
     let description = [{
       Waits for the producer DMA memory transaction to complete.
@@ -426,6 +431,52 @@ def TTIR_CoreIndexOp : TTIR_IndexOp<"core_index", [ConstantLike]> {
       Return the index of this core's coordinate inside the generic op's grid dimension.
     }];
     let hasFolder = true;
+}
+
+//===----------------------------------------------------------------------===//
+// TTIR Remote Access ops (Used in TTMetal Lowering)
+//===----------------------------------------------------------------------===//
+
+def TTIR_GetGlobalOperandOp : TTIR_GenericRegionOp<"get_global_operand", [Pure]> {
+    let summary = "Get global operand op.";
+    let description = [{
+      Access the global, aka parent generic op, operand at the specified index.
+
+      The following forms are all equivalent, but the latter forms are required
+      when moving generic regions to top level func ops in the module.
+      ```mlir
+      ttir.generic (%arg0, %arg1, %arg2) {
+        ^datamovement(%cb0, %cb1, %cb2)
+          ttir.dma %arg1, %cb1 // Capture %arg1 from parent scope
+      }
+      ```
+
+      And:
+      ```mlir
+      ttir.generic (%arg0, %arg1, %arg2) {
+        ^datamovement(%cb0, %cb1, %cb2)
+          %operand_arg1 = ttir.get_global_operand 1
+          ttir.dma %operand_arg1, %cb0
+      }
+      ```
+
+      And:
+      ```mlir
+      func.func @main(...) {
+        ttir.generic (%arg0, %arg1, %arg2) { kernel_symbols = [@dm0] }
+      }
+
+      func.func private @dm0(%cb0, %cb1, %cb2) {
+        %operand_arg1 = ttir.get_global_operand 1
+        ttir.dma %operand_arg1, %cb0
+      }
+      ```
+    }];
+
+    let arguments = (ins ConfinedAttr<I64Attr, [IntMinValue<0>]>:$operand_index);
+    let results = (outs AnyNon0RankedMemRef:$result);
+
+    let assemblyFormat = [{ `(` $operand_index `)` attr-dict `:` type($result) }];
 }
 
 #endif // TTMLIR_TTMLIR_DIALECT_TTIR_TTIRGENERICREGIONOPS_TD

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
@@ -125,7 +125,7 @@ def TTIR_TileReduceMaxOp : TTIR_GenericRegionComputeOp<"tile_reduce_max"> {
     let results = (outs TT_Tile:$result);
 }
 
-def TTIR_TileMatmulOp : TTIR_GenericRegionOp<"tile_matmul">{
+def TTIR_TileMatmulOp : TTIR_GenericRegionComputeOp<"tile_matmul">{
     let summary = "TTIR Tile Matmul Op";
     let description = [{
     }];
@@ -134,7 +134,7 @@ def TTIR_TileMatmulOp : TTIR_GenericRegionOp<"tile_matmul">{
     let results = (outs TT_Tile:$result);
 }
 
-def TTIR_TileMatmulBlockOp : TTIR_GenericRegionOp<"tile_matmul_block",
+def TTIR_TileMatmulBlockOp : TTIR_GenericRegionComputeOp<"tile_matmul_block",
   [DestinationStyleOpInterface, DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
     let summary = "TTIR Tile Matmul Block Op";
     let description = [{
@@ -205,6 +205,7 @@ def TTIR_DMAOp : TTIR_GenericRegionDatamovementOp<"dma",
       - Local to local // noc_async_write 1
       ```mlir
       %tx = ttir.dma %src, %dst : (memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+      %tx = ttir.dma %src[0, 0], %dst[0,0], 24 : (memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
       ```
 
       - Local to remote dram // noc_async_write 2
@@ -220,6 +221,7 @@ def TTIR_DMAOp : TTIR_GenericRegionDatamovementOp<"dma",
       - Local to remote L1, e.g. core[1, 2] // noc_async_write 4
       ```mlir
       %tx = ttir.dma %src, %dst, core[%c1, %c2] : (memref<6x8x!tt.tile<32x32, f32>, #dram>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+      %tx = ttir.dma %src, %dst[%c1, %c2], 24 : (memref<6x8x!tt.tile<32x32, f32>, #dram>, memref<2x2x6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
       ```
 
       - Local to mcast, e.g. starting at offset core[1, 2] with mcast shape [4, 4] (src and dst have the same SSA value, implies NoC doesn't loopback) // noc_async_write_multicast 5

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
@@ -91,7 +91,17 @@ def TTIR_TileLogOp : TTIR_GenericRegionComputeOp<"tile_log"> {
     let results = (outs TT_Tile:$result);
 }
 
-def TTIR_TileReduceSumOp : TTIR_GenericRegionComputeOp<"tile_reduce_sum"> {
+def TTIR_TileMaximumOp : TTIR_GenericRegionOp<"tile_maximum">{
+    let summary = "TTIR Tile Maximum Op";
+    let description = [{
+        The `tile_maximum` operation calculates the maximum of two tensors element-wise.
+    }];
+
+    let arguments = (ins TT_Tile:$lhs, TT_Tile:$rhs);
+    let results = (outs TT_Tile:$result);
+}
+
+def TTIR_TileReduceSumOp : TTIR_GenericRegionOp<"tile_reduce_sum">{
     let summary = "TTIR Tile Reduce Sum Op";
     let description = [{
         The `tile_reduce_sum` operation computes the weighted sum of all elements in the input tile over the specified reduction dim(s).
@@ -115,7 +125,16 @@ def TTIR_TileReduceMaxOp : TTIR_GenericRegionComputeOp<"tile_reduce_max"> {
     let results = (outs TT_Tile:$result);
 }
 
-def TTIR_TileMatmulBlockOp : TTIR_GenericRegionComputeOp<"tile_matmul_block",
+def TTIR_TileMatmulOp : TTIR_GenericRegionOp<"tile_matmul">{
+    let summary = "TTIR Tile Matmul Op";
+    let description = [{
+    }];
+
+    let arguments = (ins TT_Tile:$a, TT_Tile:$b, TT_Tile:$accum);
+    let results = (outs TT_Tile:$result);
+}
+
+def TTIR_TileMatmulBlockOp : TTIR_GenericRegionOp<"tile_matmul_block",
   [DestinationStyleOpInterface, DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
     let summary = "TTIR Tile Matmul Block Op";
     let description = [{

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
@@ -202,32 +202,32 @@ def TTIR_DMAOp : TTIR_GenericRegionDatamovementOp<"dma",
       different memory spaces. This op comes in a few flavors and is capable of roughly expressing everything
       that underlying Noc hardware can do. The op can be used to express a wide range of data movement operations:
 
-      - Local to local
+      - Local to local // noc_async_write 1
       ```mlir
       %tx = ttir.dma %src, %dst : (memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
       ```
 
-      - Local to remote dram
+      - Local to remote dram // noc_async_write 2
       ```mlir
       %tx = ttir.dma %src, %dst : (memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #dram>) -> !ttir.mem_tx
       ```
 
-      - Remote dram to local
+      - Remote dram to local // noc_async_read 3
       ```mlir
       %tx = ttir.dma %src, %dst : (memref<6x8x!tt.tile<32x32, f32>, #dram>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
       ```
 
-      - Local to remote L1, e.g. core[1, 2]
+      - Local to remote L1, e.g. core[1, 2] // noc_async_write 4
       ```mlir
       %tx = ttir.dma %src, %dst, core[%c1, %c2] : (memref<6x8x!tt.tile<32x32, f32>, #dram>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
       ```
 
-      - Local to mcast, e.g. starting at offset core[1, 2] with mcast shape [4, 4] (src and dst have the same SSA value, implies NoC doesn't loopback)
+      - Local to mcast, e.g. starting at offset core[1, 2] with mcast shape [4, 4] (src and dst have the same SSA value, implies NoC doesn't loopback) // noc_async_write_multicast 5
       ```mlir
       %tx = ttir.dma %foo, %foo, core[%c1, %c2] mcast[%c4, %c4] : (memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
       ```
 
-      - Local to mcast w/ loopback (same as above but src and dst are different SSA values)
+      - Local to mcast w/ loopback (same as above but src and dst are different SSA values) // noc_async_write_multicast_loopback_src 6
       ```mlir
       %tx = ttir.dma %src, %dst, core[%c1, %c2] mcast[%c4, %c4] : (memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
       ```

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -1679,7 +1679,15 @@ def TTIR_ReverseOp : TTIR_NamedOp<"reverse", [AllShapesMatch<["input", "result"]
     let hasCanonicalizer = 1;
 }
 
-def TTIR_EmptyOp : TTIR_Op<"empty", [Pure]> {
+def TTIR_EmptyOp : TTIR_Op<"empty",
+  [ Pure
+  , DeclareOpInterfaceMethods<BufferizableOpInterface, [ "bufferizesToMemoryRead"
+                                                       , "bufferizesToMemoryWrite"
+                                                       , "bufferize"
+                                                       , "getAliasingValues"
+                                                       , "getBufferType"
+                                                       ]>
+  ]> {
     let summary = "Empty op.";
     let description = [{
       Tensor empty operation

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -97,6 +97,7 @@ def TTIR_GenericOp : TTIR_BufferizableOp<"generic",
         grid = #tt.grid<1x1>,                        // The grid range of cores to dispatch work to.
         indexing_maps = [#map, #map, #map],          // Affine maps for indexing into the input/output tensors. See linalg.generic
         iterator_types = [#parallel, #parallel],     // Iterator types for the input/output tensors. See linalg.generic
+        threads = [#ttir.thread<compute>],           // Thread types for the regions.
         operandSegmentSizes = array<i32: 2, 1>       // Sizes of the operand segments, i.e. 2 inputs and 1 output.
       ({
       ^bb0(%arg2: memref<64x128xf32, #l1_>,
@@ -111,10 +112,50 @@ def TTIR_GenericOp : TTIR_BufferizableOp<"generic",
                          Variadic<AnyRankedTensorOrMemRef>:$outputs,
                          TT_GridAttr:$grid,
                          AffineMapArrayAttr:$indexing_maps,
-                         TT_IteratorTypeArrayAttr:$iterator_types);
+                         TT_IteratorTypeArrayAttr:$iterator_types,
+                         TTIR_ThreadArrayAttr:$threads);
     let results = (outs Variadic<AnyRankedTensor>:$results);
     let regions = (region VariadicRegion<AnyRegion>:$regions);
     let hasVerifier = 1;
+
+    let assemblyFormat = [{ attr-dict `\n`
+    ` ` ` ` ` ` ` ` `ins` `(` $inputs `:` type($inputs) `)` `\n`
+    ` ` ` ` ` ` ` ` `outs` `(` $outputs  `:` type($outputs) `)` ` `  $regions (`:`  type($results)^ )?
+    }];
+
+    let builders =
+    [
+      OpBuilder<(ins "ValueRange": $inputs,
+                     "ValueRange": $outputs,
+                     "ArrayAttr": $indexingMaps,
+                     "ArrayAttr": $iteratorTypes),
+      [{
+        assert(!indexingMaps.empty() && "expected non-empty indexing maps");
+        auto firstIndexingMap = mlir::cast<AffineMapAttr>(indexingMaps[0]).getValue();
+        auto grid = $_builder.getAttr<tt::GridAttr>(SmallVector<int64_t>(firstIndexingMap.getNumResults(), 1));
+        auto threads = $_builder.getArrayAttr($_builder.getAttr<ThreadAttr>(ThreadType::Compute));
+        build($_builder, $_state, TypeRange(outputs), inputs, outputs, grid, indexingMaps, iteratorTypes, threads, 1);
+      }]>,
+      OpBuilder<(ins "ValueRange": $inputs,
+                     "ValueRange": $outputs,
+                     "ArrayAttr": $indexingMaps,
+                     "ArrayAttr": $iteratorTypes,
+                     "llvm::function_ref<void(OpBuilder&, Location, ValueRange)>": $computeRegionBuilder),
+      [{
+        build($_builder, $_state, inputs, outputs, indexingMaps, iteratorTypes);
+        llvm::SmallVector<Type> blockTypes = llvm::map_to_vector(TypeRange($_state.operands), [&](Type t) {
+          mlir::RankedTensorType tensorType = mlir::cast<RankedTensorType>(t);
+          tt::MetalLayoutAttr layout =
+              mlir::cast<tt::MetalLayoutAttr>(tensorType.getEncoding());
+          return mlir::cast<Type>(layout.getMemref());
+        });
+        Region& region = *$_state.regions.front().get();
+        llvm::SmallVector<mlir::Location> locs($_state.operands.size(), $_state.location);
+        OpBuilder::InsertionGuard guard($_builder);
+        Block* block = $_builder.createBlock(&region, region.end(), blockTypes, locs);
+        computeRegionBuilder($_builder, $_state.location, block->getArguments());
+      }]>,
+    ];
 
     let extraClassDeclaration = [{
       MutableOperandRange getDpsInitsMutable() { return ttir::getDpsOutputs(this); }
@@ -124,6 +165,12 @@ def TTIR_GenericOp : TTIR_BufferizableOp<"generic",
       SmallVector<AffineMap> getIndexingMapsValue();
       SmallVector<IteratorType> getIteratorTypesValue();
       SmallVector<SmallVector<int64_t>> getOperandGridShapes();
+      ThreadType getRegionThreadType(unsigned regionIndex) {
+        return mlir::cast<ThreadAttr>(getThreads()[regionIndex]).getThreadType();
+      }
+      bool isAffineMapForm() { return !getIndexingMaps().empty(); }
+      bool isLoweredLoopForm() { return !isAffineMapForm(); }
+      bool isExternalSymbolForm() { return getRegions().empty(); }
     }];
 }
 

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROpsAttrs.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROpsAttrs.td
@@ -56,4 +56,26 @@ def TTIR_HoistedCallAttr : AttrDef<TTIR_Dialect, "HoistedCall", [], "::mlir::Att
   }];
 }
 
+def TTIR_ThreadAttr : AttrDef<TTIR_Dialect, "Thread", [], "::mlir::Attribute"> {
+  let mnemonic = "thread";
+  let summary = "Thread information for a generic op.";
+  let description = [{
+    Holds the thread information corresponding to a single generic op region.
+  }];
+  let parameters = (ins
+    "ThreadType":$threadType,
+    OptionalParameter<"SymbolRefAttr">:$kernelSymbol
+  );
+
+  let assemblyFormat = [{ `<` $threadType (`,` $kernelSymbol^)? `>` }];
+
+  let extraClassDeclaration = [{
+      static ThreadAttr get(::mlir::MLIRContext *context, ThreadType threadType) {
+        return get(context, threadType, nullptr);
+      }
+  }];
+}
+
+def TTIR_ThreadArrayAttr : TypedArrayAttrBase<TTIR_ThreadAttr, "">;
+
 #endif // TTMLIR_TTIR_ATTRS_TD

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROpsEnums.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROpsEnums.td
@@ -31,4 +31,15 @@ def TTIR_ReduceDim : I32EnumAttr<"ReduceDim", "TTIR ReduceDim", [
   let cppNamespace = "::mlir::tt::ttir";
 }
 
+def TTIR_ThreadTypeCompute : I32EnumAttrCase<"Compute", 0, "compute">;
+def TTIR_ThreadTypeDatamovement : I32EnumAttrCase<"Datamovement", 1, "datamovement">;
+
+def TTIR_ThreadType : I32EnumAttr<"ThreadType", "TTIR ThreadType", [
+                                  TTIR_ThreadTypeCompute,
+                                  TTIR_ThreadTypeDatamovement,
+                                ]> {
+  let genSpecializedAttr = 1;
+  let cppNamespace = "::mlir::tt::ttir";
+}
+
 #endif

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRTraits.h
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRTraits.h
@@ -9,14 +9,15 @@
 #include "mlir/Support/LLVM.h"
 
 namespace mlir {
+namespace OpTrait {
 namespace tt {
 namespace ttir {
-namespace OpTrait {
-
 namespace impl {
 bool verifyInvolution(mlir::Operation *op);
 bool verifyIdempotence(mlir::Operation *op);
 bool verifyBinaryIdempotence(mlir::Operation *op);
+mlir::LogicalResult verifyGenericRegionComputeOp(mlir::Operation *op);
+mlir::LogicalResult verifyGenericRegionDatamovementOp(mlir::Operation *op);
 mlir::OpFoldResult foldInvolution(mlir::Operation *op);
 mlir::OpFoldResult foldIdempotence(mlir::Operation *op);
 mlir::OpFoldResult foldBinaryIdempotence(mlir::Operation *op);
@@ -68,13 +69,24 @@ public:
 };
 
 template <typename ConcreteType>
-class TTIRGenericRegionOpTrait
-    : public mlir::OpTrait::TraitBase<ConcreteType, TTIRGenericRegionOpTrait> {
+struct TTIRGenericRegionComputeOpTrait
+    : public TraitBase<ConcreteType, TTIRGenericRegionComputeOpTrait> {
+  static mlir::LogicalResult verifyTrait(mlir::Operation *op) {
+    return impl::verifyGenericRegionComputeOp(op);
+  }
 };
 
-} // namespace OpTrait
+template <typename ConcreteType>
+struct TTIRGenericRegionDatamovementOpTrait
+    : public TraitBase<ConcreteType, TTIRGenericRegionDatamovementOpTrait> {
+  static mlir::LogicalResult verifyTrait(mlir::Operation *op) {
+    return impl::verifyGenericRegionDatamovementOp(op);
+  }
+};
+
 } // namespace ttir
 } // namespace tt
+} // namespace OpTrait
 } // namespace mlir
 
 #endif // TTMLIR_DIALECT_TTIR_IR_TTIRTRAITS_H

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -287,6 +287,40 @@ def TTIRGenericLowerAffineDMAs : Pass<"ttir-generic-lower-affine-dmas", "::mlir:
   }];
 }
 
+def TTIRGenericRegionsToFuncs : Pass<"ttir-generic-regions-to-funcs", "::mlir::ModuleOp"> {
+  let summary = "Move generic regions to top level functions.";
+  let description = [{
+    This pass moves the generic regions to top level functions. This is a useful prerequisite
+    step before lowering because it enables us to better separate kernel program lowering from
+    host program lowering.
+
+    ```mlir
+    func.func @main(/*...*/) {
+      ttir.generic {grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute>]}
+          ins(%arg0, %arg1 : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>)
+          outs(%alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>)  {
+      ^compute0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
+        // ...compute body...
+      }
+    }
+    ```
+
+    Into (note the new compute function / symbol @compute_kernel0):
+    ```mlir
+    func.func @main(/*...*/) {
+      ttir.generic {grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute, @compute_kernel0>]}
+          ins(%arg0, %arg1 : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>)
+          outs(%alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>)
+    }
+
+    func.func private @compute_kernel0(%arg0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>) attributes {ttir.thread_type = 0 : i32} {
+      // ...compute body...
+      return
+    }
+    ```
+  }];
+}
+
 def TTIRLayout: Pass<"ttir-layout", "::mlir::ModuleOp"> {
   let summary = "Tensor tilize all generic ops.";
   let description = [{

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -261,6 +261,32 @@ def TTIRGenericGenerateLoops : Pass<"ttir-generic-generate-loops", "::mlir::Modu
   }];
 }
 
+def TTIRGenericLowerAffineDMAs : Pass<"ttir-generic-lower-affine-dmas", "::mlir::ModuleOp"> {
+  let summary = "Lower DMA ops from their affine form to indexed form.";
+  let description = [{
+    This pass lowers DMA ops from their affine form to indexed form. This is useful for doing analysis on the DMA
+    ops and lowering them to an optimal loop nest of coalesced transactions.  This is acheived by sampling the affine
+    map over the entire parent generic op iterator space. Note that the affine map provided to the DMA op must be
+    one of the indexing maps of the parent generic op.
+
+    e.g.
+    ```mlir
+    %tx = ttir.dma %stream<#map1>, %cb0
+    ```
+
+    Might become:
+    ```mlir
+    %c2 = arith.constant 2
+    %iter0 = ttir.iter_index(0)
+    %core0 = ttir.core_index(0)
+    %0 = arith.muli %core0, %c2
+    %1 = arith.addi %0, %iter0
+    %iter2 = ttir.iter_index(2)
+    %tx = ttir.dma %stream [%1, %iter2], %cb0
+    ```
+  }];
+}
+
 def TTIRLayout: Pass<"ttir-layout", "::mlir::ModuleOp"> {
   let summary = "Tensor tilize all generic ops.";
   let description = [{

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelBase.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelBase.td
@@ -36,10 +36,34 @@ def TTKernel_Dialect : Dialect {
 }
 
 //===----------------------------------------------------------------------===//
-// Base TTKernel operation definition.
+// TTKernel Traits.
+//===----------------------------------------------------------------------===//
+
+class TTKernel_Trait<string name, list<Trait> traits = []> : NativeOpTrait<name, traits> {
+  let cppNamespace = "::mlir::tt::ttkernel::OpTrait";
+}
+
+def TTKernel_FPUOpTrait : TTKernel_Trait<"TTKernelFPUOpTrait", []>;
+
+def TTKernel_SFPUOpTrait : TTKernel_Trait<"TTKernelSFPUOpTrait", []>;
+
+def TTKernel_InitOpTrait : TTKernel_Trait<"TTKernelInitOpTrait", []>;
+
+//===----------------------------------------------------------------------===//
+// Base TTKernel operation definitions.
 //===----------------------------------------------------------------------===//
 
 class TTKernel_Op<string mnemonic, list<Trait> traits = []> :
         Op<TTKernel_Dialect, mnemonic, traits>;
+
+class TTKernel_FPUOp<string mnemonic, list<Trait> traits = [TTKernel_FPUOpTrait]> :
+        TTKernel_Op<mnemonic, traits>;
+
+class TTKernel_SFPUOp<string mnemonic, list<Trait> traits = [TTKernel_SFPUOpTrait]> :
+        TTKernel_Op<mnemonic, traits>;
+
+class TTKernel_InitOp<string mnemonic, list<Trait> traits = [TTKernel_InitOpTrait]> :
+        TTKernel_Op<mnemonic, traits>;
+
 
 #endif

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.h
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.h
@@ -15,6 +15,7 @@
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
 #include "ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.h"
+#include "ttmlir/Dialect/TTKernel/IR/TTKernelTraits.h"
 
 #define GET_OP_CLASSES
 #include "ttmlir/Dialect/TTKernel/IR/TTKernelOps.h.inc"

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -394,7 +394,7 @@ def TTKernel_GetNocAddrXYOp : TTKernel_Op<"get_noc_addr_xy"> {
       GetNocAddr api including core coordinates
     }];
 
-    let arguments = (ins I32:$x, I32:$y, I32:$l1Address);
+    let arguments = (ins Index:$x, Index:$y, I32:$l1Address);
     let results = (outs TTKernel_NocAddr:$nocAddr);
 }
 
@@ -681,7 +681,7 @@ def TTKernel_GetNocMulticastAddrOp : TTKernel_Op<"get_noc_multicast_addr"> {
     GetNocMulticastAddr
   }];
 
-  let arguments = (ins I32:$noc_x_start, I32:$noc_y_start, I32:$noc_x_end, I32:$noc_y_end, I32:$addr, Optional<I8>:$noc);
+  let arguments = (ins Index:$noc_x_start, Index:$noc_y_start, Index:$noc_x_end, Index:$noc_y_end, I32:$addr, Optional<I8>:$noc);
   let results = (outs TTKernel_NocAddr:$mcastNocAddr);
 }
 

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -637,6 +637,17 @@ def TTKernel_GetCompileArgValOp : TTKernel_Op<"get_compile_time_arg_val"> {
     let results = (outs AnyTypeOf<[TTKernel_Semaphore, I32]>:$arg_val);
 }
 
+def TTKernel_MetalCompileTimeArgOp : TTKernel_Op<"metal_compile_time_arg"> {
+    let summary = "MetalCompileTimeArg";
+    let description = [{
+      MetalCompileTimeArg
+    }];
+
+    let arguments = (ins I64Attr:$arg_index);
+
+    let results = (outs AnyTypeOf<[TTKernel_Semaphore, I32]>:$arg_val);
+}
+
 //===----------------------------------------------------------------------===//
 // TTKernel Helper functions
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -632,18 +632,7 @@ def TTKernel_GetCompileArgValOp : TTKernel_Op<"get_compile_time_arg_val"> {
       Get compile-time argument value at specified index.
     }];
 
-    let arguments = (ins I32:$arg_index);
-
-    let results = (outs AnyTypeOf<[TTKernel_Semaphore, I32]>:$arg_val);
-}
-
-def TTKernel_MetalCompileTimeArgOp : TTKernel_Op<"metal_compile_time_arg"> {
-    let summary = "MetalCompileTimeArg";
-    let description = [{
-      MetalCompileTimeArg
-    }];
-
-    let arguments = (ins I64Attr:$arg_index);
+    let arguments = (ins I32Attr:$arg_index);
 
     let results = (outs AnyTypeOf<[TTKernel_Semaphore, I32]>:$arg_val);
 }

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -77,7 +77,7 @@ def TTKernel_PackTileOp : TTKernel_Op<"pack_tile"> {
       the reserved section of the circular buffer to the consumer.
     }];
 
-    let arguments = (ins I32:$dst_index, TTKernel_CB:$out_cb, I32:$out_index);
+    let arguments = (ins Index:$dst_index, I32:$out_cb, Index:$out_index, DefaultValuedAttr<BoolAttr, "false">:$out_of_order);
 }
 
 def TTKernel_CopyTileInitOp : TTKernel_Op<"copy_tile_init"> {
@@ -86,7 +86,7 @@ def TTKernel_CopyTileInitOp : TTKernel_Op<"copy_tile_init"> {
       Must be called before copy_tile.
     }];
 
-    let arguments = (ins TTKernel_CB:$cb0);
+    let arguments = (ins I32:$cb0);
 }
 
 def TTKernel_CopyTileOp : TTKernel_Op<"copy_tile"> {
@@ -103,14 +103,14 @@ def TTKernel_CopyTileOp : TTKernel_Op<"copy_tile"> {
       engine.
     }];
 
-    let arguments = (ins TTKernel_CB:$cb0, I32:$tile_index_cb, I32:$tile_index_dst);
+    let arguments = (ins I32:$cb0, Index:$tile_index_cb, I32:$tile_index_dst);
 }
 
 //===----------------------------------------------------------------------===//
 // TTKernel FPU operations
 //===----------------------------------------------------------------------===//
 
-def TTKernel_BinaryOpInitCommonOp : TTKernel_Op<"binary_op_init_common"> {
+def TTKernel_BinaryOpInitCommonOp : TTKernel_InitOp<"binary_op_init_common"> {
     let summary = "Init function for all binary ops";
     let description = [{
       Followed by the specific init required with an opcode (binrary_op_specific_init).
@@ -119,7 +119,16 @@ def TTKernel_BinaryOpInitCommonOp : TTKernel_Op<"binary_op_init_common"> {
     let arguments = (ins TTKernel_CB:$in0_cb, TTKernel_CB:$in1_cb, TTKernel_CB:$out_cb);
 }
 
-def TTKernel_AddTilesInitOp : TTKernel_Op<"add_tiles_init"> {
+def TTKernel_MatmulTilesOp : TTKernel_FPUOp<"matmul_tiles"> {
+    let summary = "Matmul tiles operation";
+    let description = [{
+      Matmul tiles operation
+    }];
+
+    let arguments = (ins I32:$in0_cb_id, I32:$in1_cb_id, Index:$in0_tile_idx, Index:$in1_tile_idx, Index:$dst_tile_idx);
+}
+
+def TTKernel_AddTilesInitOp : TTKernel_InitOp<"add_tiles_init"> {
     let summary = "Short init function";
     let description = [{
       Must be run before add_tiles.
@@ -128,7 +137,7 @@ def TTKernel_AddTilesInitOp : TTKernel_Op<"add_tiles_init"> {
     let arguments = (ins TTKernel_CB:$in0_cb, TTKernel_CB:$in1_cb); // FIXME: , BOOL:$acc_to_dst);
 }
 
-def TTKernel_AddTilesOp : TTKernel_Op<"add_tiles"> {
+def TTKernel_AddTilesOp : TTKernel_FPUOp<"add_tiles"> {
     let summary = "Add operation";
     let description = [{
       Performs element-wise addition C=A+B of tiles in two CBs at given indices
@@ -140,7 +149,7 @@ def TTKernel_AddTilesOp : TTKernel_Op<"add_tiles"> {
     let arguments = (ins TTKernel_CB:$in0_cb, TTKernel_CB:$in1_cb, I32:$in0_tile_index, I32:$in1_tile_index, I32:$dst_index);
 }
 
-def TTKernel_MulTilesInitOp : TTKernel_Op<"mul_tiles_init"> {
+def TTKernel_MulTilesInitOp : TTKernel_InitOp<"mul_tiles_init"> {
     let summary = "Short init function";
     let description = [{
       Must be run before mul_tiles.
@@ -149,14 +158,14 @@ def TTKernel_MulTilesInitOp : TTKernel_Op<"mul_tiles_init"> {
     let arguments = (ins TTKernel_CB:$in0_cb, TTKernel_CB:$in1_cb);
 }
 
-def TTKernel_MulTilesInitFOp : TTKernel_Op<"mul_tiles_init_f"> {
+def TTKernel_MulTilesInitFOp : TTKernel_InitOp<"mul_tiles_init_f"> {
     let summary = "Short init function. Init for math only.";
     let description = [{
       Must be run before mul_tiles.
     }];
 }
 
-def TTKernel_MulTilesOp : TTKernel_Op<"mul_tiles"> {
+def TTKernel_MulTilesOp : TTKernel_FPUOp<"mul_tiles"> {
     let summary = "Mul operation";
     let description = [{
       Performs element-wise multiplication C=A*B of tiles in two CBs at given
@@ -168,7 +177,7 @@ def TTKernel_MulTilesOp : TTKernel_Op<"mul_tiles"> {
     let arguments = (ins TTKernel_CB:$in0_cb, TTKernel_CB:$in1_cb, I32:$in0_tile_index, I32:$in1_tile_index, I32:$dst_index);
 }
 
-def TTKernel_UnaryOpInitCommonOp : TTKernel_Op<"unary_op_init_common"> {
+def TTKernel_UnaryOpInitCommonOp : TTKernel_InitOp<"unary_op_init_common"> {
     let summary = "Initialization function for unary operations.";
     let description = [{
       This operation initializes all necessary components for unary operations,
@@ -178,14 +187,14 @@ def TTKernel_UnaryOpInitCommonOp : TTKernel_Op<"unary_op_init_common"> {
     let arguments = (ins TTKernel_CB:$icb, TTKernel_CB:$ocb);
 }
 
-def TTKernel_ExpTileInitOp : TTKernel_Op<"exp_tile_init"> {
+def TTKernel_ExpTileInitOp : TTKernel_InitOp<"exp_tile_init"> {
     let summary = "Short init function which configures compute unit for execution of exp_tile.";
     let description = [{
       Must be run before exp_tile.
     }];
 }
 
-def TTKernel_ExpTileOp : TTKernel_Op<"exp_tile"> {
+def TTKernel_ExpTileOp : TTKernel_FPUOp<"exp_tile"> {
     let summary = "Exp operation";
     let description = [{
       Performs element-wise computation of exponential on each element of a tile
@@ -197,14 +206,14 @@ def TTKernel_ExpTileOp : TTKernel_Op<"exp_tile"> {
     let arguments = (ins I32:$tile_index);
 }
 
-def TTKernel_RecipTileInitOp : TTKernel_Op<"recip_tile_init"> {
+def TTKernel_RecipTileInitOp : TTKernel_InitOp<"recip_tile_init"> {
     let summary = "Init function for recip_tile operation. Refer to documentation for any init function.";
     let description = [{
       Must be called before recip_tile function.
     }];
 }
 
-def TTKernel_RecipTileOp : TTKernel_Op<"recip_tile"> {
+def TTKernel_RecipTileOp : TTKernel_FPUOp<"recip_tile"> {
     let summary = "Recip tile in the DST at specified index.";
     let description = [{
       Performs element-wise computation of the reciprocal on each element of a tile
@@ -217,7 +226,7 @@ def TTKernel_RecipTileOp : TTKernel_Op<"recip_tile"> {
     let arguments = (ins I32:$tile_index);
 }
 
-def TTKernel_ReduceInitOp : TTKernel_Op<"reduce_init"> {
+def TTKernel_ReduceInitOp : TTKernel_InitOp<"reduce_init"> {
     let summary = "Init function";
     let description = [{
       Must be run before reduce_tile.
@@ -230,7 +239,7 @@ def TTKernel_ReduceInitOp : TTKernel_Op<"reduce_init"> {
                          TTKernel_ReduceDimAttr:$reduce_dim);
 }
 
-def TTKernel_ReduceTileOp : TTKernel_Op<"reduce_tile"> {
+def TTKernel_ReduceTileOp : TTKernel_FPUOp<"reduce_tile"> {
     let summary = "Reduce operation";
     let description = [{
       Performs a reduction operation *B = reduce(A)* using reduce_func for
@@ -258,7 +267,7 @@ def TTKernel_ReduceTileOp : TTKernel_Op<"reduce_tile"> {
 // TTKernel SFPU operations
 //===----------------------------------------------------------------------===//
 
-def TTKernel_MaxTilesInitOp : TTKernel_Op<"max_tile_init"> {
+def TTKernel_MaxTilesInitOp : TTKernel_InitOp<"max_tile_init"> {
     let summary = "Short init function";
     let description = [{
       Must be run before max_tile.
@@ -267,7 +276,7 @@ def TTKernel_MaxTilesInitOp : TTKernel_Op<"max_tile_init"> {
     let arguments = (ins);
 }
 
-def TTKernel_MaxTilesOp : TTKernel_Op<"max_tile"> {
+def TTKernel_MaxTilesOp : TTKernel_SFPUOp<"max_tile"> {
     let summary = "Max operation";
     let description = [{
       Performs element-wise computation of maximum operation
@@ -289,7 +298,7 @@ def TTKernel_CBPushBackOp : TTKernel_Op<"cb_push_back"> {
       CBPushBack operation
     }];
 
-    let arguments = (ins TTKernel_CB:$cb, I32:$numPages);
+    let arguments = (ins I32:$cb, I32:$numPages);
 
     let hasVerifier = 1;
 }
@@ -300,7 +309,7 @@ def TTKernel_CBPopFrontOp : TTKernel_Op<"cb_pop_front"> {
       CBPopFront operation
     }];
 
-    let arguments = (ins TTKernel_CB:$cb, I32:$numPages);
+    let arguments = (ins I32:$cb, I32:$numPages);
 
     let hasVerifier = 1;
 }
@@ -311,7 +320,7 @@ def TTKernel_CBReserveBackOp : TTKernel_Op<"cb_reserve_back"> {
       CBReserveBack operation
     }];
 
-    let arguments = (ins TTKernel_CB:$cb, I32:$numPages);
+    let arguments = (ins I32:$cb, I32:$numPages);
 
     let hasVerifier = 1;
 }
@@ -322,7 +331,7 @@ def TTKernel_CBWaitFrontOp : TTKernel_Op<"cb_wait_front"> {
       CBWaitFront operation
     }];
 
-    let arguments = (ins TTKernel_CB:$cb, I32:$numPages);
+    let arguments = (ins I32:$cb, I32:$numPages);
 
     let hasVerifier = 1;
 }

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -77,7 +77,7 @@ def TTKernel_PackTileOp : TTKernel_Op<"pack_tile"> {
       the reserved section of the circular buffer to the consumer.
     }];
 
-    let arguments = (ins Index:$dst_index, I32:$out_cb, Index:$out_index, DefaultValuedAttr<BoolAttr, "false">:$out_of_order);
+    let arguments = (ins Index:$dst_index, Index:$out_cb, Index:$out_index, DefaultValuedAttr<BoolAttr, "false">:$out_of_order);
 }
 
 def TTKernel_CopyTileInitOp : TTKernel_Op<"copy_tile_init"> {
@@ -808,7 +808,7 @@ def TTKernel_GetWritePtrOp : TTKernel_Op<"get_write_ptr"> {
       GetWritePtr operation
     }];
 
-    let arguments = (ins TTKernel_CB:$cb);
+    let arguments = (ins Index:$cb);
     let results = (outs I32:$writePtr);
 }
 
@@ -818,7 +818,7 @@ def TTKernel_GetReadPtrOp : TTKernel_Op<"get_read_ptr"> {
       GetReadPtr operation
     }];
 
-    let arguments = (ins TTKernel_CB:$cb);
+    let arguments = (ins Index:$cb);
     let results = (outs I32:$readPtr);
 }
 

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -671,6 +671,26 @@ def TTKernel_GetInterleavedAddrGenFastOp : TTKernel_Op<"get_interleaved_addr_gen
     let results = (outs TTKernel_InterleavedAddrGenFast:$result);
 }
 
+def TTKernel_MyXOp : TTKernel_Op<"my_x"> {
+    let summary = "MyX";
+    let description = [{
+      MyX
+    }];
+
+    let arguments = (ins Optional<I8>:$noc);
+    let results = (outs Index:$x);
+}
+
+def TTKernel_MyYOp : TTKernel_Op<"my_y"> {
+    let summary = "MyY";
+    let description = [{
+      MyY
+    }];
+
+    let arguments = (ins Optional<I8>:$noc);
+    let results = (outs Index:$y);
+}
+
 //===----------------------------------------------------------------------===//
 // TTKernel Multicast NoC operations
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -86,7 +86,7 @@ def TTKernel_CopyTileInitOp : TTKernel_Op<"copy_tile_init"> {
       Must be called before copy_tile.
     }];
 
-    let arguments = (ins I32:$cb0);
+    let arguments = (ins Index:$cb0);
 }
 
 def TTKernel_CopyTileOp : TTKernel_Op<"copy_tile"> {
@@ -103,7 +103,7 @@ def TTKernel_CopyTileOp : TTKernel_Op<"copy_tile"> {
       engine.
     }];
 
-    let arguments = (ins I32:$cb0, Index:$tile_index_cb, I32:$tile_index_dst);
+    let arguments = (ins Index:$cb0, Index:$tile_index_cb, I32:$tile_index_dst);
 }
 
 //===----------------------------------------------------------------------===//
@@ -125,7 +125,7 @@ def TTKernel_MatmulTilesOp : TTKernel_FPUOp<"matmul_tiles"> {
       Matmul tiles operation
     }];
 
-    let arguments = (ins I32:$in0_cb_id, I32:$in1_cb_id, Index:$in0_tile_idx, Index:$in1_tile_idx, Index:$dst_tile_idx);
+    let arguments = (ins Index:$in0_cb_id, Index:$in1_cb_id, Index:$in0_tile_idx, Index:$in1_tile_idx, Index:$dst_tile_idx);
 }
 
 def TTKernel_AddTilesInitOp : TTKernel_InitOp<"add_tiles_init"> {
@@ -298,7 +298,7 @@ def TTKernel_CBPushBackOp : TTKernel_Op<"cb_push_back"> {
       CBPushBack operation
     }];
 
-    let arguments = (ins I32:$cb, I32:$numPages);
+    let arguments = (ins Index:$cb, I32:$numPages);
 
     let hasVerifier = 1;
 }
@@ -309,7 +309,7 @@ def TTKernel_CBPopFrontOp : TTKernel_Op<"cb_pop_front"> {
       CBPopFront operation
     }];
 
-    let arguments = (ins I32:$cb, I32:$numPages);
+    let arguments = (ins Index:$cb, I32:$numPages);
 
     let hasVerifier = 1;
 }
@@ -320,7 +320,7 @@ def TTKernel_CBReserveBackOp : TTKernel_Op<"cb_reserve_back"> {
       CBReserveBack operation
     }];
 
-    let arguments = (ins I32:$cb, I32:$numPages);
+    let arguments = (ins Index:$cb, I32:$numPages);
 
     let hasVerifier = 1;
 }
@@ -331,7 +331,7 @@ def TTKernel_CBWaitFrontOp : TTKernel_Op<"cb_wait_front"> {
       CBWaitFront operation
     }];
 
-    let arguments = (ins I32:$cb, I32:$numPages);
+    let arguments = (ins Index:$cb, I32:$numPages);
 
     let hasVerifier = 1;
 }

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelTraits.h
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelTraits.h
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTIR_IR_TTKERNELTRAITS_H
+#define TTMLIR_DIALECT_TTIR_IR_TTKERNELTRAITS_H
+
+namespace mlir {
+namespace tt {
+namespace ttkernel {
+namespace OpTrait {
+
+template <typename ConcreteType>
+class TTKernelFPUOpTrait
+    : public mlir::OpTrait::TraitBase<ConcreteType, TTKernelFPUOpTrait> {};
+
+template <typename ConcreteType>
+class TTKernelSFPUOpTrait
+    : public mlir::OpTrait::TraitBase<ConcreteType, TTKernelSFPUOpTrait> {};
+
+template <typename ConcreteType>
+class TTKernelInitOpTrait
+    : public mlir::OpTrait::TraitBase<ConcreteType, TTKernelInitOpTrait> {};
+
+} // namespace OpTrait
+} // namespace ttkernel
+} // namespace tt
+} // namespace mlir
+
+#endif

--- a/include/ttmlir/Dialect/TTMetal/IR/TTMetalOps.td
+++ b/include/ttmlir/Dialect/TTMetal/IR/TTMetalOps.td
@@ -29,7 +29,7 @@ def TTMetal_EnqueueProgramOp : TTMetal_Op<"enqueue_program", [DestinationStyleOp
 
     let arguments = (ins Variadic<AnyNon0RankedMemRef>:$inputs,
                          Variadic<AnyNon0RankedMemRef>:$outputs,
-                         ArrayAttr:$kernel_symbols,
+                         ArrayAttr:$threads,
                          TTMetal_CoreRangeArrayAttr:$core_ranges,
                          TTKernel_KernelConfigArrayAttr:$kernelConfigs);
     let results = (outs Variadic<AnyNon0RankedMemRef>:$results);

--- a/include/ttmlir/Dialect/TTMetal/IR/TTMetalOps.td
+++ b/include/ttmlir/Dialect/TTMetal/IR/TTMetalOps.td
@@ -29,10 +29,10 @@ def TTMetal_EnqueueProgramOp : TTMetal_Op<"enqueue_program", [DestinationStyleOp
 
     let arguments = (ins Variadic<AnyNon0RankedMemRef>:$inputs,
                          Variadic<AnyNon0RankedMemRef>:$outputs,
+                         ArrayAttr:$kernel_symbols,
                          TTMetal_CoreRangeArrayAttr:$core_ranges,
                          TTKernel_KernelConfigArrayAttr:$kernelConfigs);
     let results = (outs Variadic<AnyNon0RankedMemRef>:$results);
-    let regions = (region VariadicRegion<AnyRegion>:$regions);
 
     let extraClassDeclaration = [{
       MutableOperandRange getDpsInitsMutable() { return getOutputsMutable(); }

--- a/include/ttmlir/Dialect/TTMetal/IR/TTMetalOps.td
+++ b/include/ttmlir/Dialect/TTMetal/IR/TTMetalOps.td
@@ -21,17 +21,17 @@ class AtLeastRegion<int numBlocks> : Region<
   CPred<"$_self.getBlocks().size() >= " # numBlocks>,
   "region with " # numBlocks # " blocks">;
 
-def TTMetal_EnqueueProgramOp : TTMetal_Op<"enqueue_program", [DestinationStyleOpInterface, AttrSizedOperandSegments]> {
+def TTMetal_EnqueueProgramOp : TTMetal_Op<"enqueue_program", [DestinationStyleOpInterface, AttrSizedOperandSegments, NoTerminator]> {
     let summary = "Enqueue program op.";
     let description = [{
       Enqueue program operation
     }];
 
-    let arguments = (ins Variadic<AnyRankedTensor>:$inputs,
-                         Variadic<AnyRankedTensor>:$outputs,
+    let arguments = (ins Variadic<AnyNon0RankedMemRef>:$inputs,
+                         Variadic<AnyNon0RankedMemRef>:$outputs,
                          TTMetal_CoreRangeArrayAttr:$core_ranges,
                          TTKernel_KernelConfigArrayAttr:$kernelConfigs);
-    let results = (outs Variadic<AnyRankedTensor>:$results);
+    let results = (outs Variadic<AnyNon0RankedMemRef>:$results);
     let regions = (region VariadicRegion<AnyRegion>:$regions);
 
     let extraClassDeclaration = [{
@@ -47,8 +47,8 @@ def TTMetal_EnqueueWriteBufferOp : TTMetal_Op<"enqueue_write_buffer", [Destinati
       Enqueue write buffer operation
     }];
 
-    let arguments = (ins AnyRankedTensor:$output, ElementsAttr:$value);
-    let results = (outs AnyRankedTensor:$result);
+    let arguments = (ins AnyNon0RankedMemRef:$output, ElementsAttr:$value);
+    let results = (outs AnyNon0RankedMemRef:$result);
 
     let extraClassDeclaration = [{
       MutableOperandRange getDpsInitsMutable() { return getOutputMutable(); }
@@ -63,9 +63,9 @@ def TTMetal_EnqueueReadBufferOp : TTMetal_Op<"enqueue_read_buffer", [Destination
       Enqueue read buffer operation
     }];
 
-    let arguments = (ins AnyRankedTensor:$input,
-                         AnyRankedTensor:$output);
-    let results = (outs AnyRankedTensor:$result);
+    let arguments = (ins AnyNon0RankedMemRef:$input,
+                         AnyNon0RankedMemRef:$output);
+    let results = (outs AnyNon0RankedMemRef:$result);
 
     let extraClassDeclaration = [{
       MutableOperandRange getDpsInitsMutable() { return getOutputMutable(); }
@@ -81,7 +81,7 @@ def TTMetal_CreateBufferOp : TTMetal_Op<"create_buffer"> {
     }];
 
     let arguments = (ins I64Attr:$address, I64Attr:$size, TT_MemorySpaceAttr:$memory_space);
-    let results = (outs AnyRankedTensor:$result);
+    let results = (outs AnyNon0RankedMemRef:$result);
 
     let hasVerifier = 1;
 }
@@ -92,7 +92,7 @@ def TTMetal_DeallocateBufferOp : TTMetal_Op<"deallocate_buffer"> {
       Deallocate buffer operation
     }];
 
-    let arguments = (ins AnyRankedTensor:$input);
+    let arguments = (ins AnyNon0RankedMemRef:$input);
 }
 
 #endif

--- a/include/ttmlir/Dialect/TTMetal/Transforms/Passes.h
+++ b/include/ttmlir/Dialect/TTMetal/Transforms/Passes.h
@@ -5,6 +5,8 @@
 #ifndef TTMLIR_DIALECT_TTMETAL_TRANSFORMS_PASSES_H
 #define TTMLIR_DIALECT_TTMETAL_TRANSFORMS_PASSES_H
 
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
 namespace mlir::tt::ttmetal {
 #define GEN_PASS_DECL
 #include "ttmlir/Dialect/TTMetal/Transforms/Passes.h.inc"

--- a/include/ttmlir/Dialect/TTMetal/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTMetal/Transforms/Passes.td
@@ -7,4 +7,11 @@
 
 include "mlir/Pass/PassBase.td"
 
+def TTMetalControlDstSection: Pass<"ttmetal-control-dst-section", "::mlir::ModuleOp"> {
+  let summary = "";
+  let description = [{
+    Analyze the graph and insert tile_regs_* ops to control the dst critical section.
+  }];
+}
+
 #endif

--- a/include/ttmlir/Utils.h
+++ b/include/ttmlir/Utils.h
@@ -489,6 +489,20 @@ OpTy replaceOpWithNewDPSOp(mlir::PatternRewriter &rewriter, mlir::Operation *op,
   return newOp;
 }
 
+template <typename... Args>
+static mlir::Region *getRegionWithParentOfType(mlir::Operation *op) {
+  mlir::Region *region = op->getParentRegion();
+  mlir::Operation *parentOp = region->getParentOp();
+  while (!mlir::isa<Args...>(parentOp)) {
+    region = parentOp->getParentRegion();
+    if (!region) {
+      break;
+    }
+    parentOp = region->getParentOp();
+  }
+  return region;
+}
+
 } // namespace ttmlir::utils
 
 #endif // TTMLIR_UTILS_H

--- a/lib/Conversion/TTIRToTTMetal/CMakeLists.txt
+++ b/lib/Conversion/TTIRToTTMetal/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_mlir_conversion_library(TTMLIRTTIRToTTMetal
   TTIRToTTMetal.cpp
+  TTIRToTTKernel.cpp
   TTIRToTTMetalPass.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTKernel.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTKernel.cpp
@@ -54,8 +54,8 @@ public:
     }
     rewriter.replaceOpWithNewOp<ttmetal::EnqueueProgramOp>(
         op, op->getResultTypes(), op.getInputs(), op.getOutputs(),
-        op.getThreads(),
-        rewriter.getArrayAttr(coreRanges), rewriter.getArrayAttr({}));
+        op.getThreads(), rewriter.getArrayAttr(coreRanges),
+        rewriter.getArrayAttr({}));
     return success();
   };
 };

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTKernel.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTKernel.cpp
@@ -1,0 +1,464 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Conversion/TTIRToTTKernel/TTIRToTTKernel.h"
+
+#include "ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIRTraits.h"
+#include "ttmlir/Dialect/TTKernel/IR/TTKernelOps.h"
+#include "ttmlir/Dialect/TTMetal/IR/TTMetalOps.h"
+
+#include <mlir/Dialect/MemRef/IR/MemRef.h>
+#include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/IR/Dominance.h>
+#include <mlir/IR/MLIRContext.h>
+#include <mlir/IR/PatternMatch.h>
+#include <mlir/Transforms/DialectConversion.h>
+
+namespace mlir::tt::ttkernel {
+
+Value i32(int32_t value, OpBuilder &builder) {
+  return builder
+      .create<arith::ConstantOp>(builder.getUnknownLoc(), builder.getI32Type(),
+                                 builder.getI32IntegerAttr(value))
+      .getResult();
+}
+
+Value index(int64_t value, OpBuilder &builder) {
+  return builder
+      .create<arith::ConstantOp>(builder.getUnknownLoc(),
+                                 builder.getIndexType(),
+                                 builder.getIndexAttr(value))
+      .getResult();
+}
+
+namespace {
+class TTIRGenericRewriter : public OpRewritePattern<ttir::GenericOp> {
+public:
+  using OpRewritePattern<ttir::GenericOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ttir::GenericOp op,
+                                PatternRewriter &rewriter) const final {
+    llvm::errs() << "ttir generic rewriter\n";
+    if (mlir::dyn_cast_or_null<ttkernel::CBType>(
+            op->getRegion(0).getBlocks().front().getArgument(0).getType())) {
+      return failure();
+    }
+
+    for (auto &region : op->getRegions()) {
+      assert(region.getBlocks().size() <= 1 &&
+             "Expected single block in region (temporary), failing.");
+      Block &block = region.getBlocks().front();
+      assert(
+          block.getNumArguments() == op.getNumOperands() &&
+          "Mismatch between number of operands and block arguments, failing.");
+      for (uint32_t i = 0; i < block.getNumArguments(); i++) {
+        auto memref = mlir::cast<MemRefType>(block.getArgument(i).getType());
+        auto cbPort = ttkernel::symbolizeCBPort(i);
+        assert(cbPort.has_value() && "Out of CBs, failing.");
+        auto cbType = ttkernel::CBType::get(rewriter.getContext(),
+                                            cbPort.value(), 0, memref);
+        for (Operation *user : block.getArgument(i).getUsers()) {
+          rewriter.eraseOp(user);
+        }
+        rewriter.modifyOpInPlace(
+            op, [&]() { block.getArgument(i).setType(cbType); });
+      }
+
+      auto enqueueProgramOp = rewriter.create<ttmetal::EnqueueProgramOp>(
+          op->getLoc(), op->getResultTypes(), op.getInputs(), op.getOutputs(),
+          rewriter.getArrayAttr({}), rewriter.getArrayAttr({}),
+          op->getNumRegions());
+      rewriter.modifyOpInPlace(enqueueProgramOp, [&]() {
+        for (uint32_t i = 0; i < op->getNumRegions(); i++) {
+          auto &region = enqueueProgramOp->getRegion(i);
+          region.takeBody(op->getRegion(i));
+        }
+      });
+
+      rewriter.eraseOp(op);
+    }
+
+    return success();
+  };
+};
+} // namespace
+
+/*
+
+========
+Old Memref Load Rewriter - keeping while lowering is WIP
+========
+
+namespace {
+
+class MemrefLoadRewriter : public OpRewritePattern<memref::LoadOp> {
+public:
+  using OpRewritePattern<memref::LoadOp>::OpRewritePattern;
+
+  static uint32_t getCbId(memref::LoadOp op) {
+    memref::CollapseShapeOp collapseOp =
+        llvm::cast<memref::CollapseShapeOp>(op.getMemref().getDefiningOp());
+    if (auto blockArg =
+            mlir::dyn_cast<mlir::BlockArgument>(collapseOp.getSrc())) {
+      return blockArg.getArgNumber();
+    }
+    assert(false && "Could not match collapse op src to block argument, cannot "
+                    "determine CB id. Failing.");
+  }
+
+  LogicalResult matchAndRewrite(memref::LoadOp op,
+                                PatternRewriter &rewriter) const final {
+
+    OpBuilder builder(op);
+    // erase the load op for now? sfpu / fpu considerations
+    assert(op.getIndices().size() == 1 && "Expected 1D memref load, failing.");
+
+    int sfpuOp = -1;
+    op->getBlock()->walk([&](Operation *op) {
+      if (op->hasTrait<OpTrait::TTKernelSFPUOpTrait>() && sfpuOp == -1) {
+        sfpuOp = 1;
+      } else if (op->hasTrait<OpTrait::TTKernelFPUOpTrait>() && sfpuOp == -1) {
+        sfpuOp = 0;
+      }
+    });
+
+    assert(sfpuOp != -1 && "Data Movement op only, unsupported, failing.");
+
+    auto cbId = i32(getCbId(op), builder);
+
+    if (sfpuOp == 1) {
+      rewriter.create<ttkernel::CopyTileInitOp>(op.getLoc(), cbId);
+      rewriter.create<ttkernel::CopyTileOp>(op.getLoc(), cbId,
+                                            op.getIndices().front(), cbId);
+    }
+
+    rewriter.eraseOp(op);
+    return success();
+  };
+};
+
+} // namespace */
+
+// memref store rewriter
+
+namespace {
+
+class MemrefStoreRewriter : public OpRewritePattern<memref::StoreOp> {
+public:
+  using OpRewritePattern<memref::StoreOp>::OpRewritePattern;
+
+  static uint32_t getCbId(memref::StoreOp op) {
+    memref::CollapseShapeOp collapseOp =
+        llvm::cast<memref::CollapseShapeOp>(op.getMemref().getDefiningOp());
+    if (auto blockArg =
+            mlir::dyn_cast<mlir::BlockArgument>(collapseOp.getSrc())) {
+      return blockArg.getArgNumber();
+    }
+    assert(false && "Could not match collapse op src to block argument, cannot "
+                    "determine CB id. Failing.");
+  }
+
+  LogicalResult matchAndRewrite(memref::StoreOp op,
+                                PatternRewriter &rewriter) const final {
+    llvm::errs() << "memref store rewriter\n";
+    OpBuilder builder(op);
+
+    auto cbId = i32(getCbId(op), builder);
+    auto storeIdx = op.getIndices().front();
+    rewriter.create<ttkernel::PackTileOp>(
+        op.getLoc(), index(0, builder), cbId, storeIdx,
+        rewriter.getBoolAttr(
+            true)); // we should lower to a pack loop (or use
+                    // matmul_pack_tile??) if input is not one tile, i.e. for
+                    // matmul_block, we need to loop pack on the whole dst
+                    // output. out_idx is ignore except for out of order pack
+
+    rewriter.eraseOp(op);
+    return success();
+  };
+};
+
+} // namespace
+
+// tile ops rewriter
+namespace {
+
+class TTIRTileOpsRewriter
+    : public OpTraitRewritePattern<ttir::OpTrait::TTIRGenericRegionOpTrait> {
+public:
+  using OpTraitRewritePattern<
+      ttir::OpTrait::TTIRGenericRegionOpTrait>::OpTraitRewritePattern;
+
+  static Value index(Value tile) {
+    Operation *loadOp = tile.getDefiningOp();
+    assert(mlir::isa<memref::LoadOp>(loadOp) && "Expected load op, failing.");
+    return mlir::cast<memref::LoadOp>(loadOp).getIndices().front();
+  }
+
+  static uint32_t getCbId(memref::LoadOp value) {
+    memref::CollapseShapeOp collapseOp =
+        mlir::cast<memref::CollapseShapeOp>(value.getMemref().getDefiningOp());
+    assert(
+        collapseOp &&
+        "Could not find assocated collapse shape op with memref load, failing");
+    if (auto blockArg =
+            mlir::dyn_cast<mlir::BlockArgument>(collapseOp.getSrc())) {
+      return blockArg.getArgNumber();
+    }
+    assert(false && "Could not match collapse op src to block argument, cannot "
+                    "determine CB id. Failing.");
+  }
+
+  static bool isFirstComputeOp(Operation *op) {
+    auto generic = op->getParentOfType<ttir::GenericOp>();
+    assert(generic && "Could not find parent generic op, failing.");
+
+    bool isFirst = 1;
+
+    generic.walk([&](Operation *walkOp) {
+      if (walkOp->hasTrait<OpTrait::TTKernelFPUOpTrait>() ||
+          walkOp->hasTrait<OpTrait::TTKernelSFPUOpTrait>()) {
+        isFirst = 0;
+      }
+    });
+
+    return isFirst;
+  }
+
+  static void lowerLoad(memref::LoadOp op, bool copyToDst, bool cbIndices,
+                        PatternRewriter &rewriter) {
+    OpBuilder builder(op);
+
+    if (copyToDst) {
+      auto cbId = i32(getCbId(op), builder);
+      rewriter.setInsertionPoint(op);
+      rewriter.create<ttkernel::CopyTileInitOp>(op.getLoc(), cbId);
+      rewriter.create<ttkernel::CopyTileOp>(op.getLoc(), cbId,
+                                            op.getIndices().front(),
+                                            cbIndices ? cbId : i32(0, builder));
+    }
+    rewriter.eraseOp(op);
+  }
+
+  LogicalResult matchAndRewrite(Operation *op,
+                                PatternRewriter &rewriter) const final {
+    llvm::errs() << "tileops & memref load rewriter\n";
+    OpBuilder builder(op);
+
+    auto first = isFirstComputeOp(op);
+    bool erase = 0;
+    Operation *newOp;
+
+    if (mlir::isa<ttir::TileMaximumOp>(op)) {
+      rewriter.create<ttkernel::MaxTilesInitOp>(op->getLoc());
+      newOp = rewriter.create<ttkernel::MaxTilesOp>(
+          op->getLoc(), i32(0, builder), i32(1, builder));
+      erase = 1;
+    } else if (mlir::isa<ttir::TileMatmulOp>(op)) {
+      auto dstIdx = rewriter.create<arith::ConstantOp>(
+          op->getLoc(), builder.getIndexType(), builder.getIndexAttr(0));
+      newOp = rewriter.create<ttkernel::MatmulTilesOp>(
+          op->getLoc(),
+          i32(getCbId(op->getOperand(0).getDefiningOp<memref::LoadOp>()),
+              builder),
+          i32(getCbId(op->getOperand(1).getDefiningOp<memref::LoadOp>()),
+              builder),
+          index(op->getOperand(0)), index(op->getOperand(1)), dstIdx);
+      erase = 1;
+    }
+
+    if (!erase) {
+      return failure(); // new ttir trait for generic region compute vs generic
+                        // region "helpers" or something
+    }
+
+    if (first) {
+      if (mlir::isa<ttkernel::MatmulTilesOp>(newOp)) {
+        lowerLoad(op->getOperand(0).getDefiningOp<memref::LoadOp>(), false,
+                  false, rewriter);
+        lowerLoad(op->getOperand(1).getDefiningOp<memref::LoadOp>(), false,
+                  false, rewriter);
+        lowerLoad(op->getOperand(2).getDefiningOp<memref::LoadOp>(), true,
+                  false, rewriter);
+      } else if (newOp->hasTrait<OpTrait::TTKernelSFPUOpTrait>()) {
+        for (uint32_t i = 0; i < op->getNumOperands(); i++) {
+          lowerLoad(op->getOperand(i).getDefiningOp<memref::LoadOp>(), true,
+                    true, rewriter);
+        }
+      } else {
+        for (uint32_t i = 0; i < op->getNumOperands(); i++) {
+          lowerLoad(op->getOperand(i).getDefiningOp<memref::LoadOp>(), false,
+                    false, rewriter);
+        }
+      }
+    }
+
+    if (erase) {
+      rewriter.eraseOp(op);
+    }
+    return success();
+  };
+};
+} // namespace
+
+// ttir await/yield rewriter
+
+namespace {
+
+template <typename T>
+class TTIRAwaitYieldRewriter : public OpRewritePattern<T> {
+public:
+  using OpRewritePattern<T>::OpRewritePattern;
+
+  static uint32_t getCbId(Value value) {
+    memref::CollapseShapeOp collapseOp =
+        llvm::cast<memref::CollapseShapeOp>(value.getDefiningOp());
+    if (auto blockArg =
+            mlir::dyn_cast<mlir::BlockArgument>(collapseOp.getSrc())) {
+      return blockArg.getArgNumber();
+    }
+    assert(false && "Could not match collapse op src to block argument, cannot "
+                    "determine CB id. Failing.");
+  }
+
+  LogicalResult matchAndRewrite(T op, PatternRewriter &rewriter) const final {
+    llvm::errs() << "ttir await/yield rewriter\n";
+    OpBuilder builder(op);
+
+    for (Value input : op.getValues()) {
+      auto cbId = i32(getCbId(input), builder);
+      auto type = mlir::cast<MemRefType>(input.getType());
+      assert(type.getShape().size() == 1 &&
+             "Expected collapsed 1D memref, failing.");
+      auto numPages = i32(type.getNumElements(), builder);
+      Block *block = op->getBlock();
+      if (mlir::isa<ttir::AwaitOp>(op)) {
+        rewriter.create<ttkernel::CBWaitFrontOp>(op.getLoc(), cbId, numPages);
+        auto popFront = rewriter.create<ttkernel::CBPopFrontOp>(op.getLoc(),
+                                                                cbId, numPages);
+        rewriter.moveOpBefore(popFront, block, block->end());
+      } else if (mlir::isa<ttir::YieldOp>(op)) {
+        auto reserveBack = rewriter.create<ttkernel::CBReserveBackOp>(
+            op.getLoc(), cbId, numPages);
+        rewriter.moveOpAfter(reserveBack, block, block->begin());
+        rewriter.create<ttkernel::CBPushBackOp>(op.getLoc(), cbId, numPages);
+        rewriter.moveOpBefore(cbId.getDefiningOp(), reserveBack);
+        rewriter.moveOpBefore(numPages.getDefiningOp(), reserveBack);
+      }
+    }
+
+    rewriter.eraseOp(op);
+    return success();
+  };
+};
+
+} // namespace
+
+// reconfig data formats
+
+// tile regs pass
+
+namespace {
+
+class TTIRTileRegsRewriter : public OpRewritePattern<ttkernel::PackTileOp> {
+public:
+  using OpRewritePattern<ttkernel::PackTileOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ttkernel::PackTileOp op,
+                                PatternRewriter &rewriter) const final {
+    llvm::errs() << "tile regs rewriter\n";
+
+    if (!op->getBlock()->getOps<ttkernel::TileRegsCommitOp>().empty()) {
+      return failure();
+    }
+
+    rewriter.moveOpAfter(
+        rewriter.create<ttkernel::TileRegsReleaseOp>(op->getLoc()), op);
+    auto regsWait = rewriter.create<ttkernel::TileRegsWaitOp>(op->getLoc());
+    rewriter.moveOpBefore(regsWait, op);
+    rewriter.moveOpBefore(
+        rewriter.create<ttkernel::TileRegsCommitOp>(op->getLoc()), regsWait);
+
+    rewriter.moveOpAfter(
+        rewriter.create<ttkernel::TileRegsAcquireOp>(op->getLoc()),
+        op->getBlock(), op->getBlock()->begin());
+
+    return success();
+  };
+};
+
+} // namespace
+
+// memref.alloc -> ttmetal.create_buffer pass
+
+namespace {
+
+class MemrefAllocRewriter : public OpRewritePattern<memref::AllocOp> {
+public:
+  using OpRewritePattern<memref::AllocOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(memref::AllocOp op,
+                                PatternRewriter &rewriter) const final {
+    llvm::errs() << "memref alloc rewriter\n";
+
+    assert(op->getAttr("address") && "No address attribute found, failing.");
+    auto address = op->getAttrOfType<IntegerAttr>("address");
+    assert(op.getMemref().getType().getMemorySpace() &&
+           "No memref memroy space found, failing.");
+    assert(mlir::isa<TileType>(op.getMemref().getType().getElementType()) &&
+           "Expected memref to have tile element type, failing.");
+    auto size = mlir::cast<TileType>(op.getMemref().getType().getElementType())
+                    .getSizeBytes() *
+                op.getMemref().getType().getNumElements();
+    auto memorySpace = mlir::cast<tt::MemorySpaceAttr>(
+        op.getMemref().getType().getMemorySpace());
+    auto createBufferOp = rewriter.create<ttmetal::CreateBufferOp>(
+        op->getLoc(), op.getMemref().getType(), address.getInt(), size,
+        memorySpace.getValue());
+    rewriter.replaceOp(op, createBufferOp);
+
+    return success();
+  };
+};
+
+} // namespace
+
+// core range and kernel config rewriter
+
+// dma rewriter
+
+// memref.dealloc -> ttmetal.deallocate_buffer pass?
+
+// init cleanup pass ?
+
+} // namespace mlir::tt::ttkernel
+
+namespace mlir::tt {
+
+void populateTTIRToTTKernelPatternsPhase1(MLIRContext *ctx,
+                                          RewritePatternSet &patterns,
+                                          TypeConverter & /*typeConverter*/) {
+
+  patterns.add<ttkernel::TTIRTileOpsRewriter, ttkernel::MemrefStoreRewriter,
+               ttkernel::TTIRAwaitYieldRewriter<ttir::AwaitOp>,
+               ttkernel::TTIRAwaitYieldRewriter<ttir::YieldOp>,
+               ttkernel::MemrefAllocRewriter>(ctx);
+}
+
+void populateTTIRToTTKernelPatternsPhase2(MLIRContext *ctx,
+                                          RewritePatternSet &patterns,
+                                          TypeConverter & /*typeConverter*/) {
+  // patterns.add<ttkernel::MemrefLoadRewriter>(ctx);
+}
+
+void populateTTIRToTTKernelPatternsPhase3(MLIRContext *ctx,
+                                          RewritePatternSet &patterns,
+                                          TypeConverter & /*typeConverter*/) {
+  patterns.add<ttkernel::TTIRGenericRewriter, ttkernel::TTIRTileRegsRewriter>(
+      ctx);
+}
+
+} // namespace mlir::tt

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTKernel.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTKernel.cpp
@@ -19,14 +19,14 @@
 
 namespace mlir::tt::ttkernel {
 
-Value i32(int32_t value, OpBuilder &builder) {
+static Value i32(int32_t value, OpBuilder &builder) {
   return builder
       .create<arith::ConstantOp>(builder.getUnknownLoc(), builder.getI32Type(),
                                  builder.getI32IntegerAttr(value))
       .getResult();
 }
 
-Value index(int64_t value, OpBuilder &builder) {
+static Value index(int64_t value, OpBuilder &builder) {
   return builder
       .create<arith::ConstantOp>(builder.getUnknownLoc(),
                                  builder.getIndexType(),
@@ -41,11 +41,6 @@ public:
 
   LogicalResult matchAndRewrite(ttir::GenericOp op,
                                 PatternRewriter &rewriter) const final {
-    if (mlir::dyn_cast_or_null<ttkernel::CBType>(
-            op->getRegion(0).getBlocks().front().getArgument(0).getType())) {
-      return failure();
-    }
-
     for (auto &region : op->getRegions()) {
       assert(region.getBlocks().size() <= 1 &&
              "Expected single block in region (temporary), failing.");
@@ -76,10 +71,9 @@ public:
           region.takeBody(op->getRegion(i));
         }
       });
-
-      rewriter.eraseOp(op);
     }
 
+    rewriter.eraseOp(op);
     return success();
   };
 };

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTKernel.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTKernel.cpp
@@ -296,9 +296,7 @@ public:
       }
     }
 
-    if (erase) {
-      rewriter.eraseOp(op);
-    }
+    rewriter.eraseOp(op);
     return success();
   };
 };
@@ -405,26 +403,20 @@ public:
 
 namespace mlir::tt {
 
-void populateTTIRToTTKernelPatternsPhase1(MLIRContext *ctx,
-                                          RewritePatternSet &patterns,
-                                          TypeConverter & /*typeConverter*/) {
+void populateTTIRToTTKernelInnerRegionPatterns(
+    MLIRContext *ctx, RewritePatternSet &patterns,
+    TypeConverter & /*typeConverter*/) {
 
   patterns.add<ttkernel::TTIRTileOpsRewriter, ttkernel::MemrefStoreRewriter,
                ttkernel::TTIRAwaitYieldRewriter<ttir::AwaitOp>,
-               ttkernel::TTIRAwaitYieldRewriter<ttir::YieldOp>,
-               ttkernel::MemrefAllocRewriter>(ctx);
+               ttkernel::TTIRAwaitYieldRewriter<ttir::YieldOp>>(ctx);
 }
 
-void populateTTIRToTTKernelPatternsPhase2(MLIRContext *ctx,
-                                          RewritePatternSet &patterns,
-                                          TypeConverter & /*typeConverter*/) {
-  // patterns.add<ttkernel::MemrefLoadRewriter>(ctx);
-}
-
-void populateTTIRToTTKernelPatternsPhase3(MLIRContext *ctx,
-                                          RewritePatternSet &patterns,
-                                          TypeConverter & /*typeConverter*/) {
-  patterns.add<ttkernel::TTIRGenericRewriter>(ctx);
+void populateTTIRToTTKernelTopLevelPatterns(MLIRContext *ctx,
+                                            RewritePatternSet &patterns,
+                                            TypeConverter & /*typeConverter*/) {
+  patterns.add<ttkernel::TTIRGenericRewriter, ttkernel::MemrefAllocRewriter>(
+      ctx);
 }
 
 } // namespace mlir::tt

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTKernel.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTKernel.cpp
@@ -96,7 +96,7 @@ public:
 } // namespace
 namespace {
 
-class TTIRTileOpsRewriter
+class TTIRComputeOpsRewriter
     : public OpTraitRewritePattern<
           mlir::OpTrait::tt::ttir::TTIRGenericRegionComputeOpTrait> {
 public:
@@ -575,7 +575,7 @@ void populateTTIRToTTKernelInnerRegionPatterns(
     MLIRContext *ctx, RewritePatternSet &patterns,
     TypeConverter & /*typeConverter*/) {
 
-  patterns.add<ttkernel::TTIRTileOpsRewriter, ttkernel::MemrefStoreRewriter,
+  patterns.add<ttkernel::TTIRComputeOpsRewriter, ttkernel::MemrefStoreRewriter,
                ttkernel::TTIRAwaitYieldRewriter<ttir::AwaitOp>,
                ttkernel::TTIRAwaitYieldRewriter<ttir::YieldOp>,
                ttkernel::TTIRDMARewriter, ttkernel::TTIRDMAWaitRewriter,

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTKernel.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTKernel.cpp
@@ -559,7 +559,7 @@ public:
 
   LogicalResult matchAndRewrite(ttir::GetGlobalOperandOp op,
                                 PatternRewriter &rewriter) const final {
-    rewriter.replaceOpWithNewOp<ttkernel::MetalCompileTimeArgOp>(
+    rewriter.replaceOpWithNewOp<ttkernel::GetCompileArgValOp>(
         op, rewriter.getI32Type(), op.getOperandIndex());
     return success();
   }

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTKernel.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTKernel.cpp
@@ -246,8 +246,7 @@ public:
         rewriter.create<ttkernel::CBWaitFrontOp>(op.getLoc(), cbId, numPages);
         auto popFront = rewriter.create<ttkernel::CBPopFrontOp>(op.getLoc(),
                                                                 cbId, numPages);
-        rewriter.moveOpBefore(popFront, block,
-                              block->getOps<func::ReturnOp>().begin());
+        rewriter.moveOpBefore(popFront, block->getTerminator());
       } else if (mlir::isa<ttir::YieldOp>(op)) {
         auto reserveBack = rewriter.create<ttkernel::CBReserveBackOp>(
             op.getLoc(), cbId, numPages);
@@ -334,10 +333,16 @@ public:
                                                    Value &nocStartX,
                                                    OperandRange mcastShape) {
     std::pair<Value, Value> nocEndCoords;
-    nocEndCoords.first = rewriter.create<arith::AddIOp>(
-        nocStartY.getLoc(), nocStartY, mcastShape[0]);
-    nocEndCoords.second = rewriter.create<arith::AddIOp>(
-        nocStartX.getLoc(), nocStartX, mcastShape[1]);
+    nocEndCoords.first = rewriter.create<arith::SubIOp>(
+        nocStartY.getLoc(),
+        rewriter.create<arith::AddIOp>(nocStartY.getLoc(), nocStartY,
+                                       mcastShape[0]),
+        index(1, rewriter));
+    nocEndCoords.second = rewriter.create<arith::SubIOp>(
+        nocStartX.getLoc(),
+        rewriter.create<arith::AddIOp>(nocStartX.getLoc(), nocStartX,
+                                       mcastShape[1]),
+        index(1, rewriter));
     return nocEndCoords;
   }
 

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTKernel.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTKernel.cpp
@@ -70,7 +70,7 @@ public:
     }
     rewriter.replaceOpWithNewOp<ttmetal::EnqueueProgramOp>(
         op, op->getResultTypes(), op.getInputs(), op.getOutputs(),
-        rewriter.getArrayAttr(op.getThreads().getValue()),
+        op.getThreads(),
         rewriter.getArrayAttr(coreRanges), rewriter.getArrayAttr({}));
     return success();
   };

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTKernel.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTKernel.cpp
@@ -264,10 +264,6 @@ public:
 
 } // namespace
 
-// reconfig data formats
-
-// memref.alloc -> ttmetal.create_buffer pass
-
 namespace {
 
 class MemrefAllocRewriter : public OpRewritePattern<memref::AllocOp> {
@@ -298,10 +294,6 @@ public:
 };
 
 } // namespace
-
-// core range and kernel config rewriter
-
-// dma rewriter
 
 namespace {
 
@@ -420,14 +412,14 @@ public:
       rewriter.create<ttkernel::NocAsyncWriteOp>(op.getLoc(), srcL1Addr,
                                                  nocAddr, transferSize);
     } else if (op.isSrcLocal() && op.isDstLocal()) {
+      // mcast & l1 to l1 single core remote
+
       Value srcL1Addr = rewriter.create<ttkernel::GetReadPtrOp>(
           op.getLoc(), getCBIndex(rewriter, op.getSrc()));
       Value dstL1Addr = rewriter.create<ttkernel::GetWritePtrOp>(
           op.getLoc(), getCBIndex(rewriter, op.getDst()));
-      // mcast & l1 to l1 single core remote
       Value transferSize =
           i32(getMemrefSizeBytes(op.getSrcMemRefType()), rewriter);
-      // mcast or l1 to l1 (local)
       assert(op.getDstCoreIndex().size() == 2 &&
              "Expected 2 core indices for dst core index, failing.");
 
@@ -510,7 +502,8 @@ public:
       rewriter.create<ttkernel::NocAsyncReadOp>(loc, srcNocAddr, dstL1Addr,
                                                 size);
     } else if (op.isSrcLocal() && !op.isDstLocal()) {
-      // write l1 to l1 or l1 to dram
+      // write l1 to dram
+      assert(false && "Unimplemented lowering l1 to dram write, failing.");
     } else {
       assert(false && "Illegal DMA op configuration.");
     }
@@ -521,11 +514,6 @@ public:
 };
 
 } // namespace
-
-// memref.dealloc -> ttmetal.deallocate_buffer pass?
-
-// init cleanup pass ?
-
 namespace {
 
 class TTIRCoreIndexRewriter : public OpRewritePattern<ttir::CoreIndexOp> {

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
@@ -3,604 +3,61 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Conversion/TTIRToTTMetal/TTIRToTTMetal.h"
-
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
-#include "ttmlir/Dialect/TT/Utils/PhysicalCoreCoord.h"
-#include "ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
-#include "ttmlir/Dialect/TTKernel/IR/TTKernelOps.h"
-#include "ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.h"
 #include "ttmlir/Dialect/TTMetal/IR/TTMetalOps.h"
-#include "ttmlir/Dialect/TTMetal/IR/TTMetalOpsTypes.h"
-#include "ttmlir/Utils.h"
 
-#include <llvm/ADT/DenseMap.h>
-#include <llvm/ADT/MapVector.h>
-#include <llvm/ADT/SmallVector.h>
-#include <llvm/Support/ErrorHandling.h>
-#include <llvm/Support/LogicalResult.h>
-#include <mlir/Analysis/Liveness.h>
-#include <mlir/Dialect/Arith/IR/Arith.h>
-#include <mlir/Dialect/Func/IR/FuncOps.h>
-#include <mlir/Dialect/Math/IR/Math.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
-#include <mlir/Dialect/SCF/IR/SCF.h>
-#include <mlir/IR/Block.h>
-#include <mlir/IR/Builders.h>
-#include <mlir/IR/BuiltinAttributes.h>
-#include <mlir/IR/BuiltinTypes.h>
-#include <mlir/IR/Location.h>
-#include <mlir/IR/PatternMatch.h>
-#include <mlir/IR/Types.h>
-#include <mlir/IR/Value.h>
-#include <mlir/IR/ValueRange.h>
-#include <mlir/Pass/PassManager.h>
-#include <mlir/Support/LogicalResult.h>
-#include <mlir/Transforms/DialectConversion.h>
-
-#include <cstdint>
-#include <utility>
 
 namespace mlir::tt::ttmetal {
 
-// This routine walks the SSA value chain to find the address of the value.
-// It runs into and gets the address from one of the following:
-//   - ttir::CreateBufferOp: The address is the address of the allocation is
-//   embedded in the op attributes.
-//   - func::FuncOp Argument: The address is taken from ArgumentAllocationAttr.
-//
-// This routine is used to lookup the address of tensors for address generation
-// and for CB creation.
-// static uint64_t lookupAddress(Value value) {
-//   auto blockArg = mlir::dyn_cast<BlockArgument>(value);
-//   if (blockArg) {
-//     auto *funcOp = blockArg.getOwner()->getParentOp();
-//     if (mlir::isa<func::FuncOp>(funcOp)) {
-//       auto argAlloc = mlir::cast<ArgumentAllocationAttr>(
-//           mlir::cast<ArrayAttr>(funcOp->getDiscardableAttr(
-//               ArgumentAllocationAttr::name))[blockArg.getArgNumber()]);
-//       return argAlloc.getAddress();
-//     }
-//   }
-
-//   auto *op = value.getDefiningOp();
-//   if (!op) {
-//     return 0;
-//   }
-
-//   while (isa<DestinationStyleOpInterface>(op)) {
-//     assert(op->getResults().size() == 1);
-//     auto dps = cast<DestinationStyleOpInterface>(op);
-//     assert(dps.getNumDpsInits() == 1);
-//     auto *opOperand = dps.getDpsInitOperand(0);
-//     value = opOperand->get();
-//     op = value.getDefiningOp();
-//   }
-
-//   auto allocOp = dyn_cast<ttir::AllocOp>(op);
-//   if (!allocOp) {
-//     return 0;
-//   }
-//   return allocOp.getAddress();
-// }
-
 namespace {
-class TTIRToTTMetalLayoutRewriter : public OpRewritePattern<ttir::ToLayoutOp> {
+class TTIRGenericRewriter : public OpRewritePattern<ttir::GenericOp> {
 public:
-  using OpRewritePattern<ttir::ToLayoutOp>::OpRewritePattern;
+  using OpRewritePattern<ttir::GenericOp>::OpRewritePattern;
 
-  // struct NocTx {
-  //   enum class Type { Read, Write };
-
-  //   Type type;
-  //   PhysicalCoreCoord coreCoord;
-  //   std::int64_t srcOffset = 0;
-  //   std::int64_t dstOffset = 0;
-  //   std::int64_t size = 0;
-  //   std::int32_t numElements = 0;
-
-  //   NocTx(Type type, PhysicalCoreCoord coreCoord, std::int64_t srcOffset,
-  //         std::int64_t dstOffset, std::int64_t size, std::int32_t
-  //         numElements)
-  //       : type(type), coreCoord(coreCoord), srcOffset(srcOffset),
-  //         dstOffset(dstOffset), size(size), numElements(numElements) {}
-
-  //   bool isContiguous(PhysicalCoreCoord nextCoord, std::int64_t
-  //   nextSrcOffset,
-  //                     std::int64_t nextDstOffset) const {
-  //     return (nextCoord == coreCoord) && (nextSrcOffset == srcOffset + size)
-  //     &&
-  //            (nextDstOffset == dstOffset + size);
-  //   }
-  // };
-
-  // // This routine calculates the data movement for a tensor layout change by
-  // // tracing the walk order of the src and dst affine maps.  The sample
-  // routine
-  // // is just a helper function that iterates over the tensor shape and calls
-  // the
-  // // lambda with the current index.  It walks the shape in innermost-major
-  // // order. It also coalesces the noc transactions.
-  // //
-  // // The return value is a map of physical cores where each core has
-  // // an associated list of noc reads/writes to be performed.
-  // static llvm::MapVector<PhysicalCoreCoord, mlir::SmallVector<NocTx>>
-  // calculateDataMovement(ArrayRef<int64_t> tensorShape, std::int64_t elemSize,
-  //                       AffineMap src, AffineMap dst, NocTx::Type type,
-  //                       std::int64_t dstCapacity) {
-  //   bool read = type == NocTx::Type::Read;
-  //   llvm::MapVector<PhysicalCoreCoord, mlir::SmallVector<NocTx>> txMap;
-  //   assert(src.getNumResults() == MemoryMapResultIdx::NumIndices);
-  //   assert(dst.getNumResults() == MemoryMapResultIdx::NumIndices);
-
-  //   ::ttmlir::utils::sample(
-  //       tensorShape, [&txMap, src, dst, elemSize, read, type,
-  //                     dstCapacity](ArrayRef<std::int64_t> index) {
-  //         SmallVector<int64_t> srcResults = src.compose(index);
-  //         SmallVector<int64_t> dstResults = dst.compose(index);
-  //         assert(srcResults.size() == src.getNumResults());
-  //         assert(dstResults.size() == dst.getNumResults());
-  //         PhysicalCoreCoord srcCoord(srcResults);
-  //         PhysicalCoreCoord dstCoord(dstResults);
-  //         std::int64_t srcOffset = srcResults.back() * elemSize;
-  //         std::int64_t dstOffset = dstResults.back() * elemSize;
-
-  //         SmallVector<NocTx> &txs = txMap[read ? dstCoord : srcCoord];
-  //         if (not txs.empty() &&
-  //             txs.back().isContiguous(read ? srcCoord : dstCoord, srcOffset,
-  //                                     dstOffset) &&
-  //             txs.back().size + elemSize <= dstCapacity) {
-  //           txs.back().size += elemSize;
-  //           txs.back().numElements++;
-  //         } else {
-  //           txs.push_back(NocTx(type, read ? srcCoord : dstCoord, srcOffset,
-  //                               dstOffset, elemSize, 1));
-  //         }
-  //       });
-
-  //   return txMap;
-  // }
-
-  // LogicalResult relayout(ttir::ToLayoutOp op, PatternRewriter &rewriter)
-  // const {
-  //   auto inputTy = mlir::cast<RankedTensorType>(op.getInput().getType());
-  //   auto outputTy = mlir::cast<RankedTensorType>(op.getType(0));
-  //   auto inputLayout =
-  //   mlir::cast<tt::MetalLayoutAttr>(inputTy.getEncoding()); auto outputLayout
-  //   = mlir::cast<tt::MetalLayoutAttr>(outputTy.getEncoding()); tt::DeviceAttr
-  //   device = op.getDevice(); assert(device); tt::SystemDescAttr systemDesc =
-  //   op.getSystemDesc(); assert(systemDesc); auto addressAlignment =
-  //   systemDesc.getAddressAlignBytes(
-  //       /*inputLayout.getMemorySpace() issue #407*/);
-  //   assert(inputLayout.getPhysicalShape(inputTy.getShape()) ==
-  //              outputLayout.getPhysicalShape(outputTy.getShape()) &&
-  //          "Physical shapes must match for now");
-
-  //   // Shape that will be traversed when calculating the data movement
-  //   between
-  //   // layouts.
-  //   SmallVector<int64_t> inputShape =
-  //       inputLayout.isTiled() ? inputLayout.getTiledShape(inputTy.getShape())
-  //                             : SmallVector<int64_t>(inputTy.getShape());
-  //   SmallVector<int64_t> outputShape =
-  //       outputLayout.isTiled() ?
-  //       outputLayout.getTiledShape(outputTy.getShape())
-  //                              : SmallVector<int64_t>(outputTy.getShape());
-
-  //   assert(inputShape == outputShape && "Shapes must be identical");
-
-  //   // If tiles are reblocked, the linear maps must be identical.
-  //   assert(!(inputLayout.isTiled() && outputLayout.isTiled()) ||
-  //          inputLayout.getLinear() == outputLayout.getLinear());
-
-  //   // When the layouts are tiled, the linear maps are the identity maps.
-  //   // Reasoning behind this is that since it's already ensured that scalar
-  //   // linear maps identical, tensors can be viewed simply as bags of tiles
-  //   // omitting any affine complexity.
-  //   AffineMap inputLinearMap = inputLayout.isTiled()
-  //                                  ? inputLayout.getIdentityTileLinearMap()
-  //                                  : inputLayout.getLinear();
-  //   AffineMap outputLinearMap = outputLayout.isTiled()
-  //                                   ? outputLayout.getIdentityTileLinearMap()
-  //                                   : outputLayout.getLinear();
-
-  //   assert(inputLayout.getMemorySpace() == MemorySpace::DeviceL1 ||
-  //          outputLayout.getMemorySpace() == MemorySpace::DeviceL1 &&
-  //              "DRAM <-> DRAM is not supported yet");
-  //   NocTx::Type dataMovementType =
-  //       outputLayout.getMemorySpace() == MemorySpace::DeviceL1
-  //           ? NocTx::Type::Read
-  //           : NocTx::Type::Write;
-
-  //   AffineMap src = inputLayout.projectOnto(
-  //       inputLinearMap, device.getMemoryMap(inputLayout.getMemref(), 0));
-
-  //   AffineMap dst = outputLayout.projectOnto(
-  //       outputLinearMap, device.getMemoryMap(outputLayout.getMemref(), 0));
-
-  //   auto dm = calculateDataMovement(
-  //       inputShape, inputLayout.getElementSizeBytes(), src, dst,
-  //       dataMovementType, outputLayout.getMemrefSizeBytes());
-
-  //   auto noc0Attr =
-  //       rewriter.getAttr<ttkernel::NocConfigAttr>(ttkernel::NocIndex::Noc0);
-  //   SmallVector<Attribute> kernelConfigs(dm.size(), noc0Attr);
-  //   SmallVector<Attribute> coreRanges;
-  //   coreRanges.reserve(dm.size());
-  //   for (auto [coreCoord, txs] : dm) {
-  //     SmallVector<int64_t> offset = {coreCoord.y, coreCoord.x};
-  //     SmallVector<int64_t> size = {1, 1};
-  //     coreRanges.push_back(
-  //         rewriter.getAttr<ttmetal::CoreRangeAttr>(offset, size));
-  //   };
-  //   std::int64_t inputBaseAddress = lookupAddress(op.getInput());
-  //   std::int64_t outputBaseAddress = lookupAddress(op.getOutput());
-
-  //   auto metalEnqueueProgram = rewriter.create<ttmetal::EnqueueProgramOp>(
-  //       op.getLoc(), SmallVector<Type>({outputTy}),
-  //       SmallVector<Value>({op.getInput()}),
-  //       SmallVector<Value>({op.getOutput()}), rewriter.getArrayAttr({}),
-  //       rewriter.getArrayAttr(coreRanges),
-  //       rewriter.getArrayAttr(kernelConfigs));
-
-  //   PhysicalCoreCoordMapping physicalCoordMapping =
-  //       PhysicalCoreCoordMapping::getMemorySpaceMapping(
-  //           device.getChipIds(), systemDesc.getChipDescs(),
-  //           dataMovementType == NocTx::Type::Read
-  //               ? inputLayout.getMemorySpace()
-  //               : outputLayout.getMemorySpace());
-
-  //   int regIdx = 0;
-  //   for (auto [dstCoord, transactions] : dm) {
-  //     Block *block =
-  //         rewriter.createBlock(&metalEnqueueProgram.getRegion(regIdx++));
-  //     createDataMovementThread(op->getLoc(), block, inputBaseAddress,
-  //                              outputBaseAddress, transactions,
-  //                              physicalCoordMapping, addressAlignment);
-  //     OpBuilder endBuilder = OpBuilder::atBlockEnd(block);
-  //     endBuilder.create<ttkernel::ReturnOp>(op->getLoc());
-  //   }
-  //   rewriter.replaceOp(op, metalEnqueueProgram);
-
-  //   return llvm::success();
-  // }
-
-  // static void createDataMovementThread(
-  //     Location loc, Block *block, int64_t inputBaseAddress,
-  //     int64_t outputBaseAddress, ArrayRef<NocTx> transactions,
-  //     const PhysicalCoreCoordMapping &physicalCoordMapping,
-  //     std::int64_t addressAlignment, Value *inputCB = nullptr) {
-
-  //   assert(inputBaseAddress);
-  //   assert(outputBaseAddress);
-  //   assert(inputBaseAddress % addressAlignment == 0);
-  //   assert(outputBaseAddress % addressAlignment == 0);
-  //   OpBuilder nocBuilder = OpBuilder::atBlockEnd(block);
-  //   NocTx::Type type = transactions.front().type;
-
-  //   // each 'entry' is {I32:$dst, I32:$src, I32:$size, I32:<$y,$x>,
-  //   // (I32:$numElements if have inputCB)}:
-  //   int32_t const entrySize = 4 + (inputCB != nullptr);
-
-  //   // convert 'transactions' into compile time 'NocTransactionsTableOp'
-  //   // parameters:
-
-  //   llvm::SmallVector<int32_t, 48> entries;
-  //   for (auto const &tx : transactions) {
-  //     // all transactions are of the same read/write type:
-  //     assert(tx.type == type);
-
-  //     assert(tx.srcOffset % addressAlignment == 0);
-  //     assert(tx.dstOffset % addressAlignment == 0);
-  //     assert(tx.size % addressAlignment == 0);
-
-  //     entries.emplace_back(outputBaseAddress + tx.dstOffset);
-  //     entries.emplace_back(inputBaseAddress + tx.srcOffset);
-  //     entries.emplace_back(tx.size);
-
-  //     auto const [yPhys, xPhys] = physicalCoordMapping[tx.coreCoord];
-  //     entries.emplace_back((yPhys << 16) | xPhys); // x:lo, y:hi
-
-  //     if (inputCB != nullptr) {
-  //       entries.emplace_back(tx.numElements);
-  //     }
-  //   }
-
-  //   mlir::IntegerType i32Type = nocBuilder.getI32Type();   // for 'scf' ops
-  //   mlir::IndexType indexType = nocBuilder.getIndexType(); // for 'memref'
-  //   ops
-
-  //   auto entriesAttr = nocBuilder.getDenseI32ArrayAttr(entries);
-  //   auto tableType = MemRefType::get(
-  //       {static_cast<int32_t>(entries.size() / entrySize), entrySize},
-  //       i32Type, AffineMap::getMultiDimIdentityMap(2,
-  //       nocBuilder.getContext()));
-  //   auto tableOp = nocBuilder.create<ttkernel::NocTransactionsTableOp>(
-  //       loc, tableType, entriesAttr);
-
-  //   auto i32 = [&](int32_t value) {
-  //     return nocBuilder.create<arith::ConstantOp>(
-  //         loc, nocBuilder.getI32IntegerAttr(value));
-  //   };
-
-  //   auto index = [&](int64_t value) {
-  //     return nocBuilder.create<arith::ConstantOp>(
-  //         loc, nocBuilder.getIndexAttr(value));
-  //   };
-
-  //   auto coordWidth = i32(16);
-  //   auto coordMask = i32(0xFFFF);
-
-  //   auto loop = nocBuilder.create<scf::ForOp>(loc, i32(0),
-  //                                             i32(transactions.size()),
-  //                                             i32(1));
-  //   nocBuilder.setInsertionPointToStart(loop.getBody());
-  //   {
-  //     // memref.load/store requires 'index'-typed indexing, but 'scf.for'
-  //     can't
-  //     // use that, so make use of arith index casting:
-
-  //     auto entry = nocBuilder.create<arith::IndexCastOp>(
-  //         loc, indexType, loop.getInductionVar());
-
-  //     int32_t slot = 0;
-
-  //     std::array<Value, 2> vs{entry, index(slot++)};
-  //     auto dst = nocBuilder.create<memref::LoadOp>(loc, tableOp, vs);
-  //     vs[1] = index(slot++);
-  //     auto src = nocBuilder.create<memref::LoadOp>(loc, tableOp, vs);
-
-  //     vs[1] = index(slot++);
-  //     auto size = nocBuilder.create<memref::LoadOp>(loc, tableOp, vs);
-
-  //     vs[1] = index(slot++);
-  //     auto xy =
-  //         nocBuilder.create<memref::LoadOp>(loc, tableOp, vs)->getResult(0);
-
-  //     // split 'xy' into an <x,y> pair:
-
-  //     auto x = nocBuilder.create<arith::AndIOp>(loc, xy, coordMask);
-  //     auto y = nocBuilder.create<arith::ShRUIOp>(loc, xy, coordWidth);
-
-  //     // emit read/write op, bracketed by CB ops if needed:
-
-  //     auto rw = [&] {
-  //       switch (type) {
-  //       case NocTx::Type::Read: {
-  //         auto srcRemote =
-  //             nocBuilder.create<ttkernel::GetNocAddrXYOp>(loc, x, y, src)
-  //                 .getResult();
-  //         nocBuilder.create<ttkernel::NocAsyncReadOp>(loc, srcRemote, dst,
-  //                                                     size);
-  //       } break;
-  //       case NocTx::Type::Write: {
-  //         auto dstRemote =
-  //             nocBuilder.create<ttkernel::GetNocAddrXYOp>(loc, x, y, dst)
-  //                 .getResult();
-  //         nocBuilder.create<ttkernel::NocAsyncWriteOp>(loc, src, dstRemote,
-  //                                                      size);
-  //       } break;
-  //       }
-  //     };
-
-  //     if (!inputCB) {
-  //       rw();
-  //     } else {
-  //       vs[1] = index(slot++);
-  //       auto numElements = nocBuilder.create<memref::LoadOp>(loc, tableOp,
-  //       vs); nocBuilder.create<ttkernel::CBReserveBackOp>(loc, *inputCB,
-  //                                                    numElements);
-  //       rw();
-  //       nocBuilder.create<ttkernel::NocAsyncReadBarrierOp>(loc);
-  //       nocBuilder.create<ttkernel::CBPushBackOp>(loc, *inputCB,
-  //       numElements);
-  //     }
-  //   }
-  //   nocBuilder.setInsertionPointAfter(loop);
-
-  //   if (!inputCB) {
-  //     switch (type) {
-  //     case NocTx::Type::Read: {
-  //       nocBuilder.create<ttkernel::NocAsyncReadBarrierOp>(loc);
-  //     } break;
-  //     case NocTx::Type::Write: {
-  //       nocBuilder.create<ttkernel::NocAsyncWriteBarrierOp>(loc);
-  //     } break;
-  //     }
-  //   }
-  // }
-
-  // LogicalResult reformat(ttir::ToLayoutOp op, PatternRewriter &rewriter)
-  // const {
-  //   auto inputTy = mlir::cast<RankedTensorType>(op.getInput().getType());
-  //   auto outputTy = mlir::cast<RankedTensorType>(op.getType(0));
-  //   auto inputLayout =
-  //   mlir::cast<tt::MetalLayoutAttr>(inputTy.getEncoding()); auto outputLayout
-  //   = mlir::cast<tt::MetalLayoutAttr>(outputTy.getEncoding()); bool
-  //   shouldTilize = not inputLayout.isTiled() && outputLayout.isTiled(); bool
-  //   shouldUntilize = inputLayout.isTiled() && not outputLayout.isTiled();
-  //   assert(shouldTilize ^ shouldUntilize);
-  //   assert(inputLayout.getGrid() == outputLayout.getGrid());
-
-  //   // Ensure tt-mlir/tt-metal agree on number, and set UnpackToDestMode per
-  //   CB uint32_t chipNumCBs =
-  //   op.getSystemDesc().getChipDescs()[0].getNumCBs(); constexpr uint32_t
-  //   kNumCBs = 1 + ttkernel::getMaxEnumValForCBPort(); assert(chipNumCBs ==
-  //   kNumCBs && "Mismatch between tt-mlir and tt-metal "
-  //                                   "number of CBs");
-
-  //   llvm::SmallVector<ttkernel::UnpackToDestMode, kNumCBs> unpackToDestModes(
-  //       kNumCBs, ttkernel::UnpackToDestMode::Default);
-
-  //   auto tensixAttr = rewriter.getAttr<ttkernel::TensixConfigAttr>(
-  //       ttkernel::MathFidelity::HiFi4, false, false, unpackToDestModes);
-  //   SmallVector<Attribute> kernelConfigs = {tensixAttr};
-  //   SmallVector<Attribute> coreRanges = {
-  //       rewriter.getAttr<ttmetal::CoreRangeAttr>(inputLayout.getGrid()),
-  //   };
-
-  //   auto metalEnqueueProgram = rewriter.create<ttmetal::EnqueueProgramOp>(
-  //       op.getLoc(), SmallVector<Type>({outputTy}),
-  //       SmallVector<Value>({op.getInput()}),
-  //       SmallVector<Value>({op.getOutput()}), rewriter.getArrayAttr({}),
-  //       rewriter.getArrayAttr(coreRanges),
-  //       rewriter.getArrayAttr(kernelConfigs), kernelConfigs.size());
-
-  //   std::int64_t inputBaseAddress = lookupAddress(op.getInput());
-  //   std::int64_t outputBaseAddress = lookupAddress(op.getOutput());
-  //   Block *tensixBlock =
-  //       rewriter.createBlock(&metalEnqueueProgram.getRegion(0));
-  //   OpBuilder tensixBuilder(tensixBlock, tensixBlock->begin());
-  //   uint64_t pageSize = inputLayout.isTiled()
-  //                           ? inputLayout.getElementSizeBytes()
-  //                           : outputLayout.getElementSizeBytes();
-  //   Type inputCBTy = rewriter.getType<ttkernel::CBType>(
-  //       ttkernel::CBPort::In0, inputBaseAddress,
-  //       mlir::cast<MemRefType>(inputLayout.getMemref()), pageSize,
-  //       /*num_buffers*/ 1);
-  //   Type outputCBTy = rewriter.getType<ttkernel::CBType>(
-  //       ttkernel::CBPort::Out0, outputBaseAddress,
-  //       mlir::cast<MemRefType>(outputLayout.getMemref()), pageSize,
-  //       /*num_buffers*/ 1);
-  //   tensixBlock->addArgument(inputCBTy, op.getLoc());
-  //   tensixBlock->addArgument(outputCBTy, op.getLoc());
-
-  //   llvm::ArrayRef<int64_t> shardTileShape =
-  //       (shouldTilize ? outputLayout.getMemref().getShape()
-  //                     : inputLayout.getMemref().getShape());
-
-  //   assert(shardTileShape.size() >= 2 && "Tile shape rank must be at least
-  //   2");
-
-  //   // How many tiles should kernel tilize in one block.
-  //   arith::ConstantOp numTilesPerBlock =
-  //       tensixBuilder.create<arith::ConstantOp>(
-  //           op.getLoc(), tensixBuilder.getI32Type(),
-  //           tensixBuilder.getI32IntegerAttr(shardTileShape.back()));
-
-  //   if (shouldTilize) {
-  //     tensixBuilder.create<ttkernel::TilizeInitOp>(
-  //         op.getLoc(), tensixBlock->getArgument(0), numTilesPerBlock,
-  //         tensixBlock->getArgument(1));
-  //   } else {
-  //     tensixBuilder.create<ttkernel::UntilizeInitOp>(
-  //         op.getLoc(), tensixBlock->getArgument(0),
-  //         tensixBlock->getArgument(1));
-  //   }
-
-  //   uint64_t shardTileVolume = 1;
-  //   for (int64_t dim : shardTileShape) {
-  //     shardTileVolume *= dim;
-  //   }
-  //   const uint64_t numBlocks = shardTileVolume / shardTileShape.back();
-
-  //   for (uint iblock = 0; iblock < numBlocks; ++iblock) {
-  //     if (shouldTilize) {
-  //       tensixBuilder.create<ttkernel::TilizeBlockOp>(
-  //           op.getLoc(), tensixBlock->getArgument(0), numTilesPerBlock,
-  //           tensixBlock->getArgument(1));
-  //     } else {
-  //       tensixBuilder.create<ttkernel::UntilizeBlockOp>(
-  //           op.getLoc(), tensixBlock->getArgument(0), numTilesPerBlock,
-  //           tensixBlock->getArgument(1));
-  //     }
-  //     tensixBuilder.create<ttkernel::CBPopFrontOp>(
-  //         op.getLoc(), tensixBlock->getArgument(0), numTilesPerBlock);
-  //     tensixBuilder.create<ttkernel::CBPushBackOp>(
-  //         op.getLoc(), tensixBlock->getArgument(1), numTilesPerBlock);
-  //   }
-
-  //   tensixBuilder.create<ttkernel::ReturnOp>(op.getLoc());
-
-  //   rewriter.replaceOp(op, metalEnqueueProgram);
-
-  //   return success();
-  // }
-
-  LogicalResult matchAndRewrite(ttir::ToLayoutOp op,
+  LogicalResult matchAndRewrite(ttir::GenericOp op,
                                 PatternRewriter &rewriter) const final {
-    // auto inputTy = mlir::cast<RankedTensorType>(op.getInput().getType());
-    // auto outputTy = mlir::cast<RankedTensorType>(op.getType(0));
-    // if (not inputTy.getEncoding() || not outputTy.getEncoding()) {
-    //   return failure();
-    // }
-    // assert(inputTy.getShape() == outputTy.getShape());
-    // assert(mlir::isa<tt::MetalLayoutAttr>(inputTy.getEncoding()));
-    // assert(mlir::isa<tt::MetalLayoutAttr>(outputTy.getEncoding()));
-    // auto inputLayout =
-    // mlir::cast<tt::MetalLayoutAttr>(inputTy.getEncoding()); auto outputLayout
-    // = mlir::cast<tt::MetalLayoutAttr>(outputTy.getEncoding());
-
-    // auto components = op.compoundComponents();
-    // bool isCompound = (static_cast<int>(components.isLayoutChange) +
-    //                    static_cast<int>(components.isGridChange ||
-    //                                     components.isMemorySpaceChange) +
-    //                    static_cast<int>(components.isFormatChange)) > 1;
-    // assert(!isCompound && "Only one change is allowed");
-
-    // assert(!isCompound && "Only one change is allowed");
-    // if (components.isMemorySpaceChange) {
-    //   if (inputLayout.isSystemMemorySpace()) {
-    //     assert(outputLayout.isDeviceMemorySpace());
-    //     assert(false && "System memory to device memory is not supported
-    //     yet");
-    //   } else if (outputLayout.isSystemMemorySpace()) {
-    //     assert(inputLayout.isDeviceMemorySpace());
-    //     rewriter.replaceOpWithNewOp<ttmetal::EnqueueReadBufferOp>(
-    //         op, outputTy, op.getInput(), op.getOutput());
-    //   } else {
-    //     return relayout(op, rewriter);
-    //   }
-    // } else if (components.isLayoutChange || components.isGridChange) {
-    //   return relayout(op, rewriter);
-    // } else {
-    //   assert(components.isFormatChange);
-    //   return reformat(op, rewriter);
-    // }
-    return failure();
-  }
+    auto coreRanges = llvm::SmallVector<Attribute>();
+    coreRanges.reserve(op.getThreads().size());
+    for (size_t i = 0; i < op.getThreads().size(); i++) {
+      coreRanges.push_back(
+          rewriter.getAttr<ttmetal::CoreRangeAttr>(op.getGrid()));
+    }
+    rewriter.replaceOpWithNewOp<ttmetal::EnqueueProgramOp>(
+        op, op->getResultTypes(), op.getInputs(), op.getOutputs(),
+        op.getThreads(), rewriter.getArrayAttr(coreRanges),
+        rewriter.getArrayAttr({}));
+    return success();
+  };
 };
 } // namespace
-
 namespace {
-class TTIRToTTMetalAllocRewriter : public OpRewritePattern<ttir::AllocOp> {
+class MemrefAllocRewriter : public OpRewritePattern<memref::AllocOp> {
 public:
-  using OpRewritePattern<ttir::AllocOp>::OpRewritePattern;
+  using OpRewritePattern<memref::AllocOp>::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(ttir::AllocOp op,
+  LogicalResult matchAndRewrite(memref::AllocOp op,
                                 PatternRewriter &rewriter) const final {
-    rewriter.replaceOpWithNewOp<ttmetal::CreateBufferOp>(
-        op, op.getType(), op.getAddress(), op.getSize(), op.getMemorySpace());
+
+    assert(op->getAttr("address") && "No address attribute found, failing.");
+    auto address = op->getAttrOfType<IntegerAttr>("address");
+    assert(op.getMemref().getType().getMemorySpace() &&
+           "No memref memroy space found, failing.");
+    assert(mlir::isa<TileType>(op.getMemref().getType().getElementType()) &&
+           "Expected memref to have tile element type, failing.");
+    auto size = mlir::cast<TileType>(op.getMemref().getType().getElementType())
+                    .getSizeBytes() *
+                op.getMemref().getType().getNumElements();
+    auto memorySpace = mlir::cast<tt::MemorySpaceAttr>(
+        op.getMemref().getType().getMemorySpace());
+    auto createBufferOp = rewriter.create<ttmetal::CreateBufferOp>(
+        op->getLoc(), op.getMemref().getType(), address.getInt(), size,
+        memorySpace.getValue());
+    rewriter.replaceOp(op, createBufferOp);
+
     return success();
-  }
-};
-} // namespace
-
-namespace {
-class TTIRToTTMetalDeallocRewriter : public OpRewritePattern<ttir::DeallocOp> {
-public:
-  using OpRewritePattern<ttir::DeallocOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(ttir::DeallocOp op,
-                                PatternRewriter &rewriter) const final {
-    rewriter.replaceOpWithNewOp<ttmetal::DeallocateBufferOp>(op,
-                                                             op.getResult());
-    return success();
-  }
-};
-} // namespace
-
-namespace {
-class TTIRToTTMetalFillRewriter : public OpRewritePattern<ttir::FillOp> {
-public:
-  using OpRewritePattern<ttir::FillOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(ttir::FillOp op,
-                                PatternRewriter &rewriter) const final {
-    rewriter.replaceOpWithNewOp<ttmetal::EnqueueWriteBufferOp>(
-        op, op.getResult().getType(), op.getOutput(), op.getValue());
-    return success();
-  }
+  };
 };
 } // namespace
 
@@ -611,10 +68,7 @@ namespace mlir::tt {
 void populateTTIRToTTMetalPatterns(MLIRContext *ctx,
                                    RewritePatternSet &patterns,
                                    TypeConverter & /*typeConverter*/) {
-  patterns.add<ttmetal::TTIRToTTMetalLayoutRewriter,
-               ttmetal::TTIRToTTMetalAllocRewriter,
-               ttmetal::TTIRToTTMetalDeallocRewriter,
-               ttmetal::TTIRToTTMetalFillRewriter>(ctx);
+  patterns.add<ttmetal::TTIRGenericRewriter, ttmetal::MemrefAllocRewriter>(ctx);
 }
 
 } // namespace mlir::tt

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
@@ -40,8 +40,11 @@ public:
   LogicalResult matchAndRewrite(memref::AllocOp op,
                                 PatternRewriter &rewriter) const final {
 
-    assert(op->getAttr("address") && "No address attribute found, failing.");
-    auto address = op->getAttrOfType<IntegerAttr>("address");
+    auto address = op->getAttr("address")
+                       ? op->getAttrOfType<IntegerAttr>("address")
+                       : rewriter.getI64IntegerAttr(
+                             1000); // arbitrary default for now, remove when
+                                    // allocate pass is implemented
     assert(op.getMemref().getType().getMemorySpace() &&
            "No memref memroy space found, failing.");
     assert(mlir::isa<TileType>(op.getMemref().getType().getElementType()) &&

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
@@ -51,492 +51,512 @@ namespace mlir::tt::ttmetal {
 //
 // This routine is used to lookup the address of tensors for address generation
 // and for CB creation.
-static uint64_t lookupAddress(Value value) {
-  auto blockArg = mlir::dyn_cast<BlockArgument>(value);
-  if (blockArg) {
-    auto *funcOp = blockArg.getOwner()->getParentOp();
-    if (mlir::isa<func::FuncOp>(funcOp)) {
-      auto argAlloc = mlir::cast<ArgumentAllocationAttr>(
-          mlir::cast<ArrayAttr>(funcOp->getDiscardableAttr(
-              ArgumentAllocationAttr::name))[blockArg.getArgNumber()]);
-      return argAlloc.getAddress();
-    }
-  }
+// static uint64_t lookupAddress(Value value) {
+//   auto blockArg = mlir::dyn_cast<BlockArgument>(value);
+//   if (blockArg) {
+//     auto *funcOp = blockArg.getOwner()->getParentOp();
+//     if (mlir::isa<func::FuncOp>(funcOp)) {
+//       auto argAlloc = mlir::cast<ArgumentAllocationAttr>(
+//           mlir::cast<ArrayAttr>(funcOp->getDiscardableAttr(
+//               ArgumentAllocationAttr::name))[blockArg.getArgNumber()]);
+//       return argAlloc.getAddress();
+//     }
+//   }
 
-  auto *op = value.getDefiningOp();
-  if (!op) {
-    return 0;
-  }
+//   auto *op = value.getDefiningOp();
+//   if (!op) {
+//     return 0;
+//   }
 
-  while (isa<DestinationStyleOpInterface>(op)) {
-    assert(op->getResults().size() == 1);
-    auto dps = cast<DestinationStyleOpInterface>(op);
-    assert(dps.getNumDpsInits() == 1);
-    auto *opOperand = dps.getDpsInitOperand(0);
-    value = opOperand->get();
-    op = value.getDefiningOp();
-  }
+//   while (isa<DestinationStyleOpInterface>(op)) {
+//     assert(op->getResults().size() == 1);
+//     auto dps = cast<DestinationStyleOpInterface>(op);
+//     assert(dps.getNumDpsInits() == 1);
+//     auto *opOperand = dps.getDpsInitOperand(0);
+//     value = opOperand->get();
+//     op = value.getDefiningOp();
+//   }
 
-  auto allocOp = dyn_cast<ttir::AllocOp>(op);
-  if (!allocOp) {
-    return 0;
-  }
-  return allocOp.getAddress();
-}
+//   auto allocOp = dyn_cast<ttir::AllocOp>(op);
+//   if (!allocOp) {
+//     return 0;
+//   }
+//   return allocOp.getAddress();
+// }
 
 namespace {
 class TTIRToTTMetalLayoutRewriter : public OpRewritePattern<ttir::ToLayoutOp> {
 public:
   using OpRewritePattern<ttir::ToLayoutOp>::OpRewritePattern;
 
-  struct NocTx {
-    enum class Type { Read, Write };
+  // struct NocTx {
+  //   enum class Type { Read, Write };
 
-    Type type;
-    PhysicalCoreCoord coreCoord;
-    std::int64_t srcOffset = 0;
-    std::int64_t dstOffset = 0;
-    std::int64_t size = 0;
-    std::int32_t numElements = 0;
+  //   Type type;
+  //   PhysicalCoreCoord coreCoord;
+  //   std::int64_t srcOffset = 0;
+  //   std::int64_t dstOffset = 0;
+  //   std::int64_t size = 0;
+  //   std::int32_t numElements = 0;
 
-    NocTx(Type type, PhysicalCoreCoord coreCoord, std::int64_t srcOffset,
-          std::int64_t dstOffset, std::int64_t size, std::int32_t numElements)
-        : type(type), coreCoord(coreCoord), srcOffset(srcOffset),
-          dstOffset(dstOffset), size(size), numElements(numElements) {}
+  //   NocTx(Type type, PhysicalCoreCoord coreCoord, std::int64_t srcOffset,
+  //         std::int64_t dstOffset, std::int64_t size, std::int32_t
+  //         numElements)
+  //       : type(type), coreCoord(coreCoord), srcOffset(srcOffset),
+  //         dstOffset(dstOffset), size(size), numElements(numElements) {}
 
-    bool isContiguous(PhysicalCoreCoord nextCoord, std::int64_t nextSrcOffset,
-                      std::int64_t nextDstOffset) const {
-      return (nextCoord == coreCoord) && (nextSrcOffset == srcOffset + size) &&
-             (nextDstOffset == dstOffset + size);
-    }
-  };
+  //   bool isContiguous(PhysicalCoreCoord nextCoord, std::int64_t
+  //   nextSrcOffset,
+  //                     std::int64_t nextDstOffset) const {
+  //     return (nextCoord == coreCoord) && (nextSrcOffset == srcOffset + size)
+  //     &&
+  //            (nextDstOffset == dstOffset + size);
+  //   }
+  // };
 
-  // This routine calculates the data movement for a tensor layout change by
-  // tracing the walk order of the src and dst affine maps.  The sample routine
-  // is just a helper function that iterates over the tensor shape and calls the
-  // lambda with the current index.  It walks the shape in innermost-major
-  // order. It also coalesces the noc transactions.
-  //
-  // The return value is a map of physical cores where each core has
-  // an associated list of noc reads/writes to be performed.
-  static llvm::MapVector<PhysicalCoreCoord, mlir::SmallVector<NocTx>>
-  calculateDataMovement(ArrayRef<int64_t> tensorShape, std::int64_t elemSize,
-                        AffineMap src, AffineMap dst, NocTx::Type type,
-                        std::int64_t dstCapacity) {
-    bool read = type == NocTx::Type::Read;
-    llvm::MapVector<PhysicalCoreCoord, mlir::SmallVector<NocTx>> txMap;
-    assert(src.getNumResults() == MemoryMapResultIdx::NumIndices);
-    assert(dst.getNumResults() == MemoryMapResultIdx::NumIndices);
+  // // This routine calculates the data movement for a tensor layout change by
+  // // tracing the walk order of the src and dst affine maps.  The sample
+  // routine
+  // // is just a helper function that iterates over the tensor shape and calls
+  // the
+  // // lambda with the current index.  It walks the shape in innermost-major
+  // // order. It also coalesces the noc transactions.
+  // //
+  // // The return value is a map of physical cores where each core has
+  // // an associated list of noc reads/writes to be performed.
+  // static llvm::MapVector<PhysicalCoreCoord, mlir::SmallVector<NocTx>>
+  // calculateDataMovement(ArrayRef<int64_t> tensorShape, std::int64_t elemSize,
+  //                       AffineMap src, AffineMap dst, NocTx::Type type,
+  //                       std::int64_t dstCapacity) {
+  //   bool read = type == NocTx::Type::Read;
+  //   llvm::MapVector<PhysicalCoreCoord, mlir::SmallVector<NocTx>> txMap;
+  //   assert(src.getNumResults() == MemoryMapResultIdx::NumIndices);
+  //   assert(dst.getNumResults() == MemoryMapResultIdx::NumIndices);
 
-    ::ttmlir::utils::sample(
-        tensorShape, [&txMap, src, dst, elemSize, read, type,
-                      dstCapacity](ArrayRef<std::int64_t> index) {
-          SmallVector<int64_t> srcResults = src.compose(index);
-          SmallVector<int64_t> dstResults = dst.compose(index);
-          assert(srcResults.size() == src.getNumResults());
-          assert(dstResults.size() == dst.getNumResults());
-          PhysicalCoreCoord srcCoord(srcResults);
-          PhysicalCoreCoord dstCoord(dstResults);
-          std::int64_t srcOffset = srcResults.back() * elemSize;
-          std::int64_t dstOffset = dstResults.back() * elemSize;
+  //   ::ttmlir::utils::sample(
+  //       tensorShape, [&txMap, src, dst, elemSize, read, type,
+  //                     dstCapacity](ArrayRef<std::int64_t> index) {
+  //         SmallVector<int64_t> srcResults = src.compose(index);
+  //         SmallVector<int64_t> dstResults = dst.compose(index);
+  //         assert(srcResults.size() == src.getNumResults());
+  //         assert(dstResults.size() == dst.getNumResults());
+  //         PhysicalCoreCoord srcCoord(srcResults);
+  //         PhysicalCoreCoord dstCoord(dstResults);
+  //         std::int64_t srcOffset = srcResults.back() * elemSize;
+  //         std::int64_t dstOffset = dstResults.back() * elemSize;
 
-          SmallVector<NocTx> &txs = txMap[read ? dstCoord : srcCoord];
-          if (not txs.empty() &&
-              txs.back().isContiguous(read ? srcCoord : dstCoord, srcOffset,
-                                      dstOffset) &&
-              txs.back().size + elemSize <= dstCapacity) {
-            txs.back().size += elemSize;
-            txs.back().numElements++;
-          } else {
-            txs.push_back(NocTx(type, read ? srcCoord : dstCoord, srcOffset,
-                                dstOffset, elemSize, 1));
-          }
-        });
+  //         SmallVector<NocTx> &txs = txMap[read ? dstCoord : srcCoord];
+  //         if (not txs.empty() &&
+  //             txs.back().isContiguous(read ? srcCoord : dstCoord, srcOffset,
+  //                                     dstOffset) &&
+  //             txs.back().size + elemSize <= dstCapacity) {
+  //           txs.back().size += elemSize;
+  //           txs.back().numElements++;
+  //         } else {
+  //           txs.push_back(NocTx(type, read ? srcCoord : dstCoord, srcOffset,
+  //                               dstOffset, elemSize, 1));
+  //         }
+  //       });
 
-    return txMap;
-  }
+  //   return txMap;
+  // }
 
-  LogicalResult relayout(ttir::ToLayoutOp op, PatternRewriter &rewriter) const {
-    auto inputTy = mlir::cast<RankedTensorType>(op.getInput().getType());
-    auto outputTy = mlir::cast<RankedTensorType>(op.getType(0));
-    auto inputLayout = mlir::cast<tt::MetalLayoutAttr>(inputTy.getEncoding());
-    auto outputLayout = mlir::cast<tt::MetalLayoutAttr>(outputTy.getEncoding());
-    tt::DeviceAttr device = op.getDevice();
-    assert(device);
-    tt::SystemDescAttr systemDesc = op.getSystemDesc();
-    assert(systemDesc);
-    auto addressAlignment = systemDesc.getAddressAlignBytes(
-        /*inputLayout.getMemorySpace() issue #407*/);
-    assert(inputLayout.getPhysicalShape(inputTy.getShape()) ==
-               outputLayout.getPhysicalShape(outputTy.getShape()) &&
-           "Physical shapes must match for now");
+  // LogicalResult relayout(ttir::ToLayoutOp op, PatternRewriter &rewriter)
+  // const {
+  //   auto inputTy = mlir::cast<RankedTensorType>(op.getInput().getType());
+  //   auto outputTy = mlir::cast<RankedTensorType>(op.getType(0));
+  //   auto inputLayout =
+  //   mlir::cast<tt::MetalLayoutAttr>(inputTy.getEncoding()); auto outputLayout
+  //   = mlir::cast<tt::MetalLayoutAttr>(outputTy.getEncoding()); tt::DeviceAttr
+  //   device = op.getDevice(); assert(device); tt::SystemDescAttr systemDesc =
+  //   op.getSystemDesc(); assert(systemDesc); auto addressAlignment =
+  //   systemDesc.getAddressAlignBytes(
+  //       /*inputLayout.getMemorySpace() issue #407*/);
+  //   assert(inputLayout.getPhysicalShape(inputTy.getShape()) ==
+  //              outputLayout.getPhysicalShape(outputTy.getShape()) &&
+  //          "Physical shapes must match for now");
 
-    // Shape that will be traversed when calculating the data movement between
-    // layouts.
-    SmallVector<int64_t> inputShape =
-        inputLayout.isTiled() ? inputLayout.getTiledShape(inputTy.getShape())
-                              : SmallVector<int64_t>(inputTy.getShape());
-    SmallVector<int64_t> outputShape =
-        outputLayout.isTiled() ? outputLayout.getTiledShape(outputTy.getShape())
-                               : SmallVector<int64_t>(outputTy.getShape());
+  //   // Shape that will be traversed when calculating the data movement
+  //   between
+  //   // layouts.
+  //   SmallVector<int64_t> inputShape =
+  //       inputLayout.isTiled() ? inputLayout.getTiledShape(inputTy.getShape())
+  //                             : SmallVector<int64_t>(inputTy.getShape());
+  //   SmallVector<int64_t> outputShape =
+  //       outputLayout.isTiled() ?
+  //       outputLayout.getTiledShape(outputTy.getShape())
+  //                              : SmallVector<int64_t>(outputTy.getShape());
 
-    assert(inputShape == outputShape && "Shapes must be identical");
+  //   assert(inputShape == outputShape && "Shapes must be identical");
 
-    // If tiles are reblocked, the linear maps must be identical.
-    assert(!(inputLayout.isTiled() && outputLayout.isTiled()) ||
-           inputLayout.getLinear() == outputLayout.getLinear());
+  //   // If tiles are reblocked, the linear maps must be identical.
+  //   assert(!(inputLayout.isTiled() && outputLayout.isTiled()) ||
+  //          inputLayout.getLinear() == outputLayout.getLinear());
 
-    // When the layouts are tiled, the linear maps are the identity maps.
-    // Reasoning behind this is that since it's already ensured that scalar
-    // linear maps identical, tensors can be viewed simply as bags of tiles
-    // omitting any affine complexity.
-    AffineMap inputLinearMap = inputLayout.isTiled()
-                                   ? inputLayout.getIdentityTileLinearMap()
-                                   : inputLayout.getLinear();
-    AffineMap outputLinearMap = outputLayout.isTiled()
-                                    ? outputLayout.getIdentityTileLinearMap()
-                                    : outputLayout.getLinear();
+  //   // When the layouts are tiled, the linear maps are the identity maps.
+  //   // Reasoning behind this is that since it's already ensured that scalar
+  //   // linear maps identical, tensors can be viewed simply as bags of tiles
+  //   // omitting any affine complexity.
+  //   AffineMap inputLinearMap = inputLayout.isTiled()
+  //                                  ? inputLayout.getIdentityTileLinearMap()
+  //                                  : inputLayout.getLinear();
+  //   AffineMap outputLinearMap = outputLayout.isTiled()
+  //                                   ? outputLayout.getIdentityTileLinearMap()
+  //                                   : outputLayout.getLinear();
 
-    assert(inputLayout.getMemorySpace() == MemorySpace::DeviceL1 ||
-           outputLayout.getMemorySpace() == MemorySpace::DeviceL1 &&
-               "DRAM <-> DRAM is not supported yet");
-    NocTx::Type dataMovementType =
-        outputLayout.getMemorySpace() == MemorySpace::DeviceL1
-            ? NocTx::Type::Read
-            : NocTx::Type::Write;
+  //   assert(inputLayout.getMemorySpace() == MemorySpace::DeviceL1 ||
+  //          outputLayout.getMemorySpace() == MemorySpace::DeviceL1 &&
+  //              "DRAM <-> DRAM is not supported yet");
+  //   NocTx::Type dataMovementType =
+  //       outputLayout.getMemorySpace() == MemorySpace::DeviceL1
+  //           ? NocTx::Type::Read
+  //           : NocTx::Type::Write;
 
-    AffineMap src = inputLayout.projectOnto(
-        inputLinearMap, device.getMemoryMap(inputLayout.getMemref(), 0));
+  //   AffineMap src = inputLayout.projectOnto(
+  //       inputLinearMap, device.getMemoryMap(inputLayout.getMemref(), 0));
 
-    AffineMap dst = outputLayout.projectOnto(
-        outputLinearMap, device.getMemoryMap(outputLayout.getMemref(), 0));
+  //   AffineMap dst = outputLayout.projectOnto(
+  //       outputLinearMap, device.getMemoryMap(outputLayout.getMemref(), 0));
 
-    auto dm = calculateDataMovement(
-        inputShape, inputLayout.getElementSizeBytes(), src, dst,
-        dataMovementType, outputLayout.getMemrefSizeBytes());
+  //   auto dm = calculateDataMovement(
+  //       inputShape, inputLayout.getElementSizeBytes(), src, dst,
+  //       dataMovementType, outputLayout.getMemrefSizeBytes());
 
-    auto noc0Attr =
-        rewriter.getAttr<ttkernel::NocConfigAttr>(ttkernel::NocIndex::Noc0);
-    SmallVector<Attribute> kernelConfigs(dm.size(), noc0Attr);
-    SmallVector<Attribute> coreRanges;
-    coreRanges.reserve(dm.size());
-    for (auto [coreCoord, txs] : dm) {
-      SmallVector<int64_t> offset = {coreCoord.y, coreCoord.x};
-      SmallVector<int64_t> size = {1, 1};
-      coreRanges.push_back(
-          rewriter.getAttr<ttmetal::CoreRangeAttr>(offset, size));
-    };
-    std::int64_t inputBaseAddress = lookupAddress(op.getInput());
-    std::int64_t outputBaseAddress = lookupAddress(op.getOutput());
+  //   auto noc0Attr =
+  //       rewriter.getAttr<ttkernel::NocConfigAttr>(ttkernel::NocIndex::Noc0);
+  //   SmallVector<Attribute> kernelConfigs(dm.size(), noc0Attr);
+  //   SmallVector<Attribute> coreRanges;
+  //   coreRanges.reserve(dm.size());
+  //   for (auto [coreCoord, txs] : dm) {
+  //     SmallVector<int64_t> offset = {coreCoord.y, coreCoord.x};
+  //     SmallVector<int64_t> size = {1, 1};
+  //     coreRanges.push_back(
+  //         rewriter.getAttr<ttmetal::CoreRangeAttr>(offset, size));
+  //   };
+  //   std::int64_t inputBaseAddress = lookupAddress(op.getInput());
+  //   std::int64_t outputBaseAddress = lookupAddress(op.getOutput());
 
-    auto metalEnqueueProgram = rewriter.create<ttmetal::EnqueueProgramOp>(
-        op.getLoc(), SmallVector<Type>({outputTy}),
-        SmallVector<Value>({op.getInput()}),
-        SmallVector<Value>({op.getOutput()}), rewriter.getArrayAttr(coreRanges),
-        rewriter.getArrayAttr(kernelConfigs), kernelConfigs.size());
+  //   auto metalEnqueueProgram = rewriter.create<ttmetal::EnqueueProgramOp>(
+  //       op.getLoc(), SmallVector<Type>({outputTy}),
+  //       SmallVector<Value>({op.getInput()}),
+  //       SmallVector<Value>({op.getOutput()}), rewriter.getArrayAttr({}),
+  //       rewriter.getArrayAttr(coreRanges),
+  //       rewriter.getArrayAttr(kernelConfigs));
 
-    PhysicalCoreCoordMapping physicalCoordMapping =
-        PhysicalCoreCoordMapping::getMemorySpaceMapping(
-            device.getChipIds(), systemDesc.getChipDescs(),
-            dataMovementType == NocTx::Type::Read
-                ? inputLayout.getMemorySpace()
-                : outputLayout.getMemorySpace());
+  //   PhysicalCoreCoordMapping physicalCoordMapping =
+  //       PhysicalCoreCoordMapping::getMemorySpaceMapping(
+  //           device.getChipIds(), systemDesc.getChipDescs(),
+  //           dataMovementType == NocTx::Type::Read
+  //               ? inputLayout.getMemorySpace()
+  //               : outputLayout.getMemorySpace());
 
-    int regIdx = 0;
-    for (auto [dstCoord, transactions] : dm) {
-      Block *block =
-          rewriter.createBlock(&metalEnqueueProgram.getRegion(regIdx++));
-      createDataMovementThread(op->getLoc(), block, inputBaseAddress,
-                               outputBaseAddress, transactions,
-                               physicalCoordMapping, addressAlignment);
-      OpBuilder endBuilder = OpBuilder::atBlockEnd(block);
-      endBuilder.create<ttkernel::ReturnOp>(op->getLoc());
-    }
-    rewriter.replaceOp(op, metalEnqueueProgram);
+  //   int regIdx = 0;
+  //   for (auto [dstCoord, transactions] : dm) {
+  //     Block *block =
+  //         rewriter.createBlock(&metalEnqueueProgram.getRegion(regIdx++));
+  //     createDataMovementThread(op->getLoc(), block, inputBaseAddress,
+  //                              outputBaseAddress, transactions,
+  //                              physicalCoordMapping, addressAlignment);
+  //     OpBuilder endBuilder = OpBuilder::atBlockEnd(block);
+  //     endBuilder.create<ttkernel::ReturnOp>(op->getLoc());
+  //   }
+  //   rewriter.replaceOp(op, metalEnqueueProgram);
 
-    return llvm::success();
-  }
+  //   return llvm::success();
+  // }
 
-  static void createDataMovementThread(
-      Location loc, Block *block, int64_t inputBaseAddress,
-      int64_t outputBaseAddress, ArrayRef<NocTx> transactions,
-      const PhysicalCoreCoordMapping &physicalCoordMapping,
-      std::int64_t addressAlignment, Value *inputCB = nullptr) {
+  // static void createDataMovementThread(
+  //     Location loc, Block *block, int64_t inputBaseAddress,
+  //     int64_t outputBaseAddress, ArrayRef<NocTx> transactions,
+  //     const PhysicalCoreCoordMapping &physicalCoordMapping,
+  //     std::int64_t addressAlignment, Value *inputCB = nullptr) {
 
-    assert(inputBaseAddress);
-    assert(outputBaseAddress);
-    assert(inputBaseAddress % addressAlignment == 0);
-    assert(outputBaseAddress % addressAlignment == 0);
-    OpBuilder nocBuilder = OpBuilder::atBlockEnd(block);
-    NocTx::Type type = transactions.front().type;
+  //   assert(inputBaseAddress);
+  //   assert(outputBaseAddress);
+  //   assert(inputBaseAddress % addressAlignment == 0);
+  //   assert(outputBaseAddress % addressAlignment == 0);
+  //   OpBuilder nocBuilder = OpBuilder::atBlockEnd(block);
+  //   NocTx::Type type = transactions.front().type;
 
-    // each 'entry' is {I32:$dst, I32:$src, I32:$size, I32:<$y,$x>,
-    // (I32:$numElements if have inputCB)}:
-    int32_t const entrySize = 4 + (inputCB != nullptr);
+  //   // each 'entry' is {I32:$dst, I32:$src, I32:$size, I32:<$y,$x>,
+  //   // (I32:$numElements if have inputCB)}:
+  //   int32_t const entrySize = 4 + (inputCB != nullptr);
 
-    // convert 'transactions' into compile time 'NocTransactionsTableOp'
-    // parameters:
+  //   // convert 'transactions' into compile time 'NocTransactionsTableOp'
+  //   // parameters:
 
-    llvm::SmallVector<int32_t, 48> entries;
-    for (auto const &tx : transactions) {
-      // all transactions are of the same read/write type:
-      assert(tx.type == type);
+  //   llvm::SmallVector<int32_t, 48> entries;
+  //   for (auto const &tx : transactions) {
+  //     // all transactions are of the same read/write type:
+  //     assert(tx.type == type);
 
-      assert(tx.srcOffset % addressAlignment == 0);
-      assert(tx.dstOffset % addressAlignment == 0);
-      assert(tx.size % addressAlignment == 0);
+  //     assert(tx.srcOffset % addressAlignment == 0);
+  //     assert(tx.dstOffset % addressAlignment == 0);
+  //     assert(tx.size % addressAlignment == 0);
 
-      entries.emplace_back(outputBaseAddress + tx.dstOffset);
-      entries.emplace_back(inputBaseAddress + tx.srcOffset);
-      entries.emplace_back(tx.size);
+  //     entries.emplace_back(outputBaseAddress + tx.dstOffset);
+  //     entries.emplace_back(inputBaseAddress + tx.srcOffset);
+  //     entries.emplace_back(tx.size);
 
-      auto const [yPhys, xPhys] = physicalCoordMapping[tx.coreCoord];
-      entries.emplace_back((yPhys << 16) | xPhys); // x:lo, y:hi
+  //     auto const [yPhys, xPhys] = physicalCoordMapping[tx.coreCoord];
+  //     entries.emplace_back((yPhys << 16) | xPhys); // x:lo, y:hi
 
-      if (inputCB != nullptr) {
-        entries.emplace_back(tx.numElements);
-      }
-    }
+  //     if (inputCB != nullptr) {
+  //       entries.emplace_back(tx.numElements);
+  //     }
+  //   }
 
-    mlir::IntegerType i32Type = nocBuilder.getI32Type();   // for 'scf' ops
-    mlir::IndexType indexType = nocBuilder.getIndexType(); // for 'memref' ops
+  //   mlir::IntegerType i32Type = nocBuilder.getI32Type();   // for 'scf' ops
+  //   mlir::IndexType indexType = nocBuilder.getIndexType(); // for 'memref'
+  //   ops
 
-    auto entriesAttr = nocBuilder.getDenseI32ArrayAttr(entries);
-    auto tableType = MemRefType::get(
-        {static_cast<int32_t>(entries.size() / entrySize), entrySize}, i32Type,
-        AffineMap::getMultiDimIdentityMap(2, nocBuilder.getContext()));
-    auto tableOp = nocBuilder.create<ttkernel::NocTransactionsTableOp>(
-        loc, tableType, entriesAttr);
+  //   auto entriesAttr = nocBuilder.getDenseI32ArrayAttr(entries);
+  //   auto tableType = MemRefType::get(
+  //       {static_cast<int32_t>(entries.size() / entrySize), entrySize},
+  //       i32Type, AffineMap::getMultiDimIdentityMap(2,
+  //       nocBuilder.getContext()));
+  //   auto tableOp = nocBuilder.create<ttkernel::NocTransactionsTableOp>(
+  //       loc, tableType, entriesAttr);
 
-    auto i32 = [&](int32_t value) {
-      return nocBuilder.create<arith::ConstantOp>(
-          loc, nocBuilder.getI32IntegerAttr(value));
-    };
+  //   auto i32 = [&](int32_t value) {
+  //     return nocBuilder.create<arith::ConstantOp>(
+  //         loc, nocBuilder.getI32IntegerAttr(value));
+  //   };
 
-    auto index = [&](int64_t value) {
-      return nocBuilder.create<arith::ConstantOp>(
-          loc, nocBuilder.getIndexAttr(value));
-    };
+  //   auto index = [&](int64_t value) {
+  //     return nocBuilder.create<arith::ConstantOp>(
+  //         loc, nocBuilder.getIndexAttr(value));
+  //   };
 
-    auto coordWidth = i32(16);
-    auto coordMask = i32(0xFFFF);
+  //   auto coordWidth = i32(16);
+  //   auto coordMask = i32(0xFFFF);
 
-    auto loop = nocBuilder.create<scf::ForOp>(loc, i32(0),
-                                              i32(transactions.size()), i32(1));
-    nocBuilder.setInsertionPointToStart(loop.getBody());
-    {
-      // memref.load/store requires 'index'-typed indexing, but 'scf.for' can't
-      // use that, so make use of arith index casting:
+  //   auto loop = nocBuilder.create<scf::ForOp>(loc, i32(0),
+  //                                             i32(transactions.size()),
+  //                                             i32(1));
+  //   nocBuilder.setInsertionPointToStart(loop.getBody());
+  //   {
+  //     // memref.load/store requires 'index'-typed indexing, but 'scf.for'
+  //     can't
+  //     // use that, so make use of arith index casting:
 
-      auto entry = nocBuilder.create<arith::IndexCastOp>(
-          loc, indexType, loop.getInductionVar());
+  //     auto entry = nocBuilder.create<arith::IndexCastOp>(
+  //         loc, indexType, loop.getInductionVar());
 
-      int32_t slot = 0;
+  //     int32_t slot = 0;
 
-      std::array<Value, 2> vs{entry, index(slot++)};
-      auto dst = nocBuilder.create<memref::LoadOp>(loc, tableOp, vs);
-      vs[1] = index(slot++);
-      auto src = nocBuilder.create<memref::LoadOp>(loc, tableOp, vs);
+  //     std::array<Value, 2> vs{entry, index(slot++)};
+  //     auto dst = nocBuilder.create<memref::LoadOp>(loc, tableOp, vs);
+  //     vs[1] = index(slot++);
+  //     auto src = nocBuilder.create<memref::LoadOp>(loc, tableOp, vs);
 
-      vs[1] = index(slot++);
-      auto size = nocBuilder.create<memref::LoadOp>(loc, tableOp, vs);
+  //     vs[1] = index(slot++);
+  //     auto size = nocBuilder.create<memref::LoadOp>(loc, tableOp, vs);
 
-      vs[1] = index(slot++);
-      auto xy =
-          nocBuilder.create<memref::LoadOp>(loc, tableOp, vs)->getResult(0);
+  //     vs[1] = index(slot++);
+  //     auto xy =
+  //         nocBuilder.create<memref::LoadOp>(loc, tableOp, vs)->getResult(0);
 
-      // split 'xy' into an <x,y> pair:
+  //     // split 'xy' into an <x,y> pair:
 
-      auto x = nocBuilder.create<arith::AndIOp>(loc, xy, coordMask);
-      auto y = nocBuilder.create<arith::ShRUIOp>(loc, xy, coordWidth);
+  //     auto x = nocBuilder.create<arith::AndIOp>(loc, xy, coordMask);
+  //     auto y = nocBuilder.create<arith::ShRUIOp>(loc, xy, coordWidth);
 
-      // emit read/write op, bracketed by CB ops if needed:
+  //     // emit read/write op, bracketed by CB ops if needed:
 
-      auto rw = [&] {
-        switch (type) {
-        case NocTx::Type::Read: {
-          auto srcRemote =
-              nocBuilder.create<ttkernel::GetNocAddrXYOp>(loc, x, y, src)
-                  .getResult();
-          nocBuilder.create<ttkernel::NocAsyncReadOp>(loc, srcRemote, dst,
-                                                      size);
-        } break;
-        case NocTx::Type::Write: {
-          auto dstRemote =
-              nocBuilder.create<ttkernel::GetNocAddrXYOp>(loc, x, y, dst)
-                  .getResult();
-          nocBuilder.create<ttkernel::NocAsyncWriteOp>(loc, src, dstRemote,
-                                                       size);
-        } break;
-        }
-      };
+  //     auto rw = [&] {
+  //       switch (type) {
+  //       case NocTx::Type::Read: {
+  //         auto srcRemote =
+  //             nocBuilder.create<ttkernel::GetNocAddrXYOp>(loc, x, y, src)
+  //                 .getResult();
+  //         nocBuilder.create<ttkernel::NocAsyncReadOp>(loc, srcRemote, dst,
+  //                                                     size);
+  //       } break;
+  //       case NocTx::Type::Write: {
+  //         auto dstRemote =
+  //             nocBuilder.create<ttkernel::GetNocAddrXYOp>(loc, x, y, dst)
+  //                 .getResult();
+  //         nocBuilder.create<ttkernel::NocAsyncWriteOp>(loc, src, dstRemote,
+  //                                                      size);
+  //       } break;
+  //       }
+  //     };
 
-      if (!inputCB) {
-        rw();
-      } else {
-        vs[1] = index(slot++);
-        auto numElements = nocBuilder.create<memref::LoadOp>(loc, tableOp, vs);
-        nocBuilder.create<ttkernel::CBReserveBackOp>(loc, *inputCB,
-                                                     numElements);
-        rw();
-        nocBuilder.create<ttkernel::NocAsyncReadBarrierOp>(loc);
-        nocBuilder.create<ttkernel::CBPushBackOp>(loc, *inputCB, numElements);
-      }
-    }
-    nocBuilder.setInsertionPointAfter(loop);
+  //     if (!inputCB) {
+  //       rw();
+  //     } else {
+  //       vs[1] = index(slot++);
+  //       auto numElements = nocBuilder.create<memref::LoadOp>(loc, tableOp,
+  //       vs); nocBuilder.create<ttkernel::CBReserveBackOp>(loc, *inputCB,
+  //                                                    numElements);
+  //       rw();
+  //       nocBuilder.create<ttkernel::NocAsyncReadBarrierOp>(loc);
+  //       nocBuilder.create<ttkernel::CBPushBackOp>(loc, *inputCB,
+  //       numElements);
+  //     }
+  //   }
+  //   nocBuilder.setInsertionPointAfter(loop);
 
-    if (!inputCB) {
-      switch (type) {
-      case NocTx::Type::Read: {
-        nocBuilder.create<ttkernel::NocAsyncReadBarrierOp>(loc);
-      } break;
-      case NocTx::Type::Write: {
-        nocBuilder.create<ttkernel::NocAsyncWriteBarrierOp>(loc);
-      } break;
-      }
-    }
-  }
+  //   if (!inputCB) {
+  //     switch (type) {
+  //     case NocTx::Type::Read: {
+  //       nocBuilder.create<ttkernel::NocAsyncReadBarrierOp>(loc);
+  //     } break;
+  //     case NocTx::Type::Write: {
+  //       nocBuilder.create<ttkernel::NocAsyncWriteBarrierOp>(loc);
+  //     } break;
+  //     }
+  //   }
+  // }
 
-  LogicalResult reformat(ttir::ToLayoutOp op, PatternRewriter &rewriter) const {
-    auto inputTy = mlir::cast<RankedTensorType>(op.getInput().getType());
-    auto outputTy = mlir::cast<RankedTensorType>(op.getType(0));
-    auto inputLayout = mlir::cast<tt::MetalLayoutAttr>(inputTy.getEncoding());
-    auto outputLayout = mlir::cast<tt::MetalLayoutAttr>(outputTy.getEncoding());
-    bool shouldTilize = not inputLayout.isTiled() && outputLayout.isTiled();
-    bool shouldUntilize = inputLayout.isTiled() && not outputLayout.isTiled();
-    assert(shouldTilize ^ shouldUntilize);
-    assert(inputLayout.getGrid() == outputLayout.getGrid());
+  // LogicalResult reformat(ttir::ToLayoutOp op, PatternRewriter &rewriter)
+  // const {
+  //   auto inputTy = mlir::cast<RankedTensorType>(op.getInput().getType());
+  //   auto outputTy = mlir::cast<RankedTensorType>(op.getType(0));
+  //   auto inputLayout =
+  //   mlir::cast<tt::MetalLayoutAttr>(inputTy.getEncoding()); auto outputLayout
+  //   = mlir::cast<tt::MetalLayoutAttr>(outputTy.getEncoding()); bool
+  //   shouldTilize = not inputLayout.isTiled() && outputLayout.isTiled(); bool
+  //   shouldUntilize = inputLayout.isTiled() && not outputLayout.isTiled();
+  //   assert(shouldTilize ^ shouldUntilize);
+  //   assert(inputLayout.getGrid() == outputLayout.getGrid());
 
-    // Ensure tt-mlir/tt-metal agree on number, and set UnpackToDestMode per CB
-    uint32_t chipNumCBs = op.getSystemDesc().getChipDescs()[0].getNumCBs();
-    constexpr uint32_t kNumCBs = 1 + ttkernel::getMaxEnumValForCBPort();
-    assert(chipNumCBs == kNumCBs && "Mismatch between tt-mlir and tt-metal "
-                                    "number of CBs");
+  //   // Ensure tt-mlir/tt-metal agree on number, and set UnpackToDestMode per
+  //   CB uint32_t chipNumCBs =
+  //   op.getSystemDesc().getChipDescs()[0].getNumCBs(); constexpr uint32_t
+  //   kNumCBs = 1 + ttkernel::getMaxEnumValForCBPort(); assert(chipNumCBs ==
+  //   kNumCBs && "Mismatch between tt-mlir and tt-metal "
+  //                                   "number of CBs");
 
-    llvm::SmallVector<ttkernel::UnpackToDestMode, kNumCBs> unpackToDestModes(
-        kNumCBs, ttkernel::UnpackToDestMode::Default);
+  //   llvm::SmallVector<ttkernel::UnpackToDestMode, kNumCBs> unpackToDestModes(
+  //       kNumCBs, ttkernel::UnpackToDestMode::Default);
 
-    auto tensixAttr = rewriter.getAttr<ttkernel::TensixConfigAttr>(
-        ttkernel::MathFidelity::HiFi4, false, false, unpackToDestModes);
-    SmallVector<Attribute> kernelConfigs = {tensixAttr};
-    SmallVector<Attribute> coreRanges = {
-        rewriter.getAttr<ttmetal::CoreRangeAttr>(inputLayout.getGrid()),
-    };
+  //   auto tensixAttr = rewriter.getAttr<ttkernel::TensixConfigAttr>(
+  //       ttkernel::MathFidelity::HiFi4, false, false, unpackToDestModes);
+  //   SmallVector<Attribute> kernelConfigs = {tensixAttr};
+  //   SmallVector<Attribute> coreRanges = {
+  //       rewriter.getAttr<ttmetal::CoreRangeAttr>(inputLayout.getGrid()),
+  //   };
 
-    auto metalEnqueueProgram = rewriter.create<ttmetal::EnqueueProgramOp>(
-        op.getLoc(), SmallVector<Type>({outputTy}),
-        SmallVector<Value>({op.getInput()}),
-        SmallVector<Value>({op.getOutput()}), rewriter.getArrayAttr(coreRanges),
-        rewriter.getArrayAttr(kernelConfigs), kernelConfigs.size());
+  //   auto metalEnqueueProgram = rewriter.create<ttmetal::EnqueueProgramOp>(
+  //       op.getLoc(), SmallVector<Type>({outputTy}),
+  //       SmallVector<Value>({op.getInput()}),
+  //       SmallVector<Value>({op.getOutput()}), rewriter.getArrayAttr({}),
+  //       rewriter.getArrayAttr(coreRanges),
+  //       rewriter.getArrayAttr(kernelConfigs), kernelConfigs.size());
 
-    std::int64_t inputBaseAddress = lookupAddress(op.getInput());
-    std::int64_t outputBaseAddress = lookupAddress(op.getOutput());
-    Block *tensixBlock =
-        rewriter.createBlock(&metalEnqueueProgram.getRegion(0));
-    OpBuilder tensixBuilder(tensixBlock, tensixBlock->begin());
-    uint64_t pageSize = inputLayout.isTiled()
-                            ? inputLayout.getElementSizeBytes()
-                            : outputLayout.getElementSizeBytes();
-    Type inputCBTy = rewriter.getType<ttkernel::CBType>(
-        ttkernel::CBPort::In0, inputBaseAddress,
-        mlir::cast<MemRefType>(inputLayout.getMemref()), pageSize,
-        /*num_buffers*/ 1);
-    Type outputCBTy = rewriter.getType<ttkernel::CBType>(
-        ttkernel::CBPort::Out0, outputBaseAddress,
-        mlir::cast<MemRefType>(outputLayout.getMemref()), pageSize,
-        /*num_buffers*/ 1);
-    tensixBlock->addArgument(inputCBTy, op.getLoc());
-    tensixBlock->addArgument(outputCBTy, op.getLoc());
+  //   std::int64_t inputBaseAddress = lookupAddress(op.getInput());
+  //   std::int64_t outputBaseAddress = lookupAddress(op.getOutput());
+  //   Block *tensixBlock =
+  //       rewriter.createBlock(&metalEnqueueProgram.getRegion(0));
+  //   OpBuilder tensixBuilder(tensixBlock, tensixBlock->begin());
+  //   uint64_t pageSize = inputLayout.isTiled()
+  //                           ? inputLayout.getElementSizeBytes()
+  //                           : outputLayout.getElementSizeBytes();
+  //   Type inputCBTy = rewriter.getType<ttkernel::CBType>(
+  //       ttkernel::CBPort::In0, inputBaseAddress,
+  //       mlir::cast<MemRefType>(inputLayout.getMemref()), pageSize,
+  //       /*num_buffers*/ 1);
+  //   Type outputCBTy = rewriter.getType<ttkernel::CBType>(
+  //       ttkernel::CBPort::Out0, outputBaseAddress,
+  //       mlir::cast<MemRefType>(outputLayout.getMemref()), pageSize,
+  //       /*num_buffers*/ 1);
+  //   tensixBlock->addArgument(inputCBTy, op.getLoc());
+  //   tensixBlock->addArgument(outputCBTy, op.getLoc());
 
-    llvm::ArrayRef<int64_t> shardTileShape =
-        (shouldTilize ? outputLayout.getMemref().getShape()
-                      : inputLayout.getMemref().getShape());
+  //   llvm::ArrayRef<int64_t> shardTileShape =
+  //       (shouldTilize ? outputLayout.getMemref().getShape()
+  //                     : inputLayout.getMemref().getShape());
 
-    assert(shardTileShape.size() >= 2 && "Tile shape rank must be at least 2");
+  //   assert(shardTileShape.size() >= 2 && "Tile shape rank must be at least
+  //   2");
 
-    // How many tiles should kernel tilize in one block.
-    arith::ConstantOp numTilesPerBlock =
-        tensixBuilder.create<arith::ConstantOp>(
-            op.getLoc(), tensixBuilder.getI32Type(),
-            tensixBuilder.getI32IntegerAttr(shardTileShape.back()));
+  //   // How many tiles should kernel tilize in one block.
+  //   arith::ConstantOp numTilesPerBlock =
+  //       tensixBuilder.create<arith::ConstantOp>(
+  //           op.getLoc(), tensixBuilder.getI32Type(),
+  //           tensixBuilder.getI32IntegerAttr(shardTileShape.back()));
 
-    if (shouldTilize) {
-      tensixBuilder.create<ttkernel::TilizeInitOp>(
-          op.getLoc(), tensixBlock->getArgument(0), numTilesPerBlock,
-          tensixBlock->getArgument(1));
-    } else {
-      tensixBuilder.create<ttkernel::UntilizeInitOp>(
-          op.getLoc(), tensixBlock->getArgument(0),
-          tensixBlock->getArgument(1));
-    }
+  //   if (shouldTilize) {
+  //     tensixBuilder.create<ttkernel::TilizeInitOp>(
+  //         op.getLoc(), tensixBlock->getArgument(0), numTilesPerBlock,
+  //         tensixBlock->getArgument(1));
+  //   } else {
+  //     tensixBuilder.create<ttkernel::UntilizeInitOp>(
+  //         op.getLoc(), tensixBlock->getArgument(0),
+  //         tensixBlock->getArgument(1));
+  //   }
 
-    uint64_t shardTileVolume = 1;
-    for (int64_t dim : shardTileShape) {
-      shardTileVolume *= dim;
-    }
-    const uint64_t numBlocks = shardTileVolume / shardTileShape.back();
+  //   uint64_t shardTileVolume = 1;
+  //   for (int64_t dim : shardTileShape) {
+  //     shardTileVolume *= dim;
+  //   }
+  //   const uint64_t numBlocks = shardTileVolume / shardTileShape.back();
 
-    for (uint iblock = 0; iblock < numBlocks; ++iblock) {
-      if (shouldTilize) {
-        tensixBuilder.create<ttkernel::TilizeBlockOp>(
-            op.getLoc(), tensixBlock->getArgument(0), numTilesPerBlock,
-            tensixBlock->getArgument(1));
-      } else {
-        tensixBuilder.create<ttkernel::UntilizeBlockOp>(
-            op.getLoc(), tensixBlock->getArgument(0), numTilesPerBlock,
-            tensixBlock->getArgument(1));
-      }
-      tensixBuilder.create<ttkernel::CBPopFrontOp>(
-          op.getLoc(), tensixBlock->getArgument(0), numTilesPerBlock);
-      tensixBuilder.create<ttkernel::CBPushBackOp>(
-          op.getLoc(), tensixBlock->getArgument(1), numTilesPerBlock);
-    }
+  //   for (uint iblock = 0; iblock < numBlocks; ++iblock) {
+  //     if (shouldTilize) {
+  //       tensixBuilder.create<ttkernel::TilizeBlockOp>(
+  //           op.getLoc(), tensixBlock->getArgument(0), numTilesPerBlock,
+  //           tensixBlock->getArgument(1));
+  //     } else {
+  //       tensixBuilder.create<ttkernel::UntilizeBlockOp>(
+  //           op.getLoc(), tensixBlock->getArgument(0), numTilesPerBlock,
+  //           tensixBlock->getArgument(1));
+  //     }
+  //     tensixBuilder.create<ttkernel::CBPopFrontOp>(
+  //         op.getLoc(), tensixBlock->getArgument(0), numTilesPerBlock);
+  //     tensixBuilder.create<ttkernel::CBPushBackOp>(
+  //         op.getLoc(), tensixBlock->getArgument(1), numTilesPerBlock);
+  //   }
 
-    tensixBuilder.create<ttkernel::ReturnOp>(op.getLoc());
+  //   tensixBuilder.create<ttkernel::ReturnOp>(op.getLoc());
 
-    rewriter.replaceOp(op, metalEnqueueProgram);
+  //   rewriter.replaceOp(op, metalEnqueueProgram);
 
-    return success();
-  }
+  //   return success();
+  // }
 
   LogicalResult matchAndRewrite(ttir::ToLayoutOp op,
                                 PatternRewriter &rewriter) const final {
-    auto inputTy = mlir::cast<RankedTensorType>(op.getInput().getType());
-    auto outputTy = mlir::cast<RankedTensorType>(op.getType(0));
-    if (not inputTy.getEncoding() || not outputTy.getEncoding()) {
-      return failure();
-    }
-    assert(inputTy.getShape() == outputTy.getShape());
-    assert(mlir::isa<tt::MetalLayoutAttr>(inputTy.getEncoding()));
-    assert(mlir::isa<tt::MetalLayoutAttr>(outputTy.getEncoding()));
-    auto inputLayout = mlir::cast<tt::MetalLayoutAttr>(inputTy.getEncoding());
-    auto outputLayout = mlir::cast<tt::MetalLayoutAttr>(outputTy.getEncoding());
+    // auto inputTy = mlir::cast<RankedTensorType>(op.getInput().getType());
+    // auto outputTy = mlir::cast<RankedTensorType>(op.getType(0));
+    // if (not inputTy.getEncoding() || not outputTy.getEncoding()) {
+    //   return failure();
+    // }
+    // assert(inputTy.getShape() == outputTy.getShape());
+    // assert(mlir::isa<tt::MetalLayoutAttr>(inputTy.getEncoding()));
+    // assert(mlir::isa<tt::MetalLayoutAttr>(outputTy.getEncoding()));
+    // auto inputLayout =
+    // mlir::cast<tt::MetalLayoutAttr>(inputTy.getEncoding()); auto outputLayout
+    // = mlir::cast<tt::MetalLayoutAttr>(outputTy.getEncoding());
 
-    auto components = op.compoundComponents();
-    bool isCompound = (static_cast<int>(components.isLayoutChange) +
-                       static_cast<int>(components.isGridChange ||
-                                        components.isMemorySpaceChange) +
-                       static_cast<int>(components.isFormatChange)) > 1;
-    assert(!isCompound && "Only one change is allowed");
+    // auto components = op.compoundComponents();
+    // bool isCompound = (static_cast<int>(components.isLayoutChange) +
+    //                    static_cast<int>(components.isGridChange ||
+    //                                     components.isMemorySpaceChange) +
+    //                    static_cast<int>(components.isFormatChange)) > 1;
+    // assert(!isCompound && "Only one change is allowed");
 
-    assert(!isCompound && "Only one change is allowed");
-    if (components.isMemorySpaceChange) {
-      if (inputLayout.isSystemMemorySpace()) {
-        assert(outputLayout.isDeviceMemorySpace());
-        assert(false && "System memory to device memory is not supported yet");
-      } else if (outputLayout.isSystemMemorySpace()) {
-        assert(inputLayout.isDeviceMemorySpace());
-        rewriter.replaceOpWithNewOp<ttmetal::EnqueueReadBufferOp>(
-            op, outputTy, op.getInput(), op.getOutput());
-      } else {
-        return relayout(op, rewriter);
-      }
-    } else if (components.isLayoutChange || components.isGridChange) {
-      return relayout(op, rewriter);
-    } else {
-      assert(components.isFormatChange);
-      return reformat(op, rewriter);
-    }
+    // assert(!isCompound && "Only one change is allowed");
+    // if (components.isMemorySpaceChange) {
+    //   if (inputLayout.isSystemMemorySpace()) {
+    //     assert(outputLayout.isDeviceMemorySpace());
+    //     assert(false && "System memory to device memory is not supported
+    //     yet");
+    //   } else if (outputLayout.isSystemMemorySpace()) {
+    //     assert(inputLayout.isDeviceMemorySpace());
+    //     rewriter.replaceOpWithNewOp<ttmetal::EnqueueReadBufferOp>(
+    //         op, outputTy, op.getInput(), op.getOutput());
+    //   } else {
+    //     return relayout(op, rewriter);
+    //   }
+    // } else if (components.isLayoutChange || components.isGridChange) {
+    //   return relayout(op, rewriter);
+    // } else {
+    //   assert(components.isFormatChange);
+    //   return reformat(op, rewriter);
+    // }
     return failure();
   }
 };

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetalPass.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetalPass.cpp
@@ -19,11 +19,8 @@
 #include "ttmlir/Dialect/TTKernel/IR/TTKernel.h"
 #include "ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.h"
 #include "ttmlir/Dialect/TTMetal/IR/TTMetal.h"
-#include <llvm/IR/Dominators.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
-#include <mlir/IR/Dominance.h>
-#include <mlir/Transforms/GreedyPatternRewriteDriver.h>
 
 using namespace mlir;
 using namespace mlir::tt;

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetalPass.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetalPass.cpp
@@ -14,6 +14,8 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "ttmlir/Dialect/TT/IR/TT.h"
+#include "ttmlir/Dialect/TT/IR/TTOps.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIR.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.h"
 #include "ttmlir/Dialect/TTKernel/IR/TTKernel.h"
@@ -80,7 +82,10 @@ struct ConvertTTIRToTTKernel
     target.addLegalDialect<scf::SCFDialect>();
     target.addIllegalDialect<ttir::TTIRDialect>();
 
+    target.addLegalOp<tt::DeviceOp>();
+    target.addLegalOp<ttir::StreamLayoutOp>();
     target.addLegalOp<ttir::GenericOp>();
+    target.addLegalOp<memref::CollapseShapeOp>();
     target.addIllegalOp<memref::StoreOp>();
 
     TypeConverter typeConverter;
@@ -99,7 +104,6 @@ struct ConvertTTIRToTTKernel
 
     target.addIllegalOp<memref::AllocOp>();
     target.addIllegalOp<memref::LoadOp>();
-    target.addIllegalOp<memref::CollapseShapeOp>();
     target.addIllegalOp<ttir::GenericOp>();
 
     RewritePatternSet topLevelPatterns(&getContext());

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetalPass.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetalPass.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "ttmlir/Conversion/TTIRToTTKernel/TTIRToTTKernel.h"
 #include "ttmlir/Conversion/TTIRToTTMetal/TTIRToTTMetal.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -14,9 +15,15 @@
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIR.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.h"
 #include "ttmlir/Dialect/TTKernel/IR/TTKernel.h"
+#include "ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.h"
 #include "ttmlir/Dialect/TTMetal/IR/TTMetal.h"
+#include <llvm/IR/Dominators.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/MemRef/IR/MemRef.h>
+#include <mlir/IR/Dominance.h>
+#include <mlir/Transforms/GreedyPatternRewriteDriver.h>
 
 using namespace mlir;
 using namespace mlir::tt;
@@ -24,6 +31,7 @@ using namespace mlir::tt;
 namespace mlir::tt::ttir {
 
 #define GEN_PASS_DEF_CONVERTTTIRTOTTMETAL
+#define GEN_PASS_DEF_CONVERTTTIRTOTTKERNEL
 #include "ttmlir/Conversion/Passes.h.inc"
 
 } // namespace mlir::tt::ttir
@@ -60,12 +68,82 @@ struct ConvertTTIRToTTMetal
   }
 };
 
+struct ConvertTTIRToTTKernel
+    : public ttir::impl::ConvertTTIRToTTKernelBase<ConvertTTIRToTTKernel> {
+  void runOnOperation() final {
+    mlir::ConversionTarget target(getContext());
+    target.addLegalDialect<BuiltinDialect>();
+    target.addLegalDialect<func::FuncDialect>();
+    target.addLegalDialect<ttmetal::TTMetalDialect>();
+    target.addLegalDialect<memref::MemRefDialect>();
+    target.addLegalDialect<ttkernel::TTKernelDialect>();
+    target.addLegalDialect<ttir::TTIRDialect>();
+    target.addLegalDialect<arith::ArithDialect>();
+    target.addIllegalDialect<math::MathDialect>();
+    target.addLegalDialect<scf::SCFDialect>();
+
+    target.addIllegalOp<memref::AllocOp>();
+    target.addIllegalOp<memref::StoreOp>();
+    target.addIllegalOp<ttir::AwaitOp>();
+    target.addIllegalOp<ttir::YieldOp>();
+    target.addIllegalOp<ttir::TileMaximumOp>();
+    target.addIllegalOp<ttir::TileMatmulOp>();
+
+    TypeConverter typeConverter;
+    // All types map 1:1.
+    typeConverter.addConversion([](Type type) { return type; });
+
+    RewritePatternSet patterns(&getContext());
+    populateTTIRToTTKernelPatternsPhase1(&getContext(), patterns,
+                                         typeConverter);
+
+    if (failed(
+            applyFullConversion(getOperation(), target, std::move(patterns)))) {
+      signalPassFailure();
+      return;
+    }
+
+    target.addIllegalOp<memref::LoadOp>();
+
+    RewritePatternSet patterns2(&getContext());
+    populateTTIRToTTKernelPatternsPhase2(&getContext(), patterns2,
+                                         typeConverter);
+
+    if (failed(applyFullConversion(getOperation(), target,
+                                   std::move(patterns2)))) {
+      signalPassFailure();
+      return;
+    }
+
+    target.addDynamicallyLegalOp<ttir::GenericOp>([](Operation *op) {
+      return mlir::isa<ttkernel::CBType>(
+          op->getRegion(0).getBlocks().front().getArgument(0).getType());
+    });
+    target.addIllegalOp<memref::CollapseShapeOp>();
+
+    RewritePatternSet patterns3(&getContext());
+    populateTTIRToTTKernelPatternsPhase3(&getContext(), patterns3,
+                                         typeConverter);
+
+    GreedyRewriteConfig config = GreedyRewriteConfig();
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns3),
+                                     config))) {
+      signalPassFailure();
+      return;
+    }
+  };
+};
+
 } // namespace
 
 namespace mlir::tt {
 
 std::unique_ptr<OperationPass<ModuleOp>> createConvertTTIRToTTMetalPass() {
   return std::make_unique<ConvertTTIRToTTMetal>();
+}
+
+std::unique_ptr<OperationPass<ModuleOp>> createConvertTTIRToTTKernelPass() {
+  return std::make_unique<ConvertTTIRToTTKernel>();
 }
 
 } // namespace mlir::tt

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetalPass.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetalPass.cpp
@@ -84,6 +84,7 @@ struct ConvertTTIRToTTKernel
 
     target.addLegalOp<tt::DeviceOp>();
     target.addLegalOp<ttir::StreamLayoutOp>();
+    target.addLegalOp<ttir::ViewLayoutOp>();
     target.addLegalOp<ttir::GenericOp>();
     target.addLegalOp<memref::CollapseShapeOp>();
     target.addIllegalOp<memref::StoreOp>();

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -863,18 +863,18 @@ LogicalResult emitOpRegionAsCpp(Region *region, llvm::raw_ostream &os,
 LogicalResult
 emitEnqueueProgramOpRegionsAsCpp(ttmetal::EnqueueProgramOp enqueueProgramOp,
                                  llvm::SmallVector<std::string> &cppStrings) {
-  assert(cppStrings.size() == enqueueProgramOp.getNumRegions() &&
-         "cppStrings size must match number of regions");
+  // assert(cppStrings.size() == enqueueProgramOp.getNumRegions() &&
+  //        "cppStrings size must match number of regions");
 
-  for (auto &reg : enqueueProgramOp->getRegions()) {
-    auto kernelConfig = mlir::cast<ttkernel::KernelConfigInterface>(
-        enqueueProgramOp.getKernelConfigs()[reg.getRegionNumber()]);
-    if (emitOpRegionAsCpp(&reg, cppStrings[reg.getRegionNumber()],
-                          kernelConfig.getThreadType())
-            .failed()) {
-      return llvm::failure();
-    }
-  }
+  // for (auto &reg : enqueueProgramOp->getRegions()) {
+  //   auto kernelConfig = mlir::cast<ttkernel::KernelConfigInterface>(
+  //       enqueueProgramOp.getKernelConfigs()[reg.getRegionNumber()]);
+  //   if (emitOpRegionAsCpp(&reg, cppStrings[reg.getRegionNumber()],
+  //                         kernelConfig.getThreadType())
+  //           .failed()) {
+  //     return llvm::failure();
+  //   }
+  // }
 
   return success();
 }

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -10,6 +10,7 @@
 #include "ttmlir/Utils.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Traits.h"
@@ -2911,12 +2912,19 @@ verifyAffineShapes(llvm::function_ref<mlir::InFlightDiagnostic()> diagFn,
 // GenericOp verification
 ::mlir::LogicalResult mlir::tt::ttir::GenericOp::verify() {
   if (!getGrid().getMapping().isEmpty()) {
-    return emitOpError("GenericOp grid mapping is not supported");
+    return emitOpError("grid mapping is not supported");
   }
 
   if (getOutputs().size() != 1) {
-    return emitOpError(
-        "GenericOp must currently have exactly one output operand");
+    return emitOpError("must currently have exactly one output operand");
+  }
+
+  if (getThreads().empty()) {
+    return emitOpError("must have at least one thread");
+  }
+
+  if (!getRegions().empty() && getRegions().size() != getThreads().size()) {
+    return emitOpError("number of regions must match the number of threads");
   }
 
   // Output grid shape must equal the GenericOp grid shape.
@@ -2943,7 +2951,7 @@ verifyAffineShapes(llvm::function_ref<mlir::InFlightDiagnostic()> diagFn,
     }
     if (opGridShape != outputGridShape) {
       return emitOpError(
-          "Output grid shape must match the GenericOp grid shape");
+          "output grid shape must match the generic op's grid shape");
     }
   }
 
@@ -2973,11 +2981,11 @@ verifyAffineShapes(llvm::function_ref<mlir::InFlightDiagnostic()> diagFn,
   auto *firstRegion = getRegions().begin();
   for (Region &region : getRegions()) {
     if (!region.hasOneBlock()) {
-      return emitOpError("GenericOp region must have a single block");
+      return emitOpError("region must have a single block");
     }
 
     if (region.getNumArguments() < this->getNumOperands()) {
-      return emitOpError("GenericOp region must have at least as many "
+      return emitOpError("region must have at least as many "
                          "arguments as the number of top-level operands");
     }
 
@@ -2998,7 +3006,7 @@ verifyAffineShapes(llvm::function_ref<mlir::InFlightDiagnostic()> diagFn,
     for (BlockArgument arg : memrefArguments) {
       auto blockMemref = mlir::dyn_cast<MemRefType>(arg.getType());
       if (!blockMemref) {
-        return emitOpError("GenericOp region arguments must be of MemRefType");
+        return emitOpError("region arguments must be of MemRefType");
       }
 
       Type operandType = operandTypes[arg.getArgNumber()];
@@ -3027,12 +3035,12 @@ verifyAffineShapes(llvm::function_ref<mlir::InFlightDiagnostic()> diagFn,
       }
 
       if (!isStream && expectedMemorySpace != blockMemref.getMemorySpace()) {
-        return emitOpError("GenericOp region argument memory space must match "
+        return emitOpError("region argument memory space must match "
                            "the memory space of the corresponding operand");
       }
 
       if (expectedShardShape != blockMemref.getShape()) {
-        return emitOpError("GenericOp region argument shape must match the "
+        return emitOpError("region argument shape must match the "
                            "shape of the corresponding operand");
       }
     }
@@ -3043,7 +3051,16 @@ verifyAffineShapes(llvm::function_ref<mlir::InFlightDiagnostic()> diagFn,
       bool supportedType = mlir::isa<SemaphoreType>(arg.getType());
       if (!supportedType) {
         return emitOpError(
-            "Additional GenericOp region arguments must be of SemaphoreType");
+            "additional region arguments must be of 'semaphore' type");
+      }
+    }
+  }
+
+  if (isExternalSymbolForm()) {
+    for (auto &thread : getThreads()) {
+      if (!mlir::cast<ThreadAttr>(thread).getKernelSymbol()) {
+        return emitOpError("threads must have a kernel symbol in external "
+                           "symbol form (i.e. without regions)");
       }
     }
   }
@@ -3156,15 +3173,14 @@ void mlir::tt::ttir::GenericOp::getAsmBlockArgumentNames(
 
 void mlir::tt::ttir::GenericOp::getAsmBlockNames(
     function_ref<void(Block *, StringRef)> setNameFn) {
-  size_t numRegions = getNumRegions();
+  std::array<int, getMaxEnumValForThreadType() + 1> threadTypeCounts{};
   for (Region &region : getRegions()) {
-    // Right now the last region is implicitly the compute region.
-    if (region.getRegionNumber() < (numRegions - 1)) {
-      setNameFn(&region.front(),
-                "datamovement" + std::to_string(region.getRegionNumber()));
-    } else {
-      setNameFn(&region.front(), "compute");
-    }
+    auto type = getRegionThreadType(region.getRegionNumber());
+    setNameFn(&region.front(),
+              stringifyEnum(type).str() +
+                  Twine(threadTypeCounts[static_cast<
+                            std::underlying_type_t<ThreadType>>(type)]++)
+                      .str());
   }
 }
 
@@ -3202,7 +3218,7 @@ mlir::LogicalResult mlir::tt::ttir::GenericOp::bufferize(
   }
   auto bufferGeneric = rewriter.create<mlir::tt::ttir::GenericOp>(
       getLoc(), ValueRange(), bufferInputs, bufferOutputs, getGrid(),
-      getIndexingMaps(), getIteratorTypes(), getNumRegions());
+      getIndexingMaps(), getIteratorTypes(), getThreads(), getNumRegions());
   for (mlir::Region &region : bufferGeneric.getRegions()) {
     region.takeBody(getRegion(region.getRegionNumber()));
   }
@@ -3415,10 +3431,14 @@ static mlir::Region *getParentRegionOfType(mlir::Operation *op) {
 
 ::mlir::LogicalResult mlir::tt::ttir::YieldOp::verify() {
   return operandsInRegionArguments(
-      getOperation(), getParentRegionOfType<GenericOp>(getOperation()));
+      getOperation(),
+      ttmlir::utils::getRegionWithParentOfType<GenericOp, func::FuncOp>(
+          getOperation()));
 }
 
 ::mlir::LogicalResult mlir::tt::ttir::AwaitOp::verify() {
   return operandsInRegionArguments(
-      getOperation(), getParentRegionOfType<GenericOp>(getOperation()));
+      getOperation(),
+      ttmlir::utils::getRegionWithParentOfType<GenericOp, func::FuncOp>(
+          getOperation()));
 }

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -130,6 +130,53 @@ void mlir::tt::ttir::BitwiseXorOp::getCanonicalizationPatterns(
 }
 
 //===----------------------------------------------------------------------===//
+// EmptyOp
+//===----------------------------------------------------------------------===//
+
+bool mlir::tt::ttir::EmptyOp::bufferizesToMemoryRead(
+    mlir::OpOperand &operand, const mlir::bufferization::AnalysisState &) {
+  // If the operand is an input, it is a bufferized to a memory read.
+  return false;
+}
+
+bool mlir::tt::ttir::EmptyOp::bufferizesToMemoryWrite(
+    mlir::OpOperand &operand, const mlir::bufferization::AnalysisState &) {
+  // If the operand is an output, it is a bufferized to a memory write.
+  return false;
+}
+
+mlir::LogicalResult mlir::tt::ttir::EmptyOp::bufferize(
+    mlir::RewriterBase &rewriter,
+    const mlir::bufferization::BufferizationOptions &options) {
+  if (getOperation()->getUses().empty()) {
+    rewriter.eraseOp(*this);
+    return success();
+  }
+
+  ::llvm::SmallVector<mlir::Value> invocationStack;
+  mlir::bufferization::replaceOpWithNewBufferizedOp<memref::AllocOp>(
+      rewriter, *this,
+      mlir::cast<MemRefType>(
+          *getBufferType(getResult(), options, invocationStack)));
+  return mlir::success();
+}
+
+mlir::bufferization::AliasingValueList
+mlir::tt::ttir::EmptyOp::getAliasingValues(
+    mlir::OpOperand &, const mlir::bufferization::AnalysisState &) {
+  bufferization::AliasingValueList result;
+  return result;
+}
+
+mlir::FailureOr<mlir::BaseMemRefType> mlir::tt::ttir::EmptyOp::getBufferType(
+    mlir::Value value, const mlir::bufferization::BufferizationOptions &,
+    ::llvm::SmallVector<mlir::Value> &) {
+  auto rankedTensorType = mlir::cast<mlir::RankedTensorType>(value.getType());
+  return mlir::cast<tt::MetalLayoutAttr>(rankedTensorType.getEncoding())
+      .getBufferType();
+}
+
+//===----------------------------------------------------------------------===//
 // ConstantOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTIR/IR/TTIROpsInterfaces.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROpsInterfaces.cpp
@@ -11,6 +11,7 @@
 #include <llvm/ADT/ArrayRef.h>
 #include <mlir/IR/ValueRange.h>
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Traits.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Operation.h"
@@ -51,7 +52,8 @@ mlir::tt::ttir::detail::verifyBroadcastable(mlir::Operation *op) {
 
 mlir::LogicalResult
 mlir::tt::ttir::detail::verifyGenericParent(mlir::Operation *op) {
-  return op->getParentOfType<ttir::GenericOp>()
+  return (op->getParentOfType<ttir::GenericOp>() ||
+          op->getParentOfType<func::FuncOp>())
              ? success()
              : op->emitOpError(
                    "TTIR Generic Ops must be inside a generic region");

--- a/lib/Dialect/TTIR/IR/TTIRTraits.cpp
+++ b/lib/Dialect/TTIR/IR/TTIRTraits.cpp
@@ -4,6 +4,9 @@
 
 #include "ttmlir/Dialect/TTIR/IR/TTIRTraits.h"
 
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+#include "ttmlir/Utils.h"
+
 // Check if all operands and result have the same type. Function assumes op has
 // at least one operand and exactly one result.
 static bool operandAndResultSameType(mlir::Operation *op) {
@@ -16,7 +19,7 @@ static bool operandAndResultSameType(mlir::Operation *op) {
 // 2. Argument is defined by the same op.
 // 3. 1) is true for the producing op of the argument.
 // op(op(T a, T r0), T r1)
-bool mlir::tt::ttir::OpTrait::impl::verifyInvolution(mlir::Operation *op) {
+bool mlir::OpTrait::tt::ttir::impl::verifyInvolution(mlir::Operation *op) {
   if (!operandAndResultSameType(op)) {
     return false;
   }
@@ -32,7 +35,7 @@ bool mlir::tt::ttir::OpTrait::impl::verifyInvolution(mlir::Operation *op) {
 // 2. Argument is defined by the same op.
 // 3. 1) is true for the producing op of the argument.
 // op(op(T a, T r0), T r1)
-bool mlir::tt::ttir::OpTrait::impl::verifyIdempotence(mlir::Operation *op) {
+bool mlir::OpTrait::tt::ttir::impl::verifyIdempotence(mlir::Operation *op) {
   if (!operandAndResultSameType(op)) {
     return false;
   }
@@ -46,7 +49,7 @@ bool mlir::tt::ttir::OpTrait::impl::verifyIdempotence(mlir::Operation *op) {
 // If Op has TTIRBinaryIdempotence trait, then it's foldable if:
 // 1. Both inputs are the same.
 // 2. Inputs and result types are the same.
-bool mlir::tt::ttir::OpTrait::impl::verifyBinaryIdempotence(
+bool mlir::OpTrait::tt::ttir::impl::verifyBinaryIdempotence(
     mlir::Operation *op) {
   if (op->getOperand(0) != op->getOperand(1)) {
     return false;
@@ -56,16 +59,47 @@ bool mlir::tt::ttir::OpTrait::impl::verifyBinaryIdempotence(
 }
 
 mlir::OpFoldResult
-mlir::tt::ttir::OpTrait::impl::foldInvolution(mlir::Operation *op) {
+mlir::OpTrait::tt::ttir::impl::foldInvolution(mlir::Operation *op) {
   return op->getOperand(0).getDefiningOp()->getOperand(0);
 }
 
 mlir::OpFoldResult
-mlir::tt::ttir::OpTrait::impl::foldIdempotence(mlir::Operation *op) {
+mlir::OpTrait::tt::ttir::impl::foldIdempotence(mlir::Operation *op) {
   return op->getOperand(0);
 }
 
 mlir::OpFoldResult
-mlir::tt::ttir::OpTrait::impl::foldBinaryIdempotence(mlir::Operation *op) {
+mlir::OpTrait::tt::ttir::impl::foldBinaryIdempotence(mlir::Operation *op) {
   return op->getOperand(0);
+}
+
+static mlir::LogicalResult
+verifyGenericRegionOpThreadType(mlir::Operation *op,
+                                mlir::tt::ttir::ThreadType threadType) {
+  mlir::Region *region =
+      ttmlir::utils::getRegionWithParentOfType<mlir::tt::ttir::GenericOp>(op);
+  if (!region) {
+    // If not enclosed in a generic op then we forgo verification.
+    return mlir::success();
+  }
+  mlir::tt::ttir::GenericOp genericOp =
+      mlir::cast<mlir::tt::ttir::GenericOp>(region->getParentOp());
+  if (genericOp.getRegionThreadType(region->getRegionNumber()) != threadType) {
+    return op->emitOpError("expected to be in a ")
+           << stringifyEnum(threadType) << " region";
+  }
+  return mlir::success();
+}
+
+mlir::LogicalResult mlir::OpTrait::tt::ttir::impl::verifyGenericRegionComputeOp(
+    mlir::Operation *op) {
+  return verifyGenericRegionOpThreadType(op,
+                                         ::mlir::tt::ttir::ThreadType::Compute);
+}
+
+mlir::LogicalResult
+mlir::OpTrait::tt::ttir::impl::verifyGenericRegionDatamovementOp(
+    mlir::Operation *op) {
+  return verifyGenericRegionOpThreadType(
+      op, ::mlir::tt::ttir::ThreadType::Datamovement);
 }

--- a/lib/Dialect/TTIR/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTIR/Transforms/CMakeLists.txt
@@ -8,6 +8,7 @@ add_mlir_dialect_library(MLIRTTIRTransforms
         GenericGenerateLoops.cpp
         GenericHWThreadSelection.cpp
         GenericLowerAffineDMAs.cpp
+        GenericRegionsToFuncs.cpp
         AttachMetalLayout.cpp
         OptimizeTensorLayout.cpp
         HoistCPUOps.cpp

--- a/lib/Dialect/TTIR/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTIR/Transforms/CMakeLists.txt
@@ -7,6 +7,7 @@ add_mlir_dialect_library(MLIRTTIRTransforms
         GenericGenerateDatamovement.cpp
         GenericGenerateLoops.cpp
         GenericHWThreadSelection.cpp
+        GenericLowerAffineDMAs.cpp
         AttachMetalLayout.cpp
         OptimizeTensorLayout.cpp
         HoistCPUOps.cpp

--- a/lib/Dialect/TTIR/Transforms/GeneralizeNamedOps.cpp
+++ b/lib/Dialect/TTIR/Transforms/GeneralizeNamedOps.cpp
@@ -134,9 +134,8 @@ private:
 
     // Create 'ttir.generic' accepting 'op's operands.
     auto generic = rewriter.create<GenericOp>(
-        loc, mlir::TypeRange(outputs), inputs, outputs, grid,
-        rewriter.getAffineMapArrayAttr(indexingMaps),
-        rewriter.getArrayAttr(iteratorTypes), /* regionsCount */ 1);
+        loc, inputs, outputs, rewriter.getAffineMapArrayAttr(indexingMaps),
+        rewriter.getArrayAttr(iteratorTypes));
 
     // Create one bb in 'generic''s region and set its arguments.
     rewriter.startOpModification(generic);
@@ -268,9 +267,8 @@ private:
 
     // Create 'ttir.generic' accepting extended operands.
     auto generic = rewriter.create<GenericOp>(
-        loc, mlir::TypeRange(outputs), newInputs, outputs, grid,
-        rewriter.getAffineMapArrayAttr(indexingMaps),
-        rewriter.getArrayAttr(iteratorTypes), /* regionsCount */ 1);
+        loc, newInputs, outputs, rewriter.getAffineMapArrayAttr(indexingMaps),
+        rewriter.getArrayAttr(iteratorTypes));
 
     // Create one bb in 'generic''s region and set its arguments.
     rewriter.startOpModification(generic);
@@ -505,9 +503,8 @@ private:
 
     // Create 'ttir.generic' accepting 'op's operands.
     auto generic = rewriter.create<GenericOp>(
-        loc, mlir::TypeRange(outputs), inputs, outputs, grid,
-        rewriter.getAffineMapArrayAttr(indexingMaps),
-        rewriter.getArrayAttr(iteratorTypes), /* regionsCount */ 1);
+        loc, inputs, outputs, rewriter.getAffineMapArrayAttr(indexingMaps),
+        rewriter.getArrayAttr(iteratorTypes));
 
     // Create one bb in 'generic''s region and set its arguments.
     rewriter.startOpModification(generic);

--- a/lib/Dialect/TTIR/Transforms/GenericGenerateDatamovement.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericGenerateDatamovement.cpp
@@ -183,11 +183,12 @@ public:
         });
   }
 
-  static LogicalResult buildDatamovementBlock(
-      PatternRewriter &builder, Location loc, Value genericOperand,
-      Value blockOperand, GridAttr grid, DeviceAttr device,
-      AffineMap operandIndexingMap, AffineMap gridIndexingMap,
-      ArrayAttr iteratorTypes, bool isOutput, MutableArrayRef<Region> regions) {
+  static LogicalResult
+  buildDatamovementBlock(PatternRewriter &builder, Location loc,
+                         Value genericOperand, Value blockOperand,
+                         GridAttr grid, DeviceAttr device,
+                         AffineMap operandIndexingMap, ArrayAttr iteratorTypes,
+                         bool isOutput, MutableArrayRef<Region> regions) {
     if (isOutput) {
       // Wait for compute.
       builder.create<ttir::AwaitOp>(loc, blockOperand);
@@ -247,11 +248,6 @@ public:
     // Insert the new data movement regions.
     unsigned outputOperandsIndex = generic.getOutputs().getBeginOperandIndex();
     unsigned outputOperandsLength = generic.getOutputs().size();
-    // The output and the grid indexing must always be aligned.
-    AffineMap gridIndexingMap =
-        mlir::cast<AffineMapAttr>(
-            generic.getIndexingMaps()[outputOperandsIndex])
-            .getValue();
     auto device = lookupDevice(generic);
     for (OpOperand &operand : generic->getOpOperands()) {
       Block *datamovementBlock =
@@ -267,7 +263,7 @@ public:
           rewriter, generic->getLoc(),
           generic->getOperand(operand.getOperandNumber()),
           datamovementBlock->getArgument(operand.getOperandNumber()),
-          generic.getGrid(), device, operandIndexingMap, gridIndexingMap,
+          generic.getGrid(), device, operandIndexingMap,
           generic.getIteratorTypes(), isOutput, newGeneric.getRegions());
       if (failed(result)) {
         return result;

--- a/lib/Dialect/TTIR/Transforms/GenericGenerateDatamovement.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericGenerateDatamovement.cpp
@@ -228,10 +228,15 @@ public:
     // One per operand.
     auto numDataMovementRegions = generic.getNumOperands();
     auto numTotalRegions = generic.getNumRegions() + numDataMovementRegions;
+    SmallVector<Attribute> threads(
+        numDataMovementRegions,
+        rewriter.getAttr<ThreadAttr>(ThreadType::Datamovement));
+    threads.append(generic.getThreads().begin(), generic.getThreads().end());
     auto newGeneric = rewriter.create<GenericOp>(
         generic->getLoc(), generic.getResultTypes(), generic.getInputs(),
         generic.getOutputs(), generic.getGrid(), generic.getIndexingMaps(),
-        generic.getIteratorTypes(), numTotalRegions);
+        generic.getIteratorTypes(), rewriter.getArrayAttr(threads),
+        numTotalRegions);
 
     // Preinitialize all regions so that we can modify their signatures on the
     // fly. i.e. adding semaphore arguments.

--- a/lib/Dialect/TTIR/Transforms/GenericGenerateLoops.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericGenerateLoops.cpp
@@ -68,7 +68,7 @@ public:
         generic->getLoc(), generic.getResultTypes(), generic.getInputs(),
         generic.getOutputs(), generic.getGrid(),
         /* indexing_maps */ rewriter.getArrayAttr({}),
-        /* iterator_types */ rewriter.getArrayAttr({}),
+        /* iterator_types */ rewriter.getArrayAttr({}), generic.getThreads(),
         generic.getNumRegions());
 
     SmallVector<int64_t> loopBounds = generic.getLoopBounds();

--- a/lib/Dialect/TTIR/Transforms/GenericHWThreadSelection.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericHWThreadSelection.cpp
@@ -57,10 +57,14 @@ public:
       return failure();
     }
 
+    SmallVector<Attribute> threads(op.getThreads().getValue());
+    // Skip the output operands block
+    threads.erase(threads.begin() + outputOperandsIndex);
     auto newGeneric = rewriter.create<GenericOp>(
         op.getLoc(), op.getResults().getTypes(), op.getInputs(),
         op.getOutputs(), op.getGrid(), op.getIndexingMaps(),
-        op.getIteratorTypes(), op.getNumRegions() - 1);
+        op.getIteratorTypes(), rewriter.getArrayAttr(threads),
+        op.getNumRegions() - 1);
 
     unsigned regionIndex = 0;
     for (mlir::Region &region : op.getRegions()) {

--- a/lib/Dialect/TTIR/Transforms/GenericLowerAffineDMAs.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericLowerAffineDMAs.cpp
@@ -1,0 +1,260 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TT/IR/TT.h"
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
+#include "ttmlir/Utils.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include <numeric>
+
+namespace mlir::tt::ttir {
+#define GEN_PASS_DEF_TTIRGENERICLOWERAFFINEDMAS
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h.inc"
+
+namespace {
+class TTIRGenericLowerAffineDMAsRewritePattern
+    : public OpRewritePattern<DMAOp> {
+public:
+  using OpRewritePattern<DMAOp>::OpRewritePattern;
+
+  // Returns a tuple of the stream index and the index bounds. The stream index
+  // represents the position in the stream that the DMA will is currently on,
+  // and is relative per core. The index bounds represent the index upper
+  // bounds.
+  static std::tuple<SmallVector<Value>, SmallVector<int64_t>>
+  buildStreamIndex(OpBuilder &builder, Location loc,
+                   ArrayRef<int64_t> gridShape, ArrayRef<int64_t> shardShape,
+                   AffineMap dmaIndexingMap, AffineMap gridIndexingMap) {
+    assert(dmaIndexingMap.getNumDims() == gridIndexingMap.getNumDims());
+    assert(dmaIndexingMap.getNumResults() == gridIndexingMap.getNumResults());
+    assert(dmaIndexingMap.getNumResults() == shardShape.size());
+    assert(gridIndexingMap.isProjectedPermutation() &&
+           "Grid indexing map must be a permutation");
+
+    SmallVector<Value> streamIndex;
+    SmallVector<int64_t> indexBounds;
+    streamIndex.reserve(dmaIndexingMap.getNumResults());
+    indexBounds.reserve(dmaIndexingMap.getNumResults());
+    for (unsigned result = 0; result < dmaIndexingMap.getNumResults();
+         result++) {
+      unsigned dim = dmaIndexingMap.getDimPosition(result);
+      std::optional<unsigned> gridResult =
+          gridIndexingMap.getResultPosition(dmaIndexingMap.getResult(result));
+      //
+      // The following assert is pretty subtle. If this operand dimension
+      // participates in the grid, for now we must assert that the relative grid
+      // result is the same as the operand result. This protects against
+      // permutations of the grid, ie. transposes.  For example, let's consider
+      // a matmul case:
+      //   dmaIndexingMap:  (m, n, k) -> (m, k)
+      //   dmaIndexingMap:  (m, n, k) -> (k, n)
+      //   gridIndexingMap: (m, n, k) -> (m, n)
+      //                                     ^
+      // This assert ensures that the m's line up. A counter example would be:
+      //   dmaIndexingMap:  (m, n, k) -> (m, k)
+      //   gridIndexingMap: (m, n, k) -> (n, m)
+      //
+      // Not currently supported.
+      //
+      assert(!gridResult || *gridResult == result);
+      bool isGridDim = gridResult.has_value();
+      Value iterIndex = builder.create<IterIndexOp>(
+          loc, builder.getIndexType(), builder.getI64IntegerAttr(dim));
+      Value index;
+      if (isGridDim) {
+        // gridI * dimI + iterI
+        Value dimConstant = builder.create<arith::ConstantOp>(
+            loc, builder.getIndexType(),
+            builder.getIndexAttr(shardShape[result]));
+        index = builder.create<CoreIndexOp>(loc, builder.getIndexType(),
+                                            builder.getI64IntegerAttr(dim));
+        index = builder.create<arith::MulIOp>(loc, builder.getIndexType(),
+                                              index, dimConstant);
+        index = builder.create<arith::AddIOp>(loc, builder.getIndexType(),
+                                              index, iterIndex);
+      } else {
+        index = iterIndex;
+      }
+      streamIndex.push_back(index);
+      indexBounds.push_back(gridShape[result]);
+    }
+    return std::make_tuple(streamIndex, indexBounds);
+  }
+
+  static size_t getElementSizeBytes(MemRefType memref) {
+    mlir::Type elementType = memref.getElementType();
+    auto tileType = mlir::dyn_cast<TileType>(elementType);
+    return tileType ? tileType.getSizeBytes()
+                    : elementType.getIntOrFloatBitWidth() / 8;
+  }
+
+  static size_t getMemRefShardSizeBytes(MemRefType memref) {
+    ArrayRef<int64_t> memrefShardShape =
+        memref.getShape().drop_front(memref.getRank() / 2);
+    return std::accumulate(memrefShardShape.begin(), memrefShardShape.end(),
+                           getElementSizeBytes(memref),
+                           std::multiplies<int64_t>());
+  }
+
+  // For now we'll do just a simple brute force check and sample the entire map
+  // to calculate the coalescing factor. In the future there are some simple
+  // checks we could do for the common case that would be much faster.
+  static size_t calculateCoalescingFactor(AffineMap memoryMap,
+                                          ArrayRef<int64_t> gridShape,
+                                          ArrayRef<int64_t> shardShape,
+                                          size_t elemSizeBytes,
+                                          ArrayRef<int64_t> indexBounds) {
+    size_t coalescingFactor = ttmlir::utils::volume(shardShape);
+    SmallVector<int64_t> memoryIndex;
+    memoryIndex.resize(gridShape.size() + shardShape.size());
+    ttmlir::utils::sample(gridShape, [&](ArrayRef<int64_t> gridIndex) {
+      size_t currentCoalescingFactor = 0;
+      SmallVector<int64_t, 4> nextAddress;
+      ttmlir::utils::sample(shardShape, [&](ArrayRef<int64_t> shardIndex) {
+        for (unsigned i = 0; i < gridIndex.size(); i++) {
+          memoryIndex[i] = gridIndex[i];
+        }
+        for (unsigned i = 0; i < shardIndex.size(); i++) {
+          memoryIndex[gridIndex.size() + i] = shardIndex[i];
+        }
+        SmallVector<int64_t, 4> address = memoryMap.compose(memoryIndex);
+        if (nextAddress.empty() || nextAddress == address) {
+          ++currentCoalescingFactor;
+        } else {
+          coalescingFactor =
+              std::gcd(coalescingFactor, currentCoalescingFactor);
+        }
+        nextAddress = address;
+        nextAddress.back() += elemSizeBytes;
+      });
+    });
+    return coalescingFactor;
+  }
+
+  static std::tuple<SmallVector<Value>, SmallVector<Value>, SmallVector<Value>>
+  getLoopBounds(OpBuilder &builder, Location loc,
+                ArrayRef<int64_t> shardShape) {
+    Value zero = builder.create<arith::ConstantOp>(loc, builder.getIndexType(),
+                                                   builder.getIndexAttr(0));
+    Value one = builder.create<arith::ConstantOp>(loc, builder.getIndexType(),
+                                                  builder.getIndexAttr(1));
+    SmallVector<Value> lbs(shardShape.size(), zero);
+    SmallVector<Value> ubs(llvm::map_range(shardShape, [&](int64_t dim) {
+      return builder.create<arith::ConstantOp>(loc, builder.getIndexType(),
+                                               builder.getIndexAttr(dim));
+    }));
+    SmallVector<Value> step(shardShape.size(), one);
+    return std::make_tuple(lbs, ubs, step);
+  }
+
+  static scf::LoopNest
+  fallbackSingleTileGatherLoop(OpBuilder &builder, Location loc, DMAOp dma,
+                               ArrayRef<Value> streamIndex,
+                               ArrayRef<int64_t> shardShape) {
+    auto [lbs, ubs, steps] = getLoopBounds(builder, loc, shardShape);
+
+    auto initTx = builder.create<ttir::NullTxOp>(dma.getLoc(),
+                                                 builder.getType<MemTxType>());
+    scf::LoopNest loopNest = scf::buildLoopNest(
+        builder, loc, lbs, ubs, steps, ValueRange(initTx),
+        [&](OpBuilder &builder, Location loc, ValueRange iters,
+            ValueRange /*args*/) {
+          SmallVector<Value> srcIndex =
+              llvm::to_vector(llvm::concat<Value>(streamIndex, iters));
+          return SmallVector<Value>{builder.create<ttir::DMAOp>(
+              dma.getLoc(), builder.getType<MemTxType>(), dma.getSrc(), nullptr,
+              srcIndex, dma.getDst(), nullptr, iters, nullptr,
+              dma.getDstCoreIndex(), dma.getMcastShape())};
+        });
+    return loopNest;
+  }
+
+  LogicalResult matchAndRewrite(DMAOp dma,
+                                PatternRewriter &rewriter) const final {
+    if (!dma.isAffine()) {
+      // Already lowered, skip.
+      return failure();
+    }
+    assert(!dma.getDstAffineMap() && "DMA dst affine map not supported yet");
+    assert(dma.getSrcAffineMap() && "DMA src affine map expected");
+
+    AffineMap dmaIndexingMap = *dma.getSrcAffineMap();
+    MemRefType memref = dma.getSrcMemRefType();
+    assert(memref.getRank() % 2 == 0 && "Only even rank memrefs are supported");
+    ArrayRef<int64_t> memrefShape = memref.getShape();
+    ArrayRef<int64_t> memrefGridShape =
+        memrefShape.take_front(memrefShape.size() / 2);
+    ArrayRef<int64_t> memrefShardShape =
+        memrefShape.drop_front(memrefShape.size() / 2);
+
+    GenericOp genericParent = dma->getParentOfType<ttir::GenericOp>();
+    unsigned outputOperandsIndex =
+        genericParent.getOutputs().getBeginOperandIndex();
+    // The output and the grid indexing must always be aligned.
+    AffineMap gridIndexingMap =
+        mlir::cast<AffineMapAttr>(
+            genericParent.getIndexingMaps()[outputOperandsIndex])
+            .getValue();
+
+    auto [streamIndex, indexBounds] =
+        buildStreamIndex(rewriter, dma.getLoc(), memrefGridShape,
+                         memrefShardShape, dmaIndexingMap, gridIndexingMap);
+
+    DeviceAttr device = genericParent.getDevice();
+    // TODO(#1909) Once we have an allocation pass, we need to lookup the page
+    // size instead of calculating it here.
+    size_t pageSize = getMemRefShardSizeBytes(memref);
+    AffineMap memoryMap = device.getMemoryMap(memref, pageSize);
+    size_t elemSizeBytes = getElementSizeBytes(memref);
+    size_t coalescingFactor =
+        calculateCoalescingFactor(memoryMap, memrefGridShape, memrefShardShape,
+                                  elemSizeBytes, indexBounds);
+
+    Operation *newDma;
+    if (coalescingFactor ==
+        static_cast<size_t>(ttmlir::utils::volume(memrefShardShape))) {
+      // Fully coalesced, we can trivially lower.
+      newDma = rewriter.create<ttir::DMAOp>(
+          dma.getLoc(), rewriter.getType<MemTxType>(), dma.getSrc(), nullptr,
+          streamIndex, dma.getDst(), nullptr, ValueRange(), nullptr,
+          dma.getDstCoreIndex(), dma.getMcastShape());
+    } else {
+      // Fallback to single tile gather for now, in the future we can chage this
+      // to support more sophisticated gathering.
+      scf::LoopNest loopNest = fallbackSingleTileGatherLoop(
+          rewriter, dma.getLoc(), dma, streamIndex, memrefShardShape);
+      assert(loopNest.loops.size() == memrefShardShape.size());
+      newDma = loopNest.loops.front();
+    }
+
+    rewriter.replaceOp(dma, newDma);
+    return success();
+  }
+};
+} // namespace
+
+namespace {
+class TTIRGenericLowerAffineDMAs
+    : public impl::TTIRGenericLowerAffineDMAsBase<TTIRGenericLowerAffineDMAs> {
+public:
+  using impl::TTIRGenericLowerAffineDMAsBase<
+      TTIRGenericLowerAffineDMAs>::TTIRGenericLowerAffineDMAsBase;
+
+  void runOnOperation() final {
+    RewritePatternSet patterns(&getContext());
+    patterns.add<TTIRGenericLowerAffineDMAsRewritePattern>(&getContext());
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+} // namespace
+
+} // namespace mlir::tt::ttir

--- a/lib/Dialect/TTIR/Transforms/GenericRegionsToFuncs.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericRegionsToFuncs.cpp
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Rewrite/FrozenRewritePatternSet.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir::tt::ttir {
+#define GEN_PASS_DEF_TTIRGENERICREGIONSTOFUNCS
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h.inc"
+
+static std::optional<unsigned> getCapturedOperandIndex(GenericOp op,
+                                                       Value operand) {
+  for (OpOperand &opOperand : op->getOpOperands()) {
+    if (opOperand.get() == operand) {
+      return opOperand.getOperandNumber();
+    }
+  }
+  return std::nullopt;
+}
+
+static void rewriteOperand(OpBuilder &builder, DMAOp dma, OpOperand &dmaOperand,
+                           unsigned operandIndex) {
+  auto globalOperand = builder.create<GetGlobalOperandOp>(
+      dma.getLoc(), dmaOperand.get().getType(), operandIndex);
+  dmaOperand.set(globalOperand.getResult());
+}
+
+static void rewriteCapturedDMAOperands(OpBuilder &builder, GenericOp generic,
+                                       DMAOp dma) {
+  auto srcIndex = getCapturedOperandIndex(generic, dma.getSrc());
+  auto dstIndex = getCapturedOperandIndex(generic, dma.getDst());
+
+  builder.setInsertionPoint(dma);
+  if (srcIndex) {
+    rewriteOperand(builder, dma, dma.getSrcMutable(), *srcIndex);
+  }
+
+  if (dstIndex) {
+    rewriteOperand(builder, dma, dma.getDstMutable(), *dstIndex);
+  }
+}
+
+namespace {
+class TTIRGenericRegionsToFuncs
+    : public impl::TTIRGenericRegionsToFuncsBase<TTIRGenericRegionsToFuncs> {
+public:
+  using impl::TTIRGenericRegionsToFuncsBase<
+      TTIRGenericRegionsToFuncs>::TTIRGenericRegionsToFuncsBase;
+
+  void runOnOperation() final {
+    ModuleOp moduleOp = getOperation();
+    OpBuilder builder(&getContext());
+    static int unique = 0;
+    moduleOp->walk([&](GenericOp generic) {
+      generic.walk([&](DMAOp dma) {
+        rewriteCapturedDMAOperands(builder, generic, dma);
+      });
+
+      SmallVector<Attribute> threads;
+      for (Region &region : generic.getRegions()) {
+        builder.setInsertionPoint(moduleOp.getBody(),
+                                  moduleOp.getBody()->end());
+        ThreadType threadType =
+            generic.getRegionThreadType(region.getRegionNumber());
+        std::string symbolName =
+            stringifyEnum(generic.getRegionThreadType(region.getRegionNumber()))
+                .str() +
+            "_kernel" + Twine(unique++).str();
+        auto func = builder.create<func::FuncOp>(
+            generic.getLoc(), symbolName,
+            FunctionType::get(builder.getContext(), region.getArgumentTypes(),
+                              {}));
+        func.setPrivate();
+        func->setAttr(TTIRDialect::getThreadTypeAttrName(),
+                      builder.getAttr<ThreadTypeAttr>(threadType));
+        func.getBody().takeBody(region);
+        builder.setInsertionPointToEnd(&func.getBody().front());
+        builder.create<func::ReturnOp>(generic.getLoc());
+
+        threads.push_back(builder.getAttr<ThreadAttr>(
+            threadType, builder.getAttr<SymbolRefAttr>(symbolName)));
+      }
+
+      builder.setInsertionPoint(generic);
+      auto symbolicGeneric = builder.create<GenericOp>(
+          generic->getLoc(), generic.getResultTypes(), generic.getInputs(),
+          generic.getOutputs(), generic.getGrid(), generic.getIndexingMaps(),
+          generic.getIteratorTypes(), builder.getArrayAttr(threads),
+          /*numRegions*/ 0);
+
+      generic.replaceAllUsesWith(symbolicGeneric);
+      generic.erase();
+    });
+  }
+};
+} // namespace
+
+} // namespace mlir::tt::ttir

--- a/lib/Dialect/TTMetal/CMakeLists.txt
+++ b/lib/Dialect/TTMetal/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(IR)
+add_subdirectory(Transforms)
 add_subdirectory(Pipelines)

--- a/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
+++ b/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
@@ -72,16 +72,6 @@ namespace mlir::tt::ttmetal {
       return emitOpError("Input tensor must be in device memory space");
     }
   }
-
-  // Assert block inputs are CBs
-  for (auto &region : getRegions()) {
-    for (auto arg : region.getArguments()) {
-      if (!mlir::isa<ttkernel::CBType>(arg.getType()) &&
-          !mlir::isa<ttkernel::SemaphoreType>(arg.getType())) {
-        return emitOpError("Block inputs must be CBType or SemType");
-      }
-    }
-  }
   return success();
 }
 

--- a/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
+++ b/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
@@ -15,43 +15,31 @@
 namespace mlir::tt::ttmetal {
 
 ::mlir::LogicalResult EnqueueWriteBufferOp::verify() {
-  ::mlir::RankedTensorType outputTy = getOutput().getType();
-  auto outputLayout = mlir::dyn_cast_if_present<mlir::tt::MetalLayoutAttr>(
-      outputTy.getEncoding());
-  if (not outputLayout) {
-    return emitOpError("Input tensor missing layout attribute");
-  }
-  if (not outputLayout.isDeviceMemorySpace()) {
+  ::mlir::MemRefType outputTy = getOutput().getType();
+  MemorySpaceAttr memSpaceAttr =
+      mlir::cast<MemorySpaceAttr>(outputTy.getMemorySpace());
+  if (not isDeviceMemorySpace(memSpaceAttr.getValue())) {
     return emitOpError("Output tensor must be in device memory space");
   }
   return success();
 }
 
 ::mlir::LogicalResult EnqueueReadBufferOp::verify() {
-  ::mlir::RankedTensorType outputTy = getOutput().getType();
-  auto outputLayout = mlir::dyn_cast_if_present<mlir::tt::MetalLayoutAttr>(
-      outputTy.getEncoding());
-  if (not outputLayout) {
-    return emitOpError("Input tensor missing layout attribute");
-  }
-  if (not outputLayout.isSystemMemorySpace()) {
+  ::mlir::MemRefType outputTy = getOutput().getType();
+  MemorySpaceAttr memSpaceAttr =
+      mlir::cast<MemorySpaceAttr>(outputTy.getMemorySpace());
+  if (not isSystemMemorySpace(memSpaceAttr.getValue())) {
     return emitOpError("Output tensor must be in system memory space");
   }
   return success();
 }
 
 ::mlir::LogicalResult CreateBufferOp::verify() {
-  auto layout = mlir::dyn_cast_if_present<mlir::tt::MetalLayoutAttr>(
-      getResult().getType().getEncoding());
-  if (not layout) {
-    return emitOpError("Result type missing layout attribute");
-  }
-
   if (getSize() == 0) {
     return emitOpError("Alloc size must be non-zero");
   }
 
-  auto memref = layout.getMemref();
+  auto memref = getResult().getType();
   auto memspace =
       mlir::cast<mlir::tt::MemorySpaceAttr>(memref.getMemorySpace()).getValue();
   if (memspace != getMemorySpace()) {
@@ -75,13 +63,12 @@ namespace mlir::tt::ttmetal {
 
 ::mlir::LogicalResult EnqueueProgramOp::verify() {
   // Assert inputs/outputs device memspace
+
   for (auto operand : getOperands()) {
-    auto layout = mlir::dyn_cast_if_present<mlir::tt::MetalLayoutAttr>(
-        mlir::cast<mlir::RankedTensorType>(operand.getType()).getEncoding());
-    if (not layout) {
-      return emitOpError("Input tensor missing layout attribute");
-    }
-    if (not layout.isDeviceMemorySpace()) {
+    ::mlir::MemRefType outputTy = mlir::cast<MemRefType>(operand.getType());
+    MemorySpaceAttr memSpaceAttr =
+        mlir::cast<MemorySpaceAttr>(outputTy.getMemorySpace());
+    if (not isDeviceMemorySpace(memSpaceAttr.getValue())) {
       return emitOpError("Input tensor must be in device memory space");
     }
   }

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -9,6 +9,7 @@
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
 
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
+#include "mlir/Dialect/Arith/Transforms/Passes.h"
 #include "mlir/Dialect/Bufferization/Transforms/OneShotAnalysis.h"
 #include "mlir/Dialect/Bufferization/Transforms/Passes.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -32,6 +33,14 @@ void createTTIRBufferizationPipeline(OpPassManager &pm) {
   // bufferDeallocationOptions;
   // mlir::bufferization::buildBufferDeallocationPipeline(
   //    pm, bufferDeallocationOptions);
+}
+
+void createOptimizationPasses(OpPassManager &pm) {
+  pm.addPass(mlir::createCanonicalizerPass());
+  pm.addPass(mlir::createLoopInvariantCodeMotionPass());
+  pm.addPass(mlir::createSCCPPass());
+  pm.addPass(mlir::createCSEPass());
+  pm.addPass(mlir::arith::createIntRangeOptimizationsPass());
 }
 
 void createTTIRToTTMetalBackendPipeline(
@@ -61,8 +70,10 @@ void createTTIRToTTMetalBackendPipeline(
   pm.addPass(mlir::tt::ttir::createTTIRGenericLinearizeMemref());
   pm.addPass(mlir::createLowerAffinePass());
   pm.addPass(mlir::tt::ttir::createTTIRGenericGenerateDatamovement());
+  pm.addPass(mlir::tt::ttir::createTTIRGenericLowerAffineDMAs());
   pm.addPass(mlir::tt::ttir::createTTIRGenericHWThreadSelection());
   pm.addPass(mlir::tt::ttir::createTTIRGenericGenerateLoops());
+  createOptimizationPasses(pm);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -74,6 +74,7 @@ void createTTIRToTTMetalBackendPipeline(
   pm.addPass(mlir::tt::ttir::createTTIRGenericHWThreadSelection());
   pm.addPass(mlir::tt::ttir::createTTIRGenericGenerateLoops());
   createOptimizationPasses(pm);
+  pm.addPass(mlir::tt::ttir::createTTIRGenericRegionsToFuncs());
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTMetal/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTMetal/Transforms/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_mlir_dialect_library(MLIRTTMetalTransforms
+        ControlDstSection.cpp
+
+        ADDITIONAL_HEADER_DIRS
+        ${PROJECT_SOURCE_DIR}/include/ttmlir
+
+        DEPENDS
+        MLIRTTMetalOpsIncGen
+        MLIRTTMetalPassesIncGen
+        MLIRTTOpsIncGen
+        )

--- a/lib/Dialect/TTMetal/Transforms/ControlDstSection.cpp
+++ b/lib/Dialect/TTMetal/Transforms/ControlDstSection.cpp
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTMetal/Transforms/Passes.h"
+
+#include "ttmlir/Dialect/TT/IR/TT.h"
+#include "ttmlir/Dialect/TTKernel/IR/TTKernel.h"
+#include "ttmlir/Dialect/TTKernel/IR/TTKernelOps.h"
+#include "ttmlir/Dialect/TTMetal/IR/TTMetal.h"
+
+#include <mlir/IR/PatternMatch.h>
+#include <mlir/Support/LLVM.h>
+#include <mlir/Transforms/GreedyPatternRewriteDriver.h>
+
+namespace mlir::tt::ttmetal {
+#define GEN_PASS_DEF_TTMETALCONTROLDSTSECTION
+#include "ttmlir/Dialect/TTMetal/Transforms/Passes.h.inc"
+
+namespace {
+
+class TTMetalTileRegsRewriter : public OpRewritePattern<ttkernel::PackTileOp> {
+public:
+  using OpRewritePattern<ttkernel::PackTileOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ttkernel::PackTileOp op,
+                                PatternRewriter &rewriter) const final {
+    if (!op->getBlock()->getOps<ttkernel::TileRegsCommitOp>().empty()) {
+      return failure();
+    }
+
+    rewriter.moveOpAfter(
+        rewriter.create<ttkernel::TileRegsReleaseOp>(op->getLoc()), op);
+    auto regsWait = rewriter.create<ttkernel::TileRegsWaitOp>(op->getLoc());
+    rewriter.moveOpBefore(regsWait, op);
+    rewriter.moveOpBefore(
+        rewriter.create<ttkernel::TileRegsCommitOp>(op->getLoc()), regsWait);
+
+    rewriter.moveOpAfter(
+        rewriter.create<ttkernel::TileRegsAcquireOp>(op->getLoc()),
+        op->getBlock(), op->getBlock()->begin());
+
+    return success();
+  };
+};
+
+} // namespace
+
+namespace {
+class TTMetalControlDstSection
+    : public impl::TTMetalControlDstSectionBase<TTMetalControlDstSection> {
+public:
+  using impl::TTMetalControlDstSectionBase<
+      TTMetalControlDstSection>::TTMetalControlDstSectionBase;
+
+  void runOnOperation() final {
+    RewritePatternSet patterns(&getContext());
+    patterns.add<TTMetalTileRegsRewriter>(&getContext());
+
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+      signalPassFailure();
+      return;
+    }
+  }
+
+  void getDependentDialects(mlir::DialectRegistry &registry) const override {
+    registry.insert<mlir::tt::ttmetal::TTMetalDialect>();
+    registry.insert<mlir::tt::ttkernel::TTKernelDialect>();
+    registry.insert<mlir::tt::TTDialect>();
+  }
+};
+} // namespace
+
+} // namespace mlir::tt::ttmetal

--- a/lib/RegisterAll.cpp
+++ b/lib/RegisterAll.cpp
@@ -46,7 +46,7 @@ void mlir::tt::registerAllDialects(mlir::DialectRegistry &registry) {
       mlir::cf::ControlFlowDialect, mlir::tosa::TosaDialect,
       mlir::vector::VectorDialect, mlir::memref::MemRefDialect,
       mlir::emitc::EmitCDialect, mlir::bufferization::BufferizationDialect,
-      mlir::LLVM::LLVMDialect>();
+      mlir::LLVM::LLVMDialect, mlir::memref::MemRefDialect>();
 
 #if TTMLIR_ENABLE_STABLEHLO
   mlir::stablehlo::registerAllDialects(registry);

--- a/test/ttmlir/Conversion/TTIRToTTKernel/dma_lowering.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTKernel/dma_lowering.mlir
@@ -1,0 +1,98 @@
+// RUN: ttmlir-opt --convert-ttir-to-ttkernel %s  | FileCheck %s
+
+#l1_ = #tt.memory_space<l1>
+#dram = #tt.memory_space<dram>
+#system_desc = #tt.system_desc<[{role = host, target_triple = "x86_64-pc-linux-gnu"}], [{arch = <wormhole_b0>, grid = 8x8, l1_size = 1499136, num_dram_channels = 12, dram_channel_size = 1073741824, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32, l1_unreserved_base = 1024, erisc_l1_unreserved_base = 1024, dram_unreserved_base = 1024, dram_unreserved_end = 1073741824, physical_cores = {worker = [ 0x0,  0x1,  0x2,  0x3,  0x4,  0x5,  0x6,  0x7,  1x0,  1x1,  1x2,  1x3,  1x4,  1x5,  1x6,  1x7,  2x0,  2x1,  2x2,  2x3,  2x4,  2x5,  2x6,  2x7,  3x0,  3x1,  3x2,  3x3,  3x4,  3x5,  3x6,  3x7,  4x0,  4x1,  4x2,  4x3,  4x4,  4x5,  4x6,  4x7,  5x0,  5x1,  5x2,  5x3,  5x4,  5x5,  5x6,  5x7,  6x0,  6x1,  6x2,  6x3,  6x4,  6x5,  6x6,  6x7,  7x0,  7x1,  7x2,  7x3,  7x4,  7x5,  7x6,  7x7] dram = [ 8x0,  9x0,  10x0,  8x1,  9x1,  10x1,  8x2,  9x2,  10x2,  8x3,  9x3,  10x3]}, supported_data_types = [<f32>, <f16>, <bf16>, <bfp_f8>, <bfp_bf8>, <bfp_f4>, <bfp_bf4>, <bfp_f2>, <bfp_bf2>, <u32>, <u16>, <u8>, <si32>], supported_tile_sizes = [ 4x16,  16x16,  32x16,  4x32,  16x32,  32x32], num_cbs = 32, num_compute_threads = 1, num_datamovement_threads = 2}], [0], [3 : i32], [ 0x0x0x0]>
+
+module attributes {tt.system_desc = #system_desc} {
+tt.device @default_device = <workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5] -> (0, 0, (((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) floordiv s4) mod 12, ((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) floordiv (s4 * 12) + ((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
+
+// Test 1: Local to local DMA within same core
+// CHECK-LABEL: func.func @test_local_to_local_same_core
+func.func @test_local_to_local_same_core(%arg0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<2x2x!tt.tile<32x32, f32>, #l1_>) {
+  // CHECK: ttkernel.get_read_ptr
+  // CHECK: ttkernel.get_write_ptr
+  // CHECK: ttkernel.get_noc_addr_xy
+  // CHECK: ttkernel.noc_async_write
+  %0 = ttir.dma %arg0, %arg1 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+  return
+}
+
+// Test 2: Local to local DMA between different cores
+// CHECK-LABEL: func.func @test_local_to_local_remote_core
+func.func @test_local_to_local_remote_core(%arg0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<2x2x!tt.tile<32x32, f32>, #l1_>) {
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  // CHECK: ttkernel.get_read_ptr
+  // CHECK: ttkernel.get_write_ptr
+  // CHECK: ttkernel.get_noc_addr_xy
+  // CHECK: ttkernel.noc_async_write
+  %0 = ttir.dma %arg0, %arg1, core[%c1, %c2] : (memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+  return
+}
+
+// Test 3: Local to remote multicast DMA with same source and destination (regular multicast)
+// CHECK-LABEL: func.func @test_local_to_remote_multicast_regular
+func.func @test_local_to_remote_multicast_regular(%arg0: memref<2x2x!tt.tile<32x32, f32>, #l1_>) {
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %c4 = arith.constant 4 : index
+  // CHECK: ttkernel.get_read_ptr
+  // CHECK: ttkernel.get_write_ptr
+  // CHECK: ttkernel.get_noc_multicast_addr
+  // CHECK: ttkernel.noc_async_write_multicast
+  %0 = ttir.dma %arg0, %arg0, core[%c1, %c2] mcast[%c3, %c4] : (memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+  return
+}
+
+// Test 4: Local to remote multicast DMA with different source and destination (loopback source)
+// CHECK-LABEL: func.func @test_local_to_remote_multicast_loopback
+func.func @test_local_to_remote_multicast_loopback(%arg0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<2x2x!tt.tile<32x32, f32>, #l1_>) {
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %c4 = arith.constant 4 : index
+  // CHECK: ttkernel.get_read_ptr
+  // CHECK: ttkernel.get_write_ptr
+  // CHECK: ttkernel.get_noc_multicast_addr
+  // CHECK: ttkernel.noc_async_write_multicast_loopback_src
+  %0 = ttir.dma %arg0, %arg1, core[%c1, %c2] mcast[%c3, %c4] : (memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+  return
+}
+
+// Test 5: Remote to local DMA (L1 from another core)
+// CHECK-LABEL: func.func @test_remote_l1_to_local
+func.func @test_remote_l1_to_local(%dst: memref<2x2x!tt.tile<32x32, f32>, #l1_>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %src = ttir.get_global_operand(0) : memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 16384 + d3 * 4096)>, #l1_>
+  // CHECK: ttkernel.get_write_ptr
+  // CHECK: ttkernel.get_noc_addr_xy
+  // CHECK: ttkernel.noc_async_read
+  %0 = ttir.dma %src[%c0, %c1], %dst : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 16384 + d3 * 4096)>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+  return
+}
+
+// Test 7: DMA wait operation for read
+// CHECK-LABEL: func.func @test_dma_wait_read
+func.func @test_dma_wait_read(%dst: memref<2x2x!tt.tile<32x32, f32>, #l1_>) {
+  %src = ttir.get_global_operand(0) : memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 16384 + d3 * 4096)>, #l1_>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %0 = ttir.dma %src[%c0, %c1], %dst : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 16384 + d3 * 4096)>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+  // CHECK: ttkernel.noc_async_read_barrier
+  ttir.dma_wait %0
+  return
+}
+
+// Test 8: DMA wait operation for write
+// CHECK-LABEL: func.func @test_dma_wait_write
+func.func @test_dma_wait_write(%arg0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<2x2x!tt.tile<32x32, f32>, #l1_>) {
+  %0 = ttir.dma %arg0, %arg1 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+  // CHECK: ttkernel.noc_async_write_barrier
+  ttir.dma_wait %0
+  return
+}
+
+}

--- a/test/ttmlir/Conversion/TTIRToTTKernel/tiled_matmul.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTKernel/tiled_matmul.mlir
@@ -1,0 +1,91 @@
+// RUN: ttmlir-opt --convert-ttir-to-ttkernel %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+
+#l1_ = #tt.memory_space<l1>
+#system_desc = #tt.system_desc<[{role = host, target_triple = "x86_64-pc-linux-gnu"}], [{arch = <wormhole_b0>, grid = 8x8, l1_size = 1499136, num_dram_channels = 12, dram_channel_size = 1073741824, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32, l1_unreserved_base = 1024, erisc_l1_unreserved_base = 1024, dram_unreserved_base = 1024, dram_unreserved_end = 1073741824, physical_cores = {worker = [ 18x18,  0x1,  0x2,  0x3,  0x4,  0x5,  0x6,  0x7,  1x0,  1x1,  1x2,  1x3,  1x4,  1x5,  1x6,  1x7,  2x0,  2x1,  2x2,  2x3,  2x4,  2x5,  2x6,  2x7,  3x0,  3x1,  3x2,  3x3,  3x4,  3x5,  3x6,  3x7,  4x0,  4x1,  4x2,  4x3,  4x4,  4x5,  4x6,  4x7,  5x0,  5x1,  5x2,  5x3,  5x4,  5x5,  5x6,  5x7,  6x0,  6x1,  6x2,  6x3,  6x4,  6x5,  6x6,  6x7,  7x0,  7x1,  7x2,  7x3,  7x4,  7x5,  7x6,  7x7] dram = [ 8x0,  9x0,  10x0,  8x1,  9x1,  10x1,  8x2,  9x2,  10x2,  8x3,  9x3,  10x3]}, supported_data_types = [<f32>, <f16>, <bf16>, <bfp_f8>, <bfp_bf8>, <bfp_f4>, <bfp_bf4>, <bfp_f2>, <bfp_bf2>, <u32>, <u16>, <u8>, <si32>], supported_tile_sizes = [ 4x16,  16x16,  32x16,  4x32,  16x32,  32x32], num_cbs = 32, num_compute_threads = 1, num_datamovement_threads = 2}], [0], [3 : i32], [ 0x0x0x0]>
+module attributes {tt.system_desc = #system_desc} {
+    tt.device @default_device = <workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5] -> (0, 0, (((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) floordiv s4) mod 12, ((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) floordiv (s4 * 12) + ((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
+    func.func private @datamovement_kernel0(%arg0: memref<1x3x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<3x4x!tt.tile<32x32, f32>, #l1_>, %arg2: memref<1x4x!tt.tile<32x32, f32>, #l1_>, %arg3: !ttir.semaphore, %arg4: !ttir.semaphore, %arg5: !ttir.semaphore, %arg6: !ttir.semaphore) attributes {ttir.thread_type = 1 : i32} {
+    %c8 = arith.constant 8 : index
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
+    %c7 = arith.constant 7 : index
+    // CHECK: %{{[0-9]+}} = "ttkernel.my_x"
+    %core1 = ttir.core_index(1) : index
+    // CHECK: %{{[0-9]+}} = "ttkernel.my_y"
+    %core0 = ttir.core_index(0) : index
+    %0 = arith.cmpi eq, %core1, %c0 : index
+    scf.for %arg7 = %c0 to %c8 step %c1 {
+      // CHECK: "ttkernel.cb_reserve_back"
+      scf.if %0 {
+        // CHECK: %{{[0-9]+}} = "ttkernel.get_compile_time_arg_val"
+        %1 = ttir.get_global_operand(0) : memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 12288 + d3 * 4096)>, #l1_>
+        // CHECK: %{{[0-9]+}} = "ttkernel.get_noc_addr_xy"
+        // CHECK: "ttkernel.noc_async_read"
+        %tx = ttir.dma %1 [%c0, %arg7], %arg0 : (memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 12288 + d3 * 4096)>, #l1_>, memref<1x3x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+        // CHECK: "ttkernel.noc_async_read_barrier"
+        ttir.dma_wait %tx
+        // ttir.semaphore_wait %arg3, %c7 reset %c0
+        // CHECK: %{{[0-9]+}} = "ttkernel.get_write_ptr"
+        // CHECK: %{{[0-9]+}} = "ttkernel.get_noc_multicast_addr"
+        // CHECK: "ttkernel.noc_async_write_multicast"
+        %tx_0 = ttir.dma %arg0, %arg0, core[%core0, %c0] mcast[%c1, %c8] : (memref<1x3x!tt.tile<32x32, f32>, #l1_>, memref<1x3x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+        // CHECK: "ttkernel.noc_async_write_barrier"
+        ttir.dma_wait %tx_0
+        // ttir.semaphore_set %arg4, %c1, core[%core0, %c0] mcast[%c1, %c8]
+      } else {
+        // ttir.semaphore_inc %arg3, %c1, core[%core0, %c0]
+        // ttir.semaphore_wait %arg4, %c1 reset %c0
+      }
+      // CHECK: "ttkernel.cb_push_back"
+      ttir.yield %arg0 : (memref<1x3x!tt.tile<32x32, f32>, #l1_>)
+    }
+    return
+  }
+
+  func.func private @compute_kernel2(%arg0: memref<1x3x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<3x4x!tt.tile<32x32, f32>, #l1_>, %arg2: memref<1x4x!tt.tile<32x32, f32>, #l1_>, %arg3: !ttir.semaphore, %arg4: !ttir.semaphore, %arg5: !ttir.semaphore, %arg6: !ttir.semaphore) attributes {ttir.thread_type = 0 : i32} {
+    %c4 = arith.constant 4 : index
+    %c3 = arith.constant 3 : index
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
+    %collapse_shape = memref.collapse_shape %arg0 [[0, 1]] : memref<1x3x!tt.tile<32x32, f32>, #l1_> into memref<3x!tt.tile<32x32, f32>, #l1_>
+    %collapse_shape_0 = memref.collapse_shape %arg1 [[0, 1]] : memref<3x4x!tt.tile<32x32, f32>, #l1_> into memref<12x!tt.tile<32x32, f32>, #l1_>
+    %collapse_shape_1 = memref.collapse_shape %arg2 [[0, 1]] : memref<1x4x!tt.tile<32x32, f32>, #l1_> into memref<4x!tt.tile<32x32, f32>, #l1_>
+    // CHECK: "ttkernel.cb_reserve_back"
+    // CHECK: "ttkernel.cb_wait_front"
+    // CHECK: "ttkernel.cb_wait_front"
+    ttir.await %arg0, %arg1 : (memref<1x3x!tt.tile<32x32, f32>, #l1_>, memref<3x4x!tt.tile<32x32, f32>, #l1_>)
+    scf.for %arg7 = %c0 to %c1 step %c1 {
+      scf.for %arg8 = %c0 to %c4 step %c1 {
+        scf.for %arg9 = %c0 to %c3 step %c1 {
+          %0 = arith.muli %arg7, %c1 overflow<nsw> : index
+          %1 = arith.addi %0, %arg9 : index
+          %2 = memref.load %collapse_shape[%1] : memref<3x!tt.tile<32x32, f32>, #l1_>
+          %3 = arith.muli %arg9, %c4 overflow<nsw> : index
+          %4 = arith.addi %3, %arg8 : index
+          %5 = memref.load %collapse_shape_0[%4] : memref<12x!tt.tile<32x32, f32>, #l1_>
+          %6 = arith.muli %arg7, %c4 overflow<nsw> : index
+          %7 = arith.addi %6, %arg8 : index
+          // CHECK: "ttkernel.copy_tile_init"
+          // CHECK: "ttkernel.copy_tile"
+          %8 = memref.load %collapse_shape_1[%7] : memref<4x!tt.tile<32x32, f32>, #l1_>
+          // CHECK: "ttkernel.matmul_tiles"
+          // CHECK-SAME: {{.*}}%c0{{.*}}%c1
+          %9 = "ttir.tile_matmul"(%2, %5, %8) : (!tt.tile<32x32, f32>, !tt.tile<32x32, f32>, !tt.tile<32x32, f32>) -> !tt.tile<32x32, f32>
+          %10 = arith.muli %arg7, %c4 overflow<nsw> : index
+          %11 = arith.addi %10, %arg8 : index
+          // CHECK: "ttkernel.pack_tile"
+          memref.store %9, %collapse_shape_1[%11] : memref<4x!tt.tile<32x32, f32>, #l1_>
+        }
+      }
+    }
+    // CHECK: "ttkernel.cb_push_back"
+    // CHECK: "ttkernel.cb_wait_front"
+    // CHECK: "ttkernel.cb_pop_front"
+    // CHECK: "ttkernel.cb_pop_front"
+    // CHECK: "ttkernel.cb_pop_front"
+    ttir.yield %arg2 : (memref<1x4x!tt.tile<32x32, f32>, #l1_>)
+    ttir.await %arg2 : (memref<1x4x!tt.tile<32x32, f32>, #l1_>)
+    return
+  }
+}

--- a/test/ttmlir/Conversion/TTIRToTTMetal/alloc_lowering.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTMetal/alloc_lowering.mlir
@@ -1,0 +1,18 @@
+// RUN: ttmlir-opt --convert-ttir-to-ttmetal %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+
+#l1_ = #tt.memory_space<l1>
+
+func.func @alloc_no_addr(%arg0: memref<1x1x8x24x!tt.tile<32x32, f32>, #tt.shard<98304x4096>, #l1_>, %arg1: memref<1x1x24x32x!tt.tile<32x32, f32>, #tt.shard<131072x4096>, #l1_>) ->memref<8x8x1x4x!tt.tile<32x32, f32>, #l1_> {
+    // CHECK: %{{[0-9]+}} = "ttmetal.create_buffer"()
+    // CHECK-SAME: {{.*}}address = 1000 : i64
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x8x1x4x!tt.tile<32x32, f32>, #l1_>
+    return %alloc : memref<8x8x1x4x!tt.tile<32x32, f32>, #l1_>
+}
+
+func.func @alloc_with_addr(%arg0: memref<1x1x8x24x!tt.tile<32x32, f32>, #tt.shard<98304x4096>, #l1_>, %arg1: memref<1x1x24x32x!tt.tile<32x32, f32>, #tt.shard<131072x4096>, #l1_>) -> memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.shard<12288x4096>, #l1_> {
+    // CHECK: %{{[0-9]+}} = "ttmetal.create_buffer"()
+    // CHECK-SAME: {{.*}}address = 86016 : i64
+    %alloc = memref.alloc() {alignment = 64 : i64, address = 0x15000 : i64} : memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.shard<12288x4096>, #l1_>
+    return %alloc : memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.shard<12288x4096>, #l1_>
+}

--- a/test/ttmlir/Conversion/TTIRToTTMetal/generic_lowering.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTMetal/generic_lowering.mlir
@@ -1,0 +1,23 @@
+// RUN: ttmlir-opt --convert-ttir-to-ttmetal %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+
+#l1_ = #tt.memory_space<l1>
+#system_desc = #tt.system_desc<[{role = host, target_triple = "x86_64-pc-linux-gnu"}], [{arch = <wormhole_b0>, grid = 8x8, l1_size = 1499136, num_dram_channels = 12, dram_channel_size = 1073741824, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32, l1_unreserved_base = 1024, erisc_l1_unreserved_base = 1024, dram_unreserved_base = 1024, dram_unreserved_end = 1073741824, physical_cores = {worker = [ 18x18,  0x1,  0x2,  0x3,  0x4,  0x5,  0x6,  0x7,  1x0,  1x1,  1x2,  1x3,  1x4,  1x5,  1x6,  1x7,  2x0,  2x1,  2x2,  2x3,  2x4,  2x5,  2x6,  2x7,  3x0,  3x1,  3x2,  3x3,  3x4,  3x5,  3x6,  3x7,  4x0,  4x1,  4x2,  4x3,  4x4,  4x5,  4x6,  4x7,  5x0,  5x1,  5x2,  5x3,  5x4,  5x5,  5x6,  5x7,  6x0,  6x1,  6x2,  6x3,  6x4,  6x5,  6x6,  6x7,  7x0,  7x1,  7x2,  7x3,  7x4,  7x5,  7x6,  7x7] dram = [ 8x0,  9x0,  10x0,  8x1,  9x1,  10x1,  8x2,  9x2,  10x2,  8x3,  9x3,  10x3]}, supported_data_types = [<f32>, <f16>, <bf16>, <bfp_f8>, <bfp_bf8>, <bfp_f4>, <bfp_bf4>, <bfp_f2>, <bfp_bf2>, <u32>, <u16>, <u8>, <si32>], supported_tile_sizes = [ 4x16,  16x16,  32x16,  4x32,  16x32,  32x32], num_cbs = 32, num_compute_threads = 1, num_datamovement_threads = 2}], [0], [3 : i32], [ 0x0x0x0]>
+module attributes {tt.system_desc = #system_desc} {
+  tt.device @default_device = <workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5] -> (0, 0, (((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) floordiv s4) mod 12, ((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) floordiv (s4 * 12) + ((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
+  func.func @matmul(%arg0: memref<1x1x8x24x!tt.tile<32x32, f32>, #tt.shard<98304x4096>, #l1_>, %arg1: memref<1x1x24x32x!tt.tile<32x32, f32>, #tt.shard<131072x4096>, #l1_>) -> memref<1x1x8x32x!tt.tile<32x32, f32>, #tt.shard<131072x4096>, #l1_> {
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x8x1x4x!tt.tile<32x32, f32>, #l1_>
+    %alloc_0 = memref.alloc() {alignment = 64 : i64, address = 0x10000} : memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.shard<12288x4096>, #l1_>
+    %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<1x1x8x24x!tt.tile<32x32, f32>, #tt.shard<98304x4096>, #l1_>, memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.shard<12288x4096>, #l1_>) -> memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 12288 + d3 * 4096)>, #l1_>
+    %alloc_1 = memref.alloc() {alignment = 64 : i64, address = 0x15000} : memref<8x8x3x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
+    %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<1x1x24x32x!tt.tile<32x32, f32>, #tt.shard<131072x4096>, #l1_>, memref<8x8x3x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>) -> memref<8x8x3x4x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 16384 + d3 * 4096)>, #l1_>
+    // CHECK: "ttmetal.enqueue_program"
+    // CHECK-SAME: {{.*}}core_ranges = [#ttmetal.core_range<0x0, 8x8>, #ttmetal.core_range<0x0, 8x8>, #ttmetal.core_range<0x0, 8x8>]
+    // CHECK-SAME: {{.*}}threads = [#ttir.thread<datamovement, @datamovement_kernel0>, #ttir.thread<datamovement, @datamovement_kernel1>, #ttir.thread<compute, @compute_kernel2>]
+    ttir.generic {grid = #tt.grid<8x8>, indexing_maps = [], iterator_types = [], threads = [#ttir.thread<datamovement, @datamovement_kernel0>, #ttir.thread<datamovement, @datamovement_kernel1>, #ttir.thread<compute, @compute_kernel2>]}
+        ins(%stream, %stream_2 : memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 12288 + d3 * 4096)>, #l1_>, memref<8x8x3x4x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 16384 + d3 * 4096)>, #l1_>)
+        outs(%alloc : memref<8x8x1x4x!tt.tile<32x32, f32>, #l1_>)
+    %view = "ttir.view_layout"(%alloc) : (memref<8x8x1x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x8x32x!tt.tile<32x32, f32>, #tt.shard<131072x4096>, #l1_>
+    return %view : memref<1x1x8x32x!tt.tile<32x32, f32>, #tt.shard<131072x4096>, #l1_>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/allocate/generic_form_streams.mlir
+++ b/test/ttmlir/Dialect/TTIR/allocate/generic_form_streams.mlir
@@ -15,8 +15,10 @@ func.func @matmul_single_core_stream(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>,
   // CHECK-NOT: "ttir.view_layout"
   // CHECK: [[rhs:%[a-z0-9_]+]] = "ttir.stream_layout"(%arg1,
   %1 = "ttir.view_layout"(%arg1) : (memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>
-  // CHECK: "ttir.generic"([[lhs]], [[rhs]], [[out:%[a-z0-9_]+]])
-  "ttir.generic"(%0, %1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>, operand_cb_mapping = array<i64>}> ({
+  // CHECK: ttir.generic{{.*}}
+  // CHECK-NEXT: ins([[lhs]], [[rhs]] : {{.*}})
+  // CHECK-NEXT: outs([[out:%[a-z0-9_]+]] : {{.*}})
+  "ttir.generic"(%0, %1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^bb0(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
     "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
   }) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
@@ -31,8 +33,10 @@ func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, 
   // CHECK-NOT: "ttir.view_layout"
   // CHECK: [[rhs:%[a-z0-9_]+]] = "ttir.stream_layout"(%arg1,
   %1 = "ttir.view_layout"(%arg1) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>
-  // CHECK: "ttir.generic"([[lhs]], [[rhs]], [[out:%[a-z0-9_]+]])
-  "ttir.generic"(%0, %1, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>, operand_cb_mapping = array<i64>}> ({
+  // CHECK: ttir.generic{{.*}}
+  // CHECK-NEXT: ins([[lhs]], [[rhs]] : {{.*}})
+  // CHECK-NEXT: outs([[out:%[a-z0-9_]+]] : {{.*}})
+  "ttir.generic"(%0, %1, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^bb0(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>):
     "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
   }) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>, memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
@@ -47,8 +51,10 @@ func.func @matmul_multi_core_transpose(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32
   // CHECK-NOT: "ttir.view_layout"
   // CHECK: [[rhs:%[a-z0-9_]+]] = "ttir.stream_layout"(%arg1, {{.*}}, #tt.stream<(d0, d1, d2, d3) -> (d1, d0, d3, d2)>,
   %1 = "ttir.view_layout"(%arg1) : (memref<4x4x8x6x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, affine_map<(d0, d1, d2, d3) -> (d1, d0, d3, d2)>, #l1_>
-  // CHECK: "ttir.generic"([[lhs]], [[rhs]], [[out:%[a-z0-9_]+]])
-  "ttir.generic"(%0, %1, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>, operand_cb_mapping = array<i64>}> ({
+  // CHECK: ttir.generic{{.*}}
+  // CHECK-NEXT: ins([[lhs]], [[rhs]] : {{.*}})
+  // CHECK-NEXT: outs([[out:%[a-z0-9_]+]] : {{.*}})
+  "ttir.generic"(%0, %1, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^bb0(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>):
     "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
   }) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<4x4x6x8x!tt.tile<32x32, f32>, affine_map<(d0, d1, d2, d3) -> (d1, d0, d3, d2)>, #l1_>, memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>) -> ()

--- a/test/ttmlir/Dialect/TTIR/bufferization/bufferization.mlir
+++ b/test/ttmlir/Dialect/TTIR/bufferization/bufferization.mlir
@@ -10,8 +10,8 @@
 func.func @matmul(%arg0: tensor<1x1x2x4x!tt.tile<32x32, f32>>, %arg1: tensor<1x1x4x2x!tt.tile<32x32, f32>>) -> tensor<1x1x2x2x!tt.tile<32x32, f32>> {
   // CHECK: = memref.alloc(){{.*}}: memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>
   %0 = ttir.empty() : tensor<1x1x2x2x!tt.tile<32x32, f32>>
-  // CHECK: {{^  "ttir.generic".*}}
-  %3 = "ttir.generic"(%arg0, %arg1, %0) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map1, #map2], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  // CHECK: {{^  ttir.generic.*}}
+  %3 = "ttir.generic"(%arg0, %arg1, %0) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map1, #map2], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg3: memref<4x2x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
     "ttir.tile_matmul_block"(%arg2, %arg3, %arg4) : (memref<2x4x!tt.tile<32x32, f32>, #l1_>, memref<4x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
   }) : (tensor<1x1x2x4x!tt.tile<32x32, f32>>, tensor<1x1x4x2x!tt.tile<32x32, f32>>, tensor<1x1x2x2x!tt.tile<32x32, f32>>) -> tensor<1x1x2x2x!tt.tile<32x32, f32>>

--- a/test/ttmlir/Dialect/TTIR/bufferization/bufferization.mlir
+++ b/test/ttmlir/Dialect/TTIR/bufferization/bufferization.mlir
@@ -8,7 +8,7 @@
 #reduction = #tt.iterator_type<reduction>
 
 func.func @matmul(%arg0: tensor<1x1x2x4x!tt.tile<32x32, f32>>, %arg1: tensor<1x1x4x2x!tt.tile<32x32, f32>>) -> tensor<1x1x2x2x!tt.tile<32x32, f32>> {
-  // CHECK: = memref.alloc() {{.*}} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  // CHECK: = memref.alloc(){{.*}}: memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>
   %0 = ttir.empty() : tensor<1x1x2x2x!tt.tile<32x32, f32>>
   // CHECK: {{^  "ttir.generic".*}}
   %3 = "ttir.generic"(%arg0, %arg1, %0) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map1, #map2], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
@@ -19,7 +19,7 @@ func.func @matmul(%arg0: tensor<1x1x2x4x!tt.tile<32x32, f32>>, %arg1: tensor<1x1
 }
 
 func.func @to_layout(%arg0: tensor<1x1x2x4x!tt.tile<32x32, f32>>) -> tensor<1x1x2x4x!tt.tile<32x32, f32>> {
-  // CHECK: = memref.alloc() {{.*}} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+  // CHECK: = memref.alloc(){{.*}}: memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
   %0 = ttir.empty() : tensor<1x1x2x4x!tt.tile<32x32, f32>>
   // CHECK: {{^  "ttir.to_layout".*}}
   %3 = "ttir.to_layout"(%arg0, %0) : (tensor<1x1x2x4x!tt.tile<32x32, f32>>, tensor<1x1x2x4x!tt.tile<32x32, f32>>) -> tensor<1x1x2x4x!tt.tile<32x32, f32>>
@@ -27,7 +27,7 @@ func.func @to_layout(%arg0: tensor<1x1x2x4x!tt.tile<32x32, f32>>) -> tensor<1x1x
 }
 
 func.func @stream_layout(%arg0: tensor<1x1x2x4x!tt.tile<32x32, f32>>) -> tensor<1x1x2x4x!tt.tile<32x32, f32>> {
-  // CHECK: = memref.alloc() {{.*}} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+  // CHECK: = memref.alloc(){{.*}}: memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
   %0 = ttir.empty() : tensor<1x1x2x4x!tt.tile<32x32, f32>>
   // CHECK: = "ttir.stream_layout"
   %3 = "ttir.stream_layout"(%arg0, %0) : (tensor<1x1x2x4x!tt.tile<32x32, f32>>, tensor<1x1x2x4x!tt.tile<32x32, f32>>) -> tensor<1x1x2x4x!tt.tile<32x32, f32>>

--- a/test/ttmlir/Dialect/TTIR/bufferization/memory_effects.mlir
+++ b/test/ttmlir/Dialect/TTIR/bufferization/memory_effects.mlir
@@ -10,8 +10,8 @@
 func.func @matmul_pure_tensors(%arg0: tensor<2x4x!tt.tile<32x32, f32>>, %arg1: tensor<4x2x!tt.tile<32x32, f32>>) -> tensor<2x2x!tt.tile<32x32, f32>> {
   %0 = ttir.empty() : tensor<2x2x!tt.tile<32x32, f32>>
   // No uses of %3, so it should be removed.
-  // CHECK-NOT: "ttir.generic"
-  %3 = "ttir.generic"(%arg0, %arg1, %0) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map1, #map2], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  // CHECK-NOT: ttir.generic
+  %3 = "ttir.generic"(%arg0, %arg1, %0) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map1, #map2], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg3: memref<4x2x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
     "ttir.tile_matmul_block"(%arg2, %arg3, %arg4) : (memref<2x4x!tt.tile<32x32, f32>, #l1_>, memref<4x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
   }) : (tensor<2x4x!tt.tile<32x32, f32>>, tensor<4x2x!tt.tile<32x32, f32>>, tensor<2x2x!tt.tile<32x32, f32>>) -> tensor<2x2x!tt.tile<32x32, f32>>
@@ -29,8 +29,8 @@ func.func @to_layout_pure_tensors(%arg0: tensor<2x4x!tt.tile<32x32, f32>>) -> te
 func.func @matmul_memref(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x4x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
   // Ensure that the generic op is not removed.
-  // CHECK: "ttir.generic"
-  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map1, #map2], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  // CHECK: ttir.generic
+  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map1, #map2], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg3: memref<4x2x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
     "ttir.tile_matmul_block"(%arg2, %arg3, %arg4) : (memref<2x4x!tt.tile<32x32, f32>, #l1_>, memref<4x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
   }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x4x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()

--- a/test/ttmlir/Dialect/TTIR/bufferization/prepare_tensors.mlir
+++ b/test/ttmlir/Dialect/TTIR/bufferization/prepare_tensors.mlir
@@ -12,11 +12,13 @@
 func.func @main(%arg0: tensor<256x384xf32, #layout1>, %arg1: tensor<256x384xf32, #layout1>) -> tensor<256x32xf32, #layout2> {
   // CHECK: ttir.empty() : tensor<1x1x8x1x!tt.tile<32x32, f32>, #layout1>
   %0 = ttir.empty() : tensor<256x32xf32, #layout2>
-  // CHECK: : (tensor<1x1x8x12x!tt.tile<32x32, f32>, #layout>, tensor<1x1x8x12x!tt.tile<32x32, f32>, #layout>, tensor<1x1x8x1x!tt.tile<32x32, f32>, #layout1>) -> tensor<1x1x8x1x!tt.tile<32x32, f32>, #layout1>
+  // CHECK: ins({{.*}} : tensor<1x1x8x12x!tt.tile<32x32, f32>, #layout>, tensor<1x1x8x12x!tt.tile<32x32, f32>, #layout>)
+  // CHECK-NEXT: outs({{.*}} : tensor<1x1x8x1x!tt.tile<32x32, f32>, #layout1>)
   %1 = "ttir.generic"(%arg0, %arg1, %0) <{
         grid = #tt.grid<1x1>,
         indexing_maps = [#map1, #map1, #map2],
         iterator_types = [#parallel, #reduction],
+        threads = [#ttir.thread<compute>],
         operandSegmentSizes = array<i32: 2, 1>
         }> ({
         ^bb0(%arg2: memref<8x12x!tt.tile<32x32, f32>, #l1_>,
@@ -41,11 +43,13 @@ func.func @main(%arg0: tensor<256x384xf32, #layout1>, %arg1: tensor<256x384xf32,
 func.func @main(%arg0: tensor<256x384xf32, #layout1>, %arg1: tensor<256x384xf32, #layout1>) -> tensor<256x32xf32, #layout2> {
   // CHECK: ttir.empty() : tensor<4x1x2x1x!tt.tile<32x32, f32>, #layout1>
   %0 = ttir.empty() : tensor<256x32xf32, #layout2>
-  // CHECK: : (tensor<4x3x2x4x!tt.tile<32x32, f32>, #layout>, tensor<4x3x2x4x!tt.tile<32x32, f32>, #layout>, tensor<4x1x2x1x!tt.tile<32x32, f32>, #layout1>) -> tensor<4x1x2x1x!tt.tile<32x32, f32>, #layout1>
+  // CHECK: ins({{.*}} : tensor<4x3x2x4x!tt.tile<32x32, f32>, #layout>, tensor<4x3x2x4x!tt.tile<32x32, f32>, #layout>)
+  // CHECK-NEXT: outs({{.*}} : tensor<4x1x2x1x!tt.tile<32x32, f32>, #layout1>)
   %1 = "ttir.generic"(%arg0, %arg1, %0) <{
         grid = #tt.grid<4x1>,
         indexing_maps = [#map1, #map1, #map2],
         iterator_types = [#parallel, #reduction],
+        threads = [#ttir.thread<compute>],
         operandSegmentSizes = array<i32: 2, 1>
         }> ({
         ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>,

--- a/test/ttmlir/Dialect/TTIR/generalization/generalization.mlir
+++ b/test/ttmlir/Dialect/TTIR/generalization/generalization.mlir
@@ -68,7 +68,7 @@ module {
 
   // CHECK-LABEL: func @named_contractions
   func.func @named_contractions(%lhs: !lhs, %rhs: !rhs, %out: !matmul_result) -> (!matmul_result) {
-    // CHECK: "ttir.generic"{{.+}}iterator_types = [#parallel, #parallel, #reduction]
+    // CHECK: ttir.generic{{.+}}iterator_types = [#parallel, #parallel, #reduction]
     // CHECK-NOT: linalg.generic
     // CHECK: ttir.tile_matmul_block
     %r = "ttir.matmul"(%lhs, %rhs, %out) : (!lhs, !rhs, !matmul_result) -> (!matmul_result)

--- a/test/ttmlir/Dialect/TTIR/generic/affine_dma.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/affine_dma.mlir
@@ -1,0 +1,236 @@
+// RUN: ttmlir-opt --tt-register-device --ttir-generic-lower-affine-dmas %s | FileCheck %s
+
+#dram = #tt.memory_space<dram>
+#l1_ = #tt.memory_space<l1>
+#map1 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map2 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map3 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#parallel = #tt.iterator_type<parallel>
+#reduction = #tt.iterator_type<reduction>
+
+func.func @matmul_single_core_stream(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>
+  %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>
+  "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  ^datamovement0(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
+    // CHECK-DAG: [[iter0:%.*]] = ttir.iter_index(0)
+    // CHECK-DAG: [[iter2:%.*]] = ttir.iter_index(2)
+    // CHECK-DAG: [[core0:%.*]] = ttir.core_index(0)
+    // CHECK-DAG: arith.muli
+    // CHECK-DAG: arith.addi
+    // CHECK: ttir.dma %stream{{[_0-9]*}} [%{{.*}}, [[iter2]]]
+    %tx = ttir.dma %stream<#map1>, %cb0 : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+    ttir.dma_wait %tx
+    ttir.yield %cb0 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^datamovement1(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
+    // CHECK-DAG: [[iter1:%.*]] = ttir.iter_index(1)
+    // CHECK-DAG: [[iter2:%.*]] = ttir.iter_index(2)
+    // CHECK-DAG: [[core1:%.*]] = ttir.core_index(1)
+    // CHECK-DAG: arith.muli
+    // CHECK-DAG: arith.addi
+    // CHECK: ttir.dma %stream{{[_0-9]*}} [[[iter2]], %{{.*}}]
+    %tx = ttir.dma %stream_2<#map2>, %cb1 : (memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+    ttir.dma_wait %tx
+    ttir.yield %cb1 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^datamovement2(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
+    ttir.await %cb2 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^compute(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
+    ttir.await %cb0, %cb1 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>)
+    "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
+    ttir.yield %cb2 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
+  }) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+}
+
+func.func @matmul_single_core_transpose(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>
+  %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d1, d0, d3, d2) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>
+  "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  ^datamovement0(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
+    // CHECK-DAG: [[iter0:%.*]] = ttir.iter_index(0)
+    // CHECK-DAG: [[iter2:%.*]] = ttir.iter_index(2)
+    // CHECK-DAG: [[core0:%.*]] = ttir.core_index(0)
+    // CHECK-DAG: arith.muli
+    // CHECK-DAG: arith.addi
+    // CHECK: ttir.dma %stream{{[_0-9]*}} [%{{.*}}, [[iter2]]]
+    %tx = ttir.dma %stream<#map1>, %cb0 : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+    ttir.dma_wait %tx
+    ttir.yield %cb0 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^datamovement1(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
+    // CHECK-DAG: [[iter2:%.*]] = ttir.iter_index(2)
+    // CHECK-DAG: [[iter1:%.*]] = ttir.iter_index(1)
+    // CHECK-DAG: [[core1:%.*]] = ttir.core_index(1)
+    // CHECK-DAG: arith.muli
+    // CHECK-DAG: arith.addi
+    // CHECK: ttir.null_tx
+    // CHECK-NEXT: scf.for
+    // CHECK-NEXT: scf.for
+    // CHECK-NEXT: ttir.dma %stream{{[_0-9]*}} [[[iter2]], %{{.*}}]
+    // CHECK: scf.yield
+    // CHECK: scf.yield
+    %tx = ttir.dma %stream_2<#map2>, %cb1 : (memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d1, d0, d3, d2) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+    ttir.dma_wait %tx
+    ttir.yield %cb1 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^datamovement2(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
+    ttir.await %cb2 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^compute(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
+    ttir.await %cb0, %cb1 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>)
+    "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
+    ttir.yield %cb2 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
+  }) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d1, d0, d3, d2) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+}
+
+func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
+  %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
+  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>
+  %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 24576 + d3 * 4096)>, #l1_>
+  %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>, memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #l1_>
+  "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  ^datamovement0(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>, %sem0: !ttir.semaphore, %sem1: !ttir.semaphore, %sem2: !ttir.semaphore, %sem3: !ttir.semaphore):
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %core0 = ttir.core_index(0) : index
+    %core1 = ttir.core_index(1) : index
+    %0 = arith.cmpi eq, %core1, %c0 : index
+    scf.if %0 {
+      // CHECK-DAG: [[iter0:%.*]] = ttir.iter_index(0)
+      // CHECK-DAG: [[iter2:%.*]] = ttir.iter_index(2)
+      // CHECK-DAG: [[core0:%.*]] = ttir.core_index(0)
+      // CHECK-DAG: arith.muli
+      // CHECK-DAG: arith.addi
+      // CHECK: ttir.dma %stream{{[_0-9]*}} [%{{.*}}, [[iter2]]]
+      %tx = ttir.dma %stream<#map1>, %cb0 : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 24576 + d3 * 4096)>, #l1_>, memref<4x6x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+      ttir.dma_wait %tx
+      ttir.semaphore_wait %sem0, %c3 reset %c0
+      %tx_3 = ttir.dma %cb0, %cb0, core[%core0, %c0] mcast[%c1, %c4] : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<4x6x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+      ttir.dma_wait %tx_3
+      ttir.semaphore_set %sem1, %c1, core[%core0, %c0] mcast[%c1, %c4]
+    } else {
+      ttir.semaphore_inc %sem0, %c1, core[%core0, %c0]
+      ttir.semaphore_wait %sem1, %c1 reset %c0
+    }
+    ttir.yield %cb0 : (memref<4x6x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^datamovement1(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>, %sem0: !ttir.semaphore, %sem1: !ttir.semaphore, %sem2: !ttir.semaphore, %sem3: !ttir.semaphore):
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %core0 = ttir.core_index(0) : index
+    %0 = arith.cmpi eq, %core0, %c0 : index
+    %core1 = ttir.core_index(1) : index
+    scf.if %0 {
+      // CHECK-DAG: [[iter1:%.*]] = ttir.iter_index(1)
+      // CHECK-DAG: [[iter2:%.*]] = ttir.iter_index(2)
+      // CHECK-DAG: [[core1:%.*]] = ttir.core_index(1)
+      // CHECK-DAG: arith.muli
+      // CHECK-DAG: arith.addi
+      // CHECK: ttir.dma %stream{{[_0-9]*}} [[[iter2]], %{{.*}}]
+      %tx = ttir.dma %stream_2<#map2>, %cb1 : (memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+      ttir.dma_wait %tx
+      ttir.semaphore_wait %sem2, %c1 reset %c0
+      %tx_3 = ttir.dma %cb1, %cb1, core[%c0, %core1] mcast[%c2, %c1] : (memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+      ttir.dma_wait %tx_3
+      ttir.semaphore_set %sem3, %c1, core[%c0, %core1] mcast[%c2, %c1]
+    } else {
+      ttir.semaphore_inc %sem2, %c1, core[%c0, %core1]
+      ttir.semaphore_wait %sem3, %c1 reset %c0
+    }
+    ttir.yield %cb1 : (memref<6x8x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^datamovement2(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>, %sem0: !ttir.semaphore, %sem1: !ttir.semaphore, %sem2: !ttir.semaphore, %sem3: !ttir.semaphore):
+    ttir.await %cb2 : (memref<4x8x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^compute(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>, %sem0: !ttir.semaphore, %sem1: !ttir.semaphore, %sem2: !ttir.semaphore, %sem3: !ttir.semaphore):
+    ttir.await %cb0, %cb1 : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>)
+    "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
+    ttir.yield %cb2 : (memref<4x8x!tt.tile<32x32, f32>, #l1_>)
+  }) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 24576 + d3 * 4096)>, #l1_>, memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #l1_>, memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
+  return %alloc : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
+}
+
+func.func @matmul_multi_core_dram_params(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<4x4x6x8x!tt.tile<32x32, f32>, #dram>) -> memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
+  %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
+  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>
+  %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 24576 + d3 * 4096)>, #l1_>
+  %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #dram>, memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #dram>
+  "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  ^datamovement0(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>, %sem0: !ttir.semaphore, %sem1: !ttir.semaphore, %sem2: !ttir.semaphore, %sem3: !ttir.semaphore):
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %core0 = ttir.core_index(0) : index
+    %core1 = ttir.core_index(1) : index
+    %0 = arith.cmpi eq, %core1, %c0 : index
+    scf.if %0 {
+      // CHECK-DAG: [[iter0:%.*]] = ttir.iter_index(0)
+      // CHECK-DAG: [[iter2:%.*]] = ttir.iter_index(2)
+      // CHECK-DAG: [[core0:%.*]] = ttir.core_index(0)
+      // CHECK-DAG: arith.muli
+      // CHECK-DAG: arith.addi
+      // CHECK: ttir.dma %stream{{[_0-9]*}} [%{{.*}}, [[iter2]]]
+      %tx = ttir.dma %stream<#map1>, %cb0 : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 24576 + d3 * 4096)>, #l1_>, memref<4x6x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+      ttir.dma_wait %tx
+      ttir.semaphore_wait %sem0, %c3 reset %c0
+      %tx_3 = ttir.dma %cb0, %cb0, core[%core0, %c0] mcast[%c1, %c4] : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<4x6x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+      ttir.dma_wait %tx_3
+      ttir.semaphore_set %sem1, %c1, core[%core0, %c0] mcast[%c1, %c4]
+    } else {
+      ttir.semaphore_inc %sem0, %c1, core[%core0, %c0]
+      ttir.semaphore_wait %sem1, %c1 reset %c0
+    }
+    ttir.yield %cb0 : (memref<4x6x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^datamovement1(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>, %sem0: !ttir.semaphore, %sem1: !ttir.semaphore, %sem2: !ttir.semaphore, %sem3: !ttir.semaphore):
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %core0 = ttir.core_index(0) : index
+    %0 = arith.cmpi eq, %core0, %c0 : index
+    %core1 = ttir.core_index(1) : index
+    scf.if %0 {
+      // CHECK-DAG: [[iter1:%.*]] = ttir.iter_index(1)
+      // CHECK-DAG: [[iter2:%.*]] = ttir.iter_index(2)
+      // CHECK-DAG: [[core1:%.*]] = ttir.core_index(1)
+      // CHECK-DAG: arith.muli
+      // CHECK-DAG: arith.addi
+      // CHECK: ttir.dma %stream{{[_0-9]*}} [[[iter2]], %{{.*}}]
+      %tx = ttir.dma %stream_2<#map2>, %cb1 : (memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #dram>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+      ttir.dma_wait %tx
+      ttir.semaphore_wait %sem2, %c1 reset %c0
+      %tx_3 = ttir.dma %cb1, %cb1, core[%c0, %core1] mcast[%c2, %c1] : (memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+      ttir.dma_wait %tx_3
+      ttir.semaphore_set %sem3, %c1, core[%c0, %core1] mcast[%c2, %c1]
+    } else {
+      ttir.semaphore_inc %sem2, %c1, core[%c0, %core1]
+      ttir.semaphore_wait %sem3, %c1 reset %c0
+    }
+    ttir.yield %cb1 : (memref<6x8x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^datamovement2(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>, %sem0: !ttir.semaphore, %sem1: !ttir.semaphore, %sem2: !ttir.semaphore, %sem3: !ttir.semaphore):
+    ttir.await %cb2 : (memref<4x8x!tt.tile<32x32, f32>, #l1_>)
+  }, {
+  ^compute(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>, %sem0: !ttir.semaphore, %sem1: !ttir.semaphore, %sem2: !ttir.semaphore, %sem3: !ttir.semaphore):
+    ttir.await %cb0, %cb1 : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>)
+    "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
+    ttir.yield %cb2 : (memref<4x8x!tt.tile<32x32, f32>, #l1_>)
+  }) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 24576 + d3 * 4096)>, #l1_>, memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #dram>, memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
+  return %alloc : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
+}

--- a/test/ttmlir/Dialect/TTIR/generic/generic_datamovement.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/generic_datamovement.mlir
@@ -76,12 +76,12 @@ func.func @matmul_single_core_stream(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>,
   // Look for 4 regions, one for each operand and one for the compute
   // Operand 0 (input)
   // CHECK: ^datamovement0
-  // CHECK-NEXT: ttir.dma [[lhs]] [#map1], %cb0
+  // CHECK-NEXT: ttir.dma [[lhs]]<#map1>, %cb0
   // CHECK-NEXT: ttir.dma_wait
   // CHECK-NEXT: ttir.yield %cb0
   // Operand 1 (input)
   // CHECK: ^datamovement1
-  // CHECK-NEXT: ttir.dma [[rhs]] [#map2], %cb1
+  // CHECK-NEXT: ttir.dma [[rhs]]<#map2>, %cb1
   // CHECK-NEXT: ttir.dma_wait
   // CHECK-NEXT: ttir.yield %cb1
   // Operand 2 (output)
@@ -109,7 +109,7 @@ func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, 
   // Look for 4 regions, one for each operand and one for the compute
   // Operand 0 (input)
   // CHECK: ^datamovement0
-  // CHECK: ttir.dma [[lhs]] [#map1], %cb0
+  // CHECK: ttir.dma [[lhs]]<#map1>, %cb0
   // CHECK-NEXT: ttir.dma_wait
   // CHECK-NEXT: ttir.semaphore_wait [[reader_ready_lhs:%[a-z0-9]+]]
   // CHECK-NEXT: ttir.dma %cb0, %cb0
@@ -120,7 +120,7 @@ func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, 
   // CHECK-NEXT: ttir.semaphore_wait [[writer_done_lhs]]
   // Operand 1 (input)
   // CHECK: ^datamovement1
-  // CHECK: ttir.dma [[rhs]] [#map2], %cb1
+  // CHECK: ttir.dma [[rhs]]<#map2>, %cb1
   // CHECK-NEXT: ttir.dma_wait
   // CHECK-NEXT: ttir.semaphore_wait [[reader_ready_rhs:%[a-z0-9]+]]
   // CHECK-NEXT: ttir.dma %cb1, %cb1
@@ -154,7 +154,7 @@ func.func @matmul_multi_core_dram_params(%arg0: memref<2x4x4x6x!tt.tile<32x32, f
   // Look for 4 regions, one for each operand and one for the compute
   // Operand 0 (input)
   // CHECK: ^datamovement0
-  // CHECK: ttir.dma [[lhs]] [#map1], %cb0
+  // CHECK: ttir.dma [[lhs]]<#map1>, %cb0
   // CHECK-NEXT: ttir.dma_wait
   // CHECK-NEXT: ttir.semaphore_wait [[reader_ready_lhs:%[a-z0-9]+]]
   // CHECK-NEXT: ttir.dma %cb0, %cb0
@@ -165,7 +165,7 @@ func.func @matmul_multi_core_dram_params(%arg0: memref<2x4x4x6x!tt.tile<32x32, f
   // CHECK-NEXT: ttir.semaphore_wait [[writer_done_lhs]]
   // Operand 1 (input)
   // CHECK: ^datamovement1
-  // CHECK: ttir.dma [[rhs]] [#map2], %cb1
+  // CHECK: ttir.dma [[rhs]]<#map2>, %cb1
   // CHECK-NEXT: ttir.dma_wait
   // CHECK-NEXT: ttir.semaphore_wait [[reader_ready_rhs:%[a-z0-9]+]]
   // CHECK-NEXT: ttir.dma %cb1, %cb1

--- a/test/ttmlir/Dialect/TTIR/generic/generic_datamovement.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/generic_datamovement.mlir
@@ -7,7 +7,7 @@
 
 func.func @add(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 2, 1>, operand_cb_mapping = array<i64>}> ({
+  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   // Look for 4 regions, one for each operand and one for the compute
   // Operand 0 (input)
   // CHECK: ^datamovement0
@@ -43,7 +43,7 @@ func.func @add(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<
 
 func.func @matmul_single_core(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x4x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>, operand_cb_mapping = array<i64>}> ({
+  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   // Look for 4 regions, one for each operand and one for the compute
   // Operand 0 (input)
   // CHECK: ^datamovement0
@@ -71,8 +71,10 @@ func.func @matmul_single_core_stream(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>,
   %cb1_alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
   %0 = "ttir.stream_layout"(%arg0, %cb0_alloc) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 2 * 4096 + d3 * 4096)>, #l1_>
   %1 = "ttir.stream_layout"(%arg1, %cb1_alloc) : (memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 2 * 4096 + d3 * 4096)>, #l1_>
-  // CHECK: "ttir.generic"([[lhs:%[a-z0-9_]+]], [[rhs:%[a-z0-9_]+]], [[out:%[a-z0-9_]+]])
-  "ttir.generic"(%0, %1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>, operand_cb_mapping = array<i64>}> ({
+  // CHECK: ttir.generic
+  // CHECK-NEXT: ins([[lhs:%[a-z0-9_]+]], [[rhs:%[a-z0-9_]+]] : {{.*}})
+  // CHECK-NEXT: outs([[out:%[a-z0-9_]+]] : {{.*}})
+  "ttir.generic"(%0, %1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   // Look for 4 regions, one for each operand and one for the compute
   // Operand 0 (input)
   // CHECK: ^datamovement0
@@ -104,8 +106,10 @@ func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, 
   %cb1_alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>
   %0 = "ttir.stream_layout"(%arg0, %cb0_alloc) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 6 * 4096 + d3 * 4096)>, #l1_>
   %1 = "ttir.stream_layout"(%arg1, %cb1_alloc) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>, memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8 * 4096 + d3 * 4096)>, #l1_>
-  // CHECK: "ttir.generic"([[lhs:%[a-z0-9_]+]], [[rhs:%[a-z0-9_]+]], [[out:%[a-z0-9_]+]])
-  "ttir.generic"(%0, %1, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>, operand_cb_mapping = array<i64>}> ({
+  // CHECK: ttir.generic
+  // CHECK-NEXT: ins([[lhs:%[a-z0-9_]+]], [[rhs:%[a-z0-9_]+]] : {{.*}})
+  // CHECK-NEXT: outs([[out:%[a-z0-9_]+]] : {{.*}})
+  "ttir.generic"(%0, %1, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   // Look for 4 regions, one for each operand and one for the compute
   // Operand 0 (input)
   // CHECK: ^datamovement0
@@ -149,8 +153,10 @@ func.func @matmul_multi_core_dram_params(%arg0: memref<2x4x4x6x!tt.tile<32x32, f
   %cb1_alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>
   %0 = "ttir.stream_layout"(%arg0, %cb0_alloc) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 6 * 4096 + d3 * 4096)>, #l1_>
   %1 = "ttir.stream_layout"(%arg1, %cb1_alloc) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #dram>, memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8 * 4096 + d3 * 4096)>, #dram>
-  // CHECK: "ttir.generic"([[lhs:%[a-z0-9_]+]], [[rhs:%[a-z0-9_]+]], [[out:%[a-z0-9_]+]])
-  "ttir.generic"(%0, %1, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>, operand_cb_mapping = array<i64>}> ({
+  // CHECK: ttir.generic
+  // CHECK-NEXT: ins([[lhs:%[a-z0-9_]+]], [[rhs:%[a-z0-9_]+]] : {{.*}})
+  // CHECK-NEXT: outs([[out:%[a-z0-9_]+]] : {{.*}})
+  "ttir.generic"(%0, %1, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   // Look for 4 regions, one for each operand and one for the compute
   // Operand 0 (input)
   // CHECK: ^datamovement0
@@ -190,7 +196,7 @@ func.func @matmul_multi_core_dram_params(%arg0: memref<2x4x4x6x!tt.tile<32x32, f
 
 func.func @tilize(%arg0: memref<2x4x128x192xf32, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>, operand_cb_mapping = array<i64>}> ({
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 1, 1>}> ({
   // Look for 4 regions, one for each operand and one for the compute
   // Operand 0 (input)
   // CHECK: ^datamovement0
@@ -211,7 +217,7 @@ func.func @tilize(%arg0: memref<2x4x128x192xf32, #l1_>) -> memref<2x4x4x6x!tt.ti
 
 func.func @untilize(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x128x192xf32, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x128x192xf32, #l1_>
-  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>, operand_cb_mapping = array<i64>}> ({
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 1, 1>}> ({
   // Look for 4 regions, one for each operand and one for the compute
   // Operand 0 (input)
   // CHECK: ^datamovement0

--- a/test/ttmlir/Dialect/TTIR/generic/generic_hw_thread_selection.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/generic_hw_thread_selection.mlir
@@ -11,7 +11,7 @@
 
 func.func @add(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 2, 1>}> ({
+  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^datamovement0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
     ttir.yield %cb0 : (memref<2x4x!tt.tile<32x32, f32>, #l1_>)
   }, {
@@ -41,7 +41,7 @@ func.func @add(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<
 
 func.func @matmul_single_core(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x4x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^datamovement0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<4x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
     ttir.yield %cb0 : (memref<2x4x!tt.tile<32x32, f32>, #l1_>)
   }, {
@@ -64,7 +64,7 @@ func.func @matmul_single_core(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>,
 
 func.func @tilize(%arg0: memref<2x4x128x192xf32, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>}> ({
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 1, 1>}> ({
   ^datamovement0(%cb0: memref<128x192xf32, #l1_>, %cb1: memref<4x6x!tt.tile<32x32, f32>, #l1_>):
     ttir.yield %cb0 : (memref<128x192xf32, #l1_>)
   }, {

--- a/test/ttmlir/Dialect/TTIR/generic/generic_loops.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/generic_loops.mlir
@@ -11,7 +11,7 @@
 
 func.func @unary2x4(%arg0: memref<2x4x128x192xf32, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>}> ({
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 1, 1>}> ({
   ^datamovement0(%cb0: memref<128x192xf32, #l1_>, %cb1: memref<4x6x!tt.tile<32x32, f32>, #l1_>):
     // CHECK: scf.for %{{.*}} = %c0 to %c1
     // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1
@@ -34,7 +34,7 @@ func.func @unary2x4(%arg0: memref<2x4x128x192xf32, #l1_>) -> memref<2x4x4x6x!tt.
 
 func.func @binary1x1(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 2, 1>}> ({
+  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^datamovement0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
     // CHECK: scf.for %{{.*}} = %c0 to %c1
     // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1
@@ -69,7 +69,7 @@ func.func @binary1x1(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: m
 
 func.func @matmul1x1(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x4x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^datamovement0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<4x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
     // CHECK: scf.for %{{.*}} = %c0 to %c1
     // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1
@@ -105,7 +105,7 @@ func.func @matmul_outer_k(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, %ar
   %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
   %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>
   %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>
-  "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^datamovement0(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
     // CHECK: scf.for %{{.*}} = %c0 to %c1
     // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1
@@ -151,7 +151,7 @@ func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, 
   %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>
   %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 24576 + d3 * 4096)>, #l1_>
   %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>, memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #l1_>
-  "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^datamovement0(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>, %sem0: !ttir.semaphore, %sem1: !ttir.semaphore, %sem2: !ttir.semaphore, %sem3: !ttir.semaphore):
     // CHECK: scf.for %{{.*}} = %c0 to %c1
     // CHECK-NEXT: scf.for %{{.*}} = %c0 to %c1

--- a/test/ttmlir/Dialect/TTIR/generic/generic_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/generic_negative.mlir
@@ -5,11 +5,11 @@
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #parallel = #tt.iterator_type<parallel>
 
-// CHECK: error: 'ttir.generic' op Output grid shape must match the GenericOp grid shape
+// CHECK: error: 'ttir.generic' op output grid shape must match the generic op's grid shape
 
 func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<2x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>}> ({
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<2x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 1, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
   }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
   return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
@@ -21,11 +21,11 @@ func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #parallel = #tt.iterator_type<parallel>
 
-// CHECK: error: 'ttir.generic' op GenericOp region must have at least as many arguments as the number of top-level operands
+// CHECK: error: 'ttir.generic' op region must have at least as many arguments as the number of top-level operands
 
 func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>}> ({
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 1, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
   }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
   return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
@@ -37,11 +37,11 @@ func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #parallel = #tt.iterator_type<parallel>
 
-// CHECK: error: 'ttir.generic' op GenericOp region arguments must be of MemRefType
+// CHECK: error: 'ttir.generic' op region arguments must be of MemRefType
 
 func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>}> ({
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 1, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: tensor<2x4x!tt.tile<32x32, f32>, #l1_>):
   }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
   return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
@@ -54,11 +54,11 @@ func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #parallel = #tt.iterator_type<parallel>
 
-// CHECK: error: 'ttir.generic' op GenericOp region argument memory space must match the memory space of the corresponding operand
+// CHECK: error: 'ttir.generic' op region argument memory space must match the memory space of the corresponding operand
 
 func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #dram_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #dram_>
-  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>}> ({
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 1, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
   }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #dram_>) -> ()
   return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #dram_>
@@ -70,11 +70,11 @@ func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #parallel = #tt.iterator_type<parallel>
 
-// CHECK: error: 'ttir.generic' op GenericOp region argument shape must match the shape of the corresponding operand
+// CHECK: error: 'ttir.generic' op region argument shape must match the shape of the corresponding operand
 
 func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>}> ({
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>, threads = [#ttir.thread<compute>]}> ({
   ^bb0(%arg2: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
   }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
   return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
@@ -90,7 +90,7 @@ func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1
 
 func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>}> ({
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 1, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
   }, {
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg5: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
@@ -109,7 +109,7 @@ func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1
 
 func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map1], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>}> ({
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map1], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 1, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
   }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
   return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
@@ -125,7 +125,7 @@ func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1
 
 func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>}> ({
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 1, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg5: !ttir.semaphore):
   }, {
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg5: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
@@ -146,7 +146,7 @@ func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1
 
 func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#lhs, #rhs, #out], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#lhs, #rhs, #out], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg3: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
   }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
   return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
@@ -165,8 +165,25 @@ func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memr
 
 func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#lhs, #rhs, #out], iterator_types = [#parallel, #parallel, #reduction], operandSegmentSizes = array<i32: 2, 1>}> ({
+  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#lhs, #rhs, #out], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg3: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
   }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+}
+
+// -----
+
+#l1_ = #tt.memory_space<l1>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #tt.iterator_type<parallel>
+
+// CHECK: error: 'ttir.tile_matmul_block' op expected to be in a compute region
+
+func.func @matmul(%arg0: memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>, threads = [#ttir.thread<datamovement>]}> ({
+  ^bb0(%arg2: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
+  "ttir.tile_matmul_block"(%arg2, %arg4, %arg4) : (memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
+  }) : (memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
   return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
 }

--- a/test/ttmlir/Dialect/TTIR/generic/generic_region_ops.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/generic_region_ops.mlir
@@ -11,6 +11,7 @@ func.func @reduce_max(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> t
         grid = #tt.grid<1x1>,
         indexing_maps = [#map, #map, #map],
         iterator_types = [#parallel, #parallel],
+        threads = [#ttir.thread<compute>],
         operandSegmentSizes = array<i32: 2, 1>
         }> ({
         ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_alias>,

--- a/test/ttmlir/Dialect/TTIR/generic/generic_region_ops_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/generic_region_ops_negative.mlir
@@ -10,6 +10,7 @@ func.func @reduce_dim_arg(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) 
       grid = #tt.grid<1x1>,
       indexing_maps = [#map, #map, #map],
       iterator_types = [#parallel, #parallel],
+      threads = [#ttir.thread<compute>],
       operandSegmentSizes = array<i32: 2, 1>
       }> ({
       ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_alias>,
@@ -29,12 +30,4 @@ func.func @reduce_dim_arg(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) 
       "ttir.yield"() : () -> ()
       }) : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
   return %1 : tensor<64x128xf32>
-}
-
-// -----
-
-func.func @not_in_generic_region(%a: !tt.tile<32x32, f32>, %b: !tt.tile<32x32, f32>) -> !tt.tile<32x32, f32> {
-    // CHECK: error: 'ttir.tile_reduce_max' op TTIR Generic Ops must be inside a generic region
-  %1 = "ttir.tile_reduce_max" (%a, %b) {reduce_dim = #ttir<reduce_dim R>} : (!tt.tile<32x32, f32>, !tt.tile<32x32, f32>) -> !tt.tile<32x32, f32>
-  return %1 : !tt.tile<32x32, f32>
 }

--- a/test/ttmlir/Dialect/TTIR/generic/generic_regions_to_funcs.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/generic_regions_to_funcs.mlir
@@ -1,0 +1,26 @@
+// RUN: ttmlir-opt --tt-register-device --ttir-generic-regions-to-funcs %s | FileCheck %s
+
+#l1_ = #tt.memory_space<l1>
+#dram = #tt.memory_space<dram>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#parallel = #tt.iterator_type<parallel>
+
+func.func @add(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+  // CHECK: [#ttir.thread<datamovement, @datamovement_kernel0>, #ttir.thread<compute, @compute_kernel1>]
+  ttir.generic {grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<datamovement>, #ttir.thread<compute>]}
+               ins(%arg0, %arg1 : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>)
+               outs(%alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) {
+  ^datamovement0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
+    %c0 = arith.constant 0 : index
+    %tx = ttir.dma %arg0[%c0, %c0], %cb0 : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<2x4x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+    "ttir.yield"() : () -> ()
+  }, {
+  ^compute0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
+    "ttir.yield"() : () -> ()
+  }
+  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+}
+// CHECK: func.func private @datamovement_kernel0{{.*}} attributes {ttir.thread_type = 1 : i32}
+// CHECK: ttir.get_global_operand(0)
+// CHECK: func.func private @compute_kernel1{{.*}} attributes {ttir.thread_type = 0 : i32}

--- a/test/ttmlir/Dialect/TTIR/loops/linearize_memref.mlir
+++ b/test/ttmlir/Dialect/TTIR/loops/linearize_memref.mlir
@@ -6,7 +6,7 @@
 
 func.func @add(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 2, 1>}> ({
+  "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^bb0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
     // CHECK: [[cshape0:%[a-z0-9_]+]] = memref.collapse_shape %cb0
     // CHECK-NEXT: [[cshape1:%[a-z0-9_]+]] = memref.collapse_shape %cb1
@@ -29,7 +29,7 @@ func.func @add(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<
 
 func.func @addT(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1T: memref<1x1x4x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
-  "ttir.generic"(%arg0, %arg1T, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 2, 1>}> ({
+  "ttir.generic"(%arg0, %arg1T, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^bb0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<4x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
     // CHECK: [[cshape0:%[a-z0-9_]+]] = memref.collapse_shape %cb0
     // CHECK-NEXT: [[cshape1:%[a-z0-9_]+]] = memref.collapse_shape %cb1

--- a/test/ttmlir/Dialect/TTIR/optimize_tensor_layout/optimize_tensor_layout.mlir
+++ b/test/ttmlir/Dialect/TTIR/optimize_tensor_layout/optimize_tensor_layout.mlir
@@ -17,9 +17,10 @@ func.func @reduce_large_grid(%arg0: tensor<256x384xf32, #layout1>, %arg1: tensor
         grid = #tt.grid<1x1>,
         indexing_maps = [#map1, #map1, #map2],
         iterator_types = [#parallel, #reduction],
+        threads = [#ttir.thread<compute>],
         operandSegmentSizes = array<i32: 2, 1>
         }> ({
-        // CHECK: ^compute(%cb0: memref<1x2x!tt.tile<32x32, f32>, #l1_>,
+        // CHECK: ^compute0(%cb0: memref<1x2x!tt.tile<32x32, f32>, #l1_>,
         // CHECK-SAME: %cb1: memref<1x2x!tt.tile<32x32, f32>, #l1_>,
         // CHECK-SAME: %cb2: memref<1x1x!tt.tile<32x32, f32>, #l1_>):
         ^bb0(%arg2: memref<8x12x!tt.tile<32x32, f32>, #l1_>,
@@ -57,9 +58,10 @@ func.func @reduce_prime(%arg0: tensor<32x608xf32, #layout1>, %arg1: tensor<32x60
         grid = #tt.grid<1x1>,
         indexing_maps = [#map1, #map1, #map2],
         iterator_types = [#parallel, #reduction],
+        threads = [#ttir.thread<compute>],
         operandSegmentSizes = array<i32: 2, 1>
         }> ({
-        // CHECK: ^compute(%cb0: memref<1x19x!tt.tile<32x32, f32>, #l1_>,
+        // CHECK: ^compute0(%cb0: memref<1x19x!tt.tile<32x32, f32>, #l1_>,
         // CHECK-SAME: %cb1: memref<1x19x!tt.tile<32x32, f32>, #l1_>,
         // CHECK-SAME: %cb2: memref<1x1x!tt.tile<32x32, f32>, #l1_>):
         ^bb0(%arg2: memref<1x19x!tt.tile<32x32, f32>, #l1_>,

--- a/test/ttmlir/Dialect/TTIR/ttir_generic_hoist.mlir
+++ b/test/ttmlir/Dialect/TTIR/ttir_generic_hoist.mlir
@@ -7,6 +7,7 @@ func.func @forward(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tens
     grid = #tt.grid<1x1>,
     indexing_maps = [#map, #map, #map],
     iterator_types = [#parallel, #parallel],
+    threads = [#ttir.thread<compute>],
     operandSegmentSizes = array<i32: 2, 1>}> ({
   ^bb0(%arg2: memref<64x128xf32>, %arg3: memref<64x128xf32>, %arg4: memref<64x128xf32>):
     // lit CHECK to make sure this constant stays inside the generic region


### PR DESCRIPTION
### Ticket
#2609 
#2608 

### Problem description
We need to lower new TTIR generic ops & functions to TTMetal and TTKernel dialects to fit the new D2M lowering scheme.

### What's changed

**TTMetal Lowering Pass**
- Replaces all old code in `TTIRToTTMetal.cpp` but maintains the pass itself
- Adds two rewriters:

  - `MemrefAllocRewriter` - rewrites `memref.alloc` ops to `ttmetal.create_buffer`
       - Pulls the `address` attr from `memref.alloc` if it exists. If not, defaults to `address = 1000` (arbitrary default until alloc pass is implemented.
       
  - `TTIRGenericRewriter` - rewrites `ttir.generic` to `ttmetal.enqueue_program`
       - Changed the `ttmetal.enqueue_program` op to include a `threads` attribute which is inherited from `ttir.generic`
       - Applies identical core ranges to each kernel, all equal to the grid size of `ttir.generic`

**TTKernel Lowering Pass**

- New `convert-ttir-to-ttkernel` pass which can be run independently from the above metal lowering. This will allow us to test kernel lowering without testing host-side lowering.

- `MemrefStoreRewriter` - rewrites `memref.store` ops to `ttkernel.pack_tile`
  - Always packs FROM the 1st tile in dst register TO the `store_idx` in the output CB from the `memref.store` op. 
   - Out of order pack is always on by default, allowing us to pack to arbitrary indices in the output CB.
      
- `TTIRComputeOpsRewriter` - rewrites TTIR generic ops with the `TTIRGenericRegionComputeOpTrait` to respective ttkernel compute ops. 
  - Also lowers the `memref.load` ops that the compute ops depend on to either `noop` or `ttkernel.copy_tile` depending on if the ttkernel being lowered has the `TTKernelSFPUOpTrait`. Matmul is special cased to copy the partials in from the output CB.
     
- `TTIRAwaitYieldRewriter` - rewrites `ttir.await` and `ttir.yield` ops to CB operations
  - `ttir.await` ops lower to `ttkernel.cb_wait_front` and inserts a matching `ttkernel.cb_pop_front` at the end of the parent block. 
   - `ttir.yield` ops lower to `ttkernel.cb_push_back` and inserts a matching `ttkernel.cb_reserve_back` op at the start of the parent block.
   - CB indices are pulled from the index of the respective block argument
   - `num_tiles` is pulled from the shape of the memrefs that the await/yield references. 

- `TTIRDMARewriter` - rewrites `ttir.dma` ops into respecting noc transactions (WIP)
  - Currently supports L1->L1 transactions only.
  - Supports local->local writes, local->remote writes, mcast, mcast w/ loopback, gather-style remote->local reads
  - See `test/ttmlir/Conversion/TTIRToTTKernel/dma_lowering.mlir` for examples

- `TTIRCoreIndexRewriter` - rewrites `ttir.core_index` ops to NEW `ttkernel.my_y`/`ttkernel.my_x` ops
    - These new ops will emit `MY_Y` / `MY_X` macros in the EmitC pass. (unimplemented)
    - These also insert a `arith::SubI` op which offsets the core coordinates based on the FIRST worker core in the system descriptor. This is to account for virtual/logical coordinate translations. This is re-accounted for in the DMA rewriter, where we implement `getVirtualCoordsFromLogicalCoords`, which contains the opposite translation. All these extra additions/subtractions are removed by canonicalization pass.

- `TTIRDMAWaitRewriter` - rewrites `ttir.dma_wait` ops with `ttkernel.noc_async_read_barrier` / `ttkernel.noc_async_write_barrier`
    - Which one of these depends on if the src of the DMA was local or remote. If src is local then we are writing, if not, we are reading.

- `TTIRGetGlobalOperandRewriter` - rewrites `ttir.get_global_operand` ops with `ttkernel.get_compile_time_arg_val` ops

**Testing**

- Adds tests for alloc lowering, generic lowering, a matmul lowering including a datamovement and compute kernel, dma lowering.

**Outstanding Work:**

- [ ] **Remove commits from `nsmith/generic7** when they are finalized & merged into main.
- [ ] Add TTKernel lowering to TTMetal lowering pipeline
- [ ] TTKernelToEmitC rewrite to match new expected function kernel form / `ttir.generic` form
- [ ] DRAM DMA lowering
- [ ] Recent changes to valid DMA forms (specifically l1 to l1 single core)
- [ ] Change to utilize ttkernel.cb` type instead of defaulting to indices
- [ ] TTIRToTTMetal pass to lower addresses into `ttmetal.get_compile_time_arg_val`
- More TBD

**Depends on:**
- Changes from `nsmith/generic7` 

FYI @xanderchin @nsmithtt @vroubtsovTT 

### Checklist
- [ ] New/Existing tests provide coverage for changes
