### PR TITLE
Uplift third_party/tt-metal to 70883c9145a607b37adaca05a22e3a9ca2f61368 2025-04-16

### DIFF
--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -780,6 +780,7 @@ public:
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
         emitter.emit(srcOp.getDim()),
+        /*keepdim=*/emitter.emit(false),
         /*sub_core_grids=*/emitter.emit(std::nullopt),
         emitter.emit(srcOp.getUseMulticore()),
         emitter.emit(srcOp.getMemoryConfig()) |

--- a/runtime/lib/ttnn/operations/reduction/argmax.cpp
+++ b/runtime/lib/ttnn/operations/reduction/argmax.cpp
@@ -18,10 +18,12 @@ runReductionArgMaxOp(::tt::target::ttnn::ReductionArgMaxOp const *op,
   std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
       ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
 
-  ::ttnn::Tensor out =
-      ::ttnn::argmax(in, op->dim(), std::nullopt, op->use_multicore(),
-                     /*memory_config_arg=*/outputMemoryConfig,
-                     /*optional_output_tensor=*/std::nullopt);
+  ::ttnn::Tensor out = ::ttnn::argmax(in, op->dim(),
+                                      /*keepdim=*/false,
+                                      /*sub_core_grids=*/std::nullopt,
+                                      /*use_multicore=*/op->use_multicore(),
+                                      /*memory_config_arg=*/outputMemoryConfig,
+                                      /*optional_output_tensor=*/std::nullopt);
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "ea25506219c719e491c8deb100c504a60bd0e392")
+set(TT_METAL_VERSION "70883c9145a607b37adaca05a22e3a9ca2f61368")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 70883c9145a607b37adaca05a22e3a9ca2f61368

- Update argmax to pass in keepdim arg after interface updated in metal commit 0d93eb7