### PR TITLE
Add unique locs pass

### DIFF
--- a/include/ttmlir/Conversion/TTIRToTTNN/Utils.h
+++ b/include/ttmlir/Conversion/TTIRToTTNN/Utils.h
@@ -16,7 +16,7 @@ mlir::tt::ttnn::ReshapeOp
 generateReshape(mlir::TypedValue<mlir::RankedTensorType> input,
                 llvm::ArrayRef<int64_t> newShape,
                 mlir::PatternRewriter &rewriter,
-                llvm::StringRef locSuffix = "");
+                llvm::StringRef locSuffix = "_reshape");
 
 // Generates a reshape operation for the given input tensor that returns 4D
 // tensor. Assumes that the input tensor is 4D. First 3 dimensions are flattened
@@ -24,7 +24,7 @@ generateReshape(mlir::TypedValue<mlir::RankedTensorType> input,
 mlir::tt::ttnn::ReshapeOp
 generateNHWFlatten(mlir::TypedValue<mlir::RankedTensorType> input,
                    mlir::PatternRewriter &rewriter,
-                   llvm::StringRef locSuffix = "");
+                   llvm::StringRef locSuffix = "_flatten");
 
 } // namespace mlir::tt::ttir_to_ttnn::utils
 

--- a/include/ttmlir/Dialect/TTIR/Utils/Utils.h
+++ b/include/ttmlir/Dialect/TTIR/Utils/Utils.h
@@ -10,6 +10,7 @@
 
 #include "mlir/IR/AffineMap.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Location.h"
 #include "llvm/ADT/STLForwardCompat.h"
 #include "llvm/ADT/SmallVector.h"
 

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -24,6 +24,15 @@ struct TTIRToTTNNBackendPipelineOptions
       llvm::cl::desc("Determine and set max valid grid for Op execution."),
       llvm::cl::init(false)};
 
+  // If this option is true, run a pass that checks if all ops relevant
+  // to the optimizer (e.g. toLayout is ignored) have unique named locations.
+  // If not, it will emit an error. This is necessary for the overrides to be
+  // applied correctly.
+  Option<bool> checkUniqueLocations{
+      *this, "check-unique-locs",
+      llvm::cl::desc("Check if all operations have unique locations."),
+      llvm::cl::init(false)};
+
   // Option to manually insert TTNN_ToLayoutOp for specific op's operand.
   // The format is a comma separated list of op names and operand index
   // separated by ':' separator.

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -184,4 +184,10 @@ def TTNNTraceHoistTransform : Pass<"ttnn-trace-hoist-transform", "::mlir::Module
   }];
 }
 
+def TTNNUniqueLocations: Pass<"ttnn-unique-locations", "::mlir::ModuleOp">
+{
+  let summary = "Check if operations have unique locations.";
+  let description = "This pass checks if all operations relevant to the optimizer have unique locations. If not, it will emit an error. This is necessary for the overrides to be applied correctly.";
+}
+
 #endif

--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceOpsRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceOpsRewritePattern.h
@@ -7,6 +7,7 @@
 
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+#include "ttmlir/Utils.h"
 
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -152,8 +153,8 @@ public:
     auto resultType = RankedTensorType::get(
         newShape, inputType.getElementType(), inputType.getEncoding());
     auto padOp = rewriter.create<mlir::tt::ttnn::PadOp>(
-        srcOp.getLoc(), resultType, srcOp.getInput(),
-        rewriter.getDenseI32ArrayAttr(paddingArray),
+        ttmlir::utils::appendLocationSuffix(srcOp.getLoc(), "_pad"), resultType,
+        srcOp.getInput(), rewriter.getDenseI32ArrayAttr(paddingArray),
         rewriter.getFloatAttr(rewriter.getF32Type(), getPaddingValue()),
         /*use_multicore=*/rewriter.getBoolAttr(true),
         /*memory_config=*/nullptr);

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -1252,7 +1252,8 @@ public:
       // addOp(lhs, negOp(rhs))
     } else {
       ttnn::NegOp negOp = rewriter.create<ttnn::NegOp>(
-          srcOp.getLoc(), adaptor.getRhs().getType(), adaptor.getRhs());
+          ttmlir::utils::appendLocationSuffix(srcOp.getLoc(), "_neg"),
+          adaptor.getRhs().getType(), adaptor.getRhs());
 
       rewriter.replaceOpWithNewOp<ttnn::AddOp>(srcOp, outputType,
                                                adaptor.getLhs(), negOp);

--- a/lib/Dialect/TTIR/Transforms/EraseInverseOps/BroadcastCommutePatterns.cpp
+++ b/lib/Dialect/TTIR/Transforms/EraseInverseOps/BroadcastCommutePatterns.cpp
@@ -34,9 +34,9 @@ public:
               newBroadcastDimensions[transposeUser.getDim1()]);
 
     auto newTranspose = ttir::utils::createDPSOp<ttir::TransposeOp>(
-        rewriter, op->getLoc(), newShape, tmResultType.getElementType(),
-        tmResultType.getEncoding(), operand, transposeUser.getDim0(),
-        transposeUser.getDim1());
+        rewriter, transposeUser.getLoc(), newShape,
+        tmResultType.getElementType(), tmResultType.getEncoding(), operand,
+        transposeUser.getDim0(), transposeUser.getDim1());
 
     assert(newBroadcastDimensions.size() ==
            static_cast<size_t>(tmResultType.getRank()));
@@ -281,7 +281,7 @@ public:
                               tmResultType.getEncoding());
 
     auto newReshape = ttir::utils::createDPSOp<ttir::ReshapeOp>(
-        rewriter, op->getLoc(), newTMResultType, op.getInput(),
+        rewriter, reshapeUser.getLoc(), newTMResultType, op.getInput(),
         rewriter.getI32ArrayAttr(SmallVector<int32_t>(newReshapeShape.begin(),
                                                       newReshapeShape.end())));
 
@@ -359,8 +359,9 @@ public:
                                         permutation);
 
     auto newPermute = ttir::utils::createDPSOp<ttir::PermuteOp>(
-        rewriter, op->getLoc(), newShape, tmResultType.getElementType(),
-        tmResultType.getEncoding(), operand, permutation);
+        rewriter, permuteUser->getLoc(), newShape,
+        tmResultType.getElementType(), tmResultType.getEncoding(), operand,
+        permutation);
 
     assert(newBroadcastDimensions.size() ==
            static_cast<size_t>(tmResultType.getRank()));

--- a/lib/Dialect/TTIR/Transforms/EraseInverseOps/ElementwiseCommutePatterns.cpp
+++ b/lib/Dialect/TTIR/Transforms/EraseInverseOps/ElementwiseCommutePatterns.cpp
@@ -44,8 +44,10 @@ public:
       newTMResultTypes.push_back(
           oldTMResultType.clone(operandType.getElementType()));
 
+      mlir::Location newLoc = ttmlir::utils::appendLocationSuffix(
+          tmUser->getLoc(), "_tm" + std::to_string(operandIdx));
       auto newTM = ttir::utils::createDPSOp<TMOpType>(
-          rewriter, op->getLoc(), newTMResultTypes[operandIdx],
+          rewriter, newLoc, newTMResultTypes[operandIdx],
           op->getOperand(operandIdx), tmUser->getAttrs());
 
       newEltwiseOperands.push_back(newTM);

--- a/lib/Dialect/TTIR/Transforms/ExplicateTMs.cpp
+++ b/lib/Dialect/TTIR/Transforms/ExplicateTMs.cpp
@@ -7,6 +7,7 @@
 #include "ttmlir/Dialect/TTIR/IR/TTIRTraits.h"
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTIR/Utils/Utils.h"
+#include "ttmlir/Utils.h"
 
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
@@ -44,8 +45,9 @@ public:
 
       // Create a new reshape operation.
       auto reshapeOp = ttir::utils::createDPSOp<ttir::ReshapeOp>(
-          rewriter, op.getLoc(), newShape, operandType.getElementType(),
-          operandType.getEncoding(),
+          rewriter,
+          ttmlir::utils::appendLocationSuffix(op.getLoc(), "_reshape"),
+          newShape, operandType.getElementType(), operandType.getEncoding(),
           op->getOperand(operand->getOperandNumber()),
           rewriter.getI32ArrayAttr(llvm::to_vector_of<int32_t>(newShape)));
 
@@ -107,7 +109,9 @@ public:
 
       // Create a new broadcast operation.
       auto broadcastOp = ttir::utils::createDPSOp<ttir::BroadcastOp>(
-          rewriter, op.getLoc(), broadcastedShape, operandType.getElementType(),
+          rewriter,
+          ttmlir::utils::appendLocationSuffix(op.getLoc(), "_broadcast"),
+          broadcastedShape, operandType.getElementType(),
           operandType.getEncoding(),
           op->getOperand(operand->getOperandNumber()), broadcastDimensions);
 

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -59,6 +59,10 @@ void createTTNNPipelineTTIRPasses(
 
 void createTTNNPipelineAnalysisPasses(
     OpPassManager &pm, const TTIRToTTNNBackendPipelineOptions &options) {
+  // Add pass to check for unique operation locations if enabled
+  if (options.checkUniqueLocations) {
+    pm.addPass(mlir::tt::ttnn::createTTNNUniqueLocations());
+  }
   if (options.optimizerPassEnabled) {
     ttnn::TTNNOptimizerOptions optimizerOptions;
     optimizerOptions.insertMemReconfig = options.insertMemReconfig;

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -8,6 +8,7 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         TTNNLayout.cpp
         TTNNDecomposeLayouts.cpp
         TTNNToCpp.cpp
+        TTNNUniqueLocs.cpp
         TTNNPrepareConv2dWeightsAndBias.cpp
         TTNNFusing.cpp
         TTNNTraceHoistTransform.cpp

--- a/lib/Dialect/TTNN/Transforms/TTNNUniqueLocs.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNUniqueLocs.cpp
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
+
+#include "mlir/IR/Location.h"
+#include "mlir/IR/MLIRContext.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace mlir::tt::ttnn {
+
+#define GEN_PASS_DEF_TTNNUNIQUELOCATIONS
+#include "ttmlir/Dialect/TTNN/Transforms/Passes.h.inc"
+
+namespace {
+
+class TTNNUniqueLocations
+    : public impl::TTNNUniqueLocationsBase<TTNNUniqueLocations> {
+
+public:
+  TTNNUniqueLocations() = default;
+
+  // Check if all operations have unique locations.
+  void runOnOperation() override {
+    ModuleOp moduleOp = getOperation();
+    llvm::StringMap<Operation *> locationMap;
+    bool hasNonUniqueLocations = false;
+
+    moduleOp.walk([&](Operation *op) {
+      if (op->getNumResults() == 0) {
+        return;
+      }
+      if (!isa<RankedTensorType>(op->getResult(0).getType())) {
+        return;
+      }
+
+      if (not isa<NameLoc>(op->getLoc())) {
+        return;
+      }
+
+      if (mlir::isa<ToLayoutOp>(op)) {
+        return;
+      }
+
+      llvm::StringRef locStr = mlir::cast<NameLoc>(op->getLoc()).getName();
+      auto it = locationMap.find(locStr);
+      if (!locationMap.try_emplace(locStr, op).second) {
+        hasNonUniqueLocations = true;
+
+        op->emitError() << "Operation '" << op->getName()
+                        << "' has a non-unique location: '" << locStr
+                        << "'. Previously seen in operation '"
+                        << it->second->getName() << "'";
+      }
+    });
+
+    if (hasNonUniqueLocations) {
+      signalPassFailure();
+    }
+  }
+};
+
+} // namespace
+
+} // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/CumSumOpRankRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/CumSumOpRankRewritePattern.cpp
@@ -32,7 +32,7 @@ CumSumOpRankRewritePattern::matchAndRewrite(ttnn::MorehCumSumOp srcOp,
   adaptedShape.append(additionalAxes, 1);
 
   ReshapeOp adaptedInput = ttir_to_ttnn::utils::generateReshape(
-      srcOp.getInput(), adaptedShape, rewriter);
+      srcOp.getInput(), adaptedShape, rewriter, "_reshapeInput");
 
   RankedTensorType outputType = srcOp.getResult().getType();
   RankedTensorType adaptedOutputType =
@@ -43,7 +43,8 @@ CumSumOpRankRewritePattern::matchAndRewrite(ttnn::MorehCumSumOp srcOp,
           /*memory_config=*/nullptr);
 
   ReshapeOp cumsumOutput = ttir_to_ttnn::utils::generateReshape(
-      adaptedCumSumOp, srcOp.getResult().getType().getShape(), rewriter);
+      adaptedCumSumOp, srcOp.getResult().getType().getShape(), rewriter,
+      "_reshapeOutput");
   rewriter.replaceOp(srcOp, cumsumOutput);
 
   return success();

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/RepeatOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/RepeatOpRewritePattern.cpp
@@ -4,6 +4,7 @@
 
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/RepeatOpRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Utils/TransformUtils.h"
+#include "ttmlir/Utils.h"
 
 #include <algorithm>
 
@@ -30,8 +31,8 @@ TTNNRepeatFoldingWorkaround::matchAndRewrite(ttnn::RepeatOp op,
 
   // Create a ZerosOp to be used with AddOp
   ttnn::ZerosOp zerosOp = rewriter.create<ttnn::ZerosOp>(
-      op->getLoc(), resultType, shapeAttr, dTypeAttr, layout, device,
-      ttnn::MemoryConfigAttr());
+      ttmlir::utils::appendLocationSuffix(op->getLoc(), "_zeros"), resultType,
+      shapeAttr, dTypeAttr, layout, device, ttnn::MemoryConfigAttr());
 
   SmallVector<Value> addInputs;
   addInputs.push_back(op.getOperand());


### PR DESCRIPTION
### Ticket
Closes #3336

### Problem description
A pass should be added to `ttir-to-ttnn-backend-pipeline` to check if all ops have a unique `NameLoc`.
Op overrides (Conv2dConfig, OutputLayout, ...) are applied to ops using their `NameLoc`. If a ttir op is decomposed to multiple ttnn ops, they will initialy share the same location. This pass will enforce adding a suffix to locs of newly generated ttnn ops, so that the overrides are applied only to the targeted op.

E.g. `ttir.conv2d` generates `ttnn.prepare_conv2d_weights`, `ttnn.covn2d` and `ttnn.reshape`. Only `ttnn.conv2d` should have the same location (and overrides) as `ttir.conv2d`, while the locs of other ops should have an appropriate suffix added.

### What's changed
Added a new pass called `TTNNUniqueLocations` to check if name locations of ttnn ops are unique. If the condition is not met, it will emit errors for all ops that have non-unique name locs and signal pass failure.
Pass is enabled by default.

Added suffix to generated ops.