### PR TITLE
#2597: Add support for all to all shlo into ttir

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -2208,6 +2208,34 @@ def TTIR_CollectivePermuteOp : TTIR_NamedOp<"collective_permute"> {
     let hasVerifier = 1;
 }
 
+def TTIR_AllToAllOp : TTIR_NamedOp<"all_to_all"> {
+    let summary = "All to All operation.";
+    let description = [{
+      The all_to_all operation redistributes slices of a tensor across a cluster of devices. It splits each local tensor along split_dimension, sends
+      the resulting slices to other devices along cluster_axis, and then concatenates the received slices along concat_dimension.
+
+      Example:
+        For a 1x2 mesh and a local input of shape [8, 4]:
+          - split_dimension = 1
+          - concat_dimension = 0
+          - split_count = 2
+          - cluster_axis = 1
+
+        Each device splits its [8, 4] tensor into two [8, 2] slices. After the exchange, each device concatenates the two received [8, 2] slices
+        into a [16, 2] output tensor.
+    }];
+
+    let arguments = (ins AnyRankedTensor:$input,
+                         AnyRankedTensor:$output,
+                         SI32Attr:$split_dim,
+                         SI32Attr:$concat_dim,
+                         SI32Attr:$split_count,
+                         UI32Attr:$cluster_axis);
+
+    let results = (outs AnyRankedTensor:$result);
+    let hasVerifier = 1;
+}
+
 def TTIR_MeshShardOp : TTIR_NamedOp<"mesh_shard"> {
     let summary = "Mesh shard operation.";
     let description = [{

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1751,6 +1751,35 @@ def TTNN_CollectivePermuteOp: TTNN_Op<"collective_permute"> {
     let hasFolder = 1;
 }
 
+def TTNN_AllToAllOp: TTNN_Op<"all_to_all"> {
+    let summary = "All to All operation.";
+    let description = [{
+      The all_to_all operation redistributes slices of a tensor across a cluster of devices. It splits each local tensor along split_dimension, sends
+      the resulting slices to other devices along cluster_axis, and then concatenates the received slices along concat_dimension.
+
+      Example:
+        For a 1x2 mesh and a local input of shape [8, 4]:
+          - split_dimension = 1
+          - concat_dimension = 0
+          - split_count = 2
+          - cluster_axis = 1
+
+        Each device splits its [8, 4] tensor into two [8, 2] slices. After the exchange, each device concatenates the two received [8, 2] slices
+        into a [16, 2] output tensor.
+    }];
+
+    let arguments = (ins AnyRankedTensor:$input,
+                         TTNN_Device:$device,
+                         SI32Attr:$split_dim,
+                         SI32Attr:$concat_dim,
+                         SI32Attr:$split_count,
+                         UI32Attr:$cluster_axis);
+
+    let results = (outs AnyRankedTensor:$result);
+
+    let hasVerifier = 1;
+}
+
 def TTNN_MeshShardOp: TTNN_Op<"mesh_shard"> {
     let summary = "Mesh shard op.";
     let description = [{

--- a/include/ttmlir/Target/TTNN/operations/ccl.fbs
+++ b/include/ttmlir/Target/TTNN/operations/ccl.fbs
@@ -19,6 +19,16 @@ table CollectivePermuteOp {
   source_target_pairs: [int64];
 }
 
+table AllToAllOp {
+  in: tt.target.ttnn.TensorRef;
+  out: tt.target.ttnn.TensorRef;
+  device: tt.target.DeviceRef;
+  split_dim: int32;
+  concat_dim: int32;
+  split_count: int32;
+  cluster_axis: uint32;
+}
+
 table MeshShardOp {
   in: tt.target.ttnn.TensorRef;
   out: tt.target.ttnn.TensorRef;

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -26,6 +26,7 @@ namespace tt.target.ttnn;
 union OpType {
   AllGatherOp,
   CollectivePermuteOp,
+  AllToAllOp,
   MeshShardOp,
   ReduceScatterOp,
   GetDeviceOp,

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -1371,7 +1371,8 @@ public:
     rewriter.replaceOpWithNewOp<ttnn::AllToAllOp>(
         op, this->getTypeConverter()->convertType(op.getType()),
         adaptor.getInput(), device, adaptor.getSplitDim(),
-        adaptor.getConcatDim(), adaptor.getClusterAxis());
+        adaptor.getConcatDim(), adaptor.getSplitCount(),
+        adaptor.getClusterAxis());
 
     return success();
   }

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -1357,6 +1357,28 @@ public:
 } // namespace
 
 namespace {
+class AllToAllOpConversionPattern
+    : public OpConversionPattern<ttir::AllToAllOp> {
+public:
+  using OpConversionPattern<ttir::AllToAllOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttir::AllToAllOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    auto device = ::ttnn::utils::getOrInsertDevice(rewriter, op);
+
+    rewriter.replaceOpWithNewOp<ttnn::AllToAllOp>(
+        op, this->getTypeConverter()->convertType(op.getType()),
+        adaptor.getInput(), device, adaptor.getSplitDim(),
+        adaptor.getConcatDim(), adaptor.getClusterAxis());
+
+    return success();
+  }
+};
+} // namespace
+
+namespace {
 class ArangeOpConversionPattern : public OpConversionPattern<ttir::ArangeOp> {
 public:
   using OpConversionPattern<ttir::ArangeOp>::OpConversionPattern;
@@ -1701,6 +1723,7 @@ void populateTTIRToTTNNPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
            AllGatherOpConversionPattern,
            ReduceScatterOpConversionPattern,
            CollectivePermuteOpConversionPattern,
+           AllToAllOpConversionPattern,
            ArangeOpConversionPattern,
            UpdateCacheOpConversionPattern,
            FillCacheOpConversionPattern,

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -3055,6 +3055,43 @@ void mlir::tt::ttir::MatmulOp::getCanonicalizationPatterns(
 }
 
 //===----------------------------------------------------------------------===//
+// AllToAllOp
+//===----------------------------------------------------------------------===//
+
+// AllToAllOp verification
+::mlir::LogicalResult mlir::tt::ttir::AllToAllOp::verify() {
+  ::mlir::RankedTensorType inputType = getInput().getType();
+  ::mlir::RankedTensorType outputType = getResult().getType();
+  auto inShape = inputType.getShape();
+  int64_t splitDim = getSplitDim();
+  int64_t concatDim = getConcatDim();
+  int64_t splitCount = getSplitCount();
+  if (splitDim < 0 || splitDim >= inputType.getRank()) {
+    return emitOpError("splitDim must be in the range [0, rank(operands)]");
+  }
+  if (splitCount <= 0) {
+    return emitOpError("splitCount must be a positive integer");
+  }
+  if (inShape[splitDim] % splitCount != 0) {
+    return emitOpError("splitDim size must be divisible by splitCount");
+  }
+  if (concatDim < 0 || concatDim >= inputType.getRank()) {
+    return emitOpError("concatDim must be in the range [0, rank(operands)]");
+  }
+  ::llvm::SmallVector<int64_t> expectedShape(inShape.begin(), inShape.end());
+  expectedShape[splitDim] = expectedShape[splitDim] / splitCount;
+  expectedShape[concatDim] = expectedShape[concatDim] * splitCount;
+  auto expectedType = mlir::RankedTensorType::get(
+      expectedShape, inputType.getElementType(), inputType.getEncoding());
+  if ((expectedType.getShape() != outputType.getShape()) ||
+      (expectedType.getElementType() != outputType.getElementType())) {
+    return emitOpError("output type mismatch: expected type=")
+           << expectedType << " output type=" << outputType;
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // MeshShardOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -2080,6 +2080,44 @@ mlir::tt::ttnn::CollectivePermuteOp::fold(FoldAdaptor adaptor) {
   }
   return {};
 }
+
+//===----------------------------------------------------------------------===//
+// AllToAllOp
+//===----------------------------------------------------------------------===//
+
+// AllToAllOp verification
+::mlir::LogicalResult AllToAllOp::verify() {
+  ::mlir::RankedTensorType inputType = getInput().getType();
+  ::mlir::RankedTensorType outputType = getResult().getType();
+  auto inShape = inputType.getShape();
+  int64_t splitDim = getSplitDim();
+  int64_t concatDim = getConcatDim();
+  int64_t splitCount = getSplitCount();
+  if (splitDim < 0 || splitDim >= inputType.getRank()) {
+    return emitOpError("splitDim must be in the range [0, rank(operands)]");
+  }
+  if (splitCount <= 0) {
+    return emitOpError("splitCount must be a positive integer");
+  }
+  if (inShape[splitDim] % splitCount != 0) {
+    return emitOpError("splitDim size must be divisible by splitCount");
+  }
+  if (concatDim < 0 || concatDim >= inputType.getRank()) {
+    return emitOpError("concatDim must be in the range [0, rank(operands)]");
+  }
+  ::llvm::SmallVector<int64_t> expectedShape(inShape.begin(), inShape.end());
+  expectedShape[splitDim] = expectedShape[splitDim] / splitCount;
+  expectedShape[concatDim] = expectedShape[concatDim] * splitCount;
+  auto expectedType = mlir::RankedTensorType::get(
+      expectedShape, inputType.getElementType(), inputType.getEncoding());
+  if ((expectedType.getShape() != outputType.getShape()) ||
+      (expectedType.getElementType() != outputType.getElementType())) {
+    return emitOpError("output type mismatch: expected type=")
+           << expectedType << " output type=" << outputType;
+  }
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // MeshShardOp
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -2120,11 +2120,12 @@ mlir::tt::ttnn::CollectivePermuteOp::fold(FoldAdaptor adaptor) {
     if (auto meshShapeAttr = deviceOp.getMeshShape(); meshShapeAttr) {
       llvm::SmallVector<int64_t, 2> meshShape{meshShapeAttr->getY(),
                                               meshShapeAttr->getX()};
-      if (meshShape[getClusterAxis()] != splitCount)
+      if (meshShape[getClusterAxis()] != splitCount) {
         return emitOpError()
                << "mesh_shape[" << getClusterAxis() << "] is "
                << meshShape[getClusterAxis()] << " but split_count is "
                << splitCount << "; they must be equal";
+      }
     }
   }
 

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -2115,6 +2115,19 @@ mlir::tt::ttnn::CollectivePermuteOp::fold(FoldAdaptor adaptor) {
     return emitOpError("output type mismatch: expected type=")
            << expectedType << " output type=" << outputType;
   }
+  if (auto deviceOp = getDevice().getDefiningOp<ttnn::GetDeviceOp>();
+      deviceOp) {
+    if (auto meshShapeAttr = deviceOp.getMeshShape(); meshShapeAttr) {
+      llvm::SmallVector<int64_t, 2> meshShape{meshShapeAttr->getY(),
+                                              meshShapeAttr->getX()};
+      if (meshShape[getClusterAxis()] != splitCount)
+        return emitOpError()
+               << "mesh_shape[" << getClusterAxis() << "] is "
+               << meshShape[getClusterAxis()] << " but split_count is "
+               << splitCount << "; they must be equal";
+    }
+  }
+
   return success();
 }
 

--- a/runtime/lib/ttnn/operations/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/CMakeLists.txt
@@ -7,6 +7,7 @@ set(TTNN_OPS_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/cache/load_cached.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ccl/all_gather.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ccl/collective_permute.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ccl/all_to_all.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ccl/mesh_shard.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ccl/reduce_scatter.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/context/get_device.cpp

--- a/runtime/lib/ttnn/operations/ccl/all_to_all.cpp
+++ b/runtime/lib/ttnn/operations/ccl/all_to_all.cpp
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "operations/ccl/collective_permute.h"
+#include "tt/runtime/detail/logger.h"
+#include "tt/runtime/detail/ttnn/operations/utils.h"
+#include "tt/runtime/detail/ttnn/ttnn.h"
+#include "tt/runtime/detail/ttnn/utils.h"
+#include "ttnn/operations/ccl/ccl_host_types.hpp"
+
+/*
+Currently, TTNN does not support collective permute as a first class API.
+Nor do they have send/recv point to point communication support.
+Therefore, this algorithm uses the host as a fallback to do the mapping.
+The collective permute operation takes a list of source_target_pairs that define
+how tensor shards currently living in a src device should move to the dest
+device. For example, for a 1x2 mesh system, you could have [0, 1], [1, 0]
+source_target_pairs list. This indicates that the device shard living in device
+0 should move to device 1, and the device shard living in device 1 should move
+to device 0. In the situation where you have incomplete devices as the 'dest',
+those devices will acquire a device shard with all values set to 0
+*/
+namespace tt::runtime::ttnn::operations::ccl {
+void run(const ::tt::target::ttnn::AllToAllOp *op, ProgramContext &context) {
+  // ToDo : implement your idea
+  // ProgramTensorPool &tensorPool = context.getTensorPool();
+
+  // const ::ttnn::Tensor &input =
+  // tensorPool.getTTNNTensorAndValidate(op->in());
+  // ::ttnn::MeshDevice *meshDevice = input.mesh_device();
+  // LOG_ASSERT(meshDevice != nullptr, "Tensor must belong to a mesh device");
+
+  // const auto *fbSourceTargetPairs = op->source_target_pairs();
+  // std::vector<int64_t> sourceTargetPairs(fbSourceTargetPairs->begin(),
+  //                                        fbSourceTargetPairs->end());
+
+  // LOG_ASSERT(sourceTargetPairs.size() % 2 == 0,
+  //            "Expected sourceTargetPairs to have size multiple of 2");
+  // LOG_ASSERT(input.storage_type() == ::ttnn::StorageType::DEVICE,
+  //            "Input of collective_permute must be device storage. id:",
+  //            op->in()->global_id());
+
+  // // Get list of individual per-device tensors. It should be returned in
+  // logical
+  // // id order.
+  // std::vector<::ttnn::Tensor> hostTensors =
+  //     ::ttnn::distributed::get_device_tensors(::ttnn::from_device(input));
+
+  // // Iterate through sourceTargetPairs and for each pair, get the source
+  // tensor
+  // // from the map and convert to device storage with dest device.
+  // std::vector<bool> foundDestDevices(hostTensors.size(), false);
+  // std::vector<::ttnn::Tensor> newHostTensors(hostTensors.size(),
+  //                                            ::ttnn::Tensor());
+
+  // for (size_t i = 0; i < sourceTargetPairs.size(); i += 2) {
+  //   int64_t src = sourceTargetPairs[i];
+  //   int64_t dest = sourceTargetPairs[i + 1];
+
+  //   LOG_ASSERT((src < static_cast<int64_t>(hostTensors.size()) && src >= 0),
+  //              "Source device id is out of bounds!");
+  //   LOG_ASSERT((dest < static_cast<int64_t>(hostTensors.size()) && dest >=
+  //   0),
+  //              "Destination device id is out of bounds!");
+
+  //   auto &srcHostTensor = hostTensors[src];
+
+  //   newHostTensors[dest] = srcHostTensor;
+  //   foundDestDevices[dest] = true;
+  // }
+
+  // // Loop through all the devices that did not participate in the swaping and
+  // // set their tensor device shard values to 0.
+  // for (size_t i = 0; i < foundDestDevices.size(); i++) {
+  //   if (foundDestDevices[i]) {
+  //     continue;
+  //   }
+
+  //   auto &srcHostTensor = hostTensors[i];
+
+  //   // We need to memset this tensor value to 0 based on collective permute
+  //   // operation semantics
+  //   void *dstPtr =
+  //   ::tt::runtime::ttnn::utils::getRawHostDataPtr(srcHostTensor); size_t size
+  //   = srcHostTensor.volume() * srcHostTensor.element_size();
+  //   std::memset(dstPtr, 0, size);
+
+  //   newHostTensors[i] = srcHostTensor;
+  //   foundDestDevices[i] = true;
+  // }
+
+  // // Combine all host tensor shards into a single host tensor with
+  // // multi device host storage.
+  // ::ttnn::Tensor out = ::ttnn::distributed::aggregate_as_tensor(
+  //     newHostTensors,
+  //     ::ttnn::distributed::get_distributed_tensor_config_from_tensor(input));
+
+  // out = ::ttnn::to_device(out, meshDevice, input.memory_config());
+  // tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+}
+} // namespace tt::runtime::ttnn::operations::ccl

--- a/runtime/lib/ttnn/operations/ccl/all_to_all.h
+++ b/runtime/lib/ttnn/operations/ccl/all_to_all.h
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef RUNTIME_LIB_TTNN_OPERATIONS_CCL_ALL_TO_ALL_H
+#define RUNTIME_LIB_TTNN_OPERATIONS_CCL_ALL_TO_ALL_H
+
+#include "tt/runtime/detail/ttnn/types.h"
+#include "ttmlir/Target/TTNN/program_generated.h"
+
+namespace tt::runtime::ttnn::operations::ccl {
+void run(const ::tt::target::ttnn::AllToAllOp *op, ProgramContext &context);
+} // namespace tt::runtime::ttnn::operations::ccl
+
+#endif // RUNTIME_LIB_TTNN_OPERATIONS_CCL_ALL_TO_ALL_H

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -6,6 +6,7 @@
 
 #include "operations/cache/load_cached.h"
 #include "operations/ccl/all_gather.h"
+#include "operations/ccl/all_to_all.h"
 #include "operations/ccl/collective_permute.h"
 #include "operations/ccl/mesh_shard.h"
 #include "operations/ccl/reduce_scatter.h"
@@ -307,6 +308,9 @@ void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
   case ::tt::target::ttnn::OpType::CollectivePermuteOp: {
     return operations::ccl::run(op->type_as_CollectivePermuteOp(),
                                 getContext());
+  }
+  case ::tt::target::ttnn::OpType::AllToAllOp: {
+    return operations::ccl::run(op->type_as_AllToAllOp(), getContext());
   }
   case ::tt::target::ttnn::OpType::MeshShardOp: {
     return operations::ccl::run(op->type_as_MeshShardOp(), getContext());

--- a/test/python/golden/test_ttir_ops_n300.py
+++ b/test/python/golden/test_ttir_ops_n300.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 
-from typing import List, Tuple
+from typing import List, Tuple, Union
 from ttir_builder.utils import compile_to_flatbuffer
 from ttir_builder import Operand, TTIRBuilder, Shape
 
@@ -499,6 +499,250 @@ def test_eltwise_multidevice(shapes: List[Shape], mesh_shape: Tuple[int, int], r
         shapes,
         mesh_shape=mesh_shape,
         test_base=request.node.name,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+    )
+
+
+def pseudo_golden_all_to_all(
+    input: torch.Tensor,
+    split_dim: int,
+    concat_dim: int,
+    mesh_shape: Tuple[int, int],
+    shard_dims: Tuple[int, int],
+    cluster_axis: int,
+):
+    # sharding
+    num_of_clusters = mesh_shape[1 - cluster_axis]
+    devices_in_cluster = mesh_shape[cluster_axis]
+    clusters = []
+
+    def sharding(
+        input: torch.Tensor, shard_dim: Union[None, int], number_of_shards: int
+    ):
+        output = []
+        if shard_dim == None or shard_dim == -1:
+            output = [input]
+        else:
+            output = torch.chunk(input, number_of_shards, dim=shard_dim)
+        return output
+
+    for cluster in sharding(input, shard_dims[1 - cluster_axis], num_of_clusters):
+        clusters.append(sharding(cluster, shard_dims[cluster_axis], devices_in_cluster))
+    output_per_cluster = []
+    # all to all
+    for cluster in clusters:
+        assert devices_in_cluster == len(cluster)
+        # prepare for all to all
+        scattered_tensors_per_device = []
+        for i in range(devices_in_cluster):
+            scattered_tensors_per_device.append([])
+        # slice and scatter/gather
+        for device_tensor in cluster:
+            sliced = torch.chunk(device_tensor, devices_in_cluster, dim=split_dim)
+            for i in range(devices_in_cluster):
+                scattered_tensors_per_device[i].append(sliced[i])
+        # concat
+        output_per_device = []
+        for i in range(devices_in_cluster):
+            output_per_device.append(
+                torch.cat(scattered_tensors_per_device[i], dim=concat_dim)
+            )
+        output_per_cluster.append(output_per_device)
+
+    def unsharding(inputs: List[torch.Tensor], shard_dim: Union[None, int]):
+        if shard_dim == None or shard_dim == -1:
+            assert len(inputs) == 1
+            return inputs[0]
+        else:
+            return torch.cat(inputs, dim=shard_dim)
+
+    # unsharding
+    outputs = []
+    for output in output_per_cluster:
+        outputs.append(unsharding(output, shard_dims[cluster_axis]))
+    output = unsharding(outputs, shard_dims[1 - cluster_axis])
+    return output
+
+
+def generateShardShape(
+    input_rank: int, mesh_shape: Tuple[int, int], shard_dims: Tuple[int, int]
+):
+    shard_shape = [1] * input_rank
+    if shard_dims[0] != -1:
+        shard_shape[shard_dims[0]] = mesh_shape[0]
+    if shard_dims[1] != -1:
+        shard_shape[shard_dims[1]] = mesh_shape[1]
+    return shard_shape
+
+
+def isValidDeviceSharding(input_shape: Shape, mesh_shape: Tuple[int, int], shard_dims):
+    if shard_dims[0] == shard_dims[1]:
+        return False
+    shard_shape = generateShardShape(len(input_shape), mesh_shape, shard_dims)
+    if all(x == 1 for x in shard_shape):
+        return False
+    if len(input_shape) != len(shard_shape):
+        return False
+    if any(i % s != 0 for i, s in zip(input_shape, shard_shape)):
+        return False
+    return True
+
+
+@pytest.mark.parametrize("input_shape", [(128, 128), (4, 4), (128, 64), (192, 12)])
+@pytest.mark.parametrize("mesh_shape", [(1, 2), (2, 1)])
+@pytest.mark.parametrize("split_dim", [0, 1])
+@pytest.mark.parametrize("concat_dim", [0, 1])
+@pytest.mark.parametrize("cluster_axis", [0, 1])
+@pytest.mark.parametrize("shard_dim_0", [-1, 0, 1])
+@pytest.mark.parametrize("shard_dim_1", [-1, 0, 1])
+def test_all_to_all_2d(
+    input_shape: Shape,
+    mesh_shape: Tuple[int, int],
+    split_dim,
+    concat_dim,
+    cluster_axis,
+    shard_dim_0,
+    shard_dim_1,
+    request,
+):
+    shard_dims = (shard_dim_0, shard_dim_1)
+    if isValidDeviceSharding(input_shape, mesh_shape, shard_dims) == False:
+        pytest.skip("Sharding is not possible")
+    shard_shape = generateShardShape(len(input_shape), mesh_shape, shard_dims)
+    if shard_dims[cluster_axis] == -1 or shard_shape[shard_dims[cluster_axis]] == 1:
+        pytest.skip("all to all across 1 device")
+    if (input_shape[split_dim] / shard_shape[split_dim]) % mesh_shape[
+        cluster_axis
+    ] != 0:
+        pytest.skip("Cannot split tensor evenly")
+
+    def all_to_all(in0: Operand, builder: TTIRBuilder):
+        input = builder._get_golden_tensor(in0)
+        golden_output = pseudo_golden_all_to_all(
+            input,
+            split_dim=split_dim,
+            concat_dim=concat_dim,
+            mesh_shape=mesh_shape,
+            shard_dims=shard_dims,
+            cluster_axis=cluster_axis,
+        )
+        builder.set_graph_input_output([input], [golden_output])
+
+        sharded = builder.mesh_shard(
+            in0,
+            shard_direction="#tt.shard_direction<full_to_shard>",
+            shard_type="#tt.shard_type<devices>",
+            shard_shape=shard_shape,
+            shard_dims=shard_dims,
+        )
+        gathered = builder.all_to_all(
+            sharded,
+            split_dim=split_dim,
+            concat_dim=concat_dim,
+            split_count=mesh_shape[cluster_axis],
+            cluster_axis=cluster_axis,
+        )
+        return builder.mesh_shard(
+            gathered,
+            shard_direction="#tt.shard_direction<shard_to_full>",
+            shard_type="#tt.shard_type<devices>",
+            shard_shape=shard_shape,
+            shard_dims=shard_dims,
+        )
+
+    def seq2str(seq, delim="x"):
+        return delim.join(str(num) for num in seq)
+
+    def generate_test_base():
+        return f"test-all-to-all_input_{seq2str(input_shape)}_mesh_{seq2str(mesh_shape)}_split_{split_dim}_concat_{concat_dim}_cluster_{cluster_axis}_shard-dims_{seq2str(shard_dims)}_shard-shape_{seq2str(shard_shape)}"
+
+    compile_to_flatbuffer(
+        all_to_all,
+        [input_shape],
+        mesh_shape=mesh_shape,
+        test_base=generate_test_base(),
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+    )
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    [(1, 1, 128, 128), (1, 1, 4, 4), (1, 1, 128, 64), (1, 16, 64, 1), (16, 4, 4, 128)],
+)
+@pytest.mark.parametrize("mesh_shape", [(1, 2), (2, 1)])
+@pytest.mark.parametrize("split_dim", [0, 1, 2, 3])
+@pytest.mark.parametrize("concat_dim", [0, 1, 2, 3])
+@pytest.mark.parametrize("cluster_axis", [0, 1])
+@pytest.mark.parametrize("shard_dim_0", [-1, 0, 1, 2, 3])
+@pytest.mark.parametrize("shard_dim_1", [-1, 0, 1, 2, 3])
+def test_all_to_all_4d(
+    input_shape: Shape,
+    mesh_shape: Tuple[int, int],
+    split_dim,
+    concat_dim,
+    cluster_axis,
+    shard_dim_0,
+    shard_dim_1,
+    request,
+):
+    shard_dims = (shard_dim_0, shard_dim_1)
+    if isValidDeviceSharding(input_shape, mesh_shape, shard_dims) == False:
+        pytest.skip("Sharding is not possible")
+    shard_shape = generateShardShape(len(input_shape), mesh_shape, shard_dims)
+    if shard_dims[cluster_axis] == -1 or shard_shape[shard_dims[cluster_axis]] == 1:
+        pytest.skip("all to all across 1 device")
+    if (input_shape[split_dim] / shard_shape[split_dim]) % mesh_shape[
+        cluster_axis
+    ] != 0:
+        pytest.skip("Cannot split tensor evenly")
+
+    def all_to_all(in0: Operand, builder: TTIRBuilder):
+        input = builder._get_golden_tensor(in0)
+        golden_output = pseudo_golden_all_to_all(
+            input,
+            split_dim=split_dim,
+            concat_dim=concat_dim,
+            mesh_shape=mesh_shape,
+            shard_dims=shard_dims,
+            cluster_axis=cluster_axis,
+        )
+        builder.set_graph_input_output([input], [golden_output])
+
+        sharded = builder.mesh_shard(
+            in0,
+            shard_direction="#tt.shard_direction<full_to_shard>",
+            shard_type="#tt.shard_type<devices>",
+            shard_shape=shard_shape,
+            shard_dims=shard_dims,
+        )
+        gathered = builder.all_to_all(
+            sharded,
+            split_dim=split_dim,
+            concat_dim=concat_dim,
+            split_count=mesh_shape[cluster_axis],
+            cluster_axis=cluster_axis,
+        )
+        return builder.mesh_shard(
+            gathered,
+            shard_direction="#tt.shard_direction<shard_to_full>",
+            shard_type="#tt.shard_type<devices>",
+            shard_shape=shard_shape,
+            shard_dims=shard_dims,
+        )
+
+    def seq2str(seq, delim="x"):
+        return delim.join(str(num) for num in seq)
+
+    def generate_test_base():
+        return f"test-all-to-all_input_{seq2str(input_shape)}_mesh_{seq2str(mesh_shape)}_split_{split_dim}_concat_{concat_dim}_cluster_{cluster_axis}_shard-dims_{seq2str(shard_dims)}_shard-shape_{seq2str(shard_shape)}"
+
+    compile_to_flatbuffer(
+        all_to_all,
+        [input_shape],
+        mesh_shape=mesh_shape,
+        test_base=generate_test_base(),
         output_root=request.config.getoption("--path"),
         system_desc_path=request.config.getoption("--sys-desc"),
     )

--- a/test/ttmlir/Conversion/StableHLOToTTIR/ccl/ccl_ops_gspmd.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/ccl/ccl_ops_gspmd.mlir
@@ -2435,3 +2435,99 @@ module @SyncTensorsGraph.13 attributes {mhlo.cross_program_prefetches = [], mhlo
     return %10 : tensor<1024x4096xf32>
   }
 }
+
+// -----
+
+module @all_to_all_1 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas = 1 : i32} {
+  func.func public @main(%arg0: tensor<2x128xf32>) -> (tensor<16x16xf32> {jax.result_info = ""}) {
+    %0 = stablehlo.custom_call @Sharding(%arg0) {backend_config = "", mhlo.sharding = "{devices=[1,8]<=[8]}"} : (tensor<2x128xf32>) -> tensor<2x128xf32>
+    %1 = stablehlo.custom_call @SPMDFullToShardShape(%0) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<2x128xf32>) -> tensor<2x16xf32>
+    // CHECK: "ttir.mesh_shard"
+    // CHECK-SAME: shard_dims = array<i64: -1, 1>
+    // CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
+    // CHECK-SAME: shard_shape = array<i64: 1, 8>
+    // CHECK-SAME: shard_type = #tt.shard_type<devices>
+    %2 = call @shmap_body(%1) : (tensor<2x16xf32>) -> tensor<16x2xf32>
+    // CHECK: "ttir.all_to_all"
+    // CHECK-SAME: cluster_axis = 1 : ui32
+    // CHECK-SAME: concat_dim = 0 : si32
+    // CHECK-SAME: split_count = 8 : si32
+    // CHECK-SAME: split_dim = 1 : si32
+    %3 = stablehlo.custom_call @Sharding(%2) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<16x2xf32>) -> tensor<16x2xf32>
+    %4 = stablehlo.custom_call @SPMDShardToFullShape(%3) {backend_config = "", mhlo.sharding = "{devices=[1,8]<=[8]}"} : (tensor<16x2xf32>) -> tensor<16x16xf32>
+    // CHECK: "ttir.mesh_shard"
+    // CHECK-SAME: shard_dims = array<i64: -1, 1>
+    // CHECK-SAME: shard_direction = #tt.shard_direction<shard_to_full>
+    // CHECK-SAME: shard_shape = array<i64: 1, 8>
+    // CHECK-SAME: shard_type = #tt.shard_type<devices>
+    return %4 : tensor<16x16xf32>
+  }
+  func.func private @shmap_body(%arg0: tensor<2x16xf32>) -> (tensor<16x2xf32> {jax.result_info = "[None, ('x',)]"}) {
+    %0 = "stablehlo.all_to_all"(%arg0) <{channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>, concat_dimension = 0 : i64, replica_groups = dense<[[0, 1, 2, 3, 4, 5, 6, 7]]> : tensor<1x8xi64>, split_count = 8 : i64, split_dimension = 1 : i64}> : (tensor<2x16xf32>) -> tensor<16x2xf32>
+    return %0 : tensor<16x2xf32>
+  }
+}
+
+// -----
+
+module @all_to_all_2 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas = 1 : i32} {
+  func.func public @main(%arg0: tensor<4x128xf32>) -> (tensor<16x32xf32> {jax.result_info = ""}) {
+    %0 = stablehlo.custom_call @Sharding(%arg0) {backend_config = "", mhlo.sharding = "{devices=[1,4,2]<=[2,4]T(1,0) last_tile_dim_replicate}"} : (tensor<4x128xf32>) -> tensor<4x128xf32>
+    %1 = stablehlo.custom_call @SPMDFullToShardShape(%0) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<4x128xf32>) -> tensor<4x32xf32>
+    // CHECK: "ttir.mesh_shard"
+    // CHECK-SAME: shard_dims = array<i64: -1, 1>
+    // CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
+    // CHECK-SAME: shard_shape = array<i64: 1, 4>
+    // CHECK-SAME: shard_type = #tt.shard_type<devices>
+    %2 = call @shmap_body(%1) : (tensor<4x32xf32>) -> tensor<16x8xf32>
+    // CHECK: "ttir.all_to_all"
+    // CHECK-SAME: cluster_axis = 1 : ui32
+    // CHECK-SAME: concat_dim = 0 : si32
+    // CHECK-SAME: split_count = 4 : si32
+    // CHECK-SAME: split_dim = 1 : si32
+    %3 = stablehlo.custom_call @Sharding(%2) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<16x8xf32>) -> tensor<16x8xf32>
+    %4 = stablehlo.custom_call @SPMDShardToFullShape(%3) {backend_config = "", mhlo.sharding = "{devices=[1,4,2]<=[2,4]T(1,0) last_tile_dim_replicate}"} : (tensor<16x8xf32>) -> tensor<16x32xf32>
+    // CHECK: "ttir.mesh_shard"
+    // CHECK-SAME: shard_dims = array<i64: -1, 1>
+    // CHECK-SAME: shard_direction = #tt.shard_direction<shard_to_full>
+    // CHECK-SAME: shard_shape = array<i64: 1, 4>
+    // CHECK-SAME: shard_type = #tt.shard_type<devices>
+    return %4 : tensor<16x32xf32>
+  }
+  func.func private @shmap_body(%arg0: tensor<4x32xf32>) -> (tensor<16x8xf32> {jax.result_info = "[None, ('y',)]"}) {
+    %0 = "stablehlo.all_to_all"(%arg0) <{channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>, concat_dimension = 0 : i64, replica_groups = dense<[[0, 1, 2, 3], [4, 5, 6, 7]]> : tensor<2x4xi64>, split_count = 4 : i64, split_dimension = 1 : i64}> : (tensor<4x32xf32>) -> tensor<16x8xf32>
+    return %0 : tensor<16x8xf32>
+  }
+}
+
+// -----
+
+module @all_to_all_3 attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas = 1 : i32} {
+  func.func public @main(%arg0: tensor<4x128xf32>) -> (tensor<16x32xf32> {jax.result_info = ""}) {
+    %0 = stablehlo.custom_call @Sharding(%arg0) {backend_config = "", mhlo.sharding = "{devices=[2,4]<=[8]}"} : (tensor<4x128xf32>) -> tensor<4x128xf32>
+    %1 = stablehlo.custom_call @SPMDFullToShardShape(%0) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<4x128xf32>) -> tensor<2x32xf32>
+    // CHECK: "ttir.mesh_shard"
+    // CHECK-SAME: shard_dims = array<i64: 0, 1>
+    // CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
+    // CHECK-SAME: shard_shape = array<i64: 2, 4>
+    // CHECK-SAME: shard_type = #tt.shard_type<devices>
+    %2 = call @shmap_body(%1) : (tensor<2x32xf32>) -> tensor<8x8xf32>
+    // CHECK: "ttir.all_to_all"
+    // CHECK-SAME: cluster_axis = 1 : ui32
+    // CHECK-SAME: concat_dim = 0 : si32
+    // CHECK-SAME: split_count = 4 : si32
+    // CHECK-SAME: split_dim = 1 : si32
+    %3 = stablehlo.custom_call @Sharding(%2) {backend_config = "", mhlo.sharding = "{manual}"} : (tensor<8x8xf32>) -> tensor<8x8xf32>
+    %4 = stablehlo.custom_call @SPMDShardToFullShape(%3) {backend_config = "", mhlo.sharding = "{devices=[2,4]<=[8]}"} : (tensor<8x8xf32>) -> tensor<16x32xf32>
+    // CHECK: "ttir.mesh_shard"
+    // CHECK-SAME: shard_dims = array<i64: 0, 1>
+    // CHECK-SAME: shard_direction = #tt.shard_direction<shard_to_full>
+    // CHECK-SAME: shard_shape = array<i64: 2, 4>
+    // CHECK-SAME: shard_type = #tt.shard_type<devices>
+    return %4 : tensor<16x32xf32>
+  }
+  func.func private @shmap_body(%arg0: tensor<2x32xf32>) -> (tensor<8x8xf32> {jax.result_info = "[('x',), ('y',)]"}) {
+    %0 = "stablehlo.all_to_all"(%arg0) <{channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>, concat_dimension = 0 : i64, replica_groups = dense<[[0, 1, 2, 3], [4, 5, 6, 7]]> : tensor<2x4xi64>, split_count = 4 : i64, split_dimension = 1 : i64}> : (tensor<2x32xf32>) -> tensor<8x8xf32>
+    return %0 : tensor<8x8xf32>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/ccl/all_to_all/all_to_all_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/ccl/all_to_all/all_to_all_negative.mlir
@@ -1,0 +1,113 @@
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+// Unit tests for ttir all_to_all op
+
+// -----
+
+module attributes {} {
+  func.func public @all_to_all_split_dimension_range_1(%arg0: tensor<1x1x32x32xf32>) -> (tensor<1x1x32x32xf32> {jax.result_info = ""}) {
+    %0 = ttir.empty() : tensor<1x1x32x32xf32>
+    %1 = "ttir.all_to_all"(%arg0, %0) <{cluster_axis = 1 : ui32, concat_dim = 3 : si32, split_count = 2 : si32, split_dim = -1 : si32}> : (tensor<1x1x32x32xf32>, tensor<1x1x32x32xf32>) -> tensor<1x1x32x32xf32>
+    return %1 : tensor<1x1x32x32xf32>
+  }
+}
+// CHECK: error: 'ttir.all_to_all' op splitDim must be in the range [0, rank(operands)]
+
+// -----
+
+module attributes {} {
+  func.func public @all_to_all_split_dimension_range_2(%arg0: tensor<1x1x32x32xf32>) -> (tensor<1x1x32x32xf32> {jax.result_info = ""}) {
+    %0 = ttir.empty() : tensor<1x1x32x32xf32>
+    %1 = "ttir.all_to_all"(%arg0, %0) <{cluster_axis = 1 : ui32, concat_dim = 3 : si32, split_count = 2 : si32, split_dim = 4 : si32}> : (tensor<1x1x32x32xf32>, tensor<1x1x32x32xf32>) -> tensor<1x1x32x32xf32>
+    return %1 : tensor<1x1x32x32xf32>
+  }
+}
+// CHECK: error: 'ttir.all_to_all' op splitDim must be in the range [0, rank(operands)]
+
+// -----
+
+module attributes {} {
+  func.func public @all_to_all_split_count_not_divisible(%arg0: tensor<1x1x32x32xf32>) -> (tensor<1x1x32x32xf32> {jax.result_info = ""}) {
+    %0 = ttir.empty() : tensor<1x1x32x32xf32>
+    %1 = "ttir.all_to_all"(%arg0, %0) <{cluster_axis = 1 : ui32, concat_dim = 3 : si32, split_count = 3 : si32, split_dim = 3 : si32}> : (tensor<1x1x32x32xf32>, tensor<1x1x32x32xf32>) -> tensor<1x1x32x32xf32>
+    return %1 : tensor<1x1x32x32xf32>
+  }
+}
+// CHECK: error: 'ttir.all_to_all' op splitDim size must be divisible by splitCount
+
+// -----
+
+module attributes {} {
+  func.func public @all_to_all_concat_dimension_range_1(%arg0: tensor<1x1x32x32xf32>) -> (tensor<1x1x32x32xf32> {jax.result_info = ""}) {
+    %0 = ttir.empty() : tensor<1x1x32x32xf32>
+    %1 = "ttir.all_to_all"(%arg0, %0) <{cluster_axis = 1 : ui32, concat_dim = -1 : si32, split_count = 2 : si32, split_dim = 3 : si32}> : (tensor<1x1x32x32xf32>, tensor<1x1x32x32xf32>) -> tensor<1x1x32x32xf32>
+    return %1 : tensor<1x1x32x32xf32>
+  }
+}
+// CHECK: error: 'ttir.all_to_all' op concatDim must be in the range [0, rank(operands)]
+
+// -----
+
+module attributes {} {
+  func.func public @all_to_all_concat_dimension_range_2(%arg0: tensor<1x1x32x32xf32>) -> (tensor<1x1x32x32xf32> {jax.result_info = ""}) {
+    %0 = ttir.empty() : tensor<1x1x32x32xf32>
+    %1 = "ttir.all_to_all"(%arg0, %0) <{cluster_axis = 1 : ui32, concat_dim = 4 : si32, split_count = 2 : si32, split_dim = 3 : si32}> : (tensor<1x1x32x32xf32>, tensor<1x1x32x32xf32>) -> tensor<1x1x32x32xf32>
+    return %1 : tensor<1x1x32x32xf32>
+  }
+}
+// CHECK: error: 'ttir.all_to_all' op concatDim must be in the range [0, rank(operands)]
+
+// -----
+
+module attributes {} {
+  func.func public @all_to_all_split_count_range(%arg0: tensor<1x1x32x32xf32>) -> (tensor<1x1x32x32xf32> {jax.result_info = ""}) {
+    %0 = ttir.empty() : tensor<1x1x32x32xf32>
+    %1 = "ttir.all_to_all"(%arg0, %0) <{cluster_axis = 1 : ui32, concat_dim = 3 : si32, split_count = 0 : si32, split_dim = 3 : si32}> : (tensor<1x1x32x32xf32>, tensor<1x1x32x32xf32>) -> tensor<1x1x32x32xf32>
+    return %1 : tensor<1x1x32x32xf32>
+  }
+}
+// CHECK: error: 'ttir.all_to_all' op splitCount must be a positive integer
+
+
+// -----
+
+module attributes {} {
+  func.func public @all_to_all_output_type_1(%arg0: tensor<1x1x32x32xf32>) -> (tensor<1x1x16x64xf32> {jax.result_info = ""}) {
+    %0 = ttir.empty() : tensor<1x1x16x64xf32>
+    %1 = "ttir.all_to_all"(%arg0, %0) <{cluster_axis = 1 : ui32, concat_dim = 3 : si32, split_count = 2 : si32, split_dim = 3 : si32}> : (tensor<1x1x32x32xf32>, tensor<1x1x16x64xf32>) -> tensor<1x1x16x64xf32>
+    return %1 : tensor<1x1x16x64xf32>
+  }
+}
+// CHECK: error: 'ttir.all_to_all' op output type mismatch: expected type='tensor<1x1x32x32xf32>' output type='tensor<1x1x16x64xf32>'
+
+// -----
+
+module attributes {} {
+  func.func public @all_to_all_output_type_2(%arg0: tensor<1x1x32x32xf32>) -> (tensor<1x1x32x32xf32> {jax.result_info = ""}) {
+    %0 = ttir.empty() : tensor<1x1x32x32xf32>
+    %1 = "ttir.all_to_all"(%arg0, %0) <{cluster_axis = 1 : ui32, concat_dim = 2 : si32, split_count = 4 : si32, split_dim = 3 : si32}> : (tensor<1x1x32x32xf32>, tensor<1x1x32x32xf32>) -> tensor<1x1x32x32xf32>
+    return %1 : tensor<1x1x32x32xf32>
+  }
+}
+// CHECK: error: 'ttir.all_to_all' op output type mismatch: expected type='tensor<1x1x128x8xf32>' output type='tensor<1x1x32x32xf32>'
+
+// -----
+
+module attributes {} {
+  func.func public @all_to_all_output_type_3(%arg0: tensor<1x1x32x32xf32>) -> (tensor<1x1x32x32xf32> {jax.result_info = ""}) {
+    %0 = ttir.empty() : tensor<1x1x32x32xf32>
+    %1 = "ttir.all_to_all"(%arg0, %0) <{cluster_axis = 1 : ui32, concat_dim = 3 : si32, split_count = 8 : si32, split_dim = 2 : si32}> : (tensor<1x1x32x32xf32>, tensor<1x1x32x32xf32>) -> tensor<1x1x32x32xf32>
+    return %1 : tensor<1x1x32x32xf32>
+  }
+}
+// CHECK: error: 'ttir.all_to_all' op output type mismatch: expected type='tensor<1x1x4x256xf32>' output type='tensor<1x1x32x32xf32>'
+
+// -----
+
+module attributes {} {
+  func.func public @all_to_all_output_type_4(%arg0: tensor<1x1x32x32xf32>) -> (tensor<1x1x32x32xi32> {jax.result_info = ""}) {
+    %0 = ttir.empty() : tensor<1x1x32x32xi32>
+    %1 = "ttir.all_to_all"(%arg0, %0) <{cluster_axis = 1 : ui32, concat_dim = 3 : si32, split_count = 2 : si32, split_dim = 3 : si32}> : (tensor<1x1x32x32xf32>, tensor<1x1x32x32xi32>) -> tensor<1x1x32x32xi32>
+    return %1 : tensor<1x1x32x32xi32>
+  }
+}
+// CHECK: error: 'ttir.all_to_all' op output type mismatch: expected type='tensor<1x1x32x32xf32>' output type='tensor<1x1x32x32xi32>'

--- a/test/ttmlir/Dialect/TTNN/ccl/all_to_all/all_to_all_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/ccl/all_to_all/all_to_all_negative.mlir
@@ -1,0 +1,122 @@
+// RUN: not ttmlir-opt --split-input-file --tt-register-device="system-desc-path=%system_desc_path%" %s 2>&1 | FileCheck %s
+// Unit tests for ttnn all_to_all op
+
+
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x4x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+module @all_to_all_split_dimension_range_1 attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 2 : i32} {
+  func.func public @main(%arg0: tensor<128x128xf32, #ttnn_layout>) -> (tensor<128x128xf32, #ttnn_layout> {}) {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
+    %1 = "ttnn.all_to_all"(%arg0, %0) <{cluster_axis = 1 : ui32, concat_dim = 1 : si32, split_count = 2 : si32, split_dim = -1 : si32}> : (tensor<128x128xf32, #ttnn_layout>, !ttnn.device) -> tensor<128x128xf32, #ttnn_layout>
+    return %1 : tensor<128x128xf32, #ttnn_layout>
+  }
+}
+// CHECK: error: 'ttnn.all_to_all' op splitDim must be in the range [0, rank(operands)]
+
+// -----
+
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x4x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+module @all_to_all_split_dimension_range_2 attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 2 : i32} {
+  func.func public @main(%arg0: tensor<128x128xf32, #ttnn_layout>) -> (tensor<128x128xf32, #ttnn_layout> {}) {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
+    %1 = "ttnn.all_to_all"(%arg0, %0) <{cluster_axis = 1 : ui32, concat_dim = 1 : si32, split_count = 2 : si32, split_dim = 2 : si32}> : (tensor<128x128xf32, #ttnn_layout>, !ttnn.device) -> tensor<128x128xf32, #ttnn_layout>
+    return %1 : tensor<128x128xf32, #ttnn_layout>
+  }
+}
+// CHECK: error: 'ttnn.all_to_all' op splitDim must be in the range [0, rank(operands)]
+
+// -----
+
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x4x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+module @all_to_all_split_count_not_divisible attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 2 : i32} {
+  func.func public @main(%arg0: tensor<128x128xf32, #ttnn_layout>) -> (tensor<128x128xf32, #ttnn_layout> {}) {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
+    %1 = "ttnn.all_to_all"(%arg0, %0) <{cluster_axis = 1 : ui32, concat_dim = 1 : si32, split_count = 3 : si32, split_dim = 1 : si32}> : (tensor<128x128xf32, #ttnn_layout>, !ttnn.device) -> tensor<128x128xf32, #ttnn_layout>
+    return %1 : tensor<128x128xf32, #ttnn_layout>
+  }
+}
+// CHECK: error: 'ttnn.all_to_all' op splitDim size must be divisible by splitCount
+
+// -----
+
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x4x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+module @all_to_all_concat_dimension_range_1 attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 2 : i32} {
+  func.func public @main(%arg0: tensor<128x128xf32, #ttnn_layout>) -> (tensor<128x128xf32, #ttnn_layout> {}) {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
+    %1 = "ttnn.all_to_all"(%arg0, %0) <{cluster_axis = 1 : ui32, concat_dim = -1 : si32, split_count = 2 : si32, split_dim = 1 : si32}> : (tensor<128x128xf32, #ttnn_layout>, !ttnn.device) -> tensor<128x128xf32, #ttnn_layout>
+    return %1 : tensor<128x128xf32, #ttnn_layout>
+  }
+}
+// CHECK: error: 'ttnn.all_to_all' op concatDim must be in the range [0, rank(operands)]
+
+// -----
+
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x4x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+module @all_to_all_concat_dimension_range_1 attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 2 : i32} {
+  func.func public @main(%arg0: tensor<128x128xf32, #ttnn_layout>) -> (tensor<128x128xf32, #ttnn_layout> {}) {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
+    %1 = "ttnn.all_to_all"(%arg0, %0) <{cluster_axis = 1 : ui32, concat_dim = 2 : si32, split_count = 2 : si32, split_dim = 1 : si32}> : (tensor<128x128xf32, #ttnn_layout>, !ttnn.device) -> tensor<128x128xf32, #ttnn_layout>
+    return %1 : tensor<128x128xf32, #ttnn_layout>
+  }
+}
+// CHECK: error: 'ttnn.all_to_all' op concatDim must be in the range [0, rank(operands)]
+
+// -----
+
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x4x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+module @all_to_all_split_count_range attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 2 : i32} {
+  func.func public @main(%arg0: tensor<128x128xf32, #ttnn_layout>) -> (tensor<128x128xf32, #ttnn_layout> {}) {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
+    %1 = "ttnn.all_to_all"(%arg0, %0) <{cluster_axis = 1 : ui32, concat_dim = 1 : si32, split_count = 0 : si32, split_dim = 1 : si32}> : (tensor<128x128xf32, #ttnn_layout>, !ttnn.device) -> tensor<128x128xf32, #ttnn_layout>
+    return %1 : tensor<128x128xf32, #ttnn_layout>
+  }
+}
+// CHECK: error: 'ttnn.all_to_all' op splitCount must be a positive integer
+
+// -----
+
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x4x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+module @all_to_all_output_type_1 attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 2 : i32} {
+  func.func public @main(%arg0: tensor<128x128xf32, #ttnn_layout>) -> (tensor<512x32xf32, #ttnn_layout> {}) {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
+    %1 = "ttnn.all_to_all"(%arg0, %0) <{cluster_axis = 1 : ui32, concat_dim = 1 : si32, split_count = 2 : si32, split_dim = 1 : si32}> : (tensor<128x128xf32, #ttnn_layout>, !ttnn.device) -> tensor<512x32xf32, #ttnn_layout>
+    return %1 : tensor<512x32xf32, #ttnn_layout>
+  }
+}
+// CHECK: error: 'ttnn.all_to_all' op output type mismatch: expected type='tensor<128x128xf32,
+// CHECK-SAME: output type='tensor<512x32xf32,
+
+// -----
+
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x4x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+module @all_to_all_output_type_2 attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 2 : i32} {
+  func.func public @main(%arg0: tensor<128x128xf32, #ttnn_layout>) -> (tensor<128x128xf32, #ttnn_layout> {}) {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
+    %1 = "ttnn.all_to_all"(%arg0, %0) <{cluster_axis = 1 : ui32, concat_dim = 0 : si32, split_count = 2 : si32, split_dim = 1 : si32}> : (tensor<128x128xf32, #ttnn_layout>, !ttnn.device) -> tensor<128x128xf32, #ttnn_layout>
+    return %1 : tensor<128x128xf32, #ttnn_layout>
+  }
+}
+// CHECK: error: 'ttnn.all_to_all' op output type mismatch: expected type='tensor<256x64xf32,
+// CHECK-SAME: output type='tensor<128x128xf32,
+
+
+// -----
+
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x4x!tt.tile<32x32, f32>, #dram>, <interleaved>>
+module @all_to_all_output_type_4 attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 2 : i32} {
+  func.func public @main(%arg0: tensor<128x128xf32, #ttnn_layout>) -> (tensor<128x128xi32, #ttnn_layout> {}) {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
+    %1 = "ttnn.all_to_all"(%arg0, %0) <{cluster_axis = 1 : ui32, concat_dim = 1 : si32, split_count = 2 : si32, split_dim = 1 : si32}> : (tensor<128x128xf32, #ttnn_layout>, !ttnn.device) -> tensor<128x128xi32, #ttnn_layout>
+    return %1 : tensor<128x128xi32, #ttnn_layout>
+  }
+}
+// CHECK: error: 'ttnn.all_to_all' op output type mismatch: expected type='tensor<128x128xf32,
+// CHECK-SAME: output type='tensor<128x128xi32,

--- a/test/ttmlir/Dialect/TTNN/ccl/all_to_all/all_to_all_positive.mlir
+++ b/test/ttmlir/Dialect/TTNN/ccl/all_to_all/all_to_all_positive.mlir
@@ -1,0 +1,66 @@
+// RUN: ttmlir-opt --split-input-file --ttir-to-ttnn-backend-pipeline="mesh-shape=1,2" %s 2>&1 | FileCheck %s
+// Unit tests for ttnn all_to_all op
+
+// -----
+
+module attributes {} {
+  // CHECK-LABEL: all_to_all_basic
+  func.func public @all_to_all_basic(%arg0: tensor<1x1x32x32xf32>) -> (tensor<1x1x32x32xf32> {jax.result_info = ""}) {
+    %0 = ttir.empty() : tensor<1x1x32x32xf32>
+    %1 = "ttir.all_to_all"(%arg0, %0) <{cluster_axis = 1 : ui32, concat_dim = 3 : si32, split_count = 2 : si32, split_dim = 3 : si32}> : (tensor<1x1x32x32xf32>, tensor<1x1x32x32xf32>) -> tensor<1x1x32x32xf32>
+    // CHECK: "ttnn.all_to_all"
+    // CHECK-SAME: cluster_axis = 1 : ui32
+    // CHECK-SAME: concat_dim = 3 : si32
+    // CHECK-SAME: split_count = 2 : si32
+    // CHECK-SAME: split_dim = 3 : si32
+    return %1 : tensor<1x1x32x32xf32>
+  }
+}
+
+// -----
+
+module attributes {} {
+  // CHECK-LABEL: all_to_all_different_dim
+  func.func public @all_to_all_different_dim(%arg0: tensor<1x1x32x32xf32>) -> (tensor<1x2x32x16xf32> {jax.result_info = ""}) {
+    %0 = ttir.empty() : tensor<1x2x32x16xf32>
+    %1 = "ttir.all_to_all"(%arg0, %0) <{cluster_axis = 1 : ui32, concat_dim = 1 : si32, split_count = 2 : si32, split_dim = 3 : si32}> : (tensor<1x1x32x32xf32>, tensor<1x2x32x16xf32>) -> tensor<1x2x32x16xf32>
+    // CHECK: "ttnn.all_to_all"
+    // CHECK-SAME: cluster_axis = 1 : ui32
+    // CHECK-SAME: concat_dim = 1 : si32
+    // CHECK-SAME: split_count = 2 : si32
+    // CHECK-SAME: split_dim = 3 : si32
+    return %1 : tensor<1x2x32x16xf32>
+  }
+}
+
+// -----
+
+module attributes {} {
+  // CHECK-LABEL: all_to_all_basic_2d
+  func.func public @all_to_all_basic_2d(%arg0: tensor<128x128xf32>) -> (tensor<128x128xf32> {jax.result_info = ""}) {
+    %0 = ttir.empty() : tensor<128x128xf32>
+    %1 = "ttir.all_to_all"(%arg0, %0) <{cluster_axis = 1 : ui32, concat_dim = 1 : si32, split_count = 2 : si32, split_dim = 1 : si32}> : (tensor<128x128xf32>, tensor<128x128xf32>) -> tensor<128x128xf32>
+    // CHECK: "ttnn.all_to_all"
+    // CHECK-SAME: cluster_axis = 1 : ui32
+    // CHECK-SAME: concat_dim = 1 : si32
+    // CHECK-SAME: split_count = 2 : si32
+    // CHECK-SAME: split_dim = 1 : si32
+    return %1 : tensor<128x128xf32>
+  }
+}
+
+// -----
+
+module attributes {} {
+  // CHECK-LABEL: all_to_all_different_dim_2d
+  func.func public @all_to_all_different_dim_2d(%arg0: tensor<128x128xf32>) -> (tensor<256x64xf32> {jax.result_info = ""}) {
+    %0 = ttir.empty() : tensor<256x64xf32>
+    %1 = "ttir.all_to_all"(%arg0, %0) <{cluster_axis = 1 : ui32, concat_dim = 0 : si32, split_count = 2 : si32, split_dim = 1 : si32}> : (tensor<128x128xf32>, tensor<256x64xf32>) -> tensor<256x64xf32>
+    // CHECK: "ttnn.all_to_all"
+    // CHECK-SAME: cluster_axis = 1 : ui32
+    // CHECK-SAME: concat_dim = 0 : si32
+    // CHECK-SAME: split_count = 2 : si32
+    // CHECK-SAME: split_dim = 1 : si32
+    return %1 : tensor<256x64xf32>
+  }
+}

--- a/test/ttmlir/Silicon/TTNN/llmbox/ccl/ccl_1x8.mlir
+++ b/test/ttmlir/Silicon/TTNN/llmbox/ccl/ccl_1x8.mlir
@@ -67,3 +67,29 @@ func.func public @collective_permute_cluster_1_partial_target_pairs(%arg0: tenso
   // CHECK: "ttnn.mesh_shard"
   return %5 : tensor<1x1x8192x512xf32>
 }
+
+func.func public @all_to_all_same_dim_cluster_1(%arg0: tensor<1x1x8192x512xf32>) -> (tensor<1x1x8192x512xf32> {jax.result_info = ""}) {
+  %0 = ttir.empty() : tensor<1x1x8192x64xf32>
+  %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 1, 8>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x8192x512xf32>, tensor<1x1x8192x64xf32>) -> tensor<1x1x8192x64xf32>
+  // CHECK: "ttnn.mesh_shard"
+  %2 = ttir.empty() : tensor<1x1x8192x64xf32>
+  %3 = "ttir.all_to_all"(%1, %2) <{cluster_axis = 1 : ui32, concat_dim = 2 : si32, split_count = 8 : si32, split_dim = 2 : si32}> : (tensor<1x1x8192x64xf32>, tensor<1x1x8192x64xf32>) -> tensor<1x1x8192x64xf32>
+  // CHECK: "ttnn.all_to_all"
+  %4 = ttir.empty() : tensor<1x1x8192x512xf32>
+  %5 = "ttir.mesh_shard"(%3, %4) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1, 1, 1, 8>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x8192x64xf32>, tensor<1x1x8192x512xf32>) -> tensor<1x1x8192x512xf32>
+  // CHECK: "ttnn.mesh_shard"
+  return %5 : tensor<1x1x8192x512xf32>
+}
+
+func.func public @all_to_all_different_dim_cluster_1(%arg0: tensor<1x1x8192x512xf32>) -> (tensor<1x1x1024x4096xf32> {jax.result_info = ""}) {
+  %0 = ttir.empty() : tensor<1x1x8192x64xf32>
+  %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 1, 8>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x8192x512xf32>, tensor<1x1x8192x64xf32>) -> tensor<1x1x8192x64xf32>
+  // CHECK: "ttnn.mesh_shard"
+  %2 = ttir.empty() : tensor<1x1x1024x512xf32>
+  %3 = "ttir.all_to_all"(%1, %2) <{cluster_axis = 1 : ui32, concat_dim = 3 : si32, split_count = 8 : si32, split_dim = 2 : si32}> : (tensor<1x1x8192x64xf32>, tensor<1x1x1024x512xf32>) -> tensor<1x1x1024x512xf32>
+  // CHECK: "ttnn.all_to_all"
+  %4 = ttir.empty() : tensor<1x1x1024x4096xf32>
+  %5 = "ttir.mesh_shard"(%3, %4) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1, 1, 1, 8>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x1024x512xf32>, tensor<1x1x1024x4096xf32>) -> tensor<1x1x1024x4096xf32>
+  // CHECK: "ttnn.mesh_shard"
+  return %5 : tensor<1x1x1024x4096xf32>
+}

--- a/test/ttmlir/Silicon/TTNN/llmbox/ccl/ccl_2x4.mlir
+++ b/test/ttmlir/Silicon/TTNN/llmbox/ccl/ccl_2x4.mlir
@@ -133,3 +133,55 @@ func.func public @collective_permute_cluster_0_partial_target_pairs(%arg0: tenso
   // CHECK: "ttnn.mesh_shard"
   return %5 : tensor<1x1x8192x512xf32>
 }
+
+func.func public @all_to_all_same_dim_cluster_0(%arg0: tensor<1x1x8192x512xf32>) -> (tensor<1x1x8192x512xf32> {jax.result_info = ""}) {
+  %0 = ttir.empty() : tensor<1x1x4096x128xf32>
+  %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 2, 4>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x8192x512xf32>, tensor<1x1x4096x128xf32>) -> tensor<1x1x4096x128xf32>
+  // CHECK: "ttnn.mesh_shard"
+  %2 = ttir.empty() : tensor<1x1x4096x128xf32>
+  %3 = "ttir.all_to_all"(%1, %2) <{cluster_axis = 0 : ui32, concat_dim = 2 : si32, split_count = 2 : si32, split_dim = 2 : si32}> : (tensor<1x1x4096x128xf32>, tensor<1x1x4096x128xf32>) -> tensor<1x1x4096x128xf32>
+  // CHECK: "ttnn.all_to_all"
+  %4 = ttir.empty() : tensor<1x1x8192x512xf32>
+  %5 = "ttir.mesh_shard"(%3, %4) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1, 1, 2, 4>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x4096x128xf32>, tensor<1x1x8192x512xf32>) -> tensor<1x1x8192x512xf32>
+  // CHECK: "ttnn.mesh_shard"
+  return %5 : tensor<1x1x8192x512xf32>
+}
+
+func.func public @all_to_all_same_dim_cluster_1(%arg0: tensor<1x1x8192x512xf32>) -> (tensor<1x1x8192x512xf32> {jax.result_info = ""}) {
+  %0 = ttir.empty() : tensor<1x1x4096x128xf32>
+  %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 2, 4>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x8192x512xf32>, tensor<1x1x4096x128xf32>) -> tensor<1x1x4096x128xf32>
+  // CHECK: "ttnn.mesh_shard"
+  %2 = ttir.empty() : tensor<1x1x4096x128xf32>
+  %3 = "ttir.all_to_all"(%1, %2) <{cluster_axis = 1 : ui32, concat_dim = 2 : si32, split_count = 4 : si32, split_dim = 2 : si32}> : (tensor<1x1x4096x128xf32>, tensor<1x1x4096x128xf32>) -> tensor<1x1x4096x128xf32>
+  // CHECK: "ttnn.all_to_all"
+  %4 = ttir.empty() : tensor<1x1x8192x512xf32>
+  %5 = "ttir.mesh_shard"(%3, %4) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1, 1, 2, 4>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x4096x128xf32>, tensor<1x1x8192x512xf32>) -> tensor<1x1x8192x512xf32>
+  // CHECK: "ttnn.mesh_shard"
+  return %5 : tensor<1x1x8192x512xf32>
+}
+
+func.func public @all_to_all_different_dim_cluster_0(%arg0: tensor<1x1x8192x512xf32>) -> (tensor<1x1x4096x1024xf32> {jax.result_info = ""}) {
+  %0 = ttir.empty() : tensor<1x1x4096x128xf32>
+  %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 2, 4>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x8192x512xf32>, tensor<1x1x4096x128xf32>) -> tensor<1x1x4096x128xf32>
+  // CHECK: "ttnn.mesh_shard"
+  %2 = ttir.empty() : tensor<1x1x2048x256xf32>
+  %3 = "ttir.all_to_all"(%1, %2) <{cluster_axis = 0 : ui32, concat_dim = 3 : si32, split_count = 2 : si32, split_dim = 2 : si32}> : (tensor<1x1x4096x128xf32>, tensor<1x1x2048x256xf32>) -> tensor<1x1x2048x256xf32>
+  // CHECK: "ttnn.all_to_all"
+  %4 = ttir.empty() : tensor<1x1x4096x1024xf32>
+  %5 = "ttir.mesh_shard"(%3, %4) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1, 1, 2, 4>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x2048x256xf32>, tensor<1x1x4096x1024xf32>) -> tensor<1x1x4096x1024xf32>
+  // CHECK: "ttnn.mesh_shard"
+  return %5 : tensor<1x1x4096x1024xf32>
+}
+
+func.func public @all_to_all_different_dim_cluster_1(%arg0: tensor<1x1x8192x512xf32>) -> (tensor<1x1x2048x2048xf32> {jax.result_info = ""}) {
+  %0 = ttir.empty() : tensor<1x1x4096x128xf32>
+  %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 2, 4>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x8192x512xf32>, tensor<1x1x4096x128xf32>) -> tensor<1x1x4096x128xf32>
+  // CHECK: "ttnn.mesh_shard"
+  %2 = ttir.empty() : tensor<1x1x1024x512xf32>
+  %3 = "ttir.all_to_all"(%1, %2) <{cluster_axis = 1 : ui32, concat_dim = 3 : si32, split_count = 4 : si32, split_dim = 2 : si32}> : (tensor<1x1x4096x128xf32>, tensor<1x1x1024x512xf32>) -> tensor<1x1x1024x512xf32>
+  // CHECK: "ttnn.all_to_all"
+  %4 = ttir.empty() : tensor<1x1x2048x2048xf32>
+  %5 = "ttir.mesh_shard"(%3, %4) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1, 1, 2, 4>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x1024x512xf32>, tensor<1x1x2048x2048xf32>) -> tensor<1x1x2048x2048xf32>
+  // CHECK: "ttnn.mesh_shard"
+  return %5 : tensor<1x1x2048x2048xf32>
+}

--- a/test/ttmlir/Silicon/TTNN/n300/ccl/ccl_1x2.mlir
+++ b/test/ttmlir/Silicon/TTNN/n300/ccl/ccl_1x2.mlir
@@ -68,6 +68,32 @@ func.func public @collective_permute_cluster_1_partial_target_pairs(%arg0: tenso
   return %5 : tensor<1x1x8192x512xf32>
 }
 
+func.func public @all_to_all_same_dim_cluster_axis_1(%arg0: tensor<1x1x8192x512xf32>) -> (tensor<1x1x8192x512xf32> {jax.result_info = ""}) {
+  %0 = ttir.empty() : tensor<1x1x8192x256xf32>
+  %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 1, 2>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x8192x512xf32>, tensor<1x1x8192x256xf32>) -> tensor<1x1x8192x256xf32>
+  // CHECK: "ttnn.mesh_shard"
+  %2 = ttir.empty() : tensor<1x1x8192x256xf32>
+  %3 = "ttir.all_to_all"(%1, %2) <{cluster_axis = 1 : ui32, concat_dim = 2 : si32, split_count = 2 : si32, split_dim = 2 : si32}> : (tensor<1x1x8192x256xf32>, tensor<1x1x8192x256xf32>) -> tensor<1x1x8192x256xf32>
+  // CHECK: "ttnn.all_to_all"
+  %4 = ttir.empty() : tensor<1x1x8192x512xf32>
+  %5 = "ttir.mesh_shard"(%3, %4) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1, 1, 1, 2>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x8192x256xf32>, tensor<1x1x8192x512xf32>) -> tensor<1x1x8192x512xf32>
+  // CHECK: "ttnn.mesh_shard"
+  return %5 : tensor<1x1x8192x512xf32>
+}
+
+func.func public @all_to_all_different_dim_cluster_axis_1(%arg0: tensor<1x1x8192x512xf32>) -> (tensor<1x1x4096x1024xf32> {jax.result_info = ""}) {
+  %0 = ttir.empty() : tensor<1x1x8192x256xf32>
+  %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 1, 2>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x8192x512xf32>, tensor<1x1x8192x256xf32>) -> tensor<1x1x8192x256xf32>
+  // CHECK: "ttnn.mesh_shard"
+  %2 = ttir.empty() : tensor<1x1x4096x512xf32>
+  %3 = "ttir.all_to_all"(%1, %2) <{cluster_axis = 1 : ui32, concat_dim = 3 : si32, split_count = 2 : si32, split_dim = 2 : si32}> : (tensor<1x1x8192x256xf32>, tensor<1x1x4096x512xf32>) -> tensor<1x1x4096x512xf32>
+  // CHECK: "ttnn.all_to_all"
+  %4 = ttir.empty() : tensor<1x1x4096x1024xf32>
+  %5 = "ttir.mesh_shard"(%3, %4) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1, 1, 1, 2>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x4096x512xf32>, tensor<1x1x4096x1024xf32>) -> tensor<1x1x4096x1024xf32>
+  // CHECK: "ttnn.mesh_shard"
+  return %5 : tensor<1x1x4096x1024xf32>
+}
+
 func.func public @main(%arg0: tensor<8192x784xf32> {mhlo.layout_mode = "default"}, %arg1: tensor<784x16384xf32> {mhlo.layout_mode = "default"}) -> (tensor<8192x16384xf32> {jax.result_info = "", mhlo.layout_mode = "default"}) {
   %0 = ttir.empty() : tensor<8192x392xf32>
   %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: -1, 1>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 2>, shard_type = #tt.shard_type<devices>}> : (tensor<8192x784xf32>, tensor<8192x392xf32>) -> tensor<8192x392xf32>

--- a/test/ttmlir/Silicon/TTNN/tg/ccl/ccl_1x32.mlir
+++ b/test/ttmlir/Silicon/TTNN/tg/ccl/ccl_1x32.mlir
@@ -64,3 +64,29 @@ func.func public @collective_permute_cluster_1_partial_target_pairs(%arg0: tenso
   // CHECK: "ttnn.mesh_shard"
   return %5 : tensor<1x1x8192x512xf32>
 }
+
+func.func public @all_to_all_same_dim(%arg0: tensor<1x1x8192x512xf32>) -> (tensor<1x1x8192x512xf32> {jax.result_info = ""}) {
+  %0 = ttir.empty() : tensor<1x1x8192x16xf32>
+  %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 1, 32>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x8192x512xf32>, tensor<1x1x8192x16xf32>) -> tensor<1x1x8192x16xf32>
+  // CHECK: "ttnn.mesh_shard"
+  %2 = ttir.empty() : tensor<1x1x8192x16xf32>
+  %3 = "ttir.all_to_all"(%1, %2) <{cluster_axis = 1 : ui32, concat_dim = 2 : si32, split_count = 32 : si32, split_dim = 2 : si32}> : (tensor<1x1x8192x16xf32>, tensor<1x1x8192x16xf32>) -> tensor<1x1x8192x16xf32>
+  // CHECK: "ttnn.all_to_all"
+  %4 = ttir.empty() : tensor<1x1x8192x512xf32>
+  %5 = "ttir.mesh_shard"(%3, %4) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1, 1, 1, 32>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x8192x16xf32>, tensor<1x1x8192x512xf32>) -> tensor<1x1x8192x512xf32>
+  // CHECK: "ttnn.mesh_shard"
+  return %5 : tensor<1x1x8192x512xf32>
+}
+
+func.func public @all_to_all_different_dim(%arg0: tensor<1x1x8192x512xf32>) -> (tensor<1x1x256x16384xf32> {jax.result_info = ""}) {
+  %0 = ttir.empty() : tensor<1x1x8192x16xf32>
+  %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 1, 32>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x8192x512xf32>, tensor<1x1x8192x16xf32>) -> tensor<1x1x8192x16xf32>
+  // CHECK: "ttnn.mesh_shard"
+  %2 = ttir.empty() : tensor<1x1x256x512xf32>
+  %3 = "ttir.all_to_all"(%1, %2) <{cluster_axis = 1 : ui32, concat_dim = 3 : si32, split_count = 32 : si32, split_dim = 2 : si32}> : (tensor<1x1x8192x16xf32>, tensor<1x1x256x512xf32>) -> tensor<1x1x256x512xf32>
+  // CHECK: "ttnn.all_to_all"
+  %4 = ttir.empty() : tensor<1x1x256x16384xf32>
+  %5 = "ttir.mesh_shard"(%3, %4) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1, 1, 1, 32>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x256x512xf32>, tensor<1x1x256x16384xf32>) -> tensor<1x1x256x16384xf32>
+  // CHECK: "ttnn.mesh_shard"
+  return %5 : tensor<1x1x256x16384xf32>
+}

--- a/test/ttmlir/Silicon/TTNN/tg/ccl/ccl_8x4.mlir
+++ b/test/ttmlir/Silicon/TTNN/tg/ccl/ccl_8x4.mlir
@@ -133,3 +133,55 @@ func.func public @collective_permute_cluster_0_partial_target_pairs(%arg0: tenso
   // CHECK: "ttnn.mesh_shard"
   return %5 : tensor<1x1x8192x512xf32>
 }
+
+func.func public @all_to_all_same_dim_cluster_axis_0(%arg0: tensor<1x1x8192x512xf32>) -> (tensor<1x1x8192x512xf32> {jax.result_info = ""}) {
+  %0 = ttir.empty() : tensor<1x1x1024x128xf32>
+  %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 8, 4>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x8192x512xf32>, tensor<1x1x1024x128xf32>) -> tensor<1x1x1024x128xf32>
+  // CHECK: "ttnn.mesh_shard"
+  %2 = ttir.empty() : tensor<1x1x1024x128xf32>
+  %3 = "ttir.all_to_all"(%1, %2) <{cluster_axis = 0 : ui32, concat_dim = 2 : si32, split_count = 8 : si32, split_dim = 2 : si32}> : (tensor<1x1x1024x128xf32>, tensor<1x1x1024x128xf32>) -> tensor<1x1x1024x128xf32>
+  // CHECK: "ttnn.all_to_all"
+  %4 = ttir.empty() : tensor<1x1x8192x512xf32>
+  %5 = "ttir.mesh_shard"(%3, %4) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1, 1, 8, 4>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x1024x128xf32>, tensor<1x1x8192x512xf32>) -> tensor<1x1x8192x512xf32>
+  // CHECK: "ttnn.mesh_shard"
+  return %5 : tensor<1x1x8192x512xf32>
+}
+
+func.func public @all_to_all_different_dim_cluster_axis_0(%arg0: tensor<1x1x8192x512xf32>) -> (tensor<1x1x1024x4096xf32> {jax.result_info = ""}) {
+  %0 = ttir.empty() : tensor<1x1x1024x128xf32>
+  %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 8, 4>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x8192x512xf32>, tensor<1x1x1024x128xf32>) -> tensor<1x1x1024x128xf32>
+  // CHECK: "ttnn.mesh_shard"
+  %2 = ttir.empty() : tensor<1x1x128x1024xf32>
+  %3 = "ttir.all_to_all"(%1, %2) <{cluster_axis = 0 : ui32, concat_dim = 3 : si32, split_count = 8 : si32, split_dim = 2 : si32}> : (tensor<1x1x1024x128xf32>, tensor<1x1x128x1024xf32>) -> tensor<1x1x128x1024xf32>
+  // CHECK: "ttnn.all_to_all"
+  %4 = ttir.empty() : tensor<1x1x1024x4096xf32>
+  %5 = "ttir.mesh_shard"(%3, %4) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1, 1, 8, 4>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x128x1024xf32>, tensor<1x1x1024x4096xf32>) -> tensor<1x1x1024x4096xf32>
+  // CHECK: "ttnn.mesh_shard"
+  return %5 : tensor<1x1x1024x4096xf32>
+}
+
+func.func public @all_to_all_same_dim_cluster_axis_1(%arg0: tensor<1x1x8192x512xf32>) -> (tensor<1x1x8192x512xf32> {jax.result_info = ""}) {
+  %0 = ttir.empty() : tensor<1x1x1024x128xf32>
+  %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 8, 4>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x8192x512xf32>, tensor<1x1x1024x128xf32>) -> tensor<1x1x1024x128xf32>
+  // CHECK: "ttnn.mesh_shard"
+  %2 = ttir.empty() : tensor<1x1x1024x128xf32>
+  %3 = "ttir.all_to_all"(%1, %2) <{cluster_axis = 1 : ui32, concat_dim = 2 : si32, split_count = 4 : si32, split_dim = 2 : si32}> : (tensor<1x1x1024x128xf32>, tensor<1x1x1024x128xf32>) -> tensor<1x1x1024x128xf32>
+  // CHECK: "ttnn.all_to_all"
+  %4 = ttir.empty() : tensor<1x1x8192x512xf32>
+  %5 = "ttir.mesh_shard"(%3, %4) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1, 1, 8, 4>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x1024x128xf32>, tensor<1x1x8192x512xf32>) -> tensor<1x1x8192x512xf32>
+  // CHECK: "ttnn.mesh_shard"
+  return %5 : tensor<1x1x8192x512xf32>
+}
+
+func.func public @all_to_all_different_dim_cluster_axis_1(%arg0: tensor<1x1x8192x512xf32>) -> (tensor<1x1x2048x2048xf32> {jax.result_info = ""}) {
+  %0 = ttir.empty() : tensor<1x1x1024x128xf32>
+  %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1, 8, 4>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x8192x512xf32>, tensor<1x1x1024x128xf32>) -> tensor<1x1x1024x128xf32>
+  // CHECK: "ttnn.mesh_shard"
+  %2 = ttir.empty() : tensor<1x1x256x512xf32>
+  %3 = "ttir.all_to_all"(%1, %2) <{cluster_axis = 1 : ui32, concat_dim = 3 : si32, split_count = 4 : si32, split_dim = 2 : si32}> : (tensor<1x1x1024x128xf32>, tensor<1x1x256x512xf32>) -> tensor<1x1x256x512xf32>
+  // CHECK: "ttnn.all_to_all"
+  %4 = ttir.empty() : tensor<1x1x2048x2048xf32>
+  %5 = "ttir.mesh_shard"(%3, %4) <{shard_dims = array<i64: 2, 3>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1, 1, 8, 4>, shard_type = #tt.shard_type<devices>}> : (tensor<1x1x256x512xf32>, tensor<1x1x2048x2048xf32>) -> tensor<1x1x2048x2048xf32>
+  // CHECK: "ttnn.mesh_shard"
+  return %5 : tensor<1x1x2048x2048xf32>
+}

--- a/tools/ttir-builder/builder.py
+++ b/tools/ttir-builder/builder.py
@@ -2115,3 +2115,24 @@ class TTIRBuilder:
             [input],
             kwargs=kwargs,
         )
+
+    def all_to_all(
+        self,
+        input: Operand,
+        split_dim: int,
+        concat_dim: int,
+        split_count: int,
+        cluster_axis: int,
+    ) -> OpView:
+        kwargs = {
+            "split_dim": split_dim,
+            "concat_dim": concat_dim,
+            "split_count": split_count,
+            "cluster_axis": cluster_axis,
+        }
+        return self.ccl_proxy(
+            all_to_all_golden,
+            ttir.AllToAllOp,
+            [input],
+            kwargs=kwargs,
+        )

--- a/tools/ttir-builder/ccl_golden.py
+++ b/tools/ttir-builder/ccl_golden.py
@@ -78,3 +78,19 @@ def collective_permute_golden(
 ) -> torch.Tensor:
     # Return a random torch.Tensor which has the correct shape and type after doing collective_permute on the input.
     return torch.randn(input.shape, dtype=input.dtype)
+
+
+def all_to_all_golden(
+    input: torch.Tensor,
+    mesh_shape: Tuple[int, int],
+    split_dim: int,
+    concat_dim: int,
+    split_count: int,
+    cluster_axis: int,
+) -> torch.Tensor:
+    # Return a random torch.Tensor which has the correct shape and type after doing all_gather on the input.
+    num_devices = mesh_shape[cluster_axis]
+    out_shape = list(input.shape)
+    out_shape[split_dim] //= num_devices
+    out_shape[concat_dim] *= num_devices
+    return torch.randn(out_shape, dtype=input.dtype)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/2597
closes #2597

### Problem description
The AllToAll CCL op is not supported anywhere in our stack: StableHLO -> TTIR -> TTNN all lack an AllToAll CCL operation. Since the TTNN API does not expose an AllToAll op, the tt-mlir runtime must provide a host-based fallback implementation.

### What's changed
 - Dialect Definition: Added an AllToAll op to the TTIR and TTNN dialects.
 - Conversion Patterns: Implemented StableHLO→TTIR and TTIR→TTNN conversion for AllToAll.
 - Runtime Support: Added a host-based fallback for AllToAll in the tt-mlir runtime.
 - TTIR Builder: Extended the Python TTIR builder with AllToAll op support.
 - Tests: Added dialect validation tests, Python golden tests, and silicon integration tests for TTIR AllToAll functionality.

### Checklist
- [x] New/Existing tests provide coverage for changes
