### PR TITLE
conv2d_transpose

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -1499,7 +1499,6 @@ def TTIR_ConvolutionOp : TTIR_NamedOp<"convolution"> {
     AnyRankedTensor:$weight,
     Optional<AnyRankedTensor>:$bias,
     AnyRankedTensor:$output,
-
     DenseI64ArrayAttr:$window_strides,
     DenseI64ArrayAttr:$padding,
     DenseI64ArrayAttr:$input_dilation,

--- a/test/ttmlir/Conversion/StableHLOToTTIR/conv_transpose2d_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/conv_transpose2d_op.mlir
@@ -1,0 +1,35 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s | FileCheck %s
+
+module @conv_transpose attributes {} {
+  func.func @test_conv_transpose2d(%arg0: tensor<1x256x32x32xf32>, %arg1: tensor<256x128x2x2xf32>, %arg2: tensor<128xf32>) -> tensor<1x128x64x64xf32> {
+    // CHECK-LABEL: @test_conv_transpose2d
+    %0 = stablehlo.transpose %arg1, dims = [2, 3, 1, 0] : (tensor<256x128x2x2xf32>) -> tensor<2x2x128x256xf32>
+    %1 = stablehlo.reverse %0, dims = [0, 1] : tensor<2x2x128x256xf32>
+    // CHECK: %{{[0-9]+}} = "ttir.convolution"(%arg0, %{{[0-9]+}}, %{{[0-9]+}})
+    // CHECK-SAME: batch_group_count = 1 : i64,
+    // CHECK-SAME: convolution_layout = #ttir<convolution_layout input_batch = 0,
+    // CHECK-SAME: input_feature = 1,
+    // CHECK-SAME: input_spatial_dimensions = 2x3,
+    // CHECK-SAME: kernel_output_feature = 2,
+    // CHECK-SAME: kernel_input_feature = 3,
+    // CHECK-SAME: kernel_spatial_dimensions = 0x1,
+    // CHECK-SAME: output_batch = 0,
+    // CHECK-SAME: output_feature = 1,
+    // CHECK-SAME: output_spatial_dimensions = 2x3>,
+    // CHECK-SAME: feature_group_count = 1 : i64,
+    // CHECK-SAME: input_dilation = array<i64: 2, 2>,
+    // CHECK-SAME: padding = array<i64: 1, 1, 1, 1>,
+    // CHECK-SAME: weight_dilation = array<i64: 1, 1>,
+    // CHECK-SAME: window_reversal = array<i1: false, false>,
+    // CHECK-SAME: window_strides = array<i64: 1, 1>
+    // CHECK-SAME: (tensor<1x256x32x32xf32>, tensor<2x2x128x256xf32>, tensor<1x128x64x64xf32>)
+    // CHECK-SAME: -> tensor<1x128x64x64xf32>
+    %2 = stablehlo.convolution(%arg0, %1) dim_numbers = [b, f, 0, 1]x[0, 1, o, i]->[b, f, 0, 1], window = {stride = [1, 1], pad = [[1, 1], [1, 1]], lhs_dilate = [2, 2], rhs_dilate = [1, 1]} {batch_group_count = 1 : i64, feature_group_count = 1 : i64} : (tensor<1x256x32x32xf32>, tensor<2x2x128x256xf32>) -> tensor<1x128x64x64xf32>
+    %3 = stablehlo.reshape %arg2 : (tensor<128xf32>) -> tensor<128x1x1xf32>
+    %4 = stablehlo.broadcast_in_dim %2, dims = [0, 1, 2, 3] : (tensor<1x128x64x64xf32>) -> tensor<1x128x64x64xf32>
+    %5 = stablehlo.broadcast_in_dim %3, dims = [1, 2, 3] : (tensor<128x1x1xf32>) -> tensor<1x128x64x64xf32>
+    %6 = stablehlo.add %4, %5 : tensor<1x128x64x64xf32>
+    return %6 : tensor<1x128x64x64xf32>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/Decomposition/conv_transpose2d_decomposition.mlir
+++ b/test/ttmlir/Dialect/TTIR/Decomposition/conv_transpose2d_decomposition.mlir
@@ -1,0 +1,41 @@
+// RUN: ttmlir-opt --ttir-to-ttir-decomposition --canonicalize %s | FileCheck %s
+
+module @test_conv_transpose {
+  func.func @test_conv_transpose2d(%arg0: tensor<1x256x32x32xf32>, %arg1: tensor<256x128x2x2xf32>, %arg2: tensor<128xf32>) -> tensor<1x128x64x64xf32> {
+    // CHECK-LABEL: @test_conv_transpose2d
+    // CHECK-NOT: ttir.reverse
+    %0 = ttir.empty() : tensor<2x2x128x256xf32>
+    %1 = "ttir.permute"(%arg1, %0) <{permutation = array<i64: 2, 3, 1, 0>}> : (tensor<256x128x2x2xf32>, tensor<2x2x128x256xf32>) -> tensor<2x2x128x256xf32>
+    %2 = ttir.empty() : tensor<2x2x128x256xf32>
+    %3 = "ttir.reverse"(%1, %2) <{dimensions = array<i64: 0, 1>}> : (tensor<2x2x128x256xf32>, tensor<2x2x128x256xf32>) -> tensor<2x2x128x256xf32>
+    %4 = ttir.empty() : tensor<1x128x64x64xf32>
+    // CHECK: %[[ARG0:[0-9]+]] = "ttir.permute"(%arg0, %{{[0-9]+}})
+    // CHECK-SAME: <{permutation = array<i64: 0, 2, 3, 1>}>
+    // CHECK-SAME: (tensor<1x256x32x32xf32>, tensor<1x32x32x256xf32>)
+    // CHECK-SAME: -> tensor<1x32x32x256xf32>
+    // CHECK: %[[CONV_T:[0-9]+]] = "ttir.conv_transpose2d"(%[[ARG0]], %arg1, %{{[0-9]+}})
+    // CHECK-SAME: dilation = array<i32: 1, 1>,
+    // CHECK-SAME: groups = 1 : i32,
+    // CHECK-SAME: output_padding = array<i32: 0, 0>,
+    // CHECK-SAME: padding = array<i32: 0, 0, 0, 0>,
+    // CHECK-SAME: stride = array<i32: 2, 2>
+    // CHECK-SAME: (tensor<1x32x32x256xf32>, tensor<256x128x2x2xf32>, tensor<1x64x64x128xf32>)
+    // CHECK-SAME: -> tensor<1x64x64x128xf32>
+    %5 = "ttir.convolution"(%arg0, %3, %4) <{batch_group_count = 1 : i64, convolution_layout = #ttir<convolution_layout input_batch = 0, input_feature = 1, input_spatial_dimensions = 2x3, kernel_output_feature = 2, kernel_input_feature = 3, kernel_spatial_dimensions = 0x1, output_batch = 0, output_feature = 1, output_spatial_dimensions = 2x3>, feature_group_count = 1 : i64, input_dilation = array<i64: 2, 2>, is_transposed = true, padding = array<i64: 1, 1, 1, 1>, weight_dilation = array<i64: 1, 1>, window_reversal = array<i1: false, false>, window_strides = array<i64: 1, 1>}> : (tensor<1x256x32x32xf32>, tensor<2x2x128x256xf32>, tensor<1x128x64x64xf32>) -> tensor<1x128x64x64xf32>
+    // CHECK: %{{[0-9]+}} = "ttir.permute"(%[[CONV_T]], %{{[0-9]+}})
+    // CHECK-SAME: permutation = array<i64: 0, 3, 1, 2>
+    // CHECK-SAME: (tensor<1x64x64x128xf32>, tensor<1x128x64x64xf32>)
+    // CHECK-SAME: -> tensor<1x128x64x64xf32>
+    %6 = ttir.empty() : tensor<128x1x1xf32>
+    %7 = "ttir.reshape"(%arg2, %6) <{shape = [128 : i32, 1 : i32, 1 : i32]}> : (tensor<128xf32>, tensor<128x1x1xf32>) -> tensor<128x1x1xf32>
+    %8 = ttir.empty() : tensor<1x128x64x64xf32>
+    %9 = "ttir.broadcast"(%5, %8) <{broadcast_dimensions = array<i64: 1, 1, 1, 1>}> : (tensor<1x128x64x64xf32>, tensor<1x128x64x64xf32>) -> tensor<1x128x64x64xf32>
+    %10 = ttir.empty() : tensor<1x128x1x1xf32>
+    %11 = "ttir.reshape"(%7, %10) <{shape = [1 : i32, 128 : i32, 1 : i32, 1 : i32]}> : (tensor<128x1x1xf32>, tensor<1x128x1x1xf32>) -> tensor<1x128x1x1xf32>
+    %12 = ttir.empty() : tensor<1x128x64x64xf32>
+    %13 = "ttir.broadcast"(%11, %12) <{broadcast_dimensions = array<i64: 1, 1, 64, 64>}> : (tensor<1x128x1x1xf32>, tensor<1x128x64x64xf32>) -> tensor<1x128x64x64xf32>
+    %14 = ttir.empty() : tensor<1x128x64x64xf32>
+    %15 = "ttir.add"(%9, %13, %14) : (tensor<1x128x64x64xf32>, tensor<1x128x64x64xf32>, tensor<1x128x64x64xf32>) -> tensor<1x128x64x64xf32>
+    return %15 : tensor<1x128x64x64xf32>
+  }
+}

--- a/test/ttmlir/Silicon/StableHLO/n150/conv_transpose2d_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/conv_transpose2d_op.mlir
@@ -1,0 +1,47 @@
+// REQUIRES: stablehlo
+// RUN: rm -rf %t.ttnn
+// RUN: rm -rf %t.mlir
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s \
+// RUN:     --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" > %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+// RUN: FileCheck --input-file=%t.mlir %s
+
+module @test_conv_transpose {
+  func.func @test_conv_transpose2d(%arg0: tensor<1x256x32x32xf32>, %arg1: tensor<256x128x2x2xf32>, %arg2: tensor<128xf32>) -> tensor<1x128x64x64xf32> {
+    // CHECK-LABEL: @test_conv_transpose2d
+    %0 = stablehlo.transpose %arg1, dims = [2, 3, 1, 0] : (tensor<256x128x2x2xf32>) -> tensor<2x2x128x256xf32>
+    %1 = stablehlo.reverse %0, dims = [0, 1] : tensor<2x2x128x256xf32>
+    // CHECK: %{{[0-9]+}} = "ttnn.permute"(%arg0)
+    // CHECK-SAME: permutation = array<i64: 0, 2, 3, 1>
+    // CHECK-SAME: tensor<1x256x32x32xf32,
+    // CHECK-SAME: -> tensor<1x32x32x256xf32,
+    // CHECK: %[[CONV_T:[0-9]+]] = "ttnn.conv_transpose2d"(%{{[0-9]+}}, %arg1, %{{[0-9]+}})
+    // CHECK-SAME: batch_size = 1 : i32,
+    // CHECK-SAME: dilation = array<i32: 1, 1>,
+    // CHECK-SAME: groups = 1 : i32,
+    // CHECK-SAME: in_channels = 256 : i32,
+    // CHECK-SAME: input_height = 32 : i32, input_width = 32 : i32,
+    // CHECK-SAME: kernel_size = array<i32: 2, 2>,
+    // CHECK-SAME: out_channels = 128 : i32,
+    // CHECK-SAME: output_padding = array<i32: 0, 0>,
+    // CHECK-SAME: padding = array<i32: 0, 0>,
+    // CHECK-SAME: stride = array<i32: 2, 2>}>
+    // CHECK-SAME: tensor<1x32x32x256xf32,
+    // CHECK-SAME: tensor<256x128x2x2xf32,
+    // CHECK-SAME: -> tensor<1x1x4096x128xf32,
+    %2 = stablehlo.convolution(%arg0, %1) dim_numbers = [b, f, 0, 1]x[0, 1, o, i]->[b, f, 0, 1], window = {stride = [1, 1], pad = [[1, 1], [1, 1]], lhs_dilate = [2, 2], rhs_dilate = [1, 1]} {batch_group_count = 1 : i64, feature_group_count = 1 : i64} : (tensor<1x256x32x32xf32>, tensor<2x2x128x256xf32>) -> tensor<1x128x64x64xf32>
+    // CHECK: %[[RESHAPE:[0-9]+]] = "ttnn.reshape"(%[[CONV_T]])
+    // CHECK-SAME: shape = [1 : i32, 64 : i32, 64 : i32, 128 : i32]
+    // CHECK-SAME: tensor<1x1x4096x128xf32,
+    // CHECK-SAME: -> tensor<1x64x64x128xf32,
+    // CHECK: %{{[0-9]+}} = "ttnn.permute"(%[[RESHAPE]])
+    // CHECK-SAME: permutation = array<i64: 0, 3, 1, 2>
+    // CHECK-SAME: tensor<1x64x64x128xf32,
+    // CHECK-SAME: -> tensor<1x128x64x64xf32,
+    %3 = stablehlo.reshape %arg2 : (tensor<128xf32>) -> tensor<128x1x1xf32>
+    %4 = stablehlo.broadcast_in_dim %2, dims = [0, 1, 2, 3] : (tensor<1x128x64x64xf32>) -> tensor<1x128x64x64xf32>
+    %5 = stablehlo.broadcast_in_dim %3, dims = [1, 2, 3] : (tensor<128x1x1xf32>) -> tensor<1x128x64x64xf32>
+    %6 = stablehlo.add %4, %5 : tensor<1x128x64x64xf32>
+    return %6 : tensor<1x128x64x64xf32>
+  }
+}


### PR DESCRIPTION
### Ticket
closes #3267 

### Problem description
Stablehlo has `convolution` op which is used for both `conv2d` and `conv_transpose2d` op.
Currently, `stablehlo.convolution` is lowered to `ttir.convolution` and
then always decomposed to `ttir.conv2d` op (TTIRToTTIRDecomposition pass).
This results in incorrect lowering of `conv_transpose2d` to `conv2d` op. 

### What's changed
Lower `ttir.convolution` to either `ttir.conv2d` or `ttir.conv_transpose2d` op in TTIRToTTIRDecomposition pass.

### Checklist
- [X] New/Existing tests provide coverage for changes
