### PR TITLE
Add workaround for concat op

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ConcatOpReshapeRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ConcatOpReshapeRewritePattern.h
@@ -11,7 +11,20 @@
 #include "mlir/Support/LogicalResult.h"
 
 namespace mlir::tt::ttnn::workarounds::decomposition {
+// concat op is not working correctly for the following two cases.
+// 1. If all input tensors have shape of [1, 1] or [1, 1, 1] and concat is
+//    performed on last dimension then the generated output is incorrect. The
+//    first element of the output is correct while all other elements are zero.
+// 2. The second case is extension of the first one if any tensor's last dim is
+//    not 1 (but not for all tensors) then it crashes with TT_FATAL error. For
+//    example we want to concatenate 3 tensors and the shapes are [1, 32],
+//    [1, 2], [1, 1] then this will crash.
+// tt-metal issue: https://github.com/tenstorrent/tt-metal/issues/21581
 
+// This workaround adds one additional dimension to all the input tensor (using
+// reshape) for the cases described above so that concatenation is not applied
+// to the last dim of the input tensors. After concatenation; output tensor is
+// reshaped back to original shape.
 class ConcatOpReshapeRewritePattern : public OpRewritePattern<ttnn::ConcatOp> {
 public:
   using OpRewritePattern<ttnn::ConcatOp>::OpRewritePattern;

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ConcatOpReshapeRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ConcatOpReshapeRewritePattern.cpp
@@ -12,72 +12,82 @@
 #include "mlir/IR/Value.h"
 #include "mlir/Support/LLVM.h"
 #include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 
 namespace mlir::tt::ttnn::workarounds::decomposition {
+static bool isWorkaroundRequired(ttnn::ConcatOp srcOp) {
+  auto areAllDimsExceptLastOne = [](auto shape) {
+    return std::all_of(shape.begin(), shape.end() - 1,
+                       [](int64_t dim) { return dim == 1; });
+  };
+  // Check if we need to apply the workaround.
+  bool anyInputLastDimOne = false;
+  for (auto input : srcOp.getInputs()) {
+    auto shape =
+        mlir::dyn_cast<mlir::RankedTensorType>(input.getType()).getShape();
+    assert(!shape.empty());
 
+    // All dimensions except the last must be 1.
+    if (!areAllDimsExceptLastOne(shape)) {
+      return false;
+    }
+
+    // At least one input must have last dimension of size 1.
+    if (shape.back() == 1) {
+      anyInputLastDimOne = true;
+    }
+  }
+
+  return anyInputLastDimOne;
+}
+
+// Issue to track in tt-metal repo:
+// https://github.com/tenstorrent/tt-metal/issues/21581.
 LogicalResult ConcatOpReshapeRewritePattern::matchAndRewrite(
     ttnn::ConcatOp srcOp, PatternRewriter &rewriter) const {
   int64_t dim = srcOp.getDim();
-  mlir::RankedTensorType outputType =
-      mlir::dyn_cast<mlir::RankedTensorType>(srcOp->getResultTypes().front());
+  mlir::RankedTensorType outputType = srcOp.getResult().getType();
   int64_t rank = outputType.getRank();
-  if ((dim + 1) != rank) {
+
+  // Check if this is a concat on the last dimension with rank 2 or 3.
+  if (((dim + 1) != rank) || (rank != 2 && rank != 3)) {
     return failure();
   }
 
-  auto inputs = srcOp.getInputs();
-  bool isWorkaroundRequired = true;
-  llvm::SmallVector<int64_t, 4> lastDims;
-
-  for (auto input : inputs) {
-    auto inputShape =
-        mlir::dyn_cast<mlir::RankedTensorType>(input.getType()).getShape();
-    lastDims.emplace_back(inputShape.back());
-    isWorkaroundRequired &=
-        llvm::all_of(inputShape, [&](int64_t index) { return index == 1; });
-  }
-
-  auto countDims =
-      llvm::count_if(lastDims, [&](int64_t index) { return index == 1; });
-
-  isWorkaroundRequired |= (countDims > 0 && countDims < rank);
-  if (!isWorkaroundRequired) {
+  if (!isWorkaroundRequired(srcOp)) {
     return failure();
   }
 
-  llvm::SmallVector<mlir::Value, 2> adaptedInputs;
+  // Apply workaround: reshape inputs by adding an extra dimension.
+  llvm::SmallVector<mlir::Value> reshapedInputs;
+  for (auto input : srcOp.getInputs()) {
+    auto typedInput = dyn_cast<mlir::TypedValue<mlir::RankedTensorType>>(input);
+    llvm::SmallVector<int64_t> newShape(typedInput.getType().getShape());
+    newShape.push_back(1);
 
-  for (auto input : inputs) {
-    auto inputShape =
-        mlir::dyn_cast<mlir::RankedTensorType>(input.getType()).getShape();
-    llvm::SmallVector<int64_t, 4> adaptedShape(inputShape);
-    adaptedShape.emplace_back(1);
-    auto check = dyn_cast<mlir::TypedValue<mlir::RankedTensorType>>(input);
-    ReshapeOp adaptedInput =
-        ttir_to_ttnn::utils::generateReshape(check, adaptedShape, rewriter);
-    adaptedInputs.emplace_back(adaptedInput);
+    reshapedInputs.push_back(
+        ttir_to_ttnn::utils::generateReshape(typedInput, newShape, rewriter));
   }
 
-  auto outputShape = outputType.getShape();
-  llvm::SmallVector<int64_t, 4> adaptedOutputShape(outputShape);
-  adaptedOutputShape.emplace_back(1);
-  mlir::RankedTensorType adaptedOutputType =
-      mlir::RankedTensorType::Builder(outputType)
-          .setShape(adaptedOutputShape)
-          .setEncoding(
-              mlir::cast<ttnn::TTNNLayoutAttr>(outputType.getEncoding())
-                  .withTensorShape(adaptedOutputShape));
+  // Create output type with extra dimension.
+  llvm::SmallVector<int64_t> newOutputShape(outputType.getShape());
+  newOutputShape.push_back(1);
 
-  ConcatOp adaptedConcatOp = rewriter.create<mlir::tt::ttnn::ConcatOp>(
-      srcOp->getLoc(), adaptedOutputType, adaptedInputs, srcOp.getDim(),
+  auto newOutputType = mlir::RankedTensorType::get(
+      newOutputShape, outputType.getElementType(),
+      mlir::cast<ttnn::TTNNLayoutAttr>(outputType.getEncoding())
+          .withTensorShape(newOutputShape));
+
+  // Create new concat op with reshaped inputs and new output type.
+  auto newConcatOp = rewriter.create<ttnn::ConcatOp>(
+      srcOp->getLoc(), newOutputType, reshapedInputs, dim,
       /*memory_config=*/nullptr);
 
-  ReshapeOp concatOutput = ttir_to_ttnn::utils::generateReshape(
-      adaptedConcatOp, srcOp.getResult().getType().getShape(), rewriter);
-  rewriter.replaceOp(srcOp, concatOutput);
+  // Reshape back to the original output shape.
+  auto result = ttir_to_ttnn::utils::generateReshape(
+      newConcatOp, outputType.getShape(), rewriter);
 
+  rewriter.replaceOp(srcOp, result);
   return success();
 }
 

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/concat_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/concat_workaround.mlir
@@ -1,15 +1,56 @@
-// RUN: ttmlir-opt --ttnn-workaround --canonicalize %s | FileCheck %s
+// RUN: ttmlir-opt --tt-register-device --ttnn-layout --convert-ttir-to-ttnn --ttnn-workaround --canonicalize %s | FileCheck %s
 
-#dram = #ttnn.buffer_type<dram>
-#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x2x!tt.tile<32x32, u32>, #dram>, <interleaved>>
-#ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!tt.tile<32x32, u32>, #dram>, <interleaved>>
-module attributes {} {
-  func.func @test_concat_workaround(%arg0: tensor<1x53xui32, #ttnn_layout>, %arg1: tensor<1x1xui32, #ttnn_layout1>) -> tensor<1x54xui32, #ttnn_layout> {
-    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.empty"(%0) <{dtype = #tt.supportedDataTypes<u32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <<1x2>>, <interleaved>>, shape = #ttnn.shape<1x54>}> : (!ttnn.device) -> tensor<1x54xui32, #ttnn_layout>
-    // CHECK: %[[CONCAT:[0-9]+]] = "ttnn.concat"
+module {
+  func.func public @test_concat_datatype_workaround(%arg0: tensor<2x53xsi32>, %arg1: tensor<2x1xsi32>) -> tensor<2x54xsi32> {
+    %0 = ttir.empty() : tensor<2x54xsi32>
+    // CHECK-LABEL: func.func public @test_concat_datatype_workaround
+    // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0, %{{[0-9]+}})
+    // CHECK-SAME: dtype = #tt.supportedDataTypes<bf16>
+    // CHECK-SAME: tensor<2x53xsi32
+    // CHECK-SAME: -> tensor<2x53xbf16
+    // CHECK: %[[ARG1:[0-9]+]] = "ttnn.to_layout"(%arg1, %{{[0-9]+}})
+    // CHECK-SAME: dtype = #tt.supportedDataTypes<bf16>
+    // CHECK-SAME: tensor<2x1xsi32
+    // CHECK-SAME: -> tensor<2x1xbf16
+    // CHECK: %[[CONCAT:[0-9]+]] = "ttnn.concat"(%[[ARG0]], %[[ARG1]])
     // CHECK-SAME: dim = 1 : si32
-    %2 = "ttnn.concat"(%arg0, %arg1, %1) <{dim = 1 : si32}> : (tensor<1x53xui32, #ttnn_layout>, tensor<1x1xui32, #ttnn_layout1>, tensor<1x54xui32, #ttnn_layout>) -> tensor<1x54xui32, #ttnn_layout>
-    return %2 : tensor<1x54xui32, #ttnn_layout>
+    // CHECK-SAME: tensor<2x53xbf16
+    // CHECK-SAME: tensor<2x1xbf16
+    // CHECK-SAME: -> tensor<2x54xbf16
+    %1 = "ttir.concat"(%arg0, %arg1, %0) <{dim = 1 : si32}> : (tensor<2x53xsi32>, tensor<2x1xsi32>, tensor<2x54xsi32>) -> tensor<2x54xsi32>
+    // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[CONCAT]], %{{[0-9]+}})
+    // CHECK-SAME: dtype = #tt.supportedDataTypes<si32>
+    // CHECK-SAME: tensor<2x54xbf16
+    // CHECK-SAME: -> tensor<2x54xsi32
+    return %1 : tensor<2x54xsi32>
+  }
+
+  func.func public @test_concat_reshape_workaround(%arg0: tensor<1x53xf32>, %arg1: tensor<1x1xf32>, %arg2: tensor<1x1xf32>) -> tensor<1x55xf32> {
+    %0 = ttir.empty() : tensor<1x55xf32>
+    // CHECK-LABEL: @test_concat_reshape_workaround
+    // CHECK: %[[ARG0:[0-9]+]] = "ttnn.reshape"(%arg0)
+    // CHECK-SAME: <{shape = [1 : i32, 53 : i32, 1 : i32]}>
+    // CHECK-SAME: tensor<1x53xf32,
+    // CHECK-SAME: -> tensor<1x53x1xf32,
+    // CHECK: %[[ARG1:[0-9]+]] = "ttnn.reshape"(%arg1)
+    // CHECK-SAME: <{shape = [1 : i32, 1 : i32, 1 : i32]}>
+    // CHECK-SAME: tensor<1x1xf32,
+    // CHECK-SAME: -> tensor<1x1x1xf32,
+    // CHECK: %[[ARG2:[0-9]+]] = "ttnn.reshape"(%arg2)
+    // CHECK-SAME: <{shape = [1 : i32, 1 : i32, 1 : i32]}>
+    // CHECK-SAME: tensor<1x1xf32,
+    // CHECK-SAME: -> tensor<1x1x1xf32,
+    // CHECK: %[[CONCAT:[0-9]+]] = "ttnn.concat"(%[[ARG0]], %[[ARG1]], %[[ARG2]])
+    // CHECK-SAME: {dim = 1 : si32}
+    // CHECK-SAME: tensor<1x53x1xf32,
+    // CHECK-SAME: tensor<1x1x1xf32,
+    // CHECK-SAME: tensor<1x1x1xf32,
+    // CHECK-SAME: -> tensor<1x55x1xf32,
+    %1 = "ttir.concat"(%arg0, %arg1, %arg2, %0) <{dim = 1 : si32}> : (tensor<1x53xf32>, tensor<1x1xf32>, tensor<1x1xf32>, tensor<1x55xf32>) -> tensor<1x55xf32>
+    // CHECK: %{{[0-9]+}} = "ttnn.reshape"(%[[CONCAT]])
+    // CHECK-SAME: {shape = [1 : i32, 55 : i32]}
+    // CHECK-SAME: tensor<1x55x1xf32,
+    // CHECK-SAME: -> tensor<1x55xf32,
+    return %1 : tensor<1x55xf32>
   }
 }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/3193)

### Problem description
Concat op is failing for following two cases. 
1. If all input tensors have shape of [1, 1] or [1, 1, 1] and concat is performed on last dimension then the generated output is incorrect. The first element of the output is correct while all other elements are zero. 
2. The second case is extension of the first one if any tensor's last dim is not `1` (but not for all tensors) then it crashes with `TT_FATAL` error. For example we want to concatenate 3 tensors and the shapes are [1, 32], [1, 2], [1, 1] then this will crash.

### What's changed
Add one additional dimension to all the input tensor (using reshape) for the cases described above so that concatenation is not applied on the last dim of the input tensor. After concatenation; reshape backe the output tensor to original shape. 

### Checklist
- [X] New/Existing tests provide coverage for changes
