### PR TITLE
Workaround for max and min reductions when dimensions are not multiple of 32

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceOpsRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceOpsRewritePattern.h
@@ -11,10 +11,11 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
-#include <cmath>
 
+#include <cmath>
 namespace mlir::tt::ttnn::workarounds::decomposition {
 
 // Extracts reduce dimensions' values from the dimArg attribute. In case when
@@ -132,45 +133,23 @@ public:
 
   LogicalResult matchAndRewrite(ReduceOp srcOp,
                                 PatternRewriter &rewriter) const override {
-    RankedTensorType inputType =
-        mlir::cast<RankedTensorType>(srcOp.getInput().getType());
-    auto reductionDims = getReduceDims(srcOp.getDimArg());
-    if (reductionDims.size() != 1) {
-      return rewriter.notifyMatchFailure(
-          srcOp,
-          "only one dim is supported"); // TODO: Expand this to support
-                                        // multiple dims. This is just for
-                                        // initial implementation only.
-    }
-    auto reductionDim = reductionDims[0];
-
-    auto shape = inputType.getShape();
-    auto paddingArray = llvm::SmallVector<int32_t>();
-    paddingArray.resize(2 * shape.size(), 0);
-
-    auto paddingDimSize = shape[reductionDim];
-    auto desiredDimSize = (paddingDimSize + 31) / 32 * 32;
-    auto paddingSize = desiredDimSize - paddingDimSize;
-    if (paddingSize <= 0) {
-      return rewriter.notifyMatchFailure(srcOp, "padding size is negative");
-    }
-    paddingArray[2 * reductionDim + 1] = paddingSize;
-
-    float paddingValue;
-    if constexpr (std::is_same_v<ReduceOp, mlir::tt::ttnn::MaxOp>) {
-      paddingValue = std::numeric_limits<float>::lowest();
-    } else if constexpr (std::is_same_v<ReduceOp, mlir::tt::ttnn::MinOp>) {
-      paddingValue = std::numeric_limits<float>::max();
-    } else {
-      return rewriter.notifyMatchFailure(srcOp, "unsupported reduce op type");
-    }
-
+    auto inputType = mlir::cast<RankedTensorType>(srcOp.getInput().getType());
+    llvm::SmallVector<int64_t> reductionDims = getReduceDims(srcOp.getDimArg());
+    llvm::ArrayRef<int64_t> shape = inputType.getShape();
     auto newShape = llvm::SmallVector<int64_t>(shape.begin(), shape.end());
-    newShape[reductionDim] = desiredDimSize;
+    llvm::SmallVector<int32_t> paddingArray(2 * shape.size(), 0);
+
+    constexpr int tileSize = 32;
+    for (auto dim : reductionDims) {
+      auto padded_size = (shape[dim] + tileSize - 1) / tileSize * tileSize;
+      newShape[dim] = padded_size;
+      paddingArray[2 * dim + 1] = padded_size - shape[dim];
+    }
+
     auto resultType = RankedTensorType::get(
         newShape, inputType.getElementType(), inputType.getEncoding());
-
-    auto PadOp = rewriter.create<mlir::tt::ttnn::PadOp>(
+    float paddingValue = getPaddingValue();
+    auto padOp = rewriter.create<mlir::tt::ttnn::PadOp>(
         srcOp.getLoc(), resultType, srcOp.getInput(),
         rewriter.getDenseI32ArrayAttr(paddingArray),
         rewriter.getFloatAttr(rewriter.getF32Type(), APFloat(paddingValue)),
@@ -178,11 +157,22 @@ public:
         /* memory_config*/ nullptr);
 
     rewriter.replaceOpWithNewOp<ReduceOp>(
-        srcOp, srcOp.getResult().getType(), PadOp.getResult(),
+        srcOp, srcOp.getResult().getType(), padOp.getResult(),
         rewriter.getBoolAttr(srcOp.getKeepDim()),
         srcOp.getDimArg().value_or(nullptr));
 
     return success();
+  }
+
+private:
+  float getPaddingValue() const {
+    if constexpr (std::is_same_v<ReduceOp, mlir::tt::ttnn::MaxOp>) {
+      return std::numeric_limits<float>::lowest();
+    } else if constexpr (std::is_same_v<ReduceOp, mlir::tt::ttnn::MinOp>) {
+      return std::numeric_limits<float>::max();
+    } else {
+      llvm_unreachable("unsupported reduce op type");
+    }
   }
 };
 } // namespace mlir::tt::ttnn::workarounds::decomposition

--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceOpsRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceOpsRewritePattern.h
@@ -141,6 +141,9 @@ public:
 
     constexpr int tileSize = 32;
     for (auto dim : reductionDims) {
+      if (dim < 0) {
+        dim += shape.size();
+      }
       auto padded_size = (shape[dim] + tileSize - 1) / tileSize * tileSize;
       newShape[dim] = padded_size;
       paddingArray[2 * dim + 1] = padded_size - shape[dim];

--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceOpsRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceOpsRewritePattern.h
@@ -16,6 +16,7 @@
 #include "llvm/ADT/SmallVector.h"
 
 #include <cmath>
+
 namespace mlir::tt::ttnn::workarounds::decomposition {
 
 // Extracts reduce dimensions' values from the dimArg attribute. In case when
@@ -133,20 +134,20 @@ public:
 
   LogicalResult matchAndRewrite(ReduceOp srcOp,
                                 PatternRewriter &rewriter) const override {
-    auto inputType = mlir::cast<RankedTensorType>(srcOp.getInput().getType());
+    RankedTensorType inputType = srcOp.getInput().getType();
     llvm::SmallVector<int64_t> reductionDims = getReduceDims(srcOp.getDimArg());
     llvm::ArrayRef<int64_t> shape = inputType.getShape();
-    auto newShape = llvm::SmallVector<int64_t>(shape.begin(), shape.end());
+    auto newShape = llvm::SmallVector<int64_t>(shape);
     llvm::SmallVector<int32_t> paddingArray(2 * shape.size(), 0);
 
-    constexpr int tileSize = 32;
+    constexpr int TileSize = 32;
     for (auto dim : reductionDims) {
       if (dim < 0) {
         dim += shape.size();
       }
-      auto padded_size = (shape[dim] + tileSize - 1) / tileSize * tileSize;
-      newShape[dim] = padded_size;
-      paddingArray[2 * dim + 1] = padded_size - shape[dim];
+      auto paddedSize = llvm::divideCeil(shape[dim], TileSize) * TileSize;
+      newShape[dim] = paddedSize;
+      paddingArray[2 * dim + 1] = paddedSize - shape[dim];
     }
     if (llvm::all_of(paddingArray, [](int32_t i) { return i == 0; })) {
       return failure();
@@ -154,31 +155,26 @@ public:
 
     auto resultType = RankedTensorType::get(
         newShape, inputType.getElementType(), inputType.getEncoding());
-    float paddingValue = getPaddingValue();
     auto padOp = rewriter.create<mlir::tt::ttnn::PadOp>(
         srcOp.getLoc(), resultType, srcOp.getInput(),
         rewriter.getDenseI32ArrayAttr(paddingArray),
-        rewriter.getFloatAttr(rewriter.getF32Type(), APFloat(paddingValue)),
-        /* use_multicore */ rewriter.getBoolAttr(true),
-        /* memory_config*/ nullptr);
+        rewriter.getFloatAttr(rewriter.getF32Type(), getPaddingValue()),
+        /*use_multicore=*/rewriter.getBoolAttr(true),
+        /*memory_config=*/nullptr);
 
-    rewriter.replaceOpWithNewOp<ReduceOp>(
-        srcOp, srcOp.getResult().getType(), padOp.getResult(),
-        rewriter.getBoolAttr(srcOp.getKeepDim()),
-        srcOp.getDimArg().value_or(nullptr));
+    rewriter.modifyOpInPlace(srcOp,
+                             [&]() { srcOp.getInputMutable().assign(padOp); });
 
     return success();
   }
 
 private:
-  float getPaddingValue() const {
-    if constexpr (std::is_same_v<ReduceOp, mlir::tt::ttnn::MaxOp>) {
-      return std::numeric_limits<float>::lowest();
-    } else if constexpr (std::is_same_v<ReduceOp, mlir::tt::ttnn::MinOp>) {
-      return std::numeric_limits<float>::max();
-    } else {
-      llvm_unreachable("unsupported reduce op type");
-    }
+  mlir::APFloat getPaddingValue() const {
+    static_assert(std::is_same_v<ReduceOp, ttnn::MinOp> ||
+                  std::is_same_v<ReduceOp, ttnn::MaxOp>);
+    return mlir::APFloat::getInf(
+        mlir::APFloat::IEEEsingle(),
+        /*Negative=*/std::is_same_v<ReduceOp, mlir::tt::ttnn::MaxOp>);
   }
 };
 } // namespace mlir::tt::ttnn::workarounds::decomposition

--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceOpsRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceOpsRewritePattern.h
@@ -145,6 +145,9 @@ public:
       newShape[dim] = padded_size;
       paddingArray[2 * dim + 1] = padded_size - shape[dim];
     }
+    if (llvm::all_of(paddingArray, [](int32_t i) { return i == 0; })) {
+      return failure();
+    }
 
     auto resultType = RankedTensorType::get(
         newShape, inputType.getElementType(), inputType.getEncoding());

--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceOpsRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceOpsRewritePattern.h
@@ -13,6 +13,7 @@
 #include "mlir/Support/LogicalResult.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
+#include <cmath>
 
 namespace mlir::tt::ttnn::workarounds::decomposition {
 
@@ -121,6 +122,67 @@ private:
     }
 
     return false;
+  }
+};
+
+template <typename ReduceOp>
+class ReduceOpsPadInputRewritePattern : public OpRewritePattern<ReduceOp> {
+public:
+  using OpRewritePattern<ReduceOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ReduceOp srcOp,
+                                PatternRewriter &rewriter) const override {
+    RankedTensorType inputType =
+        mlir::cast<RankedTensorType>(srcOp.getInput().getType());
+    auto reductionDims = getReduceDims(srcOp.getDimArg());
+    if (reductionDims.size() != 1) {
+      return rewriter.notifyMatchFailure(
+          srcOp,
+          "only one dim is supported"); // TODO: Expand this to support
+                                        // multiple dims. This is just for
+                                        // initial implementation only.
+    }
+    auto reductionDim = reductionDims[0];
+
+    auto shape = inputType.getShape();
+    auto paddingArray = llvm::SmallVector<int32_t>();
+    paddingArray.resize(2 * shape.size(), 0);
+
+    auto paddingDimSize = shape[reductionDim];
+    auto desiredDimSize = (paddingDimSize + 31) / 32 * 32;
+    auto paddingSize = desiredDimSize - paddingDimSize;
+    if (paddingSize <= 0) {
+      return rewriter.notifyMatchFailure(srcOp, "padding size is negative");
+    }
+    paddingArray[2 * reductionDim + 1] = paddingSize;
+
+    float paddingValue;
+    if constexpr (std::is_same_v<ReduceOp, mlir::tt::ttnn::MaxOp>) {
+      paddingValue = std::numeric_limits<float>::lowest();
+    } else if constexpr (std::is_same_v<ReduceOp, mlir::tt::ttnn::MinOp>) {
+      paddingValue = std::numeric_limits<float>::max();
+    } else {
+      return rewriter.notifyMatchFailure(srcOp, "unsupported reduce op type");
+    }
+
+    auto newShape = llvm::SmallVector<int64_t>(shape.begin(), shape.end());
+    newShape[reductionDim] = desiredDimSize;
+    auto resultType = RankedTensorType::get(
+        newShape, inputType.getElementType(), inputType.getEncoding());
+
+    auto PadOp = rewriter.create<mlir::tt::ttnn::PadOp>(
+        srcOp.getLoc(), resultType, srcOp.getInput(),
+        rewriter.getDenseI32ArrayAttr(paddingArray),
+        rewriter.getFloatAttr(rewriter.getF32Type(), APFloat(paddingValue)),
+        /* use_multicore */ rewriter.getBoolAttr(true),
+        /* memory_config*/ nullptr);
+
+    rewriter.replaceOpWithNewOp<ReduceOp>(
+        srcOp, srcOp.getResult().getType(), PadOp.getResult(),
+        rewriter.getBoolAttr(srcOp.getKeepDim()),
+        srcOp.getDimArg().value_or(nullptr));
+
+    return success();
   }
 };
 } // namespace mlir::tt::ttnn::workarounds::decomposition

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -591,7 +591,11 @@ public:
           workarounds::decomposition::CumSumOpDimRewritePattern,
           workarounds::decomposition::CumSumOpRankRewritePattern,
           workarounds::decomposition::EmbeddingOpSqueezeWeightRewritePattern,
-          workarounds::decomposition::ArgMaxOpRewritePattern>(&getContext());
+          workarounds::decomposition::ArgMaxOpRewritePattern,
+          workarounds::decomposition::ReduceOpsPadInputRewritePattern<
+              ttnn::MaxOp>,
+          workarounds::decomposition::ReduceOpsPadInputRewritePattern<
+              ttnn::MinOp>>(&getContext());
 
       runRewritePatterns(std::move(patterns),
                          GreedyRewriteConfig::kNoLimit /*maxIterations*/);

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/reduction_ops_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/reduction_ops_workaround.mlir
@@ -45,7 +45,7 @@ func.func public @test_reduce_max_requires_pad(%arg0: tensor<128x30xf32, #ttnn_l
   // CHECK-LABEL: @test_reduce_max_requires_pad
   // CHECK: "ttnn.pad"
   // CHECK-SAME: padding = array<i32: 0, 0, 0, 2>
-  // CHECK-SAME: value = -3.40282347E+38
+  // CHECK-SAME: value = 0xFF800000
   // CHECK: "ttnn.max"
   // CHECK-SAME: tensor<128x32xf32
   // CHECK-SAME: -> tensor<128xf32

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/reduction_ops_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/reduction_ops_workaround.mlir
@@ -3,17 +3,17 @@
 #dram = #ttnn.buffer_type<dram>
 #ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x1x!tt.tile<32x32, si32>, #dram>, <interleaved>>
 #ttnn_layout1 = #ttnn.ttnn_layout<(d0) -> (0, d0), <1x1>, memref<1x4x!tt.tile<32x32, si32>, #dram>, <interleaved>>
-func.func public @test_reduce_max(%arg0: tensor<128x10xsi32, #ttnn_layout>) -> tensor<128xsi32, #ttnn_layout1> {
+func.func public @test_reduce_max(%arg0: tensor<128x32xsi32, #ttnn_layout>) -> tensor<128xsi32, #ttnn_layout1> {
   // CHECK-LABEL: @test_reduce_max
   // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0, %{{[0-9]+}})
   // CHECK-SAME: dtype = #tt.supportedDataTypes<bf16>,
-  // CHECK-SAME: tensor<128x10xsi32,
-  // CHECK-SAME: -> tensor<128x10xbf16,
+  // CHECK-SAME: tensor<128x32xsi32,
+  // CHECK-SAME: -> tensor<128x32xbf16,
   // CHECK: %[[MAX:[0-9]+]] = "ttnn.max"(%[[ARG0]])
   // CHECK-SAME: <{dim_arg = [1 : i32], keep_dim = false}>
-  // CHECK-SAME: tensor<128x10xbf16,
+  // CHECK-SAME: tensor<128x32xbf16,
   // CHECK-SAME: -> tensor<128xbf16,
-  %0 = "ttnn.max"(%arg0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x10xsi32, #ttnn_layout>) -> tensor<128xsi32, #ttnn_layout1>
+  %0 = "ttnn.max"(%arg0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x32xsi32, #ttnn_layout>) -> tensor<128xsi32, #ttnn_layout1>
   // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[MAX]], %{{[0-9]+}})
   // CHECK-SAME: dtype = #tt.supportedDataTypes<si32>,
   // CHECK-SAME: tensor<128xbf16,
@@ -37,4 +37,18 @@ func.func public @test_reduce_sum(%arg0: tensor<128x10xsi32, #ttnn_layout>) -> t
   // CHECK-SAME: tensor<128xbf16,
   // CHECK-SAME: -> tensor<128xsi32,
   return %0 : tensor<128xsi32, #ttnn_layout1>
+}
+
+#ttnn_layout2 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x1x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+#ttnn_layout3 = #ttnn.ttnn_layout<(d0) -> (0, d0), <1x1>, memref<1x4x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+func.func public @test_reduce_max_requires_pad(%arg0: tensor<128x30xf32, #ttnn_layout2>) -> tensor<128xf32, #ttnn_layout3> {
+  // CHECK-LABEL: @test_reduce_max_requires_pad
+  // CHECK: "ttnn.pad"
+  // CHECK-SAME: padding = array<i32: 0, 0, 0, 2>
+  // CHECK-SAME: value = -3.40282347E+38
+  // CHECK: "ttnn.max"
+  // CHECK-SAME: tensor<128x32xf32
+  // CHECK-SAME: -> tensor<128xf32
+  %0 = "ttnn.max"(%arg0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x30xf32, #ttnn_layout2>) -> tensor<128xf32, #ttnn_layout3>
+  return %0 : tensor<128xf32, #ttnn_layout3>
 }

--- a/test/ttmlir/Dialect/TTNN/reduction/simple_max.mlir
+++ b/test/ttmlir/Dialect/TTNN/reduction/simple_max.mlir
@@ -7,15 +7,29 @@ module attributes {} {
     return %1 : tensor<512xbf16>
   }
 
-  func.func @test_reduce_max_multi_dim(%arg0: tensor<128x32x10x4xbf16>) -> tensor<128x1x1x1xbf16> {
+  func.func @test_reduce_max_multi_dim(%arg0: tensor<128x32x64x32xbf16>) -> tensor<128x1x1x1xbf16> {
     // CHECK-LABEL: @test_reduce_max_multi_dim(
     %0 = ttir.empty() : tensor<128x1x1x1xbf16>
     // CHECK: "ttnn.max"(%arg0)
     // CHECK-SAME: dim_arg = [1 : i32, 2 : i32, 3 : i32]
     // CHECK-SAME: keep_dim = true
-    // CHECK-SAME: tensor<128x32x10x4xbf16
+    // CHECK-SAME: tensor<128x32x64x32xbf16
     // CHECK-SAME: -> tensor<128x1x1x1xbf16
-    %1 = "ttir.max"(%arg0, %0) <{dim_arg = [1: i32, 2: i32, 3: i32], keep_dim = true}> : (tensor<128x32x10x4xbf16>, tensor<128x1x1x1xbf16>) -> tensor<128x1x1x1xbf16>
+    %1 = "ttir.max"(%arg0, %0) <{dim_arg = [1: i32, 2: i32, 3: i32], keep_dim = true}> : (tensor<128x32x64x32xbf16>, tensor<128x1x1x1xbf16>) -> tensor<128x1x1x1xbf16>
     return %1 : tensor<128x1x1x1xbf16>
+  }
+
+  func.func @test_reduce_max_requires_padding_workaround(%arg0: tensor<128x32x60x90xbf16>) -> tensor<128x1x1x90xbf16> {
+    // CHECK-LABEL: @test_reduce_max_requires_padding_workaround(
+    %0 = ttir.empty() : tensor<128x1x1x90xbf16>
+    // CHECK: "ttnn.pad"
+    // CHECK-SAME: 0, 0, 0, 0, 0, 4, 0, 0
+    // CHECK: "ttnn.max"
+    // CHECK-SAME: dim_arg = [1 : i32, 2 : i32]
+    // CHECK-SAME: keep_dim = true
+    // CHECK-SAME: tensor<128x32x64x90xbf16
+    // CHECK-SAME: -> tensor<128x1x1x90xbf16
+    %1 = "ttir.max"(%arg0, %0) <{dim_arg = [1: i32, 2: i32], keep_dim = true}> : (tensor<128x32x60x90xbf16>, tensor<128x1x1x90xbf16>) -> tensor<128x1x1x90xbf16>
+    return %1 : tensor<128x1x1x90xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/reduction/simple_reduce_min.mlir
+++ b/test/ttmlir/Dialect/TTNN/reduction/simple_reduce_min.mlir
@@ -1,59 +1,59 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
 
 module attributes {} {
-  func.func public @test_reduce_min_4to3dim(%arg0: tensor<128x10x32x4xf32>) -> tensor<128x32x4xf32> {
+  func.func public @test_reduce_min_4to3dim(%arg0: tensor<128x64x32x4xf32>) -> tensor<128x32x4xf32> {
     // CHECK-LABEL: func.func public @test_reduce_min_4to3dim
     %0 = ttir.empty() : tensor<128x32x4xf32>
     // CHECK: %[[MIN:[0-9]+]] = "ttnn.min"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: (tensor<128x10x32x4xf32,
+    // CHECK-SAME: (tensor<128x64x32x4xf32,
     // CHECK-SAME: -> tensor<128x32x4xf32,
-    %1 = "ttir.min"(%arg0, %0) <{dim_arg = [1: i32], keep_dim = false}> : (tensor<128x10x32x4xf32>, tensor<128x32x4xf32>) -> tensor<128x32x4xf32>
+    %1 = "ttir.min"(%arg0, %0) <{dim_arg = [1: i32], keep_dim = false}> : (tensor<128x64x32x4xf32>, tensor<128x32x4xf32>) -> tensor<128x32x4xf32>
     return %1 : tensor<128x32x4xf32>
   }
 
-  func.func public @test_reduce_min_4to0dim(%arg0: tensor<128x10x32x4xbf16>) -> tensor<1xbf16> {
+  func.func public @test_reduce_min_4to0dim(%arg0: tensor<128x64x32x32xbf16>) -> tensor<1xbf16> {
     // CHECK-LABEL: func.func public @test_reduce_min_4to0dim
     %0 = ttir.empty() : tensor<1xbf16>
     // CHECK-NOT: dim_arg = [1 : i32]
     // CHECK: %[[MIN:[0-9]+]] = "ttnn.min"
     // CHECK-SAME: keep_dim = true
-    // CHECK-SAME: (tensor<128x10x32x4xbf16,
+    // CHECK-SAME: (tensor<128x64x32x32xbf16,
     // CHECK-SAME: -> tensor<1x1x1x1xbf16,
     // CHECK: "ttnn.reshape"(%[[MIN]])
     // CHECK-SAME: shape = [1 : i32]
     // CHECK-SAME: tensor<1x1x1x1xbf16,
     // CHECK-SAME: -> tensor<1xbf16
-    %1 = "ttir.min"(%arg0, %0) <{dim_arg = [0 : i32, 1 : i32, 2 : i32, 3 : i32], keep_dim = false}> : (tensor<128x10x32x4xbf16>, tensor<1xbf16>) -> tensor<1xbf16>
+    %1 = "ttir.min"(%arg0, %0) <{dim_arg = [0 : i32, 1 : i32, 2 : i32, 3 : i32], keep_dim = false}> : (tensor<128x64x32x32xbf16>, tensor<1xbf16>) -> tensor<1xbf16>
     return %1 : tensor<1xbf16>
   }
 
-  func.func public @test_reduce_min_3to2dim(%arg0: tensor<128x10x4xf32>) -> tensor<128x4xf32> {
+  func.func public @test_reduce_min_3to2dim(%arg0: tensor<128x32x4xf32>) -> tensor<128x4xf32> {
     // CHECK-LABEL: func.func public @test_reduce_min_3to2dim
     %0 = ttir.empty() : tensor<128x4xf32>
     // CHECK: %[[MIN:[0-9]+]] = "ttnn.min"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: (tensor<128x10x4xf32,
+    // CHECK-SAME: (tensor<128x32x4xf32,
     // CHECK-SAME: -> tensor<128x4xf32,
-    %1 = "ttir.min"(%arg0, %0) <{dim_arg = [1: i32], keep_dim = false}> : (tensor<128x10x4xf32>, tensor<128x4xf32>) -> tensor<128x4xf32>
+    %1 = "ttir.min"(%arg0, %0) <{dim_arg = [1: i32], keep_dim = false}> : (tensor<128x32x4xf32>, tensor<128x4xf32>) -> tensor<128x4xf32>
     return %1 : tensor<128x4xf32>
   }
 
-  func.func public @test_reduce_min_3to0dim(%arg0: tensor<128x10x4xbf16>) -> tensor<1xbf16> {
+  func.func public @test_reduce_min_3to0dim(%arg0: tensor<128x32x64xbf16>) -> tensor<1xbf16> {
     // CHECK-LABEL: func.func public @test_reduce_min_3to0dim
     %0 = ttir.empty() : tensor<1xbf16>
     // CHECK-NOT: dim_arg = [1 : i32]
     // CHECK: %[[MIN:[0-9]+]] = "ttnn.min"
     // CHECK-SAME: keep_dim = true
-    // CHECK-SAME: (tensor<128x10x4xbf16,
+    // CHECK-SAME: (tensor<128x32x64xbf16,
     // CHECK-SAME: -> tensor<1x1x1xbf16,
     // CHECK: "ttnn.reshape"(%[[MIN]])
     // CHECK-SAME: shape = [1 : i32]
     // CHECK-SAME: tensor<1x1x1xbf16,
     // CHECK-SAME: -> tensor<1xbf16
-    %1 = "ttir.min"(%arg0, %0) <{dim_arg = [0 : i32, 1 : i32, 2 : i32], keep_dim = false}> : (tensor<128x10x4xbf16>, tensor<1xbf16>) -> tensor<1xbf16>
+    %1 = "ttir.min"(%arg0, %0) <{dim_arg = [0 : i32, 1 : i32, 2 : i32], keep_dim = false}> : (tensor<128x32x64xbf16>, tensor<1xbf16>) -> tensor<1xbf16>
     return %1 : tensor<1xbf16>
   }
 

--- a/test/ttmlir/Silicon/StableHLO/n150/reduction/reduce_maximum_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/reduction/reduce_maximum_op.mlir
@@ -6,83 +6,83 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
 module @jit_reduce_maximum attributes {} {
-  func.func public @test_reduce_maximum_4to0dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+  func.func public @test_reduce_maximum_4to0dim(%arg0: tensor<128x64x32x96xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: "ttnn.max"
     // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32, 3 : i32]
     // CHECK-SAME: keep_dim = true
-    // CHECK-SAME: tensor<128x10x32x4xf32,
+    // CHECK-SAME: tensor<128x64x32x96xf32,
     // CHECK-SAME: -> tensor<1x1x1x1xf32,
     // CHECK: "ttnn.reshape"
     // CHECK-SAME: shape = [1 : i32]
     // CHECK-SAME: tensor<1x1x1x1xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0, 1, 2, 3] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<f32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0, 1, 2, 3] : (tensor<128x64x32x96xf32>, tensor<f32>) -> tensor<f32>
     return %0 : tensor<f32>
   }
 
-  func.func public @test_reduce_maximum_4to1dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
+  func.func public @test_reduce_maximum_4to1dim(%arg0: tensor<128x64x32x96xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
     // CHECK-LABEL: @test_reduce_maximum_4to1dim(
     // CHECK: "ttnn.max"
     // CHECK-SAME: dim_arg = [1 : i32, 2 : i32, 3 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x32x4xf32,
+    // CHECK-SAME: tensor<128x64x32x96xf32,
     // CHECK-SAME: -> tensor<128xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1, 2, 3] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<128xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1, 2, 3] : (tensor<128x64x32x96xf32>, tensor<f32>) -> tensor<128xf32>
     return %0 : tensor<128xf32>
   }
 
-  func.func public @test_reduce_maximum_3to2dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128x4xf32> {
+  func.func public @test_reduce_maximum_3to2dim(%arg0: tensor<128x64x96xf32>, %cst_0: tensor<f32>) -> tensor<128x96xf32> {
     // CHECK: "ttnn.max"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x4xf32,
-    // CHECK-SAME: -> tensor<128x4xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128x4xf32>
-    return %0 : tensor<128x4xf32>
+    // CHECK-SAME: tensor<128x64x96xf32,
+    // CHECK-SAME: -> tensor<128x96xf32,
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1] : (tensor<128x64x96xf32>, tensor<f32>) -> tensor<128x96xf32>
+    return %0 : tensor<128x96xf32>
   }
 
-  func.func public @test_reduce_maximum_3to1dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
+  func.func public @test_reduce_maximum_3to1dim(%arg0: tensor<128x64x96xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
     // CHECK: "ttnn.max"
     // CHECK-SAME: dim_arg = [1 : i32, 2 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x4xf32,
+    // CHECK-SAME: tensor<128x64x96xf32,
     // CHECK-SAME: -> tensor<128xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1, 2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1, 2] : (tensor<128x64x96xf32>, tensor<f32>) -> tensor<128xf32>
     return %0 : tensor<128xf32>
   }
 
-  func.func public @test_reduce_maximum_3to0dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+  func.func public @test_reduce_maximum_3to0dim(%arg0: tensor<128x64x96xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: "ttnn.max"
     // CHECK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32]
     // CHECK-SAME: keep_dim = true
-    // CHECK-SAME: tensor<128x10x4xf32,
+    // CHECK-SAME: tensor<128x64x96xf32,
     // CHECK-SAME: -> tensor<1x1x1xf32,
     // CHECK: "ttnn.reshape"
     // CHECK-SAME: shape = [1 : i32]
     // CHECK-SAME: tensor<1x1x1xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0, 1, 2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<f32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0, 1, 2] : (tensor<128x64x96xf32>, tensor<f32>) -> tensor<f32>
     return %0 : tensor<f32>
   }
 
-  func.func public @test_reduce_maximum_2to1dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
+  func.func public @test_reduce_maximum_2to1dim(%arg0: tensor<128x64xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
     // CHECK: "ttnn.max"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10xf32,
+    // CHECK-SAME: tensor<128x64xf32,
     // CHECK-SAME: -> tensor<128xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<128xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [1] : (tensor<128x64xf32>, tensor<f32>) -> tensor<128xf32>
     return %0 : tensor<128xf32>
   }
 
-  func.func public @test_reduce_maximum_2to0dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+  func.func public @test_reduce_maximum_2to0dim(%arg0: tensor<128x64xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: "ttnn.max"
     // CHECK-SAME: dim_arg = [0 : i32, 1 : i32]
     // CHECK-SAME: keep_dim = true
-    // CHECK-SAME: tensor<128x10xf32,
+    // CHECK-SAME: tensor<128x64xf32,
     // CHECK-SAME: -> tensor<1x1xf32,
     // CHECK: "ttnn.reshape"
     // CHECK-SAME: shape = [1 : i32]
     // CHECK-SAME: tensor<1x1xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0, 1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<f32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.maximum across dimensions = [0, 1] : (tensor<128x64xf32>, tensor<f32>) -> tensor<f32>
     return %0 : tensor<f32>
   }
 

--- a/test/ttmlir/Silicon/StableHLO/n150/reduction/reduce_min_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/reduction/reduce_min_op.mlir
@@ -7,86 +7,86 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
 module @jit_reduce_minimum attributes {} {
-  func.func public @test_reduce_minimum_4to0dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+  func.func public @test_reduce_minimum_4to0dim(%arg0: tensor<128x64x32x96xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: "ttnn.min"
     // CEHCK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32, 3 : i32]
     // CHECK-SAME: keep_dim = true
-    // CHECK-SAME: tensor<128x10x32x4xf32,
+    // CHECK-SAME: tensor<128x64x32x96xf32,
     // CHECK-SAME: -> tensor<1x1x1x1xf32,
     // CHECK: "ttnn.reshape"
     // CHECK-SAME: shape = [1 : i32]
     // CHECK-SAME: tensor<1x1x1x1xf32,
     // CHECK-SAME: -> tensor<1xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [0, 1, 2, 3] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<f32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [0, 1, 2, 3] : (tensor<128x64x32x96xf32>, tensor<f32>) -> tensor<f32>
     return %0 : tensor<f32>
   }
 
-  func.func public @test_reduce_minimum_4to1dim(%arg0: tensor<128x10x32x4xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
+  func.func public @test_reduce_minimum_4to1dim(%arg0: tensor<128x64x32x96xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
     // CHECK-LABEL: @test_reduce_minimum_4to1dim(
     // CHECK: "ttnn.min"
     // CHECK-SAME: dim_arg = [1 : i32, 2 : i32, 3 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x32x4xf32,
+    // CHECK-SAME: tensor<128x64x32x96xf32,
     // CHECK-SAME: -> tensor<128xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [1, 2, 3] : (tensor<128x10x32x4xf32>, tensor<f32>) -> tensor<128xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [1, 2, 3] : (tensor<128x64x32x96xf32>, tensor<f32>) -> tensor<128xf32>
     return %0 : tensor<128xf32>
   }
 
-  func.func public @test_reduce_minimum_3to2dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128x4xf32> {
+  func.func public @test_reduce_minimum_3to2dim(%arg0: tensor<128x64x96xf32>, %cst_0: tensor<f32>) -> tensor<128x96xf32> {
     // CHECK: "ttnn.min"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x4xf32,
-    // CHECK-SAME: -> tensor<128x4xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [1] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128x4xf32>
-    return %0 : tensor<128x4xf32>
+    // CHECK-SAME: tensor<128x64x96xf32,
+    // CHECK-SAME: -> tensor<128x96xf32,
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [1] : (tensor<128x64x96xf32>, tensor<f32>) -> tensor<128x96xf32>
+    return %0 : tensor<128x96xf32>
   }
 
-  func.func public @test_reduce_minimum_3to1dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
+  func.func public @test_reduce_minimum_3to1dim(%arg0: tensor<128x64x96xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
     // CHECK: "ttnn.min"
     // CHECK-SAME: dim_arg = [1 : i32, 2 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x4xf32,
+    // CHECK-SAME: tensor<128x64x96xf32,
     // CHECK-SAME: -> tensor<128xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [1, 2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<128xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [1, 2] : (tensor<128x64x96xf32>, tensor<f32>) -> tensor<128xf32>
     return %0 : tensor<128xf32>
   }
 
-  func.func public @test_reduce_minimum_3to0dim(%arg0: tensor<128x10x4xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+  func.func public @test_reduce_minimum_3to0dim(%arg0: tensor<128x64x96xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: "ttnn.min"
     // CEHCK-SAME: dim_arg = [0 : i32, 1 : i32, 2 : i32]
     // CHECK-SAME: keep_dim = true
-    // CHECK-SAME: tensor<128x10x4xf32,
+    // CHECK-SAME: tensor<128x64x96xf32,
     // CHECK-SAME: -> tensor<1x1x1xf32,
     // CHECK: "ttnn.reshape"
     // CHECK-SAME: shape = [1 : i32]
     // CHECK-SAME: tensor<1x1x1xf32,
     // CHECK-SAME: -> tensor<1xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [0, 1, 2] : (tensor<128x10x4xf32>, tensor<f32>) -> tensor<f32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [0, 1, 2] : (tensor<128x64x96xf32>, tensor<f32>) -> tensor<f32>
     return %0 : tensor<f32>
   }
 
-  func.func public @test_reduce_minimum_2to1dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
+  func.func public @test_reduce_minimum_2to1dim(%arg0: tensor<128x64xf32>, %cst_0: tensor<f32>) -> tensor<128xf32> {
     // CHECK: "ttnn.min"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10xf32,
+    // CHECK-SAME: tensor<128x64xf32,
     // CHECK-SAME: -> tensor<128xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<128xf32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [1] : (tensor<128x64xf32>, tensor<f32>) -> tensor<128xf32>
     return %0 : tensor<128xf32>
   }
 
-  func.func public @test_reduce_minimum_2to0dim(%arg0: tensor<128x10xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
+  func.func public @test_reduce_minimum_2to0dim(%arg0: tensor<128x64xf32>, %cst_0: tensor<f32>) -> tensor<f32> {
     // CHECK: "ttnn.min"
     // CEHCK-SAME: dim_arg = [0 : i32, 1 : i32]
     // CHECK-SAME: keep_dim = true
-    // CHECK-SAME: tensor<128x10xf32,
+    // CHECK-SAME: tensor<128x64xf32,
     // CHECK-SAME: -> tensor<1x1xf32,
     // CHECK: "ttnn.reshape"
     // CHECK-SAME: shape = [1 : i32]
     // CHECK-SAME: tensor<1x1xf32,
     // CHECK-SAME: -> tensor<1xf32,
-    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [0, 1] : (tensor<128x10xf32>, tensor<f32>) -> tensor<f32>
+    %0 = stablehlo.reduce(%arg0 init: %cst_0) applies stablehlo.minimum across dimensions = [0, 1] : (tensor<128x64xf32>, tensor<f32>) -> tensor<f32>
     return %0 : tensor<f32>
   }
 

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_reduce_min.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_reduce_min.mlir
@@ -11,7 +11,7 @@ module {
     // CHECK: "ttnn.min"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x32x4xf32,
+    // CHECK-SAME: tensor<128x32x32x4xf32,
     // CHECK-SAME: -> tensor<128x32x4xf32,
     %1 = "ttir.min"(%arg0, %0) <{dim_arg = [1: i32], keep_dim = false}> : (tensor<128x10x32x4xf32>, tensor<128x32x4xf32>) -> tensor<128x32x4xf32>
     return %1 : tensor<128x32x4xf32>

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_reduce_min.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_reduce_min.mlir
@@ -8,6 +8,9 @@ module {
   func.func public @reduce_min_not_keep_dim(%arg0: tensor<128x10x32x4xf32>) -> tensor<128x32x4xf32> {
     // CHECK-LABEL: func.func public @reduce_min_not_keep_dim
     %0 = ttir.empty() : tensor<128x32x4xf32>
+    // CHECK: "ttnn.pad"
+    // CHECK-SAME: tensor<128x10x32x4xf32,
+    // CHECK-SAME: -> tensor<128x32x32x4xf32,
     // CHECK: "ttnn.min"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false

--- a/test/ttmlir/Silicon/TTNN/n150/simple_max.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_max.mlir
@@ -5,26 +5,39 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
 module {
-  func.func public @reduce_not_keep_dim(%arg0: tensor<128x10xf32>) -> tensor<128xf32> {
+  func.func public @reduce_padding_workaround(%arg0: tensor<128x7xf32>) -> tensor<128xf32> {
     %0 = ttir.empty() : tensor<128xf32>
     // CHECK: "ttnn.max"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10xf32,
+    // CHECK-SAME: tensor<128x32xf32,
     // CHECK-SAME: -> tensor<128xf32,
-    %1 = "ttir.max"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x10xf32>, tensor<128xf32>) -> tensor<128xf32>
+    %1 = "ttir.max"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x7xf32>, tensor<128xf32>) -> tensor<128xf32>
     return %1 : tensor<128xf32>
   }
 
-  func.func public @reduce_keep_dim(%arg0: tensor<128x10xf32>) -> tensor<128x1xf32> {
+  func.func public @reduce_not_keep_dim(%arg0: tensor<128x32xf32>) -> tensor<128xf32> {
+    %0 = ttir.empty() : tensor<128xf32>
+    // CHECK: "ttnn.max"
+    // CHECK-SAME: dim_arg = [1 : i32]
+    // CHECK-SAME: keep_dim = false
+    // CHECK-SAME: tensor<128x32xf32,
+    // CHECK-SAME: -> tensor<128xf32,
+    // CHECK-NOT: "ttnn.pad"
+    %1 = "ttir.max"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x32xf32>, tensor<128xf32>) -> tensor<128xf32>
+    return %1 : tensor<128xf32>
+  }
+
+  func.func public @reduce_keep_dim(%arg0: tensor<128x32xf32>) -> tensor<128x1xf32> {
     %0 = ttir.empty() : tensor<128x1xf32>
     // CHECK: "ttnn.max"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = true
-    // CHECK-SAME: tensor<128x10xf32,
+    // CHECK-SAME: tensor<128x32xf32,
     // CHECK-SAME: -> tensor<128x1xf32,
     // CHECK-NOT: "ttnn.reshape"
-    %1 = "ttir.max"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<128x10xf32>, tensor<128x1xf32>) -> tensor<128x1xf32>
+    // CHECK-NOT: "ttnn.pad"
+    %1 = "ttir.max"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<128x32xf32>, tensor<128x1xf32>) -> tensor<128x1xf32>
     return %1 : tensor<128x1xf32>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/simple_reduce_min.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_reduce_min.mlir
@@ -5,28 +5,28 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
 module {
-  func.func public @reduce_min_not_keep_dim(%arg0: tensor<128x10x32x4xf32>) -> tensor<128x32x4xf32> {
+  func.func public @reduce_min_not_keep_dim(%arg0: tensor<128x32x32x4xf32>) -> tensor<128x32x4xf32> {
     // CHECK-LABEL: func.func public @reduce_min_not_keep_dim
     %0 = ttir.empty() : tensor<128x32x4xf32>
     // CHECK: "ttnn.min"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = false
-    // CHECK-SAME: tensor<128x10x32x4xf32,
+    // CHECK-SAME: tensor<128x32x32x4xf32,
     // CHECK-SAME: -> tensor<128x32x4xf32,
-    %1 = "ttir.min"(%arg0, %0) <{dim_arg = [1: i32], keep_dim = false}> : (tensor<128x10x32x4xf32>, tensor<128x32x4xf32>) -> tensor<128x32x4xf32>
+    %1 = "ttir.min"(%arg0, %0) <{dim_arg = [1: i32], keep_dim = false}> : (tensor<128x32x32x4xf32>, tensor<128x32x4xf32>) -> tensor<128x32x4xf32>
     return %1 : tensor<128x32x4xf32>
   }
 
-  func.func public @reduce_min_keep_dim(%arg0: tensor<128x10x32x4xf32>) -> tensor<128x1x32x4xf32> {
+  func.func public @reduce_min_keep_dim(%arg0: tensor<128x32x32x4xf32>) -> tensor<128x1x32x4xf32> {
     // CHECK-LABEL: func.func public @reduce_min_keep_dim
     %0 = ttir.empty() : tensor<128x1x32x4xf32>
     // CHECK-NOT: "ttnn.reshape"
     // CHECK: "ttnn.min"
     // CHECK-SAME: dim_arg = [1 : i32]
     // CHECK-SAME: keep_dim = true
-    // CHECK-SAME: tensor<128x10x32x4xf32,
+    // CHECK-SAME: tensor<128x32x32x4xf32,
     // CHECK-SAME: -> tensor<128x1x32x4xf32,
-    %1 = "ttir.min"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<128x10x32x4xf32>, tensor<128x1x32x4xf32>) -> tensor<128x1x32x4xf32>
+    %1 = "ttir.min"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<128x32x32x4xf32>, tensor<128x1x32x4xf32>) -> tensor<128x1x32x4xf32>
     return %1 : tensor<128x1x32x4xf32>
   }
 }


### PR DESCRIPTION
### Ticket


### Problem description
There is a bug in metal ( https://github.com/tenstorrent/tt-metal/issues/21615 ) where max reduction with all negative inputs erroneously returns zero instead of the real maximum in cases where the dimension is not divisible by 32. This is hit in some model tests from tt-xla.
Same failure mode is observed for min and all positive inputs.

### What's changed
I added a TTNN workaround to pad the input tensor with the neutral element for reduction in cases where the input has reduction dimensions that aren't a multiple of 32.

### Checklist
- [X] New/Existing tests provide coverage for changes - I modified most of the tests to not hit the workaround so it is clearer what is being tested and added workaround specific tests.
