### PR TITLE
D2M: Align up allocation size on tile

### DIFF
--- a/lib/Dialect/TT/IR/TTOpsTypes.cpp
+++ b/lib/Dialect/TT/IR/TTOpsTypes.cpp
@@ -1127,10 +1127,8 @@ size_t DeviceAttr::getMemrefSizeBytes(MemRefType memrefType, size_t pageSize,
   mlir::Type elementType = memrefType.getElementType();
   int64_t elementSizeBytes = getElementSizeBytes(elementType);
   auto tileType = mlir::dyn_cast<TileType>(elementType);
-  size_t alignSize =
-      tileType
-          ? tileType.getSizeBytes()
-          : TileType::get(elementType).getSizeBytes();
+  size_t alignSize = tileType ? tileType.getSizeBytes()
+                              : TileType::get(elementType).getSizeBytes();
 
   ShardLayoutAttr layout =
       mlir::dyn_cast<ShardLayoutAttr>(memrefType.getLayout());

--- a/lib/Dialect/TT/IR/TTOpsTypes.cpp
+++ b/lib/Dialect/TT/IR/TTOpsTypes.cpp
@@ -1126,6 +1126,12 @@ size_t DeviceAttr::getMemrefSizeBytes(MemRefType memrefType, size_t pageSize,
   assert(pageSize == 0 && "Page size not supported yet");
   mlir::Type elementType = memrefType.getElementType();
   int64_t elementSizeBytes = getElementSizeBytes(elementType);
+  auto tileType = mlir::dyn_cast<TileType>(elementType);
+  size_t alignSize =
+      tileType
+          ? tileType.getSizeBytes()
+          : TileType::get(elementType).getSizeBytes();
+
   ShardLayoutAttr layout =
       mlir::dyn_cast<ShardLayoutAttr>(memrefType.getLayout());
   assert(
@@ -1134,9 +1140,12 @@ size_t DeviceAttr::getMemrefSizeBytes(MemRefType memrefType, size_t pageSize,
   bool isLocalMemref = (layout == nullptr);
   auto shardShape =
       isLocalMemref ? memrefType.getShape() : layout.getShardShape(memrefType);
-  return ttmlir::utils::volume(shardShape,
-                               elementSizeBytes *
-                                   (includeBuffers ? layout.getBuffers() : 1));
+
+  return ttmlir::utils::alignUp(
+      static_cast<size_t>(ttmlir::utils::volume(
+          shardShape,
+          elementSizeBytes * (includeBuffers ? layout.getBuffers() : 1))),
+      alignSize);
 }
 
 size_t DeviceAttr::getMemrefCBPageSizeBytes(MemRefType memrefType) const {

--- a/runtime/include/tt/runtime/utils.h
+++ b/runtime/include/tt/runtime/utils.h
@@ -60,6 +60,11 @@ struct overloaded : Ts... {
   using Ts::operator()...;
 };
 
+template <typename T>
+T alignUp(T ptr, T alignment) {
+  return (ptr + alignment - 1) & ~(alignment - 1);
+}
+
 } // namespace tt::runtime::utils
 
 #endif

--- a/runtime/lib/ttmetal/executor.cpp
+++ b/runtime/lib/ttmetal/executor.cpp
@@ -197,8 +197,7 @@ void CQExecutor::execute(const target::metal::HostAllocCommand *command) {
   desc.dataType = bufferDesc->data_type();
 
   size_t size =
-      utils::alignUp(desc.shape[0] * desc.stride[0], 1024U) *
-      desc.itemsize;
+      utils::alignUp(desc.shape[0] * desc.stride[0], 1024U) * desc.itemsize;
   auto data = std::shared_ptr<void>(std::malloc(size), std::free);
   if (!data) {
     LOG_FATAL("HostAllocCommand: Failed to allocate host memory.");

--- a/runtime/lib/ttmetal/executor.cpp
+++ b/runtime/lib/ttmetal/executor.cpp
@@ -196,7 +196,9 @@ void CQExecutor::execute(const target::metal::HostAllocCommand *command) {
   desc.itemsize = utils::dataTypeElementSize(bufferDesc->data_type());
   desc.dataType = bufferDesc->data_type();
 
-  size_t size = desc.shape[0] * desc.stride[0] * desc.itemsize;
+  size_t size =
+      utils::alignUp(desc.shape[0] * desc.stride[0], 1024U) *
+      desc.itemsize;
   auto data = std::shared_ptr<void>(std::malloc(size), std::free);
   if (!data) {
     LOG_FATAL("HostAllocCommand: Failed to allocate host memory.");


### PR DESCRIPTION
To simplify buffer memory management always align up allocation size on a tile of corresponding elements.