### PR TITLE
#3574: Keep shardy sharding dimensions open for propagation.

### DIFF
--- a/include/ttmlir/Dialect/StableHLO/Transforms/ShardyUtils.h
+++ b/include/ttmlir/Dialect/StableHLO/Transforms/ShardyUtils.h
@@ -210,8 +210,8 @@ getDefaultTensorSdyShardingAttr(MLIRContext *context, llvm::StringRef meshName,
   llvm::SmallVector<mlir::sdy::DimensionShardingAttr> dimShardings;
 
   for (uint32_t i = 0; i < rankedTensorType.getShape().size(); i++) {
-    dimShardings.push_back(
-        mlir::sdy::DimensionShardingAttr::get(context, {}, true));
+    dimShardings.push_back(mlir::sdy::DimensionShardingAttr::get(
+        context, {}, /*is_closed*/ false));
   }
 
   return mlir::sdy::TensorShardingAttr::get(context, meshName, dimShardings, {},

--- a/lib/Dialect/StableHLO/Transforms/ShardyAutomaticParallelization.cpp
+++ b/lib/Dialect/StableHLO/Transforms/ShardyAutomaticParallelization.cpp
@@ -517,15 +517,18 @@ public:
       mlir::sdy::AxisRefAttr axisAttr =
           mlir::sdy::AxisRefAttr::get(context, "batch");
       mlir::sdy::DimensionShardingAttr dimShardingAttr =
-          mlir::sdy::DimensionShardingAttr::get(context, {axisAttr}, true);
+          mlir::sdy::DimensionShardingAttr::get(context, {axisAttr},
+                                                /*is_closed*/ false);
       dimShardings.push_back(dimShardingAttr);
 
       mlir::sdy::DimensionShardingAttr full =
-          mlir::sdy::DimensionShardingAttr::get(context, {}, true);
+          mlir::sdy::DimensionShardingAttr::get(context, {},
+                                                /*is_closed*/ false);
       dimShardings.append(argType.getRank() - 1, full);
     } else {
       mlir::sdy::DimensionShardingAttr full =
-          mlir::sdy::DimensionShardingAttr::get(context, {}, true);
+          mlir::sdy::DimensionShardingAttr::get(context, {},
+                                                /*is_closed*/ false);
       dimShardings.append(argType.getRank(), full);
     }
 
@@ -593,7 +596,8 @@ public:
     }
 
     // Determine sdy.sharding annotation to add to this argument based on tt
-    // argument type.
+    // argument type. If it's an input, we annotate it. Otherwise, we keep it
+    // open for shardy propogation to fill it in if required.
     mlir::RankedTensorType argType =
         mlir::cast<mlir::RankedTensorType>(arg->getType());
     llvm::SmallVector<mlir::sdy::DimensionShardingAttr> dimShardings;
@@ -603,15 +607,18 @@ public:
       mlir::sdy::AxisRefAttr axisAttr =
           mlir::sdy::AxisRefAttr::get(context, "batch");
       mlir::sdy::DimensionShardingAttr dimShardingAttr =
-          mlir::sdy::DimensionShardingAttr::get(context, {axisAttr}, true);
+          mlir::sdy::DimensionShardingAttr::get(context, {axisAttr},
+                                                /*is_closed*/ false);
       dimShardings.push_back(dimShardingAttr);
 
       mlir::sdy::DimensionShardingAttr full =
-          mlir::sdy::DimensionShardingAttr::get(context, {}, true);
+          mlir::sdy::DimensionShardingAttr::get(context, {},
+                                                /*is_closed*/ false);
       dimShardings.append(argType.getRank() - 1, full);
     } else {
       mlir::sdy::DimensionShardingAttr full =
-          mlir::sdy::DimensionShardingAttr::get(context, {}, true);
+          mlir::sdy::DimensionShardingAttr::get(context, {},
+                                                /*is_closed*/ false);
       dimShardings.append(argType.getRank(), full);
     }
 


### PR DESCRIPTION
Issue: https://github.com/tenstorrent/tt-mlir/issues/3574

This PR keep sharding dimensions open for further propagation. This is necessary because if user doesn't provide shardy annotations, we deduce it based on the input type and manually insert sharding attributes. However, if the dimensions remain closed, during `sdy-aggressive-propagate` pass, it will attempt to insert collectives rather than propagate the actual sharding to the tensor (which is desired). 

Example (open dimensions indicated by `?`)
```
module {
  sdy.mesh @mesh = <["default"=1, "batch"=2]>
  func.func public @op_sequence(%arg0: tensor<32x1x8192x256xf32> {sdy.sharding = #sdy.sharding<@mesh, [{"batch", ?}, {?}, {?}, {?}]>, tt.argument_type = #tt.argument_type<input>}, %arg1: tensor<256x2048xf32> {sdy.sharding = #sdy.sharding<@mesh, [{?}, {?}]>, tt.argument_type = #tt.argument_type<parameter>}, %arg2: tensor<32x1x8192x2048xf32> {sdy.sharding = #sdy.sharding<@mesh, [{"batch", ?}, {?}, {?}, {?}]>, tt.argument_type = #tt.argument_type<input>}) -> (tensor<32x1x8192x2048xf32> {jax.result_info = ""}) {
    %0 = stablehlo.dot_general %arg0, %arg1, contracting_dims = [3] x [0], precision = [DEFAULT, DEFAULT] : (tensor<32x1x8192x256xf32>, tensor<256x2048xf32>) -> tensor<32x1x8192x2048xf32>
    return %0 : tensor<32x1x8192x2048xf32>
  }
}
```