### PR TITLE
#3563: Fixed bug when dumping memory reports to pass meshdevice instead of idevice.

### DIFF
--- a/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
@@ -92,7 +92,7 @@ void deallocateBuffers(Device device);
 void dumpMemoryReport(Device device);
 
 std::unordered_map<tt::runtime::MemoryBufferType, tt::runtime::MemoryView>
-getMemoryView(Device device, int deviceID = 0);
+getMemoryView(Device device);
 
 void wait(Event event);
 

--- a/runtime/include/tt/runtime/detail/ttnn/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn/ttnn.h
@@ -158,7 +158,7 @@ void deallocateBuffers(Device device);
 void dumpMemoryReport(Device device);
 
 std::unordered_map<tt::runtime::MemoryBufferType, tt::runtime::MemoryView>
-getMemoryView(Device device, int deviceID = 0);
+getMemoryView(Device device);
 
 void wait(Event event);
 

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -33,7 +33,7 @@ This function get the memory view per device
   }
 */
 std::unordered_map<tt::runtime::MemoryBufferType, tt::runtime::MemoryView>
-getMemoryView(Device device, int deviceID = 0);
+getMemoryView(Device device);
 
 } // namespace detail
 

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -99,15 +99,13 @@ void dumpMemoryReport(Device device) {
 
 using MemoryViewResult = std::unordered_map<::tt::runtime::MemoryBufferType,
                                             ::tt::runtime::MemoryView>;
-MemoryViewResult getMemoryView(Device device, int deviceID) {
+MemoryViewResult getMemoryView(Device device) {
   using RetType = MemoryViewResult;
   return DISPATCH_TO_CURRENT_RUNTIME(
       RetType,
+      [&]() -> RetType { return ::tt::runtime::ttnn::getMemoryView(device); },
       [&]() -> RetType {
-        return ::tt::runtime::ttnn::getMemoryView(device, deviceID);
-      },
-      [&]() -> RetType {
-        return ::tt::runtime::ttmetal::getMemoryView(device, deviceID);
+        return ::tt::runtime::ttmetal::getMemoryView(device);
       });
 }
 } // namespace detail

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -279,22 +279,20 @@ void dumpMemoryReport(Device deviceHandle) {
 }
 
 std::unordered_map<MemoryBufferType, MemoryView>
-getMemoryView(Device deviceHandle, int deviceID) {
+getMemoryView(Device deviceHandle) {
   std::unordered_map<MemoryBufferType, MemoryView> memoryMap;
   tt_metal::distributed::MeshDevice &meshDevice =
       deviceHandle.as<tt_metal::distributed::MeshDevice>(
           DeviceRuntime::TTMetal);
 
-  auto *device = meshDevice.get_device(deviceID);
-
   auto dramMemoryView =
-      tt_metal::detail::GetMemoryView(device, tt_metal::BufferType::DRAM);
+      tt_metal::detail::GetMemoryView(&meshDevice, tt_metal::BufferType::DRAM);
   auto l1MemoryView =
-      tt_metal::detail::GetMemoryView(device, tt_metal::BufferType::L1);
-  auto l1SmallMemoryView =
-      tt_metal::detail::GetMemoryView(device, tt_metal::BufferType::L1_SMALL);
+      tt_metal::detail::GetMemoryView(&meshDevice, tt_metal::BufferType::L1);
+  auto l1SmallMemoryView = tt_metal::detail::GetMemoryView(
+      &meshDevice, tt_metal::BufferType::L1_SMALL);
   auto traceMemoryView =
-      tt_metal::detail::GetMemoryView(device, tt_metal::BufferType::TRACE);
+      tt_metal::detail::GetMemoryView(&meshDevice, tt_metal::BufferType::TRACE);
 
   memoryMap[MemoryBufferType::DRAM] = createMemoryView(dramMemoryView);
   memoryMap[MemoryBufferType::L1] = createMemoryView(l1MemoryView);

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -522,22 +522,20 @@ void dumpMemoryReport(Device deviceHandle) {
 }
 
 std::unordered_map<tt::runtime::MemoryBufferType, tt::runtime::MemoryView>
-getMemoryView(Device deviceHandle, int deviceID) {
+getMemoryView(Device deviceHandle) {
   std::unordered_map<tt::runtime::MemoryBufferType, tt::runtime::MemoryView>
       memoryMap;
   ::ttnn::MeshDevice &meshDevice =
       deviceHandle.as<::ttnn::MeshDevice>(DeviceRuntime::TTNN);
 
-  auto *device = meshDevice.get_device(deviceID);
-
-  auto dramMemoryView =
-      ::tt::tt_metal::detail::GetMemoryView(device, ::ttnn::BufferType::DRAM);
-  auto l1MemoryView =
-      ::tt::tt_metal::detail::GetMemoryView(device, ::ttnn::BufferType::L1);
+  auto dramMemoryView = ::tt::tt_metal::detail::GetMemoryView(
+      &meshDevice, ::ttnn::BufferType::DRAM);
+  auto l1MemoryView = ::tt::tt_metal::detail::GetMemoryView(
+      &meshDevice, ::ttnn::BufferType::L1);
   auto l1SmallMemoryView = ::tt::tt_metal::detail::GetMemoryView(
-      device, ::ttnn::BufferType::L1_SMALL);
-  auto traceMemoryView =
-      ::tt::tt_metal::detail::GetMemoryView(device, ::ttnn::BufferType::TRACE);
+      &meshDevice, ::ttnn::BufferType::L1_SMALL);
+  auto traceMemoryView = ::tt::tt_metal::detail::GetMemoryView(
+      &meshDevice, ::ttnn::BufferType::TRACE);
 
   memoryMap[tt::runtime::MemoryBufferType::DRAM] =
       createMemoryView(dramMemoryView);

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -39,8 +39,7 @@ void registerRuntimeBindings(nb::module_ &m) {
       .def("get_l1_size_per_core", &tt::runtime::getL1SizePerCore)
       .def("deallocate_buffers", &tt::runtime::detail::deallocateBuffers)
       .def("dump_memory_report", &tt::runtime::detail::dumpMemoryReport)
-      .def("get_memory_view", &tt::runtime::detail::getMemoryView,
-           nb::arg("device_id") = 0);
+      .def("get_memory_view", &tt::runtime::detail::getMemoryView);
 
   nb::class_<tt::runtime::Event>(m, "Event");
 

--- a/runtime/tools/ttrt/ttrt/common/callback.py
+++ b/runtime/tools/ttrt/ttrt/common/callback.py
@@ -218,9 +218,8 @@ def memory(callback_runtime_config, binary, program_context, op_context):
     logging.debug("executing memory dump")
     loc = ttrt.runtime.get_op_loc_info(op_context)
     debug_str = ttrt.runtime.get_op_debug_str(op_context)
-    device_id = 0
 
-    memory_views = device.get_memory_view(device_id)
+    memory_views = device.get_memory_view()
     dram_memory_view = memory_views[ttrt.runtime.MemoryBufferType.DRAM]
     l1_memory_view = memory_views[ttrt.runtime.MemoryBufferType.L1]
     l1_small_memory_view = memory_views[ttrt.runtime.MemoryBufferType.L1_SMALL]
@@ -229,31 +228,10 @@ def memory(callback_runtime_config, binary, program_context, op_context):
     op_memory_report = {}
     op_memory_report["loc"] = loc
     op_memory_report["debug_str"] = debug_str
-
-    dram_op_device_memory_report = {}
-    dram_op_device_memory_report["device_" + str(device_id)] = create_memory_dictionary(
-        dram_memory_view
-    )
-
-    l1_op_device_memory_report = {}
-    l1_op_device_memory_report["device_" + str(device_id)] = create_memory_dictionary(
-        l1_memory_view
-    )
-
-    l1_small_op_device_memory_report = {}
-    l1_small_op_device_memory_report[
-        "device_" + str(device_id)
-    ] = create_memory_dictionary(l1_small_memory_view)
-
-    trace_op_device_memory_report = {}
-    trace_op_device_memory_report[
-        "device_" + str(device_id)
-    ] = create_memory_dictionary(trace_memory_view)
-
-    op_memory_report["dram"] = dram_op_device_memory_report
-    op_memory_report["l1"] = l1_op_device_memory_report
-    op_memory_report["l1_small"] = l1_small_op_device_memory_report
-    op_memory_report["trace"] = trace_op_device_memory_report
+    op_memory_report["dram"] = create_memory_dictionary(dram_memory_view)
+    op_memory_report["l1"] = create_memory_dictionary(l1_memory_view)
+    op_memory_report["l1_small"] = create_memory_dictionary(l1_small_memory_view)
+    op_memory_report["trace"] = create_memory_dictionary(trace_memory_view)
 
     callback_runtime_config.memory_report[
         callback_runtime_config.callback_counter()

--- a/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
@@ -874,20 +874,18 @@ def build_graph(
             loc = memory_trace[node]["loc"]
             memory_data[loc] = {}
             memory_data[loc]["dram"] = round(
-                memory_trace[node]["dram"]["device_0"]["total_bytes_allocated_per_bank"]
-                / memory_trace[node]["dram"]["device_0"]["total_bytes_per_bank"],
+                memory_trace[node]["dram"]["total_bytes_allocated_per_bank"]
+                / memory_trace[node]["dram"]["total_bytes_per_bank"],
                 4,
             )
             memory_data[loc]["l1"] = round(
-                memory_trace[node]["l1"]["device_0"]["total_bytes_allocated_per_bank"]
-                / memory_trace[node]["l1"]["device_0"]["total_bytes_per_bank"],
+                memory_trace[node]["l1"]["total_bytes_allocated_per_bank"]
+                / memory_trace[node]["l1"]["total_bytes_per_bank"],
                 4,
             )
             memory_data[loc]["l1_small"] = round(
-                memory_trace[node]["l1_small"]["device_0"][
-                    "total_bytes_allocated_per_bank"
-                ]
-                / memory_trace[node]["l1_small"]["device_0"]["total_bytes_per_bank"],
+                memory_trace[node]["l1_small"]["total_bytes_allocated_per_bank"]
+                / memory_trace[node]["l1_small"]["total_bytes_per_bank"],
                 4,
             )
 


### PR DESCRIPTION
Ticket: https://github.com/tenstorrent/tt-mlir/issues/3563

When dumping memory information, the meshDevice needs to be passed into the dump memory API if we initially opened as a mesh, not a single device. 

Running the following test: 
```
ttrt run <flatbuffer> --memory --save-artifacts
```

will produce a memory_results.json file snippet as follows:
```
"loc": "loc(\"/code/tt-mlir/build/test/ttmlir/Silicon/TTNN/n300/perf/Output/all_gather.mlir.tmp.mlir\":22:14)",
"dram": {
  "num_banks": 12,
  "total_bytes_per_bank": 1073741792,
  "total_bytes_allocated_per_bank": 8192,
  "total_bytes_free_per_bank": 1073735648,
  "largest_contiguous_bytes_free_per_bank": 1073733600,
  "block_table": [
      {
          "allocated": "yes",
          "nextID": "1",
          "prevID": "-1",
          "size": "4096",
          "address": "0",
          "blockID": "0"
      }
   ]
}
```