### PR TITLE
Make all params or `Conv2dConfigAttr` optional

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -1401,6 +1401,13 @@ def TTIR_Conv2dOp : TTIR_NamedOp<"conv2d"> {
                          I32Attr:$groups,
                          DefaultValuedAttr<TTIR_FlattenedCompatInfoAttr, "nullptr">:$flattened_compat_info);
 
+    let extraClassDeclaration = [{
+      // Get number of output channels
+      int64_t getOutputChannelSize();
+      bool verifyBias(llvm::ArrayRef<int64_t> biasDims);
+      MutableOperandRange getDpsInitsMutable() { return ttir::getDpsOutputs(this); }
+    }];
+
     let results = (outs AnyRankedTensor:$result);
 
     let hasVerifier = 1;

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
@@ -5,12 +5,13 @@
 #ifndef TTMLIR_TTMLIR_DIALECT_TTNN_TTNNOPSATTRS_TD
 #define TTMLIR_TTMLIR_DIALECT_TTNN_TTNNOPSATTRS_TD
 
+include "ttmlir/Dialect/TTNN/IR/TTNNBase.td"
+include "ttmlir/Dialect/TTNN/IR/TTNNOpsEnums.td"
+
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/EnumAttr.td"
 include "mlir/IR/BuiltinTypeInterfaces.td"
 include "mlir/IR/CommonTypeConstraints.td"
-include "ttmlir/Dialect/TTNN/IR/TTNNBase.td"
-include "ttmlir/Dialect/TTNN/IR/TTNNOpsEnums.td"
 
 //===----------------------------------------------------------------------===//
 // TTNN attr definitions
@@ -378,52 +379,36 @@ def TTNN_Conv2dConfigAttr : TTNN_Attr<"Conv2dConfig", "conv2d_config"> {
     TTNN conv2d config attribute
   }];
 
-  let parameters = (ins
-                        "DataType":$dtype,
-                        "DataType":$weights_dtype,
-                        "StringAttr":$activation,
-                        "uint32_t":$input_channels_alignment,
-                        "bool":$deallocate_activation,
-                        "bool":$reallocate_halo_output,
-                        "uint32_t":$act_block_h_override,
-                        "uint32_t":$act_block_w_div,
-                        "bool":$reshard_if_not_optimal,
-                        "bool":$override_sharding_config,
-                        OptionalParameter<"TensorMemoryLayoutAttr">:$shard_layout,
+  let parameters = (ins OptionalParameter<"std::optional<DataType>">:$dtype,
+                        OptionalParameter<"std::optional<DataType>">:$weights_dtype,
+                        OptionalParameter<"StringAttr">:$activation,
+                        OptionalParameter<"std::optional<uint32_t>">:$input_channels_alignment,
+                        OptionalParameter<"BoolAttr">:$deallocate_activation,
+                        OptionalParameter<"BoolAttr">:$reallocate_halo_output,
+                        OptionalParameter<"std::optional<uint32_t>">:$act_block_h_override,
+                        OptionalParameter<"std::optional<uint32_t>">:$act_block_w_div,
+                        OptionalParameter<"BoolAttr">:$reshard_if_not_optimal,
+                        OptionalParameter<"BoolAttr">:$override_sharding_config,
+                        OptionalParameter<"std::optional<TensorMemoryLayout>">:$shard_layout,
                         OptionalParameter<"CoreRangeSetAttr">:$core_grid,
-                        "bool":$transpose_shards,
-                        "Layout":$output_layout,
-                        "bool":$preprocess_weights_on_device,
-                        "bool":$always_preprocess_weights,
-                        "bool":$enable_act_double_buffer,
-                        "bool":$enable_weights_double_buffer,
-                        "bool":$enable_split_reader,
-                        "bool":$enable_subblock_padding);
+                        OptionalParameter<"BoolAttr">:$transpose_shards,
+                        OptionalParameter<"std::optional<Layout>">:$output_layout,
+                        OptionalParameter<"BoolAttr">:$preprocess_weights_on_device,
+                        OptionalParameter<"BoolAttr">:$always_preprocess_weights,
+                        OptionalParameter<"BoolAttr">:$enable_act_double_buffer,
+                        OptionalParameter<"BoolAttr">:$enable_weights_double_buffer,
+                        OptionalParameter<"BoolAttr">:$enable_split_reader,
+                        OptionalParameter<"BoolAttr">:$enable_subblock_padding);
 
-  let assemblyFormat = [{
-    `<` struct(
-      qualified($dtype),
-      qualified($weights_dtype),
-      $activation,
-      $input_channels_alignment,
-      $deallocate_activation,
-      $reallocate_halo_output,
-      $act_block_h_override,
-      $act_block_w_div,
-      $reshard_if_not_optimal,
-      $override_sharding_config,
-      qualified($shard_layout),
-      qualified($core_grid),
-      $transpose_shards,
-      qualified($output_layout),
-      $preprocess_weights_on_device,
-      $always_preprocess_weights,
-      $enable_act_double_buffer,
-      $enable_weights_double_buffer,
-      $enable_split_reader,
-      $enable_subblock_padding
-    ) `>`
+  let builders = [
+    AttrBuilder<(ins )>
+  ];
+
+  let extraClassDeclaration = [{
+    Conv2dConfigAttr withActivation(StringRef activation) const;
   }];
+
+  let assemblyFormat = "`<` struct(params) `>`";
 }
 
 def TTNN_MeshShapeAttr : TTNN_Mesh2DCoordAttr<"MeshShape", "mesh_shape"> {

--- a/include/ttmlir/Target/TTNN/operations/conv.fbs
+++ b/include/ttmlir/Target/TTNN/operations/conv.fbs
@@ -4,26 +4,26 @@ include "ttmlir/Target/TTNN/types.fbs";
 namespace tt.target.ttnn;
 
 table Conv2dConfig {
-  dtype: tt.target.DataType;
-  weights_dtype: tt.target.DataType;
+  dtype: DataType = null;
+  weights_dtype: DataType = null;
   activation: string;
-  input_channels_alignment: uint32;
-  deallocate_activation: bool;
-  reallocate_halo_output: bool;
-  act_block_h_override: uint32;
-  act_block_w_div: uint32;
-  reshard_if_not_optimal: bool;
-  override_sharding_config: bool;
-  shard_layout: tt.target.ttnn.TensorMemoryLayout = null;
-  core_grid: tt.target.ttnn.CoreRangeSet;
-  transpose_shards: bool;
-  output_layout: tt.target.TensorLayout;
-  preprocess_weights_on_device: bool;
-  always_preprocess_weights: bool;
-  enable_act_double_buffer: bool;
-  enable_weights_double_buffer: bool;
-  enable_split_reader: bool;
-  enable_subblock_padding: bool;
+  input_channels_alignment: uint32 = null;
+  deallocate_activation: bool = null;
+  reallocate_halo_output: bool = null;
+  act_block_h_override: uint32 = null;
+  act_block_w_div: uint32 = null;
+  reshard_if_not_optimal: bool = null;
+  override_sharding_config: bool = null;
+  shard_layout: TensorMemoryLayout = null;
+  core_grid: CoreRangeSet;
+  transpose_shards: bool = null;
+  output_layout: TensorLayout = null;
+  preprocess_weights_on_device: bool = null;
+  always_preprocess_weights: bool = null;
+  enable_act_double_buffer: bool = null;
+  enable_weights_double_buffer: bool = null;
+  enable_split_reader: bool = null;
+  enable_subblock_padding: bool = null;
 }
 
 table PrepareConv2dWeightsOp {

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -11,6 +11,7 @@
 #include "ttmlir/Target/Common/Target.h"
 #include "ttmlir/Target/TTNN/Target.h"
 #include "ttmlir/Target/Utils/FlatbufferObjectCache.h"
+#include "ttmlir/Utils.h"
 
 #include "flatbuffers/buffer.h"
 #include "llvm/ADT/STLForwardCompat.h"
@@ -463,6 +464,10 @@ toFlatbuffer(FlatbufferObjectCache &cache, ttnn::CoreRangeAttr coreRangeAttr) {
 inline ::flatbuffers::Offset<::tt::target::ttnn::CoreRangeSet>
 toFlatbuffer(FlatbufferObjectCache &cache,
              ttnn::CoreRangeSetAttr coreRangeSetAttr) {
+  if (!coreRangeSetAttr) {
+    return 0;
+  }
+
   return ::tt::target::ttnn::CreateCoreRangeSet(
       *cache.fbb, toFlatbuffer(cache, coreRangeSetAttr.getCoreRanges()));
 }
@@ -643,38 +648,47 @@ toFlatbuffer(FlatbufferObjectCache &cache,
           fusedActivation);
 }
 
-inline ::flatbuffers::Offset<::tt::target::ttnn::Conv2dConfig>
-toFlatbuffer(FlatbufferObjectCache &cache,
-             ttnn::Conv2dConfigAttr conv2dConfigAttr) {
-  ::flatbuffers::Optional<::tt::target::ttnn::TensorMemoryLayout> shardLayout;
-  if (conv2dConfigAttr.getShardLayout()) {
-    shardLayout = toFlatbuffer(cache, conv2dConfigAttr.getShardLayout());
+inline ::flatbuffers::Offset<::flatbuffers::String>
+toFlatbuffer(FlatbufferObjectCache &cache, StringAttr strAttr) {
+  if (strAttr) {
+    return toFlatbuffer(cache, strAttr.getValue());
   }
-  // TODO(vkovacevic): Add support for coreGrid #2781
-  ::flatbuffers::Offset<::tt::target::ttnn::CoreRangeSet> coreGrid;
 
-  ::flatbuffers::Offset<::tt::target::ttnn::Conv2dConfig> conv2dConfigDesc =
-      ::tt::target::ttnn::CreateConv2dConfig(
-          *cache.fbb, toFlatbuffer(cache, conv2dConfigAttr.getDtype()),
-          toFlatbuffer(cache, conv2dConfigAttr.getWeightsDtype()),
-          toFlatbuffer(cache, conv2dConfigAttr.getActivation().getValue()),
-          conv2dConfigAttr.getInputChannelsAlignment(),
-          conv2dConfigAttr.getDeallocateActivation(),
-          conv2dConfigAttr.getReallocateHaloOutput(),
-          conv2dConfigAttr.getActBlockHOverride(),
-          conv2dConfigAttr.getActBlockWDiv(),
-          conv2dConfigAttr.getReshardIfNotOptimal(),
-          conv2dConfigAttr.getOverrideShardingConfig(), shardLayout, coreGrid,
-          conv2dConfigAttr.getTransposeShards(),
-          toFlatbuffer(cache, conv2dConfigAttr.getOutputLayout()),
-          conv2dConfigAttr.getPreprocessWeightsOnDevice(),
-          conv2dConfigAttr.getAlwaysPreprocessWeights(),
-          conv2dConfigAttr.getEnableActDoubleBuffer(),
-          conv2dConfigAttr.getEnableWeightsDoubleBuffer(),
-          conv2dConfigAttr.getEnableSplitReader(),
-          conv2dConfigAttr.getEnableSubblockPadding());
+  return 0;
+}
 
-  return conv2dConfigDesc;
+inline ::flatbuffers::Optional<bool> toFlatbuffer(FlatbufferObjectCache &cache,
+                                                  BoolAttr attr) {
+  if (attr) {
+    return attr.getValue();
+  }
+
+  return ::flatbuffers::nullopt;
+}
+
+inline ::flatbuffers::Offset<::tt::target::ttnn::Conv2dConfig>
+toFlatbuffer(FlatbufferObjectCache &cache, ttnn::Conv2dConfigAttr config) {
+  return ::tt::target::ttnn::CreateConv2dConfig(
+      *cache.fbb, toFlatbuffer(cache, config.getDtype()),
+      toFlatbuffer(cache, config.getWeightsDtype()),
+      toFlatbuffer(cache, config.getActivation()),
+      toFlatbuffer(cache, config.getInputChannelsAlignment()),
+      toFlatbuffer(cache, config.getDeallocateActivation()),
+      toFlatbuffer(cache, config.getReallocateHaloOutput()),
+      toFlatbuffer(cache, config.getActBlockHOverride()),
+      toFlatbuffer(cache, config.getActBlockWDiv()),
+      toFlatbuffer(cache, config.getReshardIfNotOptimal()),
+      toFlatbuffer(cache, config.getOverrideShardingConfig()),
+      toFlatbuffer(cache, config.getShardLayout()),
+      toFlatbuffer(cache, config.getCoreGrid()),
+      toFlatbuffer(cache, config.getTransposeShards()),
+      toFlatbuffer(cache, config.getOutputLayout()),
+      toFlatbuffer(cache, config.getPreprocessWeightsOnDevice()),
+      toFlatbuffer(cache, config.getAlwaysPreprocessWeights()),
+      toFlatbuffer(cache, config.getEnableActDoubleBuffer()),
+      toFlatbuffer(cache, config.getEnableWeightsDoubleBuffer()),
+      toFlatbuffer(cache, config.getEnableSplitReader()),
+      toFlatbuffer(cache, config.getEnableSubblockPadding()));
 }
 
 } // namespace mlir::tt

--- a/lib/OpModel/TTNN/Conversion.cpp
+++ b/lib/OpModel/TTNN/Conversion.cpp
@@ -168,9 +168,7 @@ getBufferType(const ::tt::tt_metal::BufferType bufferType) {
 }
 
 ::tt::tt_metal::TensorMemoryLayout getTensorMemoryLayout(
-    const mlir::tt::ttnn::TensorMemoryLayoutAttr memLayoutAttr) {
-  auto tensorMemoryLayout = memLayoutAttr.getValue();
-
+    const mlir::tt::ttnn::TensorMemoryLayout tensorMemoryLayout) {
   switch (tensorMemoryLayout) {
   case mlir::tt::ttnn::TensorMemoryLayout::Interleaved:
     return ::tt::tt_metal::TensorMemoryLayout::INTERLEAVED;
@@ -198,6 +196,12 @@ getTensorMemoryLayout(const ::tt::tt_metal::TensorMemoryLayout memLayout) {
   case ::tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED:
     return mlir::tt::ttnn::TensorMemoryLayout::BlockSharded;
   }
+}
+
+::tt::tt_metal::TensorMemoryLayout getTensorMemoryLayout(
+    const mlir::tt::ttnn::TensorMemoryLayoutAttr memLayoutAttr) {
+  auto tensorMemoryLayout = memLayoutAttr.getValue();
+  return getTensorMemoryLayout(tensorMemoryLayout);
 }
 
 ::tt::tt_metal::MemoryConfig
@@ -238,31 +242,98 @@ std::optional<::ttnn::operations::conv::conv2d::Conv2dConfig> getConv2dConfig(
   assert(!conv2dConfig->getCoreGrid() && "CoreGrid is not supported yet");
 
   ::ttnn::operations::conv::conv2d::Conv2dConfig config;
-  config.dtype = getDataType(conv2dConfig->getDtype());
-  config.weights_dtype = getDataType(conv2dConfig->getWeightsDtype());
-  config.activation = conv2dConfig->getActivation().str();
-  config.input_channels_alignment = conv2dConfig->getInputChannelsAlignment();
-  config.deallocate_activation = conv2dConfig->getDeallocateActivation();
-  config.reallocate_halo_output = conv2dConfig->getReallocateHaloOutput();
-  config.act_block_h_override = conv2dConfig->getActBlockHOverride();
-  config.act_block_w_div = conv2dConfig->getActBlockWDiv();
-  config.reshard_if_not_optimal = conv2dConfig->getReshardIfNotOptimal();
-  config.override_sharding_config = conv2dConfig->getOverrideShardingConfig();
-  config.shard_layout = conv2dConfig->getShardLayout()
-                            ? std::make_optional(getTensorMemoryLayout(
-                                  conv2dConfig->getShardLayout()))
-                            : std::nullopt;
+
+  if (conv2dConfig->getDtype()) {
+    config.dtype = getDataType(*conv2dConfig->getDtype());
+  }
+
+  if (conv2dConfig->getWeightsDtype()) {
+    config.weights_dtype = getDataType(*conv2dConfig->getWeightsDtype());
+  }
+
+  if (conv2dConfig->getActivation()) {
+    config.activation = conv2dConfig->getActivation().getValue().str();
+  }
+
+  if (conv2dConfig->getInputChannelsAlignment()) {
+    config.input_channels_alignment =
+        *conv2dConfig->getInputChannelsAlignment();
+  }
+
+  if (conv2dConfig->getDeallocateActivation()) {
+    config.deallocate_activation =
+        conv2dConfig->getDeallocateActivation().getValue();
+  }
+
+  if (conv2dConfig->getReallocateHaloOutput()) {
+    config.reallocate_halo_output =
+        conv2dConfig->getReallocateHaloOutput().getValue();
+  }
+
+  if (conv2dConfig->getActBlockHOverride()) {
+    config.act_block_h_override = *conv2dConfig->getActBlockHOverride();
+  }
+
+  if (conv2dConfig->getActBlockWDiv()) {
+    config.act_block_w_div = *conv2dConfig->getActBlockWDiv();
+  }
+
+  if (conv2dConfig->getReshardIfNotOptimal()) {
+    config.reshard_if_not_optimal =
+        conv2dConfig->getReshardIfNotOptimal().getValue();
+  }
+
+  if (conv2dConfig->getOverrideShardingConfig()) {
+    config.override_sharding_config =
+        conv2dConfig->getOverrideShardingConfig().getValue();
+  }
+
+  if (conv2dConfig->getShardLayout()) {
+    config.shard_layout =
+        getTensorMemoryLayout(*conv2dConfig->getShardLayout());
+  } else {
+    config.shard_layout = std::nullopt;
+  }
+
   config.core_grid = std::nullopt;
-  config.transpose_shards = conv2dConfig->getTransposeShards();
-  config.output_layout = getPageLayout(conv2dConfig->getOutputLayout());
-  config.preprocess_weights_on_device =
-      conv2dConfig->getPreprocessWeightsOnDevice();
-  config.always_preprocess_weights = conv2dConfig->getAlwaysPreprocessWeights();
-  config.enable_act_double_buffer = conv2dConfig->getEnableActDoubleBuffer();
-  config.enable_weights_double_buffer =
-      conv2dConfig->getEnableWeightsDoubleBuffer();
-  config.enable_split_reader = conv2dConfig->getEnableSplitReader();
-  config.enable_subblock_padding = conv2dConfig->getEnableSubblockPadding();
+
+  if (conv2dConfig->getTransposeShards()) {
+    config.transpose_shards = conv2dConfig->getTransposeShards().getValue();
+  }
+
+  if (conv2dConfig->getOutputLayout()) {
+    config.output_layout = getPageLayout(*conv2dConfig->getOutputLayout());
+  }
+
+  if (conv2dConfig->getPreprocessWeightsOnDevice()) {
+    config.preprocess_weights_on_device =
+        conv2dConfig->getPreprocessWeightsOnDevice().getValue();
+  }
+
+  if (conv2dConfig->getAlwaysPreprocessWeights()) {
+    config.always_preprocess_weights =
+        conv2dConfig->getAlwaysPreprocessWeights().getValue();
+  }
+
+  if (conv2dConfig->getEnableActDoubleBuffer()) {
+    config.enable_act_double_buffer =
+        conv2dConfig->getEnableActDoubleBuffer().getValue();
+  }
+
+  if (conv2dConfig->getEnableWeightsDoubleBuffer()) {
+    config.enable_weights_double_buffer =
+        conv2dConfig->getEnableWeightsDoubleBuffer().getValue();
+  }
+
+  if (conv2dConfig->getEnableSplitReader()) {
+    config.enable_split_reader =
+        conv2dConfig->getEnableSplitReader().getValue();
+  }
+
+  if (conv2dConfig->getEnableSubblockPadding()) {
+    config.enable_subblock_padding =
+        conv2dConfig->getEnableSubblockPadding().getValue();
+  }
 
   return config;
 }

--- a/python/TTNNModule.cpp
+++ b/python/TTNNModule.cpp
@@ -8,8 +8,6 @@
 #include "ttmlir-c/TTNNAttrs.h"
 
 #include <nanobind/stl/optional.h>
-#include <optional>
-
 namespace mlir::ttmlir::python {
 void populateTTNNModule(nb::module_ &m) {
 
@@ -154,22 +152,28 @@ void populateTTNNModule(nb::module_ &m) {
       .def_prop_ro("data_type_as_int", [](tt::ttnn::TTNNLayoutAttr self) {
         return static_cast<uint32_t>(self.getDataType());
       });
+
   tt_attribute_class<tt::ttnn::Conv2dConfigAttr>(m, "Conv2dConfigAttr")
       .def_static(
           "get",
-          [](MlirContext ctx, tt::DataType dtype, tt::DataType weightsDtype,
-             StringAttr activation, uint32_t inputChannelsAlignment,
-             bool deallocateActivation, bool reallocateHaloOutput,
-             uint32_t actBlockHOverride, uint32_t actBlockWDiv,
-             bool reshardIfNotOptimal, bool overrideShardingConfig,
-             tt::ttnn::TensorMemoryLayoutAttr shardLayout,
-             tt::ttnn::CoreRangeSetAttr coreGrid, bool transposeShards,
-             tt::ttnn::Layout outputLayout, bool preprocessWeightsOnDevice,
-             bool alwaysPreprocessWeights, bool enableActDoubleBuffer,
-             bool enableWeightsDoubleBuffer, bool enableSplitReader,
-             bool enableSubblockPadding) {
+          [](MlirContext ctx, std::optional<tt::DataType> dtype,
+             std::optional<tt::DataType> weightsDtype, StringAttr activation,
+             std::optional<uint32_t> inputChannelsAlignment,
+             BoolAttr deallocateActivation, BoolAttr reallocateHaloOutput,
+             std::optional<uint32_t> actBlockHOverride,
+             std::optional<uint32_t> actBlockWDiv, BoolAttr reshardIfNotOptimal,
+             BoolAttr overrideShardingConfig,
+             std::optional<tt::ttnn::TensorMemoryLayout> shardLayout,
+             tt::ttnn::CoreRangeSetAttr coreGrid, BoolAttr transposeShards,
+             std::optional<tt::ttnn::Layout> outputLayout,
+             BoolAttr preprocessWeightsOnDevice,
+             BoolAttr alwaysPreprocessWeights, BoolAttr enableActDoubleBuffer,
+             BoolAttr enableWeightsDoubleBuffer, BoolAttr enableSplitReader,
+             BoolAttr enableSubblockPadding) {
+            MLIRContext *context = unwrap(ctx);
+
             return wrap(tt::ttnn::Conv2dConfigAttr::get(
-                unwrap(ctx), dtype, weightsDtype, activation,
+                context, dtype, weightsDtype, activation,
                 inputChannelsAlignment, deallocateActivation,
                 reallocateHaloOutput, actBlockHOverride, actBlockWDiv,
                 reshardIfNotOptimal, overrideShardingConfig, shardLayout,
@@ -179,86 +183,160 @@ void populateTTNNModule(nb::module_ &m) {
                 enableSplitReader, enableSubblockPadding));
           })
       .def_prop_ro("dtype_as_int",
-                   [](tt::ttnn::Conv2dConfigAttr self) {
-                     return static_cast<uint32_t>(self.getDtype());
+                   [](tt::ttnn::Conv2dConfigAttr self)
+                       -> std::variant<nb::object, uint32_t> {
+                     if (!self.getDtype()) {
+                       return nb::none();
+                     }
+                     return static_cast<uint32_t>(*self.getDtype());
                    })
       .def_prop_ro("weights_dtype_as_int",
-                   [](tt::ttnn::Conv2dConfigAttr self) {
-                     return static_cast<uint32_t>(self.getDtype());
+                   [](tt::ttnn::Conv2dConfigAttr self)
+                       -> std::variant<nb::object, uint32_t> {
+                     if (!self.getWeightsDtype()) {
+                       return nb::none();
+                     }
+                     return static_cast<uint32_t>(*self.getWeightsDtype());
                    })
       .def_prop_ro("activation",
-                   [](tt::ttnn::Conv2dConfigAttr self) {
-                     return self.getActivation().str();
+                   [](tt::ttnn::Conv2dConfigAttr self)
+                       -> std::variant<nb::object, std::string> {
+                     if (!self.getActivation()) {
+                       return nb::none();
+                     }
+                     return self.getActivation().getValue().str();
                    })
       .def_prop_ro("input_channels_alignment",
-                   [](tt::ttnn::Conv2dConfigAttr self) {
-                     return self.getInputChannelsAlignment();
+                   [](tt::ttnn::Conv2dConfigAttr self)
+                       -> std::variant<nb::object, uint32_t> {
+                     if (!self.getInputChannelsAlignment()) {
+                       return nb::none();
+                     }
+                     return static_cast<uint32_t>(
+                         *self.getInputChannelsAlignment());
                    })
       .def_prop_ro("deallocate_activation",
-                   [](tt::ttnn::Conv2dConfigAttr self) {
-                     return self.getDeallocateActivation();
+                   [](tt::ttnn::Conv2dConfigAttr self)
+                       -> std::variant<nb::object, bool> {
+                     if (!self.getDeallocateActivation()) {
+                       return nb::none();
+                     }
+                     return self.getDeallocateActivation().getValue();
                    })
       .def_prop_ro("reallocate_halo_output",
-                   [](tt::ttnn::Conv2dConfigAttr self) {
-                     return self.getReallocateHaloOutput();
+                   [](tt::ttnn::Conv2dConfigAttr self)
+                       -> std::variant<nb::object, bool> {
+                     if (!self.getReallocateHaloOutput()) {
+                       return nb::none();
+                     }
+                     return self.getReallocateHaloOutput().getValue();
                    })
       .def_prop_ro("act_block_h_override",
-                   [](tt::ttnn::Conv2dConfigAttr self) {
-                     return self.getActBlockHOverride();
+                   [](tt::ttnn::Conv2dConfigAttr self)
+                       -> std::variant<nb::object, uint32_t> {
+                     if (!self.getActBlockHOverride()) {
+                       return nb::none();
+                     }
+                     return *self.getActBlockHOverride();
                    })
       .def_prop_ro("act_block_w_div",
-                   [](tt::ttnn::Conv2dConfigAttr self) {
-                     return self.getActBlockWDiv();
+                   [](tt::ttnn::Conv2dConfigAttr self)
+                       -> std::variant<nb::object, uint32_t> {
+                     if (!self.getActBlockWDiv()) {
+                       return nb::none();
+                     }
+                     return *self.getActBlockWDiv();
                    })
       .def_prop_ro("reshard_if_not_optimal",
-                   [](tt::ttnn::Conv2dConfigAttr self) {
-                     return self.getReshardIfNotOptimal();
+                   [](tt::ttnn::Conv2dConfigAttr self)
+                       -> std::variant<nb::object, bool> {
+                     if (!self.getReshardIfNotOptimal()) {
+                       return nb::none();
+                     }
+                     return self.getReshardIfNotOptimal().getValue();
                    })
       .def_prop_ro("override_sharding_config",
-                   [](tt::ttnn::Conv2dConfigAttr self) {
-                     return self.getOverrideShardingConfig();
+                   [](tt::ttnn::Conv2dConfigAttr self)
+                       -> std::variant<nb::object, bool> {
+                     if (!self.getOverrideShardingConfig()) {
+                       return nb::none();
+                     }
+                     return self.getOverrideShardingConfig().getValue();
                    })
       .def_prop_ro("shard_layout_as_int",
-                   [](tt::ttnn::Conv2dConfigAttr self) {
-                     return self.getShardLayout()
-                                ? std::optional<uint32_t>(static_cast<uint32_t>(
-                                      self.getShardLayout().getValue()))
-                                : std::nullopt;
+                   [](tt::ttnn::Conv2dConfigAttr self)
+                       -> std::variant<nb::object, uint32_t> {
+                     if (!self.getShardLayout()) {
+                       return nb::none();
+                     }
+                     return static_cast<uint32_t>(*self.getShardLayout());
                    })
       // TODO(vkovacevic): parse core_grid #2781
       .def_prop_ro("core_grid",
                    [](tt::ttnn::Conv2dConfigAttr self) { return nb::none(); })
       .def_prop_ro("transpose_shards",
-                   [](tt::ttnn::Conv2dConfigAttr self) {
-                     return self.getTransposeShards();
+                   [](tt::ttnn::Conv2dConfigAttr self)
+                       -> std::variant<nb::object, bool> {
+                     if (!self.getTransposeShards()) {
+                       return nb::none();
+                     }
+                     return self.getTransposeShards().getValue();
                    })
       .def_prop_ro("output_layout_as_int",
-                   [](tt::ttnn::Conv2dConfigAttr self) {
-                     return static_cast<uint32_t>(self.getOutputLayout());
+                   [](tt::ttnn::Conv2dConfigAttr self)
+                       -> std::variant<nb::object, uint32_t> {
+                     if (!self.getOutputLayout()) {
+                       return nb::none();
+                     }
+                     return static_cast<uint32_t>(*self.getOutputLayout());
                    })
       .def_prop_ro("preprocess_weights_on_device",
-                   [](tt::ttnn::Conv2dConfigAttr self) {
-                     return self.getPreprocessWeightsOnDevice();
+                   [](tt::ttnn::Conv2dConfigAttr self)
+                       -> std::variant<nb::object, bool> {
+                     if (!self.getPreprocessWeightsOnDevice()) {
+                       return nb::none();
+                     }
+                     return self.getPreprocessWeightsOnDevice().getValue();
                    })
       .def_prop_ro("always_preprocess_weights",
-                   [](tt::ttnn::Conv2dConfigAttr self) {
-                     return self.getAlwaysPreprocessWeights();
+                   [](tt::ttnn::Conv2dConfigAttr self)
+                       -> std::variant<nb::object, bool> {
+                     if (!self.getAlwaysPreprocessWeights()) {
+                       return nb::none();
+                     }
+                     return self.getAlwaysPreprocessWeights().getValue();
                    })
       .def_prop_ro("enable_act_double_buffer",
-                   [](tt::ttnn::Conv2dConfigAttr self) {
-                     return self.getEnableActDoubleBuffer();
+                   [](tt::ttnn::Conv2dConfigAttr self)
+                       -> std::variant<nb::object, bool> {
+                     if (!self.getEnableActDoubleBuffer()) {
+                       return nb::none();
+                     }
+                     return self.getEnableActDoubleBuffer().getValue();
                    })
       .def_prop_ro("enable_weights_double_buffer",
-                   [](tt::ttnn::Conv2dConfigAttr self) {
-                     return self.getEnableWeightsDoubleBuffer();
+                   [](tt::ttnn::Conv2dConfigAttr self)
+                       -> std::variant<nb::object, bool> {
+                     if (!self.getEnableWeightsDoubleBuffer()) {
+                       return nb::none();
+                     }
+                     return self.getEnableWeightsDoubleBuffer().getValue();
                    })
       .def_prop_ro("enable_split_reader",
-                   [](tt::ttnn::Conv2dConfigAttr self) {
-                     return self.getEnableSplitReader();
+                   [](tt::ttnn::Conv2dConfigAttr self)
+                       -> std::variant<nb::object, bool> {
+                     if (!self.getEnableSplitReader()) {
+                       return nb::none();
+                     }
+                     return self.getEnableSplitReader().getValue();
                    })
       .def_prop_ro("enable_subblock_padding",
-                   [](tt::ttnn::Conv2dConfigAttr self) {
-                     return self.getEnableSubblockPadding();
+                   [](tt::ttnn::Conv2dConfigAttr self)
+                       -> std::variant<nb::object, bool> {
+                     if (!self.getEnableSubblockPadding()) {
+                       return nb::none();
+                     }
+                     return self.getEnableSubblockPadding().getValue();
                    });
 
   tt_attribute_class<tt::ttnn::CoreRangeAttr>(m, "CoreRangeAttr")

--- a/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/utils.cpp
+++ b/runtime/lib/ttnn/operations/include/tt/runtime/ttnn/operations/utils.cpp
@@ -251,42 +251,97 @@ createMatmulProgramConfigIfNeeded(const ::tt::target::ttnn::MatmulOp *op) {
 }
 
 ::ttnn::operations::conv::conv2d::Conv2dConfig
-createConv2dConfig(const ::tt::target::ttnn::Conv2dConfig *memcfg) {
-  std::optional<::ttnn::TensorMemoryLayout> shardLayout;
-  if (memcfg->shard_layout()) {
-    shardLayout = ::tt::runtime::ttnn::utils::toTTNNTensorMemoryLayout(
-        memcfg->shard_layout().value());
-  }
-  std::optional<::ttnn::CoreRangeSet> coreGrid;
-  if (memcfg->core_grid()) {
-    coreGrid =
-        ::tt::runtime::ttnn::utils::toTTNNCoreRangeSet(*memcfg->core_grid());
+createConv2dConfig(const ::tt::target::ttnn::Conv2dConfig *config) {
+  ::ttnn::operations::conv::Conv2dConfig conv2dConfig;
+
+  if (config->dtype()) {
+    conv2dConfig.dtype =
+        ::tt::runtime::ttnn::utils::toTTNNDataType(*config->dtype());
   }
 
-  ::ttnn::operations::conv::conv2d::Conv2dConfig conv2dConfig = {
-      .dtype = ::tt::runtime::ttnn::utils::toTTNNDataType(memcfg->dtype()),
-      .weights_dtype =
-          ::tt::runtime::ttnn::utils::toTTNNDataType(memcfg->weights_dtype()),
-      .activation = memcfg->activation()->str(),
-      .input_channels_alignment = memcfg->input_channels_alignment(),
-      .deallocate_activation = memcfg->deallocate_activation(),
-      .reallocate_halo_output = memcfg->reallocate_halo_output(),
-      .act_block_h_override = memcfg->act_block_h_override(),
-      .act_block_w_div = memcfg->act_block_w_div(),
-      .reshard_if_not_optimal = memcfg->reshard_if_not_optimal(),
-      .override_sharding_config = memcfg->override_sharding_config(),
-      .shard_layout = shardLayout,
-      .core_grid = coreGrid,
-      .transpose_shards = memcfg->transpose_shards(),
-      .output_layout =
-          ::tt::runtime::ttnn::utils::toTTNNLayout(memcfg->output_layout()),
-      .preprocess_weights_on_device = memcfg->preprocess_weights_on_device(),
-      .always_preprocess_weights = memcfg->always_preprocess_weights(),
-      .enable_act_double_buffer = memcfg->enable_act_double_buffer(),
-      .enable_weights_double_buffer = memcfg->enable_weights_double_buffer(),
-      .enable_split_reader = memcfg->enable_split_reader(),
-      .enable_subblock_padding = memcfg->enable_subblock_padding(),
-  };
+  if (config->weights_dtype()) {
+    conv2dConfig.weights_dtype =
+        ::tt::runtime::ttnn::utils::toTTNNDataType(*config->weights_dtype());
+  }
+
+  if (config->activation()) {
+    conv2dConfig.activation = config->activation()->str();
+  }
+
+  if (config->input_channels_alignment()) {
+    conv2dConfig.input_channels_alignment = *config->input_channels_alignment();
+  }
+
+  if (config->deallocate_activation()) {
+    conv2dConfig.deallocate_activation = *config->deallocate_activation();
+  }
+
+  if (config->reallocate_halo_output()) {
+    conv2dConfig.reallocate_halo_output = *config->reallocate_halo_output();
+  }
+
+  if (config->act_block_h_override()) {
+    conv2dConfig.act_block_h_override = *config->act_block_h_override();
+  }
+
+  if (config->act_block_w_div()) {
+    conv2dConfig.act_block_w_div = *config->act_block_w_div();
+  }
+
+  if (config->reshard_if_not_optimal()) {
+    conv2dConfig.reshard_if_not_optimal = *config->reshard_if_not_optimal();
+  }
+
+  if (config->override_sharding_config()) {
+    conv2dConfig.override_sharding_config = *config->override_sharding_config();
+  }
+
+  if (config->shard_layout()) {
+    conv2dConfig.shard_layout =
+        ::tt::runtime::ttnn::utils::toTTNNTensorMemoryLayout(
+            *config->shard_layout());
+  }
+
+  if (config->core_grid()) {
+    conv2dConfig.core_grid = std::make_optional(
+        ::tt::runtime::ttnn::utils::toTTNNCoreRangeSet(*config->core_grid()));
+  }
+
+  if (config->transpose_shards()) {
+    conv2dConfig.transpose_shards = *config->transpose_shards();
+  }
+
+  if (config->output_layout()) {
+    conv2dConfig.output_layout =
+        ::tt::runtime::ttnn::utils::toTTNNLayout(*config->output_layout());
+  }
+
+  if (config->preprocess_weights_on_device()) {
+    conv2dConfig.preprocess_weights_on_device =
+        *config->preprocess_weights_on_device();
+  }
+
+  if (config->always_preprocess_weights()) {
+    conv2dConfig.always_preprocess_weights =
+        *config->always_preprocess_weights();
+  }
+
+  if (config->enable_act_double_buffer()) {
+    conv2dConfig.enable_act_double_buffer = *config->enable_act_double_buffer();
+  }
+
+  if (config->enable_weights_double_buffer()) {
+    conv2dConfig.enable_weights_double_buffer =
+        *config->enable_weights_double_buffer();
+  }
+
+  if (config->enable_split_reader()) {
+    conv2dConfig.enable_split_reader = *config->enable_split_reader();
+  }
+
+  if (config->enable_subblock_padding()) {
+    conv2dConfig.enable_subblock_padding = *config->enable_subblock_padding();
+  }
 
   return conv2dConfig;
 }

--- a/test/ttmlir/Dialect/TTIR/conv2d/conv2d_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/conv2d/conv2d_tests_negative.mlir
@@ -166,7 +166,7 @@ module {
 // Verify the parsing fails if number of channels are incorrect
 // -----
 module {
-  func.func @conv2d_input_channels_not_divisible_by_groups(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<100x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x100xbf16> {
+  func.func @conv2d_input_channels_not_divisible_by_groups(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x100xbf16> {
     %0 = ttir.empty() : tensor<1x30x30x100xbf16>
     // CHECK: error: 'ttir.conv2d' op Number of input channels from input tensor must be divisible by the number of groups. Got 64 input channels and 10 groups
     %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
@@ -175,14 +175,14 @@ module {
               padding = 0: i32,
               dilation = 1: i32,
               groups = 10: i32
-            }> : (tensor<1x32x32x64xbf16>, tensor<100x64x3x3xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x100xbf16>) -> tensor<1x30x30x100xbf16>
+            }> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x100xbf16>) -> tensor<1x30x30x100xbf16>
     return %1 : tensor<1x30x30x100xbf16>
   }
 }
 
 // -----
 module {
-  func.func @conv2d_output_channels_not_divisible_by_groups(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<128x64x3x3xbf16>, %arg2: tensor<1x1x1x102xbf16>) -> tensor<1x30x30x102xbf16> {
+  func.func @conv2d_output_channels_not_divisible_by_groups(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<128x64x3x3xbf16>, %arg2: tensor<1x1x1x128xbf16>) -> tensor<1x30x30x102xbf16> {
     %0 = ttir.empty() : tensor<1x30x30x102xbf16>
     // CHECK: error: 'ttir.conv2d' op Number of output channels from output tensor must be divisible by the number of groups. Got 102 output channels and 8 groups
     %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
@@ -191,7 +191,7 @@ module {
               padding = 0: i32,
               dilation = 1: i32,
               groups = 8: i32
-            }> : (tensor<1x32x32x64xbf16>, tensor<128x64x3x3xbf16>, tensor<1x1x1x102xbf16>, tensor<1x30x30x102xbf16>) -> tensor<1x30x30x102xbf16>
+            }> : (tensor<1x32x32x64xbf16>, tensor<128x64x3x3xbf16>, tensor<1x1x1x128xbf16>, tensor<1x30x30x102xbf16>) -> tensor<1x30x30x102xbf16>
     return %1 : tensor<1x30x30x102xbf16>
   }
 }
@@ -214,7 +214,7 @@ module {
 
 // -----
 module {
-  func.func @conv2d_output_channels_missmatch_with_weight(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<128x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x64xbf16> {
+  func.func @conv2d_output_channels_missmatch_with_weight(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<128x64x3x3xbf16>, %arg2: tensor<1x1x1x128xbf16>) -> tensor<1x30x30x64xbf16> {
     %0 = ttir.empty() : tensor<1x30x30x64xbf16>
     // CHECK:  error: 'ttir.conv2d' op Number of output channels from output tensor must match the first dimension of the weight tensor. Got 64 output channels and 128 in the weight tensor
     %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
@@ -223,16 +223,16 @@ module {
               padding = 0: i32,
               dilation = 1: i32,
               groups = 1: i32
-            }> : (tensor<1x32x32x64xbf16>, tensor<128x64x3x3xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+            }> : (tensor<1x32x32x64xbf16>, tensor<128x64x3x3xbf16>, tensor<1x1x1x128xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
     return %1 : tensor<1x30x30x64xbf16>
   }
 }
 
 // -----
 module {
-  func.func @conv2d_output_channels_missmatch_with_bias(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x128xbf16>) -> tensor<1x30x30x64xbf16> {
+  func.func @conv2d_weight_and_bias_missmatch(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x128xbf16>) -> tensor<1x30x30x64xbf16> {
     %0 = ttir.empty() : tensor<1x30x30x64xbf16>
-    // CHECK: error: 'ttir.conv2d' op Mismatch in bias tensor dimensions. Bias tensor has 128 channels, but the output tensor has 64 channels
+    // CHECK: error: 'ttir.conv2d' op Bias should have shape [1, 1, 1, 64] but got [1, 1, 1, 128]
     %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
             <{
               stride = 1: i32,

--- a/test/ttmlir/Dialect/TTNN/conv/conv2d/conv2d_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/conv/conv2d/conv2d_tests_negative.mlir
@@ -291,9 +291,9 @@ module {
 
 // -----
 module {
-  func.func @conv2d_input_channels_missmatch_with_output_tensor(%arg0: tensor<1x1x1024x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x32xbf16>) -> tensor<1x1x900x64xbf16> {
+  func.func @conv2d_input_channels_missmatch_with_output_tensor(%arg0: tensor<1x1x1024x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x1x900x64xbf16> {
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    // CHECK: error: 'ttnn.conv2d' op Expected output channels attribute (32) to match the last dimension of the output tensor (64)
+    // CHECK: error: 'ttnn.conv2d' op Expected output channels attribute (32) to match the last dimension of the bias tensor (64)
     %1 = "ttnn.conv2d"(%arg0, %arg1, %arg2, %0)
             <{
               in_channels = 64: i32,
@@ -306,7 +306,7 @@ module {
               padding = array<i32: 0, 0>,
               dilation = array<i32: 1, 1>,
               groups = 1: i32
-            }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x32xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
+            }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
     return %1 : tensor<1x1x900x64xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_conv2d_config.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_conv2d_config.mlir
@@ -21,7 +21,7 @@
   act_block_w_div = 1,
   reshard_if_not_optimal = false,
   override_sharding_config = false,
-  shard_layout = #ttnn.tensor_memory_layout<height_sharded>,
+  shard_layout = height_sharded,
   core_grid = #ttnn.core_range_set<>,
   transpose_shards = true,
   output_layout = tile,


### PR DESCRIPTION
If we want to fuse relu and conv we need to set activation param in `Conv2dConfigAttr`, but since majority of it's params are non-optional we would have to determine correct parameters. This PR changes all params of `Conv2dConfgAttr` so that we can easily specify which parameter we want to override and leave the rest to default to whatever is set in ttnn.