### PR TITLE
Guard misc `tools/` against disabled bindings

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,12 +1,17 @@
 add_subdirectory(ttmlir-opt)
 add_subdirectory(ttmlir-lsp-server)
-add_subdirectory(ttir-builder)
-add_subdirectory(ttmlir-translate)
-if (TTMLIR_ENABLE_EXPLORER)
-  add_subdirectory(explorer)
-endif()
+if(TTMLIR_ENABLE_BINDINGS_PYTHON AND MLIR_ENABLE_BINDINGS_PYTHON)
+  add_subdirectory(ttir-builder)
 
-if (TTMLIR_ENABLE_PYKERNEL)
-  add_subdirectory(pykernel)
+  if (TTMLIR_ENABLE_PYKERNEL)
+    add_subdirectory(pykernel)
+  endif()
+
+  if (TTMLIR_ENABLE_EXPLORER)
+    add_subdirectory(explorer)
+  endif()
+
 endif()
+add_subdirectory(ttmlir-translate)
+
 add_subdirectory(ttnn-standalone)


### PR DESCRIPTION
Closes #3393

### Problem description
When `DTTMLIR_ENABLE_BINDINGS_PYTHON=OFF`, various tools would cause build failures.

### What's changed
Inclusion of the subdirs the problem tools live in has been guarded against the bindings being disabled