### PR TITLE
Slightly improve EmitC docs

### DIFF
--- a/docs/src/emitc-testing.md
+++ b/docs/src/emitc-testing.md
@@ -1,5 +1,7 @@
 # EmitC testing
 
+#### NOTE: This is a developer's guide on how to test EmitC as a feature. For usage of EmitC, please refer to [ttnn-standalone](ttnn-standalone.md) docs.
+
 ## Prerequisites
 
 * [Built ttmlir](https://docs.tenstorrent.com/tt-mlir/build.html#build)

--- a/docs/src/ttnn-standalone.md
+++ b/docs/src/ttnn-standalone.md
@@ -1,18 +1,24 @@
-# `ttnn-standalone`
+# ttnn-standalone
 
-TTNN Standalone is a post-compile tuning/debugging tool.
+`ttnn-standalone` is a post-compile tuning/debugging tool.
 
-Forge and third party ML models (PyTorch, Jax, ONNX, ...) can be compiled to a set of TTNN library calls in C++. This generated code can then be used outside of the compiler environment. TTNN Standalone tool offers all the scaffolding needed to run the C++ code on device (build & run scripts).
+Forge and third party ML models (PyTorch, Jax, ONNX, ...) can be compiled to a set of TTNN library op calls in C++. This generated code can then be used outside of the compiler environment. `ttnn-standalone` tool offers all the scaffolding needed to run the C++ code on device (build & run scripts).
 
 ### Usage
 
 ```bash
-# Compile a model to EmitC dialect => translate to C++ code => pipe to ttnn-standalone.cpp
-./build/bin/ttmlir-opt --ttir-to-emitc-pipeline test/ttmlir/EmitC/TTNN/sanity_add.mlir \
-| ./build/bin/ttmlir-translate --mlir-to-cpp \
-> tools/ttnn-standalone/ttnn-standalone.cpp
+# 1. Convert a model from TTIR dialect to EmitC dialect using ttmlir-opt
+# 2. Translate the resulting EmitC dialect to C++ code using ttmlir-translate
+# 3. Pipe the generated C++ code to a .cpp file
+ttmlir-opt \
+  --ttir-to-emitc-pipeline \
+  test/ttmlir/EmitC/TTNN/sanity_add.mlir | \
+ttmlir-translate \
+  --mlir-to-cpp > \
+  tools/ttnn-standalone/ttnn-standalone.cpp
 
-# Change dir to `tools/ttnn-standalone` and use the `run` script to compile and run the ttnn standalone:
+# 1. Change dir to `tools/ttnn-standalone`
+# 2. Use `run` script to compile and run the compiled binary
 cd tools/ttnn-standalone
 ./run
 ```
@@ -21,4 +27,4 @@ Note: if you receive this error
 ```bash
 -bash: ./run: Permission denied
 ```
-running `chmod +x run` will allow the execution of the script.
+running `chmod +x run` will set the execute permission on the script.


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Folks regularly open `EmitC testing` section in search of docs on how to run models thru EmitC.

### What's changed
Added a note to redirect to `ttnn-standalone`. Improved those docs a bit as well.

### Checklist
- [ ] New/Existing tests provide coverage for changes
