### PR TITLE
Automatic Golden POC

### DIFF
--- a/runtime/include/tt/runtime/detail/debug.h
+++ b/runtime/include/tt/runtime/detail/debug.h
@@ -6,7 +6,7 @@
 #define TT_RUNTIME_DETAIL_DEBUG_H
 
 #include <functional>
-#include <optional>
+#include <vector>
 #include <ostream>
 
 #include "tt/runtime/types.h"
@@ -19,7 +19,7 @@ struct Env {
 #else
   constexpr static Env
 #endif
-  get(bool loadKernelsFromDisk = false)
+  get(bool loadKernelsFromDisk = false, bool goldenEval = false)
 #if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
       ;
 #else
@@ -29,10 +29,12 @@ struct Env {
 #endif
 
   bool loadKernelsFromDisk;
+  bool goldenEval;
 
 private:
-  constexpr Env(bool loadKernelsFromDisk)
-      : loadKernelsFromDisk(loadKernelsFromDisk) {}
+  constexpr Env(bool loadKernelsFromDisk, bool goldenEval)
+      : loadKernelsFromDisk(loadKernelsFromDisk),
+        goldenEval(goldenEval) {}
 };
 
 inline std::ostream &operator<<(std::ostream &os, Env const &env) {
@@ -44,46 +46,94 @@ inline std::ostream &operator<<(std::ostream &os, Env const &env) {
 
 struct Hooks {
   using CallbackFn = std::function<void(Binary, CallbackContext, OpContext)>;
+  using CallbackHandle = std::size_t;
+  using CallbackKV = std::pair<CallbackHandle, CallbackFn>;
+
+  static constexpr std::size_t kInvalidHandle =
+      std::numeric_limits<std::size_t>::max();
+
 #if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
-  static Hooks const &
-  get(std::optional<CallbackFn> preOperatorCallback = std::nullopt,
-      std::optional<CallbackFn> postOperatorCallback = std::nullopt);
+  static Hooks &get();
 #else
   constexpr static Hooks get() { return Hooks(); }
 #endif
 
-  std::optional<CallbackFn> getPreOperatorCallback() const {
+  std::vector<CallbackKV> const& getPreOperatorCallbacks() const {
 #if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
-    return preOperatorCallback;
+    return preOperatorCallbacks;
 #else
-    return std::nullopt;
+    return {};
 #endif
   }
 
-  std::optional<CallbackFn> getPostOperatorCallback() const {
+  std::vector<CallbackKV> const& getPostOperatorCallbacks() const {
 #if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
-    return postOperatorCallback;
+    return postOperatorCallbacks;
 #else
-    return std::nullopt;
+    return {};
 #endif
   }
 
-  void unregisterHooks() const {
+  CallbackHandle registerPreOperatorCallback(CallbackFn callback) {
 #if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
-    preOperatorCallback = std::nullopt;
-    postOperatorCallback = std::nullopt;
+    CallbackHandle handle = getNextHandle();
+    preOperatorCallbacks.emplace_back(handle, callback);
+    return handle;
+#else
+    LOG_FATAL("TT_RUNTIME_DEBUG not enabled");
+    return kInvalidHandle;
+#endif
+  }
+
+  CallbackHandle registerPostOperatorCallback(CallbackFn callback) {
+#if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
+    CallbackHandle handle = getNextHandle();
+    postOperatorCallbacks.emplace_back(handle, callback);
+    return handle;
+#else
+    LOG_FATAL("TT_RUNTIME_DEBUG not enabled");
+    return kInvalidHandle;
+#endif
+  }
+
+  void unregisterPreOperatorCallback(CallbackHandle handle) {
+#if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
+    auto iter =
+        std::find_if(preOperatorCallbacks.begin(), preOperatorCallbacks.end(),
+                     [handle](CallbackKV kv) { return kv.first == handle; });
+    assert(iter != preOperatorCallbacks.end());
+    preOperatorCallbacks.erase(iter);
+#endif
+  }
+
+  void unregisterPostOperatorCallback(CallbackHandle handle) {
+#if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
+    auto iter =
+        std::find_if(postOperatorCallbacks.begin(), postOperatorCallbacks.end(),
+                     [handle](CallbackKV kv) { return kv.first == handle; });
+    assert(iter != postOperatorCallbacks.end());
+    postOperatorCallbacks.erase(iter);
+#endif
+  }
+
+  void unregisterHooks() {
+#if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
+    preOperatorCallbacks.clear();
+    postOperatorCallbacks.clear();
 #endif
   }
 
 private:
 #if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
-  Hooks(std::optional<CallbackFn> preOperatorCallback,
-        std::optional<CallbackFn> postOperatorCallback)
-      : preOperatorCallback(preOperatorCallback),
-        postOperatorCallback(postOperatorCallback) {}
+  Hooks() = default;
 
-  mutable std::optional<CallbackFn> preOperatorCallback;
-  mutable std::optional<CallbackFn> postOperatorCallback;
+  std::size_t getNextHandle() {
+    static std::size_t nextHandle = 0;
+    return nextHandle++;
+  }
+
+  std::vector<CallbackKV> preOperatorCallbacks;
+  std::vector<CallbackKV> postOperatorCallbacks;
 
 #else
   constexpr Hooks() = default;
@@ -93,13 +143,30 @@ private:
 inline std::ostream &operator<<(std::ostream &os, Hooks const &hooks) {
   os << "debug::Hooks{\n"
      << "\t"
-     << "preOperatorCallback: "
-     << static_cast<bool>(hooks.getPreOperatorCallback())
-     << "postOperatorCallback: "
-     << static_cast<bool>(hooks.getPostOperatorCallback()) << ",\n"
+     << "preOperatorCallbacks: " << hooks.getPreOperatorCallbacks().size()
+     << ",\n"
+     << "postOperatorCallbacks: " << hooks.getPostOperatorCallbacks().size()
      << "}";
   return os;
 }
+
+struct GoldenEval {
+#if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
+  GoldenEval() = default;
+  ~GoldenEval();
+
+  void initialize(const char *mlir,
+                  std::vector<::tt::runtime::Tensor> const &inputs);
+  void finalize();
+
+  Hooks::CallbackHandle callbackHandle = Hooks::kInvalidHandle;
+  bool initialized = false;
+  bool ownsInterpreter = false;
+#else
+  constexpr GoldenEval() {}
+#endif
+};
+
 } // namespace tt::runtime::debug
 
 #endif // TT_RUNTIME_DETAIL_DEBUG_H

--- a/runtime/lib/common/CMakeLists.txt
+++ b/runtime/lib/common/CMakeLists.txt
@@ -49,13 +49,20 @@ target_include_directories(TTRuntimeSysDesc SYSTEM PUBLIC "$<BUILD_INTERFACE:${T
 add_dependencies(TTRuntimeSysDesc tt-metal FBS_GENERATION)
 target_link_libraries(TTRuntimeSysDesc PUBLIC coverage_config)
 
+find_package(Python3 COMPONENTS Development REQUIRED)
+
 add_library(TTRuntimeDebug STATIC debug.cpp)
 set_property(TARGET TTRuntimeDebug PROPERTY CXX_STANDARD 20)
 target_include_directories(TTRuntimeDebug
   PUBLIC
     ${PROJECT_SOURCE_DIR}/runtime/include
 )
-target_link_libraries(TTRuntimeDebug PUBLIC coverage_config)
+target_include_directories(TTRuntimeDebug
+  SYSTEM PUBLIC
+    ${TTMLIR_PYTHON_SITE_PACKAGES}/pybind11/include
+    ${Python3_INCLUDE_DIRS}
+)
+target_link_libraries(TTRuntimeDebug PUBLIC coverage_config ${Python3_LIBRARIES})
 
 add_library(TTRuntimeDylibs STATIC dylib.cpp)
 set_property(TARGET TTRuntimeDylibs PROPERTY CXX_STANDARD 20)

--- a/runtime/lib/common/debug.cpp
+++ b/runtime/lib/common/debug.cpp
@@ -3,23 +3,59 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt/runtime/detail/debug.h"
+
+#include <pybind11/embed.h>
+#include <pybind11/stl.h>
+
 #include <set>
 
 #if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
 
+namespace py = pybind11;
+
 namespace tt::runtime::debug {
 
-Env const &Env::get(bool loadKernelsFromDisk) {
-  static Env config(loadKernelsFromDisk);
+Env const &Env::get(bool loadKernelsFromDisk, bool automaticGolden) {
+  static Env config(loadKernelsFromDisk, automaticGolden);
   return config;
 }
 
-Hooks const &
-Hooks::get(std::optional<debug::Hooks::CallbackFn> preOperatorCallback,
-           std::optional<debug::Hooks::CallbackFn> postOperatorCallback) {
-  static Hooks config(preOperatorCallback, postOperatorCallback);
+Hooks &Hooks::get() {
+  static Hooks config;
   return config;
 }
+
+void GoldenEval::initialize(const char *mlir,
+                            std::vector<::tt::runtime::Tensor> const &inputs) {
+  assert(!initialized);
+  ownsInterpreter = (Py_IsInitialized() == 0);
+  if (ownsInterpreter) {
+    py::initialize_interpreter();
+  }
+  py::module_ goldenModule = py::module_::import("ttir_golden_eval");
+  py::object goldenContext = goldenModule.attr("GoldenContext")(mlir, inputs);
+  callbackHandle = Hooks::get().registerPostOperatorCallback(
+      [=](Binary binary, CallbackContext programContext, OpContext opContext) {
+        goldenContext.attr("eval")(binary, programContext, opContext);
+      });
+  initialized = true;
+}
+
+void GoldenEval::finalize() {
+  if (!initialized) {
+    return;
+  }
+  assert(callbackHandle != Hooks::kInvalidHandle);
+  Hooks::get().unregisterPostOperatorCallback(callbackHandle);
+  if (ownsInterpreter) {
+    py::finalize_interpreter();
+    ownsInterpreter = false;
+  }
+  callbackHandle = Hooks::kInvalidHandle;
+  initialized = false;
+}
+
+GoldenEval::~GoldenEval() { finalize(); }
 
 } // namespace tt::runtime::debug
 

--- a/runtime/lib/ttnn/include/tt/runtime/ttnn/program_executor.h
+++ b/runtime/lib/ttnn/include/tt/runtime/ttnn/program_executor.h
@@ -41,8 +41,7 @@ public:
   /**
    * Executes pre and post operation callbacks if registered
    */
-  void runCallback(std::optional<debug::Hooks::CallbackFn> callback,
-                   Binary &executableHandle,
+  void runCallback(debug::Hooks::CallbackFn callback, Binary &executableHandle,
                    const ::tt::target::ttnn::Operation *opContext,
                    ProgramContext *programContext);
 
@@ -67,6 +66,7 @@ private:
   const ::tt::target::ttnn::Program *program;
   Binary executableHandle;
   std::unique_ptr<ProgramContext> context;
+  debug::GoldenEval goldenEval;
 
   /**
    * Executes a single operation

--- a/runtime/lib/ttnn/include/tt/runtime/ttnn/types.h
+++ b/runtime/lib/ttnn/include/tt/runtime/ttnn/types.h
@@ -5,6 +5,7 @@
 #ifndef TT_RUNTIME_TTNN_TYPES_H
 #define TT_RUNTIME_TTNN_TYPES_H
 
+#include "tt/runtime/detail/debug.h"
 #include "tt/runtime/detail/dylib.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn.h"

--- a/runtime/python/ttir_golden_eval.py
+++ b/runtime/python/ttir_golden_eval.py
@@ -1,0 +1,71 @@
+import ttrt
+import torch
+from ttmlir.ir import *
+from ttmlir.dialects import ttir, tt, tensor, func
+
+class GoldenContext:
+    def __init__(self, source, inputs):
+        self.mlir_ctx = Context()
+        self.mlir_ctx.allow_unregistered_dialects = True
+        self.module = Module.parse(source, self.mlir_ctx)
+        self.entry = None
+        for op in self.module.body:
+            if isinstance(op, func.FuncOp):
+                assert self.entry is None, "multiple entry points"
+                self.entry = op
+        assert self.entry is not None, "no entry point"
+        self.loc_to_op = {}
+        self.values = {}
+        for arg in self.entry.regions[0].blocks[0].arguments:
+            self.values[arg] = inputs[arg.arg_number]
+        for op in self.entry.regions[0].blocks[0]:
+            self.loc_to_op[str(op.location)] = op
+
+    def eval(self, binary, program_context, op_context):
+        loc = ttrt.runtime.get_op_loc_info(op_context)
+        op = self.loc_to_op.get(loc, None)
+        if op is None:
+            return
+        if op.result in self.values:
+            # Already evaluated this op, but this needs way more thought
+            # Many decomps will explode multiple ops with the same location.
+            # Probably heuristic , last op wins?  Maybe compiler tags the
+            # locations with a special marked for golden.
+            return
+
+        print(f"golden evaling op: {op.name} {loc}")
+        op_output_tensor = ttrt.runtime.get_op_output_tensor(op_context, program_context)
+        assert op_output_tensor
+        device_tensor = self.to_torch(op_output_tensor)
+        golden_tensor = self.eval_golden_tensor(op, program_context, op_context)
+        print(f"device: {device_tensor}")
+        print(f"golden: {golden_tensor}")
+        print(f"error: {torch.max(torch.abs(device_tensor - golden_tensor))}")
+
+    def to_torch(self, rt_tensor):
+        if type(rt_tensor) == torch.Tensor:
+            return rt_tensor
+        dtype = ttrt.common.util.ttrt_datatype_to_torch_dtype(rt_tensor.get_dtype())
+        return torch.frombuffer(rt_tensor.get_data_buffer(), dtype=dtype).flatten()
+
+    def eval_golden_tensor(self, op, program_context, op_context):
+        attr = op.name.replace(".", "_")
+        if not hasattr(self, attr):
+            print(f"No golden eval implemented for op: {op.name}")
+            return None
+        operands = []
+        for operand in op.operands:
+            if operand in self.values:
+                operands.append(self.to_torch(self.values[operand]))
+            elif operand.owner.name == "ttir.empty":
+                continue
+            else:
+                raise NotImplementedError(
+                    f"Operand {operand} not found")
+        golden = getattr(self, attr)(op, operands)
+        self.values[op.result] = golden
+        return golden
+
+    def ttir_abs(self, op, operands):
+        assert len(operands) == 1
+        return torch.abs(operands[0])

--- a/runtime/tools/python/ttrt/common/run.py
+++ b/runtime/tools/python/ttrt/common/run.py
@@ -110,6 +110,13 @@ class Run:
             help="seed for random number generator",
         )
         Run.register_arg(
+            name="--golden-eval",
+            type=bool,
+            default=False,
+            choices=[True, False],
+            help="pickup the kernels from disk (/tmp) instead of the flatbuffer",
+        )
+        Run.register_arg(
             name="--load-kernels-from-disk",
             type=bool,
             default=False,
@@ -436,7 +443,7 @@ class Run:
                 self.logging.warning(f"no binaries found to run - returning early")
                 return
 
-            debug_env = ttrt.runtime.DebugEnv.get(self["--load-kernels-from-disk"])
+            debug_env = ttrt.runtime.DebugEnv.get(self["--load-kernels-from-disk"], self["--golden-eval"])
             self.logging.debug(f"setting tt runtime debug env={debug_env}")
             workaround_env = ttrt.runtime.WorkaroundEnv.get(
                 not self["--disable-swap-binary-operands"],

--- a/runtime/tools/python/ttrt/runtime/module.cpp
+++ b/runtime/tools/python/ttrt/runtime/module.cpp
@@ -313,19 +313,19 @@ PYBIND11_MODULE(_C, m) {
           "get",
           [](py::function pre_op_func, py::function post_op_func) {
 #if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
-            tt::runtime::debug::Hooks::get(
+            auto &hooks = tt::runtime::debug::Hooks::get();
+            hooks.registerPreOperatorCallback(
                 [pre_op_func](tt::runtime::Binary Binary,
                               tt::runtime::CallbackContext programContext,
                               tt::runtime::OpContext opContext) {
                   pre_op_func(Binary, programContext, opContext);
-                },
+                });
+            hooks.registerPostOperatorCallback(
                 [post_op_func](tt::runtime::Binary Binary,
                                tt::runtime::CallbackContext programContext,
                                tt::runtime::OpContext opContext) {
                   post_op_func(Binary, programContext, opContext);
                 });
-#else
-            tt::runtime::debug::Hooks::get();
 #endif
           })
       .def("__str__", [](const tt::runtime::debug::Hooks &hooks) {


### PR DESCRIPTION
This is a draft PR that prototypes automatic golden checking.

## How it works

- C++ side: `GoldenEval` struct is part of `ProgramExecutor` it does a few things:
  - Initializes a python interpreter and bindings to a python golden eval class
  - Initializes python class with TTIR mlir source extracted from the flatbuffer + runtime tensor inputs
  - Registers post-op hooks that call into this python interface
- Python side:
  - Ingests TTIR mlir, parses it into a module and holds a reference to it
  - Holds references to the runtime tensor inputs
  - Maintains a dictionary of source locations to golden tensors

Execution flow:
- Op is executed by TTNN runtime, then post-op hooks are called
- Hook forwards into python golden eval class which looks up the current op's source location
- Lazily evaluates the op and does golden check

## Future work and challenges
- Need to port all golden evals from ttir-builder here.
- Runtime tensor to torch tensor robustness, right now that conversion is a bit awkward and loses shape info and extra metadata.
- Dealloc ops are just ignored, but ideally they also free goldens that are no longer in use.
- Decomp causes many-to-one relationship between TTNN graph and original TTIR graph, we need a way for the compiler to distinguish the last op in the decomposition as the actual golden.