### PR TITLE
D2M preliminary multicore support

### DIFF
--- a/include/ttmlir/Conversion/Passes.td
+++ b/include/ttmlir/Conversion/Passes.td
@@ -96,7 +96,7 @@ def ConvertTTIRToTTMetal: Pass<"convert-ttir-to-ttmetal", "::mlir::ModuleOp"> {
 def ConvertTTIRToTTKernel: Pass<"convert-ttir-to-ttkernel", "::mlir::ModuleOp"> {
   let summary = "Convert TTIR dialect to TTKernel dialect.";
   let constructor = "createConvertTTIRToTTKernelPass()";
-  let dependentDialects = ["mlir::tt::ttir::TTIRDialect", "mlir::tt::ttmetal::TTMetalDialect", "mlir::tt::ttkernel::TTKernelDialect", "mlir::arith::ArithDialect", "mlir::affine::AffineDialect"];
+  let dependentDialects = ["mlir::tt::ttir::TTIRDialect", "mlir::tt::ttmetal::TTMetalDialect", "mlir::tt::ttkernel::TTKernelDialect", "mlir::arith::ArithDialect"];
 }
 
 def ConvertTTNNToEmitC : Pass<"convert-ttnn-to-emitc", "::mlir::ModuleOp"> {

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
@@ -11,6 +11,7 @@ include "ttmlir/Dialect/TTIR/IR/TTIRBase.td"
 include "ttmlir/Dialect/TTIR/IR/TTIROpsAttrs.td"
 include "ttmlir/Dialect/TTIR/IR/TTIROpsInterfaces.td"
 
+include "mlir/Dialect/Bufferization/IR/BufferizableOpInterface.td"
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/InferIntRangeInterface.td"
@@ -217,6 +218,12 @@ def TTIR_DMAOp : TTIR_GenericRegionDatamovementOp<"dma",
   [ AttrSizedOperandSegments
   , DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
   , DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
+  , DeclareOpInterfaceMethods<BufferizableOpInterface, [ "bufferizesToMemoryRead"
+                                                       , "bufferizesToMemoryWrite"
+                                                       , "bufferize"
+                                                       , "getAliasingValues"
+                                                       , "getBufferType"
+                                                       ]>
   ]> {
     let summary = "TTIR DMA Op";
     let description = [{
@@ -269,8 +276,8 @@ def TTIR_DMAOp : TTIR_GenericRegionDatamovementOp<"dma",
       - src and dst cannot both be remote
     }];
 
-    let arguments = (ins AnyNon0RankedMemRef:$src, OptionalAttr<AffineMapAttr>:$srcAffineMap, Variadic<Index>:$srcIndices,
-                         AnyNon0RankedMemRef:$dst, OptionalAttr<AffineMapAttr>:$dstAffineMap, Variadic<Index>:$dstIndices,
+    let arguments = (ins AnyRankedTensorOrMemRef:$src, OptionalAttr<AffineMapAttr>:$srcAffineMap, Variadic<Index>:$srcIndices,
+                         AnyRankedTensorOrMemRef:$dst, OptionalAttr<AffineMapAttr>:$dstAffineMap, Variadic<Index>:$dstIndices,
                          OptionalAttr<I64Attr>:$optNumElems, Variadic<Index>:$mcastStartIndex, Variadic<Index>:$mcastShape);
     let results = (outs TTIR_MemTx:$result);
 
@@ -341,6 +348,7 @@ def TTIR_DMAOp : TTIR_GenericRegionDatamovementOp<"dma",
       MemRefType getSrcMemRefType() { return cast<MemRefType>(getSrc().getType()); }
       MemRefType getDstMemRefType() { return cast<MemRefType>(getDst().getType()); }
       int64_t getNumElems();
+      size_t getSizeBytes();
       bool isSrcLocal() {
         Block *block = getSrc().getParentBlock();
         Block::BlockArgListType blockArgs = block->getArguments();
@@ -356,11 +364,9 @@ def TTIR_DMAOp : TTIR_GenericRegionDatamovementOp<"dma",
       }
       bool isDstRemote() { return !isDstLocal(); }
       bool isMcast() { return !getMcastShape().empty(); }
-      bool isAffine() { return getSrcAffineMap() || getDstAffineMap(); }
-      bool isFullyIndexed() {
-        return static_cast<int64_t>(getSrcIndices().size()) == getSrcMemRefType().getRank() &&
-               static_cast<int64_t>(getDstIndices().size()) == getDstMemRefType().getRank() &&
-               getOptNumElems();
+      bool isAffine() { return (getSrcAffineMap() || getDstAffineMap()) && getSrcIndices().empty() && getDstIndices().empty(); }
+      bool isLowered() {
+        return bool(getOptNumElems());
       }
     }];
 }
@@ -516,6 +522,7 @@ class TTIR_IndexOp<string mnemonic, list<Trait> traits = []> : TTIR_GenericRegio
     let arguments = (ins ConfinedAttr<I64Attr, [IntMinValue<0>]>:$dim);
     let results = (outs Index:$result);
     let assemblyFormat = [{ `(` $dim `)` attr-dict `:` type($result) }];
+    let hasFolder = true;
 }
 
 def TTIR_IterIndexOp : TTIR_IndexOp<"iter_index"> {
@@ -525,12 +532,11 @@ def TTIR_IterIndexOp : TTIR_IndexOp<"iter_index"> {
     }];
 }
 
-def TTIR_CoreIndexOp : TTIR_IndexOp<"core_index", [ConstantLike]> {
+def TTIR_CoreIndexOp : TTIR_IndexOp<"core_index"> {
     let summary = "Core Index op.";
     let description = [{
       Return the index of this core's coordinate inside the generic op's grid dimension.
     }];
-    let hasFolder = true;
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -121,8 +121,8 @@ def TTIR_GenericOp : TTIR_BufferizableOp<"generic",
                      "ValueRange": $outputs,
                      "ArrayAttr": $indexingMaps,
                      "ArrayAttr": $iteratorTypes,
-                     CArg<"GridAttr", "nullptr">: $grid,
-                     CArg<"ThreadType", "ThreadType::Compute">: $singleThreadType),
+                     CArg<"ThreadType", "ThreadType::Compute">: $singleThreadType,
+                     CArg<"GridAttr", "nullptr">: $grid),
       [{
         assert(!indexingMaps.empty() && "expected non-empty indexing maps");
         assert(outputs.size() == 1 && "expected single output");
@@ -144,10 +144,10 @@ def TTIR_GenericOp : TTIR_BufferizableOp<"generic",
                      "ArrayAttr": $indexingMaps,
                      "ArrayAttr": $iteratorTypes,
                      "llvm::function_ref<void(OpBuilder&, Location, ValueRange)>": $singleThreadRegionBuilder,
-                     CArg<"GridAttr", "nullptr">: $grid,
-                     CArg<"ThreadType", "ThreadType::Compute">: $singleThreadType),
+                     CArg<"ThreadType", "ThreadType::Compute">: $singleThreadType,
+                     CArg<"GridAttr", "nullptr">: $grid),
       [{
-        build($_builder, $_state, inputs, outputs, indexingMaps, iteratorTypes, grid, singleThreadType);
+        build($_builder, $_state, inputs, outputs, indexingMaps, iteratorTypes, singleThreadType, grid);
         llvm::SmallVector<Type> blockTypes = llvm::map_to_vector(TypeRange($_state.operands), [&](Type t) -> Type {
           mlir::RankedTensorType tensorType = mlir::cast<RankedTensorType>(t);
           return mlir::cast<tt::MetalLayoutAttr>(tensorType.getEncoding()).getMemref();
@@ -161,14 +161,14 @@ def TTIR_GenericOp : TTIR_BufferizableOp<"generic",
       OpBuilder<(ins "ValueRange": $inputs,
                      "ValueRange": $outputs,
                      "llvm::function_ref<void(OpBuilder&, Location, ValueRange)>": $singleThreadRegionBuilder,
-                     CArg<"GridAttr", "nullptr">: $grid,
-                     CArg<"ThreadType", "ThreadType::Compute">: $singleThreadType),
+                     CArg<"ThreadType", "ThreadType::Compute">: $singleThreadType,
+                     CArg<"GridAttr", "nullptr">: $grid),
       [{
         assert(outputs.size() == 1 && "expected single output");
         RankedTensorType tensorType = mlir::cast<RankedTensorType>(outputs[0].getType());
         MetalLayoutAttr layout = mlir::cast<tt::MetalLayoutAttr>(tensorType.getEncoding());
         auto [indexingMaps, iteratorTypes] = buildParallelAffineMapsAndIteratorTypes($_builder, inputs.size() + outputs.size(), layout.getRank());
-        build($_builder, $_state, inputs, outputs, indexingMaps, iteratorTypes, singleThreadRegionBuilder, grid, singleThreadType);
+        build($_builder, $_state, inputs, outputs, indexingMaps, iteratorTypes, singleThreadRegionBuilder, singleThreadType, grid);
       }]>,
     ];
 
@@ -242,8 +242,9 @@ def TTIR_ToLayoutOp : TTIR_BufferizableOp<"to_layout"> {
 
         bool isCompound() {
           return (static_cast<int>(isLayoutChange) +
-                  static_cast<int>(isGridChange || isMemorySpaceChange) +
-                  static_cast<int>(isFormatChange)) > 1;
+                  static_cast<int>(isGridChange) +
+                  static_cast<int>(isFormatChange) +
+                  static_cast<int>(isMemorySpaceChange)) > 1;
         }
       };
 

--- a/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
+++ b/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
@@ -10,7 +10,6 @@
 #include "ttmlir/Dialect/TTKernel/IR/TTKernelOps.h"
 #include "ttmlir/Utils.h"
 
-#include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -37,7 +36,7 @@ static Value index(OpBuilder &rewriter, Location loc, int64_t value) {
 }
 
 static std::pair<Value, Value>
-getVirtualCoordsFromLogicalCoords(PatternRewriter &rewriter, Location loc,
+getVirtualCoordsFromLogicalCoords(OpBuilder &rewriter, Location loc,
                                   ChipDescAttr chipDesc,
                                   ValueRange dstCoreIndex) {
   auto offset = chipDesc.getCoordTranslationOffsets();
@@ -455,39 +454,6 @@ public:
       : OpConversionPattern<ttir::DMAOp>(typeConverter, context),
         associatedDMAWaits(associatedDMAWaits) {}
 
-  static size_t getElementSizeBytes(MemRefType memref) {
-    mlir::Type elementType = memref.getElementType();
-    auto tileType = mlir::dyn_cast<TileType>(elementType);
-    return tileType ? tileType.getSizeBytes()
-                    : elementType.getIntOrFloatBitWidth() / 8;
-  }
-
-  static int64_t getLocalMemrefSizeBytes(MemRefType memref) {
-    return getElementSizeBytes(memref) * memref.getNumElements();
-  }
-
-  // For use on REMOTE memrefs
-  static size_t getMemrefShardNumElems(MemRefType memref) {
-    DeviceLayoutInterface layout =
-        mlir::cast<DeviceLayoutInterface>(memref.getLayout());
-    return layout.getShardNumElements(memref);
-  }
-
-  static std::tuple<AffineMap, AffineMap, AffineMap>
-  getIndividualResultMaps(Operation *op, tt::DeviceAttr device,
-                          OpBuilder &builder) {
-    std::pair<MemRefType, AffineMap> memrefAndView = ttir::applyViews(op);
-    size_t pageSize =
-        device.getMemrefSizeBytes(memrefAndView.first, /*pageSize=*/0);
-    AffineMap memoryMap = device.getMemoryMap(memrefAndView, pageSize, 0)
-                              .dropResult(0); // drop the device index
-    assert(memoryMap.getNumResults() == 3);
-    auto gridY = memoryMap.dropResults({1, 2});
-    auto gridX = memoryMap.dropResults({0, 2});
-    auto offset = memoryMap.dropResults({0, 1});
-    return std::make_tuple(gridY, gridX, offset);
-  }
-
   static Value castCBTypeAsAddress(OpBuilder &rewriter, Location loc,
                                    Value cb) {
     // This is required because we blanket convert Memrefs into CBs with a type
@@ -501,9 +467,40 @@ public:
         ->getResult(0);
   }
 
+  static Value buildNocAddress(OpBuilder &rewriter, Location loc, Value cb,
+                               ValueRange index, ChipDescAttr chipDesc) {
+    auto baseAddr = castCBTypeAsAddress(rewriter, loc, cb);
+    assert(index.size() == 3);
+    auto gridY = index[0];
+    auto gridX = index[1];
+    auto offset = index[2];
+    auto offsetInt =
+        rewriter.create<arith::IndexCastOp>(loc, rewriter.getI32Type(), offset);
+    auto addr = rewriter.create<arith::AddIOp>(loc, baseAddr, offsetInt);
+    // Translate the src coordinates to virtual coordinates.
+    auto [virtY, virtX] = getVirtualCoordsFromLogicalCoords(
+        rewriter, loc, chipDesc, ValueRange{gridY, gridX});
+    return rewriter.create<ttkernel::GetNocAddrOp>(loc, virtX, virtY, addr);
+  }
+
+  template <typename ReadWritePtrOp>
+  static Value buildL1Address(OpBuilder &rewriter, Location loc, Value cb,
+                              ValueRange index) {
+    // Use the cb addr as the write address since it is local.
+    Value baseAddr = rewriter.create<ReadWritePtrOp>(loc, cb);
+    auto offset = rewriter.create<arith::IndexCastOp>(
+        loc, rewriter.getI32Type(), index[0]);
+    return rewriter.create<arith::AddIOp>(loc, baseAddr, offset);
+  }
+
   LogicalResult
   matchAndRewrite(ttir::DMAOp op, ttir::DMAOpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
+    if (!op.isLowered()) {
+      return rewriter.notifyMatchFailure(
+          op, "Unsupported DMA form that is not lowered.");
+    }
+
     auto device = lookupDevice(op);
     auto systemDesc = getCurrentScopeSystemDesc(op);
     auto chipIds = device.getChipIds();
@@ -514,24 +511,16 @@ public:
 
     // TODO(jdesousa): Temporary L1 assertion until DRAM is supported
     assert(isL1MemorySpace(mlir::cast<MemorySpaceAttr>(
-                               op.getSrc().getType().getMemorySpace())
+                               op.getSrcMemRefType().getMemorySpace())
                                .getValue()) &&
            isL1MemorySpace(mlir::cast<MemorySpaceAttr>(
-                               op.getDst().getType().getMemorySpace())
+                               op.getDstMemRefType().getMemorySpace())
                                .getValue()) &&
            "Expected src and dst memory spaces to be L1, failing.");
-
-    auto applyMap = [&](AffineMap map, ValueRange index) {
-      auto apply =
-          rewriter.create<affine::AffineApplyOp>(op.getLoc(), map, index);
-      return apply;
-    };
 
     bool isRead = false;
     if (op.isSrcLocal() && op.isDstLocal()) {
       // Local to Local Datamovement & Multicast
-
-      auto srcCb = mlir::cast<ttkernel::CBType>(adaptor.getSrc().getType());
 
       // Both src and dst are local, use the metal cb pointers to determine
       // addressing
@@ -540,8 +529,7 @@ public:
       Value dstL1Start = rewriter.create<ttkernel::GetWritePtrOp>(
           op.getLoc(), adaptor.getDst());
 
-      Value transferSize = i32(rewriter, op->getLoc(),
-                               getLocalMemrefSizeBytes(srcCb.getMemref()));
+      Value transferSize = i32(rewriter, op->getLoc(), op.getSizeBytes());
       if (op.isMcast()) {
         // Multicast lowering
         // Get virtual start coordinates from DMA op logical coordinates
@@ -590,81 +578,22 @@ public:
                                                    nocAddr, transferSize);
       }
     } else if (op.isSrcLocal() && op.isDstRemote()) {
-      // Local to Remote write
-      if (!op.getOptNumElems()) {
-        op.setOptNumElems(getMemrefShardNumElems(op.getDst().getType()));
-      }
-      auto transferSize =
-          i32(rewriter, op->getLoc(),
-              op.getNumElems() * getElementSizeBytes(op.getDstMemRefType()));
-
-      // Use the cb addr as the read address since it is local
-      Value srcL1Start = rewriter.create<ttkernel::GetReadPtrOp>(
-          op.getLoc(), adaptor.getSrc());
-
-      // Use the affine mapping from the dst memref to get the dst address and
-      // coordinates
-      AffineMap dstGridYMap, dstGridXMap, dstOffsetMap;
-      std::tie(dstGridYMap, dstGridXMap, dstOffsetMap) =
-          getIndividualResultMaps(op.getDst().getDefiningOp(), device,
-                                  rewriter);
-
-      auto dstGridY = applyMap(dstGridYMap, op.getDstIndices());
-      auto dstGridX = applyMap(dstGridXMap, op.getDstIndices());
-      auto dstOffset = applyMap(dstOffsetMap, op.getDstIndices());
-      auto dstOffsetInt = rewriter.create<arith::IndexCastOp>(
-          op.getLoc(), rewriter.getI32Type(), dstOffset);
-
-      auto dstAddrAsInt =
-          castCBTypeAsAddress(rewriter, op->getLoc(), adaptor.getDst());
-      auto dstAddr = rewriter.create<arith::AddIOp>(op.getLoc(), dstOffsetInt,
-                                                    dstAddrAsInt);
-
-      // Translate the dst coordinates to virtual coordinates
-      auto [virtY, virtX] = getVirtualCoordsFromLogicalCoords(
-          rewriter, op.getLoc(), chipDesc, ValueRange{dstGridY, dstGridX});
-      auto nocAddr = rewriter.create<ttkernel::GetNocAddrOp>(op.getLoc(), virtX,
-                                                             virtY, dstAddr);
-      rewriter.create<ttkernel::NocAsyncWriteOp>(op.getLoc(), srcL1Start,
-                                                 nocAddr, transferSize);
+      auto srcL1Addr = buildL1Address<ttkernel::GetReadPtrOp>(
+          rewriter, op.getLoc(), adaptor.getSrc(), op.getSrcIndices());
+      auto dstNocAddr = buildNocAddress(rewriter, op.getLoc(), adaptor.getDst(),
+                                        op.getDstIndices(), chipDesc);
+      auto size = i32(rewriter, op->getLoc(), op.getSizeBytes());
+      rewriter.create<ttkernel::NocAsyncWriteOp>(op.getLoc(), srcL1Addr,
+                                                 dstNocAddr, size);
+      isRead = false;
     } else if (op.isSrcRemote() && op.isDstLocal()) {
-      // Remote to Local read
-      if (!op.getOptNumElems()) {
-        op.setOptNumElems(getMemrefShardNumElems(op.getSrc().getType()));
-      }
-
-      // Use the cb addr as the write address since it is local
-      Value dstL1Start = rewriter.create<ttkernel::GetWritePtrOp>(
-          op.getLoc(), adaptor.getDst());
-
-      // Use the affine mapping from the src memref to get the src address and
-      // coordinates
-      AffineMap srcGridYMap, srcGridXMap, srcOffsetMap;
-      std::tie(srcGridYMap, srcGridXMap, srcOffsetMap) =
-          getIndividualResultMaps(op.getSrc().getDefiningOp(), device,
-                                  rewriter);
-
-      auto srcGridY = applyMap(srcGridYMap, op.getSrcIndices());
-      auto srcGridX = applyMap(srcGridXMap, op.getSrcIndices());
-      auto srcOffset = applyMap(srcOffsetMap, op.getSrcIndices());
-      auto srcOffsetInt = rewriter.create<arith::IndexCastOp>(
-          op.getLoc(), rewriter.getI32Type(), srcOffset);
-      auto size =
-          i32(rewriter, op->getLoc(),
-              op.getNumElems() * getElementSizeBytes(op.getSrcMemRefType()));
-
-      auto srcAddrAsInt =
-          castCBTypeAsAddress(rewriter, op->getLoc(), adaptor.getSrc());
-      auto srcAddr = rewriter.create<arith::AddIOp>(op.getLoc(), srcOffsetInt,
-                                                    srcAddrAsInt);
-
-      // Translate the src coordinates to virtual coordinates
-      auto [virtY, virtX] = getVirtualCoordsFromLogicalCoords(
-          rewriter, op.getLoc(), chipDesc, ValueRange{srcGridY, srcGridX});
-      auto srcNocAddr = rewriter.create<ttkernel::GetNocAddrOp>(
-          op.getLoc(), virtX, virtY, srcAddr);
+      auto srcNocAddr = buildNocAddress(rewriter, op.getLoc(), adaptor.getSrc(),
+                                        op.getSrcIndices(), chipDesc);
+      auto dstL1Addr = buildL1Address<ttkernel::GetWritePtrOp>(
+          rewriter, op.getLoc(), adaptor.getDst(), op.getDstIndices());
+      auto size = i32(rewriter, op->getLoc(), op.getSizeBytes());
       rewriter.create<ttkernel::NocAsyncReadOp>(op.getLoc(), srcNocAddr,
-                                                dstL1Start, size);
+                                                dstL1Addr, size);
       isRead = true;
     } else {
       emitError(op.getLoc(), "Unsupported DMA Configuration");

--- a/lib/Conversion/TTIRToTTKernel/TTIRToTTKernelPass.cpp
+++ b/lib/Conversion/TTIRToTTKernel/TTIRToTTKernelPass.cpp
@@ -12,8 +12,6 @@
 #include "ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.h"
 #include "ttmlir/Dialect/TTMetal/IR/TTMetal.h"
 
-#include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
-#include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Func/Transforms/FuncConversions.h"
@@ -98,7 +96,6 @@ struct ConvertTTIRToTTKernel
         patterns, typeConverter);
     populateTTIRToTTKernelPatterns(&getContext(), patterns, typeConverter,
                                    associatedDMAWaits);
-    populateAffineToStdConversionPatterns(patterns);
     scf::populateSCFStructuralTypeConversionsAndLegality(typeConverter,
                                                          patterns, target);
 

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
@@ -89,10 +89,16 @@ public:
     for (auto operand : adaptor.getOperands()) {
       auto stream = mlir::dyn_cast_if_present<ttir::StreamLayoutOp>(
           operand.getDefiningOp());
+      auto view = mlir::dyn_cast_if_present<ttir::ViewLayoutOp>(
+          operand.getDefiningOp());
       if (stream) {
         buffers.push_back(stream.getInput());
         remappedBuffers.push_back(rewriter.getRemappedValue(stream.getInput()));
         cbs.push_back(stream.getStorage());
+      } else if (view) {
+        buffers.push_back(view.getInput());
+        remappedBuffers.push_back(rewriter.getRemappedValue(view.getInput()));
+        cbs.push_back(view.getInput());
       } else {
         buffers.push_back(operand);
         remappedBuffers.push_back(rewriter.getRemappedValue(operand));

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetalPass.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetalPass.cpp
@@ -51,6 +51,7 @@ struct ConvertTTIRToTTMetal
     target.addIllegalDialect<ttir::TTIRDialect>();
 
     target.addLegalOp<ttir::StreamLayoutOp>();
+    target.addLegalOp<ttir::ViewLayoutOp>();
 
     target.addDynamicallyLegalOp<memref::AllocOp>([&](memref::AllocOp op) {
       return !mlir::dyn_cast_if_present<tt::MemorySpaceAttr>(

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -403,23 +403,23 @@ public:
 
 namespace {
 template <typename Op, typename Adaptor = typename Op::Adaptor>
-class TTKernelLiteralRewriter : public OpConversionPattern<Op> {
+class TTKernelConstantRewriter : public OpConversionPattern<Op> {
 public:
-  TTKernelLiteralRewriter(TTKernelToEmitCTypeConverter &typeConverter,
-                          MLIRContext *ctx, std::string literal)
-      : OpConversionPattern<Op>(typeConverter, ctx), literal(literal) {}
+  TTKernelConstantRewriter(TTKernelToEmitCTypeConverter &typeConverter,
+                           MLIRContext *ctx, std::string opaque)
+      : OpConversionPattern<Op>(typeConverter, ctx), opaque(opaque) {}
 
   LogicalResult
   matchAndRewrite(Op op, Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
-    rewriter.replaceOpWithNewOp<emitc::LiteralOp>(
+    rewriter.replaceOpWithNewOp<emitc::ConstantOp>(
         op, this->getTypeConverter()->convertType(op->getResultTypes()[0]),
-        literal);
+        rewriter.getAttr<emitc::OpaqueAttr>(opaque));
     return success();
   }
 
 private:
-  std::string literal;
+  std::string opaque;
 };
 } // namespace
 
@@ -625,10 +625,10 @@ public:
     patterns.add<TTKernelToEmitCOpaqueRewriter<ttkernel::GetNocAddrOp>>(
         typeConverter, funcOp.getContext(), "get_noc_addr");
 
-    patterns.add<TTKernelLiteralRewriter<ttkernel::MyXOp>>(
-        typeConverter, funcOp.getContext(), "NOC_X(my_x[noc_index])");
-    patterns.add<TTKernelLiteralRewriter<ttkernel::MyYOp>>(
-        typeConverter, funcOp.getContext(), "NOC_Y(my_y[noc_index])");
+    patterns.add<TTKernelConstantRewriter<ttkernel::MyXOp>>(
+        typeConverter, funcOp.getContext(), "my_x[noc_index]");
+    patterns.add<TTKernelConstantRewriter<ttkernel::MyYOp>>(
+        typeConverter, funcOp.getContext(), "my_y[noc_index]");
 
     patterns.add<TTKernelStoreToL1OpToEmitCOpRewriter>(typeConverter,
                                                        funcOp.getContext());

--- a/lib/Dialect/TTIR/IR/TTIRGenericRegionOps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIRGenericRegionOps.cpp
@@ -4,8 +4,10 @@
 
 #include "ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.h"
 
+#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
 #include "ttmlir/Utils.h"
 
+#include "mlir/IR/BuiltinTypeInterfaces.h"
 #include "llvm/Support/MathExtras.h"
 
 #define GET_OP_CLASSES
@@ -78,11 +80,20 @@ void mlir::tt::ttir::TileMatmulBlockOp::getEffects(
 // DMAOp
 //===----------------------------------------------------------------------===//
 ::mlir::LogicalResult mlir::tt::ttir::DMAOp::verify() {
-  MemRefType srcType = getSrc().getType();
-  MemRefType dstType = getDst().getType();
-  if (srcType.getElementType() != dstType.getElementType()) {
-    return emitOpError(
-        "MemRef operands to DMA must have the same element type");
+  ShapedType srcType = mlir::cast<ShapedType>(getSrc().getType());
+  ShapedType dstType = mlir::cast<ShapedType>(getDst().getType());
+
+  //
+  // Tensor style DMA needs additional refactoring to support the device layout
+  // shapes. These skips can be removed once this issue is resolved:
+  // https://github.com/tenstorrent/tt-mlir/issues/3389
+  //
+  bool skipChecksForTensorType = mlir::isa<RankedTensorType>(srcType) ||
+                                 mlir::isa<RankedTensorType>(dstType);
+
+  if (!skipChecksForTensorType &&
+      srcType.getElementType() != dstType.getElementType()) {
+    return emitOpError("operands to DMA must have the same element type");
   }
 
   if (isSrcRemote() && isDstRemote()) {
@@ -107,6 +118,13 @@ void mlir::tt::ttir::TileMatmulBlockOp::getEffects(
 
   if (!getMcastShape().empty() && getMcastStartIndex().empty()) {
     return emitOpError("mcast shape requires mcast start index");
+  }
+
+  //
+  // Skip below verification steps for tensor style or lowered DMA.
+  //
+  if (isLowered() || skipChecksForTensorType) {
+    return success();
   }
 
   int64_t srcIndices = getSrcAffineMap() ? getSrcAffineMap()->getNumResults()
@@ -155,6 +173,12 @@ int64_t mlir::tt::ttir::DMAOp::getNumElems() {
   return ttmlir::utils::volume(txShape);
 }
 
+size_t mlir::tt::ttir::DMAOp::getSizeBytes() {
+  auto elementSizeBytes =
+      getElementSizeBytes(getSrcMemRefType().getElementType());
+  return getNumElems() * elementSizeBytes;
+}
+
 void mlir::tt::ttir::DMAOp::getAsmResultNames(
     function_ref<void(Value, StringRef)> setNameFn) {
   setNameFn(getResult(), "tx");
@@ -170,6 +194,68 @@ void mlir::tt::ttir::DMAOp::getEffects(
   effects.emplace_back(mlir::MemoryEffects::Write::get(), &getDstMutable(),
                        0 /*stage*/, true /*effectOnFullRegion*/,
                        mlir::SideEffects::DefaultResource::get());
+}
+
+bool mlir::tt::ttir::DMAOp::bufferizesToMemoryRead(
+    mlir::OpOperand &operand, const mlir::bufferization::AnalysisState &) {
+  return operand.get() == getSrc();
+}
+
+bool mlir::tt::ttir::DMAOp::bufferizesToMemoryWrite(
+    mlir::OpOperand &operand, const mlir::bufferization::AnalysisState &) {
+  return operand.get() == getDst();
+}
+
+mlir::LogicalResult mlir::tt::ttir::DMAOp::bufferize(
+    mlir::RewriterBase &rewriter,
+    const mlir::bufferization::BufferizationOptions &options) {
+  Value src = nullptr;
+  if (isSrcRemote()) {
+    auto maybeSrc = mlir::bufferization::getBuffer(rewriter, getSrc(), options);
+    if (failed(maybeSrc)) {
+      return maybeSrc;
+    }
+    src = *maybeSrc;
+  } else {
+    src = getSrc();
+  }
+
+  Value dst = nullptr;
+  if (isDstRemote()) {
+    auto maybeDst = mlir::bufferization::getBuffer(rewriter, getDst(), options);
+    if (failed(maybeDst)) {
+      return maybeDst;
+    }
+    dst = *maybeDst;
+  } else {
+    dst = getDst();
+  }
+
+  ::llvm::SmallVector<mlir::Value> invocationStack;
+  mlir::bufferization::replaceOpWithNewBufferizedOp<mlir::tt::ttir::DMAOp>(
+      rewriter, *this, getResult().getType(), src, getSrcAffineMapAttr(),
+      getSrcIndices(), dst, getDstAffineMapAttr(), getDstIndices(),
+      getOptNumElemsAttr(), getMcastStartIndex(), getMcastShape());
+
+  return mlir::success();
+}
+
+mlir::bufferization::AliasingValueList mlir::tt::ttir::DMAOp::getAliasingValues(
+    mlir::OpOperand &operand, const mlir::bufferization::AnalysisState &) {
+  bufferization::AliasingValueList result;
+  return result;
+}
+
+mlir::FailureOr<mlir::BaseMemRefType> mlir::tt::ttir::DMAOp::getBufferType(
+    mlir::Value value, const mlir::bufferization::BufferizationOptions &,
+    ::llvm::SmallVector<mlir::Value> &) {
+  auto rankedTensorType = mlir::cast<mlir::RankedTensorType>(value.getType());
+  return mlir::cast<tt::MetalLayoutAttr>(rankedTensorType.getEncoding())
+      .getBufferType(/*isView=*/true);
+}
+
+mlir::OpFoldResult mlir::tt::ttir::IterIndexOp::fold(FoldAdaptor adaptor) {
+  return adaptor.getDimAttr();
 }
 
 void mlir::tt::ttir::IterIndexOp::getAsmResultNames(
@@ -196,7 +282,7 @@ void mlir::tt::ttir::CoreIndexOp::getAsmResultNames(
 //===----------------------------------------------------------------------===//
 
 mlir::OpFoldResult mlir::tt::ttir::CoreIndexOp::fold(FoldAdaptor adaptor) {
-  return getDimAttr();
+  return adaptor.getDimAttr();
 }
 
 void mlir::tt::ttir::CoreIndexOp::inferResultRanges(

--- a/lib/Dialect/TTIR/IR/TTIROpsInterfaces.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROpsInterfaces.cpp
@@ -68,6 +68,54 @@ mlir::tt::ttir::detail::verifyGenericParent(mlir::Operation *op) {
                    "TTIR Generic Ops must be inside a generic region");
 }
 
+static mlir::AffineMap reblockViewWorkaround(mlir::MemRefType inputMemref,
+                                             mlir::MemRefType resultMemref) {
+  assert(inputMemref.getRank() == resultMemref.getRank());
+  auto ctx = inputMemref.getContext();
+  int64_t rank = inputMemref.getRank();
+  auto inputLayout =
+      mlir::cast<mlir::tt::DeviceLayoutInterface>(inputMemref.getLayout());
+  auto resultLayout =
+      mlir::cast<mlir::tt::DeviceLayoutInterface>(resultMemref.getLayout());
+  mlir::ArrayRef<int64_t> inputGridShape =
+      inputLayout.getGridShape(inputMemref);
+  mlir::ArrayRef<int64_t> inputShardShape =
+      inputLayout.getShardShape(inputMemref);
+  mlir::ArrayRef<int64_t> resultGridShape =
+      resultLayout.getGridShape(resultMemref);
+  mlir::ArrayRef<int64_t> resultShardShape =
+      resultLayout.getShardShape(resultMemref);
+  mlir::SmallVector<mlir::AffineExpr> mapExprs(rank);
+
+  // Canonicalize.
+  for (size_t i = 0; i < resultGridShape.size(); i++) {
+    auto dG = getAffineDimExpr(i, ctx);
+    mapExprs[i] = dG.floorDiv(resultGridShape[i]);
+  }
+  for (size_t i = 0; i < resultGridShape.size(); i++) {
+    size_t j = i + resultGridShape.size();
+    auto dG = getAffineDimExpr(i, ctx);
+    auto dS = getAffineDimExpr(j, ctx);
+    mapExprs[j] = dG * resultShardShape[i] + dS;
+  }
+  auto resultToCanonical = mlir::AffineMap::get(rank, 0, mapExprs, ctx);
+
+  // Uncanonicalize.
+  for (size_t i = 0; i < inputGridShape.size(); i++) {
+    size_t j = i + inputGridShape.size();
+    auto dS = getAffineDimExpr(j, ctx);
+    mapExprs[i] = dS.floorDiv(inputShardShape[i]);
+  }
+  for (size_t i = 0; i < inputGridShape.size(); i++) {
+    size_t j = i + inputGridShape.size();
+    auto dS = getAffineDimExpr(j, ctx);
+    mapExprs[j] = dS % inputShardShape[i];
+  }
+  auto canonicalToInput = mlir::AffineMap::get(rank, 0, mapExprs, ctx);
+
+  return canonicalToInput.compose(resultToCanonical);
+}
+
 std::pair<mlir::MemRefType, mlir::AffineMap>
 mlir::tt::ttir::applyViews(mlir::Operation *op) {
   auto viewOp = mlir::dyn_cast<ttir::ViewOpInterface>(op);
@@ -81,13 +129,9 @@ mlir::tt::ttir::applyViews(mlir::Operation *op) {
       mlir::cast<tt::ViewLayoutAttr>(resultMemref.getLayout()).getAffineMap();
   Value input = viewOp.getInput();
   auto inputMemref = mlir::cast<mlir::MemRefType>(input.getType());
-  while (mlir::isa<tt::ViewLayoutAttr>(inputMemref.getLayout())) {
-    map = inputMemref.getLayout().getAffineMap().compose(map);
-    viewOp = mlir::cast<ttir::ViewOpInterface>(input.getDefiningOp());
-    input = viewOp.getInput();
-    inputMemref = mlir::cast<mlir::MemRefType>(input.getType());
-  }
-  assert(mlir::isa<tt::ShardLayoutAttr>(inputMemref.getLayout()) &&
-         "Expected ShardLayoutAttr");
-  return std::make_pair(inputMemref, map);
+  assert(
+      mlir::isa<tt::ShardLayoutAttr>(inputMemref.getLayout()) &&
+      "Expected ShardLayoutAttr, only one level of view nesting is supported");
+  auto reblockMap = reblockViewWorkaround(inputMemref, resultMemref);
+  return std::make_pair(inputMemref, reblockMap.compose(map));
 }

--- a/lib/Dialect/TTIR/Transforms/Allocate.cpp
+++ b/lib/Dialect/TTIR/Transforms/Allocate.cpp
@@ -115,12 +115,6 @@ class TTIRAllocateStreams final : public OpRewritePattern<ttir::GenericOp> {
       return false;
     }
 
-    // A view_layout signals that an op wants to take a view of an
-    // operand, possibly to switch to a different core grid shape.
-    if (mlir::isa_and_nonnull<ttir::ViewLayoutOp>(definingOp)) {
-      return true;
-    }
-
     // No stream (NOC ops) will be needed if 'operand' is already
     // allocated in L1 ("alias" mode), which is currently guaranteed
     // to be the case for outputs.

--- a/lib/Dialect/TTIR/Transforms/GenericLinearizeMemref.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericLinearizeMemref.cpp
@@ -57,11 +57,29 @@ public:
     return linearResult.compose(map);
   }
 
+  static std::optional<std::size_t> getComputeThreadIndex(ArrayAttr threads) {
+    auto isComputeThread = [](Attribute threadAttr) {
+      return mlir::cast<ThreadAttr>(threadAttr).getThreadType() ==
+             ThreadType::Compute;
+    };
+    auto computeThread =
+        std::find_if(threads.begin(), threads.end(), isComputeThread);
+    if (computeThread == threads.end()) {
+      return std::nullopt;
+    }
+    assert(std::find_if(computeThread + 1, threads.end(), isComputeThread) ==
+               threads.end() &&
+           "Unexpected multiple compute threads");
+    return std::distance(threads.begin(), computeThread);
+  }
+
   LogicalResult matchAndRewrite(GenericOp op,
                                 PatternRewriter &rewriter) const final {
-    assert(op.getNumRegions() == 1 &&
-           "expected single compute region at this stage");
-    Block *entry = &op.getRegion(0).front();
+    auto computeThreadIndex = getComputeThreadIndex(op.getThreads());
+    if (!computeThreadIndex) {
+      return failure();
+    }
+    Block *entry = &op.getRegion(*computeThreadIndex).front();
     rewriter.setInsertionPointToStart(entry);
     auto args = entry->getArguments();
     if (llvm::all_of(args, isLinearizedMemref)) {

--- a/lib/Dialect/TTIR/Transforms/GenericLowerDMAs.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericLowerDMAs.cpp
@@ -6,6 +6,8 @@
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
 #include "ttmlir/Utils.h"
 
+#include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -69,16 +71,10 @@ public:
           loc, builder.getIndexType(), builder.getI64IntegerAttr(dim));
       Value index;
       if (isGridDim) {
-        // gridI * dimI + iterI
-        Value dimConstant = builder.create<arith::ConstantOp>(
-            loc, builder.getIndexType(),
-            builder.getIndexAttr(shardShape[result]));
+        // TODO(#3231): Support blocked inputs that are multiples of the grid
+        // shape. Should be added as part of blocking support.
         index = builder.create<CoreIndexOp>(loc, builder.getIndexType(),
                                             builder.getI64IntegerAttr(dim));
-        index = builder.create<arith::MulIOp>(loc, builder.getIndexType(),
-                                              index, dimConstant);
-        index = builder.create<arith::AddIOp>(loc, builder.getIndexType(),
-                                              index, iterIndex);
       } else {
         index = iterIndex;
       }
@@ -248,12 +244,13 @@ public:
 
   LogicalResult matchAndRewrite(DMAOp dma,
                                 PatternRewriter &rewriter) const final {
-    if (dma.isAffine() || dma.isFullyIndexed()) {
+    if (dma.isAffine() || dma.isLowered()) {
       // Lower to affine first.
-      // Or if it's already fully indexed, nothing to do.
+      // Or if it's already fully lowered, nothing to do.
       return failure();
     }
 
+    // Fully index the memrefs.
     SmallVector<Value> srcIndices(dma.getSrcIndices());
     SmallVector<Value> dstIndices(dma.getDstIndices());
     Value zero = rewriter.create<arith::ConstantOp>(
@@ -266,6 +263,18 @@ public:
            static_cast<size_t>(dma.getDstMemRefType().getRank())) {
       dstIndices.push_back(zero);
     }
+
+    DeviceAttr device = lookupDevice(dma);
+    AffineMap srcMemoryMap =
+        getMemoryMap(device, dma.getSrc(), dma.isSrcRemote());
+    AffineMap dstMemoryMap =
+        getMemoryMap(device, dma.getDst(), dma.isDstRemote());
+
+    srcIndices = applyMap(rewriter, dma.getLoc(), srcMemoryMap, srcIndices,
+                          dma.isSrcRemote());
+    dstIndices = applyMap(rewriter, dma.getLoc(), dstMemoryMap, dstIndices,
+                          dma.isDstRemote());
+
     rewriter.replaceOpWithNewOp<ttir::DMAOp>(
         dma, dma.getResult().getType(), dma.getSrc(), nullptr, srcIndices,
         dma.getDst(), nullptr, dstIndices,
@@ -273,6 +282,67 @@ public:
         dma.getMcastShape());
 
     return success();
+  }
+
+  static AffineMap getMemoryMap(DeviceAttr device, Value input, bool isRemote) {
+    if (isRemote) {
+      std::pair<MemRefType, AffineMap> srcUnderlyingMemrefAndView =
+          mlir::tt::ttir::applyViews(input.getDefiningOp());
+      // TODO(#1909) Once we have an allocation pass, we need to lookup the page
+      // size instead of calculating it here.
+      size_t srcPageSize =
+          device.getMemrefSizeBytes(srcUnderlyingMemrefAndView.first,
+                                    /*pageSize=*/0);
+      return device.getMemoryMap(srcUnderlyingMemrefAndView, srcPageSize);
+    } else {
+      MemRefType inputType = mlir::cast<MemRefType>(input.getType());
+      return canonicalStridedMap(device.getContext(), inputType.getShape(),
+                                 inputType.getElementType(),
+                                 inputType.getLayout().getAffineMap());
+    }
+  }
+
+  static SmallVector<Value> applyMap(PatternRewriter &rewriter, Location loc,
+                                     AffineMap map, ValueRange index,
+                                     bool isRemote) {
+    auto affineApply = [&](AffineMap map, ValueRange index) {
+      return rewriter.create<affine::AffineApplyOp>(loc, map, index);
+    };
+
+    if (isRemote) {
+      assert(map.getNumResults() == 4);
+      // Break the map into respective gridY, gridX, offset "single result"
+      // parts. AffineApply only supports single result affine maps.
+      map = map.dropResults(0); // Drop the device index.
+      auto gridY = map.dropResults({1, 2});
+      auto gridX = map.dropResults({0, 2});
+      auto offset = map.dropResults({0, 1});
+      return {affineApply(gridY, index), affineApply(gridX, index),
+              affineApply(offset, index)};
+    } else {
+      assert(map.getNumResults() == 1);
+      return {affineApply(map, index)};
+    }
+  }
+
+  static AffineMap canonicalStridedMap(MLIRContext *context,
+                                       ArrayRef<int64_t> shape,
+                                       Type elementType, AffineMap map) {
+    assert(map.isIdentity() && "Only identity maps are supported for now.");
+    auto tileType = mlir::dyn_cast<TileType>(elementType);
+    int64_t elementSizeBytes = tileType
+                                   ? tileType.getSizeBytes()
+                                   : elementType.getIntOrFloatBitWidth() / 8;
+    int64_t currentStride = elementSizeBytes;
+    int64_t rank = shape.size();
+    mlir::AffineExpr strideExpr = getAffineConstantExpr(0, context);
+    for (int64_t i = rank - 1; i >= 0; i--) {
+      mlir::AffineExpr dim = getAffineDimExpr(i, context);
+      mlir::AffineExpr stride = getAffineConstantExpr(currentStride, context);
+      strideExpr = dim * stride + strideExpr;
+      currentStride *= shape[i];
+    }
+    return mlir::AffineMap::get(shape.size(), 0, strideExpr, context);
   }
 };
 } // namespace
@@ -289,6 +359,7 @@ public:
     patterns.add<TTIRGenericLowerAffineDMAsRewritePattern,
                  TTIRGenericLowerToFullyIndexedDMARewritePattern>(
         &getContext());
+    populateAffineToStdConversionPatterns(patterns);
     if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       signalPassFailure();
     }

--- a/lib/Dialect/TTIR/Transforms/GenericRegionsToFuncs.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericRegionsToFuncs.cpp
@@ -38,14 +38,6 @@ static void rewriteOperand(OpBuilder &builder, DMAOp dma, OpOperand &dmaOperand,
   }
   Operation *globalOperand =
       builder.create<GetGlobalOperandOp>(dma.getLoc(), memref, operandIndex);
-  if (!affineMapView.isIdentity()) {
-    globalOperand = builder.create<ViewLayoutOp>(
-        dma.getLoc(),
-        mlir::MemRefType::get(memref.getShape(), memref.getElementType(),
-                              builder.getAttr<ViewLayoutAttr>(affineMapView),
-                              memref.getMemorySpace()),
-        globalOperand->getResult(0));
-  }
   dmaOperand.set(globalOperand->getResult(0));
 }
 

--- a/lib/Dialect/TTIR/Transforms/LowerToLayout.cpp
+++ b/lib/Dialect/TTIR/Transforms/LowerToLayout.cpp
@@ -8,6 +8,7 @@
 #include "ttmlir/Dialect/TTIR/Utils/UniformTypeRewriter.h"
 #include "ttmlir/Utils.h"
 
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir::tt::ttir {
@@ -59,11 +60,20 @@ public:
                                           op.getInput())
                     .getResult();
 
+    assert(inputLayout.getRank() == outputLayout.getRank());
+    ArrayAttr indexingMaps, iteratorTypes;
+    std::tie(indexingMaps, iteratorTypes) =
+        GenericOp::buildParallelAffineMapsAndIteratorTypes(
+            rewriter, /*arity=*/2, inputLayout.getRank());
     rewriter.replaceOpWithNewOp<GenericOp>(
         op, view, op.getOutput(),
         [&](OpBuilder &builder, Location loc, ValueRange blockArgs) {
-          builder.create<YieldOp>(loc, blockArgs[0]);
-        });
+          auto dma = builder.create<ttir::DMAOp>(
+              loc, view, mlir::cast<AffineMapAttr>(indexingMaps[0]),
+              blockArgs[1]);
+          builder.create<ttir::DMAWaitOp>(loc, dma);
+        },
+        ThreadType::Datamovement);
 
     return success();
   }

--- a/runtime/tools/ttrt/ttrt/common/run.py
+++ b/runtime/tools/ttrt/ttrt/common/run.py
@@ -762,8 +762,14 @@ class Run:
                                         self.logging,
                                     )
                                     if cal_pcc < post_op_callback_runtime_config.pcc:
+                                        self.logging.info(
+                                            f"Golden:\n{golden_tensor_torch}"
+                                        )
+                                        self.logging.info(
+                                            f"Actual:\n{output_tensor_torch}"
+                                        )
                                         raise PCCErrorException(
-                                            f"Failed: prgram-level output golden comparison failed, actual_pcc={cal_pcc} < expected_pcc={post_op_callback_runtime_config.pcc}"
+                                            f"Failed: program-level output golden comparison failed, actual_pcc={cal_pcc} < expected_pcc={post_op_callback_runtime_config.pcc}"
                                         )
                                     self.logging.info(
                                         f"Program level golden for output_{idx} matched. pcc={cal_pcc}"

--- a/test/ttmlir/Conversion/TTIRToTTKernel/dma_lowering.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTKernel/dma_lowering.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --tt-register-device --convert-ttir-to-ttkernel %s | FileCheck %s
+// RUN: ttmlir-opt --tt-register-device --ttir-generic-lower-dmas --convert-ttir-to-ttkernel %s | FileCheck %s
 
 #l1_ = #tt.memory_space<l1>
 #dram = #tt.memory_space<dram>
@@ -72,8 +72,8 @@ func.func @test_remote_l1_to_local(%dst: memref<2x2x!tt.tile<32x32, f32>, #l1_>)
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %src = ttir.get_global_operand(0) : memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>
-  // CHECK: ttkernel.get_write_ptr
   // CHECK: ttkernel.get_noc_addr
+  // CHECK: ttkernel.get_write_ptr
   // CHECK: ttkernel.noc_async_read
   %0 = ttir.dma %src[%c0, %c1, %c0, %c0], %dst[%c0, %c0] : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.shard<16384x4096>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
   ttir.dma_wait %0

--- a/test/ttmlir/Conversion/TTIRToTTKernel/tiled_matmul.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTKernel/tiled_matmul.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --tt-register-device --convert-ttir-to-ttkernel --ttkernel-control-dst-section %s > %t.mlir
+// RUN: ttmlir-opt --tt-register-device --ttir-generic-lower-dmas --convert-ttir-to-ttkernel --ttkernel-control-dst-section %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 
 #l1_ = #tt.memory_space<l1>
@@ -18,8 +18,8 @@ module {
       scf.if %0 {
         // CHECK: %{{[0-9]+}} = "ttkernel.get_compile_time_arg_val"
         %1 = ttir.get_global_operand(0) : memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.shard<12288x4096>, #l1_>
-        // CHECK: %{{[0-9]+}} = "ttkernel.get_write_ptr"
         // CHECK: %{{[0-9]+}} = "ttkernel.get_noc_addr"
+        // CHECK: %{{[0-9]+}} = "ttkernel.get_write_ptr"
         // CHECK: "ttkernel.noc_async_read"
         %tx = ttir.dma %1 [%c0, %arg7, %c0, %c0], %arg0 [%c0, %c0] : (memref<8x8x1x3x!tt.tile<32x32, f32>, #tt.shard<12288x4096>, #l1_>, memref<1x3x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
         // CHECK: "ttkernel.noc_async_read_barrier"

--- a/test/ttmlir/Dialect/TTIR/generic/affine_dma.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/affine_dma.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --tt-register-device --ttir-generic-lower-dmas %s | FileCheck %s
+// RUN: ttmlir-opt --tt-register-device --ttir-generic-lower-dmas --cse %s | FileCheck %s
 
 #dram = #tt.memory_space<dram>
 #l1_ = #tt.memory_space<l1>
@@ -16,23 +16,17 @@ func.func @matmul_single_core_stream(%arg0: memref<1x2x2x2x!tt.tile<32x32, f32>,
   %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>) -> memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>
   "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^datamovement0(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
-    // CHECK-DAG: [[iter0:%.*]] = ttir.iter_index(0)
     // CHECK-DAG: [[iter2:%.*]] = ttir.iter_index(2)
     // CHECK-DAG: [[core0:%.*]] = ttir.core_index(0)
-    // CHECK-DAG: arith.muli
-    // CHECK-DAG: arith.addi
-    // CHECK: ttir.dma %stream{{[_0-9]*}} [%{{.*}}, [[iter2]], %c0, %c0]
+    // CHECK: ttir.dma %stream{{[_0-9]*}} [[[core0]], [[iter2]], %c0]
     %tx = ttir.dma %stream<#map1>, %cb0 : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
     ttir.dma_wait %tx
     ttir.yield %cb0 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
   }, {
   ^datamovement1(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
-    // CHECK-DAG: [[iter1:%.*]] = ttir.iter_index(1)
     // CHECK-DAG: [[iter2:%.*]] = ttir.iter_index(2)
     // CHECK-DAG: [[core1:%.*]] = ttir.core_index(1)
-    // CHECK-DAG: arith.muli
-    // CHECK-DAG: arith.addi
-    // CHECK: ttir.dma %stream{{[_0-9]*}} [[[iter2]], %{{.*}}, %c0, %c0]
+    // CHECK: ttir.dma %stream{{[_0-9]*}} [[[iter2]], [[core1]], %c0]
     %tx = ttir.dma %stream_2<#map2>, %cb1 : (memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
     ttir.dma_wait %tx
     ttir.yield %cb1 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
@@ -56,26 +50,20 @@ func.func @matmul_single_core_transpose(%arg0: memref<1x2x2x2x!tt.tile<32x32, f3
   %stream_2 = "ttir.stream_layout"(%arg1, %alloc_1) : (memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>, memref<1x1x2x2x!tt.tile<32x32, f32>, #tt.shard<8192x4096>, #l1_>) -> memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.view<(d0, d1, d2, d3) -> (d1, d0, d3, d2)>, #l1_>
   "ttir.generic"(%stream, %stream_2, %alloc) <{grid = #tt.grid<1x1>, indexing_maps = [#map1, #map2, #map3], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<datamovement>, #ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
   ^datamovement0(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
-    // CHECK-DAG: [[iter0:%.*]] = ttir.iter_index(0)
     // CHECK-DAG: [[iter2:%.*]] = ttir.iter_index(2)
     // CHECK-DAG: [[core0:%.*]] = ttir.core_index(0)
-    // CHECK-DAG: arith.muli
-    // CHECK-DAG: arith.addi
-    // CHECK: ttir.dma %stream{{[_0-9]*}} [%{{.*}}, [[iter2]], %c0, %c0]
+    // CHECK: ttir.dma %stream{{[_0-9]*}} [[[core0]], [[iter2]], %c0]
     %tx = ttir.dma %stream<#map1>, %cb0 : (memref<1x2x2x2x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
     ttir.dma_wait %tx
     ttir.yield %cb0 : (memref<2x2x!tt.tile<32x32, f32>, #l1_>)
   }, {
   ^datamovement1(%cb0: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb1: memref<2x2x!tt.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!tt.tile<32x32, f32>, #l1_>):
     // CHECK-DAG: [[iter2:%.*]] = ttir.iter_index(2)
-    // CHECK-DAG: [[iter1:%.*]] = ttir.iter_index(1)
     // CHECK-DAG: [[core1:%.*]] = ttir.core_index(1)
-    // CHECK-DAG: arith.muli
-    // CHECK-DAG: arith.addi
     // CHECK: ttir.null_tx
     // CHECK-NEXT: scf.for [[for_iter_i:%[a-zA-Z0-9]*]] =
     // CHECK-NEXT: scf.for [[for_iter_j:%[a-zA-Z0-9]*]] =
-    // CHECK-NEXT: ttir.dma %stream{{[_0-9]*}} [[[iter2]], %{{.*}}, [[for_iter_i]], [[for_iter_j]]]
+    // CHECK: ttir.dma %stream{{[_0-9]*}}
     // CHECK: scf.yield
     // CHECK: scf.yield
     %tx = ttir.dma %stream_2<#map2>, %cb1 : (memref<2x1x2x2x!tt.tile<32x32, f32>, #tt.view<(d0, d1, d2, d3) -> (d1, d0, d3, d2)>, #l1_>, memref<2x2x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
@@ -109,12 +97,9 @@ func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.sha
     %core1 = ttir.core_index(1) : index
     %0 = arith.cmpi eq, %core1, %c0 : index
     scf.if %0 {
-      // CHECK-DAG: [[iter0:%.*]] = ttir.iter_index(0)
       // CHECK-DAG: [[iter2:%.*]] = ttir.iter_index(2)
       // CHECK-DAG: [[core0:%.*]] = ttir.core_index(0)
-      // CHECK-DAG: arith.muli
-      // CHECK-DAG: arith.addi
-      // CHECK: ttir.dma %stream{{[_0-9]*}} [%{{.*}}, [[iter2]], %c0, %c0]
+      // CHECK: ttir.dma %stream{{[_0-9]*}} [[[core0]], [[iter2]], %c0]
       %tx = ttir.dma %stream<#map1>, %cb0 : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<4x6x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
       ttir.dma_wait %tx
       ttir.semaphore_wait %sem0, %c3 reset %c0
@@ -135,12 +120,9 @@ func.func @matmul_multi_core(%arg0: memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.sha
     %0 = arith.cmpi eq, %core0, %c0 : index
     %core1 = ttir.core_index(1) : index
     scf.if %0 {
-      // CHECK-DAG: [[iter1:%.*]] = ttir.iter_index(1)
       // CHECK-DAG: [[iter2:%.*]] = ttir.iter_index(2)
       // CHECK-DAG: [[core1:%.*]] = ttir.core_index(1)
-      // CHECK-DAG: arith.muli
-      // CHECK-DAG: arith.addi
-      // CHECK: ttir.dma %stream{{[_0-9]*}} [[[iter2]], %{{.*}}, %c0, %c0]
+      // CHECK: ttir.dma %stream{{[_0-9]*}} [[[iter2]], [[core1]], %c0]
       %tx = ttir.dma %stream_2<#map2>, %cb1 : (memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
       ttir.dma_wait %tx
       ttir.semaphore_wait %sem2, %c1 reset %c0
@@ -180,12 +162,9 @@ func.func @matmul_multi_core_dram_params(%arg0: memref<2x4x4x6x!tt.tile<32x32, f
     %core1 = ttir.core_index(1) : index
     %0 = arith.cmpi eq, %core1, %c0 : index
     scf.if %0 {
-      // CHECK-DAG: [[iter0:%.*]] = ttir.iter_index(0)
       // CHECK-DAG: [[iter2:%.*]] = ttir.iter_index(2)
       // CHECK-DAG: [[core0:%.*]] = ttir.core_index(0)
-      // CHECK-DAG: arith.muli
-      // CHECK-DAG: arith.addi
-      // CHECK: ttir.dma %stream{{[_0-9]*}} [%{{.*}}, [[iter2]], %c0, %c0]
+      // CHECK: ttir.dma %stream{{[_0-9]*}} [[[core0]], [[iter2]], %c0]
       %tx = ttir.dma %stream<#map1>, %cb0 : (memref<2x4x4x6x!tt.tile<32x32, f32>, #tt.view<map(4)>, #l1_>, memref<4x6x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
       ttir.dma_wait %tx
       ttir.semaphore_wait %sem0, %c3 reset %c0
@@ -206,12 +185,9 @@ func.func @matmul_multi_core_dram_params(%arg0: memref<2x4x4x6x!tt.tile<32x32, f
     %0 = arith.cmpi eq, %core0, %c0 : index
     %core1 = ttir.core_index(1) : index
     scf.if %0 {
-      // CHECK-DAG: [[iter1:%.*]] = ttir.iter_index(1)
       // CHECK-DAG: [[iter2:%.*]] = ttir.iter_index(2)
       // CHECK-DAG: [[core1:%.*]] = ttir.core_index(1)
-      // CHECK-DAG: arith.muli
-      // CHECK-DAG: arith.addi
-      // CHECK: ttir.dma %stream{{[_0-9]*}} [[[iter2]], %{{.*}}, %c0, %c0]
+      // CHECK: ttir.dma %stream{{[_0-9]*}}
       %tx = ttir.dma %stream_2<#map2>, %cb1 : (memref<4x4x6x8x!tt.tile<32x32, f32>, #tt.view<map(4)>, #dram>, memref<6x8x!tt.tile<32x32, f32>, #l1_>) -> !ttir.mem_tx
       ttir.dma_wait %tx
       ttir.semaphore_wait %sem2, %c1 reset %c0

--- a/test/ttmlir/Dialect/TTIR/lower_to_layout.mlir
+++ b/test/ttmlir/Dialect/TTIR/lower_to_layout.mlir
@@ -38,8 +38,7 @@ func.func @untilize(%arg0: tensor<256x768xf32, #layout1>) -> tensor<256x768xf32,
 func.func @reblock(%arg0: tensor<256x768xf32, #layout1>) -> tensor<256x768xf32, #layout2> {
   %0 = ttir.empty() : tensor<256x768xf32, #layout2>
   // CHECK: ttir.generic {grid = #tt.grid<8x8>
-  // CHECK: ^compute0
-  // CHECK-NEXT: ttir.yield %cb0 : (memref<1x3x!tt.tile<32x32, f32>, #l1_>)
+  // CHECK: ^datamovement0
   %1 = ttir.to_layout %arg0, %0 : tensor<256x768xf32, #layout1> into tensor<256x768xf32, #layout2> -> tensor<256x768xf32, #layout2>
   return %1 : tensor<256x768xf32, #layout2>
 }

--- a/tools/ttir-builder/builder.py
+++ b/tools/ttir-builder/builder.py
@@ -67,6 +67,13 @@ def get_loc_of_extra_file_callee(id: int = 0) -> Location:
     return Location.name(f"{stack[0].filename}:{str(stack[0].lineno)}:id({str(id)})")
 
 
+def get_loc_from_str(loc: Union[str, Location]) -> Location:
+    if isinstance(loc, str):
+        return Location.name(loc)
+    else:
+        return loc
+
+
 @dataclass(frozen=True)
 class Golden:
     """
@@ -506,6 +513,7 @@ class TTIRBuilder:
         output_create_fn: Optional[Callable] = None,
         golden_kwargs: dict = {},
         ttir_kwargs: dict = {},
+        loc: Optional[Union[str, Location]] = None,
     ) -> Any:
         """
         Provides a general interface for proxy-ing OPs and creating them.
@@ -589,7 +597,11 @@ class TTIRBuilder:
             else:
                 output = self.empty(output_shape, output_type)
             id = self.get_next_global_id()
-            loc = get_loc_of_extra_file_callee(id=id)
+            loc = (
+                get_loc_from_str(loc)
+                if loc is not None
+                else get_loc_of_extra_file_callee(id=id)
+            )
             # Account for cases in which ttir_arg organization is not needed:
             if (
                 not isinstance(
@@ -2014,6 +2026,7 @@ class TTIRBuilder:
         in0: Operand,
         output_type: RankedTensorType,
         unit_attrs: List[str] = None,
+        **kwargs,
     ) -> OpView:
         return self.op_proxy(
             lambda *args, **kwargs: args[0],
@@ -2027,6 +2040,7 @@ class TTIRBuilder:
                 o,
             ),
             unit_attrs=unit_attrs,
+            **kwargs,
         )
 
     # CCL ops

--- a/tools/ttir-builder/utils.py
+++ b/tools/ttir-builder/utils.py
@@ -58,7 +58,9 @@ def get_target_path(output_path, filename, target):
     return os.path.join(target_dir, filename)
 
 
-def create_custom_pipeline_fn(pipeline: str, verify: bool = True) -> Callable:
+def create_custom_pipeline_fn(
+    pipeline: str, verify: bool = True, print_ir: Union[bool, str] = False
+) -> Callable:
     def wrapper(module, device_register_options):
         register_device = "tt-register-device"
         if device_register_options:
@@ -69,6 +71,9 @@ def create_custom_pipeline_fn(pipeline: str, verify: bool = True) -> Callable:
             pm = PassManager.parse(pipeline_str)
             pm.enable_verifier(verify)
             print("Running custom pipeline:", pm)
+            if print_ir:
+                print_ir_path = print_ir if isinstance(print_ir, str) else None
+                pm.enable_ir_printing(tree_printing_dir_path=print_ir_path)
             pm.run(module.operation)
 
     return wrapper
@@ -275,6 +280,7 @@ def compile_to_flatbuffer(
     argument_types_string: Optional[str] = None,
     custom_pipeline: Union[Callable, str] = None,
     pipeline_options: List[str] = None,
+    print_ir: Union[bool, str] = False,
 ):
     """
     Compiles a TTIRBuilder function `fn` to TTIR MLIR -> TT{Metal,NN} MLIR -> Flatbuffer
@@ -326,13 +332,17 @@ def compile_to_flatbuffer(
 
     module_dump: bool
         Set to `True` to print out generated TTIR MLIR module.
+
+    print_ir: Union[bool, str]
+        Set to `True` to print IR to stdout.  Set to dir path to print IR after
+        each pass to its own file under _this_ directory.
     """
 
     if inputs_types is not None:
         assert len(inputs_shapes) == len(inputs_types)
 
     if type(custom_pipeline) is str:
-        custom_pipeline = create_custom_pipeline_fn(custom_pipeline)
+        custom_pipeline = create_custom_pipeline_fn(custom_pipeline, print_ir=print_ir)
 
     if pipeline_options is None:
         pipeline_options = []


### PR DESCRIPTION
The core of this change is twofold:
- Move all DMA lowering to a common place, i.e. GenericLowerDMAs. There is now a new form of DMA, but this affords us simplicity in TTKernel conversion + having all the DMA lowering related code in one place.
- Support for reblocking. Eventually we want to have these reblocking affine maps encoded directly in the ViewOp from the beginning, but there this support is blocked on this refactor #3389.

There are also a number of other cleanups and changes including:
- CoreIndexOp is not actually ConstantLike, I misunderstood this attribute, it previously could be replaced with a constant.
- GenericOp support for single region datamovement thread type.
- TTKernel DMA lowering cleanup. Though mcast hasn't been touched yet.
- Test framework improvements.