### PR TITLE
Fix a typo in the documentation for the PrepareConv2dWeights pass

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -138,7 +138,7 @@ def TTNNPrepareConv2dWeights : Pass<"ttnn-prepare-conv2d-weights", "::mlir::Modu
   let description = [{
     This pass inserts a PrepareConv2dWeights operation before each Conv2d op which preprocess the weights used by Conv2d operations.
     The PrepareConv2dWeights op can be then const-evaled, leading to improved performance. In order to use this pass,
-    the project must be built with the op model library by setting -DTTMLIR_ENABLE_OP_MODEL=ON during the build process.
+    the project must be built with the op model library by setting -DTTMLIR_ENABLE_OPMODEL=ON during the build process.
   }];
 }
 


### PR DESCRIPTION
### Problem description
I made a typo in the documentation for `PrepareConv2dWeights`, where I wrote `DTTMLIR_ENABLE_OP_MODEL` as the name of the flag instead of the correct `DTTMLIR_ENABLE_OPMODEL`.