### PR TITLE
Fixing ttir-builder PCC failures caused by dtype mismatch

### DIFF
--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -934,7 +934,7 @@ def test_reverse(shape: Shape, dims: List[int], request):
     )
 
 
-@pytest.mark.run_error
+@pytest.mark.skip("See issue #3685")
 @pytest.mark.parametrize("shape", [(4, 4)])
 @pytest.mark.parametrize("dim_args", [[0, 1]])
 def test_reduce_and(shape: Shape, dim_args: List[int], request):
@@ -1503,12 +1503,12 @@ def test_unary_ops(
         add,
         multiply,
         subtract,
-        eq | Marks(pytest.mark.fails_golden, pytest.mark.skip_target("ttmetal")),
-        ne | Marks(pytest.mark.fails_golden, pytest.mark.skip_target("ttmetal")),
-        le | Marks(pytest.mark.fails_golden, pytest.mark.skip_target("ttmetal")),
-        lt | Marks(pytest.mark.fails_golden, pytest.mark.skip_target("ttmetal")),
-        ge | Marks(pytest.mark.fails_golden, pytest.mark.skip_target("ttmetal")),
-        gt | Marks(pytest.mark.fails_golden, pytest.mark.skip_target("ttmetal")),
+        eq | Marks(pytest.mark.skip_target("ttmetal")),
+        ne | Marks(pytest.mark.skip_target("ttmetal")),
+        le | Marks(pytest.mark.skip_target("ttmetal")),
+        lt | Marks(pytest.mark.skip_target("ttmetal")),
+        ge | Marks(pytest.mark.skip_target("ttmetal")),
+        gt | Marks(pytest.mark.skip_target("ttmetal")),
         div | Marks(pytest.mark.skip_target("ttmetal")),
         remainder | Marks(pytest.mark.skip_target("ttmetal")),
         maximum,

--- a/tools/ttir-builder/builder.py
+++ b/tools/ttir-builder/builder.py
@@ -830,6 +830,7 @@ class TTIRBuilder:
     def neg(self, in0: Operand, unit_attrs: List[str] = None) -> OpView:
         return self.eltwise_proxy(torch.neg, ttir.NegOp, [in0], unit_attrs)
 
+    # NOTE: See issue #1719 for information on golden PCC fail
     def tan(self, in0: Operand, unit_attrs: List[str] = None) -> OpView:
         return self.eltwise_proxy(torch.tan, ttir.TanOp, [in0], unit_attrs)
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/1221)
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/1223)
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/1224)
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/1225)
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/1226)
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/1800)
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/1801)

### Problem description
TTIR `ttir.eq`, `ttir.ge`, `ttir.gt`, `ttir.le`, `ttir.lt`, `ttir.logical_not`, `ttir.logical_xor` ops are failing golden PCC checks.

### What's changed
These TTIR ops were failing PCC because of golden functions returning a different datatype than the ttir ops. Optional `out` tensor keyword arguments were added to control datatype because these torch functions don't have a `dtype` keyword.

### Checklist
- [ ] New/Existing tests provide coverage for changes
