### PR TITLE
Adding and calling ttrt.runtime API device.dump_device_profile_results()

### DIFF
--- a/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
@@ -77,6 +77,8 @@ void deallocateBuffers(Device device);
 
 void dumpMemoryReport(Device device);
 
+void dumpDeviceProfileResults(Device device);
+
 std::unordered_map<tt::runtime::MemoryBufferType, tt::runtime::MemoryView>
 getMemoryView(Device device, int deviceID = 0);
 

--- a/runtime/include/tt/runtime/detail/ttnn/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn/ttnn.h
@@ -142,6 +142,8 @@ void deallocateBuffers(Device device);
 
 void dumpMemoryReport(Device device);
 
+void dumpDeviceProfileResults(Device device);
+
 std::unordered_map<tt::runtime::MemoryBufferType, tt::runtime::MemoryView>
 getMemoryView(Device device, int deviceID = 0);
 

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -22,6 +22,7 @@ std::pair<SystemDesc, DeviceIds> getCurrentSystemDesc(
 namespace detail {
 void deallocateBuffers(Device device);
 void dumpMemoryReport(Device device);
+void dumpDeviceProfileResults(Device device);
 
 /*
 This function get the memory view per device

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -44,6 +44,21 @@ void deallocateBuffers(Device device) {
   LOG_FATAL("runtime is not enabled");
 }
 
+void dumpDeviceProfileResults(Device device) {
+#if defined(TT_RUNTIME_ENABLE_TTNN)
+  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
+    return ::tt::runtime::ttnn::dumpDeviceProfileResults(device);
+  }
+#endif
+
+#if defined(TT_RUNTIME_ENABLE_TTMETAL)
+  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
+    return ::tt::runtime::ttmetal::dumpDeviceProfileResults(device);
+  }
+#endif
+  LOG_FATAL("runtime is not enabled");
+}
+
 void dumpMemoryReport(Device device) {
 #if defined(TT_RUNTIME_ENABLE_TTNN)
   if (getCurrentRuntime() == DeviceRuntime::TTNN) {

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -196,6 +196,23 @@ void deallocateBuffers(Device deviceHandle) {
   }
 }
 
+void dumpDeviceProfileResults(Device deviceHandle) {
+  tt_metal::distributed::MeshDevice &metalMeshDevice =
+      deviceHandle.as<tt_metal::distributed::MeshDevice>(
+          DeviceRuntime::TTMetal);
+
+  LOG_ASSERT(metalMeshDevice.is_parent_mesh(),
+             "Mesh device must be a parent mesh");
+
+#if defined(TT_RUNTIME_ENABLE_PERF_TRACE)
+  for (auto *metalDevice : metalMeshDevice.get_devices()) {
+    std::cout << "Dumping profile results for device " << metalDevice
+              << std::endl;
+    ::tt::tt_metal::detail::DumpDeviceProfileResults(metalDevice);
+  }
+#endif
+}
+
 void dumpMemoryReport(Device deviceHandle) {
   tt_metal::distributed::MeshDevice &meshDevice =
       deviceHandle.as<tt_metal::distributed::MeshDevice>(

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -206,8 +206,6 @@ void dumpDeviceProfileResults(Device deviceHandle) {
 
 #if defined(TT_RUNTIME_ENABLE_PERF_TRACE)
   for (auto *metalDevice : metalMeshDevice.get_devices()) {
-    std::cout << "Dumping profile results for device " << metalDevice
-              << std::endl;
     ::tt::tt_metal::detail::DumpDeviceProfileResults(metalDevice);
   }
 #endif

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -154,7 +154,7 @@ void ProgramExecutor::dumpPerfCountersIfNeeded(::ttnn::MeshDevice &meshDevice) {
   static uint32_t counter = 0;
   if (counter++ >= debug::PerfEnv::get().dumpDeviceRate) {
     LOG_DEBUG(LogType::LogRuntimeTTNN, "Dumping device profile results after " +
-                                           std::to_string(counter) +
+                                           std::to_string(counter - 1) +
                                            " operations");
     for (::ttnn::IDevice *ttnnDevice : meshDevice.get_devices()) {
       ::tt::tt_metal::detail::DumpDeviceProfileResults(ttnnDevice);

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -454,9 +454,19 @@ void deallocateBuffers(Device deviceHandle) {
 }
 
 void dumpMemoryReport(Device deviceHandle) {
-  const ::ttnn::MeshDevice &meshDevice =
+  ::ttnn::MeshDevice &meshDevice =
       deviceHandle.as<::ttnn::MeshDevice>(DeviceRuntime::TTNN);
   ::tt::tt_metal::detail::DumpDeviceMemoryState(&meshDevice);
+}
+
+void dumpDeviceProfileResults(Device deviceHandle) {
+#if defined(TT_RUNTIME_ENABLE_PERF_TRACE)
+  ::ttnn::MeshDevice &ttnnMeshDevice =
+      deviceHandle.as<::ttnn::MeshDevice>(DeviceRuntime::TTNN);
+  for (::ttnn::IDevice *ttnnDevice : ttnnMeshDevice.get_devices()) {
+    ::tt::tt_metal::detail::DumpDeviceProfileResults(ttnnDevice);
+  }
+#endif
 }
 
 std::unordered_map<tt::runtime::MemoryBufferType, tt::runtime::MemoryView>

--- a/runtime/tools/ttrt/ttrt/common/run.py
+++ b/runtime/tools/ttrt/ttrt/common/run.py
@@ -851,6 +851,9 @@ class Run:
                         for tensor in program.output_tensors:
                             self.logging.debug(f"{tensor}\n")
 
+                        # Dump the perf data before deallocating buffers
+                        device.dump_device_profile_results()
+
                         device.deallocate_buffers()
 
                         # if golden comparison is enabled, check golden results json file to see if test passed

--- a/runtime/tools/ttrt/ttrt/runtime/module.cpp
+++ b/runtime/tools/ttrt/ttrt/runtime/module.cpp
@@ -36,6 +36,8 @@ PYBIND11_MODULE(_C, m) {
   py::class_<tt::runtime::Device>(m, "Device")
       .def("deallocate_buffers", &tt::runtime::detail::deallocateBuffers)
       .def("dump_memory_report", &tt::runtime::detail::dumpMemoryReport)
+      .def("dump_device_profile_results",
+           &tt::runtime::detail::dumpDeviceProfileResults)
       .def("get_memory_view", &tt::runtime::detail::getMemoryView,
            py::arg("device_id") = 0);
   py::class_<tt::runtime::Event>(m, "Event");


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/2752#issuecomment-2879595194)

### Problem description
Llama device perf is failing ttrt.
Device buffers get deallocated and MeshDevices get reshaped between programs. This was interfering with data that had not yet been dumped from device.

### What's changed
Wrote and pybinded a ttrt function `device.dump_device_profile_results()` and called it in `run.py` just before buffers get deallocated at the end of each program run. 

### Checklist
- [ ] New/Existing tests provide coverage for changes
