### PR TITLE
fold 'fmt' into the va args block for TTMLIR_DEBUG-like macros

### DIFF
--- a/include/ttmlir/Support/Logger.h
+++ b/include/ttmlir/Support/Logger.h
@@ -108,7 +108,7 @@ inline std::string getCurrentTimestamp() {
 
 // Main logging macro that uses DEBUG_WITH_TYPE
 #ifdef TTMLIR_ENABLE_DEBUG_LOGS
-#define TTMLIR_LOG_FMT(logComponent, logLevel, fmt, ...)                       \
+#define TTMLIR_LOG_FMT(logComponent, logLevel, /* fmt, args */...)             \
   DEBUG_WITH_TYPE(                                                             \
       ttmlir::getLogComponentStr(logComponent),                                \
       if (ttmlir::isLogLevelEnabled(logLevel)) {                               \
@@ -126,22 +126,25 @@ inline std::string getCurrentTimestamp() {
         OS.changeColor(llvm::raw_ostream::MAGENTA, /*bold=*/true);             \
         OS << ttmlir::getLogComponentStr(logComponent);                        \
         OS.resetColor();                                                       \
-        OS << "] " << llvm::formatv(fmt, __VA_ARGS__) << "\n";                 \
+        OS << "] " << llvm::formatv(__VA_ARGS__) << "\n";                      \
         if (logLevel == ttmlir::LogLevel::Fatal) {                             \
           abort();                                                             \
         }                                                                      \
       })
 #else
-#define TTMLIR_LOG_FMT(logComponent, logLevel, fmt, ...) ((void)0)
+#define TTMLIR_LOG_FMT(logComponent, logLevel, /* fmt, args */...) ((void)0)
 #endif
 
 // Public logging macros
-#define TTMLIR_TRACE(component, fmt, ...)                                      \
-  TTMLIR_LOG_FMT(component, ttmlir::LogLevel::Trace, fmt, __VA_ARGS__)
-#define TTMLIR_DEBUG(component, fmt, ...)                                      \
-  TTMLIR_LOG_FMT(component, ttmlir::LogLevel::Debug, fmt, __VA_ARGS__)
-#define TTMLIR_FATAL(component, fmt, ...)                                      \
-  TTMLIR_LOG_FMT(component, ttmlir::LogLevel::Fatal, fmt, __VA_ARGS__)
+#define TTMLIR_TRACE(component, /* fmt, args */...)                            \
+  TTMLIR_LOG_FMT(component, ttmlir::LogLevel::Trace,                           \
+                 /* fmt, args */ __VA_ARGS__)
+#define TTMLIR_DEBUG(component, /* fmt, args */...)                            \
+  TTMLIR_LOG_FMT(component, ttmlir::LogLevel::Debug,                           \
+                 /* fmt, args */ __VA_ARGS__)
+#define TTMLIR_FATAL(component, /* fmt, args */...)                            \
+  TTMLIR_LOG_FMT(component, ttmlir::LogLevel::Fatal,                           \
+                 /* fmt, args */ __VA_ARGS__)
 
 } // namespace ttmlir
 

--- a/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
+++ b/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
@@ -85,7 +85,7 @@ bool ShardSolver::resolveStep() {
   // We need special handling for the first op in the chain.
   //
   if (!preprocessFirstOp()) {
-    TTMLIR_TRACE(ttmlir::LogComponent::Optimizer, "{}",
+    TTMLIR_TRACE(ttmlir::LogComponent::Optimizer,
                  "Preprocessing first op failed, aborting.");
     return false;
   }
@@ -243,7 +243,7 @@ bool ShardSolver::resolveStep() {
     }
   }
 
-  TTMLIR_TRACE(ttmlir::LogComponent::Optimizer, "{}",
+  TTMLIR_TRACE(ttmlir::LogComponent::Optimizer,
                "ShardSolver::resolveStep: returning true");
 
   return true;

--- a/test/unittests/Support/LoggerTest.cpp
+++ b/test/unittests/Support/LoggerTest.cpp
@@ -65,20 +65,18 @@ TEST(LoggerTest, LoggingOutput) {
                "Debug message with two values: {0}, {1}", "hello", 3.14);
 
   // Test the general component
-  TTMLIR_DEBUG(LogComponent::General, "{}", "Debug with general component");
-  TTMLIR_TRACE(LogComponent::General, "{}", "Trace with general component");
+  TTMLIR_DEBUG(LogComponent::General, "Debug with general component");
+  TTMLIR_TRACE(LogComponent::General, "Trace with general component");
 
   // Switch to only general component
   llvm::setCurrentDebugType("general");
 
   // These should not be visible since optimizer component is disabled
-  TTMLIR_TRACE(LogComponent::Optimizer, "{}",
-               "This trace should not be visible");
-  TTMLIR_DEBUG(LogComponent::Optimizer, "{}",
-               "This debug should not be visible");
+  TTMLIR_TRACE(LogComponent::Optimizer, "This trace should not be visible");
+  TTMLIR_DEBUG(LogComponent::Optimizer, "This debug should not be visible");
 
   // This should be visible since general component is enabled
-  TTMLIR_DEBUG(LogComponent::General, "{}", "This debug should be visible");
+  TTMLIR_DEBUG(LogComponent::General, "This debug should be visible");
 
   // Get the captured output
   std::string outputBuffer = testing::internal::GetCapturedStderr();


### PR DESCRIPTION
### Problem description
The original macro defs required awkward workaround when logging messages without format args, e.g.
```cpp
TTMLIR_TRACE(ttmlir::LogComponent::Optimizer, "{}",
               "ShardSolver::resolveStep: returning true");
```
Needing to use "{}" above is unconventional/surprising. 

### What's changed
The original macro def expanded into malformed syntax because of the trailing comma in
```cpp
OS << "] " << llvm::formatv(fmt, __VA_ARGS__) << "\n";
```
I've changed the definition to pass `fmt` implicitly, as part of `__VA_ARGS__`.  Also added comment prefix for `...` to explain usage/signature. I've been using this version in an ongoing PR and it is working fine.

### Checklist
- [x] New/Existing tests provide coverage for changes
