### PR TITLE
D2M New TTMetal Lowering

### DIFF
--- a/include/ttmlir/Dialect/TTMetal/IR/TTMetalOps.td
+++ b/include/ttmlir/Dialect/TTMetal/IR/TTMetalOps.td
@@ -27,12 +27,12 @@ def TTMetal_EnqueueProgramOp : TTMetal_Op<"enqueue_program", [DestinationStyleOp
       Enqueue program operation
     }];
 
-    let arguments = (ins Variadic<AnyRankedTensor>:$inputs,
-                         Variadic<AnyRankedTensor>:$outputs,
+    let arguments = (ins Variadic<AnyNon0RankedMemRef>:$inputs,
+                         Variadic<AnyNon0RankedMemRef>:$outputs,
+                         ArrayAttr:$threads,
                          TTMetal_CoreRangeArrayAttr:$core_ranges,
                          TTKernel_KernelConfigArrayAttr:$kernelConfigs);
-    let results = (outs Variadic<AnyRankedTensor>:$results);
-    let regions = (region VariadicRegion<AnyRegion>:$regions);
+    let results = (outs Variadic<AnyNon0RankedMemRef>:$results);
 
     let extraClassDeclaration = [{
       MutableOperandRange getDpsInitsMutable() { return getOutputsMutable(); }
@@ -47,8 +47,8 @@ def TTMetal_EnqueueWriteBufferOp : TTMetal_Op<"enqueue_write_buffer", [Destinati
       Enqueue write buffer operation
     }];
 
-    let arguments = (ins AnyRankedTensor:$output, ElementsAttr:$value);
-    let results = (outs AnyRankedTensor:$result);
+    let arguments = (ins AnyNon0RankedMemRef:$output, ElementsAttr:$value);
+    let results = (outs AnyNon0RankedMemRef:$result);
 
     let extraClassDeclaration = [{
       MutableOperandRange getDpsInitsMutable() { return getOutputMutable(); }
@@ -63,9 +63,9 @@ def TTMetal_EnqueueReadBufferOp : TTMetal_Op<"enqueue_read_buffer", [Destination
       Enqueue read buffer operation
     }];
 
-    let arguments = (ins AnyRankedTensor:$input,
-                         AnyRankedTensor:$output);
-    let results = (outs AnyRankedTensor:$result);
+    let arguments = (ins AnyNon0RankedMemRef:$input,
+                         AnyNon0RankedMemRef:$output);
+    let results = (outs AnyNon0RankedMemRef:$result);
 
     let extraClassDeclaration = [{
       MutableOperandRange getDpsInitsMutable() { return getOutputMutable(); }
@@ -81,7 +81,7 @@ def TTMetal_CreateBufferOp : TTMetal_Op<"create_buffer"> {
     }];
 
     let arguments = (ins I64Attr:$address, I64Attr:$size, TT_MemorySpaceAttr:$memory_space);
-    let results = (outs AnyRankedTensor:$result);
+    let results = (outs AnyNon0RankedMemRef:$result);
 
     let hasVerifier = 1;
 }
@@ -92,7 +92,7 @@ def TTMetal_DeallocateBufferOp : TTMetal_Op<"deallocate_buffer"> {
       Deallocate buffer operation
     }];
 
-    let arguments = (ins AnyRankedTensor:$input);
+    let arguments = (ins AnyNon0RankedMemRef:$input);
 }
 
 #endif

--- a/include/ttmlir/Dialect/TTMetal/IR/TTMetalOps.td
+++ b/include/ttmlir/Dialect/TTMetal/IR/TTMetalOps.td
@@ -11,7 +11,6 @@ include "ttmlir/Dialect/TTMetal/IR/TTMetalOpsTypes.td"
 include "ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td"
 include "mlir/Dialect/Linalg/IR/LinalgBase.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
-include "mlir/Interfaces/DestinationStyleOpInterface.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/CommonTypeConstraints.td"
@@ -21,7 +20,7 @@ class AtLeastRegion<int numBlocks> : Region<
   CPred<"$_self.getBlocks().size() >= " # numBlocks>,
   "region with " # numBlocks # " blocks">;
 
-def TTMetal_EnqueueProgramOp : TTMetal_Op<"enqueue_program", [DestinationStyleOpInterface, AttrSizedOperandSegments]> {
+def TTMetal_EnqueueProgramOp : TTMetal_Op<"enqueue_program", [MemoryEffects<[MemRead, MemWrite]>, AttrSizedOperandSegments]> {
     let summary = "Enqueue program op.";
     let description = [{
       Enqueue program operation
@@ -32,32 +31,20 @@ def TTMetal_EnqueueProgramOp : TTMetal_Op<"enqueue_program", [DestinationStyleOp
                          ArrayAttr:$threads,
                          TTMetal_CoreRangeArrayAttr:$core_ranges,
                          TTKernel_KernelConfigArrayAttr:$kernelConfigs);
-    let results = (outs Variadic<AnyNon0RankedMemRef>:$results);
-
-    let extraClassDeclaration = [{
-      MutableOperandRange getDpsInitsMutable() { return getOutputsMutable(); }
-    }];
-
     let hasVerifier = 1;
 }
 
-def TTMetal_EnqueueWriteBufferOp : TTMetal_Op<"enqueue_write_buffer", [DestinationStyleOpInterface]> {
+def TTMetal_EnqueueWriteBufferOp : TTMetal_Op<"enqueue_write_buffer", [MemoryEffects<[MemRead, MemWrite]>]> {
     let summary = "Enqueue write buffer op.";
     let description = [{
       Enqueue write buffer operation
     }];
 
-    let arguments = (ins AnyNon0RankedMemRef:$output, ElementsAttr:$value);
-    let results = (outs AnyNon0RankedMemRef:$result);
-
-    let extraClassDeclaration = [{
-      MutableOperandRange getDpsInitsMutable() { return getOutputMutable(); }
-    }];
-
+    let arguments = (ins AnyNon0RankedMemRef:$input, AnyNon0RankedMemRef:$output);
     let hasVerifier = 1;
 }
 
-def TTMetal_EnqueueReadBufferOp : TTMetal_Op<"enqueue_read_buffer", [DestinationStyleOpInterface]> {
+def TTMetal_EnqueueReadBufferOp : TTMetal_Op<"enqueue_read_buffer", [MemoryEffects<[MemRead, MemWrite]>]> {
     let summary = "Enqueue read buffer op.";
     let description = [{
       Enqueue read buffer operation
@@ -65,16 +52,10 @@ def TTMetal_EnqueueReadBufferOp : TTMetal_Op<"enqueue_read_buffer", [Destination
 
     let arguments = (ins AnyNon0RankedMemRef:$input,
                          AnyNon0RankedMemRef:$output);
-    let results = (outs AnyNon0RankedMemRef:$result);
-
-    let extraClassDeclaration = [{
-      MutableOperandRange getDpsInitsMutable() { return getOutputMutable(); }
-    }];
-
     let hasVerifier = 1;
 }
 
-def TTMetal_CreateBufferOp : TTMetal_Op<"create_buffer"> {
+def TTMetal_CreateBufferOp : TTMetal_Op<"create_buffer", [MemoryEffects<[MemAlloc]>]> {
     let summary = "Create buffer op.";
     let description = [{
       Create buffer operation
@@ -86,7 +67,7 @@ def TTMetal_CreateBufferOp : TTMetal_Op<"create_buffer"> {
     let hasVerifier = 1;
 }
 
-def TTMetal_DeallocateBufferOp : TTMetal_Op<"deallocate_buffer"> {
+def TTMetal_DeallocateBufferOp : TTMetal_Op<"deallocate_buffer", [MemoryEffects<[MemFree]>]> {
     let summary = "Deallocate buffer op.";
     let description = [{
       Deallocate buffer operation

--- a/include/ttmlir/Target/TTMetal/command.fbs
+++ b/include/ttmlir/Target/TTMetal/command.fbs
@@ -29,7 +29,7 @@ union HostBuffer {
 }
 
 table EnqueueWriteBufferCommand {
-  src: HostBuffer;
+  src: TensorRef;
   dst: TensorRef;
 }
 

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
@@ -19,12 +19,9 @@ public:
   LogicalResult
   matchAndRewrite(ttir::GenericOp op, ttir::GenericOpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
-    llvm::SmallVector<Attribute> coreRanges;
-    coreRanges.reserve(op.getThreads().size());
-    for (size_t i = 0; i < op.getThreads().size(); i++) {
-      coreRanges.emplace_back(
-          rewriter.getAttr<ttmetal::CoreRangeAttr>(op.getGrid()));
-    }
+    llvm::SmallVector<Attribute> coreRanges(
+        op.getThreads().size(),
+        rewriter.getAttr<ttmetal::CoreRangeAttr>(op.getGrid()));
     rewriter.replaceOpWithNewOp<ttmetal::EnqueueProgramOp>(
         op, op.getInputs(), op.getOutputs(), op.getThreads(),
         rewriter.getArrayAttr(coreRanges), rewriter.getArrayAttr({}));
@@ -48,7 +45,7 @@ public:
                              1000); // TODO(#1909): arbitrary default for now,
                                     // remove when allocate pass is implemented
     assert(op.getMemref().getType().getMemorySpace() &&
-           "No memref memroy space found, failing.");
+           "No memref memory space found, failing.");
     auto memrefType = op.getMemref().getType();
     auto size = device.getMemrefSizeBytes(memrefType, 0);
     auto memorySpace =

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
@@ -3,584 +3,67 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Conversion/TTIRToTTMetal/TTIRToTTMetal.h"
-
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
-#include "ttmlir/Dialect/TT/Utils/PhysicalCoreCoord.h"
-#include "ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
-#include "ttmlir/Dialect/TTKernel/IR/TTKernelOps.h"
-#include "ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.h"
 #include "ttmlir/Dialect/TTMetal/IR/TTMetalOps.h"
-#include "ttmlir/Dialect/TTMetal/IR/TTMetalOpsTypes.h"
-#include "ttmlir/Utils.h"
 
-#include <llvm/ADT/DenseMap.h>
-#include <llvm/ADT/MapVector.h>
-#include <llvm/ADT/SmallVector.h>
-#include <llvm/Support/ErrorHandling.h>
-#include <llvm/Support/LogicalResult.h>
-#include <mlir/Analysis/Liveness.h>
-#include <mlir/Dialect/Arith/IR/Arith.h>
-#include <mlir/Dialect/Func/IR/FuncOps.h>
-#include <mlir/Dialect/Math/IR/Math.h>
-#include <mlir/Dialect/MemRef/IR/MemRef.h>
-#include <mlir/Dialect/SCF/IR/SCF.h>
-#include <mlir/IR/Block.h>
-#include <mlir/IR/Builders.h>
-#include <mlir/IR/BuiltinAttributes.h>
-#include <mlir/IR/BuiltinTypes.h>
-#include <mlir/IR/Location.h>
-#include <mlir/IR/PatternMatch.h>
-#include <mlir/IR/Types.h>
-#include <mlir/IR/Value.h>
-#include <mlir/IR/ValueRange.h>
-#include <mlir/Pass/PassManager.h>
-#include <mlir/Support/LogicalResult.h>
-#include <mlir/Transforms/DialectConversion.h>
-
-#include <cstdint>
-#include <utility>
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 
 namespace mlir::tt::ttmetal {
 
-// This routine walks the SSA value chain to find the address of the value.
-// It runs into and gets the address from one of the following:
-//   - ttir::CreateBufferOp: The address is the address of the allocation is
-//   embedded in the op attributes.
-//   - func::FuncOp Argument: The address is taken from ArgumentAllocationAttr.
-//
-// This routine is used to lookup the address of tensors for address generation
-// and for CB creation.
-static uint64_t lookupAddress(Value value) {
-  auto blockArg = mlir::dyn_cast<BlockArgument>(value);
-  if (blockArg) {
-    auto *funcOp = blockArg.getOwner()->getParentOp();
-    if (mlir::isa<func::FuncOp>(funcOp)) {
-      auto argAlloc = mlir::cast<ArgumentAllocationAttr>(
-          mlir::cast<ArrayAttr>(funcOp->getDiscardableAttr(
-              ArgumentAllocationAttr::name))[blockArg.getArgNumber()]);
-      return argAlloc.getAddress();
-    }
-  }
-
-  auto *op = value.getDefiningOp();
-  if (!op) {
-    return 0;
-  }
-
-  while (isa<DestinationStyleOpInterface>(op)) {
-    assert(op->getResults().size() == 1);
-    auto dps = cast<DestinationStyleOpInterface>(op);
-    assert(dps.getNumDpsInits() == 1);
-    auto *opOperand = dps.getDpsInitOperand(0);
-    value = opOperand->get();
-    op = value.getDefiningOp();
-  }
-
-  auto allocOp = dyn_cast<ttir::AllocOp>(op);
-  if (!allocOp) {
-    return 0;
-  }
-  return allocOp.getAddress();
-}
-
 namespace {
-class TTIRToTTMetalLayoutRewriter : public OpRewritePattern<ttir::ToLayoutOp> {
+class TTIRGenericRewriter : public OpConversionPattern<ttir::GenericOp> {
 public:
-  using OpRewritePattern<ttir::ToLayoutOp>::OpRewritePattern;
+  using OpConversionPattern<ttir::GenericOp>::OpConversionPattern;
 
-  struct NocTx {
-    enum class Type { Read, Write };
-
-    Type type;
-    PhysicalCoreCoord coreCoord;
-    std::int64_t srcOffset = 0;
-    std::int64_t dstOffset = 0;
-    std::int64_t size = 0;
-    std::int32_t numElements = 0;
-
-    NocTx(Type type, PhysicalCoreCoord coreCoord, std::int64_t srcOffset,
-          std::int64_t dstOffset, std::int64_t size, std::int32_t numElements)
-        : type(type), coreCoord(coreCoord), srcOffset(srcOffset),
-          dstOffset(dstOffset), size(size), numElements(numElements) {}
-
-    bool isContiguous(PhysicalCoreCoord nextCoord, std::int64_t nextSrcOffset,
-                      std::int64_t nextDstOffset) const {
-      return (nextCoord == coreCoord) && (nextSrcOffset == srcOffset + size) &&
-             (nextDstOffset == dstOffset + size);
+  LogicalResult
+  matchAndRewrite(ttir::GenericOp op, ttir::GenericOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    llvm::SmallVector<Attribute> coreRanges;
+    coreRanges.reserve(op.getThreads().size());
+    for (size_t i = 0; i < op.getThreads().size(); i++) {
+      coreRanges.emplace_back(
+          rewriter.getAttr<ttmetal::CoreRangeAttr>(op.getGrid()));
     }
+    rewriter.replaceOpWithNewOp<ttmetal::EnqueueProgramOp>(
+        op, op->getResultTypes(), op.getInputs(), op.getOutputs(),
+        op.getThreads(), rewriter.getArrayAttr(coreRanges),
+        rewriter.getArrayAttr({}));
+    return success();
   };
-
-  // This routine calculates the data movement for a tensor layout change by
-  // tracing the walk order of the src and dst affine maps.  The sample routine
-  // is just a helper function that iterates over the tensor shape and calls the
-  // lambda with the current index.  It walks the shape in innermost-major
-  // order. It also coalesces the noc transactions.
-  //
-  // The return value is a map of physical cores where each core has
-  // an associated list of noc reads/writes to be performed.
-  static llvm::MapVector<PhysicalCoreCoord, mlir::SmallVector<NocTx>>
-  calculateDataMovement(ArrayRef<int64_t> tensorShape, std::int64_t elemSize,
-                        AffineMap src, AffineMap dst, NocTx::Type type,
-                        std::int64_t dstCapacity) {
-    bool read = type == NocTx::Type::Read;
-    llvm::MapVector<PhysicalCoreCoord, mlir::SmallVector<NocTx>> txMap;
-    assert(src.getNumResults() == MemoryMapResultIdx::NumIndices);
-    assert(dst.getNumResults() == MemoryMapResultIdx::NumIndices);
-
-    ::ttmlir::utils::sample(
-        tensorShape, [&txMap, src, dst, elemSize, read, type,
-                      dstCapacity](ArrayRef<std::int64_t> index) {
-          SmallVector<int64_t> srcResults = src.compose(index);
-          SmallVector<int64_t> dstResults = dst.compose(index);
-          assert(srcResults.size() == src.getNumResults());
-          assert(dstResults.size() == dst.getNumResults());
-          PhysicalCoreCoord srcCoord(srcResults);
-          PhysicalCoreCoord dstCoord(dstResults);
-          std::int64_t srcOffset = srcResults.back() * elemSize;
-          std::int64_t dstOffset = dstResults.back() * elemSize;
-
-          SmallVector<NocTx> &txs = txMap[read ? dstCoord : srcCoord];
-          if (not txs.empty() &&
-              txs.back().isContiguous(read ? srcCoord : dstCoord, srcOffset,
-                                      dstOffset) &&
-              txs.back().size + elemSize <= dstCapacity) {
-            txs.back().size += elemSize;
-            txs.back().numElements++;
-          } else {
-            txs.push_back(NocTx(type, read ? srcCoord : dstCoord, srcOffset,
-                                dstOffset, elemSize, 1));
-          }
-        });
-
-    return txMap;
-  }
-
-  LogicalResult relayout(ttir::ToLayoutOp op, PatternRewriter &rewriter) const {
-    auto inputTy = mlir::cast<RankedTensorType>(op.getInput().getType());
-    auto outputTy = mlir::cast<RankedTensorType>(op.getType(0));
-    auto inputLayout = mlir::cast<tt::MetalLayoutAttr>(inputTy.getEncoding());
-    auto outputLayout = mlir::cast<tt::MetalLayoutAttr>(outputTy.getEncoding());
-    tt::DeviceAttr device = op.getDevice();
-    assert(device);
-    tt::SystemDescAttr systemDesc = op.getSystemDesc();
-    assert(systemDesc);
-    auto addressAlignment = systemDesc.getAddressAlignBytes(
-        /*inputLayout.getMemorySpace() issue #407*/);
-    assert(inputLayout.getPhysicalShape(inputTy.getShape()) ==
-               outputLayout.getPhysicalShape(outputTy.getShape()) &&
-           "Physical shapes must match for now");
-
-    // Shape that will be traversed when calculating the data movement between
-    // layouts.
-    SmallVector<int64_t> inputShape =
-        inputLayout.isTiled() ? inputLayout.getTiledShape(inputTy.getShape())
-                              : SmallVector<int64_t>(inputTy.getShape());
-    SmallVector<int64_t> outputShape =
-        outputLayout.isTiled() ? outputLayout.getTiledShape(outputTy.getShape())
-                               : SmallVector<int64_t>(outputTy.getShape());
-
-    assert(inputShape == outputShape && "Shapes must be identical");
-
-    // If tiles are reblocked, the linear maps must be identical.
-    assert(!(inputLayout.isTiled() && outputLayout.isTiled()) ||
-           inputLayout.getLinear() == outputLayout.getLinear());
-
-    // When the layouts are tiled, the linear maps are the identity maps.
-    // Reasoning behind this is that since it's already ensured that scalar
-    // linear maps identical, tensors can be viewed simply as bags of tiles
-    // omitting any affine complexity.
-    AffineMap inputLinearMap = inputLayout.isTiled()
-                                   ? inputLayout.getIdentityTileLinearMap()
-                                   : inputLayout.getLinear();
-    AffineMap outputLinearMap = outputLayout.isTiled()
-                                    ? outputLayout.getIdentityTileLinearMap()
-                                    : outputLayout.getLinear();
-
-    assert(inputLayout.getMemorySpace() == MemorySpace::DeviceL1 ||
-           outputLayout.getMemorySpace() == MemorySpace::DeviceL1 &&
-               "DRAM <-> DRAM is not supported yet");
-    NocTx::Type dataMovementType =
-        outputLayout.getMemorySpace() == MemorySpace::DeviceL1
-            ? NocTx::Type::Read
-            : NocTx::Type::Write;
-
-    AffineMap src = inputLayout.projectOnto(
-        inputLinearMap, device.getMemoryMap(inputLayout.getMemref(), 0));
-
-    AffineMap dst = outputLayout.projectOnto(
-        outputLinearMap, device.getMemoryMap(outputLayout.getMemref(), 0));
-
-    auto dm = calculateDataMovement(
-        inputShape, inputLayout.getElementSizeBytes(), src, dst,
-        dataMovementType, outputLayout.getMemrefSizeBytes());
-
-    auto noc0Attr =
-        rewriter.getAttr<ttkernel::NocConfigAttr>(ttkernel::NocIndex::Noc0);
-    SmallVector<Attribute> kernelConfigs(dm.size(), noc0Attr);
-    SmallVector<Attribute> coreRanges;
-    coreRanges.reserve(dm.size());
-    for (auto [coreCoord, txs] : dm) {
-      SmallVector<int64_t> offset = {coreCoord.y, coreCoord.x};
-      SmallVector<int64_t> size = {1, 1};
-      coreRanges.push_back(
-          rewriter.getAttr<ttmetal::CoreRangeAttr>(offset, size));
-    };
-    std::int64_t inputBaseAddress = lookupAddress(op.getInput());
-    std::int64_t outputBaseAddress = lookupAddress(op.getOutput());
-
-    auto metalEnqueueProgram = rewriter.create<ttmetal::EnqueueProgramOp>(
-        op.getLoc(), SmallVector<Type>({outputTy}),
-        SmallVector<Value>({op.getInput()}),
-        SmallVector<Value>({op.getOutput()}), rewriter.getArrayAttr(coreRanges),
-        rewriter.getArrayAttr(kernelConfigs), kernelConfigs.size());
-
-    PhysicalCoreCoordMapping physicalCoordMapping =
-        PhysicalCoreCoordMapping::getMemorySpaceMapping(
-            device.getChipIds(), systemDesc.getChipDescs(),
-            dataMovementType == NocTx::Type::Read
-                ? inputLayout.getMemorySpace()
-                : outputLayout.getMemorySpace());
-
-    int regIdx = 0;
-    for (auto [dstCoord, transactions] : dm) {
-      Block *block =
-          rewriter.createBlock(&metalEnqueueProgram.getRegion(regIdx++));
-      createDataMovementThread(op->getLoc(), block, inputBaseAddress,
-                               outputBaseAddress, transactions,
-                               physicalCoordMapping, addressAlignment);
-      OpBuilder endBuilder = OpBuilder::atBlockEnd(block);
-      endBuilder.create<ttkernel::ReturnOp>(op->getLoc());
-    }
-    rewriter.replaceOp(op, metalEnqueueProgram);
-
-    return llvm::success();
-  }
-
-  static void createDataMovementThread(
-      Location loc, Block *block, int64_t inputBaseAddress,
-      int64_t outputBaseAddress, ArrayRef<NocTx> transactions,
-      const PhysicalCoreCoordMapping &physicalCoordMapping,
-      std::int64_t addressAlignment, Value *inputCB = nullptr) {
-
-    assert(inputBaseAddress);
-    assert(outputBaseAddress);
-    assert(inputBaseAddress % addressAlignment == 0);
-    assert(outputBaseAddress % addressAlignment == 0);
-    OpBuilder nocBuilder = OpBuilder::atBlockEnd(block);
-    NocTx::Type type = transactions.front().type;
-
-    // each 'entry' is {I32:$dst, I32:$src, I32:$size, I32:<$y,$x>,
-    // (I32:$numElements if have inputCB)}:
-    int32_t const entrySize = 4 + (inputCB != nullptr);
-
-    // convert 'transactions' into compile time 'NocTransactionsTableOp'
-    // parameters:
-
-    llvm::SmallVector<int32_t, 48> entries;
-    for (auto const &tx : transactions) {
-      // all transactions are of the same read/write type:
-      assert(tx.type == type);
-
-      assert(tx.srcOffset % addressAlignment == 0);
-      assert(tx.dstOffset % addressAlignment == 0);
-      assert(tx.size % addressAlignment == 0);
-
-      entries.emplace_back(outputBaseAddress + tx.dstOffset);
-      entries.emplace_back(inputBaseAddress + tx.srcOffset);
-      entries.emplace_back(tx.size);
-
-      auto const [yPhys, xPhys] = physicalCoordMapping[tx.coreCoord];
-      entries.emplace_back((yPhys << 16) | xPhys); // x:lo, y:hi
-
-      if (inputCB != nullptr) {
-        entries.emplace_back(tx.numElements);
-      }
-    }
-
-    mlir::IntegerType i32Type = nocBuilder.getI32Type();   // for 'scf' ops
-    mlir::IndexType indexType = nocBuilder.getIndexType(); // for 'memref' ops
-
-    auto entriesAttr = nocBuilder.getDenseI32ArrayAttr(entries);
-    auto tableType = MemRefType::get(
-        {static_cast<int32_t>(entries.size() / entrySize), entrySize}, i32Type,
-        AffineMap::getMultiDimIdentityMap(2, nocBuilder.getContext()));
-    auto tableOp = nocBuilder.create<ttkernel::NocTransactionsTableOp>(
-        loc, tableType, entriesAttr);
-
-    auto i32 = [&](int32_t value) {
-      return nocBuilder.create<arith::ConstantOp>(
-          loc, nocBuilder.getI32IntegerAttr(value));
-    };
-
-    auto index = [&](int64_t value) {
-      return nocBuilder.create<arith::ConstantOp>(
-          loc, nocBuilder.getIndexAttr(value));
-    };
-
-    auto coordWidth = i32(16);
-    auto coordMask = i32(0xFFFF);
-
-    auto loop = nocBuilder.create<scf::ForOp>(loc, i32(0),
-                                              i32(transactions.size()), i32(1));
-    nocBuilder.setInsertionPointToStart(loop.getBody());
-    {
-      // memref.load/store requires 'index'-typed indexing, but 'scf.for' can't
-      // use that, so make use of arith index casting:
-
-      auto entry = nocBuilder.create<arith::IndexCastOp>(
-          loc, indexType, loop.getInductionVar());
-
-      int32_t slot = 0;
-
-      std::array<Value, 2> vs{entry, index(slot++)};
-      auto dst = nocBuilder.create<memref::LoadOp>(loc, tableOp, vs);
-      vs[1] = index(slot++);
-      auto src = nocBuilder.create<memref::LoadOp>(loc, tableOp, vs);
-
-      vs[1] = index(slot++);
-      auto size = nocBuilder.create<memref::LoadOp>(loc, tableOp, vs);
-
-      vs[1] = index(slot++);
-      auto xy =
-          nocBuilder.create<memref::LoadOp>(loc, tableOp, vs)->getResult(0);
-
-      // split 'xy' into an <x,y> pair:
-
-      auto x = nocBuilder.create<arith::AndIOp>(loc, xy, coordMask);
-      auto y = nocBuilder.create<arith::ShRUIOp>(loc, xy, coordWidth);
-
-      // emit read/write op, bracketed by CB ops if needed:
-
-      auto rw = [&] {
-        switch (type) {
-        case NocTx::Type::Read: {
-          auto srcRemote =
-              nocBuilder.create<ttkernel::GetNocAddrXYOp>(loc, x, y, src)
-                  .getResult();
-          nocBuilder.create<ttkernel::NocAsyncReadOp>(loc, srcRemote, dst,
-                                                      size);
-        } break;
-        case NocTx::Type::Write: {
-          auto dstRemote =
-              nocBuilder.create<ttkernel::GetNocAddrXYOp>(loc, x, y, dst)
-                  .getResult();
-          nocBuilder.create<ttkernel::NocAsyncWriteOp>(loc, src, dstRemote,
-                                                       size);
-        } break;
-        }
-      };
-
-      if (!inputCB) {
-        rw();
-      } else {
-        vs[1] = index(slot++);
-        auto numElements = nocBuilder.create<memref::LoadOp>(loc, tableOp, vs);
-        nocBuilder.create<ttkernel::CBReserveBackOp>(loc, *inputCB,
-                                                     numElements);
-        rw();
-        nocBuilder.create<ttkernel::NocAsyncReadBarrierOp>(loc);
-        nocBuilder.create<ttkernel::CBPushBackOp>(loc, *inputCB, numElements);
-      }
-    }
-    nocBuilder.setInsertionPointAfter(loop);
-
-    if (!inputCB) {
-      switch (type) {
-      case NocTx::Type::Read: {
-        nocBuilder.create<ttkernel::NocAsyncReadBarrierOp>(loc);
-      } break;
-      case NocTx::Type::Write: {
-        nocBuilder.create<ttkernel::NocAsyncWriteBarrierOp>(loc);
-      } break;
-      }
-    }
-  }
-
-  LogicalResult reformat(ttir::ToLayoutOp op, PatternRewriter &rewriter) const {
-    auto inputTy = mlir::cast<RankedTensorType>(op.getInput().getType());
-    auto outputTy = mlir::cast<RankedTensorType>(op.getType(0));
-    auto inputLayout = mlir::cast<tt::MetalLayoutAttr>(inputTy.getEncoding());
-    auto outputLayout = mlir::cast<tt::MetalLayoutAttr>(outputTy.getEncoding());
-    bool shouldTilize = not inputLayout.isTiled() && outputLayout.isTiled();
-    bool shouldUntilize = inputLayout.isTiled() && not outputLayout.isTiled();
-    assert(shouldTilize ^ shouldUntilize);
-    assert(inputLayout.getGrid() == outputLayout.getGrid());
-
-    // Ensure tt-mlir/tt-metal agree on number, and set UnpackToDestMode per CB
-    uint32_t chipNumCBs = op.getSystemDesc().getChipDescs()[0].getNumCBs();
-    constexpr uint32_t kNumCBs = 1 + ttkernel::getMaxEnumValForCBPort();
-    assert(chipNumCBs == kNumCBs && "Mismatch between tt-mlir and tt-metal "
-                                    "number of CBs");
-
-    llvm::SmallVector<ttkernel::UnpackToDestMode, kNumCBs> unpackToDestModes(
-        kNumCBs, ttkernel::UnpackToDestMode::Default);
-
-    auto tensixAttr = rewriter.getAttr<ttkernel::TensixConfigAttr>(
-        ttkernel::MathFidelity::HiFi4, false, false, unpackToDestModes);
-    SmallVector<Attribute> kernelConfigs = {tensixAttr};
-    SmallVector<Attribute> coreRanges = {
-        rewriter.getAttr<ttmetal::CoreRangeAttr>(inputLayout.getGrid()),
-    };
-
-    auto metalEnqueueProgram = rewriter.create<ttmetal::EnqueueProgramOp>(
-        op.getLoc(), SmallVector<Type>({outputTy}),
-        SmallVector<Value>({op.getInput()}),
-        SmallVector<Value>({op.getOutput()}), rewriter.getArrayAttr(coreRanges),
-        rewriter.getArrayAttr(kernelConfigs), kernelConfigs.size());
-
-    std::int64_t inputBaseAddress = lookupAddress(op.getInput());
-    std::int64_t outputBaseAddress = lookupAddress(op.getOutput());
-    Block *tensixBlock =
-        rewriter.createBlock(&metalEnqueueProgram.getRegion(0));
-    OpBuilder tensixBuilder(tensixBlock, tensixBlock->begin());
-    uint64_t pageSize = inputLayout.isTiled()
-                            ? inputLayout.getElementSizeBytes()
-                            : outputLayout.getElementSizeBytes();
-    Type inputCBTy = rewriter.getType<ttkernel::CBType>(
-        ttkernel::CBPort::In0, inputBaseAddress,
-        mlir::cast<MemRefType>(inputLayout.getMemref()), pageSize,
-        /*num_buffers*/ 1);
-    Type outputCBTy = rewriter.getType<ttkernel::CBType>(
-        ttkernel::CBPort::Out0, outputBaseAddress,
-        mlir::cast<MemRefType>(outputLayout.getMemref()), pageSize,
-        /*num_buffers*/ 1);
-    tensixBlock->addArgument(inputCBTy, op.getLoc());
-    tensixBlock->addArgument(outputCBTy, op.getLoc());
-
-    llvm::ArrayRef<int64_t> shardTileShape =
-        (shouldTilize ? outputLayout.getMemref().getShape()
-                      : inputLayout.getMemref().getShape());
-
-    assert(shardTileShape.size() >= 2 && "Tile shape rank must be at least 2");
-
-    // How many tiles should kernel tilize in one block.
-    arith::ConstantOp numTilesPerBlock =
-        tensixBuilder.create<arith::ConstantOp>(
-            op.getLoc(), tensixBuilder.getI32Type(),
-            tensixBuilder.getI32IntegerAttr(shardTileShape.back()));
-
-    if (shouldTilize) {
-      tensixBuilder.create<ttkernel::TilizeInitOp>(
-          op.getLoc(), tensixBlock->getArgument(0), numTilesPerBlock,
-          tensixBlock->getArgument(1));
-    } else {
-      tensixBuilder.create<ttkernel::UntilizeInitOp>(
-          op.getLoc(), tensixBlock->getArgument(0),
-          tensixBlock->getArgument(1));
-    }
-
-    uint64_t shardTileVolume = 1;
-    for (int64_t dim : shardTileShape) {
-      shardTileVolume *= dim;
-    }
-    const uint64_t numBlocks = shardTileVolume / shardTileShape.back();
-
-    for (uint iblock = 0; iblock < numBlocks; ++iblock) {
-      if (shouldTilize) {
-        tensixBuilder.create<ttkernel::TilizeBlockOp>(
-            op.getLoc(), tensixBlock->getArgument(0), numTilesPerBlock,
-            tensixBlock->getArgument(1));
-      } else {
-        tensixBuilder.create<ttkernel::UntilizeBlockOp>(
-            op.getLoc(), tensixBlock->getArgument(0), numTilesPerBlock,
-            tensixBlock->getArgument(1));
-      }
-      tensixBuilder.create<ttkernel::CBPopFrontOp>(
-          op.getLoc(), tensixBlock->getArgument(0), numTilesPerBlock);
-      tensixBuilder.create<ttkernel::CBPushBackOp>(
-          op.getLoc(), tensixBlock->getArgument(1), numTilesPerBlock);
-    }
-
-    tensixBuilder.create<ttkernel::ReturnOp>(op.getLoc());
-
-    rewriter.replaceOp(op, metalEnqueueProgram);
-
-    return success();
-  }
-
-  LogicalResult matchAndRewrite(ttir::ToLayoutOp op,
-                                PatternRewriter &rewriter) const final {
-    auto inputTy = mlir::cast<RankedTensorType>(op.getInput().getType());
-    auto outputTy = mlir::cast<RankedTensorType>(op.getType(0));
-    if (not inputTy.getEncoding() || not outputTy.getEncoding()) {
-      return failure();
-    }
-    assert(inputTy.getShape() == outputTy.getShape());
-    assert(mlir::isa<tt::MetalLayoutAttr>(inputTy.getEncoding()));
-    assert(mlir::isa<tt::MetalLayoutAttr>(outputTy.getEncoding()));
-    auto inputLayout = mlir::cast<tt::MetalLayoutAttr>(inputTy.getEncoding());
-    auto outputLayout = mlir::cast<tt::MetalLayoutAttr>(outputTy.getEncoding());
-
-    auto components = op.compoundComponents();
-    bool isCompound = (static_cast<int>(components.isLayoutChange) +
-                       static_cast<int>(components.isGridChange ||
-                                        components.isMemorySpaceChange) +
-                       static_cast<int>(components.isFormatChange)) > 1;
-    assert(!isCompound && "Only one change is allowed");
-
-    assert(!isCompound && "Only one change is allowed");
-    if (components.isMemorySpaceChange) {
-      if (inputLayout.isSystemMemorySpace()) {
-        assert(outputLayout.isDeviceMemorySpace());
-        assert(false && "System memory to device memory is not supported yet");
-      } else if (outputLayout.isSystemMemorySpace()) {
-        assert(inputLayout.isDeviceMemorySpace());
-        rewriter.replaceOpWithNewOp<ttmetal::EnqueueReadBufferOp>(
-            op, outputTy, op.getInput(), op.getOutput());
-      } else {
-        return relayout(op, rewriter);
-      }
-    } else if (components.isLayoutChange || components.isGridChange) {
-      return relayout(op, rewriter);
-    } else {
-      assert(components.isFormatChange);
-      return reformat(op, rewriter);
-    }
-    return failure();
-  }
 };
 } // namespace
-
 namespace {
-class TTIRToTTMetalAllocRewriter : public OpRewritePattern<ttir::AllocOp> {
+class MemrefAllocRewriter : public OpConversionPattern<memref::AllocOp> {
 public:
-  using OpRewritePattern<ttir::AllocOp>::OpRewritePattern;
+  using OpConversionPattern<memref::AllocOp>::OpConversionPattern;
 
-  LogicalResult matchAndRewrite(ttir::AllocOp op,
-                                PatternRewriter &rewriter) const final {
-    rewriter.replaceOpWithNewOp<ttmetal::CreateBufferOp>(
-        op, op.getType(), op.getAddress(), op.getSize(), op.getMemorySpace());
+  LogicalResult
+  matchAndRewrite(memref::AllocOp op, memref::AllocOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+
+    auto address = op->getAttr("address")
+                       ? op->getAttrOfType<IntegerAttr>("address")
+                       : rewriter.getI64IntegerAttr(
+                             1000); // TODO(#1909): arbitrary default for now,
+                                    // remove when allocate pass is implemented
+    assert(op.getMemref().getType().getMemorySpace() &&
+           "No memref memroy space found, failing.");
+    assert(mlir::isa<TileType>(op.getMemref().getType().getElementType()) &&
+           "Expected memref to have tile element type, failing.");
+    auto memrefType = op.getMemref().getType();
+    auto size =
+        mlir::cast<TileType>(memrefType.getElementType()).getSizeBytes() *
+        memrefType.getNumElements();
+    auto memorySpace =
+        mlir::cast<tt::MemorySpaceAttr>(memrefType.getMemorySpace());
+    auto createBufferOp = rewriter.create<ttmetal::CreateBufferOp>(
+        op->getLoc(), memrefType, address.getInt(), size,
+        memorySpace.getValue());
+    rewriter.replaceOp(op, createBufferOp);
+
     return success();
-  }
-};
-} // namespace
-
-namespace {
-class TTIRToTTMetalDeallocRewriter : public OpRewritePattern<ttir::DeallocOp> {
-public:
-  using OpRewritePattern<ttir::DeallocOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(ttir::DeallocOp op,
-                                PatternRewriter &rewriter) const final {
-    rewriter.replaceOpWithNewOp<ttmetal::DeallocateBufferOp>(op,
-                                                             op.getResult());
-    return success();
-  }
-};
-} // namespace
-
-namespace {
-class TTIRToTTMetalFillRewriter : public OpRewritePattern<ttir::FillOp> {
-public:
-  using OpRewritePattern<ttir::FillOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(ttir::FillOp op,
-                                PatternRewriter &rewriter) const final {
-    rewriter.replaceOpWithNewOp<ttmetal::EnqueueWriteBufferOp>(
-        op, op.getResult().getType(), op.getOutput(), op.getValue());
-    return success();
-  }
+  };
 };
 } // namespace
 
@@ -591,10 +74,7 @@ namespace mlir::tt {
 void populateTTIRToTTMetalPatterns(MLIRContext *ctx,
                                    RewritePatternSet &patterns,
                                    TypeConverter & /*typeConverter*/) {
-  patterns.add<ttmetal::TTIRToTTMetalLayoutRewriter,
-               ttmetal::TTIRToTTMetalAllocRewriter,
-               ttmetal::TTIRToTTMetalDeallocRewriter,
-               ttmetal::TTIRToTTMetalFillRewriter>(ctx);
+  patterns.add<ttmetal::TTIRGenericRewriter, ttmetal::MemrefAllocRewriter>(ctx);
 }
 
 } // namespace mlir::tt

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetalPass.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetalPass.cpp
@@ -4,19 +4,25 @@
 
 #include "ttmlir/Conversion/TTIRToTTMetal/TTIRToTTMetal.h"
 
+#include "ttmlir/Dialect/TT/IR/TT.h"
+#include "ttmlir/Dialect/TT/IR/TTOps.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIR.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.h"
+#include "ttmlir/Dialect/TTKernel/IR/TTKernel.h"
+#include "ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.h"
+#include "ttmlir/Dialect/TTMetal/IR/TTMetal.h"
+
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Func/Transforms/FuncConversions.h"
 #include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinDialect.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/DialectConversion.h"
-#include "ttmlir/Dialect/TTIR/IR/TTIR.h"
-#include "ttmlir/Dialect/TTKernel/IR/TTKernel.h"
-#include "ttmlir/Dialect/TTMetal/IR/TTMetal.h"
-#include <mlir/Dialect/Func/IR/FuncOps.h>
 
 using namespace mlir;
 using namespace mlir::tt;
@@ -35,23 +41,26 @@ struct ConvertTTIRToTTMetal
   void runOnOperation() final {
     mlir::ConversionTarget target(getContext());
     target.addLegalDialect<BuiltinDialect>();
+    target.addLegalDialect<arith::ArithDialect>();
     target.addLegalDialect<func::FuncDialect>();
+    target.addLegalDialect<memref::MemRefDialect>();
     target.addLegalDialect<ttmetal::TTMetalDialect>();
     target.addLegalDialect<ttkernel::TTKernelDialect>();
-    target.addIllegalDialect<ttir::TTIRDialect>();
-    target.addIllegalDialect<arith::ArithDialect>();
+    target.addLegalDialect<scf::SCFDialect>();
     target.addIllegalDialect<math::MathDialect>();
-    target.addIllegalDialect<scf::SCFDialect>();
+    target.addIllegalDialect<ttir::TTIRDialect>();
+
+    target.addLegalOp<tt::DeviceOp>();
+    target.addLegalOp<ttir::StreamLayoutOp>();
+    target.addLegalOp<ttir::ViewLayoutOp>();
+    target.addIllegalOp<memref::AllocOp>();
 
     TypeConverter typeConverter;
-    // All types map 1:1.
     typeConverter.addConversion([](Type type) { return type; });
 
     RewritePatternSet patterns(&getContext());
     populateTTIRToTTMetalPatterns(&getContext(), patterns, typeConverter);
 
-    // Apply full conversion
-    //
     if (failed(
             applyFullConversion(getOperation(), target, std::move(patterns)))) {
       signalPassFailure();

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetalPass.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetalPass.cpp
@@ -4,12 +4,10 @@
 
 #include "ttmlir/Conversion/TTIRToTTMetal/TTIRToTTMetal.h"
 
-#include "ttmlir/Dialect/TT/IR/TT.h"
 #include "ttmlir/Dialect/TT/IR/TTOps.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIR.h"
-#include "ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
 #include "ttmlir/Dialect/TTKernel/IR/TTKernel.h"
-#include "ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.h"
 #include "ttmlir/Dialect/TTMetal/IR/TTMetal.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetalPass.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetalPass.cpp
@@ -51,7 +51,11 @@ struct ConvertTTIRToTTMetal
     target.addLegalOp<tt::DeviceOp>();
     target.addLegalOp<ttir::StreamLayoutOp>();
     target.addLegalOp<ttir::ViewLayoutOp>();
-    target.addIllegalOp<memref::AllocOp>();
+
+    target.addDynamicallyLegalOp<memref::AllocOp>([&](memref::AllocOp op) {
+      return !mlir::dyn_cast_if_present<tt::MemorySpaceAttr>(
+          op.getMemref().getType().getMemorySpace());
+    });
 
     TypeConverter typeConverter;
     typeConverter.addConversion([](Type type) { return type; });

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -863,18 +863,18 @@ LogicalResult emitOpRegionAsCpp(Region *region, llvm::raw_ostream &os,
 LogicalResult
 emitEnqueueProgramOpRegionsAsCpp(ttmetal::EnqueueProgramOp enqueueProgramOp,
                                  llvm::SmallVector<std::string> &cppStrings) {
-  assert(cppStrings.size() == enqueueProgramOp.getNumRegions() &&
-         "cppStrings size must match number of regions");
+  // assert(cppStrings.size() == enqueueProgramOp.getNumRegions() &&
+  //        "cppStrings size must match number of regions");
 
-  for (auto &reg : enqueueProgramOp->getRegions()) {
-    auto kernelConfig = mlir::cast<ttkernel::KernelConfigInterface>(
-        enqueueProgramOp.getKernelConfigs()[reg.getRegionNumber()]);
-    if (emitOpRegionAsCpp(&reg, cppStrings[reg.getRegionNumber()],
-                          kernelConfig.getThreadType())
-            .failed()) {
-      return llvm::failure();
-    }
-  }
+  // for (auto &reg : enqueueProgramOp->getRegions()) {
+  //   auto kernelConfig = mlir::cast<ttkernel::KernelConfigInterface>(
+  //       enqueueProgramOp.getKernelConfigs()[reg.getRegionNumber()]);
+  //   if (emitOpRegionAsCpp(&reg, cppStrings[reg.getRegionNumber()],
+  //                         kernelConfig.getThreadType())
+  //           .failed()) {
+  //     return llvm::failure();
+  //   }
+  // }
 
   return success();
 }

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -863,6 +863,13 @@ LogicalResult emitOpRegionAsCpp(Region *region, llvm::raw_ostream &os,
 LogicalResult
 emitEnqueueProgramOpRegionsAsCpp(ttmetal::EnqueueProgramOp enqueueProgramOp,
                                  llvm::SmallVector<std::string> &cppStrings) {
+
+  // TODO(jdesousa #2960): This code is commented to allow for compilation after
+  // the new TTMetal lowering flow was implemented. This needs to be replaced
+  // with lowering for new enqueue program semantics.
+  llvm_unreachable("EnqueueProgramOp to C++ is not yet implemented for new D2M "
+                   "lowering flow.");
+
   // assert(cppStrings.size() == enqueueProgramOp.getNumRegions() &&
   //        "cppStrings size must match number of regions");
 

--- a/lib/Dialect/TT/IR/TTOpsTypes.cpp
+++ b/lib/Dialect/TT/IR/TTOpsTypes.cpp
@@ -1082,9 +1082,19 @@ mlir::AffineMap DeviceAttr::getMemoryMap(MemRefType memrefType, size_t pageSize,
 
 size_t DeviceAttr::getMemrefSizeBytes(MemRefType memrefType,
                                       size_t pageSize) const {
-  // TODO(nsmith): We need to implement this somehow
-  assert(false);
-  return 0;
+  assert(memrefType.getRank() % 2 == 0);
+  mlir::Type elementType = memrefType.getElementType();
+  uint64_t size = 0;
+  if (mlir::isa<TileType>(elementType)) {
+    auto tileType = mlir::cast<TileType>(elementType);
+    size = tileType.getSizeBytes();
+  } else {
+    size = elementType.getIntOrFloatBitWidth() / 8;
+  }
+
+  auto shardShape = memrefType.getShape().drop_front(memrefType.getRank() / 2);
+  return std::accumulate(shardShape.begin(), shardShape.end(), size,
+                         std::multiplies<uint64_t>());
 }
 
 // Sample the last index in the tensor to get the last addressable element of

--- a/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
+++ b/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
@@ -65,11 +65,12 @@ namespace mlir::tt::ttmetal {
   // Assert inputs/outputs device memspace
 
   for (auto operand : getOperands()) {
-    ::mlir::MemRefType outputTy = mlir::cast<MemRefType>(operand.getType());
+    ::mlir::MemRefType operandType = mlir::cast<MemRefType>(operand.getType());
     MemorySpaceAttr memSpaceAttr =
-        mlir::cast<MemorySpaceAttr>(outputTy.getMemorySpace());
+        mlir::cast<MemorySpaceAttr>(operandType.getMemorySpace());
     if (not isDeviceMemorySpace(memSpaceAttr.getValue())) {
-      return emitOpError("Input tensor must be in device memory space");
+      return emitOpError(
+          "Operand tensor to EnqueueProgramOp must be in device memory space");
     }
   }
   return success();

--- a/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
+++ b/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
@@ -27,8 +27,8 @@ namespace mlir::tt::ttmetal {
 ::mlir::LogicalResult EnqueueReadBufferOp::verify() {
   ::mlir::MemRefType outputTy = getOutput().getType();
   MemorySpaceAttr memSpaceAttr =
-      mlir::cast<MemorySpaceAttr>(outputTy.getMemorySpace());
-  if (not isSystemMemorySpace(memSpaceAttr.getValue())) {
+      mlir::dyn_cast_if_present<MemorySpaceAttr>(outputTy.getMemorySpace());
+  if (memSpaceAttr && not isSystemMemorySpace(memSpaceAttr.getValue())) {
     return emitOpError("Output tensor must be in system memory space");
   }
   return success();

--- a/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
+++ b/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
@@ -15,43 +15,31 @@
 namespace mlir::tt::ttmetal {
 
 ::mlir::LogicalResult EnqueueWriteBufferOp::verify() {
-  ::mlir::RankedTensorType outputTy = getOutput().getType();
-  auto outputLayout = mlir::dyn_cast_if_present<mlir::tt::MetalLayoutAttr>(
-      outputTy.getEncoding());
-  if (not outputLayout) {
-    return emitOpError("Input tensor missing layout attribute");
-  }
-  if (not outputLayout.isDeviceMemorySpace()) {
+  ::mlir::MemRefType outputTy = getOutput().getType();
+  MemorySpaceAttr memSpaceAttr =
+      mlir::cast<MemorySpaceAttr>(outputTy.getMemorySpace());
+  if (not isDeviceMemorySpace(memSpaceAttr.getValue())) {
     return emitOpError("Output tensor must be in device memory space");
   }
   return success();
 }
 
 ::mlir::LogicalResult EnqueueReadBufferOp::verify() {
-  ::mlir::RankedTensorType outputTy = getOutput().getType();
-  auto outputLayout = mlir::dyn_cast_if_present<mlir::tt::MetalLayoutAttr>(
-      outputTy.getEncoding());
-  if (not outputLayout) {
-    return emitOpError("Input tensor missing layout attribute");
-  }
-  if (not outputLayout.isSystemMemorySpace()) {
+  ::mlir::MemRefType outputTy = getOutput().getType();
+  MemorySpaceAttr memSpaceAttr =
+      mlir::cast<MemorySpaceAttr>(outputTy.getMemorySpace());
+  if (not isSystemMemorySpace(memSpaceAttr.getValue())) {
     return emitOpError("Output tensor must be in system memory space");
   }
   return success();
 }
 
 ::mlir::LogicalResult CreateBufferOp::verify() {
-  auto layout = mlir::dyn_cast_if_present<mlir::tt::MetalLayoutAttr>(
-      getResult().getType().getEncoding());
-  if (not layout) {
-    return emitOpError("Result type missing layout attribute");
-  }
-
   if (getSize() == 0) {
     return emitOpError("Alloc size must be non-zero");
   }
 
-  auto memref = layout.getMemref();
+  auto memref = getResult().getType();
   auto memspace =
       mlir::cast<mlir::tt::MemorySpaceAttr>(memref.getMemorySpace()).getValue();
   if (memspace != getMemorySpace()) {
@@ -75,24 +63,13 @@ namespace mlir::tt::ttmetal {
 
 ::mlir::LogicalResult EnqueueProgramOp::verify() {
   // Assert inputs/outputs device memspace
-  for (auto operand : getOperands()) {
-    auto layout = mlir::dyn_cast_if_present<mlir::tt::MetalLayoutAttr>(
-        mlir::cast<mlir::RankedTensorType>(operand.getType()).getEncoding());
-    if (not layout) {
-      return emitOpError("Input tensor missing layout attribute");
-    }
-    if (not layout.isDeviceMemorySpace()) {
-      return emitOpError("Input tensor must be in device memory space");
-    }
-  }
 
-  // Assert block inputs are CBs
-  for (auto &region : getRegions()) {
-    for (auto arg : region.getArguments()) {
-      if (!mlir::isa<ttkernel::CBType>(arg.getType()) &&
-          !mlir::isa<ttkernel::SemaphoreType>(arg.getType())) {
-        return emitOpError("Block inputs must be CBType or SemType");
-      }
+  for (auto operand : getOperands()) {
+    ::mlir::MemRefType outputTy = mlir::cast<MemRefType>(operand.getType());
+    MemorySpaceAttr memSpaceAttr =
+        mlir::cast<MemorySpaceAttr>(outputTy.getMemorySpace());
+    if (not isDeviceMemorySpace(memSpaceAttr.getValue())) {
+      return emitOpError("Input tensor must be in device memory space");
     }
   }
   return success();

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -71,7 +71,10 @@ void createTTIRToTTMetalBackendPipeline(
   pm.addPass(ttir::createTTIRGenericGenerateLoops());
   createOptimizationPasses(pm);
   pm.addPass(ttir::createTTIRGenericRegionsToFuncs());
-  pm.addPass(tt::createConvertTTIRToTTMetalPass());
+  createOptimizationPasses(pm);
+  pm.addPass(createConvertTTIRToTTMetalPass());
+  pm.addPass(createConvertTTKernelToEmitC());
+  pm.addPass(mlir::createCanonicalizerPass());
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -73,7 +73,6 @@ void createTTIRToTTMetalBackendPipeline(
   pm.addPass(ttir::createTTIRGenericRegionsToFuncs());
   createOptimizationPasses(pm);
   pm.addPass(createConvertTTIRToTTMetalPass());
-  pm.addPass(createConvertTTKernelToEmitC());
   pm.addPass(mlir::createCanonicalizerPass());
 }
 

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -71,7 +71,6 @@ void createTTIRToTTMetalBackendPipeline(
   pm.addPass(ttir::createTTIRGenericGenerateLoops());
   createOptimizationPasses(pm);
   pm.addPass(ttir::createTTIRGenericRegionsToFuncs());
-  createOptimizationPasses(pm);
   pm.addPass(createConvertTTIRToTTMetalPass());
   pm.addPass(mlir::createCanonicalizerPass());
 }

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -71,6 +71,7 @@ void createTTIRToTTMetalBackendPipeline(
   pm.addPass(ttir::createTTIRGenericGenerateLoops());
   createOptimizationPasses(pm);
   pm.addPass(ttir::createTTIRGenericRegionsToFuncs());
+  pm.addPass(tt::createConvertTTIRToTTMetalPass());
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -342,6 +342,13 @@ static std::shared_ptr<void> translateModuleToFlatbuffer(
             emitEnqueueProgramOpRegionsAsCpp(enqueueProgramOp, cppKernels);
         assert(success.succeeded() &&
                "failed to emit enqueue program op regions as cpp");
+
+        // TODO(jdesousa #2960): This code is commented to allow for compilation
+        // after the new TTMetal lowering flow was implemented. This needs to be
+        // replaced with lowering for new enqueue program semantics.
+        llvm_unreachable(
+            "EnqueueProgramOp to Flatbuffer is not yet implemented for "
+            "new D2M lowering flow.");
         // for (auto &region : enqueueProgramOp.getRegions()) {
         //   std::vector<::tt::target::Dim2dRange> coreRangeSet = {
         //       toFlatbuffer(mlir::cast<CoreRangeAttr>(

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -430,11 +430,11 @@ static std::shared_ptr<void> translateModuleToFlatbuffer(
       } else if (auto enqueueWriteBufferOp =
                      dyn_cast_if_present<tt::ttmetal::EnqueueWriteBufferOp>(op);
                  enqueueWriteBufferOp) {
-        auto [hostBufferType, hostBuffer] =
-            hostBufferToFlatbuffer(cache, enqueueWriteBufferOp.getValue());
         cqBuilder.appendCommand(
             ::tt::target::metal::CreateEnqueueWriteBufferCommand(
-                fbb, hostBufferType, hostBuffer,
+                fbb,
+                cache.at<::tt::target::metal::TensorRef>(
+                    getOperandThroughDPSOps(enqueueWriteBufferOp.getInput())),
                 cache.at<::tt::target::metal::TensorRef>(
                     getOperandThroughDPSOps(enqueueWriteBufferOp.getOutput()))),
             op);

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -342,52 +342,54 @@ static std::shared_ptr<void> translateModuleToFlatbuffer(
             emitEnqueueProgramOpRegionsAsCpp(enqueueProgramOp, cppKernels);
         assert(success.succeeded() &&
                "failed to emit enqueue program op regions as cpp");
-        for (auto &region : enqueueProgramOp.getRegions()) {
-          std::vector<::tt::target::Dim2dRange> coreRangeSet = {
-              toFlatbuffer(mlir::cast<CoreRangeAttr>(
-                  enqueueProgramOp.getCoreRanges()[region.getRegionNumber()]))};
-          std::vector<::flatbuffers::Offset<::tt::target::metal::CBRef>> cbs;
-          size_t argNumber = 0;
-          std::vector<::tt::target::metal::RuntimeArg> runtime_args_type;
-          std::vector<::flatbuffers::Offset<void>> runtime_args;
-          for (auto arg : region.getArguments()) {
-            if (mlir::isa<ttkernel::CBType>(arg.getType())) {
-              auto cbType = mlir::cast<ttkernel::CBType>(arg.getType());
-              auto cbDesc = cache.getOrCreate(cbType, cbTypeToFlatbuffer);
-              auto tensorRef =
-                  argNumber >= operands.size() ? 0 : operands[argNumber++];
-              cbs.push_back(::tt::target::metal::CreateCBRef(
-                  fbb, cache.global_id++, tensorRef, cbType.getAddress(),
-                  cbDesc));
-            } else if (mlir::isa<ttkernel::SemaphoreType>(arg.getType())) {
-              auto semType = mlir::cast<ttkernel::SemaphoreType>(arg.getType());
-              auto [runtime_arg_type, runtime_arg] =
-                  toFlatbuffer(cache, semType);
-              runtime_args_type.push_back(runtime_arg_type);
-              runtime_args.push_back(runtime_arg);
-            } else {
-              llvm_unreachable(
-                  "Block arguments must be either CBType or SemaphoreType");
-            }
-          }
+        // for (auto &region : enqueueProgramOp.getRegions()) {
+        //   std::vector<::tt::target::Dim2dRange> coreRangeSet = {
+        //       toFlatbuffer(mlir::cast<CoreRangeAttr>(
+        //           enqueueProgramOp.getCoreRanges()[region.getRegionNumber()]))};
+        //   std::vector<::flatbuffers::Offset<::tt::target::metal::CBRef>> cbs;
+        //   size_t argNumber = 0;
+        //   std::vector<::tt::target::metal::RuntimeArg> runtime_args_type;
+        //   std::vector<::flatbuffers::Offset<void>> runtime_args;
+        //   for (auto arg : region.getArguments()) {
+        //     if (mlir::isa<ttkernel::CBType>(arg.getType())) {
+        //       auto cbType = mlir::cast<ttkernel::CBType>(arg.getType());
+        //       auto cbDesc = cache.getOrCreate(cbType, cbTypeToFlatbuffer);
+        //       auto tensorRef =
+        //           argNumber >= operands.size() ? 0 : operands[argNumber++];
+        //       cbs.push_back(::tt::target::metal::CreateCBRef(
+        //           fbb, cache.global_id++, tensorRef, cbType.getAddress(),
+        //           cbDesc));
+        //     } else if (mlir::isa<ttkernel::SemaphoreType>(arg.getType())) {
+        //       auto semType =
+        //       mlir::cast<ttkernel::SemaphoreType>(arg.getType()); auto
+        //       [runtime_arg_type, runtime_arg] =
+        //           toFlatbuffer(cache, semType);
+        //       runtime_args_type.push_back(runtime_arg_type);
+        //       runtime_args.push_back(runtime_arg);
+        //     } else {
+        //       llvm_unreachable(
+        //           "Block arguments must be either CBType or SemaphoreType");
+        //     }
+        //   }
 
-          std::string &source = cppKernels[region.getRegionNumber()];
-          assert(source.size() > 0 && "empty kernel source");
+        //   std::string &source = cppKernels[region.getRegionNumber()];
+        //   assert(source.size() > 0 && "empty kernel source");
 
-          // Get pair of kernel's config type and config itself.
-          auto kernelConfig =
-              enqueueProgramOp.getKernelConfigs()[region.getRegionNumber()];
-          auto [kernelConfigType, kernelConfigUnion] = toFlatbuffer(
-              fbb, mlir::cast<ttkernel::KernelConfigInterface>(kernelConfig));
+        //   // Get pair of kernel's config type and config itself.
+        //   auto kernelConfig =
+        //       enqueueProgramOp.getKernelConfigs()[region.getRegionNumber()];
+        //   auto [kernelConfigType, kernelConfigUnion] = toFlatbuffer(
+        //       fbb,
+        //       mlir::cast<ttkernel::KernelConfigInterface>(kernelConfig));
 
-          kernels.push_back(::tt::target::metal::CreateKernelDescDirect(
-              fbb, ::tt::target::metal::Kernel::KernelSource,
-              ::tt::target::metal::CreateKernelSourceDirect(
-                  fbb, source.c_str(), kernelConfigType, kernelConfigUnion)
-                  .Union(),
-              &coreRangeSet, &cbs, &runtime_args_type, &runtime_args,
-              nullptr /*TODO debug info*/));
-        }
+        //   kernels.push_back(::tt::target::metal::CreateKernelDescDirect(
+        //       fbb, ::tt::target::metal::Kernel::KernelSource,
+        //       ::tt::target::metal::CreateKernelSourceDirect(
+        //           fbb, source.c_str(), kernelConfigType, kernelConfigUnion)
+        //           .Union(),
+        //       &coreRangeSet, &cbs, &runtime_args_type, &runtime_args,
+        //       nullptr /*TODO debug info*/));
+        // }
         ::flatbuffers::Offset<::tt::target::metal::ProgramDesc> program =
             ::tt::target::metal::CreateProgramDescDirect(fbb, &kernels);
 

--- a/runtime/lib/ttmetal/command_queue.cpp
+++ b/runtime/lib/ttmetal/command_queue.cpp
@@ -502,35 +502,12 @@ void CQExecutor::execute(
 void CQExecutor::execute(
     ::tt::target::metal::EnqueueWriteBufferCommand const *command) {
   ZoneScopedN("EnqueueWriteBufferCommand");
-  LOG_ASSERT(buffers.contains(command->dst()->global_id()),
-             "Buffer not allocated");
-  auto buffer = buffers[command->dst()->global_id()];
-  constexpr bool blocking = false;
-  switch (command->src_type()) { // currently only supporting ConstantBuffer32
-  case tt::target::metal::HostBuffer::ConstantBuffer32: {
-    const auto *src = command->src_as_ConstantBuffer32();
-    LOG_ASSERT(src->data() != nullptr && (*src->data()).size() == 1,
-               "Only scalar constant supported");
-    LOG_ASSERT(command->dst()->size() ==
-                   buffers[command->dst()->global_id()]->size(),
-               "Size mismatch: ", command->dst()->size(),
-               " != ", buffers[command->dst()->global_id()]->size());
-    int shapeAccumulate = std::accumulate(
-        (*command->dst()->desc()->shape()).begin(),
-        (*command->dst()->desc()->shape()).end(), 1, std::multiplies<int>());
-    std::vector<uint32_t> vec(shapeAccumulate, (*src->data())[0]);
-    ::tt::tt_metal::EnqueueWriteBuffer(*cq, buffer, vec, blocking);
-    break;
-  }
-  default:
-    LOG_FATAL("Unsupported HostBuffer type");
-  }
+  LOG_FATAL("Unsupported EnqueueWriteBufferCommand");
 }
 
 void CQExecutor::execute(
     ::tt::target::metal::EnqueueReadBufferCommand const *command) {
   ZoneScopedN("EnqueueReadBufferCommand");
-  // Maybe we will need this in the future, like paging to system mem?
   LOG_FATAL("Unsupported EnqueueReadBufferCommand");
 }
 

--- a/test/ttmlir/Conversion/TTIRToTTMetal/alloc_lowering.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTMetal/alloc_lowering.mlir
@@ -1,0 +1,23 @@
+// RUN: ttmlir-opt --convert-ttir-to-ttmetal %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+
+#l1_ = #tt.memory_space<l1>
+
+func.func @alloc_no_addr(%arg0: memref<1x1x8x24x!tt.tile<32x32, f32>, #tt.shard<98304x4096>, #l1_>, %arg1: memref<1x1x24x32x!tt.tile<32x32, f32>, #tt.shard<131072x4096>, #l1_>) ->memref<8x8x1x4x!tt.tile<32x32, f32>, #l1_> {
+    // CHECK: %{{[0-9]+}} = "ttmetal.create_buffer"()
+    // CHECK-SAME: {{.*}}address = 1000 : i64
+    // TODO(#1909): Change this default address to whatever the allocation pass decides the address is.
+    // CHECK-SAME: {{.*}}memory_space = #l1_
+    // CHECK-SAME: {{.*}}size = 1048576 : i64
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x8x1x4x!tt.tile<32x32, f32>, #l1_>
+    return %alloc : memref<8x8x1x4x!tt.tile<32x32, f32>, #l1_>
+}
+
+func.func @alloc_with_addr(%arg0: memref<1x1x8x24x!tt.tile<32x32, f32>, #tt.shard<98304x4096>, #l1_>, %arg1: memref<1x1x24x32x!tt.tile<32x32, f32>, #tt.shard<131072x4096>, #l1_>) -> memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.shard<12288x4096>, #l1_> {
+    // CHECK: %{{[0-9]+}} = "ttmetal.create_buffer"()
+    // CHECK-SAME: {{.*}}address = 86016 : i64
+    // CHECK-SAME: {{.*}}memory_space = #l1_
+    // CHECK-SAME: {{.*}}size = 786432 : i64
+    %alloc = memref.alloc() {alignment = 64 : i64, address = 0x15000 : i64} : memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.shard<12288x4096>, #l1_>
+    return %alloc : memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.shard<12288x4096>, #l1_>
+}

--- a/test/ttmlir/Conversion/TTIRToTTMetal/alloc_lowering.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTMetal/alloc_lowering.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --convert-ttir-to-ttmetal %s > %t.mlir
+// RUN: ttmlir-opt --tt-register-device --convert-ttir-to-ttmetal %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 
 #l1_ = #tt.memory_space<l1>
@@ -8,7 +8,7 @@ func.func @alloc_no_addr(%arg0: memref<1x1x8x24x!tt.tile<32x32, f32>, #tt.shard<
     // CHECK-SAME: {{.*}}address = 1000 : i64
     // TODO(#1909): Change this default address to whatever the allocation pass decides the address is.
     // CHECK-SAME: {{.*}}memory_space = #l1_
-    // CHECK-SAME: {{.*}}size = 1048576 : i64
+    // CHECK-SAME: {{.*}}size = 16384 : i64
     %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x8x1x4x!tt.tile<32x32, f32>, #l1_>
     return %alloc : memref<8x8x1x4x!tt.tile<32x32, f32>, #l1_>
 }
@@ -17,7 +17,7 @@ func.func @alloc_with_addr(%arg0: memref<1x1x8x24x!tt.tile<32x32, f32>, #tt.shar
     // CHECK: %{{[0-9]+}} = "ttmetal.create_buffer"()
     // CHECK-SAME: {{.*}}address = 86016 : i64
     // CHECK-SAME: {{.*}}memory_space = #l1_
-    // CHECK-SAME: {{.*}}size = 786432 : i64
+    // CHECK-SAME: {{.*}}size = 12288 : i64
     %alloc = memref.alloc() {alignment = 64 : i64, address = 0x15000 : i64} : memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.shard<12288x4096>, #l1_>
     return %alloc : memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.shard<12288x4096>, #l1_>
 }

--- a/test/ttmlir/Conversion/TTIRToTTMetal/generic_lowering.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTMetal/generic_lowering.mlir
@@ -1,10 +1,8 @@
-// RUN: ttmlir-opt --convert-ttir-to-ttmetal %s > %t.mlir
+// RUN: ttmlir-opt --tt-register-device --convert-ttir-to-ttmetal %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 
 #l1_ = #tt.memory_space<l1>
-#system_desc = #tt.system_desc<[{role = host, target_triple = "x86_64-pc-linux-gnu"}], [{arch = <wormhole_b0>, grid = 8x8, l1_size = 1499136, num_dram_channels = 12, dram_channel_size = 1073741824, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32, l1_unreserved_base = 1024, erisc_l1_unreserved_base = 1024, dram_unreserved_base = 1024, dram_unreserved_end = 1073741824, physical_cores = {worker = [ 18x18,  0x1,  0x2,  0x3,  0x4,  0x5,  0x6,  0x7,  1x0,  1x1,  1x2,  1x3,  1x4,  1x5,  1x6,  1x7,  2x0,  2x1,  2x2,  2x3,  2x4,  2x5,  2x6,  2x7,  3x0,  3x1,  3x2,  3x3,  3x4,  3x5,  3x6,  3x7,  4x0,  4x1,  4x2,  4x3,  4x4,  4x5,  4x6,  4x7,  5x0,  5x1,  5x2,  5x3,  5x4,  5x5,  5x6,  5x7,  6x0,  6x1,  6x2,  6x3,  6x4,  6x5,  6x6,  6x7,  7x0,  7x1,  7x2,  7x3,  7x4,  7x5,  7x6,  7x7] dram = [ 8x0,  9x0,  10x0,  8x1,  9x1,  10x1,  8x2,  9x2,  10x2,  8x3,  9x3,  10x3]}, supported_data_types = [<f32>, <f16>, <bf16>, <bfp_f8>, <bfp_bf8>, <bfp_f4>, <bfp_bf4>, <bfp_f2>, <bfp_bf2>, <u32>, <u16>, <u8>, <si32>], supported_tile_sizes = [ 4x16,  16x16,  32x16,  4x32,  16x32,  32x32], num_cbs = 32, num_compute_threads = 1, num_datamovement_threads = 2}], [0], [3 : i32], [ 0x0x0x0]>
-module attributes {tt.system_desc = #system_desc} {
-  tt.device @default_device = <workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5] -> (0, 0, (((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) floordiv s4) mod 12, ((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) floordiv (s4 * 12) + ((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
+module {
   func.func @generic0(%arg0: memref<1x1x8x24x!tt.tile<32x32, f32>, #tt.shard<98304x4096>, #l1_>, %arg1: memref<1x1x24x32x!tt.tile<32x32, f32>, #tt.shard<131072x4096>, #l1_>) -> memref<1x1x8x32x!tt.tile<32x32, f32>, #tt.shard<131072x4096>, #l1_> {
     %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x8x1x4x!tt.tile<32x32, f32>, #l1_>
     %alloc_0 = memref.alloc() {alignment = 64 : i64, address = 0x10000} : memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.shard<12288x4096>, #l1_>

--- a/test/ttmlir/Conversion/TTIRToTTMetal/generic_lowering.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTMetal/generic_lowering.mlir
@@ -19,15 +19,15 @@ module {
     return %view : memref<1x1x8x32x!tt.tile<32x32, f32>, #tt.shard<131072x4096>, #l1_>
   }
 
-  func.func private @datamovement_kernel0(%arg0: memref<1x3x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<3x4x!tt.tile<32x32, f32>, #l1_>, %arg2: memref<1x4x!tt.tile<32x32, f32>, #l1_>, %arg3: !ttir.semaphore, %arg4: !ttir.semaphore, %arg5: !ttir.semaphore, %arg6: !ttir.semaphore) attributes {ttir.thread_type = 1 : i32} {
+  func.func private @datamovement_kernel0(%arg0: memref<1x3x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<3x4x!tt.tile<32x32, f32>, #l1_>, %arg2: memref<1x4x!tt.tile<32x32, f32>, #l1_>, %arg3: !ttir.semaphore, %arg4: !ttir.semaphore, %arg5: !ttir.semaphore, %arg6: !ttir.semaphore) attributes {ttir.thread = #ttir.thread<datamovement>} {
     return
   }
 
-  func.func private @datamovement_kernel1(%arg0: memref<1x3x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<3x4x!tt.tile<32x32, f32>, #l1_>, %arg2: memref<1x4x!tt.tile<32x32, f32>, #l1_>, %arg3: !ttir.semaphore, %arg4: !ttir.semaphore, %arg5: !ttir.semaphore, %arg6: !ttir.semaphore) attributes {ttir.thread_type = 1 : i32} {
+  func.func private @datamovement_kernel1(%arg0: memref<1x3x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<3x4x!tt.tile<32x32, f32>, #l1_>, %arg2: memref<1x4x!tt.tile<32x32, f32>, #l1_>, %arg3: !ttir.semaphore, %arg4: !ttir.semaphore, %arg5: !ttir.semaphore, %arg6: !ttir.semaphore) attributes {ttir.thread = #ttir.thread<datamovement>} {
     return
   }
 
-  func.func private @compute_kernel2(%arg0: memref<1x3x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<3x4x!tt.tile<32x32, f32>, #l1_>, %arg2: memref<1x4x!tt.tile<32x32, f32>, #l1_>, %arg3: !ttir.semaphore, %arg4: !ttir.semaphore, %arg5: !ttir.semaphore, %arg6: !ttir.semaphore) attributes {ttir.thread_type = 1 : i32} {
+  func.func private @compute_kernel2(%arg0: memref<1x3x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<3x4x!tt.tile<32x32, f32>, #l1_>, %arg2: memref<1x4x!tt.tile<32x32, f32>, #l1_>, %arg3: !ttir.semaphore, %arg4: !ttir.semaphore, %arg5: !ttir.semaphore, %arg6: !ttir.semaphore) attributes {ttir.thread = #ttir.thread<compute>} {
     return
   }
 }

--- a/test/ttmlir/Conversion/TTIRToTTMetal/generic_lowering.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTMetal/generic_lowering.mlir
@@ -1,0 +1,35 @@
+// RUN: ttmlir-opt --convert-ttir-to-ttmetal %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+
+#l1_ = #tt.memory_space<l1>
+#system_desc = #tt.system_desc<[{role = host, target_triple = "x86_64-pc-linux-gnu"}], [{arch = <wormhole_b0>, grid = 8x8, l1_size = 1499136, num_dram_channels = 12, dram_channel_size = 1073741824, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32, l1_unreserved_base = 1024, erisc_l1_unreserved_base = 1024, dram_unreserved_base = 1024, dram_unreserved_end = 1073741824, physical_cores = {worker = [ 18x18,  0x1,  0x2,  0x3,  0x4,  0x5,  0x6,  0x7,  1x0,  1x1,  1x2,  1x3,  1x4,  1x5,  1x6,  1x7,  2x0,  2x1,  2x2,  2x3,  2x4,  2x5,  2x6,  2x7,  3x0,  3x1,  3x2,  3x3,  3x4,  3x5,  3x6,  3x7,  4x0,  4x1,  4x2,  4x3,  4x4,  4x5,  4x6,  4x7,  5x0,  5x1,  5x2,  5x3,  5x4,  5x5,  5x6,  5x7,  6x0,  6x1,  6x2,  6x3,  6x4,  6x5,  6x6,  6x7,  7x0,  7x1,  7x2,  7x3,  7x4,  7x5,  7x6,  7x7] dram = [ 8x0,  9x0,  10x0,  8x1,  9x1,  10x1,  8x2,  9x2,  10x2,  8x3,  9x3,  10x3]}, supported_data_types = [<f32>, <f16>, <bf16>, <bfp_f8>, <bfp_bf8>, <bfp_f4>, <bfp_bf4>, <bfp_f2>, <bfp_bf2>, <u32>, <u16>, <u8>, <si32>], supported_tile_sizes = [ 4x16,  16x16,  32x16,  4x32,  16x32,  32x32], num_cbs = 32, num_compute_threads = 1, num_datamovement_threads = 2}], [0], [3 : i32], [ 0x0x0x0]>
+module attributes {tt.system_desc = #system_desc} {
+  tt.device @default_device = <workerGrid = #tt.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5] -> (0, 0, (((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) floordiv s4) mod 12, ((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) floordiv (s4 * 12) + ((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
+  func.func @generic0(%arg0: memref<1x1x8x24x!tt.tile<32x32, f32>, #tt.shard<98304x4096>, #l1_>, %arg1: memref<1x1x24x32x!tt.tile<32x32, f32>, #tt.shard<131072x4096>, #l1_>) -> memref<1x1x8x32x!tt.tile<32x32, f32>, #tt.shard<131072x4096>, #l1_> {
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x8x1x4x!tt.tile<32x32, f32>, #l1_>
+    %alloc_0 = memref.alloc() {alignment = 64 : i64, address = 0x10000} : memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.shard<12288x4096>, #l1_>
+    %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<1x1x8x24x!tt.tile<32x32, f32>, #tt.shard<98304x4096>, #l1_>, memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.shard<12288x4096>, #l1_>) -> memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 12288 + d3 * 4096)>, #l1_>
+    %alloc_1 = memref.alloc() {alignment = 64 : i64, address = 0x15000} : memref<8x8x3x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
+    %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<1x1x24x32x!tt.tile<32x32, f32>, #tt.shard<131072x4096>, #l1_>, memref<8x8x3x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>) -> memref<8x8x3x4x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 16384 + d3 * 4096)>, #l1_>
+    // CHECK: "ttmetal.enqueue_program"
+    // CHECK-SAME: {{.*}}core_ranges = [#ttmetal.core_range<0x0, 8x8>, #ttmetal.core_range<0x0, 8x8>, #ttmetal.core_range<0x0, 8x8>]
+    // CHECK-SAME: {{.*}}threads = [#ttir.thread<datamovement, @datamovement_kernel0>, #ttir.thread<datamovement, @datamovement_kernel1>, #ttir.thread<compute, @compute_kernel2>]
+    ttir.generic {grid = #tt.grid<8x8>, indexing_maps = [], iterator_types = [], threads = [#ttir.thread<datamovement, @datamovement_kernel0>, #ttir.thread<datamovement, @datamovement_kernel1>, #ttir.thread<compute, @compute_kernel2>]}
+        ins(%stream, %stream_2 : memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 12288 + d3 * 4096)>, #l1_>, memref<8x8x3x4x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 16384 + d3 * 4096)>, #l1_>)
+        outs(%alloc : memref<8x8x1x4x!tt.tile<32x32, f32>, #l1_>)
+    %view = "ttir.view_layout"(%alloc) : (memref<8x8x1x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x8x32x!tt.tile<32x32, f32>, #tt.shard<131072x4096>, #l1_>
+    return %view : memref<1x1x8x32x!tt.tile<32x32, f32>, #tt.shard<131072x4096>, #l1_>
+  }
+
+  func.func private @datamovement_kernel0(%arg0: memref<1x3x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<3x4x!tt.tile<32x32, f32>, #l1_>, %arg2: memref<1x4x!tt.tile<32x32, f32>, #l1_>, %arg3: !ttir.semaphore, %arg4: !ttir.semaphore, %arg5: !ttir.semaphore, %arg6: !ttir.semaphore) attributes {ttir.thread_type = 1 : i32} {
+    return
+  }
+
+  func.func private @datamovement_kernel1(%arg0: memref<1x3x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<3x4x!tt.tile<32x32, f32>, #l1_>, %arg2: memref<1x4x!tt.tile<32x32, f32>, #l1_>, %arg3: !ttir.semaphore, %arg4: !ttir.semaphore, %arg5: !ttir.semaphore, %arg6: !ttir.semaphore) attributes {ttir.thread_type = 1 : i32} {
+    return
+  }
+
+  func.func private @compute_kernel2(%arg0: memref<1x3x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<3x4x!tt.tile<32x32, f32>, #l1_>, %arg2: memref<1x4x!tt.tile<32x32, f32>, #l1_>, %arg3: !ttir.semaphore, %arg4: !ttir.semaphore, %arg5: !ttir.semaphore, %arg6: !ttir.semaphore) attributes {ttir.thread_type = 1 : i32} {
+    return
+  }
+}


### PR DESCRIPTION
**Split from #2809**

### Ticket
#2609

### Problem description

We need to lower new TTIR generic ops & functions to TTMetal and TTKernel dialects to fit the new D2M lowering scheme.

### What's changed

**TTMetal Lowering Pass**
- Replaces all old code in `TTIRToTTMetal.cpp` but maintains the pass itself
- Adds two rewriters:

  - `MemrefAllocRewriter` - rewrites `memref.alloc` ops to `ttmetal.create_buffer`
       - Pulls the `address` attr from `memref.alloc` if it exists. If not, defaults to `address = 1000` (arbitrary default until alloc pass is implemented.
       
  - `TTIRGenericRewriter` - rewrites `ttir.generic` to `ttmetal.enqueue_program`
       - Changed the `ttmetal.enqueue_program` op to include a `threads` attribute which is inherited from `ttir.generic`
       - Applies identical core ranges to each kernel, all equal to the grid size of `ttir.generic`

Parts of `lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp` and `lib/Target/TTMetal/TTMetalToFlatbuffer.cpp` are temporarily disabled to accomadate the changes to the `ttmetal.enqueue_program` op. Resupporting this lowering will follow on in a subsequent PR. 

Tests are added in `test/ttmlir/Conversion/TTIRToTTMetal` (alloc lowering & generic lowering)

**Outstanding Work:**

- [ ] TTKernelToEmitC rewrite to match new expected function kernel form / `ttir.generic` form #2960 
- [ ] TTIRToTTMetal pass to lower addresses into `ttmetal.get_compile_time_arg_val`

### Checklist
- [x] New/Existing tests provide coverage for changes
