### PR TITLE
Refactor OpModel APIs to take OpConfig instead of just output layout

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/OpConfig.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpConfig.h
@@ -19,7 +19,8 @@ struct OpConfig {
   Attribute config;
 
   OpConfig() = default;
-  OpConfig(TTNNLayoutAttr outputLayout) : outputLayout(outputLayout) {}
+  OpConfig(TTNNLayoutAttr outputLayout)
+      : outputLayout(outputLayout), config(nullptr) {}
 
   bool operator==(const OpConfig &other) const {
     return outputLayout == other.outputLayout && config == other.config;

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpConfig.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpConfig.h
@@ -19,8 +19,9 @@ struct OpConfig {
   Attribute config;
 
   OpConfig() = default;
-  OpConfig(TTNNLayoutAttr outputLayout)
-      : outputLayout(outputLayout), config(nullptr) {}
+  OpConfig(TTNNLayoutAttr outputLayout) : outputLayout(outputLayout) {}
+  OpConfig(TTNNLayoutAttr outputLayout, Attribute config)
+      : outputLayout(outputLayout), config(config) {}
 
   bool operator==(const OpConfig &other) const {
     return outputLayout == other.outputLayout && config == other.config;

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.h
@@ -5,7 +5,7 @@
 #ifndef TTMLIR_DIALECT_TTNN_IR_TTNNOPMODELINTERFACE_H
 #define TTMLIR_DIALECT_TTNN_IR_TTNNOPMODELINTERFACE_H
 
-#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
 // This include is required for llvm::Expected in the tablegen'd
 // TTNNOpModelInterface methods
 #include "llvm/Support/Error.h"

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.td
@@ -21,7 +21,7 @@ def TTNN_OpModelInterface : OpInterface<"OpModel"> {
             }],
             /*retTy=*/"llvm::Expected<size_t>",
             /*methodName=*/"getOpRuntime",
-            /*args=*/(ins "const std::vector<TTNNLayoutAttr>&":$inputs, "const TTNNLayoutAttr&":$output),
+            /*args=*/(ins "const std::vector<TTNNLayoutAttr>&":$inputs, "const OpConfig&":$config),
             /*methodBody=*/"",
             /*defaultImplementation=*/"return llvm::createStringError(\"Not Implemented\");"
         >,
@@ -37,7 +37,7 @@ def TTNN_OpModelInterface : OpInterface<"OpModel"> {
             }],
             /*retTy=*/"llvm::Expected<std::tuple<size_t, size_t, size_t, ::mlir::tt::ttnn::TTNNLayoutAttr>>",
             /*methodName=*/"getOpConstraints",
-            /*args=*/(ins "const std::vector<TTNNLayoutAttr>&":$inputs, "const TTNNLayoutAttr&":$output),
+            /*args=*/(ins "const std::vector<TTNNLayoutAttr>&":$inputs, "const OpConfig&":$config),
             /*methodBody=*/"",
             /*defaultImplementation=*/"return llvm::createStringError(\"Not Implemented\");"
         >,

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1197,7 +1197,7 @@ def TTNN_PrepareConv2dWeightsOp : TTNN_Op<"prepare_conv2d_weights"> {
 }
 
 def TTNN_Conv2dOp : TTNN_Op<"conv2d",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpRuntime"]>]
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
       > {
     let summary = "Conv2d operation.";
     let description = [{
@@ -1280,9 +1280,6 @@ def TTNN_Conv2dOp : TTNN_Op<"conv2d",
             getBias() != nullptr
         );
       }
-
-      llvm::Expected<std::tuple<size_t, size_t, size_t>> getOpConstraints(
-        const std::vector<TTNNLayoutAttr> &inputs, const TTNNLayoutAttr &output, Conv2dConfigAttr conv2dConfigAttr = nullptr);
     }];
 }
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1197,7 +1197,7 @@ def TTNN_PrepareConv2dWeightsOp : TTNN_Op<"prepare_conv2d_weights"> {
 }
 
 def TTNN_Conv2dOp : TTNN_Op<"conv2d",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpRuntime"]>]
       > {
     let summary = "Conv2d operation.";
     let description = [{
@@ -1280,6 +1280,9 @@ def TTNN_Conv2dOp : TTNN_Op<"conv2d",
             getBias() != nullptr
         );
       }
+
+      llvm::Expected<std::tuple<size_t, size_t, size_t>> getOpConstraints(
+        const std::vector<TTNNLayoutAttr> &inputs, const TTNNLayoutAttr &output, Conv2dConfigAttr conv2dConfigAttr = nullptr);
     }];
 }
 

--- a/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
+++ b/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
@@ -774,8 +774,7 @@ llvm::Expected<bool> ShardSolver::checkShardCompatible(
 
     llvm::Expected<
         std::tuple<size_t, size_t, size_t, ::mlir::tt::ttnn::TTNNLayoutAttr>>
-        l1UsageExp =
-            backend.getOpConstraints(inputLayouts, consumerConfig);
+        l1UsageExp = backend.getOpConstraints(inputLayouts, consumerConfig);
 
     if (!l1UsageExp) {
       llvm::Error error = l1UsageExp.takeError();

--- a/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
+++ b/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
@@ -772,12 +772,10 @@ llvm::Expected<bool> ShardSolver::checkShardCompatible(
 
     assert(inputUnderCheckFound && "Input under check not found");
 
-    // TODO(odjuricic): This needs to change to pass full consumer config once #
-    // is completed.
     llvm::Expected<
         std::tuple<size_t, size_t, size_t, ::mlir::tt::ttnn::TTNNLayoutAttr>>
         l1UsageExp =
-            backend.getOpConstraints(inputLayouts, consumerConfig.outputLayout);
+            backend.getOpConstraints(inputLayouts, consumerConfig);
 
     if (!l1UsageExp) {
       llvm::Error error = l1UsageExp.takeError();

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -499,10 +499,13 @@ Conv2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
 
   // If a conv config has been specified, use that. If not, read the op property
-  auto conv2dConfig =
-      opConfig.config
-          ? std::make_optional(mlir::cast<Conv2dConfigAttr>(opConfig.config))
-          : getConv2dConfig();
+  std::optional<Conv2dConfigAttr> conv2dConfig = std::nullopt;
+  if (opConfig.config) {
+    assert(mlir::isa<Conv2dConfigAttr>(opConfig.config));
+    conv2dConfig = mlir::cast<Conv2dConfigAttr>(opConfig.config);
+  } else {
+    conv2dConfig = getConv2dConfig();
+  }
 
   return op_model::ttnn::Conv2dOpInterface::getOpConstraints(
       deviceGrid, inputShape, inputs[0], weightShape, inputs[1], biasShape,
@@ -530,10 +533,13 @@ Conv2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   const auto outputShape = getResult().getType().getShape();
 
   // If a conv config has been specified, use that. If not, read the op property
-  auto conv2dConfig =
-      opConfig.config
-          ? std::make_optional(mlir::cast<Conv2dConfigAttr>(opConfig.config))
-          : getConv2dConfig();
+  std::optional<Conv2dConfigAttr> conv2dConfig = std::nullopt;
+  if (opConfig.config) {
+    assert(mlir::isa<Conv2dConfigAttr>(opConfig.config));
+    conv2dConfig = mlir::cast<Conv2dConfigAttr>(opConfig.config);
+  } else {
+    conv2dConfig = getConv2dConfig();
+  }
 
   return op_model::ttnn::Conv2dOpInterface::getOpRuntime(
       inputShape, inputs[0], weightShape, inputs[1], biasShape, biasLayout,

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -501,7 +501,8 @@ Conv2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   // If a conv config has been specified, use that. If not, read the op property
   std::optional<Conv2dConfigAttr> conv2dConfig = std::nullopt;
   if (opConfig.config) {
-    assert(mlir::isa<Conv2dConfigAttr>(opConfig.config));
+    assert(mlir::isa<Conv2dConfigAttr>(opConfig.config) &&
+           "Unexpected OpConfig.config. Expected Conv2ConfigAttr");
     conv2dConfig = mlir::cast<Conv2dConfigAttr>(opConfig.config);
   } else {
     conv2dConfig = getConv2dConfig();
@@ -535,7 +536,8 @@ Conv2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   // If a conv config has been specified, use that. If not, read the op property
   std::optional<Conv2dConfigAttr> conv2dConfig = std::nullopt;
   if (opConfig.config) {
-    assert(mlir::isa<Conv2dConfigAttr>(opConfig.config));
+    assert(mlir::isa<Conv2dConfigAttr>(opConfig.config) &&
+           "Unexpected OpConfig.config. Expected Conv2ConfigAttr");
     conv2dConfig = mlir::cast<Conv2dConfigAttr>(opConfig.config);
   } else {
     conv2dConfig = getConv2dConfig();

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -466,7 +466,8 @@ MultiplyOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 llvm::Expected<
     std::tuple<size_t, size_t, size_t, ::mlir::tt::ttnn::TTNNLayoutAttr>>
 Conv2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                           const TTNNLayoutAttr &output) {
+                           const TTNNLayoutAttr &output,
+                           Conv2dConfigAttr conv2dConfigAttr) {
   assert(inputs.size() == 2 || inputs.size() == 3);
 
   const auto inputShape = getInput().getType().getShape();
@@ -487,12 +488,16 @@ Conv2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   }
   GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
 
+  // If a conv config has been specified, use that. If not, read the op property
+  auto config = conv2dConfigAttr != nullptr
+                    ? std::make_optional(conv2dConfigAttr)
+                    : getConv2dConfig();
+
   return op_model::ttnn::Conv2dOpInterface::getOpConstraints(
-      deviceGrid, inputShape, inputs[0], weightShape, inputs[1], biasShape,
-      biasLayout, getInChannels(), getOutChannels(), getBatchSize(),
-      getInputHeight(), getInputWidth(), getKernelSize(), getStride(),
-      getPadding(), getDilation(), getGroups(), getConv2dConfig(), outputShape,
-      output);
+      deviceGrid, inputShape, inputs[0], weightShape, inputs[1], biasShape, biasLayout,
+      getInChannels(), getOutChannels(), getBatchSize(), getInputHeight(),
+      getInputWidth(), getKernelSize(), getStride(), getPadding(),
+      getDilation(), getGroups(), config, outputShape, output);
 }
 
 llvm::Expected<size_t>

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -144,7 +144,7 @@ AddOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   return op_model::ttnn::AddOpInterface::getOpConstraints(
       deviceGrid, inputShapeA, inputs[0], inputShapeB, inputs[1], outputShape,
-     
+
       opConfig.outputLayout);
 }
 
@@ -222,7 +222,8 @@ MeanOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   return op_model::ttnn::MeanOpInterface::getOpConstraints(
       deviceGrid, inputShape, inputs[0],
-      detail::convertReductionArg(getDimArg()), getKeepDim(), opConfig.outputLayout);
+      detail::convertReductionArg(getDimArg()), getKeepDim(),
+      opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -333,7 +334,8 @@ ToLayoutOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
 
   return op_model::ttnn::ToLayoutOpInterface::getOpConstraints(
-      deviceGrid, inputShape, inputs[0], getDtype(), opConfig.outputLayout, passDevicePtr);
+      deviceGrid, inputShape, inputs[0], getDtype(), opConfig.outputLayout,
+      passDevicePtr);
 }
 
 llvm::Expected<size_t>
@@ -370,7 +372,8 @@ TransposeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
 
   return op_model::ttnn::TransposeOpInterface::getOpConstraints(
-      deviceGrid, inputShape, inputs[0], getDim0(), getDim1(), opConfig.outputLayout);
+      deviceGrid, inputShape, inputs[0], getDim0(), getDim1(),
+      opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -448,7 +451,7 @@ MultiplyOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   return op_model::ttnn::MultiplyOpInterface::getOpConstraints(
       deviceGrid, inputShapeA, inputs[0], inputShapeB, inputs[1], outputShape,
-     
+
       opConfig.outputLayout);
 }
 
@@ -502,10 +505,10 @@ Conv2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
           : getConv2dConfig();
 
   return op_model::ttnn::Conv2dOpInterface::getOpConstraints(
-      deviceGrid, inputShape, inputs[0], weightShape, inputs[1], biasShape, biasLayout,
-      getInChannels(), getOutChannels(), getBatchSize(), getInputHeight(),
-      getInputWidth(), getKernelSize(), getStride(), getPadding(),
-      getDilation(), getGroups(), conv2dConfig, outputShape,
+      deviceGrid, inputShape, inputs[0], weightShape, inputs[1], biasShape,
+      biasLayout, getInChannels(), getOutChannels(), getBatchSize(),
+      getInputHeight(), getInputWidth(), getKernelSize(), getStride(),
+      getPadding(), getDilation(), getGroups(), conv2dConfig, outputShape,
       opConfig.outputLayout);
 }
 
@@ -564,7 +567,8 @@ MaxPool2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   return op_model::ttnn::MaxPool2DInterface::getOpConstraints(
       deviceGrid, inputShape, inputs[0], getBatchSize(), getInputHeight(),
       getInputWidth(), getChannels(), getKernelSize(), getStride(),
-      getPadding(), getDilation(), getCeilMode(), outputShape, opConfig.outputLayout);
+      getPadding(), getDilation(), getCeilMode(), outputShape,
+      opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -52,7 +52,7 @@ convertReductionArg(std::optional<mlir::ArrayAttr> arrayOpt) {
 llvm::Expected<
     std::tuple<size_t, size_t, size_t, ::mlir::tt::ttnn::TTNNLayoutAttr>>
 ReluOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                         const TTNNLayoutAttr &output) {
+                         const OpConfig &opConfig) {
   assert(inputs.size() == 1);
 
   const auto inputShape = getInput().getType().getShape();
@@ -66,12 +66,12 @@ ReluOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
 
   return op_model::ttnn::ReluOpInterface::getOpConstraints(
-      deviceGrid, inputShape, inputs[0], outputShape, output);
+      deviceGrid, inputShape, inputs[0], outputShape, opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
 ReluOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                     const TTNNLayoutAttr &output) {
+                     const OpConfig &opConfig) {
 
   assert(inputs.size() == 1);
 
@@ -79,8 +79,8 @@ ReluOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto outputShape = getType().getShape();
 
-  return op_model::ttnn::ReluOpInterface::getOpRuntime(inputShape, inputs[0],
-                                                       outputShape, output);
+  return op_model::ttnn::ReluOpInterface::getOpRuntime(
+      inputShape, inputs[0], outputShape, opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//
@@ -90,7 +90,7 @@ ReluOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 llvm::Expected<
     std::tuple<size_t, size_t, size_t, ::mlir::tt::ttnn::TTNNLayoutAttr>>
 SqrtOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                         const TTNNLayoutAttr &output) {
+                         const OpConfig &opConfig) {
   assert(inputs.size() == 1);
 
   const auto inputShape = getInput().getType().getShape();
@@ -104,12 +104,12 @@ SqrtOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
 
   return op_model::ttnn::SqrtOpInterface::getOpConstraints(
-      deviceGrid, inputShape, inputs[0], outputShape, output);
+      deviceGrid, inputShape, inputs[0], outputShape, opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
 SqrtOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                     const TTNNLayoutAttr &output) {
+                     const OpConfig &opConfig) {
 
   assert(inputs.size() == 1);
 
@@ -117,8 +117,8 @@ SqrtOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto outputShape = getType().getShape();
 
-  return op_model::ttnn::SqrtOpInterface::getOpRuntime(inputShape, inputs[0],
-                                                       outputShape, output);
+  return op_model::ttnn::SqrtOpInterface::getOpRuntime(
+      inputShape, inputs[0], outputShape, opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//
@@ -128,7 +128,7 @@ SqrtOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 llvm::Expected<
     std::tuple<size_t, size_t, size_t, ::mlir::tt::ttnn::TTNNLayoutAttr>>
 AddOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                        const TTNNLayoutAttr &output) {
+                        const OpConfig &opConfig) {
   assert(inputs.size() == 2);
 
   const auto inputShapeA = getLhs().getType().getShape();
@@ -144,12 +144,13 @@ AddOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   return op_model::ttnn::AddOpInterface::getOpConstraints(
       deviceGrid, inputShapeA, inputs[0], inputShapeB, inputs[1], outputShape,
-      output);
+     
+      opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
 AddOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                    const TTNNLayoutAttr &output) {
+                    const OpConfig &opConfig) {
   assert(inputs.size() == 2);
 
   const auto inputShapeA = getLhs().getType().getShape();
@@ -158,7 +159,8 @@ AddOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   const auto outputShape = getType().getShape();
 
   return op_model::ttnn::AddOpInterface::getOpRuntime(
-      inputShapeA, inputs[0], inputShapeB, inputs[1], outputShape, output);
+      inputShapeA, inputs[0], inputShapeB, inputs[1], outputShape,
+      opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//
@@ -168,7 +170,7 @@ AddOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 llvm::Expected<
     std::tuple<size_t, size_t, size_t, ::mlir::tt::ttnn::TTNNLayoutAttr>>
 SoftmaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                            const TTNNLayoutAttr &output) {
+                            const OpConfig &opConfig) {
   assert(inputs.size() == 1);
 
   const auto inputShape = getInput().getType().getShape();
@@ -182,12 +184,13 @@ SoftmaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
 
   return op_model::ttnn::SoftmaxOpInterface::getOpConstraints(
-      deviceGrid, inputShape, inputs[0], getDimension(), outputShape, output);
+      deviceGrid, inputShape, inputs[0], getDimension(), outputShape,
+      opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
 SoftmaxOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                        const TTNNLayoutAttr &output) {
+                        const OpConfig &opConfig) {
   assert(inputs.size() == 1);
 
   const auto inputShape = getInput().getType().getShape();
@@ -195,7 +198,8 @@ SoftmaxOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   const auto outputShape = getResult().getType().getShape();
 
   return op_model::ttnn::SoftmaxOpInterface::getOpRuntime(
-      inputShape, inputs[0], getDimension(), outputShape, output);
+      inputShape, inputs[0], getDimension(), outputShape,
+      opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//
@@ -205,7 +209,7 @@ SoftmaxOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 llvm::Expected<
     std::tuple<size_t, size_t, size_t, ::mlir::tt::ttnn::TTNNLayoutAttr>>
 MeanOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                         const TTNNLayoutAttr &output) {
+                         const OpConfig &opConfig) {
   assert(inputs.size() == 1);
 
   const auto inputShape = getInput().getType().getShape();
@@ -218,19 +222,19 @@ MeanOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   return op_model::ttnn::MeanOpInterface::getOpConstraints(
       deviceGrid, inputShape, inputs[0],
-      detail::convertReductionArg(getDimArg()), getKeepDim(), output);
+      detail::convertReductionArg(getDimArg()), getKeepDim(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
 MeanOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                     const TTNNLayoutAttr &output) {
+                     const OpConfig &opConfig) {
   assert(inputs.size() == 1);
 
   const auto inputShape = getInput().getType().getShape();
 
   return op_model::ttnn::MeanOpInterface::getOpRuntime(
       inputShape, inputs[0], detail::convertReductionArg(getDimArg()),
-      getKeepDim(), output);
+      getKeepDim(), opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//
@@ -240,7 +244,7 @@ MeanOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 llvm::Expected<
     std::tuple<size_t, size_t, size_t, ::mlir::tt::ttnn::TTNNLayoutAttr>>
 ReshapeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                            const TTNNLayoutAttr &output) {
+                            const OpConfig &opConfig) {
   assert(inputs.size() == 1);
 
   const auto inputShape = getInput().getType().getShape();
@@ -254,19 +258,19 @@ ReshapeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
 
   return op_model::ttnn::ReshapeOpInterface::getOpConstraints(
-      deviceGrid, inputShape, inputs[0], outputShape, output);
+      deviceGrid, inputShape, inputs[0], outputShape, opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
 ReshapeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                        const TTNNLayoutAttr &output) {
+                        const OpConfig &opConfig) {
   assert(inputs.size() == 1);
 
   const auto inputShape = getInput().getType().getShape();
   const auto outputShape = getResult().getType().getShape();
 
-  return op_model::ttnn::ReshapeOpInterface::getOpRuntime(inputShape, inputs[0],
-                                                          outputShape, output);
+  return op_model::ttnn::ReshapeOpInterface::getOpRuntime(
+      inputShape, inputs[0], outputShape, opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//
@@ -276,7 +280,7 @@ ReshapeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 llvm::Expected<
     std::tuple<size_t, size_t, size_t, ::mlir::tt::ttnn::TTNNLayoutAttr>>
 TypecastOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                             const TTNNLayoutAttr &output) {
+                             const OpConfig &opConfig) {
   assert(inputs.size() == 1);
 
   const auto inputShape = getInput().getType().getShape();
@@ -289,19 +293,21 @@ TypecastOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
 
   return op_model::ttnn::TypecastOpInterface::getOpConstraints(
-      deviceGrid, inputShape, inputs[0], getDtypeAttr(), outputShape, output);
+      deviceGrid, inputShape, inputs[0], getDtypeAttr(), outputShape,
+      opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
 TypecastOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                         const TTNNLayoutAttr &output) {
+                         const OpConfig &opConfig) {
   assert(inputs.size() == 1);
 
   const auto inputShape = getInput().getType().getShape();
   const auto outputShape = getResult().getType().getShape();
 
   return op_model::ttnn::TypecastOpInterface::getOpRuntime(
-      inputShape, inputs[0], getDtypeAttr(), outputShape, output);
+      inputShape, inputs[0], getDtypeAttr(), outputShape,
+      opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//
@@ -311,9 +317,9 @@ TypecastOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 llvm::Expected<
     std::tuple<size_t, size_t, size_t, ::mlir::tt::ttnn::TTNNLayoutAttr>>
 ToLayoutOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                             const TTNNLayoutAttr &output) {
+                             const OpConfig &opConfig) {
   assert(inputs.size() == 1);
-  assert(output.getLayout() == getLayout());
+  assert(opConfig.outputLayout.getLayout() == getLayout());
 
   const auto inputShape = getInput().getType().getShape();
 
@@ -327,14 +333,14 @@ ToLayoutOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
 
   return op_model::ttnn::ToLayoutOpInterface::getOpConstraints(
-      deviceGrid, inputShape, inputs[0], getDtype(), output, passDevicePtr);
+      deviceGrid, inputShape, inputs[0], getDtype(), opConfig.outputLayout, passDevicePtr);
 }
 
 llvm::Expected<size_t>
 ToLayoutOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                         const TTNNLayoutAttr &output) {
+                         const OpConfig &opConfig) {
   assert(inputs.size() == 1);
-  assert(output.getLayout() == getLayout());
+  assert(opConfig.outputLayout.getLayout() == getLayout());
 
   const auto inputShape = getInput().getType().getShape();
 
@@ -342,7 +348,7 @@ ToLayoutOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   const bool passDevicePtr = !deviceOperand;
 
   return op_model::ttnn::ToLayoutOpInterface::getOpRuntime(
-      inputShape, inputs[0], getDtype(), output, passDevicePtr);
+      inputShape, inputs[0], getDtype(), opConfig.outputLayout, passDevicePtr);
 }
 
 //===----------------------------------------------------------------------===//
@@ -352,7 +358,7 @@ ToLayoutOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 llvm::Expected<
     std::tuple<size_t, size_t, size_t, ::mlir::tt::ttnn::TTNNLayoutAttr>>
 TransposeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                              const TTNNLayoutAttr &output) {
+                              const OpConfig &opConfig) {
   assert(inputs.size() == 1);
 
   const auto inputShape = getInput().getType().getShape();
@@ -364,18 +370,18 @@ TransposeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
 
   return op_model::ttnn::TransposeOpInterface::getOpConstraints(
-      deviceGrid, inputShape, inputs[0], getDim0(), getDim1(), output);
+      deviceGrid, inputShape, inputs[0], getDim0(), getDim1(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
 TransposeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                          const TTNNLayoutAttr &output) {
+                          const OpConfig &opConfig) {
   assert(inputs.size() == 1);
 
   const auto inputShape = getInput().getType().getShape();
 
   return op_model::ttnn::TransposeOpInterface::getOpRuntime(
-      inputShape, inputs[0], getDim0(), getDim1(), output);
+      inputShape, inputs[0], getDim0(), getDim1(), opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//
@@ -385,7 +391,7 @@ TransposeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 llvm::Expected<
     std::tuple<size_t, size_t, size_t, ::mlir::tt::ttnn::TTNNLayoutAttr>>
 MatmulOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                           const TTNNLayoutAttr &output) {
+                           const OpConfig &opConfig) {
   assert(inputs.size() == 2);
 
   const auto inputShapeA = getA().getType().getShape();
@@ -401,12 +407,12 @@ MatmulOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   return op_model::ttnn::MatmulOpInterface::getOpConstraints(
       deviceGrid, inputShapeA, inputs[0], inputShapeB, inputs[1], outputShape,
-      output, false, false);
+      opConfig.outputLayout, false, false);
 }
 
 llvm::Expected<size_t>
 MatmulOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                       const TTNNLayoutAttr &output) {
+                       const OpConfig &opConfig) {
   assert(inputs.size() == 2);
 
   const auto inputShapeA = getA().getType().getShape();
@@ -415,8 +421,8 @@ MatmulOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   const auto outputShape = getType().getShape();
 
   return op_model::ttnn::MatmulOpInterface::getOpRuntime(
-      inputShapeA, inputs[0], inputShapeB, inputs[1], outputShape, output,
-      false, false);
+      inputShapeA, inputs[0], inputShapeB, inputs[1], outputShape,
+      opConfig.outputLayout, false, false);
 }
 
 //===----------------------------------------------------------------------===//
@@ -426,7 +432,7 @@ MatmulOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 llvm::Expected<
     std::tuple<size_t, size_t, size_t, ::mlir::tt::ttnn::TTNNLayoutAttr>>
 MultiplyOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                             const TTNNLayoutAttr &output) {
+                             const OpConfig &opConfig) {
   assert(inputs.size() == 2);
 
   const auto inputShapeA = getLhs().getType().getShape();
@@ -442,12 +448,13 @@ MultiplyOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   return op_model::ttnn::MultiplyOpInterface::getOpConstraints(
       deviceGrid, inputShapeA, inputs[0], inputShapeB, inputs[1], outputShape,
-      output);
+     
+      opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
 MultiplyOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                         const TTNNLayoutAttr &output) {
+                         const OpConfig &opConfig) {
   assert(inputs.size() == 2);
 
   const auto inputShapeA = getLhs().getType().getShape();
@@ -456,7 +463,8 @@ MultiplyOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   const auto outputShape = getType().getShape();
 
   return op_model::ttnn::MultiplyOpInterface::getOpRuntime(
-      inputShapeA, inputs[0], inputShapeB, inputs[1], outputShape, output);
+      inputShapeA, inputs[0], inputShapeB, inputs[1], outputShape,
+      opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//
@@ -466,8 +474,7 @@ MultiplyOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 llvm::Expected<
     std::tuple<size_t, size_t, size_t, ::mlir::tt::ttnn::TTNNLayoutAttr>>
 Conv2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                           const TTNNLayoutAttr &output,
-                           Conv2dConfigAttr conv2dConfigAttr) {
+                           const OpConfig &opConfig) {
   assert(inputs.size() == 2 || inputs.size() == 3);
 
   const auto inputShape = getInput().getType().getShape();
@@ -489,20 +496,22 @@ Conv2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
 
   // If a conv config has been specified, use that. If not, read the op property
-  auto config = conv2dConfigAttr != nullptr
-                    ? std::make_optional(conv2dConfigAttr)
-                    : getConv2dConfig();
+  auto conv2dConfig =
+      opConfig.config
+          ? std::make_optional(mlir::cast<Conv2dConfigAttr>(opConfig.config))
+          : getConv2dConfig();
 
   return op_model::ttnn::Conv2dOpInterface::getOpConstraints(
       deviceGrid, inputShape, inputs[0], weightShape, inputs[1], biasShape, biasLayout,
       getInChannels(), getOutChannels(), getBatchSize(), getInputHeight(),
       getInputWidth(), getKernelSize(), getStride(), getPadding(),
-      getDilation(), getGroups(), config, outputShape, output);
+      getDilation(), getGroups(), conv2dConfig, outputShape,
+      opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
 Conv2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                       const TTNNLayoutAttr &output) {
+                       const OpConfig &opConfig) {
   assert(inputs.size() == 2 || inputs.size() == 3);
 
   const auto inputShape = getInput().getType().getShape();
@@ -517,11 +526,18 @@ Conv2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto outputShape = getResult().getType().getShape();
 
+  // If a conv config has been specified, use that. If not, read the op property
+  auto conv2dConfig =
+      opConfig.config
+          ? std::make_optional(mlir::cast<Conv2dConfigAttr>(opConfig.config))
+          : getConv2dConfig();
+
   return op_model::ttnn::Conv2dOpInterface::getOpRuntime(
       inputShape, inputs[0], weightShape, inputs[1], biasShape, biasLayout,
       getInChannels(), getOutChannels(), getBatchSize(), getInputHeight(),
       getInputWidth(), getKernelSize(), getStride(), getPadding(),
-      getDilation(), getGroups(), getConv2dConfig(), outputShape, output);
+      getDilation(), getGroups(), conv2dConfig, outputShape,
+      opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//
@@ -531,7 +547,7 @@ Conv2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 llvm::Expected<
     std::tuple<size_t, size_t, size_t, ::mlir::tt::ttnn::TTNNLayoutAttr>>
 MaxPool2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                              const TTNNLayoutAttr &output) {
+                              const OpConfig &opConfig) {
   assert(inputs.size() == 1);
 
   const auto inputShape = getInput().getType().getShape();
@@ -548,12 +564,12 @@ MaxPool2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   return op_model::ttnn::MaxPool2DInterface::getOpConstraints(
       deviceGrid, inputShape, inputs[0], getBatchSize(), getInputHeight(),
       getInputWidth(), getChannels(), getKernelSize(), getStride(),
-      getPadding(), getDilation(), getCeilMode(), outputShape, output);
+      getPadding(), getDilation(), getCeilMode(), outputShape, opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
 MaxPool2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                          const TTNNLayoutAttr &output) {
+                          const OpConfig &opConfig) {
   assert(inputs.size() == 1);
 
   const auto inputShape = getInput().getType().getShape();
@@ -564,7 +580,7 @@ MaxPool2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   return op_model::ttnn::MaxPool2DInterface::getOpRuntime(
       inputShape, inputs[0], getBatchSize(), getInputHeight(), getInputWidth(),
       getChannels(), getKernelSize(), getStride(), getPadding(), getDilation(),
-      getCeilMode(), outputShape, output);
+      getCeilMode(), outputShape, opConfig.outputLayout);
 }
 
 } // namespace mlir::tt::ttnn

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -785,13 +785,15 @@ TEST_F(OpModelBase, Conv2dInterfaceConfigs) {
 
   // Device hangs otherwise.
   mlir::tt::op_model::ttnn::SingletonDeviceContext::resetInstance();
-
   auto badConvConfig = Conv2dConfigAttr::get(
       &context, DataType::BFloat16, DataType::BFloat16,
-      StringAttr::get(&context, ""), 32, false, true, 0, 1, false, false,
-      TensorMemoryLayoutAttr::get(&context, TensorMemoryLayout::Interleaved),
-      ttnn::CoreRangeSetAttr(), false, Layout::Tile, false, false, false, false,
-      false, false);
+      StringAttr::get(&context, ""), 32, BoolAttr::get(&context, false),
+      BoolAttr::get(&context, true), 0, 1, BoolAttr::get(&context, false),
+      BoolAttr::get(&context, false), TensorMemoryLayout::Interleaved,
+      ttnn::CoreRangeSetAttr(), BoolAttr::get(&context, false), Layout::Tile,
+      BoolAttr::get(&context, false), BoolAttr::get(&context, false),
+      BoolAttr::get(&context, false), BoolAttr::get(&context, false),
+      BoolAttr::get(&context, false), BoolAttr::get(&context, false));
   OpModel backend = dyn_cast<OpModel>(conv2d.getOperation());
   auto constraintsExp = backend.getOpConstraints(
       getInputLayouts(conv2d),
@@ -813,10 +815,14 @@ TEST_F(OpModelBase, Conv2dInterfaceConfigs) {
 
   auto goodConvConfig = Conv2dConfigAttr::get(
       &context, DataType::BFloat16, DataType::BFloat16,
-      StringAttr::get(&context, ""), 32, false, true, 0, 1, false, false,
-      TensorMemoryLayoutAttr(), ttnn::CoreRangeSetAttr(), false, Layout::Tile,
-      false, false, /*enable_act_double_buffer=*/true,
-      /*enable_weights_double_buffer=*/true, false, false);
+      StringAttr::get(&context, ""), 32, BoolAttr::get(&context, false),
+      BoolAttr::get(&context, true), 0, 1, BoolAttr::get(&context, false),
+      BoolAttr::get(&context, false), std::nullopt, ttnn::CoreRangeSetAttr(),
+      BoolAttr::get(&context, false), Layout::Tile,
+      BoolAttr::get(&context, false), BoolAttr::get(&context, false),
+      /*enable_act_double_buffer=*/BoolAttr::get(&context, true),
+      /*enable_weights_double_buffer=*/BoolAttr::get(&context, true),
+      BoolAttr::get(&context, false), BoolAttr::get(&context, false));
 
   constraintsExp = backend.getOpConstraints(
       getInputLayouts(conv2d),

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -796,6 +796,11 @@ TEST_F(OpModelBase, Conv2dInterfaceConfigs) {
 
   // Device hangs otherwise.
   mlir::tt::op_model::ttnn::SingletonDeviceContext::resetInstance();
+
+  // Will fail due to assertion at
+  // tt-metal/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp:156 "Conv2d
+  // supports Height, Block or Width Sharded Layouts but got
+  // TensorMemoryLayout::INTERLEAVED"
   auto badConvConfig = Conv2dConfigAttr::get(
       &context, /*dtype=*/DataType::BFloat16,
       /*weights_dtype=*/DataType::BFloat16,

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -157,7 +157,7 @@ TEST_F(OpModelBase, ReluOpInterfaceNullOutput) {
   // test ReluOp interface
   OpModel backend = dyn_cast<OpModel>(relu.getOperation());
   auto constraintsExp =
-      backend.getOpConstraints(getInputLayouts(relu), nullptr);
+      backend.getOpConstraints(getInputLayouts(relu), OpConfig(nullptr));
 
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
   const auto &[cbSize, peakSize, outputSize, outputLayout] =
@@ -282,7 +282,8 @@ TEST_F(OpModelBase, AddOpInterfaceNullOutput) {
 
   // test AddOp interface
   OpModel backend = dyn_cast<OpModel>(add.getOperation());
-  auto constraintsExp = backend.getOpConstraints(getInputLayouts(add), nullptr);
+  auto constraintsExp =
+      backend.getOpConstraints(getInputLayouts(add), OpConfig(nullptr));
 
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
   const auto &[cbSize, peakSize, outputSize, outputLayout] =
@@ -379,7 +380,7 @@ TEST_F(OpModelBase, MatmulOpInterfaceNullOutput) {
   // test MatmulOp interface
   OpModel backend = dyn_cast<OpModel>(matmul.getOperation());
   auto constraintsExp =
-      backend.getOpConstraints(getInputLayouts(matmul), nullptr);
+      backend.getOpConstraints(getInputLayouts(matmul), OpConfig(nullptr));
 
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
   const auto &[cbSize, peakSize, outputSize, outputLayout] =
@@ -702,7 +703,7 @@ TEST_F(OpModelBase, Conv2dInterfaceNullOutput) {
   // test Conv2dOp interface
   OpModel backend = dyn_cast<OpModel>(conv2d.getOperation());
   auto constraintsExp =
-      backend.getOpConstraints(getInputLayouts(conv2d), nullptr);
+      backend.getOpConstraints(getInputLayouts(conv2d), OpConfig(nullptr));
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
   const auto &[cbSize, peakSize, outputSize, outputLayout] =
       constraintsExp.get();
@@ -821,7 +822,8 @@ TEST_F(OpModelBase, Conv2dInterfaceConfigs) {
       getInputLayouts(conv2d),
       OpConfig(getOutputLayout(conv2d), goodConvConfig));
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cb_size, peak_size, output_size] = constraintsExp.get();
+  const auto &[cb_size, peak_size, output_size, outputLayout] =
+      constraintsExp.get();
   EXPECT_EQ(
       cb_size,
       243776); // Higher CB usage than baseline Conv2dInterface test due to

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -156,8 +156,8 @@ TEST_F(OpModelBase, ReluOpInterfaceNullOutput) {
 
   // test ReluOp interface
   OpModel backend = dyn_cast<OpModel>(relu.getOperation());
-  auto constraintsExp =
-      backend.getOpConstraints(getInputLayouts(relu), OpConfig(nullptr));
+  auto constraintsExp = backend.getOpConstraints(
+      getInputLayouts(relu), OpConfig(/*outputLayout=*/nullptr));
 
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
   const auto &[cbSize, peakSize, outputSize, outputLayout] =
@@ -282,8 +282,8 @@ TEST_F(OpModelBase, AddOpInterfaceNullOutput) {
 
   // test AddOp interface
   OpModel backend = dyn_cast<OpModel>(add.getOperation());
-  auto constraintsExp =
-      backend.getOpConstraints(getInputLayouts(add), OpConfig(nullptr));
+  auto constraintsExp = backend.getOpConstraints(
+      getInputLayouts(add), OpConfig(/*outputLayout=*/nullptr));
 
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
   const auto &[cbSize, peakSize, outputSize, outputLayout] =
@@ -379,8 +379,8 @@ TEST_F(OpModelBase, MatmulOpInterfaceNullOutput) {
 
   // test MatmulOp interface
   OpModel backend = dyn_cast<OpModel>(matmul.getOperation());
-  auto constraintsExp =
-      backend.getOpConstraints(getInputLayouts(matmul), OpConfig(nullptr));
+  auto constraintsExp = backend.getOpConstraints(
+      getInputLayouts(matmul), OpConfig(/*outputLayout=*/nullptr));
 
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
   const auto &[cbSize, peakSize, outputSize, outputLayout] =
@@ -702,8 +702,8 @@ TEST_F(OpModelBase, Conv2dInterfaceNullOutput) {
 
   // test Conv2dOp interface
   OpModel backend = dyn_cast<OpModel>(conv2d.getOperation());
-  auto constraintsExp =
-      backend.getOpConstraints(getInputLayouts(conv2d), OpConfig(nullptr));
+  auto constraintsExp = backend.getOpConstraints(
+      getInputLayouts(conv2d), OpConfig(/*outputLayout=*/nullptr));
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
   const auto &[cbSize, peakSize, outputSize, outputLayout] =
       constraintsExp.get();
@@ -797,14 +797,26 @@ TEST_F(OpModelBase, Conv2dInterfaceConfigs) {
   // Device hangs otherwise.
   mlir::tt::op_model::ttnn::SingletonDeviceContext::resetInstance();
   auto badConvConfig = Conv2dConfigAttr::get(
-      &context, DataType::BFloat16, DataType::BFloat16,
-      StringAttr::get(&context, ""), 32, BoolAttr::get(&context, false),
-      BoolAttr::get(&context, true), 0, 1, BoolAttr::get(&context, false),
-      BoolAttr::get(&context, false), TensorMemoryLayout::Interleaved,
-      ttnn::CoreRangeSetAttr(), BoolAttr::get(&context, false), Layout::Tile,
-      BoolAttr::get(&context, false), BoolAttr::get(&context, false),
-      BoolAttr::get(&context, false), BoolAttr::get(&context, false),
-      BoolAttr::get(&context, false), BoolAttr::get(&context, false));
+      &context, /*dtype=*/DataType::BFloat16,
+      /*weights_dtype=*/DataType::BFloat16,
+      /*activation=*/StringAttr::get(&context, ""),
+      /*input_channels_alignment=*/32,
+      /*deallocate_activation=*/BoolAttr::get(&context, false),
+      /*reallocate_halo_output=*/BoolAttr::get(&context, true),
+      /*act_block_h_override=*/0, /*act_block_w_div=*/1,
+      /*reshard_if_not_optimal=*/BoolAttr::get(&context, false),
+      /*override_sharding_config=*/BoolAttr::get(&context, false),
+      /*shard_layout=*/TensorMemoryLayout::Interleaved,
+      /*core_grid=*/ttnn::CoreRangeSetAttr(),
+      /*transpose_shards=*/BoolAttr::get(&context, false),
+      /*output_layout=*/Layout::Tile,
+      /*preprocess_weights_on_device=*/BoolAttr::get(&context, false),
+      /*always_preprocess_weights=*/BoolAttr::get(&context, false),
+      /*enable_act_double_buffer=*/BoolAttr::get(&context, false),
+      /*enable_weights_double_buffer=*/BoolAttr::get(&context, false),
+      /*enable_split_reader=*/BoolAttr::get(&context, false),
+      /*enable_subblock_padding=*/BoolAttr::get(&context, false));
+
   OpModel backend = dyn_cast<OpModel>(conv2d.getOperation());
   auto constraintsExp = backend.getOpConstraints(
       getInputLayouts(conv2d),
@@ -825,15 +837,25 @@ TEST_F(OpModelBase, Conv2dInterfaceConfigs) {
   mlir::tt::op_model::ttnn::SingletonDeviceContext::resetInstance();
 
   auto goodConvConfig = Conv2dConfigAttr::get(
-      &context, DataType::BFloat16, DataType::BFloat16,
-      StringAttr::get(&context, ""), 32, BoolAttr::get(&context, false),
-      BoolAttr::get(&context, true), 0, 1, BoolAttr::get(&context, false),
-      BoolAttr::get(&context, false), std::nullopt, ttnn::CoreRangeSetAttr(),
-      BoolAttr::get(&context, false), Layout::Tile,
-      BoolAttr::get(&context, false), BoolAttr::get(&context, false),
+      &context, /*dtype=*/DataType::BFloat16,
+      /*weights_dtype=*/DataType::BFloat16,
+      /*activation=*/StringAttr::get(&context, ""),
+      /*input_channels_alignment=*/32,
+      /*deallocate_activation=*/BoolAttr::get(&context, false),
+      /*reallocate_halo_output=*/BoolAttr::get(&context, true),
+      /*act_block_h_override=*/0, /*act_block_w_div=*/1,
+      /*reshard_if_not_optimal=*/BoolAttr::get(&context, false),
+      /*override_sharding_config=*/BoolAttr::get(&context, false),
+      /*shard_layout=*/std::nullopt,
+      /*core_grid=*/ttnn::CoreRangeSetAttr(),
+      /*transpose_shards=*/BoolAttr::get(&context, false),
+      /*output_layout=*/Layout::Tile,
+      /*preprocess_weights_on_device=*/BoolAttr::get(&context, false),
+      /*always_preprocess_weights=*/BoolAttr::get(&context, false),
       /*enable_act_double_buffer=*/BoolAttr::get(&context, true),
       /*enable_weights_double_buffer=*/BoolAttr::get(&context, true),
-      BoolAttr::get(&context, false), BoolAttr::get(&context, false));
+      /*enable_split_reader=*/BoolAttr::get(&context, false),
+      /*enable_subblock_padding=*/BoolAttr::get(&context, false));
 
   constraintsExp = backend.getOpConstraints(
       getInputLayouts(conv2d),


### PR DESCRIPTION
### Ticket
#2441

### Problem description
Some important ops (e.g. conv2d, matmul) have op-sepcific config structs that greatly affect op performance/legality. The optimizer uses the `OpConfig` struct to generically encapsulate the output layout and these config structs. OpModel APIs (`getOpConstraints` and `getOpRuntime`) should accept these structs to allow easy sweeping.

To start, Conv2dConfig should be enabled end to end

### What's changed
- Closes #2441 
- Modify the OpModelInterface methods to accept an `OpConfig` struct in place of `TTNNLayoutAttr outputLayout`
  - For all ops, read the output layout from the struct
  - For conv2d, check if the config attribute has been set. If set, cast and pass it in. If not, read the op property (previous behaviour)
- Add unit tests to ensure Conv2dConfig is being passed all the way to the TTNN op
  - Pass an illegal config and assert the op is illegal
  - Pass a config with higher CB usage than the default config and verify the constraints

### Checklist
- [X] New/Existing tests provide coverage for changes
