### PR TITLE
Add D2M codeowners for TTIRToTTKernel conversions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -61,6 +61,9 @@ LICENSE @nsmithtt
 /lib/Conversion/TTIRToTTMetal/ @tenstorrent/forge-developers-mlir-d2m
 /lib/Conversion/TTKernelToEmitC/ @tenstorrent/forge-developers-mlir-d2m
 /test/ttmlir/Conversion/TTKernelToEmitC/ @tenstorrent/forge-developers-mlir-d2m
+/include/ttmlir/Conversion/TTIRToTTKernel/ @tenstorrent/forge-developers-mlir-d2m
+/lib/Conversion/TTIRToTTKernel/ @tenstorrent/forge-developers-mlir-d2m
+/test/ttmlir/Conversion/TTIRToTTKernel/ @tenstorrent/forge-developers-mlir-d2m
 
 # LLVM Dialect
 /include/ttmlir/Dialect/LLVM/ @vwellsTT @mtopalovicTT


### PR DESCRIPTION
### Problem description
TTIRToTTKernel path files are missing codeowners

### What's changed
Add the d2m team to own these files. 

