### PR TITLE
#2959: Add support for measuring e2e perf from ttrt.

### DIFF
--- a/runtime/tools/ttrt/test/test_run.py
+++ b/runtime/tools/ttrt/test/test_run.py
@@ -308,3 +308,15 @@ def test_enable_async_ttnn_run():
 def test_enable_async_ttnn_cmd_run():
     command = f"ttrt run {BINARY_FILE_PATH} --log-file ttrt-results/{inspect.currentframe().f_code.co_name}.log --result-file ttrt-results/{inspect.currentframe().f_code.co_name}.json"
     sub_process_command(command)
+
+
+def test_benchmark_run():
+    API.initialize_apis()
+    custom_args = {}
+    custom_args[
+        "--result-file"
+    ] = f"ttrt-results/{inspect.currentframe().f_code.co_name}.json"
+    custom_args["binary"] = BINARY_FILE_PATH
+    custom_args["--benchmark"] = True
+    run_instance = API.Run(args=custom_args)
+    run_instance()

--- a/runtime/tools/ttrt/ttrt/common/util.py
+++ b/runtime/tools/ttrt/ttrt/common/util.py
@@ -650,6 +650,7 @@ class Binary(Flatbuffer):
         self.fbb_dict = ttrt.binary.as_dict(self.fbb)
         self.version = self.fbb.version
         self.programs = []
+        self.e2e_duration_milliseconds = 0
 
         for i in range(len(self.fbb_dict["programs"])):
             program = Binary.Program(i, self.fbb_dict["programs"][i])


### PR DESCRIPTION
Issue: https://github.com/tenstorrent/tt-mlir/issues/2959

Usage
```
ttrt run <flatbuffer>
```

This will populate a host duration time per op in the results.json file

run_results.json
```
[
  {
    "file_path": "/code/tt-mlir/build/test/ttmlir/Silicon/TTNN/n300/ccl/Output/ccl_1x2_all_gather.mlir.tmp.ttnn",
    "result": "pass",
    "exception": "",
    "log_file": "",
    "artifacts": "/code/tt-mlir/ttrt-artifacts",
    "program_index": "all",
    "e2e_duration_milliseconds": 19785.75575305149
  }
]
```