### PR TITLE
docker habor pull through cache and preserve original docker tag

### DIFF
--- a/.github/build-docker-images.sh
+++ b/.github/build-docker-images.sh
@@ -44,8 +44,9 @@ build_and_push() {
 
     # If we are on main branch also push the latest tag
     if [ "$on_main" = "true" ]; then
-        docker manifest create $image_name:latest --amend $image_name:$DOCKER_TAG
-        docker manifest push $image_name:latest
+        printf "\nPushing latest tag for $image_name"
+        # Used to push both tags in one command on the original sha256 sum layer remotely (docker create manifest create a new sha256 sum only with only with new tag)
+        docker buildx imagetools create $image_name:$DOCKER_TAG --tag $image_name:latest --tag $image_name:$DOCKER_TAG
     fi
 }
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -34,12 +34,13 @@ jobs:
     runs-on:
       - builder
     outputs:
+      docker-image-harbor: ${{ steps.build.outputs.docker-image-harbor }}
       docker-image: ${{ steps.build.outputs.docker-image }}
     steps:
 
       - name: Fix permissions
         shell: bash
-        run: sudo chown ubuntu:ubuntu -R $(pwd)
+        run: sudo chown ubuntu:ubuntu -R $(pwd) || true
 
       - uses: actions/checkout@v4
         with:
@@ -61,6 +62,7 @@ jobs:
           .github/build-docker-images.sh | tee docker.log
           DOCKER_CI_IMAGE=$(tail -n 1 docker.log)
           echo "DOCKER_CI_IMAGE $DOCKER_CI_IMAGE"
+          echo "docker-image-harbor=harbor.ci.tenstorrent.net/$DOCKER_CI_IMAGE" >> "$GITHUB_OUTPUT"
           echo "docker-image=$DOCKER_CI_IMAGE" >> "$GITHUB_OUTPUT"
 
   # Build tt-mlir images
@@ -147,44 +149,43 @@ jobs:
       fail-fast: false
       matrix:
         build: [
-          {runs-on: n150,   name: "run",  suite: "unit",              image: "speedy", type: "unit",    container-options: "--device /dev/tenstorrent/0"},
-          {runs-on: nXX0,   name: "run",  suite: "unit",              image: "tracy",  type: "unit",    container-options: "--device /dev/tenstorrent/0"},
-          {runs-on: n150,   name: "run",  suite: "run",               image: "speedy", type: "ttrt",    path: "Silicon", flags: "--non-zero", container-options: "--device /dev/tenstorrent/0"},
-          {runs-on: n150,   name: "perf", suite: "perf",              image: "tracy",  type: "ttrt",    path: "Silicon/TTNN/n150/perf", container-options: "--device /dev/tenstorrent/0"},
-          {runs-on: n150,   name: "perf", suite: "optimizer",         image: "tracy",  type: "ttrt",    path: "Silicon/TTNN/n150/optimizer", container-options: "--device /dev/tenstorrent/0"},
-          {runs-on: n150,   name: "run",  suite: "emitc",             image: "tracy",  type: "ttrt",    path: "EmitC", flags: "--emitc", container-options: "--device /dev/tenstorrent/0"},
-          {runs-on: n150,   name: "run",  suite: "op_model",          image: "speedy", type: "ttrt",    path: "Silicon/TTNN/n150/optimizer", flags: "--non-zero", container-options: "--device /dev/tenstorrent/0"},
-          {runs-on: n150,   name: "run",  suite: "runtime_debug",     image: "tracy",  type: "ttrt",    path: "Silicon", flags: "--non-zero", container-options: "--device /dev/tenstorrent/0"},
-          {runs-on: n300,   name: "run",  suite: "run",               image: "speedy", type: "ttrt",    path: "Silicon", flags: "--non-zero", container-options: "--device /dev/tenstorrent/0"},
-          {runs-on: n300,   name: "perf", suite: "perf",              image: "tracy",  type: "ttrt",    path: "Silicon/TTNN/n300/perf", container-options: "--device /dev/tenstorrent/0"},
-          {runs-on: llmbox, name: "run",  suite: "run",               image: "speedy", type: "ttrt",    path: "Silicon", flags: "--non-zero", container-options: "--device /dev/tenstorrent/0 --device /dev/tenstorrent/1 --device /dev/tenstorrent/2 --device /dev/tenstorrent/3"},
-          {runs-on: llmbox, name: "perf", suite: "perf",              image: "tracy",  type: "ttrt",    path: "Silicon/TTNN/llmbox/perf", container-options: "--device /dev/tenstorrent/0 --device /dev/tenstorrent/1 --device /dev/tenstorrent/2 --device /dev/tenstorrent/3"},
-          {runs-on: n150,   name: "run",  suite: "consteval",         image: "speedy", type: "ttrt",    path: "test/python/const-eval", ttrt_flags: "--loops 5 --dirty-tensor-schedule=0:2,1:1,3:1,3:3 --check-cache-stats=hits:2,misses:3 --artifact-dir=ttrt-artifacts/const-eval", container-options: "--device /dev/tenstorrent/0"},
-          # {runs-on: tg,     name: "run",  suite: "run",             image: "speedy", type: "ttrt",    path: "Silicon", ttrt_flags: "--non-zero --disable-eth-dispatch", container-options: "--device /dev/tenstorrent/0 --device /dev/tenstorrent/1 --device /dev/tenstorrent/2 --device /dev/tenstorrent/3"},
-          # {runs-on: tg,     name: "perf", suite: "perf",            image: "tracy",  type: "ttrt",    path: "Silicon/TTNN/tg/perf", ttrt_flags: "--disable-eth-dispatch", container-options: "--device /dev/tenstorrent/0 --device /dev/tenstorrent/1 --device /dev/tenstorrent/2 --device /dev/tenstorrent/3"},
-          {runs-on: n150,   name: "perf", suite: "perf",              image: "tracy",  type: "pytest",  path: "runtime/tools/ttrt/test", container-options: "--device /dev/tenstorrent/0"},
-          {runs-on: n150,   name: "run",  suite: "op_golden",         image: "tracy",  type: "builder",  path: "test/python/golden/test_ttir_ops.py", flags: "-m \"not run_error and not fails_golden\"", run-ttrt: true, container-options: "--device /dev/tenstorrent/0"},
-          {runs-on: n150,   name: "run",  suite: "model_golden",      image: "tracy",  type: "builder",  path: "test/python/golden/test_ttir_models.py", flags: "-m \"not run_error and not fails_golden\"", run-ttrt: true, container-options: "--device /dev/tenstorrent/0"},
-          {runs-on: n150,   name: "run",  suite: "op_compile",        image: "tracy",  type: "builder",  path: "test/python/golden/test_ttir_ops.py", flags: "-m \"run_error or fails_golden\"", run-ttrt: false, container-options: "--device /dev/tenstorrent/0"},
-          {runs-on: n150,   name: "run",  suite: "model_compile",     image: "tracy",  type: "builder",  path: "test/python/golden/test_ttir_models.py", flags: "-m \"run_error or fails_golden\"", run-ttrt: false, container-options: "--device /dev/tenstorrent/0"},
-          {runs-on: n300,   name: "run",  suite: "op_golden",         image: "tracy",  type: "builder",  path: "test/python/golden/test_ttir_ops_n300.py", flags: "-m \"not run_error and not fails_golden\"", run-ttrt: true, container-options: "--device /dev/tenstorrent/0"},
-          {runs-on: llmbox,   name: "run",  suite: "op_golden",         image: "tracy",  type: "builder",  path: "test/python/golden/test_ttir_ops_llmbox.py", flags: "-m \"not run_error and not fails_golden\"", run-ttrt: true, container-options: "--device /dev/tenstorrent/0 --device /dev/tenstorrent/1 --device /dev/tenstorrent/2 --device /dev/tenstorrent/3"},
+          # When sh-run is true, the runner will use TT-shared GH infra and pull from harbor for image cache pull through
+          {runs-on: n150,   sh-run: false, name: "run",   suite: "unit",               image: "speedy", type: "unit"},
+          {runs-on: nXX0,   sh-run: false, name: "run",  suite: "unit",              image: "tracy",  type: "unit"},
+          {runs-on: n150,   sh-run: true, name: "run",  suite: "run",               image: "speedy", type: "ttrt",     path: "Silicon", flags: "--non-zero"},
+          {runs-on: n150,   sh-run: false, name: "perf", suite: "perf",              image: "tracy",  type: "ttrt",     path: "Silicon/TTNN/n150/perf"},
+          {runs-on: n150,   sh-run: false, name: "perf", suite: "optimizer",         image: "tracy",  type: "ttrt",     path: "Silicon/TTNN/n150/optimizer"},
+          {runs-on: n150,   sh-run: false, name: "run",  suite: "emitc",             image: "tracy",  type: "ttrt",     path: "EmitC", flags: "--emitc"},
+          {runs-on: n150,   sh-run: false, name: "run",  suite: "op_model",          image: "speedy", type: "ttrt",     path: "Silicon/TTNN/n150/optimizer", flags: "--non-zero"},
+          {runs-on: n150,   sh-run: false, name: "run",  suite: "runtime_debug",     image: "tracy",  type: "ttrt",     path: "Silicon", flags: "--non-zero"},
+          {runs-on: n300,   sh-run: true, name: "run",  suite: "run",               image: "speedy", type: "ttrt",     path: "Silicon", flags: "--non-zero"},
+          {runs-on: n300,   sh-run: false, name: "perf", suite: "perf",              image: "tracy",  type: "ttrt",     path: "Silicon/TTNN/n300/perf"},
+          {runs-on: llmbox, sh-run: false, name: "run",  suite: "run",               image: "speedy", type: "ttrt",     path: "Silicon", flags: "--non-zero"},
+          {runs-on: llmbox, sh-run: false, name: "perf", suite: "perf",              image: "tracy",  type: "ttrt",     path: "Silicon/TTNN/llmbox/perf"},
+          {runs-on: n150,   sh-run: false, name: "run",  suite: "consteval",         image: "speedy", type: "ttrt",     path: "test/python/const-eval", ttrt_flags: "--loops 5 --dirty-tensor-schedule=0:2,1:1,3:1,3:3 --check-cache-stats=hits:2,misses:3 --artifact-dir=ttrt-artifacts/const-eval"},
+          # {runs-on: tg,     sh-run: false, name: "run",  suite: "run",               image: "speedy", type: "ttrt",     path: "Silicon", ttrt_flags: "--non-zero --disable-eth-dispatch"},
+          # {runs-on: tg,     sh-run: false, name: "perf", suite: "perf",              image: "tracy",  type: "ttrt",     path: "Silicon/TTNN/tg/perf", ttrt_flags: "--disable-eth-dispatch"},
+          {runs-on: n150,   sh-run: false, name: "perf", suite: "perf",              image: "tracy",  type: "pytest",   path: "runtime/tools/ttrt/test"},
+          {runs-on: n150,   sh-run: false, name: "run",  suite: "op_golden",         image: "tracy",  type: "builder",  path: "test/python/golden/test_ttir_ops.py", flags: "-m \"not run_error and not fails_golden\"", run-ttrt: true},
+          {runs-on: n150,   sh-run: false, name: "run",  suite: "model_golden",      image: "tracy",  type: "builder",  path: "test/python/golden/test_ttir_models.py", flags: "-m \"not run_error and not fails_golden\"", run-ttrt: true},
+          {runs-on: n150,   sh-run: false, name: "run",  suite: "op_compile",        image: "tracy",  type: "builder",  path: "test/python/golden/test_ttir_ops.py", flags: "-m \"run_error or fails_golden\"", run-ttrt: false},
+          {runs-on: n150,   sh-run: false, name: "run",  suite: "model_compile",     image: "tracy",  type: "builder",  path: "test/python/golden/test_ttir_models.py", flags: "-m \"run_error or fails_golden\"", run-ttrt: false},
+          {runs-on: n300,   sh-run: false, name: "run",  suite: "op_golden",         image: "tracy",  type: "builder",  path: "test/python/golden/test_ttir_ops_n300.py", flags: "-m \"not run_error and not fails_golden\"", run-ttrt: true},
+          {runs-on: llmbox, sh-run: false, name: "run",   suite: "op_golden",         image: "tracy",  type: "builder",  path: "test/python/golden/test_ttir_ops_llmbox.py", flags: "-m \"not run_error and not fails_golden\"", run-ttrt: true},
           # Although these runtime tests are device agnostic, they depend on n150 compiled mlir artifacts
           # Therefore running these tests on n150 specifically
-          {runs-on: n150,   name: "run",  suite: "ttnn_runtime",      image: "speedy", type: "pytest",  path: "runtime/test/python/ttnn/device_agnostic", container-options: "--device /dev/tenstorrent/0"},
-          {runs-on: n150,   name: "perf", suite: "explorer",          image: "tracy",  type: "pytest",  path: "tools/explorer/test/run_tests.py", container-options: "--device /dev/tenstorrent/0"},
-          {runs-on: n150,   name: "run",  suite: "op_by_op_infra",    image: "tracy",  type: "pytest",  path: "test/python/op_by_op_infra",            container-options: "--device /dev/tenstorrent/0"},
-          {runs-on: n300,   name: "run",  suite: "ttnn_runtime",      image: "speedy", type: "pytest",  path: "runtime/test/python/ttnn/multi_device", container-options: "--device /dev/tenstorrent/0"},
+          {runs-on: n150,   sh-run: false, name: "run",  suite: "ttnn_runtime",      image: "speedy", type: "pytest",  path: "runtime/test/python/ttnn/device_agnostic"},
+          {runs-on: n150,   sh-run: false, name: "perf", suite: "explorer",          image: "tracy",  type: "pytest",  path: "tools/explorer/test/run_tests.py"},
+          {runs-on: n150,   sh-run: false, name: "run",  suite: "op_by_op_infra",    image: "tracy",  type: "pytest",  path: "test/python/op_by_op_infra"},
+          {runs-on: n300,   sh-run: false, name: "run",  suite: "ttnn_runtime",      image: "speedy", type: "pytest",  path: "runtime/test/python/ttnn/multi_device"},
         ]
     name: "run-tests (${{ matrix.build.runs-on }},${{ matrix.build.image }},${{ matrix.build.suite }},${{ matrix.build.type }},${{ strategy.job-index }})"
 
-    runs-on:
-      - in-service
-      - ${{ matrix.build.runs-on }}
+    runs-on: ${{ matrix.build.sh-run && format('tt-beta-ubuntu-2204-{0}-large-stable', matrix.build.runs-on) || fromJson(format('["{0}", "in-service"]', matrix.build.runs-on)) }}
 
     container:
-      image: ${{ needs.build-image.outputs.docker-image }}
-      options: ${{ matrix.build.container-options }}
+      image: ${{ matrix.build.sh-run && needs.build-image.outputs.docker-image-harbor || needs.build-image.outputs.docker-image }}
+      options: ${{ matrix.build.container-options || '--device /dev/tenstorrent' }}
       volumes:
         - /dev/hugepages:/dev/hugepages
         - /dev/hugepages-1G:/dev/hugepages-1G


### PR DESCRIPTION

### Problem description
- Fixed the issue where the latest tag would overwrite the original docker tag. Now, it appends the newest tag and perverse the original tag. This had a chance of causing cache thrashing for other PRs when merged to the main.

- Added configured to load shed n150 runners (need to wait for capacity from GHA infra team)

#### Test with shared GitHub v2 runner.
https://github.com/tenstorrent/tt-mlir/actions/runs/14842530718/job/41761015424#step:3:18
