### PR TITLE
Uplift third_party/tt-metal to 4f706555c6cfcb35a6a1f69783333c04e20ce683 2025-04-14

### DIFF
--- a/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
+++ b/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
@@ -40,6 +40,20 @@ struct IDevice;
 struct Tensor;
 
 namespace operations {
+namespace unary {
+
+// Mock definition of VecMode enum from tt-metal
+enum class VecMode {
+  None = 0,
+  R = 1,
+  C = 2,
+  RC = 4,
+  RC_custom = 6,
+  Invalid = 0xFF,
+};
+
+} // namespace unary
+
 namespace creation::detail {
 struct OptionalAnyDevice;
 } // namespace creation::detail

--- a/runtime/lib/ttnn/operations/conv/conv2d.cpp
+++ b/runtime/lib/ttnn/operations/conv/conv2d.cpp
@@ -59,11 +59,11 @@ void run(const ::tt::target::ttnn::Conv2dOp *op, ProgramContext &context) {
   ::ttnn::Tensor out = std::visit(
       [&](auto &&targetDevice) -> ::ttnn::Tensor {
         return std::get<0>(::ttnn::operations::conv::conv2d::conv2d(
-            input, weight, &(targetDevice.get()), op->in_channels(),
-            op->out_channels(), op->batch_size(), op->input_height(),
-            op->input_width(), kernelSize, stride, padding, dilation,
-            op->groups(), bias, conv2dConfig, computeConfig,
-            outputMemoryConfig));
+            ::ttnn::QueueId(0), input, weight, &(targetDevice.get()),
+            op->in_channels(), op->out_channels(), op->batch_size(),
+            op->input_height(), op->input_width(), kernelSize, stride, padding,
+            dilation, op->groups(), bias, conv2dConfig, computeConfig,
+            outputMemoryConfig, std::nullopt));
       },
       targetDevice);
 

--- a/runtime/lib/ttnn/operations/eltwise/binary/binary_composite.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/binary/binary_composite.cpp
@@ -36,12 +36,46 @@ static void runEltwiseBinaryCompositeOp(
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }
 
+static void runEltwiseBinaryCompositeMaxOp(
+    const ::tt::target::ttnn::EltwiseBinaryCompositeOp *op,
+    ProgramTensorPool &tensorPool,
+    const std::function<::ttnn::Tensor(
+        const ::ttnn::Tensor &, const ::ttnn::Tensor &,
+        const std::optional<const ::ttnn::DataType> &,
+        const std::optional<::ttnn::MemoryConfig> &,
+        const std::optional<::ttnn::Tensor> &,
+        tt::stl::Span<const ::ttnn::operations::unary::UnaryWithParam>,
+        tt::stl::Span<const ::ttnn::operations::unary::UnaryWithParam>,
+        tt::stl::Span<const ::ttnn::operations::unary::UnaryWithParam>,
+        std::optional<bool>)> &ttnnOp) {
+
+  ::ttnn::Tensor *lhs = &(tensorPool.getTTNNTensorAndValidate(op->lhs()));
+  ::ttnn::Tensor *rhs = &(tensorPool.getTTNNTensorAndValidate(op->rhs()));
+
+  if (op->type() != ::tt::target::ttnn::EltwiseBinaryCompositeOpType::Scatter &&
+      operations::utils::shouldSwapBinaryOperands(*lhs, *rhs)) {
+    std::swap(lhs, rhs);
+  }
+
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
+          op->memory_config());
+  LOG_ASSERT(::tt::runtime::ttnn::utils::inSystemMemory(op->out()) ||
+                 outputMemoryConfig.has_value(),
+             "Memory config must exist for device tensors");
+
+  ::ttnn::Tensor out = ttnnOp(*lhs, *rhs, std::nullopt, outputMemoryConfig,
+                              std::nullopt, {}, {}, {}, std::nullopt);
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+}
+
 void run(const ::tt::target::ttnn::EltwiseBinaryCompositeOp *op,
          ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
   switch (op->type()) {
   case ::tt::target::ttnn::EltwiseBinaryCompositeOpType::Maximum: {
-    runEltwiseBinaryCompositeOp(op, tensorPool, ::ttnn::maximum);
+    runEltwiseBinaryCompositeMaxOp(op, tensorPool, ::ttnn::maximum);
     break;
   }
   case ::tt::target::ttnn::EltwiseBinaryCompositeOpType::Minimum: {

--- a/runtime/lib/ttnn/operations/eltwise/unary/unary.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/unary/unary.cpp
@@ -55,7 +55,7 @@ static void runEltwiseUnaryWithFastAndApproximateModeOp(
 static void runEltwiseUnaryWithVectorAndFastAndApproximateModeOp(
     const ::tt::target::ttnn::EltwiseUnaryOp *op, ProgramTensorPool &tensorPool,
     const std::function<
-        ::ttnn::Tensor(const ::ttnn::Tensor &, const bool, const int,
+        ::ttnn::Tensor(const ::ttnn::Tensor &, const int, const bool,
                        const std::optional<::ttnn::MemoryConfig> &,
                        const std::optional<::ttnn::Tensor> &)> &ttnnOp) {
 

--- a/runtime/lib/ttnn/operations/eltwise/unary/unary.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/unary/unary.cpp
@@ -8,6 +8,7 @@
 #include "tt/runtime/ttnn/utils.h"
 #include "ttmlir/Target/TTNN/program_generated.h"
 #include "ttnn/operations/copy.hpp"
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
 
 namespace tt::runtime::ttnn::operations::eltwise::unary {
 
@@ -47,6 +48,28 @@ static void runEltwiseUnaryWithFastAndApproximateModeOp(
 
   ::ttnn::Tensor out =
       ttnnOp(in, /*parameter=*/false, outputMemoryConfig, std::nullopt);
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+}
+
+static void runEltwiseUnaryWithVectorAndFastAndApproximateModeOp(
+    const ::tt::target::ttnn::EltwiseUnaryOp *op, ProgramTensorPool &tensorPool,
+    const std::function<
+        ::ttnn::Tensor(const ::ttnn::Tensor &, const bool, const int,
+                       const std::optional<::ttnn::MemoryConfig> &,
+                       const std::optional<::ttnn::Tensor> &)> &ttnnOp) {
+
+  const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
+          op->memory_config());
+  LOG_ASSERT(::tt::runtime::ttnn::utils::inSystemMemory(op->out()) ||
+                 outputMemoryConfig.has_value(),
+             "Memory config must exist for device tensors");
+
+  ::ttnn::Tensor out =
+      ttnnOp(in, (int)::ttnn::operations::unary::VecMode::RC,
+             /*parameter=*/false, outputMemoryConfig, std::nullopt);
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }
@@ -120,8 +143,8 @@ void run(const ::tt::target::ttnn::EltwiseUnaryOp *op,
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::Sigmoid: {
-    runEltwiseUnaryWithFastAndApproximateModeOp(op, tensorPool,
-                                                ::ttnn::sigmoid);
+    runEltwiseUnaryWithVectorAndFastAndApproximateModeOp(op, tensorPool,
+                                                         ::ttnn::sigmoid);
     break;
   }
   case ::tt::target::ttnn::EltwiseUnaryOpType::Sin: {

--- a/runtime/lib/ttnn/operations/eltwise/unary/unary.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/unary/unary.cpp
@@ -68,7 +68,7 @@ static void runEltwiseUnaryWithVectorAndFastAndApproximateModeOp(
              "Memory config must exist for device tensors");
 
   ::ttnn::Tensor out =
-      ttnnOp(in, (int)::ttnn::operations::unary::VecMode::RC,
+      ttnnOp(in, static_cast<int>(::ttnn::operations::unary::VecMode::RC),
              /*parameter=*/false, outputMemoryConfig, std::nullopt);
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "ddba2f06d0a120ce4d65ecfad15befd65400e9c7")
+set(TT_METAL_VERSION "4f706555c6cfcb35a6a1f69783333c04e20ce683")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 4f706555c6cfcb35a6a1f69783333c04e20ce683

- Update binary maximum function signature after update in metal change 5b5b45e
- Update sigmoid op to take vector mode param reflecting new registration method in metal change 15c097d
- Update conv op to reflect new combined interface after metal change 7796cd1