### PR TITLE
TTNN EmitC fixes for FEs bringup

### DIFF
--- a/runtime/include/tt/runtime/test/ttnn/dylib.h
+++ b/runtime/include/tt/runtime/test/ttnn/dylib.h
@@ -11,7 +11,7 @@ namespace tt::runtime::test::ttnn {
 
 void *openSo(std::string_view path);
 void closeSo(void *handle);
-std::vector<Tensor> runSoProgram(void *so, std::string funcName,
+std::vector<Tensor> runSoProgram(void *so, std::string_view funcName,
                                  std::vector<Tensor> inputs, Device device);
 bool compareOuts(std::vector<Tensor> &lhs, std::vector<Tensor> &rhs);
 } // namespace tt::runtime::test::ttnn

--- a/runtime/include/tt/runtime/test/ttnn/dylib.h
+++ b/runtime/include/tt/runtime/test/ttnn/dylib.h
@@ -9,9 +9,9 @@
 
 namespace tt::runtime::test::ttnn {
 
-void *openSo(std::string path);
+void *openSo(std::string_view path);
 void closeSo(void *handle);
-std::vector<Tensor> runSoProgram(void *so, std::string func_name,
+std::vector<Tensor> runSoProgram(void *so, std::string funcName,
                                  std::vector<Tensor> inputs, Device device);
 bool compareOuts(std::vector<Tensor> &lhs, std::vector<Tensor> &rhs);
 } // namespace tt::runtime::test::ttnn

--- a/runtime/test/ttnn/CMakeLists.txt
+++ b/runtime/test/ttnn/CMakeLists.txt
@@ -22,10 +22,11 @@ set(TTMLIR_RUNTIME_TEST_TTNN_PUBLIC_HEADERS
   "${PROJECT_SOURCE_DIR}/runtime/include/tt/runtime/test/ttnn/dylib.h"
 )
 set_target_properties(TTRuntimeTTNNTestLib PROPERTIES PUBLIC_HEADER "${TTMLIR_RUNTIME_TEST_TTNN_PUBLIC_HEADERS}")
+include(GNUInstallDirs)
 install(TARGETS TTRuntimeTTNNTestLib
+  COMPONENT TTNNStandalone
   PUBLIC_HEADER
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tt/runtime/test
-    COMPONENT TTNNStandalone
 )
 
 add_subdirectory(gtest)

--- a/runtime/test/ttnn/dylib.cpp
+++ b/runtime/test/ttnn/dylib.cpp
@@ -19,10 +19,26 @@ static constexpr const char *POTENTIAL_MANGLING_ADDITIONS[] = {
     "PNS1_11distributed10MeshDeviceE",
 };
 
-void *openSo(std::string path) {
+static std::string getMangledName(std::string_view funcName,
+                                  std::string_view suffix) {
+  std::string mangledName = "_Z";
+  // If the model function name is `main`, we need to prepend it with `_`, as
+  // the `main` has a special semantic in C/C++.
+  if (funcName == "main") {
+    mangledName += "5_main";
+  } else {
+    mangledName += std::to_string(funcName.size());
+    mangledName += funcName;
+  }
+  mangledName += "St6vectorIN2tt8tt_metal6TensorESaIS2_EE";
+  mangledName += suffix;
+  return mangledName;
+}
+
+void *openSo(std::string_view path) {
   LOG_ASSERT(getCurrentRuntime() == DeviceRuntime::TTNN);
 
-  void *handle = dlopen(path.c_str(), RTLD_LAZY);
+  void *handle = dlopen(path.data(), RTLD_LAZY);
   if (!handle) {
     std::cerr << "Failed to load shared object: " << dlerror() << std::endl;
     throw std::runtime_error("Failed to load shared object");
@@ -36,12 +52,13 @@ void closeSo(void *handle) {
   int ret = dlclose(handle);
 
   if (ret != 0) {
+    std::cerr << "Failed to close shared object: " << dlerror() << std::endl;
     exit(ret);
   }
 }
 
 std::vector<::tt::runtime::Tensor>
-runSoProgram(void *so, std::string func_name,
+runSoProgram(void *so, std::string_view funcName,
              std::vector<::tt::runtime::Tensor> inputs, Device device) {
   LOG_ASSERT(getCurrentRuntime() == DeviceRuntime::TTNN);
 
@@ -73,20 +90,20 @@ runSoProgram(void *so, std::string func_name,
   using ForwardFunctionNoDevice =
       std::vector<::ttnn::Tensor> (*)(std::vector<::ttnn::Tensor>);
 
-  const char *dlsym_error;
+  const char *dlsymError;
   void *symbol;
   std::string mangledName;
   for (const char *addition : POTENTIAL_MANGLING_ADDITIONS) {
-    mangledName = func_name + addition;
+    mangledName = getMangledName(funcName, addition);
     symbol = dlsym(so, mangledName.c_str());
-    dlsym_error = dlerror();
-    if (!dlsym_error) {
+    dlsymError = dlerror();
+    if (!dlsymError) {
       break;
     }
   }
-  if (dlsym_error) {
+  if (dlsymError) {
     dlclose(so);
-    LOG_FATAL("Failed to load symbol: ", dlsym_error);
+    LOG_FATAL("Failed to load symbol: ", dlsymError);
   }
 
   // Call program/function

--- a/runtime/tools/ttrt/ttrt/common/run.py
+++ b/runtime/tools/ttrt/ttrt/common/run.py
@@ -799,8 +799,6 @@ class Run:
                         if self["--emitc"]:
                             # Create symbol string to read from dylib
                             fwd_func_name = program.program["name"]
-                            fwd_func_name_len = len(fwd_func_name)
-                            fwd_func_sym = f"_Z{fwd_func_name_len}{fwd_func_name}St6vectorIN2tt8tt_metal6TensorESaIS2_EE"
 
                             # pre-upload inputs
                             inputs = convert_input_layouts(
@@ -810,7 +808,7 @@ class Run:
                             for loop in range(self["--loops"]):
                                 emitc_outs = ttrt.runtime.testing.run_so_program(
                                     emitc_dylib_handle,
-                                    fwd_func_sym,
+                                    fwd_func_name,
                                     inputs,
                                     device,
                                 )

--- a/tools/ttnn-standalone/CMakeLists.txt
+++ b/tools/ttnn-standalone/CMakeLists.txt
@@ -4,27 +4,33 @@ project(ttnn-standalone CXX)
 set(CMAKE_CXX_STANDARD 20 CACHE STRING "C++ standard to conform to")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-# set(CMAKE_VERBOSE_MAKEFILE on)
+add_library(TTNNCompileSo SHARED compile_so.cpp)
+set_target_properties(TTNNCompileSo PROPERTIES
+    PUBLIC_HEADER compile_so.hpp
+)
 
-# Installation
 install(
-  FILES
-    ci_compile_dylib.py
-    CMakeLists.txt
-    compile_so.cpp
-    compile_so.hpp
-    README.md
-    ttnn-precompiled.hpp
-    ttnn-standalone.cpp
-    workarounds.hpp
-  DESTINATION "tools/ttnn-standalone"
+  TARGETS TTNNCompileSo
   COMPONENT TTNNStandalone
+  PUBLIC_HEADER DESTINATION include/ttmlir/tools/ttnn-standalone
 )
 
 install(
   PROGRAMS
     run
-  DESTINATION "tools/ttnn-standalone"
+    ci_compile_dylib.py
+  DESTINATION tools/ttnn-standalone
+  COMPONENT TTNNStandalone
+)
+
+install(
+  FILES
+    CMakeLists.txt
+    README.md
+    ttnn-precompiled.hpp
+    ttnn-standalone.cpp
+    workarounds.hpp
+  DESTINATION tools/ttnn-standalone
   COMPONENT TTNNStandalone
 )
 

--- a/tools/ttnn-standalone/CMakeLists.txt
+++ b/tools/ttnn-standalone/CMakeLists.txt
@@ -30,6 +30,8 @@ install(
     ttnn-precompiled.hpp
     ttnn-standalone.cpp
     workarounds.hpp
+    compile_so.hpp
+    compile_so.cpp
   DESTINATION tools/ttnn-standalone
   COMPONENT TTNNStandalone
 )


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Few problems that I've spotted during the bringup of TTNN EmitC test infrastructure in `tt-torch`.

### What's changed
- The `tt-torch` generates an entry function with the name `main`. This causes an issue during compilation, as the `main` function is treated specially in C/C++. I've special cased it, such that if MLIR function is named `main`, I've renamed it to `_main`.
- Moved the whole logic of getting a mangled name of a function to the `dylib.cpp`. There is no reason for FEs to know about mangling at all, this is a temporary solution until the proper one is implemented https://github.com/tenstorrent/tt-mlir/issues/2478.
- Few problems related to the installation of `TTNNStandalone` component. Made `TTNNCompileSo` a library.

### Checklist
- [ ] New/Existing tests provide coverage for changes
