### PR TITLE
Enable pre-op and post-op hooks at the same time

### DIFF
--- a/runtime/include/tt/runtime/detail/debug.h
+++ b/runtime/include/tt/runtime/detail/debug.h
@@ -44,6 +44,7 @@ inline std::ostream &operator<<(std::ostream &os, Env const &env) {
 
 struct Hooks {
 #if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
+  static std::unordered_map<std::string, Hooks> config;
   static Hooks const &
   get(std::optional<std::string> callbackKey = std::nullopt,
       std::optional<std::function<void(Binary, CallbackContext, OpContext)>>
@@ -69,15 +70,16 @@ struct Hooks {
 #endif
   }
 
-  void unregisterHooks() const {
+  static void unregisterHooks() {
 #if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
-    callbackKey = std::nullopt;
-    operatorCallback = std::nullopt;
+    config.clear();
 #endif
   }
 
 private:
 #if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
+  Hooks() : callbackKey(std::nullopt), operatorCallback(std::nullopt) {}
+  
   Hooks(std::optional<std::string> callbackKey,
         std::optional<std::function<void(Binary, CallbackContext, OpContext)>>
             operatorCallback)

--- a/runtime/include/tt/runtime/detail/debug.h
+++ b/runtime/include/tt/runtime/detail/debug.h
@@ -79,7 +79,7 @@ struct Hooks {
 private:
 #if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
   Hooks() : callbackKey(std::nullopt), operatorCallback(std::nullopt) {}
-  
+
   Hooks(std::optional<std::string> callbackKey,
         std::optional<std::function<void(Binary, CallbackContext, OpContext)>>
             operatorCallback)

--- a/runtime/lib/common/debug.cpp
+++ b/runtime/lib/common/debug.cpp
@@ -26,21 +26,22 @@ Hooks const &Hooks::get(
     throw std::runtime_error("callbackKey must be 'post-op' or 'pre-op', got " +
                              callbackKey.value());
   }
-  
+
   if (!callbackKey) {
     static Hooks defaultHooks{};
     return defaultHooks;
   }
-  
+
   if (config.contains(callbackKey.value())) {
     return config.at(callbackKey.value());
   }
-  
+
   if (!operatorCallback) {
     throw std::runtime_error("operatorCallback must be provided");
   }
-  
-  config.insert({callbackKey.value(), Hooks(callbackKey, operatorCallback.value())});
+
+  config.insert(
+      {callbackKey.value(), Hooks(callbackKey, operatorCallback.value())});
   return config.at(callbackKey.value());
 }
 

--- a/runtime/lib/ttnn/program.cpp
+++ b/runtime/lib/ttnn/program.cpp
@@ -142,8 +142,8 @@ void ProgramExecutor::runCallback(
     std::string callbackKey, Binary &executableHandle,
     const ::tt::target::ttnn::Operation *opContext,
     ProgramContext *programContext) {
-  if (auto callback = debug::Hooks::get().getOperatorCallback();
-      callback and debug::Hooks::get().getCallbackKey() == callbackKey) {
+  if (auto callback = debug::Hooks::get(callbackKey).getOperatorCallback();
+      callback) {
     std::shared_ptr<void> programContextPtr =
         ::tt::runtime::utils::unsafe_borrow_shared(programContext);
     std::shared_ptr<void> opContextPtr =

--- a/runtime/tools/python/ttrt/runtime/module.cpp
+++ b/runtime/tools/python/ttrt/runtime/module.cpp
@@ -341,9 +341,9 @@ PYBIND11_MODULE(_C, m) {
    * Cleanup code to force a well ordered destruction w.r.t. the GIL
    */
   auto cleanup_callback = []() {
-    ::tt::runtime::debug::Hooks::get().unregisterHooks();
+    ::tt::runtime::debug::Hooks::unregisterHooks();
   };
   m.add_object("_cleanup", py::capsule(cleanup_callback));
   m.def("unregister_hooks",
-        []() { ::tt::runtime::debug::Hooks::get().unregisterHooks(); });
+        []() { ::tt::runtime::debug::Hooks::unregisterHooks(); });
 }


### PR DESCRIPTION
### Ticket
#2594

### Problem description
Currently, pre-op and post-op are mutually exclusive.

### What's changed
Added ability to have both pre-op and post-op hooks at the same time


