### PR TITLE
Add manually sharded llama block builder test for n300

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -171,8 +171,8 @@ jobs:
           {runs-on: n150,   sh-run: false, name: "run",  suite: "model_golden",      image: "tracy",  type: "builder",  path: "test/python/golden/test_ttir_models.py", flags: "-m \"not run_error and not fails_golden\"", run-ttrt: true},
           {runs-on: n150,   sh-run: false, name: "run",  suite: "op_compile",        image: "tracy",  type: "builder",  path: "test/python/golden/test_ttir_ops.py", flags: "-m \"run_error or fails_golden\"", run-ttrt: false},
           {runs-on: n150,   sh-run: false, name: "run",  suite: "model_compile",     image: "tracy",  type: "builder",  path: "test/python/golden/test_ttir_models.py", flags: "-m \"run_error or fails_golden\"", run-ttrt: false},
-          {runs-on: n300,   sh-run: false, name: "run",  suite: "op_golden",         image: "tracy",  type: "builder",  path: "test/python/golden/test_ttir_ops_n300.py", flags: "-m \"not run_error and not fails_golden\"", run-ttrt: true},
-          {runs-on: n300-llmbox, sh-run: true,  name: "run",  suite: "op_golden",         image: "tracy",  type: "builder",  path: "test/python/golden/test_ttir_ops_llmbox.py", flags: "-m \"not run_error and not fails_golden\"", run-ttrt: true},
+          {runs-on: n300,   sh-run: false, name: "run",  suite: "golden",            image: "tracy",  type: "builder",  path: "test/python/golden", flags: "-m \"not run_error and not fails_golden and n300\"", run-ttrt: true},
+          {runs-on: n300-llmbox, sh-run: true,  name: "run",  suite: "golden",       image: "tracy",  type: "builder",  path: "test/python/golden/test_ttir_ops_llmbox.py", flags: "-m \"not run_error and not fails_golden and llmbox\"", run-ttrt: true},
           # Although these runtime tests are device agnostic, they depend on n150 compiled mlir artifacts
           # Therefore running these tests on n150 specifically
           {runs-on: n150,   sh-run: true,  name: "run",  suite: "ttnn_runtime",      image: "speedy", type: "pytest",  path: "runtime/test/python/ttnn/device_agnostic"},

--- a/test/python/golden/test_ttir_llama_1x2_tp.py
+++ b/test/python/golden/test_ttir_llama_1x2_tp.py
@@ -1,0 +1,464 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+
+from typing import List, Tuple
+from ttir_builder.utils import compile_to_flatbuffer
+from ttir_builder import Operand, TTIRBuilder, Shape
+
+pytestmark = pytest.mark.n300
+
+
+# utility functions to increase readability
+def get_input_tensors_from_builder(args: List, builder: TTIRBuilder):
+    input_tensors = []
+    for arg in args:
+        input_tensors.append(builder._get_golden_tensor(arg))
+    return input_tensors
+
+
+def full_to_shard_device(input, builder, dim):
+    rank = len(builder._get_golden_tensor(input).shape)
+    shard_shape = [1] * rank
+    shard_shape[dim] = 2
+    return builder.mesh_shard(
+        input,
+        shard_direction="#tt.shard_direction<full_to_shard>",
+        shard_type="#tt.shard_type<devices>",
+        shard_shape=shard_shape,
+        shard_dims=[-1, dim],
+    )
+
+
+def full_to_shard_replicate(input, builder):
+    return builder.mesh_shard(
+        input,
+        shard_direction="#tt.shard_direction<full_to_shard>",
+        shard_type="#tt.shard_type<replicate>",
+        shard_shape=[1],
+        shard_dims=[-1],
+    )
+
+
+def shard_to_full_device(input, builder, dim):
+    rank = len(builder._get_golden_tensor(input).shape)
+    shard_shape = [1] * rank
+    shard_shape[dim] = 2
+    return builder.mesh_shard(
+        input,
+        shard_direction="#tt.shard_direction<shard_to_full>",
+        shard_type="#tt.shard_type<devices>",
+        shard_shape=shard_shape,
+        shard_dims=[-1, dim],
+    )
+
+
+def shard_to_full_replicate(input, builder):
+    return builder.mesh_shard(
+        input,
+        shard_direction="#tt.shard_direction<shard_to_full>",
+        shard_type="#tt.shard_type<replicate>",
+        shard_shape=[1],
+        shard_dims=[-1],
+    )
+
+
+# On a 1×2 mesh the full Llama‑attention test loses PCC near the op that
+# makes `output83`. The error seems to grow as tensors move through the
+# model and may come from a backend precision issue.
+# Refer to : https://github.com/tenstorrent/tt-metal/issues/21722
+# We split the test into Part1 and Part2 and give Part2 a new input
+# tensor; now each part matches the golden result.
+def golden_part1(
+    arg0: torch.Tensor,
+    arg2: torch.Tensor,
+    arg3: torch.Tensor,
+    arg4: torch.Tensor,
+    arg5: torch.Tensor,
+    arg6: torch.Tensor,
+    arg7: torch.Tensor,
+    arg8: torch.Tensor,
+    arg9: torch.Tensor,
+    arg11: torch.Tensor,
+    arg12: torch.Tensor,
+):
+    output1 = torch.squeeze(arg0, dim=0)
+    output3 = torch.matmul(output1, arg11)
+    output5 = torch.reshape(output3, shape=(1, 128, 32, 128))
+    output7 = torch.transpose(output5, dim0=-3, dim1=-2)
+    output9 = torch.unsqueeze(arg2, dim=1)
+    output11 = torch.matmul(arg3, output9)  # [1, 64, 128]
+    output13 = torch.transpose(output11, dim0=-2, dim1=-1)  # [1, 128, 64]
+    output15 = torch.concat((output13, output13), dim=-1)  # [1, 128, 128]
+    output17 = torch.cos(output15)  # [1, 128, 128]
+    output19 = torch.unsqueeze(output17, dim=1)  # [1, 1, 128, 128]
+    output21 = torch.multiply(output7, output19)  # [1, 32, 128, 128]
+    output23 = torch.transpose(output7, dim0=-2, dim1=-1)  # [1, 32, 128, 128]
+    output25 = torch.matmul(arg4, output23)  # [1, 32, 64, 128]
+    output27 = torch.transpose(output25, dim0=-2, dim1=-1)  # [1, 32, 128, 64]
+    output29 = torch.multiply(output27, arg5)  # [1, 32, 128, 64]
+    output31 = torch.transpose(output7, dim0=-2, dim1=-1)  # [1, 32, 128, 128]
+    output33 = torch.matmul(arg6, output31)  # [1, 32, 64, 128]
+    output35 = torch.transpose(output33, dim0=-2, dim1=-1)  # [1, 32, 128, 64]
+    output37 = torch.concat((output29, output35), dim=-1)  # [1, 32, 128, 128]
+    output39 = torch.sin(output15)  # [1, 128, 128]
+    output41 = torch.unsqueeze(output39, dim=1)  # [1, 1, 128, 128]
+    output43 = torch.multiply(output37, output41)  # [1, 32, 128, 128]
+    output45 = torch.add(output21, output43)  # [1, 32, 128, 128]
+    output47 = torch.squeeze(output45, dim=0)  # [32, 128, 128]
+
+    output49 = torch.matmul(output1, arg12)  # [128, 4096]
+    output51 = torch.reshape(output49, shape=(1, 128, 32, 128))  # [1, 128, 32, 128]
+    output53 = torch.transpose(output51, dim0=-3, dim1=-2)  # [1, 32, 128, 128]
+    output55 = torch.multiply(output53, output19)  # [1, 32, 128, 128]
+    output57 = torch.transpose(output53, dim0=-2, dim1=-1)  # [1, 32, 128, 128]
+    output59 = torch.matmul(arg7, output57)  # [1, 32, 64, 128]
+    output61 = torch.transpose(output59, dim0=-2, dim1=-1)  # [1, 32, 128, 64]
+    output63 = torch.multiply(output61, arg8)  # [1, 32, 128, 64]
+    output65 = torch.transpose(output53, dim0=-2, dim1=-1)  # [1, 32, 128, 128]
+    output67 = torch.matmul(arg9, output65)  # [1, 32, 64, 128]
+    output69 = torch.transpose(output67, dim0=-2, dim1=-1)  # [1, 32, 128, 64]
+    output71 = torch.concat([output63, output69], -1)  # [1, 32, 128, 128]
+    output73 = torch.multiply(output71, output41)  # [1, 32, 128, 128]
+    output75 = torch.add(output55, output73)  # [1, 32, 128, 128]
+    output77 = torch.squeeze(output75, dim=0)  # [32, 128, 128]
+
+    output79 = torch.transpose(output77, dim0=-2, dim1=-1)  # [32, 128, 128]
+    output81 = torch.matmul(output47, output79)  # [32, 128, 128]
+    output83 = torch.unsqueeze(output81, dim=0)  # [1, 32, 128, 128]
+    return output83
+
+
+def golden_part2(
+    arg0: torch.Tensor,
+    arg1: torch.Tensor,
+    arg10: torch.Tensor,
+    arg13: torch.Tensor,
+    arg14: torch.Tensor,
+    output83: torch.Tensor,
+):
+    output1 = torch.squeeze(arg0, dim=0)
+    output85 = torch.multiply(output83, arg10)  # [1, 32, 128, 128]
+    output87 = torch.add(output85, arg1)  # [1, 32, 128, 128]
+    output89 = torch.softmax(output87, dim=-1)  # [1, 32, 128, 128]
+    output91 = torch.squeeze(output89, dim=0)  # [32, 128, 128]
+    output93 = torch.matmul(output1, arg13)  # [128, 4096]
+    output95 = torch.reshape(output93, shape=(1, 128, 32, 128))  # [1, 128, 32, 128]
+    output97 = torch.transpose(output95, dim0=-3, dim1=-2)  # [1, 32, 128, 128]
+    output99 = torch.transpose(output97, dim0=-2, dim1=-1)  # [1, 32, 128, 128]
+    output101 = torch.squeeze(output99, dim=0)  # [32, 128, 128]
+    output103 = torch.transpose(output101, dim0=-2, dim1=-1)  # [32, 128, 128]
+    output105 = torch.matmul(output91, output103)  # [32, 128, 128]
+    output107 = torch.unsqueeze(output105, dim=0)  # [1, 32, 128, 128]
+    output109 = torch.transpose(output107, dim0=-3, dim1=-2)  # [1, 128, 32, 128]
+    output111 = torch.reshape(output109, shape=(128, 4096))  # [128, 4096]
+    output113 = torch.matmul(output111, arg14)  # [128, 4096]
+    output115 = torch.unsqueeze(output113, dim=0)  # [1, 128, 4096]
+    return output115
+
+
+# llama attention part 1 with 1x2
+@pytest.mark.parametrize(
+    "shapes",
+    [
+        [
+            (1, 128, 4096),  # arg0
+            (1, 128),  # arg2
+            (1, 64, 1),  # arg3
+            (1, 32, 64, 128),  # arg4
+            (1, 1),  # arg5
+            (1, 32, 64, 128),  # arg6
+            (1, 32, 64, 128),  # arg7
+            (1, 1),  # arg8
+            (1, 32, 64, 128),  # arg9
+            (4096, 4096),  # arg11
+            (4096, 4096),  # arg12
+        ],
+    ],
+)
+@pytest.mark.parametrize("dtypes", [[torch.float32] * 11], ids=["f32"])
+@pytest.mark.parametrize(
+    "target",
+    [
+        "ttnn",
+        pytest.param("ttmetal", marks=pytest.mark.skip("TTMetal not supported yet")),
+    ],
+)
+@pytest.mark.parametrize("mesh_shape", [(1, 2)])
+def test_llama_attention_1x2_tp_part1(
+    shapes: List[Shape],
+    dtypes: List[torch.dtype],
+    target: str,
+    mesh_shape: Tuple[int, int],
+    request,
+):
+    def model_part1(
+        arg0: Operand,
+        arg2: Operand,
+        arg3: Operand,
+        arg4: Operand,
+        arg5: Operand,
+        arg6: Operand,
+        arg7: Operand,
+        arg8: Operand,
+        arg9: Operand,
+        arg11: Operand,
+        arg12: Operand,
+        builder: TTIRBuilder,
+    ):
+        input_tensors = get_input_tensors_from_builder(
+            [
+                arg0,
+                arg2,
+                arg3,
+                arg4,
+                arg5,
+                arg6,
+                arg7,
+                arg8,
+                arg9,
+                arg11,
+                arg12,
+            ],
+            builder,
+        )
+        output1 = full_to_shard_device(arg0, builder, 2)  # [1, 128, 2048]
+        output1 = builder.squeeze(output1, 0)  # [128, 2048]
+        arg11 = full_to_shard_device(arg11, builder, 0)  # [2048, 4096]
+        output3 = builder.matmul(output1, arg11)  # [128, 4096]
+        output3 = builder.all_reduce(
+            output3, reduce_type="#tt.reduce_type<sum>", cluster_axis=1
+        )  # [128, 4096]
+        output5 = builder.reshape(output3, (1, 128, 32, 128))  # [1, 128, 32, 128]
+        output7 = builder.transpose(output5, -3, -2)  # [1, 32, 128, 128]
+        output7 = shard_to_full_replicate(output7, builder)  # [1, 32, 128, 128]
+        output7 = full_to_shard_device(output7, builder, 3)  # [1, 32, 128, 64]
+        output9 = full_to_shard_device(arg2, builder, 1)  # [1, 64]
+        output9 = builder.unsqueeze(output9, 1)  # [1, 1, 64]
+        arg3 = full_to_shard_replicate(arg3, builder)  # [1, 64, 1]
+        output11 = builder.matmul(arg3, output9)  # [1, 64, 64]
+        output11 = builder.all_gather(
+            output11,
+            all_gather_dim=2,
+            cluster_axis=1,
+        )  # [1, 64, 128]
+        output13 = builder.transpose(output11, -2, -1)  # [1, 128, 64]
+        # output15 = builder.concat([output13, output13], -1)
+        # Concatenating output13 with itself along dim ‑1 would still give each device
+        # the same data, because output13 was already all‑gathered. After sharding,
+        # the concat changes nothing, so we skip it and just keep the variable name
+        # to match the numbering in the golden function.
+        output15 = output13
+        output17 = builder.cos(output15)  # [1, 128, 64]
+        output19 = builder.unsqueeze(output17, 1)  # [1, 1, 128, 64]
+        output21 = builder.multiply(output7, output19)  # [1, 32, 128, 64]
+        output23 = builder.transpose(output7, -2, -1)  # [1, 32, 64, 128]
+        arg4 = full_to_shard_device(arg4, builder, 3)  # [1, 32, 64, 64]
+        output25 = builder.matmul(arg4, output23)  # [1, 32, 64, 128]
+        output25 = builder.reduce_scatter(
+            output25, reduce_type="#tt.reduce_type<sum>", scatter_dim=3, cluster_axis=1
+        )  # [1, 32, 64, 64]
+        output27 = builder.transpose(output25, -2, -1)  # [1, 32, 64, 64]
+        arg5 = full_to_shard_replicate(arg5, builder)  # [1, 1]
+        output29 = builder.multiply(output27, arg5)  # [1, 32, 64, 64]
+        output31 = builder.transpose(output7, -2, -1)  # [1, 32, 64, 128]
+        arg6 = full_to_shard_device(arg6, builder, 3)  # [1, 32, 64, 64]
+        output33 = builder.matmul(arg6, output31)  # [1, 32, 64, 128]
+        output33 = builder.reduce_scatter(
+            output33, reduce_type="#tt.reduce_type<sum>", scatter_dim=3, cluster_axis=1
+        )  # [1, 32, 64, 64]
+        output35 = builder.transpose(output33, -2, -1)  # [1, 32, 64, 64]
+        output35 = builder.all_gather(
+            output35, all_gather_dim=2, cluster_axis=1
+        )  # [1, 32, 128, 64]
+        output29 = builder.all_gather(
+            output29, all_gather_dim=2, cluster_axis=1
+        )  # [1, 32, 128, 64]
+        output37 = builder.concat([output29, output35], -1)  # [1, 32, 128, 128]
+        output37 = shard_to_full_replicate(output37, builder)  # [1, 32, 128, 128]
+        output37 = full_to_shard_device(output37, builder, 3)  # [1, 32, 128, 64]
+        output39 = builder.sin(output15)  # [1, 128, 64]
+        output41 = builder.unsqueeze(output39, 1)  # [1, 1, 128, 64]
+        output43 = builder.multiply(output37, output41)  # [1, 32, 128, 64]
+        output45 = builder.add(output21, output43)  # [1, 32, 128, 64]
+        output47 = builder.squeeze(output45, 0)  # [32, 128, 64]
+        arg12 = full_to_shard_device(arg12, builder, 0)  # [2048, 4096]
+        output49 = builder.matmul(output1, arg12)  # [128, 4096]
+        output49 = builder.all_reduce(
+            output49, reduce_type="#tt.reduce_type<sum>", cluster_axis=1
+        )  # [128, 4096]
+        output51 = builder.reshape(output49, (1, 128, 32, 128))  # [1, 128, 32, 128]
+        output53 = builder.transpose(output51, -3, -2)  # [1, 32, 128, 128]
+        output53 = shard_to_full_replicate(output53, builder)  # [1, 32, 128, 128]
+        output53 = full_to_shard_device(output53, builder, 3)  # [1, 32, 128, 64]
+        output55 = builder.multiply(output53, output19)  # [1, 32, 128, 64]
+        output57 = builder.transpose(output53, -2, -1)  # [1, 32, 64, 128]
+        arg7 = full_to_shard_device(arg7, builder, 3)  # [1, 32, 64, 64]
+        output59 = builder.matmul(arg7, output57)  # [1, 32, 64, 128]
+        output59 = builder.reduce_scatter(
+            output59, reduce_type="#tt.reduce_type<sum>", scatter_dim=3, cluster_axis=1
+        )  # [1, 32, 64, 64]
+        output61 = builder.transpose(output59, -2, -1)  # [1, 32, 64, 64]
+        arg8 = full_to_shard_replicate(arg8, builder)  # [1, 1]
+        output63 = builder.multiply(output61, arg8)  # [1, 32, 64, 64]
+        output65 = builder.transpose(output53, -2, -1)  # [1, 32, 64, 128]
+        arg9 = full_to_shard_device(arg9, builder, 3)  # [1, 32, 64, 64]
+        output67 = builder.matmul(arg9, output65)  # [1, 32, 64, 128]
+        output67 = builder.reduce_scatter(
+            output67, reduce_type="#tt.reduce_type<sum>", scatter_dim=3, cluster_axis=1
+        )  # [1, 32, 64, 64]
+        output69 = builder.transpose(output67, -2, -1)  # [1, 32, 64, 64]
+        output63 = builder.all_gather(
+            output63, all_gather_dim=2, cluster_axis=1
+        )  # [1, 32, 128, 64]
+        output69 = builder.all_gather(
+            output69, all_gather_dim=2, cluster_axis=1
+        )  # [1, 32, 128, 64]
+        output71 = builder.concat([output63, output69], -1)  # [1, 32, 128, 128]
+        output71 = shard_to_full_replicate(output71, builder)  # [1, 32, 128, 128]
+        output71 = full_to_shard_device(output71, builder, 3)  # [1, 32, 128, 64]
+        output73 = builder.multiply(output71, output41)  # [1, 32, 128, 64]
+        output75 = builder.add(output55, output73)  # [1, 32, 128, 64]
+        output77 = builder.squeeze(output75, 0)  # [32, 128, 64]
+        output79 = builder.transpose(output77, -2, -1)  # [32, 64, 128]
+
+        # Use weight sharding to avoid PCC drop
+        output47 = shard_to_full_device(output47, builder, 2)  # [32, 128, 128]
+        output79 = shard_to_full_device(output79, builder, 1)  # [32, 128, 128]
+        output47 = full_to_shard_replicate(output47, builder)  # [32, 128, 128]
+        output79 = full_to_shard_device(output79, builder, 2)  # [32, 128, 64]
+        output81 = builder.matmul(output47, output79)  # [32, 128, 64]
+        output83 = builder.unsqueeze(output81, 0)  # [1, 32, 128, 64]
+        output83 = shard_to_full_device(output83, builder, 3)
+
+        builder.set_graph_input_output(
+            input_tensors,
+            [
+                golden_part1(*input_tensors),
+            ],
+        )
+
+        return output83
+
+    compile_to_flatbuffer(
+        model_part1,
+        shapes,
+        dtypes,
+        target=target,
+        mesh_shape=mesh_shape,
+        test_base=request.node.name,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+    )
+
+
+# llama attention part 2 with 1x2
+@pytest.mark.parametrize(
+    "shapes",
+    [
+        [
+            (1, 128, 4096),  # arg0
+            (1, 1, 128, 128),  # arg1
+            (1, 1),  # arg10
+            (4096, 4096),  # arg13
+            (4096, 4096),  # arg14
+            (1, 32, 128, 128),  # output83
+        ],
+    ],
+)
+@pytest.mark.parametrize("dtypes", [[torch.float32] * 6], ids=["f32"])
+@pytest.mark.parametrize(
+    "target",
+    [
+        "ttnn",
+        pytest.param("ttmetal", marks=pytest.mark.skip("TTMetal not supported yet")),
+    ],
+)
+@pytest.mark.parametrize("mesh_shape", [(1, 2)])
+def test_llama_attention_1x2_tp_part2(
+    shapes: List[Shape],
+    dtypes: List[torch.dtype],
+    target: str,
+    mesh_shape: Tuple[int, int],
+    request,
+):
+    def model_part2(
+        arg0: Operand,
+        arg1: Operand,
+        arg10: Operand,
+        arg13: Operand,
+        arg14: Operand,
+        output83: Operand,
+        builder: TTIRBuilder,
+    ):
+        input_tensors = get_input_tensors_from_builder(
+            [
+                arg0,
+                arg1,
+                arg10,
+                arg13,
+                arg14,
+                output83,
+            ],
+            builder,
+        )
+        output1 = full_to_shard_device(arg0, builder, 2)  # [1, 128, 2048]
+        output1 = builder.squeeze(output1, 0)  # [128, 2048]
+
+        output83 = full_to_shard_device(output83, builder, 3)
+        arg10 = full_to_shard_replicate(arg10, builder)  # [1, 1]
+        output85 = builder.multiply(output83, arg10)  # [1, 32, 128, 64]
+        arg1 = full_to_shard_device(arg1, builder, 3)  # [1, 1, 128, 64]
+        output87 = builder.add(output85, arg1)  # [1, 32, 128, 64]
+        output87 = shard_to_full_device(output87, builder, 3)
+        output87 = full_to_shard_device(output87, builder, 2)
+        output89 = builder.softmax(output87, -1)  # [1, 32, 64, 128]
+        output89 = shard_to_full_device(output89, builder, 2)
+        output89 = full_to_shard_device(output89, builder, 3)
+        output91 = builder.squeeze(output89, 0)  # [32, 128, 64]
+        arg13 = full_to_shard_device(arg13, builder, 0)  # [2048, 4096]
+        output93 = builder.matmul(output1, arg13)  # [128, 4096]
+        output93 = builder.all_reduce(
+            output93, reduce_type="#tt.reduce_type<sum>", cluster_axis=1
+        )  # [128, 4096]
+        output95 = builder.reshape(output93, (1, 128, 32, 128))  # [1, 128, 32, 128]
+        output95 = shard_to_full_replicate(output95, builder)  # [1, 128, 32, 128]
+        output95 = full_to_shard_device(output95, builder, 1)  # [1, 64, 32, 128]
+        output97 = builder.transpose(output95, -3, -2)  # [1, 32, 64, 128]
+        output99 = builder.transpose(output97, -2, -1)  # [1, 32, 128, 64]
+        output101 = builder.squeeze(output99, 0)  # [32, 128, 64]
+        output103 = builder.transpose(output101, -2, -1)  # [32, 64, 128]
+        output105 = builder.matmul(output91, output103)  # [32, 128, 128]
+        output105 = builder.all_reduce(
+            output105, reduce_type="#tt.reduce_type<sum>", cluster_axis=1
+        )  # [32, 128, 128]
+        output107 = builder.unsqueeze(output105, 0)  # [1, 32, 128, 128]
+        output109 = builder.transpose(output107, -3, -2)  # [1, 128, 32, 128]
+        output111 = builder.reshape(output109, (128, 4096))  # [128, 4096]
+        arg14 = full_to_shard_device(arg14, builder, 1)  # [4096, 2048]
+        output113 = builder.matmul(output111, arg14)  # [128, 2048]
+        output115 = builder.unsqueeze(output113, 0)  # [1, 128, 2048]
+        output115 = shard_to_full_device(output115, builder, dim=2)  # [1, 128, 4096]
+
+        builder.set_graph_input_output(
+            input_tensors,
+            [
+                golden_part2(*input_tensors),
+            ],
+        )
+
+        return output115
+
+    compile_to_flatbuffer(
+        model_part2,
+        shapes,
+        dtypes,
+        target=target,
+        mesh_shape=mesh_shape,
+        test_base=request.node.name,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+    )


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/3414


### What's changed
 - Added a new ttir_builder test case for the Llama model manually sharded on a (1, 2) mesh targeting the N300 device.  
 - The model is divided into two sub-graphs; each sub-graph is compiled and compared against golden outputs to avoid precision mismatches.  

### Checklist
- [ ] New/Existing tests provide coverage for changes
