### PR TITLE
Uplift third_party/tt-metal to ccfdebb197663efa8b85cc5ec0d83f30c174e0c9 2025-05-13

### DIFF
--- a/runtime/include/tt/runtime/detail/ttnn/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn/ttnn.h
@@ -8,6 +8,7 @@
 #define FMT_HEADER_ONLY
 #include "hostdevcommon/common_values.hpp"
 #include "tt-metalium/host_api.hpp"
+#include "tt-metalium/host_buffer.hpp"
 #include "tt-metalium/memory_reporter.hpp"
 #include "tt-metalium/mesh_device.hpp"
 #include "ttnn/device.hpp"
@@ -39,7 +40,6 @@
 #include "ttnn/operations/reduction/generic/generic_reductions.hpp"
 #include "ttnn/operations/reduction/prod/prod.hpp"
 #include "ttnn/tensor/host_buffer/functions.hpp"
-#include "ttnn/tensor/host_buffer/host_buffer.hpp"
 #include "ttnn/tensor/shape/shape.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/types.hpp"

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "97e512f95c50f41767ccc2cd86e4ff824bb37e73")
+set(TT_METAL_VERSION "ccfdebb197663efa8b85cc5ec0d83f30c174e0c9")
 
 file(GLOB XTENSOR_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/xtensor/*/include")
 file(GLOB XTENSOR_BLAS_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/.cpmcache/xtensor-blas/*/include")


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the ccfdebb197663efa8b85cc5ec0d83f30c174e0c9

- Update host_buffer header include after metal change 9f2d64d6e1