### PR TITLE
Automatic Port Selection for Explorer Tests

### DIFF
--- a/tools/explorer/test/run_tests.py
+++ b/tools/explorer/test/run_tests.py
@@ -10,9 +10,11 @@ import pytest
 import glob
 import os
 import logging
+import portpicker
 
 HOST = "localhost"
-PORT = 8002
+# Use portpicker to pick a port for us. (say that 10 times fast)
+PORT = portpicker.pick_unused_port()
 COMMAND_URL = "http://" + HOST + ":" + str(PORT) + "/apipost/v1/send_command"
 TEST_LOAD_MODEL_PATHS = [
     "test/ttmlir/Explorer/**/*.mlir",


### PR DESCRIPTION
### Problem description
- As we move onto shared runners we are running into issues with the static port selection in our ports.

### What's changed
- Used `portpicker` (dependency from `model-explorer` to select port for explorer usage.
