### PR TITLE
Fix bug in parsing mesh_shard op

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/ShardingUtils.cpp
+++ b/lib/Conversion/StableHLOToTTIR/ShardingUtils.cpp
@@ -444,7 +444,7 @@ void MeshSharding::extractMeshShardingFromTensorMeshShardingAttr(
 
   auto axes = tensorMeshShardingAttr.getTensorMeshShardingAxis();
   shardShape.resize(axes.size());
-  shardDims.resize(axes.size(), -1);
+  shardDims.resize(meshShape.size(), -1);
   for (auto [dim, axis] : llvm::enumerate(axes)) {
     shardShape[dim] = axis.getShardShape();
     for (auto deviceDim : axis.getAxes()) {

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -1870,7 +1870,7 @@ public:
         auto fullToShardCustomCall =
             mlir::dyn_cast_if_present<mlir::stablehlo::CustomCallOp>(
                 *srcOp->user_begin());
-        if (!fullToShardCustomCall || !fullToShardCustomCall->hasOneUse()) {
+        if (!fullToShardCustomCall || !srcOp->hasOneUse()) {
           return failure();
         }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/3035

### Problem description
Bug 1. shard_dims should have the size of meshShape but has size of input tensor shape
Bug 2. checking custom_call op with stablehlo should confirm one use of current op not following custom_call op.

### What's changed
Fix 1. change the shape of shard_dims using meshShape.
Fix 2. checking srcOp use instead of following custom_call op's uses.

### Checklist
- [X] New/Existing tests provide coverage for changes
