### PR TITLE
Uplift third_party/tt-metal to 1a9bf1ab81550daf2031b928e7152aabf1396260 2025-05-02

### DIFF
--- a/include/ttmlir/OpModel/TTNN/SingletonDeviceContext.h
+++ b/include/ttmlir/OpModel/TTNN/SingletonDeviceContext.h
@@ -8,10 +8,13 @@
 
 #include "hostdevcommon/common_values.hpp"
 #include <cstddef>
+#include <memory>
 
 namespace tt {
 namespace tt_metal {
-class IDevice;
+namespace distributed {
+class MeshDevice;
+} // namespace distributed
 } // namespace tt_metal
 } // namespace tt
 
@@ -30,7 +33,9 @@ public:
   static void resetInstance();
   static void closeInstance();
 
-  ::tt::tt_metal::IDevice *getDevice() { return m_device; }
+  ::tt::tt_metal::distributed::MeshDevice *getDevice() {
+    return m_device.get();
+  }
 
 private:
   SingletonDeviceContext(
@@ -40,7 +45,7 @@ private:
   SingletonDeviceContext(const SingletonDeviceContext &) = delete;
   SingletonDeviceContext &operator=(const SingletonDeviceContext &) = delete;
 
-  ::tt::tt_metal::IDevice *m_device;
+  std::shared_ptr<::tt::tt_metal::distributed::MeshDevice> m_device;
 
   void openDevice(const size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE);
   void closeDevice();

--- a/lib/OpModel/TTNN/SingletonDeviceContext.cpp
+++ b/lib/OpModel/TTNN/SingletonDeviceContext.cpp
@@ -13,8 +13,9 @@ namespace mlir::tt::op_model::ttnn {
 // todo(arminaleTT): look into dynamically adjusting this
 // getOpRuntime() uses trace capture to run and measure the runtime of an op.
 // This requires the device to be opened with sufficient trace region size. This
-// number is currently set based on manual testing of supported ops
-static constexpr size_t opModelDefaultTraceRegionSize = 200000;
+// number is currently set based on manual testing of supported ops to
+// accommodate the highest required trace buffer size (304128B)
+static constexpr size_t opModelDefaultTraceRegionSize = 350000;
 
 SingletonDeviceContext::SingletonDeviceContext(const size_t traceRegionSize) {
   openDevice(traceRegionSize);
@@ -49,15 +50,18 @@ void SingletonDeviceContext::openDevice(const size_t traceRegionSize) {
   ::tt::tt_metal::DispatchCoreType dispatchCoreType =
       numDevices == numPCIeDevices ? ::tt::tt_metal::DispatchCoreType::WORKER
                                    : ::tt::tt_metal::DispatchCoreType::ETH;
-  m_device = ::tt::tt_metal::CreateDevice(
-      0, /* num_hw_cqs = */ 1,
+
+  ::tt::tt_metal::distributed::MeshShape shape{1, 1};
+  m_device = ::tt::tt_metal::distributed::MeshDevice::create(
+      ::tt::tt_metal::distributed::MeshDeviceConfig{shape},
       /* l1_small_size = */ ::tt::constants::L1_SMALL_SIZE,
-      /* trace_region_size = */ traceRegionSize, dispatchCoreType);
+      /* trace_region_size = */ traceRegionSize,
+      /* num_hw_cqs = */ 1, dispatchCoreType);
 }
 
 void SingletonDeviceContext::closeDevice() {
   if (m_device) {
-    ::tt::tt_metal::CloseDevice(m_device);
+    m_device->close();
     m_device = nullptr;
   }
 }

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -170,7 +170,7 @@ void checkGrid(const ::tt::tt_metal::CoreCoord &computeGridSize,
  * @param device Pointer to an open device to obtain the compute grid size
  */
 llvm::Expected<::ttnn::TensorSpec>
-convertToTensorSpec(::tt::tt_metal::IDevice *device,
+convertToTensorSpec(::tt::tt_metal::distributed::MeshDevice *device,
                     ::llvm::ArrayRef<int64_t> shape,
                     ::mlir::tt::ttnn::TTNNLayoutAttr layout) {
   const ::ttnn::TensorSpec spec = conversion::getTensorSpec(shape, layout);
@@ -282,7 +282,7 @@ getPrepareConv2dWeightsOpOutputTensorSpec(
   ::tt::tt_metal::Tensor weightTensor =
       createMetalHostTensor(weightShape, weightLayout.getDataType());
 
-  ::tt::tt_metal::IDevice *device =
+  ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
   auto inputSpecExp =
@@ -296,7 +296,7 @@ getPrepareConv2dWeightsOpOutputTensorSpec(
       conv2dConfigConverted = conversion::getConv2dConfig(conv2dConfig);
 
   auto prepare_fn = &::ttnn::operations::conv::conv2d::prepare_conv_weights<
-      ::tt::tt_metal::IDevice>;
+      ::tt::tt_metal::distributed::MeshDevice>;
   // Create query closure
   auto prepareConv2dWeightsOpQuery = [=]() {
     ::ttnn::operations::conv::conv2d::Conv2dConfig localConfig;
@@ -407,7 +407,7 @@ getEltwiseUnaryOpConstraints(std::string_view opName, OpSymbol opSymbol,
                              mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
                              llvm::ArrayRef<int64_t> outputShape,
                              mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
-  ::tt::tt_metal::IDevice *device =
+  ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
   auto inputSpecExp =
@@ -435,7 +435,7 @@ getEltwiseUnaryOpRuntime(std::string_view opName, OpSymbol opSymbol,
                          mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
                          llvm::ArrayRef<int64_t> outputShape,
                          mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
-  ::tt::tt_metal::IDevice *device =
+  ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
   auto inputSpecExp =
@@ -472,7 +472,7 @@ getEltwiseBinaryOpConstraints(std::string_view opName, OpSymbol opSymbol,
                               mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
                               llvm::ArrayRef<int64_t> outputShape,
                               mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
-  ::tt::tt_metal::IDevice *device =
+  ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
   auto inputSpecAExp =
@@ -522,7 +522,7 @@ getEltwiseBinaryOpRuntime(std::string_view opName, OpSymbol opSymbol,
                           mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
                           llvm::ArrayRef<int64_t> outputShape,
                           mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
-  ::tt::tt_metal::IDevice *device =
+  ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
   auto inputSpecAExp =
@@ -637,7 +637,7 @@ SigmoidOpInterface::getOpConstraints(
     llvm::ArrayRef<int64_t> outputShape,
     mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  ::tt::tt_metal::IDevice *device =
+  ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
   auto inputSpecExp =
@@ -672,7 +672,7 @@ SigmoidOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                  llvm::ArrayRef<int64_t> outputShape,
                                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  ::tt::tt_metal::IDevice *device =
+  ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
   auto inputSpecExp =
@@ -748,7 +748,7 @@ SoftmaxOpInterface::getOpConstraints(
     llvm::ArrayRef<int64_t> outputShape,
     mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  ::tt::tt_metal::IDevice *device =
+  ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
   auto inputSpecExp =
@@ -780,7 +780,7 @@ SoftmaxOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                  llvm::ArrayRef<int64_t> outputShape,
                                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  ::tt::tt_metal::IDevice *device =
+  ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
   auto inputSpecExp =
@@ -815,7 +815,7 @@ MeanOpInterface::getOpConstraints(GridAttr deviceGrid,
                                   bool keepDim,
                                   mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  ::tt::tt_metal::IDevice *device =
+  ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
   auto inputSpecExp =
@@ -854,7 +854,7 @@ MeanOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                               bool keepDim,
                               mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  ::tt::tt_metal::IDevice *device =
+  ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
   auto inputSpecExp =
@@ -896,7 +896,7 @@ ReshapeOpInterface::getOpConstraints(
     llvm::ArrayRef<int64_t> outputShape,
     mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  ::tt::tt_metal::IDevice *device =
+  ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
   auto inputSpecExp =
@@ -927,7 +927,7 @@ ReshapeOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                  llvm::ArrayRef<int64_t> outputShape,
                                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  ::tt::tt_metal::IDevice *device =
+  ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
   auto inputSpecExp =
@@ -961,7 +961,7 @@ TypecastOpInterface::getOpConstraints(
     llvm::ArrayRef<int64_t> outputShape,
     mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  ::tt::tt_metal::IDevice *device =
+  ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
   auto inputSpecExp =
@@ -994,7 +994,7 @@ TypecastOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                   llvm::ArrayRef<int64_t> outputShape,
                                   mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  ::tt::tt_metal::IDevice *device =
+  ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
   auto inputSpecExp =
@@ -1029,7 +1029,7 @@ ToLayoutOpInterface::getOpConstraints(
     std::optional<mlir::tt::DataType> outputDtype,
     mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool passDevicePtr) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  ::tt::tt_metal::IDevice *device =
+  ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
   auto inputSpecExp =
@@ -1069,7 +1069,7 @@ ToLayoutOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                   mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
                                   bool passDevicePtr) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  ::tt::tt_metal::IDevice *device =
+  ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
   auto inputSpecExp =
@@ -1111,7 +1111,7 @@ TransposeOpInterface::getOpConstraints(
     mlir::tt::ttnn::TTNNLayoutAttr inputLayout, const int dim0, const int dim1,
     mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  ::tt::tt_metal::IDevice *device =
+  ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
   auto inputSpecExp =
@@ -1141,7 +1141,7 @@ llvm::Expected<size_t> TransposeOpInterface::getOpRuntime(
     mlir::tt::ttnn::TTNNLayoutAttr inputLayout, const int dim0, const int dim1,
     mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  ::tt::tt_metal::IDevice *device =
+  ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
   auto inputSpecExp =
@@ -1178,7 +1178,7 @@ MatmulOpInterface::getOpConstraints(GridAttr deviceGrid,
                                     mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
                                     bool transposeA, bool transposeB) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  ::tt::tt_metal::IDevice *device =
+  ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
   auto inputSpecAExp =
@@ -1232,7 +1232,7 @@ MatmulOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
                                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
                                 bool transposeA, bool transposeB) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  ::tt::tt_metal::IDevice *device =
+  ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
   auto inputSpecAExp =
@@ -1342,7 +1342,7 @@ Conv2dOpInterface::getOpConstraints(
   }
   ::ttnn::TensorSpec weightSpec = preparedWeightExp.get();
 
-  ::tt::tt_metal::IDevice *device =
+  ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
   auto inputSpecExp =
@@ -1425,7 +1425,7 @@ llvm::Expected<size_t> Conv2dOpInterface::getOpRuntime(
 
   ::ttnn::TensorSpec weightSpec = preparedWeightExp.get();
 
-  ::tt::tt_metal::IDevice *device =
+  ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
   auto inputSpecExp =
@@ -1489,7 +1489,7 @@ MaxPool2DInterface::getOpConstraints(
     mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
-  ::tt::tt_metal::IDevice *device =
+  ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
   // convert all signed integers to unsigned integers
@@ -1537,7 +1537,7 @@ llvm::Expected<size_t> MaxPool2DInterface::getOpRuntime(
     bool ceilMode, llvm::ArrayRef<int64_t> outputShape,
     mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  ::tt::tt_metal::IDevice *device =
+  ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
   // convert all signed integers to unsigned integers
@@ -1586,7 +1586,7 @@ ClampScalarInterface::getOpConstraints(
     mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
-  ::tt::tt_metal::IDevice *device =
+  ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
   // Convert float
@@ -1622,7 +1622,7 @@ llvm::Expected<size_t> ClampScalarInterface::getOpRuntime(
     mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
-  ::tt::tt_metal::IDevice *device =
+  ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
 
   // Convert float

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -24,7 +24,6 @@ namespace tt::runtime::ttnn {
 
 using ::tt::runtime::DeviceRuntime;
 using ::tt::tt_metal::DistributedTensorConfig;
-using ::tt::tt_metal::raise_unsupported_storage;
 
 static tt::runtime::MemoryView
 createMemoryView(const tt::tt_metal::detail::MemoryView &memoryView) {

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "d3c455c9de1431ab0bfd0f2d89bf0e79b354a3bf")
+set(TT_METAL_VERSION "ccf08c0038fe32cc4281a9014fa607652c0c7bd0")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -2,6 +2,10 @@ include(ExternalProject)
 
 set(TT_METAL_VERSION "1a9bf1ab81550daf2031b928e7152aabf1396260")
 
+file(GLOB XTENSOR_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/xtensor/*/include")
+file(GLOB XTENSOR_BLAS_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/xtensor-blas/*/include")
+file(GLOB XTL_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/xtl/*/include")
+
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 
 if ("$ENV{ARCH_NAME}" STREQUAL "grayskull")
@@ -51,9 +55,9 @@ set(TTMETAL_INCLUDE_DIRS
   ${CPM_SOURCE_CACHE}/magic_enum/4d76fe0a5b27a0e62d6c15976d02b33c54207096/include
   ${CPM_SOURCE_CACHE}/boost/1359e136761ab2d10afa1c4e21086c8d824735cd/libs/core/include
   ${CPM_SOURCE_CACHE}/nlohmann_json/798e0374658476027d9723eeb67a262d0f3c8308/include
-  ${CPM_SOURCE_CACHE}/xtensor/c46fa4d34d719a7efc5f310a89f10bdf1e167ebc/include
-  ${CPM_SOURCE_CACHE}/xtensor-blas/0047541801f16eb7eefdacfdf251c5f06c8f10d0/include
-  ${CPM_SOURCE_CACHE}/xtl/47c2dd39d2d18cfa94b1db25e7dace936e428f78/include
+  ${XTENSOR_INCLUDE_DIRS}
+  ${XTENSOR_BLAS_INCLUDE_DIRS}
+  ${XTL_INCLUDE_DIRS}
   PARENT_SCOPE
 )
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "ccf08c0038fe32cc4281a9014fa607652c0c7bd0")
+set(TT_METAL_VERSION "1a9bf1ab81550daf2031b928e7152aabf1396260")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -51,9 +51,9 @@ set(TTMETAL_INCLUDE_DIRS
   ${CPM_SOURCE_CACHE}/magic_enum/4d76fe0a5b27a0e62d6c15976d02b33c54207096/include
   ${CPM_SOURCE_CACHE}/boost/1359e136761ab2d10afa1c4e21086c8d824735cd/libs/core/include
   ${CPM_SOURCE_CACHE}/nlohmann_json/798e0374658476027d9723eeb67a262d0f3c8308/include
-  ${CPM_SOURCE_CACHE}/xtensor/4a957e26c765b48cbec4a4235fe9e518d5a85d3d/include
-  ${CPM_SOURCE_CACHE}/xtensor-blas/190c3a4314355b67291a7d78b20a2100de3f8f54/include
-  ${CPM_SOURCE_CACHE}/xtl/0918808959d33a292c551b9f014a0e808bc4a95c/include
+  ${CPM_SOURCE_CACHE}/xtensor/c46fa4d34d719a7efc5f310a89f10bdf1e167ebc/include
+  ${CPM_SOURCE_CACHE}/xtensor-blas/0047541801f16eb7eefdacfdf251c5f06c8f10d0/include
+  ${CPM_SOURCE_CACHE}/xtl/47c2dd39d2d18cfa94b1db25e7dace936e428f78/include
   PARENT_SCOPE
 )
 

--- a/tools/ttnn-standalone/CMakeLists.txt
+++ b/tools/ttnn-standalone/CMakeLists.txt
@@ -69,9 +69,9 @@ set(INCLUDE_DIRS
     ${CPM_SOURCE_CACHE}/magic_enum/4d76fe0a5b27a0e62d6c15976d02b33c54207096/include
     ${CPM_SOURCE_CACHE}/boost/1359e136761ab2d10afa1c4e21086c8d824735cd/libs/core/include
     ${CPM_SOURCE_CACHE}/nlohmann_json/798e0374658476027d9723eeb67a262d0f3c8308/include
-    ${CPM_SOURCE_CACHE}/xtensor/4a957e26c765b48cbec4a4235fe9e518d5a85d3d/include
-    ${CPM_SOURCE_CACHE}/xtensor-blas/190c3a4314355b67291a7d78b20a2100de3f8f54/include
-    ${CPM_SOURCE_CACHE}/xtl/0918808959d33a292c551b9f014a0e808bc4a95c/include
+    ${CPM_SOURCE_CACHE}/xtensor/c46fa4d34d719a7efc5f310a89f10bdf1e167ebc/include
+    ${CPM_SOURCE_CACHE}/xtensor-blas/0047541801f16eb7eefdacfdf251c5f06c8f10d0/include
+    ${CPM_SOURCE_CACHE}/xtl/47c2dd39d2d18cfa94b1db25e7dace936e428f78/include
 
     # Metalium
     $ENV{TT_METAL_HOME}

--- a/tools/ttnn-standalone/CMakeLists.txt
+++ b/tools/ttnn-standalone/CMakeLists.txt
@@ -60,6 +60,10 @@ else()
 endif()
 message(STATUS "Setting tt-metal CPM cache to: ${CPM_SOURCE_CACHE}")
 
+file(GLOB XTENSOR_INCLUDE_DIRS "${CPM_SOURCE_CACHE}/xtensor/*/include")
+file(GLOB XTENSOR_BLAS_INCLUDE_DIRS "${CPM_SOURCE_CACHE}/xtensor-blas/*/include")
+file(GLOB XTL_INCLUDE_DIRS "${CPM_SOURCE_CACHE}/xtl/*/include")
+
 # Directories to search for headers
 #
 set(INCLUDE_DIRS
@@ -69,9 +73,9 @@ set(INCLUDE_DIRS
     ${CPM_SOURCE_CACHE}/magic_enum/4d76fe0a5b27a0e62d6c15976d02b33c54207096/include
     ${CPM_SOURCE_CACHE}/boost/1359e136761ab2d10afa1c4e21086c8d824735cd/libs/core/include
     ${CPM_SOURCE_CACHE}/nlohmann_json/798e0374658476027d9723eeb67a262d0f3c8308/include
-    ${CPM_SOURCE_CACHE}/xtensor/c46fa4d34d719a7efc5f310a89f10bdf1e167ebc/include
-    ${CPM_SOURCE_CACHE}/xtensor-blas/0047541801f16eb7eefdacfdf251c5f06c8f10d0/include
-    ${CPM_SOURCE_CACHE}/xtl/47c2dd39d2d18cfa94b1db25e7dace936e428f78/include
+    ${XTENSOR_INCLUDE_DIRS}
+    ${XTENSOR_BLAS_INCLUDE_DIRS}
+    ${XTL_INCLUDE_DIRS}
 
     # Metalium
     $ENV{TT_METAL_HOME}


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 1a9bf1ab81550daf2031b928e7152aabf1396260

- Remove reference to raise_unsupported_storage removed in tt-metal 6f3458e
- Replace references to IDevice with MeshDevice and increase traceregionsize after metal commit ebbdb91397
- Update xtensor lib include paths after metal commit 458187359b
    - Temporarily using `file(GLOB ...)` to find xtensor include path, since local and CI resolve to different include paths.