### PR TITLE
CumSumOp negative axis index attr

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -1122,6 +1122,8 @@ def TTIR_CumSumOp : TTIR_NamedOp<"cumsum"> {
   let results = (outs AnyRankedTensor:$result);
 
   let hasVerifier = 1;
+
+  let hasFolder = 1;
 }
 
 def TTIR_SoftmaxOp : TTIR_NamedOp<"softmax"> {

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -3814,7 +3814,7 @@ verifyReduceOp(llvm::function_ref<mlir::InFlightDiagnostic()> emitOpError,
 
 // CumSumOp verification
 ::mlir::LogicalResult mlir::tt::ttir::CumSumOp::verify() {
-  int64_t dim = getDimAttr().getSInt();
+  int64_t dim = getDim();
   int64_t inputRank = getInput().getType().getRank();
   if (dim < -inputRank || dim >= inputRank) {
     return emitOpError() << "specified dimension should be between "
@@ -3828,7 +3828,7 @@ verifyReduceOp(llvm::function_ref<mlir::InFlightDiagnostic()> emitOpError,
 // CumSumOp folding
 ::mlir::OpFoldResult mlir::tt::ttir::CumSumOp::fold(FoldAdaptor adaptor) {
   // Normalize `dim` to be in range [0, rank).
-  int64_t dim = getDimAttr().getSInt();
+  int64_t dim = getDim();
   int64_t rank = getInput().getType().getRank();
   if (dim < 0) {
     setDim(dim + rank);

--- a/test/ttmlir/Dialect/TTIR/cumsum/cumsum_test_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/cumsum/cumsum_test_negative.mlir
@@ -3,9 +3,9 @@
 
 module attributes {} {
   func.func public @test_moreh_cumsum_neg_dim(%arg0: tensor<1x32x128x128xbf16>) -> tensor<1x32x128x128xbf16> {
-    // CHECK: error: 'ttir.cumsum' op specified dimension should be between 0 and 3, but got: -2.
+    // CHECK: error: 'ttir.cumsum' op specified dimension should be between -4 and 3, but got: -6
     %0 = ttir.empty() : tensor<1x32x128x128xbf16>
-    %1 = "ttir.cumsum"(%arg0, %0) <{dim = -2 : i64}> : (tensor<1x32x128x128xbf16>, tensor<1x32x128x128xbf16>) -> tensor<1x32x128x128xbf16>
+    %1 = "ttir.cumsum"(%arg0, %0) <{dim = -6 : i64}> : (tensor<1x32x128x128xbf16>, tensor<1x32x128x128xbf16>) -> tensor<1x32x128x128xbf16>
     return %1 : tensor<1x32x128x128xbf16>
   }
 }
@@ -14,7 +14,7 @@ module attributes {} {
 
 module attributes {} {
   func.func public @test_moreh_cumsum_high_dim(%arg0: tensor<1x32x128xbf16>) -> tensor<1x32x128xbf16> {
-    // CHECK: error: 'ttir.cumsum' op specified dimension should be between 0 and 2, but got: 4.
+    // CHECK: error: 'ttir.cumsum' op specified dimension should be between -3 and 2, but got: 4
     %0 = ttir.empty() : tensor<1x32x128xbf16>
     %1 = "ttir.cumsum"(%arg0, %0) <{dim = 4 : i64}> : (tensor<1x32x128xbf16>, tensor<1x32x128xbf16>) -> tensor<1x32x128xbf16>
     return %1 : tensor<1x32x128xbf16>

--- a/test/ttmlir/Dialect/TTNN/simple_cumsum.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_cumsum.mlir
@@ -44,4 +44,26 @@ module @moreh_cumsum attributes {} {
     %1 = "ttir.cumsum"(%arg0, %0) <{dim = 3 : i64}> : (tensor<4x4x128x128xf32>, tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32>
     return %1 : tensor<4x4x128x128xf32>
   }
+
+  func.func public @test_moreh_cumsum_neg_dim2(%arg0: tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32> {
+    // CHECK-LABEL: func.func public @test_moreh_cumsum_neg_dim2
+    %0 = ttir.empty() : tensor<4x4x128x128xf32>
+    // CHECK: ttnn.moreh_cumsum
+    // CHECK-SAME: dim = 2 : i64
+    // CHECK-SAME: tensor<4x4x128x128xf32,
+    // CHECK-SAME: -> tensor<4x4x128x128xf32,
+    %1 = "ttir.cumsum"(%arg0, %0) <{dim = -2 : i64}> : (tensor<4x4x128x128xf32>, tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32>
+    return %1 : tensor<4x4x128x128xf32>
+  }
+
+  func.func public @test_moreh_cumsum_neg_dim3(%arg0: tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32> {
+    // CHECK-LABEL: func.func public @test_moreh_cumsum_neg_dim3
+    %0 = ttir.empty() : tensor<4x4x128x128xf32>
+    // CHECK: ttnn.moreh_cumsum
+    // CHECK-SAME: dim = 1 : i64
+    // CHECK-SAME: tensor<4x4x128x128xf32,
+    // CHECK-SAME: -> tensor<4x4x128x128xf32,
+    %1 = "ttir.cumsum"(%arg0, %0) <{dim = -3 : i64}> : (tensor<4x4x128x128xf32>, tensor<4x4x128x128xf32>) -> tensor<4x4x128x128xf32>
+    return %1 : tensor<4x4x128x128xf32>
+  }
 }


### PR DESCRIPTION
### Ticket
Part of the https://github.com/tenstorrent/tt-mlir/issues/3053

### Problem description
CumSumOp assumed that axis index attribute will be in the range [0, rank).

### What's changed
Relaxed the condition so it now accepts axis index in the range [-rank, rank) on the input and normalize that range to [0, rank) as a part of the folding.

### Checklist
- [x] New/Existing tests provide coverage for changes
