### PR TITLE
Add TTNN bug repro guide doc

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -17,6 +17,7 @@
     - [Usage & API](./tt-explorer-usage-api.md)
     - [Roadmap](./tt-explorer-roadmap.md)
   - [ttnn-standalone](./ttnn-standalone.md)
+- [Creating bug repros for TTNN](./ttnn-bug-repros.md)
 - [Python Bindings](./python-bindings.md)
 - [Flatbuffers](./flatbuffers.md)
 - [CI](./ci.md)

--- a/docs/src/ttnn-bug-repros.md
+++ b/docs/src/ttnn-bug-repros.md
@@ -38,7 +38,23 @@ Place your `.cpp` file in:
 tests/ttnn/unit_tests/gtests/emitc/
 ```
 
+and add it to the cmake file:
+
+```
+tests/ttnn/unit_tests/gtests/CMakeLists.txt
+```
+
+like so:
+
+```cmake
+set(EMITC_UNIT_TESTS_SRC
+    ${CMAKE_CURRENT_SOURCE_DIR}/emitc/test_sanity.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/emitc/your_test_name.cpp  # <<<===
+)
+```
+
 Use the existing file `test_sanity.cpp` in that directory as a reference.
+
 
 ### 5. Modify the Repro for GTest
 
@@ -52,7 +68,7 @@ TEST(EmitC, YourTestName) {
 }
 ```
 
-- Remove any `return` statements from the function body.
+- Remove any `return` statements from the `TEST(...)` function body.
 - Replace `#include "ttnn-precompiled.hpp"` with `#include "emitc.hpp"`
 
 ### 6. Build the TTNN EmitC Tests

--- a/docs/src/ttnn-bug-repros.md
+++ b/docs/src/ttnn-bug-repros.md
@@ -1,0 +1,98 @@
+# Creating Bug Repros for TTNN Using TT-MLIR Codegen
+
+While developing in [tt-mlir](https://github.com/tenstorrent/tt-mlir), it's not uncommon to encounter bugs originating in the [TTNN](https://github.com/tenstorrent/tt-metal/tree/main/ttnn) library. To isolate and report such bugs, a practical approach is to use the C++ codegen feature (`EmitC`) to generate a minimal repro. This guide walks you through how to create such repros and integrate them into the [tt-metal](https://github.com/tenstorrent/tt-metal) repository, where TTNN is developed.
+
+---
+
+## Step-by-Step Guide
+
+> **Note:** If you run into issues while following these steps, check the [Known Issues](#known-issues) section at the end of this guide for common problems and solutions.
+
+### 1. Generate C++ Code from TT-MLIR
+
+Use the `ttnn-standalone` tool to run the compiler and emit C++ code.
+
+> 📖 See [ttnn-standalone.md](ttnn-standalone.md) for instructions on how to generate C++ code from your MLIR input using EmitC.
+
+### 2. Scope Down the Repro
+
+Once you've generated the C++ code:
+- Use the `ttnn-standalone` tool to run and debug it in isolation.
+- Reduce the repro to the minimal example that still triggers the bug.
+- Confirm the issue still reproduces reliably.
+
+### 3. Clone the TT-Metal Repository
+
+Clone the tt-metal repo:
+
+```bash
+git clone git@github.com:tenstorrent/tt-metal.git
+cd tt-metal
+```
+
+### 4. Add the Repro to the GTest Infrastructure
+
+Place your `.cpp` file in:
+
+```
+tests/ttnn/unit_tests/gtests/emitc/
+```
+
+Use the existing file `test_sanity.cpp` in that directory as a reference.
+
+### 5. Modify the Repro for GTest
+
+There are some modifications that need to be made in order to fit the GTest infra:
+
+- Convert the `main()` function to a `TEST(...)` macro:
+
+```cpp
+TEST(EmitC, YourTestName) {
+    // Your original main function body here
+}
+```
+
+- Remove any `return` statements from the function body.
+- Replace `#include "ttnn-precompiled.hpp"` with `#include "emitc.hpp"`
+
+### 6. Build the TTNN EmitC Tests
+
+From the root of the repo:
+
+```bash
+./build_metal.sh --build-ttnn-tests
+```
+
+### 7. Run the EmitC Unit Tests
+
+To run all EmitC tests:
+
+```bash
+./build/test/ttnn/unit_tests_ttnn_emitc
+```
+
+To run a specific test:
+
+```bash
+./build/test/ttnn/unit_tests_ttnn_emitc --gtest_filter=EmitC.YourTestName
+```
+
+### 8. Share the Repro
+
+- Create a branch with your changes.
+- Open a GitHub issue or comment on an existing one.
+- Link to your branch and include the instructions for running the repro
+
+```bash
+./build_metal.sh --build-ttnn-tests
+./build/test/ttnn/unit_tests_ttnn_emitc
+./build/test/ttnn/unit_tests_ttnn_emitc --gtest_filter=EmitC.YourTestName
+```
+
+## Known Issues
+
+- **Missing `sfpi` compiler or other dependencies**
+  If you encounter errors about a missing `sfpi` compiler or other system-level dependencies, refer to the [tt-metal installation guide](https://github.com/tenstorrent/tt-metal/blob/main/INSTALLING.md#install-system-level-dependencies) for instructions on installing the required packages.
+
+- **TTNN test compilation failures**
+  If the build fails when compiling TTNN tests, inspect the specific tests that caused the failure. If the failures are unrelated to EmitC tests, they can typically be ignored — this is a known issue.

--- a/docs/src/ttnn-bug-repros.md
+++ b/docs/src/ttnn-bug-repros.md
@@ -73,11 +73,20 @@ TEST(EmitC, YourTestName) {
 
 ### 6. Build the TTNN EmitC Tests
 
-From the root of the repo:
+First, activate the python virtual env, and set some env variables:
+```bash
+source python_env/bin/activate
+export TT_METAL_HOME=$(pwd)
+export PYTHONPATH=$(pwd)
+```
+
+Then, build the tests:
 
 ```bash
 ./build_metal.sh --build-ttnn-tests
 ```
+
+Note: some unrelated gtests might fail here, we can ignore them.
 
 ### 7. Run the EmitC Unit Tests
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18551

### Problem description
tt-mlir compiler is able to generate TTNN op calls in C++ (EmitC) - it is not trivial for metal devs to consume and run these code snippets.

### What's changed
Change https://github.com/tenstorrent/tt-metal/pull/22241 enabled easy plug&play of generated C++ code (EmitC) to tt-metal's GTest infra. This change adds docs in tt-mlir on how to use the infra.

### Checklist
- [ ] New/Existing tests provide coverage for changes
