### PR TITLE
D2M: Multi Core MM Fixes (nsmith/blocking0 base)

### DIFF
--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -809,7 +809,17 @@ def TTKernel_MyYOp : TTKernel_Op<"my_y"> {
 def TTKernel_GetNocMulticastAddrOp : TTKernel_Op<"get_noc_multicast_addr"> {
   let summary = "GetNocMulticastAddr";
   let description = [{
-    GetNocMulticastAddr
+    Default tt-metal get_noc_multicast_addr
+  }];
+
+  let arguments = (ins IndexLike:$noc_x_start, IndexLike:$noc_y_start, IndexLike:$noc_x_end, IndexLike:$noc_y_end, AnyTypeOf<[I32, TTKernel_L1Addr, TTKernel_Semaphore]>:$addr, Optional<I8>:$noc);
+  let results = (outs TTKernel_NocAddr:$mcastNocAddr);
+}
+
+def TTKernel_ExperimentalGetNocMulticastAddrOp : TTKernel_Op<"experimental::get_noc_multicast_addr"> {
+  let summary = "Experimental GetNocMulticastAddr";
+  let description = [{
+    Default tt-metal get_noc_multicast_addr, but flips mcast start and end coordinates on NOC1.
   }];
 
   let arguments = (ins IndexLike:$noc_x_start, IndexLike:$noc_y_start, IndexLike:$noc_x_end, IndexLike:$noc_y_end, AnyTypeOf<[I32, TTKernel_L1Addr, TTKernel_Semaphore]>:$addr, Optional<I8>:$noc);

--- a/include/ttmlir/Target/TTKernel/LLKs/CMakeLists.txt
+++ b/include/ttmlir/Target/TTKernel/LLKs/CMakeLists.txt
@@ -5,6 +5,7 @@ include(GenerateRawStringHeader)
 set(LLK_HEADERS
     ${CMAKE_SOURCE_DIR}/include/ttmlir/Target/TTKernel/LLKs/experimental_tilize_llks.h
     ${CMAKE_SOURCE_DIR}/include/ttmlir/Target/TTKernel/LLKs/experimental_untilize_llks.h
+    ${CMAKE_SOURCE_DIR}/include/ttmlir/Target/TTKernel/LLKs/experimental_dataflow_api.h
 )
 
 # Set the output directory for generated headers

--- a/include/ttmlir/Target/TTKernel/LLKs/experimental_dataflow_api.h
+++ b/include/ttmlir/Target/TTKernel/LLKs/experimental_dataflow_api.h
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_TARGET_TTKERNEL_LLKS_EXPERIMENTAL_DATAFLOW_API_H
+#define TTMLIR_TARGET_TTKERNEL_LLKS_EXPERIMENTAL_DATAFLOW_API_H
+
+namespace experimental {
+
+FORCE_INLINE
+std::uint64_t
+get_noc_multicast_addr(std::uint32_t noc_x_start, std::uint32_t noc_y_start,
+                       std::uint32_t noc_x_end, std::uint32_t noc_y_end,
+                       std::uint32_t addr, uint8_t noc = noc_index) {
+  /*
+      Get an encoding which contains tensix core and address you want to
+      read from/write to via the noc
+  */
+  if (noc) {
+    // noc 1
+    return NOC_MULTICAST_ADDR(
+        DYNAMIC_NOC_X(noc, noc_x_end), DYNAMIC_NOC_Y(noc, noc_y_end),
+        DYNAMIC_NOC_X(noc, noc_x_start), DYNAMIC_NOC_Y(noc, noc_y_start), addr);
+  } else {
+    // noc 0
+    return NOC_MULTICAST_ADDR(
+        DYNAMIC_NOC_X(noc, noc_x_start), DYNAMIC_NOC_Y(noc, noc_y_start),
+        DYNAMIC_NOC_X(noc, noc_x_end), DYNAMIC_NOC_Y(noc, noc_y_end), addr);
+  }
+}
+
+} // namespace experimental
+
+#endif

--- a/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
+++ b/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
@@ -152,8 +152,7 @@ public:
     auto outCB = getOutCB(rewriter, op);
     auto storeIdx = op.getIndices().front();
     rewriter.replaceOpWithNewOp<ttkernel::PackTileOp>(
-        op, dst, outCB, storeIdx,
-        rewriter.getBoolAttr(true));
+        op, dst, outCB, storeIdx, rewriter.getBoolAttr(true));
 
     return success();
   };
@@ -494,9 +493,10 @@ public:
             op.getLoc(), op.getMcastShape()[0], op.getMcastShape()[1]);
         auto numDests = rewriter.create<arith::IndexCastOp>(
             op.getLoc(), rewriter.getI32Type(), numDestsIdx);
-        auto mcastAddr = rewriter.create<ttkernel::GetNocMulticastAddrOp>(
-            op.getLoc(), virtX, virtY, mcastEndX, mcastEndY, dstL1Start,
-            nullptr);
+        auto mcastAddr =
+            rewriter.create<ttkernel::ExperimentalGetNocMulticastAddrOp>(
+                op.getLoc(), virtX, virtY, mcastEndX, mcastEndY, dstL1Start,
+                nullptr);
         if (adaptor.getSrc() == adaptor.getDst()) {
           // If src and dst refer to the same memref, we do not loopback mcast
           // Dests are one less because the sender core is not included
@@ -840,9 +840,10 @@ public:
           op.getLoc(), op.getMcastShape()[0], op.getMcastShape()[1]);
       Value numDests = rewriter.create<arith::IndexCastOp>(
           op.getLoc(), rewriter.getI32Type(), numDestsIdx);
-      auto mcastAddr = rewriter.create<ttkernel::GetNocMulticastAddrOp>(
-          op.getLoc(), virtX, virtY, mcastEndX, mcastEndY, semaphoreAddr,
-          nullptr);
+      auto mcastAddr =
+          rewriter.create<ttkernel::ExperimentalGetNocMulticastAddrOp>(
+              op.getLoc(), virtX, virtY, mcastEndX, mcastEndY, semaphoreAddr,
+              nullptr);
 
       auto semaphorePtr =
           rewriter.create<ttkernel::CastToL1PtrOp>(op.getLoc(), semaphoreAddr);

--- a/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
+++ b/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
@@ -710,23 +710,25 @@ class TTIRKernelFunctionArgsRewriter
 public:
   using OpConversionPattern<func::FuncOp>::OpConversionPattern;
 
+  static ThreadType getThreadType(func::FuncOp op) {
+    ttir::ThreadAttr threadAttr =
+        op->getAttrOfType<ttir::ThreadAttr>(ttir::ThreadAttr::name);
+    switch (threadAttr.getThreadType()) {
+    case ttir::ThreadType::Compute: {
+      return ThreadType::Compute;
+    }
+    case ttir::ThreadType::Datamovement: {
+      return ThreadType::Noc;
+    }
+    }
+  }
+
   static void convertFunctionAttrs(Builder &builder, func::FuncOp op,
                                    ArrayRef<ArgAttr> rtArgs,
                                    ArrayRef<ArgAttr> ctArgs) {
-    ttir::ThreadAttr threadAttr =
-        op->getAttrOfType<ttir::ThreadAttr>(ttir::ThreadAttr::name);
+
+    ThreadType threadType = getThreadType(op);
     op->removeAttr(ttir::ThreadAttr::name);
-    ThreadType threadType;
-    switch (threadAttr.getThreadType()) {
-    case ttir::ThreadType::Compute: {
-      threadType = ThreadType::Compute;
-      break;
-    }
-    case ttir::ThreadType::Datamovement: {
-      threadType = ThreadType::Noc;
-      break;
-    }
-    }
     op->setAttr(ThreadTypeAttr::name,
                 builder.getAttr<ThreadTypeAttr>(threadType));
     ArgSpecAttr::setArgSpec(op, builder.getAttr<ArgSpecAttr>(rtArgs, ctArgs));
@@ -760,6 +762,9 @@ public:
         ctArgSpecVector.push_back(
             rewriter.getAttr<ArgAttr>(ArgType::CBPort, arg.getArgNumber()));
       } else if (mlir::isa<SemaphoreType>(argType)) {
+        if (getThreadType(op) != ThreadType::Noc) {
+          continue;
+        }
         size_t ctArgIndex = ctArgSpecVector.size();
         auto semaphoreIndex = rewriter.create<GetCompileArgValOp>(
             op.getLoc(), rewriter.getI32Type(),

--- a/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
+++ b/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
@@ -500,10 +500,8 @@ public:
         if (adaptor.getSrc() == adaptor.getDst()) {
           // If src and dst refer to the same memref, we do not loopback mcast
           // Dests are one less because the sender core is not included
-          auto numDestsLessOne = rewriter.create<arith::SubIOp>(
-              op.getLoc(), numDests, i32(rewriter, op->getLoc(), 1));
           rewriter.create<ttkernel::NocAsyncWriteMulticastOp>(
-              op.getLoc(), srcL1Start, mcastAddr, transferSize, numDestsLessOne,
+              op.getLoc(), srcL1Start, mcastAddr, transferSize, numDests,
               nullptr, nullptr, nullptr);
         } else {
           // If src != dst, we loopback mcast

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -615,6 +615,8 @@ public:
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncWriteBarrierOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::GetNocMulticastAddrOp>,
         TTKernelToEmitCOpaqueRewriter<
+            ttkernel::ExperimentalGetNocMulticastAddrOp>,
+        TTKernelToEmitCOpaqueRewriter<
             ttkernel::NocAsyncWriteMulticastOnePacketOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::NocAsyncWriteMulticastOp>,
         TTKernelToEmitCOpaqueRewriter<

--- a/lib/Dialect/TTIR/Transforms/OptimizeTensorLayout.cpp
+++ b/lib/Dialect/TTIR/Transforms/OptimizeTensorLayout.cpp
@@ -173,8 +173,9 @@ struct TTIRGenericTensorLayoutRewriter : public OpRewritePattern<GenericOp> {
         MetalLayoutAttr viewMetalLayout;
         std::tie(view, viewMetalLayout) =
             blockedView(rewriter, op->getLoc(), operand.get(), newOperandType,
+                        metalLayout.getGrid(),
                         op.getIndexingMapsValue()[operand.getOperandNumber()],
-                        blockFactors);
+                        blockFactors, op.getIteratorTypesValue());
         rewriter.modifyOpInPlace(op, [&]() { operand.set(view); });
 
         if (dpsOp.isDpsInit(&operand)) {
@@ -214,26 +215,43 @@ struct TTIRGenericTensorLayoutRewriter : public OpRewritePattern<GenericOp> {
 
   static std::pair<Value, MetalLayoutAttr>
   blockedView(PatternRewriter &rewriter, Location loc, Value tensor,
-              RankedTensorType newOperandType, AffineMap indexingMap,
-              ArrayRef<int64_t> blockFactors) {
-    auto emptyOp = rewriter.create<EmptyOp>(loc, newOperandType);
+              RankedTensorType newTensorType, GridAttr computeGrid,
+              AffineMap indexingMap, ArrayRef<int64_t> blockFactors,
+              SmallVector<IteratorType> iteratorType) {
+    auto emptyOp = rewriter.create<EmptyOp>(loc, newTensorType);
     auto toLayoutOp =
         rewriter.create<ToLayoutOp>(loc, tensor, emptyOp.getResult());
-    MetalLayoutAttr metalLayout =
-        mlir::cast<MetalLayoutAttr>(newOperandType.getEncoding());
-    SmallVector<int64_t> blockShape = indexingMap.compose(blockFactors);
-    for (auto [i, dim] : llvm::enumerate(metalLayout.getGrid().getShape())) {
-      blockShape[i] *= dim;
+
+    auto tensorType = mlir::cast<RankedTensorType>(tensor.getType());
+    auto tensorLayout = mlir::cast<MetalLayoutAttr>(tensorType.getEncoding());
+    SmallVector<int64_t> numBlocks = indexingMap.compose(blockFactors);
+
+    // Map iterator types according to the affine map
+    // For example: (d0, d1, d2) -> (d0, d2) with [parallel, parallel,
+    // reduction] should give [parallel, reduction]
+    SmallVector<IteratorType> mappedIteratorTypes;
+
+    // Get the results of the indexing map
+    for (auto expr : indexingMap.getResults()) {
+      // Check if this is a dimension expression
+      if (auto dimExpr = mlir::dyn_cast<mlir::AffineDimExpr>(expr)) {
+        mappedIteratorTypes.push_back(iteratorType[dimExpr.getPosition()]);
+      }
     }
-    MetalLayoutAttr viewLayout = metalLayout.withGrid(blockShape);
+
+    for (auto [i, dim] : llvm::enumerate(computeGrid.getShape())) {
+      int multiple = mappedIteratorTypes[i] == IteratorType::Parallel ? dim : 1;
+      numBlocks[i] *= multiple;
+    }
+
+    MetalLayoutAttr viewLayout = tensorLayout.withGrid(numBlocks);
     return std::make_pair(
         rewriter
             .create<ViewLayoutOp>(
                 loc,
-                RankedTensorType::get(newOperandType.getShape(),
-                                      newOperandType.getElementType(),
-                                      viewLayout),
-                toLayoutOp.getResult(0))
+                RankedTensorType::get(tensorType.getShape(),
+                                      tensorType.getElementType(), viewLayout),
+                toLayoutOp->getResult(0))
             .getResult(),
         viewLayout);
   }

--- a/lib/Target/TTKernel/TTKernelToCpp.cpp
+++ b/lib/Target/TTKernel/TTKernelToCpp.cpp
@@ -6,6 +6,7 @@
 
 #include "ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.h"
 
+#include "ttmlir/Target/TTKernel/LLKs/experimental_dataflow_api_generated.h"
 #include "ttmlir/Target/TTKernel/LLKs/experimental_tilize_llks_generated.h"
 #include "ttmlir/Target/TTKernel/LLKs/experimental_untilize_llks_generated.h"
 
@@ -42,6 +43,7 @@ public:
     if (threadType == ThreadType::Noc) {
       builder->create<emitc::IncludeOp>(loc, "dataflow_api.h",
                                         /*isStandard=*/false);
+      emitExperimentalLLKs();
     }
     if (threadType == ThreadType::Compute) {
       builder->create<emitc::IncludeOp>(loc, "llk_defs.h",
@@ -151,6 +153,13 @@ void dprint(Arg &&arg, ArgV&&... argv) {
           StringRef(experimental_untilize_llks_generated,
                     experimental_untilize_llks_generated_len);
       builder->create<emitc::VerbatimOp>(loc, experimentalUntilizeLLKs);
+    }
+
+    if (hasCall("experimental::get_noc_multicast_addr")) {
+      auto experimentalDataflowLLKs =
+          StringRef(experimental_dataflow_api_generated,
+                    experimental_dataflow_api_generated_len);
+      builder->create<emitc::VerbatimOp>(loc, experimentalDataflowLLKs);
     }
   }
 


### PR DESCRIPTION
### What's changed
- Adds experimental `get_noc_multicast_addr` API that flips start/end coords on noc1
- Prevents lowering of `get_semaphore` ops into TRISC kernels
- Changes to gather/mcast lowering (mostly off-by-1 issues with coordinates)
- Adds dprints to gather/mcast routine (we don't need to keep this)
- numBlocks is multiplied by grid dim only on parallel iterator dims

### Checklist
- [ ] New/Existing tests provide coverage for changes
