### PR TITLE
Add golden output verification to CI pipeline

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -143,6 +143,8 @@ jobs:
           {runs-on: n150,   name: "run",  suite: "ttnn_runtime",      image: "speedy", type: "pytest",  path: "runtime/test/python/ttnn/device_agnostic", container-options: "--device /dev/tenstorrent/0"},
           {runs-on: n150,   name: "perf", suite: "explorer",          image: "tracy",  type: "pytest",  path: "tools/explorer/test/run_tests.py", container-options: "--device /dev/tenstorrent/0"},
           {runs-on: n300,   name: "run",  suite: "ttnn_runtime",      image: "speedy", type: "pytest",  path: "runtime/test/python/ttnn/multi_device", container-options: "--device /dev/tenstorrent/0"},
+          {runs-on: n300,   name: "run",  suite: "multidevice",       image: "speedy", type: "golden",  path: "ccl_test/n300", ttrt_flags: "--non-zero", container-options: "--device /dev/tenstorrent/0"},
+          {runs-on: llmbox, name: "run",  suite: "multidevice",       image: "speedy", type: "golden",  path: "ccl_test/llmbox", ttrt_flags: "--non-zero", container-options: "--device /dev/tenstorrent/0 --device /dev/tenstorrent/1 --device /dev/tenstorrent/2 --device /dev/tenstorrent/3"},
         ]
     name: "run-tests (${{ matrix.build.runs-on }},${{ matrix.build.image }},${{ matrix.build.suite }},${{ matrix.build.type}})"
 
@@ -311,6 +313,13 @@ jobs:
         export TT_EXPLORER_GENERATED_MLIR_TEST_DIRS=${{ steps.strings.outputs.build-output-dir }}/test/ttmlir/Silicon/TTNN/n150/perf,${{ steps.strings.outputs.build-output-dir }}/test/python/golden/ttnn
         export TT_EXPLORER_GENERATED_TTNN_TEST_DIRS=${{ steps.strings.outputs.build-output-dir }}/test/python/golden/ttnn
         pytest -ssv ${{ matrix.build.path }} --junit-xml=${{ steps.strings.outputs.test_report_path }}
+
+    - name: Run golden tests
+      if: matrix.build.type == 'golden'
+      shell: bash
+      run: |
+        source env/activate
+        ttrt ${{ matrix.build.name }} ${{ matrix.build.ttrt_flags }} ${{ steps.strings.outputs.build-output-dir }}/test/python/golden/${{ matrix.build.path }}
 
     - name: Collect and Upload Perf Reports
       if: matrix.build.name == 'perf'

--- a/runtime/tools/python/ttrt/common/run.py
+++ b/runtime/tools/python/ttrt/common/run.py
@@ -579,19 +579,20 @@ class Run:
                                 )
                             )
                         # load output golden tensors
-                        golden_outputs_torch = []
-                        for idx in range(0, len(program.output_tensors)):
-                            golden_tensor = bin.fbb.get_debug_info_golden(
-                                f"output_{idx}"
-                            )
-                            if golden_tensor is not None:
-                                golden_tensor_torch = torch.frombuffer(
-                                    golden_tensor,
-                                    dtype=ttrt_datatype_to_torch_dtype(
-                                        golden_tensor.dtype
-                                    ),
-                                ).reshape(golden_tensor.shape)
-                                golden_outputs_torch.append(golden_tensor_torch)
+                        if not self["--disable-golden"]:
+                            golden_outputs_torch = []
+                            for idx in range(0, len(program.output_tensors)):
+                                golden_tensor = bin.fbb.get_debug_info_golden(
+                                    f"output_{idx}"
+                                )
+                                if golden_tensor is not None:
+                                    golden_tensor_torch = torch.frombuffer(
+                                        golden_tensor,
+                                        dtype=ttrt_datatype_to_torch_dtype(
+                                            golden_tensor.dtype
+                                        ),
+                                    ).reshape(golden_tensor.shape)
+                                    golden_outputs_torch.append(golden_tensor_torch)
 
                         event = None
 
@@ -711,7 +712,9 @@ class Run:
                                     )
 
                                     # compare program level golden.
-                                    if i < len(golden_outputs_torch):
+                                    if (not self["--disable-golden"]) and (
+                                        i < len(golden_outputs_torch)
+                                    ):
                                         self.logging.debug(
                                             f"executing program level golden comparison for output_{i}"
                                         )

--- a/test/python/golden/ccl_test/llmbox/test_ttir_ccl_ops_llmbox.py
+++ b/test/python/golden/ccl_test/llmbox/test_ttir_ccl_ops_llmbox.py
@@ -188,6 +188,333 @@ def test_collective_permute(in0: Operand, builder: TTIRBuilder):
     )
 
 
+@compile_to_flatbuffer(
+    [
+        (8192, 784),
+        (784, 16384),
+    ],
+    targets=["ttnn"],
+    mesh_shape=[2, 4],
+)
+def test_matmul_2x4(in0: Operand, in1: Operand, builder: TTIRBuilder):
+    input = builder._get_golden_tensor(in0)
+    weight = builder._get_golden_tensor(in1)
+    golden_output = torch.matmul(input, weight)
+    builder.set_graph_input_output([input, weight], [golden_output])
+
+    sharded_in0 = builder.mesh_shard(
+        in0,
+        shard_direction="#tt.shard_direction<full_to_shard>",
+        shard_type="#tt.shard_type<devices>",
+        shard_shape=[2, 4],
+        shard_dims=[0, 1],
+    )
+    sharded_in1 = builder.mesh_shard(
+        in1,
+        shard_direction="#tt.shard_direction<full_to_shard>",
+        shard_type="#tt.shard_type<devices>",
+        shard_shape=[4, 1],
+        shard_dims=[-1, 0],
+    )
+    partial_matmul = builder.matmul(sharded_in0, sharded_in1)
+    reduced = builder.all_reduce(
+        partial_matmul,
+        reduce_type="#tt.reduce_type<sum>",
+        cluster_axis=1,
+    )
+    return builder.mesh_shard(
+        reduced,
+        shard_direction="#tt.shard_direction<shard_to_full>",
+        shard_type="#tt.shard_type<devices>",
+        shard_shape=[2, 1],
+        shard_dims=[0, -1],
+    )
+
+
+@compile_to_flatbuffer(
+    [
+        (8192, 784),
+        (784, 16384),
+    ],
+    targets=["ttnn"],
+    mesh_shape=[1, 8],
+)
+def test_matmul_1x8(in0: Operand, in1: Operand, builder: TTIRBuilder):
+    input = builder._get_golden_tensor(in0)
+    weight = builder._get_golden_tensor(in1)
+    golden_output = torch.matmul(input, weight)
+    builder.set_graph_input_output([input, weight], [golden_output])
+
+    sharded_in0 = builder.mesh_shard(
+        in0,
+        shard_direction="#tt.shard_direction<full_to_shard>",
+        shard_type="#tt.shard_type<devices>",
+        shard_shape=[1, 8],
+        shard_dims=[-1, 1],
+    )
+    sharded_in1 = builder.mesh_shard(
+        in1,
+        shard_direction="#tt.shard_direction<full_to_shard>",
+        shard_type="#tt.shard_type<devices>",
+        shard_shape=[8, 1],
+        shard_dims=[-1, 0],
+    )
+    partial_matmul = builder.matmul(sharded_in0, sharded_in1)
+    reduced = builder.all_reduce(
+        partial_matmul,
+        reduce_type="#tt.reduce_type<sum>",
+        cluster_axis=1,
+    )
+    return builder.mesh_shard(
+        reduced,
+        shard_direction="#tt.shard_direction<shard_to_full>",
+        shard_type="#tt.shard_type<replicate>",
+        shard_shape=[1],
+        shard_dims=[-1],
+    )
+
+
+@compile_to_flatbuffer(
+    [
+        (1, 256, 64, 256),
+    ],
+    targets=["ttnn"],
+    mesh_shape=[2, 4],
+)
+def test_neg_2x4(in0: Operand, builder: TTIRBuilder):
+    input = builder._get_golden_tensor(in0)
+    golden_output = torch.neg(input)
+    builder.set_graph_input_output([input], [golden_output])
+
+    sharded_in0 = builder.mesh_shard(
+        in0,
+        shard_direction="#tt.shard_direction<full_to_shard>",
+        shard_type="#tt.shard_type<devices>",
+        shard_shape=[1, 2, 1, 4],
+        shard_dims=[1, 3],
+    )
+    neg_output = builder.neg(sharded_in0)
+    return builder.mesh_shard(
+        neg_output,
+        shard_direction="#tt.shard_direction<shard_to_full>",
+        shard_type="#tt.shard_type<devices>",
+        shard_shape=[1, 2, 1, 4],
+        shard_dims=[1, 3],
+    )
+
+
+@compile_to_flatbuffer(
+    [
+        (1, 256, 64, 256),
+    ],
+    targets=["ttnn"],
+    mesh_shape=[2, 4],
+)
+def test_neg_2x4_cluster_0(in0: Operand, builder: TTIRBuilder):
+    input = builder._get_golden_tensor(in0)
+    golden_output = torch.neg(input)
+    builder.set_graph_input_output([input], [golden_output])
+
+    sharded_in0 = builder.mesh_shard(
+        in0,
+        shard_direction="#tt.shard_direction<full_to_shard>",
+        shard_type="#tt.shard_type<devices>",
+        shard_shape=[1, 2, 1, 1],
+        shard_dims=[1, -1],
+    )
+    neg_output = builder.neg(sharded_in0)
+    return builder.mesh_shard(
+        neg_output,
+        shard_direction="#tt.shard_direction<shard_to_full>",
+        shard_type="#tt.shard_type<devices>",
+        shard_shape=[1, 2, 1, 1],
+        shard_dims=[1, -1],
+    )
+
+
+@compile_to_flatbuffer(
+    [
+        (1, 256, 64, 256),
+    ],
+    targets=["ttnn"],
+    mesh_shape=[2, 4],
+)
+def test_neg_2x4_cluster_1(in0: Operand, builder: TTIRBuilder):
+    input = builder._get_golden_tensor(in0)
+    golden_output = torch.neg(input)
+    builder.set_graph_input_output([input], [golden_output])
+
+    sharded_in0 = builder.mesh_shard(
+        in0,
+        shard_direction="#tt.shard_direction<full_to_shard>",
+        shard_type="#tt.shard_type<devices>",
+        shard_shape=[1, 1, 1, 4],
+        shard_dims=[1, 3],
+    )
+    neg_output = builder.neg(sharded_in0)
+    return builder.mesh_shard(
+        neg_output,
+        shard_direction="#tt.shard_direction<shard_to_full>",
+        shard_type="#tt.shard_type<devices>",
+        shard_shape=[1, 1, 1, 4],
+        shard_dims=[1, 3],
+    )
+
+
+@compile_to_flatbuffer(
+    [
+        (1, 256, 64, 256),
+    ],
+    targets=["ttnn"],
+    mesh_shape=[2, 4],
+)
+def test_neg_2x4_reversed_cluster(in0: Operand, builder: TTIRBuilder):
+    input = builder._get_golden_tensor(in0)
+    golden_output = torch.neg(input)
+    builder.set_graph_input_output([input], [golden_output])
+
+    sharded_in0 = builder.mesh_shard(
+        in0,
+        shard_direction="#tt.shard_direction<full_to_shard>",
+        shard_type="#tt.shard_type<devices>",
+        shard_shape=[1, 4, 1, 2],
+        shard_dims=[3, 1],
+    )
+    neg_output = builder.neg(sharded_in0)
+    return builder.mesh_shard(
+        neg_output,
+        shard_direction="#tt.shard_direction<shard_to_full>",
+        shard_type="#tt.shard_type<devices>",
+        shard_shape=[1, 4, 1, 2],
+        shard_dims=[3, 1],
+    )
+
+
+@compile_to_flatbuffer(
+    [
+        (1, 256, 64, 256),
+    ],
+    targets=["ttnn"],
+    mesh_shape=[2, 4],
+)
+def test_neg_2x4_reversed_cluster_0(in0: Operand, builder: TTIRBuilder):
+    input = builder._get_golden_tensor(in0)
+    golden_output = torch.neg(input)
+    builder.set_graph_input_output([input], [golden_output])
+
+    sharded_in0 = builder.mesh_shard(
+        in0,
+        shard_direction="#tt.shard_direction<full_to_shard>",
+        shard_type="#tt.shard_type<devices>",
+        shard_shape=[1, 1, 1, 2],
+        shard_dims=[3, -1],
+    )
+    neg_output = builder.neg(sharded_in0)
+    return builder.mesh_shard(
+        neg_output,
+        shard_direction="#tt.shard_direction<shard_to_full>",
+        shard_type="#tt.shard_type<devices>",
+        shard_shape=[1, 1, 1, 2],
+        shard_dims=[3, -1],
+    )
+
+
+@compile_to_flatbuffer(
+    [
+        (1, 256, 64, 256),
+    ],
+    targets=["ttnn"],
+    mesh_shape=[1, 8],
+)
+def test_neg_1x8_dim_3(in0: Operand, builder: TTIRBuilder):
+    input = builder._get_golden_tensor(in0)
+    golden_output = torch.neg(input)
+    builder.set_graph_input_output([input], [golden_output])
+
+    sharded_in0 = builder.mesh_shard(
+        in0,
+        shard_direction="#tt.shard_direction<full_to_shard>",
+        shard_type="#tt.shard_type<devices>",
+        shard_shape=[1, 1, 1, 8],
+        shard_dims=[-1, 3],
+    )
+    neg_output = builder.neg(sharded_in0)
+    return builder.mesh_shard(
+        neg_output,
+        shard_direction="#tt.shard_direction<shard_to_full>",
+        shard_type="#tt.shard_type<devices>",
+        shard_shape=[1, 1, 1, 8],
+        shard_dims=[-1, 3],
+    )
+
+
+@compile_to_flatbuffer(
+    [
+        (1, 256, 64, 256),
+    ],
+    targets=["ttnn"],
+    mesh_shape=[1, 8],
+)
+def test_neg_1x8_dim_1(in0: Operand, builder: TTIRBuilder):
+    input = builder._get_golden_tensor(in0)
+    golden_output = torch.neg(input)
+    builder.set_graph_input_output([input], [golden_output])
+
+    sharded_in0 = builder.mesh_shard(
+        in0,
+        shard_direction="#tt.shard_direction<full_to_shard>",
+        shard_type="#tt.shard_type<devices>",
+        shard_shape=[1, 8, 1, 1],
+        shard_dims=[-1, 1],
+    )
+    neg_output = builder.neg(sharded_in0)
+    return builder.mesh_shard(
+        neg_output,
+        shard_direction="#tt.shard_direction<shard_to_full>",
+        shard_type="#tt.shard_type<devices>",
+        shard_shape=[1, 8, 1, 1],
+        shard_dims=[-1, 1],
+    )
+
+
+@compile_to_flatbuffer(
+    [
+        (512, 1024),
+        (512, 1024),
+    ],
+    targets=["ttnn"],
+    mesh_shape=[2, 4],
+)
+def test_eltwise_multidevice(in0: Operand, in1: Operand, builder: TTIRBuilder):
+    input = builder._get_golden_tensor(in0)
+    weight = builder._get_golden_tensor(in1)
+    golden_output = torch.add(input, weight)
+    builder.set_graph_input_output([input, weight], [golden_output])
+
+    sharded_in0 = builder.mesh_shard(
+        in0,
+        shard_direction="#tt.shard_direction<full_to_shard>",
+        shard_type="#tt.shard_type<devices>",
+        shard_shape=[2, 4],
+        shard_dims=[0, 1],
+    )
+    sharded_in1 = builder.mesh_shard(
+        in1,
+        shard_direction="#tt.shard_direction<full_to_shard>",
+        shard_type="#tt.shard_type<devices>",
+        shard_shape=[2, 4],
+        shard_dims=[0, 1],
+    )
+    partial_sum = builder.add(sharded_in0, sharded_in1)
+    return builder.mesh_shard(
+        partial_sum,
+        shard_direction="#tt.shard_direction<shard_to_full>",
+        shard_type="#tt.shard_type<devices>",
+        shard_shape=[2, 4],
+        shard_dims=[0, 1],
+    )
+
+
 if __name__ == "__main__":
     import argparse, os
 


### PR DESCRIPTION
### Ticket
closes #3092 

### Problem description
The CI pipeline currently does not execute any golden‐output verification tests, so regressions in operator calculations can slip through undetected. We recently ran into an issue that CI didn’t catch because no golden tests were being run on CI.

### What's changed
- Introduce a new test type 'golden that runs our hand-written golden verification testcases .
- Add additional multidevice golden testcases under `test/python/golden/ccl_tests` (generate with TTIRBuilder)  

### Checklist
- [x] New/Existing tests provide coverage for changes
