### PR TITLE
Changing PadOp golden kwarg handling

### DIFF
--- a/python/test_infra/ttir_builder.py
+++ b/python/test_infra/ttir_builder.py
@@ -1274,8 +1274,11 @@ class TTIRBuilder:
         )
 
     def pad(self, in0: Operand, padding: List[int], value: int) -> OpView:
-        golden_padding = padding.copy()
-        golden_padding.reverse()
+        # Reformatting padding dimensions for golden tensor:
+        golden_padding = []
+        for i in range(int(len(padding) / 2)):
+            golden_padding.append(padding[-((2 * i) + 2)])
+            golden_padding.append(padding[-((2 * i) + 1)])
         return self.op_proxy(
             torch.nn.functional.pad,
             ttir.PadOp,

--- a/python/test_infra/ttir_builder.py
+++ b/python/test_infra/ttir_builder.py
@@ -1276,7 +1276,7 @@ class TTIRBuilder:
     def pad(self, in0: Operand, padding: List[int], value: int) -> OpView:
         # Reformatting padding dimensions for golden tensor:
         golden_padding = []
-        for i in range(int(len(padding) / 2)):
+        for i in range(len(padding) // 2):
             golden_padding.append(padding[-((2 * i) + 2)])
             golden_padding.append(padding[-((2 * i) + 1)])
         return self.op_proxy(

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -656,7 +656,7 @@ def test_max_pool2d(in0: Operand, in1: Operand, builder: TTIRBuilder):
     targets=["ttnn"],
 )
 def test_pad(in0: Operand, builder: TTIRBuilder):
-    return builder.pad(in0, padding=[0, 0, 0, 0, 1, 1, 1, 1], value=0)
+    return builder.pad(in0, padding=[0, 1, 2, 3, 4, 5, 6, 7], value=0)
 
 
 @compile_to_flatbuffer([(32, 64)], targets=["ttnn"])


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/2849)

### Problem description
PadOp golden padding had incorrect dimension handling.

### What's changed
Reformatted golden padding dimensions.

### Checklist
- [ ] New/Existing tests provide coverage for changes
