### PR TITLE
Adopt virtualized/translated worker core coordinates

### DIFF
--- a/include/ttmlir-c/TTAttrs.h
+++ b/include/ttmlir-c/TTAttrs.h
@@ -27,13 +27,15 @@ ttmlirTTDataTypeAttrGet(MlirContext ctx, uint16_t *supportedDataTypes);
 
 MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTChipDescAttrGet(
     MlirContext ctx, MlirAttribute arch, int64_t *grid, size_t gridSize,
+    int64_t *coordTranslationOffsets, size_t coordTranslationOffsetsSize,
     unsigned l1Size, unsigned numDramChannels, unsigned dramChannelSize,
     unsigned nocL1AddressAlignBytes, unsigned pcieAddressAlignBytes,
     unsigned nocDRAMAddressAlignBytes, unsigned l1UnreservedBase,
     unsigned eriscL1UnreservedBase, unsigned dramUnreservedBase,
-    MlirAttribute chipPhysicalCores, MlirAttribute *supportedDataTypes,
-    MlirAttribute *supportedTileSizes, unsigned numCBs,
-    unsigned numComputeThreads, unsigned numDatamovementThreads);
+    unsigned dramUnreservedEnd, MlirAttribute chipPhysicalHelperCores,
+    MlirAttribute *supportedDataTypes, MlirAttribute *supportedTileSizes,
+    unsigned numCBs, unsigned numComputeThreads,
+    unsigned numDatamovementThreads);
 
 MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTChipCoordAttrGet(
     MlirContext ctx, unsigned rack, unsigned shelf, unsigned y, unsigned x);
@@ -70,10 +72,9 @@ MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTIteratorTypeArrayAttrGet(
 MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTTileSizeAttrGet(MlirContext ctx,
                                                          int64_t y, int64_t x);
 
-MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTChipPhysicalCoresAttrGet(
-    MlirContext ctx, MlirAttribute *worker, size_t workerSize,
-    MlirAttribute *dram, size_t dramSize, MlirAttribute *eth, size_t ethSize,
-    MlirAttribute *eth_inactive, size_t eth_inactiveSize);
+MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTChipPhysicalHelperCoresAttrGet(
+    MlirContext ctx, MlirAttribute *dram, size_t dramSize, MlirAttribute *eth,
+    size_t ethSize, MlirAttribute *eth_inactive, size_t eth_inactiveSize);
 
 MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTCoreCoordAttrGet(MlirContext ctx,
                                                           int64_t y, int64_t x);

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -68,16 +68,6 @@ def TT_GridAttr : TT_Attr<"Grid", "grid"> {
   }];
 }
 
-def TT_CoordTranslationOffsetsAttr : TT_Attr<"CoordTranslationOffsets", "coord_translation_offsets"> {
-  let summary = "TT coord_translation_offsets attribute";
-  let description = [{
-    TT coord_translation_offsets attribute containing the offsets that translate physical coordinates to translated coordinates for the worker cores.
-  }];
-
-  let parameters = (ins ArrayRefParameter<"int64_t">:$offset_pair);
-  let assemblyFormat = "custom<DimensionList>($offset_pair)";
-}
-
 def TT_ArchAttr : EnumAttr<TT_Dialect, TT_Arch, "arch"> {
   let assemblyFormat = "`<` $value `>`";
 }

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -68,6 +68,16 @@ def TT_GridAttr : TT_Attr<"Grid", "grid"> {
   }];
 }
 
+def TT_CoordTranslationOffsetsAttr : TT_Attr<"CoordTranslationOffsets", "coord_translation_offsets"> {
+  let summary = "TT coord_translation_offsets attribute";
+  let description = [{
+    TT coord_translation_offsets attribute containing the offsets that translate physical coordinates to translated coordinates for the worker cores.
+  }];
+
+  let parameters = (ins ArrayRefParameter<"int64_t">:$offset_pair);
+  let assemblyFormat = "custom<DimensionList>($offset_pair)";
+}
+
 def TT_ArchAttr : EnumAttr<TT_Dialect, TT_Arch, "arch"> {
   let assemblyFormat = "`<` $value `>`";
 }
@@ -97,14 +107,14 @@ def TT_TileSizeAttr : TT_Attr<"TileSize", "tile_size"> {
 }
 
 
-def TT_ChipPhysicalCoresAttr : TT_Attr<"ChipPhysicalCores", "chip_physical_cores"> {
-  let summary = "TT chip_physical_cores attribute";
+def TT_ChipPhysicalHelperCoresAttr : TT_Attr<"ChipPhysicalHelperCores", "chip_physical_helper_cores"> {
+  let summary = "TT chip_physical_helper_cores attribute";
   let description = [{
-    TT chip_physical_cores attribute containing arrays of physical cores by core type in order of logical cores.
+    TT chip_physical_helper_cores attribute containing arrays of physical helper cores by core type in order of logical cores.
   }];
 
-  let parameters = (ins ArrayRefParameter<"CoreCoordAttr">:$worker, ArrayRefParameter<"CoreCoordAttr">:$dram, OptionalArrayRefParameter<"CoreCoordAttr">:$eth, OptionalArrayRefParameter<"CoreCoordAttr">:$eth_inactive);
-  let assemblyFormat = "`{` `worker` `=` `[` $worker `]` `dram` `=` `[` $dram `]` (`eth` `=` `[` $eth^ `]`)? (`eth_inactive` `=` `[` $eth_inactive^ `]`)? `}`";
+  let parameters = (ins ArrayRefParameter<"CoreCoordAttr">:$dram, OptionalArrayRefParameter<"CoreCoordAttr">:$eth, OptionalArrayRefParameter<"CoreCoordAttr">:$eth_inactive);
+  let assemblyFormat = "`{` `dram` `=` `[` $dram `]` (`eth` `=` `[` $eth^ `]`)? (`eth_inactive` `=` `[` $eth_inactive^ `]`)? `}`";
 }
 
 def TT_ChipDescAttr : TT_Attr<"ChipDesc", "chip_desc"> {
@@ -115,6 +125,7 @@ def TT_ChipDescAttr : TT_Attr<"ChipDesc", "chip_desc"> {
 
   let parameters = (ins "ArchAttr":$arch,
                     ArrayRefParameter<"int64_t">:$grid,
+                    ArrayRefParameter<"int64_t">:$coordTranslationOffsets,
                     "unsigned":$l1Size,
                     "unsigned":$numDramChannels,
                     "unsigned":$dramChannelSize,
@@ -125,7 +136,7 @@ def TT_ChipDescAttr : TT_Attr<"ChipDesc", "chip_desc"> {
                     "unsigned":$eriscL1UnreservedBase,
                     "unsigned":$dramUnreservedBase,
                     "unsigned":$dramUnreservedEnd,
-                    "ChipPhysicalCoresAttr":$chipPhysicalCores,
+                    "ChipPhysicalHelperCoresAttr":$chipPhysicalHelperCores,
                     ArrayRefParameter<"DataTypeAttr">:$supportedDataTypes,
                     ArrayRefParameter<"TileSizeAttr">:$supportedTileSizes,
                     "unsigned":$numCBs,
@@ -133,6 +144,7 @@ def TT_ChipDescAttr : TT_Attr<"ChipDesc", "chip_desc"> {
                     "unsigned":$numDatamovementThreads);
   let assemblyFormat = [{`{` `arch` `=` $arch `,`
                              `grid` `=` custom<DimensionList>($grid) `,`
+                             `coord_translation_offsets` `=` custom<DimensionList>($coordTranslationOffsets) `,`
                              `l1_size` `=` $l1Size `,`
                              `num_dram_channels` `=` $numDramChannels `,`
                              `dram_channel_size` `=` $dramChannelSize `,`
@@ -143,7 +155,7 @@ def TT_ChipDescAttr : TT_Attr<"ChipDesc", "chip_desc"> {
                              `erisc_l1_unreserved_base` `=` $eriscL1UnreservedBase `,`
                              `dram_unreserved_base` `=` $dramUnreservedBase `,`
                              `dram_unreserved_end` `=` $dramUnreservedEnd `,`
-                             `physical_cores` `=` $chipPhysicalCores `,`
+                             `physical_helper_cores` `=` $chipPhysicalHelperCores `,`
                              `supported_data_types` `=` `[` $supportedDataTypes `]` `,`
                              `supported_tile_sizes` `=` `[` $supportedTileSizes `]` `,`
                              `num_cbs` `=` $numCBs `,`

--- a/include/ttmlir/Dialect/TT/Utils/PhysicalCoreCoord.h
+++ b/include/ttmlir/Dialect/TT/Utils/PhysicalCoreCoord.h
@@ -62,11 +62,13 @@ public:
       auto chipDesc = chipDescs[chipId];
       auto chipGrid = chipDesc.getGrid();
       assert(chipGrid == firstChipGrid);
-      ChipPhysicalCoresAttr chipPhysicalCores = chipDesc.getChipPhysicalCores();
-      assert(chipPhysicalCores.getWorker().size() ==
-             static_cast<size_t>(grid[0] * grid[1]));
-      for (auto worker : chipPhysicalCores.getWorker()) {
-        physCores.push_back({worker.getY(), worker.getX()});
+      const ArrayRef<int64_t> coordTranslationOffsets =
+          chipDesc.getCoordTranslationOffsets();
+      for (int64_t y = 0; y < grid[0]; y++) {
+        for (int64_t x = 0; x < grid[1]; x++) {
+          physCores.push_back(
+              {y + coordTranslationOffsets[0], x + coordTranslationOffsets[1]});
+        }
       }
     }
     assert(physCores.size() == chipIds.size() * grid[0] * grid[1]);
@@ -77,7 +79,7 @@ public:
   getDramMapping(ArrayRef<unsigned> chipIds,
                  ArrayRef<tt::ChipDescAttr> chipDescs) {
     ArrayRef<CoreCoordAttr> firstChipDramCores =
-        chipDescs[chipIds.front()].getChipPhysicalCores().getDram();
+        chipDescs[chipIds.front()].getChipPhysicalHelperCores().getDram();
 
     std::array<int64_t, 2> grid = {
         1, static_cast<int64_t>(firstChipDramCores.size())};
@@ -85,10 +87,11 @@ public:
     physCores.reserve(chipIds.size() * grid[0] * grid[1]);
     for (auto chipId : chipIds) {
       auto chipDesc = chipDescs[chipId];
-      ChipPhysicalCoresAttr chipPhysicalCores = chipDesc.getChipPhysicalCores();
-      assert(chipPhysicalCores.getDram().size() ==
+      ChipPhysicalHelperCoresAttr chipPhysicalHelperCores =
+          chipDesc.getChipPhysicalHelperCores();
+      assert(chipPhysicalHelperCores.getDram().size() ==
              static_cast<size_t>(grid[0] * grid[1]));
-      for (auto dram : chipPhysicalCores.getDram()) {
+      for (auto dram : chipPhysicalHelperCores.getDram()) {
         physCores.push_back({dram.getY(), dram.getX()});
       }
     }

--- a/include/ttmlir/Target/Common/types.fbs
+++ b/include/ttmlir/Target/Common/types.fbs
@@ -69,6 +69,7 @@ enum BufferType: ushort {
 table ChipDesc {
   arch: Arch;
   grid_size: Dim2d;
+  coord_translation_offsets: Dim2d;
   l1_size: uint64;
   num_dram_channels: uint32;
   dram_channel_size: uint64;
@@ -79,7 +80,7 @@ table ChipDesc {
   erisc_l1_unreserved_base: uint32;
   dram_unreserved_base: uint32;
   dram_unreserved_end: uint32;
-  physical_cores: ChipPhysicalCores;
+  physical_helper_cores: ChipPhysicalHelperCores;
   supported_data_types: [DataType];
   supported_tile_sizes: [Dim2d];
   num_cbs: uint32;
@@ -101,8 +102,7 @@ struct ChipChannel {
   ethernet_core_coord1: Dim2d;
 }
 
-table ChipPhysicalCores {
-  worker: [Dim2d];
+table ChipPhysicalHelperCores {
   dram: [Dim2d];
   eth: [Dim2d];
   eth_inactive: [Dim2d];

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -226,31 +226,26 @@ inline ::tt::target::Dim2d toFlatbuffer(FlatbufferObjectCache &cache,
   return ::tt::target::Dim2d(arch.getShape()[0], arch.getShape()[1]);
 }
 
-inline flatbuffers::Offset<::tt::target::ChipPhysicalCores>
+inline flatbuffers::Offset<::tt::target::ChipPhysicalHelperCores>
 toFlatbuffer(FlatbufferObjectCache &cache,
-             ChipPhysicalCoresAttr chipPhysicalCores) {
+             ChipPhysicalHelperCoresAttr chipPhysicalHelperCores) {
 
   // Create a Flatbuffer Dim2d struct for each type of core.
-  std::vector<::tt::target::Dim2d> workerCores, dramCores, ethCores,
-      ethInactiveCores;
+  std::vector<::tt::target::Dim2d> dramCores, ethCores, ethInactiveCores;
 
-  for (auto const &coreCoord : chipPhysicalCores.getWorker()) {
-    workerCores.emplace_back(coreCoord.getY(), coreCoord.getX());
-  }
-  for (auto const &coreCoord : chipPhysicalCores.getDram()) {
+  for (auto const &coreCoord : chipPhysicalHelperCores.getDram()) {
     dramCores.emplace_back(coreCoord.getY(), coreCoord.getX());
   }
-  for (auto const &coreCoord : chipPhysicalCores.getEth()) {
+  for (auto const &coreCoord : chipPhysicalHelperCores.getEth()) {
     ethCores.emplace_back(coreCoord.getY(), coreCoord.getX());
   }
-  for (auto const &coreCoord : chipPhysicalCores.getEthInactive()) {
+  for (auto const &coreCoord : chipPhysicalHelperCores.getEthInactive()) {
     ethInactiveCores.emplace_back(coreCoord.getY(), coreCoord.getX());
   }
 
-  // Create and return the ChipPhysicalCores flatbuffer object
-  return ::tt::target::CreateChipPhysicalCores(
+  // Create and return the ChipPhysicalHelperCores flatbuffer object
+  return ::tt::target::CreateChipPhysicalHelperCores(
       *cache.fbb,
-      cache.fbb->CreateVectorOfStructs<::tt::target::Dim2d>(workerCores),
       cache.fbb->CreateVectorOfStructs<::tt::target::Dim2d>(dramCores),
       cache.fbb->CreateVectorOfStructs<::tt::target::Dim2d>(ethCores),
       cache.fbb->CreateVectorOfStructs<::tt::target::Dim2d>(ethInactiveCores));
@@ -314,15 +309,18 @@ inline flatbuffers::Offset<::tt::target::ChipDesc>
 toFlatbuffer(FlatbufferObjectCache &cache, ChipDescAttr chipDesc) {
   assert(chipDesc.getGrid().size() == 2 && "expected a 2D grid");
   auto grid = ::tt::target::Dim2d(chipDesc.getGrid()[0], chipDesc.getGrid()[1]);
+  auto coordTranslationOffsets =
+      ::tt::target::Dim2d(chipDesc.getCoordTranslationOffsets()[0],
+                          chipDesc.getCoordTranslationOffsets()[1]);
   return ::tt::target::CreateChipDesc(
       *cache.fbb, toFlatbuffer(cache, chipDesc.getArch()), &grid,
-      chipDesc.getL1Size(), chipDesc.getNumDramChannels(),
-      chipDesc.getDramChannelSize(), chipDesc.getNocL1AddressAlignBytes(),
-      chipDesc.getPcieAddressAlignBytes(),
+      &coordTranslationOffsets, chipDesc.getL1Size(),
+      chipDesc.getNumDramChannels(), chipDesc.getDramChannelSize(),
+      chipDesc.getNocL1AddressAlignBytes(), chipDesc.getPcieAddressAlignBytes(),
       chipDesc.getNocDRAMAddressAlignBytes(), chipDesc.getL1UnreservedBase(),
       chipDesc.getEriscL1UnreservedBase(), chipDesc.getDramUnreservedBase(),
       chipDesc.getDramUnreservedEnd(),
-      toFlatbuffer(cache, chipDesc.getChipPhysicalCores()),
+      toFlatbuffer(cache, chipDesc.getChipPhysicalHelperCores()),
       toFlatbuffer(cache, chipDesc.getSupportedDataTypes()),
       toFlatbuffer(cache, chipDesc.getSupportedTileSizes()),
       chipDesc.getNumCBs(), chipDesc.getNumComputeThreads(),

--- a/lib/CAPI/TTAttrs.cpp
+++ b/lib/CAPI/TTAttrs.cpp
@@ -34,21 +34,27 @@ MlirAttribute ttmlirTTDataTypeAttrGet(MlirContext ctx,
 
 MlirAttribute ttmlirTTChipDescAttrGet(
     MlirContext ctx, MlirAttribute arch, int64_t *grid, size_t gridSize,
+    int64_t *coordTranslationOffsets, size_t coordTranslationOffsetsSize,
     unsigned l1Size, unsigned numDramChannels, unsigned dramChannelSize,
     unsigned nocL1AddressAlignBytes, unsigned pcieAddressAlignBytes,
     unsigned nocDRAMAddressAlignBytes, unsigned l1UnreservedBase,
     unsigned eriscL1UnreservedBase, unsigned dramUnreservedBase,
-    unsigned dramUnreservedEnd, MlirAttribute chipPhysicalCores,
+    unsigned dramUnreservedEnd, MlirAttribute chipPhysicalHelperCores,
     MlirAttribute *supportedDataTypes, MlirAttribute *supportedTileSizes,
     unsigned numCBs, unsigned numComputeThreads,
     unsigned numDatamovementThreads) {
   std::vector<int64_t> gridVec(grid, grid + gridSize);
+  std::vector<int64_t> coordTranslationOffsetsVec(
+      coordTranslationOffsets,
+      coordTranslationOffsets + coordTranslationOffsetsSize);
   return wrap(ChipDescAttr::get(
-      unwrap(ctx), mlir::dyn_cast<ArchAttr>(unwrap(arch)), gridVec, l1Size,
-      numDramChannels, dramChannelSize, nocL1AddressAlignBytes,
-      pcieAddressAlignBytes, nocDRAMAddressAlignBytes, l1UnreservedBase,
-      eriscL1UnreservedBase, dramUnreservedBase, dramUnreservedEnd,
-      mlir::dyn_cast<ChipPhysicalCoresAttr>(unwrap(chipPhysicalCores)),
+      unwrap(ctx), mlir::dyn_cast<ArchAttr>(unwrap(arch)), gridVec,
+      coordTranslationOffsetsVec, l1Size, numDramChannels, dramChannelSize,
+      nocL1AddressAlignBytes, pcieAddressAlignBytes, nocDRAMAddressAlignBytes,
+      l1UnreservedBase, eriscL1UnreservedBase, dramUnreservedBase,
+      dramUnreservedEnd,
+      mlir::dyn_cast<ChipPhysicalHelperCoresAttr>(
+          unwrap(chipPhysicalHelperCores)),
       mlir::dyn_cast<DataTypeAttr>(unwrap(*supportedDataTypes)),
       mlir::dyn_cast<TileSizeAttr>(unwrap(*supportedTileSizes)), numCBs,
       numComputeThreads, numDatamovementThreads));
@@ -166,15 +172,10 @@ MlirAttribute ttmlirTTTileSizeAttrGet(MlirContext ctx, int64_t y, int64_t x) {
   return wrap(TileSizeAttr::get(unwrap(ctx), y, x));
 }
 
-MlirAttribute ttmlirTTChipPhysicalCoresAttrGet(
-    MlirContext ctx, MlirAttribute *worker, size_t workerSize,
-    MlirAttribute *dram, size_t dramSize, MlirAttribute *eth, size_t ethSize,
-    MlirAttribute *eth_inactive, size_t eth_inactiveSize) {
-  std::vector<CoreCoordAttr> workerVec, dramVec, ethVec, ethInactiveVec;
-  for (size_t i = 0; i < workerSize; i++) {
-    workerVec.push_back(mlir::cast<CoreCoordAttr>(unwrap(worker[i])));
-  }
-
+MlirAttribute ttmlirTTChipPhysicalHelperCoresAttrGet(
+    MlirContext ctx, MlirAttribute *dram, size_t dramSize, MlirAttribute *eth,
+    size_t ethSize, MlirAttribute *eth_inactive, size_t eth_inactiveSize) {
+  std::vector<CoreCoordAttr> dramVec, ethVec, ethInactiveVec;
   for (size_t i = 0; i < dramSize; i++) {
     dramVec.push_back(mlir::cast<CoreCoordAttr>(unwrap(dram[i])));
   }
@@ -188,8 +189,8 @@ MlirAttribute ttmlirTTChipPhysicalCoresAttrGet(
         mlir::cast<CoreCoordAttr>(unwrap(eth_inactive[i])));
   }
 
-  return wrap(ChipPhysicalCoresAttr::get(unwrap(ctx), workerVec, dramVec,
-                                         ethVec, ethInactiveVec));
+  return wrap(ChipPhysicalHelperCoresAttr::get(unwrap(ctx), dramVec, ethVec,
+                                               ethInactiveVec));
 }
 
 MlirAttribute ttmlirTTCoreCoordAttrGet(MlirContext ctx, int64_t y, int64_t x) {

--- a/lib/Dialect/TT/IR/TTOpsTypes.cpp
+++ b/lib/Dialect/TT/IR/TTOpsTypes.cpp
@@ -67,7 +67,7 @@ mlir::tt::SystemDescAttr mlir::tt::SystemDescAttr::getDefault(
   llvm::SmallVector<std::int64_t> coordTranslationOffsets = {18, 18};
 
   // Populate a placeholder for supported tile sizes.
-  llvm::SmallVector<DataTypeAttr> supported_data_types = {
+  llvm::SmallVector<DataTypeAttr> supportedDataTypes = {
       DataTypeAttr::get(context, DataType::Float32),
       DataTypeAttr::get(context, DataType::Float16),
       DataTypeAttr::get(context, DataType::BFloat16),
@@ -84,7 +84,7 @@ mlir::tt::SystemDescAttr mlir::tt::SystemDescAttr::getDefault(
   };
 
   // Populate a placeholder for supported tile sizes.
-  llvm::SmallVector<TileSizeAttr> supported_tile_sizes = {
+  llvm::SmallVector<TileSizeAttr> supportedTileSizes = {
       TileSizeAttr::get(context, 4, 16),  TileSizeAttr::get(context, 16, 16),
       TileSizeAttr::get(context, 32, 16), TileSizeAttr::get(context, 4, 32),
       TileSizeAttr::get(context, 16, 32), TileSizeAttr::get(context, 32, 32),
@@ -113,7 +113,7 @@ mlir::tt::SystemDescAttr mlir::tt::SystemDescAttr::getDefault(
         l1UnreservedBase, eriscL1UnreservedBase, dramUnreservedBase,
         dramUnreservedEnd,
         ChipPhysicalHelperCoresAttr::get(context, dramCores, {}, {}),
-        supported_data_types, supported_tile_sizes, numCBs, numComputeThreads,
+        supportedDataTypes, supportedTileSizes, numCBs, numComputeThreads,
         numDatamovementThreads));
   }
 
@@ -173,25 +173,24 @@ mlir::tt::SystemDescAttr::getFromPath(MLIRContext *context, std::string &path) {
   fbb.read(static_cast<char *>(buffer.get()), size);
 
   // Read relevant information from binary
-  auto const *binary_system_desc =
+  auto const *binarySystemDesc =
       ::tt::target::GetSizePrefixedSystemDescRoot(buffer.get())->system_desc();
-  auto const *binary_cpu_desc = binary_system_desc->cpu_descs();
-  auto const *binary_chip_desc = binary_system_desc->chip_descs();
-  auto const *binary_chip_desc_indices =
-      binary_system_desc->chip_desc_indices();
-  auto const *chip_capabilities = binary_system_desc->chip_capabilities();
-  auto const *binary_chip_coords = binary_system_desc->chip_coords();
-  auto const *chip_channel_connections = binary_system_desc->chip_channels();
+  auto const *binaryCpuDesc = binarySystemDesc->cpu_descs();
+  auto const *binaryChipDesc = binarySystemDesc->chip_descs();
+  auto const *binaryChipDescIndices = binarySystemDesc->chip_desc_indices();
+  auto const *chipCapabilities = binarySystemDesc->chip_capabilities();
+  auto const *binaryChipCoords = binarySystemDesc->chip_coords();
+  auto const *chipChannelConnections = binarySystemDesc->chip_channels();
 
   // Acquire cpu descs
-  std::vector<tt::CPUDescAttr> cpu_desc_list;
-  for (auto const *element : *binary_cpu_desc) {
+  std::vector<tt::CPUDescAttr> cpuDescList;
+  for (auto const *element : *binaryCpuDesc) {
     static_assert(llvm::to_underlying(::mlir::tt::CPURole::Device) ==
                   llvm::to_underlying(::tt::target::CPURole::Device));
     static_assert(llvm::to_underlying(::mlir::tt::CPURole::Host) ==
                   llvm::to_underlying(::tt::target::CPURole::Host));
     const auto *flatbufferTargetTripleString = element->target_triple();
-    cpu_desc_list.emplace_back(tt::CPUDescAttr::get(
+    cpuDescList.emplace_back(tt::CPUDescAttr::get(
         context, static_cast<mlir::tt::CPURole>(element->role()),
         mlir::StringAttr::get(
             context, std::string(flatbufferTargetTripleString->c_str(),
@@ -199,29 +198,29 @@ mlir::tt::SystemDescAttr::getFromPath(MLIRContext *context, std::string &path) {
   }
 
   // Acquire chip descs
-  std::vector<tt::ChipDescAttr> chip_desc_list;
-  for (auto const *element : *binary_chip_desc) {
-    std::vector<tt::CoreCoordAttr> dram_cores, eth_cores, eth_inactive_cores;
-    auto const *physical_helper_cores = element->physical_helper_cores();
+  std::vector<tt::ChipDescAttr> chipDescList;
+  for (auto const *element : *binaryChipDesc) {
+    std::vector<tt::CoreCoordAttr> dramCores, ethCores, ethInactiveCores;
+    auto const *physicalHelperCores = element->physical_helper_cores();
 
     // Populate all vecrors with CoreCoordAttr instances
-    for (auto const &core : *physical_helper_cores->dram()) {
-      dram_cores.emplace_back(
+    for (auto const &core : *physicalHelperCores->dram()) {
+      dramCores.emplace_back(
           tt::CoreCoordAttr::get(context, core->y(), core->x()));
     }
-    for (auto const &core : *physical_helper_cores->eth()) {
-      eth_cores.emplace_back(
+    for (auto const &core : *physicalHelperCores->eth()) {
+      ethCores.emplace_back(
           tt::CoreCoordAttr::get(context, core->y(), core->x()));
     }
-    for (auto const &core : *physical_helper_cores->eth_inactive()) {
-      eth_inactive_cores.emplace_back(
+    for (auto const &core : *physicalHelperCores->eth_inactive()) {
+      ethInactiveCores.emplace_back(
           tt::CoreCoordAttr::get(context, core->y(), core->x()));
     }
 
     // Create ChipPhysicalHelperCoresAttr from the list of CoreCoordAttr
     // instances
-    auto chip_physical_helper_cores_attr = tt::ChipPhysicalHelperCoresAttr::get(
-        context, dram_cores, eth_cores, eth_inactive_cores);
+    auto chipPhysicalHelperCoresAttr = tt::ChipPhysicalHelperCoresAttr::get(
+        context, dramCores, ethCores, ethInactiveCores);
 
     tt::Arch arch;
     switch (element->arch()) {
@@ -236,73 +235,73 @@ mlir::tt::SystemDescAttr::getFromPath(MLIRContext *context, std::string &path) {
       break;
     }
 
-    std::vector<tt::DataTypeAttr> supported_data_types_attr;
+    std::vector<tt::DataTypeAttr> supportedDataTypesAttr;
 
     for (auto it : *(element->supported_data_types())) {
       switch (it) {
       case ::tt::target::DataType::Float32:
-        supported_data_types_attr.push_back(
+        supportedDataTypesAttr.push_back(
             tt::DataTypeAttr::get(context, tt::DataType::Float32));
         break;
       case ::tt::target::DataType::Float16:
-        supported_data_types_attr.push_back(
+        supportedDataTypesAttr.push_back(
             tt::DataTypeAttr::get(context, tt::DataType::Float16));
         break;
       case ::tt::target::DataType::BFloat16:
-        supported_data_types_attr.push_back(
+        supportedDataTypesAttr.push_back(
             tt::DataTypeAttr::get(context, tt::DataType::BFloat16));
         break;
       case ::tt::target::DataType::BFP_Float8:
-        supported_data_types_attr.push_back(
+        supportedDataTypesAttr.push_back(
             tt::DataTypeAttr::get(context, tt::DataType::BFP_Float8));
         break;
       case ::tt::target::DataType::BFP_BFloat8:
-        supported_data_types_attr.push_back(
+        supportedDataTypesAttr.push_back(
             tt::DataTypeAttr::get(context, tt::DataType::BFP_BFloat8));
         break;
       case ::tt::target::DataType::BFP_Float4:
-        supported_data_types_attr.push_back(
+        supportedDataTypesAttr.push_back(
             tt::DataTypeAttr::get(context, tt::DataType::BFP_Float4));
         break;
       case ::tt::target::DataType::BFP_BFloat4:
-        supported_data_types_attr.push_back(
+        supportedDataTypesAttr.push_back(
             tt::DataTypeAttr::get(context, tt::DataType::BFP_BFloat4));
         break;
       case ::tt::target::DataType::BFP_Float2:
-        supported_data_types_attr.push_back(
+        supportedDataTypesAttr.push_back(
             tt::DataTypeAttr::get(context, tt::DataType::BFP_Float2));
         break;
       case ::tt::target::DataType::BFP_BFloat2:
-        supported_data_types_attr.push_back(
+        supportedDataTypesAttr.push_back(
             tt::DataTypeAttr::get(context, tt::DataType::BFP_BFloat2));
         break;
       case ::tt::target::DataType::UInt32:
-        supported_data_types_attr.push_back(
+        supportedDataTypesAttr.push_back(
             tt::DataTypeAttr::get(context, tt::DataType::UInt32));
         break;
       case ::tt::target::DataType::UInt16:
-        supported_data_types_attr.push_back(
+        supportedDataTypesAttr.push_back(
             tt::DataTypeAttr::get(context, tt::DataType::UInt16));
         break;
       case ::tt::target::DataType::UInt8:
-        supported_data_types_attr.push_back(
+        supportedDataTypesAttr.push_back(
             tt::DataTypeAttr::get(context, tt::DataType::UInt8));
         break;
       case ::tt::target::DataType::Int32:
-        supported_data_types_attr.push_back(
+        supportedDataTypesAttr.push_back(
             tt::DataTypeAttr::get(context, tt::DataType::Int32));
         break;
       }
     }
 
-    SmallVector<tt::TileSizeAttr> supported_tile_sizes_attr;
+    SmallVector<tt::TileSizeAttr> supportedTileSizesAttr;
 
     for (auto const *it : *(element->supported_tile_sizes())) {
-      supported_tile_sizes_attr.push_back(
+      supportedTileSizesAttr.push_back(
           tt::TileSizeAttr::get(context, it->y(), it->x()));
     }
 
-    auto current_chip_desc_attr = tt::ChipDescAttr::get(
+    auto currentChipDescAttr = tt::ChipDescAttr::get(
         context, tt::ArchAttr::get(context, arch),
         {element->grid_size()->y(), element->grid_size()->x()},
         {element->coord_translation_offsets()->y(),
@@ -312,62 +311,61 @@ mlir::tt::SystemDescAttr::getFromPath(MLIRContext *context, std::string &path) {
         element->pcie_address_align_bytes(),
         element->noc_dram_address_align_bytes(), element->l1_unreserved_base(),
         element->erisc_l1_unreserved_base(), element->dram_unreserved_base(),
-        element->dram_unreserved_end(), chip_physical_helper_cores_attr,
-        supported_data_types_attr, supported_tile_sizes_attr,
-        element->num_cbs(), element->num_compute_threads(),
-        element->num_datamovement_threads());
-    chip_desc_list.push_back(current_chip_desc_attr);
+        element->dram_unreserved_end(), chipPhysicalHelperCoresAttr,
+        supportedDataTypesAttr, supportedTileSizesAttr, element->num_cbs(),
+        element->num_compute_threads(), element->num_datamovement_threads());
+    chipDescList.push_back(currentChipDescAttr);
   }
 
   // Acquire chip indices
-  std::vector<uint32_t> chip_indices_list;
-  for (auto element : *binary_chip_desc_indices) {
-    chip_indices_list.push_back(element);
+  std::vector<uint32_t> chipIndicesList;
+  for (auto element : *binaryChipDescIndices) {
+    chipIndicesList.push_back(element);
   }
 
   // Acquire chip capabilities
-  std::vector<tt::ChipCapabilityAttr> chip_capabilities_list;
-  for (auto element : *chip_capabilities) {
+  std::vector<tt::ChipCapabilityAttr> chipCapabilitiesList;
+  for (auto element : *chipCapabilities) {
     static_assert(llvm::to_underlying(::mlir::tt::ChipCapability::PCIE) ==
                   llvm::to_underlying(::tt::target::ChipCapability::PCIE));
     static_assert(llvm::to_underlying(::mlir::tt::ChipCapability::HostMMIO) ==
                   llvm::to_underlying(::tt::target::ChipCapability::HostMMIO));
 
-    auto chip_capabilities_attr = tt::ChipCapabilityAttr::get(
+    auto chipCapabilitiesAttr = tt::ChipCapabilityAttr::get(
         context, static_cast<::mlir::tt::ChipCapability>(element));
-    chip_capabilities_list.push_back(chip_capabilities_attr);
+    chipCapabilitiesList.push_back(chipCapabilitiesAttr);
   }
 
   // Acquire chip coordinates
-  std::vector<tt::ChipCoordAttr> chip_coordinate_list;
-  for (auto const *element : *binary_chip_coords) {
-    auto chip_coordinate_attr = tt::ChipCoordAttr::get(
+  std::vector<tt::ChipCoordAttr> chipCoordinateList;
+  for (auto const *element : *binaryChipCoords) {
+    auto chipCoordinateAttr = tt::ChipCoordAttr::get(
         context, element->rack(), element->shelf(), element->y(), element->x());
-    chip_coordinate_list.push_back(chip_coordinate_attr);
+    chipCoordinateList.push_back(chipCoordinateAttr);
   }
 
-  std::vector<tt::ChipChannelAttr> chip_channel_list;
-  for (auto const *element : *chip_channel_connections) {
-    std::vector<int64_t> ethernet_core_coord0_vec = {
+  std::vector<tt::ChipChannelAttr> chipChannelList;
+  for (auto const *element : *chipChannelConnections) {
+    std::vector<int64_t> ethernetCoreCoord0Vec = {
         element->ethernet_core_coord0().y(),
         element->ethernet_core_coord0().x()};
 
-    std::vector<int64_t> ethernet_core_coord1_vec = {
+    std::vector<int64_t> ethernetCoreCoord1Vec = {
         element->ethernet_core_coord1().y(),
         element->ethernet_core_coord1().x()};
 
-    auto chip_channel_attr = tt::ChipChannelAttr::get(
-        context, element->device_id0(), ethernet_core_coord0_vec,
-        element->device_id1(), ethernet_core_coord1_vec);
-    chip_channel_list.push_back(chip_channel_attr);
+    auto chipChannelAttr = tt::ChipChannelAttr::get(
+        context, element->device_id0(), ethernetCoreCoord0Vec,
+        element->device_id1(), ethernetCoreCoord1Vec);
+    chipChannelList.push_back(chipChannelAttr);
   }
 
   // Generate system desc attribute
-  auto system_desc_attr = tt::SystemDescAttr::get(
-      context, cpu_desc_list, chip_desc_list, chip_indices_list,
-      chip_capabilities_list, chip_coordinate_list, chip_channel_list);
+  auto systemDescAttr = tt::SystemDescAttr::get(
+      context, cpuDescList, chipDescList, chipIndicesList, chipCapabilitiesList,
+      chipCoordinateList, chipChannelList);
 
-  return system_desc_attr;
+  return systemDescAttr;
 }
 
 unsigned SystemDescAttr::getAddressAlignBytes(unsigned chipIndex) const {

--- a/python/TTModule.cpp
+++ b/python/TTModule.cpp
@@ -179,6 +179,10 @@ void populateTTModule(nb::module_ &m) {
       .def_prop_ro("arch", &tt::ChipDescAttr::getArch)
       .def_prop_ro("grid",
                    [](tt::ChipDescAttr self) { return self.getGrid().vec(); })
+      .def_prop_ro("coord_translation_offsets",
+                   [](tt::ChipDescAttr self) {
+                     return self.getCoordTranslationOffsets().vec();
+                   })
       .def_prop_ro("l1_size", &tt::ChipDescAttr::getL1Size)
       .def_prop_ro("num_dram_channels", &tt::ChipDescAttr::getNumDramChannels)
       .def_prop_ro("dram_channel_size", &tt::ChipDescAttr::getDramChannelSize)

--- a/python/TTModule.cpp
+++ b/python/TTModule.cpp
@@ -152,22 +152,23 @@ void populateTTModule(nb::module_ &m) {
       .def_static(
           "get",
           [](MlirContext ctx, MlirAttribute arch, std::vector<int64_t> grid,
-             unsigned l1Size, unsigned numDramChannels,
-             unsigned dramChannelSize, unsigned nocL1AddressAlignBytes,
-             unsigned pcieAddressAlignBytes, unsigned nocDRAMAddressAlignBytes,
-             unsigned l1UnreservedBase, unsigned eriscL1UnreservedBase,
-             unsigned dramUnreservedBase, unsigned dramUnreservedEnd,
-             MlirAttribute chipPhysicalCores, MlirAttribute supportedDataTypes,
-             MlirAttribute supportedTileSizes, unsigned numCBs,
-             unsigned numComputeThreads, unsigned numDatamovementThreads) {
+             std::vector<int64_t> coordTranslationOffsets, unsigned l1Size,
+             unsigned numDramChannels, unsigned dramChannelSize,
+             unsigned nocL1AddressAlignBytes, unsigned pcieAddressAlignBytes,
+             unsigned nocDRAMAddressAlignBytes, unsigned l1UnreservedBase,
+             unsigned eriscL1UnreservedBase, unsigned dramUnreservedBase,
+             unsigned dramUnreservedEnd, MlirAttribute chipPhysicalHelperCores,
+             MlirAttribute supportedDataTypes, MlirAttribute supportedTileSizes,
+             unsigned numCBs, unsigned numComputeThreads,
+             unsigned numDatamovementThreads) {
             return wrap(tt::ChipDescAttr::get(
                 unwrap(ctx), mlir::cast<tt::ArchAttr>(unwrap(arch)), grid,
-                l1Size, numDramChannels, dramChannelSize,
-                nocL1AddressAlignBytes, pcieAddressAlignBytes,
+                coordTranslationOffsets, l1Size, numDramChannels,
+                dramChannelSize, nocL1AddressAlignBytes, pcieAddressAlignBytes,
                 nocDRAMAddressAlignBytes, l1UnreservedBase,
                 eriscL1UnreservedBase, dramUnreservedBase, dramUnreservedEnd,
-                mlir::dyn_cast<tt::ChipPhysicalCoresAttr>(
-                    unwrap(chipPhysicalCores)),
+                mlir::dyn_cast<tt::ChipPhysicalHelperCoresAttr>(
+                    unwrap(chipPhysicalHelperCores)),
                 mlir::cast<tt::DataTypeAttr>(unwrap(supportedDataTypes)),
                 mlir::cast<tt::TileSizeAttr>(unwrap(supportedTileSizes)),
                 numCBs, numComputeThreads, numDatamovementThreads));
@@ -194,8 +195,8 @@ void populateTTModule(nb::module_ &m) {
                    &tt::ChipDescAttr::getDramUnreservedBase)
       .def_prop_ro("dram_unreserved_end",
                    &tt::ChipDescAttr::getDramUnreservedEnd)
-      .def_prop_ro("chip_physical_cores",
-                   &tt::ChipDescAttr::getChipPhysicalCores)
+      .def_prop_ro("chip_physical_helper_cores",
+                   &tt::ChipDescAttr::getChipPhysicalHelperCores)
       .def_prop_ro("supported_data_types",
                    [](tt::ChipDescAttr self) {
                      return self.getSupportedDataTypes().vec();
@@ -214,25 +215,24 @@ void populateTTModule(nb::module_ &m) {
       .def_prop_ro("y", &tt::TileSizeAttr::getY)
       .def_prop_ro("x", &tt::TileSizeAttr::getX);
 
-  tt_attribute_class<tt::ChipPhysicalCoresAttr>(m, "ChipPhysicalCoresAttr")
+  tt_attribute_class<tt::ChipPhysicalHelperCoresAttr>(
+      m, "ChipPhysicalHelperCoresAttr")
       .def_static("get",
-                  [](MlirContext ctx, std::vector<tt::CoreCoordAttr> worker,
-                     std::vector<tt::CoreCoordAttr> dram,
+                  [](MlirContext ctx, std::vector<tt::CoreCoordAttr> dram,
                      std::vector<tt::CoreCoordAttr> eth,
                      std::vector<tt::CoreCoordAttr> eth_inactive) {
-                    return wrap(tt::ChipPhysicalCoresAttr::get(
-                        unwrap(ctx), worker, dram, eth, eth_inactive));
+                    return wrap(tt::ChipPhysicalHelperCoresAttr::get(
+                        unwrap(ctx), dram, eth, eth_inactive));
                   })
-      .def_prop_ro(
-          "worker",
-          [](tt::ChipPhysicalCoresAttr self) { return self.getWorker().vec(); })
-      .def_prop_ro(
-          "dram",
-          [](tt::ChipPhysicalCoresAttr self) { return self.getDram().vec(); })
-      .def_prop_ro(
-          "eth",
-          [](tt::ChipPhysicalCoresAttr self) { return self.getEth().vec(); })
-      .def_prop_ro("eth_inactive", [](tt::ChipPhysicalCoresAttr self) {
+      .def_prop_ro("dram",
+                   [](tt::ChipPhysicalHelperCoresAttr self) {
+                     return self.getDram().vec();
+                   })
+      .def_prop_ro("eth",
+                   [](tt::ChipPhysicalHelperCoresAttr self) {
+                     return self.getEth().vec();
+                   })
+      .def_prop_ro("eth_inactive", [](tt::ChipPhysicalHelperCoresAttr self) {
         return self.getEthInactive().vec();
       });
 

--- a/runtime/lib/common/system_desc.cpp
+++ b/runtime/lib/common/system_desc.cpp
@@ -97,43 +97,42 @@ static flatbuffers::Offset<::tt::target::ChipPhysicalHelperCores>
 createChipPhysicalHelperCores(const ::tt::tt_metal::IDevice *device,
                               flatbuffers::FlatBufferBuilder &fbb) {
 
-  std::vector<::tt::target::Dim2d> dram_cores, eth_cores, eth_inactive_cores;
+  std::vector<::tt::target::Dim2d> dramCores, ethCores, ethInactiveCores;
 
-  for (int dram_channel = 0; dram_channel < device->num_dram_channels();
-       ++dram_channel) {
-    CoreCoord logical = device->logical_core_from_dram_channel(dram_channel);
-    dram_cores.emplace_back(::tt::target::Dim2d(logical.y, logical.x));
+  for (int dramChannel = 0; dramChannel < device->num_dram_channels();
+       ++dramChannel) {
+    CoreCoord logical = device->logical_core_from_dram_channel(dramChannel);
+    dramCores.emplace_back(::tt::target::Dim2d(logical.y, logical.x));
   }
 
   for (const CoreCoord &logical : device->get_active_ethernet_cores(true)) {
     CoreCoord physical = device->ethernet_core_from_logical_core(logical);
-    eth_cores.emplace_back(::tt::target::Dim2d(physical.y, physical.x));
+    ethCores.emplace_back(::tt::target::Dim2d(physical.y, physical.x));
   }
 
   for (const CoreCoord &logical : device->get_inactive_ethernet_cores()) {
     CoreCoord physical = device->ethernet_core_from_logical_core(logical);
-    eth_inactive_cores.emplace_back(
-        ::tt::target::Dim2d(physical.y, physical.x));
+    ethInactiveCores.emplace_back(::tt::target::Dim2d(physical.y, physical.x));
   }
 
-  sort(dram_cores);
-  sort(eth_cores);
-  sort(eth_inactive_cores);
+  sort(dramCores);
+  sort(ethCores);
+  sort(ethInactiveCores);
 
   return ::tt::target::CreateChipPhysicalHelperCores(
-      fbb, fbb.CreateVectorOfStructs(dram_cores),
-      fbb.CreateVectorOfStructs(eth_cores),
-      fbb.CreateVectorOfStructs(eth_inactive_cores));
+      fbb, fbb.CreateVectorOfStructs(dramCores),
+      fbb.CreateVectorOfStructs(ethCores),
+      fbb.CreateVectorOfStructs(ethInactiveCores));
 }
 
 ::tt::target::Dim2d
 getCoordinateTranslationOffsets(const ::tt::tt_metal::IDevice *device) {
-  const CoreCoord worker_nw_corner =
+  const CoreCoord workerNWCorner =
       device->worker_core_from_logical_core({0, 0});
-  const CoreCoord worker_nw_corner_translated =
-      device->virtual_noc0_coordinate(0, worker_nw_corner);
-  return ::tt::target::Dim2d(worker_nw_corner_translated.y,
-                             worker_nw_corner_translated.x);
+  const CoreCoord workerNWCornerTranslated =
+      device->virtual_noc0_coordinate(0, workerNWCorner);
+  return ::tt::target::Dim2d(workerNWCornerTranslated.y,
+                             workerNWCornerTranslated.x);
 }
 
 // Calculate the end of the DRAM region that is not usable by compiler.  This

--- a/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
@@ -233,7 +233,7 @@ def parse_tt_system_desc(attr):
                 value=", ".join(
                     [
                         "x".join(map(str, (coord.y, coord.x)))
-                        for coord in chip_desc.chip_physical_cores.dram
+                        for coord in chip_desc.chip_physical_helper_cores.dram
                     ]
                 ),
             )
@@ -244,7 +244,7 @@ def parse_tt_system_desc(attr):
                 value=", ".join(
                     [
                         "x".join(map(str, (coord.y, coord.x)))
-                        for coord in chip_desc.chip_physical_cores.eth
+                        for coord in chip_desc.chip_physical_helper_cores.eth
                     ]
                 ),
             )
@@ -255,7 +255,7 @@ def parse_tt_system_desc(attr):
                 value=", ".join(
                     [
                         "x".join(map(str, (coord.y, coord.x)))
-                        for coord in chip_desc.chip_physical_cores.eth_inactive
+                        for coord in chip_desc.chip_physical_helper_cores.eth_inactive
                     ]
                 ),
             )
@@ -265,8 +265,17 @@ def parse_tt_system_desc(attr):
                 key=f"chip#{i}-worker-core-coords",
                 value=", ".join(
                     [
-                        "x".join(map(str, (coord.y, coord.x)))
-                        for coord in chip_desc.chip_physical_cores.worker
+                        "x".join(
+                            map(
+                                str,
+                                (
+                                    chip_desc.coord_translation_offsets[0] + y,
+                                    chip_desc.coord_translation_offsets[1] + x,
+                                ),
+                            )
+                        )
+                        for y in range(chip_desc.grid[0])
+                        for x in range(chip_desc.grid[1])
                     ]
                 ),
             )


### PR DESCRIPTION
### Ticket
#2056

### Problem description
We would like to switch to [translated coordinates](https://github.com/tenstorrent/tt-umd/blob/main/docs/coordinate_systems.md#translated-coordinates) (tt-metal calls them virtual coordinates but will change in the future) for the worker cores.

### What's changed
Calculate the physical-to-translated coordinate translation offsets by querying what coordinates does the worker core `{0, 0}` translates to, and do subtraction (assuming the worker core grid is contiguous in the translated coordinates).
Store the offsets in the system descriptor flatbuffer schema and the tablegen file.
Compute the full worker core grid when needed.
The array of worker core coordinates is removed from the flatbuffer schema and tablegen file.
The structure that holds the dram/eth/inactive_eth core coordinates remains, but renamed to indicate that they're helper cores.

### Checklist
- [ ] New/Existing tests provide coverage for changes
