### PR TITLE
[OpModel] fix names of namespaces

### DIFF
--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -327,7 +327,7 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 //===----------------------------------------------------------------------===//
 // MaxPool2D
 //===----------------------------------------------------------------------===//
-namespace MaxPool2DInterface {
+namespace MaxPool2DOpInterface {
 llvm::Expected<
     std::tuple<size_t, size_t, size_t, ::mlir::tt::ttnn::TTNNLayoutAttr>>
 getOpConstraints(GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
@@ -349,12 +349,12 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
              bool ceilMode, llvm::ArrayRef<int64_t> outputShape,
              mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
 
-}; // namespace MaxPool2DInterface
+}; // namespace MaxPool2DOpInterface
 
 //===----------------------------------------------------------------------===//
 // ClampScalar
 //===----------------------------------------------------------------------===//
-namespace ClampScalarInterface {
+namespace ClampScalarOpInterface {
 llvm::Expected<
     std::tuple<size_t, size_t, size_t, ::mlir::tt::ttnn::TTNNLayoutAttr>>
 getOpConstraints(GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
@@ -367,7 +367,7 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
              mlir::tt::ttnn::TTNNLayoutAttr inputLayout, llvm::APFloat min,
              llvm::APFloat max, llvm::ArrayRef<int64_t> outputShape,
              mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
-}; // namespace ClampScalarInterface
+}; // namespace ClampScalarOpInterface
 
 } // namespace mlir::tt::op_model::ttnn
 #endif // TTMLIR_OPMODEL_TTNN_TTNNOPMODEL_H

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -611,7 +611,7 @@ MaxPool2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   }
   GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
 
-  return op_model::ttnn::MaxPool2DInterface::getOpConstraints(
+  return op_model::ttnn::MaxPool2DOpInterface::getOpConstraints(
       deviceGrid, inputShape, inputs[0], getBatchSize(), getInputHeight(),
       getInputWidth(), getChannels(), getKernelSize(), getStride(),
       getPadding(), getDilation(), getCeilMode(), outputShape,
@@ -627,7 +627,7 @@ MaxPool2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto outputShape = getResult().getType().getShape();
 
-  return op_model::ttnn::MaxPool2DInterface::getOpRuntime(
+  return op_model::ttnn::MaxPool2DOpInterface::getOpRuntime(
       inputShape, inputs[0], getBatchSize(), getInputHeight(), getInputWidth(),
       getChannels(), getKernelSize(), getStride(), getPadding(), getDilation(),
       getCeilMode(), outputShape, opConfig.outputLayout);
@@ -653,7 +653,7 @@ ClampScalarOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   }
   GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
 
-  return op_model::ttnn::ClampScalarInterface::getOpConstraints(
+  return op_model::ttnn::ClampScalarOpInterface::getOpConstraints(
       deviceGrid, inputShape, inputs[0], getMin(), getMax(), outputShape,
       opConfig.outputLayout);
 }
@@ -667,7 +667,7 @@ ClampScalarOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto outputShape = getResult().getType().getShape();
 
-  return op_model::ttnn::ClampScalarInterface::getOpRuntime(
+  return op_model::ttnn::ClampScalarOpInterface::getOpRuntime(
       inputShape, inputs[0], getMin(), getMax(), outputShape,
       opConfig.outputLayout);
 }

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -1480,7 +1480,7 @@ llvm::Expected<size_t> Conv2dOpInterface::getOpRuntime(
 //===----------------------------------------------------------------------===//
 llvm::Expected<
     std::tuple<size_t, size_t, size_t, ::mlir::tt::ttnn::TTNNLayoutAttr>>
-MaxPool2DInterface::getOpConstraints(
+MaxPool2DOpInterface::getOpConstraints(
     GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayout, int32_t batchSize,
     int32_t inputHeight, int32_t inputWidth, int32_t inputChannels,
@@ -1521,7 +1521,7 @@ MaxPool2DInterface::getOpConstraints(
         std::nullopt /* applied_shard_scheme */, ceilMode);
   };
 
-  return operation::getOpConstraints("MaxPool2DInterface",
+  return operation::getOpConstraints("MaxPool2DOpInterface",
                                      inputLayout.getContext(), deviceGrid,
                                      maxPool2DQuery);
 #else
@@ -1529,7 +1529,7 @@ MaxPool2DInterface::getOpConstraints(
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
-llvm::Expected<size_t> MaxPool2DInterface::getOpRuntime(
+llvm::Expected<size_t> MaxPool2DOpInterface::getOpRuntime(
     llvm::ArrayRef<int64_t> inputShape,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayout, int32_t batchSize,
     int32_t inputHeight, int32_t inputWidth, int32_t inputChannels,
@@ -1569,7 +1569,7 @@ llvm::Expected<size_t> MaxPool2DInterface::getOpRuntime(
         std::nullopt /* applied_shard_scheme */, ceilMode);
   };
 
-  return operation::getOpRuntime("MaxPool2DInterface", maxPool2DQuery);
+  return operation::getOpRuntime("MaxPool2DOpInterface", maxPool2DQuery);
 #else
   return llvm::createStringError("Not Implemented");
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1580,7 +1580,7 @@ llvm::Expected<size_t> MaxPool2DInterface::getOpRuntime(
 //===----------------------------------------------------------------------===//
 llvm::Expected<
     std::tuple<size_t, size_t, size_t, ::mlir::tt::ttnn::TTNNLayoutAttr>>
-ClampScalarInterface::getOpConstraints(
+ClampScalarOpInterface::getOpConstraints(
     GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayout, llvm::APFloat min,
     llvm::APFloat max, llvm::ArrayRef<int64_t> outputShape,
@@ -1608,7 +1608,7 @@ ClampScalarInterface::getOpConstraints(
         detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints("ClampScalarInterface",
+  return operation::getOpConstraints("ClampScalarOpInterface",
                                      inputLayout.getContext(), deviceGrid,
                                      clampScalarQuery);
 #else
@@ -1616,7 +1616,7 @@ ClampScalarInterface::getOpConstraints(
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
-llvm::Expected<size_t> ClampScalarInterface::getOpRuntime(
+llvm::Expected<size_t> ClampScalarOpInterface::getOpRuntime(
     llvm::ArrayRef<int64_t> inputShape,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayout, llvm::APFloat min,
     llvm::APFloat max, llvm::ArrayRef<int64_t> outputShape,
@@ -1644,7 +1644,7 @@ llvm::Expected<size_t> ClampScalarInterface::getOpRuntime(
         detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpRuntime("ClampScalarInterface", clampScalarQuery);
+  return operation::getOpRuntime("ClampScalarOpInterface", clampScalarQuery);
 #else
   return llvm::createStringError("Not Implemented");
 #endif // TTMLIR_ENABLE_OPMODEL

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -1197,7 +1197,7 @@ TEST_P(OpModelMaxPool2DParam, MaxPool2DParam) {
 
   SingletonDeviceContext::resetInstance();
 
-  auto constraintsExp = MaxPool2DInterface::getOpConstraints(
+  auto constraintsExp = MaxPool2DOpInterface::getOpConstraints(
       CreateWorkerGrid(), inputShape, inputLayout, batchSize, inputHeight,
       inputWidth, inputChannels, kernelSize, stride, padding, dilation,
       ceilMode, outputShape, outputLayout);
@@ -1220,7 +1220,7 @@ TEST_P(OpModelMaxPool2DParam, MaxPool2DParam) {
 
   SingletonDeviceContext::resetInstance();
 
-  auto runtimeExp = MaxPool2DInterface::getOpRuntime(
+  auto runtimeExp = MaxPool2DOpInterface::getOpRuntime(
       inputShape, inputLayout, batchSize, inputHeight, inputWidth,
       inputChannels, kernelSize, stride, padding, dilation, ceilMode,
       outputShape, outputLayout);
@@ -1292,7 +1292,7 @@ TEST_P(OpModelClampScalarParam, ClampScalarParam) {
 
   SingletonDeviceContext::resetInstance();
 
-  auto constraintsExp = ClampScalarInterface::getOpConstraints(
+  auto constraintsExp = ClampScalarOpInterface::getOpConstraints(
       CreateWorkerGrid(), inputShape, inputLayout, minVal, maxVal, outputShape,
       outputLayout);
   if (!constraintsExp) {
@@ -1314,7 +1314,7 @@ TEST_P(OpModelClampScalarParam, ClampScalarParam) {
 
   SingletonDeviceContext::resetInstance();
 
-  auto runtimeExp = ClampScalarInterface::getOpRuntime(
+  auto runtimeExp = ClampScalarOpInterface::getOpRuntime(
       inputShape, inputLayout, minVal, maxVal, outputShape, outputLayout);
   EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
   if (runtimeExp) {


### PR DESCRIPTION
For consistency, use op name + "OpInterface".

