### PR TITLE
(nit): Update tt-explorer.md documentation

### DIFF
--- a/docs/src/tt-explorer.md
+++ b/docs/src/tt-explorer.md
@@ -10,7 +10,7 @@ TT-Explorer comes packaged as a tool in the `tt-mlir` repo.
     - `-DTT_RUNTIME_ENABLE_PERF_TRACE=ON -DTTMLIR_ENABLE_RUNTIME=ON -DTT_RUNTIME_DEBUG=ON`
 3. Build `explorer` target in `tt-mlir` using `cmake --build build -- explorer`
 5. Run `tt-explorer` in terminal to start tt-explorer instance. (Refer to CLI section in API for specifics)
-    - Note that tt-explorer requires [Pandas](https://pypi.org/project/pandas/) in addition to the `tt-mlir` [System Dependencies](https://docs.tenstorrent.com/tt-mlir/getting-started.html#system-dependencies).    
+    - Note that tt-explorer requires [Pandas](https://pypi.org/project/pandas/) in addition to the `tt-mlir` [System Dependencies](https://docs.tenstorrent.com/tt-mlir/getting-started.html#system-dependencies).
 6. Ensure server has started in `tt-explorer` shell instance (check for message below)
 ```sh
 Starting Model Explorer server at:

--- a/docs/src/tt-explorer.md
+++ b/docs/src/tt-explorer.md
@@ -9,8 +9,9 @@ TT-Explorer comes packaged as a tool in the `tt-mlir` repo.
 2. Ensure `tt-mlir` is built with atleast these flags:
     - `-DTT_RUNTIME_ENABLE_PERF_TRACE=ON -DTTMLIR_ENABLE_RUNTIME=ON -DTT_RUNTIME_DEBUG=ON`
 3. Build `explorer` target in `tt-mlir` using `cmake --build build -- explorer`
-4. Run `tt-explorer` in terminal to start tt-explorer instance. (Refer to CLI section in API for specifics)
-5. Ensure server has started in `tt-explorer` shell instance (check for message below)
+5. Run `tt-explorer` in terminal to start tt-explorer instance. (Refer to CLI section in API for specifics)
+    - Note that tt-explorer requires [Pandas](https://pypi.org/project/pandas/) in addition to the `tt-mlir` [System Dependencies](https://docs.tenstorrent.com/tt-mlir/getting-started.html#system-dependencies).    
+6. Ensure server has started in `tt-explorer` shell instance (check for message below)
 ```sh
 Starting Model Explorer server at:
 http://localhost:8080


### PR DESCRIPTION
Explained in title. 

@vprajapati-tt Can you comment on moving the Project Arch (high-level summary) before Quick Start? Seems more intuitive so the user can understand what the tool is before proceeding. 

Also the TT-Explorer page launched by `tt-explorer` says the following:
> Supported model formats: [TF](https://www.tensorflow.org/) (.pb, .pbtxt, .graphdef), [TFLite](https://www.tensorflow.org/lite) (.tflite), [TFJS](https://www.tensorflow.org/js) (.json), [JAX](https://www.tensorflow.org/guide/jax2tf) (.pb), [PyTorch ExportedProgram](https://github.com/google-ai-edge/model-explorer/wiki/2.-User-Guide#how-to-select-pytorch-models) (.pt2), MLIR (.mlir, .mlirbc).

But it sounds like we can support .ttnn files as well?