### PR TITLE
Skip build and tests on docs changes

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,7 +6,31 @@ on:
 
 jobs:
 
+  ignore-files:
+    runs-on: ubuntu-latest
+    outputs:
+      other_changed_files: ${{ steps.ignore-files.outputs.other_changed_files }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Ignore files
+        id: ignore-files
+        uses: tj-actions/changed-files@v46
+        with:
+          files: |
+            docs/**
+      - name: echo ignore_files
+        run: |
+          echo "any_changed=${{ steps.ignore-files.outputs.any_changed }}"
+          echo "only_changed=${{ steps.ignore-files.outputs.only_changed }}"
+          echo "other_changed_files=${{ steps.ignore-files.outputs.other_changed_files }}"
+          echo "all_changed_files=${{ steps.ignore-files.outputs.all_changed_files }}"
+
+
   build-image:
+    needs: ignore-files
+    if: ${{ needs.ignore-files.outputs.other_changed_files }}
     runs-on:
       - builder
     outputs:


### PR DESCRIPTION
### Problem description
Skip build and testing when there is a doc change under `docs/**`

### Tests

#### Skip change when docs change in the commit 
https://github.com/tenstorrent/tt-mlir/actions/runs/14784683204/job/41510878937#step:4:10  

#### Execute build and test on change when only other files (besides docs) are in the commit  
https://github.com/tenstorrent/tt-mlir/actions/runs/14784662445/job/41510824160#step:4:10   

#### Executes build and test when other_files and docs are in the same commit. 
 https://github.com/tenstorrent/tt-mlir/actions/runs/14784723841/job/41510990480#step:4:10