### PR TITLE
greedy-by-size algorithm implementation for the ttir-allocate pass

### DIFF
--- a/include/ttmlir/Dialect/TTIR/Analysis/AllocationPlanner.h
+++ b/include/ttmlir/Dialect/TTIR/Analysis/AllocationPlanner.h
@@ -5,10 +5,10 @@
 #ifndef TTMLIR_DIALECT_TTIR_ANALYSIS_ALLOCATIONPLANNER_H
 #define TTMLIR_DIALECT_TTIR_ANALYSIS_ALLOCATIONPLANNER_H
 
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <cstdint>
-#include <vector>
 
 namespace mlir::tt::ttir {
 
@@ -62,7 +62,7 @@ public:
     template <AllocationPlanner::Algorithm Algorithm>
     friend class PlannerImpl;
 
-    std::vector<Record> records;
+    llvm::SmallVector<Record> records;
   };
 
   /// Descriptor of allocation and verification outcomes.

--- a/include/ttmlir/Dialect/TTIR/Analysis/AllocationPlanner.h
+++ b/include/ttmlir/Dialect/TTIR/Analysis/AllocationPlanner.h
@@ -8,13 +8,12 @@
 #include "llvm/Support/raw_ostream.h"
 
 #include <cstdint>
-#include <optional>
 #include <vector>
 
 namespace mlir::tt::ttir {
 
 /// An API for static DSA ("dynamic storage allocation") algorithms.
-class AllocationPlanner final {
+class AllocationPlanner {
 public:
   /// Enum for planning algorithms exposed by this API.
   /// @see AllocationPlanner::allocate()
@@ -30,7 +29,7 @@ public:
 
   /// An allocation descriptor, a range of memory usage `[offset, offset+size)`
   /// over a liveness range `[first, last]`.
-  struct Record final {
+  struct Record {
 
     friend llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
                                          const Record &obj);
@@ -68,7 +67,7 @@ public:
   };
 
   /// Descriptor of allocation and verification outcomes.
-  struct Stats final {
+  struct Stats {
 
     friend llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
                                          const Stats &obj);

--- a/include/ttmlir/Dialect/TTIR/Analysis/AllocationPlanner.h
+++ b/include/ttmlir/Dialect/TTIR/Analysis/AllocationPlanner.h
@@ -18,8 +18,8 @@ public:
   /// Enum for planning algorithms exposed by this API.
   /// @see AllocationPlanner::allocate()
   enum class Algorithm : std::int32_t {
-    simple, //! Monotonic "bumper" allocator, does not support dealloc.
-    greedy  //! Greedy-by-size allocator.
+    Simple, //! Monotonic "bumper" allocator, does not support dealloc.
+    Greedy  //! Greedy-by-size allocator.
   };
 
   // Type for address-like values.
@@ -43,7 +43,6 @@ public:
   /// An allocation planning problem descriptor. Callers may extend to
   /// associate additional information.
   struct Context {
-  public:
     Context() = default;
 
     /// @result count of request records
@@ -94,7 +93,7 @@ public:
   /// to have `size`, `first`, and `last` fields set).
   /// @return `Stats` with `maxSize` and `memUsage` fields set
   [[nodiscard]] static Stats allocate(Context &context,
-                                      Algorithm algorithm = Algorithm::greedy);
+                                      Algorithm algorithm = Algorithm::Greedy);
 
   /// Validate the allocation plan in `context` for proper memory/liveness
   /// conflict resolution and return stats with *all* fields recomputed.

--- a/include/ttmlir/Dialect/TTIR/Analysis/AllocationPlanner.h
+++ b/include/ttmlir/Dialect/TTIR/Analysis/AllocationPlanner.h
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTIR_ANALYSIS_ALLOCATIONPLANNER_H
+#define TTMLIR_DIALECT_TTIR_ANALYSIS_ALLOCATIONPLANNER_H
+
+#include "llvm/Support/raw_ostream.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace mlir::tt::ttir {
+
+/// An API for static DSA ("dynamic storage allocation") algorithms.
+class AllocationPlanner final {
+public:
+  /// Enum for planning algorithms exposed by this API.
+  /// @see AllocationPlanner::allocate()
+  struct Algorithm {
+    // clang-format off
+    enum enum_t : std::int32_t {
+      simple,   //! Monotonic "bumper" allocator, does not support dealloc.
+      greedy    //! Greedy-by-size allocator.
+    };
+    // clang-format on
+  };
+
+  // Type for address-like values.
+  using AllocSizeT = std::int64_t;
+  // Type for liveness "logical time".
+  using SequenceT = std::int32_t;
+
+  /// An allocation descriptor, a range of memory usage `[offset, offset+size)`
+  /// over a liveness range `[first, last]`.
+  struct Record final {
+
+    friend llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                         const Record &obj);
+
+    // clang-format off
+    AllocSizeT offset;  //! Start memory address (negative means N/A).
+    AllocSizeT size;    //! Requested memory size.
+    SequenceT first;    //! (Inclusive) start of live range.
+    SequenceT last;     //! (Inclusive) end of live range.
+    // clang-format on
+
+  }; // end of class
+
+  /// An allocation planning problem descriptor. Callers may extend to
+  /// associate additional information.
+  struct Context {
+  public:
+    Context() = default;
+
+    /// @result count of request records
+    [[nodiscard]] std::size_t size() const { return records.size(); }
+
+    /// @result index'th allocation request as a `Record`
+    [[nodiscard]] const Record &operator[](std::size_t index) const {
+      return records[index];
+    }
+
+    /// Add an allocation request of given `size` and live range `[first,
+    /// last]`.
+    void add(AllocSizeT size, SequenceT first, SequenceT last);
+
+  protected:
+    friend class AllocationPlanner;
+    template <AllocationPlanner::Algorithm::enum_t Algorithm>
+    friend class PlannerImpl;
+
+    std::vector<Record> records;
+
+  }; // end of class
+
+  /// Descriptor of allocation and verification outcomes.
+  struct Stats final {
+
+    friend llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                         const Stats &obj);
+
+    /// @return `memUsage/maxLoad` ratio if `maxLoad` is non-zero,
+    /// double NaN otherwise
+    double usageRatio() const {
+      return maxLoad ? static_cast<double>(memUsage) / maxLoad
+                     : std::numeric_limits<double>::quiet_NaN();
+    }
+
+    /// Largest single-record memory size within an allocation context.
+    AllocSizeT maxSize;
+    /// Allocation needed `[0, memUsage)` memory strip to satisfy the
+    /// allocation request (also known as "makespan").
+    AllocSizeT memUsage;
+    /// "Load" is the sum of sizes of all requests live at a given
+    /// logical instant. This is the maximum such value across the
+    /// entire logical time range. (0 indicates N/A)
+    AllocSizeT maxLoad;
+
+  }; // end of class
+
+  /// Find a feasible allocation for Records in `context` (expected
+  /// to have `size`, `first`, and `last` fields set).
+  /// @return `Stats` with `maxSize` and `memUsage` fields set
+  [[nodiscard]] static Stats
+  allocate(Context &context, Algorithm::enum_t algorithm = Algorithm::greedy);
+
+  /// Validate the allocation plan in `context` for proper memory/liveness
+  /// conflict resolution and return stats with *all* fields recomputed.
+  [[nodiscard]] static Stats verify(const Context &context);
+
+private:
+  AllocationPlanner() = default; // Non-instantiable.
+
+}; // end of class
+//............................................................................
+
+inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                     const AllocationPlanner::Record &obj) {
+  return os << obj.size << " [" << obj.first << ", " << obj.last << "] @ "
+            << obj.offset;
+}
+
+inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                     const AllocationPlanner::Stats &obj) {
+  os << "{max size = " << obj.maxSize << ", mem usage = " << obj.memUsage;
+  if (obj.maxLoad) {
+    os << ", max load = " << obj.maxLoad;
+  }
+  return os << "}";
+}
+
+} // namespace mlir::tt::ttir
+
+#endif // TTMLIR_DIALECT_TTIR_ANALYSIS_ALLOCATIONPLANNER_H

--- a/include/ttmlir/Support/Logger.h
+++ b/include/ttmlir/Support/Logger.h
@@ -19,7 +19,7 @@
 namespace ttmlir {
 
 // Log components for different components
-enum class LogComponent { Optimizer, General };
+enum class LogComponent { Optimizer, Allocator, Test, General };
 
 // Log levels in order of verbosity
 enum class LogLevel {
@@ -33,6 +33,10 @@ inline constexpr const char *getLogComponentStr(LogComponent type) {
   switch (type) {
   case LogComponent::Optimizer:
     return "optimizer";
+  case LogComponent::Allocator:
+    return "allocator";
+  case LogComponent::Test:
+    return "test";
   case LogComponent::General:
     return "general";
   }

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
@@ -126,9 +126,8 @@ public:
            "No memref memory space found, failing.");
     auto memrefType = op.getMemref().getType();
     assert(mlir::isa<tt::ShardLayoutAttr>(memrefType.getLayout()));
-    auto createBufferOp = rewriter.create<ttmetal::CreateBufferOp>(
-        op->getLoc(), memrefType, address);
-    rewriter.replaceOp(op, createBufferOp);
+    rewriter.replaceOpWithNewOp<ttmetal::CreateBufferOp>(op, memrefType,
+                                                         address);
 
     return success();
   };
@@ -143,9 +142,8 @@ public:
   LogicalResult
   matchAndRewrite(memref::DeallocOp op, memref::DeallocOpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
-    auto deallocateBufferOp = rewriter.create<ttmetal::DeallocateBufferOp>(
-        op->getLoc(), op.getMemref());
-    rewriter.replaceOp(op, deallocateBufferOp);
+    rewriter.replaceOpWithNewOp<ttmetal::DeallocateBufferOp>(op,
+                                                             op.getMemref());
 
     return success();
   };

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetalPass.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetalPass.cpp
@@ -56,6 +56,10 @@ struct ConvertTTIRToTTMetal
       return !mlir::dyn_cast_if_present<tt::MemorySpaceAttr>(
           op.getMemref().getType().getMemorySpace());
     });
+    target.addDynamicallyLegalOp<memref::DeallocOp>([&](memref::DeallocOp op) {
+      return !mlir::dyn_cast_if_present<tt::MemorySpaceAttr>(
+          op.getMemref().getType().getMemorySpace());
+    });
 
     TypeConverter typeConverter;
     typeConverter.addConversion([](Type type) { return type; });

--- a/lib/Dialect/TTIR/Analysis/AllocationPlanner.cpp
+++ b/lib/Dialect/TTIR/Analysis/AllocationPlanner.cpp
@@ -1,0 +1,281 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTIR/Analysis/AllocationPlanner.h"
+
+#include "ttmlir/Support/Logger.h"
+
+#include "llvm/ADT/IntervalTree.h"
+
+#include <algorithm>
+#include <limits>
+#include <map>
+#include <queue>
+
+namespace mlir::tt::ttir {
+
+// Define some local convenience macros.
+
+#define TT_assert(condition, msg) assert((condition) && "message")
+
+#define TT_LOG_debug(/* fmt, args */...)                                       \
+  TTMLIR_DEBUG(ttmlir::LogComponent::General, __VA_ARGS__)
+
+#define TT_LOG_trace(/* fmt, args */...)                                       \
+  TTMLIR_TRACE(ttmlir::LogComponent::General, __VA_ARGS__)
+
+//............................................................................
+
+using Record = AllocationPlanner::Record;
+using AllocSizeT = AllocationPlanner::AllocSizeT;
+using SequenceT = AllocationPlanner::SequenceT;
+using IndexT = std::int32_t;
+
+//............................................................................
+
+void AllocationPlanner::Context::add(AllocSizeT size, SequenceT first,
+                                     SequenceT last) {
+  TT_assert(size > 0, "expected positive size");
+  TT_assert(0 <= first && 0 <= last, "expected non-negative op positions");
+  TT_assert(first < last, "expected first < last");
+
+  [[maybe_unused]] const auto &r =
+      records.emplace_back(Record{-1, size, first, last});
+  TT_LOG_trace("added request record #{}: {}", (records.size() - 1), r);
+}
+//............................................................................
+
+template <AllocationPlanner::Algorithm::enum_t A>
+class PlannerImpl {
+public:
+  static inline AllocationPlanner::Stats
+  allocate(AllocationPlanner::Context &context);
+
+}; // end of class
+//............................................................................
+//
+// A simple bumper allocator. It ignores live ranges and thus can't reuse
+// memory.
+//
+template <>
+inline AllocationPlanner::Stats
+PlannerImpl<AllocationPlanner::Algorithm::simple>::allocate(
+    AllocationPlanner::Context &context) {
+  auto &records = context.records;
+  const IndexT n = static_cast<IndexT>(records.size());
+  TT_LOG_debug("allocating {} record(s) ...", n);
+
+  AllocSizeT memUsage = 0;
+  AllocSizeT maxSize = 0;
+
+  // Not required for correctness, but for easier result interpretation
+  // visit allocation records in IR preorder.
+
+  auto lexicographic = [&](IndexT lhs, IndexT rhs) {
+    return (records[lhs].first > records[rhs].first) ||
+           ((records[lhs].first == records[rhs].first) &&
+            (records[lhs].last > records[rhs].last));
+  };
+  std::priority_queue<IndexT, std::vector<IndexT>, decltype(lexicographic)> pq(
+      lexicographic);
+  for (IndexT i = 0; i < n; ++i) {
+    pq.push(i);
+  }
+
+  while (!pq.empty()) {
+    const IndexT i = pq.top();
+    pq.pop();
+    Record &record = records[i];
+    TT_LOG_trace("record #{}: {}", i, record);
+
+    record.offset = memUsage;
+    memUsage += record.size;
+
+    TT_LOG_trace("record #{}: placed at offset {}", i, record.offset);
+
+    maxSize = std::max(maxSize, record.size);
+  }
+
+  TT_LOG_debug("allocated {} record(s): max alloc size {}, mem usage {}", n,
+               maxSize, memUsage);
+
+  return {maxSize, memUsage, 0};
+}
+//............................................................................
+//
+// Greedy-by-size allocator:
+//  1. visit requests in decreasing memory size order;
+//  2. place each request into the tighest gap found within the conflict set
+//     formed by already placed requests; if no such gap is found extend
+//     the solution makespan.
+template <>
+inline AllocationPlanner::Stats
+PlannerImpl<AllocationPlanner::Algorithm::greedy>::allocate(
+    AllocationPlanner::Context &context) {
+  auto &records = context.records;
+  const IndexT n = static_cast<IndexT>(records.size());
+  TT_LOG_debug("allocating {} record(s) ...", n);
+
+  auto bySize = [&](IndexT lhs, IndexT rhs) {
+    return (records[lhs].size < records[rhs].size);
+  };
+  std::priority_queue<IndexT, std::vector<IndexT>, decltype(bySize)> pq(bySize);
+  for (IndexT i = 0; i < n; ++i) {
+    pq.push(i);
+  }
+
+  // An index of already visited records in increasing offset order.
+  std::multimap<AllocSizeT, IndexT> allocatedOrderedByOffset;
+
+  AllocSizeT memUsage = 0;
+  AllocSizeT maxSize = 0;
+
+  while (!pq.empty()) {
+    const IndexT i = pq.top();
+    pq.pop();
+    Record &record = records[i];
+    TT_LOG_trace("record #{}: {}", i, record);
+    TT_assert(record.offset < 0, "record should not be marked allocated yet");
+
+    AllocSizeT gapBest = std::numeric_limits<AllocSizeT>::max();
+    AllocSizeT offsetPrev = 0;
+    AllocSizeT offsetBest = -1;
+
+    for (const auto &[kOffset, k] : allocatedOrderedByOffset) {
+      const Record &allocatedRecord = records[k];
+      TT_assert(kOffset >= 0 && kOffset == allocatedRecord.offset,
+                "iterating over allocated records");
+
+      const SequenceT maxFirst = std::max(record.first, allocatedRecord.first);
+      const SequenceT minLast = std::min(record.last, allocatedRecord.last);
+
+      // If `allocatedRecord` conflicts with `record`, check if we can use the
+      // gap between it and the previous conflict.
+
+      if (maxFirst <= minLast) {
+        TT_LOG_trace("\tconflict record #{}: {}", k, allocatedRecord);
+        const AllocSizeT gap = allocatedRecord.offset - offsetPrev;
+        if (gap >= allocatedRecord.size && gap < gapBest) {
+          gapBest = gap;
+          offsetBest = offsetPrev;
+        }
+        offsetPrev =
+            std::max(offsetPrev, allocatedRecord.offset + allocatedRecord.size);
+      }
+    }
+
+    if (offsetBest < 0) {
+      offsetBest = offsetPrev;
+    }
+
+    TT_LOG_trace("record #{}: placed at offset {}", i, offsetBest);
+
+    record.offset = offsetBest;
+    allocatedOrderedByOffset.emplace(offsetBest, i);
+
+    memUsage = std::max(memUsage, offsetBest + record.size);
+    maxSize = std::max(maxSize, record.size);
+  }
+
+  TT_LOG_debug("allocated {} record(s): max alloc size {}, mem usage {}", n,
+               maxSize, memUsage);
+  return {maxSize, memUsage, 0};
+}
+//............................................................................
+
+AllocationPlanner::Stats
+AllocationPlanner::allocate(Context &context, Algorithm::enum_t algorithm) {
+  switch (algorithm) {
+  case Algorithm::simple:
+    return PlannerImpl<Algorithm::simple>::allocate(context);
+  case Algorithm::greedy:
+    return PlannerImpl<Algorithm::greedy>::allocate(context);
+  }
+}
+//............................................................................
+
+AllocationPlanner::Stats AllocationPlanner::verify(const Context &context) {
+  TT_LOG_trace("verifying {} allocation(s)", context.size());
+  if (!context.size()) {
+    return {0, 0, 0};
+  }
+
+  // Use an interval tree to both verify interval conflicts and calculate max
+  // load/usage.
+  //
+  // Note that even though LLVM's interval tree only supports interval stabbing
+  // queries (find all intervals containing a given point), it is sufficient for
+  // our verification purposes: for any two overlapping intervals it is true
+  // that one of their starting points stabs the other interval and thus our
+  // sweep is guaranteed to visit each such conflict edge, either when visiting
+  // the first interval or when visiting the second. And hence no load
+  // contributions will be missed by the sweep.
+
+  using IntervalTree = llvm::IntervalTree<SequenceT, IndexT>;
+
+  IntervalTree::Allocator allocator;
+  IntervalTree iv(allocator);
+
+  const IndexT n = static_cast<IndexT>(context.size());
+
+  for (IndexT i = 0; i < n; ++i) {
+    const Record &record = context[i];
+    iv.insert(record.first, record.last, i);
+  }
+  iv.create();
+
+  AllocSizeT memUsage = 0;
+  AllocSizeT maxSize = 0;
+  AllocSizeT maxLoad = 0;
+
+  for (IndexT i = 0; i < n; ++i) {
+    const Record &record = context[i];
+
+    TT_assert(record.offset >= 0, "unallocated record");
+    AllocSizeT load = record.size;
+
+    const auto conflicts = iv.getContaining(record.first);
+    for (const auto &entry : conflicts) {
+      if (entry->value() != i) {
+        const Record &conflict = context[entry->value()];
+
+        // 'conflict' and 'record' must not overlap in memory space.
+        // Note that a memory range is considered half-open, i.e. [offset,
+        // offset+size).
+
+        [[maybe_unused]] const bool memOverlap =
+            std::max(record.offset, conflict.offset) <
+            std::min(record.offset + record.size,
+                     conflict.offset + conflict.size);
+        TT_assert(!memOverlap, "memory overlap");
+
+        load += conflict.size;
+      }
+    }
+
+    TT_LOG_trace("record #{}: {} conflict(s), size {}, load {}", i,
+                 (conflicts.size() - 1), record.size, load);
+
+    memUsage = std::max(memUsage, record.offset + record.size);
+    maxLoad = std::max(maxLoad, load);
+    maxSize = std::max(maxSize, record.size);
+  }
+
+  TT_assert(maxLoad > 0, "should have seen positive max load");
+  TT_assert(maxLoad <= memUsage,
+            "inconsistent max load/mem usage metrics inferred");
+
+  TT_LOG_debug(
+      "verified allocation plan with {} record(s): max alloc size {}, mem "
+      "usage {}, max load {} (ratio {})",
+      context.size(), maxSize, memUsage, maxLoad,
+      static_cast<double>(memUsage) / maxLoad);
+
+  return {maxSize, memUsage, maxLoad};
+}
+
+#undef TT_LOG_trace
+#undef TT_LOG_debug
+
+} // namespace mlir::tt::ttir

--- a/lib/Dialect/TTIR/Analysis/AllocationPlanner.cpp
+++ b/lib/Dialect/TTIR/Analysis/AllocationPlanner.cpp
@@ -34,7 +34,7 @@ void AllocationPlanner::Context::add(AllocSizeT size, SequenceT first,
                                      SequenceT last) {
   TT_assert(size > 0, "expected positive size");
   TT_assert(0 <= first && 0 <= last, "expected non-negative op positions");
-  TT_assert(first < last, "expected first < last");
+  TT_assert(first <= last, "expected first <= last");
 
   [[maybe_unused]] const auto &r =
       records.emplace_back(Record{-1, size, first, last});

--- a/lib/Dialect/TTIR/Analysis/CMakeLists.txt
+++ b/lib/Dialect/TTIR/Analysis/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_mlir_dialect_library(MLIRTTIRAnalysis
+  AllocationPlanner.cpp
   AssociatedDMAWaits.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/lib/Dialect/TTIR/Transforms/Allocate.cpp
+++ b/lib/Dialect/TTIR/Transforms/Allocate.cpp
@@ -5,13 +5,20 @@
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
 
 #include "ttmlir/Dialect/TT/IR/TT.h"
+#include "ttmlir/Dialect/TTIR/Analysis/AllocationPlanner.h"
+#include "ttmlir/Support/Logger.h"
 #include "ttmlir/Utils.h"
 
+#include "mlir/Analysis/Liveness.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/OpDefinition.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLForwardCompat.h"
 #include "llvm/ADT/SmallSet.h"
+
+#include <algorithm>
 
 // ----------------------------------------------------------------------------
 namespace mlir::tt::ttir {
@@ -20,8 +27,16 @@ namespace mlir::tt::ttir {
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h.inc"
 
 //===----------------------------------------------------------------------===//
-// Helper methods.
+// Helper definitions.
 //===----------------------------------------------------------------------===//
+
+#define TT_assert(condition, msg) assert((condition) && "message")
+
+#define TT_LOG_debug(/* fmt, args */...)                                       \
+  TTMLIR_DEBUG(ttmlir::LogComponent::General, __VA_ARGS__)
+
+#define TT_LOG_trace(/* fmt, args */...)                                       \
+  TTMLIR_TRACE(ttmlir::LogComponent::General, __VA_ARGS__)
 
 inline MemorySpace getMemorySpace(MemRefType memref, MemorySpace dflt) {
   auto memSpace = memref.getMemorySpace();
@@ -34,43 +49,71 @@ inline MemorySpace getMemorySpace(MemRefType memref, MemorySpace dflt) {
 // Helper classes.
 //===----------------------------------------------------------------------===//
 namespace {
-struct SimpleAllocator {
-  struct MemorySpaceInfo {
-    uint64_t baseAddress = 0;
-    uint64_t size = 0;
-    uint64_t alignment = 0;
 
-    MemorySpaceInfo() = default;
-    MemorySpaceInfo(uint64_t baseAddress, uint64_t size, uint64_t alignment)
-        : baseAddress(baseAddress), size(size), alignment(alignment) {}
-    inline uint64_t end() const { return baseAddress + size; }
-  };
+using AllocSizeT = AllocationPlanner::AllocSizeT;
+using SequenceT = AllocationPlanner::SequenceT;
 
-  SimpleAllocator(SmallVector<MemorySpaceInfo> memorySpaceInfo)
-      : currPtr(llvm::map_to_vector(
-            memorySpaceInfo, [](auto &&info) { return info.baseAddress; })),
-        memorySpaceInfo(memorySpaceInfo) {}
+struct MemorySpaceInfo final {
 
-  std::array<uint64_t, 2> allocate(uint64_t size, MemorySpace memorySpace) {
-    if (isSystemMemorySpace(memorySpace)) {
-      return {0, 0};
-    }
-
-    const auto index = llvm::to_underlying(memorySpace);
-    uint64_t &ptr = currPtr[index];
-    const uint64_t alignment = memorySpaceInfo[index].alignment;
-    ptr = ttmlir::utils::alignUp(ptr, alignment);
-    const uint64_t result = ptr;
-    ptr += size;
-    assert(ptr <= memorySpaceInfo[index].end() && "Out of memory");
-    return {result, alignment};
+  MemorySpaceInfo() = default;
+  MemorySpaceInfo(AllocSizeT baseAddress, AllocSizeT size, AllocSizeT alignment)
+      : baseAddress(baseAddress), size(size), alignment(alignment) {
+    assert(baseAddress % alignment == 0 && "expected aligned base address");
   }
 
-  SmallVector<uint64_t> currPtr;
-  SmallVector<MemorySpaceInfo> memorySpaceInfo;
-}; // end of class
-} // namespace
+  AllocSizeT baseAddress = 0;
+  AllocSizeT size = 0;
+  AllocSizeT alignment = 0;
 
+  static constexpr std::size_t maxEnumValForMemorySpace =
+      (getMaxEnumValForMemorySpace() + 1);
+}; // end of class
+
+struct MemorySpaces final {
+
+  MemorySpaces(
+      std::array<MemorySpaceInfo, MemorySpaceInfo::maxEnumValForMemorySpace>
+          &&memorySpaceInfo)
+      : memorySpaceInfo(std::move(memorySpaceInfo)) {}
+
+  std::array<MemorySpaceInfo, MemorySpaceInfo::maxEnumValForMemorySpace>
+      memorySpaceInfo;
+
+}; // end of class
+
+struct FuncAnalysisData final : public AllocationPlanner::Context {
+
+  using base = AllocationPlanner::Context;
+
+  using base::base;
+
+  void add(AllocSizeT size, SequenceT first, SequenceT last,
+           memref::AllocOp alloc) {
+    base::add(size, first, last);
+    allocs.emplace_back(alloc);
+  }
+
+  // A list of alloc ops, parallel to `base::records`
+  std::vector<memref::AllocOp> allocs;
+
+  // Within a func body scope, maps logical time positions (in preorder)
+  // to their `Operation`s.
+  std::vector<Operation *> positionMap;
+  // Inverse of `positionMap`.
+  DenseMap<Operation *, SequenceT> operationMap;
+
+}; // end of class
+
+struct ModuleAnalysisData final {
+
+  ModuleAnalysisData(MemorySpaces memSpaces) : memSpaces(memSpaces) {}
+
+  MemorySpaces memSpaces;
+  DenseMap<func::FuncOp, FuncAnalysisData> funcAnalysis;
+
+}; // end of class
+
+} // namespace
 //===----------------------------------------------------------------------===//
 // Pass implementation.
 //===----------------------------------------------------------------------===//
@@ -191,37 +234,180 @@ class TTIRAllocate final : public impl::TTIRAllocateBase<TTIRAllocate> {
   void runOnOperation() final {
     ModuleOp moduleOp = getOperation();
 
-    // Currently, these steps appear independent
-    // this will change (e.g. to use shared analysis context).
-
+    // (1) Create streams (with their backing buffers) where needed.
     if (failed(runAllocateStreams(moduleOp))) {
       signalPassFailure();
       return;
     }
 
-    if (failed(runAllocateBuffers(moduleOp))) {
+    // (2) Solve static buffer allocation problem.
+    FailureOr<ModuleAnalysisData> analysis = runAnalyzeBuffers(moduleOp);
+    if (failed(analysis)) {
+      signalPassFailure();
+      return;
+    }
+
+    // (3) Annotate buffers with addresses and pair allocs with their deallocs.
+    if (failed(runAllocateBuffers(moduleOp, *analysis))) {
       signalPassFailure();
       return;
     }
   }
 
+  // Create/allocate streams within a module.
   LogicalResult runAllocateStreams(ModuleOp moduleOp) {
     RewritePatternSet patterns(&getContext());
     patterns.add<TTIRAllocateStreams>(&getContext());
     return mlir::applyPatternsGreedily(getOperation(), std::move(patterns));
   }
 
-  LogicalResult runAllocateBuffers(ModuleOp moduleOp) {
+  // Analyze buffer allocation needs for a module.
+  FailureOr<ModuleAnalysisData> runAnalyzeBuffers(ModuleOp moduleOp) {
 
     SystemDescAttr systemDesc = getCurrentScopeSystemDesc(moduleOp);
     ChipDescAttr chipDesc = systemDesc.getChipDescs().front();
 
-    auto result = moduleOp->walk([&](func::FuncOp func) {
+    MemorySpaces memSpaces = getMemorySpaces(chipDesc);
+    ModuleAnalysisData moduleAnalysis(memSpaces);
+
+    moduleOp->walk([&](func::FuncOp func) {
       if (func.isDeclaration()) {
         return WalkResult::skip();
       }
 
-      if (failed(runAllocateBuffers(func, chipDesc))) {
+      FailureOr<FuncAnalysisData> funcAnalysis =
+          runAnalyzeBuffers(func, memSpaces);
+      if (failed(funcAnalysis)) {
+        return WalkResult::interrupt();
+      }
+
+      moduleAnalysis.funcAnalysis[func] = std::move(*funcAnalysis);
+      return WalkResult::advance();
+    });
+
+    return moduleAnalysis;
+  }
+
+  struct LivenessClosure final {
+    Operation *lastOp;
+    SequenceT first;
+    SequenceT maxLast;
+  }; // end of class
+
+  // Analyze and plan buffer allocation for a func.
+  FailureOr<FuncAnalysisData> runAnalyzeBuffers(func::FuncOp func,
+                                                const MemorySpaces &memSpaces) {
+    DeviceAttr device = lookupDevice(func);
+    Block &funcBody = func.getBody().front();
+
+    // Start with SSA liveness for `func`.
+
+    Liveness liveness(func.getOperation());
+    const LivenessBlockInfo *li = liveness.getLiveness(&funcBody);
+
+    FuncAnalysisData analysis;
+
+    //  (a) Build `Operation` <-> preorder position mappings for all `func` ops.
+    //  (b) Collect a separate set of "ops of interest", which are
+    //  `memref.alloc`s as well as certain ops that we imbue with semantics
+    //   of extending liveness of their memref operands.
+
+    llvm::DenseMap<Operation *, LivenessClosure> livenessJoinGraph;
+
+    funcBody.walk<WalkOrder::PreOrder>([&](Operation *op) {
+      const SequenceT position = analysis.positionMap.size();
+      TT_LOG_trace("preorder visit @{}: {}", position, *op);
+
+      analysis.operationMap[op] = position;
+      analysis.positionMap.emplace_back(op);
+
+      if (llvm::isa<memref::AllocOp, ttir::ViewLayoutOp, ttir::StreamLayoutOp>(
+              op)) {
+        TT_assert(op->getNumResults() == 1, "expected a single-result op");
+        Value result = op->getResult(0);
+
+        Operation *firstOp = li->getStartOperation(result);
+        Operation *lastOp = li->getEndOperation(result, firstOp);
+
+        livenessJoinGraph[op] = {lastOp, position, -1};
+      }
+    });
+
+    // Ops in `livenessJoinGraph` form a graph of Values and their users where
+    // some Values have their original SSA liveness "extended" by stream op
+    // users (ttir.view_layout, ttir.stream_layout).
+    //
+    // We calculate the "last use position" by computing for each value
+    // the max over its users over a traversal through this graph.
+
+    for (auto &[op, ctx] : livenessJoinGraph) {
+      // Initial maxLast values are from the SSA liveness calculation.
+      auto i = analysis.operationMap.find(ctx.lastOp);
+      TT_assert(i != analysis.operationMap.end(),
+                "couldn't map the starting lastOp");
+      ctx.maxLast = i->second;
+    }
+
+    for (auto &[op, ctx] : livenessJoinGraph) {
+      const SequenceT maxLast = resolve(op, livenessJoinGraph);
+      TT_LOG_debug("last use of @{} extended from {} to {}", ctx.first,
+                   ctx.maxLast, maxLast);
+      ctx.maxLast = maxLast;
+    }
+
+    // Finish building the allocation planner context by computing
+    // (aligned) sizes of all buffers under consideration.
+
+    for (auto &[op, ctx] : livenessJoinGraph) {
+      if (memref::AllocOp alloc = llvm::dyn_cast<memref::AllocOp>(op)) {
+        MemRefType memrefTy = alloc.getType();
+        MemorySpace memorySpace = getMemorySpace(
+            memrefTy, MemorySpace::System); // Interpret unset as "host memory".
+
+        if (!isL1MemorySpace(memorySpace)) {
+          continue; // Only handling L1 space at the moment.
+        }
+
+        const AllocSizeT alignment =
+            memSpaces.memorySpaceInfo[llvm::to_underlying(memorySpace)]
+                .alignment;
+        const AllocSizeT sizeBytes = device.getMemrefSizeBytes(memrefTy, 0);
+        const AllocSizeT alignedSize =
+            ttmlir::utils::alignUp(sizeBytes, alignment);
+
+        analysis.add(alignedSize, ctx.first, ctx.maxLast, alloc);
+      }
+    }
+
+    const AllocationPlanner::Stats stats =
+        AllocationPlanner::allocate(analysis);
+
+    // TODO(#3378) dump this instead (usageRatio() is useful) in "debug" mode:
+    // AllocationPlanner::Stats stats = AllocationPlanner::verify(analysis);
+    TT_LOG_debug("allocation planning outcome: {}", stats);
+
+    const auto memSizeL1 =
+        memSpaces.memorySpaceInfo[llvm::to_underlying(MemorySpace::DeviceL1)]
+            .size;
+    if (stats.memUsage > memSizeL1) {
+      return func.emitOpError() << "required memory usage " << stats.memUsage
+                                << " exceeds memory size " << memSizeL1;
+    }
+
+    return analysis;
+  }
+
+  // Apply buffer allocation `analysis` to `moduleOp`.
+  LogicalResult runAllocateBuffers(ModuleOp moduleOp,
+                                   const ModuleAnalysisData &analysis) {
+    auto result = moduleOp->walk([&](func::FuncOp func) {
+      auto funcAnalysis = analysis.funcAnalysis.find(func);
+      if (funcAnalysis == analysis.funcAnalysis.end()) {
+        return WalkResult::skip();
+      }
+
+      if (failed(runAllocateBuffers(func, funcAnalysis->second,
+                                    analysis.memSpaces))) {
         return WalkResult::interrupt();
       }
 
@@ -231,31 +417,35 @@ class TTIRAllocate final : public impl::TTIRAllocateBase<TTIRAllocate> {
     return success(!result.wasInterrupted());
   }
 
+  // Apply buffer allocation `analysis` to `func`.
   LogicalResult runAllocateBuffers(func::FuncOp func,
-                                   const ChipDescAttr &chipDesc) {
+                                   const FuncAnalysisData &analysis,
+                                   const MemorySpaces &memSpaces) {
     assert(func.getBody().hasOneBlock() &&
            "found func that didn't have one block!");
-
-    DeviceAttr device = lookupDevice(func);
-    SimpleAllocator allocator = createSimpleAllocator(chipDesc);
 
     // Augment all 'memref.alloc's in device memory with allocated addresses and
     // correct alignments.
 
     IRRewriter rewriter(&getContext());
 
-    func->walk([&](memref::AllocOp alloc) {
+    for (std::size_t t = 0; t < analysis.size(); ++t) {
+      const AllocationPlanner::Record &record = analysis[t];
+      memref::AllocOp alloc = analysis.allocs[t];
+
       MemRefType memrefTy = alloc.getType();
       MemorySpace memorySpace = getMemorySpace(
           memrefTy, MemorySpace::System); // Interpret unset as "host memory".
 
-      if (!isDeviceMemorySpace(memorySpace)) {
-        return;
+      if (!isL1MemorySpace(memorySpace)) {
+        continue; // Same WIP guard as in the analyze step.
       }
 
-      const auto sizeBytes = device.getMemrefSizeBytes(memrefTy, 0);
-      const auto [address, alignment] =
-          allocator.allocate(sizeBytes, memorySpace);
+      const auto &info =
+          memSpaces.memorySpaceInfo[llvm::to_underlying(memorySpace)];
+
+      const AllocSizeT alignment = info.alignment;
+      const AllocSizeT address = info.baseAddress + record.offset;
 
       rewriter.startOpModification(alloc);
       {
@@ -263,27 +453,54 @@ class TTIRAllocate final : public impl::TTIRAllocateBase<TTIRAllocate> {
         alloc->setAttr("address", rewriter.getI64IntegerAttr(address));
       };
       rewriter.finalizeOpModification(alloc);
-    });
 
-    // Currently, this step always succeeds; out-of-memory condition will result
-    // in hard assert failure.
+      Operation *lastOp = analysis.positionMap[record.last];
+      if (!llvm::isa<func::ReturnOp>(lastOp)) {
+        rewriter.setInsertionPointAfter(lastOp);
+        rewriter.create<memref::DeallocOp>(lastOp->getLoc(), alloc.getResult());
+      }
+    }
 
     return success();
   }
 
-  static SimpleAllocator createSimpleAllocator(ChipDescAttr chipDesc) {
-    SmallVector<SimpleAllocator::MemorySpaceInfo> memorySpaceInfo;
-    memorySpaceInfo.resize(getMaxEnumValForMemorySpace() + 1llu);
-    memorySpaceInfo[llvm::to_underlying(MemorySpace::DeviceL1)] =
-        SimpleAllocator::MemorySpaceInfo(chipDesc.getL1UnreservedBase(),
-                                         chipDesc.getL1Size() -
-                                             chipDesc.getScratchL1RegionSize(),
-                                         chipDesc.getNocL1AddressAlignBytes());
-    memorySpaceInfo[llvm::to_underlying(MemorySpace::DeviceDRAM)] =
-        SimpleAllocator::MemorySpaceInfo(
-            chipDesc.getDramUnreservedBase(), chipDesc.getDramChannelSize(),
-            chipDesc.getNocDRAMAddressAlignBytes());
-    return SimpleAllocator(memorySpaceInfo);
+  // Recursive helper for `runAnalyzeBuffers(func::FuncOp func...)`.
+  // Note: the overall traversal cost can be reduced by memoizing
+  // final maxLast values and/or visiting Values in a reverse topological
+  // sort order. This is not done at the moment.
+  static SequenceT
+  resolve(Operation *op,
+          const llvm::DenseMap<Operation *, LivenessClosure> &graph) {
+
+    auto opClosure = graph.find(op);
+    TT_assert(opClosure != graph.end(), "malformed liveness closure graph");
+    SequenceT maxLast = opClosure->second.maxLast;
+
+    for (Operation *user : op->getResult(0).getUsers()) {
+      if (graph.contains(user)) {
+        if (llvm::isa<ttir::ViewLayoutOp, ttir::StreamLayoutOp>(user)) {
+          maxLast = std::max(maxLast, resolve(user, graph));
+        }
+      }
+    }
+
+    return maxLast;
+  }
+
+  static MemorySpaces getMemorySpaces(ChipDescAttr chipDesc) {
+    std::array<MemorySpaceInfo, MemorySpaceInfo::maxEnumValForMemorySpace> info;
+    // Currently, we only need some slots in 'info'.
+    {
+      info[llvm::to_underlying(MemorySpace::DeviceL1)] = MemorySpaceInfo(
+          chipDesc.getL1UnreservedBase(),
+          chipDesc.getL1Size() - chipDesc.getScratchL1RegionSize(),
+          chipDesc.getNocL1AddressAlignBytes());
+
+      info[llvm::to_underlying(MemorySpace::DeviceDRAM)] = MemorySpaceInfo(
+          chipDesc.getDramUnreservedBase(), chipDesc.getDramChannelSize(),
+          chipDesc.getNocDRAMAddressAlignBytes());
+    }
+    return {std::move(info)};
   }
 
 }; // end of class

--- a/lib/Dialect/TTIR/Transforms/Allocate.cpp
+++ b/lib/Dialect/TTIR/Transforms/Allocate.cpp
@@ -67,7 +67,7 @@ struct MemorySpaceInfo final {
 
   static constexpr std::size_t maxEnumValForMemorySpace =
       (getMaxEnumValForMemorySpace() + 1);
-}; // end of class
+};
 
 struct MemorySpaces final {
 
@@ -78,8 +78,7 @@ struct MemorySpaces final {
 
   std::array<MemorySpaceInfo, MemorySpaceInfo::maxEnumValForMemorySpace>
       memorySpaceInfo;
-
-}; // end of class
+};
 
 struct FuncAnalysisData final : public AllocationPlanner::Context {
 
@@ -101,8 +100,7 @@ struct FuncAnalysisData final : public AllocationPlanner::Context {
   std::vector<Operation *> positionMap;
   // Inverse of `positionMap`.
   DenseMap<Operation *, SequenceT> operationMap;
-
-}; // end of class
+};
 
 struct ModuleAnalysisData final {
 
@@ -110,8 +108,7 @@ struct ModuleAnalysisData final {
 
   MemorySpaces memSpaces;
   DenseMap<func::FuncOp, FuncAnalysisData> funcAnalysis;
-
-}; // end of class
+};
 
 } // namespace
 //===----------------------------------------------------------------------===//
@@ -220,10 +217,8 @@ class TTIRAllocateStreams final : public OpRewritePattern<ttir::GenericOp> {
     rewriter.modifyOpInPlace(
         op, [&]() { operand.assign(streamLayout.getResult()); });
   }
-
-}; // end of class
+};
 } // namespace
-// ............................................................................
 
 namespace {
 class TTIRAllocate final : public impl::TTIRAllocateBase<TTIRAllocate> {
@@ -292,7 +287,7 @@ class TTIRAllocate final : public impl::TTIRAllocateBase<TTIRAllocate> {
     Operation *lastOp;
     SequenceT first;
     SequenceT maxLast;
-  }; // end of class
+  };
 
   // Analyze and plan buffer allocation for a func.
   FailureOr<FuncAnalysisData> runAnalyzeBuffers(func::FuncOp func,
@@ -438,7 +433,7 @@ class TTIRAllocate final : public impl::TTIRAllocateBase<TTIRAllocate> {
           memrefTy, MemorySpace::System); // Interpret unset as "host memory".
 
       if (!isL1MemorySpace(memorySpace)) {
-        continue; // Same WIP guard as in the analyze step.
+        continue; // Only handling L1 space at the moment.
       }
 
       const auto &info =
@@ -502,8 +497,7 @@ class TTIRAllocate final : public impl::TTIRAllocateBase<TTIRAllocate> {
     }
     return {std::move(info)};
   }
-
-}; // end of class
+};
 } // namespace
 
 } // namespace mlir::tt::ttir

--- a/lib/Dialect/TTIR/Transforms/Allocate.cpp
+++ b/lib/Dialect/TTIR/Transforms/Allocate.cpp
@@ -53,7 +53,7 @@ namespace {
 using AllocSizeT = AllocationPlanner::AllocSizeT;
 using SequenceT = AllocationPlanner::SequenceT;
 
-struct MemorySpaceInfo final {
+struct MemorySpaceInfo {
 
   MemorySpaceInfo() = default;
   MemorySpaceInfo(AllocSizeT baseAddress, AllocSizeT size, AllocSizeT alignment)
@@ -69,7 +69,7 @@ struct MemorySpaceInfo final {
       (getMaxEnumValForMemorySpace() + 1);
 };
 
-struct MemorySpaces final {
+struct MemorySpaces {
 
   MemorySpaces(
       std::array<MemorySpaceInfo, MemorySpaceInfo::maxEnumValForMemorySpace>
@@ -102,7 +102,7 @@ struct FuncAnalysisData final : public AllocationPlanner::Context {
   DenseMap<Operation *, SequenceT> operationMap;
 };
 
-struct ModuleAnalysisData final {
+struct ModuleAnalysisData {
 
   ModuleAnalysisData(MemorySpaces memSpaces) : memSpaces(memSpaces) {}
 
@@ -283,7 +283,7 @@ class TTIRAllocate final : public impl::TTIRAllocateBase<TTIRAllocate> {
     return moduleAnalysis;
   }
 
-  struct LivenessClosure final {
+  struct LivenessClosure {
     Operation *lastOp;
     SequenceT first;
     SequenceT maxLast;

--- a/lib/Dialect/TTIR/Transforms/Allocate.cpp
+++ b/lib/Dialect/TTIR/Transforms/Allocate.cpp
@@ -65,26 +65,26 @@ struct MemorySpaceInfo {
   AllocSizeT size = 0;
   AllocSizeT alignment = 0;
 
-  static constexpr std::size_t maxEnumValForMemorySpace =
+  static constexpr std::size_t kMaxEnumValForMemorySpace =
       (getMaxEnumValForMemorySpace() + 1);
 };
 
 using MemorySpaces =
-    std::array<MemorySpaceInfo, MemorySpaceInfo::maxEnumValForMemorySpace>;
+    std::array<MemorySpaceInfo, MemorySpaceInfo::kMaxEnumValForMemorySpace>;
 
 struct FuncAnalysisData final : public AllocationPlanner::Context {
 
-  using base = AllocationPlanner::Context;
+  using Base = AllocationPlanner::Context;
 
-  using base::base;
+  using Base::Base;
 
   void add(AllocSizeT size, SequenceT first, SequenceT last,
            memref::AllocOp alloc) {
-    base::add(size, first, last);
+    Base::add(size, first, last);
     allocs.emplace_back(alloc);
   }
 
-  // A list of alloc ops, parallel to `base::records`
+  // A list of alloc ops, parallel to `Base::records`
   std::vector<memref::AllocOp> allocs;
 
   // Within a func body scope, maps logical time positions (in preorder)
@@ -108,9 +108,9 @@ struct ModuleAnalysisData {
 //===----------------------------------------------------------------------===//
 namespace {
 class TTIRAllocateStreams final : public OpRewritePattern<ttir::GenericOp> {
-  using base = OpRewritePattern<ttir::GenericOp>;
+  using Base = OpRewritePattern<ttir::GenericOp>;
 
-  using base::base;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(ttir::GenericOp op,
                                 PatternRewriter &rewriter) const final {
@@ -214,9 +214,9 @@ class TTIRAllocateStreams final : public OpRewritePattern<ttir::GenericOp> {
 
 namespace {
 class TTIRAllocate final : public impl::TTIRAllocateBase<TTIRAllocate> {
-  using base = impl::TTIRAllocateBase<TTIRAllocate>;
+  using Base = impl::TTIRAllocateBase<TTIRAllocate>;
 
-  using base::base;
+  using Base::Base;
 
   void runOnOperation() final {
     ModuleOp moduleOp = getOperation();
@@ -472,7 +472,8 @@ class TTIRAllocate final : public impl::TTIRAllocateBase<TTIRAllocate> {
   }
 
   static MemorySpaces getMemorySpaces(ChipDescAttr chipDesc) {
-    std::array<MemorySpaceInfo, MemorySpaceInfo::maxEnumValForMemorySpace> info;
+    std::array<MemorySpaceInfo, MemorySpaceInfo::kMaxEnumValForMemorySpace>
+        info;
     // Currently, we only need some slots in 'info'.
     {
       info[llvm::to_underlying(MemorySpace::DeviceL1)] = MemorySpaceInfo(

--- a/test/unittests/Allocation/CMakeLists.txt
+++ b/test/unittests/Allocation/CMakeLists.txt
@@ -5,4 +5,5 @@ add_mlir_unittest(AllocationTests
 target_link_libraries(AllocationTests
     PRIVATE
     MLIRTTIRAnalysis
+    coverage_config
 )

--- a/test/unittests/Allocation/CMakeLists.txt
+++ b/test/unittests/Allocation/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_mlir_unittest(AllocationTests
+    TestAllocation.cpp
+)
+
+target_link_libraries(AllocationTests
+    PRIVATE
+    MLIRTTIRAnalysis
+)

--- a/test/unittests/Allocation/TestAllocation.cpp
+++ b/test/unittests/Allocation/TestAllocation.cpp
@@ -6,7 +6,7 @@
 
 #include "ttmlir/Support/Logger.h"
 
-#include "gtest/gtest.h"
+#include "llvm-gtest/gtest/gtest.h"
 
 #include <cstdint>
 #include <cstdlib>

--- a/test/unittests/Allocation/TestAllocation.cpp
+++ b/test/unittests/Allocation/TestAllocation.cpp
@@ -163,11 +163,11 @@ TEST(GreedyAllocationTest, ConflictFree) {
   constexpr AllocationPlanner::SequenceT positionLimit = 1000; // Soft limit.
 
   std::uniform_int_distribution<std::int32_t> unifSize(
-      1, sizeLimit - 1); // [0, sizeLimit)
+      1, sizeLimit - 1); // [1, sizeLimit)
 
   for (std::int32_t repeat = 0; repeat < repeats; ++repeat) {
     gen.seed(seed + repeat);
-    std::uniform_int_distribution<std::int32_t> unifLength(1, 5 + 2 * repeat);
+    std::uniform_int_distribution<std::int32_t> unifLength(0, 5 + 2 * repeat);
 
     AllocationPlanner::AllocSizeT maxSize = 0;
     AllocationPlanner::Context ctx;
@@ -180,7 +180,7 @@ TEST(GreedyAllocationTest, ConflictFree) {
         ctx.add(size, first, last);
 
         maxSize = std::max(maxSize, size);
-        first = last + unifLength(gen); // Ensure no position overlap.
+        first = last + 1 + unifLength(gen); // Ensure no position overlap.
       }
     }
 

--- a/test/unittests/Allocation/TestAllocation.cpp
+++ b/test/unittests/Allocation/TestAllocation.cpp
@@ -22,8 +22,8 @@ struct TestScenario {
 };
 
 using TestScenarios =
-    gtest::Types<TestScenario<AllocationPlanner::Algorithm::simple>,
-                 TestScenario<AllocationPlanner::Algorithm::greedy>>;
+    gtest::Types<TestScenario<AllocationPlanner::Algorithm::Simple>,
+                 TestScenario<AllocationPlanner::Algorithm::Greedy>>;
 
 template <typename T>
 struct AllocationTest : public gtest::Test {};
@@ -97,7 +97,7 @@ TYPED_TEST(AllocationTest, Conflicts) {
     for (std::int32_t drift : {2, 10, 100}) {
       for (std::int32_t durationScale : {drift / 2, drift, drift * 2}) {
         for (std::int32_t repeat = 0; repeat < repeats; ++repeat) {
-          TTMLIR_DEBUG(ttmlir::LogComponent::General,
+          TTMLIR_DEBUG(ttmlir::LogComponent::Test,
                        "[{}/{}] sub-scenario: n = {}, drift = {}, "
                        "durationScale = {} ...",
                        (repeat + 1), repeats, n, drift, durationScale);
@@ -193,7 +193,7 @@ TEST(GreedyAllocationTest, ConflictFree) {
     const AllocationPlanner::Stats verifyStats = AllocationPlanner::verify(ctx);
 
     ASSERT_EQ(verifyStats.usageRatio(), 1.0)
-        << "inconsistent max load/mem usage calculation";
+        << "expected max load/mem usage ratio of exactly 1.0";
   }
 }
 

--- a/test/unittests/Allocation/TestAllocation.cpp
+++ b/test/unittests/Allocation/TestAllocation.cpp
@@ -1,0 +1,206 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTIR/Analysis/AllocationPlanner.h"
+
+#include "ttmlir/Support/Logger.h"
+
+#include "gtest/gtest.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <random>
+
+namespace mlir::tt::ttir {
+
+namespace gtest = ::testing;
+
+//............................................................................
+
+template <AllocationPlanner::Algorithm::enum_t Algorithm>
+struct TestScenario {
+  static constexpr AllocationPlanner::Algorithm::enum_t algorithm = Algorithm;
+};
+
+using TestScenarios =
+    gtest::Types<TestScenario<AllocationPlanner::Algorithm::simple>,
+                 TestScenario<AllocationPlanner::Algorithm::greedy>>;
+
+template <typename T>
+struct AllocationTest : public gtest::Test {};
+TYPED_TEST_SUITE(AllocationTest, TestScenarios,
+                 /* clang variadic macro issue workaround */);
+
+//............................................................................
+
+TYPED_TEST(AllocationTest, EdgeCases) {
+
+  using Scenario = TypeParam;
+
+  // An empty allocation plan is valid input.
+  {
+    AllocationPlanner::Context ctx;
+    ASSERT_EQ(ctx.size(), 0);
+
+    const AllocationPlanner::Stats allocateStats =
+        AllocationPlanner::allocate(ctx, Scenario::algorithm);
+    const AllocationPlanner::Stats verifyStats = AllocationPlanner::verify(ctx);
+
+    ASSERT_EQ(allocateStats.maxSize, verifyStats.maxSize);
+    ASSERT_EQ(allocateStats.memUsage, verifyStats.memUsage);
+
+    ASSERT_EQ(allocateStats.memUsage, 0);
+    ASSERT_EQ(allocateStats.maxSize, 0);
+    ASSERT_EQ(allocateStats.maxLoad, 0);
+  }
+  // A one-allocation plan has a trivial outcome regardless of the algorithm.
+  {
+    AllocationPlanner::Context ctx;
+
+    ctx.add(100'000, 1, 2);
+    ASSERT_EQ(ctx.size(), 1);
+
+    const AllocationPlanner::Stats allocateStats =
+        AllocationPlanner::allocate(ctx, Scenario::algorithm);
+    const AllocationPlanner::Stats verifyStats = AllocationPlanner::verify(ctx);
+
+    ASSERT_EQ(allocateStats.maxSize, verifyStats.maxSize);
+    ASSERT_EQ(allocateStats.memUsage, verifyStats.memUsage);
+
+    ASSERT_EQ(ctx[0].offset, 0)
+        << "single request should have been allocated at zero offset";
+  }
+}
+//............................................................................
+
+// Run all algorithms against request sequences with varying density over scope
+// time axis and varying probability of liveness conflicts.
+TYPED_TEST(AllocationTest, Conflicts) {
+
+  using Scenario = TypeParam;
+
+  constexpr std::int32_t repeats = 3;
+  std::uint64_t seed = 1747264320186267367; // TODO(#3377) time-varying seeding
+
+  std::mt19937 gen;
+
+  constexpr AllocationPlanner::AllocSizeT sizeLimit = 1000;
+  constexpr AllocationPlanner::SequenceT positionLimit = 1000; // Soft limit.
+
+  std::uniform_int_distribution<std::int32_t> unifSize(
+      1, sizeLimit - 1); // [1, sizeLimit)
+  std::uniform_int_distribution<std::int32_t> unifPosition(
+      0, positionLimit); // [1, positionLimit]
+  std::uniform_real_distribution<> unif(0.0, 1.0);
+
+  // Loosely control the expected probability of conflicts by sprinkling request
+  // intervals using a random walk of sorts, with varying "drift" of the
+  // interval midpoint.
+
+  for (std::int32_t n : {10, 100, 1000}) {
+    for (std::int32_t drift : {2, 10, 100}) {
+      for (std::int32_t durationScale : {drift / 2, drift, drift * 2}) {
+        for (std::int32_t repeat = 0; repeat < repeats; ++repeat) {
+          TTMLIR_DEBUG(ttmlir::LogComponent::General,
+                       "[{}/{}] sub-scenario: n = {}, drift = {}, "
+                       "durationScale = {} ...",
+                       (repeat + 1), repeats, n, drift, durationScale);
+          gen.seed(seed++);
+
+          AllocationPlanner::Context ctx;
+          {
+            AllocationPlanner::SequenceT midPrev = unifPosition(gen);
+
+            for (auto i = 0; i < n; ++i) {
+              const AllocationPlanner::AllocSizeT size = unifSize(gen);
+
+              const AllocationPlanner::SequenceT mid =
+                  std::abs(static_cast<AllocationPlanner::SequenceT>(
+                      midPrev + drift * (0.5 - unif(gen)))) %
+                  positionLimit;
+
+              const AllocationPlanner::SequenceT halfDuration =
+                  durationScale * unif(gen);
+              const AllocationPlanner::SequenceT first =
+                  std::max(0, mid - halfDuration);
+              const AllocationPlanner::SequenceT last =
+                  std::min(positionLimit, mid + 1 + halfDuration);
+
+              ctx.add(size, first, last);
+
+              midPrev = mid;
+            }
+          }
+          ASSERT_EQ(ctx.size(), n);
+
+          const AllocationPlanner::Stats allocateStats =
+              AllocationPlanner::allocate(ctx, Scenario::algorithm);
+          const AllocationPlanner::Stats verifyStats =
+              AllocationPlanner::verify(ctx);
+
+          // Verification will compute the same max size and mem usage.
+
+          ASSERT_EQ(allocateStats.maxSize, verifyStats.maxSize);
+          ASSERT_EQ(allocateStats.memUsage, verifyStats.memUsage);
+
+          ASSERT_GE(verifyStats.usageRatio(), 1.0)
+              << "inconsistent max load/mem usage calculation";
+        }
+      }
+    }
+  }
+}
+//............................................................................
+
+// When no allocation requests have actual live conflicts, any non-naive
+// algorithm should produce a plan that
+//  - has max memory usage equal to the largest request size;
+//  - verifies to max mem/max load ratio of exactly 1.0.
+// This test verifies these expectations for the default algorithm.
+TEST(GreedyAllocationTest, ConflictFree) {
+
+  constexpr std::int32_t repeats = 3;
+  std::uint64_t seed = 1747264320186267367; // TODO(#3377) time-varying seeding
+
+  std::mt19937 gen;
+
+  constexpr AllocationPlanner::AllocSizeT sizeLimit = 1000;
+  constexpr AllocationPlanner::SequenceT positionLimit = 1000; // Soft limit.
+
+  std::uniform_int_distribution<std::int32_t> unifSize(
+      1, sizeLimit - 1); // [0, sizeLimit)
+
+  for (std::int32_t repeat = 0; repeat < repeats; ++repeat) {
+    gen.seed(seed + repeat);
+    std::uniform_int_distribution<std::int32_t> unifLength(1, 5 + 2 * repeat);
+
+    AllocationPlanner::AllocSizeT maxSize = 0;
+    AllocationPlanner::Context ctx;
+    {
+      AllocationPlanner::SequenceT first = 0;
+      while (first < positionLimit) {
+        const AllocationPlanner::AllocSizeT size = unifSize(gen);
+        const AllocationPlanner::SequenceT last = first + unifLength(gen);
+
+        ctx.add(size, first, last);
+
+        maxSize = std::max(maxSize, size);
+        first = last + unifLength(gen); // Ensure no position overlap.
+      }
+    }
+
+    const AllocationPlanner::Stats allocateStats =
+        AllocationPlanner::allocate(ctx);
+
+    ASSERT_EQ(allocateStats.memUsage, maxSize);
+    ASSERT_EQ(allocateStats.maxSize, maxSize);
+
+    const AllocationPlanner::Stats verifyStats = AllocationPlanner::verify(ctx);
+
+    ASSERT_EQ(verifyStats.usageRatio(), 1.0)
+        << "inconsistent max load/mem usage calculation";
+  }
+}
+
+} // namespace mlir::tt::ttir

--- a/test/unittests/Allocation/TestAllocation.cpp
+++ b/test/unittests/Allocation/TestAllocation.cpp
@@ -16,11 +16,9 @@ namespace mlir::tt::ttir {
 
 namespace gtest = ::testing;
 
-//............................................................................
-
-template <AllocationPlanner::Algorithm::enum_t Algorithm>
+template <AllocationPlanner::Algorithm Algorithm>
 struct TestScenario {
-  static constexpr AllocationPlanner::Algorithm::enum_t algorithm = Algorithm;
+  static constexpr AllocationPlanner::Algorithm algorithm = Algorithm;
 };
 
 using TestScenarios =
@@ -31,8 +29,6 @@ template <typename T>
 struct AllocationTest : public gtest::Test {};
 TYPED_TEST_SUITE(AllocationTest, TestScenarios,
                  /* clang variadic macro issue workaround */);
-
-//............................................................................
 
 TYPED_TEST(AllocationTest, EdgeCases) {
 
@@ -72,7 +68,6 @@ TYPED_TEST(AllocationTest, EdgeCases) {
         << "single request should have been allocated at zero offset";
   }
 }
-//............................................................................
 
 // Run all algorithms against request sequences with varying density over scope
 // time axis and varying probability of liveness conflicts.
@@ -151,7 +146,6 @@ TYPED_TEST(AllocationTest, Conflicts) {
     }
   }
 }
-//............................................................................
 
 // When no allocation requests have actual live conflicts, any non-naive
 // algorithm should produce a plan that

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -5,6 +5,7 @@ function(add_mlir_unittest test_dirname)
   add_unittest(MLIRUnitTests ${test_dirname} ${ARGN})
 endfunction()
 
+add_subdirectory(Allocation)
 add_subdirectory(Support)
 add_subdirectory(TestScheduler)
 add_subdirectory(Optimizer)


### PR DESCRIPTION
### Ticket

Implements one algorithm for #3034, "greedy-by-size" as used by TFLite and derivative projects. 
(Alternative impl path was investigated in related #2246.)

### Problem description

This is our first non-naive "static memory allocator" in the sense that it can re-use memory based on live range analysis. On randomized inputs this seems to generate allocation plans with usage ratios (mem usage/max load) of 1.X, with X in single or teen per cent. Further perf work will be done to assess this on realistic model inputs.

Good background reference is:

- Pisarchyk, Lee, [“Efficient Memory Management for Deep Neural Net Inference”](https://arxiv.org/abs/2001.03288), 2020

### What's changed

- to help experiment with more algorithms in the future, the planner is encapsulated behind the API in `include/ttmlir/Dialect/TTIR/Analysis/AllocationPlanner.h`; the planner algorithm communicates with the `Allocate` pass impl via a "context" object (the planner works with mem and logical time ranges, the pass needs to have MLIR Operations and related content)
- to help with unit testing that's outside of `lit` capability, a new googletest suite has been created in `test/unittests/Allocation`
  - the unit test drivers are handy for cli experimenting, but are currently invoked by the `lit` driver; it would be handy to extend our googletest infrastructure towards making it an incremental dev/research tool (#3377)
- `Allocator` is again emitting `memref.dealloc`s and the necessary changes were made to `TTIRToTTMetal` to lower those to `ttmetal.deallocate_buffer` ops

Some immediate follow-up work:

- #3378

### Checklist
- [x] Existing tests that involve ttir-allocate provide coverage for changes
- [x] New set of unit tests in `test/unittests/Allocation/TestAllocation.cpp`
