### PR TITLE
Enable `UNSUPPORTED` EmitC test

### DIFF
--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/atan2.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/atan2.mlir
@@ -2,9 +2,6 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
 // RUN: ttmlir-opt --ttnn-modify-signatures-for-dylib --convert-ttnn-to-emitc %t.mlir > %t2.mlir
 // RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
-// UNSUPPORTED: true
-// Marked as unsupported because of the following issue:
-// https://github.com/tenstorrent/tt-mlir/issues/2771
 
 func.func @atan2(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
   %0 = ttir.empty() : tensor<64x128xf32>

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/maximum.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/maximum.mlir
@@ -2,9 +2,6 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
 // RUN: ttmlir-opt --ttnn-modify-signatures-for-dylib --convert-ttnn-to-emitc %t.mlir > %t2.mlir
 // RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
-// UNSUPPORTED: true
-// Marked as unsupported because of the following issue:
-// https://github.com/tenstorrent/tt-mlir/issues/2508
 
 func.func @maximum(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
   %0 = ttir.empty() : tensor<64x128xf32>

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/minimum.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/minimum.mlir
@@ -2,9 +2,6 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
 // RUN: ttmlir-opt --ttnn-modify-signatures-for-dylib --convert-ttnn-to-emitc %t.mlir > %t2.mlir
 // RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
-// UNSUPPORTED: true
-// Marked as unsupported because of the following issue:
-// https://github.com/tenstorrent/tt-mlir/issues/2508
 
 func.func @minimum(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
   %0 = ttir.empty() : tensor<64x128xf32>

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/remainder.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/remainder.mlir
@@ -2,9 +2,6 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
 // RUN: ttmlir-opt --ttnn-modify-signatures-for-dylib --convert-ttnn-to-emitc %t.mlir > %t2.mlir
 // RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
-// UNSUPPORTED: true
-// Marked as unsupported because of the following issue:
-// https://github.com/tenstorrent/tt-mlir/issues/2508
 
 func.func @remainder(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
   %0 = ttir.empty() : tensor<64x128xf32>

--- a/test/ttmlir/EmitC/TTNN/eltwise_binary/scatter.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_binary/scatter.mlir
@@ -2,16 +2,10 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
 // RUN: ttmlir-opt --ttnn-modify-signatures-for-dylib --convert-ttnn-to-emitc %t.mlir > %t2.mlir
 // RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
-// UNSUPPORTED: true
-// Marked as unsupported because of the following issue:
-// https://github.com/tenstorrent/tt-mlir/issues/2508
 
 func.func @scatter(%arg0: tensor<1x3x320x320xf32>, %arg1: tensor<1x3x32x32xf32>) -> tensor<1x3x320x320xf32> {
   %0 = ttir.empty() : tensor<1x3x320x320xf32>
   %1 = ttir.empty() : tensor<1x1xi32>
-  %2 = "ttir.scatter"(%arg0, %1, %arg1, %0) <{index_vector_dim = 1 : i32, indices_are_sorted = false, input_batching_dims = array<i32>, inserted_window_dims = array<i32: 0>, scatter_dims_to_operand_dims = array<i32: 0>, scatter_indices_batching_dims = array<i32>, unique_indices = false, update_window_dims = array<i32: 1, 2, 3>}> ({
-  ^bb0(%arg3: tensor<1xf32>, %arg4: tensor<1xf32>):
-    "ttir.yield"(%arg4) : (tensor<1xf32>) -> ()
-  }) : (tensor<1x3x320x320xf32>, tensor<1x1xi32>, tensor<1x3x32x32xf32>, tensor<1x3x320x320xf32>) -> tensor<1x3x320x320xf32>
+  %2 = "ttir.scatter"(%arg0, %1, %arg1, %0) <{index_vector_dim = 1 : i32, indices_are_sorted = false, input_batching_dims = array<i32>, inserted_window_dims = array<i32: 0>, scatter_dims_to_operand_dims = array<i32: 0>, scatter_indices_batching_dims = array<i32>, unique_indices = false, update_window_dims = array<i32: 1, 2, 3>}> : (tensor<1x3x320x320xf32>, tensor<1x1xi32>, tensor<1x3x32x32xf32>, tensor<1x3x320x320xf32>) -> tensor<1x3x320x320xf32>
   return %2 : tensor<1x3x320x320xf32>
 }

--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/cbrt.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/cbrt.mlir
@@ -2,9 +2,6 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
 // RUN: ttmlir-opt --ttnn-modify-signatures-for-dylib --convert-ttnn-to-emitc %t.mlir > %t2.mlir
 // RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
-// UNSUPPORTED: true
-// There is an issue where this test fails when it is run as a part of the group of tests. It passes when run individually.
-// Related issue: https://github.com/tenstorrent/tt-mlir/issues/2261
 
 func.func @cbrt(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
   %0 = ttir.empty() : tensor<64x128xf32>

--- a/test/ttmlir/EmitC/TTNN/tensor/permute.mlir
+++ b/test/ttmlir/EmitC/TTNN/tensor/permute.mlir
@@ -2,12 +2,9 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
 // RUN: ttmlir-opt --ttnn-modify-signatures-for-dylib --convert-ttnn-to-emitc %t.mlir > %t2.mlir
 // RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
-// UNSUPPORTED: true
-// Marked as unsupported because of the following issue:
-// https://github.com/tenstorrent/tt-mlir/issues/2713
 
 func.func @permute(%arg0: tensor<1x4x32x64xf32>) -> tensor<4x32x64x1xf32> {
-    %0 = ttir.empty() : tensor<4x32x64x1xf32>
-    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 1, 2, 3, 0>}> : (tensor<1x4x32x64xf32>, tensor<4x32x64x1xf32>) -> tensor<4x32x64x1xf32>
-    return %1 : tensor<4x32x64x1xf32>
-  }
+  %0 = ttir.empty() : tensor<4x32x64x1xf32>
+  %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 1, 2, 3, 0>}> : (tensor<1x4x32x64xf32>, tensor<4x32x64x1xf32>) -> tensor<4x32x64x1xf32>
+  return %1 : tensor<4x32x64x1xf32>
+}


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/2508
Closes https://github.com/tenstorrent/tt-mlir/issues/2261
Closes https://github.com/tenstorrent/tt-mlir/issues/2713

### Problem description
These tests used to fail during runtime when you run them in a group.

### What's changed
\-

### Checklist
- [ ] New/Existing tests provide coverage for changes
