### PR TITLE
[EmitC] Add TTNN to EmitC conversion for ConvTranspose2D

### DIFF
--- a/test/ttmlir/EmitC/TTNN/conv/conv_transpose2d.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/conv_transpose2d.mlir
@@ -1,0 +1,32 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
+// RUN: ttmlir-opt --ttnn-modify-signatures-for-dylib --convert-ttnn-to-emitc %t.mlir > %t2.mlir
+// RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
+
+module {
+  func.func @conv_transpose2d_bf16(%arg0: tensor<3x8x8x256xbf16>, %arg1: tensor<256x256x3x3xbf16>, %arg2: tensor<1x1x1x256xbf16>) -> tensor<3x10x10x256xbf16> {
+    %0 = ttir.empty() : tensor<3x10x10x256xbf16>
+    %1 = "ttir.conv_transpose2d"(%arg0, %arg1, %arg2, %0)
+            <{
+              stride = 1: i32,
+              padding = 0: i32,
+              output_padding = 0: i32,
+              dilation = 1: i32,
+              groups = 1: i32}
+            > : (tensor<3x8x8x256xbf16>, tensor<256x256x3x3xbf16>, tensor<1x1x1x256xbf16>, tensor<3x10x10x256xbf16>) -> tensor<3x10x10x256xbf16>
+    return %1 : tensor<3x10x10x256xbf16>
+  }
+
+  func.func @conv_transpose2d_f32(%arg0: tensor<3x8x8x256xf32>, %arg1: tensor<256x256x3x3xf32>, %arg2: tensor<1x1x1x256xf32>) -> tensor<3x10x10x256xf32> {
+    %0 = ttir.empty() : tensor<3x10x10x256xf32>
+    %1 = "ttir.conv_transpose2d"(%arg0, %arg1, %arg2, %0)
+            <{
+              stride = 1: i32,
+              padding = 0: i32,
+              output_padding = 0: i32,
+              dilation = 1: i32,
+              groups = 1: i32}
+            > : (tensor<3x8x8x256xf32>, tensor<256x256x3x3xf32>, tensor<1x1x1x256xf32>, tensor<3x10x10x256xf32>) -> tensor<3x10x10x256xf32>
+    return %1 : tensor<3x10x10x256xf32>
+  }
+}

--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -14,6 +14,7 @@
 #include "operations/ccl/reduce_scatter/reduce_scatter.hpp"
 #include "operations/conv/conv2d/conv2d.hpp"
 #include "operations/conv/conv2d/prepare_conv2d_weights.cpp"
+#include "operations/conv/conv_transpose2d/conv_transpose2d.hpp"
 #include "operations/copy.hpp"
 #include "operations/core/core.hpp"
 #include "operations/creation.hpp"


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/orgs/tenstorrent/projects/54/views/5?filterQuery=Emitc&pane=issue&itemId=94186922&issue=tenstorrent%7Ctt-mlir%7C1877)

### What's changed
Added a conversion for ConvTranspose2D in EmitC
