### PR TITLE
TT-MLIR logger

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,11 @@ if (NOT DEFINED ENV{TTMLIR_TOOLCHAIN_DIR})
     message(FATAL_ERROR "TTMLIR_TOOLCHAIN_DIR environment variable not set. Please run 'source env/activate'.")
 endif()
 
+# Enable debug logs only in Debug mode
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    add_compile_definitions(TTMLIR_ENABLE_DEBUG_LOGS)
+endif()
+
 add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wno-unused-parameter --system-header-prefix=ENV{TTMLIR_TOOLCHAIN_DIR})
 
 include(TTMLIRBuildTypes)

--- a/include/ttmlir/Support/Logger.h
+++ b/include/ttmlir/Support/Logger.h
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_SUPPORT_LOGGER_H
+#define TTMLIR_SUPPORT_LOGGER_H
+
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/FormatVariadic.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <chrono>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <type_traits>
+
+namespace ttmlir {
+
+// Log components for different components
+enum class LogComponent { Optimizer, General };
+
+// Log levels in order of verbosity
+enum class LogLevel {
+  Trace, // Most verbose, enabled only with TTMLIR_LOGGER_LEVEL=trace
+  Debug, // Default level
+  Fatal  // Fatal errors
+};
+
+// Define LLVM log component type strings
+inline constexpr const char *getLogComponentStr(LogComponent type) {
+  switch (type) {
+  case LogComponent::Optimizer:
+    return "optimizer";
+  case LogComponent::General:
+    return "general";
+  }
+  return "unknown";
+}
+
+// String representations of log levels
+inline constexpr const char *getLogLevelStr(LogLevel level) {
+  switch (level) {
+  case LogLevel::Trace:
+    return "TRACE";
+  case LogLevel::Debug:
+    return "DEBUG";
+  case LogLevel::Fatal:
+    return "FATAL";
+  }
+}
+
+// Get LLVM color type for log level
+inline llvm::raw_ostream::Colors getLogLevelColor(LogLevel level) {
+  switch (level) {
+  case LogLevel::Trace:
+    return llvm::raw_ostream::CYAN;
+  case LogLevel::Debug:
+    return llvm::raw_ostream::GREEN;
+  case LogLevel::Fatal:
+    return llvm::raw_ostream::RED;
+  }
+  return llvm::raw_ostream::RESET;
+}
+
+// Get minimum log level from environment
+inline LogLevel getMinLogLevel() {
+  static LogLevel minLevel = []() {
+    const char *env = std::getenv("TTMLIR_LOGGER_LEVEL");
+    if (!env) {
+      // Default to Debug level
+      return LogLevel::Debug;
+    }
+
+    std::string level(env);
+    // Convert to uppercase for case-insensitive comparison
+    std::transform(level.begin(), level.end(), level.begin(), ::toupper);
+
+    if (level == "TRACE") {
+      return LogLevel::Trace;
+    }
+
+    // Any unrecognized value defaults to Debug
+    return LogLevel::Debug;
+  }();
+  return minLevel;
+}
+
+// Check if a log level is enabled
+inline bool isLogLevelEnabled(LogLevel level) {
+  return static_cast<int>(level) >= static_cast<int>(getMinLogLevel());
+}
+
+// Get current timestamp
+inline std::string getCurrentTimestamp() {
+  auto now = std::chrono::system_clock::now();
+  auto time = std::chrono::system_clock::to_time_t(now);
+  auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                now.time_since_epoch()) %
+            1000;
+
+  std::stringstream ss;
+  ss << std::put_time(std::localtime(&time), "%Y-%m-%d %H:%M:%S") << '.'
+     << std::setfill('0') << std::setw(3) << ms.count();
+  return ss.str();
+}
+
+// Main logging macro that uses DEBUG_WITH_TYPE
+#ifdef TTMLIR_ENABLE_DEBUG_LOGS
+#define TTMLIR_LOG_FMT(logComponent, logLevel, fmt, ...)                       \
+  DEBUG_WITH_TYPE(                                                             \
+      ttmlir::getLogComponentStr(logComponent),                                \
+      if (ttmlir::isLogLevelEnabled(logLevel)) {                               \
+        auto &OS = llvm::dbgs();                                               \
+        OS.enable_colors(true);                                                \
+        OS << "[";                                                             \
+        OS.changeColor(llvm::raw_ostream::GREEN, /*bold=*/true);               \
+        OS << ttmlir::getCurrentTimestamp();                                   \
+        OS.resetColor();                                                       \
+        OS << "] [";                                                           \
+        OS.changeColor(ttmlir::getLogLevelColor(logLevel), /*bold=*/true);     \
+        OS << ttmlir::getLogLevelStr(logLevel);                                \
+        OS.resetColor();                                                       \
+        OS << "] [";                                                           \
+        OS.changeColor(llvm::raw_ostream::MAGENTA, /*bold=*/true);             \
+        OS << ttmlir::getLogComponentStr(logComponent);                        \
+        OS.resetColor();                                                       \
+        OS << "] " << llvm::formatv(fmt, __VA_ARGS__) << "\n";                 \
+        if (logLevel == LogLevel::Fatal) {                                     \
+          abort();                                                             \
+        }                                                                      \
+      })
+#else
+#define TTMLIR_LOG_FMT(logComponent, logLevel, fmt, ...) ((void)0)
+#endif
+
+// Public logging macros
+#define TTMLIR_TRACE(component, fmt, ...)                                      \
+  TTMLIR_LOG_FMT(component, LogLevel::Trace, fmt, __VA_ARGS__)
+#define TTMLIR_DEBUG(component, fmt, ...)                                      \
+  TTMLIR_LOG_FMT(component, LogLevel::Debug, fmt, __VA_ARGS__)
+#define TTMLIR_FATAL(component, fmt, ...)                                      \
+  TTMLIR_LOG_FMT(component, LogLevel::Fatal, fmt, __VA_ARGS__)
+
+} // namespace ttmlir
+
+#endif // TTMLIR_SUPPORT_LOGGER_H

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -5,6 +5,7 @@ function(add_mlir_unittest test_dirname)
   add_unittest(MLIRUnitTests ${test_dirname} ${ARGN})
 endfunction()
 
+add_subdirectory(Support)
 add_subdirectory(TestScheduler)
 add_subdirectory(Optimizer)
 add_subdirectory(OpModel)

--- a/test/unittests/Support/CMakeLists.txt
+++ b/test/unittests/Support/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_mlir_unittest(TTMLIRSupportTests
+  LoggerTest.cpp
+  )
+
+target_link_libraries(TTMLIRSupportTests
+  PRIVATE
+  MLIRSupport
+  )

--- a/test/unittests/Support/LoggerTest.cpp
+++ b/test/unittests/Support/LoggerTest.cpp
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Support/Logger.h"
+
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+#include "gtest/gtest.h"
+
+#include <cstdlib>
+#include <sstream>
+
+using namespace ttmlir;
+
+TEST(LoggerTest, LogLevels) {
+  // Test log level string conversions
+  EXPECT_STREQ(getLogLevelStr(LogLevel::Trace), "TRACE");
+  EXPECT_STREQ(getLogLevelStr(LogLevel::Debug), "DEBUG");
+  EXPECT_STREQ(getLogLevelStr(LogLevel::Fatal), "FATAL");
+}
+
+TEST(LoggerTest, LogComponents) {
+  // Test log component string conversions
+  EXPECT_STREQ(getLogComponentStr(LogComponent::Optimizer), "optimizer");
+  EXPECT_STREQ(getLogComponentStr(LogComponent::General), "general");
+}
+
+TEST(LoggerTest, LogLevelColors) {
+  // Test log level color assignments
+  EXPECT_EQ(getLogLevelColor(LogLevel::Trace), llvm::raw_ostream::CYAN);
+  EXPECT_EQ(getLogLevelColor(LogLevel::Debug), llvm::raw_ostream::GREEN);
+  EXPECT_EQ(getLogLevelColor(LogLevel::Fatal), llvm::raw_ostream::RED);
+}
+
+TEST(LoggerTest, Timestamp) {
+  std::string timestamp = getCurrentTimestamp();
+
+  // Verify timestamp format: YYYY-MM-DD HH:MM:SS.mmm
+  EXPECT_EQ(timestamp.length(), 23);
+  EXPECT_EQ(timestamp[4], '-');
+  EXPECT_EQ(timestamp[7], '-');
+  EXPECT_EQ(timestamp[10], ' ');
+  EXPECT_EQ(timestamp[13], ':');
+  EXPECT_EQ(timestamp[16], ':');
+  EXPECT_EQ(timestamp[19], '.');
+}
+
+TEST(LoggerTest, LoggingOutput) {
+  // Enable debug logging for both optimizer and general components
+  llvm::DebugFlag = true;
+  const char *debugTypes[] = {"general", "optimizer", nullptr};
+  llvm::setCurrentDebugTypes(debugTypes, 2);
+
+  // Set log level to TRACE to see all messages
+  setenv("TTMLIR_LOGGER_LEVEL", "TRACE", 1);
+
+  // Start capturing stderr because that's where the logs go
+  testing::internal::CaptureStderr();
+
+  // Test all log levels with the optimizer component
+  TTMLIR_TRACE(LogComponent::Optimizer,
+               "This is a trace message with value: {0}", 42);
+  TTMLIR_DEBUG(LogComponent::Optimizer,
+               "Debug message with two values: {0}, {1}", "hello", 3.14);
+
+  // Test the general component
+  TTMLIR_DEBUG(LogComponent::General, "{}", "Debug with general component");
+  TTMLIR_TRACE(LogComponent::General, "{}", "Trace with general component");
+
+  // Switch to only general component
+  llvm::setCurrentDebugType("general");
+
+  // These should not be visible since optimizer component is disabled
+  TTMLIR_TRACE(LogComponent::Optimizer, "{}",
+               "This trace should not be visible");
+  TTMLIR_DEBUG(LogComponent::Optimizer, "{}",
+               "This debug should not be visible");
+
+  // This should be visible since general component is enabled
+  TTMLIR_DEBUG(LogComponent::General, "{}", "This debug should be visible");
+
+  // Get the captured output
+  std::string outputBuffer = testing::internal::GetCapturedStderr();
+
+#ifdef TTMLIR_ENABLE_DEBUG_LOGS
+  // Verify output contains expected messages
+  EXPECT_TRUE(outputBuffer.find("trace message with value: 42") !=
+              std::string::npos);
+  EXPECT_TRUE(outputBuffer.find("Debug message with two values: hello, 3.14") !=
+              std::string::npos);
+  EXPECT_TRUE(outputBuffer.find("Debug with general component") !=
+              std::string::npos);
+  EXPECT_TRUE(outputBuffer.find("Trace with general component") !=
+              std::string::npos);
+  EXPECT_TRUE(outputBuffer.find("This debug should be visible") !=
+              std::string::npos);
+
+  // Verify messages that should not appear
+  EXPECT_TRUE(outputBuffer.find("This trace should not be visible") ==
+              std::string::npos);
+  EXPECT_TRUE(outputBuffer.find("This debug should not be visible") ==
+              std::string::npos);
+#else
+  EXPECT_TRUE(outputBuffer.empty());
+#endif
+}


### PR DESCRIPTION
### Problem description

Currently there is no proper way to log things around in tt-mlir compiler (except in runtime which has its own logger). We can't reuse the same logger as it is built specifically for runtime with exceptions which are not supported in llvm based tt-mlir. 

### What's changed

LLVM provides with basic macro for debugging. This commit adds a logger which is basically a wrapper around it. It will be possible to specify log level (verbosity) and log component (optimizer, d2m, ttnn dialect...). To run with logs enabled we have to run in debug build, and set option `-debug` to enable all logs. This includes mlir logs so better use would be to set option `-debug-only=<log-component>`. 

Log looks like:
<img width="669" alt="image" src="https://github.com/user-attachments/assets/116e7299-2cb1-46c2-bfc7-846a2f9480db" />


### Checklist
- [x] New/Existing tests provide coverage for changes
