### PR TITLE
D2M: Remove port, address, pageSize, numBuffers from TTKernel CBType

### DIFF
--- a/docs/src/python-bindings.md
+++ b/docs/src/python-bindings.md
@@ -272,8 +272,8 @@ MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(
 
 using namespace mlir::tt::ttkernel;
 
-MlirType ttmlirTTKernelCBTypeGet(MlirContext ctx, uint64_t port, uint64_t address, MlirType memrefType) {
-  return wrap(CBType::get(unwrap(ctx), symbolizeCBPort(port).value(), address, mlir::cast<mlir::MemRefType>(unwrap(memrefType))));
+MlirType ttmlirTTKernelCBTypeGet(MlirContext ctx, MlirType memrefType) {
+  return wrap(CBType::get(unwrap(ctx), mlir::cast<mlir::MemRefType>(unwrap(memrefType))));
 }
 ```
 7. Define the `nanobind` build target in `python/CMakeLists.txt` by adding `ttkernel` as a dialect, and providing `TTkernelModule.cpp` as a source for `TTMLIRPythonExtensions.Main`.

--- a/include/ttmlir-c/TTKernelTypes.h
+++ b/include/ttmlir-c/TTKernelTypes.h
@@ -14,8 +14,36 @@ extern "C" {
 MLIR_CAPI_EXPORTED MlirType ttmlirTTKernelCBTypeGet(MlirContext ctx,
                                                     MlirType memrefType);
 
+MLIR_CAPI_EXPORTED MlirType ttmlirTTKernelSemaphoreTypeGet(MlirContext ctx);
+
+MLIR_CAPI_EXPORTED MlirType ttmlirTTKernelNocAddrTypeGet(MlirContext ctx);
+
 MLIR_CAPI_EXPORTED MlirAttribute
 ttmlirTTKernelThreadTypeAttrGet(MlirContext ctx, uint32_t enumValue);
+
+MLIR_CAPI_EXPORTED MlirAttribute
+ttmlirTTKernelReduceTypeAttrGet(MlirContext ctx, uint32_t enumValue);
+
+MLIR_CAPI_EXPORTED MlirAttribute
+ttmlirTTKernelReduceDimAttrGet(MlirContext ctx, uint32_t enumValue);
+
+MLIR_CAPI_EXPORTED MlirType ttmlirTTKernelL1AddrTypeGet(MlirContext ctx);
+
+MLIR_CAPI_EXPORTED MlirType ttmlirTTKernelL1AddrPtrTypeGet(MlirContext ctx);
+
+MLIR_CAPI_EXPORTED MlirType
+ttmlirTTKernelInterleavedAddrGenFastTypeGet(MlirContext ctx);
+
+MLIR_CAPI_EXPORTED MlirType ttmlirTTKernelDataFormatTypeGet(MlirContext ctx);
+
+MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTKernelArgAttrGet(MlirContext ctx,
+                                                          MlirType argType,
+                                                          size_t operandIndex,
+                                                          bool is_uniform);
+
+MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTKernelArgSpecAttrGet(
+    MlirContext ctx, MlirAttribute *rt_args, size_t rt_args_size,
+    MlirAttribute *ct_args, size_t ct_args_size);
 
 #ifdef __cplusplus
 }

--- a/include/ttmlir-c/TTKernelTypes.h
+++ b/include/ttmlir-c/TTKernelTypes.h
@@ -39,11 +39,11 @@ MLIR_CAPI_EXPORTED MlirType ttmlirTTKernelDataFormatTypeGet(MlirContext ctx);
 MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTKernelArgAttrGet(MlirContext ctx,
                                                           MlirType argType,
                                                           size_t operandIndex,
-                                                          bool is_uniform);
+                                                          bool isUniform);
 
 MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTKernelArgSpecAttrGet(
-    MlirContext ctx, MlirAttribute *rt_args, size_t rt_args_size,
-    MlirAttribute *ct_args, size_t ct_args_size);
+    MlirContext ctx, MlirAttribute *rtArgs, size_t rtArgsSize,
+    MlirAttribute *ctArgs, size_t ctArgsSize);
 
 #ifdef __cplusplus
 }

--- a/include/ttmlir-c/TTKernelTypes.h
+++ b/include/ttmlir-c/TTKernelTypes.h
@@ -12,8 +12,6 @@ extern "C" {
 #endif
 
 MLIR_CAPI_EXPORTED MlirType ttmlirTTKernelCBTypeGet(MlirContext ctx,
-                                                    uint64_t address,
-                                                    uint64_t port,
                                                     MlirType memrefType);
 
 MLIR_CAPI_EXPORTED MlirAttribute

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
@@ -20,28 +20,10 @@ class TTKernel_Type<string name, string typeMnemonic, list<Trait> traits = []>
 def TTKernel_CB : TTKernel_Type<"CB", "cb"> {
     let summary = "TTKernel cb";
     let description = "Circular buffer type in TTKernel dialect";
-    let parameters = (ins "CBPort":$port,
-                          "uint64_t":$address,
-                          "MemRefType":$memref,
-                          "uint64_t":$page_size,
-                          "uint64_t":$num_buffers);
-    let assemblyFormat = "`<` $port`,` $address`,` $memref`,` $page_size`,` $num_buffers `>`";
+    let parameters = (ins "MemRefType":$memref);
+    let assemblyFormat = "`<` $memref `>`";
 
     let extraClassDeclaration = [{
-        static CBType get(::mlir::MLIRContext *context,
-                              CBPort port,
-                              uint64_t address,
-                              MemRefType memref) {
-          uint64_t numBuffers = 1;
-          uint64_t pageSize = 0;
-          if (::mlir::isa<::mlir::tt::TileType>(memref.getElementType())) {
-            pageSize = ::mlir::cast<::mlir::tt::TileType>(memref.getElementType()).getSizeBytes();
-          } else {
-            pageSize = memref.getShape().back() * (memref.getElementType().getIntOrFloatBitWidth() / 8);
-          }
-          return CBType::get(context, port, address, memref, pageSize, numBuffers);
-        }
-
         ::llvm::ArrayRef<int64_t> getShape() const {
           return getMemref().getShape();
         }

--- a/lib/CAPI/TTKernelTypes.cpp
+++ b/lib/CAPI/TTKernelTypes.cpp
@@ -70,11 +70,13 @@ MlirAttribute ttmlirTTKernelArgSpecAttrGet(MlirContext ctx,
                                            size_t ct_args_size) {
   std::vector<ArgAttr> _rt_args, _ct_args;
 
-  for (size_t i = 0; i < rt_args_size; i++)
+  for (size_t i = 0; i < rt_args_size; i++) {
     _rt_args.emplace_back(mlir::cast<ArgAttr>(unwrap(rt_args[i])));
+  }
 
-  for (size_t i = 0; i < ct_args_size; i++)
+  for (size_t i = 0; i < ct_args_size; i++) {
     _ct_args.emplace_back(mlir::cast<ArgAttr>(unwrap(ct_args[i])));
+  }
 
   return wrap(ArgSpecAttr::get(unwrap(ctx), _rt_args, _ct_args));
 }

--- a/lib/CAPI/TTKernelTypes.cpp
+++ b/lib/CAPI/TTKernelTypes.cpp
@@ -58,24 +58,24 @@ MlirType ttmlirTTKernelDataFormatTypeGet(MlirContext ctx) {
 }
 
 MlirAttribute ttmlirTTKernelArgAttrGet(MlirContext ctx, uint32_t argTypeValue,
-                                       size_t operandIndex, bool is_uniform) {
+                                       size_t operandIndex, bool isUniform) {
   return wrap(ArgAttr::get(unwrap(ctx), static_cast<ArgType>(argTypeValue),
                            operandIndex));
 }
 
 MlirAttribute ttmlirTTKernelArgSpecAttrGet(MlirContext ctx,
-                                           MlirAttribute *rt_args,
-                                           size_t rt_args_size,
-                                           MlirAttribute *ct_args,
-                                           size_t ct_args_size) {
+                                           MlirAttribute *rtArgs,
+                                           size_t rtArgsSize,
+                                           MlirAttribute *ctArgs,
+                                           size_t ctArgsSize) {
   std::vector<ArgAttr> _rt_args, _ct_args;
 
-  for (size_t i = 0; i < rt_args_size; i++) {
-    _rt_args.emplace_back(mlir::cast<ArgAttr>(unwrap(rt_args[i])));
+  for (size_t i = 0; i < rtArgsSize; i++) {
+    _rt_args.emplace_back(mlir::cast<ArgAttr>(unwrap(rtArgs[i])));
   }
 
-  for (size_t i = 0; i < ct_args_size; i++) {
-    _ct_args.emplace_back(mlir::cast<ArgAttr>(unwrap(ct_args[i])));
+  for (size_t i = 0; i < ctArgsSize; i++) {
+    _ct_args.emplace_back(mlir::cast<ArgAttr>(unwrap(ctArgs[i])));
   }
 
   return wrap(ArgSpecAttr::get(unwrap(ctx), _rt_args, _ct_args));

--- a/lib/CAPI/TTKernelTypes.cpp
+++ b/lib/CAPI/TTKernelTypes.cpp
@@ -10,9 +10,8 @@
 
 using namespace mlir::tt::ttkernel;
 
-MlirType ttmlirTTKernelCBTypeGet(MlirContext ctx, uint64_t address,
-                                 uint64_t port, MlirType memrefType) {
-  return wrap(CBType::get(unwrap(ctx), symbolizeCBPort(port).value(), address,
+MlirType ttmlirTTKernelCBTypeGet(MlirContext ctx, MlirType memrefType) {
+  return wrap(CBType::get(unwrap(ctx),
                           mlir::cast<mlir::MemRefType>(unwrap(memrefType))));
 }
 

--- a/lib/CAPI/TTKernelTypes.cpp
+++ b/lib/CAPI/TTKernelTypes.cpp
@@ -15,8 +15,66 @@ MlirType ttmlirTTKernelCBTypeGet(MlirContext ctx, MlirType memrefType) {
                           mlir::cast<mlir::MemRefType>(unwrap(memrefType))));
 }
 
-MLIR_CAPI_EXPORTED MlirAttribute
-ttmlirTTKernelThreadTypeAttrGet(MlirContext ctx, uint32_t enumValue) {
+MlirType ttmlirTTKernelSemaphoreTypeGet(MlirContext ctx) {
+  return wrap(SemaphoreType::get(unwrap(ctx)));
+}
+
+MlirType ttmlirTTKernelNocAddrTypeGet(MlirContext ctx) {
+  return wrap(NocAddrType::get(unwrap(ctx)));
+}
+
+MlirAttribute ttmlirTTKernelThreadTypeAttrGet(MlirContext ctx,
+                                              uint32_t enumValue) {
   return wrap(
       ThreadTypeAttr::get(unwrap(ctx), static_cast<ThreadType>(enumValue)));
+}
+
+MlirAttribute ttmlirTTKernelReduceTypeAttrGet(MlirContext ctx,
+                                              uint32_t enumValue) {
+  return wrap(
+      ReduceTypeAttr::get(unwrap(ctx), static_cast<ReduceType>(enumValue)));
+}
+
+MlirAttribute ttmlirTTKernelReduceDimAttrGet(MlirContext ctx,
+                                             uint32_t enumValue) {
+  return wrap(
+      ReduceDimAttr::get(unwrap(ctx), static_cast<ReduceDim>(enumValue)));
+}
+
+MlirType ttmlirTTKernelL1AddrTypeGet(MlirContext ctx) {
+  return wrap(L1AddrType::get(unwrap(ctx)));
+}
+
+MlirType ttmlirTTKernelL1AddrPtrTypeGet(MlirContext ctx) {
+  return wrap(L1AddrPtrType::get(unwrap(ctx)));
+}
+
+MlirType ttmlirTTKernelInterleavedAddrGenFastTypeGet(MlirContext ctx) {
+  return wrap(InterleavedAddrGenFastType::get(unwrap(ctx)));
+}
+
+MlirType ttmlirTTKernelDataFormatTypeGet(MlirContext ctx) {
+  return wrap(DataFormatType::get(unwrap(ctx)));
+}
+
+MlirAttribute ttmlirTTKernelArgAttrGet(MlirContext ctx, uint32_t argTypeValue,
+                                       size_t operandIndex, bool is_uniform) {
+  return wrap(ArgAttr::get(unwrap(ctx), static_cast<ArgType>(argTypeValue),
+                           operandIndex));
+}
+
+MlirAttribute ttmlirTTKernelArgSpecAttrGet(MlirContext ctx,
+                                           MlirAttribute *rt_args,
+                                           size_t rt_args_size,
+                                           MlirAttribute *ct_args,
+                                           size_t ct_args_size) {
+  std::vector<ArgAttr> _rt_args, _ct_args;
+
+  for (size_t i = 0; i < rt_args_size; i++)
+    _rt_args.emplace_back(mlir::cast<ArgAttr>(unwrap(rt_args[i])));
+
+  for (size_t i = 0; i < ct_args_size; i++)
+    _ct_args.emplace_back(mlir::cast<ArgAttr>(unwrap(ct_args[i])));
+
+  return wrap(ArgSpecAttr::get(unwrap(ctx), _rt_args, _ct_args));
 }

--- a/lib/Conversion/TTIRToTTKernel/TTIRToTTKernelPass.cpp
+++ b/lib/Conversion/TTIRToTTKernel/TTIRToTTKernelPass.cpp
@@ -85,7 +85,7 @@ struct ConvertTTIRToTTKernel
         return IndexType::get(memref.getContext());
       }
       return ttkernel::CBType::get(
-          memref.getContext(), ttkernel::symbolizeCBPort(0).value(), 0, memref);
+          memref.getContext(), memref);
     });
     typeConverter.addConversion([](ttir::SemaphoreType semaphore) {
       return ttkernel::SemaphoreType::get(semaphore.getContext());

--- a/lib/Conversion/TTIRToTTKernel/TTIRToTTKernelPass.cpp
+++ b/lib/Conversion/TTIRToTTKernel/TTIRToTTKernelPass.cpp
@@ -84,8 +84,7 @@ struct ConvertTTIRToTTKernel
       if (tt::getMemorySpace(memref) == tt::MemorySpace::RegisterDst) {
         return IndexType::get(memref.getContext());
       }
-      return ttkernel::CBType::get(
-          memref.getContext(), memref);
+      return ttkernel::CBType::get(memref.getContext(), memref);
     });
     typeConverter.addConversion([](ttir::SemaphoreType semaphore) {
       return ttkernel::SemaphoreType::get(semaphore.getContext());

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -234,47 +234,6 @@ public:
 } // namespace
 
 namespace {
-class TTKernelToEmitCFuncArgsRewriter
-    : public OpConversionPattern<func::FuncOp> {
-public:
-  TTKernelToEmitCFuncArgsRewriter(TTKernelToEmitCTypeConverter &typeConverter,
-                                  MLIRContext *ctx)
-      : OpConversionPattern<func::FuncOp>(typeConverter, ctx) {}
-
-  LogicalResult
-  matchAndRewrite(func::FuncOp op, func::FuncOp::Adaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const final {
-    assert(op.getCallableRegion());
-    assert(op.getCallableRegion()->hasOneBlock());
-    Block *block = &op.getCallableRegion()->front();
-    auto blockArgs = block->getArguments();
-    if (blockArgs.empty()) {
-      return rewriter.notifyMatchFailure(op, "No block arguments");
-    }
-
-    TypeConverter::SignatureConversion signatureConverter(op.getNumArguments());
-    OpBuilder::InsertionGuard funcInsertionGuard(rewriter);
-    rewriter.setInsertionPointToStart(block);
-    for (auto arg : blockArgs) {
-      auto cb = cast<ttkernel::CBType>(arg.getType());
-      auto cbType = getTypeConverter()->convertType(cb);
-      auto cbPort = rewriter.create<emitc::ConstantOp>(
-          op.getLoc(), cbType, convertCBPort(rewriter, cb.getPort()));
-      signatureConverter.remapInput(arg.getArgNumber(), cbPort.getResult());
-    }
-
-    rewriter.applySignatureConversion(block, signatureConverter,
-                                      getTypeConverter());
-    rewriter.modifyOpInPlace(op, [&]() {
-      op.setType(rewriter.getFunctionType(TypeRange(), TypeRange()));
-    });
-
-    return success();
-  }
-};
-} // namespace
-
-namespace {
 template <typename SourceOp, typename Adaptor = typename SourceOp::Adaptor>
 class TTKernelToEmitCOpaqueRewriter : public OpConversionPattern<SourceOp> {
 public:
@@ -605,7 +564,6 @@ public:
     populateMemRefToEmitCConversionPatterns(patterns, typeConverter);
 
     patterns.add<
-        TTKernelToEmitCFuncArgsRewriter,
         TTKernelToEmitCGetCompileArgValRewriter, TTKernelToEmitCDPrintRewriter,
         TTKernelToEmitCPassthroughRewriter<ttkernel::CBReinterpretShapeOp>,
         TTKernelMacroOpToEmitCOpRewriter<ttkernel::MemZerosBaseOp>,

--- a/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
@@ -159,25 +159,11 @@ static std::string verifyTilizeUntilizeCBs(CBType tilizedCB, CBType scalarCB) {
 ::mlir::LogicalResult CBReinterpretShapeOp::verify() {
   auto inCBType = getInput().getType();
   auto outCBType = getOutput().getType();
-  if (inCBType.getPort() != outCBType.getPort()) {
-    return emitOpError("input circular buffer port and output circular buffer "
-                       "port must be the same");
-  }
-
-  if (inCBType.getAddress() != outCBType.getAddress()) {
-    return emitOpError("input circular buffer address and output circular "
-                       "buffer address must be the same");
-  }
 
   if (inCBType.getMemref().getElementType() !=
       outCBType.getMemref().getElementType()) {
     return emitOpError("input circular buffer element type and output "
                        "circular buffer element type must be the same");
-  }
-
-  if (inCBType.getNumBuffers() != outCBType.getNumBuffers()) {
-    return emitOpError("input circular buffer number of buffers and output "
-                       "circular buffer number of buffers must be the same");
   }
 
   return success();

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -45,6 +45,8 @@ declare_mlir_dialect_python_bindings(
   ADD_TO_PARENT TTMLIRPythonSources.Dialects
   ROOT_DIR "${TTMLIR_PYTHON_ROOT_DIR}"
   TD_FILE dialects/TTKernelBinding.td
+  GEN_ENUM_BINDINGS ON
+  GEN_ENUM_BINDINGS_TD_FILE dialects/TTKernelEnumBinding.td
   SOURCES dialects/ttkernel.py
   DIALECT_NAME ttkernel
 )

--- a/python/TTKernelModule.cpp
+++ b/python/TTKernelModule.cpp
@@ -95,16 +95,16 @@ void populateTTKernelModule(nb::module_ &m) {
 
   tt_attribute_class<tt::ttkernel::ArgSpecAttr>(m, "ArgSpecAttr")
       .def_static("get",
-                  [](MlirContext ctx, std::vector<MlirAttribute> rt_args,
-                     std::vector<MlirAttribute> ct_args) {
+                  [](MlirContext ctx, std::vector<MlirAttribute> rtArgs,
+                     std::vector<MlirAttribute> ctArgs) {
                     std::vector<tt::ttkernel::ArgAttr> _rt_args, _ct_args;
 
-                    for (const auto &x : rt_args) {
+                    for (const auto &x : rtArgs) {
                       _rt_args.emplace_back(
                           mlir::cast<tt::ttkernel::ArgAttr>(unwrap(x)));
                     }
 
-                    for (const auto &x : ct_args) {
+                    for (const auto &x : ctArgs) {
                       _ct_args.emplace_back(
                           mlir::cast<tt::ttkernel::ArgAttr>(unwrap(x)));
                     }

--- a/python/TTKernelModule.cpp
+++ b/python/TTKernelModule.cpp
@@ -15,10 +15,8 @@ namespace mlir::ttmlir::python {
 void populateTTKernelModule(nb::module_ &m) {
   tt_type_class<tt::ttkernel::CBType>(m, "CBType")
       .def_static("get",
-                  [](MlirContext ctx, uint64_t address, uint64_t port,
-                     MlirType memrefType) {
-                    return ttmlirTTKernelCBTypeGet(ctx, address, port,
-                                                   memrefType);
+                  [](MlirContext ctx, MlirType memrefType) {
+                    return ttmlirTTKernelCBTypeGet(ctx, memrefType);
                   })
       .def_static("cast",
                   [](MlirType &ty) {

--- a/python/TTKernelModule.cpp
+++ b/python/TTKernelModule.cpp
@@ -99,13 +99,15 @@ void populateTTKernelModule(nb::module_ &m) {
                      std::vector<MlirAttribute> ct_args) {
                     std::vector<tt::ttkernel::ArgAttr> _rt_args, _ct_args;
 
-                    for (const auto &x : rt_args)
+                    for (const auto &x : rt_args) {
                       _rt_args.emplace_back(
                           mlir::cast<tt::ttkernel::ArgAttr>(unwrap(x)));
+                    }
 
-                    for (const auto &x : ct_args)
+                    for (const auto &x : ct_args) {
                       _ct_args.emplace_back(
                           mlir::cast<tt::ttkernel::ArgAttr>(unwrap(x)));
+                    }
 
                     return wrap(tt::ttkernel::ArgSpecAttr::get(
                         unwrap(ctx), _rt_args, _ct_args));

--- a/python/TTKernelModule.cpp
+++ b/python/TTKernelModule.cpp
@@ -28,6 +28,12 @@ void populateTTKernelModule(nb::module_ &m) {
                    })
       .def_prop_ro("memref", &tt::ttkernel::CBType::getMemref);
 
+  tt_type_class<tt::ttkernel::SemaphoreType>(m, "SemaphoreType")
+      .def_static("get", &ttmlirTTKernelSemaphoreTypeGet);
+
+  tt_type_class<tt::ttkernel::NocAddrType>(m, "NocAddrType")
+      .def_static("get", &ttmlirTTKernelNocAddrTypeGet);
+
   tt_attribute_class<tt::ttkernel::ThreadTypeAttr>(m, "ThreadTypeAttr")
       .def_prop_ro_static("name",
                           [](nb::handle /*unused*/) {
@@ -47,6 +53,65 @@ void populateTTKernelModule(nb::module_ &m) {
         return ttmlirTTKernelThreadTypeAttrGet(
             ctx, static_cast<std::underlying_type_t<tt::ttkernel::ThreadType>>(
                      threadType));
+      });
+
+  tt_attribute_class<tt::ttkernel::ReduceTypeAttr>(m, "ReduceTypeAttr")
+      .def_static("get", &ttmlirTTKernelReduceTypeAttrGet)
+      .def_prop_ro("value", &tt::ttkernel::ReduceTypeAttr::getValue);
+
+  tt_attribute_class<tt::ttkernel::ReduceDimAttr>(m, "ReduceDimAttr")
+      .def_static("get", &ttmlirTTKernelReduceDimAttrGet)
+      .def_prop_ro("value", &tt::ttkernel::ReduceDimAttr::getValue);
+
+  tt_type_class<tt::ttkernel::L1AddrType>(m, "L1AddrType")
+      .def_static("get", &ttmlirTTKernelL1AddrTypeGet);
+
+  tt_type_class<tt::ttkernel::L1AddrPtrType>(m, "L1AddrPtrType")
+      .def_static("get", &ttmlirTTKernelL1AddrPtrTypeGet);
+
+  tt_type_class<tt::ttkernel::InterleavedAddrGenFastType>(
+      m, "InterleavedAddrGenFastType")
+      .def_static("get", &ttmlirTTKernelInterleavedAddrGenFastTypeGet);
+
+  tt_type_class<tt::ttkernel::DataFormatType>(m, "DataFormatType")
+      .def_static("get", &ttmlirTTKernelDataFormatTypeGet);
+
+  tt_attribute_class<tt::ttkernel::ArgAttr>(m, "ArgAttr")
+      .def_static(
+          "get",
+          [](MlirContext ctx, uint32_t argTypeValue, size_t operandIndex,
+             bool isUniform = true) {
+            return wrap(tt::ttkernel::ArgAttr::get(
+                unwrap(ctx), static_cast<tt::ttkernel::ArgType>(argTypeValue),
+                operandIndex, isUniform));
+          },
+          nb::arg("ctx"), nb::arg("argTypeValue"), nb::arg("operandIndex"),
+          nb::arg("isUniform") = true)
+      .def_prop_ro("is_uniform", &tt::ttkernel::ArgAttr::getIsUniform)
+      .def_prop_ro("operand_index", &tt::ttkernel::ArgAttr::getOperandIndex)
+      .def_prop_ro("arg_type_as_value", [](tt::ttkernel::ArgAttr &self) {
+        return static_cast<uint32_t>(self.getArgType());
+      });
+
+  tt_attribute_class<tt::ttkernel::ArgSpecAttr>(m, "ArgSpecAttr")
+      .def_static("get",
+                  [](MlirContext ctx, std::vector<MlirAttribute> rt_args,
+                     std::vector<MlirAttribute> ct_args) {
+                    std::vector<tt::ttkernel::ArgAttr> _rt_args, _ct_args;
+
+                    for (const auto &x : rt_args)
+                      _rt_args.emplace_back(
+                          mlir::cast<tt::ttkernel::ArgAttr>(unwrap(x)));
+
+                    for (const auto &x : ct_args)
+                      _ct_args.emplace_back(
+                          mlir::cast<tt::ttkernel::ArgAttr>(unwrap(x)));
+
+                    return wrap(tt::ttkernel::ArgSpecAttr::get(
+                        unwrap(ctx), _rt_args, _ct_args));
+                  })
+      .def_prop_ro_static("name", [](nb::handle) {
+        return std::string(tt::ttkernel::ArgSpecAttr::name);
       });
 }
 } // namespace mlir::ttmlir::python

--- a/python/ttmlir/dialects/TTKernelEnumBinding.td
+++ b/python/ttmlir/dialects/TTKernelEnumBinding.td
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PYTHON_BINDINGS_TTMLIR_TTKERNELENUMS
+#define PYTHON_BINDINGS_TTMLIR_TTKERNELENUMS
+
+include "ttmlir/Dialect/TTKernel/IR/TTKernelOpsEnums.td"
+
+#endif

--- a/python/ttmlir/dialects/ttkernel.py
+++ b/python/ttmlir/dialects/ttkernel.py
@@ -3,4 +3,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from ._ttkernel_ops_gen import *
+from ._ttkernel_enum_gen import *
 from .._mlir_libs._ttmlir import ttkernel_ir as ir

--- a/test/pykernel/eltwise_sfpu/eltwise_sfpu.py
+++ b/test/pykernel/eltwise_sfpu/eltwise_sfpu.py
@@ -12,13 +12,13 @@ from pykernel.types import *
 @ttkernel_tensix_compile()
 def eltwise_sfpu(cb_in: CircularBuffer, cb_out: CircularBuffer):
     # CHECK: module {
-    # CHECK: func.func @{{.*}}(%arg0: !ttkernel.cb<{{.*}}>, %arg1: !ttkernel.cb<{{.*}}>) attributes {ttkernel.thread = #ttkernel.thread<compute>} {
+    # CHECK: func.func @eltwise_sfpu() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
     # CHECK: {{.*}}"ttkernel.get_compile_time_arg_val"{{.*}}
     # CHECK: {{.*}}"ttkernel.get_compile_time_arg_val"{{.*}}
-    per_core_block_cnt = get_compile_time_arg_val(int, 0)
-    per_core_block_dim = get_compile_time_arg_val(int, 1)
+    per_core_block_cnt = get_compile_time_arg_val(int, 2)
+    per_core_block_dim = get_compile_time_arg_val(int, 3)
 
-    # CHECK: "ttkernel.unary_op_init_common"(%arg0, %arg1){{.*}}
+    # CHECK: "ttkernel.unary_op_init_common"({{.*}})
     unary_op_init_common(cb_in, cb_out)
 
     for i in range(0, per_core_block_cnt, 1):

--- a/test/pykernel/eltwise_sfpu/reader_unary.py
+++ b/test/pykernel/eltwise_sfpu/reader_unary.py
@@ -12,7 +12,7 @@ from pykernel.types import *
 @ttkernel_noc_compile(verbose=True)
 def reader_unary(cb_in: CircularBuffer, cb_out: CircularBuffer):
     # CHECK: module {
-    # CHECK: func.func @{{.*}}(%arg0: !ttkernel.cb<{{.*}}>, %arg1: !ttkernel.cb<{{.*}}>) attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+    # CHECK: func.func @reader_unary() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<noc>} {
     # CHECK: emitc.verbatim "// --- Python Function {{.*}}"
     # CHECK: emitc.verbatim "// src_addr: int = get_arg_val{{.*}}"
     # CHECK: {{.*}}"ttkernel.get_arg_val"{{.*}}

--- a/test/pykernel/eltwise_sfpu/writer_unary.py
+++ b/test/pykernel/eltwise_sfpu/writer_unary.py
@@ -12,7 +12,7 @@ from pykernel.types import *
 @ttkernel_noc_compile()
 def writer_unary(cb_in: CircularBuffer, cb_out: CircularBuffer):
     # CHECK: module {
-    # CHECK: func.func @{{.*}}(%arg0: !ttkernel.cb<{{.*}}>, %arg1: !ttkernel.cb<{{.*}}>) attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+    # CHECK: func.func @writer_unary() attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<noc>} {
     # CHECK: {{.*}}"ttkernel.get_arg_val"{{.*}}
     # CHECK: %[[DST_ADDR:.*]] = memref.alloca(){{.*}}
     # CHECK: %[[BANK_ID:.*]] = "ttkernel.get_arg_val"{{.*}}

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -186,18 +186,22 @@ module {
     }
 
     // CHECK-LABEL: func @sub_tiles_init
-    func.func @sub_tiles_init(%cb0: !cb0_tiles, %cb1: !cb1_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
-      // CHECK: %[[CB0:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
-      // CHECK: %[[CB1:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+    func.func @sub_tiles_init() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[CB0:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %cb0 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
+      // CHECK: %[[CB1:.*]] = emitc.literal "get_compile_time_arg_val(1)"
+      %cb1 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> !cb1_tiles
       // CHECK: emitc.call_opaque "sub_tiles_init"(%[[CB0]], %[[CB1]])
       "ttkernel.sub_tiles_init"(%cb0, %cb1) : (!cb0_tiles, !cb1_tiles) -> ()
       return
     }
 
     // CHECK-LABEL: func @sub_tiles
-    func.func @sub_tiles(%cb0: !cb0_tiles, %cb1: !cb1_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
-      // CHECK: %[[CB0:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
-      // CHECK: %[[CB1:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+    func.func @sub_tiles() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[CB0:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %cb0 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
+      // CHECK: %[[CB1:.*]] = emitc.literal "get_compile_time_arg_val(1)"
+      %cb1 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> !cb1_tiles
       // CHECK: %[[CB0_INDEX:.*]] = "emitc.constant"
       %cb0_index = arith.constant 1 : index
       // CHECK: %[[CB1_INDEX:.*]] = "emitc.constant"
@@ -238,10 +242,13 @@ module {
     }
 
     // CHECK-LABEL: func @mm_init
-    func.func @mm_init(%cb_A: !cb0_tiles, %cb_B: !cb1_tiles, %cb_C: !cb2_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
-      // CHECK: %[[CB_A:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
-      // CHECK: %[[CB_B:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
-      // CHECK: %[[CB_C:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+    func.func @mm_init() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>, <arg_type = cb_port, operand_index = 2>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[CB_A:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %cb_A = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
+      // CHECK: %[[CB_B:.*]] = emitc.literal "get_compile_time_arg_val(1)"
+      %cb_B = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> !cb1_tiles
+      // CHECK: %[[CB_C:.*]] = emitc.literal "get_compile_time_arg_val(2)"
+      %cb_C = "ttkernel.get_compile_time_arg_val"() <{arg_index = 2 : i32}> : () -> !cb2_tiles
       // CHECK: %[[TRANSPOSE:.*]] = "emitc.constant"
       %transpose = arith.constant 0 : i32
       // CHECK: emitc.call_opaque "mm_init"(%[[CB_A]], %[[CB_B]], %[[CB_C]], %[[TRANSPOSE]])
@@ -250,9 +257,11 @@ module {
     }
 
     // CHECK-LABEL: func @mm_init_short
-    func.func @mm_init_short(%cb_A: !cb0_tiles, %cb_B: !cb1_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
-      // CHECK: %[[CB_A:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
-      // CHECK: %[[CB_B:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+    func.func @mm_init_short() -> () attributes {ttkernerl.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[CB_A:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %cb_A = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
+      // CHECK: %[[CB_B:.*]] = emitc.literal "get_compile_time_arg_val(1)"
+      %cb_B = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> !cb1_tiles
       // CHECK: %[[TRANSPOSE:.*]] = "emitc.constant"
       %transpose = arith.constant 0 : i32
       // CHECK: emitc.call_opaque "mm_init_short"(%[[CB_A]], %[[CB_B]], %[[TRANSPOSE]])
@@ -261,9 +270,11 @@ module {
     }
 
     // CHECK-LABEL: func @matmul_tiles
-    func.func @matmul_tiles(%cb_A: !cb0_tiles, %cb_B: !cb1_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
-      // CHECK: %[[CB_A:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
-      // CHECK: %[[CB_B:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+    func.func @matmul_tiles() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[CB_A:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %cb_A = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
+      // CHECK: %[[CB_B:.*]] = emitc.literal "get_compile_time_arg_val(1)"
+      %cb_B = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> !cb1_tiles
       // CHECK: %[[TRANSPOSE:.*]] = "emitc.constant"
       // CHECK: %[[CB_IDX_A:.*]] = "emitc.constant"
       // CHECK: %[[CB_IDX_B:.*]] = "emitc.constant"

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -2,13 +2,13 @@
 
 #l1_ = #tt.memory_space<l1>
 
-!cb0_scalar = !ttkernel.cb<cb_in0, 294912, memref<64x128xf32, #l1_>, 4096, 1>
-!cb1_scalar = !ttkernel.cb<cb_in1, 299008, memref<64x128xf32, #l1_>, 4096, 1>
-!cb2_scalar = !ttkernel.cb<cb_in2, 303104, memref<64x128xf32, #l1_>, 4096, 1>
+!cb0_scalar = !ttkernel.cb<memref<64x128xf32, #l1_>>
+!cb1_scalar = !ttkernel.cb<memref<64x128xf32, #l1_>>
+!cb2_scalar = !ttkernel.cb<memref<64x128xf32, #l1_>>
 
-!cb0_tiles = !ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>
-!cb1_tiles = !ttkernel.cb<cb_in1, 299008, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>
-!cb2_tiles = !ttkernel.cb<cb_in2, 303104, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>
+!cb0_tiles = !ttkernel.cb<memref<2x4x!tt.tile<32x32, f32>, #l1_>>
+!cb1_tiles = !ttkernel.cb<memref<2x4x!tt.tile<32x32, f32>, #l1_>>
+!cb2_tiles = !ttkernel.cb<memref<2x4x!tt.tile<32x32, f32>, #l1_>>
 
 module {
 
@@ -48,8 +48,9 @@ module {
     }
 
     // CHECK-LABEL: func @pack_tile
-    func.func @pack_tile(%out_cb: !cb0_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
-      // CHECK: %[[OUT_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+    func.func @pack_tile() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[OUT_CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %out_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
       // CHECK: %[[DST_INDEX:.*]] = "emitc.constant"
       %dst_index = arith.constant 3 : index
       // CHECK: %[[OUT_CB_INDEX:.*]] = "emitc.constant"
@@ -60,16 +61,18 @@ module {
     }
 
     // CHECK-LABEL: func @copy_tile_init
-    func.func @copy_tile_init(%cb: !cb0_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
-      // CHECK: %[[CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+    func.func @copy_tile_init() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
       // CHECK: emitc.call_opaque "copy_tile_init"(%[[CB]])
       "ttkernel.copy_tile_init"(%cb) : (!cb0_tiles) -> ()
       return
     }
 
     // CHECK-LABEL: func @copy_tile
-    func.func @copy_tile(%cb: !cb0_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
-      // CHECK: %[[CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+    func.func @copy_tile() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
       // CHECK: %[[CB_INDEX:.*]] = "emitc.constant"
       %cb_index = arith.constant 2 : index
       // CHECK: %[[DST_INDEX:.*]] = "emitc.constant"
@@ -131,37 +134,46 @@ module {
   module @ttkernel_fpu_operations {
 
     // CHECK-LABEL: func @unary_op_init_common
-    func.func @unary_op_init_common(%in_cb: !cb0_tiles, %out_cb: !cb1_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
-      // CHECK: %[[IN_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
-      // CHECK: %[[OUT_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+    func.func @unary_op_init_common() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[IN_CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %in_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
+      // CHECK: %[[OUT_CB:.*]] = emitc.literal "get_compile_time_arg_val(1)"
+      %out_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> !cb1_tiles
       // CHECK: emitc.call_opaque "unary_op_init_common"(%[[IN_CB]], %[[OUT_CB]])
       "ttkernel.unary_op_init_common"(%in_cb, %out_cb) : (!cb0_tiles, !cb1_tiles) -> ()
       return
     }
 
     // CHECK-LABEL: func @binary_op_init_common
-    func.func @binary_op_init_common(%cb0: !cb0_tiles, %cb1: !cb1_tiles, %out_cb: !cb2_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
-      // CHECK: %[[CB0:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
-      // CHECK: %[[CB1:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
-      // CHECK: %[[OUT_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+    func.func @binary_op_init_common() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>, <arg_type = cb_port, operand_index = 2>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[CB0:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %cb0 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
+      // CHECK: %[[CB1:.*]] = emitc.literal "get_compile_time_arg_val(1)"
+      %cb1 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> !cb1_tiles
+      // CHECK: %[[OUT_CB:.*]] = emitc.literal "get_compile_time_arg_val(2)"
+      %out_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 2 : i32}> : () -> !cb2_tiles
       // CHECK: emitc.call_opaque "binary_op_init_common"(%[[CB0]], %[[CB1]], %[[OUT_CB]])
       "ttkernel.binary_op_init_common"(%cb0, %cb1, %out_cb) : (!cb0_tiles, !cb1_tiles, !cb2_tiles) -> ()
       return
     }
 
     // CHECK-LABEL: func @add_tiles_init
-    func.func @add_tiles_init(%cb0: !cb0_tiles, %cb1: !cb1_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
-      // CHECK: %[[CB0:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
-      // CHECK: %[[CB1:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+    func.func @add_tiles_init() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[CB0:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %cb0 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
+      // CHECK: %[[CB1:.*]] = emitc.literal "get_compile_time_arg_val(1)"
+      %cb1 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> !cb1_tiles
       // CHECK: emitc.call_opaque "add_tiles_init"(%[[CB0]], %[[CB1]])
       "ttkernel.add_tiles_init"(%cb0, %cb1) : (!cb0_tiles, !cb1_tiles) -> ()
       return
     }
 
     // CHECK-LABEL: func @add_tiles
-    func.func @add_tiles(%cb0: !cb0_tiles, %cb1: !cb1_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
-      // CHECK: %[[CB0:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
-      // CHECK: %[[CB1:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+    func.func @add_tiles() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[CB0:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %cb0 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
+      // CHECK: %[[CB1:.*]] = emitc.literal "get_compile_time_arg_val(1)"
+      %cb1 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> !cb1_tiles
       // CHECK: %[[CB0_INDEX:.*]] = "emitc.constant"
       %cb0_index = arith.constant 1 : index
       // CHECK: %[[CB1_INDEX:.*]] = "emitc.constant"
@@ -198,18 +210,22 @@ module {
     }
 
     // CHECK-LABEL: func @mul_tiles_init
-    func.func @mul_tiles_init(%cb0: !cb0_tiles, %cb1: !cb1_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
-      // CHECK: %[[CB0:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
-      // CHECK: %[[CB1:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+    func.func @mul_tiles_init() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[CB0:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %cb0 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
+      // CHECK: %[[CB1:.*]] = emitc.literal "get_compile_time_arg_val(1)"
+      %cb1 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> !cb1_tiles
       // CHECK: emitc.call_opaque "mul_tiles_init"(%[[CB0]], %[[CB1]])
       "ttkernel.mul_tiles_init"(%cb0, %cb1) : (!cb0_tiles, !cb1_tiles) -> ()
       return
     }
 
     // CHECK-LABEL: func @mul_tiles
-    func.func @mul_tiles(%cb0: !cb0_tiles, %cb1: !cb1_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
-      // CHECK: %[[CB0:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
-      // CHECK: %[[CB1:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+    func.func @mul_tiles() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[CB0:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %cb0 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
+      // CHECK: %[[CB1:.*]] = emitc.literal "get_compile_time_arg_val(1)"
+      %cb1 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> !cb1_tiles
       // CHECK: %[[CB0_INDEX:.*]] = "emitc.constant"
       %cb0_index = arith.constant 1 : i32
       // CHECK: %[[CB1_INDEX:.*]] = "emitc.constant"
@@ -262,19 +278,24 @@ module {
     }
 
     // CHECK-LABEL: func @reduce_init
-    func.func @reduce_init(%in_cb: !cb0_tiles, %scaling_cb: !cb1_tiles, %out_cb: !cb2_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
-      // CHECK: %[[IN_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
-      // CHECK: %[[SCALING_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
-      // CHECK: %[[OUT_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+    func.func @reduce_init() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>, <arg_type = cb_port, operand_index = 2>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[IN_CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %in_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
+      // CHECK: %[[SCALING_CB:.*]] = emitc.literal "get_compile_time_arg_val(1)"
+      %scaling_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> !cb1_tiles
+      // CHECK: %[[OUT_CB:.*]] = emitc.literal "get_compile_time_arg_val(2)"
+      %out_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 2 : i32}> : () -> !cb2_tiles
       // CHECK: emitc.call_opaque "reduce_init"(%[[IN_CB]], %[[SCALING_CB]], %[[OUT_CB]]) {{.+}}SUM{{.+}}REDUCE_SCALAR
       "ttkernel.reduce_init"(%in_cb, %scaling_cb, %out_cb) <{reduce_dim = #ttkernel.reduce_dim<reduce_dim_scalar>, reduce_type = #ttkernel.reduce_type<reduce_sum>}> : (!cb0_tiles, !cb1_tiles, !cb2_tiles) -> ()
       return
     }
 
     // CHECK-LABEL: func @reduce_tile
-    func.func @reduce_tile(%in_cb: !cb0_tiles, %scaling_cb: !cb1_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
-      // CHECK: %[[IN_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
-      // CHECK: %[[SCALING_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+    func.func @reduce_tile() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[IN_CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %in_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
+      // CHECK: %[[SCALING_CB:.*]] = emitc.literal "get_compile_time_arg_val(1)"
+      %scaling_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> !cb1_tiles
       // CHECK: %[[IN_TILE_INDEX:.*]] = "emitc.constant"
       %in_tile_index = arith.constant 1 : i32
       // CHECK: %[[SCALING_TILE_INDEX:.*]] = "emitc.constant"
@@ -298,9 +319,11 @@ module {
   module @ttkernel_sfpu_operations {
 
     // CHECK-LABEL: func @init_sfpu
-    func.func @init_sfpu(%in_cb: !cb0_tiles, %out_cb: !cb1_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
-      // CHECK: %[[IN_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
-      // CHECK: %[[OUT_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+    func.func @init_sfpu() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[IN_CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %in_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
+      // CHECK: %[[OUT_CB:.*]] = emitc.literal "get_compile_time_arg_val(1)"
+      %out_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> !cb1_tiles
       // CHECK: emitc.call_opaque "init_sfpu"(%[[IN_CB]], %[[OUT_CB]])
       "ttkernel.init_sfpu"(%in_cb, %out_cb) : (!cb0_tiles, !cb1_tiles) -> ()
       return
@@ -506,8 +529,9 @@ module {
   module @ttkernel_cb_operations {
 
     // CHECK-LABEL: func @cb_push_back
-    func.func @cb_push_back(%cb: !cb0_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
-      // CHECK: %[[CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+    func.func @cb_push_back() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
       // CHECK: %[[NUM_PAGES:.*]] = "emitc.constant"
       %num_pages = arith.constant 1 : i32
       // CHECK: emitc.call_opaque "cb_push_back"(%[[CB]], %[[NUM_PAGES]])
@@ -516,8 +540,9 @@ module {
     }
 
     // CHECK-LABEL: func @cb_pop_front
-    func.func @cb_pop_front(%cb: !cb0_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
-      // CHECK: %[[CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+    func.func @cb_pop_front() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
       // CHECK: %[[NUM_PAGES:.*]] = "emitc.constant"
       %num_pages = arith.constant 1 : i32
       // CHECK: emitc.call_opaque "cb_pop_front"(%[[CB]], %[[NUM_PAGES]])
@@ -526,8 +551,9 @@ module {
     }
 
     // CHECK-LABEL: func @cb_reserve_back
-    func.func @cb_reserve_back(%cb: !cb0_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
-      // CHECK: %[[CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+    func.func @cb_reserve_back() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
       // CHECK: %[[NUM_PAGES:.*]] = "emitc.constant"
       %num_pages = arith.constant 1 : i32
       // CHECK: emitc.call_opaque "cb_reserve_back"(%[[CB]], %[[NUM_PAGES]])
@@ -536,8 +562,9 @@ module {
     }
 
     // CHECK-LABEL: func @cb_wait_front
-    func.func @cb_wait_front(%cb: !cb0_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
-      // CHECK: %[[CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+    func.func @cb_wait_front() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
       // CHECK: %[[NUM_PAGES:.*]] = "emitc.constant"
       %num_pages = arith.constant 1 : i32
       // CHECK: emitc.call_opaque "cb_wait_front"(%[[CB]], %[[NUM_PAGES]])
@@ -555,9 +582,11 @@ module {
   module @ttkernel_tile_operations {
 
     // CHECK-LABEL: func @tilize_init
-    func.func @tilize_init(%in_cb: !cb0_scalar, %out_cb: !cb1_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
-      // CHECK: %[[IN_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
-      // CHECK: %[[OUT_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+    func.func @tilize_init() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[IN_CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %in_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_scalar
+      // CHECK: %[[OUT_CB:.*]] = emitc.literal "get_compile_time_arg_val(1)"
+      %out_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> !cb1_tiles
       // CHECK: %[[NUM_TILES:.*]] = "emitc.constant"
       %num_tiles = arith.constant 3 : i32
       // CHECK: emitc.call_opaque "tilize_init"(%[[IN_CB]], %[[NUM_TILES]], %[[OUT_CB]])
@@ -566,9 +595,11 @@ module {
     }
 
     // CHECK-LABEL: func @tilize_init_short
-    func.func @tilize_init_short(%in_cb: !cb0_scalar, %out_cb: !cb1_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
-      // CHECK: %[[IN_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
-      // CHECK: %[[OUT_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+    func.func @tilize_init_short() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[IN_CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %in_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_scalar
+      // CHECK: %[[OUT_CB:.*]] = emitc.literal "get_compile_time_arg_val(1)"
+      %out_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> !cb1_tiles
       // CHECK: %[[NUM_TILES:.*]] = "emitc.constant"
       %num_tiles = arith.constant 3 : i32
       // CHECK: emitc.call_opaque "tilize_init_short"(%[[IN_CB]], %[[NUM_TILES]], %[[OUT_CB]])
@@ -577,43 +608,51 @@ module {
     }
 
     // CHECK-LABEL: func @tilize_uninit
-    func.func @tilize_uninit(%in_cb: !cb0_scalar, %out_cb: !cb1_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
-      // CHECK: %[[IN_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
-      // CHECK: %[[OUT_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+    func.func @tilize_uninit() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[IN_CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %in_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_scalar
+      // CHECK: %[[OUT_CB:.*]] = emitc.literal "get_compile_time_arg_val(1)"
+      %out_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> !cb1_tiles
       // CHECK: emitc.call_opaque "tilize_uninit"(%[[IN_CB]], %[[OUT_CB]])
       "ttkernel.tilize_uninit"(%in_cb, %out_cb) : (!cb0_scalar, !cb1_tiles) -> ()
       return
     }
 
     // CHECK-LABEL: func @untilize_init
-    func.func @untilize_init(%in_cb: !cb0_tiles, %out_cb: !cb1_scalar) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
-      // CHECK: %[[IN_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
-      // CHECK: %[[OUT_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+    func.func @untilize_init() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[IN_CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %in_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
+      // CHECK: %[[OUT_CB:.*]] = emitc.literal "get_compile_time_arg_val(1)"
+      %out_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> !cb1_scalar
       // CHECK: emitc.call_opaque "untilize_init"(%[[IN_CB]], %[[OUT_CB]])
       "ttkernel.untilize_init"(%in_cb, %out_cb) : (!cb0_tiles, !cb1_scalar) -> ()
       return
     }
 
     // CHECK-LABEL: func @untilize_init_short
-    func.func @untilize_init_short(%in_cb: !cb0_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
-      // CHECK: %[[IN_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+    func.func @untilize_init_short() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[IN_CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %in_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
       // CHECK: emitc.call_opaque "untilize_init_short"(%[[IN_CB]])
       "ttkernel.untilize_init_short"(%in_cb) : (!cb0_tiles) -> ()
       return
     }
 
     // CHECK-LABEL: func @untilize_uninit
-    func.func @untilize_uninit(%in_cb: !cb0_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
-      // CHECK: %[[IN_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+    func.func @untilize_uninit() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[IN_CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %in_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
       // CHECK: emitc.call_opaque "untilize_uninit"(%[[IN_CB]])
       "ttkernel.untilize_uninit"(%in_cb) : (!cb0_tiles) -> ()
       return
     }
 
     // CHECK-LABEL: func @tilize_block
-    func.func @tilize_block(%in_cb: !cb0_scalar, %out_cb: !cb1_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
-      // CHECK: %[[IN_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
-      // CHECK: %[[OUT_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+    func.func @tilize_block() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[IN_CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %in_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_scalar
+      // CHECK: %[[OUT_CB:.*]] = emitc.literal "get_compile_time_arg_val(1)"
+      %out_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> !cb1_tiles
       // CHECK: %[[NUM_TILES:.*]] = "emitc.constant"
       %num_tiles = arith.constant 3 : i32
       // CHECK: emitc.call_opaque "tilize_block"(%[[IN_CB]], %[[NUM_TILES]], %[[OUT_CB]])
@@ -622,9 +661,11 @@ module {
     }
 
     // CHECK-LABEL: func @untilize_block
-    func.func @untilize_block(%in_cb: !cb0_tiles, %out_cb: !cb1_scalar) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
-      // CHECK: %[[IN_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
-      // CHECK: %[[OUT_CB:.*]] = "emitc.constant"{{.+}}<"::tt::CB">
+    func.func @untilize_block() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+      // CHECK: %[[IN_CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %in_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
+      // CHECK: %[[OUT_CB:.*]] = emitc.literal "get_compile_time_arg_val(1)"
+      %out_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> !cb1_scalar
       // CHECK: %[[NUM_TILES:.*]] = "emitc.constant"
       %num_tiles = arith.constant 3 : i32
       // CHECK: emitc.call_opaque "untilize_block"(%[[IN_CB]], %[[NUM_TILES]], %[[OUT_CB]])
@@ -843,7 +884,9 @@ module {
     }
 
     // CHECK-LABEL: func @interleaved_addr_gen_fast_funcs
-    func.func @interleaved_addr_gen_fast_funcs(%cb: !cb0_tiles) -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+    func.func @interleaved_addr_gen_fast_funcs() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<noc>} {
+      // CHECK: %[[CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
+      %cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
       // CHECK: %[[DATA_FORMAT:.*]]= emitc.call_opaque "get_dataformat"
       %data_format = "ttkernel.get_dataformat"(%cb) : (!cb0_tiles) -> !ttkernel.DataFormat
       // CHECK: = "emitc.constant"() <{value = true}>

--- a/test/ttmlir/Dialect/TTKernel/ops.mlir
+++ b/test/ttmlir/Dialect/TTKernel/ops.mlir
@@ -2,25 +2,32 @@
 
 #l1_ = #tt.memory_space<l1>
 // CHECK-LABEL: func @test_untilize_init_short
-func.func @test_untilize_init_short(%tilized_cb : !ttkernel.cb<cb_in0, 0, memref<4x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>) -> () {
-  "ttkernel.untilize_init_short"(%tilized_cb) : (!ttkernel.cb<cb_in0, 0, memref<4x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>) -> ()
+func.func @test_untilize_init_short() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>]>} {
+  %tilized_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !ttkernel.cb<memref<4x4x!tt.tile<32x32, f32>, #l1_>>
+  "ttkernel.untilize_init_short"(%tilized_cb) : (!ttkernel.cb<memref<4x4x!tt.tile<32x32, f32>, #l1_>>) -> ()
   return
 }
 
 // CHECK-LABEL: func @test_tilize_init_short
-func.func @test_tilize_init_short(%tilized_cb : !ttkernel.cb<cb_in0, 0, memref<4x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, %untilized_cb : !ttkernel.cb<cb_in0, 0, memref<128x128xf32, #l1_>, 512, 1>, %num_tiles : i32) -> () {
-  "ttkernel.tilize_init_short"(%untilized_cb, %num_tiles, %tilized_cb) : (!ttkernel.cb<cb_in0, 0, memref<128x128xf32, #l1_>, 512, 1>, i32, !ttkernel.cb<cb_in0, 0, memref<4x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>) -> ()
+func.func @test_tilize_init_short() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>} {
+  %tilized_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !ttkernel.cb<memref<4x4x!tt.tile<32x32, f32>, #l1_>>
+  %untilized_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> !ttkernel.cb<memref<128x128xf32, #l1_>>
+  %num_tiles = arith.constant 4 : i32
+  "ttkernel.tilize_init_short"(%untilized_cb, %num_tiles, %tilized_cb) : (!ttkernel.cb<memref<128x128xf32, #l1_>>, i32, !ttkernel.cb<memref<4x4x!tt.tile<32x32, f32>, #l1_>>) -> ()
   return
 }
 
 // CHECK-LABEL: func.func @test_tilize_uninit
-func.func @test_tilize_uninit(%tilized_cb : !ttkernel.cb<cb_in0, 0, memref<4x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, %untilized_cb : !ttkernel.cb<cb_in0, 0, memref<128x128xf32, #l1_>, 512, 1>) -> () {
-  "ttkernel.tilize_uninit"(%untilized_cb, %tilized_cb) : (!ttkernel.cb<cb_in0, 0, memref<128x128xf32, #l1_>, 512, 1>, !ttkernel.cb<cb_in0, 0, memref<4x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>) -> ()
+func.func @test_tilize_uninit() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>} {
+  %tilized_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !ttkernel.cb<memref<4x4x!tt.tile<32x32, f32>, #l1_>>
+  %untilized_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> !ttkernel.cb<memref<128x128xf32, #l1_>>
+  "ttkernel.tilize_uninit"(%untilized_cb, %tilized_cb) : (!ttkernel.cb<memref<128x128xf32, #l1_>>, !ttkernel.cb<memref<4x4x!tt.tile<32x32, f32>, #l1_>>) -> ()
   return
 }
 
 // CHECK-LABEL: func.func @test_untilize_uninit
-func.func @test_untilize_uninit(%tilized_cb : !ttkernel.cb<cb_in0, 0, memref<4x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>) -> () {
-  "ttkernel.untilize_uninit"(%tilized_cb) : (!ttkernel.cb<cb_in0, 0, memref<4x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>) -> ()
+func.func @test_untilize_uninit() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>]>} {
+  %tilized_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !ttkernel.cb<memref<4x4x!tt.tile<32x32, f32>, #l1_>>
+  "ttkernel.untilize_uninit"(%tilized_cb) : (!ttkernel.cb<memref<4x4x!tt.tile<32x32, f32>, #l1_>>) -> ()
   return
 }

--- a/test/ttmlir/Translate/TTKernel/ttkernel_compute.mlir
+++ b/test/ttmlir/Translate/TTKernel/ttkernel_compute.mlir
@@ -2,28 +2,26 @@
 
 #l1_ = #tt.memory_space<l1>
 
-// CHECK: void kernel_main
-func.func @ttkernel_compute(%arg1: !ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>,
-                            %arg2: !ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1>) -> () attributes {ttkernel.thread = #ttkernel.thread<compute>} {
-
-    // CHECK: ::tt::CB [[CBIN0:.*]] = ::tt::CB::c_in0
-    // CHECK: ::tt::CB [[CBOUT0:.*]] = ::tt::CB::c_out0
-    // CHECK: int32_t [[C:.*]] = 4
+// CHECK: void kernel_main()
+func.func @ttkernel_compute() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+    // CHECK: int32_t v1 = 4
     %c4_i32 = arith.constant 4 : i32
-    // CHECK: untilize_init([[CBIN0]], [[CBOUT0]])
-    "ttkernel.untilize_init"(%arg1, %arg2) : (!ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, !ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1>) -> ()
-    // CHECK: untilize_block([[CBIN0]], [[C]], [[CBOUT0]])
-    "ttkernel.untilize_block"(%arg1, %c4_i32, %arg2) : (!ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, i32, !ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1>) -> ()
-    // CHECK: cb_pop_front([[CBIN0]], [[C]])
-    "ttkernel.cb_pop_front"(%arg1, %c4_i32) : (!ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, i32) -> ()
-    // CHECK: cb_push_back([[CBOUT0]], [[C]])
-    "ttkernel.cb_push_back"(%arg2, %c4_i32) : (!ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1>, i32) -> ()
-    // CHECK: untilize_block([[CBIN0]], [[C]], [[CBOUT0]])
-    "ttkernel.untilize_block"(%arg1, %c4_i32, %arg2) : (!ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, i32, !ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1>) -> ()
-    // CHECK: cb_pop_front([[CBIN0]], [[C]])
-    "ttkernel.cb_pop_front"(%arg1, %c4_i32) : (!ttkernel.cb<cb_in0, 294912, memref<2x4x!tt.tile<32x32, f32>, #l1_>, 4096, 1>, i32) -> ()
-    // CHECK: cb_push_back([[CBOUT0]], [[C]])
-    "ttkernel.cb_push_back"(%arg2, %c4_i32) : (!ttkernel.cb<cb_out0, 327680, memref<64x128xf32, #l1_>, 4096, 1>, i32) -> ()
+    %arg1 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !ttkernel.cb<memref<2x4x!tt.tile<32x32, f32>, #l1_>>
+    %arg2 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> !ttkernel.cb<memref<64x128xf32, #l1_>>
+    // CHECK: untilize_init(get_compile_time_arg_val(0), get_compile_time_arg_val(1))
+    "ttkernel.untilize_init"(%arg1, %arg2) : (!ttkernel.cb<memref<2x4x!tt.tile<32x32, f32>, #l1_>>, !ttkernel.cb<memref<64x128xf32, #l1_>>) -> ()
+    // CHECK: untilize_block(get_compile_time_arg_val(0), v1, get_compile_time_arg_val(1))
+    "ttkernel.untilize_block"(%arg1, %c4_i32, %arg2) : (!ttkernel.cb<memref<2x4x!tt.tile<32x32, f32>, #l1_>>, i32, !ttkernel.cb<memref<64x128xf32, #l1_>>) -> ()
+    // CHECK: cb_pop_front(get_compile_time_arg_val(0), v1)
+    "ttkernel.cb_pop_front"(%arg1, %c4_i32) : (!ttkernel.cb<memref<2x4x!tt.tile<32x32, f32>, #l1_>>, i32) -> ()
+    // CHECK: cb_push_back(get_compile_time_arg_val(1), v1)
+    "ttkernel.cb_push_back"(%arg2, %c4_i32) : (!ttkernel.cb<memref<64x128xf32, #l1_>>, i32) -> ()
+    // CHECK: untilize_block(get_compile_time_arg_val(0), v1, get_compile_time_arg_val(1))
+    "ttkernel.untilize_block"(%arg1, %c4_i32, %arg2) : (!ttkernel.cb<memref<2x4x!tt.tile<32x32, f32>, #l1_>>, i32, !ttkernel.cb<memref<64x128xf32, #l1_>>) -> ()
+    // CHECK: cb_pop_front(get_compile_time_arg_val(0), v1)
+    "ttkernel.cb_pop_front"(%arg1, %c4_i32) : (!ttkernel.cb<memref<2x4x!tt.tile<32x32, f32>, #l1_>>, i32) -> ()
+    // CHECK: cb_push_back(get_compile_time_arg_val(1), v1)
+    "ttkernel.cb_push_back"(%arg2, %c4_i32) : (!ttkernel.cb<memref<64x128xf32, #l1_>>, i32) -> ()
     // CHECK: return
     func.return
 }

--- a/tools/pykernel/op.py
+++ b/tools/pykernel/op.py
@@ -143,7 +143,7 @@ class PyKernelOp:
         cb_type = CircularBuffer(
             buffer_index,
             tuple(tensor.shape)[1:],
-            self._mlir_dtype_from_ttnn_dtype(int(dtype)),
+            dtype=self._mlir_dtype_from_ttnn_dtype(int(dtype)),
         )
 
         return OpCircularBuffer(cb_type, cb_format, cb_desc)
@@ -165,10 +165,12 @@ class PyKernelOp:
         kernel_desc_args = {
             "kernel_source": kernel_path,
             "core_ranges": self._defined_core_ranges,
-            "compile_time_args": [x.value for x in ct_args],
+            "compile_time_args": [cb.cb_id for cb in cb_args],
             "runtime_args": [[rt_args]],
             "config": config(),
         }
+
+        print(kernel.__name__, kernel_desc_args)
 
         if hasattr(self, "common_runtime_args"):
             kernel_desc_args["common_runtime_args"] = self.common_runtime_args


### PR DESCRIPTION
### Ticket
#3089 

### Problem description
We have legacy unused attributes on the TTKernel CB type

### What's changed
Remove the unused attributes from this type, making it a low level wrapper of a memref. 
Remove supporting code that utilizes/depends on these attributes.

### Checklist
- [X] New/Existing tests provide coverage for changes
