### PR TITLE
Fixing header linking for frontend uplift

### DIFF
--- a/runtime/include/tt/runtime/detail/common.h
+++ b/runtime/include/tt/runtime/detail/common.h
@@ -10,6 +10,7 @@
 #define FMT_HEADER_ONLY
 #include "tt-metalium/host_api.hpp"
 
+#include "tt/runtime/detail/flatbuffer_operator_ostream.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/types.h"
 

--- a/runtime/include/tt/runtime/utils.h
+++ b/runtime/include/tt/runtime/utils.h
@@ -13,8 +13,6 @@
 #include "ttmlir/Target/Common/types_generated.h"
 #pragma clang diagnostic pop
 
-#include "tt/runtime/detail/flatbuffer_operator_ostream.h"
-
 namespace tt::runtime::utils {
 
 inline std::shared_ptr<void> malloc_shared(size_t size) {


### PR DESCRIPTION
Header file that is exposed to the frontends (`runtime/include/tt/runtime/utils.h`) now includes `tt/runtime/detail/flatbuffer_operator_ostream.h`, which is not, causing uplifts to fail. This PR fixes that.