### PR TITLE
Create API for prepare conv2d weight output

### DIFF
--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -9,10 +9,9 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 
+#include "mlir/IR/BuiltinTypes.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/Error.h"
-
-#include "mlir/IR/BuiltinTypes.h"
 #include <tuple>
 
 namespace mlir::tt::op_model::ttnn {
@@ -21,9 +20,9 @@ namespace mlir::tt::op_model::ttnn {
 bool isLayoutLegalForTensorShape(llvm::ArrayRef<int64_t> tensorShape,
                                  mlir::tt::ttnn::TTNNLayoutAttr layout);
 
-// Calculate the output tensor of the prepared weights for a conv2d op.
+// Calculate the output tensor type of the prepared weights for a conv2d op.
 mlir::RankedTensorType
-getPreparedConv2dWeightsOutput(mlir::tt::ttnn::Conv2dOp *op);
+getPreparedConv2dWeightsOutputTensor(mlir::tt::ttnn::Conv2dOp *op);
 
 //===----------------------------------------------------------------------===//
 // Device
@@ -277,12 +276,12 @@ getOpConstraints(GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr weightLayout,
                  std::optional<llvm::ArrayRef<int64_t>> biasShape,
                  std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
-                 int32_t in_channels, int32_t out_channels, int32_t batch_size,
-                 int32_t input_height, int32_t input_width,
-                 llvm::ArrayRef<int32_t> kernel_size,
+                 uint32_t in_channels, uint32_t out_channels,
+                 uint32_t batch_size, uint32_t input_height,
+                 uint32_t input_width, llvm::ArrayRef<int32_t> kernel_size,
                  llvm::ArrayRef<int32_t> stride,
                  llvm::ArrayRef<int32_t> padding,
-                 llvm::ArrayRef<int32_t> dilation, int32_t groups,
+                 llvm::ArrayRef<int32_t> dilation, uint32_t groups,
                  std::optional<mlir::tt::ttnn::Conv2dConfigAttr> conv2dConfig,
                  llvm::ArrayRef<int64_t> outputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
@@ -294,11 +293,11 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
              mlir::tt::ttnn::TTNNLayoutAttr weightLayout,
              std::optional<llvm::ArrayRef<int64_t>> biasShape,
              std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
-             int32_t in_channels, int32_t out_channels, int32_t batch_size,
-             int32_t input_height, int32_t input_width,
+             uint32_t in_channels, uint32_t out_channels, uint32_t batch_size,
+             uint32_t input_height, uint32_t input_width,
              llvm::ArrayRef<int32_t> kernel_size,
              llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
-             llvm::ArrayRef<int32_t> dilation, int32_t groups,
+             llvm::ArrayRef<int32_t> dilation, uint32_t groups,
              std::optional<mlir::tt::ttnn::Conv2dConfigAttr> conv2dConfig,
              llvm::ArrayRef<int64_t> outputShape,
              mlir::tt::ttnn::TTNNLayoutAttr outputLayout);

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -6,11 +6,13 @@
 #define TTMLIR_OPMODEL_TTNN_TTNNOPMODEL_H
 
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpModelInterface.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/Error.h"
 
+#include "mlir/IR/BuiltinTypes.h"
 #include <tuple>
 
 namespace mlir::tt::op_model::ttnn {
@@ -18,6 +20,10 @@ namespace mlir::tt::op_model::ttnn {
 // Checks if the tensor layout is legal for the given tensor shape.
 bool isLayoutLegalForTensorShape(llvm::ArrayRef<int64_t> tensorShape,
                                  mlir::tt::ttnn::TTNNLayoutAttr layout);
+
+// Calculate the output tensor of the prepared weights for a conv2d op.
+mlir::RankedTensorType
+getPreparedConv2dWeightsOutput(mlir::tt::ttnn::Conv2dOp *op);
 
 //===----------------------------------------------------------------------===//
 // Device

--- a/lib/OpModel/TTNN/MetalHeaders.h
+++ b/lib/OpModel/TTNN/MetalHeaders.h
@@ -68,6 +68,7 @@ using IDevice = ::tt::tt_metal::IDevice;
 #include "ttnn/graph/graph_query_op_runtime.hpp"
 #include "ttnn/graph/graph_trace_utils.hpp"
 #include "ttnn/operations/conv/conv2d/conv2d.hpp"
+#include "ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp"
 #include "ttnn/operations/copy.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/data_movement/reshape_view/reshape.hpp"

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -614,10 +614,24 @@ TEST_F(OpModelBase, Conv2dInterface) {
       ttnn::MeshOffsetAttr::get(builder.getContext(), 0, 0));
 
   Conv2dOp conv2d = builder.create<Conv2dOp>(
-      builder.getUnknownLoc(), outputType, input, weight, nullptr, deviceOp, 3,
-      64, 1, 224, 224, llvm::ArrayRef<int32_t>({7, 7}),
-      llvm::ArrayRef<int32_t>({2, 2}), llvm::ArrayRef<int32_t>({3, 3}),
-      llvm::ArrayRef<int32_t>({1, 1}), 1, nullptr);
+      builder.getUnknownLoc(),         // Location
+      outputType,                      // Output type
+      input,                           // Input tensor
+      weight,                          // Weight tensor
+      nullptr,                         // Bias tensor (optional)
+      deviceOp,                        // Device operation
+      3,                               // Input channels
+      64,                              // Output channels
+      1,                               // Batch size
+      224,                             // Input height
+      224,                             // Input width
+      llvm::ArrayRef<int32_t>({7, 7}), // Kernel size [H, W]
+      llvm::ArrayRef<int32_t>({2, 2}), // Stride [H, W]
+      llvm::ArrayRef<int32_t>({3, 3}), // Padding [H, W]
+      llvm::ArrayRef<int32_t>({1, 1}), // Dilation [H, W]
+      1,                               // Groups
+      nullptr                          // Padding mode (optional)
+  );
 
   // Device hangs otherwise.
   mlir::tt::op_model::ttnn::SingletonDeviceContext::resetInstance();
@@ -663,10 +677,24 @@ TEST_F(OpModelBase, Conv2dInterfaceNullOutput) {
       ttnn::MeshOffsetAttr::get(builder.getContext(), 0, 0));
 
   Conv2dOp conv2d = builder.create<Conv2dOp>(
-      builder.getUnknownLoc(), outputType, input, weight, nullptr, deviceOp, 3,
-      64, 1, 224, 224, llvm::ArrayRef<int32_t>({7, 7}),
-      llvm::ArrayRef<int32_t>({2, 2}), llvm::ArrayRef<int32_t>({3, 3}),
-      llvm::ArrayRef<int32_t>({1, 1}), 1, nullptr);
+      builder.getUnknownLoc(),         // Location
+      outputType,                      // Output type
+      input,                           // Input tensor
+      weight,                          // Weight tensor
+      nullptr,                         // Bias tensor (optional)
+      deviceOp,                        // Device operation
+      3,                               // Input channels
+      64,                              // Output channels
+      1,                               // Batch size
+      224,                             // Input height
+      224,                             // Input width
+      llvm::ArrayRef<int32_t>({7, 7}), // Kernel size [H, W]
+      llvm::ArrayRef<int32_t>({2, 2}), // Stride [H, W]
+      llvm::ArrayRef<int32_t>({3, 3}), // Padding [H, W]
+      llvm::ArrayRef<int32_t>({1, 1}), // Dilation [H, W]
+      1,                               // Groups
+      nullptr                          // Padding mode (optional)
+  );
 
   // Device hangs otherwise.
   mlir::tt::op_model::ttnn::SingletonDeviceContext::resetInstance();
@@ -722,7 +750,7 @@ TEST_F(OpModelBase, PrepareConv2dWeightsOutput) {
       llvm::ArrayRef<int32_t>({1, 1}), 1, nullptr);
 
   auto preparedWeightOutput =
-      mlir::tt::op_model::ttnn::getPreparedConv2dWeightsOutput(&conv2d);
+      mlir::tt::op_model::ttnn::getPreparedConv2dWeightsOutputTensor(&conv2d);
 
   auto preparedShape = preparedWeightOutput.getShape();
   llvm::SmallVector<int64_t> expectedShape = {1, 1, 147, 64};

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -630,7 +630,7 @@ TEST_F(OpModelBase, Conv2dInterface) {
       llvm::ArrayRef<int32_t>({3, 3}), // Padding [H, W]
       llvm::ArrayRef<int32_t>({1, 1}), // Dilation [H, W]
       1,                               // Groups
-      nullptr                          // Padding mode (optional)
+      nullptr                          // Conv2dConfig (optional)
   );
 
   // Device hangs otherwise.
@@ -693,7 +693,7 @@ TEST_F(OpModelBase, Conv2dInterfaceNullOutput) {
       llvm::ArrayRef<int32_t>({3, 3}), // Padding [H, W]
       llvm::ArrayRef<int32_t>({1, 1}), // Dilation [H, W]
       1,                               // Groups
-      nullptr                          // Padding mode (optional)
+      nullptr                          // Conv2dConfig (optional)
   );
 
   // Device hangs otherwise.

--- a/test/unittests/OpModel/TTNN/OpModelFixture.h
+++ b/test/unittests/OpModel/TTNN/OpModelFixture.h
@@ -41,16 +41,6 @@ public:
     mlir::tt::registerDevice(module.get());
   }
 
-  // helper function
-  llvm::SmallVector<int64_t>
-  GetTensorShapeInTiles(const llvm::ArrayRef<int64_t> &tensorShape) {
-    llvm::SmallVector<int64_t> shapeInTiles;
-    for (const auto &dim : tensorShape) {
-      shapeInTiles.push_back(ttmlir::utils::alignUp(dim, 32L));
-    }
-    return shapeInTiles;
-  }
-
   static llvm::SmallVector<int64_t> GetPhysicalGridSize() {
     llvm::SmallVector<int64_t> grid = {gridShapeHwN300[0], gridShapeHwN300[1]};
     return grid;
@@ -72,7 +62,7 @@ public:
       physicalShape[0] *= tilePaddedShape[i];
     }
     auto shapeInTiles = llvm::SmallVector<int64_t, 2>(
-        {physicalShape[0] / 32, physicalShape[1] / 32});
+        {physicalShape[0] / TILE_HEIGHT, physicalShape[1] / TILE_WIDTH});
 
     int64_t tensorTiles = 1;
     for (const auto &dim : physicalShape) {
@@ -189,6 +179,8 @@ public:
 
   static constexpr std::array<int64_t, 2> gridShapeHwN300 = {8, 8};
   static constexpr size_t workerCoresN300 = 64;
+  static constexpr int64_t TILE_HEIGHT = 32;
+  static constexpr int64_t TILE_WIDTH = 32;
 };
 
 #endif // UNITTESTS_OPMODEL_TTNN_OPMODELFIXTURE_H


### PR DESCRIPTION
### Problem description
PrepareConv2dWeightsOp has vary complex logic around calculating the resulting shape of the weights. This is dependent on the input memory config and Conv2dConfig params.

In order not to replicate this logic inside IR we call PrepareConv2dWeights with graph capture and read the resulting output TensorSpec.

### What's changed
* Add OpModel API to return output of prepared weights 
* Adjust conv2d constraint calls so that weights are prepared first

### Checklist
- [x] New/Existing tests provide coverage for changes
