### PR TITLE
[Optimizer] Add Additional Validation for TensorSpecs Created from TTNNLayoutAttrs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -278,6 +278,9 @@ jobs:
         ln -sf ${{ steps.strings.outputs.install-output-dir }} ${{ steps.strings.outputs.build-output-dir }}
         llvm-lit -sv ${{ steps.strings.outputs.build-output-dir }}/test
 
+        echo "Running optimizer tests"
+        ${{ steps.strings.outputs.build-output-dir }}/test/unittests/Optimizer/OptimizerTests
+
         if [ "${{ matrix.build.suite }}" == "op_model" ]; then
           export TT_METAL_HOME="${{ steps.strings.outputs.install-output-dir }}/tt-metal"
           echo "Running op-model test Conversion"

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -18,7 +18,8 @@ namespace mlir::tt::op_model::ttnn {
 
 // Checks if the tensor layout is legal for the given tensor shape.
 bool isLayoutLegalForTensorShape(llvm::ArrayRef<int64_t> tensorShape,
-                                 mlir::tt::ttnn::TTNNLayoutAttr layout);
+                                 mlir::tt::ttnn::TTNNLayoutAttr layout,
+                                 GridAttr maxGrid);
 
 // Calculate the output tensor type of the prepared weights for a conv2d op.
 mlir::RankedTensorType

--- a/lib/Dialect/TTNN/Analysis/AllPossibleLayoutsAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/AllPossibleLayoutsAnalysis.cpp
@@ -23,7 +23,8 @@ namespace mlir::tt::ttnn {
 // desired grid. This is not necessarily a requirement, but it is a good
 // heuristic to reduce the search space.
 static bool tensorShapeCompatibleWithShard(RankedTensorType tensorType,
-                                           TTNNLayoutAttr layout) {
+                                           TTNNLayoutAttr layout,
+                                           GridAttr maxGrid) {
 
   if (!layout.hasShardedTensorMemoryLayout()) {
     return true;
@@ -31,7 +32,8 @@ static bool tensorShapeCompatibleWithShard(RankedTensorType tensorType,
 
   llvm::ArrayRef<int64_t> tensorShape = tensorType.getShape();
 
-  if (!op_model::ttnn::isLayoutLegalForTensorShape(tensorShape, layout)) {
+  if (!op_model::ttnn::isLayoutLegalForTensorShape(tensorShape, layout,
+                                                   maxGrid)) {
     return false;
   }
 
@@ -186,9 +188,9 @@ static std::vector<TTNNLayoutAttr> generateAllPossibleLayouts(
   // Filter layouts based on output tensor legality for current op.
   shardedResults.erase(
       std::remove_if(shardedResults.begin(), shardedResults.end(),
-                     [tensorType](TTNNLayoutAttr layout) {
+                     [tensorType, maxGrid](TTNNLayoutAttr layout) {
                        return !tensorShapeCompatibleWithShard(tensorType,
-                                                              layout);
+                                                              layout, maxGrid);
                      }),
       shardedResults.end());
 

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -199,12 +199,17 @@ getNullableMemoryConfig(::mlir::tt::ttnn::TTNNLayoutAttr layout) {
 #endif // TTMLIR_ENABLE_OPMODEL
 
 bool isLayoutLegalForTensorShape(llvm::ArrayRef<int64_t> tensorShape,
-                                 mlir::tt::ttnn::TTNNLayoutAttr layout) {
+                                 mlir::tt::ttnn::TTNNLayoutAttr layout,
+                                 GridAttr maxGrid) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   // Conversion to TensorSpec may throw if the layout is invalid, in which case
   // we return false.
   try {
-    conversion::getTensorSpec(tensorShape, layout);
+    auto tensorSpec = conversion::getTensorSpec(tensorShape, layout);
+    auto computeGridSize = ::tt::tt_metal::CoreCoord{
+        static_cast<std::size_t>(maxGrid.getShape()[0]),
+        static_cast<std::size_t>(maxGrid.getShape()[1])};
+    return conversion::validateTensorSpec(tensorSpec, computeGridSize);
   } catch (const std::exception &e) {
     return false;
   }

--- a/test/unittests/Optimizer/CMakeLists.txt
+++ b/test/unittests/Optimizer/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(OptimizerTests
     gtest_main
     MLIRTTDialect
     MLIRTTNNAnalysis
-    MLIRTTNNPipelines
+    MLIRTTNNDialect
     MLIRTTTransforms
+    TTMLIRTTNNUtils
 )

--- a/test/unittests/Optimizer/CMakeLists.txt
+++ b/test/unittests/Optimizer/CMakeLists.txt
@@ -19,4 +19,5 @@ target_link_libraries(OptimizerTests
     MLIRTTDialect
     MLIRTTNNAnalysis
     MLIRTTNNPipelines
+    MLIRTTTransforms
 )

--- a/test/unittests/Optimizer/CMakeLists.txt
+++ b/test/unittests/Optimizer/CMakeLists.txt
@@ -1,13 +1,21 @@
-add_mlir_unittest(OptimizerTests
+# Generate a standalone binary instead an mlir_unittest since TestLayoutAnalysis tests
+# needs to run serially. llvm-lit runs tests in parallel
+add_executable(OptimizerTests
     TestShardSolver.cpp
     TestOptimizerOverrides.cpp
     TestGreedyL1InterleavedPolicy.cpp
     TestLayoutAnalysis.cpp
-    PARTIAL_SOURCES_INTENDED
+)
+
+target_compile_options(OptimizerTests
+    PRIVATE
+    -fno-rtti
 )
 
 target_link_libraries(OptimizerTests
     PRIVATE
+    gtest
+    gtest_main
     MLIRTTDialect
     MLIRTTNNAnalysis
     MLIRTTNNPipelines

--- a/test/unittests/Optimizer/TestLayoutAnalysis.cpp
+++ b/test/unittests/Optimizer/TestLayoutAnalysis.cpp
@@ -120,7 +120,12 @@ protected:
 };
 
 // Test that layouts are correctly generated for all tensor types with different
-// parameters
+// parameters.
+//
+// This test must be run serially for different inputs. Layout validation
+// includes calls into TensorSpec APIs that require the creation of the cluster
+// descriptor file. If multiple processes/threads attempt that in parallel, the
+// test will fail
 TEST_P(AllPossibleLayoutsAnalysisTest, GenerateAndCategorizeLayouts) {
   createTestOps();
 


### PR DESCRIPTION
### Ticket
#3436

### Problem description
#3207 introduced additional validation on `TensorSpec`s obtained from converting `TTNNLayoutAttr`s. That PR only performs the extra validation prior to running `getOpConstraint` queries. It would be useful to upstream these checks to eliminate illegal layouts earlier from the optimizer search

### What's changed
- Replicate the extra validation to the `AllPossibleLayoutsAnalysis`
- Closes #3436

### Checklist
- [X] New/Existing tests provide coverage for changes
