### PR TITLE
Ensure link against llvm gtest

### DIFF
--- a/test/unittests/Optimizer/TestGreedyL1InterleavedPolicy.cpp
+++ b/test/unittests/Optimizer/TestGreedyL1InterleavedPolicy.cpp
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <gtest/gtest.h>
-
+#include "llvm-gtest/gtest/gtest.h"
 #include "mlir/IR/Value.h"
 #include "mlir/IR/ValueRange.h"
 #include "llvm/ADT/SmallVector.h"

--- a/test/unittests/Optimizer/TestLayoutAnalysis.cpp
+++ b/test/unittests/Optimizer/TestLayoutAnalysis.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <gtest/gtest.h>
 #include <optional>
 
 #include "ttmlir/Dialect/TT/IR/TT.h"
@@ -17,6 +16,7 @@
 #include "ttmlir/Dialect/TTNN/Utils/OptimizerUtils.h"
 #include "ttmlir/Dialect/TTNN/Utils/TransformUtils.h"
 
+#include "llvm-gtest/gtest/gtest.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"

--- a/test/unittests/Optimizer/TestOptimizerOverrides.cpp
+++ b/test/unittests/Optimizer/TestOptimizerOverrides.cpp
@@ -2,12 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttmlir/Dialect/TTNN/Utils/OptimizerOverrides.h"
-#include "llvm/Support/CommandLine.h"
-#include <gtest/gtest.h>
-
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/Utils/OptimizerOverrides.h"
+
+#include "llvm-gtest/gtest/gtest.h"
+#include "llvm/Support/CommandLine.h"
 
 using namespace mlir::tt::ttnn;
 

--- a/test/unittests/Optimizer/TestShardSolver.cpp
+++ b/test/unittests/Optimizer/TestShardSolver.cpp
@@ -2,17 +2,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <gtest/gtest.h>
-
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
 #include "ttmlir/Dialect/TT/Transforms/Transforms.h"
+#include "ttmlir/Dialect/TTNN/Analysis/L1ChainConfig.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNN.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
-
-#include "ttmlir/Dialect/TTNN/Analysis/L1ChainConfig.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 
+#include "llvm-gtest/gtest/gtest.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"

--- a/test/unittests/Support/LoggerTest.cpp
+++ b/test/unittests/Support/LoggerTest.cpp
@@ -4,9 +4,9 @@
 
 #include "ttmlir/Support/Logger.h"
 
+#include "llvm-gtest/gtest/gtest.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
-#include "gtest/gtest.h"
 
 #include <cstdlib>
 #include <sstream>

--- a/test/unittests/TestScheduler/TestScheduler.cpp
+++ b/test/unittests/TestScheduler/TestScheduler.cpp
@@ -2,9 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <gtest/gtest.h>
 #include <random>
 
+#include "llvm-gtest/gtest/gtest.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Value.h"


### PR DESCRIPTION
We use llvm cmake macro's to link against their included version of gtest, ensure the headers pickup the llvm version explicitly in the case when there might be a system gtest installation also present.