### PR TITLE
Fix forge-fe nanobind build issue

### DIFF
--- a/runtime/python/CMakeLists.txt
+++ b/runtime/python/CMakeLists.txt
@@ -33,8 +33,8 @@ target_link_libraries(_ttmlir_runtime
 
 add_dependencies(_ttmlir_runtime TTMLIRRuntime)
 
-if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  target_compile_options("nanobind-static" PRIVATE
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  target_compile_options(nanobind-static PRIVATE
       -Wno-cast-qual
       -Wno-zero-length-array
       -Wno-nested-anon-types


### PR DESCRIPTION
### Problem description
Nanobind compile was triggering build failures on tt-forge-fe

### What's changed
Suppress warnings for `nanobind-static` for all builds.

### Checklist
- Build passing on with fix on ffe: https://github.com/tenstorrent/tt-forge-fe/actions/runs/15221750869
