### PR TITLE
Fix MacOS build

### DIFF
--- a/lib/RegisterAll.cpp
+++ b/lib/RegisterAll.cpp
@@ -25,6 +25,7 @@
 #include "mlir/Dialect/Bufferization/IR/DstBufferizableOpInterfaceImpl.h"
 #include "mlir/Dialect/Func/Extensions/InlinerExtension.h"
 #include "mlir/Dialect/Linalg/Transforms/BufferizableOpInterfaceImpl.h"
+#include "mlir/Dialect/Quant/IR/Quant.h"
 #include "mlir/Dialect/SCF/Transforms/BufferizableOpInterfaceImpl.h"
 #include "mlir/Dialect/Tensor/Transforms/BufferizableOpInterfaceImpl.h"
 #include "mlir/Dialect/Vector/Transforms/BufferizableOpInterfaceImpl.h"
@@ -48,7 +49,7 @@ void mlir::tt::registerAllDialects(mlir::DialectRegistry &registry) {
       mlir::cf::ControlFlowDialect, mlir::tosa::TosaDialect,
       mlir::vector::VectorDialect, mlir::memref::MemRefDialect,
       mlir::emitc::EmitCDialect, mlir::bufferization::BufferizationDialect,
-      mlir::LLVM::LLVMDialect>();
+      mlir::LLVM::LLVMDialect, mlir::quant::QuantDialect>();
 
 #if TTMLIR_ENABLE_STABLEHLO
   mlir::stablehlo::registerAllDialects(registry);


### PR DESCRIPTION
On MacOS build (and generally any build that disables `StableHLO`) unregistered `QuantDialect` causes some tests to fail https://github.com/tenstorrent/tt-mlir/actions/runs/14288814075/job/40047365326. On build that enables `StableHLO` it's registered through `mlir::stablehlo::registerAllDialects(registry)`.