### PR TITLE
Add gdb support to ttrt

### DIFF
--- a/docs/src/ttrt.md
+++ b/docs/src/ttrt.md
@@ -249,6 +249,15 @@ ttrt check --save-artifacts --artifact-dir /path/to/some/dir out.ttnn
 ttrt check out.ttnn --result-file result.json
 ```
 
+### gdb
+You can relaunch `ttrt` inside of gdb which can be useful for debugging C++
+runtime components.
+
+```bash
+ttrt --gdb run ...
+ttrt --gdb perf ...
+```
+
 ## ttrt as a python package
 
 The other way to use the APIs under ttrt is importing it as a library. This allows the user to use it in custom scripts.

--- a/runtime/tools/ttrt/ttrt/__init__.py
+++ b/runtime/tools/ttrt/ttrt/__init__.py
@@ -13,12 +13,22 @@ import ttrt.library_tweaks
 ttrt.library_tweaks.set_tt_metal_home()
 
 import ttrt.binary
+import sys
+import os
 from ttrt.common.api import API
 from importlib.metadata import version
 
 
+def relaunch_as_gdb(args):
+    args = [arg for arg in args if arg != "--gdb"]
+    os.execvp("gdb", ["gdb", "-ex", "run", "--args", sys.executable] + args)
+
+
 def main():
     import argparse
+
+    if "--gdb" in sys.argv:
+        relaunch_as_gdb(sys.argv)
 
     parser = argparse.ArgumentParser(
         description="ttrt: a runtime tool for parsing and executing flatbuffer binaries"
@@ -26,6 +36,7 @@ def main():
     parser.add_argument(
         "-V", "--version", action="version", version=f"ttrt {version('ttrt')}"
     )
+    parser.add_argument("--gdb", action="store_true", help="launch ttrt with gdb")
     subparsers = parser.add_subparsers(required=True)
 
     API.initialize_apis()


### PR DESCRIPTION
Relaunch ttrt inside of gdb automatically with:
```
ttrt --gdb run ...
```