### PR TITLE
Fix handling of FP special values in EmitC

### DIFF
--- a/test/ttmlir/EmitC/TTNN/eltwise_unary/clamp.mlir
+++ b/test/ttmlir/EmitC/TTNN/eltwise_unary/clamp.mlir
@@ -8,3 +8,17 @@ func.func @clamp(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
   %1 = "ttir.clamp_scalar"(%arg0, %0) <{max = 3.000000e+00 : f32, min = 2.000000e+00 : f32}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
   return %1 : tensor<64x128xbf16>
 }
+
+func.func @clamp_only_positive(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  // Testing with negative infinity.
+  %1 = "ttir.clamp_scalar"(%arg0, %0) <{max = 1.000000e+00 : f32, min = 0xFF800000 : f32}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+  return %1 : tensor<64x128xbf16>
+}
+
+func.func @clamp_only_negative(%arg0: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+  %0 = ttir.empty() : tensor<64x128xbf16>
+  // Testing with positive infinity.
+  %1 = "ttir.clamp_scalar"(%arg0, %0) <{max = 0x7F800000 : f32, min = -1.000000e+00 : f32}> : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+  return %1 : tensor<64x128xbf16>
+}

--- a/test/unittests/TTNNToEmitC/TestEmitCConversion.cpp
+++ b/test/unittests/TTNNToEmitC/TestEmitCConversion.cpp
@@ -9,6 +9,8 @@
 #include "mlir/IR/MLIRContext.h"
 #include "gtest/gtest.h"
 
+#include <limits>
+
 namespace mlir {
 namespace tt {
 namespace ttnn_to_emitc {
@@ -162,6 +164,24 @@ TEST_F(EmitCConversionTest, ConvertCFPType) {
 
   converted = EmitCTypeConverter<double>::convert(f32Val);
   EXPECT_EQ(converted, "42.000000");
+}
+
+TEST_F(EmitCConversionTest, ConvertCFPTypeNonFiniteValues) {
+  float nanValue = std::numeric_limits<float>::quiet_NaN();
+  std::string converted = EmitCTypeConverter<float>::convert(nanValue);
+  EXPECT_EQ(converted, "::std::numeric_limits<float>::quiet_NaN()");
+
+  float infValue = std::numeric_limits<float>::infinity();
+  converted = EmitCTypeConverter<float>::convert(infValue);
+  EXPECT_EQ(converted, "::std::numeric_limits<float>::infinity()");
+
+  double inf64Value = std::numeric_limits<double>::infinity();
+  converted = EmitCTypeConverter<float>::convert(inf64Value);
+  EXPECT_EQ(converted, "::std::numeric_limits<float>::infinity()");
+
+  float negInfValue = -std::numeric_limits<float>::infinity();
+  converted = EmitCTypeConverter<double>::convert(negInfValue);
+  EXPECT_EQ(converted, "-::std::numeric_limits<double>::infinity()");
 }
 
 TEST_F(EmitCConversionTest, FloatingPointExpectedFailure) {

--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -48,6 +48,7 @@
 #include <cassert>
 #include <cstddef>
 #include <iostream>
+#include <limits>
 #include <vector>
 
 namespace ttnn {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/3538

### Problem description
`std::to_string(v)` returns `inf` when `v` is the FP infinity value, and `nan` when it's a `NaN` value, respectively. Those aren't recognized as symbolic values in C++.

### What's changed
Changed the handling of those values so that they are emitted as special values using `std::numeric_limits`.

### Checklist
- [x] New/Existing tests provide coverage for changes
