### PR TITLE
Reenable Skipped OpModel Tests

### DIFF
--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -224,10 +224,6 @@ class OpModelReductionParam
                      detail::ExpectedResult>> {};
 
 TEST_P(OpModelReductionParam, Reduction) {
-  // Disabled due to segfault after reshape op called with program cache enabled
-  // TODO(brataTT): Re-enable after
-  // https://github.com/tenstorrent/tt-mlir/issues/3054
-  GTEST_SKIP();
   auto params = GetParam();
   const auto [inputShape, inputTensorLayout, inputBufferType,
               inputVirtualGrid] = std::get<0>(params);
@@ -292,10 +288,6 @@ INSTANTIATE_TEST_SUITE_P(
                         detail::ExpectedResult{true, 12288, 0, 0})));
 
 TEST_F(OpModelTest, SoftmaxInterleaved) {
-  // Disabled due to segfault after reshape op called with program cache enabled
-  // TODO(brataTT): Re-enable after
-  // https://github.com/tenstorrent/tt-mlir/issues/3054
-  GTEST_SKIP();
   const llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
   const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
   const mlir::tt::ttnn::TTNNLayoutAttr inputLayout_dram =
@@ -373,10 +365,6 @@ TEST_F(OpModelTest, SoftmaxInterleaved) {
 }
 
 TEST_F(OpModelTest, Reshape) {
-  // Disabled due to segfault after reshape op called with program cache enabled
-  // TODO(brataTT): Re-enable after
-  // https://github.com/tenstorrent/tt-mlir/issues/3054
-  GTEST_SKIP();
   const llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
   const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
   const mlir::tt::ttnn::TTNNLayoutAttr layoutDRAM =
@@ -479,10 +467,6 @@ TEST_F(OpModelTest, ToLayout) {
 }
 
 TEST_F(OpModelTest, Transpose) {
-  // Disabled due to segfault after reshape op called with program cache enabled
-  // TODO(brataTT): Re-enable after
-  // https://github.com/tenstorrent/tt-mlir/issues/3054
-  GTEST_SKIP();
   const llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
   const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);
   const mlir::tt::ttnn::TTNNLayoutAttr layoutDRAM =
@@ -539,10 +523,6 @@ TEST_F(OpModelTest, Transpose) {
 }
 
 TEST_F(OpModelTest, SoftmaxSharded) {
-  // Disabled due to segfault after reshape op called with program cache enabled
-  // TODO(brataTT): Re-enable after
-  // https://github.com/tenstorrent/tt-mlir/issues/3054
-  GTEST_SKIP();
   const llvm::SmallVector<int64_t> tensorShape = {16 * workerCoresN300 * 32,
                                                   32};
   const auto workerGrid = CreateWorkerGrid(gridShapeHwN300);

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -234,10 +234,6 @@ TEST_F(OpModelBase, SigmoidOpInterface) {
 }
 
 TEST_F(OpModelBase, SoftmaxOpInterface) {
-  // Disabled due to segfault after reshape op called with program cache enabled
-  // TODO(brataTT): Re-enable after
-  // https://github.com/tenstorrent/tt-mlir/issues/3054
-  GTEST_SKIP();
   // create SoftmaxOp
   llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
 
@@ -461,10 +457,6 @@ TEST_F(OpModelBase, MeanOpInterface) {
 }
 
 TEST_F(OpModelBase, ReshapeOpInterface) {
-  // Disabled due to segfault after reshape op called with program cache enabled
-  // TODO(brataTT): Re-enable after
-  // https://github.com/tenstorrent/tt-mlir/issues/3054
-  GTEST_SKIP();
   // create ReshapeOp
   llvm::SmallVector<int64_t> tensorShapeA = {64, 1024};
   llvm::SmallVector<int64_t> tensorShapeO = {64 * 4, 1024 / 4};
@@ -482,8 +474,8 @@ TEST_F(OpModelBase, ReshapeOpInterface) {
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
     const auto &[cbSize, peakSize, outputSize, outputLayout] = l1;
-    EXPECT_EQ(cbSize, 262144);
-    EXPECT_EQ(peakSize, 4096);
+    EXPECT_EQ(cbSize, 5120);
+    EXPECT_EQ(peakSize, 2048);
     EXPECT_EQ(outputSize, 2048);
   } else {
     FAIL() << "Missing L1 constraints; Error="
@@ -553,10 +545,6 @@ TEST_F(OpModelBase, toLayoutOp) {
 }
 
 TEST_F(OpModelBase, transposeOp) {
-  // Disabled due to segfault after reshape op called with program cache enabled
-  // TODO(brataTT): Re-enable after
-  // https://github.com/tenstorrent/tt-mlir/issues/3054
-  GTEST_SKIP();
   // create TransposeOp
   llvm::SmallVector<int64_t> tensorShapeA = {64, 1024};
   llvm::SmallVector<int64_t> tensorShapeO = {1024, 64};


### PR DESCRIPTION
### Ticket
#3054

### Problem description
A change in `ttnn.reshape` led to segfaults in some OpModel tests. We skipped those tests temporarily as the problem was not affecting any production code. This was root caused in https://github.com/tenstorrent/tt-metal/issues/21315 and has been fixed.

### What's changed
- The skipped tests are being reenabled
- Closes #3054 

### Checklist
- [X] New/Existing tests provide coverage for changes
