### PR TITLE
1x1 convolution to matmul optimization first pass

### DIFF
--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -503,6 +503,13 @@ def TTIRQuantDataTypeConversionPass : Pass<"ttir-quant-data-type-conversion", ":
   ];
 }
 
+def TTIRConv2DToMatmulPass : Pass<"ttir-conv2d-to-matmul", "::mlir::ModuleOp">
+{
+  let summary = "Convert Conv2D to Matmul.";
+  let description = "This pass converts Conv2D operations to Matmul operations.";
+  let dependentDialects = ["mlir::tt::ttir::TTIRDialect"];
+}
+
 def TTIRFusing: Pass<"ttir-fusing", "::mlir::ModuleOp">
 {
   let summary = "TTIR fusing pass.";

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -197,6 +197,10 @@ struct TTIRToTTNNBackendPipelineOptions
       *this, "enable-erase-inverse-ops-pass",
       llvm::cl::desc("Enable erase inverse ops pass."), llvm::cl::init(true)};
 
+  Option<bool> conv2dToMatmulEnabled{
+      *this, "enable-conv2d-to-matmul-pass",
+      llvm::cl::desc("Enable conv2d to matmul pass."), llvm::cl::init(false)};
+
   Option<bool> enableFusing{*this, "enable-fusing-pass",
                             llvm::cl::desc("Enable fusing pass."),
                             llvm::cl::init(false)};

--- a/lib/Dialect/TTIR/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTIR/Transforms/CMakeLists.txt
@@ -2,6 +2,7 @@ add_subdirectory(EraseInverseOps)
 add_mlir_dialect_library(MLIRTTIRTransforms
         Allocate.cpp
         Broadcast.cpp
+        Conv2DToMatmul.cpp
         FlattenSlidingWindow.cpp
         GenericLinearizeMemref.cpp
         GenericGenerateDatamovement.cpp

--- a/lib/Dialect/TTIR/Transforms/Conv2DToMatmul.cpp
+++ b/lib/Dialect/TTIR/Transforms/Conv2DToMatmul.cpp
@@ -1,0 +1,181 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/ValueRange.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+
+using namespace mlir;
+using namespace llvm;
+
+namespace mlir {
+namespace tt {
+namespace ttir {
+
+#define GEN_PASS_DEF_TTIRCONV2DTOMATMULPASS
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h.inc"
+
+namespace {
+// Pattern to convert Conv2D operations with 1x1 kernels to MatMul operations
+// when applicable. Requirements: The kernel size must be 1x1, the stride must
+// be 1 and the padding must be 0. Resulting transform:
+//     Input of [N, C, H, W] reshaped to [N*H*W, C]
+//     Weight vector of [O, I, H, W] permuted to [I, O, H, W] and reshaped to
+//     [I*O*H, W] Matmul of [N*H*W, C] and [I*O*H, W] with output [N*H*W, W]
+//     Reshape of [N*H*W, W] to original output tensor of [N, H, W, C]
+class Conv2DToMatmulPattern : public OpRewritePattern<ttir::Conv2dOp> {
+public:
+  Conv2DToMatmulPattern(MLIRContext *context, PatternBenefit benefit = 1)
+      : OpRewritePattern<ttir::Conv2dOp>(context, benefit) {}
+
+  LogicalResult matchAndRewrite(ttir::Conv2dOp op,
+                                PatternRewriter &rewriter) const override {
+    RankedTensorType weightType =
+        mlir::cast<RankedTensorType>(op.getWeight().getType());
+    llvm::ArrayRef<int64_t> weightShape = weightType.getShape();
+
+    // Check kernel size is 1x1.
+    if (weightShape[2] != 1 || weightShape[3] != 1) {
+      return failure();
+    }
+
+    // Check stride is 1.
+    mlir::Attribute rawStrideAttr = op.getStride();
+    mlir::DenseI32ArrayAttr strideAttr =
+        mlir::dyn_cast<mlir::DenseI32ArrayAttr>(rawStrideAttr);
+    llvm::ArrayRef<int32_t> strides = strideAttr.asArrayRef();
+    if (strides.size() != 2 || strides[0] != 1 || strides[1] != 1) {
+      return failure();
+    }
+
+    // Check padding is 0.
+    mlir::Attribute paddingAttr = op.getPadding();
+    mlir::DenseI32ArrayAttr paddingArrayAttr =
+        mlir::dyn_cast<mlir::DenseI32ArrayAttr>(paddingAttr);
+    if (!paddingArrayAttr || paddingArrayAttr.size() != 4 ||
+        llvm::any_of(paddingArrayAttr.asArrayRef(),
+                     [](int32_t v) { return v != 0; })) {
+      return failure();
+    }
+
+    RankedTensorType inputType =
+        mlir::cast<RankedTensorType>(op.getInput().getType());
+    llvm::ArrayRef<int64_t> inputShape = inputType.getShape();
+    RankedTensorType outputType =
+        mlir::cast<RankedTensorType>(op.getResult().getType());
+
+    // Input is OIHW.
+    int64_t flattenedSpatialDim = inputShape[1] * inputShape[2];
+    int64_t inputChannel = inputShape[3];
+    int64_t outputChannel = weightShape[0];
+
+    // Create reshaped input: [N*H*W, C].
+    SmallVector<int64_t> reshapedInputShape = {
+        inputShape[0] * flattenedSpatialDim, inputChannel};
+    RankedTensorType reshapedInputType =
+        RankedTensorType::get(reshapedInputShape, inputType.getElementType());
+
+    // Create empty tensor for reshape output.
+    Value emptyReshapedInput =
+        rewriter.create<ttir::EmptyOp>(op.getLoc(), reshapedInputType);
+    SmallVector<int32_t> reshapedInputShape32;
+    for (int64_t dim : reshapedInputShape) {
+      reshapedInputShape32.push_back(static_cast<int32_t>(dim));
+    }
+    mlir::ArrayAttr reshapedInputShapeAttr =
+        rewriter.getI32ArrayAttr(reshapedInputShape32);
+
+    Value reshapedInput = rewriter.create<ttir::ReshapeOp>(
+        op.getLoc(), reshapedInputType, op.getInput(), emptyReshapedInput,
+        reshapedInputShapeAttr);
+
+    // Permute weights.
+    SmallVector<int64_t> transposeWeightShape = {weightShape[1], weightShape[0],
+                                                 1, 1};
+    SmallVector<int64_t> permutation = {1, 0, 2, 3};
+    RankedTensorType transposedWeightType = RankedTensorType::get(
+        transposeWeightShape, weightType.getElementType());
+    Value emptyTransposedWeight =
+        rewriter.create<ttir::EmptyOp>(op.getLoc(), transposedWeightType);
+    mlir::DenseI64ArrayAttr permAttr =
+        rewriter.getDenseI64ArrayAttr(permutation);
+
+    Value transposedWeight = rewriter.create<ttir::PermuteOp>(
+        op.getLoc(), transposedWeightType, op.getWeight(),
+        emptyTransposedWeight, permAttr);
+
+    // Reshape weight to [I, O].
+    SmallVector<int64_t> reshapedWeightShape = {inputChannel, outputChannel};
+    RankedTensorType reshapedWeightType =
+        RankedTensorType::get(reshapedWeightShape, weightType.getElementType());
+    Value emptyReshapedWeight =
+        rewriter.create<ttir::EmptyOp>(op.getLoc(), reshapedWeightType);
+    SmallVector<int32_t> reshapedWeightShape32;
+    for (int64_t dim : reshapedWeightShape) {
+      reshapedWeightShape32.push_back(static_cast<int32_t>(dim));
+    }
+    mlir::ArrayAttr reshapedWeightShapeAttr =
+        rewriter.getI32ArrayAttr(reshapedWeightShape32);
+
+    Value reshapedWeight = rewriter.create<ttir::ReshapeOp>(
+        op.getLoc(), reshapedWeightType, transposedWeight, emptyReshapedWeight,
+        reshapedWeightShapeAttr);
+    SmallVector<int64_t> matmulOutputShape = {
+        inputShape[0] * flattenedSpatialDim, outputChannel};
+    RankedTensorType matmulOutputType =
+        RankedTensorType::get(matmulOutputShape, outputType.getElementType());
+
+    Value emptyTensor =
+        rewriter.create<ttir::EmptyOp>(op.getLoc(), matmulOutputType);
+
+    // Create the matmul operation.
+    Value matmulResult = rewriter.create<ttir::MatmulOp>(
+        op.getLoc(), matmulOutputType, reshapedInput, reshapedWeight,
+        emptyTensor);
+
+    // Reshape matmul result back to NHWC format
+    SmallVector<int64_t> finalOutputShape = {inputShape[0], inputShape[1],
+                                             inputShape[2], outputChannel};
+    SmallVector<int32_t> finalOutputShape32;
+    for (int64_t dim : finalOutputShape) {
+      finalOutputShape32.push_back(static_cast<int32_t>(dim));
+    }
+    mlir::ArrayAttr finalOutputShapeAttr =
+        rewriter.getI32ArrayAttr(finalOutputShape32);
+
+    // Replace the original op with a new ReshapeOp in one step
+    rewriter.replaceOpWithNewOp<ttir::ReshapeOp>(
+        op, outputType, matmulResult, op.getOutput(), finalOutputShapeAttr);
+    return success();
+  }
+};
+
+struct TTIRConv2DToMatmulPass
+    : public impl::TTIRConv2DToMatmulPassBase<TTIRConv2DToMatmulPass> {
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    MLIRContext *context = module.getContext();
+
+    RewritePatternSet patterns(context);
+    patterns.add<Conv2DToMatmulPattern>(context);
+
+    if (failed(applyPatternsGreedily(module, std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+
+} // namespace
+
+} // namespace ttir
+} // namespace tt
+} // namespace mlir

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -39,6 +39,11 @@ void createTTNNPipelineTTIRPasses(
     pm.addPass(mlir::tt::ttir::createTTIRFusing());
   }
   pm.addPass(mlir::tt::createTTIRToTTIRDecompositionPass());
+
+  if (options.conv2dToMatmulEnabled) {
+    pm.addPass(mlir::tt::ttir::createTTIRConv2DToMatmulPass());
+  }
+
   pm.addPass(mlir::createCanonicalizerPass());
 
   // Inlines all private functions. I.e flattens the program into the main

--- a/test/ttmlir/Dialect/TTIR/Decomposition/convolution_to_matmul.mlir
+++ b/test/ttmlir/Dialect/TTIR/Decomposition/convolution_to_matmul.mlir
@@ -1,0 +1,31 @@
+// RUN: ttmlir-opt --ttir-conv2d-to-matmul %s | FileCheck %s
+
+module {
+  func.func @test_conv_1x1_to_matmul(%arg0: tensor<1x512x7x7xf32>, %arg1: tensor<2048x512x1x1xf32>) -> tensor<1x2048x7x7xf32> {
+    // CHECK-LABEL: func.func @test_conv_1x1_to_matmul
+    // CHECK: %[[EMPTY0:[0-9]+]] = ttir.empty() : tensor<1x2048x7x7xf32>
+    // CHECK: %[[EMPTY1:[0-9]+]] = ttir.empty() : tensor<1x7x7x512xf32>
+    // CHECK: %[[PERM0:[0-9]+]] = "ttir.permute"(%arg0, %[[EMPTY1]]) <{permutation = array<i64: 0, 2, 3, 1>}>
+    // CHECK: %[[EMPTY2:[0-9]+]] = ttir.empty() : tensor<1x7x7x2048xf32>
+    // CHECK: %[[EMPTY3:[0-9]+]] = ttir.empty() : tensor<49x512xf32>
+    // CHECK: %[[RESHAPE0:[0-9]+]] = "ttir.reshape"(%[[PERM0]], %[[EMPTY3]]) <{shape = [49 : i32, 512 : i32]}>
+    // CHECK: %[[EMPTY4:[0-9]+]] = ttir.empty() : tensor<512x2048x1x1xf32>
+    // CHECK: %[[PERM1:[0-9]+]] = "ttir.permute"(%arg1, %[[EMPTY4]]) <{permutation = array<i64: 1, 0, 2, 3>}>
+    // CHECK: %[[EMPTY5:[0-9]+]] = ttir.empty() : tensor<512x2048xf32>
+    // CHECK: %[[RESHAPE1:[0-9]+]] = "ttir.reshape"(%[[PERM1]], %[[EMPTY5]]) <{shape = [512 : i32, 2048 : i32]}>
+    // CHECK: %[[EMPTY6:[0-9]+]] = ttir.empty() : tensor<49x2048xf32>
+    // CHECK: %[[MATMUL:[0-9]+]] = "ttir.matmul"(%[[RESHAPE0]], %[[RESHAPE1]], %[[EMPTY6]]) <{transpose_a = false, transpose_b = false}>
+    // CHECK: %[[RESHAPE2:[0-9]+]] = "ttir.reshape"(%[[MATMUL]], %[[EMPTY2]]) <{shape = [1 : i32, 7 : i32, 7 : i32, 2048 : i32]}>
+    // CHECK: %[[RESULT:[0-9]+]] = "ttir.permute"(%[[RESHAPE2]], %[[EMPTY0]]) <{permutation = array<i64: 0, 3, 1, 2>}>
+    // CHECK: return %[[RESULT]]
+    %0 = ttir.empty() : tensor<1x2048x7x7xf32>
+    %1 = ttir.empty() : tensor<1x7x7x512xf32>
+    %2 = "ttir.permute"(%arg0, %1) <{permutation = array<i64: 0, 2, 3, 1>}> : (tensor<1x512x7x7xf32>, tensor<1x7x7x512xf32>) -> tensor<1x7x7x512xf32>
+    %3 = ttir.empty() : tensor<2048x512x1x1xf32>
+    %4 = "ttir.permute"(%arg1, %3) <{permutation = array<i64: 0, 1, 2, 3>}> : (tensor<2048x512x1x1xf32>, tensor<2048x512x1x1xf32>) -> tensor<2048x512x1x1xf32>
+    %5 = ttir.empty() : tensor<1x7x7x2048xf32>
+    %6 = "ttir.conv2d"(%2, %4, %5) <{dilation = array<i32: 1, 1>, groups = 1 : i32, padding = array<i32: 0, 0, 0, 0>, stride = array<i32: 1, 1>}> : (tensor<1x7x7x512xf32>, tensor<2048x512x1x1xf32>, tensor<1x7x7x2048xf32>) -> tensor<1x7x7x2048xf32>
+    %7 = "ttir.permute"(%6, %0) <{permutation = array<i64: 0, 3, 1, 2>}> : (tensor<1x7x7x2048xf32>, tensor<1x2048x7x7xf32>) -> tensor<1x2048x7x7xf32>
+    return %7 : tensor<1x2048x7x7xf32>
+  }
+}


### PR DESCRIPTION
### Problem description
A 1x1 convolution with stride of 1 and padding of 0 can be simplified to a matmul. 

### What's changed
An optional pass has been added immediately after the TTIRToTTIR decomposition that checks that convolutions are 1x1 : The kernel size must be 1x1, the stride must be 1 and the padding must be 0. If so, the NCHW input is reshaped to [N*H*W, C] and the OIHW weight vector is permuted to [I, O, H, W] and reshaped to [I*O*H, W]. The convolution is replaced with a matmul of [N*H*W, C] and [I*O*H, W] with output [N*H*W, W]. Finally the output is reshaped to the original output tensor of [N, H, W, C].