### PR TITLE
Create DeviceLayoutInterface

### DIFF
--- a/include/ttmlir/Dialect/TT/IR/CMakeLists.txt
+++ b/include/ttmlir/Dialect/TT/IR/CMakeLists.txt
@@ -4,6 +4,12 @@ add_mlir_doc(TTOps TTOp src/autogen/md/Dialect/ -gen-op-doc)
 add_mlir_doc(TTOpsTypes TTAttr src/autogen/md/Dialect/ -gen-attrdef-doc)
 add_mlir_doc(TTOpsTypes TTType src/autogen/md/Dialect/ -gen-typedef-doc)
 
+set(LLVM_TARGET_DEFINITIONS TTAttrInterfaces.td)
+mlir_tablegen(TTAttrInterfaces.h.inc -gen-attr-interface-decls)
+mlir_tablegen(TTAttrInterfaces.cpp.inc -gen-attr-interface-defs)
+add_public_tablegen_target(TTAttrInterfacesIncGen)
+add_dependencies(mlir-headers TTAttrInterfacesIncGen)
+
 set(LLVM_TARGET_DEFINITIONS TTOps.td)
 mlir_tablegen(TTOpsAttrDefs.h.inc -gen-attrdef-decls)
 mlir_tablegen(TTOpsAttrDefs.cpp.inc -gen-attrdef-defs)

--- a/include/ttmlir/Dialect/TT/IR/TTAttrInterfaces.td
+++ b/include/ttmlir/Dialect/TT/IR/TTAttrInterfaces.td
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_TTMLIR_DIALECT_TT_TTATTRINTERFACES_TD
+#define TTMLIR_TTMLIR_DIALECT_TT_TTATTRINTERFACES_TD
+
+include "mlir/IR/Interfaces.td"
+include "mlir/IR/BuiltinAttributeInterfaces.td"
+
+//===----------------------------------------------------------------------===//
+// TT attribute interface definitions
+//===----------------------------------------------------------------------===//
+
+def TT_DeviceLayoutInterface : AttrInterface<"DeviceLayoutInterface", [MemRefLayoutAttrInterface]> {
+  let summary = "TT DeviceLayoutInterface";
+  let cppNamespace = "::mlir::tt";
+  let description = [{
+    This interface implies a MemRefLayoutAttrInterface that conforms to Tenstorrent device layout.
+    Tenstorrent devices are divided into a grid of cores, onto which we map tensors that have been
+    chunked into shards.  This device layout attribute semantically means exactly this, i.e. we have
+    some tensors that are distributed amongst the device core grid. This means that memref shapes
+    should be reinterpreted as a concatenation of a grid shape and a shard shape, for example,
+    memref<1x2x3x4xtt.tile> should be interpreted as a grid of 1x2 and a shard of 3x4. This interface
+    provides some convenience methods for working with this interpretation of memref shape.
+  }];
+  let methods = [
+    InterfaceMethod<
+      "Get the grid shape part of the memref shape (aka the first half)",
+      "llvm::ArrayRef<int64_t>", "getGridShape", (ins "MemRefType":$memrefType),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        assert(memrefType.getRank() % 2 == 0 && "rank must be even");
+        return memrefType.getShape().take_front(memrefType.getRank() / 2);
+      }]
+    >,
+    InterfaceMethod<
+      "Get the shard shape part of the memref shape (aka the second half)",
+      "llvm::ArrayRef<int64_t>", "getShardShape", (ins "MemRefType":$memrefType),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        assert(memrefType.getRank() % 2 == 0 && "rank must be even");
+        return memrefType.getShape().drop_front(memrefType.getRank() / 2);
+      }]
+    >,
+    InterfaceMethod<
+      "Get the number of elements for the shard shape part of the memref shape (aka the second half)",
+      "int64_t", "getShardNumElements", (ins "MemRefType":$memrefType),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        auto shardShape = getShardShape(memrefType);
+        return std::accumulate(shardShape.begin(), shardShape.end(), 1LL, std::multiplies<int64_t>());
+      }]
+    >,
+  ];
+}
+
+#endif

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.h
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.h
@@ -12,6 +12,8 @@
 
 #include "ttmlir/Dialect/TT/IR/TTOpsEnums.h.inc"
 
+#include <numeric>
+
 namespace mlir::tt {
 struct PhysGridResultIdx {
   enum : int64_t {
@@ -212,6 +214,8 @@ inline DataType elementTypeToDataType(Type elementType) {
   llvm_unreachable("Unsupported element type.");
 }
 } // namespace mlir::tt
+
+#include "ttmlir/Dialect/TT/IR/TTAttrInterfaces.h.inc"
 
 #define GET_ATTRDEF_CLASSES
 #include "ttmlir/Dialect/TT/IR/TTOpsAttrDefs.h.inc"

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -5,14 +5,14 @@
 #ifndef TTMLIR_TTMLIR_TTOPSTYPES_TD
 #define TTMLIR_TTMLIR_TTOPSTYPES_TD
 
-include "mlir/IR/AttrTypeBase.td"
-include "mlir/IR/EnumAttr.td"
-include "mlir/IR/BuiltinAttributeInterfaces.td"
-include "mlir/IR/BuiltinTypeInterfaces.td"
-include "mlir/IR/CommonTypeConstraints.td"
-
 include "ttmlir/Dialect/TT/IR/TTBase.td"
 include "ttmlir/Dialect/TT/IR/TTOpsEnums.td"
+include "ttmlir/Dialect/TT/IR/TTAttrInterfaces.td"
+
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/EnumAttr.td"
+include "mlir/IR/BuiltinTypeInterfaces.td"
+include "mlir/IR/CommonTypeConstraints.td"
 
 //===----------------------------------------------------------------------===//
 // TT attr definitions
@@ -224,7 +224,7 @@ def TT_SystemDescAttr : TT_Attr<"SystemDesc", "system_desc"> {
   }];
 }
 
-def TT_ViewLayoutAttr : TT_Attr<"ViewLayout", "view", [MemRefLayoutAttrInterface]> {
+def TT_ViewLayoutAttr : TT_Attr<"ViewLayout", "view", [TT_DeviceLayoutInterface]> {
   let summary = "View layout attribute in TT dialect";
   let description = [{
     Describes a view layout of a memref buffer.
@@ -250,7 +250,7 @@ def TT_ViewLayoutAttr : TT_Attr<"ViewLayout", "view", [MemRefLayoutAttrInterface
   }];
 }
 
-def TT_ShardLayoutAttr : TT_Attr<"ShardLayout", "shard", [MemRefLayoutAttrInterface]> {
+def TT_ShardLayoutAttr : TT_Attr<"ShardLayout", "shard", [TT_DeviceLayoutInterface]> {
   let summary = "Shard layout attribute in TT dialect";
   let description = [{
     Describes shard layout of a memref buffer.

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -132,9 +132,8 @@ def TTIR_GenericOp : TTIR_BufferizableOp<"generic",
             grid = mlir::cast<tt::MetalLayoutAttr>(tensorType.getEncoding()).getGrid();
           } else {
             MemRefType memrefType = mlir::cast<MemRefType>(outputs[0].getType());
-            assert(memrefType.getRank() % 2 == 0 && "expected even rank");
-            ArrayRef<int64_t> gridShape = memrefType.getShape().take_front(memrefType.getRank() / 2);
-            grid = $_builder.getAttr<tt::GridAttr>(gridShape);
+            DeviceLayoutInterface layout = mlir::cast<DeviceLayoutInterface>(memrefType.getLayout());
+            grid = $_builder.getAttr<tt::GridAttr>(layout.getGridShape(memrefType));
           }
         }
         auto threads = $_builder.getArrayAttr($_builder.getAttr<ThreadAttr>(singleThreadType));

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -1936,7 +1936,6 @@ verifyLayoutOp(mlir::Operation *op, mlir::Type inputTensorOrMemrefTy,
                mlir::Type outputTensorOrMemrefTy, bool allowFormatChange,
                bool allowMemorySpaceChange, bool checkMemrefRank = false,
                bool checkMemrefGridShardForm = false,
-               bool checkMemrefGridShape = false,
                bool checkMemrefShardShape = false) {
   if (mlir::RankedTensorType inputTy =
           mlir::dyn_cast<mlir::RankedTensorType>(inputTensorOrMemrefTy)) {
@@ -1998,27 +1997,20 @@ verifyLayoutOp(mlir::Operation *op, mlir::Type inputTensorOrMemrefTy,
       return op->emitOpError("Input and output memref ranks must be the same");
     }
 
-    bool inputGridShardForm = inputTy.getShape().size() % 2 == 0;
-    if (checkMemrefGridShardForm && !inputGridShardForm) {
+    auto inputDeviceLayout =
+        mlir::dyn_cast<mlir::tt::DeviceLayoutInterface>(inputTy.getLayout());
+    if (checkMemrefGridShardForm && !inputDeviceLayout) {
       return op->emitOpError(
-          "Input memref must be in grid-shard form, i.e. have even rank, grid "
+          "input memref must have device layout, i.e. have even rank, grid "
           "shape followed by shard shape of equal rank, e.g. GxGxSxS");
     }
 
-    bool outputGridShardForm = outputTy.getShape().size() % 2 == 0;
-    if (checkMemrefGridShardForm && !outputGridShardForm) {
+    auto outputDeviceLayout =
+        mlir::dyn_cast<mlir::tt::DeviceLayoutInterface>(outputTy.getLayout());
+    if (checkMemrefGridShardForm && !outputDeviceLayout) {
       return op->emitOpError(
-          "Output memref must be in grid-shard form, i.e. have even rank, grid "
+          "output memref must have device layout, i.e. have even rank, grid "
           "shape followed by shard shape of equal rank, e.g. GxGxSxS");
-    }
-
-    llvm::ArrayRef<int64_t> inputGridShape =
-        inputTy.getShape().take_front(inputTy.getShape().size() / 2);
-    llvm::ArrayRef<int64_t> outputGridShape =
-        outputTy.getShape().take_front(outputTy.getShape().size() / 2);
-    if (checkMemrefGridShape && inputGridShape != outputGridShape) {
-      return op->emitOpError(
-          "Input and output memref grid shapes must be the same");
     }
 
     return mlir::success();
@@ -2197,7 +2189,6 @@ mlir::LogicalResult mlir::tt::ttir::StreamLayoutOp::verify() {
                      /*allowMemorySpaceChange*/ true,
                      /*checkMemrefRank*/ true,
                      /*checkMemrefGridShardForm */ true,
-                     /*checkMemrefGridShape*/ false,
                      /*checkMemrefShardShape*/ false);
   if (failed(inputStorageVerification)) {
     return inputStorageVerification;
@@ -2209,7 +2200,6 @@ mlir::LogicalResult mlir::tt::ttir::StreamLayoutOp::verify() {
                      /*allowMemorySpaceChange*/ true,
                      /*checkMemrefRank*/ true,
                      /*checkMemrefGridShardForm */ true,
-                     /*checkMemrefGridShape*/ false,
                      /*checkMemrefShardShape*/ true);
   if (failed(storageResultVerification)) {
     return storageResultVerification;
@@ -3460,8 +3450,9 @@ verifyAffineShapes(llvm::function_ref<mlir::InFlightDiagnostic()> diagFn,
       // If the top level operand is a memref, the front half of its shape
       // is the grid shape, so we cut it off the back to get just the grid
       // shape.
-      assert(memref.getRank() % 2 == 0);
-      outputGridShape = memref.getShape().take_front(memref.getRank() / 2);
+      mlir::tt::DeviceLayoutInterface layout =
+          mlir::cast<mlir::tt::DeviceLayoutInterface>(memref.getLayout());
+      outputGridShape = layout.getGridShape(memref);
     }
     if (opGridShape != outputGridShape) {
       return emitOpError(
@@ -3543,8 +3534,9 @@ verifyAffineShapes(llvm::function_ref<mlir::InFlightDiagnostic()> diagFn,
         // If the top level operand is a memref, the front half of its shape
         // will include the grid shape, so we cut it off to get just the shard
         // shape.
-        assert(memref.getRank() % 2 == 0);
-        expectedShardShape = memref.getShape().take_back(memref.getRank() / 2);
+        mlir::tt::DeviceLayoutInterface layout =
+            mlir::cast<mlir::tt::DeviceLayoutInterface>(memref.getLayout());
+        expectedShardShape = layout.getShardShape(memref);
         isStream = mlir::isa<tt::ViewLayoutAttr>(memref.getLayout());
       }
 
@@ -3614,9 +3606,9 @@ mlir::tt::ttir::GenericOp::getOperandGridShapes() {
   for (auto operand : this->getOperands()) {
     auto memrefType = mlir::dyn_cast<MemRefType>(operand.getType());
     if (memrefType) {
-      assert(memrefType.getRank() % 2 == 0);
-      gridShapes.emplace_back(
-          memrefType.getShape().take_front(memrefType.getRank() / 2));
+      mlir::tt::DeviceLayoutInterface layout =
+          mlir::cast<mlir::tt::DeviceLayoutInterface>(memrefType.getLayout());
+      gridShapes.emplace_back(layout.getGridShape(memrefType));
     } else {
       auto tensorType = mlir::cast<RankedTensorType>(operand.getType());
       MetalLayoutAttr layout =

--- a/lib/Dialect/TTIR/Transforms/GenericLowerDMAs.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericLowerDMAs.cpp
@@ -185,12 +185,10 @@ public:
 
     AffineMap dmaIndexingMap = *dma.getSrcAffineMap();
     MemRefType memref = dma.getSrcMemRefType();
-    assert(memref.getRank() % 2 == 0 && "Only even rank memrefs are supported");
-    ArrayRef<int64_t> memrefShape = memref.getShape();
-    ArrayRef<int64_t> memrefGridShape =
-        memrefShape.take_front(memrefShape.size() / 2);
-    ArrayRef<int64_t> memrefShardShape =
-        memrefShape.drop_front(memrefShape.size() / 2);
+    DeviceLayoutInterface layout =
+        mlir::cast<DeviceLayoutInterface>(memref.getLayout());
+    ArrayRef<int64_t> memrefGridShape = layout.getGridShape(memref);
+    ArrayRef<int64_t> memrefShardShape = layout.getShardShape(memref);
 
     GenericOp genericParent = dma->getParentOfType<ttir::GenericOp>();
     unsigned outputOperandsIndex =
@@ -211,7 +209,8 @@ public:
             .applyViews();
     // TODO(#1909) Once we have an allocation pass, we need to lookup the page
     // size instead of calculating it here.
-    size_t pageSize = getMemRefShardSizeBytes(memref);
+    size_t pageSize = device.getMemrefSizeBytes(underlyingMemrefAndView.first,
+                                                /*pageSize=*/0);
     AffineMap memoryMap =
         device.getMemoryMap(underlyingMemrefAndView, pageSize);
     size_t elemSizeBytes = getElementSizeBytes(memref);

--- a/test/ttmlir/Conversion/TTIRToTTMetal/alloc_lowering.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTMetal/alloc_lowering.mlir
@@ -3,14 +3,14 @@
 
 #l1_ = #tt.memory_space<l1>
 
-func.func @alloc_no_addr(%arg0: memref<1x1x8x24x!tt.tile<32x32, f32>, #tt.shard<98304x4096>, #l1_>, %arg1: memref<1x1x24x32x!tt.tile<32x32, f32>, #tt.shard<131072x4096>, #l1_>) ->memref<8x8x1x4x!tt.tile<32x32, f32>, #l1_> {
+func.func @alloc_no_addr(%arg0: memref<1x1x8x24x!tt.tile<32x32, f32>, #tt.shard<98304x4096>, #l1_>, %arg1: memref<1x1x24x32x!tt.tile<32x32, f32>, #tt.shard<131072x4096>, #l1_>) -> memref<8x8x1x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_> {
     // CHECK: %{{[0-9]+}} = "ttmetal.create_buffer"()
     // CHECK-SAME: {{.*}}address = 1000 : i64
     // TODO(#1909): Change this default address to whatever the allocation pass decides the address is.
     // CHECK-SAME: {{.*}}memory_space = #l1_
     // CHECK-SAME: {{.*}}size = 16384 : i64
-    %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x8x1x4x!tt.tile<32x32, f32>, #l1_>
-    return %alloc : memref<8x8x1x4x!tt.tile<32x32, f32>, #l1_>
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x8x1x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
+    return %alloc : memref<8x8x1x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
 }
 
 func.func @alloc_with_addr(%arg0: memref<1x1x8x24x!tt.tile<32x32, f32>, #tt.shard<98304x4096>, #l1_>, %arg1: memref<1x1x24x32x!tt.tile<32x32, f32>, #tt.shard<131072x4096>, #l1_>) -> memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.shard<12288x4096>, #l1_> {

--- a/test/ttmlir/Conversion/TTIRToTTMetal/generic_lowering.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTMetal/generic_lowering.mlir
@@ -4,7 +4,7 @@
 #l1_ = #tt.memory_space<l1>
 module {
   func.func @generic0(%arg0: memref<1x1x8x24x!tt.tile<32x32, f32>, #tt.shard<98304x4096>, #l1_>, %arg1: memref<1x1x24x32x!tt.tile<32x32, f32>, #tt.shard<131072x4096>, #l1_>) -> memref<1x1x8x32x!tt.tile<32x32, f32>, #tt.shard<131072x4096>, #l1_> {
-    %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x8x1x4x!tt.tile<32x32, f32>, #l1_>
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<8x8x1x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
     %alloc_0 = memref.alloc() {alignment = 64 : i64, address = 0x10000} : memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.shard<12288x4096>, #l1_>
     %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<1x1x8x24x!tt.tile<32x32, f32>, #tt.shard<98304x4096>, #l1_>, memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.shard<12288x4096>, #l1_>) -> memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
     %alloc_1 = memref.alloc() {alignment = 64 : i64, address = 0x15000} : memref<8x8x3x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
@@ -14,8 +14,8 @@ module {
     // CHECK-SAME: {{.*}}threads = [#ttir.thread<datamovement, @datamovement_kernel0>, #ttir.thread<datamovement, @datamovement_kernel1>, #ttir.thread<compute, @compute_kernel2>]
     ttir.generic {grid = #tt.grid<8x8>, indexing_maps = [], iterator_types = [], threads = [#ttir.thread<datamovement, @datamovement_kernel0>, #ttir.thread<datamovement, @datamovement_kernel1>, #ttir.thread<compute, @compute_kernel2>]}
         ins(%stream, %stream_2 : memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<8x8x3x4x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>)
-        outs(%alloc : memref<8x8x1x4x!tt.tile<32x32, f32>, #l1_>)
-    %view = "ttir.view_layout"(%alloc) : (memref<8x8x1x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x8x32x!tt.tile<32x32, f32>, #tt.shard<131072x4096>, #l1_>
+        outs(%alloc : memref<8x8x1x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>)
+    %view = "ttir.view_layout"(%alloc) : (memref<8x8x1x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>) -> memref<1x1x8x32x!tt.tile<32x32, f32>, #tt.shard<131072x4096>, #l1_>
     return %view : memref<1x1x8x32x!tt.tile<32x32, f32>, #tt.shard<131072x4096>, #l1_>
   }
 

--- a/test/ttmlir/Dialect/TTIR/allocate/generic_form_streams_matmul.mlir
+++ b/test/ttmlir/Dialect/TTIR/allocate/generic_form_streams_matmul.mlir
@@ -7,56 +7,56 @@
 #mapR = affine_map<(d0, d1, d2) -> (d2, d1)>
 #mapO = affine_map<(d0, d1, d2) -> (d0, d1)>
 
-func.func @matmul_single_core_stream(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+func.func @matmul_single_core_stream(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>, %arg1: memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>
   // CHECK-NOT: "ttir.view_layout"
   // CHECK: [[lhs:%[a-z0-9_]+]] = "ttir.stream_layout"(%arg0,
-  %0 = "ttir.view_layout"(%arg0) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>
+  %0 = "ttir.view_layout"(%arg0) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>) -> memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
   // CHECK-NOT: "ttir.view_layout"
   // CHECK: [[rhs:%[a-z0-9_]+]] = "ttir.stream_layout"(%arg1,
-  %1 = "ttir.view_layout"(%arg1) : (memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  %1 = "ttir.view_layout"(%arg1) : (memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>) -> memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
   // CHECK: ttir.generic{{.*}}
   // CHECK-NEXT: ins([[lhs]], [[rhs]] : {{.*}})
   // CHECK-NEXT: outs([[out:%[a-z0-9_]+]] : {{.*}})
   "ttir.generic"(%0, %1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^bb0(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
     "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
-  }) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
-  return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  }) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>
 }
 
-func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
+func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.shard<24576x4096>, #l1_>, %arg1: memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #l1_>) -> memref<2x4x4x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #l1_>
   // CHECK-NOT: "ttir.view_layout"
   // CHECK: [[lhs:%[a-z0-9_]+]] = "ttir.stream_layout"(%arg0,
-  %0 = "ttir.view_layout"(%arg0) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
+  %0 = "ttir.view_layout"(%arg0) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.shard<24576x4096>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
   // CHECK-NOT: "ttir.view_layout"
   // CHECK: [[rhs:%[a-z0-9_]+]] = "ttir.stream_layout"(%arg1,
-  %1 = "ttir.view_layout"(%arg1) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>
+  %1 = "ttir.view_layout"(%arg1) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
   // CHECK: ttir.generic{{.*}}
   // CHECK-NEXT: ins([[lhs]], [[rhs]] : {{.*}})
   // CHECK-NEXT: outs([[out:%[a-z0-9_]+]] : {{.*}})
   "ttir.generic"(%0, %1, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^bb0(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>):
     "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
-  }) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>, memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
-  return %alloc : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
+  }) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<2x4x4x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #l1_>) -> ()
+  return %alloc : memref<2x4x4x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #l1_>
 }
 
-func.func @matmul_multi_core_transpose(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<4x4x8x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
+func.func @matmul_multi_core_transpose(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.shard<24576x4096>, #l1_>, %arg1: memref<4x4x8x6x!tt.tile<32x32, f32>, #tt.shard<24576x4096>, #l1_>) -> memref<2x4x4x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #l1_>
   // CHECK-NOT: "ttir.view_layout"
   // CHECK: [[lhs:%[a-z0-9_]+]] = "ttir.stream_layout"(%arg0,
-  %0 = "ttir.view_layout"(%arg0) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
+  %0 = "ttir.view_layout"(%arg0) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.shard<24576x4096>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
   // CHECK-NOT: "ttir.view_layout"
   // CHECK: [[rhs:%[a-z0-9_]+]] = "ttir.stream_layout"(%arg1, {{.*}}, #tt.view<(d0, d1, d2, d3) -> (d1, d0, d3, d2)>,
-  %1 = "ttir.view_layout"(%arg1) : (memref<4x4x8x6x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, affine_map<(d0, d1, d2, d3) -> (d1, d0, d3, d2)>, #l1_>
+  %1 = "ttir.view_layout"(%arg1) : (memref<4x4x8x6x!tt.tile<32x32, f32>, #tt.shard<24576x4096>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.view<(d0, d1, d2, d3) -> (d1, d0, d3, d2)>, #l1_>
   // CHECK: ttir.generic{{.*}}
   // CHECK-NEXT: ins([[lhs]], [[rhs]] : {{.*}})
   // CHECK-NEXT: outs([[out:%[a-z0-9_]+]] : {{.*}})
   "ttir.generic"(%0, %1, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#mapL, #mapR, #mapO], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^bb0(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>):
     "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
-  }) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<4x4x6x8x!tt.tile<32x32, f32>, affine_map<(d0, d1, d2, d3) -> (d1, d0, d3, d2)>, #l1_>, memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
-  return %alloc : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
+  }) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.view<(d0, d1, d2, d3) -> (d1, d0, d3, d2)>, #l1_>, memref<2x4x4x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #l1_>) -> ()
+  return %alloc : memref<2x4x4x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #l1_>
 }

--- a/test/ttmlir/Dialect/TTIR/bufferization/memory_effects.mlir
+++ b/test/ttmlir/Dialect/TTIR/bufferization/memory_effects.mlir
@@ -26,21 +26,21 @@ func.func @to_layout_pure_tensors(%arg0: tensor<2x4x!tt.tile<32x32, f32>>) -> te
   return %0 : tensor<2x4x!tt.tile<32x32, f32>>
 }
 
-func.func @matmul_memref(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x4x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+func.func @matmul_memref(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>, %arg1: memref<1x1x4x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>
   // Ensure that the generic op is not removed.
   // CHECK: ttir.generic
   "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map1, #map2], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg3: memref<4x2x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
     "ttir.tile_matmul_block"(%arg2, %arg3, %arg4) : (memref<2x4x!tt.tile<32x32, f32>, #l1_>, memref<4x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
-  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x4x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
-  return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>, memref<1x1x4x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>
 }
 
-func.func @to_layout_memref(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+func.func @to_layout_memref(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
   // Ensure that the layout op is not removed.
   // CHECK: ttir.to_layout
-  "ttir.to_layout"(%arg0, %alloc) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
-  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+  "ttir.to_layout"(%arg0, %alloc) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
 }

--- a/test/ttmlir/Dialect/TTIR/generic/generic_hw_thread_selection.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/generic_hw_thread_selection.mlir
@@ -9,8 +9,8 @@
 #parallel = #tt.iterator_type<parallel>
 #reduction = #tt.iterator_type<reduction>
 
-func.func @add(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+func.func @add(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>, %arg1: memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
   "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^datamovement0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
     ttir.yield %cb0 : (memref<2x4x!tt.tile<32x32, f32>, #l1_>)
@@ -35,12 +35,12 @@ func.func @add(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<
       }
     }
     ttir.yield %cb2 : (memref<2x4x!tt.tile<32x32, f32>, #l1_>)
-  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
-  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
 }
 
-func.func @matmul_single_core(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x4x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+func.func @matmul_single_core(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>, %arg1: memref<1x1x4x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>
   "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^datamovement0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<4x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
     ttir.yield %cb0 : (memref<2x4x!tt.tile<32x32, f32>, #l1_>)
@@ -58,12 +58,12 @@ func.func @matmul_single_core(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>,
     ttir.await %cb0, %cb1 : (memref<2x4x!tt.tile<32x32, f32>, #l1_>, memref<4x2x!tt.tile<32x32, f32>, #l1_>)
     "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<2x4x!tt.tile<32x32, f32>, #l1_>, memref<4x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
     ttir.yield %cb2 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
-  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x4x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
-  return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>, memref<1x1x4x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>
 }
 
-func.func @tilize(%arg0: memref<2x4x128x192xf32, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
+func.func @tilize(%arg0: memref<2x4x128x192xf32, #tt.shard<768x4>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.shard<24576x4096>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.shard<24576x4096>, #l1_>
   "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 1, 1>}> ({
   ^datamovement0(%cb0: memref<128x192xf32, #l1_>, %cb1: memref<4x6x!tt.tile<32x32, f32>, #l1_>):
     ttir.yield %cb0 : (memref<128x192xf32, #l1_>)
@@ -78,6 +78,6 @@ func.func @tilize(%arg0: memref<2x4x128x192xf32, #l1_>) -> memref<2x4x4x6x!tt.ti
     ttir.await %cb0 : (memref<128x192xf32, #l1_>)
     "ttir.tile_tilize_block"(%cb0, %cb1) : (memref<128x192xf32, #l1_>, memref<4x6x!tt.tile<32x32, f32>, #l1_>) -> ()
     ttir.yield %cb1 : (memref<4x6x!tt.tile<32x32, f32>, #l1_>)
-  }) : (memref<2x4x128x192xf32, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> ()
-  return %alloc : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
+  }) : (memref<2x4x128x192xf32, #tt.shard<768x4>, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.shard<24576x4096>, #l1_>) -> ()
+  return %alloc : memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.shard<24576x4096>, #l1_>
 }

--- a/test/ttmlir/Dialect/TTIR/generic/generic_loops.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/generic_loops.mlir
@@ -9,8 +9,8 @@
 #parallel = #tt.iterator_type<parallel>
 #reduction = #tt.iterator_type<reduction>
 
-func.func @unary2x4(%arg0: memref<2x4x128x192xf32, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
+func.func @unary2x4(%arg0: memref<2x4x128x192xf32, #tt.shard<768x4>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.shard<24576x4096>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.shard<24576x4096>, #l1_>
   "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 1, 1>}> ({
   ^datamovement0(%cb0: memref<128x192xf32, #l1_>, %cb1: memref<4x6x!tt.tile<32x32, f32>, #l1_>):
     // CHECK: scf.for %{{.*}} = %c0 to %c1
@@ -28,12 +28,12 @@ func.func @unary2x4(%arg0: memref<2x4x128x192xf32, #l1_>) -> memref<2x4x4x6x!tt.
     ttir.await %cb0 : (memref<128x192xf32, #l1_>)
     "ttir.tile_tilize_block"(%cb0, %cb1) : (memref<128x192xf32, #l1_>, memref<4x6x!tt.tile<32x32, f32>, #l1_>) -> ()
     ttir.yield %cb1 : (memref<4x6x!tt.tile<32x32, f32>, #l1_>)
-  }) : (memref<2x4x128x192xf32, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> ()
-  return %alloc : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
+  }) : (memref<2x4x128x192xf32, #tt.shard<768x4>, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.shard<24576x4096>, #l1_>) -> ()
+  return %alloc : memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.shard<24576x4096>, #l1_>
 }
 
-func.func @binary1x1(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+func.func @binary1x1(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>, %arg1: memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
   "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^datamovement0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
     // CHECK: scf.for %{{.*}} = %c0 to %c1
@@ -63,12 +63,12 @@ func.func @binary1x1(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: m
       }
     }
     ttir.yield %cb2 : (memref<2x4x!tt.tile<32x32, f32>, #l1_>)
-  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
-  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
 }
 
-func.func @matmul1x1(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x4x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+func.func @matmul1x1(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>, %arg1: memref<1x1x4x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>
   "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^datamovement0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<4x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
     // CHECK: scf.for %{{.*}} = %c0 to %c1
@@ -95,16 +95,16 @@ func.func @matmul1x1(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: m
     ttir.await %cb0, %cb1 : (memref<2x4x!tt.tile<32x32, f32>, #l1_>, memref<4x2x!tt.tile<32x32, f32>, #l1_>)
     "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<2x4x!tt.tile<32x32, f32>, #l1_>, memref<4x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
     ttir.yield %cb2 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
-  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x4x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
-  return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>, memref<1x1x4x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>
 }
 
-func.func @matmul_outer_k(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
-  %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
-  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
-  %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
-  %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
+func.func @matmul_outer_k(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>, %arg1: memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>
+  %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>
+  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>
+  %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>) -> memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
+  %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>) -> memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
   "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^datamovement0(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
     // CHECK: scf.for %{{.*}} = %c0 to %c1
@@ -141,16 +141,16 @@ func.func @matmul_outer_k(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, %ar
     ttir.await %cb0, %cb1 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>)
     "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
     ttir.yield %cb2 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
-  }) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
-  return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  }) : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>
 }
 
-func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
-  %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>
-  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>
-  %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
-  %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #l1_>, memref<2x4x6x8x!tt.tile<32x32, f32>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
+func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.shard<24576x4096>, #l1_>, %arg1: memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #l1_>) -> memref<2x4x4x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #l1_>
+  %alloc_0 = memref.alloc() {alignment = 64 : i64} : memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.shard<24576x4096>, #l1_>
+  %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<2x4x6x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #l1_>
+  %stream = "ttir.stream_layout"(%arg0, %alloc_0) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.shard<24576x4096>, #l1_>, memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.shard<24576x4096>, #l1_>) -> memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
+  %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #l1_>, memref<2x4x6x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #l1_>) -> memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #tt.view<map(4)>, #l1_>
   "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<2x4>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^datamovement0(%cb0: memref<4x6x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<6x8x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<4x8x!tt.tile<32x32, f32>, #l1_>, %sem0: !ttir.semaphore, %sem1: !ttir.semaphore, %sem2: !ttir.semaphore, %sem3: !ttir.semaphore):
     // CHECK: scf.for %{{.*}} = %c0 to %c1
@@ -177,6 +177,6 @@ func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #l1_>, 
     ttir.await %cb0, %cb1 : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>)
     "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<4x6x!tt.tile<32x32, f32>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>, memref<4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
     ttir.yield %cb2 : (memref<4x8x!tt.tile<32x32, f32>, #l1_>)
-  }) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>) -> ()
-  return %alloc : memref<2x4x4x8x!tt.tile<32x32, f32>, #l1_>
+  }) : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #tt.view<map(4)>, #l1_>, memref<2x4x4x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #l1_>) -> ()
+  return %alloc : memref<2x4x4x8x!tt.tile<32x32, f32>, #tt.shard<32768x4096>, #l1_>
 }

--- a/test/ttmlir/Dialect/TTIR/generic/generic_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/generic_negative.mlir
@@ -7,12 +7,12 @@
 
 // CHECK: error: 'ttir.generic' op output grid shape must match the generic op's grid shape
 
-func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
   "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<2x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 1, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
-  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
-  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
 }
 
 // -----
@@ -23,12 +23,12 @@ func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1
 
 // CHECK: error: 'ttir.generic' op region must have at least as many arguments as the number of top-level operands
 
-func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
   "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 1, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
-  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
-  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
 }
 
 // -----
@@ -39,12 +39,12 @@ func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1
 
 // CHECK: error: 'ttir.generic' op region arguments must be of MemRefType
 
-func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
   "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 1, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: tensor<2x4x!tt.tile<32x32, f32>, #l1_>):
-  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
-  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
 }
 
 // -----
@@ -56,12 +56,12 @@ func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1
 
 // CHECK: error: 'ttir.generic' op region argument memory space must match the memory space of the corresponding operand
 
-func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #dram_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #dram_>
+func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #dram_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #dram_>
   "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 1, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
-  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #dram_>) -> ()
-  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #dram_>
+  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #dram_>) -> ()
+  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #dram_>
 }
 
 // -----
@@ -72,12 +72,12 @@ func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1
 
 // CHECK: error: 'ttir.generic' op region argument shape must match the shape of the corresponding operand
 
-func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
   "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>, threads = [#ttir.thread<compute>]}> ({
   ^bb0(%arg2: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
-  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
-  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
 }
 
 // -----
@@ -88,14 +88,14 @@ func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1
 
 // CHECK: error: 'ttir.generic' op all regions must have the same number of arguments
 
-func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
   "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 1, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
   }, {
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg5: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
-  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
-  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
 }
 
 // -----
@@ -107,12 +107,12 @@ func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1
 
 // CHECK: error: 'ttir.generic' op all indexing maps must have the same number of dimensions
 
-func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
   "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map1], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 1, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
-  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
-  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
 }
 
 // -----
@@ -123,14 +123,14 @@ func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1
 
 // CHECK: error: 'ttir.generic' op all regions must have the same argument types
 
-func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
   "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 1, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg5: !ttir.semaphore):
   }, {
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg5: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
-  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
-  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
 }
 
 // -----
@@ -144,12 +144,12 @@ func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1
 
 // CHECK: error: 'ttir.generic' op grid shape mismatch between operand[1] grid_shape=[1, 2] and operand[2] grid_shape=[1, 1] at affine dim d1
 
-func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>, %arg1: memref<1x2x2x4x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>
   "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#lhs, #rhs, #out], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg3: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
-  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x2x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
-  return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>, memref<1x2x2x4x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>
 }
 
 // -----
@@ -163,12 +163,12 @@ func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memr
 
 // CHECK: error: 'ttir.generic' op grid shape mismatch between operand[0] grid_shape=[1, 1] and operand[1] grid_shape=[2, 1] at affine dim d2
 
-func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>, %arg1: memref<2x1x2x4x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>
   "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#lhs, #rhs, #out], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^bb0(%arg2: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %arg3: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
-  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<2x1x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
-  return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>, memref<2x1x2x4x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>
 }
 
 // -----
@@ -179,11 +179,11 @@ func.func @matmul(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memr
 
 // CHECK: error: 'ttir.tile_matmul_block' op expected to be in a compute region
 
-func.func @matmul(%arg0: memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+func.func @matmul(%arg0: memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>) -> memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>
   "ttir.generic"(%arg0, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map], iterator_types = [#parallel, #parallel], operandSegmentSizes = array<i32: 1, 1>, threads = [#ttir.thread<datamovement>]}> ({
   ^bb0(%arg2: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %arg4: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
   "ttir.tile_matmul_block"(%arg2, %arg4, %arg4) : (memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
-  }) : (memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>) -> ()
-  return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #l1_>
+  }) : (memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>
 }

--- a/test/ttmlir/Dialect/TTIR/loops/linearize_memref.mlir
+++ b/test/ttmlir/Dialect/TTIR/loops/linearize_memref.mlir
@@ -4,8 +4,8 @@
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #parallel = #tt.iterator_type<parallel>
 
-func.func @add(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+func.func @add(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>, %arg1: memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
   "ttir.generic"(%arg0, %arg1, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^bb0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
     // CHECK: [[cshape0:%[a-z0-9_]+]] = memref.collapse_shape %cb0
@@ -23,12 +23,12 @@ func.func @add(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1: memref<
       }
     }
     ttir.yield %cb2 : (memref<2x4x!tt.tile<32x32, f32>, #l1_>)
-  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
-  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
 }
 
-func.func @addT(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1T: memref<1x1x4x2x!tt.tile<32x32, f32>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_> {
-  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+func.func @addT(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>, %arg1T: memref<1x1x4x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>) -> memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
   "ttir.generic"(%arg0, %arg1T, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map, #map, #map], iterator_types = [#parallel, #parallel], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^bb0(%cb0: memref<2x4x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<4x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x4x!tt.tile<32x32, f32>, #l1_>):
     // CHECK: [[cshape0:%[a-z0-9_]+]] = memref.collapse_shape %cb0
@@ -46,6 +46,6 @@ func.func @addT(%arg0: memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, %arg1T: memre
       }
     }
     ttir.yield %cb2 : (memref<2x4x!tt.tile<32x32, f32>, #l1_>)
-  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>, memref<1x1x4x2x!tt.tile<32x32, f32>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>) -> ()
-  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #l1_>
+  }) : (memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>, memref<1x1x4x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>, memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x4x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
 }


### PR DESCRIPTION
This interface implies a MemRefLayoutAttrInterface that conforms to Tenstorrent device layout. Tenstorrent devices are divided into a grid of cores, onto which we map tensors that have been chunked into shards.  This device layout attribute semantically means exactly this, i.e. we have some tensors that are distributed amongst the device core grid. This means that memref shapes should be reinterpreted as a concatenation of a grid shape and a shard shape, for example, memref<1x2x3x4xtt.tile> should be interpreted as a grid of 1x2 and a shard of 3x4. This interface provides some convenience methods for working with this interpretation of memref shape.

This commit introduces this interface and fixes up all of the places where we previously assumed this layout.
