### PR TITLE
Fixed a bug set default l1 small size on opening the device (##3214)

### DIFF
--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -58,9 +58,11 @@ namespace ttnn {
 //
 class DeviceGetter {
 public:
+  static constexpr std::size_t l1SmallSize = 1 << 15;
+
   static ttnn::IDevice *getInstance() {
     static std::shared_ptr<ttnn::MeshDevice> instance =
-        ::ttnn::MeshDevice::create_unit_mesh(0, 1 << 15);
+        ::ttnn::MeshDevice::create_unit_mesh(0, l1SmallSize);
 
     return instance.get();
   }


### PR DESCRIPTION
### Ticket
#3214

### Problem description
ttnn-standalone opens device with a default l1_small_size of 0. 

### What's changed
Changed l1_small_size to 1 << 15 (32 kB) as it is in tt-mlir runtime.

### Checklist
- [ ] New/Existing tests provide coverage for changes
