### PR TITLE
#3576: Added tensor encoding to embedding op generation during ttir decomposition pass.

### DIFF
--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -654,7 +654,8 @@ struct GatherToEmbeddingConversionPattern
     newOutputShape.push_back(input.getType().getShape()[1]);
 
     auto embeddingOutputType = mlir::RankedTensorType::get(
-        newOutputShape, input.getType().getElementType());
+        newOutputShape, input.getType().getElementType(),
+        input.getType().getEncoding());
     ttir::EmbeddingOp embeddingOp = ttir::utils::createDPSOp<ttir::EmbeddingOp>(
         rewriter, op.getLoc(), embeddingOutputType, startIndices, input);
 


### PR DESCRIPTION
Issue: https://github.com/tenstorrent/tt-mlir/issues/3576

This pr added the output tensor encoding during embedding op generation. Previously, it was not propagating the tensor mesh embedding.

example 

before
```
%794 = "ttir.embedding"(%95, %792, %793) : (tensor<2x23xsi32, #tt.mesh_sharding<"mesh">>, tensor<51200x2048xf32, #tt.mesh_sharding<"mesh">>, tensor<2x23x2048xf32>) -> tensor<2x23x2048xf32>
```

after
```
%794 = "ttir.embedding"(%95, %792, %793) : (tensor<2x23xsi32, #tt.mesh_sharding<"mesh">>, tensor<51200x2048xf32, #tt.mesh_sharding<"mesh">>, tensor<2x23x2048xf32, #tt.mesh_sharding<"mesh">>) -> tensor<2x23x2048xf32, #tt.mesh_sharding<"mesh">>
```
