### PR TITLE
Data type workaround for reduction ops

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -686,18 +686,25 @@ def TTNN_Atan2Op :  TTNN_ElementwiseBinaryOp<"atan2"> {
 }
 
 class TTNN_ReductionOp<string mnemonic, list<Trait> traits = []> : TTNN_Op<mnemonic, traits> {
-    let summary = "Reduction op.";
-    let description = [{
-      Reduction op.
-    }];
+  let summary = "Reduction op.";
+  let description = [{
+    Reduction op.
+  }];
 
-    let arguments = (ins AnyRankedTensor:$input,
-                         BoolAttr:$keep_dim,
-                         OptionalAttr<I32ArrayAttr>:$dim_arg);
+  let arguments = (ins AnyRankedTensor:$input,
+                       BoolAttr:$keep_dim,
+                       OptionalAttr<I32ArrayAttr>:$dim_arg);
 
-    let results = (outs AnyRankedTensor:$result);
+  let results = (outs AnyRankedTensor:$result);
 
-    let hasVerifier = 1;
+  let extraClassDeclaration = [{
+    wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
+      return
+        wa::TTNNOperandsWorkaroundsFactory::createReductionOpOperandsWorkarounds(*this);
+    }
+  }];
+
+  let hasVerifier = 1;
 }
 
 def TTNN_SumOp : TTNN_ReductionOp<"sum"> {

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
@@ -285,6 +285,10 @@ public:
 
   // Create workarounds for arange op.
   static TTNNOperandsWorkarounds createArangeOpOperandsWorkarounds();
+
+  // Create workarounds for reduction op operands.
+  static TTNNOperandsWorkarounds
+  createReductionOpOperandsWorkarounds(mlir::Operation *op);
 };
 
 } // namespace mlir::tt::ttnn::wa

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/reduction_ops_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/reduction_ops_workaround.mlir
@@ -1,0 +1,40 @@
+// RUN: ttmlir-opt --tt-register-device="system-desc-path=%system_desc_path%"  --ttnn-workaround --canonicalize %s | FileCheck %s
+
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x1x!tt.tile<32x32, si32>, #dram>, <interleaved>>
+#ttnn_layout1 = #ttnn.ttnn_layout<(d0) -> (0, d0), <1x1>, memref<1x4x!tt.tile<32x32, si32>, #dram>, <interleaved>>
+func.func public @test_reduce_max(%arg0: tensor<128x10xsi32, #ttnn_layout>) -> tensor<128xsi32, #ttnn_layout1> {
+  // CHECK-LABEL: @test_reduce_max
+  // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0, %{{[0-9]+}})
+  // CHECK-SAME: dtype = #tt.supportedDataTypes<bf16>,
+  // CHECK-SAME: tensor<128x10xsi32,
+  // CHECK-SAME: -> tensor<128x10xbf16,
+  // CHECK: %[[MAX:[0-9]+]] = "ttnn.max"(%[[ARG0]])
+  // CHECK-SAME: <{dim_arg = [1 : i32], keep_dim = false}>
+  // CHECK-SAME: tensor<128x10xbf16,
+  // CHECK-SAME: -> tensor<128xbf16,
+  %0 = "ttnn.max"(%arg0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x10xsi32, #ttnn_layout>) -> tensor<128xsi32, #ttnn_layout1>
+  // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[MAX]], %{{[0-9]+}})
+  // CHECK-SAME: dtype = #tt.supportedDataTypes<si32>,
+  // CHECK-SAME: tensor<128xbf16,
+  // CHECK-SAME: -> tensor<128xsi32,
+  return %0 : tensor<128xsi32, #ttnn_layout1>
+}
+
+func.func public @test_reduce_sum(%arg0: tensor<128x10xsi32, #ttnn_layout>) -> tensor<128xsi32, #ttnn_layout1> {
+  // CHECK-LABEL: @test_reduce_sum
+  // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0, %{{[0-9]+}})
+  // CHECK-SAME: dtype = #tt.supportedDataTypes<bf16>,
+  // CHECK-SAME: tensor<128x10xsi32,
+  // CHECK-SAME: -> tensor<128x10xbf16,
+  // CHECK: %[[SUM:[0-9]+]] = "ttnn.sum"(%[[ARG0]])
+  // CHECK-SAME: <{dim_arg = [1 : i32], keep_dim = false}>
+  // CHECK-SAME: tensor<128x10xbf16,
+  // CHECK-SAME: -> tensor<128xbf16,
+  %0 = "ttnn.sum"(%arg0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x10xsi32, #ttnn_layout>) -> tensor<128xsi32, #ttnn_layout1>
+  // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[SUM]], %{{[0-9]+}})
+  // CHECK-SAME: dtype = #tt.supportedDataTypes<si32>,
+  // CHECK-SAME: tensor<128xbf16,
+  // CHECK-SAME: -> tensor<128xsi32,
+  return %0 : tensor<128xsi32, #ttnn_layout1>
+}


### PR DESCRIPTION
### Ticket
closes #3074 

### Problem description
TTNN reduction ops does not work correctly for integer inputs.

### What's changed
Add a workaround for reduction ops in case of integer inputs.

### Checklist
- [X] New/Existing tests provide coverage for changes
