### PR TITLE
Disable f32 by default

### DIFF
--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -424,7 +424,7 @@ def ElementTypeNormalization: Pass<"ttir-element-type-normalization", "::mlir::M
   let options = [
     Option<"enableFP32", "enable-fp32",
           "bool",
-          /*default=*/"true",
+          /*default=*/"false",
           "Enables fp32 type.">
   ];
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -82,6 +82,8 @@ def TTNN_TypecastOp : TTNN_Op<"typecast",
     let arguments = (ins AnyRankedTensor:$input,
                          TT_DataTypeAttr:$dtype);
     let results = (outs AnyRankedTensor:$result);
+
+    let hasVerifier = 1;
 }
 
 def TTNN_ToDTypeOp : TTNN_Op<"to_dtype"> {

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -177,7 +177,7 @@ struct TTIRToTTNNBackendPipelineOptions
 
   Option<bool> enableFP32{*this, "enable-fp32",
                           llvm::cl::desc("Enable fp32 type."),
-                          llvm::cl::init(true)};
+                          llvm::cl::init(false)};
 };
 
 // TTIR to EmitC pipeline options.

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -1221,6 +1221,21 @@ void mlir::tt::ttnn::ToLayoutOp::getCanonicalizationPatterns(
 }
 
 //===----------------------------------------------------------------------===//
+// TypecastOp
+//===----------------------------------------------------------------------===//
+
+::mlir::LogicalResult mlir::tt::ttnn::TypecastOp::verify() {
+  const DataType dtype = getDtype();
+  Type outputElTy = getResult().getType().getElementType();
+  if (dtype != elementTypeToDataType(outputElTy)) {
+    return emitOpError(
+        "Data type between dtype attribute and output element type.");
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // LinearOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/Transforms/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/Optimizer.cpp
@@ -273,7 +273,10 @@ public:
         //
         if (opConfigAnalysis.getResult().contains(op)) {
           RankedTensorType newTensorType = RankedTensorType::get(
-              tensorShape, tensorType.getElementType(),
+              tensorShape,
+              opConfigAnalysis.getResult()
+                  .at(op)
+                  .outputLayout.getScalarElementType(),
               opConfigAnalysis.getResult().at(op).outputLayout);
 
           // Update the memory space and layout of the op.
@@ -466,7 +469,7 @@ private:
       // layout and other inputs.
       //
       RankedTensorType newTensorType = RankedTensorType::get(
-          producerOpTensorShape, producerOpTensorType.getElementType(),
+          producerOpTensorShape, consumerOpOutputLayout.getScalarElementType(),
           producerOpLayout
               .withElementType(consumerOp->getContext(),
                                consumerOpOutputLayout.getElementType(),

--- a/test/ttmlir/Dialect/TTNN/constant/positive/simple_constant.mlir
+++ b/test/ttmlir/Dialect/TTNN/constant/positive/simple_constant.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-fp32=true" %s | FileCheck %s
 module attributes {} {
   func.func @test_empty_int8() -> tensor<64x128xi8> {
     %0 = "ttir.constant"() <{value = dense<0> : tensor<64x128xi8>}> : () -> tensor<64x128xi8>

--- a/test/ttmlir/Dialect/TTNN/convolution/simple_conv1d.mlir
+++ b/test/ttmlir/Dialect/TTNN/convolution/simple_conv1d.mlir
@@ -1,7 +1,7 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module {
-  func.func @conv1d_test1(%arg0: tensor<1x256x512xf32>, %arg1: tensor<1024x256x1xf32>, %arg2: tensor<1024xf32>) -> tensor<1x1024x512xf32> {
-    %0 = ttir.empty() : tensor<1x1024x512xf32>
+  func.func @conv1d_test1(%arg0: tensor<1x256x512xbf16>, %arg1: tensor<1024x256x1xbf16>, %arg2: tensor<1024xbf16>) -> tensor<1x1024x512xbf16> {
+    %0 = ttir.empty() : tensor<1x1024x512xbf16>
     // CHECK: "ttnn.reshape"
     // CHECK-SAME: shape = [1 : i32, 256 : i32, 512 : i32, 1 : i32]
     // CHECK: "ttnn.reshape"
@@ -13,9 +13,9 @@ module {
     // CHECK-SAME: permutation = array<i64: 0, 3, 1, 2>
     // CHECK: "ttnn.reshape"
     // CHECK-SAME: shape = [1 : i32, 1024 : i32, 512 : i32]
-    %1 = "ttir.convolution"(%arg0, %arg1, %0) <{batch_group_count = 1 : i64, convolution_layout = #ttir<convolution_layout input_batch = 0, input_feature = 1, input_spatial_dimensions = 2, kernel_output_feature = 0, kernel_input_feature = 1, kernel_spatial_dimensions = 2, output_batch = 0, output_feature = 1, output_spatial_dimensions = 2>, feature_group_count = 1 : i64, input_dilation = array<i64: 1>, padding = array<i64: 0, 0>, weight_dilation = array<i64: 1>, window_reversal = array<i1: false>, window_strides = array<i64: 1>}> : (tensor<1x256x512xf32>, tensor<1024x256x1xf32>, tensor<1x1024x512xf32>) -> tensor<1x1024x512xf32>
-    // CHECK: return %{{.*}} : tensor<1x1024x512xf32, #ttnn_layout3>
-    return %1 : tensor<1x1024x512xf32>
+    %1 = "ttir.convolution"(%arg0, %arg1, %0) <{batch_group_count = 1 : i64, convolution_layout = #ttir<convolution_layout input_batch = 0, input_feature = 1, input_spatial_dimensions = 2, kernel_output_feature = 0, kernel_input_feature = 1, kernel_spatial_dimensions = 2, output_batch = 0, output_feature = 1, output_spatial_dimensions = 2>, feature_group_count = 1 : i64, input_dilation = array<i64: 1>, padding = array<i64: 0, 0>, weight_dilation = array<i64: 1>, window_reversal = array<i1: false>, window_strides = array<i64: 1>}> : (tensor<1x256x512xbf16>, tensor<1024x256x1xbf16>, tensor<1x1024x512xbf16>) -> tensor<1x1024x512xbf16>
+    // CHECK: return %{{.*}} : tensor<1x1024x512xbf16, #ttnn_layout3>
+    return %1 : tensor<1x1024x512xbf16>
   }
 
   // Test a different ordering of dimensions

--- a/test/ttmlir/Dialect/TTNN/data_movement/permute/permute_tests_positive.mlir
+++ b/test/ttmlir/Dialect/TTNN/data_movement/permute/permute_tests_positive.mlir
@@ -1,12 +1,12 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module {
-  func.func @permute_general(%arg0: tensor<8x32x64x128xf32>) -> tensor<64x8x128x32xf32> {
-    %0 = ttir.empty() : tensor<64x8x128x32xf32>
+  func.func @permute_general(%arg0: tensor<8x32x64x128xbf16>) -> tensor<64x8x128x32xbf16> {
+    %0 = ttir.empty() : tensor<64x8x128x32xbf16>
     // CHECK: "ttnn.permute"
     // CHECK-SAME: permutation = array<i64: 2, 0, 3, 1>
-    // CHECK-SAME: tensor<8x32x64x128xf32
-    // CHECK-SAME: tensor<64x8x128x32xf32
-    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 2, 0, 3, 1>}> : (tensor<8x32x64x128xf32>, tensor<64x8x128x32xf32>) -> tensor<64x8x128x32xf32>
-    return %1 : tensor<64x8x128x32xf32>
+    // CHECK-SAME: tensor<8x32x64x128xbf16
+    // CHECK-SAME: tensor<64x8x128x32xbf16
+    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 2, 0, 3, 1>}> : (tensor<8x32x64x128xbf16>, tensor<64x8x128x32xbf16>) -> tensor<64x8x128x32xbf16>
+    return %1 : tensor<64x8x128x32xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/data_movement/permute/simple_permute.mlir
+++ b/test/ttmlir/Dialect/TTNN/data_movement/permute/simple_permute.mlir
@@ -1,12 +1,12 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module {
-  func.func @permute(%arg0: tensor<1x4x32x64xf32>) -> tensor<4x32x64x1xf32> {
-    %0 = ttir.empty() : tensor<4x32x64x1xf32>
+  func.func @permute(%arg0: tensor<1x4x32x64xbf16>) -> tensor<4x32x64x1xbf16> {
+    %0 = ttir.empty() : tensor<4x32x64x1xbf16>
     // CHECK: "ttnn.permute"
     // CHECK-SAME: permutation = array<i64: 1, 2, 3, 0>
-    // CHECK-SAME: tensor<1x4x32x64xf32
-    // CHECK-SAME: tensor<4x32x64x1xf32
-    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 1, 2, 3, 0>}> : (tensor<1x4x32x64xf32>, tensor<4x32x64x1xf32>) -> tensor<4x32x64x1xf32>
-    return %1 : tensor<4x32x64x1xf32>
+    // CHECK-SAME: tensor<1x4x32x64xbf16
+    // CHECK-SAME: tensor<4x32x64x1xbf16
+    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 1, 2, 3, 0>}> : (tensor<1x4x32x64xbf16>, tensor<4x32x64x1xbf16>) -> tensor<4x32x64x1xbf16>
+    return %1 : tensor<4x32x64x1xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/binary/atan2/simple_atan2.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/binary/atan2/simple_atan2.mlir
@@ -1,12 +1,12 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @atan2(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x32xf32> {
-    %0 = ttir.empty() : tensor<32x32xf32>
-    %1 = "ttir.atan2"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+  func.func @atan2(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>) -> tensor<32x32xbf16> {
+    %0 = ttir.empty() : tensor<32x32xbf16>
+    %1 = "ttir.atan2"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
     // CHECK: "ttnn.atan2"
-    // CHECK-SAME: tensor<32x32xf32
-    // CHECK-SAME: tensor<32x32xf32
-    // CHECK-SAME: -> tensor<32x32xf32
-    return %1 : tensor<32x32xf32>
+    // CHECK-SAME: tensor<32x32xbf16
+    // CHECK-SAME: tensor<32x32xbf16
+    // CHECK-SAME: -> tensor<32x32xbf16
+    return %1 : tensor<32x32xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/binary/compare/simple_compare.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/binary/compare/simple_compare.mlir
@@ -1,82 +1,82 @@
 // RUN: ttmlir-opt --split-input-file --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @equal(%arg0: tensor<13x31xf32>, %arg1: tensor<13x31xf32>) -> tensor<13x31xf32> {
-    %0 = ttir.empty() : tensor<13x31xf32>
-    %1 = "ttir.eq"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x31xf32>, tensor<13x31xf32>, tensor<13x31xf32>) -> tensor<13x31xf32>
+  func.func @equal(%arg0: tensor<13x31xbf16>, %arg1: tensor<13x31xbf16>) -> tensor<13x31xbf16> {
+    %0 = ttir.empty() : tensor<13x31xbf16>
+    %1 = "ttir.eq"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x31xbf16>, tensor<13x31xbf16>, tensor<13x31xbf16>) -> tensor<13x31xbf16>
     // CHECK: "ttnn.eq"
-    // CHECK-SAME: tensor<13x31xf32
-    // CHECK-SAME: tensor<13x31xf32
-    // CHECK-SAME: -> tensor<13x31xf32
-    return %1 : tensor<13x31xf32>
+    // CHECK-SAME: tensor<13x31xbf16
+    // CHECK-SAME: tensor<13x31xbf16
+    // CHECK-SAME: -> tensor<13x31xbf16
+    return %1 : tensor<13x31xbf16>
   }
 }
 
 // -----
 
 module attributes {} {
-  func.func @not_equal(%arg0: tensor<13x31xf32>, %arg1: tensor<13x31xf32>) -> tensor<13x31xf32> {
-    %0 = ttir.empty() : tensor<13x31xf32>
-    %1 = "ttir.ne"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x31xf32>, tensor<13x31xf32>, tensor<13x31xf32>) -> tensor<13x31xf32>
+  func.func @not_equal(%arg0: tensor<13x31xbf16>, %arg1: tensor<13x31xbf16>) -> tensor<13x31xbf16> {
+    %0 = ttir.empty() : tensor<13x31xbf16>
+    %1 = "ttir.ne"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x31xbf16>, tensor<13x31xbf16>, tensor<13x31xbf16>) -> tensor<13x31xbf16>
     // CHECK: "ttnn.ne"
-    // CHECK-SAME: tensor<13x31xf32
-    // CHECK-SAME: tensor<13x31xf32
-    // CHECK-SAME: -> tensor<13x31xf32
-    return %1 : tensor<13x31xf32>
+    // CHECK-SAME: tensor<13x31xbf16
+    // CHECK-SAME: tensor<13x31xbf16
+    // CHECK-SAME: -> tensor<13x31xbf16
+    return %1 : tensor<13x31xbf16>
   }
 }
 
 // -----
 
 module attributes {} {
-  func.func @greater_equal(%arg0: tensor<13x31xf32>, %arg1: tensor<13x31xf32>) -> tensor<13x31xf32> {
-    %0 = ttir.empty() : tensor<13x31xf32>
-    %1 = "ttir.ge"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x31xf32>, tensor<13x31xf32>, tensor<13x31xf32>) -> tensor<13x31xf32>
+  func.func @greater_equal(%arg0: tensor<13x31xbf16>, %arg1: tensor<13x31xbf16>) -> tensor<13x31xbf16> {
+    %0 = ttir.empty() : tensor<13x31xbf16>
+    %1 = "ttir.ge"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x31xbf16>, tensor<13x31xbf16>, tensor<13x31xbf16>) -> tensor<13x31xbf16>
     // CHECK: "ttnn.ge"
-    // CHECK-SAME: tensor<13x31xf32
-    // CHECK-SAME: tensor<13x31xf32
-    // CHECK-SAME: -> tensor<13x31xf32
-    return %1 : tensor<13x31xf32>
+    // CHECK-SAME: tensor<13x31xbf16
+    // CHECK-SAME: tensor<13x31xbf16
+    // CHECK-SAME: -> tensor<13x31xbf16
+    return %1 : tensor<13x31xbf16>
   }
 }
 
 // -----
 
 module attributes {} {
-  func.func @greater_than(%arg0: tensor<13x31xf32>, %arg1: tensor<13x31xf32>) -> tensor<13x31xf32> {
-    %0 = ttir.empty() : tensor<13x31xf32>
-    %1 = "ttir.gt"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x31xf32>, tensor<13x31xf32>, tensor<13x31xf32>) -> tensor<13x31xf32>
+  func.func @greater_than(%arg0: tensor<13x31xbf16>, %arg1: tensor<13x31xbf16>) -> tensor<13x31xbf16> {
+    %0 = ttir.empty() : tensor<13x31xbf16>
+    %1 = "ttir.gt"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x31xbf16>, tensor<13x31xbf16>, tensor<13x31xbf16>) -> tensor<13x31xbf16>
     // CHECK: "ttnn.gt"
-    // CHECK-SAME: tensor<13x31xf32
-    // CHECK-SAME: tensor<13x31xf32
-    // CHECK-SAME: -> tensor<13x31xf32
-    return %1 : tensor<13x31xf32>
+    // CHECK-SAME: tensor<13x31xbf16
+    // CHECK-SAME: tensor<13x31xbf16
+    // CHECK-SAME: -> tensor<13x31xbf16
+    return %1 : tensor<13x31xbf16>
   }
 }
 
 // -----
 
 module attributes {} {
-  func.func @less_equal(%arg0: tensor<13x31xf32>, %arg1: tensor<13x31xf32>) -> tensor<13x31xf32> {
-    %0 = ttir.empty() : tensor<13x31xf32>
-    %1 = "ttir.le"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x31xf32>, tensor<13x31xf32>, tensor<13x31xf32>) -> tensor<13x31xf32>
+  func.func @less_equal(%arg0: tensor<13x31xbf16>, %arg1: tensor<13x31xbf16>) -> tensor<13x31xbf16> {
+    %0 = ttir.empty() : tensor<13x31xbf16>
+    %1 = "ttir.le"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x31xbf16>, tensor<13x31xbf16>, tensor<13x31xbf16>) -> tensor<13x31xbf16>
     // CHECK: "ttnn.le"
-    // CHECK-SAME: tensor<13x31xf32
-    // CHECK-SAME: tensor<13x31xf32
-    // CHECK-SAME: -> tensor<13x31xf32
-    return %1 : tensor<13x31xf32>
+    // CHECK-SAME: tensor<13x31xbf16
+    // CHECK-SAME: tensor<13x31xbf16
+    // CHECK-SAME: -> tensor<13x31xbf16
+    return %1 : tensor<13x31xbf16>
   }
 }
 
 // -----
 
 module attributes {} {
-  func.func @less_than(%arg0: tensor<13x31xf32>, %arg1: tensor<13x31xf32>) -> tensor<13x31xf32> {
-    %0 = ttir.empty() : tensor<13x31xf32>
-    %1 = "ttir.lt"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x31xf32>, tensor<13x31xf32>, tensor<13x31xf32>) -> tensor<13x31xf32>
+  func.func @less_than(%arg0: tensor<13x31xbf16>, %arg1: tensor<13x31xbf16>) -> tensor<13x31xbf16> {
+    %0 = ttir.empty() : tensor<13x31xbf16>
+    %1 = "ttir.lt"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x31xbf16>, tensor<13x31xbf16>, tensor<13x31xbf16>) -> tensor<13x31xbf16>
     // CHECK: "ttnn.lt"
-    // CHECK-SAME: tensor<13x31xf32
-    // CHECK-SAME: tensor<13x31xf32
-    // CHECK-SAME: -> tensor<13x31xf32
-    return %1 : tensor<13x31xf32>
+    // CHECK-SAME: tensor<13x31xbf16
+    // CHECK-SAME: tensor<13x31xbf16
+    // CHECK-SAME: -> tensor<13x31xbf16
+    return %1 : tensor<13x31xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/binary/divide/simple_divide.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/binary/divide/simple_divide.mlir
@@ -1,12 +1,12 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @forward(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.div"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @forward(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.div"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.divide"
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/binary/logical_and/simple_and.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/binary/logical_and/simple_and.mlir
@@ -1,12 +1,12 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @logical_and(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.logical_and"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @logical_and(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.logical_and"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.logical_and"
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/binary/logical_or/simple_or.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/binary/logical_or/simple_or.mlir
@@ -1,12 +1,12 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @logical_or(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.logical_or"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @logical_or(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.logical_or"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.logical_or"
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/binary/maximum/simple_maximum.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/binary/maximum/simple_maximum.mlir
@@ -1,12 +1,12 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @forward(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.maximum"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @forward(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.maximum"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.maximum"
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/binary/minimum/simple_minimum.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/binary/minimum/simple_minimum.mlir
@@ -1,12 +1,12 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @forward(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.minimum"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @forward(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.minimum"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.minimum"
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/binary/multiply/simple_multiply.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/binary/multiply/simple_multiply.mlir
@@ -1,12 +1,12 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @forward(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.multiply"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @forward(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.multiply"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.multiply"
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/binary/pow/simple_pow.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/binary/pow/simple_pow.mlir
@@ -1,12 +1,12 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @pow(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.pow"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @pow(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.pow"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.pow"
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/binary/remainder/simple_remainder.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/binary/remainder/simple_remainder.mlir
@@ -1,12 +1,12 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @remainder(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x32xf32> {
-    %0 = ttir.empty() : tensor<32x32xf32>
-    %1 = "ttir.remainder"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+  func.func @remainder(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>) -> tensor<32x32xbf16> {
+    %0 = ttir.empty() : tensor<32x32xbf16>
+    %1 = "ttir.remainder"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
     // CHECK: "ttnn.remainder"
-    // CHECK-SAME: tensor<32x32xf32
-    // CHECK-SAME: tensor<32x32xf32
-    // CHECK-SAME: -> tensor<32x32xf32
-    return %1 : tensor<32x32xf32>
+    // CHECK-SAME: tensor<32x32xbf16
+    // CHECK-SAME: tensor<32x32xbf16
+    // CHECK-SAME: -> tensor<32x32xbf16
+    return %1 : tensor<32x32xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/binary/subtract/simple_subtract.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/binary/subtract/simple_subtract.mlir
@@ -1,30 +1,30 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @forward(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.subtract"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @forward(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.subtract"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.subtract"
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 
-  func.func @subtract_with_neg_and_add_1(%arg0: tensor<64x128xf32>, %arg1: tensor<1x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
+  func.func @subtract_with_neg_and_add_1(%arg0: tensor<64x128xbf16>, %arg1: tensor<1x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
     // CHECK: = "ttnn.neg"
     // CHECK: = "ttnn.add"
     // CHECK-NOT: = "ttnn.subtract"
-    %1 = "ttir.subtract"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<1x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
-    return %1 : tensor<64x128xf32>
+    %1 = "ttir.subtract"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xbf16>, tensor<1x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+    return %1 : tensor<64x128xbf16>
   }
 
-  func.func @subtract_with_neg_and_add_2(%arg0: tensor<1x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-     %0 = ttir.empty() : tensor<64x128xf32>
+  func.func @subtract_with_neg_and_add_2(%arg0: tensor<1x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+     %0 = ttir.empty() : tensor<64x128xbf16>
     // CHECK: = "ttnn.neg"
     // CHECK: = "ttnn.add"
     // CHECK-NOT: = "ttnn.subtract"
-    %1 = "ttir.subtract"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
-    return %1 : tensor<64x128xf32>
+    %1 = "ttir.subtract"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+    return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/ternary/where/simple_where.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/ternary/where/simple_where.mlir
@@ -1,19 +1,19 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module @jit_eltwise_where {
-  func.func public @test_where(%arg0: tensor<13x37xf32>, %arg1: tensor<13x37xf32>) -> tensor<13x37xf32> {
-    %0 = ttir.empty() : tensor<13x37xf32>
-    %1 = "ttir.eq"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x37xf32>, tensor<13x37xf32>, tensor<13x37xf32>) -> tensor<13x37xf32>
-    %2 = ttir.empty() : tensor<13x37xf32>
-    %3 = "ttir.where"(%1, %arg0, %arg1, %2) <{operandSegmentSizes = array<i32: 3, 1>}> : (tensor<13x37xf32>, tensor<13x37xf32>, tensor<13x37xf32>, tensor<13x37xf32>) -> tensor<13x37xf32>
+  func.func public @test_where(%arg0: tensor<13x37xbf16>, %arg1: tensor<13x37xbf16>) -> tensor<13x37xbf16> {
+    %0 = ttir.empty() : tensor<13x37xbf16>
+    %1 = "ttir.eq"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x37xbf16>, tensor<13x37xbf16>, tensor<13x37xbf16>) -> tensor<13x37xbf16>
+    %2 = ttir.empty() : tensor<13x37xbf16>
+    %3 = "ttir.where"(%1, %arg0, %arg1, %2) <{operandSegmentSizes = array<i32: 3, 1>}> : (tensor<13x37xbf16>, tensor<13x37xbf16>, tensor<13x37xbf16>, tensor<13x37xbf16>) -> tensor<13x37xbf16>
     // CHECK: "ttnn.eq"
-    // CHECK-SAME: tensor<13x37xf32
-    // CHECK-SAME: tensor<13x37xf32
-    // CHECK-SAME: -> tensor<13x37xf32
+    // CHECK-SAME: tensor<13x37xbf16
+    // CHECK-SAME: tensor<13x37xbf16
+    // CHECK-SAME: -> tensor<13x37xbf16
     // CHECK: "ttnn.where"
-    // CHECK-SAME: tensor<13x37xf32
-    // CHECK-SAME: tensor<13x37xf32
-    // CHECK-SAME: tensor<13x37xf32
-    // CHECK-SAME: -> tensor<13x37xf32
-     return %3 : tensor<13x37xf32>
+    // CHECK-SAME: tensor<13x37xbf16
+    // CHECK-SAME: tensor<13x37xbf16
+    // CHECK-SAME: tensor<13x37xbf16
+    // CHECK-SAME: -> tensor<13x37xbf16
+     return %3 : tensor<13x37xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/unary/abs/simple_abs.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/unary/abs/simple_abs.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @forward(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.abs"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @forward(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.abs"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.abs"
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/unary/atan/simple_atan.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/unary/atan/simple_atan.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @atan(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.atan"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @atan(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.atan"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.atan"
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/unary/cast/simple_cast.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/unary/cast/simple_cast.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-fp32=true" %s | FileCheck %s
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xf32>) -> tensor<64x128xbf16> {
     %0 = ttir.empty() : tensor<64x128xbf16>

--- a/test/ttmlir/Dialect/TTNN/eltwise/unary/cbrt/simple_cbrt.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/unary/cbrt/simple_cbrt.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @forward(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.cbrt"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @forward(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.cbrt"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.cbrt"
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/unary/ceil/simple_ceil.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/unary/ceil/simple_ceil.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @forward(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.ceil"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @forward(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.ceil"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.ceil"
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/unary/cos/simple_cos.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/unary/cos/simple_cos.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @forward(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.cos"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @forward(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.cos"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.cos"
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/unary/expm1/simple_expm1.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/unary/expm1/simple_expm1.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @forward(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.expm1"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @forward(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.expm1"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK:"ttnn.expm1"
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/unary/floor/simple_floor.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/unary/floor/simple_floor.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @floor(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.floor"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @floor(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.floor"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.floor"
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/unary/gelu/simple_gelu.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/unary/gelu/simple_gelu.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @forward(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.gelu"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @forward(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.gelu"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.gelu"
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/unary/leaky_relu/simple_leaky_relu.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/unary/leaky_relu/simple_leaky_relu.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @leaky_relu(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.leaky_relu"(%arg0, %0) <{parameter = 0.01 : f32, operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @leaky_relu(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.leaky_relu"(%arg0, %0) <{parameter = 0.01 : f32, operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.leaky_relu"
-    // CHECK-SAME: (tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: (tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/unary/log1p/simple_log1p.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/unary/log1p/simple_log1p.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @forward(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.log1p"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @forward(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.log1p"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.log1p"
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/unary/logical_not/simple_not.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/unary/logical_not/simple_not.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @logical_not(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.logical_not"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @logical_not(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.logical_not"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.logical_not"
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/unary/negate/simple_neg.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/unary/negate/simple_neg.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @forward(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.neg"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @forward(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.neg"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.neg"
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/unary/reciprocal/simple_reciprocal.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/unary/reciprocal/simple_reciprocal.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @forward(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.reciprocal"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @forward(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.reciprocal"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.reciprocal"
-    // CHECK-SAME: (tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: (tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/unary/relu/simple_relu.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/unary/relu/simple_relu.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @forward(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.relu"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @forward(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.relu"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.relu"
-    // CHECK-SAME: (tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: (tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/unary/rsqrt/simple_rsqrt.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/unary/rsqrt/simple_rsqrt.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @forward(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.rsqrt"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @forward(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.rsqrt"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.rsqrt"
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/unary/sigmoid/simple_sigmoid.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/unary/sigmoid/simple_sigmoid.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @forward(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.sigmoid"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @forward(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.sigmoid"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.sigmoid"
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/unary/sign/simple_sign.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/unary/sign/simple_sign.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @forward(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.sign"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @forward(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.sign"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.sign"
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/unary/sin/simple_sin.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/unary/sin/simple_sin.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @forward(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.sin"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @forward(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.sin"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.sin"
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/unary/sqrt/simple_sqrt.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/unary/sqrt/simple_sqrt.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @forward(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.sqrt"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @forward(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.sqrt"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.sqrt"
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/unary/tan/simple_tan.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/unary/tan/simple_tan.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @forward(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.tan"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @forward(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.tan"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.tan"
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/eltwise/unary/tanh/simple_tanh.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/unary/tanh/simple_tanh.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @forward(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.tanh"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @forward(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.tanh"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.tanh"
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/embedding/gather_to_embedding.mlir
+++ b/test/ttmlir/Dialect/TTNN/embedding/gather_to_embedding.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-fp32=true" %s | FileCheck %s
 module attributes {} {
   func.func @gather_0(%operand: tensor<32000x1024xbf16>, %start_indices: tensor<1x32xi32>) -> tensor<1x32x1024xbf16> {
     %0 = ttir.empty() : tensor<1x32x1024xbf16>

--- a/test/ttmlir/Dialect/TTNN/multiple_func.mlir
+++ b/test/ttmlir/Dialect/TTNN/multiple_func.mlir
@@ -1,17 +1,17 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @main(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = call @do_mult(%arg0, %arg1, %0) : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @main(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = call @do_mult(%arg0, %arg1, %0) : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.multiply"
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 
-  func.func private @do_mult(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>, %arg2: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = "ttir.multiply"(%arg0, %arg1, %arg2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
-    return %0 : tensor<64x128xf32>
+  func.func private @do_mult(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>, %arg2: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = "ttir.multiply"(%arg0, %arg1, %arg2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+    return %0 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/optimizer/greedy_l1_interleaved_policy/mnist_l1_interleaved.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/greedy_l1_interleaved_policy/mnist_l1_interleaved.mlir
@@ -1,27 +1,27 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true memory-layout-analysis-enabled=true memory-layout-analysis-policy=GreedyL1Interleaved" %s | FileCheck %s
 #loc = loc("MNISTLinear":4294967295:0)
 module @"tt-forge-graph" attributes {} {
-  func.func @main(%arg0: tensor<1x784xf32> loc("MNISTLinear":4294967295:0), %arg1: tensor<1x10xf32> loc("MNISTLinear":4294967295:0), %arg2: tensor<256x10xf32> loc("MNISTLinear":4294967295:0), %arg3: tensor<1x256xf32> loc("MNISTLinear":4294967295:0), %arg4: tensor<784x256xf32> loc("MNISTLinear":4294967295:0)) -> tensor<1x10xf32> {
+  func.func @main(%arg0: tensor<1x784xbf16> loc("MNISTLinear":4294967295:0), %arg1: tensor<1x10xbf16> loc("MNISTLinear":4294967295:0), %arg2: tensor<256x10xbf16> loc("MNISTLinear":4294967295:0), %arg3: tensor<1x256xbf16> loc("MNISTLinear":4294967295:0), %arg4: tensor<784x256xbf16> loc("MNISTLinear":4294967295:0)) -> tensor<1x10xbf16> {
     // CHECK: #[[LAYOUT_L1:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <{{.*}}>, memref<{{.*}}, #l1_>, <interleaved>>
-    %0 = ttir.empty() : tensor<1x256xf32> loc(#loc8)
-    // CHECK: %{{.*}} = "ttnn.matmul"{{.*}} -> tensor<1x256xf32, #[[LAYOUT_L1]]>
-    %1 = "ttir.matmul"(%arg0, %arg4, %0) : (tensor<1x784xf32>, tensor<784x256xf32>, tensor<1x256xf32>) -> tensor<1x256xf32> loc(#loc8)
-    %2 = ttir.empty() : tensor<1x256xf32> loc(#loc9)
-    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x256xf32, #[[LAYOUT_L1]]>
-    %3 = "ttir.add"(%1, %arg3, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x256xf32>, tensor<1x256xf32>, tensor<1x256xf32>) -> tensor<1x256xf32> loc(#loc9)
-    %4 = ttir.empty() : tensor<1x256xf32> loc(#loc10)
-    // CHECK: %{{.*}} = "ttnn.relu"{{.*}} -> tensor<1x256xf32, #[[LAYOUT_L1]]>
-    %5 = "ttir.relu"(%3, %4) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x256xf32>, tensor<1x256xf32>) -> tensor<1x256xf32> loc(#loc10)
-    %6 = ttir.empty() : tensor<1x10xf32> loc(#loc11)
-    // CHECK: %{{.*}} = "ttnn.matmul"{{.*}} -> tensor<1x10xf32, #[[LAYOUT_L1]]>
-    %7 = "ttir.matmul"(%5, %arg2, %6) : (tensor<1x256xf32>, tensor<256x10xf32>, tensor<1x10xf32>) -> tensor<1x10xf32> loc(#loc11)
-    %8 = ttir.empty() : tensor<1x10xf32> loc(#loc12)
-    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x10xf32, #[[LAYOUT_L1]]>
-    %9 = "ttir.add"(%7, %arg1, %8) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x10xf32>, tensor<1x10xf32>, tensor<1x10xf32>) -> tensor<1x10xf32> loc(#loc12)
-    %10 = ttir.empty() : tensor<1x10xf32> loc(#loc13)
-    // CHECK: %{{.*}} = "ttnn.softmax"{{.*}} -> tensor<1x10xf32, #[[LAYOUT_L1]]>
-    %11 = "ttir.softmax"(%9, %10) <{dimension = 1 : si32}> : (tensor<1x10xf32>, tensor<1x10xf32>) -> tensor<1x10xf32> loc(#loc13)
-    return %11 : tensor<1x10xf32> loc(#loc7)
+    %0 = ttir.empty() : tensor<1x256xbf16> loc(#loc8)
+    // CHECK: %{{.*}} = "ttnn.matmul"{{.*}} -> tensor<1x256xbf16, #[[LAYOUT_L1]]>
+    %1 = "ttir.matmul"(%arg0, %arg4, %0) : (tensor<1x784xbf16>, tensor<784x256xbf16>, tensor<1x256xbf16>) -> tensor<1x256xbf16> loc(#loc8)
+    %2 = ttir.empty() : tensor<1x256xbf16> loc(#loc9)
+    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x256xbf16, #[[LAYOUT_L1]]>
+    %3 = "ttir.add"(%1, %arg3, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x256xbf16>, tensor<1x256xbf16>, tensor<1x256xbf16>) -> tensor<1x256xbf16> loc(#loc9)
+    %4 = ttir.empty() : tensor<1x256xbf16> loc(#loc10)
+    // CHECK: %{{.*}} = "ttnn.relu"{{.*}} -> tensor<1x256xbf16, #[[LAYOUT_L1]]>
+    %5 = "ttir.relu"(%3, %4) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x256xbf16>, tensor<1x256xbf16>) -> tensor<1x256xbf16> loc(#loc10)
+    %6 = ttir.empty() : tensor<1x10xbf16> loc(#loc11)
+    // CHECK: %{{.*}} = "ttnn.matmul"{{.*}} -> tensor<1x10xbf16, #[[LAYOUT_L1]]>
+    %7 = "ttir.matmul"(%5, %arg2, %6) : (tensor<1x256xbf16>, tensor<256x10xbf16>, tensor<1x10xbf16>) -> tensor<1x10xbf16> loc(#loc11)
+    %8 = ttir.empty() : tensor<1x10xbf16> loc(#loc12)
+    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x10xbf16, #[[LAYOUT_L1]]>
+    %9 = "ttir.add"(%7, %arg1, %8) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x10xbf16>, tensor<1x10xbf16>, tensor<1x10xbf16>) -> tensor<1x10xbf16> loc(#loc12)
+    %10 = ttir.empty() : tensor<1x10xbf16> loc(#loc13)
+    // CHECK: %{{.*}} = "ttnn.softmax"{{.*}} -> tensor<1x10xbf16, #[[LAYOUT_L1]]>
+    %11 = "ttir.softmax"(%9, %10) <{dimension = 1 : si32}> : (tensor<1x10xbf16>, tensor<1x10xbf16>) -> tensor<1x10xbf16> loc(#loc13)
+    return %11 : tensor<1x10xbf16> loc(#loc7)
   } loc(#loc)
 } loc(#loc)
 #loc1 = loc("MNISTLinear":4294967295:10)

--- a/test/ttmlir/Dialect/TTNN/optimizer/insert_memreconfig_override.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/insert_memreconfig_override.mlir
@@ -1,20 +1,20 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true memory-layout-analysis-enabled=true memreconfig-enabled=true insert-memreconfig=add_0_1_2=0 override-output-layout=add_1_2=1x1:dram:interleaved:row_major:f32" %s | FileCheck %s
 #loc = loc("test_ops.py:17_0_0":0:0)
 module attributes {} {
-  func.func @main(%arg0: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0), %arg1: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0), %arg2: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0)) -> tensor<1x32x32xf32> {
+  func.func @main(%arg0: tensor<1x32x32xbf16> loc("test_ops.py:17_0_0":0:0), %arg1: tensor<1x32x32xbf16> loc("test_ops.py:17_0_0":0:0), %arg2: tensor<1x32x32xbf16> loc("test_ops.py:17_0_0":0:0)) -> tensor<1x32x32xbf16> {
     // CHECK: #[[L1_:.*]] = #ttnn.buffer_type<l1>
-    // CHECK-DAG: #[[LAYOUT_1:.*]] = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1, (d0, d1) -> (0, d1 floordiv 8, d1 mod 8)>, memref<1x1x!tt.tile<32x32, f32>, #l1_>, <width_sharded>>
+    // CHECK-DAG: #[[LAYOUT_1:.*]] = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1, (d0, d1) -> (0, d1 floordiv 8, d1 mod 8)>, memref<1x1x!tt.tile<32x32, bf16>, #l1_>, <width_sharded>>
     // CHECK-DAG: #[[LAYOUT_2:.*]] = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x32xf32, #dram>, <interleaved>>
-    %0 = ttir.empty() : tensor<1x32x32xf32> loc(#loc5)
+    %0 = ttir.empty() : tensor<1x32x32xbf16> loc(#loc5)
     // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x32x32xf32, #[[LAYOUT_2]]>
-    %1 = "ttir.add"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xf32>, tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> tensor<1x32x32xf32> loc(#loc5)
-    %2 = ttir.empty() : tensor<1x32x32xf32> loc(#loc6)
-    // CHECK: %[[IDX:.*]] = "ttnn.to_memory_config"{{.*}} -> tensor<1x32x32xf32, #[[LAYOUT_1]]>
+    %1 = "ttir.add"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xbf16>, tensor<1x32x32xbf16>, tensor<1x32x32xbf16>) -> tensor<1x32x32xbf16> loc(#loc5)
+    %2 = ttir.empty() : tensor<1x32x32xbf16> loc(#loc6)
+    // CHECK: %[[IDX:.*]] = "ttnn.to_memory_config"{{.*}} -> tensor<1x32x32xbf16, #[[LAYOUT_1]]>
     // CHECK: %{{.*}} = "ttnn.add"(%[[IDX]]{{.*}}
-    %3 = "ttir.add"(%1, %arg0, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xf32>, tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> tensor<1x32x32xf32> loc(#loc6)
-    %4 = ttir.empty() : tensor<1x32x32xf32> loc(#loc7)
-    %5 = "ttir.relu"(%3, %4) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> tensor<1x32x32xf32> loc(#loc7)
-    return %5 : tensor<1x32x32xf32> loc(#loc4)
+    %3 = "ttir.add"(%1, %arg0, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xbf16>, tensor<1x32x32xbf16>, tensor<1x32x32xbf16>) -> tensor<1x32x32xbf16> loc(#loc6)
+    %4 = ttir.empty() : tensor<1x32x32xbf16> loc(#loc7)
+    %5 = "ttir.relu"(%3, %4) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x32x32xbf16>, tensor<1x32x32xbf16>) -> tensor<1x32x32xbf16> loc(#loc7)
+    return %5 : tensor<1x32x32xbf16> loc(#loc4)
   } loc(#loc)
 } loc(#loc)
 #loc1 = loc("test_ops.py:17_0_0":0:4)

--- a/test/ttmlir/Dialect/TTNN/optimizer/multiple_add_with_loc.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/multiple_add_with_loc.mlir
@@ -1,19 +1,18 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true" %s | FileCheck %s
 #loc = loc("test_ops.py:17_0_0":0:0)
 module attributes {} {
-  func.func @main(%arg0: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0), %arg1: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0), %arg2: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0)) -> (tensor<1x32x32xf32>, tensor<1x32x32xf32>) {
-    // CHECK: #[[LAYOUT:.*]] = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <8x8, (d0, d1) -> (0, d0, d1)>, memref<1x1x!tt.tile<32x32, f32>, #dram>, <interleaved>>
-    %0 = ttir.empty() : tensor<1x32x32xf32> loc(#loc5)
-    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x32x32xf32, #[[LAYOUT]]>
-    %1 = "ttir.add"(%arg1, %arg2, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xf32>, tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> tensor<1x32x32xf32> loc(#loc5)
-    %2 = ttir.empty() : tensor<1x32x32xf32> loc(#loc6)
-    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x32x32xf32, #[[LAYOUT]]>
-    %3 = "ttir.add"(%1, %arg0, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xf32>, tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> tensor<1x32x32xf32> loc(#loc6)
-    %4 = ttir.empty() : tensor<1x32x32xf32> loc(#loc7)
-    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x32x32xf32, #[[LAYOUT]]>
-    %5 = "ttir.add"(%arg2, %arg1, %4) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xf32>, tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> tensor<1x32x32xf32> loc(#loc7)
-    // CHECK: return %[[R0:.*]], %[[R1:.*]] : tensor<1x32x32xf32, #ttnn_layout1>, tensor<1x32x32xf32, #ttnn_layout1>
-    return %3, %5 : tensor<1x32x32xf32>, tensor<1x32x32xf32> loc(#loc4)
+  func.func @main(%arg0: tensor<1x32x32xbf16> loc("test_ops.py:17_0_0":0:0), %arg1: tensor<1x32x32xbf16> loc("test_ops.py:17_0_0":0:0), %arg2: tensor<1x32x32xbf16> loc("test_ops.py:17_0_0":0:0)) -> (tensor<1x32x32xbf16>, tensor<1x32x32xbf16>) {
+    // CHECK: #[[LAYOUT:.*]] = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <8x8, (d0, d1) -> (0, d0, d1)>, memref<1x1x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
+    %0 = ttir.empty() : tensor<1x32x32xbf16> loc(#loc5)
+    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x32x32xbf16, #[[LAYOUT]]>
+    %1 = "ttir.add"(%arg1, %arg2, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xbf16>, tensor<1x32x32xbf16>, tensor<1x32x32xbf16>) -> tensor<1x32x32xbf16> loc(#loc5)
+    %2 = ttir.empty() : tensor<1x32x32xbf16> loc(#loc6)
+    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x32x32xbf16, #[[LAYOUT]]>
+    %3 = "ttir.add"(%1, %arg0, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xbf16>, tensor<1x32x32xbf16>, tensor<1x32x32xbf16>) -> tensor<1x32x32xbf16> loc(#loc6)
+    %4 = ttir.empty() : tensor<1x32x32xbf16> loc(#loc7)
+    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x32x32xbf16, #[[LAYOUT]]>
+    %5 = "ttir.add"(%arg2, %arg1, %4) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xbf16>, tensor<1x32x32xbf16>, tensor<1x32x32xbf16>) -> tensor<1x32x32xbf16> loc(#loc7)
+    return %3, %5 : tensor<1x32x32xbf16>, tensor<1x32x32xbf16> loc(#loc4)
   } loc(#loc)
 } loc(#loc)
 #loc1 = loc("test_ops.py:17_0_0":0:4)

--- a/test/ttmlir/Dialect/TTNN/optimizer/output_layout_override.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/output_layout_override.mlir
@@ -1,45 +1,42 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true override-output-layout=add_0=1x1,add_1=l1,add_2=block_sharded,add_3=bf16,add_4=l1:interleaved,add_5=width_sharded:tile,add_6=4x4:dram:interleaved:row_major:bf16,add_7=4x4:l1:interleaved:tile:f32" %s | FileCheck %s
+// RUN: ttmlir-opt --mlir-print-local-scope --ttir-to-ttnn-backend-pipeline="enable-optimizer=true override-output-layout=add_0=1x1,add_1=l1,add_2=block_sharded,add_3=f32,add_4=l1:interleaved,add_5=width_sharded:tile,add_6=4x4:dram:interleaved:row_major:f32,add_7=4x4:l1:interleaved:tile:f32" %s | FileCheck %s
 #loc = loc("test_ops.py:17_0_0":0:0)
 module attributes {} {
-  func.func @main(%arg0: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0), %arg1: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0), %arg2: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0)) -> (tensor<1x32x32xf32>, tensor<1x32x32xf32>) {
-    // CHECK: #[[L1_:.*]] = #ttnn.buffer_type<l1>
-    // CHECK: #[[LAYOUT_0:.*]] = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<1x1x!tt.tile<32x32, f32>, #dram>, <interleaved>>
-    // CHECK: #[[LAYOUT_1:.*]] = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <8x8, (d0, d1) -> (0, d0, d1)>, memref<1x1x!tt.tile<32x32, f32>, #l1_>, <interleaved>>
-    // CHECK: #[[LAYOUT_2:.*]] = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <8x8, (d0, d1) -> (0, d0, d1)>, memref<1x1x!tt.tile<32x32, f32>, #dram>, <interleaved>>
-    // CHECK: #[[LAYOUT_3:.*]] = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1, (d0, d1) -> (0, d0, d1)>, memref<1x1x!tt.tile<32x32, f32>, #l1_>, <block_sharded>>
-    // CHECK: #[[LAYOUT_4:.*]] = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <8x8, (d0, d1) -> (0, d0, d1)>, memref<1x1x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
-    // CHECK: #[[LAYOUT_5:.*]] = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1, (d0, d1) -> (0, d1 floordiv 8, d1 mod 8)>, memref<1x1x!tt.tile<32x32, f32>, #l1_>, <width_sharded>>
-    // CHECK: #[[LAYOUT_6:.*]] = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <4x4>, memref<8x8xbf16, #dram>, <interleaved>>
-    // CHECK: #[[LAYOUT_7:.*]] = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <4x4>, memref<1x1x!tt.tile<32x32, f32>, #l1_>, <interleaved>>
-    %0 = ttir.empty() : tensor<1x32x32xf32> loc(#loc5)
-    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x32x32xf32, #[[LAYOUT_3]]>
-    %1 = "ttir.add"(%arg1, %arg2, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xf32>, tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> tensor<1x32x32xf32> loc(#loc5)
-    %2 = ttir.empty() : tensor<1x32x32xf32> loc(#loc6)
-    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x32x32xf32, #[[LAYOUT_1]]>
-    %3 = "ttir.add"(%1, %arg0, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xf32>, tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> tensor<1x32x32xf32> loc(#loc6)
-    %4 = ttir.empty() : tensor<1x32x32xf32> loc(#loc7)
-    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x32x32xf32, #[[LAYOUT_3]]>
-    %5 = "ttir.add"(%arg2, %arg1, %4) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xf32>, tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> tensor<1x32x32xf32> loc(#loc7)
-    %6 = ttir.empty() : tensor<1x32x32xf32>
-    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x32x32xf32, #[[LAYOUT_4]]>
-    %7 = "ttir.add"(%arg1, %5, %6) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xf32>, tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> tensor<1x32x32xf32> loc(#loc8)
-    %8 = ttir.empty() : tensor<1x32x32xf32>
-    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x32x32xf32, #[[LAYOUT_1]]>
-    %9 = "ttir.add"(%arg1, %7, %8) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xf32>, tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> tensor<1x32x32xf32> loc(#loc9)
-    %10 = ttir.empty() : tensor<1x32x32xf32>
-    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x32x32xf32, #[[LAYOUT_5]]>
-    %11 = "ttir.add"(%arg1, %9, %10) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xf32>, tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> tensor<1x32x32xf32> loc(#loc10)
-    %12 = ttir.empty() : tensor<1x32x32xf32>
-    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x32x32xf32, #[[LAYOUT_6]]>
-    %13 = "ttir.add"(%arg1, %11, %12) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xf32>, tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> tensor<1x32x32xf32> loc(#loc11)
-    %14 = ttir.empty() : tensor<1x32x32xf32>
-    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x32x32xf32, #[[LAYOUT_7]]>
-    %15 = "ttir.add"(%arg1, %13, %14) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xf32>, tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> tensor<1x32x32xf32> loc(#loc12)
-    %16 = ttir.empty() : tensor<1x32x32xf32>
-    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x32x32xf32, #[[LAYOUT_2]]>
-    %17 = "ttir.add"(%arg1, %15, %16) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xf32>, tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> tensor<1x32x32xf32> loc(#loc13)
-    // CHECK: return %[[R0:.*]], %[[R1:.*]] : tensor<1x32x32xf32, #[[LAYOUT_1]]>, tensor<1x32x32xf32, #[[LAYOUT_2]]>
-    return %3, %17 : tensor<1x32x32xf32>, tensor<1x32x32xf32> loc(#loc4)
+  func.func @main(%arg0: tensor<1x32x32xbf16> loc("test_ops.py:17_0_0":0:0), %arg1: tensor<1x32x32xbf16> loc("test_ops.py:17_0_0":0:0), %arg2: tensor<1x32x32xbf16> loc("test_ops.py:17_0_0":0:0)) -> (tensor<1x32x32xbf16>, tensor<1x32x32xbf16>) {
+    %0 = ttir.empty() : tensor<1x32x32xbf16> loc(#loc5)
+    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x32x32xbf16
+    // CHECK-SAME: <1x1, (d0, d1) -> (0, d0, d1)>
+    %1 = "ttir.add"(%arg1, %arg2, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xbf16>, tensor<1x32x32xbf16>, tensor<1x32x32xbf16>) -> tensor<1x32x32xbf16> loc(#loc5)
+    %2 = ttir.empty() : tensor<1x32x32xbf16> loc(#loc6)
+    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x32x32xbf16
+    // CHECK-SAME: #ttnn.buffer_type<l1>
+    %3 = "ttir.add"(%1, %arg0, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xbf16>, tensor<1x32x32xbf16>, tensor<1x32x32xbf16>) -> tensor<1x32x32xbf16> loc(#loc6)
+    %4 = ttir.empty() : tensor<1x32x32xbf16> loc(#loc7)
+    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x32x32xbf16
+    // CHECK-SAME: <block_sharded>
+    %5 = "ttir.add"(%arg2, %arg1, %4) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xbf16>, tensor<1x32x32xbf16>, tensor<1x32x32xbf16>) -> tensor<1x32x32xbf16> loc(#loc7)
+    %6 = ttir.empty() : tensor<1x32x32xbf16>
+    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x32x32xf32
+    // CHECK-SAME: memref<{{.*}}f32
+    %7 = "ttir.add"(%arg1, %5, %6) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xbf16>, tensor<1x32x32xbf16>, tensor<1x32x32xbf16>) -> tensor<1x32x32xbf16> loc(#loc8)
+    %8 = ttir.empty() : tensor<1x32x32xbf16>
+    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x32x32xbf16
+    // CHECK-SAME: #ttnn.buffer_type<l1>>, <interleaved>
+    %9 = "ttir.add"(%arg1, %7, %8) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xbf16>, tensor<1x32x32xbf16>, tensor<1x32x32xbf16>) -> tensor<1x32x32xbf16> loc(#loc9)
+    %10 = ttir.empty() : tensor<1x32x32xbf16>
+    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x32x32xbf16
+    // CHECK-SAME: memref<{{.*}}tt.tile{{.*}}, <width_sharded>
+    %11 = "ttir.add"(%arg1, %9, %10) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xbf16>, tensor<1x32x32xbf16>, tensor<1x32x32xbf16>) -> tensor<1x32x32xbf16> loc(#loc10)
+    %12 = ttir.empty() : tensor<1x32x32xbf16>
+    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x32x32xf32
+    // CHECK-SAME: <4x4>, memref<8x8xf32, #ttnn.buffer_type<dram>>, <interleaved>>
+    %13 = "ttir.add"(%arg1, %11, %12) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xbf16>, tensor<1x32x32xbf16>, tensor<1x32x32xbf16>) -> tensor<1x32x32xbf16> loc(#loc11)
+    %14 = ttir.empty() : tensor<1x32x32xbf16>
+    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x32x32xf32
+    // CHECK-SAME: <4x4>, memref<1x1x!tt.tile<32x32, f32>, #ttnn.buffer_type<l1>>, <interleaved>>
+    %15 = "ttir.add"(%arg1, %13, %14) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xbf16>, tensor<1x32x32xbf16>, tensor<1x32x32xbf16>) -> tensor<1x32x32xbf16> loc(#loc12)
+    %16 = ttir.empty() : tensor<1x32x32xbf16>
+    %17 = "ttir.add"(%arg1, %15, %16) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xbf16>, tensor<1x32x32xbf16>, tensor<1x32x32xbf16>) -> tensor<1x32x32xbf16> loc(#loc13)
+    return %3, %17 : tensor<1x32x32xbf16>, tensor<1x32x32xbf16> loc(#loc4)
   } loc(#loc)
 } loc(#loc)
 #loc1 = loc("test_ops.py:17_0_0":0:4)

--- a/test/ttmlir/Dialect/TTNN/optimizer/partial_output_layout_override.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/partial_output_layout_override.mlir
@@ -1,14 +1,14 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true override-output-layout=add_1=row_major" %s | FileCheck %s
 #loc = loc("test_ops.py:17_0_0":0:0)
 module attributes {} {
-  func.func @main(%arg0: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0), %arg1: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0), %arg2: tensor<1x32x32xf32> loc("test_ops.py:17_0_0":0:0)) -> (tensor<1x32x32xf32>, tensor<1x32x32xf32>) {
-    // CHECK: #[[LAYOUT_1:.*]] = #ttnn.ttnn_layout<{{.*}}memref<4x4xf32{{.*}}
-    %0 = ttir.empty() : tensor<1x32x32xf32> loc(#loc5)
-    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x32x32xf32, #[[LAYOUT_1]]>
-    %1 = "ttir.add"(%arg1, %arg2, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xf32>, tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> tensor<1x32x32xf32> loc(#loc5)
-    %2 = ttir.empty() : tensor<1x32x32xf32> loc(#loc6)
-    %3 = "ttir.add"(%1, %arg0, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xf32>, tensor<1x32x32xf32>, tensor<1x32x32xf32>) -> tensor<1x32x32xf32> loc(#loc6)
-    return %1, %3 : tensor<1x32x32xf32>, tensor<1x32x32xf32> loc(#loc4)
+  func.func @main(%arg0: tensor<1x32x32xbf16> loc("test_ops.py:17_0_0":0:0), %arg1: tensor<1x32x32xbf16> loc("test_ops.py:17_0_0":0:0), %arg2: tensor<1x32x32xbf16> loc("test_ops.py:17_0_0":0:0)) -> (tensor<1x32x32xbf16>, tensor<1x32x32xbf16>) {
+    // CHECK: #[[LAYOUT_1:.*]] = #ttnn.ttnn_layout<{{.*}}memref<4x4xbf16{{.*}}
+    %0 = ttir.empty() : tensor<1x32x32xbf16> loc(#loc5)
+    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x32x32xbf16, #[[LAYOUT_1]]>
+    %1 = "ttir.add"(%arg1, %arg2, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xbf16>, tensor<1x32x32xbf16>, tensor<1x32x32xbf16>) -> tensor<1x32x32xbf16> loc(#loc5)
+    %2 = ttir.empty() : tensor<1x32x32xbf16> loc(#loc6)
+    %3 = "ttir.add"(%1, %arg0, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x32x32xbf16>, tensor<1x32x32xbf16>, tensor<1x32x32xbf16>) -> tensor<1x32x32xbf16> loc(#loc6)
+    return %1, %3 : tensor<1x32x32xbf16>, tensor<1x32x32xbf16> loc(#loc4)
   } loc(#loc)
 } loc(#loc)
 #loc1 = loc("test_ops.py:17_0_0":0:4)

--- a/test/ttmlir/Dialect/TTNN/reduction/negative_reduce_prod_op.mlir
+++ b/test/ttmlir/Dialect/TTNN/reduction/negative_reduce_prod_op.mlir
@@ -1,4 +1,4 @@
-// RUN: not ttmlir-opt --ttir-to-ttnn-backend-pipeline --split-input-file %s 2>&1 | FileCheck %s
+// RUN: not ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-fp32=true" --split-input-file %s 2>&1 | FileCheck %s
 // Negative tests for reduce(prod) op
 
 // CHECK: error: failed to legalize operation 'ttir.prod'

--- a/test/ttmlir/Dialect/TTNN/reduction/simple_prod.mlir
+++ b/test/ttmlir/Dialect/TTNN/reduction/simple_prod.mlir
@@ -1,17 +1,17 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 
 module attributes {} {
-  func.func public @test_reduce_prod_4to3dim(%arg0: tensor<128x10x32x4xf32>) -> tensor<128x32x4xf32> {
+  func.func public @test_reduce_prod_4to3dim(%arg0: tensor<128x10x32x4xbf16>) -> tensor<128x32x4xbf16> {
     // CHECK-LABEL: func.func public @test_reduce_prod_4to3dim
-    %0 = ttir.empty() : tensor<128x32x4xf32>
+    %0 = ttir.empty() : tensor<128x32x4xbf16>
     // CHECK: "ttnn.prod"
     // CHECK: all_dimensions = false
     // CHECK-SAME: dim_arg = 1
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: (tensor<128x10x32x4xf32,
-    // CHECK-SAME: -> tensor<128x32x4xf32,
-    %1 = "ttir.prod"(%arg0, %0) <{dim_arg = [1: i32], keep_dim = false}> : (tensor<128x10x32x4xf32>, tensor<128x32x4xf32>) -> tensor<128x32x4xf32>
-    return %1 : tensor<128x32x4xf32>
+    // CHECK-SAME: (tensor<128x10x32x4xbf16,
+    // CHECK-SAME: -> tensor<128x32x4xbf16,
+    %1 = "ttir.prod"(%arg0, %0) <{dim_arg = [1: i32], keep_dim = false}> : (tensor<128x10x32x4xbf16>, tensor<128x32x4xbf16>) -> tensor<128x32x4xbf16>
+    return %1 : tensor<128x32x4xbf16>
   }
 
   func.func public @test_reduce_prod_4to0dim(%arg0: tensor<128x10x32x4xbf16>) -> tensor<1xbf16> {
@@ -27,17 +27,17 @@ module attributes {} {
     return %1 : tensor<1xbf16>
   }
 
-  func.func public @test_reduce_prod_3to2dim(%arg0: tensor<128x10x4xf32>) -> tensor<128x4xf32> {
+  func.func public @test_reduce_prod_3to2dim(%arg0: tensor<128x10x4xbf16>) -> tensor<128x4xbf16> {
     // CHECK-LABEL: func.func public @test_reduce_prod_3to2dim
-    %0 = ttir.empty() : tensor<128x4xf32>
+    %0 = ttir.empty() : tensor<128x4xbf16>
     // CHECK: "ttnn.prod"
     // CHECK: all_dimensions = false
     // CHECK-SAME: dim_arg = 1
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: (tensor<128x10x4xf32,
-    // CHECK-SAME: -> tensor<128x4xf32,
-    %1 = "ttir.prod"(%arg0, %0) <{dim_arg = [1: i32], keep_dim = false}> : (tensor<128x10x4xf32>, tensor<128x4xf32>) -> tensor<128x4xf32>
-    return %1 : tensor<128x4xf32>
+    // CHECK-SAME: (tensor<128x10x4xbf16,
+    // CHECK-SAME: -> tensor<128x4xbf16,
+    %1 = "ttir.prod"(%arg0, %0) <{dim_arg = [1: i32], keep_dim = false}> : (tensor<128x10x4xbf16>, tensor<128x4xbf16>) -> tensor<128x4xbf16>
+    return %1 : tensor<128x4xbf16>
   }
 
   func.func public @test_reduce_prod_3to0dim(%arg0: tensor<128x10x4xbf16>) -> tensor<1xbf16> {

--- a/test/ttmlir/Dialect/TTNN/reduction/simple_reduce_min.mlir
+++ b/test/ttmlir/Dialect/TTNN/reduction/simple_reduce_min.mlir
@@ -1,16 +1,16 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 
 module attributes {} {
-  func.func public @test_reduce_min_4to3dim(%arg0: tensor<128x10x32x4xf32>) -> tensor<128x32x4xf32> {
+  func.func public @test_reduce_min_4to3dim(%arg0: tensor<128x10x32x4xbf16>) -> tensor<128x32x4xbf16> {
     // CHECK-LABEL: func.func public @test_reduce_min_4to3dim
-    %0 = ttir.empty() : tensor<128x32x4xf32>
+    %0 = ttir.empty() : tensor<128x32x4xbf16>
     // CHECK: %[[MIN:[0-9]+]] = "ttnn.min"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: (tensor<128x10x32x4xf32,
-    // CHECK-SAME: -> tensor<128x32x4xf32,
-    %1 = "ttir.min"(%arg0, %0) <{dim_arg = [1: i32], keep_dim = false}> : (tensor<128x10x32x4xf32>, tensor<128x32x4xf32>) -> tensor<128x32x4xf32>
-    return %1 : tensor<128x32x4xf32>
+    // CHECK-SAME: (tensor<128x10x32x4xbf16,
+    // CHECK-SAME: -> tensor<128x32x4xbf16,
+    %1 = "ttir.min"(%arg0, %0) <{dim_arg = [1: i32], keep_dim = false}> : (tensor<128x10x32x4xbf16>, tensor<128x32x4xbf16>) -> tensor<128x32x4xbf16>
+    return %1 : tensor<128x32x4xbf16>
   }
 
   func.func public @test_reduce_min_4to0dim(%arg0: tensor<128x10x32x4xbf16>) -> tensor<1xbf16> {
@@ -29,16 +29,16 @@ module attributes {} {
     return %1 : tensor<1xbf16>
   }
 
-  func.func public @test_reduce_min_3to2dim(%arg0: tensor<128x10x4xf32>) -> tensor<128x4xf32> {
+  func.func public @test_reduce_min_3to2dim(%arg0: tensor<128x10x4xbf16>) -> tensor<128x4xbf16> {
     // CHECK-LABEL: func.func public @test_reduce_min_3to2dim
-    %0 = ttir.empty() : tensor<128x4xf32>
+    %0 = ttir.empty() : tensor<128x4xbf16>
     // CHECK: %[[MIN:[0-9]+]] = "ttnn.min"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: (tensor<128x10x4xf32,
-    // CHECK-SAME: -> tensor<128x4xf32,
-    %1 = "ttir.min"(%arg0, %0) <{dim_arg = [1: i32], keep_dim = false}> : (tensor<128x10x4xf32>, tensor<128x4xf32>) -> tensor<128x4xf32>
-    return %1 : tensor<128x4xf32>
+    // CHECK-SAME: (tensor<128x10x4xbf16,
+    // CHECK-SAME: -> tensor<128x4xbf16,
+    %1 = "ttir.min"(%arg0, %0) <{dim_arg = [1: i32], keep_dim = false}> : (tensor<128x10x4xbf16>, tensor<128x4xbf16>) -> tensor<128x4xbf16>
+    return %1 : tensor<128x4xbf16>
   }
 
   func.func public @test_reduce_min_3to0dim(%arg0: tensor<128x10x4xbf16>) -> tensor<1xbf16> {

--- a/test/ttmlir/Dialect/TTNN/simple_clamp_tensor.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_clamp_tensor.mlir
@@ -1,13 +1,13 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func public @test_clamp_tensor(%arg0: tensor<32x64xf32>, %arg1: tensor<32x64xf32>, %arg2: tensor<32x64xf32>) -> tensor<32x64xf32> {
-    %0 = ttir.empty() : tensor<32x64xf32>
+  func.func public @test_clamp_tensor(%arg0: tensor<32x64xbf16>, %arg1: tensor<32x64xbf16>, %arg2: tensor<32x64xbf16>) -> tensor<32x64xbf16> {
+    %0 = ttir.empty() : tensor<32x64xbf16>
     // CHECK: %{{[0-9]+}} = "ttnn.clamp_tensor"(%arg0, %arg1, %arg2)
-    // CHECK-SAME: tensor<32x64xf32,
-    // CHECK-SAME: tensor<32x64xf32,
-    // CHECK-SAME: tensor<32x64xf32,
-    // CHECK-SAME: -> tensor<32x64xf32,
-    %1 = "ttir.clamp_tensor"(%arg0, %arg1, %arg2, %0) : (tensor<32x64xf32>, tensor<32x64xf32>, tensor<32x64xf32>, tensor<32x64xf32>) -> tensor<32x64xf32>
-    return %1 : tensor<32x64xf32>
+    // CHECK-SAME: tensor<32x64xbf16,
+    // CHECK-SAME: tensor<32x64xbf16,
+    // CHECK-SAME: tensor<32x64xbf16,
+    // CHECK-SAME: -> tensor<32x64xbf16,
+    %1 = "ttir.clamp_tensor"(%arg0, %arg1, %arg2, %0) : (tensor<32x64xbf16>, tensor<32x64xbf16>, tensor<32x64xbf16>, tensor<32x64xbf16>) -> tensor<32x64xbf16>
+    return %1 : tensor<32x64xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/simple_cumsum.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_cumsum.mlir
@@ -12,14 +12,14 @@ module @moreh_cumsum attributes {} {
     return %1 : tensor<1x32x128x128xbf16>
   }
 
-  func.func public @test_moreh_cumsum_dim1(%arg0: tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32> {
+  func.func public @test_moreh_cumsum_dim1(%arg0: tensor<4x4x128x128xbf16>) -> tensor<4x4x128x128xbf16> {
     // CHECK-LABEL: func.func public @test_moreh_cumsum_dim1
-    %0 = ttir.empty() : tensor<4x4x128x128xf32>
+    %0 = ttir.empty() : tensor<4x4x128x128xbf16>
     // CHECK: ttnn.moreh_cumsum
     // CHECK-SAME: dim = 1 : i64
-    // CHECK-SAME: tensor<4x4x128x128xf32,
-    // CHECK-SAME: -> tensor<4x4x128x128xf32,
-    %1 = "ttir.cumsum"(%arg0, %0) <{dim = 1 : i64}> : (tensor<4x4x128x128xf32>, tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32>
-    return %1 : tensor<4x4x128x128xf32>
+    // CHECK-SAME: tensor<4x4x128x128xbf16,
+    // CHECK-SAME: -> tensor<4x4x128x128xbf16,
+    %1 = "ttir.cumsum"(%arg0, %0) <{dim = 1 : i64}> : (tensor<4x4x128x128xbf16>, tensor<4x4x128x128xbf16>) -> tensor<4x4x128x128xbf16>
+    return %1 : tensor<4x4x128x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/simple_scatter.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_scatter.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @forward(%arg0: tensor<1x3x320x320xf32>, %arg1: tensor<1x3x32x32xf32>) -> tensor<1x3x320x320xf32> {
-    %0 = ttir.empty() : tensor<1x3x320x320xf32>
+  func.func @forward(%arg0: tensor<1x3x320x320xbf16>, %arg1: tensor<1x3x32x32xbf16>) -> tensor<1x3x320x320xbf16> {
+    %0 = ttir.empty() : tensor<1x3x320x320xbf16>
     %1 = ttir.empty() : tensor<1x1xi32>
-    %2 = "ttir.scatter"(%arg0, %1, %arg1, %0) <{index_vector_dim = 1 : i32, indices_are_sorted = false, input_batching_dims = array<i32>, inserted_window_dims = array<i32: 0>, scatter_dims_to_operand_dims = array<i32: 0>, scatter_indices_batching_dims = array<i32>, unique_indices = false, update_window_dims = array<i32: 1, 2, 3>}> : (tensor<1x3x320x320xf32>, tensor<1x1xi32>, tensor<1x3x32x32xf32>, tensor<1x3x320x320xf32>) -> tensor<1x3x320x320xf32>
-    // CHECK: %{{[0-9]+}} = "ttnn.scatter"(%arg1, %arg0) : (tensor<1x3x32x32xf32, {{.*}}>, tensor<1x3x320x320xf32, {{.*}}>) -> tensor<1x3x320x320xf32, {{.*}}>
-    return %2 : tensor<1x3x320x320xf32>
-    // CHECK: return %{{[0-9]+}} : tensor<1x3x320x320xf32, {{.*}}>
+    %2 = "ttir.scatter"(%arg0, %1, %arg1, %0) <{index_vector_dim = 1 : i32, indices_are_sorted = false, input_batching_dims = array<i32>, inserted_window_dims = array<i32: 0>, scatter_dims_to_operand_dims = array<i32: 0>, scatter_indices_batching_dims = array<i32>, unique_indices = false, update_window_dims = array<i32: 1, 2, 3>}> : (tensor<1x3x320x320xbf16>, tensor<1x1xi32>, tensor<1x3x32x32xbf16>, tensor<1x3x320x320xbf16>) -> tensor<1x3x320x320xbf16>
+    // CHECK: %{{[0-9]+}} = "ttnn.scatter"(%arg1, %arg0) : (tensor<1x3x32x32xbf16, {{.*}}>, tensor<1x3x320x320xbf16, {{.*}}>) -> tensor<1x3x320x320xbf16, {{.*}}>
+    return %2 : tensor<1x3x320x320xbf16>
+    // CHECK: return %{{[0-9]+}} : tensor<1x3x320x320xbf16, {{.*}}>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/ttir_to_ttnn_pipeline_custom_opt.mlir
+++ b/test/ttmlir/Dialect/TTNN/ttir_to_ttnn_pipeline_custom_opt.mlir
@@ -1,10 +1,10 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=false" %s | FileCheck %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @forward(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    // CHECK: #[[LAYOUT_1:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!tt.tile<32x32, f32>, #dram>, <interleaved>>
-    %0 = ttir.empty() : tensor<64x128xf32>
-    // CHECK: %{{.*}} = "ttnn.multiply"{{.*}} -> tensor<64x128xf32, #[[LAYOUT_1:.*]]>
-    %1 = "ttir.multiply"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
-    return %1 : tensor<64x128xf32>
+  func.func @forward(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    // CHECK: #[[LAYOUT_1:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    // CHECK: %{{.*}} = "ttnn.multiply"{{.*}} -> tensor<64x128xbf16, #[[LAYOUT_1:.*]]>
+    %1 = "ttir.multiply"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+    return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/ttir_to_ttnn_pipeline_hoist_call.mlir
+++ b/test/ttmlir/Dialect/TTNN/ttir_to_ttnn_pipeline_hoist_call.mlir
@@ -1,32 +1,28 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module {
-    // CHECK-DAG: #{{.*}} = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<64x128xf32, #system_memory>>
-    // CHECK-DAG: #{{.*}} = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+    // CHECK-DAG: #[[dram_layout:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
+    // CHECK-DAG: #[[system_layout_f32:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<64x128xf32, #system_memory>>
 
   // CHECK: tt.device_module {
   // CHECK: builtin.module attributes {{.*}} {
   // CHECK: func.func @forward
-  func.func @forward(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    // CHECK: %{{.*}} = "ttnn.multiply"(%{{.*}}, %{{.*}})
-    %1 = "ttir.multiply"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @forward(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    // CHECK: %{{.*}} = "ttnn.multiply"({{.*}}, {{.*}}) : (tensor<64x128xbf16, #[[dram_layout]]>, tensor<64x128xbf16, #[[dram_layout]]>) -> tensor<64x128xbf16, #[[dram_layout]]>
+    %1 = "ttir.multiply"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: %{{.*}} = "ttnn.ones"
-    %2 = "ttir.ones"() <{shape = array<i32:64, 128>}> : () -> tensor<64x128xf32>
-    // CHECK: %{{.*}} = "ttnn.from_device"(%{{.*}}) : (tensor<[[DIMS:.*]], #{{.*}}>) -> tensor<[[DIMS]], #{{.*}}>
-    // CHECK: %{{.*}} = call @hoisted_ttir_add_64x128_64x128_64x128_func_decl(%{{.*}}, %{{.*}}, %{{.*}})
-    %3 = "ttir.add"(%arg0, %1, %2) <{operandSegmentSizes = array<i32: 2, 1>}> {should_hoist} : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+    // CHECK-SAME: -> tensor<64x128xbf16, #ttnn_layout>
+    %2 = "ttir.ones"() <{shape = array<i32:64, 128>}> : () -> tensor<64x128xbf16>
+    // CHECK: %{{.*}} = call @hoisted_ttir_add_64x128_64x128_64x128_func_decl({{.*}}, {{.*}}, {{.*}}) : (tensor<64x128xf32, #[[system_layout_f32]]>, tensor<64x128xf32, #[[system_layout_f32]]>, tensor<64x128xf32, #[[system_layout_f32]]>) -> tensor<64x128xf32, #[[system_layout_f32]]>
+    %3 = "ttir.add"(%arg0, %1, %2) <{operandSegmentSizes = array<i32: 2, 1>}> {should_hoist} : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: %{{.*}} = "ttnn.construct_tensor"
-    %4 = ttir.empty() : tensor<64x128xf32>
-    // CHECK: %{{.*}} = call @hoisted_ttir_add_64x128_64x128_64x128_func_decl(%{{.*}}, %{{.*}}, %{{.*}})
-    %5 = "ttir.add"(%arg0, %3, %4) <{operandSegmentSizes = array<i32: 2, 1>}> {should_hoist} : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
-    %6 = ttir.empty() : tensor<64x128xf32>
-    // CHECK: %{{.*}} = "ttnn.to_layout"(%{{.*}}) <{layout = #ttnn.layout<{{.*}}>}> : (tensor<[[DIMS:.*]], #{{.*}}>) -> tensor<[[DIMS]], #{{.*}}>
-    // CHECK: %{{.*}} = "ttnn.to_device"(%{{.*}}, %{{.*}}) <{memory_config = {{.*}}}> : (tensor<[[DIMS:.*]], #{{.*}}>, !ttnn.device) -> tensor<[[DIMS]], #{{.*}}>
-    // CHECK: %{{.*}} = "ttnn.to_layout"(%{{.*}}) <{layout = #ttnn.layout<{{.*}}>}> : (tensor<[[DIMS:.*]], #{{.*}}>) -> tensor<[[DIMS]], #{{.*}}>
-    // CHECK: %{{.*}} = "ttnn.to_device"(%{{.*}}, %{{.*}}) <{memory_config = {{.*}}}> : (tensor<[[DIMS:.*]], #{{.*}}>, !ttnn.device) -> tensor<[[DIMS]], #{{.*}}>
-    // CHECK: %{{.*}} = "ttnn.multiply"(%{{.*}}, %{{.*}})
-    %7 = "ttir.multiply"(%3, %5, %6) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
-    return %7 : tensor<64x128xf32>
+    %4 = ttir.empty() : tensor<64x128xbf16>
+    // CHECK: %{{.*}} = call @hoisted_ttir_add_64x128_64x128_64x128_func_decl(%{{.*}}, %{{.*}}, %{{.*}}) : (tensor<64x128xf32, #[[system_layout_f32]]>, tensor<64x128xf32, #[[system_layout_f32]]>, tensor<64x128xf32, #[[system_layout_f32]]>) -> tensor<64x128xf32, #[[system_layout_f32]]>
+    %5 = "ttir.add"(%arg0, %3, %4) <{operandSegmentSizes = array<i32: 2, 1>}> {should_hoist} : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+    %6 = ttir.empty() : tensor<64x128xbf16>
+    // CHECK: %{{.*}} = "ttnn.multiply"(%{{.*}}, %{{.*}}) : (tensor<64x128xbf16, #[[dram_layout]]>, tensor<64x128xbf16, #[[dram_layout]]>) -> tensor<64x128xbf16, #[[dram_layout]]>
+    %7 = "ttir.multiply"(%3, %5, %6) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+    return %7 : tensor<64x128xbf16>
   }
   // CHECK: func.func private @hoisted_ttir_add_64x128_64x128_64x128_func_decl
   // CHECK: tt.cpu_module {

--- a/test/ttmlir/Silicon/StableHLO/n150/Binary/add_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Binary/add_op.mlir
@@ -7,13 +7,13 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module @jit_eltwise_add attributes {} {
-  func.func public @test_add(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  func.func public @test_add(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
     // CHECK-LABEL: func.func public @test_add
     // CHECK: ttnn.add
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: -> tensor<64x128xf32,
-    %0 = stablehlo.add %arg0, %arg1 : tensor<64x128xf32>
-    return %0 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: -> tensor<64x128xbf16,
+    %0 = stablehlo.add %arg0, %arg1 : tensor<64x128xbf16>
+    return %0 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/Binary/compare_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Binary/compare_op.mlir
@@ -7,63 +7,63 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module @jit_eltwise_compare attributes {} {
-  func.func public @test_eq(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xi1> {
+  func.func public @test_eq(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xi1> {
     // CHECK-LABEL: func.func public @test_eq
     // CHECK: ttnn.eq
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: tensor<64x128xf32,
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: tensor<64x128xbf16,
     // CHECK-SAME: -> tensor<64x128xbf16,
-    %0 = stablehlo.compare  EQ, %arg0, %arg1 : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xi1>
+    %0 = stablehlo.compare  EQ, %arg0, %arg1 : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xi1>
     return %0 : tensor<64x128xi1>
   }
 
-  func.func public @test_ne(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xi1> {
+  func.func public @test_ne(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xi1> {
     // CHECK-LABEL: func.func public @test_ne
     // CHECK: ttnn.ne
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: tensor<64x128xf32,
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: tensor<64x128xbf16,
     // CHECK-SAME: -> tensor<64x128xbf16,
-    %0 = stablehlo.compare  NE, %arg0, %arg1 : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xi1>
+    %0 = stablehlo.compare  NE, %arg0, %arg1 : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xi1>
     return %0 : tensor<64x128xi1>
   }
 
-  func.func public @test_ge(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xi1> {
+  func.func public @test_ge(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xi1> {
     // CHECK-LABEL: func.func public @test_ge
     // CHECK: ttnn.ge
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: tensor<64x128xf32,
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: tensor<64x128xbf16,
     // CHECK-SAME: -> tensor<64x128xbf16,
-    %0 = stablehlo.compare  GE, %arg0, %arg1 : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xi1>
+    %0 = stablehlo.compare  GE, %arg0, %arg1 : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xi1>
     return %0 : tensor<64x128xi1>
   }
 
-  func.func public @test_gt(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xi1> {
+  func.func public @test_gt(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xi1> {
     // CHECK-LABEL: func.func public @test_gt
     // CHECK: ttnn.gt
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: tensor<64x128xf32,
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: tensor<64x128xbf16,
     // CHECK-SAME: -> tensor<64x128xbf16,
-    %0 = stablehlo.compare  GT, %arg0, %arg1 : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xi1>
+    %0 = stablehlo.compare  GT, %arg0, %arg1 : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xi1>
     return %0 : tensor<64x128xi1>
   }
 
-  func.func public @test_le(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xi1> {
+  func.func public @test_le(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xi1> {
     // CHECK-LABEL: func.func public @test_le
     // CHECK: ttnn.le
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: tensor<64x128xf32,
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: tensor<64x128xbf16,
     // CHECK-SAME: -> tensor<64x128xbf16,
-    %0 = stablehlo.compare  LE, %arg0, %arg1 : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xi1>
+    %0 = stablehlo.compare  LE, %arg0, %arg1 : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xi1>
     return %0 : tensor<64x128xi1>
   }
 
-  func.func public @test_lt(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xi1> {
+  func.func public @test_lt(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xi1> {
     // CHECK-LABEL: func.func public @test_lt
     // CHECK: ttnn.lt
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: tensor<64x128xf32,
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: tensor<64x128xbf16,
     // CHECK-SAME: -> tensor<64x128xbf16,
-    %0 = stablehlo.compare  LT, %arg0, %arg1 : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xi1>
+    %0 = stablehlo.compare  LT, %arg0, %arg1 : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xi1>
     return %0 : tensor<64x128xi1>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/Binary/concat_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Binary/concat_op.mlir
@@ -7,70 +7,70 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module @jit_concat attributes {} {
-  func.func public @test_concat_0(%arg0: tensor<32x32xf32>, %arg1: tensor<64x32xf32>) -> tensor<96x32xf32> {
+  func.func public @test_concat_0(%arg0: tensor<32x32xbf16>, %arg1: tensor<64x32xbf16>) -> tensor<96x32xbf16> {
     // CHECK-LABEL: func.func public @test_concat_0
     // CHECK: ttnn.concat
     // CHECK-SAME: dim = 0
-    // CHECK-SAME: tensor<32x32xf32,
-    // CHECK-SAME: tensor<64x32xf32,
-    // CHECK-SAME: -> tensor<96x32xf32,
+    // CHECK-SAME: tensor<32x32xbf16,
+    // CHECK-SAME: tensor<64x32xbf16,
+    // CHECK-SAME: -> tensor<96x32xbf16,
     %0 = "stablehlo.concatenate"(%arg0, %arg1) {
     dimension = 0 : i64
-    } : (tensor<32x32xf32>, tensor<64x32xf32>) -> tensor<96x32xf32>
-    return %0 : tensor<96x32xf32>
+    } : (tensor<32x32xbf16>, tensor<64x32xbf16>) -> tensor<96x32xbf16>
+    return %0 : tensor<96x32xbf16>
   }
 
-  func.func public @test_concat_1(%arg0: tensor<32x32xf32>, %arg1: tensor<32x64xf32>) -> tensor<32x96xf32> {
+  func.func public @test_concat_1(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x64xbf16>) -> tensor<32x96xbf16> {
     // CHECK-LABEL: func.func public @test_concat_1
     // CHECK: ttnn.concat
     // CHECK-SAME: dim = 1
-    // CHECK-SAME: tensor<32x32xf32,
-    // CHECK-SAME: tensor<32x64xf32,
-    // CHECK-SAME: -> tensor<32x96xf32,
+    // CHECK-SAME: tensor<32x32xbf16,
+    // CHECK-SAME: tensor<32x64xbf16,
+    // CHECK-SAME: -> tensor<32x96xbf16,
     %0 = "stablehlo.concatenate"(%arg0, %arg1) {
     dimension = 1 : i64
-    } : (tensor<32x32xf32>, tensor<32x64xf32>) -> tensor<32x96xf32>
-    return %0 : tensor<32x96xf32>
+    } : (tensor<32x32xbf16>, tensor<32x64xbf16>) -> tensor<32x96xbf16>
+    return %0 : tensor<32x96xbf16>
   }
 
 
-  func.func public @test_concat_2(%arg0: tensor<128x64xf32>, %arg1: tensor<128x96xf32>) -> tensor<128x160xf32> {
+  func.func public @test_concat_2(%arg0: tensor<128x64xbf16>, %arg1: tensor<128x96xbf16>) -> tensor<128x160xbf16> {
     // CHECK-LABEL: func.func public @test_concat_2
     // CHECK: ttnn.concat
     // CHECK-SAME: dim = 1
-    // CHECK-SAME: tensor<128x64xf32,
-    // CHECK-SAME: tensor<128x96xf32,
-    // CHECK-SAME: -> tensor<128x160xf32,
+    // CHECK-SAME: tensor<128x64xbf16,
+    // CHECK-SAME: tensor<128x96xbf16,
+    // CHECK-SAME: -> tensor<128x160xbf16,
     %0 = "stablehlo.concatenate"(%arg0, %arg1) {
       dimension = 1 : i64
-    } : (tensor<128x64xf32>, tensor<128x96xf32>) -> tensor<128x160xf32>
-    return %0 : tensor<128x160xf32>
+    } : (tensor<128x64xbf16>, tensor<128x96xbf16>) -> tensor<128x160xbf16>
+    return %0 : tensor<128x160xbf16>
   }
 
-  func.func public @test_concat_3(%arg0: tensor<64x32xf32>, %arg1: tensor<64x64xf32>) -> tensor<64x96xf32> {
+  func.func public @test_concat_3(%arg0: tensor<64x32xbf16>, %arg1: tensor<64x64xbf16>) -> tensor<64x96xbf16> {
     // CHECK-LABEL: func.func public @test_concat_3
     // CHECK: ttnn.concat
     // CHECK-SAME: dim = 1
-    // CHECK-SAME: tensor<64x32xf32,
-    // CHECK-SAME: tensor<64x64xf32,
-    // CHECK-SAME: -> tensor<64x96xf32,
+    // CHECK-SAME: tensor<64x32xbf16,
+    // CHECK-SAME: tensor<64x64xbf16,
+    // CHECK-SAME: -> tensor<64x96xbf16,
     %0 = "stablehlo.concatenate"(%arg0, %arg1) {
       dimension = 1 : i64
-    } : (tensor<64x32xf32>, tensor<64x64xf32>) -> tensor<64x96xf32>
-    return %0 : tensor<64x96xf32>
+    } : (tensor<64x32xbf16>, tensor<64x64xbf16>) -> tensor<64x96xbf16>
+    return %0 : tensor<64x96xbf16>
   }
 
-  func.func public @test_concat_4(%arg0: tensor<32x32x32x32xf32>, %arg1: tensor<32x32x32x64xf32>) -> tensor<32x32x32x96xf32> {
+  func.func public @test_concat_4(%arg0: tensor<32x32x32x32xbf16>, %arg1: tensor<32x32x32x64xbf16>) -> tensor<32x32x32x96xbf16> {
     // CHECK-LABEL: func.func public @test_concat_4
     // CHECK: ttnn.concat
     // CHECK-SAME: dim = 3
-    // CHECK-SAME: tensor<32x32x32x32xf32,
-    // CHECK-SAME: tensor<32x32x32x64xf32,
-    // CHECK-SAME: -> tensor<32x32x32x96xf32,
+    // CHECK-SAME: tensor<32x32x32x32xbf16,
+    // CHECK-SAME: tensor<32x32x32x64xbf16,
+    // CHECK-SAME: -> tensor<32x32x32x96xbf16,
     %0 = "stablehlo.concatenate"(%arg0, %arg1) {
       dimension = 3 : i64
-    } : (tensor<32x32x32x32xf32>, tensor<32x32x32x64xf32>) -> tensor<32x32x32x96xf32>
-    return %0 : tensor<32x32x32x96xf32>
+    } : (tensor<32x32x32x32xbf16>, tensor<32x32x32x64xbf16>) -> tensor<32x32x32x96xbf16>
+    return %0 : tensor<32x32x32x96xbf16>
   }
 
   func.func public @test_concat_5(%arg0: tensor<1x53xi64>, %arg1: tensor<1x1xi64>) -> tensor<1x54xi64> {

--- a/test/ttmlir/Silicon/StableHLO/n150/Binary/divide_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Binary/divide_op.mlir
@@ -7,13 +7,13 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module @jit_eltwise_divice attributes {} {
-  func.func public @test_divide(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  func.func public @test_divide(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
     // CHECK-LABEL: func.func public @test_divide
     // CHECK: ttnn.divide
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: -> tensor<64x128xf32,
-    %0 = stablehlo.divide %arg0, %arg1 : tensor<64x128xf32>
-    return %0 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: -> tensor<64x128xbf16,
+    %0 = stablehlo.divide %arg0, %arg1 : tensor<64x128xbf16>
+    return %0 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/Binary/maximum_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Binary/maximum_op.mlir
@@ -7,13 +7,13 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module @jit_eltwise_maximum attributes {} {
-  func.func public @test_maximum(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  func.func public @test_maximum(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
     // CHECK-LABEL: func.func public @test_maximum
     // CHECK: ttnn.maximum
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: -> tensor<64x128xf32,
-    %0 = stablehlo.maximum %arg0, %arg1 : tensor<64x128xf32>
-    return %0 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: -> tensor<64x128xbf16,
+    %0 = stablehlo.maximum %arg0, %arg1 : tensor<64x128xbf16>
+    return %0 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/Binary/minimum_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Binary/minimum_op.mlir
@@ -7,13 +7,13 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module @jit_eltwise_minimum attributes {} {
-  func.func public @test_minimum(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  func.func public @test_minimum(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
     // CHECK-LABEL: func.func public @test_minimum
     // CHECK: ttnn.minimum
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: -> tensor<64x128xf32,
-    %0 = stablehlo.minimum %arg0, %arg1 : tensor<64x128xf32>
-    return %0 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: -> tensor<64x128xbf16,
+    %0 = stablehlo.minimum %arg0, %arg1 : tensor<64x128xbf16>
+    return %0 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/Binary/multiply_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Binary/multiply_op.mlir
@@ -7,13 +7,13 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module @jit_eltwise_multiply attributes {} {
-  func.func public @test_multiply(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  func.func public @test_multiply(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
     // CHECK-LABEL: func.func public @test_multiply
     // CHECK: ttnn.multiply
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: -> tensor<64x128xf32,
-    %0 = stablehlo.multiply %arg0, %arg1 : tensor<64x128xf32>
-    return %0 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: -> tensor<64x128xbf16,
+    %0 = stablehlo.multiply %arg0, %arg1 : tensor<64x128xbf16>
+    return %0 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/Binary/pow_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Binary/pow_op.mlir
@@ -6,13 +6,13 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module @jit_eltwise_pow attributes {} {
-  func.func public @test_power(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  func.func public @test_power(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
     // CHECK-LABEL: func.func public @test_power
     // CHECK: ttnn.pow
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: -> tensor<64x128xf32,
-    %0 = stablehlo.power %arg0, %arg1 : tensor<64x128xf32>
-    return %0 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: -> tensor<64x128xbf16,
+    %0 = stablehlo.power %arg0, %arg1 : tensor<64x128xbf16>
+    return %0 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/Binary/remainder_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Binary/remainder_op.mlir
@@ -7,13 +7,13 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module @jit_eltwise_remainder attributes {} {
-  func.func public @test_remainder(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  func.func public @test_remainder(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
     // CHECK-LABEL: func.func public @test_remainder
     // CHECK: ttnn.remainder
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: -> tensor<64x128xf32,
-    %0 = stablehlo.remainder %arg0, %arg1 : tensor<64x128xf32>
-    return %0 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: -> tensor<64x128xbf16,
+    %0 = stablehlo.remainder %arg0, %arg1 : tensor<64x128xbf16>
+    return %0 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/Binary/subtract_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Binary/subtract_op.mlir
@@ -7,13 +7,13 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module @jit_eltwise_subtract attributes {} {
-  func.func public @test_subtract(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  func.func public @test_subtract(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
     // CHECK-LABEL: func.func public @test_subtract
     // CHECK: ttnn.subtract
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: -> tensor<64x128xf32,
-    %0 = stablehlo.subtract %arg0, %arg1 : tensor<64x128xf32>
-    return %0 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: -> tensor<64x128xbf16,
+    %0 = stablehlo.subtract %arg0, %arg1 : tensor<64x128xbf16>
+    return %0 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/Constant/constant_f32.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Constant/constant_f32.mlir
@@ -10,7 +10,7 @@ module @jit_constant attributes {} {
     // CHECK-LABEL: func.func public @test_float_scalar
     // CHECK: ttnn.full
     // CHECK-SAME: fillValue = 3.000000e+00 : f32
-    // CHECK-SAME: -> tensor<1xf32
+    // CHECK-SAME: -> tensor<1xbf16
     %0 = stablehlo.constant dense<3.0> : tensor<f32>
     return %0 : tensor<f32>
   }
@@ -18,25 +18,25 @@ module @jit_constant attributes {} {
   func.func public @test_float_scalar_empty() -> tensor<f32> {
     // CHECK-LABEL: func.func public @test_float_scalar_empty
     // CHECK: ttnn.full
-    // CHECK-SAME: -> tensor<1xf32
+    // CHECK-SAME: -> tensor<1xbf16
     %0 = stablehlo.constant dense<0.0> : tensor<f32>
     return %0 : tensor<f32>
   }
 
-  func.func public @test_float_empty() -> tensor<64x128xf32> {
+  func.func public @test_float_empty() -> tensor<64x128xbf16> {
     // CHECK-LABEL: func.func public @test_float_empty
     // CHECK: ttnn.full
-    // CHECK-SAME: -> tensor<64x128xf32
-    %0 = stablehlo.constant dense<0.0> : tensor<64x128xf32>
-    return %0 : tensor<64x128xf32>
+    // CHECK-SAME: -> tensor<64x128xbf16
+    %0 = stablehlo.constant dense<0.0> : tensor<64x128xbf16>
+    return %0 : tensor<64x128xbf16>
   }
 
-  func.func public @test_float_splat() -> tensor<64x128xf32> {
+  func.func public @test_float_splat() -> tensor<64x128xbf16> {
     // CHECK-LABEL: func.func public @test_float_splat
     // CHECK: ttnn.full
     // CHECK-SAME: fillValue = 3.000000e+00 : f32
-    // CHECK-SAME: -> tensor<64x128xf32
-    %0 = stablehlo.constant dense<3.0> : tensor<64x128xf32>
-    return %0 : tensor<64x128xf32>
+    // CHECK-SAME: -> tensor<64x128xbf16
+    %0 = stablehlo.constant dense<3.0> : tensor<64x128xbf16>
+    return %0 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/Constant/constant_f64.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Constant/constant_f64.mlir
@@ -10,7 +10,7 @@ module @jit_constant attributes {} {
     // CHECK-LABEL: func.func public @test_f64_scalar
     // CHECK: ttnn.full
     // CHECK-SAME: fillValue = 3.000000e+00 : f32
-    // CHECK-SAME: -> tensor<1xf32
+    // CHECK-SAME: -> tensor<1xbf16
     %0 = stablehlo.constant dense<3.0> : tensor<f64>
     return %0 : tensor<f64>
   }
@@ -18,7 +18,7 @@ module @jit_constant attributes {} {
   func.func public @test_f64_scalar_empty() -> tensor<f64> {
     // CHECK-LABEL: func.func public @test_f64_scalar_empty
     // CHECK: ttnn.full
-    // CHECK-SAME: -> tensor<1xf32
+    // CHECK-SAME: -> tensor<1xbf16
     %0 = stablehlo.constant dense<0.0> : tensor<f64>
     return %0 : tensor<f64>
   }
@@ -26,7 +26,7 @@ module @jit_constant attributes {} {
   func.func public @test_f64_empty() -> tensor<64x128xf64> {
     // CHECK-LABEL: func.func public @test_f64_empty
     // CHECK: ttnn.full
-    // CHECK-SAME: -> tensor<64x128xf32
+    // CHECK-SAME: -> tensor<64x128xbf16
     %0 = stablehlo.constant dense<0.0> : tensor<64x128xf64>
     return %0 : tensor<64x128xf64>
   }
@@ -35,7 +35,7 @@ module @jit_constant attributes {} {
     // CHECK-LABEL: func.func public @test_f64_splat
     // CHECK: ttnn.full
     // CHECK-SAME: fillValue = 3.000000e+00 : f32
-    // CHECK-SAME: -> tensor<64x128xf32
+    // CHECK-SAME: -> tensor<64x128xbf16
     %0 = stablehlo.constant dense<3.0> : tensor<64x128xf64>
     return %0 : tensor<64x128xf64>
   }

--- a/test/ttmlir/Silicon/StableHLO/n150/Unary/absolute_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Unary/absolute_op.mlir
@@ -7,12 +7,12 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module @jit_eltwise_abs attributes {} {
-  func.func public @test_abs(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  func.func public @test_abs(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
     // CHECK-LABEL: func.func public @test_abs
     // CHECK: ttnn.abs
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: -> tensor<64x128xf32,
-    %0 = stablehlo.abs %arg0 : tensor<64x128xf32>
-    return %0 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: -> tensor<64x128xbf16,
+    %0 = stablehlo.abs %arg0 : tensor<64x128xbf16>
+    return %0 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/Unary/cbrt_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Unary/cbrt_op.mlir
@@ -7,12 +7,12 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module @jit_eltwise_rsqrt attributes {} {
-  func.func public @test_cbrt(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  func.func public @test_cbrt(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
     // CHECK-LABEL: func.func public @test_cbrt
     // CHECK: ttnn.cbrt
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: -> tensor<64x128xf32,
-    %0 = stablehlo.cbrt %arg0 : tensor<64x128xf32>
-    return %0 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: -> tensor<64x128xbf16,
+    %0 = stablehlo.cbrt %arg0 : tensor<64x128xbf16>
+    return %0 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/Unary/ceil_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Unary/ceil_op.mlir
@@ -7,12 +7,12 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module @jit_eltwise_ceil attributes {} {
-  func.func public @test_ceil(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  func.func public @test_ceil(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
     // CHECK-LABEL: func.func public @test_ceil
     // CHECK: ttnn.ceil
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: -> tensor<64x128xf32,
-    %0 = stablehlo.ceil %arg0 : tensor<64x128xf32>
-    return %0 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: -> tensor<64x128xbf16,
+    %0 = stablehlo.ceil %arg0 : tensor<64x128xbf16>
+    return %0 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/Unary/clamp_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Unary/clamp_op.mlir
@@ -7,16 +7,16 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module @test_clamp attributes {} {
-  func.func public @test_clamp_constant(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  func.func public @test_clamp_constant(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
     // CHECK-LABEL: func.func public @test_clamp_constant(
     // CHECK: ttnn.clamp_scalar
     // CHECK-SAME: {max = 3.000000e+00 : f32, min = 2.000000e+00 : f32}
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: -> tensor<64x128xf32,
-    %cst = stablehlo.constant dense<2.000000e+00> : tensor<64x128xf32>
-    %cst_0 = stablehlo.constant dense<3.000000e+00> : tensor<64x128xf32>
-    %0 = stablehlo.clamp %cst, %arg0, %cst_0 : tensor<64x128xf32>
-    return %0 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: -> tensor<64x128xbf16,
+    %cst = stablehlo.constant dense<2.000000e+00> : tensor<64x128xbf16>
+    %cst_0 = stablehlo.constant dense<3.000000e+00> : tensor<64x128xbf16>
+    %0 = stablehlo.clamp %cst, %arg0, %cst_0 : tensor<64x128xbf16>
+    return %0 : tensor<64x128xbf16>
   }
 
   func.func public @test_clamp_indirect_constant_reshape(%arg0: tensor<1x16xbf16>) -> tensor<1x16xbf16> {

--- a/test/ttmlir/Silicon/StableHLO/n150/Unary/clamp_tensor_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Unary/clamp_tensor_op.mlir
@@ -7,15 +7,15 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module @test_clamp_tensor attributes {} {
-  func.func public @test_clamp_tensor(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>, %arg2: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  func.func public @test_clamp_tensor(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>, %arg2: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
     // CHECK-LABEL: func.func public @test_clamp_tensor(
     // CHECK: %{{[0-9]+}} = "ttnn.clamp_tensor"(%arg0, %arg1, %arg2)
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: -> tensor<64x128xf32,
-    %0 = stablehlo.clamp %arg1, %arg0, %arg2 : tensor<64x128xf32>
-    return %0 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: -> tensor<64x128xbf16,
+    %0 = stablehlo.clamp %arg1, %arg0, %arg2 : tensor<64x128xbf16>
+    return %0 : tensor<64x128xbf16>
   }
 
   func.func public @test_clamp_tensor_constant(%arg0: tensor<32x32xbf16>, %arg1: tensor<bf16>) -> tensor<32x32xbf16> {

--- a/test/ttmlir/Silicon/StableHLO/n150/Unary/cosine_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Unary/cosine_op.mlir
@@ -7,12 +7,12 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module @jit_eltwise_cosine attributes {} {
-  func.func public @test_cosine(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  func.func public @test_cosine(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
     // CHECK-LABEL: func.func public @test_cosine
     // CHECK: ttnn.cos
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: -> tensor<64x128xf32,
-    %0 = stablehlo.cosine %arg0 : tensor<64x128xf32>
-    return %0 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: -> tensor<64x128xbf16,
+    %0 = stablehlo.cosine %arg0 : tensor<64x128xbf16>
+    return %0 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/Unary/exponential_minus_one_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Unary/exponential_minus_one_op.mlir
@@ -7,12 +7,12 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module @jit_eltwise_expm1 attributes {} {
-  func.func public @test_expm1(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  func.func public @test_expm1(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
     // CHECK-LABEL: func.func public @test_expm1
     // CHECK: ttnn.expm1
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: -> tensor<64x128xf32,
-    %0 = stablehlo.exponential_minus_one %arg0 : tensor<64x128xf32>
-    return %0 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: -> tensor<64x128xbf16,
+    %0 = stablehlo.exponential_minus_one %arg0 : tensor<64x128xbf16>
+    return %0 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/Unary/exponential_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Unary/exponential_op.mlir
@@ -7,12 +7,12 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module @jit_eltwise_exp attributes {} {
-  func.func public @test_exp(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  func.func public @test_exp(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
     // CHECK-LABEL: func.func public @test_exp
     // CHECK: ttnn.exp
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: -> tensor<64x128xf32,
-    %0 = stablehlo.exponential %arg0 : tensor<64x128xf32>
-    return %0 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: -> tensor<64x128xbf16,
+    %0 = stablehlo.exponential %arg0 : tensor<64x128xbf16>
+    return %0 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/Unary/floor_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Unary/floor_op.mlir
@@ -7,12 +7,12 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module @jit_eltwise_floor attributes {} {
-  func.func public @test_floor(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  func.func public @test_floor(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
     // CHECK-LABEL: func.func public @test_floor
     // CHECK: ttnn.floor
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: -> tensor<64x128xf32,
-    %0 = stablehlo.floor %arg0 : tensor<64x128xf32>
-    return %0 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: -> tensor<64x128xbf16,
+    %0 = stablehlo.floor %arg0 : tensor<64x128xbf16>
+    return %0 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/Unary/log_plus_one_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Unary/log_plus_one_op.mlir
@@ -7,12 +7,12 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module @jit_eltwise_log_plus_one attributes {} {
-  func.func public @test_log_plus_one(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  func.func public @test_log_plus_one(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
     // CHECK-LABEL: func.func public @test_log_plus_one
     // CHECK: ttnn.log1p
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: -> tensor<64x128xf32,
-    %0 = stablehlo.log_plus_one %arg0 : tensor<64x128xf32>
-    return %0 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: -> tensor<64x128xbf16,
+    %0 = stablehlo.log_plus_one %arg0 : tensor<64x128xbf16>
+    return %0 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/Unary/negate_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Unary/negate_op.mlir
@@ -7,12 +7,12 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module @jit_eltwise_neg attributes {} {
-  func.func public @test_neg(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  func.func public @test_neg(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
     // CHECK-LABEL: func.func public @test_neg
     // CHECK: ttnn.neg
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: -> tensor<64x128xf32,
-    %0 = stablehlo.negate %arg0 : tensor<64x128xf32>
-    return %0 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: -> tensor<64x128xbf16,
+    %0 = stablehlo.negate %arg0 : tensor<64x128xbf16>
+    return %0 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/Unary/permute_transpose_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Unary/permute_transpose_op.mlir
@@ -7,13 +7,13 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module {
-  func.func public @test_permute_transpose(%arg0: tensor<1x32x64x128xf32>) -> tensor<1x128x32x64xf32> {
+  func.func public @test_permute_transpose(%arg0: tensor<1x32x64x128xbf16>) -> tensor<1x128x32x64xbf16> {
     // CHECK-LABEL: func.func public @test_permute_transpose
     // CHECK: %[[VAL:[0-9]+]] = "ttnn.permute"
     // CHECK-SAME: permutation = array<i64: 0, 3, 1, 2>
-    // CHECK-SAME: tensor<1x32x64x128xf32,
-    // CHECK-SAME: -> tensor<1x128x32x64xf32,
-    %0 = stablehlo.transpose %arg0, dims = [0, 3, 1, 2] : (tensor<1x32x64x128xf32>) -> tensor<1x128x32x64xf32>
-    return %0 : tensor<1x128x32x64xf32>
+    // CHECK-SAME: tensor<1x32x64x128xbf16,
+    // CHECK-SAME: -> tensor<1x128x32x64xbf16,
+    %0 = stablehlo.transpose %arg0, dims = [0, 3, 1, 2] : (tensor<1x32x64x128xbf16>) -> tensor<1x128x32x64xbf16>
+    return %0 : tensor<1x128x32x64xbf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/Unary/rsqrt_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Unary/rsqrt_op.mlir
@@ -7,12 +7,12 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module @jit_eltwise_rsqrt attributes {} {
-  func.func public @test_rsqrt(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  func.func public @test_rsqrt(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
     // CHECK-LABEL: func.func public @test_rsqrt
     // CHECK: ttnn.rsqrt
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: -> tensor<64x128xf32,
-    %0 = stablehlo.rsqrt %arg0 : tensor<64x128xf32>
-    return %0 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: -> tensor<64x128xbf16,
+    %0 = stablehlo.rsqrt %arg0 : tensor<64x128xbf16>
+    return %0 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/Unary/sign_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Unary/sign_op.mlir
@@ -7,12 +7,12 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module @jit_eltwise_sign attributes {} {
-  func.func public @test_sign(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  func.func public @test_sign(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
     // CHECK-LABEL: func.func public @test_sign
     // CHECK: ttnn.sign
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: -> tensor<64x128xf32,
-    %0 = stablehlo.sign %arg0 : tensor<64x128xf32>
-    return %0 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: -> tensor<64x128xbf16,
+    %0 = stablehlo.sign %arg0 : tensor<64x128xbf16>
+    return %0 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/Unary/sine_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Unary/sine_op.mlir
@@ -7,12 +7,12 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module @jit_eltwise_sine attributes {} {
-  func.func public @test_sine(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  func.func public @test_sine(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
     // CHECK-LABEL: func.func public @test_sine
     // CHECK: ttnn.sin
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: -> tensor<64x128xf32,
-    %0 = stablehlo.sine %arg0 : tensor<64x128xf32>
-    return %0 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: -> tensor<64x128xbf16,
+    %0 = stablehlo.sine %arg0 : tensor<64x128xbf16>
+    return %0 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/Unary/sqrt_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Unary/sqrt_op.mlir
@@ -7,12 +7,12 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module @jit_eltwise_sqrt attributes {} {
-  func.func public @test_sqrt(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  func.func public @test_sqrt(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
     // CHECK-LABEL: func.func public @test_sqrt
     // CHECK: ttnn.sqrt
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: -> tensor<64x128xf32,
-    %0 = stablehlo.sqrt %arg0 : tensor<64x128xf32>
-    return %0 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: -> tensor<64x128xbf16,
+    %0 = stablehlo.sqrt %arg0 : tensor<64x128xbf16>
+    return %0 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/Unary/tranpose_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Unary/tranpose_op.mlir
@@ -7,13 +7,13 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module @jit_transpose attributes {} {
-  func.func public @test_transpose(%arg0: tensor<64x128xf32>) -> tensor<128x64xf32> {
+  func.func public @test_transpose(%arg0: tensor<64x128xbf16>) -> tensor<128x64xbf16> {
     // CHECK-LABEL: func.func public @test_transpose
     // CHECK: "ttnn.permute"
     // CHECK-SAME: permutation = array<i64: 1, 0>
-    // CHECK-SAME: tensor<64x128xf32,
-    // CHECK-SAME: -> tensor<128x64xf32,
-    %0 = stablehlo.transpose %arg0, dims = [1,0] : (tensor<64x128xf32>) -> tensor<128x64xf32>
-    return %0 : tensor<128x64xf32>
+    // CHECK-SAME: tensor<64x128xbf16,
+    // CHECK-SAME: -> tensor<128x64xbf16,
+    %0 = stablehlo.transpose %arg0, dims = [1,0] : (tensor<64x128xbf16>) -> tensor<128x64xbf16>
+    return %0 : tensor<128x64xbf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/convert_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/convert_op.mlir
@@ -2,7 +2,7 @@
 // RUN: rm -rf %t.ttnn
 // RUN: rm -rf %t.mlir
 // RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s | \
-// RUN:     ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" > %t.mlir
+// RUN:     ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-fp32=true system-desc-path=%system_desc_path%" > %t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 // RUN: FileCheck --input-file=%t.mlir %s
 

--- a/test/ttmlir/Silicon/StableHLO/n150/dot_general/dot_general_op_2d.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/dot_general/dot_general_op_2d.mlir
@@ -7,13 +7,13 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module @jit_dot_general_2d attributes {} {
-  func.func public @test_dot_general_2d(%arg0 : tensor<16x32xf32>, %arg1 : tensor<32x8xf32>) -> tensor<16x8xf32> {
+  func.func public @test_dot_general_2d(%arg0 : tensor<16x32xbf16>, %arg1 : tensor<32x8xbf16>) -> tensor<16x8xbf16> {
     // CHECK-LABEL: func.func public @test_dot_general
     // CHECK: ttnn.matmul
-    // CHECK-SAME: tensor<16x32xf32,
-    // CHECK-SAME: tensor<32x8xf32,
-    // CHECK-SAME: -> tensor<16x8xf32
-    %0 = stablehlo.dot_general %arg0, %arg1, contracting_dims = [1] x [0] : (tensor<16x32xf32>, tensor<32x8xf32>) -> tensor<16x8xf32>
-    return %0 : tensor<16x8xf32>
+    // CHECK-SAME: tensor<16x32xbf16,
+    // CHECK-SAME: tensor<32x8xbf16,
+    // CHECK-SAME: -> tensor<16x8xbf16
+    %0 = stablehlo.dot_general %arg0, %arg1, contracting_dims = [1] x [0] : (tensor<16x32xbf16>, tensor<32x8xbf16>) -> tensor<16x8xbf16>
+    return %0 : tensor<16x8xbf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/dot_general/dot_general_op_batch_matmul.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/dot_general/dot_general_op_batch_matmul.mlir
@@ -7,13 +7,13 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module @jit_dot_general_4d attributes {} {
-  func.func public @test_dot_general_4d(%arg0 : tensor<1x128x16x32xf32>, %arg1 : tensor<1x128x32x8xf32>) -> tensor<1x128x16x8xf32> {
+  func.func public @test_dot_general_4d(%arg0 : tensor<1x128x16x32xbf16>, %arg1 : tensor<1x128x32x8xbf16>) -> tensor<1x128x16x8xbf16> {
     // CHECK-LABEL: func.func public @test_dot_general
     // CHECK: ttnn.matmul
-    // CHECK-SAME: tensor<1x128x16x32xf32,
-    // CHECK-SAME: tensor<1x128x32x8xf32,
-    // CHECK-SAME: -> tensor<1x128x16x8xf32
-    %0 = stablehlo.dot_general %arg0, %arg1, batching_dims = [0, 1] x [0, 1], contracting_dims = [3] x [2] : (tensor<1x128x16x32xf32>, tensor<1x128x32x8xf32>) -> tensor<1x128x16x8xf32>
-    return %0 : tensor<1x128x16x8xf32>
+    // CHECK-SAME: tensor<1x128x16x32xbf16,
+    // CHECK-SAME: tensor<1x128x32x8xbf16,
+    // CHECK-SAME: -> tensor<1x128x16x8xbf16
+    %0 = stablehlo.dot_general %arg0, %arg1, batching_dims = [0, 1] x [0, 1], contracting_dims = [3] x [2] : (tensor<1x128x16x32xbf16>, tensor<1x128x32x8xbf16>) -> tensor<1x128x16x8xbf16>
+    return %0 : tensor<1x128x16x8xbf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/reduction/reduce_add_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/reduction/reduce_add_op.mlir
@@ -6,94 +6,94 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
 module @jit_reduce_add attributes {} {
-  func.func public @test_reduce_add_4to0dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+  func.func public @test_reduce_add_4to0dim(%arg0: tensor<128x10x32x4xbf16>, %cst_0: tensor<bf16>) -> tensor<bf16> {
     // CHECK: "ttnn.sum"
     // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32, 3 : i32]
     // CHECK-SAME: keep_dim = true
-    // CHECK-SAME: tensor<128x10x32x4xf32,
-    // CHECK-SAME: -> tensor<1x1x1x1xf32,
+    // CHECK-SAME: tensor<128x10x32x4xbf16,
+    // CHECK-SAME: -> tensor<1x1x1x1xbf16,
     // CHECK: "ttnn.reshape"
     // CHECK-SAME: shape = [1 : i32]
-    // CHECK-SAME: tensor<1x1x1x1xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [0, 1, 2, 3] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<f32>
-    return %0 : tensor<f32>
+    // CHECK-SAME: tensor<1x1x1x1xbf16,
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [0, 1, 2, 3] : (tensor<128x10x32x4xbf16>, tensor<bf16>) -> tensor<bf16>
+    return %0 : tensor<bf16>
   }
 
-  func.func public @test_reduce_add_4to1dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
+  func.func public @test_reduce_add_4to1dim(%arg0: tensor<128x10x32x4xbf16>, %cst_0: tensor<bf16>) -> tensor<128xbf16> {
     // CHECK-LABEL: @test_reduce_add_4to1dim(
     // CHECK: "ttnn.sum"
     // CHECK-SAME: dim_arg = [1 : i32, 2 : i32, 3 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x32x4xf32,
-    // CHECK-SAME: -> tensor<128xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [1, 2, 3] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<128xf32>
-    return %0 : tensor<128xf32>
+    // CHECK-SAME: tensor<128x10x32x4xbf16,
+    // CHECK-SAME: -> tensor<128xbf16,
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [1, 2, 3] : (tensor<128x10x32x4xbf16>, tensor<bf16>) -> tensor<128xbf16>
+    return %0 : tensor<128xbf16>
   }
 
-  func.func public @test_reduce_add_3to2dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128x4xf32> {
+  func.func public @test_reduce_add_3to2dim(%arg0: tensor<128x10x4xbf16>, %cst_0: tensor<bf16>) -> tensor<128x4xbf16> {
     // CHECK: "ttnn.sum"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x4xf32,
-    // CHECK-SAME: -> tensor<128x4xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [1] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128x4xf32>
-    return %0 : tensor<128x4xf32>
+    // CHECK-SAME: tensor<128x10x4xbf16,
+    // CHECK-SAME: -> tensor<128x4xbf16,
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [1] : (tensor<128x10x4xbf16>, tensor<bf16>) -> tensor<128x4xbf16>
+    return %0 : tensor<128x4xbf16>
   }
 
-  func.func public @test_reduce_add_3to1dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
+  func.func public @test_reduce_add_3to1dim(%arg0: tensor<128x10x4xbf16>, %cst_0: tensor<bf16>) -> tensor<128xbf16> {
     // CHECK: "ttnn.sum"
     // CHECK-SAME: dim_arg = [1 : i32, 2 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x4xf32,
-    // CHECK-SAME: -> tensor<128xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [1, 2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128xf32>
-    return %0 : tensor<128xf32>
+    // CHECK-SAME: tensor<128x10x4xbf16,
+    // CHECK-SAME: -> tensor<128xbf16,
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [1, 2] : (tensor<128x10x4xbf16>, tensor<bf16>) -> tensor<128xbf16>
+    return %0 : tensor<128xbf16>
   }
 
-  func.func public @test_reduce_add_3to0dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+  func.func public @test_reduce_add_3to0dim(%arg0: tensor<128x10x4xbf16>, %cst_0: tensor<bf16>) -> tensor<bf16> {
     // CHECK: "ttnn.sum"
     // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32]
     // CHECK-SAME: keep_dim = true
-    // CHECK-SAME: tensor<128x10x4xf32,
-    // CHECK-SAME: -> tensor<1x1x1xf32,
+    // CHECK-SAME: tensor<128x10x4xbf16,
+    // CHECK-SAME: -> tensor<1x1x1xbf16,
     // CHECK: "ttnn.reshape"
     // CHECK-SAME: shape = [1 : i32]
-    // CHECK-SAME: tensor<1x1x1xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [0, 1, 2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<f32>
-    return %0 : tensor<f32>
+    // CHECK-SAME: tensor<1x1x1xbf16,
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [0, 1, 2] : (tensor<128x10x4xbf16>, tensor<bf16>) -> tensor<bf16>
+    return %0 : tensor<bf16>
   }
 
-  func.func public @test_reduce_add_2to1dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
+  func.func public @test_reduce_add_2to1dim(%arg0: tensor<128x10xbf16>, %cst_0: tensor<bf16>) -> tensor<128xbf16> {
     // CHECK: "ttnn.sum"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10xf32,
-    // CHECK-SAME: -> tensor<128xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<128xf32>
-    return %0 : tensor<128xf32>
+    // CHECK-SAME: tensor<128x10xbf16,
+    // CHECK-SAME: -> tensor<128xbf16,
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [1] : (tensor<128x10xbf16>, tensor<bf16>) -> tensor<128xbf16>
+    return %0 : tensor<128xbf16>
   }
 
-  func.func public @test_reduce_add_2to0dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+  func.func public @test_reduce_add_2to0dim(%arg0: tensor<128x10xbf16>, %cst_0: tensor<bf16>) -> tensor<bf16> {
     // CHECK: "ttnn.sum"
     // CHECK-SAME: dim_arg = [0 : i32, 1 : i32]
     // CHECK-SAME: keep_dim = true
-    // CHECK-SAME: tensor<128x10xf32,
-    // CHECK-SAME: -> tensor<1x1xf32,
+    // CHECK-SAME: tensor<128x10xbf16,
+    // CHECK-SAME: -> tensor<1x1xbf16,
     // CHECK: "ttnn.reshape"
     // CHECK-SAME: shape = [1 : i32]
-    // CHECK-SAME: tensor<1x1xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [0, 1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<f32>
-    return %0 : tensor<f32>
+    // CHECK-SAME: tensor<1x1xbf16,
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [0, 1] : (tensor<128x10xbf16>, tensor<bf16>) -> tensor<bf16>
+    return %0 : tensor<bf16>
   }
 
-  func.func public @test_reduce_add_1to0dim(%arg0: tensor<128xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+  func.func public @test_reduce_add_1to0dim(%arg0: tensor<128xbf16>, %cst_0: tensor<bf16>) -> tensor<bf16> {
     // CHECK: "ttnn.sum"
     // CHECK-SAME: dim_arg = [0 : i32]
     // CHECK-SAME: keep_dim = true
-    // CHECK-SAME: tensor<128xf32,
-    // CHECK-SAME: -> tensor<1xf32,
+    // CHECK-SAME: tensor<128xbf16,
+    // CHECK-SAME: -> tensor<1xbf16,
     // CHECK-NOT: "ttnn.reshape"
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [0] : (tensor<128xf32>, tensor<f32>) -> tensor<f32>
-    return %0 : tensor<f32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.add across dimensions = [0] : (tensor<128xbf16>, tensor<bf16>) -> tensor<bf16>
+    return %0 : tensor<bf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/reduction/reduce_maximum_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/reduction/reduce_maximum_op.mlir
@@ -6,94 +6,94 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
 module @jit_reduce_maximum attributes {} {
-  func.func public @test_reduce_maximum_4to0dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+  func.func public @test_reduce_maximum_4to0dim(%arg0: tensor<128x10x32x4xbf16>, %cst_0: tensor<bf16>) -> tensor<bf16> {
     // CHECK: "ttnn.max"
     // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32, 3 : i32]
     // CHECK-SAME: keep_dim = true
-    // CHECK-SAME: tensor<128x10x32x4xf32,
-    // CHECK-SAME: -> tensor<1x1x1x1xf32,
+    // CHECK-SAME: tensor<128x10x32x4xbf16,
+    // CHECK-SAME: -> tensor<1x1x1x1xbf16,
     // CHECK: "ttnn.reshape"
     // CHECK-SAME: shape = [1 : i32]
-    // CHECK-SAME: tensor<1x1x1x1xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0, 1, 2, 3] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<f32>
-    return %0 : tensor<f32>
+    // CHECK-SAME: tensor<1x1x1x1xbf16,
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0, 1, 2, 3] : (tensor<128x10x32x4xbf16>, tensor<bf16>) -> tensor<bf16>
+    return %0 : tensor<bf16>
   }
 
-  func.func public @test_reduce_maximum_4to1dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
+  func.func public @test_reduce_maximum_4to1dim(%arg0: tensor<128x10x32x4xbf16>, %cst_0: tensor<bf16>) -> tensor<128xbf16> {
     // CHECK-LABEL: @test_reduce_maximum_4to1dim(
     // CHECK: "ttnn.max"
     // CHECK-SAME: dim_arg = [1 : i32, 2 : i32, 3 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x32x4xf32,
-    // CHECK-SAME: -> tensor<128xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1, 2, 3] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<128xf32>
-    return %0 : tensor<128xf32>
+    // CHECK-SAME: tensor<128x10x32x4xbf16,
+    // CHECK-SAME: -> tensor<128xbf16,
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1, 2, 3] : (tensor<128x10x32x4xbf16>, tensor<bf16>) -> tensor<128xbf16>
+    return %0 : tensor<128xbf16>
   }
 
-  func.func public @test_reduce_maximum_3to2dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128x4xf32> {
+  func.func public @test_reduce_maximum_3to2dim(%arg0: tensor<128x10x4xbf16>, %cst_0: tensor<bf16>) -> tensor<128x4xbf16> {
     // CHECK: "ttnn.max"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x4xf32,
-    // CHECK-SAME: -> tensor<128x4xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128x4xf32>
-    return %0 : tensor<128x4xf32>
+    // CHECK-SAME: tensor<128x10x4xbf16,
+    // CHECK-SAME: -> tensor<128x4xbf16,
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1] : (tensor<128x10x4xbf16>, tensor<bf16>) -> tensor<128x4xbf16>
+    return %0 : tensor<128x4xbf16>
   }
 
-  func.func public @test_reduce_maximum_3to1dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
+  func.func public @test_reduce_maximum_3to1dim(%arg0: tensor<128x10x4xbf16>, %cst_0: tensor<bf16>) -> tensor<128xbf16> {
     // CHECK: "ttnn.max"
     // CHECK-SAME: dim_arg = [1 : i32, 2 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x4xf32,
-    // CHECK-SAME: -> tensor<128xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1, 2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128xf32>
-    return %0 : tensor<128xf32>
+    // CHECK-SAME: tensor<128x10x4xbf16,
+    // CHECK-SAME: -> tensor<128xbf16,
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1, 2] : (tensor<128x10x4xbf16>, tensor<bf16>) -> tensor<128xbf16>
+    return %0 : tensor<128xbf16>
   }
 
-  func.func public @test_reduce_maximum_3to0dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+  func.func public @test_reduce_maximum_3to0dim(%arg0: tensor<128x10x4xbf16>, %cst_0: tensor<bf16>) -> tensor<bf16> {
     // CHECK: "ttnn.max"
     // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32]
     // CHECK-SAME: keep_dim = true
-    // CHECK-SAME: tensor<128x10x4xf32,
-    // CHECK-SAME: -> tensor<1x1x1xf32,
+    // CHECK-SAME: tensor<128x10x4xbf16,
+    // CHECK-SAME: -> tensor<1x1x1xbf16,
     // CHECK: "ttnn.reshape"
     // CHECK-SAME: shape = [1 : i32]
-    // CHECK-SAME: tensor<1x1x1xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0, 1, 2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<f32>
-    return %0 : tensor<f32>
+    // CHECK-SAME: tensor<1x1x1xbf16,
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0, 1, 2] : (tensor<128x10x4xbf16>, tensor<bf16>) -> tensor<bf16>
+    return %0 : tensor<bf16>
   }
 
-  func.func public @test_reduce_maximum_2to1dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
+  func.func public @test_reduce_maximum_2to1dim(%arg0: tensor<128x10xbf16>, %cst_0: tensor<bf16>) -> tensor<128xbf16> {
     // CHECK: "ttnn.max"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10xf32,
-    // CHECK-SAME: -> tensor<128xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<128xf32>
-    return %0 : tensor<128xf32>
+    // CHECK-SAME: tensor<128x10xbf16,
+    // CHECK-SAME: -> tensor<128xbf16,
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1] : (tensor<128x10xbf16>, tensor<bf16>) -> tensor<128xbf16>
+    return %0 : tensor<128xbf16>
   }
 
-  func.func public @test_reduce_maximum_2to0dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+  func.func public @test_reduce_maximum_2to0dim(%arg0: tensor<128x10xbf16>, %cst_0: tensor<bf16>) -> tensor<bf16> {
     // CHECK: "ttnn.max"
     // CHECK-SAME: dim_arg = [0 : i32, 1 : i32]
     // CHECK-SAME: keep_dim = true
-    // CHECK-SAME: tensor<128x10xf32,
-    // CHECK-SAME: -> tensor<1x1xf32,
+    // CHECK-SAME: tensor<128x10xbf16,
+    // CHECK-SAME: -> tensor<1x1xbf16,
     // CHECK: "ttnn.reshape"
     // CHECK-SAME: shape = [1 : i32]
-    // CHECK-SAME: tensor<1x1xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0, 1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<f32>
-    return %0 : tensor<f32>
+    // CHECK-SAME: tensor<1x1xbf16,
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0, 1] : (tensor<128x10xbf16>, tensor<bf16>) -> tensor<bf16>
+    return %0 : tensor<bf16>
   }
 
-  func.func public @test_reduce_maximum_1to0dim(%arg0: tensor<128xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+  func.func public @test_reduce_maximum_1to0dim(%arg0: tensor<128xbf16>, %cst_0: tensor<bf16>) -> tensor<bf16> {
     // CHECK: "ttnn.max"
     // CHECK-SAME: dim_arg = [0 : i32]
     // CHECK-SAME: keep_dim = true
-    // CHECK-SAME: tensor<128xf32,
-    // CHECK-SAME: -> tensor<1xf32,
+    // CHECK-SAME: tensor<128xbf16,
+    // CHECK-SAME: -> tensor<1xbf16,
     // CHECK-NOT: "ttnn.reshape"
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0] : (tensor<128xf32>, tensor<f32>) -> tensor<f32>
-    return %0 : tensor<f32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0] : (tensor<128xbf16>, tensor<bf16>) -> tensor<bf16>
+    return %0 : tensor<bf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/reduction/reduce_min_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/reduction/reduce_min_op.mlir
@@ -7,97 +7,97 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
 module @jit_reduce_minimum attributes {} {
-  func.func public @test_reduce_minimum_4to0dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+  func.func public @test_reduce_minimum_4to0dim(%arg0: tensor<128x10x32x4xbf16>, %cst_0: tensor<bf16>) -> tensor<bf16> {
     // CHECK: "ttnn.min"
     // CEHCK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32, 3 : i32]
     // CHECK-SAME: keep_dim = true
-    // CHECK-SAME: tensor<128x10x32x4xf32,
-    // CHECK-SAME: -> tensor<1x1x1x1xf32,
+    // CHECK-SAME: tensor<128x10x32x4xbf16,
+    // CHECK-SAME: -> tensor<1x1x1x1xbf16,
     // CHECK: "ttnn.reshape"
     // CHECK-SAME: shape = [1 : i32]
-    // CHECK-SAME: tensor<1x1x1x1xf32,
-    // CHECK-SAME: -> tensor<1xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [0, 1, 2, 3] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<f32>
-    return %0 : tensor<f32>
+    // CHECK-SAME: tensor<1x1x1x1xbf16,
+    // CHECK-SAME: -> tensor<1xbf16,
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [0, 1, 2, 3] : (tensor<128x10x32x4xbf16>, tensor<bf16>) -> tensor<bf16>
+    return %0 : tensor<bf16>
   }
 
-  func.func public @test_reduce_minimum_4to1dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
+  func.func public @test_reduce_minimum_4to1dim(%arg0: tensor<128x10x32x4xbf16>, %cst_0: tensor<bf16>) -> tensor<128xbf16> {
     // CHECK-LABEL: @test_reduce_minimum_4to1dim(
     // CHECK: "ttnn.min"
     // CHECK-SAME: dim_arg = [1 : i32, 2 : i32, 3 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x32x4xf32,
-    // CHECK-SAME: -> tensor<128xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [1, 2, 3] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<128xf32>
-    return %0 : tensor<128xf32>
+    // CHECK-SAME: tensor<128x10x32x4xbf16,
+    // CHECK-SAME: -> tensor<128xbf16,
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [1, 2, 3] : (tensor<128x10x32x4xbf16>, tensor<bf16>) -> tensor<128xbf16>
+    return %0 : tensor<128xbf16>
   }
 
-  func.func public @test_reduce_minimum_3to2dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128x4xf32> {
+  func.func public @test_reduce_minimum_3to2dim(%arg0: tensor<128x10x4xbf16>, %cst_0: tensor<bf16>) -> tensor<128x4xbf16> {
     // CHECK: "ttnn.min"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x4xf32,
-    // CHECK-SAME: -> tensor<128x4xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [1] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128x4xf32>
-    return %0 : tensor<128x4xf32>
+    // CHECK-SAME: tensor<128x10x4xbf16,
+    // CHECK-SAME: -> tensor<128x4xbf16,
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [1] : (tensor<128x10x4xbf16>, tensor<bf16>) -> tensor<128x4xbf16>
+    return %0 : tensor<128x4xbf16>
   }
 
-  func.func public @test_reduce_minimum_3to1dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
+  func.func public @test_reduce_minimum_3to1dim(%arg0: tensor<128x10x4xbf16>, %cst_0: tensor<bf16>) -> tensor<128xbf16> {
     // CHECK: "ttnn.min"
     // CHECK-SAME: dim_arg = [1 : i32, 2 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x4xf32,
-    // CHECK-SAME: -> tensor<128xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [1, 2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128xf32>
-    return %0 : tensor<128xf32>
+    // CHECK-SAME: tensor<128x10x4xbf16,
+    // CHECK-SAME: -> tensor<128xbf16,
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [1, 2] : (tensor<128x10x4xbf16>, tensor<bf16>) -> tensor<128xbf16>
+    return %0 : tensor<128xbf16>
   }
 
-  func.func public @test_reduce_minimum_3to0dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+  func.func public @test_reduce_minimum_3to0dim(%arg0: tensor<128x10x4xbf16>, %cst_0: tensor<bf16>) -> tensor<bf16> {
     // CHECK: "ttnn.min"
     // CEHCK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32]
     // CHECK-SAME: keep_dim = true
-    // CHECK-SAME: tensor<128x10x4xf32,
-    // CHECK-SAME: -> tensor<1x1x1xf32,
+    // CHECK-SAME: tensor<128x10x4xbf16,
+    // CHECK-SAME: -> tensor<1x1x1xbf16,
     // CHECK: "ttnn.reshape"
     // CHECK-SAME: shape = [1 : i32]
-    // CHECK-SAME: tensor<1x1x1xf32,
-    // CHECK-SAME: -> tensor<1xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [0, 1, 2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<f32>
-    return %0 : tensor<f32>
+    // CHECK-SAME: tensor<1x1x1xbf16,
+    // CHECK-SAME: -> tensor<1xbf16,
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [0, 1, 2] : (tensor<128x10x4xbf16>, tensor<bf16>) -> tensor<bf16>
+    return %0 : tensor<bf16>
   }
 
-  func.func public @test_reduce_minimum_2to1dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
+  func.func public @test_reduce_minimum_2to1dim(%arg0: tensor<128x10xbf16>, %cst_0: tensor<bf16>) -> tensor<128xbf16> {
     // CHECK: "ttnn.min"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10xf32,
-    // CHECK-SAME: -> tensor<128xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<128xf32>
-    return %0 : tensor<128xf32>
+    // CHECK-SAME: tensor<128x10xbf16,
+    // CHECK-SAME: -> tensor<128xbf16,
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [1] : (tensor<128x10xbf16>, tensor<bf16>) -> tensor<128xbf16>
+    return %0 : tensor<128xbf16>
   }
 
-  func.func public @test_reduce_minimum_2to0dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+  func.func public @test_reduce_minimum_2to0dim(%arg0: tensor<128x10xbf16>, %cst_0: tensor<bf16>) -> tensor<bf16> {
     // CHECK: "ttnn.min"
     // CEHCK-SAME: dim_arg = [0 : i32, 1 : i32]
     // CHECK-SAME: keep_dim = true
-    // CHECK-SAME: tensor<128x10xf32,
-    // CHECK-SAME: -> tensor<1x1xf32,
+    // CHECK-SAME: tensor<128x10xbf16,
+    // CHECK-SAME: -> tensor<1x1xbf16,
     // CHECK: "ttnn.reshape"
     // CHECK-SAME: shape = [1 : i32]
-    // CHECK-SAME: tensor<1x1xf32,
-    // CHECK-SAME: -> tensor<1xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [0, 1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<f32>
-    return %0 : tensor<f32>
+    // CHECK-SAME: tensor<1x1xbf16,
+    // CHECK-SAME: -> tensor<1xbf16,
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [0, 1] : (tensor<128x10xbf16>, tensor<bf16>) -> tensor<bf16>
+    return %0 : tensor<bf16>
   }
 
-  func.func public @test_reduce_minimum_1to0dim(%arg0: tensor<128xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+  func.func public @test_reduce_minimum_1to0dim(%arg0: tensor<128xbf16>, %cst_0: tensor<bf16>) -> tensor<bf16> {
     // CHECK: "ttnn.min"
     // CEHCK-SAME: dim_arg = [0 : i32]
     // CHECK-SAME: keep_dim = true
-    // CHECK-SAME: tensor<128xf32,
-    // CHECK-SAME: -> tensor<1xf32,
+    // CHECK-SAME: tensor<128xbf16,
+    // CHECK-SAME: -> tensor<1xbf16,
     // CHECK-NOT: "ttnn.reshape"
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [0] : (tensor<128xf32>, tensor<f32>) -> tensor<f32>
-    return %0 : tensor<f32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [0] : (tensor<128xbf16>, tensor<bf16>) -> tensor<bf16>
+    return %0 : tensor<bf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/reduction/reduce_prod_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/reduction/reduce_prod_op.mlir
@@ -7,39 +7,39 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module @jit_reduce_prod attributes {} {
-  func.func public @test_reduce_prod_4to3dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<128x32x4xf32> {
+  func.func public @test_reduce_prod_4to3dim(%arg0: tensor<128x10x32x4xbf16>, %cst_0: tensor<f32>) -> tensor<128x32x4xbf16> {
     // CHECK-LABEL: func.func public @test_reduce_prod_4to3dim
     // CHECK: "ttnn.prod"
     // CHECK: all_dimensions = false
     // CHECK-SAME: dim_arg = 1
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: (tensor<128x10x32x4xf32,
-    // CHECK-SAME: -> tensor<128x32x4xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.multiply across dimensions = [1] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<128x32x4xf32>
-    return %0 : tensor<128x32x4xf32>
+    // CHECK-SAME: (tensor<128x10x32x4xbf16,
+    // CHECK-SAME: -> tensor<128x32x4xbf16,
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.multiply across dimensions = [1] : (tensor<128x10x32x4xbf16>, tensor<f32>) -> tensor<128x32x4xbf16>
+    return %0 : tensor<128x32x4xbf16>
   }
 
-  func.func public @test_reduce_prod_3to2dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128x10xf32> {
+  func.func public @test_reduce_prod_3to2dim(%arg0: tensor<128x10x4xbf16>, %cst_0: tensor<f32>) -> tensor<128x10xbf16> {
     // CHECK-LABEL: func.func public @test_reduce_prod_3to2dim
     // CHECK: "ttnn.prod"
     // CHECK: all_dimensions = false
     // CHECK-SAME: dim_arg = 2
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: (tensor<128x10x4xf32,
-    // CHECK-SAME: -> tensor<128x10xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.multiply across dimensions = [2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128x10xf32>
-    return %0 : tensor<128x10xf32>
+    // CHECK-SAME: (tensor<128x10x4xbf16,
+    // CHECK-SAME: -> tensor<128x10xbf16,
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.multiply across dimensions = [2] : (tensor<128x10x4xbf16>, tensor<f32>) -> tensor<128x10xbf16>
+    return %0 : tensor<128x10xbf16>
   }
 
-  func.func public @test_reduce_prod_2to1dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
+  func.func public @test_reduce_prod_2to1dim(%arg0: tensor<128x10xbf16>, %cst_0: tensor<f32>) -> tensor<128xbf16> {
     // CHECK-LABEL: func.func public @test_reduce_prod_2to1dim
     // CHECK: "ttnn.prod"
     // CHECK: all_dimensions = false
     // CHECK-SAME: dim_arg = 1
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: (tensor<128x10xf32,
-    // CHECK-SAME: -> tensor<128xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.multiply across dimensions = [1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<128xf32>
-    return %0 : tensor<128xf32>
+    // CHECK-SAME: (tensor<128x10xbf16,
+    // CHECK-SAME: -> tensor<128xbf16,
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.multiply across dimensions = [1] : (tensor<128x10xbf16>, tensor<f32>) -> tensor<128xbf16>
+    return %0 : tensor<128xbf16>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/reshape_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/reshape_op.mlir
@@ -7,14 +7,14 @@
 // RUN: FileCheck --input-file=%t.mlir %s
 
 module @jit_module_reshape attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
-  func.func public @test_reshape(%arg0: tensor<1x64x64x64xf32> {mhlo.layout_mode = "default", mhlo.sharding = "{replicated}"}) -> (tensor<1x1x4096x64xf32> {jax.result_info = "", mhlo.layout_mode = "default"}) {
+  func.func public @test_reshape(%arg0: tensor<1x64x64x64xbf16> {mhlo.layout_mode = "default", mhlo.sharding = "{replicated}"}) -> (tensor<1x1x4096x64xbf16> {jax.result_info = "", mhlo.layout_mode = "default"}) {
     // CHECK-LABEL: func.func public @test_reshape
     // CHECK: ttnn.reshape
     // CHECK-SAME: {shape = [1 : i32, 1 : i32, 4096 : i32, 64 : i32]}
-    // CHECK-SAME: tensor<1x64x64x64xf32
-    // CHECK-SAME: -> tensor<1x1x4096x64xf32
-    %0 = stablehlo.reshape %arg0 : (tensor<1x64x64x64xf32>) -> tensor<1x1x4096x64xf32>
-    return %0 : tensor<1x1x4096x64xf32>
+    // CHECK-SAME: tensor<1x64x64x64xbf16
+    // CHECK-SAME: -> tensor<1x1x4096x64xbf16
+    %0 = stablehlo.reshape %arg0 : (tensor<1x64x64x64xbf16>) -> tensor<1x1x4096x64xbf16>
+    return %0 : tensor<1x1x4096x64xbf16>
   }
 
   func.func public @test_reshape_i64(%arg0: tensor<1x1x1xi64>) -> tensor<1x1xi64> {

--- a/test/ttmlir/Silicon/StableHLO/n150/scalar_add_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/scalar_add_op.mlir
@@ -9,9 +9,9 @@ module @jit_eltwise_scalar_add attributes {} {
   func.func public @test_scalar_add(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
     // CHECK-LABEL: func.func public @test_scalar_add
     // CHECK: ttnn.add
-    // CHECK-SAME: tensor<1xf32,
-    // CHECK-SAME: tensor<1xf32,
-    // CHECK-SAME: -> tensor<1xf32,
+    // CHECK-SAME: tensor<1xbf16,
+    // CHECK-SAME: tensor<1xbf16,
+    // CHECK-SAME: -> tensor<1xbf16,
     %0 = stablehlo.add %arg0, %arg1 : tensor<f32>
     return %0 : tensor<f32>
   }

--- a/test/ttmlir/Silicon/StableHLO/n150/slice_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/slice_op.mlir
@@ -2,7 +2,7 @@
 // RUN: rm -rf %t.ttnn
 // RUN: rm -rf %t.mlir
 // RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s \
-// RUN:     --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" > %t.mlir
+// RUN:     --ttir-to-ttnn-backend-pipeline="enable-fp32=true system-desc-path=%system_desc_path%" > %t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 // RUN: FileCheck --input-file=%t.mlir %s
 

--- a/test/ttmlir/Silicon/TTNN/n150/deallocate.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/deallocate.mlir
@@ -3,28 +3,28 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 #loc = loc("Dealloc":4294967295:0)
 module @"dealloc_test" attributes {} {
-  func.func @main(%arg0: tensor<1x784xf32> loc("Dealloc":4294967295:0), %arg1: tensor<1x10xf32> loc("Dealloc":4294967295:0), %arg2: tensor<256x10xf32> loc("Dealloc":4294967295:0), %arg3: tensor<1x256xf32> loc("Dealloc":4294967295:0), %arg4: tensor<784x256xf32> loc("Dealloc":4294967295:0)) -> tensor<1x10xf32> {
-    %0 = ttir.empty() : tensor<1x256xf32> loc(#loc8)
-    %1 = "ttir.matmul"(%arg0, %arg4, %0) : (tensor<1x784xf32>, tensor<784x256xf32>, tensor<1x256xf32>) -> tensor<1x256xf32> loc(#loc8)
-    // CHECK: %[[MATMUL1:.*]] = "ttnn.matmul"([[I1:%.+]], [[I2:%.+]]) {{.+}} -> tensor<1x256xf32, {{.+}}>
-    %2 = ttir.empty() : tensor<1x256xf32> loc(#loc9)
-    %3 = "ttir.add"(%1, %arg3, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x256xf32>, tensor<1x256xf32>, tensor<1x256xf32>) -> tensor<1x256xf32> loc(#loc9)
-    // CHECK: %{{.+}} = "ttnn.add"([[I1:%.+]], [[I2:%.+]]) {{.+}} -> tensor<1x256xf32, {{.+}}>
-    // CHECK: "ttnn.deallocate"(%[[MATMUL1]]) {{.+}} : (tensor<1x256xf32, {{.+}}>) -> ()
-    %4 = ttir.empty() : tensor<1x256xf32> loc(#loc10)
-    %5 = "ttir.relu"(%3, %4) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x256xf32>, tensor<1x256xf32>) -> tensor<1x256xf32> loc(#loc10)
-    // CHECK: %{{.+}} = "ttnn.relu"([[I1:%.+]]) {{.+}} -> tensor<1x256xf32, {{.+}}>
-    %6 = ttir.empty() : tensor<1x10xf32> loc(#loc11)
-    %7 = "ttir.matmul"(%5, %arg2, %6) : (tensor<1x256xf32>, tensor<256x10xf32>, tensor<1x10xf32>) -> tensor<1x10xf32> loc(#loc11)
-    // CHECK: %[[MATMUL2:.*]] = "ttnn.matmul"([[I1:%.+]], [[I2:%.+]]) {{.+}} -> tensor<1x10xf32, {{.+}}>
-    %8 = ttir.empty() : tensor<1x10xf32> loc(#loc12)
-    %9 = "ttir.add"(%7, %arg1, %8) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x10xf32>, tensor<1x10xf32>, tensor<1x10xf32>) -> tensor<1x10xf32> loc(#loc12)
-    // CHECK: %{{.+}} = "ttnn.add"([[I1:%.+]], [[I2:%.+]]) {{.+}} -> tensor<1x10xf32,{{.+}}>
-    // CHECK: "ttnn.deallocate"(%[[MATMUL2]]) {{.+}} : (tensor<1x10xf32, {{.+}}>) -> ()
-    %10 = ttir.empty() : tensor<1x10xf32> loc(#loc13)
-    %11 = "ttir.softmax"(%9, %10) <{dimension = 1 : si32}> : (tensor<1x10xf32>, tensor<1x10xf32>) -> tensor<1x10xf32> loc(#loc13)
-    // CHECK: %{{.+}} = "ttnn.softmax"([[I1:%.+]]) {{.+}} -> tensor<1x10xf32, {{.+}}>
-    return %11 : tensor<1x10xf32> loc(#loc7)
+  func.func @main(%arg0: tensor<1x784xbf16> loc("Dealloc":4294967295:0), %arg1: tensor<1x10xbf16> loc("Dealloc":4294967295:0), %arg2: tensor<256x10xbf16> loc("Dealloc":4294967295:0), %arg3: tensor<1x256xbf16> loc("Dealloc":4294967295:0), %arg4: tensor<784x256xbf16> loc("Dealloc":4294967295:0)) -> tensor<1x10xbf16> {
+    %0 = ttir.empty() : tensor<1x256xbf16> loc(#loc8)
+    %1 = "ttir.matmul"(%arg0, %arg4, %0) : (tensor<1x784xbf16>, tensor<784x256xbf16>, tensor<1x256xbf16>) -> tensor<1x256xbf16> loc(#loc8)
+    // CHECK: %[[MATMUL1:.*]] = "ttnn.matmul"([[I1:%.+]], [[I2:%.+]]) {{.+}} -> tensor<1x256xbf16, {{.+}}>
+    %2 = ttir.empty() : tensor<1x256xbf16> loc(#loc9)
+    %3 = "ttir.add"(%1, %arg3, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x256xbf16>, tensor<1x256xbf16>, tensor<1x256xbf16>) -> tensor<1x256xbf16> loc(#loc9)
+    // CHECK: %{{.+}} = "ttnn.add"([[I1:%.+]], [[I2:%.+]]) {{.+}} -> tensor<1x256xbf16, {{.+}}>
+    // CHECK: "ttnn.deallocate"(%[[MATMUL1]]) {{.+}} : (tensor<1x256xbf16, {{.+}}>) -> ()
+    %4 = ttir.empty() : tensor<1x256xbf16> loc(#loc10)
+    %5 = "ttir.relu"(%3, %4) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x256xbf16>, tensor<1x256xbf16>) -> tensor<1x256xbf16> loc(#loc10)
+    // CHECK: %{{.+}} = "ttnn.relu"([[I1:%.+]]) {{.+}} -> tensor<1x256xbf16, {{.+}}>
+    %6 = ttir.empty() : tensor<1x10xbf16> loc(#loc11)
+    %7 = "ttir.matmul"(%5, %arg2, %6) : (tensor<1x256xbf16>, tensor<256x10xbf16>, tensor<1x10xbf16>) -> tensor<1x10xbf16> loc(#loc11)
+    // CHECK: %[[MATMUL2:.*]] = "ttnn.matmul"([[I1:%.+]], [[I2:%.+]]) {{.+}} -> tensor<1x10xbf16, {{.+}}>
+    %8 = ttir.empty() : tensor<1x10xbf16> loc(#loc12)
+    %9 = "ttir.add"(%7, %arg1, %8) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x10xbf16>, tensor<1x10xbf16>, tensor<1x10xbf16>) -> tensor<1x10xbf16> loc(#loc12)
+    // CHECK: %{{.+}} = "ttnn.add"([[I1:%.+]], [[I2:%.+]]) {{.+}} -> tensor<1x10xbf16,{{.+}}>
+    // CHECK: "ttnn.deallocate"(%[[MATMUL2]]) {{.+}} : (tensor<1x10xbf16, {{.+}}>) -> ()
+    %10 = ttir.empty() : tensor<1x10xbf16> loc(#loc13)
+    %11 = "ttir.softmax"(%9, %10) <{dimension = 1 : si32}> : (tensor<1x10xbf16>, tensor<1x10xbf16>) -> tensor<1x10xbf16> loc(#loc13)
+    // CHECK: %{{.+}} = "ttnn.softmax"([[I1:%.+]]) {{.+}} -> tensor<1x10xbf16, {{.+}}>
+    return %11 : tensor<1x10xbf16> loc(#loc7)
   } loc(#loc)
 } loc(#loc)
 #loc1 = loc("Dealloc":4294967295:10)

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/binary/add/add.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/binary/add/add.mlir
@@ -2,12 +2,12 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @add(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.add"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @add(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.add"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.add"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/binary/atan2/simple_atan2.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/binary/atan2/simple_atan2.mlir
@@ -3,13 +3,13 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
 module attributes {} {
-  func.func @atan2(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x32xf32> {
-    %0 = ttir.empty() : tensor<32x32xf32>
-    %1 = "ttir.atan2"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+  func.func @atan2(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>) -> tensor<32x32xbf16> {
+    %0 = ttir.empty() : tensor<32x32xbf16>
+    %1 = "ttir.atan2"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
     // CHECK: "ttnn.atan2"
-    // CHECK-SAME: tensor<32x32xf32
-    // CHECK-SAME: tensor<32x32xf32
-    // CHECK-SAME: -> tensor<32x32xf32
-    return %1 : tensor<32x32xf32>
+    // CHECK-SAME: tensor<32x32xbf16
+    // CHECK-SAME: tensor<32x32xbf16
+    // CHECK-SAME: -> tensor<32x32xbf16
+    return %1 : tensor<32x32xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/binary/compare/simple_compare.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/binary/compare/simple_compare.mlir
@@ -2,63 +2,63 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 module attributes {} {
-  func.func @equal(%arg0: tensor<13x31xf32>, %arg1: tensor<13x31xf32>) -> tensor<13x31xf32> {
-    %0 = ttir.empty() : tensor<13x31xf32>
-    %1 = "ttir.eq"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x31xf32>, tensor<13x31xf32>, tensor<13x31xf32>) -> tensor<13x31xf32>
+  func.func @equal(%arg0: tensor<13x31xbf16>, %arg1: tensor<13x31xbf16>) -> tensor<13x31xbf16> {
+    %0 = ttir.empty() : tensor<13x31xbf16>
+    %1 = "ttir.eq"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x31xbf16>, tensor<13x31xbf16>, tensor<13x31xbf16>) -> tensor<13x31xbf16>
     // CHECK: "ttnn.eq"
-    // CHECK-SAME: tensor<13x31xf32
-    // CHECK-SAME: tensor<13x31xf32
-    // CHECK-SAME: -> tensor<13x31xf32
-    return %1 : tensor<13x31xf32>
+    // CHECK-SAME: tensor<13x31xbf16
+    // CHECK-SAME: tensor<13x31xbf16
+    // CHECK-SAME: -> tensor<13x31xbf16
+    return %1 : tensor<13x31xbf16>
   }
 
-  func.func @not_equal(%arg0: tensor<13x31xf32>, %arg1: tensor<13x31xf32>) -> tensor<13x31xf32> {
-    %0 = ttir.empty() : tensor<13x31xf32>
-    %1 = "ttir.ne"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x31xf32>, tensor<13x31xf32>, tensor<13x31xf32>) -> tensor<13x31xf32>
+  func.func @not_equal(%arg0: tensor<13x31xbf16>, %arg1: tensor<13x31xbf16>) -> tensor<13x31xbf16> {
+    %0 = ttir.empty() : tensor<13x31xbf16>
+    %1 = "ttir.ne"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x31xbf16>, tensor<13x31xbf16>, tensor<13x31xbf16>) -> tensor<13x31xbf16>
     // CHECK: "ttnn.ne"
-    // CHECK-SAME: tensor<13x31xf32
-    // CHECK-SAME: tensor<13x31xf32
-    // CHECK-SAME: -> tensor<13x31xf32
-    return %1 : tensor<13x31xf32>
+    // CHECK-SAME: tensor<13x31xbf16
+    // CHECK-SAME: tensor<13x31xbf16
+    // CHECK-SAME: -> tensor<13x31xbf16
+    return %1 : tensor<13x31xbf16>
   }
 
-  func.func @greater_equal(%arg0: tensor<13x31xf32>, %arg1: tensor<13x31xf32>) -> tensor<13x31xf32> {
-    %0 = ttir.empty() : tensor<13x31xf32>
-    %1 = "ttir.ge"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x31xf32>, tensor<13x31xf32>, tensor<13x31xf32>) -> tensor<13x31xf32>
+  func.func @greater_equal(%arg0: tensor<13x31xbf16>, %arg1: tensor<13x31xbf16>) -> tensor<13x31xbf16> {
+    %0 = ttir.empty() : tensor<13x31xbf16>
+    %1 = "ttir.ge"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x31xbf16>, tensor<13x31xbf16>, tensor<13x31xbf16>) -> tensor<13x31xbf16>
     // CHECK: "ttnn.ge"
-    // CHECK-SAME: tensor<13x31xf32
-    // CHECK-SAME: tensor<13x31xf32
-    // CHECK-SAME: -> tensor<13x31xf32
-    return %1 : tensor<13x31xf32>
+    // CHECK-SAME: tensor<13x31xbf16
+    // CHECK-SAME: tensor<13x31xbf16
+    // CHECK-SAME: -> tensor<13x31xbf16
+    return %1 : tensor<13x31xbf16>
   }
 
-  func.func @greater_than(%arg0: tensor<13x31xf32>, %arg1: tensor<13x31xf32>) -> tensor<13x31xf32> {
-    %0 = ttir.empty() : tensor<13x31xf32>
-    %1 = "ttir.gt"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x31xf32>, tensor<13x31xf32>, tensor<13x31xf32>) -> tensor<13x31xf32>
+  func.func @greater_than(%arg0: tensor<13x31xbf16>, %arg1: tensor<13x31xbf16>) -> tensor<13x31xbf16> {
+    %0 = ttir.empty() : tensor<13x31xbf16>
+    %1 = "ttir.gt"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x31xbf16>, tensor<13x31xbf16>, tensor<13x31xbf16>) -> tensor<13x31xbf16>
     // CHECK: "ttnn.gt"
-    // CHECK-SAME: tensor<13x31xf32
-    // CHECK-SAME: tensor<13x31xf32
-    // CHECK-SAME: -> tensor<13x31xf32
-    return %1 : tensor<13x31xf32>
+    // CHECK-SAME: tensor<13x31xbf16
+    // CHECK-SAME: tensor<13x31xbf16
+    // CHECK-SAME: -> tensor<13x31xbf16
+    return %1 : tensor<13x31xbf16>
   }
 
-  func.func @less_equal(%arg0: tensor<13x31xf32>, %arg1: tensor<13x31xf32>) -> tensor<13x31xf32> {
-    %0 = ttir.empty() : tensor<13x31xf32>
-    %1 = "ttir.le"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x31xf32>, tensor<13x31xf32>, tensor<13x31xf32>) -> tensor<13x31xf32>
+  func.func @less_equal(%arg0: tensor<13x31xbf16>, %arg1: tensor<13x31xbf16>) -> tensor<13x31xbf16> {
+    %0 = ttir.empty() : tensor<13x31xbf16>
+    %1 = "ttir.le"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x31xbf16>, tensor<13x31xbf16>, tensor<13x31xbf16>) -> tensor<13x31xbf16>
     // CHECK: "ttnn.le"
-    // CHECK-SAME: tensor<13x31xf32
-    // CHECK-SAME: tensor<13x31xf32
-    // CHECK-SAME: -> tensor<13x31xf32
-    return %1 : tensor<13x31xf32>
+    // CHECK-SAME: tensor<13x31xbf16
+    // CHECK-SAME: tensor<13x31xbf16
+    // CHECK-SAME: -> tensor<13x31xbf16
+    return %1 : tensor<13x31xbf16>
   }
 
-  func.func @less_than(%arg0: tensor<13x31xf32>, %arg1: tensor<13x31xf32>) -> tensor<13x31xf32> {
-    %0 = ttir.empty() : tensor<13x31xf32>
-    %1 = "ttir.lt"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x31xf32>, tensor<13x31xf32>, tensor<13x31xf32>) -> tensor<13x31xf32>
+  func.func @less_than(%arg0: tensor<13x31xbf16>, %arg1: tensor<13x31xbf16>) -> tensor<13x31xbf16> {
+    %0 = ttir.empty() : tensor<13x31xbf16>
+    %1 = "ttir.lt"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x31xbf16>, tensor<13x31xbf16>, tensor<13x31xbf16>) -> tensor<13x31xbf16>
     // CHECK: "ttnn.lt"
-    // CHECK-SAME: tensor<13x31xf32
-    // CHECK-SAME: tensor<13x31xf32
-    // CHECK-SAME: -> tensor<13x31xf32
-    return %1 : tensor<13x31xf32>
+    // CHECK-SAME: tensor<13x31xbf16
+    // CHECK-SAME: tensor<13x31xbf16
+    // CHECK-SAME: -> tensor<13x31xbf16
+    return %1 : tensor<13x31xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/binary/div/div.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/binary/div/div.mlir
@@ -2,12 +2,12 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @div(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.div"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @div(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.div"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.divide"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/binary/ge/ge.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/binary/ge/ge.mlir
@@ -2,12 +2,12 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @ge(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.ge"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @ge(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.ge"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.ge"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/binary/logical/simple_logical.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/binary/logical/simple_logical.mlir
@@ -3,24 +3,24 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
 module attributes {} {
-  func.func @logical_and(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.logical_and"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @logical_and(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.logical_and"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.logical_and"
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 
-  func.func @logical_or(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.logical_or"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @logical_or(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.logical_or"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.logical_or"
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 
   func.func @logical_xor(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/binary/maximum/maximum.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/binary/maximum/maximum.mlir
@@ -2,12 +2,12 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @maximum(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.maximum"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @maximum(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.maximum"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.maximum"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/binary/minimum/minimum.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/binary/minimum/minimum.mlir
@@ -2,12 +2,12 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @minimum(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.minimum"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @minimum(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.minimum"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.minimum"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/binary/multiply/multiply.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/binary/multiply/multiply.mlir
@@ -2,12 +2,12 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @multiply(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.multiply"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @multiply(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.multiply"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.multiply"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/binary/pow/pow.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/binary/pow/pow.mlir
@@ -2,12 +2,12 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @pow(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x32xf32> {
-  %0 = ttir.empty() : tensor<32x32xf32>
-  %1 = "ttir.pow"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+func.func @pow(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>) -> tensor<32x32xbf16> {
+  %0 = ttir.empty() : tensor<32x32xbf16>
+  %1 = "ttir.pow"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
   // CHECK: "ttnn.pow"
-  // CHECK-SAME: tensor<32x32xf32
-  // CHECK-SAME: tensor<32x32xf32
-  // CHECK-SAME: -> tensor<32x32xf32
-  return %1 : tensor<32x32xf32>
+  // CHECK-SAME: tensor<32x32xbf16
+  // CHECK-SAME: tensor<32x32xbf16
+  // CHECK-SAME: -> tensor<32x32xbf16
+  return %1 : tensor<32x32xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/binary/remainder/remainder.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/binary/remainder/remainder.mlir
@@ -2,12 +2,12 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @remainder(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x32xf32> {
-  %0 = ttir.empty() : tensor<32x32xf32>
-  %1 = "ttir.remainder"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+func.func @remainder(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>) -> tensor<32x32xbf16> {
+  %0 = ttir.empty() : tensor<32x32xbf16>
+  %1 = "ttir.remainder"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
   // CHECK: "ttnn.remainder"
-  // CHECK-SAME: tensor<32x32xf32
-  // CHECK-SAME: tensor<32x32xf32
-  // CHECK-SAME: -> tensor<32x32xf32
-  return %1 : tensor<32x32xf32>
+  // CHECK-SAME: tensor<32x32xbf16
+  // CHECK-SAME: tensor<32x32xbf16
+  // CHECK-SAME: -> tensor<32x32xbf16
+  return %1 : tensor<32x32xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/binary/subtract/subtract.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/binary/subtract/subtract.mlir
@@ -2,12 +2,12 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @subtract(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.subtract"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @subtract(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.subtract"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.subtract"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/atan/atan.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/atan/atan.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 module attributes {} {
-  func.func @atan(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.atan"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @atan(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.atan"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.atan"
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/cbrt/cbrt.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/cbrt/cbrt.mlir
@@ -2,11 +2,11 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @cbrt(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.cbrt"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @cbrt(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.cbrt"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.cbrt"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/ceil/ceil.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/ceil/ceil.mlir
@@ -2,11 +2,11 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @ceil(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
-  %0 = ttir.empty() : tensor<32x32xf32>
-  %1 = "ttir.ceil"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+func.func @ceil(%arg0: tensor<32x32xbf16>) -> tensor<32x32xbf16> {
+  %0 = ttir.empty() : tensor<32x32xbf16>
+  %1 = "ttir.ceil"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
   // CHECK: "ttnn.ceil"
-  // CHECK-SAME: tensor<32x32xf32
-  // CHECK-SAME: -> tensor<32x32xf32
-  return %1 : tensor<32x32xf32>
+  // CHECK-SAME: tensor<32x32xbf16
+  // CHECK-SAME: -> tensor<32x32xbf16
+  return %1 : tensor<32x32xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/clamp/clamp_tensor.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/clamp/clamp_tensor.mlir
@@ -2,14 +2,14 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func public @test_clamp_tensor(%arg0: tensor<32x64xf32>, %arg1: tensor<32x64xf32>, %arg2: tensor<32x64xf32>) -> tensor<32x64xf32> {
+func.func public @test_clamp_tensor(%arg0: tensor<32x64xbf16>, %arg1: tensor<32x64xbf16>, %arg2: tensor<32x64xbf16>) -> tensor<32x64xbf16> {
   // CHECK-LABEL: func.func public @test_clamp_tensor(
-  %0 = ttir.empty() : tensor<32x64xf32>
+  %0 = ttir.empty() : tensor<32x64xbf16>
   // CHECK: %{{[0-9]+}} = "ttnn.clamp_tensor"(%arg0, %arg1, %arg2)
-  // CHECK-SAME: tensor<32x64xf32,
-  // CHECK-SAME: tensor<32x64xf32,
-  // CHECK-SAME: tensor<32x64xf32,
-  // CHECK-SAME: -> tensor<32x64xf32,
-  %1 = "ttir.clamp_tensor"(%arg0, %arg1, %arg2, %0) : (tensor<32x64xf32>, tensor<32x64xf32>, tensor<32x64xf32>, tensor<32x64xf32>) -> tensor<32x64xf32>
-  return %1 : tensor<32x64xf32>
+  // CHECK-SAME: tensor<32x64xbf16,
+  // CHECK-SAME: tensor<32x64xbf16,
+  // CHECK-SAME: tensor<32x64xbf16,
+  // CHECK-SAME: -> tensor<32x64xbf16,
+  %1 = "ttir.clamp_tensor"(%arg0, %arg1, %arg2, %0) : (tensor<32x64xbf16>, tensor<32x64xbf16>, tensor<32x64xbf16>, tensor<32x64xbf16>) -> tensor<32x64xbf16>
+  return %1 : tensor<32x64xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/cosine/cosine.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/cosine/cosine.mlir
@@ -2,11 +2,11 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @cosine(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
-  %0 = ttir.empty() : tensor<32x32xf32>
-  %1 = "ttir.cos"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+func.func @cosine(%arg0: tensor<32x32xbf16>) -> tensor<32x32xbf16> {
+  %0 = ttir.empty() : tensor<32x32xbf16>
+  %1 = "ttir.cos"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
   // CHECK: "ttnn.cos"
-  // CHECK-SAME: tensor<32x32xf32
-  // CHECK-SAME: -> tensor<32x32xf32
-  return %1 : tensor<32x32xf32>
+  // CHECK-SAME: tensor<32x32xbf16
+  // CHECK-SAME: -> tensor<32x32xbf16
+  return %1 : tensor<32x32xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/expm1/expm1.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/expm1/expm1.mlir
@@ -2,11 +2,11 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @expm1(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.expm1"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @expm1(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.expm1"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.expm1"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/floor/floor.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/floor/floor.mlir
@@ -2,11 +2,11 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @floor(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.floor"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @floor(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.floor"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.floor"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/gelu/gelu.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/gelu/gelu.mlir
@@ -2,11 +2,11 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @gelu(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.gelu"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @gelu(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.gelu"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.gelu"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/leaky_relu/leaky_relu.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/leaky_relu/leaky_relu.mlir
@@ -2,12 +2,12 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @leaky_relu(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.leaky_relu"(%arg0, %0) <{parameter = 0.01 : f32, operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @leaky_relu(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.leaky_relu"(%arg0, %0) <{parameter = 0.01 : f32, operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.leaky_relu"
     // CHECK-SAME: <{parameter = 0.00999999977 : f32}>
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/log/log.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/log/log.mlir
@@ -2,11 +2,11 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @log(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.log"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @log(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.log"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.log"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/log1p/log1p.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/log1p/log1p.mlir
@@ -2,11 +2,11 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @log1p(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.log1p"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @log1p(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.log1p"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.log1p"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/logical_not/simple_not.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/logical_not/simple_not.mlir
@@ -3,12 +3,12 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
 module attributes {} {
-  func.func @logical_not(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.logical_not"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  func.func @logical_not(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.logical_not"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.logical_not"
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/negate/negate.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/negate/negate.mlir
@@ -2,11 +2,11 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @negate(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
-  %0 = ttir.empty() : tensor<32x32xf32>
-  %1 = "ttir.neg"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+func.func @negate(%arg0: tensor<32x32xbf16>) -> tensor<32x32xbf16> {
+  %0 = ttir.empty() : tensor<32x32xbf16>
+  %1 = "ttir.neg"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
   // CHECK: "ttnn.neg"
-  // CHECK-SAME: tensor<32x32xf32
-  // CHECK-SAME: -> tensor<32x32xf32
-  return %1 : tensor<32x32xf32>
+  // CHECK-SAME: tensor<32x32xbf16
+  // CHECK-SAME: -> tensor<32x32xbf16
+  return %1 : tensor<32x32xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/recipricol/recipricol.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/recipricol/recipricol.mlir
@@ -2,11 +2,11 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @reciprocal(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.reciprocal"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @reciprocal(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.reciprocal"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.reciprocal"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/relu/relu.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/relu/relu.mlir
@@ -2,11 +2,11 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @relu(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.relu"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @relu(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.relu"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.relu"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/rsqrt/rsqrt.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/rsqrt/rsqrt.mlir
@@ -2,11 +2,11 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @rsqrt(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.rsqrt"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @rsqrt(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.rsqrt"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.rsqrt"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/sigmoid/sigmoid.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/sigmoid/sigmoid.mlir
@@ -2,11 +2,11 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @sigmoid(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.sigmoid"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @sigmoid(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.sigmoid"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.sigmoid"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/sign/sign.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/sign/sign.mlir
@@ -2,11 +2,11 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @sign(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.sign"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @sign(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.sign"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.sign"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/sine/sine.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/sine/sine.mlir
@@ -2,11 +2,11 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @sine(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
-  %0 = ttir.empty() : tensor<32x32xf32>
-  %1 = "ttir.sin"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+func.func @sine(%arg0: tensor<32x32xbf16>) -> tensor<32x32xbf16> {
+  %0 = ttir.empty() : tensor<32x32xbf16>
+  %1 = "ttir.sin"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
   // CHECK: "ttnn.sin"
-  // CHECK-SAME: tensor<32x32xf32
-  // CHECK-SAME: -> tensor<32x32xf32
-  return %1 : tensor<32x32xf32>
+  // CHECK-SAME: tensor<32x32xbf16
+  // CHECK-SAME: -> tensor<32x32xbf16
+  return %1 : tensor<32x32xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/sqrt/sqrt.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/sqrt/sqrt.mlir
@@ -2,11 +2,11 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @sqrt(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.sqrt"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @sqrt(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.sqrt"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.sqrt"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/ones.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/ones.mlir
@@ -21,9 +21,9 @@ module {
     return %0 : tensor<13x24x56x42xbf16>
   }
 
-  func.func @ones_f32() -> tensor<32x64x128xf32> {
-    // CHECK: {{.*}} = "ttnn.ones"({{.*}}) {{.*}} -> tensor<32x64x128xf32{{.*}}>
-    %0 = "ttir.ones"() <{shape = array<i32:32, 64, 128>}> : () -> tensor<32x64x128xf32>
-    return %0 : tensor<32x64x128xf32>
+  func.func @ones_f32() -> tensor<32x64x128xbf16> {
+    // CHECK: {{.*}} = "ttnn.ones"({{.*}}) {{.*}} -> tensor<32x64x128xbf16{{.*}}>
+    %0 = "ttir.ones"() <{shape = array<i32:32, 64, 128>}> : () -> tensor<32x64x128xbf16>
+    return %0 : tensor<32x64x128xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/mnist_linear.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/mnist_linear.mlir
@@ -3,30 +3,30 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer mnist_linear_out.mlir > %t.ttnn
 #loc = loc("MNISTLinear":0:0)
 module @MNISTLinear attributes {} {
-  func.func @forward(%arg0: tensor<1x784xf32> {ttir.name = "input_1"} loc("MNISTLinear":0:0), %arg1: tensor<784x256xf32> {ttir.name = "l1.weight"} loc("MNISTLinear":0:0), %arg2: tensor<256xf32> {ttir.name = "l1.bias"} loc("MNISTLinear":0:0), %arg3: tensor<256x10xf32> {ttir.name = "l2.weight"} loc("MNISTLinear":0:0), %arg4: tensor<10xf32> {ttir.name = "l2.bias"} loc("MNISTLinear":0:0)) -> (tensor<1x10xf32> {ttir.name = "MNISTLinear.output_softmax_9"}) {
-    // CHECK-DAG: #[[LAYOUT_8:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x8x!tt.tile<32x32, f32>, #dram>, <interleaved>>
-    // CHECK-DAG: #[[LAYOUT_10:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<8x1x!tt.tile<32x32, f32>, #dram>, <interleaved>>
-    // CHECK-DAG: #[[LAYOUT_11:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!tt.tile<32x32, f32>, #dram>, <interleaved>>
-    // CHECK-DAG: #[[LAYOUT_12:.*]] = #ttnn.ttnn_layout<(d0) -> (0, d0), <1x1>, memref<1x1x!tt.tile<32x32, f32>, #dram>, <interleaved>>
-    %0 = ttir.empty() : tensor<1x256xf32> loc(#loc8)
-    // CHECK: %{{.*}} = "ttnn.matmul"{{.*}} -> tensor<1x256xf32, #[[LAYOUT_8]]>
-    %1 = "ttir.matmul"(%arg0, %arg1, %0) : (tensor<1x784xf32>, tensor<784x256xf32>, tensor<1x256xf32>) -> tensor<1x256xf32> loc(#loc8)
-    %2 = ttir.empty() : tensor<1x256xf32> loc(#loc9)
-    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x256xf32, #[[LAYOUT_8]]>
-    %3 = "ttir.add"(%1, %arg2, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x256xf32>, tensor<256xf32>, tensor<1x256xf32>) -> tensor<1x256xf32> loc(#loc9)
-    %4 = ttir.empty() : tensor<1x256xf32> loc(#loc10)
-    // CHECK: %{{.*}} = "ttnn.relu"{{.*}} -> tensor<1x256xf32, #[[LAYOUT_8]]>
-    %5 = "ttir.relu"(%3, %4) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x256xf32>, tensor<1x256xf32>) -> tensor<1x256xf32> loc(#loc10)
-    %6 = ttir.empty() : tensor<1x10xf32> loc(#loc11)
-    // CHECK: %{{.*}} = "ttnn.matmul"{{.*}} -> tensor<1x10xf32, #[[LAYOUT_11]]>
-    %7 = "ttir.matmul"(%5, %arg3, %6) : (tensor<1x256xf32>, tensor<256x10xf32>, tensor<1x10xf32>) -> tensor<1x10xf32> loc(#loc11)
-    %8 = ttir.empty() : tensor<1x10xf32> loc(#loc12)
-    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x10xf32, #[[LAYOUT_11]]>
-    %9 = "ttir.add"(%7, %arg4, %8) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x10xf32>, tensor<10xf32>, tensor<1x10xf32>) -> tensor<1x10xf32> loc(#loc12)
-    %10 = ttir.empty() : tensor<1x10xf32> loc(#loc13)
-    // CHECK: %{{.*}} = "ttnn.softmax"{{.*}} -> tensor<1x10xf32, #[[LAYOUT_11]]>
-    %11 = "ttir.softmax"(%9, %10) <{dimension = 1 : si32}> : (tensor<1x10xf32>, tensor<1x10xf32>) -> tensor<1x10xf32> loc(#loc13)
-    return %11 : tensor<1x10xf32> loc(#loc7)
+  func.func @forward(%arg0: tensor<1x784xbf16> {ttir.name = "input_1"} loc("MNISTLinear":0:0), %arg1: tensor<784x256xbf16> {ttir.name = "l1.weight"} loc("MNISTLinear":0:0), %arg2: tensor<256xbf16> {ttir.name = "l1.bias"} loc("MNISTLinear":0:0), %arg3: tensor<256x10xbf16> {ttir.name = "l2.weight"} loc("MNISTLinear":0:0), %arg4: tensor<10xbf16> {ttir.name = "l2.bias"} loc("MNISTLinear":0:0)) -> (tensor<1x10xbf16> {ttir.name = "MNISTLinear.output_softmax_9"}) {
+    // CHECK-DAG: #[[LAYOUT_8:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x8x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
+    // CHECK-DAG: #[[LAYOUT_10:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<8x1x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
+    // CHECK-DAG: #[[LAYOUT_11:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
+    // CHECK-DAG: #[[LAYOUT_12:.*]] = #ttnn.ttnn_layout<(d0) -> (0, d0), <1x1>, memref<1x1x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
+    %0 = ttir.empty() : tensor<1x256xbf16> loc(#loc8)
+    // CHECK: %{{.*}} = "ttnn.matmul"{{.*}} -> tensor<1x256xbf16, #[[LAYOUT_8]]>
+    %1 = "ttir.matmul"(%arg0, %arg1, %0) : (tensor<1x784xbf16>, tensor<784x256xbf16>, tensor<1x256xbf16>) -> tensor<1x256xbf16> loc(#loc8)
+    %2 = ttir.empty() : tensor<1x256xbf16> loc(#loc9)
+    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x256xbf16, #[[LAYOUT_8]]>
+    %3 = "ttir.add"(%1, %arg2, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x256xbf16>, tensor<256xbf16>, tensor<1x256xbf16>) -> tensor<1x256xbf16> loc(#loc9)
+    %4 = ttir.empty() : tensor<1x256xbf16> loc(#loc10)
+    // CHECK: %{{.*}} = "ttnn.relu"{{.*}} -> tensor<1x256xbf16, #[[LAYOUT_8]]>
+    %5 = "ttir.relu"(%3, %4) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x256xbf16>, tensor<1x256xbf16>) -> tensor<1x256xbf16> loc(#loc10)
+    %6 = ttir.empty() : tensor<1x10xbf16> loc(#loc11)
+    // CHECK: %{{.*}} = "ttnn.matmul"{{.*}} -> tensor<1x10xbf16, #[[LAYOUT_11]]>
+    %7 = "ttir.matmul"(%5, %arg3, %6) : (tensor<1x256xbf16>, tensor<256x10xbf16>, tensor<1x10xbf16>) -> tensor<1x10xbf16> loc(#loc11)
+    %8 = ttir.empty() : tensor<1x10xbf16> loc(#loc12)
+    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x10xbf16, #[[LAYOUT_11]]>
+    %9 = "ttir.add"(%7, %arg4, %8) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x10xbf16>, tensor<10xbf16>, tensor<1x10xbf16>) -> tensor<1x10xbf16> loc(#loc12)
+    %10 = ttir.empty() : tensor<1x10xbf16> loc(#loc13)
+    // CHECK: %{{.*}} = "ttnn.softmax"{{.*}} -> tensor<1x10xbf16, #[[LAYOUT_11]]>
+    %11 = "ttir.softmax"(%9, %10) <{dimension = 1 : si32}> : (tensor<1x10xbf16>, tensor<1x10xbf16>) -> tensor<1x10xbf16> loc(#loc13)
+    return %11 : tensor<1x10xbf16> loc(#loc7)
   } loc(#loc1)
 } loc(#loc)
 #loc1 = loc("forward":4294967295:23)

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_and.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_and.mlir
@@ -1,12 +1,12 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-func.func @logical_and(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.logical_and"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @logical_and(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.logical_and"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.logical_and"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_ceil.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_ceil.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-func.func @ceil(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.ceil"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @ceil(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.ceil"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.ceil"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_cosine.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_cosine.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-func.func @cosine(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.cos"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @cosine(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.cos"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.cos"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_cumsum.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_cumsum.mlir
@@ -3,14 +3,14 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
 module @moreh_cumsum attributes {} {
-  func.func public @test_moreh_cumsum_dim0(%arg0: tensor<1x32x128x128xf32>) -> tensor<1x32x128x128xf32> {
+  func.func public @test_moreh_cumsum_dim0(%arg0: tensor<1x32x128x128xbf16>) -> tensor<1x32x128x128xbf16> {
     // CHECK-LABEL: func.func public @test_moreh_cumsum_dim0
-    %0 = ttir.empty() : tensor<1x32x128x128xf32>
+    %0 = ttir.empty() : tensor<1x32x128x128xbf16>
     // CHECK: ttnn.moreh_cumsum
     // CHECK-SAME: dim = 0 : i64
-    // CHECK-SAME: tensor<1x32x128x128xf32,
-    // CHECK-SAME: -> tensor<1x32x128x128xf32,
-    %1 = "ttir.cumsum"(%arg0, %0) <{dim = 0 : i64}> : (tensor<1x32x128x128xf32>, tensor<1x32x128x128xf32>) -> tensor<1x32x128x128xf32>
-    return %1 : tensor<1x32x128x128xf32>
+    // CHECK-SAME: tensor<1x32x128x128xbf16,
+    // CHECK-SAME: -> tensor<1x32x128x128xbf16,
+    %1 = "ttir.cumsum"(%arg0, %0) <{dim = 0 : i64}> : (tensor<1x32x128x128xbf16>, tensor<1x32x128x128xbf16>) -> tensor<1x32x128x128xbf16>
+    return %1 : tensor<1x32x128x128xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_div.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_div.mlir
@@ -1,12 +1,12 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-func.func @div(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.div"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @div(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.div"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.divide"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_eq.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_eq.mlir
@@ -2,13 +2,13 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 module attributes {} {
-  func.func @equal(%arg0: tensor<13x31xf32>, %arg1: tensor<13x31xf32>) -> tensor<13x31xf32> {
-    %0 = ttir.empty() : tensor<13x31xf32>
-    %1 = "ttir.eq"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x31xf32>, tensor<13x31xf32>, tensor<13x31xf32>) -> tensor<13x31xf32>
+  func.func @equal(%arg0: tensor<13x31xbf16>, %arg1: tensor<13x31xbf16>) -> tensor<13x31xbf16> {
+    %0 = ttir.empty() : tensor<13x31xbf16>
+    %1 = "ttir.eq"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x31xbf16>, tensor<13x31xbf16>, tensor<13x31xbf16>) -> tensor<13x31xbf16>
     // CHECK: "ttnn.eq"
-    // CHECK-SAME: tensor<13x31xf32
-    // CHECK-SAME: tensor<13x31xf32
-    // CHECK-SAME: -> tensor<13x31xf32
-    return %1 : tensor<13x31xf32>
+    // CHECK-SAME: tensor<13x31xbf16
+    // CHECK-SAME: tensor<13x31xbf16
+    // CHECK-SAME: -> tensor<13x31xbf16
+    return %1 : tensor<13x31xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_expm1.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_expm1.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-func.func @expm1(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.expm1"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @expm1(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.expm1"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.expm1"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_floor.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_floor.mlir
@@ -2,11 +2,11 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @floor(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.floor"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @floor(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.floor"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.floor"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_ge.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_ge.mlir
@@ -2,12 +2,12 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @ge(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.ge"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @ge(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.ge"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.ge"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_gelu.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_gelu.mlir
@@ -2,11 +2,11 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @gelu(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.gelu"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @gelu(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.gelu"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.gelu"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_gt.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_gt.mlir
@@ -2,13 +2,13 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 module attributes {} {
-  func.func @greater_than(%arg0: tensor<13x31xf32>, %arg1: tensor<13x31xf32>) -> tensor<13x31xf32> {
-    %0 = ttir.empty() : tensor<13x31xf32>
-    %1 = "ttir.gt"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x31xf32>, tensor<13x31xf32>, tensor<13x31xf32>) -> tensor<13x31xf32>
+  func.func @greater_than(%arg0: tensor<13x31xbf16>, %arg1: tensor<13x31xbf16>) -> tensor<13x31xbf16> {
+    %0 = ttir.empty() : tensor<13x31xbf16>
+    %1 = "ttir.gt"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x31xbf16>, tensor<13x31xbf16>, tensor<13x31xbf16>) -> tensor<13x31xbf16>
     // CHECK: "ttnn.gt"
-    // CHECK-SAME: tensor<13x31xf32
-    // CHECK-SAME: tensor<13x31xf32
-    // CHECK-SAME: -> tensor<13x31xf32
-    return %1 : tensor<13x31xf32>
+    // CHECK-SAME: tensor<13x31xbf16
+    // CHECK-SAME: tensor<13x31xbf16
+    // CHECK-SAME: -> tensor<13x31xbf16
+    return %1 : tensor<13x31xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_log.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_log.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-func.func @log(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.log"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @log(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.log"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.log"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_log1p.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_log1p.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-func.func @log1p(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.log1p"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @log1p(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.log1p"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.log1p"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_lt.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_lt.mlir
@@ -2,13 +2,13 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 module attributes {} {
-  func.func @less_than(%arg0: tensor<13x31xf32>, %arg1: tensor<13x31xf32>) -> tensor<13x31xf32> {
-    %0 = ttir.empty() : tensor<13x31xf32>
-    %1 = "ttir.lt"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x31xf32>, tensor<13x31xf32>, tensor<13x31xf32>) -> tensor<13x31xf32>
+  func.func @less_than(%arg0: tensor<13x31xbf16>, %arg1: tensor<13x31xbf16>) -> tensor<13x31xbf16> {
+    %0 = ttir.empty() : tensor<13x31xbf16>
+    %1 = "ttir.lt"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x31xbf16>, tensor<13x31xbf16>, tensor<13x31xbf16>) -> tensor<13x31xbf16>
     // CHECK: "ttnn.lt"
-    // CHECK-SAME: tensor<13x31xf32
-    // CHECK-SAME: tensor<13x31xf32
-    // CHECK-SAME: -> tensor<13x31xf32
-    return %1 : tensor<13x31xf32>
+    // CHECK-SAME: tensor<13x31xbf16
+    // CHECK-SAME: tensor<13x31xbf16
+    // CHECK-SAME: -> tensor<13x31xbf16
+    return %1 : tensor<13x31xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_maximum.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_maximum.mlir
@@ -1,12 +1,12 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-func.func @maximum(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.maximum"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @maximum(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.maximum"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.maximum"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_multiply.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_multiply.mlir
@@ -1,12 +1,12 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-func.func @multiply(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.multiply"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @multiply(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.multiply"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.multiply"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_ne.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_ne.mlir
@@ -2,13 +2,13 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 module attributes {} {
-  func.func @not_equal(%arg0: tensor<13x31xf32>, %arg1: tensor<13x31xf32>) -> tensor<13x31xf32> {
-    %0 = ttir.empty() : tensor<13x31xf32>
-    %1 = "ttir.ne"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x31xf32>, tensor<13x31xf32>, tensor<13x31xf32>) -> tensor<13x31xf32>
+  func.func @not_equal(%arg0: tensor<13x31xbf16>, %arg1: tensor<13x31xbf16>) -> tensor<13x31xbf16> {
+    %0 = ttir.empty() : tensor<13x31xbf16>
+    %1 = "ttir.ne"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<13x31xbf16>, tensor<13x31xbf16>, tensor<13x31xbf16>) -> tensor<13x31xbf16>
     // CHECK: "ttnn.ne"
-    // CHECK-SAME: tensor<13x31xf32
-    // CHECK-SAME: tensor<13x31xf32
-    // CHECK-SAME: -> tensor<13x31xf32
-    return %1 : tensor<13x31xf32>
+    // CHECK-SAME: tensor<13x31xbf16
+    // CHECK-SAME: tensor<13x31xbf16
+    // CHECK-SAME: -> tensor<13x31xbf16
+    return %1 : tensor<13x31xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_neg.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_neg.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-func.func @negate(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
-  %0 = ttir.empty() : tensor<32x32xf32>
-  %1 = "ttir.neg"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+func.func @negate(%arg0: tensor<32x32xbf16>) -> tensor<32x32xbf16> {
+  %0 = ttir.empty() : tensor<32x32xbf16>
+  %1 = "ttir.neg"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
   // CHECK: "ttnn.neg"
-  // CHECK-SAME: tensor<32x32xf32
-  // CHECK-SAME: -> tensor<32x32xf32
-  return %1 : tensor<32x32xf32>
+  // CHECK-SAME: tensor<32x32xbf16
+  // CHECK-SAME: -> tensor<32x32xbf16
+  return %1 : tensor<32x32xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_not.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_not.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-func.func @logical_not(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.logical_not"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @logical_not(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.logical_not"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.logical_not"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_or.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_or.mlir
@@ -1,12 +1,12 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-func.func @logical_or(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.logical_or"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @logical_or(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.logical_or"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.logical_or"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_permute.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_permute.mlir
@@ -2,13 +2,13 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 module {
-  func.func @permute(%arg0: tensor<1x4x32x64xf32>) -> tensor<4x32x64x1xf32> {
-    %0 = ttir.empty() : tensor<4x32x64x1xf32>
+  func.func @permute(%arg0: tensor<1x4x32x64xbf16>) -> tensor<4x32x64x1xbf16> {
+    %0 = ttir.empty() : tensor<4x32x64x1xbf16>
     // CHECK: "ttnn.permute"
     // CHECK-SAME: permutation = array<i64: 1, 2, 3, 0>
-    // CHECK-SAME: tensor<1x4x32x64xf32
-    // CHECK-SAME: tensor<4x32x64x1xf32
-    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 1, 2, 3, 0>}> : (tensor<1x4x32x64xf32>, tensor<4x32x64x1xf32>) -> tensor<4x32x64x1xf32>
-    return %1 : tensor<4x32x64x1xf32>
+    // CHECK-SAME: tensor<1x4x32x64xbf16
+    // CHECK-SAME: tensor<4x32x64x1xbf16
+    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 1, 2, 3, 0>}> : (tensor<1x4x32x64xbf16>, tensor<4x32x64x1xbf16>) -> tensor<4x32x64x1xbf16>
+    return %1 : tensor<4x32x64x1xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_pow.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_pow.mlir
@@ -1,12 +1,12 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-func.func @pow(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x32xf32> {
-  %0 = ttir.empty() : tensor<32x32xf32>
-  %1 = "ttir.pow"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+func.func @pow(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>) -> tensor<32x32xbf16> {
+  %0 = ttir.empty() : tensor<32x32xbf16>
+  %1 = "ttir.pow"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
   // CHECK: "ttnn.pow"
-  // CHECK-SAME: tensor<32x32xf32
-  // CHECK-SAME: tensor<32x32xf32
-  // CHECK-SAME: -> tensor<32x32xf32
-  return %1 : tensor<32x32xf32>
+  // CHECK-SAME: tensor<32x32xbf16
+  // CHECK-SAME: tensor<32x32xbf16
+  // CHECK-SAME: -> tensor<32x32xbf16
+  return %1 : tensor<32x32xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_reciprocal.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_reciprocal.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-func.func @reciprocal(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.reciprocal"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @reciprocal(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.reciprocal"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.reciprocal"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_reduce_min.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_reduce_min.mlir
@@ -5,15 +5,15 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
 module {
-  func.func public @reduce_min_not_keep_dim(%arg0: tensor<128x10x32x4xf32>) -> tensor<128x32x4xf32> {
+  func.func public @reduce_min_not_keep_dim(%arg0: tensor<128x10x32x4xbf16>) -> tensor<128x32x4xbf16> {
     // CHECK-LABEL: func.func public @reduce_min_not_keep_dim
-    %0 = ttir.empty() : tensor<128x32x4xf32>
+    %0 = ttir.empty() : tensor<128x32x4xbf16>
     // CHECK: "ttnn.min"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x32x4xf32,
-    // CHECK-SAME: -> tensor<128x32x4xf32,
-    %1 = "ttir.min"(%arg0, %0) <{dim_arg = [1: i32], keep_dim = false}> : (tensor<128x10x32x4xf32>, tensor<128x32x4xf32>) -> tensor<128x32x4xf32>
-    return %1 : tensor<128x32x4xf32>
+    // CHECK-SAME: tensor<128x10x32x4xbf16,
+    // CHECK-SAME: -> tensor<128x32x4xbf16,
+    %1 = "ttir.min"(%arg0, %0) <{dim_arg = [1: i32], keep_dim = false}> : (tensor<128x10x32x4xbf16>, tensor<128x32x4xbf16>) -> tensor<128x32x4xbf16>
+    return %1 : tensor<128x32x4xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_reduce_prod.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_reduce_prod.mlir
@@ -5,16 +5,16 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
 module {
-  func.func public @reduce_prod_not_keep_dim(%arg0: tensor<128x10x32x4xf32>) -> tensor<128x32x4xf32> {
+  func.func public @reduce_prod_not_keep_dim(%arg0: tensor<128x10x32x4xbf16>) -> tensor<128x32x4xbf16> {
     // CHECK-LABEL: func.func public @reduce_prod_not_keep_dim
-    %0 = ttir.empty() : tensor<128x32x4xf32>
+    %0 = ttir.empty() : tensor<128x32x4xbf16>
     // CHECK: "ttnn.prod"
     // CHECK: all_dimensions = false
     // CHECK-SAME: dim_arg = 1
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x32x4xf32,
-    // CHECK-SAME: -> tensor<128x32x4xf32,
-    %1 = "ttir.prod"(%arg0, %0) <{dim_arg = [1: i32], keep_dim = false}> : (tensor<128x10x32x4xf32>, tensor<128x32x4xf32>) -> tensor<128x32x4xf32>
-    return %1 : tensor<128x32x4xf32>
+    // CHECK-SAME: tensor<128x10x32x4xbf16,
+    // CHECK-SAME: -> tensor<128x32x4xbf16,
+    %1 = "ttir.prod"(%arg0, %0) <{dim_arg = [1: i32], keep_dim = false}> : (tensor<128x10x32x4xbf16>, tensor<128x32x4xbf16>) -> tensor<128x32x4xbf16>
+    return %1 : tensor<128x32x4xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_relu.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_relu.mlir
@@ -2,11 +2,11 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @relu(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.relu"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @relu(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.relu"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.relu"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_remainder.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_remainder.mlir
@@ -1,12 +1,12 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-func.func @remainder(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x32xf32> {
-  %0 = ttir.empty() : tensor<32x32xf32>
-  %1 = "ttir.remainder"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+func.func @remainder(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>) -> tensor<32x32xbf16> {
+  %0 = ttir.empty() : tensor<32x32xbf16>
+  %1 = "ttir.remainder"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
   // CHECK: "ttnn.remainder"
-  // CHECK-SAME: tensor<32x32xf32
-  // CHECK-SAME: tensor<32x32xf32
-  // CHECK-SAME: -> tensor<32x32xf32
-  return %1 : tensor<32x32xf32>
+  // CHECK-SAME: tensor<32x32xbf16
+  // CHECK-SAME: tensor<32x32xbf16
+  // CHECK-SAME: -> tensor<32x32xbf16
+  return %1 : tensor<32x32xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_rsqrt.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_rsqrt.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-func.func @rsqrt(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.rsqrt"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @rsqrt(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.rsqrt"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.rsqrt"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_sigmoid.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_sigmoid.mlir
@@ -2,11 +2,11 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @sigmoid(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.sigmoid"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @sigmoid(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.sigmoid"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.sigmoid"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_sign.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_sign.mlir
@@ -2,11 +2,11 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @sign(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-    %0 = ttir.empty() : tensor<64x128xf32>
-    %1 = "ttir.sign"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @sign(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.sign"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
     // CHECK: "ttnn.sign"
-    // CHECK-SAME: tensor<64x128xf32
-    // CHECK-SAME: -> tensor<64x128xf32
-    return %1 : tensor<64x128xf32>
+    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
+    return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_sine.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_sine.mlir
@@ -2,11 +2,11 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @sine(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.sin"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @sine(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.sin"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.sin"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_sqrt.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_sqrt.mlir
@@ -1,11 +1,11 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-func.func @sqrt(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.sqrt"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @sqrt(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.sqrt"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.sqrt"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_subtract.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_subtract.mlir
@@ -1,12 +1,12 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
-func.func @subtract(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.subtract"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @subtract(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.subtract"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.subtract"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_tan.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_tan.mlir
@@ -2,11 +2,11 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @tan(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.tan"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @tan(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.tan"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.tan"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_tanh.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_tanh.mlir
@@ -2,11 +2,11 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
-func.func @tanh(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
-  %0 = ttir.empty() : tensor<64x128xf32>
-  %1 = "ttir.tanh"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+func.func @tanh(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  %1 = "ttir.tanh"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   // CHECK: "ttnn.tanh"
-  // CHECK-SAME: tensor<64x128xf32
-  // CHECK-SAME: -> tensor<64x128xf32
-  return %1 : tensor<64x128xf32>
+  // CHECK-SAME: tensor<64x128xbf16
+  // CHECK-SAME: -> tensor<64x128xbf16
+  return %1 : tensor<64x128xbf16>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_typecast.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_typecast.mlir
@@ -1,5 +1,5 @@
 
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-fp32=true system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 func.func @typecast(%arg0: tensor<64x128xf32>) -> tensor<64x128xbf16> {

--- a/test/ttmlir/Silicon/TTNN/n150/simple_cumsum.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_cumsum.mlir
@@ -5,47 +5,47 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
 module @moreh_cumsum attributes {} {
-  func.func public @test_moreh_cumsum_dim0(%arg0: tensor<1x32x128x128xf32>) -> tensor<1x32x128x128xf32> {
+  func.func public @test_moreh_cumsum_dim0(%arg0: tensor<1x32x128x128xbf16>) -> tensor<1x32x128x128xbf16> {
     // CHECK-LABEL: func.func public @test_moreh_cumsum_dim0
-    %0 = ttir.empty() : tensor<1x32x128x128xf32>
+    %0 = ttir.empty() : tensor<1x32x128x128xbf16>
     // CHECK: ttnn.moreh_cumsum
     // CHECK-SAME: dim = 0 : i64
-    // CHECK-SAME: tensor<1x32x128x128xf32,
-    // CHECK-SAME: -> tensor<1x32x128x128xf32,
-    %1 = "ttir.cumsum"(%arg0, %0) <{dim = 0 : i64}> : (tensor<1x32x128x128xf32>, tensor<1x32x128x128xf32>) -> tensor<1x32x128x128xf32>
-    return %1 : tensor<1x32x128x128xf32>
+    // CHECK-SAME: tensor<1x32x128x128xbf16,
+    // CHECK-SAME: -> tensor<1x32x128x128xbf16,
+    %1 = "ttir.cumsum"(%arg0, %0) <{dim = 0 : i64}> : (tensor<1x32x128x128xbf16>, tensor<1x32x128x128xbf16>) -> tensor<1x32x128x128xbf16>
+    return %1 : tensor<1x32x128x128xbf16>
   }
 
-  func.func public @test_moreh_cumsum_dim1(%arg0: tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32> {
+  func.func public @test_moreh_cumsum_dim1(%arg0: tensor<4x4x128x128xbf16>) -> tensor<4x4x128x128xbf16> {
     // CHECK-LABEL: func.func public @test_moreh_cumsum_dim1
-    %0 = ttir.empty() : tensor<4x4x128x128xf32>
+    %0 = ttir.empty() : tensor<4x4x128x128xbf16>
     // CHECK: ttnn.moreh_cumsum
     // CHECK-SAME: dim = 1 : i64
-    // CHECK-SAME: tensor<4x4x128x128xf32,
-    // CHECK-SAME: -> tensor<4x4x128x128xf32,
-    %1 = "ttir.cumsum"(%arg0, %0) <{dim = 1 : i64}> : (tensor<4x4x128x128xf32>, tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32>
-    return %1 : tensor<4x4x128x128xf32>
+    // CHECK-SAME: tensor<4x4x128x128xbf16,
+    // CHECK-SAME: -> tensor<4x4x128x128xbf16,
+    %1 = "ttir.cumsum"(%arg0, %0) <{dim = 1 : i64}> : (tensor<4x4x128x128xbf16>, tensor<4x4x128x128xbf16>) -> tensor<4x4x128x128xbf16>
+    return %1 : tensor<4x4x128x128xbf16>
   }
 
-  func.func public @test_moreh_cumsum_dim2(%arg0: tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32> {
+  func.func public @test_moreh_cumsum_dim2(%arg0: tensor<4x4x128x128xbf16>) -> tensor<4x4x128x128xbf16> {
     // CHECK-LABEL: func.func public @test_moreh_cumsum_dim2
-    %0 = ttir.empty() : tensor<4x4x128x128xf32>
+    %0 = ttir.empty() : tensor<4x4x128x128xbf16>
     // CHECK: ttnn.moreh_cumsum
     // CHECK-SAME: dim = 2 : i64
-    // CHECK-SAME: tensor<4x4x128x128xf32,
-    // CHECK-SAME: -> tensor<4x4x128x128xf32,
-    %1 = "ttir.cumsum"(%arg0, %0) <{dim = 2 : i64}> : (tensor<4x4x128x128xf32>, tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32>
-    return %1 : tensor<4x4x128x128xf32>
+    // CHECK-SAME: tensor<4x4x128x128xbf16,
+    // CHECK-SAME: -> tensor<4x4x128x128xbf16,
+    %1 = "ttir.cumsum"(%arg0, %0) <{dim = 2 : i64}> : (tensor<4x4x128x128xbf16>, tensor<4x4x128x128xbf16>) -> tensor<4x4x128x128xbf16>
+    return %1 : tensor<4x4x128x128xbf16>
   }
 
-  func.func public @test_moreh_cumsum_dim3(%arg0: tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32> {
+  func.func public @test_moreh_cumsum_dim3(%arg0: tensor<4x4x128x128xbf16>) -> tensor<4x4x128x128xbf16> {
     // CHECK-LABEL: func.func public @test_moreh_cumsum_dim3
-    %0 = ttir.empty() : tensor<4x4x128x128xf32>
+    %0 = ttir.empty() : tensor<4x4x128x128xbf16>
     // CHECK: ttnn.moreh_cumsum
     // CHECK-SAME: dim = 3 : i64
-    // CHECK-SAME: tensor<4x4x128x128xf32,
-    // CHECK-SAME: -> tensor<4x4x128x128xf32,
-    %1 = "ttir.cumsum"(%arg0, %0) <{dim = 3 : i64}> : (tensor<4x4x128x128xf32>, tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32>
-    return %1 : tensor<4x4x128x128xf32>
+    // CHECK-SAME: tensor<4x4x128x128xbf16,
+    // CHECK-SAME: -> tensor<4x4x128x128xbf16,
+    %1 = "ttir.cumsum"(%arg0, %0) <{dim = 3 : i64}> : (tensor<4x4x128x128xbf16>, tensor<4x4x128x128xbf16>) -> tensor<4x4x128x128xbf16>
+    return %1 : tensor<4x4x128x128xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/simple_max.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_max.mlir
@@ -5,26 +5,26 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
 module {
-  func.func public @reduce_not_keep_dim(%arg0: tensor<128x10xf32>) -> tensor<128xf32> {
-    %0 = ttir.empty() : tensor<128xf32>
+  func.func public @reduce_not_keep_dim(%arg0: tensor<128x10xbf16>) -> tensor<128xbf16> {
+    %0 = ttir.empty() : tensor<128xbf16>
     // CHECK: "ttnn.max"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10xf32,
-    // CHECK-SAME: -> tensor<128xf32,
-    %1 = "ttir.max"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x10xf32>, tensor<128xf32>) -> tensor<128xf32>
-    return %1 : tensor<128xf32>
+    // CHECK-SAME: tensor<128x10xbf16,
+    // CHECK-SAME: -> tensor<128xbf16,
+    %1 = "ttir.max"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x10xbf16>, tensor<128xbf16>) -> tensor<128xbf16>
+    return %1 : tensor<128xbf16>
   }
 
-  func.func public @reduce_keep_dim(%arg0: tensor<128x10xf32>) -> tensor<128x1xf32> {
-    %0 = ttir.empty() : tensor<128x1xf32>
+  func.func public @reduce_keep_dim(%arg0: tensor<128x10xbf16>) -> tensor<128x1xbf16> {
+    %0 = ttir.empty() : tensor<128x1xbf16>
     // CHECK: "ttnn.max"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = true
-    // CHECK-SAME: tensor<128x10xf32,
-    // CHECK-SAME: -> tensor<128x1xf32,
+    // CHECK-SAME: tensor<128x10xbf16,
+    // CHECK-SAME: -> tensor<128x1xbf16,
     // CHECK-NOT: "ttnn.reshape"
-    %1 = "ttir.max"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<128x10xf32>, tensor<128x1xf32>) -> tensor<128x1xf32>
-    return %1 : tensor<128x1xf32>
+    %1 = "ttir.max"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<128x10xbf16>, tensor<128x1xbf16>) -> tensor<128x1xbf16>
+    return %1 : tensor<128x1xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/simple_mean.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_mean.mlir
@@ -5,26 +5,26 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
 module {
-  func.func public @reduce_not_keep_dim(%arg0: tensor<128x10xf32>) -> tensor<128xf32> {
-    %0 = ttir.empty() : tensor<128xf32>
+  func.func public @reduce_not_keep_dim(%arg0: tensor<128x10xbf16>) -> tensor<128xbf16> {
+    %0 = ttir.empty() : tensor<128xbf16>
     // CHECK: "ttnn.mean"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10xf32,
-    // CHECK-SAME: -> tensor<128xf32,
-    %1 = "ttir.mean"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x10xf32>, tensor<128xf32>) -> tensor<128xf32>
-    return %1 : tensor<128xf32>
+    // CHECK-SAME: tensor<128x10xbf16,
+    // CHECK-SAME: -> tensor<128xbf16,
+    %1 = "ttir.mean"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x10xbf16>, tensor<128xbf16>) -> tensor<128xbf16>
+    return %1 : tensor<128xbf16>
   }
 
-  func.func public @reduce_keep_dim(%arg0: tensor<128x10xf32>) -> tensor<128x1xf32> {
-    %0 = ttir.empty() : tensor<128x1xf32>
+  func.func public @reduce_keep_dim(%arg0: tensor<128x10xbf16>) -> tensor<128x1xbf16> {
+    %0 = ttir.empty() : tensor<128x1xbf16>
     // CHECK: "ttnn.mean"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = true
-    // CHECK-SAME: tensor<128x10xf32,
-    // CHECK-SAME: -> tensor<128x1xf32,
+    // CHECK-SAME: tensor<128x10xbf16,
+    // CHECK-SAME: -> tensor<128x1xbf16,
     // CHECK-NOT: "ttnn.reshape"
-    %1 = "ttir.mean"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<128x10xf32>, tensor<128x1xf32>) -> tensor<128x1xf32>
-    return %1 : tensor<128x1xf32>
+    %1 = "ttir.mean"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<128x10xbf16>, tensor<128x1xbf16>) -> tensor<128x1xbf16>
+    return %1 : tensor<128x1xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/simple_nop.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_nop.mlir
@@ -2,8 +2,8 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 module @jit_convert_element_type attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
-  func.func public @main(%arg0: tensor<2x2xf32> {mhlo.layout_mode = "default"}) -> (tensor<2x2xf32> {jax.result_info = "", mhlo.layout_mode = "default"}) {
-    // CHECK: return %arg0 : tensor<2x2xf32, #ttnn_layout>
-    return %arg0 : tensor<2x2xf32>
+  func.func public @main(%arg0: tensor<2x2xbf16> {mhlo.layout_mode = "default"}) -> (tensor<2x2xbf16> {jax.result_info = "", mhlo.layout_mode = "default"}) {
+    // CHECK: return %arg0 : tensor<2x2xbf16, #ttnn_layout>
+    return %arg0 : tensor<2x2xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/simple_permute.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_permute.mlir
@@ -2,13 +2,13 @@
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 module {
-  func.func @permute(%arg0: tensor<1x4x32x64xf32>) -> tensor<4x32x64x1xf32> {
-    %0 = ttir.empty() : tensor<4x32x64x1xf32>
+  func.func @permute(%arg0: tensor<1x4x32x64xbf16>) -> tensor<4x32x64x1xbf16> {
+    %0 = ttir.empty() : tensor<4x32x64x1xbf16>
     // CHECK: "ttnn.permute"
     // CHECK-SAME: permutation = array<i64: 1, 2, 3, 0>
-    // CHECK-SAME: tensor<1x4x32x64xf32
-    // CHECK-SAME: tensor<4x32x64x1xf32
-    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 1, 2, 3, 0>}> : (tensor<1x4x32x64xf32>, tensor<4x32x64x1xf32>) -> tensor<4x32x64x1xf32>
-    return %1 : tensor<4x32x64x1xf32>
+    // CHECK-SAME: tensor<1x4x32x64xbf16
+    // CHECK-SAME: tensor<4x32x64x1xbf16
+    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 1, 2, 3, 0>}> : (tensor<1x4x32x64xbf16>, tensor<4x32x64x1xbf16>) -> tensor<4x32x64x1xbf16>
+    return %1 : tensor<4x32x64x1xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/simple_reduce_min.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_reduce_min.mlir
@@ -5,28 +5,28 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
 module {
-  func.func public @reduce_min_not_keep_dim(%arg0: tensor<128x10x32x4xf32>) -> tensor<128x32x4xf32> {
+  func.func public @reduce_min_not_keep_dim(%arg0: tensor<128x10x32x4xbf16>) -> tensor<128x32x4xbf16> {
     // CHECK-LABEL: func.func public @reduce_min_not_keep_dim
-    %0 = ttir.empty() : tensor<128x32x4xf32>
+    %0 = ttir.empty() : tensor<128x32x4xbf16>
     // CHECK: "ttnn.min"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x32x4xf32,
-    // CHECK-SAME: -> tensor<128x32x4xf32,
-    %1 = "ttir.min"(%arg0, %0) <{dim_arg = [1: i32], keep_dim = false}> : (tensor<128x10x32x4xf32>, tensor<128x32x4xf32>) -> tensor<128x32x4xf32>
-    return %1 : tensor<128x32x4xf32>
+    // CHECK-SAME: tensor<128x10x32x4xbf16,
+    // CHECK-SAME: -> tensor<128x32x4xbf16,
+    %1 = "ttir.min"(%arg0, %0) <{dim_arg = [1: i32], keep_dim = false}> : (tensor<128x10x32x4xbf16>, tensor<128x32x4xbf16>) -> tensor<128x32x4xbf16>
+    return %1 : tensor<128x32x4xbf16>
   }
 
-  func.func public @reduce_min_keep_dim(%arg0: tensor<128x10x32x4xf32>) -> tensor<128x1x32x4xf32> {
+  func.func public @reduce_min_keep_dim(%arg0: tensor<128x10x32x4xbf16>) -> tensor<128x1x32x4xbf16> {
     // CHECK-LABEL: func.func public @reduce_min_keep_dim
-    %0 = ttir.empty() : tensor<128x1x32x4xf32>
+    %0 = ttir.empty() : tensor<128x1x32x4xbf16>
     // CHECK-NOT: "ttnn.reshape"
     // CHECK: "ttnn.min"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = true
-    // CHECK-SAME: tensor<128x10x32x4xf32,
-    // CHECK-SAME: -> tensor<128x1x32x4xf32,
-    %1 = "ttir.min"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<128x10x32x4xf32>, tensor<128x1x32x4xf32>) -> tensor<128x1x32x4xf32>
-    return %1 : tensor<128x1x32x4xf32>
+    // CHECK-SAME: tensor<128x10x32x4xbf16,
+    // CHECK-SAME: -> tensor<128x1x32x4xbf16,
+    %1 = "ttir.min"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<128x10x32x4xbf16>, tensor<128x1x32x4xbf16>) -> tensor<128x1x32x4xbf16>
+    return %1 : tensor<128x1x32x4xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/simple_reduce_prod.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_reduce_prod.mlir
@@ -5,29 +5,29 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
 module {
-  func.func public @reduce_prod_not_keep_dim(%arg0: tensor<128x10x32x4xf32>) -> tensor<128x32x4xf32> {
+  func.func public @reduce_prod_not_keep_dim(%arg0: tensor<128x10x32x4xbf16>) -> tensor<128x32x4xbf16> {
     // CHECK-LABEL: func.func public @reduce_prod_not_keep_dim
-    %0 = ttir.empty() : tensor<128x32x4xf32>
+    %0 = ttir.empty() : tensor<128x32x4xbf16>
     // CHECK: "ttnn.prod"
     // CHECK: all_dimensions = false
     // CHECK-SAME: dim_arg = 1
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x32x4xf32,
-    // CHECK-SAME: -> tensor<128x32x4xf32,
-    %1 = "ttir.prod"(%arg0, %0) <{dim_arg = [1: i32], keep_dim = false}> : (tensor<128x10x32x4xf32>, tensor<128x32x4xf32>) -> tensor<128x32x4xf32>
-    return %1 : tensor<128x32x4xf32>
+    // CHECK-SAME: tensor<128x10x32x4xbf16,
+    // CHECK-SAME: -> tensor<128x32x4xbf16,
+    %1 = "ttir.prod"(%arg0, %0) <{dim_arg = [1: i32], keep_dim = false}> : (tensor<128x10x32x4xbf16>, tensor<128x32x4xbf16>) -> tensor<128x32x4xbf16>
+    return %1 : tensor<128x32x4xbf16>
   }
 
-  func.func public @reduce_prod_keep_dim(%arg0: tensor<128x10x32x4xf32>) -> tensor<128x1x32x4xf32> {
+  func.func public @reduce_prod_keep_dim(%arg0: tensor<128x10x32x4xbf16>) -> tensor<128x1x32x4xbf16> {
     // CHECK-LABEL: func.func public @reduce_prod_keep_dim
-    %0 = ttir.empty() : tensor<128x1x32x4xf32>
+    %0 = ttir.empty() : tensor<128x1x32x4xbf16>
     // CHECK: "ttnn.prod"
     // CHECK: all_dimensions = false
     // CHECK-SAME: dim_arg = 1
     // CHECK-SAME: keep_dim = true
-    // CHECK-SAME: tensor<128x10x32x4xf32,
-    // CHECK-SAME: -> tensor<128x1x32x4xf32,
-    %1 = "ttir.prod"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<128x10x32x4xf32>, tensor<128x1x32x4xf32>) -> tensor<128x1x32x4xf32>
-    return %1 : tensor<128x1x32x4xf32>
+    // CHECK-SAME: tensor<128x10x32x4xbf16,
+    // CHECK-SAME: -> tensor<128x1x32x4xbf16,
+    %1 = "ttir.prod"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<128x10x32x4xbf16>, tensor<128x1x32x4xbf16>) -> tensor<128x1x32x4xbf16>
+    return %1 : tensor<128x1x32x4xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/simple_sum.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_sum.mlir
@@ -5,26 +5,26 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
 module {
-  func.func public @reduce_not_keep_dim(%arg0: tensor<128x10xf32>) -> tensor<128xf32> {
-    %0 = ttir.empty() : tensor<128xf32>
+  func.func public @reduce_not_keep_dim(%arg0: tensor<128x10xbf16>) -> tensor<128xbf16> {
+    %0 = ttir.empty() : tensor<128xbf16>
     // CHECK: "ttnn.sum"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10xf32,
-    // CHECK-SAME: -> tensor<128xf32,
-    %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x10xf32>, tensor<128xf32>) -> tensor<128xf32>
-    return %1 : tensor<128xf32>
+    // CHECK-SAME: tensor<128x10xbf16,
+    // CHECK-SAME: -> tensor<128xbf16,
+    %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x10xbf16>, tensor<128xbf16>) -> tensor<128xbf16>
+    return %1 : tensor<128xbf16>
   }
 
-  func.func public @reduce_keep_dim(%arg0: tensor<128x10xf32>) -> tensor<128x1xf32> {
-    %0 = ttir.empty() : tensor<128x1xf32>
+  func.func public @reduce_keep_dim(%arg0: tensor<128x10xbf16>) -> tensor<128x1xbf16> {
+    %0 = ttir.empty() : tensor<128x1xbf16>
     // CHECK: "ttnn.sum"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = true
-    // CHECK-SAME: tensor<128x10xf32,
-    // CHECK-SAME: -> tensor<128x1xf32,
+    // CHECK-SAME: tensor<128x10xbf16,
+    // CHECK-SAME: -> tensor<128x1xbf16,
     // CHECK-NOT: "ttnn.reshape"
-    %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<128x10xf32>, tensor<128x1xf32>) -> tensor<128x1xf32>
-    return %1 : tensor<128x1xf32>
+    %1 = "ttir.sum"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<128x10xbf16>, tensor<128x1xbf16>) -> tensor<128x1xbf16>
+    return %1 : tensor<128x1xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/simple_typecast.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_typecast.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-fp32=true system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 

--- a/test/ttmlir/Silicon/TTNN/n150/zeros.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/zeros.mlir
@@ -21,9 +21,9 @@ module {
     return %0 : tensor<13x24x56x42xbf16>
   }
 
-  func.func @zeros_f32() -> tensor<32x64x128xf32> {
-    // CHECK: {{.*}} = "ttnn.zeros"({{.*}}) {{.*}} -> tensor<32x64x128xf32{{.*}}>
-    %0 = "ttir.zeros"() <{shape = array<i32:32, 64, 128>}> : () -> tensor<32x64x128xf32>
-    return %0 : tensor<32x64x128xf32>
+  func.func @zeros_f32() -> tensor<32x64x128xbf16> {
+    // CHECK: {{.*}} = "ttnn.zeros"({{.*}}) {{.*}} -> tensor<32x64x128xbf16{{.*}}>
+    %0 = "ttir.zeros"() <{shape = array<i32:32, 64, 128>}> : () -> tensor<32x64x128xbf16>
+    return %0 : tensor<32x64x128xbf16>
   }
 }


### PR DESCRIPTION
DRAFT

* This commit turns on conversion of f32 into bf16
* Optimizer - fix couple spots where we had mismatch between RankedTensor element type and encoding element type
   i.e `tensor<32x32xbf16, ttnn.layout<32x32xf32...>`
* All tests - convert fp32 to bf16. For certain tests I left fp32 since we are either testing fp32 workaround or we are testing error message if type is fp32 or it's typecast op tests.
* Verifier for typecast

Bulk of the changes are in tests where I simply converted f32 types to bf16

TODO:
* Remove shlo type converter
* Forge pipeline - check what kind of implications do we have when typecasting input constants