### PR TITLE
Added TT_DEBUG_DUMP_RATE

### DIFF
--- a/include/ttmlir/Target/Common/debug_info.fbs
+++ b/include/ttmlir/Target/Common/debug_info.fbs
@@ -30,4 +30,5 @@ table DebugInfo {
   cpp: string;
   mlir_stages: [MLIR];
   golden_info: GoldenInfo;
+  dump_device_rate: uint32;
 }

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -2145,9 +2145,17 @@ std::shared_ptr<void> ttnnToFlatbuffer(
     moduleCacheList.push_back(moduleCacheItem);
   }
 
+  const char *env = std::getenv("TT_DEBUG_DUMP_RATE");
+  std::uint32_t TT_DEBUG_DUMP_RATE;
+  if (env) {
+    TT_DEBUG_DUMP_RATE = std::stoi(env);
+  } else {
+    TT_DEBUG_DUMP_RATE = 1000;
+  }
+
   auto goldenInfo = ::tt::target::CreateGoldenInfoDirect(fbb, &goldenKVList);
   auto debugInfo = ::tt::target::CreateDebugInfoDirect(
-      fbb, mlir, cpp.c_str(), &moduleCacheList, goldenInfo);
+      fbb, mlir, cpp.c_str(), &moduleCacheList, goldenInfo, TT_DEBUG_DUMP_RATE);
 
   std::vector<::flatbuffers::Offset<::tt::target::ttnn::Program>> programs;
   module->walk([&](func::FuncOp func) {

--- a/runtime/lib/ttnn/program.cpp
+++ b/runtime/lib/ttnn/program.cpp
@@ -115,8 +115,7 @@ public:
                    const ::tt::target::ttnn::Operation *opContext,
                    ProgramContext *programContext);
 
-  void dumpPerfCountersIfNeeded(::ttnn::MeshDevice &meshDevice,
-                                std::uint32_t sampleRate = 1000);
+  void dumpPerfCountersIfNeeded(::ttnn::MeshDevice &meshDevice);
 
   void execute() {
     for (const ::tt::target::ttnn::Operation *op : *program->operations()) {
@@ -162,11 +161,10 @@ void ProgramExecutor::runCallback(
   }
 }
 
-void ProgramExecutor::dumpPerfCountersIfNeeded(::ttnn::MeshDevice &meshDevice,
-                                               std::uint32_t sampleRate) {
+void ProgramExecutor::dumpPerfCountersIfNeeded(::ttnn::MeshDevice &meshDevice) {
 #if defined(TT_RUNTIME_ENABLE_PERF_TRACE)
   static uint32_t counter = 0;
-  if (counter++ >= sampleRate) {
+  if (counter++ >= program->debug_info()->dump_device_rate()) {
     LOG_DEBUG(LogType::LogRuntimeTTNN, "Dumping device profile results after " +
                                            std::to_string(counter) +
                                            " operations");


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/2876)

### Problem description
ttrt's dump device rate is not accessible.

### What's changed
Added environment variable TT_DEBUG_DUMP_RATE to enable easy changes of dump frequency.

### Checklist
- [ ] New/Existing tests provide coverage for changes
