### PR TITLE
Added Backend changes to generate C++ code

### DIFF
--- a/docs/src/tt-explorer-usage-api.md
+++ b/docs/src/tt-explorer-usage-api.md
@@ -43,14 +43,20 @@ The performance overlay is generated on **every** execution, it highlights the t
 #### Accuracy Overlay
 The accuracy overlay is _only_ generated when executing from a compatible flatbuffer (`.ttnn` file extension with Debug Info). The overlay consists of either Green or Red node overlays. Green if the node passed a "golden" test, Red if not. The value for the overlay is the actual Pearson Correlation Coefficient (PCC) value with the "golden" tensor subtracted by the expected PCC value. If the number is `< 0` we know it doesn't match the expected PCC, otherwise it is an accurate comparison.
 
-#### Opt. Policy
+#### Advanced Settings
+This menu will open a window with some advanced settings for Model execution.
+
+##### Opt. Policy
 This dropdown provides a list of **Optimization Policies** which will be used when the model is executed. These policies are applied when lowering from a `ttir` module to an executable `ttnn` module.
 
-#### "Upload" Button
-Once Overridden Fields have been changed or modified, this button will be available to send the overrides to the backend. The overrides will then be processed and the module recompiled to include these new changes.
+##### Generate C++ Code
+This toggle will run the `EmitC` pass in the `tt-mlir` compiler to generate TTNN C++ Code and make it available to you after running a model. Default value for this toggle is `Off`.
 
 #### "Play" Button
 This button invokes the `execute` function which will compile and execute the model. The button will then be "loading" until execution is finished. Once execution is finished a performance trace should be overlayed on the graph and it should reload.
+
+#### "Code" Button
+If the `Generate C++ Code` flag is set, this button will become available to view and download the C++ code in a window within explorer.
 
 #### "Comment" Button
 This button will open a window to view the shell logs while execution is running. If any errors occur they will be displayed here.

--- a/tools/explorer/CMakeLists.txt
+++ b/tools/explorer/CMakeLists.txt
@@ -3,7 +3,7 @@ include(ExternalProject)
 set(TT_EXPLORER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/run.py)
 set(TTMLIR_BUILD_BIN_DIR ${TTMLIR_BINARY_DIR}/bin)
 
-set(MODEL_EXPLORER_VERSION "583bce92024a1aaffb3ff9780eb05daeef7f2c25")
+set(MODEL_EXPLORER_VERSION "53609eecc6a611b3c7f7c0fdc52db27ca1759c57")
 
 ExternalProject_Add(
   model-explorer

--- a/tools/explorer/CMakeLists.txt
+++ b/tools/explorer/CMakeLists.txt
@@ -3,7 +3,7 @@ include(ExternalProject)
 set(TT_EXPLORER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/run.py)
 set(TTMLIR_BUILD_BIN_DIR ${TTMLIR_BINARY_DIR}/bin)
 
-set(MODEL_EXPLORER_VERSION "53609eecc6a611b3c7f7c0fdc52db27ca1759c57")
+set(MODEL_EXPLORER_VERSION "9a141aa2206b7ff7e5d6469b55954aa6f062297a")
 
 ExternalProject_Add(
   model-explorer

--- a/tools/explorer/test/run_tests.py
+++ b/tools/explorer/test/run_tests.py
@@ -240,6 +240,19 @@ def test_execute_and_check_memory_data_exists():
     assert "display_type" in str(result)
 
 
+def test_get_emitc_cpp_code():
+    execute_command_and_wait(
+        MNIST_SHARDING_PATH,
+        {
+            "optimizationPolicy": "Optimizer Disabled",
+            "generateCppCode": True,
+        },
+        timeout=300,
+    )
+    result = convert_command_and_assert(MNIST_SHARDING_PATH)
+    assert "cppCode" in result["graphs"][0]
+
+
 # TODO: figure out if this should be deleted, or adapted with new tests
 @pytest.mark.skip(
     "This is now handled by tests under `test/python/golden/test_ttir_models.py`"

--- a/tools/explorer/tt_adapter/src/tt_adapter/main.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/main.py
@@ -179,6 +179,7 @@ class TTAdapter(model_explorer.Adapter):
             perf_trace = self.model_runner.get_perf_trace(model_path)
             memory_trace = self.model_runner.get_memory_usage(model_path)
             golden_results = self.model_runner.get_golden_results(model_path)
+            cpp_code = self.model_runner.get_cpp_code(model_path)
 
             with open(optimized_model_path, "r") as model_file:
                 module = utils.parse_mlir_str(model_file.read())
@@ -193,6 +194,9 @@ class TTAdapter(model_explorer.Adapter):
 
             if overrides := self.model_runner.get_overrides(model_path):
                 graph = utils.add_to_dataclass(graph, "overrides", overrides)
+
+            if cpp_code:
+                graph = utils.add_to_dataclass(graph, "cppCode", cpp_code)
         else:
             if model_path.endswith(".ttnn"):
                 # Executing on a Flatbuffer so we should parse through that path
@@ -219,9 +223,7 @@ class TTAdapter(model_explorer.Adapter):
         override_handler = settings_to_overrides(
             settings, self.model_runner.get_artifacts_dir()
         )
-        self.model_runner.run(
-            model_path, override_handler.to_string(), settings.get("overrides", None)
-        )
+        self.model_runner.run(model_path, override_handler.to_string(), settings)
 
         return {"graphs": []}
 

--- a/tools/explorer/tt_adapter/src/tt_adapter/main.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/main.py
@@ -13,10 +13,10 @@ OVERRIDE_PARAMETER_DISABLED_STR = "None"
 OPTIMIZER_DISABLED_POLICY = "Optimizer Disabled"
 
 OPTIMIZATION_POLICIES = {
+    OPTIMIZER_DISABLED_POLICY: False,
     "DF Sharding": optimizer_overrides.MemoryLayoutAnalysisPolicyType.DFSharding,
     "Greedy L1 Interleaved": optimizer_overrides.MemoryLayoutAnalysisPolicyType.GreedyL1Interleaved,
     "BF Interleaved": optimizer_overrides.MemoryLayoutAnalysisPolicyType.BFInterleaved,
-    OPTIMIZER_DISABLED_POLICY: False,
 }
 
 

--- a/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
@@ -835,7 +835,12 @@ FILTERED_OPS = [
 
 
 def build_graph(
-    module_path: str, module, perf_trace=None, memory_trace=None, golden_results=None
+    module_path: str,
+    module,
+    perf_trace=None,
+    memory_trace=None,
+    golden_results=None,
+    cpp_code=None,
 ):
     graph_id = Path(module_path).name
     output_connections = defaultdict(int)

--- a/tools/explorer/tt_adapter/src/tt_adapter/runner.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/runner.py
@@ -274,7 +274,7 @@ class ModelRunner:
 
         ########################### EmitC Generation #############################
 
-        if self.get_generate_cpp_code():
+        if self.get_generate_cpp_code(model_path):
             # Backend Pipeline has already been run, the file is stored to ttnn_ir_file
             # The translation to flatbuffer will happen, need to run the pass to emitc and then store the artifact
             self.log("Enabled C++ Code Generation w/ EmitC")
@@ -284,7 +284,7 @@ class ModelRunner:
             )
             emitc_command = [
                 f"{self._build_dir}/bin/ttmlir-opt",
-                "--ttnn-modify-signatured-for-dylib",
+                "--ttnn-modify-signatures-for-dylib",
                 "--convert-ttnn-to-emitc",
                 ttnn_ir_file,
                 "-o",
@@ -307,7 +307,7 @@ class ModelRunner:
                 f"{self._build_dir}/bin/ttmlir-translate",
                 "--mlir-to-cpp",
                 emitc_ir_file,
-                ">",
+                "-o",
                 c_code_file,
             ]
 


### PR DESCRIPTION
### Ticket
- PR closes #3241 (backend side)

### Problem description
- Need to generate EmitC code for further testing and analysis and optimization space by hand.

### What's changed
- Added options to hook into FE changes and produce `.cpp` code using Compiler passes and return for FE to process in Explorer.
- TODO: Add support for using the `--emitc` flag with `ttrt perf`.

### Checklist
- [x] New/Existing tests provide coverage for changes
