### PR TITLE
Fix namespace order ttmlir/Target/TTNN/utils.h

### DIFF
--- a/include/ttmlir/Target/TTNN/utils.h
+++ b/include/ttmlir/Target/TTNN/utils.h
@@ -10,7 +10,7 @@
 #include "ttmlir/Target/Common/types_generated.h"
 #include "llvm/Support/ErrorHandling.h"
 
-namespace tt::mlir::ttnn::utils {
+namespace mlir::tt::ttnn::utils {
 
 inline ::tt::target::ttnn::TensorMemoryLayout toTargetTensorMemoryLayout(
     ::mlir::tt::ttnn::TensorMemoryLayout tensorMemoryLayout) {
@@ -93,6 +93,6 @@ inline ::tt::target::DataType toTargetDataType(::mlir::tt::DataType dataType) {
   llvm_unreachable("Unsupported DataType");
 }
 
-} // namespace tt::mlir::ttnn::utils
+} // namespace mlir::tt::ttnn::utils
 
 #endif // TTMLIR_TARGET_TTNN_UTILS_H

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -796,7 +796,7 @@ toFlatbuffer(FlatbufferObjectCache &cache,
   ::tt::target::ttnn::TensorMemoryLayout tensorMemoryLayout =
       toFlatbuffer(cache, tensorMemoryLayoutAttr);
   ::tt::target::BufferType bufferType =
-      ::tt::mlir::ttnn::utils::toTargetBufferType(
+      ::mlir::tt::ttnn::utils::toTargetBufferType(
           memoryConfigAttr.getBufferType().getValue());
 
   ::flatbuffers::Offset<::tt::target::ttnn::ShardSpec> shardSpec = 0;

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -213,7 +213,7 @@ createOp(FlatbufferObjectCache &cache, ToLayoutOp op) {
   auto input = cache.at<::tt::target::ttnn::TensorRef>(
       getOperandThroughDPSOps(op.getInput()));
   ::tt::target::TensorLayout layout =
-      ::tt::mlir::ttnn::utils::toTargetTensorLayout(op.getLayout());
+      ::mlir::tt::ttnn::utils::toTargetTensorLayout(op.getLayout());
   auto output = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
                                   kHostAllocatedSize);
 
@@ -236,7 +236,7 @@ createOp(FlatbufferObjectCache &cache, ToDTypeOp op) {
   auto input = cache.at<::tt::target::ttnn::TensorRef>(
       getOperandThroughDPSOps(op.getInput()));
   ::tt::target::DataType dtype =
-      ::tt::mlir::ttnn::utils::toTargetDataType(op.getDtype());
+      ::mlir::tt::ttnn::utils::toTargetDataType(op.getDtype());
   auto output = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
                                   kHostAllocatedSize);
 
@@ -248,7 +248,7 @@ createOp(FlatbufferObjectCache &cache, TypecastOp op) {
   auto input = cache.at<::tt::target::ttnn::TensorRef>(
       getOperandThroughDPSOps(op.getInput()));
   ::tt::target::DataType dtype =
-      ::tt::mlir::ttnn::utils::toTargetDataType(op.getDtype());
+      ::mlir::tt::ttnn::utils::toTargetDataType(op.getDtype());
   auto output = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
                                   kHostAllocatedSize);
 
@@ -362,9 +362,9 @@ createDistributionStrategy(FlatbufferObjectCache &cache,
 createOp(FlatbufferObjectCache &cache, EmptyOp op) {
   ::llvm::ArrayRef<int64_t> shape = op.getShape().getShape();
   ::tt::target::DataType dtype =
-      ::tt::mlir::ttnn::utils::toTargetDataType(op.getDtype());
+      ::mlir::tt::ttnn::utils::toTargetDataType(op.getDtype());
   ::tt::target::TensorLayout layout =
-      ::tt::mlir::ttnn::utils::toTargetTensorLayout(op.getLayout());
+      ::mlir::tt::ttnn::utils::toTargetTensorLayout(op.getLayout());
 
   auto output = getOperandThroughDPSOps(op.getResult());
   auto device = getOperandThroughDPSOps(op.getDevice());
@@ -866,7 +866,7 @@ createEltwiseBinaryOp(FlatbufferObjectCache &cache, EltwiseBinaryOp op) {
   auto outputType = mlir::cast<RankedTensorType>(result.getType());
   DataType outputDtype = elementTypeToDataType(outputType.getElementType());
   ::tt::target::DataType targetDtype =
-      ::tt::mlir::ttnn::utils::toTargetDataType(outputDtype);
+      ::mlir::tt::ttnn::utils::toTargetDataType(outputDtype);
 
   auto memoryConfig = getMemoryConfigIfNeeded(cache, op);
 


### PR DESCRIPTION
This fixes the namespace ordering from `tt::mlir` to `mlir::tt`.
