### PR TITLE
Remove metal cpm cache

### DIFF
--- a/.github/actions/build-tt-mlir-action/action.yaml
+++ b/.github/actions/build-tt-mlir-action/action.yaml
@@ -40,17 +40,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Setup Metal CPM Cache
-      uses: actions/cache@v4
-      with:
-        path: ${{ github.workspace }}/.cpm_cache
-        key: metal-cpm-cache
-
-    - name: Set Metal CPM Cache Environment Variable
-      shell: bash
-      run: |
-        mkdir -p ${{ github.workspace }}/.cpm_cache
-        echo "CPM_SOURCE_CACHE=${{ github.workspace }}/.cpm_cache" >> $GITHUB_ENV
 
     - name: Configure CMake
       shell: bash


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
CPM cache size is affecting our GitHub actions cache due to its size (over 600 Mb), which causes cache thrashing. Disabling this only for CI until we figure out another plan

### What's changed

### Checklist
- [ ] New/Existing tests provide coverage for changes
