### PR TITLE
Adjust empty and single sdy mesh shape

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/ShardingUtils.cpp
+++ b/lib/Conversion/StableHLOToTTIR/ShardingUtils.cpp
@@ -358,6 +358,12 @@ llvm::Expected<bool> MeshSharding::convertSdyShardingToMeshSharding(
     sdy::TensorShardingAttr sdySharding, sdy::MeshAttr meshAttr,
     tt::MeshShardDirection direction) {
 
+  // Empty meshAttr indicates single device, so no need to convert.
+  if (meshAttr.empty()) {
+    meshShape.clear();
+    return true;
+  }
+
   shardDirection = direction;
   meshName = sdySharding.getMeshName();
 
@@ -427,6 +433,12 @@ bool MeshSharding::checkAndUpdateShardyRetSharding(
 // Get TensorMeshShardingAttr given MeshSharding info.
 mlir::tt::TensorMeshShardingAttr
 MeshSharding::getTensorMeshShardingAttr(mlir::PatternRewriter &rewriter) {
+  // Empty meshShape indicates single device, so no TensorMeshShardingAttr needs
+  // to be created.
+  if (meshShape.empty()) {
+    return nullptr;
+  }
+
   MLIRContext *context = rewriter.getContext();
   auto meshNameStrAttr = mlir::StringAttr::get(context, meshName);
   llvm::SmallVector<llvm::SmallVector<int64_t>> tensorAxes(

--- a/lib/Conversion/StableHLOToTTIR/ShardyToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/ShardyToTTIRPatterns.cpp
@@ -197,7 +197,9 @@ public:
     // ManualComputationOp include one mesh for all in/out shardings, so we can
     // pick up first sharding and get mesh info.
     mlir::sdy::TensorShardingAttr firstSharding = *shardings.begin();
-    mlir::sdy::MeshAttr targetMesh = firstSharding.getMesh(symbolTable);
+    mlir::sdy::MeshAttr targetMesh =
+        mlir::tt::sharding_utils::adjustSdyMeshAttr(
+            srcOp, firstSharding.getMesh(symbolTable));
     if (!targetMesh) {
       llvm_unreachable(
           "mlir::sdy::TensorShardingAttr requires mesh definition.");
@@ -348,16 +350,16 @@ public:
     }
 
     mlir::StringAttr meshName = srcOp.getSymNameAttr();
-    llvm::SmallVector<int64_t> meshShape;
-    mlir::sdy::MeshAttr sdyMesh = srcOp.getMesh();
-    for (auto meshAxisAttr : sdyMesh.getAxes()) {
-      meshShape.push_back(meshAxisAttr.getSize());
+    mlir::sdy::MeshAttr sdyMesh =
+        mlir::tt::sharding_utils::adjustSdyMeshAttr(srcOp, srcOp.getMesh());
+    if (!sdyMesh.empty()) {
+      llvm::SmallVector<int64_t> meshShape;
+      for (auto meshAxisAttr : sdyMesh.getAxes()) {
+        meshShape.push_back(meshAxisAttr.getSize());
+      }
+      mlir::tt::utils::addMeshToModuleAttribute(rewriter, module, meshName,
+                                                meshShape);
     }
-    if (meshShape.size() < 2) {
-      llvm_unreachable("1d hardware mesh is not supported.");
-    }
-    mlir::tt::utils::addMeshToModuleAttribute(rewriter, module, meshName,
-                                              meshShape);
 
     // Before erasing MeshOp, visit public functions and properly handle
     // argument and return sharding attributes that are not used or defined by


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/3130

### Problem description
Current code restrict sdy mesh to be size of 2d, which may hurt user experience of using JAX with our hardware.

### What's changed
This patch allows sdy mesh to be either empty or 1d.

