### PR TITLE
Skip deallocation of conv2d activation when it is overridden

### DIFF
--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -320,6 +320,16 @@ foldConsecutiveDataCastOps(T op, ::mlir::PatternRewriter &rewriter) {
            << ", output_width = " << calculatedWOut;
   }
 
+  if (getConv2dConfig() && getConv2dConfig()->getDeallocateActivation() &&
+      getConv2dConfig()->getDeallocateActivation().getValue()) {
+    for (auto *user : getInput().getUsers()) {
+      if (this->getOperation()->isBeforeInBlock(user)) {
+        return emitOpError()
+               << "Conv2dOp with `deallocate_activation` set to true "
+                  "must be the last user of the input tensor. ";
+      }
+    }
+  }
   return success();
 }
 

--- a/lib/Dialect/TTNN/Transforms/Passes.cpp
+++ b/lib/Dialect/TTNN/Transforms/Passes.cpp
@@ -132,6 +132,19 @@ public:
             continue;
           }
 
+          // Don't deallocate the activation after conv2d op if
+          // 'deallocate_activation' in Conv2dConfig is set to true.
+          if (auto conv2dOp = mlir::dyn_cast<ttnn::Conv2dOp>(lastOp)) {
+            if (conv2dOp.getInput() == result &&
+                conv2dOp.getConv2dConfigAttr() &&
+                conv2dOp.getConv2dConfigAttr().getDeallocateActivation() &&
+                conv2dOp.getConv2dConfigAttr()
+                    .getDeallocateActivation()
+                    .getValue()) {
+              continue;
+            }
+          }
+
           rewriter.setInsertionPointAfter(lastOp);
           rewriter.create<DeallocateOp>(lastOp->getLoc(), result);
         }

--- a/test/ttmlir/Dialect/TTNN/optimizer/conv2d_config_override.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/conv2d_config_override.mlir
@@ -3,7 +3,24 @@
 module {
   func.func @forward(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x32x32x64xbf16> {
     %0 = ttir.empty() : tensor<1x32x32x64xbf16>
-    // CHECK: %{{.*}} = "ttnn.conv2d"{{.*}} conv2d_config = #ttnn.conv2d_config<dtype = bf16, weights_dtype = bf16, activation = "relu", deallocate_activation = false, reallocate_halo_output = true, act_block_h_override = 0, act_block_w_div = 1, reshard_if_not_optimal = false, override_sharding_config = false, transpose_shards = true, output_layout = row_major, preprocess_weights_on_device = false, always_preprocess_weights = false, enable_act_double_buffer = false, enable_weights_double_buffer = false, enable_split_reader = false, enable_subblock_padding = false>{{.*}}
+    // CHECK: "ttnn.conv2d"{{.*}} conv2d_config = #ttnn.conv2d_config<
+    // CHECK-SAME: dtype = bf16
+    // CHECK-SAME: weights_dtype = bf16
+    // CHECK-SAME: activation = "relu"
+    // CHECK-SAME: deallocate_activation = false
+    // CHECK-SAME: reallocate_halo_output = true
+    // CHECK-SAME: act_block_h_override = 0
+    // CHECK-SAME: act_block_w_div = 1
+    // CHECK-SAME: reshard_if_not_optimal = false
+    // CHECK-SAME: override_sharding_config = false
+    // CHECK-SAME: transpose_shards = true
+    // CHECK-SAME: output_layout = row_major
+    // CHECK-SAME: preprocess_weights_on_device = false
+    // CHECK-SAME: always_preprocess_weights = false
+    // CHECK-SAME: enable_act_double_buffer = false
+    // CHECK-SAME: enable_weights_double_buffer = false
+    // CHECK-SAME: enable_split_reader = false
+    // CHECK-SAME: enable_subblock_padding = false
     %1 = "ttir.conv2d"(%arg0, %arg1, %arg2, %0)
             <{
               stride = array<i32: 1, 1>,

--- a/test/ttmlir/Silicon/TTNN/n150/deallocate_override.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/deallocate_override.mlir
@@ -1,0 +1,79 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-optimizer=true memory-layout-analysis-enabled=false override-conv2d-config=conv1=deallocate_activation#true,conv2=deallocate_activation#true" -o deallocate_override_ttnn.mlir %s --mlir-print-debuginfo
+// RUN: FileCheck %s --input-file=deallocate_override_ttnn.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer deallocate_override_ttnn.mlir > %t.ttnn
+
+#loc = loc("ResNetForImageClassification")
+module @ResNetBlock attributes {} {
+  func.func @forward(%arg0: tensor<8x56x56x256xbf16> {ttir.name = "input"},
+                     %arg1: tensor<64x256x1x1xbf16> {ttir.name = "conv1.weight"},
+                     %arg2: tensor<1x1x1x64xbf16> {ttir.name = "conv1.scale"},
+                     %arg3: tensor<1x1x1x64xbf16> {ttir.name = "conv1.bias"},
+                     %arg4: tensor<64x64x3x3xbf16> {ttir.name = "conv2.weight"},
+                     %arg5: tensor<1x1x1x64xbf16> {ttir.name = "conv2.scale"},
+                     %arg6: tensor<1x1x1x64xbf16> {ttir.name = "conv2.bias"},
+                     %arg7: tensor<256x64x1x1xbf16> {ttir.name = "conv3.weight"},
+                     %arg8: tensor<1x1x1x256xbf16> {ttir.name = "conv3.scale"},
+                     %arg9: tensor<1x1x1x256xbf16> {ttir.name = "conv3.bias"})
+                     -> (tensor<8x56x56x256xbf16> {ttir.name = "output"}) {
+    %0 = ttir.empty() : tensor<8x56x56x256xbf16> loc(#loc1)
+    %1 = "ttir.relu"(%arg0, %0) : (tensor<8x56x56x256xbf16>, tensor<8x56x56x256xbf16>) -> tensor<8x56x56x256xbf16> loc(#loc2)
+    %2 = ttir.empty() : tensor<8x56x56x64xbf16> loc(#loc3)
+    // CHECK: "ttnn.conv2d"([[INPUT1:%.+]], [[WEIGHTS1:%.+]], {{%.*}}) {{.*}} conv2d_config = #ttnn.conv2d_config<{{.*}}deallocate_activation = true{{.*}}>
+    %3 = "ttir.conv2d"(%1, %arg1, %2) <{dilation = array<i32: 1, 1>, groups = 1 : i32, padding = array<i32: 0, 0, 0, 0>, stride = array<i32: 1, 1>}> {channel_last = 1 : si32} : (tensor<8x56x56x256xbf16>, tensor<64x256x1x1xbf16>, tensor<8x56x56x64xbf16>) -> tensor<8x56x56x64xbf16> loc(#loc4)
+    // CHECK-NOT: "ttnn.deallocate"([[INPUT1]])
+    // CHECK: "ttnn.deallocate"([[WEIGHTS1]])
+    %4 = ttir.empty() : tensor<8x56x56x64xbf16> loc(#loc5)
+    %5 = "ttir.multiply"(%3, %arg2, %4) : (tensor<8x56x56x64xbf16>, tensor<1x1x1x64xbf16>, tensor<8x56x56x64xbf16>) -> tensor<8x56x56x64xbf16> loc(#loc6)
+    %6 = ttir.empty() : tensor<8x56x56x64xbf16> loc(#loc7)
+    %7 = "ttir.add"(%5, %arg3, %6) : (tensor<8x56x56x64xbf16>, tensor<1x1x1x64xbf16>, tensor<8x56x56x64xbf16>) -> tensor<8x56x56x64xbf16> loc(#loc8)
+    %8 = ttir.empty() : tensor<8x56x56x64xbf16> loc(#loc9)
+    %9 = "ttir.relu"(%7, %8) : (tensor<8x56x56x64xbf16>, tensor<8x56x56x64xbf16>) -> tensor<8x56x56x64xbf16> loc(#loc10)
+    %10 = ttir.empty() : tensor<8x56x56x64xbf16> loc(#loc11)
+    // CHECK: "ttnn.conv2d"([[INPUT2:%.+]], [[WEIGHTS2:%.+]], {{%.*}}) {{.*}} conv2d_config = #ttnn.conv2d_config<{{.*}}deallocate_activation = true{{.*}}>
+    %11 = "ttir.conv2d"(%9, %arg4, %10) <{dilation = array<i32: 1, 1>, groups = 1 : i32, padding = array<i32: 1, 1, 1, 1>, stride = array<i32: 1, 1>}> {channel_last = 1 : si32} : (tensor<8x56x56x64xbf16>, tensor<64x64x3x3xbf16>, tensor<8x56x56x64xbf16>) -> tensor<8x56x56x64xbf16> loc(#loc12)
+    // CHECK-NOT: "ttnn.deallocate"([[INPUT2]])
+    // CHECK: "ttnn.deallocate"([[WEIGHTS2]])
+    %12 = ttir.empty() : tensor<8x56x56x64xbf16> loc(#loc13)
+    %13 = "ttir.multiply"(%11, %arg5, %12) : (tensor<8x56x56x64xbf16>, tensor<1x1x1x64xbf16>, tensor<8x56x56x64xbf16>) -> tensor<8x56x56x64xbf16> loc(#loc14)
+    %14 = ttir.empty() : tensor<8x56x56x64xbf16> loc(#loc15)
+    %15 = "ttir.add"(%13, %arg6, %14) : (tensor<8x56x56x64xbf16>, tensor<1x1x1x64xbf16>, tensor<8x56x56x64xbf16>) -> tensor<8x56x56x64xbf16> loc(#loc16)
+    %16 = ttir.empty() : tensor<8x56x56x64xbf16> loc(#loc17)
+    %17 = "ttir.relu"(%15, %16) : (tensor<8x56x56x64xbf16>, tensor<8x56x56x64xbf16>) -> tensor<8x56x56x64xbf16> loc(#loc18)
+    %18 = ttir.empty() : tensor<8x56x56x256xbf16> loc(#loc19)
+    %19 = "ttir.conv2d"(%17, %arg7, %18) <{dilation = array<i32: 1, 1>, groups = 1 : i32, padding = array<i32: 0, 0, 0, 0>, stride = array<i32: 1, 1>}> {channel_last = 1 : si32} : (tensor<8x56x56x64xbf16>, tensor<256x64x1x1xbf16>, tensor<8x56x56x256xbf16>) -> tensor<8x56x56x256xbf16> loc(#loc20)
+    %20 = ttir.empty() : tensor<8x56x56x256xbf16> loc(#loc21)
+    %21 = "ttir.multiply"(%19, %arg8, %20) : (tensor<8x56x56x256xbf16>, tensor<1x1x1x256xbf16>, tensor<8x56x56x256xbf16>) -> tensor<8x56x56x256xbf16> loc(#loc22)
+    %22 = ttir.empty() : tensor<8x56x56x256xbf16> loc(#loc23)
+    %23 = "ttir.add"(%21, %arg9, %22) : (tensor<8x56x56x256xbf16>, tensor<1x1x1x256xbf16>, tensor<8x56x56x256xbf16>) -> tensor<8x56x56x256xbf16> loc(#loc24)
+    %24 = ttir.empty() : tensor<8x56x56x256xbf16> loc(#loc25)
+    %25 = "ttir.add"(%23, %1, %24) : (tensor<8x56x56x256xbf16>, tensor<8x56x56x256xbf16>, tensor<8x56x56x256xbf16>) -> tensor<8x56x56x256xbf16> loc(#loc26)
+    return %25 : tensor<8x56x56x256xbf16>
+  }
+}
+#loc1 = loc("empty_for_initial_relu")
+#loc2 = loc("initial_relu")
+#loc3 = loc("empty_for_conv1")
+#loc4 = loc("conv1")
+#loc5 = loc("empty_for_conv1_scale")
+#loc6 = loc("conv1_scale")
+#loc7 = loc("empty_for_conv1_bias")
+#loc8 = loc("conv1_bias")
+#loc9 = loc("empty_for_conv1_relu")
+#loc10 = loc("conv1_relu")
+#loc11 = loc("empty_for_conv2")
+#loc12 = loc("conv2")
+#loc13 = loc("empty_for_conv2_scale")
+#loc14 = loc("conv2_scale")
+#loc15 = loc("empty_for_conv2_bias")
+#loc16 = loc("conv2_bias")
+#loc17 = loc("empty_for_conv2_relu")
+#loc18 = loc("conv2_relu")
+#loc19 = loc("empty_for_conv3")
+#loc20 = loc("conv3")
+#loc21 = loc("empty_for_conv3_scale")
+#loc22 = loc("conv3_scale")
+#loc23 = loc("empty_for_conv3_bias")
+#loc24 = loc("conv3_bias")
+#loc25 = loc("empty_for_residual")
+#loc26 = loc("residual_add")


### PR DESCRIPTION
### Ticket
Closes #3383

### Problem description
When overriding `dellocate_activation` parameter in Conv2dConfig, a `ttnnTensor.is_allocated()` error may occur in runtime due to a deallocate op for conv2d activation already being added in the `TTNNDeallocate` pass.

### What's changed
- `ttnn.deallocate` will not be added in `TTNNDeallocate` pass for conv2d op activation if `deallocate_activation` parameter is set to `true`.
- added a test `test/ttmlir/Silicon/TTNN/n150/deallocate_override.mlir`
- (_not related to the issue_) changed `test/ttmlir/Dialect/TTNN/optimizer/conv2d_config_override.mlir` to be more flexible if new conv2d config parameters are added