### PR TITLE
TTNN eltwise ops separate signature by arity

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -147,11 +147,8 @@ class TTNN_ElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
 
     let extraClassDeclaration = [{
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
-        ::mlir::Operation::operand_range inputs = getOperands();
-        mlir::Operation *op = getOperation();
         return
-          wa::TTNNOperandsWorkaroundsFactory::createBinaryOpOperandsWorkarounds(
-                                                                        inputs, op);
+          wa::TTNNOperandsWorkaroundsFactory::createBinaryOpOperandsWorkarounds(*this);
       }
     }];
 }

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -145,17 +145,8 @@ class TTNN_ElementwiseUnaryOp<string mnemonic, list<Trait> traits = []> :
       Eltwise unary op.
     }];
 
-    let builders =
-    [
-      OpBuilder<(ins "Value": $in, "Type": $outputType),
-      [{
-        build($_builder, $_state, {outputType}, in);
-      }]>,
-      OpBuilder<(ins "Value": $in),
-      [{
-        build($_builder, $_state, in, in.getType());
-      }]>
-    ];
+    let arguments = (ins AnyRankedTensor:$input);
+    let results = (outs AnyRankedTensor:$result);
 }
 
 class TTNN_ElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
@@ -165,17 +156,13 @@ class TTNN_ElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
       Eltwise binary op.
     }];
 
-    let builders =
-    [
-      OpBuilder<(ins "Value": $lhs, "Value": $rhs, "Type": $outputType),
-      [{
-        build($_builder, $_state, {outputType}, {lhs, rhs});
-      }]>
-    ];
+    let arguments = (ins AnyRankedTensor:$lhs,
+                         AnyRankedTensor:$rhs);
+    let results = (outs AnyRankedTensor:$result);
 
     let extraClassDeclaration = [{
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
-        ::mlir::Operation::operand_range inputs = getInputs();
+        ::mlir::Operation::operand_range inputs = getOperands();
         mlir::Operation *op = getOperation();
         return
           wa::TTNNOperandsWorkaroundsFactory::createBinaryOpOperandsWorkarounds(
@@ -191,13 +178,10 @@ class TTNN_ElementwiseTernaryOp<string mnemonic, list<Trait> traits = []> :
       Eltwise ternary op.
     }];
 
-    let builders =
-    [
-      OpBuilder<(ins "Value": $first, "Value": $second, "Value": $third, "Type": $outputType),
-      [{
-        build($_builder, $_state, {outputType}, {first, second, third});
-      }]>
-    ];
+    let arguments = (ins AnyRankedTensor:$first,
+                         AnyRankedTensor:$second,
+                         AnyRankedTensor:$third);
+    let results = (outs AnyRankedTensor:$result);
 }
 
 def TTNN_WhereOp : TTNN_ElementwiseTernaryOp<"where"> {
@@ -208,7 +192,7 @@ def TTNN_WhereOp : TTNN_ElementwiseTernaryOp<"where"> {
 
     let extraClassDeclaration = [{
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
-        ::mlir::Operation::operand_range inputs = getInputs();
+        ::mlir::Operation::operand_range inputs = getOperands();
         return
           wa::TTNNOperandsWorkaroundsFactory::createWhereOpOperandsWorkarounds(
                                                                         inputs);
@@ -427,16 +411,8 @@ class TTNN_ElementwiseUnaryWithFloatParameterOp<string mnemonic, list<Trait> tra
       Eltwise unary op with the float parameter.
     }];
 
-    let arguments = (ins Variadic<AnyRankedTensor>:$inputs,
+    let arguments = (ins AnyRankedTensor:$input,
                          F32Attr:$parameter);
-
-    let builders =
-    [
-      OpBuilder<(ins "Value": $in, "FloatAttr":$parameter),
-      [{
-        build($_builder, $_state, {in.getType()}, {in}, parameter);
-      }]>
-    ];
 }
 
 def TTNN_LeakyReluOp : TTNN_ElementwiseUnaryWithFloatParameterOp<"leaky_relu"> {
@@ -1370,11 +1346,11 @@ def TTNN_ClampScalarOp : TTNN_Op<"clamp_scalar"> {
         -> %out = [[2, 2, 2, 3, 4, 5, 5, 5]]
     }];
 
-    let arguments = (ins Variadic<AnyRankedTensor>:$inputs,
+    let arguments = (ins AnyRankedTensor:$input,
                          F32Attr:$min,
                          F32Attr:$max);
 
-    let results = (outs Variadic<AnyRankedTensor>:$result);
+    let results = (outs AnyRankedTensor:$result);
 
     let hasVerifier = 1;
 }
@@ -1393,11 +1369,11 @@ def TTNN_ClampTensorOp : TTNN_Op<"clamp_tensor"> {
       %out:  [[2, 2, 2, 3, 4, 5, 6, 6]]
   }];
 
-  let arguments = (ins Variadic<AnyRankedTensor>:$inputs,
+  let arguments = (ins AnyRankedTensor:$input,
                        AnyRankedTensor:$min,
                        AnyRankedTensor:$max);
 
-  let results = (outs Variadic<AnyRankedTensor>:$result);
+  let results = (outs AnyRankedTensor:$result);
 }
 
 def TTNN_EmptyOp : TTNN_Op<"empty", [TT_CreationOpTrait]> {

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -123,23 +123,8 @@ def TTNN_FromDeviceOp : TTNN_Op<"from_device"> {
     let results = (outs AnyRankedTensor:$result);
 }
 
-
-class TTNN_NamedDPSOp<string mnemonic, list<Trait> traits = []> :
-    TTNN_Op<mnemonic, !listconcat(traits, [DestinationStyleOpInterface])> {
-    let extraClassDeclaration = [{
-      MutableOperandRange getDpsInitsMutable() { return getOutputsMutable(); }
-    }];
-}
-
-class TTNN_ElementwiseOp<string mnemonic, list<Trait> traits = []> :
-    TTNN_Op<mnemonic, traits> {
-
-    let arguments = (ins Variadic<AnyRankedTensor>:$inputs);
-    let results = (outs Variadic<AnyRankedTensor>:$results);
-}
-
 class TTNN_ElementwiseUnaryOp<string mnemonic, list<Trait> traits = []> :
-    TTNN_ElementwiseOp<mnemonic, !listconcat([OneOperand], traits)> {
+    TTNN_Op<mnemonic, traits> {
     let summary = "Eltwise unary op.";
     let description = [{
       Eltwise unary op.
@@ -150,7 +135,7 @@ class TTNN_ElementwiseUnaryOp<string mnemonic, list<Trait> traits = []> :
 }
 
 class TTNN_ElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
-    TTNN_ElementwiseOp<mnemonic, !listconcat([TwoOperands], traits)> {
+    TTNN_Op<mnemonic, traits> {
     let summary = "Eltwise binary op.";
     let description = [{
       Eltwise binary op.
@@ -172,7 +157,7 @@ class TTNN_ElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
 }
 
 class TTNN_ElementwiseTernaryOp<string mnemonic, list<Trait> traits = []> :
-    TTNN_ElementwiseOp<mnemonic, !listconcat([ThreeOperands], traits)> {
+    TTNN_Op<mnemonic, traits> {
     let summary = "Eltwise ternary op.";
     let description = [{
       Eltwise ternary op.

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1702,7 +1702,7 @@ def TTNN_QuantizeOp : TTNN_Op<"quantize"> {
       Applies quantization to the input tensor.
 
       Inputs:
-        - `input` Variadic<AnyRankedTensor>: The input tensor to be quantized.
+        - `input` AnyRankedTensor: The input tensor to be quantized.
         - `scale` f32: The scale factor.
         - `zero_point` i32: The zero point value.
         - `axis` Optional<i32>: The axis along which quantization is applied.
@@ -1719,14 +1719,14 @@ def TTNN_QuantizeOp : TTNN_Op<"quantize"> {
       ```
     }];
 
-    let arguments = (ins Variadic<AnyRankedTensor>:$inputs,
+    let arguments = (ins AnyRankedTensor:$input,
                          F32Attr:$scale,
                          I32Attr:$zero_point,
                          OptionalAttr<I32Attr>:$axis,
                          OptionalAttr<TT_DataTypeAttr>:$output_dtype,
                          OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
 
-    let results = (outs Variadic<AnyRankedTensor>:$result);
+    let results = (outs AnyRankedTensor:$result);
 
     let hasVerifier = 1;
 }
@@ -1737,7 +1737,7 @@ def TTNN_DequantizeOp : TTNN_Op<"dequantize"> {
       Applies dequantization to the input tensor.
 
       Inputs:
-        - `input` Variadic<AnyRankedTensor>: The input tensor to be dequantized.
+        - `input` AnyRankedTensor: The input tensor to be dequantized.
         - `scale` f32: The scale factor.
         - `zero_point` i32: The zero point value.
         - `axis` Optional<i32>: The axis along which quantization is applied.
@@ -1754,14 +1754,14 @@ def TTNN_DequantizeOp : TTNN_Op<"dequantize"> {
       ```
     }];
 
-    let arguments = (ins Variadic<AnyRankedTensor>:$inputs,
+    let arguments = (ins AnyRankedTensor:$input,
                          F32Attr:$scale,
                          I32Attr:$zero_point,
                          OptionalAttr<I32Attr>:$axis,
                          OptionalAttr<TT_DataTypeAttr>:$output_dtype,
                          OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
 
-    let results = (outs Variadic<AnyRankedTensor>:$result);
+    let results = (outs AnyRankedTensor:$result);
 
     let hasVerifier = 1;
 }
@@ -1772,7 +1772,7 @@ def TTNN_RequantizeOp : TTNN_Op<"requantize"> {
       Applies requantization to the input tensor.
 
       Inputs:
-        - `input` Variadic<AnyRankedTensor>: The input tensor to be requantized.
+        - `input` AnyRankedTensor: The input tensor to be requantized.
         - `in_scale` f32: The input scale factor.
         - `in_zero_point` i32: The input zero point value.
         - `out_scale` f32: The output scale factor.
@@ -1791,7 +1791,7 @@ def TTNN_RequantizeOp : TTNN_Op<"requantize"> {
       ```
     }];
 
-    let arguments = (ins Variadic<AnyRankedTensor>:$inputs,
+    let arguments = (ins AnyRankedTensor:$input,
                          F32Attr:$in_scale,
                          I32Attr:$in_zero_point,
                          F32Attr:$out_scale,
@@ -1800,7 +1800,7 @@ def TTNN_RequantizeOp : TTNN_Op<"requantize"> {
                          OptionalAttr<TT_DataTypeAttr>:$output_dtype,
                          OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
 
-    let results = (outs Variadic<AnyRankedTensor>:$result);
+    let results = (outs AnyRankedTensor:$result);
 
     let hasVerifier = 1;
 }

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNTraits.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNTraits.h
@@ -71,24 +71,6 @@ public:
   }
 };
 
-// Trait to verify that operations have exactly N operands.
-template <unsigned N>
-class NOperandTTNN {
-public:
-  template <typename ConcreteType>
-  class Impl
-      : public mlir::OpTrait::TraitBase<ConcreteType, NOperandTTNN<N>::Impl> {
-  public:
-    static LogicalResult verifyTrait(Operation *op) {
-      if (op->getNumOperands() != N) {
-        return op->emitOpError() << "Operation " << op->getName()
-                                 << " must have exactly " << N << " operands.";
-      }
-      return success();
-    }
-  };
-};
-
 } // namespace mlir::tt::ttnn
 
 #endif

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNTraits.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNTraits.td
@@ -17,22 +17,4 @@ def HasMemoryConfigTrait : NativeOpTrait<"HasMemoryConfigTrait">
   let cppNamespace = "mlir::tt::ttnn";
 }
 
-// Trait for ops with variadic operands to specify the number of operands.
-//
-// Trait for ops with one operand.
-def OneOperand : ParamNativeOpTrait<"NOperandTTNN", "1">
-{
-  let cppNamespace = "mlir::tt::ttnn";
-}
-// Trait for ops with two operands.
-def TwoOperands : ParamNativeOpTrait<"NOperandTTNN", "2">
-{
-  let cppNamespace = "mlir::tt::ttnn";
-}
-// Trait for ops with three operands.
-def ThreeOperands : ParamNativeOpTrait<"NOperandTTNN", "3">
-{
-  let cppNamespace = "mlir::tt::ttnn";
-}
-
 #endif // TTMLIR_TTMLIR_DIALECT_TTNN_TTNNTRAITS_TD

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkarounds.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkarounds.h
@@ -265,8 +265,7 @@ public:
 
   // Create workarounds for binary op operands.
   static TTNNOperandsWorkarounds
-  createBinaryOpOperandsWorkarounds(mlir::Operation::operand_range inputs,
-                                    mlir::Operation *op);
+  createBinaryOpOperandsWorkarounds(mlir::Operation *op);
 
   // Create workarounds for ArgMax op operands.
   static TTNNOperandsWorkarounds createArgMaxOpOperandsWorkarounds();

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -555,7 +555,7 @@ public:
     ttnn_to_emitc::EmitCTTNNEmitter<OpType> emitter(op, adaptor, rewriter);
 
     llvm::SmallVector<mlir::Attribute> args{
-        emitter.emit(op.getInputs()[0]),
+        emitter.emit(op.getInput()),
         emitter.emit(op.getScale()),
         emitter.emit(op.getZeroPoint()),
         emitter.emit(op.getAxis()),
@@ -582,7 +582,7 @@ public:
                                                                     rewriter);
 
     llvm::SmallVector<mlir::Attribute> args{
-        emitter.emit(op.getInputs()[0]),
+        emitter.emit(op.getInput()),
         emitter.emit(op.getInScale()),
         emitter.emit(op.getInZeroPoint()),
         emitter.emit(op.getOutScale()),

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -137,9 +137,8 @@ public:
     ttnn_to_emitc::EmitCTTNNEmitter<SourceOp> emitter(srcOp, adaptor, rewriter);
 
     llvm::SmallVector<mlir::Attribute> args{
-        emitter.emit(srcOp.getInputs()[0]),
-        emitter.emit(std::nullopt) |
-            emitter.getMemoryConfig(srcOp->getResult(0)),
+        emitter.emit(srcOp.getInput()),
+        emitter.emit(std::nullopt) | emitter.getMemoryConfig(srcOp.getResult()),
     };
 
     emitter.replaceOp(*this, args);
@@ -171,10 +170,9 @@ public:
     ttnn_to_emitc::EmitCTTNNEmitter<SourceOp> emitter(srcOp, adaptor, rewriter);
 
     llvm::SmallVector<mlir::Attribute> args{
-        emitter.emit(srcOp.getInputs()[0]),
+        emitter.emit(srcOp.getInput()),
         /*parameter=*/emitter.emit(false),
-        emitter.emit(std::nullopt) |
-            emitter.getMemoryConfig(srcOp->getResult(0)),
+        emitter.emit(std::nullopt) | emitter.getMemoryConfig(srcOp.getResult()),
     };
 
     emitter.replaceOp(*this, args);
@@ -206,10 +204,9 @@ public:
     ttnn_to_emitc::EmitCTTNNEmitter<SourceOp> emitter(srcOp, adaptor, rewriter);
 
     llvm::SmallVector<mlir::Attribute> args{
-        emitter.emit(srcOp.getInputs()[0]),
+        emitter.emit(srcOp.getInput()),
         /*parameter=*/emitter.emit(srcOp.getParameter()),
-        emitter.emit(std::nullopt) |
-            emitter.getMemoryConfig(srcOp->getResult(0)),
+        emitter.emit(std::nullopt) | emitter.getMemoryConfig(srcOp.getResult()),
     };
 
     emitter.replaceOp(*this, args);
@@ -241,9 +238,8 @@ public:
     ttnn_to_emitc::EmitCTTNNEmitter<SourceOp> emitter(srcOp, adaptor, rewriter);
 
     llvm::SmallVector<mlir::Attribute> args{
-        emitter.emit(srcOp.getInputs()[0]),
-        emitter.emit(std::nullopt) |
-            emitter.getMemoryConfig(srcOp->getResult(0)),
+        emitter.emit(srcOp.getInput()),
+        emitter.emit(std::nullopt) | emitter.getMemoryConfig(srcOp.getResult()),
     };
 
     emitter.replaceOp(*this, args);
@@ -286,11 +282,10 @@ public:
 
     ttnn_to_emitc::EmitCTTNNEmitter<SourceOp> emitter(srcOp, adaptor, rewriter);
     llvm::SmallVector<mlir::Attribute> args{
-        emitter.emit(srcOp.getInputs()[0]),
+        emitter.emit(srcOp.getInput()),
         emitter.emit(srcOp.getMin()),
         emitter.emit(srcOp.getMax()),
-        emitter.emit(std::nullopt) |
-            emitter.getMemoryConfig(srcOp->getResult(0)),
+        emitter.emit(std::nullopt) | emitter.getMemoryConfig(srcOp.getResult()),
     };
 
     emitter.replaceOp(*this, args);
@@ -322,11 +317,10 @@ public:
     ttnn_to_emitc::EmitCTTNNEmitter<SourceOp> emitter(srcOp, adaptor, rewriter);
 
     llvm::SmallVector<mlir::Attribute> args{
-        emitter.emit(srcOp.getInputs()[0]),
-        emitter.emit(srcOp.getInputs()[1]),
+        emitter.emit(srcOp.getLhs()),
+        emitter.emit(srcOp.getRhs()),
         /*dtype=*/emitter.emit(std::nullopt),
-        emitter.emit(std::nullopt) |
-            emitter.getMemoryConfig(srcOp->getResult(0)),
+        emitter.emit(std::nullopt) | emitter.getMemoryConfig(srcOp.getResult()),
     };
 
     emitter.replaceOp(*this, args);
@@ -358,10 +352,9 @@ public:
     ttnn_to_emitc::EmitCTTNNEmitter<SourceOp> emitter(srcOp, adaptor, rewriter);
 
     llvm::SmallVector<mlir::Attribute> args{
-        emitter.emit(srcOp.getInputs()[0]),
-        emitter.emit(srcOp.getInputs()[1]),
-        emitter.emit(std::nullopt) |
-            emitter.getMemoryConfig(srcOp->getResult(0)),
+        emitter.emit(srcOp.getLhs()),
+        emitter.emit(srcOp.getRhs()),
+        emitter.emit(std::nullopt) | emitter.getMemoryConfig(srcOp.getResult()),
     };
 
     emitter.replaceOp(*this, args);
@@ -393,11 +386,10 @@ public:
     ttnn_to_emitc::EmitCTTNNEmitter<SourceOp> emitter(srcOp, adaptor, rewriter);
 
     llvm::SmallVector<mlir::Attribute> args{
-        emitter.emit(srcOp.getInputs()[0]),
-        emitter.emit(srcOp.getInputs()[1]),
-        emitter.emit(srcOp.getInputs()[2]),
-        emitter.emit(std::nullopt) |
-            emitter.getMemoryConfig(srcOp->getResult(0)),
+        emitter.emit(srcOp.getFirst()),
+        emitter.emit(srcOp.getSecond()),
+        emitter.emit(srcOp.getThird()),
+        emitter.emit(std::nullopt) | emitter.getMemoryConfig(srcOp.getResult()),
     };
 
     emitter.replaceOp(*this, args);

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -53,11 +53,9 @@ ReluOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                          const TTNNLayoutAttr &output) {
   assert(inputs.size() == 1);
 
-  const auto inputShape =
-      mlir::cast<RankedTensorType>(getOperand(0).getType()).getShape();
+  const auto inputShape = getInput().getType().getShape();
 
-  const auto outputShape =
-      mlir::cast<RankedTensorType>(getResults().front().getType()).getShape();
+  const auto outputShape = getType().getShape();
 
   llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
   if (!check) {
@@ -74,11 +72,9 @@ ReluOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 
   assert(inputs.size() == 1);
 
-  const auto inputShape =
-      mlir::cast<RankedTensorType>(getOperand(0).getType()).getShape();
+  const auto inputShape = getInput().getType().getShape();
 
-  const auto outputShape =
-      mlir::cast<RankedTensorType>(getResults().front().getType()).getShape();
+  const auto outputShape = getType().getShape();
 
   return op_model::ttnn::ReluOpInterface::getOpRuntime(inputShape, inputs[0],
                                                        outputShape, output);
@@ -93,11 +89,9 @@ SqrtOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                          const TTNNLayoutAttr &output) {
   assert(inputs.size() == 1);
 
-  const auto inputShape =
-      mlir::cast<RankedTensorType>(getOperand(0).getType()).getShape();
+  const auto inputShape = getInput().getType().getShape();
 
-  const auto outputShape =
-      mlir::cast<RankedTensorType>(getResults().front().getType()).getShape();
+  const auto outputShape = getType().getShape();
 
   llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
   if (!check) {
@@ -114,11 +108,9 @@ SqrtOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 
   assert(inputs.size() == 1);
 
-  const auto inputShape =
-      mlir::cast<RankedTensorType>(getOperand(0).getType()).getShape();
+  const auto inputShape = getInput().getType().getShape();
 
-  const auto outputShape =
-      mlir::cast<RankedTensorType>(getResults().front().getType()).getShape();
+  const auto outputShape = getType().getShape();
 
   return op_model::ttnn::SqrtOpInterface::getOpRuntime(inputShape, inputs[0],
                                                        outputShape, output);
@@ -133,13 +125,10 @@ AddOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                         const TTNNLayoutAttr &output) {
   assert(inputs.size() == 2);
 
-  const auto inputShapeA =
-      mlir::cast<RankedTensorType>(getOperand(0).getType()).getShape();
-  const auto inputShapeB =
-      mlir::cast<RankedTensorType>(getOperand(1).getType()).getShape();
+  const auto inputShapeA = getLhs().getType().getShape();
+  const auto inputShapeB = getRhs().getType().getShape();
 
-  const auto outputShape =
-      mlir::cast<RankedTensorType>(getResult(0).getType()).getShape();
+  const auto outputShape = getType().getShape();
 
   llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
   if (!check) {
@@ -155,13 +144,10 @@ AddOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                     const TTNNLayoutAttr &output) {
   assert(inputs.size() == 2);
 
-  const auto inputShapeA =
-      mlir::cast<RankedTensorType>(getOperand(0).getType()).getShape();
-  const auto inputShapeB =
-      mlir::cast<RankedTensorType>(getOperand(1).getType()).getShape();
+  const auto inputShapeA = getLhs().getType().getShape();
+  const auto inputShapeB = getRhs().getType().getShape();
 
-  const auto outputShape =
-      mlir::cast<RankedTensorType>(getResult(0).getType()).getShape();
+  const auto outputShape = getType().getShape();
 
   return op_model::ttnn::AddOpInterface::getOpRuntime(
       inputShapeA, inputs[0], inputShapeB, inputs[1], outputShape, output);
@@ -381,12 +367,10 @@ MatmulOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                            const TTNNLayoutAttr &output) {
   assert(inputs.size() == 2);
 
-  const auto inputShapeA =
-      mlir::cast<RankedTensorType>(getOperand(0).getType()).getShape();
-  const auto inputShapeB =
-      mlir::cast<RankedTensorType>(getOperand(1).getType()).getShape();
+  const auto inputShapeA = getA().getType().getShape();
+  const auto inputShapeB = getB().getType().getShape();
 
-  const auto outputShape = getResult().getType().getShape();
+  const auto outputShape = getType().getShape();
 
   llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
   if (!check) {
@@ -403,12 +387,10 @@ MatmulOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                        const TTNNLayoutAttr &output) {
   assert(inputs.size() == 2);
 
-  const auto inputShapeA =
-      mlir::cast<RankedTensorType>(getOperand(0).getType()).getShape();
-  const auto inputShapeB =
-      mlir::cast<RankedTensorType>(getOperand(1).getType()).getShape();
+  const auto inputShapeA = getA().getType().getShape();
+  const auto inputShapeB = getB().getType().getShape();
 
-  const auto outputShape = getResult().getType().getShape();
+  const auto outputShape = getType().getShape();
 
   return op_model::ttnn::MatmulOpInterface::getOpRuntime(
       inputShapeA, inputs[0], inputShapeB, inputs[1], outputShape, output,
@@ -424,13 +406,10 @@ MultiplyOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                              const TTNNLayoutAttr &output) {
   assert(inputs.size() == 2);
 
-  const auto inputShapeA =
-      mlir::cast<RankedTensorType>(getOperand(0).getType()).getShape();
-  const auto inputShapeB =
-      mlir::cast<RankedTensorType>(getOperand(1).getType()).getShape();
+  const auto inputShapeA = getLhs().getType().getShape();
+  const auto inputShapeB = getRhs().getType().getShape();
 
-  const auto outputShape =
-      mlir::cast<RankedTensorType>(getResult(0).getType()).getShape();
+  const auto outputShape = getType().getShape();
 
   llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
   if (!check) {
@@ -446,13 +425,10 @@ MultiplyOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                          const TTNNLayoutAttr &output) {
   assert(inputs.size() == 2);
 
-  const auto inputShapeA =
-      mlir::cast<RankedTensorType>(getOperand(0).getType()).getShape();
-  const auto inputShapeB =
-      mlir::cast<RankedTensorType>(getOperand(1).getType()).getShape();
+  const auto inputShapeA = getLhs().getType().getShape();
+  const auto inputShapeB = getRhs().getType().getShape();
 
-  const auto outputShape =
-      mlir::cast<RankedTensorType>(getResult(0).getType()).getShape();
+  const auto outputShape = getType().getShape();
 
   return op_model::ttnn::MultiplyOpInterface::getOpRuntime(
       inputShapeA, inputs[0], inputShapeB, inputs[1], outputShape, output);

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -289,27 +289,11 @@ static ::mlir::LogicalResult verifyQuantizeOpCommon(
 
 // QuantizeOp verification.
 ::mlir::LogicalResult QuantizeOp::verify() {
-  ::mlir::Operation::operand_range inputs = getInputs();
-  ::mlir::Operation::result_range outputs = getResults();
-
-  if (inputs.size() != 1) {
-    return emitOpError() << "Expects one tensor as input but got "
-                         << inputs.size();
-  }
-
-  if (outputs.size() != 1) {
-    return emitOpError() << "Generates one tensor as output but got "
-                         << outputs.size();
-  }
-
-  const RankedTensorType inputTensorType =
-      mlir::cast<RankedTensorType>(inputs.front().getType());
-
-  const RankedTensorType outputTensorType =
-      mlir::cast<RankedTensorType>(outputs.front().getType());
+  RankedTensorType inputTensorType = getInput().getType();
+  RankedTensorType resultTensorType = getResult().getType();
 
   auto inputElemType = inputTensorType.getElementType();
-  auto outputElemType = outputTensorType.getElementType();
+  auto resultElemType = resultTensorType.getElementType();
 
   if (!mlir::isa<mlir::FloatType>(inputElemType)) {
     return emitOpError() << "Input element type must be float, but got "
@@ -317,15 +301,15 @@ static ::mlir::LogicalResult verifyQuantizeOpCommon(
   }
 
   if (!mlir::isa<mlir::quant::UniformQuantizedType,
-                 mlir::quant::UniformQuantizedPerAxisType>(outputElemType)) {
+                 mlir::quant::UniformQuantizedPerAxisType>(resultElemType)) {
     return emitOpError()
-           << "Output element type must be UniformQuantizedType or "
+           << "Result element type must be UniformQuantizedType or "
               "UniformQuantizedPerAxisType, but got "
-           << outputElemType;
+           << resultElemType;
   }
 
   return verifyQuantizeOpCommon([&]() { return emitOpError(); },
-                                inputTensorType, outputTensorType, getAxis());
+                                inputTensorType, resultTensorType, getAxis());
 }
 
 //===----------------------------------------------------------------------===//
@@ -334,27 +318,11 @@ static ::mlir::LogicalResult verifyQuantizeOpCommon(
 
 // DequantizeOp verification.
 ::mlir::LogicalResult DequantizeOp::verify() {
-  ::mlir::Operation::operand_range inputs = getInputs();
-  ::mlir::Operation::result_range outputs = getResults();
-
-  if (inputs.size() != 1) {
-    return emitOpError() << "Expects one tensor as input but got "
-                         << inputs.size();
-  }
-
-  if (outputs.size() != 1) {
-    return emitOpError() << "Generates one tensor as output but got "
-                         << outputs.size();
-  }
-
-  const RankedTensorType inputTensorType =
-      mlir::cast<RankedTensorType>(inputs.front().getType());
-
-  const RankedTensorType outputTensorType =
-      mlir::cast<RankedTensorType>(outputs.front().getType());
+  RankedTensorType inputTensorType = getInput().getType();
+  RankedTensorType resultTensorType = getResult().getType();
 
   auto inputElemType = inputTensorType.getElementType();
-  auto outputElemType = outputTensorType.getElementType();
+  auto resultElemType = resultTensorType.getElementType();
 
   if (!mlir::isa<mlir::quant::UniformQuantizedType,
                  mlir::quant::UniformQuantizedPerAxisType>(inputElemType)) {
@@ -363,13 +331,13 @@ static ::mlir::LogicalResult verifyQuantizeOpCommon(
                          << inputElemType;
   }
 
-  if (!mlir::isa<mlir::FloatType>(outputElemType)) {
-    return emitOpError() << "Output element type must be float, but got "
-                         << outputElemType;
+  if (!mlir::isa<mlir::FloatType>(resultElemType)) {
+    return emitOpError() << "Result element type must be float, but got "
+                         << resultElemType;
   }
 
   return verifyQuantizeOpCommon([&]() { return emitOpError(); },
-                                inputTensorType, outputTensorType, getAxis());
+                                inputTensorType, resultTensorType, getAxis());
 }
 
 //===----------------------------------------------------------------------===//
@@ -378,27 +346,11 @@ static ::mlir::LogicalResult verifyQuantizeOpCommon(
 
 // RequantizeOp verification.
 ::mlir::LogicalResult RequantizeOp::verify() {
-  ::mlir::Operation::operand_range inputs = getInputs();
-  ::mlir::Operation::result_range outputs = getResults();
-
-  if (inputs.size() != 1) {
-    return emitOpError() << "Expects one tensor as input but got "
-                         << inputs.size();
-  }
-
-  if (outputs.size() != 1) {
-    return emitOpError() << "Generates one tensor as output but got "
-                         << outputs.size();
-  }
-
-  const RankedTensorType inputTensorType =
-      mlir::cast<RankedTensorType>(inputs.front().getType());
-
-  const RankedTensorType outputTensorType =
-      mlir::cast<RankedTensorType>(outputs.front().getType());
+  const RankedTensorType inputTensorType = getInput().getType();
+  const RankedTensorType resultTensorType = getResult().getType();
 
   auto inputElemType = inputTensorType.getElementType();
-  auto outputElemType = outputTensorType.getElementType();
+  auto resultElemType = resultTensorType.getElementType();
 
   if (!mlir::isa<mlir::quant::UniformQuantizedType,
                  mlir::quant::UniformQuantizedPerAxisType>(inputElemType)) {
@@ -408,14 +360,14 @@ static ::mlir::LogicalResult verifyQuantizeOpCommon(
   }
 
   if (!mlir::isa<mlir::quant::UniformQuantizedType,
-                 mlir::quant::UniformQuantizedPerAxisType>(outputElemType)) {
-    return emitOpError() << "Output element type must be UniformQuantizedType "
+                 mlir::quant::UniformQuantizedPerAxisType>(resultElemType)) {
+    return emitOpError() << "Result element type must be UniformQuantizedType "
                             "or UniformQuantizedPerAxisType, but got "
-                         << outputElemType;
+                         << resultElemType;
   }
 
   return verifyQuantizeOpCommon([&]() { return emitOpError(); },
-                                inputTensorType, outputTensorType, getAxis());
+                                inputTensorType, resultTensorType, getAxis());
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -42,22 +42,9 @@ namespace mlir::tt::ttnn {
 //===----------------------------------------------------------------------===//
 
 ::mlir::LogicalResult mlir::tt::ttnn::ClampScalarOp::verify() {
-  ::mlir::Operation::operand_range inputs = getInputs();
-  ::mlir::Operation::result_range outputs = getResults();
+  const RankedTensorType inputTensorType = getInput().getType();
 
-  if (inputs.size() != 1) {
-    return emitOpError("expects one tensor as input.");
-  }
-
-  if (outputs.size() != 1) {
-    return emitOpError("generates one tensor as output.");
-  }
-
-  const RankedTensorType inputTensorType =
-      mlir::cast<RankedTensorType>(inputs.front().getType());
-
-  const RankedTensorType outputTensorType =
-      mlir::cast<RankedTensorType>(outputs.front().getType());
+  const RankedTensorType outputTensorType = getResult().getType();
 
   if (inputTensorType.getShape() != outputTensorType.getShape()) {
     return emitOpError("input and output must have same shape.");

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -1031,9 +1031,18 @@ createNonDPSEltwiseOp(FlatbufferObjectCache &cache, EltwiseOp op) {
   }
 
   std::vector<::flatbuffers::Offset<::tt::target::ttnn::TensorRef>> ins;
-  for (auto input : op->getOperands()) {
-    ins.push_back(cache.at<::tt::target::ttnn::TensorRef>(
-        getOperandThroughDPSOps(input)));
+  // ClampTensorOp is mapped to a unary composite op in the TTNN, even though
+  // it's technically a ternary elementwise op. To keep the mapping in the
+  // runtime consistent, we have to treat it as a special case where only
+  // `input` operand is the input, and `min` and `max` are parameters.
+  if constexpr (std::is_same_v<EltwiseOp, ClampTensorOp>) {
+    ins.emplace_back(cache.at<::tt::target::ttnn::TensorRef>(
+        getOperandThroughDPSOps(op.getInput())));
+  } else {
+    for (auto input : op->getOperands()) {
+      ins.emplace_back(cache.at<::tt::target::ttnn::TensorRef>(
+          getOperandThroughDPSOps(input)));
+    }
   }
   auto out = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
                                kHostAllocatedSize);

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -1031,12 +1031,11 @@ createNonDPSEltwiseOp(FlatbufferObjectCache &cache, EltwiseOp op) {
   }
 
   std::vector<::flatbuffers::Offset<::tt::target::ttnn::TensorRef>> ins;
-  for (auto input : op.getInputs()) {
+  for (auto input : op->getOperands()) {
     ins.push_back(cache.at<::tt::target::ttnn::TensorRef>(
         getOperandThroughDPSOps(input)));
   }
-  assert(op.getResults().size() == 1);
-  auto out = cache.getOrCreate(op.getResults().front(), tensorValueToFlatbuffer,
+  auto out = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
                                kHostAllocatedSize);
   return ::tt::target::ttnn::CreateEltwiseOpDirect(*cache.fbb, type, &ins, out,
                                                    paramsType, params);
@@ -1155,12 +1154,11 @@ createEltwiseOp(FlatbufferObjectCache &cache, EltwiseOp op) {
     llvm_unreachable("unhandled EltwiseOp");
   }
   std::vector<::flatbuffers::Offset<::tt::target::ttnn::TensorRef>> ins;
-  for (auto input : op.getInputs()) {
+  for (auto input : op->getOperands()) {
     ins.push_back(cache.at<::tt::target::ttnn::TensorRef>(
         getOperandThroughDPSOps(input)));
   }
-  assert(op.getResults().size() == 1);
-  auto out = cache.getOrCreate(op.getResult(0), tensorValueToFlatbuffer,
+  auto out = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
                                kHostAllocatedSize);
 
   return ::tt::target::ttnn::CreateEltwiseOpDirect(*cache.fbb, type, &ins, out,

--- a/test/ttmlir/Dialect/TTNN/clamp/clamp_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/clamp/clamp_tests_negative.mlir
@@ -15,7 +15,7 @@ module attributes {} {
 // -----
 module attributes {} {
   func.func @clamp2(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
-    // CHECK: error: 'ttnn.clamp_scalar' op expects one tensor as input.
+    // CHECK: error: 'ttnn.clamp_scalar' op requires a single operand
     %0 = ttir.empty() : tensor<64x128xbf16>
     %1 = "ttnn.clamp_scalar"(%arg0, %arg1) <{max = 3.000000e+00 : f32, min = 2.000000e+00 : f32}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     return %1 : tensor<64x128xbf16>

--- a/test/ttmlir/Dialect/TTNN/eltwise/binary/binary_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/binary/binary_tests_negative.mlir
@@ -6,7 +6,7 @@ module attributes {} {
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     %1 = "ttnn.empty"(%0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <<2x4>>, <interleaved>>, shape = #ttnn.shape<64x128>}> : (!ttnn.device) -> tensor<64x128xf32, #ttnn_layout>
     %2 = "ttnn.add"(%arg0, %arg1, %1) : (tensor<64x128xf32, #ttnn_layout>, tensor<64x128xf32, #ttnn_layout>, tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout>
-    // CHECK: error: 'ttnn.add' op Operation ttnn.add must have exactly 2 operands.
+    // CHECK: error: 'ttnn.add' op expected 2 operands, but found 3
     return %2 : tensor<64x128xf32, #ttnn_layout>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/ternary/ternary_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/ternary/ternary_tests_negative.mlir
@@ -7,7 +7,7 @@ module attributes {} {
     %1 = "ttnn.empty"(%0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <<2x4>>, <interleaved>>, shape = #ttnn.shape<64x128>}> : (!ttnn.device) -> tensor<64x128xf32, #ttnn_layout>
     %2 = "ttnn.empty"(%0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <<2x4>>, <interleaved>>, shape = #ttnn.shape<64x128>}> : (!ttnn.device) -> tensor<64x128xf32, #ttnn_layout>
     %3 = "ttnn.where"(%arg0, %arg1, %1, %2) : (tensor<64x128xf32, #ttnn_layout>, tensor<64x128xf32, #ttnn_layout>, tensor<64x128xf32, #ttnn_layout>, tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout>
-    // CHECK: error: 'ttnn.where' op Operation ttnn.where must have exactly 3 operands.
+    // CHECK: error: 'ttnn.where' op expected 3 operands, but found 4
     return %2 : tensor<64x128xf32, #ttnn_layout>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/unary/unary_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/unary/unary_tests_negative.mlir
@@ -6,7 +6,7 @@ module attributes {} {
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     %1 = "ttnn.empty"(%0) <{dtype = #tt.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <<2x4>>, <interleaved>>, shape = #ttnn.shape<64x128>}> : (!ttnn.device) -> tensor<64x128xf32, #ttnn_layout>
     %2 = "ttnn.relu"(%arg0, %arg1, %1) : (tensor<64x128xf32, #ttnn_layout>, tensor<64x128xf32, #ttnn_layout>, tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout>
-    // CHECK: error: 'ttnn.relu' op Operation ttnn.relu must have exactly 1 operands.
+    // CHECK: error: 'ttnn.relu' op requires a single operand
     return %2 : tensor<64x128xf32, #ttnn_layout>
   }
 }

--- a/test/unittests/Optimizer/TestGreedyL1InterleavedPolicy.cpp
+++ b/test/unittests/Optimizer/TestGreedyL1InterleavedPolicy.cpp
@@ -136,7 +136,7 @@ TEST_F(GreedyL1InterleavedPolicyBase, VerifyGreedyPolicy) {
   mlir::Value lhs = func.getBody().getBlocks().front().getArgument(0);
   mlir::Value rhs = func.getBody().getBlocks().front().getArgument(1);
   mlir::Operation *opA =
-      builder.create<AddOp>(builder.getUnknownLoc(), lhs, rhs, lhs.getType());
+      builder.create<AddOp>(builder.getUnknownLoc(), lhs.getType(), lhs, rhs);
   uint64_t outputL1Usage = 2;
   uint64_t requiredL1Usage = 8;
   prepareOpForGreedyConfigPicker(opA, outputL1Usage, requiredL1Usage,
@@ -146,7 +146,7 @@ TEST_F(GreedyL1InterleavedPolicyBase, VerifyGreedyPolicy) {
   lhs = func.getBody().getBlocks().front().getArgument(0);
   rhs = func.getBody().getBlocks().front().getArgument(1);
   mlir::Operation *opB =
-      builder.create<AddOp>(builder.getUnknownLoc(), lhs, rhs, lhs.getType());
+      builder.create<AddOp>(builder.getUnknownLoc(), lhs.getType(), lhs, rhs);
   outputL1Usage = 3;
   requiredL1Usage = 7;
   prepareOpForGreedyConfigPicker(opB, outputL1Usage, requiredL1Usage,
@@ -156,7 +156,7 @@ TEST_F(GreedyL1InterleavedPolicyBase, VerifyGreedyPolicy) {
   lhs = func.getBody().getBlocks().front().getArgument(0);
   rhs = func.getBody().getBlocks().front().getArgument(1);
   mlir::Operation *opC =
-      builder.create<AddOp>(builder.getUnknownLoc(), lhs, rhs, lhs.getType());
+      builder.create<AddOp>(builder.getUnknownLoc(), lhs.getType(), lhs, rhs);
   outputL1Usage = 1;
   requiredL1Usage = 9;
   prepareOpForGreedyConfigPicker(opC, outputL1Usage, requiredL1Usage,
@@ -166,7 +166,7 @@ TEST_F(GreedyL1InterleavedPolicyBase, VerifyGreedyPolicy) {
   lhs = func.getBody().getBlocks().front().getArgument(0);
   rhs = func.getBody().getBlocks().front().getArgument(1);
   mlir::Operation *opD =
-      builder.create<AddOp>(builder.getUnknownLoc(), lhs, rhs, lhs.getType());
+      builder.create<AddOp>(builder.getUnknownLoc(), lhs.getType(), lhs, rhs);
   outputL1Usage = 4;
   requiredL1Usage = 0;
   prepareOpForGreedyConfigPicker(opD, outputL1Usage, requiredL1Usage,

--- a/test/unittests/Optimizer/TestShardSolver.cpp
+++ b/test/unittests/Optimizer/TestShardSolver.cpp
@@ -156,7 +156,7 @@ TEST_F(ShardSolverBase, VerifyProduceMaxCoreUsage) {
   mlir::Value lhs = func.getBody().getBlocks().front().getArgument(0);
   mlir::Value rhs = func.getBody().getBlocks().front().getArgument(1);
   mlir::Operation *op =
-      builder.create<AddOp>(builder.getUnknownLoc(), lhs, rhs, lhs.getType());
+      builder.create<AddOp>(builder.getUnknownLoc(), lhs.getType(), lhs, rhs);
   mlir::Operation *firstOp = op;
 
   prepareOpForShardSolver(op, opL1MemSpecs, l1ChainedOps);
@@ -168,7 +168,7 @@ TEST_F(ShardSolverBase, VerifyProduceMaxCoreUsage) {
                  TensorMemoryLayout::BlockSharded, 2, 2);
 
   rhs = op->getResult(0);
-  op = builder.create<ReluOp>(builder.getUnknownLoc(), rhs);
+  op = builder.create<ReluOp>(builder.getUnknownLoc(), rhs.getType(), rhs);
   prepareOpForShardSolver(op, opL1MemSpecs, l1ChainedOps);
   addConfigForOp(op, legalConfigs, BufferType::L1,
                  TensorMemoryLayout::WidthSharded, 1, 8);
@@ -180,7 +180,7 @@ TEST_F(ShardSolverBase, VerifyProduceMaxCoreUsage) {
   lhs = func.getBody().getBlocks().front().getArgument(0);
   rhs = op->getResult(0);
 
-  op = builder.create<AddOp>(builder.getUnknownLoc(), lhs, rhs, lhs.getType());
+  op = builder.create<AddOp>(builder.getUnknownLoc(), lhs.getType(), lhs, rhs);
   prepareOpForShardSolver(op, opL1MemSpecs, l1ChainedOps);
   addConfigForOp(op, legalConfigs, BufferType::L1,
                  TensorMemoryLayout::WidthSharded, 1, 4);
@@ -189,7 +189,7 @@ TEST_F(ShardSolverBase, VerifyProduceMaxCoreUsage) {
   addConfigForOp(op, legalConfigs, BufferType::L1,
                  TensorMemoryLayout::BlockSharded, 1, 1);
 
-  op = builder.create<AddOp>(builder.getUnknownLoc(), lhs, rhs, lhs.getType());
+  op = builder.create<AddOp>(builder.getUnknownLoc(), lhs.getType(), lhs, rhs);
   prepareOpForShardSolver(op, opL1MemSpecs, l1ChainedOps);
   addConfigForOp(op, legalConfigs, BufferType::L1,
                  TensorMemoryLayout::WidthSharded, 1, 4);
@@ -200,7 +200,7 @@ TEST_F(ShardSolverBase, VerifyProduceMaxCoreUsage) {
 
   lhs = opL1MemSpecs[opL1MemSpecs.size() - 2].op->getResult(0);
   rhs = opL1MemSpecs[opL1MemSpecs.size() - 1].op->getResult(0);
-  op = builder.create<AddOp>(builder.getUnknownLoc(), lhs, rhs, lhs.getType());
+  op = builder.create<AddOp>(builder.getUnknownLoc(), lhs.getType(), lhs, rhs);
   prepareOpForShardSolver(op, opL1MemSpecs, l1ChainedOps);
   addConfigForOp(op, legalConfigs, BufferType::L1,
                  TensorMemoryLayout::WidthSharded, 1, 2);
@@ -210,7 +210,7 @@ TEST_F(ShardSolverBase, VerifyProduceMaxCoreUsage) {
                  TensorMemoryLayout::BlockSharded, 1, 1);
 
   rhs = op->getResult(0);
-  op = builder.create<ReluOp>(builder.getUnknownLoc(), rhs);
+  op = builder.create<ReluOp>(builder.getUnknownLoc(), rhs.getType(), rhs);
   prepareOpForShardSolver(op, opL1MemSpecs, l1ChainedOps);
   addConfigForOp(op, legalConfigs, BufferType::L1,
                  TensorMemoryLayout::WidthSharded, 1, 2);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/2815

### Problem description
All TTNN eltwise ops regardless of arity have this signature
```mlir
class TTNN_ElementwiseOp<string mnemonic, list<Trait> traits = []> :
    TTNN_Op<mnemonic, traits> {

    let arguments = (ins Variadic<AnyRankedTensor>:$inputs);
    let results = (outs Variadic<AnyRankedTensor>:$results);
}
```
This comes with all the pros and cons of such a generic signature. The main argument of having a separate signature for different arity is that arity is bounded below by 1 and bounded above by 3 (inclusive), so the cons easily outweigh the pros in this case.

### What's changed
All eltwise classes (defined by arity) now have separate signatures
```mlir
class TTNN_ElementwiseUnaryOp<string mnemonic, list<Trait> traits = []> :
    TTNN_Op<mnemonic, traits> {
    let summary = "Eltwise unary op.";
    let description = [{
      Eltwise unary op.
    }];

    let arguments = (ins AnyRankedTensor:$input);
    let results = (outs AnyRankedTensor:$result);
}

class TTNN_ElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
    TTNN_Op<mnemonic, traits> {
    let summary = "Eltwise binary op.";
    let description = [{
      Eltwise binary op.
    }];

    let arguments = (ins AnyRankedTensor:$lhs,
                         AnyRankedTensor:$rhs);
    let results = (outs AnyRankedTensor:$result);
}

class TTNN_ElementwiseTernaryOp<string mnemonic, list<Trait> traits = []> :
    TTNN_Op<mnemonic, traits> {
    let summary = "Eltwise ternary op.";
    let description = [{
      Eltwise ternary op.
    }];

    let arguments = (ins AnyRankedTensor:$first,
                         AnyRankedTensor:$second,
                         AnyRankedTensor:$third);
    let results = (outs AnyRankedTensor:$result);
}
```
This PR is limited to changes in the TTNN dialect.

### Checklist
- [x] New/Existing tests provide coverage for changes
