### PR TITLE
Uplift third_party/tt-metal to c9e4a1ac43c37f0b801788ac6280c25960ad5296 2025-04-10

### DIFF
--- a/runtime/lib/ttnn/operations/data_movement/pad.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/pad.cpp
@@ -22,9 +22,9 @@ void run(const ::tt::target::ttnn::PadOp *op, ProgramContext &context) {
 
   ::ttnn::Tensor out;
 
-  ::ttnn::SmallVector<::ttnn::operations::data_movement::PadSpecDim> padding;
+  std::vector<std::pair<uint32_t, uint32_t>> padding;
   for (uint32_t i = 0; i < op->padding()->size(); i += 2) {
-    padding.push_back({op->padding()->Get(i), op->padding()->Get(i + 1)});
+    padding.emplace_back(op->padding()->Get(i), op->padding()->Get(i + 1));
   }
 
   std::optional<::ttnn::MemoryConfig> outputMemoryConfig =

--- a/runtime/lib/ttnn/operations/eltwise/binary/binary.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/binary/binary.cpp
@@ -17,8 +17,10 @@ static void runEltwiseBinaryOp(
         const std::optional<const ::ttnn::DataType> &,
         const std::optional<::ttnn::MemoryConfig> &,
         std::optional<::ttnn::Tensor>,
-        std::optional<::ttnn::operations::unary::FusedActivations>,
-        std::optional<::ttnn::operations::unary::UnaryWithParam>)> &ttnnOp) {
+        tt::stl::Span<const ::ttnn::operations::unary::UnaryWithParam>,
+        tt::stl::Span<const ::ttnn::operations::unary::UnaryWithParam>,
+        tt::stl::Span<const ::ttnn::operations::unary::UnaryWithParam>)>
+        &ttnnOp) {
 
   const ::ttnn::Tensor &lhs = tensorPool.getTTNNTensorAndValidate(op->lhs());
   const ::ttnn::Tensor &rhs = tensorPool.getTTNNTensorAndValidate(op->rhs());
@@ -37,7 +39,7 @@ static void runEltwiseBinaryOp(
              "Memory config must exist for device tensors");
 
   ::ttnn::Tensor out = ttnnOp(lhs, rhs, outputDataType, outputMemoryConfig,
-                              std::nullopt, std::nullopt, std::nullopt);
+                              std::nullopt, {}, {}, {});
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "678a464f7f15d3581fae286df0017100882e7975")
+set(TT_METAL_VERSION "c9e4a1ac43c37f0b801788ac6280c25960ad5296")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the c9e4a1ac43c37f0b801788ac6280c25960ad5296

- Revert "Update pad op after metal commit 8d50fef" since change reverted in metal commit ce1f5de
- update binary op params after metal change d7a8dcd