### PR TITLE
Uplift third_party/tt-metal to f50d050e2d0ce343b9766a3f8826c1975d0802e3 2025-04-17

### DIFF
--- a/runtime/lib/common/system_desc.cpp
+++ b/runtime/lib/common/system_desc.cpp
@@ -14,8 +14,8 @@
 #define FMT_HEADER_ONLY
 #include "eth_l1_address_map.h"
 #include "hostdevcommon/common_values.hpp"
-#include "llrt/hal.hpp"
 #include "tt-metalium/allocator.hpp"
+#include "tt-metalium/hal.hpp"
 #include "tt-metalium/host_api.hpp"
 #include "tt-metalium/mesh_device.hpp"
 
@@ -181,8 +181,7 @@ static std::unique_ptr<::tt::runtime::SystemDesc> getCurrentSystemDescImpl(
       ::tt::target::ChipCoord(0, 0, 0, 0)};
   ::flatbuffers::FlatBufferBuilder fbb;
 
-  std::uint32_t pcieAlignment =
-      ::tt::tt_metal::hal_ref.get_alignment(HalMemType::HOST);
+  std::uint32_t pcieAlignment = ::tt::tt_metal::hal::get_pcie_alignment();
 
   for (const ::tt::tt_metal::IDevice *device : devices) {
     size_t l1UnreservedBase =

--- a/runtime/lib/ttnn/operations/data_movement/pad.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/pad.cpp
@@ -22,7 +22,7 @@ void run(const ::tt::target::ttnn::PadOp *op, ProgramContext &context) {
 
   ::ttnn::Tensor out;
 
-  std::vector<std::pair<uint32_t, uint32_t>> padding;
+  ::ttnn::SmallVector<::ttnn::operations::data_movement::PadSpecDim> padding;
   for (uint32_t i = 0; i < op->padding()->size(); i += 2) {
     padding.emplace_back(op->padding()->Get(i), op->padding()->Get(i + 1));
   }

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "70883c9145a607b37adaca05a22e3a9ca2f61368")
+set(TT_METAL_VERSION "f50d050e2d0ce343b9766a3f8826c1975d0802e3")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the f50d050e2d0ce343b9766a3f8826c1975d0802e3

- Remove reference to hal_ref after metal change 760ad8f
- Update pad op padding datatype after metal change fa45df9