### PR TITLE
Remove fixed clang-tidy NOLINT's

### DIFF
--- a/lib/Dialect/TT/IR/TTDialect.cpp
+++ b/lib/Dialect/TT/IR/TTDialect.cpp
@@ -53,7 +53,6 @@ void TTDialect::initialize() {
 #define GET_OP_LIST
 #include "ttmlir/Dialect/TT/IR/TTOps.cpp.inc"
       >();
-  // NOLINTNEXTLINE
   addAttributes<
 #define GET_ATTRDEF_LIST
 #include "ttmlir/Dialect/TT/IR/TTOpsAttrDefs.cpp.inc"

--- a/lib/Dialect/TT/IR/TTOpsTypes.cpp
+++ b/lib/Dialect/TT/IR/TTOpsTypes.cpp
@@ -1450,7 +1450,6 @@ mlir::Type TileType::getElementType() const {
 }
 
 void TTDialect::registerTypes() {
-  // NOLINTNEXTLINE
   addTypes<
 #define GET_TYPEDEF_LIST
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.cpp.inc"

--- a/lib/Dialect/TTIR/IR/TTIRGenericRegionOps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIRGenericRegionOps.cpp
@@ -210,7 +210,6 @@ mlir::LogicalResult mlir::tt::ttir::DMAOp::bufferize(
     mlir::RewriterBase &rewriter,
     const mlir::bufferization::BufferizationOptions &options) {
   Value src = nullptr;
-  // NOLINTNEXTLINE
   if (isSrcRemote()) {
     auto maybeSrc = mlir::bufferization::getBuffer(rewriter, getSrc(), options);
     if (failed(maybeSrc)) {
@@ -222,7 +221,6 @@ mlir::LogicalResult mlir::tt::ttir::DMAOp::bufferize(
   }
 
   Value dst = nullptr;
-  // NOLINTNEXTLINE
   if (isDstRemote()) {
     auto maybeDst = mlir::bufferization::getBuffer(rewriter, getDst(), options);
     if (failed(maybeDst)) {
@@ -234,7 +232,6 @@ mlir::LogicalResult mlir::tt::ttir::DMAOp::bufferize(
   }
 
   ::llvm::SmallVector<mlir::Value> invocationStack;
-  // NOLINTNEXTLINE
   mlir::bufferization::replaceOpWithNewBufferizedOp<mlir::tt::ttir::DMAOp>(
       rewriter, *this, getResult().getType(), src, getSrcAffineMapAttr(),
       getSrcIndices(), dst, getDstAffineMapAttr(), getDstIndices(),

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -54,7 +54,6 @@ static MemRefType getBufferType(Type type, bool isView) {
 // BitwiseXorOp canonicalization
 void mlir::tt::ttir::BitwiseXorOp::getCanonicalizationPatterns(
     mlir::RewritePatternSet &patterns, mlir::MLIRContext *context) {
-  // NOLINTBEGIN(clang-analyzer-core.StackAddressEscape)
   // x ^ x == 0
   patterns.add(
       +[](mlir::tt::ttir::BitwiseXorOp op, mlir::PatternRewriter &rewriter) {
@@ -78,7 +77,6 @@ void mlir::tt::ttir::BitwiseXorOp::getCanonicalizationPatterns(
             op, op->getOperand(0).getType(), resultType);
         return mlir::success();
       });
-  // NOLINTEND(clang-analyzer-core.StackAddressEscape)
 }
 
 //===----------------------------------------------------------------------===//
@@ -2623,7 +2621,6 @@ getTransposeOpOperand(mlir::TypedValue<mlir::RankedTensorType> value) {
 // LinearOp canonicalization
 void mlir::tt::ttir::LinearOp::getCanonicalizationPatterns(
     mlir::RewritePatternSet &patterns, mlir::MLIRContext *context) {
-  // NOLINTBEGIN(clang-analyzer-core.StackAddressEscape)
   // If bias is not provided, linear operation is equivalent to matmul.
   patterns.add(+[](ttir::LinearOp op, mlir::PatternRewriter &rewriter) {
     if (!op.getBias()) {
@@ -2664,7 +2661,6 @@ void mlir::tt::ttir::LinearOp::getCanonicalizationPatterns(
 
     return mlir::success();
   });
-  // NOLINTEND(clang-analyzer-core.StackAddressEscape)
 }
 
 //===----------------------------------------------------------------------===//
@@ -2801,7 +2797,6 @@ void mlir::tt::ttir::LinearOp::getCanonicalizationPatterns(
 // MatmulOp canonicalization
 void mlir::tt::ttir::MatmulOp::getCanonicalizationPatterns(
     mlir::RewritePatternSet &patterns, mlir::MLIRContext *context) {
-  // NOLINTBEGIN(clang-analyzer-core.StackAddressEscape)
   // matmul(transpose(a), b, transpose_a, transpose_b) ->
   //   matmul(a, b, !transpose_a, transpose_b)
   patterns.add(+[](ttir::MatmulOp op, mlir::PatternRewriter &rewriter) {
@@ -2831,7 +2826,6 @@ void mlir::tt::ttir::MatmulOp::getCanonicalizationPatterns(
 
     return mlir::success();
   });
-  // NOLINTEND(clang-analyzer-core.StackAddressEscape)
 }
 
 //===----------------------------------------------------------------------===//
@@ -3368,7 +3362,6 @@ void mlir::tt::ttir::MatmulOp::getCanonicalizationPatterns(
 // ReverseOp canonicalization
 void mlir::tt::ttir::ReverseOp::getCanonicalizationPatterns(
     mlir::RewritePatternSet &patterns, mlir::MLIRContext *context) {
-  // NOLINTBEGIN(clang-analyzer-core.StackAddressEscape)
   // Reverse dimensions of two consecutive ReverseOps can be folded into a
   // single ReverseOp where the dimensions are the symmetric difference of the
   // two sets of dimensions.
@@ -3407,7 +3400,6 @@ void mlir::tt::ttir::ReverseOp::getCanonicalizationPatterns(
         rewriter.replaceAllOpUsesWith(op, op.getInput());
         return mlir::success();
       });
-  // NOLINTEND(clang-analyzer-core.StackAddressEscape)
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTIR/IR/TTIROpsTypes.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROpsTypes.cpp
@@ -17,7 +17,6 @@ using namespace mlir::tt::ttir;
 #include "ttmlir/Dialect/TTIR/IR/TTIROpsTypeDefs.cpp.inc"
 
 void TTIRDialect::registerTypes() {
-  // NOLINTNEXTLINE
   addTypes<
 #define GET_TYPEDEF_LIST
 #include "ttmlir/Dialect/TTIR/IR/TTIROpsTypeDefs.cpp.inc"

--- a/lib/Dialect/TTKernel/IR/TTKernelDialect.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelDialect.cpp
@@ -28,7 +28,6 @@ void TTKernelDialect::initialize() {
 #define GET_OP_LIST
 #include "ttmlir/Dialect/TTKernel/IR/TTKernelOps.cpp.inc"
       >();
-  // NOLINTNEXTLINE
   addAttributes<
 #define GET_ATTRDEF_LIST
 #include "ttmlir/Dialect/TTKernel/IR/TTKernelOpsAttrDefs.cpp.inc"

--- a/lib/Dialect/TTKernel/IR/TTKernelOpsTypes.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOpsTypes.cpp
@@ -56,7 +56,6 @@ size_t mlir::tt::ttkernel::ArgSpecAttr::appendRuntimeArg(func::FuncOp op,
 }
 
 void TTKernelDialect::registerTypes() {
-  // NOLINTNEXTLINE
   addTypes<
 #define GET_TYPEDEF_LIST
 #include "ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.cpp.inc"

--- a/lib/Dialect/TTMetal/IR/TTMetalDialect.cpp
+++ b/lib/Dialect/TTMetal/IR/TTMetalDialect.cpp
@@ -72,7 +72,6 @@ void TTMetalDialect::initialize() {
 #define GET_OP_LIST
 #include "ttmlir/Dialect/TTMetal/IR/TTMetalOps.cpp.inc"
       >();
-  // NOLINTNEXTLINE
   addAttributes<
 #define GET_ATTRDEF_LIST
 #include "ttmlir/Dialect/TTMetal/IR/TTMetalOpsAttrDefs.cpp.inc"

--- a/lib/Dialect/TTMetal/IR/TTMetalOpsTypes.cpp
+++ b/lib/Dialect/TTMetal/IR/TTMetalOpsTypes.cpp
@@ -19,7 +19,6 @@ using namespace mlir::tt::ttmetal;
 #include "ttmlir/Dialect/TTMetal/IR/TTMetalOpsTypes.cpp.inc"
 
 void TTMetalDialect::registerTypes() {
-  // NOLINTNEXTLINE
   addTypes<
 #define GET_TYPEDEF_LIST
 #include "ttmlir/Dialect/TTMetal/IR/TTMetalOpsTypes.cpp.inc"

--- a/lib/Dialect/TTNN/IR/TTNNDialect.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNDialect.cpp
@@ -61,7 +61,6 @@ void TTNNDialect::initialize() {
 #define GET_OP_LIST
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.cpp.inc"
       >();
-  // NOLINTNEXTLINE
   addAttributes<
 #define GET_ATTRDEF_LIST
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrDefs.cpp.inc"

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -695,7 +695,6 @@ mlir::tt::ttnn::TypecastOp::canonicalize(TypecastOp typecastOp,
 ::llvm::LogicalResult
 mlir::tt::ttnn::ToDTypeOp::canonicalize(ToDTypeOp op,
                                         ::mlir::PatternRewriter &rewriter) {
-  // NOLINTNEXTLINE
   return foldConsecutiveDataCastOps(op, rewriter);
 }
 
@@ -1478,7 +1477,6 @@ void mlir::tt::ttnn::ToLayoutOp::getCanonicalizationPatterns(
     ToLayoutOp previousToLayoutOp =
         toLayoutOp.getInput().getDefiningOp<ToLayoutOp>();
 
-    // NOLINTNEXTLINE
     if (!previousToLayoutOp) {
       return mlir::failure();
     }

--- a/lib/Dialect/TTNN/IR/TTNNOpsTypes.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpsTypes.cpp
@@ -16,7 +16,6 @@ using namespace mlir::tt::ttnn;
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsTypes.cpp.inc"
 
 void TTNNDialect::registerTypes() {
-  // NOLINTNEXTLINE
   addTypes<
 #define GET_TYPEDEF_LIST
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsTypes.cpp.inc"


### PR DESCRIPTION
With our most recent llvm uplift, we consumed a fix for all clang-tidy lint errors of type:
  clang-analyzer-core.StackAddressEscape

Remove these ignore directives since it's no longer an issue.