### PR TITLE
[tt-explorer] Update graph id to be based on the file name

### DIFF
--- a/tools/explorer/tt_adapter/src/tt_adapter/main.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/main.py
@@ -189,7 +189,7 @@ class TTAdapter(model_explorer.Adapter):
 
             # Convert TTIR to Model Explorer Graphs and Display/Return
             graph, overlays = mlir.build_graph(
-                module, perf_trace, memory_trace, golden_results
+                model_path, module, perf_trace, memory_trace, golden_results
             )
 
             if overlays:
@@ -213,7 +213,7 @@ class TTAdapter(model_explorer.Adapter):
                     module = utils.parse_mlir_str(model_file.read())
 
             # Convert TTIR to Model Explorer Graphs and Display/Return
-            graph, _ = mlir.build_graph(module)
+            graph, _ = mlir.build_graph(model_path, module)
 
         return {"graphs": [graph]}
 

--- a/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
@@ -847,7 +847,7 @@ FILTERED_OPS = [
 
 
 def build_graph(module_path: str, module, perf_trace=None, memory_trace=None, golden_results=None):
-    graph_id = f"TT Graph: {Path(module_path).stem}"
+    graph_id = Path(module_path).name
     output_connections = defaultdict(int)
     graph = graph_builder.Graph(id=graph_id)
 

--- a/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Utility library for parsing MLIR
 import re
+from pathlib import Path
 from collections import defaultdict
 from model_explorer import graph_builder, node_data_builder
 
@@ -845,9 +846,10 @@ FILTERED_OPS = [
 ]
 
 
-def build_graph(module, perf_trace=None, memory_trace=None, golden_results=None):
+def build_graph(module_path: str, module, perf_trace=None, memory_trace=None, golden_results=None):
+    graph_id = f"TT Graph: {Path(module_path).stem}"
     output_connections = defaultdict(int)
-    graph = graph_builder.Graph(id="tt-graph")
+    graph = graph_builder.Graph(id=graph_id)
 
     op_to_graph_node = {}
     # Track operands already added to graph to avoid duplicates
@@ -941,7 +943,7 @@ def build_graph(module, perf_trace=None, memory_trace=None, golden_results=None)
             results=perf_node_data, gradient=gradient
         )
         overlays["perf_data"] = node_data_builder.ModelNodeData(
-            graphsData={"tt-graph": graph_node_data}
+            graphsData={graph_id: graph_node_data}
         ).graphsData
 
     if accuracy_node_data:
@@ -955,7 +957,7 @@ def build_graph(module, perf_trace=None, memory_trace=None, golden_results=None)
             results=accuracy_node_data, thresholds=thres
         )
         overlays["accuracy_data"] = node_data_builder.ModelNodeData(
-            graphsData={"tt-graph": graph_node_data}
+            graphsData={graph_id: graph_node_data}
         ).graphsData
 
     OpHandler.schedule = 0

--- a/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
@@ -846,7 +846,9 @@ FILTERED_OPS = [
 ]
 
 
-def build_graph(module_path: str, module, perf_trace=None, memory_trace=None, golden_results=None):
+def build_graph(
+    module_path: str, module, perf_trace=None, memory_trace=None, golden_results=None
+):
     graph_id = Path(module_path).name
     output_connections = defaultdict(int)
     graph = graph_builder.Graph(id=graph_id)


### PR DESCRIPTION
Change the graph id, so it is based on the file name instead of the hard coded `tt-graph`.

Resolves: https://github.com/tenstorrent/model-explorer/issues/37, https://github.com/tenstorrent/model-explorer/issues/43

Relates to: https://github.com/tenstorrent/model-explorer/pull/44