### PR TITLE
Re-enable op level golden check

### DIFF
--- a/tools/builder/base/builder.py
+++ b/tools/builder/base/builder.py
@@ -97,6 +97,7 @@ class Builder:
         inputs: List[torch.Tensor],
         outputs: Optional[List[torch.Tensor]] = None,
         override: bool = False,
+        check_level: GoldenCheckLevel = GoldenCheckLevel.GRAPH_LEVEL,
     ) -> None:
         for index, tensor in enumerate(inputs):
             input_key = f"input_{index}"
@@ -119,7 +120,7 @@ class Builder:
             self._id_golden_map[input_key] = Golden(tensor)
 
         if outputs is not None:
-            self.golden_check_level = GoldenCheckLevel.GRAPH_LEVEL
+            self.golden_check_level = check_level
             for index, tensor in enumerate(outputs):
                 output_key = f"output_{index}"
                 if not override and output_key in self._id_golden_map:

--- a/tools/builder/ttir/ttir_utils.py
+++ b/tools/builder/ttir/ttir_utils.py
@@ -209,10 +209,10 @@ def build_ttir_module(
                     )
                 result = fn(*inputs, ttir_builder)
                 output_ops = result if hasattr(result, "__iter__") else (result,)
-                output_goldens = [
-                    ttir_builder._get_golden_tensor(op) for op in output_ops
-                ]
-                ttir_builder.set_graph_input_output(input_goldens, output_goldens)
+                output_goldens = [ttir_builder._get_golden_tensor(op) for op in output_ops]
+                ttir_builder.set_graph_input_output(
+                    input_goldens, output_goldens, check_level=GoldenCheckLevel.OP_LEVEL
+                )
                 return result
 
         print(f"`{fn.__name__}` sucessfully transformed into a MLIR module.")


### PR DESCRIPTION
### Ticket
Closes #3499 

### Problem description
Provide context for the problem.

### What's changed
This change supplies a `check_level` arg to `set_graph_input_output` instead of always assuming `GRAPH_LEVEL` to allow finer grain control over what using this function does. From this point on, non CCL tests will always be op level golden checked, allowing finer grain testing.