### PR TITLE
utils lib for gtest unit testing

### DIFF
--- a/test/unittests/Allocation/CMakeLists.txt
+++ b/test/unittests/Allocation/CMakeLists.txt
@@ -1,9 +1,17 @@
-add_mlir_unittest(AllocationTests
+set(TESTSUITE AllocationTests)
+
+add_mlir_unittest(${TESTSUITE}
     TestAllocation.cpp
 )
 
-target_link_libraries(AllocationTests
-    PRIVATE
+target_include_directories(${TESTSUITE}
+  PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/../
+)
+
+target_link_libraries(${TESTSUITE}
+  PRIVATE
+    TTMLIRTestUtils
     MLIRTTIRAnalysis
     coverage_config
 )

--- a/test/unittests/Allocation/TestAllocation.cpp
+++ b/test/unittests/Allocation/TestAllocation.cpp
@@ -6,10 +6,9 @@
 
 #include "ttmlir/Support/Logger.h"
 
-#include "llvm-gtest/gtest/gtest.h"
+#include "testing/Utils.h"
 
 #include <cstdint>
-#include <cstdlib>
 #include <random>
 
 namespace mlir::tt::ttir {
@@ -76,7 +75,7 @@ TYPED_TEST(AllocationTest, Conflicts) {
   using Scenario = TypeParam;
 
   constexpr std::int32_t repeats = 3;
-  std::uint64_t seed = 1747264320186267367; // TODO(#3377) time-varying seeding
+  std::uint64_t seed = tt::testing::randomSeed();
 
   std::mt19937 gen;
 
@@ -155,7 +154,7 @@ TYPED_TEST(AllocationTest, Conflicts) {
 TEST(GreedyAllocationTest, ConflictFree) {
 
   constexpr std::int32_t repeats = 3;
-  std::uint64_t seed = 1747264320186267367; // TODO(#3377) time-varying seeding
+  std::uint64_t seed = tt::testing::randomSeed();
 
   std::mt19937 gen;
 

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -5,6 +5,8 @@ function(add_mlir_unittest test_dirname)
   add_unittest(MLIRUnitTests ${test_dirname} ${ARGN})
 endfunction()
 
+add_subdirectory(lib) # test util lib
+
 add_subdirectory(Allocation)
 add_subdirectory(Support)
 add_subdirectory(TestScheduler)

--- a/test/unittests/lib/CMakeLists.txt
+++ b/test/unittests/lib/CMakeLists.txt
@@ -1,0 +1,19 @@
+
+# TestUtils lib provides extensions to gtest functionality.
+
+set(TESTLIB TTMLIRTestUtils)
+add_library(${TESTLIB} "")
+
+# TestUtils lib sources.
+
+target_sources(${TESTLIB}
+  PRIVATE
+    Utils.cpp
+)
+
+# TestUtils lib includes.
+
+target_include_directories(${TESTLIB}
+  PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/../
+)

--- a/test/unittests/lib/Utils.cpp
+++ b/test/unittests/lib/Utils.cpp
@@ -1,0 +1,82 @@
+
+#include "testing/Utils.h"
+
+#include <charconv>
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+namespace mlir::tt::testing {
+
+#define TT_ENV_TEST_SEED "TTMLIR_TEST_SEED"
+#define TT_ENV_TEST_WORKFLOW "TTMLIR_TEST_WORKFLOW"
+#define TT_TEST_WORKFLOW_NIGHTLY "nightly"
+#define TT_TEST_SEED_KEY "seed"
+
+static std::uint64_t getRandomSeed() {
+  std::uint64_t seed = 0;
+
+  const char *seedOverride = std::getenv(TT_ENV_TEST_SEED);
+  // If seed is overridden by the env, assume we're running in repro mode
+  // and parse the override string as-is.
+  if (seedOverride != nullptr && seedOverride[0]) {
+    std::from_chars(seedOverride, seedOverride + std::strlen(seedOverride),
+                    seed);
+  }
+  if (!seed) {
+    // If no env override or its parsing failed, generate a seed value.
+    const char *workflow = std::getenv(TT_ENV_TEST_WORKFLOW);
+    // (a) If running in nightly workflow, generate a time-varying value.
+    if (workflow != nullptr &&
+        !std::strncmp(workflow, TT_TEST_WORKFLOW_NIGHTLY,
+                      sizeof(TT_TEST_WORKFLOW_NIGHTLY))) {
+      // Use hr clock, make sure some low and some high bits are always set.
+      seed = (std::chrono::high_resolution_clock::now()
+                  .time_since_epoch()
+                  .count() |
+              (1L << 53) | (1 << 13));
+    } else {
+      // (b) Otherwise, use a hardcoded const.
+      seed = 1756947448940470413L;
+    }
+  }
+
+  return seed;
+}
+
+#undef TT_TEST_WORKFLOW_NIGHTLY
+#undef TT_ENV_TEST_WORKFLOW
+#undef TT_ENV_TEST_SEED
+
+// A global singleton object to help obtain test env settings and log some of
+// them at both the beginning and the end of normal gtest stdout output.
+namespace {
+struct TestEnv {
+  TestEnv() : seed(getRandomSeed()) {
+    std::cout << "[testsuite random seed: " << seed << "]\n";
+  }
+
+  ~TestEnv() { std::cout << "[testsuite random seed: " << seed << "]\n"; }
+
+  std::uint64_t seed;
+};
+} // namespace
+
+static const TestEnv &env() {
+  static TestEnv instance;
+  return instance;
+}
+
+std::uint64_t randomSeed() {
+  const auto seed = env().seed;
+  // Use gtest test property facilities to record test case/test suite random
+  // seeds so that they are captured in XML/JSON reports along with standard
+  // test results.
+  ::testing::Test::RecordProperty(TT_TEST_SEED_KEY, std::to_string(seed));
+  return seed;
+}
+
+#undef TT_TEST_SEED_KEY
+
+} // namespace mlir::tt::testing

--- a/test/unittests/lit.cfg.py
+++ b/test/unittests/lit.cfg.py
@@ -40,6 +40,10 @@ if "TEMP" in os.environ:
 if "HOME" in os.environ:
     config.environment["HOME"] = os.environ["HOME"]
 
+# Propagate testlib env variables.
+for var in ("TTMLIR_TEST_WORKFLOW", "TTMLIR_TEST_SEED"):
+    if var in os.environ:
+        config.environment[var] = os.environ[var]
 
 if "TT_MLIR_HOME" in os.environ:
     config.environment["TT_MLIR_HOME"] = os.environ["TT_MLIR_HOME"]

--- a/test/unittests/testing/Utils.h
+++ b/test/unittests/testing/Utils.h
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TT_TESTING_UTILS_H
+#define TT_TESTING_UTILS_H
+
+// A convenience include so that tests only need "testing/Utils.h".
+#include "llvm-gtest/gtest/gtest.h"
+
+#include <cstdint>
+
+namespace mlir::tt::testing {
+
+// Return a 64-bit random seed that can be used by randomized tests. This value
+// is a sigleton in the current process and it generated according to the
+// following rules:
+//
+// (a) by default, this is a constant that is hardcoded/doesn't vary with time;
+//
+// (b) if the  process is running in nightly mode (indicated by env var
+// "TTMLIR_TEST_WORKFLOW" set to "nightly"), the value will vary for each
+// process run;
+//
+// (c) if the process is running in repro mode (indicated by env var
+// "TTMLIR_TEST_SEED" set to a 64-bit int string), the value will be set to this
+// override.
+//
+// This function also ensures that the seed is captured in gtest reports as test
+// properties at the scope (test/suite/etc) from which it is invoked. These will
+// show up in the XML report as
+// clang-format off
+//  <properties>
+//    <property name="seed" value="1756947448940470413"/>
+//  </properties>
+// clang-format on
+extern std::uint64_t randomSeed();
+
+} // namespace mlir::tt::testing
+
+#endif // TT_TESTING_UTILS_H


### PR DESCRIPTION

### Ticket
This provides most of what's asked for in #3377; some more CI work is likely needed.

### Problem description
Randomizing test data is a deceptively effective unit testing technique. It helps neutralize subconscious biases by developers when they write unit tests for their own production code and expands code coverage by automatically varying test inputs over repeated test runs.

This PR starts a lib of supporting utils that build on top of gtest facilities and that can be linked by any gtest suite that wants to benefit. `test/unittests/Allocation/TestAllocation.cpp` is an example of using `randomSeed()`.

Some care has been taken to enable randomization only when CI executes a compatible workflow ("nightly"). This part is to be tested.

### What's changed

- new source folders `test/unittests/lib` and `test/unittests/testing`
- the build is structured so that a gtest unit test only needs to do
```cpp
#include "testing/Utils.h"
```
  but the dir structure can change depending on feedback.
- some more env vars are being propagated in `test/unittests/lit.cfg.py` but I am not 100% that's enough; `lit` does an amazing job of being an hard-to-use driver of gtests
