### PR TITLE
Added Arrays to PyKernel

### DIFF
--- a/test/pykernel/unit_tests.py
+++ b/test/pykernel/unit_tests.py
@@ -7,6 +7,10 @@
 
 from pykernel.pykernel_ast import *
 
+# NOTE: The FileCheck directives in this file use CHECK-LABEL to find function definitions
+# regardless of their order in the output. This makes the tests more robust against
+# variations in the generated MLIR code.
+
 
 @ttkernel_compile()
 def test_assign():
@@ -254,6 +258,161 @@ def test_unary_ops():
     return
 
 
+@ttkernel_compile(optimize=False)
+def test_array_assign():
+    # CHECK-LABEL: func.func @test_array_assign
+
+    # TEST: Array declaration and initialization with size
+    # CHECK: memref<5xi32>
+    a: [int, 5] = 0
+
+    # TEST: Array initialization with list of values
+    # CHECK: memref<3xi32>
+    # CHECK: memref.store {{.*}} : memref<3xi32>
+    b = [1, 2, 3]
+
+    return
+
+
+@ttkernel_compile(optimize=False)
+def test_array_access():
+    # CHECK-LABEL: func.func @test_array_access
+
+    # TEST: Array declaration and element access
+    # CHECK: memref<5xi32>
+    a = [0, 1, 2, 3, 4]
+
+    # TEST: Array element assignment with constant index
+    # CHECK: arith.constant 42 : i32
+    # CHECK: memref.store {{.*}} : memref<5xi32>
+    a[2] = 42
+
+    # TEST: Array element access with constant index
+    # CHECK: memref.load {{.*}} : memref<5xi32>
+    b = a[2]
+
+    # TEST: Array element access with variable index
+    # CHECK: arith.constant 3 : i32
+    i = 3
+    # CHECK: arith.index_cast {{.*}} : i32 to index
+    # CHECK: memref.load {{.*}} : memref<5xi32>
+    c = a[i]
+
+    # TEST: Array element assignment with expression index
+    # CHECK: arith.addi {{.*}} : i32
+    # CHECK: arith.constant 99 : i32
+    a[i + 1] = 99
+
+    return
+
+
+@ttkernel_noc_compile(optimize=False)
+def test_array_iteration():
+    # CHECK-LABEL: func.func @test_array_iteration
+
+    # TEST: Array declaration
+    # CHECK: memref<5xi32>
+    a = [0, 0, 0, 0, 0]
+
+    # Initialize array with values
+    # CHECK: arith.constant 1 : i32
+    a[0] = 1
+    # CHECK: arith.constant 2 : i32
+    a[1] = 2
+    # CHECK: arith.constant 3 : i32
+    a[2] = 3
+    # CHECK: arith.constant 4 : i32
+    a[3] = 4
+    # CHECK: arith.constant 5 : i32
+    a[4] = 5
+
+    # TEST: Sum array elements using loop with index
+    # CHECK: memref<1xi32>
+    # CHECK: arith.constant 0 : i32
+    sum: int = 0
+
+    # CHECK: scf.for
+    for i in range(0, 5, 1):
+        # CHECK: arith.addi {{.*}} : i32
+        sum += a[i]
+
+    # TEST: Regular for loop with range
+    # CHECK: memref<1xi32>
+    # CHECK: arith.constant 1 : i32
+    prod: int = 1
+
+    # CHECK: scf.for
+    for i in range(0, 5, 1):
+        # CHECK: arith.muli {{.*}} : i32
+        prod = prod * a[i]
+
+    return
+
+
+# Additional test for array operations
+@ttkernel_compile(optimize=False)
+def test_array_additional():
+    # CHECK-LABEL: func.func @test_array_additional
+
+    # TEST: Create array with constants
+    # CHECK: memref<3xi32>
+    a = [2, 4, 6]
+
+    # TEST: Access with variable index
+    idx = 1
+    # CHECK: arith.index_cast {{.*}} : i32 to index
+    # CHECK: memref.load {{.*}} : memref<3xi32>
+    b = a[idx]  # Should be 4
+
+    # TEST: Modify array element
+    # CHECK: arith.constant 10 : i32
+    # CHECK: memref.store {{.*}} : memref<3xi32>
+    a[idx] = 10
+
+    return
+
+
+# Test for multidimensional arrays
+@ttkernel_compile(optimize=False)
+def test_multidim_arrays():
+    # CHECK-LABEL: func.func @test_multidim_arrays
+
+    # TEST: 2D array initialization
+    # CHECK: memref<2x3xi32>
+    matrix = [[1, 2, 3], [4, 5, 6]]
+
+    return
+
+
+# Test for array creation with expressions as values
+@ttkernel_compile(optimize=False)
+def test_array_with_expressions():
+    # CHECK-LABEL: func.func @test_array_with_expressions
+
+    # TEST: Define variables for expressions
+    # CHECK: arith.constant 5 : i32
+    a = 5
+    # CHECK: arith.constant 10 : i32
+    b = 10
+
+    # TEST: Compute expressions before array creation
+    # CHECK: arith.addi
+    # CHECK: arith.subi
+    # CHECK: arith.muli
+    # CHECK: arith.constant 42 : i32
+
+    # TEST: Create array with expressions
+    # CHECK: memref<4xi32>
+    # CHECK: memref.store {{.*}} : memref<4xi32>
+    arr = [a + b, a - b, a * b, 42]
+
+    # TEST: Access array elements
+    # CHECK: memref.load {{.*}} : memref<4xi32>
+    c = arr[0]  # Should be 15
+
+    return
+
+
 test_assign()
 test_ifstmt()
 test_for()
@@ -261,3 +420,9 @@ test_binops()
 test_compare_expr()
 test_bool_ops()
 test_unary_ops()
+test_array_assign()
+test_array_access()
+test_array_iteration()
+test_array_additional()
+test_multidim_arrays()
+test_array_with_expressions()


### PR DESCRIPTION
### Ticket
- PR closes #1840 

### Problem description
- Couldn't create arrays using alloca in PyKernel. 

### What's changed
- Create Arrays using List notation: `l = [1, 2, 3]`
- Create Nested Arrays: `l = [[1, 2], [3, 4]]`
- Create Arrays with Variables + Expressions: `l = [x - 1, 3, x + 1]`
- Access and modify list elements: `l[0] = 42` `for i in range(10): sum += l[i]`
- Create Memrefs of certain sizes without initial values: `l: [int, 8, 8] = 0 -> memref<8x8xi32>` 
- Added Tests
