### PR TITLE
Fix TTIR tablegen op class inconsistencies

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -620,6 +620,13 @@ def TTIR_Expm1Op: TTIR_ElementwiseUnaryOp<"expm1"> {
   }];
 }
 
+def TTIR_ExpOp: TTIR_ElementwiseUnaryOp<"exp"> {
+    let summary = "Eltwise exponential op.";
+    let description = [{
+      Eltwise exponential operation. Calculates e^x for all elements x in input tensor.
+    }];
+}
+
 class TTIR_ElementwiseUnaryWithFloatParameterOp<string mnemonic, list<Trait> traits = []> :
     TTIR_ElementwiseUnaryOp<mnemonic, traits> {
     let summary = "Eltwise unary op with the float parameter.";
@@ -863,6 +870,39 @@ def TTIR_Atan2Op :  TTIR_ElementwiseBinaryOp<"atan2"> {
         %result = "ttir.atan2"(%lhs, %rhs) : (tensor<3xf64>, tensor<3xf64>) -> tensor<3xf64>
         // %result: [0.0, 1.57079637, -1.57079637] // [0.0, pi/2, -pi/2]
       ```
+    }];
+}
+
+def TTIR_AddOp : TTIR_ElementwiseBinaryOp<"add", [TTIR_FullyBroadcastable]> {
+    let summary = "Eltwise add.";
+    let description = [{
+      Eltwise add operation.
+    }];
+}
+
+def TTIR_MultiplyOp : TTIR_ElementwiseBinaryOp<"multiply", [TTIR_PartiallyBroadcastable]> {
+    let summary = "Eltwise multiply.";
+    let description = [{
+      Eltwise multiply operation.
+    }];
+}
+
+def TTIR_DivOp : TTIR_ElementwiseBinaryOp<"div", [TTIR_PartiallyBroadcastable]> {
+    let summary = "Eltwise divide.";
+    let description = [{
+      Eltwise divide operation.
+    }];
+}
+
+def TTIR_MaximumOp : TTIR_ElementwiseBinaryOp<"maximum"> {
+    let summary = "Eltwise maximum.";
+    let description = [{
+      Calculates maximum of input tensors' values element-wise and stores result in output tensor.
+
+      Example:
+        %lhs: [[3, 2, 7], [1, 4, 4]]
+        %rhs: [[1, 4, 2], [1, 2, 3]]
+        "ttir.maximum"(%lhs, %rhs, %out) -> %out: [[3, 4, 7], [1, 4, 4]]
     }];
 }
 
@@ -1951,58 +1991,6 @@ def TTIR_Upsample2dOp : TTIR_NamedOp<"upsample2d"> {
     let results = (outs AnyRankedTensor:$result);
 
     let hasVerifier = 1;
-}
-
-//===----------------------------------------------------------------------===//
-// TTIR top level generic ops
-//===----------------------------------------------------------------------===//
-
-class TTIR_GenericElementwiseUnaryOp<string mnemonic, list<Trait> traits = []> :
-    TTIR_ElementwiseUnaryOp<mnemonic, traits> {
-}
-
-def TTIR_ExpOp: TTIR_GenericElementwiseUnaryOp<"exp"> {
-    let summary = "Eltwise exponential op.";
-    let description = [{
-      Eltwise exponential operation. Calculates e^x for all elements x in input tensor.
-    }];
-}
-
-class TTIR_GenericElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
-    TTIR_ElementwiseBinaryOp<mnemonic, traits> {
-}
-
-def TTIR_AddOp : TTIR_GenericElementwiseBinaryOp<"add", [TTIR_FullyBroadcastable]> {
-    let summary = "Eltwise add.";
-    let description = [{
-      Eltwise add operation.
-    }];
-}
-
-def TTIR_MultiplyOp : TTIR_GenericElementwiseBinaryOp<"multiply", [TTIR_PartiallyBroadcastable]> {
-    let summary = "Eltwise multiply.";
-    let description = [{
-      Eltwise multiply operation.
-    }];
-}
-
-def TTIR_DivOp : TTIR_GenericElementwiseBinaryOp<"div", [TTIR_PartiallyBroadcastable]> {
-    let summary = "Eltwise divide.";
-    let description = [{
-      Eltwise divide operation.
-    }];
-}
-
-def TTIR_MaximumOp : TTIR_GenericElementwiseBinaryOp<"maximum"> {
-    let summary = "Eltwise maximum.";
-    let description = [{
-      Calculates maximum of input tensors' values element-wise and stores result in output tensor.
-
-      Example:
-        %lhs: [[3, 2, 7], [1, 4, 4]]
-        %rhs: [[1, 4, 2], [1, 2, 3]]
-        "ttir.maximum"(%lhs, %rhs, %out) -> %out: [[3, 4, 7], [1, 4, 4]]
-    }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -1488,7 +1488,7 @@ def TTIR_ReshapeOp: TTIR_NamedOp<"reshape"> {
     let hasFolder = 1;
 }
 
-def TTIR_PadOp: TTIR_Op<"pad"> {
+def TTIR_PadOp: TTIR_NamedOp<"pad"> {
     let summary = "Pad op.";
     let description = [{
       Pad input tensor with tuple of padding values.
@@ -1515,6 +1515,7 @@ def TTIR_PadOp: TTIR_Op<"pad"> {
     }];
 
     let arguments = (ins AnyRankedTensor:$input,
+                         AnyRankedTensor:$output,
                          DenseI32ArrayAttr:$padding,
                          F32Attr:$value);
 

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -2078,7 +2078,7 @@ def TTIR_AllReduceOp : TTIR_NamedOp<"all_reduce"> {
     let hasVerifier = 1;
 }
 
-def TTIR_ReduceScatterOp : TTIR_DPSOp<"reduce_scatter"> {
+def TTIR_ReduceScatterOp : TTIR_NamedOp<"reduce_scatter"> {
     let summary = "Reduce scatter operation.";
     let description = [{
       Reduce scatter op.
@@ -2093,7 +2093,7 @@ def TTIR_ReduceScatterOp : TTIR_DPSOp<"reduce_scatter"> {
     let hasVerifier = 1;
 }
 
-def TTIR_CollectivePermuteOp : TTIR_DPSOp<"collective_permute"> {
+def TTIR_CollectivePermuteOp : TTIR_NamedOp<"collective_permute"> {
     let summary = "Collective permute operation.";
     let description = [{
       Collective permute op. This operation ingests a multi-device tensor spread across multi-devices and will shuffle the data according to source_target_pairs [['src', 'dest']].

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -1707,81 +1707,6 @@ def TTIR_ClampTensorOp : TTIR_NamedOp<"clamp_tensor"> {
   let hasCanonicalizer = 1;
 }
 
-def TTIR_ArangeOp : TTIR_Op<"arange", [TT_CreationOpTrait]> {
-  let summary = "Arange operation.";
-  let description = [{
-    Tensor arange operation.
-
-    Produces a tensor with values from `start` to `end` (exclusive) with a step size of `step`, along the dimension specified by `arange_dimension`.
-
-    Examples:
-      %0 = "ttir.arange"() {start = 0 : i64, end = 5 : i64 step = 1 : i64, arange_dimension = 0 : i64} : () -> tensor<5xi64>
-      // %0: [0, 1, 2, 3, 4]
-
-      %1 = "ttir.arange"() {start = 0 : i64, end = 10 : i64, step = 2 : i64, arange_dimension = 0 : i64} : () -> tensor<5xf32>
-      // %1: [0.0, 2.0, 4.0, 6.0, 8.0]
-
-      %2 = "ttir.arange"() {start = 0 : i64, end = 5 : i64, step = 1 : i64, arange_dimension = 0 : i64} : () -> tensor<5x3xi64>
-      // %2: [
-              [0, 0, 0],
-              [1, 1, 1],
-              [2, 2, 2],
-              [3, 3, 3],
-              [4, 4, 4]
-             ]
-
-      %3 = "ttir.arange"() {start = 0 : i64, end = 3 : i64, step = 1 : i64, arange_dimension = 1 : i64} : () -> tensor<5x3xi64>
-      // %3: [
-              [0, 1, 2],
-              [0, 1, 2],
-              [0, 1, 2],
-              [0, 1, 2],
-              [0, 1, 2]
-             ]
-  }];
-
-  let arguments = (ins SI64Attr:$start,
-                       SI64Attr:$end,
-                       SI64Attr:$step,
-                       I64Attr:$arange_dimension);
-
-  let results = (outs AnyRankedTensor:$result);
-  let hasVerifier = 1;
-}
-
-class TTIR_NamedFullOp<string mnemonic, list<Trait> traits = []> :
-  TTIR_Op<mnemonic, traits> {
-  let arguments = (ins DenseI32ArrayAttr:$shape);
-
-  let results = (outs AnyRankedTensor:$result);
-}
-
-def TTIR_ZerosOp : TTIR_NamedFullOp<"zeros", [TT_CreationOpTrait]> {
-  let summary = "Creates a tensor filled with zeros.";
-  let description = [{
-    Tensor operation to create a tensor filled with zeros.
-
-    Given a `shape`, produces a tensor with the shape, filled with zeros.
-
-    Example:
-      %0 = "ttir.zeros"() <{shape = array<i32:64, 28, 28>}> : () -> tensor<64x28x28xbf16>
-      // %0: [[[0, 0, 0, ..., 0], [0, 0, 0, ..., 0], ..., [0, 0, 0, ..., 0]]]
-  }];
-}
-
-def TTIR_OnesOp : TTIR_NamedFullOp<"ones", [TT_CreationOpTrait]> {
-  let summary = "Creates a tensor filled with ones.";
-  let description = [{
-    Tensor operation to create a tensor filled with ones.
-
-    Given a `shape`, produces a tensor with the shape, filled with ones.
-
-    Example:
-      %0 = "ttir.ones"() <{shape = array<i32:64, 28, 28>}> : () -> tensor<64x28x28xbf16>
-      // %0: [[[1, 1, 1, ..., 1], [1, 1, 1, ..., 1], ..., [1, 1, 1, ..., 1]]]
-  }];
-}
-
 def TTIR_ReverseOp : TTIR_NamedOp<"reverse", [AllShapesMatch<["input", "result"]>]> {
   let summary = "Reverse operation.";
 
@@ -1812,68 +1737,6 @@ def TTIR_ReverseOp : TTIR_NamedOp<"reverse", [AllShapesMatch<["input", "result"]
     let hasVerifier = 1;
 
     let hasCanonicalizer = 1;
-}
-
-def TTIR_EmptyOp : TTIR_Op<"empty",
-  [ Pure
-  , TT_CreationOpTrait
-  , DeclareOpInterfaceMethods<BufferizableOpInterface, [ "bufferizesToMemoryRead"
-                                                       , "bufferizesToMemoryWrite"
-                                                       , "bufferizesToAllocation"
-                                                       , "bufferize"
-                                                       , "getAliasingValues"
-                                                       , "getBufferType"
-                                                       ]>
-  ]> {
-    let summary = "Empty op.";
-    let description = [{
-      Tensor empty operation
-    }];
-
-    let results = (outs AnyRankedTensor:$result);
-
-    let builders =
-    [
-      OpBuilder<(ins "ArrayRef<int64_t>": $shape, "Type": $elementType, "Attribute": $encoding),
-      [{
-        build($_builder, $_state, RankedTensorType::get(shape, elementType, encoding));
-      }]>,
-      OpBuilder<(ins "ArrayRef<int64_t>": $shape, "Type": $elementType),
-      [{
-        build($_builder, $_state, shape, elementType, nullptr);
-      }]>
-    ];
-
-    let assemblyFormat = "`(` `)` attr-dict `:` type($result)";
-}
-
-def TTIR_ConstantOp : TTIR_Op<"constant",
-  [ ConstantLike
-  , AllShapesMatch<["value", "result"]>
-  , TT_CreationOpTrait
-  , DeclareOpInterfaceMethods<BufferizableOpInterface, [ "bufferizesToMemoryRead"
-                                                       , "bufferizesToMemoryWrite"
-                                                       , "bufferize"
-                                                       , "getAliasingValues"
-                                                       , "getBufferType"
-                                                       ]>
-  ]> {
-    let summary = "Constant op.";
-    let description = [{
-      Produces tensor filled with given constant value.
-
-      Examples:
-        %0 = "ttir.constant"() {value = dense<0> : tensor<2x3xi32>} : () -> tensor<2x3xi32>
-        // %0: [[0, 0, 0], [0, 0, 0]]
-        %1 = "ttir.constant"() {value = dense<[0.2, 1.3]> : tensor<2xf32>} : () -> tensor<2xf32>
-        // %1: [0.2, 1.3]
-    }];
-
-    let arguments = (ins ElementsAttr:$value);
-
-    let results = (outs AnyRankedTensor:$result);
-
-    let hasFolder = 1;
 }
 
 def TTIR_FillOp : TTIR_NamedOp<"fill", [AllShapesMatch<["value", "result"]>]> {
@@ -1993,8 +1856,6 @@ def TTIR_Upsample2dOp : TTIR_NamedOp<"upsample2d"> {
     let hasVerifier = 1;
 }
 
-//===----------------------------------------------------------------------===//
-
 def TTIR_ScatterOp: TTIR_NamedOp<"scatter"> {
   let summary = "Scatter operation";
   let description = [{
@@ -2019,6 +1880,148 @@ def TTIR_ScatterOp: TTIR_NamedOp<"scatter"> {
   let results = (outs AnyRankedTensor:$result);
 
   let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// TTIR creation ops
+//===----------------------------------------------------------------------===//
+
+class TTIR_CreationOp<string mnemonic, list<Trait> traits = []> :
+    TTIR_DPSOp<mnemonic, !listconcat([Pure, TT_CreationOpTrait], traits)>;
+
+
+def TTIR_ArangeOp : TTIR_CreationOp<"arange"> {
+  let summary = "Arange operation.";
+  let description = [{
+    Tensor arange operation.
+
+    Produces a tensor with values from `start` to `end` (exclusive) with a step size of `step`, along the dimension specified by `arange_dimension`.
+
+    Examples:
+      %0 = "ttir.arange"() {start = 0 : i64, end = 5 : i64 step = 1 : i64, arange_dimension = 0 : i64} : () -> tensor<5xi64>
+      // %0: [0, 1, 2, 3, 4]
+
+      %1 = "ttir.arange"() {start = 0 : i64, end = 10 : i64, step = 2 : i64, arange_dimension = 0 : i64} : () -> tensor<5xf32>
+      // %1: [0.0, 2.0, 4.0, 6.0, 8.0]
+
+      %2 = "ttir.arange"() {start = 0 : i64, end = 5 : i64, step = 1 : i64, arange_dimension = 0 : i64} : () -> tensor<5x3xi64>
+      // %2: [
+              [0, 0, 0],
+              [1, 1, 1],
+              [2, 2, 2],
+              [3, 3, 3],
+              [4, 4, 4]
+             ]
+
+      %3 = "ttir.arange"() {start = 0 : i64, end = 3 : i64, step = 1 : i64, arange_dimension = 1 : i64} : () -> tensor<5x3xi64>
+      // %3: [
+              [0, 1, 2],
+              [0, 1, 2],
+              [0, 1, 2],
+              [0, 1, 2],
+              [0, 1, 2]
+             ]
+  }];
+
+  let arguments = (ins SI64Attr:$start,
+                       SI64Attr:$end,
+                       SI64Attr:$step,
+                       I64Attr:$arange_dimension);
+
+  let results = (outs AnyRankedTensor:$result);
+  let hasVerifier = 1;
+}
+
+class TTIR_NamedFullOp<string mnemonic, list<Trait> traits = []> :
+  TTIR_CreationOp<mnemonic, traits> {
+  let arguments = (ins DenseI32ArrayAttr:$shape);
+
+  let results = (outs AnyRankedTensor:$result);
+}
+
+def TTIR_ZerosOp : TTIR_NamedFullOp<"zeros"> {
+  let summary = "Creates a tensor filled with zeros.";
+  let description = [{
+    Tensor operation to create a tensor filled with zeros.
+
+    Given a `shape`, produces a tensor with the shape, filled with zeros.
+
+    Example:
+      %0 = "ttir.zeros"() <{shape = array<i32:64, 28, 28>}> : () -> tensor<64x28x28xbf16>
+      // %0: [[[0, 0, 0, ..., 0], [0, 0, 0, ..., 0], ..., [0, 0, 0, ..., 0]]]
+  }];
+}
+
+def TTIR_OnesOp : TTIR_NamedFullOp<"ones"> {
+  let summary = "Creates a tensor filled with ones.";
+  let description = [{
+    Tensor operation to create a tensor filled with ones.
+
+    Given a `shape`, produces a tensor with the shape, filled with ones.
+
+    Example:
+      %0 = "ttir.ones"() <{shape = array<i32:64, 28, 28>}> : () -> tensor<64x28x28xbf16>
+      // %0: [[[1, 1, 1, ..., 1], [1, 1, 1, ..., 1], ..., [1, 1, 1, ..., 1]]]
+  }];
+}
+
+def TTIR_EmptyOp : TTIR_Op<"empty",
+  [DeclareOpInterfaceMethods<BufferizableOpInterface, [ "bufferizesToMemoryRead"
+                                                      , "bufferizesToMemoryWrite"
+                                                      , "bufferizesToAllocation"
+                                                      , "bufferize"
+                                                      , "getAliasingValues"
+                                                      , "getBufferType"
+                                                      ]>
+  ]> {
+    let summary = "Empty op.";
+    let description = [{
+      Tensor empty operation
+    }];
+
+    let results = (outs AnyRankedTensor:$result);
+
+    let builders =
+    [
+      OpBuilder<(ins "ArrayRef<int64_t>": $shape, "Type": $elementType, "Attribute": $encoding),
+      [{
+        build($_builder, $_state, RankedTensorType::get(shape, elementType, encoding));
+      }]>,
+      OpBuilder<(ins "ArrayRef<int64_t>": $shape, "Type": $elementType),
+      [{
+        build($_builder, $_state, shape, elementType, nullptr);
+      }]>
+    ];
+
+    let assemblyFormat = "`(` `)` attr-dict `:` type($result)";
+}
+
+def TTIR_ConstantOp : TTIR_Op<"constant",
+  [ ConstantLike
+  , AllShapesMatch<["value", "result"]>
+  , DeclareOpInterfaceMethods<BufferizableOpInterface, [ "bufferizesToMemoryRead"
+                                                       , "bufferizesToMemoryWrite"
+                                                       , "bufferize"
+                                                       , "getAliasingValues"
+                                                       , "getBufferType"
+                                                       ]>
+  ]> {
+    let summary = "Constant op.";
+    let description = [{
+      Produces tensor filled with given constant value.
+
+      Examples:
+        %0 = "ttir.constant"() {value = dense<0> : tensor<2x3xi32>} : () -> tensor<2x3xi32>
+        // %0: [[0, 0, 0], [0, 0, 0]]
+        %1 = "ttir.constant"() {value = dense<[0.2, 1.3]> : tensor<2xf32>} : () -> tensor<2xf32>
+        // %1: [0.2, 1.3]
+    }];
+
+    let arguments = (ins ElementsAttr:$value);
+
+    let results = (outs AnyRankedTensor:$result);
+
+    let hasFolder = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -1965,7 +1965,7 @@ def TTIR_OnesOp : TTIR_NamedFullOp<"ones"> {
   }];
 }
 
-def TTIR_EmptyOp : TTIR_Op<"empty",
+def TTIR_EmptyOp : TTIR_CreationOp<"empty",
   [DeclareOpInterfaceMethods<BufferizableOpInterface, [ "bufferizesToMemoryRead"
                                                       , "bufferizesToMemoryWrite"
                                                       , "bufferizesToAllocation"
@@ -1996,7 +1996,7 @@ def TTIR_EmptyOp : TTIR_Op<"empty",
     let assemblyFormat = "`(` `)` attr-dict `:` type($result)";
 }
 
-def TTIR_ConstantOp : TTIR_Op<"constant",
+def TTIR_ConstantOp : TTIR_CreationOp<"constant",
   [ ConstantLike
   , AllShapesMatch<["value", "result"]>
   , DeclareOpInterfaceMethods<BufferizableOpInterface, [ "bufferizesToMemoryRead"

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -22,7 +22,7 @@ include "mlir/IR/CommonAttrConstraints.td"
 include "mlir/IR/OpBase.td"
 
 class TTIR_DPSOp<string mnemonic, list<Trait> traits = []> :
-    TTIR_Op<mnemonic, !listconcat([TTIROpInterface, DestinationStyleOpInterface], traits)> {
+    TTIR_Op<mnemonic, [TTIROpInterface, DestinationStyleOpInterface] # traits> {
     let extraClassDeclaration = [{
       // base implementation that will detect getOutputMutable() or getOutputsMutable()
       MutableOperandRange getDpsInitsMutable() { return ttir::getDpsOutputs(this); }
@@ -360,10 +360,10 @@ def TTIR_DeallocOp : TTIR_Op<"dealloc"> {
 //===----------------------------------------------------------------------===//
 
 class TTIR_NamedOp<string mnemonic, list<Trait> traits = []> :
-    TTIR_DPSOp<mnemonic, !listconcat([Pure], traits)>;
+    TTIR_DPSOp<mnemonic, [Pure] # traits>;
 
 class TTIR_ElementwiseOp<string mnemonic, list<Trait> traits = []> :
-    TTIR_NamedOp<mnemonic, !listconcat([AttrSizedOperandSegments, TTIR_Broadcastable], traits)> {
+    TTIR_NamedOp<mnemonic, [AttrSizedOperandSegments, TTIR_Broadcastable] # traits> {
 
     let description = [{
       Base class for elementwise operations. Elementwise operations can take inputs with different shape,
@@ -376,7 +376,7 @@ class TTIR_ElementwiseOp<string mnemonic, list<Trait> traits = []> :
 }
 
 class TTIR_ElementwiseTernaryOp<string mnemonic, list<Trait> traits = []> :
-    TTIR_ElementwiseOp<mnemonic, !listconcat([FourOperands], traits)> {
+    TTIR_ElementwiseOp<mnemonic, [FourOperands] # traits> {
     let summary = "Eltwise ternary op.";
     let description = [{
       Eltwise ternary op.
@@ -399,7 +399,7 @@ def TTIR_WhereOp: TTIR_ElementwiseTernaryOp<"where", [TTIR_PartiallyBroadcastabl
 }
 
 class TTIR_ElementwiseUnaryOp<string mnemonic, list<Trait> traits = []> :
-    TTIR_ElementwiseOp<mnemonic, !listconcat([TwoOperands], traits)> {
+    TTIR_ElementwiseOp<mnemonic, [TwoOperands] # traits> {
     let summary = "Eltwise unary op.";
     let description = [{
       Eltwise unary op.
@@ -671,7 +671,7 @@ def TTIR_LeakyReluOp : TTIR_ElementwiseUnaryWithFloatParameterOp<"leaky_relu"> {
 }
 
 class TTIR_ElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
-    TTIR_ElementwiseOp<mnemonic, !listconcat([ThreeOperands], traits)> {
+    TTIR_ElementwiseOp<mnemonic, [ThreeOperands] # traits> {
     let summary = "Eltwise binary op.";
     let description = [{
       Eltwise binary op.
@@ -1887,7 +1887,7 @@ def TTIR_ScatterOp: TTIR_NamedOp<"scatter"> {
 //===----------------------------------------------------------------------===//
 
 class TTIR_CreationOp<string mnemonic, list<Trait> traits = []> :
-    TTIR_DPSOp<mnemonic, !listconcat([Pure, TT_CreationOpTrait], traits)>;
+    TTIR_Op<mnemonic, [Pure, TT_CreationOpTrait] # traits>;
 
 
 def TTIR_ArangeOp : TTIR_CreationOp<"arange"> {

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -2189,13 +2189,9 @@ public:
       value = paddingValueAttr.getSplatValue<APFloat>().convertToDouble();
     }
 
-    rewriter.replaceOpWithNewOp<mlir::tt::ttir::PadOp>(
-        srcOp,
-        outputType,                            // result type
-        adaptor.getOperand(),                  // input
-        rewriter.getDenseI32ArrayAttr(padDim), // padding dimensions
-        rewriter.getF32FloatAttr(value)        // padding value
-    );
+    ttmlir::utils::replaceOpWithNewDPSOp<mlir::tt::ttir::PadOp>(
+        rewriter, srcOp, outputType, adaptor.getOperand(),
+        rewriter.getDenseI32ArrayAttr(padDim), rewriter.getF32FloatAttr(value));
 
     return success();
   }

--- a/python/test_infra/ttir_builder.py
+++ b/python/test_infra/ttir_builder.py
@@ -1331,7 +1331,7 @@ class TTIRBuilder:
             organize_ttir_args=lambda i, o, _: (self._get_type(o), i[0], o),
         )
 
-    def pad(self, in0: Operand, padding: List[int], value: int) -> OpView:
+    def pad(self, in0: Operand, in1: Operand, padding: List[int], value: int) -> OpView:
         # Reformatting padding dimensions for golden tensor:
         golden_padding = []
         for i in range(len(padding) // 2):
@@ -1340,10 +1340,11 @@ class TTIRBuilder:
         return self.op_proxy(
             torch.nn.functional.pad,
             ttir.PadOp,
-            [in0],
+            [in0, in1],
             golden_kwargs={"pad": golden_padding, "mode": "constant", "value": value},
             ttir_kwargs={"padding": padding, "value": value},
-            organize_ttir_args=lambda i, o, _: (self._get_type(o), i[0]),
+            organize_golden_args=lambda i: [self._get_golden_tensor(i[0])],
+            organize_ttir_args=lambda i, o, _: (self._get_type(o), i[0], i[1]),
         )
 
     def select(

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -651,7 +651,7 @@ def test_max_pool2d(in0: Operand, in1: Operand, builder: TTIRBuilder):
 @compile_to_flatbuffer(
     [
         (1, 1, 5, 5),
-        (1, 1, 7, 7),
+        (2, 6, 14, 18),
     ],
     inputs_types=[torch.bfloat16, torch.bfloat16],
     targets=["ttnn"],

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -651,12 +651,13 @@ def test_max_pool2d(in0: Operand, in1: Operand, builder: TTIRBuilder):
 @compile_to_flatbuffer(
     [
         (1, 1, 5, 5),
+        (1, 1, 7, 7),
     ],
-    inputs_types=[torch.bfloat16],
+    inputs_types=[torch.bfloat16, torch.bfloat16],
     targets=["ttnn"],
 )
-def test_pad(in0: Operand, builder: TTIRBuilder):
-    return builder.pad(in0, padding=[0, 1, 2, 3, 4, 5, 6, 7], value=0)
+def test_pad(in0: Operand, in1: Operand, builder: TTIRBuilder):
+    return builder.pad(in0, in1, padding=[0, 1, 2, 3, 4, 5, 6, 7], value=0)
 
 
 @compile_to_flatbuffer([(32, 64)], targets=["ttnn"])

--- a/test/ttmlir/Conversion/StableHLOToTTIR/pad_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/pad_op.mlir
@@ -5,7 +5,7 @@ module {
     // CHECK: ttir.pad
     // CHECK-SAME: padding = array<i32: 0, 0, 0, 4, 0, 4, 0, 0>
     // CHECK-SAME: value = 0.000000e+00 : f32
-    // CHECK-SAME: (tensor<1x128x128x384xf32>) -> tensor<1x132x132x384xf32>
+    // CHECK-SAME: (tensor<1x128x128x384xf32>, tensor<1x132x132x384xf32>) -> tensor<1x132x132x384xf32>
     %cst = arith.constant dense<0.000000e+00> : tensor<1xf64>
     %0 = stablehlo.convert %cst : (tensor<1xf64>) -> tensor<1xf32>
     %1 = stablehlo.reshape %0 : (tensor<1xf32>) -> tensor<f32>
@@ -19,7 +19,7 @@ module {
     // CHECK: ttir.pad
     // CHECK-SAME: padding = array<i32: 0, 0, 0, 8, 0, 8, 0, 0>
     // CHECK-SAME: value = 0.000000e+00 : f32
-    // CHECK-SAME: (tensor<1x64x64x384xf32>) -> tensor<1x72x72x384xf32>
+    // CHECK-SAME: (tensor<1x64x64x384xf32>, tensor<1x72x72x384xf32>) -> tensor<1x72x72x384xf32>
     %cst = arith.constant dense<0.000000e+00> : tensor<1xf64>
     %0 = stablehlo.convert %cst : (tensor<1xf64>) -> tensor<1xf32>
     %1 = stablehlo.reshape %0 : (tensor<1xf32>) -> tensor<f32>
@@ -33,7 +33,7 @@ module {
     // CHECK: ttir.pad
     // CHECK-SAME: padding = array<i32: 0, 0, 0, 8, 0, 8, 0, 0>
     // CHECK-SAME: value = 0.000000e+00 : f32
-    // CHECK-SAME: (tensor<1x64x64x768xbf16>) -> tensor<1x72x72x768xbf16>
+    // CHECK-SAME: (tensor<1x64x64x768xbf16>, tensor<1x72x72x768xbf16>) -> tensor<1x72x72x768xbf16>
     %cst = arith.constant dense<0.000000e+00> : tensor<1xbf16>
     %0 = stablehlo.convert %cst : (tensor<1xbf16>) -> tensor<1xbf16>
     %1 = stablehlo.reshape %0 : (tensor<1xbf16>) -> tensor<bf16>
@@ -47,7 +47,7 @@ module {
     // CHECK: ttir.pad
     // CHECK-SAME: padding = array<i32: 0, 0, 0, 8, 0, 8, 0, 0>
     // CHECK-SAME: value = 0.000000e+00 : f32
-    // CHECK-SAME: (tensor<1x64x64x768xi32>) -> tensor<1x72x72x768xi32>
+    // CHECK-SAME: (tensor<1x64x64x768xi32>, tensor<1x72x72x768xi32>) -> tensor<1x72x72x768xi32>
     %cst = arith.constant dense<0> : tensor<1xi32>
     %0 = stablehlo.convert %cst : (tensor<1xi32>) -> tensor<1xi32>
     %1 = stablehlo.reshape %0 : (tensor<1xi32>) -> tensor<i32>
@@ -61,11 +61,12 @@ module {
     // CHECK: ttir.pad
     // CHECK-SAME: padding = array<i32: 0, 0, 0, 0, 0, 0, 2, 2>
     // CHECK-SAME: value = 0.000000e+00 : f32
-    // CHECK-SAME: (tensor<4x54x54x64xbf16>) -> tensor<4x54x54x68xbf16>
+    // CHECK-SAME: (tensor<4x54x54x64xbf16>, tensor<4x54x54x68xbf16>) -> tensor<4x54x54x68xbf16>
     %cst = stablehlo.constant dense<0> : tensor<i32>
     %0 = call @_pad(%arg0, %cst) : (tensor<4x54x54x64xbf16>, tensor<i32>) -> tensor<4x54x54x68xbf16>
     return %0 : tensor<4x54x54x68xbf16>
   }
+
   func.func private @_pad(%arg0: tensor<4x54x54x64xbf16>, %arg1: tensor<i32>) -> tensor<4x54x54x68xbf16> {
     %0 = stablehlo.convert %arg1 : (tensor<i32>) -> tensor<bf16>
     %1 = stablehlo.pad %arg0, %0, low = [0, 0, 0, 2], high = [0, 0, 0, 2], interior = [0, 0, 0, 0] : (tensor<4x54x54x64xbf16>, tensor<bf16>) -> tensor<4x54x54x68xbf16>

--- a/test/ttmlir/Dialect/TTNN/simple_pad.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_pad.mlir
@@ -2,9 +2,10 @@
 
 module {
   func.func @main(%arg0: tensor<1x1x5x5xbf16>) -> tensor<1x1x7x7xbf16> {
+    %0 = ttir.empty() : tensor<1x1x7x7xbf16>
     // CHECK: ttnn.pad
     // CHECK: padding = array<i32: 0, 0, 0, 0, 1, 1, 1, 1>
-    %1 = "ttir.pad"(%arg0) <{padding = array<i32: 0, 0, 0, 0, 1, 1, 1, 1>, value = 0.000000e+00 : f32}> : (tensor<1x1x5x5xbf16>) -> tensor<1x1x7x7xbf16>
+    %1 = "ttir.pad"(%arg0, %0) <{padding = array<i32: 0, 0, 0, 0, 1, 1, 1, 1>, value = 0.000000e+00 : f32}> : (tensor<1x1x5x5xbf16>, tensor<1x1x7x7xbf16>) -> tensor<1x1x7x7xbf16>
     return %1 : tensor<1x1x7x7xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/simple_pad.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_pad.mlir
@@ -2,9 +2,10 @@
 
 module {
   func.func @main(%arg0: tensor<1x128x128x384xf32>) -> tensor<1x132x132x384xf32> {
+    %0 = ttir.empty() : tensor<1x132x132x384xf32>
     // CHECK: ttnn.pad
     // CHECK-SAME: padding = array<i32: 0, 0, 2, 2, 2, 2, 0, 0>
-    %1 = "ttir.pad"(%arg0) <{padding = array<i32: 0, 0, 2, 2, 2, 2, 0, 0>, value = 0.000000e+00 : f32}> : (tensor<1x128x128x384xf32>) -> tensor<1x132x132x384xf32>
+    %1 = "ttir.pad"(%arg0, %0) <{padding = array<i32: 0, 0, 2, 2, 2, 2, 0, 0>, value = 0.000000e+00 : f32}> : (tensor<1x128x128x384xf32>, tensor<1x132x132x384xf32>) -> tensor<1x132x132x384xf32>
     return %1 : tensor<1x132x132x384xf32>
   }
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/2854

### Problem description
- PadOp is non-DPS op, but should be (more precisely it should belong to `TTIR_NamedOp` class)
- creations ops (`empty`, `arange`, `constant`, `zeros`, `ones` etc.) should have their own op class, because they aren't `DPS`, but are `Pure`
- `TTIR_GenericElementwiseXOp` doesn't make sense anymore, and they should be transferred to `TTIR_ElementwiseXOp` class
- some CCL ops were only `TTIR_DPSOp`s, but should be `TTIR_NamedOp`s

### What's changed
Fixed mentioned inconsistencies.

### Checklist
- [x] New/Existing tests provide coverage for changes
