### PR TITLE
D2M: Add mm_init_short and reposition init/init_short for matmul

### DIFF
--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -130,6 +130,15 @@ def TTKernel_MatmulInitOp : TTKernel_InitOp<"mm_init"> {
     let arguments = (ins TTKernel_CB:$in0_cb, TTKernel_CB:$in1_cb, TTKernel_CB:$out_cb, I32:$transpose);
 }
 
+def TTKernel_MatmulInitShortOp : TTKernel_InitOp<"mm_init_short"> {
+    let summary = "Matmul init function";
+    let description = [{
+      Must be run before matmul.
+    }];
+
+    let arguments = (ins TTKernel_CB:$in0_cb, TTKernel_CB:$in1_cb, I32:$transpose);
+}
+
 def TTKernel_MatmulTilesOp : TTKernel_FPUOp<"matmul_tiles", [TTKernel_TernaryOpTrait]> {
     let summary = "Matmul tiles operation";
     let description = [{

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -124,16 +124,16 @@ def TTKernel_BinaryOpInitCommonOp : TTKernel_InitOp<"binary_op_init_common"> {
 def TTKernel_MatmulInitOp : TTKernel_InitOp<"mm_init"> {
     let summary = "Matmul init function";
     let description = [{
-      Must be run before matmul.
+      Can only be run ONCE per kernel. Should be run before matmul.
     }];
 
     let arguments = (ins TTKernel_CB:$in0_cb, TTKernel_CB:$in1_cb, TTKernel_CB:$out_cb, I32:$transpose);
 }
 
 def TTKernel_MatmulInitShortOp : TTKernel_InitOp<"mm_init_short"> {
-    let summary = "Matmul init function";
+    let summary = "Matmul short init function";
     let description = [{
-      Must be run before matmul.
+      Can be run MULTIPLE times per kernel. Should be run before matmul. Use this if some other init was called between mm_init and matmul_tiles. (i.e. in a loop)
     }];
 
     let arguments = (ins TTKernel_CB:$in0_cb, TTKernel_CB:$in1_cb, I32:$transpose);

--- a/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
+++ b/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
@@ -99,7 +99,7 @@ static void lowerLoadToCopyTile(memref::LoadOp op, bool cbIdxAsDstIdx,
                     : index(0));
 }
 
-static void setInsertionPointAfterOperands(PatternRewriter &rewriter,
+static void setInsertionPointAfterOperands(OpBuilder &rewriter,
                                            llvm::ArrayRef<Value> operands) {
   Operation *latestDefOp = nullptr;
   for (Value operand : operands) {

--- a/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
+++ b/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
@@ -99,6 +99,20 @@ static void lowerLoadToCopyTile(memref::LoadOp op, bool cbIdxAsDstIdx,
                     : index(0));
 }
 
+static void setInsertionPointAfterOperands(PatternRewriter &rewriter,
+                                           llvm::ArrayRef<Value> operands) {
+  Operation *latestDefOp = nullptr;
+  for (Value operand : operands) {
+    Operation *definingOp = operand.getDefiningOp();
+    if (!latestDefOp ||
+        (definingOp && !definingOp->isBeforeInBlock(latestDefOp))) {
+      latestDefOp = definingOp;
+    }
+  }
+
+  rewriter.setInsertionPointAfter(latestDefOp);
+}
+
 } // namespace
 
 namespace {
@@ -164,16 +178,23 @@ public:
           getCB(rewriter, adaptor.getRhs()), getLoadIndex(adaptor.getLhs()),
           getLoadIndex(adaptor.getRhs()), dstIdx);
     } else if constexpr (std::is_same_v<ConcreteOp, ttir::TileMatmulOp>) {
-      auto mmInitOp = rewriter.create<ttkernel::MatmulInitOp>(
-          op->getLoc(), getCB(rewriter, adaptor.getA()),
-          getCB(rewriter, adaptor.getB()), getCB(rewriter, adaptor.getC()),
+      auto insertionPoint = rewriter.getInsertionPoint();
+      auto cbA = getCB(rewriter, adaptor.getA());
+      auto cbB = getCB(rewriter, adaptor.getB());
+      auto cbC = getCB(rewriter, adaptor.getC());
+      setInsertionPointAfterOperands(rewriter, {cbA, cbB, cbC});
+      rewriter.create<ttkernel::MatmulInitOp>(
+          op->getLoc(), cbA, cbB, cbC,
+          /* transpose */ i32(rewriter, op->getLoc(), 0));
+      rewriter.setInsertionPoint(insertionPoint->getBlock(), insertionPoint);
+      auto mmInitShortOp = rewriter.create<ttkernel::MatmulInitShortOp>(
+          op->getLoc(), cbA, cbB,
           /* transpose */ i32(rewriter, op->getLoc(), 0));
       rewriter.create<ttkernel::MatmulTilesOp>(
-          op->getLoc(), getCB(rewriter, adaptor.getA()),
-          getCB(rewriter, adaptor.getB()), getLoadIndex(adaptor.getA()),
+          op->getLoc(), cbA, cbB, getLoadIndex(adaptor.getA()),
           getLoadIndex(adaptor.getB()), dstIdx,
           /* transpose */ i32(rewriter, op->getLoc(), 0));
-      rewriter.setInsertionPoint(mmInitOp);
+      rewriter.setInsertionPoint(mmInitShortOp);
       lowerLoadToCopyTile(
           adaptor.getC().template getDefiningOp<memref::LoadOp>(), false,
           rewriter);

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -580,6 +580,7 @@ public:
         TTKernelToEmitCOpaqueRewriter<ttkernel::MaxTilesInitOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::SinTileInitOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::MatmulInitOp>,
+        TTKernelToEmitCOpaqueRewriter<ttkernel::MatmulInitShortOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::MatmulTilesOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::AddTilesOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::MulTilesOp>,

--- a/test/ttmlir/Conversion/TTIRToTTKernel/tiled_matmul.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTKernel/tiled_matmul.mlir
@@ -66,6 +66,7 @@ module {
     %collapse_shape = memref.collapse_shape %arg0 [[0, 1]] : memref<1x3x!tt.tile<32x32, f32>, #l1_> into memref<3x!tt.tile<32x32, f32>, #l1_>
     %collapse_shape_0 = memref.collapse_shape %arg1 [[0, 1]] : memref<3x4x!tt.tile<32x32, f32>, #l1_> into memref<12x!tt.tile<32x32, f32>, #l1_>
     %collapse_shape_1 = memref.collapse_shape %arg2 [[0, 1]] : memref<1x4x!tt.tile<32x32, f32>, #l1_> into memref<4x!tt.tile<32x32, f32>, #l1_>
+    // CHECK: "ttkernel.mm_init"
     // CHECK: "ttkernel.cb_wait_front"
     // CHECK: "ttkernel.cb_wait_front"
     ttir.await %arg0, %arg1 : (memref<1x3x!tt.tile<32x32, f32>, #l1_>, memref<3x4x!tt.tile<32x32, f32>, #l1_>)
@@ -84,7 +85,7 @@ module {
           // CHECK: "ttkernel.copy_tile_init"
           // CHECK: "ttkernel.copy_tile"
           %8 = memref.load %collapse_shape_1[%7] : memref<4x!tt.tile<32x32, f32>, #l1_>
-          // CHECK: "ttkernel.mm_init"
+          // CHECK: "ttkernel.mm_init_short"
           // CHECK: "ttkernel.matmul_tiles"
           // CHECK: "ttkernel.tile_regs_commit"
           %9 = "ttir.tile_matmul"(%2, %5, %8) : (!tt.tile<32x32, f32>, !tt.tile<32x32, f32>, !tt.tile<32x32, f32>) -> !tt.tile<32x32, f32>


### PR DESCRIPTION
### Ticket
#3230 

### Problem description
We incorrectly used `mm_init` for matmul lowering and were missing `mm_init_short`.

### What's changed
- Add `mm_init_short` op
- Insert `mm_init_short` instead of `mm_init` inside loops 
- Insert `mm_init` at the earliest possible position in the kernel, outside of the loops

### Checklist
- [X] New/Existing tests provide coverage for changes
