### PR TITLE
Remove QueueId from conv2d call in runtime

### DIFF
--- a/runtime/lib/ttnn/operations/conv/conv2d.cpp
+++ b/runtime/lib/ttnn/operations/conv/conv2d.cpp
@@ -58,12 +58,12 @@ void run(const ::tt::target::ttnn::Conv2dOp *op, ProgramContext &context) {
       context.getTargetDevice(op->device()->global_id());
   ::ttnn::Tensor out = std::visit(
       [&](auto &&targetDevice) -> ::ttnn::Tensor {
-        return std::get<0>(::ttnn::operations::conv::conv2d::conv2d(
-            ::ttnn::QueueId(0), input, weight, &(targetDevice.get()),
-            op->in_channels(), op->out_channels(), op->batch_size(),
-            op->input_height(), op->input_width(), kernelSize, stride, padding,
-            dilation, op->groups(), bias, conv2dConfig, computeConfig,
-            outputMemoryConfig, std::nullopt));
+        return std::get<0>(::ttnn::conv2d(
+            input, weight, &(targetDevice.get()), op->in_channels(),
+            op->out_channels(), op->batch_size(), op->input_height(),
+            op->input_width(), kernelSize, stride, padding, dilation,
+            op->groups(), bias, conv2dConfig, computeConfig, outputMemoryConfig,
+            std::nullopt));
       },
       targetDevice);
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/pull/2927#discussion_r2043926633

### Problem description
During uplift, `QueueId()` had to be added to conv2d call.

### What's changed
Instead of targeting a specific impl of conv2d, now the "generic" `::ttnn::conv2d` interface is called, allowing the removal of `QueueId` param.

### Checklist
- [ ] New/Existing tests provide coverage for changes

fyi @brataTT 
