### PR TITLE
Update runtime function dispatch with new flow, add trace region param, add device query APIs and tests

### DIFF
--- a/runtime/include/tt/runtime/detail/common.h
+++ b/runtime/include/tt/runtime/detail/common.h
@@ -72,5 +72,20 @@ inline ::tt::DataFormat toDataFormat(::tt::target::DataType dataType) {
   }
 }
 
+inline ::tt::runtime::Arch toRuntimeArch(::tt::ARCH arch) {
+  switch (arch) {
+  case ::tt::ARCH::GRAYSKULL:
+    return ::tt::runtime::Arch::GRAYSKULL;
+  case ::tt::ARCH::WORMHOLE_B0:
+    return ::tt::runtime::Arch::WORMHOLE_B0;
+  case ::tt::ARCH::BLACKHOLE:
+    return ::tt::runtime::Arch::BLACKHOLE;
+  case ::tt::ARCH::QUASAR:
+    return ::tt::runtime::Arch::QUASAR;
+  default:
+    LOG_FATAL("Unsupported device architecture");
+  }
+}
+
 } // namespace tt::runtime::common
 #endif // TT_RUNTIME_DETAIL_COMMON_H

--- a/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
@@ -8,9 +8,11 @@
 #define FMT_HEADER_ONLY
 #include "tt-metalium/circular_buffer.hpp"
 #include "tt-metalium/event.hpp"
+#include "tt-metalium/hal.hpp"
 #include "tt-metalium/host_api.hpp"
 #include "tt-metalium/memory_reporter.hpp"
 #include "tt-metalium/mesh_device.hpp"
+#include "tt-metalium/program_cache.hpp"
 #include "tt-metalium/tt_metal.hpp"
 
 #include "tt/runtime/types.h"
@@ -56,6 +58,8 @@ TensorDesc getTensorDesc(::tt::runtime::Tensor tensor);
 bool getTensorRetain(Tensor tensor);
 void setTensorRetain(Tensor tensor, bool retain);
 
+Arch getArch();
+
 size_t getNumAvailableDevices();
 
 Device openMeshDevice(const std::vector<uint32_t> &meshShape,
@@ -72,6 +76,13 @@ void releaseSubMeshDevice(Device subMesh);
 
 void reshapeMeshDevice(Device meshDevice,
                        const std::vector<uint32_t> &meshShape);
+
+std::vector<uint32_t> getMeshShape(Device meshDevice);
+std::vector<int> getDeviceIds(Device meshDevice);
+size_t getNumHwCqs(Device meshDevice);
+bool isProgramCacheEnabled(Device meshDevice);
+size_t getL1SmallSize(Device meshDevice);
+size_t getTraceRegionSize(Device meshDevice);
 
 void deallocateBuffers(Device device);
 

--- a/runtime/include/tt/runtime/detail/ttnn/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn/ttnn.h
@@ -7,10 +7,12 @@
 
 #define FMT_HEADER_ONLY
 #include "hostdevcommon/common_values.hpp"
+#include "tt-metalium/hal.hpp"
 #include "tt-metalium/host_api.hpp"
 #include "tt-metalium/host_buffer.hpp"
 #include "tt-metalium/memory_reporter.hpp"
 #include "tt-metalium/mesh_device.hpp"
+#include "tt-metalium/program_cache.hpp"
 #include "ttnn/device.hpp"
 #include "ttnn/operations/ccl/all_gather/all_gather.hpp"
 #include "ttnn/operations/conv/conv2d/conv2d.hpp"
@@ -121,6 +123,8 @@ TensorDesc getTensorDesc(::tt::runtime::Tensor tensor);
 bool getTensorRetain(::tt::runtime::Tensor tensor);
 void setTensorRetain(::tt::runtime::Tensor tensor, bool retain);
 
+Arch getArch();
+
 size_t getNumAvailableDevices();
 
 Device openMeshDevice(const std::vector<uint32_t> &meshShape,
@@ -137,6 +141,14 @@ void releaseSubMeshDevice(Device subMesh);
 
 void reshapeMeshDevice(Device meshDevice,
                        const std::vector<uint32_t> &meshShape);
+
+std::vector<uint32_t> getMeshShape(Device meshDevice);
+std::vector<uint32_t> getMeshOffset(Device meshDevice);
+std::vector<int> getDeviceIds(Device meshDevice);
+size_t getNumHwCqs(Device meshDevice);
+bool isProgramCacheEnabled(Device meshDevice);
+size_t getL1SmallSize(Device meshDevice);
+size_t getTraceRegionSize(Device meshDevice);
 
 void deallocateBuffers(Device device);
 

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -37,9 +37,9 @@ getMemoryView(Device device, int deviceID = 0);
 
 } // namespace detail
 
-DeviceRuntime getCurrentRuntime();
-
 std::vector<DeviceRuntime> getAvailableRuntimes();
+
+DeviceRuntime getCurrentRuntime();
 
 void setCurrentRuntime(const DeviceRuntime &runtime);
 
@@ -131,6 +131,8 @@ TensorDesc getTensorDesc(Tensor tensor);
 bool getTensorRetain(Tensor tensor);
 void setTensorRetain(Tensor tensor, bool retain);
 
+Arch getArch();
+
 size_t getNumAvailableDevices();
 
 Device openMeshDevice(const std::vector<uint32_t> &meshShape,
@@ -147,6 +149,13 @@ void releaseSubMeshDevice(Device subMesh);
 
 void reshapeMeshDevice(Device meshDevice,
                        const std::vector<uint32_t> &meshShape);
+
+std::vector<uint32_t> getMeshShape(Device meshDevice);
+std::vector<int> getDeviceIds(Device meshDevice);
+size_t getNumHwCqs(Device meshDevice);
+bool isProgramCacheEnabled(Device meshDevice);
+size_t getL1SmallSize(Device meshDevice);
+size_t getTraceRegionSize(Device meshDevice);
 
 void wait(Event event);
 

--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -42,10 +42,23 @@ enum class DeviceRuntime {
   TTMetal,
 };
 
+inline std::string toString(DeviceRuntime runtime) {
+  switch (runtime) {
+  case DeviceRuntime::TTNN:
+    return "TTNN";
+  case DeviceRuntime::TTMetal:
+    return "TTMetal";
+  case DeviceRuntime::Disabled:
+    return "Disabled";
+  }
+}
+
 enum class DispatchCoreType {
   WORKER,
   ETH,
 };
+
+enum class Arch { GRAYSKULL = 1, WORMHOLE_B0 = 2, BLACKHOLE = 3, QUASAR = 4 };
 
 namespace detail {
 struct ObjectImpl {
@@ -135,6 +148,7 @@ struct MeshDeviceOptions {
   size_t numHWCQs = 1;
   bool enableProgramCache = false;
   std::optional<size_t> l1SmallSize = std::nullopt;
+  std::optional<size_t> traceRegionSize = std::nullopt;
   std::optional<DispatchCoreType> dispatchCoreType = std::nullopt;
 };
 

--- a/runtime/lib/common/system_desc.cpp
+++ b/runtime/lib/common/system_desc.cpp
@@ -181,17 +181,14 @@ static std::unique_ptr<::tt::runtime::SystemDesc> getCurrentSystemDescImpl(
   ::flatbuffers::FlatBufferBuilder fbb;
 
   std::uint32_t pcieAlignment = ::tt::tt_metal::hal::get_pcie_alignment();
+  std::uint32_t l1Alignment = ::tt::tt_metal::hal::get_l1_alignment();
+  std::uint32_t dramAlignment = ::tt::tt_metal::hal::get_dram_alignment();
 
   for (const ::tt::tt_metal::IDevice *device : devices) {
     size_t l1UnreservedBase =
         device->allocator()->get_base_allocator_addr(HalMemType::L1);
     size_t dramUnreservedBase =
         device->allocator()->get_base_allocator_addr(HalMemType::DRAM);
-    std::uint32_t l1Alignment =
-        device->allocator()->get_alignment(BufferType::L1);
-    std::uint32_t dramAlignment =
-        device->allocator()->get_alignment(BufferType::DRAM);
-
     // Construct chip descriptor
     ::tt::target::Dim2d deviceGrid =
         toFlatbuffer(device->compute_with_storage_grid_size());

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -7,117 +7,153 @@
 #include "tt/runtime/utils.h"
 #include "ttmlir/Target/TTNN/Target.h"
 #include "ttmlir/Version.h"
+#include <atomic>
 
-#if defined(TT_RUNTIME_ENABLE_TTNN)
+#if defined(TT_RUNTIME_ENABLE_TTNN) && (TT_RUNTIME_ENABLE_TTNN == 1)
 #include "tt/runtime/detail/ttnn/ttnn.h"
 #endif
 
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
+#if defined(TT_RUNTIME_ENABLE_TTMETAL) && (TT_RUNTIME_ENABLE_TTMETAL == 1)
 #include "tt/runtime/detail/ttmetal/ttmetal.h"
 #endif
 
-namespace tt::runtime {
-
-namespace detail {
-// NOLINTBEGIN
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-DeviceRuntime globalCurrentRuntime = DeviceRuntime::TTNN;
-#elif defined(TT_RUNTIME_ENABLE_TTMETAL)
-DeviceRuntime globalCurrentRuntime = DeviceRuntime::TTMetal;
+#if defined(TT_RUNTIME_ENABLE_TTNN) && (TT_RUNTIME_ENABLE_TTNN == 1)
+#define IF_TTNN_ENABLED(code) code
 #else
-DeviceRuntime globalCurrentRuntime = DeviceRuntime::Disabled;
+#define IF_TTNN_ENABLED(code)
 #endif
-// NOLINTEND
+
+#if defined(TT_RUNTIME_ENABLE_TTMETAL) && (TT_RUNTIME_ENABLE_TTMETAL == 1)
+#define IF_TTMETAL_ENABLED(code) code
+#else
+#define IF_TTMETAL_ENABLED(code)
+#endif
+
+// This macro dispatches function calls to the current runtime implementation.
+// An explicit retType is required because with auto deduction (-> auto),
+// the compiler can't determine if the lambda should return the expected type
+// or void in the default branch, causing compilation errors. Since ttnnImpl
+// and/or ttmetalImpl may not exist, inferring return type from these functions
+// is also not feasible, this is also why a macro is used over a templated
+// approach.
+#define DISPATCH_TO_CURRENT_RUNTIME(retType, ttnnImpl, ttmetalImpl)            \
+  [&]() -> retType {                                                           \
+    IF_TTNN_ENABLED(                                                           \
+        static_assert(std::is_invocable_v<decltype((ttnnImpl))>,               \
+                      "TTNN implementation must be invocable");                \
+        static_assert(                                                         \
+            std::is_same_v<retType,                                            \
+                           std::invoke_result_t<decltype((ttnnImpl))>>,        \
+            "Return type must match TTNN implementation return type");)        \
+    IF_TTMETAL_ENABLED(                                                        \
+        static_assert(std::is_invocable_v<decltype((ttmetalImpl))>,            \
+                      "TTMetal implementation must be invocable");             \
+        static_assert(                                                         \
+            std::is_same_v<retType,                                            \
+                           std::invoke_result_t<decltype((ttmetalImpl))>>,     \
+            "Return type must match TTMetal implementation return type");)     \
+    switch (::tt::runtime::getCurrentRuntime()) {                              \
+      IF_TTNN_ENABLED(case ::tt::runtime::DeviceRuntime::TTNN                  \
+                      : { return (ttnnImpl)(); })                              \
+      IF_TTMETAL_ENABLED(case ::tt::runtime::DeviceRuntime::TTMetal            \
+                         : { return (ttmetalImpl)(); })                        \
+    default: {                                                                 \
+      LOG_FATAL("Runtime is not enabled");                                     \
+    }                                                                          \
+    }                                                                          \
+  }()
+
+namespace tt::runtime {
+namespace detail {
+static std::atomic<DeviceRuntime> &currentRuntime() {
+#if defined(TT_RUNTIME_ENABLE_TTNN) && (TT_RUNTIME_ENABLE_TTNN == 1)
+  static std::atomic<DeviceRuntime> globalRuntime = DeviceRuntime::TTNN;
+#elif defined(TT_RUNTIME_ENABLE_TTMETAL) && (TT_RUNTIME_ENABLE_TTMETAL == 1)
+  static std::atomic<DeviceRuntime> globalRuntime = DeviceRuntime::TTMetal;
+#else
+  static std::atomic<DeviceRuntime> globalRuntime = DeviceRuntime::Disabled;
+#endif
+  return globalRuntime;
+}
+
+[[noreturn, maybe_unused]] static void
+fatalNotImplemented(const std::string &funcName, DeviceRuntime runtime) {
+  std::string message = "Function " + funcName + " is not implemented for " +
+                        toString(runtime) + " runtime";
+  LOG_FATAL(message);
+}
 
 void deallocateBuffers(Device device) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::deallocateBuffers(device);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::deallocateBuffers(device);
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+  using RetType = void;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType, [&]() { ::tt::runtime::ttnn::deallocateBuffers(device); },
+      [&]() { ::tt::runtime::ttmetal::deallocateBuffers(device); });
 }
 
 void dumpMemoryReport(Device device) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::dumpMemoryReport(device);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::dumpMemoryReport(device);
-  }
-#endif
-
-  LOG_FATAL("runtime is not enabled");
+  using RetType = void;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType, [&]() { ::tt::runtime::ttnn::dumpMemoryReport(device); },
+      [&]() { ::tt::runtime::ttmetal::dumpMemoryReport(device); });
 }
 
-std::unordered_map<tt::runtime::MemoryBufferType, tt::runtime::MemoryView>
-getMemoryView(Device device, int deviceID) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::getMemoryView(device, deviceID);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::getMemoryView(device, deviceID);
-  }
-#endif
-
-  LOG_FATAL("runtime is not enabled");
+using MemoryViewResult = std::unordered_map<::tt::runtime::MemoryBufferType,
+                                            ::tt::runtime::MemoryView>;
+MemoryViewResult getMemoryView(Device device, int deviceID) {
+  using RetType = MemoryViewResult;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::ttnn::getMemoryView(device, deviceID);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::getMemoryView(device, deviceID);
+      });
 }
 } // namespace detail
 
-DeviceRuntime getCurrentRuntime() {
-#if !defined(TT_RUNTIME_ENABLE_TTNN)
-  LOG_ASSERT(detail::globalCurrentRuntime != DeviceRuntime::TTNN);
-#endif
-#if !defined(TT_RUNTIME_ENABLE_TTMETAL)
-  LOG_ASSERT(detail::globalCurrentRuntime != DeviceRuntime::TTMetal);
-#endif
-  return detail::globalCurrentRuntime;
-}
-
 std::vector<DeviceRuntime> getAvailableRuntimes() {
   std::vector<DeviceRuntime> runtimes;
-#if defined(TT_RUNTIME_ENABLE_TTNN)
+#if defined(TT_RUNTIME_ENABLE_TTNN) && (TT_RUNTIME_ENABLE_TTNN == 1)
   runtimes.push_back(DeviceRuntime::TTNN);
 #endif
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
+#if defined(TT_RUNTIME_ENABLE_TTMETAL) && (TT_RUNTIME_ENABLE_TTMETAL == 1)
   runtimes.push_back(DeviceRuntime::TTMetal);
 #endif
   return runtimes;
 }
 
-void setCurrentRuntime(const DeviceRuntime &runtime) {
-#if !defined(TT_RUNTIME_ENABLE_TTNN)
+DeviceRuntime getCurrentRuntime() {
+  DeviceRuntime runtime =
+      detail::currentRuntime().load(std::memory_order_relaxed);
+#if !defined(TT_RUNTIME_ENABLE_TTNN) || (TT_RUNTIME_ENABLE_TTNN == 0)
   LOG_ASSERT(runtime != DeviceRuntime::TTNN);
 #endif
-#if !defined(TT_RUNTIME_ENABLE_TTMETAL)
+#if !defined(TT_RUNTIME_ENABLE_TTMETAL) || (TT_RUNTIME_ENABLE_TTMETAL == 0)
   LOG_ASSERT(runtime != DeviceRuntime::TTMetal);
 #endif
-  detail::globalCurrentRuntime = runtime;
+  return runtime;
+}
+
+void setCurrentRuntime(const DeviceRuntime &runtime) {
+#if !defined(TT_RUNTIME_ENABLE_TTNN) || (TT_RUNTIME_ENABLE_TTNN == 0)
+  LOG_ASSERT(runtime != DeviceRuntime::TTNN);
+#endif
+#if !defined(TT_RUNTIME_ENABLE_TTMETAL) || (TT_RUNTIME_ENABLE_TTMETAL == 0)
+  LOG_ASSERT(runtime != DeviceRuntime::TTMetal);
+#endif
+  detail::currentRuntime().store(runtime, std::memory_order_relaxed);
 }
 
 void setCompatibleRuntime(const Binary &binary) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
+#if defined(TT_RUNTIME_ENABLE_TTNN) && (TT_RUNTIME_ENABLE_TTNN == 1)
   if (binary.getFileIdentifier() ==
       ::tt::target::ttnn::TTNNBinaryIdentifier()) {
     return setCurrentRuntime(DeviceRuntime::TTNN);
   }
 #endif
 
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
+#if defined(TT_RUNTIME_ENABLE_TTMETAL) && (TT_RUNTIME_ENABLE_TTMETAL == 1)
   if (binary.getFileIdentifier() ==
       ::tt::target::metal::TTMetalBinaryIdentifier()) {
     return setCurrentRuntime(DeviceRuntime::TTMetal);
@@ -129,7 +165,8 @@ void setCompatibleRuntime(const Binary &binary) {
 std::pair<SystemDesc, DeviceIds>
 getCurrentSystemDesc(std::optional<DispatchCoreType> dispatchCoreType,
                      std::optional<Device> meshDevice) {
-#if defined(TT_RUNTIME_ENABLE_TTNN) || defined(TT_RUNTIME_ENABLE_TTMETAL)
+#if (defined(TT_RUNTIME_ENABLE_TTNN) && (TT_RUNTIME_ENABLE_TTNN == 1)) ||      \
+    (defined(TT_RUNTIME_ENABLE_TTMETAL) && (TT_RUNTIME_ENABLE_TTMETAL == 1))
   return system_desc::getCurrentSystemDesc(dispatchCoreType, meshDevice);
 #endif
   LOG_FATAL("runtime is not enabled");
@@ -140,23 +177,20 @@ Tensor createBorrowedHostTensor(void *data,
                                 const std::vector<std::uint32_t> &stride,
                                 std::uint32_t itemsize,
                                 ::tt::target::DataType dataType) {
+  using RetType = Tensor;
   LOG_ASSERT(!shape.empty());
   LOG_ASSERT(!stride.empty());
   LOG_ASSERT(itemsize > 0);
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::createBorrowedHostTensor(data, shape, stride,
-                                                         itemsize, dataType);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::createBorrowedHostTensor(
-        data, TensorDesc(shape, stride, itemsize, dataType));
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::ttnn::createBorrowedHostTensor(
+            data, shape, stride, itemsize, dataType);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::createBorrowedHostTensor(
+            data, TensorDesc(shape, stride, itemsize, dataType));
+      });
 }
 
 Tensor createOwnedHostTensor(const void *data,
@@ -164,23 +198,20 @@ Tensor createOwnedHostTensor(const void *data,
                              const std::vector<std::uint32_t> &stride,
                              std::uint32_t itemsize,
                              ::tt::target::DataType dataType) {
+  using RetType = Tensor;
   LOG_ASSERT(!shape.empty());
   LOG_ASSERT(!stride.empty());
   LOG_ASSERT(itemsize > 0);
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::createOwnedHostTensor(data, shape, stride,
-                                                      itemsize, dataType);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::createOwnedHostTensor(
-        data, TensorDesc(shape, stride, itemsize, dataType));
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::ttnn::createOwnedHostTensor(data, shape, stride,
+                                                          itemsize, dataType);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::createOwnedHostTensor(
+            data, TensorDesc(shape, stride, itemsize, dataType));
+      });
 }
 
 // TODO(mrakita): Should be deprecated but D2M path is using this, investigate
@@ -190,23 +221,20 @@ Tensor createTensor(std::shared_ptr<void> data,
                     const std::vector<std::uint32_t> &shape,
                     const std::vector<std::uint32_t> &stride,
                     std::uint32_t itemsize, ::tt::target::DataType dataType) {
+  using RetType = Tensor;
   LOG_ASSERT(!shape.empty());
   LOG_ASSERT(!stride.empty());
   LOG_ASSERT(itemsize > 0);
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::createBorrowedHostTensor(
-        data.get(), shape, stride, itemsize, dataType);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::createBorrowedHostTensor(
-        data, TensorDesc(shape, stride, itemsize, dataType));
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::ttnn::createBorrowedHostTensor(
+            data.get(), shape, stride, itemsize, dataType);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::createBorrowedHostTensor(
+            data, TensorDesc(shape, stride, itemsize, dataType));
+      });
 }
 
 Tensor createMultiDeviceHostTensor(
@@ -215,530 +243,431 @@ Tensor createMultiDeviceHostTensor(
     const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType,
     const std::unordered_map<std::string, std::string> &strategy) {
+  using RetType = Tensor;
   LOG_ASSERT(!shape.empty());
   LOG_ASSERT(!stride.empty());
   LOG_ASSERT(itemsize > 0);
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::createMultiDeviceHostTensor(
-        data, shape, stride, itemsize, dataType, strategy);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    LOG_FATAL("Not implemented");
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::ttnn::createMultiDeviceHostTensor(
+            data, shape, stride, itemsize, dataType, strategy);
+      },
+      [&]() -> RetType {
+        detail::fatalNotImplemented(__FUNCTION__, DeviceRuntime::TTMetal);
+      });
 }
 
 Tensor createMultiDeviceHostTensor(
     const std::vector<Tensor> &tensorShards,
     const std::unordered_map<std::string, std::string> &strategy) {
+  using RetType = Tensor;
   LOG_ASSERT(!tensorShards.empty());
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::createMultiDeviceHostTensor(tensorShards,
-                                                            strategy);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    LOG_FATAL("Not implemented");
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::ttnn::createMultiDeviceHostTensor(tensorShards,
+                                                                strategy);
+      },
+      [&]() -> RetType {
+        detail::fatalNotImplemented(__FUNCTION__, DeviceRuntime::TTMetal);
+      });
 }
 
 Tensor createEmptyTensor(Device device, Layout layout,
                          const std::vector<std::uint32_t> &shape,
                          const std::vector<std::uint32_t> &stride,
                          std::uint32_t itemsize) {
+  using RetType = Tensor;
   LOG_ASSERT(!shape.empty());
   LOG_ASSERT(!stride.empty());
   LOG_ASSERT(itemsize > 0);
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::createEmptyTensor(device, layout, shape, stride,
-                                                  itemsize);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    LOG_FATAL("Not implemented");
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::ttnn::createEmptyTensor(device, layout, shape,
+                                                      stride, itemsize);
+      },
+      [&]() -> RetType {
+        detail::fatalNotImplemented(__FUNCTION__, DeviceRuntime::TTMetal);
+      });
 }
 
 bool isTensorAllocated(Tensor tensor) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::isTensorAllocated(tensor);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::isTensorAllocated(tensor);
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+  using RetType = bool;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::ttnn::isTensorAllocated(tensor);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::isTensorAllocated(tensor);
+      });
 }
 
-tt::target::DataType getTensorDataType(Tensor tensor) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::getTensorDataType(tensor);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::getTensorDataType(tensor);
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+::tt::target::DataType getTensorDataType(Tensor tensor) {
+  using RetType = ::tt::target::DataType;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::ttnn::getTensorDataType(tensor);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::getTensorDataType(tensor);
+      });
 }
 
 std::vector<std::byte> getTensorDataBuffer(Tensor t) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::getTensorDataBuffer(t);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::getTensorDataBuffer(t);
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+  using RetType = std::vector<std::byte>;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType { return ::tt::runtime::ttnn::getTensorDataBuffer(t); },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::getTensorDataBuffer(t);
+      });
 }
 
 std::vector<std::uint32_t> getTensorShape(Tensor t) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::getTensorShape(t);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::getTensorShape(t);
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+  using RetType = std::vector<std::uint32_t>;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType { return ::tt::runtime::ttnn::getTensorShape(t); },
+      [&]() -> RetType { return ::tt::runtime::ttmetal::getTensorShape(t); });
 }
 
 std::vector<std::uint32_t> getTensorStride(Tensor t) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::getTensorStride(t);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::getTensorStride(t);
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
-}
-
-target::DataType getDtype(Tensor t) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::getTensorDataType(t);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::getTensorDataType(t);
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+  using RetType = std::vector<std::uint32_t>;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType { return ::tt::runtime::ttnn::getTensorStride(t); },
+      [&]() -> RetType { return ::tt::runtime::ttmetal::getTensorStride(t); });
 }
 
 std::uint32_t getTensorElementSize(Tensor t) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::getTensorElementSize(t);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::getTensorElementSize(t);
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+  using RetType = std::uint32_t;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType { return ::tt::runtime::ttnn::getTensorElementSize(t); },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::getTensorElementSize(t);
+      });
 }
 
 std::uint32_t getTensorVolume(Tensor t) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::getTensorVolume(t);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::getTensorVolume(t);
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+  using RetType = std::uint32_t;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType { return ::tt::runtime::ttnn::getTensorVolume(t); },
+      [&]() -> RetType { return ::tt::runtime::ttmetal::getTensorVolume(t); });
 }
 
 TensorDesc getTensorDesc(Tensor t) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::getTensorDesc(t);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::getTensorDesc(t);
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+  using RetType = TensorDesc;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType { return ::tt::runtime::ttnn::getTensorDesc(t); },
+      [&]() -> RetType { return ::tt::runtime::ttmetal::getTensorDesc(t); });
 }
 
 bool getTensorRetain(Tensor tensor) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::getTensorRetain(tensor);
-  }
-#endif
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::getTensorRetain(tensor);
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+  using RetType = bool;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType { return ::tt::runtime::ttnn::getTensorRetain(tensor); },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::getTensorRetain(tensor);
+      });
 }
 
 void setTensorRetain(Tensor tensor, bool retain) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::setTensorRetain(tensor, retain);
-  }
-#endif
+  using RetType = void;
+  DISPATCH_TO_CURRENT_RUNTIME(
+      RetType, [&]() { ::tt::runtime::ttnn::setTensorRetain(tensor, retain); },
+      [&]() { ::tt::runtime::ttmetal::setTensorRetain(tensor, retain); });
+}
 
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::setTensorRetain(tensor, retain);
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+Arch getArch() {
+  using RetType = Arch;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType, [&]() -> RetType { return ::tt::runtime::ttnn::getArch(); },
+      [&]() -> RetType { return ::tt::runtime::ttmetal::getArch(); });
 }
 
 size_t getNumAvailableDevices() {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::getNumAvailableDevices();
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::getNumAvailableDevices();
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+  using RetType = size_t;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::ttnn::getNumAvailableDevices();
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::getNumAvailableDevices();
+      });
 }
 
 Device openMeshDevice(const std::vector<uint32_t> &meshShape,
                       const MeshDeviceOptions &options) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::openMeshDevice(meshShape, options);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::openMeshDevice(meshShape, options);
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+  using RetType = Device;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::ttnn::openMeshDevice(meshShape, options);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::openMeshDevice(meshShape, options);
+      });
 }
 
 void closeMeshDevice(Device parentMesh) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::closeMeshDevice(parentMesh);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::closeMeshDevice(parentMesh);
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+  using RetType = void;
+  DISPATCH_TO_CURRENT_RUNTIME(
+      RetType, [&]() { ::tt::runtime::ttnn::closeMeshDevice(parentMesh); },
+      [&]() { ::tt::runtime::ttmetal::closeMeshDevice(parentMesh); });
 }
 
 Device createSubMeshDevice(
     Device parentMesh, const std::vector<uint32_t> &meshShape,
     const std::optional<const std::vector<uint32_t>> &meshOffset) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::createSubMeshDevice(parentMesh, meshShape,
-                                                    meshOffset);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::createSubMeshDevice(parentMesh, meshShape,
-                                                       meshOffset);
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+  using RetType = Device;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::ttnn::createSubMeshDevice(parentMesh, meshShape,
+                                                        meshOffset);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::createSubMeshDevice(
+            parentMesh, meshShape, meshOffset);
+      });
 }
 
 void releaseSubMeshDevice(Device subMesh) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::releaseSubMeshDevice(subMesh);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::releaseSubMeshDevice(subMesh);
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+  using RetType = void;
+  DISPATCH_TO_CURRENT_RUNTIME(
+      RetType, [&]() { ::tt::runtime::ttnn::releaseSubMeshDevice(subMesh); },
+      [&]() { ::tt::runtime::ttmetal::releaseSubMeshDevice(subMesh); });
 }
 
 void reshapeMeshDevice(Device meshDevice,
                        const std::vector<uint32_t> &meshShape) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::reshapeMeshDevice(meshDevice, meshShape);
-  }
-#endif
+  using RetType = void;
+  DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() { ::tt::runtime::ttnn::reshapeMeshDevice(meshDevice, meshShape); },
+      [&]() {
+        ::tt::runtime::ttmetal::reshapeMeshDevice(meshDevice, meshShape);
+      });
+}
 
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::reshapeMeshDevice(meshDevice, meshShape);
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+std::vector<uint32_t> getMeshShape(Device meshDevice) {
+  using RetType = std::vector<uint32_t>;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::ttnn::getMeshShape(meshDevice);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::getMeshShape(meshDevice);
+      });
+}
+
+std::vector<int> getDeviceIds(Device meshDevice) {
+  using RetType = std::vector<int>;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::ttnn::getDeviceIds(meshDevice);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::getDeviceIds(meshDevice);
+      });
+}
+
+size_t getNumHwCqs(Device meshDevice) {
+  using RetType = size_t;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType { return ::tt::runtime::ttnn::getNumHwCqs(meshDevice); },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::getNumHwCqs(meshDevice);
+      });
+}
+
+bool isProgramCacheEnabled(Device meshDevice) {
+  using RetType = bool;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::ttnn::isProgramCacheEnabled(meshDevice);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::isProgramCacheEnabled(meshDevice);
+      });
+}
+
+size_t getL1SmallSize(Device meshDevice) {
+  using RetType = size_t;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::ttnn::getL1SmallSize(meshDevice);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::getL1SmallSize(meshDevice);
+      });
+}
+
+size_t getTraceRegionSize(Device meshDevice) {
+  using RetType = size_t;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::ttnn::getTraceRegionSize(meshDevice);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::getTraceRegionSize(meshDevice);
+      });
 }
 
 void wait(Event event) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    LOG_WARNING("wait API will be deprecated for TTNN runtime.");
-    return ::tt::runtime::ttnn::wait(event);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::wait(event);
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+  using RetType = void;
+  DISPATCH_TO_CURRENT_RUNTIME(
+      RetType, [&]() { ::tt::runtime::ttnn::wait(event); },
+      [&]() { ::tt::runtime::ttmetal::wait(event); });
 }
 
 void wait(Tensor tensor) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::wait(tensor);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::wait(tensor);
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+  using RetType = void;
+  DISPATCH_TO_CURRENT_RUNTIME(
+      RetType, [&]() { ::tt::runtime::ttnn::wait(tensor); },
+      [&]() { ::tt::runtime::ttmetal::wait(tensor); });
 }
 
 void wait(const std::vector<Tensor> &tensors) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::wait(tensors);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::wait(tensors);
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+  using RetType = void;
+  DISPATCH_TO_CURRENT_RUNTIME(
+      RetType, [&]() { ::tt::runtime::ttnn::wait(tensors); },
+      [&]() { ::tt::runtime::ttmetal::wait(tensors); });
 }
 
 std::vector<Tensor> toHost(Tensor tensor, bool untilize) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::toHost(tensor, untilize);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::toHost(tensor, untilize);
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+  using RetType = std::vector<Tensor>;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::ttnn::toHost(tensor, untilize);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::toHost(tensor, untilize);
+      });
 }
 
 Tensor toLayout(Tensor tensor, Device device, Layout layout,
                 std::optional<bool> retain) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::toLayout(tensor, device, layout, retain);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::toLayout(tensor, device, layout, retain);
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+  using RetType = Tensor;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::ttnn::toLayout(tensor, device, layout, retain);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::toLayout(tensor, device, layout, retain);
+      });
 }
 
 Layout getLayout(Binary executableHandle, std::uint32_t programIndex,
                  std::uint32_t inputIndex) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::getLayout(executableHandle, programIndex,
-                                          inputIndex);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::getLayout(executableHandle, programIndex,
-                                             inputIndex);
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+  using RetType = Layout;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::ttnn::getLayout(executableHandle, programIndex,
+                                              inputIndex);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::getLayout(executableHandle, programIndex,
+                                                 inputIndex);
+      });
 }
 
 void memcpy(void *dst, Tensor src) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::memcpy(dst, src);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::memcpy(dst, src);
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+  using RetType = void;
+  DISPATCH_TO_CURRENT_RUNTIME(
+      RetType, [&]() { ::tt::runtime::ttnn::memcpy(dst, src); },
+      [&]() { ::tt::runtime::ttmetal::memcpy(dst, src); });
 }
 
 void memcpy(Tensor dst, Tensor src) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::memcpy(dst, src);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::memcpy(dst, src);
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+  using RetType = void;
+  DISPATCH_TO_CURRENT_RUNTIME(
+      RetType, [&]() { ::tt::runtime::ttnn::memcpy(dst, src); },
+      [&]() { ::tt::runtime::ttmetal::memcpy(dst, src); });
 }
 
 void deallocateTensor(Tensor &tensor, bool force) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::deallocateTensor(tensor, force);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::deallocateTensor(tensor, force);
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+  using RetType = void;
+  DISPATCH_TO_CURRENT_RUNTIME(
+      RetType, [&]() { ::tt::runtime::ttnn::deallocateTensor(tensor, force); },
+      [&]() { ::tt::runtime::ttmetal::deallocateTensor(tensor, force); });
 }
 
 std::string getOpDebugString(OpContext opContextHandle) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::getOpDebugString(opContextHandle);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::getOpDebugString(opContextHandle);
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+  using RetType = std::string;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::ttnn::getOpDebugString(opContextHandle);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::getOpDebugString(opContextHandle);
+      });
 }
 
 std::string getOpLocInfo(OpContext opContextHandle) {
-#ifdef TT_RUNTIME_ENABLE_TTNN
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::getOpLocInfo(opContextHandle);
-  }
-#endif
-
-#ifdef TT_RUNTIME_ENABLE_TTMETAL
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::getOpLocInfo(opContextHandle);
-  }
-#endif
-  throw std::runtime_error("runtime is not enabled");
+  using RetType = std::string;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::ttnn::getOpLocInfo(opContextHandle);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::getOpLocInfo(opContextHandle);
+      });
 }
 
 Tensor getOpOutputTensor(OpContext opContextHandle,
                          CallbackContext programContextHandle) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::getOpOutputTensor(opContextHandle,
-                                                  programContextHandle);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::getOpOutputTensor(opContextHandle,
-                                                     programContextHandle);
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+  using RetType = Tensor;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::ttnn::getOpOutputTensor(opContextHandle,
+                                                      programContextHandle);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::getOpOutputTensor(opContextHandle,
+                                                         programContextHandle);
+      });
 }
 
 std::vector<Tensor> submit(Device deviceHandle, Binary executableHandle,
                            std::uint32_t programIndex,
                            std::vector<Tensor> &inputs) {
-#if defined(TT_RUNTIME_ENABLE_TTNN)
-  if (getCurrentRuntime() == DeviceRuntime::TTNN) {
-    return ::tt::runtime::ttnn::submit(deviceHandle, executableHandle,
-                                       programIndex, inputs);
-  }
-#endif
-
-#if defined(TT_RUNTIME_ENABLE_TTMETAL)
-  if (getCurrentRuntime() == DeviceRuntime::TTMetal) {
-    return ::tt::runtime::ttmetal::submit(deviceHandle, executableHandle,
-                                          programIndex, inputs);
-  }
-#endif
-  LOG_FATAL("runtime is not enabled");
+  using RetType = std::vector<Tensor>;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::ttnn::submit(deviceHandle, executableHandle,
+                                           programIndex, inputs);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::submit(deviceHandle, executableHandle,
+                                              programIndex, inputs);
+      });
 }
+
+#undef IF_TTNN_ENABLED
+#undef IF_TTMETAL_ENABLED
+#undef DISPATCH_TO_CURRENT_RUNTIME
 
 } // namespace tt::runtime

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -90,6 +90,10 @@ void setTensorRetain(Tensor tensor, bool retain) {
   LOG_FATAL("setTensorRetain not implemented for metal runtime");
 }
 
+Arch getArch() {
+  return ::tt::runtime::common::toRuntimeArch(::tt::tt_metal::hal::get_arch());
+}
+
 size_t getNumAvailableDevices() { return tt_metal::GetNumAvailableDevices(); }
 
 Device openMeshDevice(const std::vector<uint32_t> &meshShape,
@@ -101,6 +105,8 @@ Device openMeshDevice(const std::vector<uint32_t> &meshShape,
   tt_metal::distributed::MeshCoordinate offset(options.meshOffset);
 
   size_t l1SmallSize = options.l1SmallSize.value_or(DEFAULT_L1_SMALL_SIZE);
+  size_t traceRegionSize =
+      options.traceRegionSize.value_or(DEFAULT_TRACE_REGION_SIZE);
   tt_metal::DispatchCoreType dispatchCoreType =
       common::getDispatchCoreType(options.dispatchCoreType);
 
@@ -109,7 +115,7 @@ Device openMeshDevice(const std::vector<uint32_t> &meshShape,
 
   std::shared_ptr<tt_metal::distributed::MeshDevice> meshDevice =
       tt_metal::distributed::MeshDevice::create(
-          meshConfig, l1SmallSize, DEFAULT_TRACE_REGION_SIZE, options.numHWCQs,
+          meshConfig, l1SmallSize, traceRegionSize, options.numHWCQs,
           dispatchCoreType);
 
   LOG_DEBUG("Device grid size = { ",
@@ -184,6 +190,50 @@ void reshapeMeshDevice(Device meshDevice,
 
   metalMeshDevice.reshape(
       ::tt::tt_metal::distributed::MeshShape(meshShape[0], meshShape[1]));
+}
+
+std::vector<uint32_t> getMeshShape(Device meshDevice) {
+  ::tt::tt_metal::distributed::MeshDevice &metalMeshDevice =
+      meshDevice.as<::tt::tt_metal::distributed::MeshDevice>(
+          DeviceRuntime::TTMetal);
+  std::vector<uint32_t> shape(metalMeshDevice.shape().view().begin(),
+                              metalMeshDevice.shape().view().end());
+  return shape;
+}
+
+std::vector<int> getDeviceIds(Device meshDevice) {
+  ::tt::tt_metal::distributed::MeshDevice &metalMeshDevice =
+      meshDevice.as<::tt::tt_metal::distributed::MeshDevice>(
+          DeviceRuntime::TTMetal);
+  return metalMeshDevice.get_device_ids();
+}
+
+size_t getNumHwCqs(Device meshDevice) {
+  ::tt::tt_metal::distributed::MeshDevice &metalMeshDevice =
+      meshDevice.as<::tt::tt_metal::distributed::MeshDevice>(
+          DeviceRuntime::TTMetal);
+  return static_cast<size_t>(metalMeshDevice.num_hw_cqs());
+}
+
+bool isProgramCacheEnabled(Device meshDevice) {
+  ::tt::tt_metal::distributed::MeshDevice &metalMeshDevice =
+      meshDevice.as<::tt::tt_metal::distributed::MeshDevice>(
+          DeviceRuntime::TTMetal);
+  return metalMeshDevice.get_program_cache().is_enabled();
+}
+
+size_t getL1SmallSize(Device meshDevice) {
+  ::tt::tt_metal::distributed::MeshDevice &metalMeshDevice =
+      meshDevice.as<::tt::tt_metal::distributed::MeshDevice>(
+          DeviceRuntime::TTMetal);
+  return metalMeshDevice.allocator()->get_config().l1_small_size;
+}
+
+size_t getTraceRegionSize(Device meshDevice) {
+  ::tt::tt_metal::distributed::MeshDevice &metalMeshDevice =
+      meshDevice.as<::tt::tt_metal::distributed::MeshDevice>(
+          DeviceRuntime::TTMetal);
+  return metalMeshDevice.allocator()->get_config().trace_region_size;
 }
 
 void deallocateBuffers(Device deviceHandle) {

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -347,6 +347,10 @@ void setTensorRetain(::tt::runtime::Tensor tensor, bool retain) {
   return tensorWrapper.setRetain(retain);
 }
 
+Arch getArch() {
+  return ::tt::runtime::common::toRuntimeArch(::tt::tt_metal::hal::get_arch());
+}
+
 size_t getNumAvailableDevices() {
   return ::tt::tt_metal::GetNumAvailableDevices();
 }
@@ -361,14 +365,16 @@ Device openMeshDevice(const std::vector<uint32_t> &meshShape,
 
   size_t l1SmallSize =
       options.l1SmallSize.value_or(::tt::constants::L1_SMALL_SIZE);
+  size_t traceRegionSize =
+      options.traceRegionSize.value_or(DEFAULT_TRACE_REGION_SIZE);
   ::tt::tt_metal::DispatchCoreType dispatchCoreTypeValue =
       tt::runtime::common::getDispatchCoreType(options.dispatchCoreType);
 
   ::ttnn::MeshDeviceConfig meshConfig(shape, offset, options.deviceIds);
 
-  std::shared_ptr<::ttnn::MeshDevice> meshDevice = ::ttnn::MeshDevice::create(
-      meshConfig, l1SmallSize, DEFAULT_TRACE_REGION_SIZE, options.numHWCQs,
-      dispatchCoreTypeValue);
+  std::shared_ptr<::ttnn::MeshDevice> meshDevice =
+      ::ttnn::MeshDevice::create(meshConfig, l1SmallSize, traceRegionSize,
+                                 options.numHWCQs, dispatchCoreTypeValue);
 
   if (options.enableProgramCache) {
     meshDevice->enable_program_cache();
@@ -445,6 +451,44 @@ void reshapeMeshDevice(Device meshDevice,
       meshDevice.as<::ttnn::MeshDevice>(DeviceRuntime::TTNN);
 
   ttnnMeshDevice.reshape(::ttnn::MeshShape(meshShape[0], meshShape[1]));
+}
+
+std::vector<uint32_t> getMeshShape(Device meshDevice) {
+  ::ttnn::MeshDevice &ttnnMeshDevice =
+      meshDevice.as<::ttnn::MeshDevice>(DeviceRuntime::TTNN);
+  std::vector<uint32_t> shape(ttnnMeshDevice.shape().view().begin(),
+                              ttnnMeshDevice.shape().view().end());
+  return shape;
+}
+
+std::vector<int> getDeviceIds(Device meshDevice) {
+  ::ttnn::MeshDevice &ttnnMeshDevice =
+      meshDevice.as<::ttnn::MeshDevice>(DeviceRuntime::TTNN);
+  return ttnnMeshDevice.get_device_ids();
+}
+
+size_t getNumHwCqs(Device meshDevice) {
+  ::ttnn::MeshDevice &ttnnMeshDevice =
+      meshDevice.as<::ttnn::MeshDevice>(DeviceRuntime::TTNN);
+  return static_cast<size_t>(ttnnMeshDevice.num_hw_cqs());
+}
+
+bool isProgramCacheEnabled(Device meshDevice) {
+  ::ttnn::MeshDevice &ttnnMeshDevice =
+      meshDevice.as<::ttnn::MeshDevice>(DeviceRuntime::TTNN);
+  return ttnnMeshDevice.get_program_cache().is_enabled();
+}
+
+size_t getL1SmallSize(Device meshDevice) {
+  ::ttnn::MeshDevice &ttnnMeshDevice =
+      meshDevice.as<::ttnn::MeshDevice>(DeviceRuntime::TTNN);
+  return ttnnMeshDevice.allocator()->get_config().l1_small_size;
+}
+
+size_t getTraceRegionSize(Device meshDevice) {
+  ::ttnn::MeshDevice &ttnnMeshDevice =
+      meshDevice.as<::ttnn::MeshDevice>(DeviceRuntime::TTNN);
+  return ttnnMeshDevice.allocator()->get_config().trace_region_size;
 }
 
 void deallocateBuffers(Device deviceHandle) {

--- a/runtime/test/python/ttnn/device_agnostic/test_runtime_api.py
+++ b/runtime/test/python/ttnn/device_agnostic/test_runtime_api.py
@@ -179,23 +179,6 @@ def test_create_tensor_memcpy(helper: Helper, shape, dtype, request):
     helper.teardown()
 
 
-def test_set_program_cache(helper):
-    num_devices = ttrt.runtime.get_num_available_devices()
-    with DeviceContext(
-        mesh_shape=[1, num_devices], enable_program_cache=False
-    ) as device:
-        assert (
-            ttrt.runtime.testing.is_program_cache_enabled(device) == False
-        ), "Expected program cache to be disabled"
-
-    with DeviceContext(
-        mesh_shape=[1, num_devices], enable_program_cache=True
-    ) as device:
-        assert (
-            ttrt.runtime.testing.is_program_cache_enabled(device) == True
-        ), "Expected program cache to be enabled"
-
-
 @pytest.mark.parametrize(
     "runtime",
     [ttrt.runtime.DeviceRuntime.TTNN, ttrt.runtime.DeviceRuntime.TTMetal],

--- a/runtime/test/python/ttnn/multi_device/test_runtime_api.py
+++ b/runtime/test/python/ttnn/multi_device/test_runtime_api.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+import pytest
+import ttrt
+import ttrt.runtime
+from ttrt.common.util import *
+
+
+@pytest.mark.parametrize(
+    "mesh_shape",
+    [[1, 1], [1, 2]],
+)
+@pytest.mark.parametrize(
+    "mesh_offset",
+    [[0, 0]],
+)
+@pytest.mark.parametrize(
+    "num_hw_cqs",
+    [1, 2],
+)
+@pytest.mark.parametrize(
+    "enable_program_cache",
+    [False, True],
+)
+@pytest.mark.parametrize(
+    "l1_small_size",
+    [0, 1024, 2048],
+)
+@pytest.mark.parametrize(
+    "trace_region_size",
+    [0, 1024, 2048],
+)
+def test_open_mesh_device(
+    helper,
+    mesh_shape,
+    mesh_offset,
+    num_hw_cqs,
+    enable_program_cache,
+    l1_small_size,
+    trace_region_size,
+):
+    num_devices = ttrt.runtime.get_num_available_devices()
+    assert num_devices == 2, f"Expected 2 devices, got {num_devices}"
+    options = ttrt.runtime.MeshDeviceOptions()
+    options.mesh_offset = mesh_offset
+    options.num_hw_cqs = num_hw_cqs
+    options.enable_program_cache = enable_program_cache
+    options.l1_small_size = l1_small_size
+    options.trace_region_size = trace_region_size
+    device = ttrt.runtime.open_mesh_device(mesh_shape, options)
+    device_ids = device.get_device_ids()
+    assert device_ids == list(range(math.prod(mesh_shape)))
+    assert device.get_mesh_shape() == mesh_shape
+    assert device.get_num_hw_cqs() == num_hw_cqs
+    assert device.is_program_cache_enabled() == enable_program_cache
+    assert device.get_l1_small_size() == l1_small_size
+    assert device.get_trace_region_size() == trace_region_size
+    ttrt.runtime.close_mesh_device(device)

--- a/runtime/tools/ttrt/ttrt/runtime/module.cpp
+++ b/runtime/tools/ttrt/ttrt/runtime/module.cpp
@@ -34,6 +34,12 @@ PYBIND11_MODULE(_C, m) {
                     &tt::runtime::MemoryView::largestContiguousBytesFreePerBank)
       .def_readonly("block_table", &tt::runtime::MemoryView::blockTable);
   py::class_<tt::runtime::Device>(m, "Device")
+      .def("get_mesh_shape", &tt::runtime::getMeshShape)
+      .def("get_device_ids", &tt::runtime::getDeviceIds)
+      .def("get_num_hw_cqs", &tt::runtime::getNumHwCqs)
+      .def("is_program_cache_enabled", &tt::runtime::isProgramCacheEnabled)
+      .def("get_l1_small_size", &tt::runtime::getL1SmallSize)
+      .def("get_trace_region_size", &tt::runtime::getTraceRegionSize)
       .def("deallocate_buffers", &tt::runtime::detail::deallocateBuffers)
       .def("dump_memory_report", &tt::runtime::detail::dumpMemoryReport)
       .def("get_memory_view", &tt::runtime::detail::getMemoryView,
@@ -61,6 +67,18 @@ PYBIND11_MODULE(_C, m) {
             o.l1SmallSize = py::none().is(value)
                                 ? std::nullopt
                                 : std::make_optional(value.cast<size_t>());
+          })
+      .def_property(
+          "trace_region_size",
+          [](const tt::runtime::MeshDeviceOptions &o) {
+            return o.traceRegionSize.has_value()
+                       ? py::cast(o.traceRegionSize.value())
+                       : py::none();
+          },
+          [](tt::runtime::MeshDeviceOptions &o, py::handle value) {
+            o.traceRegionSize = py::none().is(value)
+                                    ? std::nullopt
+                                    : std::make_optional(value.cast<size_t>());
           })
       .def_property(
           "dispatch_core_type",
@@ -150,6 +168,11 @@ PYBIND11_MODULE(_C, m) {
   py::enum_<::tt::runtime::DispatchCoreType>(m, "DispatchCoreType")
       .value("WORKER", ::tt::runtime::DispatchCoreType::WORKER)
       .value("ETH", ::tt::runtime::DispatchCoreType::ETH);
+  py::enum_<::tt::runtime::Arch>(m, "Arch")
+      .value("GRAYSKULL", ::tt::runtime::Arch::GRAYSKULL)
+      .value("WORMHOLE_B0", ::tt::runtime::Arch::WORMHOLE_B0)
+      .value("BLACKHOLE", ::tt::runtime::Arch::BLACKHOLE)
+      .value("QUASAR", ::tt::runtime::Arch::QUASAR);
   m.def("get_current_runtime", &tt::runtime::getCurrentRuntime,
         "Get the backend device runtime type");
   m.def("get_available_runtimes", &tt::runtime::getAvailableRuntimes,
@@ -210,6 +233,8 @@ PYBIND11_MODULE(_C, m) {
             data, shape, stride, itemsize, dataType, strategy);
       },
       "Create a multi-device host tensor with owned memory");
+  m.def("get_arch", &tt::runtime::getArch,
+        "Get the architecture of the device");
   m.def("get_num_available_devices", &tt::runtime::getNumAvailableDevices,
         "Get the number of available devices");
   m.def("open_mesh_device", &tt::runtime::openMeshDevice, py::arg("mesh_shape"),
@@ -348,9 +373,6 @@ PYBIND11_MODULE(_C, m) {
   testing.def("get_host_row_major_layout",
               &tt::runtime::test::ttnn::getHostRowMajorLayout, py::arg("dtype"),
               "Get host row major layout");
-  testing.def("is_program_cache_enabled",
-              &tt::runtime::test::ttnn::isProgramCacheEnabled,
-              py::arg("device"), "Check if program cache is enabled");
   testing.def("open_so", &tt::runtime::test::ttnn::openSo, py::arg("path"),
               "Open a shared object");
   testing.def("close_so", &tt::runtime::test::ttnn::closeSo, py::arg("handle"),


### PR DESCRIPTION
### Problem description
* One pre-requisite for metal trace is to allocate a trace buffer on device. To do this, we need to expose a `trace_region_size` parameter when opening the device
* We didn't have APIs to query device information or tests that validated the parameters of the device
* There was boiler-plate when dispatching APIs to the current runtime in `runtime/lib/runtime.cpp`
* `currentRuntime` was a non-thread-safe global variable

### What's changed
* Added `trace_region_size` to meshDeviceOptions
* Added device query APIs and validation tests that sweep over each parameter and validate the parameter value
* Added a macro that encapsulates the logic for dispatching functions to the current runtime, removing boilerplate and ensuring consistency
* Updated `currentRuntime` to be an atomic singleton

### Checklist
- [X] New/Existing tests provide coverage for changes
