### PR TITLE
Refactor GetDevice handling in EmitC dylib signature conversion

### DIFF
--- a/lib/Dialect/TTNN/Transforms/Passes.cpp
+++ b/lib/Dialect/TTNN/Transforms/Passes.cpp
@@ -408,7 +408,7 @@ public:
           mlir::TupleType::get(&getContext(), originalFuncType.getResults());
 
       // Create modified function type (signature) that takes the input tuple
-      // as an operand, and returns the output tuple
+      // as an operand, and returns the output tuple.
       //
       FunctionType modifiedFuncType =
           originalFuncType.clone(tuplifiedInputTensors, tuplifiedOutputTensors);
@@ -452,7 +452,7 @@ public:
       entryBlock.eraseArguments(paramOffset,
                                 originalFuncType.getInputs().size());
 
-      // Find return statement and replace with tuple
+      // Find return statement and replace with tuple.
       //
       forwardFuncOp.walk<WalkOrder::PostOrder, ReverseIterator>(
           [&](mlir::func::ReturnOp returnOp) {

--- a/runtime/test/ttnn/dylib.cpp
+++ b/runtime/test/ttnn/dylib.cpp
@@ -77,7 +77,7 @@ runSoProgram(void *so, std::string_view funcName,
   // locally we may have 2 devices.
   assert(ttnnMeshDevice.get_devices().size() > 0);
 
-  // Clear any previous errors
+  // Clear any previous errors.
   //
   dlerror();
 
@@ -102,10 +102,6 @@ runSoProgram(void *so, std::string_view funcName,
         input.as<::tt::runtime::ttnn::TTNNTensorWrapper>(DeviceRuntime::TTNN)
             .getTensor());
   }
-
-  // Clear previous errors.
-  //
-  dlerror();
 
   // Get function from the shared object.
   //

--- a/test/ttmlir/EmitC/TTNN/other/const-eval-device.mlir
+++ b/test/ttmlir/EmitC/TTNN/other/const-eval-device.mlir
@@ -1,9 +1,9 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-const-eval=true" %s > %t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
-// RUN: ttmlir-opt --ttnn-modify-signatures-for-dylib --convert-ttnn-to-emitc %t.mlir > %t2.mlir
-// RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
+// RUN: ttmlir-opt --ttnn-modify-signatures-for-dylib --convert-ttnn-to-emitc --allow-unregistered-dialect %t.mlir > %t2.mlir
+// RUN: ttmlir-translate --mlir-to-cpp --allow-unregistered-dialect %t2.mlir > %basename_t.cpp
 
-func.func @embedding(%arg0: tensor<32x32xbf16>, %arg1: tensor<512x128xbf16>) -> tensor<32x32x128xbf16> {
+func.func @embedding(%arg0: tensor<32x32xbf16> {tt.argument_type = #tt.argument_type<constant>}, %arg1: tensor<512x128xbf16>) -> tensor<32x32x128xbf16> {
   %0 = ttir.empty() : tensor<32x32x128xbf16>
   %1 = "ttir.embedding"(%arg0, %arg1, %0) : (tensor<32x32xbf16>, tensor<512x128xbf16>, tensor<32x32x128xbf16>) -> tensor<32x32x128xbf16>
   return %1 : tensor<32x32x128xbf16>

--- a/test/ttmlir/EmitC/TTNN/other/embedding.mlir
+++ b/test/ttmlir/EmitC/TTNN/other/embedding.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-const-eval=true" %s > %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
 // RUN: ttmlir-opt --ttnn-modify-signatures-for-dylib --convert-ttnn-to-emitc %t.mlir > %t2.mlir
 // RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp

--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -48,7 +48,6 @@
 #include <cassert>
 #include <cstddef>
 #include <iostream>
-#include <mutex>
 #include <vector>
 
 namespace ttnn {
@@ -64,6 +63,7 @@ public:
   static ttnn::MeshDevice *getInstance() {
     // If we have an external device, use it.
     if (externalDevice) {
+      assert(ownedDevice == nullptr);
       return externalDevice;
     }
 
@@ -76,8 +76,8 @@ public:
 
   // Set an external device (we don't own it)
   static void setInstance(ttnn::MeshDevice *newInstance) {
-    // Clear any owned device we might have.
-    ownedDevice.reset();
+    // We don't want to mix and match owned/external devices.
+    assert(ownedDevice == nullptr);
 
     // Store the external device pointer.
     externalDevice = newInstance;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/3397#issuecomment-2893207925

### Problem description
EmitC currently has special handling for getDevice ops which changes function signatures, which was breaking logic in const-eval for subgraphs which use getDevice ops.

### What's changed
Instead of passing the device as an argument to functions with getDevices op, we want to utilize the existing conversion to get a singleton device object.  This requires adding a global setter for this field in the precompiled .hpp as well, and invoking it via the dylib in `ttrt` prior to execution.

### Checklist
- [X] New/Existing tests provide coverage for changes
