### PR TITLE
TTIR decomposition of ttir.prod op

### DIFF
--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecompositionPass.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecompositionPass.cpp
@@ -74,6 +74,15 @@ struct TTIRToTTIRDecompositionPass
               meanType.getRank() == 4 && varType.getRank() == 4);
     });
 
+    target.addDynamicallyLegalOp<ttir::ProdOp>([&](ttir::ProdOp op) {
+      auto dimArg = op.getDimArg();
+      if (!dimArg) {
+        return true;
+      }
+      uint64_t rank = op.getInput().getType().getRank();
+      return (dimArg->size() == 1 || dimArg->size() == rank);
+    });
+
     TypeConverter typeConverter;
     // All types map 1:1.
     typeConverter.addConversion([](Type type) { return type; });

--- a/test/ttmlir/Dialect/TTIR/Decomposition/reduce_prod.mlir
+++ b/test/ttmlir/Dialect/TTIR/Decomposition/reduce_prod.mlir
@@ -1,0 +1,29 @@
+// RUN: ttmlir-opt --ttir-to-ttir-decomposition %s | FileCheck %s
+
+module attributes {} {
+  func.func public @test_reduce_add_4to2dim(%arg0: tensor<128x10x32x4xf32>) -> tensor<128x32xf32> {
+    // CHECK-LABEL: @test_reduce_add_4to2dim(
+    %0 = ttir.empty() : tensor<128x32xf32>
+    // CHECK: %[[PROD:[0-9]+]] = "ttir.prod"(%arg0, %{{[0-9]+}})
+    // CHECK-SAME: <{dim_arg = [3 : i32], keep_dim = false}>
+    // CHECK-SAME: (tensor<128x10x32x4xf32>, tensor<128x10x32xf32>) -> tensor<128x10x32xf32>
+    // CHECK: %{{[0-9]+}} = "ttir.prod"(%[[PROD]], %{{[0-9]+}})
+    // CHECK-SAME: <{dim_arg = [1 : i32], keep_dim = false}>
+    // CHECK-SAME: (tensor<128x10x32xf32>, tensor<128x32xf32>) -> tensor<128x32xf32>
+    %1 = "ttir.prod"(%arg0, %0) <{dim_arg = [1 : i32, 3 : i32], keep_dim = false}> : (tensor<128x10x32x4xf32>, tensor<128x32xf32>) -> tensor<128x32xf32>
+    return %1 : tensor<128x32xf32>
+  }
+
+  func.func public @test_reduce_add_4to2dim_keepdim(%arg0: tensor<128x10x32x4xf32>) -> tensor<128x1x32x1xf32> {
+    // CHECK-LABEL: @test_reduce_add_4to2dim_keepdim
+    %0 = ttir.empty() : tensor<128x1x32x1xf32>
+    // CHECK: %[[PROD:[0-9]+]] = "ttir.prod"(%arg0, %{{[0-9]+}})
+    // CHECK-SAME: <{dim_arg = [3 : i32], keep_dim = true}>
+    // CHECK-SAME: (tensor<128x10x32x4xf32>, tensor<128x10x32x1xf32>) -> tensor<128x10x32x1xf32>
+    // CHECK: %{{[0-9]+}} = "ttir.prod"(%[[PROD]], %{{[0-9]+}})
+    // CHECK-SAME: <{dim_arg = [1 : i32], keep_dim = true}>
+    // CHECK-SAME: (tensor<128x10x32x1xf32>, tensor<128x1x32x1xf32>) -> tensor<128x1x32x1xf32>
+    %1 = "ttir.prod"(%arg0, %0) <{dim_arg = [1 : i32, 3 : i32], keep_dim = true}> : (tensor<128x10x32x4xf32>, tensor<128x1x32x1xf32>) -> tensor<128x1x32x1xf32>
+    return %1 : tensor<128x1x32x1xf32>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/reduction/negative_reduce_prod_op.mlir
+++ b/test/ttmlir/Dialect/TTNN/reduction/negative_reduce_prod_op.mlir
@@ -1,14 +1,6 @@
 // RUN: not ttmlir-opt --ttir-to-ttnn-backend-pipeline --split-input-file %s 2>&1 | FileCheck %s
 // Negative tests for reduce(prod) op
 
-// CHECK: error: failed to legalize operation 'ttir.prod'
-func.func public @test_reduce_prod_multiple_dims(%arg0: tensor<128x10x32x4xf32>) -> tensor<128x32xf32> {
-  %0 = ttir.empty() : tensor<128x32xf32>
-  %1 = "ttir.prod"(%arg0, %0) <{dim_arg = [1 : i32, 3 : i32], keep_dim = false}> : (tensor<128x10x32x4xf32>, tensor<128x32xf32>) -> tensor<128x32xf32>
-  return %1 : tensor<128x32xf32>
-}
-
-// -----
 // CHECK: error: 'ttnn.prod' op TTNN only supports Reduce(prod) along all dimensions for bfloat16 datatype.
 func.func public @test_reduce_prod_all_dims_f32(%arg0: tensor<128x10x32x4xf32>) -> tensor<1xf32> {
   %0 = ttir.empty() : tensor<1xf32>


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-mlir/issues/1861

### Problem description
tt-metal supports product reduction along one or all dimensions. 

### What's changed
TTIR->TTIR decomposition is added to transform product reduction op to
multiple reduction ops. Each op will perform reduction along one dimension only.

### Checklist
- [X] New/Existing tests provide coverage for changes
