### PR TITLE
[TTNN] Introduce TTNNPrepareConv2dWeights pass

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -133,4 +133,11 @@ def TTNNModifySignaturesForDylib: Pass<"ttnn-modify-signatures-for-dylib", "::ml
   }];
 }
 
+def TTNNOptimizeConv2d : Pass<"ttnn-optimize-conv2d", "::mlir::ModuleOp"> {
+  let summary = "Optimize Conv2d ops by inserting PrepareConv2dWeights before them";
+  let description = [{
+    This pass inserts a PrepareConv2dWeights op that preprocesses the weights used by Conv2d operations.
+  }];
+}
+
 #endif

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -134,9 +134,11 @@ def TTNNModifySignaturesForDylib: Pass<"ttnn-modify-signatures-for-dylib", "::ml
 }
 
 def TTNNPrepareConv2dWeights : Pass<"ttnn-prepare-conv2d-weights", "::mlir::ModuleOp"> {
-  let summary = "Optimize Conv2d ops by inserting PrepareConv2dWeights before them";
+  let summary = "Optimize Conv2d ops by inserting PrepareConv2dWeights before them.";
   let description = [{
-    This pass inserts a PrepareConv2dWeights op that preprocesses the weights used by Conv2d operations.
+    This pass inserts a PrepareConv2dWeights operation before each Conv2d op which preprocess the weights used by Conv2d operations.
+    The PrepareConv2dWeights op can be then const-evaled, leading to improved performance. In order to use this pass,
+    the project must be built with the op model library by setting -DTTMLIR_ENABLE_OP_MODEL=ON during the build process.
   }];
 }
 

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -133,7 +133,7 @@ def TTNNModifySignaturesForDylib: Pass<"ttnn-modify-signatures-for-dylib", "::ml
   }];
 }
 
-def TTNNOptimizeConv2d : Pass<"ttnn-optimize-conv2d", "::mlir::ModuleOp"> {
+def TTNNPrepareConv2dWeights : Pass<"ttnn-prepare-conv2d-weights", "::mlir::ModuleOp"> {
   let summary = "Optimize Conv2d ops by inserting PrepareConv2dWeights before them";
   let description = [{
     This pass inserts a PrepareConv2dWeights op that preprocesses the weights used by Conv2d operations.

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -67,7 +67,7 @@ void createTTNNPipelineAnalysisPasses(
     optimizerOptions.maxLegalLayouts = options.maxLegalLayouts;
     optimizerOptions.rowMajorEnabled = options.rowMajorEnabled;
     pm.addPass(mlir::tt::ttnn::createTTNNOptimizer(optimizerOptions));
-    pm.addPass(mlir::tt::ttnn::createTTNNOptimizeConv2d());
+    pm.addPass(mlir::tt::ttnn::createTTNNPrepareConv2dWeights());
   }
 }
 

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -67,6 +67,7 @@ void createTTNNPipelineAnalysisPasses(
     optimizerOptions.maxLegalLayouts = options.maxLegalLayouts;
     optimizerOptions.rowMajorEnabled = options.rowMajorEnabled;
     pm.addPass(mlir::tt::ttnn::createTTNNOptimizer(optimizerOptions));
+    pm.addPass(mlir::tt::ttnn::createTTNNOptimizeConv2d());
   }
 }
 

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -4,6 +4,7 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         TTNNLayout.cpp
         TTNNDecomposeLayouts.cpp
         TTNNToCpp.cpp
+        TTNNOptimizeConv2d.cpp
         Workarounds/Decomposition/ArgMaxOpRewritePattern.cpp
         Workarounds/Decomposition/CumSumOpRewritePattern.cpp
         Workarounds/Decomposition/EmbeddingOpSqueezeWeightRewritePattern.cpp

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -4,7 +4,7 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         TTNNLayout.cpp
         TTNNDecomposeLayouts.cpp
         TTNNToCpp.cpp
-        TTNNOptimizeConv2d.cpp
+        TTNNPrepareConv2dWeights.cpp
         Workarounds/Decomposition/ArgMaxOpRewritePattern.cpp
         Workarounds/Decomposition/CumSumOpRewritePattern.cpp
         Workarounds/Decomposition/EmbeddingOpSqueezeWeightRewritePattern.cpp

--- a/lib/Dialect/TTNN/Transforms/TTNNOptimizeConv2d.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNOptimizeConv2d.cpp
@@ -6,6 +6,7 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
 #include "ttmlir/OpModel/TTNN/TTNNOpModel.h"
+#include "ttmlir/Utils.h"
 
 namespace mlir::tt::ttnn {
 #define GEN_PASS_DEF_TTNNOPTIMIZECONV2D
@@ -43,8 +44,10 @@ public:
       rewriter.setInsertionPoint(conv2dOp);
       ttnn::PrepareConv2dWeightsOp prepareConv2dWeightsOp =
           rewriter.create<ttnn::PrepareConv2dWeightsOp>(
-              conv2dOp.getLoc(), getPreparedWeightsType(conv2dOp),
-              conv2dOp.getWeight(), inputMemConfigAttr,
+              ttmlir::utils::appendLocationSuffix(conv2dOp.getLoc(),
+                                                  "_prepare_conv2d"),
+              getPreparedWeightsType(conv2dOp), conv2dOp.getWeight(),
+              inputMemConfigAttr,
               rewriter.getAttr<ttnn::LayoutAttr>(inputLayoutAttr.getLayout()),
               rewriter.getStringAttr("OIHW"), conv2dOp.getInChannelsAttr(),
               conv2dOp.getOutChannelsAttr(), conv2dOp.getBatchSizeAttr(),

--- a/lib/Dialect/TTNN/Transforms/TTNNOptimizeConv2d.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNOptimizeConv2d.cpp
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
+#include "ttmlir/OpModel/TTNN/TTNNOpModel.h"
+
+namespace mlir::tt::ttnn {
+#define GEN_PASS_DEF_TTNNOPTIMIZECONV2D
+#include "ttmlir/Dialect/TTNN/Transforms/Passes.h.inc"
+
+class TTNNOptimizeConv2d
+    : public impl::TTNNOptimizeConv2dBase<TTNNOptimizeConv2d> {
+
+public:
+  using impl::TTNNOptimizeConv2dBase<
+      TTNNOptimizeConv2d>::TTNNOptimizeConv2dBase;
+
+  // Insert PrepareConv2dWeightsOp before every Conv2dOp that prepares weights
+  // for convolution. This is a prerequisite for constevaluation, which will
+  // improve performance by eliminating the need for preprocessing the weights
+  // on the host/device.
+  void runOnOperation() final {
+    ModuleOp moduleOp = getOperation();
+    IRRewriter rewriter(&getContext());
+
+    moduleOp.walk([&](ttnn::Conv2dOp conv2dOp) {
+      mlir::RankedTensorType inputType = conv2dOp.getInput().getType();
+
+      ttnn::TTNNLayoutAttr inputLayoutAttr =
+          mlir::cast<ttnn::TTNNLayoutAttr>(inputType.getEncoding());
+      ttnn::MemoryConfigAttr inputMemConfigAttr =
+          rewriter.getAttr<ttnn::MemoryConfigAttr>(
+              rewriter.getAttr<ttnn::BufferTypeAttr>(
+                  inputLayoutAttr.getBufferType()),
+              rewriter.getAttr<ttnn::ShardSpecAttr>(
+                  rewriter.getAttr<ttnn::ShapeAttr>(
+                      inputLayoutAttr.getShardShape())),
+              inputLayoutAttr.getMemLayout());
+
+      rewriter.setInsertionPoint(conv2dOp);
+      ttnn::PrepareConv2dWeightsOp prepareConv2dWeightsOp =
+          rewriter.create<ttnn::PrepareConv2dWeightsOp>(
+              conv2dOp.getLoc(), getPreparedWeightsType(conv2dOp),
+              conv2dOp.getWeight(), inputMemConfigAttr,
+              rewriter.getAttr<ttnn::LayoutAttr>(inputLayoutAttr.getLayout()),
+              rewriter.getStringAttr("OIHW"), conv2dOp.getInChannelsAttr(),
+              conv2dOp.getOutChannelsAttr(), conv2dOp.getBatchSizeAttr(),
+              conv2dOp.getInputHeightAttr(), conv2dOp.getInputWidthAttr(),
+              conv2dOp.getKernelSizeAttr(), conv2dOp.getStrideAttr(),
+              conv2dOp.getPaddingAttr(), conv2dOp.getDilationAttr(),
+              rewriter.getBoolAttr(conv2dOp.getBias() != nullptr),
+              conv2dOp.getGroupsAttr(), conv2dOp.getDevice(),
+              conv2dOp.getConv2dConfigAttr());
+
+      // Update only the weight operand since PrepareConv2dWeightsOp will change
+      // the shape and layout of the weight
+      IRMapping mapper;
+      mapper.map(conv2dOp.getWeight(), prepareConv2dWeightsOp.getResult());
+
+      rewriter.replaceOp(conv2dOp,
+                         rewriter.clone(*conv2dOp.getOperation(), mapper));
+    });
+  }
+
+private:
+  ::mlir::RankedTensorType getPreparedWeightsType(ttnn::Conv2dOp conv2dOp) {
+    return op_model::ttnn::getPreparedConv2dWeightsOutputTensor(&conv2dOp);
+  }
+};
+} // namespace mlir::tt::ttnn

--- a/test/ttmlir/Dialect/TTNN/optimizer/conv2d_config_override.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/conv2d_config_override.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: opmodel
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true override-conv2d-config=conv2d_1=dtype#bf16:weights_dtype#bf16:activation#relu:input_channels_alignment#32:deallocate_activation#false:reallocate_halo_output#true:act_block_h_override#0:act_block_w_div#1:reshard_if_not_optimal#false:override_sharding_config#false:transpose_shards#true:output_layout#row_major:enable_act_double_buffer#false:enable_weights_double_buffer#false:enable_split_reader#false:enable_subblock_padding#false" %s | FileCheck %s
 module {
   func.func @forward(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x32x32x64xbf16> {

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/prepare_conv2d_weights.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/prepare_conv2d_weights.mlir
@@ -1,0 +1,18 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-optimizer=true" %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+
+func.func @prepare_conv2d_weights(%arg0: tensor<16x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<16x30x30x64xbf16> {
+    %0 = ttir.empty() : tensor<16x30x30x64xbf16>
+    // CHECK: = "ttnn.prepare_conv2d_weights"
+    // CHECK: = "ttnn.conv2d"
+    %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
+            <{
+                stride = 1: i32,
+                padding = 0: i32,
+                dilation = 1: i32,
+                groups = 1: i32
+            }> : (tensor<16x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, tensor<16x30x30x64xbf16>) -> tensor<16x30x30x64xbf16>
+    return %1 : tensor<16x30x30x64xbf16>
+}

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/prepare_conv2d_weights.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/prepare_conv2d_weights.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: opmodel
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-optimizer=true" %s > %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-optimizer=true" %s -o %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/issues/assigned?issue=tenstorrent%7Ctt-mlir%7C2636)

### Problem description
Each time the `ttnn.conv2d` operation is executed, it preprocesses the weights under the hood. This introduces significant performance overhead, as a lot of time is spent preparing the weights on the host and then copying them to the device.

To address this, instead of allowing `ttnn.conv2d` to implicitly prepare the weights each time, we’ve extracted a dedicated operation called `ttnn.prepare_conv2d_weights`. The idea is to insert this operation before every  `ttnn.conv2d` in the graph so that it can be consteval’d once consteval support is complete.

### What's changed
Introduced the `TTNNPrepareConv2dWeights` pass, which inserts `ttnn.prepare_conv2d_weights` before every `ttnn.conv2d` op in the graph.

When calculating the output tensor’s shape and layout from `ttnn.prepare_conv2d_weights`, we currently rely on a graph capture API created by @odjuricicTT. This API simulates the behavior of `ttnn.prepare_conv2d_weights`, allowing us to retrieve the shape and layout.

In the next iteration, we plan to use an API that Metal needs to expose, which will directly compute the shape and layout. This change is important, as the current approach impacts compile time and is not very clean.