### PR TITLE
Allow getCurrentSystemDesc to take in Device as optional parameter

### DIFF
--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -15,7 +15,8 @@ namespace tt::runtime {
 
 namespace system_desc {
 std::pair<SystemDesc, DeviceIds> getCurrentSystemDesc(
-    std::optional<DispatchCoreType> dispatchCoreType = std::nullopt);
+    std::optional<DispatchCoreType> dispatchCoreType = std::nullopt,
+    std::optional<Device> meshDevice = std::nullopt);
 } // namespace system_desc
 
 namespace detail {
@@ -45,7 +46,8 @@ void setCurrentRuntime(const DeviceRuntime &runtime);
 void setCompatibleRuntime(const Binary &binary);
 
 std::pair<SystemDesc, DeviceIds> getCurrentSystemDesc(
-    std::optional<DispatchCoreType> dispatchCoreType = std::nullopt);
+    std::optional<DispatchCoreType> dispatchCoreType = std::nullopt,
+    std::optional<Device> meshDevice = std::nullopt);
 
 // Creates host tensor with owned storage (the buffer of the tensor is on the
 // host and its allocation/deallocation is owned by this tensor instance).

--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -73,18 +73,25 @@ struct RuntimeCheckedObjectImpl {
   bool matchesRuntime(DeviceRuntime runtime) const {
     return associatedRuntime == runtime;
   }
+  void assertMatchesRuntime(DeviceRuntime expectedRuntime) const {
+    assert(matchesRuntime(expectedRuntime) &&
+           "Associated runtime does not match expected runtime of cast");
+  }
 
   template <typename T>
   T &as(DeviceRuntime expectedRuntime) {
-    assert(associatedRuntime == expectedRuntime &&
-           "Associated runtime does not match expected runtime of cast");
+    assertMatchesRuntime(expectedRuntime);
     return *static_cast<T *>(handle.get());
   }
   template <typename T>
   T const &as(DeviceRuntime expectedRuntime) const {
-    assert(associatedRuntime == expectedRuntime &&
-           "Associated runtime does not match expected runtime of cast");
+    assertMatchesRuntime(expectedRuntime);
     return *static_cast<T const *>(handle.get());
+  }
+  template <typename T>
+  std::shared_ptr<T> asSharedPtr(DeviceRuntime expectedRuntime) const {
+    assertMatchesRuntime(expectedRuntime);
+    return std::static_pointer_cast<T>(handle);
   }
 };
 

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -127,9 +127,10 @@ void setCompatibleRuntime(const Binary &binary) {
 }
 
 std::pair<SystemDesc, DeviceIds>
-getCurrentSystemDesc(std::optional<DispatchCoreType> dispatchCoreType) {
+getCurrentSystemDesc(std::optional<DispatchCoreType> dispatchCoreType,
+                     std::optional<Device> meshDevice) {
 #if defined(TT_RUNTIME_ENABLE_TTNN) || defined(TT_RUNTIME_ENABLE_TTMETAL)
-  return system_desc::getCurrentSystemDesc(dispatchCoreType);
+  return system_desc::getCurrentSystemDesc(dispatchCoreType, meshDevice);
 #endif
   LOG_FATAL("runtime is not enabled");
 }

--- a/runtime/test/python/ttnn/device_agnostic/test_runtime_api.py
+++ b/runtime/test/python/ttnn/device_agnostic/test_runtime_api.py
@@ -194,3 +194,42 @@ def test_set_program_cache(helper):
         assert (
             ttrt.runtime.testing.is_program_cache_enabled(device) == True
         ), "Expected program cache to be enabled"
+
+
+@pytest.mark.parametrize(
+    "runtime",
+    [ttrt.runtime.DeviceRuntime.TTNN, ttrt.runtime.DeviceRuntime.TTMetal],
+    ids=["ttnn", "ttmetal"],
+)
+@pytest.mark.parametrize(
+    "dispatch_core_type",
+    [None, ttrt.runtime.DispatchCoreType.ETH, ttrt.runtime.DispatchCoreType.WORKER],
+    ids=["no_dispatch_core", "eth_dispatch_core", "worker_dispatch_core"],
+)
+@pytest.mark.parametrize("with_device", [False, True], ids=["no_device", "with_device"])
+def test_get_system_desc(runtime, dispatch_core_type, with_device):
+    ttrt.runtime.set_current_runtime(runtime)
+    num_devices = ttrt.runtime.get_num_available_devices()
+
+    if with_device:
+        with DeviceContext(mesh_shape=[1, num_devices]) as device:
+            system_desc, device_ids = ttrt.runtime.get_current_system_desc(
+                dispatch_core_type, device
+            )
+
+    else:
+        system_desc, device_ids = ttrt.runtime.get_current_system_desc(
+            dispatch_core_type
+        )
+
+        assert (
+            len(device_ids) == num_devices
+        ), f"Expected {num_devices} device IDs, got {len(device_ids)}"
+
+    assert system_desc is not None, "System descriptor should exist"
+    assert device_ids is not None, "Device IDs should exist"
+
+    sorted_device_ids = sorted(device_ids)
+    assert (
+        device_ids == sorted_device_ids
+    ), f"Expected device IDs {sorted_device_ids}, got {device_ids}"

--- a/runtime/tools/python/ttrt/runtime/module.cpp
+++ b/runtime/tools/python/ttrt/runtime/module.cpp
@@ -162,6 +162,8 @@ PYBIND11_MODULE(_C, m) {
   m.def("set_current_runtime", &tt::runtime::setCurrentRuntime,
         py::arg("runtime"), "Set the backend device runtime type");
   m.def("get_current_system_desc", &tt::runtime::getCurrentSystemDesc,
+        py::arg("dispatch_core_type") = py::none(),
+        py::arg("mesh_device") = py::none(),
         "Get the current system descriptor");
   m.def(
       "create_tensor",


### PR DESCRIPTION
### Ticket
[Torch Issue 580](https://github.com/tenstorrent/tt-torch/issues/580)

### Problem description
Creating system descriptor currently opens a device by itself. Which means callers cannot have the same device open when `getCurrentSystemDesc` is called.

### What's changed
Allow `getCurrentSystemDesc` to accept a device as argument so it doesn't need to create one itself and callers can have the same device open when this function is called.

### Checklist
- [x] New/Existing tests provide coverage for changes
- [x] Tested usage in tt-torch [[link to torch branch]](https://github.com/tenstorrent/tt-torch/compare/main...brata/sysdesc_device)
