### PR TITLE
Fix `ttnn-precompiled.hpp`

### DIFF
--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -13,7 +13,7 @@
 #include "operations/ccl/mesh_shard_impl.h"
 #include "operations/ccl/reduce_scatter/reduce_scatter.hpp"
 #include "operations/conv/conv2d/conv2d.hpp"
-#include "operations/conv/conv2d/prepare_conv2d_weights.cpp"
+#include "operations/conv/conv2d/prepare_conv2d_weights.hpp"
 #include "operations/conv/conv_transpose2d/conv_transpose2d.hpp"
 #include "operations/copy.hpp"
 #include "operations/core/core.hpp"
@@ -66,13 +66,10 @@ public:
   }
 
 private:
-  ~DeviceGetter() { ttnn::close_device(*device); }
+  DeviceGetter() = default;
 
-public:
   DeviceGetter(const DeviceGetter &) = delete;
-  void operator=(const DeviceGetter &) = delete;
-
-  ttnn::IDevice *device;
+  DeviceGetter &operator=(const DeviceGetter &) = delete;
 };
 
 // Wrapper to abstract const-eval logic out of runtime funcs to keep them


### PR DESCRIPTION
### Ticket
N/A

- Accidental inclusion of `cpp` instead of `hpp`
- Updated `DeviceGetter` to better reflect the current situation with TTNN device(s), as some parts were out of place

### Checklist
- [ ] New/Existing tests provide coverage for changes
