### PR TITLE
Removing reshape workaround for dump_device

### DIFF
--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -286,18 +286,11 @@ void dumpDeviceProfileResults(Device deviceHandle) {
 
   LOG_ASSERT(metalMeshDevice.is_parent_mesh(),
              "Mesh device must be a parent mesh");
-// NOTE: Reshaping the device before and after this dump is a temporary
-// workaround for tt-metal issue #22285 ttrt.common.run reshapes devices to (1,
-// number of device ids) tt-metal's DumpDeviceProfileResults expects the
-// mesh_shape in the SystemDesc This was throwing errors in llmbox tests
+
 #if defined(TT_RUNTIME_ENABLE_PERF_TRACE)
-  auto originalMeshShape = metalMeshDevice.shape();
-  metalMeshDevice.reshape(
-      ::tt::tt_metal::distributed::MeshShape(1, originalMeshShape.mesh_size()));
   for (tt_metal::IDevice *metalDevice : metalMeshDevice.get_devices()) {
     ::tt::tt_metal::detail::DumpDeviceProfileResults(metalDevice);
   }
-  metalMeshDevice.reshape(originalMeshShape);
 #endif
 }
 

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -529,17 +529,10 @@ void dumpDeviceProfileResults(Device deviceHandle) {
   LOG_ASSERT(ttnnMeshDevice.is_parent_mesh(),
              "Mesh device must be a parent mesh");
 
-// NOTE: Reshaping the device before and after this dump is a temporary
-// workaround for tt-metal issue #22285 ttrt.common.run reshapes devices to (1,
-// number of device ids) tt-metal's DumpDeviceProfileResults expects the
-// mesh_shape in the SystemDesc This was throwing errors in llmbox tests
 #if defined(TT_RUNTIME_ENABLE_PERF_TRACE)
-  auto originalMeshShape = ttnnMeshDevice.shape();
-  ttnnMeshDevice.reshape(::ttnn::MeshShape(1, originalMeshShape.mesh_size()));
   for (::ttnn::IDevice *ttnnDevice : ttnnMeshDevice.get_devices()) {
     ::tt::tt_metal::detail::DumpDeviceProfileResults(ttnnDevice);
   }
-  ttnnMeshDevice.reshape(originalMeshShape);
 #endif
 }
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/22285)

### Problem description
A [workaround](https://github.com/tenstorrent/tt-mlir/pull/3581) that reshaped the mesh device before and after profile dump was merged close this [mlir issue](https://github.com/tenstorrent/tt-mlir/issues/3428) and [metal issue](https://github.com/tenstorrent/tt-metal/issues/22285)

### What's changed
Removing workaround.

### Checklist
- [ ] New/Existing tests provide coverage for changes
