### PR TITLE
[Optimizer] Perform Additional Validation on TensorSpecs While Looking for Valid TTNNLayoutAttrs

### DIFF
--- a/include/ttmlir/OpModel/TTNN/Conversion.h
+++ b/include/ttmlir/OpModel/TTNN/Conversion.h
@@ -52,6 +52,27 @@ getTensorLayout(const mlir::tt::ttnn::TTNNLayoutAttr &layout);
 ::ttnn::TensorSpec getTensorSpec(const ::llvm::ArrayRef<int64_t> shape,
                                  const mlir::tt::ttnn::TTNNLayoutAttr &layout);
 
+/**
+ * @brief Perform various validity checks on a converted TensorSpec
+ *
+ * 1. Checks if the shard bounding box fits within the available grid size.
+ *  This check fails if the memory configuration is sharded and the shard
+ * bounding box exceeds the available grid size.
+ *
+ * 2. Checks if the TensorSpec can compute attributes required for tensor
+ * creation (e.g. shard_spec_buffer). This check fails if any of the calls
+ * fail
+ *
+ * May lead to TT_FATAL being called.
+ *
+ * @param memoryConfig The tensor spec to validate.
+ * @param computeGridSize The compute grid size for the target device.
+ *
+ * @return false if any checks fail
+ */
+bool validateTensorSpec(const ::ttnn::TensorSpec &tensorSpec,
+                        const ::tt::tt_metal::CoreCoord &computeGridSize);
+
 ::ttnn::SmallVector<int>
 convertLLVMSmallVecToTTNNSmallVec(const ::llvm::ArrayRef<int64_t> vec);
 

--- a/include/ttmlir/OpModel/TTNN/Conversion.h
+++ b/include/ttmlir/OpModel/TTNN/Conversion.h
@@ -56,19 +56,18 @@ getTensorLayout(const mlir::tt::ttnn::TTNNLayoutAttr &layout);
  * @brief Perform various validity checks on a converted TensorSpec
  *
  * 1. Checks if the shard bounding box fits within the available grid size.
- *  This check fails if the memory configuration is sharded and the shard
+ * This check fails if the memory configuration is sharded and the shard
  * bounding box exceeds the available grid size.
  *
  * 2. Checks if the TensorSpec can compute attributes required for tensor
  * creation (e.g. shard_spec_buffer). This check fails if any of the calls
- * fail
+ * fail.
  *
  * May lead to TT_FATAL being called.
  *
- * @param memoryConfig The tensor spec to validate.
+ * @param tensorSpec The tensor spec to validate.
  * @param computeGridSize The compute grid size for the target device.
- *
- * @return false if any checks fail
+ * @return false if any check fails
  */
 bool validateTensorSpec(const ::ttnn::TensorSpec &tensorSpec,
                         const ::tt::tt_metal::CoreCoord &computeGridSize);

--- a/lib/OpModel/TTNN/Conversion.cpp
+++ b/lib/OpModel/TTNN/Conversion.cpp
@@ -245,12 +245,9 @@ bool validateTensorSpec(const ::ttnn::TensorSpec &tensorSpec,
   // Check attributes required for allocation
   // May call TT_THROW or TT_FATAL for malformed TensorSpecs
   try {
-    [[maybe_unused]] auto buffer_size_bytes =
-        tensorSpec.compute_packed_buffer_size_bytes();
-    [[maybe_unused]] auto page_size_bytes =
-        tensorSpec.compute_page_size_bytes();
-    [[maybe_unused]] auto shard_spec_buffer =
-        tensorSpec.compute_shard_spec_buffer();
+    tensorSpec.compute_packed_buffer_size_bytes();
+    tensorSpec.compute_page_size_bytes();
+    tensorSpec.compute_shard_spec_buffer();
   } catch (const std::exception &e) {
     return false;
   }

--- a/lib/OpModel/TTNN/Conversion.cpp
+++ b/lib/OpModel/TTNN/Conversion.cpp
@@ -226,6 +226,37 @@ getTensorLayout(const mlir::tt::ttnn::TTNNLayoutAttr &layout) {
   return ::ttnn::TensorSpec(getShape(shape), getTensorLayout(layout));
 }
 
+bool validateTensorSpec(const ::ttnn::TensorSpec &tensorSpec,
+                        const ::tt::tt_metal::CoreCoord &computeGridSize) {
+  // Check the shard bounding box
+  auto memoryConfig = tensorSpec.memory_config();
+  if (memoryConfig.is_sharded()) {
+    ::tt::tt_metal::CoreRange shardBoundingBox =
+        memoryConfig.shard_spec.value().grid.bounding_box();
+    ::tt::tt_metal::CoreRangeSet deviceWorkerCores{::tt::tt_metal::CoreRange{
+        ::tt::tt_metal::CoreCoord{0, 0},
+        ::tt::tt_metal::CoreCoord{computeGridSize.x - 1,
+                                  computeGridSize.y - 1}}};
+    if (!deviceWorkerCores.contains(shardBoundingBox)) {
+      return false;
+    }
+  }
+
+  // Check attributes required for allocation
+  // May call TT_THROW or TT_FATAL for malformed TensorSpecs
+  try {
+    [[maybe_unused]] auto buffer_size_bytes =
+        tensorSpec.compute_packed_buffer_size_bytes();
+    [[maybe_unused]] auto page_size_bytes =
+        tensorSpec.compute_page_size_bytes();
+    [[maybe_unused]] auto shard_spec_buffer =
+        tensorSpec.compute_shard_spec_buffer();
+  } catch (const std::exception &e) {
+    return false;
+  }
+  return true;
+}
+
 ::ttnn::SmallVector<int>
 convertLLVMSmallVecToTTNNSmallVec(const ::llvm::ArrayRef<int64_t> vec) {
   return ::ttnn::SmallVector<int>(vec.begin(), vec.end());

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -179,7 +179,8 @@ convertToTensorSpec(::tt::tt_metal::IDevice *device,
     return spec;
   }
 
-  return llvm::createStringError("Invalid TensorSpec");
+  return llvm::createStringError(
+      "Unable to create TensorSpec out of given shape and layout");
 }
 
 /**

--- a/test/unittests/OpModel/TTNN/Conversion/TestConversion.cpp
+++ b/test/unittests/OpModel/TTNN/Conversion/TestConversion.cpp
@@ -631,10 +631,12 @@ TEST_F(Conversion, TensorSpecToLayout) {
   for (mlir::tt::ttnn::TTNNLayoutAttr originalLayout : layouts) {
     const auto tensorSpec = mlir::tt::op_model::ttnn::conversion::getTensorSpec(
         tensorShape, originalLayout);
+    EXPECT_TRUE(mlir::tt::op_model::ttnn::conversion::validateTensorSpec(
+        tensorSpec, {8, 8}));
+
     const auto reconvertedLayout =
         mlir::tt::op_model::ttnn::conversion::getLayoutAttrFromTensorSpec(
             &context, tensorSpec, /*deviceGrid=*/{8, 8});
-
     ExpectLayoutsEQ(originalLayout, reconvertedLayout);
   }
 }
@@ -713,5 +715,7 @@ TEST_F(Conversion, TensorSpecToLayoutReversed) {
             mlir::tt::op_model::ttnn::conversion::getShape(tensorShape),
             layout);
     EXPECT_EQ(reconvertedTensorSpec, originalTensorSpec);
+    EXPECT_TRUE(mlir::tt::op_model::ttnn::conversion::validateTensorSpec(
+        reconvertedTensorSpec, {8, 8}));
   }
 }


### PR DESCRIPTION
### Ticket
#3082

### Problem description
The optimizer sweeps a large space of `TTNNLayoutAttr`s to discover legal layouts for ops. Some of these `TTNNLayoutAttr`s are not valid `TensorSpec`s at all. It would be preferable to detect these early rather than waiting for the op execution to fail during the `getOpConstraints` call.

### What's changed
- Frontload the calls to `TensorSpec` methods needed during `allocate_device_tensor` so validation happens prior to setting up the rest of the `query_op_constraints` infrastructure
- Create a new `conversions::validateTensorSpec` function that includes both previous and new checks
- Refactor the `TTNNLayoutAttr` -> `TensorSpec` conversion wrapper to:
  - call the new validation function
  - get rid of complicated templating that was used for batch conversions (no longer needed)
- Closes #3082 

### Checklist
- [X] New/Existing tests provide coverage for changes
