### PR TITLE
Uplift third_party/tt-metal to f025854dea69b6b62c8b1ce0075917daffce6898 2025-05-21

### DIFF
--- a/include/ttmlir/OpModel/TTNN/MetalHeaders.h
+++ b/include/ttmlir/OpModel/TTNN/MetalHeaders.h
@@ -69,7 +69,7 @@ using IDevice = ::tt::tt_metal::IDevice;
 #include "ttnn/graph/graph_trace_utils.hpp"
 #include "ttnn/operations/conv/conv2d/conv2d.hpp"
 #include "ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp"
-#include "ttnn/operations/copy.hpp"
+#include "ttnn/operations/copy/typecast/typecast.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
 #include "ttnn/operations/data_movement/transpose/transpose.hpp"

--- a/runtime/include/tt/runtime/detail/ttnn/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn/ttnn.h
@@ -16,7 +16,7 @@
 #include "ttnn/device.hpp"
 #include "ttnn/operations/ccl/all_gather/all_gather.hpp"
 #include "ttnn/operations/conv/conv2d/conv2d.hpp"
-#include "ttnn/operations/copy.hpp"
+#include "ttnn/operations/copy/typecast/typecast.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/creation.hpp"
 #include "ttnn/operations/data_movement/clone/clone.hpp"

--- a/runtime/lib/ttnn/operations/eltwise/unary/unary.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/unary/unary.cpp
@@ -7,7 +7,7 @@
 #include "tt/runtime/detail/ttnn/ttnn.h"
 #include "tt/runtime/detail/ttnn/utils.h"
 #include "ttmlir/Target/TTNN/program_generated.h"
-#include "ttnn/operations/copy.hpp"
+#include "ttnn/operations/copy/typecast/typecast.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
 
 namespace tt::runtime::ttnn::operations::eltwise::unary {

--- a/runtime/test/python/ttnn/multi_device/test_input_deallocate.py
+++ b/runtime/test/python/ttnn/multi_device/test_input_deallocate.py
@@ -62,9 +62,11 @@ def verify_to_layout_deallocation(helper: Helper, retain_flags, storage):
 
         # Verify allocation status after to_layout
         for i, runtime_input in enumerate(runtime_inputs):
+            # Deallocation of host tensor does nothing
+            # https://github.com/tenstorrent/tt-mlir/issues/3488
             assert (
-                should_retain[i] == runtime_input.is_allocated()
-            ), f"After to_layout: Retain flag and tensor allocation mismatch ({should_retain[i]} != {runtime_input.is_allocated()} at idx: {i})"
+                True == runtime_input.is_allocated()
+            ), f"After to_layout: Retain flag and tensor allocation mismatch ({True} != {runtime_input.is_allocated()} at idx: {i})"
 
 
 def verify_submit_deallocation(helper: Helper, retain_flags, storage):

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "9db65c24f94168528d1c31fc5df5f1d089bb890d")
+set(TT_METAL_VERSION "f025854dea69b6b62c8b1ce0075917daffce6898")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "7ff86ba507e61e5b6cb9fd267030c4514a5223d1")
+set(TT_METAL_VERSION "9db65c24f94168528d1c31fc5df5f1d089bb890d")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 

--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -12,7 +12,6 @@
 #include "operations/conv/conv2d/conv2d.hpp"
 #include "operations/conv/conv2d/prepare_conv2d_weights.hpp"
 #include "operations/conv/conv_transpose2d/conv_transpose2d.hpp"
-#include "operations/copy.hpp"
 #include "operations/core/core.hpp"
 #include "operations/creation.hpp"
 #include "operations/data_movement/concat/concat.hpp"
@@ -41,6 +40,7 @@
 #include "tt-metalium/small_vector.hpp"
 #include "ttnn/core.hpp"
 #include "ttnn/device.hpp"
+#include "ttnn/operations/copy/typecast/typecast.hpp"
 #include "ttnn/types.hpp"
 #include "workarounds.hpp"
 // ANCHOR_END: standalone_includes


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the f025854dea69b6b62c8b1ce0075917daffce6898

- Update to_layout test after host tensor deallocation updated in metal change 0ed611c
- Update copy.hpp location after moved in metal change d6e9bf6ba4