### PR TITLE
Shard join nodes

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/Edge.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/Edge.h
@@ -26,8 +26,15 @@ struct Edge {
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Edge &edge) {
   auto producerName =
       edge.producerOp ? edge.producerOp->getName().getStringRef() : "nullptr";
-  os << "Edge(" << producerName << ", " << edge.consumerOp->getName() << ", "
-     << edge.operandIndex << ")";
+  auto consumerName =
+      edge.consumerOp ? edge.consumerOp->getName().getStringRef() : "nullptr";
+  os << "Edge(" << producerName << " (" << edge.producerOp << " @ "
+     << (edge.producerOp ? edge.producerOp->getLoc()
+                         : mlir::UnknownLoc::get(edge.consumerOp->getContext()))
+     << "), " << consumerName << " (" << edge.consumerOp << " @ "
+     << (edge.consumerOp ? edge.consumerOp->getLoc()
+                         : mlir::UnknownLoc::get(edge.consumerOp->getContext()))
+     << "), " << edge.operandIndex << ")";
   return os;
 }
 

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1ChainConfig.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1ChainConfig.h
@@ -106,11 +106,9 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
   os << "L1ChainConfig(size=" << config.size() << ")";
   os << "\n\tState: " << config.getStateString();
   for (const auto &opL1MemSpec : config.getOpL1MemSpecs()) {
-
     os << "\n\t" << opL1MemSpec.op->getName().getStringRef() << "\t"
        << utils::getOpLocName(opL1MemSpec.op);
-
-    os << "\n\t\t" << opL1MemSpec.config.outputLayout;
+    os << "\n\t outputLayout: " << opL1MemSpec.config.outputLayout;
   }
   return os;
 }

--- a/include/ttmlir/Scheduler/Scheduler.h
+++ b/include/ttmlir/Scheduler/Scheduler.h
@@ -43,13 +43,17 @@ public:
   bool hasUnscheduledOps() const;
 
 private:
-  // Map of scheduled operations
+  // Map of scheduled operations.
   llvm::DenseSet<mlir::Operation *> scheduledOpsMap;
-  // Operation schedule in order of execution
+
+  // Operation schedule in order of execution.
   llvm::SmallVector<mlir::Operation *> schedule;
-  // Set of unscheduled operations
-  llvm::DenseSet<mlir::Operation *> unscheduledOps;
-  // Map of dependencies
+
+  // Vector of all operations in deterministic order.
+  llvm::SmallVector<mlir::Operation *> funcOps;
+
+  // Map of dependencies. Dependencies are the operations that must be scheduled
+  // before the given operation.
   llvm::DenseMap<mlir::Operation *, llvm::SmallVector<mlir::Operation *>>
       dependencies;
 };

--- a/include/ttmlir/Scheduler/Scheduler.h
+++ b/include/ttmlir/Scheduler/Scheduler.h
@@ -21,7 +21,7 @@ public:
   Scheduler(const Scheduler &scheduler);
 
   // Method to get the next set of schedulable operations
-  llvm::SmallVector<mlir::Operation *> getScheduleableOps();
+  llvm::SmallVector<mlir::Operation *> getSchedulableOps();
 
   // Method to check if an operation is either a TTIR op or a
   // TTNN scheduleable op.
@@ -50,7 +50,7 @@ private:
   llvm::SmallVector<mlir::Operation *> schedule;
 
   // Vector of all operations in deterministic order.
-  llvm::SmallVector<mlir::Operation *> funcOps;
+  llvm::SmallVector<mlir::Operation *> opsWithinFuncOp;
 
   // Map of dependencies. Dependencies are the operations that must be scheduled
   // before the given operation.

--- a/lib/Dialect/TTNN/Analysis/BFInterleavedPolicy.cpp
+++ b/lib/Dialect/TTNN/Analysis/BFInterleavedPolicy.cpp
@@ -32,7 +32,7 @@ void BFInterleavedPolicy::run() {
 
       nextOpForScheduling = nullptr;
       minimalChangeInL1Usage = std::numeric_limits<uint64_t>::max();
-      for (Operation *op : scheduler.getScheduleableOps()) {
+      for (Operation *op : scheduler.getSchedulableOps()) {
         uint64_t deallocOfL1Mem, allocOfL1Mem, changeInL1Usage;
         BufferType opBufferType;
 

--- a/lib/Dialect/TTNN/Analysis/DFShardingPolicy.cpp
+++ b/lib/Dialect/TTNN/Analysis/DFShardingPolicy.cpp
@@ -85,126 +85,129 @@ void DFShardingPolicy::run() {
           }
         }
 
-        if (nextOp) {
+        bool validForSharding =
+            legalConfigs.lookup(currentOp).size() > 0 &&
+            (nextOp ? legalConfigs.lookup(nextOp).size() > 0 : true);
 
-          // V0 Before adding to shard chain config check that currentOp is not
-          // fork/join op.
+        // TODO(odjuricic): Skip all ops that don't support sharding due to
+        // bugs and incomplete implementation. This needs to be addressed in
+        // the near future.
+        //
+        if (llvm::isa<
+                // TODO(rpavlovicTT) Eliminating Transpose because we are
+                // failing to shard it thus it bumps our successful sharding
+                // percentage. Re-enable once we have a fix for transpose
+                // sharding.
+                ttnn::TransposeOp,
+
+                ttnn::ZerosOp, ttnn::OnesOp,
+                // TODO(#3242): Re-enable once we are able to query backend
+                // for matmul.
+                ttnn::MatmulOp,
+                // TODO(#2038): Remove this once this bug is fixed.
+                // TODO(#2042): And constraints are implemented.
+                ttnn::ReshapeOp,
+                // TODO(#2038): Remove this once this bug is fixed.
+                ttnn::ConcatOp,
+                // TODO(#2041): Remove once constraints are added for MeanOp.
+                // TODO(#2084): Remove once constraints are added for all
+                // Llama ops.
+                ttnn::MeanOp, ttnn::SinOp, ttnn::CosOp, ttnn::ReciprocalOp,
+
+                // TODO(#2588): Blocked by graph capture issue.
+                ttnn::MaxPool2dOp>(currentOp)) {
+          validForSharding = false;
+        }
+
+        if (validForSharding) {
+          // Fetch largest legal sharded L1 layouts for currentOp and nextOp.
           //
-          bool validForSharding = currentOp->hasOneUse() &&
-                                  legalConfigs.lookup(currentOp).size() > 0 &&
-                                  legalConfigs.lookup(nextOp).size() > 0;
-
-          // TODO(odjuricic): Skip all ops that don't support sharding due to
-          // bugs and incomplete implementation. This needs to be addressed in
-          // the near future.
+          // Calculate L1 tensor memory usage based on :
+          // currentOp output tensor shard spec, nextOp exec and nextOp output
+          // tensor.
           //
-          if (llvm::isa<
-                  ttnn::ZerosOp, ttnn::OnesOp,
-                  // TODO(#3242): Re-enable once we are able to query backend
-                  // for matmul.
-                  ttnn::MatmulOp,
-                  // TODO(#2038): Remove this once this bug is fixed.
-                  // TODO(#2042): And constraints are implemented.
-                  ttnn::ReshapeOp,
-                  // TODO(#2038): Remove this once this bug is fixed.
-                  ttnn::ConcatOp,
-                  // TODO(#2041): Remove once constraints are added for MeanOp.
-                  // TODO(#2084): Remove once constraints are added for all
-                  // Llama ops.
-                  ttnn::MeanOp, ttnn::SinOp, ttnn::CosOp, ttnn::ReciprocalOp,
+          OpConfig currentOpConfig = legalConfigs.lookup(currentOp).front();
+          assert(currentOpConfig.outputLayout.hasShardedL1TensorMemoryLayout());
+          uint64_t currentOpL1OutputUsage =
+              currentOpConfig.outputLayout.getShardSizeInBytes();
+          uint64_t nextOpL1OutputUsage = 0;
 
-                  // Following binary eltwise ops are blocked by metal issue
-                  // https://github.com/tenstorrent/tt-metal/issues/21846
-                  ttnn::AddOp, ttnn::SubtractOp, ttnn::MultiplyOp,
-
-                  // TODO(#2588): Blocked by graph capture issue.
-                  ttnn::MaxPool2dOp>(currentOp)) {
-            validForSharding = false;
-          }
-
-          if (validForSharding) {
-            // Fetch largest legal sharded L1 layouts for currentOp and nextOp.
-            //
-            // Calculate L1 tensor memory usage based on :
-            // currentOp output tensor shard spec, nextOp exec and nextOp output
-            // tensor.
-            //
-            OpConfig currentOpConfig = legalConfigs.lookup(currentOp).front();
-            assert(
-                currentOpConfig.outputLayout.hasShardedL1TensorMemoryLayout());
-            uint64_t currentOpL1OutputUsage =
-                currentOpConfig.outputLayout.getShardSizeInBytes();
-
+          if (nextOp) {
             OpConfig nextOpConfig = legalConfigs.lookup(nextOp).front();
             assert(nextOpConfig.outputLayout.hasShardedL1TensorMemoryLayout());
-            uint64_t nextOpL1OutputUsage =
+            nextOpL1OutputUsage =
                 nextOpConfig.outputLayout.getShardSizeInBytes();
+          }
 
-            // Figure out this const based on exec data, but will be replaced
-            // with API.
+          // Figure out this const based on exec data, but will be replaced
+          // with API.
+          //
+          constexpr float tensorL1UsageCap = 0.8;
+          bool l1UsageValid = (currentOpL1OutputUsage + nextOpL1OutputUsage) <
+                              tensorL1UsageCap * usableL1CacheSize;
+
+          if (l1UsageValid) {
+            // TODO(nobradovic)
+            // It seems that some TTNN ops have constraints which prevent
+            // them from being sharded if both inputs are interleaved,
+            // so proposal for now is starting a shard chain
+            // with reshard op. For this reason we also need to validate that
+            // currentOp can fit into L1 with its first input sharded.
             //
-            constexpr float tensorL1UsageCap = 0.8;
-            bool l1UsageValid = (currentOpL1OutputUsage + nextOpL1OutputUsage) <
-                                tensorL1UsageCap * usableL1CacheSize;
+            bool firstInputL1UsageValid = true;
+            if (l1ChainConfigs->back().isEmpty() &&
+                (overrideReshardEdges.count(Edge(
+                     currentOp->getOperand(0).getDefiningOp(), currentOp, 0)) >
+                 0)) {
+              RankedTensorType firstOpInputTensorType =
+                  mlir::cast<RankedTensorType>(currentOp->getOperand(0)
+                                                   .getDefiningOp()
+                                                   ->getResult(0)
+                                                   .getType());
+              TTNNLayoutAttr firstOpInputLayout = mlir::cast<TTNNLayoutAttr>(
+                  firstOpInputTensorType.getEncoding());
 
-            if (l1UsageValid) {
-              // TODO(nobradovic)
-              // It seems that some TTNN ops have constraints which prevent
-              // them from being sharded if both inputs are interleaved,
-              // so proposal for now is starting a shard chain
-              // with reshard op. For this reason we also need to validate that
-              // currentOp can fit into L1 with its first input sharded.
+              TTNNLayoutAttr firstOpInputShardedLayout =
+                  firstOpInputLayout
+                      .withBufferType(
+                          currentOpConfig.outputLayout.getBufferType())
+                      .withMemoryLayout(
+                          currentOpConfig.outputLayout.getMemLayout())
+                      .withGrid(firstOpInputTensorType,
+                                currentOpConfig.outputLayout.getGrid());
+
+              uint64_t firstInputL1Usage =
+                  firstOpInputShardedLayout.getShardSizeInBytes();
+
+              firstInputL1UsageValid =
+                  (firstInputL1Usage + currentOpL1OutputUsage) <
+                  tensorL1UsageCap * usableL1CacheSize;
+            }
+
+            if (firstInputL1UsageValid) {
+              // Add to shard chain config.
               //
-              bool firstInputL1UsageValid = true;
-              if (l1ChainConfigs->back().isEmpty() &&
-                  (overrideReshardEdges.count(
-                       Edge(currentOp->getOperand(0).getDefiningOp(), currentOp,
-                            0)) > 0)) {
-                RankedTensorType firstOpInputTensorType =
-                    mlir::cast<RankedTensorType>(currentOp->getOperand(0)
-                                                     .getDefiningOp()
-                                                     ->getResult(0)
-                                                     .getType());
-                TTNNLayoutAttr firstOpInputLayout = mlir::cast<TTNNLayoutAttr>(
-                    firstOpInputTensorType.getEncoding());
+              OpL1MemSpec shardSpec;
+              shardSpec.op = currentOp;
 
-                TTNNLayoutAttr firstOpInputShardedLayout =
-                    firstOpInputLayout
-                        .withBufferType(
-                            currentOpConfig.outputLayout.getBufferType())
-                        .withMemoryLayout(
-                            currentOpConfig.outputLayout.getMemLayout())
-                        .withGrid(firstOpInputTensorType,
-                                  currentOpConfig.outputLayout.getGrid());
+              // Hardcoded tensor split factor for now, until pipeline OP
+              // support is added.
+              //
+              shardSpec.tensorSplitFactor = 1;
+              l1ChainConfigs->back().addOpL1MemSpec(std::move(shardSpec));
 
-                uint64_t firstInputL1Usage =
-                    firstOpInputShardedLayout.getShardSizeInBytes();
-
-                firstInputL1UsageValid =
-                    (firstInputL1Usage + currentOpL1OutputUsage) <
-                    tensorL1UsageCap * usableL1CacheSize;
-              }
-
-              if (firstInputL1UsageValid) {
-                // Add to shard chain config.
-                //
-                OpL1MemSpec shardSpec;
-                shardSpec.op = currentOp;
-
-                // Hardcoded tensor split factor for now, until pipeline OP
-                // support is added.
-                //
-                shardSpec.tensorSplitFactor = 1;
-                l1ChainConfigs->back().addOpL1MemSpec(std::move(shardSpec));
+              // Only if nextOp is valid and currentOp is not a fork keep
+              // growing the chain.
+              if (nextOp && currentOp->hasOneUse()) {
                 currentOp = nextOp;
                 continue;
               }
             }
           }
-        }
+        } // endif validForSharding
 
         currentOp = nullptr;
-      }
+      } // endif hasUnscheduledOps
 
       if (!l1ChainConfigs->back().isEmpty()) {
         l1ChainConfigs->back().build();
@@ -217,6 +220,11 @@ void DFShardingPolicy::run() {
 
   if (l1ChainConfigs->back().isEmpty()) {
     l1ChainConfigs->pop_back();
+  }
+
+  for ([[maybe_unused]] L1ChainConfig &l1ChainConfig : *l1ChainConfigs) {
+    TTMLIR_DEBUG(ttmlir::LogComponent::Optimizer, "L1 chain config {}",
+                 l1ChainConfig);
   }
 
   // Resolve shard chain configs.

--- a/lib/Dialect/TTNN/Analysis/DFShardingPolicy.cpp
+++ b/lib/Dialect/TTNN/Analysis/DFShardingPolicy.cpp
@@ -37,7 +37,7 @@ void DFShardingPolicy::run() {
     // 4. Op is considered sharded if its output is sharded to L1.
     //
     while (scheduler.hasUnscheduledOps()) {
-      scheduleableOps = scheduler.getScheduleableOps();
+      scheduleableOps = scheduler.getSchedulableOps();
 
       // Before starting a sharding chain, schedule layout/memory management ops
       // first until they are exhausted from schedulable ops.
@@ -71,7 +71,7 @@ void DFShardingPolicy::run() {
       }
 
       if (scheduler.hasUnscheduledOps()) {
-        scheduleableOps = scheduler.getScheduleableOps();
+        scheduleableOps = scheduler.getSchedulableOps();
 
         // Check if currentOp has a valid successor.
         //
@@ -85,9 +85,9 @@ void DFShardingPolicy::run() {
           }
         }
 
-        bool validForSharding =
-            legalConfigs.lookup(currentOp).size() > 0 &&
-            (nextOp ? legalConfigs.lookup(nextOp).size() > 0 : true);
+        // Consider sharding only if we found at least single legal config for
+        // the current op.
+        bool validForSharding = legalConfigs.lookup(currentOp).size() > 0;
 
         // TODO(odjuricic): Skip all ops that don't support sharding due to
         // bugs and incomplete implementation. This needs to be addressed in
@@ -120,91 +120,22 @@ void DFShardingPolicy::run() {
         }
 
         if (validForSharding) {
-          // Fetch largest legal sharded L1 layouts for currentOp and nextOp.
+          OpL1MemSpec shardSpec;
+          shardSpec.op = currentOp;
+
+          // Hardcoded tensor split factor for now, until pipeline OP
+          // support is added.
           //
-          // Calculate L1 tensor memory usage based on :
-          // currentOp output tensor shard spec, nextOp exec and nextOp output
-          // tensor.
-          //
-          OpConfig currentOpConfig = legalConfigs.lookup(currentOp).front();
-          assert(currentOpConfig.outputLayout.hasShardedL1TensorMemoryLayout());
-          uint64_t currentOpL1OutputUsage =
-              currentOpConfig.outputLayout.getShardSizeInBytes();
-          uint64_t nextOpL1OutputUsage = 0;
+          shardSpec.tensorSplitFactor = 1;
+          l1ChainConfigs->back().addOpL1MemSpec(std::move(shardSpec));
+        }
 
-          if (nextOp) {
-            OpConfig nextOpConfig = legalConfigs.lookup(nextOp).front();
-            assert(nextOpConfig.outputLayout.hasShardedL1TensorMemoryLayout());
-            nextOpL1OutputUsage =
-                nextOpConfig.outputLayout.getShardSizeInBytes();
-          }
-
-          // Figure out this const based on exec data, but will be replaced
-          // with API.
-          //
-          constexpr float tensorL1UsageCap = 0.8;
-          bool l1UsageValid = (currentOpL1OutputUsage + nextOpL1OutputUsage) <
-                              tensorL1UsageCap * usableL1CacheSize;
-
-          if (l1UsageValid) {
-            // TODO(nobradovic)
-            // It seems that some TTNN ops have constraints which prevent
-            // them from being sharded if both inputs are interleaved,
-            // so proposal for now is starting a shard chain
-            // with reshard op. For this reason we also need to validate that
-            // currentOp can fit into L1 with its first input sharded.
-            //
-            bool firstInputL1UsageValid = true;
-            if (l1ChainConfigs->back().isEmpty() &&
-                (overrideReshardEdges.count(Edge(
-                     currentOp->getOperand(0).getDefiningOp(), currentOp, 0)) >
-                 0)) {
-              RankedTensorType firstOpInputTensorType =
-                  mlir::cast<RankedTensorType>(currentOp->getOperand(0)
-                                                   .getDefiningOp()
-                                                   ->getResult(0)
-                                                   .getType());
-              TTNNLayoutAttr firstOpInputLayout = mlir::cast<TTNNLayoutAttr>(
-                  firstOpInputTensorType.getEncoding());
-
-              TTNNLayoutAttr firstOpInputShardedLayout =
-                  firstOpInputLayout
-                      .withBufferType(
-                          currentOpConfig.outputLayout.getBufferType())
-                      .withMemoryLayout(
-                          currentOpConfig.outputLayout.getMemLayout())
-                      .withGrid(firstOpInputTensorType,
-                                currentOpConfig.outputLayout.getGrid());
-
-              uint64_t firstInputL1Usage =
-                  firstOpInputShardedLayout.getShardSizeInBytes();
-
-              firstInputL1UsageValid =
-                  (firstInputL1Usage + currentOpL1OutputUsage) <
-                  tensorL1UsageCap * usableL1CacheSize;
-            }
-
-            if (firstInputL1UsageValid) {
-              // Add to shard chain config.
-              //
-              OpL1MemSpec shardSpec;
-              shardSpec.op = currentOp;
-
-              // Hardcoded tensor split factor for now, until pipeline OP
-              // support is added.
-              //
-              shardSpec.tensorSplitFactor = 1;
-              l1ChainConfigs->back().addOpL1MemSpec(std::move(shardSpec));
-
-              // Only if nextOp is valid and currentOp is not a fork keep
-              // growing the chain.
-              if (nextOp && currentOp->hasOneUse()) {
-                currentOp = nextOp;
-                continue;
-              }
-            }
-          }
-        } // endif validForSharding
+        if (nextOp && currentOp->hasOneUse()) {
+          // Only if nextOp is valid and currentOp is not a fork keep
+          // growing the chain.
+          currentOp = nextOp;
+          continue;
+        }
 
         currentOp = nullptr;
       } // endif hasUnscheduledOps

--- a/lib/Dialect/TTNN/Analysis/GreedyL1InterleavedPolicy.cpp
+++ b/lib/Dialect/TTNN/Analysis/GreedyL1InterleavedPolicy.cpp
@@ -147,7 +147,7 @@ void GreedyL1InterleavedPolicy::run() {
     llvm::SmallVector<Operation *> scheduleableOps;
 
     while (scheduler.hasUnscheduledOps()) {
-      scheduleableOps = scheduler.getScheduleableOps();
+      scheduleableOps = scheduler.getSchedulableOps();
 
       for (Operation *op : scheduleableOps) {
         // Schedule the op.

--- a/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
+++ b/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
@@ -167,6 +167,9 @@ bool ShardSolver::resolveStep() {
       } else {
         for (std::uint64_t producerId = 0; producerId < producerCount;
              ++producerId) {
+          // TODO(rpavlovicTT) After we inserted reshard in
+          // preprocessFirstOp we dont need to try every producerId here, right?
+
           // If the producer cannot accomodate this path, continue.
           // Also if this is not the OpConfig we selected, continue.
           if (!producerBitset->test(producerId)) {
@@ -189,6 +192,12 @@ bool ShardSolver::resolveStep() {
                  ++consumerId) {
 
               if (consumerConfigs[consumerId].outputLayout != consumerLayout) {
+                TTMLIR_TRACE(
+                    ttmlir::LogComponent::Optimizer,
+                    "OpName: {} Generated consumer layout {} does not match "
+                    "backend returned layout {}",
+                    consumerOp->getName(),
+                    consumerConfigs[consumerId].outputLayout, consumerLayout);
                 continue;
               }
 
@@ -296,6 +305,8 @@ bool ShardSolver::supportsInterleavedInputShardedOutput(Operation *op,
                "Checking if interleaved to sharded is possible for op : {}",
                op->getName());
 
+  // TODO(rpavlovicTT) this is bad as we are hardcoding this layout, while it
+  // could be overriden.
   inputLayout = inputLayout.withBufferType(BufferType::DRAM)
                     .withMemoryLayout(TensorMemoryLayout::Interleaved);
 
@@ -820,10 +831,6 @@ llvm::Expected<TTNNLayoutAttr> ShardSolver::checkShardCompatible(
     auto layout = mlir::cast<TTNNLayoutAttr>(input.getEncoding());
 
     assert(layout && "Input operand must have a layout");
-
-    TTMLIR_TRACE(ttmlir::LogComponent::Optimizer,
-                 "Op {0} has additional operand with layout {1}",
-                 consumerOp->getName(), layout);
     inputLayouts.push_back(layout);
   }
 
@@ -865,9 +872,14 @@ llvm::Expected<TTNNLayoutAttr> ShardSolver::checkShardCompatible(
 
   if (!l1UsageValid) {
     TTMLIR_DEBUG(ttmlir::LogComponent::Optimizer,
-                 "OpModel constraints failed: {0}->{1} :: {2}",
+                 "Not enough L1 memory. OpModel constraints failed: {0}->{1} "
+                 "\n producerLayout: {2}, outputLayout: {3}, l1Usage: {4}, "
+                 "producerL1OutputUsage: {5}, "
+                 "outputTensorUsage: {6}, cBUsagePeak: {7}",
                  producerOperand.getLoc(), consumerOp->getName(),
-                 "Not enough L1 memory");
+                 producerLayout, outputLayout,
+                 cBUsagePeak + outputTensorUsage + producerL1OutputUsage,
+                 producerL1OutputUsage, outputTensorUsage, cBUsagePeak);
     return llvm::createStringError("Not enough L1 memory");
   }
 
@@ -875,10 +887,13 @@ llvm::Expected<TTNNLayoutAttr> ShardSolver::checkShardCompatible(
       ttmlir::LogComponent::Optimizer,
       "OpModel constraints valid. Producer: {0} -> Consumer: {1}\n"
       "ProducerLayout: {2}\nOutputLayout: {3}\n"
-      "L1 usage: cBUsagePeak: {4}, tensorUsage: {5}, outputTensorUsage: {6}\n"
+      "L1 usage: cBUsagePeak: {4}, tensorUsage: {5}, outputTensorUsage: {6}, "
+      "producerL1OutputUsage: {7}, totalL1Usage: {8}\n"
       "=== End of debug dump ===",
       producerOperand.getLoc(), consumerOp->getName(), producerLayout,
-      outputLayout, cBUsagePeak, tensorUsage, outputTensorUsage);
+      outputLayout, cBUsagePeak, tensorUsage, outputTensorUsage,
+      producerL1OutputUsage,
+      cBUsagePeak + outputTensorUsage + producerL1OutputUsage);
 
   return outputLayout;
 }

--- a/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
+++ b/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
@@ -305,8 +305,6 @@ bool ShardSolver::supportsInterleavedInputShardedOutput(Operation *op,
                "Checking if interleaved to sharded is possible for op : {}",
                op->getName());
 
-  // TODO(rpavlovicTT) this is bad as we are hardcoding this layout, while it
-  // could be overriden.
   inputLayout = inputLayout.withBufferType(BufferType::DRAM)
                     .withMemoryLayout(TensorMemoryLayout::Interleaved);
 
@@ -347,6 +345,9 @@ bool ShardSolver::preprocessFirstOp() {
     TTNNLayoutAttr firstOpLayout = firstOpConfigs[i].outputLayout;
     assert(firstOpLayout.hasShardedL1TensorMemoryLayout());
 
+    // TODO(rpavlovicTT) this is bad as we are hardcoding this layout, while it
+    // could be overriden.
+    // https://github.com/tenstorrent/tt-mlir/issues/3749
     if (!supportsInterleavedInputShardedOutput(firstOp, firstOpConfigs[i])) {
       TTMLIR_TRACE(ttmlir::LogComponent::Optimizer,
                    "Interleaved to sharded not possible for config idx {}", i);

--- a/lib/Dialect/TTNN/Transforms/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/Optimizer.cpp
@@ -30,6 +30,7 @@
 #include "mlir/IR/OperationSupport.h"
 #include "mlir/IR/Value.h"
 #include "mlir/IR/Visitors.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -420,11 +421,13 @@ public:
         }
       });
 
+      llvm::DenseMap<Operation *, Operation *> insertedMemoryReconfigOps;
       if (memReconfigEnabled) {
-        processMemReconfigEdges(memReconfigEntryMap, deviceGrid);
+        insertedMemoryReconfigOps =
+            processMemReconfigEdges(memReconfigEntryMap, deviceGrid);
       }
 
-      processSpillOps(spillToDramOps, deviceGrid);
+      processSpillOps(spillToDramOps, deviceGrid, insertedMemoryReconfigOps);
 
       // Update the function type to reflect the updated return operation's
       // result types.
@@ -514,8 +517,8 @@ private:
     assert(insertMemReconfig.size() == overrideReshardEdges.size());
   }
 
-  mlir::TypedValue<DeviceType> getOrCreateDeviceOpValue(Operation *contextOp,
-                                                        OpBuilder &builder) {
+  static mlir::TypedValue<DeviceType>
+  getOrCreateDeviceOpValue(Operation *contextOp, OpBuilder &builder) {
     Block *block = contextOp->getBlock();
     for (auto &op : block->getOperations()) {
       if (GetDeviceOp deviceOp = dyn_cast<GetDeviceOp>(op)) {
@@ -545,9 +548,12 @@ private:
     return deviceOp;
   }
 
-  void processMemReconfigEdges(
+  static llvm::DenseMap<Operation *, Operation *> processMemReconfigEdges(
       const llvm::DenseMap<Edge, MemReconfigEntry> &memReconfigEntryMap,
       GridAttr deviceGrid) {
+
+    // Mapping from producer op to inserted memory reconfig op.
+    llvm::DenseMap<Operation *, Operation *> insertedMemoryReconfigOps;
 
     // Insert memory reconfig ops here based on results of memory layout
     // analysis.
@@ -630,17 +636,26 @@ private:
         TTMLIR_TRACE(ttmlir::LogComponent::Optimizer,
                      "Inserted memory reconfig op: {}",
                      mlir::cast<ToLayoutOp>(memoryReconfigOp));
+        if (producerOp) {
+          insertedMemoryReconfigOps[producerOp] = memoryReconfigOp;
+        }
       }
     }
+    return insertedMemoryReconfigOps;
   }
 
   void processSpillOps(const std::vector<Operation *> &spillToDramOps,
-                       GridAttr deviceGrid) {
-    for (Operation *op : spillToDramOps) {
-      TTMLIR_TRACE(ttmlir::LogComponent::Optimizer, "Processing spill op: {}",
-                   op->getName());
+                       GridAttr deviceGrid,
+                       const llvm::DenseMap<Operation *, Operation *>
+                           &insertedMemoryReconfigOps) {
+
+    for (Operation *spilledOp : spillToDramOps) {
+      TTMLIR_TRACE(ttmlir::LogComponent::Optimizer,
+                   "Processing spilled op: {} {} @{}", spilledOp,
+                   spilledOp->getName(), spilledOp->getLoc());
+
       RankedTensorType tensorType =
-          mlir::cast<RankedTensorType>(op->getResult(0).getType());
+          mlir::cast<RankedTensorType>(spilledOp->getResult(0).getType());
       llvm::ArrayRef<int64_t> tensorShape = tensorType.getShape();
       TTNNLayoutAttr layoutAttr =
           mlir::cast<TTNNLayoutAttr>(tensorType.getEncoding());
@@ -653,31 +668,93 @@ private:
           tensorShape, tensorType.getElementType(), dramLayout);
 
       // Create a ToLayoutOp with the new DRAM layout.
-      OpBuilder builder(op->getContext());
+      OpBuilder builder(spilledOp->getContext());
       DataTypeAttr dataType =
-          DataTypeAttr::get(op->getContext(), dramLayout.getDataType());
+          DataTypeAttr::get(spilledOp->getContext(), dramLayout.getDataType());
       LayoutAttr newLayout =
-          LayoutAttr::get(op->getContext(), dramLayout.getLayout());
+          LayoutAttr::get(spilledOp->getContext(), dramLayout.getLayout());
 
       MemoryConfigAttr memConfigAttr = MemoryConfigAttr::get(
-          op->getContext(), dramLayout.getMemLayout(),
-          BufferTypeAttr::get(op->getContext(), BufferType::DRAM),
+          spilledOp->getContext(), dramLayout.getMemLayout(),
+          BufferTypeAttr::get(spilledOp->getContext(), BufferType::DRAM),
           utils::createShardSpecIfNeeded(dramLayout, deviceGrid));
 
-      builder.setInsertionPointAfter(op);
+      builder.setInsertionPointAfter(spilledOp);
       Location loc =
-          ttmlir::utils::appendLocationSuffix(op->getLoc(), "_spill");
-      Operation *toLayoutOp = builder.create<ToLayoutOp>(
-          loc, newTensorType, op->getResult(0), newLayout, dataType,
-          memConfigAttr, getOrCreateDeviceOpValue(op, builder));
-      TTMLIR_TRACE(ttmlir::LogComponent::Optimizer,
-                   "Inserted spill to DRAM prevLayout: {}\nnewLayout: {}",
-                   layoutAttr, newLayout);
+          ttmlir::utils::appendLocationSuffix(spilledOp->getLoc(), "_spill");
 
-      for (auto &use : op->getResult(0).getUses()) {
-        if (use.getOwner() != toLayoutOp) {
-          use.getOwner()->setOperand(use.getOperandNumber(),
-                                     toLayoutOp->getResult(0));
+      // Step 1: Save all uses as (Operation*, operand index).
+      llvm::SmallVector<std::pair<Operation *, unsigned>> uses;
+      for (auto &use : spilledOp->getResult(0).getUses()) {
+        uses.emplace_back(use.getOwner(), use.getOperandNumber());
+      }
+
+      // Step 2: Insert spilling to DRAM.
+      Operation *spillToDRAMOp = builder.create<ToLayoutOp>(
+          loc, newTensorType, spilledOp->getResult(0), newLayout, dataType,
+          memConfigAttr, getOrCreateDeviceOpValue(spilledOp, builder));
+
+      // Step 3: Reconnect uses.
+      for (auto &use : uses) {
+        Operation *useOp = use.first;
+        useOp->setOperand(use.second, spillToDRAMOp->getResult(0));
+      }
+
+      // TODO(rpavlovicTT): It's possible that spilled op was followed by
+      // memory reconfig ops. It's also possible that spilled op is a fork and
+      // has memory reconfig ops on more than one branch. In that case we should
+      // wire through each memory reconfig op and choose one which can inherit
+      // L1 tensor. Rest of the users must read from tensor spilled to DRAM.
+      // Right now we save only last memory reconfig op and try to skip spill
+      // to DRAM on that branch.
+      if (insertedMemoryReconfigOps.count(spilledOp)) {
+        // There is a memory reconfig op inserted on a branch outgoing from
+        // spilled op. We will avoid spill to DRAM on that branch.
+        Operation *memoryReconfigOp = insertedMemoryReconfigOps.at(spilledOp);
+        auto spilledOpResultLayout = mlir::cast<TTNNLayoutAttr>(
+            mlir::cast<RankedTensorType>(spilledOp->getResult(0).getType())
+                .getEncoding());
+        assert(spilledOpResultLayout &&
+               "Expected spilled op result to have layout");
+        auto memoryReconfigOpLayout = mlir::cast<TTNNLayoutAttr>(
+            mlir::cast<RankedTensorType>(
+                memoryReconfigOp->getResult(0).getType())
+                .getEncoding());
+        assert(memoryReconfigOpLayout &&
+               "Expected memory reconfig op result to have layout");
+
+        if (memoryReconfigOpLayout == spilledOpResultLayout) {
+          // Memory reconfig op has same layout as spilled op. We will avoid
+          // memory reconfig op on that branch. Data will flow directly from
+          // spilled op to consumer of memory reconfig op and will not leave L1.
+          assert(memoryReconfigOp->hasOneUse() &&
+                 "Expected memory reconfig op to have one use");
+          auto memoryReconfigOpConsumerOperand =
+              memoryReconfigOp->getResult(0).getUses().begin();
+
+          Operation *memoryReconfigOpConsumerOp =
+              memoryReconfigOpConsumerOperand->getOwner();
+          memoryReconfigOpConsumerOp->setOperand(
+              memoryReconfigOpConsumerOperand->getOperandNumber(),
+              spilledOp->getResult(0));
+
+          // Ensure memory reconfig op consumer is after spilling to DRAM to
+          // avoid losing data. This is a sanity check. Schedule should
+          // guarantee valid order.
+          assert(
+              spillToDRAMOp->isBeforeInBlock(memoryReconfigOpConsumerOp) &&
+              "Memory reconfig op consumer should be after spilling to DRAM");
+
+          memoryReconfigOp->erase();
+          TTMLIR_TRACE(ttmlir::LogComponent::Optimizer,
+                       "Erased memory reconfig op: {}@{}",
+                       memoryReconfigOp->getName(), memoryReconfigOp->getLoc());
+        } else {
+          // Memory reconfig op does not have the same layout as spilled op.
+          // We can't get rid of memory reconfig op but we can avoid reading
+          // from DRAM on that branch. MemoryReconfigOp has only one operand and
+          // we will wire it to spilled op's result.
+          memoryReconfigOp->setOperand(0, spilledOp->getResult(0));
         }
       }
     }

--- a/lib/Scheduler/Scheduler.cpp
+++ b/lib/Scheduler/Scheduler.cpp
@@ -9,6 +9,7 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Operation.h"
 
@@ -34,7 +35,7 @@ Scheduler::Scheduler(func::FuncOp *func) {
   for (auto &op : func->getOps()) {
     if (isTTSchedulableOp(&op)) {
       dependencies[&op] = {};
-      unscheduledOps.insert(&op);
+      funcOps.push_back(&op);
     }
   }
 
@@ -59,15 +60,58 @@ Scheduler::Scheduler(func::FuncOp *func) {
 
 Scheduler::Scheduler(const Scheduler &scheduler)
     : scheduledOpsMap(scheduler.scheduledOpsMap), schedule(scheduler.schedule),
-      unscheduledOps(scheduler.unscheduledOps),
-      dependencies(scheduler.dependencies) {}
+      funcOps(scheduler.funcOps), dependencies(scheduler.dependencies) {}
 
 llvm::SmallVector<mlir::Operation *> Scheduler::getScheduleableOps() {
   llvm::SmallVector<mlir::Operation *> scheduleableOps;
-  for (auto &op : unscheduledOps) {
-    if (canSchedule(op)) {
+  for (auto &op : funcOps) {
+    if (!scheduledOpsMap.contains(op) && canSchedule(op)) {
       scheduleableOps.push_back(op);
     }
+  }
+
+  // We will sort schedulable ops by prioritizing ops whose successors are still
+  // blocked after scheduling it. This is a heuristic that lets us create longer
+  // chains of ops that contain join nodes in fork-join structure.
+  if (scheduleableOps.size() > 1) {
+    auto hasBlockedSuccessor = [&](mlir::Operation *op) -> bool {
+      // A successor is any op for which 'op' is a dependency.
+      for (Operation *succ : funcOps) {
+        if (succ == op) {
+          continue;
+        }
+        auto it = dependencies.find(succ);
+        if (it == dependencies.end()) {
+          continue;
+        }
+        ArrayRef<Operation *> succDeps = it->second;
+
+        // Check if 'op' is a dependency of 'succ'.
+        if (std::find(succDeps.begin(), succDeps.end(), op) != succDeps.end()) {
+          // Simulate scheduling 'op' and check if 'succ' would still have
+          // unscheduled deps.
+          for (Operation *dep : succDeps) {
+            if (dep == op) {
+              continue;
+            }
+            if (!scheduledOpsMap.contains(dep)) {
+              // Found a successor that would still be blocked.
+              return true;
+            }
+          }
+        }
+      }
+      return false;
+    };
+    std::stable_sort(scheduleableOps.begin(), scheduleableOps.end(),
+                     [&](mlir::Operation *a, mlir::Operation *b) {
+                       bool aBlocked = hasBlockedSuccessor(a);
+                       bool bBlocked = hasBlockedSuccessor(b);
+                       if (aBlocked != bBlocked) {
+                         return aBlocked > bBlocked;
+                       }
+                       return false;
+                     });
   }
 
   return scheduleableOps;
@@ -84,8 +128,8 @@ bool Scheduler::canSchedule(mlir::Operation *op) {
 }
 
 void Scheduler::scheduleOp(mlir::Operation *op) {
+  assert(!scheduledOpsMap.contains(op) && "op is already scheduled");
   scheduledOpsMap.insert(op);
-  unscheduledOps.erase(op);
   schedule.push_back(op);
 }
 
@@ -97,5 +141,8 @@ llvm::SmallVector<mlir::Operation *> Scheduler::getSchedule() const {
   return schedule;
 }
 
-bool Scheduler::hasUnscheduledOps() const { return !unscheduledOps.empty(); }
+bool Scheduler::hasUnscheduledOps() const {
+  return scheduledOpsMap.size() < funcOps.size();
+}
+
 } // namespace mlir::tt::scheduler

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/shard_transpose.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/shard_transpose.mlir
@@ -6,6 +6,8 @@
 // Test is failing with an ND hang after metal commit daf8fbadc8
 // See issue https://github.com/tenstorrent/tt-mlir/issues/3743
 
+// TODO(rpavlovicTT): transpose-op sharding still not supported by default
+// It will be fixed with #3205 and #2637.
 module attributes {} {
   func.func @main(%arg0: tensor<1x3x224x224xf32>) -> tensor<1x224x3x224xf32> {
     %0 = ttir.empty() : tensor<1x224x3x224xf32> loc(#loc1)

--- a/test/unittests/TestScheduler/TestScheduler.cpp
+++ b/test/unittests/TestScheduler/TestScheduler.cpp
@@ -129,7 +129,7 @@ TEST_F(SchedulerBase, FixedSchedule) {
   mlir::tt::scheduler::Scheduler scheduler(&func);
   for (std::size_t i = 0; i < NumberOfOps; i++) {
     llvm::SmallVector<mlir::Operation *> scheduleableOps =
-        scheduler.getScheduleableOps();
+        scheduler.getSchedulableOps();
     ASSERT_EQ(scheduleableOps.size(), 1);
     ASSERT_TRUE(scheduler.hasUnscheduledOps());
     ;
@@ -161,7 +161,7 @@ TEST_F(SchedulerBase, SingleOp) {
   mlir::tt::scheduler::Scheduler scheduler(&func);
   ASSERT_TRUE(scheduler.hasUnscheduledOps());
   llvm::SmallVector<mlir::Operation *> scheduleableOps =
-      scheduler.getScheduleableOps();
+      scheduler.getSchedulableOps();
   ASSERT_EQ(scheduleableOps.size(), 1);
   scheduler.scheduleOp(scheduleableOps[0]);
   ASSERT_FALSE(scheduler.hasUnscheduledOps());
@@ -207,19 +207,19 @@ TEST_F(SchedulerBase, VerifyFork) {
 
   mlir::tt::scheduler::Scheduler scheduler(&func);
   llvm::SmallVector<mlir::Operation *> scheduleableOps =
-      scheduler.getScheduleableOps();
+      scheduler.getSchedulableOps();
   ASSERT_EQ(scheduleableOps.size(), 1);
 
   scheduler.scheduleOp(scheduleableOps[0]);
-  scheduleableOps = scheduler.getScheduleableOps();
+  scheduleableOps = scheduler.getSchedulableOps();
   ASSERT_EQ(scheduleableOps.size(), 2);
 
   scheduler.scheduleOp(scheduleableOps[0]);
-  scheduleableOps = scheduler.getScheduleableOps();
+  scheduleableOps = scheduler.getSchedulableOps();
   ASSERT_EQ(scheduleableOps.size(), 1);
 
   scheduler.scheduleOp(scheduleableOps[0]);
-  scheduleableOps = scheduler.getScheduleableOps();
+  scheduleableOps = scheduler.getSchedulableOps();
   ASSERT_EQ(scheduleableOps.size(), 1);
 
   scheduler.scheduleOp(scheduleableOps[0]);


### PR DESCRIPTION
Three fold change in this commit:
1. Allow sharding join nodes in fork-join structure.
2. Change scheduler to prioritize "shorter" branches first. This will enabled us create longer chains including join nodes.
3. Fix connections after creating spill to dram op following join node. This node is followed by other chains and it's possible to skip reading from DRAM in some paths.

Piggyback: re-enable sharding of eltwise binary ops.

Related to https://github.com/tenstorrent/tt-mlir/issues/2276