### PR TITLE
Add workaround for int broadcasting in 'Add' op

### DIFF
--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -394,8 +394,23 @@ static std::optional<DataType> binaryOpDTypeWorkaround(mlir::Operation *op,
 
   if (isa<ttnn::AddOp, ttnn::SubtractOp>(op)) {
     if (dType == DataType::Float32 || dType == DataType::BFloat16 ||
-        dType == DataType::BFP_BFloat8 || dType == DataType::BFP_BFloat4 ||
-        dType == DataType::Int32) {
+        dType == DataType::BFP_BFloat8 || dType == DataType::BFP_BFloat4) {
+      return {};
+    }
+    if (dType == DataType::Int32) {
+      // Although TTNN claims to support int32 for Add and Subtract ops,
+      // broadcasting with int32 inputs does not currently work as expected.
+      // As a temporary workaround, we fall back to BFloat16 when input shapes
+      // differ. This should be removed once int32 broadcasting is properly
+      // supported.
+      auto lhsType =
+          mlir::cast<mlir::RankedTensorType>(op->getOperand(0).getType());
+      auto rhsType =
+          mlir::cast<mlir::RankedTensorType>(op->getOperand(1).getType());
+
+      if (lhsType.getShape() != rhsType.getShape()) {
+        return DataType::BFloat16;
+      }
       return {};
     }
     return DataType::BFloat16;

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/add_integer_broadcasting_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/add_integer_broadcasting_workaround.mlir
@@ -1,0 +1,18 @@
+// RUN: ttmlir-opt --tt-register-device --ttnn-workaround %s | FileCheck %s
+
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 128 + d1 * 128 + d2, d3), <1x1>, memref<4x4x!tt.tile<32x32, si32>, #dram>, <interleaved>>
+#ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1 * 32 + d2, d3), <1x1>, memref<1x4x!tt.tile<32x32, si32>, #dram>, <interleaved>>
+#ttnn_layout2 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 128 + d1 * 128 + d2, d3), <1x1>, memref<4x4x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
+module attributes {} {
+  func.func @add_integer_broadcast(%arg0: tensor<1x1x1x128xsi32,#ttnn_layout1>, %arg1: tensor<1x1x128x128xsi32,#ttnn_layout>) -> tensor<1x1x128x128xbf16,#ttnn_layout2> {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+    // CHECK: "ttnn.add"
+    // CHECK-SAME: tensor<1x1x1x128xbf16
+    // CHECK-SAME: tensor<1x1x128x128xbf16
+    // CHECK-SAME: tensor<1x1x128x128xbf16
+    %1 = "ttnn.add"(%arg0, %arg1) : (tensor<1x1x1x128xsi32,#ttnn_layout1>, tensor<1x1x128x128xsi32,#ttnn_layout>) -> tensor<1x1x128x128xsi32,#ttnn_layout>
+    %2 = "ttnn.to_layout"(%1, %0) <{dtype = #tt.supportedDataTypes<si32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <<4x4>>, <interleaved>>}> : (tensor<1x1x128x128xsi32, #ttnn_layout>, !ttnn.device) -> tensor<1x1x128x128xbf16, #ttnn_layout2>
+    return %2 : tensor<1x1x128x128xbf16,#ttnn_layout2>
+  }
+}


### PR DESCRIPTION
### Ticket
[#489](https://github.com/tenstorrent/tt-torch/issues/489) in tt-torch

### Problem description
TTNN currently fails to handle broadcasting for int32 inputs in the `add` op, which is used internally to represent `expand` operations. When an `expand` op with int32 is lowered to `add` with broadcasting, execution does not work as expected.

### What's changed
As a temporary workaround, inputs are converted to bfloat16 when shapes differ. This should be removed once TTNN properly supports broadcasting for int.

### Checklist
- [x] full evaluation of bert model
