### PR TITLE
#3515: Fixed bug in conversion from manual computation to mesh shard op for scalar operands.

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/ShardyToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/ShardyToTTIRPatterns.cpp
@@ -239,7 +239,7 @@ public:
     // Add mesh_shard (FullToShardShape) for inputs.
     llvm::SmallVector<mlir::Value> fullToShardResults;
     for (auto [globalOperand, argSharding, localArgType] : llvm::zip_equal(
-             srcOp.getOperands(), srcOp.getInShardings().getShardings(),
+             adaptor.getOperands(), srcOp.getInShardings().getShardings(),
              srcOp.getBody().getArgumentTypes())) {
 
       mlir::tt::sharding_utils::MeshSharding meshSharding;

--- a/test/ttmlir/Conversion/StableHLOToTTIR/ccl/ccl_ops_shardy.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/ccl/ccl_ops_shardy.mlir
@@ -464,3 +464,20 @@ module @jit__unnamed_wrapped_function_ attributes {mhlo.num_partitions = 8 : i32
 // CHECK-SAME: tensor<1024x1024xf32, #tt.mesh_sharding<"mesh", [ 8(1),  1]>>
 // CHECK-SAME: tensor<1024x1024xf32, #tt.mesh_sharding<"mesh", [ 8(1),  1]>>
 // CHECK-SAME: tensor<1024x1024xf32, #tt.mesh_sharding<"mesh", [ 8(1),  1]>>
+
+// -----
+module @sdy_manual_computation_constant {
+  sdy.mesh @mesh = <["x"=1, "batch"=8]>
+  func.func public @main(%arg0: tensor<f32>) -> tensor<f32> {
+    %0 = sdy.manual_computation(%arg0) in_shardings=[<@mesh, []>] out_shardings=[<@mesh, []>] manual_axes={"x", "batch"} (%arg1: tensor<f32>) {
+      sdy.return %arg1 : tensor<f32>
+    } : (tensor<f32>) -> tensor<f32>
+    return %0 : tensor<f32>
+  }
+}
+
+// CHECK: "ttir.mesh_shard"
+// CHECK-SAME: shard_dims = array<i64: -1>
+// CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
+// CHECK-SAME: shard_shape = array<i64: 1>
+// CHECK-SAME: shard_type = #tt.shard_type<replicate>

--- a/test/ttmlir/Dialect/StableHLO/shardy_automatic_parallelization/user_annotations_simple.mlir
+++ b/test/ttmlir/Dialect/StableHLO/shardy_automatic_parallelization/user_annotations_simple.mlir
@@ -113,3 +113,10 @@ func.func public @multiple_output(%arg0: tensor<64x128xf32> {sdy.sharding = #sdy
 // CHECK: %1 = stablehlo.cbrt %arg1 : tensor<32x128xf32>
 // CHECK: %2 = stablehlo.cbrt %arg1 : tensor<32x128xf32>
 // CHECK: sdy.return %1, %2 : tensor<32x128xf32>, tensor<32x128xf32>
+
+func.func public @constant_operand(%arg0: tensor<f32> {sdy.sharding = #sdy.sharding<@mesh, []>}) -> (tensor<f32>) {
+  return %arg0 :tensor<f32>
+}
+
+// CHECK: %0 = sdy.manual_computation(%arg0) in_shardings=[<@mesh, []>] out_shardings=[<@mesh, []>]
+// CHECK: sdy.return %arg1 : tensor<f32>


### PR DESCRIPTION
https://github.com/tenstorrent/tt-mlir/issues/3515

When trying to convert scalar operands via sdy manual computation op, there was a bug where it wouldn't apply the type converter to the operand.

```
ttmlir-opt --stablehlo-to-ttir-pipeline
```

Before
```
module @sdy_manual_computation_constant {
  sdy.mesh @mesh = <["x"=2, "y"=4]>
  func.func public @main(%arg0: tensor<f32>) -> tensor<f32> {
    %0 = sdy.manual_computation(%arg0) in_shardings=[<@mesh, []>] out_shardings=[<@mesh, []>] manual_axes={"x", "y"} (%arg1: tensor<f32>) {
      sdy.return %arg1 : tensor<f32>
    } : (tensor<f32>) -> tensor<f32>
    return %0 : tensor<f32>
  }
}

->
failed to legalize unresolved materialization from ('tensor<1xi32>') to ('tensor') that remained live after conversion
```

After (conversion applied successfully)
```
module @sdy_manual_computation_constant attributes {tt.meshes = #tt.meshes<[<"mesh" = 2x4>]>} {
  func.func public @main(%arg0: tensor<1xf32>) -> tensor<1xf32> {
    %0 = ttir.empty() : tensor<1xf32, #tt.mesh_sharding<"mesh">>
    %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: -1>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1>, shard_type = #tt.shard_type<replicate>}> : (tensor<1xf32>, tensor<1xf32, #tt.mesh_sharding<"mesh">>) -> tensor<1xf32, #tt.mesh_sharding<"mesh">>
    %2 = ttir.empty() : tensor<1xf32>
    %3 = "ttir.mesh_shard"(%1, %2) <{shard_dims = array<i64: -1>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1>, shard_type = #tt.shard_type<replicate>}> : (tensor<1xf32, #tt.mesh_sharding<"mesh">>, tensor<1xf32>) -> tensor<1xf32>
    return %3 : tensor<1xf32>
  }
}
```