### PR TITLE
Fixing ttir-builder upsample2d

### DIFF
--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -1010,7 +1010,6 @@ def test_permute(shapes: List[Shape], permutation: List[int], request):
     )
 
 
-@pytest.mark.run_error
 @pytest.mark.parametrize("shapes", [[(10, 64, 32, 3), (10, 128, 128, 3)]])
 @pytest.mark.parametrize("scale_factor", [[2, 4]])
 def test_upsample2d(shapes: List[Shape], scale_factor: List[int], request):

--- a/tools/ttir-builder/builder.py
+++ b/tools/ttir-builder/builder.py
@@ -1922,19 +1922,32 @@ class TTIRBuilder:
         mode: str = "nearest",
         unit_attrs: List[str] = None,
     ) -> OpView:
-        golden_scale_factor = (
-            tuple(scale_factor) if not isinstance(scale_factor, int) else scale_factor
-        )
-        upsample_obj = torch.nn.Upsample(scale_factor=golden_scale_factor, mode=mode)
+        output_shape = self._get_golden_tensor(in1).shape
+        kwargs = {"scale_factor": scale_factor, "mode": mode}
         return self.op_proxy(
-            upsample_obj,
+            self.upsample2d_golden_function,
             ttir.Upsample2dOp,
             [in0, in1],
-            ttir_kwargs={"scale_factor": scale_factor, "mode": mode},
-            organize_golden_args=lambda i: [self._get_golden_tensor(i[0])],
-            organize_ttir_args=lambda i, o, _: (self._get_type(i[1]), i[0], i[1]),
+            golden_kwargs=kwargs,
+            ttir_kwargs=kwargs,
+            organize_ttir_args=lambda i, o, _: (self._get_type(i[1]), i[0], o),
+            output_shape=output_shape,
             unit_attrs=unit_attrs,
         )
+
+    def upsample2d_golden_function(
+        self,
+        in0: Operand,
+        in1: Operand,
+        scale_factor: Union[SI32Attr, DenseI32ArrayAttr],
+        mode: str = "nearest",
+    ) -> OpView:
+        transposed_golden = torch.transpose(in0, 1, 3)
+        golden_output_shape = in1.shape[1:-1]
+        output = torch.nn.functional.interpolate(
+            transposed_golden, size=golden_output_shape, mode=mode
+        )
+        return torch.transpose(output, 1, 3)
 
     def arange(
         self,


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/3678)

### Problem description
ttir-builder's `upsample2d` was throwing a size mismatch error

### What's changed
Fixed it

### Checklist
- [ ] New/Existing tests provide coverage for changes
