### PR TITLE
Update to manylinux image to latest tag

### DIFF
--- a/.github/workflows/wheel-build.yml
+++ b/.github/workflows/wheel-build.yml
@@ -38,8 +38,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.23.2
         env:
           CIBW_ENVIRONMENT: "IN_CIBW_ENV=ON"
-          # TODO(vprajapati): Use static tagged until merged with main to update latest tag
-          CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/tenstorrent/tt-mlir/tt-mlir-manylinux-2-34:dt-35f2834c5f5d1cb68b599e12d7dae7751a73ff292364a80ee43f9adfb9b937ec
+          CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/tenstorrent/tt-mlir/tt-mlir-manylinux-2-34
         with:
           output-dir: ${{ steps.strings.outputs.wheel-output-dir }}
           package-dir: ${{ steps.strings.outputs.work-dir }}/python


### PR DESCRIPTION
### Problem description
- Since dev branch with container was not on main, the latest tag was never updated. Now it will pull from the latest tag.

### What's changed
- Update to pull from "latest" tag.
