### PR TITLE
Swap personal in favor of team aliases

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,11 +5,11 @@
 LICENSE @nsmithtt
 
 # CI
-/.github/ @vmilosevic @jmcgrathTT @nsumrakTT
+/.github/ @tenstorrent/forge-developers-mlir-devops
 
 # Build
-*.cmake @nsmithtt @mtopalovicTT @vwellsTT
-*.txt @nsmithtt @mtopalovicTT  @vwellsTT
+*.cmake @tenstorrent/forge-developers-mlir-build
+*.txt @tenstorrent/forge-developers-mlir-build
 
 # Docs
 *.md @nsmithtt @sdjordjevicTT
@@ -36,31 +36,31 @@ LICENSE @nsmithtt
 /test/ttmlir/Conversion/TTIRToLinalg/ @vwellsTT @ctodTT @nsmithTT
 
 # Tosa Conversion
-/include/ttmlir/Conversion/TosaToTTIR/ @mrakitaTT @sgligorijevicTT @sdjukicTT
-/lib/Conversion/TosaToTTIR/ @mrakitaTT @sgligorijevicTT @sdjukicTT
-/test/ttmlir/Conversion/TosaToTTIR/ @mrakitaTT @sgligorijevicTT @sdjukicTT
+/include/ttmlir/Conversion/TosaToTTIR/ @tenstorrent/forge-developers-mlir-stablehlo
+/lib/Conversion/TosaToTTIR/ @tenstorrent/forge-developers-mlir-stablehlo
+/test/ttmlir/Conversion/TosaToTTIR/ @tenstorrent/forge-developers-mlir-stablehlo
 
 # TTNN Conversions
-/include/ttmlir/Conversion/TTIRToTTIRDecomposition/ @svuckovicTT @sdjordjevicTT @mtopalovicTT @jserbedzijaTT @azecevicTT
-/include/ttmlir/Conversion/TTIRToTTNN/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @jserbedzijaTT @jnie-TT @azecevicTT
-/include/ttmlir/Conversion/TTNNToEmitC/ @svuckovicTT @sdjordjevicTT @mtopalovicTT @jserbedzijaTT @azecevicTT
-/lib/Conversion/TTIRToTTIRDecomposition/ @svuckovicTT @sdjordjevicTT @mtopalovicTT @jserbedzijaTT @azecevicTT
-/lib/Conversion/TTIRToTTNN/ @svuckovicTT @sdjordjevicTT @mtopalovicTT @jserbedzijaTT @azecevicTT
-/lib/Conversion/TTNNToEmitC/ @svuckovicTT @sdjordjevicTT @mtopalovicTT @jserbedzijaTT @azecevicTT
-/test/ttmlir/Conversion/TTIRToTTIRDecomposition/ @svuckovicTT @sdjordjevicTT @mtopalovicTT @jserbedzijaTT @azecevicTT
-/test/ttmlir/Conversion/TTIRToTTNN/ @svuckovicTT @sdjordjevicTT @mtopalovicTT @jserbedzijaTT @azecevicTT
-/test/ttmlir/Conversion/TTNNToEmitC/ @svuckovicTT @sdjordjevicTT @mtopalovicTT @jserbedzijaTT @azecevicTT
-/test/ttmlir/EmitC/ @svuckovicTT @sdjordjevicTT @mtopalovicTT @jserbedzijaTT @azecevicTT
+/include/ttmlir/Conversion/TTIRToTTIRDecomposition/ @tenstorrent/forge-developers-mlir-core
+/include/ttmlir/Conversion/TTIRToTTNN/ @tenstorrent/forge-developers-mlir-core
+/include/ttmlir/Conversion/TTNNToEmitC/ @tenstorrent/forge-developers-mlir-core
+/lib/Conversion/TTIRToTTIRDecomposition/ @tenstorrent/forge-developers-mlir-core
+/lib/Conversion/TTIRToTTNN/ @tenstorrent/forge-developers-mlir-core
+/lib/Conversion/TTNNToEmitC/ @tenstorrent/forge-developers-mlir-core
+/test/ttmlir/Conversion/TTIRToTTIRDecomposition/ @tenstorrent/forge-developers-mlir-core
+/test/ttmlir/Conversion/TTIRToTTNN/ @tenstorrent/forge-developers-mlir-core
+/test/ttmlir/Conversion/TTNNToEmitC/ @tenstorrent/forge-developers-mlir-core
+/test/ttmlir/EmitC/ @tenstorrent/forge-developers-mlir-core
 
 # Metal Conversions
-/include/ttmlir/Conversion/TTIRToTTIRGeneric/ @nsmithtt @vroubtsovTT
-/lib/Conversion/TTIRToTTIRGeneric/ @nsmithtt @vroubtsovTT
-/test/ttmlir/Conversion/TTIRToTTIRGeneric/ @nsmithtt @vroubtsovTT
-/include/ttmlir/Conversion/TTIRToTTMetal/ @nsmithtt @vroubtsovTT
-/include/ttmlir/Conversion/TTKernelToEmitC/ @nsmithtt @vroubtsovTT
-/lib/Conversion/TTIRToTTMetal/ @nsmithtt @vroubtsovTT
-/lib/Conversion/TTKernelToEmitC/ @nsmithtt @vroubtsovTT
-/test/ttmlir/Conversion/TTKernelToEmitC/ @nsmithtt @vroubtsovTT
+/include/ttmlir/Conversion/TTIRToTTIRGeneric/ @tenstorrent/forge-developers-mlir-d2m
+/lib/Conversion/TTIRToTTIRGeneric/ @tenstorrent/forge-developers-mlir-d2m
+/test/ttmlir/Conversion/TTIRToTTIRGeneric/ @tenstorrent/forge-developers-mlir-d2m
+/include/ttmlir/Conversion/TTIRToTTMetal/ @tenstorrent/forge-developers-mlir-d2m
+/include/ttmlir/Conversion/TTKernelToEmitC/ @tenstorrent/forge-developers-mlir-d2m
+/lib/Conversion/TTIRToTTMetal/ @tenstorrent/forge-developers-mlir-d2m
+/lib/Conversion/TTKernelToEmitC/ @tenstorrent/forge-developers-mlir-d2m
+/test/ttmlir/Conversion/TTKernelToEmitC/ @tenstorrent/forge-developers-mlir-d2m
 
 # LLVM Dialect
 /include/ttmlir/Dialect/LLVM/ @vwellsTT @mtopalovicTT
@@ -68,24 +68,24 @@ LICENSE @nsmithtt
 /test/ttmlir/Dialect/LLVM/ @vwellsTT @mtopalovicTT
 
 # TT Dialect
-/include/ttmlir/Dialect/TT/ @sdjordjevicTT @nsmithtt @svuckovicTT @mtopalovicTT @mrakitaTT @jserbedzijaTT @azecevicTT
-/lib/Dialect/TT/ @sdjordjevicTT @nsmithtt @svuckovicTT @mtopalovicTT @mrakitaTT @jserbedzijaTT @azecevicTT
-/test/ttmlir/Dialect/TT/ @sdjordjevicTT @nsmithtt @svuckovicTT @mtopalovicTT @mrakitaTT @jserbedzijaTT @azecevicTT
+/include/ttmlir/Dialect/TT/ @tenstorrent/forge-developers-mlir-core @nsmithtt @mrakitaTT
+/lib/Dialect/TT/ @tenstorrent/forge-developers-mlir-core @nsmithtt @mrakitaTT
+/test/ttmlir/Dialect/TT/ @tenstorrent/forge-developers-mlir-core @nsmithtt @mrakitaTT
 
 # TTIR Dialect
-/include/ttmlir/Dialect/TTIR/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @mrakitaTT @jserbedzijaTT @azecevicTT
-/lib/Dialect/TTIR/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @mrakitaTT @jserbedzijaTT @azecevicTT
-/test/ttmlir/Dialect/TTIR/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @mrakitaTT @jserbedzijaTT @azecevicTT
+/include/ttmlir/Dialect/TTIR/ @tenstorrent/forge-developers-mlir-core @mrakitaTT
+/lib/Dialect/TTIR/ @tenstorrent/forge-developers-mlir-core @mrakitaTT
+/test/ttmlir/Dialect/TTIR/ @tenstorrent/forge-developers-mlir-core @mrakitaTT
 
 # Metal Dialects
-/include/ttmlir/Dialect/TTIR/IR/TTIRGeneric* @nsmithtt @vroubtsovTT
-/include/ttmlir/Dialect/TTKernel/ @nsmithtt @vroubtsovTT
-/include/ttmlir/Dialect/TTMetal/ @nsmithtt @vroubtsovTT
-/lib/Dialect/TTIR/Transforms/ @nsmithtt @vroubtsovTT
-/lib/Dialect/TTKernel/ @nsmithtt @vroubtsovTT
-/lib/Dialect/TTMetal/ @nsmithtt @vroubtsovTT
-/test/ttmlir/Dialect/TTKernel/ @nsmithtt @vroubtsovTT
-/test/ttmlir/Dialect/TTMetal/ @nsmithtt @vroubtsovTT
+/include/ttmlir/Dialect/TTIR/IR/TTIRGeneric* @tenstorrent/forge-developers-mlir-d2m
+/include/ttmlir/Dialect/TTKernel/ @tenstorrent/forge-developers-mlir-d2m
+/include/ttmlir/Dialect/TTMetal/ @tenstorrent/forge-developers-mlir-d2m
+/lib/Dialect/TTIR/Transforms/ @tenstorrent/forge-developers-mlir-d2m
+/lib/Dialect/TTKernel/ @tenstorrent/forge-developers-mlir-d2m
+/lib/Dialect/TTMetal/ @tenstorrent/forge-developers-mlir-d2m
+/test/ttmlir/Dialect/TTKernel/ @tenstorrent/forge-developers-mlir-d2m
+/test/ttmlir/Dialect/TTMetal/ @tenstorrent/forge-developers-mlir-d2m
 
 # TTIR Erase Inverse Ops Optimization Pass
 /include/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/ @LPanosTT @azecevicTT
@@ -93,52 +93,52 @@ LICENSE @nsmithtt
 /test/ttmlir/Dialect/TTIR/erase_inverse_ops/ @LPanosTT @azecevicTT
 
 # TTNN Dialects
-/include/ttmlir/Dialect/TTNN/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @jserbedzijaTT @azecevicTT
-/lib/Dialect/TTNN/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @jserbedzijaTT @jnie-TT @azecevicTT
-/test/ttmlir/Dialect/TTNN/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @jserbedzijaTT @azecevicTT
+/include/ttmlir/Dialect/TTNN/ @tenstorrent/forge-developers-mlir-core
+/lib/Dialect/TTNN/ @tenstorrent/forge-developers-mlir-core
+/test/ttmlir/Dialect/TTNN/ @tenstorrent/forge-developers-mlir-core
 
 # TTNN Utils
-/include/ttmlir/Dialect/TTNN/Utils/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @jserbedzijaTT @azecevicTT @odjuricicTT @rpavlovicTT
+/include/ttmlir/Dialect/TTNN/Utils/ @tenstorrent/forge-developers-mlir-core @rpavlovicTT
 
 # TTNN Optimizer
-/include/ttmlir/Dialect/TTNN/Analysis/ @odjuricicTT @rpavlovicTT @sdjordjevicTT
-/include/ttmlir/OpModel/ @arminaleTT @odjuricicTT @rpavlovicTT @sdjordjevicTT
-/include/ttmlir/Scheduler/ @odjuricicTT @rpavlovicTT @sdjordjevicTT
-/lib/Dialect/TTNN/Analysis/ @odjuricicTT @rpavlovicTT @sdjordjevicTT
-/lib/OpModel/ @arminaleTT @odjuricicTT @rpavlovicTT
-/lib/Scheduler/ @odjuricicTT @rpavlovicTT @sdjordjevicTT
-/test/ttmlir/Dialect/TTNN/optimizer/ @odjuricicTT @rpavlovicTT @sdjordjevicTT
-/test/ttmlir/Silicon/TTNN/**/optimizer/ @odjuricicTT @rpavlovicTT @sdjordjevicTT
-/test/unittests/Optimizer @odjuricicTT @rpavlovicTT @sdjordjevicTT
-/test/unittests/OpModel @arminaleTT @odjuricicTT @rpavlovicTT
-/test/unittests/TestScheduler/ @odjuricicTT @rpavlovicTT @sdjordjevicTT
+/include/ttmlir/Dialect/TTNN/Analysis/ @tenstorrent/forge-developers-mlir-optimizer
+/include/ttmlir/OpModel/ @tenstorrent/forge-developers-mlir-optimizer @arminaleTT
+/include/ttmlir/Scheduler/ @tenstorrent/forge-developers-mlir-optimizer
+/lib/Dialect/TTNN/Analysis/ @tenstorrent/forge-developers-mlir-optimizer
+/lib/OpModel/ @tenstorrent/forge-developers-mlir-optimizer @arminaleTT
+/lib/Scheduler/ @tenstorrent/forge-developers-mlir-optimizer
+/test/ttmlir/Dialect/TTNN/optimizer/ @tenstorrent/forge-developers-mlir-optimizer
+/test/ttmlir/Silicon/TTNN/**/optimizer/ @tenstorrent/forge-developers-mlir-optimizer
+/test/unittests/Optimizer @tenstorrent/forge-developers-mlir-optimizer
+/test/unittests/OpModel @tenstorrent/forge-developers-mlir-optimizer @arminaleTT
+/test/unittests/TestScheduler/ @tenstorrent/forge-developers-mlir-optimizer
 
 # LLVM Target
 /include/ttmlir/Target/LLVM/ @vwellsTT @mtopalovicTT
 /lib/Target/LLVM/ @vwellsTT @mtopalovicTT
 
 # Metal Target
-/include/ttmlir/Target/TTKernel/ @nsmithtt @vroubtsovTT
-/include/ttmlir/Target/TTMetal/ @nsmithtt @vroubtsovTT
-/lib/Target/TTKernel/ @nsmithtt @vroubtsovTT
-/lib/Target/TTMetal/ @nsmithtt @vroubtsovTT
+/include/ttmlir/Target/TTKernel/ @tenstorrent/forge-developers-mlir-d2m
+/include/ttmlir/Target/TTMetal/ @tenstorrent/forge-developers-mlir-d2m
+/lib/Target/TTKernel/ @tenstorrent/forge-developers-mlir-d2m
+/lib/Target/TTMetal/ @tenstorrent/forge-developers-mlir-d2m
 
 # TTNN Target
-/include/ttmlir/Target/TTNN/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @jserbedzijaTT @azecevicTT
-/lib/Target/TTNN/ @sdjordjevicTT @svuckovicTT @mtopalovicTT @jserbedzijaTT @azecevicTT
+/include/ttmlir/Target/TTNN/ @tenstorrent/forge-developers-mlir-core
+/lib/Target/TTNN/ @tenstorrent/forge-developers-mlir-core
 
 # Runtime
-/runtime/ @jnie-TT @kmabeeTT @AleksKnezevic @pilkicTT
+/runtime/ @tenstorrent/forge-developers-mlir-runtime
 /runtime/tools/ @tapspatel @ctodTT
 
 # TTIRBuilder
 /python/test_infra @ctodTT @tapspatel
 
 # tt-explorer
-/tools/explorer/ @tapspatel @odjuricicTT @vprajapati-tt @vcanicTT
+/tools/explorer/ @tenstorrent/forge-developers-mlir-explorer
 
 # ttnn-standalone
-/tools/ttnn-standalone @svuckovicTT @mtopalovicTT @sdjordjevicTT @azecevicTT @jserbedzijaTT
+/tools/ttnn-standalone @tenstorrent/forge-developers-mlir-core
 
 # Scripts
 /tools/scripts/ @nsmithtt @ddilbazTT

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,13 +36,13 @@ LICENSE @nsmithtt
 /test/ttmlir/Conversion/TTIRToLinalg/ @vwellsTT @ctodTT @nsmithTT
 
 # Tosa Conversion
-/include/ttmlir/Conversion/TosaToTTIR/ @mrakitaTT @sgligorijevicTT @sdjukicTT
-/lib/Conversion/TosaToTTIR/ @mrakitaTT @sgligorijevicTT @sdjukicTT
-/test/ttmlir/Conversion/TosaToTTIR/ @mrakitaTT @sgligorijevicTT @sdjukicTT
+/include/ttmlir/Conversion/TosaToTTIR/ @tenstorrent/forge-developers-mlir-tosa
+/lib/Conversion/TosaToTTIR/ @tenstorrent/forge-developers-mlir-tosa
+/test/ttmlir/Conversion/TosaToTTIR/ @tenstorrent/forge-developers-mlir-tosa
 
 # TTNN Conversions
 /include/ttmlir/Conversion/TTIRToTTIRDecomposition/ @tenstorrent/forge-developers-mlir-core
-/include/ttmlir/Conversion/TTIRToTTNN/ @tenstorrent/forge-developers-mlir-core
+/include/ttmlir/Conversion/TTIRToTTNN/ @tenstorrent/forge-developers-mlir-core @jnie-TT
 /include/ttmlir/Conversion/TTNNToEmitC/ @tenstorrent/forge-developers-mlir-core
 /lib/Conversion/TTIRToTTIRDecomposition/ @tenstorrent/forge-developers-mlir-core
 /lib/Conversion/TTIRToTTNN/ @tenstorrent/forge-developers-mlir-core

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,7 +20,7 @@ LICENSE @nsmithtt
 /include/ttmlir-c/ @ctodTT @tapspatel @vprajapati-tt @vcanicTT
 /lib/CAPI/ @ctodTT @tapspatel @vprajapati-tt @vcanicTT
 /python/ @ctodTT @tapspatel @vprajapati-tt @vcanicTT
-/python/pykernel/ @vtangTT @xanderchin
+/python/pykernel/ @xanderchin @vprajapati-tt
 
 # StableHLO Conversion
 /include/ttmlir/Conversion/ArithToStableHLO/ @tenstorrent/forge-developers-mlir-stablehlo

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,12 +23,12 @@ LICENSE @nsmithtt
 /python/pykernel/ @vtangTT @xanderchin
 
 # StableHLO Conversion
-/include/ttmlir/Conversion/ArithToStableHLO/ @mrakitaTT @mmanzoorTT @wooseokTT @azecevicTT
-/include/ttmlir/Conversion/StableHLOToTTIR/ @mrakitaTT @mmanzoorTT @wooseokTT @azecevicTT
-/lib/Conversion/StableHLOToTTIR/ @mrakitaTT @mmanzoorTT @wooseokTT @azecevicTT
-/test/ttmlir/Conversion/ArithToStableHLO/ @mrakitaTT @mmanzoorTT @wooseokTT @azecevicTT
-/test/ttmlir/Conversion/StableHLOToTTIR/ @mrakitaTT @mmanzoorTT @wooseokTT @azecevicTT
-/test/ttmlir/Silicon/StableHLO/ @mrakitaTT @mmanzoorTT @wooseokTT @azecevicTT
+/include/ttmlir/Conversion/ArithToStableHLO/ @tenstorrent/forge-developers-mlir-stablehlo
+/include/ttmlir/Conversion/StableHLOToTTIR/ @tenstorrent/forge-developers-mlir-stablehlo
+/lib/Conversion/StableHLOToTTIR/ @tenstorrent/forge-developers-mlir-stablehlo
+/test/ttmlir/Conversion/ArithToStableHLO/ @tenstorrent/forge-developers-mlir-stablehlo
+/test/ttmlir/Conversion/StableHLOToTTIR/ @tenstorrent/forge-developers-mlir-stablehlo
+/test/ttmlir/Silicon/StableHLO/ @tenstorrent/forge-developers-mlir-stablehlo
 
 # Linalg Conversion
 /include/ttmlir/Conversion/TTIRToLinalg/ @vwellsTT @ctodTT @nsmithTT
@@ -36,9 +36,9 @@ LICENSE @nsmithtt
 /test/ttmlir/Conversion/TTIRToLinalg/ @vwellsTT @ctodTT @nsmithTT
 
 # Tosa Conversion
-/include/ttmlir/Conversion/TosaToTTIR/ @tenstorrent/forge-developers-mlir-stablehlo
-/lib/Conversion/TosaToTTIR/ @tenstorrent/forge-developers-mlir-stablehlo
-/test/ttmlir/Conversion/TosaToTTIR/ @tenstorrent/forge-developers-mlir-stablehlo
+/include/ttmlir/Conversion/TosaToTTIR/ @mrakitaTT @sgligorijevicTT @sdjukicTT
+/lib/Conversion/TosaToTTIR/ @mrakitaTT @sgligorijevicTT @sdjukicTT
+/test/ttmlir/Conversion/TosaToTTIR/ @mrakitaTT @sgligorijevicTT @sdjukicTT
 
 # TTNN Conversions
 /include/ttmlir/Conversion/TTIRToTTIRDecomposition/ @tenstorrent/forge-developers-mlir-core


### PR DESCRIPTION
### Ticket
N/A

### Problem description
N/A

### What's changed
@staylorTT has added [mlir teams](https://github.com/orgs/tenstorrent/teams/forge/teams) within the github tenstorrent org - these are all the teams prefixed with `forge-developers-mlir-`. This PR changes CODEOWNERS to use teams instead of personal aliases, where possible.

This change will make it easier to track which groups of people are needed to review PRs.

Let's keep a working list of teams here so that folks can edit - when we're ready, we'll then update the teams in github and mark this PR as ready. Comment on the CODEOWNERS file as well where needed, and please let me know if we need to add/remove some teams, and @staylorTT will happily jump in to lend a hand :)

List of teams:
- forge-developers-mlir-build - @nsmithtt @mtopalovicTT @vwellsTT
- forge-developers-mlir-core - @sdjordjevicTT @svuckovicTT @mtopalovicTT @jserbedzijaTT @azecevicTT
- forge-developers-mlir-d2m - @nsmithtt @vroubtsovTT @phizalev-TT 
- forge-developers-mlir-devops - @vmilosevic @jmcgrathTT @nsumrakTT
- forge-developers-mlir-explorer - @tapspatel @odjuricicTT @vprajapati-tt @vcanicTT
- forge-developers-mlir-multidevice -
- forge-developers-mlir-optimizer - @odjuricicTT @rpavlovicTT @sdjordjevicTT
- forge-developers-mlir-runtime - @jnie-TT @kmabeeTT @AleksKnezevic @pilkicTT
- forge-developers-mlir-stablehlo - @mrakitaTT @mmanzoorTT @wooseokTT @azecevicTT
- forge-developers-mlir-tosa - @mrakitaTT @sgligorijevicTT @sdjukicTT @azecevicTT

### Checklist
- [ ] New/Existing tests provide coverage for changes
