### PR TITLE
EmbeddingOp enhanced verification

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/EmbeddingOpSqueezeWeightRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/EmbeddingOpSqueezeWeightRewritePattern.h
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_EMBEDDINGOPSQUEEZEWEIGHTREWRITEPATTERN_H
+#define TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_EMBEDDINGOPSQUEEZEWEIGHTREWRITEPATTERN_H
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+
+// TTNN EmbeddingOp supports at most 4D weight tensor, where all dimensions
+// except the last 2 are equal to 1. This pattern rewrites the EmbeddingOp to a
+// 4D tensor with the first two dimensions squeezed to 1, and the last two
+// dimensions being the original weight tensor dimensions. This is done to
+// ensure compatibility with the TTNN EmbeddingOp, which requires a 4D tensor as
+// input.
+class EmbeddingOpSqueezeWeightRewritePattern
+    : public OpRewritePattern<ttnn::EmbeddingOp> {
+public:
+  using OpRewritePattern<ttnn::EmbeddingOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ttnn::EmbeddingOp srcOp,
+                                PatternRewriter &rewriter) const override;
+};
+
+} // namespace mlir::tt::ttnn::workarounds::decomposition
+
+#endif // TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_EMBEDDINGOPSQUEEZEWEIGHTREWRITEPATTERN_H

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -1866,19 +1866,34 @@ mlir::tt::ttir::TypecastOp::canonicalize(mlir::tt::ttir::TypecastOp op,
   ::mlir::RankedTensorType weightType = getWeight().getType();
   ::mlir::RankedTensorType outputType = getOutput().getType();
 
-  // inputType can have any rank
-
-  // weightType must have rank of 2: (dictionary_size, embedding_size)
-  //
-  if (weightType.getRank() != 2) {
-    return emitOpError("Weight must be a 2D tensor");
+  // Intput tensor must be at most 2D tensor.
+  if (inputType.getRank() > 2) {
+    return emitOpError("input must be at most a 2D tensor, got ")
+           << inputType.getRank() << "D ranked tensor";
   }
 
-  // outputType must have rank of inputType + and additional dimension of
-  // embedding_size
-  //
-  if (outputType.getRank() - inputType.getRank() != 1) {
-    return emitOpError("Output must have one dimension more than input");
+  // Weight tensor must be effectively 2D tensor. It means that it must have
+  // shape of (1, 1,..., 1, N, M) where N is the dictionary size and M is the
+  // embedding size.
+  if (weightType.getRank() < 2) {
+    return emitOpError("weight must be at least 2D tensor, got ")
+           << weightType.getRank() << "D ranked tensor";
+  }
+  if (std::any_of(weightType.getShape().begin(),
+                  weightType.getShape().end() - 2,
+                  [](int64_t dim) { return dim != 1; })) {
+    return emitOpError("weight must be effectively 2D tensor");
+  }
+
+  // Output tensor is expected to have the shape of (*inputTensorShape,
+  // embeddingSize).
+  int64_t embeddingSize = weightType.getDimSize(weightType.getRank() - 1);
+  llvm::SmallVector<int64_t, 3> expectedOutputShape(inputType.getShape());
+  expectedOutputShape.push_back(embeddingSize);
+
+  if (!llvm::equal(expectedOutputShape, outputType.getShape())) {
+    return emitOpError() << "expected output shape of (" << expectedOutputShape
+                         << ") but got (" << outputType.getShape() << ")";
   }
 
   return success();

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -1866,7 +1866,7 @@ mlir::tt::ttir::TypecastOp::canonicalize(mlir::tt::ttir::TypecastOp op,
   ::mlir::RankedTensorType weightType = getWeight().getType();
   ::mlir::RankedTensorType outputType = getOutput().getType();
 
-  // Intput tensor must be at most 2D tensor.
+  // Input tensor must be at most 2D tensor.
   if (inputType.getRank() > 2) {
     return emitOpError("input must be at most a 2D tensor, got ")
            << inputType.getRank() << "D ranked tensor";

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -1244,19 +1244,34 @@ static ::mlir::LogicalResult namedOpVerify(Op op) {
   ::mlir::RankedTensorType weightType = getWeight().getType();
   ::mlir::RankedTensorType outputType = getResult().getType();
 
-  // inputType can have any rank
-
-  // weightType must have rank of 2: (dictionary_size, embedding_size)
-  //
-  if (weightType.getRank() != 2) {
-    return emitOpError("Weight must be a 2D tensor");
+  // Intput tensor must be at most 2D tensor.
+  if (inputType.getRank() > 2) {
+    return emitOpError("input must be at most a 2D tensor, got ")
+           << inputType.getRank() << "D ranked tensor";
   }
 
-  // outputType must have rank of inputType + and additional dimension of
-  // embedding_size
-  //
-  if (outputType.getRank() - inputType.getRank() != 1) {
-    return emitOpError("Output must have one dimension more than input");
+  // Weight tensor must be effectively 2D tensor. It means that it must have
+  // shape of (1, 1,..., 1, N, M) where N is the dictionary size and M is the
+  // embedding size.
+  if (weightType.getRank() < 2) {
+    return emitOpError("weight must be at least 2D tensor, got ")
+           << weightType.getRank() << "D ranked tensor";
+  }
+  if (std::any_of(weightType.getShape().begin(),
+                  weightType.getShape().end() - 2,
+                  [](int64_t dim) { return dim != 1; })) {
+    return emitOpError("weight must be effectively 2D tensor");
+  }
+
+  // Output tensor is expected to have the shape of (*inputTensorShape,
+  // embeddingSize).
+  int64_t embeddingSize = weightType.getDimSize(weightType.getRank() - 1);
+  llvm::SmallVector<int64_t, 3> expectedOutputShape(inputType.getShape());
+  expectedOutputShape.push_back(embeddingSize);
+
+  if (!llvm::equal(expectedOutputShape, outputType.getShape())) {
+    return emitOpError() << "expected output shape of (" << expectedOutputShape
+                         << ") but got (" << outputType.getShape() << ")";
   }
 
   return success();

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -6,6 +6,7 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         TTNNToCpp.cpp
         Workarounds/Decomposition/ArgMaxOpRewritePattern.cpp
         Workarounds/Decomposition/CumSumOpRewritePattern.cpp
+        Workarounds/Decomposition/EmbeddingOpSqueezeWeightRewritePattern.cpp
         Workarounds/Decomposition/ReduceOpsRewritePattern.cpp
         Workarounds/Decomposition/RepeatOpRewritePattern.cpp
         Workarounds/TTNNWorkaroundsPatterns.cpp

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/EmbeddingOpSqueezeWeightRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/EmbeddingOpSqueezeWeightRewritePattern.cpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/EmbeddingOpSqueezeWeightRewritePattern.h"
+
+#include "ttmlir/Conversion/TTIRToTTNN/Utils.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Support/LLVM.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+LogicalResult EmbeddingOpSqueezeWeightRewritePattern::matchAndRewrite(
+    ttnn::EmbeddingOp srcOp, PatternRewriter &rewriter) const {
+  mlir::RankedTensorType weightType = srcOp.getWeight().getType();
+  if (weightType.getRank() <= 4) {
+    return failure();
+  }
+
+  llvm::ArrayRef<int64_t> weightShape = weightType.getShape();
+  assert(std::all_of(weightShape.begin(), weightShape.end() - 2,
+                     [](int64_t dim) { return dim == 1; }) &&
+         "Weight tensor must be effectively 2D tensor");
+
+  // Create new shape for weight tensor to make it 4D tensor. It's going to be
+  // (1, 1, weightShape[-2], weightShape[-1]).
+  llvm::SmallVector<int64_t, 4> adaptedWeightShape(2, 1);
+  adaptedWeightShape.append(weightShape.end() - 2, weightShape.end());
+
+  // Create reshape op to squeeze weight tensor to 4D.
+  ReshapeOp reshapeWeightOp = ttir_to_ttnn::utils::generateReshape(
+      srcOp.getInput(), adaptedWeightShape, rewriter);
+
+  rewriter.modifyOpInPlace(
+      srcOp, [&]() { srcOp.getWeightMutable().assign(reshapeWeightOp); });
+
+  return success();
+}
+
+} // namespace mlir::tt::ttnn::workarounds::decomposition

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/EmbeddingOpSqueezeWeightRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/EmbeddingOpSqueezeWeightRewritePattern.cpp
@@ -34,7 +34,7 @@ LogicalResult EmbeddingOpSqueezeWeightRewritePattern::matchAndRewrite(
 
   // Create reshape op to squeeze weight tensor to 4D.
   ReshapeOp reshapeWeightOp = ttir_to_ttnn::utils::generateReshape(
-      srcOp.getInput(), adaptedWeightShape, rewriter);
+      srcOp.getWeight(), adaptedWeightShape, rewriter);
 
   rewriter.modifyOpInPlace(
       srcOp, [&]() { srcOp.getWeightMutable().assign(reshapeWeightOp); });

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -10,6 +10,7 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ArgMaxOpRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/CumSumOpRewritePattern.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/EmbeddingOpSqueezeWeightRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceOpsRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/RepeatOpRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Types/Types.h"
@@ -579,17 +580,19 @@ public:
   void runOnOperation() final {
     if (decompositionWorkaroundsEnabled) {
       RewritePatternSet patterns(&getContext());
-      patterns.add<TTNNAllReduceWorkarounds,
-                   workarounds::decomposition::ReduceOpsKeepDimRewritePattern<
-                       ttnn::SumOp, /*keepDimUnsupported*/ false>,
-                   workarounds::decomposition::ReduceOpsKeepDimRewritePattern<
-                       ttnn::MaxOp, /*keepDimUnsupported*/ false>,
-                   workarounds::decomposition::ReduceOpsKeepDimRewritePattern<
-                       ttnn::MeanOp, /*keepDimUnsupported*/ false>,
-                   workarounds::decomposition::ReduceOpsKeepDimRewritePattern<
-                       ttnn::MinOp, /*keepDimUnsupported*/ false>,
-                   workarounds::decomposition::CumSumOpRewritePattern,
-                   workarounds::decomposition::ArgMaxOpRewritePattern>(
+      patterns.add<
+          TTNNAllReduceWorkarounds,
+          workarounds::decomposition::ReduceOpsKeepDimRewritePattern<
+              ttnn::SumOp, /*keepDimUnsupported*/ false>,
+          workarounds::decomposition::ReduceOpsKeepDimRewritePattern<
+              ttnn::MaxOp, /*keepDimUnsupported*/ false>,
+          workarounds::decomposition::ReduceOpsKeepDimRewritePattern<
+              ttnn::MeanOp, /*keepDimUnsupported*/ false>,
+          workarounds::decomposition::ReduceOpsKeepDimRewritePattern<
+              ttnn::MinOp, /*keepDimUnsupported*/ false>,
+          workarounds::decomposition::CumSumOpRewritePattern,
+          workarounds::decomposition::ArgMaxOpRewritePattern,
+          workarounds::decomposition::EmbeddingOpSqueezeWeightRewritePattern>(
           &getContext());
 
       runRewritePatterns(std::move(patterns),

--- a/test/ttmlir/Dialect/TTIR/embedding/embedding_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/embedding/embedding_negative.mlir
@@ -33,7 +33,7 @@ module {
 }
 
 // -----
-// Veirify that the output shpae is equal to the input shape with the addition of the last dim of the weight tensor.
+// Verify that the output shape is equal to the input shape with the addition of the last dim of the weight tensor.
 module {
   func.func @embedding_output_shape(%input: tensor<2x4xui32>, %weight: tensor<1x5x10xbf16>) -> tensor<2x4x5x10xbf16> {
     %output = ttir.empty() : tensor<2x4x5x10xbf16>

--- a/test/ttmlir/Dialect/TTIR/embedding/embedding_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/embedding/embedding_negative.mlir
@@ -1,0 +1,44 @@
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+
+// Verify that input tensor is at most 2D tensor.
+module {
+  func.func @embedding_input_3D(%input: tensor<2x4x8xui32>, %weight: tensor<5x10xbf16>) -> tensor<4x8x10xbf16> {
+    %output = ttir.empty() : tensor<4x8x10xbf16>
+    // CHECK: error: 'ttir.embedding' op input must be at most a 2D tensor, got 3D ranked tensor
+    %result = "ttir.embedding"(%input, %weight, %output) : (tensor<2x4x8xui32>, tensor<5x10xbf16>, tensor<4x8x10xbf16>) -> tensor<4x8x10xbf16>
+    return %result : tensor<4x8x10xbf16>
+  }
+}
+
+// -----
+// Verify that the weight tensor is at least 2D tensor.
+module {
+  func.func @embedding_weight_1D(%input: tensor<2x4xui32>, %weight: tensor<10xbf16>) -> tensor<2x4x10xbf16> {
+    %output = ttir.empty() : tensor<2x4x10xbf16>
+    // CHECK: error: 'ttir.embedding' op weight must be at least 2D tensor, got 1D ranked tensor
+    %result = "ttir.embedding"(%input, %weight, %output) : (tensor<2x4xui32>, tensor<10xbf16>, tensor<2x4x10xbf16>) -> tensor<2x4x10xbf16>
+    return %result : tensor<2x4x10xbf16>
+  }
+}
+
+// -----
+// Verify that all dims of the weight tensor except the last two are equal to 1.
+module {
+  func.func @embedding_weight_non_2D_effective(%input: tensor<2x4xui32>, %weight: tensor<1x2x3x4xbf16>) -> tensor<2x4x4xbf16> {
+    %output = ttir.empty() : tensor<2x4x4xbf16>
+    // CHECK: error: 'ttir.embedding' op weight must be effectively 2D tensor
+    %result = "ttir.embedding"(%input, %weight, %output) : (tensor<2x4xui32>, tensor<1x2x3x4xbf16>, tensor<2x4x4xbf16>) -> tensor<2x4x4xbf16>
+    return %result : tensor<2x4x4xbf16>
+  }
+}
+
+// -----
+// Veirify that the output shpae is equal to the input shape with the addition of the last dim of the weight tensor.
+module {
+  func.func @embedding_output_shape(%input: tensor<2x4xui32>, %weight: tensor<1x5x10xbf16>) -> tensor<2x4x5x10xbf16> {
+    %output = ttir.empty() : tensor<2x4x5x10xbf16>
+    // CHECK: error: 'ttir.embedding' op expected output shape of (2, 4, 10) but got (2, 4, 5, 10)
+    %result = "ttir.embedding"(%input, %weight, %output) : (tensor<2x4xui32>, tensor<1x5x10xbf16>, tensor<2x4x5x10xbf16>) -> tensor<2x4x5x10xbf16>
+    return %result : tensor<2x4x5x10xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/embedding_weight_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/embedding_weight_workaround.mlir
@@ -1,0 +1,12 @@
+// RUN: ttmlir-opt --tt-register-device --ttnn-layout --ttnn-workaround %s | FileCheck %s
+
+module  {
+  func.func @embedding_weight_6D(%input: tensor<2x4xui32>, %weight: tensor<1x1x1x1x10x10xbf16>) -> tensor<2x4x10xbf16> {
+    // CHECK-LABEL: func.func @embedding_weight_6D
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: shape = [1 : i32, 1 : i32, 10 : i32, 10 : i32]
+    // CHECK: "ttnn.embedding"
+    %result = "ttnn.embedding"(%input, %weight) : (tensor<2x4xui32>, tensor<1x1x1x1x10x10xbf16>) -> tensor<2x4x10xbf16>
+    return %result : tensor<2x4x10xbf16>
+  }
+}

--- a/test/ttmlir/Silicon/TTNN/n150/embedding/embedding_6D_weight.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/embedding/embedding_6D_weight.mlir
@@ -1,0 +1,13 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+
+func.func @embedding_weight_6D(%input: tensor<2x4xui32>, %weight: tensor<1x1x1x1x10x10xbf16>) -> tensor<2x4x10xbf16> {
+  // CHECK-LABEL: func.func @embedding_weight_6D
+  %output = ttir.empty() : tensor<2x4x10xbf16>
+  // CHECK: "ttnn.reshape"
+  // CHECK-SAME: shape = [1 : i32, 1 : i32, 10 : i32, 10 : i32]
+  // CHECK: "ttnn.embedding"
+  %result = "ttir.embedding"(%input, %weight, %output) : (tensor<2x4xui32>, tensor<1x1x1x1x10x10xbf16>, tensor<2x4x10xbf16>) -> tensor<2x4x10xbf16>
+  return %result : tensor<2x4x10xbf16>
+}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/2845

### Problem description
Verification of EmbeddingOp was lacking in all departments in both dialects.

### What's changed
- Enhanced verification and added appropriate tests (input with a rank !=2 will not fail but it seems it doesn't produce meaningful result, I will have to check with TTNN folks)
- Added a workaround for >4D weight tensor (with leading 1s)

### Checklist
- [x] New/Existing tests provide coverage for changes
