### PR TITLE
Different fixes for fusing

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
@@ -405,6 +405,24 @@ def TTNN_Conv2dConfigAttr : TTNN_Attr<"Conv2dConfig", "conv2d_config"> {
 
   let extraClassDeclaration = [{
     Conv2dConfigAttr withActivation(StringRef activation) const;
+    Conv2dConfigAttr withDtype(DataType dtype) const;
+    Conv2dConfigAttr withWeightsDtype(DataType dtype) const;
+    Conv2dConfigAttr withDeallocateActivation(bool value) const;
+    Conv2dConfigAttr withReallocateHaloOutput(bool value) const;
+    Conv2dConfigAttr withActBlockHOverride(uint32_t value) const;
+    Conv2dConfigAttr withActBlockWDiv(uint32_t value) const;
+    Conv2dConfigAttr withReshardIfNotOptimal(bool value) const;
+    Conv2dConfigAttr withOverrideShardingConfig(bool value) const;
+    Conv2dConfigAttr withShardLayout(TensorMemoryLayout layout) const;
+    Conv2dConfigAttr withCoreGrid(CoreRangeSetAttr grid) const;
+    Conv2dConfigAttr withTransposeShards(bool value) const;
+    Conv2dConfigAttr withOutputLayout(Layout layout) const;
+    Conv2dConfigAttr withPreprocessWeightsOnDevice(bool value) const;
+    Conv2dConfigAttr withAlwaysPreprocessWeights(bool value) const;
+    Conv2dConfigAttr withEnableActDoubleBuffer(bool value) const;
+    Conv2dConfigAttr withEnableWeightsDoubleBuffer(bool value) const;
+    Conv2dConfigAttr withEnableSplitReader(bool value) const;
+    Conv2dConfigAttr withEnableSubblockPadding(bool value) const;
     bool hasActivation() const;
   }];
 

--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -336,9 +336,9 @@ private:
 
     // Create and return the reshape operation.
     return ttir::utils::createDPSOp<ttir::ReshapeOp>(
-        rewriter, loc, newShape, scaleType.getElementType(),
-        scaleType.getEncoding(), scaleValue,
-        rewriter.getI32ArrayAttr(newShapeI32));
+        rewriter, ttmlir::utils::appendLocationSuffix(loc, "_reshape"),
+        newShape, scaleType.getElementType(), scaleType.getEncoding(),
+        scaleValue, rewriter.getI32ArrayAttr(newShapeI32));
   }
 
   /// Create pre-multiplied weights.
@@ -347,8 +347,9 @@ private:
                                    Value reshapedScale) {
     // Create a multiplication of the weights by the reshaped scale.
     return utils::createDPSOp<MultiplyOp>(
-        rewriter, loc, mlir::cast<RankedTensorType>(weightValue.getType()),
-        weightValue, reshapedScale);
+        rewriter, ttmlir::utils::appendLocationSuffix(loc, "_multiply"),
+        mlir::cast<RankedTensorType>(weightValue.getType()), weightValue,
+        reshapedScale);
   }
 };
 

--- a/lib/Dialect/TTNN/Analysis/LegalLayoutAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/LegalLayoutAnalysis.cpp
@@ -38,7 +38,7 @@ bool cantChangeOutputLayout(Operation *op) {
   return false;
 }
 
-void applyConv2dConfigOverrides(Operation *op,
+void applyConv2dConfigOverrides(ttnn::Conv2dOp op,
                                 const Conv2dConfigOverrideParams &overrides,
                                 std::vector<OpConfig> &analysisResult) {
   // Apply conv2d config overrides to all legal (layout) configurations of
@@ -52,11 +52,6 @@ void applyConv2dConfigOverrides(Operation *op,
   // prepare_conv2d_weights.cpp where `weight_tensor_.get_dtype() ==
   // weights_bias_dtype`.
   //
-  MLIRContext *context = op->getContext();
-  auto getBoolAttr = [context](bool value) {
-    return BoolAttr::get(context, value);
-  };
-
   DataType dtype = elementTypeToDataType(
       mlir::cast<RankedTensorType>(op->getOperand(0).getType())
           .getElementType());
@@ -64,52 +59,102 @@ void applyConv2dConfigOverrides(Operation *op,
       mlir::cast<RankedTensorType>(op->getOperand(1).getType())
           .getElementType());
 
-  StringAttr activation =
-      StringAttr::get(context, overrides.activation.value_or(""));
-  BoolAttr deallocateActivation =
-      getBoolAttr(overrides.deallocateActivation.value_or(false));
-  BoolAttr reallocateHaloOutput =
-      getBoolAttr(overrides.reallocateHaloOutput.value_or(true));
-  uint32_t actBlockHOverride = overrides.actBlockHOverride.value_or(0);
-  uint32_t actBlockWDiv = overrides.actBlockWDiv.value_or(1);
-  BoolAttr reshardIfNotOptimal =
-      getBoolAttr(overrides.reshardIfNotOptimal.value_or(false));
-  BoolAttr overrideShardingConfig =
-      getBoolAttr(overrides.overrideShardingConfig.value_or(false));
-
-  std::optional<ttnn::TensorMemoryLayout> shardLayout;
-  if (overrides.shardLayout.has_value()) {
-    shardLayout = overrides.shardLayout;
+  // If conv2d config is not set get default conv2d config.
+  Conv2dConfigAttr conv2dConfigAttr = op.getConv2dConfigAttr();
+  if (!conv2dConfigAttr) {
+    conv2dConfigAttr = Conv2dConfigAttr::get(op.getContext());
   }
 
-  ttnn::CoreRangeSetAttr coreGrid =
-      overrides.coreGrid.value_or(ttnn::CoreRangeSetAttr());
-  BoolAttr transposeShards =
-      getBoolAttr(overrides.transposeShards.value_or(false));
-  Layout outputLayout = overrides.outputLayout.value_or(Layout::Tile);
-  BoolAttr preprocessWeightsOnDevice =
-      getBoolAttr(overrides.preprocessWeightsOnDevice.value_or(false));
-  BoolAttr alwaysPreprocessWeights =
-      getBoolAttr(overrides.alwaysPreprocessWeights.value_or(false));
-  BoolAttr enableActDoubleBuffer =
-      getBoolAttr(overrides.enableActDoubleBuffer.value_or(false));
-  BoolAttr enableWeightsDoubleBuffer =
-      getBoolAttr(overrides.enableWeightsDoubleBuffer.value_or(false));
-  BoolAttr enableSplitReader =
-      getBoolAttr(overrides.enableSplitReader.value_or(false));
-  BoolAttr enableSubblockPadding =
-      getBoolAttr(overrides.enableSubblockPadding.value_or(false));
+  conv2dConfigAttr = conv2dConfigAttr.withDtype(dtype);
+
+  conv2dConfigAttr = conv2dConfigAttr.withWeightsDtype(weightsDtype);
+
+  if (overrides.activation.has_value()) {
+    conv2dConfigAttr = conv2dConfigAttr.withActivation(*overrides.activation);
+  }
+
+  if (overrides.deallocateActivation.has_value()) {
+    conv2dConfigAttr = conv2dConfigAttr.withDeallocateActivation(
+        *overrides.deallocateActivation);
+  }
+
+  if (overrides.reallocateHaloOutput.has_value()) {
+    conv2dConfigAttr = conv2dConfigAttr.withReallocateHaloOutput(
+        *overrides.reallocateHaloOutput);
+  }
+
+  if (overrides.actBlockHOverride.has_value()) {
+    conv2dConfigAttr =
+        conv2dConfigAttr.withActBlockHOverride(*overrides.actBlockHOverride);
+  }
+
+  if (overrides.actBlockWDiv.has_value()) {
+    conv2dConfigAttr =
+        conv2dConfigAttr.withActBlockWDiv(*overrides.actBlockWDiv);
+  }
+
+  if (overrides.reshardIfNotOptimal.has_value()) {
+    conv2dConfigAttr = conv2dConfigAttr.withReshardIfNotOptimal(
+        *overrides.reshardIfNotOptimal);
+  }
+
+  if (overrides.overrideShardingConfig.has_value()) {
+    conv2dConfigAttr = conv2dConfigAttr.withOverrideShardingConfig(
+        *overrides.overrideShardingConfig);
+  }
+
+  if (overrides.shardLayout.has_value()) {
+    conv2dConfigAttr = conv2dConfigAttr.withShardLayout(*overrides.shardLayout);
+  }
+
+  if (overrides.coreGrid.has_value()) {
+    conv2dConfigAttr = conv2dConfigAttr.withCoreGrid(*overrides.coreGrid);
+  }
+
+  if (overrides.transposeShards.has_value()) {
+    conv2dConfigAttr =
+        conv2dConfigAttr.withTransposeShards(*overrides.transposeShards);
+  }
+
+  if (overrides.outputLayout.has_value()) {
+    conv2dConfigAttr =
+        conv2dConfigAttr.withOutputLayout(*overrides.outputLayout);
+  }
+
+  if (overrides.preprocessWeightsOnDevice.has_value()) {
+    conv2dConfigAttr = conv2dConfigAttr.withPreprocessWeightsOnDevice(
+        *overrides.preprocessWeightsOnDevice);
+  }
+
+  if (overrides.alwaysPreprocessWeights.has_value()) {
+    conv2dConfigAttr = conv2dConfigAttr.withAlwaysPreprocessWeights(
+        *overrides.alwaysPreprocessWeights);
+  }
+
+  if (overrides.enableActDoubleBuffer.has_value()) {
+    conv2dConfigAttr = conv2dConfigAttr.withEnableActDoubleBuffer(
+        *overrides.enableActDoubleBuffer);
+  }
+
+  if (overrides.enableWeightsDoubleBuffer.has_value()) {
+    conv2dConfigAttr = conv2dConfigAttr.withEnableWeightsDoubleBuffer(
+        *overrides.enableWeightsDoubleBuffer);
+  }
+
+  if (overrides.enableSplitReader.has_value()) {
+    conv2dConfigAttr =
+        conv2dConfigAttr.withEnableSplitReader(*overrides.enableSplitReader);
+  }
+
+  if (overrides.enableSubblockPadding.has_value()) {
+    conv2dConfigAttr = conv2dConfigAttr.withEnableSubblockPadding(
+        *overrides.enableSubblockPadding);
+  }
 
   for (auto &opConfig : analysisResult) {
     assert(!opConfig.opSpecificAttr &&
            "OpConfig should not have a config set before applying overrides");
-    opConfig.opSpecificAttr = Conv2dConfigAttr::get(
-        context, dtype, weightsDtype, activation, deallocateActivation,
-        reallocateHaloOutput, actBlockHOverride, actBlockWDiv,
-        reshardIfNotOptimal, overrideShardingConfig, shardLayout, coreGrid,
-        transposeShards, outputLayout, preprocessWeightsOnDevice,
-        alwaysPreprocessWeights, enableActDoubleBuffer,
-        enableWeightsDoubleBuffer, enableSplitReader, enableSubblockPadding);
+    opConfig.opSpecificAttr = conv2dConfigAttr;
   }
 }
 
@@ -171,7 +216,7 @@ bool LegalLayoutAnalysis::applyOverrides() {
   // If they do not exist, or they do not exist for a specific conv2d op, set
   // conv2d config with default values.
   //
-  if (isa<ttnn::Conv2dOp>(op)) {
+  if (auto convOp = mlir::dyn_cast<ttnn::Conv2dOp>(op)) {
     Conv2dConfigOverrideParams conv2dConfigOverrides;
     if (analysisInput.conv2dConfigOverrides) {
       auto overrideConv2dIt =
@@ -180,7 +225,7 @@ bool LegalLayoutAnalysis::applyOverrides() {
         conv2dConfigOverrides = overrideConv2dIt->getValue();
       }
     }
-    applyConv2dConfigOverrides(op, conv2dConfigOverrides, analysisResult);
+    applyConv2dConfigOverrides(convOp, conv2dConfigOverrides, analysisResult);
   }
   return true;
 }
@@ -370,7 +415,7 @@ void LegalLayoutAnalysis::analysisImplementation() {
   //
   if (auto opLoc = mlir::dyn_cast<NameLoc>(op->getLoc())) {
     StringRef opLocName = opLoc.getName().strref();
-    if (isa<ttnn::Conv2dOp>(op)) {
+    if (auto convOp = mlir::dyn_cast<ttnn::Conv2dOp>(op)) {
       Conv2dConfigOverrideParams conv2dConfigOverrides;
       if (analysisInput.conv2dConfigOverrides) {
         auto overrideConv2dIt =
@@ -379,7 +424,7 @@ void LegalLayoutAnalysis::analysisImplementation() {
           conv2dConfigOverrides = overrideConv2dIt->getValue();
         }
       }
-      applyConv2dConfigOverrides(op, conv2dConfigOverrides, analysisResult);
+      applyConv2dConfigOverrides(convOp, conv2dConfigOverrides, analysisResult);
     }
   }
 

--- a/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
@@ -27,11 +27,17 @@ public:
     Value reluInput = reluOp.getInput();
 
     mlir::StringAttr activation = rewriter.getStringAttr("relu");
+    DataType inputDtype =
+        elementTypeToDataType(srcOp.getInput().getType().getElementType());
+    DataType weightDtype =
+        elementTypeToDataType(srcOp.getWeight().getType().getElementType());
     Conv2dConfigAttr conv2dConfigAttr =
         srcOp.getConv2dConfigAttr()
             ? srcOp.getConv2dConfigAttr()
             : Conv2dConfigAttr::get(rewriter.getContext());
-    conv2dConfigAttr = conv2dConfigAttr.withActivation(activation);
+    conv2dConfigAttr = conv2dConfigAttr.withActivation(activation)
+                           .withDtype(inputDtype)
+                           .withWeightsDtype(weightDtype);
 
     rewriter.modifyOpInPlace(
         srcOp, [&]() { srcOp.setConv2dConfigAttr(conv2dConfigAttr); });

--- a/test/ttmlir/Silicon/TTNN/n150/fusing/resnet_pattern_fusing.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/fusing/resnet_pattern_fusing.mlir
@@ -1,0 +1,25 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-fusing-pass=true" %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+
+// This is common pattern throught Resnet. We have conv2d with constant weight, followed by multiply with constant input. This will be commuted through conv2d.
+// Then we fuse add into conv2d with bias and lastly we fuse conv2d and relu into conv2d with activation.
+module {
+  func.func @main(%weight: tensor<64x64x3x3xf32> {tt.argument_type = #tt.argument_type<constant>}, %arg5: tensor<1x1x1x64xf32> {tt.argument_type = #tt.argument_type<constant>}, %arg6: tensor<1x1x1x64xf32>, %input: tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32> {
+    // CHECK: "ttnn.multiply"
+    // CHECK: "ttnn.conv2d"
+    // CHECK-SAME: activation = "relu"
+    %0 = ttir.empty() : tensor<1x56x56x64xf32>
+    %1 = "ttir.conv2d"(%input, %weight, %0) <{dilation = array<i32: 1, 1>, groups = 1 : i32, padding = array<i32: 1, 1, 1, 1>, stride = array<i32: 1, 1>}> {channel_last = 1 : si32} : (tensor<1x56x56x64xf32>, tensor<64x64x3x3xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %2 = ttir.empty() : tensor<1x56x56x64xf32>
+    // CHECK-NOT: "ttnn.multiply"
+    // CHECK-NOT: "ttnn.add"
+    // CHECK-NOT: "ttnn.relu"
+    %3 = "ttir.multiply"(%1, %arg5, %2) : (tensor<1x56x56x64xf32>, tensor<1x1x1x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %4 = ttir.empty() : tensor<1x56x56x64xf32>
+    %5 = "ttir.add"(%3, %arg6, %4) : (tensor<1x56x56x64xf32>, tensor<1x1x1x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    %6 = ttir.empty() : tensor<1x56x56x64xf32>
+    %7 = "ttir.relu"(%5, %6) : (tensor<1x56x56x64xf32>, tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+    return %7 : tensor<1x56x56x64xf32>
+  }
+}

--- a/test/ttmlir/Silicon/TTNN/n150/fusing/softmax_fusing.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/fusing/softmax_fusing.mlir
@@ -1,0 +1,81 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-fusing-pass=true" %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+
+
+module {
+  // CHECK-LABEL: func.func @softmax_fusion_dim1
+  func.func @softmax_fusion_dim1(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    // CHECK-NOT: ttir.exp
+    // CHECK-NOT: ttir.sum
+    // CHECK-NOT: ttir.broadcast
+    // CHECK-NOT: ttir.div
+    // CHECK: %[[RESULT:.*]] = "ttnn.softmax"(%arg0) <{dimension = 1 : si32}>
+    // CHECK: return %[[RESULT]]
+
+    %0 = ttir.empty() : tensor<32x32xf32>
+    %1 = "ttir.exp"(%arg0, %0) : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    %2 = ttir.empty() : tensor<32x1xf32>
+    %3 = "ttir.sum"(%1, %2) {dim_arg = [1 : i32], keep_dim = true} : (tensor<32x32xf32>, tensor<32x1xf32>) -> tensor<32x1xf32>
+
+    %4 = ttir.empty() : tensor<32x32xf32>
+    %5 = "ttir.broadcast"(%3, %4) {broadcast_dimensions = array<i64: 1, 32>} : (tensor<32x1xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    %6 = ttir.empty() : tensor<32x32xf32>
+    %7 = "ttir.div"(%1, %5, %6) : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    return %7 : tensor<32x32xf32>
+  }
+
+  func.func @softmax_fusion_dim0(%arg0: tensor<32x32xbf16>) -> tensor<32x32xbf16> {
+    // CHECK-NOT: ttir.exp
+    // CHECK-NOT: ttir.sum
+    // CHECK-NOT: ttir.broadcast
+    // CHECK-NOT: ttir.div
+    // CHECK: %[[RESULT:.*]] = "ttnn.softmax"(%arg0) <{dimension = 0 : si32}>
+    // CHECK: return %[[RESULT]]
+
+    %0 = ttir.empty() : tensor<32x32xbf16>
+    %1 = "ttir.exp"(%arg0, %0) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+
+    %2 = ttir.empty() : tensor<1x32xbf16>
+    %3 = "ttir.sum"(%1, %2) {dim_arg = [0 : i32], keep_dim = true} : (tensor<32x32xbf16>, tensor<1x32xbf16>) -> tensor<1x32xbf16>
+
+    %4 = ttir.empty() : tensor<32x32xbf16>
+    %5 = "ttir.broadcast"(%3, %4) {broadcast_dimensions = array<i64: 32, 1>} : (tensor<1x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+
+    %6 = ttir.empty() : tensor<32x32xbf16>
+    %7 = "ttir.div"(%1, %5, %6) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+
+    return %7 : tensor<32x32xbf16>
+  }
+
+  // Test case where rehape is fused into reduction and we can fuse into softmax.
+  func.func @no_fusion_keep_dim_false(%arg0: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    // CHECK-NOT: ttir.exp
+    // CHECK-NOT: ttir.sum
+    // CHECK-NOT: ttir.broadcast
+    // CHECK-NOT: ttir.div
+    // CHECK: %[[RESULT:.*]] = "ttnn.softmax"(%arg0) <{dimension = 1 : si32}>
+    // CHECK: return %[[RESULT]]
+
+    %0 = ttir.empty() : tensor<32x32xf32>
+    %1 = "ttir.exp"(%arg0, %0) : (tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    %2 = ttir.empty() : tensor<32xf32>
+    %3 = "ttir.sum"(%1, %2) {dim_arg = [1 : i32], keep_dim = false} : (tensor<32x32xf32>, tensor<32xf32>) -> tensor<32xf32>
+
+    %4 = ttir.empty() : tensor<32x1xf32>
+    %5 = "ttir.reshape"(%3, %4) {shape = [32 : i32, 1 : i32]} : (tensor<32xf32>, tensor<32x1xf32>) -> tensor<32x1xf32>
+
+    %6 = ttir.empty() : tensor<32x32xf32>
+    %7 = "ttir.broadcast"(%5, %6) {broadcast_dimensions = array<i64: 1, 32>} : (tensor<32x1xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    %8 = ttir.empty() : tensor<32x32xf32>
+    %9 = "ttir.div"(%1, %7, %8) : (tensor<32x32xf32>, tensor<32x32xf32>, tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    return %9 : tensor<32x32xf32>
+  }
+
+}


### PR DESCRIPTION
We found couple of issues with fusing while testing resnet. Below is first batch of fixes. Second batch should only contain layout changes and moving conv2d to workarounds.

* Address second bullet from #3308 as well as aligns `Conv2dConfigParams` constructor with `Conv2dConfig` from metal because we didn't represent well `shard_layout` which should be `optional<TensorMemoryLayout>` and `reallocate_halo_output` should be true.
* On optimizer side when applying conv2d config overrides we need to merge them with conv2d config on op - previously we ignored conv2d config from op when applying overrides which lead to some settings being overriden.
* Fix locations of ops which are created by fusing.