### PR TITLE
#3495: Added gather op support for automatic parallelization pass with shardy.

### DIFF
--- a/include/ttmlir/Dialect/StableHLO/Transforms/ShardyUtils.h
+++ b/include/ttmlir/Dialect/StableHLO/Transforms/ShardyUtils.h
@@ -306,9 +306,9 @@ getOutShardingAttrs(MLIRContext *context, func::FuncOp &funcOp,
 
 // Calculate the updated shape based on the tensor sharding annotation.
 inline FailureOr<int64_t>
-calculateUpdatedShapeDim(mlir::sdy::MeshAttr meshAttr,
-                         mlir::sdy::DimensionShardingAttr dimShardingAttr,
-                         int64_t oldShapeDim) {
+calculateUpdatedDim(mlir::sdy::MeshAttr meshAttr,
+                    mlir::sdy::DimensionShardingAttr dimShardingAttr,
+                    int64_t oldShapeDim) {
   int64_t updatedShapeDim = oldShapeDim;
   MeshMap meshMap = createMeshMapFromMeshAttr(meshAttr);
   llvm::ArrayRef<mlir::sdy::AxisRefAttr> shardingAxes =
@@ -339,7 +339,7 @@ populateShardedOutputType(mlir::sdy::MeshAttr meshAttr,
 
   for (uint32_t i = 0; i < newShape.size(); i++) {
     FailureOr<int64_t> updatedShapeDim =
-        calculateUpdatedShapeDim(meshAttr, dimShardings[i], newShape[i]);
+        calculateUpdatedDim(meshAttr, dimShardings[i], newShape[i]);
 
     if (failed(updatedShapeDim)) {
       return failure();

--- a/test/ttmlir/Dialect/StableHLO/shardy_automatic_parallelization/gather.mlir
+++ b/test/ttmlir/Dialect/StableHLO/shardy_automatic_parallelization/gather.mlir
@@ -1,0 +1,14 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --automatic-sharding-pipeline="mesh-shape=1,2" %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+
+sdy.mesh @mesh = <["model"=1, "batch"=2]>
+
+func.func @gather_simple(%arg0: tensor<4x56x56x96xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{"batch"}, {}, {}, {}]>}, %arg1: tensor<56xi64>) -> tensor<4x56x56x96xbf16> {
+  %0 = "stablehlo.gather"(%arg0, %arg1) <{dimension_numbers = #stablehlo.gather<offset_dims = [0, 2, 3], collapsed_slice_dims = [1], start_index_map = [1], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 4, 1, 56, 96>}> : (tensor<4x56x56x96xbf16>, tensor<56xi64>) -> tensor<4x56x56x96xbf16>
+  return %0 : tensor<4x56x56x96xbf16>
+}
+
+// CHECK: sdy.manual_computation(%arg0, %arg1) in_shardings=[<@mesh, [{"batch"}, {}, {}, {}]>, <@mesh, [{}]>] out_shardings=[<@mesh, [{"batch"}, {}, {}, {}]>]
+// CHECK: "stablehlo.gather"(%arg2, %arg3) <{dimension_numbers = #stablehlo.gather<offset_dims = [0, 2, 3], collapsed_slice_dims = [1], start_index_map = [1], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 2, 1, 56, 96>}> : (tensor<2x56x56x96xbf16>, tensor<56xi64>) -> tensor<2x56x56x96xbf16>
+// CHECK: sdy.return %1 : tensor<2x56x56x96xbf16>


### PR DESCRIPTION
Ticket: https://github.com/tenstorrent/tt-mlir/issues/3495

Problem description

Gather op in automatic shardy pass needed to be supported specially because it encodes the shape of it's output in it's attribute dictionary, whereas most other ops do not. Thus, when updating the shapes of the tensors to match their shard shape, we also need to pay careful attention to gather.

Example

```
ttmlir-opt --automatic-sharding-pipeline="mesh-shape=1,2"
```

```
func.func @gather_simple(%arg0: tensor<4x56x56x96xbf16>, %arg1: tensor<56xi64>) -> tensor<4x56x56x96xbf16> {
    %0 = sdy.manual_computation(%arg0, %arg1) in_shardings=[<@mesh, [{"batch"}, {}, {}, {}]>, <@mesh, [{}]>] out_shardings=[<@mesh, [{"batch"}, {}, {}, {}]>] manual_axes={"model", "batch"} (%arg2: tensor<2x56x56x96xbf16>, %arg3: tensor<56xi64>) {
      %1 = "stablehlo.gather"(%arg2, %arg3) <{dimension_numbers = #stablehlo.gather<offset_dims = [0, 2, 3], collapsed_slice_dims = [1], start_index_map = [1], index_vector_dim = 1>, indices_are_sorted = false, slice_sizes = array<i64: 2, 1, 56, 96>}> : (tensor<2x56x56x96xbf16>, tensor<56xi64>) -> tensor<2x56x56x96xbf16>
      sdy.return %1 : tensor<2x56x56x96xbf16>
    } : (tensor<4x56x56x96xbf16>, tensor<56xi64>) -> tensor<4x56x56x96xbf16>
    return %0 : tensor<4x56x56x96xbf16>
  }
```