### PR TITLE
Fix tt-metal build dir path for tracy to work

### DIFF
--- a/env/activate
+++ b/env/activate
@@ -24,7 +24,7 @@ fi
 export TTMLIR_ENV_ACTIVATED=1
 export PATH="$(pwd)/${BUILD_DIR:=build}/bin:$TTMLIR_TOOLCHAIN_DIR/bin:$TTMLIR_TOOLCHAIN_DIR/venv/bin:$PATH"
 export TT_METAL_HOME="$(pwd)/third_party/tt-metal/src/tt-metal"
-export TT_METAL_BUILD_HOME="$(pwd)/third_party/tt-metal/src/tt-metal-build"
+export TT_METAL_BUILD_HOME="$(pwd)/third_party/tt-metal/src/tt-metal/build"
 export TT_MLIR_HOME="$(pwd)"
 export PYTHONPATH="$(pwd)/${BUILD_DIR:=build}/python_packages:$(pwd)/.local/toolchain/python_packages/mlir_core:${TT_METAL_HOME}:${TT_METAL_HOME}/tt_eager:${TT_METAL_BUILD_HOME}/tools/profiler/bin:${TT_METAL_HOME}/ttnn"
 export ARCH_NAME="${ARCH_NAME:-wormhole_b0}"

--- a/env/activate.fish
+++ b/env/activate.fish
@@ -15,7 +15,7 @@ end
 set -gx TTMLIR_ENV_ACTIVATED 1
 set -gx PATH (pwd)/build/bin $TTMLIR_TOOLCHAIN_DIR/bin $TTMLIR_TOOLCHAIN_DIR/venv/bin $PATH
 set -gx TT_METAL_HOME (pwd)/third_party/tt-metal/src/tt-metal
-set -gx TT_METAL_BUILD_HOME (pwd)/third_party/tt-metal/src/tt-metal-build
+set -gx TT_METAL_BUILD_HOME (pwd)/third_party/tt-metal/src/tt-metal/build
 set -gx TT_MLIR_HOME (pwd)
 set -gx PYTHONPATH (pwd)/build/python_packages:(pwd)/.local/toolchain/python_packages/mlir_core:$TT_METAL_HOME:$TT_METAL_HOME/tt_eager:$TT_METAL_BUILD_HOME/tools/profiler/bin:$TT_METAL_HOME/ttnn
 set -gx ARCH_NAME (set -q ARCH_NAME; and echo $ARCH_NAME; or echo "wormhole_b0")

--- a/runtime/tools/ttrt/setup.py
+++ b/runtime/tools/ttrt/setup.py
@@ -24,7 +24,7 @@ ttmlir_build_dir = os.environ.get(
     os.path.join(src_dir, "build"),
 )
 toolchain = os.environ.get("TTMLIR_TOOLCHAIN_DIR", "/opt/ttmlir-toolchain")
-metaldir = f"{src_dir}/third_party/tt-metal/src/tt-metal-build"
+metaldir = f"{src_dir}/third_party/tt-metal/src/tt-metal/build"
 ttmetalhome = os.environ.get("TT_METAL_HOME", "")
 
 os.environ["LDFLAGS"] = "-Wl,-rpath,'$ORIGIN'"

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -28,7 +28,7 @@ else()
 endif()
 message(STATUS "Setting tt-metal CPM cache to: ${CPM_SOURCE_CACHE}")
 
-set(METAL_INSTALL_PREFIX "${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal-build/")
+set(METAL_INSTALL_PREFIX "${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/build/")
 set(TTMETAL_INCLUDE_DIRS
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/ttnn
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/ttnn/cpp
@@ -48,7 +48,7 @@ set(TTMETAL_INCLUDE_DIRS
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_stl
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_stl/tt_stl
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_eager
-  ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal-build/include
+  ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/build/include
   ${CPM_SOURCE_CACHE}/reflect/e75434c4c5f669e4a74e4d84e0a30d7249c1e66f
   ${CPM_SOURCE_CACHE}/nanomsg/28cc32d5bdb6a858fe53b3ccf7e923957e53eada/include
   ${CPM_SOURCE_CACHE}/fmt/69912fb6b71fcb1f7e5deca191a2bb4748c4e7b6/include
@@ -61,7 +61,7 @@ set(TTMETAL_INCLUDE_DIRS
   PARENT_SCOPE
 )
 
-set(TTMETAL_LIBRARY_DIR ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal-build/lib)
+set(TTMETAL_LIBRARY_DIR ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/build/lib)
 set(TTNN_LIBRARY_PATH ${TTMETAL_LIBRARY_DIR}/_ttnn.so)
 set(TTMETAL_LIBRARY_PATH ${TTMETAL_LIBRARY_DIR}/libtt_metal.so)
 set(DEVICE_LIBRARY_PATH ${TTMETAL_LIBRARY_DIR}/libdevice.so)
@@ -89,9 +89,13 @@ set(TTMETAL_BUILD_TYPE "Release")
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(TTMETAL_BUILD_TYPE "Debug")
 endif()
+
+# Ensure the build directory exists before adding the external project
+file(MAKE_DIRECTORY "${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/build")
 ExternalProject_Add(
   tt-metal
   PREFIX ${TTMLIR_SOURCE_DIR}/third_party/tt-metal
+  BINARY_DIR ${TTMLIR_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/build
   CMAKE_ARGS
     -DCMAKE_INSTALL_MESSAGE=LAZY
   CMAKE_GENERATOR Ninja

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -28,7 +28,6 @@ else()
 endif()
 message(STATUS "Setting tt-metal CPM cache to: ${CPM_SOURCE_CACHE}")
 
-set(METAL_INSTALL_PREFIX "${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/build/")
 set(TTMETAL_INCLUDE_DIRS
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/ttnn
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/ttnn/cpp
@@ -90,12 +89,14 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(TTMETAL_BUILD_TYPE "Debug")
 endif()
 
-# Ensure the build directory exists before adding the external project
-file(MAKE_DIRECTORY "${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/build")
+set(METAL_BUILD_DIR ${TTMLIR_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/build)
+set(METAL_INSTALL_PREFIX "${METAL_BUILD_DIR}")
 ExternalProject_Add(
   tt-metal
   PREFIX ${TTMLIR_SOURCE_DIR}/third_party/tt-metal
-  BINARY_DIR ${TTMLIR_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/build
+  BINARY_DIR ${METAL_BUILD_DIR}
+  # This patch command creates the build dir that otherwise doesn't get created
+  PATCH_COMMAND ${CMAKE_COMMAND} -E make_directory ${METAL_BUILD_DIR}
   CMAKE_ARGS
     -DCMAKE_INSTALL_MESSAGE=LAZY
   CMAKE_GENERATOR Ninja

--- a/tools/ttnn-standalone/CMakeLists.txt
+++ b/tools/ttnn-standalone/CMakeLists.txt
@@ -54,7 +54,7 @@ endif()
 
 # Metal dir variables
 set(METAL_SRC_DIR "$ENV{TT_METAL_HOME}" CACHE PATH "Path to the tt-metal root src directory")
-set(METAL_LIB_DIR "$ENV{TT_METAL_HOME}-build/lib" CACHE PATH "Path to the tt-metal lib directory")
+set(METAL_LIB_DIR "$ENV{TT_METAL_HOME}/build/lib" CACHE PATH "Path to the tt-metal lib directory")
 
 if (DEFINED ENV{CPM_SOURCE_CACHE})
   set(CPM_SOURCE_CACHE $ENV{CPM_SOURCE_CACHE})


### PR DESCRIPTION
### Ticket
#3279

### Problem description
Compiling ttnn-standalone and running `tracy` results in errors. Upon debugging, it looks like tracy expects `tt-metal` dir to have a `build` dir. However, we're using cmake's `ExternalProject_Add`, which will by default create a `tt-metal-build` dir.

### What's changed
Explicitly set build dir path in `ExternalProject_Add` command for  tt-metal, so that it changes from:
`third_party/tt-metal/src/tt-metal-build`
to
`third_party/tt-metal/src/tt-metal/build`

With this (and a follow-up fix), tracy works for ttnn-standalone.

### Checklist
- [ ] New/Existing tests provide coverage for changes
