### PR TITLE
Remove clang diagnostic pragmas from OpModel

### DIFF
--- a/include/ttmlir/OpModel/TTNN/MetalHeaders.h
+++ b/include/ttmlir/OpModel/TTNN/MetalHeaders.h
@@ -5,50 +5,6 @@
 #ifndef TTMLIR_OPMODEL_TTNN_METALHEADERS_H
 #define TTMLIR_OPMODEL_TTNN_METALHEADERS_H
 
-// This header resolves tt-metal warnings that would otherwise be treated as
-// errors in the MLIR build. Ensure that this is the only place where tt-metal
-// headers are included.
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wcast-qual"
-#pragma clang diagnostic ignored "-Wctad-maybe-unsupported"
-#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#pragma clang diagnostic ignored "-Wignored-qualifiers"
-#pragma clang diagnostic ignored "-Wvla-extension"
-#pragma clang diagnostic ignored "-Wcovered-switch-default"
-#pragma clang diagnostic ignored "-Wsign-compare"
-#pragma clang diagnostic ignored "-Wc++20-extensions"
-#pragma clang diagnostic ignored "-Wc++20-designator"
-#pragma clang diagnostic ignored "-Wnon-virtual-dtor"
-#pragma clang diagnostic ignored "-Wunused-variable"
-#pragma clang diagnostic ignored "-Wunknown-warning-option"
-#pragma clang diagnostic ignored "-Wsuggest-override"
-#pragma clang diagnostic ignored "-Wgnu-anonymous-struct"
-#pragma clang diagnostic ignored "-Wnested-anon-types"
-#pragma clang diagnostic ignored "-Wreorder-ctor"
-#pragma clang diagnostic ignored "-Wmismatched-tags"
-#pragma clang diagnostic ignored "-Wunused-lambda-capture"
-#pragma clang diagnostic ignored "-Wmissing-field-initializers"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#pragma clang diagnostic ignored "-Wimplicit-fallthrough"
-#pragma clang diagnostic ignored "-Wstring-conversion"
-#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
-#pragma clang diagnostic ignored "-Wunused-local-typedef"
-#pragma clang diagnostic ignored "-Wunused-function"
-#pragma clang diagnostic ignored "-Wpessimizing-move"
-#pragma clang diagnostic ignored "-Wparentheses"
-#pragma clang diagnostic ignored "-Wdeprecated-volatile"
-#pragma clang diagnostic ignored "-Wdeprecated-this-capture"
-#pragma clang diagnostic ignored "-Wc++23-extensions"
-#pragma clang diagnostic ignored "-Wunused-but-set-variable"
-#pragma clang diagnostic ignored "-Wlogical-op-parentheses"
-#pragma clang diagnostic ignored "-Wundefined-inline"
-#pragma clang diagnostic ignored "-Wc99-extensions"
-#pragma clang diagnostic ignored "-Wc++11-narrowing"
-#pragma clang diagnostic ignored "-Wzero-length-array"
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#pragma clang diagnostic ignored "-Werror,-Wctad-maybe-unsupported"
-
 #define FMT_HEADER_ONLY
 
 #include "tt-metalium/buffer.hpp"
@@ -85,7 +41,5 @@ using IDevice = ::tt::tt_metal::IDevice;
 #include "ttnn/tensor/tensor_spec.hpp"
 #include "ttnn/tensor/types.hpp"
 #include <ttnn/tensor/enum_types.hpp>
-
-#pragma clang diagnostic pop
 
 #endif // TTMLIR_OPMODEL_TTNN_METALHEADERS_H


### PR DESCRIPTION
### Ticket
N/A

### Problem description
There were a bunch of clang diagnostic pragmas to suppress warnings.

### What's changed
Since those include dirs are searched with `-isystem`, warnings will be suppressed anyway.

### Checklist
- [ ] New/Existing tests provide coverage for changes
