### PR TITLE
Metal Trace POC

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -177,10 +177,10 @@ jobs:
           {runs-on: n300-llmbox, sh-run: true, name: "run",  suite: "silicon",       image: "tracy",  type: "builder",  path: "test/python/golden", flags: "-m \"not run_error and not fails_golden\"", run-ttrt: true},
           # Although these runtime tests are device agnostic, they depend on n150 compiled mlir artifacts
           # Therefore running these tests on n150 specifically
-          {runs-on: n150,   sh-run: true,  name: "run",  suite: "ttnn_runtime",      image: "speedy", type: "pytest",  path: "runtime/test/python/ttnn/device_agnostic"},
+          {runs-on: n150,   sh-run: true,  name: "run",  suite: "ttnn_runtime",      image: "tracy",  type: "pytest",  path: "runtime/test/python/ttnn/device_agnostic"},
           {runs-on: n150,   sh-run: false, name: "perf", suite: "explorer",          image: "tracy",  type: "pytest",  path: "tools/explorer/test/run_tests.py"},
           {runs-on: n150,   sh-run: false, name: "run",  suite: "op_by_op_infra",    image: "tracy",  type: "pytest",  path: "test/python/op_by_op_infra"},
-          {runs-on: n300,   sh-run: true,  name: "run",  suite: "ttnn_runtime",      image: "speedy", type: "pytest",  path: "runtime/test/python/ttnn/multi_device"},
+          {runs-on: n300,   sh-run: true,  name: "run",  suite: "ttnn_runtime",      image: "tracy",  type: "pytest",  path: "runtime/test/python/ttnn/multi_device"},
           {runs-on: n300,   sh-run: true,  name: "run",  suite: "run",               image: "tracy",  type: "pykernel"},
         ]
     name: "run-tests (${{ matrix.build.runs-on }},${{ matrix.build.image }},${{ matrix.build.suite }},${{ matrix.build.type }},${{ strategy.job-index }})"

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -2029,4 +2029,65 @@ def TTNN_RequantizeOp : TTNN_Op<"requantize"> {
 
     let hasVerifier = 1;
 }
+
+def TTNN_TraceOp : TTNN_Op<"trace"> {
+    let summary = "Trace capture and execute operation.";
+    let description = [{
+      Executes metal trace for the called function within the trace op. The called function will be a collection
+      of hoisted operations from the original graph. For now, all ttnn operations that come after getDevice and const-eval
+      will be hoisted.
+
+      Inputs:
+        - `device` TTNN_Device: The device to capture and execute the trace on.
+        - `cq_id` i32: The command queue to capture the trace with. Must be 0 or 1.
+        - `blocking` bool: Whether the trace should be executed synchronously.
+        - `callee` FlatSymbolRefAttr: The symbol of the function to trace.
+        - `inputs` Variadic<AnyRankedTensor>: The input tensors to the trace.
+
+      Outputs:
+        - `results` Variadic<AnyRankedTensor>: The output tensors from the trace.
+
+      Example:
+
+      ```mlir
+      %0 = ttir.empty() : tensor<32x32xbf16>
+      %1 = "ttir.add"(%arg0, %arg1, %0) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+      return %1 : tensor<32x32xbf16>
+      ```
+
+      will generate the following trace function (arbitrarily naming it as `single_add_trace_0`):
+
+      ```mlir
+      func.func @single_add_trace_0(%arg0: tensor<32x32xbf16, #ttnn_layout>, %arg1: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout> attributes {ttnn.trace} {
+        %0 = "ttnn.add"(%arg0, %arg1) : (tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout>
+        return %0 : tensor<32x32xbf16, #ttnn_layout>
+      }
+      ```
+
+      The main function call will get transformed to a ttnn.trace call that traces the `single_add_trace_0` function:
+
+      ```mlir
+      %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+      %1 = ttnn.trace(%0, 0, true, @single_add_trace_0, [%arg0, %arg1]) : (tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout>
+      ```
+    }];
+
+    let arguments = (ins
+      TTNN_Device:$device,
+      I32Attr:$cq_id,
+      BoolAttr:$blocking,
+      FlatSymbolRefAttr:$callee,
+      Variadic<AnyRankedTensor>:$inputs
+    );
+
+    let results = (outs
+      Variadic<AnyRankedTensor>:$results
+    );
+
+    let assemblyFormat = [{
+      `(` $device `,` $cq_id `,` $blocking `,` $callee `,` `[` $inputs `]` `)` attr-dict `:` functional-type($inputs, $results)
+    }];
+
+    let hasVerifier = 1;
+}
 #endif

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -243,6 +243,10 @@ struct TTIRToTTNNBackendPipelineOptions
       llvm::cl::desc("Enable const-eval optimization pass."),
       llvm::cl::init(true)};
 
+  Option<bool> enableTrace{*this, "enable-trace",
+                           llvm::cl::desc("Enable trace optimization pass."),
+                           llvm::cl::init(false)};
+
   // Option to specify the target bit width for quantized data types.
   Option<uint32_t> quantBitWidth{
       *this, "target-bit-width",

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -149,4 +149,39 @@ def TTNNFusing: Pass<"ttnn-fusing", "::mlir::ModuleOp">
   let description = "This pass tries to fuse operations together with goal to reduce the number of operations in the graph.";
 }
 
+def TTNNTraceHoistTransform : Pass<"ttnn-trace-hoist-transform", "::mlir::ModuleOp"> {
+  let summary = "TTNN Trace hoist transform";
+  let description = [{
+    Transform pass which runs an analysis pass to find traceable subgraphs and hoist them into separate trace functions.
+    The ops within the trace functions are then captured and replayed during runtime using the metal trace infra.
+    This is a performance optimization feature that enables batches of ops to be replayed with a single command instead
+    of dispatching commands for each op individually. One hard requirement is that all ops within a trace must be device
+    operations and cannot have any host involvements.
+
+    Example:
+
+    ```mlir
+    %0 = ttir.empty() : tensor<32x32xbf16>
+    %1 = "ttir.add"(%arg0, %arg1, %0) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+    return %1 : tensor<32x32xbf16>
+    ```
+
+    will generate the following trace function (arbitrarily naming it as `single_add_trace_0`) that will get captured and replayed at runtime:
+
+    ```mlir
+    func.func @single_add_trace_0(%arg0: tensor<32x32xbf16, #ttnn_layout>, %arg1: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout> attributes {ttnn.trace} {
+      %0 = "ttnn.add"(%arg0, %arg1) : (tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout>
+      return %0 : tensor<32x32xbf16, #ttnn_layout>
+    }
+    ```
+
+    and a ttnn.trace operation will get inserted in the original mlir to signal this:
+
+    ```mlir
+    %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+    %1 = ttnn.trace(%0, 0, true, @single_add_trace_0, [%arg0, %arg1]) : (tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout>
+    ```
+  }];
+}
+
 #endif

--- a/include/ttmlir/Dialect/TTNN/Utils/Utils.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/Utils.h
@@ -5,14 +5,18 @@
 #ifndef TTMLIR_DIALECT_TTNN_UTILS_UTILS_H
 #define TTMLIR_DIALECT_TTNN_UTILS_UTILS_H
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Value.h"
-
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsTypes.h"
+#include "llvm/Support/CommandLine.h"
 
 #include "mlir/IR/BuiltinTypes.h"
 
 namespace mlir::tt::ttnn::utils {
+
+constexpr inline llvm::StringLiteral g_TTNNTraceAttrName = "ttnn.trace";
 
 // Map tt::MemorySpace to ttnn::BufferType
 //
@@ -79,6 +83,8 @@ std::optional<ShardSpecAttr>
 createShardSpecIfNeeded(TensorMemoryLayoutAttr tensorMemoryLayout,
                         ShapeAttr shardShape, GridAttr shardGrid,
                         GridAttr deviceGrid);
+
+bool isTTNNTraceFunc(func::FuncOp funcOp);
 
 } // namespace mlir::tt::ttnn::utils
 

--- a/include/ttmlir/Target/TTNN/CMakeLists.txt
+++ b/include/ttmlir/Target/TTNN/CMakeLists.txt
@@ -21,6 +21,7 @@ set(TTNN_OPERATIONS_FBS_GEN_SOURCES
   operations/normalization.fbs
   operations/pool.fbs
   operations/reduction.fbs
+  operations/trace.fbs
 )
 
 set(TTNN_FBS_GEN_SOURCES

--- a/include/ttmlir/Target/TTNN/operations/trace.fbs
+++ b/include/ttmlir/Target/TTNN/operations/trace.fbs
@@ -1,0 +1,14 @@
+include "ttmlir/Target/Common/types.fbs";
+include "ttmlir/Target/TTNN/types.fbs";
+
+namespace tt.target.ttnn;
+
+table TraceOp {
+  device: tt.target.DeviceRef;
+  cq_id: uint32;
+  blocking: bool;
+  callee_name: string;
+  callee_program_idx: uint32;
+  inputs: [tt.target.ttnn.TensorRef];
+  outputs: [tt.target.ttnn.TensorRef];
+}

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -20,6 +20,7 @@ include "ttmlir/Target/TTNN/operations/moreh_cumsum.fbs";
 include "ttmlir/Target/TTNN/operations/normalization.fbs";
 include "ttmlir/Target/TTNN/operations/pool.fbs";
 include "ttmlir/Target/TTNN/operations/reduction.fbs";
+include "ttmlir/Target/TTNN/operations/trace.fbs";
 
 namespace tt.target.ttnn;
 
@@ -75,7 +76,8 @@ union OpType {
   ReductionOp,
   ReductionProdOp,
   LoadCachedOp,
-  BatchNormOp
+  BatchNormOp,
+  TraceOp
 }
 
 table Operation {

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -2514,4 +2514,158 @@ verifyReduceProdOp(tt::ttnn::ProdOp *reduceOp,
   return verifyReduceProdOp(this, getInput().getType());
 }
 
+//===----------------------------------------------------------------------===//
+// TraceOp
+//===----------------------------------------------------------------------===//
+
+static ::mlir::LogicalResult verifyTensorList(TraceOp *op,
+                                              ::mlir::ValueRange opValues,
+                                              ::mlir::TypeRange fnTypes,
+                                              bool isInput) {
+  // Verify count
+  if (opValues.size() != fnTypes.size()) {
+    return op->emitOpError("Incorrect number of ")
+           << (isInput ? "operands" : "results") << " for callee"
+           << " -- expected " << fnTypes.size()
+           << " but got: " << opValues.size();
+  }
+
+  // Verify types
+  for (unsigned i = 0; i < fnTypes.size(); ++i) {
+    if (opValues[i].getType() != fnTypes[i]) {
+      return op->emitOpError() << (isInput ? "Operand" : "Result")
+                               << " type mismatch at index " << i;
+    }
+  }
+
+  return ::mlir::success();
+}
+
+static bool isTensorOnDevice(::mlir::RankedTensorType tensorType) {
+  auto ttnnLayoutAttr =
+      ::mlir::cast<ttnn::TTNNLayoutAttr>(tensorType.getEncoding());
+  bool isOnDevice =
+      ttnnLayoutAttr.getBufferType() != ttnn::BufferType::SystemMemory;
+  return isOnDevice;
+}
+
+::mlir::LogicalResult TraceOp::verify() {
+  auto device = this->getDevice();
+  if (!device) {
+    return emitOpError() << "Device must be set for trace op";
+  }
+
+  uint32_t cqId = this->getCqId();
+  if (cqId != 0 && cqId != 1) {
+    return emitOpError() << "CQ ID must be 0 or 1 for trace op, got: " << cqId;
+  }
+
+  // Verify that the callee exists and has the right type.
+  FlatSymbolRefAttr calleeAttr = this->getCalleeAttr();
+  func::FuncOp funcOp =
+      SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(*this, calleeAttr);
+  if (!funcOp) {
+    return emitOpError() << "'" << calleeAttr.getValue()
+                         << "' does not reference a function";
+  }
+
+  FunctionType fnType = funcOp.getFunctionType();
+
+  LogicalResult inputVerificationResult =
+      verifyTensorList(this, this->getInputs(), fnType.getInputs(),
+                       /*isInput=*/true);
+  if (failed(inputVerificationResult)) {
+    return inputVerificationResult;
+  }
+
+  LogicalResult outputVerificationResult =
+      verifyTensorList(this, this->getResults(), fnType.getResults(),
+                       /*isInput=*/false);
+  if (failed(outputVerificationResult)) {
+    return outputVerificationResult;
+  }
+
+  for (BlockArgument arg : funcOp.getArguments()) {
+    if (!::mlir::isa<RankedTensorType>(arg.getType())) {
+      return emitOpError() << "All input arguments of trace function must be "
+                           << "ranked tensors";
+    }
+    auto tensorType = ::mlir::cast<RankedTensorType>(arg.getType());
+    if (!isTensorOnDevice(tensorType)) {
+      return emitOpError()
+             << "All input arguments of trace function must be on device."
+             << arg << " is not on device.";
+    }
+  }
+
+  ::mlir::WalkResult walkResult =
+      funcOp.walk(
+          [&](Operation *op) -> ::mlir::WalkResult {
+            if (::mlir::isa<TraceOp>(op)) {
+              emitOpError()
+                  << "Trace op must not be nested within another trace op";
+              return ::mlir::WalkResult::interrupt();
+            }
+
+            if (::mlir::isa<::mlir::tt::LoadCachedOp>(op)) {
+              emitOpError()
+                  << "LoadCached op must not be nested within trace op";
+              return ::mlir::WalkResult::interrupt();
+            }
+
+            if (::mlir::isa<GetDeviceOp>(op)) {
+              auto traceDevice = this->getDevice();
+              auto traceDeviceOp = traceDevice.getDefiningOp<GetDeviceOp>();
+
+              auto calleeDeviceOp = ::mlir::cast<GetDeviceOp>(op);
+
+              // Need to make sure that the device attributes of the trace op
+              // and the device within the callee function match
+              if (traceDeviceOp.getMeshShape() !=
+                      calleeDeviceOp.getMeshShape() ||
+                  traceDeviceOp.getMeshOffset() !=
+                      calleeDeviceOp.getMeshOffset()) {
+                return emitOpError()
+                       << "Device configuration of get_device op in callee "
+                       << "must match device configuration of trace op";
+              }
+              return ::mlir::WalkResult::advance();
+            }
+
+            // Make sure all input tensors are on device
+            for (Value operand : op->getOperands()) {
+              if (!::mlir::isa<RankedTensorType>(operand.getType())) {
+                continue;
+              }
+              auto tensorType =
+                  ::mlir::cast<RankedTensorType>(operand.getType());
+              if (!isTensorOnDevice(tensorType)) {
+                emitOpError()
+                    << "All input tensors of trace function must be on device."
+                    << operand << " is not on device.";
+                return ::mlir::WalkResult::interrupt();
+              }
+            }
+
+            // Make sure all output tensors are on device
+            for (Value result : op->getResults()) {
+              if (!::mlir::isa<RankedTensorType>(result.getType())) {
+                continue;
+              }
+              auto tensorType =
+                  ::mlir::cast<RankedTensorType>(result.getType());
+              if (!isTensorOnDevice(tensorType)) {
+                emitOpError()
+                    << "All output tensors of trace function must be on device."
+                    << result << " is not on device.";
+                return ::mlir::WalkResult::interrupt();
+              }
+            }
+
+            return ::mlir::WalkResult::advance();
+          });
+
+  return walkResult.wasInterrupted() ? ::mlir::failure() : ::mlir::success();
+}
+
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -155,6 +155,9 @@ void createTTIRToTTNNBackendPipeline(
     devicePm.addPass(transforms::createConstEvalHoistTransform());
   }
   createTTNNPipelineLayoutDecompositionPass(devicePm, options);
+  if (options.enableTrace) {
+    devicePm.addPass(tt::ttnn::createTTNNTraceHoistTransform());
+  }
   createTTNNPipelineDeallocPass(devicePm, options);
 
   // Run lowering to LLVM pass on hoisted funcs in CPUModule.
@@ -164,6 +167,10 @@ void createTTIRToTTNNBackendPipeline(
 
 void createTTIRToEmitCPipeline(OpPassManager &pm,
                                const TTIRToEmitCPipelineOptions &options) {
+  if (options.enableTrace) {
+    llvm::report_fatal_error(
+        "Trace currently not supported in createTTIRToEmitCPipeline");
+  }
   createTTIRToTTNNBackendPipeline(pm, options);
   pm.addPass(tt::createTTUnwrapDeviceModulePass());
   pm.addPass(createTTNNTuplifyTensors());

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -10,6 +10,7 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         TTNNToCpp.cpp
         TTNNPrepareConv2dWeights.cpp
         TTNNFusing.cpp
+        TTNNTraceHoistTransform.cpp
         Workarounds/Decomposition/ArgMaxOpRewritePattern.cpp
         Workarounds/Decomposition/CumSumOpDimRewritePattern.cpp
         Workarounds/Decomposition/CumSumOpRankRewritePattern.cpp

--- a/lib/Dialect/TTNN/Transforms/Passes.cpp
+++ b/lib/Dialect/TTNN/Transforms/Passes.cpp
@@ -80,9 +80,10 @@ public:
       const LivenessBlockInfo *livenessInfo =
           liveness.getLiveness(&func.getBody().front());
 
-      // Const eval subgraphs may not dealloc their params since they don't own
-      // them.
-      if (!ttmlir::utils::isConstEvalFunc(func)) {
+      // Const eval subgraphs and trace functions may not dealloc their params
+      // since they don't own them.
+      if (!ttmlir::utils::isConstEvalFunc(func) &&
+          !utils::isTTNNTraceFunc(func)) {
         // Handle func op input parameters
         for (BlockArgument arg : func.getArguments()) {
           if (!isa<RankedTensorType>(arg.getType())) {

--- a/lib/Dialect/TTNN/Transforms/TTNNTraceHoistTransform.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNTraceHoistTransform.cpp
@@ -1,0 +1,260 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
+#include "ttmlir/Dialect/TTNN/Utils/TransformUtils.h"
+#include "ttmlir/Utils.h"
+
+namespace mlir::tt::ttnn {
+#define GEN_PASS_DEF_TTNNTRACEHOISTTRANSFORM
+#include "ttmlir/Dialect/TTNN/Transforms/Passes.h.inc"
+
+class TTNNTraceHoistTransform
+    : public impl::TTNNTraceHoistTransformBase<TTNNTraceHoistTransform> {
+public:
+  using impl::TTNNTraceHoistTransformBase<
+      TTNNTraceHoistTransform>::TTNNTraceHoistTransformBase;
+
+  void runOnOperation() final {
+    mlir::ModuleOp moduleOp = this->getOperation();
+    moduleOp.walk([&](func::FuncOp funcOp) {
+      if (failed(processFuncOp(funcOp))) {
+        signalPassFailure();
+      }
+    });
+  }
+
+private:
+  bool shouldHoistOp(Operation *op) {
+    bool shouldHoist = true;
+    shouldHoist &= !::mlir::isa<func::ReturnOp>(op);
+    shouldHoist &= !::mlir::isa<mlir::tt::LoadCachedOp>(op);
+    shouldHoist &= !::mlir::isa<mlir::tt::ttnn::TraceOp>(op);
+    shouldHoist &= !::mlir::isa<mlir::tt::ttnn::GetDeviceOp>(op);
+    return shouldHoist;
+  }
+
+  // Collect all inputs and outputs outside the operation set to hoist
+  void collectFunctionBoundary(llvm::ArrayRef<Operation *> opsToHoist,
+                               llvm::SmallVector<mlir::Value> &inputs,
+                               llvm::SmallVector<mlir::Value> &outputs) {
+
+    // Create set for quick lookup
+    llvm::SmallPtrSet<Operation *, 16> opSet(opsToHoist.begin(),
+                                             opsToHoist.end());
+    llvm::SmallPtrSet<mlir::Value, 16> seenInputs;
+
+    // Collect inputs: operands that come from outside the operation set
+    for (Operation *op : opsToHoist) {
+      for (auto operand : op->getOperands()) {
+        if (!::mlir::isa<RankedTensorType>(operand.getType())) {
+          continue;
+        }
+        Operation *definingOp = operand.getDefiningOp();
+        if (!definingOp || !opSet.contains(definingOp)) {
+          if (seenInputs.insert(operand).second) {
+            inputs.push_back(operand);
+          }
+        }
+      }
+    }
+
+    llvm::sort(inputs.begin(), inputs.end(), [](mlir::Value a, mlir::Value b) {
+      // prioritize block arguments
+      // this is ok now since we check that the funcOp has only 1 block
+      // should be updated if we support multiple blocks in the future
+      if (::mlir::isa<mlir::BlockArgument>(a) &&
+          ::mlir::isa<mlir::BlockArgument>(b)) {
+        return ::mlir::cast<mlir::BlockArgument>(a).getArgNumber() <
+               ::mlir::cast<mlir::BlockArgument>(b).getArgNumber();
+      }
+      if (::mlir::isa<mlir::BlockArgument>(a)) {
+        return true;
+      }
+      if (::mlir::isa<mlir::BlockArgument>(b)) {
+        return false;
+      }
+
+      auto aResult = ::mlir::cast<mlir::OpResult>(a);
+      auto bResult = ::mlir::cast<mlir::OpResult>(b);
+
+      if (aResult.getOwner() == bResult.getOwner()) {
+        return aResult.getResultNumber() < bResult.getResultNumber();
+      }
+      return aResult.getOwner()->isBeforeInBlock(bResult.getOwner());
+    });
+
+    // Collect outputs: results used outside the operation set
+    for (Operation *op : opsToHoist) {
+      for (auto result : op->getResults()) {
+        for (auto &use : result.getUses()) {
+          Operation *user = use.getOwner();
+          if (!opSet.contains(user)) {
+            outputs.push_back(result);
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  ::mlir::LogicalResult
+  createTraceFunctionAndOp(func::FuncOp funcOp,
+                           llvm::ArrayRef<Operation *> opsToHoist,
+                           size_t traceFuncIndex) {
+    mlir::MLIRContext *context = &this->getContext();
+    mlir::OpBuilder builder(context);
+    mlir::IRRewriter rewriter(builder);
+
+    llvm::SmallVector<mlir::Value> inputs;
+    llvm::SmallVector<mlir::Type> inputTypes;
+    llvm::SmallVector<mlir::Value> outputs;
+    llvm::SmallVector<mlir::Type> outputTypes;
+
+    collectFunctionBoundary(opsToHoist, inputs, outputs);
+
+    for (mlir::Value input : inputs) {
+      inputTypes.push_back(input.getType());
+    }
+    for (mlir::Value output : outputs) {
+      outputTypes.push_back(output.getType());
+    }
+
+    llvm::SmallString<32> traceFuncName(funcOp.getName());
+    traceFuncName.append("_trace_");
+    traceFuncName.append(std::to_string(traceFuncIndex));
+
+    auto traceFuncType = builder.getFunctionType(inputTypes, outputTypes);
+
+    // Create the function
+    builder.setInsertionPoint(funcOp);
+    auto traceFuncOp = builder.create<func::FuncOp>(
+        funcOp.getLoc(), traceFuncName, traceFuncType);
+    traceFuncOp->setAttr(utils::g_TTNNTraceAttrName, builder.getUnitAttr());
+
+    // Build the body of the new function
+    auto *traceFuncEntryBlock = traceFuncOp.addEntryBlock();
+    builder.setInsertionPointToStart(traceFuncEntryBlock);
+
+    // maps original input values to trace function input
+    // arguments/intermediates
+    llvm::DenseMap<mlir::Value, mlir::Value> valueMap;
+    for (size_t i = 0; i < inputs.size(); i++) {
+      valueMap.insert({inputs[i], traceFuncEntryBlock->getArgument(i)});
+    }
+
+    for (Operation *op : opsToHoist) {
+      // clone the operation into the trace function
+      Operation *clonedOp = builder.clone(*op);
+
+      // Update the op's operands with trace function input arguments
+      for (size_t i = 0; i < clonedOp->getNumOperands(); i++) {
+        auto originalOperand = op->getOperand(i);
+        auto it = valueMap.find(originalOperand);
+        if (it != valueMap.end()) {
+          clonedOp->setOperand(i, it->second);
+          continue;
+        }
+        // Special case where an op has a device operand.
+        // In this case, we need to insert a GetDeviceOp within the trace
+        // function. The verifier will ensure that this device matches the
+        // device of the trace op.
+        if (::mlir::isa<DeviceType>(originalOperand.getType())) {
+          auto device = utils::getOrInsertDevice(rewriter, clonedOp);
+          clonedOp->setOperand(i, device);
+          continue;
+        }
+        return funcOp.emitError("Could not map operand in hoisted function");
+      }
+
+      // Update the op's results with trace function op output result
+      for (size_t i = 0; i < op->getNumResults(); i++) {
+        valueMap[op->getResult(i)] = clonedOp->getResult(i);
+      }
+    }
+
+    // Finally, we need to add a return operation to the trace function
+    llvm::SmallVector<mlir::Value> returnValues;
+    for (mlir::Value output : outputs) {
+      auto it = valueMap.find(output);
+      if (it != valueMap.end()) {
+        returnValues.push_back(it->second);
+      } else {
+        return funcOp.emitError(
+            "Could not map output value in hoisted function");
+      }
+    }
+    builder.create<func::ReturnOp>(funcOp.getLoc(), returnValues);
+
+    // Function construction is done, we now need to reference it within
+    // a ttnn trace op
+    auto calleeAttr =
+        mlir::SymbolRefAttr::get(builder.getContext(), traceFuncName);
+    Operation *firstOp = opsToHoist.front();
+    builder.setInsertionPoint(firstOp);
+    auto device = utils::getOrInsertDevice(rewriter, firstOp);
+    auto cqIdAttr = builder.getI32IntegerAttr(traceFuncIndex);
+    auto blockingAttr = builder.getBoolAttr(true);
+    auto traceOp = builder.create<mlir::tt::ttnn::TraceOp>(
+        firstOp->getLoc(), outputTypes, device, cqIdAttr, blockingAttr,
+        calleeAttr, ValueRange(inputs));
+
+    // Replace uses of original outputs with the output of the trace op function
+    for (size_t i = 0; i < outputs.size(); i++) {
+      outputs[i].replaceAllUsesWith(traceOp->getResult(i));
+    }
+
+    // Remove the original ops in reverse order (to avoid dependency issues)
+    for (auto it = opsToHoist.rbegin(); it != opsToHoist.rend(); it++) {
+      rewriter.eraseOp(*it);
+    }
+
+    return mlir::success();
+  }
+
+  mlir::LogicalResult processFuncOp(func::FuncOp funcOp) {
+    // skip const-eval functions
+    if (ttmlir::utils::isConstEvalFunc(funcOp)) {
+      return mlir::success();
+    }
+
+    // skip trace functions
+    if (utils::isTTNNTraceFunc(funcOp)) {
+      return mlir::success();
+    }
+
+    if (funcOp.getBlocks().size() != 1) {
+      return funcOp.emitError("FuncOp should have exactly one block");
+    }
+
+    llvm::SmallVector<Operation *> opsToHoist;
+
+    bool seenHoistableOp = false;
+    mlir::Block &block = funcOp.getBlocks().front();
+    for (mlir::Operation &op : block.getOperations()) {
+      if (shouldHoistOp(&op)) {
+        // Hoist all ops starting from this op into a new func
+        seenHoistableOp = true;
+        opsToHoist.push_back(&op);
+        continue;
+      }
+      // If a non-hoistable op is found after a hoistable op, it must be a
+      // return op
+      if (seenHoistableOp && !::mlir::isa<func::ReturnOp>(op)) {
+        return op.emitError(
+            "Non-hoistable op found after seeing a hoistable op");
+      }
+    }
+
+    // Create trace function and trace op if there are ops to hoist
+    if (!opsToHoist.empty()) {
+      return createTraceFunctionAndOp(funcOp, opsToHoist, 0);
+    }
+
+    return mlir::success();
+  }
+};
+} // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Utils/Utils.cpp
+++ b/lib/Dialect/TTNN/Utils/Utils.cpp
@@ -206,4 +206,8 @@ createShardSpecIfNeeded(TensorMemoryLayoutAttr tensorMemoryLayoutAttr,
   return shardSpecAttr;
 }
 
+bool isTTNNTraceFunc(func::FuncOp funcOp) {
+  return funcOp->hasAttr(g_TTNNTraceAttrName);
+}
+
 } // namespace mlir::tt::ttnn::utils

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -1633,6 +1633,37 @@ createOp(FlatbufferObjectCache &cache, tt::LoadCachedOp op,
   return ::tt::target::ttnn::CreateLoadCachedOpDirect(
       *cache.fbb, &ins, op.getCallee().str().c_str(), programIdx, &outputs);
 }
+
+::flatbuffers::Offset<::tt::target::ttnn::TraceOp>
+createOp(FlatbufferObjectCache &cache, TraceOp op,
+         const llvm::StringMap<uint32_t> &programIndexMap) {
+
+  ::mlir::Value device = getOperandThroughDPSOps(op.getDevice());
+  uint32_t cqId = op.getCqId();
+  bool blocking = op.getBlocking();
+
+  std::vector<::flatbuffers::Offset<::tt::target::ttnn::TensorRef>> inputs;
+  for (auto input : op.getInputs()) {
+    inputs.push_back(cache.at<::tt::target::ttnn::TensorRef>(
+        getOperandThroughDPSOps(input)));
+  }
+
+  std::vector<::flatbuffers::Offset<::tt::target::ttnn::TensorRef>> outputs;
+  for (auto result : op.getResults()) {
+    outputs.push_back(
+        cache.getOrCreate(result, tensorValueToFlatbuffer, kHostAllocatedSize));
+  }
+
+  auto it = programIndexMap.find(op.getCallee().str());
+  assert(it != programIndexMap.end() &&
+         "Program name not found in program index map!");
+  const uint32_t programIdx = it->second;
+
+  return ::tt::target::ttnn::CreateTraceOpDirect(
+      *cache.fbb, cache.at<::tt::target::DeviceRef>(device), cqId, blocking,
+      op.getCallee().str().c_str(), programIdx, &inputs, &outputs);
+}
+
 ::flatbuffers::Offset<::tt::target::ttnn::Operation>
 emitTTNNOperation(FlatbufferObjectCache &cache, Operation *op,
                   const llvm::StringMap<uint32_t> &programIndexMap,
@@ -2078,6 +2109,10 @@ emitTTNNOperation(FlatbufferObjectCache &cache, Operation *op,
                            createOp(cache, loadCachedOp, programIndexMap),
                            debugString, locInfo);
   }
+  if (auto traceOp = dyn_cast<TraceOp>(op); traceOp) {
+    return createOperation(cache, createOp(cache, traceOp, programIndexMap),
+                           debugString, locInfo);
+  }
 
   llvm_unreachable("unhandled op in emitTTNNOperation");
 }
@@ -2111,14 +2146,8 @@ std::shared_ptr<void> ttnnToFlatbuffer(
       toFlatbuffer(cache, mlir::cast<tt::SystemDescAttr>(
                               module->getAttr(tt::SystemDescAttr::name)));
 
-  std::string cpp;
-  llvm::raw_string_ostream os(cpp);
-  auto result = mlir::tt::ttnn::emitTTNNAsCpp(module, os);
-  (void)result;
-
   flatbuffers::Offset<::tt::target::DebugInfo> debugInfo =
-      debugInfoToFlatbuffer(fbb, "ttnn", rootModule, goldenMap, moduleCache,
-                            cpp.c_str());
+      debugInfoToFlatbuffer(fbb, "ttnn", rootModule, goldenMap, moduleCache);
 
   // Handle dylib creation and packaging, if needed.
   // Currently, we only have 1 CPUModuleOp and 1 top-level ModuleOp; we use a
@@ -2144,49 +2173,63 @@ std::shared_ptr<void> ttnnToFlatbuffer(
 
   size_t programIdx = 0;
   llvm::StringMap<uint32_t> programIdxMap;
-  // Preserve original ordering by skipping const-eval in the first pass.
-  module->walk([&](func::FuncOp func) {
-    if (ttmlir::utils::isConstEvalFunc(func)) {
-      return;
-    }
-    programIdxMap[func.getSymName().str()] = programIdx++;
-  });
 
-  // Add const-eval funcs after normal funcs.
-  module->walk([&](func::FuncOp func) {
-    if (!ttmlir::utils::isConstEvalFunc(func)) {
-      return;
-    }
-    programIdxMap[func.getSymName().str()] = programIdx++;
+  auto populateProgramIdxMap =
+      [&](std::function<bool(func::FuncOp)> shouldSkip) -> void {
+    module->walk([&](func::FuncOp func) {
+      if (shouldSkip(func)) {
+        return;
+      }
+      programIdxMap[func.getSymName().str()] = programIdx++;
+    });
+  };
+
+  // Preserve original ordering by skipping const-eval and tracein the first
+  // pass.
+  populateProgramIdxMap([](func::FuncOp func) {
+    return ttmlir::utils::isConstEvalFunc(func) ||
+           ttnn::utils::isTTNNTraceFunc(func);
   });
+  // Add const-eval funcs after normal funcs.
+  populateProgramIdxMap(
+      [](func::FuncOp func) { return !ttmlir::utils::isConstEvalFunc(func); });
+  // Finally add trace funcs.
+  populateProgramIdxMap(
+      [](func::FuncOp func) { return !ttnn::utils::isTTNNTraceFunc(func); });
 
   std::vector<::flatbuffers::Offset<::tt::target::ttnn::Program>> programs;
-  // Again, process original funcs in order first to perserve input order.
-  module->walk([&](func::FuncOp func) {
-    if (ttmlir::utils::isConstEvalFunc(func)) {
-      return;
-    }
-    Program<::tt::target::ttnn::Operation> program =
-        funcOpToProgram<::tt::target::ttnn::Operation>(
-            cache, func, emitTTNNOperation, tensorValueToFlatbuffer,
-            programIdxMap);
-    programs.push_back(::tt::target::ttnn::CreateProgramDirect(
-        fbb, program.name, &program.inputs, &program.outputs, &program.ops,
-        &dylibs, debugInfo, /*private=*/false));
-  });
+
+  auto generatePrograms = [&](std::function<bool(func::FuncOp)> shouldSkip,
+                              bool isPrivate) -> void {
+    module->walk([&](func::FuncOp func) {
+      if (shouldSkip(func)) {
+        return;
+      }
+      Program<::tt::target::ttnn::Operation> program =
+          funcOpToProgram<::tt::target::ttnn::Operation>(
+              cache, func, emitTTNNOperation, tensorValueToFlatbuffer,
+              programIdxMap);
+      programs.push_back(::tt::target::ttnn::CreateProgramDirect(
+          fbb, program.name, &program.inputs, &program.outputs, &program.ops,
+          &dylibs, debugInfo, isPrivate));
+    });
+  };
+
+  // Again, process original funcs in order first to preserve input order.
+  generatePrograms(
+      [](func::FuncOp func) {
+        return ttmlir::utils::isConstEvalFunc(func) ||
+               ttnn::utils::isTTNNTraceFunc(func);
+      },
+      /*isPrivate=*/false);
   // Then process const-eval funcs in 2nd pass.
-  module->walk([&](func::FuncOp func) {
-    if (!ttmlir::utils::isConstEvalFunc(func)) {
-      return;
-    }
-    Program<::tt::target::ttnn::Operation> program =
-        funcOpToProgram<::tt::target::ttnn::Operation>(
-            cache, func, emitTTNNOperation, tensorValueToFlatbuffer,
-            programIdxMap);
-    programs.push_back(::tt::target::ttnn::CreateProgramDirect(
-        fbb, program.name, &program.inputs, &program.outputs, &program.ops,
-        &dylibs, debugInfo, /*private=*/true));
-  });
+  generatePrograms(
+      [](func::FuncOp func) { return !ttmlir::utils::isConstEvalFunc(func); },
+      /*isPrivate=*/true);
+  // Finally process trace funcs.
+  generatePrograms(
+      [](func::FuncOp func) { return !ttnn::utils::isTTNNTraceFunc(func); },
+      /*isPrivate=*/true);
 
   auto binary = ::tt::target::ttnn::CreateTTNNBinaryDirect(
       fbb, &binaryVersion, ::tt::target::ttnn::binary_bfbs_schema_hash,

--- a/runtime/include/tt/runtime/detail/test/ttnn/utils.h
+++ b/runtime/include/tt/runtime/detail/test/ttnn/utils.h
@@ -12,6 +12,8 @@ namespace tt::runtime::test::ttnn {
 Layout getDramInterleavedTileLayout(::tt::target::DataType dataType);
 Layout getDramInterleavedRowMajorLayout(::tt::target::DataType dataType);
 Layout getHostRowMajorLayout(::tt::target::DataType dataType);
+std::optional<size_t> getTraceCacheDebugStat(::tt::runtime::Device device,
+                                             const std::string &statName);
 } // namespace tt::runtime::test::ttnn
 
 #endif // TT_RUNTIME_DETAIL_TEST_TTNN_UTILS_H

--- a/runtime/include/tt/runtime/detail/ttnn/operations/utils.h
+++ b/runtime/include/tt/runtime/detail/ttnn/operations/utils.h
@@ -54,5 +54,9 @@ createConv2dConfig(const ::tt::target::ttnn::Conv2dConfig *memcfg);
                             const ::ttnn::Shape &shape,
                             const ::ttnn::DataType &dataType);
 
+::ttnn::Tensor
+allocateTensorOnDevice(const ::tt::target::ttnn::TensorRef *tensorRef,
+                       ::ttnn::MeshDevice &meshDevice);
+
 } // namespace tt::runtime::ttnn::operations::utils
 #endif

--- a/runtime/include/tt/runtime/detail/ttnn/program_executor.h
+++ b/runtime/include/tt/runtime/detail/ttnn/program_executor.h
@@ -25,10 +25,11 @@ class ProgramContext; // Forward declaration
 class ProgramExecutor {
 public:
   // Constructor for executing a program
-  ProgramExecutor(const Binary &executableHandle,
+  ProgramExecutor(::tt::runtime::Device deviceHandle,
+                  ::tt::runtime::Binary &executableHandle,
+                  const size_t programIndex,
                   std::vector<::tt::runtime::Tensor> &programInputs,
-                  std::shared_ptr<::ttnn::MeshDevice> meshDevice,
-                  const size_t programIndex = 0, bool constEvalProgram = false);
+                  bool constEvalProgram = false);
 
   /**
    * Executes pre and post operation callbacks if registered

--- a/runtime/include/tt/runtime/detail/ttnn/trace_cache.h
+++ b/runtime/include/tt/runtime/detail/ttnn/trace_cache.h
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TT_RUNTIME_DETAIL_TTNN_TRACE_CACHE_H
+#define TT_RUNTIME_DETAIL_TTNN_TRACE_CACHE_H
+
+#include "tt/runtime/detail/logger.h"
+#include "tt/runtime/detail/ttnn/ttnn.h"
+
+namespace tt::runtime::ttnn {
+
+std::string generateTraceCacheOuterKey(const uint64_t binaryId,
+                                       const size_t programId);
+
+struct TraceData {
+  ::ttnn::MeshTraceId traceId;
+  // Input tensor buffers to write the input tensors to
+  std::vector<::tt::runtime::Tensor> inputTensors;
+  // Output tensor buffers to write the output tensors to
+  std::vector<::tt::runtime::Tensor> outputTensors;
+};
+
+class TraceCache {
+public:
+  TraceCache(std::shared_ptr<::ttnn::MeshDevice> meshDevice)
+      : meshDevice(meshDevice) {}
+
+  TraceCache(const TraceCache &) = delete;
+  TraceCache &operator=(const TraceCache &) = delete;
+
+  TraceCache(TraceCache &&) = delete;
+  TraceCache &operator=(TraceCache &&) = delete;
+
+  bool contains(uint64_t binaryId, size_t programId,
+                const std::string &traceFuncName) const;
+  TraceData *get(uint64_t binaryId, size_t programId,
+                 const std::string &traceFuncName);
+  void insert(uint64_t binaryId, size_t programId,
+              const std::string &traceFuncName, const TraceData &traceData);
+  bool erase(uint64_t binaryId, size_t programId);
+  bool erase(uint64_t binaryId, size_t programId,
+             const std::string &traceFuncName);
+
+  // Debug stats
+  std::optional<size_t> getDebugStat(const std::string &statName) const;
+  void incrementDebugStat(const std::string &statName) const;
+  void printDebugStats() const;
+  void clearDebugStats() const;
+
+private:
+  std::weak_ptr<::ttnn::MeshDevice> meshDevice;
+  // Outer key should be combination of device id and program index, created via
+  // generateCacheOuterKey. Inner key will be trace func name.
+  std::unordered_map<std::string, std::unordered_map<std::string, TraceData>>
+      cache;
+
+  // Debug stats, only gathered when TT_RUNTIME_DEBUG is enabled
+#if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
+  mutable std::unordered_map<std::string, size_t> stats;
+#endif
+};
+} // namespace tt::runtime::ttnn
+
+#endif

--- a/runtime/include/tt/runtime/detail/ttnn/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn/ttnn.h
@@ -42,6 +42,7 @@
 #include "ttnn/operations/reduction/argmax/argmax.hpp"
 #include "ttnn/operations/reduction/generic/generic_reductions.hpp"
 #include "ttnn/operations/reduction/prod/prod.hpp"
+#include "ttnn/operations/trace.hpp"
 #include "ttnn/tensor/host_buffer/functions.hpp"
 #include "ttnn/tensor/shape/shape.hpp"
 #include "ttnn/tensor/tensor.hpp"
@@ -154,6 +155,8 @@ size_t getNumDramChannels(Device meshDevice);
 size_t getDramSizePerChannel(Device meshDevice);
 size_t getL1SizePerCore(Device meshDevice);
 
+bool releaseTrace(Device meshDevice, std::uint64_t binaryId, size_t programId);
+
 void deallocateBuffers(Device device);
 
 void dumpMemoryReport(Device device);
@@ -195,11 +198,6 @@ std::string getOpLocInfo(OpContext opContextHandle);
 std::vector<::tt::runtime::Tensor>
 submit(Device deviceHandle, Binary executableHandle, std::uint32_t programIndex,
        std::vector<::tt::runtime::Tensor> &inputs);
-
-std::vector<::tt::runtime::Tensor>
-runProgram(std::shared_ptr<::ttnn::MeshDevice> meshDevice,
-           Binary executableHandle, std::uint32_t programIndex,
-           std::vector<::tt::runtime::Tensor> &inputs);
 
 } // namespace tt::runtime::ttnn
 

--- a/runtime/include/tt/runtime/detail/ttnn/utils.h
+++ b/runtime/include/tt/runtime/detail/ttnn/utils.h
@@ -26,6 +26,9 @@ bool isSharded(
 const ::tt::target::ttnn::TTNNBinary *
 getBinary(::tt::runtime::Flatbuffer binary);
 
+const ::tt::target::ttnn::Program *getProgram(const Binary &executableHandle,
+                                              std::uint32_t programIndex);
+
 ::ttnn::operations::reduction::ReduceType getReduceType(uint32_t reduceType);
 
 ::ttnn::DataType toTTNNDataType(::tt::target::DataType dataType);
@@ -67,6 +70,8 @@ createMemoryConfigIfNeeded(const ::tt::target::ttnn::MemoryConfig *memcfg);
 
 ::tt::runtime::Tensor createRuntimeTensorFromTTNN(const ::ttnn::Tensor &tensor,
                                                   bool retain = false);
+
+::ttnn::Tensor &getTTNNTensorFromRuntimeTensor(::tt::runtime::Tensor tensor);
 
 void *getRawHostDataPtr(const ::ttnn::Tensor &tensor);
 

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -161,6 +161,8 @@ size_t getNumDramChannels(Device meshDevice);
 size_t getDramSizePerChannel(Device meshDevice);
 size_t getL1SizePerCore(Device meshDevice);
 
+bool releaseTrace(Device meshDevice, std::uint64_t binaryId, size_t programId);
+
 void wait(Event event);
 
 void wait(Tensor tensor);

--- a/runtime/include/tt/runtime/tensor_cache.h
+++ b/runtime/include/tt/runtime/tensor_cache.h
@@ -6,6 +6,7 @@
 #define TT_RUNTIME_TENSOR_CACHE_H
 
 #include "tt/runtime/types.h"
+#include "tt/runtime/utils.h"
 
 #include <cstdint>
 #include <mutex>

--- a/runtime/include/tt/runtime/workarounds.h
+++ b/runtime/include/tt/runtime/workarounds.h
@@ -12,10 +12,11 @@ namespace tt::runtime::workaround {
 struct Env {
   static const Env &get(bool swapBinaryOperands = true,
                         bool readUpdateIndexFromDeviceForKVCache = true,
-                        bool rawHostDataPointerWrapper = true) {
+                        bool rawHostDataPointerWrapper = true,
+                        bool traceImplicitFromDevice = true) {
     static const Env config(swapBinaryOperands,
                             readUpdateIndexFromDeviceForKVCache,
-                            rawHostDataPointerWrapper);
+                            rawHostDataPointerWrapper, traceImplicitFromDevice);
     return config;
   }
 
@@ -38,14 +39,22 @@ struct Env {
   // added
   bool rawHostDataPointerWrapper;
 
+  // TODO(bug #3695): Currently ttnn only supports writing to a pre-allocated
+  // device tensor from host. Therefore, the trace op implicitly reads any
+  // device input back to host, then writes it to the designated buffer. This
+  // should be updated in the future either when ttnn supports device to device
+  // memcpy or when we model this behaviour in the compiler.
+  bool traceImplicitFromDevice;
+
 private:
   constexpr Env(bool swapBinaryOperands,
                 bool readUpdateIndexFromDeviceForKVCache,
-                bool rawHostDataPointerWrapper)
+                bool rawHostDataPointerWrapper, bool traceImplicitFromDevice)
       : swapBinaryOperands(swapBinaryOperands),
         readUpdateIndexFromDeviceForKVCache(
             readUpdateIndexFromDeviceForKVCache),
-        rawHostDataPointerWrapper(rawHostDataPointerWrapper) {}
+        rawHostDataPointerWrapper(rawHostDataPointerWrapper),
+        traceImplicitFromDevice(traceImplicitFromDevice) {}
 };
 
 inline std::ostream &operator<<(std::ostream &os, const Env &env) {
@@ -57,6 +66,8 @@ inline std::ostream &operator<<(std::ostream &os, const Env &env) {
      << env.readUpdateIndexFromDeviceForKVCache << "\n";
   os << "\t"
      << "rawHostDataPointerWrapper: " << env.rawHostDataPointerWrapper << "\n";
+  os << "\t"
+     << "traceImplicitFromDevice: " << env.traceImplicitFromDevice << "\n";
   os << "}";
   return os;
 }

--- a/runtime/lib/binary.cpp
+++ b/runtime/lib/binary.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <atomic>
 #include <fstream>
 
 #include "flatbuffers/idl.h"
@@ -20,26 +21,43 @@
 namespace tt::runtime {
 
 Binary::Binary(Flatbuffer fb)
-    : Flatbuffer(fb), cache(std::make_shared<TensorCache>()) {}
+    : Flatbuffer(fb), binaryId(nextBinaryId()),
+      tensorCache(std::make_shared<TensorCache>()) {}
 
 Binary::Binary(std::shared_ptr<void> handle)
-    : Flatbuffer(handle), cache(std::make_shared<TensorCache>()) {}
+    : Flatbuffer(handle), binaryId(nextBinaryId()),
+      tensorCache(std::make_shared<TensorCache>()) {}
 
 Binary &Binary::operator=(Flatbuffer fb) {
   this->handle = fb.handle;
-  if (!cache) {
-    cache = std::make_shared<TensorCache>();
-  }
+
+  binaryId = nextBinaryId();
+
+  // Reinitialize tensor cache since binary handle contents
+  // are now different
+  tensorCache = std::make_shared<TensorCache>();
+
   return *this;
 }
 
 Binary &Binary::operator=(std::shared_ptr<void> handle) {
   this->handle = handle;
-  if (!cache) {
-    cache = std::make_shared<TensorCache>();
-  }
+
+  binaryId = nextBinaryId();
+
+  // Reinitialize tensor cache since binary handle contents
+  // are now different
+  tensorCache = std::make_shared<TensorCache>();
+
   return *this;
 }
+
+std::uint64_t Binary::nextBinaryId() {
+  static std::atomic<uint64_t> id{0};
+  return id++;
+}
+
+std::uint64_t Binary::id() const { return binaryId; }
 
 static flatbuffers::Parser getParser(const uint8_t *binarySchema,
                                      size_t schemaSize) {

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -570,6 +570,19 @@ size_t getL1SizePerCore(Device meshDevice) {
       });
 }
 
+bool releaseTrace(Device meshDevice, std::uint64_t binaryId, size_t programId) {
+  using RetType = bool;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        return ::tt::runtime::ttnn::releaseTrace(meshDevice, binaryId,
+                                                 programId);
+      },
+      [&]() -> RetType {
+        detail::fatalNotImplemented(__FUNCTION__, DeviceRuntime::TTMetal);
+      });
+}
+
 void wait(Event event) {
   using RetType = void;
   DISPATCH_TO_CURRENT_RUNTIME(

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -124,7 +124,7 @@ Device openMeshDevice(const std::vector<uint32_t> &meshShape,
             meshDevice->compute_with_storage_grid_size().y, " }");
 
   return Device(std::static_pointer_cast<void>(meshDevice),
-                DeviceRuntime::TTMetal);
+                /*traceCache=*/nullptr, DeviceRuntime::TTMetal);
 }
 
 void closeMeshDevice(Device parentMesh) {
@@ -170,7 +170,7 @@ Device createSubMeshDevice(
       parentMeshDevice.create_submesh(shape, offset);
 
   return Device(std::static_pointer_cast<void>(subMeshDevice),
-                DeviceRuntime::TTMetal);
+                /*traceCache=*/nullptr, DeviceRuntime::TTMetal);
 }
 
 void releaseSubMeshDevice(Device subMesh) {

--- a/runtime/lib/ttnn/operations/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/CMakeLists.txt
@@ -55,6 +55,7 @@ set(TTNN_OPS_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/reduction/argmax.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/reduction/prod.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/reduction/reduction.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/trace/trace.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/utils/utils.cpp
 )
 

--- a/runtime/lib/ttnn/operations/cache/load_cached.cpp
+++ b/runtime/lib/ttnn/operations/cache/load_cached.cpp
@@ -18,7 +18,7 @@ namespace tt::runtime::ttnn::operations::cache {
 using LogType = ::tt::runtime::logger::LogType;
 
 void run(const ::tt::target::ttnn::LoadCachedOp *op, ProgramContext &context) {
-  std::shared_ptr<TensorCache> cache = context.getCache();
+  std::shared_ptr<TensorCache> cache = context.getConstEvalTensorCache();
   LOG_ASSERT(cache, "Cache must be enabled to support const-eval ops.");
 
   // Get the device ID from the parent mesh
@@ -45,8 +45,7 @@ void run(const ::tt::target::ttnn::LoadCachedOp *op, ProgramContext &context) {
 
     assert(cachedOutputs->size() == op->outputs()->size());
     for (size_t i = 0; i < cachedOutputs->size(); ++i) {
-      auto &output =
-          (*cachedOutputs)[i].as<::ttnn::Tensor>(DeviceRuntime::TTNN);
+      auto &output = utils::getTTNNTensorFromRuntimeTensor((*cachedOutputs)[i]);
       context.getTensorPool().insertTTNNTensorAndValidate(op->outputs()->Get(i),
                                                           output);
     }
@@ -66,18 +65,17 @@ void run(const ::tt::target::ttnn::LoadCachedOp *op, ProgramContext &context) {
 
   // Execute the function
   const size_t programIndex = op->program_idx();
-  ProgramExecutor exec(context.getExecutableHandle(), inputs,
-                       context.getMeshDevicePtr(), programIndex,
-                       /*cachedProgram*/ true);
+  ProgramExecutor exec(context.getDeviceHandle(), context.getExecutableHandle(),
+                       programIndex, inputs, /*constEvalProgram=*/true);
   exec.execute();
   LOG_DEBUG("executed sub-func: ", constEvalFuncname);
-  std::vector<Tensor> outputs = exec.gatherOutputTensors();
+  std::vector<::tt::runtime::Tensor> outputs = exec.gatherOutputTensors();
 
   cache->store(cacheKey, constEvalFuncname, std::move(inputVersions), outputs);
 
   for (size_t i = 0; i < outputs.size(); ++i) {
-    Tensor &runtimeOutput = outputs[i];
-    auto &output = runtimeOutput.as<::ttnn::Tensor>(DeviceRuntime::TTNN);
+    ::tt::runtime::Tensor &runtimeOutput = outputs[i];
+    auto &output = utils::getTTNNTensorFromRuntimeTensor(runtimeOutput);
     context.getTensorPool().insertTTNNTensorAndValidate(op->outputs()->Get(i),
                                                         output);
   }

--- a/runtime/lib/ttnn/operations/ccl/reduce_scatter.cpp
+++ b/runtime/lib/ttnn/operations/ccl/reduce_scatter.cpp
@@ -35,16 +35,9 @@ void run(const ::tt::target::ttnn::ReduceScatterOp *op,
              "Memory config must exist for device tensors");
 
   ::ttnn::MeshDevice &meshDevice = context.getMeshDevice();
-  ::ttnn::Tensor out;
-  try {
-    out = ::ttnn::reduce_scatter(
-        input, scatterDimension, clusterAxis, meshDevice, reduceType, numLinks,
-        outputMemoryConfig, ::ttnn::ccl::Topology::Linear);
-  } catch (const std::exception &e) {
-    auto bt = ::tt::runtime::logger::detail::backtrace_to_string(128, 0);
-    LOG_INFO("Stack trace: ", bt);
-    throw;
-  }
+  ::ttnn::Tensor out = ::ttnn::reduce_scatter(
+      input, scatterDimension, clusterAxis, meshDevice, reduceType, numLinks,
+      outputMemoryConfig, ::ttnn::ccl::Topology::Linear);
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }

--- a/runtime/lib/ttnn/operations/trace/trace.cpp
+++ b/runtime/lib/ttnn/operations/trace/trace.cpp
@@ -1,0 +1,198 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "operations/trace/trace.h"
+#include "tt/runtime/detail/logger.h"
+#include "tt/runtime/detail/ttnn/operations/utils.h"
+#include "tt/runtime/detail/ttnn/program_executor.h"
+#include "tt/runtime/detail/ttnn/trace_cache.h"
+#include "tt/runtime/detail/ttnn/types.h"
+#include "tt/runtime/detail/ttnn/utils.h"
+#include "tt/runtime/types.h"
+#include "tt/runtime/workarounds.h"
+
+namespace tt::runtime::ttnn::operations::trace {
+
+static void
+copyTensor(const ::tt::target::ttnn::TensorRef *srcTensorDesc,
+           const ::ttnn::Tensor &srcTensor, ::ttnn::Tensor &dstTensor,
+           const ::ttnn::QueueId &queueId = ::ttnn::DefaultQueueId) {
+
+  if (::tt::runtime::ttnn::utils::inSystemMemory(srcTensorDesc)) {
+    ::tt::tt_metal::write_tensor(srcTensor, dstTensor, queueId);
+    return;
+  }
+
+  LOG_ASSERT(::tt::runtime::workaround::Env::get().traceImplicitFromDevice,
+             "traceImplicitFromDevice workaround must be enabled.");
+  ::ttnn::Tensor hostSrcTensor = ::ttnn::from_device(srcTensor);
+  ::tt::tt_metal::write_tensor(hostSrcTensor, dstTensor, queueId);
+}
+
+static void executeTraceProgramAndCaptureTrace(
+    const ::tt::target::ttnn::TraceOp *op, ProgramContext &context,
+    ::tt::runtime::ttnn::TraceCache &traceCache) {
+
+  ::tt::runtime::Device deviceHandle = context.getDeviceHandle();
+  ::ttnn::MeshDevice &meshDevice =
+      deviceHandle.as<::ttnn::MeshDevice>(DeviceRuntime::TTNN);
+
+  std::vector<::tt::runtime::Tensor> traceInputTensors;
+  for (const ::tt::target::ttnn::TensorRef *input : *op->inputs()) {
+    // Allocate a tensor buffer on device. This will hold the input data for the
+    // trace
+    ::ttnn::Tensor traceInputTensorTTNN =
+        utils::allocateTensorOnDevice(input, meshDevice);
+
+    // Copy the input data from the runtime tensor pool to the trace tensor
+    ::tt::runtime::ttnn::TTNNTensorWrapper &inputTensorWrapper =
+        context.getTensorPool().getTTNNTensorWrapperAndValidate(input);
+    copyTensor(input, inputTensorWrapper.getTensor(), traceInputTensorTTNN);
+
+    // Store the trace input tensor
+    ::tt::runtime::Tensor traceInputTensor =
+        ::tt::runtime::ttnn::utils::createRuntimeTensorFromTTNN(
+            traceInputTensorTTNN, /*retain=*/true);
+    ::tt::runtime::ttnn::TTNNTensorWrapper &traceInputTensorWrapper =
+        traceInputTensor.as<::tt::runtime::ttnn::TTNNTensorWrapper>(
+            DeviceRuntime::TTNN);
+    traceInputTensorWrapper.syncVersion(inputTensorWrapper);
+
+    traceInputTensors.push_back(traceInputTensor);
+  }
+
+  // Execute the trace program to compile kernels and get compute results
+  const size_t calleeProgramIndex = op->callee_program_idx();
+  ProgramExecutor traceFuncExecutor(deviceHandle, context.getExecutableHandle(),
+                                    calleeProgramIndex, traceInputTensors);
+  traceFuncExecutor.execute();
+  LOG_DEBUG("Finished execution of trace function: ", op->callee_name()->str());
+  std::vector<::tt::runtime::Tensor> outputs =
+      traceFuncExecutor.gatherOutputTensors();
+
+  for (size_t i = 0; i < outputs.size(); i++) {
+    ::ttnn::Tensor &output =
+        ::tt::runtime::ttnn::utils::getTTNNTensorFromRuntimeTensor(outputs[i]);
+    context.getTensorPool().insertTTNNTensorAndValidate(op->outputs()->Get(i),
+                                                        output);
+  }
+
+  // Now that the program has been executed and kernels have been compiled
+  // We can capture the trace
+  ProgramExecutor traceCaptureExecutor(deviceHandle,
+                                       context.getExecutableHandle(),
+                                       calleeProgramIndex, traceInputTensors);
+
+  // Capture the trace
+  ::ttnn::QueueId ttnnCqId = ::ttnn::QueueId(op->cq_id());
+  ::ttnn::MeshTraceId traceId =
+      ::ttnn::operations::trace::begin_trace_capture(&meshDevice, ttnnCqId);
+  traceCaptureExecutor.execute();
+  std::vector<::tt::runtime::Tensor> traceOutputs =
+      traceCaptureExecutor.gatherOutputTensors();
+  ::ttnn::operations::trace::end_trace_capture(&meshDevice, traceId, ttnnCqId);
+
+  // Store the trace data in the cache
+  TraceData traceData{.traceId = traceId,
+                      .inputTensors = traceInputTensors,
+                      .outputTensors = traceOutputs};
+
+  uint64_t binaryId = context.getExecutableHandle().id();
+  uint32_t programId = context.getProgramIndex();
+  const std::string &traceFuncName = op->callee_name()->str();
+
+  traceCache.insert(binaryId, programId, traceFuncName, traceData);
+}
+
+static void executeTrace(const ::tt::target::ttnn::TraceOp *op,
+                         ProgramContext &context, TraceData &traceData) {
+  ::ttnn::MeshDevice &meshDevice = context.getMeshDevice();
+
+  std::vector<::ttnn::Tensor> inputs;
+  LOG_ASSERT(op->inputs()->size() == traceData.inputTensors.size());
+
+  for (size_t i = 0; i < op->inputs()->size(); i++) {
+    const ::tt::target::ttnn::TensorRef *input = op->inputs()->Get(i);
+    ::tt::runtime::ttnn::TTNNTensorWrapper &inputTensorWrapper =
+        context.getTensorPool().getTTNNTensorWrapperAndValidate(input);
+
+    ::tt::runtime::ttnn::TTNNTensorWrapper &inputSlotWrapper =
+        traceData.inputTensors[i].as<::tt::runtime::ttnn::TTNNTensorWrapper>(
+            DeviceRuntime::TTNN);
+
+    // If the input tensor versions match (i.e. has been constant since the
+    // previous trace) then we can skip the copy
+    if (inputTensorWrapper.getVersion() == inputSlotWrapper.getVersion()) {
+      continue;
+    }
+
+    copyTensor(input, inputTensorWrapper.getTensor(),
+               inputSlotWrapper.getTensor());
+
+    // Input slot will now contain identical data as the input tensor
+    // Thus we can syncronize their versions
+    inputSlotWrapper.syncVersion(inputTensorWrapper);
+  }
+
+  ::ttnn::QueueId ttnnCqId = ::ttnn::QueueId(op->cq_id());
+  // Execute the trace
+  ::ttnn::operations::trace::execute_trace(&meshDevice, traceData.traceId,
+                                           ttnnCqId, op->blocking());
+
+  size_t outputIndex = 0;
+  for (const ::tt::target::ttnn::TensorRef *output : *op->outputs()) {
+    const ::ttnn::Tensor &outputTensor =
+        ::tt::runtime::ttnn::utils::getTTNNTensorFromRuntimeTensor(
+            traceData.outputTensors[outputIndex++]);
+    // These outputs must be retained as they are output slots of the trace
+    context.getTensorPool().insertTTNNTensorAndValidate(output, outputTensor,
+                                                        /*retain=*/true);
+  }
+}
+
+static inline void
+incrementDebugStat(const ::tt::runtime::ttnn::TraceCache &cache,
+                   const std::string &statName) {
+#if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
+  cache.incrementDebugStat(statName);
+#else
+  LOG_WARNING_ONCE("Trace cache debug stats are disabled in release mode. To "
+                   "record debug stats, TT_RUNTIME_DEBUG must be set");
+#endif
+}
+
+void run(const ::tt::target::ttnn::TraceOp *op, ProgramContext &context) {
+  ::tt::runtime::Device deviceHandle = context.getDeviceHandle();
+  ::ttnn::MeshDevice &meshDevice =
+      deviceHandle.as<::ttnn::MeshDevice>(DeviceRuntime::TTNN);
+
+  LOG_ASSERT(meshDevice.get_program_cache().is_enabled(),
+             "Program cache must be enabled");
+  LOG_ASSERT(meshDevice.allocator()->get_config().trace_region_size > 0,
+             "Trace region size must be greater than 0");
+
+  Binary &executableHandle = context.getExecutableHandle();
+
+  auto traceCache =
+      deviceHandle.getTraceCache()
+          ->asSharedPtr<::tt::runtime::ttnn::TraceCache>(DeviceRuntime::TTNN);
+  LOG_ASSERT(traceCache, "TraceCache must be initialized in DeviceHandle");
+
+  uint64_t binaryId = executableHandle.id();
+  uint32_t programId = context.getProgramIndex();
+  const std::string &traceFuncName = op->callee_name()->str();
+
+  if (!traceCache->contains(binaryId, programId, traceFuncName)) {
+    executeTraceProgramAndCaptureTrace(op, context, *traceCache);
+    incrementDebugStat(*traceCache, "cacheMiss");
+    incrementDebugStat(*traceCache, "capturedTrace");
+    return;
+  }
+
+  TraceData *traceData = traceCache->get(binaryId, programId, traceFuncName);
+  LOG_ASSERT(traceData, "TraceData must be populated in TraceCache");
+  executeTrace(op, context, *traceData);
+  incrementDebugStat(*traceCache, "executedTrace");
+}
+} // namespace tt::runtime::ttnn::operations::trace

--- a/runtime/lib/ttnn/operations/trace/trace.h
+++ b/runtime/lib/ttnn/operations/trace/trace.h
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TT_RUNTIME_TTNN_OPERATIONS_TRACE_TRACE_H
+#define TT_RUNTIME_TTNN_OPERATIONS_TRACE_TRACE_H
+
+#include "tt/runtime/detail/ttnn/types.h"
+#include "ttmlir/Target/TTNN/Target.h"
+
+namespace tt::runtime::ttnn::operations::trace {
+
+void run(const ::tt::target::ttnn::TraceOp *op, ProgramContext &context);
+
+} // namespace tt::runtime::ttnn::operations::trace
+
+#endif // TT_RUNTIME_TTNN_OPERATIONS_TRACE_TRACE_H

--- a/runtime/lib/ttnn/operations/utils/utils.cpp
+++ b/runtime/lib/ttnn/operations/utils/utils.cpp
@@ -410,4 +410,22 @@ toTTNNTensorImpl(const ::flatbuffers::Vector<uint8_t> *data,
   }
 }
 
+::ttnn::Tensor
+allocateTensorOnDevice(const ::tt::target::ttnn::TensorRef *tensorRef,
+                       ::ttnn::MeshDevice &meshDevice) {
+  ::ttnn::Shape ttnnShape = toTTNNShape(*tensorRef->desc()->shape());
+  ::ttnn::DataType ttnnDataType = ::tt::runtime::ttnn::utils::toTTNNDataType(
+      tensorRef->desc()->layout()->memory_desc()->data_type());
+  ::ttnn::Layout ttnnLayout =
+      ::tt::runtime::ttnn::utils::inferLayoutFromTileShape(tensorRef);
+  std::optional<::ttnn::MemoryConfig> memoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
+          ::tt::runtime::ttnn::utils::getTensorRefMemoryConfig(tensorRef));
+  LOG_ASSERT(memoryConfig.has_value());
+  ::ttnn::Tensor deviceTensor =
+      ::ttnn::operations::core::allocate_tensor_on_device(
+          ttnnShape, ttnnDataType, ttnnLayout, &meshDevice, memoryConfig);
+  return deviceTensor;
+}
+
 } // namespace tt::runtime::ttnn::operations::utils

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -53,6 +53,7 @@
 #include "operations/reduction/argmax.h"
 #include "operations/reduction/prod.h"
 #include "operations/reduction/reduction.h"
+#include "operations/trace/trace.h"
 #include "tt/runtime/detail/debug.h"
 #include "tt/runtime/detail/ttnn/types.h"
 #include "tt/runtime/utils.h"
@@ -82,21 +83,11 @@ static void tracyLogConstEvalProgram(const ::tt::target::ttnn::Operation *op,
 #endif
 }
 
-static const ::tt::target::ttnn::Program *
-getProgram(const Binary &executableHandle, std::uint32_t programIndex) {
-  const ::tt::target::ttnn::TTNNBinary &fbb =
-      *utils::getBinary(executableHandle);
-  const ::tt::target::ttnn::Program *program =
-      fbb.programs()->Get(programIndex);
-  return program;
-}
-
 ProgramExecutor::ProgramExecutor(
-    const Binary &executableHandle,
-    std::vector<::tt::runtime::Tensor> &programInputs,
-    std::shared_ptr<::ttnn::MeshDevice> meshDevice, const size_t programIndex,
-    bool constEvalProgram)
-    : program(getProgram(executableHandle, programIndex)),
+    ::tt::runtime::Device deviceHandle, ::tt::runtime::Binary &executableHandle,
+    const size_t programIndex,
+    std::vector<::tt::runtime::Tensor> &programInputs, bool constEvalProgram)
+    : program(utils::getProgram(executableHandle, programIndex)),
       executableHandle(executableHandle), constEvalProgram(constEvalProgram) {
   LOG_ASSERT(program, "Program must be provided for execution");
 
@@ -120,7 +111,7 @@ ProgramExecutor::ProgramExecutor(
 
   context = std::make_unique<ProgramContext>(
       programInputIds, programOutputIds, std::move(liveTensors),
-      common::DylibManager(program->dylibs()), std::move(meshDevice),
+      common::DylibManager(program->dylibs()), std::move(deviceHandle),
       executableHandle, programIndex);
 }
 
@@ -348,6 +339,9 @@ void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
   }
   case ::tt::target::ttnn::OpType::BatchNormOp: {
     return operations::batch_norm::run(op->type_as_BatchNormOp(), getContext());
+  }
+  case ::tt::target::ttnn::OpType::TraceOp: {
+    return operations::trace::run(op->type_as_TraceOp(), getContext());
   }
   default: {
     LOG_FATAL("Unsupported operation type: ",

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -11,6 +11,7 @@
 #include "tt/runtime/detail/ttnn/debug_apis.h"
 #include "tt/runtime/detail/ttnn/layout_converter.h"
 #include "tt/runtime/detail/ttnn/program_executor.h"
+#include "tt/runtime/detail/ttnn/trace_cache.h"
 #include "tt/runtime/detail/ttnn/ttnn.h"
 #include "tt/runtime/detail/ttnn/types.h"
 #include "tt/runtime/detail/ttnn/utils.h"
@@ -150,10 +151,7 @@ createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
   std::transform(tensorShards.begin(), tensorShards.end(),
                  std::back_inserter(ttnnTensorShards),
                  [&](::tt::runtime::Tensor tensorShard) -> ::ttnn::Tensor {
-                   return tensorShard
-                       .as<::tt::runtime::ttnn::TTNNTensorWrapper>(
-                           DeviceRuntime::TTNN)
-                       .getTensor();
+                   return utils::getTTNNTensorFromRuntimeTensor(tensorShard);
                  });
 
   DistributedTensorConfig distributionStrategy =
@@ -203,22 +201,19 @@ createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
 
 bool isTensorAllocated(::tt::runtime::Tensor tensor) {
   const ::ttnn::Tensor &ttnnTensor =
-      tensor.as<::tt::runtime::ttnn::TTNNTensorWrapper>(DeviceRuntime::TTNN)
-          .getTensor();
+      utils::getTTNNTensorFromRuntimeTensor(tensor);
   return ttnnTensor.is_allocated();
 }
 
 tt::target::DataType getTensorDataType(::tt::runtime::Tensor tensor) {
-  const ::ttnn::Tensor &nnTensor =
-      tensor.as<::tt::runtime::ttnn::TTNNTensorWrapper>(DeviceRuntime::TTNN)
-          .getTensor();
-  return utils::fromTTNNDataType(nnTensor.dtype());
+  const ::ttnn::Tensor &ttnnTensor =
+      utils::getTTNNTensorFromRuntimeTensor(tensor);
+  return utils::fromTTNNDataType(ttnnTensor.dtype());
 }
 
 std::vector<std::byte> getTensorDataBuffer(::tt::runtime::Tensor tensor) {
   const ::ttnn::Tensor &ttnnTensor =
-      tensor.as<::tt::runtime::ttnn::TTNNTensorWrapper>(DeviceRuntime::TTNN)
-          .getTensor();
+      utils::getTTNNTensorFromRuntimeTensor(tensor);
   void *dataPtr = nullptr;
   std::vector<std::byte> dataVec(getTensorElementSize(tensor) *
                                  getTensorVolume(tensor));
@@ -293,8 +288,7 @@ std::vector<std::byte> getTensorDataBuffer(::tt::runtime::Tensor tensor) {
 
 std::vector<std::uint32_t> getTensorShape(::tt::runtime::Tensor tensor) {
   const ::ttnn::Tensor &ttnnTensor =
-      tensor.as<::tt::runtime::ttnn::TTNNTensorWrapper>(DeviceRuntime::TTNN)
-          .getTensor();
+      utils::getTTNNTensorFromRuntimeTensor(tensor);
   std::vector<std::uint32_t> shape;
   for (size_t i = 0; i < ttnnTensor.logical_shape().size(); ++i) {
     shape.push_back(ttnnTensor.logical_shape()[i]);
@@ -304,8 +298,7 @@ std::vector<std::uint32_t> getTensorShape(::tt::runtime::Tensor tensor) {
 
 std::vector<std::uint32_t> getTensorStride(::tt::runtime::Tensor tensor) {
   const ::ttnn::Tensor &ttnnTensor =
-      tensor.as<::tt::runtime::ttnn::TTNNTensorWrapper>(DeviceRuntime::TTNN)
-          .getTensor();
+      utils::getTTNNTensorFromRuntimeTensor(tensor);
   std::vector<std::uint32_t> stride;
   for (size_t i = 0; i < ttnnTensor.strides().size(); ++i) {
     stride.push_back(ttnnTensor.strides()[i]);
@@ -315,15 +308,13 @@ std::vector<std::uint32_t> getTensorStride(::tt::runtime::Tensor tensor) {
 
 std::uint32_t getTensorElementSize(::tt::runtime::Tensor tensor) {
   const ::ttnn::Tensor &ttnnTensor =
-      tensor.as<::tt::runtime::ttnn::TTNNTensorWrapper>(DeviceRuntime::TTNN)
-          .getTensor();
+      utils::getTTNNTensorFromRuntimeTensor(tensor);
   return ttnnTensor.element_size();
 }
 
 std::uint32_t getTensorVolume(::tt::runtime::Tensor tensor) {
   const ::ttnn::Tensor &ttnnTensor =
-      tensor.as<::tt::runtime::ttnn::TTNNTensorWrapper>(DeviceRuntime::TTNN)
-          .getTensor();
+      utils::getTTNNTensorFromRuntimeTensor(tensor);
   return ttnnTensor.padded_volume();
 }
 
@@ -385,7 +376,12 @@ Device openMeshDevice(const std::vector<uint32_t> &meshShape,
             meshDevice->compute_with_storage_grid_size().x, ", ",
             meshDevice->compute_with_storage_grid_size().y, " }");
 
-  return Device(std::static_pointer_cast<void>(meshDevice),
+  auto ttnnTraceCache =
+      std::make_shared<::tt::runtime::ttnn::TraceCache>(meshDevice);
+  auto traceCache = std::make_shared<::tt::runtime::TraceCache>(
+      std::static_pointer_cast<void>(ttnnTraceCache), DeviceRuntime::TTNN);
+
+  return Device(std::static_pointer_cast<void>(meshDevice), traceCache,
                 DeviceRuntime::TTNN);
 }
 
@@ -433,7 +429,11 @@ Device createSubMeshDevice(
   std::shared_ptr<::ttnn::MeshDevice> subMeshDevice =
       parentMeshDevice.create_submesh(shape, offset);
 
-  return Device(std::static_pointer_cast<void>(subMeshDevice),
+  auto ttnnTraceCache =
+      std::make_shared<::tt::runtime::ttnn::TraceCache>(subMeshDevice);
+  auto traceCache = std::make_shared<::tt::runtime::TraceCache>(
+      std::static_pointer_cast<void>(ttnnTraceCache), DeviceRuntime::TTNN);
+  return Device(std::static_pointer_cast<void>(subMeshDevice), traceCache,
                 DeviceRuntime::TTNN);
 }
 
@@ -508,6 +508,12 @@ size_t getL1SizePerCore(Device meshDevice) {
   ::ttnn::MeshDevice &ttnnMeshDevice =
       meshDevice.as<::ttnn::MeshDevice>(DeviceRuntime::TTNN);
   return ttnnMeshDevice.l1_size_per_core();
+}
+
+bool releaseTrace(Device meshDevice, std::uint64_t binaryId, size_t programId) {
+  ::tt::runtime::ttnn::TraceCache &traceCache =
+      meshDevice.getTraceCache()->as<TraceCache>(DeviceRuntime::TTNN);
+  return traceCache.erase(binaryId, programId);
 }
 
 void deallocateBuffers(Device deviceHandle) {
@@ -588,21 +594,20 @@ std::vector<::tt::runtime::Tensor> toHost(::tt::runtime::Tensor tensor,
   const ::ttnn::Tensor &multiDeviceTensor = tensorWrapper.getTensor();
   bool shouldRetain = tensorWrapper.shouldRetain();
 
-  std::vector<::tt::runtime::Tensor> hostTensors;
-  ::tt::runtime::Tensor hostMultideviceTensor =
+  ::tt::runtime::Tensor hostMultiDeviceTensor =
       ::tt::runtime::ttnn::toHostSingleTensor(
           utils::createRuntimeTensorFromTTNN(multiDeviceTensor, shouldRetain),
           untilize);
-  ::tt::runtime::ttnn::TTNNTensorWrapper &hostMultideviceTensorWrapper =
-      hostMultideviceTensor.as<::tt::runtime::ttnn::TTNNTensorWrapper>(
-          DeviceRuntime::TTNN);
   std::vector<::ttnn::Tensor> singleTensors =
       ::ttnn::distributed::get_device_tensors(
-          hostMultideviceTensorWrapper.getTensor());
-  for (auto &tensor : singleTensors) {
+          utils::getTTNNTensorFromRuntimeTensor(hostMultiDeviceTensor));
+
+  std::vector<::tt::runtime::Tensor> hostTensors;
+  for (const ::ttnn::Tensor &tensor : singleTensors) {
     hostTensors.push_back(
         utils::createRuntimeTensorFromTTNN(tensor, shouldRetain));
   }
+
   return hostTensors;
 }
 
@@ -667,9 +672,7 @@ Layout getLayout(Binary executableHandle, std::uint32_t programIndex,
 }
 
 void memcpy(void *dst, ::tt::runtime::Tensor src) {
-  const ::ttnn::Tensor &srcTensor =
-      src.as<::tt::runtime::ttnn::TTNNTensorWrapper>(DeviceRuntime::TTNN)
-          .getTensor();
+  const ::ttnn::Tensor &srcTensor = utils::getTTNNTensorFromRuntimeTensor(src);
   if (utils::isOnHost(srcTensor.storage_type())) {
     const void *srcPtr = utils::getRawHostDataPtr(srcTensor);
     size_t size = srcTensor.padded_volume() * srcTensor.element_size();
@@ -680,12 +683,8 @@ void memcpy(void *dst, ::tt::runtime::Tensor src) {
 }
 
 void memcpy(::tt::runtime::Tensor dst, ::tt::runtime::Tensor src) {
-  ::ttnn::Tensor &dstTensor =
-      dst.as<::tt::runtime::ttnn::TTNNTensorWrapper>(DeviceRuntime::TTNN)
-          .getTensor();
-  const ::ttnn::Tensor &srcTensor =
-      src.as<::tt::runtime::ttnn::TTNNTensorWrapper>(DeviceRuntime::TTNN)
-          .getTensor();
+  ::ttnn::Tensor &dstTensor = utils::getTTNNTensorFromRuntimeTensor(dst);
+  const ::ttnn::Tensor &srcTensor = utils::getTTNNTensorFromRuntimeTensor(src);
   LOG_ASSERT(srcTensor.padded_volume() * srcTensor.element_size() ==
                  dstTensor.padded_volume() * dstTensor.element_size(),
              "Input output tensor size mismatch in memcpy: ",
@@ -704,9 +703,13 @@ void memcpy(::tt::runtime::Tensor dst, ::tt::runtime::Tensor src) {
 }
 
 void deallocateTensor(::tt::runtime::Tensor &tensor, bool force) {
-  ::ttnn::Tensor &ttnnTensor =
-      tensor.as<::tt::runtime::ttnn::TTNNTensorWrapper>(DeviceRuntime::TTNN)
-          .getTensor();
+  // If the tensor is retained, do not deallocate
+  if (getTensorRetain(tensor)) {
+    LOG_DEBUG("Tensor is retained thus not deallocating. To deallocate, set "
+              "retain to false first");
+    return;
+  }
+  ::ttnn::Tensor &ttnnTensor = utils::getTTNNTensorFromRuntimeTensor(tensor);
   ::ttnn::deallocate(ttnnTensor, force);
 }
 
@@ -945,24 +948,12 @@ std::vector<::tt::runtime::Tensor>
 submit(Device deviceHandle, Binary executableHandle, std::uint32_t programIndex,
        std::vector<::tt::runtime::Tensor> &inputs) {
 
-  std::shared_ptr<::ttnn::MeshDevice> meshDevice =
-      deviceHandle.asSharedPtr<::ttnn::MeshDevice>(DeviceRuntime::TTNN);
-
-  std::vector<::tt::runtime::Tensor> outputs = ::tt::runtime::ttnn::runProgram(
-      std::move(meshDevice), executableHandle, programIndex, inputs);
-
-  return outputs;
-}
-
-std::vector<Tensor> runProgram(std::shared_ptr<::ttnn::MeshDevice> meshDevice,
-                               Binary executableHandle,
-                               std::uint32_t programIndex,
-                               std::vector<::tt::runtime::Tensor> &inputs) {
-  ProgramExecutor executor(executableHandle, inputs, std::move(meshDevice),
-                           programIndex);
+  ProgramExecutor executor(deviceHandle, executableHandle, programIndex,
+                           inputs);
   executor.execute();
   std::vector<::tt::runtime::Tensor> outputTensors =
       executor.gatherOutputTensors();
+
   return outputTensors;
 }
 

--- a/runtime/lib/ttnn/types/CMakeLists.txt
+++ b/runtime/lib/ttnn/types/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(TTRuntimeTTNNTypes
   STATIC
   types.cpp
   layout_converter.cpp
+  trace_cache.cpp
 )
 set_property(TARGET TTRuntimeTTNNTypes PROPERTY CXX_STANDARD 20)
 target_compile_options(TTRuntimeTTNNTypes PUBLIC -mavx -mavx2)

--- a/runtime/lib/ttnn/types/layout_converter.cpp
+++ b/runtime/lib/ttnn/types/layout_converter.cpp
@@ -49,12 +49,12 @@ bool LayoutConverter::canUntilizeDataTypeOnDevice(
   if (shouldTilize) {
     return ::ttnn::to_layout(input, ::ttnn::Layout::TILE, std::nullopt,
                              std::nullopt,
-                             static_cast<::ttnn::IDevice *>(nullptr));
+                             static_cast<::ttnn::MeshDevice *>(nullptr));
   }
   if (shouldUntilize) {
     return ::ttnn::to_layout(input, ::ttnn::Layout::ROW_MAJOR, std::nullopt,
                              std::nullopt,
-                             static_cast<::ttnn::IDevice *>(nullptr));
+                             static_cast<::ttnn::MeshDevice *>(nullptr));
   }
   return input;
 }

--- a/runtime/lib/ttnn/types/trace_cache.cpp
+++ b/runtime/lib/ttnn/types/trace_cache.cpp
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt/runtime/detail/ttnn/trace_cache.h"
+#include <sstream>
+
+namespace tt::runtime::ttnn {
+
+std::string generateTraceCacheOuterKey(const uint64_t binaryId,
+                                       const size_t programId) {
+  return std::to_string(binaryId) + ":" + std::to_string(programId);
+}
+
+bool TraceCache::contains(uint64_t binaryId, size_t programId,
+                          const std::string &traceFuncName) const {
+  auto outerKey = generateTraceCacheOuterKey(binaryId, programId);
+  auto outerIt = cache.find(outerKey);
+  if (outerIt == cache.end()) {
+    return false;
+  }
+
+  return outerIt->second.contains(traceFuncName);
+}
+
+TraceData *TraceCache::get(uint64_t binaryId, size_t programId,
+                           const std::string &traceFuncName) {
+  auto outerKey = generateTraceCacheOuterKey(binaryId, programId);
+  auto outerIt = cache.find(outerKey);
+  if (outerIt == cache.end()) {
+    return nullptr;
+  }
+
+  auto innerIt = outerIt->second.find(traceFuncName);
+  if (innerIt == outerIt->second.end()) {
+    return nullptr;
+  }
+
+  return &innerIt->second;
+}
+
+void TraceCache::insert(uint64_t binaryId, size_t programId,
+                        const std::string &traceFuncName,
+                        const TraceData &traceData) {
+  auto outerKey = generateTraceCacheOuterKey(binaryId, programId);
+  cache[outerKey][traceFuncName] = traceData;
+}
+
+bool TraceCache::erase(uint64_t binaryId, size_t programId) {
+  auto outerKey = generateTraceCacheOuterKey(binaryId, programId);
+  auto outerIt = cache.find(outerKey);
+  if (outerIt == cache.end()) {
+    return false;
+  }
+
+  std::shared_ptr<::ttnn::MeshDevice> lockedDevice = meshDevice.lock();
+  if (lockedDevice && lockedDevice->is_initialized()) {
+    for (const auto &[_, traceData] : outerIt->second) {
+      ::ttnn::operations::trace::release_trace(lockedDevice.get(),
+                                               traceData.traceId);
+    }
+  }
+
+  cache.erase(outerIt);
+  return true;
+}
+
+bool TraceCache::erase(uint64_t binaryId, size_t programId,
+                       const std::string &traceFuncName) {
+  auto outerKey = generateTraceCacheOuterKey(binaryId, programId);
+  auto outerIt = cache.find(outerKey);
+  if (outerIt == cache.end()) {
+    return false;
+  }
+
+  auto innerIt = outerIt->second.find(traceFuncName);
+  if (innerIt == outerIt->second.end()) {
+    return false;
+  }
+
+  std::shared_ptr<::ttnn::MeshDevice> lockedDevice = meshDevice.lock();
+  if (lockedDevice && lockedDevice->is_initialized()) {
+    ::ttnn::operations::trace::release_trace(lockedDevice.get(),
+                                             innerIt->second.traceId);
+  }
+
+  outerIt->second.erase(innerIt);
+  return true;
+}
+
+std::optional<size_t>
+TraceCache::getDebugStat(const std::string &statName) const {
+#if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
+  auto it = stats.find(statName);
+  if (it != stats.end()) {
+    return it->second;
+  }
+#endif
+  return std::nullopt;
+}
+
+void TraceCache::incrementDebugStat(const std::string &statName) const {
+#if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
+  stats[statName]++;
+#endif
+}
+
+void TraceCache::printDebugStats() const {
+#if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
+  std::ostringstream ss;
+  ss << "TraceCache Debug Stats:\n";
+  for (const auto &[statName, value] : stats) {
+    ss << "  " << statName << ": " << value << "\n";
+  }
+  LOG_DEBUG(ss.str());
+#endif
+}
+
+void TraceCache::clearDebugStats() const {
+#if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
+  stats.clear();
+#endif
+}
+
+} // namespace tt::runtime::ttnn

--- a/runtime/lib/ttnn/types/types.cpp
+++ b/runtime/lib/ttnn/types/types.cpp
@@ -15,8 +15,7 @@ using tt::runtime::DeviceRuntime;
 //
 LayoutDesc LayoutDesc::fromTensor(const ::tt::runtime::Tensor &tensor) {
   const ::ttnn::Tensor &ttnnTensor =
-      tensor.as<::tt::runtime::ttnn::TTNNTensorWrapper>(DeviceRuntime::TTNN)
-          .getTensor();
+      ::tt::runtime::ttnn::utils::getTTNNTensorFromRuntimeTensor(tensor);
   ::ttnn::StorageType storageType = ttnnTensor.storage_type();
   ::ttnn::Layout layout = ttnnTensor.layout();
   ::ttnn::DataType dtype = ttnnTensor.dtype();
@@ -73,9 +72,7 @@ const ::tt::runtime::Tensor &ProgramTensorPool::getRuntimeTensorAndValidate(
   const ::tt::runtime::Tensor &runtimeTensor =
       getRuntimeTensor(tensorRef->global_id());
   const ::ttnn::Tensor &ttnnTensor =
-      runtimeTensor
-          .as<::tt::runtime::ttnn::TTNNTensorWrapper>(DeviceRuntime::TTNN)
-          .getTensor();
+      ::tt::runtime::ttnn::utils::getTTNNTensorFromRuntimeTensor(runtimeTensor);
   DEBUG_ASSERT(ttnnTensor.is_allocated());
   debug::checkTensorRefMatchesTTNNTensor(tensorRef, ttnnTensor);
   return runtimeTensor;
@@ -142,10 +139,6 @@ std::vector<::tt::runtime::Tensor> ProgramTensorPool::gatherOutputTensors() {
   std::transform(programOutputIds.begin(), programOutputIds.end(),
                  std::back_inserter(outputs), [this](std::uint32_t globalId) {
                    ::tt::runtime::Tensor &out = getRuntimeTensor(globalId);
-                   ::tt::runtime::ttnn::TTNNTensorWrapper &ttnnTensor =
-                       out.as<::tt::runtime::ttnn::TTNNTensorWrapper>(
-                           DeviceRuntime::TTNN);
-                   ttnnTensor.setRetain(false);
                    return out;
                  });
   return outputs;

--- a/runtime/lib/ttnn/utils/utils.cpp
+++ b/runtime/lib/ttnn/utils/utils.cpp
@@ -58,6 +58,15 @@ getBinary(::tt::runtime::Flatbuffer binary) {
   return ::tt::target::ttnn::GetSizePrefixedTTNNBinary(binary.handle.get());
 }
 
+const ::tt::target::ttnn::Program *
+getProgram(const ::tt::runtime::Binary &executableHandle,
+           std::uint32_t programIndex) {
+  const ::tt::target::ttnn::TTNNBinary &fbb = *getBinary(executableHandle);
+  const ::tt::target::ttnn::Program *program =
+      fbb.programs()->Get(programIndex);
+  return program;
+}
+
 ::ttnn::operations::reduction::ReduceType getReduceType(uint32_t reduceType) {
   switch (reduceType) {
   case 0:
@@ -308,6 +317,11 @@ createMemoryConfigIfNeeded(const ::tt::target::ttnn::MemoryConfig *memcfg) {
       std::make_shared<::tt::runtime::ttnn::TTNNTensorWrapper>(tensor, retain);
   return ::tt::runtime::Tensor(std::static_pointer_cast<void>(tensorPtr),
                                nullptr, DeviceRuntime::TTNN);
+}
+
+::ttnn::Tensor &getTTNNTensorFromRuntimeTensor(::tt::runtime::Tensor tensor) {
+  return tensor.as<::tt::runtime::ttnn::TTNNTensorWrapper>(DeviceRuntime::TTNN)
+      .getTensor();
 }
 
 void *getRawHostDataPtr(const ::ttnn::Tensor &tensor) {

--- a/runtime/python/binary/binary.cpp
+++ b/runtime/python/binary/binary.cpp
@@ -57,7 +57,9 @@ void registerBinaryBindings(nb::module_ &m) {
            nb::rv_policy::reference)
       .def(
           "get_tensor_cache",
-          [](tt::runtime::Binary &bin) { return bin.getCache(); },
+          [](tt::runtime::Binary &bin) {
+            return bin.getConstEvalTensorCache();
+          },
           nb::rv_policy::reference);
 
   nb::class_<tt::runtime::SystemDesc>(m, "SystemDesc")

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -37,6 +37,7 @@ void registerRuntimeBindings(nb::module_ &m) {
       .def("get_num_dram_channels", &tt::runtime::getNumDramChannels)
       .def("get_dram_size_per_channel", &tt::runtime::getDramSizePerChannel)
       .def("get_l1_size_per_core", &tt::runtime::getL1SizePerCore)
+      .def("release_trace", &tt::runtime::releaseTrace)
       .def("deallocate_buffers", &tt::runtime::detail::deallocateBuffers)
       .def("dump_memory_report", &tt::runtime::detail::dumpMemoryReport)
       .def("dump_device_profile_results",

--- a/runtime/python/runtime/test.cpp
+++ b/runtime/python/runtime/test.cpp
@@ -32,6 +32,9 @@ void registerRuntimeTestBindings(nb::module_ &m) {
         "Run a program from a shared object file");
   m.def("compare_outs", &tt::runtime::test::ttnn::compareOuts, nb::arg("lhs"),
         nb::arg("rhs"));
+  m.def("get_trace_cache_debug_stat",
+        &tt::runtime::test::ttnn::getTraceCacheDebugStat, nb::arg("device"),
+        nb::arg("stat_name"));
 }
 } // namespace tt::runtime::python
 

--- a/runtime/test/python/ttnn/device_agnostic/test_trace.py
+++ b/runtime/test/python/ttnn/device_agnostic/test_trace.py
@@ -1,0 +1,213 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import ttrt
+import ttrt.runtime
+import torch
+from ttrt.common.util import *
+from ..utils import (
+    TT_MLIR_HOME,
+    Helper,
+    DeviceContext,
+    assert_pcc,
+    get_torch_inputs,
+    get_runtime_tensor_from_torch,
+    get_torch_output_container,
+)
+
+FLATBUFFER_BASE_PATH = (
+    f"{TT_MLIR_HOME}/build/test/ttmlir/Runtime/TTNN/n150/trace/Output"
+)
+
+
+def get_inputs_and_golden(device, helper, program, program_index):
+    inputs_torch = get_torch_inputs(program)
+    inputs_runtime = [
+        get_runtime_tensor_from_torch(torch_input) for torch_input in inputs_torch
+    ]
+    input_layouts = [
+        ttrt.runtime.get_layout(
+            executable=helper.binary.fbb, program_index=program_index, input_index=i
+        )
+        for i in range(len(inputs_runtime))
+    ]
+    inputs_runtime_with_layout = [
+        ttrt.runtime.to_layout(rt_input, device, layout, True)
+        for rt_input, layout in zip(inputs_runtime, input_layouts)
+    ]
+
+    golden = (inputs_torch[0] @ inputs_torch[1]) + inputs_torch[2]
+
+    return inputs_runtime_with_layout, golden
+
+
+def run_program_and_compare_golden(device, helper, program, program_index):
+    inputs_runtime_with_layout, golden = get_inputs_and_golden(
+        device, helper, program, program_index
+    )
+
+    output_torch = get_torch_output_container(program)
+
+    output = ttrt.runtime.submit(
+        device, helper.binary.fbb, program_index, inputs_runtime_with_layout
+    )[0]
+
+    output = ttrt.runtime.to_host(output, untilize=True)[0]
+    ttrt.runtime.memcpy(output_torch.data_ptr(), output)
+    assert_pcc(output_torch, golden)
+
+
+def test_trace_matmul_add_no_consteval(helper: Helper, request):
+    binary_path = os.path.join(
+        FLATBUFFER_BASE_PATH, "matmul_add_no_consteval.mlir.tmp.ttnn"
+    )
+    assert os.path.exists(binary_path), f"Binary file not found: {binary_path}"
+    helper.initialize(request.node.name, binary_path)
+    helper.check_constraints()
+
+    program_index = 0
+    program: Binary.Program = helper.binary.get_program(program_index)
+    assert not program.is_private()
+
+    assert program.num_inputs() == 3
+
+    with DeviceContext(
+        mesh_shape=[1, 1], enable_program_cache=True, trace_region_size=16384
+    ) as device:
+
+        # First execute, should be a trace cache miss
+        run_program_and_compare_golden(device, helper, program, program_index)
+        assert ttrt.runtime.test.get_trace_cache_debug_stat(device, "cacheMiss") == 1
+        assert (
+            ttrt.runtime.test.get_trace_cache_debug_stat(device, "capturedTrace") == 1
+        )
+
+        # Second execute, should find and execute trace
+        run_program_and_compare_golden(device, helper, program, program_index)
+        assert ttrt.runtime.test.get_trace_cache_debug_stat(device, "cacheMiss") == 1
+        assert (
+            ttrt.runtime.test.get_trace_cache_debug_stat(device, "capturedTrace") == 1
+        )
+        assert (
+            ttrt.runtime.test.get_trace_cache_debug_stat(device, "executedTrace") == 1
+        )
+
+        # Third execute, should find and execute trace
+        run_program_and_compare_golden(device, helper, program, program_index)
+        assert ttrt.runtime.test.get_trace_cache_debug_stat(device, "cacheMiss") == 1
+        assert (
+            ttrt.runtime.test.get_trace_cache_debug_stat(device, "capturedTrace") == 1
+        )
+        assert (
+            ttrt.runtime.test.get_trace_cache_debug_stat(device, "executedTrace") == 2
+        )
+
+        # Fourth execute, should find and execute trace
+        run_program_and_compare_golden(device, helper, program, program_index)
+        assert ttrt.runtime.test.get_trace_cache_debug_stat(device, "cacheMiss") == 1
+        assert (
+            ttrt.runtime.test.get_trace_cache_debug_stat(device, "capturedTrace") == 1
+        )
+        assert (
+            ttrt.runtime.test.get_trace_cache_debug_stat(device, "executedTrace") == 3
+        )
+
+    helper.teardown()
+
+
+def test_trace_matmul_add_with_consteval(helper: Helper, request):
+    binary_path = os.path.join(
+        FLATBUFFER_BASE_PATH, "matmul_add_consteval.mlir.tmp.ttnn"
+    )
+    assert os.path.exists(binary_path), f"Binary file not found: {binary_path}"
+    helper.initialize(request.node.name, binary_path)
+    helper.check_constraints()
+
+    program_index = 0
+    program: Binary.Program = helper.binary.get_program(program_index)
+    assert not program.is_private()
+
+    assert program.num_inputs() == 3
+
+    output_torch = get_torch_output_container(program)
+
+    with DeviceContext(
+        mesh_shape=[1, 1], enable_program_cache=True, trace_region_size=16384
+    ) as device:
+
+        inputs_runtime_with_layout, golden = get_inputs_and_golden(
+            device, helper, program, program_index
+        )
+
+        # First execute, should be a trace cache miss and consteval cache miss
+        output = ttrt.runtime.submit(
+            device, helper.binary.fbb, program_index, inputs_runtime_with_layout
+        )[0]
+        output = ttrt.runtime.to_host(output, untilize=True)[0]
+        ttrt.runtime.memcpy(output_torch.data_ptr(), output)
+        assert_pcc(output_torch, golden)
+        assert ttrt.runtime.test.get_trace_cache_debug_stat(device, "cacheMiss") == 1
+        assert (
+            ttrt.runtime.test.get_trace_cache_debug_stat(device, "capturedTrace") == 1
+        )
+        const_eval_cache_stats = helper.binary.fbb.get_tensor_cache().get_stats()
+        assert const_eval_cache_stats.get("hits", 0) == 0
+        assert const_eval_cache_stats.get("misses", 0) == 1
+
+        # Second execute, should find and execute trace
+        output = ttrt.runtime.submit(
+            device, helper.binary.fbb, program_index, inputs_runtime_with_layout
+        )[0]
+        output = ttrt.runtime.to_host(output, untilize=True)[0]
+        ttrt.runtime.memcpy(output_torch.data_ptr(), output)
+        assert_pcc(output_torch, golden)
+        assert ttrt.runtime.test.get_trace_cache_debug_stat(device, "cacheMiss") == 1
+        assert (
+            ttrt.runtime.test.get_trace_cache_debug_stat(device, "capturedTrace") == 1
+        )
+        assert (
+            ttrt.runtime.test.get_trace_cache_debug_stat(device, "executedTrace") == 1
+        )
+        const_eval_cache_stats = helper.binary.fbb.get_tensor_cache().get_stats()
+        assert const_eval_cache_stats.get("hits", 0) == 1
+        assert const_eval_cache_stats.get("misses", 0) == 1
+
+        # Third execute, should find and execute trace
+        output = ttrt.runtime.submit(
+            device, helper.binary.fbb, program_index, inputs_runtime_with_layout
+        )[0]
+        output = ttrt.runtime.to_host(output, untilize=True)[0]
+        ttrt.runtime.memcpy(output_torch.data_ptr(), output)
+        assert_pcc(output_torch, golden)
+        assert ttrt.runtime.test.get_trace_cache_debug_stat(device, "cacheMiss") == 1
+        assert (
+            ttrt.runtime.test.get_trace_cache_debug_stat(device, "capturedTrace") == 1
+        )
+        assert (
+            ttrt.runtime.test.get_trace_cache_debug_stat(device, "executedTrace") == 2
+        )
+        const_eval_cache_stats = helper.binary.fbb.get_tensor_cache().get_stats()
+        assert const_eval_cache_stats.get("hits", 0) == 2
+        assert const_eval_cache_stats.get("misses", 0) == 1
+
+        # Fourth execute, should find and execute trace
+        output = ttrt.runtime.submit(
+            device, helper.binary.fbb, program_index, inputs_runtime_with_layout
+        )[0]
+        output = ttrt.runtime.to_host(output, untilize=True)[0]
+        ttrt.runtime.memcpy(output_torch.data_ptr(), output)
+        assert_pcc(output_torch, golden)
+        assert ttrt.runtime.test.get_trace_cache_debug_stat(device, "cacheMiss") == 1
+        assert (
+            ttrt.runtime.test.get_trace_cache_debug_stat(device, "capturedTrace") == 1
+        )
+        assert (
+            ttrt.runtime.test.get_trace_cache_debug_stat(device, "executedTrace") == 3
+        )
+        const_eval_cache_stats = helper.binary.fbb.get_tensor_cache().get_stats()
+        assert const_eval_cache_stats.get("hits", 0) == 3
+        assert const_eval_cache_stats.get("misses", 0) == 1
+
+    helper.teardown()

--- a/runtime/test/python/ttnn/utils.py
+++ b/runtime/test/python/ttnn/utils.py
@@ -53,11 +53,18 @@ class Helper:
 
 
 class DeviceContext:
-    def __init__(self, mesh_shape, mesh_offset=None, enable_program_cache=False):
+    def __init__(
+        self,
+        mesh_shape,
+        mesh_offset=None,
+        enable_program_cache=False,
+        trace_region_size=0,
+    ):
         options = ttrt.runtime.MeshDeviceOptions()
         if mesh_offset is not None:
             options.mesh_offset = mesh_offset
         options.enable_program_cache = enable_program_cache
+        options.trace_region_size = trace_region_size
         self.device = ttrt.runtime.open_mesh_device(mesh_shape, options)
 
     def __enter__(self):

--- a/runtime/test/ttnn/dylib.cpp
+++ b/runtime/test/ttnn/dylib.cpp
@@ -91,8 +91,7 @@ runSoProgram(void *so, const std::string &funcName,
   for (auto &input : inputs) {
     LOG_ASSERT(input.matchesRuntime(DeviceRuntime::TTNN));
     ttnnInputs.push_back(
-        input.as<::tt::runtime::ttnn::TTNNTensorWrapper>(DeviceRuntime::TTNN)
-            .getTensor());
+        ::tt::runtime::ttnn::utils::getTTNNTensorFromRuntimeTensor(input));
   }
 
   // Get function from the shared object.
@@ -224,13 +223,11 @@ bool compareOuts(std::vector<::tt::runtime::Tensor> &lhs,
 
   for (auto &tensor : lhs) {
     lhsTensors.push_back(
-        &(tensor.as<::tt::runtime::ttnn::TTNNTensorWrapper>(getCurrentRuntime())
-              .getTensor()));
+        &::tt::runtime::ttnn::utils::getTTNNTensorFromRuntimeTensor(tensor));
   }
   for (auto &tensor : rhs) {
     rhsTensors.push_back(
-        &(tensor.as<::tt::runtime::ttnn::TTNNTensorWrapper>(getCurrentRuntime())
-              .getTensor()));
+        &::tt::runtime::ttnn::utils::getTTNNTensorFromRuntimeTensor(tensor));
   }
   LOG_ASSERT(lhsTensors.size() == rhsTensors.size());
 

--- a/runtime/test/ttnn/utils.cpp
+++ b/runtime/test/ttnn/utils.cpp
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
-
 #include "tt/runtime/detail/test/ttnn/utils.h"
 #include "tt/runtime/detail/logger.h"
+#include "tt/runtime/detail/ttnn/trace_cache.h"
 #include "tt/runtime/detail/ttnn/types.h"
 #include "tt/runtime/detail/ttnn/utils.h"
 #include "tt/runtime/runtime.h"
@@ -46,5 +46,14 @@ Layout getDramInterleavedRowMajorLayout(::tt::target::DataType dataType) {
       std::static_pointer_cast<void>(
           std::make_shared<::tt::runtime::ttnn::LayoutDesc>(layoutDesc)),
       DeviceRuntime::TTNN);
+}
+
+std::optional<size_t> getTraceCacheDebugStat(::tt::runtime::Device device,
+                                             const std::string &statName) {
+  LOG_ASSERT(getCurrentRuntime() == DeviceRuntime::TTNN);
+  auto traceCache =
+      device.getTraceCache()->asSharedPtr<tt::runtime::ttnn::TraceCache>(
+          DeviceRuntime::TTNN);
+  return traceCache->getDebugStat(statName);
 }
 } // namespace tt::runtime::test::ttnn

--- a/test/ttmlir/Dialect/TTNN/trace/creation_no_consteval.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/creation_no_consteval.mlir
@@ -1,0 +1,29 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-const-eval=false enable-trace=true" %s | FileCheck %s
+
+module {
+  // CHECK-LABEL: func.func @creation_ops_trace
+  // CHECK: "ttnn.add"
+
+
+  // CHECK-LABEL: func.func @creation_ops(
+  func.func @creation_ops() -> tensor<4x4xbf16> {
+    // CHECK: %[[GET_DEVICE:.+]] = "ttnn.get_device"()
+    // CHECK-NEXT: %[[TRACE_RESULT:.+]] = ttnn.trace(%[[GET_DEVICE]], 0, true, @creation_ops_trace_0, [])
+    // CHECK-NOT: "ttnn.zeros"
+    // CHECK-NOT: "ttnn.ones"
+    // CHECK-NOT: "ttnn.arange"
+    // CHECK-NOT: "ttnn.add"
+    // CHECK: return %[[TRACE_RESULT]]
+    %0 = "ttir.zeros"() <{shape = array<i32: 4, 4>}> : () -> tensor<4x4xbf16>
+    %1 = "ttir.ones"() <{shape = array<i32: 4, 4>}> : () -> tensor<4x4xbf16>
+
+    %2 = ttir.empty() : tensor<4x4xbf16>
+    %3 = "ttir.add"(%0, %1, %2) : (tensor<4x4xbf16>, tensor<4x4xbf16>, tensor<4x4xbf16>) -> tensor<4x4xbf16>
+
+    %4 = ttir.empty() : tensor<4x4xbf16>
+    %5 = "ttir.arange"() {start = 0 : si64, end = 4 : si64, step = 1 : si64, arange_dimension = 0 : i64} : () -> tensor<4x4xbf16>
+    %6 = "ttir.add"(%3, %5, %4) : (tensor<4x4xbf16>, tensor<4x4xbf16>, tensor<4x4xbf16>) -> tensor<4x4xbf16>
+
+    return %6 : tensor<4x4xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/trace/matmul_add_consteval.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/matmul_add_consteval.mlir
@@ -1,0 +1,24 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-const-eval=true enable-trace=true" %s | FileCheck %s
+
+module {
+  // CHECK-LABEL: func.func @matmul_with_bias_const_eval_0
+  // CHECK: "ttnn.matmul"
+
+  // CHECK-LABEL: func.func @matmul_with_bias_trace_0
+  // CHECK: "ttnn.add"(%arg1, %arg0)
+
+  // CHECK-LABEL: func.func @matmul_with_bias(
+  func.func @matmul_with_bias(%arg0: tensor<64x32xbf16> {tt.argument_type = #tt.argument_type<parameter>}, %arg1: tensor<32x64xbf16> {tt.argument_type = #tt.argument_type<parameter>}, %arg2: tensor<64x64xbf16> {tt.argument_type = #tt.argument_type<input>}) -> tensor<64x64xbf16> {
+    // CHECK: %[[GET_DEVICE:.+]] = "ttnn.get_device"()
+    // CHECK: %[[LOAD_CACHED_RESULT:.+]] = tt.load_cached(@matmul_with_bias_const_eval_0, [%arg0, %arg1])
+    // CHECK: %[[TRACE_RESULT:.+]] = ttnn.trace(%[[GET_DEVICE]], 0, true, @matmul_with_bias_trace_0, [%arg2, %[[LOAD_CACHED_RESULT]]])
+    // CHECK-NOT: "ttnn.add"
+    // CHECK-NOT: "ttnn.matmul"
+    // CHECK: return %[[TRACE_RESULT]]
+    %0 = ttir.empty() : tensor<64x64xbf16>
+    %1 = "ttir.matmul"(%arg0, %arg1, %0) : (tensor<64x32xbf16>, tensor<32x64xbf16>, tensor<64x64xbf16>) -> tensor<64x64xbf16>
+    %2 = ttir.empty() : tensor<64x64xbf16>
+    %3 = "ttir.add"(%1, %arg2, %2) : (tensor<64x64xbf16>, tensor<64x64xbf16>, tensor<64x64xbf16>) -> tensor<64x64xbf16>
+    return %3 : tensor<64x64xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/trace/matmul_add_no_consteval.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/matmul_add_no_consteval.mlir
@@ -1,0 +1,21 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-const-eval=false enable-trace=true" %s | FileCheck %s
+
+module {
+  // CHECK-LABEL: func.func @matmul_with_bias_trace
+  // CHECK: "ttnn.matmul"
+  // CHECK: "ttnn.add"
+
+  // CHECK-LABEL: func.func @matmul_with_bias(
+  func.func @matmul_with_bias(%arg0: tensor<64x32xbf16>, %arg1: tensor<32x64xbf16>, %arg2: tensor<64x64xbf16>) -> tensor<64x64xbf16> {
+    // CHECK: %[[GET_DEVICE:.+]] = "ttnn.get_device"()
+    // CHECK-NEXT: %[[TRACE_RESULT:.+]] = ttnn.trace(%[[GET_DEVICE]], 0, true, @matmul_with_bias_trace_0, [%arg0, %arg1, %arg2])
+    // CHECK-NOT: "ttnn.add"
+    // CHECK-NOT: "ttnn.matmul"
+    // CHECK: return %[[TRACE_RESULT]]
+    %0 = ttir.empty() : tensor<64x64xbf16>
+    %1 = "ttir.matmul"(%arg0, %arg1, %0) : (tensor<64x32xbf16>, tensor<32x64xbf16>, tensor<64x64xbf16>) -> tensor<64x64xbf16>
+    %2 = ttir.empty() : tensor<64x64xbf16>
+    %3 = "ttir.add"(%1, %arg2, %2) : (tensor<64x64xbf16>, tensor<64x64xbf16>, tensor<64x64xbf16>) -> tensor<64x64xbf16>
+    return %3 : tensor<64x64xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/trace/single_add_no_consteval.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/single_add_no_consteval.mlir
@@ -1,0 +1,17 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-const-eval=false enable-trace=true" %s | FileCheck %s
+
+module {
+  // CHECK-LABEL: func.func @single_add_trace
+  // CHECK: "ttnn.add"
+
+  // CHECK-LABEL: func.func @single_add(
+  func.func @single_add(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>) -> tensor<32x32xbf16> {
+    // CHECK: %[[GET_DEVICE:.+]] = "ttnn.get_device"()
+    // CHECK-NEXT: %[[TRACE_RESULT:.+]] = ttnn.trace(%[[GET_DEVICE]], 0, true, @single_add_trace_0, [%arg0, %arg1])
+    // CHECK-NOT: "ttnn.add"
+    // CHECK: return %[[TRACE_RESULT]]
+    %0 = ttir.empty() : tensor<32x32xbf16>
+    %1 = "ttir.add"(%arg0, %arg1, %0) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+    return %1 : tensor<32x32xbf16>
+  }
+}

--- a/test/ttmlir/Runtime/TTNN/n150/trace/matmul_add_consteval.mlir
+++ b/test/ttmlir/Runtime/TTNN/n150/trace/matmul_add_consteval.mlir
@@ -1,0 +1,15 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-const-eval=true enable-trace=true" %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+
+module {
+  func.func @matmul_with_bias(%arg0: tensor<784x1096xbf16> {tt.argument_type = #tt.argument_type<parameter>}, %arg1: tensor<1096x784xbf16> {tt.argument_type = #tt.argument_type<parameter>}, %arg2: tensor<784x784xbf16> {tt.argument_type = #tt.argument_type<input>}) -> tensor<784x784xbf16> {
+    // CHECK: tt.load_cached
+    // CHECK: ttnn.trace
+    %0 = ttir.empty() : tensor<784x784xbf16>
+    %1 = "ttir.matmul"(%arg0, %arg1, %0) : (tensor<784x1096xbf16>, tensor<1096x784xbf16>, tensor<784x784xbf16>) -> tensor<784x784xbf16>
+    %2 = ttir.empty() : tensor<784x784xbf16>
+    %3 = "ttir.add"(%1, %arg2, %2) : (tensor<784x784xbf16>, tensor<784x784xbf16>, tensor<784x784xbf16>) -> tensor<784x784xbf16>
+    return %3 : tensor<784x784xbf16>
+  }
+}

--- a/test/ttmlir/Runtime/TTNN/n150/trace/matmul_add_no_consteval.mlir
+++ b/test/ttmlir/Runtime/TTNN/n150/trace/matmul_add_no_consteval.mlir
@@ -1,0 +1,14 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-const-eval=false enable-trace=true" %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+
+module {
+  func.func @matmul_with_bias(%arg0: tensor<784x1096xbf16> {tt.argument_type = #tt.argument_type<parameter>}, %arg1: tensor<1096x784xbf16> {tt.argument_type = #tt.argument_type<parameter>}, %arg2: tensor<784x784xbf16> {tt.argument_type = #tt.argument_type<input>}) -> tensor<784x784xbf16> {
+    // CHECK: ttnn.trace
+    %0 = ttir.empty() : tensor<784x784xbf16>
+    %1 = "ttir.matmul"(%arg0, %arg1, %0) : (tensor<784x1096xbf16>, tensor<1096x784xbf16>, tensor<784x784xbf16>) -> tensor<784x784xbf16>
+    %2 = ttir.empty() : tensor<784x784xbf16>
+    %3 = "ttir.add"(%1, %arg2, %2) : (tensor<784x784xbf16>, tensor<784x784xbf16>, tensor<784x784xbf16>) -> tensor<784x784xbf16>
+    return %3 : tensor<784x784xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket
Closes #2703 

### Problem description
We want to support metal trace in our execution flow for perf improvements.

### What's changed
Added an e2e implementation of trace. Initially I wanted to target runtime only, but that turned out to be overly hacky, so I implemented a minimum update in the compiler to support this. I tried to make this as similar to const-eval as possible.

* Added `TTNN_TraceOp` that contains the information of the trace
* Added `TTNNTraceHoistTransform` pass that hoists ttnn operations into a separate function to trace. This pass is guarded by the command-line arg `enable-trace` in the ttnn pipeline
* Added lowering from TTNN to flatbuffer
* Added runtime op implementation, which involves a trace cache that is tied to the runtime device
  * This also helps ensure "thread safety" since executing two binaries on the same device in parallel is undefined behaviour anyway.

### Example

The following IR:
```
  func.func @matmul_with_bias(%arg0: tensor<64x32xbf16>, %arg1: tensor<32x64xbf16>, %arg2: tensor<64x64xbf16>) -> tensor<64x64xbf16> {
    // CHECK: ttnn.trace
    %0 = ttir.empty() : tensor<64x64xbf16>
    %1 = "ttir.matmul"(%arg0, %arg1, %0) : (tensor<64x32xbf16>, tensor<32x64xbf16>, tensor<64x64xbf16>) -> tensor<64x64xbf16>
    %2 = ttir.empty() : tensor<64x64xbf16>
    %3 = "ttir.add"(%1, %arg2, %2) : (tensor<64x64xbf16>, tensor<64x64xbf16>, tensor<64x64xbf16>) -> tensor<64x64xbf16>
    return %3 : tensor<64x64xbf16>
  }
```

Gets compiled into:

```
  func.func @matmul_with_bias_trace_0(%arg0: tensor<64x32xbf16, #ttnn_layout>, %arg1: tensor<32x64xbf16, #ttnn_layout1>, %arg2: tensor<64x64xbf16, #ttnn_layout2>) -> tensor<64x64xbf16, #ttnn_layout2> attributes {ttnn.trace} {
    %0 = "ttnn.matmul"(%arg0, %arg1) <{transpose_a = false, transpose_b = false}> : (tensor<64x32xbf16, #ttnn_layout>, tensor<32x64xbf16, #ttnn_layout1>) -> tensor<64x64xbf16, #ttnn_layout2>
    %1 = "ttnn.add"(%0, %arg2) : (tensor<64x64xbf16, #ttnn_layout2>, tensor<64x64xbf16, #ttnn_layout2>) -> tensor<64x64xbf16, #ttnn_layout2>
    "ttnn.deallocate"(%0) <{force = false}> : (tensor<64x64xbf16, #ttnn_layout2>) -> ()
    return %1 : tensor<64x64xbf16, #ttnn_layout2>
  }

  func.func @matmul_with_bias(%arg0: tensor<64x32xbf16, #ttnn_layout>, %arg1: tensor<32x64xbf16, #ttnn_layout1>, %arg2: tensor<64x64xbf16, #ttnn_layout2>) -> tensor<64x64xbf16, #ttnn_layout2> {
    %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
    %1 = ttnn.trace(%0, 0, true, @matmul_with_bias_trace_0, [%arg0, %arg1, %arg2]) : (tensor<64x32xbf16, #ttnn_layout>, tensor<32x64xbf16, #ttnn_layout1>, tensor<64x64xbf16, #ttnn_layout2>) -> tensor<64x64xbf16, #ttnn_layout2>
    "ttnn.deallocate"(%arg2) <{force = false}> : (tensor<64x64xbf16, #ttnn_layout2>) -> ()
    "ttnn.deallocate"(%arg1) <{force = false}> : (tensor<32x64xbf16, #ttnn_layout1>) -> ()
    "ttnn.deallocate"(%arg0) <{force = false}> : (tensor<64x32xbf16, #ttnn_layout>) -> ()
    return %1 : tensor<64x64xbf16, #ttnn_layout2>
  }
```

This also works with const-eval:
```
func.func @matmul_with_bias_const_eval_0(%arg0: tensor<64x32xbf16, #ttnn_layout>, %arg1: tensor<32x64xbf16, #ttnn_layout1>) -> tensor<64x64xbf16, #ttnn_layout2> attributes {const_eval} {
  %0 = "ttnn.matmul"(%arg0, %arg1) <{transpose_a = false, transpose_b = false}> : (tensor<64x32xbf16, #ttnn_layout>, tensor<32x64xbf16, #ttnn_layout1>) -> tensor<64x64xbf16, #ttnn_layout2>
  return %0 : tensor<64x64xbf16, #ttnn_layout2>
}
func.func @matmul_with_bias_trace_0(%arg0: tensor<64x64xbf16, #ttnn_layout2>, %arg1: tensor<64x64xbf16, #ttnn_layout2>) -> tensor<64x64xbf16, #ttnn_layout2> attributes {ttnn.trace} {
  %0 = "ttnn.add"(%arg1, %arg0) : (tensor<64x64xbf16, #ttnn_layout2>, tensor<64x64xbf16, #ttnn_layout2>) -> tensor<64x64xbf16, #ttnn_layout2>
  return %0 : tensor<64x64xbf16, #ttnn_layout2>
}
func.func @matmul_with_bias(%arg0: tensor<64x32xbf16, #ttnn_layout> {tt.argument_type = #tt.argument_type<parameter>}, %arg1: tensor<32x64xbf16, #ttnn_layout1> {tt.argument_type = #tt.argument_type<parameter>}, %arg2: tensor<64x64xbf16, #ttnn_layout2> {tt.argument_type = #tt.argument_type<input>}) -> tensor<64x64xbf16, #ttnn_layout2> {
  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
  %1 = tt.load_cached(@matmul_with_bias_const_eval_0, [%arg0, %arg1]) : (tensor<64x32xbf16, #ttnn_layout>, tensor<32x64xbf16, #ttnn_layout1>) -> tensor<64x64xbf16, #ttnn_layout2>
  "ttnn.deallocate"(%arg1) <{force = false}> : (tensor<32x64xbf16, #ttnn_layout1>) -> ()
  "ttnn.deallocate"(%arg0) <{force = false}> : (tensor<64x32xbf16, #ttnn_layout>) -> ()
  %2 = ttnn.trace(%0, 0, true, @matmul_with_bias_trace_0, [%arg2, %1]) : (tensor<64x64xbf16, #ttnn_layout2>, tensor<64x64xbf16, #ttnn_layout2>) -> tensor<64x64xbf16, #ttnn_layout2>
  "ttnn.deallocate"(%1) <{force = false}> : (tensor<64x64xbf16, #ttnn_layout2>) -> ()
  "ttnn.deallocate"(%arg2) <{force = false}> : (tensor<64x64xbf16, #ttnn_layout2>) -> ()
  return %2 : tensor<64x64xbf16, #ttnn_layout2>
}
```

### Future improvements
The current implementation is more of a POC and by no means the final form of this feature. Some future tasks include:
* Add dynamic/multi-trace support, presumably integrating this into the optimizer
* Add support for multiple cqs, and l1 trace buffers
* Currently trace_region_size needs to be determined by the user in a trial-and-error fashion - keep increasing it until the trace fits. Could we potentially do this in op-model by repeatedly attempting to capture the trace until it fits on device, and bake the trace region size within the op?
* Add emitC support if needed. Currently the emitC pass asserts that `enable-trace` is not set
* Model tensor read-back in the compiler before executing trace if needed. Currently metal doesn't support device to device memcpy, and therefore trace needs to implicitly bounce the tensor off of host. I added a workaround flag in runtime to track this.
* Currently any callbacks that call ttnn ops that fall back to host will disrupt the trace and result in an error. This limits any golden callbacks from being hooked into runtime when trace is enabled. 

### Checklist
- [X] New/Existing tests provide coverage for changes
  - Added compiler/Dialect tests under `test/ttmlir/Dialect/TTNN/trace`
  - added `runtime/test/python/ttnn/device_agnostic/test_trace.py` that tests trace end to end with/without const eval
