### PR TITLE
#3545: Updated ttrt return code if no binaries or directories are found to error.

### DIFF
--- a/runtime/tools/ttrt/ttrt/common/check.py
+++ b/runtime/tools/ttrt/ttrt/common/check.py
@@ -124,13 +124,25 @@ class Check:
     def check_constraints(self):
         self.logging.debug(f"------checking constraints for check API")
 
-        ttsys_binary_paths = self.file_manager.find_ttsys_binary_paths(
-            self["--system-desc"]
-        )
-        ttnn_binary_paths = self.file_manager.find_ttnn_binary_paths(self["binary"])
-        ttmetal_binary_paths = self.file_manager.find_ttmetal_binary_paths(
-            self["binary"]
-        )
+        ttnn_binary_paths, ttmetal_binary_paths, ttsys_binary_paths = [], [], []
+        try:
+            ttsys_binary_paths = self.file_manager.find_ttsys_binary_paths(
+                self["--system-desc"]
+            )
+            ttnn_binary_paths = self.file_manager.find_ttnn_binary_paths(self["binary"])
+            ttmetal_binary_paths = self.file_manager.find_ttmetal_binary_paths(
+                self["binary"]
+            )
+        except Exception as e:
+            test_result = {
+                "file_path": self["binary"],
+                "result": "error",
+                "exception": str(e),
+                "log_file": self.logger.file_name,
+                "artifacts": self.artifacts.artifacts_folder_path,
+                "program_index": self["--program-index"],
+            }
+            self.results.add_result(test_result)
 
         self.logging.debug(f"ttsys_binary_paths={ttsys_binary_paths}")
         self.logging.debug(f"ttnn_binary_paths={ttnn_binary_paths}")

--- a/runtime/tools/ttrt/ttrt/common/perf.py
+++ b/runtime/tools/ttrt/ttrt/common/perf.py
@@ -222,10 +222,24 @@ class Perf:
                     return
             self.ttnn_binaries.append(bin)
         else:
-            ttnn_binary_paths = self.file_manager.find_ttnn_binary_paths(self["binary"])
-            ttmetal_binary_paths = self.file_manager.find_ttmetal_binary_paths(
-                self["binary"]
-            )
+            ttnn_binary_paths, ttmetal_binary_paths = [], []
+            try:
+                ttnn_binary_paths = self.file_manager.find_ttnn_binary_paths(
+                    self["binary"]
+                )
+                ttmetal_binary_paths = self.file_manager.find_ttmetal_binary_paths(
+                    self["binary"]
+                )
+            except Exception as e:
+                test_result = {
+                    "file_path": self["binary"],
+                    "result": "error",
+                    "exception": str(e),
+                    "log_file": self.logger.file_name,
+                    "artifacts": self.artifacts.artifacts_folder_path,
+                    "program_index": self["--program-index"],
+                }
+                self.results.add_result(test_result)
 
             self.logging.debug(f"ttnn_binary_paths={ttnn_binary_paths}")
             self.logging.debug(f"ttmetal_binary_paths={ttmetal_binary_paths}")

--- a/runtime/tools/ttrt/ttrt/common/read.py
+++ b/runtime/tools/ttrt/ttrt/common/read.py
@@ -144,11 +144,25 @@ class Read:
     def check_constraints(self):
         self.logging.debug(f"------checking constraints for read API")
 
-        ttsys_binary_paths = self.file_manager.find_ttsys_binary_paths(self["binary"])
-        ttnn_binary_paths = self.file_manager.find_ttnn_binary_paths(self["binary"])
-        ttmetal_binary_paths = self.file_manager.find_ttmetal_binary_paths(
-            self["binary"]
-        )
+        ttnn_binary_paths, ttmetal_binary_paths, ttsys_binary_paths = [], [], []
+        try:
+            ttsys_binary_paths = self.file_manager.find_ttsys_binary_paths(
+                self["--system-desc"]
+            )
+            ttnn_binary_paths = self.file_manager.find_ttnn_binary_paths(self["binary"])
+            ttmetal_binary_paths = self.file_manager.find_ttmetal_binary_paths(
+                self["binary"]
+            )
+        except Exception as e:
+            test_result = {
+                "file_path": self["binary"],
+                "result": "error",
+                "exception": str(e),
+                "log_file": self.logger.file_name,
+                "artifacts": self.artifacts.artifacts_folder_path,
+                "program_index": self["--program-index"],
+            }
+            self.results.add_result(test_result)
 
         self.logging.debug(f"ttsys_binary_paths={ttsys_binary_paths}")
         self.logging.debug(f"ttnn_binary_paths={ttnn_binary_paths}")

--- a/runtime/tools/ttrt/ttrt/common/run.py
+++ b/runtime/tools/ttrt/ttrt/common/run.py
@@ -331,10 +331,22 @@ class Run:
     def check_constraints(self):
         self.logging.debug(f"------checking constraints for run API")
 
-        ttnn_binary_paths = self.file_manager.find_ttnn_binary_paths(self["binary"])
-        ttmetal_binary_paths = self.file_manager.find_ttmetal_binary_paths(
-            self["binary"]
-        )
+        ttnn_binary_paths, ttmetal_binary_paths = [], []
+        try:
+            ttnn_binary_paths = self.file_manager.find_ttnn_binary_paths(self["binary"])
+            ttmetal_binary_paths = self.file_manager.find_ttmetal_binary_paths(
+                self["binary"]
+            )
+        except Exception as e:
+            test_result = {
+                "file_path": self["binary"],
+                "result": "error",
+                "exception": str(e),
+                "log_file": self.logger.file_name,
+                "artifacts": self.artifacts.artifacts_folder_path,
+                "program_index": self["--program-index"],
+            }
+            self.results.add_result(test_result)
 
         self.logging.debug(f"ttnn_binary_paths={ttnn_binary_paths}")
         self.logging.debug(f"ttmetal_binary_paths={ttmetal_binary_paths}")

--- a/runtime/tools/ttrt/ttrt/common/util.py
+++ b/runtime/tools/ttrt/ttrt/common/util.py
@@ -415,9 +415,11 @@ class FileManager:
                     ttnn_files.append(path)
                     self.logging.debug(f"found file={path}")
             else:
-                self.logging.info(f"file '{path}' not found - skipping")
+                raise Exception(f"file '{path}' not found")
         else:
-            self.check_directory_exists(path)
+            if not self.check_directory_exists(path):
+                raise Exception(f"'{path}' not found")
+
             try:
                 for root, _, files in os.walk(path):
                     for file in files:
@@ -445,9 +447,11 @@ class FileManager:
                     ttmetal_files.append(path)
                     self.logging.debug(f"found file={path}")
             else:
-                self.logging.info(f"file '{path}' not found - skipping")
+                raise Exception(f"file '{path}' not found")
         else:
-            self.check_directory_exists(path)
+            if not self.check_directory_exists(path):
+                raise Exception(f"'{path}' not found")
+
             try:
                 for root, _, files in os.walk(path):
                     for file in files:
@@ -475,9 +479,11 @@ class FileManager:
                     ttsys_files.append(path)
                     self.logging.debug(f"found file={path}")
             else:
-                self.logging.info(f"file '{path}' not found - skipping")
+                raise Exception(f"file '{path}' not found")
         else:
-            self.check_directory_exists(path)
+            if not self.check_directory_exists(path):
+                raise Exception(f"'{path}' not found")
+
             try:
                 for root, _, files in os.walk(path):
                     for file in files:


### PR DESCRIPTION
Issue: https://github.com/tenstorrent/tt-mlir/issues/3545#issuecomment-2910473821

This PR updates ttrt return code to error if the user provides a flatbuffer path or directory which does not exist.

Example
```
ttrt run dont_exists.ttnn
```

now returns exit code 1. 