### PR TITLE
tt-register device mock system desc arg CLI cleanup

### DIFF
--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -215,7 +215,7 @@ def TT_SystemDescAttr : TT_Attr<"SystemDesc", "system_desc"> {
 
   let extraClassDeclaration = [{
     static tt::SystemDescAttr getDefault(MLIRContext *context, tt::Arch arch = tt::Arch::WormholeB0, const llvm::SmallVector<int64_t> &meshShape = {1});
-    static tt::SystemDescAttr getFromPath(MLIRContext *context, const std::string& path);
+    static tt::SystemDescAttr getFromPath(MLIRContext *context, StringRef path);
     unsigned getAddressAlignBytes(unsigned chipIndex = 0) const;
     unsigned getAddressAlignBytes(MemorySpace memorySpace, unsigned chipIndex = 0) const;
     unsigned getNocL1AddressAlignBytes(unsigned chipIndex = 0) const;

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -215,7 +215,7 @@ def TT_SystemDescAttr : TT_Attr<"SystemDesc", "system_desc"> {
 
   let extraClassDeclaration = [{
     static tt::SystemDescAttr getDefault(MLIRContext *context, tt::Arch arch = tt::Arch::WormholeB0, const llvm::SmallVector<int64_t> &meshShape = {1});
-    static tt::SystemDescAttr getFromPath(MLIRContext *context, std::string& path);
+    static tt::SystemDescAttr getFromPath(MLIRContext *context, const std::string& path);
     unsigned getAddressAlignBytes(unsigned chipIndex = 0) const;
     unsigned getAddressAlignBytes(MemorySpace memorySpace, unsigned chipIndex = 0) const;
     unsigned getNocL1AddressAlignBytes(unsigned chipIndex = 0) const;

--- a/include/ttmlir/Dialect/TT/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TT/Transforms/Passes.td
@@ -58,7 +58,15 @@ def TTRegisterDevicePass : Pass<"tt-register-device", "::mlir::ModuleOp"> {
   }];
 
   list<Option> options = [
-        Option<"archName", "arch-name-for-mock-system-desc", "tt::Arch", "tt::Arch::WormholeB0", "Arch name">,
+        Option<"mockSystemDescArch", "mock-system-desc-arch", "tt::Arch",
+            /*default=*/"tt::Arch::WormholeB0",
+            "Arch name for constructing a mock system descriptor in lieu of system-desc-path.",
+            [{::llvm::cl::values(
+              clEnumValN(tt::Arch::WormholeB0, "wormhole_b0",
+               "Use mock wormhole_b0 system desc."),
+              clEnumValN(tt::Arch::Blackhole, "blackhole",
+               "Use mock blackhole system desc.")
+             )}]>,
         Option<"systemDescPath", "system-desc-path", "std::string", "", "System desc path">,
         ListOption<"meshShape", "mesh-shape", "int64_t", "Set the mesh shape">,
     ];

--- a/include/ttmlir/Dialect/TT/Transforms/Transforms.h
+++ b/include/ttmlir/Dialect/TT/Transforms/Transforms.h
@@ -12,8 +12,12 @@
 
 namespace mlir::tt {
 
-void registerDevice(ModuleOp module, tt::Arch arch = tt::Arch::WormholeB0,
-                    std::string path = {}, ArrayRef<int64_t> meshShape = {});
+void registerDevice(ModuleOp module,
+                    tt::Arch mockSystemDescArch = tt::Arch::WormholeB0,
+                    ArrayRef<int64_t> meshShape = {});
+
+void registerDevice(ModuleOp module, const std::string &systemDescPath,
+                    ArrayRef<int64_t> meshShape = {});
 
 } // namespace mlir::tt
 

--- a/include/ttmlir/Dialect/TTMetal/Pipelines/TTMetalPipelines.h
+++ b/include/ttmlir/Dialect/TTMetal/Pipelines/TTMetalPipelines.h
@@ -5,6 +5,8 @@
 #ifndef TTMLIR_DIALECT_TTMETAL_PIPELINES_TTMETALPIPELINES_H
 #define TTMLIR_DIALECT_TTMETAL_PIPELINES_TTMETALPIPELINES_H
 
+#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
+
 #include "mlir/Pass/PassOptions.h"
 
 namespace mlir::tt::ttmetal {
@@ -27,6 +29,19 @@ struct TTIRToTTMetalBackendPipelineOptions
       llvm::cl::desc(
           "Pass in a system descriptor flatbuffer to compile against."),
       llvm::cl::init("")};
+
+  // Option to provide a fallback mock system descriptor arch to compile
+  // against.
+  //
+  Option<tt::Arch> mockSystemDescArch{
+      *this, "mock-system-desc-arch",
+      llvm::cl::desc(
+          "Arch name for constructing a mock system descriptor in lieu of "
+          "system-desc-path."),
+      llvm::cl::values(clEnumValN(tt::Arch::WormholeB0, "wormhole_b0",
+                                  "Use mock wormhole_b0 system desc."),
+                       clEnumValN(tt::Arch::Blackhole, "blackhole",
+                                  "Use mock blackhole system desc."))};
 };
 
 void createTTIRBufferizationPipeline(OpPassManager &pm);

--- a/include/ttmlir/Dialect/TTMetal/Pipelines/TTMetalPipelines.h
+++ b/include/ttmlir/Dialect/TTMetal/Pipelines/TTMetalPipelines.h
@@ -41,7 +41,8 @@ struct TTIRToTTMetalBackendPipelineOptions
       llvm::cl::values(clEnumValN(tt::Arch::WormholeB0, "wormhole_b0",
                                   "Use mock wormhole_b0 system desc."),
                        clEnumValN(tt::Arch::Blackhole, "blackhole",
-                                  "Use mock blackhole system desc."))};
+                                  "Use mock blackhole system desc.")),
+      llvm::cl::init(tt::Arch::WormholeB0)};
 };
 
 void createTTIRBufferizationPipeline(OpPassManager &pm);

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -151,8 +151,21 @@ struct TTIRToTTNNBackendPipelineOptions
           "Pass in a system descriptor flatbuffer to compile against."),
       llvm::cl::init("")};
 
-  // Option to override maximum number of sharded layouts to be generated in
-  // legal layout analysis.
+  // Option to provide a fallback mock system descriptor arch to compile
+  // against.
+  //
+  Option<tt::Arch> mockSystemDescArch{
+      *this, OptionNames::mockSystemDescArch,
+      llvm::cl::desc(
+          "Arch name for constructing a mock system descriptor in lieu of "
+          "system-desc-path."),
+      llvm::cl::values(clEnumValN(tt::Arch::WormholeB0, "wormhole_b0",
+                                  "Use mock wormhole_b0 system desc."),
+                       clEnumValN(tt::Arch::Blackhole, "blackhole",
+                                  "Use mock blackhole system desc."))};
+
+  // Option to override maximum number of sharded layouts to be generated
+  // in legal layout analysis.
   //
   Option<int64_t> maxLegalLayouts{
       *this, OptionNames::maxLegalLayouts,

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -162,7 +162,8 @@ struct TTIRToTTNNBackendPipelineOptions
       llvm::cl::values(clEnumValN(tt::Arch::WormholeB0, "wormhole_b0",
                                   "Use mock wormhole_b0 system desc."),
                        clEnumValN(tt::Arch::Blackhole, "blackhole",
-                                  "Use mock blackhole system desc."))};
+                                  "Use mock blackhole system desc.")),
+      llvm::cl::init(tt::Arch::WormholeB0)};
 
   // Option to override maximum number of sharded layouts to be generated
   // in legal layout analysis.

--- a/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
@@ -26,6 +26,7 @@ struct OptionNames {
   static constexpr StringRef memoryLayoutAnalysisPolicy =
       "memory-layout-analysis-policy";
   static constexpr StringRef systemDescPath = "system-desc-path";
+  static constexpr StringRef mockSystemDescArch = "mock-system-desc-arch";
   static constexpr StringRef maxLegalLayouts = "max-legal-layouts";
   static constexpr StringRef meshShape = "mesh-shape";
 };

--- a/lib/Dialect/TT/IR/TTOpsTypes.cpp
+++ b/lib/Dialect/TT/IR/TTOpsTypes.cpp
@@ -299,7 +299,8 @@ mlir::tt::SystemDescAttr mlir::tt::SystemDescAttr::getDefault(
 }
 
 mlir::tt::SystemDescAttr
-mlir::tt::SystemDescAttr::getFromPath(MLIRContext *context, std::string &path) {
+mlir::tt::SystemDescAttr::getFromPath(MLIRContext *context,
+                                      const std::string &path) {
   // Check if file exists
   assert(!path.empty() && "system desc path must not be empty!");
   std::ifstream fbb(path, std::ios::binary | std::ios::ate);

--- a/lib/Dialect/TT/IR/TTOpsTypes.cpp
+++ b/lib/Dialect/TT/IR/TTOpsTypes.cpp
@@ -299,11 +299,10 @@ mlir::tt::SystemDescAttr mlir::tt::SystemDescAttr::getDefault(
 }
 
 mlir::tt::SystemDescAttr
-mlir::tt::SystemDescAttr::getFromPath(MLIRContext *context,
-                                      const std::string &path) {
+mlir::tt::SystemDescAttr::getFromPath(MLIRContext *context, StringRef path) {
   // Check if file exists
   assert(!path.empty() && "system desc path must not be empty!");
-  std::ifstream fbb(path, std::ios::binary | std::ios::ate);
+  std::ifstream fbb(path.data(), std::ios::binary | std::ios::ate);
   assert(fbb.good() && "system desc does not exist!");
   std::streampos size = fbb.tellg();
   fbb.seekg(0, std::ios::beg);

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -52,6 +52,7 @@ void createTTIRToTTMetalFrontendPipeline(
   tt::TTRegisterDevicePassOptions registerDeviceOptions;
   {
     registerDeviceOptions.systemDescPath = options.systemDescPath;
+    registerDeviceOptions.mockSystemDescArch = options.mockSystemDescArch;
     registerDeviceOptions.meshShape = llvm::to_vector(options.meshShape);
   }
   pm.addPass(tt::createTTRegisterDevicePass(registerDeviceOptions));

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -29,6 +29,7 @@ void createTTNNPipelineTTIRPasses(
   tt::TTRegisterDevicePassOptions registerDeviceOptions;
   {
     registerDeviceOptions.systemDescPath = options.systemDescPath;
+    registerDeviceOptions.mockSystemDescArch = options.mockSystemDescArch;
     registerDeviceOptions.meshShape = llvm::to_vector(options.meshShape);
   }
   pm.addPass(mlir::tt::createTTRegisterDevicePass(registerDeviceOptions));


### PR DESCRIPTION
This change cleans up the naming and creation of system descriptors via the mock arch enum path.  It also plumbs it through backend pipeline options.
