### PR TITLE
Fix macos build

### DIFF
--- a/lib/Dialect/TTIR/Transforms/EraseInverseOps/BroadcastCommutePatterns.cpp
+++ b/lib/Dialect/TTIR/Transforms/EraseInverseOps/BroadcastCommutePatterns.cpp
@@ -49,6 +49,9 @@ public:
     for (auto *user : users) {
       assert(checkIdenticalTms(transposeUser, user) &&
              "shouldCommute should have ensured this is true");
+    }
+
+    for (auto *user : users) {
       rewriter.replaceOp(user, newBroadcast);
     }
   }
@@ -292,6 +295,9 @@ public:
     for (auto *user : users) {
       assert(checkIdenticalTms(reshapeUser, user) &&
              "shouldCommute should have ensured this is true");
+    }
+
+    for (auto *user : users) {
       rewriter.replaceOp(user, newBroadcast);
     }
   }
@@ -362,6 +368,9 @@ public:
     for (auto *user : users) {
       assert(checkIdenticalTms(permuteUser, user) &&
              "shouldCommute should have ensured this is true");
+    }
+
+    for (auto *user : users) {
       rewriter.replaceOp(user, newBroadcast);
     }
   }

--- a/lib/Dialect/TTIR/Transforms/EraseInverseOps/ElementwiseCommutePatterns.cpp
+++ b/lib/Dialect/TTIR/Transforms/EraseInverseOps/ElementwiseCommutePatterns.cpp
@@ -66,6 +66,9 @@ public:
     for (auto *user : users) {
       assert(checkIdenticalTms(tmUser, user) &&
              "shouldCommute should have ensured this is true");
+    }
+
+    for (auto *user : users) {
       rewriter.replaceOp(user, newEltwise);
     }
   }


### PR DESCRIPTION
There was some UB in the erase inverse ops pass because we were erasing ops on the fly that participated in the preceding check.
