### PR TITLE
Fix const-eval bug for case where subgraphs only share creation op

### DIFF
--- a/lib/Transforms/ConstEvalHoist.cpp
+++ b/lib/Transforms/ConstEvalHoist.cpp
@@ -245,6 +245,10 @@ private:
     // Add creation ops to the subgraph as well
     for (Operation *creationOp : creationOps) {
       opToSubgraphMap[creationOp] = targetSubgraphId;
+      // Also map the creation op's results
+      for (auto result : creationOp->getResults()) {
+        valueToSubgraphMap[result] = targetSubgraphId;
+      }
     }
 
     // Store input parameters for this subgraph

--- a/test/ttmlir/Dialect/TTNN/const-eval/const-eval.mlir
+++ b/test/ttmlir/Dialect/TTNN/const-eval/const-eval.mlir
@@ -112,6 +112,25 @@ module {
     %5 = ttir.empty() : tensor<32x32xbf16>
     %6 = "ttir.add"(%arg2, %0, %5)  : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
     %7 = ttir.empty() : tensor<32x32xbf16>
+    // CHECK: = "ttnn.multiply"(%{{.*}}, %{{.*}})
+    %8 = "ttir.multiply"(%2, %6, %7) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+    %9 = ttir.empty() : tensor<32x32xbf16>
+    %10 = "ttir.multiply"(%4, %8, %9) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+    return %10 : tensor<32x32xbf16>
+  }
+
+
+  func.func @forward_reuse_constant_merge(%arg0: tensor<32x32xbf16> {tt.argument_type = #tt.argument_type<input>}, %arg1: tensor<32x32xbf16> {tt.argument_type = #tt.argument_type<parameter>}, %arg2: tensor<32x32xbf16> {tt.argument_type = #tt.argument_type<parameter>}, %arg3: tensor<32x32xbf16> {tt.argument_type = #tt.argument_type<constant>}) -> tensor<32x32xbf16> {
+    // CHECK: = tt.load_cached(@forward_reuse_zeros_const_eval_0, [%arg1, %arg2])
+    %0 = "ttir.constant"() <{value = dense<1.111e+00> : tensor<32x32xbf16>}> : () -> tensor<32x32xbf16>
+    %1 = ttir.empty() : tensor<32x32xbf16>
+    // CHECK: = "ttnn.add"(%arg0, %{{.*}})
+    %2 = "ttir.add"(%arg0, %0, %1)  : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+    %3 = ttir.empty() : tensor<32x32xbf16>
+    %4 = "ttir.add"(%arg1, %0, %3)  : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+    %5 = ttir.empty() : tensor<32x32xbf16>
+    %6 = "ttir.add"(%arg2, %0, %5)  : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+    %7 = ttir.empty() : tensor<32x32xbf16>
     %8 = "ttir.multiply"(%4, %6, %7) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
     %9 = ttir.empty() : tensor<32x32xbf16>
     // CHECK: = "ttnn.multiply"(%{{.*}}, %{{.*}})

--- a/test/ttmlir/Dialect/TTNN/const-eval/const-eval.mlir
+++ b/test/ttmlir/Dialect/TTNN/const-eval/const-eval.mlir
@@ -98,7 +98,6 @@ module {
   // CHECK: = "ttnn.zeros"(%{{.*}})
   // CHECK: = "ttnn.add"(%{{.*}}, %{{.*}})
   // CHECK: = "ttnn.add"(%{{.*}}, %{{.*}})
-  // CHECK: = "ttnn.multiply"(%{{.*}}, %{{.*}})
 
   // CHECK: func.func @forward_reuse_zeros(
   func.func @forward_reuse_zeros(%arg0: tensor<32x32xbf16> {tt.argument_type = #tt.argument_type<input>}, %arg1: tensor<32x32xbf16> {tt.argument_type = #tt.argument_type<parameter>}, %arg2: tensor<32x32xbf16> {tt.argument_type = #tt.argument_type<parameter>}, %arg3: tensor<32x32xbf16> {tt.argument_type = #tt.argument_type<constant>}) -> tensor<32x32xbf16> {
@@ -115,13 +114,21 @@ module {
     // CHECK: = "ttnn.multiply"(%{{.*}}, %{{.*}})
     %8 = "ttir.multiply"(%2, %6, %7) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
     %9 = ttir.empty() : tensor<32x32xbf16>
+    // CHECK: = "ttnn.multiply"(%{{.*}}, %{{.*}})
     %10 = "ttir.multiply"(%4, %8, %9) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
     return %10 : tensor<32x32xbf16>
   }
 
 
+  // CHECK-LABEL: func.func @forward_reuse_constant_merge_const_eval_0
+  // CHECK: = "ttnn.get_device"
+  // CHECK: = "ttnn.full"(%{{.*}})
+  // CHECK: = "ttnn.add"(%{{.*}}, %{{.*}})
+  // CHECK: = "ttnn.add"(%{{.*}}, %{{.*}})
+  // CHECK: = "ttnn.multiply"(%{{.*}}, %{{.*}})
+
   func.func @forward_reuse_constant_merge(%arg0: tensor<32x32xbf16> {tt.argument_type = #tt.argument_type<input>}, %arg1: tensor<32x32xbf16> {tt.argument_type = #tt.argument_type<parameter>}, %arg2: tensor<32x32xbf16> {tt.argument_type = #tt.argument_type<parameter>}, %arg3: tensor<32x32xbf16> {tt.argument_type = #tt.argument_type<constant>}) -> tensor<32x32xbf16> {
-    // CHECK: = tt.load_cached(@forward_reuse_zeros_const_eval_0, [%arg1, %arg2])
+    // CHECK: = tt.load_cached(@forward_reuse_constant_merge_const_eval_0, [%arg1, %arg2])
     %0 = "ttir.constant"() <{value = dense<1.111e+00> : tensor<32x32xbf16>}> : () -> tensor<32x32xbf16>
     %1 = ttir.empty() : tensor<32x32xbf16>
     // CHECK: = "ttnn.add"(%arg0, %{{.*}})


### PR DESCRIPTION
### Ticket
NA

### Problem description
@AleksKnezevic found a bug in const-eval during tt-torch testing.  In the case of `CreationOps`, we want to treat them specially s.t. not ever tensor creation is always const-eval'ed.  However, I was missing logic to properly treat the Values of a creationOp which has been merged into a subgraph as part of that subgraph w.r.t. merging other subgraphs.

### What's changed
Any creationOp added to a given subgraph also has the values it produces treated as part of this subgraph, s.t. proper merging occurs  when multiple subgraphs share a creationOp

### Checklist
- [x] New/Existing tests provide coverage for changes
