### PR TITLE
Update runtime API for tensor creation

### DIFF
--- a/runtime/include/tt/runtime/detail/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn.h
@@ -52,7 +52,7 @@ namespace tt::runtime::ttnn {
 // Creates host tensor with owned storage (the buffer of the tensor is on the
 // host and its allocation/deallocation is owned by this tensor instance).
 ::tt::runtime::Tensor
-createOwnedHostTensor(void *data, std::vector<std::uint32_t> const &shape,
+createOwnedHostTensor(void const *data, std::vector<std::uint32_t> const &shape,
                       std::vector<std::uint32_t> const &stride,
                       std::uint32_t itemsize, ::tt::target::DataType dataType);
 
@@ -69,7 +69,8 @@ createBorrowedHostTensor(void *data, std::vector<std::uint32_t> const &shape,
 // are on the host and their allocation/deallocation is owned by this tensor
 // instance).
 ::tt::runtime::Tensor createOwnedMultiDeviceHostTensor(
-    std::vector<void *> const &data, std::vector<std::uint32_t> const &shape,
+    std::vector<void const *> const &data,
+    std::vector<std::uint32_t> const &shape,
     std::vector<std::uint32_t> const &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType,
     std::unordered_map<std::string, std::string> const &strategy);
@@ -84,7 +85,7 @@ createBorrowedHostTensor(void *data, std::vector<std::uint32_t> const &shape,
     Device device, Layout layout, std::vector<std::uint32_t> const &shape,
     std::vector<std::uint32_t> const &stride, std::uint32_t itemsize);
 
-inline ::tt::runtime::Tensor createOwnedHostTensor(void *data,
+inline ::tt::runtime::Tensor createOwnedHostTensor(void const *data,
                                                    TensorDesc const &desc) {
   return ::tt::runtime::ttnn::createOwnedHostTensor(
       data, desc.shape, desc.stride, desc.itemsize, desc.dataType);
@@ -97,7 +98,7 @@ inline ::tt::runtime::Tensor createBorrowedHostTensor(void *data,
 }
 
 inline ::tt::runtime::Tensor createOwnedMultiDeviceHostTensor(
-    std::vector<void *> const &data, TensorDesc const &desc,
+    std::vector<void const *> const &data, TensorDesc const &desc,
     std::unordered_map<std::string, std::string> const &strategy) {
   return ::tt::runtime::ttnn::createOwnedMultiDeviceHostTensor(
       data, desc.shape, desc.stride, desc.itemsize, desc.dataType, strategy);

--- a/runtime/include/tt/runtime/detail/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn.h
@@ -49,47 +49,64 @@
 
 namespace tt::runtime::ttnn {
 
+// Creates host tensor with owned storage (the buffer of the tensor is on the
+// host and its allocation/deallocation is owned by this tensor instance).
 ::tt::runtime::Tensor
-createOwnedTensor(std::shared_ptr<void> data,
-                  std::vector<std::uint32_t> const &shape,
-                  std::vector<std::uint32_t> const &stride,
-                  std::uint32_t itemsize, ::tt::target::DataType dataType);
+createOwnedHostTensor(void *data, std::vector<std::uint32_t> const &shape,
+                      std::vector<std::uint32_t> const &stride,
+                      std::uint32_t itemsize, ::tt::target::DataType dataType);
 
-::tt::runtime::Tensor createTensor(std::shared_ptr<void> data,
-                                   std::vector<std::uint32_t> const &shape,
-                                   std::vector<std::uint32_t> const &stride,
-                                   std::uint32_t itemsize,
-                                   ::tt::target::DataType dataType);
-
+// Creates host tensor with borrowed storage (the buffer of the tensor is on the
+// host and it was borrowed from an external buffer which is responsible for its
+// allocation/deallocation).
 ::tt::runtime::Tensor
-createTensor(std::vector<std::shared_ptr<void>> &data,
-             std::vector<std::uint32_t> const &shape,
-             std::vector<std::uint32_t> const &stride, std::uint32_t itemsize,
-             ::tt::target::DataType dataType,
-             std::unordered_map<std::string, std::string> const &strategy);
+createBorrowedHostTensor(void *data, std::vector<std::uint32_t> const &shape,
+                         std::vector<std::uint32_t> const &stride,
+                         std::uint32_t itemsize,
+                         ::tt::target::DataType dataType);
 
-::tt::runtime::Tensor createTensor(Device device, Layout layout,
-                                   std::vector<std::uint32_t> const &shape,
-                                   std::vector<std::uint32_t> const &stride,
-                                   std::uint32_t itemsize);
+// Creates multi-device host tensor with owned storage (buffers of the tensor
+// are on the host and their allocation/deallocation is owned by this tensor
+// instance).
+::tt::runtime::Tensor createOwnedMultiDeviceHostTensor(
+    std::vector<void *> const &data, std::vector<std::uint32_t> const &shape,
+    std::vector<std::uint32_t> const &stride, std::uint32_t itemsize,
+    ::tt::target::DataType dataType,
+    std::unordered_map<std::string, std::string> const &strategy);
 
-inline ::tt::runtime::Tensor createTensor(std::shared_ptr<void> data,
-                                          TensorDesc const &desc) {
-  return ::tt::runtime::ttnn::createTensor(data, desc.shape, desc.stride,
-                                           desc.itemsize, desc.dataType);
+// Creates multi-device host tensor from already existing host tensor shards.
+// Tensor shards can be host tensors with either owned or borrowed storage.
+::tt::runtime::Tensor createMultiDeviceHostTensor(
+    std::vector<::tt::runtime::Tensor> const &tensorShards,
+    std::unordered_map<std::string, std::string> const &strategy);
+
+::tt::runtime::Tensor createEmptyTensor(
+    Device device, Layout layout, std::vector<std::uint32_t> const &shape,
+    std::vector<std::uint32_t> const &stride, std::uint32_t itemsize);
+
+inline ::tt::runtime::Tensor createOwnedHostTensor(void *data,
+                                                   TensorDesc const &desc) {
+  return ::tt::runtime::ttnn::createOwnedHostTensor(
+      data, desc.shape, desc.stride, desc.itemsize, desc.dataType);
 }
 
-inline ::tt::runtime::Tensor
-createTensor(std::vector<std::shared_ptr<void>> &data, TensorDesc const &desc,
-             std::unordered_map<std::string, std::string> const &strategy) {
-  return ::tt::runtime::ttnn::createTensor(
+inline ::tt::runtime::Tensor createBorrowedHostTensor(void *data,
+                                                      TensorDesc const &desc) {
+  return ::tt::runtime::ttnn::createBorrowedHostTensor(
+      data, desc.shape, desc.stride, desc.itemsize, desc.dataType);
+}
+
+inline ::tt::runtime::Tensor createOwnedMultiDeviceHostTensor(
+    std::vector<void *> const &data, TensorDesc const &desc,
+    std::unordered_map<std::string, std::string> const &strategy) {
+  return ::tt::runtime::ttnn::createOwnedMultiDeviceHostTensor(
       data, desc.shape, desc.stride, desc.itemsize, desc.dataType, strategy);
 }
 
-inline ::tt::runtime::Tensor createTensor(Device device, Layout layout,
-                                          TensorDesc const &desc) {
-  return ::tt::runtime::ttnn::createTensor(device, layout, desc.shape,
-                                           desc.stride, desc.itemsize);
+inline ::tt::runtime::Tensor createEmptyTensor(Device device, Layout layout,
+                                               TensorDesc const &desc) {
+  return ::tt::runtime::ttnn::createEmptyTensor(device, layout, desc.shape,
+                                                desc.stride, desc.itemsize);
 }
 
 bool isTensorAllocated(::tt::runtime::Tensor tensor);

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -47,45 +47,81 @@ void setCompatibleRuntime(const Binary &binary);
 std::pair<SystemDesc, DeviceIds> getCurrentSystemDesc(
     std::optional<DispatchCoreType> dispatchCoreType = std::nullopt);
 
+// Creates host tensor with owned storage (the buffer of the tensor is on the
+// host and its allocation/deallocation is owned by this tensor instance).
+Tensor createOwnedHostTensor(void *data,
+                             std::vector<std::uint32_t> const &shape,
+                             std::vector<std::uint32_t> const &stride,
+                             std::uint32_t itemsize,
+                             ::tt::target::DataType dataType);
+
+// TODO(mrakita): Deprecated, will be removed after frontends uplift.
+// https://github.com/tenstorrent/tt-mlir/issues/2757
 Tensor createOwnedTensor(std::shared_ptr<void> data,
                          std::vector<std::uint32_t> const &shape,
                          std::vector<std::uint32_t> const &stride,
                          std::uint32_t itemsize,
                          ::tt::target::DataType dataType);
 
+// Creates host tensor with borrowed storage (the buffer of the tensor is on the
+// host and it was borrowed from an external buffer which is responsible for its
+// allocation/deallocation).
+Tensor createBorrowedHostTensor(void *data,
+                                std::vector<std::uint32_t> const &shape,
+                                std::vector<std::uint32_t> const &stride,
+                                std::uint32_t itemsize,
+                                ::tt::target::DataType dataType);
+
+// TODO(mrakita): Should be deprecated but D2M path is using this, investigate
+// if it can also use the new `createBorrowedHostTensor` function.
+// https://github.com/tenstorrent/tt-mlir/issues/2757
 Tensor createTensor(std::shared_ptr<void> data,
                     std::vector<std::uint32_t> const &shape,
                     std::vector<std::uint32_t> const &stride,
                     std::uint32_t itemsize, ::tt::target::DataType dataType);
 
-Tensor
-createTensor(std::vector<std::shared_ptr<void>> &data,
-             std::vector<std::uint32_t> const &shape,
-             std::vector<std::uint32_t> const &stride, std::uint32_t itemsize,
-             ::tt::target::DataType dataType,
-             std::unordered_map<std::string, std::string> const &strategy);
+// Creates multi-device host tensor with owned storage (buffers of the tensor
+// are on the host and their allocation/deallocation is owned by this tensor
+// instance).
+Tensor createOwnedMultiDeviceHostTensor(
+    std::vector<void *> const &data, std::vector<std::uint32_t> const &shape,
+    std::vector<std::uint32_t> const &stride, std::uint32_t itemsize,
+    ::tt::target::DataType dataType,
+    std::unordered_map<std::string, std::string> const &strategy);
 
-Tensor createTensor(Device device, Layout layout,
-                    std::vector<std::uint32_t> const &shape,
-                    std::vector<std::uint32_t> const &stride,
-                    std::uint32_t itemsize);
+// Creates multi-device host tensor from already existing host tensor shards.
+// Tensor shards can be host tensors with either owned or borrowed storage.
+Tensor createMultiDeviceHostTensor(
+    std::vector<Tensor> const &tensorShards,
+    std::unordered_map<std::string, std::string> const &strategy);
 
-inline Tensor createTensor(std::shared_ptr<void> data, TensorDesc const &desc) {
-  return ::tt::runtime::createTensor(data, desc.shape, desc.stride,
-                                     desc.itemsize, desc.dataType);
+// Creates empty tensor on host/device depending on the passed layout.
+Tensor createEmptyTensor(Device device, Layout layout,
+                         std::vector<std::uint32_t> const &shape,
+                         std::vector<std::uint32_t> const &stride,
+                         std::uint32_t itemsize);
+
+inline Tensor createOwnedHostTensor(void *data, TensorDesc const &desc) {
+  return ::tt::runtime::createOwnedHostTensor(data, desc.shape, desc.stride,
+                                              desc.itemsize, desc.dataType);
 }
 
-inline Tensor
-createTensor(std::vector<std::shared_ptr<void>> &data, TensorDesc const &desc,
-             std::unordered_map<std::string, std::string> const &strategy) {
-  return ::tt::runtime::createTensor(data, desc.shape, desc.stride,
-                                     desc.itemsize, desc.dataType, strategy);
+inline Tensor createBorrowedHostTensor(void *data, TensorDesc const &desc) {
+  return ::tt::runtime::createBorrowedHostTensor(data, desc.shape, desc.stride,
+                                                 desc.itemsize, desc.dataType);
 }
 
-inline Tensor createTensor(Device device, Layout layout,
-                           TensorDesc const &desc) {
-  return ::tt::runtime::createTensor(device, layout, desc.shape, desc.stride,
-                                     desc.itemsize);
+inline Tensor createOwnedMultiDeviceHostTensor(
+    std::vector<void *> const &data, TensorDesc const &desc,
+    std::unordered_map<std::string, std::string> const &strategy) {
+  return ::tt::runtime::createOwnedMultiDeviceHostTensor(
+      data, desc.shape, desc.stride, desc.itemsize, desc.dataType, strategy);
+}
+
+inline Tensor createEmptyTensor(Device device, Layout layout,
+                                TensorDesc const &desc) {
+  return ::tt::runtime::createEmptyTensor(device, layout, desc.shape,
+                                          desc.stride, desc.itemsize);
 }
 
 bool isTensorAllocated(Tensor tensor);
@@ -119,6 +155,8 @@ void wait(Tensor tensor);
 
 void wait(std::vector<Tensor> const &tensors);
 
+// Copies device tensor data to host tensor with owned storage, with option to
+// untilize data.
 std::vector<Tensor> toHost(Tensor tensor, bool untilize = false);
 
 Tensor toLayout(Tensor tensor, Device device, Layout layout,
@@ -131,6 +169,8 @@ void memcpy(void *dst, Tensor src);
 
 void memcpy(Tensor dst, Tensor src);
 
+// Deallocates tensor, both device and host. Cannot deallocate host tensors with
+// borrowed storage.
 void deallocateTensor(Tensor &tensor, bool force = false);
 
 std::string getOpDebugString(OpContext opContextHandle);

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -49,7 +49,7 @@ std::pair<SystemDesc, DeviceIds> getCurrentSystemDesc(
 
 // Creates host tensor with owned storage (the buffer of the tensor is on the
 // host and its allocation/deallocation is owned by this tensor instance).
-Tensor createOwnedHostTensor(void *data,
+Tensor createOwnedHostTensor(void const *data,
                              std::vector<std::uint32_t> const &shape,
                              std::vector<std::uint32_t> const &stride,
                              std::uint32_t itemsize,
@@ -84,7 +84,8 @@ Tensor createTensor(std::shared_ptr<void> data,
 // are on the host and their allocation/deallocation is owned by this tensor
 // instance).
 Tensor createOwnedMultiDeviceHostTensor(
-    std::vector<void *> const &data, std::vector<std::uint32_t> const &shape,
+    std::vector<void const *> const &data,
+    std::vector<std::uint32_t> const &shape,
     std::vector<std::uint32_t> const &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType,
     std::unordered_map<std::string, std::string> const &strategy);
@@ -101,7 +102,7 @@ Tensor createEmptyTensor(Device device, Layout layout,
                          std::vector<std::uint32_t> const &stride,
                          std::uint32_t itemsize);
 
-inline Tensor createOwnedHostTensor(void *data, TensorDesc const &desc) {
+inline Tensor createOwnedHostTensor(void const *data, TensorDesc const &desc) {
   return ::tt::runtime::createOwnedHostTensor(data, desc.shape, desc.stride,
                                               desc.itemsize, desc.dataType);
 }
@@ -112,7 +113,7 @@ inline Tensor createBorrowedHostTensor(void *data, TensorDesc const &desc) {
 }
 
 inline Tensor createOwnedMultiDeviceHostTensor(
-    std::vector<void *> const &data, TensorDesc const &desc,
+    std::vector<void const *> const &data, TensorDesc const &desc,
     std::unordered_map<std::string, std::string> const &strategy) {
   return ::tt::runtime::createOwnedMultiDeviceHostTensor(
       data, desc.shape, desc.stride, desc.itemsize, desc.dataType, strategy);

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -134,7 +134,7 @@ getCurrentSystemDesc(std::optional<DispatchCoreType> dispatchCoreType) {
   LOG_FATAL("runtime is not enabled");
 }
 
-Tensor createOwnedHostTensor(void *data,
+Tensor createOwnedHostTensor(void const *data,
                              std::vector<std::uint32_t> const &shape,
                              std::vector<std::uint32_t> const &stride,
                              std::uint32_t itemsize,
@@ -233,7 +233,8 @@ Tensor createTensor(std::shared_ptr<void> data,
 }
 
 Tensor createOwnedMultiDeviceHostTensor(
-    std::vector<void *> const &data, std::vector<std::uint32_t> const &shape,
+    std::vector<void const *> const &data,
+    std::vector<std::uint32_t> const &shape,
     std::vector<std::uint32_t> const &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType,
     std::unordered_map<std::string, std::string> const &strategy) {

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -134,18 +134,18 @@ getCurrentSystemDesc(std::optional<DispatchCoreType> dispatchCoreType) {
   LOG_FATAL("runtime is not enabled");
 }
 
-Tensor createOwnedTensor(std::shared_ptr<void> data,
-                         std::vector<std::uint32_t> const &shape,
-                         std::vector<std::uint32_t> const &stride,
-                         std::uint32_t itemsize,
-                         ::tt::target::DataType dataType) {
+Tensor createOwnedHostTensor(void *data,
+                             std::vector<std::uint32_t> const &shape,
+                             std::vector<std::uint32_t> const &stride,
+                             std::uint32_t itemsize,
+                             ::tt::target::DataType dataType) {
   LOG_ASSERT(!shape.empty());
   LOG_ASSERT(!stride.empty());
   LOG_ASSERT(itemsize > 0);
 #if defined(TT_RUNTIME_ENABLE_TTNN)
   if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::createOwnedTensor(data, shape, stride, itemsize,
-                                                  dataType);
+    return ::tt::runtime::ttnn::createOwnedHostTensor(data, shape, stride,
+                                                      itemsize, dataType);
   }
 #endif
 
@@ -157,6 +157,58 @@ Tensor createOwnedTensor(std::shared_ptr<void> data,
   LOG_FATAL("runtime is not enabled");
 }
 
+// TODO(mrakita): Deprecated, will be removed after frontends uplift.
+// https://github.com/tenstorrent/tt-mlir/issues/2757
+Tensor createOwnedTensor(std::shared_ptr<void> data,
+                         std::vector<std::uint32_t> const &shape,
+                         std::vector<std::uint32_t> const &stride,
+                         std::uint32_t itemsize,
+                         ::tt::target::DataType dataType) {
+  LOG_ASSERT(!shape.empty());
+  LOG_ASSERT(!stride.empty());
+  LOG_ASSERT(itemsize > 0);
+#if defined(TT_RUNTIME_ENABLE_TTNN)
+  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
+    return ::tt::runtime::ttnn::createOwnedHostTensor(data.get(), shape, stride,
+                                                      itemsize, dataType);
+  }
+#endif
+
+#if defined(TT_RUNTIME_ENABLE_TTMETAL)
+  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
+    LOG_FATAL("TT Metal runtime does not support creating owned tensors");
+  }
+#endif
+  LOG_FATAL("runtime is not enabled");
+}
+
+Tensor createBorrowedHostTensor(void *data,
+                                std::vector<std::uint32_t> const &shape,
+                                std::vector<std::uint32_t> const &stride,
+                                std::uint32_t itemsize,
+                                ::tt::target::DataType dataType) {
+  LOG_ASSERT(!shape.empty());
+  LOG_ASSERT(!stride.empty());
+  LOG_ASSERT(itemsize > 0);
+#if defined(TT_RUNTIME_ENABLE_TTNN)
+  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
+    return ::tt::runtime::ttnn::createBorrowedHostTensor(data, shape, stride,
+                                                         itemsize, dataType);
+  }
+#endif
+
+#if defined(TT_RUNTIME_ENABLE_TTMETAL)
+  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
+    LOG_FATAL("TT Metal runtime does not support creating borrowed host tensor "
+              "from direct pointer to data");
+  }
+#endif
+  LOG_FATAL("runtime is not enabled");
+}
+
+// TODO(mrakita): Should be deprecated but D2M path is using this, investigate
+// if it can also use the new `createBorrowedHostTensor` function.
+// https://github.com/tenstorrent/tt-mlir/issues/2757
 Tensor createTensor(std::shared_ptr<void> data,
                     std::vector<std::uint32_t> const &shape,
                     std::vector<std::uint32_t> const &stride,
@@ -166,8 +218,8 @@ Tensor createTensor(std::shared_ptr<void> data,
   LOG_ASSERT(itemsize > 0);
 #if defined(TT_RUNTIME_ENABLE_TTNN)
   if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::createTensor(data, shape, stride, itemsize,
-                                             dataType);
+    return ::tt::runtime::ttnn::createBorrowedHostTensor(
+        data.get(), shape, stride, itemsize, dataType);
   }
 #endif
 
@@ -180,19 +232,18 @@ Tensor createTensor(std::shared_ptr<void> data,
   LOG_FATAL("runtime is not enabled");
 }
 
-Tensor
-createTensor(std::vector<std::shared_ptr<void>> &data,
-             std::vector<std::uint32_t> const &shape,
-             std::vector<std::uint32_t> const &stride, std::uint32_t itemsize,
-             ::tt::target::DataType dataType,
-             std::unordered_map<std::string, std::string> const &strategy) {
+Tensor createOwnedMultiDeviceHostTensor(
+    std::vector<void *> const &data, std::vector<std::uint32_t> const &shape,
+    std::vector<std::uint32_t> const &stride, std::uint32_t itemsize,
+    ::tt::target::DataType dataType,
+    std::unordered_map<std::string, std::string> const &strategy) {
   LOG_ASSERT(!shape.empty());
   LOG_ASSERT(!stride.empty());
   LOG_ASSERT(itemsize > 0);
 #if defined(TT_RUNTIME_ENABLE_TTNN)
   if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::createTensor(data, shape, stride, itemsize,
-                                             dataType, strategy);
+    return ::tt::runtime::ttnn::createOwnedMultiDeviceHostTensor(
+        data, shape, stride, itemsize, dataType, strategy);
   }
 #endif
 
@@ -204,17 +255,36 @@ createTensor(std::vector<std::shared_ptr<void>> &data,
   LOG_FATAL("runtime is not enabled");
 }
 
-Tensor createTensor(Device device, Layout layout,
-                    std::vector<std::uint32_t> const &shape,
-                    std::vector<std::uint32_t> const &stride,
-                    std::uint32_t itemsize) {
+Tensor createMultiDeviceHostTensor(
+    std::vector<Tensor> const &tensorShards,
+    std::unordered_map<std::string, std::string> const &strategy) {
+  LOG_ASSERT(!tensorShards.empty());
+#if defined(TT_RUNTIME_ENABLE_TTNN)
+  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
+    return ::tt::runtime::ttnn::createMultiDeviceHostTensor(tensorShards,
+                                                            strategy);
+  }
+#endif
+
+#if defined(TT_RUNTIME_ENABLE_TTMETAL)
+  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
+    LOG_FATAL("Not implemented");
+  }
+#endif
+  LOG_FATAL("runtime is not enabled");
+}
+
+Tensor createEmptyTensor(Device device, Layout layout,
+                         std::vector<std::uint32_t> const &shape,
+                         std::vector<std::uint32_t> const &stride,
+                         std::uint32_t itemsize) {
   LOG_ASSERT(!shape.empty());
   LOG_ASSERT(!stride.empty());
   LOG_ASSERT(itemsize > 0);
 #if defined(TT_RUNTIME_ENABLE_TTNN)
   if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::createTensor(device, layout, shape, stride,
-                                             itemsize);
+    return ::tt::runtime::ttnn::createEmptyTensor(device, layout, shape, stride,
+                                                  itemsize);
   }
 #endif
 

--- a/runtime/test/ttnn/gtest/test_subtract.cpp
+++ b/runtime/test/ttnn/gtest/test_subtract.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <numeric>
 #include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -33,19 +34,23 @@ TEST(TTNNSubtract, Equal) {
     tensorSize *= dim;
   }
 
+  std::vector<std::shared_ptr<void>> inputData;
+  inputData.reserve(inputDescs.size());
   for (const auto &desc : inputDescs) {
     std::shared_ptr<void> data =
         ::tt::runtime::utils::malloc_shared(tensorSize);
     std::memset(data.get(), 1, tensorSize);
-    inputTensors.emplace_back(::tt::runtime::createTensor(data, desc));
+    inputTensors.emplace_back(
+        ::tt::runtime::createBorrowedHostTensor(data.get(), desc));
+    inputData.emplace_back(std::move(data));
   }
 
   std::shared_ptr<void> outputDataPtr =
       ::tt::runtime::utils::malloc_shared(tensorSize);
   // Set to wrong value on purpose here
   std::memset(outputDataPtr.get(), 1, tensorSize);
-  ::tt::runtime::Tensor outputTensor =
-      ::tt::runtime::createTensor(outputDataPtr, outputDescs[0]);
+  ::tt::runtime::Tensor outputTensor = ::tt::runtime::createBorrowedHostTensor(
+      outputDataPtr.get(), outputDescs[0]);
 
   uint32_t numDevices =
       static_cast<uint32_t>(::tt::runtime::getNumAvailableDevices());

--- a/runtime/tools/python/ttrt/runtime/module.cpp
+++ b/runtime/tools/python/ttrt/runtime/module.cpp
@@ -179,10 +179,9 @@ PYBIND11_MODULE(_C, m) {
       [](std::uintptr_t ptr, std::vector<std::uint32_t> const &shape,
          std::vector<std::uint32_t> const &stride, std::uint32_t itemsize,
          ::tt::target::DataType dataType) {
-        return tt::runtime::createOwnedTensor(
-            ::tt::runtime::utils::unsafe_borrow_shared(
-                reinterpret_cast<void *>(ptr)),
-            shape, stride, itemsize, dataType);
+        return tt::runtime::createOwnedHostTensor(
+            reinterpret_cast<void const *>(ptr), shape, stride, itemsize,
+            dataType);
       },
       "Create a tensor with owned memory");
   m.def(
@@ -203,9 +202,10 @@ PYBIND11_MODULE(_C, m) {
          std::unordered_map<std::string, std::string> const &strategy) {
         std::vector<void *> data;
         data.reserve(ptrs.size());
-        std::transform(
-            ptrs.begin(), ptrs.end(), std::back_inserter(data),
-            [](std::uintptr_t ptr) { return reinterpret_cast<void *>(ptr); });
+        std::transform(ptrs.begin(), ptrs.end(), std::back_inserter(data),
+                       [](std::uintptr_t ptr) {
+                         return reinterpret_cast<void const *>(ptr);
+                       });
         return tt::runtime::createOwnedMultiDeviceHostTensor(
             data, shape, stride, itemsize, dataType, strategy);
       },

--- a/runtime/tools/python/ttrt/runtime/module.cpp
+++ b/runtime/tools/python/ttrt/runtime/module.cpp
@@ -200,7 +200,7 @@ PYBIND11_MODULE(_C, m) {
          std::vector<std::uint32_t> const &stride, std::uint32_t itemsize,
          ::tt::target::DataType dataType,
          std::unordered_map<std::string, std::string> const &strategy) {
-        std::vector<void *> data;
+        std::vector<void const *> data;
         data.reserve(ptrs.size());
         std::transform(ptrs.begin(), ptrs.end(), std::back_inserter(data),
                        [](std::uintptr_t ptr) {

--- a/runtime/tools/python/ttrt/runtime/module.cpp
+++ b/runtime/tools/python/ttrt/runtime/module.cpp
@@ -173,7 +173,7 @@ PYBIND11_MODULE(_C, m) {
                 reinterpret_cast<void *>(ptr)),
             shape, stride, itemsize, dataType);
       },
-      "Create a tensor with borrowed memory");
+      "Create a host tensor with borrowed memory");
   m.def(
       "create_owned_tensor",
       [](std::uintptr_t ptr, std::vector<std::uint32_t> const &shape,
@@ -190,8 +190,8 @@ PYBIND11_MODULE(_C, m) {
       [](::tt::runtime::Device device, ::tt::runtime::Layout layout,
          std::vector<std::uint32_t> const &shape,
          std::vector<std::uint32_t> const &stride, std::uint32_t itemsize) {
-        return tt::runtime::createTensor(device, layout, shape, stride,
-                                         itemsize);
+        return tt::runtime::createEmptyTensor(device, layout, shape, stride,
+                                              itemsize);
       },
       "Create an empty tensor with the specified layout");
   m.def(
@@ -201,15 +201,13 @@ PYBIND11_MODULE(_C, m) {
          std::vector<std::uint32_t> const &stride, std::uint32_t itemsize,
          ::tt::target::DataType dataType,
          std::unordered_map<std::string, std::string> const &strategy) {
-        std::vector<std::shared_ptr<void>> data;
+        std::vector<void *> data;
         data.reserve(ptrs.size());
-        std::transform(ptrs.begin(), ptrs.end(), std::back_inserter(data),
-                       [](std::uintptr_t ptr) {
-                         return ::tt::runtime::utils::unsafe_borrow_shared(
-                             reinterpret_cast<void *>(ptr));
-                       });
-        return tt::runtime::createTensor(data, shape, stride, itemsize,
-                                         dataType, strategy);
+        std::transform(
+            ptrs.begin(), ptrs.end(), std::back_inserter(data),
+            [](std::uintptr_t ptr) { return reinterpret_cast<void *>(ptr); });
+        return tt::runtime::createOwnedMultiDeviceHostTensor(
+            data, shape, stride, itemsize, dataType, strategy);
       },
       "Create a multi-device host tensor with owned memory");
   m.def("get_num_available_devices", &tt::runtime::getNumAvailableDevices,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/2757

### Problem description
Explained in details in the ticket https://github.com/tenstorrent/tt-mlir/issues/2757

### What's changed
- Changed tensor creation API functions to use `void *` instead of `shared_ptr` so frontends don't have to create `shared_ptr` with empty deleters to use the runtime API.
- Renamed tensor creation API functions to state clearly on which device is buffer created and with which storage type, and added documentation comments in header files. Beside more clarity about what each function does, now it's much easier to track usages of each function across the codebase, before if you searched `createTensor` you'd get tons of hits and would have to look at argument types.
- Added new tensor creation API function to create multi-device tensor from already existing tensor shards. We need this in tt-xla because we first create tensors for each input buffer (that's how PJRT API works), and then after compilation when we know the multi-device strategy we need to create multi-device tensor (if needed), so we need to create it from already existing tensors.

### Checklist
- [x] New/Existing tests provide coverage for changes

I've prepared uplift PRs for frontends:
- tt-torch: https://github.com/tenstorrent/tt-torch/pull/568
- tt-forge-fe: https://github.com/tenstorrent/tt-forge-fe/pull/1707
- tt-xla: I'm making on some other changes there that will make use of this, so I will send PR for both later

Frontend on-pr CI jobs passed:
- [tt-torch](https://github.com/tenstorrent/tt-torch/actions/runs/14285792087)
- [tt-forge-fe](https://github.com/tenstorrent/tt-forge-fe/actions/runs/14286335280)