### PR TITLE
Fix Shardy parsing related bugs

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/ShardyToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/ShardyToTTIRPatterns.cpp
@@ -407,7 +407,9 @@ public:
         if (!retShardingAttr) {
           continue;
         }
-        if (mlir::isa<mlir::sdy::ManualComputationOp>(ret.getDefiningOp())) {
+
+        if (mlir::isa_and_present<mlir::sdy::ManualComputationOp>(
+                ret.getDefiningOp())) {
           continue;
         }
 
@@ -474,11 +476,12 @@ analyzeSingleOpAndFixWrongTensorAnnotation(mlir::tt::MeshesAttr meshes,
                   argType.getEncoding())) {
         // If pre-existing TensorMeshShardingAttr is different from the
         // expected one, then fail.
-        if (argTensorMeshShardingAttr != tensorMeshShardingAttr) {
+        if (argTensorMeshShardingAttr.getName() !=
+            tensorMeshShardingAttr.getName()) {
           srcOp->emitError()
               << "Inconsistency found in TensorMeshShardingAttr : expected ("
-              << tensorMeshShardingAttr << ") and current ("
-              << argTensorMeshShardingAttr << ") are different.";
+              << tensorMeshShardingAttr.getName() << ") and current ("
+              << argTensorMeshShardingAttr.getName() << ") are different.";
         }
         continue;
       }

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -252,7 +252,8 @@ private:
     auto outputType = mlir::cast<RankedTensorType>(
         getTypeConverter()->convertType(srcOp.getResultTypes()[1]));
     ttir::EmptyOp outputTensor = rewriter.create<ttir::EmptyOp>(
-        srcOp.getLoc(), outputType.getShape(), outputType.getElementType());
+        srcOp.getLoc(), outputType.getShape(), outputType.getElementType(),
+        outputType.getEncoding());
 
     // Can't reuse the original dimensions attribute because it uses i64 type.
     mlir::ArrayAttr dimArg = rewriter.getI32ArrayAttr(
@@ -919,7 +920,8 @@ public:
     SmallVector<Value> outputsVec;
     for (uint32_t i = 0; i < srcOp.getResults().size(); i++) {
       ttir::EmptyOp outputTensor = rewriter.create<ttir::EmptyOp>(
-          srcOp.getLoc(), outputType.getShape(), outputType.getElementType());
+          srcOp.getLoc(), outputType.getShape(), outputType.getElementType(),
+          outputType.getEncoding());
       outputsVec.push_back(outputTensor);
     }
     ValueRange outputs = outputsVec;

--- a/test/ttmlir/Conversion/StableHLOToTTIR/ccl/ccl_ops_shardy.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/ccl/ccl_ops_shardy.mlir
@@ -440,3 +440,27 @@ module @jit_reshape attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas
 // CHECK-SAME: shard_direction = #tt.shard_direction<shard_to_full>
 // CHECK-SAME: shard_shape = array<i64: 8, 1, 1, 1>
 // CHECK-SAME: shard_type = #tt.shard_type<devices>
+
+// -----
+
+// torchax - DDP with automatic parallelism
+module @jit__unnamed_wrapped_function_ attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas = 1 : i32} {
+  sdy.mesh @mesh = <["x"=1, "batch"=8]>
+  func.func public @main(%arg0: tensor<1024x1024xf32> {sdy.sharding = #sdy.sharding<@mesh, [{}, {}]>}, %arg1: tensor<1024xf32> {sdy.sharding = #sdy.sharding<@mesh, [{}]>}, %arg2: tensor<1024x1024xf32> {sdy.sharding = #sdy.sharding<@mesh, [{"batch"}, {}]>}) -> (tensor<1024x1024xf32> {jax.result_info = "[0]['_module.linear.weight']", sdy.sharding = #sdy.sharding<@mesh, [{}, {}]>}, tensor<1024xf32> {jax.result_info = "[0]['_module.linear.bias']", sdy.sharding = #sdy.sharding<@mesh, [{}]>}, tensor<1024x1024xf32> {jax.result_info = "[1]", sdy.sharding = #sdy.sharding<@mesh, [{"batch"}, {}]>}) {
+    %cst = stablehlo.constant dense<1.000000e+00> : tensor<f32>
+    %0 = stablehlo.transpose %arg0, dims = [1, 0] : (tensor<1024x1024xf32>) -> tensor<1024x1024xf32>
+    %1 = stablehlo.broadcast_in_dim %cst, dims = [] : (tensor<f32>) -> tensor<1024xf32>
+    %2 = stablehlo.multiply %arg1, %1 : tensor<1024xf32>
+    %3 = stablehlo.dot_general %arg2, %0, contracting_dims = [1] x [0] : (tensor<1024x1024xf32>, tensor<1024x1024xf32>) -> tensor<1024x1024xf32>
+    %4 = stablehlo.broadcast_in_dim %cst, dims = [] : (tensor<f32>) -> tensor<1024x1024xf32>
+    %5 = stablehlo.multiply %4, %3 : tensor<1024x1024xf32>
+    %6 = stablehlo.reshape %2 : (tensor<1024xf32>) -> tensor<1x1024xf32>
+    %7 = stablehlo.broadcast_in_dim %6, dims = [0, 1] : (tensor<1x1024xf32>) -> tensor<1024x1024xf32>
+    %8 = stablehlo.add %7, %5 : tensor<1024x1024xf32>
+    return %arg0, %arg1, %8 : tensor<1024x1024xf32>, tensor<1024xf32>, tensor<1024x1024xf32>
+  }
+}
+// CHECK: "ttir.dot_general"
+// CHECK-SAME: tensor<1024x1024xf32, #tt.mesh_sharding<"mesh", [ 8(1),  1]>>
+// CHECK-SAME: tensor<1024x1024xf32, #tt.mesh_sharding<"mesh", [ 8(1),  1]>>
+// CHECK-SAME: tensor<1024x1024xf32, #tt.mesh_sharding<"mesh", [ 8(1),  1]>>


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/549
https://github.com/tenstorrent/tt-mlir/issues/3132

### Problem description
1. error: 'ttir.pooling' op expected type of operand #1 ('tensor<16x26x26x64xbf16>') to match type of corresponding result ('tensor<16x26x26x64xbf16, #tt.mesh_sharding<"mesh">>')
2.  Inconsistency found in TensorMeshShardingAttr : expected (#tt.mesh_sharding<"mesh", [ 8(1),  1]>) and current (#tt.mesh_sharding<"mesh">) are different.

### What's changed
This patch fix two bugs in parsing graph with Shardy. First, add missing tensor encoding and second relax check and let the following pass handles the issue.

### Checklist
- [X] New/Existing tests provide coverage for changes
