### PR TITLE
Remove inservice label in pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,7 +28,6 @@ jobs:
         ]
 
     runs-on:
-      - in-service
       - ${{ matrix.build.runs-on }}
 
     container:


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Pages won't run if the `in-service` label

### What's changed
https://github.com/tenstorrent/tt-mlir/actions/runs/14783193228/job/41506428466

### Checklist
- [ ] New/Existing tests provide coverage for changes
