### PR TITLE
D2M: ttir.constant -> memref.get_global -> HostAllocCommand

### DIFF
--- a/include/ttmlir/Target/TTMetal/command.fbs
+++ b/include/ttmlir/Target/TTMetal/command.fbs
@@ -59,6 +59,11 @@ table EventQueryCommand {
 table FinishCommand {
 }
 
+table GetGlobalCommand {
+  dst: BufferRef;
+  data: [ubyte];
+}
+
 union CommandType {
   HostAllocCommand,
   ReturnCommand,
@@ -73,6 +78,7 @@ union CommandType {
   EventSynchronizeCommand,
   EventQueryCommand,
   FinishCommand,
+  GetGlobalCommand,
 }
 
 table Command {

--- a/include/ttmlir/Target/TTMetal/command.fbs
+++ b/include/ttmlir/Target/TTMetal/command.fbs
@@ -6,6 +6,7 @@ namespace tt.target.metal;
 
 table HostAllocCommand {
   dst: BufferRef;
+  data: [ubyte];
 }
 
 table ReturnCommand {
@@ -59,11 +60,6 @@ table EventQueryCommand {
 table FinishCommand {
 }
 
-table GetGlobalCommand {
-  dst: BufferRef;
-  data: [ubyte];
-}
-
 union CommandType {
   HostAllocCommand,
   ReturnCommand,
@@ -78,7 +74,6 @@ union CommandType {
   EventSynchronizeCommand,
   EventQueryCommand,
   FinishCommand,
-  GetGlobalCommand,
 }
 
 table Command {

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -730,6 +730,21 @@ toFlatbuffer(FlatbufferObjectCache &cache, ttnn::Conv2dConfigAttr config) {
       toFlatbuffer(cache, config.getEnableSubblockPadding()));
 }
 
+template <typename T>
+static flatbuffers::Offset<::flatbuffers::Vector<uint8_t>>
+toFlatbufferByteVector(FlatbufferObjectCache &cache,
+                       mlir::DenseElementsAttr &attr) {
+  size_t size_bytes = attr.getNumElements() * sizeof(T);
+  cache.fbb->StartVector<flatbuffers::Offset<uint8_t>>(size_bytes);
+
+  for (auto i = attr.value_begin<T>(); i != attr.value_end<T>(); i++) {
+    T value = *i;
+    uint8_t *buf = reinterpret_cast<uint8_t *>(&value);
+    cache.fbb->PushBytes(buf, sizeof(T));
+  }
+  return cache.fbb->EndVector(size_bytes);
+}
+
 } // namespace mlir::tt
 
 #endif

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -737,6 +737,7 @@ toFlatbufferByteVector(FlatbufferObjectCache &cache,
   size_t sizeBytes = attr.getNumElements() * sizeof(T);
   cache.fbb->StartVector<flatbuffers::Offset<uint8_t>>(sizeBytes);
 
+  // Iterate over the values to make sure splat is unrolled correctly
   for (auto i = attr.value_begin<T>(); i != attr.value_end<T>(); i++) {
     T value = *i;
     uint8_t *buf = reinterpret_cast<uint8_t *>(&value);

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -734,15 +734,15 @@ template <typename T>
 static flatbuffers::Offset<::flatbuffers::Vector<uint8_t>>
 toFlatbufferByteVector(FlatbufferObjectCache &cache,
                        mlir::DenseElementsAttr &attr) {
-  size_t size_bytes = attr.getNumElements() * sizeof(T);
-  cache.fbb->StartVector<flatbuffers::Offset<uint8_t>>(size_bytes);
+  size_t sizeBytes = attr.getNumElements() * sizeof(T);
+  cache.fbb->StartVector<flatbuffers::Offset<uint8_t>>(sizeBytes);
 
   for (auto i = attr.value_begin<T>(); i != attr.value_end<T>(); i++) {
     T value = *i;
     uint8_t *buf = reinterpret_cast<uint8_t *>(&value);
     cache.fbb->PushBytes(buf, sizeof(T));
   }
-  return cache.fbb->EndVector(size_bytes);
+  return cache.fbb->EndVector(sizeBytes);
 }
 
 } // namespace mlir::tt

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -580,37 +580,6 @@ static std::shared_ptr<void> translateModuleToFlatbuffer(
         auto globalOp = mlir::cast<memref::GlobalOp>(
             symbolTable.lookup(globalSymbolRef.getValue()));
         auto globalResult = getGlobalOp.getResult();
-
-        if (auto value =
-                mlir::dyn_cast<MemRefType>(globalOp.getTypeAttr().getValue());
-            value) {
-
-          if (mlir::isa<FloatType>(value.getElementType())) {
-
-            auto initial_value_attr = mlir::cast<mlir::DenseElementsAttr>(
-                globalOp.getInitialValueAttr());
-
-            fbb.StartVector<flatbuffers::Offset<float>>(
-                initial_value_attr.getNumElements());
-
-            for (auto i = initial_value_attr.value_begin<float>();
-                 i != initial_value_attr.value_end<float>(); i++) {
-              fbb.PushElement(*i);
-            }
-            auto vector = fbb.EndVector(initial_value_attr.getNumElements());
-
-            cqBuilder.appendCommand(
-                target::metal::CreateHostAllocCommand(
-                    fbb,
-                    cache.getOrCreate(globalResult, bufferValueToFlatbuffer, 0),
-                    vector),
-                op);
-          } else {
-            assert(false);
-          }
-        } else {
-          assert(false);
-        }
         cqBuilder.appendCommand(
             target::metal::CreateHostAllocCommand(
                 fbb,

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -535,6 +535,10 @@ static std::shared_ptr<void> translateModuleToFlatbuffer(
       } else if (auto finishOp = dyn_cast_if_present<tt::ttmetal::FinishOp>(op);
                  finishOp) {
         cqBuilder.appendCommand(target::metal::CreateFinishCommand(fbb), op);
+      } else if (auto getGlobalOp =
+                     dyn_cast_if_present<memref::GetGlobalOp>(op);
+                 getGlobalOp) {
+        cache.getOrCreate(getGlobalOp.getResult(), bufferValueToFlatbuffer, 0);
       } else if (auto funcOp = dyn_cast_if_present<func::FuncOp>(op); funcOp) {
         // Unqualified walk will visit the root op itself last, we should ignore
         // this.

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -568,12 +568,16 @@ static std::shared_ptr<void> translateModuleToFlatbuffer(
             auto vector = fbb.EndVector(initial_value_attr.getNumElements());
 
             cqBuilder.appendCommand(
-                target::metal::CreateGetGlobalCommand(
+                target::metal::CreateHostAllocCommand(
                     fbb,
                     cache.getOrCreate(globalResult, bufferValueToFlatbuffer, 0),
                     vector),
                 op);
+          } else {
+            assert(false);
           }
+        } else {
+          assert(false);
         }
       } else if (auto funcOp = dyn_cast_if_present<func::FuncOp>(op); funcOp) {
         // Unqualified walk will visit the root op itself last, we should

--- a/runtime/lib/ttmetal/executor.cpp
+++ b/runtime/lib/ttmetal/executor.cpp
@@ -202,6 +202,11 @@ void CQExecutor::execute(const target::metal::HostAllocCommand *command) {
     LOG_FATAL("HostAllocCommand: Failed to allocate host memory.");
   }
 
+  if (command->data() != nullptr) {
+    assert(command->data()->size() == size);
+    std::memcpy(data.get(), command->data()->data(), size);
+  }
+
   std::shared_ptr<MetalTensor> tensor = std::make_shared<MetalTensor>(desc);
   auto [_, inserted] = hostBuffers.try_emplace(
       command->dst()->global_id(), static_pointer_cast<void>(tensor), data,


### PR DESCRIPTION
### Ticket
Closes #3022 

### Problem description
`ttir.constant` is lowered to `memref.global`/`memref.get_global`. It needs to be further lowered to TTMetal command to allocate the memory and load its content from `ttm` Flatbuffers.

### What's changed
- Extend `HostAllocCommand` with `data` field containing constant bytes
- Emit `HostAllocCommand` for `memref.get_global`
