### PR TITLE
Fix llvm-lit warnings

### DIFF
--- a/test/python/golden/lit.local.cfg
+++ b/test/python/golden/lit.local.cfg
@@ -1,4 +1,0 @@
-# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
-#
-# SPDX-License-Identifier: Apache-2.0
-config.standalone_tests = True

--- a/test/python/lit.local.cfg
+++ b/test/python/lit.local.cfg
@@ -1,4 +1,11 @@
 config.suffixes.add(".py")
 
+config.excludes.add("golden")
+config.excludes.add("op_by_op_infra")
+
+if not config.enable_bindings_python:
+    config.unsupported = True
+
+
 if not config.enable_bindings_python:
     config.unsupported = True

--- a/test/python/lit.local.cfg
+++ b/test/python/lit.local.cfg
@@ -5,7 +5,3 @@ config.excludes.add("op_by_op_infra")
 
 if not config.enable_bindings_python:
     config.unsupported = True
-
-
-if not config.enable_bindings_python:
-    config.unsupported = True

--- a/test/python/op_by_op_infra/lit.cfg.py
+++ b/test/python/op_by_op_infra/lit.cfg.py
@@ -1,4 +1,0 @@
-# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
-#
-# SPDX-License-Identifier: Apache-2.0
-config.standalone_tests = True

--- a/test/unittests/lit.cfg.py
+++ b/test/unittests/lit.cfg.py
@@ -15,7 +15,7 @@ import lit.formats
 config.name = "TTMLIR-Unit"
 
 # suffixes: A list of file extensions to treat as test files.
-config.suffixes = []
+config.suffixes = [".cpp"]
 
 # is_early; Request to run this suite early.
 config.is_early = True


### PR DESCRIPTION
Fix warning from `llvm-lit` when running `cmake --build build -- check-ttmlir`:

```
llvm-lit: /localdev/mtopalovic/src/tt-mlir/env/build/llvm-project-prefix/src/llvm-project/llvm/utils/lit/lit/discovery.py:184: warning: standalone_tests set in LIT config but suffixes or excludes are also set
llvm-lit: /localdev/mtopalovic/src/tt-mlir/env/build/llvm-project-prefix/src/llvm-project/llvm/utils/lit/lit/discovery.py:250: warning: test suite '<unnamed>' contained no tests
```

`test/python/op_by_op_infra` and `test/python/golden` are not run using `llvm-lit`. In CI we are using `pytest` to run these tests. Regardless llvm-lit searches for tests in these directories and reports warnings. This PR explicitly excludes this directories in top level config file. 
