### PR TITLE
Restructure runtime mesh_shard op for emitC

### DIFF
--- a/runtime/include/tt/runtime/workarounds.h
+++ b/runtime/include/tt/runtime/workarounds.h
@@ -12,11 +12,10 @@ namespace tt::runtime::workaround {
 struct Env {
   static const Env &get(bool swapBinaryOperands = true,
                         bool readUpdateIndexFromDeviceForKVCache = true,
-                        bool toLayoutAPIAssumeSingleChip = true,
-                        bool manualDeviceStorageFromBorrowedStorage = true) {
-    static const Env config(
-        swapBinaryOperands, readUpdateIndexFromDeviceForKVCache,
-        toLayoutAPIAssumeSingleChip, manualDeviceStorageFromBorrowedStorage);
+                        bool toLayoutAPIAssumeSingleChip = true) {
+    static const Env config(swapBinaryOperands,
+                            readUpdateIndexFromDeviceForKVCache,
+                            toLayoutAPIAssumeSingleChip);
     return config;
   }
 
@@ -40,23 +39,14 @@ struct Env {
   // grid information to the tensorDesc.
   bool toLayoutAPIAssumeSingleChip;
 
-  // TODO(bug tenstorrent/tt-metal#18842) ReplicateTensorToMesh api currently
-  // has a bug where it can only accept device storage tensors, not borrowed
-  // storage. This workaround manually creates a device storage tensor if the
-  // tensor is of borrowed storage.
-  bool manualDeviceStorageFromBorrowedStorage;
-
 private:
   constexpr Env(bool swapBinaryOperands,
                 bool readUpdateIndexFromDeviceForKVCache,
-                bool toLayoutAPIAssumeSingleChip,
-                bool manualDeviceStorageFromBorrowedStorage)
+                bool toLayoutAPIAssumeSingleChip)
       : swapBinaryOperands(swapBinaryOperands),
         readUpdateIndexFromDeviceForKVCache(
             readUpdateIndexFromDeviceForKVCache),
-        toLayoutAPIAssumeSingleChip(toLayoutAPIAssumeSingleChip),
-        manualDeviceStorageFromBorrowedStorage(
-            manualDeviceStorageFromBorrowedStorage) {}
+        toLayoutAPIAssumeSingleChip(toLayoutAPIAssumeSingleChip) {}
 };
 
 inline std::ostream &operator<<(std::ostream &os, const Env &env) {
@@ -69,9 +59,6 @@ inline std::ostream &operator<<(std::ostream &os, const Env &env) {
   os << "\t"
      << "toLayoutAPIAssumeSingleChip: " << env.toLayoutAPIAssumeSingleChip
      << "\n";
-  os << "\t"
-     << "manualDeviceStorageFromBorrowedStorage: "
-     << env.manualDeviceStorageFromBorrowedStorage << "\n";
   os << "}";
   return os;
 }

--- a/runtime/lib/ttnn/operations/ccl/mesh_shard_impl.h
+++ b/runtime/lib/ttnn/operations/ccl/mesh_shard_impl.h
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef RUNTIME_LIB_TTNN_OPERATIONS_CCL_MESH_SHARD_IMPL_H
+#define RUNTIME_LIB_TTNN_OPERATIONS_CCL_MESH_SHARD_IMPL_H
+
+#include "ttnn/distributed/distributed_tensor.hpp"
+#include "ttnn/tensor/xtensor/partition.hpp"
+
+namespace tt::runtime::ttnn::operations::ccl::mesh_shard {
+
+enum class MeshShardDirection : uint32_t {
+  FullToShardShape = 0,
+  ShardToFullShape = 1,
+  MIN = FullToShardShape,
+  MAX = ShardToFullShape
+};
+
+enum class MeshShardType : uint32_t {
+  Identity = 0,
+  Replicate = 1,
+  Maximal = 2,
+  Devices = 3,
+  MIN = Identity,
+  MAX = Devices
+};
+
+inline ::ttnn::Tensor FullToShardShape(const ::ttnn::Tensor &input,
+                                       ::ttnn::MeshDevice &meshDevice,
+                                       const MeshShardType &shardType,
+                                       const std::vector<int64_t> &shardShape,
+                                       const std::vector<int64_t> &shardDims) {
+  if (shardType == MeshShardType::Replicate) {
+    return ::ttnn::distributed::distribute_tensor(
+        input,
+        *::ttnn::distributed::replicate_tensor_to_mesh_mapper(meshDevice));
+  } else {
+    ::ttnn::distributed::Shard2dConfig shard2dConfig{std::nullopt,
+                                                     std::nullopt};
+    if (shardDims[0] >= 0) {
+      shard2dConfig.row_dim = shardDims[0];
+    }
+    if (shardDims[1] >= 0) {
+      shard2dConfig.col_dim = shardDims[1];
+    }
+    return ::ttnn::distributed::distribute_tensor(
+        input, *::ttnn::distributed::shard_tensor_to_2d_mesh_mapper(
+                   meshDevice, meshDevice.shape(), shard2dConfig));
+  }
+}
+
+inline ::ttnn::Tensor ShardToFullShape(const ::ttnn::Tensor &input,
+                                       ::ttnn::MeshDevice &meshDevice,
+                                       const MeshShardType &shardType,
+                                       const std::vector<int64_t> &shardShape,
+                                       const std::vector<int64_t> &shardDims) {
+  std::vector<::ttnn::Tensor> input_tensors =
+      ::ttnn::distributed::get_tensors_from_multi_device_storage(input);
+  if (shardType == MeshShardType::Replicate) {
+    return input_tensors[0];
+  } else {
+    bool bFullConcat = std::all_of(shardDims.begin(), shardDims.end(),
+                                   [](int n) { return n >= 0; });
+    if (bFullConcat) {
+      // Full multi-device storage concatenation.
+      ::ttnn::distributed::Concat2dConfig concat2dConfig{
+          static_cast<int>(shardDims[0]), static_cast<int>(shardDims[1])};
+      return ::ttnn::distributed::aggregate_tensor(
+          input, *::ttnn::distributed::concat_2d_mesh_to_tensor_composer(
+                     meshDevice, concat2dConfig));
+    } else {
+      // Partial multi-device storage concatenation.
+      // Current ttnn api does not support partial multi-device storage
+      // concatenation. Thus, xtensor APIs are being called directly from here.
+      size_t stride = 0;
+      int targetDim = 0;
+      size_t iteration = 0;
+      if (shardDims[0] >= 0) {
+        targetDim = shardDims[0];
+        iteration = shardShape[targetDim];
+        stride = meshDevice.num_cols();
+      } else {
+        targetDim = shardDims[1];
+        iteration = shardShape[targetDim];
+        stride = 1;
+      }
+      std::vector<::ttnn::Tensor> target_tensors;
+      for (size_t i = 0; i < iteration; ++i) {
+        target_tensors.push_back(input_tensors[i * stride]);
+      }
+      return ::ttnn::experimental::xtensor::concat(target_tensors, targetDim);
+    }
+  }
+}
+
+// TODO(wooseoklee): This file is used for code sharing between runtime and
+// ttnn-standalone. Once these functions are stabilized, remove this file and
+// emitC will directly generate stable function code.
+// https://github.com/tenstorrent/tt-mlir/issues/2936
+inline ::ttnn::Tensor mesh_shard(const ::ttnn::Tensor &input,
+                                 ::ttnn::MeshDevice &meshDevice,
+                                 const MeshShardDirection &shardDirection,
+                                 const MeshShardType &shardType,
+                                 const std::vector<int64_t> &shardShape,
+                                 const std::vector<int64_t> &shardDims) {
+  if (shardType == MeshShardType::Identity) {
+    // Forward tensor in runtime for identity shard type assuming that the input
+    // tensor is pre-sharded by frontend and output tensor is expected to be
+    // pre-sharded by frontend.
+    return input;
+  }
+
+  if (shardDirection == MeshShardDirection::FullToShardShape) {
+    return FullToShardShape(input, meshDevice, shardType, shardShape,
+                            shardDims);
+  } else {
+    return ShardToFullShape(input, meshDevice, shardType, shardShape,
+                            shardDims);
+  }
+}
+} // namespace tt::runtime::ttnn::operations::ccl::mesh_shard
+
+#endif

--- a/runtime/tools/python/ttrt/common/run.py
+++ b/runtime/tools/python/ttrt/common/run.py
@@ -428,7 +428,6 @@ class Run:
                 not self["--disable-swap-binary-operands"],
                 not self["--disable-read-update-index-for-kv-cache"],
                 not self["--disable-to-layout-api-assume-single-chip"],
-                not self["--disable-manual-device-storage-from-borrowed-storage"],
             )
             self.logging.debug(f"setting tt runtime workaround env={workaround_env}")
             self.logging.debug(f"setting torch manual seed={self['--seed']}")

--- a/tools/ttnn-standalone/CMakeLists.txt
+++ b/tools/ttnn-standalone/CMakeLists.txt
@@ -62,6 +62,9 @@ set(INCLUDE_DIRS
     $ENV{TT_METAL_HOME}/.cpmcache/magic_enum/4d76fe0a5b27a0e62d6c15976d02b33c54207096/include
     $ENV{TT_METAL_HOME}/.cpmcache/boost/1359e136761ab2d10afa1c4e21086c8d824735cd/libs/core/include
     $ENV{TT_METAL_HOME}/.cpmcache/nlohmann_json/798e0374658476027d9723eeb67a262d0f3c8308/include
+    $ENV{TT_METAL_HOME}/.cpmcache/xtensor/4a957e26c765b48cbec4a4235fe9e518d5a85d3d/include
+    $ENV{TT_METAL_HOME}/.cpmcache/xtensor-blas/190c3a4314355b67291a7d78b20a2100de3f8f54/include
+    $ENV{TT_METAL_HOME}/.cpmcache/xtl/0918808959d33a292c551b9f014a0e808bc4a95c/include
 
     # Metalium
     $ENV{TT_METAL_HOME}
@@ -87,6 +90,9 @@ set(INCLUDE_DIRS
     $ENV{TT_METAL_HOME}/ttnn/cpp
     $ENV{TT_METAL_HOME}/ttnn/cpp/ttnn
     $ENV{TT_METAL_HOME}/ttnn/cpp/ttnn/deprecated
+
+    # TT_MLIR Runtime
+    $ENV{TT_MLIR_HOME}/runtime/lib/ttnn
 )
 
 # Link directories

--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -10,6 +10,7 @@
 #include "device.hpp"
 #include "operations/ccl/all_gather/all_gather.hpp"
 #include "operations/ccl/ccl_host_types.hpp"
+#include "operations/ccl/mesh_shard_impl.h"
 #include "operations/ccl/reduce_scatter/reduce_scatter.hpp"
 #include "operations/conv/conv2d/conv2d.hpp"
 #include "operations/conv/conv2d/prepare_conv2d_weights.cpp"


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/2367

### Problem description
Need to clean up mesh_shard op for emitC.

### What's changed
Restructured code such that mesh_shard function emulates the ttnn::mesh_shard and standalone emitC can reuse the code from ttnn-precompiled.hpp. 
Remove workaround as https://github.com/tenstorrent/tt-metal/issues/18842 is closed.

