### PR TITLE
StreamLayoutOp should have Pure memory semantics

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -261,8 +261,15 @@ def TTIR_ToLayoutOp : TTIR_BufferizableOp<"to_layout"> {
     let hasCanonicalizer = 1;
 }
 
-def TTIR_StreamLayoutOp : TTIR_BufferizableOp<"stream_layout",
-  [ DeclareOpInterfaceMethods<OpAsmOpInterface , ["getAsmResultNames"]>
+def TTIR_StreamLayoutOp : TTIR_Op<"stream_layout",
+  [ Pure
+  , DeclareOpInterfaceMethods<OpAsmOpInterface , ["getAsmResultNames"]>
+  , DeclareOpInterfaceMethods<BufferizableOpInterface, [ "bufferizesToMemoryRead"
+                                                       , "bufferizesToMemoryWrite"
+                                                       , "bufferize"
+                                                       , "getAliasingValues"
+                                                       , "getBufferType"
+                                                       ]>
   , TTIR_ViewOpInterface
   ]> {
     let summary = "Stream Layout op.";

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -2212,6 +2212,16 @@ mlir::LogicalResult mlir::tt::ttir::StreamLayoutOp::verify() {
   return success();
 }
 
+bool mlir::tt::ttir::StreamLayoutOp::bufferizesToMemoryRead(
+    mlir::OpOperand &, const mlir::bufferization::AnalysisState &) {
+  return false;
+}
+
+bool mlir::tt::ttir::StreamLayoutOp::bufferizesToMemoryWrite(
+    mlir::OpOperand &, const mlir::bufferization::AnalysisState &) {
+  return false;
+}
+
 mlir::LogicalResult mlir::tt::ttir::StreamLayoutOp::bufferize(
     mlir::RewriterBase &rewriter,
     const mlir::bufferization::BufferizationOptions &options) {
@@ -2237,6 +2247,13 @@ mlir::LogicalResult mlir::tt::ttir::StreamLayoutOp::bufferize(
       *maybeInput, *maybeStorage);
   mlir::bufferization::replaceOpWithBufferizedValues(rewriter, *this, result);
   return success();
+}
+
+mlir::bufferization::AliasingValueList
+mlir::tt::ttir::StreamLayoutOp::getAliasingValues(
+    mlir::OpOperand &, const mlir::bufferization::AnalysisState &) {
+  bufferization::AliasingValueList result;
+  return result;
 }
 
 mlir::FailureOr<mlir::BaseMemRefType>


### PR DESCRIPTION
This op previously had incorrect memory semantics, it should have always been pure.  This op is only representational.