### PR TITLE
Uplift third_party/tt-metal to 1a58dca1c570bc38bdef6b728b692ee4e8c34a55 2025-05-15

### DIFF
--- a/lib/Dialect/TTNN/Analysis/LegalLayoutAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/LegalLayoutAnalysis.cpp
@@ -49,7 +49,7 @@ void applyConv2dConfigOverrides(Operation *op,
   //
 
   // vkovacevic: This is needed to get through a tt-metal assert in
-  // prepare_conv2d_weights.cpp where `weight_tensor_.get_dtype() ==
+  // prepare_conv2d_weights.cpp where `weight_tensor_.dtype() ==
   // weights_bias_dtype`.
   //
   MLIRContext *context = op->getContext();

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -306,7 +306,7 @@ getPrepareConv2dWeightsOpOutputTensorSpec(
       // TODO(#2441): Need to match tensor dtypes with conv2d config.
       // This will be fixed on IR side shortly.
       localConfig.dtype = inputSpec.data_type();
-      localConfig.weights_dtype = weightTensor.get_dtype();
+      localConfig.weights_dtype = weightTensor.dtype();
     } else {
       localConfig = *conv2dConfigConverted;
     }

--- a/runtime/lib/ttnn/debug/debug_apis.cpp
+++ b/runtime/lib/ttnn/debug/debug_apis.cpp
@@ -17,14 +17,14 @@ void checkTensorRefMatchesTTNNTensor(
     const ::ttnn::Tensor &ttnnTensor) {
   ::ttnn::Layout expectedLayout =
       ::tt::runtime::ttnn::utils::inferLayoutFromTileShape(tensorRef);
-  ::ttnn::Layout actualLayout = ttnnTensor.get_layout();
+  ::ttnn::Layout actualLayout = ttnnTensor.layout();
   DEBUG_ASSERT(expectedLayout == actualLayout, "Layout mismatch, expected ",
                toString(expectedLayout), ", got ", toString(actualLayout));
 
   ::ttnn::DataType expectedDataType =
       ::tt::runtime::ttnn::utils::toTTNNDataType(
           tensorRef->desc()->layout()->memory_desc()->data_type());
-  ::ttnn::DataType actualDataType = ttnnTensor.get_dtype();
+  ::ttnn::DataType actualDataType = ttnnTensor.dtype();
   DEBUG_ASSERT(expectedDataType == actualDataType,
                "DataType mismatch, expected ", toString(expectedDataType),
                ", got ", toString(actualDataType));

--- a/runtime/lib/ttnn/operations/ccl/collective_permute.cpp
+++ b/runtime/lib/ttnn/operations/ccl/collective_permute.cpp
@@ -78,7 +78,7 @@ void run(const ::tt::target::ttnn::CollectivePermuteOp *op,
     // We need to memset this tensor value to 0 based on collective permute
     // operation semantics
     void *dstPtr = ::tt::runtime::ttnn::utils::getRawHostDataPtr(srcHostTensor);
-    size_t size = srcHostTensor.volume() * srcHostTensor.element_size();
+    size_t size = srcHostTensor.padded_volume() * srcHostTensor.element_size();
     std::memset(dstPtr, 0, size);
 
     newHostTensors[i] = srcHostTensor;
@@ -88,7 +88,7 @@ void run(const ::tt::target::ttnn::CollectivePermuteOp *op,
   // Combine all host tensor shards into a single host tensor with
   // multi device host storage.
   ::ttnn::Tensor out = ::ttnn::distributed::aggregate_as_tensor(
-      newHostTensors, input.get_distributed_tensor_config());
+      newHostTensors, input.distributed_tensor_config());
 
   out = ::ttnn::to_device(out, meshDevice, input.memory_config());
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);

--- a/runtime/lib/ttnn/operations/eltwise/binary/binary_composite.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/binary/binary_composite.cpp
@@ -65,7 +65,7 @@ static void runEltwiseBinaryNGCompositeOp(
              "Memory config must exist for device tensors");
 
   std::optional<bool> use_legacy = std::nullopt;
-  if (lhs->get_logical_shape() != rhs->get_logical_shape()) {
+  if (lhs->logical_shape() != rhs->logical_shape()) {
     // Set use_legacy to false when shapes require broadcasting
     // TODO(brataTT): Remove after
     // https://github.com/tenstorrent/tt-metal/issues/16147 is closed

--- a/runtime/lib/ttnn/operations/kv_cache/update_cache.cpp
+++ b/runtime/lib/ttnn/operations/kv_cache/update_cache.cpp
@@ -23,7 +23,7 @@ void run(const ::tt::target::ttnn::UpdateCacheOp *op, ProgramContext &context) {
   if (workaround::Env::get().readUpdateIndexFromDeviceForKVCache) {
 
     const ::ttnn::Tensor indexOnHost = ::ttnn::from_device(updateIndex);
-    const auto &storage = indexOnHost.get_storage();
+    const auto &storage = indexOnHost.storage();
     const auto &multiDeviceHostStorage =
         std::get<tt_metal::MultiDeviceHostStorage>(storage);
     const auto &buffer = multiDeviceHostStorage.get_buffer(0);

--- a/runtime/lib/ttnn/operations/utils/utils.cpp
+++ b/runtime/lib/ttnn/operations/utils/utils.cpp
@@ -48,7 +48,7 @@ bool isTilized(const ::tt::target::ttnn::TensorRef *tensorRef) {
 bool shouldSwapBinaryOperands(const ::ttnn::Tensor &lhs,
                               const ::ttnn::Tensor &rhs) {
   return (workaround::Env::get().swapBinaryOperands) &&
-         (lhs.volume() < rhs.volume());
+         (lhs.padded_volume() < rhs.padded_volume());
 }
 
 ::ttnn::operations::unary::UnaryOpType

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -211,7 +211,7 @@ tt::target::DataType getTensorDataType(::tt::runtime::Tensor tensor) {
   const ::ttnn::Tensor &nnTensor =
       tensor.as<::tt::runtime::ttnn::TTNNTensorWrapper>(DeviceRuntime::TTNN)
           .getTensor();
-  return utils::fromTTNNDataType(nnTensor.get_dtype());
+  return utils::fromTTNNDataType(nnTensor.dtype());
 }
 
 std::vector<std::byte> getTensorDataBuffer(::tt::runtime::Tensor tensor) {
@@ -323,7 +323,7 @@ std::uint32_t getTensorVolume(::tt::runtime::Tensor tensor) {
   const ::ttnn::Tensor &ttnnTensor =
       tensor.as<::tt::runtime::ttnn::TTNNTensorWrapper>(DeviceRuntime::TTNN)
           .getTensor();
-  return ttnnTensor.volume();
+  return ttnnTensor.padded_volume();
 }
 
 TensorDesc getTensorDesc(::tt::runtime::Tensor tensor) {
@@ -589,7 +589,7 @@ void memcpy(void *dst, ::tt::runtime::Tensor src) {
           .getTensor();
   if (utils::isOnHost(srcTensor.storage_type())) {
     const void *srcPtr = utils::getRawHostDataPtr(srcTensor);
-    size_t size = srcTensor.volume() * srcTensor.element_size();
+    size_t size = srcTensor.padded_volume() * srcTensor.element_size();
     std::memcpy(dst, srcPtr, size);
   } else {
     ::tt::tt_metal::memcpy(dst, srcTensor);
@@ -603,16 +603,17 @@ void memcpy(::tt::runtime::Tensor dst, ::tt::runtime::Tensor src) {
   const ::ttnn::Tensor &srcTensor =
       src.as<::tt::runtime::ttnn::TTNNTensorWrapper>(DeviceRuntime::TTNN)
           .getTensor();
-  LOG_ASSERT(srcTensor.volume() * srcTensor.element_size() ==
-                 dstTensor.volume() * dstTensor.element_size(),
+  LOG_ASSERT(srcTensor.padded_volume() * srcTensor.element_size() ==
+                 dstTensor.padded_volume() * dstTensor.element_size(),
              "Input output tensor size mismatch in memcpy: ",
-             srcTensor.volume(), " * ", srcTensor.element_size(),
-             " != ", dstTensor.volume(), " * ", dstTensor.element_size());
+             srcTensor.padded_volume(), " * ", srcTensor.element_size(),
+             " != ", dstTensor.padded_volume(), " * ",
+             dstTensor.element_size());
   if (utils::isOnHost(srcTensor.storage_type()) &&
       utils::isOnHost(dstTensor.storage_type())) {
     void *dstPtr = utils::getRawHostDataPtr(dstTensor);
     const void *srcPtr = utils::getRawHostDataPtr(srcTensor);
-    size_t size = srcTensor.volume() * srcTensor.element_size();
+    size_t size = srcTensor.padded_volume() * srcTensor.element_size();
     std::memcpy(dstPtr, srcPtr, size);
   } else {
     ::tt::tt_metal::memcpy(dstTensor, srcTensor);

--- a/runtime/lib/ttnn/types/types.cpp
+++ b/runtime/lib/ttnn/types/types.cpp
@@ -18,8 +18,8 @@ LayoutDesc LayoutDesc::fromTensor(const ::tt::runtime::Tensor &tensor) {
       tensor.as<::tt::runtime::ttnn::TTNNTensorWrapper>(DeviceRuntime::TTNN)
           .getTensor();
   ::ttnn::StorageType storageType = ttnnTensor.storage_type();
-  ::ttnn::Layout layout = ttnnTensor.get_layout();
-  ::ttnn::DataType dtype = ttnnTensor.get_dtype();
+  ::ttnn::Layout layout = ttnnTensor.layout();
+  ::ttnn::DataType dtype = ttnnTensor.dtype();
 
   std::optional<::ttnn::MemoryConfig> memoryConfig = std::nullopt;
   if (storageType == ::ttnn::StorageType::DEVICE) {

--- a/runtime/lib/ttnn/utils/utils.cpp
+++ b/runtime/lib/ttnn/utils/utils.cpp
@@ -289,7 +289,7 @@ void *getRawHostDataPtr(const ::ttnn::Tensor &tensor) {
             LOG_FATAL("Unsupported storage type ", debug::toString(storage));
             return nullptr;
           }},
-      tensor.get_storage());
+      tensor.storage());
   return dataPtr;
 }
 

--- a/runtime/test/ttnn/dylib.cpp
+++ b/runtime/test/ttnn/dylib.cpp
@@ -225,14 +225,14 @@ bool compareOuts(std::vector<::tt::runtime::Tensor> &lhs,
 
     // Compare various tensor properties
     //
-    LOG_ASSERT(lhsTensor->get_dtype() == rhsTensor->get_dtype(),
-               "DType: ", lhsTensor->get_dtype(), ", ", rhsTensor->get_dtype());
-    LOG_ASSERT(lhsTensor->get_layout() == rhsTensor->get_layout(),
-               "Layout: ", static_cast<int>(lhsTensor->get_layout()), ", ",
-               static_cast<int>(rhsTensor->get_layout()));
-    LOG_ASSERT(lhsTensor->get_logical_shape() == rhsTensor->get_logical_shape(),
-               "Logical shape: ", lhsTensor->get_logical_shape(), ", ",
-               rhsTensor->get_logical_shape());
+    LOG_ASSERT(lhsTensor->dtype() == rhsTensor->dtype(),
+               "DType: ", lhsTensor->dtype(), ", ", rhsTensor->dtype());
+    LOG_ASSERT(lhsTensor->layout() == rhsTensor->layout(),
+               "Layout: ", static_cast<int>(lhsTensor->layout()), ", ",
+               static_cast<int>(rhsTensor->layout()));
+    LOG_ASSERT(lhsTensor->logical_shape() == rhsTensor->logical_shape(),
+               "Logical shape: ", lhsTensor->logical_shape(), ", ",
+               rhsTensor->logical_shape());
 
     // Compare tensor data
     //
@@ -241,14 +241,14 @@ bool compareOuts(std::vector<::tt::runtime::Tensor> &lhs,
         ::tt::runtime::ttnn::utils::getRawHostDataPtr(*lhsTensor));
     uint8_t *rhsData = static_cast<uint8_t *>(
         ::tt::runtime::ttnn::utils::getRawHostDataPtr(*rhsTensor));
-    for (size_t i = 0; i < lhsTensor->volume(); ++i) {
+    for (size_t i = 0; i < lhsTensor->padded_volume(); ++i) {
       SupportedTypes lhsVal =
-          getValueForDType(lhsTensor->get_dtype(), lhsData + i * elementSize);
+          getValueForDType(lhsTensor->dtype(), lhsData + i * elementSize);
       SupportedTypes rhsVal =
-          getValueForDType(rhsTensor->get_dtype(), rhsData + i * elementSize);
+          getValueForDType(rhsTensor->dtype(), rhsData + i * elementSize);
       if (lhsVal != rhsVal) {
         LOG_FATAL("Mismatch at index ",
-                  toString(getIndex(lhsTensor->get_logical_shape(), i)), ": ",
+                  toString(getIndex(lhsTensor->logical_shape(), i)), ": ",
                   toString(lhsVal), " != ", toString(rhsVal));
         return false;
       }

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -26,7 +26,10 @@ message(STATUS "Setting tt-metal CPM cache to: ${CPM_SOURCE_CACHE}")
 
 set(TTMETAL_INCLUDE_DIRS
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/ttnn
+  ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/ttnn/api
+  ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/ttnn/core
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/ttnn/cpp
+  ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/deprecated
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/api
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "6f8b06c566a627fa06117852643175e1f9298c0a")
+set(TT_METAL_VERSION "1a58dca1c570bc38bdef6b728b692ee4e8c34a55")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 

--- a/tools/ttnn-standalone/CMakeLists.txt
+++ b/tools/ttnn-standalone/CMakeLists.txt
@@ -101,6 +101,8 @@ set(INCLUDE_DIRS
 
     # TTNN
     ${METAL_SRC_DIR}/ttnn
+    ${METAL_SRC_DIR}/ttnn/api
+    ${METAL_SRC_DIR}/ttnn/core
     ${METAL_SRC_DIR}/ttnn/cpp
     ${METAL_SRC_DIR}/ttnn/cpp/ttnn
 )

--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -6,8 +6,6 @@
 #define TOOLS_TTNN_STANDALONE_TTNN_PRECOMPILED_HPP
 
 // ANCHOR: standalone_includes
-#include "core.hpp"
-#include "device.hpp"
 #include "operations/ccl/all_gather/all_gather.hpp"
 #include "operations/ccl/ccl_host_types.hpp"
 #include "operations/ccl/reduce_scatter/reduce_scatter.hpp"
@@ -41,7 +39,9 @@
 #include "tensor/types.hpp"
 #include "tt-metalium/bfloat16.hpp"
 #include "tt-metalium/small_vector.hpp"
-#include "types.hpp"
+#include "ttnn/core.hpp"
+#include "ttnn/device.hpp"
+#include "ttnn/types.hpp"
 #include "workarounds.hpp"
 // ANCHOR_END: standalone_includes
 


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 1a58dca1c570bc38bdef6b728b692ee4e8c34a55

- Update Tensor getters after metal change 11cedac
- Include paths for new ttnn core and api components after metal change 89cf9e2