### PR TITLE
Fix loc assert

### DIFF
--- a/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
@@ -20,8 +20,7 @@ def parse_loc_string(loc_str):
     This can be replaced by ttmlir.ir.Module.parse, but requires some further work to extract the actual location object from the module.
     """
     match = re.match(r'^loc\("([^"]+)"', loc_str)
-    # https://github.com/tenstorrent/tt-mlir/issues/3255
-    # assert match, f"Failed to parse location string: {loc_str}"
+    assert match, f"Failed to parse location string: {loc_str}"
     return match.group(1) if match else None
 
 
@@ -608,7 +607,7 @@ def parse_conv2d_config(attr):
         )
     )
     shard_layout = OVERRIDE_PARAMETER_DISABLED_STR
-    if conv2d_config.override_sharding_config:
+    if conv2d_config.shard_layout_as_int:
         shard_layout = str(ttnn.TensorMemoryLayout(conv2d_config.shard_layout_as_int))
     result.append(
         utils.make_editable_kv(
@@ -945,8 +944,7 @@ def build_graph(
 
     # Check if all perf locations match some graph node
     for loc in loc_to_perf.keys():
-        pass  # https://github.com/tenstorrent/tt-mlir/issues/3255
-        # assert loc in processed_locs, f"Perf location {loc} not found in graph nodes"
+        assert loc in processed_locs, f"Perf location {loc} not found in graph nodes"
 
     # Add Overlay Data if it exists
     overlays = {}
@@ -1051,7 +1049,7 @@ def process_operations(
 
         # Create graph node for this operation
         operation = OpHandler(op)
-        processed_locs.add(operation.named_location)
+        processed_locs.add(operation.full_location)
 
         if (
             operation.full_location in loc_to_perf


### PR DESCRIPTION
### Ticket
Closes #3255 

### Problem description
In tt-explorer, assert for checking if all perf loc's are present in the model is failing.
This is caused by using `named_location` instead of `full_location` which should used as id for ops since #3144 .

### What's changed
Use `full_location` instead of `named_location` as op id.