### PR TITLE
Rename OpConfig Field for Readability

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/OpConfig.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpConfig.h
@@ -11,28 +11,27 @@ namespace mlir::tt::ttnn {
 
 struct OpConfig {
   // Desired output layout for the op.
-  //
   TTNNLayoutAttr outputLayout;
 
-  // Op specific configuration. E.g. Conv2dConfigAttr for Conv2dOp.
-  //
-  Attribute config;
+  // E.g. Conv2dConfigAttr for Conv2dOp.
+  Attribute opSpecificAttr;
 
   OpConfig() = default;
   OpConfig(TTNNLayoutAttr outputLayout) : outputLayout(outputLayout) {}
-  OpConfig(TTNNLayoutAttr outputLayout, Attribute config)
-      : outputLayout(outputLayout), config(config) {}
+  OpConfig(TTNNLayoutAttr outputLayout, Attribute opSpecificAttr)
+      : outputLayout(outputLayout), opSpecificAttr(opSpecificAttr) {}
 
   bool operator==(const OpConfig &other) const {
-    return outputLayout == other.outputLayout && config == other.config;
+    return outputLayout == other.outputLayout &&
+           opSpecificAttr == other.opSpecificAttr;
   }
 
   void dump() const {
     if (outputLayout) {
       outputLayout.dump();
     }
-    if (config) {
-      config.dump();
+    if (opSpecificAttr) {
+      opSpecificAttr.dump();
     }
   }
 };

--- a/lib/Dialect/TTNN/Analysis/LegalLayoutAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/LegalLayoutAnalysis.cpp
@@ -99,9 +99,9 @@ void applyConv2dConfigOverrides(Operation *op,
       getBoolAttr(overrides.enableSubblockPadding.value_or(false));
 
   for (auto &opConfig : analysisResult) {
-    assert(!opConfig.config &&
+    assert(!opConfig.opSpecificAttr &&
            "OpConfig should not have a config set before applying overrides");
-    opConfig.config = Conv2dConfigAttr::get(
+    opConfig.opSpecificAttr = Conv2dConfigAttr::get(
         context, dtype, weightsDtype, activation, inputChannelsAlignment,
         deallocateActivation, reallocateHaloOutput, actBlockHOverride,
         actBlockWDiv, reshardIfNotOptimal, overrideShardingConfig, shardLayout,

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -500,10 +500,11 @@ Conv2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   // If a conv config has been specified, use that. If not, read the op property
   std::optional<Conv2dConfigAttr> conv2dConfig = std::nullopt;
-  if (opConfig.config) {
-    assert(mlir::isa<Conv2dConfigAttr>(opConfig.config) &&
-           "Unexpected OpConfig.config. Expected Conv2ConfigAttr");
-    conv2dConfig = mlir::cast<Conv2dConfigAttr>(opConfig.config);
+  if (opConfig.opSpecificAttr) {
+    assert(mlir::isa<Conv2dConfigAttr>(opConfig.opSpecificAttr) &&
+           "Unexpected type for OpConfig.opSpecificAttr. Expected "
+           "Conv2ConfigAttr");
+    conv2dConfig = mlir::cast<Conv2dConfigAttr>(opConfig.opSpecificAttr);
   } else {
     conv2dConfig = getConv2dConfig();
   }
@@ -535,10 +536,11 @@ Conv2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 
   // If a conv config has been specified, use that. If not, read the op property
   std::optional<Conv2dConfigAttr> conv2dConfig = std::nullopt;
-  if (opConfig.config) {
-    assert(mlir::isa<Conv2dConfigAttr>(opConfig.config) &&
-           "Unexpected OpConfig.config. Expected Conv2ConfigAttr");
-    conv2dConfig = mlir::cast<Conv2dConfigAttr>(opConfig.config);
+  if (opConfig.opSpecificAttr) {
+    assert(mlir::isa<Conv2dConfigAttr>(opConfig.opSpecificAttr) &&
+           "Unexpected type for OpConfig.confopSpecificAttrig. Expected "
+           "Conv2ConfigAttr");
+    conv2dConfig = mlir::cast<Conv2dConfigAttr>(opConfig.opSpecificAttr);
   } else {
     conv2dConfig = getConv2dConfig();
   }

--- a/lib/Dialect/TTNN/Transforms/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/Optimizer.cpp
@@ -363,7 +363,7 @@ public:
           if (auto conv2dOp = mlir::dyn_cast<ttnn::Conv2dOp>(op)) {
             if (auto conv2dConfig =
                     mlir::dyn_cast_if_present<ttnn::Conv2dConfigAttr>(
-                        opConfigAnalysis.getResult().at(op).config)) {
+                        opConfigAnalysis.getResult().at(op).opSpecificAttr)) {
               conv2dOp.setConv2dConfigAttr(conv2dConfig);
             }
           }


### PR DESCRIPTION
### Ticket
#2441 

### Problem description
#2979 addressed the functionality required for #2441, but introduced awkward and difficult to understand statements like `opConfig.config`.

The `OpConfig` struct represents a particular configuration of a TTNN Op for the purpose of the optimizer. It has two fields:
- `TTNNLayoutAttr outputLayout` representing a specific output tensor layout for the op
- `Attribute config` representing op-specific configuration structs (e.g. matmul or conv2d)

We should better distinguish between `OpConfig` and its field `config`.

### What's changed
- Rename `config` to `opSpecificAttr` so `opConfig.config` becomes `opConfig.opSpecificAttr`

#### Details
The initial discussion in #2979 was centred around renaming `OpConfig` to `OpParams` or `TTNNOperationParams`. However, this would necessitate changing a large number of variables and APIs within the optimizer to match, without significantly improving readability. 

`opParams.config` is only slightly better than `opConfig.config`; however, the optimizer has many APIs in the form of `getXConfig` and many variables and containers in the form `xConfigs` all dealing with `OpConfig` objects. These APIs and variables would all need to be renamed to `params` to match `OpParams`.

The new field name is now more clear that this attribute is op-specific

### Checklist
- [X] New/Existing tests provide coverage for changes
