### PR TITLE
Support for non-bf16 types for Conv2dOp in EmitC

### DIFF
--- a/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
+++ b/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
@@ -39,11 +39,15 @@ struct IDevice;
 
 struct Tensor;
 
-namespace operations::creation::detail {
-
+namespace operations {
+namespace creation::detail {
 struct OptionalAnyDevice;
+} // namespace creation::detail
 
-} // namespace operations::creation::detail
+namespace conv::conv2d {
+struct Conv2dConfig;
+} // namespace conv::conv2d
+} // namespace operations
 } // namespace ttnn
 
 namespace mlir {
@@ -157,6 +161,12 @@ struct TypeName<::ttnn::operations::creation::detail::OptionalAnyDevice> {
 template <>
 struct TypeName<::ttnn::Tensor> {
   inline static const std::string value = "::ttnn::Tensor";
+};
+
+template <>
+struct TypeName<::ttnn::operations::conv::conv2d::Conv2dConfig> {
+  inline static const std::string value =
+      "::ttnn::operations::conv::conv2d::Conv2dConfig";
 };
 
 template <>
@@ -937,6 +947,31 @@ public:
                                     /*shardSpec=*/nullptr, tensorMemoryLayout);
 
     return emit(memoryConfigAttr);
+  }
+
+  // TODO (azecevic): This is a temporary solution for handling the case when
+  // the value of the Conv2dConfigAttr is nullptr. This should be removed once
+  // https://github.com/tenstorrent/tt-mlir/issues/2852 lands.
+  mlir::Attribute getConv2dConfig(mlir::Value input, mlir::Value weight) {
+    auto inputType = mlir::cast<RankedTensorType>(input.getType());
+    auto weightType = mlir::cast<RankedTensorType>(weight.getType());
+
+    auto inputLayoutAttr =
+        mlir::cast<ttnn::TTNNLayoutAttr>(inputType.getEncoding());
+    auto weightLayoutAttr =
+        mlir::cast<ttnn::TTNNLayoutAttr>(weightType.getEncoding());
+
+    DataType inputDataType = inputLayoutAttr.getDataType();
+    DataType weightDataType = weightLayoutAttr.getDataType();
+
+    std::string buf;
+    llvm::raw_string_ostream rso(buf);
+    rso << TypeNameV<::ttnn::operations::conv::conv2d::Conv2dConfig> << "{";
+    rso << ".dtype = " << convert(inputDataType) << ", ";
+    rso << ".weights_dtype = " << convert(weightDataType);
+    rso << "}";
+
+    return rewriter.getType<emitc::OpaqueAttr>(buf);
   }
 
 private:

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -823,7 +823,8 @@ public:
         emitter.emit<std::array<uint32_t, 2>>(srcOp.getDilationAttr()),
         emitter.emit(srcOp.getGroups()),
         emitter.emit(srcOp.getBias()),
-        /*conv2d_config=*/emitter.emit(std::nullopt),
+        emitter.emit(std::nullopt) |
+            emitter.getConv2dConfig(srcOp.getInput(), srcOp.getWeight()),
         /*compute_config=*/emitter.emit(std::nullopt),
         emitter.emit(std::nullopt) | emitter.getMemoryConfig(srcOp.getResult()),
     };

--- a/test/ttmlir/EmitC/TTNN/conv/conv2d.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/conv2d.mlir
@@ -3,14 +3,28 @@
 // RUN: ttmlir-opt --ttnn-modify-signatures-for-dylib --convert-ttnn-to-emitc %t.mlir > %t2.mlir
 // RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
 
-func.func @conv2d(%arg0: tensor<3x32x32x8xbf16>, %arg1: tensor<16x8x3x3xbf16>, %arg2: tensor<1x1x1x16xbf16>) -> tensor<3x15x15x16xbf16> {
-    %0 = ttir.empty() : tensor<3x15x15x16xbf16>
-    %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
-            <{
-                stride = 2: i32,
-                padding = 0: i32,
-                dilation = 1: i32,
-                groups = 1: i32
-            }> : (tensor<3x32x32x8xbf16>, tensor<16x8x3x3xbf16>, tensor<1x1x1x16xbf16>, tensor<3x15x15x16xbf16>) -> tensor<3x15x15x16xbf16>
-    return %1 : tensor<3x15x15x16xbf16>
+module {
+    func.func @conv2d_bf16(%arg0: tensor<3x32x32x8xbf16>, %arg1: tensor<16x8x3x3xbf16>, %arg2: tensor<1x1x1x16xbf16>) -> tensor<3x15x15x16xbf16> {
+        %0 = ttir.empty() : tensor<3x15x15x16xbf16>
+        %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
+                <{
+                    stride = 2: i32,
+                    padding = 0: i32,
+                    dilation = 1: i32,
+                    groups = 1: i32
+                }> : (tensor<3x32x32x8xbf16>, tensor<16x8x3x3xbf16>, tensor<1x1x1x16xbf16>, tensor<3x15x15x16xbf16>) -> tensor<3x15x15x16xbf16>
+        return %1 : tensor<3x15x15x16xbf16>
+    }
+
+    func.func @conv2d_f32(%arg0: tensor<3x32x32x8xf32>, %arg1: tensor<16x8x3x3xf32>, %arg2: tensor<1x1x1x16xf32>) -> tensor<3x15x15x16xf32> {
+        %0 = ttir.empty() : tensor<3x15x15x16xf32>
+        %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
+                <{
+                    stride = 2: i32,
+                    padding = 0: i32,
+                    dilation = 1: i32,
+                    groups = 1: i32
+                }> : (tensor<3x32x32x8xf32>, tensor<16x8x3x3xf32>, tensor<1x1x1x16xf32>, tensor<3x15x15x16xf32>) -> tensor<3x15x15x16xf32>
+        return %1 : tensor<3x15x15x16xf32>
+    }
 }


### PR DESCRIPTION
### Ticket
N/A

### Problem description
For non-bf16 types TTNN asserts with current implementation.

### What's changed
Added a configuration that mirrors the one in the runtime, which should enable other input types as well (most notably f32).

### Checklist
- [x] New/Existing tests provide coverage for changes
