### PR TITLE
Add compile_so API for FEs

### DIFF
--- a/tools/ttnn-standalone/CMakeLists.txt
+++ b/tools/ttnn-standalone/CMakeLists.txt
@@ -156,3 +156,9 @@ set_target_properties(ttnn-dylib PROPERTIES PUBLIC_HEADER ttnn-dylib.h)
 target_compile_options(ttnn-dylib PRIVATE -mavx -mavx2)
 
 target_precompile_headers(ttnn-dylib PRIVATE ttnn-precompiled.hpp)
+
+# Test compile_so
+add_executable(test_compile_so
+    test_compile_so.cpp
+    compile_so.cpp
+)

--- a/tools/ttnn-standalone/compile_so.cpp
+++ b/tools/ttnn-standalone/compile_so.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+
+namespace fs = std::filesystem;
+
+std::string compile_cpp_to_so(const std::string &cpp_source,
+                              const std::string &tmp_path_dir) {
+
+  fs::path directoryPath = fs::path(tmp_path_dir);
+  fs::path filePath = directoryPath / "emitted.cpp";
+
+  std::ofstream outFile(filePath);
+  if (!outFile.is_open()) {
+    std::cerr << "Error: Could not open file for writing: " << filePath
+              << std::endl;
+    exit(1); // TODO: how do we handle errors in this situation?
+  }
+
+  outFile << cpp_source;
+  outFile.close();
+
+  std::cout << "Successfully wrote C++ code to: " << filePath << std::endl;
+
+  // Compile the C++ code to a shared object.
+  //
+  std::string pythonScriptPath = std::string(std::getenv("TT_MLIR_HOME")) +
+                                 "/tools/ttnn-standalone/ci_compile_dylib.py";
+
+  // Check if the script exists
+  if (!fs::exists(pythonScriptPath)) {
+    std::cerr << "Error: Python script not found: " << pythonScriptPath
+              << std::endl;
+    exit(1);
+  }
+
+  std::string command =
+      "python " + pythonScriptPath + " --file " + filePath.string();
+
+  int result = std::system(command.c_str());
+
+  if (result == 0) {
+    std::cout << "Python script executed successfully." << std::endl;
+  } else {
+    std::cerr << "Error: Python script execution failed with code: " << result
+              << std::endl;
+    exit(1);
+  }
+
+  fs::path soPath = filePath;
+  soPath.replace_extension(".so");
+
+  return soPath.string();
+}

--- a/tools/ttnn-standalone/compile_so.hpp
+++ b/tools/ttnn-standalone/compile_so.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_TOOLS_TTNN_STANDALONE_COMPILE_SO_HPP
+#define TTMLIR_TOOLS_TTNN_STANDALONE_COMPILE_SO_HPP
+
+#include <string>
+
+std::string compile_cpp_to_so(const std::string &cpp_source,
+                              const std::string &tmp_path_dir);
+
+#endif // TTMLIR_TOOLS_TTNN_STANDALONE_COMPILE_SO_HPP

--- a/tools/ttnn-standalone/test_compile_so.cpp
+++ b/tools/ttnn-standalone/test_compile_so.cpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "compile_so.hpp"
+
+#include <fstream>
+#include <iterator>
+#include <string>
+
+std::string loadFileToString(const std::string &filename) {
+  std::ifstream file(filename);
+  if (!file) {
+    exit(1);
+  }
+  return std::string(std::istreambuf_iterator<char>(file),
+                     std::istreambuf_iterator<char>());
+}
+
+int main() {
+  std::string ttmlir_home = std::getenv("TT_MLIR_HOME");
+
+  std::string cpp_source =
+      loadFileToString(ttmlir_home + "/tools/ttnn-standalone/ttnn-dylib.cpp");
+  std::string tmp_path_dir = ttmlir_home;
+
+  compile_cpp_to_so(cpp_source, tmp_path_dir);
+}


### PR DESCRIPTION
### Ticket
#2956 

### Problem description
Frontends need to compile generated C++ code (`ttir-to-emitc-so-pipeline`) to shared objects. Having an API within ttnn-standalone will unify how FEs compile this.

### What's changed
Added `compile_so.hpp` that provides the following API:
```
std::string compile_cpp_to_so(const std::string &cpp_source,
                              const std::string &tmp_path_dir)
```

### Checklist
- [ ] New/Existing tests provide coverage for changes

Not sure how to test this, maybe a gtest or something, will think about it - added a `test_compile_so.cpp` - to compile as executable and run:
```sh
cd tools/ttnn-standalone
cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
cmake --build build -- test_compile_so
./build/test_compile_so
```