### PR TITLE
Don't fold during element type normalization

### DIFF
--- a/lib/Dialect/TTIR/Transforms/ElementTypeNormalization.cpp
+++ b/lib/Dialect/TTIR/Transforms/ElementTypeNormalization.cpp
@@ -144,10 +144,7 @@ struct ElementTypeNormalization
     RewritePatternSet patterns(&getContext());
     patterns.add<UniformTypeRewriter>(converter, &getContext());
     patterns.add<ConstantOpAttrRewriter>(converter, &getContext());
-    GreedyRewriteConfig config;
-    config.fold = false;
-    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns),
-                                     config))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       signalPassFailure();
       return;
     }

--- a/lib/Dialect/TTIR/Transforms/ElementTypeNormalization.cpp
+++ b/lib/Dialect/TTIR/Transforms/ElementTypeNormalization.cpp
@@ -144,7 +144,10 @@ struct ElementTypeNormalization
     RewritePatternSet patterns(&getContext());
     patterns.add<UniformTypeRewriter>(converter, &getContext());
     patterns.add<ConstantOpAttrRewriter>(converter, &getContext());
-    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+    GreedyRewriteConfig config;
+    config.fold = false;
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns),
+                                     config))) {
       signalPassFailure();
       return;
     }

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -153,6 +153,7 @@ void createTTNNPipelineTTIRImplicitBroadcastFoldPassFromString(
 
 void createTTIRToTTNNBackendPipeline(
     OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options) {
+  pm.addPass(mlir::createCanonicalizerPass());
   // Element type normalization should be the first pass in the pipeline.
   pm.addPass(ttir::createElementTypeNormalization());
   // Create DeviceModule to wrap all ops.

--- a/test/ttmlir/Dialect/TTIR/element_type_normalization/element_type_normalization_positive.mlir
+++ b/test/ttmlir/Dialect/TTIR/element_type_normalization/element_type_normalization_positive.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttir-element-type-normalization %s | FileCheck %s
+// RUN: ttmlir-opt --canonicalize --ttir-element-type-normalization %s | FileCheck %s
 
 func.func public @constant_i1() -> tensor<32x32xi1> {
   // CHECK: "ttir.constant"
@@ -191,10 +191,8 @@ func.func @constant_bf16() -> tensor<32x32xbf16> {
 }
 
 func.func @main(%arg0 : tensor<1x256x1xf64>) -> tensor<1x256x1xf64> {
-  // CHECK: "ttir.broadcast"
-  // CHECK-SAME: tensor<1x256x1xf32>
-  // CHECK-SAME: tensor<1x256x1xf32>
-  // CHECK-SAME: -> tensor<1x256x1xf32>
+  // CHECK-NOT: "ttir.broadcast"
+  // CHECK: -> tensor<1x256x1xf32>
   %0 = ttir.empty() : tensor<1x256x1xf64>
   %1 = "ttir.broadcast"(%arg0, %0) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x256x1xf64>, tensor<1x256x1xf64>) -> tensor<1x256x1xf64>
   return %1 : tensor<1x256x1xf64>

--- a/test/ttmlir/Dialect/TTIR/element_type_normalization/element_type_normalization_positive.mlir
+++ b/test/ttmlir/Dialect/TTIR/element_type_normalization/element_type_normalization_positive.mlir
@@ -189,3 +189,13 @@ func.func @constant_bf16() -> tensor<32x32xbf16> {
   %0 = "ttir.constant"() <{value = dense<1.0> : tensor<32x32xbf16>}> : () -> tensor<32x32xbf16>
   return %0 : tensor<32x32xbf16>
 }
+
+func.func @main(%arg0 : tensor<1x256x1xf64>) -> tensor<1x256x1xf64> {
+  // CHECK: "ttir.broadcast"
+  // CHECK-SAME: tensor<1x256x1xf32>
+  // CHECK-SAME: tensor<1x256x1xf32>
+  // CHECK-SAME: -> tensor<1x256x1xf32>
+  %0 = ttir.empty() : tensor<1x256x1xf64>
+  %1 = "ttir.broadcast"(%arg0, %0) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x256x1xf64>, tensor<1x256x1xf64>) -> tensor<1x256x1xf64>
+  return %1 : tensor<1x256x1xf64>
+}

--- a/test/ttmlir/Dialect/TTIR/element_type_normalization/element_type_normalization_positive.mlir
+++ b/test/ttmlir/Dialect/TTIR/element_type_normalization/element_type_normalization_positive.mlir
@@ -190,7 +190,7 @@ func.func @constant_bf16() -> tensor<32x32xbf16> {
   return %0 : tensor<32x32xbf16>
 }
 
-func.func @main(%arg0 : tensor<1x256x1xf64>) -> tensor<1x256x1xf64> {
+func.func @fold_broadcast(%arg0 : tensor<1x256x1xf64>) -> tensor<1x256x1xf64> {
   // CHECK-NOT: "ttir.broadcast"
   // CHECK: -> tensor<1x256x1xf32>
   %0 = ttir.empty() : tensor<1x256x1xf64>


### PR DESCRIPTION
Given this IR:
```mlir
  %0 = ttir.empty() : tensor<1x256x1xf64>
  %1 = "ttir.broadcast"(%arg0, %0) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x256x1xf64>, tensor<1x256x1xf64>) -> tensor<1x256x1xf64>
  return %1 : tensor<1x256x1xf64>
```

When we are updating types we start from `return` op and we update it's first operand to `f32`. This will prompt mlir to update `ttir.broadcast` return type to `f32` (probably to keep IR consistent) , so after the update on `return` op we end up with:

```mlir
  %0 = ttir.empty() : tensor<1x256x1xf64>
  %1 = "ttir.broadcast"(%arg0, %0) <{broadcast_dimensions = array<i64: 1, 1, 1>}> : (tensor<1x256x1xf32>, tensor<1x256x1xf64>) -> tensor<1x256x1xf64>
  return %1 : tensor<1x256x1xf32>
```

Then next up is broadcast op. `applyPatternsGreedily` first try to fold op it wants to pattern match to avoid unnecessary rewriters, so in case of our broadcast its foldable and we return `%arg0`, but this is invalid since fold logic expects fold result to be of the same type as operation result. In this case `%arg0` is f64 but `ttir.broadcast` is `f32`.

As simple fix I've added canonicalization as first pass in pipeline, this solves the issue. We could also turn off folding in pipeline itself, but that might elide opportunity for some folds but I'm not against turning it off in pipeline also.