### PR TITLE
Introduce CMake target for `Lint (clang-tidy)` CI job

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -441,9 +441,7 @@ jobs:
       shell: bash
       run: |
         source env/activate
-        cmake --build ${{ steps.strings.outputs.build-output-dir }} -- FBS_GENERATION mlir-headers mlir-generic-headers tt-metal-download tt-metal-update tt-metal-configure TTKernelGeneratedLLKHeaders
-        python3 tools/scripts/filter-compile-commands.py --diff ${{ steps.strings.outputs.build-output-dir }}/compile_commands.json
-        cmake --build ${{ steps.strings.outputs.build-output-dir }} -- clang-tidy
+        cmake --build ${{ steps.strings.outputs.build-output-dir }} -- clang-tidy-ci
 
     - name: Unique-ify clang-tidy fixes
       shell: bash

--- a/cmake/modules/LintTools.cmake
+++ b/cmake/modules/LintTools.cmake
@@ -7,4 +7,20 @@ add_custom_target(clang-tidy COMMAND run-clang-tidy.py -p ${PROJECT_BINARY_DIR} 
     tt-metal-configure
     FBS_GENERATION
 )
+
+# clang-tidy setup for CI run
+add_custom_target(clang-tidy-ci
+  COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/scripts/filter-compile-commands.py --prefix ${CMAKE_SOURCE_DIR} --diff ${CMAKE_BINARY_DIR}/compile_commands.json
+  COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} -- clang-tidy
+  COMMENT "Running clang-tidy CI checks"
+  DEPENDS
+    FBS_GENERATION
+    mlir-headers
+    mlir-generic-headers
+    tt-metal-download
+    tt-metal-update
+    tt-metal-configure
+    TTKernelGeneratedLLKHeaders
+)
+
 add_custom_target(clang-format COMMAND git-clang-format)

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -131,6 +131,13 @@ source env/activate
 cmake --build build -- clang-tidy
 ```
 
+> **Note for developers:** You can run:
+> ```bash
+> source env/activate
+> cmake --build build -- clang-tidy-ci
+> ```
+> This reproduces the `Lint (clang-tidy)` CI job. It runs `clang-tidy` only on committed files that have been modified relative to the `origin/main` branch.
+
 ### Pre-Commit
 Pre-Commit applies a git hook to the local repository such that linting is checked and applied on every `git commit` action. Install from the root of the repository using:
 

--- a/tools/scripts/filter-compile-commands.py
+++ b/tools/scripts/filter-compile-commands.py
@@ -11,11 +11,17 @@ import sys
 
 
 def get_diff_files(compile_commands):
+    subprocess.check_call(["git", "fetch", "origin", "main"])
     diff = subprocess.check_output(
         ["git", "diff", "--name-only", "origin/main...@"]
     ).decode("utf-8")
-    cwd = os.getcwd()
-    processed = map(lambda x: os.path.join(cwd, x.strip()), diff.split("\n"))
+    home_dir = os.getenv(
+        "TT_MLIR_HOME",
+        subprocess.check_output(["git", "rev-parse", "--show-toplevel"])
+        .decode("utf-8")
+        .strip(),
+    )
+    processed = map(lambda x: os.path.join(home_dir, x.strip()), diff.split("\n"))
     return set(
         filter(
             lambda x: x.endswith(".c")


### PR DESCRIPTION
We run `Lint (clang-tidy)` CI job as a series of commands. Introduce a new CMake target `clang-tidy-ci` that does the same, so it's easier to reproduce the job run locally.