### PR TITLE
Add ttir-builder flag allow-subset-mesh

### DIFF
--- a/test/python/golden/conftest.py
+++ b/test/python/golden/conftest.py
@@ -20,6 +20,11 @@ def pytest_addoption(parser):
         default="ttrt-artifacts/system_desc.ttsys",
         help="Path to system descriptor",
     )
+    parser.addoption(
+        "--allow-subset-mesh",
+        action="store_true",
+        help="Enable running tests whose mesh shapes are a subset of the current device",
+    )
 
 
 def pytest_runtest_setup(item):
@@ -37,9 +42,12 @@ def pytest_runtest_setup(item):
             pytest.skip(f"Operation not supported on {target_to_skip} target")
 
 
-def filter_valid_mesh_shape(system_desc, params):
+def filter_valid_mesh_shape(system_desc, params, allow_subset_mesh=False):
     num_chips = reduce(operator.mul, params.get("mesh_shape", [1]), 1)
-    return num_chips == len(system_desc["chip_desc_indices"])
+    if allow_subset_mesh:
+        return num_chips <= len(system_desc["chip_desc_indices"])
+    else:
+        return num_chips == len(system_desc["chip_desc_indices"])
 
 
 def pytest_collection_modifyitems(config, items):
@@ -53,7 +61,9 @@ def pytest_collection_modifyitems(config, items):
         # Only check parameterized tests
         if hasattr(item, "callspec"):
             params = item.callspec.params
-            if not filter_valid_mesh_shape(system_desc, params):
+            if not filter_valid_mesh_shape(
+                system_desc, params, allow_subset_mesh=config.option.allow_subset_mesh
+            ):
                 # Deselect the test case
                 deselected.append(item)
                 continue


### PR DESCRIPTION
Enable running tests whose mesh shapes are a subset of the current device.
