### PR TITLE
Add small developer QoL changes

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -40,7 +40,8 @@ RUN wget https://apt.llvm.org/llvm.sh && \
     ./llvm.sh 17 && \
     apt install -y libc++-17-dev libc++abi-17-dev && \
     ln -s /usr/bin/clang-17 /usr/bin/clang && \
-    ln -s /usr/bin/clang++-17 /usr/bin/clang++
+    ln -s /usr/bin/clang++-17 /usr/bin/clang++ && \
+    ln -s /usr/bin/clangd-17 /usr/bin/clangd
 
 # Install python packages
 RUN pip install cmake

--- a/.github/Dockerfile.ird
+++ b/.github/Dockerfile.ird
@@ -16,7 +16,8 @@ RUN apt-get update && apt-get install -y \
     vim \
     nano \
     tmux \
-    clangd
+    psmisc \
+    bash-completion
 
 # Create a directory for the toolchain and set permissions
 RUN mkdir -p $TTMLIR_TOOLCHAIN_DIR && \

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ cluster_descriptor.yaml
 tools/ttnn-standalone/ttnn-dylib.cpp
 
 CMakeUserPresets.json
+compile_commands.json
 
 # ttrt generated files
 ttrt-artifacts/*

--- a/env/activate.fish
+++ b/env/activate.fish
@@ -1,0 +1,21 @@
+# Step 1: Check if TTMLIR_TOOLCHAIN_DIR is already set, if not, set it to /opt/ttmlir-toolchain
+if test -z "$TTMLIR_TOOLCHAIN_DIR"
+  set -gx TTMLIR_TOOLCHAIN_DIR "/opt/ttmlir-toolchain"
+end
+
+# Step 2: Check if TTMLIR_VENV_DIR is already set, if not, set it to the venv directory inside TTMLIR_TOOLCHAIN_DIR
+if test -z "$TTMLIR_VENV_DIR"
+  set -gx TTMLIR_VENV_DIR "$TTMLIR_TOOLCHAIN_DIR/venv"
+end
+
+if test -f $TTMLIR_VENV_DIR/bin/activate.fish
+  source $TTMLIR_VENV_DIR/bin/activate.fish
+end
+
+set -gx TTMLIR_ENV_ACTIVATED 1
+set -gx PATH (pwd)/build/bin $TTMLIR_TOOLCHAIN_DIR/bin $TTMLIR_TOOLCHAIN_DIR/venv/bin $PATH
+set -gx TT_METAL_HOME (pwd)/third_party/tt-metal/src/tt-metal
+set -gx TT_METAL_BUILD_HOME (pwd)/third_party/tt-metal/src/tt-metal-build
+set -gx TT_MLIR_HOME (pwd)
+set -gx PYTHONPATH (pwd)/build/python_packages:(pwd)/.local/toolchain/python_packages/mlir_core:$TT_METAL_HOME:$TT_METAL_HOME/tt_eager:$TT_METAL_BUILD_HOME/tools/profiler/bin:$TT_METAL_HOME/ttnn
+set -gx ARCH_NAME (set -q ARCH_NAME; and echo $ARCH_NAME; or echo "wormhole_b0")

--- a/runtime/tools/python/ttrt/__init__.py
+++ b/runtime/tools/python/ttrt/__init__.py
@@ -14,6 +14,7 @@ ttrt.library_tweaks.set_tt_metal_home()
 
 import ttrt.binary
 from ttrt.common.api import API
+from importlib.metadata import version
 
 
 def main():
@@ -21,6 +22,9 @@ def main():
 
     parser = argparse.ArgumentParser(
         description="ttrt: a runtime tool for parsing and executing flatbuffer binaries"
+    )
+    parser.add_argument(
+        "-V", "--version", action="version", version=f"ttrt {version('ttrt')}"
     )
     subparsers = parser.add_subparsers(required=True)
 
@@ -30,8 +34,7 @@ def main():
 
     try:
         args = parser.parse_args()
-    except:
-        parser.print_help()
+    except SystemExit:
         return 1
 
     request_api = args.api(args)


### PR DESCRIPTION
### Ticket
N/A

### Problem description
There're a few very minor issues that can be addressed to improve developer QoL

### What's changed
Replace `clangd` with the already installed `clangd-17`
Add `psmisc` for the `killall` command
Add `bash-completion` to help with cmdline completions
Tell git to ignore the `compile_commands.json` file
Add environment activation script for the fish shell
Fix double-print of the help message when running `ttrt --help`
Add a `--version` option to `ttrt` to print tt-mlir version

### Checklist
- [x] New/Existing tests provide coverage for changes
