### PR TITLE
Add TTIRToTTIRDecomposition pass to metal pipeline

### DIFF
--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -5,6 +5,7 @@
 #include "ttmlir/Dialect/TTMetal/Pipelines/TTMetalPipelines.h"
 
 #include "ttmlir/Conversion/Passes.h"
+#include "ttmlir/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.h"
 #include "ttmlir/Dialect/TT/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTKernel/Transforms/Passes.h"
@@ -52,6 +53,8 @@ void createTTIRToTTMetalBackendPipeline(
     registerDeviceOptions.meshShape = llvm::to_vector(options.meshShape);
   }
   pm.addPass(tt::createTTRegisterDevicePass(registerDeviceOptions));
+  pm.addPass(tt::createTTIRToTTIRDecompositionPass());
+  pm.addPass(mlir::createCanonicalizerPass());
   pm.addPass(tt::createTTIRToTTIRGenericPass());
   pm.addPass(mlir::createCanonicalizerPass());
   ttir::TTIROptimizeTensorLayoutOptions optimizeTensorLayoutOptions;

--- a/test/ttmlir/Conversion/TTIRToTTMetal/decomposable_lowering_dot_general.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTMetal/decomposable_lowering_dot_general.mlir
@@ -1,0 +1,12 @@
+// RUN: ttmlir-opt --ttir-to-ttmetal-backend-pipeline %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+
+module {
+  func.func @test_dot_general_2d_2d(%arg0: tensor<64x32xf32>, %arg1: tensor<32x128xf32>) -> tensor<64x128xf32> {
+    // CHECK-NOT: ttir.dot_general
+    // CHECK: mm_init
+    // CHECK: matmul_tiles
+    %0 = "ttir.dot_general"(%arg0, %arg1) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 1>, contract_dims_rhs = array<i64: 0>}> : (tensor<64x32xf32>, tensor<32x128xf32>) -> tensor<64x128xf32>
+    return %0 : tensor<64x128xf32>
+  }
+}

--- a/test/ttmlir/Conversion/TTIRToTTMetal/decomposable_lowering_dot_general.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTMetal/decomposable_lowering_dot_general.mlir
@@ -1,5 +1,8 @@
 // RUN: ttmlir-opt --ttir-to-ttmetal-backend-pipeline %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
+// Higher-dimension tests requires:
+//   Permute: https://github.com/tenstorrent/tt-mlir/issues/3025
+//   Reshape: https://github.com/tenstorrent/tt-mlir/issues/3027
 
 module {
   func.func @test_dot_general_2d_2d(%arg0: tensor<64x32xf32>, %arg1: tensor<32x128xf32>) -> tensor<64x128xf32> {

--- a/test/ttmlir/Conversion/TTIRToTTMetal/decomposable_lowering_gather.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTMetal/decomposable_lowering_gather.mlir
@@ -1,0 +1,22 @@
+// RUN: ttmlir-opt --ttir-to-ttmetal-backend-pipeline %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+// UNSUPPORTED: true
+
+module attributes {} {
+  func.func @test_gather(%operand: tensor<32x32xf32>, %start_indices: tensor<4x32xi32>) -> tensor<4x32x32xf32> {
+    %0 = ttir.empty() : tensor<4x32x32xf32>
+    // CHECK-NOT: ttir.gather
+    // CHECK: embedding
+    %1 = "ttir.gather"(%operand, %start_indices, %0) {
+        offset_dims = array<i64: 2>,
+        collapsed_slice_dims = array<i64: 0>,
+        operand_batching_dims = array<i64>,
+        start_indices_batching_dims = array<i64>,
+        start_index_map = array<i64: 0>,
+        index_vector_dim = 2 : si64,
+        slice_sizes = array<i64: 1, 32>,
+        indices_are_sorted = false
+    } : (tensor<32x32xf32>, tensor<4x32xi32>, tensor<4x32x32xf32>) -> tensor<4x32x32xf32>
+    return %1 : tensor<4x32x32xf32>
+  }
+}

--- a/test/ttmlir/Conversion/TTIRToTTMetal/decomposable_lowering_gather.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTMetal/decomposable_lowering_gather.mlir
@@ -1,8 +1,10 @@
 // RUN: ttmlir-opt --ttir-to-ttmetal-backend-pipeline %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // UNSUPPORTED: true
+// Full lowering requires:
+//   Embedding: https://github.com/tenstorrent/tt-mlir/issues/3024
 
-module attributes {} {
+module {
   func.func @test_gather(%operand: tensor<32x32xf32>, %start_indices: tensor<4x32xi32>) -> tensor<4x32x32xf32> {
     %0 = ttir.empty() : tensor<4x32x32xf32>
     // CHECK-NOT: ttir.gather

--- a/test/ttmlir/Conversion/TTIRToTTMetal/decomposable_lowering_reduce_or.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTMetal/decomposable_lowering_reduce_or.mlir
@@ -1,6 +1,8 @@
 // RUN: ttmlir-opt --ttir-to-ttmetal-backend-pipeline %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // UNSUPPORTED: true
+// Full lowering requires:
+//   Sum: https://github.com/tenstorrent/tt-mlir/issues/3018
 
 module {
   func.func @test_reduce_or_2d(%arg0: tensor<32x32xbf16>) -> tensor<32x1xbf16> {

--- a/test/ttmlir/Conversion/TTIRToTTMetal/decomposable_lowering_reduce_or.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTMetal/decomposable_lowering_reduce_or.mlir
@@ -1,0 +1,23 @@
+// RUN: ttmlir-opt --ttir-to-ttmetal-backend-pipeline %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+// UNSUPPORTED: true
+
+module {
+  func.func @test_reduce_or_2d(%arg0: tensor<32x32xbf16>) -> tensor<32x1xbf16> {
+    %0 = ttir.empty() : tensor<32x1xbf16>
+    // CHECK-NOT: ttir.reduce_or
+    // CHECK: add_tiles_init
+    // CHECK: add_tiles
+    %1 = "ttir.reduce_or"(%arg0, %0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<32x32xbf16>, tensor<32x1xbf16>) -> tensor<32x1xbf16>
+    return %1 : tensor<32x1xbf16>
+  }
+
+  func.func @test_reduce_or_3d(%arg0: tensor<32x32x32xbf16>) -> tensor<32x32x1xbf16> {
+    %0 = ttir.empty() : tensor<32x32x1xbf16>
+    // CHECK-NOT: ttir.reduce_or
+    // CHECK: add_tiles_init
+    // CHECK: add_tiles
+    %1 = "ttir.reduce_or"(%arg0, %0) <{dim_arg = [2 : i32], keep_dim = true}> : (tensor<32x32x32xbf16>, tensor<32x32x1xbf16>) -> tensor<32x32x1xbf16>
+    return %1 : tensor<32x32x1xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket
Closes #3038

### What's changed
Do the TTIR decomposition pass in the D2M pipeline as well
Only `dot_general` -> `matmul` lowering with 2D multiples-of-32 tiles is actually tested, higher dimensions require #3027 and/or #3025
The `gather` -> `embedding` test depends on #3024 and so is disabled for now
The `reduce_or` -> `sum` tests are causing hangs/crashes depending on input shapes, so they are disabled as well

### Checklist
- [ ] New/Existing tests provide coverage for changes