### PR TITLE
Enable Conv2dConfig overrides in explorer

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Utils/OptimizerOverrides.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/OptimizerOverrides.h
@@ -19,47 +19,40 @@ public:
   OptimizerOverridesHandler() {};
   ~OptimizerOverridesHandler() {};
 
-  // Setters for the overrides
-  // These are used to enable/disable the optimizer passes
+  // Enable/disable the optimizer passes.
   void setEnableOptimizer(bool);
-  // These are used to enable/disable the memory configurations
+  // Enable/disable the memory configurations.
   void setMemoryReconfig(bool);
   void setEnableMemoryLayoutAnalysis(bool);
   void setEnableMemoryLayoutAnalysisPolicy(bool);
   void setMemoryLayoutAnalysisPolicy(MemoryLayoutAnalysisPolicyType);
-  // These are used to set the input/output layout overrides
   void setInputLayoutOverrides(llvm::StringMap<InputLayoutOverrideParams> &);
   void setOutputLayoutOverrides(llvm::StringMap<OutputLayoutOverrideParams> &);
-  // These are used to add system descriptor path
+  void setConv2dConfigOverrides(llvm::StringMap<Conv2dConfigOverrideParams> &);
+  // Add system descriptor path.
   void setSystemDescPath(std::string);
-  // These are used to set the maximum number of legal layouts for grid analysis
+  // Set the maximum number of legal layouts for grid analysis.
   void setMaxLegalLayouts(int64_t);
-  // These are used to set the mesh shape
   void setMeshShape(std::vector<int64_t>);
 
-  // Getters for the overrides
-  // These are used to get the current state of the optimizer passes
+  // Get the current state of the optimizer passes.
   bool getEnableOptimizer() const;
-  // These are used to get the current state of the memory configurations
+  // Get the current state of the memory configurations.
   bool getMemoryReconfig() const;
   bool getEnableMemoryLayoutAnalysis() const;
   bool getEnableMemoryLayoutAnalysisPolicy() const;
   MemoryLayoutAnalysisPolicyType getMemoryLayoutAnalysisPolicy() const;
-  // These are used to get the current input/output layout overrides
   llvm::StringMap<InputLayoutOverrideParams> getInputLayoutOverrides() const;
   llvm::StringMap<OutputLayoutOverrideParams> getOutputLayoutOverrides() const;
-  // These are used to get the current system descriptor path
+  llvm::StringMap<Conv2dConfigOverrideParams> getConv2dConfigOverrides() const;
   std::string getSystemDescPath() const;
-  // These are used to get the current maximum number of legal layouts for grid
-  // analysis
+  // Get the current maximum number of legal layouts for grid analysis.
   int64_t getMaxLegalLayouts() const;
-  // These are used to get the current mesh shape
   std::vector<int64_t> getMeshShape() const;
 
-  // Method that converts the overrides to a string
   std::string toString() const;
 
-  // Fill input/output layout overrides maps.
+  // Fill override maps.
   // This is used from tt-forge frontend where we define and compile the models.
   void addInputLayoutOverride(StringRef, InputLayoutOverrideParams);
   void addInputLayoutOverride(StringRef, SmallVector<int64_t> &);
@@ -67,18 +60,21 @@ public:
   void addOutputLayoutOverride(StringRef, SmallVector<int64_t> &, BufferType,
                                TensorMemoryLayout, tt::ttnn::Layout,
                                tt::DataType);
+  void addConv2dConfigOverride(StringRef, Conv2dConfigOverrideParams);
 
-  // Wrapper methods we use to expose the adders to the python bindings
   std::unordered_map<std::string, InputLayoutOverrideParams>
   getInputLayoutOverridesNanobindWrapper() const;
   std::unordered_map<std::string, OutputLayoutOverrideParams>
   getOutputLayoutOverridesNanobindWrapper() const;
+  std::unordered_map<std::string, Conv2dConfigOverrideParams>
+  getConv2dConfigOverridesNanobindWrapper() const;
 
-  // Wrapper methods we use to expose the adders to the python bindings
   void addInputLayoutOverrideNanobindWrapper(std::string,
                                              std::vector<int64_t> &);
   void addOutputLayoutOverrideNanobindWrapper(std::string,
                                               OutputLayoutOverrideParams);
+  void addConv2dConfigOverrideNanobindWrapper(std::string,
+                                              Conv2dConfigOverrideParams);
 
 private:
   // Flags for enabling/disabling the optimizer passes
@@ -88,13 +84,12 @@ private:
   bool enableMemoryReconfig = true;
   bool enableMemoryLayoutAnalysis = false;
 
-  // Input layout overrides
   llvm::StringMap<InputLayoutOverrideParams> inputLayoutOverrides;
 
-  // Output layout overrides
   llvm::StringMap<OutputLayoutOverrideParams> outputLayoutOverrides;
 
-  // Memory layout analysis policy
+  llvm::StringMap<Conv2dConfigOverrideParams> conv2dConfigOverrides;
+
   bool enableMemoryLayoutAnalysisPolicy = false;
   MemoryLayoutAnalysisPolicyType memoryLayoutAnalysisPolicy;
 
@@ -104,7 +99,6 @@ private:
   // Maximum number of legal layouts for grid analysis
   int64_t maxLegalLayouts = 0;
 
-  // Mesh shape
   std::vector<int64_t> meshShape;
 
 }; // class OptimizerOverridesHandler

--- a/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
@@ -51,6 +51,23 @@ struct Conv2dConfigOverrideParams {
   std::optional<bool> enableWeightsDoubleBuffer = std::nullopt;
   std::optional<bool> enableSplitReader = std::nullopt;
   std::optional<bool> enableSubblockPadding = std::nullopt;
+
+  bool empty() const {
+    return !dtype.has_value() && !weightsDtype.has_value() &&
+           !activation.has_value() && !inputChannelsAlignment.has_value() &&
+           !deallocateActivation.has_value() &&
+           !reallocateHaloOutput.has_value() &&
+           !actBlockHOverride.has_value() && !actBlockWDiv.has_value() &&
+           !reshardIfNotOptimal.has_value() &&
+           !overrideShardingConfig.has_value() && !shardLayout.has_value() &&
+           !coreGrid.has_value() && !transposeShards.has_value() &&
+           !outputLayout.has_value() &&
+           !preprocessWeightsOnDevice.has_value() &&
+           !alwaysPreprocessWeights.has_value() &&
+           !enableActDoubleBuffer.has_value() &&
+           !enableWeightsDoubleBuffer.has_value() &&
+           !enableSplitReader.has_value() && !enableSubblockPadding.has_value();
+  }
 };
 
 struct OutputLayoutOverrideParams {
@@ -60,6 +77,12 @@ struct OutputLayoutOverrideParams {
       std::nullopt; // INTERLEAVED / SHARDED etc...
   std::optional<Layout> memoryLayout = std::nullopt; // ROW_MAJOR / TILE
   std::optional<tt::DataType> dataType = std::nullopt;
+
+  bool empty() const {
+    return !grid.has_value() && !bufferType.has_value() &&
+           !tensorMemoryLayout.has_value() && !memoryLayout.has_value() &&
+           !dataType.has_value();
+  }
 
   // Check if all layout parameters that are generated in LegalLayoutAnalysis
   // are overridden. DataType is the only that is not.
@@ -159,12 +182,16 @@ public:
   Conv2dConfigOverrideParser(llvm::cl::Option &opt)
       : llvm::cl::parser<llvm::StringMap<Conv2dConfigOverrideParams>>(opt) {}
 
-  // Parse override-conv2d-config string. If string format is invalid, return
-  // true, else return false.
+  // Parse string in override-conv2d-config format.
+  // Return true if string format is invalid to indicate error.
+  // Example of a valid string:
+  // "conv2d_1=enable_weights_double_buffer#true:activation#none,conv2d_2=dtype#bf16"
+  //
   bool parse(llvm::cl::Option &opt, StringRef argName, StringRef arg,
              llvm::StringMap<Conv2dConfigOverrideParams> &value);
 
   // Return override-conv2d-config string represenation.
+  //
   static std::string
   toString(const llvm::StringMap<Conv2dConfigOverrideParams> &);
 

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -648,27 +648,35 @@ toFlatbuffer(FlatbufferObjectCache &cache,
 inline ::flatbuffers::Offset<::tt::target::ttnn::Conv2dConfig>
 toFlatbuffer(FlatbufferObjectCache &cache,
              ttnn::Conv2dConfigAttr conv2dConfigAttr) {
-  return ::tt::target::ttnn::CreateConv2dConfig(
-      *cache.fbb, toFlatbuffer(cache, conv2dConfigAttr.getDtype()),
-      toFlatbuffer(cache, conv2dConfigAttr.getWeightsDtype()),
-      toFlatbuffer(cache, conv2dConfigAttr.getActivation().getValue()),
-      conv2dConfigAttr.getInputChannelsAlignment(),
-      conv2dConfigAttr.getDeallocateActivation(),
-      conv2dConfigAttr.getReallocateHaloOutput(),
-      conv2dConfigAttr.getActBlockHOverride(),
-      conv2dConfigAttr.getActBlockWDiv(),
-      conv2dConfigAttr.getReshardIfNotOptimal(),
-      conv2dConfigAttr.getOverrideShardingConfig(),
-      toFlatbuffer(cache, conv2dConfigAttr.getShardLayout()),
-      toFlatbuffer(cache, conv2dConfigAttr.getCoreGrid()),
-      conv2dConfigAttr.getTransposeShards(),
-      toFlatbuffer(cache, conv2dConfigAttr.getOutputLayout()),
-      conv2dConfigAttr.getPreprocessWeightsOnDevice(),
-      conv2dConfigAttr.getAlwaysPreprocessWeights(),
-      conv2dConfigAttr.getEnableActDoubleBuffer(),
-      conv2dConfigAttr.getEnableWeightsDoubleBuffer(),
-      conv2dConfigAttr.getEnableSplitReader(),
-      conv2dConfigAttr.getEnableSubblockPadding());
+  ::flatbuffers::Optional<::tt::target::ttnn::TensorMemoryLayout> shardLayout;
+  if (conv2dConfigAttr.getShardLayout()) {
+    shardLayout = toFlatbuffer(cache, conv2dConfigAttr.getShardLayout());
+  }
+  // TODO(vkovacevic): Add support for coreGrid #2781
+  ::flatbuffers::Offset<::tt::target::ttnn::CoreRangeSet> coreGrid;
+
+  ::flatbuffers::Offset<::tt::target::ttnn::Conv2dConfig> conv2dConfigDesc =
+      ::tt::target::ttnn::CreateConv2dConfig(
+          *cache.fbb, toFlatbuffer(cache, conv2dConfigAttr.getDtype()),
+          toFlatbuffer(cache, conv2dConfigAttr.getWeightsDtype()),
+          toFlatbuffer(cache, conv2dConfigAttr.getActivation().getValue()),
+          conv2dConfigAttr.getInputChannelsAlignment(),
+          conv2dConfigAttr.getDeallocateActivation(),
+          conv2dConfigAttr.getReallocateHaloOutput(),
+          conv2dConfigAttr.getActBlockHOverride(),
+          conv2dConfigAttr.getActBlockWDiv(),
+          conv2dConfigAttr.getReshardIfNotOptimal(),
+          conv2dConfigAttr.getOverrideShardingConfig(), shardLayout, coreGrid,
+          conv2dConfigAttr.getTransposeShards(),
+          toFlatbuffer(cache, conv2dConfigAttr.getOutputLayout()),
+          conv2dConfigAttr.getPreprocessWeightsOnDevice(),
+          conv2dConfigAttr.getAlwaysPreprocessWeights(),
+          conv2dConfigAttr.getEnableActDoubleBuffer(),
+          conv2dConfigAttr.getEnableWeightsDoubleBuffer(),
+          conv2dConfigAttr.getEnableSplitReader(),
+          conv2dConfigAttr.getEnableSubblockPadding());
+
+  return conv2dConfigDesc;
 }
 
 } // namespace mlir::tt

--- a/lib/Dialect/TTNN/Utils/OptimizerOverrides.cpp
+++ b/lib/Dialect/TTNN/Utils/OptimizerOverrides.cpp
@@ -45,6 +45,11 @@ void OptimizerOverridesHandler::setMeshShape(std::vector<int64_t> value) {
   meshShape = value;
 }
 
+void OptimizerOverridesHandler::setConv2dConfigOverrides(
+    llvm::StringMap<Conv2dConfigOverrideParams> &value) {
+  conv2dConfigOverrides = value;
+}
+
 bool OptimizerOverridesHandler::getEnableOptimizer() const {
   return enableOptimizer;
 }
@@ -82,6 +87,11 @@ OptimizerOverridesHandler::getOutputLayoutOverrides() const {
   return outputLayoutOverrides;
 }
 
+llvm::StringMap<Conv2dConfigOverrideParams>
+OptimizerOverridesHandler::getConv2dConfigOverrides() const {
+  return conv2dConfigOverrides;
+}
+
 std::unordered_map<std::string, InputLayoutOverrideParams>
 OptimizerOverridesHandler::getInputLayoutOverridesNanobindWrapper() const {
   std::unordered_map<std::string, InputLayoutOverrideParams>
@@ -100,6 +110,16 @@ OptimizerOverridesHandler::getOutputLayoutOverridesNanobindWrapper() const {
     outputLayoutOverridesWrapper[entry.getKey().str()] = entry.getValue();
   }
   return outputLayoutOverridesWrapper;
+}
+
+std::unordered_map<std::string, Conv2dConfigOverrideParams>
+OptimizerOverridesHandler::getConv2dConfigOverridesNanobindWrapper() const {
+  std::unordered_map<std::string, Conv2dConfigOverrideParams>
+      conv2dConfigOverridesWrapper;
+  for (auto &entry : conv2dConfigOverrides) {
+    conv2dConfigOverridesWrapper[entry.getKey().str()] = entry.getValue();
+  }
+  return conv2dConfigOverridesWrapper;
 }
 
 std::string OptimizerOverridesHandler::toString() const {
@@ -141,6 +161,12 @@ std::string OptimizerOverridesHandler::toString() const {
   if (outputLayoutOverrides.size() > 0) {
     options += OptionNames::overrideOutputLayout.str() + "=" +
                OutputLayoutOverrideParser::toString(outputLayoutOverrides) +
+               " ";
+  }
+
+  if (conv2dConfigOverrides.size() > 0) {
+    options += OptionNames::overrideConv2dConfig.str() + "=" +
+               Conv2dConfigOverrideParser::toString(conv2dConfigOverrides) +
                " ";
   }
 
@@ -190,6 +216,11 @@ void OptimizerOverridesHandler::addOutputLayoutOverride(
       std::move(grid), bufferType, tensorMemoryLayout, memoryLayout, dataType};
 }
 
+void OptimizerOverridesHandler::addConv2dConfigOverride(
+    StringRef opName, Conv2dConfigOverrideParams params) {
+  conv2dConfigOverrides[opName] = params;
+}
+
 void OptimizerOverridesHandler::addInputLayoutOverrideNanobindWrapper(
     std::string opName, std::vector<int64_t> &operandIdxes) {
   StringRef opNameStringRef(opName);
@@ -202,6 +233,12 @@ void OptimizerOverridesHandler::addOutputLayoutOverrideNanobindWrapper(
     std::string opName, OutputLayoutOverrideParams overrideParams) {
   StringRef opNameStringRef(opName);
   addOutputLayoutOverride(opNameStringRef, overrideParams);
+}
+
+void OptimizerOverridesHandler::addConv2dConfigOverrideNanobindWrapper(
+    std::string opName, Conv2dConfigOverrideParams overrideParams) {
+  StringRef opNameStringRef(opName);
+  addConv2dConfigOverride(opNameStringRef, overrideParams);
 }
 
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Utils/PassOverrides.cpp
+++ b/lib/Dialect/TTNN/Utils/PassOverrides.cpp
@@ -114,7 +114,8 @@ bool Conv2dConfigOverrideParser::parse(
           opt.error("Duplicate activation: " + paramValue);
           return true;
         }
-        params.activation = activation.str();
+        params.activation =
+            activation.equals_insensitive("none") ? "" : activation.str();
       } else if (paramName == "input_channels_alignment") {
         uint32_t inputChannelsAlignment;
         if (paramValue.getAsInteger<uint32_t>(10, inputChannelsAlignment)) {

--- a/python/OptimizerOverrides.cpp
+++ b/python/OptimizerOverrides.cpp
@@ -60,6 +60,9 @@ void populateOptimizerOverridesModule(nb::module_ &m) {
       .def("get_output_layout_overrides",
            &tt::ttnn::OptimizerOverridesHandler::
                getOutputLayoutOverridesNanobindWrapper)
+      .def("get_conv2d_config_overrides",
+           &tt::ttnn::OptimizerOverridesHandler::
+               getConv2dConfigOverridesNanobindWrapper)
 
       .def("add_input_layout_override",
            &tt::ttnn::OptimizerOverridesHandler::
@@ -67,6 +70,9 @@ void populateOptimizerOverridesModule(nb::module_ &m) {
       .def("add_output_layout_override",
            &tt::ttnn::OptimizerOverridesHandler::
                addOutputLayoutOverrideNanobindWrapper)
+      .def("add_conv2d_config_override",
+           &tt::ttnn::OptimizerOverridesHandler::
+               addConv2dConfigOverrideNanobindWrapper)
 
       .def("to_string", &tt::ttnn::OptimizerOverridesHandler::toString);
 
@@ -198,7 +204,184 @@ void populateOptimizerOverridesModule(nb::module_ &m) {
              } else {
                throw std::invalid_argument("Invalid data type: " + value);
              }
-           });
+           })
+      .def("empty", &mlir::tt::ttnn::OutputLayoutOverrideParams::empty);
+
+  nb::class_<mlir::tt::ttnn::Conv2dConfigOverrideParams>(
+      m, "Conv2dConfigOverrideParams")
+      .def(nb::init<>())
+      .def_rw("dtype", &mlir::tt::ttnn::Conv2dConfigOverrideParams::dtype)
+      .def_rw("weights_dtype",
+              &mlir::tt::ttnn::Conv2dConfigOverrideParams::weightsDtype)
+      .def_rw("activation",
+              &mlir::tt::ttnn::Conv2dConfigOverrideParams::activation)
+      .def_rw(
+          "input_channels_alignment",
+          &mlir::tt::ttnn::Conv2dConfigOverrideParams::inputChannelsAlignment)
+      .def_rw("deallocate_activation",
+              &mlir::tt::ttnn::Conv2dConfigOverrideParams::deallocateActivation)
+      .def_rw("reallocate_halo_output",
+              &mlir::tt::ttnn::Conv2dConfigOverrideParams::reallocateHaloOutput)
+      .def_rw("act_block_h_override",
+              &mlir::tt::ttnn::Conv2dConfigOverrideParams::actBlockHOverride)
+      .def_rw("act_block_w_div",
+              &mlir::tt::ttnn::Conv2dConfigOverrideParams::actBlockWDiv)
+      .def_rw("reshard_if_not_optimal",
+              &mlir::tt::ttnn::Conv2dConfigOverrideParams::reshardIfNotOptimal)
+      .def_rw(
+          "override_sharding_config",
+          &mlir::tt::ttnn::Conv2dConfigOverrideParams::overrideShardingConfig)
+      .def_rw("shard_layout",
+              &mlir::tt::ttnn::Conv2dConfigOverrideParams::shardLayout)
+      .def_rw("core_grid",
+              &mlir::tt::ttnn::Conv2dConfigOverrideParams::coreGrid)
+      .def_rw("transpose_shards",
+              &mlir::tt::ttnn::Conv2dConfigOverrideParams::transposeShards)
+      .def_rw("output_layout",
+              &mlir::tt::ttnn::Conv2dConfigOverrideParams::outputLayout)
+      .def_rw("preprocess_weights_on_device",
+              &mlir::tt::ttnn::Conv2dConfigOverrideParams::
+                  preprocessWeightsOnDevice)
+      .def_rw(
+          "always_preprocess_weights",
+          &mlir::tt::ttnn::Conv2dConfigOverrideParams::alwaysPreprocessWeights)
+      .def_rw(
+          "enable_act_double_buffer",
+          &mlir::tt::ttnn::Conv2dConfigOverrideParams::enableActDoubleBuffer)
+      .def_rw("enable_weights_double_buffer",
+              &mlir::tt::ttnn::Conv2dConfigOverrideParams::
+                  enableWeightsDoubleBuffer)
+      .def_rw("enable_split_reader",
+              &mlir::tt::ttnn::Conv2dConfigOverrideParams::enableSplitReader)
+      .def_rw(
+          "enable_subblock_padding",
+          &mlir::tt::ttnn::Conv2dConfigOverrideParams::enableSubblockPadding)
+      .def("set_dtype_from_str",
+           [](mlir::tt::ttnn::Conv2dConfigOverrideParams &obj,
+              const std::string &value) {
+             if (auto dtype_ = mlir::tt::DataTypeStringToEnum(value)) {
+               obj.dtype = dtype_;
+             } else {
+               throw std::invalid_argument("Invalid dtype: " + value);
+             }
+           })
+      .def("set_weights_dtype_from_str",
+           [](mlir::tt::ttnn::Conv2dConfigOverrideParams &obj,
+              const std::string &value) {
+             if (auto weightsDtype_ = mlir::tt::DataTypeStringToEnum(value)) {
+               obj.weightsDtype = weightsDtype_;
+             } else {
+               throw std::invalid_argument("Invalid weights dtype: " + value);
+             }
+           })
+      .def("set_activation_from_str",
+           [](mlir::tt::ttnn::Conv2dConfigOverrideParams &obj,
+              const std::string &value) {
+             if (value != "none" && value != "relu") {
+               throw std::invalid_argument("Invalid activation: " + value);
+             }
+             obj.activation = value;
+           })
+      .def("set_input_channels_alignment_from_str",
+           [](mlir::tt::ttnn::Conv2dConfigOverrideParams &obj,
+              const std::string &value) {
+             obj.inputChannelsAlignment = std::stoul(value);
+           })
+      .def("set_deallocate_activation_from_str",
+           [](mlir::tt::ttnn::Conv2dConfigOverrideParams &obj,
+              const std::string &value) {
+             obj.deallocateActivation = (value == "True");
+           })
+      .def("set_reallocate_halo_output_from_str",
+           [](mlir::tt::ttnn::Conv2dConfigOverrideParams &obj,
+              const std::string &value) {
+             obj.reallocateHaloOutput = (value == "True");
+           })
+      .def("set_act_block_h_override_from_str",
+           [](mlir::tt::ttnn::Conv2dConfigOverrideParams &obj,
+              const std::string &value) {
+             obj.actBlockHOverride = std::stoul(value);
+           })
+      .def("set_act_block_w_div_from_str",
+           [](mlir::tt::ttnn::Conv2dConfigOverrideParams &obj,
+              const std::string &value) {
+             obj.actBlockWDiv = std::stoul(value);
+           })
+      .def("set_reshard_if_not_optimal_from_str",
+           [](mlir::tt::ttnn::Conv2dConfigOverrideParams &obj,
+              const std::string &value) {
+             obj.reshardIfNotOptimal = (value == "True");
+           })
+      .def("set_override_sharding_config_from_str",
+           [](mlir::tt::ttnn::Conv2dConfigOverrideParams &obj,
+              const std::string &value) {
+             obj.overrideShardingConfig = (value == "True");
+           })
+      .def("set_shard_layout_from_str",
+           [](mlir::tt::ttnn::Conv2dConfigOverrideParams &obj,
+              const std::string &value) {
+             if (auto shardLayout_ =
+                     mlir::tt::ttnn::symbolizeTensorMemoryLayout(value)) {
+               obj.shardLayout = shardLayout_;
+             } else {
+               throw std::invalid_argument("Invalid shard layout: " + value);
+             }
+           })
+      // TODO(vkovacevic): #2781
+      //.def("set_core_grid_from_str",
+      //[](mlir::tt::ttnn::Conv2dConfigOverrideParams &obj, const std::string
+      //&value) {
+      //    if (auto coreGrid_ = mlir::tt::ttnn::symbolizeAttribute(value)) {
+      //        obj.coreGrid = coreGrid_;
+      //    } else {
+      //        throw std::invalid_argument("Invalid core grid: " + value);
+      //    }
+      //})
+      .def("set_transpose_shards_from_str",
+           [](mlir::tt::ttnn::Conv2dConfigOverrideParams &obj,
+              const std::string &value) {
+             obj.transposeShards = (value == "True");
+           })
+      .def("set_output_layout_from_str",
+           [](mlir::tt::ttnn::Conv2dConfigOverrideParams &obj,
+              const std::string &value) {
+             if (auto outputLayout_ = mlir::tt::ttnn::symbolizeLayout(value)) {
+               obj.outputLayout = outputLayout_;
+             } else {
+               throw std::invalid_argument("Invalid output layout: " + value);
+             }
+           })
+      .def("set_preprocess_weights_on_device_from_str",
+           [](mlir::tt::ttnn::Conv2dConfigOverrideParams &obj,
+              const std::string &value) {
+             obj.preprocessWeightsOnDevice = (value == "True");
+           })
+      .def("set_always_preprocess_weights_from_str",
+           [](mlir::tt::ttnn::Conv2dConfigOverrideParams &obj,
+              const std::string &value) {
+             obj.alwaysPreprocessWeights = (value == "True");
+           })
+      .def("set_enable_act_double_buffer_from_str",
+           [](mlir::tt::ttnn::Conv2dConfigOverrideParams &obj,
+              const std::string &value) {
+             obj.enableActDoubleBuffer = (value == "True");
+           })
+      .def("set_enable_weights_double_buffer_from_str",
+           [](mlir::tt::ttnn::Conv2dConfigOverrideParams &obj,
+              const std::string &value) {
+             obj.enableWeightsDoubleBuffer = (value == "True");
+           })
+      .def("set_enable_split_reader_from_str",
+           [](mlir::tt::ttnn::Conv2dConfigOverrideParams &obj,
+              const std::string &value) {
+             obj.enableSplitReader = (value == "True");
+           })
+      .def("set_enable_subblock_padding_from_str",
+           [](mlir::tt::ttnn::Conv2dConfigOverrideParams &obj,
+              const std::string &value) {
+             obj.enableSubblockPadding = (value == "True");
+           })
+      .def("empty", &mlir::tt::ttnn::Conv2dConfigOverrideParams::empty);
 }
 
 } // namespace mlir::ttmlir::python

--- a/python/TTNNModule.cpp
+++ b/python/TTNNModule.cpp
@@ -8,6 +8,8 @@
 #include "ttmlir-c/TTNNAttrs.h"
 
 #include <nanobind/stl/optional.h>
+#include <optional>
+
 namespace mlir::ttmlir::python {
 void populateTTNNModule(nb::module_ &m) {
 
@@ -218,10 +220,12 @@ void populateTTNNModule(nb::module_ &m) {
                    })
       .def_prop_ro("shard_layout_as_int",
                    [](tt::ttnn::Conv2dConfigAttr self) {
-                     return static_cast<uint32_t>(
-                         self.getShardLayout().getValue());
+                     return self.getShardLayout()
+                                ? std::optional<uint32_t>(static_cast<uint32_t>(
+                                      self.getShardLayout().getValue()))
+                                : std::nullopt;
                    })
-      // TODO(vkovacevic): parse core_grid
+      // TODO(vkovacevic): parse core_grid #2781
       .def_prop_ro("core_grid",
                    [](tt::ttnn::Conv2dConfigAttr self) { return nb::none(); })
       .def_prop_ro("transpose_shards",

--- a/test/unittests/Optimizer/TestOptimizerOverrides.cpp
+++ b/test/unittests/Optimizer/TestOptimizerOverrides.cpp
@@ -114,7 +114,7 @@ TEST_F(Conv2dConfigOverrideTest, ParsePartialConv2dConfigOverride) {
   ASSERT_TRUE(params.dtype.has_value());
   ASSERT_EQ(params.dtype.value(), mlir::tt::DataType::Float32);
   ASSERT_TRUE(params.activation.has_value());
-  ASSERT_EQ(params.activation.value(), "none");
+  ASSERT_EQ(params.activation.value(), "");
   ASSERT_FALSE(params.weightsDtype.has_value());
   ASSERT_FALSE(params.inputChannelsAlignment.has_value());
   ASSERT_FALSE(params.deallocateActivation.has_value());
@@ -153,7 +153,7 @@ TEST_F(Conv2dConfigOverrideTest, ParseMultipleOps) {
   ASSERT_TRUE(params0.dtype.has_value());
   ASSERT_EQ(params0.dtype.value(), mlir::tt::DataType::Float32);
   ASSERT_TRUE(params0.activation.has_value());
-  ASSERT_EQ(params0.activation.value(), "none");
+  ASSERT_EQ(params0.activation.value(), "");
 
   const auto &params1 = parsedOverride["op1"];
   ASSERT_TRUE(params1.dtype.has_value());

--- a/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
@@ -10,6 +10,8 @@ from ttmlir.dialects import tt, ttnn, ttir
 from ttmlir import ir, util
 from . import utils
 
+OVERRIDE_PARAMETER_DISABLED_STR = "None"
+
 
 def parse_loc_string(loc_str):
     """
@@ -498,7 +500,7 @@ def parse_conv2d_config(attr):
     )
     activation = str(conv2d_config.activation)
     if len(activation) == 0:
-        activation = "none"
+        activation = OVERRIDE_PARAMETER_DISABLED_STR
     result.append(
         utils.make_editable_kv(
             graph_builder.KeyValue(
@@ -507,7 +509,7 @@ def parse_conv2d_config(attr):
             ),
             editable={
                 "input_type": "value_list",
-                "options": ["relu", "none"],
+                "options": ["relu", OVERRIDE_PARAMETER_DISABLED_STR],
             },
         )
     )
@@ -594,15 +596,19 @@ def parse_conv2d_config(attr):
             },
         )
     )
+    shard_layout = OVERRIDE_PARAMETER_DISABLED_STR
+    if conv2d_config.override_sharding_config:
+        shard_layout = str(ttnn.TensorMemoryLayout(conv2d_config.shard_layout_as_int))
     result.append(
         utils.make_editable_kv(
             graph_builder.KeyValue(
                 key="shard_layout",
-                value=str(ttnn.TensorMemoryLayout(conv2d_config.shard_layout_as_int)),
+                value=shard_layout,
             ),
             editable={
                 "input_type": "value_list",
-                "options": [str(o) for o in ttnn.TensorMemoryLayout],
+                "options": [str(o) for o in ttnn.TensorMemoryLayout]
+                + [OVERRIDE_PARAMETER_DISABLED_STR],
             },
         )
     )
@@ -641,6 +647,30 @@ def parse_conv2d_config(attr):
             graph_builder.KeyValue(
                 key="enable_act_double_buffer",
                 value=str(conv2d_config.enable_act_double_buffer),
+            ),
+            editable={
+                "input_type": "value_list",
+                "options": ["True", "False"],
+            },
+        )
+    )
+    result.append(
+        utils.make_editable_kv(
+            graph_builder.KeyValue(
+                key="preprocess_weights_on_device",
+                value=str(conv2d_config.preprocess_weights_on_device),
+            ),
+            editable={
+                "input_type": "value_list",
+                "options": ["True", "False"],
+            },
+        )
+    )
+    result.append(
+        utils.make_editable_kv(
+            graph_builder.KeyValue(
+                key="always_preprocess_weights",
+                value=str(conv2d_config.always_preprocess_weights),
             ),
             editable={
                 "input_type": "value_list",

--- a/tools/explorer/tt_adapter/src/tt_adapter/runner.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/runner.py
@@ -314,7 +314,7 @@ class ModelRunner:
             translate_process = self.run_in_subprocess(to_flatbuffer_command)
             if translate_process.returncode != 0:
                 error = "Error while running TTNN to Flatbuffer File"
-                self.log(error, severtity=logging.error)
+                self.log(error, severity=logging.error)
                 raise ExplorerRunException(error)
 
         self.progress = 30


### PR DESCRIPTION
### Ticket
Closes #2454 

### What's changed
- Added python bindings for overriding Conv2dConfig in tt-explorer
- In *LegalLayoutAnalysis.cpp*, made Conv2dConfig attribute always present for conv2d ops (if nothing is overridden, default values are set) so that it appears in the explorer 
- Added a temporary solution in *MLIRToFlatbuffer.h* to handle optional parameters (will be changed properly in #2912 or #2913 ) 
- Set `dtype` and `weights_dtype` parameters in *LegalLayoutAnalysis.cpp* to get through a tt-metal assert in *prepare_conv2d_weights.cpp* where `weight_tensor_.get_dtype() == weights_bias_dtype`
- Removed some redundant comments in *OptimizerOverrides.h*