### PR TITLE
Update ttmetal.enqueue_program_op verifier

### DIFF
--- a/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
+++ b/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
@@ -62,11 +62,6 @@ namespace mlir::tt::ttmetal {
 }
 
 ::mlir::LogicalResult EnqueueProgramOp::verify() {
-  // Assert inputs/outputs device memspace
-  if (getBuffers().size() != getCbs().size()) {
-    return emitOpError("number of buffers and cbs must be the same");
-  }
-
   for (auto operand : getOperands()) {
     ::mlir::MemRefType operandType = mlir::cast<MemRefType>(operand.getType());
     MemorySpaceAttr memSpaceAttr =


### PR DESCRIPTION

### Ticket
Link to Github Issue

### Problem description
Update ttmetal.enqueue_program_op verifier to remove a check that ensures that the number of buffer operands and the cb operands are equal.

### What's changed
Update ttmetal.enqueue_program_op verifier to remove a check that ensures that the number of buffer operands and the cb operands are equal. This condition need not be always true. e.g. a compute kernel might only read and write to circular buffers and do not depend on any global buffer.

### Checklist
- [ ] New/Existing tests provide coverage for changes
