### PR TITLE
Add missing attributes to max pool op

### DIFF
--- a/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
+++ b/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
@@ -785,6 +785,14 @@ public:
     return rewriter.getAttr<emitc::OpaqueAttr>(convert(attr));
   }
 
+  mlir::Attribute emit(ttnn::TensorMemoryLayout attr) {
+    return rewriter.getAttr<emitc::OpaqueAttr>(convert(attr));
+  }
+
+  mlir::Attribute emit(ttnn::TensorMemoryLayoutAttr attr) {
+    return rewriter.getAttr<emitc::OpaqueAttr>(convert(attr));
+  }
+
   mlir::Attribute emit(tt::ttnn::MemoryConfigAttr attr) {
     return rewriter.getType<emitc::OpaqueAttr>(convert(attr));
   }

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1370,7 +1370,39 @@ def TTNN_ConvTranspose2dOp : TTNN_Op<"conv_transpose2d"> {
     }];
 }
 
-def TTNN_AvgPool2dOp : TTNN_Op<"avg_pool2d"> {
+class TTNN_PoolingOp<string mnemonic, list<Trait> traits = []> :
+    TTNN_Op<mnemonic, [HasMemoryConfigTrait] # traits> {
+    let summary = "Generic pooling op.";
+    let description = [{
+      Generic pooling op.
+    }];
+
+    let arguments = (ins AnyRankedTensor:$input,
+                         SI32Attr:$batch_size,
+                         SI32Attr:$input_height,
+                         SI32Attr:$input_width,
+                         SI32Attr:$channels,
+                         DenseI32ArrayAttr:$kernel_size,
+                         DenseI32ArrayAttr:$stride,
+                         DenseI32ArrayAttr:$padding,
+                         DenseI32ArrayAttr:$dilation,
+                         OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config,
+                         OptionalAttr<TTNN_TensorMemoryLayoutAttr>:$applied_shard_scheme,
+                         BoolAttr:$ceil_mode,
+                         BoolAttr:$in_place_halo);
+
+    let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
+        return wa::TTNNOperandsWorkaroundsFactory::createPool2DOpOperandsWorkarounds();
+      }
+    }];
+
+    let hasVerifier = 1;
+}
+
+def TTNN_AvgPool2dOp : TTNN_PoolingOp<"avg_pool2d"> {
   let summary = "Applies a 2D average pooling over an input signal composed of several input planes.";
   let description = [{
     It is a downsampling operation to reduce the spatial dimensions (height and width) of a input tensor by computing averages with in a window.
@@ -1389,57 +1421,15 @@ def TTNN_AvgPool2dOp : TTNN_Op<"avg_pool2d"> {
       output: [[3, 4],
                [6, 7]]
   }];
-
-  let arguments = (ins AnyRankedTensor:$input,
-                       UI32Attr:$batch_size,
-                       UI32Attr:$input_height,
-                       UI32Attr:$input_width,
-                       UI32Attr:$channels,
-                       DenseI32ArrayAttr:$kernel_size,
-                       DenseI32ArrayAttr:$stride,
-                       DenseI32ArrayAttr:$padding,
-                       DenseI32ArrayAttr:$dilation,
-                       BoolAttr:$ceil_mode);
-
-  let results = (outs AnyRankedTensor:$result);
-
-  let extraClassDeclaration = [{
-    wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
-      return wa::TTNNOperandsWorkaroundsFactory::createPool2DOpOperandsWorkarounds();
-    }
-  }];
-
-  let hasVerifier = 1;
 }
 
-def TTNN_MaxPool2dOp : TTNN_Op<"max_pool2d",
+def TTNN_MaxPool2dOp : TTNN_PoolingOp<"max_pool2d",
       [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
       > {
     let summary = "Applies a 2D max pooling over an input signal composed of several input planes.";
     let description = [{
       Applies a 2D max pooling over an input signal composed of several input planes.
     }];
-
-    let arguments = (ins AnyRankedTensor:$input,
-                         SI32Attr:$batch_size,
-                         SI32Attr:$input_height,
-                         SI32Attr:$input_width,
-                         SI32Attr:$channels,
-                         DenseI32ArrayAttr:$kernel_size,
-                         DenseI32ArrayAttr:$stride,
-                         DenseI32ArrayAttr:$padding,
-                         DenseI32ArrayAttr:$dilation,
-                         BoolAttr:$ceil_mode);
-
-    let results = (outs AnyRankedTensor:$result);
-
-    let extraClassDeclaration = [{
-      wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
-        return wa::TTNNOperandsWorkaroundsFactory::createPool2DOpOperandsWorkarounds();
-      }
-    }];
-
-    let hasVerifier = 1;
 }
 
 def TTNN_ClampScalarOp : TTNN_Op<"clamp_scalar", [HasMemoryConfigTrait,

--- a/include/ttmlir/Target/TTNN/operations/pool.fbs
+++ b/include/ttmlir/Target/TTNN/operations/pool.fbs
@@ -20,7 +20,10 @@ table Pool2dOp {
   stride: [int32];
   padding: [int32];
   dilation: [int32];
-  ceil_mode: bool;
+  memory_config: tt.target.ttnn.MemoryConfig;
+  applied_shard_scheme: tt.target.ttnn.TensorMemoryLayout = null;
+  ceil_mode: bool = false;
+  in_place_halo: bool = false;
 }
 
 table UniformScale2D {

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -301,7 +301,7 @@ public:
     rewriter.replaceOpWithNewOp<ttnn::ProdOp>(
         op, this->getTypeConverter()->convertType(op.getType()),
         adaptor.getInput(), newDimArg, adaptor.getKeepDim(),
-        /*memoryConfig*/ nullptr);
+        /*memoryConfig=*/nullptr);
     return success();
   }
 };
@@ -602,7 +602,7 @@ public:
     rewriter.replaceOpWithNewOp<ttnn::ConcatOp>(
         op, this->getTypeConverter()->convertType(op.getType()),
         adaptor.getInputs(), dim,
-        /* memory_config */ nullptr);
+        /*memory_config=*/nullptr);
     return success();
   }
 };
@@ -618,7 +618,7 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     rewriter.replaceOpWithNewOp<ttnn::ReshapeOp>(
         op, this->getTypeConverter()->convertType(op.getType()),
-        adaptor.getInput(), adaptor.getShape(), /* memory_config */ nullptr);
+        adaptor.getInput(), adaptor.getShape(), /*memory_config=*/nullptr);
     return success();
   }
 };
@@ -678,7 +678,7 @@ public:
     // Replace the SqueezeOp with a ReshapeOp
     rewriter.replaceOpWithNewOp<ttnn::ReshapeOp>(
         op, this->getTypeConverter()->convertType(op.getType()),
-        adaptor.getInput(), shapeAttr, /* memory_config */ nullptr);
+        adaptor.getInput(), shapeAttr, /*memory_config=*/nullptr);
 
     return success();
   }
@@ -747,7 +747,7 @@ public:
     rewriter.replaceOpWithNewOp<ttnn::PadOp>(
         op, this->getTypeConverter()->convertType(op.getType()),
         adaptor.getInput(), adaptor.getPaddingAttr(), adaptor.getValue(),
-        /* use_multicore */ true, memcfg);
+        /*use_multicore=*/true, memcfg);
 
     return success();
   }
@@ -797,7 +797,7 @@ public:
     // Replace the UnsqueezeOp with a ReshapeOp
     rewriter.replaceOpWithNewOp<ttnn::ReshapeOp>(
         op, this->getTypeConverter()->convertType(op.getType()),
-        adaptor.getInput(), shapeAttr, /* memory_config */ nullptr);
+        adaptor.getInput(), shapeAttr, /*memory_config=*/nullptr);
 
     return success();
   }
@@ -1091,7 +1091,7 @@ public:
         adaptor.getBias(), device, inChannelsAttr, outChannelsAttr,
         batchSizeAttr, inputHeightAttr, inputWidthAttr, kernelSizeAttr,
         *strideAttr, reducedPaddingAttr, *outputPaddingAttr, *dilationAttr,
-        groupsAttr, /*memoryConfig*/ nullptr);
+        groupsAttr, /*memoryConfig=*/nullptr);
 
     // Restore the normal shape (N x H x W x C).
     Value output =
@@ -1184,9 +1184,9 @@ public:
         adaptor.getFlattenedCompatInfo().getInputHeight(),
         adaptor.getFlattenedCompatInfo().getInputWidth(), channels,
         kernelSizeAttr, strideAttr, paddingAttr, dilationAttr,
-        /* memory_config */ nullptr,
-        /* applied_shard_scheme */ nullptr, adaptor.getCeilMode(),
-        /* in_place_halo */ false);
+        /*memory_config=*/nullptr,
+        /* applied_shard_scheme=*/nullptr, adaptor.getCeilMode(),
+        /* in_place_halo=*/false);
 
     return success();
   }

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -1184,7 +1184,9 @@ public:
         adaptor.getFlattenedCompatInfo().getInputHeight(),
         adaptor.getFlattenedCompatInfo().getInputWidth(), channels,
         kernelSizeAttr, strideAttr, paddingAttr, dilationAttr,
-        adaptor.getCeilMode());
+        /* memory_config */ nullptr,
+        /* applied_shard_scheme */ nullptr, adaptor.getCeilMode(),
+        /* in_place_halo */ false);
 
     return success();
   }

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -568,9 +568,10 @@ public:
         emitter.template emit<std::array<uint32_t, 2>>(srcOp.getStrideAttr()),
         emitter.template emit<std::array<uint32_t, 2>>(srcOp.getPaddingAttr()),
         emitter.template emit<std::array<uint32_t, 2>>(srcOp.getDilationAttr()),
-        emitter.emit(std::nullopt) | emitter.getMemoryConfig(srcOp.getResult()),
-        /*applied_shard_scheme=*/emitter.emit(std::nullopt),
+        emitter.getMemoryConfig(srcOp.getResult()),
+        emitter.emit(srcOp.getAppliedShardScheme()),
         emitter.emit(srcOp.getCeilMode()),
+        emitter.emit(srcOp.getInPlaceHalo()),
     };
 
     emitter.replaceOp(*this, args);

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -1360,10 +1360,13 @@ createPool2dOp(FlatbufferObjectCache &cache, Pool2dOp op) {
   ::flatbuffers::Offset<::flatbuffers::Vector<int32_t>> dilation =
       toFlatbuffer(cache, op.getDilation());
 
+  auto memoryConfig = getMemoryConfigIfNeeded(cache, op);
+
   return ::tt::target::ttnn::CreatePool2dOp(
       *cache.fbb, type, in, out, op.getBatchSize(), op.getInputHeight(),
       op.getInputWidth(), op.getChannels(), kernelSize, stride, padding,
-      dilation, op.getCeilMode());
+      dilation, memoryConfig, toFlatbuffer(cache, op.getAppliedShardScheme()),
+      op.getCeilMode(), op.getInPlaceHalo());
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::RepeatInterleaveOp>

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/max_pool2d_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/max_pool2d_workaround.mlir
@@ -19,7 +19,7 @@ module attributes {} {
     // CHECK-SAME: memory_config = #ttnn.memory_config<#dram, <interleaved>>
     // CHECK-SAME: -> tensor<1x1x16384x32xbf16,
     // %3 = "ttnn.max_pool2d"(%2, %0) <{batch_size = 1 : si32, ceil_mode = false, channels = 32 : si32, dilation_height = 1 : si32, dilation_width = 1 : si32, input_height = 128 : si32, input_width = 128 : si32, kernel_height = 2 : si32, kernel_width = 2 : si32, padding_height = 0 : si32, padding_width = 0 : si32, stride_height = 2 : si32, stride_width = 2 : si32}> : (tensor<1x1x16384x32xf32, #ttnn_layout2>, !tt.device<#device>) -> tensor<1x1x4096x32xf32, #ttnn_layout3>
-    %3 = "ttnn.max_pool2d"(%2) <{batch_size = 1 : si32, ceil_mode = false, channels = 32 : si32, input_height = 128 : si32, input_width = 128 : si32, kernel_size = array<i32: 2, 2>, stride = array<i32: 2, 2>, dilation = array<i32: 1, 1>, padding = array<i32: 0, 0>}> : (tensor<1x1x16384x32xf32, #ttnn_layout2>) -> tensor<1x1x4096x32xf32, #ttnn_layout3>
+    %3 = "ttnn.max_pool2d"(%2) <{batch_size = 1 : si32, ceil_mode = false, channels = 32 : si32, input_height = 128 : si32, input_width = 128 : si32, kernel_size = array<i32: 2, 2>, stride = array<i32: 2, 2>, dilation = array<i32: 1, 1>, padding = array<i32: 0, 0>, in_place_halo = false}> : (tensor<1x1x16384x32xf32, #ttnn_layout2>) -> tensor<1x1x4096x32xf32, #ttnn_layout3>
     // CHECK-NEXT: %[[MAX_POOL_2D_OP:.*]] = "ttnn.max_pool2d"(%[[TO_LAYOUT_INPUT]])
     // Check that the output operand is transformed back into the tile and f32 data type.
     // CHECK-NEXT: %[[TO_LAYOUT_OUTPUT:.*]] = "ttnn.to_layout"(%[[MAX_POOL_2D_OP]], %[[DEVICE_OP]])

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -937,9 +937,12 @@ TEST_F(OpModelBase, maxPool2DOp) {
   int32_t strideWidth = 2;
   int32_t dilationHeight = 1;
   int32_t dilationWidth = 1;
-  bool ceilMode = false;
   int32_t paddingHeight = 0;
   int32_t paddingWidth = 0;
+  MemoryConfigAttr memoryConfigAttr = nullptr;
+  TensorMemoryLayoutAttr appliedShardScheme = nullptr;
+  bool ceilMode = false;
+  bool inPlaceHalo = false;
 
   llvm::SmallVector<int32_t, 2> kernelSize = {kernelHeight, kernelWidth};
   llvm::SmallVector<int32_t, 2> stride = {strideHeight, strideWidth};
@@ -948,7 +951,8 @@ TEST_F(OpModelBase, maxPool2DOp) {
 
   auto maxPool2DOp = builder.create<MaxPool2dOp>(
       builder.getUnknownLoc(), output.getType(), input, batchSize, inputHeight,
-      inputWidth, numChannels, kernelSize, stride, padding, dilation, ceilMode);
+      inputWidth, numChannels, kernelSize, stride, padding, dilation,
+      memoryConfigAttr, appliedShardScheme, ceilMode, inPlaceHalo);
   maxPool2DOp->setAttr(DeviceAttr::name, getFakeDeviceAttr());
 
   constexpr int32_t numRuns = 10;


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/2547

### Problem description
Few attributes were missing from the pooling ops.

### What's changed
This PR adds missing attributes to pooling ops:
- memory_config
- applied_shard_scheme
- inPlaceHalo

Additionally this PR merges Max and Avg pool into a single class definition in TTNN dialect.

### Checklist
- [x] New/Existing tests provide coverage for changes
