### PR TITLE
Add device dram/l1 query APIs

### DIFF
--- a/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
@@ -83,6 +83,9 @@ size_t getNumHwCqs(Device meshDevice);
 bool isProgramCacheEnabled(Device meshDevice);
 size_t getL1SmallSize(Device meshDevice);
 size_t getTraceRegionSize(Device meshDevice);
+size_t getNumDramChannels(Device meshDevice);
+size_t getDramSizePerChannel(Device meshDevice);
+size_t getL1SizePerCore(Device meshDevice);
 
 void deallocateBuffers(Device device);
 

--- a/runtime/include/tt/runtime/detail/ttnn/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn/ttnn.h
@@ -149,6 +149,9 @@ size_t getNumHwCqs(Device meshDevice);
 bool isProgramCacheEnabled(Device meshDevice);
 size_t getL1SmallSize(Device meshDevice);
 size_t getTraceRegionSize(Device meshDevice);
+size_t getNumDramChannels(Device meshDevice);
+size_t getDramSizePerChannel(Device meshDevice);
+size_t getL1SizePerCore(Device meshDevice);
 
 void deallocateBuffers(Device device);
 

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -156,6 +156,9 @@ size_t getNumHwCqs(Device meshDevice);
 bool isProgramCacheEnabled(Device meshDevice);
 size_t getL1SmallSize(Device meshDevice);
 size_t getTraceRegionSize(Device meshDevice);
+size_t getNumDramChannels(Device meshDevice);
+size_t getDramSizePerChannel(Device meshDevice);
+size_t getL1SizePerCore(Device meshDevice);
 
 void wait(Event event);
 

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -529,6 +529,42 @@ size_t getTraceRegionSize(Device meshDevice) {
       });
 }
 
+size_t getNumDramChannels(Device meshDevice) {
+  using RetType = size_t;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::ttnn::getNumDramChannels(meshDevice);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::getNumDramChannels(meshDevice);
+      });
+}
+
+size_t getDramSizePerChannel(Device meshDevice) {
+  using RetType = size_t;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::ttnn::getDramSizePerChannel(meshDevice);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::getDramSizePerChannel(meshDevice);
+      });
+}
+
+size_t getL1SizePerCore(Device meshDevice) {
+  using RetType = size_t;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::ttnn::getL1SizePerCore(meshDevice);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::getL1SizePerCore(meshDevice);
+      });
+}
+
 void wait(Event event) {
   using RetType = void;
   DISPATCH_TO_CURRENT_RUNTIME(

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -237,6 +237,27 @@ size_t getTraceRegionSize(Device meshDevice) {
   return metalMeshDevice.allocator()->get_config().trace_region_size;
 }
 
+size_t getNumDramChannels(Device meshDevice) {
+  ::tt::tt_metal::distributed::MeshDevice &metalMeshDevice =
+      meshDevice.as<::tt::tt_metal::distributed::MeshDevice>(
+          DeviceRuntime::TTMetal);
+  return metalMeshDevice.num_dram_channels();
+}
+
+size_t getDramSizePerChannel(Device meshDevice) {
+  ::tt::tt_metal::distributed::MeshDevice &metalMeshDevice =
+      meshDevice.as<::tt::tt_metal::distributed::MeshDevice>(
+          DeviceRuntime::TTMetal);
+  return metalMeshDevice.dram_size_per_channel();
+}
+
+size_t getL1SizePerCore(Device meshDevice) {
+  ::tt::tt_metal::distributed::MeshDevice &metalMeshDevice =
+      meshDevice.as<::tt::tt_metal::distributed::MeshDevice>(
+          DeviceRuntime::TTMetal);
+  return metalMeshDevice.l1_size_per_core();
+}
+
 void deallocateBuffers(Device deviceHandle) {
   tt_metal::distributed::MeshDevice &meshDevice =
       deviceHandle.as<tt_metal::distributed::MeshDevice>(

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -491,6 +491,24 @@ size_t getTraceRegionSize(Device meshDevice) {
   return ttnnMeshDevice.allocator()->get_config().trace_region_size;
 }
 
+size_t getNumDramChannels(Device meshDevice) {
+  ::ttnn::MeshDevice &ttnnMeshDevice =
+      meshDevice.as<::ttnn::MeshDevice>(DeviceRuntime::TTNN);
+  return ttnnMeshDevice.num_dram_channels();
+}
+
+size_t getDramSizePerChannel(Device meshDevice) {
+  ::ttnn::MeshDevice &ttnnMeshDevice =
+      meshDevice.as<::ttnn::MeshDevice>(DeviceRuntime::TTNN);
+  return ttnnMeshDevice.dram_size_per_channel();
+}
+
+size_t getL1SizePerCore(Device meshDevice) {
+  ::ttnn::MeshDevice &ttnnMeshDevice =
+      meshDevice.as<::ttnn::MeshDevice>(DeviceRuntime::TTNN);
+  return ttnnMeshDevice.l1_size_per_core();
+}
+
 void deallocateBuffers(Device deviceHandle) {
   ::ttnn::MeshDevice &meshDevice =
       deviceHandle.as<::ttnn::MeshDevice>(DeviceRuntime::TTNN);

--- a/runtime/test/python/ttnn/multi_device/test_runtime_api.py
+++ b/runtime/test/python/ttnn/multi_device/test_runtime_api.py
@@ -58,4 +58,7 @@ def test_open_mesh_device(
     assert device.is_program_cache_enabled() == enable_program_cache
     assert device.get_l1_small_size() == l1_small_size
     assert device.get_trace_region_size() == trace_region_size
+    assert device.get_num_dram_channels() != 0
+    assert device.get_dram_size_per_channel() != 0
+    assert device.get_l1_size_per_core() != 0
     ttrt.runtime.close_mesh_device(device)

--- a/runtime/tools/ttrt/ttrt/runtime/module.cpp
+++ b/runtime/tools/ttrt/ttrt/runtime/module.cpp
@@ -40,6 +40,9 @@ PYBIND11_MODULE(_C, m) {
       .def("is_program_cache_enabled", &tt::runtime::isProgramCacheEnabled)
       .def("get_l1_small_size", &tt::runtime::getL1SmallSize)
       .def("get_trace_region_size", &tt::runtime::getTraceRegionSize)
+      .def("get_num_dram_channels", &tt::runtime::getNumDramChannels)
+      .def("get_dram_size_per_channel", &tt::runtime::getDramSizePerChannel)
+      .def("get_l1_size_per_core", &tt::runtime::getL1SizePerCore)
       .def("deallocate_buffers", &tt::runtime::detail::deallocateBuffers)
       .def("dump_memory_report", &tt::runtime::detail::dumpMemoryReport)
       .def("get_memory_view", &tt::runtime::detail::getMemoryView,


### PR DESCRIPTION
### Problem description
With automatic pipeline parallel enabled on tt-torch, it would be desirable to dynamically query the dram size from device so that we can cut the model correctly.

### What's changed
Added APIs to query dram/l1 sizes.

### Checklist
- [X] New/Existing tests provide coverage for changes
