### PR TITLE
Enable FFE build with OPMODEL

### DIFF
--- a/include/ttmlir/OpModel/TTNN/SingletonDeviceContext.h
+++ b/include/ttmlir/OpModel/TTNN/SingletonDeviceContext.h
@@ -28,6 +28,7 @@ class SingletonDeviceContext {
 public:
   static SingletonDeviceContext &getInstance();
   static void resetInstance();
+  static void closeInstance();
 
   ::tt::tt_metal::IDevice *getDevice() { return m_device; }
 
@@ -41,7 +42,8 @@ private:
 
   ::tt::tt_metal::IDevice *m_device;
 
-  void resetDevice(const size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE);
+  void openDevice(const size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE);
+  void closeDevice();
 };
 } // namespace mlir::tt::op_model::ttnn
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -44,6 +44,10 @@ add_mlir_library(TTMLIRCompilerStatic
 #
 add_library(TTMLIRCompiler SHARED RegisterAll.cpp)
 
+
+set_target_properties(TTMLIRCompiler PROPERTIES INSTALL_RPATH "$ORIGIN")
+set_target_properties(TTMLIRCompiler PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE)
+
 # Forces the inclusion of all symbols in the shared object
 # This is necessary because the JIT will not be able to find the symbols otherwise
 if (APPLE)

--- a/lib/Dialect/TTNN/Analysis/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Analysis/CMakeLists.txt
@@ -18,8 +18,10 @@ add_mlir_dialect_library(MLIRTTNNAnalysis
         MLIRTTNNOpsIncGen
         MLIRTTNNPassesIncGen
         MLIRTTOpsIncGen
+        TTNNOpModelLib
 
         LINK_LIBS PUBLIC
         MLIRScheduler
         TTMLIRTTNNUtils
+        TTNNOpModelLib
         )

--- a/lib/Dialect/TTNN/Transforms/TTNNPrepareConv2dWeights.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNPrepareConv2dWeights.cpp
@@ -5,6 +5,7 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
+#include "ttmlir/OpModel/TTNN/SingletonDeviceContext.h"
 #include "ttmlir/OpModel/TTNN/TTNNOpModel.h"
 #include "ttmlir/Utils.h"
 
@@ -64,6 +65,14 @@ public:
         conv2dOp.getWeightMutable().assign(prepareConv2dWeightsOp);
       });
     });
+
+#ifdef TTMLIR_ENABLE_OPMODEL
+    // Explicitly close device, leaving it open causes issues in frontend
+    // runtime.
+    // This will be removed once we switch to virtual device:
+    // https://github.com/tenstorrent/tt-metal/issues/14000
+    mlir::tt::op_model::ttnn::SingletonDeviceContext::closeInstance();
+#endif
   }
 
 private:

--- a/lib/OpModel/TTNN/CMakeLists.txt
+++ b/lib/OpModel/TTNN/CMakeLists.txt
@@ -14,10 +14,10 @@ message(STATUS "TTMLIR_ENABLE_OPMODEL[${TTMLIR_ENABLE_OPMODEL}]")
 if (TTMLIR_ENABLE_OPMODEL)
     # Building op model library will invoke building tt-metal; and it requires TT_METAL_HOME and ARCH_NAME environment variables to be set.
     if("$ENV{TT_METAL_HOME}" STREQUAL "")
-        message(FATAL_ERROR "TT_METAL_HOME is not set")
+        message(WARNING "TT_METAL_HOME is not set")
     endif()
     if("$ENV{ARCH_NAME}" STREQUAL "")
-        message(FATAL_ERROR "ARCH_NAME is not set")
+        message(WARNING "ARCH_NAME is not set")
     endif()
 
     # Link to tt-metal libs and include directories


### PR DESCRIPTION
### Ticket
Related: https://github.com/tenstorrent/tt-forge-fe/issues/1597

### Problem description
In order to enable optimizer in benchmark tests FFE build of tt-mlir needs to set `TTMLIR_ENABLE_OPMODEL=ON`.

### What's changed
* Explicitly close device after opmodel constraint calls
* Set install RPATH for TTMLIRCompiler target