### PR TITLE
Removed need for register_dialect for Python Bindings

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -84,6 +84,13 @@ declare_mlir_python_sources(TTMLIRPythonTestInfra.TestInfra
     test_utils.py
 )
 
+# Enable Site Initialization Target to be piped into _mlir_libs/__init__.py
+declare_mlir_python_sources(TTMLIRPythonSiteInitialize
+  ROOT_DIR "${TTMLIR_PYTHON_ROOT_DIR}"
+  ADD_TO_PARENT TTMLIRPythonSources
+  SOURCES _mlir_libs/_site_initialize_0.py
+)
+
 declare_mlir_python_extension(TTMLIRPythonExtensions.Main
   MODULE_NAME _ttmlir
   ADD_TO_PARENT TTMLIRPythonExtensions
@@ -138,6 +145,7 @@ set(TTMLIR_PYTHON_SOURCES
   TTMLIRPythonSources
   TTMLIRPythonExtensions
   TTMLIRPythonTestInfra
+  TTMLIRPythonSiteInitialize
 )
 
 add_mlir_python_common_capi_library(TTMLIRPythonCAPI

--- a/python/TTMLIRModule.cpp
+++ b/python/TTMLIRModule.cpp
@@ -7,6 +7,23 @@
 NB_MODULE(_ttmlir, m) {
   m.doc() = "ttmlir main python extension";
 
+  // Create specialized register_dialects function to be called on site
+  // initialize
+  // TODO: Currently we will maintain the register_dialect function to match the
+  // syntax presented in other MLIR projects However, the function will not be
+  // exposed anywhere except for the _ttmlir so.
+  m.def(
+      "register_dialects",
+      [](MlirDialectRegistry _registry) {
+        mlir::registerAllPasses();
+
+        mlir::DialectRegistry *registry = unwrap(_registry);
+
+        mlir::tt::registerAllDialects(*registry);
+        mlir::tt::registerAllExtensions(*registry);
+      },
+      nb::arg("dialectRegistry"));
+
   m.def(
       "register_dialect",
       [](MlirContext context, bool load) {

--- a/python/pykernel/pykernel_ast.py
+++ b/python/pykernel/pykernel_ast.py
@@ -117,7 +117,6 @@ class TTKernelCompiler(ast.NodeVisitor):
         self.func_entry = None
         self.symbol_tables = []
         self.supported_nodes = get_supported_nodes()
-        ttkernel.register_dialect(self.ctx)
 
         self.cb_args = args
         self.rt_args = None

--- a/python/test_infra/ttir_builder.py
+++ b/python/test_infra/ttir_builder.py
@@ -116,9 +116,6 @@ class TTIRBuilder:
         self._ctx = ctx
         self._loc = location
 
-        tt.register_dialect(self._ctx)
-        ttir.register_dialect(self._ctx)
-
         self._seed = 0
         # Dictionary to store Golden for each Operand we encounter in MLIR
         # graph.

--- a/python/ttmlir/_mlir_libs/_site_initialize_0.py
+++ b/python/ttmlir/_mlir_libs/_site_initialize_0.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from .._mlir_libs._ttmlir import register_dialects

--- a/python/ttmlir/dialects/tt.py
+++ b/python/ttmlir/dialects/tt.py
@@ -4,4 +4,4 @@
 
 from ._tt_ops_gen import *
 from ._tt_enum_gen import *
-from .._mlir_libs._ttmlir import tt_ir as ir, register_dialect
+from .._mlir_libs._ttmlir import tt_ir as ir

--- a/python/ttmlir/dialects/ttir.py
+++ b/python/ttmlir/dialects/ttir.py
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from ._ttir_ops_gen import *
-from .._mlir_libs._ttmlir import register_dialect, ttir_ir as ir
+from .._mlir_libs._ttmlir import ttir_ir as ir

--- a/python/ttmlir/dialects/ttkernel.py
+++ b/python/ttmlir/dialects/ttkernel.py
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from ._ttkernel_ops_gen import *
-from .._mlir_libs._ttmlir import register_dialect, ttkernel_ir as ir
+from .._mlir_libs._ttmlir import ttkernel_ir as ir

--- a/python/ttmlir/dialects/ttnn.py
+++ b/python/ttmlir/dialects/ttnn.py
@@ -4,4 +4,4 @@
 
 from ._ttnn_ops_gen import *
 from ._ttnn_enum_gen import *
-from .._mlir_libs._ttmlir import register_dialect, ttnn_ir as ir
+from .._mlir_libs._ttmlir import ttnn_ir as ir

--- a/test/python/device_attr.py
+++ b/test/python/device_attr.py
@@ -8,7 +8,6 @@ from ttmlir.ir import *
 from ttmlir.dialects import tt
 
 ctx = Context()
-tt.register_dialect(ctx)
 
 
 def updiv(n, d):

--- a/test/python/smoketest.py
+++ b/test/python/smoketest.py
@@ -8,7 +8,6 @@ from ttmlir.ir import *
 from ttmlir.dialects import tt, ttir
 
 with Context() as ctx:
-    ttir.register_dialect(ctx)
 
     module = Module.parse(
         """

--- a/test/python/tensor_layout.py
+++ b/test/python/tensor_layout.py
@@ -8,7 +8,6 @@ from ttmlir.ir import *
 from ttmlir.dialects import tt
 
 ctx = Context()
-tt.register_dialect(ctx)
 
 
 def createTensorLayout(

--- a/tools/explorer/tt_adapter/src/tt_adapter/utils.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/utils.py
@@ -14,9 +14,6 @@ TTRT_INSTALLED = importlib.util.find_spec("ttrt") is not None
 
 def parse_mlir_str(module_str):
     with ttmlir.ir.Context() as ctx:
-        ttmlir.dialects.ttir.register_dialect(ctx)
-        ttmlir.dialects.tt.register_dialect(ctx)
-        ttmlir.dialects.ttnn.register_dialect(ctx)
         module = ttmlir.ir.Module.parse(module_str, ctx)
         return module
 

--- a/tools/scripts/parted.py
+++ b/tools/scripts/parted.py
@@ -118,6 +118,5 @@ if __name__ == "__main__":
 
     with Context() as ctx, open(args.mlir, "r") as mlir_fd:
         ctx.allow_unregistered_dialects = True
-        ttir.register_dialect(ctx)
         module = Module.parse(mlir_fd.read(), ctx)
         print(parted(module))

--- a/ttnn/test_llama_attention_ttnn.mlir
+++ b/ttnn/test_llama_attention_ttnn.mlir
@@ -1,0 +1,135 @@
+#dram = #ttnn.buffer_type<dram>
+#system_desc = #tt.system_desc<[{role = host, target_triple = "x86_64-pc-linux-gnu"}], [{arch = <wormhole_b0>, grid = 8x8, l1_size = 1499136, num_dram_channels = 12, dram_channel_size = 1073741824, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32, l1_unreserved_base = 1024, erisc_l1_unreserved_base = 1024, dram_unreserved_base = 1024, dram_unreserved_end = 1073741824, physical_cores = {worker = [ 0x0,  0x1,  0x2,  0x3,  0x4,  0x5,  0x6,  0x7,  1x0,  1x1,  1x2,  1x3,  1x4,  1x5,  1x6,  1x7,  2x0,  2x1,  2x2,  2x3,  2x4,  2x5,  2x6,  2x7,  3x0,  3x1,  3x2,  3x3,  3x4,  3x5,  3x6,  3x7,  4x0,  4x1,  4x2,  4x3,  4x4,  4x5,  4x6,  4x7,  5x0,  5x1,  5x2,  5x3,  5x4,  5x5,  5x6,  5x7,  6x0,  6x1,  6x2,  6x3,  6x4,  6x5,  6x6,  6x7,  7x0,  7x1,  7x2,  7x3,  7x4,  7x5,  7x6,  7x7] dram = [ 8x0,  9x0,  10x0,  8x1,  9x1,  10x1,  8x2,  9x2,  10x2,  8x3,  9x3,  10x3]}, supported_data_types = [<f32>, <f16>, <bf16>, <bfp_f8>, <bfp_bf8>, <bfp_f4>, <bfp_bf4>, <bfp_f2>, <bfp_bf2>, <u32>, <u16>, <u8>, <si32>], supported_tile_sizes = [ 4x16,  16x16,  32x16,  4x32,  16x32,  32x32], num_cbs = 32, num_compute_threads = 1, num_datamovement_threads = 2}], [0], [3 : i32], [ 0x0x0x0]>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<1x100x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+#ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1 * 32 + d2, d3), <1x1>, memref<1x1x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+#ttnn_layout2 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+#ttnn_layout3 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 64 + d1, d2), <1x1>, memref<2x1x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+#ttnn_layout4 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 2048 + d1 * 64 + d2, d3), <1x1>, memref<64x4x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+#ttnn_layout5 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<100x100x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+#ttnn_layout6 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x100x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+#ttnn_layout7 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 384 + d1 * 32 + d2, d3), <1x1>, memref<12x4x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+#ttnn_layout8 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 32 + d2, d3), <1x1>, memref<32x4x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+#ttnn_layout9 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<1x1x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+#ttnn_layout10 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<1x2x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+#ttnn_layout11 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<1x4x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+#ttnn_layout12 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1 * 32 + d2, d3), <1x1>, memref<1x4x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+#ttnn_layout13 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 2048 + d1 * 64 + d2, d3), <1x1>, memref<64x1x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+#ttnn_layout14 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 32 + d2, d3), <1x1>, memref<32x2x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+#ttnn_layout15 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x4x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+#ttnn_layout16 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x1x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+#ttnn_layout17 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 32 + d2, d3), <1x1>, memref<32x1x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+#ttnn_layout18 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 4096 + d1 * 128 + d2, d3), <1x1>, memref<128x1x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+#ttnn_layout19 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 128 + d1, d2), <1x1>, memref<128x1x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+module {
+  tt.device_module {
+    builtin.module attributes {tt.system_desc = #system_desc} {
+      tt.device @default_device = <workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5] -> (0, 0, (((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) floordiv s4) mod 12, ((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) floordiv (s4 * 12) + ((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
+      func.func @test_llama_attention(%arg0: tensor<1x12x3200xf32, #ttnn_layout>, %arg1: tensor<1x1x12x12xf32, #ttnn_layout1>, %arg2: tensor<1x12xf32, #ttnn_layout2>, %arg3: tensor<1x50x1xf32, #ttnn_layout3>, %arg4: tensor<1x32x50x100xf32, #ttnn_layout4>, %arg5: tensor<1x1xf32, #ttnn_layout2>, %arg6: tensor<1x32x50x100xf32, #ttnn_layout4>, %arg7: tensor<1x32x50x100xf32, #ttnn_layout4>, %arg8: tensor<1x1xf32, #ttnn_layout2>, %arg9: tensor<1x32x50x100xf32, #ttnn_layout4>, %arg10: tensor<1x1xf32, #ttnn_layout2>, %arg11: tensor<3200x3200xf32, #ttnn_layout5>, %arg12: tensor<3200x3200xf32, #ttnn_layout5>, %arg13: tensor<3200x3200xf32, #ttnn_layout5>, %arg14: tensor<3200x3200xf32, #ttnn_layout5>) -> tensor<1x12x3200xf32, #ttnn_layout> {
+        %0 = "ttnn.reshape"(%arg0) <{shape = [12 : i32, 3200 : i32]}> : (tensor<1x12x3200xf32, #ttnn_layout>) -> tensor<12x3200xf32, #ttnn_layout6>
+        %1 = "ttnn.matmul"(%0, %arg11) <{transpose_a = false, transpose_b = false}> : (tensor<12x3200xf32, #ttnn_layout6>, tensor<3200x3200xf32, #ttnn_layout5>) -> tensor<12x3200xf32, #ttnn_layout6>
+        %2 = "ttnn.reshape"(%1) <{shape = [1 : i32, 12 : i32, 32 : i32, 100 : i32]}> : (tensor<12x3200xf32, #ttnn_layout6>) -> tensor<1x12x32x100xf32, #ttnn_layout7>
+        "ttnn.deallocate"(%1) <{force = false}> : (tensor<12x3200xf32, #ttnn_layout6>) -> ()
+        %3 = "ttnn.transpose"(%2) <{dim0 = 1 : si32, dim1 = 2 : si32}> : (tensor<1x12x32x100xf32, #ttnn_layout7>) -> tensor<1x32x12x100xf32, #ttnn_layout8>
+        "ttnn.deallocate"(%2) <{force = false}> : (tensor<1x12x32x100xf32, #ttnn_layout7>) -> ()
+        %4 = "ttnn.reshape"(%arg2) <{shape = [1 : i32, 1 : i32, 12 : i32]}> : (tensor<1x12xf32, #ttnn_layout2>) -> tensor<1x1x12xf32, #ttnn_layout9>
+        %5 = "ttnn.matmul"(%arg3, %4) <{transpose_a = false, transpose_b = false}> : (tensor<1x50x1xf32, #ttnn_layout3>, tensor<1x1x12xf32, #ttnn_layout9>) -> tensor<1x50x12xf32, #ttnn_layout3>
+        "ttnn.deallocate"(%4) <{force = false}> : (tensor<1x1x12xf32, #ttnn_layout9>) -> ()
+        %6 = "ttnn.transpose"(%5) <{dim0 = 1 : si32, dim1 = 2 : si32}> : (tensor<1x50x12xf32, #ttnn_layout3>) -> tensor<1x12x50xf32, #ttnn_layout10>
+        "ttnn.deallocate"(%5) <{force = false}> : (tensor<1x50x12xf32, #ttnn_layout3>) -> ()
+        %7 = "ttnn.concat"(%6, %6) <{dim = 2 : si32}> : (tensor<1x12x50xf32, #ttnn_layout10>, tensor<1x12x50xf32, #ttnn_layout10>) -> tensor<1x12x100xf32, #ttnn_layout11>
+        "ttnn.deallocate"(%6) <{force = false}> : (tensor<1x12x50xf32, #ttnn_layout10>) -> ()
+        %8 = "ttnn.cos"(%7) : (tensor<1x12x100xf32, #ttnn_layout11>) -> tensor<1x12x100xf32, #ttnn_layout11>
+        %9 = "ttnn.reshape"(%8) <{shape = [1 : i32, 1 : i32, 12 : i32, 100 : i32]}> : (tensor<1x12x100xf32, #ttnn_layout11>) -> tensor<1x1x12x100xf32, #ttnn_layout12>
+        "ttnn.deallocate"(%8) <{force = false}> : (tensor<1x12x100xf32, #ttnn_layout11>) -> ()
+        %10 = "ttnn.multiply"(%3, %9) : (tensor<1x32x12x100xf32, #ttnn_layout8>, tensor<1x1x12x100xf32, #ttnn_layout12>) -> tensor<1x32x12x100xf32, #ttnn_layout8>
+        %11 = "ttnn.matmul"(%arg4, %3) <{transpose_a = false, transpose_b = true}> : (tensor<1x32x50x100xf32, #ttnn_layout4>, tensor<1x32x12x100xf32, #ttnn_layout8>) -> tensor<1x32x50x12xf32, #ttnn_layout13>
+        %12 = "ttnn.transpose"(%11) <{dim0 = 2 : si32, dim1 = 3 : si32}> : (tensor<1x32x50x12xf32, #ttnn_layout13>) -> tensor<1x32x12x50xf32, #ttnn_layout14>
+        "ttnn.deallocate"(%11) <{force = false}> : (tensor<1x32x50x12xf32, #ttnn_layout13>) -> ()
+        %13 = "ttnn.multiply"(%12, %arg5) : (tensor<1x32x12x50xf32, #ttnn_layout14>, tensor<1x1xf32, #ttnn_layout2>) -> tensor<1x32x12x50xf32, #ttnn_layout14>
+        "ttnn.deallocate"(%12) <{force = false}> : (tensor<1x32x12x50xf32, #ttnn_layout14>) -> ()
+        %14 = "ttnn.matmul"(%arg6, %3) <{transpose_a = false, transpose_b = true}> : (tensor<1x32x50x100xf32, #ttnn_layout4>, tensor<1x32x12x100xf32, #ttnn_layout8>) -> tensor<1x32x50x12xf32, #ttnn_layout13>
+        "ttnn.deallocate"(%3) <{force = false}> : (tensor<1x32x12x100xf32, #ttnn_layout8>) -> ()
+        %15 = "ttnn.transpose"(%14) <{dim0 = 2 : si32, dim1 = 3 : si32}> : (tensor<1x32x50x12xf32, #ttnn_layout13>) -> tensor<1x32x12x50xf32, #ttnn_layout14>
+        "ttnn.deallocate"(%14) <{force = false}> : (tensor<1x32x50x12xf32, #ttnn_layout13>) -> ()
+        %16 = "ttnn.concat"(%13, %15) <{dim = 3 : si32}> : (tensor<1x32x12x50xf32, #ttnn_layout14>, tensor<1x32x12x50xf32, #ttnn_layout14>) -> tensor<1x32x12x100xf32, #ttnn_layout8>
+        "ttnn.deallocate"(%15) <{force = false}> : (tensor<1x32x12x50xf32, #ttnn_layout14>) -> ()
+        "ttnn.deallocate"(%13) <{force = false}> : (tensor<1x32x12x50xf32, #ttnn_layout14>) -> ()
+        %17 = "ttnn.sin"(%7) : (tensor<1x12x100xf32, #ttnn_layout11>) -> tensor<1x12x100xf32, #ttnn_layout11>
+        "ttnn.deallocate"(%7) <{force = false}> : (tensor<1x12x100xf32, #ttnn_layout11>) -> ()
+        %18 = "ttnn.reshape"(%17) <{shape = [1 : i32, 1 : i32, 12 : i32, 100 : i32]}> : (tensor<1x12x100xf32, #ttnn_layout11>) -> tensor<1x1x12x100xf32, #ttnn_layout12>
+        "ttnn.deallocate"(%17) <{force = false}> : (tensor<1x12x100xf32, #ttnn_layout11>) -> ()
+        %19 = "ttnn.multiply"(%16, %18) : (tensor<1x32x12x100xf32, #ttnn_layout8>, tensor<1x1x12x100xf32, #ttnn_layout12>) -> tensor<1x32x12x100xf32, #ttnn_layout8>
+        "ttnn.deallocate"(%16) <{force = false}> : (tensor<1x32x12x100xf32, #ttnn_layout8>) -> ()
+        %20 = "ttnn.add"(%10, %19) : (tensor<1x32x12x100xf32, #ttnn_layout8>, tensor<1x32x12x100xf32, #ttnn_layout8>) -> tensor<1x32x12x100xf32, #ttnn_layout8>
+        "ttnn.deallocate"(%19) <{force = false}> : (tensor<1x32x12x100xf32, #ttnn_layout8>) -> ()
+        "ttnn.deallocate"(%10) <{force = false}> : (tensor<1x32x12x100xf32, #ttnn_layout8>) -> ()
+        %21 = "ttnn.reshape"(%20) <{shape = [32 : i32, 12 : i32, 100 : i32]}> : (tensor<1x32x12x100xf32, #ttnn_layout8>) -> tensor<32x12x100xf32, #ttnn_layout15>
+        "ttnn.deallocate"(%20) <{force = false}> : (tensor<1x32x12x100xf32, #ttnn_layout8>) -> ()
+        %22 = "ttnn.matmul"(%0, %arg12) <{transpose_a = false, transpose_b = false}> : (tensor<12x3200xf32, #ttnn_layout6>, tensor<3200x3200xf32, #ttnn_layout5>) -> tensor<12x3200xf32, #ttnn_layout6>
+        %23 = "ttnn.reshape"(%22) <{shape = [1 : i32, 12 : i32, 32 : i32, 100 : i32]}> : (tensor<12x3200xf32, #ttnn_layout6>) -> tensor<1x12x32x100xf32, #ttnn_layout7>
+        "ttnn.deallocate"(%22) <{force = false}> : (tensor<12x3200xf32, #ttnn_layout6>) -> ()
+        %24 = "ttnn.transpose"(%23) <{dim0 = 1 : si32, dim1 = 2 : si32}> : (tensor<1x12x32x100xf32, #ttnn_layout7>) -> tensor<1x32x12x100xf32, #ttnn_layout8>
+        "ttnn.deallocate"(%23) <{force = false}> : (tensor<1x12x32x100xf32, #ttnn_layout7>) -> ()
+        %25 = "ttnn.multiply"(%24, %9) : (tensor<1x32x12x100xf32, #ttnn_layout8>, tensor<1x1x12x100xf32, #ttnn_layout12>) -> tensor<1x32x12x100xf32, #ttnn_layout8>
+        "ttnn.deallocate"(%9) <{force = false}> : (tensor<1x1x12x100xf32, #ttnn_layout12>) -> ()
+        %26 = "ttnn.matmul"(%arg7, %24) <{transpose_a = false, transpose_b = true}> : (tensor<1x32x50x100xf32, #ttnn_layout4>, tensor<1x32x12x100xf32, #ttnn_layout8>) -> tensor<1x32x50x12xf32, #ttnn_layout13>
+        %27 = "ttnn.transpose"(%26) <{dim0 = 2 : si32, dim1 = 3 : si32}> : (tensor<1x32x50x12xf32, #ttnn_layout13>) -> tensor<1x32x12x50xf32, #ttnn_layout14>
+        "ttnn.deallocate"(%26) <{force = false}> : (tensor<1x32x50x12xf32, #ttnn_layout13>) -> ()
+        %28 = "ttnn.multiply"(%27, %arg8) : (tensor<1x32x12x50xf32, #ttnn_layout14>, tensor<1x1xf32, #ttnn_layout2>) -> tensor<1x32x12x50xf32, #ttnn_layout14>
+        "ttnn.deallocate"(%27) <{force = false}> : (tensor<1x32x12x50xf32, #ttnn_layout14>) -> ()
+        %29 = "ttnn.matmul"(%arg9, %24) <{transpose_a = false, transpose_b = true}> : (tensor<1x32x50x100xf32, #ttnn_layout4>, tensor<1x32x12x100xf32, #ttnn_layout8>) -> tensor<1x32x50x12xf32, #ttnn_layout13>
+        "ttnn.deallocate"(%24) <{force = false}> : (tensor<1x32x12x100xf32, #ttnn_layout8>) -> ()
+        %30 = "ttnn.transpose"(%29) <{dim0 = 2 : si32, dim1 = 3 : si32}> : (tensor<1x32x50x12xf32, #ttnn_layout13>) -> tensor<1x32x12x50xf32, #ttnn_layout14>
+        "ttnn.deallocate"(%29) <{force = false}> : (tensor<1x32x50x12xf32, #ttnn_layout13>) -> ()
+        %31 = "ttnn.concat"(%28, %30) <{dim = 3 : si32}> : (tensor<1x32x12x50xf32, #ttnn_layout14>, tensor<1x32x12x50xf32, #ttnn_layout14>) -> tensor<1x32x12x100xf32, #ttnn_layout8>
+        "ttnn.deallocate"(%30) <{force = false}> : (tensor<1x32x12x50xf32, #ttnn_layout14>) -> ()
+        "ttnn.deallocate"(%28) <{force = false}> : (tensor<1x32x12x50xf32, #ttnn_layout14>) -> ()
+        %32 = "ttnn.multiply"(%31, %18) : (tensor<1x32x12x100xf32, #ttnn_layout8>, tensor<1x1x12x100xf32, #ttnn_layout12>) -> tensor<1x32x12x100xf32, #ttnn_layout8>
+        "ttnn.deallocate"(%31) <{force = false}> : (tensor<1x32x12x100xf32, #ttnn_layout8>) -> ()
+        "ttnn.deallocate"(%18) <{force = false}> : (tensor<1x1x12x100xf32, #ttnn_layout12>) -> ()
+        %33 = "ttnn.add"(%25, %32) : (tensor<1x32x12x100xf32, #ttnn_layout8>, tensor<1x32x12x100xf32, #ttnn_layout8>) -> tensor<1x32x12x100xf32, #ttnn_layout8>
+        "ttnn.deallocate"(%32) <{force = false}> : (tensor<1x32x12x100xf32, #ttnn_layout8>) -> ()
+        "ttnn.deallocate"(%25) <{force = false}> : (tensor<1x32x12x100xf32, #ttnn_layout8>) -> ()
+        %34 = "ttnn.reshape"(%33) <{shape = [32 : i32, 12 : i32, 100 : i32]}> : (tensor<1x32x12x100xf32, #ttnn_layout8>) -> tensor<32x12x100xf32, #ttnn_layout15>
+        "ttnn.deallocate"(%33) <{force = false}> : (tensor<1x32x12x100xf32, #ttnn_layout8>) -> ()
+        %35 = "ttnn.matmul"(%21, %34) <{transpose_a = false, transpose_b = true}> : (tensor<32x12x100xf32, #ttnn_layout15>, tensor<32x12x100xf32, #ttnn_layout15>) -> tensor<32x12x12xf32, #ttnn_layout16>
+        "ttnn.deallocate"(%34) <{force = false}> : (tensor<32x12x100xf32, #ttnn_layout15>) -> ()
+        "ttnn.deallocate"(%21) <{force = false}> : (tensor<32x12x100xf32, #ttnn_layout15>) -> ()
+        %36 = "ttnn.reshape"(%35) <{shape = [1 : i32, 32 : i32, 12 : i32, 12 : i32]}> : (tensor<32x12x12xf32, #ttnn_layout16>) -> tensor<1x32x12x12xf32, #ttnn_layout17>
+        "ttnn.deallocate"(%35) <{force = false}> : (tensor<32x12x12xf32, #ttnn_layout16>) -> ()
+        %37 = "ttnn.multiply"(%36, %arg10) : (tensor<1x32x12x12xf32, #ttnn_layout17>, tensor<1x1xf32, #ttnn_layout2>) -> tensor<1x32x12x12xf32, #ttnn_layout17>
+        "ttnn.deallocate"(%36) <{force = false}> : (tensor<1x32x12x12xf32, #ttnn_layout17>) -> ()
+        %38 = "ttnn.add"(%37, %arg1) : (tensor<1x32x12x12xf32, #ttnn_layout17>, tensor<1x1x12x12xf32, #ttnn_layout1>) -> tensor<1x32x12x12xf32, #ttnn_layout17>
+        "ttnn.deallocate"(%37) <{force = false}> : (tensor<1x32x12x12xf32, #ttnn_layout17>) -> ()
+        %39 = "ttnn.softmax"(%38) <{dimension = -1 : si32}> : (tensor<1x32x12x12xf32, #ttnn_layout17>) -> tensor<1x32x12x12xf32, #ttnn_layout17>
+        "ttnn.deallocate"(%38) <{force = false}> : (tensor<1x32x12x12xf32, #ttnn_layout17>) -> ()
+        %40 = "ttnn.reshape"(%39) <{shape = [32 : i32, 12 : i32, 12 : i32]}> : (tensor<1x32x12x12xf32, #ttnn_layout17>) -> tensor<32x12x12xf32, #ttnn_layout16>
+        "ttnn.deallocate"(%39) <{force = false}> : (tensor<1x32x12x12xf32, #ttnn_layout17>) -> ()
+        %41 = "ttnn.matmul"(%0, %arg13) <{transpose_a = false, transpose_b = false}> : (tensor<12x3200xf32, #ttnn_layout6>, tensor<3200x3200xf32, #ttnn_layout5>) -> tensor<12x3200xf32, #ttnn_layout6>
+        "ttnn.deallocate"(%0) <{force = false}> : (tensor<12x3200xf32, #ttnn_layout6>) -> ()
+        %42 = "ttnn.reshape"(%41) <{shape = [1 : i32, 12 : i32, 32 : i32, 100 : i32]}> : (tensor<12x3200xf32, #ttnn_layout6>) -> tensor<1x12x32x100xf32, #ttnn_layout7>
+        "ttnn.deallocate"(%41) <{force = false}> : (tensor<12x3200xf32, #ttnn_layout6>) -> ()
+        %43 = "ttnn.transpose"(%42) <{dim0 = 1 : si32, dim1 = 2 : si32}> : (tensor<1x12x32x100xf32, #ttnn_layout7>) -> tensor<1x32x12x100xf32, #ttnn_layout8>
+        "ttnn.deallocate"(%42) <{force = false}> : (tensor<1x12x32x100xf32, #ttnn_layout7>) -> ()
+        %44 = "ttnn.transpose"(%43) <{dim0 = 2 : si32, dim1 = 3 : si32}> : (tensor<1x32x12x100xf32, #ttnn_layout8>) -> tensor<1x32x100x12xf32, #ttnn_layout18>
+        "ttnn.deallocate"(%43) <{force = false}> : (tensor<1x32x12x100xf32, #ttnn_layout8>) -> ()
+        %45 = "ttnn.reshape"(%44) <{shape = [32 : i32, 100 : i32, 12 : i32]}> : (tensor<1x32x100x12xf32, #ttnn_layout18>) -> tensor<32x100x12xf32, #ttnn_layout19>
+        "ttnn.deallocate"(%44) <{force = false}> : (tensor<1x32x100x12xf32, #ttnn_layout18>) -> ()
+        %46 = "ttnn.matmul"(%40, %45) <{transpose_a = false, transpose_b = true}> : (tensor<32x12x12xf32, #ttnn_layout16>, tensor<32x100x12xf32, #ttnn_layout19>) -> tensor<32x12x100xf32, #ttnn_layout15>
+        "ttnn.deallocate"(%45) <{force = false}> : (tensor<32x100x12xf32, #ttnn_layout19>) -> ()
+        "ttnn.deallocate"(%40) <{force = false}> : (tensor<32x12x12xf32, #ttnn_layout16>) -> ()
+        %47 = "ttnn.reshape"(%46) <{shape = [1 : i32, 32 : i32, 12 : i32, 100 : i32]}> : (tensor<32x12x100xf32, #ttnn_layout15>) -> tensor<1x32x12x100xf32, #ttnn_layout8>
+        "ttnn.deallocate"(%46) <{force = false}> : (tensor<32x12x100xf32, #ttnn_layout15>) -> ()
+        %48 = "ttnn.transpose"(%47) <{dim0 = 1 : si32, dim1 = 2 : si32}> : (tensor<1x32x12x100xf32, #ttnn_layout8>) -> tensor<1x12x32x100xf32, #ttnn_layout7>
+        "ttnn.deallocate"(%47) <{force = false}> : (tensor<1x32x12x100xf32, #ttnn_layout8>) -> ()
+        %49 = "ttnn.reshape"(%48) <{shape = [12 : i32, 3200 : i32]}> : (tensor<1x12x32x100xf32, #ttnn_layout7>) -> tensor<12x3200xf32, #ttnn_layout6>
+        "ttnn.deallocate"(%48) <{force = false}> : (tensor<1x12x32x100xf32, #ttnn_layout7>) -> ()
+        %50 = "ttnn.matmul"(%49, %arg14) <{transpose_a = false, transpose_b = false}> : (tensor<12x3200xf32, #ttnn_layout6>, tensor<3200x3200xf32, #ttnn_layout5>) -> tensor<12x3200xf32, #ttnn_layout6>
+        "ttnn.deallocate"(%49) <{force = false}> : (tensor<12x3200xf32, #ttnn_layout6>) -> ()
+        %51 = "ttnn.reshape"(%50) <{shape = [1 : i32, 12 : i32, 3200 : i32]}> : (tensor<12x3200xf32, #ttnn_layout6>) -> tensor<1x12x3200xf32, #ttnn_layout>
+        "ttnn.deallocate"(%50) <{force = false}> : (tensor<12x3200xf32, #ttnn_layout6>) -> ()
+        return %51 : tensor<1x12x3200xf32, #ttnn_layout>
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Problem description
- Registering passes and pipelines through python would make our testing infra a lot more robust, unfortunately this is managed by a global singleton.
- If passes are registered twice there are conflicts and it makes for quite the mess.

### What's changed
- Leverages the `_site_initialize` infrastructure in `_mlir_lib/__init__.py` to initialize the dialects on import globally for python usecases (also thread-safe!)
