### PR TITLE
Add a workaround to perform WhereOp in float32

### DIFF
--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -343,7 +343,7 @@ TTNNOperandsWorkaroundsFactory::createWhereOpOperandsWorkarounds(
   mlir::Type inputElementType = inputType.getElementType();
   TTNNOperandWorkarounds typeWorkaround = TTNNOperandWorkarounds();
   if(predicateElementType.isInteger() || inputElementType.isInteger()) {
-    typeWorkaround = TTNNOperandWorkarounds(DataType::BFLOAT16);
+    typeWorkaround = TTNNOperandWorkarounds(DataType::BFloat16);
   } else {
     if (predicateElementType != inputElementType) {
       typeWorkaround =

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -342,11 +342,11 @@ TTNNOperandsWorkaroundsFactory::createWhereOpOperandsWorkarounds(
       mlir::cast<RankedTensorType>(inputs.back().getType());
   mlir::Type inputElementType = inputType.getElementType();
   TTNNOperandWorkarounds typeWorkaround = TTNNOperandWorkarounds();
-  if(predicateElementType.isInteger() || inputElementType.isInteger()) {
+  if (predicateElementType.isInteger() || inputElementType.isInteger()) {
     typeWorkaround = TTNNOperandWorkarounds(DataType::Float32);
   } else if (predicateElementType != inputElementType) {
-      typeWorkaround =
-          TTNNOperandWorkarounds(elementTypeToDataType(inputElementType));
+    typeWorkaround =
+        TTNNOperandWorkarounds(elementTypeToDataType(inputElementType));
   }
 
   return TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -344,11 +344,9 @@ TTNNOperandsWorkaroundsFactory::createWhereOpOperandsWorkarounds(
   TTNNOperandWorkarounds typeWorkaround = TTNNOperandWorkarounds();
   if(predicateElementType.isInteger() || inputElementType.isInteger()) {
     typeWorkaround = TTNNOperandWorkarounds(DataType::BFloat16);
-  } else {
-    if (predicateElementType != inputElementType) {
+  } else if (predicateElementType != inputElementType) {
       typeWorkaround =
           TTNNOperandWorkarounds(elementTypeToDataType(inputElementType));
-      }
   }
 
   return TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -328,7 +328,7 @@ TTNNOperandsWorkaroundsFactory::createConstantOpOperandsWorkarounds() {
 // tt-metal issue to track mixed data types ops bug.
 // https://github.com/tenstorrent/tt-metal/issues/17998
 // Where also does not work with int32
-// so we also force everything to bfloat16 in that case
+// so we also force everything to float32 in that case
 // https://github.com/tenstorrent/tt-mlir/issues/3154
 TTNNOperandsWorkarounds
 TTNNOperandsWorkaroundsFactory::createWhereOpOperandsWorkarounds(
@@ -343,7 +343,7 @@ TTNNOperandsWorkaroundsFactory::createWhereOpOperandsWorkarounds(
   mlir::Type inputElementType = inputType.getElementType();
   TTNNOperandWorkarounds typeWorkaround = TTNNOperandWorkarounds();
   if(predicateElementType.isInteger() || inputElementType.isInteger()) {
-    typeWorkaround = TTNNOperandWorkarounds(DataType::BFloat16);
+    typeWorkaround = TTNNOperandWorkarounds(DataType::Float32);
   } else if (predicateElementType != inputElementType) {
       typeWorkaround =
           TTNNOperandWorkarounds(elementTypeToDataType(inputElementType));

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -327,6 +327,9 @@ TTNNOperandsWorkaroundsFactory::createConstantOpOperandsWorkarounds() {
 // type does not match with input.
 // tt-metal issue to track mixed data types ops bug.
 // https://github.com/tenstorrent/tt-metal/issues/17998
+// Where also does not work with int32
+// so we also force everything to bfloat16 in that case
+// https://github.com/tenstorrent/tt-mlir/issues/3154
 TTNNOperandsWorkarounds
 TTNNOperandsWorkaroundsFactory::createWhereOpOperandsWorkarounds(
     mlir::Operation::operand_range inputs) {
@@ -338,10 +341,15 @@ TTNNOperandsWorkaroundsFactory::createWhereOpOperandsWorkarounds(
   mlir::RankedTensorType inputType =
       mlir::cast<RankedTensorType>(inputs.back().getType());
   mlir::Type inputElementType = inputType.getElementType();
-  TTNNOperandWorkarounds typeWorkaround =
-      predicateElementType != inputElementType
-          ? TTNNOperandWorkarounds(elementTypeToDataType(inputElementType))
-          : TTNNOperandWorkarounds();
+  TTNNOperandWorkarounds typeWorkaround = TTNNOperandWorkarounds();
+  if(predicateElementType.isInteger() || inputElementType.isInteger()) {
+    typeWorkaround = TTNNOperandWorkarounds(DataType::BFLOAT16);
+  } else {
+    if (predicateElementType != inputElementType) {
+      typeWorkaround =
+          TTNNOperandWorkarounds(elementTypeToDataType(inputElementType));
+      }
+  }
 
   return TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
       .addInputOperandWorkaround(typeWorkaround)


### PR DESCRIPTION
### Ticket
Related: #3154 

### Problem description
WhereOp gives all zeros when ran using int32 datatype.

### What's changed
Added a workaround to cast both the predicate and the inputs to bfloat16 using the workarounds pass.

### Checklist
- [ ] New/Existing tests provide coverage for changes
