### PR TITLE
Mark ttkernel.get_compile_time_arg_val op as Pure

### DIFF
--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -620,7 +620,8 @@ def TTKernel_GetArgValOp : TTKernel_Op<"get_arg_val"> {
     let results = (outs TTKernel_ArgResultType:$arg_val);
 }
 
-def TTKernel_GetCompileArgValOp : TTKernel_Op<"get_compile_time_arg_val"> {
+def TTKernel_GetCompileArgValOp : TTKernel_Op<"get_compile_time_arg_val",
+                                              [Pure]> {
     let summary = "Get compile-time arg value.";
     let description = [{
       Get compile-time argument value at specified index.


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Mark ttkernel.get_compile_time_arg_val op as Pure

### What's changed
This will enable to get rid of the duplicates of this op with the help of CSE pass. Also, it will enable hoisting out of this op to the top.

### Checklist
- [ ] New/Existing tests provide coverage for changes
