### PR TITLE
#3369: Add support for all to all shardy conversion to stablehlo in shardy automatic parallelization pass.

### DIFF
--- a/include/ttmlir/Dialect/StableHLO/Transforms/ShardyCCLToStableHLOCCL.h
+++ b/include/ttmlir/Dialect/StableHLO/Transforms/ShardyCCLToStableHLOCCL.h
@@ -21,30 +21,8 @@ namespace mlir::tt::stablehlo {
 
 #ifdef TTMLIR_ENABLE_STABLEHLO
 
-class ShardyTypeConverter : public TypeConverter {
-public:
-  ShardyTypeConverter(MLIRContext *ctx) {
-    addConversion([](Type type) {
-      assert(isa<RankedTensorType>(type) &&
-             "only ranked tensor type supported");
-      return type;
-    });
-
-    // Convert scalars to 1D tensors.
-    addConversion([&](RankedTensorType type) -> RankedTensorType {
-      if (!type.getShape().empty()) {
-        return type;
-      }
-
-      return RankedTensorType::get(/*shape=*/{1}, type.getElementType(),
-                                   type.getEncoding());
-    });
-  }
-};
-
 void populateShardyCCLToStableHLOCCLPatterns(MLIRContext *ctx,
-                                             RewritePatternSet &patterns,
-                                             TypeConverter &typeConverter);
+                                             RewritePatternSet &patterns);
 
 #endif // #ifdef TTMLIR_ENABLE_STABLEHLO
 

--- a/include/ttmlir/Dialect/StableHLO/Transforms/ShardyUtils.h
+++ b/include/ttmlir/Dialect/StableHLO/Transforms/ShardyUtils.h
@@ -351,6 +351,52 @@ populateShardedOutputType(mlir::sdy::MeshAttr meshAttr,
   return RankedTensorType::get(newShape, oldType.getElementType());
 };
 
+// Loop through all the tensorShardings and apply them to each output.
+inline FailureOr<llvm::SmallVector<mlir::RankedTensorType>> getNewResultTypes(
+    mlir::Operation *op, mlir::sdy::MeshOp &globalMeshOp,
+    llvm::ArrayRef<mlir::sdy::TensorShardingAttr> tensorShardings) {
+  llvm::SmallVector<mlir::RankedTensorType> newTypes;
+  for (uint32_t i = 0; i < tensorShardings.size(); i++) {
+    mlir::sdy::TensorShardingAttr tensorShardingAttr = tensorShardings[i];
+    mlir::RankedTensorType oldType =
+        mlir::cast<mlir::RankedTensorType>(op->getResult(i).getType());
+    FailureOr<mlir::RankedTensorType> newType = populateShardedOutputType(
+        globalMeshOp.getMesh(), oldType, tensorShardingAttr);
+
+    if (failed(newType)) {
+      return mlir::failure();
+    }
+
+    newTypes.push_back(*newType);
+  }
+
+  return newTypes;
+}
+
+// Copy nested regions between srcOp and destOp
+inline void copyNestedRegions(mlir::OpBuilder &builder, mlir::Operation *srcOp,
+                              mlir::Operation *destOp) {
+  for (unsigned i = 0; i < srcOp->getNumRegions(); i++) {
+    auto &oldRegion = srcOp->getRegion(i);
+    auto &newRegion = destOp->getRegion(i);
+
+    // Figure out new operand mapping and apply to newly created op.
+    mlir::IRMapping mapping;
+    auto *oldBlock = &oldRegion.front();
+    std::unique_ptr<mlir::Block> newBlock = std::make_unique<mlir::Block>();
+    for (auto oldArg : oldBlock->getArguments()) {
+      auto newArg = newBlock->addArgument(oldArg.getType(), oldArg.getLoc());
+      mapping.map(oldArg, newArg);
+    }
+
+    for (auto &srcOp : *oldBlock) {
+      builder.setInsertionPointToEnd(newBlock.get());
+      builder.clone(srcOp, mapping);
+    }
+    newRegion.push_back(newBlock.release());
+  }
+}
+
 #endif // #ifdef TTMLIR_ENABLE_STABLEHLO
 
 } // namespace mlir::tt::sdy_utils

--- a/lib/Dialect/StableHLO/Transforms/ShardyCCLToStableHLOCCLPatterns.cpp
+++ b/lib/Dialect/StableHLO/Transforms/ShardyCCLToStableHLOCCLPatterns.cpp
@@ -13,6 +13,7 @@
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/TypeUtilities.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -121,7 +122,7 @@ static mlir::tt::sdy_utils::MeshMap getMeshMap(SrcOp &srcOp) {
 }
 
 template <typename SrcOp>
-static void addReductionBlock(ConversionPatternRewriter &rewriter, SrcOp &srcOp,
+static void addReductionBlock(PatternRewriter &rewriter, SrcOp &srcOp,
                               mlir::RankedTensorType outputType) {
   mlir::Location loc = srcOp.getLoc();
 
@@ -138,29 +139,27 @@ static void addReductionBlock(ConversionPatternRewriter &rewriter, SrcOp &srcOp,
 }
 
 // AllGatherOp
-class ShardyToStableHLOAllGatherOpConversionPattern
-    : public OpConversionPattern<mlir::sdy::AllGatherOp> {
-  using OpConversionPattern<mlir::sdy::AllGatherOp>::OpConversionPattern;
+class ShardyToStableHLOAllGatherOpRewritePattern
+    : public OpRewritePattern<mlir::sdy::AllGatherOp> {
+  using OpRewritePattern::OpRewritePattern;
 
 public:
-  LogicalResult
-  matchAndRewrite(mlir::sdy::AllGatherOp srcOp,
-                  mlir::sdy::AllGatherOp::Adaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
+  LogicalResult matchAndRewrite(mlir::sdy::AllGatherOp srcOp,
+                                PatternRewriter &rewriter) const override {
     MLIRContext *context = getContext();
 
     // Set a default channel handle attr since we don't use it in tt-mlir stack
     // but stablehlo::AllGatherOp rewriter requires it.
     mlir::stablehlo::ChannelHandleAttr channelHandleAttr =
-        mlir::stablehlo::ChannelHandleAttr::get(context, /*handle*/ 1,
-                                                /*type*/ 1);
+        mlir::stablehlo::ChannelHandleAttr::get(context, /*handle=*/1,
+                                                /*type=*/1);
 
     // Iterate through gathering axes and create an all gather operation for
     // each axes that needs to be gathered.
     mlir::tt::sdy_utils::MeshMap meshMap =
         getMeshMap<mlir::sdy::AllGatherOp>(srcOp);
 
-    Value result = adaptor.getOperands()[0];
+    Value result = srcOp.getOperand();
     for (auto [allGatherDim, axisRefListAttr] :
          llvm::enumerate(srcOp.getGatheringAxes())) {
       llvm::ArrayRef<mlir::sdy::AxisRefAttr> axisRefList =
@@ -183,16 +182,14 @@ public:
       // all gather dimension.
       mlir::StringRef meshAxis = axisRefList[0].getName();
       mlir::RankedTensorType prevOutputType =
-          mlir::cast<mlir::RankedTensorType>(
-              getTypeConverter()->convertType(result.getType()));
+          mlir::cast<mlir::RankedTensorType>(result.getType());
       llvm::SmallVector<int64_t> newShape =
           llvm::SmallVector<int64_t>(prevOutputType.getShape());
       newShape[allGatherDim] *= meshMap[meshAxis];
       mlir::RankedTensorType newOutputType = mlir::RankedTensorType::get(
           newShape, prevOutputType.getElementType());
 
-      // Create new all gather op and replace the previous op's uses with this
-      // new op.
+      // Create new chained all gather ops depending on the number of shardings.
       mlir::stablehlo::AllGatherOp allGatherOp =
           rewriter.create<mlir::stablehlo::AllGatherOp>(
               srcOp.getLoc(), newOutputType, result, allGatherDim,
@@ -209,15 +206,13 @@ public:
 };
 
 // ReduceScatterOp
-class ShardyToStableHLOReduceScatterOpConversionPattern
-    : public OpConversionPattern<mlir::sdy::ReduceScatterOp> {
-  using OpConversionPattern<mlir::sdy::ReduceScatterOp>::OpConversionPattern;
+class ShardyToStableHLOReduceScatterOpRewritePattern
+    : public OpRewritePattern<mlir::sdy::ReduceScatterOp> {
+  using OpRewritePattern::OpRewritePattern;
 
 public:
-  LogicalResult
-  matchAndRewrite(mlir::sdy::ReduceScatterOp srcOp,
-                  mlir::sdy::ReduceScatterOp::Adaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
+  LogicalResult matchAndRewrite(mlir::sdy::ReduceScatterOp srcOp,
+                                PatternRewriter &rewriter) const override {
     MLIRContext *context = getContext();
 
     // Set a default channel handle attr since we don't use it in tt-mlir stack
@@ -231,7 +226,7 @@ public:
     mlir::tt::sdy_utils::MeshMap meshMap =
         getMeshMap<mlir::sdy::ReduceScatterOp>(srcOp);
 
-    Value result = adaptor.getOperands()[0];
+    Value result = srcOp.getOperand();
     for (auto [reduceScatterDim, axisRefListAttr] :
          llvm::enumerate(srcOp.getReduceScatterAxes())) {
       llvm::ArrayRef<mlir::sdy::AxisRefAttr> axisRefList =
@@ -255,16 +250,15 @@ public:
       // reduce scatter dimension.
       mlir::StringRef meshAxis = axisRefList[0].getName();
       mlir::RankedTensorType prevOutputType =
-          mlir::cast<mlir::RankedTensorType>(
-              getTypeConverter()->convertType(result.getType()));
+          mlir::cast<mlir::RankedTensorType>(result.getType());
       llvm::SmallVector<int64_t> newShape =
           llvm::SmallVector<int64_t>(prevOutputType.getShape());
       newShape[reduceScatterDim] /= meshMap[meshAxis];
       mlir::RankedTensorType newOutputType = mlir::RankedTensorType::get(
           newShape, prevOutputType.getElementType());
 
-      // Create new reduce scatter op and replace the previous op's uses with
-      // this new op.
+      // Create new chained reduce scatter ops depending on the number of
+      // shardings.
       mlir::stablehlo::ReduceScatterOp reduceScatterOp =
           rewriter.create<mlir::stablehlo::ReduceScatterOp>(
               srcOp.getLoc(), newOutputType, result, reduceScatterDim,
@@ -287,15 +281,13 @@ public:
 };
 
 // AllReduceOp
-class ShardyToStableHLOAllReduceOpConversionPattern
-    : public OpConversionPattern<mlir::sdy::AllReduceOp> {
-  using OpConversionPattern<mlir::sdy::AllReduceOp>::OpConversionPattern;
+class ShardyToStableHLOAllReduceOpRewritePattern
+    : public OpRewritePattern<mlir::sdy::AllReduceOp> {
+  using OpRewritePattern::OpRewritePattern;
 
 public:
-  LogicalResult
-  matchAndRewrite(mlir::sdy::AllReduceOp srcOp,
-                  mlir::sdy::AllReduceOp::Adaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
+  LogicalResult matchAndRewrite(mlir::sdy::AllReduceOp srcOp,
+                                PatternRewriter &rewriter) const override {
     MLIRContext *context = getContext();
 
     // Set a default channel handle attr since we don't use it in tt-mlir stack
@@ -308,14 +300,14 @@ public:
     // each axes that needs to be reduced.
     mlir::tt::sdy_utils::MeshMap meshMap =
         getMeshMap<mlir::sdy::AllReduceOp>(srcOp);
-    Value result = adaptor.getOperands()[0];
+    Value result = srcOp.getOperand();
 
     for (auto reductionAxis : srcOp.getReductionAxes()) {
-      // Create new all reduce op and replace the previous op's uses with this
-      // new op. The shape of the all reduce will not change.
+      // Create new chained all reduce ops depending on the number of shardings.
+      // The shape of the all reduce will not change.
       mlir::StringRef meshAxis = reductionAxis.getName();
-      mlir::RankedTensorType newOutputType = mlir::cast<mlir::RankedTensorType>(
-          getTypeConverter()->convertType(result.getType()));
+      mlir::RankedTensorType newOutputType =
+          mlir::cast<mlir::RankedTensorType>(result.getType());
       mlir::stablehlo::AllReduceOp allReduceOp =
           rewriter.create<mlir::stablehlo::AllReduceOp>(
               srcOp.getLoc(), newOutputType, result,
@@ -337,15 +329,80 @@ public:
   }
 };
 
+// AllToAllOp
+class ShardyToStableHLOAllToAllOpRewritePattern
+    : public OpRewritePattern<mlir::sdy::AllToAllOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+public:
+  LogicalResult matchAndRewrite(mlir::sdy::AllToAllOp srcOp,
+                                PatternRewriter &rewriter) const override {
+    MLIRContext *context = getContext();
+
+    // Set a default channel handle attr since we don't use it in tt-mlir stack
+    // but stablehlo::AllToAllOp rewriter requires it.
+    mlir::stablehlo::ChannelHandleAttr channelHandleAttr =
+        mlir::stablehlo::ChannelHandleAttr::get(context, /*handle*/ 1,
+                                                /*type*/ 1);
+
+    // Iterate through all all to all parameter attributes and insert a new all
+    // to all op for each axis to perform the operation on.
+    mlir::tt::sdy_utils::MeshMap meshMap =
+        getMeshMap<mlir::sdy::AllToAllOp>(srcOp);
+    Value result = srcOp.getOperand();
+
+    for (mlir::sdy::AllToAllParamAttr allToAllParamAttr : srcOp.getParams()) {
+      uint64_t sliceDim = allToAllParamAttr.getTgtDim();
+      uint64_t concatDim = allToAllParamAttr.getSrcDim();
+      llvm::ArrayRef<mlir::sdy::AxisRefAttr> axisRefList =
+          allToAllParamAttr.getAxes();
+
+      // If the tensor dimension doesn't have any sharding on it, skip it.
+      if (axisRefList.size() == 0) {
+        continue;
+      }
+
+      // Currently we don't support multi-sharding on a single tensor dimension
+      // across different mesh axes.
+      if (axisRefList.size() > 1) {
+        return rewriter.notifyMatchFailure(
+            srcOp, "AllToAllOp does not support multi-sharding on a single "
+                   "tensor dimension across different mesh axes.");
+      }
+
+      // Create new chained all to all ops depending on the number of shardings.
+      // Calculate new output type based on split and concat dims.
+      mlir::StringRef meshAxis = axisRefList[0].getName();
+      mlir::RankedTensorType prevOutputType =
+          mlir::cast<mlir::RankedTensorType>(result.getType());
+      llvm::SmallVector<int64_t> newShape =
+          llvm::SmallVector<int64_t>(prevOutputType.getShape());
+      newShape[sliceDim] /= meshMap[meshAxis];
+      newShape[concatDim] *= meshMap[meshAxis];
+      mlir::RankedTensorType newOutputType = mlir::RankedTensorType::get(
+          newShape, prevOutputType.getElementType());
+      mlir::stablehlo::AllToAllOp allToAllOp =
+          rewriter.create<mlir::stablehlo::AllToAllOp>(
+              srcOp.getLoc(), newOutputType, result, sliceDim, concatDim,
+              meshMap[meshAxis],
+              createDenseAttrFromReplicaGroups(
+                  context, populateReplicaGroups(meshMap, meshAxis)),
+              channelHandleAttr);
+      result = allToAllOp.getResult(0);
+    }
+
+    rewriter.replaceAllUsesWith(srcOp, result);
+    srcOp->erase();
+    return success();
+  }
+};
+
 void populateShardyCCLToStableHLOCCLPatterns(MLIRContext *ctx,
-                                             RewritePatternSet &patterns,
-                                             TypeConverter &typeConverter) {
-  patterns.add<ShardyToStableHLOAllGatherOpConversionPattern>(typeConverter,
-                                                              ctx);
-  patterns.add<ShardyToStableHLOReduceScatterOpConversionPattern>(typeConverter,
-                                                                  ctx);
-  patterns.add<ShardyToStableHLOAllReduceOpConversionPattern>(typeConverter,
-                                                              ctx);
+                                             RewritePatternSet &patterns) {
+  patterns.add<ShardyToStableHLOAllGatherOpRewritePattern>(ctx);
+  patterns.add<ShardyToStableHLOAllReduceOpRewritePattern>(ctx);
+  patterns.add<ShardyToStableHLOReduceScatterOpRewritePattern>(ctx);
+  patterns.add<ShardyToStableHLOAllToAllOpRewritePattern>(ctx);
 }
 
 } // namespace mlir::tt::stablehlo

--- a/test/ttmlir/Dialect/StableHLO/shardy_automatic_parallelization/automatic_collectives.mlir
+++ b/test/ttmlir/Dialect/StableHLO/shardy_automatic_parallelization/automatic_collectives.mlir
@@ -80,3 +80,12 @@ func.func @dot_compatible_contracting_dim_sharded(
 // CHECK: sdy.manual_computation(%arg0, %arg1) in_shardings=[<@mesh, [{"batch"}, {"model"}]>, <@mesh, [{"model"}, {}]>] out_shardings=[<@mesh, [{"batch"}, {}]>]
 // CHECK: stablehlo.all_reduce
 // CHECK: sdy.return %2 : tensor<2x16xf32>
+
+func.func @all_to_all_single_axis(%arg0 : tensor<8x8x8xf32> {sdy.sharding=#sdy.sharding<@mesh, [{"batch"}, {"model"}, {}]>}) -> tensor<8x8x8xf32> {
+  %0 = sdy.reshard %arg0 <@mesh, [{}, {"model"}, {"batch"}]> : tensor<8x8x8xf32>
+  return %0 : tensor<8x8x8xf32>
+}
+
+// CHECK: sdy.manual_computation(%arg0) in_shardings=[<@mesh, [{"batch"}, {"model"}, {}]>] out_shardings=[<@mesh, [{}, {"model"}, {"batch"}]>]
+// CHECK: stablehlo.all_to_all
+// CHECK: sdy.return %1 : tensor<8x4x2xf32>


### PR DESCRIPTION
Issue: https://github.com/tenstorrent/tt-mlir/issues/3369 + https://github.com/tenstorrent/tt-mlir/issues/3530

This PR adds shardy to stablehlo all to all conversion. This is required when there are reshards or sharding constraints that convert into all to all collectives during shardy automatic parallelization pass. This PR also migrates all the current shardy ccl conversions into stablehlo to use Greedy Rewrite Pattern in case of multiple CCL's inheriting from one another.

Example:

before
```
func.func @all_to_all_single_axis(%arg0 : tensor<8x8x8xf32> {sdy.sharding=#sdy.sharding<@mesh, [{"batch"}, {"model"}, {}]>}) -> tensor<8x8x8xf32> {
  %0 = sdy.reshard %arg0 <@mesh, [{}, {"model"}, {"batch"}]> : tensor<8x8x8xf32>
  return %0 : tensor<8x8x8xf32>
}
```

after
```
func.func @all_to_all_single_axis(%arg0: tensor<8x8x8xf32>) -> tensor<8x8x8xf32> {
    %0 = sdy.manual_computation(%arg0) in_shardings=[<@mesh, [{"batch"}, {"model"}, {}]>] out_shardings=[<@mesh, [{}, {"model"}, {"batch"}]>] manual_axes={"model", "batch"} (%arg1: tensor<2x4x8xf32>) {
      %1 = "stablehlo.all_to_all"(%arg1) <{channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>, concat_dimension = 0 : i64, replica_groups = dense<[[0, 1, 2, 3], [4, 5, 6, 7]]> : tensor<2x4xi64>, split_count = 4 : i64, split_dimension = 2 : i64}> : (tensor<2x4x8xf32>) -> tensor<8x4x2xf32>
      sdy.return %1 : tensor<8x4x2xf32>
    } : (tensor<8x8x8xf32>) -> tensor<8x8x8xf32>
    return %0 : tensor<8x8x8xf32>
  }
```