### PR TITLE
Use GH_SECRET_PROJECTS token

### DIFF
--- a/.github/workflows/issue-last-updated.yml
+++ b/.github/workflows/issue-last-updated.yml
@@ -2,8 +2,6 @@ name: Update Project Date on Issue Update
 
 
 on:
-  workflow_dispatch:
-  push:
   issues:
     types: [opened, edited, deleted, closed, reopened, assigned, unassigned, labeled, unlabeled]
   issue_comment:

--- a/.github/workflows/issue-last-updated.yml
+++ b/.github/workflows/issue-last-updated.yml
@@ -2,6 +2,8 @@ name: Update Project Date on Issue Update
 
 
 on:
+  workflow_dispatch:
+  push:
   issues:
     types: [opened, edited, deleted, closed, reopened, assigned, unassigned, labeled, unlabeled]
   issue_comment:
@@ -9,7 +11,7 @@ on:
 
 
 env:
-  GITHUB_TOKEN: ${{ secrets.ISSUE_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GH_SECRET_PROJECTS }}
 
 
 jobs:
@@ -26,7 +28,7 @@ jobs:
         id: get_issue_id
         run: |
           issue_number=${{ github.event.issue.number }}
-          issue_details=$(curl -H "Authorization: Bearer ${{ secrets.ISSUE_TOKEN }}" -s "https://api.github.com/repos/${{ github.repository }}/issues/$issue_number")
+          issue_details=$(curl -H "Authorization: Bearer ${{ secrets.GH_SECRET_PROJECTS}}" -s "https://api.github.com/repos/${{ github.repository }}/issues/$issue_number")
           issue_id=$(echo "$issue_details" | jq -r '.node_id')
           echo "issue_id=$issue_id" >> $GITHUB_ENV
 
@@ -124,7 +126,7 @@ jobs:
       - name: Update Project Field
         run: |
           current_date=$(date +%Y-%m-%d)
-          curl -H "Authorization: Bearer ${{ secrets.ISSUE_TOKEN }}" \
+          curl -H "Authorization: Bearer ${{ secrets.GH_SECRET_PROJECTS }}" \
                -H "Content-Type: application/json" \
                -d "{ \"query\": \"mutation { updateProjectV2ItemFieldValue(input: { projectId: \\\"${{ env.project_id }}\\\", itemId: \\\"${{ env.ITEM_ID }}\\\", fieldId: \\\"${{ env.field_id }}\\\", value: { date: \\\"$current_date\\\" } }) { clientMutationId } }\" }" \
                -X POST \


### PR DESCRIPTION
Updated GitHub workflow token from ISSUE_TOKEN to GH_SECRET_PROJECTS. This change is needed to use the new token for calls in the issue last updated workflow.


