### PR TITLE
Build-and-test workflow's logic fix

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -247,7 +247,6 @@ jobs:
 
     - name: Download Build Artifacts
       uses: ./.github/actions/download-artifact
-      if: ${{ matrix.build.type == 'unit' || matrix.build.suite == 'explorer' }}
       with:
         name: build-artifacts-${{ matrix.build.image }}
         path: build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -247,6 +247,7 @@ jobs:
 
     - name: Download Build Artifacts
       uses: ./.github/actions/download-artifact
+      if: ${{ matrix.build.type == 'unit' || matrix.build.suite == 'explorer' }}
       with:
         name: build-artifacts-${{ matrix.build.image }}
         path: build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -247,7 +247,6 @@ jobs:
 
     - name: Download Build Artifacts
       uses: ./.github/actions/download-artifact
-      if: ${{ matrix.build.type }} == "unit" || ${{ matrix.build.suite }} == "explorer"
       with:
         name: build-artifacts-${{ matrix.build.image }}
         path: build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -252,7 +252,6 @@ jobs:
         path: build
         github_token: ${{ secrets.GITHUB_TOKEN }}
 
-
     # TG galaxy doesn't have support for dispatch on eth cores - thus need to disable it
     - name: Generate system descriptor
       shell: bash

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -252,6 +252,7 @@ jobs:
         path: build
         github_token: ${{ secrets.GITHUB_TOKEN }}
 
+
     # TG galaxy doesn't have support for dispatch on eth cores - thus need to disable it
     - name: Generate system descriptor
       shell: bash


### PR DESCRIPTION
### Problem description
The "Download build artifacts" job step had a poorly defined "if" clause which resulted in the step always getting triggered.

### What's changed
Upon fixing the condition and it working as intended by the clause, all of the tests failed ([workflow preview](https://github.com/tenstorrent/tt-mlir/actions/runs/14991074320)) because they actually require the step to get executed. 
In the end I just removed the condition so that it is obvious that we always want it to run.
Workflow's behaviour hasn't changed.

### Tests
Tests are still passing [workflow](https://github.com/tenstorrent/tt-mlir/actions/runs/14993789564)