### PR TITLE
Support TOSA negate

### DIFF
--- a/test/ttmlir/Conversion/TosaToTTIR/elementwise_unary/negate.mlir
+++ b/test/ttmlir/Conversion/TosaToTTIR/elementwise_unary/negate.mlir
@@ -1,12 +1,13 @@
 // RUN: ttmlir-opt --convert-tosa-to-ttir %s | FileCheck %s
 // Support TOSA negate #3502
-// UNSUPPORTED: true
 module attributes {} {
   func.func @test_negate(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
-    %0 = tosa.negate %arg0 : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+    %0 = "tosa.const"() { values = dense<0.0> : tensor<1xf32> } : () -> tensor<1xf32>
+    %1 = tosa.negate %arg0, %0, %0 : (tensor<13x21x3xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<13x21x3xf32>
+    // CHECK: %[[CST:[0-9]+]] = "ttir.constant"() <{value = dense<0.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
     // CHECK: %[[OP_OUT:[0-9]+]] = ttir.empty() : [[TENSOR_SIZE:tensor<[0-9]+x[0-9]+x[0-9]+xf[0-9]+>]]
     // CHECK: %[[VAL:[0-9]+]] = "ttir.neg"(%arg{{[0-9]+}}, %[[OP_OUT]]) : ([[TENSOR_SIZE]], [[TENSOR_SIZE]]) -> [[TENSOR_SIZE]]
     // CHECK: return %[[VAL]] : [[TENSOR_SIZE]]
-    return %0 : tensor<13x21x3xf32>
+    return %1 : tensor<13x21x3xf32>
   }
 }


### PR DESCRIPTION
### Ticket
Fixes issue #3502 

### Problem description
TOSA negate Op changes after the uplift from 1 argument to 3 arguments required. 

### What's changed
updated the test in `test/ttmlir/Conversion/TosaToTTIR/elementwise_unary/negate.mlir`
Added a custom ConversionPattern instead of using the default generic DPS pattern.
