### PR TITLE
Dynamic includes generation based on function ops.

### DIFF
--- a/lib/Target/TTKernel/TTKernelToCpp.cpp
+++ b/lib/Target/TTKernel/TTKernelToCpp.cpp
@@ -19,9 +19,111 @@
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Target/Cpp/CppEmitter.h"
 #include "llvm/ADT/ScopeExit.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace mlir::tt::ttkernel {
+
+static constexpr llvm::StringRef SFPU_INCLUDE =
+    "compute_kernel_api/eltwise_unary/sfpu_split_includes.h";
+static constexpr llvm::StringRef NOC_INCLUDE = "dataflow_api.h";
+
+static const llvm::StringMap<llvm::StringRef> includeMapping{
+    // Register operations
+    {"tile_regs_acquire", "compute_kernel_api/reg_api.h"},
+    {"tile_regs_commit", "compute_kernel_api/reg_api.h"},
+    {"tile_regs_wait", "compute_kernel_api/reg_api.h"},
+    {"tile_regs_release", "compute_kernel_api/reg_api.h"},
+    {"pack_tile", "compute_kernel_api/pack.h"},
+    {"copy_tile_init", "compute_kernel_api/tile_move_copy.h"},
+    {"copy_tile", "compute_kernel_api/tile_move_copy.h"},
+
+    // FPU operations
+    {"unary_op_init_common",
+     "compute_kernel_api/eltwise_unary/eltwise_unary.h"},
+    {"binary_op_init_common", "compute_kernel_api/eltwise_binary.h"},
+    {"mm_init", "compute_kernel_api/matmul.h"},
+    {"mm_init_short", "compute_kernel_api/matmul.h"},
+    {"matmul_tiles", "compute_kernel_api/matmul.h"},
+    {"add_tiles_init", "compute_kernel_api/eltwise_binary.h"},
+    {"add_tiles", "compute_kernel_api/eltwise_binary.h"},
+    {"mul_tiles_init", "compute_kernel_api/eltwise_binary.h"},
+    {"mul_tiles", "compute_kernel_api/eltwise_binary.h"},
+    {"reduce_init", "compute_kernel_api/reduce.h"},
+    {"reduce_tile", "compute_kernel_api/reduce.h"},
+
+    // SFPU operations
+    {"init_sfpu", SFPU_INCLUDE},
+    {"max_tile_init", SFPU_INCLUDE},
+    {"max_tile", SFPU_INCLUDE},
+    {"div_binary_tile_init", SFPU_INCLUDE},
+    {"div_binary_tile", SFPU_INCLUDE},
+    {"recip_tile_init", SFPU_INCLUDE},
+    {"recip_tile", SFPU_INCLUDE},
+    {"exp_tile_init", SFPU_INCLUDE},
+    {"exp_tile", SFPU_INCLUDE},
+    {"sin_tile_init", SFPU_INCLUDE},
+    {"sin_tile", SFPU_INCLUDE},
+
+    // CB operations
+    {"cb_push_back", "compute_kernel_api/cb_api.h"},
+    {"cb_pop_front", "compute_kernel_api/cb_api.h"},
+    {"cb_reserve_back", "compute_kernel_api/cb_api.h"},
+    {"cb_wait_front", "compute_kernel_api/cb_api.h"},
+
+    // Tile operations
+    {"tilize_block", "compute_kernel_api/tilize.h"},
+    // {"experimental::tilize_block", ???},  // see below question
+    {"tilize_init", "compute_kernel_api/tilize.h"},
+    {"tilize_init_short", "compute_kernel_api/tilize.h"},
+    {"tilize_uninit", "compute_kernel_api/tilize.h"},
+    {"untilize_block", "compute_kernel_api/untilize.h"},
+    // {"experimental::untilize_block", ???},  // see below question
+    {"untilize_init", "compute_kernel_api/untilize.h"},
+    {"untilize_init_short", "compute_kernel_api/untilize.h"},
+    {"untilize_uninit", "compute_kernel_api/untilize.h"},
+
+    // NOC operations
+    // {"get_noc_addr", ???},
+    {"get_noc_addr_from_bank_id", NOC_INCLUDE},
+    {"noc_async_read", NOC_INCLUDE},
+    {"noc_async_read_tile", NOC_INCLUDE},
+    {"noc_async_read_one_packet_set_state", NOC_INCLUDE},
+    {"noc_async_read_one_packet_with_state", NOC_INCLUDE},
+    {"noc_async_read_barrier", NOC_INCLUDE},
+    {"noc_async_write", NOC_INCLUDE},
+    {"noc_async_write_tile", NOC_INCLUDE},
+    {"noc_async_write_barrier", NOC_INCLUDE},
+    {"get_semaphore", NOC_INCLUDE},
+    {"noc_semaphore_inc", NOC_INCLUDE},
+    {"noc_semaphore_set", NOC_INCLUDE},
+    {"noc_semaphore_wait", NOC_INCLUDE},
+    {"noc_semaphore_wait_min", NOC_INCLUDE},
+    {"noc_semaphore_set_multicast", NOC_INCLUDE},
+    {"noc_semaphore_set_multicast_loopback_src", NOC_INCLUDE},
+
+    // Compile/runtime arg ops
+    {"get_arg_val", "compute_kernel_api/common.h"},
+    {"get_compile_time_arg_val",
+     "accessor/sharded_accessor.h"}, // is this include path correct?
+
+    // Multicast NoC
+    {"get_noc_multicast_addr", NOC_INCLUDE},
+    {"noc_async_write_multicast_one_packet", NOC_INCLUDE},
+    {"noc_async_write_multicast", NOC_INCLUDE},
+    {"noc_async_write_multicast_loopback_src", NOC_INCLUDE},
+
+    // Misc operations
+    // {"unreachable", ???},
+    {"mem_zeros_base", "dev_mem_map.h"}, // Is this the correct path?
+    {"mem_zeros_size", "dev_mem_map.h"}, // Is this the correct path?
+    {"get_write_ptr", "dataflow_api.h"},
+    {"get_read_ptr", "dataflow_api.h"},
+    {"get_tile_size", "dataflow_api.h"},
+    {"get_dataformat", "dataflow_api.h"},
+    // {"cb_reinterpret_shape", ???}
+};
 
 // Class used to add includes and other boilerplate code to the generated
 // kernel.


### PR DESCRIPTION
### Ticket
Fix #772 .

### Problem description
Currently `TTKernelToCpp` generate `emitc::IncludeOp` statically based on the thread type, which is hacky.

### What's changed
This PR adds the includes dynamically based on the kinds of operations in the target region.
The include map is a manually derived map that is statically stored in a `llvm::StringMap`.

This is done by declaring a static op -> include map (currently one-to-one).
Walk through the target region and collect mapped includes in a set.
Sorting them and emitting them at the top of the file.

### TODOs:
- Please double check my includes, I have listed out operations I am unsure of in https://github.com/tenstorrent/tt-mlir/issues/772#issuecomment-2921122647 , please follow up on that issue or comment on the line directly in this PR, I will keep the table in the comment and the table in the source code in sync.
- How do we want to approach testing for this?

### Checklist
- [ ] New/Existing tests provide coverage for changes
