### PR TITLE
Add automatic upstream remote configuration for version tags

### DIFF
--- a/cmake/modules/TTMLIRVersion.cmake
+++ b/cmake/modules/TTMLIRVersion.cmake
@@ -16,6 +16,23 @@ execute_process(
 
 if("${EXISTING_TAGS}" STREQUAL "")
   message(STATUS "No version tags found locally. Fetching tags from upstream...")
+
+  # Check if 'upstream' is set
+  execute_process(
+    COMMAND git remote
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+    OUTPUT_VARIABLE REMOTES
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+
+  # Add 'upstream' if not already present
+  if(NOT "${REMOTES}" MATCHES "upstream")
+    execute_process(
+      COMMAND git remote add upstream https://github.com/tenstorrent/tt-mlir.git
+      WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+    )
+  endif()
+
   execute_process(
     COMMAND git fetch --tags upstream
     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}


### PR DESCRIPTION
### Ticket
N/A

### Problem description
When forking a repository using `gh repo fork`, the upstream remote is automatically configured. However, when forking through other methods, the upstream remote needs to be manually set.

### What's changed
This commit check if upstream remote exists, then adds it automatically if not configured.

### Checklist
- [ ] New/Existing tests provide coverage for changes
