### PR TITLE
Update TensorDesc APIs to int64_t, move dylib out of detail, compare storage in debug mode

### DIFF
--- a/runtime/include/tt/runtime/detail/test/ttnn/utils.h
+++ b/runtime/include/tt/runtime/detail/test/ttnn/utils.h
@@ -2,17 +2,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef TT_RUNTIME_DETAIL_TTNN_TEST_UTILS_H
-#define TT_RUNTIME_DETAIL_TTNN_TEST_UTILS_H
+#ifndef TT_RUNTIME_DETAIL_TEST_TTNN_UTILS_H
+#define TT_RUNTIME_DETAIL_TEST_TTNN_UTILS_H
 
 #include "tt/runtime/types.h"
 
 // Utility functions for testing TTNN runtime
-namespace tt::runtime::ttnn::test {
+namespace tt::runtime::test::ttnn {
 Layout getDramInterleavedTileLayout(::tt::target::DataType dataType);
 Layout getDramInterleavedRowMajorLayout(::tt::target::DataType dataType);
 Layout getHostRowMajorLayout(::tt::target::DataType dataType);
 bool isProgramCacheEnabled(::tt::runtime::Device device);
-} // namespace tt::runtime::ttnn::test
+} // namespace tt::runtime::test::ttnn
 
-#endif // TT_RUNTIME_DETAIL_TTNN_TEST_UTILS_H
+#endif // TT_RUNTIME_DETAIL_TEST_TTNN_UTILS_H

--- a/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
@@ -26,8 +26,8 @@ Tensor createBorrowedHostTensor(std::shared_ptr<void> data,
                                 const TensorDesc &desc);
 
 inline Tensor createOwnedHostTensor(const void *data, const TensorDesc &desc) {
-  std::shared_ptr<void> owned = utils::malloc_shared(desc.size());
-  std::memcpy(owned.get(), data, desc.size());
+  std::shared_ptr<void> owned = utils::malloc_shared(desc.sizeBytes());
+  std::memcpy(owned.get(), data, desc.sizeBytes());
   return ttmetal::createBorrowedHostTensor(owned, desc);
 }
 

--- a/runtime/include/tt/runtime/detail/ttnn/debug_apis.h
+++ b/runtime/include/tt/runtime/detail/ttnn/debug_apis.h
@@ -7,6 +7,7 @@
 
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn/ttnn.h"
+#include "tt/runtime/utils.h"
 #include "ttmlir/Target/TTNN/Target.h"
 
 #if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
@@ -60,6 +61,22 @@ inline std::string toString(const ::ttnn::StorageType &storageType) {
   case ::ttnn::StorageType::MULTI_DEVICE_HOST:
     return "MULTI_DEVICE_HOST";
   }
+}
+
+inline std::string toString(const ::tt::tt_metal::Storage &storage) {
+  return std::visit(
+      ::tt::runtime::utils::overloaded{
+          [](const ::tt::tt_metal::HostStorage &) -> std::string {
+            return "HOST";
+          },
+          [](const ::tt::tt_metal::DeviceStorage &) -> std::string {
+            return "DEVICE";
+          },
+          [](const ::tt::tt_metal::MultiDeviceHostStorage &) -> std::string {
+            return "MULTI_DEVICE_HOST";
+          },
+      },
+      storage);
 }
 
 RUNTIME_DEBUG_MAYBE_INLINE void

--- a/runtime/include/tt/runtime/detail/ttnn/program_executor.h
+++ b/runtime/include/tt/runtime/detail/ttnn/program_executor.h
@@ -25,8 +25,7 @@ class ProgramContext; // Forward declaration
 class ProgramExecutor {
 public:
   // Constructor for executing a program
-  ProgramExecutor(const ::tt::target::ttnn::Program *program,
-                  const Binary &executableHandle,
+  ProgramExecutor(const Binary &executableHandle,
                   std::vector<::tt::runtime::Tensor> &programInputs,
                   std::shared_ptr<::ttnn::MeshDevice> meshDevice,
                   const size_t programIndex = 0);

--- a/runtime/include/tt/runtime/test/ttnn/dylib.h
+++ b/runtime/include/tt/runtime/test/ttnn/dylib.h
@@ -2,18 +2,18 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef TT_RUNTIME_DETAIL_TTNN_TEST_DYLIB_H
-#define TT_RUNTIME_DETAIL_TTNN_TEST_DYLIB_H
+#ifndef TT_RUNTIME_TEST_TTNN_DYLIB_H
+#define TT_RUNTIME_TEST_TTNN_DYLIB_H
 
 #include "tt/runtime/types.h"
 
-namespace tt::runtime::ttnn::test {
+namespace tt::runtime::test::ttnn {
 
 void *openSo(std::string path);
 void closeSo(void *handle);
 std::vector<Tensor> runSoProgram(void *so, std::string func_name,
                                  std::vector<Tensor> inputs, Device device);
 bool compareOuts(std::vector<Tensor> &lhs, std::vector<Tensor> &rhs);
-} // namespace tt::runtime::ttnn::test
+} // namespace tt::runtime::test::ttnn
 
-#endif // TT_RUNTIME_DETAIL_TTNN_TEST_DYLIB_H
+#endif // TT_RUNTIME_TEST_TTNN_DYLIB_H

--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -113,12 +113,11 @@ struct TensorDesc {
              ::tt::target::DataType dataType)
       : shape(shape), stride(stride), itemsize(itemsize), dataType(dataType) {}
 
-  std::uint32_t size() const { return shape[0] * stride[0] * itemsize; }
-  std::size_t volume() const {
-    return std::accumulate(shape.begin(), shape.end(),
-                           static_cast<std::size_t>(1),
-                           std::multiplies<std::size_t>());
+  std::int64_t volume() const {
+    return std::accumulate(shape.begin(), shape.end(), static_cast<int64_t>(1),
+                           std::multiplies<int64_t>());
   }
+  std::int64_t sizeBytes() const { return volume() * itemsize; }
 };
 
 struct MemoryView {

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -265,7 +265,7 @@ void memcpy(void *dst, Tensor src) {
   LOG_ASSERT(std::holds_alternative<TensorDesc>(metalSrc),
              "Only TensorDesc supported for now");
   const auto &hostSrc = std::get<TensorDesc>(metalSrc);
-  std::memcpy(dst, src.data.get(), hostSrc.size());
+  std::memcpy(dst, src.data.get(), hostSrc.sizeBytes());
 }
 
 void memcpy(Tensor dst, Tensor src) {
@@ -277,7 +277,8 @@ void memcpy(Tensor dst, Tensor src) {
              "Only TensorDesc supported for now");
   auto &hostDst = std::get<TensorDesc>(metalDst);
   const auto &hostSrc = std::get<TensorDesc>(metalSrc);
-  LOG_ASSERT(hostDst.size() == hostSrc.size(), "Tensor size mismatch");
+  LOG_ASSERT(hostDst.sizeBytes() == hostSrc.sizeBytes(),
+             "Tensor size mismatch");
   LOG_ASSERT(hostDst.dataType == hostSrc.dataType, "Tensor data type mismatch");
   return ::tt::runtime::ttmetal::memcpy(dst.data.get(), src);
 }
@@ -353,7 +354,7 @@ std::vector<std::byte> getTensorDataBuffer(Tensor tensor) {
             const std::byte *data =
                 static_cast<const std::byte *>(tensor.data.get());
             assert(data);
-            return std::vector<std::byte>(data, data + desc.size());
+            return std::vector<std::byte>(data, data + desc.sizeBytes());
           },
           [&](const DeviceBuffer &buffer) {
             LOG_FATAL("getTensorDataBuffer from DeviceBuffer not supported.");

--- a/runtime/lib/ttnn/operations/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/CMakeLists.txt
@@ -4,46 +4,46 @@ if (NOT TTNN_RUNTIME_ENABLED)
 endif()
 
 set(TTNN_OPS_SRCS
-  ${CMAKE_CURRENT_SOURCE_DIR}/utils/utils.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cache/load_cached.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ccl/all_gather.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/ccl/reduce_scatter.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ccl/collective_permute.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ccl/mesh_shard.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/conv/prepare_conv2d_weights.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ccl/reduce_scatter.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/context/get_device.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/conv/conv2d.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/conv/conv_transpose2d.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/conv/prepare_conv2d_weights.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/cpu/cpu.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/creation/arange.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/creation/constant.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/conv/conv_transpose2d.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/creation/empty.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/creation/full_with.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/creation/full.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/cpu/cpu.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/creation/full_with.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/data_movement/concat.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/data_movement/pad.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/data_movement/permute.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/data_movement/reshape.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/data_movement/repeat.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/data_movement/repeat_interleave.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/data_movement/reshape.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/data_movement/slice.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/data_movement/transpose.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/data_movement/pad.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/deletion/deallocate.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/eltwise/binary/binary.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/eltwise/binary/binary_composite.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/eltwise/quantization/quantization.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/eltwise/ternary/where.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/eltwise/unary/unary.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/eltwise/unary/unary_composite.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/eltwise/ternary/where.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/eltwise/quantization/quantization.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/embedding/embedding.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/embedding/embedding_backward.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/kv_cache/fill_cache.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/kv_cache/update_cache.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/embedding/embedding_backward.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/layout/to_device.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/layout/from_device.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/layout/to_layout.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/layout/to_device.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/layout/to_dtype.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/layout/typecast.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/layout/to_layout.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/layout/to_memory_config.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/layout/typecast.cpp
   # ANCHOR: adding_an_op_matmul_runtime_cmake
   ${CMAKE_CURRENT_SOURCE_DIR}/matmul/matmul.cpp
   # ANCHOR_END: adding_an_op_matmul_runtime_cmake
@@ -54,7 +54,7 @@ set(TTNN_OPS_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/reduction/argmax.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/reduction/prod.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/reduction/reduction.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/context/get_device.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/utils/utils.cpp
 )
 
 add_library(TTRuntimeTTNNOps

--- a/runtime/lib/ttnn/operations/cache/load_cached.cpp
+++ b/runtime/lib/ttnn/operations/cache/load_cached.cpp
@@ -66,11 +66,7 @@ void run(const ::tt::target::ttnn::LoadCachedOp *op, ProgramContext &context) {
 
   // Execute the function
   const size_t programIndex = op->program_idx();
-  const ::tt::target::ttnn::TTNNBinary &fbb =
-      *::tt::runtime::ttnn::utils::getBinary(context.getExecutableHandle());
-  const ::tt::target::ttnn::Program *subProgram =
-      fbb.programs()->Get(programIndex);
-  ProgramExecutor exec(subProgram, context.getExecutableHandle(), inputs,
+  ProgramExecutor exec(context.getExecutableHandle(), inputs,
                        context.getMeshDevicePtr(), programIndex);
   exec.execute();
   LOG_DEBUG("executed sub-func: ", constEvalFuncname);

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -70,11 +70,21 @@ static void tracyLogOpLocation(const ::tt::target::ttnn::Operation *op) {
 #endif
 }
 
+static const ::tt::target::ttnn::Program *
+getProgram(const Binary &executableHandle, std::uint32_t programIndex) {
+  const ::tt::target::ttnn::TTNNBinary &fbb =
+      *utils::getBinary(executableHandle);
+  const ::tt::target::ttnn::Program *program =
+      fbb.programs()->Get(programIndex);
+  return program;
+}
+
 ProgramExecutor::ProgramExecutor(
-    const ::tt::target::ttnn::Program *program, const Binary &executableHandle,
+    const Binary &executableHandle,
     std::vector<::tt::runtime::Tensor> &programInputs,
     std::shared_ptr<::ttnn::MeshDevice> meshDevice, const size_t programIndex)
-    : program(program), executableHandle(executableHandle) {
+    : program(getProgram(executableHandle, programIndex)),
+      executableHandle(executableHandle) {
   LOG_ASSERT(program, "Program must be provided for execution");
 
   std::vector<uint32_t> programInputIds;

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -873,12 +873,8 @@ std::vector<Tensor> runProgram(std::shared_ptr<::ttnn::MeshDevice> meshDevice,
                                Binary executableHandle,
                                std::uint32_t programIndex,
                                std::vector<::tt::runtime::Tensor> &inputs) {
-  const ::tt::target::ttnn::TTNNBinary &fbb =
-      *utils::getBinary(executableHandle);
-  const ::tt::target::ttnn::Program *program =
-      fbb.programs()->Get(programIndex);
-  ProgramExecutor executor(program, executableHandle, inputs,
-                           std::move(meshDevice), programIndex);
+  ProgramExecutor executor(executableHandle, inputs, std::move(meshDevice),
+                           programIndex);
   executor.execute();
   std::vector<::tt::runtime::Tensor> outputTensors =
       executor.gatherOutputTensors();

--- a/runtime/lib/ttnn/utils/utils.cpp
+++ b/runtime/lib/ttnn/utils/utils.cpp
@@ -2,11 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "tt/runtime/detail/ttnn/utils.h"
+#include "tt/runtime/utils.h"
 #include "tt/runtime/detail/common.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn/debug_apis.h"
 #include "tt/runtime/detail/ttnn/types.h"
+#include "tt/runtime/detail/ttnn/utils.h"
 #include "tt/runtime/workarounds.h"
 
 namespace tt::runtime::ttnn::utils {
@@ -274,22 +275,20 @@ void *getRawHostDataPtr(const ::ttnn::Tensor &tensor) {
       workaround::Env::get().rawHostDataPointerWrapper,
       "rawHostDataPointerWrapper workaround must be enabled to use this API");
   void *dataPtr = std::visit(
-      [&tensor](auto &&storage) -> void * {
-        using T = std::decay_t<decltype(storage)>;
-        if constexpr (std::is_same_v<T, ::tt::tt_metal::HostStorage>) {
-          ::tt::tt_metal::HostBuffer hostBuffer = storage.buffer;
-          return static_cast<void *>(hostBuffer.view_bytes().data());
-        } else if constexpr (std::is_same_v<
-                                 T, ::tt::tt_metal::MultiDeviceHostStorage>) {
-          LOG_ASSERT(storage.num_buffers() == 1);
-          ::tt::tt_metal::HostBuffer hostBuffer = storage.get_buffer(0);
-          return static_cast<void *>(hostBuffer.view_bytes().data());
-        } else {
-          LOG_FATAL("Unsupported storage type ",
-                    debug::toString(tensor.storage_type()));
-          return nullptr;
-        }
-      },
+      ::tt::runtime::utils::overloaded{
+          [&](const ::tt::tt_metal::HostStorage &storage) -> void * {
+            ::tt::tt_metal::HostBuffer hostBuffer = storage.buffer;
+            return static_cast<void *>(hostBuffer.view_bytes().data());
+          },
+          [&](const ::tt::tt_metal::MultiDeviceHostStorage &storage) -> void * {
+            LOG_ASSERT(storage.num_buffers() == 1);
+            ::tt::tt_metal::HostBuffer hostBuffer = storage.get_buffer(0);
+            return static_cast<void *>(hostBuffer.view_bytes().data());
+          },
+          [](auto &&storage) -> void * {
+            LOG_FATAL("Unsupported storage type ", debug::toString(storage));
+            return nullptr;
+          }},
       tensor.get_storage());
   return dataPtr;
 }

--- a/runtime/test/ttnn/CMakeLists.txt
+++ b/runtime/test/ttnn/CMakeLists.txt
@@ -18,10 +18,10 @@ target_include_directories(TTRuntimeTTNNTestLib SYSTEM PUBLIC "$<BUILD_INTERFACE
 add_dependencies(TTRuntimeTTNNTestLib TTRuntimeTTNNUtils FBS_GENERATION)
 target_link_libraries(TTRuntimeTTNNTestLib PUBLIC TTRuntimeTTNNUtils)
 
-set(TTMLIR_RUNTIME_TEST_PUBLIC_HEADERS
-  "${PROJECT_SOURCE_DIR}/runtime/include/tt/runtime/detail/ttnn/test/dylib.h"
+set(TTMLIR_RUNTIME_TEST_TTNN_PUBLIC_HEADERS
+  "${PROJECT_SOURCE_DIR}/runtime/include/tt/runtime/test/ttnn/dylib.h"
 )
-set_target_properties(TTRuntimeTTNNTestLib PROPERTIES PUBLIC_HEADER "${TTMLIR_RUNTIME_TEST_PUBLIC_HEADERS}")
+set_target_properties(TTRuntimeTTNNTestLib PROPERTIES PUBLIC_HEADER "${TTMLIR_RUNTIME_TEST_TTNN_PUBLIC_HEADERS}")
 install(TARGETS TTRuntimeTTNNTestLib
   PUBLIC_HEADER
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tt/runtime/test

--- a/runtime/test/ttnn/utils.cpp
+++ b/runtime/test/ttnn/utils.cpp
@@ -2,14 +2,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "tt/runtime/detail/ttnn/test/utils.h"
+#include "tt/runtime/detail/test/ttnn/utils.h"
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn/types.h"
 #include "tt/runtime/detail/ttnn/utils.h"
 #include "tt/runtime/runtime.h"
 #include "tt/runtime/types.h"
 
-namespace tt::runtime::ttnn::test {
+namespace tt::runtime::test::ttnn {
 using ::tt::runtime::DeviceRuntime;
 Layout getDramInterleavedTileLayout(::tt::target::DataType dataType) {
   LOG_ASSERT(getCurrentRuntime() == DeviceRuntime::TTNN);
@@ -54,4 +54,4 @@ bool isProgramCacheEnabled(::tt::runtime::Device device) {
       device.as<::ttnn::MeshDevice>(DeviceRuntime::TTNN);
   return meshDevice.get_program_cache().is_enabled();
 }
-} // namespace tt::runtime::ttnn::test
+} // namespace tt::runtime::test::ttnn

--- a/runtime/tools/ttrt/ttrt/runtime/module.cpp
+++ b/runtime/tools/ttrt/ttrt/runtime/module.cpp
@@ -9,8 +9,8 @@
 #include "tt/runtime/utils.h"
 #include "tt/runtime/workarounds.h"
 #if defined(TTMLIR_ENABLE_RUNTIME_TESTS) && TTMLIR_ENABLE_RUNTIME_TESTS == 1
-#include "tt/runtime/detail/ttnn/test/dylib.h"
-#include "tt/runtime/detail/ttnn/test/utils.h"
+#include "tt/runtime/detail/test/ttnn/utils.h"
+#include "tt/runtime/test/ttnn/dylib.h"
 #endif
 
 #include <pybind11/functional.h>
@@ -340,25 +340,25 @@ PYBIND11_MODULE(_C, m) {
 #if defined(TTMLIR_ENABLE_RUNTIME_TESTS) && TTMLIR_ENABLE_RUNTIME_TESTS == 1
   auto testing = m.def_submodule("testing");
   testing.def("get_dram_interleaved_tile_layout",
-              &tt::runtime::ttnn::test::getDramInterleavedTileLayout,
+              &tt::runtime::test::ttnn::getDramInterleavedTileLayout,
               py::arg("dtype"), "Get dram interleaved tile layout");
   testing.def("get_dram_interleaved_row_major_layout",
-              &tt::runtime::ttnn::test::getDramInterleavedRowMajorLayout,
+              &tt::runtime::test::ttnn::getDramInterleavedRowMajorLayout,
               py::arg("dtype"), "Get dram interleaved row major layout");
   testing.def("get_host_row_major_layout",
-              &tt::runtime::ttnn::test::getHostRowMajorLayout, py::arg("dtype"),
+              &tt::runtime::test::ttnn::getHostRowMajorLayout, py::arg("dtype"),
               "Get host row major layout");
   testing.def("is_program_cache_enabled",
-              &tt::runtime::ttnn::test::isProgramCacheEnabled,
+              &tt::runtime::test::ttnn::isProgramCacheEnabled,
               py::arg("device"), "Check if program cache is enabled");
-  testing.def("open_so", &tt::runtime::ttnn::test::openSo, py::arg("path"),
+  testing.def("open_so", &tt::runtime::test::ttnn::openSo, py::arg("path"),
               "Open a shared object");
-  testing.def("close_so", &tt::runtime::ttnn::test::closeSo, py::arg("handle"),
+  testing.def("close_so", &tt::runtime::test::ttnn::closeSo, py::arg("handle"),
               "Close a shared object");
-  testing.def("run_so_program", &tt::runtime::ttnn::test::runSoProgram,
+  testing.def("run_so_program", &tt::runtime::test::ttnn::runSoProgram,
               py::arg("so"), py::arg("func_name"), py::arg("inputs"),
               py::arg("device"), "Run a program from a shared object file");
-  testing.def("compare_outs", &tt::runtime::ttnn::test::compareOuts,
+  testing.def("compare_outs", &tt::runtime::test::ttnn::compareOuts,
               py::arg("lhs"), py::arg("rhs"));
 #endif
 

--- a/test/ttmlir/EmitC/TTNN/conv/conv2d_with_prepare_conv2d_weights.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/conv2d_with_prepare_conv2d_weights.mlir
@@ -7,7 +7,7 @@
 #system_memory = #ttnn.buffer_type<system_memory>
 #ttnn_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 32 + d2, d3), <1x1>, memref<32x2x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
 #ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 48 + d1 * 3 + d2, d3), <1x1>, memref<3072x3xbf16, #system_memory>>
-#ttnn_layout2 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 576 + d1 * 576 + d2, d3), <1x1>, memref<18x2x!tt.tile<32x32, bf16>, #system_memory>>
+#ttnn_layout2 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 576 + d1 * 576 + d2, d3), <1x1>, memref<18x2x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
 #ttnn_layout3 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1 * 32 + d2, d3), <1x1>, memref<1x2x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
 #ttnn_layout4 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 256 + d1 * 32 + d2, d3), <1x1>, memref<8x2x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
 #ttnn_layout5 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 1024 + d2, d3), <1x1>, memref<32x2x!tt.tile<32x32, bf16>, #dram>, <interleaved>>

--- a/test/ttmlir/EmitC/TTNN/conv/prepare_conv2d_weights.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/prepare_conv2d_weights.mlir
@@ -6,7 +6,7 @@
 #dram = #ttnn.buffer_type<dram>
 #system_memory = #ttnn.buffer_type<system_memory>
 #ttnn_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 192 + d1 * 3 + d2, d3), <1x1>, memref<12288x3xbf16, #system_memory>>
-#ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 576 + d1 * 576 + d2, d3), <1x1>, memref<18x2x!tt.tile<32x32, bf16>, #system_memory>>
+#ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 576 + d1 * 576 + d2, d3), <1x1>, memref<18x2x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
 
 func.func @prepare_conv2d_weights(%arg0: tensor<64x64x3x3xbf16, #ttnn_layout>) -> tensor<1x1x576x64xbf16, #ttnn_layout1> {
   %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device

--- a/test/ttmlir/Silicon/TTNN/n150/conv/prepare_conv2d_weights/simple_prepare_conv2d_weights.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/conv/prepare_conv2d_weights/simple_prepare_conv2d_weights.mlir
@@ -4,7 +4,7 @@
 #dram = #ttnn.buffer_type<dram>
 #system_memory = #ttnn.buffer_type<system_memory>
 #ttnn_layout = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 192 + d1 * 3 + d2, d3), <1x1>, memref<12288x3xbf16, #system_memory>>
-#ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 576 + d1 * 576 + d2, d3), <1x1>, memref<18x2x!tt.tile<32x32, bf16>, #system_memory>>
+#ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 576 + d1 * 576 + d2, d3), <1x1>, memref<18x2x!tt.tile<32x32, bf16>, #dram>, <interleaved>>
 
 module {
   func.func @prepare_conv2d_weights(%arg0: tensor<64x64x3x3xbf16, #ttnn_layout>) -> tensor<1x1x576x64xbf16, #ttnn_layout1> {


### PR DESCRIPTION
### Ticket
Closes #3247 
Closes #3254 

### Problem description
* `detail/test/ttnn/dylib.h` is now a public emitC header thus moving it out of detail
* TensorDesc `volume` and `size` APIs should use int64_t to prevent overflow and also be compatible with torch data types. 
  * I didn't update the member variable data types because that would cause inconsistency with runtime APIs as well as TTNN APIs (TTNN uses uint32_t for shape, stride etc.)
* We weren't comparing expected vs actual tensor location in runtime debug mode.

  
### What's changed
* Renamed `detail/test/ttnn/dylib.h` as `test/ttnn/dylib.h`
* Updated tensor descriptor API return types
* Added storage comparison when running in runtime debug mode. 
  * Updated prepare_conv2d_weights tests because the output tensor location was set incorrectly in the tests.

Misc
* Renamed `TensorDesc.size()` to `TensorDesc.sizeBytes()` for better clarity
* Updated `std::visit` to use the overloaded visitor pattern

I'll create a nightly uplift job on the FEs and update as needed once this lands.

