### PR TITLE
Fix macOS nanobind build failure

### DIFF
--- a/runtime/python/CMakeLists.txt
+++ b/runtime/python/CMakeLists.txt
@@ -32,3 +32,13 @@ target_link_libraries(_ttmlir_runtime
 )
 
 add_dependencies(_ttmlir_runtime TTMLIRRuntime)
+
+if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  target_compile_options("nanobind-static" PRIVATE
+      -Wno-cast-qual
+      -Wno-zero-length-array
+      -Wno-nested-anon-types
+      -Wno-c++98-compat-extra-semi
+      -Wno-covered-switch-default
+  )
+endif()


### PR DESCRIPTION
On macOS nanobind fails with some warnings that we treat as errors. This patch works around the issue by disabling those warnings on the nanobind target.
