### PR TITLE
Update rewriteOutput as per-result based checking

### DIFF
--- a/test/ttmlir/Dialect/TTNN/ccl/mesh_shard.mlir
+++ b/test/ttmlir/Dialect/TTNN/ccl/mesh_shard.mlir
@@ -29,3 +29,28 @@ module @mesh_shard_test attributes {tt.meshes = #tt.meshes<[<"mesh" = 1x1>]>} {
 // CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
 // CHECK-SAME: shard_shape = array<i64: 1, 2>
 // CHECK-SAME: shard_type = #tt.shard_type<identity>
+
+// -----
+
+module @mesh_shard_test attributes {tt.meshes = #tt.meshes<[<"mesh" = 1x1>]>} {
+  func.func @forward(%arg0: tensor<8192x784xf32, #tt.mesh_sharding<"mesh">>) -> (tensor<8192x392xf32, #tt.mesh_sharding<"mesh", [ 2(0),  1]>>, tensor<1xf32>) {
+    %cst = "ttir.constant"() <{value = dense<6.400000e+01> : tensor<1xf32>}> : () -> tensor<1xf32, #tt.mesh_sharding<"mesh">>
+    %0 = ttir.empty() : tensor<8192x392xf32, #tt.mesh_sharding<"mesh", [ 2(0),  1]>>
+    %1 = "ttir.mesh_shard"(%arg0, %0) <{shard_dims = array<i64: 0, 1>, shard_direction = #tt.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 2>, shard_type = #tt.shard_type<identity>}> : (tensor<8192x784xf32, #tt.mesh_sharding<"mesh">>, tensor<8192x392xf32, #tt.mesh_sharding<"mesh", [ 2(0),  1]>>) -> tensor<8192x392xf32, #tt.mesh_sharding<"mesh", [ 2(0),  1]>>
+    %2 = ttir.empty() : tensor<1xf32>
+    %3 = "ttir.mesh_shard"(%cst, %2) <{shard_dims = array<i64: -1>, shard_direction = #tt.shard_direction<shard_to_full>, shard_shape = array<i64: 1>, shard_type = #tt.shard_type<replicate>}> : (tensor<1xf32, #tt.mesh_sharding<"mesh">>, tensor<1xf32>) -> tensor<1xf32>
+    return %1, %3 : tensor<8192x392xf32, #tt.mesh_sharding<"mesh", [ 2(0),  1]>>, tensor<1xf32>
+  }
+}
+// CHECK: [[DEVICE:%[0-9]+]] = "ttnn.get_device"()
+// CHECK: [[REG:.*]] = "ttnn.mesh_shard"([[ARG:.*]], [[DEVICE]])
+// CHECK-SAME: shard_dims = array<i64: -1>
+// CHECK-SAME: shard_direction = #tt.shard_direction<shard_to_full>
+// CHECK-SAME: shard_shape = array<i64: 1>
+// CHECK-SAME: shard_type = #tt.shard_type<replicate>
+// CHECK: [[DEVICE2:%[0-9]+]] = "ttnn.get_device"()
+// CHECK-NEXT: [[REG:.*]] = "ttnn.mesh_shard"([[ARG:.*]], [[DEVICE2]])
+// CHECK-SAME: shard_dims = array<i64: 0, 1>
+// CHECK-SAME: shard_direction = #tt.shard_direction<full_to_shard>
+// CHECK-SAME: shard_shape = array<i64: 1, 2>
+// CHECK-SAME: shard_type = #tt.shard_type<identity>


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/3733

### Problem description
Current ttnnLayout pass forces outputs to system memory if any of the result is from mesh_shard op. However, Andrej reported that new version of JAX mixes multi-device return values with single device one, causing issue. 

### What's changed
Update TTNNLayout rewriteOutput to be per-output based approach.

### Checklist
- [X] New/Existing tests provide coverage for changes
