### PR TITLE
Add mesh offset to get device op, update runtime implementation

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -22,10 +22,13 @@ include "mlir/IR/CommonAttrConstraints.td"
 def TTNN_GetDeviceOp : TTNN_Op<"get_device", [TT_DuplicateConstEvalTrait]> {
     let summary = "Get Device op.";
     let description = [{
-      This op returns the current runtime device.
+      This op returns a submesh carved out from the parent runtime device.
+      Mesh shape and mesh offset define the size and offset of the submesh.
     }];
 
-    let arguments = (ins OptionalAttr<TTNN_MeshShapeAttr>:$mesh_shape);
+    let arguments = (ins OptionalAttr<TTNN_MeshShapeAttr>:$mesh_shape,
+                         OptionalAttr<TTNN_MeshOffsetAttr>:$mesh_offset);
+
     let results = (outs TTNN_Device:$device);
 }
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
@@ -23,6 +23,11 @@ class TTNN_Attr<string name, string attrMnemonic, list<Trait> traits = [],
   let attrName = "ttnn." # attrMnemonic;
 }
 
+class TTNN_Mesh2DCoordAttr<string name, string mnemonic> : TTNN_Attr<name, mnemonic> {
+  let parameters = (ins "int64_t":$y, "int64_t":$x);
+  let assemblyFormat = "custom<VargDimensionList>($y, $x)";
+}
+
 def TTNN_CoreCoordAttr : TTNN_Attr<"CoreCoord", "core_coord"> {
   let summary = "A 2D coordinate of a core in the core grid";
   let description = [{
@@ -421,14 +426,18 @@ def TTNN_Conv2dConfigAttr : TTNN_Attr<"Conv2dConfig", "conv2d_config"> {
   }];
 }
 
-def TTNN_MeshShapeAttr : TTNN_Attr<"MeshShape", "mesh_shape"> {
+def TTNN_MeshShapeAttr : TTNN_Mesh2DCoordAttr<"MeshShape", "mesh_shape"> {
   let summary = "TTNN Mesh Shape";
   let description = [{
-    TTNN mesh shape
+    TTNN mesh shape representing the dimensions of a 2D mesh.
   }];
+}
 
-  let parameters = (ins "int64_t":$y, "int64_t":$x);
-  let assemblyFormat = "custom<VargDimensionList>($y, $x)";
+def TTNN_MeshOffsetAttr : TTNN_Mesh2DCoordAttr<"MeshOffset", "mesh_offset"> {
+  let summary = "TTNN Mesh Offset";
+  let description = [{
+    TTNN mesh offset representing the starting coordinates in a 2D mesh.
+  }];
 }
 
 def TTNN_TTNNLayoutAttr: TTNN_Attr<"TTNNLayout", "ttnn_layout"> {

--- a/include/ttmlir/Target/TTNN/operations/get_device.fbs
+++ b/include/ttmlir/Target/TTNN/operations/get_device.fbs
@@ -5,6 +5,7 @@ namespace tt.target.ttnn;
 
 table GetDeviceOp {
   mesh: tt.target.Dim2d;
+  offset: tt.target.Dim2d;
   chip_ids: [uint32];
   out: tt.target.DeviceRef;
 }

--- a/lib/Dialect/TTNN/Transforms/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/Optimizer.cpp
@@ -481,10 +481,16 @@ private:
     if (meshShape.empty()) {
       meshShape = llvm::SmallVector<int64_t, 2>{1, 1};
     }
+    // TODO (jnie): Currently hardcoding the mesh offset to 0x0
+    // Need a proper plan to dynamically determine this.
+    llvm::SmallVector<int64_t, 2> meshOffset{0, 0};
+
     auto deviceOp = builder.create<ttnn::GetDeviceOp>(
         contextOp->getLoc(), builder.getType<DeviceType>(),
         ttnn::MeshShapeAttr::get(contextOp->getContext(), meshShape[0],
-                                 meshShape[1]));
+                                 meshShape[1]),
+        ttnn::MeshOffsetAttr::get(contextOp->getContext(), meshOffset[0],
+                                  meshOffset[1]));
     builder.restoreInsertionPoint(currentInsertionPoint);
     return deviceOp;
   }

--- a/lib/Dialect/TTNN/Utils/TransformUtils.cpp
+++ b/lib/Dialect/TTNN/Utils/TransformUtils.cpp
@@ -28,9 +28,14 @@ GetDeviceOp getOrInsertDevice(RewriterBase &rewriter, Operation *op) {
   if (meshShape.empty()) {
     meshShape = llvm::SmallVector<int64_t, 2>{1, 1};
   }
+  // TODO (jnie): Currently hardcoding the mesh offset to 0x0
+  // Need a proper plan to dynamically determine this.
+  llvm::SmallVector<int64_t, 2> meshOffset{0, 0};
   auto deviceOp = rewriter.create<ttnn::GetDeviceOp>(
       op->getLoc(), rewriter.getType<DeviceType>(),
-      ttnn::MeshShapeAttr::get(op->getContext(), meshShape[0], meshShape[1]));
+      ttnn::MeshShapeAttr::get(op->getContext(), meshShape[0], meshShape[1]),
+      ttnn::MeshOffsetAttr::get(op->getContext(), meshOffset[0],
+                                meshOffset[1]));
   rewriter.restoreInsertionPoint(currentInsertionPoint);
   return deviceOp;
 }

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -336,9 +336,15 @@ createOp(FlatbufferObjectCache &cache, GetDeviceOp op) {
     mesh = ::tt::target::Dim2d(1, 1);
   }
 
+  ::tt::target::Dim2d offset(0, 0);
+  if (auto offsetAttr = op.getMeshOffset()) {
+    offset = ::tt::target::Dim2d(offsetAttr->getY(), offsetAttr->getX());
+  }
+
   auto chipIds = toFlatbuffer(cache, desc.getChipIds());
   auto out = cache.getOrCreate(result, createDeviceRef);
-  return ::tt::target::ttnn::CreateGetDeviceOp(*cache.fbb, &mesh, chipIds, out);
+  return ::tt::target::ttnn::CreateGetDeviceOp(*cache.fbb, &mesh, &offset,
+                                               chipIds, out);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::ToMemoryConfigOp>

--- a/runtime/lib/ttnn/operations/context/get_device.cpp
+++ b/runtime/lib/ttnn/operations/context/get_device.cpp
@@ -13,40 +13,20 @@ namespace tt::runtime::ttnn::operations::context {
 using ::tt::tt_metal::distributed::MeshCoordinate;
 using ::tt::tt_metal::distributed::MeshShape;
 
-static MeshCoordinate
-calculateMeshCoordinate(const ::ttnn::MeshDevice &parentMesh,
-                        const std::unordered_set<uint32_t> &desiredDeviceIds,
-                        const ::tt::target::Dim2d *subMeshShape) {
-  for (uint32_t row = 0; row < parentMesh.shape()[0]; row++) {
-    for (uint32_t col = 0; col < parentMesh.shape()[1]; col++) {
-      const ::ttnn::IDevice *currDevice = parentMesh.get_device({row, col});
-      if (desiredDeviceIds.contains(currDevice->id())) {
-        return MeshCoordinate(row, col);
-      }
-    }
-  }
-  LOG_FATAL("Could not find any desired device in parent mesh");
-}
-
 static std::shared_ptr<::ttnn::MeshDevice>
 createSubMeshDevice(::ttnn::MeshDevice &parentMesh,
-                    const std::unordered_set<uint32_t> &desiredDeviceIds,
-                    const ::tt::target::Dim2d *subMeshShape) {
+                    const ::tt::target::Dim2d *subMeshShape,
+                    const ::tt::target::Dim2d *subMeshOffset) {
   // Carve out a submesh from the parentMesh
   MeshShape meshShape(subMeshShape->y(), subMeshShape->x());
-  MeshCoordinate coordinate =
-      calculateMeshCoordinate(parentMesh, desiredDeviceIds, subMeshShape);
-  return parentMesh.create_submesh(meshShape, coordinate);
+  MeshCoordinate meshOffset(subMeshOffset->y(), subMeshOffset->x());
+  return parentMesh.create_submesh(meshShape, meshOffset);
 }
 
 void run(const ::tt::target::ttnn::GetDeviceOp *op, ProgramContext &context) {
   ::ttnn::MeshDevice &meshDevice = context.getParentMesh();
   const ::tt::target::Dim2d *subMeshShape = op->mesh();
-  const ::flatbuffers::Vector<uint32_t> *deviceIds = op->chip_ids();
-  std::unordered_set<uint32_t> desiredDeviceIds(deviceIds->begin(),
-                                                deviceIds->end());
-  LOG_ASSERT(desiredDeviceIds.size() == deviceIds->size(),
-             "Duplicate device ids in get device op");
+  const ::tt::target::Dim2d *subMeshOffset = op->offset();
 
   // Re-map mesh if subMeshShape cannot be a submesh of current shape
   MeshShape meshShape = meshDevice.shape();
@@ -57,7 +37,7 @@ void run(const ::tt::target::ttnn::GetDeviceOp *op, ProgramContext &context) {
              meshDevice.shape()[1], "]");
   }
   std::shared_ptr<::ttnn::MeshDevice> subMesh =
-      createSubMeshDevice(meshDevice, desiredDeviceIds, subMeshShape);
+      createSubMeshDevice(meshDevice, subMeshShape, subMeshOffset);
   context.addSubMesh(op->out()->global_id(), subMesh);
 }
 } // namespace tt::runtime::ttnn::operations::context

--- a/runtime/tools/python/ttrt/common/run.py
+++ b/runtime/tools/python/ttrt/common/run.py
@@ -443,7 +443,6 @@ class Run:
 
             mesh_shape = [1, len(self.query.device_ids)]
             mesh_options = ttrt.runtime.MeshDeviceOptions()
-            mesh_options.device_ids = self.query.device_ids
             mesh_options.dispatch_core_type = dispatch_core_type
             mesh_options.enable_async_ttnn = self["--enable-async-ttnn"]
             device = ttrt.runtime.open_mesh_device(mesh_shape, mesh_options)

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -367,7 +367,8 @@ TEST_F(OpModelBase, toLayoutOp) {
   // device
   GetDeviceOp deviceOp = builder.create<ttnn::GetDeviceOp>(
       builder.getUnknownLoc(), builder.getType<DeviceType>(),
-      ttnn::MeshShapeAttr::get(builder.getContext(), 1, 1));
+      ttnn::MeshShapeAttr::get(builder.getContext(), 1, 1),
+      ttnn::MeshOffsetAttr::get(builder.getContext(), 0, 0));
   ToLayoutOp toLayout = builder.create<ToLayoutOp>(
       builder.getUnknownLoc(), tensor.getType(), tensor, Layout::Tile, nullptr,
       nullptr, deviceOp);
@@ -493,7 +494,8 @@ TEST_F(OpModelBase, Conv2dInterface) {
 
   GetDeviceOp deviceOp = builder.create<ttnn::GetDeviceOp>(
       builder.getUnknownLoc(), builder.getType<DeviceType>(),
-      ttnn::MeshShapeAttr::get(builder.getContext(), 1, 1));
+      ttnn::MeshShapeAttr::get(builder.getContext(), 1, 1),
+      ttnn::MeshOffsetAttr::get(builder.getContext(), 0, 0));
 
   Conv2dOp conv2d = builder.create<Conv2dOp>(
       builder.getUnknownLoc(), outputType, input, weight, nullptr, deviceOp, 3,


### PR DESCRIPTION
### Ticket
closes [tt-xla#484](https://github.com/tenstorrent/tt-xla/issues/484)

### Problem description
Get device op is still using device ids while we should be using mesh shape and offset.

### What's changed
Added mesh offset input attribute to `GetDeviceOp`, defaulting to (0, 0) for now, future plans would be to dynamically determine in the compiler or pass in by the user.

cc @wooseokTT @ajakovljevicTT 

### Checklist
- [X] New/Existing tests provide coverage for changes
