### PR TITLE
Enable explicit ceil_mode handling in SHLO-to-TTIR Pooling conversion

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -1547,7 +1547,9 @@ def TTIR_PoolingOp : TTIR_NamedOp<"pooling", [AttrSizedOperandSegments]> {
     DenseI64ArrayAttr:$window_strides,
     DenseI64ArrayAttr:$base_dilations,
     DenseI64ArrayAttr:$window_dilations,
-    DenseI64ArrayAttr:$padding
+    DenseI64ArrayAttr:$padding,
+    BoolAttr:$ceil_mode,
+    DenseI64ArrayAttr:$ceil_mode_padding
   );
 
   let results = (outs Variadic<AnyRankedTensor>);

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -1248,16 +1248,23 @@ private:
         adaptor.getWindowDilations()[spatialDimIndices[0]]);
     auto dilationWidthAttr = rewriter.getSI32IntegerAttr(
         adaptor.getWindowDilations()[spatialDimIndices[1]]);
-    auto ceilModeAttr = rewriter.getBoolAttr(false);
+    auto ceilMode = op.getCeilMode();
+    auto ceilModeAttr = rewriter.getBoolAttr(ceilMode);
+    auto paddingTop = op.getPadding()[2 * spatialDimIndices[0]];
+    auto paddingBottom = op.getPadding()[2 * spatialDimIndices[0] + 1];
+    auto paddingLeft = op.getPadding()[2 * spatialDimIndices[1]];
+    auto paddingRight = op.getPadding()[2 * spatialDimIndices[1] + 1];
+    if (ceilMode) {
+      paddingTop -= op.getCeilModePadding()[2 * spatialDimIndices[0]];
+      paddingBottom -= op.getCeilModePadding()[2 * spatialDimIndices[0] + 1];
+      paddingLeft -= op.getCeilModePadding()[2 * spatialDimIndices[1]];
+      paddingRight -= op.getCeilModePadding()[2 * spatialDimIndices[1] + 1];
+    }
 
-    auto paddingTopAttr =
-        rewriter.getSI32IntegerAttr(op.getPadding()[2 * spatialDimIndices[0]]);
-    auto paddingBottomAttr = rewriter.getSI32IntegerAttr(
-        op.getPadding()[2 * spatialDimIndices[0] + 1]);
-    auto paddingLeftAttr =
-        rewriter.getSI32IntegerAttr(op.getPadding()[2 * spatialDimIndices[1]]);
-    auto paddingRightAttr = rewriter.getSI32IntegerAttr(
-        op.getPadding()[2 * spatialDimIndices[1] + 1]);
+    auto paddingTopAttr = rewriter.getSI32IntegerAttr(paddingTop);
+    auto paddingBottomAttr = rewriter.getSI32IntegerAttr(paddingBottom);
+    auto paddingLeftAttr = rewriter.getSI32IntegerAttr(paddingLeft);
+    auto paddingRightAttr = rewriter.getSI32IntegerAttr(paddingRight);
 
     llvm::SmallVector<Value> outputs;
     for (Value input : adaptor.getInputs()) {


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-torch/issues/816)

### Problem description
Previously, StableHLO handled `ceil_mode` implicitly by adding symmetric padding. However, this does not match PyTorch's behavior, which applies asymmetric padding (e.g., only to the bottom and right) when `ceil_mode` is enabled. 

### What's changed
Now that TT-Metal supports `ceil_mode` correctly, this patch removes the additional padding from SHLO during the SHLO-to-TTIR conversion. 
The `ceil_mode` attribute for pooling will be explicitly represented in StableHLO IR after https://github.com/tenstorrent/llvm-torch-mlir/pull/9. To preserve original padding information, a new `ceil_mode_padding` attribute is introduced. This ensures TTIR matches PyTorch semantics when `ceil_mode=true`.

### Checklist
- [ v] Run vovnet with good PCC
