### PR TITLE
Fix bug with getInstance logic for emitC standalone

### DIFF
--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -64,21 +64,20 @@ public:
   static ttnn::MeshDevice *getInstance() {
     // If we have an external device, use it.
     if (externalDevice) {
-      assert(ownedDevice == nullptr);
+      assert(!hasOwnedDevice);
       return externalDevice;
     }
 
-    // Otherwise, create and use our own device.
-    if (!ownedDevice) {
-      ownedDevice = ::ttnn::MeshDevice::create_unit_mesh(0, l1SmallSize);
-    }
-    return ownedDevice.get();
+    static std::shared_ptr<ttnn::MeshDevice> ownedInstance =
+        ::ttnn::MeshDevice::create_unit_mesh(0, l1SmallSize);
+    hasOwnedDevice = true;
+    return ownedInstance.get();
   }
 
   // Set an external device (we don't own it)
   static void setInstance(ttnn::MeshDevice *newInstance) {
     // We don't want to mix and match owned/external devices.
-    assert(ownedDevice == nullptr);
+    assert(!hasOwnedDevice);
 
     // Store the external device pointer.
     externalDevice = newInstance;
@@ -92,13 +91,12 @@ private:
 
   // External device (not owned by us).
   static ttnn::MeshDevice *externalDevice;
-
-  // Our owned device (only used if no external device is set).
-  static std::shared_ptr<ttnn::MeshDevice> ownedDevice;
+  // Flag to track if we've set local ownedInstance or not.
+  static bool hasOwnedDevice;
 };
 
 inline ttnn::MeshDevice *DeviceGetter::externalDevice = nullptr;
-inline std::shared_ptr<ttnn::MeshDevice> DeviceGetter::ownedDevice;
+inline bool DeviceGetter::hasOwnedDevice = false;
 
 // Function to be exported from the dylib that can be called to set the
 // device--extern to avoid mangling.


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/3595

### Problem description
My recent changes to the way emitC handles getInstance seems to have broken some tt_metal dtor ordering due to changing the type of static variable involved.  Unfortunately, CI did not catch this issue, but it is causing segfaults when running ttnn-standalone.

### What's changed
This should resolve the issue by keeping the "ownedInstance" as a local static variable instead of a class-level variable, as before.  Locally, this fixes the issue

### Checklist
- [ ] New/Existing tests provide coverage for changes--CI fix which should have caught this are in the works by @vvukomanovicTT I believe
