### PR TITLE
Remove stable hlo type converter

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -2024,6 +2024,8 @@ def TTIR_ConstantOp : TTIR_CreationOp<"constant",
     let results = (outs AnyRankedTensor:$result);
 
     let hasFolder = 1;
+
+    let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -406,15 +406,6 @@ def ElementTypeNormalization: Pass<"ttir-element-type-normalization", "::mlir::M
     "This pass walks through the graph and normalizes the element types into a list of supported types. This is useful for lowering
         to a target that only supports a subset of the element types.
   }];
-
-  let options = [
-    Option<"enableFP32", "enable-fp32",
-          "bool",
-          /*default=*/"true",
-          "Enables fp32 type.">
-  ];
-
-  let dependentDialects = ["::mlir::tt::TTDialect",  "::mlir::tt::ttir::TTIRDialect", "::mlir::func::FuncDialect"];
 }
 
 def TTIRFlattenSlidingWindow: Pass<"ttir-flatten-sliding-window", "::mlir::ModuleOp">

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -223,10 +223,6 @@ struct TTIRToTTNNBackendPipelineOptions
       *this, "enable-const-eval",
       llvm::cl::desc("Enable const-eval optimization pass."),
       llvm::cl::init(false)};
-
-  Option<bool> enableFP32{*this, "enable-fp32",
-                          llvm::cl::desc("Enable fp32 type."),
-                          llvm::cl::init(true)};
 };
 
 // TTIR to EmitC pipeline options.

--- a/lib/Dialect/TT/IR/CMakeLists.txt
+++ b/lib/Dialect/TT/IR/CMakeLists.txt
@@ -9,4 +9,7 @@ add_mlir_dialect_library(MLIRTTDialect
 
         DEPENDS
         MLIRTTOpsIncGen
+
+        LINK_LIBS PUBLIC
+        MLIRQuantDialect
         )

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -311,6 +311,19 @@ mlir::FailureOr<mlir::BaseMemRefType> mlir::tt::ttir::EmptyOp::getBufferType(
   return getValueAttr();
 }
 
+::mlir::LogicalResult mlir::tt::ttir::ConstantOp::verify() {
+  if (!isa<DenseResourceElementsAttr, DenseElementsAttr>(getValue())) {
+    return emitOpError("value attribute must be one of "
+                       "DenseResourceElementsAttr or DenseElementsAttr.");
+  }
+
+  if (!getValue().getElementType().isIntOrFloat()) {
+    return emitOpError("value attribute must be of int or float type.");
+  }
+
+  return success();
+}
+
 bool mlir::tt::ttir::ConstantOp::bufferizesToMemoryRead(
     mlir::OpOperand &, const mlir::bufferization::AnalysisState &) {
   return false;

--- a/lib/Dialect/TTIR/Transforms/ElementTypeNormalization.cpp
+++ b/lib/Dialect/TTIR/Transforms/ElementTypeNormalization.cpp
@@ -6,10 +6,8 @@
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTIR/Utils/UniformTypeRewriter.h"
 
-#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Quant/IR/QuantTypes.h"
-#include "mlir/Rewrite/FrozenRewritePatternSet.h"
-#include "mlir/Transforms/WalkPatternRewriteDriver.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir::tt::ttir {
 #define GEN_PASS_DEF_ELEMENTTYPENORMALIZATION
@@ -18,41 +16,116 @@ namespace mlir::tt::ttir {
 namespace {
 class ElementTypeConverter : public TypeConverter {
 public:
-  ElementTypeConverter(bool enableFP32) {
-    addConversion([](Type type) -> Type { return type; });
-    addConversion([enableFP32](RankedTensorType type) -> RankedTensorType {
+  ElementTypeConverter() {
+    addConversion([](RankedTensorType type) -> std::optional<RankedTensorType> {
       Type elementType = type.getElementType();
-      MLIRContext *context = elementType.getContext();
 
       // Skip quantized types - don't modify them.
       if (isa<quant::QuantizedType>(elementType)) {
         return type;
       }
 
-      size_t bitWidth = type.getElementTypeBitWidth();
-
-      // Convert bools to bf16, since not all ttnn ops
-      // support uint8.
-      if (bitWidth == 1) {
-        elementType = BFloat16Type::get(context);
-      } else if (isa<FloatType>(elementType) && bitWidth >= 32) {
-        if (enableFP32) {
-          elementType = Float32Type::get(context);
-        } else {
-          elementType = BFloat16Type::get(context);
-        }
-      } else {
-        elementType =
-            dataTypeToElementType(context, elementTypeToDataType(elementType));
+      elementType = toTTMLIRSupportedDataType(elementType);
+      if (!elementType) {
+        return {};
       }
 
-      SmallVector<int64_t> shape(type.getShape());
-      if (shape.empty()) {
-        shape = {1};
-      }
-
-      return RankedTensorType::get(shape, elementType);
+      return RankedTensorType::get(type.getShape(), elementType,
+                                   type.getEncoding());
     });
+  }
+};
+
+// TODO(milant): https://github.com/tenstorrent/tt-mlir/issues/2847
+// We need more sophisticated rewriting of the constant op,
+// since current logic doesn't rely on the type converter and
+// doesn't support DenseResourceElementsAttr conversion.
+class ConstantOpAttrRewriter : public OpRewritePattern<tt::ttir::ConstantOp> {
+public:
+  using OpRewritePattern<tt::ttir::ConstantOp>::OpRewritePattern;
+
+  ConstantOpAttrRewriter(const TypeConverter &converter, MLIRContext *ctx)
+      : OpRewritePattern(ctx), converter(converter) {}
+
+  LogicalResult matchAndRewrite(tt::ttir::ConstantOp op,
+                                PatternRewriter &rewriter) const override {
+    if (auto newAttr = rebuildElementsAttr(op.getValue())) {
+      if (newAttr == op.getValue()) {
+        return failure();
+      }
+
+      rewriter.modifyOpInPlace(op, [&]() { op.setValueAttr(newAttr); });
+      return success();
+    }
+
+    return rewriter.notifyMatchFailure(
+        op, "ttir.constant op only supports int or float types.");
+  }
+
+private:
+  TypeConverter converter;
+
+  mlir::ElementsAttr rebuildElementsAttr(mlir::ElementsAttr attr) const {
+    auto elementType = attr.getElementType();
+    auto newType = mlir::cast<mlir::ShapedType>(
+        converter.convertType(attr.getShapedType()));
+
+    // Skip rewriting if type is already supported or if the attribute is
+    // DenseResourceElementsAttr (conversion not supported yet).
+    if (newType.getElementType() == elementType ||
+        isa<DenseResourceElementsAttr>(attr)) {
+      return attr;
+    }
+
+    if (isa<IntegerType>(elementType)) {
+      return rebuildIntAttr(attr, newType);
+    }
+    if (isa<FloatType>(elementType)) {
+      return rebuildFloatAttr(attr, newType);
+    }
+
+    return nullptr;
+  }
+
+  mlir::ElementsAttr rebuildIntAttr(mlir::ElementsAttr attr,
+                                    mlir::ShapedType newType) const {
+    const size_t bitWidth = attr.getElementType().getIntOrFloatBitWidth();
+
+    // Represent booleans as bfloat16 APFloats
+    if (bitWidth == 1) {
+      llvm::SmallVector<mlir::APFloat> bf16Values;
+      for (bool v : attr.getValues<bool>()) {
+        bf16Values.emplace_back(mlir::APFloat::BFloat(), v);
+      }
+
+      return mlir::DenseElementsAttr::get(newType, bf16Values);
+    }
+
+    llvm::SmallVector<mlir::APInt> intValues;
+    for (mlir::APInt v : attr.getValues<mlir::APInt>()) {
+      intValues.push_back(bitWidth == 64 ? v.truncSSat(32) : v);
+    }
+
+    return mlir::DenseElementsAttr::get(newType, intValues);
+  }
+
+  mlir::ElementsAttr rebuildFloatAttr(mlir::ElementsAttr attr,
+                                      mlir::ShapedType newType) const {
+    const size_t bitWidth = attr.getElementType().getIntOrFloatBitWidth();
+    llvm::SmallVector<mlir::APFloat> floatValues;
+
+    if (bitWidth == 64) {
+      // Convert f64 -> f32
+      for (mlir::APFloat v : attr.getValues<mlir::APFloat>()) {
+        float f = static_cast<float>(v.convertToDouble());
+        floatValues.emplace_back(f);
+      }
+    } else {
+      floatValues.assign(attr.getValues<mlir::APFloat>().begin(),
+                         attr.getValues<mlir::APFloat>().end());
+    }
+
+    return mlir::DenseElementsAttr::get(newType, floatValues);
   }
 };
 
@@ -62,10 +135,56 @@ struct ElementTypeNormalization
       ElementTypeNormalization>::ElementTypeNormalizationBase;
 
   void runOnOperation() final {
+    // Check that all types are supported by TTMLIR.
+    if (!checkSupportedTypes()) {
+      signalPassFailure();
+      return;
+    }
+
     RewritePatternSet patterns(&getContext());
-    ElementTypeConverter converter(enableFP32);
     patterns.add<UniformTypeRewriter>(converter, &getContext());
-    walkAndApplyPatterns(getOperation(), std::move(patterns));
+    patterns.add<ConstantOpAttrRewriter>(converter, &getContext());
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+      signalPassFailure();
+      return;
+    }
+  }
+
+private:
+  ElementTypeConverter converter;
+
+  bool isLegal(Type type) const {
+    return converter.convertType(type) != nullptr;
+  }
+
+  bool isLegal(Operation *op) const {
+    auto isTypeLegal = [this](Type type) { return isLegal(type); };
+
+    // Special handling for function signature
+    if (auto funcOp = llvm::dyn_cast<func::FuncOp>(op)) {
+      return llvm::all_of(funcOp.getArgumentTypes(), isTypeLegal) &&
+             llvm::all_of(funcOp.getResultTypes(), isTypeLegal);
+    }
+
+    // Default case: check operand and result types
+    return llvm::all_of(op->getOperandTypes(), isTypeLegal) &&
+           llvm::all_of(op->getResultTypes(), isTypeLegal);
+  }
+
+  // Check that all operations in module are using supported types.
+  bool checkSupportedTypes() {
+    ModuleOp moduleOp = getOperation();
+    WalkResult walkResult =
+        moduleOp->walk<WalkOrder::PreOrder>([&](Operation *op) {
+          if (!isLegal(op)) {
+            op->emitOpError("Unsupported type.");
+            return WalkResult::interrupt();
+          }
+
+          return WalkResult::advance();
+        });
+
+    return !walkResult.wasInterrupted();
   }
 };
 } // namespace

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -153,11 +153,10 @@ void createTTNNPipelineTTIRImplicitBroadcastFoldPassFromString(
 
 void createTTIRToTTNNBackendPipeline(
     OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options) {
+  // Element type normalization should be the first pass in the pipeline.
+  pm.addPass(ttir::createElementTypeNormalization());
   // Create DeviceModule to wrap all ops.
   pm.addPass(tt::createTTWrapDeviceModulePass());
-  ttir::ElementTypeNormalizationOptions normalizationOptions{
-      options.enableFP32};
-  pm.addPass(ttir::createElementTypeNormalization(normalizationOptions));
   // Create CPUModuleOp to wrap hoisted ops (if any).
   pm.addPass(ttir::createTTIRHoistTransform());
 

--- a/test/ttmlir/Conversion/StableHLOToTTIR/binary/compare_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/binary/compare_op.mlir
@@ -3,55 +3,55 @@
 module @jit_eltwise_compare attributes {} {
   func.func public @test_eq(%arg0: tensor<13x31xf32>, %arg1: tensor<13x31xf32>) -> tensor<13x31xi1> {
     %0 = stablehlo.compare  EQ, %arg0, %arg1 : (tensor<13x31xf32>, tensor<13x31xf32>) -> tensor<13x31xi1>
-    // CHECK: %[[E:.*]] = ttir.empty() : tensor<13x31xbf16>
+    // CHECK: %[[E:.*]] = ttir.empty() : tensor<13x31xi1>
     // CHECK: = "ttir.eq"(%arg0, %arg1, %[[E]])
-    // CHECK-SAME: (tensor<13x31xf32>, tensor<13x31xf32>, tensor<13x31xbf16>) -> tensor<13x31xbf16>
+    // CHECK-SAME: (tensor<13x31xf32>, tensor<13x31xf32>, tensor<13x31xi1>) -> tensor<13x31xi1>
     return %0 : tensor<13x31xi1>
-    // CHECK: return %1 : tensor<13x31xbf16>
+    // CHECK: return %1 : tensor<13x31xi1>
   }
 
   func.func public @test_ne(%arg0: tensor<13x31xf32>, %arg1: tensor<13x31xf32>) -> tensor<13x31xi1> {
     %0 = stablehlo.compare  NE, %arg0, %arg1 : (tensor<13x31xf32>, tensor<13x31xf32>) -> tensor<13x31xi1>
-    // CHECK: %[[E:.*]] = ttir.empty() : tensor<13x31xbf16>
+    // CHECK: %[[E:.*]] = ttir.empty() : tensor<13x31xi1>
     // CHECK: = "ttir.ne"(%arg0, %arg1, %[[E]])
-    // CHECK-SAME: (tensor<13x31xf32>, tensor<13x31xf32>, tensor<13x31xbf16>) -> tensor<13x31xbf16>
+    // CHECK-SAME: (tensor<13x31xf32>, tensor<13x31xf32>, tensor<13x31xi1>) -> tensor<13x31xi1>
     return %0 : tensor<13x31xi1>
-    // CHECK: return %1 : tensor<13x31xbf16>
+    // CHECK: return %1 : tensor<13x31xi1>
   }
 
   func.func public @test_ge(%arg0: tensor<13x31xf32>, %arg1: tensor<13x31xf32>) -> tensor<13x31xi1> {
     %0 = stablehlo.compare  GE, %arg0, %arg1 : (tensor<13x31xf32>, tensor<13x31xf32>) -> tensor<13x31xi1>
-    // CHECK: %[[E:.*]] = ttir.empty() : tensor<13x31xbf16>
+    // CHECK: %[[E:.*]] = ttir.empty() : tensor<13x31xi1>
     // CHECK: = "ttir.ge"(%arg0, %arg1, %[[E]])
-    // CHECK-SAME: (tensor<13x31xf32>, tensor<13x31xf32>, tensor<13x31xbf16>) -> tensor<13x31xbf16>
+    // CHECK-SAME: (tensor<13x31xf32>, tensor<13x31xf32>, tensor<13x31xi1>) -> tensor<13x31xi1>
     return %0 : tensor<13x31xi1>
-    // CHECK: return %1 : tensor<13x31xbf16>
+    // CHECK: return %1 : tensor<13x31xi1>
   }
 
   func.func public @test_gt(%arg0: tensor<13x31xf32>, %arg1: tensor<13x31xf32>) -> tensor<13x31xi1> {
     %0 = stablehlo.compare  GT, %arg0, %arg1 : (tensor<13x31xf32>, tensor<13x31xf32>) -> tensor<13x31xi1>
-    // CHECK: %[[E:.*]] = ttir.empty() : tensor<13x31xbf16>
+    // CHECK: %[[E:.*]] = ttir.empty() : tensor<13x31xi1>
     // CHECK: = "ttir.gt"(%arg0, %arg1, %[[E]])
-    // CHECK-SAME: (tensor<13x31xf32>, tensor<13x31xf32>, tensor<13x31xbf16>) -> tensor<13x31xbf16>
+    // CHECK-SAME: (tensor<13x31xf32>, tensor<13x31xf32>, tensor<13x31xi1>) -> tensor<13x31xi1>
     return %0 : tensor<13x31xi1>
-    // CHECK: return %1 : tensor<13x31xbf16>
+    // CHECK: return %1 : tensor<13x31xi1>
   }
 
   func.func public @test_le(%arg0: tensor<13x31xf32>, %arg1: tensor<13x31xf32>) -> tensor<13x31xi1> {
     %0 = stablehlo.compare  LE, %arg0, %arg1 : (tensor<13x31xf32>, tensor<13x31xf32>) -> tensor<13x31xi1>
-    // CHECK: %[[E:.*]] = ttir.empty() : tensor<13x31xbf16>
+    // CHECK: %[[E:.*]] = ttir.empty() : tensor<13x31xi1>
     // CHECK: = "ttir.le"(%arg0, %arg1, %[[E]])
-    // CHECK-SAME: (tensor<13x31xf32>, tensor<13x31xf32>, tensor<13x31xbf16>) -> tensor<13x31xbf16>
+    // CHECK-SAME: (tensor<13x31xf32>, tensor<13x31xf32>, tensor<13x31xi1>) -> tensor<13x31xi1>
     return %0 : tensor<13x31xi1>
-    // CHECK: return %1 : tensor<13x31xbf16>
+    // CHECK: return %1 : tensor<13x31xi1>
   }
 
   func.func public @test_lt(%arg0: tensor<13x31xf32>, %arg1: tensor<13x31xf32>) -> tensor<13x31xi1> {
     %0 = stablehlo.compare  LT, %arg0, %arg1 : (tensor<13x31xf32>, tensor<13x31xf32>) -> tensor<13x31xi1>
-    // CHECK: %[[E:.*]] = ttir.empty() : tensor<13x31xbf16>
+    // CHECK: %[[E:.*]] = ttir.empty() : tensor<13x31xi1>
     // CHECK: = "ttir.lt"(%arg0, %arg1, %[[E]])
-    // CHECK-SAME: (tensor<13x31xf32>, tensor<13x31xf32>, tensor<13x31xbf16>) -> tensor<13x31xbf16>
+    // CHECK-SAME: (tensor<13x31xf32>, tensor<13x31xf32>, tensor<13x31xi1>) -> tensor<13x31xi1>
     return %0 : tensor<13x31xi1>
-    // CHECK: return %1 : tensor<13x31xbf16>
+    // CHECK: return %1 : tensor<13x31xi1>
   }
 }

--- a/test/ttmlir/Conversion/StableHLOToTTIR/binary/concat_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/binary/concat_op.mlir
@@ -15,7 +15,7 @@ module @jit_concat attributes {} {
     dimension = 0 : i64
     } : (tensor<3x2xi64>, tensor<1x2xi64>) -> tensor<4x2xi64>
     // CHECK: = ttir.empty
-    // CHECK: = "ttir.concat"(%arg0, %arg1, %0) <{dim = 0 : si32}> : (tensor<3x2xi32>, tensor<1x2xi32>, tensor<4x2xi32>) -> tensor<4x2xi32>
+    // CHECK: = "ttir.concat"(%arg0, %arg1, %0) <{dim = 0 : si32}> : (tensor<3x2xi64>, tensor<1x2xi64>, tensor<4x2xi64>) -> tensor<4x2xi64>
     return %0 : tensor<4x2xi64>
   }
 
@@ -42,7 +42,7 @@ module @jit_concat attributes {} {
       dimension = 1 : i64
     } : (tensor<256x512xi64>, tensor<256x256xi64>) -> tensor<256x768xi64>
     // CHECK: = ttir.empty
-    // CHECK: = "ttir.concat"(%arg0, %arg1, %0) <{dim = 1 : si32}> : (tensor<256x512xi32>, tensor<256x256xi32>, tensor<256x768xi32>) -> tensor<256x768xi32>
+    // CHECK: = "ttir.concat"(%arg0, %arg1, %0) <{dim = 1 : si32}> : (tensor<256x512xi64>, tensor<256x256xi64>, tensor<256x768xi64>) -> tensor<256x768xi64>
     return %0 : tensor<256x768xi64>
   }
 
@@ -51,7 +51,7 @@ module @jit_concat attributes {} {
       dimension = 1 : i64
     } : (tensor<64x32xf64>, tensor<64x64xf64>) -> tensor<64x96xf64>
     // CHECK: = ttir.empty
-    // CHECK: = "ttir.concat"(%arg0, %arg1, %0) <{dim = 1 : si32}> : (tensor<64x32xf32>, tensor<64x64xf32>, tensor<64x96xf32>) -> tensor<64x96xf32>
+    // CHECK: = "ttir.concat"(%arg0, %arg1, %0) <{dim = 1 : si32}> : (tensor<64x32xf64>, tensor<64x64xf64>, tensor<64x96xf64>) -> tensor<64x96xf64>
     return %0 : tensor<64x96xf64>
   }
 
@@ -69,7 +69,7 @@ module @jit_concat attributes {} {
       dimension = 3 : i64
     } : (tensor<3x2x4x5xf64>, tensor<3x2x4x3xf64>) -> tensor<3x2x4x8xf64>
     // CHECK: = ttir.empty
-    // CHECK: = "ttir.concat"(%arg0, %arg1, %0) <{dim = 3 : si32}> : (tensor<3x2x4x5xf32>, tensor<3x2x4x3xf32>, tensor<3x2x4x8xf32>) -> tensor<3x2x4x8xf32>
+    // CHECK: = "ttir.concat"(%arg0, %arg1, %0) <{dim = 3 : si32}> : (tensor<3x2x4x5xf64>, tensor<3x2x4x3xf64>, tensor<3x2x4x8xf64>) -> tensor<3x2x4x8xf64>
     return %0 : tensor<3x2x4x8xf64>
   }
 

--- a/test/ttmlir/Conversion/StableHLOToTTIR/binary/logical_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/binary/logical_op.mlir
@@ -2,7 +2,7 @@
 // RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s | FileCheck %s
 module @jit_eltwise_logical attributes {} {
   func.func public @logical_and(%arg0: tensor<32x32xi1>, %arg1: tensor<32x32xi1>) -> tensor<32x32xi1> {
-    // CHECK: %[[E:.*]] = ttir.empty() : [[TENSOR:tensor<32x32xbf16>]]
+    // CHECK: %[[E:.*]] = ttir.empty() : [[TENSOR:tensor<32x32xi1>]]
     // CHECK: = "ttir.logical_and"(%arg0, %arg1, %[[E]])
     // CHECK-SAME: ([[TENSOR]], [[TENSOR]], [[TENSOR]]) -> [[TENSOR]]
     %0 = stablehlo.and  %arg0, %arg1 : tensor<32x32xi1>
@@ -11,7 +11,7 @@ module @jit_eltwise_logical attributes {} {
   }
 
   func.func public @logical_or(%arg0: tensor<32x32xi1>, %arg1: tensor<32x32xi1>) -> tensor<32x32xi1> {
-    // CHECK: %[[E:.*]] = ttir.empty() : [[TENSOR:tensor<32x32xbf16>]]
+    // CHECK: %[[E:.*]] = ttir.empty() : [[TENSOR:tensor<32x32xi1>]]
     // CHECK: = "ttir.logical_or"(%arg0, %arg1, %[[E]])
     // CHECK-SAME: ([[TENSOR]], [[TENSOR]], [[TENSOR]]) -> [[TENSOR]]
     %0 = stablehlo.or  %arg0, %arg1 : tensor<32x32xi1>
@@ -20,7 +20,7 @@ module @jit_eltwise_logical attributes {} {
   }
 
   func.func public @logical_xor(%arg0: tensor<32x32xi1>, %arg1: tensor<32x32xi1>) -> tensor<32x32xi1> {
-    // CHECK: %[[E:.*]] = ttir.empty() : [[TENSOR:tensor<32x32xbf16>]]
+    // CHECK: %[[E:.*]] = ttir.empty() : [[TENSOR:tensor<32x32xi1>]]
     // CHECK: = "ttir.logical_xor"(%arg0, %arg1, %[[E]])
     // CHECK-SAME: ([[TENSOR]], [[TENSOR]], [[TENSOR]]) -> [[TENSOR]]
     %0 = stablehlo.xor  %arg0, %arg1 : tensor<32x32xi1>

--- a/test/ttmlir/Conversion/StableHLOToTTIR/constant_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/constant_op.mlir
@@ -2,25 +2,25 @@
 // RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s | FileCheck %s
 module @jit_constant attributes {} {
   func.func public @test_boolean_scalar() -> tensor<i1> {
-    // CHECK: %{{[0-9]+}} = "ttir.constant"() <{value = dense<1.000000e+00> : tensor<1xbf16>}> : () -> tensor<1xbf16>
+    // CHECK: %{{[0-9]+}} = "ttir.constant"() <{value = dense<true> : tensor<1xi1>}> : () -> tensor<1xi1>
     %0 = stablehlo.constant dense<true> : tensor<i1>
-    // CHECK: return %{{[0-9]+}} : tensor<1xbf16>
+    // CHECK: return %{{[0-9]+}} : tensor<1xi1>
     return %0 : tensor<i1>
   }
 
   func.func public @test_boolean_splat() -> tensor<64xi1> {
-    // CHECK: %{{[0-9]+}} = "ttir.constant"() <{value = dense<1.000000e+00> : tensor<64xbf16>}> : () -> tensor<64xbf16>
+    // CHECK: %{{[0-9]+}} = "ttir.constant"() <{value = dense<true> : tensor<64xi1>}> : () -> tensor<64xi1>
     %0 = stablehlo.constant dense<true> : tensor<64xi1>
-    // CHECK: return %{{[0-9]+}} : tensor<64xbf16>
+    // CHECK: return %{{[0-9]+}} : tensor<64xi1>
     return %0 : tensor<64xi1>
   }
 
   func.func public @test_boolean_multiple() -> tensor<2x2xi1> {
     // The ugly regex after `dense` is necessary because double square opening
     // brackets indicate substitution block in FileCheck syntax.
-    // CHECK: %{{[0-9]+}} = "ttir.constant"() <{value = dense<{{([[])}}[1.000000e+00, 0.000000e+00], [0.000000e+00, 1.000000e+00]]> : tensor<2x2xbf16>}> : () -> tensor<2x2xbf16>
+    // CHECK: %{{[0-9]+}} = "ttir.constant"() <{value = dense<{{([[])}}[true, false], [false, true]]> : tensor<2x2xi1>}> : () -> tensor<2x2xi1>
     %0 = stablehlo.constant dense<[[true, false], [false, true]]> : tensor<2x2xi1>
-    // CHECK: return %{{[0-9]+}} : tensor<2x2xbf16>
+    // CHECK: return %{{[0-9]+}} : tensor<2x2xi1>
     return %0 : tensor<2x2xi1>
   }
 
@@ -94,32 +94,32 @@ module @jit_constant attributes {} {
   }
 
   func.func public @test_f64_scalar() -> tensor<f64> {
-    // CHECK: %[[VAL:[0-9]+]] = "ttir.constant"() <{value = dense<3.000000e-01> : tensor<1xf32>}> : () -> tensor<1xf32>
+    // CHECK: %[[VAL:[0-9]+]] = "ttir.constant"() <{value = dense<3.000000e-01> : tensor<1xf64>}> : () -> tensor<1xf64>
     %0 = stablehlo.constant dense<0.3> : tensor<f64>
-    // CHECK: return %[[VAL]] : tensor<1xf32>
+    // CHECK: return %[[VAL]] : tensor<1xf64>
     return %0 : tensor<f64>
   }
 
   func.func public @test_f64_splat() -> tensor<64xf64> {
-    // CHECK: %[[VAL:[0-9]+]] = "ttir.constant"() <{value = dense<3.000000e-01> : tensor<64xf32>}> : () -> tensor<64xf32>
+    // CHECK: %[[VAL:[0-9]+]] = "ttir.constant"() <{value = dense<3.000000e-01> : tensor<64xf64>}> : () -> tensor<64xf64>
     %0 = stablehlo.constant dense<0.3> : tensor<64xf64>
-    // CHECK: return %[[VAL]] : tensor<64xf32>
+    // CHECK: return %[[VAL]] : tensor<64xf64>
     return %0 : tensor<64xf64>
   }
 
   func.func public @test_f64_multiple() -> tensor<2x2xf64> {
     // The ugly regex after `dense` is necessary because double square opening
     // brackets indicate substitution block in FileCheck syntax.
-    // CHECK: %[[VAL:[0-9]+]] = "ttir.constant"() <{value = dense<{{([[])}}[0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00]]> : tensor<2x2xf32>}> : () -> tensor<2x2xf32>
+    // CHECK: %[[VAL:[0-9]+]] = "ttir.constant"() <{value = dense<{{([[])}}[0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00]]> : tensor<2x2xf64>}> : () -> tensor<2x2xf64>
     %0 = stablehlo.constant dense<[[0.0, 1.0], [2.0, 3.0]]> : tensor<2x2xf64>
-    // CHECK: return %[[VAL]] : tensor<2x2xf32>
+    // CHECK: return %[[VAL]] : tensor<2x2xf64>
     return %0 : tensor<2x2xf64>
   }
 
   func.func public @test_f64_inf() -> tensor<f64> {
-    // CHECK: %[[VAL:[0-9]+]] = "ttir.constant"() <{value = dense<0xFF800000> : tensor<1xf32>}> : () -> tensor<1xf32>
+    // CHECK: %[[VAL:[0-9]+]] = "ttir.constant"() <{value = dense<0xFFF0000000000000> : tensor<1xf64>}> : () -> tensor<1xf64>
     %0 = stablehlo.constant dense<0xFFF0000000000000> : tensor<f64>
-    // CHECK: return %[[VAL]] : tensor<1xf32>
+    // CHECK: return %[[VAL]] : tensor<1xf64>
     return %0 : tensor<f64>
   }
 
@@ -193,25 +193,25 @@ module @jit_constant attributes {} {
   }
 
   func.func public @test_int64_scalar() -> tensor<i64> {
-    // CHECK: %{{[0-9]+}} = "ttir.constant"() <{value = dense<3> : tensor<1xi32>}> : () -> tensor<1xi32>
+    // CHECK: %{{[0-9]+}} = "ttir.constant"() <{value = dense<3> : tensor<1xi64>}> : () -> tensor<1xi64>
     %0 = stablehlo.constant dense<3> : tensor<i64>
-    // CHECK: return %{{[0-9]+}} : tensor<1xi32>
+    // CHECK: return %{{[0-9]+}} : tensor<1xi64>
     return %0 : tensor<i64>
   }
 
   func.func public @test_int64_splat() -> tensor<64xi64> {
-    // CHECK: %{{[0-9]+}} = "ttir.constant"() <{value = dense<3> : tensor<64xi32>}> : () -> tensor<64xi32>
+    // CHECK: %{{[0-9]+}} = "ttir.constant"() <{value = dense<3> : tensor<64xi64>}> : () -> tensor<64xi64>
     %0 = stablehlo.constant dense<3> : tensor<64xi64>
-    // CHECK: return %{{[0-9]+}} : tensor<64xi32>
+    // CHECK: return %{{[0-9]+}} : tensor<64xi64>
     return %0 : tensor<64xi64>
   }
 
   func.func public @test_int64_multiple() -> tensor<2x2xi64> {
     // The ugly regex after `dense` is necessary because double square opening
     // brackets indicate substitution block in FileCheck syntax.
-    // CHECK: %{{[0-9]+}} = "ttir.constant"() <{value = dense<{{([[])}}[0, 1], [2, 3]]> : tensor<2x2xi32>}> : () -> tensor<2x2xi32>
+    // CHECK: %{{[0-9]+}} = "ttir.constant"() <{value = dense<{{([[])}}[0, 1], [2, 3]]> : tensor<2x2xi64>}> : () -> tensor<2x2xi64>
     %0 = stablehlo.constant dense<[[0, 1], [2, 3]]> : tensor<2x2xi64>
-    // CHECK: return %{{[0-9]+}} : tensor<2x2xi32>
+    // CHECK: return %{{[0-9]+}} : tensor<2x2xi64>
     return %0 : tensor<2x2xi64>
   }
 
@@ -285,25 +285,25 @@ module @jit_constant attributes {} {
   }
 
   func.func public @test_uint64_scalar() -> tensor<ui64> {
-    // CHECK: %{{[0-9]+}} = "ttir.constant"() <{value = dense<3> : tensor<1xui32>}> : () -> tensor<1xui32>
+    // CHECK: %{{[0-9]+}} = "ttir.constant"() <{value = dense<3> : tensor<1xui64>}> : () -> tensor<1xui64>
     %0 = stablehlo.constant dense<3> : tensor<ui64>
-    // CHECK: return %{{[0-9]+}} : tensor<1xui32>
+    // CHECK: return %{{[0-9]+}} : tensor<1xui64>
     return %0 : tensor<ui64>
   }
 
   func.func public @test_uint64_splat() -> tensor<64xui64> {
-    // CHECK: %{{[0-9]+}} = "ttir.constant"() <{value = dense<3> : tensor<64xui32>}> : () -> tensor<64xui32>
+    // CHECK: %{{[0-9]+}} = "ttir.constant"() <{value = dense<3> : tensor<64xui64>}> : () -> tensor<64xui64>
     %0 = stablehlo.constant dense<3> : tensor<64xui64>
-    // CHECK: return %{{[0-9]+}} : tensor<64xui32>
+    // CHECK: return %{{[0-9]+}} : tensor<64xui64>
     return %0 : tensor<64xui64>
   }
 
   func.func public @test_uint64_multiple() -> tensor<2x2xui64> {
     // The ugly regex after `dense` is necessary because double square opening
     // brackets indicate substitution block in FileCheck syntax.
-    // CHECK: %{{[0-9]+}} = "ttir.constant"() <{value = dense<{{([[])}}[0, 1], [2, 3]]> : tensor<2x2xui32>}> : () -> tensor<2x2xui32>
+    // CHECK: %{{[0-9]+}} = "ttir.constant"() <{value = dense<{{([[])}}[0, 1], [2, 3]]> : tensor<2x2xui64>}> : () -> tensor<2x2xui64>
     %0 = stablehlo.constant dense<[[0, 1], [2, 3]]> : tensor<2x2xui64>
-    // CHECK: return %{{[0-9]+}} : tensor<2x2xui32>
+    // CHECK: return %{{[0-9]+}} : tensor<2x2xui64>
     return %0 : tensor<2x2xui64>
   }
 
@@ -334,9 +334,9 @@ module @jit_constant attributes {} {
 
   func.func public @test_int64_negative_min_scalar() -> tensor<i64> {
     // CHECK-LABEL: func.func public @test_int64_negative_min_scalar
-    // CHECK: %[[CONSTANT:[0-9]+]] = "ttir.constant"() <{value = dense<-2147483648> : tensor<1xi32>}> : () -> tensor<1xi32>
+    // CHECK: %[[CONSTANT:[0-9]+]] = "ttir.constant"() <{value = dense<-9223372036854775808> : tensor<1xi64>}> : () -> tensor<1xi64>
     %0 = stablehlo.constant dense<9223372036854775808> : tensor<i64>
-    // CHECK: return %[[CONSTANT]] : tensor<1xi32>
+    // CHECK: return %[[CONSTANT]] : tensor<1xi64>
     return %0 : tensor<i64>
   }
 

--- a/test/ttmlir/Conversion/StableHLOToTTIR/cumsum_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/cumsum_op.mlir
@@ -4,7 +4,7 @@
 module @moreh_cumsum attributes {} {
   func.func @test_moreh_cumsum_0_dim1(%arg0: tensor<1x10xi64>) -> tensor<1x10xi64> {
     // CHECK-LABEL: func.func @test_moreh_cumsum_0_dim1
-    // CHECK: %[[EMPTY:[0-9]+]] = ttir.empty() : [[TENSOR:tensor<1x10xi32>]]
+    // CHECK: %[[EMPTY:[0-9]+]] = ttir.empty() : [[TENSOR:tensor<1x10xi64>]]
     // CHECK: %[[RET:[0-9]+]] = "ttir.cumsum"(%arg0, %[[EMPTY]])
     // CHECK-SAME: <{dim = 1 : i64}>
     // CHECK-SAME: ([[TENSOR]], [[TENSOR]]) -> [[TENSOR]]
@@ -21,7 +21,7 @@ module @moreh_cumsum attributes {} {
   func.func @test_moreh_cumsum_1_dim0(%arg0: tensor<5xi64>) -> tensor<5xi64> {
     %c = stablehlo.constant dense<0> : tensor<i64>
     // CHECK-LABEL: func.func @test_moreh_cumsum_1_dim0
-    // CHECK: %[[EMPTY:[0-9]+]] = ttir.empty() : [[TENSOR:tensor<5xi32>]]
+    // CHECK: %[[EMPTY:[0-9]+]] = ttir.empty() : [[TENSOR:tensor<5xi64>]]
     // CHECK: %[[RET:[0-9]+]] = "ttir.cumsum"(%arg0, %[[EMPTY]])
     // CHECK-SAME: <{dim = 0 : i64}>
     // CHECK-SAME: ([[TENSOR]], [[TENSOR]]) -> [[TENSOR]]
@@ -36,7 +36,7 @@ module @moreh_cumsum attributes {} {
 
   func.func @test_moreh_cumsum_2_dim0(%arg0: tensor<8x2x4x16xi32>) -> tensor<8x2x4x16xi64> {
     // CHECK-LABEL: func.func @test_moreh_cumsum_2_dim0
-    // CHECK: ttir.empty() : [[TENSOR:tensor<8x2x4x16xi32>]]
+    // CHECK: ttir.empty() : [[TENSOR:tensor<8x2x4x16xi64>]]
     // CHECK: %[[RET:[0-9]+]] = "ttir.cumsum"
     // CHECK-SAME: <{dim = 0 : i64}>
     // CHECK-SAME: ([[TENSOR]], [[TENSOR]]) -> [[TENSOR]]
@@ -53,7 +53,7 @@ module @moreh_cumsum attributes {} {
 
   func.func @test_moreh_cumsum_2_dim2(%arg0: tensor<8x2x4x16xi32>) -> tensor<8x2x4x16xi64> {
     // CHECK-LABEL: func.func @test_moreh_cumsum_2_dim2
-    // CHECK: ttir.empty() : [[TENSOR:tensor<8x2x4x16xi32>]]
+    // CHECK: ttir.empty() : [[TENSOR:tensor<8x2x4x16xi64>]]
     // CHECK: %[[RET:[0-9]+]] = "ttir.cumsum"
     // CHECK-SAME: <{dim = 2 : i64}>
     // CHECK-SAME: ([[TENSOR]], [[TENSOR]]) -> [[TENSOR]]
@@ -70,7 +70,7 @@ module @moreh_cumsum attributes {} {
 
   func.func @test_moreh_cumsum_3_dim1(%arg0: tensor<8x1x4x16xi32>) -> tensor<8x1x4x16xi64> {
     // CHECK-LABEL: func.func @test_moreh_cumsum_3_dim1
-    // CHECK: ttir.empty() : [[TENSOR:tensor<8x1x4x16xi32>]]
+    // CHECK: ttir.empty() : [[TENSOR:tensor<8x1x4x16xi64>]]
     // CHECK: %[[RET:[0-9]+]] = "ttir.cumsum"
     // CHECK-SAME: <{dim = 1 : i64}>
     // CHECK-SAME: ([[TENSOR]], [[TENSOR]]) -> [[TENSOR]]

--- a/test/ttmlir/Conversion/StableHLOToTTIR/empty_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/empty_op.mlir
@@ -3,9 +3,9 @@
 module @module_empty {
   func.func @test_empty_boolean() -> tensor<1xi1> {
     // CHECK-LABEL: @test_empty_boolean
-    // CHECK: %[[EMPTY:[0-9]+]] = ttir.empty() : tensor<1xbf16>
+    // CHECK: %[[EMPTY:[0-9]+]] = ttir.empty() : tensor<1xi1>
     %0 = tensor.empty() : tensor<1xi1>
-    // CHECK: return %[[EMPTY]] : tensor<1xbf16>
+    // CHECK: return %[[EMPTY]] : tensor<1xi1>
     return %0 : tensor<1xi1>
   }
 

--- a/test/ttmlir/Conversion/StableHLOToTTIR/gather_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/gather_op.mlir
@@ -33,7 +33,7 @@ module @jit_gather attributes {} {
     // CHECK-SAME: slice_sizes = array<i64: 1, 512>,
     // CHECK-SAME: start_index_map = array<i64: 0>,
     // CHECK-SAME: start_indices_batching_dims = array<i64>
-    // CHECK-SAME: (tensor<32128x512xbf16>, tensor<1x15xi32>, tensor<1x15x512xbf16>) -> tensor<1x15x512xbf16>
+    // CHECK-SAME: (tensor<32128x512xbf16>, tensor<1x15xi64>, tensor<1x15x512xbf16>) -> tensor<1x15x512xbf16>
     %0 = "stablehlo.gather"(%arg0, %arg1) <{dimension_numbers = #stablehlo.gather<offset_dims = [2], collapsed_slice_dims = [0], start_index_map = [0], index_vector_dim = 2>, indices_are_sorted = false, slice_sizes = array<i64: 1, 512>}> : (tensor<32128x512xbf16>, tensor<1x15xi64>) -> tensor<1x15x512xbf16>
     // CEHCK: return %[[VAL]] : tensor<1x15x512xbf16>
     return %0 : tensor<1x15x512xbf16>

--- a/test/ttmlir/Conversion/StableHLOToTTIR/get_dimension_size_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/get_dimension_size_op.mlir
@@ -9,7 +9,7 @@ module @jit_get_dimension_size attributes {} {
   }
 
   func.func public @test_get_dimension_size_f64(%arg0: tensor<64x64xf64>) -> tensor<i32> {
-    // CHECK: [[VAL:%[0-9]+]] = "ttir.get_dimension_size"(%arg0) <{dimension = 1 : i32}> : (tensor<64x64xf32>) -> tensor<1xi32>
+    // CHECK: [[VAL:%[0-9]+]] = "ttir.get_dimension_size"(%arg0) <{dimension = 1 : i32}> : (tensor<64x64xf64>) -> tensor<1xi32>
     %0 = stablehlo.get_dimension_size %arg0, dim = 1 : (tensor<64x64xf64>) -> tensor<i32>
     // CHECK: return [[VAL]] : tensor<1xi32>
     return %0 : tensor<i32>

--- a/test/ttmlir/Conversion/StableHLOToTTIR/isfinite_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/isfinite_op.mlir
@@ -2,11 +2,11 @@
 // RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s | FileCheck %s
 module @jit_eltwise_isfinite attributes {} {
   func.func public @test_isfinite(%arg0: tensor<32x32x3xf32>) -> tensor<32x32x3xi1> {
-    // CHECK: %[[E:.*]] = ttir.empty() : tensor<32x32x3xbf16>
+    // CHECK: %[[E:.*]] = ttir.empty() : tensor<32x32x3xi1>
     // CHECK: %[[C:.*]] = "ttir.isfinite"(%arg0, %[[E]])
-    // CHECK-SAME: (tensor<32x32x3xf32>, tensor<32x32x3xbf16>) -> tensor<32x32x3xbf16>
+    // CHECK-SAME: (tensor<32x32x3xf32>, tensor<32x32x3xi1>) -> tensor<32x32x3xi1>
     %0 = stablehlo.is_finite %arg0 : (tensor<32x32x3xf32>) -> tensor<32x32x3xi1>
-    // CHECK: return %[[C]] : tensor<32x32x3xbf16>
+    // CHECK: return %[[C]] : tensor<32x32x3xi1>
     return %0 : tensor<32x32x3xi1>
   }
 }

--- a/test/ttmlir/Conversion/StableHLOToTTIR/reduction/argmax_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/reduction/argmax_op.mlir
@@ -4,12 +4,12 @@
 module @module_argmax attributes {} {
   func.func public @argmax_torch_2d(%arg0: tensor<1x32128xf32>) -> tensor<1xi64> {
     // CHECK-LABEL: func.func public @argmax_torch_2d(
-    // CHECK: %[[EMPTY:[0-9]+]] = ttir.empty() : tensor<1xi32>
+    // CHECK: %[[EMPTY:[0-9]+]] = ttir.empty() : tensor<1xi64>
     // CHECK: %[[VAL:[0-9]+]] = "ttir.argmax"(%arg0, %[[EMPTY]])
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: (tensor<1x32128xf32>, tensor<1xi32>) -> tensor<1xi32>
-    // CHECK: return %[[VAL]] : tensor<1xi32>
+    // CHECK-SAME: (tensor<1x32128xf32>, tensor<1xi64>) -> tensor<1xi64>
+    // CHECK: return %[[VAL]] : tensor<1xi64>
     %cst = stablehlo.constant dense<0xFF800000> : tensor<f32>
     %c = stablehlo.constant dense<0> : tensor<i64>
     %0 = stablehlo.iota dim = 1 : tensor<1x32128xi64>
@@ -82,12 +82,12 @@ module @module_argmax attributes {} {
 
   func.func public @argmax_torch_4d(%arg0: tensor<4x8x128x64xf32>) -> tensor<4x8x64xi64> {
     // CHECK-LABEL: func.func public @argmax_torch_4d(
-    // CHECK: %[[EMPTY:[0-9]+]] = ttir.empty() : tensor<4x8x64xi32>
+    // CHECK: %[[EMPTY:[0-9]+]] = ttir.empty() : tensor<4x8x64xi64>
     // CHECK: %[[VAL:[0-9]+]] = "ttir.argmax"(%arg0, %[[EMPTY]])
     // CHECK-SAME: dim_arg = [2 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: (tensor<4x8x128x64xf32>, tensor<4x8x64xi32>) -> tensor<4x8x64xi32>
-    // CHECK: return %[[VAL]] : tensor<4x8x64xi32>
+    // CHECK-SAME: (tensor<4x8x128x64xf32>, tensor<4x8x64xi64>) -> tensor<4x8x64xi64>
+    // CHECK: return %[[VAL]] : tensor<4x8x64xi64>
     %cst = stablehlo.constant dense<0xFF800000> : tensor<f32>
     %c = stablehlo.constant dense<0> : tensor<i64>
     %0 = stablehlo.iota dim = 2 : tensor<4x8x128x64xi64>
@@ -110,7 +110,7 @@ module @module_argmax attributes {} {
     // CHECK: %[[VAL:[0-9]+]] = "ttir.argmax"(%arg0, %[[EMPTY]])
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: (tensor<2x7xbf16>, tensor<2xi32>) -> tensor<2xi32>
+    // CHECK-SAME: (tensor<2x7xi1>, tensor<2xi32>) -> tensor<2xi32>
     // CHECK: return %[[VAL]] : tensor<2xi32>
     %c = stablehlo.constant dense<0> : tensor<i32>
     %c_0 = stablehlo.constant dense<false> : tensor<i1>

--- a/test/ttmlir/Conversion/StableHLOToTTIR/reduction/reduce_and_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/reduction/reduce_and_op.mlir
@@ -7,8 +7,8 @@ module @jit_reduce_and attributes {} {
     // CHECK: "ttir.reduce_and"
     // CHECK-SAME: dim_arg = [3 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x32x4xbf16>
-    // CHECK-SAME: -> tensor<128x10x32xbf16>
+    // CHECK-SAME: tensor<128x10x32x4xi1>
+    // CHECK-SAME: -> tensor<128x10x32xi1>
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.and across dimensions = [3] : (tensor<128x10x32x4xi1>, tensor<i1>) -> tensor<128x10x32xi1>
     return %0 : tensor<128x10x32xi1>
   }
@@ -19,8 +19,8 @@ module @jit_reduce_and attributes {} {
     // CHECK: "ttir.reduce_and"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x4xbf16>
-    // CHECK-SAME: -> tensor<128x4xbf16>
+    // CHECK-SAME: tensor<128x10x4xi1>
+    // CHECK-SAME: -> tensor<128x4xi1>
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.and across dimensions = [1] : (tensor<128x10x4xi1>, tensor<i1>) -> tensor<128x4xi1>
     return %0 : tensor<128x4xi1>
   }
@@ -31,8 +31,8 @@ module @jit_reduce_and attributes {} {
     // CHECK: "ttir.reduce_and"
     // CHECK-SAME: dim_arg = [0 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10xbf16>
-    // CHECK-SAME: -> tensor<10xbf16>
+    // CHECK-SAME: tensor<128x10xi1>
+    // CHECK-SAME: -> tensor<10xi1>
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.and across dimensions = [0] : (tensor<128x10xi1>, tensor<i1>) -> tensor<10xi1>
     return %0 : tensor<10xi1>
   }

--- a/test/ttmlir/Conversion/StableHLOToTTIR/reduction/reduce_or_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/reduction/reduce_or_op.mlir
@@ -7,8 +7,8 @@ module @jit_reduce_or attributes {} {
     // CHECK: "ttir.reduce_or"
     // CHECK-SAME: dim_arg = [3 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x32x4xbf16>
-    // CHECK-SAME: -> tensor<128x10x32xbf16>
+    // CHECK-SAME: tensor<128x10x32x4xi1>
+    // CHECK-SAME: -> tensor<128x10x32xi1>
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.or across dimensions = [3] : (tensor<128x10x32x4xi1>, tensor<i1>) -> tensor<128x10x32xi1>
     return %0 : tensor<128x10x32xi1>
   }
@@ -19,8 +19,8 @@ module @jit_reduce_or attributes {} {
     // CHECK: "ttir.reduce_or"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x4xbf16>
-    // CHECK-SAME: -> tensor<128x4xbf16>
+    // CHECK-SAME: tensor<128x10x4xi1>
+    // CHECK-SAME: -> tensor<128x4xi1>
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.or across dimensions = [1] : (tensor<128x10x4xi1>, tensor<i1>) -> tensor<128x4xi1>
     return %0 : tensor<128x4xi1>
   }
@@ -31,8 +31,8 @@ module @jit_reduce_or attributes {} {
     // CHECK: "ttir.reduce_or"
     // CHECK-SAME: dim_arg = [0 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10xbf16>
-    // CHECK-SAME: -> tensor<10xbf16>
+    // CHECK-SAME: tensor<128x10xi1>
+    // CHECK-SAME: -> tensor<10xi1>
     %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.or across dimensions = [0] : (tensor<128x10xi1>, tensor<i1>) -> tensor<10xi1>
     return %0 : tensor<10xi1>
   }

--- a/test/ttmlir/Conversion/StableHLOToTTIR/reshape_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/reshape_op.mlir
@@ -17,7 +17,7 @@ module @jit_module_reshape attributes {mhlo.num_partitions = 1 : i32, mhlo.num_r
     // CHECK: %[[EMPTY:[0-9]+]] = ttir.empty
     // CHECK: %[[VAL:[0-9]+]] = "ttir.reshape"(%arg0, %[[EMPTY]])
     // CHECK-SAME: shape = [1 : i32]
-    // CHECK-SAME: (tensor<1x1xi32>, tensor<1xi32>) -> tensor<1xi32>
+    // CHECK-SAME: (tensor<1x1xi64>, tensor<1xi64>) -> tensor<1xi64>
     %0 = stablehlo.reshape %arg0 : (tensor<1x1xi64>) -> tensor<1xi64>
     // CHECK: return %[[VAL]]
     return %0 : tensor<1xi64>
@@ -28,7 +28,7 @@ module @jit_module_reshape attributes {mhlo.num_partitions = 1 : i32, mhlo.num_r
     // CHECK: %[[EMPTY:[0-9]+]] = ttir.empty
     // CHECK: %[[VAL:[0-9]+]] = "ttir.reshape"(%arg0, %[[EMPTY]])
     // CHECK-SAME: shape = [7 : i32, 2 : i32]
-    // CHECK-SAME: (tensor<2x7xbf16>, tensor<7x2xbf16>) -> tensor<7x2xbf16>
+    // CHECK-SAME: (tensor<2x7xi1>, tensor<7x2xi1>) -> tensor<7x2xi1>
     %0 = stablehlo.reshape %arg0 : (tensor<2x7xi1>) -> tensor<7x2xi1>
     // CHECK: return %[[VAL]]
     return %0 : tensor<7x2xi1>

--- a/test/ttmlir/Conversion/StableHLOToTTIR/scatter_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/scatter_op.mlir
@@ -8,7 +8,7 @@ module @jit_scatter attributes {} {
             stablehlo.return %arg4 : tensor<f32>
         }) : (tensor<1x3x320x320xf32>, tensor<1x1xi64>, tensor<1x3x32x32xf32>) -> tensor<1x3x320x320xf32>
         // CHECK: [[VAL1:%[0-9]+]] = "ttir.scatter"(%arg0, %arg1, %arg2, [[VAL0]]) <{index_vector_dim = 1 : i32, indices_are_sorted = false, input_batching_dims = array<i32>, inserted_window_dims = array<i32: 0>, scatter_dims_to_operand_dims = array<i32: 0>, scatter_indices_batching_dims = array<i32>, unique_indices = false, update_window_dims = array<i32: 1, 2, 3>}
-        // CHECK: ([[TENSOR_SIZE1]], tensor<1x1xi32>, tensor<1x3x32x32xf32>, [[TENSOR_SIZE1]]) -> tensor<1x3x320x320xf32>
+        // CHECK-SAME: ([[TENSOR_SIZE1]], tensor<1x1xi64>, tensor<1x3x32x32xf32>, [[TENSOR_SIZE1]]) -> tensor<1x3x320x320xf32>
         return %result : tensor<1x3x320x320xf32>
         // CHECK: return [[VAL1]] : [[TENSOR_SIZE1]]
     }

--- a/test/ttmlir/Conversion/StableHLOToTTIR/select_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/select_op.mlir
@@ -6,7 +6,7 @@ module @jit_eltwise_select attributes {} {
     %1 = stablehlo.select %0, %arg0, %arg1 : (tensor<13x37xi1>, tensor<13x37xf32>, tensor<13x37xf32>) -> tensor<13x37xf32>
     // CHECK: %[[EMPTY:[0-9]+]] = ttir.empty()
     // CHECK: %[[VAL1:[0-9]+]] = "ttir.eq"
-    // CHECK: %[[SELECT:[0-9]+]] = "ttir.where"(%[[VAL1:[0-9]+]], %arg0, %arg1, %[[EMPTY:[0-9]+]]) <{operandSegmentSizes = array<i32: 3, 1>}> : (tensor<13x37xbf16>, tensor<13x37xf32>, tensor<13x37xf32>, tensor<13x37xf32>) -> tensor<13x37xf32>
+    // CHECK: %[[SELECT:[0-9]+]] = "ttir.where"(%[[VAL1:[0-9]+]], %arg0, %arg1, %[[EMPTY:[0-9]+]]) <{operandSegmentSizes = array<i32: 3, 1>}> : (tensor<13x37xi1>, tensor<13x37xf32>, tensor<13x37xf32>, tensor<13x37xf32>) -> tensor<13x37xf32>
     return %1 : tensor<13x37xf32>
   }
 }

--- a/test/ttmlir/Conversion/StableHLOToTTIR/unary/clamp_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/unary/clamp_op.mlir
@@ -53,10 +53,10 @@ module @jit_clamp attributes {} {
 
   func.func public @test_clamp_tensor_constant(%arg0: tensor<1x16xbf16>, %arg1: tensor<bf16>) -> tensor<1x16xbf16> {
     // CHECK-LABEL: func.func public @test_clamp_tensor_constant(
-    // CHECK: %[[CONSTANT:[0-9]+]] = "ttir.constant"() <{value = dense<3.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
+    // CHECK: %[[CONSTANT:[0-9]+]] = "ttir.constant"() <{value = dense<3.000000e+00> : tensor<1xf64>}> : () -> tensor<1xf64>
     %cst = arith.constant dense<3.0> : tensor<1xf64>
     // CHECK: %[[CAST:[0-9]+]] = "ttir.typecast"(%[[CONSTANT]],
-    // CHECK-SAME: (tensor<1xf32>, tensor<1xbf16>) -> tensor<1xbf16>
+    // CHECK-SAME: (tensor<1xf64>, tensor<1xbf16>) -> tensor<1xbf16>
     %0 = stablehlo.convert %cst : (tensor<1xf64>) -> tensor<1xbf16>
     // CHECK: %[[MIN:[0-9]+]] = "ttir.reshape"(%[[CAST]],
     // CHECK-SAME: shape = [1 : i32]

--- a/test/ttmlir/Conversion/StableHLOToTTIR/unary/logical_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/unary/logical_op.mlir
@@ -2,7 +2,7 @@
 // RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s | FileCheck %s
 module @jit_eltwise_logical attributes {} {
   func.func public @logical_not(%arg0: tensor<32x32xi1>) -> tensor<32x32xi1> {
-    // CHECK: %[[E:.*]] = ttir.empty() : [[TENSOR:tensor<32x32xbf16>]]
+    // CHECK: %[[E:.*]] = ttir.empty() : [[TENSOR:tensor<32x32xi1>]]
     // CHECK: = "ttir.logical_not"(%arg0, %[[E]])
     // CHECK-SAME: ([[TENSOR]], [[TENSOR]]) -> [[TENSOR]]
     %0 = stablehlo.not  %arg0 : tensor<32x32xi1>
@@ -11,7 +11,7 @@ module @jit_eltwise_logical attributes {} {
   }
 
   func.func public @logical_not_scalar(%arg0: tensor<i1>) -> tensor<i1> {
-    // CHECK: %[[E:.*]] = ttir.empty() : [[TENSOR:tensor<1xbf16>]]
+    // CHECK: %[[E:.*]] = ttir.empty() : [[TENSOR:tensor<1xi1>]]
     // CHECK: = "ttir.logical_not"(%arg0, %[[E]])
     // CHECK-SAME: ([[TENSOR]], [[TENSOR]]) -> [[TENSOR]]
     %0 = stablehlo.not  %arg0 : tensor<i1>

--- a/test/ttmlir/Dialect/TTIR/element_type_normalization/element_type_normalization_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/element_type_normalization/element_type_normalization_negative.mlir
@@ -1,0 +1,19 @@
+// RUN: not ttmlir-opt --split-input-file --ttir-element-type-normalization %s 2>&1 | FileCheck %s
+
+module {
+  func.func @test_dense_attr_complex(%arg0: tensor<1x2xcomplex<f32>>) -> tensor<1x2xcomplex<f32>> {
+    // CHECK: error: 'func.func' op Unsupported type.
+    return %arg0 : tensor<1x2xcomplex<f32>>
+  }
+}
+
+// -----
+module {
+  func.func @test_dense_attr_complex() -> tensor<1x2xf32> {
+    // CHECK: error: 'ttir.empty' op Unsupported type.
+    %0 = ttir.empty() : tensor<1x2xcomplex<f32>>
+    %1 = ttir.empty() : tensor<1x2xf32>
+    %2 = "ttir.typecast"(%0, %1) <{operandSegmentSizes = array<i32: 1, 1>}>  : (tensor<1x2xcomplex<f32>>, tensor<1x2xf32>) -> tensor<1x2xf32>
+    return %2: tensor<1x2xf32>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/element_type_normalization/element_type_normalization_positive.mlir
+++ b/test/ttmlir/Dialect/TTIR/element_type_normalization/element_type_normalization_positive.mlir
@@ -1,0 +1,191 @@
+// RUN: ttmlir-opt --ttir-element-type-normalization %s | FileCheck %s
+
+func.func public @constant_i1() -> tensor<32x32xi1> {
+  // CHECK: "ttir.constant"
+  // CHECK-SAME: value = dense
+  // CHECK-SAME: 1.000000e+00
+  // CHECK-SAME: tensor<32x32xbf16>
+  // CHECK-SAME: -> tensor<32x32xbf16>
+  %0 = "ttir.constant"() <{value = dense<true> : tensor<32x32xi1>}> : () -> tensor<32x32xi1>
+  return %0 : tensor<32x32xi1>
+}
+
+func.func public @constant_i8() -> tensor<32x32xi8> {
+  // CHECK: "ttir.constant"
+  // CHECK-SAME: value = dense
+  // CHECK-SAME: 1
+  // CHECK-SAME: tensor<32x32xui8>
+  // CHECK-SAME: -> tensor<32x32xui8>
+  %0 = "ttir.constant"() <{value = dense<1> : tensor<32x32xi8>}> : () -> tensor<32x32xi8>
+  return %0 : tensor<32x32xi8>
+}
+
+func.func public @constant_i16() -> tensor<32x32xi16> {
+  // CHECK: "ttir.constant"
+  // CHECK-SAME: value = dense
+  // CHECK-SAME: 1
+  // CHECK-SAME: tensor<32x32xui16>
+  // CHECK-SAME: -> tensor<32x32xui16>
+  %0 = "ttir.constant"() <{value = dense<1> : tensor<32x32xi16>}> : () -> tensor<32x32xi16>
+  return %0 : tensor<32x32xi16>
+}
+
+func.func @constant_i32() -> tensor<32x32xi32> {
+  // CHECK: "ttir.constant"
+  // CHECK-SAME: value = dense
+  // CHECK-SAME: 1
+  // CHECK-SAME: tensor<32x32xsi32>
+  // CHECK-SAME: -> tensor<32x32xsi32>
+  %0 = "ttir.constant"() <{value = dense<1> : tensor<32x32xi32>}> : () -> tensor<32x32xi32>
+  return %0 : tensor<32x32xi32>
+}
+
+func.func @constant_i64() -> tensor<32x32xi64> {
+  // CHECK: "ttir.constant"
+  // CHECK-SAME: value = dense
+  // CHECK-SAME: 1
+  // CHECK-SAME: tensor<32x32xsi32>
+  // CHECK-SAME: -> tensor<32x32xsi32>
+  %0 = "ttir.constant"() <{value = dense<1> : tensor<32x32xi64>}> : () -> tensor<32x32xi64>
+  return %0 : tensor<32x32xi64>
+}
+
+func.func @constant_ui1() -> tensor<32x32xui1> {
+  // CHECK: "ttir.constant"
+  // CHECK-SAME: value = dense
+  // CHECK-SAME: 1.000000e+00
+  // CHECK-SAME: tensor<32x32xbf16>
+  // CHECK-SAME: -> tensor<32x32xbf16>
+  %0 = "ttir.constant"() <{value = dense<1> : tensor<32x32xui1>}> : () -> tensor<32x32xui1>
+  return %0 : tensor<32x32xui1>
+}
+
+func.func @constant_ui8() -> tensor<32x32xui8> {
+  // CHECK: "ttir.constant"
+  // CHECK-SAME: value = dense
+  // CHECK-SAME: 1
+  // CHECK-SAME: tensor<32x32xui8>
+  // CHECK-SAME: -> tensor<32x32xui8>
+  %0 = "ttir.constant"() <{value = dense<1> : tensor<32x32xui8>}> : () -> tensor<32x32xui8>
+  return %0 : tensor<32x32xui8>
+}
+
+func.func @constant_ui16() -> tensor<32x32xui16> {
+  // CHECK: "ttir.constant"
+  // CHECK-SAME: value = dense
+  // CHECK-SAME: 1
+  // CHECK-SAME: tensor<32x32xui16>
+  // CHECK-SAME: -> tensor<32x32xui16>
+  %0 = "ttir.constant"() <{value = dense<1> : tensor<32x32xui16>}> : () -> tensor<32x32xui16>
+  return %0 : tensor<32x32xui16>
+}
+
+func.func @constant_ui32() -> tensor<32x32xui32> {
+  // CHECK: "ttir.constant"
+  // CHECK-SAME: value = dense
+  // CHECK-SAME: 1
+  // CHECK-SAME: tensor<32x32xui32>
+  // CHECK-SAME: -> tensor<32x32xui32>
+  %0 = "ttir.constant"() <{value = dense<1> : tensor<32x32xui32>}> : () -> tensor<32x32xui32>
+  return %0 : tensor<32x32xui32>
+}
+
+func.func @constant_ui64() -> tensor<32x32xui64> {
+  // CHECK: "ttir.constant"
+  // CHECK-SAME: value = dense
+  // CHECK-SAME: 1
+  // CHECK-SAME: tensor<32x32xui32>
+  // CHECK-SAME: -> tensor<32x32xui32>
+  %0 = "ttir.constant"() <{value = dense<1> : tensor<32x32xui64>}> : () -> tensor<32x32xui64>
+  return %0 : tensor<32x32xui64>
+}
+
+func.func @constant_f16() -> tensor<32x32xf16> {
+  // CHECK: "ttir.constant"
+  // CHECK-SAME: value = dense
+  // CHECK-SAME: 1.000000e+00
+  // CHECK-SAME: tensor<32x32xf16>
+  // CHECK-SAME: -> tensor<32x32xf16>
+  %0 = "ttir.constant"() <{value = dense<1.0> : tensor<32x32xf16>}> : () -> tensor<32x32xf16>
+  return %0 : tensor<32x32xf16>
+}
+
+func.func @constant_f32() -> tensor<32x32xf32> {
+  // CHECK: "ttir.constant"
+  // CHECK-SAME: value = dense
+  // CHECK-SAME: 1.000000e+00
+  // CHECK-SAME: tensor<32x32xf32>
+  // CHECK-SAME: -> tensor<32x32xf32>
+  %0 = "ttir.constant"() <{value = dense<1.0> : tensor<32x32xf32>}> : () -> tensor<32x32xf32>
+  return %0 : tensor<32x32xf32>
+}
+
+func.func @constant_f64() -> tensor<32x32xf64> {
+  // CHECK: "ttir.constant"
+  // CHECK-SAME: value = dense
+  // CHECK-SAME: 1.000000e+00
+  // CHECK-SAME: tensor<32x32xf32>
+  // CHECK-SAME: -> tensor<32x32xf32>
+  %0 = "ttir.constant"() <{value = dense<1.0> : tensor<32x32xf64>}> : () -> tensor<32x32xf64>
+  return %0 : tensor<32x32xf64>
+}
+
+func.func @constant_si1() -> tensor<32x32xsi1> {
+  // CHECK: "ttir.constant"
+  // CHECK-SAME: value = dense
+  // CHECK-SAME: 1.000000e+00
+  // CHECK-SAME: tensor<32x32xbf16>
+  // CHECK-SAME: -> tensor<32x32xbf16>
+  %0 = "ttir.constant"() <{value = dense<true> : tensor<32x32xsi1>}> : () -> tensor<32x32xsi1>
+  return %0 : tensor<32x32xsi1>
+}
+
+func.func @constant_si8() -> tensor<32x32xsi8> {
+  // CHECK: "ttir.constant"
+  // CHECK-SAME: value = dense
+  // CHECK-SAME: 1
+  // CHECK-SAME: tensor<32x32xui8>
+  // CHECK-SAME: -> tensor<32x32xui8>
+  %0 = "ttir.constant"() <{value = dense<1> : tensor<32x32xsi8>}> : () -> tensor<32x32xsi8>
+  return %0 : tensor<32x32xsi8>
+}
+
+func.func @constant_si16() -> tensor<32x32xsi16> {
+  // CHECK: "ttir.constant"
+  // CHECK-SAME: value = dense
+  // CHECK-SAME: 1
+  // CHECK-SAME: tensor<32x32xui16>
+  // CHECK-SAME: -> tensor<32x32xui16>
+  %0 = "ttir.constant"() <{value = dense<1> : tensor<32x32xsi16>}> : () -> tensor<32x32xsi16>
+  return %0 : tensor<32x32xsi16>
+}
+
+func.func @constant_si32() -> tensor<32x32xsi32> {
+  // CHECK: "ttir.constant"
+  // CHECK-SAME: value = dense
+  // CHECK-SAME: 1
+  // CHECK-SAME: tensor<32x32xsi32>
+  // CHECK-SAME: -> tensor<32x32xsi32>
+  %0 = "ttir.constant"() <{value = dense<1> : tensor<32x32xsi32>}> : () -> tensor<32x32xsi32>
+  return %0 : tensor<32x32xsi32>
+}
+
+func.func @constant_si64() -> tensor<32x32xsi64> {
+  // CHECK: "ttir.constant"
+  // CHECK-SAME: value = dense
+  // CHECK-SAME: 1
+  // CHECK-SAME: tensor<32x32xsi32>
+  // CHECK-SAME: -> tensor<32x32xsi32>
+  %0 = "ttir.constant"() <{value = dense<1> : tensor<32x32xsi64>}> : () -> tensor<32x32xsi64>
+  return %0 : tensor<32x32xsi64>
+}
+
+func.func @constant_bf16() -> tensor<32x32xbf16> {
+  // CHECK: "ttir.constant"
+  // CHECK-SAME: value = dense
+  // CHECK-SAME: 1.000000e+00
+  // CHECK-SAME: tensor<32x32xbf16>
+  // CHECK-SAME: -> tensor<32x32xbf16>
+  %0 = "ttir.constant"() <{value = dense<1.0> : tensor<32x32xbf16>}> : () -> tensor<32x32xbf16>
+  return %0 : tensor<32x32xbf16>
+}

--- a/test/ttmlir/Dialect/TTNN/constant/negative/simple_constant_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/constant/negative/simple_constant_negative.mlir
@@ -1,0 +1,19 @@
+// RUN: not ttmlir-opt --split-input-file --ttir-to-ttnn-backend-pipeline %s 2>&1 | FileCheck %s
+
+module {
+  func.func @test_dense_attr() -> tensor<1x2xbf16> {
+    // CHECK: error: 'ttir.constant' op value attribute must be one of DenseResourceElementsAttr or DenseElementsAttr.
+    %0 = "ttir.constant"() <{value = sparse<[[0, 0], [0, 1]], [2.0, 2.0]> : tensor<1x2xbf16>}> : () -> tensor<1x2xbf16>
+    return %0 : tensor<1x2xbf16>
+  }
+}
+
+// -----
+
+module {
+  func.func @test_dense_attr_complex() -> tensor<1x2xcomplex<f32>> {
+    // CHECK: error: 'ttir.constant' op value attribute must be of int or float type.
+    %0 = "ttir.constant"() <{value = dense<[ [(2.0, 0.0), (3.0, 0.0)]]> : tensor<1x2xcomplex<f32>>}> : () -> tensor<1x2xcomplex<f32>>
+    return %0 : tensor<1x2xcomplex<f32>>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/constant/negative/simple_constant_sparse_resource.mlir
+++ b/test/ttmlir/Dialect/TTNN/constant/negative/simple_constant_sparse_resource.mlir
@@ -1,9 +1,0 @@
-// RUN: not ttmlir-opt --ttir-to-ttnn-backend-pipeline %s 2>&1 | FileCheck %s
-
-module attributes {} {
-    func.func @test_dense_attr() -> tensor<1x2xbf16> {
-        // CHECK: error: 'ttnn.constant' op value attribute must be one of DenseResourceElementsAttr or DenseElementsAttr.
-        %0 = "ttir.constant"() <{value = sparse<[[0, 0], [0, 1]], [2.0, 2.0]> : tensor<1x2xbf16>}> : () -> tensor<1x2xbf16>
-        return %0 : tensor<1x2xbf16>
-  }
-}

--- a/test/ttmlir/Dialect/TTNN/constant/positive/simple_constant_positive.mlir
+++ b/test/ttmlir/Dialect/TTNN/constant/positive/simple_constant_positive.mlir
@@ -3,43 +3,57 @@ module attributes {} {
   func.func @test_empty_int8() -> tensor<64x128xi8> {
     %0 = "ttir.constant"() <{value = dense<0> : tensor<64x128xi8>}> : () -> tensor<64x128xi8>
     // CHECK: %{{[0-9]+}} = "ttnn.full"
+    // CHECK-SAME: fillValue = 0.000000e+00 : f32
+    // CHECK-SAME: -> tensor<64x128xui8
     return %0 : tensor<64x128xi8>
   }
 
   func.func @test_empty_int16() -> tensor<64x128xi16> {
     %0 = "ttir.constant"() <{value = dense<0> : tensor<64x128xi16>}> : () -> tensor<64x128xi16>
     // CHECK: %{{[0-9]+}} = "ttnn.full"
+    // CHECK-SAME: fillValue = 0.000000e+00 : f32
+    // CHECK-SAME: -> tensor<64x128xui16
     return %0 : tensor<64x128xi16>
   }
 
   func.func @test_empty_int() -> tensor<64x128xi32> {
     %0 = "ttir.constant"() <{value = dense<0> : tensor<64x128xi32>}> : () -> tensor<64x128xi32>
     // CHECK: %{{[0-9]+}} = "ttnn.full"
+    // CHECK-SAME: fillValue = 0.000000e+00 : f32
+    // CHECK-SAME: -> tensor<64x128xui32
+    // CHECK: %{{[0-9]+}} = "ttnn.typecast"
+    // CHECK-SAME: -> tensor<64x128xsi32
     return %0 : tensor<64x128xi32>
   }
 
   func.func @test_empty_uint() -> tensor<64x128xui32> {
     %0 = "ttir.constant"() <{value = dense<0> : tensor<64x128xui32>}> : () -> tensor<64x128xui32>
     // CHECK: %{{[0-9]+}} = "ttnn.full"
+    // CHECK-SAME: fillValue = 0.000000e+00 : f32
+    // CHECK-SAME: -> tensor<64x128xui32
     return %0 : tensor<64x128xui32>
   }
 
   func.func @test_empty_bfloat16() -> tensor<64x128xbf16> {
     %0 = "ttir.constant"() <{value = dense<0.000000e+00> : tensor<64x128xbf16>}> : () -> tensor<64x128xbf16>
     // CHECK: %{{[0-9]+}} = "ttnn.full"
+    // CHECK-SAME: fillValue = 0.000000e+00 : f32
+    // CHECK-SAME: -> tensor<64x128xbf16
     return %0 : tensor<64x128xbf16>
   }
 
   func.func @test_empty_float() -> tensor<64x128xf32> {
-    %0 = "ttir.constant"() <{value = dense<0.000000e+00> : tensor<64x128xf32>}> : () -> tensor<64x128xf32>
     // CHECK: %{{[0-9]+}} = "ttnn.full"
+    // CHECK-SAME: fillValue = 0.000000e+00 : f32
+    // CHECK-SAME: -> tensor<64x128xf32
+    %0 = "ttir.constant"() <{value = dense<0.000000e+00> : tensor<64x128xf32>}> : () -> tensor<64x128xf32>
     return %0 : tensor<64x128xf32>
   }
 
   func.func @test_full_int8() -> tensor<64x128xi8> {
     // CHECK: %{{[0-9]+}} = "ttnn.full"
     // CHECK-SAME: fillValue = 1.000000e+00 : f32
-    // CHECK-SAME: tensor<64x128xui8
+    // CHECK-SAME: -> tensor<64x128xui8
     %0 = "ttir.constant"() <{value = dense<1> : tensor<64x128xi8>}> : () -> tensor<64x128xi8>
     return %0 : tensor<64x128xi8>
   }
@@ -47,7 +61,7 @@ module attributes {} {
   func.func @test_full_int16() -> tensor<64x128xi16> {
     // CHECK: %{{[0-9]+}} = "ttnn.full"
     // CHECK-SAME: fillValue = 1.000000e+00 : f32
-    // CHECK-SAME: tensor<64x128xui16
+    // CHECK-SAME: -> tensor<64x128xui16
     %0 = "ttir.constant"() <{value = dense<1> : tensor<64x128xi16>}> : () -> tensor<64x128xi16>
     return %0 : tensor<64x128xi16>
   }
@@ -55,9 +69,9 @@ module attributes {} {
   func.func @test_full_int() -> tensor<64x128xi32> {
     // CHECK: %{{[0-9]+}} = "ttnn.full"
     // CHECK-SAME: fillValue = 1.000000e+00 : f32
-    // CHECK-SAME: tensor<64x128xui32
+    // CHECK-SAME: -> tensor<64x128xui32
     // CHECK: %{{[0-9]+}} = "ttnn.typecast"
-    // CHECK-SAME: tensor<64x128xsi32
+    // CHECK-SAME: -> tensor<64x128xsi32
     %0 = "ttir.constant"() <{value = dense<1> : tensor<64x128xi32>}> : () -> tensor<64x128xi32>
     return %0 : tensor<64x128xi32>
   }
@@ -65,7 +79,7 @@ module attributes {} {
   func.func @test_full_uint() -> tensor<64x128xui32> {
     // CHECK: %{{[0-9]+}} = "ttnn.full"
     // CHECK-SAME: fillValue = 1.000000e+00 : f32
-    // CHECK-SAME: tensor<64x128xui32
+    // CHECK-SAME: -> tensor<64x128xui32
     %0 = "ttir.constant"() <{value = dense<1> : tensor<64x128xui32>}> : () -> tensor<64x128xui32>
     return %0 : tensor<64x128xui32>
   }
@@ -73,7 +87,7 @@ module attributes {} {
   func.func @test_full_bfloat16() -> tensor<64x128xbf16> {
     // CHECK: %{{[0-9]+}} = "ttnn.full"
     // CHECK-SAME: fillValue = 1.000000e+00 : f32
-    // CHECK-SAME: tensor<64x128xbf16
+    // CHECK-SAME: -> tensor<64x128xbf16
     %0 = "ttir.constant"() <{value = dense<1.000000e+00> : tensor<64x128xbf16>}> : () -> tensor<64x128xbf16>
     return %0 : tensor<64x128xbf16>
   }
@@ -81,7 +95,7 @@ module attributes {} {
   func.func @test_full_float() -> tensor<64x128xf32> {
     // CHECK: %{{[0-9]+}} = "ttnn.full"
     // CHECK-SAME: fillValue = 1.000000e+00 : f32
-    // CHECK-SAME: tensor<64x128xf32
+    // CHECK-SAME: -> tensor<64x128xf32
     %0 = "ttir.constant"() <{value = dense<1.000000e+00> : tensor<64x128xf32>}> : () -> tensor<64x128xf32>
     return %0 : tensor<64x128xf32>
   }
@@ -92,6 +106,8 @@ module attributes {} {
     // CHECK-SAME: value = dense
     // CHECK-SAME: -1.100000e+00, 2.200000e+00, -3.300000e+00
     // CHECK-SAME: 4.400000e+00, -5.500000e+00, 6.600000e+00
+    // CHECK-SAME: tensor<2x3xf32>
+    // CHECK-SAME: -> tensor<2x3xf32
     %0 = "ttir.constant"() <{value = dense<[[-1.1, 2.2, -3.3], [4.4, -5.5, 6.6]]> : tensor<2x3xf32>}> : () -> tensor<2x3xf32>
     return %0 : tensor<2x3xf32>
   }
@@ -100,6 +116,8 @@ module attributes {} {
     // CHECK: "ttnn.constant"
     // CHECK-SAME: value = dense
     // CHECK-SAME: -1.101560e+00, 2.203130e+00, -3.296880e+00, 4.406250e+00
+    // CHECK-SAME: tensor<1x4xbf16>
+    // CHECK-SAME: -> tensor<1x4xbf16
     %0 = "ttir.constant"() <{value = dense<[[-1.1, 2.2, -3.3, 4.4]]> : tensor<1x4xbf16>}> : () -> tensor<1x4xbf16>
     return %0 : tensor<1x4xbf16>
   }
@@ -108,6 +126,8 @@ module attributes {} {
     // CHECK: "ttnn.constant"
     // CHECK-SAME: value = dense
     // CHECK-SAME: 1, 2, 3
+    // CHECK-SAME: tensor<1x1x3xui32>
+    // CHECK-SAME: -> tensor<1x1x3xui32
     %0 = "ttir.constant"() <{value = dense<[[[1, 2, 3]]]> : tensor<1x1x3xui32>}> : () -> tensor<1x1x3xui32>
     return %0 : tensor<1x1x3xui32>
   }
@@ -116,6 +136,8 @@ module attributes {} {
     // CHECK: "ttnn.constant"
     // CHECK-SAME: value = dense
     // CHECK-SAME: 1, 2, 3, 4
+    // CHECK-SAME: tensor<4xui16>
+    // CHECK-SAME: -> tensor<4xui16
     %0 = "ttir.constant"() <{value = dense<[1, 2, 3, 4]> : tensor<4xui16>}> : () -> tensor<4xui16>
     return %0 : tensor<4xui16>
   }
@@ -126,23 +148,37 @@ module attributes {} {
     // CHECK-SAME: 1
     // CHECK-SAME: 2
     // CHECK-SAME: 3
+    // CHECK-SAME: tensor<3x1xui8>
+    // CHECK-SAME: -> tensor<3x1xui8
     %0 = "ttir.constant"() <{value = dense<[[1], [2], [3]]> : tensor<3x1xui8>}> : () -> tensor<3x1xui8>
     return %0 : tensor<3x1xui8>
   }
 
-  func.func @test_constant_i32_negative() -> tensor<1x1x3xi32> {
+  func.func @test_constant_i32() -> tensor<1x1x3xi32> {
     // CHECK: "ttnn.constant"
     // CHECK-SAME: value = dense
     // CHECK-SAME: -1, 2, 3
+    // CHECK-SAME: tensor<1x1x3xsi32>
+    // CHECK-SAME: -> tensor<1x1x3xsi32
     %0 = "ttir.constant"() <{value = dense<[[[-1, 2, 3]]]> : tensor<1x1x3xi32>}> : () -> tensor<1x1x3xi32>
     return %0 : tensor<1x1x3xi32>
   }
 
-  func.func @test_dense_attr() -> tensor<1x2xbf16> {
-    %0 = "ttir.constant"() <{value = dense_resource<dense_attr> : tensor<1x2xbf16>}> : () -> tensor<1x2xbf16>
+  func.func @test_constant_i64() -> tensor<1x1x3xi64> {
+    // CHECK: "ttnn.constant"
+    // CHECK-SAME: value = dense
+    // CHECK-SAME: -1, 2, 3
+    // CHECK-SAME: tensor<1x1x3xsi32>
+    // CHECK-SAME: -> tensor<1x1x3xsi32
+    %0 = "ttir.constant"() <{value = dense<[[[-1, 2, 3]]]> : tensor<1x1x3xi64>}> : () -> tensor<1x1x3xi64>
+    return %0 : tensor<1x1x3xi64>
+  }
+
+  func.func @test_dense_attr() -> tensor<1x2xf64> {
+    %0 = "ttir.constant"() <{value = dense_resource<dense_attr> : tensor<1x2xf64>}> : () -> tensor<1x2xf64>
     // CHECK: "ttnn.constant"
     // CHECK-SAME: value = dense_resource<dense_attr>
-    return %0 : tensor<1x2xbf16>
+    return %0 : tensor<1x2xf64>
   }
 }
 {-#


### PR DESCRIPTION
* Added `checkSupportedTypes` which walks IR and checks if all operations are using types which are suported by compiler.

* Removed type conversion logic from StableHLO to TTIR. This responsibility is now handled by the `ElementTypeNormalization` pass in TTIR. The SHLO to TTIR converter now only lifts scalars to 1D tensors.

* Removed `shlo::ConstantOp` type conversion logic, as it’s no longer necessary. We only convert value attribute scalars to 1D tensors.

* Updated SHLO tests to reflect changes.

* Added a basic rewriter for ttir::ConstantOp, mirroring the former shlo::ConstantOp conversion pattern. Note: this rewriter still needs refinement since the conversion does not follow types which are returned by type conversion. This is bug which is already present in code.

* Removed automatic conversion from f32 to bf16 in ElementTypeNormalization. Any type supported by TTNN is now accepted directly, per offline descussion.