### PR TITLE
Add finish barrier after any enqueue_buffer_read ops to ensure sync

### DIFF
--- a/include/ttmlir/Dialect/TTMetal/IR/TTMetalOps.td
+++ b/include/ttmlir/Dialect/TTMetal/IR/TTMetalOps.td
@@ -73,4 +73,11 @@ def TTMetal_DeallocateBufferOp : TTMetal_Op<"deallocate_buffer", [MemoryEffects<
     let arguments = (ins AnyNon0RankedMemRef:$input);
 }
 
+def TTMetal_FinishOp : TTMetal_Op<"finish", [MemoryEffects<[MemRead, MemWrite]>]> {
+    let summary = "Finish op for command queue.";
+    let description = [{
+      Global barrier op, used to wait for all commands on queue to finish.
+    }];
+}
+
 #endif

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
@@ -162,6 +162,9 @@ public:
     if (inputMemorySpace) {
       rewriter.replaceOpWithNewOp<ttmetal::EnqueueReadBufferOp>(op, input,
                                                                 output);
+      // Insert global barrier to ensure the read completes before subsequent
+      // ops use it.
+      rewriter.create<ttmetal::FinishOp>(op->getLoc());
     } else {
       rewriter.replaceOpWithNewOp<ttmetal::EnqueueWriteBufferOp>(op, input,
                                                                  output);

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -531,6 +531,15 @@ static std::shared_ptr<void> translateModuleToFlatbuffer(
         cqBuilder.appendCommand(
             target::metal::CreateReturnCommandDirect(fbb, &cqBuilder.outputs),
             op);
+      } else if (auto finishOp = dyn_cast_if_present<tt::ttmetal::FinishOp>(op);
+                 finishOp) {
+        cqBuilder.appendCommand(target::metal::CreateFinishCommand(fbb), op);
+      } else if (auto funcOp = dyn_cast_if_present<func::FuncOp>(op); funcOp) {
+        // Unqualified walk will visit the root op itself last, we should ignore
+        // this.
+        return;
+      } else {
+        llvm_unreachable("Encountered unsupported op.");
       }
     });
 

--- a/test/ttmlir/Silicon/TTMetal/n150/simple_add.mlir
+++ b/test/ttmlir/Silicon/TTMetal/n150/simple_add.mlir
@@ -7,5 +7,7 @@ func.func @add(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<6
   %0 = ttir.empty() : tensor<64x128xf32>
   // CHECK: "ttmetal.enqueue_program"
   %1 = "ttir.add"(%arg0, %arg1, %0) : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+  // CHECK: "ttmetal.enqueue_read_buffer"
+  // CHECK: "ttmetal.finish"
   return %1 : tensor<64x128xf32>
 }


### PR DESCRIPTION
### Ticket
NA

### Problem description
When transferring a buffer from device to host, we ought to barrier to ensure queued commands complete before moving the data.

### What's changed
Whenever we generate an enqueue_buffer_read op, we also enqueue a finish op to barrier right afterwards.  In the future, we should insert a targeted wait op instead and only await whichever ops we strictly depend on, but this seems like an easy first step.

### Checklist
- [x] New/Existing tests provide coverage for changes
