### PR TITLE
Fix missing struct field initializer after metal uplift

### DIFF
--- a/include/ttmlir-c/TTNNAttrs.h
+++ b/include/ttmlir-c/TTNNAttrs.h
@@ -45,7 +45,7 @@ ttmlirTTNNMatmulMultiCoreReuseMultiCast1DProgramConfigAttrGet(
     uint64_t outBlockH, uint64_t outBlockW, uint64_t perCoreM,
     uint64_t perCoreN, bool fuseBatch, MlirAttribute fusedActivation,
     bool mcastIn0, bool gatherIn0, MlirAttribute hopCores,
-    uint64_t numGlobalCbReceivers);
+    uint64_t numGlobalCbReceivers, bool untilizeOut);
 
 MLIR_CAPI_EXPORTED MlirAttribute
 ttmlirTTNNMatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttrGet(

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
@@ -371,7 +371,8 @@ def TTNN_MatmulMultiCoreReuseMultiCast1DProgramConfigAttr : TTNN_Attr<"MatmulMul
       mcast_in0 = true,
       gather_in0 = false,
       hop_cores = #ttnn.core_range_set<>,
-      num_global_cb_receivers = 0
+      num_global_cb_receivers = 0,
+      untilize_out = false
     >
     ```
   }];
@@ -389,7 +390,8 @@ def TTNN_MatmulMultiCoreReuseMultiCast1DProgramConfigAttr : TTNN_Attr<"MatmulMul
                         "bool":$mcast_in0,
                         "bool":$gather_in0,
                         "CoreRangeSetAttr":$hop_cores,
-                        "uint64_t":$num_global_cb_receivers);
+                        "uint64_t":$num_global_cb_receivers,
+                        "bool":$untilize_out);
 
   let assemblyFormat = [{
     `<` struct(
@@ -406,7 +408,8 @@ def TTNN_MatmulMultiCoreReuseMultiCast1DProgramConfigAttr : TTNN_Attr<"MatmulMul
       $mcast_in0,
       $gather_in0,
       qualified($hop_cores),
-      $num_global_cb_receivers
+      $num_global_cb_receivers,
+      $untilize_out
     ) `>`
   }];
 }

--- a/include/ttmlir/Target/TTNN/operations/matmul.fbs
+++ b/include/ttmlir/Target/TTNN/operations/matmul.fbs
@@ -42,6 +42,7 @@ table MatmulMultiCoreReuseMultiCast1DProgramConfig {
   gather_in0: bool;
   hop_cores: tt.target.ttnn.CoreRangeSet;
   num_global_cb_receivers: uint64;
+  untilize_out: bool;
 }
 
 table MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig {

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -690,7 +690,8 @@ toFlatbuffer(
       matmulConfigAttr.getFuseBatch(), fusedActivation,
       matmulConfigAttr.getMcastIn0(), matmulConfigAttr.getGatherIn0(),
       toFlatbuffer(cache, matmulConfigAttr.getHopCores()),
-      matmulConfigAttr.getNumGlobalCbReceivers());
+      matmulConfigAttr.getNumGlobalCbReceivers(),
+      matmulConfigAttr.getUntilizeOut());
 }
 
 inline ::flatbuffers::Offset<

--- a/lib/CAPI/TTNNAttrs.cpp
+++ b/lib/CAPI/TTNNAttrs.cpp
@@ -70,14 +70,14 @@ MlirAttribute ttmlirTTNNMatmulMultiCoreReuseMultiCast1DProgramConfigAttrGet(
     uint64_t outBlockH, uint64_t outBlockW, uint64_t perCoreM,
     uint64_t perCoreN, bool fuseBatch, MlirAttribute fusedActivation,
     bool mcastIn0, bool gatherIn0, MlirAttribute hopCores,
-    uint64_t numGlobalCbReceivers) {
+    uint64_t numGlobalCbReceivers, bool untilizeOut) {
   return wrap(MatmulMultiCoreReuseMultiCast1DProgramConfigAttr::get(
       unwrap(ctx),
       mlir::cast<CoreCoordAttr>(unwrap(computeWithStorageGridSize)), in0BlockW,
       outSubblockH, outSubblockW, outBlockH, outBlockW, perCoreM, perCoreN,
       fuseBatch, mlir::cast<UnaryWithParamAttr>(unwrap(fusedActivation)),
       mcastIn0, gatherIn0, mlir::cast<CoreRangeSetAttr>(unwrap(hopCores)),
-      numGlobalCbReceivers));
+      numGlobalCbReceivers, untilizeOut));
 }
 
 MlirAttribute

--- a/python/TTNNModule.cpp
+++ b/python/TTNNModule.cpp
@@ -472,12 +472,12 @@ void populateTTNNModule(nb::module_ &m) {
              uint64_t outBlockH, uint64_t outBlockW, uint64_t perCoreM,
              uint64_t perCoreN, bool fuseBatch, MlirAttribute fusedActivation,
              bool mcastIn0, bool gatherIn0, MlirAttribute hopCores,
-             uint64_t numGlobalCbReceivers) {
+             uint64_t numGlobalCbReceivers, bool untilizeOut) {
             return ttmlirTTNNMatmulMultiCoreReuseMultiCast1DProgramConfigAttrGet(
                 ctx, computeWithStorageGridSize, in0BlockW, outSubblockH,
                 outSubblockW, outBlockH, outBlockW, perCoreM, perCoreN,
                 fuseBatch, fusedActivation, mcastIn0, gatherIn0, hopCores,
-                numGlobalCbReceivers);
+                numGlobalCbReceivers, untilizeOut);
           })
       .def_prop_ro(
           "compute_with_storage_grid_size",
@@ -526,7 +526,10 @@ void populateTTNNModule(nb::module_ &m) {
           })
       .def_prop_ro("num_global_cb_receivers",
                    &tt::ttnn::MatmulMultiCoreReuseMultiCast1DProgramConfigAttr::
-                       getNumGlobalCbReceivers);
+                       getNumGlobalCbReceivers)
+      .def_prop_ro("untilize_out",
+                   &tt::ttnn::MatmulMultiCoreReuseMultiCast1DProgramConfigAttr::
+                       getUntilizeOut);
 
   tt_attribute_class<
       tt::ttnn::MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr>(

--- a/runtime/lib/ttnn/operations/utils/utils.cpp
+++ b/runtime/lib/ttnn/operations/utils/utils.cpp
@@ -228,7 +228,7 @@ createMatmulProgramConfigIfNeeded(const ::tt::target::ttnn::MatmulOp *op) {
             .hop_cores = ::tt::runtime::ttnn::utils::toTTNNCoreRangeSet(
                 *config->hop_cores()),
             .num_global_cb_receivers = config->num_global_cb_receivers(),
-            .untilize_out = false};
+            .untilize_out = config->untilize_out()};
   }
   case ::tt::target::ttnn::MatmulProgramConfig::
       MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig: {

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_matmul_multi_core_reuse_multi_cast_1d_program_config.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_matmul_multi_core_reuse_multi_cast_1d_program_config.mlir
@@ -20,7 +20,8 @@
   mcast_in0 = true,
   gather_in0 = false,
   hop_cores = #ttnn.core_range_set<>,
-  num_global_cb_receivers = 0
+  num_global_cb_receivers = 0,
+  untilize_out = false
 >
 
 module attributes {} {


### PR DESCRIPTION
### Ticket
N/A

### Problem description
A new `untilize_out` field isn't initialized, newer versions of clang will error out

### What's changed
Initialize the field

### Checklist
- [x] New/Existing tests provide coverage for changes
