### PR TITLE
Prevent unintended clipping in Reshape workaround

### DIFF
--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -384,7 +384,7 @@ TTNNOperandsWorkaroundsFactory::createReshapeOpOperandsWorkarounds(
   TTNNOperandWorkarounds typeWorkarounds;
   mlir::tt::DataType dataType = elementTypeToDataType(inputElementType);
   if (dataType == mlir::tt::DataType::Int32) {
-    typeWorkarounds.tensorDataTypeWorkaround = mlir::tt::DataType::UInt32;
+    typeWorkarounds.tensorDataTypeWorkaround = mlir::tt::DataType::Float32;
   }
   return TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
       .addInputOperandWorkaround(typeWorkarounds)

--- a/test/ttmlir/Silicon/StableHLO/n150/moreh_cumsum_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/moreh_cumsum_op.mlir
@@ -80,16 +80,16 @@ module @moreh_cumsum attributes {} {
     %c = stablehlo.constant dense<0> : tensor<i64>
     // CHECK: %[[RESHAPE:[0-9]+]] = "ttnn.reshape"
     // CHECK-SAME: {shape = [1 : i32, 10 : i32, 1 : i32, 1 : i32]}
-    // CHECK-SAME: tensor<1x10xui32
-    // CHECK-SAME: -> tensor<1x10x1x1xui32
+    // CHECK-SAME: tensor<1x10xf32
+    // CHECK-SAME: -> tensor<1x10x1x1xf32
     // CHECK: %[[CUMSUM:[0-9]+]] = "ttnn.moreh_cumsum"
     // CHECK-SAME: <{dim = 1 : i64}>
     // CHECK-SAME: tensor<1x10x1x1xsi32
     // CHECK-SAME: -> tensor<1x10x1x1xsi32
     // CHECK: %[[RESHAPE_FINAL:[0-9]+]] = "ttnn.reshape"
     // CHECK-SAME: <{shape = [1 : i32, 10 : i32]}>
-    // CHECK-SAME: tensor<1x10x1x1xui32
-    // CHECK-SAME: -> tensor<1x10xui32
+    // CHECK-SAME: tensor<1x10x1x1xf32
+    // CHECK-SAME: -> tensor<1x10xf32
     %0 = "stablehlo.reduce_window"(%arg0, %c) <{padding = dense<[[0, 0], [9, 0]]> : tensor<2x2xi64>, window_dilations = array<i64: 1, 1>, window_dimensions = array<i64: 1, 10>, window_strides = array<i64: 1, 1>}> ({
     ^bb0(%arg1: tensor<i64>, %arg2: tensor<i64>):
       %1 = stablehlo.add %arg1, %arg2 : tensor<i64>

--- a/test/ttmlir/Silicon/StableHLO/n150/reshape_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/reshape_op.mlir
@@ -21,8 +21,8 @@ module @jit_module_reshape attributes {mhlo.num_partitions = 1 : i32, mhlo.num_r
     // CHECK-LABEL: func.func public @test_reshape_i64
     // CHECK: ttnn.reshape
     // CHECK-SAME: {shape = [1 : i32, 1 : i32]}
-    // CHECK-SAME: tensor<1x1x1xui32,
-    // CHECK-SAME: -> tensor<1x1xui32,
+    // CHECK-SAME: tensor<1x1x1xf32,
+    // CHECK-SAME: -> tensor<1x1xf32,
     %0 = stablehlo.reshape %arg0 : (tensor<1x1x1xi64>) -> tensor<1x1xi64>
     return %0 : tensor<1x1xi64>
   }


### PR DESCRIPTION
### Ticket
N/A

### Problem description
In the workaround pass for reshape, when the input is int32, a typecast to uint32 is inserted to satisfy TTNN requirements. However, this causes unintended behavior in certain cases, such as:

Original:
where (int32)
reshape (int32)

After workaround:
1. typecast (int32 -> float32)
2. where (float32 -> float32)
3. typecast (float32 -> int32)
4. typecast (int32 -> uint32)
5. reshape (uint32 -> uint32)
6. typecast (uint32 -> int32) 

Steps (3) and (4) are merged into typecast(float32 -> uint32) by the canonicalizer. If the result of where contains negative values, casting float32â-> uint32 clips them to 0, leading to incorrect behavior.

### What's changed
To avoid this, step (4) is now changed to typecast(int32 -> float32) before applying the reshape, preserving negative values safely.

### Checklist
- [ ] New/Existing tests provide coverage for changes
