### PR TITLE
[Fusing] Move conv2d weights to Host/RM workaround

### DIFF
--- a/include/ttmlir/Utils.h
+++ b/include/ttmlir/Utils.h
@@ -28,6 +28,8 @@
 namespace ttmlir::utils {
 
 constexpr inline llvm::StringLiteral g_constEvalAttrName = "const_eval";
+constexpr inline llvm::StringLiteral g_conv2dWeightAttrName =
+    "ttir.conv2d_weight";
 
 template <typename T>
 T alignUp(T ptr, T alignment) {

--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -353,29 +353,78 @@ private:
   }
 };
 
+// Tag all block arguments which are direct inputs to Conv2dOp with
+// discardable attribute. This is used during Layouting to check if
+// function argument need to be put to Host/RM. This is temporary
+// solution until we complete refactor of TTNNLayout see:
+// https://github.com/tenstorrent/tt-mlir/issues/3432.
+class Conv2dTagWeights : public mlir::OpRewritePattern<Conv2dOp> {
+public:
+  Conv2dTagWeights(MLIRContext *context)
+      : OpRewritePattern(context, PatternBenefit(2)) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(Conv2dOp conv2d,
+                  mlir::PatternRewriter &rewriter) const final {
+    if (BlockArgument blockArg = dyn_cast<BlockArgument>(conv2d.getWeight())) {
+      // Get the function that owns this block argument.
+      func::FuncOp owningFunc =
+          cast<func::FuncOp>(blockArg.getOwner()->getParentOp());
+
+      // Get the argument index.
+      uint32_t argIdx = blockArg.getArgNumber();
+
+      // Check if the argument already has the g_conv2dWeight attribute.
+      if (owningFunc.getArgAttr(argIdx,
+                                ttmlir::utils::g_conv2dWeightAttrName)) {
+        return failure();
+      }
+
+      // Create the g_conv2dWeight attribute.
+      auto gConv2dWeightAttr = rewriter.getUnitAttr();
+      owningFunc.setArgAttr(argIdx, ttmlir::utils::g_conv2dWeightAttrName,
+                            gConv2dWeightAttr);
+
+      return success();
+    }
+
+    return failure();
+  }
+};
+
 class TTIRFusingPass : public impl::TTIRFusingBase<TTIRFusingPass> {
 public:
   using impl::TTIRFusingBase<TTIRFusingPass>::TTIRFusingBase;
   void runOnOperation() final {
-    RewritePatternSet patterns(&getContext());
-    patterns.add<TTIRConv2dWithBias>(&getContext());
+    {
+      RewritePatternSet patterns(&getContext());
+      patterns.add<Conv2dTagWeights>(&getContext());
+      if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+        signalPassFailure();
+        return;
+      }
+    }
+    {
+      RewritePatternSet patterns(&getContext());
+      patterns.add<TTIRConv2dWithBias>(&getContext());
 
-    // Add patterns for each reduction op type.
-    patterns.add<ReductionWithReshapePattern<SumOp>>(&getContext());
-    patterns.add<ReductionWithReshapePattern<MeanOp>>(&getContext());
-    patterns.add<ReductionWithReshapePattern<MaxOp>>(&getContext());
-    patterns.add<ReductionWithReshapePattern<MinOp>>(&getContext());
-    patterns.add<ReductionWithReshapePattern<ProdOp>>(&getContext());
-    patterns.add<ReductionWithReshapePattern<ReduceAndOp>>(&getContext());
-    patterns.add<ReductionWithReshapePattern<ReduceOrOp>>(&getContext());
-    patterns.add<ReductionWithReshapePattern<ArgMaxOp>>(&getContext());
+      // Add patterns for each reduction op type.
+      patterns.add<ReductionWithReshapePattern<SumOp>>(&getContext());
+      patterns.add<ReductionWithReshapePattern<MeanOp>>(&getContext());
+      patterns.add<ReductionWithReshapePattern<MaxOp>>(&getContext());
+      patterns.add<ReductionWithReshapePattern<MinOp>>(&getContext());
+      patterns.add<ReductionWithReshapePattern<ProdOp>>(&getContext());
+      patterns.add<ReductionWithReshapePattern<ReduceAndOp>>(&getContext());
+      patterns.add<ReductionWithReshapePattern<ReduceOrOp>>(&getContext());
+      patterns.add<ReductionWithReshapePattern<ArgMaxOp>>(&getContext());
 
-    patterns.add<SoftmaxFusionPattern>(&getContext());
-    patterns.add<Conv2dWithMultiply>(&getContext());
+      patterns.add<SoftmaxFusionPattern>(&getContext());
+      patterns.add<Conv2dWithMultiply>(&getContext());
 
-    GreedyRewriteConfig config;
-    config.useTopDownTraversal = true;
-    (void)applyPatternsGreedily(getOperation(), std::move(patterns));
+      GreedyRewriteConfig config;
+      config.useTopDownTraversal = true;
+      (void)applyPatternsGreedily(getOperation(), std::move(patterns), config);
+    }
   }
 };
 } // namespace

--- a/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
@@ -550,6 +550,15 @@ private:
         return true;
       }
     }
+
+    // For block arguments which are maked as conv2d weights leave them on host.
+    func::FuncOp owningFunc = cast<func::FuncOp>(arg.getOwner()->getParentOp());
+    uint32_t argIdx = arg.getArgNumber();
+
+    if (owningFunc.getArgAttr(argIdx, ttmlir::utils::g_conv2dWeightAttrName)) {
+      return true;
+    }
+
     return false;
   }
 

--- a/test/ttmlir/Dialect/TTIR/fusing/weight_tagging.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/weight_tagging.mlir
@@ -1,0 +1,18 @@
+// RUN: ttmlir-opt --tt-register-device --ttir-fusing --mlir-print-local-scope --ttnn-layout %s | FileCheck %s
+
+module {
+  // CHECK: func.func @tagging
+  // CHECK-SAME: tensor<64x64x3x3
+  // CHECK-SAME: memref<12288x3xbf16, #ttnn.buffer_type<system_memory>
+  func.func @tagging(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>) -> tensor<1x30x30x64xbf16> {
+    %0 = ttir.empty() : tensor<1x30x30x64xbf16>
+    %1 = "ttir.conv2d"(%arg0, %arg1, %0)
+            <{
+              stride = 1: i32,
+              padding = 0: i32,
+              dilation = 1: i32,
+              groups = 1: i32
+            }> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x30x30x64xbf16>) -> tensor<1x30x30x64xbf16>
+    return %1: tensor<1x30x30x64xbf16>
+  }
+}


### PR DESCRIPTION
Context

When testing fusing for resnet we hit OOM when pushing inputs from host to DRAM. This is because layouting logic prefers inputs in tile/dram when possible. This wasn't the case before fusing because we had special casing in layouting for function inputs which are used by conv2d to put them in host/rm.
When fusing came some operations were commuted upward which made this special cases useless in sense that now all inputs were forced in tile/dram. Since resnet has weights which are not channel last when tilized these tensors become quite large and they can't fit into dram.

Workaround

Long term we want to have all layouts in host/rm but this is not quite simple. While trying to convert all to RM/Host we found some bugs which are not easy fix (see https://github.com/tenstorrent/tt-mlir/issues/3432). While we work separately on this bugfixes we need some temporary solution for resnet case. There were couple of solutions which were considered (if interested I can add them to description separately), but in the end we decided to go with discardable attributes and tag all weights of conv2d before fusing and change layouting logic to check this attributes.

Longterm

Like said longterm fix is to move everything Host/RM https://github.com/tenstorrent/tt-mlir/issues/3432 and let optimizer change layouts when needed.