### PR TITLE
Fixes for wheel-build run to integrate with tt-forge releases

### DIFF
--- a/.github/workflows/wheel-build.yml
+++ b/.github/workflows/wheel-build.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       # Use the provided docker image from workflow_call or build our own for direct triggers
-      image: ${{ inputs.docker-image != '' && inputs.docker-image || 'ghcr.io/tenstorrent/tt-mlir-dev:latest' }}
+      image: ${{ inputs.docker-image != '' && inputs.docker-image || 'ghcr.io/tenstorrent/tt-mlir/tt-mlir-ci-ubuntu-22-04:latest' }}
 
     steps:
       - name: Maximize space

--- a/.github/workflows/wheel-build.yml
+++ b/.github/workflows/wheel-build.yml
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       # Use the provided docker image from workflow_call or build our own for direct triggers
-      image: ${{ inputs.docker-image != '' && inputs.docker-image || 'ghcr.io/tenstorrent/tt-mlir-dev:latest' }}
+      image: ${{ inputs.docker-image != '' && inputs.docker-image || 'ghcr.io/tenstorrent/tt-mlir/tt-mlir-ci-ubuntu-22-04:latest' }}
 
     steps:
       - uses: actions/checkout@v4

--- a/python/setup.py
+++ b/python/setup.py
@@ -85,7 +85,7 @@ date = (
     .decode("ascii")
     .strip()
 )
-version = "0.1." + date + "+dev." + short_hash
+version = "0.1." + date + ".dev0"
 
 # Only the ttmlir package relies on the CMake build process
 ttmlir_c = TTExtension("ttmlir")


### PR DESCRIPTION
### Problem description
- Issues with how `tt-forge` will integrate with artifacts from wheel-build.

### What's changed
- Fixed Default Docker Image for `workflow-dispatch` runs.
