### PR TITLE
Add D2M typecast support

### DIFF
--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.h
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.h
@@ -238,6 +238,7 @@ inline bool isFloat(const DataType dtype) {
 }
 
 inline uint8_t getExponentSize(const DataType dtype) {
+  assert(isFloat(dtype));
   switch (dtype) {
   case DataType::Float16:
   case DataType::BFP_Float8:
@@ -256,6 +257,7 @@ inline uint8_t getExponentSize(const DataType dtype) {
 }
 
 inline uint8_t getMantissaSize(const DataType dtype) {
+  assert(isFloat(dtype));
   switch (dtype) {
   case DataType::Float32:
     return 23;

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.h
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.h
@@ -215,7 +215,7 @@ inline DataType elementTypeToDataType(Type elementType) {
 }
 
 // The BFP formats are TT home-brew, if not for them we could have used MLIR's
-// built-in FloatTypes and getWidth()/getFPMantissaWidth()
+// built-in FloatTypes and getWidth()/getFPMantissaWidth().
 inline bool isSignedInteger(const DataType dtype) {
   return dtype == DataType::Int32;
 }

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.h
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.h
@@ -298,7 +298,6 @@ inline uint8_t getNumberOfBits(const DataType dtype) {
   case DataType::BFP_BFloat2:
     return 2;
   }
-  llvm_unreachable("Unexpected DataType");
 }
 
 } // namespace mlir::tt

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.h
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.h
@@ -213,6 +213,94 @@ inline DataType elementTypeToDataType(Type elementType) {
 
   llvm_unreachable("Unsupported element type.");
 }
+
+// The BFP formats are TT home-brew, if not for them we could have used MLIR's
+// built-in FloatTypes and getWidth()/getFPMantissaWidth()
+inline bool isSignedInteger(const DataType dtype) {
+  return dtype == DataType::Int32;
+}
+
+inline bool isFloat(const DataType dtype) {
+  switch (dtype) {
+  case DataType::Float32:
+  case DataType::Float16:
+  case DataType::BFloat16:
+  case DataType::BFP_Float8:
+  case DataType::BFP_BFloat8:
+  case DataType::BFP_Float4:
+  case DataType::BFP_BFloat4:
+  case DataType::BFP_Float2:
+  case DataType::BFP_BFloat2:
+    return true;
+  default:
+    return false;
+  }
+}
+
+inline uint8_t getExponentSize(const DataType dtype) {
+  switch (dtype) {
+  case DataType::Float16:
+  case DataType::BFP_Float8:
+  case DataType::BFP_Float4:
+  case DataType::BFP_Float2:
+    return 5;
+  case DataType::Float32:
+  case DataType::BFloat16:
+  case DataType::BFP_BFloat8:
+  case DataType::BFP_BFloat4:
+  case DataType::BFP_BFloat2:
+    return 8;
+  default:
+    return 0;
+  }
+}
+
+inline uint8_t getMantissaSize(const DataType dtype) {
+  switch (dtype) {
+  case DataType::Float32:
+    return 23;
+  case DataType::Float16:
+    return 10;
+  case DataType::BFloat16:
+    return 7;
+  case DataType::BFP_Float8:
+  case DataType::BFP_BFloat8:
+    return 7;
+  case DataType::BFP_Float4:
+  case DataType::BFP_BFloat4:
+    return 3;
+  case DataType::BFP_Float2:
+  case DataType::BFP_BFloat2:
+    return 1;
+  default:
+    return 0;
+  }
+}
+
+inline uint8_t getNumberOfBits(const DataType dtype) {
+  switch (dtype) {
+  case DataType::Float32:
+  case DataType::UInt32:
+  case DataType::Int32:
+    return 32;
+  case DataType::Float16:
+  case DataType::BFloat16:
+  case DataType::UInt16:
+    return 16;
+  case DataType::BFP_Float8:
+  case DataType::BFP_BFloat8:
+  case DataType::UInt8:
+    return 8;
+  case DataType::BFP_Float4:
+  case DataType::BFP_BFloat4:
+    return 4;
+  case DataType::BFP_Float2:
+  case DataType::BFP_BFloat2:
+    return 2;
+  }
+  llvm_unreachable("Unexpected DataType");
+}
+
 } // namespace mlir::tt
 
 #include "ttmlir/Dialect/TT/IR/TTAttrInterfaces.h.inc"

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
@@ -219,6 +219,16 @@ def TTIR_TileUntilizeBlockOp : TTIR_GenericRegionComputeOp<"tile_untilize_block"
     let hasVerifier = 1;
 }
 
+def TTIR_TileTypecastOp : TTIR_GenericRegionComputeOp<"tile_typecast"> {
+    let summary = "TTIR Tile Typecast Op";
+    let description = [{
+        The `tile_typecast` operation casts the input tile to the desired dataformat.
+    }];
+
+    let arguments = (ins TT_Tile:$input);
+    let results = (outs TT_Tile:$result);
+}
+
 
 //===----------------------------------------------------------------------===//
 // TTIR Generic Region Datamovement Ops (Used in TTMetal Lowering)

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -456,8 +456,10 @@ class TTIR_ElementwiseUnaryOp<string mnemonic, list<Trait> traits = []> :
       Eltwise unary op.
     }];
 
-    let arguments = (ins AnyRankedTensor:$input,
-                         AnyRankedTensor:$output);
+    dag commonArgs = (ins AnyRankedTensor:$input,
+                          AnyRankedTensor:$output);
+
+    let arguments = commonArgs;
 
     let results = (outs AnyRankedTensor:$result);
 
@@ -642,6 +644,9 @@ def TTIR_TypecastOp: TTIR_ElementwiseUnaryOp<"typecast"> {
     let description = [{
       Eltwise cast operation.
     }];
+
+    let arguments = !con(commonArgs,
+                         (ins DefaultValuedAttr<BoolAttr, "false">:$conservative_folding));
 
     let hasFolder = 1;
     let hasCanonicalizeMethod = 1;

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -82,7 +82,7 @@ def TTKernel_PackTileOp : TTKernel_Op<"pack_tile"> {
     let arguments = (ins IndexLike:$dst_index, TTKernel_CB:$out_cb, IndexLike:$out_index, DefaultValuedAttr<BoolAttr, "false">:$out_of_order);
 }
 
-def TTKernel_CopyTileInitOp : TTKernel_Op<"copy_tile_init"> {
+def TTKernel_CopyTileInitOp : TTKernel_InitOp<"copy_tile_init"> {
     let summary = "Perform the init for copy tile. This does not reconfigure the unpacker data types.";
     let description = [{
       Must be called before copy_tile.
@@ -106,6 +106,29 @@ def TTKernel_CopyTileOp : TTKernel_Op<"copy_tile"> {
     }];
 
     let arguments = (ins TTKernel_CB:$cb0, IndexLike:$tile_index_cb, IndexLike:$tile_index_dst);
+}
+
+def TTKernel_TypecastTileInitOp : TTKernel_InitOp<"typecast_tile_init"> {
+    let summary = "Init function for typecast_tile operation. Refer to documentation for any init function.";
+    let description = [{
+      Must be run before typecast_tile.
+    }];
+
+    let arguments = (ins);
+}
+
+def TTKernel_TypecastTileOp : TTKernel_SFPUOp<"typecast_tile", [TTKernel_UnaryOpTrait]> {
+    let summary = "Cast the dataformat of the tile in the DST at specified index.";
+    let description = [{
+      Performs element-wise typecast operation
+      DST[dst0_index] <- typecast<in_dataformat, out_dataformat>(DST[dst0_index])
+      on DST register operands. The DST register buffer must be in
+      acquired state via *tile_regs_acquire* call.
+    }];
+
+    let arguments = (ins IndexLike:$dst0_index,
+                         TT_DataTypeAttr:$in_dtype,
+                         TT_DataTypeAttr:$out_dtype);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/TTIRToTTIRGeneric/TTIRToTTIRGeneric.cpp
+++ b/lib/Conversion/TTIRToTTIRGeneric/TTIRToTTIRGeneric.cpp
@@ -632,7 +632,9 @@ void populateTTIRToTTIRGenericPatterns(MLIRContext *ctx,
     TTIRNamedElementwiseRewriter<ttir::SinOp,       ttir::TileSinOp>,
     // Reductions.
     TTIRNamedReductionRewriter<ttir::SumOp,         ttir::TileReduceSumOp>,
-    TTIRNamedReductionRewriter<ttir::MaxOp,         ttir::TileReduceMaxOp>
+    TTIRNamedReductionRewriter<ttir::MaxOp,         ttir::TileReduceMaxOp>,
+    // Data movement.
+    TTIRNamedElementwiseRewriter<ttir::TypecastOp,  ttir::TileTypecastOp>
   >(typeConverter, ctx, deviceGridRank);
 
   // Matmul.

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -2006,7 +2006,8 @@ bool isNarrowingConversion(const ::mlir::tt::DataType srcDtype,
   if (!srcIsSigned && dstIsSigned) {
     return srcNumberOfBits >= dstNumberOfBits;
   }
-  return false;
+  assert(srcIsSigned && !dstIsSigned);
+  return true;
 }
 
 } // namespace

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -1989,25 +1989,28 @@ static bool isNarrowingConversion(const ::mlir::tt::DataType srcDtype,
            srcMantissaSize > dstMantissaSize;
   }
 
-  // With the same number of bits, the FP type has bigger range but lost too
-  // much precision when representing the integer type
+  // For integer to FP, it is narrowing if the FP type has fewer bits in its
+  // mantissa than the integer type's magnitude bits.
   if (!srcIsFloat && dstIsFloat) {
-    return srcNumberOfBits >= dstNumberOfBits;
+    if (isSignedInteger(srcDtype)) {
+      return srcNumberOfBits - 1 > getMantissaSize(dstDtype);
+    }
+    return srcNumberOfBits > getMantissaSize(dstDtype);
   }
 
   assert(!srcIsFloat && !dstIsFloat);
   const auto srcIsSigned = isSignedInteger(srcDtype);
   const auto dstIsSigned = isSignedInteger(dstDtype);
-  // When signedness are the same, reducing the number of bits is narrowing
+  // When signedness are the same, reducing the number of bits is narrowing.
   if (srcIsSigned == dstIsSigned) {
     return srcNumberOfBits > dstNumberOfBits;
   }
-  // Unsigned->Signed is narrowing when the signed type can't hold the largest
+  // Unsigned->Signed is narrowing when the signed type can't hold the largest.
   // value of the unsigned type
   if (!srcIsSigned && dstIsSigned) {
     return srcNumberOfBits >= dstNumberOfBits;
   }
-  // Signed->Unsigned is always narrowing
+  // Signed->Unsigned is always narrowing.
   assert(srcIsSigned && !dstIsSigned);
   return true;
 }
@@ -2031,19 +2034,13 @@ mlir::tt::ttir::TypecastOp::canonicalize(mlir::tt::ttir::TypecastOp op,
     // Disable folding if it has the potential to cause too much numerical
     // differences.
     auto dtypeIn =
-        elementTypeToDataType(mlir::cast<ttir::TypecastOp>(producerOp)
-                                  .getInput()
-                                  .getType()
-                                  .getElementType());
-    auto dtypeMid = elementTypeToDataType(
-        mlir::cast<ttir::TypecastOp>(op).getInput().getType().getElementType());
-    auto dtypeOut = elementTypeToDataType(
-        mlir::cast<ttir::TypecastOp>(op).getType().getElementType());
+        elementTypeToDataType(producerOp.getInput().getType().getElementType());
+    auto dtypeMid =
+        elementTypeToDataType(op.getInput().getType().getElementType());
+    auto dtypeOut = elementTypeToDataType(op.getType().getElementType());
 
     assert(dtypeMid ==
-           elementTypeToDataType(mlir::cast<ttir::TypecastOp>(producerOp)
-                                     .getType()
-                                     .getElementType()));
+           elementTypeToDataType(producerOp.getType().getElementType()));
 
     // If the 1st Op is narrowing and the 2nd Op is widening, we shouldn't fold.
     // FP->Int->FP is special and should never fold, due to its truncation
@@ -2057,7 +2054,7 @@ mlir::tt::ttir::TypecastOp::canonicalize(mlir::tt::ttir::TypecastOp op,
     }
   }
 
-  // The resulting Op is conservative iff both typecast ops were conservative
+  // The resulting Op is conservative iff both typecast ops were conservative.
   ttir::utils::replaceOpWithNewDPSOp<ttir::TypecastOp>(
       rewriter, op, op.getType(), producerOp.getInput(),
       op.getConservativeFolding() && producerOp.getConservativeFolding());

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -2056,8 +2056,10 @@ mlir::tt::ttir::TypecastOp::canonicalize(mlir::tt::ttir::TypecastOp op,
     }
   }
 
+  // The resulting Op is conservative iff both typecast ops were conservative
   ttir::utils::replaceOpWithNewDPSOp<ttir::TypecastOp>(
-      rewriter, op, op.getType(), producerOp.getInput());
+      rewriter, op, op.getType(), producerOp.getInput(),
+      op.getConservativeFolding() && producerOp.getConservativeFolding());
 
   return mlir::success();
 }

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -1969,10 +1969,8 @@ mlir::OpFoldResult mlir::tt::ttir::TypecastOp::fold(FoldAdaptor adaptor) {
   return {};
 }
 
-namespace {
-
-bool isNarrowingConversion(const ::mlir::tt::DataType srcDtype,
-                           const ::mlir::tt::DataType dstDtype) {
+static bool isNarrowingConversion(const ::mlir::tt::DataType srcDtype,
+                                  const ::mlir::tt::DataType dstDtype) {
   const bool srcIsFloat = isFloat(srcDtype);
   const bool dstIsFloat = isFloat(dstDtype);
   const auto srcNumberOfBits = getNumberOfBits(srcDtype);
@@ -2009,8 +2007,6 @@ bool isNarrowingConversion(const ::mlir::tt::DataType srcDtype,
   assert(srcIsSigned && !dstIsSigned);
   return true;
 }
-
-} // namespace
 
 // TypecastOp canonicalization method
 ::llvm::LogicalResult

--- a/lib/Target/TTKernel/TTKernelToCpp.cpp
+++ b/lib/Target/TTKernel/TTKernelToCpp.cpp
@@ -87,6 +87,9 @@ public:
       builder->create<emitc::IncludeOp>(
           loc, "compute_kernel_api/eltwise_unary/trigonometry.h",
           /*isStandard=*/false);
+      builder->create<emitc::IncludeOp>(
+          loc, "compute_kernel_api/eltwise_unary/typecast.h",
+          /*isStandard=*/false);
       // Must define macros REDUCE_OP and REDUCE_DIM before including reduce.h
       // because they are default template parameters values in reduce api.
       builder->create<emitc::VerbatimOp>(loc,

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -94,6 +94,30 @@ module {
       // CHECK-SAME: #emitc.opaque<"static_cast<std::underlying_type_t<DataFormat>>(DataFormat::Float32)">
       // CHECK-SAME: #emitc.opaque<"static_cast<std::underlying_type_t<DataFormat>>(DataFormat::Float16_b)">
       "ttkernel.typecast_tile"(%dst0_index) <{in_dtype = #tt.supportedDataTypes<f32>, out_dtype = #tt.supportedDataTypes<bf16>}> : (i32) -> ()
+      // CHECK: emitc.call_opaque "typecast_tile"(%[[DST0_INDEX]]) {template_args =
+      // CHECK-SAME: #emitc.opaque<"static_cast<std::underlying_type_t<DataFormat>>(DataFormat::Float16)">
+      // CHECK-SAME: #emitc.opaque<"static_cast<std::underlying_type_t<DataFormat>>(DataFormat::Int32)">
+      "ttkernel.typecast_tile"(%dst0_index) <{in_dtype = #tt.supportedDataTypes<f16>, out_dtype = #tt.supportedDataTypes<si32>}> : (i32) -> ()
+      // CHECK: emitc.call_opaque "typecast_tile"(%[[DST0_INDEX]]) {template_args =
+      // CHECK-SAME: #emitc.opaque<"static_cast<std::underlying_type_t<DataFormat>>(DataFormat::Bfp8_b)">
+      // CHECK-SAME: #emitc.opaque<"static_cast<std::underlying_type_t<DataFormat>>(DataFormat::Bfp8)">
+      "ttkernel.typecast_tile"(%dst0_index) <{in_dtype = #tt.supportedDataTypes<bfp_bf8>, out_dtype = #tt.supportedDataTypes<bfp_f8>}> : (i32) -> ()
+      // CHECK: emitc.call_opaque "typecast_tile"(%[[DST0_INDEX]]) {template_args =
+      // CHECK-SAME: #emitc.opaque<"static_cast<std::underlying_type_t<DataFormat>>(DataFormat::Bfp4_b)">
+      // CHECK-SAME: #emitc.opaque<"static_cast<std::underlying_type_t<DataFormat>>(DataFormat::Bfp4)">
+      "ttkernel.typecast_tile"(%dst0_index) <{in_dtype = #tt.supportedDataTypes<bfp_bf4>, out_dtype = #tt.supportedDataTypes<bfp_f4>}> : (i32) -> ()
+      // CHECK: emitc.call_opaque "typecast_tile"(%[[DST0_INDEX]]) {template_args =
+      // CHECK-SAME: #emitc.opaque<"static_cast<std::underlying_type_t<DataFormat>>(DataFormat::Bfp2_b)">
+      // CHECK-SAME: #emitc.opaque<"static_cast<std::underlying_type_t<DataFormat>>(DataFormat::Bfp2)">
+      "ttkernel.typecast_tile"(%dst0_index) <{in_dtype = #tt.supportedDataTypes<bfp_bf2>, out_dtype = #tt.supportedDataTypes<bfp_f2>}> : (i32) -> ()
+      // CHECK: emitc.call_opaque "typecast_tile"(%[[DST0_INDEX]]) {template_args =
+      // CHECK-SAME: #emitc.opaque<"static_cast<std::underlying_type_t<DataFormat>>(DataFormat::UInt32)">
+      // CHECK-SAME: #emitc.opaque<"static_cast<std::underlying_type_t<DataFormat>>(DataFormat::UInt16)">
+      "ttkernel.typecast_tile"(%dst0_index) <{in_dtype = #tt.supportedDataTypes<u32>, out_dtype = #tt.supportedDataTypes<u16>}> : (i32) -> ()
+      // CHECK: emitc.call_opaque "typecast_tile"(%[[DST0_INDEX]]) {template_args =
+      // CHECK-SAME: #emitc.opaque<"static_cast<std::underlying_type_t<DataFormat>>(DataFormat::UInt16)">
+      // CHECK-SAME: #emitc.opaque<"static_cast<std::underlying_type_t<DataFormat>>(DataFormat::UInt8)">
+      "ttkernel.typecast_tile"(%dst0_index) <{in_dtype = #tt.supportedDataTypes<u16>, out_dtype = #tt.supportedDataTypes<u8>}> : (i32) -> ()
       return
     }
 

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -79,6 +79,24 @@ module {
       return
     }
 
+    // CHECK-LABEL: func @typecast_tile_init
+    func.func @typecast_tile_init() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: emitc.call_opaque "typecast_tile_init"() : () -> ()
+      "ttkernel.typecast_tile_init"() : () -> ()
+      return
+    }
+
+    // CHECK-LABEL: func @typecast_tile
+    func.func @typecast_tile() -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[DST0_INDEX:.*]] = "emitc.constant"
+      %dst0_index = arith.constant 1 : i32
+      // CHECK: emitc.call_opaque "typecast_tile"(%[[DST0_INDEX]]) {template_args =
+      // CHECK-SAME: #emitc.opaque<"static_cast<std::underlying_type_t<DataFormat>>(DataFormat::Float32)">
+      // CHECK-SAME: #emitc.opaque<"static_cast<std::underlying_type_t<DataFormat>>(DataFormat::Float16_b)">
+      "ttkernel.typecast_tile"(%dst0_index) <{in_dtype = #tt.supportedDataTypes<f32>, out_dtype = #tt.supportedDataTypes<bf16>}> : (i32) -> ()
+      return
+    }
+
   } // module
 
   //===----------------------------------------------------------------------===//

--- a/test/ttmlir/Conversion/TosaToTTIR/elementwise_unary/cast.mlir
+++ b/test/ttmlir/Conversion/TosaToTTIR/elementwise_unary/cast.mlir
@@ -3,7 +3,7 @@ module attributes {} {
   func.func @test_cast(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xbf16> {
     %0 = tosa.cast %arg0 : (tensor<13x21x3xf32>) -> tensor<13x21x3xbf16>
     // CHECK: [[VAL0:%[0-9]+]] = ttir.empty() : [[TENSOR_SIZE:tensor<13x21x3xbf16>]]
-    // CHECK: [[VAL1:%[0-9]+]] = "ttir.typecast"(%arg{{[0-9]+}}, [[VAL0]]) : (tensor<13x21x3xf32>, [[TENSOR_SIZE]]) -> [[TENSOR_SIZE]]
+    // CHECK: [[VAL1:%[0-9]+]] = "ttir.typecast"(%arg{{[0-9]+}}, [[VAL0]]) <{conservative_folding = false}> : (tensor<13x21x3xf32>, [[TENSOR_SIZE]]) -> [[TENSOR_SIZE]]
     return %0 : tensor<13x21x3xbf16>
     // CHECK: return [[VAL1]] : [[TENSOR_SIZE]]
   }

--- a/test/ttmlir/Dialect/TTIR/data_movement/typecast/typecast_folding.mlir
+++ b/test/ttmlir/Dialect/TTIR/data_movement/typecast/typecast_folding.mlir
@@ -2,7 +2,8 @@
 
 module attributes {} {
     // Test case to verify the folding of typecast operation.
-    func.func @typecast_folding(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
+    // CHECK-LABEL: typecast_folding_identity
+    func.func @typecast_folding_identity(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
         // Verify that we fold the typecast when we try to cast to the same data type.
         // CHECK: return %arg0 : tensor<64x128xf32>
         %0 = "ttir.empty"() : () -> tensor<64x128xf32>
@@ -10,20 +11,104 @@ module attributes {} {
         return %1 : tensor<64x128xf32>
     }
 
-    // Test case to verify consecutive typecast op folding.
-    func.func @typecast_folding_consecutive_typecasts(%arg0: tensor<64x128xf32>) -> tensor<64x128xbf16> {
-        // Verify that we fold two consecutive typecast ops into a single one.
+    // Test case to verify consecutive narrowing typecast op folding.
+    // CHECK-LABEL: typecast_folding_consecutive_narrowing_typecasts
+    func.func @typecast_folding_consecutive_narrowing_typecasts(%arg0: tensor<64x128xf32>) -> tensor<64x128xi32> {
+        // Verify that we fold two consecutive narrowing typecast ops into a single one.
         // CHECK: ttir.typecast
-        // CHECK-SAME: -> tensor<64x128xbf16>
+        // CHECK-SAME: -> tensor<64x128xi32>
+        // CHECK-NOT: ttir.typecast
+        %0 = "ttir.empty"() : () -> tensor<64x128xbf16>
+        %1 = "ttir.typecast"(%arg0, %0) : (tensor<64x128xf32>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+        %2 = "ttir.empty"() : () -> tensor<64x128xi32>
+        %3 = "ttir.typecast"(%1, %2) : (tensor<64x128xbf16>, tensor<64x128xi32>) -> tensor<64x128xi32>
+        return %3 : tensor<64x128xi32>
+    }
+
+    // Test case to verify consecutive widening typecast op folding.
+    // CHECK-LABEL: typecast_folding_consecutive_widening_typecasts
+    func.func @typecast_folding_consecutive_widening_typecasts(%arg0: tensor<64x128xi8>) -> tensor<64x128xf32> {
+        // Verify that we fold two consecutive narrowing typecast ops into a single one.
+        // CHECK: ttir.typecast
+        // CHECK-SAME: -> tensor<64x128xf32>
+        // CHECK-NOT: ttir.typecast
+        %0 = "ttir.empty"() : () -> tensor<64x128xbf16>
+        %1 = "ttir.typecast"(%arg0, %0) : (tensor<64x128xi8>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+        %2 = "ttir.empty"() : () -> tensor<64x128xf32>
+        %3 = "ttir.typecast"(%1, %2) : (tensor<64x128xbf16>, tensor<64x128xf32>) -> tensor<64x128xf32>
+        return %3 : tensor<64x128xf32>
+    }
+
+    // Test case to verify widening-then-narrowing typecast op folding.
+    // CHECK-LABEL: typecast_folding_widening_then_narrowing_typecasts
+    func.func @typecast_folding_widening_then_narrowing_typecasts(%arg0: tensor<64x128xbf16>) -> tensor<64x128xf16> {
+        // Verify that we fold widening-then-narrowing typecast ops into a single one.
+        // CHECK: ttir.typecast
+        // CHECK-SAME: -> tensor<64x128xf16>
+        // CHECK-NOT: ttir.typecast
+        %0 = "ttir.empty"() : () -> tensor<64x128xf32>
+        %1 = "ttir.typecast"(%arg0, %0) : (tensor<64x128xbf16>, tensor<64x128xf32>) -> tensor<64x128xf32>
+        %2 = "ttir.empty"() : () -> tensor<64x128xf16>
+        %3 = "ttir.typecast"(%1, %2) : (tensor<64x128xf32>, tensor<64x128xf16>) -> tensor<64x128xf16>
+        return %3 : tensor<64x128xf16>
+    }
+
+    // Test case to verify that we do fold consecutive FP -> Int -> FP typecast ops.
+    // CHECK-LABEL: typecast_folding_decimal_truncating_typecasts
+    func.func @typecast_folding_decimal_truncating_typecasts(%arg0: tensor<64x128xbf16>) -> tensor<64x128xf32> {
+        // CHECK: ttir.typecast
+        // CHECK-SAME: -> tensor<64x128xf32>
         // CHECK-NOT: ttir.typecast
         %0 = "ttir.empty"() : () -> tensor<64x128xi32>
-        %1 = "ttir.typecast"(%arg0, %0) : (tensor<64x128xf32>, tensor<64x128xi32>) -> tensor<64x128xi32>
-        %2 = "ttir.empty"() : () -> tensor<64x128xbf16>
-        %3 = "ttir.typecast"(%1, %2) : (tensor<64x128xi32>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
-        return %3 : tensor<64x128xbf16>
+        %1 = "ttir.typecast"(%arg0, %0) : (tensor<64x128xbf16>, tensor<64x128xi32>) -> tensor<64x128xi32>
+        %2 = "ttir.empty"() : () -> tensor<64x128xf32>
+        %3 = "ttir.typecast"(%1, %2) : (tensor<64x128xi32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+        return %3 : tensor<64x128xf32>
+    }
+
+    // Test case to verify that we do fold consecutive narrowing-then-widening typecast ops.
+    // CHECK-LABEL: typecast_folding_narrowing_then_widening_typecasts
+    func.func @typecast_folding_narrowing_then_widening_typecasts(%arg0: tensor<64x128xf16>) -> tensor<64x128xf32> {
+        // CHECK: ttir.typecast
+        // CHECK-SAME: -> tensor<64x128xf32>
+        // CHECK-NOT: ttir.typecast
+        %0 = "ttir.empty"() : () -> tensor<64x128xbf16>
+        %1 = "ttir.typecast"(%arg0, %0) : (tensor<64x128xf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+        %2 = "ttir.empty"() : () -> tensor<64x128xf32>
+        %3 = "ttir.typecast"(%1, %2) : (tensor<64x128xbf16>, tensor<64x128xf32>) -> tensor<64x128xf32>
+        return %3 : tensor<64x128xf32>
+    }
+
+    // Test case to verify that we do not fold consecutive typecast ops if it's FP -> Int -> FP and we're in conservative mode.
+    // CHECK-LABEL: typecast_folding_decimal_truncating_typecasts_conservative
+    func.func @typecast_folding_decimal_truncating_typecasts_conservative(%arg0: tensor<64x128xbf16>) -> tensor<64x128xf32> {
+        // CHECK: ttir.typecast
+        // CHECK-SAME: -> tensor<64x128xi32>
+        // CHECK: ttir.typecast
+        // CHECK-SAME: -> tensor<64x128xf32>
+        %0 = "ttir.empty"() : () -> tensor<64x128xi32>
+        %1 = "ttir.typecast"(%arg0, %0) <{conservative_folding = true}> : (tensor<64x128xbf16>, tensor<64x128xi32>) -> tensor<64x128xi32>
+        %2 = "ttir.empty"() : () -> tensor<64x128xf32>
+        %3 = "ttir.typecast"(%1, %2) : (tensor<64x128xi32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+        return %3 : tensor<64x128xf32>
+    }
+
+    // Test case to verify that we do not fold consecutive typecast ops if it's narrowing-then-widening and we're in conservative mode.
+    // CHECK-LABEL: typecast_folding_narrowing_then_widening_typecasts_conservative
+    func.func @typecast_folding_narrowing_then_widening_typecasts_conservative(%arg0: tensor<64x128xf16>) -> tensor<64x128xf32> {
+        // CHECK: ttir.typecast
+        // CHECK-SAME: -> tensor<64x128xbf16>
+        // CHECK: ttir.typecast
+        // CHECK-SAME: -> tensor<64x128xf32>
+        %0 = "ttir.empty"() : () -> tensor<64x128xbf16>
+        %1 = "ttir.typecast"(%arg0, %0) : (tensor<64x128xf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+        %2 = "ttir.empty"() : () -> tensor<64x128xf32>
+        %3 = "ttir.typecast"(%1, %2) <{conservative_folding = true}> : (tensor<64x128xbf16>, tensor<64x128xf32>) -> tensor<64x128xf32>
+        return %3 : tensor<64x128xf32>
     }
 
     // Test case to verify that we do not fold consecutive typecast ops if the first typecast have more than a single use.
+    // CHECK-LABEL: typecast_folding_consecutive_typecasts_with_multiple_uses
     func.func @typecast_folding_consecutive_typecasts_with_multiple_uses(%arg0: tensor<64x128xf32>) -> (tensor<64x128xbf16>, tensor<64x128xi32>) {
         // Verify that both typecasts exists.
         // CHECK: ttir.typecast

--- a/test/ttmlir/Dialect/TTIR/data_movement/typecast/typecast_folding.mlir
+++ b/test/ttmlir/Dialect/TTIR/data_movement/typecast/typecast_folding.mlir
@@ -146,6 +146,62 @@ module attributes {} {
         return %3 : tensor<64x128xui8>
     }
 
+    // Test case to verify that two conservative typecast ops folds into a conservative typecast op.
+    // CHECK-LABEL: typecast_folding_consecutive_conservative_typecasts
+    func.func @typecast_folding_consecutive_conservative_typecasts(%arg0: tensor<64x128xui8>) -> tensor<64x128xf32> {
+        // CHECK: ttir.typecast
+        // CHECK-SAME: <{conservative_folding = true}>
+        // CHECK-SAME: -> tensor<64x128xf32>
+        // CHECK-NOT: ttir.typecast
+        %0 = "ttir.empty"() : () -> tensor<64x128xf16>
+        %1 = "ttir.typecast"(%arg0, %0) <{conservative_folding = true}> : (tensor<64x128xui8>, tensor<64x128xf16>) -> tensor<64x128xf16>
+        %2 = "ttir.empty"() : () -> tensor<64x128xf32>
+        %3 = "ttir.typecast"(%1, %2) <{conservative_folding = true}> : (tensor<64x128xf16>, tensor<64x128xf32>) -> tensor<64x128xf32>
+        return %3 : tensor<64x128xf32>
+    }
+
+    // Test case to verify that a conservative and a non-conservative typecast ops folds into a non-conservative typecast op.
+    // CHECK-LABEL: typecast_folding_consecutive_conservative_and_non_conservative_typecasts
+    func.func @typecast_folding_consecutive_conservative_and_non_conservative_typecasts(%arg0: tensor<64x128xf32>) -> tensor<64x128xui16> {
+        // CHECK: ttir.typecast
+        // CHECK-SAME: <{conservative_folding = false}>
+        // CHECK-SAME: -> tensor<64x128xui16>
+        // CHECK-NOT: ttir.typecast
+        %0 = "ttir.empty"() : () -> tensor<64x128xbf16>
+        %1 = "ttir.typecast"(%arg0, %0) <{conservative_folding = true}> : (tensor<64x128xf32>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+        %2 = "ttir.empty"() : () -> tensor<64x128xui16>
+        %3 = "ttir.typecast"(%1, %2) <{conservative_folding = false}> : (tensor<64x128xbf16>, tensor<64x128xui16>) -> tensor<64x128xui16>
+        return %3 : tensor<64x128xui16>
+    }
+
+    // Test case to verify that a non-conservative and a conservative typecast ops folds into a non-conservative typecast op.
+    // CHECK-LABEL: typecast_folding_consecutive_non_conservative_and_conservative_typecasts
+    func.func @typecast_folding_consecutive_non_conservative_and_conservative_typecasts(%arg0: tensor<64x128xf32>) -> tensor<64x128xui16> {
+        // CHECK: ttir.typecast
+        // CHECK-SAME: <{conservative_folding = false}>
+        // CHECK-SAME: -> tensor<64x128xui16>
+        // CHECK-NOT: ttir.typecast
+        %0 = "ttir.empty"() : () -> tensor<64x128xi32>
+        %1 = "ttir.typecast"(%arg0, %0) <{conservative_folding = false}> : (tensor<64x128xf32>, tensor<64x128xi32>) -> tensor<64x128xi32>
+        %2 = "ttir.empty"() : () -> tensor<64x128xui16>
+        %3 = "ttir.typecast"(%1, %2) <{conservative_folding = true}> : (tensor<64x128xi32>, tensor<64x128xui16>) -> tensor<64x128xui16>
+        return %3 : tensor<64x128xui16>
+    }
+
+    // Test cast to very that two non-conservative typecast ops folds into a non-conservative typecast op.
+    // CHECK-LABEL: typecast_folding_consecutive_non_conservative_typecasts
+    func.func @typecast_folding_consecutive_non_conservative_typecasts(%arg0: tensor<64x128xbf16>) -> tensor<64x128xui8> {
+        // CHECK: ttir.typecast
+        // CHECK-SAME: <{conservative_folding = true}>
+        // CHECK-SAME: -> tensor<64x128xui8>
+        // CHECK-NOT: ttir.typecast
+        %0 = "ttir.empty"() : () -> tensor<64x128xf16>
+        %1 = "ttir.typecast"(%arg0, %0) <{conservative_folding = true}> : (tensor<64x128xbf16>, tensor<64x128xf16>) -> tensor<64x128xf16>
+        %2 = "ttir.empty"() : () -> tensor<64x128xui8>
+        %3 = "ttir.typecast"(%1, %2) <{conservative_folding = true}> : (tensor<64x128xf16>, tensor<64x128xui8>) -> tensor<64x128xui8>
+        return %3 : tensor<64x128xui8>
+    }
+
     // Test case to verify that we do not fold consecutive typecast ops if the first typecast have more than a single use.
     // CHECK-LABEL: typecast_folding_consecutive_typecasts_with_multiple_uses
     func.func @typecast_folding_consecutive_typecasts_with_multiple_uses(%arg0: tensor<64x128xf32>) -> (tensor<64x128xbf16>, tensor<64x128xi32>) {

--- a/test/ttmlir/Dialect/TTIR/data_movement/typecast/typecast_folding.mlir
+++ b/test/ttmlir/Dialect/TTIR/data_movement/typecast/typecast_folding.mlir
@@ -107,6 +107,45 @@ module attributes {} {
         return %3 : tensor<64x128xf32>
     }
 
+    // Test case to verify that we do fold consecutive typecast ops if it's narrowing-then-narrowing and we're in conservative mode.
+    // CHECK-LABEL: typecast_folding_narrowing_then_narrowing_typecasts_conservative
+    func.func @typecast_folding_narrowing_then_narrowing_typecasts_conservative(%arg0: tensor<64x128xui32>) -> tensor<64x128xui8> {
+        // CHECK: ttir.typecast
+        // CHECK-SAME: -> tensor<64x128xui8>
+        // CHECK-NOT: ttir.typecast
+        %0 = "ttir.empty"() : () -> tensor<64x128xui16>
+        %1 = "ttir.typecast"(%arg0, %0) <{conservative_folding = true}> : (tensor<64x128xui32>, tensor<64x128xui16>) -> tensor<64x128xui16>
+        %2 = "ttir.empty"() : () -> tensor<64x128xui8>
+        %3 = "ttir.typecast"(%1, %2) : (tensor<64x128xui16>, tensor<64x128xui8>) -> tensor<64x128xui8>
+        return %3 : tensor<64x128xui8>
+    }
+
+    // Test case to verify that we do fold consecutive typecast ops if it's widening-then-widening and we're in conservative mode.
+    // CHECK-LABEL: typecast_folding_widening_then_widening_typecasts_conservative
+    func.func @typecast_folding_widening_then_widening_typecasts_conservative(%arg0: tensor<64x128xui8>) -> tensor<64x128xi32> {
+        // CHECK: ttir.typecast
+        // CHECK-SAME: -> tensor<64x128xi32>
+        // CHECK-NOT: ttir.typecast
+        %0 = "ttir.empty"() : () -> tensor<64x128xui16>
+        %1 = "ttir.typecast"(%arg0, %0) : (tensor<64x128xui8>, tensor<64x128xui16>) -> tensor<64x128xui16>
+        %2 = "ttir.empty"() : () -> tensor<64x128xi32>
+        %3 = "ttir.typecast"(%1, %2) <{conservative_folding = true}> : (tensor<64x128xui16>, tensor<64x128xi32>) -> tensor<64x128xi32>
+        return %3 : tensor<64x128xi32>
+    }
+
+    // Test case to verify that we do fold consecutive typecast ops if it's widening-then-narrowing and we're in conservative mode.
+    // CHECK-LABEL: typecast_folding_widening_then_narrowing_typecasts_conservative
+    func.func @typecast_folding_widening_then_narrowing_typecasts_conservative(%arg0: tensor<64x128xui16>) -> tensor<64x128xui8> {
+        // CHECK: ttir.typecast
+        // CHECK-SAME: -> tensor<64x128xui8>
+        // CHECK-NOT: ttir.typecast
+        %0 = "ttir.empty"() : () -> tensor<64x128xi32>
+        %1 = "ttir.typecast"(%arg0, %0) <{conservative_folding = true}> : (tensor<64x128xui16>, tensor<64x128xi32>) -> tensor<64x128xi32>
+        %2 = "ttir.empty"() : () -> tensor<64x128xui8>
+        %3 = "ttir.typecast"(%1, %2) : (tensor<64x128xi32>, tensor<64x128xui8>) -> tensor<64x128xui8>
+        return %3 : tensor<64x128xui8>
+    }
+
     // Test case to verify that we do not fold consecutive typecast ops if the first typecast have more than a single use.
     // CHECK-LABEL: typecast_folding_consecutive_typecasts_with_multiple_uses
     func.func @typecast_folding_consecutive_typecasts_with_multiple_uses(%arg0: tensor<64x128xf32>) -> (tensor<64x128xbf16>, tensor<64x128xi32>) {

--- a/test/ttmlir/Silicon/TTMetal/n150/typecast.mlir
+++ b/test/ttmlir/Silicon/TTMetal/n150/typecast.mlir
@@ -1,0 +1,22 @@
+// RUN: ttmlir-opt --ttir-to-ttmetal-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttmetal-to-flatbuffer %t.mlir > %t.ttm
+func.func @test_typecast(%arg0: tensor<64x128xf32>) -> (tensor<64x128xi32>, tensor<64x128xbf16>) {
+  %0 = "ttir.empty"() : () -> tensor<64x128xi32>
+  // CHECK: emitc.call_opaque "copy_tile_init"
+  // CHECK-NEXT: emitc.call_opaque "copy_tile"
+  // CHECK-NEXT: emitc.call_opaque "typecast_tile_init"
+  // CHECK-NEXT: emitc.call_opaque "typecast_tile"(%{{[0-9]+}}) {template_args =
+  // CHECK-SAME: #emitc.opaque<"static_cast<std::underlying_type_t<DataFormat>>(DataFormat::Float32)">
+  // CHECK-SAME: #emitc.opaque<"static_cast<std::underlying_type_t<DataFormat>>(DataFormat::Int32)">
+  %1 = "ttir.typecast"(%arg0, %0) <{conservative_folding = true}> : (tensor<64x128xf32>, tensor<64x128xi32>) -> tensor<64x128xi32>
+  %2 = "ttir.empty"() : () -> tensor<64x128xbf16>
+  // CHECK: emitc.call_opaque "copy_tile_init"
+  // CHECK-NEXT: emitc.call_opaque "copy_tile"
+  // CHECK-NEXT: emitc.call_opaque "typecast_tile_init"
+  // CHECK-NEXT: emitc.call_opaque "typecast_tile"(%{{[0-9]+}}) {template_args =
+  // CHECK-SAME: #emitc.opaque<"static_cast<std::underlying_type_t<DataFormat>>(DataFormat::Int32)">
+  // CHECK-SAME: #emitc.opaque<"static_cast<std::underlying_type_t<DataFormat>>(DataFormat::Float16_b)">
+  %3 = "ttir.typecast"(%1, %2) <{conservative_folding = true}> : (tensor<64x128xi32>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+  return %1, %3 : tensor<64x128xi32>, tensor<64x128xbf16>
+}


### PR DESCRIPTION
### Ticket
Closes #3012

### What's changed
Add typecast support to the D2M path
Changed the TTIR typecast folding canonicalizer: instead of folding any two consecutive typecasts, check the narrowing/widening feature of the two ops and only fold if it won't introduce breaking changes to the semantics or accuracy of the original code
Add an additional `conservative_folding` boolean attribute to `ttir.typecast`that enables the check above, off by default

### Checklist
- [ ] New/Existing tests provide coverage for changes (BFPs are not used yet so some of the related parts are left untested)
