### PR TITLE
Add more testcases with shapes not a multiple of tilesize

### DIFF
--- a/test/python/golden/test_ttir_ops_llmbox.py
+++ b/test/python/golden/test_ttir_ops_llmbox.py
@@ -18,7 +18,27 @@ def pseudo_golden_all_gather(
     return output_tensor
 
 
-@pytest.mark.parametrize("shape", [(1, 1, 256, 512)])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1, 32, 256, 512),
+        (1, 1, 64, 128),
+        (1, 1, 66, 128),
+        (1, 1, 62, 128),
+        pytest.param(
+            (1, 1, 64, 132), marks=pytest.mark.fails_golden
+        ),  # https://github.com/tenstorrent/tt-metal/issues/21964
+        pytest.param((1, 1, 66, 132), marks=pytest.mark.fails_golden),
+        pytest.param((1, 1, 64, 124), marks=pytest.mark.fails_golden),
+        pytest.param((1, 1, 62, 124), marks=pytest.mark.fails_golden),
+        pytest.param((1, 32, 258, 516), marks=pytest.mark.fails_golden),
+        pytest.param((1, 32, 260, 520), marks=pytest.mark.fails_golden),
+        pytest.param((1, 32, 254, 508), marks=pytest.mark.fails_golden),
+        pytest.param((1, 32, 252, 504), marks=pytest.mark.fails_golden),
+        pytest.param((1, 32, 32, 64), marks=pytest.mark.fails_golden),
+        pytest.param((1, 1, 2, 4), marks=pytest.mark.fails_golden),
+    ],
+)
 @pytest.mark.parametrize("mesh_shape", [(2, 4)])
 def test_all_gather(shape: Shape, mesh_shape: Tuple[int, int], request):
     def all_gather(in0: Operand, builder: TTIRBuilder):
@@ -56,7 +76,22 @@ def pseudo_golden_all_reduce(input_tensor: torch.Tensor):
     return sum(shards)
 
 
-@pytest.mark.parametrize("shape", [(1, 1, 256, 512)])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1, 1, 256, 512),
+        (1, 1, 2, 4),
+        pytest.param(
+            (1, 1, 64, 128), marks=pytest.mark.run_error
+        ),  # https://github.com/tenstorrent/tt-metal/issues/21987
+        pytest.param((1, 1, 64, 256), marks=pytest.mark.run_error),
+        pytest.param((1, 1, 128, 256), marks=pytest.mark.run_error),
+        pytest.param((1, 1, 256, 256), marks=pytest.mark.run_error),
+        pytest.param(
+            (1, 1, 128, 512), marks=pytest.mark.run_error
+        ),  # hangs # https://github.com/tenstorrent/tt-metal/issues/21987
+    ],
+)
 @pytest.mark.parametrize("mesh_shape", [(2, 4)])
 def test_all_reduce(shape: Shape, mesh_shape: Tuple[int, int], request):
     def all_reduce(in0: Operand, builder: TTIRBuilder):
@@ -97,7 +132,32 @@ def pseudo_golden_reduce_scatter(
     return sum(shards)
 
 
-@pytest.mark.parametrize("shape", [(1, 1, 8192, 512)])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1, 1, 512, 512),
+        (1, 1, 256, 1024),
+        (1, 1, 256, 512),
+        (1, 1, 254, 1024),
+        (1, 1, 256, 1024),
+        (1, 1, 128, 1024),
+        pytest.param(
+            (1, 1, 256, 1008), marks=pytest.mark.run_error
+        ),  # https://github.com/tenstorrent/tt-metal/issues/21987
+        pytest.param((1, 1, 256, 1040), marks=pytest.mark.run_error),
+        pytest.param((1, 1, 128, 256), marks=pytest.mark.run_error),
+        pytest.param((1, 1, 128, 128), marks=pytest.mark.run_error),
+        pytest.param((1, 1, 128, 64), marks=pytest.mark.run_error),
+        pytest.param((1, 1, 64, 64), marks=pytest.mark.run_error),
+        pytest.param((1, 1, 64, 128), marks=pytest.mark.run_error),
+        pytest.param((1, 1, 2, 16), marks=pytest.mark.run_error),
+        pytest.param(
+            (1, 1, 128, 512), marks=pytest.mark.run_error
+        ),  # hangs # https://github.com/tenstorrent/tt-metal/issues/21987
+        pytest.param((1, 1, 64, 512), marks=pytest.mark.run_error),  # hangs
+        pytest.param((1, 1, 32, 512), marks=pytest.mark.run_error),  # hangs
+    ],
+)
 @pytest.mark.parametrize("mesh_shape", [(2, 4)])
 def test_reduce_scatter(shape: Shape, mesh_shape: Tuple[int, int], request):
     def reduce_scatter(in0: Operand, builder: TTIRBuilder):
@@ -157,7 +217,22 @@ def pseudo_golden_collective_permute(
     )
 
 
-@pytest.mark.parametrize("shape", [(1, 1, 256, 4096)])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1, 1, 256, 4096),
+        (1, 1, 258, 4096),
+        (1, 1, 260, 4096),
+        (1, 1, 254, 4096),
+        (1, 1, 252, 4096),
+        (1, 1, 256, 4100),
+        (1, 1, 256, 4104),
+        (1, 1, 256, 4092),
+        (1, 1, 256, 4088),
+        (1, 1, 30, 32),
+        (1, 1, 2, 4),
+    ],
+)
 @pytest.mark.parametrize("mesh_shape", [(2, 4)])
 def test_collective_permute(shape: Shape, mesh_shape: Tuple[int, int], request):
     def collective_permute(in0: Operand, builder: TTIRBuilder):
@@ -194,7 +269,34 @@ def test_collective_permute(shape: Shape, mesh_shape: Tuple[int, int], request):
 
 
 # TODO: many of these tests can be combined with some logic around `mesh_shape`
-@pytest.mark.parametrize("shapes", [[(8192, 784), (784, 16384)]])
+@pytest.mark.parametrize(
+    "shapes",
+    [
+        [(8192, 784), (784, 16384)],
+        [(1024, 32), (32, 512)],
+        [(512, 32), (32, 128)],
+        [(1024, 16), (16, 512)],
+        [(1024, 8), (8, 512)],
+        [(1024, 8), (8, 512)],
+        [(256, 128), (128, 128)],
+        [(256, 128), (128, 124)],
+        [(256, 128), (128, 120)],
+        [(256, 130), (130, 128)],
+        [(254, 128), (128, 128)],
+        [(252, 128), (128, 128)],
+        pytest.param(
+            [(258, 128), (128, 128)], marks=pytest.mark.fails_golden
+        ),  # https://github.com/tenstorrent/tt-metal/issues/21964
+        pytest.param([(260, 128), (128, 128)], marks=pytest.mark.fails_golden),
+        pytest.param(
+            [(256, 128), (128, 132)], marks=pytest.mark.run_error
+        ),  # https://github.com/tenstorrent/tt-metal/issues/21987
+        pytest.param([(256, 128), (128, 136)], marks=pytest.mark.run_error),
+        pytest.param([(256, 32), (32, 64)], marks=pytest.mark.run_error),
+        pytest.param([(128, 32), (32, 32)], marks=pytest.mark.run_error),
+        pytest.param([(64, 32), (32, 16)], marks=pytest.mark.run_error),
+    ],
+)
 @pytest.mark.parametrize("mesh_shape", [(2, 4)])
 def test_matmul_2x4(shapes: List[Shape], mesh_shape: Tuple[int, int], request):
     def matmul_2x4(in0: Operand, in1: Operand, builder: TTIRBuilder):
@@ -239,7 +341,32 @@ def test_matmul_2x4(shapes: List[Shape], mesh_shape: Tuple[int, int], request):
     )
 
 
-@pytest.mark.parametrize("shapes", [[(8192, 784), (784, 16384)]])
+@pytest.mark.parametrize(
+    "shapes",
+    [
+        # [(8192, 784), (784, 16384)],
+        [(1024, 32), (32, 512)],
+        [(1024, 16), (16, 512)],
+        [(1024, 8), (8, 512)],
+        [(256, 128), (128, 124)],
+        pytest.param(
+            [(256, 128), (128, 132)], marks=pytest.mark.run_error
+        ),  # https://github.com/tenstorrent/tt-metal/issues/21987
+        pytest.param([(1024, 8), (8, 512)], marks=pytest.mark.run_error),
+        pytest.param([(512, 32), (32, 128)], marks=pytest.mark.run_error),
+        pytest.param([(256, 128), (128, 128)], marks=pytest.mark.run_error),
+        pytest.param([(256, 128), (128, 120)], marks=pytest.mark.run_error),
+        pytest.param([(256, 130), (130, 128)], marks=pytest.mark.run_error),
+        pytest.param([(254, 128), (128, 128)], marks=pytest.mark.run_error),
+        pytest.param([(252, 128), (128, 128)], marks=pytest.mark.run_error),
+        pytest.param([(258, 128), (128, 128)], marks=pytest.mark.run_error),
+        pytest.param([(260, 128), (128, 128)], marks=pytest.mark.run_error),
+        pytest.param([(256, 128), (128, 136)], marks=pytest.mark.run_error),
+        pytest.param([(256, 32), (32, 64)], marks=pytest.mark.run_error),
+        pytest.param([(128, 32), (32, 32)], marks=pytest.mark.run_error),
+        pytest.param([(64, 32), (32, 16)], marks=pytest.mark.run_error),
+    ],
+)
 @pytest.mark.parametrize("mesh_shape", [(1, 8)])
 def test_matmul_1x8(shapes: List[Shape], mesh_shape: Tuple[int, int], request):
     def matmul_1x8(in0: Operand, in1: Operand, builder: TTIRBuilder):
@@ -284,7 +411,23 @@ def test_matmul_1x8(shapes: List[Shape], mesh_shape: Tuple[int, int], request):
     )
 
 
-@pytest.mark.parametrize("shape", [(1, 256, 64, 256)])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1, 64, 16, 128),
+        (1, 64, 16, 124),
+        (1, 64, 16, 120),
+        (1, 64, 16, 132),
+        (1, 64, 16, 136),
+        (1, 62, 16, 128),
+        (1, 60, 16, 128),
+        (1, 66, 16, 128),
+        (1, 68, 16, 128),
+        (1, 64, 7, 128),
+        (1, 18, 3, 36),
+        (1, 2, 1, 4),
+    ],
+)
 @pytest.mark.parametrize("mesh_shape", [(2, 4)])
 def test_neg_2x4(shape: Shape, mesh_shape: Tuple[int, int], request):
     def neg_2x4(in0: Operand, builder: TTIRBuilder):
@@ -316,7 +459,23 @@ def test_neg_2x4(shape: Shape, mesh_shape: Tuple[int, int], request):
     )
 
 
-@pytest.mark.parametrize("shape", [(1, 256, 64, 256)])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1, 64, 16, 128),
+        (1, 64, 16, 124),
+        (1, 64, 16, 120),
+        (1, 64, 16, 132),
+        (1, 64, 16, 136),
+        (1, 62, 16, 128),
+        (1, 60, 16, 128),
+        (1, 66, 16, 128),
+        (1, 68, 16, 128),
+        (1, 64, 7, 128),
+        (1, 18, 3, 36),
+        (1, 2, 1, 4),
+    ],
+)
 @pytest.mark.parametrize("mesh_shape", [(2, 4)])
 def test_neg_2x4_cluster_0(shape: Shape, mesh_shape: Tuple[int, int], request):
     def neg_2x4_cluster_0(in0: Operand, builder: TTIRBuilder):
@@ -348,7 +507,23 @@ def test_neg_2x4_cluster_0(shape: Shape, mesh_shape: Tuple[int, int], request):
     )
 
 
-@pytest.mark.parametrize("shape", [(1, 256, 64, 256)])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1, 64, 16, 128),
+        (1, 64, 16, 124),
+        (1, 64, 16, 120),
+        (1, 64, 16, 132),
+        (1, 64, 16, 136),
+        (1, 62, 16, 128),
+        (1, 60, 16, 128),
+        (1, 66, 16, 128),
+        (1, 68, 16, 128),
+        (1, 64, 7, 128),
+        (1, 18, 3, 36),
+        (1, 2, 1, 4),
+    ],
+)
 @pytest.mark.parametrize("mesh_shape", [(2, 4)])
 def test_neg_2x4_cluster_1(shape: Shape, mesh_shape: Tuple[int, int], request):
     def neg_2x4_cluster_1(in0: Operand, builder: TTIRBuilder):
@@ -380,7 +555,23 @@ def test_neg_2x4_cluster_1(shape: Shape, mesh_shape: Tuple[int, int], request):
     )
 
 
-@pytest.mark.parametrize("shape", [(1, 256, 64, 256)])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1, 128, 16, 64),
+        (1, 124, 16, 64),
+        (1, 120, 16, 64),
+        (1, 132, 16, 64),
+        (1, 136, 16, 64),
+        (1, 128, 16, 62),
+        (1, 128, 16, 60),
+        (1, 128, 16, 66),
+        (1, 128, 16, 68),
+        (1, 128, 7, 64),
+        (1, 36, 3, 18),
+        (1, 4, 1, 2),
+    ],
+)
 @pytest.mark.parametrize("mesh_shape", [(2, 4)])
 def test_neg_2x4_reversed_cluster(shape: Shape, mesh_shape: Tuple[int, int], request):
     def neg_2x4_reversed_cluster(in0: Operand, builder: TTIRBuilder):
@@ -412,7 +603,23 @@ def test_neg_2x4_reversed_cluster(shape: Shape, mesh_shape: Tuple[int, int], req
     )
 
 
-@pytest.mark.parametrize("shape", [(1, 256, 64, 256)])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1, 128, 16, 64),
+        (1, 124, 16, 64),
+        (1, 120, 16, 64),
+        (1, 132, 16, 64),
+        (1, 136, 16, 64),
+        (1, 128, 16, 62),
+        (1, 128, 16, 60),
+        (1, 128, 16, 66),
+        (1, 128, 16, 68),
+        (1, 128, 7, 64),
+        (1, 36, 3, 18),
+        (1, 4, 1, 2),
+    ],
+)
 @pytest.mark.parametrize("mesh_shape", [(2, 4)])
 def test_neg_2x4_reversed_cluster_0(shape: Shape, mesh_shape: Tuple[int, int], request):
     def neg_2x4_reversed_cluster_0(in0: Operand, builder: TTIRBuilder):
@@ -444,7 +651,24 @@ def test_neg_2x4_reversed_cluster_0(shape: Shape, mesh_shape: Tuple[int, int], r
     )
 
 
-@pytest.mark.parametrize("shape", [(1, 256, 64, 256)])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1, 128, 16, 64),
+        (1, 16, 16, 64),
+        (1, 15, 16, 64),
+        (1, 7, 16, 64),
+        (1, 16, 16, 136),
+        (1, 16, 16, 128),
+        (1, 16, 16, 40),
+        (1, 16, 7, 64),
+        (1, 7, 7, 64),
+        (1, 10, 3, 64),
+        (1, 1, 1, 64),
+        (1, 1, 1, 24),
+        (1, 1, 1, 8),
+    ],
+)
 @pytest.mark.parametrize("mesh_shape", [(1, 8)])
 def test_neg_1x8_dim_3(shape: Shape, mesh_shape: Tuple[int, int], request):
     def neg_1x8_dim_3(in0: Operand, builder: TTIRBuilder):
@@ -476,7 +700,24 @@ def test_neg_1x8_dim_3(shape: Shape, mesh_shape: Tuple[int, int], request):
     )
 
 
-@pytest.mark.parametrize("shape", [(1, 256, 64, 256)])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1, 64, 16, 128),
+        (1, 64, 16, 16),
+        (1, 64, 16, 15),
+        (1, 64, 16, 7),
+        (1, 136, 16, 16),
+        (1, 128, 16, 16),
+        (1, 40, 16, 16),
+        (1, 64, 7, 16),
+        (1, 64, 7, 7),
+        (1, 64, 3, 10),
+        (1, 64, 1, 1),
+        (1, 24, 1, 1),
+        (1, 8, 1, 1),
+    ],
+)
 @pytest.mark.parametrize("mesh_shape", [(1, 8)])
 def test_neg_1x8_dim_1(shape: Shape, mesh_shape: Tuple[int, int], request):
     def neg_1x8_dim_1(in0: Operand, builder: TTIRBuilder):
@@ -508,7 +749,24 @@ def test_neg_1x8_dim_1(shape: Shape, mesh_shape: Tuple[int, int], request):
     )
 
 
-@pytest.mark.parametrize("shapes", [[(512, 1024), (512, 1024)]])
+@pytest.mark.parametrize(
+    "shapes",
+    [
+        [(512, 1024), (512, 1024)],
+        [(64, 128), (64, 128)],
+        [(62, 128), (62, 128)],
+        [(60, 128), (60, 128)],
+        [(66, 128), (66, 128)],
+        [(68, 128), (68, 128)],
+        [(64, 124), (64, 124)],
+        [(64, 120), (64, 120)],
+        [(64, 132), (64, 132)],
+        [(64, 136), (64, 136)],
+        [(14, 44), (14, 44)],
+        [(6, 12), (6, 12)],
+        [(2, 4), (2, 4)],
+    ],
+)
 @pytest.mark.parametrize("mesh_shape", [(2, 4)])
 def test_eltwise_multidevice(shapes: List[Shape], mesh_shape: Tuple[int, int], request):
     def eltwise_multidevice(in0: Operand, in1: Operand, builder: TTIRBuilder):

--- a/test/python/golden/test_ttir_ops_n300.py
+++ b/test/python/golden/test_ttir_ops_n300.py
@@ -69,7 +69,12 @@ def test_all_gather(shape: Shape, mesh_shape: Tuple[int, int], request):
         )
 
     compile_to_flatbuffer(
-        all_gather, [shape], mesh_shape=mesh_shape, test_base=request.node.name
+        all_gather,
+        [shape],
+        mesh_shape=mesh_shape,
+        test_base=request.node.name,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
     )
 
 
@@ -135,6 +140,8 @@ def test_all_reduce(shape: Shape, mesh_shape: Tuple[int, int], request):
         mesh_shape=mesh_shape,
         test_base=request.node.name,
         module_dump=True,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
     )
 
 
@@ -201,7 +208,12 @@ def test_reduce_scatter(shape: Shape, mesh_shape: Tuple[int, int], request):
         )
 
     compile_to_flatbuffer(
-        reduce_scatter, [shape], mesh_shape=mesh_shape, test_base=request.node.name
+        reduce_scatter,
+        [shape],
+        mesh_shape=mesh_shape,
+        test_base=request.node.name,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
     )
 
 
@@ -255,7 +267,12 @@ def test_collective_permute(shape: Shape, mesh_shape: Tuple[int, int], request):
         )
 
     compile_to_flatbuffer(
-        collective_permute, [shape], mesh_shape=mesh_shape, test_base=request.node.name
+        collective_permute,
+        [shape],
+        mesh_shape=mesh_shape,
+        test_base=request.node.name,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
     )
 
 
@@ -310,7 +327,12 @@ def test_matmul_1x2(shapes: List[Shape], mesh_shape: Tuple[int, int], request):
         )
 
     compile_to_flatbuffer(
-        matmul_1x2, shapes, mesh_shape=mesh_shape, test_base=request.node.name
+        matmul_1x2,
+        shapes,
+        mesh_shape=mesh_shape,
+        test_base=request.node.name,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
     )
 
 
@@ -364,6 +386,8 @@ def test_neg_1x2_dim_3(shape: Shape, mesh_shape: Tuple[int, int], request):
         [shape],
         mesh_shape=mesh_shape,
         test_base=request.node.name,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
     )
 
 
@@ -417,6 +441,8 @@ def test_neg_1x2_dim_1(shape: Shape, mesh_shape: Tuple[int, int], request):
         [shape],
         mesh_shape=mesh_shape,
         test_base=request.node.name,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
     )
 
 
@@ -469,5 +495,10 @@ def test_eltwise_multidevice(shapes: List[Shape], mesh_shape: Tuple[int, int], r
         )
 
     compile_to_flatbuffer(
-        eltwise_multidevice, shapes, mesh_shape=mesh_shape, test_base=request.node.name
+        eltwise_multidevice,
+        shapes,
+        mesh_shape=mesh_shape,
+        test_base=request.node.name,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
     )


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/3410
closes #3410

### Problem description
The recent uplift brought in a tt-metal commit that fixes an execution issue with shapes whose dimensions are not multiples of the tile size.
To validate this fix, we added TTIR-builder test cases and run them in CI to ensure the improvement is preserved going forward.

### What's changed
 - Added new TTIR-builder tests for n300 and llmbox.
 - Marked several tests as run_error or fails_golden because of additional issues that still need to be addressed (see #3410).

### Checklist
- [x] New/Existing tests provide coverage for changes
