### PR TITLE
D2M: Fix matmul and dma lowering issues

### DIFF
--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -121,6 +121,15 @@ def TTKernel_BinaryOpInitCommonOp : TTKernel_InitOp<"binary_op_init_common"> {
     let arguments = (ins TTKernel_CB:$in0_cb, TTKernel_CB:$in1_cb, TTKernel_CB:$out_cb);
 }
 
+def TTKernel_MatmulInitOp : TTKernel_InitOp<"mm_init"> {
+    let summary = "Matmul init function";
+    let description = [{
+      Must be run before matmul.
+    }];
+
+    let arguments = (ins TTKernel_CB:$in0_cb, TTKernel_CB:$in1_cb, TTKernel_CB:$out_cb, I32:$transpose);
+}
+
 def TTKernel_MatmulTilesOp : TTKernel_FPUOp<"matmul_tiles"> {
     let summary = "Matmul tiles operation";
     let description = [{
@@ -134,7 +143,8 @@ def TTKernel_MatmulTilesOp : TTKernel_FPUOp<"matmul_tiles"> {
                          TTKernel_CB:$in1_cb_id,
                          IndexLike:$in0_tile_idx,
                          IndexLike:$in1_tile_idx,
-                         IndexLike:$dst_tile_idx);
+                         IndexLike:$dst_tile_idx,
+                         I32:$transpose);
 }
 
 def TTKernel_AddTilesInitOp : TTKernel_InitOp<"add_tiles_init"> {

--- a/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
+++ b/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
@@ -306,6 +306,13 @@ public:
     return std::make_tuple(gridY, gridX, offset);
   }
 
+  static Value castCBTypeAsAddress(OpBuilder &rewriter, Location loc,
+                                   Value cb) {
+    return rewriter
+        .create<UnrealizedConversionCastOp>(loc, rewriter.getI32Type(), cb)
+        ->getResult(0);
+  }
+
   LogicalResult
   matchAndRewrite(ttir::DMAOp op, ttir::DMAOpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
@@ -421,10 +428,7 @@ public:
           op.getLoc(), rewriter.getI32Type(), dstOffset);
 
       auto dstAddrAsInt =
-          rewriter
-              .create<UnrealizedConversionCastOp>(
-                  op.getLoc(), rewriter.getI32Type(), adaptor.getDst())
-              ->getResult(0);
+          castCBTypeAsAddress(rewriter, op->getLoc(), adaptor.getDst());
       auto dstAddr = rewriter.create<arith::AddIOp>(op.getLoc(), dstOffsetInt,
                                                     dstAddrAsInt);
 
@@ -462,10 +466,7 @@ public:
               op.getNumElems() * getElementSizeBytes(op.getSrcMemRefType()));
 
       auto srcAddrAsInt =
-          rewriter
-              .create<UnrealizedConversionCastOp>(
-                  op.getLoc(), rewriter.getI32Type(), adaptor.getSrc())
-              ->getResult(0);
+          castCBTypeAsAddress(rewriter, op->getLoc(), adaptor.getSrc());
       auto srcAddr = rewriter.create<arith::AddIOp>(op.getLoc(), srcOffsetInt,
                                                     srcAddrAsInt);
 

--- a/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
+++ b/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
@@ -115,7 +115,16 @@ public:
           op->getLoc(), i32(rewriter, op->getLoc(), 0),
           i32(rewriter, op->getLoc(), 1));
     } else if (mlir::isa<ttir::TileAddOp>(op)) {
+      assert(op->hasOneUse());
+      auto store = mlir::cast<memref::StoreOp>(*op->user_begin());
+      auto outCB = rewriter.getRemappedValue(store.getMemref());
+      rewriter.create<ttkernel::BinaryOpInitCommonOp>(
+          op->getLoc(), getCB(rewriter, operands[0]),
+          getCB(rewriter, operands[1]), outCB);
       auto dstIdx = index(rewriter, op->getLoc(), 0);
+      rewriter.create<ttkernel::AddTilesInitOp>(op->getLoc(),
+                                                getCB(rewriter, operands[0]),
+                                                getCB(rewriter, operands[1]));
       newOp = rewriter.create<ttkernel::AddTilesOp>(
           op->getLoc(), getCB(rewriter, operands[0]),
           getCB(rewriter, operands[1]), getLoadIndex(operands[0]),

--- a/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
+++ b/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
@@ -134,12 +134,12 @@ public:
       initOp = rewriter.create<ttkernel::MatmulInitOp>(
           op->getLoc(), getCB(rewriter, operands[0]),
           getCB(rewriter, operands[1]), getCB(rewriter, operands[2]),
-          i32(rewriter, op->getLoc(), 0) /* transpose */);
+          /* transpose */ i32(rewriter, op->getLoc(), 0));
       newOp = rewriter.create<ttkernel::MatmulTilesOp>(
           op->getLoc(), getCB(rewriter, operands[0]),
           getCB(rewriter, operands[1]), getLoadIndex(operands[0]),
           getLoadIndex(operands[1]), dstIdx,
-          i32(rewriter, op->getLoc(), 0) /* transpose */);
+          /* transpose */ i32(rewriter, op->getLoc(), 0));
     } else if (mlir::isa<ttir::TileTilizeBlockOp>(op)) {
       assert(operands.size() == 2);
       Value src = operands[0];

--- a/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
+++ b/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
@@ -118,7 +118,7 @@ public:
       assert(op->hasOneUse());
       auto store = mlir::cast<memref::StoreOp>(*op->user_begin());
       auto outCB = rewriter.getRemappedValue(store.getMemref());
-      rewriter.create<ttkernel::BinaryOpInitCommonOp>(
+      initOp = rewriter.create<ttkernel::BinaryOpInitCommonOp>(
           op->getLoc(), getCB(rewriter, operands[0]),
           getCB(rewriter, operands[1]), outCB);
       auto dstIdx = index(rewriter, op->getLoc(), 0);

--- a/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
+++ b/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
@@ -317,6 +317,12 @@ public:
 
   static Value castCBTypeAsAddress(OpBuilder &rewriter, Location loc,
                                    Value cb) {
+    // This is required because we blanket convert Memrefs into CBs with a type
+    // converter, however there are actually two paths a memref can take:
+    // 1. It can be a CBType, which is the case for local memrefs
+    // 2. It can represent remote data, which we need to lower to a compile time
+    // address (I32 type)
+    // More information on ticket #3172
     return rewriter
         .create<UnrealizedConversionCastOp>(loc, rewriter.getI32Type(), cb)
         ->getResult(0);

--- a/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
+++ b/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
@@ -107,9 +107,10 @@ public:
   matchAndRewrite(Operation *op, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const final {
     Operation *newOp;
+    Operation *initOp = nullptr;
 
     if (mlir::isa<ttir::TileMaximumOp>(op)) {
-      rewriter.create<ttkernel::MaxTilesInitOp>(op->getLoc());
+      initOp = rewriter.create<ttkernel::MaxTilesInitOp>(op->getLoc());
       newOp = rewriter.create<ttkernel::MaxTilesOp>(
           op->getLoc(), i32(rewriter, op->getLoc(), 0),
           i32(rewriter, op->getLoc(), 1));
@@ -121,10 +122,15 @@ public:
           getLoadIndex(operands[1]), dstIdx);
     } else if (mlir::isa<ttir::TileMatmulOp>(op)) {
       auto dstIdx = index(rewriter, op->getLoc(), 0);
+      initOp = rewriter.create<ttkernel::MatmulInitOp>(
+          op->getLoc(), getCB(rewriter, operands[0]),
+          getCB(rewriter, operands[1]), getCB(rewriter, operands[2]),
+          i32(rewriter, op->getLoc(), 0) /* transpose */);
       newOp = rewriter.create<ttkernel::MatmulTilesOp>(
           op->getLoc(), getCB(rewriter, operands[0]),
           getCB(rewriter, operands[1]), getLoadIndex(operands[0]),
-          getLoadIndex(operands[1]), dstIdx);
+          getLoadIndex(operands[1]), dstIdx,
+          i32(rewriter, op->getLoc(), 0) /* transpose */);
     } else if (mlir::isa<ttir::TileTilizeBlockOp>(op)) {
       assert(operands.size() == 2);
       Value src = operands[0];
@@ -132,6 +138,8 @@ public:
       auto numTiles =
           i32(rewriter, op->getLoc(),
               mlir::cast<ttkernel::CBType>(dst.getType()).getNumTiles());
+      initOp = rewriter.create<ttkernel::TilizeInitOp>(op->getLoc(), src,
+                                                       numTiles, dst);
       newOp = rewriter.create<ttkernel::TilizeBlockOp>(op->getLoc(), src,
                                                        numTiles, dst);
     } else if (mlir::isa<ttir::TileUntilizeBlockOp>(op)) {
@@ -141,13 +149,15 @@ public:
       auto numTiles =
           i32(rewriter, op->getLoc(),
               mlir::cast<ttkernel::CBType>(src.getType()).getNumTiles());
+      initOp =
+          rewriter.create<ttkernel::UntilizeInitOp>(op->getLoc(), src, dst);
       newOp = rewriter.create<ttkernel::UntilizeBlockOp>(op->getLoc(), src,
                                                          numTiles, dst);
     } else {
       return failure();
     }
 
-    rewriter.setInsertionPoint(newOp);
+    rewriter.setInsertionPoint(initOp == nullptr ? newOp : initOp);
     if (mlir::isa<ttkernel::MatmulTilesOp>(newOp)) {
       lowerLoadToCopyTile(operands[2].getDefiningOp<memref::LoadOp>(), false,
                           rewriter);
@@ -410,11 +420,19 @@ public:
       auto dstOffsetInt = rewriter.create<arith::IndexCastOp>(
           op.getLoc(), rewriter.getI32Type(), dstOffset);
 
+      auto dstAddrAsInt =
+          rewriter
+              .create<UnrealizedConversionCastOp>(
+                  op.getLoc(), rewriter.getI32Type(), adaptor.getDst())
+              ->getResult(0);
+      auto dstAddr = rewriter.create<arith::AddIOp>(op.getLoc(), dstOffsetInt,
+                                                    dstAddrAsInt);
+
       // Translate the dst coordinates to virtual coordinates
       auto [virtY, virtX] = getVirtualCoordsFromLogicalCoords(
           rewriter, op.getLoc(), chipDesc, ValueRange{dstGridY, dstGridX});
-      auto nocAddr = rewriter.create<ttkernel::GetNocAddrOp>(
-          op.getLoc(), virtX, virtY, dstOffsetInt);
+      auto nocAddr = rewriter.create<ttkernel::GetNocAddrOp>(op.getLoc(), virtX,
+                                                             virtY, dstAddr);
       rewriter.create<ttkernel::NocAsyncWriteOp>(op.getLoc(), srcL1Start,
                                                  nocAddr, transferSize);
     } else if (op.isSrcRemote() && op.isDstLocal()) {
@@ -442,11 +460,20 @@ public:
       auto size =
           i32(rewriter, op->getLoc(),
               op.getNumElems() * getElementSizeBytes(op.getSrcMemRefType()));
+
+      auto srcAddrAsInt =
+          rewriter
+              .create<UnrealizedConversionCastOp>(
+                  op.getLoc(), rewriter.getI32Type(), adaptor.getSrc())
+              ->getResult(0);
+      auto srcAddr = rewriter.create<arith::AddIOp>(op.getLoc(), srcOffsetInt,
+                                                    srcAddrAsInt);
+
       // Translate the src coordinates to virtual coordinates
       auto [virtY, virtX] = getVirtualCoordsFromLogicalCoords(
           rewriter, op.getLoc(), chipDesc, ValueRange{srcGridY, srcGridX});
       auto srcNocAddr = rewriter.create<ttkernel::GetNocAddrOp>(
-          op.getLoc(), virtX, virtY, srcOffsetInt);
+          op.getLoc(), virtX, virtY, srcAddr);
       rewriter.create<ttkernel::NocAsyncReadOp>(op.getLoc(), srcNocAddr,
                                                 dstL1Start, size);
       isRead = true;

--- a/lib/Conversion/TTIRToTTKernel/TTIRToTTKernelPass.cpp
+++ b/lib/Conversion/TTIRToTTKernel/TTIRToTTKernelPass.cpp
@@ -75,6 +75,18 @@ struct ConvertTTIRToTTKernel
           memref.getContext(), ttkernel::symbolizeCBPort(0).value(), 0, memref);
     });
 
+    auto materializeAsUnrealizedCast = [](OpBuilder &builder, Type resultType,
+                                          ValueRange inputs,
+                                          Location loc) -> Value {
+      if (inputs.size() != 1) {
+        return Value();
+      }
+      return builder.create<UnrealizedConversionCastOp>(loc, resultType, inputs)
+          .getResult(0);
+    };
+    typeConverter.addSourceMaterialization(materializeAsUnrealizedCast);
+    typeConverter.addTargetMaterialization(materializeAsUnrealizedCast);
+
     ttir::AssociatedDMAWaits associatedDMAWaits =
         getAnalysis<ttir::AssociatedDMAWaits>();
 

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -535,6 +535,8 @@ public:
         TTKernelToEmitCOpaqueRewriter<ttkernel::MulTilesInitOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::MulTilesInitFOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::MaxTilesInitOp>,
+        TTKernelToEmitCOpaqueRewriter<ttkernel::MatmulInitOp>,
+        TTKernelToEmitCOpaqueRewriter<ttkernel::MatmulTilesOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::AddTilesOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::MulTilesOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::MaxTilesOp>,

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -75,6 +75,7 @@ void createTTIRToTTMetalBackendPipeline(
   createOptimizationPasses(pm);
   pm.addPass(ttir::createTTIRGenericRegionsToFuncs());
   pm.addPass(tt::createConvertTTIRToTTKernelPass());
+  pm.addPass(mlir::createCanonicalizerPass());
   pm.addPass(ttkernel::createTTKernelControlDstSection());
   createOptimizationPasses(pm);
   pm.addPass(createConvertTTIRToTTMetalPass());

--- a/lib/Target/TTKernel/TTKernelToCpp.cpp
+++ b/lib/Target/TTKernel/TTKernelToCpp.cpp
@@ -41,6 +41,8 @@ public:
                                         /*isStandard=*/false);
       builder->create<emitc::IncludeOp>(loc, "compute_kernel_api/common.h",
                                         /*isStandard=*/false);
+      builder->create<emitc::IncludeOp>(loc, "compute_kernel_api/matmul.h",
+                                        /*isStandard=*/false);
       builder->create<emitc::IncludeOp>(loc, "compute_kernel_api/tilize.h",
                                         /*isStandard=*/false);
       builder->create<emitc::IncludeOp>(loc, "compute_kernel_api/untilize.h",

--- a/test/ttmlir/Conversion/TTIRToTTKernel/tiled_matmul.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTKernel/tiled_matmul.mlir
@@ -73,6 +73,7 @@ module {
           // CHECK: "ttkernel.copy_tile_init"
           // CHECK: "ttkernel.copy_tile"
           %8 = memref.load %collapse_shape_1[%7] : memref<4x!tt.tile<32x32, f32>, #l1_>
+          // CHECK: "ttkernel.mm_init"
           // CHECK: "ttkernel.matmul_tiles"
           // CHECK: "ttkernel.tile_regs_commit"
           %9 = "ttir.tile_matmul"(%2, %5, %8) : (!tt.tile<32x32, f32>, !tt.tile<32x32, f32>, !tt.tile<32x32, f32>) -> !tt.tile<32x32, f32>


### PR DESCRIPTION
### Ticket
#2608 

### Problem description
Various follow on fixes for d2m backend. 

### What's changed
- Added DMA lowering address offsets from compile time buffer addresses 
- Added matmul init, fixed matmul syntax (transpose flag)
- Added matmul include to emitc lowering 
- Fixed insertion point for load lowering for ops with inits 

### Checklist
- [X] New/Existing tests provide coverage for changes
