### PR TITLE
Add option to lower ttir.matmul to linalg.generic plus ttir.tile_matmul

### DIFF
--- a/include/ttmlir/Conversion/TTIRToTTIRGeneric/TTIRToTTIRGeneric.h
+++ b/include/ttmlir/Conversion/TTIRToTTIRGeneric/TTIRToTTIRGeneric.h
@@ -13,7 +13,8 @@ namespace mlir::tt {
 void populateTTIRToTTIRGenericPatterns(MLIRContext *ctx,
                                        RewritePatternSet &patterns,
                                        TypeConverter &typeConverter,
-                                       uint64_t deviceGridRank);
+                                       uint64_t deviceGridRank,
+                                       bool useTileMatmul);
 
 std::unique_ptr<OperationPass<ModuleOp>> createTTIRToTTIRGenericPass();
 

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
@@ -115,6 +115,16 @@ def TTIR_TileReduceMaxOp : TTIR_GenericRegionComputeOp<"tile_reduce_max"> {
     let results = (outs TT_Tile:$result);
 }
 
+def TTIR_TileMatmulOp : TTIR_GenericRegionComputeOp<"tile_matmul"> {
+  let summary = "TTIR Tile Matmul Op";
+  let description = [{
+        The `tile_matmul` operation computes the matrix multiplication of two input tiles and adds third tile A * B + C.
+    }];
+
+  let arguments = (ins TT_Tile:$a, TT_Tile:$b, TT_Tile:$c);
+  let results = (outs TT_Tile:$result);
+}
+
 def TTIR_TileMatmulBlockOp : TTIR_GenericRegionComputeOp<"tile_matmul_block",
   [DestinationStyleOpInterface, DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
     let summary = "TTIR Tile Matmul Block Op";

--- a/lib/Conversion/TTIRToTTIRGeneric/TTIRToTTIRGeneric.cpp
+++ b/lib/Conversion/TTIRToTTIRGeneric/TTIRToTTIRGeneric.cpp
@@ -594,8 +594,8 @@ class TTIRMatmulWithLinalgGenericRewriter final
 
   using ConcreteOp = ttir::MatmulOp;
   using TileOp = ttir::TileMatmulOp;
-  static constexpr std::size_t const tileOpNumInputs = 3;
-  static constexpr std::size_t const tileOpNumOutputs = 1;
+  static constexpr std::size_t tileOpNumInputs = 3;
+  static constexpr std::size_t tileOpNumOutputs = 1;
 
 public:
   TTIRMatmulWithLinalgGenericRewriter(const TypeConverter &typeConverter,
@@ -617,15 +617,15 @@ private:
         toLayoutOperands(rewriter, adaptor, op.getDpsInits().size(),
                          deviceGridRank, /*tiled*/ true);
 
-    std::size_t const numInputs = inputs.size();
-    std::size_t const numOutputs = outputs.size();
-    std::size_t const numOperands = (numInputs + numOutputs);
+    const std::size_t numInputs = inputs.size();
+    const std::size_t numOutputs = outputs.size();
+    const std::size_t numOperands = (numInputs + numOutputs);
 
     assert(numOperands == op->getNumOperands());
 
     tt::GridAttr grid = tt::GridAttr::get(ctx, expectedInputGridShape());
 
-    std::size_t const rank = grid.getShape().size();
+    const std::size_t rank = grid.getShape().size();
 
     // TODO(#2591) handle 'transpose_{a,b}' attributes
 

--- a/lib/Conversion/TTIRToTTIRGeneric/TTIRToTTIRGeneric.cpp
+++ b/lib/Conversion/TTIRToTTIRGeneric/TTIRToTTIRGeneric.cpp
@@ -481,6 +481,9 @@ class TTIRMatmulRewriter final
       TTIRNamedRewriterCommon {
 
   using ConcreteOp = ttir::MatmulOp;
+  static_assert(std::is_same_v<TileOp, ttir::TileMatmulBlockOp> ||
+                    std::is_same_v<TileOp, ttir::TileMatmulOp>,
+                "Unsupported Matmul TileOp");
 
 public:
   TTIRMatmulRewriter(const TypeConverter &typeConverter, mlir::MLIRContext *ctx,
@@ -564,8 +567,6 @@ private:
 
                 bbBuilder.create<mlir::linalg::YieldOp>(bbLoc, yield);
               });
-        } else {
-          static_assert(false, "Unsupported Matmul TileOp");
         }
       }
     }

--- a/lib/Conversion/TTIRToTTIRGeneric/TTIRToTTIRGeneric.cpp
+++ b/lib/Conversion/TTIRToTTIRGeneric/TTIRToTTIRGeneric.cpp
@@ -587,11 +587,140 @@ private:
 }; // end of class
 } // namespace
 // ............................................................................
+namespace {
+class TTIRMatmulWithLinalgGenericRewriter final
+    : public mlir::OpConversionPattern<ttir::MatmulOp>,
+      TTIRNamedRewriterCommon {
+
+  using ConcreteOp = ttir::MatmulOp;
+  using TileOp = ttir::TileMatmulOp;
+  static constexpr std::size_t const tileOpNumInputs = 3;
+  static constexpr std::size_t const tileOpNumOutputs = 1;
+
+public:
+  TTIRMatmulWithLinalgGenericRewriter(const TypeConverter &typeConverter,
+                                      mlir::MLIRContext *ctx,
+                                      uint64_t deviceGridRank)
+      : OpConversionPattern<ConcreteOp>(typeConverter, ctx),
+        TTIRNamedRewriterCommon(deviceGridRank) {}
+
+private:
+  LogicalResult
+  matchAndRewrite(ConcreteOp op, typename ConcreteOp::Adaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const final {
+    checkPreconditions(op);
+
+    mlir::MLIRContext *ctx = rewriter.getContext();
+    mlir::Location loc = op->getLoc();
+
+    auto [inputs, outputs] =
+        toLayoutOperands(rewriter, adaptor, op.getDpsInits().size(),
+                         deviceGridRank, /*tiled*/ true);
+
+    std::size_t const numInputs = inputs.size();
+    std::size_t const numOutputs = outputs.size();
+    std::size_t const numOperands = (numInputs + numOutputs);
+
+    assert(numOperands == op->getNumOperands());
+
+    tt::GridAttr grid = tt::GridAttr::get(ctx, expectedInputGridShape());
+
+    std::size_t const rank = grid.getShape().size();
+
+    // TODO(#2591) handle 'transpose_{a,b}' attributes
+
+    SmallVector<mlir::AffineMap> indexingMaps =
+        getAffineMapsArray(rewriter, numOperands, rank);
+    SmallVector<mlir::Attribute> iteratorTypes =
+        getIteratorTypesArray(rewriter, rank);
+
+    // Create 'ttir.generic' accepting 'op's operands.
+    auto generic = rewriter.create<ttir::GenericOp>(
+        loc, inputs, outputs, rewriter.getAffineMapArrayAttr(indexingMaps),
+        rewriter.getArrayAttr(iteratorTypes));
+
+    // Create one bb in 'generic''s region and set its arguments.
+    auto insertPoint = rewriter.saveInsertionPoint();
+    rewriter.startOpModification(generic);
+    {
+      mlir::Region &region = generic->getRegions().front();
+      mlir::Block *block = rewriter.createBlock(&region);
+
+      // Populate 'block'.
+      {
+        auto blockArgs = createBlockArguments(block, loc, TypeRange(inputs),
+                                              TypeRange(outputs));
+
+        // Delegate next level of nesting to a "block" op.
+
+        SmallVector<mlir::AffineMap> linalgIndexingMaps =
+            getAffineMapsArray(rewriter, numOperands, rank);
+        SmallVector<mlir::utils::IteratorType> linalgIteratorTypes =
+            iteratorTypeTTIRToLinalg(rewriter, iteratorTypes);
+
+        rewriter.create<mlir::linalg::GenericOp>(
+            loc, /* inputs */ blockArgs.take_front(numInputs),
+            /* outputs */ blockArgs.take_back(numOutputs), linalgIndexingMaps,
+            linalgIteratorTypes,
+            [&](mlir::OpBuilder &bbBuilder, mlir::Location bbLoc,
+                mlir::ValueRange bbArgs) {
+              mlir::Value yield = bbBuilder.create<TileOp>(
+                  loc, /* resultTypes */ bbArgs.take_back(tileOpNumOutputs),
+                  /* operands */ bbArgs.take_front(tileOpNumInputs));
+
+              bbBuilder.create<mlir::linalg::YieldOp>(bbLoc, yield);
+            });
+      }
+    }
+    rewriter.finalizeOpModification(generic);
+    rewriter.restoreInsertionPoint(insertPoint);
+
+    rewriter.replaceOp(op, unLayoutResult(rewriter, generic->getResult(0),
+                                          op->getResult(0).getType()));
+    return llvm::success();
+  }
+
+  static void checkPreconditions(ConcreteOp op) {
+    assert((!op.getTransposeA() && !op.getTransposeB()) &&
+           "TODO(#2591) expected no transpose attributes");
+  }
+
+  static SmallVector<mlir::AffineMap>
+  getAffineMapsArray(mlir::OpBuilder &builder, std::size_t arity,
+                     std::size_t rank) {
+    assert(arity == 3 && "expected 3 operands");
+    // TODO(#2592) handle higher ranks, if needed in this pass
+    assert(rank == 2 && "expected a rank 2 operation");
+    mlir::MLIRContext *ctx = builder.getContext();
+
+    return SmallVector<mlir::AffineMap>{makeAffineMap(ctx, {0, 2}),
+                                        makeAffineMap(ctx, {2, 1}),
+                                        makeAffineMap(ctx, {0, 1})};
+  }
+
+  static SmallVector<mlir::Attribute>
+  getIteratorTypesArray(mlir::OpBuilder &builder, std::size_t rank) {
+    assert(rank == 2 && "expected a rank 2 operation");
+    auto parallel = tt::IteratorTypeAttr::get(builder.getContext(),
+                                              tt::IteratorType::Parallel);
+    auto reduction = tt::IteratorTypeAttr::get(builder.getContext(),
+                                               tt::IteratorType::Reduction);
+    return SmallVector<mlir::Attribute>{parallel, parallel, reduction};
+  }
+
+  static mlir::AffineMap makeAffineMap(mlir::MLIRContext *ctx,
+                                       std::array<unsigned, 2> targets) {
+    return mlir::AffineMap::getMultiDimMapWithTargets(3, targets, ctx);
+  }
+}; // end of class
+} // namespace
+// ............................................................................
 
 void populateTTIRToTTIRGenericPatterns(MLIRContext *ctx,
                                        RewritePatternSet &patterns,
                                        TypeConverter &typeConverter,
-                                       uint64_t deviceGridRank) {
+                                       uint64_t deviceGridRank,
+                                       bool useTileMatmul) {
   // clang-format off
   patterns.add<
     // Elementwise.
@@ -601,10 +730,16 @@ void populateTTIRToTTIRGenericPatterns(MLIRContext *ctx,
     TTIRNamedElementwiseRewriter<ttir::LogOp,       ttir::TileLogOp>,
     // Reductions.
     TTIRNamedReductionRewriter<ttir::SumOp,         ttir::TileReduceSumOp>,
-    TTIRNamedReductionRewriter<ttir::MaxOp,         ttir::TileReduceMaxOp>,
-    // Matmul.
-    TTIRMatmulRewriter
+    TTIRNamedReductionRewriter<ttir::MaxOp,         ttir::TileReduceMaxOp>
   >(typeConverter, ctx, deviceGridRank);
+
+  // Matmul.
+  if (useTileMatmul) {
+    patterns.add<TTIRMatmulWithLinalgGenericRewriter>(typeConverter, ctx, deviceGridRank);
+  }
+  else {
+    patterns.add<TTIRMatmulRewriter>(typeConverter, ctx, deviceGridRank);
+  }
   // clang-format on
 }
 

--- a/lib/Conversion/TTIRToTTIRGeneric/TTIRToTTIRGenericPass.cpp
+++ b/lib/Conversion/TTIRToTTIRGeneric/TTIRToTTIRGenericPass.cpp
@@ -93,7 +93,7 @@ struct TTIRToTTIRGenericPass final
 protected:
   Option<bool> useTileMatmul{*this, "use-tile-matmul",
                              llvm::cl::desc("Use tile_matmul"),
-                             llvm::cl::init(false)};
+                             llvm::cl::init(true)};
 
 }; // end of class
 } // namespace

--- a/test/ttmlir/Conversion/TTIRToTTIRGeneric/named_to_generic.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTIRGeneric/named_to_generic.mlir
@@ -69,8 +69,8 @@ module {
   // CHECK-LABEL: func @named_contractions
   func.func @named_contractions(%lhs: !lhs, %rhs: !rhs, %out: !matmul_result) -> (!matmul_result) {
     // CHECK: ttir.generic{{.+}}iterator_types = [#parallel, #parallel, #reduction]
-    // CHECK-NOT: linalg.generic
-    // CHECK: ttir.tile_matmul_block
+    // CHECK: linalg.generic
+    // CHECK: ttir.tile_matmul
     %r = "ttir.matmul"(%lhs, %rhs, %out) : (!lhs, !rhs, !matmul_result) -> (!matmul_result)
     return %r : !matmul_result
   }

--- a/test/ttmlir/Conversion/TTIRToTTIRGeneric/use_tile_matmul.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTIRGeneric/use_tile_matmul.mlir
@@ -1,0 +1,18 @@
+// RUN: ttmlir-opt --tt-register-device --ttir-to-ttir-generic="use-tile-matmul=true" %s | FileCheck %s
+
+!ttype = tensor<128x96xf32>
+
+!lhs = tensor<128x96xf32>
+!rhs = tensor<96x64xf32>
+!matmul_result = tensor<128x64xf32>
+
+module {
+  // CHECK-LABEL: func @named_contractions
+  func.func @named_contractions(%lhs: !lhs, %rhs: !rhs, %out: !matmul_result) -> (!matmul_result) {
+    // CHECK: ttir.generic{{.+}}iterator_types = [#parallel, #parallel, #reduction]
+    // CHECK: linalg.generic
+    // CHECK: ttir.tile_matmul
+    %r = "ttir.matmul"(%lhs, %rhs, %out) : (!lhs, !rhs, !matmul_result) -> (!matmul_result)
+    return %r : !matmul_result
+  }
+}

--- a/test/ttmlir/Conversion/TTIRToTTIRGeneric/use_tile_matmul_false.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTIRGeneric/use_tile_matmul_false.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --tt-register-device --ttir-to-ttir-generic="use-tile-matmul=true" %s | FileCheck %s
+// RUN: ttmlir-opt --tt-register-device --ttir-to-ttir-generic="use-tile-matmul=false" %s | FileCheck %s
 
 !ttype = tensor<128x96xf32>
 
@@ -10,8 +10,8 @@ module {
   // CHECK-LABEL: func @named_contractions
   func.func @named_contractions(%lhs: !lhs, %rhs: !rhs, %out: !matmul_result) -> (!matmul_result) {
     // CHECK: ttir.generic{{.+}}iterator_types = [#parallel, #parallel, #reduction]
-    // CHECK: linalg.generic
-    // CHECK: ttir.tile_matmul
+    // CHECK-NOT: linalg.generic
+    // CHECK: ttir.tile_matmul_block
     %r = "ttir.matmul"(%lhs, %rhs, %out) : (!lhs, !rhs, !matmul_result) -> (!matmul_result)
     return %r : !matmul_result
   }


### PR DESCRIPTION
### Ticket
Closes #2937 

### What's changed
- Add `ttir.tile_matmul` operation;
- Add `use-tile-matmul` flag to `ttir-to-ttir-generic` pass;
- When flag is set use alternative rewriting for `ttir.matmul`.