### PR TITLE
Changes required to use tt-mlir dialects out-of-tree

### DIFF
--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(ttmlir_cmake_builddir "${CMAKE_BINARY_DIR}/lib/cmake/ttmlir")
 
-set_property(GLOBAL APPEND PROPERTY TTMLIR_EXPORTS "MLIRTTDialect;MLIRTTNNDialect;TTMLIRTTNNUtils;MLIRTTKernelDialect;MLIRTTMetalDialect;")
+set_property(GLOBAL APPEND PROPERTY TTMLIR_EXPORTS "MLIRTTDialect;MLIRTTNNDialect;TTMLIRTTNNUtils;MLIRTTKernelDialect;MLIRTTMetalDialect;TTNNOpModelLib;coverage_config")
 get_property(TTMLIR_EXPORTS GLOBAL PROPERTY TTMLIR_EXPORTS)
 export(TARGETS ${TTMLIR_EXPORTS} FILE ${ttmlir_cmake_builddir}/TTMLIRTargets.cmake)
 

--- a/lib/Dialect/TTKernel/IR/CMakeLists.txt
+++ b/lib/Dialect/TTKernel/IR/CMakeLists.txt
@@ -12,4 +12,5 @@ add_mlir_dialect_library(MLIRTTKernelDialect
 
         LINK_LIBS PUBLIC
         MLIRTTMetalDialect
+        MLIRTTDialect
         )

--- a/lib/Dialect/TTMetal/IR/CMakeLists.txt
+++ b/lib/Dialect/TTMetal/IR/CMakeLists.txt
@@ -9,4 +9,5 @@ add_mlir_dialect_library(MLIRTTMetalDialect
         DEPENDS
         MLIRTTMetalOpsIncGen
         MLIRTTOpsIncGen
+        MLIRSupport
         )


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
While trying to set up an out-of-tree pass that lowers to TTKernel and TTMetal dialects. Linking failed as it was not able to   find the definitions for MemorySpaceAttr, MetalLayoutAttr, TypeIDResolver, etc.


And another error while finding the TTMLIRConfig:
```
CMake Error at CMakeLists.txt:27 (find_package):
  Found package configuration file:

    ../tt-mlir/build/lib/cmake/ttmlir/TTMLIRConfig.cmake

  but it set TTMLIR_FOUND to FALSE so package "TTMLIR" is considered to be
  NOT FOUND.  Reason given by package:

  The following imported targets are referenced, but are missing:
  TTNN::TTNNOpModelLib
 ```

### What's changed
Export `TTNNOpModelLib` and `coverage_config` as part of `TTMLIR_EXPORTS`.
Set right dependencies for `MLIRTTKernelDialect` and `MLIRTTMetalDialect`

### Checklist
- [ ] New/Existing tests provide coverage for changes
