### PR TITLE
Extending ttrt.binary pybinding into ttrt.runtime pybinding for callback function consistency

### DIFF
--- a/runtime/tools/ttrt/ttrt/common/callback.py
+++ b/runtime/tools/ttrt/ttrt/common/callback.py
@@ -114,7 +114,6 @@ class CallbackRuntimeConfig:
 def golden(callback_runtime_config, binary, program_context, op_context):
     import torch
     import ttrt.runtime
-    import ttrt.binary
 
     logging = callback_runtime_config.logging
     logging.debug("executing golden comparison")
@@ -213,7 +212,6 @@ def create_memory_dictionary(memory_view):
 
 def memory(callback_runtime_config, binary, program_context, op_context):
     import ttrt.runtime
-    import ttrt.binary
 
     device = callback_runtime_config.device
     logging = callback_runtime_config.logging
@@ -270,7 +268,6 @@ def memory(callback_runtime_config, binary, program_context, op_context):
 def debugger(callback_runtime_config, binary, program_context, op_context):
     import pdb
     import ttrt.runtime
-    import ttrt.binary
 
     device = callback_runtime_config.device
     logging = callback_runtime_config.logging

--- a/runtime/tools/ttrt/ttrt/common/read.py
+++ b/runtime/tools/ttrt/ttrt/common/read.py
@@ -17,7 +17,7 @@ import shutil
 import atexit
 
 from ttrt.common.util import *
-import ttrt.binary
+import ttrt.runtime
 
 
 class Read:
@@ -421,12 +421,12 @@ class Read:
 
     def system_desc(self, *binaries):
         return self._operate_on_binary(
-            binaries, lambda binary: ttrt.binary.as_dict(binary.fbb)["system_desc"]
+            binaries, lambda binary: ttrt.runtime.as_dict(binary.fbb)["system_desc"]
         )
 
     def mlir(self, *binaries):
         def _get_mlir(binary):
-            bin_dict = ttrt.binary.as_dict(binary.fbb)
+            bin_dict = ttrt.runtime.as_dict(binary.fbb)
             results = []
             for program in bin_dict["programs"]:
                 if "debug_info" not in program:
@@ -447,7 +447,7 @@ class Read:
 
     def cpp(self, *binaries):
         def _get_cpp(binary):
-            bin_dict = ttrt.binary.as_dict(binary.fbb)
+            bin_dict = ttrt.runtime.as_dict(binary.fbb)
             results = []
             for program in bin_dict["programs"]:
                 if "debug_info" not in program:
@@ -465,7 +465,7 @@ class Read:
             binaries,
             lambda binary: [
                 {program["name"]: program["inputs"]}
-                for program in ttrt.binary.as_dict(binary.fbb)["programs"]
+                for program in ttrt.runtime.as_dict(binary.fbb)["programs"]
             ],
         )
 
@@ -474,13 +474,13 @@ class Read:
             binaries,
             lambda binary: [
                 {program["name"]: program["outputs"]}
-                for program in ttrt.binary.as_dict(binary.fbb)["programs"]
+                for program in ttrt.runtime.as_dict(binary.fbb)["programs"]
             ],
         )
 
     def op_stats(self, *binaries):
         return self._operate_on_binary(
-            binaries, lambda binary: ttrt.binary.stats.collect_op_stats(binary.fbb)
+            binaries, lambda binary: ttrt.runtime.stats.collect_op_stats(binary.fbb)
         )
 
     @staticmethod

--- a/runtime/tools/ttrt/ttrt/common/util.py
+++ b/runtime/tools/ttrt/ttrt/common/util.py
@@ -595,8 +595,6 @@ class Flatbuffer:
     ttsys_file_extension = ".ttsys"
 
     def __init__(self, logger, file_manager, file_path, capsule=None):
-        import ttrt.binary
-
         self.logger = logger
         self.logging = self.logger.get_logger()
         self.file_manager = file_manager
@@ -641,13 +639,13 @@ class Binary(Flatbuffer):
         super().__init__(logger, file_manager, file_path, capsule=capsule)
 
         import torch
-        import ttrt.binary
+        import ttrt.runtime
 
         if not capsule:
-            self.fbb = ttrt.binary.load_binary_from_path(file_path)
+            self.fbb = ttrt.runtime.load_binary_from_path(file_path)
         else:
-            self.fbb = ttrt.binary.load_binary_from_capsule(capsule)
-        self.fbb_dict = ttrt.binary.as_dict(self.fbb)
+            self.fbb = ttrt.runtime.load_binary_from_capsule(capsule)
+        self.fbb_dict = ttrt.runtime.as_dict(self.fbb)
         self.version = self.fbb.version
         self.programs = []
 
@@ -656,8 +654,6 @@ class Binary(Flatbuffer):
             self.programs.append(program)
 
     def check_system_desc(self, query):
-        import ttrt.binary
-
         try:
             fbb_system_desc = self.fbb_dict["system_desc"]
             device_system_desc = query.get_system_desc_as_dict()["system_desc"]
@@ -821,10 +817,10 @@ class SystemDesc(Flatbuffer):
     def __init__(self, logger, file_manager, file_path):
         super().__init__(logger, file_manager, file_path)
 
-        import ttrt.binary
+        import ttrt.runtime
 
-        self.fbb = ttrt.binary.load_system_desc_from_path(file_path)
-        self.fbb_dict = ttrt.binary.as_dict(self.fbb)
+        self.fbb = ttrt.runtime.load_system_desc_from_path(file_path)
+        self.fbb_dict = ttrt.runtime.as_dict(self.fbb)
         self.version = self.fbb.version
 
         # temporary state value to check if test failed

--- a/runtime/tools/ttrt/ttrt/runtime/__init__.py
+++ b/runtime/tools/ttrt/ttrt/runtime/__init__.py
@@ -42,6 +42,12 @@ try:
         WorkaroundEnv,
         get_op_loc_info,
         unregister_hooks,
+        load_from_path,
+        load_binary_from_path,
+        load_binary_from_capsule,
+        load_system_desc_from_path,
+        Flatbuffer,
+        GoldenTensor,
     )
 except ModuleNotFoundError:
     raise ImportError(
@@ -54,3 +60,15 @@ except ImportError:
     print(
         "Warning: not importing testing submodule since project was not built with runtime testing enabled. To enable, rebuild with: -DTTMLIR_ENABLE_RUNTIME_TESTS=ON"
     )
+
+import json
+
+
+def as_dict(bin):
+    tmp = bin.as_json()
+    # Flatbuffers emits 'nan' and 'inf'
+    # But Python's JSON accepts only 'NaN' and 'Infinity' and nothing else
+    # We include the comma to avoid replacing 'inf' in contexts like 'info'
+    tmp = tmp.replace("nan,", "NaN,")
+    tmp = tmp.replace("inf,", "Infinity,")
+    return json.loads(tmp)

--- a/runtime/tools/ttrt/ttrt/runtime/module.cpp
+++ b/runtime/tools/ttrt/ttrt/runtime/module.cpp
@@ -2,10 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <numeric>
 #include <sstream>
 
 #include "tt/runtime/detail/debug.h"
 #include "tt/runtime/runtime.h"
+#include "tt/runtime/tensor_cache.h"
+#include "tt/runtime/types.h"
 #include "tt/runtime/utils.h"
 #include "tt/runtime/workarounds.h"
 #if defined(TTMLIR_ENABLE_RUNTIME_TESTS) && TTMLIR_ENABLE_RUNTIME_TESTS == 1
@@ -21,7 +24,7 @@ namespace py = pybind11;
 
 PYBIND11_MODULE(_C, m) {
   m.doc() = "ttrt.runtime python extension for interacting with the "
-            "Tenstorrent devices";
+            "Tenstorrent devices, extends ttrt.binary";
   py::class_<tt::runtime::MemoryView>(m, "MemoryView")
       .def_readonly("num_banks", &tt::runtime::MemoryView::numBanks)
       .def_readonly("total_bytes_per_bank",
@@ -371,4 +374,140 @@ PYBIND11_MODULE(_C, m) {
   m.add_object("_cleanup", py::capsule(cleanup_callback));
   m.def("unregister_hooks",
         []() { ::tt::runtime::debug::Hooks::get().unregisterHooks(); });
+
+  // Extension of ttrt.binary
+  py::class_<tt::runtime::Flatbuffer>(m, "Flatbuffer", py::module_local())
+      .def_property_readonly("version", &tt::runtime::Flatbuffer::getVersion)
+      .def_property_readonly("ttmlir_git_hash",
+                             &tt::runtime::Flatbuffer::getTTMLIRGitHash)
+      .def_property_readonly("file_identifier",
+                             &tt::runtime::Flatbuffer::getFileIdentifier)
+      .def("as_json", &tt::runtime::Flatbuffer::asJson)
+      .def("store", &tt::runtime::Flatbuffer::store);
+  py::class_<tt::runtime::Binary>(m, "Binary", py::module_local())
+      .def_property_readonly("version", &tt::runtime::Binary::getVersion)
+      .def_property_readonly("ttmlir_git_hash",
+                             &tt::runtime::Binary::getTTMLIRGitHash)
+      .def_property_readonly("file_identifier",
+                             &tt::runtime::Binary::getFileIdentifier)
+      .def("as_json", &tt::runtime::Binary::asJson)
+      .def("store", &tt::runtime::Binary::store)
+      .def("get_debug_info_golden", &::tt::runtime::Binary::getDebugInfoGolden,
+           py::return_value_policy::reference)
+      .def(
+          "get_tensor_cache",
+          [](tt::runtime::Binary &bin) { return bin.getCache(); },
+          py::return_value_policy::reference);
+  py::class_<tt::runtime::SystemDesc>(m, "SystemDesc", py::module_local())
+      .def_property_readonly("version", &tt::runtime::SystemDesc::getVersion)
+      .def_property_readonly("ttmlir_git_hash",
+                             &tt::runtime::SystemDesc::getTTMLIRGitHash)
+      .def_property_readonly("file_identifier",
+                             &tt::runtime::SystemDesc::getFileIdentifier)
+      .def("as_json", &tt::runtime::SystemDesc::asJson)
+      .def("store", &tt::runtime::SystemDesc::store);
+  m.def("load_from_path", &tt::runtime::Flatbuffer::loadFromPath);
+  m.def("load_binary_from_path", &tt::runtime::Binary::loadFromPath);
+  m.def("load_binary_from_capsule", [](py::capsule capsule) {
+    std::shared_ptr<void> *binary =
+        static_cast<std::shared_ptr<void> *>(capsule.get_pointer());
+    return tt::runtime::Binary(
+        tt::runtime::Flatbuffer(*binary).handle); // Dereference capsule,
+                                                  // and then dereference
+                                                  // shared_ptr*
+  });
+  m.def("load_system_desc_from_path", &tt::runtime::SystemDesc::loadFromPath);
+  /**
+   * Binding for the `GoldenTensor` type
+   */
+  py::class_<tt::target::GoldenTensor>(m, "GoldenTensor", py::module_local(),
+                                       py::buffer_protocol())
+      .def_property_readonly(
+          "name",
+          [](const ::tt::target::GoldenTensor *t) -> std::string {
+            assert(t != nullptr && t->name() != nullptr);
+            return t->name()->str();
+          })
+      .def_property_readonly(
+          "shape",
+          [](const ::tt::target::GoldenTensor *t) -> std::vector<int> {
+            assert(t != nullptr && t->shape() != nullptr);
+            return std::vector<int>(t->shape()->begin(), t->shape()->end());
+          })
+      .def_property_readonly(
+          "stride",
+          [](const ::tt::target::GoldenTensor *t) -> std::vector<int> {
+            assert(t != nullptr && t->stride() != nullptr);
+            return std::vector<int>(t->stride()->begin(), t->stride()->end());
+          })
+      .def_property_readonly("dtype", &::tt::target::GoldenTensor::dtype)
+      .def_buffer([](const tt::target::GoldenTensor *t) -> py::buffer_info {
+        assert(t != nullptr && t->data() != nullptr && t->shape() != nullptr &&
+               t->stride() != nullptr);
+
+        // Format string to be passed to `py::buffer_info`
+        std::string format;
+
+        // Element size to be passed to `py::buffer_info`
+        size_t size;
+
+        switch (t->dtype()) {
+
+        case tt::target::DataType::UInt8:
+          format = py::format_descriptor<uint8_t>::format();
+          size = sizeof(uint8_t);
+          break;
+
+        case tt::target::DataType::UInt16:
+          format = py::format_descriptor<uint16_t>::format();
+          size = sizeof(uint16_t);
+          break;
+
+        case tt::target::DataType::UInt32:
+          format = py::format_descriptor<uint32_t>::format();
+          size = sizeof(uint32_t);
+          break;
+
+        case tt::target::DataType::Int32:
+          format = py::format_descriptor<int32_t>::format();
+          size = sizeof(int32_t);
+          break;
+
+        case tt::target::DataType::Float32:
+          format = py::format_descriptor<float>::format();
+          size = sizeof(float);
+          break;
+
+        default:
+          throw std::runtime_error(
+              "Only 32-bit floats and unsigned ints are currently supported "
+              "for GoldenTensor bindings");
+        }
+
+        return py::buffer_info(
+            (void *)t->data()->data(), /* ptr to underlying data */
+            size,                      /* size of element */
+            format,                    /* format */
+            t->shape()->size(),        /* rank */
+            *(t->shape()),             /* shape */
+            *(t->stride()),            /* stride of buffer */
+            false                      /* read only */
+        );
+      });
+  py::class_<tt::runtime::TensorCache,
+             std::shared_ptr<tt::runtime::TensorCache>>(m, "TensorCache",
+                                                        py::module_local())
+      .def(py::init<>())
+      .def("clear", &tt::runtime::TensorCache::clear)
+      .def("size", &tt::runtime::TensorCache::size)
+      .def("get_stats", &tt::runtime::TensorCache::getStats)
+      .def(
+          "remove_program",
+          [](tt::runtime::TensorCache &cache, const int meshId,
+             size_t programIndex) {
+            std::string outerKey =
+                tt::runtime::generateCacheOuterKey(meshId, programIndex);
+            cache.remove(outerKey);
+          },
+          "Remove cache entries for a specific device id and program index");
 }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/2994)

### Problem description
Callback functions use `ttrt.binary` module for some functions and `ttrt.runtime` for others. 

### What's changed
Incorporated `ttrt.binary` pybinding into `ttrt.runtime` pybinding.
Changed `ttrt/common` files to only import `ttrt.runtime`.

### Checklist
- [ ] New/Existing tests provide coverage for changes
