### PR TITLE
Hoist constant op in TTNN

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -1991,13 +1991,13 @@ def TTIR_ArangeOp : TTIR_CreationOp<"arange"> {
     Produces a tensor with values from `start` to `end` (exclusive) with a step size of `step`, along the dimension specified by `arange_dimension`.
 
     Examples:
-      %0 = "ttir.arange"() {start = 0 : i64, end = 5 : i64 step = 1 : i64, arange_dimension = 0 : i64} : () -> tensor<5xi64>
+      %0 = "ttir.arange"() {start = 0 : si64, end = 5 : si64 step = 1 : i64, arange_dimension = 0 : i64} : () -> tensor<5xi64>
       // %0: [0, 1, 2, 3, 4]
 
-      %1 = "ttir.arange"() {start = 0 : i64, end = 10 : i64, step = 2 : i64, arange_dimension = 0 : i64} : () -> tensor<5xf32>
+      %1 = "ttir.arange"() {start = 0 : si64, end = 10 : si64, step = 2 : si64, arange_dimension = 0 : i64} : () -> tensor<5xf32>
       // %1: [0.0, 2.0, 4.0, 6.0, 8.0]
 
-      %2 = "ttir.arange"() {start = 0 : i64, end = 5 : i64, step = 1 : i64, arange_dimension = 0 : i64} : () -> tensor<5x3xi64>
+      %2 = "ttir.arange"() {start = 0 : si64, end = 5 : si64, step = 1 : si64, arange_dimension = 0 : i64} : () -> tensor<5x3xi64>
       // %2: [
               [0, 0, 0],
               [1, 1, 1],
@@ -2006,7 +2006,7 @@ def TTIR_ArangeOp : TTIR_CreationOp<"arange"> {
               [4, 4, 4]
              ]
 
-      %3 = "ttir.arange"() {start = 0 : i64, end = 3 : i64, step = 1 : i64, arange_dimension = 1 : i64} : () -> tensor<5x3xi64>
+      %3 = "ttir.arange"() {start = 0 : si64, end = 3 : si64, step = 1 : si64, arange_dimension = 1 : i64} : () -> tensor<5x3xi64>
       // %3: [
               [0, 1, 2],
               [0, 1, 2],

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1507,7 +1507,10 @@ def TTNN_ClampTensorOp : TTNN_Op<"clamp_tensor", [HasMemoryConfigTrait]> {
     ];
 }
 
-def TTNN_EmptyOp : TTNN_Op<"empty", [TT_CreationOpTrait]> {
+class TTNN_CreationOp<string mnemonic, list<Trait> traits = []> :
+    TTNN_Op<mnemonic, [TT_CreationOpTrait] # traits>;
+
+def TTNN_EmptyOp : TTNN_CreationOp<"empty"> {
     let summary = "Empty op.";
     let description = [{
       Tensor empty operation
@@ -1524,7 +1527,7 @@ def TTNN_EmptyOp : TTNN_Op<"empty", [TT_CreationOpTrait]> {
     let hasVerifier = 1;
 }
 
-def TTNN_ArangeOp : TTNN_Op<"arange", [TT_CreationOpTrait]> {
+def TTNN_ArangeOp : TTNN_CreationOp<"arange"> {
   let summary = "Arange operation.";
   let description = [{
     Tensor arange operation.
@@ -1557,7 +1560,7 @@ def TTNN_ArangeOp : TTNN_Op<"arange", [TT_CreationOpTrait]> {
 }
 
 class TTNN_NamedFullOp<string mnemonic, list<Trait> traits = []> :
-  TTNN_Op<mnemonic, [HasMemoryConfigTrait] # traits> {
+  TTNN_CreationOp<mnemonic, [HasMemoryConfigTrait] # traits> {
   let arguments = (ins TTNN_ShapeAttr:$shape,
                        OptionalAttr<TT_DataTypeAttr>:$dtype,
                        OptionalAttr<TTNN_LayoutAttr>:$layout,
@@ -1569,7 +1572,7 @@ class TTNN_NamedFullOp<string mnemonic, list<Trait> traits = []> :
   let hasVerifier = 1;
 }
 
-def TTNN_ZerosOp : TTNN_NamedFullOp<"zeros", [TT_CreationOpTrait]> {
+def TTNN_ZerosOp : TTNN_NamedFullOp<"zeros"> {
   let summary = "Creates a tensor filled with zeros.";
   let description = [{
     Tensor operation to create a tensor filled with zeros.
@@ -1582,7 +1585,7 @@ def TTNN_ZerosOp : TTNN_NamedFullOp<"zeros", [TT_CreationOpTrait]> {
   }];
 }
 
-def TTNN_OnesOp : TTNN_NamedFullOp<"ones", [TT_CreationOpTrait]> {
+def TTNN_OnesOp : TTNN_NamedFullOp<"ones"> {
   let summary = "Creates a tensor filled with ones.";
   let description = [{
     Tensor operation to create a tensor filled with ones.
@@ -1595,7 +1598,7 @@ def TTNN_OnesOp : TTNN_NamedFullOp<"ones", [TT_CreationOpTrait]> {
   }];
 }
 
-def TTNN_FullOp : TTNN_Op<"full", [TT_CreationOpTrait]> {
+def TTNN_FullOp : TTNN_CreationOp<"full"> {
     let summary = "Full op.";
     let description = [{
       Tensor full operation
@@ -1611,6 +1614,31 @@ def TTNN_FullOp : TTNN_Op<"full", [TT_CreationOpTrait]> {
         return wa::TTNNOperandsWorkaroundsFactory::createFullOpOperandsWorkarounds(outputType);
       }
     }];
+}
+
+def TTNN_ConstantOp : TTNN_CreationOp<"constant", [AllShapesMatch<["value", "result"]>]> {
+    let summary = "Constant op.";
+    let description = [{
+      Produces tensor filled with given constant value.
+
+      Examples:
+        %0 = "ttnn.constant"() {value = dense<[[3, 4, 2], [1, 7, 8]]> : tensor<2x3xui16>} : () -> tensor<2x3xui16>
+        // %0: [[3, 4, 2], [1, 7, 8]]
+        %1 = "ttnn.constant"() {value = dense<[0.2, 1.3]> : tensor<2xf32>} : () -> tensor<2xf32>
+        // %1: [0.2, 1.3]
+    }];
+
+    let arguments = (ins ElementsAttr:$value);
+
+    let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
+        return wa::TTNNOperandsWorkaroundsFactory::createConstantOpOperandsWorkarounds();
+      }
+    }];
+
+    let hasVerifier = 1;
 }
 
 def TTNN_AllocOp : TTNN_Op<"alloc", [TT_CreationOpTrait]> {
@@ -1805,31 +1833,6 @@ def TTNN_UpsampleOp : TTNN_Op<"upsample"> {
     let extraClassDeclaration = [{
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createUpsampleOpOperandsWorkarounds();
-      }
-    }];
-
-    let hasVerifier = 1;
-}
-
-def TTNN_ConstantOp : TTNN_Op<"constant", [AllShapesMatch<["value", "result"]>]> {
-    let summary = "Constant op.";
-    let description = [{
-      Produces tensor filled with given constant value.
-
-      Examples:
-        %0 = "ttnn.constant"() {value = dense<[[3, 4, 2], [1, 7, 8]]> : tensor<2x3xui16>} : () -> tensor<2x3xui16>
-        // %0: [[3, 4, 2], [1, 7, 8]]
-        %1 = "ttnn.constant"() {value = dense<[0.2, 1.3]> : tensor<2xf32>} : () -> tensor<2xf32>
-        // %1: [0.2, 1.3]
-    }];
-
-    let arguments = (ins ElementsAttr:$value);
-
-    let results = (outs AnyRankedTensor:$result);
-
-    let extraClassDeclaration = [{
-      wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
-        return wa::TTNNOperandsWorkaroundsFactory::createConstantOpOperandsWorkarounds();
       }
     }];
 

--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -294,13 +294,14 @@ private:
     mlir::func::FuncOp funcOp = conv2dOp->getParentOfType<mlir::func::FuncOp>();
     llvm::SmallPtrSet<BlockArgument, 4> constParams =
         ttmlir::utils::populateConstParams(funcOp);
-    auto isConstant = [&constParams](mlir::Value value) {
+    auto isConstant = [&constParams, conv2dOp](mlir::Value value) {
       if (auto blockArg = mlir::dyn_cast<BlockArgument>(value)) {
         return constParams.contains(blockArg);
       }
 
-      // TODO(milant): Check for TT_CreationOpTrait after issue #3180 lands.
-      return false;
+      Operation *op = value.getDefiningOp();
+      return op->hasTrait<mlir::tt::Trait::TTCreationOpTrait>() &&
+             op->isBeforeInBlock(conv2dOp);
     };
 
     // Both scale and weight must be constant.

--- a/lib/Transforms/ConstEvalHoist.cpp
+++ b/lib/Transforms/ConstEvalHoist.cpp
@@ -159,6 +159,11 @@ private:
   }
 
   void processOp(Operation *op) {
+    // Skip terminator ops.
+    if (op->hasTrait<mlir::OpTrait::IsTerminator>()) {
+      return;
+    }
+
     // Skip creation ops, they have special handling.
     if (isCreationOp(op)) {
       return;

--- a/test/ttmlir/Dialect/TTIR/fusing/conv2d_multiply_commute.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/conv2d_multiply_commute.mlir
@@ -109,4 +109,49 @@ module {
     %6 = "ttir.multiply"(%4, %arg2, %5) : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
     return %6: tensor<1x30x30x64xbf16>
   }
+
+  // Verify that we can commute when weight and scale are creation ops.
+  // CHECK-LABEL: func.func @conv2d_creation_op_commute
+  func.func @conv2d_creation_op_commute(%input: tensor<1x32x32x64xbf16>) -> tensor<1x30x30x64xbf16> {
+    // CHECK: "ttir.reshape"
+    // CHECK: "ttir.multiply"
+    // CHECK: "ttir.conv2d"
+    %0 = ttir.empty() : tensor<1x30x30x64xbf16>
+    %weight = "ttir.zeros"() <{shape = array<i32: 64, 64, 3, 3>}> : () -> tensor<64x64x3x3xbf16>
+    %scale = "ttir.ones"() <{shape = array<i32: 1, 1, 1, 64>}> : () -> tensor<1x1x1x64xbf16>
+    %conv = "ttir.conv2d"(%input, %weight, %0)
+            <{
+              stride = 1: i32,
+              padding = 0: i32,
+              dilation = 1: i32,
+              groups = 1: i32
+            }> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    // CHECK-NOT: "ttir.multiply"
+    %1 = ttir.empty() : tensor<1x30x30x64xbf16>
+    %2 = "ttir.multiply"(%conv, %scale, %1) : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+
+    return %2: tensor<1x30x30x64xbf16>
+  }
+
+  // Check that we can't commute since %scale is not before %conv in block.
+  // CHECK-LABEL: func.func @conv2d_creation_op_non_commutable
+  func.func @conv2d_creation_op_non_commutable(%input: tensor<1x32x32x64xbf16>) -> tensor<1x30x30x64xbf16> {
+    // CHECK-NOT: "ttir.reshape"
+    // CHECK: "ttir.conv2d"
+    %0 = ttir.empty() : tensor<1x30x30x64xbf16>
+    %weight = "ttir.zeros"() <{shape = array<i32: 64, 64, 3, 3>}> : () -> tensor<64x64x3x3xbf16>
+    %conv = "ttir.conv2d"(%input, %weight, %0)
+            <{
+              stride = 1: i32,
+              padding = 0: i32,
+              dilation = 1: i32,
+              groups = 1: i32
+            }> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    // CHECK: "ttir.multiply"
+    %scale = "ttir.ones"() <{shape = array<i32: 1, 1, 1, 64>}> : () -> tensor<1x1x1x64xbf16>
+    %1 = ttir.empty() : tensor<1x30x30x64xbf16>
+    %2 = "ttir.multiply"(%conv, %scale, %1) : (tensor<1x30x30x64xbf16>, tensor<1x1x1x64xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+
+    return %2: tensor<1x30x30x64xbf16>
+  }
 }

--- a/test/ttmlir/Dialect/TTNN/const-eval/const-eval.mlir
+++ b/test/ttmlir/Dialect/TTNN/const-eval/const-eval.mlir
@@ -183,4 +183,18 @@ module {
 
     return %6 : tensor<4x4xbf16>
   }
+
+  // CHECK-LABEL: func.func @forward_all_const_const_eval
+  // CHECK: "ttnn.add"
+
+
+  // CHECK-LABEL: func.func @forward_all_const(
+  func.func @forward_all_const(%arg0: tensor<32x32xbf16> {tt.argument_type = #tt.argument_type<constant>}, %arg1: tensor<32x32xbf16> {tt.argument_type = #tt.argument_type<constant>}) -> tensor<32x32xbf16> {
+    // CHECK: %[[LOAD_CACHED_RESULT:.+]] = tt.load_cached(@forward_all_const_const_eval_0, [%arg0, %arg1])
+    // CHECK-NOT: "ttnn.add"
+    %0 = ttir.empty() : tensor<32x32xbf16>
+    %1 = "ttir.add"(%arg0, %arg1, %0) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+    // CHECK: return %[[LOAD_CACHED_RESULT]]
+    return %1 : tensor<32x32xbf16>
+  }
 }

--- a/test/ttmlir/Dialect/TTNN/const-eval/const-eval.mlir
+++ b/test/ttmlir/Dialect/TTNN/const-eval/const-eval.mlir
@@ -127,6 +127,7 @@ module {
   // CHECK: = "ttnn.add"(%{{.*}}, %{{.*}})
   // CHECK: = "ttnn.multiply"(%{{.*}}, %{{.*}})
 
+  // CHECK-LABEL: func.func @forward_reuse_constant_merge(
   func.func @forward_reuse_constant_merge(%arg0: tensor<32x32xbf16> {tt.argument_type = #tt.argument_type<input>}, %arg1: tensor<32x32xbf16> {tt.argument_type = #tt.argument_type<parameter>}, %arg2: tensor<32x32xbf16> {tt.argument_type = #tt.argument_type<parameter>}, %arg3: tensor<32x32xbf16> {tt.argument_type = #tt.argument_type<constant>}) -> tensor<32x32xbf16> {
     // CHECK: = tt.load_cached(@forward_reuse_constant_merge_const_eval_0, [%arg1, %arg2])
     %0 = "ttir.constant"() <{value = dense<1.111e+00> : tensor<32x32xbf16>}> : () -> tensor<32x32xbf16>
@@ -143,5 +144,43 @@ module {
     // CHECK: = "ttnn.multiply"(%{{.*}}, %{{.*}})
     %10 = "ttir.multiply"(%2, %8, %9) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
     return %10 : tensor<32x32xbf16>
+  }
+
+  // CHECK-LABEL: func.func @non_splat_constant_const_eval_0
+  // CHECK: = "ttnn.get_device"
+  // CHECK: = "ttnn.constant"() <{value = dense<{{\[\[}}1.000000e+00, 2.000000e+00], [3.000000e+00, 4.000000e+00]]> : tensor<2x2xbf16>}>
+
+  // CHECK: func.func @non_splat_constant(
+  func.func @non_splat_constant(%arg0: tensor<2x2xbf16> {tt.argument_type = #tt.argument_type<input>}) -> tensor<2x2xbf16> {
+    // CHECK: = tt.load_cached(@non_splat_constant_const_eval_0, [])
+    // Create a non-splat constant with different values
+    %0 = "ttir.constant"() <{value = dense<[[1.0, 2.0], [3.0, 4.0]]> : tensor<2x2xbf16>}> : () -> tensor<2x2xbf16>
+    %1 = ttir.empty() : tensor<2x2xbf16>
+    // CHECK: = "ttnn.add"(%arg0, %{{.*}})
+    %2 = "ttir.add"(%arg0, %0, %1) : (tensor<2x2xbf16>, tensor<2x2xbf16>, tensor<2x2xbf16>) -> tensor<2x2xbf16>
+    return %2 : tensor<2x2xbf16>
+  }
+
+  // CHECK-LABEL: func.func @creation_ops_const_eval_0
+  // CHECK: "ttnn.zeros"
+  // CHECK: "ttnn.ones"
+  // CHECK: "ttnn.add"
+  // CHECK: "ttnn.arange"
+  // CHECK: "ttnn.add"
+
+  // CHECK-LABEL: func.func @creation_ops(
+  func.func @creation_ops() -> tensor<4x4xbf16> {
+    // CHECK: = tt.load_cached(@creation_ops_const_eval_0, [])
+    %0 = "ttir.zeros"() <{shape = array<i32: 4, 4>}> : () -> tensor<4x4xbf16>
+    %1 = "ttir.ones"() <{shape = array<i32: 4, 4>}> : () -> tensor<4x4xbf16>
+
+    %2 = ttir.empty() : tensor<4x4xbf16>
+    %3 = "ttir.add"(%0, %1, %2) : (tensor<4x4xbf16>, tensor<4x4xbf16>, tensor<4x4xbf16>) -> tensor<4x4xbf16>
+
+    %4 = ttir.empty() : tensor<4x4xbf16>
+    %5 = "ttir.arange"() {start = 0 : si64, end = 4 : si64, step = 1 : si64, arange_dimension = 0 : i64} : () -> tensor<4x4xbf16>
+    %6 = "ttir.add"(%3, %5, %4) : (tensor<4x4xbf16>, tensor<4x4xbf16>, tensor<4x4xbf16>) -> tensor<4x4xbf16>
+
+    return %6 : tensor<4x4xbf16>
   }
 }


### PR DESCRIPTION
* Previously constant op in TTNN was not tagged with CreationOp trait. This PR adds tag for constant op and reconstructs creation ops in TTNN to have similar strucutre to TTIR equivalents.
* Fixed bug when return op was pulled in for hoisting. This can happen if whole graph can be const evaled.
* Removed constant for commuting conv2d and multiply to function arguments only.
* Added test for both commuting creation ops in conv2d+multiply commute and const evaling creation ops.

closes #3180