### PR TITLE
View layout op interface

### DIFF
--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.h
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.h
@@ -46,20 +46,20 @@ inline bool isL1MemorySpace(MemorySpace memorySpace) {
   return memorySpace == MemorySpace::DeviceL1;
 }
 
-inline void printDimensionList(::mlir::AsmPrinter &printer,
-                               ::llvm::ArrayRef<int64_t> shape) {
+inline void printDimensionList(mlir::AsmPrinter &printer,
+                               llvm::ArrayRef<int64_t> shape) {
   printer.printDimensionList(shape);
 }
 
-inline ::mlir::ParseResult
-parseDimensionList(::mlir::AsmParser &odsParser,
-                   ::llvm::SmallVector<int64_t> &dimensions) {
+inline mlir::ParseResult
+parseDimensionList(mlir::AsmParser &odsParser,
+                   llvm::SmallVector<int64_t> &dimensions) {
   return odsParser.parseDimensionList(dimensions, false, false);
 }
 
 template <typename... Args>
-inline void printVargDimensionList(::mlir::AsmPrinter &printer, Args... dims) {
-  printDimensionList(printer, ::llvm::SmallVector<int64_t>({dims...}));
+inline void printVargDimensionList(mlir::AsmPrinter &printer, Args... dims) {
+  printDimensionList(printer, llvm::SmallVector<int64_t>({dims...}));
 }
 
 inline void printIdentityAffineMap(mlir::AsmPrinter &printer,
@@ -73,8 +73,8 @@ inline void printIdentityAffineMap(mlir::AsmPrinter &printer,
   affineMap.print(printer.getStream());
 }
 
-inline ::mlir::ParseResult parseIdentityAffineMap(::mlir::AsmParser &odsParser,
-                                                  mlir::AffineMap &affineMap) {
+inline mlir::ParseResult parseIdentityAffineMap(mlir::AsmParser &odsParser,
+                                                mlir::AffineMap &affineMap) {
   if (odsParser.parseOptionalKeyword("map").succeeded()) {
     if (odsParser.parseLParen().failed()) {
       return failure();
@@ -98,12 +98,12 @@ inline ::mlir::ParseResult parseIdentityAffineMap(::mlir::AsmParser &odsParser,
 }
 
 template <typename... Args>
-inline ::mlir::ParseResult parseVargDimensionList(::mlir::AsmParser &odsParser,
-                                                  Args &...dims) {
-  ::llvm::SmallVector<int64_t> dimensions;
-  ::mlir::ParseResult result = parseDimensionList(odsParser, dimensions);
+inline mlir::ParseResult parseVargDimensionList(mlir::AsmParser &odsParser,
+                                                Args &...dims) {
+  llvm::SmallVector<int64_t> dimensions;
+  mlir::ParseResult result = parseDimensionList(odsParser, dimensions);
   if (succeeded(result)) {
-    ::llvm::SmallVector<std::tuple_element_t<0, std::tuple<Args...>> *> copy(
+    llvm::SmallVector<std::tuple_element_t<0, std::tuple<Args...>> *> copy(
         {&dims...});
     assert(dimensions.size() == sizeof...(dims));
     for (size_t i = 0; i < dimensions.size(); ++i) {
@@ -154,8 +154,7 @@ inline std::optional<DataType> elementTypeToDataTypeImpl(Type elementType) {
   return {};
 }
 
-inline Type dataTypeToElementType(::mlir::MLIRContext *context,
-                                  DataType dtype) {
+inline Type dataTypeToElementType(mlir::MLIRContext *context, DataType dtype) {
   switch (dtype) {
   case DataType::Float32:
     return Float32Type::get(context);
@@ -191,7 +190,7 @@ inline Type dataTypeToElementType(::mlir::MLIRContext *context,
 }
 
 // Convenience function to convert any type to TTMLIR supported type.
-inline ::mlir::Type toTTMLIRSupportedDataType(Type elementType) {
+inline mlir::Type toTTMLIRSupportedDataType(Type elementType) {
   std::optional<DataType> dataType = elementTypeToDataTypeImpl(elementType);
 
   if (dataType) {
@@ -219,19 +218,19 @@ inline DataType elementTypeToDataType(Type elementType) {
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h.inc"
 
 mlir::AffineMap collapsedLinearAffineMap(
-    ::mlir::MLIRContext *context, ::llvm::ArrayRef<int64_t> shape,
-    ::llvm::ArrayRef<int64_t> gridShape,
-    ::llvm::ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals);
+    mlir::MLIRContext *context, llvm::ArrayRef<int64_t> shape,
+    llvm::ArrayRef<int64_t> gridShape,
+    llvm::ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals);
 
 mlir::SmallVector<std::int64_t>
 calculateLogicalShardShape(mlir::ArrayRef<int64_t> tensorShape,
                            mlir::AffineMap linear, mlir::tt::GridAttr grid);
 
 template <typename T, typename TAttr>
-mlir::MemRefType buildMemRef(::mlir::MLIRContext *context,
-                             ::llvm::ArrayRef<int64_t> shardShape,
-                             ::mlir::Type elementType, T memorySpace) {
-  ::llvm::SmallVector<int64_t> scalarShardShape(shardShape);
+mlir::MemRefType buildMemRef(mlir::MLIRContext *context,
+                             llvm::ArrayRef<int64_t> shardShape,
+                             mlir::Type elementType, T memorySpace) {
+  llvm::SmallVector<int64_t> scalarShardShape(shardShape);
   if (mlir::isa<mlir::tt::TileType>(elementType)) {
     scalarShardShape = mlir::cast<mlir::tt::TileType>(elementType)
                            .getTiledShape(scalarShardShape);

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -224,24 +224,30 @@ def TT_SystemDescAttr : TT_Attr<"SystemDesc", "system_desc"> {
   }];
 }
 
-def TT_StreamLayoutAttr : TT_Attr<"StreamLayout", "stream", [MemRefLayoutAttrInterface]> {
-  let summary = "Stream layout attribute in TT dialect";
+def TT_ViewLayoutAttr : TT_Attr<"ViewLayout", "view", [MemRefLayoutAttrInterface]> {
+  let summary = "View layout attribute in TT dialect";
   let description = [{
-    Describes a stream layout of a memref buffer.
-    - AffineMap: Provides affine map indexing into the associated data stream.
+    Describes a view layout of a memref buffer.
+    - AffineMap: Provides affine map indexing into the associated data view.
 
-    Only the stream_layout op should return memref's with this attribute.  The stream layout
-    attribute is necessary for two reasons:
-      - It provides a way to reblock the data stream into a different shape (via affine map).
+    Only the view_layout or stream_layout ops should return memref's with this attribute.
+    The view layout attribute is necessary for two reasons:
+      - It provides a way to reblock the data view into a different shape (via affine map).
         Usually this would be some subblock of the original backing memory to chunk the data
         into smaller pieces.
-      - The type itself is a signal to datamovement passes that the memref is a stream and
+      - The type itself is a signal to datamovement passes that the memref is a view and
         should be treated as such.
   }];
 
   let parameters = (ins "AffineMap":$affineMap);
 
-  let assemblyFormat = "`<` $affineMap `>`";
+  let assemblyFormat = "`<` custom<IdentityAffineMap>($affineMap) `>`";
+
+  let extraClassDeclaration = [{
+      static ViewLayoutAttr get(::mlir::MLIRContext *context, unsigned rank) {
+        return get(context, mlir::AffineMap::getMultiDimIdentityMap(rank, context));
+      }
+  }];
 }
 
 def TT_ShardLayoutAttr : TT_Attr<"ShardLayout", "shard", [MemRefLayoutAttrInterface]> {
@@ -367,7 +373,6 @@ def TT_MetalLayoutAttr : TT_Attr<"MetalLayout", "metal_layout"> {
       MetalLayoutAttr withElementType(::mlir::MLIRContext *context, Type elementType);
       MetalLayoutAttr withMemorySpace(::mlir::MLIRContext *context, MemorySpace memorySpace);
       MetalLayoutAttr withShardShape(::mlir::MLIRContext *context, llvm::SmallVector<int64_t> shardShape);
-      MetalLayoutAttr withStreamLayout(::mlir::MLIRContext *context, StreamLayoutAttr stream);
 
       uint64_t getMemrefSizeBytes() const;
       MemorySpace getMemorySpace() const;
@@ -390,7 +395,7 @@ def TT_MetalLayoutAttr : TT_Attr<"MetalLayout", "metal_layout"> {
       // used as the buffer type for bufferization, e.g.:
       //   metal_layout<..., <2x3>, memref<4x5xtt.tile<32x32, f32>>>
       //     -> memref<2x3x4x5xtt.tile<32x32, f32>>
-      MemRefType getBufferType() const;
+      MemRefType getBufferType(bool isView = false) const;
   }];
 }
 
@@ -417,7 +422,13 @@ def TT_DeviceAttr : TT_Attr<"Device", "device", []> {
   let extraClassDeclaration = [{
       static DeviceAttr get(::mlir::MLIRContext *context, SystemDescAttr systemDesc, ArrayRef<int64_t> meshShape, ArrayRef<unsigned> chipIds);
       static DeviceAttr get(::mlir::MLIRContext *context, SystemDescAttr systemDesc, ArrayRef<int64_t> meshShape = {});
-      AffineMap getMemoryMap(MemRefType memrefType, size_t pageSize, size_t baseOffset = 0) const;
+      AffineMap getMemoryMap(MemRefType memrefType,
+                             size_t pageSize,
+                             std::optional<AffineMap> view = std::nullopt,
+                             size_t baseOffset = 0) const;
+      AffineMap getMemoryMap(std::pair<MemRefType, AffineMap> memrefAndView,
+                             size_t pageSize,
+                             size_t baseOffset = 0) const;
       size_t getMemrefSizeBytes(MemRefType memrefType, size_t pageSize) const;
 
       // Returns the footprint size in bytes of the tensor layout distributed across the given memory space.

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
@@ -240,7 +240,7 @@ def TTIR_DMAOp : TTIR_GenericRegionDatamovementOp<"dma",
         Given some affine map, as demonstrated below, the dma op will be evaluated at each point in the affine map's iteration space.
       ```mlir
       #map1 = affine_map<(d0, d1, d2) -> (d0, d2)>
-      %tx = ttir.dma %stream<#map1>, %cb0 : (memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+      %tx = ttir.dma %stream<#map1>, %cb0 : (memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.view<rank(4)>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
       ```
 
       Some constraints:

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -63,14 +63,6 @@ class TTIR_BufferizableOp<string mnemonic, list<Trait> traits = []> :
         return result;
       }
 
-      FailureOr<mlir::BaseMemRefType> $cppClass::getBufferType(
-          Value value, const bufferization::BufferizationOptions &,
-          SmallVector<mlir::Value> &) {
-        auto rankedTensorType = mlir::cast<mlir::RankedTensorType>(value.getType());
-        return mlir::cast<tt::MetalLayoutAttr>(rankedTensorType.getEncoding())
-            .getBufferType();
-      }
-
       void $cppClass::getEffects(
           SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
               &effects) {
@@ -270,7 +262,9 @@ def TTIR_ToLayoutOp : TTIR_BufferizableOp<"to_layout"> {
 }
 
 def TTIR_StreamLayoutOp : TTIR_BufferizableOp<"stream_layout",
-  [DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {
+  [ DeclareOpInterfaceMethods<OpAsmOpInterface , ["getAsmResultNames"]>
+  , TTIR_ViewOpInterface
+  ]> {
     let summary = "Stream Layout op.";
     let description = [{
       StreamLayout operation used to form a stream between remote and local memory spaces. Note that this op has
@@ -288,7 +282,7 @@ def TTIR_StreamLayoutOp : TTIR_BufferizableOp<"stream_layout",
       ```llvm
       %input = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
       %storage = memref.alloc() {alignment = 64 : i64} : memref<2x4x1x1x!tt.tile<32x32, f32>, #l1_>
-      %stream = "ttir.stream_layout"(%input, %storage) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<2x4x1x1x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3)>, #l1_>
+      %stream = "ttir.stream_layout"(%input, %storage) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<2x4x1x1x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
       ```
     }];
 
@@ -314,6 +308,7 @@ def TTIR_ViewLayoutOp : TTIR_Op<"view_layout",
                                                        , "getAliasingValues"
                                                        , "getBufferType"
                                                        ]>
+  , TTIR_ViewOpInterface
   ]> {
     let summary = "View Layout op.";
     let description = [{

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROpsInterfaces.h
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROpsInterfaces.h
@@ -8,16 +8,16 @@
 #include "ttmlir/Dialect/TT/IR/Utils.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIR.h"
 
-namespace mlir {
-namespace tt {
-namespace ttir {
+namespace mlir::tt::ttir {
+
 namespace detail {
 mlir::LogicalResult verifyBroadcastable(mlir::Operation *op);
 mlir::LogicalResult verifyGenericParent(mlir::Operation *op);
 } // namespace detail
-} // namespace ttir
-} // namespace tt
-} // namespace mlir
+
+std::pair<mlir::MemRefType, mlir::AffineMap> applyViews(mlir::Operation *op);
+
+} // namespace mlir::tt::ttir
 
 #include "ttmlir/Dialect/TTIR/IR/TTIROpsInterfaces.h.inc"
 

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROpsInterfaces.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROpsInterfaces.td
@@ -94,4 +94,36 @@ def TTIR_TensorManipulation : OpInterface<"TensorManipulation"> {
   let cppNamespace = "::mlir::tt::ttir";
 }
 
+def TTIR_ViewOpInterface : OpInterface<"ViewOpInterface"> {
+  let cppNamespace = "::mlir::tt::ttir";
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/[{
+        Get the input of the view op.
+      }],
+      /*retTy=*/"mlir::Value",
+      /*methodName=*/"getInput"
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Get the result of the view op.
+      }],
+      /*retTy=*/"mlir::Value",
+      /*methodName=*/"getResult"
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Recursively apply view interface ops until a shard layout is reached.
+        Returns a pair of the underlying memref with shard layout and an
+        affine map that describes a view over this memref.
+      }],
+      /*retTy=*/"std::pair<mlir::MemRefType, mlir::AffineMap>",
+      /*methodName=*/"applyViews",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/"return ttir::applyViews($_op);"
+    >,
+  ];
+}
+
 #endif

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -350,12 +350,12 @@ def TTIRAllocate: Pass<"ttir-allocate", "::mlir::ModuleOp"> {
     %alloc_1 = memref.alloc() {address = 41984 : i64, alignment = 16 : i64} : memref<1x8x1x1x!tt.tile<32x32, f32>, #tt.shard<4096x4096>, #l1_>
     %alloc_2 = memref.alloc() {address = 46080 : i64, alignment = 16 : i64} : memref<1x5x1x5x!tt.tile<32x32, f32>, #tt.shard<20480x4096>, #l1_>
     %stream = "ttir.stream_layout"(%alloc, %alloc_2) : (memref<1x5x1x5x!tt.tile<32x32, f32>, #tt.shard<20480x4096>, #l1_>, memref<1x5x1x5x!tt.tile<32x32, f32>, #tt.shard<20480x4096>, #l1_>)
-     -> memref<1x5x1x5x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, #l1_>
+     -> memref<1x5x1x5x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
     %alloc_3 = memref.alloc() {address = 66560 : i64, alignment = 16 : i64} : memref<5x8x5x1x!tt.tile<32x32, f32>, #tt.shard<4096x4096>, #l1_>
     %stream_4 = "ttir.stream_layout"(%alloc_0, %alloc_3) : (memref<5x8x5x1x!tt.tile<32x32, f32>, #tt.shard<4096x4096>, #l1_>, memref<5x8x5x1x!tt.tile<32x32, f32>, #tt.shard<4096x4096>, #l1_>)
-     -> memref<5x8x5x1x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, #l1_>
+     -> memref<5x8x5x1x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
     ttir.generic {grid = #tt.grid<1x8>, indexing_maps = [#map, #map1, #map2], iterator_types = [#parallel, #parallel, #reduction], ...}
-        ins(%stream, %stream_4 : memref<1x5x1x5x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, #l1_>, memref<5x8x5x1x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, #l1_>)
+        ins(%stream, %stream_4 : memref<1x5x1x5x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<5x8x5x1x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>)
         outs(%alloc_1 : memref<1x8x1x1x!tt.tile<32x32, f32>, #tt.shard<4096x4096>, #l1_>)  {
       ...
     }

--- a/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
+++ b/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
@@ -292,10 +292,11 @@ public:
   }
 
   static std::tuple<AffineMap, AffineMap, AffineMap>
-  getIndividualResultMaps(MemRefType memref, tt::DeviceAttr device,
+  getIndividualResultMaps(Operation *op, tt::DeviceAttr device,
                           OpBuilder &builder) {
-    size_t pageSize = getMemrefShardSizeBytes(memref);
-    AffineMap memoryMap = device.getMemoryMap(memref, pageSize, 0)
+    std::pair<MemRefType, AffineMap> memrefAndView = ttir::applyViews(op);
+    size_t pageSize = getMemrefShardSizeBytes(memrefAndView.first);
+    AffineMap memoryMap = device.getMemoryMap(memrefAndView, pageSize, 0)
                               .dropResult(0); // drop the device index
     assert(memoryMap.getNumResults() == 3);
     auto gridY = memoryMap.dropResults({1, 2});
@@ -409,7 +410,8 @@ public:
       // coordinates
       AffineMap dstGridYMap, dstGridXMap, dstOffsetMap;
       std::tie(dstGridYMap, dstGridXMap, dstOffsetMap) =
-          getIndividualResultMaps(op.getDstMemRefType(), device, rewriter);
+          getIndividualResultMaps(op.getDst().getDefiningOp(), device,
+                                  rewriter);
 
       auto dstGridY = applyMap(dstGridYMap, op.getDstIndices());
       auto dstGridX = applyMap(dstGridXMap, op.getDstIndices());
@@ -438,7 +440,8 @@ public:
       // coordinates
       AffineMap srcGridYMap, srcGridXMap, srcOffsetMap;
       std::tie(srcGridYMap, srcGridXMap, srcOffsetMap) =
-          getIndividualResultMaps(op.getSrcMemRefType(), device, rewriter);
+          getIndividualResultMaps(op.getSrc().getDefiningOp(), device,
+                                  rewriter);
 
       auto srcGridY = applyMap(srcGridYMap, op.getSrcIndices());
       auto srcGridX = applyMap(srcGridXMap, op.getSrcIndices());

--- a/lib/Dialect/TTIR/IR/TTIROpsInterfaces.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROpsInterfaces.cpp
@@ -58,3 +58,27 @@ mlir::tt::ttir::detail::verifyGenericParent(mlir::Operation *op) {
              : op->emitOpError(
                    "TTIR Generic Ops must be inside a generic region");
 }
+
+std::pair<mlir::MemRefType, mlir::AffineMap>
+mlir::tt::ttir::applyViews(mlir::Operation *op) {
+  auto viewOp = mlir::dyn_cast<ttir::ViewOpInterface>(op);
+  auto resultMemref = mlir::cast<mlir::MemRefType>(op->getResult(0).getType());
+  if (!viewOp) {
+    return std::make_pair(
+        resultMemref, mlir::AffineMap::getMultiDimIdentityMap(
+                          resultMemref.getRank(), resultMemref.getContext()));
+  }
+  auto map =
+      mlir::cast<tt::ViewLayoutAttr>(resultMemref.getLayout()).getAffineMap();
+  Value input = viewOp.getInput();
+  auto inputMemref = mlir::cast<mlir::MemRefType>(input.getType());
+  while (mlir::isa<tt::ViewLayoutAttr>(inputMemref.getLayout())) {
+    map = inputMemref.getLayout().getAffineMap().compose(map);
+    viewOp = mlir::cast<ttir::ViewOpInterface>(input.getDefiningOp());
+    input = viewOp.getInput();
+    inputMemref = mlir::cast<mlir::MemRefType>(input.getType());
+  }
+  assert(mlir::isa<tt::ShardLayoutAttr>(inputMemref.getLayout()) &&
+         "Expected ShardLayoutAttr");
+  return std::make_pair(inputMemref, map);
+}

--- a/lib/Dialect/TTIR/Transforms/Allocate.cpp
+++ b/lib/Dialect/TTIR/Transforms/Allocate.cpp
@@ -162,7 +162,7 @@ class TTIRAllocateStreams final : public OpRewritePattern<ttir::GenericOp> {
   static void insertStream(PatternRewriter &rewriter, OpOperand &operand,
                            ttir::GenericOp op) {
     auto memref = mlir::cast<MemRefType>(operand.get().getType());
-    auto streamAttr = rewriter.getAttr<StreamLayoutAttr>(
+    auto streamAttr = rewriter.getAttr<ViewLayoutAttr>(
         rewriter.getMultiDimIdentityMap(memref.getRank()));
     auto streamMemref =
         MemRefType::get(memref.getShape(), memref.getElementType(), streamAttr,

--- a/lib/Dialect/TTIR/Transforms/GenericGenerateDatamovement.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericGenerateDatamovement.cpp
@@ -27,7 +27,7 @@ public:
   using OpRewritePattern<GenericOp>::OpRewritePattern;
 
   static bool isStream(Type ty) {
-    return mlir::isa<StreamLayoutAttr>(mlir::cast<MemRefType>(ty).getLayout());
+    return mlir::isa<ViewLayoutAttr>(mlir::cast<MemRefType>(ty).getLayout());
   }
 
   static bool compatibleDeviceGrid(DeviceAttr device, GridAttr grid) {

--- a/lib/Dialect/TTIR/Transforms/GenericLowerDMAs.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericLowerDMAs.cpp
@@ -206,10 +206,14 @@ public:
                          memrefShardShape, dmaIndexingMap, gridIndexingMap);
 
     DeviceAttr device = genericParent.getDevice();
+    std::pair<MemRefType, AffineMap> underlyingMemrefAndView =
+        mlir::cast<ttir::ViewOpInterface>(dma.getSrc().getDefiningOp())
+            .applyViews();
     // TODO(#1909) Once we have an allocation pass, we need to lookup the page
     // size instead of calculating it here.
     size_t pageSize = getMemRefShardSizeBytes(memref);
-    AffineMap memoryMap = device.getMemoryMap(memref, pageSize);
+    AffineMap memoryMap =
+        device.getMemoryMap(underlyingMemrefAndView, pageSize);
     size_t elemSizeBytes = getElementSizeBytes(memref);
     size_t coalescingFactor =
         calculateCoalescingFactor(memoryMap, memrefGridShape, memrefShardShape,

--- a/lib/Dialect/TTIR/Transforms/GenericRegionsToFuncs.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericRegionsToFuncs.cpp
@@ -4,6 +4,8 @@
 
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
 
+#include "ttmlir/Dialect/TTIR/IR/TTIROpsInterfaces.h"
+
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -28,9 +30,23 @@ static std::optional<unsigned> getCapturedOperandIndex(GenericOp op,
 
 static void rewriteOperand(OpBuilder &builder, DMAOp dma, OpOperand &dmaOperand,
                            unsigned operandIndex) {
-  auto globalOperand = builder.create<GetGlobalOperandOp>(
-      dma.getLoc(), dmaOperand.get().getType(), operandIndex);
-  dmaOperand.set(globalOperand.getResult());
+  MemRefType memref = mlir::cast<MemRefType>(dmaOperand.get().getType());
+  AffineMap affineMapView = builder.getMultiDimIdentityMap(memref.getRank());
+  if (dmaOperand.get().getDefiningOp()) {
+    std::tie(memref, affineMapView) =
+        applyViews(dmaOperand.get().getDefiningOp());
+  }
+  Operation *globalOperand =
+      builder.create<GetGlobalOperandOp>(dma.getLoc(), memref, operandIndex);
+  if (!affineMapView.isIdentity()) {
+    globalOperand = builder.create<ViewLayoutOp>(
+        dma.getLoc(),
+        mlir::MemRefType::get(memref.getShape(), memref.getElementType(),
+                              builder.getAttr<ViewLayoutAttr>(affineMapView),
+                              memref.getMemorySpace()),
+        globalOperand->getResult(0));
+  }
+  dmaOperand.set(globalOperand->getResult(0));
 }
 
 static void rewriteCapturedDMAOperands(OpBuilder &builder, GenericOp generic,

--- a/test/ttmlir/Conversion/TTIRToTTKernel/tiled_matmul.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTKernel/tiled_matmul.mlir
@@ -17,11 +17,11 @@ module {
       // CHECK: "ttkernel.cb_reserve_back"
       scf.if %0 {
         // CHECK: %{{[0-9]+}} = "ttkernel.get_compile_time_arg_val"
-        %1 = ttir.get_global_operand(0) : memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 12288 + d3 * 4096)>, #l1_>
+        %1 = ttir.get_global_operand(0) : memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.shard<12288x4096>, #l1_>
         // CHECK: %{{[0-9]+}} = "ttkernel.get_write_ptr"
         // CHECK: %{{[0-9]+}} = "ttkernel.get_noc_addr"
         // CHECK: "ttkernel.noc_async_read"
-        %tx = ttir.dma %1 [%c0, %arg7, %c0, %c0], %arg0 [%c0, %c0] : (memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 12288 + d3 * 4096)>, #l1_>, memref<1x3x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+        %tx = ttir.dma %1 [%c0, %arg7, %c0, %c0], %arg0 [%c0, %c0] : (memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.shard<12288x4096>, #l1_>, memref<1x3x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
         // CHECK: "ttkernel.noc_async_read_barrier"
         ttir.dma_wait %tx
         // ttir.semaphore_wait %arg3, %c7 reset %c0

--- a/test/ttmlir/Conversion/TTIRToTTMetal/generic_lowering.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTMetal/generic_lowering.mlir
@@ -6,14 +6,14 @@ module {
   func.func @generic0(%arg0: memref<1x1x8x24x!tt.tile<32x32, f32>, #tt.shard<98304x4096>, #l1_>, %arg1: memref<1x1x24x32x!tt.tile<32x32, f32>, #tt.shard<131072x4096>, #l1_>) -> memref<1x1x8x32x!tt.tile<32x32, f32>, #tt.shard<131072x4096>, #l1_> {
     %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x8x1x4x!tt.tile<32x32, f32>, #l1_>
     %alloc_0 = memref.alloc() {alignment = 64 : i64, address = 0x10000} : memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.shard<12288x4096>, #l1_>
-    %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<1x1x8x24x!tt.tile<32x32, f32>, #tt.shard<98304x4096>, #l1_>, memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.shard<12288x4096>, #l1_>) -> memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 12288 + d3 * 4096)>, #l1_>
+    %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<1x1x8x24x!tt.tile<32x32, f32>, #tt.shard<98304x4096>, #l1_>, memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.shard<12288x4096>, #l1_>) -> memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
     %alloc_1 = memref.alloc() {alignment = 64 : i64, address = 0x15000} : memref<8x8x3x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
-    %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<1x1x24x32x!tt.tile<32x32, f32>, #tt.shard<131072x4096>, #l1_>, memref<8x8x3x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>) -> memref<8x8x3x4x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 16384 + d3 * 4096)>, #l1_>
+    %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<1x1x24x32x!tt.tile<32x32, f32>, #tt.shard<131072x4096>, #l1_>, memref<8x8x3x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>) -> memref<8x8x3x4x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
     // CHECK: "ttmetal.enqueue_program"
     // CHECK-SAME: {{.*}}core_ranges = [#ttmetal.core_range<0x0, 8x8>, #ttmetal.core_range<0x0, 8x8>, #ttmetal.core_range<0x0, 8x8>]
     // CHECK-SAME: {{.*}}threads = [#ttir.thread<datamovement, @datamovement_kernel0>, #ttir.thread<datamovement, @datamovement_kernel1>, #ttir.thread<compute, @compute_kernel2>]
     ttir.generic {grid = #tt.grid<8x8>, indexing_maps = [], iterator_types = [], threads = [#ttir.thread<datamovement, @datamovement_kernel0>, #ttir.thread<datamovement, @datamovement_kernel1>, #ttir.thread<compute, @compute_kernel2>]}
-        ins(%stream, %stream_2 : memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 12288 + d3 * 4096)>, #l1_>, memref<8x8x3x4x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 16384 + d3 * 4096)>, #l1_>)
+        ins(%stream, %stream_2 : memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<8x8x3x4x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>)
         outs(%alloc : memref<8x8x1x4x!tt.tile<32x32, f32>, #l1_>)
     %view = "ttir.view_layout"(%alloc) : (memref<8x8x1x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x8x32x!tt.tile<32x32, f32>, #tt.shard<131072x4096>, #l1_>
     return %view : memref<1x1x8x32x!tt.tile<32x32, f32>, #tt.shard<131072x4096>, #l1_>

--- a/test/ttmlir/Dialect/TTIR/allocate/generic_form_streams_matmul.mlir
+++ b/test/ttmlir/Dialect/TTIR/allocate/generic_form_streams_matmul.mlir
@@ -49,7 +49,7 @@ func.func @matmul_multi_core_transpose(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32
   // CHECK: [[lhs:%[a-z0-9_]+]] = "ttir.stream_layout"(%arg0,
   %0 = "ttir.view_layout"(%arg0) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
   // CHECK-NOT: "ttir.view_layout"
-  // CHECK: [[rhs:%[a-z0-9_]+]] = "ttir.stream_layout"(%arg1, {{.*}}, #tt.stream<(d0, d1, d2, d3) -> (d1, d0, d3, d2)>,
+  // CHECK: [[rhs:%[a-z0-9_]+]] = "ttir.stream_layout"(%arg1, {{.*}}, #tt.view<(d0, d1, d2, d3) -> (d1, d0, d3, d2)>,
   %1 = "ttir.view_layout"(%arg1) : (memref<4x4x8x6x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, affine_map<(d0, d1, d2, d3) -> (d1, d0, d3, d2)>, #l1_>
   // CHECK: ttir.generic{{.*}}
   // CHECK-NEXT: ins([[lhs]], [[rhs]] : {{.*}})

--- a/test/ttmlir/Dialect/TTIR/generic/affine_dma.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/affine_dma.mlir
@@ -8,12 +8,12 @@
 #parallel = #tt.iterator_type<parallel>
 #reduction = #tt.iterator_type<reduction>
 
-func.func @matmul_single_core_stream(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
-  %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
-  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
-  %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>
-  %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>
+func.func @matmul_single_core_stream(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>, %arg1: memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>
+  %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>
+  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>
+  %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>) -> memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
+  %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>) -> memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
   "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^datamovement0(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
     // CHECK-DAG: [[iter0:%.*]] = ttir.iter_index(0)
@@ -22,7 +22,7 @@ func.func @matmul_single_core_stream(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>,
     // CHECK-DAG: arith.muli
     // CHECK-DAG: arith.addi
     // CHECK: ttir.dma %stream{{[_0-9]*}} [%{{.*}}, [[iter2]], %c0, %c0]
-    %tx = ttir.dma %stream<#map1>, %cb0 : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+    %tx = ttir.dma %stream<#map1>, %cb0 : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
     ttir.dma_wait %tx
     ttir.yield %cb0 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
   }, {
@@ -33,7 +33,7 @@ func.func @matmul_single_core_stream(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>,
     // CHECK-DAG: arith.muli
     // CHECK-DAG: arith.addi
     // CHECK: ttir.dma %stream{{[_0-9]*}} [[[iter2]], %{{.*}}, %c0, %c0]
-    %tx = ttir.dma %stream_2<#map2>, %cb1 : (memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+    %tx = ttir.dma %stream_2<#map2>, %cb1 : (memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
     ttir.dma_wait %tx
     ttir.yield %cb1 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
   }, {
@@ -44,16 +44,16 @@ func.func @matmul_single_core_stream(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>,
     ttir.await %cb0, %cb1 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>)
     "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
     ttir.yield %cb2 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
-  }) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
-  return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  }) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>
 }
 
-func.func @matmul_single_core_transpose(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
-  %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
-  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
-  %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>
-  %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d1, d0, d3, d2) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>
+func.func @matmul_single_core_transpose(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>, %arg1: memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>
+  %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>
+  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>
+  %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>) -> memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
+  %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>) -> memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.view<(d0, d1, d2, d3) -> (d1, d0, d3, d2)>, #l1_>
   "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^datamovement0(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
     // CHECK-DAG: [[iter0:%.*]] = ttir.iter_index(0)
@@ -62,7 +62,7 @@ func.func @matmul_single_core_transpose(%arg0: memref<1x2x2x2x!tt.tile<32x32, f3
     // CHECK-DAG: arith.muli
     // CHECK-DAG: arith.addi
     // CHECK: ttir.dma %stream{{[_0-9]*}} [%{{.*}}, [[iter2]], %c0, %c0]
-    %tx = ttir.dma %stream<#map1>, %cb0 : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+    %tx = ttir.dma %stream<#map1>, %cb0 : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
     ttir.dma_wait %tx
     ttir.yield %cb0 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
   }, {
@@ -78,7 +78,7 @@ func.func @matmul_single_core_transpose(%arg0: memref<1x2x2x2x!tt.tile<32x32, f3
     // CHECK-NEXT: ttir.dma %stream{{[_0-9]*}} [[[iter2]], %{{.*}}, [[for_iter_i]], [[for_iter_j]]]
     // CHECK: scf.yield
     // CHECK: scf.yield
-    %tx = ttir.dma %stream_2<#map2>, %cb1 : (memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d1, d0, d3, d2) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+    %tx = ttir.dma %stream_2<#map2>, %cb1 : (memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.view<(d0, d1, d2, d3) -> (d1, d0, d3, d2)>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
     ttir.dma_wait %tx
     ttir.yield %cb1 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
   }, {
@@ -89,16 +89,16 @@ func.func @matmul_single_core_transpose(%arg0: memref<1x2x2x2x!tt.tile<32x32, f3
     ttir.await %cb0, %cb1 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>)
     "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
     ttir.yield %cb2 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
-  }) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d1, d0, d3, d2) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
-  return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  }) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.view<(d0, d1, d2, d3) -> (d1, d0, d3, d2)>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>
 }
 
-func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
-  %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
-  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>
-  %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 24576 + d3 * 4096)>, #l1_>
-  %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>, memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #l1_>
+func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.shard<24576x4096>, #l1_>, %arg1: memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #l1_>) -> memref<2x4x4x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #l1_>
+  %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.shard<24576x4096>, #l1_>
+  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<2x4x6x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #l1_>
+  %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.shard<24576x4096>, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.shard<24576x4096>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
+  %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #l1_>, memref<2x4x6x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
   "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^datamovement0(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>, %sem0: !ttir.semaphore, %sem1: !ttir.semaphore, %sem2: !ttir.semaphore, %sem3: !ttir.semaphore):
     %c3 = arith.constant 3 : index
@@ -115,7 +115,7 @@ func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, 
       // CHECK-DAG: arith.muli
       // CHECK-DAG: arith.addi
       // CHECK: ttir.dma %stream{{[_0-9]*}} [%{{.*}}, [[iter2]], %c0, %c0]
-      %tx = ttir.dma %stream<#map1>, %cb0 : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 24576 + d3 * 4096)>, #l1_>, memref<4x6x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+      %tx = ttir.dma %stream<#map1>, %cb0 : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<4x6x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
       ttir.dma_wait %tx
       ttir.semaphore_wait %sem0, %c3 reset %c0
       %tx_3 = ttir.dma %cb0, %cb0 core[%core0, %c0] mcast[%c1, %c4] : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<4x6x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
@@ -141,7 +141,7 @@ func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, 
       // CHECK-DAG: arith.muli
       // CHECK-DAG: arith.addi
       // CHECK: ttir.dma %stream{{[_0-9]*}} [[[iter2]], %{{.*}}, %c0, %c0]
-      %tx = ttir.dma %stream_2<#map2>, %cb1 : (memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+      %tx = ttir.dma %stream_2<#map2>, %cb1 : (memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
       ttir.dma_wait %tx
       ttir.semaphore_wait %sem2, %c1 reset %c0
       %tx_3 = ttir.dma %cb1, %cb1 core[%c0, %core1] mcast[%c2, %c1] : (memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
@@ -160,16 +160,16 @@ func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, 
     ttir.await %cb0, %cb1 : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>)
     "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
     ttir.yield %cb2 : (memref<4x8x!tt.tile<32x32, f32>, #l1_>)
-  }) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 24576 + d3 * 4096)>, #l1_>, memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #l1_>, memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
-  return %alloc : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
+  }) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<2x4x4x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #l1_>) -> ()
+  return %alloc : memref<2x4x4x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #l1_>
 }
 
-func.func @matmul_multi_core_dram_params(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<4x4x6x8x!tt.tile<32x32, f32>, #dram>) -> memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
-  %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
-  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>
-  %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 24576 + d3 * 4096)>, #l1_>
-  %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #dram>, memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #dram>
+func.func @matmul_multi_core_dram_params(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.shard<24576x4096>, #l1_>, %arg1: memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #dram>) -> memref<2x4x4x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #l1_>
+  %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.shard<24576x4096>, #l1_>
+  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<2x4x6x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #l1_>
+  %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.shard<24576x4096>, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.shard<24576x4096>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
+  %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #dram>, memref<2x4x6x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.view<map(4)>, #dram>
   "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^datamovement0(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>, %sem0: !ttir.semaphore, %sem1: !ttir.semaphore, %sem2: !ttir.semaphore, %sem3: !ttir.semaphore):
     %c3 = arith.constant 3 : index
@@ -186,7 +186,7 @@ func.func @matmul_multi_core_dram_params(%arg0: memref<2x4x4x6x!tt.tile<32x32, f
       // CHECK-DAG: arith.muli
       // CHECK-DAG: arith.addi
       // CHECK: ttir.dma %stream{{[_0-9]*}} [%{{.*}}, [[iter2]], %c0, %c0]
-      %tx = ttir.dma %stream<#map1>, %cb0 : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 24576 + d3 * 4096)>, #l1_>, memref<4x6x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+      %tx = ttir.dma %stream<#map1>, %cb0 : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<4x6x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
       ttir.dma_wait %tx
       ttir.semaphore_wait %sem0, %c3 reset %c0
       %tx_3 = ttir.dma %cb0, %cb0 core[%core0, %c0] mcast[%c1, %c4] : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<4x6x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
@@ -212,7 +212,7 @@ func.func @matmul_multi_core_dram_params(%arg0: memref<2x4x4x6x!tt.tile<32x32, f
       // CHECK-DAG: arith.muli
       // CHECK-DAG: arith.addi
       // CHECK: ttir.dma %stream{{[_0-9]*}} [[[iter2]], %{{.*}}, %c0, %c0]
-      %tx = ttir.dma %stream_2<#map2>, %cb1 : (memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #dram>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+      %tx = ttir.dma %stream_2<#map2>, %cb1 : (memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.view<map(4)>, #dram>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
       ttir.dma_wait %tx
       ttir.semaphore_wait %sem2, %c1 reset %c0
       %tx_3 = ttir.dma %cb1, %cb1 core[%c0, %core1] mcast[%c2, %c1] : (memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
@@ -231,6 +231,6 @@ func.func @matmul_multi_core_dram_params(%arg0: memref<2x4x4x6x!tt.tile<32x32, f
     ttir.await %cb0, %cb1 : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>)
     "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
     ttir.yield %cb2 : (memref<4x8x!tt.tile<32x32, f32>, #l1_>)
-  }) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 24576 + d3 * 4096)>, #l1_>, memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #dram>, memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
-  return %alloc : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
+  }) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.view<map(4)>, #dram>, memref<2x4x4x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #l1_>) -> ()
+  return %alloc : memref<2x4x4x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #l1_>
 }

--- a/test/ttmlir/Dialect/TTIR/generic/generic_datamovement.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/generic_datamovement.mlir
@@ -69,8 +69,8 @@ func.func @matmul_single_core_stream(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>,
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
   %cb0_alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
   %cb1_alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
-  %0 = "ttir.stream_layout"(%arg0, %cb0_alloc) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 2 * 4096 + d3 * 4096)>, #l1_>
-  %1 = "ttir.stream_layout"(%arg1, %cb1_alloc) : (memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 2 * 4096 + d3 * 4096)>, #l1_>
+  %0 = "ttir.stream_layout"(%arg0, %cb0_alloc) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
+  %1 = "ttir.stream_layout"(%arg1, %cb1_alloc) : (memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
   // CHECK: ttir.generic
   // CHECK-NEXT: ins([[lhs:%[a-z0-9_]+]], [[rhs:%[a-z0-9_]+]] : {{.*}})
   // CHECK-NEXT: outs([[out:%[a-z0-9_]+]] : {{.*}})
@@ -96,7 +96,7 @@ func.func @matmul_single_core_stream(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>,
   // CHECK: ttir.yield
   ^bb0(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
     "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
-  }) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 2 * 4096 + d3 * 4096)>, #l1_>, memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 2 * 4096 + d3 * 4096)>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
+  }) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
   return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
 }
 
@@ -104,8 +104,8 @@ func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, 
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
   %cb0_alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
   %cb1_alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>
-  %0 = "ttir.stream_layout"(%arg0, %cb0_alloc) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 6 * 4096 + d3 * 4096)>, #l1_>
-  %1 = "ttir.stream_layout"(%arg1, %cb1_alloc) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>, memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8 * 4096 + d3 * 4096)>, #l1_>
+  %0 = "ttir.stream_layout"(%arg0, %cb0_alloc) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
+  %1 = "ttir.stream_layout"(%arg1, %cb1_alloc) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>, memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
   // CHECK: ttir.generic
   // CHECK-NEXT: ins([[lhs:%[a-z0-9_]+]], [[rhs:%[a-z0-9_]+]] : {{.*}})
   // CHECK-NEXT: outs([[out:%[a-z0-9_]+]] : {{.*}})
@@ -143,7 +143,7 @@ func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, 
   // CHECK: ttir.yield
   ^bb0(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>):
     "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
-  }) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 6 * 4096 + d3 * 4096)>, #l1_>, memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8 * 4096 + d3 * 4096)>, #l1_>, memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
+  }) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
   return %alloc : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
 }
 
@@ -151,8 +151,8 @@ func.func @matmul_multi_core_dram_params(%arg0: memref<2x4x4x6x!tt.tile<32x32, f
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
   %cb0_alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
   %cb1_alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>
-  %0 = "ttir.stream_layout"(%arg0, %cb0_alloc) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 6 * 4096 + d3 * 4096)>, #l1_>
-  %1 = "ttir.stream_layout"(%arg1, %cb1_alloc) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #dram>, memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8 * 4096 + d3 * 4096)>, #dram>
+  %0 = "ttir.stream_layout"(%arg0, %cb0_alloc) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
+  %1 = "ttir.stream_layout"(%arg1, %cb1_alloc) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #dram>, memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.view<map(4)>, #dram>
   // CHECK: ttir.generic
   // CHECK-NEXT: ins([[lhs:%[a-z0-9_]+]], [[rhs:%[a-z0-9_]+]] : {{.*}})
   // CHECK-NEXT: outs([[out:%[a-z0-9_]+]] : {{.*}})
@@ -190,7 +190,7 @@ func.func @matmul_multi_core_dram_params(%arg0: memref<2x4x4x6x!tt.tile<32x32, f
   // CHECK: ttir.yield
   ^bb0(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>):
     "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
-  }) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 6 * 4096 + d3 * 4096)>, #l1_>, memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8 * 4096 + d3 * 4096)>, #dram>, memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
+  }) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.view<map(4)>, #dram>, memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
   return %alloc : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
 }
 

--- a/test/ttmlir/Dialect/TTIR/generic/generic_loops.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/generic_loops.mlir
@@ -103,8 +103,8 @@ func.func @matmul_outer_k(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, %ar
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
   %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
   %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
-  %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>
-  %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>
+  %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
+  %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
   "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^datamovement0(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
     // CHECK: scf.for %{{.*}} = %c0 to %c1
@@ -113,7 +113,7 @@ func.func @matmul_outer_k(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, %ar
     // CHECK-NEXT: ttir.dma %{{.*}}[%c0, %[[I]]]
     %c0 = arith.constant 0 : index
     %k = ttir.iter_index(2) : index
-    %tx = ttir.dma %stream[%c0, %k], %cb0 : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+    %tx = ttir.dma %stream[%c0, %k], %cb0 : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
     ttir.dma_wait %tx
     ttir.yield %cb0 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
   }, {
@@ -124,7 +124,7 @@ func.func @matmul_outer_k(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, %ar
     // CHECK-NEXT: ttir.dma %{{.*}}[%[[I]], %c0]
     %c0 = arith.constant 0 : index
     %k = ttir.iter_index(2) : index
-    %tx = ttir.dma %stream_2[%k, %c0], %cb1 : (memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+    %tx = ttir.dma %stream_2[%k, %c0], %cb1 : (memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
     ttir.dma_wait %tx
     ttir.yield %cb1 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
   }, {
@@ -141,7 +141,7 @@ func.func @matmul_outer_k(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, %ar
     ttir.await %cb0, %cb1 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>)
     "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
     ttir.yield %cb2 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
-  }) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 8192 + d3 * 4096)>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
+  }) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
   return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
 }
 
@@ -149,8 +149,8 @@ func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, 
   %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
   %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
   %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>
-  %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 24576 + d3 * 4096)>, #l1_>
-  %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>, memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #l1_>
+  %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
+  %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>, memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
   "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^datamovement0(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>, %sem0: !ttir.semaphore, %sem1: !ttir.semaphore, %sem2: !ttir.semaphore, %sem3: !ttir.semaphore):
     // CHECK: scf.for %{{.*}} = %c0 to %c1
@@ -177,6 +177,6 @@ func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, 
     ttir.await %cb0, %cb1 : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>)
     "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
     ttir.yield %cb2 : (memref<4x8x!tt.tile<32x32, f32>, #l1_>)
-  }) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 24576 + d3 * 4096)>, #l1_>, memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.stream<(d0, d1, d2, d3) -> (d0, d1, d2 * 32768 + d3 * 4096)>, #l1_>, memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
+  }) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
   return %alloc : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
 }

--- a/test/ttmlir/Dialect/TTIR/generic/generic_regions_to_funcs.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/generic_regions_to_funcs.mlir
@@ -5,21 +5,21 @@
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #parallel = #tt.iterator_type<parallel>
 
-func.func @add(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+func.func @add(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<0x0>, #l1_>, %arg1: memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<0x0>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<0x0>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<0x0>, #l1_>
   // CHECK: [#ttir.thread<datamovement, @datamovement_kernel0>, #ttir.thread<compute, @compute_kernel1>]
   ttir.generic {grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<datamovement>, #ttir.thread<compute>]}
-               ins(%arg0, %arg1 : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>)
-               outs(%alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) {
+               ins(%arg0, %arg1 : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<0x0>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<0x0>, #l1_>)
+               outs(%alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<0x0>, #l1_>) {
   ^datamovement0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
     %c0 = arith.constant 0 : index
-    %tx = ttir.dma %arg0[%c0, %c0], %cb0 : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<2x4x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
+    %tx = ttir.dma %arg0[%c0, %c0], %cb0 : (memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<0x0>, #l1_>, memref<2x4x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
     "ttir.yield"() : () -> ()
   }, {
   ^compute0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
     "ttir.yield"() : () -> ()
   }
-  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<0x0>, #l1_>
 }
 // CHECK: func.func private @datamovement_kernel0{{.*}} attributes {ttir.thread = #ttir.thread<datamovement>}
 // CHECK: ttir.get_global_operand(0)


### PR DESCRIPTION
Introduce a new op interface for ops that can take views of memory, i.e. view_layout and stream_layout ops.  This interface generalizes and applyViews function which recursively evaluates chains of view ops over their underlying physical memory.

This change also renames StreamLayoutAttr to ViewLayoutAttr to better align with the semantics.  That is, view layout ops always return memrefs with layout ViewLayoutAttr, of which stream_layout is a special case.