### PR TITLE
Query alignment info from device and hal

### DIFF
--- a/runtime/lib/common/system_desc.cpp
+++ b/runtime/lib/common/system_desc.cpp
@@ -14,12 +14,16 @@
 #define FMT_HEADER_ONLY
 #include "eth_l1_address_map.h"
 #include "hostdevcommon/common_values.hpp"
-#include "noc/noc_parameters.h"
+#include "llrt/hal.hpp"
 #include "tt-metalium/allocator.hpp"
 #include "tt-metalium/host_api.hpp"
 #include "tt-metalium/mesh_device.hpp"
 
 namespace tt::runtime::system_desc {
+
+using HalMemType = ::tt::tt_metal::HalMemType;
+using BufferType = ::tt::tt_metal::BufferType;
+
 static ::tt::target::Dim2d toFlatbuffer(const CoreCoord &coreCoord) {
   return ::tt::target::Dim2d(coreCoord.y, coreCoord.x);
 }
@@ -143,19 +147,21 @@ calculateDRAMUnreservedEnd(const ::tt::tt_metal::IDevice *device) {
                              device->get_active_ethernet_cores().size();
   std::uint32_t totalDramCores = dramGridSize.x * dramGridSize.y;
   std::uint32_t programCarveOutPerCore =
-      device->allocator()->get_base_allocator_addr(
-          ::tt::tt_metal::HalMemType::L1);
+      device->allocator()->get_base_allocator_addr(HalMemType::L1);
   std::uint32_t totalProgramCarveOut = programCarveOutPerCore * totalCores;
   // The total carve out can be interleaved between all dram channels
   std::uint32_t programCarveOutDramSpace =
       (totalProgramCarveOut + totalDramCores - 1) / totalDramCores;
-  static_assert(DRAM_ALIGNMENT > 0);
-  static_assert((DRAM_ALIGNMENT & (DRAM_ALIGNMENT - 1)) == 0);
+
+  std::uint32_t dramAlignment =
+      device->allocator()->get_alignment(BufferType::DRAM);
+  LOG_ASSERT(dramAlignment > 0);
+  LOG_ASSERT((dramAlignment & (dramAlignment - 1)) == 0);
   LOG_ASSERT(programCarveOutDramSpace < device->dram_size_per_channel());
   std::uint32_t dramUnreservedEnd =
       device->dram_size_per_channel() - programCarveOutDramSpace;
-  // Align to DRAM_ALIGNMENT
-  dramUnreservedEnd = dramUnreservedEnd & ~(DRAM_ALIGNMENT - 1);
+  // Align to dramAlignment
+  dramUnreservedEnd = dramUnreservedEnd & ~(dramAlignment - 1);
   return dramUnreservedEnd;
 }
 
@@ -175,11 +181,18 @@ static std::unique_ptr<::tt::runtime::SystemDesc> getCurrentSystemDescImpl(
       ::tt::target::ChipCoord(0, 0, 0, 0)};
   ::flatbuffers::FlatBufferBuilder fbb;
 
+  std::uint32_t pcieAlignment =
+      ::tt::tt_metal::hal_ref.get_alignment(HalMemType::HOST);
+
   for (const ::tt::tt_metal::IDevice *device : devices) {
-    size_t l1UnreservedBase = device->allocator()->get_base_allocator_addr(
-        ::tt::tt_metal::HalMemType::L1);
-    size_t dramUnreservedBase = device->allocator()->get_base_allocator_addr(
-        ::tt::tt_metal::HalMemType::DRAM);
+    size_t l1UnreservedBase =
+        device->allocator()->get_base_allocator_addr(HalMemType::L1);
+    size_t dramUnreservedBase =
+        device->allocator()->get_base_allocator_addr(HalMemType::DRAM);
+    std::uint32_t l1Alignment =
+        device->allocator()->get_alignment(BufferType::L1);
+    std::uint32_t dramAlignment =
+        device->allocator()->get_alignment(BufferType::DRAM);
 
     // Construct chip descriptor
     ::tt::target::Dim2d deviceGrid =
@@ -216,8 +229,8 @@ static std::unique_ptr<::tt::runtime::SystemDesc> getCurrentSystemDescImpl(
     chipDescs.emplace_back(::tt::target::CreateChipDesc(
         fbb, toFlatbuffer(device->arch()), &deviceGrid,
         device->l1_size_per_core(), device->num_dram_channels(),
-        device->dram_size_per_channel(), L1_ALIGNMENT, PCIE_ALIGNMENT,
-        DRAM_ALIGNMENT, l1UnreservedBase,
+        device->dram_size_per_channel(), l1Alignment, pcieAlignment,
+        dramAlignment, l1UnreservedBase,
         ::eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE, dramUnreservedBase,
         dramUnreservedEnd, chipPhysicalCores, supportedDataTypes,
         supportedTileSizes, NUM_CIRCULAR_BUFFERS, kNumComputeThreads,


### PR DESCRIPTION
### Ticket
closes #300 

### Problem description
We were using default alignment values when creating system descriptor

### What's changed
Metal now has support for dynamically querying alignments from device/hal. Migrated the hardcoded values to use the dynamic ones.

### Checklist
- [X] New/Existing tests provide coverage for changes
