### PR TITLE
Changed the folding patterns of all_reduce 

### DIFF
--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -2110,19 +2110,11 @@ mlir::tt::ttnn::ReduceScatterOp::fold(FoldAdaptor adaptor) {
   llvm::SmallVector<int64_t> meshShape{device.getMeshShape()};
   // AllReduce Op is semantically meaningless when gathering across a single
   // mesh device.
-  if (meshShape.empty() || meshShape[getClusterAxis()] != 1) {
-    return {};
+  if (!meshShape.empty() && meshShape[getClusterAxis()] == 1) {
+    return getInput();
   }
-  // The input and output shapes must be identical in order to fold this op as
-  // a no-op.
-  llvm::ArrayRef<int64_t> inputShape = getInput().getType().getShape();
-  llvm::ArrayRef<int64_t> outputShape = getResult().getType().getShape();
-  if (inputShape != outputShape) {
-    return {};
-  }
-  emitWarning() << "Removing this CCL op because performing a CCL operation "
-                   "on a single mesh device is semantically meaningless.";
-  return getInput();
+
+  return {};
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
The folding pattern of the TTNN all_reduce op was used if the shapes of the input and output were the same. In a general case, this operation should still execute, so erasing that part.