### PR TITLE
Pass logger instance explicitly into get_atol_rtol_pcc to fix NameError (#3210)

### DIFF
--- a/runtime/tools/python/ttrt/common/callback.py
+++ b/runtime/tools/python/ttrt/common/callback.py
@@ -156,7 +156,7 @@ def golden(callback_runtime_config, binary, program_context, op_context):
         return
 
     _, _, cal_pcc, output_str = get_atol_rtol_pcc(
-        golden_tensor_torch, output_tensor_torch
+        golden_tensor_torch, output_tensor_torch, logging
     )
 
     logging.debug(f"PCC={cal_pcc}")

--- a/runtime/tools/python/ttrt/common/run.py
+++ b/runtime/tools/python/ttrt/common/run.py
@@ -727,7 +727,9 @@ class Run:
                                                 f"Failed: program-level output doesn't match golden shape! golden_shape={golden_tensor_torch.shape}, output_shape={output_tensor_torch.shape}"
                                             )
                                         _, _, cal_pcc, _ = get_atol_rtol_pcc(
-                                            golden_tensor_torch, output_tensor_torch
+                                            golden_tensor_torch,
+                                            output_tensor_torch,
+                                            self.logging,
                                         )
                                         if (
                                             cal_pcc

--- a/runtime/tools/python/ttrt/common/util.py
+++ b/runtime/tools/python/ttrt/common/util.py
@@ -70,7 +70,7 @@ def get_ttrt_metal_home_path():
     return tt_metal_home
 
 
-def get_atol_rtol_pcc(golden, calculated):
+def get_atol_rtol_pcc(golden, calculated, logging):
     import numpy as np
     import torch
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/3210
closes #3210

### Problem description
Moving get_atol_rtol_pcc from callback.py to util.py left it calling logging.debug(…) without the logging symbol in scope.
When a numerical check triggers that debug branch (e.g., tensors containing NaNs), the function raises
```
NameError: name 'logging' is not defined
```


### What's changed
Added a required logger parameter to get_atol_rtol_pcc; removed implicit logging reference.
Passes the active logger when invoking get_atol_rtol_pcc.


### Checklist
- [ ] New/Existing tests provide coverage for changes
