### PR TITLE
Use LLVM provided STL utils from future versions

### DIFF
--- a/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
+++ b/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
@@ -15,6 +15,7 @@
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/STLForwardCompat.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -821,10 +822,10 @@ public:
   template <typename TargetTy = void, typename SourceTy>
   std::enable_if_t<!IsMLIRTypeV<SourceTy>, mlir::Attribute>
   emit(SourceTy &&attr) {
-    using ActualTargetTy = std::conditional_t<
-        std::is_void_v<TargetTy>,
-        TTNNTargetT<std::remove_reference_t<std::remove_cv_t<SourceTy>>>,
-        TargetTy>;
+    using ActualTargetTy =
+        std::conditional_t<std::is_void_v<TargetTy>,
+                           TTNNTargetT<llvm::remove_cvref_t<SourceTy>>,
+                           TargetTy>;
     auto result = EmitCTypeConverter<ActualTargetTy>::convert(
         std::forward<SourceTy>(attr));
     // It's assumed that the conversion will always succeed, if the result is

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -13,6 +13,8 @@
 #include "ttmlir/Target/Utils/FlatbufferObjectCache.h"
 #include "ttmlir/Utils.h"
 
+#include "llvm/ADT/STLForwardCompat.h"
+
 #include "flatbuffers/flatbuffers.h"
 
 #include <numeric>
@@ -212,18 +214,11 @@ inline ::tt::target::Dim2d toFlatbuffer(FlatbufferObjectCache &cache,
 inline ::tt::target::ChipCapability
 toFlatbuffer(FlatbufferObjectCache &, ChipCapabilityAttr capabilityAttr) {
   auto capabilities = capabilityAttr.getValue();
-  static_assert(
-      static_cast<std::underlying_type_t<ChipCapability>>(
-          ChipCapability::PCIE) ==
-      static_cast<std::underlying_type_t<::tt::target::ChipCapability>>(
-          ::tt::target::ChipCapability::PCIE));
-  static_assert(
-      static_cast<std::underlying_type_t<ChipCapability>>(
-          ChipCapability::HostMMIO) ==
-      static_cast<std::underlying_type_t<::tt::target::ChipCapability>>(
-          ::tt::target::ChipCapability::HostMMIO));
-  assert((static_cast<std::underlying_type_t<ChipCapability>>(capabilities) &
-          ~0b11) == 0 &&
+  static_assert(llvm::to_underlying(ChipCapability::PCIE) ==
+                llvm::to_underlying(::tt::target::ChipCapability::PCIE));
+  static_assert(llvm::to_underlying(ChipCapability::HostMMIO) ==
+                llvm::to_underlying(::tt::target::ChipCapability::HostMMIO));
+  assert((llvm::to_underlying(capabilities) & ~0b11) == 0 &&
          "unsupported chip capabilities");
   return static_cast<::tt::target::ChipCapability>(capabilities);
 }

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -11,13 +11,9 @@
 #include "ttmlir/Target/Common/Target.h"
 #include "ttmlir/Target/TTNN/Target.h"
 #include "ttmlir/Target/Utils/FlatbufferObjectCache.h"
-#include "ttmlir/Utils.h"
 
 #include "llvm/ADT/STLForwardCompat.h"
 
-#include "flatbuffers/flatbuffers.h"
-
-#include <numeric>
 #include <type_traits>
 
 namespace mlir::tt {

--- a/include/ttmlir/Utils.h
+++ b/include/ttmlir/Utils.h
@@ -9,7 +9,6 @@
 
 #include "mlir-c/IR.h"
 #include "mlir/CAPI/IR.h"
-#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Traits.h"
 #include "mlir/IR/AffineMap.h"
 #include "mlir/IR/BuiltinAttributes.h"

--- a/include/ttmlir/Utils.h
+++ b/include/ttmlir/Utils.h
@@ -103,11 +103,6 @@ IntType volume(mlir::ArrayRef<IntType> shape) {
   return result;
 }
 
-template <typename Enum>
-constexpr std::underlying_type_t<Enum> enum_as_int(Enum e) {
-  return static_cast<std::underlying_type_t<Enum>>(e);
-}
-
 // Returns a string that is the concatenation of the string representations of
 // Range R elements interleaved with separator. Example: join({1, 2, 3}, ", ")
 // -> "1, 2, 3"

--- a/lib/Dialect/TT/IR/TTOpsTypes.cpp
+++ b/lib/Dialect/TT/IR/TTOpsTypes.cpp
@@ -8,6 +8,7 @@
 #include "ttmlir/Target/Common/Target.h"
 #include "ttmlir/Utils.h"
 
+#include "llvm/ADT/STLForwardCompat.h"
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringExtras.h>
 #include <llvm/ADT/TypeSwitch.h>
@@ -191,14 +192,10 @@ mlir::tt::SystemDescAttr::getFromPath(MLIRContext *context, std::string &path) {
   // Acquire cpu descs
   std::vector<tt::CPUDescAttr> cpu_desc_list;
   for (auto const *element : *binary_cpu_desc) {
-    static_assert(static_cast<std::underlying_type_t<::tt::target::CPURole>>(
-                      ::mlir::tt::CPURole::Device) ==
-                  static_cast<std::underlying_type_t<::tt::target::CPURole>>(
-                      ::tt::target::CPURole::Device));
-    static_assert(static_cast<std::underlying_type_t<::tt::target::CPURole>>(
-                      ::mlir::tt::CPURole::Host) ==
-                  static_cast<std::underlying_type_t<::tt::target::CPURole>>(
-                      ::tt::target::CPURole::Host));
+    static_assert(llvm::to_underlying(::mlir::tt::CPURole::Device) ==
+                  llvm::to_underlying(::tt::target::CPURole::Device));
+    static_assert(llvm::to_underlying(::mlir::tt::CPURole::Host) ==
+                  llvm::to_underlying(::tt::target::CPURole::Host));
     const auto *flatbufferTargetTripleString = element->target_triple();
     cpu_desc_list.emplace_back(tt::CPUDescAttr::get(
         context, static_cast<mlir::tt::CPURole>(element->role()),
@@ -339,16 +336,10 @@ mlir::tt::SystemDescAttr::getFromPath(MLIRContext *context, std::string &path) {
   // Acquire chip capabilities
   std::vector<tt::ChipCapabilityAttr> chip_capabilities_list;
   for (auto element : *chip_capabilities) {
-    static_assert(
-        static_cast<std::underlying_type_t<::tt::target::ChipCapability>>(
-            ::mlir::tt::ChipCapability::PCIE) ==
-        static_cast<std::underlying_type_t<::tt::target::ChipCapability>>(
-            ::tt::target::ChipCapability::PCIE));
-    static_assert(
-        static_cast<std::underlying_type_t<::tt::target::ChipCapability>>(
-            ::mlir::tt::ChipCapability::HostMMIO) ==
-        static_cast<std::underlying_type_t<::tt::target::ChipCapability>>(
-            ::tt::target::ChipCapability::HostMMIO));
+    static_assert(llvm::to_underlying(::mlir::tt::ChipCapability::PCIE) ==
+                  llvm::to_underlying(::tt::target::ChipCapability::PCIE));
+    static_assert(llvm::to_underlying(::mlir::tt::ChipCapability::HostMMIO) ==
+                  llvm::to_underlying(::tt::target::ChipCapability::HostMMIO));
 
     auto chip_capabilities_attr = tt::ChipCapabilityAttr::get(
         context, static_cast<::mlir::tt::ChipCapability>(element));

--- a/lib/Dialect/TT/IR/TTOpsTypes.cpp
+++ b/lib/Dialect/TT/IR/TTOpsTypes.cpp
@@ -8,16 +8,14 @@
 #include "ttmlir/Target/Common/Target.h"
 #include "ttmlir/Utils.h"
 
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "mlir/Support/LLVM.h"
 #include "llvm/ADT/STLForwardCompat.h"
-#include <llvm/ADT/SmallVector.h>
-#include <llvm/ADT/StringExtras.h>
-#include <llvm/ADT/TypeSwitch.h>
-#include <llvm/Support/Casting.h>
-#include <mlir/IR/Builders.h>
-#include <mlir/IR/BuiltinOps.h>
-#include <mlir/IR/BuiltinTypes.h>
-#include <mlir/IR/DialectImplementation.h>
-#include <mlir/Support/LLVM.h>
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Casting.h"
 
 #include <cstdint>
 #include <fstream>

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -10,9 +10,7 @@
 #include "ttmlir/Dialect/TTIR/IR/TTIROpsInterfaces.cpp.inc"
 #include "ttmlir/Utils.h"
 
-#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Quant/IR/QuantTypes.h"
 #include "mlir/Dialect/Traits.h"

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -23,6 +23,7 @@
 #include "mlir/IR/Location.h"
 #include "mlir/IR/PatternMatch.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLForwardCompat.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/LogicalResult.h"
@@ -3461,9 +3462,7 @@ void mlir::tt::ttir::GenericOp::getAsmBlockNames(
     auto type = getRegionThreadType(region.getRegionNumber());
     setNameFn(&region.front(),
               stringifyEnum(type).str() +
-                  Twine(threadTypeCounts[static_cast<
-                            std::underlying_type_t<ThreadType>>(type)]++)
-                      .str());
+                  Twine(threadTypeCounts[llvm::to_underlying(type)]++).str());
   }
 }
 

--- a/lib/Dialect/TTIR/Transforms/Allocate.cpp
+++ b/lib/Dialect/TTIR/Transforms/Allocate.cpp
@@ -12,6 +12,7 @@
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/STLForwardCompat.h"
 
 namespace mlir::tt::ttir {
 #define GEN_PASS_DEF_TTIRALLOCATE
@@ -67,7 +68,7 @@ class TTIRAllocate : public impl::TTIRAllocateBase<TTIRAllocate> {
         return 0;
       }
 
-      auto index = ttmlir::utils::enum_as_int(memorySpace);
+      auto index = llvm::to_underlying(memorySpace);
       uint64_t &ptr = currPtr[index];
       ptr = ttmlir::utils::alignUp(ptr, memorySpaceInfo[index].alignment);
       auto result = ptr;
@@ -111,12 +112,12 @@ public:
   SimpleAllocator createSimpleAllocator(ChipDescAttr chipDesc) {
     SmallVector<SimpleAllocator::MemorySpaceInfo> memorySpaceInfo;
     memorySpaceInfo.resize(getMaxEnumValForMemorySpace() + 1llu);
-    memorySpaceInfo[ttmlir::utils::enum_as_int(MemorySpace::DeviceL1)] =
+    memorySpaceInfo[llvm::to_underlying(MemorySpace::DeviceL1)] =
         SimpleAllocator::MemorySpaceInfo(chipDesc.getL1UnreservedBase(),
                                          chipDesc.getL1Size() -
                                              chipDesc.getScratchL1RegionSize(),
                                          chipDesc.getNocL1AddressAlignBytes());
-    memorySpaceInfo[ttmlir::utils::enum_as_int(MemorySpace::DeviceDRAM)] =
+    memorySpaceInfo[llvm::to_underlying(MemorySpace::DeviceDRAM)] =
         SimpleAllocator::MemorySpaceInfo(
             chipDesc.getDramUnreservedBase(), chipDesc.getDramChannelSize(),
             chipDesc.getNocDRAMAddressAlignBytes());

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -2,17 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cassert>
-#include <cstddef>
-#include <flatbuffers/buffer.h>
-#include <memory>
-
 #include "ttmlir/Conversion/TTKernelToEmitC/TTKernelToEmitC.h"
-#include "ttmlir/Dialect/TT/IR/TT.h"
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
 #include "ttmlir/Dialect/TT/IR/Utils.h"
-#include "ttmlir/Dialect/TTKernel/IR/TTKernel.h"
-#include "ttmlir/Dialect/TTKernel/IR/TTKernelOps.h"
 #include "ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.h"
 #include "ttmlir/Dialect/TTMetal/IR/TTMetalOpsTypes.h"
 #include "ttmlir/Target/TTMetal/Target.h"
@@ -20,7 +12,7 @@
 #include "ttmlir/Target/Utils/MLIRToFlatbuffer.h"
 #include "ttmlir/Version.h"
 
-#include "mlir/Dialect/EmitC/IR/EmitC.h"
+#include "flatbuffers/buffer.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Support/LLVM.h"
@@ -29,6 +21,10 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/raw_ostream.h"
+
+#include <cassert>
+#include <cstddef>
+#include <memory>
 
 namespace mlir::tt {
 flatbuffers::Offset<::tt::target::metal::MemoryDesc>

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -7,15 +7,6 @@
 #include <flatbuffers/buffer.h>
 #include <memory>
 
-#include "mlir/Dialect/EmitC/IR/EmitC.h"
-#include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/IR/BuiltinOps.h"
-#include "mlir/Support/LLVM.h"
-#include "mlir/Support/LogicalResult.h"
-#include "llvm/ADT/SmallVector.h"
-#include "llvm/Support/LogicalResult.h"
-#include "llvm/Support/raw_ostream.h"
-
 #include "ttmlir/Conversion/TTKernelToEmitC/TTKernelToEmitC.h"
 #include "ttmlir/Dialect/TT/IR/TT.h"
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
@@ -28,6 +19,16 @@
 #include "ttmlir/Target/Utils/FlatbufferObjectCache.h"
 #include "ttmlir/Target/Utils/MLIRToFlatbuffer.h"
 #include "ttmlir/Version.h"
+
+#include "mlir/Dialect/EmitC/IR/EmitC.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/STLForwardCompat.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/LogicalResult.h"
+#include "llvm/Support/raw_ostream.h"
 
 namespace mlir::tt {
 flatbuffers::Offset<::tt::target::metal::MemoryDesc>
@@ -212,9 +213,8 @@ toFlatbuffer(::flatbuffers::FlatBufferBuilder &fbb,
 cbTypeToFlatbuffer(FlatbufferObjectCache &cache, ttkernel::CBType cbType) {
   auto memref = cache.getOrCreate(cbType.getMemref(), memrefAttrToFlatbuffer);
   return ::tt::target::metal::CreateCBDesc(
-      *cache.fbb,
-      static_cast<std::underlying_type_t<ttkernel::CBPort>>(cbType.getPort()),
-      memref, cbType.getPageSize(), cbType.getNumBuffers());
+      *cache.fbb, llvm::to_underlying(cbType.getPort()), memref,
+      cbType.getPageSize(), cbType.getNumBuffers());
 }
 
 std::pair<::tt::target::metal::RuntimeArg, ::flatbuffers::Offset<void>>


### PR DESCRIPTION
### Ticket
N/A

### Problem description
LLVM currently builds with C++17 but provides some STL utilities that we've been using that are available in future versions https://llvm.org/doxygen/STLForwardCompat_8h_source.html.

### What's changed
Replaced existing functionalities with provided utilities, this will also be useful once LLVM starts to build with C++20/23, as these utilities will be marked as deprecated, and it will be easier to replace them with STL implementation. Fixed includes in touched files.

### Checklist
- [ ] New/Existing tests provide coverage for changes
