### PR TITLE
Build tt-mlir with cmake 3.24

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.24.0)
 
 if(NOT DEFINED CMAKE_C_COMPILER)
   set(CMAKE_C_COMPILER clang CACHE STRING "C Compiler" FORCE)

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -16,7 +16,7 @@ You can use tt-mlir with Ubuntu or Mac OS, however the runtime does not work on 
 * Ubuntu 22.04 OS or Mac OS
 * Clang >= 14 & <= 18
 * Ninja
-* CMake 3.20 or higher
+* CMake 3.24 or higher
 * Python 3.10
 * python3.10-venv
 * openmpi

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -39,6 +39,8 @@ if (TTMLIR_ENABLE_STABLEHLO)
     SdyTransformsPropagationShardingGroupMap
     SdyTransformsPropagationShardingProjection
     SdyTransformsPropagationAutoPartitionerRegistry
+    SdyAxisListRef
+    SdyExplicitReshardsUtil
     SdyTransformsPropagationUtils
     SdyTransformsPropagationBasicFactorPropagation
     SdyTransformsPropagationAggressiveFactorPropagation


### PR DESCRIPTION
The docs state that CMake 3.20 or higher is required to build tt-mlir. 

However, tt-metal (a third party dependency) now requires CMake 3.24. That is now the new minimal requirement to build tt-mlir. 

Additionally when building the project with CMake 3.24 and configured with -DTTMLIR_ENABLE_STABLEHLO=ON the following error is observed:

```
undefined reference to `mlir::sdy::AxisListRef::strictPrefixOf(mlir::sdy::AxisListRef const&) const'
undefined reference to `mlir::sdy::AxisListRef::truncateWithoutOverlap(mlir::sdy::AxisListRef const&)'
undefined reference to `mlir::sdy::AxisListRef::getShardingSize(mlir::sdy::MeshAttr) const'
undefined reference to `mlir::sdy::AxisListRef::toVector() const'
undefined reference to `mlir::sdy::AxisListRef::operator<(mlir::sdy::AxisListRef const&) const'
```

The project fails to link due to unresolved references to symbols defined in libSdyAxisListRef.a. The linker errors occur when building executables like ttmlir-lsp-server and ttmlir-opt. 

Mysteriously this error is not observed when building with CMake 4.0.2. Perhaps the newer version of CMake can automatically handle the library dependencies. I could not find a definite answer as to why it worked with the updated CMake version. 

Changes
- Added SdyAxisListRef to the SHARDY_LIBS list in lib/CMakeLists.txt
- Explicitly added SdyExplicitReshardsUtil after SdyAxisListRef in the list to ensure correct linking order
- Updated documentation to specify CMake 3.24 as the minimum required version (previously listed as 3.20)