### PR TITLE
Sgligorijevic/switch to binary ng

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -182,6 +182,12 @@ class TTNN_ElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
       [{
         build($_builder, $_state, resultType, lhs, rhs, /*memory_config=*/nullptr,
               /*use_legacy=*/nullptr);
+      }]>,
+      OpBuilder<(ins "Type": $resultType, "Value": $lhs, "Value": $rhs,
+                 "BoolAttr": $use_legacy),
+      [{
+        build($_builder, $_state, resultType, lhs, rhs, /*memory_config=*/nullptr,
+              use_legacy);
       }]>
     ];
 }

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -165,7 +165,8 @@ class TTNN_ElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
 
     let arguments = (ins AnyRankedTensor:$lhs,
                          AnyRankedTensor:$rhs,
-                         OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
+                         OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config,
+                         OptionalAttr<BoolAttr>:$use_legacy);
     let results = (outs AnyRankedTensor:$result);
 
     let extraClassDeclaration = [{
@@ -179,7 +180,8 @@ class TTNN_ElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
     [
       OpBuilder<(ins "Type": $resultType, "Value": $lhs, "Value": $rhs),
       [{
-        build($_builder, $_state, resultType, lhs, rhs, /*memory_config=*/nullptr);
+        build($_builder, $_state, resultType, lhs, rhs, /*memory_config=*/nullptr,
+              /*use_legacy=*/nullptr);
       }]>
     ];
 }

--- a/include/ttmlir/Target/TTNN/operations/eltwise.fbs
+++ b/include/ttmlir/Target/TTNN/operations/eltwise.fbs
@@ -30,6 +30,7 @@ table EltwiseBinaryOp {
   output_dtype: tt.target.DataType = null;
   memory_config: tt.target.ttnn.MemoryConfig;
   out: tt.target.ttnn.TensorRef;
+  use_legacy: bool;
 }
 
 enum EltwiseBinaryCompositeOpType: uint32 {

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -260,6 +260,36 @@ public:
 namespace {
 template <typename TTIROpTy, typename TTNNOpTy,
           typename OpAdaptor = typename TTIROpTy::Adaptor>
+class ElementwiseBinaryOpConversionPattern
+    : public OpConversionPattern<TTIROpTy> {
+public:
+  using OpConversionPattern<TTIROpTy>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(TTIROpTy op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    SmallVector<Type> resultTypes;
+    if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(),
+                                                      resultTypes))) {
+      return failure();
+    }
+
+    if (resultTypes.size() != 1) {
+      return rewriter.notifyMatchFailure(
+          op, "TTNN ElementwiseBinaryOpConversionPattern one result type");
+    }
+
+    rewriter.replaceOpWithNewOp<TTNNOpTy>(
+        op, resultTypes[0], adaptor.getInputs()[0], adaptor.getInputs()[1],
+        rewriter.getBoolAttr(false) /*use_legacy*/);
+    return success();
+  }
+};
+} // namespace
+
+namespace {
+template <typename TTIROpTy, typename TTNNOpTy,
+          typename OpAdaptor = typename TTIROpTy::Adaptor>
 class ReductionOpConversionPattern : public OpConversionPattern<TTIROpTy> {
 public:
   using OpConversionPattern<TTIROpTy>::OpConversionPattern;
@@ -1240,9 +1270,10 @@ public:
     Type outputType = this->getTypeConverter()->convertType(srcOp.getType(0));
 
     if (lhsType.getShape() == rhsType.getShape()) {
-      rewriter.replaceOpWithNewOp<ttnn::SubtractOp>(srcOp, outputType,
-                                                    adaptor.getInputs().front(),
-                                                    adaptor.getInputs().back());
+      rewriter.replaceOpWithNewOp<ttnn::SubtractOp>(
+          srcOp, outputType, adaptor.getInputs().front(),
+          adaptor.getInputs().back(),
+          rewriter.getBoolAttr(false) /*use_legacy*/);
 
       // Broadcast for rhs operand require the operation to be commutative to
       // allow switching the order of operands. To allow this conversion, the
@@ -1635,27 +1666,27 @@ void populateTTIRToTTNNPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
            DequantizeOpConversionPattern,
            RequantizeOpConversionPattern,
            ElementwiseOpConversionPattern<ttir::AbsOp, ttnn::AbsOp>,
-           ElementwiseOpConversionPattern<ttir::AddOp, ttnn::AddOp>,
+           ElementwiseBinaryOpConversionPattern<ttir::AddOp, ttnn::AddOp>,
            ElementwiseOpConversionPattern<ttir::CbrtOp, ttnn::CbrtOp>,
            ElementwiseOpConversionPattern<ttir::FloorOp, ttnn::FloorOp>,
            ElementwiseOpConversionPattern<ttir::IsFiniteOp, ttnn::IsFiniteOp>,
-           ElementwiseOpConversionPattern<ttir::LogicalAndOp, ttnn::LogicalAndOp>,
-           ElementwiseOpConversionPattern<ttir::LogicalOrOp, ttnn::LogicalOrOp>,
+           ElementwiseBinaryOpConversionPattern<ttir::LogicalAndOp, ttnn::LogicalAndOp>,
+           ElementwiseBinaryOpConversionPattern<ttir::LogicalOrOp, ttnn::LogicalOrOp>,
            ElementwiseOpConversionPattern<ttir::LogicalNotOp, ttnn::LogicalNotOp>,
-           ElementwiseOpConversionPattern<ttir::LogicalXorOp, ttnn::LogicalXorOp>,
-           ElementwiseOpConversionPattern<ttir::BitwiseAndOp, ttnn::BitwiseAndOp>,
-           ElementwiseOpConversionPattern<ttir::BitwiseOrOp, ttnn::BitwiseOrOp>,
-           ElementwiseOpConversionPattern<ttir::BitwiseXorOp, ttnn::BitwiseXorOp>,
+           ElementwiseBinaryOpConversionPattern<ttir::LogicalXorOp, ttnn::LogicalXorOp>,
+           ElementwiseBinaryOpConversionPattern<ttir::BitwiseAndOp, ttnn::BitwiseAndOp>,
+           ElementwiseBinaryOpConversionPattern<ttir::BitwiseOrOp, ttnn::BitwiseOrOp>,
+           ElementwiseBinaryOpConversionPattern<ttir::BitwiseXorOp, ttnn::BitwiseXorOp>,
            ElementwiseOpConversionPattern<ttir::BitwiseNotOp, ttnn::BitwiseNotOp>,
-           ElementwiseOpConversionPattern<ttir::MultiplyOp, ttnn::MultiplyOp>,
-           ElementwiseOpConversionPattern<ttir::EqualOp, ttnn::EqualOp>,
-           ElementwiseOpConversionPattern<ttir::NotEqualOp, ttnn::NotEqualOp>,
-           ElementwiseOpConversionPattern<ttir::GreaterEqualOp, ttnn::GreaterEqualOp>,
-           ElementwiseOpConversionPattern<ttir::GreaterThanOp, ttnn::GreaterThanOp>,
-           ElementwiseOpConversionPattern<ttir::LessEqualOp, ttnn::LessEqualOp>,
-           ElementwiseOpConversionPattern<ttir::LessThanOp, ttnn::LessThanOp>,
-           ElementwiseOpConversionPattern<ttir::MaximumOp, ttnn::MaximumOp>,
-           ElementwiseOpConversionPattern<ttir::MinimumOp, ttnn::MinimumOp>,
+           ElementwiseBinaryOpConversionPattern<ttir::MultiplyOp, ttnn::MultiplyOp>,
+           ElementwiseBinaryOpConversionPattern<ttir::EqualOp, ttnn::EqualOp>,
+           ElementwiseBinaryOpConversionPattern<ttir::NotEqualOp, ttnn::NotEqualOp>,
+           ElementwiseBinaryOpConversionPattern<ttir::GreaterEqualOp, ttnn::GreaterEqualOp>,
+           ElementwiseBinaryOpConversionPattern<ttir::GreaterThanOp, ttnn::GreaterThanOp>,
+           ElementwiseBinaryOpConversionPattern<ttir::LessEqualOp, ttnn::LessEqualOp>,
+           ElementwiseBinaryOpConversionPattern<ttir::LessThanOp, ttnn::LessThanOp>,
+           ElementwiseBinaryOpConversionPattern<ttir::MaximumOp, ttnn::MaximumOp>,
+           ElementwiseBinaryOpConversionPattern<ttir::MinimumOp, ttnn::MinimumOp>,
            ElementwiseOpConversionPattern<ttir::NegOp, ttnn::NegOp>,
            ElementwiseOpConversionPattern<ttir::ReluOp, ttnn::ReluOp>,
            ElementwiseOpConversionPattern<ttir::GeluOp, ttnn::GeluOp>,
@@ -1667,18 +1698,18 @@ void populateTTIRToTTNNPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
            ElementwiseOpConversionPattern<ttir::ReciprocalOp, ttnn::ReciprocalOp>,
            ElementwiseOpConversionPattern<ttir::ExpOp, ttnn::ExpOp>,
            ElementwiseOpConversionPattern<ttir::LogOp, ttnn::LogOp>,
-           ElementwiseOpConversionPattern<ttir::DivOp, ttnn::DivideOp>,
+           ElementwiseBinaryOpConversionPattern<ttir::DivOp, ttnn::DivideOp>,
            ElementwiseOpConversionPattern<ttir::CeilOp, ttnn::CeilOp>,
            ElementwiseOpConversionPattern<ttir::SinOp, ttnn::SinOp>,
            ElementwiseOpConversionPattern<ttir::CosOp, ttnn::CosOp>,
            ElementwiseOpConversionPattern<ttir::Expm1Op, ttnn::Expm1Op>,
-           ElementwiseOpConversionPattern<ttir::RemainderOp, ttnn::RemainderOp>,
+           ElementwiseBinaryOpConversionPattern<ttir::RemainderOp, ttnn::RemainderOp>,
            ElementwiseOpConversionPattern<ttir::WhereOp, ttnn::WhereOp>,
            ElementwiseOpConversionPattern<ttir::TanOp, ttnn::TanOp>,
            ElementwiseOpConversionPattern<ttir::TanhOp, ttnn::TanhOp>,
            ElementwiseOpConversionPattern<ttir::AtanOp, ttnn::AtanOp>,
-           ElementwiseOpConversionPattern<ttir::Atan2Op, ttnn::Atan2Op>,
-           ElementwiseOpConversionPattern<ttir::PowOp, ttnn::PowOp>,
+           ElementwiseBinaryOpConversionPattern<ttir::Atan2Op, ttnn::Atan2Op>,
+           ElementwiseBinaryOpConversionPattern<ttir::PowOp, ttnn::PowOp>,
            ReductionOpConversionPattern<ttir::SumOp, ttnn::SumOp>,
            ReductionOpConversionPattern<ttir::MeanOp, ttnn::MeanOp>,
            ReductionOpConversionPattern<ttir::MaxOp, ttnn::MaxOp>,

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/RepeatOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/RepeatOpRewritePattern.cpp
@@ -31,8 +31,9 @@ TTNNRepeatFoldingWorkaround::matchAndRewrite(ttnn::RepeatOp op,
   addInputs.push_back(zeroOp.getResult());
 
   // Replace the RepeatOp with an AddOp to perform implicit repeat.
-  rewriter.replaceOpWithNewOp<ttnn::AddOp>(op, op.getResult().getType(),
-                                           addInputs);
+  rewriter.replaceOpWithNewOp<ttnn::AddOp>(
+      op, op.getResult().getType(), addInputs[0], addInputs[1],
+      rewriter.getBoolAttr(false) /*use_legacy*/);
 
   return success();
 }

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -1083,8 +1083,10 @@ createEltwiseBinaryOp(FlatbufferObjectCache &cache, EltwiseBinaryOp op) {
 
   auto memoryConfig = getMemoryConfigIfNeeded(cache, op);
 
+  auto useLegacy = op.getUseLegacy().value_or(true);
+
   return ::tt::target::ttnn::CreateEltwiseBinaryOp(
-      *cache.fbb, type, lhs, rhs, targetDtype, memoryConfig, out);
+      *cache.fbb, type, lhs, rhs, targetDtype, memoryConfig, out, useLegacy);
 }
 
 template <typename EltwiseBinaryCompositeOp>

--- a/runtime/lib/ttnn/operations/eltwise/binary/binary.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/binary/binary.cpp
@@ -19,8 +19,8 @@ static void runEltwiseBinaryOp(
         std::optional<::ttnn::Tensor>,
         tt::stl::Span<const ::ttnn::operations::unary::UnaryWithParam>,
         tt::stl::Span<const ::ttnn::operations::unary::UnaryWithParam>,
-        tt::stl::Span<const ::ttnn::operations::unary::UnaryWithParam>)>
-        &ttnnOp) {
+        tt::stl::Span<const ::ttnn::operations::unary::UnaryWithParam>,
+        std::optional<bool> &)> &ttnnOp) {
 
   ::ttnn::Tensor *lhs = &(tensorPool.getTTNNTensorAndValidate(op->lhs()));
   ::ttnn::Tensor *rhs = &(tensorPool.getTTNNTensorAndValidate(op->rhs()));
@@ -42,8 +42,15 @@ static void runEltwiseBinaryOp(
                  outputMemoryConfig.has_value(),
              "Memory config must exist for device tensors");
 
+  std::optional<bool> useLegacy = op->use_legacy();
+  if (useLegacy.has_value()) {
+    std::cout << "useLegacy value: " << useLegacy.value() << std::endl;
+  } else {
+    std::cout << "useLegacy is not set" << std::endl;
+  }
+
   ::ttnn::Tensor out = ttnnOp(*lhs, *rhs, outputDataType, outputMemoryConfig,
-                              std::nullopt, {}, {}, {});
+                              std::nullopt, {}, {}, {}, useLegacy);
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }


### PR DESCRIPTION
### Ticket
None

### Problem description
We want to try using binary_ng implementations for binary ops in metal.

### What's changed
I modeled the `use_legacy` flag as an attribute in TTNN ops.
I changed the TTIR->TTNN conversion for binary ops to set the flag to false. This is not a perfect solution, if somebody has a better idea I'm all ears.

### Checklist
- [ ] New/Existing tests provide coverage for changes

CI:
tt-torch:  [**FAILING**](https://github.com/tenstorrent/tt-torch/actions/runs/14468023915)
tt-xla: [Passing](https://github.com/tenstorrent/tt-xla/actions/runs/14468001183/job/40574865397)
tt-forge-fe [**FAILING**](https://github.com/tenstorrent/tt-forge-fe/actions/runs/14468018465) - All failures appear to be `XPASS(strict)` 

I will investigate what is going on