### PR TITLE
Add back binary op operand swapping logic

### DIFF
--- a/runtime/lib/ttnn/operations/eltwise/binary/binary.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/binary/binary.cpp
@@ -22,8 +22,12 @@ static void runEltwiseBinaryOp(
         tt::stl::Span<const ::ttnn::operations::unary::UnaryWithParam>)>
         &ttnnOp) {
 
-  const ::ttnn::Tensor &lhs = tensorPool.getTTNNTensorAndValidate(op->lhs());
-  const ::ttnn::Tensor &rhs = tensorPool.getTTNNTensorAndValidate(op->rhs());
+  ::ttnn::Tensor *lhs = &(tensorPool.getTTNNTensorAndValidate(op->lhs()));
+  ::ttnn::Tensor *rhs = &(tensorPool.getTTNNTensorAndValidate(op->rhs()));
+
+  if (operations::utils::shouldSwapBinaryOperands(*lhs, *rhs)) {
+    std::swap(lhs, rhs);
+  }
 
   std::optional<::ttnn::DataType> outputDataType = std::nullopt;
   if (op->output_dtype()) {
@@ -38,7 +42,7 @@ static void runEltwiseBinaryOp(
                  outputMemoryConfig.has_value(),
              "Memory config must exist for device tensors");
 
-  ::ttnn::Tensor out = ttnnOp(lhs, rhs, outputDataType, outputMemoryConfig,
+  ::ttnn::Tensor out = ttnnOp(*lhs, *rhs, outputDataType, outputMemoryConfig,
                               std::nullopt, {}, {}, {});
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);

--- a/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/utils.cpp
+++ b/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/utils.cpp
@@ -4,6 +4,7 @@
 #include "tt/runtime/ttnn/operations/utils.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/ttnn/utils.h"
+#include "tt/runtime/workarounds.h"
 
 namespace tt::runtime::ttnn::operations::utils {
 
@@ -42,6 +43,12 @@ bool isTilized(const ::tt::target::ttnn::TensorRef *tensorRef) {
     LOG_FATAL("Unsupported distributed tensor config");
   }
   }
+}
+
+bool shouldSwapBinaryOperands(const ::ttnn::Tensor &lhs,
+                              const ::ttnn::Tensor &rhs) {
+  return (workaround::Env::get().swapBinaryOperands) &&
+         (lhs.volume() < rhs.volume());
 }
 
 ::ttnn::operations::unary::UnaryOpType

--- a/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/utils.h
+++ b/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/utils.h
@@ -22,6 +22,9 @@ bool isTilized(const ::tt::target::ttnn::TensorRef *tensorRef);
 ::tt::tt_metal::DistributedTensorConfig distributedTensorConfigFromFlatbuffer(
     const ::tt::target::ttnn::DistributionStrategy *strategy);
 
+bool shouldSwapBinaryOperands(const ::ttnn::Tensor &lhs,
+                              const ::ttnn::Tensor &rhs);
+
 template <std::integral T>
 inline ::ttnn::Shape toTTNNShape(const flatbuffers::Vector<T> &vec) {
   std::vector<uint32_t> rawShape;


### PR DESCRIPTION
### Problem description
BInary operand swapping logic was accidentally removed during refactor, causing uplifts to fail on tt-torch.

### What's changed
Add back operand swapping logic for binary ops. Confirmed that this fixes uplifts on tt-torch. Since this unblocks uplifts, would probably want to merge in before 24h limit

FYI @brataTT 

### Checklist
- [X] New/Existing tests provide coverage for changes
