### PR TITLE
fix ttnn-standalone

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -430,9 +430,6 @@ jobs:
         source env/activate
         cmake --build ${{ steps.strings.outputs.build-output-dir }} -- FBS_GENERATION mlir-headers mlir-generic-headers tt-metal-download tt-metal-update tt-metal-configure
         python3 tools/scripts/filter-compile-commands.py --diff ${{ steps.strings.outputs.build-output-dir }}/compile_commands.json
-        # Manually remove any ttnn-standalone entries from compile_commands.json
-        jq 'map(select(.file | test("/tools/ttnn-standalone/") | not))' ${{ steps.strings.outputs.build-output-dir }}/compile_commands.json > ${{ steps.strings.outputs.build-output-dir }}/filtere_standalone_compile_commands.json
-        cat ${{ steps.strings.outputs.build-output-dir }}/filtere_standalone_compile_commands.json > ${{ steps.strings.outputs.build-output-dir }}/compile_commands.json
         cmake --build ${{ steps.strings.outputs.build-output-dir }} -- clang-tidy
 
     - name: Unique-ify clang-tidy fixes

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -428,7 +428,7 @@ jobs:
       shell: bash
       run: |
         source env/activate
-        cmake --build ${{ steps.strings.outputs.build-output-dir }} -- FBS_GENERATION mlir-headers mlir-generic-headers
+        cmake --build ${{ steps.strings.outputs.build-output-dir }} -- FBS_GENERATION mlir-headers mlir-generic-headers tt-metal-download tt-metal-update tt-metal-configure
         python3 tools/scripts/filter-compile-commands.py --diff ${{ steps.strings.outputs.build-output-dir }}/compile_commands.json
         cmake --build ${{ steps.strings.outputs.build-output-dir }} -- clang-tidy
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -429,6 +429,10 @@ jobs:
       run: |
         source env/activate
         cmake --build ${{ steps.strings.outputs.build-output-dir }} -- FBS_GENERATION mlir-headers mlir-generic-headers tt-metal-download tt-metal-update tt-metal-configure
+        cd ${{ steps.strings.outputs.work-dir }}/tools/ttnn-standalone
+        cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=clang++
+        cmake --build build -- ttnn-standalone  # clang-tidy expects the precompiled header to be built, so forcing the build here
+        cd -
         python3 tools/scripts/filter-compile-commands.py --diff ${{ steps.strings.outputs.build-output-dir }}/compile_commands.json
         cmake --build ${{ steps.strings.outputs.build-output-dir }} -- clang-tidy
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -429,11 +429,10 @@ jobs:
       run: |
         source env/activate
         cmake --build ${{ steps.strings.outputs.build-output-dir }} -- FBS_GENERATION mlir-headers mlir-generic-headers tt-metal-download tt-metal-update tt-metal-configure
-        cd ${{ steps.strings.outputs.work-dir }}/tools/ttnn-standalone
-        cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=clang++
-        cmake --build build -- ttnn-standalone  # clang-tidy expects the precompiled header to be built, so forcing the build here
-        cd -
         python3 tools/scripts/filter-compile-commands.py --diff ${{ steps.strings.outputs.build-output-dir }}/compile_commands.json
+        # Manually remove any ttnn-standalone entries from compile_commands.json
+        jq 'map(select(.file | test("/tools/ttnn-standalone/") | not))' ${{ steps.strings.outputs.build-output-dir }}/compile_commands.json > ${{ steps.strings.outputs.build-output-dir }}/filtere_standalone_compile_commands.json
+        cat ${{ steps.strings.outputs.build-output-dir }}/filtere_standalone_compile_commands.json > ${{ steps.strings.outputs.build-output-dir }}/compile_commands.json
         cmake --build ${{ steps.strings.outputs.build-output-dir }} -- clang-tidy
 
     - name: Unique-ify clang-tidy fixes

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -114,8 +114,9 @@ ExternalProject_Add(
   BUILD_BYPRODUCTS ${TTNN_LIBRARY_PATH} ${TTMETAL_LIBRARY_PATH} ${TRACY_LIBRARY_PATH} ${DEVICE_LIBRARY_PATH}
 )
 
-ExternalProject_Add_StepTargets(tt-metal download configure)
+ExternalProject_Add_StepTargets(tt-metal download update configure)
 set_target_properties(tt-metal-download PROPERTIES EXCLUDE_FROM_ALL TRUE)
+set_target_properties(tt-metal-update PROPERTIES EXCLUDE_FROM_ALL TRUE)
 set_target_properties(tt-metal-configure PROPERTIES EXCLUDE_FROM_ALL TRUE)
 
 set_target_properties(tt-metal PROPERTIES EXCLUDE_FROM_ALL TRUE)
@@ -228,5 +229,6 @@ else() # TTMLIR_ENABLE_RUNTIME
   add_library(TTMETAL_LIBRARY INTERFACE)
   add_library(DEVICE_LIBRARY INTERFACE)
   add_library(tt-metal-download INTERFACE EXCLUDE_FROM_ALL)
+  add_library(tt-metal-update INTERFACE EXCLUDE_FROM_ALL)
   add_library(tt-metal-configure INTERFACE EXCLUDE_FROM_ALL)
 endif() # TTMLIR_ENABLE_RUNTIME

--- a/tools/scripts/filter-compile-commands.py
+++ b/tools/scripts/filter-compile-commands.py
@@ -50,7 +50,9 @@ def main(args):
         compile_commands = json.load(f)
 
     filtered_commands = []
-    m = re.compile(r"^{}/((?!third_party).)*$".format(args.prefix))
+    m = re.compile(
+        r"^{}/((?!third_party|tools/ttnn-standalone).)*$".format(args.prefix)
+    )
     diff_files = get_diff_files(compile_commands) if args.diff else set()
     compile_commands = sorted(
         compile_commands, key=lambda x: x["file"] not in diff_files

--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -60,7 +60,7 @@ class DeviceGetter {
 public:
   static constexpr std::size_t l1SmallSize = 1 << 15;
 
-  static ttnn::IDevice *getInstance() {
+  static ttnn::MeshDevice *getInstance() {
     static std::shared_ptr<ttnn::MeshDevice> instance =
         ::ttnn::MeshDevice::create_unit_mesh(0, l1SmallSize);
 

--- a/tools/ttnn-standalone/ttnn-standalone.cpp
+++ b/tools/ttnn-standalone/ttnn-standalone.cpp
@@ -3,42 +3,27 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn-precompiled.hpp"
-ttnn::Tensor add(ttnn::Tensor v1, ttnn::Tensor v2) {
-  ttnn::IDevice* v3 = ttnn::DeviceGetter::getInstance();
-  ttnn::MemoryConfig v4 = ttnn::MemoryConfig(ttnn::TensorMemoryLayout::INTERLEAVED, ttnn::BufferType::DRAM);
-  ttnn::Tensor v5 = ttnn::to_device(v1, v3, v4);
-  ttnn::Tensor v6 = ttnn::to_layout(v5, ttnn::Layout::TILE, std::nullopt, std::nullopt, static_cast<::ttnn::IDevice *>(nullptr));
-  ttnn::deallocate(v5, false);
-  ttnn::MemoryConfig v7 = ttnn::MemoryConfig(ttnn::TensorMemoryLayout::INTERLEAVED, ttnn::BufferType::DRAM);
-  ttnn::Tensor v8 = ttnn::to_device(v2, v3, v7);
-  ttnn::Tensor v9 = ttnn::to_layout(v8, ttnn::Layout::TILE, std::nullopt, std::nullopt, static_cast<::ttnn::IDevice *>(nullptr));
-  ttnn::deallocate(v8, false);
-  ttnn::Shape v10 = ttnn::Shape({32, 32});
-  ttnn::MemoryConfig v11 = ttnn::MemoryConfig(ttnn::TensorMemoryLayout::INTERLEAVED, ttnn::BufferType::DRAM);
-  ttnn::Tensor v12 = ttnn::empty(v10, ttnn::DataType::BFLOAT16, ttnn::Layout::TILE, v3, v11);
-  ttnn::Tensor v13 = ttnn::add(v6, v9, std::nullopt, std::nullopt, v12);
-  ttnn::deallocate(v9, false);
-  ttnn::deallocate(v6, false);
-  ttnn::Tensor v14 = ttnn::from_device(v13);
-  ttnn::deallocate(v12, false);
-  ttnn::Tensor v15 = ttnn::to_layout(v14, ttnn::Layout::ROW_MAJOR, std::nullopt, std::nullopt, static_cast<::ttnn::IDevice *>(nullptr));
-  ttnn::deallocate(v14, false);
-  return v15;
+::ttnn::Tensor add(::ttnn::Tensor v1, ::ttnn::Tensor v2) {
+  ::ttnn::Tensor v3 = ttnn::add(v1, v2, ::std::nullopt, ::ttnn::MemoryConfig{::ttnn::TensorMemoryLayout::INTERLEAVED, ::ttnn::BufferType::DRAM});
+  ttnn::deallocate(v2, false);
+  ttnn::deallocate(v1, false);
+  return v3;
 }
 
-std::tuple<ttnn::Tensor, ttnn::Tensor> createInputsFor_add() {
-  ttnn::Shape v1 = ttnn::Shape({32, 32});
-  ttnn::Tensor v2 = ttnn::ones(v1, ttnn::DataType::BFLOAT16, ttnn::Layout::ROW_MAJOR, std::nullopt, std::nullopt);
-  ttnn::Shape v3 = ttnn::Shape({32, 32});
-  ttnn::Tensor v4 = ttnn::ones(v3, ttnn::DataType::BFLOAT16, ttnn::Layout::ROW_MAJOR, std::nullopt, std::nullopt);
-  return std::make_tuple(v2, v4);
+std::tuple<::ttnn::Tensor, ::ttnn::Tensor> create_inputs_for_add() {
+  ttnn::distributed::MeshDevice* v1 = ttnn::DeviceGetter::getInstance();
+  ::ttnn::Tensor v2 = ttnn::ones(::ttnn::Shape({32, 32}), ::ttnn::DataType::BFLOAT16, ::ttnn::Layout::TILE, ::std::nullopt, ::ttnn::MemoryConfig{::ttnn::TensorMemoryLayout::INTERLEAVED, ::ttnn::BufferType::DRAM});
+  ::ttnn::Tensor v3 = ttnn::to_device(v2, v1, ::ttnn::MemoryConfig{::ttnn::TensorMemoryLayout::INTERLEAVED, ::ttnn::BufferType::DRAM});
+  ::ttnn::Tensor v4 = ttnn::ones(::ttnn::Shape({32, 32}), ::ttnn::DataType::BFLOAT16, ::ttnn::Layout::TILE, ::std::nullopt, ::ttnn::MemoryConfig{::ttnn::TensorMemoryLayout::INTERLEAVED, ::ttnn::BufferType::DRAM});
+  ::ttnn::Tensor v5 = ttnn::to_device(v4, v1, ::ttnn::MemoryConfig{::ttnn::TensorMemoryLayout::INTERLEAVED, ::ttnn::BufferType::DRAM});
+  return std::make_tuple(v3, v5);
 }
 
 int32_t main() {
-  ttnn::Tensor v1;
-  ttnn::Tensor v2;
-  std::tie(v1, v2) = createInputsFor_add();
-  ttnn::Tensor v3 = add(v1, v2);
+  ::ttnn::Tensor v1;
+  ::ttnn::Tensor v2;
+  std::tie(v1, v2) = create_inputs_for_add();
+  ::ttnn::Tensor v3 = add(v1, v2);
   int32_t v4 = 0;
   return v4;
 }


### PR DESCRIPTION
### Ticket
N/A

### Problem description
As @vvukomanTT was adding CI test for ttnn-standalone, he realized the default example broke on main with a recent metal uplift.

### What's changed
Remove `IDevice*` in favor of `MeshDevice*` and regenerate the example C++.

### Checklist
- [ ] New/Existing tests provide coverage for changes
