### PR TITLE
Fixing ttir-builder ttir.index golden PCC fail

### DIFF
--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -823,7 +823,6 @@ def test_pad(shapes: List[Shape], padding: List[int], value: int, request):
     )
 
 
-@pytest.mark.fails_golden
 @pytest.mark.parametrize("shape", [(32, 64)])
 @pytest.mark.parametrize("dim,begin,end,step", [(0, 0, 3, 1)])
 def test_index(shape: Shape, dim: int, begin: int, end: int, step: int, request):

--- a/tools/ttir-builder/builder.py
+++ b/tools/ttir-builder/builder.py
@@ -1712,13 +1712,19 @@ class TTIRBuilder:
     def index(
         self,
         in0: Operand,
-        dim: int = 0,
-        begin: int = 0,
-        end: int = 3,
-        step: int = 1,
+        dim: int,
+        begin: int,
+        end: int,
+        step: int,
         unit_attrs: List[str] = None,
     ) -> OpView:
-        index = torch.tensor([begin, end, step])
+        import math
+
+        num_indices = math.ceil((end - begin) / step)
+        indices = []
+        for i in range(num_indices):
+            indices.append((begin + i) * step)
+        index = torch.tensor(indices)
         return self.op_proxy(
             torch.index_select,
             ttir.IndexOp,


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/2604)

### Problem description
`ttir.index` is failing PCC golden check.

### What's changed
Changed the handling of golden function kwargs

### Checklist
- [ ] New/Existing tests provide coverage for changes
