### PR TITLE
Fusing

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -1417,7 +1417,7 @@ def TTIR_Conv2dOp : TTIR_NamedOp<"conv2d"> {
     let extraClassDeclaration = [{
       // Get number of output channels
       int64_t getOutputChannelSize();
-      bool verifyBias(llvm::ArrayRef<int64_t> biasDims);
+      bool isBiasCompatible(llvm::ArrayRef<int64_t> biasDims);
       MutableOperandRange getDpsInitsMutable() { return ttir::getDpsOutputs(this); }
     }];
 

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -503,5 +503,10 @@ def TTIRQuantDataTypeConversionPass : Pass<"ttir-quant-data-type-conversion", ":
   ];
 }
 
+def TTIRFusing: Pass<"ttir-fusing", "::mlir::ModuleOp">
+{
+  let summary = "TTIR fusing pass.";
+  let description = "This pass tries to fuse operations together with goal to reduce the number of operations in the graph.";
+}
 
 #endif

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1274,7 +1274,7 @@ def TTNN_Conv2dOp : TTNN_Op<"conv2d",
     let extraClassDeclaration = [{
       // Get number of output channels.
       int64_t getOutputChannelSize();
-      bool verifyBias(llvm::ArrayRef<int64_t> biasDims);
+      bool isBiasCompatible(llvm::ArrayRef<int64_t> biasDims);
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createConv2dOpOperandsWorkarounds(
             getBias() != nullptr

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1272,6 +1272,9 @@ def TTNN_Conv2dOp : TTNN_Op<"conv2d",
     let hasVerifier = 1;
 
     let extraClassDeclaration = [{
+      // Get number of output channels.
+      int64_t getOutputChannelSize();
+      bool verifyBias(llvm::ArrayRef<int64_t> biasDims);
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createConv2dOpOperandsWorkarounds(
             getBias() != nullptr

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
@@ -406,6 +406,7 @@ def TTNN_Conv2dConfigAttr : TTNN_Attr<"Conv2dConfig", "conv2d_config"> {
 
   let extraClassDeclaration = [{
     Conv2dConfigAttr withActivation(StringRef activation) const;
+    bool hasActivation() const;
   }];
 
   let assemblyFormat = "`<` struct(params) `>`";

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -142,4 +142,10 @@ def TTNNPrepareConv2dWeights : Pass<"ttnn-prepare-conv2d-weights", "::mlir::Modu
   }];
 }
 
+def TTNNFusing: Pass<"ttnn-fusing", "::mlir::ModuleOp">
+{
+  let summary = "TTNN fusing pass.";
+  let description = "This pass tries to fuse operations together with goal to reduce the number of operations in the graph.";
+}
+
 #endif

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -423,7 +423,7 @@ mlir::tt::ttir::GetDimensionSizeOp::fold(FoldAdaptor adaptor) {
       return emitOpError("Bias must be a 4D tensor");
     }
     auto biasShape = bias->getShape();
-    if (!verifyBias(biasShape)) {
+    if (!isBiasCompatible(biasShape)) {
       return emitOpError() << "Bias should have shape [1, 1, 1, "
                            << getOutputChannelSize() << "] but got ["
                            << biasShape << "]";
@@ -594,7 +594,7 @@ int64_t mlir::tt::ttir::Conv2dOp::getOutputChannelSize() {
 }
 
 // Verify that bias dimensions are compatible with conv2d operation
-bool mlir::tt::ttir::Conv2dOp::verifyBias(llvm::ArrayRef<int64_t> bias) {
+bool mlir::tt::ttir::Conv2dOp::isBiasCompatible(llvm::ArrayRef<int64_t> bias) {
   return bias[0] == 1 && bias[1] == 1 && bias[2] == 1 &&
          bias[3] == getOutputChannelSize();
 }

--- a/lib/Dialect/TTIR/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTIR/Transforms/CMakeLists.txt
@@ -16,6 +16,7 @@ add_mlir_dialect_library(MLIRTTIRTransforms
         LowerToLayout.cpp
         Quantization.cpp
         Transforms.cpp
+        TTIRFusing.cpp
 
         ADDITIONAL_HEADER_DIRS
         ${PROJECT_SOURCE_DIR}/include/ttmlir

--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -187,6 +187,7 @@ public:
     // - exp should have exactly 2 users (sum and div)
     // - sum should have exactly 1 user (broadcast)
     // - broadcast should have exactly 1 user (div)
+    // TODO(milant): Relax requirements for fusing #3183.
     if (ttmlir::utils::countUsers(expOp.getResult()) != 2 ||
         !sumOp.getResult().hasOneUse() ||
         !broadcastOp.getResult().hasOneUse()) {
@@ -209,10 +210,9 @@ public:
     int64_t reduceDim = mlir::cast<mlir::IntegerAttr>(reduceDims[0]).getInt();
 
     // Replace div op with new softmax op.
-    utils::replaceOpWithNewDPSOp<SoftmaxOp>(
-        rewriter, divOp,
-        mlir::cast<RankedTensorType>(divOp.getResult().getType()),
-        expOp.getInput(), reduceDim);
+    utils::replaceOpWithNewDPSOp<SoftmaxOp>(rewriter, divOp,
+                                            divOp.getResult().getType(),
+                                            expOp.getInput(), reduceDim);
 
     return mlir::success();
   }

--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -1,0 +1,441 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
+#include "ttmlir/Dialect/TTIR/Utils/Utils.h"
+#include "ttmlir/Utils.h"
+
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir::tt::ttir {
+#define GEN_PASS_DEF_TTIRFUSING
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h.inc"
+
+namespace {
+// Check if we can fuse conv2d followed by add into conv2d with bias.
+class TTIRConv2dWithBias : public mlir::OpRewritePattern<Conv2dOp> {
+  using mlir::OpRewritePattern<Conv2dOp>::OpRewritePattern;
+
+public:
+  mlir::LogicalResult
+  matchAndRewrite(Conv2dOp srcOp, mlir::PatternRewriter &rewriter) const final {
+    if (!isFusable(srcOp)) {
+      return mlir::failure();
+    }
+
+    // Get the other operand of the add op.
+    mlir::OpOperand *nonConvOperand = getBiasOperand(srcOp);
+    mlir::Value newBias = nonConvOperand->get();
+
+    // Modify conv2d in place to add bias.
+    rewriter.modifyOpInPlace(srcOp,
+                             [&]() { srcOp.getBiasMutable().assign(newBias); });
+
+    // Replace add op uses with conv2d.
+    rewriter.replaceAllOpUsesWith(nonConvOperand->getOwner(), srcOp);
+
+    // The original conv2d op will be removed by DCE since it's no longer
+    // used.
+    return mlir::success();
+  }
+
+private:
+  bool isFusable(Conv2dOp srcOp) const {
+    // If bias already exists on Conv2d we cannot fuse.
+    if (srcOp.getBias().getImpl()) {
+      return false;
+    }
+
+    // If conv2d has more than one use we cannot fuse.
+    // If it's only user is not AddOp we cannot fuse.
+    if (!srcOp.getResult().hasOneUse() ||
+        !ttmlir::utils::allUsers<AddOp>(srcOp)) {
+      return false;
+    }
+
+    // If we have this IR:
+    // %0 = empty()
+    // %1 = conv2d()
+    // %2 = add(%1, %0)
+    // we want to get type of %0 and check if it is compatible with conv2d bias.
+    OpOperand *nonConvOperand = getBiasOperand(srcOp);
+    mlir::Operation *otherOperation = nonConvOperand->get().getDefiningOp();
+    mlir::RankedTensorType nonConvType =
+        mlir::cast<mlir::RankedTensorType>(nonConvOperand->get().getType());
+
+    // If nonConvOperand is not defined by an operation, its a block argument
+    // and we can fuse if bias is compatible with its shape.
+    if (otherOperation == nullptr) {
+      return srcOp.verifyBias(nonConvType.getShape());
+    }
+
+    // If we have this IR:
+    // %0 = conv2d()
+    // %1 = empty()
+    // %2 = add(%0, %1)
+    // We cannot fuse since %1 comes after conv2d. In this simple case
+    // we can move empty above covn2d, but in general case it would
+    // require more complex analysis.
+    if (!otherOperation->isBeforeInBlock(srcOp)) {
+      return false;
+    }
+
+    return srcOp.verifyBias(nonConvType.getShape());
+  }
+
+  OpOperand *getBiasOperand(Conv2dOp srcOp) const {
+    auto addOp = mlir::cast<AddOp>(*srcOp.getResult().getUsers().begin());
+    auto otherOperands = ttmlir::utils::getOtherOperands(addOp, srcOp);
+    return otherOperands.front();
+  }
+};
+
+// This pattern detects when a reduction operation is followed by a reshape
+// operation that simply adds back dimensions that were reduced. In such cases,
+// we can fuse the reshape into the reduction operation by setting
+// keep_dim=true.
+template <typename ReductionOpTy>
+class ReductionWithReshapePattern
+    : public mlir::OpRewritePattern<ReductionOpTy> {
+  using mlir::OpRewritePattern<ReductionOpTy>::OpRewritePattern;
+
+public:
+  mlir::LogicalResult
+  matchAndRewrite(ReductionOpTy srcOp,
+                  mlir::PatternRewriter &rewriter) const final {
+    // Check if the reduction op has exactly one use and it's a reshape op.
+    if (!srcOp.getResult().hasOneUse() ||
+        !ttmlir::utils::allUsers<ReshapeOp>(srcOp)) {
+      return mlir::failure();
+    }
+
+    // Get the reshape op that follows the reduction op.
+    auto reshapeOp =
+        mlir::cast<ReshapeOp>(*srcOp.getResult().getUsers().begin());
+
+    // If the reduction already has keep_dim=true, there's nothing to fuse.
+    if (srcOp.getKeepDim()) {
+      return mlir::failure();
+    }
+
+    // Get the input and output shapes.
+    ArrayRef<int64_t> inputShape = srcOp.getInput().getType().getShape();
+    ArrayRef<int64_t> reshapeOutputShape =
+        reshapeOp.getResult().getType().getShape();
+
+    // Check if the reshape is simply adding back dimensions that were reduced.
+    // For this, the reshape output shape should have the same rank as the input
+    // shape.
+    if (reshapeOutputShape.size() != inputShape.size()) {
+      return mlir::failure();
+    }
+
+    // Get the reduction dimensions.
+    llvm::BitVector reduceDimsMask(inputShape.size(), false);
+    if (!srcOp.getDimArg()) {
+      // If no dimensions are specified, all dimensions are reduced.
+      reduceDimsMask.set();
+    } else {
+      mlir::ArrayAttr reduceDims = *srcOp.getDimArg();
+      for (mlir::Attribute reduceDim : reduceDims) {
+        int64_t reduceDimInt =
+            mlir::cast<mlir::IntegerAttr>(reduceDim).getInt();
+        // Handle negative indices
+        reduceDimInt = (reduceDimInt + inputShape.size()) % inputShape.size();
+        reduceDimsMask.set(reduceDimInt);
+      }
+    }
+
+    // Check if the reshape output shape has 1s in the reduced dimensions and
+    // matches the original shape in the non-reduced dimensions.
+    for (size_t i = 0; i < inputShape.size(); ++i) {
+      if (reduceDimsMask[i]) {
+        // Reduced dimension should be 1 in the reshape output.
+        if (reshapeOutputShape[i] != 1) {
+          return mlir::failure();
+        }
+      } else {
+        // Non-reduced dimension should match the original input shape.
+        if (reshapeOutputShape[i] != inputShape[i]) {
+          return mlir::failure();
+        }
+      }
+    }
+
+    // Create a new reduction op with keep_dim=true.
+    auto newReductionOp = utils::createDPSOp<ReductionOpTy>(
+        rewriter, srcOp.getLoc(), reshapeOp.getResult().getType(),
+        srcOp.getInput(), rewriter.getBoolAttr(true), srcOp.getDimArgAttr());
+
+    // Replace the reshape op with the result of the new reduction op.
+    rewriter.replaceOp(reshapeOp, newReductionOp.getResult());
+
+    // The original reduction op will be removed by DCE since it's no longer
+    // used.
+    return mlir::success();
+  }
+};
+
+// This pattern detects and fuses a sequence of operations that implement
+// softmax:
+// 1. exp(x)
+// 2. sum(exp(x)) along a dimension with keep_dim=true
+// 3. broadcast the sum
+// 4. divide exp(x) by the broadcasted sum
+class SoftmaxFusionPattern : public mlir::OpRewritePattern<DivOp> {
+  using mlir::OpRewritePattern<DivOp>::OpRewritePattern;
+
+public:
+  // Pattern: div(exp(x), broadcast(sum(exp(x), keep_dim=true)))
+  mlir::LogicalResult
+  matchAndRewrite(DivOp srcOp, mlir::PatternRewriter &rewriter) const final {
+
+    // Get the numerator (exp) and denominator (broadcast)
+    mlir::Value numerator = srcOp.getInputs()[0];
+    mlir::Value denominator = srcOp.getInputs()[1];
+
+    // Check that the numerator is an exp operation
+    auto expOp = numerator.getDefiningOp<ExpOp>();
+    if (!expOp) {
+      return mlir::failure();
+    }
+
+    // Check that the denominator is a broadcast operation
+    auto broadcastOp = denominator.getDefiningOp<BroadcastOp>();
+    if (!broadcastOp) {
+      return mlir::failure();
+    }
+
+    // Check that the broadcast input is a sum operation with keep_dim=true
+    auto sumOp = broadcastOp.getInput().getDefiningOp<SumOp>();
+    if (!sumOp || !sumOp.getKeepDim()) {
+      return mlir::failure();
+    }
+
+    // Check that the sum input is the same exp operation as the numerator
+    if (sumOp.getInput() != expOp.getResult(0)) {
+      return mlir::failure();
+    }
+
+    // Check correct user counts for each operation in the pattern:
+    // - exp should have exactly 2 users (sum and div)
+    // - sum should have exactly 1 user (broadcast)
+    // - broadcast should have exactly 1 user (div)
+    if (ttmlir::utils::countUsers(expOp.getResult(0)) != 2 ||
+        !sumOp.getResult().hasOneUse() ||
+        !broadcastOp.getResult().hasOneUse()) {
+      return mlir::failure();
+    }
+
+    // Get the reduction dimension from the sum operation
+    if (!sumOp.getDimArg()) {
+      // If no dimensions are specified, all dimensions are reduced, which is
+      // not what we want for softmax
+      return mlir::failure();
+    }
+
+    mlir::ArrayAttr reduceDims = *sumOp.getDimArg();
+    if (reduceDims.size() != 1) {
+      // Softmax reduces along a single dimension
+      return mlir::failure();
+    }
+
+    int64_t reduceDim = mlir::cast<mlir::IntegerAttr>(reduceDims[0]).getInt();
+
+    // Create a new softmax operation
+    auto softmaxOp = utils::createDPSOp<SoftmaxOp>(
+        rewriter, srcOp.getLoc(),
+        mlir::cast<RankedTensorType>(srcOp.getResult(0).getType()),
+        expOp.getInputs()[0], reduceDim);
+
+    // Replace the div operation with the softmax operation
+    rewriter.replaceOp(srcOp, softmaxOp.getResult());
+
+    return mlir::success();
+  }
+};
+
+class Conv2dWithMultiply : public mlir::OpRewritePattern<Conv2dOp> {
+  using mlir::OpRewritePattern<Conv2dOp>::OpRewritePattern;
+
+public:
+  /// Pattern: conv2d(input, weight) * scale
+  ///
+  /// This pattern detects when a Conv2d operation (with constant weights) is
+  /// followed by a multiplication with a constant scale factor. It optimizes
+  /// this pattern by pre-multiplying the convolution weights with the scale
+  /// factor, which eliminates the runtime multiplication operation.
+  ///
+  /// Input pattern:
+  ///   %conv = conv2d(%input, %weight)  // weight is constant
+  ///   %result = multiply(%conv, %scale)  // scale is constant
+  ///   (1,1,1,out_channels)
+  ///
+  /// Output pattern:
+  ///   %reshaped_scale = reshape(%scale) to (out_channels,1,1,1)
+  ///   %scaled_weight = multiply(%weight, %reshaped_scale)
+  ///   %result = conv2d(%input, %scaled_weight)
+  mlir::LogicalResult
+  matchAndRewrite(Conv2dOp convOp,
+                  mlir::PatternRewriter &rewriter) const final {
+    // Check if this pattern is applicable
+    if (!isCommutable(convOp)) {
+      return mlir::failure();
+    }
+
+    // Get the scale factor from the multiply operation
+    OpOperand *scaleOperand = getScaleOperand(convOp);
+    Value scaleValue = scaleOperand->get();
+
+    // Get the convolution weight
+    Value weightValue = convOp.getWeight();
+
+    // Create a reshaped scale factor suitable for multiplying with weights
+    Value reshapedScale = createReshapedScale(rewriter, convOp, scaleValue);
+
+    // Create pre-multiplied weights
+    Value scaledWeights =
+        createScaledWeights(rewriter, convOp, weightValue, reshapedScale);
+
+    // Modify conv2d in place to add scaled weights.
+    rewriter.modifyOpInPlace(
+        convOp, [&]() { convOp.getWeightMutable().assign(scaledWeights); });
+
+    // Replace the multiply operation uses with conv2d.
+    rewriter.replaceAllOpUsesWith(scaleOperand->getOwner(), convOp);
+
+    return mlir::success();
+  }
+
+private:
+  bool isCommutable(Conv2dOp convOp) const {
+    // Convolution must have exactly one use and it must be a multiply operation
+    if (!convOp.getResult().hasOneUse() ||
+        !ttmlir::utils::allUsers<MultiplyOp>(convOp)) {
+      return false;
+    }
+
+    // Get the function containing this operation
+    mlir::func::FuncOp funcOp = convOp->getParentOfType<mlir::func::FuncOp>();
+
+    // Get all constant parameters in the function
+    SmallPtrSet<BlockArgument, 4> constParams =
+        ttmlir::utils::populateConstParams(funcOp);
+
+    // Both the weight and scale must be constants
+    if (!isConstant(convOp.getWeight(), constParams) ||
+        !isConstant(getScaleOperand(convOp)->get(), constParams)) {
+      return false;
+    }
+
+    // The scale must have the correct shape (1,1,1,out_channels)
+    return hasValidScaleShape(convOp, getScaleOperand(convOp));
+  }
+
+  /// Check if a value is a constant parameter
+  bool isConstant(mlir::Value value,
+                  const SmallPtrSet<BlockArgument, 4> &constParams) const {
+    if (auto blockArg = mlir::dyn_cast<BlockArgument>(value)) {
+      return constParams.contains(blockArg);
+    }
+    return false;
+  }
+
+  /// Check if the scale has the correct shape (1,1,1,out_channels)
+  bool hasValidScaleShape(Conv2dOp convOp, OpOperand *scaleOperand) const {
+    int64_t outChannels = convOp.getOutputChannelSize();
+    RankedTensorType scaleType =
+        mlir::cast<RankedTensorType>(scaleOperand->get().getType());
+
+    // Scale must be a 4D tensor
+    if (scaleType.getRank() != 4) {
+      return false;
+    }
+
+    // Scale must have shape (1,1,1,out_channels)
+    return scaleType.getDimSize(0) == 1 && scaleType.getDimSize(1) == 1 &&
+           scaleType.getDimSize(2) == 1 &&
+           scaleType.getDimSize(3) == outChannels;
+  }
+
+  /// Get the scale operand from the multiply operation
+  OpOperand *getScaleOperand(Conv2dOp convOp) const {
+    MultiplyOp multiplyOp =
+        mlir::cast<MultiplyOp>(*convOp.getResult().getUsers().begin());
+    return ttmlir::utils::getOtherOperands(multiplyOp, convOp).front();
+  }
+
+  /// Create a reshaped scale factor suitable for multiplying with weights
+  Value createReshapedScale(mlir::PatternRewriter &rewriter, Conv2dOp convOp,
+                            Value scaleValue) const {
+    // Get the scale's type
+    RankedTensorType scaleType =
+        mlir::cast<RankedTensorType>(scaleValue.getType());
+
+    // Create a new shape (out_channels,1,1,1) from (1,1,1,out_channels)
+    llvm::SmallVector<int64_t> newShape(scaleType.getShape());
+    std::swap(newShape[0], newShape[3]); // Swap first and last dimensions
+
+    // Convert to int32 for the reshape operation
+    llvm::SmallVector<int32_t> newShapeI32(newShape.begin(), newShape.end());
+
+    // Create and return the reshape operation
+    return ttir::utils::createDPSOp<ttir::ReshapeOp>(
+               rewriter, convOp.getLoc(), newShape, scaleType.getElementType(),
+               scaleType.getEncoding(), scaleValue,
+               rewriter.getI32ArrayAttr(newShapeI32))
+        .getResult();
+  }
+
+  /// Create pre-multiplied weights
+  Value createScaledWeights(mlir::PatternRewriter &rewriter, Conv2dOp convOp,
+                            Value weightValue, Value reshapedScale) const {
+    // Create a multiplication of the weights by the reshaped scale
+    return utils::createDPSOp<MultiplyOp>(
+               rewriter, convOp.getLoc(),
+               mlir::cast<RankedTensorType>(weightValue.getType()), weightValue,
+               reshapedScale)
+        .getResult(0);
+  }
+
+  /// Create a new convolution with the scaled weights
+  Conv2dOp createConvWithScaledWeights(mlir::PatternRewriter &rewriter,
+                                       Conv2dOp originalConv,
+                                       Value scaledWeights) const {
+    // Create a new convolution operation with the scaled weights
+    return utils::createDPSOp<Conv2dOp>(
+        rewriter, originalConv.getLoc(), originalConv.getResult().getType(),
+        originalConv.getInput(), scaledWeights, originalConv.getBias(),
+        originalConv.getStride(), originalConv.getPadding(),
+        originalConv.getDilation(), originalConv.getGroupsAttr(),
+        originalConv.getFlattenedCompatInfo());
+  }
+};
+
+class TTIRFusingPass : public impl::TTIRFusingBase<TTIRFusingPass> {
+public:
+  using impl::TTIRFusingBase<TTIRFusingPass>::TTIRFusingBase;
+  void runOnOperation() final {
+    RewritePatternSet patterns(&getContext());
+    patterns.add<TTIRConv2dWithBias>(&getContext());
+
+    // Add patterns for each reduction op type
+    patterns.add<ReductionWithReshapePattern<SumOp>>(&getContext());
+    patterns.add<ReductionWithReshapePattern<MeanOp>>(&getContext());
+    patterns.add<ReductionWithReshapePattern<MaxOp>>(&getContext());
+    patterns.add<ReductionWithReshapePattern<MinOp>>(&getContext());
+    patterns.add<ReductionWithReshapePattern<ProdOp>>(&getContext());
+    patterns.add<ReductionWithReshapePattern<ReduceAndOp>>(&getContext());
+    patterns.add<ReductionWithReshapePattern<ReduceOrOp>>(&getContext());
+    patterns.add<ReductionWithReshapePattern<ArgMaxOp>>(&getContext());
+    patterns.add<SoftmaxFusionPattern>(&getContext());
+    patterns.add<Conv2dWithMultiply>(&getContext());
+
+    GreedyRewriteConfig config;
+    config.useTopDownTraversal = true;
+    (void)applyPatternsGreedily(getOperation(), std::move(patterns));
+  }
+};
+} // namespace
+} // namespace mlir::tt::ttir

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -323,6 +323,22 @@ foldConsecutiveDataCastOps(T op, ::mlir::PatternRewriter &rewriter) {
   return success();
 }
 
+// Get number of output channels.
+int64_t mlir::tt::ttnn::Conv2dOp::getOutputChannelSize() {
+  RankedTensorType weightTy = getWeight().getType();
+  return weightTy.getShape()[0];
+}
+
+// Verify that bias dimensions are compatible with conv2d operation.
+bool mlir::tt::ttnn::Conv2dOp::verifyBias(llvm::ArrayRef<int64_t> bias) {
+  return bias[0] == 1 && bias[1] == 1 && bias[2] == 1 &&
+         bias[3] == getOutputChannelSize();
+}
+
+//===----------------------------------------------------------------------===//
+// Quantize Ops
+//===----------------------------------------------------------------------===//
+
 static ::mlir::LogicalResult verifyQuantizeOpCommon(
     llvm::function_ref<mlir::InFlightDiagnostic()> emitOpError,
     ::mlir::RankedTensorType inputType, ::mlir::RankedTensorType outputType,

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -330,7 +330,7 @@ int64_t mlir::tt::ttnn::Conv2dOp::getOutputChannelSize() {
 }
 
 // Verify that bias dimensions are compatible with conv2d operation.
-bool mlir::tt::ttnn::Conv2dOp::verifyBias(llvm::ArrayRef<int64_t> bias) {
+bool mlir::tt::ttnn::Conv2dOp::isBiasCompatible(llvm::ArrayRef<int64_t> bias) {
   return bias[0] == 1 && bias[1] == 1 && bias[2] == 1 &&
          bias[3] == getOutputChannelSize();
 }

--- a/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp
@@ -684,3 +684,7 @@ Conv2dConfigAttr Conv2dConfigAttr::withActivation(StringRef activation) const {
   params.activation = StringAttr::get(getContext(), activation);
   return params.buildConv2dConfig(getContext());
 }
+
+bool Conv2dConfigAttr::hasActivation() const {
+  return getActivation() != nullptr && getActivation().getValue() != "";
+}

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -35,6 +35,7 @@ void createTTNNPipelineTTIRPasses(
 
   pm.addPass(mlir::tt::createTTPopulateArgumentTypes(options.argumentTypeMap));
   pm.addPass(mlir::createCanonicalizerPass());
+  pm.addPass(mlir::tt::ttir::createTTIRFusing());
   pm.addPass(mlir::tt::createTTIRToTTIRDecompositionPass());
   pm.addPass(mlir::createCanonicalizerPass());
 
@@ -45,7 +46,7 @@ void createTTNNPipelineTTIRPasses(
   // Flattening sliding window ops for compatibility with conversion to TTNN
   pm.addPass(mlir::tt::ttir::createTTIRFlattenSlidingWindow());
 
-  // Add pass to erase inverse ops. This is disabled by default
+  // Add pass to erase inverse ops. This is enabled by default
   // while the pass is experimental.
   if (options.eraseInverseOpsEnabled) {
     pm.addPass(mlir::tt::ttir::createTTIREraseInverseOps());
@@ -136,6 +137,7 @@ void createTTIRToTTNNBackendPipeline(
   devicePm.addPass(ttir::createTTIRQuantDataTypeConversionPass(quantOptions));
 
   createTTNNPipelineLoweringPasses(devicePm, options);
+  devicePm.addPass(tt::ttnn::createTTNNFusing());
   createTTNNPipelineWorkaroundPass(devicePm, options);
   if (options.enableConstEval) {
     devicePm.addPass(transforms::createConstEvalHoistTransform());

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -5,6 +5,7 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         TTNNDecomposeLayouts.cpp
         TTNNToCpp.cpp
         TTNNPrepareConv2dWeights.cpp
+        TTNNFusing.cpp
         Workarounds/Decomposition/ArgMaxOpRewritePattern.cpp
         Workarounds/Decomposition/CumSumOpDimRewritePattern.cpp
         Workarounds/Decomposition/CumSumOpRankRewritePattern.cpp

--- a/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
@@ -54,6 +54,10 @@ private:
 
     ReshapeOp reshapeOp =
         mlir::cast<ReshapeOp>(*srcOp.getResult().getUsers().begin());
+
+    assert(reshapeOp.getResult().hasOneUse() &&
+           ttmlir::utils::allUsersOfType<ReluOp>(reshapeOp) &&
+           "Reshape should have only one user and that user should be relu.");
     return mlir::cast<ReluOp>(*reshapeOp.getResult().getUsers().begin());
   }
 

--- a/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
+#include "ttmlir/Utils.h"
+
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir::tt::ttnn {
+#define GEN_PASS_DEF_TTNNFUSING
+#include "ttmlir/Dialect/TTNN/Transforms/Passes.h.inc"
+
+namespace {
+
+class TTNNConv2dWithActivation : public mlir::OpRewritePattern<Conv2dOp> {
+  using TTNNConv2dWithActivation::OpRewritePattern<Conv2dOp>::OpRewritePattern;
+
+public:
+  mlir::LogicalResult
+  matchAndRewrite(Conv2dOp srcOp, mlir::PatternRewriter &rewriter) const final {
+    if (!isFusable(srcOp)) {
+      return failure();
+    }
+
+    auto [reluOp, reluInput] = getReluOpAndReluInput(srcOp);
+
+    mlir::StringAttr activation = rewriter.getStringAttr("relu");
+    Conv2dConfigAttr conv2dConfigAttr =
+        srcOp.getConv2dConfigAttr()
+            ? srcOp.getConv2dConfigAttr()
+            : Conv2dConfigAttr::get(rewriter.getContext());
+    conv2dConfigAttr = conv2dConfigAttr.withActivation(activation);
+
+    rewriter.modifyOpInPlace(
+        srcOp, [&]() { srcOp.setConv2dConfigAttr(conv2dConfigAttr); });
+
+    // Replace the relu op uses with either conv2d or reshape
+    // depending on if reshape was present.
+    rewriter.replaceAllUsesWith(reluOp, reluInput);
+
+    return mlir::success();
+  }
+
+private:
+  std::pair<ReluOp, mlir::Value> getReluOpAndReluInput(Conv2dOp srcOp) const {
+    assert((ttmlir::utils::allUsers<ReshapeOp, ReluOp>(srcOp)) &&
+           "Conv2d should have either Relu or Reshape as user.");
+
+    if (ttmlir::utils::allUsers<ReluOp>(srcOp)) {
+      return {mlir::cast<ReluOp>(*srcOp.getResult().getUsers().begin()),
+              srcOp.getResult()};
+    }
+
+    ReshapeOp reshapeOp =
+        mlir::cast<ReshapeOp>(*srcOp.getResult().getUsers().begin());
+    ReluOp reluOp =
+        mlir::cast<ReluOp>(*reshapeOp.getResult().getUsers().begin());
+
+    return {reluOp, reshapeOp.getResult()};
+  }
+
+  bool isFusable(Conv2dOp srcOp) const {
+    if (srcOp.getConv2dConfig() && srcOp.getConv2dConfig()->hasActivation()) {
+      return false;
+    }
+
+    // Conv2d has multiple uses so we cannot fuse.
+    if (!srcOp.getResult().hasOneUse()) {
+      return false;
+    }
+
+    // Conv2d only user is ReLU so we can fuse.
+    if (ttmlir::utils::allUsers<ReluOp>(srcOp)) {
+      return true;
+    }
+
+    // Since window flattening will add rehape after conv we need to check
+    // if there is reshape right after conv2d.
+    if (!ttmlir::utils::allUsers<ReshapeOp>(srcOp)) {
+      return false;
+    }
+
+    ReshapeOp reshapeOp =
+        mlir::cast<ReshapeOp>(*srcOp.getResult().getUsers().begin());
+
+    // If we want to fuse relu to conv we need to make sure that reshape
+    // has only one user and that user is relu.
+    return reshapeOp.getResult().hasOneUse() &&
+           ttmlir::utils::allUsers<ReluOp>(reshapeOp);
+  }
+};
+
+class TTNNFusingPass : public impl::TTNNFusingBase<TTNNFusingPass> {
+public:
+  using impl::TTNNFusingBase<TTNNFusingPass>::TTNNFusingBase;
+
+  void runOnOperation() final {
+    RewritePatternSet patterns(&getContext());
+    patterns.add<TTNNConv2dWithActivation>(&getContext());
+    GreedyRewriteConfig config;
+    config.useTopDownTraversal = true;
+    (void)applyPatternsGreedily(getOperation(), std::move(patterns));
+  }
+};
+} // namespace
+
+} // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
@@ -669,6 +669,7 @@ public:
 
   void getDependentDialects(mlir::DialectRegistry &registry) const override {
     registry.insert<mlir::tt::ttir::TTIRDialect>();
+    registry.insert<mlir::tt::ttnn::TTNNDialect>();
     registry.insert<mlir::tt::TTDialect>();
     registry.insert<mlir::func::FuncDialect>();
   }

--- a/lib/Transforms/ConstEvalHoist.cpp
+++ b/lib/Transforms/ConstEvalHoist.cpp
@@ -5,6 +5,7 @@
 #include "ttmlir/Dialect/TT/IR/TTOps.h"
 #include "ttmlir/Dialect/TT/IR/TTTraits.h"
 #include "ttmlir/Transforms/Passes.h"
+#include "ttmlir/Utils.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
@@ -110,32 +111,7 @@ private:
       return;
     }
 
-    auto args = funcOp->getArguments();
-
-    // Iterate through arguments and check their tt.argument_type attributes
-    for (auto arg : args) {
-      auto argAttrs = funcOp->getArgAttrDict(arg.getArgNumber());
-      if (!argAttrs) {
-        continue;
-      }
-      auto typeAttr = argAttrs.get("tt.argument_type");
-      if (!typeAttr) {
-        continue;
-      }
-
-      // Cast to ArgumentTypeAttr
-      if (auto enumAttr =
-              mlir::dyn_cast<mlir::tt::ArgumentTypeAttr>(typeAttr)) {
-        // Get the enum value
-        mlir::tt::ArgumentType attrValue = enumAttr.getValue();
-
-        // Compare with Parameter and Constant
-        if (attrValue == mlir::tt::ArgumentType::Parameter ||
-            attrValue == mlir::tt::ArgumentType::Constant) {
-          constParams.insert(arg);
-        }
-      }
-    }
+    constParams = ttmlir::utils::populateConstParams(*funcOp);
   }
 
   // Recurse up hierarchy to find root of given subset.

--- a/test/ttmlir/Dialect/TTIR/fusing/conv2d_bias_fusing.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/conv2d_bias_fusing.mlir
@@ -20,7 +20,7 @@ module {
               groups = 1: i32
             }> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
     %2 = ttir.empty() : tensor<1x30x30x64xbf16>
-    %4 = "ttir.add"(%1, %arg2, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %4 = "ttir.add"(%1, %arg2, %2) : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
     return %4: tensor<1x30x30x64xbf16>
   }
 }
@@ -48,7 +48,7 @@ module {
     // This bias comes after conv2d so we cannot fuse. Ideally we can check if this only use of bias
     // and commute it before conv2d. For now we will cover this simple case.
     %3 = ttir.empty() : tensor<1x1x1x64xbf16>
-    %4 = "ttir.add"(%1, %3, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %4 = "ttir.add"(%1, %3, %2) : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
     return %4: tensor<1x30x30x64xbf16>
   }
 }
@@ -75,12 +75,12 @@ module {
     // CHECK: %[[RETURNADD:.*]] = "ttir.add"
     %2 = ttir.empty() : tensor<1x30x30x64xbf16>
     // First use of conv2d.
-    %3 = "ttir.add"(%1, %arg2, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %3 = "ttir.add"(%1, %arg2, %2) : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
     %4 = ttir.empty() : tensor<1x30x30x64xbf16>
     // Second use of conv2d (we cannot fuse).
-    %5 = "ttir.add"(%1, %arg2, %4) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %5 = "ttir.add"(%1, %arg2, %4) : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
     %6 = ttir.empty() : tensor<1x30x30x64xbf16>
-    %7 = "ttir.add"(%3, %5, %6) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %7 = "ttir.add"(%3, %5, %6) : (tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
     // CHECK-NEXT: return %[[RETURNADD]]
     return %7: tensor<1x30x30x64xbf16>
   }
@@ -105,11 +105,11 @@ module {
             }> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
     %2 = ttir.empty() : tensor<1x30x30x64xbf16>
     // We fuse this add into bias.
-    %4 = "ttir.add"(%1, %arg2, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %4 = "ttir.add"(%1, %arg2, %2) : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
     %5 = ttir.empty() : tensor<1x30x30x64xbf16>
     // CHECK: %[[RETURNADD:.*]] = "ttir.add"(%[[CONV]], %arg2
     // Pattern driver will try to fuse this add also but it should fail because we already fused one bias.
-    %6 = "ttir.add"(%4, %arg2, %5) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %6 = "ttir.add"(%4, %arg2, %5) : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
     // CHECK-NEXT: return %[[RETURNADD]]
     return %6: tensor<1x30x30x64xbf16>
   }
@@ -136,7 +136,7 @@ module {
             }> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
     // CHECK: %[[RETURNADD:.*]] = "ttir.add"(%[[CONV]]
     %3 = ttir.empty() : tensor<1x30x30x64xbf16>
-    %4 = "ttir.add"(%2, %1, %3) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %4 = "ttir.add"(%2, %1, %3) : (tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
     // CHECK-NEXT: return %[[RETURNADD]]
     return %4: tensor<1x30x30x64xbf16>
   }

--- a/test/ttmlir/Dialect/TTIR/fusing/conv2d_bias_fusing.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/conv2d_bias_fusing.mlir
@@ -1,0 +1,145 @@
+// RUN: ttmlir-opt --ttir-fusing %s | FileCheck %s
+
+// Fuse add into conv. We also check that all uses of add are updated.
+module {
+  // CHECK-LABEL: func.func @conv2d_fuse
+  func.func @conv2d_fuse(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x64xbf16> {
+    %0 = ttir.empty() : tensor<1x30x30x64xbf16>
+    // CHECK: %[[CONV:.*]] = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
+    // CHECK-SAME: dilation = 1
+    // CHECK-SAME: groups = 1
+    // CHECK-SAME: padding = 0
+    // CHECK-SAME: stride = 1
+    // CHECK-NEXT: return %[[CONV]]
+    %1 = "ttir.conv2d"(%arg0, %arg1, %0)
+            <{
+              stride = 1: i32,
+              padding = 0: i32,
+              dilation = 1: i32,
+              groups = 1: i32
+            }> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %2 = ttir.empty() : tensor<1x30x30x64xbf16>
+    %4 = "ttir.add"(%1, %arg2, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    return %4: tensor<1x30x30x64xbf16>
+  }
+}
+
+// Test that we cannot fuse conv2d and bias because it would break dominance order.
+module {
+  // CHECK-LABEL: func.func @conv2d_dominance_order
+  func.func @conv2d_dominance_order(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>) -> tensor<1x30x30x64xbf16> {
+    %0 = ttir.empty() : tensor<1x30x30x64xbf16>
+    // CHECK: %[[CONV:.*]] = "ttir.conv2d"
+    // CHECK-SAME: dilation = 1
+    // CHECK-SAME: groups = 1
+    // CHECK-SAME: padding = 0
+    // CHECK-SAME: stride = 1
+    // CHECK-SAME: tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x30x30x64xbf16>
+    %1 = "ttir.conv2d"(%arg0, %arg1, %0)
+            <{
+              stride = 1: i32,
+              padding = 0: i32,
+              dilation = 1: i32,
+              groups = 1: i32
+            }> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    // CHECK-NEXT: ttir.empty
+    %2 = ttir.empty() : tensor<1x30x30x64xbf16>
+    // CHECK-NEXT: ttir.empty
+    // This bias comes after conv2d so we cannot fuse. Ideally we can check if this only use of bias
+    // and commute it before conv2d. For now we will cover this simple case.
+    %3 = ttir.empty() : tensor<1x1x1x64xbf16>
+    // CHECK-NEXT: %[[ADD:.*]] = "ttir.add"
+    %4 = "ttir.add"(%1, %3, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    // CHECK-NEXT: return %[[ADD]]
+    return %4: tensor<1x30x30x64xbf16>
+  }
+}
+
+// Test that we cannot fuse conv2d and bias because conv2d has more than one use.
+module {
+  // CHECK-LABEL: func.func @conv2d_multiple_uses
+  func.func @conv2d_multiple_uses(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x64xbf16> {
+    %0 = ttir.empty() : tensor<1x30x30x64xbf16>
+    // CHECK: %[[CONV:.*]] = "ttir.conv2d"(%arg0, %arg1, %0)
+    // CHECK-SAME: dilation = 1
+    // CHECK-SAME: groups = 1
+    // CHECK-SAME: padding = 0
+    // CHECK-SAME: stride = 1
+    %1 = "ttir.conv2d"(%arg0, %arg1, %0)
+            <{
+              stride = 1: i32,
+              padding = 0: i32,
+              dilation = 1: i32,
+              groups = 1: i32
+            }> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    // CHECK: ttir.add
+    // CHECK: ttir.add
+    // CHECK: %[[RETURNADD:.*]] = "ttir.add"
+    %2 = ttir.empty() : tensor<1x30x30x64xbf16>
+    // First use of conv2d.
+    %3 = "ttir.add"(%1, %arg2, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %4 = ttir.empty() : tensor<1x30x30x64xbf16>
+    // Second use of conv2d (we cannot fuse).
+    %5 = "ttir.add"(%1, %arg2, %4) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %6 = ttir.empty() : tensor<1x30x30x64xbf16>
+    %7 = "ttir.add"(%3, %5, %6) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    // CHECK-NEXT: return %[[RETURNADD]]
+    return %7: tensor<1x30x30x64xbf16>
+  }
+}
+
+// Check that we can only fuse one add into conv2d. Second add is not fused.
+module {
+  // CHECK-LABEL: func.func @conv2d_single_add
+  func.func @conv2d_single_add(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x64xbf16> {
+    %0 = ttir.empty() : tensor<1x30x30x64xbf16>
+    // CHECK: %[[CONV:.*]] = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
+    // CHECK-SAME: dilation = 1
+    // CHECK-SAME: groups = 1
+    // CHECK-SAME: padding = 0
+    // CHECK-SAME: stride = 1
+    %1 = "ttir.conv2d"(%arg0, %arg1, %0)
+            <{
+              stride = 1: i32,
+              padding = 0: i32,
+              dilation = 1: i32,
+              groups = 1: i32
+            }> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %2 = ttir.empty() : tensor<1x30x30x64xbf16>
+    // We fuse this add into bias.
+    %4 = "ttir.add"(%1, %arg2, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %5 = ttir.empty() : tensor<1x30x30x64xbf16>
+    // CHECK: %[[RETURNADD:.*]] = "ttir.add"(%[[CONV]], %arg2
+    // Pattern driver will try to fuse this add also but it should fail because we already fused one bias.
+    %6 = "ttir.add"(%4, %arg2, %5) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    // CHECK-NEXT: return %[[RETURNADD]]
+    return %6: tensor<1x30x30x64xbf16>
+  }
+}
+
+// Check that we cannot fuse because add because second argument to add next to conv is not suitable for bias.
+module {
+  // CHECK-LABEL: func.func @conv2d_not_suitable_for_bias
+  func.func @conv2d_not_suitable_for_bias(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>) -> tensor<1x30x30x64xbf16> {
+    %0 = ttir.empty() : tensor<1x30x30x64xbf16>
+    // We will add this empty tensor to conv2d output. This cannot be fused this its not in the right format.
+    %1 = ttir.empty() : tensor<1x30x30x64xbf16>
+    // CHECK: %[[CONV:.*]] = "ttir.conv2d"(%arg0, %arg1, %0)
+    // CHECK-SAME: dilation = 1
+    // CHECK-SAME: groups = 1
+    // CHECK-SAME: padding = 0
+    // CHECK-SAME: stride = 1
+    %2 = "ttir.conv2d"(%arg0, %arg1, %0)
+            <{
+              stride = 1: i32,
+              padding = 0: i32,
+              dilation = 1: i32,
+              groups = 1: i32
+            }> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    // CHECK: %[[RETURNADD:.*]] = "ttir.add"(%[[CONV]]
+    %3 = ttir.empty() : tensor<1x30x30x64xbf16>
+    %4 = "ttir.add"(%2, %1, %3) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    // CHECK-NEXT: return %[[RETURNADD]]
+    return %4: tensor<1x30x30x64xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/fusing/conv2d_multiply_commute.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/conv2d_multiply_commute.mlir
@@ -19,7 +19,7 @@ module {
               groups = 1: i32
             }> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
     %2 = ttir.empty() : tensor<1x30x30x64xbf16>
-    %4 = "ttir.multiply"(%1, %arg2, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %4 = "ttir.multiply"(%1, %arg2, %2) : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
 
     // CHECK: return %[[CONV]]
     return %4: tensor<1x30x30x64xbf16>
@@ -41,11 +41,11 @@ module {
               groups = 1: i32
             }> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
     %2 = ttir.empty() : tensor<1x30x30x64xbf16>
-    %4 = "ttir.multiply"(%1, %arg2, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %4 = "ttir.multiply"(%1, %arg2, %2) : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
     %5 = ttir.empty() : tensor<1x30x30x64xbf16>
-    %6 = "ttir.multiply"(%1, %arg2, %5) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %6 = "ttir.multiply"(%1, %arg2, %5) : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
     %7 = ttir.empty() : tensor<1x30x30x64xbf16>
-    %8 = "ttir.add"(%6, %4, %7) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %8 = "ttir.add"(%6, %4, %7) : (tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
     return %8: tensor<1x30x30x64xbf16>
   }
 
@@ -63,7 +63,7 @@ module {
               groups = 1: i32
             }> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
     %2 = ttir.empty() : tensor<1x30x30x64xbf16>
-    %4 = "ttir.multiply"(%1, %arg2, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x1x30x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %4 = "ttir.multiply"(%1, %arg2, %2) : (tensor<1x30x30x64xbf16>, tensor<1x1x30x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
     return %4: tensor<1x30x30x64xbf16>
   }
 
@@ -81,7 +81,7 @@ module {
               groups = 1: i32
             }> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
     %2 = ttir.empty() : tensor<1x30x30x64xbf16>
-    %4 = "ttir.multiply"(%1, %arg2, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %4 = "ttir.multiply"(%1, %arg2, %2) : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
     return %4: tensor<1x30x30x64xbf16>
   }
 
@@ -102,11 +102,11 @@ module {
               groups = 1: i32
             }> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
     %2 = ttir.empty() : tensor<1x30x30x64xbf16>
-    %4 = "ttir.multiply"(%1, %arg2, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %4 = "ttir.multiply"(%1, %arg2, %2) : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
 
     // CHECK: "ttir.multiply"
     %5 = ttir.empty() : tensor<1x30x30x64xbf16>
-    %6 = "ttir.multiply"(%4, %arg2, %5) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %6 = "ttir.multiply"(%4, %arg2, %5) : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
     return %6: tensor<1x30x30x64xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTIR/fusing/conv2d_multiply_commute.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/conv2d_multiply_commute.mlir
@@ -1,0 +1,112 @@
+// RUN: ttmlir-opt --ttir-fusing %s | FileCheck %s
+
+// Commute multiply before conv2d.
+module {
+  // CHECK-LABEL: func.func @commute_multiply
+  func.func @commute_multiply(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16> {tt.argument_type = #tt.argument_type<constant>}, %arg2: tensor<1x1x1x64xbf16> {tt.argument_type = #tt.argument_type<constant>}) -> tensor<1x30x30x64xbf16> {
+    // CHECK: %[[SCALE:.*]] = "ttir.reshape"
+    // CHECK-SAME: (%arg2
+    // CHECK: %[[WEIGHT_SCALED:.*]] = "ttir.multiply"
+    // CHECK-SAME: (%arg1, %[[SCALE]]
+    // CHECK: %[[CONV:.*]] = "ttir.conv2d"
+    // CHECK: (%arg0, %[[WEIGHT_SCALED]]
+    %0 = ttir.empty() : tensor<1x30x30x64xbf16>
+    %1 = "ttir.conv2d"(%arg0, %arg1, %0)
+            <{
+              stride = 1: i32,
+              padding = 0: i32,
+              dilation = 1: i32,
+              groups = 1: i32
+            }> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %2 = ttir.empty() : tensor<1x30x30x64xbf16>
+    %4 = "ttir.multiply"(%1, %arg2, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+
+    // CHECK: return %[[CONV]]
+    return %4: tensor<1x30x30x64xbf16>
+  }
+
+  // Check that we can't commute because conv has more than one use.
+  // CHECK-LABEL: func.func @conv2d_with_multiple_uses
+  func.func @conv2d_with_multiple_uses(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16> {tt.argument_type = #tt.argument_type<constant>}, %arg2: tensor<1x1x1x64xbf16> {tt.argument_type = #tt.argument_type<constant>}) -> tensor<1x30x30x64xbf16> {
+    // CHECK: "ttir.conv2d"
+    // CHECK: "ttir.multiply"
+    // CHECK: "ttir.multiply"
+    // CHECK: "ttir.add"
+    %0 = ttir.empty() : tensor<1x30x30x64xbf16>
+    %1 = "ttir.conv2d"(%arg0, %arg1, %0)
+            <{
+              stride = 1: i32,
+              padding = 0: i32,
+              dilation = 1: i32,
+              groups = 1: i32
+            }> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %2 = ttir.empty() : tensor<1x30x30x64xbf16>
+    %4 = "ttir.multiply"(%1, %arg2, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %5 = ttir.empty() : tensor<1x30x30x64xbf16>
+    %6 = "ttir.multiply"(%1, %arg2, %5) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %7 = ttir.empty() : tensor<1x30x30x64xbf16>
+    %8 = "ttir.add"(%6, %4, %7) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    return %8: tensor<1x30x30x64xbf16>
+  }
+
+  // Check that we can't commute because scale operand is not in format (1, 1, 1, out_channels).
+  // CHECK-LABEL: func.func @conv2d_with_invalid_scale
+  func.func @conv2d_with_invalid_scale(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16> {tt.argument_type = #tt.argument_type<constant>}, %arg2: tensor<1x1x30x64xbf16> {tt.argument_type = #tt.argument_type<constant>}) -> tensor<1x30x30x64xbf16> {
+    // CHECK: "ttir.conv2d"
+    // CHECK: "ttir.multiply"
+    %0 = ttir.empty() : tensor<1x30x30x64xbf16>
+    %1 = "ttir.conv2d"(%arg0, %arg1, %0)
+            <{
+              stride = 1: i32,
+              padding = 0: i32,
+              dilation = 1: i32,
+              groups = 1: i32
+            }> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %2 = ttir.empty() : tensor<1x30x30x64xbf16>
+    %4 = "ttir.multiply"(%1, %arg2, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x1x30x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    return %4: tensor<1x30x30x64xbf16>
+  }
+
+  // Verify that we can't commute because function arguments are not constants.
+  // %arg2 is not constant in this case.
+  func.func @conv2d_with_non_constant_scale(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16> {tt.argument_type = #tt.argument_type<constant>}, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x64xbf16> {
+    // CHECK: "ttir.conv2d"
+    // CHECK: "ttir.multiply"
+    %0 = ttir.empty() : tensor<1x30x30x64xbf16>
+    %1 = "ttir.conv2d"(%arg0, %arg1, %0)
+            <{
+              stride = 1: i32,
+              padding = 0: i32,
+              dilation = 1: i32,
+              groups = 1: i32
+            }> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %2 = ttir.empty() : tensor<1x30x30x64xbf16>
+    %4 = "ttir.multiply"(%1, %arg2, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    return %4: tensor<1x30x30x64xbf16>
+  }
+
+  // Verify that we can commute only first multiply.
+  // This is because when rewriting we check if weight argument to conv is constant block argument, which is not the case after we commute first multiply.
+  // Ideally we would commute second one also, but it would require more complex analysis.
+  // CHECK-LABEL: func.func @conv2d_with_chain_of_multiply
+  func.func @conv2d_with_chain_of_multiply(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16> {tt.argument_type = #tt.argument_type<constant>}, %arg2: tensor<1x1x1x64xbf16> {tt.argument_type = #tt.argument_type<constant>}) -> tensor<1x30x30x64xbf16> {
+    // CHECK: "ttir.reshape"
+    // CHECK: "ttir.multiply"
+    // CHECK: "ttir.conv2d"
+    %0 = ttir.empty() : tensor<1x30x30x64xbf16>
+    %1 = "ttir.conv2d"(%arg0, %arg1, %0)
+            <{
+              stride = 1: i32,
+              padding = 0: i32,
+              dilation = 1: i32,
+              groups = 1: i32
+            }> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %2 = ttir.empty() : tensor<1x30x30x64xbf16>
+    %4 = "ttir.multiply"(%1, %arg2, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+
+    // CHECK: "ttir.multiply"
+    %5 = ttir.empty() : tensor<1x30x30x64xbf16>
+    %6 = "ttir.multiply"(%4, %arg2, %5) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    return %6: tensor<1x30x30x64xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/fusing/reduction_fusing.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/reduction_fusing.mlir
@@ -1,0 +1,157 @@
+// RUN: ttmlir-opt %s --ttir-fusing | FileCheck %s
+
+// Test basic reduction + reshape fusion (sum operation).
+module {
+  // CHECK-LABEL: func.func @sum_reshape_fusion
+  func.func @sum_reshape_fusion(%arg0: tensor<32x64x128xf32>) -> tensor<32x1x128xf32> {
+    // CHECK-NOT: ttir.reshape
+    // CHECK: %[[RESULT:.*]] = "ttir.sum"(%arg0, %{{.*}}) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<32x64x128xf32>, tensor<32x1x128xf32>) -> tensor<32x1x128xf32>
+    // CHECK: return %[[RESULT]]
+
+    %0 = ttir.empty() : tensor<32x128xf32>
+    %1 = "ttir.sum"(%arg0, %0) {dim_arg = [1 : i32], keep_dim = false} : (tensor<32x64x128xf32>, tensor<32x128xf32>) -> tensor<32x128xf32>
+
+    %2 = ttir.empty() : tensor<32x1x128xf32>
+    %3 = "ttir.reshape"(%1, %2) {shape = [32 : i32, 1 : i32, 128 : i32]} : (tensor<32x128xf32>, tensor<32x1x128xf32>) -> tensor<32x1x128xf32>
+
+    return %3 : tensor<32x1x128xf32>
+  }
+}
+
+// Test reduction + reshape fusion with mean operation.
+module {
+  // CHECK-LABEL: func.func @mean_reshape_fusion
+  func.func @mean_reshape_fusion(%arg0: tensor<32x64x128xf32>) -> tensor<32x64x1xf32> {
+    // CHECK-NOT: ttir.reshape
+    // CHECK: %[[RESULT:.*]] = "ttir.mean"(%arg0, %{{.*}}) <{dim_arg = [2 : i32], keep_dim = true}> : (tensor<32x64x128xf32>, tensor<32x64x1xf32>) -> tensor<32x64x1xf32>
+    // CHECK: return %[[RESULT]]
+
+    %0 = ttir.empty() : tensor<32x64xf32>
+    %1 = "ttir.mean"(%arg0, %0) {dim_arg = [2 : i32], keep_dim = false} : (tensor<32x64x128xf32>, tensor<32x64xf32>) -> tensor<32x64xf32>
+
+    %2 = ttir.empty() : tensor<32x64x1xf32>
+    %3 = "ttir.reshape"(%1, %2) {shape = [32 : i32, 64 : i32, 1 : i32]} : (tensor<32x64xf32>, tensor<32x64x1xf32>) -> tensor<32x64x1xf32>
+
+    return %3 : tensor<32x64x1xf32>
+  }
+}
+
+// Test reduction + reshape fusion with max operation.
+module {
+  // CHECK-LABEL: func.func @max_reshape_fusion
+  func.func @max_reshape_fusion(%arg0: tensor<32x64x128xf32>) -> tensor<1x64x128xf32> {
+    // CHECK-NOT: ttir.reshape
+    // CHECK: %[[RESULT:.*]] = "ttir.max"(%arg0, %{{.*}}) <{dim_arg = [0 : i32], keep_dim = true}> : (tensor<32x64x128xf32>, tensor<1x64x128xf32>) -> tensor<1x64x128xf32>
+    // CHECK: return %[[RESULT]]
+
+    %0 = ttir.empty() : tensor<64x128xf32>
+    %1 = "ttir.max"(%arg0, %0) {dim_arg = [0 : i32], keep_dim = false} : (tensor<32x64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+
+    %2 = ttir.empty() : tensor<1x64x128xf32>
+    %3 = "ttir.reshape"(%1, %2) {shape = [1 : i32, 64 : i32, 128 : i32]} : (tensor<64x128xf32>, tensor<1x64x128xf32>) -> tensor<1x64x128xf32>
+
+    return %3 : tensor<1x64x128xf32>
+  }
+}
+
+// Test reduction + reshape fusion with multiple reduction dimensions.
+module {
+  // CHECK-LABEL: func.func @multi_dim_reduction_reshape_fusion
+  func.func @multi_dim_reduction_reshape_fusion(%arg0: tensor<32x64x128xf32>) -> tensor<32x1x1xf32> {
+    // CHECK-NOT: ttir.reshape
+    // CHECK: %[[RESULT:.*]] = "ttir.sum"(%arg0, %{{.*}}) <{dim_arg = [1 : i32, 2 : i32], keep_dim = true}> : (tensor<32x64x128xf32>, tensor<32x1x1xf32>) -> tensor<32x1x1xf32>
+    // CHECK: return %[[RESULT]]
+
+    %0 = ttir.empty() : tensor<32xf32>
+    %1 = "ttir.sum"(%arg0, %0) {dim_arg = [1 : i32, 2 : i32], keep_dim = false} : (tensor<32x64x128xf32>, tensor<32xf32>) -> tensor<32xf32>
+
+    %2 = ttir.empty() : tensor<32x1x1xf32>
+    %3 = "ttir.reshape"(%1, %2) {shape = [32 : i32, 1 : i32, 1 : i32]} : (tensor<32xf32>, tensor<32x1x1xf32>) -> tensor<32x1x1xf32>
+
+    return %3 : tensor<32x1x1xf32>
+  }
+}
+
+// Test negative case - reduction already has keep_dim=true.
+module {
+  // CHECK-LABEL: func.func @no_fusion_already_keep_dim
+  func.func @no_fusion_already_keep_dim(%arg0: tensor<32x64x128xf32>) -> tensor<32x1x128xf32> {
+    // CHECK: ttir.sum
+    // CHECK-NOT: ttir.reshape
+
+    // Reduction already has keep_dim=true, so we cannot fuse. Reshape will be folded.
+    %0 = ttir.empty() : tensor<32x1x128xf32>
+    %1 = "ttir.sum"(%arg0, %0) {dim_arg = [1 : i32], keep_dim = true} : (tensor<32x64x128xf32>, tensor<32x1x128xf32>) -> tensor<32x1x128xf32>
+
+    %2 = ttir.empty() : tensor<32x1x128xf32>
+    %3 = "ttir.reshape"(%1, %2) {shape = [32 : i32, 1 : i32, 128 : i32]} : (tensor<32x1x128xf32>, tensor<32x1x128xf32>) -> tensor<32x1x128xf32>
+
+    return %1 : tensor<32x1x128xf32>
+  }
+}
+
+// Test negative case - reduction has more than one use.
+module {
+  // CHECK-LABEL: func.func @no_fusion_more_than_one_use
+  func.func @no_fusion_more_than_one_use(%arg0: tensor<32x64x128xf32>) -> tensor<32x1x128xf32> {
+    // CHECK: ttir.sum
+    // CHECK: ttir.add
+    // CHECK: ttir.reshape
+    // CHECK: ttir.reshape
+    // CHECK: ttir.add
+
+    %0 = ttir.empty() : tensor<32x128xf32>
+    %1 = "ttir.sum"(%arg0, %0) {dim_arg = [1 : i32], keep_dim = false} : (tensor<32x64x128xf32>, tensor<32x128xf32>) -> tensor<32x128xf32>
+
+    // Extra use of the reduction result prevents fusion.
+    %2 = ttir.empty() : tensor<32x128xf32>
+    %3 = "ttir.add"(%1, %1, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x128xf32>, tensor<32x128xf32>, tensor<32x128xf32>) -> tensor<32x128xf32>
+
+    %4 = ttir.empty() : tensor<32x1x128xf32>
+    %5 = "ttir.reshape"(%3, %4) {shape = [32 : i32, 1 : i32, 128 : i32]} : (tensor<32x128xf32>, tensor<32x1x128xf32>) -> tensor<32x1x128xf32>
+
+    %6 = ttir.empty() : tensor<32x1x128xf32>
+    %7 = "ttir.reshape"(%1, %6) {shape = [32 : i32, 1 : i32, 128 : i32]} : (tensor<32x128xf32>, tensor<32x1x128xf32>) -> tensor<32x1x128xf32>
+
+    %8 = ttir.empty() : tensor<32x1x128xf32>
+    %9 = "ttir.add"(%5, %7, %8) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x1x128xf32>, tensor<32x1x128xf32>, tensor<32x1x128xf32>) -> tensor<32x1x128xf32>
+
+    return %9 : tensor<32x1x128xf32>
+  }
+}
+
+// Test negative case - cannot fuse reduction + reshape because reshape rank and reduce rank dont match.
+module {
+  // CHECK-LABEL: func.func @no_fusion_rank_mismatch
+  func.func @no_fusion_rank_mismatch(%arg0: tensor<32x64x128xf32>) -> tensor<32x1x1x128xf32> {
+    // CHECK: ttir.sum
+    // CHECK: ttir.reshape
+
+    %0 = ttir.empty() : tensor<32x128xf32>
+    %1 = "ttir.sum"(%arg0, %0) {dim_arg = [1 : i32], keep_dim = false} : (tensor<32x64x128xf32>, tensor<32x128xf32>) -> tensor<32x128xf32>
+
+    // Reshape unsqueezes the result to greater rank so cannot fuse.
+    %2 = ttir.empty() : tensor<32x1x1x128xf32>
+    %3 = "ttir.reshape"(%1, %2) {shape = [32 : i32, 1 : i32, 1 : i32, 128 : i32]} : (tensor<32x128xf32>, tensor<32x1x1x128xf32>) -> tensor<32x1x1x128xf32>
+
+    return %3 : tensor<32x1x1x128xf32>
+  }
+}
+
+// Test negative case - cannot fuse reduction + reshape because reduced dims don't match.
+module {
+  // CHECK-LABEL: func.func @no_fusion_reduced_dims_mismatch
+  func.func @no_fusion_reduced_dims_mismatch(%arg0: tensor<32x64x128xf32>) -> tensor<1x32x128xf32> {
+    // CHECK: ttir.sum
+    // CHECK: ttir.reshape
+
+    %0 = ttir.empty() : tensor<32x128xf32>
+    %1 = "ttir.sum"(%arg0, %0) {dim_arg = [1 : i32], keep_dim = false} : (tensor<32x64x128xf32>, tensor<32x128xf32>) -> tensor<32x128xf32>
+
+    // Reshape adds new dimension but it's not the same as the reduction dim.
+    %2 = ttir.empty() : tensor<1x32x128xf32>
+    %3 = "ttir.reshape"(%1, %2) {shape = [1 : i32, 32 : i32, 128 : i32]} : (tensor<32x128xf32>, tensor<1x32x128xf32>) -> tensor<1x32x128xf32>
+
+    return %3 : tensor<1x32x128xf32>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/fusing/reduction_fusing.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/reduction_fusing.mlir
@@ -105,7 +105,7 @@ module {
 
     // Extra use of the reduction result prevents fusion.
     %2 = ttir.empty() : tensor<32x128xf32>
-    %3 = "ttir.add"(%1, %1, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x128xf32>, tensor<32x128xf32>, tensor<32x128xf32>) -> tensor<32x128xf32>
+    %3 = "ttir.add"(%1, %1, %2) : (tensor<32x128xf32>, tensor<32x128xf32>, tensor<32x128xf32>) -> tensor<32x128xf32>
 
     %4 = ttir.empty() : tensor<32x1x128xf32>
     %5 = "ttir.reshape"(%3, %4) {shape = [32 : i32, 1 : i32, 128 : i32]} : (tensor<32x128xf32>, tensor<32x1x128xf32>) -> tensor<32x1x128xf32>
@@ -114,7 +114,7 @@ module {
     %7 = "ttir.reshape"(%1, %6) {shape = [32 : i32, 1 : i32, 128 : i32]} : (tensor<32x128xf32>, tensor<32x1x128xf32>) -> tensor<32x1x128xf32>
 
     %8 = ttir.empty() : tensor<32x1x128xf32>
-    %9 = "ttir.add"(%5, %7, %8) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x1x128xf32>, tensor<32x1x128xf32>, tensor<32x1x128xf32>) -> tensor<32x1x128xf32>
+    %9 = "ttir.add"(%5, %7, %8) : (tensor<32x1x128xf32>, tensor<32x1x128xf32>, tensor<32x1x128xf32>) -> tensor<32x1x128xf32>
 
     return %9 : tensor<32x1x128xf32>
   }

--- a/test/ttmlir/Dialect/TTIR/fusing/reduction_fusing.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/reduction_fusing.mlir
@@ -4,8 +4,8 @@
 module {
   // CHECK-LABEL: func.func @sum_reshape_fusion
   func.func @sum_reshape_fusion(%arg0: tensor<32x64x128xf32>) -> tensor<32x1x128xf32> {
-    // CHECK-NOT: ttir.reshape
     // CHECK: %[[RESULT:.*]] = "ttir.sum"(%arg0, %{{.*}}) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<32x64x128xf32>, tensor<32x1x128xf32>) -> tensor<32x1x128xf32>
+    // CHECK-NOT: ttir.reshape
     // CHECK: return %[[RESULT]]
 
     %0 = ttir.empty() : tensor<32x128xf32>
@@ -22,8 +22,8 @@ module {
 module {
   // CHECK-LABEL: func.func @mean_reshape_fusion
   func.func @mean_reshape_fusion(%arg0: tensor<32x64x128xf32>) -> tensor<32x64x1xf32> {
-    // CHECK-NOT: ttir.reshape
     // CHECK: %[[RESULT:.*]] = "ttir.mean"(%arg0, %{{.*}}) <{dim_arg = [2 : i32], keep_dim = true}> : (tensor<32x64x128xf32>, tensor<32x64x1xf32>) -> tensor<32x64x1xf32>
+    // CHECK-NOT: ttir.reshape
     // CHECK: return %[[RESULT]]
 
     %0 = ttir.empty() : tensor<32x64xf32>
@@ -40,8 +40,8 @@ module {
 module {
   // CHECK-LABEL: func.func @max_reshape_fusion
   func.func @max_reshape_fusion(%arg0: tensor<32x64x128xf32>) -> tensor<1x64x128xf32> {
-    // CHECK-NOT: ttir.reshape
     // CHECK: %[[RESULT:.*]] = "ttir.max"(%arg0, %{{.*}}) <{dim_arg = [0 : i32], keep_dim = true}> : (tensor<32x64x128xf32>, tensor<1x64x128xf32>) -> tensor<1x64x128xf32>
+    // CHECK-NOT: ttir.reshape
     // CHECK: return %[[RESULT]]
 
     %0 = ttir.empty() : tensor<64x128xf32>
@@ -58,8 +58,8 @@ module {
 module {
   // CHECK-LABEL: func.func @multi_dim_reduction_reshape_fusion
   func.func @multi_dim_reduction_reshape_fusion(%arg0: tensor<32x64x128xf32>) -> tensor<32x1x1xf32> {
-    // CHECK-NOT: ttir.reshape
     // CHECK: %[[RESULT:.*]] = "ttir.sum"(%arg0, %{{.*}}) <{dim_arg = [1 : i32, 2 : i32], keep_dim = true}> : (tensor<32x64x128xf32>, tensor<32x1x1xf32>) -> tensor<32x1x1xf32>
+    // CHECK-NOT: ttir.reshape
     // CHECK: return %[[RESULT]]
 
     %0 = ttir.empty() : tensor<32xf32>

--- a/test/ttmlir/Dialect/TTIR/fusing/softmax_fusing.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/softmax_fusing.mlir
@@ -11,7 +11,7 @@ module {
     // CHECK: return %[[RESULT]]
 
     %0 = ttir.empty() : tensor<32x32xf32>
-    %1 = "ttir.exp"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}>  : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %1 = "ttir.exp"(%arg0, %0) : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
 
     %2 = ttir.empty() : tensor<32x1xf32>
     %3 = "ttir.sum"(%1, %2) {dim_arg = [1 : i32], keep_dim = true} : (tensor<32x32xf32>, tensor<32x1xf32>) -> tensor<32x1xf32>
@@ -20,7 +20,7 @@ module {
     %5 = "ttir.broadcast"(%3, %4) {broadcast_dimensions = array<i64: 1, 32>} : (tensor<32x1xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
 
     %6 = ttir.empty() : tensor<32x32xf32>
-    %7 = "ttir.div"(%1, %5, %6) <{operandSegmentSizes = array<i32: 2, 1>}>: (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %7 = "ttir.div"(%1, %5, %6) : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
 
     return %7 : tensor<32x32xf32>
   }
@@ -37,7 +37,7 @@ module {
     // CHECK: return %[[RESULT]]
 
     %0 = ttir.empty() : tensor<32x32xf32>
-    %1 = "ttir.exp"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %1 = "ttir.exp"(%arg0, %0) : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
 
     %2 = ttir.empty() : tensor<1x32xf32>
     %3 = "ttir.sum"(%1, %2) {dim_arg = [0 : i32], keep_dim = true} : (tensor<32x32xf32>, tensor<1x32xf32>) -> tensor<1x32xf32>
@@ -46,7 +46,7 @@ module {
     %5 = "ttir.broadcast"(%3, %4) {broadcast_dimensions = array<i64: 32, 1>} : (tensor<1x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
 
     %6 = ttir.empty() : tensor<32x32xf32>
-    %7 = "ttir.div"(%1, %5, %6) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %7 = "ttir.div"(%1, %5, %6) : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
 
     return %7 : tensor<32x32xf32>
   }
@@ -63,7 +63,7 @@ module {
     // CHECK-NOT: ttir.softmax
 
     %0 = ttir.empty() : tensor<32x32xf32>
-    %1 = "ttir.exp"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %1 = "ttir.exp"(%arg0, %0) : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
 
     // Here we are using %%arg1 for reduction instead of the exp output, so we cannot fuse.
     %2 = ttir.empty() : tensor<32x1xf32>
@@ -73,7 +73,7 @@ module {
     %5 = "ttir.broadcast"(%3, %4) {broadcast_dimensions = array<i64: 1, 32>} : (tensor<32x1xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
 
     %6 = ttir.empty() : tensor<32x32xf32>
-    %7 = "ttir.div"(%1, %5, %6) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %7 = "ttir.div"(%1, %5, %6) : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
 
     return %7 : tensor<32x32xf32>
   }
@@ -91,7 +91,7 @@ module {
     // CHECK: return %[[RESULT]]
 
     %0 = ttir.empty() : tensor<32x32xf32>
-    %1 = "ttir.exp"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %1 = "ttir.exp"(%arg0, %0) : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
 
     %2 = ttir.empty() : tensor<32xf32>
     %3 = "ttir.sum"(%1, %2) {dim_arg = [1 : i32], keep_dim = false} : (tensor<32x32xf32>, tensor<32xf32>) -> tensor<32xf32>
@@ -103,7 +103,7 @@ module {
     %7 = "ttir.broadcast"(%5, %6) {broadcast_dimensions = array<i64: 1, 32>} : (tensor<32x1xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
 
     %8 = ttir.empty() : tensor<32x32xf32>
-    %9 = "ttir.div"(%1, %7, %8) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %9 = "ttir.div"(%1, %7, %8) : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
 
     return %9 : tensor<32x32xf32>
   }
@@ -121,7 +121,7 @@ module {
     // CHECK-NOT: ttir.softmax
 
     %0 = ttir.empty() : tensor<32x32xf32>
-    %1 = "ttir.exp"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %1 = "ttir.exp"(%arg0, %0) : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
 
     %2 = ttir.empty() : tensor<32x1xf32>
     %3 = "ttir.sum"(%1, %2) {dim_arg = [1 : i32], keep_dim = true} : (tensor<32x32xf32>, tensor<32x1xf32>) -> tensor<32x1xf32>
@@ -130,11 +130,11 @@ module {
     %5 = "ttir.broadcast"(%3, %4) {broadcast_dimensions = array<i64: 1, 32>} : (tensor<32x1xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
 
     %6 = ttir.empty() : tensor<32x32xf32>
-    %7 = "ttir.div"(%1, %5, %6) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %7 = "ttir.div"(%1, %5, %6) : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
 
     // Extra use of the exp result prevents fusion.
     %8 = ttir.empty() : tensor<32x32xf32>
-    %9 = "ttir.add"(%1, %7, %8) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %9 = "ttir.add"(%1, %7, %8) : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
 
     return %9 : tensor<32x32xf32>
   }
@@ -152,7 +152,7 @@ module {
     // CHECK-NOT: ttir.softmax
 
     %0 = ttir.empty() : tensor<32x32xf32>
-    %1 = "ttir.exp"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %1 = "ttir.exp"(%arg0, %0) : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
 
     %2 = ttir.empty() : tensor<32x1xf32>
     %3 = "ttir.sum"(%1, %2) {dim_arg = [1 : i32], keep_dim = true} : (tensor<32x32xf32>, tensor<32x1xf32>) -> tensor<32x1xf32>
@@ -161,11 +161,11 @@ module {
     %5 = "ttir.broadcast"(%3, %4) {broadcast_dimensions = array<i64: 1, 32>} : (tensor<32x1xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
 
     %6 = ttir.empty() : tensor<32x32xf32>
-    %7 = "ttir.div"(%1, %5, %6) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %7 = "ttir.div"(%1, %5, %6) : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
 
     // Extra use of the sum result prevents fusion.
     %8 = ttir.empty() : tensor<32x32xf32>
-    %9 = "ttir.add"(%3, %7, %8) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x1xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %9 = "ttir.add"(%3, %7, %8) : (tensor<32x1xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
 
     return %9: tensor<32x32xf32>
   }
@@ -183,7 +183,7 @@ module {
     // CHECK-NOT: ttir.softmax
 
     %0 = ttir.empty() : tensor<32x32xf32>
-    %1 = "ttir.exp"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %1 = "ttir.exp"(%arg0, %0) : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
 
     %2 = ttir.empty() : tensor<32x1xf32>
     %3 = "ttir.sum"(%1, %2) {dim_arg = [1 : i32], keep_dim = true} : (tensor<32x32xf32>, tensor<32x1xf32>) -> tensor<32x1xf32>
@@ -192,11 +192,11 @@ module {
     %5 = "ttir.broadcast"(%3, %4) {broadcast_dimensions = array<i64: 1, 32>} : (tensor<32x1xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
 
     %6 = ttir.empty() : tensor<32x32xf32>
-    %7 = "ttir.div"(%1, %5, %6) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %7 = "ttir.div"(%1, %5, %6) : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
 
     // Extra use of the broadcast result prevents fusion.
     %8 = ttir.empty() : tensor<32x32xf32>
-    %9 = "ttir.add"(%5, %7, %8) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    %9 = "ttir.add"(%5, %7, %8) : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
 
     return %9 : tensor<32x32xf32>
   }

--- a/test/ttmlir/Dialect/TTIR/fusing/softmax_fusing.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/softmax_fusing.mlir
@@ -1,0 +1,203 @@
+// RUN: ttmlir-opt %s -ttir-fusing | FileCheck %s
+
+module {
+  // CHECK-LABEL: func.func @softmax_fusion_dim1
+  func.func @softmax_fusion_dim1(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    // CHECK-NOT: ttir.exp
+    // CHECK-NOT: ttir.sum
+    // CHECK-NOT: ttir.broadcast
+    // CHECK-NOT: ttir.div
+    // CHECK: %[[RESULT:.*]] = "ttir.softmax"(%arg0, %{{.*}}) <{dimension = 1 : si32}> : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    // CHECK: return %[[RESULT]]
+
+    %0 = ttir.empty() : tensor<32x32xf32>
+    %1 = "ttir.exp"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}>  : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    %2 = ttir.empty() : tensor<32x1xf32>
+    %3 = "ttir.sum"(%1, %2) {dim_arg = [1 : i32], keep_dim = true} : (tensor<32x32xf32>, tensor<32x1xf32>) -> tensor<32x1xf32>
+
+    %4 = ttir.empty() : tensor<32x32xf32>
+    %5 = "ttir.broadcast"(%3, %4) {broadcast_dimensions = array<i64: 1, 32>} : (tensor<32x1xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    %6 = ttir.empty() : tensor<32x32xf32>
+    %7 = "ttir.div"(%1, %5, %6) <{operandSegmentSizes = array<i32: 2, 1>}>: (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    return %7 : tensor<32x32xf32>
+  }
+}
+
+module {
+  // CHECK-LABEL: func.func @softmax_fusion_dim0
+  func.func @softmax_fusion_dim0(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    // CHECK-NOT: ttir.exp
+    // CHECK-NOT: ttir.sum
+    // CHECK-NOT: ttir.broadcast
+    // CHECK-NOT: ttir.div
+    // CHECK: %[[RESULT:.*]] = "ttir.softmax"(%arg0, %{{.*}}) <{dimension = 0 : si32}> : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    // CHECK: return %[[RESULT]]
+
+    %0 = ttir.empty() : tensor<32x32xf32>
+    %1 = "ttir.exp"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    %2 = ttir.empty() : tensor<1x32xf32>
+    %3 = "ttir.sum"(%1, %2) {dim_arg = [0 : i32], keep_dim = true} : (tensor<32x32xf32>, tensor<1x32xf32>) -> tensor<1x32xf32>
+
+    %4 = ttir.empty() : tensor<32x32xf32>
+    %5 = "ttir.broadcast"(%3, %4) {broadcast_dimensions = array<i64: 32, 1>} : (tensor<1x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    %6 = ttir.empty() : tensor<32x32xf32>
+    %7 = "ttir.div"(%1, %5, %6) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    return %7 : tensor<32x32xf32>
+  }
+}
+
+// Test case with a negative pattern - different input to exp and sum.
+module {
+  // CHECK-LABEL: func.func @no_fusion_different_inputs
+  func.func @no_fusion_different_inputs(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    // CHECK: ttir.exp
+    // CHECK: ttir.sum
+    // CHECK: ttir.broadcast
+    // CHECK: ttir.div
+    // CHECK-NOT: ttir.softmax
+
+    %0 = ttir.empty() : tensor<32x32xf32>
+    %1 = "ttir.exp"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    // Here we are using %%arg1 for reduction instead of the exp output, so we cannot fuse.
+    %2 = ttir.empty() : tensor<32x1xf32>
+    %3 = "ttir.sum"(%arg1, %2) {dim_arg = [1 : i32], keep_dim = true} : (tensor<32x32xf32>, tensor<32x1xf32>) -> tensor<32x1xf32>
+
+    %4 = ttir.empty() : tensor<32x32xf32>
+    %5 = "ttir.broadcast"(%3, %4) {broadcast_dimensions = array<i64: 1, 32>} : (tensor<32x1xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    %6 = ttir.empty() : tensor<32x32xf32>
+    %7 = "ttir.div"(%1, %5, %6) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    return %7 : tensor<32x32xf32>
+  }
+}
+
+// Test case where rehape is fused into reduction and we can fuse into softmax.
+module {
+  // CHECK-LABEL: func.func @no_fusion_keep_dim_false
+  func.func @no_fusion_keep_dim_false(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    // CHECK-NOT: ttir.exp
+    // CHECK-NOT: ttir.sum
+    // CHECK-NOT: ttir.broadcast
+    // CHECK-NOT: ttir.div
+    // CHECK: %[[RESULT:.*]] = "ttir.softmax"(%arg0, %{{.*}}) <{dimension = 1 : si32}> : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    // CHECK: return %[[RESULT]]
+
+    %0 = ttir.empty() : tensor<32x32xf32>
+    %1 = "ttir.exp"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    %2 = ttir.empty() : tensor<32xf32>
+    %3 = "ttir.sum"(%1, %2) {dim_arg = [1 : i32], keep_dim = false} : (tensor<32x32xf32>, tensor<32xf32>) -> tensor<32xf32>
+
+    %4 = ttir.empty() : tensor<32x1xf32>
+    %5 = "ttir.reshape"(%3, %4) {shape = [32 : i32, 1 : i32]} : (tensor<32xf32>, tensor<32x1xf32>) -> tensor<32x1xf32>
+
+    %6 = ttir.empty() : tensor<32x32xf32>
+    %7 = "ttir.broadcast"(%5, %6) {broadcast_dimensions = array<i64: 1, 32>} : (tensor<32x1xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    %8 = ttir.empty() : tensor<32x32xf32>
+    %9 = "ttir.div"(%1, %7, %8) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    return %9 : tensor<32x32xf32>
+  }
+}
+
+// Test case with a negative pattern - exp has more than two users.
+module {
+  // CHECK-LABEL: func.func @no_fusion_exp_multiple_users
+  func.func @no_fusion_exp_multiple_users(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    // CHECK: ttir.exp
+    // CHECK: ttir.sum
+    // CHECK: ttir.broadcast
+    // CHECK: ttir.div
+    // CHECK: ttir.add
+    // CHECK-NOT: ttir.softmax
+
+    %0 = ttir.empty() : tensor<32x32xf32>
+    %1 = "ttir.exp"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    %2 = ttir.empty() : tensor<32x1xf32>
+    %3 = "ttir.sum"(%1, %2) {dim_arg = [1 : i32], keep_dim = true} : (tensor<32x32xf32>, tensor<32x1xf32>) -> tensor<32x1xf32>
+
+    %4 = ttir.empty() : tensor<32x32xf32>
+    %5 = "ttir.broadcast"(%3, %4) {broadcast_dimensions = array<i64: 1, 32>} : (tensor<32x1xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    %6 = ttir.empty() : tensor<32x32xf32>
+    %7 = "ttir.div"(%1, %5, %6) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    // Extra use of the exp result prevents fusion.
+    %8 = ttir.empty() : tensor<32x32xf32>
+    %9 = "ttir.add"(%1, %7, %8) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    return %9 : tensor<32x32xf32>
+  }
+}
+
+// Test case with a negative pattern - sum has more than one user.
+module {
+  // CHECK-LABEL: func.func @no_fusion_sum_multiple_users
+  func.func @no_fusion_sum_multiple_users(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    // CHECK: ttir.exp
+    // CHECK: ttir.sum
+    // CHECK: ttir.broadcast
+    // CHECK: ttir.div
+    // CHECK: ttir.add
+    // CHECK-NOT: ttir.softmax
+
+    %0 = ttir.empty() : tensor<32x32xf32>
+    %1 = "ttir.exp"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    %2 = ttir.empty() : tensor<32x1xf32>
+    %3 = "ttir.sum"(%1, %2) {dim_arg = [1 : i32], keep_dim = true} : (tensor<32x32xf32>, tensor<32x1xf32>) -> tensor<32x1xf32>
+
+    %4 = ttir.empty() : tensor<32x32xf32>
+    %5 = "ttir.broadcast"(%3, %4) {broadcast_dimensions = array<i64: 1, 32>} : (tensor<32x1xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    %6 = ttir.empty() : tensor<32x32xf32>
+    %7 = "ttir.div"(%1, %5, %6) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    // Extra use of the sum result prevents fusion.
+    %8 = ttir.empty() : tensor<32x32xf32>
+    %9 = "ttir.add"(%3, %7, %8) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x1xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    return %9: tensor<32x32xf32>
+  }
+}
+
+// Test case with a negative pattern - broadcast has more than one user.
+module {
+  // CHECK-LABEL: func.func @no_fusion_broadcast_multiple_users
+  func.func @no_fusion_broadcast_multiple_users(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    // CHECK: ttir.exp
+    // CHECK: ttir.sum
+    // CHECK: ttir.broadcast
+    // CHECK: ttir.div
+    // CHECK: ttir.add
+    // CHECK-NOT: ttir.softmax
+
+    %0 = ttir.empty() : tensor<32x32xf32>
+    %1 = "ttir.exp"(%arg0, %0) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    %2 = ttir.empty() : tensor<32x1xf32>
+    %3 = "ttir.sum"(%1, %2) {dim_arg = [1 : i32], keep_dim = true} : (tensor<32x32xf32>, tensor<32x1xf32>) -> tensor<32x1xf32>
+
+    %4 = ttir.empty() : tensor<32x32xf32>
+    %5 = "ttir.broadcast"(%3, %4) {broadcast_dimensions = array<i64: 1, 32>} : (tensor<32x1xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    %6 = ttir.empty() : tensor<32x32xf32>
+    %7 = "ttir.div"(%1, %5, %6) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    // Extra use of the broadcast result prevents fusion.
+    %8 = ttir.empty() : tensor<32x32xf32>
+    %9 = "ttir.add"(%5, %7, %8) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    return %9 : tensor<32x32xf32>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/fusing/conv2d_activation_fusing.mlir
+++ b/test/ttmlir/Dialect/TTNN/fusing/conv2d_activation_fusing.mlir
@@ -1,0 +1,77 @@
+// RUN: ttmlir-opt --tt-register-device --ttir-flatten-sliding-window --ttnn-layout --convert-ttir-to-ttnn --ttnn-fusing %s | FileCheck %s
+
+module {
+  // Test fusion of Conv2d with ReLU activation.
+  // CHECK-LABEL: func.func @conv2d_with_relu
+  func.func @conv2d_with_relu(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x64xbf16> {
+    %0 = ttir.empty() : tensor<1x30x30x64xbf16>
+    // CHECK: %[[CONV:.*]] = "ttnn.conv2d"
+    %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
+            <{
+              stride = 1: i32,
+              padding = 0: i32,
+              dilation = 1: i32,
+              groups = 1: i32
+            }> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+
+    // CHECK-NOT: ttnn.relu
+    %2 = ttir.empty() : tensor<1x30x30x64xbf16>
+    %3 = "ttir.relu"(%1, %2) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+
+    // This reshape is comming from flattening sliding window.
+    // CHECK: %[[RESHAPE:.*]] = "ttnn.reshape"(%[[CONV]])
+
+    // CHECK: return %[[RESHAPE]]
+    return %3 : tensor<1x30x30x64xbf16>
+  }
+
+  // Test that we cannot fuse Conv2d and ReLU because Conv2d has multiple uses.
+  // CHECK-LABEL: func.func @conv2d_with_multiple_uses
+  func.func @conv2d_with_multiple_uses(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x64xbf16> {
+    %0 = ttir.empty() : tensor<1x30x30x64xbf16>
+    // CHECK: %{{.*}} = "ttnn.conv2d"
+    // CHECK-NOT: activation = "relu"
+    %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
+            <{
+              stride = 1: i32,
+              padding = 0: i32,
+              dilation = 1: i32,
+              groups = 1: i32
+            }> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+
+    // CHECK: %[[RELU:.*]] = "ttnn.relu"
+    %2 = ttir.empty() : tensor<1x30x30x64xbf16>
+    %3 = "ttir.relu"(%1, %2) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+
+    // CHECK: %[[ADD:.*]] = "ttnn.add"
+    %4 = ttir.empty() : tensor<1x30x30x64xbf16>
+    // Second use of conv2d, we cannot fuse.
+    %5 = "ttir.add"(%1, %3, %4) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+
+    return %5 :tensor<1x30x30x64xbf16>
+  }
+
+  // Test that we cannot fuse Conv2d and Sigmoid because Conv2d only allows ReLU activation.
+  // CHECK-LABEL: func.func @conv2d_with_sigmoid
+  func.func @conv2d_with_sigmoid(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x64xbf16> {
+    %0 = ttir.empty() : tensor<1x30x30x64xbf16>
+    // CHECK: %{{.*}} = "ttnn.conv2d"
+    // CHECK-NOT: activation = "sigmoid"
+    %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
+            <{
+              stride = 1: i32,
+              padding = 0: i32,
+              dilation = 1: i32,
+              groups = 1: i32
+            }> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+
+    // CHECK: %[[SIGMOID:.*]] = "ttnn.sigmoid"
+    %2 = ttir.empty() : tensor<1x30x30x64xbf16>
+
+    // Sigmoid cannot be fused with conv2d.
+    %3 = "ttir.sigmoid"(%1, %2) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+
+    // CHECK: return %[[SIGMOID]]
+    return %3 : tensor<1x30x30x64xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/fusing/conv2d_activation_fusing.mlir
+++ b/test/ttmlir/Dialect/TTNN/fusing/conv2d_activation_fusing.mlir
@@ -16,7 +16,7 @@ module {
 
     // CHECK-NOT: ttnn.relu
     %2 = ttir.empty() : tensor<1x30x30x64xbf16>
-    %3 = "ttir.relu"(%1, %2) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %3 = "ttir.relu"(%1, %2) : (tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
 
     // This reshape is comming from flattening sliding window.
     // CHECK: %[[RESHAPE:.*]] = "ttnn.reshape"(%[[CONV]])
@@ -41,12 +41,12 @@ module {
 
     // CHECK: %[[RELU:.*]] = "ttnn.relu"
     %2 = ttir.empty() : tensor<1x30x30x64xbf16>
-    %3 = "ttir.relu"(%1, %2) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %3 = "ttir.relu"(%1, %2) : (tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
 
     // CHECK: %[[ADD:.*]] = "ttnn.add"
     %4 = ttir.empty() : tensor<1x30x30x64xbf16>
     // Second use of conv2d, we cannot fuse.
-    %5 = "ttir.add"(%1, %3, %4) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %5 = "ttir.add"(%1, %3, %4) : (tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
 
     return %5 :tensor<1x30x30x64xbf16>
   }
@@ -69,7 +69,7 @@ module {
     %2 = ttir.empty() : tensor<1x30x30x64xbf16>
 
     // Sigmoid cannot be fused with conv2d.
-    %3 = "ttir.sigmoid"(%1, %2) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    %3 = "ttir.sigmoid"(%1, %2) : (tensor<1x30x30x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
 
     // CHECK: return %[[SIGMOID]]
     return %3 : tensor<1x30x30x64xbf16>

--- a/test/ttmlir/Dialect/TTNN/fusing/conv2d_activation_fusing_ttnn.mlir
+++ b/test/ttmlir/Dialect/TTNN/fusing/conv2d_activation_fusing_ttnn.mlir
@@ -1,0 +1,47 @@
+// RUN: ttmlir-opt --tt-register-device --ttnn-fusing %s | FileCheck %s
+
+// These test are written in TTNN dialect because TTIR is not flexible enough to represent all the patterns we want to test.
+
+#dram = #ttnn.buffer_type<dram>
+#system_memory = #ttnn.buffer_type<system_memory>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 32 + d2, d3), <1x1>, memref<32x2x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
+#ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 192 + d1 * 3 + d2, d3), <1x1>, memref<12288x3xbf16, #system_memory>>
+#ttnn_layout2 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1 * 32 + d2, d3), <1x1>, memref<1x2x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
+#ttnn_layout3 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 960 + d1 * 32 + d2, d3), <1x1>, memref<30x2x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
+#ttnn_layout4 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 1024 + d2, d3), <1x1>, memref<32x2x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
+#ttnn_layout5 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 928 + d1 * 928 + d2, d3), <1x1>, memref<29x2x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
+module {
+  // Here we want to test that we cant fuse relu into conv2d because conv2d already has activation.
+
+  // CHECK-LABEL: func.func @conv2d_relu_chain
+  func.func @conv2d_relu_chain(%arg0: tensor<1x32x32x64xbf16, #ttnn_layout>, %arg1: tensor<64x64x3x3xbf16, #ttnn_layout1>, %arg2: tensor<1x1x1x64xbf16, #ttnn_layout2>) -> tensor<1x30x30x64xbf16, #ttnn_layout3> {
+    // CHECK: "ttnn.conv2d"
+    // CHECK-SAME: activation = "relu"
+
+    %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+    %1 = "ttnn.reshape"(%arg0) <{shape = [1 : i32, 1 : i32, 1024 : i32, 64 : i32]}> : (tensor<1x32x32x64xbf16, #ttnn_layout>) -> tensor<1x1x1024x64xbf16, #ttnn_layout4>
+    %2 = "ttnn.conv2d"(%1, %arg1, %arg2, %0) <{batch_size = 1 : i32, conv2d_config = #ttnn.conv2d_config<dtype = bf16, weights_dtype = bf16, activation = "relu", input_channels_alignment = 32, deallocate_activation = false, reallocate_halo_output = false, act_block_h_override = 0, act_block_w_div = 1, reshard_if_not_optimal = false, override_sharding_config = false, shard_layout = height_sharded, transpose_shards = false, output_layout = tile, preprocess_weights_on_device = false, always_preprocess_weights = false, enable_act_double_buffer = false, enable_weights_double_buffer = false, enable_split_reader = false, enable_subblock_padding = false>, dilation = array<i32: 1, 1>, groups = 1 : i32, in_channels = 64 : i32, input_height = 32 : i32, input_width = 32 : i32, kernel_size = array<i32: 3, 3>, out_channels = 64 : i32, padding = array<i32: 0, 0>, stride = array<i32: 1, 1>}> : (tensor<1x1x1024x64xbf16, #ttnn_layout4>, tensor<64x64x3x3xbf16, #ttnn_layout1>, tensor<1x1x1x64xbf16, #ttnn_layout2>, !ttnn.device) -> tensor<1x1x900x64xbf16, #ttnn_layout5>
+    %3 = "ttnn.reshape"(%2) <{shape = [1 : i32, 30 : i32, 30 : i32, 64 : i32]}> : (tensor<1x1x900x64xbf16, #ttnn_layout5>) -> tensor<1x30x30x64xbf16, #ttnn_layout3>
+
+    // CHECK: "ttnn.relu"
+    %4 = "ttnn.relu"(%3) : (tensor<1x30x30x64xbf16, #ttnn_layout3>) -> tensor<1x30x30x64xbf16, #ttnn_layout3>
+    return %4 : tensor<1x30x30x64xbf16, #ttnn_layout3>
+  }
+
+  // Test that we can fuse conv2d -> relu into conv2d. This test differs from rest of the tests because in other tests we add flattening to conv2d which adds reshapes before and after conv2d.
+
+  // CHECK-LABEL: func.func @conv2d_with_relu_after
+  func.func @conv2d_with_relu_after(%arg0: tensor<1x32x32x64xbf16, #ttnn_layout>, %arg1: tensor<64x64x3x3xbf16, #ttnn_layout1>, %arg2: tensor<1x1x1x64xbf16, #ttnn_layout2>) -> tensor<1x30x30x64xbf16, #ttnn_layout3> {
+    // CHECK: "ttnn.conv2d"
+    // CHECK-SAME: activation = "relu"
+
+    %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+    %1 = "ttnn.reshape"(%arg0) <{shape = [1 : i32, 1 : i32, 1024 : i32, 64 : i32]}> : (tensor<1x32x32x64xbf16, #ttnn_layout>) -> tensor<1x1x1024x64xbf16, #ttnn_layout4>
+    %2 = "ttnn.conv2d"(%1, %arg1, %arg2, %0) <{batch_size = 1 : i32, dilation = array<i32: 1, 1>, groups = 1 : i32, in_channels = 64 : i32, input_height = 32 : i32, input_width = 32 : i32, kernel_size = array<i32: 3, 3>, out_channels = 64 : i32, padding = array<i32: 0, 0>, stride = array<i32: 1, 1>}> : (tensor<1x1x1024x64xbf16, #ttnn_layout4>, tensor<64x64x3x3xbf16, #ttnn_layout1>, tensor<1x1x1x64xbf16, #ttnn_layout2>, !ttnn.device) -> tensor<1x1x900x64xbf16, #ttnn_layout5>
+
+    // CHECK-NOT: "ttnn.relu"
+    %3 = "ttnn.relu"(%2) : (tensor<1x1x900x64xbf16, #ttnn_layout5>) -> tensor<1x1x900x64xbf16, #ttnn_layout5>
+    %4 = "ttnn.reshape"(%3) <{shape = [1 : i32, 30 : i32, 30 : i32, 64 : i32]}> : (tensor<1x1x900x64xbf16, #ttnn_layout5>) -> tensor<1x30x30x64xbf16, #ttnn_layout3>
+    return %4 : tensor<1x30x30x64xbf16, #ttnn_layout3>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/fusing/resnet_pattern_fusing.mlir
+++ b/test/ttmlir/Dialect/TTNN/fusing/resnet_pattern_fusing.mlir
@@ -13,11 +13,11 @@ module {
     // CHECK-NOT: "ttnn.multiply"
     // CHECK-NOT: "ttnn.add"
     // CHECK-NOT: "ttnn.relu"
-    %3 = "ttir.multiply"(%1, %arg5, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x56x56x64xf32>, tensor<1x1x1x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %3 = "ttir.multiply"(%1, %arg5, %2) : (tensor<1x56x56x64xf32>, tensor<1x1x1x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
     %4 = ttir.empty() : tensor<1x56x56x64xf32>
-    %5 = "ttir.add"(%3, %arg6, %4) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x56x56x64xf32>, tensor<1x1x1x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %5 = "ttir.add"(%3, %arg6, %4) : (tensor<1x56x56x64xf32>, tensor<1x1x1x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
     %6 = ttir.empty() : tensor<1x56x56x64xf32>
-    %7 = "ttir.relu"(%5, %6) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x56x56x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %7 = "ttir.relu"(%5, %6) : (tensor<1x56x56x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
     return %7 : tensor<1x56x56x64xf32>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/fusing/resnet_pattern_fusing.mlir
+++ b/test/ttmlir/Dialect/TTNN/fusing/resnet_pattern_fusing.mlir
@@ -1,0 +1,23 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
+
+// This is common pattern throught Resnet. We have conv2d with constant weight, followed by multiply with constant input. This will be commuted through conv2d.
+// Then we fuse add into conv2d with bias and lastly we fuse conv2d and relu into conv2d with activation.
+module {
+  func.func @main(%weight: tensor<64x64x3x3xf32> {tt.argument_type = #tt.argument_type<constant>}, %arg5: tensor<1x1x1x64xf32> {tt.argument_type = #tt.argument_type<constant>}, %arg6: tensor<1x1x1x64xf32>, %input: tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32> {
+    // CHECK: "ttnn.multiply"
+    // CHECK: "ttnn.conv2d"
+    // CHECK-SAME: activation = "relu"
+    %0 = ttir.empty() : tensor<1x56x56x64xf32>
+    %1 = "ttir.conv2d"(%input, %weight, %0) <{dilation = array<i32: 1, 1>, groups = 1 : i32, padding = array<i32: 1, 1, 1, 1>, stride = array<i32: 1, 1>}> {channel_last = 1 : si32} : (tensor<1x56x56x64xf32>, tensor<64x64x3x3xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %2 = ttir.empty() : tensor<1x56x56x64xf32>
+    // CHECK-NOT: "ttnn.multiply"
+    // CHECK-NOT: "ttnn.add"
+    // CHECK-NOT: "ttnn.relu"
+    %3 = "ttir.multiply"(%1, %arg5, %2) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x56x56x64xf32>, tensor<1x1x1x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %4 = ttir.empty() : tensor<1x56x56x64xf32>
+    %5 = "ttir.add"(%3, %arg6, %4) <{operandSegmentSizes = array<i32: 2, 1>}> : (tensor<1x56x56x64xf32>, tensor<1x1x1x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %6 = ttir.empty() : tensor<1x56x56x64xf32>
+    %7 = "ttir.relu"(%5, %6) <{operandSegmentSizes = array<i32: 1, 1>}> : (tensor<1x56x56x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    return %7 : tensor<1x56x56x64xf32>
+  }
+}


### PR DESCRIPTION
Adding basic fusing support:
	•	`conv2d + add` → fused into `conv2d` with bias (in **TTIR**)
	•	`conv2d + relu` → fused into `conv2d` with activation (in **TTNN**)
	•	`reduction + reshape` → fused into reduction (in **TTIR**)
	•	`exp(x) / sum(exp(x))` → fused into `softmax` (in **TTIR**)
	•	`conv2d + multiply` → commuted into `reshape + multiply + conv2d` (in **TTIR**)
_(only applied when multiply can be constant-evaluated)_

Other possible fusions (future work):
	•	`linear / conv2d_transpose + add` → fused into `linear / conv2d_transpose` with bias (in TTIR)
	•	`matmul + activation` → fused into `matmul` with activation (in TTNN)

Additional fusion opportunities involving commuting operations through the graph are possible but will initially be handled case-by-case.

Note:
This fusion will be integrated into the pipeline later. For now, it will likely be inserted at the beginning of the passes for the **TTIR** and **TTNN** dialects.