### PR TITLE
Switched PyKernel Deps to force TestPyPi index instead of searching latest forge release

### DIFF
--- a/.github/workflows/wheel-build.yml
+++ b/.github/workflows/wheel-build.yml
@@ -91,14 +91,6 @@ jobs:
         run: |
           python3.10 -m pip install wheel setuptools
 
-      # Add some of John's Bash Dark Magic to Update requirements.txt if possible.
-      - name: Update ttmlir Requirement
-        shell: bash
-        run: |
-          URL=$(curl -s https://api.github.com/repos/tenstorrent/tt-forge/releases | jq -r 'map(select(.prerelease)) | first | .assets | map(select(.browser_download_url | contains("mlir"))) | .[].browser_download_url')
-          echo "ttmlir @ $URL" > tools/pykernel/requirements.txt
-          echo "Updated requirements.txt with: $URL"
-
       - name: Build pykernel wheel
         shell: bash
         run: |

--- a/env/activate
+++ b/env/activate
@@ -28,3 +28,6 @@ export TT_METAL_BUILD_HOME="$(pwd)/third_party/tt-metal/src/tt-metal/build"
 export TT_MLIR_HOME="$(pwd)"
 export PYTHONPATH="$(pwd)/${BUILD_DIR:=build}/python_packages:$(pwd)/.local/toolchain/python_packages/mlir_core:${TT_METAL_HOME}:${TT_METAL_HOME}/tt_eager:${TT_METAL_BUILD_HOME}/tools/profiler/bin:${TT_METAL_HOME}/ttnn"
 export ARCH_NAME="${ARCH_NAME:-wormhole_b0}"
+
+# Allow TestPyPi here
+export PIP_EXTRA_INDEX_URL="https://test.pypi.org/simple/ https://download.pytorch.org/whl/cpu"

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,5 +1,9 @@
 add_subdirectory(ttmlir-opt)
 add_subdirectory(ttmlir-lsp-server)
+add_subdirectory(ttmlir-translate)
+add_subdirectory(ttnn-standalone)
+
+# Tools that rely on Python Bindings
 if(TTMLIR_ENABLE_BINDINGS_PYTHON AND MLIR_ENABLE_BINDINGS_PYTHON)
   add_subdirectory(ttir-builder)
 
@@ -12,6 +16,3 @@ if(TTMLIR_ENABLE_BINDINGS_PYTHON AND MLIR_ENABLE_BINDINGS_PYTHON)
   endif()
 
 endif()
-add_subdirectory(ttmlir-translate)
-
-add_subdirectory(ttnn-standalone)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,12 +1,17 @@
 add_subdirectory(ttmlir-opt)
 add_subdirectory(ttmlir-lsp-server)
-add_subdirectory(ttir-builder)
-add_subdirectory(ttmlir-translate)
-if (TTMLIR_ENABLE_EXPLORER)
-  add_subdirectory(explorer)
-endif()
+if(TTMLIR_ENABLE_BINDINGS_PYTHON AND MLIR_ENABLE_BINDINGS_PYTHON)
+  add_subdirectory(ttir-builder)
 
-if (TTMLIR_ENABLE_PYKERNEL)
-  add_subdirectory(pykernel)
+  if (TTMLIR_ENABLE_PYKERNEL)
+    add_subdirectory(pykernel)
+  endif()
+
+  if (TTMLIR_ENABLE_EXPLORER)
+    add_subdirectory(explorer)
+  endif()
+
 endif()
+add_subdirectory(ttmlir-translate)
+
 add_subdirectory(ttnn-standalone)

--- a/tools/pykernel/requirements.txt
+++ b/tools/pykernel/requirements.txt
@@ -1,1 +1,1 @@
-ttmlir @ https://github.com/tenstorrent/tt-forge/releases/download/nightly-0.1.0.dev20250505060214/ttmlir-0.1.0.dev20250505060214-cp310-cp310-manylinux_2_34_x86_64.whl
+ttmlir


### PR DESCRIPTION
- Relies on the hotfix that Collin added (#3394) 

### Problem description
- Hotfix failed PyKernel build because of some wild API issue. 
- Highlights the fragile dependency resolution mechanism we are currently using.


### What's changed
- Considering we already use TestPyPi, this PR forces the switch over by leveraging the environment variables to force extra index URLs.
- Causes an issue where if the wheel is installed on a system that doesn't have this env variable, the dep doesn't get resolved.
