### PR TITLE
Fix program-level golden comparison logic in ttrt

### DIFF
--- a/runtime/tools/python/ttrt/common/run.py
+++ b/runtime/tools/python/ttrt/common/run.py
@@ -579,19 +579,20 @@ class Run:
                                 )
                             )
                         # load output golden tensors
-                        golden_outputs_torch = []
-                        for idx in range(0, len(program.output_tensors)):
-                            golden_tensor = bin.fbb.get_debug_info_golden(
-                                f"output_{idx}"
-                            )
-                            if golden_tensor is not None:
-                                golden_tensor_torch = torch.frombuffer(
-                                    golden_tensor,
-                                    dtype=ttrt_datatype_to_torch_dtype(
-                                        golden_tensor.dtype
-                                    ),
-                                ).reshape(golden_tensor.shape)
-                                golden_outputs_torch.append(golden_tensor_torch)
+                        if not self["--disable-golden"]:
+                            golden_outputs_torch = []
+                            for idx in range(0, len(program.output_tensors)):
+                                golden_tensor = bin.fbb.get_debug_info_golden(
+                                    f"output_{idx}"
+                                )
+                                if golden_tensor is not None:
+                                    golden_tensor_torch = torch.frombuffer(
+                                        golden_tensor,
+                                        dtype=ttrt_datatype_to_torch_dtype(
+                                            golden_tensor.dtype
+                                        ),
+                                    ).reshape(golden_tensor.shape)
+                                    golden_outputs_torch.append(golden_tensor_torch)
 
                         event = None
 
@@ -711,7 +712,9 @@ class Run:
                                     )
 
                                     # compare program level golden.
-                                    if i < len(golden_outputs_torch):
+                                    if (not self["--disable-golden"]) and (
+                                        i < len(golden_outputs_torch)
+                                    ):
                                         self.logging.debug(
                                             f"executing program level golden comparison for output_{i}"
                                         )


### PR DESCRIPTION
### Ticket
Fix program level golden comparison on ttrt #3086
close #3086

### Problem description
The program-level golden comparison code in runtime/tools/python/ttrt/common/run.py still references the now-removed total_outputs variable, causing ttrt to throw an exception when running with program-level golden tensors 

### What's changed
Load all golden outputs and compare each against the corresponding runtime output
Remove the outdated total_outputs-based comparison block

### Checklist
- [ ] New/Existing tests provide coverage for changes
