### PR TITLE
[EmitC] Add TTIR to EmitC SO pipeline

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -230,6 +230,11 @@ struct TTIRToTTNNBackendPipelineOptions
 //
 struct TTIRToEmitCPipelineOptions : public TTIRToTTNNBackendPipelineOptions {};
 
+// TTIR to EmitC SO pipeline options.
+// Inherit from TTIRToEmitCPipelineOptions to reuse the options.
+//
+struct TTIRToEmitCSOPipelineOptions : public TTIRToEmitCPipelineOptions {};
+
 void createTTNNPipelineTTIRPasses(
     OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options);
 
@@ -265,6 +270,9 @@ void createTTIRToTTNNBackendPipeline(
 
 void createTTIRToEmitCPipeline(OpPassManager &pm,
                                const TTIRToEmitCPipelineOptions &options);
+
+void createTTIRToEmitCSOPipeline(OpPassManager &pm,
+                                 const TTIRToEmitCSOPipelineOptions &options);
 
 /// Registers all pipelines for the `bufferization` dialect. Currently,
 /// this includes only the "ttir-to-ttnn-backend-pipeline".

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -191,6 +191,14 @@ void createTTIRToEmitCPipeline(OpPassManager &pm,
   pm.addPass(createConvertTTNNToEmitCPass());
 }
 
+void createTTIRToEmitCSOPipeline(OpPassManager &pm,
+                                 const TTIRToEmitCSOPipelineOptions &options) {
+  createTTIRToTTNNBackendPipeline(pm, options);
+  pm.addPass(tt::createTTUnwrapDeviceModulePass());
+  pm.addPass(createTTNNModifySignaturesForDylib());
+  pm.addPass(createConvertTTNNToEmitCPass());
+}
+
 //===----------------------------------------------------------------------===//
 // Pipeline registration.
 //===----------------------------------------------------------------------===//
@@ -212,5 +220,14 @@ void registerTTNNPipelines() {
       "--ttir-to-ttnn-backend-pipeline and then converts the resulting TTNN "
       "dialect to EmitC.",
       mlir::tt::ttnn::createTTIRToEmitCPipeline);
+
+  // TTIR to EmitC SO pipeline.
+  //
+  mlir::PassPipelineRegistration<mlir::tt::ttnn::TTIRToEmitCSOPipelineOptions>(
+      "ttir-to-emitc-so-pipeline",
+      "Pipeline lowering TTIR to EmitC, similar to TTIRToEmitCPipeline, but "
+      "with emitted C++ code packaged so that it's suitable for compiling into "
+      "a shared object.",
+      mlir::tt::ttnn::createTTIRToEmitCSOPipeline);
 }
 } // namespace mlir::tt::ttnn

--- a/test/ttmlir/Dialect/EmitC/ttir_to_emitc_pipeline_sanity.mlir
+++ b/test/ttmlir/Dialect/EmitC/ttir_to_emitc_pipeline_sanity.mlir
@@ -1,10 +1,14 @@
 // RUN: ttmlir-opt --ttir-to-emitc-pipeline="system-desc-path=%system_desc_path%" %s > %direct.mlir
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" --tt-unwrap-device-module --ttnn-create-input-gens --convert-ttnn-to-emitc %s > %indirect.mlir
 // RUN: diff %direct.mlir %indirect.mlir
+// RUN: FileCheck %s --input-file=%direct.mlir
 //
 // This test checks that the (TTIR to EmitC pipeline) is equivalent to (TTIR to TTNN pipeline + dialect conversion from TTNN to EmitC).
 // The `diff` command will return 0 if files are identical, otherwise it will return the diff, which will make `llvm-lit` treat the test as failed.
 
+// CHECK: func.func @add(%arg0: !emitc.opaque<"::ttnn::Tensor">, %arg1: !emitc.opaque<"::ttnn::Tensor">) -> !emitc.opaque<"::ttnn::Tensor"
+// CHECK: func.func @createInputsFor_add() -> (!emitc.opaque<"::ttnn::Tensor">, !emitc.opaque<"::ttnn::Tensor">)
+// CHECK: func.func @main() -> i32
 func.func @add(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
   %0 = ttir.empty() : tensor<64x128xf32>
   %1 = "ttir.add"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>

--- a/test/ttmlir/Dialect/EmitC/ttir_to_emitc_pipeline_sanity.mlir
+++ b/test/ttmlir/Dialect/EmitC/ttir_to_emitc_pipeline_sanity.mlir
@@ -1,7 +1,7 @@
-// RUN: ttmlir-opt --ttir-to-emitc-pipeline="system-desc-path=%system_desc_path%" %s > %direct.mlir
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" --tt-unwrap-device-module --ttnn-create-input-gens --convert-ttnn-to-emitc %s > %indirect.mlir
-// RUN: diff %direct.mlir %indirect.mlir
-// RUN: FileCheck %s --input-file=%direct.mlir
+// RUN: ttmlir-opt --ttir-to-emitc-pipeline="system-desc-path=%system_desc_path%" %s > %t_direct.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" --tt-unwrap-device-module --ttnn-create-input-gens --convert-ttnn-to-emitc %s > %t_indirect.mlir
+// RUN: diff %t_direct.mlir %t_indirect.mlir
+// RUN: FileCheck %s --input-file=%t_direct.mlir
 //
 // This test checks that the (TTIR to EmitC pipeline) is equivalent to (TTIR to TTNN pipeline + dialect conversion from TTNN to EmitC).
 // The `diff` command will return 0 if files are identical, otherwise it will return the diff, which will make `llvm-lit` treat the test as failed.

--- a/test/ttmlir/Dialect/EmitC/ttir_to_emitc_so_pipeline_sanity.mlir
+++ b/test/ttmlir/Dialect/EmitC/ttir_to_emitc_so_pipeline_sanity.mlir
@@ -1,7 +1,7 @@
-// RUN: ttmlir-opt --ttir-to-emitc-so-pipeline="system-desc-path=%system_desc_path%" %s > %direct.mlir
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" --tt-unwrap-device-module --ttnn-modify-signatures-for-dylib --convert-ttnn-to-emitc %s > %indirect.mlir
-// RUN: diff %direct.mlir %indirect.mlir
-// RUN: FileCheck %s --input-file=%direct.mlir
+// RUN: ttmlir-opt --ttir-to-emitc-so-pipeline="system-desc-path=%system_desc_path%" %s > %t_direct.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" --tt-unwrap-device-module --ttnn-modify-signatures-for-dylib --convert-ttnn-to-emitc %s > %t_indirect.mlir
+// RUN: diff %t_direct.mlir %t_indirect.mlir
+// RUN: FileCheck %s --input-file=%t_direct.mlir
 //
 // This test checks that the (TTIR to EmitC SO pipeline) is equivalent to (TTIR to TTNN pipeline + dialect conversion from TTNN to EmitC).
 // The `diff` command will return 0 if files are identical, otherwise it will return the diff, which will make `llvm-lit` treat the test as failed.

--- a/test/ttmlir/Dialect/EmitC/ttir_to_emitc_so_pipeline_sanity.mlir
+++ b/test/ttmlir/Dialect/EmitC/ttir_to_emitc_so_pipeline_sanity.mlir
@@ -1,0 +1,15 @@
+// RUN: ttmlir-opt --ttir-to-emitc-so-pipeline="system-desc-path=%system_desc_path%" %s > %direct.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" --tt-unwrap-device-module --ttnn-modify-signatures-for-dylib --convert-ttnn-to-emitc %s > %indirect.mlir
+// RUN: diff %direct.mlir %indirect.mlir
+// RUN: FileCheck %s --input-file=%direct.mlir
+//
+// This test checks that the (TTIR to EmitC SO pipeline) is equivalent to (TTIR to TTNN pipeline + dialect conversion from TTNN to EmitC).
+// The `diff` command will return 0 if files are identical, otherwise it will return the diff, which will make `llvm-lit` treat the test as failed.
+
+// CHECK: func.func @add(%arg0: !emitc.opaque<"::std::vector<::ttnn::Tensor>">) -> !emitc.opaque<"::std::vector<::ttnn::Tensor>">
+func.func @add(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
+  %0 = ttir.empty() : tensor<64x128xf32>
+  %1 = "ttir.add"(%arg0, %arg1, %0) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  // CHECK: return %{{[0-9]+}} : !emitc.opaque<"::std::vector<::ttnn::Tensor>">
+  return %1 : tensor<64x128xf32>
+}


### PR DESCRIPTION
### Ticket
#2953 

### Problem description
TTNN to EmitC conversion is done in 2 ways: one for ttnn-standalone, and one for ttnn-dylib (i.e. shared object path).

We already have a pipeline for ttnn-standalone (ttir-to-emitc-pipeline), we want to add ttir-to-emitc-so-pipeline for the shared object path.

These pipelines differ only in surrounding boilerplate around the emitted forward function. The ttir-to-emitc-pipeline adds a function to generate inputs, and a main fn to drive execution, while the ttir-to-emitc-so-pipeline will repackage forward function to take in a vector of tensors and a device (targeted for shared object compilation).

### What's changed
Added the new pipeline, added a test, changes to `ttir-to-emitc-pipeline` test making it more robust.

### Checklist
- [x] New/Existing tests provide coverage for changes
