### PR TITLE
Fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -77,11 +77,6 @@ LICENSE @nsmithtt
 /lib/Dialect/TTIR/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @mrakitaTT @jserbedzijaTT @azecevicTT
 /test/ttmlir/Dialect/TTIR/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @mrakitaTT @jserbedzijaTT @azecevicTT
 
-# TTIR Erase Inverse Ops Optimization Pass
-/include/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps @LPanosTT @azecevicTT
-/lib/Dialect/TTIR/Transforms/EraseInverseOps @LPanosTT @azecevicTT
-/test/ttmlir/Dialect/TTIR/erase_inverse_ops @LPanosTT @azecevicTT
-
 # Metal Dialects
 /include/ttmlir/Dialect/TTIR/IR/TTIRGeneric* @nsmithtt @vroubtsovTT
 /include/ttmlir/Dialect/TTKernel/ @nsmithtt @vroubtsovTT
@@ -91,6 +86,11 @@ LICENSE @nsmithtt
 /lib/Dialect/TTMetal/ @nsmithtt @vroubtsovTT
 /test/ttmlir/Dialect/TTKernel/ @nsmithtt @vroubtsovTT
 /test/ttmlir/Dialect/TTMetal/ @nsmithtt @vroubtsovTT
+
+# TTIR Erase Inverse Ops Optimization Pass
+/include/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/ @LPanosTT @azecevicTT
+/lib/Dialect/TTIR/Transforms/EraseInverseOps/ @LPanosTT @azecevicTT
+/test/ttmlir/Dialect/TTIR/erase_inverse_ops/ @LPanosTT @azecevicTT
 
 # TTNN Dialects
 /include/ttmlir/Dialect/TTNN/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @jserbedzijaTT @azecevicTT


### PR DESCRIPTION
According to github CODEOWNERS rules last match wins. As seen here https://github.com/tenstorrent/tt-mlir/pull/2920, `/lib/Dialect/TTIR/Transforms/` wins over `/lib/Dialect/TTIR/Transforms/EraseInverseOps`, even though the latter (or former in the file) is more specific. I'm looking if there are some other cases as well, if someone can spot it it would be great.