### PR TITLE
Move unsupported moreh cumsum silicon tests

### DIFF
--- a/test/ttmlir/Dialect/TTNN/simple_cumsum.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_cumsum.mlir
@@ -22,4 +22,26 @@ module @moreh_cumsum attributes {} {
     %1 = "ttir.cumsum"(%arg0, %0) <{dim = 1 : i64}> : (tensor<4x4x128x128xf32>, tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32>
     return %1 : tensor<4x4x128x128xf32>
   }
+
+  func.func public @test_moreh_cumsum_dim2(%arg0: tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32> {
+    // CHECK-LABEL: func.func public @test_moreh_cumsum_dim2
+    %0 = ttir.empty() : tensor<4x4x128x128xf32>
+    // CHECK: ttnn.moreh_cumsum
+    // CHECK-SAME: dim = 2 : i64
+    // CHECK-SAME: tensor<4x4x128x128xf32,
+    // CHECK-SAME: -> tensor<4x4x128x128xf32,
+    %1 = "ttir.cumsum"(%arg0, %0) <{dim = 2 : i64}> : (tensor<4x4x128x128xf32>, tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32>
+    return %1 : tensor<4x4x128x128xf32>
+  }
+
+  func.func public @test_moreh_cumsum_dim3(%arg0: tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32> {
+    // CHECK-LABEL: func.func public @test_moreh_cumsum_dim3
+    %0 = ttir.empty() : tensor<4x4x128x128xf32>
+    // CHECK: ttnn.moreh_cumsum
+    // CHECK-SAME: dim = 3 : i64
+    // CHECK-SAME: tensor<4x4x128x128xf32,
+    // CHECK-SAME: -> tensor<4x4x128x128xf32,
+    %1 = "ttir.cumsum"(%arg0, %0) <{dim = 3 : i64}> : (tensor<4x4x128x128xf32>, tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32>
+    return %1 : tensor<4x4x128x128xf32>
+  }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/simple_cumsum.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_cumsum.mlir
@@ -26,26 +26,4 @@ module @moreh_cumsum attributes {} {
     %1 = "ttir.cumsum"(%arg0, %0) <{dim = 1 : i64}> : (tensor<4x4x128x128xf32>, tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32>
     return %1 : tensor<4x4x128x128xf32>
   }
-
-  func.func public @test_moreh_cumsum_dim2(%arg0: tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32> {
-    // CHECK-LABEL: func.func public @test_moreh_cumsum_dim2
-    %0 = ttir.empty() : tensor<4x4x128x128xf32>
-    // CHECK: ttnn.moreh_cumsum
-    // CHECK-SAME: dim = 2 : i64
-    // CHECK-SAME: tensor<4x4x128x128xf32,
-    // CHECK-SAME: -> tensor<4x4x128x128xf32,
-    %1 = "ttir.cumsum"(%arg0, %0) <{dim = 2 : i64}> : (tensor<4x4x128x128xf32>, tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32>
-    return %1 : tensor<4x4x128x128xf32>
-  }
-
-  func.func public @test_moreh_cumsum_dim3(%arg0: tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32> {
-    // CHECK-LABEL: func.func public @test_moreh_cumsum_dim3
-    %0 = ttir.empty() : tensor<4x4x128x128xf32>
-    // CHECK: ttnn.moreh_cumsum
-    // CHECK-SAME: dim = 3 : i64
-    // CHECK-SAME: tensor<4x4x128x128xf32,
-    // CHECK-SAME: -> tensor<4x4x128x128xf32,
-    %1 = "ttir.cumsum"(%arg0, %0) <{dim = 3 : i64}> : (tensor<4x4x128x128xf32>, tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32>
-    return %1 : tensor<4x4x128x128xf32>
-  }
 }


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Currently moreh cumsum in ttnn only supports `dim == 0` and `dim == 1`.
When tt-metal is built with debug mode, the following assertion will be triggered for higher dimensions:
https://github.com/tenstorrent/tt-metal/blob/6943a39ea9a136d00e8841f4f6db3cfdc1acba2b/ttnn/cpp/ttnn/operations/moreh/moreh_cumsum/device/moreh_cumsum_program_factory.cpp#L23

### What's changed
Move the unsupported tests from silicon test to a regular test

### Checklist
- [x] New/Existing tests provide coverage for changes
