### PR TITLE
Constant folding compile time (Reshape)

### DIFF
--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -305,12 +305,12 @@ static mlir::OpFoldResult foldConstantOpHelper(OpTy op, TransformFn transform) {
     return nullptr;
 
   mlir::Attribute constAttr = constantOp.getValue();
-  // Handle DenseElementsAttr
+  // Handle DenseElementsAttr.
   if (auto denseAttr = mlir::dyn_cast<mlir::DenseElementsAttr>(constAttr)) {
     return transform(denseAttr);
   }
 
-  // Handle DenseResourceElementsAttr by materializing to DenseElementsAttr
+  // Handle DenseResourceElementsAttr by materializing to DenseElementsAttr.
   if (auto resourceAttr =
           mlir::dyn_cast<mlir::DenseResourceElementsAttr>(constAttr)) {
     auto originalType =

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
-
 #include "ttmlir/Dialect/TT/IR/TTOps.h"
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.h"
@@ -296,6 +295,34 @@ mlir::FailureOr<mlir::BaseMemRefType> mlir::tt::ttir::EmptyOp::getBufferType(
 //===----------------------------------------------------------------------===//
 // ConstantOp
 //===----------------------------------------------------------------------===//
+
+// Common Utilities
+template <typename OpTy, typename TransformFn>
+static mlir::OpFoldResult foldConstantOpHelper(OpTy op, TransformFn transform) {
+  auto constantOp =
+      op.getInput().template getDefiningOp<mlir::tt::ttir::ConstantOp>();
+  if (!constantOp)
+    return nullptr;
+
+  mlir::Attribute constAttr = constantOp.getValue();
+  // Handle DenseElementsAttr
+  if (auto denseAttr = mlir::dyn_cast<mlir::DenseElementsAttr>(constAttr)) {
+    return transform(denseAttr);
+  }
+
+  // Handle DenseResourceElementsAttr by materializing to DenseElementsAttr
+  if (auto resourceAttr =
+          mlir::dyn_cast<mlir::DenseResourceElementsAttr>(constAttr)) {
+    auto originalType =
+        mlir::cast<mlir::RankedTensorType>(resourceAttr.getType());
+    mlir::ArrayRef<char> rawData = resourceAttr.getData();
+    mlir::DenseElementsAttr tempDenseAttr =
+        mlir::DenseElementsAttr::getFromRawBuffer(originalType, rawData);
+    return transform(tempDenseAttr);
+  }
+
+  return nullptr;
+}
 
 // ConstantOp folder
 ::mlir::OpFoldResult mlir::tt::ttir::ConstantOp::fold(FoldAdaptor) {
@@ -1248,43 +1275,11 @@ static mlir::OpFoldResult foldConsecutiveReshape(mlir::tt::ttir::ReshapeOp op) {
 
 // Fold reshape of a constant into a new constant with the reshaped data.
 static mlir::OpFoldResult foldConstantReshape(mlir::tt::ttir::ReshapeOp op) {
-  // Check if the input is a constant operation
-  auto constantOp = op.getInput().getDefiningOp<mlir::tt::ttir::ConstantOp>();
-  if (!constantOp) {
-    return nullptr;
-  }
-
-  // Get the constant value and the target reshaped type
-  mlir::Attribute constAttr = constantOp.getValue();
   auto reshapedType = mlir::cast<mlir::RankedTensorType>(op.getType());
-
-  if (auto denseAttr = mlir::dyn_cast<mlir::DenseElementsAttr>(constAttr)) {
-    // Reshape DenseElementsAttr directly
-    return denseAttr.reshape(reshapedType);
-  }
-
-  if (auto resourceAttr =
-          mlir::dyn_cast<mlir::DenseResourceElementsAttr>(constAttr)) {
-    // For DenseResourceElementsAttr, materialize it to DenseElementsAttr first,
-    // then reshape.
-
-    // Get the original type of the resource attribute
-    auto originalResourceType =
-        mlir::cast<mlir::RankedTensorType>(resourceAttr.getType());
-
-    // Get raw data using getData()
-    mlir::ArrayRef<char> rawData = resourceAttr.getData();
-
-    // Create a temporary DenseElementsAttr from the raw buffer.
-    mlir::DenseElementsAttr tempDenseAttr =
-        mlir::DenseElementsAttr::getFromRawBuffer(originalResourceType,
-                                                  rawData);
-
-    // Reshape the materialized DenseElementsAttr
-    return tempDenseAttr.reshape(reshapedType);
-  }
-
-  return nullptr;
+  return foldConstantOpHelper(
+      op, [&](mlir::DenseElementsAttr attr) -> mlir::Attribute {
+        return attr.reshape(reshapedType);
+      });
 }
 
 // ReshapeOp folder
@@ -1791,7 +1786,7 @@ foldIdentityTranspose(mlir::tt::ttir::TransposeOp op) {
 
 // Rewrite a transpose op to a canonical form where the 'dim0' is less than
 // 'dim1'.
-static mlir::OpFoldResult sortTansposeDims(mlir::tt::ttir::TransposeOp op) {
+static mlir::OpFoldResult sortTransposeDims(mlir::tt::ttir::TransposeOp op) {
   if (op.getDim0() < op.getDim1()) {
     return nullptr;
   }
@@ -1839,7 +1834,7 @@ mlir::OpFoldResult mlir::tt::ttir::TransposeOp::fold(FoldAdaptor adaptor) {
     return foldResult;
   }
 
-  if (auto foldResult = sortTansposeDims(*this)) {
+  if (auto foldResult = sortTransposeDims(*this)) {
     return foldResult;
   }
 

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -1246,6 +1246,47 @@ static mlir::OpFoldResult foldConsecutiveReshape(mlir::tt::ttir::ReshapeOp op) {
   return nullptr;
 }
 
+// Fold reshape of a constant into a new constant with the reshaped data.
+static mlir::OpFoldResult foldConstantReshape(mlir::tt::ttir::ReshapeOp op) {
+  // Check if the input is a constant operation
+  auto constantOp = op.getInput().getDefiningOp<mlir::tt::ttir::ConstantOp>();
+  if (!constantOp) {
+    return nullptr;
+  }
+
+  // Get the constant value and the target reshaped type
+  mlir::Attribute constAttr = constantOp.getValue();
+  auto reshapedType = mlir::cast<mlir::RankedTensorType>(op.getType());
+
+  if (auto denseAttr = mlir::dyn_cast<mlir::DenseElementsAttr>(constAttr)) {
+    // Reshape DenseElementsAttr directly
+    return denseAttr.reshape(reshapedType);
+  }
+
+  if (auto resourceAttr =
+          mlir::dyn_cast<mlir::DenseResourceElementsAttr>(constAttr)) {
+    // For DenseResourceElementsAttr, materialize it to DenseElementsAttr first,
+    // then reshape.
+
+    // Get the original type of the resource attribute
+    auto originalResourceType =
+        mlir::cast<mlir::RankedTensorType>(resourceAttr.getType());
+
+    // Get raw data using getData()
+    mlir::ArrayRef<char> rawData = resourceAttr.getData();
+
+    // Create a temporary DenseElementsAttr from the raw buffer.
+    mlir::DenseElementsAttr tempDenseAttr =
+        mlir::DenseElementsAttr::getFromRawBuffer(originalResourceType,
+                                                  rawData);
+
+    // Reshape the materialized DenseElementsAttr
+    return tempDenseAttr.reshape(reshapedType);
+  }
+
+  return nullptr;
+}
+
 // ReshapeOp folder
 ::mlir::OpFoldResult mlir::tt::ttir::ReshapeOp::fold(FoldAdaptor adaptor) {
   if (auto foldResult = foldIdentityReshape(*this)) {
@@ -1253,6 +1294,10 @@ static mlir::OpFoldResult foldConsecutiveReshape(mlir::tt::ttir::ReshapeOp op) {
   }
 
   if (auto foldResult = foldConsecutiveReshape(*this)) {
+    return foldResult;
+  }
+
+  if (auto foldResult = foldConstantReshape(*this)) {
     return foldResult;
   }
 

--- a/test/ttmlir/Dialect/TTIR/fusing/fuse_constant_bias.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/fuse_constant_bias.mlir
@@ -1,0 +1,30 @@
+// RUN: ttmlir-opt --canonicalize %s | ttmlir-opt --ttir-fusing %s | FileCheck %s
+
+// Fuse constant bias + reshape + add into conv. We also check that all uses of add are updated.
+module {
+  // CHECK-LABEL: func.func @conv2d_fuse
+  func.func @conv2d_fuse(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<2x64x3x3xbf16>) -> tensor<1x30x30x2xbf16> {
+    %0 = ttir.empty() : tensor<1x30x30x2xbf16>
+    // CHECK: %[[CONV:.*]] = "ttir.conv2d"(%arg0, %arg1, %0, %1)
+    // CHECK-SAME: dilation = 1
+    // CHECK-SAME: groups = 1
+    // CHECK-SAME: padding = 0
+    // CHECK-SAME: stride = 1
+    // CHECK-NOT: "ttir.add"
+    // CHECK-NOT: "ttir.reshape"
+    // CHECK-NEXT: return %[[CONV]]
+    %1 = "ttir.conv2d"(%arg0, %arg1, %0)
+            <{
+              stride = 1: i32,
+              padding = 0: i32,
+              dilation = 1: i32,
+              groups = 1: i32
+            }> : (tensor<1x32x32x64xbf16>, tensor<2x64x3x3xbf16>, tensor<1x30x30x2xbf16>) -> tensor<1x30x30x2xbf16>
+    %2 = ttir.empty() : tensor<1x30x30x2xbf16>
+    %3 = "ttir.constant"() <{value = dense<[1.01, 2.02]> : tensor<2xf32>}> : () -> tensor<2xf32>
+    %4 = ttir.empty() : tensor<1x1x1x2xf32>
+    %5 = "ttir.reshape"(%3, %4) <{shape = [1 : i32, 1 : i32, 1 : i32, 2 : i32]}> : (tensor<2xf32>, tensor<1x1x1x2xf32>) -> tensor<1x1x1x2xf32>
+    %6 = "ttir.add"(%1, %5, %2) : (tensor<1x30x30x2xbf16>, tensor<1x1x1x2xf32>, tensor<1x30x30x2xbf16>) -> tensor<1x30x30x2xbf16>
+    return %6: tensor<1x30x30x2xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/data_movement/reshape/reshape_folding_test.mlir
+++ b/test/ttmlir/Dialect/TTNN/data_movement/reshape/reshape_folding_test.mlir
@@ -9,4 +9,13 @@ module @reshape_test {
     return %1 : tensor<1xi32>
     // CHECK: return %arg0 : tensor<1xsi32, #{{.*}}>
   }
+  // Test folding of "ttir.reshape" when called after a constant op.
+  func.func @test_constant_reshape() -> tensor<1x2x1x1xf32> {
+    %1 = "ttir.constant"() <{value = dense<[1.01, 2.02]> : tensor<2xf32>}> : () -> tensor<2xf32>
+    %2 = ttir.empty() : tensor<1x2x1x1xf32>
+    // CHECK-NOT: = "ttnn.reshape"
+    %3 = "ttir.reshape"(%1, %2) <{shape = [1 : i32, 2 : i32, 1 : i32, 1 : i32]}> : (tensor<2xf32>, tensor<1x2x1x1xf32>) -> tensor<1x2x1x1xf32>
+    // CHECK: return %0 : tensor<1x2x1x1xf32, #{{.*}}>
+    return %3 : tensor<1x2x1x1xf32>
+  }
 }


### PR DESCRIPTION
### Problem description
Many models have the following structure (diagram credit @LPanosTT):
![image](https://github.com/user-attachments/assets/1301c881-f951-4628-b6d1-5c66903807e2)

Instead of const-eval'ing the reshape at runtime this can be folded and subsequently fused (into the conv2d) at compile time. Reshape is trivial as there is already a `DenseElementsAttr::reshape()`. This logic can extend to more complex ops like permute, quantize/dequantize/requantize and other unary(ish) ops. These implementations can potentially reside in TTIROps.cpp (wanted to get feedback first).  

### What's changed
Common function for constant folding + reshape folding.
Added tests for conv2d+constant bias sequence and constant+reshape sequence. 
