### PR TITLE
Fixing various ttir-builder PCC failures

### DIFF
--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -901,12 +901,11 @@ def test_empty(shape: Shape, request):
     )
 
 
-# @pytest.mark.fails_golden
 @pytest.mark.parametrize("shapes", [[(128, 128)]])
-@pytest.mark.parametrize("dim", [1])
-def test_argmax(shapes, dim, request):
+@pytest.mark.parametrize("dim_arg", [[1]])
+def test_argmax(shapes, dim_arg, request):
     def argmax(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
-        return builder.argmax(in0, [dim], unit_attrs=unit_attrs)
+        return builder.argmax(in0, dim_arg=dim_arg, unit_attrs=unit_attrs)
 
     compile_to_flatbuffer(
         argmax,

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -905,7 +905,7 @@ def test_empty(shape: Shape, request):
 @pytest.mark.parametrize("dim_arg", [[1]])
 def test_argmax(shapes, dim_arg, request):
     def argmax(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
-        return builder.argmax(in0, dim_arg=dim_arg, unit_attrs=unit_attrs)
+        return builder.argmax(in0, dim_arg, unit_attrs=unit_attrs)
 
     compile_to_flatbuffer(
         argmax,
@@ -1454,7 +1454,7 @@ unary_ops = [
     gelu | Marks(pytest.mark.skip_target("ttmetal")),
     leaky_relu | Marks(pytest.mark.skip_target("ttmetal")),
     sqrt | Marks(pytest.mark.skip_target("ttmetal")),
-    cbrt | Marks(pytest.mark.fails_golden, pytest.mark.skip_target("ttmetal")),
+    cbrt | Marks(pytest.mark.skip_target("ttmetal")),
     rsqrt | Marks(pytest.mark.fails_golden),
     sigmoid,
     reciprocal | Marks(pytest.mark.skip_target("ttmetal")),

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -823,7 +823,6 @@ def test_pad(shapes: List[Shape], padding: List[int], value: int, request):
     )
 
 
-@pytest.mark.fails_golden
 @pytest.mark.parametrize("shape", [(32, 64)])
 @pytest.mark.parametrize("dim,begin,end,step", [(0, 0, 3, 1)])
 def test_index(shape: Shape, dim: int, begin: int, end: int, step: int, request):
@@ -902,7 +901,7 @@ def test_empty(shape: Shape, request):
     )
 
 
-@pytest.mark.fails_golden
+# @pytest.mark.fails_golden
 @pytest.mark.parametrize("shapes", [[(128, 128)]])
 @pytest.mark.parametrize("dim", [1])
 def test_argmax(shapes, dim, request):

--- a/tools/ttir-builder/builder.py
+++ b/tools/ttir-builder/builder.py
@@ -1037,9 +1037,8 @@ class TTIRBuilder:
     def argmax_golden_function(
         self, in0: Operand, dim_arg: List[int], keep_dim: bool = False
     ) -> OpView:
-        for dim in dim_arg:
-            in0 = torch.argmax(in0, dim=dim, keepdim=keep_dim)
-        return in0.to(torch.int32)
+        in1 = torch.argmax(in0, dim=dim_arg[0], keepdim=keep_dim)
+        return in1.to(torch.int32)
 
     def sum(
         self,


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/2604)
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/2658)
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/3680)

### Problem description
`ttir.index`, `ttir.cbrt`, and `ttir.argmax` are failing golden PCC checks.

### What's changed
Fixed 'em.
`builder.index` was failing due to incorrect golden keyword argument handling.
`builder.cbrt` was failing because `torch.pow` doesn't carry negative signs. Multiplied result of `torch.pow` by `torch.sign`.
`builder.argmax` was returning the wrong datatype for its golden function.

### Checklist
- [ ] New/Existing tests provide coverage for changes
