### PR TITLE
bugfix const-eval loadcached op for getOutputCallback

### DIFF
--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -830,6 +830,7 @@ std::string getOpLocInfo(OpContext opContextHandle) {
     tensorRef = opContext.type_as_UpdateCacheOp()->cache();
     break;
   }
+  case ::tt::target::ttnn::OpType::LoadCacheOp:
   case ::tt::target::ttnn::OpType::GetDeviceOp:
   case ::tt::target::ttnn::OpType::DeallocateOp: {
     LOG_WARNING("getting output tensor is not supported for ",

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -830,7 +830,7 @@ std::string getOpLocInfo(OpContext opContextHandle) {
     tensorRef = opContext.type_as_UpdateCacheOp()->cache();
     break;
   }
-  case ::tt::target::ttnn::OpType::LoadCacheOp:
+  case ::tt::target::ttnn::OpType::LoadCachedOp:
   case ::tt::target::ttnn::OpType::GetDeviceOp:
   case ::tt::target::ttnn::OpType::DeallocateOp: {
     LOG_WARNING("getting output tensor is not supported for ",


### PR DESCRIPTION
### Ticket
NA

### Problem description
LoadCached op is missing from `getOpOutputTensor` callbacks.

### What's changed
Add LoadCachedOp to set of ops which aren't supported (because it returns arbitrary number of tensors, and this callback expects an op to return a single tensor).

### Checklist
- [ ] New/Existing tests provide coverage for changes
