### PR TITLE
Prevent unintended typecast from uint32 to float32

### DIFF
--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -175,7 +175,7 @@ TTNNOperandsWorkaroundsFactory::createUpsampleOpOperandsWorkarounds() {
 
 // Factory method to create a set of workarounds for zeros op output operand.
 // ttnn::zeros does not support output dtype int32. If the output data type of
-// ttnn::zeros is int32, we override to uint32 and typecast separately.
+// ttnn::zeros is int32, we override to float32 and typecast separately.
 TTNNOperandsWorkarounds
 TTNNOperandsWorkaroundsFactory::createZerosOpOperandsWorkarounds(
     RankedTensorType outputType) {
@@ -184,7 +184,7 @@ TTNNOperandsWorkaroundsFactory::createZerosOpOperandsWorkarounds(
       elementTypeToDataType(outputType.getElementType());
   if (dataType == mlir::tt::DataType::Int32) {
     fullOpOutputWorkarounds.tensorDataTypeWorkaround =
-        mlir::tt::DataType::UInt32;
+        mlir::tt::DataType::Float32;
   }
   return wa::TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
       .addOutputOperandWorkaround(fullOpOutputWorkarounds);
@@ -195,7 +195,7 @@ TTNNOperandsWorkaroundsFactory::createZerosOpOperandsWorkarounds(
 // If the output of full is a 1D tensor and is tiled
 // we need to convert it to row major layout then tilize separately
 // ttnn::full does not support output dtype int32. If the output data type of
-// full is int32, we override to uint32 and typecast separately.
+// full is int32, we override to float32 and typecast separately.
 TTNNOperandsWorkarounds
 TTNNOperandsWorkaroundsFactory::createFullOpOperandsWorkarounds(
     RankedTensorType outputType) {
@@ -209,7 +209,7 @@ TTNNOperandsWorkaroundsFactory::createFullOpOperandsWorkarounds(
       elementTypeToDataType(outputType.getElementType());
   if (dataType == mlir::tt::DataType::Int32) {
     fullOpOutputWorkarounds.tensorDataTypeWorkaround =
-        mlir::tt::DataType::UInt32;
+        mlir::tt::DataType::Float32;
   }
   return wa::TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
       .addOutputOperandWorkaround(fullOpOutputWorkarounds);
@@ -375,7 +375,7 @@ TTNNOperandsWorkaroundsFactory::createWhereOpOperandsWorkarounds(
 }
 
 // Factory method to create a set of workarounds for reshape operation operands.
-// Reshape op only does not work with int32 - force to uint32 then typecast
+// Reshape op only does not work with int32 - force to float32 then typecast
 // separately.
 TTNNOperandsWorkarounds
 TTNNOperandsWorkaroundsFactory::createReshapeOpOperandsWorkarounds(

--- a/test/ttmlir/Dialect/TTNN/constant/positive/simple_constant_positive.mlir
+++ b/test/ttmlir/Dialect/TTNN/constant/positive/simple_constant_positive.mlir
@@ -20,7 +20,7 @@ module attributes {} {
     %0 = "ttir.constant"() <{value = dense<0> : tensor<64x128xi32>}> : () -> tensor<64x128xi32>
     // CHECK: %{{[0-9]+}} = "ttnn.full"
     // CHECK-SAME: fill_value = 0 : i32
-    // CHECK-SAME: -> tensor<64x128xui32
+    // CHECK-SAME: -> tensor<64x128xf32
     // CHECK: %{{[0-9]+}} = "ttnn.typecast"
     // CHECK-SAME: -> tensor<64x128xsi32
     return %0 : tensor<64x128xi32>
@@ -69,7 +69,7 @@ module attributes {} {
   func.func @test_full_int() -> tensor<64x128xi32> {
     // CHECK: %{{[0-9]+}} = "ttnn.full"
     // CHECK-SAME: fill_value = 1 : i32
-    // CHECK-SAME: -> tensor<64x128xui32
+    // CHECK-SAME: -> tensor<64x128xf32
     // CHECK: %{{[0-9]+}} = "ttnn.typecast"
     // CHECK-SAME: -> tensor<64x128xsi32
     %0 = "ttir.constant"() <{value = dense<1> : tensor<64x128xi32>}> : () -> tensor<64x128xi32>

--- a/test/ttmlir/Dialect/TTNN/quantization/simple_dequantize.mlir
+++ b/test/ttmlir/Dialect/TTNN/quantization/simple_dequantize.mlir
@@ -6,7 +6,7 @@ module {
     // CHECK: "ttnn.get_device"
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 0
-    // CHECK-SAME: -> tensor<1xui32,
+    // CHECK-SAME: -> tensor<1xf32,
     // CHECK: "ttnn.typecast"
     // CHECK-SAME: dtype = #tt.supportedDataTypes<si32>
     // CHECK-SAME: -> tensor<1xsi32,
@@ -32,7 +32,7 @@ module {
     // CHECK-SAME: -> tensor<3xf32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 0
-    // CHECK-SAME: -> tensor<3xui32,
+    // CHECK-SAME: -> tensor<3xf32,
     // CHECK: "ttnn.typecast"
     // CHECK-SAME: dtype = #tt.supportedDataTypes<si32>
     // CHECK-SAME: -> tensor<3xsi32,

--- a/test/ttmlir/Dialect/TTNN/quantization/simple_quantize.mlir
+++ b/test/ttmlir/Dialect/TTNN/quantization/simple_quantize.mlir
@@ -5,7 +5,7 @@ module {
     %0 = ttir.empty() : tensor<1x3x224x224x!quant.uniform<i32:f32, 2.000000e-02>>
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 0
-    // CHECK-SAME: -> tensor<1xui32,
+    // CHECK-SAME: -> tensor<1xf32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 2.000000e-02 : f32
     // CHECK-SAME: -> tensor<1xf32,
@@ -27,7 +27,7 @@ module {
     // CHECK-SAME: -> tensor<3xf32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 0
-    // CHECK-SAME: -> tensor<3xui32,
+    // CHECK-SAME: -> tensor<3xf32,
     // CHECK: "ttnn.quantize"
     // CHECK-SAME: axis = 1 : i32
     // CHECK-SAME: output_dtype = #tt.supportedDataTypes<si32>

--- a/test/ttmlir/Dialect/TTNN/quantization/simple_requantize.mlir
+++ b/test/ttmlir/Dialect/TTNN/quantization/simple_requantize.mlir
@@ -8,7 +8,7 @@ module {
     // CHECK-SAME: -> tensor<1xf32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 0 : i32
-    // CHECK-SAME: -> tensor<1xui32,
+    // CHECK-SAME: -> tensor<1xf32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 1.000000e-01 : f32
     // CHECK-SAME: -> tensor<1xf32,
@@ -32,7 +32,7 @@ module {
     // CHECK-SAME: -> tensor<3xf32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 0
-    // CHECK-SAME: -> tensor<3xui32,
+    // CHECK-SAME: -> tensor<3xf32,
     // CHECK: "ttnn.requantize"
     // CHECK-SAME: <{axis = 1 : i32, output_dtype = #tt.supportedDataTypes<si32>}
     // CHECK-SAME: tensor<1x3x320x320x!quant.uniform<i32:f32:1, {1.000000e-01,2.000000e-01,3.000000e-01}>,

--- a/test/ttmlir/Dialect/TTNN/simple_get_dimension_size.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_get_dimension_size.mlir
@@ -4,7 +4,7 @@ module attributes {} {
     %0 = "ttir.get_dimension_size"(%arg0) <{dimension = 1 : i32}> : (tensor<13x21x3xf32>) -> tensor<1xi32>
     // CHECK: [[VAL:%[0-9]+]] = "ttnn.full"(%{{[0-9]+}})
     // CHECK-SAME: fill_value = 21 : i32
-    // CHECK-SAME: -> tensor<1xui32
+    // CHECK-SAME: -> tensor<1xf32
     return %0 : tensor<1xi32>
   }
 }

--- a/test/ttmlir/Silicon/StableHLO/n150/Constant/constant_i32.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Constant/constant_i32.mlir
@@ -10,7 +10,7 @@ module @jit_constant attributes {} {
     // CHECK-LABEL: func.func public @test_int32_scalar
     // CHECK: ttnn.full
     // CHECK-SAME: fill_value = 3 : i32
-    // CHECK-SAME: -> tensor<1xui32
+    // CHECK-SAME: -> tensor<1xf32
     // CHECK: ttnn.typecast
     // CHECK-SAME: -> tensor<1xsi32
     %0 = stablehlo.constant dense<3> : tensor<i32>
@@ -21,7 +21,7 @@ module @jit_constant attributes {} {
     // CHECK-LABEL: func.func public @test_int32_scalar_empty
     // CHECK: ttnn.full
     // CHECK-SAME: fill_value = 0 : i32
-    // CHECK-SAME: -> tensor<1xui32
+    // CHECK-SAME: -> tensor<1xf32
     // CHECK: ttnn.typecast
     // CHECK-SAME: -> tensor<1xsi32
     %0 = stablehlo.constant dense<0> : tensor<i32>
@@ -32,7 +32,7 @@ module @jit_constant attributes {} {
     // CHECK-LABEL: func.func public @test_int32_empty
     // CHECK: ttnn.full
     // CHECK-SAME: fill_value = 0 : i32
-    // CHECK-SAME: -> tensor<64x128xui32
+    // CHECK-SAME: -> tensor<64x128xf32
     // CHECK: ttnn.typecast
     // CHECK-SAME: -> tensor<64x128xsi32
     %0 = stablehlo.constant dense<0> : tensor<64x128xi32>
@@ -43,7 +43,7 @@ module @jit_constant attributes {} {
     // CHECK-LABEL: func.func public @test_int32_splat
     // CHECK: ttnn.full
     // CHECK-SAME: fill_value = 3 : i32
-    // CHECK-SAME: -> tensor<64x128xui32
+    // CHECK-SAME: -> tensor<64x128xf32
     // CHECK: ttnn.typecast
     // CHECK-SAME: -> tensor<64x128xsi32
     %0 = stablehlo.constant dense<3> : tensor<64x128xi32>

--- a/test/ttmlir/Silicon/StableHLO/n150/Constant/constant_i64.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/Constant/constant_i64.mlir
@@ -10,7 +10,7 @@ module @jit_constant attributes {} {
     // CHECK-LABEL: func.func public @test_int64_scalar
     // CHECK: ttnn.full
     // CHECK-SAME: fill_value = 3 : i32
-    // CHECK-SAME: -> tensor<1xui32
+    // CHECK-SAME: -> tensor<1xf32
     // CHECK: ttnn.typecast
     // CHECK-SAME: -> tensor<1xsi32
     %0 = stablehlo.constant dense<3> : tensor<i64>
@@ -21,7 +21,7 @@ module @jit_constant attributes {} {
     // CHECK-LABEL: func.func public @test_int64_scalar_empty
     // CHECK: ttnn.full
     // CHECK-SAME: fill_value = 0 : i32
-    // CHECK-SAME: -> tensor<1xui32
+    // CHECK-SAME: -> tensor<1xf32
     // CHECK: ttnn.typecast
     // CHECK-SAME: -> tensor<1xsi32
     %0 = stablehlo.constant dense<0> : tensor<i64>
@@ -32,7 +32,7 @@ module @jit_constant attributes {} {
     // CHECK-LABEL: func.func public @test_int64_empty
     // CHECK: ttnn.full
     // CHECK-SAME: fill_value = 0 : i32
-    // CHECK-SAME: -> tensor<64x128xui32
+    // CHECK-SAME: -> tensor<64x128xf32
     // CHECK: ttnn.typecast
     // CHECK-SAME: -> tensor<64x128xsi32
     %0 = stablehlo.constant dense<0> : tensor<64x128xi64>
@@ -43,7 +43,7 @@ module @jit_constant attributes {} {
     // CHECK-LABEL: func.func public @test_int64_splat
     // CHECK: ttnn.full
     // CHECK-SAME: fill_value = 3 : i32
-    // CHECK-SAME: -> tensor<64x128xui32
+    // CHECK-SAME: -> tensor<64x128xf32
     // CHECK: ttnn.typecast
     // CHECK-SAME: -> tensor<64x128xsi32
     %0 = stablehlo.constant dense<3> : tensor<64x128xi64>

--- a/test/ttmlir/Silicon/StableHLO/n150/get_dimension_size_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/get_dimension_size_op.mlir
@@ -11,7 +11,7 @@ module @jit_get_dimension_size attributes {} {
     // CHECK-LABEL: func.func public @test_get_dimension_size
     // CHECK: ttnn.full
     // CHECK-SAME: fill_value = 128 : i32
-    // CHECK-SAME: -> tensor<1xui32
+    // CHECK-SAME: -> tensor<1xf32
     %0 = stablehlo.get_dimension_size %arg0, dim = 1 : (tensor<64x128xf32>) -> tensor<i32>
     return %0 : tensor<i32>
   }
@@ -20,7 +20,7 @@ module @jit_get_dimension_size attributes {} {
     // CHECK-LABEL: func.func public @test_get_dimension_size_f64
     // CHECK: ttnn.full
     // CHECK-SAME: fill_value = 128 : i32
-    // CHECK-SAME: -> tensor<1xui32
+    // CHECK-SAME: -> tensor<1xf32
     %0 = stablehlo.get_dimension_size %arg0, dim = 1 : (tensor<64x128xf64>) -> tensor<i32>
     return %0 : tensor<i32>
   }

--- a/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/get_dimension_size/get_dimension_size.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/eltwise/unary/get_dimension_size/get_dimension_size.mlir
@@ -6,6 +6,6 @@ func.func @get_dimension_size(%arg0: tensor<13x21x1x3xf32>) -> tensor<1xi32> {
   %0 = "ttir.get_dimension_size"(%arg0) <{dimension = 1 : i32}> : (tensor<13x21x1x3xf32>) -> tensor<1xi32>
   // CHECK: [[VAL:%[0-9]+]] = "ttnn.full"(%{{[0-9]+}})
   // CHECK-SAME: fill_value = 21 : i32
-  // CHECK-SAME: -> tensor<1xui32
+  // CHECK-SAME: -> tensor<1xf32
   return %0 : tensor<1xi32>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_dequantize.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_dequantize.mlir
@@ -9,7 +9,7 @@ module {
     // CHECK: "ttnn.get_device"
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 0
-    // CHECK-SAME: -> tensor<1xui32,
+    // CHECK-SAME: -> tensor<1xf32,
     // CHECK: "ttnn.typecast"
     // CHECK-SAME: dtype = #tt.supportedDataTypes<si32>
     // CHECK-SAME: -> tensor<1xsi32,

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_quantize.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_quantize.mlir
@@ -8,7 +8,7 @@ module {
     %0 = ttir.empty() : tensor<1x3x224x224x!quant.uniform<i32:f32, 2.000000e-02>>
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 0
-    // CHECK-SAME: -> tensor<1xui32,
+    // CHECK-SAME: -> tensor<1xf32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 2.000000e-02 : f32
     // CHECK-SAME: -> tensor<1xf32,

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_requantize.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_requantize.mlir
@@ -11,7 +11,7 @@ func.func @requantize_per_tensor_scales_per_tensor_zps(%arg0: tensor<1x3x320x320
     // CHECK-SAME: -> tensor<1xf32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 0 : i32
-    // CHECK-SAME: -> tensor<1xui32,
+    // CHECK-SAME: -> tensor<1xf32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 1.000000e-01 : f32
     // CHECK-SAME: -> tensor<1xf32,

--- a/test/ttmlir/Silicon/TTNN/n150/quantization/simple_dequantize.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/quantization/simple_dequantize.mlir
@@ -9,7 +9,7 @@ module {
     // CHECK: "ttnn.get_device"
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 0
-    // CHECK-SAME: -> tensor<1xui32,
+    // CHECK-SAME: -> tensor<1xf32,
     // CHECK: "ttnn.typecast"
     // CHECK-SAME: dtype = #tt.supportedDataTypes<si32>
     // CHECK-SAME: -> tensor<1xsi32,
@@ -35,7 +35,7 @@ module {
     // CHECK-SAME: -> tensor<3xf32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 0
-    // CHECK-SAME: -> tensor<3xui32,
+    // CHECK-SAME: -> tensor<3xf32,
     // CHECK: "ttnn.typecast"
     // CHECK-SAME: dtype = #tt.supportedDataTypes<si32>
     // CHECK-SAME: -> tensor<3xsi32,

--- a/test/ttmlir/Silicon/TTNN/n150/quantization/simple_quantize.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/quantization/simple_quantize.mlir
@@ -8,7 +8,7 @@ module {
     %0 = ttir.empty() : tensor<1x3x224x224x!quant.uniform<i32:f32, 2.000000e-02>>
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 0
-    // CHECK-SAME: -> tensor<1xui32,
+    // CHECK-SAME: -> tensor<1xf32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 2.000000e-02 : f32
     // CHECK-SAME: -> tensor<1xf32,
@@ -30,7 +30,7 @@ module {
     // CHECK-SAME: -> tensor<3xf32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 0
-    // CHECK-SAME: -> tensor<3xui32,
+    // CHECK-SAME: -> tensor<3xf32,
     // CHECK: "ttnn.quantize"
     // CHECK-SAME: axis = 1 : i32
     // CHECK-SAME: output_dtype = #tt.supportedDataTypes<si32>

--- a/test/ttmlir/Silicon/TTNN/n150/quantization/simple_requantize.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/quantization/simple_requantize.mlir
@@ -11,7 +11,7 @@ module {
     // CHECK-SAME: -> tensor<1xf32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 0 : i32
-    // CHECK-SAME: -> tensor<1xui32,
+    // CHECK-SAME: -> tensor<1xf32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 1.000000e-01 : f32
     // CHECK-SAME: -> tensor<1xf32,
@@ -35,7 +35,7 @@ module {
     // CHECK-SAME: -> tensor<3xf32,
     // CHECK: "ttnn.full"
     // CHECK-SAME: fill_value = 0
-    // CHECK-SAME: -> tensor<3xui32,
+    // CHECK-SAME: -> tensor<3xf32,
     // CHECK: "ttnn.requantize"
     // CHECK-SAME: <{axis = 1 : i32, output_dtype = #tt.supportedDataTypes<si32>}
     // CHECK-SAME: tensor<1x3x320x320x!quant.uniform<i32:f32:1, {1.000000e-01,2.000000e-01,3.000000e-01}>,


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-torch/issues/895)

### Problem description
There are several op combinations that may implicitly trigger a uint32 -> float32 typecast. For example, broadcasting with a constant integer value (int32 dtype) followed by an unsqueeze can result in the following decomposition:

ttnn.full
ttnn.reshape

->
ttnn.full (uint32)
ttnn.typecast (uint32 -> int32)
ttnn.typecast (int32 -> float32)
ttnn.reshape (float32)

This sequence introduces an unintended uint32 -> float32 conversion.

This patch extends the existing typecast prevention logic to cover these additional cases and avoid such conversions.

### What's changed
Building on the same idea as #3637 , this patch prevents additional cases of unintended uint32 -> float32 typecasts. 

### Checklist
- [ ] New/Existing tests provide coverage for changes
