### PR TITLE
Improved flatbuffer schema verification

### DIFF
--- a/cmake/modules/BuildFlatbuffers.cmake
+++ b/cmake/modules/BuildFlatbuffers.cmake
@@ -1,10 +1,10 @@
 find_program(FLATBUFFERS_COMPILER flatc)
 
-function(build_flatbuffers sources target)
+function(build_flatbuffers namespace sources target)
 # Query deps if they exist
 set(deps)
-if(ARGC GREATER 2)
-  foreach(target_dep IN LISTS ARGV2)
+if(ARGC GREATER 3)
+  foreach(target_dep IN LISTS ARGV3)
     get_property(target_sources TARGET ${target_dep} PROPERTY SOURCES)
     list(APPEND deps ${target_sources})
   endforeach()
@@ -15,9 +15,11 @@ set(FBS_GEN_OUTPUTS)
 foreach(FILE ${sources})
   get_filename_component(FILE_DIR ${FILE} DIRECTORY)
   get_filename_component(BASE_NAME ${FILE} NAME_WE)
+  set(FBS_GEN_FILE "${CMAKE_CURRENT_BINARY_DIR}/${FILE_DIR}/${BASE_NAME}_generated.h")
+  set(FBS_GEN_BFBS_FILE "${CMAKE_CURRENT_BINARY_DIR}/${FILE_DIR}/${BASE_NAME}_bfbs_generated.h")
   add_custom_command(OUTPUT
-    "${CMAKE_CURRENT_BINARY_DIR}/${FILE_DIR}/${BASE_NAME}_generated.h"
-    "${CMAKE_CURRENT_BINARY_DIR}/${FILE_DIR}/${BASE_NAME}_bfbs_generated.h"
+    "${FBS_GEN_FILE}"
+    "${FBS_GEN_BFBS_FILE}"
     COMMAND ${FLATBUFFERS_COMPILER}
     ARGS -I ${PROJECT_SOURCE_DIR}/include/
     ARGS --bfbs-gen-embed
@@ -26,10 +28,28 @@ foreach(FILE ${sources})
     ARGS --keep-prefix
     ARGS --gen-name-strings
     ARGS -o "${CMAKE_CURRENT_BINARY_DIR}/${FILE_DIR}/" "${FILE}"
+    COMMENT "Generating flatbuffer file: ${FBS_GEN_FILE}"
     DEPENDS ${FILE} ${deps} ${sources}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-  list(APPEND FBS_GEN_OUTPUTS ${CMAKE_CURRENT_BINARY_DIR}/${FILE_DIR}/${BASE_NAME}_generated.h)
-  list(APPEND FBS_GEN_OUTPUTS ${CMAKE_CURRENT_BINARY_DIR}/${FILE_DIR}/${BASE_NAME}_bfbs_generated.h)
+  list(APPEND FBS_GEN_OUTPUTS ${FBS_GEN_FILE})
+  list(APPEND FBS_GEN_OUTPUTS ${FBS_GEN_BFBS_FILE})
+
+  # Compute sha256 hash of the schema (via the bfbs file itself)
+  set(FBS_GEN_PYTHON_SHA256_SCRIPT "${PROJECT_SOURCE_DIR}/tools/scripts/sha256-include-gen.py")
+  set(FBS_GEN_BFBS_HASH_FILE "${CMAKE_CURRENT_BINARY_DIR}/${FILE_DIR}/${BASE_NAME}_bfbs_hash_generated.h")
+  set(FBS_GEN_BFBS_NAMESPACE "tt::target::${namespace}")
+  set(FBS_GEN_BFBS_VARIABLE_NAME "${BASE_NAME}_bfbs_schema_hash")
+
+  add_custom_command(OUTPUT
+    "${FBS_GEN_BFBS_HASH_FILE}"
+    COMMAND ${Python3_EXECUTABLE} "${FBS_GEN_PYTHON_SHA256_SCRIPT}" ${FBS_GEN_BFBS_NAMESPACE} ${FBS_GEN_BFBS_VARIABLE_NAME} ${FBS_GEN_BFBS_FILE} ${FBS_GEN_BFBS_HASH_FILE}
+    DEPENDS ${FBS_GEN_BFBS_FILE}
+    COMMENT "Generating schema hash file: ${FBS_GEN_BFBS_HASH_FILE}"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    VERBATIM
+  )
+  list(APPEND FBS_GEN_OUTPUTS ${FBS_GEN_BFBS_HASH_FILE})
+
 endforeach()
 add_library(${target} INTERFACE ${FBS_GEN_OUTPUTS})
 endfunction()

--- a/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
+++ b/include/ttmlir/Dialect/TT/IR/TTOpsTypes.td
@@ -217,7 +217,7 @@ def TT_SystemDescAttr : TT_Attr<"SystemDesc", "system_desc"> {
 
   let extraClassDeclaration = [{
     static tt::SystemDescAttr getDefault(MLIRContext *context, tt::Arch arch = tt::Arch::WormholeB0, const llvm::SmallVector<int64_t> &meshShape = {1});
-    static tt::SystemDescAttr getFromPath(MLIRContext *context, StringRef path);
+    static FailureOr<tt::SystemDescAttr> getFromPath(MLIRContext *context, StringRef path, llvm::function_ref<mlir::InFlightDiagnostic()> diagFn);
     unsigned getAddressAlignBytes(unsigned chipIndex = 0) const;
     unsigned getAddressAlignBytes(MemorySpace memorySpace, unsigned chipIndex = 0) const;
     unsigned getNocL1AddressAlignBytes(unsigned chipIndex = 0) const;

--- a/include/ttmlir/Target/Common/CMakeLists.txt
+++ b/include/ttmlir/Target/Common/CMakeLists.txt
@@ -7,4 +7,4 @@ set(COMMON_FBS_GEN_SOURCES
   debug_info.fbs
 )
 
-build_flatbuffers("${COMMON_FBS_GEN_SOURCES}" COMMON_FBS)
+build_flatbuffers("common" "${COMMON_FBS_GEN_SOURCES}" COMMON_FBS)

--- a/include/ttmlir/Target/Common/Target.h
+++ b/include/ttmlir/Target/Common/Target.h
@@ -9,6 +9,7 @@
 #pragma clang diagnostic ignored "-Wcovered-switch-default"
 
 #include "ttmlir/Target/Common/debug_info_generated.h"
+#include "ttmlir/Target/Common/system_desc_bfbs_hash_generated.h"
 #include "ttmlir/Target/Common/system_desc_generated.h"
 #include "ttmlir/Target/Common/types_generated.h"
 #include "ttmlir/Target/Common/version_generated.h"

--- a/include/ttmlir/Target/Common/system_desc.fbs
+++ b/include/ttmlir/Target/Common/system_desc.fbs
@@ -5,6 +5,7 @@ namespace tt.target;
 
 table SystemDescRoot {
   version: tt.target.Version;
+  schema_hash: string;
   ttmlir_git_hash: string;
   product_identifier: string;
   system_desc: tt.target.SystemDesc;

--- a/include/ttmlir/Target/TTMetal/CMakeLists.txt
+++ b/include/ttmlir/Target/TTMetal/CMakeLists.txt
@@ -7,4 +7,4 @@ set(TTMETAL_FBS_GEN_SOURCES
   binary.fbs
 )
 
-build_flatbuffers("${TTMETAL_FBS_GEN_SOURCES}" TTMETAL_FBS COMMON_FBS)
+build_flatbuffers("ttmetal" "${TTMETAL_FBS_GEN_SOURCES}" TTMETAL_FBS COMMON_FBS)

--- a/include/ttmlir/Target/TTMetal/Target.h
+++ b/include/ttmlir/Target/TTMetal/Target.h
@@ -8,9 +8,8 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcovered-switch-default"
 
-#include "ttmlir/Target/Common/system_desc_generated.h"
-#include "ttmlir/Target/Common/types_generated.h"
-#include "ttmlir/Target/Common/version_generated.h"
+#include "ttmlir/Target/Common/Target.h"
+#include "ttmlir/Target/TTMetal/binary_bfbs_hash_generated.h"
 #include "ttmlir/Target/TTMetal/binary_generated.h"
 #include "ttmlir/Target/TTMetal/command_generated.h"
 #include "ttmlir/Target/TTMetal/program_generated.h"

--- a/include/ttmlir/Target/TTMetal/binary.fbs
+++ b/include/ttmlir/Target/TTMetal/binary.fbs
@@ -47,6 +47,7 @@ table Program {
 
 table TTMetalBinary {
   version: Version;
+  schema_hash: string;
   ttmlir_git_hash: string;
   system_desc: SystemDesc;
   programs: [Program];

--- a/include/ttmlir/Target/TTNN/CMakeLists.txt
+++ b/include/ttmlir/Target/TTNN/CMakeLists.txt
@@ -30,4 +30,4 @@ set(TTNN_FBS_GEN_SOURCES
   binary.fbs
 )
 
-build_flatbuffers("${TTNN_FBS_GEN_SOURCES}" TTNN_FBS COMMON_FBS)
+build_flatbuffers("ttnn" "${TTNN_FBS_GEN_SOURCES}" TTNN_FBS COMMON_FBS)

--- a/include/ttmlir/Target/TTNN/Target.h
+++ b/include/ttmlir/Target/TTNN/Target.h
@@ -8,10 +8,8 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcovered-switch-default"
 
-#include "ttmlir/Target/Common/debug_info_generated.h"
-#include "ttmlir/Target/Common/system_desc_generated.h"
-#include "ttmlir/Target/Common/types_generated.h"
-#include "ttmlir/Target/Common/version_generated.h"
+#include "ttmlir/Target/Common/Target.h"
+#include "ttmlir/Target/TTNN/binary_bfbs_hash_generated.h"
 #include "ttmlir/Target/TTNN/binary_generated.h"
 #pragma clang diagnostic pop
 

--- a/include/ttmlir/Target/TTNN/binary.fbs
+++ b/include/ttmlir/Target/TTNN/binary.fbs
@@ -7,6 +7,7 @@ namespace tt.target.ttnn;
 
 table TTNNBinary {
   version: tt.target.Version;
+  schema_hash: string;
   ttmlir_git_hash: string;
   system_desc: tt.target.SystemDesc;
   programs: [Program];

--- a/lib/Dialect/TT/IR/TTOpsTypes.cpp
+++ b/lib/Dialect/TT/IR/TTOpsTypes.cpp
@@ -6,6 +6,7 @@
 
 #include "ttmlir/Dialect/TT/IR/TT.h"
 #include "ttmlir/Target/Common/Target.h"
+#include "ttmlir/Target/Common/system_desc_bfbs_hash_generated.h"
 #include "ttmlir/Utils.h"
 
 #include "mlir/IR/Builders.h"
@@ -300,20 +301,35 @@ mlir::tt::SystemDescAttr mlir::tt::SystemDescAttr::getDefault(
   }
 }
 
-mlir::tt::SystemDescAttr
-mlir::tt::SystemDescAttr::getFromPath(MLIRContext *context, StringRef path) {
-  // Check if file exists
-  assert(!path.empty() && "system desc path must not be empty!");
+mlir::FailureOr<mlir::tt::SystemDescAttr> mlir::tt::SystemDescAttr::getFromPath(
+    MLIRContext *context, StringRef path,
+    llvm::function_ref<mlir::InFlightDiagnostic()> diagFn) {
+  if (path.empty()) {
+    diagFn() << "system desc path must not be empty";
+    return failure();
+  }
+
   std::ifstream fbb(path.data(), std::ios::binary | std::ios::ate);
-  assert(fbb.good() && "system desc does not exist!");
+  if (!fbb.good()) {
+    diagFn() << "system desc does not exist: " << path;
+    return failure();
+  }
   std::streampos size = fbb.tellg();
   fbb.seekg(0, std::ios::beg);
   auto buffer = std::shared_ptr<void>(std::malloc(size), std::free);
   fbb.read(static_cast<char *>(buffer.get()), size);
 
   // Read relevant information from binary
-  const auto *binarySystemDesc =
-      ::tt::target::GetSizePrefixedSystemDescRoot(buffer.get())->system_desc();
+  const auto *binarySystemDescRoot =
+      ::tt::target::GetSizePrefixedSystemDescRoot(buffer.get());
+  if (binarySystemDescRoot->schema_hash()->string_view() !=
+      ::tt::target::common::system_desc_bfbs_schema_hash) {
+    diagFn() << "system desc schema mismatch, please collect a system desc "
+                "with a runtime compiled with the same schema version";
+    return failure();
+  }
+
+  const auto *binarySystemDesc = binarySystemDescRoot->system_desc();
   const auto *binaryCpuDesc = binarySystemDesc->cpu_descs();
   const auto *binaryChipDesc = binarySystemDesc->chip_descs();
   const auto *binaryChipDescIndices = binarySystemDesc->chip_desc_indices();

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -681,8 +681,9 @@ static std::shared_ptr<void> translateModuleToFlatbuffer(
   });
 
   auto binary = target::metal::CreateTTMetalBinaryDirect(
-      fbb, &binaryVersion, ttmlir::getGitHash(),
-      toFlatbuffer(cache, systemDesc), &programs, &dylibs);
+      fbb, &binaryVersion, target::ttmetal::binary_bfbs_schema_hash,
+      ttmlir::getGitHash(), toFlatbuffer(cache, systemDesc), &programs,
+      &dylibs);
 
   FinishSizePrefixedTTMetalBinaryBuffer(fbb, binary);
   flatbuffers::Verifier verifier(fbb.GetBufferPointer(), fbb.GetSize());

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -2189,7 +2189,8 @@ std::shared_ptr<void> ttnnToFlatbuffer(
   });
 
   auto binary = ::tt::target::ttnn::CreateTTNNBinaryDirect(
-      fbb, &binaryVersion, ::ttmlir::getGitHash(), systemDesc, &programs);
+      fbb, &binaryVersion, ::tt::target::ttnn::binary_bfbs_schema_hash,
+      ::ttmlir::getGitHash(), systemDesc, &programs);
 
   ::tt::target::ttnn::FinishSizePrefixedTTNNBinaryBuffer(fbb, binary);
   ::flatbuffers::Verifier verifier(fbb.GetBufferPointer(), fbb.GetSize());

--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -159,6 +159,8 @@ struct Flatbuffer : public detail::ObjectImpl {
   void store(const char *path) const;
   std::string_view getFileIdentifier() const;
   std::string getVersion() const;
+  std::string_view getSchemaHash() const;
+  bool checkSchemaHash() const;
   std::string_view getTTMLIRGitHash() const;
   std::string asJson() const;
 };

--- a/runtime/lib/binary.cpp
+++ b/runtime/lib/binary.cpp
@@ -75,6 +75,10 @@ std::string getVersion(Flatbuffer binary) {
          std::to_string(version->patch());
 }
 
+std::string_view getSchemaHash(Flatbuffer binary) {
+  return getBinary(binary)->schema_hash()->c_str();
+}
+
 std::string_view getTTMLIRGitHash(Flatbuffer binary) {
   return getBinary(binary)->ttmlir_git_hash()->c_str();
 }
@@ -152,6 +156,10 @@ std::string getVersion(Flatbuffer binary) {
   return std::to_string(version->major()) + "." +
          std::to_string(version->minor()) + "." +
          std::to_string(version->patch());
+}
+
+std::string_view getSchemaHash(Flatbuffer binary) {
+  return getBinary(binary)->schema_hash()->c_str();
 }
 
 std::string_view getTTMLIRGitHash(Flatbuffer binary) {
@@ -235,6 +243,10 @@ std::string getVersion(Flatbuffer binary) {
          std::to_string(version->patch());
 }
 
+std::string_view getSchemaHash(Flatbuffer binary) {
+  return getBinary(binary)->schema_hash()->c_str();
+}
+
 std::string_view getTTMLIRGitHash(Flatbuffer binary) {
   return getBinary(binary)->ttmlir_git_hash()->c_str();
 }
@@ -299,6 +311,47 @@ std::string Flatbuffer::getVersion() const {
   if (::tt::target::SizePrefixedSystemDescRootBufferHasIdentifier(
           handle.get())) {
     return system_desc::getVersion(*this);
+  }
+
+  LOG_FATAL("Unsupported binary format");
+}
+
+std::string_view Flatbuffer::getSchemaHash() const {
+  if (::tt::target::ttnn::SizePrefixedTTNNBinaryBufferHasIdentifier(
+          handle.get())) {
+    return ttnn::getSchemaHash(*this);
+  }
+
+  if (::tt::target::metal::SizePrefixedTTMetalBinaryBufferHasIdentifier(
+          handle.get())) {
+    return metal::getSchemaHash(*this);
+  }
+
+  if (::tt::target::SizePrefixedSystemDescRootBufferHasIdentifier(
+          handle.get())) {
+    return system_desc::getSchemaHash(*this);
+  }
+
+  LOG_FATAL("Unsupported binary format");
+}
+
+bool Flatbuffer::checkSchemaHash() const {
+  if (::tt::target::ttnn::SizePrefixedTTNNBinaryBufferHasIdentifier(
+          handle.get())) {
+    return ttnn::getSchemaHash(*this) ==
+           ::tt::target::ttnn::binary_bfbs_schema_hash;
+  }
+
+  if (::tt::target::metal::SizePrefixedTTMetalBinaryBufferHasIdentifier(
+          handle.get())) {
+    return metal::getSchemaHash(*this) ==
+           ::tt::target::ttmetal::binary_bfbs_schema_hash;
+  }
+
+  if (::tt::target::SizePrefixedSystemDescRootBufferHasIdentifier(
+          handle.get())) {
+    return system_desc::getSchemaHash(*this) ==
+           ::tt::target::common::system_desc_bfbs_schema_hash;
   }
 
   LOG_FATAL("Unsupported binary format");

--- a/runtime/lib/common/system_desc.cpp
+++ b/runtime/lib/common/system_desc.cpp
@@ -6,6 +6,7 @@
 #include "tt/runtime/runtime.h"
 #include "tt/runtime/types.h"
 #include "tt/runtime/utils.h"
+#include "ttmlir/Target/Common/system_desc_bfbs_hash_generated.h"
 #include "ttmlir/Target/TTNN/Target.h"
 #include "ttmlir/Version.h"
 #include "types_generated.h"
@@ -273,7 +274,8 @@ static std::unique_ptr<::tt::runtime::SystemDesc> getCurrentSystemDescImpl(
   ::tt::target::Version version(ttmlirVersion.major, ttmlirVersion.minor,
                                 ttmlirVersion.patch);
   auto root = ::tt::target::CreateSystemDescRootDirect(
-      fbb, &version, ::ttmlir::getGitHash(), "unknown", systemDesc);
+      fbb, &version, tt::target::common::system_desc_bfbs_schema_hash,
+      ::ttmlir::getGitHash(), "unknown", systemDesc);
   ::tt::target::FinishSizePrefixedSystemDescRootBuffer(fbb, root);
   ::flatbuffers::Verifier verifier(fbb.GetBufferPointer(), fbb.GetSize());
   if (!::tt::target::VerifySizePrefixedSystemDescRootBuffer(verifier)) {

--- a/runtime/python/binary/binary.cpp
+++ b/runtime/python/binary/binary.cpp
@@ -16,6 +16,8 @@ namespace tt::runtime::python {
 void registerBinaryBindings(nb::module_ &m) {
   nb::class_<tt::runtime::Flatbuffer>(m, "Flatbuffer")
       .def_prop_ro("version", &tt::runtime::Flatbuffer::getVersion)
+      .def_prop_ro("schema_hash", &tt::runtime::Flatbuffer::getSchemaHash)
+      .def("check_schema_hash", &tt::runtime::Flatbuffer::checkSchemaHash)
       .def_prop_ro("ttmlir_git_hash",
                    &tt::runtime::Flatbuffer::getTTMLIRGitHash)
       .def_prop_ro("file_identifier",
@@ -25,6 +27,8 @@ void registerBinaryBindings(nb::module_ &m) {
 
   nb::class_<tt::runtime::Binary>(m, "Binary")
       .def_prop_ro("version", &tt::runtime::Binary::getVersion)
+      .def_prop_ro("schema_hash", &tt::runtime::Flatbuffer::getSchemaHash)
+      .def("check_schema_hash", &tt::runtime::Flatbuffer::checkSchemaHash)
       .def_prop_ro("ttmlir_git_hash", &tt::runtime::Binary::getTTMLIRGitHash)
       .def_prop_ro("file_identifier", &tt::runtime::Binary::getFileIdentifier)
       .def("as_json", &tt::runtime::Binary::asJson)
@@ -38,6 +42,8 @@ void registerBinaryBindings(nb::module_ &m) {
 
   nb::class_<tt::runtime::SystemDesc>(m, "SystemDesc")
       .def_prop_ro("version", &tt::runtime::SystemDesc::getVersion)
+      .def_prop_ro("schema_hash", &tt::runtime::Flatbuffer::getSchemaHash)
+      .def("check_schema_hash", &tt::runtime::Flatbuffer::checkSchemaHash)
       .def_prop_ro("ttmlir_git_hash",
                    &tt::runtime::SystemDesc::getTTMLIRGitHash)
       .def_prop_ro("file_identifier",

--- a/runtime/tools/ttrt/ttrt/common/util.py
+++ b/runtime/tools/ttrt/ttrt/common/util.py
@@ -623,19 +623,7 @@ class Flatbuffer:
         self.test_result = "pass"
 
     def check_version(self, ignore: bool = False):
-        package_name = "ttrt"
-
-        try:
-            package_version = get_distribution(package_name).version
-        except Exception as e:
-            raise Exception(f"error retrieving version: {e} for {package_name}")
-
-        if package_version != self.version and not ignore:
-            raise Exception(
-                f"{package_name}: v{package_version} does not match flatbuffer: v{self.version} for flatbuffer: {self.file_path} - skipping this test"
-            )
-
-        return True
+        raise UnimplementedError
 
     @staticmethod
     def get_ttnn_file_extension():
@@ -669,6 +657,13 @@ class Binary(Flatbuffer):
         for i in range(len(self.fbb_dict["programs"])):
             program = Binary.Program(i, self.fbb_dict["programs"][i])
             self.programs.append(program)
+
+    def check_version(self, ignore: bool = False):
+        if not ignore and not self.fbb.check_schema_hash():
+            raise Exception(
+                "Binary schema mismatch, please recompile the binary with the compiler at the same schema version"
+            )
+        return True
 
     def check_system_desc(self, query):
         import ttrt.binary

--- a/tools/scripts/sha256-include-gen.py
+++ b/tools/scripts/sha256-include-gen.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+import hashlib
+import sys
+
+namespace = sys.argv[1]
+variable_name = sys.argv[2]
+in_file_name = sys.argv[3]
+out_file_name = sys.argv[4]
+
+in_file_contents = open(in_file_name).read().encode()
+sha = hashlib.sha256(in_file_contents).hexdigest()
+define = (
+    f"TTMLIR_SHA256_INCLUDE_GEN_{namespace.replace('::', '_').upper()}_{variable_name.upper()}"
+)
+
+out_file = open(out_file_name, "w")
+out_file.write(
+    f"""// Auto-generated do not edit directly
+#ifndef {define}
+#define {define}
+namespace {namespace} {{
+static constexpr char {variable_name}[] = \"{sha}\";
+}}
+#endif // {define}
+"""
+)

--- a/tools/scripts/sha256-include-gen.py
+++ b/tools/scripts/sha256-include-gen.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
 import hashlib
 import sys
 
@@ -9,9 +12,7 @@ out_file_name = sys.argv[4]
 
 in_file_contents = open(in_file_name).read().encode()
 sha = hashlib.sha256(in_file_contents).hexdigest()
-define = (
-    f"TTMLIR_SHA256_INCLUDE_GEN_{namespace.replace('::', '_').upper()}_{variable_name.upper()}"
-)
+define = f"TTMLIR_SHA256_INCLUDE_GEN_{namespace.replace('::', '_').upper()}_{variable_name.upper()}"
 
 out_file = open(out_file_name, "w")
 out_file.write(


### PR DESCRIPTION
The current flatbuffer schema verification check is flawed since it only checks the git tag version is the same, this is problematic for 2 reasons:
1. False positives: You could have changed the schema as part of _this_ commit and the compiler would be perfectly fine loading this system desc and parsing fields out (incorrectly).
2. False negatives: You could have committed a change that has nothing to do with flatbuffer schema, but this commit bumps the patch number which causes a system desc version mismatch.

This patch resolves both of these issues by hashing the flatbuffer schemas and storing the hash in the flatbuffer.  This enables both the runtime and the compiler to verify the schema is at the expected version.  It has the added benefit of passing the verification when no flatbuffer schema has changed.
