### PR TITLE
Add opmodel definition for MLIRTTNNTransforms

### DIFF
--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -1,3 +1,7 @@
+if (TTMLIR_ENABLE_OPMODEL)
+        add_definitions(-DTTMLIR_ENABLE_OPMODEL)
+endif()
+
 add_mlir_dialect_library(MLIRTTNNTransforms
         Optimizer.cpp
         Passes.cpp


### PR DESCRIPTION
### Problem description
FFE build with optimizer TTMLIR_ENABLE_OPMODEL definition in order to properly close device.

### What's changed
* Add `TTMLIR_ENABLE_OPMODEL` to `MLIRTTNNTransforms`

### Checklist
- [ ] New/Existing tests provide coverage for changes
