### PR TITLE
Set pykernel dep. to latest tt-mlir wheel release on tt-forge

### DIFF
--- a/.github/workflows/wheel-build.yml
+++ b/.github/workflows/wheel-build.yml
@@ -91,14 +91,6 @@ jobs:
         run: |
           python3.10 -m pip install wheel setuptools
 
-      # Add some of John's Bash Dark Magic to Update requirements.txt if possible.
-      - name: Update ttmlir Requirement
-        shell: bash
-        run: |
-          URL=$(curl -s https://api.github.com/repos/tenstorrent/tt-forge/releases | jq -r 'map(select(.name | contains("tt-mlir nightly"))) | first | .assets | map(select(.browser_download_url | contains("ttmlir"))) | .[].browser_download_url')
-          echo "ttmlir @ $URL" > tools/pykernel/requirements.txt
-          echo "Updated requirements.txt with: $URL"
-
       - name: Build pykernel wheel
         shell: bash
         run: |

--- a/tools/pykernel/requirements.txt
+++ b/tools/pykernel/requirements.txt
@@ -1,1 +1,1 @@
-ttmlir @ https://github.com/tenstorrent/tt-forge/releases/download/nightly-0.1.0.dev20250505060214/ttmlir-0.1.0.dev20250505060214-cp310-cp310-manylinux_2_34_x86_64.whl
+ttmlir @ https://github.com/tenstorrent/tt-forge/releases/download/tt-mlir-0.1.0.dev20250608/ttmlir-0.1.0.dev20250608-cp310-cp310-manylinux_2_34_x86_64.whl


### PR DESCRIPTION
### Problem description
- Previous bash script to get latest release is failing, resolve to a static release.
- Permanent solution is to package `ttmlir` within PyKernel, this is an incoming PR. Hotfix is meant to keep CI green.
