### PR TITLE
Fix hyper link in docs

### DIFF
--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -32,8 +32,7 @@ You should now have the required dependencies installed.
 > **NOTE:** If you intend to build with runtime enabled
 > (`-DTTMLIR_ENABLE_RUNTIME=ON`), you also need to install tt-metal
 > dependencies which can be found
-> [here](https://docs.tenstorrent.com/tt-metal/latest/ttnn/ttnn/installing.
-> html#install-system-level-dependencies).
+> [here](https://docs.tenstorrent.com/tt-metal/latest/ttnn/ttnn/installing.html#install-system-level-dependencies).
 
 #### Mac OS
 On MacOS we need to install the latest version of [cmake](https://cmake.org/), and [ninja](https://ninja-build.org/) which can be done using Homebrew with (Docs for installing Homebrew: https://brew.sh).


### PR DESCRIPTION
### Ticket
None made yet.

### Problem description
Currently for the "getting-started" docs, under the ubuntu section, the "here" link in the note is not shown correctly.
![image](https://github.com/user-attachments/assets/ee743c24-a3e9-4bb5-ae95-815d05a97743)

### What's changed
Made the link work as intended.

### Checklist
- [ ] New/Existing tests provide coverage for changes
