### PR TITLE
add constraint APIs for MaximumOp and MinimumOp

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -619,7 +619,9 @@ def TTNN_BitwiseXorOp : TTNN_ElementwiseBinaryOp<"bitwise_xor"> {
     }];
 }
 
-def TTNN_MaximumOp :  TTNN_ElementwiseBinaryOp<"maximum"> {
+def TTNN_MaximumOp :  TTNN_ElementwiseBinaryOp<"maximum",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
     let summary = "Eltwise maximum OP.";
     let description = [{
       Calculates maximum of input tensors' values element-wise and stores result in output tensor.
@@ -631,7 +633,9 @@ def TTNN_MaximumOp :  TTNN_ElementwiseBinaryOp<"maximum"> {
     }];
 }
 
-def TTNN_MinimumOp :  TTNN_ElementwiseBinaryOp<"minimum"> {
+def TTNN_MinimumOp :  TTNN_ElementwiseBinaryOp<"minimum",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
     let summary = "Eltwise minimum OP.";
     let description = [{
       Calculates minimum of input tensors' values element-wise and stores result

--- a/include/ttmlir/OpModel/TTNN/MetalHeaders.h
+++ b/include/ttmlir/OpModel/TTNN/MetalHeaders.h
@@ -31,6 +31,7 @@ using IDevice = ::tt::tt_metal::IDevice;
 #include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
 #include "ttnn/operations/data_movement/transpose/transpose.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"
+#include "ttnn/operations/eltwise/binary/binary_composite.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"
 #include "ttnn/operations/eltwise/unary/unary_composite.hpp"

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -412,5 +412,47 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
              mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
 } // namespace SubtractOpInterface
 
+//===----------------------------------------------------------------------===//
+// Maximum
+//===----------------------------------------------------------------------===//
+namespace MaximumOpInterface {
+llvm::Expected<OpConstraints>
+getOpConstraints(GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                 llvm::ArrayRef<int64_t> inputShapeB,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                 llvm::ArrayRef<int64_t> outputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+
+llvm::Expected<size_t>
+getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+             llvm::ArrayRef<int64_t> inputShapeB,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+             llvm::ArrayRef<int64_t> outputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+} // namespace MaximumOpInterface
+
+//===----------------------------------------------------------------------===//
+// Minimum
+//===----------------------------------------------------------------------===//
+namespace MinimumOpInterface {
+llvm::Expected<OpConstraints>
+getOpConstraints(GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                 llvm::ArrayRef<int64_t> inputShapeB,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                 llvm::ArrayRef<int64_t> outputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+
+llvm::Expected<size_t>
+getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+             llvm::ArrayRef<int64_t> inputShapeB,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+             llvm::ArrayRef<int64_t> outputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+} // namespace MinimumOpInterface
+
 } // namespace mlir::tt::op_model::ttnn
 #endif // TTMLIR_OPMODEL_TTNN_TTNNOPMODEL_H

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -45,6 +45,53 @@ convertReductionArg(std::optional<mlir::ArrayAttr> arrayOpt) {
 
 } // namespace detail
 
+using BinaryOpConstraintsFunc =
+    std::function<llvm::Expected<op_model::ttnn::OpConstraints>(
+        GridAttr, llvm::ArrayRef<int64_t>, mlir::tt::ttnn::TTNNLayoutAttr,
+        llvm::ArrayRef<int64_t>, mlir::tt::ttnn::TTNNLayoutAttr,
+        llvm::ArrayRef<int64_t>, mlir::tt::ttnn::TTNNLayoutAttr)>;
+
+using BinaryOpRuntimeFunc = std::function<llvm::Expected<size_t>(
+    llvm::ArrayRef<int64_t>, mlir::tt::ttnn::TTNNLayoutAttr,
+    llvm::ArrayRef<int64_t>, mlir::tt::ttnn::TTNNLayoutAttr,
+    llvm::ArrayRef<int64_t>, mlir::tt::ttnn::TTNNLayoutAttr)>;
+
+template <typename OpT>
+llvm::Expected<op_model::ttnn::OpConstraints>
+getBinaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
+                       const OpConfig &opConfig,
+                       BinaryOpConstraintsFunc getConstraintsFunc) {
+  assert(inputs.size() == 2);
+
+  const auto inputShapeA = op.getLhs().getType().getShape();
+  const auto inputShapeB = op.getRhs().getType().getShape();
+  const auto outputShape = op.getType().getShape();
+
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(op.getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  GridAttr deviceGrid = lookupDevice(op.getOperation()).getWorkerGrid();
+
+  return getConstraintsFunc(deviceGrid, inputShapeA, inputs[0], inputShapeB,
+                            inputs[1], outputShape, opConfig.outputLayout);
+}
+
+template <typename OpT>
+llvm::Expected<size_t>
+getBinaryOpRuntime(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
+                   const OpConfig &opConfig,
+                   BinaryOpRuntimeFunc getRuntimeFunc) {
+  assert(inputs.size() == 2);
+
+  const auto inputShapeA = op.getLhs().getType().getShape();
+  const auto inputShapeB = op.getRhs().getType().getShape();
+  const auto outputShape = op.getType().getShape();
+
+  return getRuntimeFunc(inputShapeA, inputs[0], inputShapeB, inputs[1],
+                        outputShape, opConfig.outputLayout);
+}
+
 //===----------------------------------------------------------------------===//
 // ReluOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
@@ -163,38 +210,16 @@ SigmoidOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 llvm::Expected<op_model::ttnn::OpConstraints>
 AddOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                         const OpConfig &opConfig) {
-  assert(inputs.size() == 2);
-
-  const auto inputShapeA = getLhs().getType().getShape();
-  const auto inputShapeB = getRhs().getType().getShape();
-
-  const auto outputShape = getType().getShape();
-
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
-
-  return op_model::ttnn::AddOpInterface::getOpConstraints(
-      deviceGrid, inputShapeA, inputs[0], inputShapeB, inputs[1], outputShape,
-
-      opConfig.outputLayout);
+  return getBinaryOpConstraints(
+      *this, inputs, opConfig,
+      op_model::ttnn::AddOpInterface::getOpConstraints);
 }
 
 llvm::Expected<size_t>
 AddOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                     const OpConfig &opConfig) {
-  assert(inputs.size() == 2);
-
-  const auto inputShapeA = getLhs().getType().getShape();
-  const auto inputShapeB = getRhs().getType().getShape();
-
-  const auto outputShape = getType().getShape();
-
-  return op_model::ttnn::AddOpInterface::getOpRuntime(
-      inputShapeA, inputs[0], inputShapeB, inputs[1], outputShape,
-      opConfig.outputLayout);
+  return getBinaryOpRuntime(*this, inputs, opConfig,
+                            op_model::ttnn::AddOpInterface::getOpRuntime);
 }
 
 //===----------------------------------------------------------------------===//
@@ -462,38 +487,16 @@ MatmulOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 llvm::Expected<op_model::ttnn::OpConstraints>
 MultiplyOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                              const OpConfig &opConfig) {
-  assert(inputs.size() == 2);
-
-  const auto inputShapeA = getLhs().getType().getShape();
-  const auto inputShapeB = getRhs().getType().getShape();
-
-  const auto outputShape = getType().getShape();
-
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
-
-  return op_model::ttnn::MultiplyOpInterface::getOpConstraints(
-      deviceGrid, inputShapeA, inputs[0], inputShapeB, inputs[1], outputShape,
-
-      opConfig.outputLayout);
+  return getBinaryOpConstraints(
+      *this, inputs, opConfig,
+      op_model::ttnn::MultiplyOpInterface::getOpConstraints);
 }
 
 llvm::Expected<size_t>
 MultiplyOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                          const OpConfig &opConfig) {
-  assert(inputs.size() == 2);
-
-  const auto inputShapeA = getLhs().getType().getShape();
-  const auto inputShapeB = getRhs().getType().getShape();
-
-  const auto outputShape = getType().getShape();
-
-  return op_model::ttnn::MultiplyOpInterface::getOpRuntime(
-      inputShapeA, inputs[0], inputShapeB, inputs[1], outputShape,
-      opConfig.outputLayout);
+  return getBinaryOpRuntime(*this, inputs, opConfig,
+                            op_model::ttnn::MultiplyOpInterface::getOpRuntime);
 }
 
 //===----------------------------------------------------------------------===//
@@ -740,37 +743,54 @@ UpsampleOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 llvm::Expected<op_model::ttnn::OpConstraints>
 SubtractOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                              const OpConfig &opConfig) {
-  assert(inputs.size() == 2);
-
-  const auto inputShapeA = getLhs().getType().getShape();
-  const auto inputShapeB = getRhs().getType().getShape();
-
-  const auto outputShape = getType().getShape();
-
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
-
-  return op_model::ttnn::SubtractOpInterface::getOpConstraints(
-      deviceGrid, inputShapeA, inputs[0], inputShapeB, inputs[1], outputShape,
-      opConfig.outputLayout);
+  return getBinaryOpConstraints(
+      *this, inputs, opConfig,
+      op_model::ttnn::SubtractOpInterface::getOpConstraints);
 }
 
 llvm::Expected<size_t>
 SubtractOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                          const OpConfig &opConfig) {
-  assert(inputs.size() == 2);
+  return getBinaryOpRuntime(*this, inputs, opConfig,
+                            op_model::ttnn::SubtractOpInterface::getOpRuntime);
+}
 
-  const auto inputShapeA = getLhs().getType().getShape();
-  const auto inputShapeB = getRhs().getType().getShape();
+//===----------------------------------------------------------------------===//
+// MaximumOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
 
-  const auto outputShape = getType().getShape();
+llvm::Expected<op_model::ttnn::OpConstraints>
+MaximumOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                            const OpConfig &opConfig) {
+  return getBinaryOpConstraints(
+      *this, inputs, opConfig,
+      op_model::ttnn::MaximumOpInterface::getOpConstraints);
+}
 
-  return op_model::ttnn::SubtractOpInterface::getOpRuntime(
-      inputShapeA, inputs[0], inputShapeB, inputs[1], outputShape,
-      opConfig.outputLayout);
+llvm::Expected<size_t>
+MaximumOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                        const OpConfig &opConfig) {
+  return getBinaryOpRuntime(*this, inputs, opConfig,
+                            op_model::ttnn::MaximumOpInterface::getOpRuntime);
+}
+
+//===----------------------------------------------------------------------===//
+// MinimumOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::ttnn::OpConstraints>
+MinimumOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                            const OpConfig &opConfig) {
+  return getBinaryOpConstraints(
+      *this, inputs, opConfig,
+      op_model::ttnn::MinimumOpInterface::getOpConstraints);
+}
+
+llvm::Expected<size_t>
+MinimumOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                        const OpConfig &opConfig) {
+  return getBinaryOpRuntime(*this, inputs, opConfig,
+                            op_model::ttnn::MinimumOpInterface::getOpRuntime);
 }
 
 } // namespace mlir::tt::ttnn

--- a/lib/OpModel/TTNN/SingletonDeviceContext.cpp
+++ b/lib/OpModel/TTNN/SingletonDeviceContext.cpp
@@ -14,8 +14,8 @@ namespace mlir::tt::op_model::ttnn {
 // getOpRuntime() uses trace capture to run and measure the runtime of an op.
 // This requires the device to be opened with sufficient trace region size. This
 // number is currently set based on manual testing of supported ops to
-// accommodate the highest required trace buffer size (304128B)
-static constexpr size_t opModelDefaultTraceRegionSize = 350000;
+// accommodate the highest required trace buffer size (384000B)
+static constexpr size_t opModelDefaultTraceRegionSize = 400000;
 
 SingletonDeviceContext::SingletonDeviceContext(const size_t traceRegionSize) {
   openDevice(traceRegionSize);

--- a/lib/OpModel/TTNN/SingletonDeviceContext.cpp
+++ b/lib/OpModel/TTNN/SingletonDeviceContext.cpp
@@ -14,8 +14,8 @@ namespace mlir::tt::op_model::ttnn {
 // getOpRuntime() uses trace capture to run and measure the runtime of an op.
 // This requires the device to be opened with sufficient trace region size. This
 // number is currently set based on manual testing of supported ops to
-// accommodate the highest required trace buffer size (384000B)
-static constexpr size_t opModelDefaultTraceRegionSize = 400000;
+// accommodate the highest required trace buffer size (400384B)
+static constexpr size_t opModelDefaultTraceRegionSize = 500000;
 
 SingletonDeviceContext::SingletonDeviceContext(const size_t traceRegionSize) {
   openDevice(traceRegionSize);

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -1836,4 +1836,74 @@ SubtractOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
+//===----------------------------------------------------------------------===//
+// MaximumOp
+//===----------------------------------------------------------------------===//
+llvm::Expected<OpConstraints> MaximumOpInterface::getOpConstraints(
+    GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+    llvm::ArrayRef<int64_t> outputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  return getEltwiseBinaryOpConstraints(
+      "MaximumOpInterface", ::ttnn::maximum, deviceGrid, inputShapeA,
+      inputLayoutA, inputShapeB, inputLayoutB, outputShape, outputLayout);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t>
+MaximumOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
+                                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                                 llvm::ArrayRef<int64_t> inputShapeB,
+                                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                                 llvm::ArrayRef<int64_t> outputShape,
+                                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  return getEltwiseBinaryOpRuntime("MaximumOpInterface", ::ttnn::maximum,
+                                   inputShapeA, inputLayoutA, inputShapeB,
+                                   inputLayoutB, outputShape, outputLayout);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
+// MinimumOp
+//===----------------------------------------------------------------------===//
+llvm::Expected<OpConstraints> MinimumOpInterface::getOpConstraints(
+    GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+    llvm::ArrayRef<int64_t> outputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  return getEltwiseBinaryOpConstraints(
+      "MinimumOpInterface", ::ttnn::minimum, deviceGrid, inputShapeA,
+      inputLayoutA, inputShapeB, inputLayoutB, outputShape, outputLayout);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t>
+MinimumOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
+                                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                                 llvm::ArrayRef<int64_t> inputShapeB,
+                                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                                 llvm::ArrayRef<int64_t> outputShape,
+                                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  return getEltwiseBinaryOpRuntime("MinimumOpInterface", ::ttnn::minimum,
+                                   inputShapeA, inputLayoutA, inputShapeB,
+                                   inputLayoutB, outputShape, outputLayout);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
 } // namespace mlir::tt::op_model::ttnn

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -608,7 +608,7 @@ TEST_F(OpModelTest, Typecast) {
 }
 
 // ==== Binary Eltwise Ops Starts ====
-enum class BinaryEltwiseOpType { Add, Mul, Subtract };
+enum class BinaryEltwiseOpType { Add, Mul, Subtract, Maximum, Minimum };
 class OpModelBinaryEltwiseParam : public OpModelTest,
                                   public testing::WithParamInterface<
                                       std::tuple<BinaryEltwiseOpType,
@@ -627,6 +627,8 @@ protected:
           {BinaryEltwiseOpType::Add, AddOpInterface::getOpRuntime},
           {BinaryEltwiseOpType::Mul, MultiplyOpInterface::getOpRuntime},
           {BinaryEltwiseOpType::Subtract, SubtractOpInterface::getOpRuntime},
+          {BinaryEltwiseOpType::Maximum, MaximumOpInterface::getOpRuntime},
+          {BinaryEltwiseOpType::Minimum, MinimumOpInterface::getOpRuntime},
       };
 
   std::map<
@@ -640,6 +642,8 @@ protected:
           {BinaryEltwiseOpType::Mul, MultiplyOpInterface::getOpConstraints},
           {BinaryEltwiseOpType::Subtract,
            SubtractOpInterface::getOpConstraints},
+          {BinaryEltwiseOpType::Maximum, MaximumOpInterface::getOpConstraints},
+          {BinaryEltwiseOpType::Minimum, MinimumOpInterface::getOpConstraints},
       };
 
   void RunTest() {
@@ -808,6 +812,16 @@ INSTANTIATE_TEST_SUITE_P(MulTests, OpModelBinaryEltwiseParam,
 INSTANTIATE_TEST_SUITE_P(
     SubtractTests, OpModelBinaryEltwiseParam,
     generateBinaryEltwiseParams(BinaryEltwiseOpType::Subtract,
+                                binaryEltwiseParams));
+
+INSTANTIATE_TEST_SUITE_P(
+    MaximumTests, OpModelBinaryEltwiseParam,
+    generateBinaryEltwiseParams(BinaryEltwiseOpType::Maximum,
+                                binaryEltwiseParams));
+
+INSTANTIATE_TEST_SUITE_P(
+    MinimumTests, OpModelBinaryEltwiseParam,
+    generateBinaryEltwiseParams(BinaryEltwiseOpType::Minimum,
                                 binaryEltwiseParams));
 
 // ==== Binary Eltwise Ops Ends ====

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -357,7 +357,6 @@ TEST_F(OpModelBase, MultiplyOpInterface) {
 }
 
 TEST_F(OpModelBase, MatmulOpInterface) {
-  GTEST_SKIP_("Skipping since this test hangs!");
   // create MatmulOp
   llvm::SmallVector<int64_t> tensorShapeA = {2048, 1024};
   llvm::SmallVector<int64_t> tensorShapeB = {1024, 2048};

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -357,6 +357,7 @@ TEST_F(OpModelBase, MultiplyOpInterface) {
 }
 
 TEST_F(OpModelBase, MatmulOpInterface) {
+  GTEST_SKIP_("Skipping since this test hangs!");
   // create MatmulOp
   llvm::SmallVector<int64_t> tensorShapeA = {2048, 1024};
   llvm::SmallVector<int64_t> tensorShapeB = {1024, 2048};
@@ -1146,6 +1147,126 @@ TEST_F(OpModelBase, SubtractOpInterfaceNullOutput) {
   OpModel backend = dyn_cast<OpModel>(sub.getOperation());
   auto constraintsExp = backend.getOpConstraints(
       getInputLayouts(sub), OpConfig(/*outputLayout=*/nullptr));
+
+  ASSERT_TRUE(static_cast<bool>(constraintsExp));
+  const auto &[cbSize, peakSize, outputSize, outputLayout] =
+      constraintsExp.get();
+  EXPECT_EQ(cbSize, 12288);
+  EXPECT_EQ(peakSize, 2048);
+  EXPECT_EQ(outputSize, 2048);
+
+  ASSERT_TRUE(outputLayout);
+  EXPECT_EQ(outputLayout.getLayout(), Layout::Tile);
+  EXPECT_TRUE(outputLayout.hasInterleavedL1TensorMemoryLayout());
+}
+
+TEST_F(OpModelBase, MaximumOpInterface) {
+  // create MaximumOp
+  llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
+
+  auto input1 = createEmptyTensor(tensorShape);
+  auto input2 = createEmptyTensor(tensorShape);
+  auto outputType = createRankedTensorType(tensorShape);
+
+  auto max = builder.create<MaximumOp>(builder.getUnknownLoc(), outputType,
+                                       ::mlir::ValueRange{input1, input2});
+
+  // test MaximumOp interface
+  auto constraintsExp = getOpConstraints(max.getOperation());
+  if (constraintsExp) {
+    auto l1 = constraintsExp.get();
+    const auto [cbSize, peakSize, outputSize, outputLayout] = l1;
+    EXPECT_EQ(cbSize, 12288);
+    EXPECT_EQ(peakSize, 2048);
+    EXPECT_EQ(outputSize, 2048);
+  } else {
+    FAIL() << "Missing L1 constraints; Error="
+           << llvm::toString(constraintsExp.takeError()) << std::endl;
+  }
+
+  auto runtimeExp = getOpRuntime(max.getOperation());
+  if (runtimeExp) {
+    EXPECT_TRUE(runtimeExp.get() > 0);
+  } else {
+    FAIL() << llvm::toString(runtimeExp.takeError());
+  }
+}
+
+TEST_F(OpModelBase, MaximumOpInterfaceNullOutput) {
+  // create MaximumOp
+  llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
+
+  auto input1 = createEmptyTensor(tensorShape);
+  auto input2 = createEmptyTensor(tensorShape);
+  auto outputType = createRankedTensorType(tensorShape);
+
+  auto max = builder.create<MaximumOp>(builder.getUnknownLoc(), outputType,
+                                       ::mlir::ValueRange{input1, input2});
+
+  // test MaximumOp interface
+  OpModel backend = dyn_cast<OpModel>(max.getOperation());
+  auto constraintsExp = backend.getOpConstraints(
+      getInputLayouts(max), OpConfig(/*outputLayout=*/nullptr));
+
+  ASSERT_TRUE(static_cast<bool>(constraintsExp));
+  const auto &[cbSize, peakSize, outputSize, outputLayout] =
+      constraintsExp.get();
+  EXPECT_EQ(cbSize, 12288);
+  EXPECT_EQ(peakSize, 2048);
+  EXPECT_EQ(outputSize, 2048);
+
+  ASSERT_TRUE(outputLayout);
+  EXPECT_EQ(outputLayout.getLayout(), Layout::Tile);
+  EXPECT_TRUE(outputLayout.hasInterleavedL1TensorMemoryLayout());
+}
+
+TEST_F(OpModelBase, MinimumOpInterface) {
+  // create MinimumOp
+  llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
+
+  auto input1 = createEmptyTensor(tensorShape);
+  auto input2 = createEmptyTensor(tensorShape);
+  auto outputType = createRankedTensorType(tensorShape);
+
+  auto min = builder.create<MinimumOp>(builder.getUnknownLoc(), outputType,
+                                       ::mlir::ValueRange{input1, input2});
+
+  // test MinimumOp interface
+  auto constraintsExp = getOpConstraints(min.getOperation());
+  if (constraintsExp) {
+    auto l1 = constraintsExp.get();
+    const auto [cbSize, peakSize, outputSize, outputLayout] = l1;
+    EXPECT_EQ(cbSize, 12288);
+    EXPECT_EQ(peakSize, 2048);
+    EXPECT_EQ(outputSize, 2048);
+  } else {
+    FAIL() << "Missing L1 constraints; Error="
+           << llvm::toString(constraintsExp.takeError()) << std::endl;
+  }
+
+  auto runtimeExp = getOpRuntime(min.getOperation());
+  if (runtimeExp) {
+    EXPECT_TRUE(runtimeExp.get() > 0);
+  } else {
+    FAIL() << llvm::toString(runtimeExp.takeError());
+  }
+}
+
+TEST_F(OpModelBase, MinimumOpInterfaceNullOutput) {
+  // create MinimumOp
+  llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
+
+  auto input1 = createEmptyTensor(tensorShape);
+  auto input2 = createEmptyTensor(tensorShape);
+  auto outputType = createRankedTensorType(tensorShape);
+
+  auto min = builder.create<MinimumOp>(builder.getUnknownLoc(), outputType,
+                                       ::mlir::ValueRange{input1, input2});
+
+  // test MinimumOp interface
+  OpModel backend = dyn_cast<OpModel>(min.getOperation());
+  auto constraintsExp = backend.getOpConstraints(
+      getInputLayouts(min), OpConfig(/*outputLayout=*/nullptr));
 
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
   const auto &[cbSize, peakSize, outputSize, outputLayout] =


### PR DESCRIPTION
### Ticket
#3639 

### Problem description
Missing support for constraint API for `ttnn::maximum`.

### What's changed
This PR:
- Adds constraint APIs for `MaximumOp`,
- Adds constraint APIs for `MinimumOp`,
- Commonizes some code in `TTNNOpModelInterface`.


### Checklist
- [X] New/Existing tests provide coverage for changes
