### PR TITLE
[EmitC] Fix function name collision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,10 @@ third_party/tt-metal
 *pycache*
 *.egg-info
 cluster_descriptor.yaml
+
+# ttnn-dylib and ttnn-standalone artifacts
 tools/ttnn-standalone/ttnn-dylib.cpp
+tools/ttnn-standalone/ttnn-standalone.cpp
 
 CMakeUserPresets.json
 compile_commands.json

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -64,25 +64,26 @@ def TTNNCreateInputGenerators: Pass<"ttnn-create-input-gens", "::mlir::ModuleOp"
 
     Given a forward function like this:
 
-    ```
+    ```mlir
     func.func @add(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>) -> tensor<32x32xbf16> {
       %0 = "ttnn.add"(%arg0, %arg1) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
       return %0 : tensor<32x32xbf16>
     }
     ```
 
-    The pass will create two function like this:
+    The pass will prepend `_` to the existing function name to avoid name collision
+    and create two function like this:
 
-    ```
-    func.func @createInputsFor_add() -> (tensor<32x32xbf16>, tensor<32x32xbf16>) {
+    ```mlir
+    func.func @create_inputs_for_add() -> (tensor<32x32xbf16>, tensor<32x32xbf16>) {
       %0 = "ttnn.empty"() <{shape = #ttnn.shape<32x32>}> : () -> tensor<32x32xbf16>
       %1 = "ttnn.empty"() <{shape = #ttnn.shape<32x32>}> : () -> tensor<32x32xbf16>
       return %0, %1 : tensor<32x32xbf16>, tensor<32x32xbf16>
     }
 
     func.func @main() -> i32 {
-      %0:2 = call @createInputsFor_add() : () -> (tensor<32x32xbf16>, tensor<32x32xbf16>)
-      %1 = call @add(%0#0, %0#1) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+      %0:2 = call @create_inputs_for_add() : () -> (tensor<32x32xbf16>, tensor<32x32xbf16>)
+      %1 = call @_add(%0#0, %0#1) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
       %c0_i32 = arith.constant 0 : i32
       return %c0_i32 : i32
     }

--- a/lib/Dialect/TTNN/Transforms/Passes.cpp
+++ b/lib/Dialect/TTNN/Transforms/Passes.cpp
@@ -17,6 +17,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/TypeRange.h"
 #include "mlir/IR/ValueRange.h"
@@ -145,185 +146,181 @@ public:
       TTNNCreateInputGenerators>::TTNNCreateInputGeneratorsBase;
 
   void runOnOperation() final {
-    ModuleOp module = getOperation();
+    ModuleOp moduleOp = getOperation();
     IRRewriter rewriter(&getContext());
 
     // Ensure that the module has a single region and a single block within that
-    // region
-    assert(module->getRegions().size() == 1);
-    assert(module->getRegion(0).getBlocks().size() == 1);
-
-    // Get the first block of the region at index 0
+    // region.
     //
-    Block *firstBlock = module.getBody(0);
+    assert(moduleOp->getRegions().size() == 1);
+    assert(moduleOp->getRegion(0).hasOneBlock());
 
-    // Find all the func.func ops in the module that are "forward" functions
+    // Get the only existing block.
+    //
+    Block *block = moduleOp.getBody(0);
+
+    // Find all the func.func ops in the module that are "forward" functions.
     //
     SmallVector<func::FuncOp, 1> forwardFuncOps;
-    for (mlir::Operation &op : firstBlock->getOperations()) {
-      if (mlir::func::FuncOp funcOp = dyn_cast<func::FuncOp>(op)) {
+    block->walk([&](func::FuncOp funcOp) {
+      // Rename the function to be prefixed with an underscore. This is done to
+      // avoid name conflicts with the input generator functions and the `main`
+      // function.
+      //
+      rewriter.modifyOpInPlace(
+          funcOp, [&]() { funcOp.setSymName("_" + funcOp.getName().str()); });
 
-        // Skip functions that are called elsewhere in the IR
-        //
-        // This will skip utility functions that are used by other functions,
-        // only top-level "forward" functions should be considered
-        //
-        if (!funcOp->getUses().empty()) {
-          continue;
-        }
-
-        forwardFuncOps.push_back(funcOp);
+      if (!funcOp->getUses().empty()) {
+        mlir::WalkResult::skip();
       }
-    }
+      forwardFuncOps.push_back(funcOp);
+    });
 
-    // Iterate over all the func ops and add input tensor generator functions
+    // Iterate over all func ops and add input tensor generator functions.
     //
+    llvm::SmallVector<mlir::func::FuncOp, 1> inputGenFuncOps;
     for (mlir::func::FuncOp forwardFuncOp : forwardFuncOps) {
-      // Get all the input tensors for the current forward func
-      //
-      llvm::SmallVector<mlir::RankedTensorType, 2> inputTensors;
-      for (auto input : forwardFuncOp.getFunctionType().getInputs()) {
-        inputTensors.push_back(llvm::cast<mlir::RankedTensorType>(input));
-      }
-
-      // Create a new function that will generate the input tensors
-      //
-      std::string inputGenFuncName =
-          "createInputsFor_" + forwardFuncOp.getName().str();
-
-      // Create function type
-      //
-      mlir::TypeRange returnTypeRange =
-          mlir::TypeRange(forwardFuncOp.getFunctionType().getInputs());
-      FunctionType functionType =
-          mlir::FunctionType::get(&getContext(), {}, returnTypeRange);
-
-      // Set insertion point to end of first block
-      //
-      rewriter.setInsertionPointToEnd(firstBlock);
-
-      // Create the function
-      //
-      func::FuncOp inputGenFuncOp = rewriter.create<mlir::func::FuncOp>(
-          module->getLoc(), inputGenFuncName, functionType);
-
-      // Add a Block to func op and set insertion point to the beginning of the
-      // Block
-      //
-      ::mlir::Block *currFnBlock = inputGenFuncOp.addEntryBlock();
-      rewriter.setInsertionPointToStart(currFnBlock);
-
-      // Create the input tensors
-      //
-      SmallVector<Value, 2> generatedTensors;
-      for (Type tensorType : returnTypeRange) {
-        assert(llvm::isa<mlir::RankedTensorType>(tensorType));
-
-        RankedTensorType tensor =
-            llvm::cast<mlir::RankedTensorType>(tensorType);
-
-        // Get the layout attribute
-        //
-        ttnn::TTNNLayoutAttr layoutAttr =
-            mlir::cast<ttnn::TTNNLayoutAttr>(tensor.getEncoding());
-
-        // Get the shape of the tensor, tensor layout, and data type
-        //
-        ShapeAttr shapeAttr =
-            ttnn::ShapeAttr::get(&getContext(), tensor.getShape());
-        ttnn::LayoutAttr tensorLayoutAttr =
-            ttnn::LayoutAttr::get(&getContext(), layoutAttr.getLayout());
-        DataTypeAttr dTypeAttr =
-            DataTypeAttr::get(&getContext(), layoutAttr.getDataType());
-
-        // Create a new tensor
-        //
-        ttnn::OnesOp onesOp = rewriter.create<ttnn::OnesOp>(
-            forwardFuncOp->getLoc(), tensorType, shapeAttr, dTypeAttr,
-            tensorLayoutAttr, nullptr, nullptr);
-
-        // If tensor is meant to be on device, add ToDevice op
-        //
-        if (layoutAttr.isDeviceBufferType()) {
-          ttnn::GetDeviceOp device =
-              ttnn::utils::getOrInsertDevice(rewriter, onesOp);
-
-          mlir::Value tensorOnDevice = rewriter.create<ttnn::ToDeviceOp>(
-              forwardFuncOp->getLoc(), tensorType, onesOp.getResult(),
-              device.getResult(), nullptr);
-
-          generatedTensors.push_back(tensorOnDevice);
-        } else {
-          generatedTensors.push_back(onesOp.getResult());
-        }
-      }
-
-      // Return the generated tensors
-      //
-      rewriter.create<func::ReturnOp>(forwardFuncOp->getLoc(),
-                                      generatedTensors);
+      rewriter.setInsertionPointToEnd(block);
+      inputGenFuncOps.emplace_back(createInputGeneratorFunction(
+          rewriter, moduleOp.getLoc(), forwardFuncOp));
     }
 
-    // Create a main function to call input generators and forward funcs
+    // Create a main function to call input generators and forward funcs.
     //
     {
-      // Create a new function that will generate the input tensors
-      //
       std::string mainFuncName = "main";
 
-      // Create function type
+      // Create a function type.
       //
-      mlir::Type i32Type = rewriter.getI32Type();
-      mlir::TypeRange returnTypeRange = mlir::TypeRange(i32Type);
       FunctionType functionType =
-          mlir::FunctionType::get(&getContext(), {}, returnTypeRange);
+          mlir::FunctionType::get(&getContext(), {}, rewriter.getI32Type());
 
-      // Set insertion point to end of first block
+      // Set insertion point to end of the block.
       //
-      rewriter.setInsertionPointToEnd(firstBlock);
+      rewriter.setInsertionPointToEnd(block);
 
-      // Create the function
+      // Create the main function.
       //
       func::FuncOp mainFuncOp = rewriter.create<mlir::func::FuncOp>(
-          module->getLoc(), mainFuncName, functionType);
+          moduleOp.getLoc(), mainFuncName, functionType);
 
-      ::mlir::Block *currFnBlock = mainFuncOp.addEntryBlock();
-
-      // Set insertion point to the beginning of the block
+      // Set insertion point to the start of the main function.
       //
-      rewriter.setInsertionPointToStart(currFnBlock);
+      rewriter.modifyOpInPlace(mainFuncOp, [&]() {
+        rewriter.setInsertionPointToStart(mainFuncOp.addEntryBlock());
+      });
 
-      // Call the input generators
-      //
-      for (mlir::func::FuncOp forwardFuncOp : forwardFuncOps) {
-        std::string inputGenFuncName =
-            "createInputsFor_" + forwardFuncOp.getName().str();
+      for (auto [forwardFuncOp, inputGenFuncOp] :
+           llvm::zip_equal(forwardFuncOps, inputGenFuncOps)) {
 
-        // Get the input generator function
+        // Generate the input tensors for a forwardFuncOp.
         //
-        mlir::func::FuncOp inputGenFuncOp =
-            module.lookupSymbol<mlir::func::FuncOp>(inputGenFuncName);
+        func::CallOp generatedTensors = rewriter.create<mlir::func::CallOp>(
+            forwardFuncOp.getLoc(), inputGenFuncOp, /*operands=*/ValueRange());
 
-        // Call the input generator function
+        // Call a forward function with the generated tensors.
         //
-        func::CallOp createdTensors = rewriter.create<mlir::func::CallOp>(
-            forwardFuncOp->getLoc(), inputGenFuncOp, ValueRange());
-
-        rewriter.create<mlir::func::CallOp>(forwardFuncOp->getLoc(),
+        rewriter.create<mlir::func::CallOp>(forwardFuncOp.getLoc(),
                                             forwardFuncOp,
-                                            createdTensors->getResults());
+                                            generatedTensors->getResults());
       }
 
       // Return 0
       //
       // func::ReturnOp requires a Value to be returned, which means that an SSA
-      // needs to be returned, hence create a constant 0 via arith::ConstantOp
+      // needs to be returned, hence create a constant 0 via arith::ConstantOp.
       //
       Value constantZero = rewriter.create<arith::ConstantOp>(
           rewriter.getUnknownLoc(), rewriter.getI32Type(),
           rewriter.getI32IntegerAttr(0));
       rewriter.create<func::ReturnOp>(mainFuncOp->getLoc(), constantZero);
     }
+  }
+
+private:
+  static func::FuncOp createInputGeneratorFunction(IRRewriter &rewriter,
+                                                   Location loc,
+                                                   func::FuncOp forwardFuncOp) {
+    MLIRContext *ctx = rewriter.getContext();
+    // Get all the input tensors for the current forward func.
+    //
+    llvm::SmallVector<mlir::RankedTensorType, 2> inputTensors(
+        llvm::map_to_vector(forwardFuncOp.getFunctionType().getInputs(),
+                            [](Type type) {
+                              return llvm::cast<mlir::RankedTensorType>(type);
+                            }));
+
+    // Create a new function that will generate the input tensors.
+    //
+    std::string inputGenFuncName =
+        "create_inputs_for" + forwardFuncOp.getName().str();
+
+    // Create the function type.
+    //
+    auto returnTypes = forwardFuncOp.getFunctionType().getInputs();
+    FunctionType functionType = mlir::FunctionType::get(ctx, {}, returnTypes);
+
+    // Create the function.
+    //
+    func::FuncOp inputGenFuncOp = rewriter.create<mlir::func::FuncOp>(
+        loc, inputGenFuncName, functionType);
+
+    // Add a Block to func op and set insertion point to the beginning of the
+    // Block.
+    //
+    rewriter.modifyOpInPlace(inputGenFuncOp, [&]() {
+      rewriter.setInsertionPointToStart(inputGenFuncOp.addEntryBlock());
+    });
+
+    // Create input tensors. Currently, we only create tensors of ones.
+    //
+    SmallVector<Value, 2> generatedTensors(
+        llvm::map_to_vector(returnTypes, [&](Type type) {
+          return generateTensor(rewriter, loc, type);
+        }));
+
+    rewriter.create<func::ReturnOp>(forwardFuncOp.getLoc(), generatedTensors);
+    return inputGenFuncOp;
+  }
+
+  // Currently only supports generating tensors of ones.
+  // TODO(azecevic): Support generating other types of tensors that has a
+  // `TT_CreationOpTrait`.
+  static mlir::Value generateTensor(IRRewriter &rewriter, Location loc,
+                                    Type type) {
+    MLIRContext *ctx = rewriter.getContext();
+    RankedTensorType tensorType = llvm::cast<mlir::RankedTensorType>(type);
+
+    // Get the layout attribute.
+    //
+    ttnn::TTNNLayoutAttr layoutAttr =
+        mlir::cast<ttnn::TTNNLayoutAttr>(tensorType.getEncoding());
+
+    // Get the shape of the tensor, tensor layout, and data type.
+    //
+    ShapeAttr shapeAttr = ttnn::ShapeAttr::get(ctx, tensorType.getShape());
+    ttnn::LayoutAttr tensorLayoutAttr =
+        ttnn::LayoutAttr::get(ctx, layoutAttr.getLayout());
+    DataTypeAttr dTypeAttr = DataTypeAttr::get(ctx, layoutAttr.getDataType());
+
+    // Create a new tensor of ones.
+    //
+    ttnn::OnesOp onesOp =
+        rewriter.create<ttnn::OnesOp>(loc, tensorType, shapeAttr, dTypeAttr,
+                                      tensorLayoutAttr, nullptr, nullptr);
+
+    // If tensor is meant to be on device, add ToDevice op.
+    //
+    if (layoutAttr.isDeviceBufferType()) {
+      ttnn::GetDeviceOp device =
+          ttnn::utils::getOrInsertDevice(rewriter, onesOp);
+
+      mlir::Value tensorOnDevice = rewriter.create<ttnn::ToDeviceOp>(
+          loc, tensorType, onesOp, device, nullptr);
+
+      return tensorOnDevice;
+    }
+    return onesOp;
   }
 };
 

--- a/test/ttmlir/Dialect/EmitC/func_name_collision.mlir
+++ b/test/ttmlir/Dialect/EmitC/func_name_collision.mlir
@@ -1,0 +1,22 @@
+// RUN: ttmlir-opt -ttir-to-emitc-pipeline="system-desc-path=%system_desc_path%" %s | FileCheck %s
+
+// This test asserts that the function names in the TTIR module doesn't
+// conflict with the function names that are introduced as a part of the pipeline.
+module {
+  func.func @main(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    %0 = ttir.empty() : tensor<32x32xf32>
+    %1 = "ttir.add"(%arg0, %arg1, %0) : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+    return %1 : tensor<32x32xf32>
+  }
+}
+
+// CHECK-LABEL: func.func @_main
+// CHECK: %[[RET_VAL:.*]] = emitc.call_opaque "ttnn::add"
+// CHECK: return %[[RET_VAL]]
+
+// CHECK-LABEL: func.func @create_inputs_for_main
+// CHECK: return %{{.*}}, %{{.*}}
+
+// CHECK-LABEL: func.func @main
+// CHECK: call @create_inputs_for_main
+// CHECK: call @_main

--- a/test/ttmlir/Dialect/EmitC/func_name_collision.mlir
+++ b/test/ttmlir/Dialect/EmitC/func_name_collision.mlir
@@ -1,6 +1,6 @@
 // RUN: ttmlir-opt -ttir-to-emitc-pipeline="system-desc-path=%system_desc_path%" %s | FileCheck %s
 
-// This test asserts that the function names in the TTIR module doesn't
+// This test asserts that the function names in the TTIR module don't
 // conflict with the function names that are introduced as a part of the pipeline.
 module {
   func.func @main(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x32xf32> {
@@ -14,9 +14,9 @@ module {
 // CHECK: %[[RET_VAL:.*]] = emitc.call_opaque "ttnn::add"
 // CHECK: return %[[RET_VAL]]
 
-// CHECK-LABEL: func.func @create_inputs_for_main
+// CHECK-LABEL: func.func @create_inputs_for__main
 // CHECK: return %{{.*}}, %{{.*}}
 
 // CHECK-LABEL: func.func @main
-// CHECK: call @create_inputs_for_main
+// CHECK: call @create_inputs_for__main
 // CHECK: call @_main

--- a/test/ttmlir/Dialect/EmitC/ttir_to_emitc_pipeline_sanity.mlir
+++ b/test/ttmlir/Dialect/EmitC/ttir_to_emitc_pipeline_sanity.mlir
@@ -6,8 +6,8 @@
 // This test checks that the (TTIR to EmitC pipeline) is equivalent to (TTIR to TTNN pipeline + dialect conversion from TTNN to EmitC).
 // The `diff` command will return 0 if files are identical, otherwise it will return the diff, which will make `llvm-lit` treat the test as failed.
 
-// CHECK: func.func @add(%arg0: !emitc.opaque<"::ttnn::Tensor">, %arg1: !emitc.opaque<"::ttnn::Tensor">) -> !emitc.opaque<"::ttnn::Tensor"
-// CHECK: func.func @createInputsFor_add() -> (!emitc.opaque<"::ttnn::Tensor">, !emitc.opaque<"::ttnn::Tensor">)
+// CHECK: func.func @_add(%arg0: !emitc.opaque<"::ttnn::Tensor">, %arg1: !emitc.opaque<"::ttnn::Tensor">) -> !emitc.opaque<"::ttnn::Tensor"
+// CHECK: func.func @create_inputs_for_add() -> (!emitc.opaque<"::ttnn::Tensor">, !emitc.opaque<"::ttnn::Tensor">)
 // CHECK: func.func @main() -> i32
 func.func @add(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
   %0 = ttir.empty() : tensor<64x128xf32>

--- a/test/ttmlir/Dialect/EmitC/ttir_to_emitc_pipeline_sanity.mlir
+++ b/test/ttmlir/Dialect/EmitC/ttir_to_emitc_pipeline_sanity.mlir
@@ -6,7 +6,7 @@
 // This test checks that the (TTIR to EmitC pipeline) is equivalent to (TTIR to TTNN pipeline + dialect conversion from TTNN to EmitC).
 // The `diff` command will return 0 if files are identical, otherwise it will return the diff, which will make `llvm-lit` treat the test as failed.
 
-// CHECK: func.func @_add(%arg0: !emitc.opaque<"::ttnn::Tensor">, %arg1: !emitc.opaque<"::ttnn::Tensor">) -> !emitc.opaque<"::ttnn::Tensor"
+// CHECK: func.func @add(%arg0: !emitc.opaque<"::ttnn::Tensor">, %arg1: !emitc.opaque<"::ttnn::Tensor">) -> !emitc.opaque<"::ttnn::Tensor"
 // CHECK: func.func @create_inputs_for_add() -> (!emitc.opaque<"::ttnn::Tensor">, !emitc.opaque<"::ttnn::Tensor">)
 // CHECK: func.func @main() -> i32
 func.func @add(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/Dialect/TTNN/Transforms/ttnn_create_input_gens_0.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/ttnn_create_input_gens_0.mlir
@@ -7,7 +7,7 @@
 #ttnn_layout2 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
 #ttnn_layout3 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!tt.tile<32x32, bf16>, #system_memory>>
 module attributes {} {
-  // CHECK: func.func @_add(%arg0: [[TENSOR_A:.*]], %arg1: [[TENSOR_B:.*]]) -> [[TENSOR_OUT:.*]] {
+  // CHECK: func.func @add(%arg0: [[TENSOR_A:.*]], %arg1: [[TENSOR_B:.*]]) -> [[TENSOR_OUT:.*]] {
   func.func @add(%arg0: tensor<32x32xbf16, #ttnn_layout>, %arg1: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout> {
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     %1 = "ttnn.to_device"(%arg0, %0) <{memory_config = #ttnn.memory_config<#dram, <<1x1>>, <interleaved>>}> : (tensor<32x32xbf16, #ttnn_layout>, !ttnn.device) -> tensor<32x32xbf16, #ttnn_layout1>
@@ -31,5 +31,5 @@ module attributes {} {
 //
 // CHECK: func.func @main() -> i32 {
 // CHECK: %0:2 = call @create_inputs_for_add() : () -> ([[TENSOR_A]], [[TENSOR_B]])
-// CHECK: %1 = call @_add(%0#0, %0#1) : ([[TENSOR_A]], [[TENSOR_B]]) -> [[TENSOR_OUT]]
+// CHECK: %1 = call @add(%0#0, %0#1) : ([[TENSOR_A]], [[TENSOR_B]]) -> [[TENSOR_OUT]]
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/ttnn_create_input_gens_0.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/ttnn_create_input_gens_0.mlir
@@ -7,7 +7,7 @@
 #ttnn_layout2 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
 #ttnn_layout3 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!tt.tile<32x32, bf16>, #system_memory>>
 module attributes {} {
-  // CHECK: func.func @add(%arg0: [[TENSOR_A:.*]], %arg1: [[TENSOR_B:.*]]) -> [[TENSOR_OUT:.*]] {
+  // CHECK: func.func @_add(%arg0: [[TENSOR_A:.*]], %arg1: [[TENSOR_B:.*]]) -> [[TENSOR_OUT:.*]] {
   func.func @add(%arg0: tensor<32x32xbf16, #ttnn_layout>, %arg1: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout> {
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     %1 = "ttnn.to_device"(%arg0, %0) <{memory_config = #ttnn.memory_config<#dram, <<1x1>>, <interleaved>>}> : (tensor<32x32xbf16, #ttnn_layout>, !ttnn.device) -> tensor<32x32xbf16, #ttnn_layout1>
@@ -22,7 +22,7 @@ module attributes {} {
 
 // Confirm that the generator func is generated, and that the tensor attrs match:
 //
-// CHECK: func.func @createInputsFor_add() -> ([[TENSOR_A]], [[TENSOR_B]]) {
+// CHECK: func.func @create_inputs_for_add() -> ([[TENSOR_A]], [[TENSOR_B]]) {
 // CHECK: {{.*}} -> [[TENSOR_A]]
 // CHECK: {{.*}} -> [[TENSOR_B]]
 // CHECK: return %0, %1 : [[TENSOR_A]], [[TENSOR_B]]
@@ -30,6 +30,6 @@ module attributes {} {
 // Confirm that the main func is generated, and that the tensor attrs match:
 //
 // CHECK: func.func @main() -> i32 {
-// CHECK: %0:2 = call @createInputsFor_add() : () -> ([[TENSOR_A]], [[TENSOR_B]])
-// CHECK: %1 = call @add(%0#0, %0#1) : ([[TENSOR_A]], [[TENSOR_B]]) -> [[TENSOR_OUT]]
+// CHECK: %0:2 = call @create_inputs_for_add() : () -> ([[TENSOR_A]], [[TENSOR_B]])
+// CHECK: %1 = call @_add(%0#0, %0#1) : ([[TENSOR_A]], [[TENSOR_B]]) -> [[TENSOR_OUT]]
 }

--- a/tools/ttnn-standalone/ttnn-standalone.cpp
+++ b/tools/ttnn-standalone/ttnn-standalone.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn-precompiled.hpp"
-::ttnn::Tensor _add(::ttnn::Tensor v1, ::ttnn::Tensor v2) {
+::ttnn::Tensor add(::ttnn::Tensor v1, ::ttnn::Tensor v2) {
   ::ttnn::Tensor v3 = ttnn::add(v1, v2, ::std::nullopt, ::ttnn::MemoryConfig {.memory_layout = ::ttnn::TensorMemoryLayout::INTERLEAVED, .buffer_type = ::ttnn::BufferType::DRAM});
   ttnn::deallocate(v2, false);
   ttnn::deallocate(v1, false);
@@ -23,7 +23,7 @@ int32_t main() {
   ::ttnn::Tensor v1;
   ::ttnn::Tensor v2;
   std::tie(v1, v2) = create_inputs_for_add();
-  ::ttnn::Tensor v3 = _add(v1, v2);
+  ::ttnn::Tensor v3 = add(v1, v2);
   int32_t v4 = 0;
   return v4;
 }

--- a/tools/ttnn-standalone/ttnn-standalone.cpp
+++ b/tools/ttnn-standalone/ttnn-standalone.cpp
@@ -3,42 +3,27 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn-precompiled.hpp"
-ttnn::Tensor add(ttnn::Tensor v1, ttnn::Tensor v2) {
-  ttnn::IDevice* v3 = ttnn::DeviceGetter::getInstance();
-  ttnn::MemoryConfig v4 = ttnn::MemoryConfig(ttnn::TensorMemoryLayout::INTERLEAVED, ttnn::BufferType::DRAM);
-  ttnn::Tensor v5 = ttnn::to_device(v1, v3, v4);
-  ttnn::Tensor v6 = ttnn::to_layout(v5, ttnn::Layout::TILE, std::nullopt, std::nullopt, static_cast<::ttnn::IDevice *>(nullptr));
-  ttnn::deallocate(v5, false);
-  ttnn::MemoryConfig v7 = ttnn::MemoryConfig(ttnn::TensorMemoryLayout::INTERLEAVED, ttnn::BufferType::DRAM);
-  ttnn::Tensor v8 = ttnn::to_device(v2, v3, v7);
-  ttnn::Tensor v9 = ttnn::to_layout(v8, ttnn::Layout::TILE, std::nullopt, std::nullopt, static_cast<::ttnn::IDevice *>(nullptr));
-  ttnn::deallocate(v8, false);
-  ttnn::Shape v10 = ttnn::Shape({32, 32});
-  ttnn::MemoryConfig v11 = ttnn::MemoryConfig(ttnn::TensorMemoryLayout::INTERLEAVED, ttnn::BufferType::DRAM);
-  ttnn::Tensor v12 = ttnn::empty(v10, ttnn::DataType::BFLOAT16, ttnn::Layout::TILE, v3, v11);
-  ttnn::Tensor v13 = ttnn::add(v6, v9, std::nullopt, std::nullopt, v12);
-  ttnn::deallocate(v9, false);
-  ttnn::deallocate(v6, false);
-  ttnn::Tensor v14 = ttnn::from_device(v13);
-  ttnn::deallocate(v12, false);
-  ttnn::Tensor v15 = ttnn::to_layout(v14, ttnn::Layout::ROW_MAJOR, std::nullopt, std::nullopt, static_cast<::ttnn::IDevice *>(nullptr));
-  ttnn::deallocate(v14, false);
-  return v15;
+::ttnn::Tensor _add(::ttnn::Tensor v1, ::ttnn::Tensor v2) {
+  ::ttnn::Tensor v3 = ttnn::add(v1, v2, ::std::nullopt, ::ttnn::MemoryConfig {.memory_layout = ::ttnn::TensorMemoryLayout::INTERLEAVED, .buffer_type = ::ttnn::BufferType::DRAM});
+  ttnn::deallocate(v2, false);
+  ttnn::deallocate(v1, false);
+  return v3;
 }
 
-std::tuple<ttnn::Tensor, ttnn::Tensor> createInputsFor_add() {
-  ttnn::Shape v1 = ttnn::Shape({32, 32});
-  ttnn::Tensor v2 = ttnn::ones(v1, ttnn::DataType::BFLOAT16, ttnn::Layout::ROW_MAJOR, std::nullopt, std::nullopt);
-  ttnn::Shape v3 = ttnn::Shape({32, 32});
-  ttnn::Tensor v4 = ttnn::ones(v3, ttnn::DataType::BFLOAT16, ttnn::Layout::ROW_MAJOR, std::nullopt, std::nullopt);
-  return std::make_tuple(v2, v4);
+std::tuple<::ttnn::Tensor, ::ttnn::Tensor> create_inputs_for_add() {
+  ttnn::IDevice* v1 = ttnn::DeviceGetter::getInstance();
+  ::ttnn::Tensor v2 = ttnn::ones(::ttnn::Shape({32, 32}), ::ttnn::DataType::BFLOAT16, ::ttnn::Layout::TILE, ::std::nullopt, ::ttnn::MemoryConfig {.memory_layout = ::ttnn::TensorMemoryLayout::INTERLEAVED, .buffer_type = ::ttnn::BufferType::DRAM});
+  ::ttnn::Tensor v3 = ttnn::to_device(v2, v1, ::ttnn::MemoryConfig {.memory_layout = ::ttnn::TensorMemoryLayout::INTERLEAVED, .buffer_type = ::ttnn::BufferType::DRAM});
+  ::ttnn::Tensor v4 = ttnn::ones(::ttnn::Shape({32, 32}), ::ttnn::DataType::BFLOAT16, ::ttnn::Layout::TILE, ::std::nullopt, ::ttnn::MemoryConfig {.memory_layout = ::ttnn::TensorMemoryLayout::INTERLEAVED, .buffer_type = ::ttnn::BufferType::DRAM});
+  ::ttnn::Tensor v5 = ttnn::to_device(v4, v1, ::ttnn::MemoryConfig {.memory_layout = ::ttnn::TensorMemoryLayout::INTERLEAVED, .buffer_type = ::ttnn::BufferType::DRAM});
+  return std::make_tuple(v3, v5);
 }
 
 int32_t main() {
-  ttnn::Tensor v1;
-  ttnn::Tensor v2;
-  std::tie(v1, v2) = createInputsFor_add();
-  ttnn::Tensor v3 = add(v1, v2);
+  ::ttnn::Tensor v1;
+  ::ttnn::Tensor v2;
+  std::tie(v1, v2) = create_inputs_for_add();
+  ::ttnn::Tensor v3 = _add(v1, v2);
   int32_t v4 = 0;
   return v4;
 }

--- a/tools/ttnn-standalone/ttnn-standalone.cpp
+++ b/tools/ttnn-standalone/ttnn-standalone.cpp
@@ -3,27 +3,42 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn-precompiled.hpp"
-::ttnn::Tensor add(::ttnn::Tensor v1, ::ttnn::Tensor v2) {
-  ::ttnn::Tensor v3 = ttnn::add(v1, v2, ::std::nullopt, ::ttnn::MemoryConfig {.memory_layout = ::ttnn::TensorMemoryLayout::INTERLEAVED, .buffer_type = ::ttnn::BufferType::DRAM});
-  ttnn::deallocate(v2, false);
-  ttnn::deallocate(v1, false);
-  return v3;
+ttnn::Tensor add(ttnn::Tensor v1, ttnn::Tensor v2) {
+  ttnn::IDevice* v3 = ttnn::DeviceGetter::getInstance();
+  ttnn::MemoryConfig v4 = ttnn::MemoryConfig(ttnn::TensorMemoryLayout::INTERLEAVED, ttnn::BufferType::DRAM);
+  ttnn::Tensor v5 = ttnn::to_device(v1, v3, v4);
+  ttnn::Tensor v6 = ttnn::to_layout(v5, ttnn::Layout::TILE, std::nullopt, std::nullopt, static_cast<::ttnn::IDevice *>(nullptr));
+  ttnn::deallocate(v5, false);
+  ttnn::MemoryConfig v7 = ttnn::MemoryConfig(ttnn::TensorMemoryLayout::INTERLEAVED, ttnn::BufferType::DRAM);
+  ttnn::Tensor v8 = ttnn::to_device(v2, v3, v7);
+  ttnn::Tensor v9 = ttnn::to_layout(v8, ttnn::Layout::TILE, std::nullopt, std::nullopt, static_cast<::ttnn::IDevice *>(nullptr));
+  ttnn::deallocate(v8, false);
+  ttnn::Shape v10 = ttnn::Shape({32, 32});
+  ttnn::MemoryConfig v11 = ttnn::MemoryConfig(ttnn::TensorMemoryLayout::INTERLEAVED, ttnn::BufferType::DRAM);
+  ttnn::Tensor v12 = ttnn::empty(v10, ttnn::DataType::BFLOAT16, ttnn::Layout::TILE, v3, v11);
+  ttnn::Tensor v13 = ttnn::add(v6, v9, std::nullopt, std::nullopt, v12);
+  ttnn::deallocate(v9, false);
+  ttnn::deallocate(v6, false);
+  ttnn::Tensor v14 = ttnn::from_device(v13);
+  ttnn::deallocate(v12, false);
+  ttnn::Tensor v15 = ttnn::to_layout(v14, ttnn::Layout::ROW_MAJOR, std::nullopt, std::nullopt, static_cast<::ttnn::IDevice *>(nullptr));
+  ttnn::deallocate(v14, false);
+  return v15;
 }
 
-std::tuple<::ttnn::Tensor, ::ttnn::Tensor> create_inputs_for_add() {
-  ttnn::IDevice* v1 = ttnn::DeviceGetter::getInstance();
-  ::ttnn::Tensor v2 = ttnn::ones(::ttnn::Shape({32, 32}), ::ttnn::DataType::BFLOAT16, ::ttnn::Layout::TILE, ::std::nullopt, ::ttnn::MemoryConfig {.memory_layout = ::ttnn::TensorMemoryLayout::INTERLEAVED, .buffer_type = ::ttnn::BufferType::DRAM});
-  ::ttnn::Tensor v3 = ttnn::to_device(v2, v1, ::ttnn::MemoryConfig {.memory_layout = ::ttnn::TensorMemoryLayout::INTERLEAVED, .buffer_type = ::ttnn::BufferType::DRAM});
-  ::ttnn::Tensor v4 = ttnn::ones(::ttnn::Shape({32, 32}), ::ttnn::DataType::BFLOAT16, ::ttnn::Layout::TILE, ::std::nullopt, ::ttnn::MemoryConfig {.memory_layout = ::ttnn::TensorMemoryLayout::INTERLEAVED, .buffer_type = ::ttnn::BufferType::DRAM});
-  ::ttnn::Tensor v5 = ttnn::to_device(v4, v1, ::ttnn::MemoryConfig {.memory_layout = ::ttnn::TensorMemoryLayout::INTERLEAVED, .buffer_type = ::ttnn::BufferType::DRAM});
-  return std::make_tuple(v3, v5);
+std::tuple<ttnn::Tensor, ttnn::Tensor> createInputsFor_add() {
+  ttnn::Shape v1 = ttnn::Shape({32, 32});
+  ttnn::Tensor v2 = ttnn::ones(v1, ttnn::DataType::BFLOAT16, ttnn::Layout::ROW_MAJOR, std::nullopt, std::nullopt);
+  ttnn::Shape v3 = ttnn::Shape({32, 32});
+  ttnn::Tensor v4 = ttnn::ones(v3, ttnn::DataType::BFLOAT16, ttnn::Layout::ROW_MAJOR, std::nullopt, std::nullopt);
+  return std::make_tuple(v2, v4);
 }
 
 int32_t main() {
-  ::ttnn::Tensor v1;
-  ::ttnn::Tensor v2;
-  std::tie(v1, v2) = create_inputs_for_add();
-  ::ttnn::Tensor v3 = add(v1, v2);
+  ttnn::Tensor v1;
+  ttnn::Tensor v2;
+  std::tie(v1, v2) = createInputsFor_add();
+  ttnn::Tensor v3 = add(v1, v2);
   int32_t v4 = 0;
   return v4;
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/3240

### Problem description
`TTNNCreateInputGenerators` creates `main` and `createInputsFor_${funcName}`. If one of the existing module functions have the same name, it will cause a name collision and module's symbol table will report a following error during verification
```
error: redefinition of symbol named '${funcName}'
```

### What's changed
- prepended a `_` to all existing functions to avoid name collision (namespaces would be a better idea in C++, but that would require major refactoring of the pass pipeline; if someone has a better idea, please let me know)
- decided to refactor the whole `TTNNCreateInputGenerators`, which I'm sure will make extending the generation of inputs to different creation functions a much easier task in the future

### Checklist
- [x] New/Existing tests provide coverage for changes
