### PR TITLE
D2M: Fix first copy guard condition

### DIFF
--- a/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
+++ b/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
@@ -173,9 +173,9 @@ static void lowerLoadToCopyTile(memref::LoadOp op, bool cbIdxAsDstIdx,
       condition =
           rewriter
               .create<arith::OrIOp>(op.getLoc(), condition,
-                                     rewriter.create<arith::CmpIOp>(
-                                         op.getLoc(), arith::CmpIPredicate::ne,
-                                         innerLoopVar, index(0)))
+                                    rewriter.create<arith::CmpIOp>(
+                                        op.getLoc(), arith::CmpIPredicate::ne,
+                                        innerLoopVar, index(0)))
               .getResult();
     }
     auto ifOp = rewriter.create<scf::IfOp>(op.getLoc(), condition);

--- a/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
+++ b/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
@@ -172,7 +172,7 @@ static void lowerLoadToCopyTile(memref::LoadOp op, bool cbIdxAsDstIdx,
       auto innerLoopVar = innerLoopVars.pop_back_val();
       condition =
           rewriter
-              .create<arith::AndIOp>(op.getLoc(), condition,
+              .create<arith::OrIOp>(op.getLoc(), condition,
                                      rewriter.create<arith::CmpIOp>(
                                          op.getLoc(), arith::CmpIPredicate::ne,
                                          innerLoopVar, index(0)))

--- a/test/ttmlir/Conversion/TTIRToTTKernel/copy_tile_guards.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTKernel/copy_tile_guards.mlir
@@ -187,7 +187,7 @@ module {
           %8 = memref.load %collapse_shape_1[%c0] : memref<64x!tt.tile<32x32, f16>, #l1_>
           // CHECK: [[COND1:[%0-9]+]] = arith.cmpi ne, [[INNER1]], %c0
           // CHECK: [[COND2:[%0-9]+]] = arith.cmpi ne, [[INNER2]], %c0
-          // CHECK: [[AND:[%0-9]+]] = arith.andi [[COND1]], [[COND2]]
+          // CHECK: [[AND:[%0-9]+]] = arith.ori [[COND1]], [[COND2]]
           // CHECK: scf.if [[AND]] {
           // CHECK: "ttkernel.copy_tile_init"
           // CHECK: "ttkernel.copy_tile"


### PR DESCRIPTION
Condition for first copy guard (not first iteration) should be `(arg0 != 0) || (arg1 != 0) || ...`