### PR TITLE
Remove redundant context param from `with*` attribute member functions

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
@@ -160,8 +160,8 @@ def TTNN_MemoryConfigAttr : TTNN_Attr<"MemoryConfig", "memory_config"> {
 
   let extraClassDeclaration = [{
     llvm::ArrayRef<int64_t> getShardShape(bool convertTileToScalar = true) const;
-    MemoryConfigAttr withBufferType(::mlir::MLIRContext *context, BufferType bufferType);
-    MemoryConfigAttr withMemoryLayout(::mlir::MLIRContext *context, TensorMemoryLayout memLayout);
+    MemoryConfigAttr withBufferType(BufferType bufferType);
+    MemoryConfigAttr withMemoryLayout(TensorMemoryLayout memLayout);
   }];
 
   let genVerifyDecl = 1;
@@ -470,17 +470,16 @@ def TTNN_TTNNLayoutAttr: TTNN_Attr<"TTNNLayout", "ttnn_layout"> {
                         TensorMeshShardingAttr tensorMeshShardingAttr = nullptr,
                         ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}});
 
-    TTNNLayoutAttr withGrid(::mlir::MLIRContext *context, ArrayRef<int64_t> tensorShape, GridAttr grid, ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}});
-    TTNNLayoutAttr withGrid(::mlir::MLIRContext *context,
-                        RankedTensorType ty,
+    TTNNLayoutAttr withGrid(ArrayRef<int64_t> tensorShape, GridAttr grid, ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}});
+    TTNNLayoutAttr withGrid(RankedTensorType ty,
                         GridAttr grid,
                         ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}});
-    TTNNLayoutAttr withElementType(::mlir::MLIRContext *context, Type elementType, ArrayRef<int64_t> tensorShape, ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}});
-    TTNNLayoutAttr withBufferType(::mlir::MLIRContext *context, BufferType bufferType);
-    TTNNLayoutAttr withMemoryLayout(::mlir::MLIRContext *context, TensorMemoryLayoutAttr memLayoutAttr);
-    TTNNLayoutAttr withMemoryLayout(::mlir::MLIRContext *context, TensorMemoryLayout memLayout);
-    TTNNLayoutAttr withShardShape(::mlir::MLIRContext *context, llvm::SmallVector<int64_t> shardShape);
-    TTNNLayoutAttr withTensorShape(::mlir::MLIRContext *context, ArrayRef<int64_t> tensorShape);
+    TTNNLayoutAttr withElementType(Type elementType, ArrayRef<int64_t> tensorShape, ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}});
+    TTNNLayoutAttr withBufferType(BufferType bufferType);
+    TTNNLayoutAttr withMemoryLayout(TensorMemoryLayoutAttr memLayoutAttr);
+    TTNNLayoutAttr withMemoryLayout(TensorMemoryLayout memLayout);
+    TTNNLayoutAttr withShardShape(llvm::SmallVector<int64_t> shardShape);
+    TTNNLayoutAttr withTensorShape(ArrayRef<int64_t> tensorShape);
 
     bool isSystemBufferType() const { return ::mlir::tt::ttnn::isSystemBufferType(getBufferType()); }
     bool isDeviceBufferType() const { return ::mlir::tt::ttnn::isDeviceBufferType(getBufferType()); }

--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceOpsRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceOpsRewritePattern.h
@@ -78,7 +78,7 @@ private:
 
     TTNNLayoutAttr newOutputLayoutAttr =
         mlir::cast<TTNNLayoutAttr>(outputType.getEncoding())
-            .withTensorShape(rewriter.getContext(), outputShapeVec);
+            .withTensorShape(outputShapeVec);
 
     RankedTensorType newOutputType = RankedTensorType::get(
         outputShapeVec, outputType.getElementType(), newOutputLayoutAttr);

--- a/lib/Conversion/TTIRToTTNN/Utils.cpp
+++ b/lib/Conversion/TTIRToTTNN/Utils.cpp
@@ -23,7 +23,7 @@ ttnn::ReshapeOp generateReshape(mlir::TypedValue<mlir::RankedTensorType> input,
   ttnn::TTNNLayoutAttr inputLayoutAttr =
       mlir::cast<ttnn::TTNNLayoutAttr>(inputType.getEncoding());
   ttnn::TTNNLayoutAttr outputLayoutAttr =
-      inputLayoutAttr.withTensorShape(rewriter.getContext(), newShape);
+      inputLayoutAttr.withTensorShape(newShape);
 
   // Create a new output type for reshape operation with new shape and new
   // output layout.

--- a/lib/Dialect/TTNN/Analysis/DFShardingPolicy.cpp
+++ b/lib/Dialect/TTNN/Analysis/DFShardingPolicy.cpp
@@ -160,13 +160,10 @@ void DFShardingPolicy::run() {
                 TTNNLayoutAttr firstOpInputShardedLayout =
                     firstOpInputLayout
                         .withBufferType(
-                            currentOp->getContext(),
                             currentOpConfig.outputLayout.getBufferType())
                         .withMemoryLayout(
-                            currentOp->getContext(),
                             currentOpConfig.outputLayout.getMemLayout())
-                        .withGrid(currentOp->getContext(),
-                                  firstOpInputTensorType,
+                        .withGrid(firstOpInputTensorType,
                                   currentOpConfig.outputLayout.getGrid());
 
                 uint64_t firstInputL1Usage =

--- a/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
+++ b/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
@@ -237,9 +237,8 @@ bool ShardSolver::supportsInterleavedInputShardedOutput(Operation *op,
   TTNNLayoutAttr inputLayout = mlir::cast<TTNNLayoutAttr>(
       mlir::cast<RankedTensorType>(op->getOperand(0).getType()).getEncoding());
 
-  inputLayout =
-      inputLayout.withBufferType(op->getContext(), BufferType::DRAM)
-          .withMemoryLayout(op->getContext(), TensorMemoryLayout::Interleaved);
+  inputLayout = inputLayout.withBufferType(BufferType::DRAM)
+                    .withMemoryLayout(TensorMemoryLayout::Interleaved);
 
   llvm::Expected<bool> shardCompatible =
       checkShardCompatible(op->getOperand(0), inputLayout, op, outputConfig);

--- a/lib/Dialect/TTNN/Transforms/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/Optimizer.cpp
@@ -591,9 +591,8 @@ private:
 
       // Create a new tensor type with DRAM layout.
       TTNNLayoutAttr dramLayout =
-          layoutAttr.withBufferType(op->getContext(), BufferType::DRAM)
-              .withMemoryLayout(op->getContext(),
-                                TensorMemoryLayout::Interleaved);
+          layoutAttr.withBufferType(BufferType::DRAM)
+              .withMemoryLayout(TensorMemoryLayout::Interleaved);
       RankedTensorType newTensorType = RankedTensorType::get(
           tensorShape, tensorType.getElementType(), dramLayout);
 

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ArgMaxOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ArgMaxOpRewritePattern.cpp
@@ -50,7 +50,7 @@ ArgMaxOpRewritePattern::matchAndRewrite(ttnn::ArgMaxOp srcOp,
   // output type.
   ttnn::TTNNLayoutAttr newOutputLayoutAttr =
       mlir::cast<ttnn::TTNNLayoutAttr>(outputType.getEncoding())
-          .withTensorShape(rewriter.getContext(), argMaxOutputShape);
+          .withTensorShape(argMaxOutputShape);
   RankedTensorType newOutputType = RankedTensorType::get(
       argMaxOutputShape, outputType.getElementType(), newOutputLayoutAttr);
 

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/CumSumOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/CumSumOpRewritePattern.cpp
@@ -42,7 +42,7 @@ CumSumOpRewritePattern::matchAndRewrite(ttnn::MorehCumSumOp srcOp,
       mlir::RankedTensorType::Builder(inputType).setShape(reshapeOutputShape);
   ttnn::TTNNLayoutAttr newOutputLayoutAttr =
       mlir::cast<ttnn::TTNNLayoutAttr>(outputType.getEncoding())
-          .withTensorShape(rewriter.getContext(), reshapeOutputType.getShape());
+          .withTensorShape(reshapeOutputType.getShape());
   RankedTensorType newOutputType =
       RankedTensorType::get(reshapeOutputType.getShape(),
                             outputType.getElementType(), newOutputLayoutAttr);

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -161,13 +161,10 @@ workaroundOutputOperand(mlir::TypedValue<RankedTensorType> opResult,
   // Create the new output layout attribute with the updated tensor layout,
   // buffer type, memory layout and data type.
   TTNNLayoutAttr newOutputLayoutAttr =
-      opResultLayoutAttr
-          .withElementType(rewriter.getContext(), elementType,
-                           opResultType.getShape())
+      opResultLayoutAttr.withElementType(elementType, opResultType.getShape())
           .withBufferType(
-              rewriter.getContext(),
               outputWorkaroundResults.tensorBufferTypeResult.targetValue)
-          .withMemoryLayout(rewriter.getContext(), outputMemLayoutAttr);
+          .withMemoryLayout(outputMemLayoutAttr);
 
   // Create the new output result type with the updated data type and layout.
   RankedTensorType newOutputResultType =
@@ -211,14 +208,12 @@ workaroundOutputOperand(mlir::TypedValue<RankedTensorType> opResult,
       // Check if the buffer type got updated.
       if (outputWorkaroundResults.tensorBufferTypeResult.isModified()) {
         currentMemoryConfig = currentMemoryConfig.withBufferType(
-            rewriter.getContext(),
             outputWorkaroundResults.tensorBufferTypeResult.targetValue);
       }
 
       // Check if the memory layout got updated.
       if (outputWorkaroundResults.tensorMemoryLayoutResult.isModified()) {
         currentMemoryConfig = currentMemoryConfig.withMemoryLayout(
-            rewriter.getContext(),
             outputWorkaroundResults.tensorMemoryLayoutResult.targetValue
                 .value());
       }

--- a/lib/Dialect/TTNN/Utils/OptimizerUtils.cpp
+++ b/lib/Dialect/TTNN/Utils/OptimizerUtils.cpp
@@ -147,9 +147,9 @@ std::vector<TTNNLayoutAttr> generateAllPossibleLayouts(
 
     // L1 Sharded
     TTNNLayoutAttr shardedBase =
-        layoutAttr.withBufferType(ctx, BufferType::L1)
-            .withMemoryLayout(ctx, TensorMemoryLayout::BlockSharded)
-            .withElementType(ctx, elementType, tensorShape);
+        layoutAttr.withBufferType(BufferType::L1)
+            .withMemoryLayout(TensorMemoryLayout::BlockSharded)
+            .withElementType(elementType, tensorShape);
 
     assert(maxGrid.getShape().size() == 2 &&
            "Max device grid is expected to be 2D.");
@@ -160,9 +160,9 @@ std::vector<TTNNLayoutAttr> generateAllPossibleLayouts(
       for (int width = 1; width <= maxGrid.getShape()[1]; ++width) {
         shardedResults.push_back(
             shardedBase
-                .withGrid(ctx, tensorType,
+                .withGrid(tensorType,
                           GridAttr::get(ctx, {height, width}, affineMapBs))
-                .withMemoryLayout(ctx, TensorMemoryLayout::BlockSharded));
+                .withMemoryLayout(TensorMemoryLayout::BlockSharded));
       }
     }
 
@@ -174,9 +174,9 @@ std::vector<TTNNLayoutAttr> generateAllPossibleLayouts(
     for (int height = 1; height <= numCores; ++height) {
       shardedResults.push_back(
           shardedBase
-              .withGrid(ctx, tensorType,
+              .withGrid(tensorType,
                         GridAttr::get(ctx, {height, 1}, affineMapHs))
-              .withMemoryLayout(ctx, TensorMemoryLayout::HeightSharded));
+              .withMemoryLayout(TensorMemoryLayout::HeightSharded));
     }
 
     // Width Sharded
@@ -185,9 +185,8 @@ std::vector<TTNNLayoutAttr> generateAllPossibleLayouts(
     for (int width = 1; width <= numCores; ++width) {
       shardedResults.push_back(
           shardedBase
-              .withGrid(ctx, tensorType,
-                        GridAttr::get(ctx, {1, width}, affineMapWs))
-              .withMemoryLayout(ctx, TensorMemoryLayout::WidthSharded));
+              .withGrid(tensorType, GridAttr::get(ctx, {1, width}, affineMapWs))
+              .withMemoryLayout(TensorMemoryLayout::WidthSharded));
     }
   }
 

--- a/lib/Dialect/TTNN/Utils/TransformUtils.cpp
+++ b/lib/Dialect/TTNN/Utils/TransformUtils.cpp
@@ -68,10 +68,9 @@ createToLayoutOp(Operation *op, mlir::TypedValue<RankedTensorType> inputValue,
   // Create the new encoding for the output tensor type.
   TTNNLayoutAttr toLayoutOpResultEncoding =
       inputLayoutAttr
-          .withElementType(rewriter.getContext(), elementType,
-                           inputToLayoutOpType.getShape())
-          .withBufferType(rewriter.getContext(), targetTensorBufferType)
-          .withMemoryLayout(rewriter.getContext(), outputMemLayoutAttr);
+          .withElementType(elementType, inputToLayoutOpType.getShape())
+          .withBufferType(targetTensorBufferType)
+          .withMemoryLayout(outputMemLayoutAttr);
 
   // Create the output result type with the new data type and encoding.
   RankedTensorType toLayoutOpResultType =

--- a/lib/Dialect/TTNN/Utils/Utils.cpp
+++ b/lib/Dialect/TTNN/Utils/Utils.cpp
@@ -60,8 +60,8 @@ RankedTensorType
 createRankedTensorTypeWithElementType(RankedTensorType tensorType,
                                       Type elementType) {
   TTNNLayoutAttr oldEncoding = getLayoutAttrFromTensor(tensorType);
-  TTNNLayoutAttr newEncoding = oldEncoding.withElementType(
-      tensorType.getContext(), elementType, tensorType.getShape());
+  TTNNLayoutAttr newEncoding =
+      oldEncoding.withElementType(elementType, tensorType.getShape());
   Type newElementType = elementType;
   if (TileType tileType = dyn_cast<TileType>(elementType)) {
     newElementType = tileType.getElementType();
@@ -75,8 +75,7 @@ RankedTensorType
 createRankedTensorTypeWithBufferType(RankedTensorType tensorType,
                                      ttnn::BufferType bufferType) {
   TTNNLayoutAttr oldEncoding = getLayoutAttrFromTensor(tensorType);
-  TTNNLayoutAttr newEncoding =
-      oldEncoding.withBufferType(tensorType.getContext(), bufferType);
+  TTNNLayoutAttr newEncoding = oldEncoding.withBufferType(bufferType);
   return createRankedTensorTypeWithEncoding(tensorType, newEncoding);
 }
 
@@ -85,8 +84,7 @@ RankedTensorType
 createRankedTensorTypeWithMemoryLayout(RankedTensorType tensorType,
                                        ttnn::TensorMemoryLayout memoryLayout) {
   TTNNLayoutAttr oldEncoding = getLayoutAttrFromTensor(tensorType);
-  TTNNLayoutAttr newEncoding =
-      oldEncoding.withMemoryLayout(tensorType.getContext(), memoryLayout);
+  TTNNLayoutAttr newEncoding = oldEncoding.withMemoryLayout(memoryLayout);
   return createRankedTensorTypeWithEncoding(tensorType, newEncoding);
 }
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`with*` member functions of `MemoryConfigAttr` and `TTNNLayoutAttr` are taking `MLIRContext` as a first parameter. The idea behind these functions is to create the attribute that's the same as the provided one except for one of its parameters changes. I can't think of any case were we would want to instantiate that attribute in the different context than the provided one, but if someone can think about the use-case please let me know.

### What's changed
Removed `MLIRContext` param from those functions.

### Checklist
- [x] New/Existing tests provide coverage for changes
