### PR TITLE
Fix shlo constant op rewriter (slowdown seen in tt-torch ops)

### DIFF
--- a/test/ttmlir/Conversion/StableHLOToTTIR/constant_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/constant_op.mlir
@@ -346,6 +346,13 @@ module @jit_constant attributes {} {
     // CHECK: return %{{[0-9]+}} : tensor<1x2xbf16>
     return %0 : tensor<1x2xbf16>
   }
+
+  func.func @test_big_splat() -> tensor<1x19200x256xbf16> {
+    // CHECK: %[[CONSTANT:[0-9]+]] = "ttir.constant"() <{value = dense<1.000000e+00> : tensor<1x19200x256xbf16>}> : () -> tensor<1x19200x256xbf16>
+    %0 = stablehlo.constant dense<1.000000e+00> : tensor<1x19200x256xbf16>
+    // CHECK: return %[[CONSTANT]] : tensor<1x19200x256xbf16>
+    return %0: tensor<1x19200x256xbf16>
+  }
 }
 {-#
     dialect_resources: {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/2988

### Problem description
 - With recent commit fc6cfdad28918ce0d75da8f6f96c9357fbb97a56 which moves type conversion from stable hlo to ttmlir, dropped special case: `value` ElementAttr of `shlo.constant` op needs to be rewritten only in case we are dealing with a scalar. Current code rewrites this attribute regardless if we are dealing with scalar or shaped tensor. 
 
 ### What's changed
 - This PR address this by skipping `value` attr rewrite in case its shaped type, like previous code.

### Checklist
- Bunch of problematic gelu ops in tt-torch models, new test
- Note: One thing to note (and this was the case with old code), if we have splat value which is 1 bit or 64 bits rewrites will take long time also. True with previous version of code too, not fixed here.

closes #2988 