### PR TITLE
Fix: Add tag fetching from upstream for forked repositories

### DIFF
--- a/cmake/modules/TTMLIRVersion.cmake
+++ b/cmake/modules/TTMLIRVersion.cmake
@@ -6,6 +6,22 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
+# Check if tags exist and fetch from remote if they don't
+execute_process(
+  COMMAND git tag -l "v[0-9]*.[0-9]*"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+  OUTPUT_VARIABLE EXISTING_TAGS
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+if("${EXISTING_TAGS}" STREQUAL "")
+  message(STATUS "No version tags found locally. Fetching tags from upstream...")
+  execute_process(
+    COMMAND git fetch --tags upstream
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+  )
+endif()
+
 # get the latest tag from git matching 'v<major>.<minor>' format
 # (note: matching a glob(7) pattern, not a regex)
 execute_process(


### PR DESCRIPTION
### Ticket
N/A

### Problem description
When building in a forked repository, the version detection fails because git tags are not automatically fetched from the upstream repository. This causes the `git describe` command to fail with the error "No names found, cannot describe anything", resulting in an empty `GIT_TAG` variable.

#### Error at cmake configuration

```bash
fatal: No names found, cannot describe anything.
CMake Error at cmake/modules/TTMLIRVersion.cmake:27 (string):
  string sub-command REGEX, mode MATCH needs at least 5 arguments total to
  command.
Call Stack (most recent call first):
  CMakeLists.txt:73 (include)
```

### What's changed
This PR fixes the issue by:
1. Adding a check for the existence of version tags locally using `git tag -l`
2. If no tags are found, explicitly fetching tags from the upstream repository using `git fetch --tags upstream`

### Checklist
- [ ] New/Existing tests provide coverage for changes
