### PR TITLE
Disable fusing pass by default

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -198,6 +198,10 @@ struct TTIRToTTNNBackendPipelineOptions
       *this, "enable-erase-inverse-ops-pass",
       llvm::cl::desc("Enable erase inverse ops pass."), llvm::cl::init(true)};
 
+  Option<bool> enableFusing{*this, "enable-fusing-pass",
+                            llvm::cl::desc("Enable fusing pass."),
+                            llvm::cl::init(false)};
+
   Option<tt::TTArgumentTypeMap, tt::ArgumentTypeMapParser> argumentTypeMap{
       *this, tt::OptionNames::argumentTypes,
       llvm::cl::desc(

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -35,7 +35,9 @@ void createTTNNPipelineTTIRPasses(
 
   pm.addPass(mlir::tt::createTTPopulateArgumentTypes(options.argumentTypeMap));
   pm.addPass(mlir::createCanonicalizerPass());
-  pm.addPass(mlir::tt::ttir::createTTIRFusing());
+  if (options.enableFusing) {
+    pm.addPass(mlir::tt::ttir::createTTIRFusing());
+  }
   pm.addPass(mlir::tt::createTTIRToTTIRDecompositionPass());
   pm.addPass(mlir::createCanonicalizerPass());
 
@@ -137,7 +139,9 @@ void createTTIRToTTNNBackendPipeline(
   devicePm.addPass(ttir::createTTIRQuantDataTypeConversionPass(quantOptions));
 
   createTTNNPipelineLoweringPasses(devicePm, options);
-  devicePm.addPass(tt::ttnn::createTTNNFusing());
+  if (options.enableFusing) {
+    devicePm.addPass(tt::ttnn::createTTNNFusing());
+  }
   createTTNNPipelineWorkaroundPass(devicePm, options);
   if (options.enableConstEval) {
     devicePm.addPass(transforms::createConstEvalHoistTransform());

--- a/test/ttmlir/Dialect/TTNN/fusing/resnet_pattern_fusing.mlir
+++ b/test/ttmlir/Dialect/TTNN/fusing/resnet_pattern_fusing.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-fusing-pass=true" %s | FileCheck %s
 
 // This is common pattern throught Resnet. We have conv2d with constant weight, followed by multiply with constant input. This will be commuted through conv2d.
 // Then we fuse add into conv2d with bias and lastly we fuse conv2d and relu into conv2d with activation.


### PR DESCRIPTION
When trying to uplift FFE it seems that fusing is triggering some code paths in metal which are untested, and we are getting asserts. Disable fusing by default to unblock FFE uplift. This is hotfix change.