### PR TITLE
clean up #include order in test/unittests

### DIFF
--- a/test/unittests/OpModel/TTNN/Conversion/TestConversion.cpp
+++ b/test/unittests/OpModel/TTNN/Conversion/TestConversion.cpp
@@ -3,11 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "OpModelFixture.h"
+
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/OpModel/TTNN/Conversion.h"
 
 #include "llvm/ADT/SmallVector.h"
-#include "gtest/gtest.h"
 
 class MlirToTtnnConversion : public OpModelFixture {};
 class Conversion : public OpModelFixture {};

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -4,15 +4,14 @@
 
 #include "OpModelFixture.h"
 
-#include "TTNNOpConstraints.h"
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/OpModel/TTNN/SingletonDeviceContext.h"
+#include "ttmlir/OpModel/TTNN/TTNNOpConstraints.h"
 #include "ttmlir/OpModel/TTNN/TTNNOpModel.h"
 
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Error.h"
-#include "gtest/gtest.h"
 
 #include <cstdint>
 #include <functional>

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -12,7 +12,6 @@
 
 #include "mlir/IR/AffineExpr.h"
 #include "llvm/ADT/SmallVector.h"
-#include "gtest/gtest.h"
 
 #include <cstdint>
 

--- a/test/unittests/OpModel/TTNN/OpModelFixture.h
+++ b/test/unittests/OpModel/TTNN/OpModelFixture.h
@@ -20,6 +20,7 @@
 #include "mlir/IR/MLIRContext.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
+
 #include "gtest/gtest.h"
 
 #include <algorithm>

--- a/test/unittests/Optimizer/TestGreedyL1InterleavedPolicy.cpp
+++ b/test/unittests/Optimizer/TestGreedyL1InterleavedPolicy.cpp
@@ -2,24 +2,22 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "mlir/IR/Value.h"
-#include "mlir/IR/ValueRange.h"
-#include "llvm/ADT/SmallVector.h"
-#include "gtest/gtest.h"
+#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
+#include "ttmlir/Dialect/TT/IR/Utils.h"
+#include "ttmlir/Dialect/TT/Transforms/Transforms.h"
+#include "ttmlir/Dialect/TTNN/Analysis/GreedyL1InterleavedPolicy.h"
+#include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNN.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/Value.h"
+#include "llvm/ADT/SmallVector.h"
 
-#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
-#include "ttmlir/Dialect/TT/IR/Utils.h"
-#include "ttmlir/Dialect/TT/Transforms/Transforms.h"
-#include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
-#include "ttmlir/Dialect/TTNN/IR/TTNN.h"
-#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
-
-#include "ttmlir/Dialect/TTNN/Analysis/GreedyL1InterleavedPolicy.h"
+#include "gtest/gtest.h"
 
 using namespace mlir::tt::ttnn;
 

--- a/test/unittests/Optimizer/TestLayoutAnalysis.cpp
+++ b/test/unittests/Optimizer/TestLayoutAnalysis.cpp
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <optional>
-
 #include "ttmlir/Dialect/TT/IR/TT.h"
 #include "ttmlir/Dialect/TT/Transforms/Transforms.h"
 #include "ttmlir/Dialect/TTNN/Analysis/AllPossibleLayoutsAnalysis.h"
@@ -24,7 +22,10 @@
 #include "mlir/IR/ValueRange.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
+
 #include "gtest/gtest.h"
+
+#include <optional>
 
 using namespace mlir::tt::ttnn;
 

--- a/test/unittests/Optimizer/TestOptimizerOverrides.cpp
+++ b/test/unittests/Optimizer/TestOptimizerOverrides.cpp
@@ -7,6 +7,7 @@
 #include "ttmlir/Dialect/TTNN/Utils/OptimizerOverrides.h"
 
 #include "llvm/Support/CommandLine.h"
+
 #include "gtest/gtest.h"
 
 using namespace mlir::tt::ttnn;

--- a/test/unittests/Optimizer/TestShardSolver.cpp
+++ b/test/unittests/Optimizer/TestShardSolver.cpp
@@ -18,6 +18,7 @@
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Error.h"
+
 #include "gtest/gtest.h"
 
 using namespace mlir::tt::ttnn;

--- a/test/unittests/Support/LoggerTest.cpp
+++ b/test/unittests/Support/LoggerTest.cpp
@@ -6,6 +6,7 @@
 
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
+
 #include "gtest/gtest.h"
 
 #include <cstdlib>

--- a/test/unittests/TTNNToEmitC/TestEmitCConversion.cpp
+++ b/test/unittests/TTNNToEmitC/TestEmitCConversion.cpp
@@ -7,6 +7,7 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/MLIRContext.h"
+
 #include "gtest/gtest.h"
 
 #include <limits>

--- a/test/unittests/TestScheduler/TestScheduler.cpp
+++ b/test/unittests/TestScheduler/TestScheduler.cpp
@@ -2,33 +2,27 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <random>
-
-#include "mlir/IR/Attributes.h"
-#include "mlir/IR/BuiltinAttributes.h"
-#include "mlir/IR/Value.h"
-#include "mlir/IR/ValueRange.h"
-#include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/SmallVector.h"
-#include "llvm/ADT/StringRef.h"
-#include "gtest/gtest.h"
+#include "ttmlir/Dialect/TT/IR/TT.h"
+#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
+#include "ttmlir/Dialect/TT/Transforms/Transforms.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIR.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIROpsInterfaces.h"
+#include "ttmlir/Scheduler/Scheduler.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/OperationSupport.h"
+#include "mlir/IR/Value.h"
 #include "mlir/IR/Verifier.h"
+#include "llvm/ADT/SmallVector.h"
 
-#include "ttmlir/Dialect/TT/IR/TT.h"
-#include "ttmlir/Dialect/TT/Transforms/Transforms.h"
-#include "ttmlir/Dialect/TTIR/IR/TTIR.h"
-#include "ttmlir/Scheduler/Scheduler.h"
+#include "gtest/gtest.h"
 
-#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
-#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
-#include "ttmlir/Dialect/TTIR/IR/TTIROpsInterfaces.h"
+#include <random>
 
 using namespace mlir::tt;
 


### PR DESCRIPTION
### Problem description
`"gtest/gtest.h"` was included previously in an inconsistent manner throughout the unit testsuites, this PR attempts to clean things up a bit.

### What's changed
- gtest is treated as a "3rd party" include, but as a separate include group from "llvm"/"mlir", to make the source file stand out as a unit test implementation
- some redundant and unused includes removed
- some include groups that were unordered were merged and sorted
