### PR TITLE
[runtime] use worker cores for dispatching on BH

### DIFF
--- a/runtime/include/tt/runtime/detail/common.h
+++ b/runtime/include/tt/runtime/detail/common.h
@@ -8,6 +8,7 @@
 #include <optional>
 
 #define FMT_HEADER_ONLY
+#include "tt-metalium/hal.hpp"
 #include "tt-metalium/host_api.hpp"
 
 #include "tt/runtime/detail/flatbuffer_operator_ostream.h"
@@ -28,6 +29,8 @@ getDispatchCoreType(std::optional<DispatchCoreType> dispatchCoreType) {
     } else {
       LOG_FATAL("Unsupported dispatch core type");
     }
+  } else if (::tt::tt_metal::hal::get_arch() == ::tt::ARCH::BLACKHOLE) {
+    type = ::tt::tt_metal::DispatchCoreType::WORKER;
   } else {
     size_t numDevices = ::tt::tt_metal::GetNumAvailableDevices();
     size_t numPCIeDevices = ::tt::tt_metal::GetNumPCIeDevices();


### PR DESCRIPTION
This would override any existing settings. For example, `ttrt query` uses ETH cores unless the option `--disable-eth-dispatch` is specified, but this change will override ttrt's settings.

### Problem description
Using ethernet cores for dispatching caused a series of "coordinates not found" errors on BH. This workaround fixes it.

FWIW this is the default behaviour of tt-metal's functions:
```cpp
    DispatchCoreConfig() : type_(DispatchCoreType::WORKER) {}
```

```cpp
    // inside class MeshDevice
    static std::shared_ptr<MeshDevice> create(
        const MeshDeviceConfig& config,
        size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
        size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
        size_t num_command_queues = 1,
        const DispatchCoreConfig& dispatch_core_config = DispatchCoreConfig{},
        tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
        size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE);
```