### PR TITLE
TTRT Output bugfix

### DIFF
--- a/runtime/tools/python/ttrt/common/run.py
+++ b/runtime/tools/python/ttrt/common/run.py
@@ -570,7 +570,7 @@ class Run:
 
                         for i in program.output_tensors:
                             outputs.append(
-                                ttrt.runtime.create_owned_tensor(
+                                ttrt.runtime.create_tensor(
                                     i.data_ptr(),
                                     list(i.shape),
                                     list(i.stride()),


### PR DESCRIPTION
### Problem description
Typo in const-eval PR changed the buffer type for output tensors to owned_buffer, which isn't desirable + leads to wrong outputs showing.

### What's changed
Revert output to regular `create_tensor` instead of `create_owned_tensor`

### Checklist
- [ ] New/Existing tests provide coverage for changes
