### PR TITLE
Fix macos build timeout

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -65,6 +65,7 @@ jobs:
         -DCMAKE_C_COMPILER=${{ matrix.build.c_compiler }} \
         -DCMAKE_BUILD_TYPE=${{ matrix.build.build_type }} \
         -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+        -DCMAKE_BUILD_PARALLEL_LEVEL=4 \
         -DTTMLIR_ENABLE_RUNTIME=${{ matrix.build.enable_runtime }} \
         -DTTMLIR_ENABLE_RUNTIME_TESTS=${{ matrix.build.enable_runtime }} \
         -S ${{ github.workspace }}

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -102,6 +102,7 @@ You can add different flags to your build. Here are some options to consider:
 * To enable the ttnn/metal runtime add `-DTTMLIR_ENABLE_RUNTIME=ON`. Clang 17 is the minimum required version when enabling the runtime.
 * To enable the ttnn/metal perf runtime add `-DTT_RUNTIME_ENABLE_PERF_TRACE=ON`.
 * To accelerate the builds with ccache use `-DCMAKE_CXX_COMPILER_LAUNCHER=ccache`.
+* To workaround OOM issues it can be useful to decrease the number of parallel jobs with `-DCMAKE_BUILD_PARALLEL_LEVEL=4`.
 * If Python bindings aren't required for your project, you can accelerate builds further with the command `-DTTMLIR_ENABLE_BINDINGS_PYTHON=OFF`.
 * The TTNN build is automatically integrated / handled by the tt-mlir cmake build system.  For debugging and further information regarding the TTNN backend build step, please refer to [TTNN Documentation](https://tenstorrent.github.io/tt-metal/latest/ttnn/ttnn/installing.html).
 * The runtime build depends on the `TT_METAL_HOME` variable, which is also set in `env/activate` script. For more information, please refer to [TT-NN and TT-Metailium installation documentation](https://tenstorrent.github.io/tt-metal/latest/ttnn/ttnn/installing.html#step-4-install-and-start-using-tt-nn-and-tt-metalium).


### PR DESCRIPTION
Some macos builds are timing out at 6 hours.  Locally I have to set this cmake flag to avoid IO thrashing and kernel slowdown.  I speculate the same could be happening here so going to try this fix.
