### PR TITLE
Fix docs CI build

### DIFF
--- a/include/ttmlir/Dialect/TTMetal/IR/CMakeLists.txt
+++ b/include/ttmlir/Dialect/TTMetal/IR/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_mlir_dialect(TTMetalOps ttmetal)
 add_mlir_doc(TTMetalBase TTMetalDialect src/autogen/md/Dialect/ -gen-dialect-doc)
 add_mlir_doc(TTMetalOps TTMetalOp src/autogen/md/Dialect/ -gen-op-doc)
-add_mlir_doc(TTMetalOpsBaseAttrs TTMetalBaseAttrs src/autogen/md/Dialect/ -gen-attrdef-doc)
 add_mlir_doc(TTMetalOpsAttrs TTMetalAttrs src/autogen/md/Dialect/ -gen-attrdef-doc)
 
 set(LLVM_TARGET_DEFINITIONS TTMetalAttrInterfaces.td)


### PR DESCRIPTION
Removed `TTMetalBaseAttrs` generation from `TTMetalOpsBaseAttrs.td` that doesn't exist.