### PR TITLE
TTKernel to EmitC to C++ refactor

### DIFF
--- a/env/activate
+++ b/env/activate
@@ -10,9 +10,9 @@ fi
 
 [ -f $TTMLIR_VENV_DIR/bin/activate ] && source $TTMLIR_VENV_DIR/bin/activate
 export TTMLIR_ENV_ACTIVATED=1
-export PATH="$(pwd)/build/bin:$TTMLIR_TOOLCHAIN_DIR/bin:$TTMLIR_TOOLCHAIN_DIR/venv/bin:$PATH"
+export PATH="$(pwd)/${BUILD_DIR:=build}/bin:$TTMLIR_TOOLCHAIN_DIR/bin:$TTMLIR_TOOLCHAIN_DIR/venv/bin:$PATH"
 export TT_METAL_HOME="$(pwd)/third_party/tt-metal/src/tt-metal"
 export TT_METAL_BUILD_HOME="$(pwd)/third_party/tt-metal/src/tt-metal-build"
 export TT_MLIR_HOME="$(pwd)"
-export PYTHONPATH="$(pwd)/build/python_packages:$(pwd)/.local/toolchain/python_packages/mlir_core:${TT_METAL_HOME}:${TT_METAL_HOME}/tt_eager:${TT_METAL_BUILD_HOME}/tools/profiler/bin:${TT_METAL_HOME}/ttnn"
+export PYTHONPATH="$(pwd)/${BUILD_DIR:=build}/python_packages:$(pwd)/.local/toolchain/python_packages/mlir_core:${TT_METAL_HOME}:${TT_METAL_HOME}/tt_eager:${TT_METAL_BUILD_HOME}/tools/profiler/bin:${TT_METAL_HOME}/ttnn"
 export ARCH_NAME="${ARCH_NAME:-wormhole_b0}"

--- a/include/ttmlir-c/TTKernelTypes.h
+++ b/include/ttmlir-c/TTKernelTypes.h
@@ -16,6 +16,9 @@ MLIR_CAPI_EXPORTED MlirType ttmlirTTKernelCBTypeGet(MlirContext ctx,
                                                     uint64_t port,
                                                     MlirType memrefType);
 
+MLIR_CAPI_EXPORTED MlirAttribute
+ttmlirTTKernelThreadTypeAttrGet(MlirContext ctx, uint32_t enumValue);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/ttmlir/Conversion/TTKernelToEmitC/TTKernelToEmitC.h
+++ b/include/ttmlir/Conversion/TTKernelToEmitC/TTKernelToEmitC.h
@@ -15,30 +15,6 @@
 namespace mlir::tt {
 #define GEN_PASS_DECL_CONVERTTTKERNELTOEMITC
 #include "ttmlir/Conversion/Passes.h.inc"
-
-//===----------------------------------------------------------------------===//
-// IR -> C++ text codegen:
-//===----------------------------------------------------------------------===//
-
-// Converts given region to EmitC dialect and translates it to C++ code.
-LogicalResult emitOpRegionAsCpp(Region *region, std::string &regionCpp,
-                                const ttkernel::ThreadType &threadType);
-
-// Converts given region to EmitC dialect and writes it as C++ code to 'os'.
-LogicalResult emitOpRegionAsCpp(Region *region, llvm::raw_ostream &os,
-                                const ttkernel::ThreadType &threadType);
-
-// Converts enqueue program op's regions to EmitC dialect and writes
-// them as C++ code to 'cppStrings' (in the same order as
-// 'enqueueProgramOp' regions).
-LogicalResult
-emitEnqueueProgramOpRegionsAsCpp(ttmetal::EnqueueProgramOp enqueueProgramOp,
-                                 llvm::SmallVector<std::string> &cppStrings);
-
-// Converts all FuncOps in 'op' as if by emitOpRegionAsCpp().
-LogicalResult emitKernelAsCpp(mlir::ModuleOp op, llvm::raw_ostream &os,
-                              const ttkernel::ThreadType &threadType);
-
 } // namespace mlir::tt
 
 #endif

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -593,23 +593,6 @@ def TTKernel_NocSemaphoreSetMulticastLoopbackOp : TTKernel_Op<"noc_semaphore_set
                          BoolAttr:$multicast_path_reserve);
 }
 
-def TTKernel_NocTransactionsTableOp : TTKernel_Op<"noc_transactions_table"> {
-    let summary = [{define an array of parameter entries for a sequence of NOC
-     read/write operations
-    }];
-    let description = [{
-      Encapsulates parameters for a group of NOC read/write operations as
-      an array of (dst, src, size, dst_x, dst_y, numElements) entries, with
-      each entry slot of type int32_t.
-      An entry defines an src->dst data movement operation and as either
-      a read (remote src, local dst) or a write (local src, remote dst) by
-      the calling core.
-    }];
-
-    let arguments = (ins DenseI32ArrayAttr:$entries);
-    let results = (outs AnyStaticShapeMemRef:$table);
-}
-
 //===----------------------------------------------------------------------===//
 // TTKernel Compile and runtime arguments operations
 //===----------------------------------------------------------------------===//
@@ -767,15 +750,6 @@ def TTKernel_NocAsyncWriteMulticastLoopbackSrcOp : TTKernel_Op<"noc_async_write_
 //===----------------------------------------------------------------------===//
 // TTKernel Misc operations
 //===----------------------------------------------------------------------===//
-
-def TTKernel_ReturnOp : TTKernel_Op<"return", [Pure, ReturnLike, Terminator]> {
-    let summary = "Return op.";
-    let description = [{
-      Return operation
-    }];
-
-    let hasVerifier = 1;
-}
 
 def TTKernel_UnreachableOp : TTKernel_Op<"unreachable", [Pure, ReturnLike, Terminator]> {
     let summary = "Unreachable op.";

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsEnums.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsEnums.td
@@ -8,13 +8,13 @@
 include "mlir/IR/EnumAttr.td"
 
 def TTKernel_ThreadTypeNoc : I32EnumAttrCase<"Noc", 0, "noc">;
-def TTKernel_ThreadTypeTensix : I32EnumAttrCase<"Tensix", 1, "tensix">;
+def TTKernel_ThreadTypeCompute : I32EnumAttrCase<"Compute", 1, "compute">;
 def TTKernel_ThreadTypeEthernet : I32EnumAttrCase<"Ethernet", 2, "ethernet">;
 
 def TTKernel_ThreadType : I32EnumAttr<"ThreadType", "TTKernel ThreadTypes",
                            [
                             TTKernel_ThreadTypeNoc,
-                            TTKernel_ThreadTypeTensix,
+                            TTKernel_ThreadTypeCompute,
                             TTKernel_ThreadTypeEthernet,
                            ]> {
   let genSpecializedAttr = 0;

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
@@ -25,8 +25,8 @@ class TTKernel_Attr<string name, string attrMnemonic, list<Trait> traits = [],
   let attrName = "ttkernel." # attrMnemonic;
 }
 
-def TTKernel_TensixConfigAttr: TTKernel_Attr<"TensixConfig", "tensix_config", [TTKernel_KernelConfigInterface]> {
-  let summary = "TT TensixConfig attribute";
+def TTKernel_ComputeConfigAttr: TTKernel_Attr<"ComputeConfig", "compute_config", [TTKernel_KernelConfigInterface]> {
+  let summary = "TT ComputeConfig attribute";
   let description = [{
     TT compute_desc attribute
   }];
@@ -37,11 +37,11 @@ def TTKernel_TensixConfigAttr: TTKernel_Attr<"TensixConfig", "tensix_config", [T
   let assemblyFormat =  "`<` $math_fidelity`,` $fp32_dest_acc_en`,` $math_approx_mode`,` `[` $unpack_to_dest_mode `]` `>`";
 
   let extraClassDeclaration = [{
-    static TensixConfigAttr get(::mlir::MLIRContext *context){
-      return TensixConfigAttr::get(context, MathFidelity::HiFi4, false, false, {UnpackToDestMode::Default});
+    static ComputeConfigAttr get(::mlir::MLIRContext *context){
+      return ComputeConfigAttr::get(context, MathFidelity::HiFi4, false, false, {UnpackToDestMode::Default});
     };
 
-    ThreadType getThreadType() const { return ThreadType::Tensix; }
+    ThreadType getThreadType() const { return ThreadType::Compute; }
   }];
 }
 
@@ -70,7 +70,7 @@ def TTKernel_EthernetConfigAttr: TTKernel_Attr<"EthernetConfig", "ethernet_confi
   }];
 }
 
-def TTKernel_KernelConfigAttr : AnyAttrOf<[TTKernel_TensixConfigAttr, TTKernel_NocConfigAttr, TTKernel_EthernetConfigAttr]>;
+def TTKernel_KernelConfigAttr : AnyAttrOf<[TTKernel_ComputeConfigAttr, TTKernel_NocConfigAttr, TTKernel_EthernetConfigAttr]>;
 
 def TTKernel_KernelConfigArrayAttr : TypedArrayAttrBase<TTKernel_KernelConfigAttr, "">;
 
@@ -157,7 +157,7 @@ def TTKernel_InterleavedAddrGenFast : TTKernel_Type<"InterleavedAddrGenFast", "i
 }
 
 def TTKernel_DataFormat : TTKernel_Type<"DataFormat", "DataFormat"> {
-    let summary = "TTKernel tensix data format type";
+    let summary = "TTKernel compute data format type";
     let description = "Data format type in TTKernel dialect";
 }
 

--- a/include/ttmlir/Target/TTKernel/TTKernelToCpp.h
+++ b/include/ttmlir/Target/TTKernel/TTKernelToCpp.h
@@ -9,12 +9,27 @@
 #include "mlir/Support/LogicalResult.h"
 #include "ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.h"
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Support/LogicalResult.h"
+
 namespace mlir::tt::ttkernel {
 
-// Translates a TTKernel operation to C++ and writes it to the given
-// stream.
-LogicalResult translateTTKernelToCpp(Operation *op, llvm::raw_ostream &os,
-                                     const ThreadType &threadType);
+// Translates a top level TTKernel func op (already converted to EmitC) to C++
+// and writes it to the given stream.
+LogicalResult translateKernelFuncToCpp(func::FuncOp entry,
+                                       llvm::raw_ostream &os);
+
+// Translates a top level TTKernel func op (already converted to EmitC) to C++
+// for the given symbol name and writes it to the given stream.
+LogicalResult translateTopLevelKernelToCpp(ModuleOp moduleOp,
+                                           llvm::raw_ostream &os,
+                                           StringRef symbolName);
+
+// Walks over all top level TTKernel func ops (already converted to EmitC) in
+// the given module and writes them to the given stream.
+LogicalResult translateTopLevelKernelsToCpp(ModuleOp moduleOp,
+                                            llvm::raw_ostream &os);
 
 } // namespace mlir::tt::ttkernel
 

--- a/lib/CAPI/TTKernelTypes.cpp
+++ b/lib/CAPI/TTKernelTypes.cpp
@@ -15,3 +15,9 @@ MlirType ttmlirTTKernelCBTypeGet(MlirContext ctx, uint64_t address,
   return wrap(CBType::get(unwrap(ctx), symbolizeCBPort(port).value(), address,
                           mlir::cast<mlir::MemRefType>(unwrap(memrefType))));
 }
+
+MLIR_CAPI_EXPORTED MlirAttribute
+ttmlirTTKernelThreadTypeAttrGet(MlirContext ctx, uint32_t enumValue) {
+  return wrap(
+      ThreadTypeAttr::get(unwrap(ctx), static_cast<ThreadType>(enumValue)));
+}

--- a/lib/Conversion/TTIRToTTKernel/CMakeLists.txt
+++ b/lib/Conversion/TTIRToTTKernel/CMakeLists.txt
@@ -6,7 +6,6 @@ add_mlir_conversion_library(TTMLIRTTIRToTTKernel
   TTMLIRConversionPassIncGen
 
   LINK_LIBS PUBLIC
-  MLIRTTIRAnalysis
   MLIRIR
   MLIRPass
   MLIRTTIRAnalysis

--- a/lib/Conversion/TTIRToTTKernel/CMakeLists.txt
+++ b/lib/Conversion/TTIRToTTKernel/CMakeLists.txt
@@ -6,6 +6,7 @@ add_mlir_conversion_library(TTMLIRTTIRToTTKernel
   TTMLIRConversionPassIncGen
 
   LINK_LIBS PUBLIC
+  MLIRTTIRAnalysis
   MLIRIR
   MLIRPass
   MLIRTTIRAnalysis

--- a/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
+++ b/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
@@ -611,7 +611,7 @@ public:
     ThreadType threadType;
     switch (threadAttr.getThreadType()) {
     case ttir::ThreadType::Compute: {
-      threadType = ThreadType::Tensix;
+      threadType = ThreadType::Compute;
       break;
     }
     case ttir::ThreadType::Datamovement: {

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -191,6 +191,8 @@ public:
   LogicalResult
   matchAndRewrite(func::FuncOp op, func::FuncOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
+    assert(op.getCallableRegion());
+    assert(op.getCallableRegion()->hasOneBlock());
     Block *block = &op.getCallableRegion()->front();
     auto blockArgs = block->getArguments();
     if (blockArgs.empty()) {

--- a/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
@@ -130,13 +130,6 @@ static std::string verifyTilizeUntilizeCBs(CBType tilizedCB, CBType scalarCB) {
   return success();
 }
 
-::mlir::LogicalResult ReturnOp::verify() {
-  if (!insideEnqueueProgramOpRegion(getOperation())) {
-    return emitOpError("ReturnOp must be inside of a EnqueueProgramOp region");
-  }
-  return success();
-}
-
 ::mlir::LogicalResult CBReinterpretShapeOp::verify() {
   auto inCBType = getInput().getType();
   auto outCBType = getOutput().getType();

--- a/lib/Target/TTKernel/CMakeLists.txt
+++ b/lib/Target/TTKernel/CMakeLists.txt
@@ -7,8 +7,5 @@ add_mlir_translation_library(TTKernelTargetCpp
 
     LINK_LIBS PUBLIC
     MLIRTTKernelDialect
-    TTMLIRTTKernelToEmitC
-    MLIRFuncToEmitC
-    MLIRSCFToEmitC
-    MLIRArithToEmitC
+    MLIRTTIRDialect
 )

--- a/lib/Target/TTKernel/TTKernelToCpp.cpp
+++ b/lib/Target/TTKernel/TTKernelToCpp.cpp
@@ -132,7 +132,8 @@ LogicalResult translateKernelFuncToCpp(func::FuncOp entry,
 
   ThreadType threadType =
       entry->getAttrOfType<ThreadTypeAttr>(ThreadTypeAttr::name).getValue();
-  auto kernelModule = cloneEntryIntoStandaloneModule(entry, threadType);
+  FailureOr<mlir::ModuleOp> kernelModule =
+      cloneEntryIntoStandaloneModule(entry, threadType);
   if (failed(kernelModule)) {
     return failure();
   }

--- a/lib/Target/TTKernel/TTKernelToCpp.cpp
+++ b/lib/Target/TTKernel/TTKernelToCpp.cpp
@@ -2,30 +2,168 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "ttmlir/Target/TTKernel/TTKernelToCpp.h"
+
+#include "ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.h"
+
+#include "mlir/Dialect/EmitC/IR/EmitC.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/IRMapping.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Target/Cpp/CppEmitter.h"
-#include "ttmlir/Conversion/TTKernelToEmitC/TTKernelToEmitC.h"
 #include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/raw_ostream.h"
+
 #include <cassert>
 
 namespace mlir::tt::ttkernel {
 
-static llvm::LogicalResult
-translateModuleToCpp(Operation *op, llvm::raw_ostream &os,
-                     const ttkernel::ThreadType &threadType) {
+// Class used to add includes and other boilerplate code to the generated
+// kernel.
+namespace {
+class ScopedModuleHelper {
+public:
+  ScopedModuleHelper(OpBuilder *builder, Location loc, ThreadType threadType)
+      : builder(builder), loc(loc), threadType(threadType) {
+    builder->create<emitc::IncludeOp>(loc, "cstdint",
+                                      /*isStandard=*/true);
+    if (threadType == ThreadType::Noc) {
 
-  ModuleOp module = dyn_cast<ModuleOp>(op);
-  assert(module && "Expected ModuleOp as top level operation");
-  return mlir::tt::emitKernelAsCpp(module, os, threadType);
+      builder->create<emitc::IncludeOp>(loc, "dataflow_api.h",
+                                        /*isStandard=*/false);
+    }
+    if (threadType == ThreadType::Compute) {
+      builder->create<emitc::IncludeOp>(loc, "llk_defs.h",
+                                        /*isStandard=*/false);
+      builder->create<emitc::IncludeOp>(loc, "compute_kernel_api/common.h",
+                                        /*isStandard=*/false);
+      builder->create<emitc::IncludeOp>(loc, "compute_kernel_api/tilize.h",
+                                        /*isStandard=*/false);
+      builder->create<emitc::IncludeOp>(loc, "compute_kernel_api/untilize.h",
+                                        /*isStandard=*/false);
+      builder->create<emitc::IncludeOp>(loc,
+                                        "compute_kernel_api/eltwise_binary.h",
+                                        /*isStandard=*/false);
+      builder->create<emitc::IncludeOp>(loc, "compute_kernel_api.h", // max ops
+                                        /*isStandard=*/false);
+      builder->create<emitc::IncludeOp>(loc,
+                                        "compute_kernel_api/tile_move_copy.h",
+                                        /*isStandard=*/false);
+      builder->create<emitc::IncludeOp>(
+          loc, "compute_kernel_api/eltwise_unary/eltwise_unary.h",
+          /*isStandard=*/false);
+      // TODO (kmitrovic) exp.h is an ExpOp-specific include. Every op has one,
+      // should be handled in general, not like this.
+      // Issue: https://github.com/tenstorrent/tt-mlir/issues/772
+      builder->create<emitc::IncludeOp>(
+          loc, "compute_kernel_api/eltwise_unary/exp.h",
+          /*isStandard=*/false);
+      builder->create<emitc::IncludeOp>(
+          loc, "compute_kernel_api/eltwise_unary/sfpu_split_includes.h",
+          /*isStandard=*/false);
+      builder->create<emitc::IncludeOp>(
+          loc, "compute_kernel_api/eltwise_unary/recip.h",
+          /*isStandard=*/false);
+      // Must define macros REDUCE_OP and REDUCE_DIM before including reduce.h
+      // because they are default template parameters values in reduce api.
+      builder->create<emitc::VerbatimOp>(loc,
+                                         "#define REDUCE_OP PoolType::SUM");
+      builder->create<emitc::VerbatimOp>(
+          loc, "#define REDUCE_DIM ReduceDim::REDUCE_COL");
+      builder->create<emitc::IncludeOp>(loc, "compute_kernel_api/reduce.h",
+                                        /*isStandard=*/false);
+      builder->create<emitc::VerbatimOp>(loc, "namespace NAMESPACE {");
+    }
+  }
+
+  ~ScopedModuleHelper() {
+    if (threadType == ThreadType::Compute) {
+      builder->create<emitc::VerbatimOp>(loc, "void MAIN { kernel_main(); }");
+      builder->create<emitc::VerbatimOp>(loc,
+                                         "}"); // close namespace NAMESPACE
+    }
+  }
+
+private:
+  OpBuilder *builder;
+  Location loc;
+  ThreadType threadType;
+};
+} // namespace
+
+static FailureOr<mlir::ModuleOp>
+cloneEntryIntoStandaloneModule(func::FuncOp origEntry, ThreadType threadType) {
+  auto *ctx = origEntry.getContext();
+  Region *region = &origEntry.getBody();
+  auto loc = origEntry.getLoc();
+
+  OpBuilder builder(ctx);
+
+  // We will wrap everything in a standalone module op so that we can run the
+  // translation.
+  auto moduleWrapper = builder.create<mlir::ModuleOp>(loc, "module_wrapper");
+  builder.setInsertionPointToStart(moduleWrapper.getBody());
+
+  Region *kernelMainRegion;
+  {
+    ScopedModuleHelper threadConfigHelper(&builder, loc, threadType);
+
+    // Clone 'region' into a new func op nested inside 'moduleWrapper':
+    auto kernelMain = builder.create<func::FuncOp>(
+        loc, "kernel_main",
+        builder.getType<FunctionType>(region->getArgumentTypes(), TypeRange()));
+    kernelMainRegion = &kernelMain.getBody();
+  }
+
+  IRMapping irMapper;
+  region->cloneInto(kernelMainRegion, irMapper);
+  return moduleWrapper;
 }
 
-LogicalResult translateTTKernelToCpp(Operation *op, llvm::raw_ostream &os,
-                                     const ttkernel::ThreadType &threadType) {
-  return translateModuleToCpp(op, os, threadType);
+LogicalResult translateKernelFuncToCpp(func::FuncOp entry,
+                                       llvm::raw_ostream &os) {
+  if (!entry->hasAttr(ThreadTypeAttr::name)) {
+    return failure();
+  }
+
+  ThreadType threadType =
+      entry->getAttrOfType<ThreadTypeAttr>(ThreadTypeAttr::name).getValue();
+  auto kernelModule = cloneEntryIntoStandaloneModule(entry, threadType);
+  if (failed(kernelModule)) {
+    return failure();
+  }
+  return emitc::translateToCpp(*kernelModule, os);
+}
+
+LogicalResult translateTopLevelKernelToCpp(ModuleOp moduleOp,
+                                           llvm::raw_ostream &os,
+                                           StringRef symbolName) {
+  SymbolTable symbolTable(moduleOp);
+  auto entry = symbolTable.lookup<func::FuncOp>(symbolName);
+  if (!entry) {
+    return failure();
+  }
+  return translateKernelFuncToCpp(entry, os);
+}
+
+LogicalResult translateTopLevelKernelsToCpp(ModuleOp moduleOp,
+                                            llvm::raw_ostream &os) {
+  LogicalResult result = success();
+  moduleOp->walk([&](func::FuncOp entry) {
+    if (!entry->hasAttr(ThreadTypeAttr::name)) {
+      return;
+    }
+
+    if (failed(translateKernelFuncToCpp(entry, os))) {
+      result = failure();
+      return;
+    }
+  });
+  return result;
 }
 
 } // namespace mlir::tt::ttkernel

--- a/lib/Target/TTKernel/TTKernelToCppRegistration.cpp
+++ b/lib/Target/TTKernel/TTKernelToCppRegistration.cpp
@@ -2,47 +2,33 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "ttmlir/Target/TTKernel/TTKernelToCpp.h"
+
+#include "ttmlir/Dialect/TT/IR/TT.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIR.h"
+#include "ttmlir/Dialect/TTKernel/IR/TTKernel.h"
+#include "ttmlir/Dialect/TTMetal/IR/TTMetal.h"
+
 #include "mlir/Dialect/EmitC/IR/EmitC.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Tools/mlir-translate/Translation.h"
-#include "ttmlir/Dialect/TT/IR/TT.h"
-#include "ttmlir/Dialect/TTKernel/IR/TTKernel.h"
-#include "ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.h"
-#include "ttmlir/Target/TTKernel/TTKernelToCpp.h"
+
 using namespace mlir;
 
 namespace mlir::tt::ttkernel {
 
-// TODO(bug #1874): Should generalize this to read kernel type from Attribute?
-void registerTensixKernelToCpp() {
+void registerTTKernelToCpp() {
   TranslateFromMLIRRegistration reg(
-      "ttkernel-to-cpp-tensix", "translate tensix kernel to C++",
+      "ttkernel-to-cpp", "translate ttkernel to C++",
       [](Operation *op, llvm::raw_ostream &os) -> LogicalResult {
-        return translateTTKernelToCpp(op, os, tt::ttkernel::ThreadType::Tensix);
+        return translateTopLevelKernelsToCpp(mlir::cast<ModuleOp>(op), os);
       },
       [](DialectRegistry &registry) {
-        registry
-            .insert<mlir::scf::SCFDialect, mlir::tt::ttkernel::TTKernelDialect,
-                    mlir::arith::ArithDialect, mlir::emitc::EmitCDialect,
-                    mlir::func::FuncDialect, mlir::tt::TTDialect,
-                    mlir::memref::MemRefDialect>();
-      });
-}
-
-void registerNocKernelToCpp() {
-  TranslateFromMLIRRegistration reg(
-      "ttkernel-to-cpp-noc", "translate noc kernel to C++",
-      [](Operation *op, llvm::raw_ostream &os) -> LogicalResult {
-        return translateTTKernelToCpp(op, os, tt::ttkernel::ThreadType::Noc);
-      },
-      [](DialectRegistry &registry) {
-        registry
-            .insert<mlir::scf::SCFDialect, mlir::tt::ttkernel::TTKernelDialect,
-                    mlir::arith::ArithDialect, mlir::emitc::EmitCDialect,
-                    mlir::func::FuncDialect, mlir::tt::TTDialect,
-                    mlir::memref::MemRefDialect>();
+        registry.insert<mlir::tt::ttkernel::TTKernelDialect,
+                        mlir::tt::ttmetal::TTMetalDialect, mlir::tt::TTDialect,
+                        mlir::tt::ttir::TTIRDialect, mlir::emitc::EmitCDialect,
+                        mlir::memref::MemRefDialect, mlir::func::FuncDialect>();
       });
 }
 

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -174,9 +174,9 @@ toFlatbuffer(::flatbuffers::FlatBufferBuilder &fbb,
         fbb, toFlatbuffer(nocConfigAttr.getNocIndex()));
     return std::make_pair(configType, config.Union());
   }
-  case ttkernel::ThreadType::Tensix: {
+  case ttkernel::ThreadType::Compute: {
     auto tensixConfigAttr =
-        mlir::dyn_cast<ttkernel::TensixConfigAttr>(kernelConfig);
+        mlir::dyn_cast<ttkernel::ComputeConfigAttr>(kernelConfig);
     auto configType = ::tt::target::metal::KernelConfig::TensixConfig;
     auto unpackToDestModeVec =
         toFlatbuffer(tensixConfigAttr.getUnpackToDestMode());
@@ -336,12 +336,12 @@ static std::shared_ptr<void> translateModuleToFlatbuffer(
         std::vector<::flatbuffers::Offset<::tt::target::metal::KernelDesc>>
             kernels;
 
-        llvm::SmallVector<std::string> cppKernels(
-            enqueueProgramOp->getNumRegions());
-        llvm::LogicalResult success =
-            emitEnqueueProgramOpRegionsAsCpp(enqueueProgramOp, cppKernels);
-        assert(success.succeeded() &&
-               "failed to emit enqueue program op regions as cpp");
+        // llvm::SmallVector<std::string> cppKernels(
+        //     enqueueProgramOp->getNumRegions());
+        // llvm::LogicalResult success =
+        //     emitEnqueueProgramOpRegionsAsCpp(enqueueProgramOp, cppKernels);
+        // assert(success.succeeded() &&
+        //        "failed to emit enqueue program op regions as cpp");
 
         // TODO(jdesousa #2960): This code is commented to allow for compilation
         // after the new TTMetal lowering flow was implemented. This needs to be

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -336,13 +336,6 @@ static std::shared_ptr<void> translateModuleToFlatbuffer(
         std::vector<::flatbuffers::Offset<::tt::target::metal::KernelDesc>>
             kernels;
 
-        // llvm::SmallVector<std::string> cppKernels(
-        //     enqueueProgramOp->getNumRegions());
-        // llvm::LogicalResult success =
-        //     emitEnqueueProgramOpRegionsAsCpp(enqueueProgramOp, cppKernels);
-        // assert(success.succeeded() &&
-        //        "failed to emit enqueue program op regions as cpp");
-
         // TODO(jdesousa #2960): This code is commented to allow for compilation
         // after the new TTMetal lowering flow was implemented. This needs to be
         // replaced with lowering for new enqueue program semantics.

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -174,17 +174,6 @@ declare_mlir_python_sources(TTMLIRPythonTestInfra.Main
     ttir_builder.py
 )
 
-if(TTMLIR_ENABLE_PYKERNEL)
-  declare_mlir_python_sources(TTPykernelSources)
-
-  declare_mlir_python_sources(TTPykernelSources.Main
-    ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/pykernel"
-    SOURCES
-      pykernel_ast.py
-      types.py
-  )
-endif()
-
 ################################################################################
 # Generate packages and shared library
 ################################################################################

--- a/python/Passes.cpp
+++ b/python/Passes.cpp
@@ -7,10 +7,12 @@
 
 #include "ttmlir/Bindings/Python/TTMLIRModule.h"
 #include "ttmlir/Conversion/Passes.h"
+#include "ttmlir/Dialect/TTKernel/Transforms/Passes.h"
 #include "ttmlir/RegisterAll.h"
 #include "ttmlir/Target/TTKernel/TTKernelToCpp.h"
 #include "ttmlir/Target/TTMetal/TTMetalToFlatbuffer.h"
 #include "ttmlir/Target/TTNN/TTNNToFlatbuffer.h"
+
 #include <cstdint>
 #include <nanobind/stl/bind_map.h>
 #include <nanobind/stl/bind_vector.h>
@@ -278,21 +280,27 @@ void populatePassesModule(nb::module_ &m) {
 
   m.def(
       "ttkernel_to_cpp",
-      [](MlirModule module, bool isTensixKernel) {
+      [](MlirModule module) {
         mlir::Operation *moduleOp = unwrap(mlirModuleGetOperation(module));
-        tt::ttkernel::ThreadType threadType =
-            isTensixKernel ? tt::ttkernel::ThreadType::Tensix
-                           : tt::ttkernel::ThreadType::Noc;
+
+        // Convert to EmitC
+        mlir::PassManager pm(moduleOp->getName());
+        pm.addPass(mlir::tt::createConvertTTKernelToEmitC());
+        if (mlir::failed(pm.run(moduleOp))) {
+          throw std::runtime_error("Failed to run pass manager");
+        }
+
+        // Translate to C++
         std::string output;
         llvm::raw_string_ostream output_stream(output);
-        if (mlir::failed(mlir::tt::ttkernel::translateTTKernelToCpp(
-                moduleOp, output_stream, threadType))) {
+        if (mlir::failed(mlir::tt::ttkernel::translateTopLevelKernelsToCpp(
+                mlir::cast<ModuleOp>(moduleOp), output_stream))) {
           throw std::runtime_error("Failed to generate cpp");
         }
         output_stream.flush();
         return output;
       },
-      nb::arg("module"), nb::arg("isTensixKernel"));
+      nb::arg("module"));
 
   m.def(
       "pykernel_compile_pipeline",

--- a/python/TTKernelModule.cpp
+++ b/python/TTKernelModule.cpp
@@ -29,5 +29,26 @@ void populateTTKernelModule(nb::module_ &m) {
                      return std::vector<int64_t>(cb.getShape());
                    })
       .def_prop_ro("memref", &tt::ttkernel::CBType::getMemref);
+
+  tt_attribute_class<tt::ttkernel::ThreadTypeAttr>(m, "ThreadTypeAttr")
+      .def_prop_ro_static("name",
+                          [](nb::handle /*unused*/) {
+                            return std::string(
+                                tt::ttkernel::ThreadTypeAttr::name);
+                          })
+      .def_static("get", [](MlirContext ctx, std::string threadTypeStr) {
+        tt::ttkernel::ThreadType threadType;
+        if (threadTypeStr == "compute") {
+          threadType = tt::ttkernel::ThreadType::Compute;
+        } else if (threadTypeStr == "noc") {
+          threadType = tt::ttkernel::ThreadType::Noc;
+        } else {
+          throw std::runtime_error("Unknown thread type " + threadTypeStr);
+        }
+
+        return ttmlirTTKernelThreadTypeAttrGet(
+            ctx, static_cast<std::underlying_type_t<tt::ttkernel::ThreadType>>(
+                     threadType));
+      });
 }
 } // namespace mlir::ttmlir::python

--- a/test/pykernel/eltwise_sfpu/eltwise_sfpu.py
+++ b/test/pykernel/eltwise_sfpu/eltwise_sfpu.py
@@ -12,7 +12,7 @@ from pykernel.types import *
 @ttkernel_tensix_compile()
 def eltwise_sfpu(cb_in: CircularBuffer, cb_out: CircularBuffer):
     # CHECK: module {
-    # CHECK: func.func @{{.*}}(%arg0: !ttkernel.cb<{{.*}}>, %arg1: !ttkernel.cb<{{.*}}>) {
+    # CHECK: func.func @{{.*}}(%arg0: !ttkernel.cb<{{.*}}>, %arg1: !ttkernel.cb<{{.*}}>) attributes {ttkernel.thread = #ttkernel.thread<compute>} {
     # CHECK: {{.*}}"ttkernel.get_compile_time_arg_val"{{.*}}
     # CHECK: {{.*}}"ttkernel.get_compile_time_arg_val"{{.*}}
     per_core_block_cnt = get_compile_time_arg_val(int, 0)

--- a/test/pykernel/eltwise_sfpu/reader_unary.py
+++ b/test/pykernel/eltwise_sfpu/reader_unary.py
@@ -12,7 +12,7 @@ from pykernel.types import *
 @ttkernel_noc_compile(verbose=True)
 def reader_unary(cb_in: CircularBuffer, cb_out: CircularBuffer, rt_args):
     # CHECK: module {
-    # CHECK: func.func @{{.*}}(%arg0: !ttkernel.cb<{{.*}}>, %arg1: !ttkernel.cb<{{.*}}>) {
+    # CHECK: func.func @{{.*}}(%arg0: !ttkernel.cb<{{.*}}>, %arg1: !ttkernel.cb<{{.*}}>) attributes {ttkernel.thread = #ttkernel.thread<noc>} {
     # CHECK: emitc.verbatim "// --- Python Function {{.*}}"
     # CHECK: emitc.verbatim "// src_addr: int = rt_args[0]"
     # CHECK: {{.*}}"ttkernel.get_arg_val"{{.*}}

--- a/test/pykernel/eltwise_sfpu/writer_unary.py
+++ b/test/pykernel/eltwise_sfpu/writer_unary.py
@@ -12,7 +12,7 @@ from pykernel.types import *
 @ttkernel_noc_compile()
 def writer_unary(cb_in: CircularBuffer, cb_out: CircularBuffer, rt_args):
     # CHECK: module {
-    # CHECK: func.func @{{.*}}(%arg0: !ttkernel.cb<{{.*}}>, %arg1: !ttkernel.cb<{{.*}}>) {
+    # CHECK: func.func @{{.*}}(%arg0: !ttkernel.cb<{{.*}}>, %arg1: !ttkernel.cb<{{.*}}>) attributes {ttkernel.thread = #ttkernel.thread<noc>} {
     # CHECK: {{.*}}"ttkernel.get_arg_val"{{.*}}
     # CHECK: %[[DST_ADDR:.*]] = memref.alloca(){{.*}}
     # CHECK: %[[BANK_ID:.*]] = "ttkernel.get_arg_val"{{.*}}

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -20,36 +20,36 @@ module {
   module @ttkernel_register_operations {
 
     // CHECK-LABEL: func @tile_regs_acquire
-    func.func @tile_regs_acquire() -> () {
+    func.func @tile_regs_acquire() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
       // CHECK: emitc.call_opaque "tile_regs_acquire"()
       "ttkernel.tile_regs_acquire"() : () -> ()
       return
     }
 
     // CHECK-LABEL: func @tile_regs_commit
-    func.func @tile_regs_commit() -> () {
+    func.func @tile_regs_commit() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
       // CHECK: emitc.call_opaque "tile_regs_commit"()
       "ttkernel.tile_regs_commit"() : () -> ()
       return
     }
 
     // CHECK-LABEL: func @tile_regs_wait
-    func.func @tile_regs_wait() -> () {
+    func.func @tile_regs_wait() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
       // CHECK: emitc.call_opaque "tile_regs_wait"()
       "ttkernel.tile_regs_wait"() : () -> ()
       return
     }
 
     // CHECK-LABEL: func @tile_regs_release
-    func.func @tile_regs_release() -> () {
+    func.func @tile_regs_release() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
       // CHECK: emitc.call_opaque "tile_regs_release"()
       "ttkernel.tile_regs_release"() : () -> ()
       return
     }
 
     // CHECK-LABEL: func @pack_tile
-    func.func @pack_tile(%out_cb: !cb0_tiles) -> () {
-      // CHECK: %[[OUT_CB:.*]] = emitc.load{{.+}}<"::tt::CB">
+    func.func @pack_tile(%out_cb: !cb0_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[OUT_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
       // CHECK: %[[DST_INDEX:.*]] = "emitc.constant"
       %dst_index = arith.constant 3 : index
       // CHECK: %[[OUT_CB_INDEX:.*]] = "emitc.constant"
@@ -60,16 +60,16 @@ module {
     }
 
     // CHECK-LABEL: func @copy_tile_init
-    func.func @copy_tile_init(%cb: !cb0_tiles) -> () {
-      // CHECK: %[[CB:.*]] = emitc.load{{.+}}<"::tt::CB">
+    func.func @copy_tile_init(%cb: !cb0_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
       // CHECK: emitc.call_opaque "copy_tile_init"(%[[CB]])
       "ttkernel.copy_tile_init"(%cb) : (!cb0_tiles) -> ()
       return
     }
 
     // CHECK-LABEL: func @copy_tile
-    func.func @copy_tile(%cb: !cb0_tiles) -> () {
-      // CHECK: %[[CB:.*]] = emitc.load{{.+}}<"::tt::CB">
+    func.func @copy_tile(%cb: !cb0_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
       // CHECK: %[[CB_INDEX:.*]] = "emitc.constant"
       %cb_index = arith.constant 2 : index
       // CHECK: %[[DST_INDEX:.*]] = "emitc.constant"
@@ -89,28 +89,28 @@ module {
   module @ttkernel_fpu_operations {
 
     // CHECK-LABEL: func @binary_op_init_common
-    func.func @binary_op_init_common(%cb0: !cb0_tiles, %cb1: !cb1_tiles, %out_cb: !cb2_tiles) -> () {
-      // CHECK: %[[CB0:.*]] = emitc.load{{.+}}<"::tt::CB">
-      // CHECK: %[[CB1:.*]] = emitc.load{{.+}}<"::tt::CB">
-      // CHECK: %[[OUT_CB:.*]] = emitc.load{{.+}}<"::tt::CB">
+    func.func @binary_op_init_common(%cb0: !cb0_tiles, %cb1: !cb1_tiles, %out_cb: !cb2_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[CB0:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+      // CHECK: %[[CB1:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+      // CHECK: %[[OUT_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
       // CHECK: emitc.call_opaque "binary_op_init_common"(%[[CB0]], %[[CB1]], %[[OUT_CB]])
       "ttkernel.binary_op_init_common"(%cb0, %cb1, %out_cb) : (!cb0_tiles, !cb1_tiles, !cb2_tiles) -> ()
       return
     }
 
     // CHECK-LABEL: func @add_tiles_init
-    func.func @add_tiles_init(%cb0: !cb0_tiles, %cb1: !cb1_tiles) -> () {
-      // CHECK: %[[CB0:.*]] = emitc.load{{.+}}<"::tt::CB">
-      // CHECK: %[[CB1:.*]] = emitc.load{{.+}}<"::tt::CB">
+    func.func @add_tiles_init(%cb0: !cb0_tiles, %cb1: !cb1_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[CB0:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+      // CHECK: %[[CB1:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
       // CHECK: emitc.call_opaque "add_tiles_init"(%[[CB0]], %[[CB1]])
       "ttkernel.add_tiles_init"(%cb0, %cb1) : (!cb0_tiles, !cb1_tiles) -> ()
       return
     }
 
     // CHECK-LABEL: func @add_tiles
-    func.func @add_tiles(%cb0: !cb0_tiles, %cb1: !cb1_tiles) -> () {
-      // CHECK: %[[CB0:.*]] = emitc.load{{.+}}<"::tt::CB">
-      // CHECK: %[[CB1:.*]] = emitc.load{{.+}}<"::tt::CB">
+    func.func @add_tiles(%cb0: !cb0_tiles, %cb1: !cb1_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[CB0:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+      // CHECK: %[[CB1:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
       // CHECK: %[[CB0_INDEX:.*]] = "emitc.constant"
       %cb0_index = arith.constant 1 : index
       // CHECK: %[[CB1_INDEX:.*]] = "emitc.constant"
@@ -123,25 +123,25 @@ module {
     }
 
     // CHECK-LABEL: func @mul_tiles_init
-    func.func @mul_tiles_init(%cb0: !cb0_tiles, %cb1: !cb1_tiles) -> () {
-      // CHECK: %[[CB0:.*]] = emitc.load{{.+}}<"::tt::CB">
-      // CHECK: %[[CB1:.*]] = emitc.load{{.+}}<"::tt::CB">
+    func.func @mul_tiles_init(%cb0: !cb0_tiles, %cb1: !cb1_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[CB0:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+      // CHECK: %[[CB1:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
       // CHECK: emitc.call_opaque "mul_tiles_init"(%[[CB0]], %[[CB1]])
       "ttkernel.mul_tiles_init"(%cb0, %cb1) : (!cb0_tiles, !cb1_tiles) -> ()
       return
     }
 
     // CHECK-LABEL: func @mul_tiles_init_f
-    func.func @mul_tiles_init_f() -> () {
+    func.func @mul_tiles_init_f() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
       // CHECK: emitc.call_opaque "mul_tiles_init_f"()
       "ttkernel.mul_tiles_init_f"() : () -> ()
       return
     }
 
     // CHECK-LABEL: func @mul_tiles
-    func.func @mul_tiles(%cb0: !cb0_tiles, %cb1: !cb1_tiles) -> () {
-      // CHECK: %[[CB0:.*]] = emitc.load{{.+}}<"::tt::CB">
-      // CHECK: %[[CB1:.*]] = emitc.load{{.+}}<"::tt::CB">
+    func.func @mul_tiles(%cb0: !cb0_tiles, %cb1: !cb1_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[CB0:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+      // CHECK: %[[CB1:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
       // CHECK: %[[CB0_INDEX:.*]] = "emitc.constant"
       %cb0_index = arith.constant 1 : i32
       // CHECK: %[[CB1_INDEX:.*]] = "emitc.constant"
@@ -154,23 +154,23 @@ module {
     }
 
     // CHECK-LABEL: func @unary_op_init_common
-    func.func @unary_op_init_common(%in_cb: !cb0_tiles, %out_cb: !cb1_tiles) -> () {
-      // CHECK: %[[IN_CB:.*]] = emitc.load{{.+}}<"::tt::CB">
-      // CHECK: %[[OUT_CB:.*]] = emitc.load{{.+}}<"::tt::CB">
+    func.func @unary_op_init_common(%in_cb: !cb0_tiles, %out_cb: !cb1_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[IN_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+      // CHECK: %[[OUT_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
       // CHECK: emitc.call_opaque "unary_op_init_common"(%[[IN_CB]], %[[OUT_CB]])
       "ttkernel.unary_op_init_common"(%in_cb, %out_cb) : (!cb0_tiles, !cb1_tiles) -> ()
       return
     }
 
     // CHECK-LABEL: func @exp_tile_init
-    func.func @exp_tile_init() -> () {
+    func.func @exp_tile_init() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
       // CHECK: emitc.call_opaque "exp_tile_init"()
       "ttkernel.exp_tile_init"() : () -> ()
       return
     }
 
     // CHECK-LABEL: func @exp_tile
-    func.func @exp_tile() -> () {
+    func.func @exp_tile() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
       // CHECK: %[[DST_INDEX:.*]] = "emitc.constant"
       %dst_index = arith.constant 3 : i32
       // CHECK: emitc.call_opaque "exp_tile"(%[[DST_INDEX]])
@@ -179,14 +179,14 @@ module {
     }
 
     // CHECK-LABEL: func @recip_tile_init
-    func.func @recip_tile_init() -> () {
+    func.func @recip_tile_init() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
       // CHECK: emitc.call_opaque "recip_tile_init"()
       "ttkernel.recip_tile_init"() : () -> ()
       return
     }
 
     // CHECK-LABEL: func @recip_tile
-    func.func @recip_tile() -> () {
+    func.func @recip_tile() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
       // CHECK: %[[DST_INDEX:.*]] = "emitc.constant"
       %dst_index = arith.constant 3 : i32
       // CHECK: emitc.call_opaque "recip_tile"(%[[DST_INDEX]])
@@ -195,19 +195,19 @@ module {
     }
 
     // CHECK-LABEL: func @reduce_init
-    func.func @reduce_init(%in_cb: !cb0_tiles, %scaling_cb: !cb1_tiles, %out_cb: !cb2_tiles) -> () {
-      // CHECK: %[[IN_CB:.*]] = emitc.load{{.+}}<"::tt::CB">
-      // CHECK: %[[SCALING_CB:.*]] = emitc.load{{.+}}<"::tt::CB">
-      // CHECK: %[[OUT_CB:.*]] = emitc.load{{.+}}<"::tt::CB">
+    func.func @reduce_init(%in_cb: !cb0_tiles, %scaling_cb: !cb1_tiles, %out_cb: !cb2_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[IN_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+      // CHECK: %[[SCALING_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+      // CHECK: %[[OUT_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
       // CHECK: emitc.call_opaque "reduce_init"(%[[IN_CB]], %[[SCALING_CB]], %[[OUT_CB]]) {{.+}}SUM{{.+}}REDUCE_SCALAR
       "ttkernel.reduce_init"(%in_cb, %scaling_cb, %out_cb) <{reduce_dim = #ttkernel.reduce_dim<reduce_dim_scalar>, reduce_type = #ttkernel.reduce_type<reduce_sum>}> : (!cb0_tiles, !cb1_tiles, !cb2_tiles) -> ()
       return
     }
 
     // CHECK-LABEL: func @reduce_tile
-    func.func @reduce_tile(%in_cb: !cb0_tiles, %scaling_cb: !cb1_tiles) -> () {
-      // CHECK: %[[IN_CB:.*]] = emitc.load{{.+}}<"::tt::CB">
-      // CHECK: %[[SCALING_CB:.*]] = emitc.load{{.+}}<"::tt::CB">
+    func.func @reduce_tile(%in_cb: !cb0_tiles, %scaling_cb: !cb1_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[IN_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+      // CHECK: %[[SCALING_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
       // CHECK: %[[IN_TILE_INDEX:.*]] = "emitc.constant"
       %in_tile_index = arith.constant 1 : i32
       // CHECK: %[[SCALING_TILE_INDEX:.*]] = "emitc.constant"
@@ -231,14 +231,14 @@ module {
   module @ttkernel_sfpu_operations {
 
     // CHECK-LABEL: func @max_tile_init
-    func.func @max_tile_init() -> () {
+    func.func @max_tile_init() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
       // CHECK: emitc.call_opaque "max_tile_init"()
       "ttkernel.max_tile_init"() : () -> ()
       return
     }
 
     // CHECK-LABEL: func @max_tile
-    func.func @max_tile() -> () {
+    func.func @max_tile() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
       // CHECK: %[[DST0_INDEX:.*]] = "emitc.constant"
       %dst0_index = arith.constant 1 : i32
       // CHECK: %[[DST1_INDEX:.*]] = "emitc.constant"
@@ -258,8 +258,8 @@ module {
   module @ttkernel_cb_operations {
 
     // CHECK-LABEL: func @cb_push_back
-    func.func @cb_push_back(%cb: !cb0_tiles) -> () {
-      // CHECK: %[[CB:.*]] = emitc.load{{.+}}<"::tt::CB">
+    func.func @cb_push_back(%cb: !cb0_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
       // CHECK: %[[NUM_PAGES:.*]] = "emitc.constant"
       %num_pages = arith.constant 1 : i32
       // CHECK: emitc.call_opaque "cb_push_back"(%[[CB]], %[[NUM_PAGES]])
@@ -268,8 +268,8 @@ module {
     }
 
     // CHECK-LABEL: func @cb_pop_front
-    func.func @cb_pop_front(%cb: !cb0_tiles) -> () {
-      // CHECK: %[[CB:.*]] = emitc.load{{.+}}<"::tt::CB">
+    func.func @cb_pop_front(%cb: !cb0_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
       // CHECK: %[[NUM_PAGES:.*]] = "emitc.constant"
       %num_pages = arith.constant 1 : i32
       // CHECK: emitc.call_opaque "cb_pop_front"(%[[CB]], %[[NUM_PAGES]])
@@ -278,8 +278,8 @@ module {
     }
 
     // CHECK-LABEL: func @cb_reserve_back
-    func.func @cb_reserve_back(%cb: !cb0_tiles) -> () {
-      // CHECK: %[[CB:.*]] = emitc.load{{.+}}<"::tt::CB">
+    func.func @cb_reserve_back(%cb: !cb0_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
       // CHECK: %[[NUM_PAGES:.*]] = "emitc.constant"
       %num_pages = arith.constant 1 : i32
       // CHECK: emitc.call_opaque "cb_reserve_back"(%[[CB]], %[[NUM_PAGES]])
@@ -288,8 +288,8 @@ module {
     }
 
     // CHECK-LABEL: func @cb_wait_front
-    func.func @cb_wait_front(%cb: !cb0_tiles) -> () {
-      // CHECK: %[[CB:.*]] = emitc.load{{.+}}<"::tt::CB">
+    func.func @cb_wait_front(%cb: !cb0_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
       // CHECK: %[[NUM_PAGES:.*]] = "emitc.constant"
       %num_pages = arith.constant 1 : i32
       // CHECK: emitc.call_opaque "cb_wait_front"(%[[CB]], %[[NUM_PAGES]])
@@ -307,9 +307,9 @@ module {
   module @ttkernel_tile_operations {
 
     // CHECK-LABEL: func @tilize_init
-    func.func @tilize_init(%in_cb: !cb0_scalar, %out_cb: !cb1_tiles) -> () {
-      // CHECK: %[[IN_CB:.*]] = emitc.load{{.+}}<"::tt::CB">
-      // CHECK: %[[OUT_CB:.*]] = emitc.load{{.+}}<"::tt::CB">
+    func.func @tilize_init(%in_cb: !cb0_scalar, %out_cb: !cb1_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[IN_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+      // CHECK: %[[OUT_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
       // CHECK: %[[NUM_TILES:.*]] = "emitc.constant"
       %num_tiles = arith.constant 3 : i32
       // CHECK: emitc.call_opaque "tilize_init"(%[[IN_CB]], %[[NUM_TILES]], %[[OUT_CB]])
@@ -318,18 +318,18 @@ module {
     }
 
     // CHECK-LABEL: func @untilize_init
-    func.func @untilize_init(%in_cb: !cb0_tiles, %out_cb: !cb1_scalar) -> () {
-      // CHECK: %[[IN_CB:.*]] = emitc.load{{.+}}<"::tt::CB">
-      // CHECK: %[[OUT_CB:.*]] = emitc.load{{.+}}<"::tt::CB">
+    func.func @untilize_init(%in_cb: !cb0_tiles, %out_cb: !cb1_scalar) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[IN_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+      // CHECK: %[[OUT_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
       // CHECK: emitc.call_opaque "untilize_init"(%[[IN_CB]], %[[OUT_CB]])
       "ttkernel.untilize_init"(%in_cb, %out_cb) : (!cb0_tiles, !cb1_scalar) -> ()
       return
     }
 
     // CHECK-LABEL: func @tilize_block
-    func.func @tilize_block(%in_cb: !cb0_scalar, %out_cb: !cb1_tiles) -> () {
-      // CHECK: %[[IN_CB:.*]] = emitc.load{{.+}}<"::tt::CB">
-      // CHECK: %[[OUT_CB:.*]] = emitc.load{{.+}}<"::tt::CB">
+    func.func @tilize_block(%in_cb: !cb0_scalar, %out_cb: !cb1_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[IN_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+      // CHECK: %[[OUT_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
       // CHECK: %[[NUM_TILES:.*]] = "emitc.constant"
       %num_tiles = arith.constant 3 : i32
       // CHECK: emitc.call_opaque "tilize_block"(%[[IN_CB]], %[[NUM_TILES]], %[[OUT_CB]])
@@ -338,9 +338,9 @@ module {
     }
 
     // CHECK-LABEL: func @untilize_block
-    func.func @untilize_block(%in_cb: !cb0_tiles, %out_cb: !cb1_scalar) -> () {
-      // CHECK: %[[IN_CB:.*]] = emitc.load{{.+}}<"::tt::CB">
-      // CHECK: %[[OUT_CB:.*]] = emitc.load{{.+}}<"::tt::CB">
+    func.func @untilize_block(%in_cb: !cb0_tiles, %out_cb: !cb1_scalar) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[IN_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+      // CHECK: %[[OUT_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
       // CHECK: %[[NUM_TILES:.*]] = "emitc.constant"
       %num_tiles = arith.constant 3 : i32
       // CHECK: emitc.call_opaque "untilize_block"(%[[IN_CB]], %[[NUM_TILES]], %[[OUT_CB]])
@@ -358,7 +358,7 @@ module {
   module @ttkernel_noc_operations {
 
     // CHECK-LABEL: func @get_noc_addr
-    func.func @get_noc_addr() -> () {
+    func.func @get_noc_addr() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: %[[X:.*]] = "emitc.constant"
       %x = arith.constant 1 : index
       // CHECK: %[[Y:.*]] = "emitc.constant"
@@ -372,7 +372,7 @@ module {
     }
 
     // CHECK-LABEL: func @get_noc_addr_from_bank_id
-    func.func @get_noc_addr_from_bank_id() -> () {
+    func.func @get_noc_addr_from_bank_id() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: %[[BANK_ID:.*]] = "emitc.constant"
       %bank_id = arith.constant 1 : i32
       // CHECK: %[[ADDR_OFFSET:.*]] = "emitc.constant"
@@ -383,7 +383,7 @@ module {
     }
 
     // CHECK-LABEL: func @noc_async_read
-    func.func @noc_async_read() -> () {
+    func.func @noc_async_read() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: %[[SRC_ADDR:.*]] = emitc.call_opaque "get_noc_addr"
       %x = arith.constant 1 : index
       %y = arith.constant 1 : index
@@ -399,7 +399,7 @@ module {
     }
 
     // CHECK-LABEL: func @noc_async_read_one_packet_set_state
-    func.func @noc_async_read_one_packet_set_state() -> () {
+    func.func @noc_async_read_one_packet_set_state() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: %[[SRC_ADDR:.*]] = emitc.call_opaque "get_noc_addr"
       %x = arith.constant 1 : index
       %y = arith.constant 1 : index
@@ -413,7 +413,7 @@ module {
     }
 
     // CHECK-LABEL: func @noc_async_read_one_packet_with_state
-    func.func @noc_async_read_one_packet_with_state() -> () {
+    func.func @noc_async_read_one_packet_with_state() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: %[[SRC_ADDR:.*]] = emitc.call_opaque "get_noc_addr"
       %x = arith.constant 1 : index
       %y = arith.constant 1 : index
@@ -428,14 +428,14 @@ module {
     }
 
     // CHECK-LABEL: func @noc_async_read_barrier
-    func.func @noc_async_read_barrier() -> () {
+    func.func @noc_async_read_barrier() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: emitc.call_opaque "noc_async_read_barrier"()
       "ttkernel.noc_async_read_barrier"() : () -> ()
       return
     }
 
     // CHECK-LABEL: func @noc_async_write
-    func.func @noc_async_write() -> () {
+    func.func @noc_async_write() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: %[[SRC_ADDR:.*]] = "emitc.constant"
       %src_addr = arith.constant 303104 : i32
       // CHECK: %[[DST_ADDR:.*]] = emitc.call_opaque "get_noc_addr"
@@ -451,14 +451,14 @@ module {
     }
 
     // CHECK-LABEL: func @noc_async_write_barrier
-    func.func @noc_async_write_barrier() -> () {
+    func.func @noc_async_write_barrier() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: emitc.call_opaque "noc_async_write_barrier"()
       "ttkernel.noc_async_write_barrier"() : () -> ()
       return
     }
 
     // CHECK-LABEL: func @get_semaphore
-    func.func @get_semaphore() -> () {
+    func.func @get_semaphore() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: %[[SEMAPHORE_ID:.*]] = "emitc.constant"
       %semaphore_id = arith.constant 2 : i32
       // CHECK: emitc.call_opaque "get_semaphore"(%[[SEMAPHORE_ID]])
@@ -467,7 +467,7 @@ module {
     }
 
     // CHECK-LABEL: func @noc_semaphore_inc
-    func.func @noc_semaphore_inc() -> () {
+    func.func @noc_semaphore_inc() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: %[[ADDR:.*]] = emitc.call_opaque "get_noc_addr"
       %x = arith.constant 1 : index
       %y = arith.constant 1 : index
@@ -483,7 +483,7 @@ module {
     }
 
     // CHECK-LABEL: func @noc_semaphore_set
-    func.func @noc_semaphore_set() -> () {
+    func.func @noc_semaphore_set() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: %[[ADDR:.*]] = emitc.call_opaque "reinterpret_cast
       %temp = arith.constant 262400 : i32
       %addr = "ttkernel.reinterpret_cast<volatile tt_l1_ptr uint32_t*>"(%temp) : (i32) -> (!ttkernel.l1_addr_ptr) // a dummy l1 addr ptr
@@ -495,7 +495,7 @@ module {
     }
 
     // CHECK-LABEL: func @noc_semaphore_wait
-    func.func @noc_semaphore_wait() -> () {
+    func.func @noc_semaphore_wait() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: %[[ADDR:.*]] = emitc.call_opaque "reinterpret_cast
       %temp = arith.constant 262400 : i32
       %addr = "ttkernel.reinterpret_cast<volatile tt_l1_ptr uint32_t*>"(%temp) : (i32) -> (!ttkernel.l1_addr_ptr) // a dummy l1 addr ptr
@@ -507,7 +507,7 @@ module {
     }
 
     // CHECK-LABEL: func @noc_semaphore_wait_min
-    func.func @noc_semaphore_wait_min() -> () {
+    func.func @noc_semaphore_wait_min() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: %[[ADDR:.*]] = emitc.call_opaque "reinterpret_cast
       %temp = arith.constant 262400 : i32
       %addr = "ttkernel.reinterpret_cast<volatile tt_l1_ptr uint32_t*>"(%temp) : (i32) -> (!ttkernel.l1_addr_ptr) // a dummy l1 addr ptr
@@ -519,7 +519,7 @@ module {
     }
 
     // CHECK-LABEL: func @noc_semaphore_set_multicast
-    func.func @noc_semaphore_set_multicast() -> () {
+    func.func @noc_semaphore_set_multicast() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: %[[SRC_ADDR:.*]] = emitc.call_opaque "get_semaphore"
       %temp1 = arith.constant 2 : i32
       %src_addr = "ttkernel.get_semaphore"(%temp1) : (i32) -> (!ttkernel.l1_addr) // a dummy l1 addr
@@ -539,7 +539,7 @@ module {
     }
 
     // CHECK-LABEL: func @noc_semaphore_set_multicast_loopback_src
-    func.func @noc_semaphore_set_multicast_loopback_src() -> () {
+    func.func @noc_semaphore_set_multicast_loopback_src() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: %[[SRC_ADDR:.*]] = emitc.call_opaque "get_semaphore"
       %temp1 = arith.constant 2 : i32
       %src_addr = "ttkernel.get_semaphore"(%temp1) : (i32) -> (!ttkernel.l1_addr) // a dummy l1 addr
@@ -558,26 +558,8 @@ module {
       return
     }
 
-    // TODO(#2230): without a use like the commented out part below the noc table def will be simply elided; however,
-    // the current lowering doesn't seem to work with nested modules, so just testing the elision for now:
-
-    // CHECK-LABEL: func @noc_transactions_table
-    func.func @noc_transactions_table() -> () {
-      // CHECK: %{{.+}} = "emitc.constant"
-      %unused = arith.constant 0 : i32
-      // CHECK-NOT: emitc
-      %table = "ttkernel.noc_transactions_table"() <{
-          entries = array<i32: 99360, 99104, 32, 1179666, 99392, 99168, 32, 1179666>
-        }> : () -> memref<2x4xi32>
-      // %i = arith.constant 1 : index
-      // %j = arith.constant 0 : index
-      // %entry = memref.load %table[%i, %j] : memref<2x4xi32>
-      // CHECK-NEXT: return
-      return
-    }
-
     // CHECK-LABEL: func @interleaved_addr_gen_fast_funcs
-    func.func @interleaved_addr_gen_fast_funcs(%cb: !cb0_tiles) -> () {
+    func.func @interleaved_addr_gen_fast_funcs(%cb: !cb0_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
       // CHECK: %[[DATA_FORMAT:.*]]= emitc.call_opaque "get_dataformat"
       %data_format = "ttkernel.get_dataformat"(%cb) : (!cb0_tiles) -> !ttkernel.DataFormat
       // CHECK: = "emitc.constant"() <{value = true}>

--- a/test/ttmlir/Translate/TTKernel/ttkernel_compute.mlir
+++ b/test/ttmlir/Translate/TTKernel/ttkernel_compute.mlir
@@ -1,31 +1,29 @@
-// RUN: ttmlir-translate --ttkernel-to-cpp-tensix %s | FileCheck %s
+// RUN: ttmlir-opt --convert-ttkernel-to-emitc %s | ttmlir-translate --ttkernel-to-cpp | FileCheck %s
 
 #l1_ = #tt.memory_space<l1>
 
 // CHECK: void kernel_main
-func.func @ttkernel_tensix(%arg1: !ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>,
-                            %arg2: !ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1>) -> () {
+func.func @ttkernel_compute(%arg1: !ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>,
+                            %arg2: !ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1>) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
 
     // CHECK: ::tt::CB [[CBIN0:.*]] = ::tt::CB::c_in0
-    // CHECK: ::tt::CB [[CBIN0ARG:.*]] = [[CBIN0]]
     // CHECK: ::tt::CB [[CBOUT0:.*]] = ::tt::CB::c_out0
-    // CHECK: ::tt::CB [[CBOUT0ARG:.*]] = [[CBOUT0]]
     // CHECK: int32_t [[C:.*]] = 4
     %c4_i32 = arith.constant 4 : i32
-    // CHECK: untilize_init([[CBIN0ARG]], [[CBOUT0ARG]])
+    // CHECK: untilize_init([[CBIN0]], [[CBOUT0]])
     "ttkernel.untilize_init"(%arg1, %arg2) : (!ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, !ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1>) -> ()
-    // CHECK: untilize_block([[CBIN0ARG]], [[C]], [[CBOUT0ARG]])
+    // CHECK: untilize_block([[CBIN0]], [[C]], [[CBOUT0]])
     "ttkernel.untilize_block"(%arg1, %c4_i32, %arg2) : (!ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, i32, !ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1>) -> ()
-    // CHECK: cb_pop_front([[CBIN0ARG]], [[C]])
+    // CHECK: cb_pop_front([[CBIN0]], [[C]])
     "ttkernel.cb_pop_front"(%arg1, %c4_i32) : (!ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, i32) -> ()
-    // CHECK: cb_push_back([[CBOUT0ARG]], [[C]])
+    // CHECK: cb_push_back([[CBOUT0]], [[C]])
     "ttkernel.cb_push_back"(%arg2, %c4_i32) : (!ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1>, i32) -> ()
-    // CHECK: untilize_block([[CBIN0ARG]], [[C]], [[CBOUT0ARG]])
+    // CHECK: untilize_block([[CBIN0]], [[C]], [[CBOUT0]])
     "ttkernel.untilize_block"(%arg1, %c4_i32, %arg2) : (!ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, i32, !ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1>) -> ()
-    // CHECK: cb_pop_front([[CBIN0ARG]], [[C]])
+    // CHECK: cb_pop_front([[CBIN0]], [[C]])
     "ttkernel.cb_pop_front"(%arg1, %c4_i32) : (!ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, i32) -> ()
-    // CHECK: cb_push_back([[CBOUT0ARG]], [[C]])
+    // CHECK: cb_push_back([[CBOUT0]], [[C]])
     "ttkernel.cb_push_back"(%arg2, %c4_i32) : (!ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1>, i32) -> ()
     // CHECK: return
-    "ttkernel.return"() : () -> ()
+    func.return
 }

--- a/test/ttmlir/Translate/TTKernel/ttkernel_noc.mlir
+++ b/test/ttmlir/Translate/TTKernel/ttkernel_noc.mlir
@@ -1,8 +1,8 @@
-// RUN: ttmlir-translate --ttkernel-to-cpp-noc %s | FileCheck %s
+// RUN: ttmlir-opt --convert-ttkernel-to-emitc %s | ttmlir-translate --ttkernel-to-cpp | FileCheck %s
 
 // CHECK: #include "dataflow_api.h"
 // CHECK: void kernel_main
-func.func @ttkernel_noc() -> () {
+func.func @ttkernel_noc() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
     // CHECK: int32_t [[B0:.*]] = 262432
     %c262432_i32 = arith.constant 262432 : i32
     // CHECK: int32_t [[B1:.*]] = 262208
@@ -26,5 +26,5 @@ func.func @ttkernel_noc() -> () {
     // CHECK: noc_async_read_barrier
     "ttkernel.noc_async_read_barrier"() : () -> ()
     // CHECK: return
-    "ttkernel.return"() : () -> ()
+    func.return
 }

--- a/tools/ttmlir-translate/ttmlir-translate.cpp
+++ b/tools/ttmlir-translate/ttmlir-translate.cpp
@@ -22,8 +22,7 @@ void registerLLVMToDynamicLibrary();
 } // namespace mlir::tt::llvm_to_cpu
 
 namespace mlir::tt::ttkernel {
-void registerTensixKernelToCpp();
-void registerNocKernelToCpp();
+void registerTTKernelToCpp();
 } // namespace mlir::tt::ttkernel
 
 // Place to register all the custom translations
@@ -32,9 +31,7 @@ static void registerCustomTranslations() {
     mlir::tt::ttnn::registerTTNNToFlatbuffer();
     mlir::tt::ttmetal::registerTTMetalToFlatbuffer();
     mlir::tt::llvm_to_cpu::registerLLVMToDynamicLibrary();
-    mlir::tt::ttkernel::registerNocKernelToCpp();
-    mlir::tt::ttkernel::registerTensixKernelToCpp();
-
+    mlir::tt::ttkernel::registerTTKernelToCpp();
     return true;
   }();
   (void)initOnce;


### PR DESCRIPTION
This change does a number of cleanups to the ttkernel to emitc flow including:
- Remove old/dead code paths for D2M emitc generation.
- Removal of some TTKernel ops and EmitC conversions that are no longer used.
- Cleanup of some emitc conversions.
- Support for MyXOp and MyYOp via new literal rewriter.
- Rename Tensix thread type to Compute to better align with tt-metal naming convention.
- Clear separation between EmitC dialect conversion and C++ translation, these two worlds are no longer mixed and matched.
- Tagging ttkernel thread type as a function attribute, which avoids the need to have separate function handlers or passing around an enum:
```mlir
func.func @ttkernel_compute(...) attributes {ttkernel.thread = #ttkernel.thread<compute>} {
```
