### PR TITLE
Speedup build for both local and CI

### DIFF
--- a/.github/actions/build-tt-mlir-action/action.yaml
+++ b/.github/actions/build-tt-mlir-action/action.yaml
@@ -40,6 +40,17 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Setup Metal CPM Cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/.cpm_cache
+        key: metal-cpm-cache
+
+    - name: Set Metal CPM Cache Environment Variable
+      shell: bash
+      run: |
+        mkdir -p ${{ github.workspace }}/.cpm_cache
+        echo "CPM_SOURCE_CACHE=${{ github.workspace }}/.cpm_cache" >> $GITHUB_ENV
 
     - name: Configure CMake
       shell: bash
@@ -64,7 +75,9 @@ runs:
       shell: bash
       run: |
         source env/activate
+        ccache -z
         cmake --build ${{ inputs.build-output-dir }}
+        ccache -s
 
     - name: Build ttrt
       shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,19 @@ endif()
 
 add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wno-unused-parameter --system-header-prefix=ENV{TTMLIR_TOOLCHAIN_DIR})
 
+set(CMAKE_LINKER_TYPE DEFAULT)
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  execute_process(COMMAND ${CMAKE_CXX_COMPILER} --version OUTPUT_VARIABLE CLANG_VERSION_INFO ERROR_QUIET)
+  string(REGEX MATCH "version ([0-9]+)\\.[0-9]+" CLANG_VERSION "${CLANG_VERSION_INFO}")
+  set(LLD_EXECUTABLE "lld-${CMAKE_MATCH_1}")
+  set(LD_LLD_EXECUTABLE "ld.lld-${CMAKE_MATCH_1}")
+  find_program(LLD NAMES ${LLD_EXECUTABLE} ${LD_LLD_EXECUTABLE})
+  if(LLD)
+    message(STATUS "Using linker: ${LLD}")
+    set(CMAKE_LINKER_TYPE LLD)
+  endif()
+endif()
+
 include(TTMLIRBuildTypes)
 
 if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -17,6 +17,13 @@ else()
   message(FATAL_ERROR "Unsupported ARCH_NAME: $ENV{ARCH_NAME}")
 endif()
 
+if (DEFINED ENV{CPM_SOURCE_CACHE})
+  set(CPM_SOURCE_CACHE $ENV{CPM_SOURCE_CACHE})
+else()
+  set(CPM_SOURCE_CACHE "${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache")
+endif()
+message(STATUS "Setting tt-metal CPM cache to: ${CPM_SOURCE_CACHE}")
+
 set(METAL_INSTALL_PREFIX "${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal-build/")
 set(TTMETAL_INCLUDE_DIRS
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/ttnn
@@ -38,15 +45,15 @@ set(TTMETAL_INCLUDE_DIRS
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_stl/tt_stl
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_eager
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal-build/include
-  ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/reflect/e75434c4c5f669e4a74e4d84e0a30d7249c1e66f
-  ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/nanomsg/28cc32d5bdb6a858fe53b3ccf7e923957e53eada/include
-  ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/fmt/73b5ec45edbd92babfd91c3777a9e1ab9cac8238/include
-  ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/magic_enum/4d76fe0a5b27a0e62d6c15976d02b33c54207096/include
-  ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/boost/1359e136761ab2d10afa1c4e21086c8d824735cd/libs/core/include
-  ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/nlohmann_json/798e0374658476027d9723eeb67a262d0f3c8308/include
-  ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/xtensor/4a957e26c765b48cbec4a4235fe9e518d5a85d3d/include
-  ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/xtensor-blas/190c3a4314355b67291a7d78b20a2100de3f8f54/include
-  ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/xtl/0918808959d33a292c551b9f014a0e808bc4a95c/include
+  ${CPM_SOURCE_CACHE}/reflect/e75434c4c5f669e4a74e4d84e0a30d7249c1e66f
+  ${CPM_SOURCE_CACHE}/nanomsg/28cc32d5bdb6a858fe53b3ccf7e923957e53eada/include
+  ${CPM_SOURCE_CACHE}/fmt/73b5ec45edbd92babfd91c3777a9e1ab9cac8238/include
+  ${CPM_SOURCE_CACHE}/magic_enum/4d76fe0a5b27a0e62d6c15976d02b33c54207096/include
+  ${CPM_SOURCE_CACHE}/boost/1359e136761ab2d10afa1c4e21086c8d824735cd/libs/core/include
+  ${CPM_SOURCE_CACHE}/nlohmann_json/798e0374658476027d9723eeb67a262d0f3c8308/include
+  ${CPM_SOURCE_CACHE}/xtensor/4a957e26c765b48cbec4a4235fe9e518d5a85d3d/include
+  ${CPM_SOURCE_CACHE}/xtensor-blas/190c3a4314355b67291a7d78b20a2100de3f8f54/include
+  ${CPM_SOURCE_CACHE}/xtl/0918808959d33a292c551b9f014a0e808bc4a95c/include
   PARENT_SCOPE
 )
 
@@ -90,6 +97,8 @@ ExternalProject_Add(
     -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
     -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
     -DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}
+    -DCMAKE_LINKER_TYPE=${CMAKE_LINKER_TYPE}
+    -DCPM_SOURCE_CACHE=${CPM_SOURCE_CACHE}
     -DENABLE_CCACHE=${TTMETAL_ENABLE_CCACHE}
     -DCMAKE_DISABLE_PRECOMPILE_HEADERS=${TTMETAL_DISABLE_PRECOMPILE_HEADERS}
     -DENABLE_TRACY=${TT_RUNTIME_ENABLE_PERF_TRACE}

--- a/tools/ttnn-standalone/CMakeLists.txt
+++ b/tools/ttnn-standalone/CMakeLists.txt
@@ -53,18 +53,25 @@ endif()
 
 message($ENV{TT_METAL_HOME}/tt_metal/third_party/src/firmware/riscv/$ENV{ARCH_NAME})
 
+if (DEFINED ENV{CPM_SOURCE_CACHE})
+  set(CPM_SOURCE_CACHE $ENV{CPM_SOURCE_CACHE})
+else()
+  set(CPM_SOURCE_CACHE $ENV{TT_METAL_HOME}/.cpmcache)
+endif()
+message(STATUS "Setting tt-metal CPM cache to: ${CPM_SOURCE_CACHE}")
+
 # Directories to search for headers
 #
 set(INCLUDE_DIRS
     # TODO: Remove these when ttmetal removes the dependencies from public facing headers
-    $ENV{TT_METAL_HOME}/.cpmcache/reflect/e75434c4c5f669e4a74e4d84e0a30d7249c1e66f
-    $ENV{TT_METAL_HOME}/.cpmcache/fmt/73b5ec45edbd92babfd91c3777a9e1ab9cac8238/include
-    $ENV{TT_METAL_HOME}/.cpmcache/magic_enum/4d76fe0a5b27a0e62d6c15976d02b33c54207096/include
-    $ENV{TT_METAL_HOME}/.cpmcache/boost/1359e136761ab2d10afa1c4e21086c8d824735cd/libs/core/include
-    $ENV{TT_METAL_HOME}/.cpmcache/nlohmann_json/798e0374658476027d9723eeb67a262d0f3c8308/include
-    $ENV{TT_METAL_HOME}/.cpmcache/xtensor/4a957e26c765b48cbec4a4235fe9e518d5a85d3d/include
-    $ENV{TT_METAL_HOME}/.cpmcache/xtensor-blas/190c3a4314355b67291a7d78b20a2100de3f8f54/include
-    $ENV{TT_METAL_HOME}/.cpmcache/xtl/0918808959d33a292c551b9f014a0e808bc4a95c/include
+    ${CPM_SOURCE_CACHE}/reflect/e75434c4c5f669e4a74e4d84e0a30d7249c1e66f
+    ${CPM_SOURCE_CACHE}/fmt/73b5ec45edbd92babfd91c3777a9e1ab9cac8238/include
+    ${CPM_SOURCE_CACHE}/magic_enum/4d76fe0a5b27a0e62d6c15976d02b33c54207096/include
+    ${CPM_SOURCE_CACHE}/boost/1359e136761ab2d10afa1c4e21086c8d824735cd/libs/core/include
+    ${CPM_SOURCE_CACHE}/nlohmann_json/798e0374658476027d9723eeb67a262d0f3c8308/include
+    ${CPM_SOURCE_CACHE}/xtensor/4a957e26c765b48cbec4a4235fe9e518d5a85d3d/include
+    ${CPM_SOURCE_CACHE}/xtensor-blas/190c3a4314355b67291a7d78b20a2100de3f8f54/include
+    ${CPM_SOURCE_CACHE}/xtl/0918808959d33a292c551b9f014a0e808bc4a95c/include
 
     # Metalium
     $ENV{TT_METAL_HOME}


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Building the tt-mlir repo takes a long time (sometimes over 30 min on CI), especially for a fresh build

### What's changed
When clang is used as the compiler, try to find and use the matching lld linker
The same linker is passed to the tt-metal external project as well
Detect the `CPM_SOURCE_CACHE` environment variable and pass it to the tt-metal build command, so we don't re-download the 1.4 GB tt-metal external dependencies every time, if the environment variable is set to some out-of-tree location
Set up persistent cmake CPM cache in the CI

### Checklist
- [x] New/Existing tests provide coverage for changes
