### PR TITLE
Add fusing path to match/rewrite scatter op intoupdate/fill_cache

### DIFF
--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -29,6 +29,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
 
+#include "llvm/Support/LogicalResult.h"
 #include <cstdint>
 #include <optional>
 
@@ -1418,6 +1419,11 @@ public:
   LogicalResult
   matchAndRewrite(ttir::ScatterOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    if (!hasValidInsertedWindowDims(op)) {
+      return rewriter.notifyMatchFailure(
+          op, "ttnn and tt-metal have limited scatter support. Inserted window "
+              "dimenstion must be 1 in the input tensor shape.");
+    }
     // The ttnn interface has the inverse inputs of the TTIR dialect op (which
     // matches torch ops).
     rewriter.replaceOpWithNewOp<ttnn::ScatterOp>(
@@ -1425,6 +1431,20 @@ public:
         adaptor.getInput());
 
     return success();
+  }
+
+private:
+  bool hasValidInsertedWindowDims(ttir::ScatterOp op) const {
+    ArrayRef<int64_t> inputShape = op.getInput().getType().getShape();
+
+    for (uint64_t insertedWindowDims : op.getInsertedWindowDims()) {
+      if (insertedWindowDims < inputShape.size() &&
+          inputShape[insertedWindowDims] != 1) {
+        return false;
+      }
+    }
+
+    return true;
   }
 };
 } // namespace

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -3294,12 +3294,6 @@ void mlir::tt::ttir::MatmulOp::getCanonicalizationPatterns(
     return emitOpError("Batching currently not supported");
   }
 
-  for (uint64_t insertedWindowDims : getInsertedWindowDims()) {
-    if (inputShape[insertedWindowDims] != 1) {
-      return emitOpError("Dimension size to slice into must be 1");
-    }
-  }
-
   return success();
 }
 

--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -6,6 +6,7 @@
 #include "ttmlir/Dialect/TTIR/Utils/Utils.h"
 #include "ttmlir/Utils.h"
 
+#include "mlir/IR/Value.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir::tt::ttir {
@@ -392,6 +393,340 @@ public:
   }
 };
 
+class CacheFillUpdatePattern : public mlir::OpRewritePattern<ScatterOp> {
+  using mlir::OpRewritePattern<ScatterOp>::OpRewritePattern;
+
+public:
+  /// Pattern: scatter(input, indices, updates)
+  ///
+  /// This pattern detects when a ScatterOp is used as a fill/update for a
+  /// cache. We check for its input, indices, and update tensors to ensure they
+  /// match the expected cache fill/update pattern.
+  ///
+  /// Input pattern:
+  ///   %result = scatter(%cache, %indices, %updates)
+  ///   - Given a cache with shape (B, N, M, H) and a updates tensor with shape
+  ///   (B, N, S, H), the indices tensor should have shape (B, N, S, H, 4),
+  ///   representing the index where each element in %updates should placed in
+  ///   the %cache.
+  ///   - %indices can be tracked back to the function's cachePositions input
+  ///   that represents the indices of the cache to fill/update.
+  /// Output pattern:
+  ///   %result = fillCacheOp(%cache, %updates)
+  ///   or (if S == 1)
+  ///   %result = updateCacheOp(%cache, %updates, %update_index)
+  mlir::LogicalResult
+  matchAndRewrite(ScatterOp scatterOp,
+                  mlir::PatternRewriter &rewriter) const final {
+    auto CachePositions = getCacheUpdatePositions(scatterOp);
+    if (!CachePositions) {
+      return mlir::failure();
+    }
+
+    auto cacheUpdateInputType =
+        mlir::cast<RankedTensorType>((*CachePositions).getType());
+    auto cacheUpdateInputShape = cacheUpdateInputType.getShape();
+    if (cacheUpdateInputShape.size() != 1) {
+      return mlir::failure();
+    }
+
+    Value cache = scatterOp.getInput();
+    Value updates = scatterOp.getUpdate();
+    auto batchOffsetAttr = rewriter.getI32IntegerAttr(0);
+
+    // If the cachePositions tensor has more than one element we assume it
+    // represents a set of aranged indices (0, cachePositions.size), so we
+    // replace it with FillCacheOp. If the tensor has only one element, we
+    // assume it represents the update index for UpateCacheOp.
+    if (cacheUpdateInputShape[0] != 1) {
+      rewriter.replaceOpWithNewOp<FillCacheOp>(
+          scatterOp, scatterOp.getResult().getType(), // Result type
+          cache,                                      // Cache tensor
+          updates,                                    // Updates tensor
+          batchOffsetAttr                             // Batch offset
+      );
+    } else {
+      rewriter.replaceOpWithNewOp<UpdateCacheOp>(
+          scatterOp, scatterOp.getResult().getType(), // Result type
+          cache,                                      // Cache tensor
+          updates,                                    // Updates tensor
+          *CachePositions,                            // Cache Idx
+          batchOffsetAttr                             // Batch offset
+      );
+    }
+
+    return mlir::success();
+  }
+
+private:
+  // Check if the scatter op is a cache fill/update, and track the
+  // cachePositions input tensor if it is.
+  //
+  // We are looking for:
+  // %indices = "ttir.concat"(%0, %1, %2, %3):
+  //        (B,N,S,H,1), (B,N,S,H,1), (B,N,S,H,1), (B,N,S,H,1)) -> (B,N,S,H,4)
+  // %result = "ttir.scatter"(%cache, %indices, %updates)
+  // Where:
+  //    1. %0, %1, and %3 come from a const aranged vector representing
+  //       the first, second, and fourth dimension indices of the cache.
+  //    2. %2 comes from the input representing the cachePositions tensor.
+  static std::optional<mlir::Value>
+  getCacheUpdatePositions(ttir::ScatterOp scatterOp) {
+    // Check that the scatter op inputs represent a cache fill/update:
+    //    1. The input is a 4D (B, N, M, H)
+    //    2. The update tensor is a 4D tensor (B, N, S, H)
+    //    3. The scatter indices is a 5D tensor (B, N, S, H, 4)
+    auto scatterIndices = scatterOp.getScatterIndices();
+    ArrayRef<int64_t> inputShape =
+        mlir::cast<RankedTensorType>(scatterOp.getInput().getType()).getShape();
+    ArrayRef<int64_t> scatterIdxShape =
+        mlir::cast<RankedTensorType>(scatterIndices.getType()).getShape();
+    ArrayRef<int64_t> updateShape =
+        mlir::cast<RankedTensorType>(scatterOp.getUpdate().getType())
+            .getShape();
+    if (inputShape.size() != 4 || scatterIdxShape.size() != 5 ||
+        updateShape.size() != 4) {
+      return std::nullopt;
+    }
+    for (size_t i = 0; i < updateShape.size(); ++i) {
+      if (scatterIdxShape[i] != updateShape[i]) {
+        return std::nullopt;
+      }
+    }
+    if (scatterIdxShape[4] != 4) {
+      return std::nullopt;
+    }
+    if (!(inputShape[0] == updateShape[0] && inputShape[1] == updateShape[1] &&
+          inputShape[3] == updateShape[3])) {
+      return std::nullopt;
+    }
+
+    // Check that the scatter indices input is a concat op that produces the
+    // scatter indices for a cache update/fill:
+    //    1. Check that the 1st, 2nd and 4th inputs come from a 1D const aranged
+    //    tensor
+    //    2. Check that the 3rd input comes from the cachePositions func input
+    ConcatOp concatOp = scatterIndices.getDefiningOp<ttir::ConcatOp>();
+    if (!concatOp) {
+      return std::nullopt;
+    }
+
+    mlir::OperandRange inputs = concatOp.getInputs();
+    int32_t dim = concatOp.getDim();
+    if (inputs.size() != 4 || dim != 4) {
+      return std::nullopt;
+    }
+
+    if (!isBroadcastedDimIndices(inputs[0], 0) ||
+        !isBroadcastedDimIndices(inputs[1], 1) ||
+        !isBroadcastedDimIndices(inputs[3], 3)) {
+      return std::nullopt;
+    }
+
+    auto cachePositionInput = getCachePositionsInput(inputs[2]);
+    return cachePositionInput;
+  }
+
+  // For the concat input that can be tracked to the cachePositions input,
+  // check the pattern and track value up to the cachePositions tensor input.
+  //  %1 = "ttir.reshape"(%arg, %0) -> (S, 1)
+  //  %3 = "ttir.reshape"(%1, %2) -> (1, 1, S, 1)
+  //  %5 = "ttir.broadcast"(%3, %4) -> (B, N, S, H)
+  //  %7 = "ttir.reshape"(%5, %6) -> (B, N, S, H, 1)
+  // Where:
+  //  1. %arg is (S, ) and is the cachePositions input tensor.
+  //  2. B, S and H are const values.
+  static std::optional<mlir::Value>
+  getCachePositionsInput(mlir::Value inputValue) {
+    // 1. Check that value is a reshape op.
+    // 2. Check that the reshape's input and output shapes are compatible:
+    //    - Output.rank() = Input.rank() + 1
+    //    - All the input dims are the same as the output dims except the
+    //      last one which is 1.
+    auto reshapeOp = inputValue.getDefiningOp<ttir::ReshapeOp>();
+    if (!reshapeOp) {
+      return std::nullopt;
+    }
+    auto reshapeInput = reshapeOp.getInput();
+    auto inputShape =
+        mlir::cast<RankedTensorType>(reshapeInput.getType()).getShape();
+    auto outputShape =
+        mlir::cast<RankedTensorType>(reshapeOp.getOutput().getType())
+            .getShape();
+    if (inputShape.size() != outputShape.size() - 1) {
+      return std::nullopt;
+    }
+    for (size_t i = 0; i < inputShape.size(); ++i) {
+      if (inputShape[i] != outputShape[i]) {
+        return std::nullopt;
+      }
+    }
+
+    // 1. Check that input to reshape is a broadcast op.
+    // 2. Check that the broadcast's input and output ranks are the same.
+    // 3. Check that all dims in broadcast input are 1 or inputShape[i] ==
+    //    outputShape[i]
+    auto broadcastOp = reshapeInput.getDefiningOp<BroadcastOp>();
+    if (!broadcastOp) {
+      return std::nullopt;
+    }
+    inputShape = mlir::cast<RankedTensorType>(broadcastOp.getInput().getType())
+                     .getShape();
+    outputShape =
+        mlir::cast<RankedTensorType>(broadcastOp.getOutput().getType())
+            .getShape();
+    if (inputShape.size() != outputShape.size()) {
+      return std::nullopt;
+    }
+    for (size_t i = 0; i < inputShape.size(); ++i) {
+      if (inputShape[i] != 1 && inputShape[i] != outputShape[i]) {
+        return std::nullopt;
+      }
+    }
+
+    // Check that the input to broadcast are reshapes and loop through them
+    // until we reach the input to the first reshape.
+    auto nextInput = broadcastOp.getInput();
+    while (auto intermediateReshapeOp =
+               nextInput.getDefiningOp<ttir::ReshapeOp>()) {
+      nextInput = intermediateReshapeOp.getInput();
+    }
+
+    // Check that the input of the reshape chain is a single dim flat
+    // tensor. We will assume that this is the cachePositions tensor.
+    // TODO(jazpur): Check that this is a 1D aranged tensor coming from the
+    // input.
+    auto inputTensor = nextInput;
+    auto inputTensorShape =
+        mlir::cast<RankedTensorType>(inputTensor.getType()).getShape();
+    if (inputTensorShape.size() != 1) {
+      return std::nullopt;
+    }
+
+    return inputTensor;
+  }
+
+  // For each (const) input of the concat op we check for:
+  //  %2 = "ttir.reshape"(%0, %1) -> (N, 1)
+  //  %4 = "ttir.reshape"(%2, %3) -> (N, 1, 1)
+  //  %6 = "ttir.reshape"(%4, %5) -> (1, N, 1, 1)
+  //  %8 = "ttir.broadcast"(%6, %7) -> (B, N, S, H)
+  //  %10 = "ttir.reshape"(%8, %9) -> (B, N, S, H, 1)
+  // Where:
+  //  1. %0 is a const aranged tensor with shape (N,))
+  //  2. depending on dimIdx, same pattern applies for the B, and H dims
+  static bool isBroadcastedDimIndices(mlir::Value inputValue, int64_t dimIdx) {
+    // 1. Check that valueInput is a reshape op.
+    // 2. Check that the reshape's input and output shapes are compatible:
+    //    - Output.rank() = input.rank() + 1
+    //    - All the input dims are the same as the output dims except the
+    //      last one which is 1.
+    auto reshapeOp = inputValue.getDefiningOp<ttir::ReshapeOp>();
+    if (!reshapeOp) {
+      return false;
+    }
+    auto reshapeInput = reshapeOp.getInput();
+    auto inputShape =
+        mlir::cast<RankedTensorType>(reshapeInput.getType()).getShape();
+    auto outputShape =
+        mlir::cast<RankedTensorType>(reshapeOp.getOutput().getType())
+            .getShape();
+    if (inputShape.size() != outputShape.size() - 1) {
+      return false;
+    }
+    for (size_t i = 0; i < inputShape.size(); ++i) {
+      if (inputShape[i] != outputShape[i]) {
+        return false;
+      }
+    }
+
+    // 1. Check that input to reshape is a broadcast op.
+    // 2. Check that broadcast input and output rank is the same.
+    // 3. Check that all dims in broadcast input are 1 or inputShape[i] ==
+    //    outputShape[i]
+    auto broadcastOp = reshapeInput.getDefiningOp<BroadcastOp>();
+    if (!broadcastOp) {
+      return false;
+    }
+    inputShape = mlir::cast<RankedTensorType>(broadcastOp.getInput().getType())
+                     .getShape();
+    outputShape =
+        mlir::cast<RankedTensorType>(broadcastOp.getOutput().getType())
+            .getShape();
+    if (inputShape.size() != outputShape.size()) {
+      return false;
+    }
+    for (size_t i = 0; i < inputShape.size(); ++i) {
+      if (inputShape[i] != 1 && inputShape[i] != outputShape[i]) {
+        return false;
+      }
+    }
+
+    // Check that the input to broadcast is a reshape and loop through it until
+    // we reach the input to the first reshape.
+    auto nextInput = broadcastOp.getInput();
+    while (auto intermediateReshapeOp =
+               nextInput.getDefiningOp<ttir::ReshapeOp>()) {
+      nextInput = intermediateReshapeOp.getInput();
+    }
+
+    // 1. Check that the first input of the reshape chain is a single dim flat
+    //    tensor.
+    // 2. Check that the input is a const aranged tensor.
+    auto arangedTensor = nextInput;
+    auto arangedTensorShape =
+        mlir::cast<RankedTensorType>(arangedTensor.getType()).getShape();
+    if (arangedTensorShape.size() != 1) {
+      return false;
+    }
+
+    auto tensorType = mlir::cast<RankedTensorType>(inputValue.getType());
+    auto tensorShape = tensorType.getShape();
+    int64_t dim = tensorShape[dimIdx];
+    if (!isConstArangedTensor(arangedTensor, dim)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  // We are looking for a pattern like to this (from bottom up):
+  //  %0 = "ttir.arange"() {arr_dim = 0, end = N, start = 0, step = 1} -> (N, )
+  //  %2 = "ttir.multiply"(%0, 1, %1) -> (N,)
+  //  %4 = "ttir.add"(%2, 0, %3) -> (N,)
+  static bool isConstArangedTensor(mlir::Value inputValue, int64_t dim) {
+    // 1. Check that inputValue is an add op.
+    // 2. Check that the add's input is a multiply op.
+    auto addOp = inputValue.getDefiningOp<AddOp>();
+    if (!addOp) {
+      return false;
+    }
+    auto addInput = addOp.getLhs();
+    auto multiplyOp = addInput.getDefiningOp<MultiplyOp>();
+    if (!multiplyOp) {
+      return false;
+    }
+
+    // 1. Check that the multiply's input is an arange op.
+    // 2. Check that the arange op has start=0, end=dim, step=1, and
+    //    arange_dim=0.
+    auto arangeOp = multiplyOp.getLhs().getDefiningOp<ArangeOp>();
+    if (!arangeOp) {
+      return false;
+    }
+    const int64_t arangeStart = arangeOp.getStart();
+    const int64_t arangeEnd = arangeOp.getEnd();
+    const int64_t arangeStep = arangeOp.getStep();
+    const int64_t arangeDim = arangeOp.getArangeDimension();
+    if (arangeStart != 0 || arangeEnd != dim || arangeStep != 1 ||
+        arangeDim != 0) {
+      return false;
+    }
+
+    return true;
+  }
+};
+
 class TTIRFusingPass : public impl::TTIRFusingBase<TTIRFusingPass> {
 public:
   using impl::TTIRFusingBase<TTIRFusingPass>::TTIRFusingBase;
@@ -420,6 +755,7 @@ public:
 
       patterns.add<SoftmaxFusionPattern>(&getContext());
       patterns.add<Conv2dWithMultiply>(&getContext());
+      patterns.add<CacheFillUpdatePattern>(&getContext());
 
       GreedyRewriteConfig config;
       config.setUseTopDownTraversal(true);

--- a/test/ttmlir/Dialect/TTIR/fusing/kv_cache_fusing.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/kv_cache_fusing.mlir
@@ -1,0 +1,207 @@
+// RUN: ttmlir-opt %s -ttir-fusing | FileCheck %s
+
+// Test case with a FillCache scatter op pattern
+module @scatter_fill_cache{
+  func.func @fill_cache(%arg0: tensor<1x8x64x128xbf16>, %arg1: tensor<15xi64>, %arg2: tensor<1x8x15x128xbf16>) -> tensor<1x8x64x128xbf16> {
+    // CHECK-NOT: ttir.multiply
+    // CHECK-NOT: ttir.add
+    // CHECK-NOT: ttir.broadcast
+    // CHECK-NOT: ttir.reshape
+    // CHECK-NOT: ttir.arange
+    // CHECK-NOT: ttir.concat
+    // CHECK-NOT: ttir.scatter
+    // CHECK-NOT: ttir.update_cache
+    // CHECK: %[[RESULT:.*]] = "ttir.fill_cache"(%arg0, %arg2) <{batch_offset = 0 : i32}> : (tensor<1x8x64x128xbf16>, tensor<1x8x15x128xbf16>) -> tensor<1x8x64x128xbf16>
+    // CHECK: return %[[RESULT]] : tensor<1x8x64x128xbf16>
+
+    %0 = "ttir.constant"() <{value = dense<0> : tensor<1xi64>}> : () -> tensor<1xi64>
+    %1 = "ttir.constant"() <{value = dense<1> : tensor<1xi64>}> : () -> tensor<1xi64>
+    %2 = "ttir.constant"() <{value = dense<0> : tensor<8xi64>}> : () -> tensor<8xi64>
+    %3 = "ttir.constant"() <{value = dense<1> : tensor<8xi64>}> : () -> tensor<8xi64>
+    %4 = "ttir.constant"() <{value = dense<0> : tensor<128xi64>}> : () -> tensor<128xi64>
+    %5 = "ttir.constant"() <{value = dense<1> : tensor<128xi64>}> : () -> tensor<128xi64>
+    %6 = "ttir.arange"() <{arange_dimension = 0 : i64, end = 128 : si64, start = 0 : si64, step = 1 : si64}> : () -> tensor<128xi64>
+    %7 = ttir.empty() : tensor<128xi64>
+    %8 = "ttir.multiply"(%6, %5, %7) : (tensor<128xi64>, tensor<128xi64>, tensor<128xi64>) -> tensor<128xi64>
+    %9 = ttir.empty() : tensor<128xi64>
+    %10 = "ttir.add"(%8, %4, %9) : (tensor<128xi64>, tensor<128xi64>, tensor<128xi64>) -> tensor<128xi64>
+    %11 = "ttir.arange"() <{arange_dimension = 0 : i64, end = 8 : si64, start = 0 : si64, step = 1 : si64}> : () -> tensor<8xi64>
+    %12 = ttir.empty() : tensor<8xi64>
+    %13 = "ttir.multiply"(%11, %3, %12) : (tensor<8xi64>, tensor<8xi64>, tensor<8xi64>) -> tensor<8xi64>
+    %14 = ttir.empty() : tensor<8xi64>
+    %15 = "ttir.add"(%13, %2, %14) : (tensor<8xi64>, tensor<8xi64>, tensor<8xi64>) -> tensor<8xi64>
+    %16 = "ttir.arange"() <{arange_dimension = 0 : i64, end = 1 : si64, start = 0 : si64, step = 1 : si64}> : () -> tensor<1xi64>
+    %17 = ttir.empty() : tensor<1xi64>
+    %18 = "ttir.multiply"(%16, %1, %17) : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
+    %19 = ttir.empty() : tensor<1xi64>
+    %20 = "ttir.add"(%18, %0, %19) : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
+    %21 = ttir.empty() : tensor<1x1x1x1xi64>
+    %22 = "ttir.reshape"(%20, %21) <{shape = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<1xi64>, tensor<1x1x1x1xi64>) -> tensor<1x1x1x1xi64>
+    %23 = ttir.empty() : tensor<1x8x15x128xi64>
+    %24 = "ttir.broadcast"(%22, %23) <{broadcast_dimensions = array<i64: 1, 8, 15, 128>}> : (tensor<1x1x1x1xi64>, tensor<1x8x15x128xi64>) -> tensor<1x8x15x128xi64>
+    %25 = ttir.empty() : tensor<1x8x15x128x1xi64>
+    %26 = "ttir.reshape"(%24, %25) <{shape = [1 : i32, 8 : i32, 15 : i32, 128 : i32, 1 : i32]}> : (tensor<1x8x15x128xi64>, tensor<1x8x15x128x1xi64>) -> tensor<1x8x15x128x1xi64>
+    %27 = ttir.empty() : tensor<1x8x1x1xi64>
+    %28 = "ttir.reshape"(%15, %27) <{shape = [1 : i32, 8 : i32, 1 : i32, 1 : i32]}> : (tensor<8xi64>, tensor<1x8x1x1xi64>) -> tensor<1x8x1x1xi64>
+    %29 = ttir.empty() : tensor<1x8x15x128xi64>
+    %30 = "ttir.broadcast"(%28, %29) <{broadcast_dimensions = array<i64: 1, 1, 15, 128>}> : (tensor<1x8x1x1xi64>, tensor<1x8x15x128xi64>) -> tensor<1x8x15x128xi64>
+    %31 = ttir.empty() : tensor<1x8x15x128x1xi64>
+    %32 = "ttir.reshape"(%30, %31) <{shape = [1 : i32, 8 : i32, 15 : i32, 128 : i32, 1 : i32]}> : (tensor<1x8x15x128xi64>, tensor<1x8x15x128x1xi64>) -> tensor<1x8x15x128x1xi64>
+    %33 = ttir.empty() : tensor<1x1x15x1xi64>
+    %34 = "ttir.reshape"(%arg1, %33) <{shape = [1 : i32, 1 : i32, 15 : i32, 1 : i32]}> : (tensor<15xi64>, tensor<1x1x15x1xi64>) -> tensor<1x1x15x1xi64>
+    %35 = ttir.empty() : tensor<1x8x15x128xi64>
+    %36 = "ttir.broadcast"(%34, %35) <{broadcast_dimensions = array<i64: 1, 8, 1, 128>}> : (tensor<1x1x15x1xi64>, tensor<1x8x15x128xi64>) -> tensor<1x8x15x128xi64>
+    %37 = ttir.empty() : tensor<1x8x15x128x1xi64>
+    %38 = "ttir.reshape"(%36, %37) <{shape = [1 : i32, 8 : i32, 15 : i32, 128 : i32, 1 : i32]}> : (tensor<1x8x15x128xi64>, tensor<1x8x15x128x1xi64>) -> tensor<1x8x15x128x1xi64>
+    %39 = ttir.empty() : tensor<1x1x1x128xi64>
+    %40 = "ttir.reshape"(%10, %39) <{shape = [1 : i32, 1 : i32, 1 : i32, 128 : i32]}> : (tensor<128xi64>, tensor<1x1x1x128xi64>) -> tensor<1x1x1x128xi64>
+    %41 = ttir.empty() : tensor<1x8x15x128xi64>
+    %42 = "ttir.broadcast"(%40, %41) <{broadcast_dimensions = array<i64: 1, 8, 15, 1>}> : (tensor<1x1x1x128xi64>, tensor<1x8x15x128xi64>) -> tensor<1x8x15x128xi64>
+    %43 = ttir.empty() : tensor<1x8x15x128x1xi64>
+    %44 = "ttir.reshape"(%42, %43) <{shape = [1 : i32, 8 : i32, 15 : i32, 128 : i32, 1 : i32]}> : (tensor<1x8x15x128xi64>, tensor<1x8x15x128x1xi64>) -> tensor<1x8x15x128x1xi64>
+    %45 = ttir.empty() : tensor<1x8x15x128x4xi64>
+    %46 = "ttir.concat"(%26, %32, %38, %44, %45) <{dim = 4 : si32}> : (tensor<1x8x15x128x1xi64>, tensor<1x8x15x128x1xi64>, tensor<1x8x15x128x1xi64>, tensor<1x8x15x128x1xi64>, tensor<1x8x15x128x4xi64>) -> tensor<1x8x15x128x4xi64>
+    %47 = ttir.empty() : tensor<1x8x64x128xbf16>
+    %48 = "ttir.scatter"(%arg0, %46, %arg2, %47) <{index_vector_dim = 4 : i32, indices_are_sorted = false, input_batching_dims = array<i32>, inserted_window_dims = array<i32: 0, 1, 2, 3>, scatter_dims_to_operand_dims = array<i32: 0, 1, 2, 3>, scatter_indices_batching_dims = array<i32>, unique_indices = false, update_window_dims = array<i32>}> : (tensor<1x8x64x128xbf16>, tensor<1x8x15x128x4xi64>, tensor<1x8x15x128xbf16>, tensor<1x8x64x128xbf16>) -> tensor<1x8x64x128xbf16>
+    return %48 : tensor<1x8x64x128xbf16>
+  }
+}
+
+// Test case with a UpdateCache scatter op pattern
+module @scatter_update_cache{
+  func.func @update_cache(%arg0: tensor<1x8x64x128xbf16>, %arg1: tensor<1xi64>, %arg2: tensor<1x8x1x128xbf16>) -> tensor<1x8x64x128xbf16> {
+    // CHECK-NOT: ttir.multiply
+    // CHECK-NOT: ttir.add
+    // CHECK-NOT: ttir.broadcast
+    // CHECK-NOT: ttir.reshape
+    // CHECK-NOT: ttir.arange
+    // CHECK-NOT: ttir.concat
+    // CHECK-NOT: ttir.scatter
+    // CHECK-NOT: ttir.fill_cache
+    // CHECK: %[[RESULT:.*]] = "ttir.update_cache"(%arg0, %arg2, %arg1) <{batch_offset = 0 : i32}> : (tensor<1x8x64x128xbf16>, tensor<1x8x1x128xbf16>, tensor<1xi64>) -> tensor<1x8x64x128xbf16>
+    // CHECK: return %[[RESULT]] : tensor<1x8x64x128xbf16>
+
+    %0 = "ttir.constant"() <{value = dense<0> : tensor<1xi64>}> : () -> tensor<1xi64>
+    %1 = "ttir.constant"() <{value = dense<1> : tensor<1xi64>}> : () -> tensor<1xi64>
+    %2 = "ttir.constant"() <{value = dense<0> : tensor<8xi64>}> : () -> tensor<8xi64>
+    %3 = "ttir.constant"() <{value = dense<1> : tensor<8xi64>}> : () -> tensor<8xi64>
+    %4 = "ttir.constant"() <{value = dense<0> : tensor<128xi64>}> : () -> tensor<128xi64>
+    %5 = "ttir.constant"() <{value = dense<1> : tensor<128xi64>}> : () -> tensor<128xi64>
+    %6 = "ttir.arange"() <{arange_dimension = 0 : i64, end = 128 : si64, start = 0 : si64, step = 1 : si64}> : () -> tensor<128xi64>
+    %7 = ttir.empty() : tensor<128xi64>
+    %8 = "ttir.multiply"(%6, %5, %7) : (tensor<128xi64>, tensor<128xi64>, tensor<128xi64>) -> tensor<128xi64>
+    %9 = ttir.empty() : tensor<128xi64>
+    %10 = "ttir.add"(%8, %4, %9) : (tensor<128xi64>, tensor<128xi64>, tensor<128xi64>) -> tensor<128xi64>
+    %11 = "ttir.arange"() <{arange_dimension = 0 : i64, end = 8 : si64, start = 0 : si64, step = 1 : si64}> : () -> tensor<8xi64>
+    %12 = ttir.empty() : tensor<8xi64>
+    %13 = "ttir.multiply"(%11, %3, %12) : (tensor<8xi64>, tensor<8xi64>, tensor<8xi64>) -> tensor<8xi64>
+    %14 = ttir.empty() : tensor<8xi64>
+    %15 = "ttir.add"(%13, %2, %14) : (tensor<8xi64>, tensor<8xi64>, tensor<8xi64>) -> tensor<8xi64>
+    %16 = "ttir.arange"() <{arange_dimension = 0 : i64, end = 1 : si64, start = 0 : si64, step = 1 : si64}> : () -> tensor<1xi64>
+    %17 = ttir.empty() : tensor<1xi64>
+    %18 = "ttir.multiply"(%16, %1, %17) : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
+    %19 = ttir.empty() : tensor<1xi64>
+    %20 = "ttir.add"(%18, %0, %19) : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
+    %21 = ttir.empty() : tensor<1x1x1x1xi64>
+    %22 = "ttir.reshape"(%20, %21) <{shape = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<1xi64>, tensor<1x1x1x1xi64>) -> tensor<1x1x1x1xi64>
+    %23 = ttir.empty() : tensor<1x8x1x128xi64>
+    %24 = "ttir.broadcast"(%22, %23) <{broadcast_dimensions = array<i64: 1, 8, 1, 128>}> : (tensor<1x1x1x1xi64>, tensor<1x8x1x128xi64>) -> tensor<1x8x1x128xi64>
+    %25 = ttir.empty() : tensor<1x8x1x128x1xi64>
+    %26 = "ttir.reshape"(%24, %25) <{shape = [1 : i32, 8 : i32, 1 : i32, 128 : i32, 1 : i32]}> : (tensor<1x8x1x128xi64>, tensor<1x8x1x128x1xi64>) -> tensor<1x8x1x128x1xi64>
+    %27 = ttir.empty() : tensor<1x8x1x1xi64>
+    %28 = "ttir.reshape"(%15, %27) <{shape = [1 : i32, 8 : i32, 1 : i32, 1 : i32]}> : (tensor<8xi64>, tensor<1x8x1x1xi64>) -> tensor<1x8x1x1xi64>
+    %29 = ttir.empty() : tensor<1x8x1x128xi64>
+    %30 = "ttir.broadcast"(%28, %29) <{broadcast_dimensions = array<i64: 1, 1, 1, 128>}> : (tensor<1x8x1x1xi64>, tensor<1x8x1x128xi64>) -> tensor<1x8x1x128xi64>
+    %31 = ttir.empty() : tensor<1x8x1x128x1xi64>
+    %32 = "ttir.reshape"(%30, %31) <{shape = [1 : i32, 8 : i32, 1 : i32, 128 : i32, 1 : i32]}> : (tensor<1x8x1x128xi64>, tensor<1x8x1x128x1xi64>) -> tensor<1x8x1x128x1xi64>
+    %33 = ttir.empty() : tensor<1x1x1x1xi64>
+    %34 = "ttir.reshape"(%arg1, %33) <{shape = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<1xi64>, tensor<1x1x1x1xi64>) -> tensor<1x1x1x1xi64>
+    %35 = ttir.empty() : tensor<1x8x1x128xi64>
+    %36 = "ttir.broadcast"(%34, %35) <{broadcast_dimensions = array<i64: 1, 8, 1, 128>}> : (tensor<1x1x1x1xi64>, tensor<1x8x1x128xi64>) -> tensor<1x8x1x128xi64>
+    %37 = ttir.empty() : tensor<1x8x1x128x1xi64>
+    %38 = "ttir.reshape"(%36, %37) <{shape = [1 : i32, 8 : i32, 1 : i32, 128 : i32, 1 : i32]}> : (tensor<1x8x1x128xi64>, tensor<1x8x1x128x1xi64>) -> tensor<1x8x1x128x1xi64>
+    %39 = ttir.empty() : tensor<1x1x1x128xi64>
+    %40 = "ttir.reshape"(%10, %39) <{shape = [1 : i32, 1 : i32, 1 : i32, 128 : i32]}> : (tensor<128xi64>, tensor<1x1x1x128xi64>) -> tensor<1x1x1x128xi64>
+    %41 = ttir.empty() : tensor<1x8x1x128xi64>
+    %42 = "ttir.broadcast"(%40, %41) <{broadcast_dimensions = array<i64: 1, 8, 1, 1>}> : (tensor<1x1x1x128xi64>, tensor<1x8x1x128xi64>) -> tensor<1x8x1x128xi64>
+    %43 = ttir.empty() : tensor<1x8x1x128x1xi64>
+    %44 = "ttir.reshape"(%42, %43) <{shape = [1 : i32, 8 : i32, 1 : i32, 128 : i32, 1 : i32]}> : (tensor<1x8x1x128xi64>, tensor<1x8x1x128x1xi64>) -> tensor<1x8x1x128x1xi64>
+    %45 = ttir.empty() : tensor<1x8x1x128x4xi64>
+    %46 = "ttir.concat"(%26, %32, %38, %44, %45) <{dim = 4 : si32}> : (tensor<1x8x1x128x1xi64>, tensor<1x8x1x128x1xi64>, tensor<1x8x1x128x1xi64>, tensor<1x8x1x128x1xi64>, tensor<1x8x1x128x4xi64>) -> tensor<1x8x1x128x4xi64>
+    %47 = ttir.empty() : tensor<1x8x64x128xbf16>
+    %48 = "ttir.scatter"(%arg0, %46, %arg2, %47) <{index_vector_dim = 4 : i32, indices_are_sorted = false, input_batching_dims = array<i32>, inserted_window_dims = array<i32: 0, 1, 2, 3>, scatter_dims_to_operand_dims = array<i32: 0, 1, 2, 3>, scatter_indices_batching_dims = array<i32>, unique_indices = false, update_window_dims = array<i32>}> : (tensor<1x8x64x128xbf16>, tensor<1x8x1x128x4xi64>, tensor<1x8x1x128xbf16>, tensor<1x8x64x128xbf16>) -> tensor<1x8x64x128xbf16>
+    return %48 : tensor<1x8x64x128xbf16>
+  }
+}
+
+// Test case with a simple scatter op does not match fill/update cache pattern
+module @scatter {
+  func.func public @test_scatter(%arg0: tensor<1x3x320x320xf32>, %arg1: tensor<1x1xi64>, %arg2: tensor<1x3x32x32xf32>) -> tensor<1x3x320x320xf32> {
+    // CHECK-NOT: ttir.fill_cache
+    // CHECK-NOT: ttir.update_cache
+    // CHECK: ttir.scatter
+    %0 = ttir.empty() : tensor<1x3x320x320xf32>
+    %1 = "ttir.scatter"(%arg0, %arg1, %arg2, %0) <{index_vector_dim = 1 : i32, indices_are_sorted = false, input_batching_dims = array<i32>, inserted_window_dims = array<i32: 0>, scatter_dims_to_operand_dims = array<i32: 0>, scatter_indices_batching_dims = array<i32>, unique_indices = false, update_window_dims = array<i32: 1, 2, 3>}> : (tensor<1x3x320x320xf32>, tensor<1x1xi64>, tensor<1x3x32x32xf32>, tensor<1x3x320x320xf32>) -> tensor<1x3x320x320xf32>
+    return %1 : tensor<1x3x320x320xf32>
+  }
+}
+
+// Test case with a scatter op that has to track all the way up to a const arange with the wrong values. Should not fuse scatter into ttir.update_cache
+module {
+  func.func @main(%arg0: tensor<1x8x64x128xbf16>, %arg1: tensor<1xi64>, %arg2: tensor<1x8x1x128xbf16>) -> tensor<1x8x64x128xbf16> {
+    // CHECK: ttir.scatter
+    // CHECK-NOT: ttir.update_cache
+    // CHECK-NOT: ttir.fill_cache
+
+    %0 = "ttir.constant"() <{value = dense<0> : tensor<1xi64>}> : () -> tensor<1xi64>
+    %1 = "ttir.constant"() <{value = dense<1> : tensor<1xi64>}> : () -> tensor<1xi64>
+    %2 = "ttir.constant"() <{value = dense<0> : tensor<8xi64>}> : () -> tensor<8xi64>
+    %3 = "ttir.constant"() <{value = dense<1> : tensor<8xi64>}> : () -> tensor<8xi64>
+    %4 = "ttir.constant"() <{value = dense<0> : tensor<128xi64>}> : () -> tensor<128xi64>
+    %5 = "ttir.constant"() <{value = dense<1> : tensor<128xi64>}> : () -> tensor<128xi64>
+    %6 = "ttir.arange"() <{arange_dimension = 0 : i64, end = 128 : si64, start = 0 : si64, step = 1 : si64}> : () -> tensor<128xi64>
+    %7 = ttir.empty() : tensor<128xi64>
+    %8 = "ttir.multiply"(%6, %5, %7) : (tensor<128xi64>, tensor<128xi64>, tensor<128xi64>) -> tensor<128xi64>
+    %9 = ttir.empty() : tensor<128xi64>
+    %10 = "ttir.add"(%8, %4, %9) : (tensor<128xi64>, tensor<128xi64>, tensor<128xi64>) -> tensor<128xi64>
+    %11 = "ttir.arange"() <{arange_dimension = 0 : i64, end = 16 : si64, start = 8 : si64, step = 1 : si64}> : () -> tensor<8xi64>
+    %12 = ttir.empty() : tensor<8xi64>
+    %13 = "ttir.multiply"(%11, %3, %12) : (tensor<8xi64>, tensor<8xi64>, tensor<8xi64>) -> tensor<8xi64>
+    %14 = ttir.empty() : tensor<8xi64>
+    %15 = "ttir.add"(%13, %2, %14) : (tensor<8xi64>, tensor<8xi64>, tensor<8xi64>) -> tensor<8xi64>
+    %16 = "ttir.arange"() <{arange_dimension = 0 : i64, end = 1 : si64, start = 0 : si64, step = 1 : si64}> : () -> tensor<1xi64>
+    %17 = ttir.empty() : tensor<1xi64>
+    %18 = "ttir.multiply"(%16, %1, %17) : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
+    %19 = ttir.empty() : tensor<1xi64>
+    %20 = "ttir.add"(%18, %0, %19) : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
+    %21 = ttir.empty() : tensor<1x1x1x1xi64>
+    %22 = "ttir.reshape"(%20, %21) <{shape = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<1xi64>, tensor<1x1x1x1xi64>) -> tensor<1x1x1x1xi64>
+    %23 = ttir.empty() : tensor<1x8x1x128xi64>
+    %24 = "ttir.broadcast"(%22, %23) <{broadcast_dimensions = array<i64: 1, 8, 1, 128>}> : (tensor<1x1x1x1xi64>, tensor<1x8x1x128xi64>) -> tensor<1x8x1x128xi64>
+    %25 = ttir.empty() : tensor<1x8x1x128x1xi64>
+    %26 = "ttir.reshape"(%24, %25) <{shape = [1 : i32, 8 : i32, 1 : i32, 128 : i32, 1 : i32]}> : (tensor<1x8x1x128xi64>, tensor<1x8x1x128x1xi64>) -> tensor<1x8x1x128x1xi64>
+    %27 = ttir.empty() : tensor<1x8x1x1xi64>
+    %28 = "ttir.reshape"(%15, %27) <{shape = [1 : i32, 8 : i32, 1 : i32, 1 : i32]}> : (tensor<8xi64>, tensor<1x8x1x1xi64>) -> tensor<1x8x1x1xi64>
+    %29 = ttir.empty() : tensor<1x8x1x128xi64>
+    %30 = "ttir.broadcast"(%28, %29) <{broadcast_dimensions = array<i64: 1, 1, 1, 128>}> : (tensor<1x8x1x1xi64>, tensor<1x8x1x128xi64>) -> tensor<1x8x1x128xi64>
+    %31 = ttir.empty() : tensor<1x8x1x128x1xi64>
+    %32 = "ttir.reshape"(%30, %31) <{shape = [1 : i32, 8 : i32, 1 : i32, 128 : i32, 1 : i32]}> : (tensor<1x8x1x128xi64>, tensor<1x8x1x128x1xi64>) -> tensor<1x8x1x128x1xi64>
+    %33 = ttir.empty() : tensor<1x1x1x1xi64>
+    %34 = "ttir.reshape"(%arg1, %33) <{shape = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<1xi64>, tensor<1x1x1x1xi64>) -> tensor<1x1x1x1xi64>
+    %35 = ttir.empty() : tensor<1x8x1x128xi64>
+    %36 = "ttir.broadcast"(%34, %35) <{broadcast_dimensions = array<i64: 1, 8, 1, 128>}> : (tensor<1x1x1x1xi64>, tensor<1x8x1x128xi64>) -> tensor<1x8x1x128xi64>
+    %37 = ttir.empty() : tensor<1x8x1x128x1xi64>
+    %38 = "ttir.reshape"(%36, %37) <{shape = [1 : i32, 8 : i32, 1 : i32, 128 : i32, 1 : i32]}> : (tensor<1x8x1x128xi64>, tensor<1x8x1x128x1xi64>) -> tensor<1x8x1x128x1xi64>
+    %39 = ttir.empty() : tensor<1x1x1x128xi64>
+    %40 = "ttir.reshape"(%10, %39) <{shape = [1 : i32, 1 : i32, 1 : i32, 128 : i32]}> : (tensor<128xi64>, tensor<1x1x1x128xi64>) -> tensor<1x1x1x128xi64>
+    %41 = ttir.empty() : tensor<1x8x1x128xi64>
+    %42 = "ttir.broadcast"(%40, %41) <{broadcast_dimensions = array<i64: 1, 8, 1, 1>}> : (tensor<1x1x1x128xi64>, tensor<1x8x1x128xi64>) -> tensor<1x8x1x128xi64>
+    %43 = ttir.empty() : tensor<1x8x1x128x1xi64>
+    %44 = "ttir.reshape"(%42, %43) <{shape = [1 : i32, 8 : i32, 1 : i32, 128 : i32, 1 : i32]}> : (tensor<1x8x1x128xi64>, tensor<1x8x1x128x1xi64>) -> tensor<1x8x1x128x1xi64>
+    %45 = ttir.empty() : tensor<1x8x1x128x4xi64>
+    %46 = "ttir.concat"(%26, %32, %38, %44, %45) <{dim = 4 : si32}> : (tensor<1x8x1x128x1xi64>, tensor<1x8x1x128x1xi64>, tensor<1x8x1x128x1xi64>, tensor<1x8x1x128x1xi64>, tensor<1x8x1x128x4xi64>) -> tensor<1x8x1x128x4xi64>
+    %47 = ttir.empty() : tensor<1x8x64x128xbf16>
+    %48 = "ttir.scatter"(%arg0, %46, %arg2, %47) <{index_vector_dim = 4 : i32, indices_are_sorted = false, input_batching_dims = array<i32>, inserted_window_dims = array<i32: 0, 1, 2, 3>, scatter_dims_to_operand_dims = array<i32: 0, 1, 2, 3>, scatter_indices_batching_dims = array<i32>, unique_indices = false, update_window_dims = array<i32>}> : (tensor<1x8x64x128xbf16>, tensor<1x8x1x128x4xi64>, tensor<1x8x1x128xbf16>, tensor<1x8x64x128xbf16>) -> tensor<1x8x64x128xbf16>
+    return %48 : tensor<1x8x64x128xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket
We are looking to [support generative models](https://github.com/tenstorrent/tt-torch/issues/614)

### Problem description
To support generative models we need to enable KV-static cache fill/updates. Once we lower the module to stableHLO the cache update is a 20+ op pattern that start with a scatter op and can be traced all the way to a tensor containing the cache indices that need to be updated. We want to add a pattern matcher for scatter ops that represent a kv-cache fill/update and replace with a single Fill/UpdateCacheOp.

### What's changed
- Add a pattern matcher to TTIRFusing pass to determine if a scatter op can be replaced with a FillCacheOp or UpdateCacheOp
- Move conditions from ttir::ScatterOp::verify() into TTIRtoTTNN pass to allow kv-cache scattter ops to be rewritten into Cache ops
- Added test cases for FillCache and UpdateCache rewrites.

### Checklist
- [x] New/Existing tests provide coverage for changes
