### PR TITLE
[Optimizer] Use of backend returned output tensor

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/MemReconfig.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/MemReconfig.h
@@ -69,11 +69,9 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
     }
     os << ")";
   }
-  os << "\n";
-  os << "SelectedReshardOutputConfigBitIndex: "
-     << memReconfigEntry.selectedReshardOutputConfigBitIndex << "\n";
-  os << "\n";
-  os << "OverridenReconfig: " << memReconfigEntry.hasOverridenReconfig()
+  os << " SelectedReshardOutputConfigBitIndex: "
+     << memReconfigEntry.selectedReshardOutputConfigBitIndex;
+  os << " OverridenReconfig: " << memReconfigEntry.hasOverridenReconfig()
      << "\n";
   return os;
 }

--- a/include/ttmlir/Dialect/TTNN/Analysis/ShardSolver.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/ShardSolver.h
@@ -278,7 +278,16 @@ private:
                            Operation *ignoreOp = nullptr);
 
   bool preprocessFirstOp();
-  llvm::Expected<bool> checkShardCompatible(
+
+  // Performs backend check to see if producer tensor is compatible with
+  // consumer op. Backend may or
+  // may not respect consumer config. Backend returns actual output tensor
+  // layout that is being created for the given producer tensor. This function
+  // will return error if producer and consumer are not compatible. Also, it
+  // will return an error if provided consumer config is not the same as actual
+  // consumer layout. Otherwise, it will return TTNNLayoutAttr with actual
+  // consumer layout.
+  llvm::Expected<TTNNLayoutAttr> checkShardCompatible(
       Value producerOperand, const TTNNLayoutAttr &producerLayout,
       Operation *consumerOp, const OpConfig &consumerConfig) const;
 
@@ -290,8 +299,8 @@ public:
       const llvm::DenseSet<Operation *> &shardedOps,
       const unsigned usableL1CacheSize,
       const llvm::DenseSet<Edge> &overrideReshardEdges,
-      std::function<bool(mlir::Value, TTNNLayoutAttr, mlir::Operation *,
-                         OpConfig)>
+      std::function<llvm::Expected<TTNNLayoutAttr>(Value, TTNNLayoutAttr,
+                                                   Operation *, OpConfig)>
           customCheckShardCompatible = nullptr);
   RemainingConfigAttrs at(Operation *operation) const;
   void set(Operation *operation, const OpConfig &config);
@@ -328,7 +337,8 @@ private:
   // Edges indicated for resharding.
   llvm::DenseSet<Edge> memReconfigEdges;
 
-  std::function<bool(mlir::Value, TTNNLayoutAttr, mlir::Operation *, OpConfig)>
+  std::function<llvm::Expected<TTNNLayoutAttr>(mlir::Value, TTNNLayoutAttr,
+                                               mlir::Operation *, OpConfig)>
       customCheckShardCompatible;
 };
 

--- a/lib/Dialect/TTNN/Analysis/DFShardingPolicy.cpp
+++ b/lib/Dialect/TTNN/Analysis/DFShardingPolicy.cpp
@@ -91,13 +91,18 @@ void DFShardingPolicy::run() {
           // the near future.
           //
           if (llvm::isa<
+                  // TODO(#3242): Re-enable once we are able to query backend
+                  // for matmul.
+                  ttnn::MatmulOp,
                   // TODO(#2038): Remove this once this bug is fixed.
                   // TODO(#2042): And constraints are implemented.
                   ttnn::ReshapeOp,
                   // TODO(#2038): Remove this once this bug is fixed.
                   ttnn::ConcatOp,
                   // TODO(#2041): Remove once constraints are added for MeanOp.
-                  ttnn::MeanOp,
+                  // TODO(#2084): Remove once constraints are added for all
+                  // Llama ops.
+                  ttnn::MeanOp, ttnn::SinOp, ttnn::CosOp, ttnn::ReciprocalOp,
                   // TODO(#2588): Blocked by graph capture issue.
                   ttnn::Conv2dOp, ttnn::MaxPool2dOp>(currentOp)) {
             validForSharding = false;

--- a/lib/Dialect/TTNN/Transforms/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/Optimizer.cpp
@@ -32,6 +32,7 @@
 #include "mlir/IR/Visitors.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/ErrorHandling.h"
 
 namespace mlir::tt::ttnn {
 
@@ -468,8 +469,8 @@ private:
 
     for (const auto &[opLoc, opOverridenAndExists] : overridenOpExists) {
       if (!opOverridenAndExists) {
-        llvm::errs() << "Trying to override non-existing op: " << opLoc << "\n";
-        assert(false && "Trying to override non-existing op");
+        llvm::report_fatal_error("Trying to override non-existing op: " +
+                                 opLoc + ". Check logs for details");
       }
     }
   }

--- a/lib/OpModel/TTNN/Conversion.cpp
+++ b/lib/OpModel/TTNN/Conversion.cpp
@@ -387,8 +387,8 @@ getLogicalGridShape(const ::tt::tt_metal::MemoryConfig &memoryConfig,
     assert(memoryConfig.shard_spec().has_value());
     CoreRange boundingGrid = memoryConfig.shard_spec()->grid.bounding_box();
     assert(memoryConfig.shard_spec()->num_cores() == boundingGrid.size());
-    return {static_cast<long>(boundingGrid.grid_size().x),
-            static_cast<long>(boundingGrid.grid_size().y)};
+    return {static_cast<int64_t>(boundingGrid.grid_size().y),
+            static_cast<int64_t>(boundingGrid.grid_size().x)};
   }
 
   // interleaved

--- a/test/ttmlir/Dialect/TTNN/optimizer/bf_interleaved_policy/all_dram_buffer_type.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/bf_interleaved_policy/all_dram_buffer_type.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: opmodel
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true memory-layout-analysis-enabled=true memory-layout-analysis-policy=BFInterleaved" %s | FileCheck %s
 // XFAIL: *
 #any_device = #tt.operand_constraint<dram|l1|scalar|tile|any_device|any_device_tile>

--- a/test/ttmlir/Dialect/TTNN/optimizer/bf_interleaved_policy/all_dram_operands_l1_op.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/bf_interleaved_policy/all_dram_operands_l1_op.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: opmodel
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true memory-layout-analysis-enabled=true memory-layout-analysis-policy=BFInterleaved" %s | FileCheck %s
 module attributes {} {
   func.func @forward(%arg0: tensor<5120x8192xbf16>, %arg1: tensor<8192x5120xbf16>) -> tensor<5120x5120xbf16> {

--- a/test/ttmlir/Dialect/TTNN/optimizer/bf_interleaved_policy/all_l1_operands_dram_op.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/bf_interleaved_policy/all_l1_operands_dram_op.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: opmodel
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true memory-layout-analysis-enabled=true memory-layout-analysis-policy=BFInterleaved" %s | FileCheck %s
 module attributes {} {
   func.func @forward(%arg0: tensor<6144x1024xbf16>, %arg1: tensor<1024x6144xbf16>) -> tensor<6144x6144xbf16> {

--- a/test/ttmlir/Dialect/TTNN/optimizer/bf_interleaved_policy/fork_join_01.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/bf_interleaved_policy/fork_join_01.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: opmodel
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true memory-layout-analysis-enabled=true memory-layout-analysis-policy=BFInterleaved" %s | FileCheck %s
 //
 //         A

--- a/test/ttmlir/Dialect/TTNN/optimizer/bf_interleaved_policy/fork_join_02.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/bf_interleaved_policy/fork_join_02.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: opmodel
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true memory-layout-analysis-enabled=true memory-layout-analysis-policy=BFInterleaved" %s | FileCheck %s
 //
 //         A

--- a/test/ttmlir/Dialect/TTNN/optimizer/greedy_l1_interleaved_policy/all_l1_interleaved_policy.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/greedy_l1_interleaved_policy/all_l1_interleaved_policy.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: opmodel
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true memory-layout-analysis-enabled=true memory-layout-analysis-policy=GreedyL1Interleaved" %s | FileCheck %s
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x96xbf16>, %arg2: tensor<64x96xbf16>, %arg3: tensor<96x32xbf16>, %arg4: tensor<64x32xbf16>) -> tensor<64x32xbf16> {

--- a/test/ttmlir/Dialect/TTNN/optimizer/greedy_l1_interleaved_policy/fork_join.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/greedy_l1_interleaved_policy/fork_join.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: opmodel
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true memory-layout-analysis-enabled=true memory-layout-analysis-policy=GreedyL1Interleaved" %s | FileCheck %s
 //
 //         A

--- a/test/ttmlir/Dialect/TTNN/optimizer/greedy_l1_interleaved_policy/mnist_l1_interleaved.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/greedy_l1_interleaved_policy/mnist_l1_interleaved.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: opmodel
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true memory-layout-analysis-enabled=true memory-layout-analysis-policy=GreedyL1Interleaved" %s | FileCheck %s
 #loc = loc("MNISTLinear":4294967295:0)
 module @"tt-forge-graph" attributes {} {

--- a/test/ttmlir/Dialect/TTNN/optimizer/greedy_l1_interleaved_policy/simple_join_tests/dram_ABC_l1_None.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/greedy_l1_interleaved_policy/simple_join_tests/dram_ABC_l1_None.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: opmodel
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true memory-layout-analysis-enabled=true memory-layout-analysis-policy=GreedyL1Interleaved" %s | FileCheck %s
 //
 //       A     B

--- a/test/ttmlir/Dialect/TTNN/optimizer/greedy_l1_interleaved_policy/simple_join_tests/dram_AB_l1_C.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/greedy_l1_interleaved_policy/simple_join_tests/dram_AB_l1_C.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: opmodel
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true memory-layout-analysis-enabled=true memory-layout-analysis-policy=GreedyL1Interleaved" %s | FileCheck %s
 //
 //       A     B

--- a/test/ttmlir/Dialect/TTNN/optimizer/greedy_l1_interleaved_policy/simple_join_tests/dram_AC_l1_B.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/greedy_l1_interleaved_policy/simple_join_tests/dram_AC_l1_B.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: opmodel
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true memory-layout-analysis-enabled=true memory-layout-analysis-policy=GreedyL1Interleaved" %s | FileCheck %s
 //
 //       A     B

--- a/test/ttmlir/Dialect/TTNN/optimizer/greedy_l1_interleaved_policy/simple_join_tests/dram_A_l1_BC.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/greedy_l1_interleaved_policy/simple_join_tests/dram_A_l1_BC.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: opmodel
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true memory-layout-analysis-enabled=true memory-layout-analysis-policy=GreedyL1Interleaved" %s | FileCheck %s
 //
 //       A     B

--- a/test/ttmlir/Dialect/TTNN/optimizer/greedy_l1_interleaved_policy/simple_join_tests/dram_BC_l1_A.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/greedy_l1_interleaved_policy/simple_join_tests/dram_BC_l1_A.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: opmodel
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true memory-layout-analysis-enabled=true memory-layout-analysis-policy=GreedyL1Interleaved" %s | FileCheck %s
 //
 //       A     B

--- a/test/ttmlir/Dialect/TTNN/optimizer/greedy_l1_interleaved_policy/simple_join_tests/dram_B_l1_AC.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/greedy_l1_interleaved_policy/simple_join_tests/dram_B_l1_AC.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: opmodel
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true memory-layout-analysis-enabled=true memory-layout-analysis-policy=GreedyL1Interleaved" %s | FileCheck %s
 //
 //       A     B

--- a/test/ttmlir/Dialect/TTNN/optimizer/greedy_l1_interleaved_policy/simple_join_tests/dram_C_l1_AB.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/greedy_l1_interleaved_policy/simple_join_tests/dram_C_l1_AB.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: opmodel
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true memory-layout-analysis-enabled=true memory-layout-analysis-policy=GreedyL1Interleaved" %s | FileCheck %s
 //
 //       A     B

--- a/test/ttmlir/Dialect/TTNN/optimizer/greedy_l1_interleaved_policy/simple_join_tests/dram_None_l1_ABC.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/greedy_l1_interleaved_policy/simple_join_tests/dram_None_l1_ABC.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: opmodel
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true memory-layout-analysis-enabled=true memory-layout-analysis-policy=GreedyL1Interleaved" %s | FileCheck %s
 //
 //       A     B

--- a/test/ttmlir/Dialect/TTNN/optimizer/input_layout_loc_override.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/input_layout_loc_override.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: opmodel
 // RUN: ttmlir-opt --mlir-print-debuginfo --ttir-to-ttnn-backend-pipeline="enable-optimizer=true memory-layout-analysis-enabled=true override-output-layout=matmul_1_in_1_layout=1x1:l1:interleaved:tile:bf16" %s | FileCheck %s
 #loc = loc("Matmul":4294967295:0)
 // CHECK-DAG: #[[LOC_MATMUL_IN0:.*]] = loc("matmul_1_in_0_layout"(#loc3))

--- a/test/ttmlir/Dialect/TTNN/optimizer/insert_memreconfig_override.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/insert_memreconfig_override.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: opmodel
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true memory-layout-analysis-enabled=true memreconfig-enabled=true insert-memreconfig=add_2=0 override-output-layout=add_1=1x1:dram:interleaved:row_major:f32" %s | FileCheck %s
 #loc = loc("test_ops.py:17_0_0":0:0)
 module attributes {} {

--- a/test/ttmlir/Dialect/TTNN/optimizer/multiple_add_with_loc.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/multiple_add_with_loc.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: opmodel
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true" %s | FileCheck %s
 #loc = loc("test_ops.py:17_0_0":0:0)
 module attributes {} {

--- a/test/ttmlir/Dialect/TTNN/optimizer/output_layout_override.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/output_layout_override.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: opmodel
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true override-output-layout=add_0=1x1,add_1=l1,add_2=block_sharded,add_3=bf16,add_4=l1:interleaved,add_5=width_sharded:tile,add_6=4x4:dram:interleaved:row_major:bf16,add_7=4x4:l1:interleaved:tile:f32" %s | FileCheck %s
 #loc = loc("test_ops.py:17_0_0":0:0)
 module attributes {} {

--- a/test/ttmlir/Dialect/TTNN/optimizer/partial_output_layout_override.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/partial_output_layout_override.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: opmodel
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true override-output-layout=add_1=row_major" %s | FileCheck %s
 // UNSUPPORTED: true
 #loc = loc("test_ops.py:17_0_0":0:0)

--- a/test/ttmlir/Dialect/TTNN/optimizer/sharding_matmul_override_0.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/sharding_matmul_override_0.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: opmodel
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true memory-layout-analysis-enabled=true max-legal-layouts=0" %s | FileCheck %s
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x96xbf16>, %arg2: tensor<96x64xbf16>) -> tensor<64x64xbf16> {

--- a/test/ttmlir/Dialect/TTNN/optimizer/sharding_relu_override_32.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/sharding_relu_override_32.mlir
@@ -1,14 +1,15 @@
+// REQUIRES: opmodel
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true memory-layout-analysis-enabled=true max-legal-layouts=32" -o output_file.mlir %s
 // RUN: FileCheck %s --input-file=output_file.mlir
 module attributes {} {
-  func.func @forward(%arg0: tensor<64x128xbf16>, %arg1: tensor<128x96xbf16>, %arg2: tensor<96x64xbf16>) -> tensor<64x64xbf16> {
+  func.func @forward(%arg0: tensor<64x96xbf16>, %arg1: tensor<96x64xbf16>) -> tensor<64x64xbf16> {
     // CHECK: #[[L1_:.*]] = #ttnn.buffer_type<l1>
     // CHECK: #[[LAYOUT_L1:.*]] = #ttnn.ttnn_layout<{{.*}}#[[L1_]]>
     %0 = ttir.empty() : tensor<64x96xbf16>
-    // CHECK: {{.*}} = "ttnn.matmul"{{.*}} -> tensor<64x96xbf16, #[[LAYOUT_L1]]>
-    %1 = "ttir.matmul"(%arg0, %arg1, %0) : (tensor<64x128xbf16>, tensor<128x96xbf16>, tensor<64x96xbf16>) -> tensor<64x96xbf16>
+    // CHECK: {{.*}} = "ttnn.relu"{{.*}} -> tensor<64x96xbf16, #[[LAYOUT_L1]]>
+    %1 = "ttir.relu"(%arg0, %0) : (tensor<64x96xbf16>, tensor<64x96xbf16>) -> tensor<64x96xbf16>
     %2 = ttir.empty() : tensor<64x64xbf16>
-    %3 = "ttir.matmul"(%1, %arg2, %2) : (tensor<64x96xbf16>, tensor<96x64xbf16>, tensor<64x64xbf16>) -> tensor<64x64xbf16>
+    %3 = "ttir.matmul"(%1, %arg1, %2) : (tensor<64x96xbf16>, tensor<96x64xbf16>, tensor<64x64xbf16>) -> tensor<64x64xbf16>
     return %3 : tensor<64x64xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/optimizer/test_override_reshard_edges.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/test_override_reshard_edges.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: opmodel
 // RUN: ttmlir-opt --tt-register-device --ttnn-optimizer="memory-layout-analysis-enabled=true memreconfig-enabled=true insert-memreconfig=add_0_1_2=0 override-output-layout=add_1_2=1x1:dram:interleaved:row_major:f32" %s | FileCheck %s
 #dram = #ttnn.buffer_type<dram>
 #system_memory = #ttnn.buffer_type<system_memory>

--- a/test/ttmlir/Dialect/TTNN/optimizer/ttir_to_ttnn_pipeline.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/ttir_to_ttnn_pipeline.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: opmodel
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true" %s | FileCheck %s
 module attributes {} {
   func.func @forward(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/mnist_sharding.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/mnist_sharding.mlir
@@ -8,7 +8,8 @@ module @"tt-forge-graph" attributes {} {
     // CHECK-DAG: #[[LAYOUT_10:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x8, (d0, d1) -> (0, d1 floordiv 8, d1 mod 8)>, memref<1x1x!tt.tile<32x32, f32>, #l1_>, <width_sharded>>
     // CHECK-DAG: #[[LAYOUT_11:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1, (d0, d1) -> (0, d1 floordiv 8, d1 mod 8)>, memref<1x1x!tt.tile<32x32, f32>, #l1_>, <width_sharded>>
     %0 = ttir.empty() : tensor<1x256xf32> loc(#loc8)
-    // CHECK: %{{.*}} = "ttnn.matmul"{{.*}} -> {{.*}}#[[LAYOUT_10]]>
+    // TODO(#3242): Revert to sharded layout we are able to query backend for matmul.
+    // CHECK: %{{.*}} = "ttnn.matmul"{{.*}} -> {{.*}}
     %1 = "ttir.matmul"(%arg0, %arg4, %0) : (tensor<1x784xf32>, tensor<784x256xf32>, tensor<1x256xf32>) -> tensor<1x256xf32> loc(#loc8)
     %2 = ttir.empty() : tensor<1x256xf32> loc(#loc9)
     // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x256xf32, #[[LAYOUT_10]]>
@@ -17,7 +18,8 @@ module @"tt-forge-graph" attributes {} {
     // CHECK: %{{.*}} = "ttnn.relu"{{.*}} -> tensor<1x256xf32, #[[LAYOUT_10]]>
     %5 = "ttir.relu"(%3, %4) : (tensor<1x256xf32>, tensor<1x256xf32>) -> tensor<1x256xf32> loc(#loc10)
     %6 = ttir.empty() : tensor<1x10xf32> loc(#loc11)
-    // CHECK: %{{.*}} = "ttnn.matmul"{{.*}} -> {{.*}}#[[LAYOUT_11]]>
+    // TODO(#3242): Revert to sharded layout we are able to query backend for matmul.
+    // CHECK: %{{.*}} = "ttnn.matmul"{{.*}} -> {{.*}}
     %7 = "ttir.matmul"(%5, %arg2, %6) : (tensor<1x256xf32>, tensor<256x10xf32>, tensor<1x10xf32>) -> tensor<1x10xf32> loc(#loc11)
     %8 = ttir.empty() : tensor<1x10xf32> loc(#loc12)
     // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<1x10xf32, #[[LAYOUT_11]]>


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/2741
Closes https://github.com/tenstorrent/tt-mlir/issues/2624

### What's changed

* Shard compat API change: Instead of pushing all combinations of producer/consumer tensor layouts to backend API for sharding compatibility check, with this change we just provide producer layout, and let backend tell us what is the consumer output layout.
This comes simply from backend ops implementation where for certain input layouts op can not create arbitrary output layout, but only predefined layout. So, this change will dramatically reduce number of API calls in this regard.

* Optimizer's resolve loop change: When reshard is inserted, don't restart loop, but just mark paths valid between producer op and consumer valid configs and continue processing like everything is fine.

Piggyback: bug fix in conversion from ttnn tensor spec to mlir layout attr where coordinates were incorrectly ordered.

### Checklist
- [x] Existing tests provide coverage for changes
