### PR TITLE
Fix `conv*` Tests & General Builder API Cleanup

### DIFF
--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -62,7 +62,7 @@ def cos(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = No
 @pytest.mark.parametrize("shape", [(128, 128)])
 @pytest.mark.parametrize("dtype", [torch.float32], ids=["f32"])
 def test_tan(shape: Shape, dtype: torch.dtype, request):
-    def tan(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+    def tan(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None):
         import math
 
         randn_tensor = torch.randn(shape, dtype=dtype)
@@ -95,7 +95,7 @@ def tanh(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = N
 @pytest.mark.parametrize("shape", [(128, 128)])
 @pytest.mark.parametrize("dtype", [torch.float32], ids=["f32"])
 def test_log(shape: Shape, dtype: torch.dtype, request):
-    def log(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+    def log(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None):
         randn_tensor = torch.randn(shape, dtype=dtype)
         abs_tensor = torch.abs(randn_tensor)
         error_margin = torch.full(randn_tensor.shape, 0.01)
@@ -118,7 +118,9 @@ def test_log(shape: Shape, dtype: torch.dtype, request):
 @pytest.mark.parametrize("shape", [(128, 128)])
 @pytest.mark.parametrize("dtype", [torch.float32], ids=["f32"])
 def test_log1p(shape: Shape, dtype: torch.dtype, request):
-    def log1p(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+    def log1p(
+        in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+    ):
         randn_tensor = torch.randn(shape, dtype=dtype)
         abs_tensor = torch.abs(randn_tensor)
         error_margin = torch.full(randn_tensor.shape, -0.99)
@@ -549,7 +551,7 @@ def broadcast(
     in0: Operand,
     in1: Operand,
     builder: TTIRBuilder,
-    broadcast_dimensions: List[int] = None,
+    broadcast_dimensions: Optional[List[int]] = None,
     unit_attrs: Optional[List[str]] = None,
 ):
     return builder.broadcast(

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -4,53 +4,57 @@
 
 import pytest
 import torch
-from typing import Callable, List
+from typing import Callable, List, Optional
 
 from ttir_builder import Operand, TTIRBuilder, Shape, TypeInfo
 from ttir_builder.utils import compile_to_flatbuffer, Marks, shape_str
 
 
-def exp(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def exp(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None):
     return builder.exp(in0, unit_attrs=unit_attrs)
 
 
-def expm1(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def expm1(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None):
     return builder.expm1(in0, unit_attrs=unit_attrs)
 
 
-def ceil(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def ceil(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None):
     return builder.ceil(in0, unit_attrs=unit_attrs)
 
 
-def floor(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def floor(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None):
     return builder.floor(in0, unit_attrs=unit_attrs)
 
 
-def abs(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def abs(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None):
     return builder.abs(in0, unit_attrs=unit_attrs)
 
 
-def logical_not(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def logical_not(
+    in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+):
     return builder.logical_not(in0, unit_attrs=unit_attrs)
 
 
-def bitwise_not(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def bitwise_not(
+    in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+):
     return builder.bitwise_not(in0, unit_attrs=unit_attrs)
 
 
-def neg(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def neg(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None):
     return builder.neg(in0, unit_attrs=unit_attrs)
 
 
-def sign(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def sign(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None):
     return builder.sign(in0, unit_attrs=unit_attrs)
 
 
-def sin(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def sin(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None):
     return builder.sin(in0, unit_attrs=unit_attrs)
 
 
-def cos(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def cos(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None):
     return builder.cos(in0, unit_attrs=unit_attrs)
 
 
@@ -79,11 +83,11 @@ def test_tan(shape: Shape, dtype: torch.dtype, request):
     )
 
 
-def atan(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def atan(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None):
     return builder.atan(in0, unit_attrs=unit_attrs)
 
 
-def tanh(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def tanh(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None):
     return builder.tanh(in0, unit_attrs=unit_attrs)
 
 
@@ -133,18 +137,20 @@ def test_log1p(shape: Shape, dtype: torch.dtype, request):
     )
 
 
-def relu(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def relu(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None):
     return builder.relu(in0, unit_attrs=unit_attrs)
 
 
-def gelu(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def gelu(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None):
     return builder.gelu(in0, unit_attrs=unit_attrs)
 
 
 @pytest.mark.parametrize("shape", [(64, 128)])
 @pytest.mark.parametrize("max_arg,min_arg", [(3.0, 2.0)])
 def test_clamp_scalar(shape: Shape, max_arg: float, min_arg: float, request):
-    def clamp_scalar(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+    def clamp_scalar(
+        in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+    ):
         return builder.clamp_scalar(
             in0, max_arg=max_arg, min_arg=min_arg, unit_attrs=unit_attrs
         )
@@ -166,7 +172,7 @@ def test_clamp_tensor(shapes: List[Shape], request):
         in2: Operand,
         in3: Operand,
         builder: TTIRBuilder,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ):
         return builder.clamp_tensor(in0, in1, in2, in3, unit_attrs=unit_attrs)
 
@@ -179,36 +185,42 @@ def test_clamp_tensor(shapes: List[Shape], request):
     )
 
 
-def leaky_relu(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def leaky_relu(
+    in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+):
     return builder.leaky_relu(in0, unit_attrs=unit_attrs)
 
 
-def sqrt(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def sqrt(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None):
     return builder.sqrt(in0, unit_attrs=unit_attrs)
 
 
-def cbrt(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def cbrt(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None):
     return builder.cbrt(in0, unit_attrs=unit_attrs)
 
 
-def rsqrt(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def rsqrt(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None):
     return builder.rsqrt(in0, unit_attrs=unit_attrs)
 
 
-def sigmoid(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def sigmoid(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None):
     return builder.sigmoid(in0, unit_attrs=unit_attrs)
 
 
-def reciprocal(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def reciprocal(
+    in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+):
     return builder.reciprocal(in0, unit_attrs=unit_attrs)
 
 
-def is_finite(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def is_finite(
+    in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+):
     return builder.is_finite(in0, unit_attrs=unit_attrs)
 
 
 def get_dimension_size(
-    in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None
+    in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
 ):
     return builder.get_dimension_size(in0, unit_attrs=unit_attrs)
 
@@ -239,7 +251,7 @@ def test_dot_general(
         in1: Operand,
         out0: Operand,
         builder: TTIRBuilder,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ):
         return builder.dot_general(
             in0,
@@ -261,100 +273,173 @@ def test_dot_general(
     )
 
 
-def add(in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def add(
+    in0: Operand,
+    in1: Operand,
+    builder: TTIRBuilder,
+    unit_attrs: Optional[List[str]] = None,
+):
     return builder.add(in0, in1, unit_attrs=unit_attrs)
 
 
 def multiply(
-    in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None
+    in0: Operand,
+    in1: Operand,
+    builder: TTIRBuilder,
+    unit_attrs: Optional[List[str]] = None,
 ):
     return builder.multiply(in0, in1, unit_attrs=unit_attrs)
 
 
 def logical_and(
-    in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None
+    in0: Operand,
+    in1: Operand,
+    builder: TTIRBuilder,
+    unit_attrs: Optional[List[str]] = None,
 ):
     return builder.logical_and(in0, in1, unit_attrs=unit_attrs)
 
 
 def logical_or(
-    in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None
+    in0: Operand,
+    in1: Operand,
+    builder: TTIRBuilder,
+    unit_attrs: Optional[List[str]] = None,
 ):
     return builder.logical_or(in0, in1, unit_attrs=unit_attrs)
 
 
 def logical_xor(
-    in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None
+    in0: Operand,
+    in1: Operand,
+    builder: TTIRBuilder,
+    unit_attrs: Optional[List[str]] = None,
 ):
     return builder.logical_xor(in0, in1, unit_attrs=unit_attrs)
 
 
 def bitwise_and(
-    in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None
+    in0: Operand,
+    in1: Operand,
+    builder: TTIRBuilder,
+    unit_attrs: Optional[List[str]] = None,
 ):
     return builder.bitwise_and(in0, in1, unit_attrs=unit_attrs)
 
 
 def bitwise_or(
-    in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None
+    in0: Operand,
+    in1: Operand,
+    builder: TTIRBuilder,
+    unit_attrs: Optional[List[str]] = None,
 ):
     return builder.bitwise_or(in0, in1, unit_attrs=unit_attrs)
 
 
 def bitwise_xor(
-    in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None
+    in0: Operand,
+    in1: Operand,
+    builder: TTIRBuilder,
+    unit_attrs: Optional[List[str]] = None,
 ):
     return builder.bitwise_xor(in0, in1, unit_attrs=unit_attrs)
 
 
 def subtract(
-    in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None
+    in0: Operand,
+    in1: Operand,
+    builder: TTIRBuilder,
+    unit_attrs: Optional[List[str]] = None,
 ):
     return builder.subtract(in0, in1, unit_attrs=unit_attrs)
 
 
-def eq(in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def eq(
+    in0: Operand,
+    in1: Operand,
+    builder: TTIRBuilder,
+    unit_attrs: Optional[List[str]] = None,
+):
     return builder.eq(in0, in1, unit_attrs=unit_attrs)
 
 
-def ne(in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def ne(
+    in0: Operand,
+    in1: Operand,
+    builder: TTIRBuilder,
+    unit_attrs: Optional[List[str]] = None,
+):
     return builder.ne(in0, in1, unit_attrs=unit_attrs)
 
 
-def ge(in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def ge(
+    in0: Operand,
+    in1: Operand,
+    builder: TTIRBuilder,
+    unit_attrs: Optional[List[str]] = None,
+):
     return builder.ge(in0, in1, unit_attrs=unit_attrs)
 
 
-def gt(in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def gt(
+    in0: Operand,
+    in1: Operand,
+    builder: TTIRBuilder,
+    unit_attrs: Optional[List[str]] = None,
+):
     return builder.gt(in0, in1, unit_attrs=unit_attrs)
 
 
-def le(in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def le(
+    in0: Operand,
+    in1: Operand,
+    builder: TTIRBuilder,
+    unit_attrs: Optional[List[str]] = None,
+):
     return builder.le(in0, in1, unit_attrs=unit_attrs)
 
 
-def lt(in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def lt(
+    in0: Operand,
+    in1: Operand,
+    builder: TTIRBuilder,
+    unit_attrs: Optional[List[str]] = None,
+):
     return builder.lt(in0, in1, unit_attrs=unit_attrs)
 
 
-def div(in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def div(
+    in0: Operand,
+    in1: Operand,
+    builder: TTIRBuilder,
+    unit_attrs: Optional[List[str]] = None,
+):
     return builder.div(in0, in1, unit_attrs=unit_attrs)
 
 
 def remainder(
-    in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None
+    in0: Operand,
+    in1: Operand,
+    builder: TTIRBuilder,
+    unit_attrs: Optional[List[str]] = None,
 ):
     return builder.remainder(in0, in1, unit_attrs=unit_attrs)
 
 
 def maximum(
-    in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None
+    in0: Operand,
+    in1: Operand,
+    builder: TTIRBuilder,
+    unit_attrs: Optional[List[str]] = None,
 ):
     return builder.maximum(in0, in1, unit_attrs=unit_attrs)
 
 
 def minimum(
-    in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None
+    in0: Operand,
+    in1: Operand,
+    builder: TTIRBuilder,
+    unit_attrs: Optional[List[str]] = None,
 ):
     return builder.minimum(in0, in1, unit_attrs=unit_attrs)
 
@@ -366,7 +451,7 @@ def test_linear(shapes: List[Shape], request):
         in1: Operand,
         in2: Operand,
         builder: TTIRBuilder,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ):
         return builder.linear(in0, in1, in2, unit_attrs=unit_attrs)
 
@@ -379,33 +464,41 @@ def test_linear(shapes: List[Shape], request):
     )
 
 
-def pow(in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def pow(
+    in0: Operand,
+    in1: Operand,
+    builder: TTIRBuilder,
+    unit_attrs: Optional[List[str]] = None,
+):
     return builder.pow(in0, in1, unit_attrs=unit_attrs)
 
 
 def matmul(
-    in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None
+    in0: Operand,
+    in1: Operand,
+    builder: TTIRBuilder,
+    unit_attrs: Optional[List[str]] = None,
 ):
     return builder.matmul(in0, in1, unit_attrs=unit_attrs)
 
 
-def sum(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def sum(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None):
     return builder.sum(in0, unit_attrs=unit_attrs)
 
 
-def mean(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def mean(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None):
     return builder.mean(in0, unit_attrs=unit_attrs)
 
 
-def max(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def max(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None):
     return builder.max(in0, unit_attrs=unit_attrs)
 
 
-def min(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def min(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None):
     return builder.min(in0, unit_attrs=unit_attrs)
 
 
-def reshape(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def reshape(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None):
     # Calculate total elements in the input tensor
     input_shape = builder.get_shape(in0)
     total_elements = 1
@@ -417,7 +510,9 @@ def reshape(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
     return builder.reshape(in0, new_shape, unit_attrs=unit_attrs)
 
 
-def transpose(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def transpose(
+    in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+):
     return builder.transpose(in0, unit_attrs=unit_attrs)
 
 
@@ -426,7 +521,9 @@ def transpose(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
 @pytest.mark.parametrize("dim_arg", [0])
 @pytest.mark.parametrize("keep_dim", [False])
 def test_prod(shape: Shape, dim_arg: int, keep_dim: bool, request):
-    def prod(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+    def prod(
+        in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+    ):
         return builder.prod(in0, [dim_arg], keep_dim, unit_attrs=unit_attrs)
 
     compile_to_flatbuffer(
@@ -443,7 +540,7 @@ def where(
     in1: Operand,
     in2: Operand,
     builder: TTIRBuilder,
-    unit_attrs: List[str] = None,
+    unit_attrs: Optional[List[str]] = None,
 ):
     return builder.where(in0, in1, in2, unit_attrs=unit_attrs)
 
@@ -453,7 +550,7 @@ def broadcast(
     in1: Operand,
     builder: TTIRBuilder,
     broadcast_dimensions: List[int] = None,
-    unit_attrs: List[str] = None,
+    unit_attrs: Optional[List[str]] = None,
 ):
     return builder.broadcast(
         in0, in1, broadcast_dimensions=broadcast_dimensions, unit_attrs=unit_attrs
@@ -466,7 +563,7 @@ def concat(
     in2: Operand,
     dim: int,
     builder: TTIRBuilder,
-    unit_attrs: List[str] = None,
+    unit_attrs: Optional[List[str]] = None,
 ):
     return builder.concat([in0, in1, in2], dim=dim, unit_attrs=unit_attrs)
 
@@ -476,7 +573,10 @@ def concat(
 def test_broadcast(shapes: List[Shape], broadcast_dimensions: List[int], request):
     # Create a wrapper function that captures broadcast_dimensions
     def broadcast_wrapper(
-        in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None
+        in0: Operand,
+        in1: Operand,
+        builder: TTIRBuilder,
+        unit_attrs: Optional[List[str]] = None,
     ):
         return broadcast(in0, in1, builder, broadcast_dimensions, unit_attrs)
 
@@ -510,7 +610,7 @@ def test_concat(shapes: List[Shape], dim: int, request):
         in1: Operand,
         in2: Operand,
         builder: TTIRBuilder,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ):
         return concat(in0, in1, in2, dim, builder, unit_attrs)
 
@@ -532,7 +632,9 @@ def test_concat(shapes: List[Shape], dim: int, request):
 @pytest.mark.parametrize("shape", [(1, 128, 128, 1)])
 @pytest.mark.parametrize("dim", [0])
 def test_squeeze(shape: Shape, dim: int, request):
-    def squeeze(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+    def squeeze(
+        in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+    ):
         return builder.squeeze(in0, dim, unit_attrs=unit_attrs)
 
     compile_to_flatbuffer(
@@ -550,7 +652,9 @@ def test_squeeze(shape: Shape, dim: int, request):
 @pytest.mark.parametrize("shape", [(128, 128)])
 @pytest.mark.parametrize("dim", [0])
 def test_unsqueeze(shape: Shape, dim: int, request):
-    def unsqueeze(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+    def unsqueeze(
+        in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+    ):
         return builder.unsqueeze(in0, dim, unit_attrs=unit_attrs)
 
     compile_to_flatbuffer(
@@ -565,7 +669,9 @@ def test_unsqueeze(shape: Shape, dim: int, request):
 @pytest.mark.parametrize("shape", [(1, 32, 32)])
 @pytest.mark.parametrize("dims", [[32, 1, 1]])
 def test_repeat(shape: Shape, dims: List[int], request):
-    def repeat(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+    def repeat(
+        in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+    ):
         return builder.repeat(in0, dims=dims, unit_attrs=unit_attrs)
 
     compile_to_flatbuffer(
@@ -590,7 +696,10 @@ def test_repeat(shape: Shape, dims: List[int], request):
 @pytest.mark.parametrize("repeats", [1])
 def test_repeat_interleave(shapes: List[Shape], repeats: int, dim: int, request):
     def repeat_interleave(
-        in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None
+        in0: Operand,
+        in1: Operand,
+        builder: TTIRBuilder,
+        unit_attrs: Optional[List[str]] = None,
     ):
         return builder.repeat_interleave(
             in0, in1, repeats=repeats, dim=dim, unit_attrs=unit_attrs
@@ -623,7 +732,7 @@ def test_concat(shapes: List[Shape], dim: int, request):
         in1: Operand,
         in2: Operand,
         builder: TTIRBuilder,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ):
         return concat(in0, in1, in2, dim, builder, unit_attrs)
 
@@ -669,7 +778,7 @@ def test_conv2d(
         bias: Operand,
         in1: Operand,
         builder: TTIRBuilder,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ):
         return builder.conv2d(
             in0,
@@ -722,7 +831,7 @@ def test_conv2d_consteval(
         bias: Operand,
         in1: Operand,
         builder: TTIRBuilder,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ):
         return builder.conv2d(
             in0,
@@ -775,7 +884,7 @@ def test_conv_transpose2d(
         bias: Operand,
         in1: Operand,
         builder: TTIRBuilder,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ):
         return builder.conv_transpose2d(
             in0,
@@ -823,7 +932,10 @@ def test_max_pool2d(
     request,
 ):
     def max_pool2d(
-        in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None
+        in0: Operand,
+        in1: Operand,
+        builder: TTIRBuilder,
+        unit_attrs: Optional[List[str]] = None,
     ):
         return builder.max_pool2d(
             in0,
@@ -858,7 +970,10 @@ def test_max_pool2d(
 @pytest.mark.parametrize("value", [0])
 def test_pad(shapes: List[Shape], padding: List[int], value: int, request):
     def pad(
-        in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None
+        in0: Operand,
+        in1: Operand,
+        builder: TTIRBuilder,
+        unit_attrs: Optional[List[str]] = None,
     ):
         return builder.pad(
             in0, in1, padding=padding, value=value, unit_attrs=unit_attrs
@@ -876,7 +991,9 @@ def test_pad(shapes: List[Shape], padding: List[int], value: int, request):
 @pytest.mark.parametrize("shape", [(32, 64)])
 @pytest.mark.parametrize("dim,begin,end,step", [(0, 0, 3, 1)])
 def test_index(shape: Shape, dim: int, begin: int, end: int, step: int, request):
-    def index(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+    def index(
+        in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+    ):
         return builder.index(
             in0, dim=dim, begin=begin, end=end, step=step, unit_attrs=unit_attrs
         )
@@ -894,7 +1011,9 @@ def test_index(shape: Shape, dim: int, begin: int, end: int, step: int, request)
 @pytest.mark.parametrize("shape", [(4, 4)])
 @pytest.mark.parametrize("dim,begin,length", [(1, 2, 2)])
 def test_select(shape: Shape, dim: int, begin: int, length: int, request):
-    def select(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+    def select(
+        in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+    ):
         return builder.select(
             in0, dim=dim, begin=begin, length=length, unit_attrs=unit_attrs
         )
@@ -911,7 +1030,7 @@ def test_select(shape: Shape, dim: int, begin: int, length: int, request):
 # TODO: these three nullary tensor creation ops can probably be combined in some way
 @pytest.mark.parametrize("shape", [(128, 128)], ids=["128x128"])
 def test_zeros(shape: Shape, request):
-    def zeros(builder: TTIRBuilder, unit_attrs: List[str] = None):
+    def zeros(builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None):
         return builder.zeros(shape, unit_attrs=unit_attrs)
 
     compile_to_flatbuffer(
@@ -925,7 +1044,7 @@ def test_zeros(shape: Shape, request):
 
 @pytest.mark.parametrize("shape", [(128, 128)], ids=["128x128"])
 def test_ones(shape: Shape, request):
-    def ones(builder: TTIRBuilder, unit_attrs: List[str] = None):
+    def ones(builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None):
         return builder.ones(shape, unit_attrs=unit_attrs)
 
     compile_to_flatbuffer(
@@ -940,7 +1059,9 @@ def test_ones(shape: Shape, request):
 @pytest.mark.parametrize("shapes", [[(128, 128)]])
 @pytest.mark.parametrize("dim_arg", [[1]])
 def test_argmax(shapes, dim_arg, request):
-    def argmax(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+    def argmax(
+        in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+    ):
         return builder.argmax(in0, dim_arg, unit_attrs=unit_attrs)
 
     compile_to_flatbuffer(
@@ -956,7 +1077,9 @@ def test_argmax(shapes, dim_arg, request):
 @pytest.mark.parametrize("shape", [(64, 64)])
 @pytest.mark.parametrize("dims", [[0, 1]])
 def test_reverse(shape: Shape, dims: List[int], request):
-    def reverse(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+    def reverse(
+        in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+    ):
         return builder.reverse(in0, dims=dims, unit_attrs=unit_attrs)
 
     compile_to_flatbuffer(
@@ -972,7 +1095,9 @@ def test_reverse(shape: Shape, dims: List[int], request):
 @pytest.mark.parametrize("shape", [(4, 4)])
 @pytest.mark.parametrize("dim_args", [[0, 1]])
 def test_reduce_and(shape: Shape, dim_args: List[int], request):
-    def reduce_and(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+    def reduce_and(
+        in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+    ):
         return builder.reduce_and(in0, dim_args=dim_args, unit_attrs=unit_attrs)
 
     compile_to_flatbuffer(
@@ -989,7 +1114,9 @@ def test_reduce_and(shape: Shape, dim_args: List[int], request):
 @pytest.mark.parametrize("shape", [(4, 4)])
 @pytest.mark.parametrize("dim_args", [[0, 1]])
 def test_reduce_or(shape: Shape, dim_args: List[int], request):
-    def reduce_or(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+    def reduce_or(
+        in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+    ):
         return builder.reduce_or(in0, dim_args=dim_args, unit_attrs=unit_attrs)
 
     compile_to_flatbuffer(
@@ -1007,7 +1134,7 @@ def permute(
     in1: Operand,
     builder: TTIRBuilder,
     permutation: List[int],
-    unit_attrs: List[str] = None,
+    unit_attrs: Optional[List[str]] = None,
 ):
     return builder.permute(
         in0,
@@ -1022,7 +1149,10 @@ def permute(
 def test_permute(shapes: List[Shape], permutation: List[int], request):
     # Create a wrapper function that captures permutation
     def permute_wrapper(
-        in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None
+        in0: Operand,
+        in1: Operand,
+        builder: TTIRBuilder,
+        unit_attrs: Optional[List[str]] = None,
     ):
         return permute(in0, in1, builder, permutation, unit_attrs)
 
@@ -1042,7 +1172,10 @@ def test_permute(shapes: List[Shape], permutation: List[int], request):
 @pytest.mark.parametrize("scale_factor", [[2, 4]])
 def test_upsample2d(shapes: List[Shape], scale_factor: List[int], request):
     def upsample2d(
-        in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None
+        in0: Operand,
+        in1: Operand,
+        builder: TTIRBuilder,
+        unit_attrs: Optional[List[str]] = None,
     ):
         return builder.upsample2d(
             in0,
@@ -1062,7 +1195,9 @@ def test_upsample2d(shapes: List[Shape], scale_factor: List[int], request):
 
 @pytest.mark.parametrize("shape,start,end,step,dim", [((5,), 0, 5, 1, 0)])
 def test_arange(shape: Shape, start: int, end: int, step: int, dim: int, request):
-    def arange(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+    def arange(
+        in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+    ):
         return builder.arange(in0, start, end, step, dim, unit_attrs=unit_attrs)
 
     compile_to_flatbuffer(
@@ -1084,7 +1219,10 @@ def test_typecast(
     shape: Shape, from_type: torch.dtype, to_type: torch.dtype, target: str, request
 ):
     def typecast(
-        in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None
+        in0: Operand,
+        in1: Operand,
+        builder: TTIRBuilder,
+        unit_attrs: Optional[List[str]] = None,
     ):
         return builder.typecast(in0, in1, unit_attrs=unit_attrs)
 
@@ -1107,7 +1245,10 @@ def test_typecast(
 @pytest.mark.parametrize("dim", [1])
 def test_cumsum(shapes: List[Shape], dim: int, request):
     def cumsum(
-        in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None
+        in0: Operand,
+        in1: Operand,
+        builder: TTIRBuilder,
+        unit_attrs: Optional[List[str]] = None,
     ):
         return builder.cumsum(in0, in1, dim=dim, unit_attrs=unit_attrs)
 
@@ -1120,7 +1261,7 @@ def test_cumsum(shapes: List[Shape], dim: int, request):
     )
 
 
-def prod(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+def prod(in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None):
     return builder.prod(in0, [1], False, unit_attrs=unit_attrs)
 
 
@@ -1128,7 +1269,10 @@ def prod(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
 @pytest.mark.parametrize("shapes", [[(1, 32, 64, 512), (1, 32, 3, 512)]])
 def test_fill_cache(shapes: List[Shape], request):
     def fill_cache(
-        in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None
+        in0: Operand,
+        in1: Operand,
+        builder: TTIRBuilder,
+        unit_attrs: Optional[List[str]] = None,
     ):
         return builder.fill_cache(in0, in1, unit_attrs=unit_attrs)
 
@@ -1145,7 +1289,7 @@ def softmax(
     in0: Operand,
     builder: TTIRBuilder,
     dimension: int = -1,
-    unit_attrs: List[str] = None,
+    unit_attrs: Optional[List[str]] = None,
 ):
     return builder.softmax(in0, dimension=dimension, unit_attrs=unit_attrs)
 
@@ -1155,7 +1299,7 @@ def softmax(
 def test_softmax(shape: Shape, dimension: int, request):
     # Create a wrapper function that captures dimension
     def softmax_wrapper(
-        in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None
+        in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
     ):
         return softmax(in0, builder, dimension, unit_attrs)
 
@@ -1180,7 +1324,7 @@ def test_update_cache(shapes: List[Shape], dtypes: List[torch.dtype], request):
         in1: Operand,
         in2: Operand,
         builder: TTIRBuilder,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ):
         return builder.update_cache(in0, in1, in2, unit_attrs=unit_attrs)
 
@@ -1195,7 +1339,10 @@ def test_update_cache(shapes: List[Shape], dtypes: List[torch.dtype], request):
 
 
 def embedding(
-    in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None
+    in0: Operand,
+    in1: Operand,
+    builder: TTIRBuilder,
+    unit_attrs: Optional[List[str]] = None,
 ):
     return builder.embedding(in0, in1, unit_attrs=unit_attrs)
 
@@ -1207,7 +1354,9 @@ def embedding(
 def test_quantize(
     shape: Shape, scale: float, zero_point: int, dtype: torch.dtype, request
 ):
-    def quantize(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+    def quantize(
+        in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+    ):
         return builder.quantize(in0, scale, zero_point, dtype, unit_attrs=unit_attrs)
 
     pipeline_options = ["enable-const-eval=false"]  # temporary workaround. Issue #3505.
@@ -1234,7 +1383,9 @@ def test_dequantize(
     dtype: torch.dtype,
     request,
 ):
-    def dequantize(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+    def dequantize(
+        in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+    ):
         return builder.dequantize(in0, scale, zero_point, dtype, unit_attrs=unit_attrs)
 
     pipeline_options = ["enable-const-eval=false"]  # temporary workaround. Issue #3505.
@@ -1262,7 +1413,9 @@ def test_requantize(
     dtype: torch.dtype,
     request,
 ):
-    def requantize(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+    def requantize(
+        in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
+    ):
         return builder.requantize(in0, scale, zero_point, dtype, unit_attrs=unit_attrs)
 
     pipeline_options = ["enable-const-eval=false"]  # temporary workaround. Issue #3505.
@@ -1453,7 +1606,10 @@ def test_hoisted_permute(shapes_and_perms, request, target: str):
     shapes, permutation = shapes_and_perms
 
     def permute_wrapper(
-        in0: Operand, in1: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None
+        in0: Operand,
+        in1: Operand,
+        builder: TTIRBuilder,
+        unit_attrs: Optional[List[str]] = None,
     ):
         return permute(in0, in1, builder, permutation, unit_attrs=["should_hoist"])
 

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -592,40 +592,6 @@ def test_broadcast(shapes: List[Shape], broadcast_dimensions: List[int], request
     )
 
 
-@pytest.mark.parametrize(
-    "shapes",
-    [
-        [
-            (64, 128),
-            (32, 128),
-            (16, 128),
-        ]
-    ],
-)
-@pytest.mark.parametrize("dim", [0])
-def test_concat(shapes: List[Shape], dim: int, request):
-    # Create a wrapper function that captures dim
-    def concat_wrapper(
-        in0: Operand,
-        in1: Operand,
-        in2: Operand,
-        builder: TTIRBuilder,
-        unit_attrs: Optional[List[str]] = None,
-    ):
-        return concat(in0, in1, in2, dim, builder, unit_attrs)
-
-    # Set the name for better test identification
-    concat_wrapper.__name__ = "concat"
-
-    compile_to_flatbuffer(
-        concat_wrapper,
-        shapes,
-        test_base=request.node.name,
-        output_root=request.config.getoption("--path"),
-        system_desc_path=request.config.getoption("--sys-desc"),
-    )
-
-
 @pytest.mark.skip(
     "This test is not valid for TTRT Perf due to weird issues with perf collection. Issue #2371"
 )

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -8,10 +8,6 @@ from typing import Callable, List
 
 from ttir_builder import Operand, TTIRBuilder, Shape, TypeInfo
 from ttir_builder.utils import compile_to_flatbuffer, Marks, shape_str
-from ttmlir.ir import (
-    DenseI64ArrayAttr,
-    DenseI32ArrayAttr,
-)
 
 
 def exp(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
@@ -643,7 +639,6 @@ def test_concat(shapes: List[Shape], dim: int, request):
     )
 
 
-@pytest.mark.skip("IntegerAttr type mismatch, see issue #2683")
 @pytest.mark.parametrize(
     "shapes",
     [
@@ -709,15 +704,15 @@ def test_conv2d(
         ]
     ],
 )
-@pytest.mark.parametrize("_stride", [[2, 1]])
-@pytest.mark.parametrize("_dilation", [[2, 1]])
-@pytest.mark.parametrize("_padding", [[2, 1]])
+@pytest.mark.parametrize("stride", [[2, 1]])
+@pytest.mark.parametrize("dilation", [[2, 1]])
+@pytest.mark.parametrize("padding", [[2, 1]])
 @pytest.mark.parametrize("groups", [2])
 def test_conv2d_consteval(
     shapes: List[Shape],
-    _stride: List[int],
-    _padding: List[int],
-    _dilation: List[int],
+    stride: List[int],
+    padding: List[int],
+    dilation: List[int],
     groups: int,
     request,
 ):
@@ -729,9 +724,6 @@ def test_conv2d_consteval(
         builder: TTIRBuilder,
         unit_attrs: List[str] = None,
     ):
-        stride = DenseI32ArrayAttr.get(_stride)
-        padding = DenseI32ArrayAttr.get(_padding)
-        dilation = DenseI32ArrayAttr.get(_dilation)
         return builder.conv2d(
             in0,
             weight,
@@ -752,7 +744,6 @@ def test_conv2d_consteval(
     )
 
 
-@pytest.mark.skip("IntegerAttr type mismatch, see issue #2683")
 @pytest.mark.parametrize(
     "shapes",
     [
@@ -1021,7 +1012,7 @@ def permute(
     return builder.permute(
         in0,
         in1,
-        permutation=DenseI64ArrayAttr.get(permutation),
+        permutation=permutation,
         unit_attrs=unit_attrs,
     )
 
@@ -1056,7 +1047,7 @@ def test_upsample2d(shapes: List[Shape], scale_factor: List[int], request):
         return builder.upsample2d(
             in0,
             in1,
-            scale_factor=DenseI32ArrayAttr.get(scale_factor),
+            scale_factor=scale_factor,
             unit_attrs=unit_attrs,
         )
 

--- a/tools/ttir-builder/builder.py
+++ b/tools/ttir-builder/builder.py
@@ -11,7 +11,6 @@ from ttmlir.ir import *
 from ttmlir.dialects import ttir, ttcore, tensor, quant
 from ttmlir.passes import GoldenTensor, DataType
 import torch
-import array
 from enum import Enum, auto
 import re
 from .ccl_golden import *
@@ -90,7 +89,7 @@ class Golden:
     # only for randomly generated tensors, for example args of MLIR function
     # wrapped around user-written op graph. Every other tensor is output of some
     # op from graph.
-    seed: int = None
+    seed: Opional[int] = None
 
     def __repr__(self) -> str:
         s = f"\nRandom seed: {self.seed}" if self.seed is not None else ""

--- a/tools/ttir-builder/builder.py
+++ b/tools/ttir-builder/builder.py
@@ -1468,15 +1468,21 @@ class TTIRBuilder:
                 "groups": groups,
             },
             ttir_kwargs={
-                "stride": IntegerAttr.get(IntegerType.get_signed(32), stride)
-                if isinstance(stride, int)
-                else DenseI32ArrayAttr.get(stride),
-                "padding": IntegerAttr.get(IntegerType.get_signed(32), padding)
-                if isinstance(padding, int)
-                else DenseI32ArrayAttr.get(padding),
-                "dilation": IntegerAttr.get(IntegerType.get_signed(32), dilation)
-                if isinstance(dilation, int)
-                else DenseI32ArrayAttr.get(dilation),
+                "stride": (
+                    IntegerAttr.get(IntegerType.get_signed(32), stride)
+                    if isinstance(stride, int)
+                    else DenseI32ArrayAttr.get(stride)
+                ),
+                "padding": (
+                    IntegerAttr.get(IntegerType.get_signed(32), padding)
+                    if isinstance(padding, int)
+                    else DenseI32ArrayAttr.get(padding)
+                ),
+                "dilation": (
+                    IntegerAttr.get(IntegerType.get_signed(32), dilation)
+                    if isinstance(dilation, int)
+                    else DenseI32ArrayAttr.get(dilation)
+                ),
                 "groups": groups,
             },
             organize_ttir_args=lambda i, o, _: (self._get_type(o), i[0], i[1], o),
@@ -1542,13 +1548,31 @@ class TTIRBuilder:
                 "groups": groups,
             },
             ttir_kwargs={
-                "stride": IntegerAttr.get(IntegerType.get_signless(32), stride),
-                "padding": IntegerAttr.get(IntegerType.get_signless(32), padding),
-                "output_padding": IntegerAttr.get(
-                    IntegerType.get_signless(32), output_padding
+                "stride": (
+                    IntegerAttr.get(IntegerType.get_signless(32), stride)
+                    if isinstance(stride, int)
+                    else DenseI32ArrayAttr.get(stride)
                 ),
-                "dilation": IntegerAttr.get(IntegerType.get_signless(32), dilation),
-                "groups": IntegerAttr.get(IntegerType.get_signless(32), groups),
+                "padding": (
+                    IntegerAttr.get(IntegerType.get_signless(32), padding)
+                    if isinstance(padding, int)
+                    else DenseI32ArrayAttr.get(padding)
+                ),
+                "output_padding": (
+                    IntegerAttr.get(IntegerType.get_signless(32), output_padding)
+                    if isinstance(output_padding, int)
+                    else DenseI32ArrayAttr.get(output_padding)
+                ),
+                "dilation": (
+                    IntegerAttr.get(IntegerType.get_signless(32), dilation)
+                    if isinstance(dilation, int)
+                    else DenseI32ArrayAttr.get(dilation)
+                ),
+                "groups": (
+                    IntegerAttr.get(IntegerType.get_signless(32), groups)
+                    if isinstance(groups, int)
+                    else DenseI32ArrayAttr.get(groups)
+                ),
                 "bias": bias,
             },
             unit_attrs=unit_attrs,
@@ -2010,9 +2034,11 @@ class TTIRBuilder:
     ) -> OpView:
         output_shape = self._get_golden_tensor(in1).shape
         kwargs = {
-            "scale_factor": IntegerAttr.get(IntegerType.get_signed(32), scale_factor)
-            if isinstance(scale_factor, int)
-            else DenseI32ArrayAttr.get(scale_factor),
+            "scale_factor": (
+                IntegerAttr.get(IntegerType.get_signed(32), scale_factor)
+                if isinstance(scale_factor, int)
+                else DenseI32ArrayAttr.get(scale_factor)
+            ),
             "mode": mode,
         }
         return self.op_proxy(

--- a/tools/ttir-builder/builder.py
+++ b/tools/ttir-builder/builder.py
@@ -525,7 +525,7 @@ class TTIRBuilder:
         op_golden_function: Callable,
         op_ttir_function: Callable,
         inputs: List[Operand],
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
         organize_ttir_args: Optional[Callable] = None,
         organize_golden_args: Optional[Callable] = None,
         output_shape: Optional[Shape] = None,
@@ -638,7 +638,7 @@ class TTIRBuilder:
                 )
 
             # Add unit attributes if specified
-            if unit_attrs:
+            if unit_attrs is not None:
                 from ttmlir.ir import UnitAttr
 
                 for attr_name in unit_attrs:
@@ -653,7 +653,7 @@ class TTIRBuilder:
         op_golden_function: Callable,
         op_ttir_function: Callable,
         inputs: List[Operand],
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         return self.op_proxy(op_golden_function, op_ttir_function, inputs, unit_attrs)
 
@@ -685,7 +685,7 @@ class TTIRBuilder:
     # TTIR top level ops
 
     def get_dimension_size(
-        self, in0: Operand, dimension: int = 0, unit_attrs: List[str] = None
+        self, in0: Operand, dimension: int = 0, unit_attrs: Optional[List[str]] = None
     ) -> OpView:
         golden_data = [self._get_golden_tensor(in0).size(dimension)]
         return self.op_proxy(
@@ -709,7 +709,7 @@ class TTIRBuilder:
         contract_dims_lhs: List[int],
         batch_dims_rhs: List[int],
         contract_dims_rhs: List[int],
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         kwargs = {
             "batch_dims_lhs": batch_dims_lhs,
@@ -770,7 +770,11 @@ class TTIRBuilder:
     # class TTIR_ElementwiseTernaryOp
 
     def where(
-        self, in0: Operand, in1: Operand, in2: Operand, unit_attrs: List[str] = None
+        self,
+        in0: Operand,
+        in1: Operand,
+        in2: Operand,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         # Handle golden condition tensor
         in0_tensor = self._get_golden_tensor(in0)
@@ -790,10 +794,10 @@ class TTIRBuilder:
 
     # class TTIR_ElementwiseUnaryOp
 
-    def abs(self, in0: Operand, unit_attrs: List[str] = None) -> OpView:
+    def abs(self, in0: Operand, unit_attrs: Optional[List[str]] = None) -> OpView:
         return self.eltwise_proxy(torch.abs, ttir.AbsOp, [in0], unit_attrs)
 
-    def cbrt(self, in0: Operand, unit_attrs: List[str] = None) -> OpView:
+    def cbrt(self, in0: Operand, unit_attrs: Optional[List[str]] = None) -> OpView:
         golden = self._get_golden_tensor(in0)
         golden_sign = torch.sign(golden)
         golden_cbrt = torch.pow(torch.abs(golden), 1 / 3)
@@ -806,24 +810,26 @@ class TTIRBuilder:
             unit_attrs=unit_attrs,
         )
 
-    def ceil(self, in0: Operand, unit_attrs: List[str] = None) -> OpView:
+    def ceil(self, in0: Operand, unit_attrs: Optional[List[str]] = None) -> OpView:
         return self.eltwise_proxy(torch.ceil, ttir.CeilOp, [in0], unit_attrs)
 
-    def cos(self, in0: Operand, unit_attrs: List[str] = None) -> OpView:
+    def cos(self, in0: Operand, unit_attrs: Optional[List[str]] = None) -> OpView:
         return self.eltwise_proxy(torch.cos, ttir.CosOp, [in0], unit_attrs)
 
-    def floor(self, in0: Operand, unit_attrs: List[str] = None) -> OpView:
+    def floor(self, in0: Operand, unit_attrs: Optional[List[str]] = None) -> OpView:
         return self.eltwise_proxy(torch.floor, ttir.FloorOp, [in0], unit_attrs)
 
-    def gelu(self, in0: Operand, unit_attrs: List[str] = None) -> OpView:
+    def gelu(self, in0: Operand, unit_attrs: Optional[List[str]] = None) -> OpView:
         return self.eltwise_proxy(
             torch.nn.functional.gelu, ttir.GeluOp, [in0], unit_attrs
         )
 
-    def is_finite(self, in0: Operand, unit_attrs: List[str] = None) -> OpView:
+    def is_finite(self, in0: Operand, unit_attrs: Optional[List[str]] = None) -> OpView:
         return self.eltwise_proxy(torch.isfinite, ttir.IsFiniteOp, [in0], unit_attrs)
 
-    def logical_not(self, in0: Operand, unit_attrs: List[str] = None) -> OpView:
+    def logical_not(
+        self, in0: Operand, unit_attrs: Optional[List[str]] = None
+    ) -> OpView:
         golden = self._get_golden_tensor(in0)
         golden_output = torch.empty(golden.shape, dtype=golden.dtype)
         return self.op_proxy(
@@ -834,49 +840,53 @@ class TTIRBuilder:
             unit_attrs=unit_attrs,
         )
 
-    def bitwise_not(self, in0: Operand, unit_attrs: List[str] = None) -> OpView:
+    def bitwise_not(
+        self, in0: Operand, unit_attrs: Optional[List[str]] = None
+    ) -> OpView:
         return self.eltwise_proxy(
             torch.bitwise_not, ttir.BitwiseNotOp, [in0], unit_attrs
         )
 
-    def neg(self, in0: Operand, unit_attrs: List[str] = None) -> OpView:
+    def neg(self, in0: Operand, unit_attrs: Optional[List[str]] = None) -> OpView:
         return self.eltwise_proxy(torch.neg, ttir.NegOp, [in0], unit_attrs)
 
     # NOTE: See issue #1719 for information on golden PCC fail
-    def tan(self, in0: Operand, unit_attrs: List[str] = None) -> OpView:
+    def tan(self, in0: Operand, unit_attrs: Optional[List[str]] = None) -> OpView:
         return self.eltwise_proxy(torch.tan, ttir.TanOp, [in0], unit_attrs)
 
-    def atan(self, in0: Operand, unit_attrs: List[str] = None) -> OpView:
+    def atan(self, in0: Operand, unit_attrs: Optional[List[str]] = None) -> OpView:
         return self.eltwise_proxy(torch.atan, ttir.AtanOp, [in0], unit_attrs)
 
-    def tanh(self, in0: Operand, unit_attrs: List[str] = None) -> OpView:
+    def tanh(self, in0: Operand, unit_attrs: Optional[List[str]] = None) -> OpView:
         return self.eltwise_proxy(torch.tanh, ttir.TanhOp, [in0], unit_attrs)
 
-    def reciprocal(self, in0: Operand, unit_attrs: List[str] = None) -> OpView:
+    def reciprocal(
+        self, in0: Operand, unit_attrs: Optional[List[str]] = None
+    ) -> OpView:
         return self.eltwise_proxy(
             torch.reciprocal, ttir.ReciprocalOp, [in0], unit_attrs
         )
 
-    def relu(self, in0: Operand, unit_attrs: List[str] = None) -> OpView:
+    def relu(self, in0: Operand, unit_attrs: Optional[List[str]] = None) -> OpView:
         return self.eltwise_proxy(torch.relu, ttir.ReluOp, [in0], unit_attrs)
 
-    def rsqrt(self, in0: Operand, unit_attrs: List[str] = None) -> OpView:
+    def rsqrt(self, in0: Operand, unit_attrs: Optional[List[str]] = None) -> OpView:
         return self.eltwise_proxy(torch.rsqrt, ttir.RsqrtOp, [in0], unit_attrs)
 
-    def sigmoid(self, in0: Operand, unit_attrs: List[str] = None) -> OpView:
+    def sigmoid(self, in0: Operand, unit_attrs: Optional[List[str]] = None) -> OpView:
         return self.eltwise_proxy(torch.sigmoid, ttir.SigmoidOp, [in0], unit_attrs)
 
-    def sign(self, in0: Operand, unit_attrs: List[str] = None) -> OpView:
+    def sign(self, in0: Operand, unit_attrs: Optional[List[str]] = None) -> OpView:
         return self.eltwise_proxy(torch.sign, ttir.SignOp, [in0], unit_attrs)
 
-    def sin(self, in0: Operand, unit_attrs: List[str] = None) -> OpView:
+    def sin(self, in0: Operand, unit_attrs: Optional[List[str]] = None) -> OpView:
         return self.eltwise_proxy(torch.sin, ttir.SinOp, [in0], unit_attrs)
 
-    def sqrt(self, in0: Operand, unit_attrs: List[str] = None) -> OpView:
+    def sqrt(self, in0: Operand, unit_attrs: Optional[List[str]] = None) -> OpView:
         return self.eltwise_proxy(torch.sqrt, ttir.SqrtOp, [in0], unit_attrs)
 
     def typecast(
-        self, in0: Operand, out: Operand, unit_attrs: List[str] = None
+        self, in0: Operand, out: Operand, unit_attrs: Optional[List[str]] = None
     ) -> OpView:
         output_type = self.get_type_from_torch_dtype(self._get_golden_tensor(out).dtype)
         return self.op_proxy(
@@ -888,19 +898,22 @@ class TTIRBuilder:
             unit_attrs=unit_attrs,
         )
 
-    def log(self, in0: Operand, unit_attrs: List[str] = None) -> OpView:
+    def log(self, in0: Operand, unit_attrs: Optional[List[str]] = None) -> OpView:
         return self.eltwise_proxy(torch.log, ttir.LogOp, [in0], unit_attrs)
 
-    def log1p(self, in0: Operand, unit_attrs: List[str] = None) -> OpView:
+    def log1p(self, in0: Operand, unit_attrs: Optional[List[str]] = None) -> OpView:
         return self.eltwise_proxy(torch.log1p, ttir.Log1pOp, [in0], unit_attrs)
 
-    def expm1(self, in0: Operand, unit_attrs: List[str] = None) -> OpView:
+    def expm1(self, in0: Operand, unit_attrs: Optional[List[str]] = None) -> OpView:
         return self.eltwise_proxy(torch.expm1, ttir.Expm1Op, [in0], unit_attrs)
 
     # class TTIR_ElementwiseUnaryWithFloatParameterOp
 
     def leaky_relu(
-        self, in0: Operand, parameter: float = 0.01, unit_attrs: List[str] = None
+        self,
+        in0: Operand,
+        parameter: float = 0.01,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         # TODO: reconcile this naming mismatch
         ttir_kwargs = {"parameter": parameter}
@@ -916,7 +929,9 @@ class TTIRBuilder:
 
     # class TTIR_ElementwiseBinaryOp
 
-    def eq(self, in0: Operand, in1: Operand, unit_attrs: List[str] = None) -> OpView:
+    def eq(
+        self, in0: Operand, in1: Operand, unit_attrs: Optional[List[str]] = None
+    ) -> OpView:
         golden = self._get_golden_tensor(in0)
         golden_output = torch.empty(golden.shape, dtype=golden.dtype)
         return self.op_proxy(
@@ -927,7 +942,9 @@ class TTIRBuilder:
             unit_attrs=unit_attrs,
         )
 
-    def ne(self, in0: Operand, in1: Operand, unit_attrs: List[str] = None) -> OpView:
+    def ne(
+        self, in0: Operand, in1: Operand, unit_attrs: Optional[List[str]] = None
+    ) -> OpView:
         return self.op_proxy(
             torch.ne,
             ttir.NotEqualOp,
@@ -935,7 +952,9 @@ class TTIRBuilder:
             unit_attrs=unit_attrs,
         )
 
-    def ge(self, in0: Operand, in1: Operand, unit_attrs: List[str] = None) -> OpView:
+    def ge(
+        self, in0: Operand, in1: Operand, unit_attrs: Optional[List[str]] = None
+    ) -> OpView:
         golden = self._get_golden_tensor(in0)
         golden_output = torch.empty(golden.shape, dtype=golden.dtype)
         return self.op_proxy(
@@ -946,7 +965,9 @@ class TTIRBuilder:
             unit_attrs=unit_attrs,
         )
 
-    def gt(self, in0: Operand, in1: Operand, unit_attrs: List[str] = None) -> OpView:
+    def gt(
+        self, in0: Operand, in1: Operand, unit_attrs: Optional[List[str]] = None
+    ) -> OpView:
         golden = self._get_golden_tensor(in0)
         golden_output = torch.empty(golden.shape, dtype=golden.dtype)
         return self.op_proxy(
@@ -957,7 +978,9 @@ class TTIRBuilder:
             unit_attrs=unit_attrs,
         )
 
-    def le(self, in0: Operand, in1: Operand, unit_attrs: List[str] = None) -> OpView:
+    def le(
+        self, in0: Operand, in1: Operand, unit_attrs: Optional[List[str]] = None
+    ) -> OpView:
         golden = self._get_golden_tensor(in0)
         golden_output = torch.empty(golden.shape, dtype=golden.dtype)
         return self.op_proxy(
@@ -968,7 +991,9 @@ class TTIRBuilder:
             unit_attrs=unit_attrs,
         )
 
-    def lt(self, in0: Operand, in1: Operand, unit_attrs: List[str] = None) -> OpView:
+    def lt(
+        self, in0: Operand, in1: Operand, unit_attrs: Optional[List[str]] = None
+    ) -> OpView:
         golden = self._get_golden_tensor(in0)
         golden_output = torch.empty(golden.shape, dtype=golden.dtype)
         return self.op_proxy(
@@ -980,7 +1005,7 @@ class TTIRBuilder:
         )
 
     def logical_and(
-        self, in0: Operand, in1: Operand, unit_attrs: List[str] = None
+        self, in0: Operand, in1: Operand, unit_attrs: Optional[List[str]] = None
     ) -> OpView:
         golden = self._get_golden_tensor(in0)
         golden_output = torch.empty(golden.shape, dtype=golden.dtype)
@@ -993,7 +1018,7 @@ class TTIRBuilder:
         )
 
     def logical_or(
-        self, in0: Operand, in1: Operand, unit_attrs: List[str] = None
+        self, in0: Operand, in1: Operand, unit_attrs: Optional[List[str]] = None
     ) -> OpView:
         golden = self._get_golden_tensor(in0)
         golden_output = torch.empty(golden.shape, dtype=golden.dtype)
@@ -1006,7 +1031,7 @@ class TTIRBuilder:
         )
 
     def logical_xor(
-        self, in0: Operand, in1: Operand, unit_attrs: List[str] = None
+        self, in0: Operand, in1: Operand, unit_attrs: Optional[List[str]] = None
     ) -> OpView:
         golden = self._get_golden_tensor(in0)
         golden_output = torch.empty(golden.shape, dtype=golden.dtype)
@@ -1019,48 +1044,50 @@ class TTIRBuilder:
         )
 
     def bitwise_and(
-        self, in0: Operand, in1: Operand, unit_attrs: List[str] = None
+        self, in0: Operand, in1: Operand, unit_attrs: Optional[List[str]] = None
     ) -> OpView:
         return self.eltwise_proxy(
             torch.bitwise_and, ttir.BitwiseAndOp, [in0, in1], unit_attrs=unit_attrs
         )
 
     def bitwise_or(
-        self, in0: Operand, in1: Operand, unit_attrs: List[str] = None
+        self, in0: Operand, in1: Operand, unit_attrs: Optional[List[str]] = None
     ) -> OpView:
         return self.eltwise_proxy(
             torch.bitwise_or, ttir.BitwiseOrOp, [in0, in1], unit_attrs=unit_attrs
         )
 
     def bitwise_xor(
-        self, in0: Operand, in1: Operand, unit_attrs: List[str] = None
+        self, in0: Operand, in1: Operand, unit_attrs: Optional[List[str]] = None
     ) -> OpView:
         return self.eltwise_proxy(
             torch.bitwise_xor, ttir.BitwiseXorOp, [in0, in1], unit_attrs=unit_attrs
         )
 
     def minimum(
-        self, in0: Operand, in1: Operand, unit_attrs: List[str] = None
+        self, in0: Operand, in1: Operand, unit_attrs: Optional[List[str]] = None
     ) -> OpView:
         return self.eltwise_proxy(
             torch.minimum, ttir.MinimumOp, [in0, in1], unit_attrs=unit_attrs
         )
 
     def subtract(
-        self, in0: Operand, in1: Operand, unit_attrs: List[str] = None
+        self, in0: Operand, in1: Operand, unit_attrs: Optional[List[str]] = None
     ) -> OpView:
         return self.eltwise_proxy(
             torch.subtract, ttir.SubtractOp, [in0, in1], unit_attrs=unit_attrs
         )
 
     def remainder(
-        self, in0: Operand, in1: Operand, unit_attrs: List[str] = None
+        self, in0: Operand, in1: Operand, unit_attrs: Optional[List[str]] = None
     ) -> OpView:
         return self.eltwise_proxy(
             torch.remainder, ttir.RemainderOp, [in0, in1], unit_attrs=unit_attrs
         )
 
-    def pow(self, in0: Operand, in1: Operand, unit_attrs: List[str] = None) -> OpView:
+    def pow(
+        self, in0: Operand, in1: Operand, unit_attrs: Optional[List[str]] = None
+    ) -> OpView:
         return self.eltwise_proxy(
             torch.pow, ttir.PowOp, [in0, in1], unit_attrs=unit_attrs
         )
@@ -1072,7 +1099,7 @@ class TTIRBuilder:
         in0: Operand,
         dim_arg: List[int],
         keep_dim: bool = False,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         kwargs = {"dim_arg": dim_arg, "keep_dim": keep_dim}
         return self.op_proxy(
@@ -1096,7 +1123,7 @@ class TTIRBuilder:
         in0: Operand,
         dim_arg: List[int] = [0],
         keep_dim: bool = True,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         return self.op_proxy(
             torch.sum,
@@ -1112,7 +1139,7 @@ class TTIRBuilder:
         in0: Operand,
         dim_arg: List[int] = [0],
         keep_dim: bool = True,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         return self.op_proxy(
             torch.mean,
@@ -1128,7 +1155,7 @@ class TTIRBuilder:
         in0: Operand,
         dim_arg: int = None,
         keep_dim: bool = True,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         # Handle ttir and golden function arguments for edge cases
         golden_kwargs = {}
@@ -1155,7 +1182,7 @@ class TTIRBuilder:
         in0: Operand,
         dim_arg: int = None,
         keep_dim: bool = True,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         # Handle ttir and golden function arguments for edge cases
         golden_kwargs = {}
@@ -1183,7 +1210,7 @@ class TTIRBuilder:
         in0: Operand,
         keep_dim: bool = True,
         dim_args: Optional[List] = None,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         return self.op_proxy(
             torch.all,
@@ -1200,7 +1227,7 @@ class TTIRBuilder:
         in0: Operand,
         keep_dim: bool = True,
         dim_args: Optional[List] = None,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         return self.op_proxy(
             torch.any,
@@ -1216,7 +1243,7 @@ class TTIRBuilder:
         in0: Operand,
         dim_arg: List[int],
         keep_dim: bool = False,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         golden_kwargs = {}
         if len(dim_arg) == 1:
@@ -1235,7 +1262,7 @@ class TTIRBuilder:
         )
 
     def embedding(
-        self, in0: Operand, in1: Operand, unit_attrs: List[str] = None
+        self, in0: Operand, in1: Operand, unit_attrs: Optional[List[str]] = None
     ) -> OpView:
         embedding = torch.nn.Embedding.from_pretrained(self._get_golden_tensor(in1))
         golden_typecast = self._get_golden_tensor(in0).to(torch.int32)
@@ -1251,7 +1278,11 @@ class TTIRBuilder:
         )
 
     def cumsum(
-        self, in0: Operand, in1: Operand, dim: int, unit_attrs: List[str] = None
+        self,
+        in0: Operand,
+        in1: Operand,
+        dim: int,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         return self.op_proxy(
             torch.cumsum,
@@ -1265,7 +1296,7 @@ class TTIRBuilder:
         )
 
     def softmax(
-        self, in0: Operand, dimension: int = 1, unit_attrs: List[str] = None
+        self, in0: Operand, dimension: int = 1, unit_attrs: Optional[List[str]] = None
     ) -> OpView:
         return self.op_proxy(
             # torch.softmax,
@@ -1283,7 +1314,11 @@ class TTIRBuilder:
         )
 
     def transpose(
-        self, in0: Operand, dim0: int = 0, dim1: int = 1, unit_attrs: List[str] = None
+        self,
+        in0: Operand,
+        dim0: int = 0,
+        dim1: int = 1,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         kwargs = {"dim0": dim0, "dim1": dim1}
         return self.op_proxy(
@@ -1296,7 +1331,7 @@ class TTIRBuilder:
         )
 
     def concat(
-        self, ins: List[Operand], dim: int = 0, unit_attrs: List[str] = None
+        self, ins: List[Operand], dim: int = 0, unit_attrs: Optional[List[str]] = None
     ) -> OpView:
         kwargs = {"dim": dim}
         return self.op_proxy(
@@ -1314,7 +1349,7 @@ class TTIRBuilder:
         )
 
     def repeat(
-        self, in0: Operand, dims: List[int], unit_attrs: List[str] = None
+        self, in0: Operand, dims: List[int], unit_attrs: Optional[List[str]] = None
     ) -> OpView:
         return self.op_proxy(
             torch.Tensor.repeat,
@@ -1331,7 +1366,7 @@ class TTIRBuilder:
         in1: Operand,
         repeats: int,
         dim: int,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         return self.op_proxy(
             torch.repeat_interleave,
@@ -1352,7 +1387,7 @@ class TTIRBuilder:
         in0: Operand,
         in1: Operand,
         batch_offset: int = 0,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         cache_tensor = self._get_golden_tensor(in0)
         input_tensor = self._get_golden_tensor(in1)
@@ -1374,7 +1409,7 @@ class TTIRBuilder:
         in1: Operand,
         in2: Operand,
         batch_offset: int = 0,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         cache = self._get_golden_tensor(in0)
         input_tensor = self._get_golden_tensor(in1)
@@ -1398,7 +1433,7 @@ class TTIRBuilder:
         in0: Operand,
         in1: Operand,
         broadcast_dimensions: List[int],
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         return self.op_proxy(
             torch.broadcast_to,
@@ -1419,7 +1454,7 @@ class TTIRBuilder:
         padding: Union[int, List[int]],
         dilation: Union[int, List[int]],
         groups: int,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         if not bias:
             bias = None
@@ -1492,7 +1527,7 @@ class TTIRBuilder:
         output_padding: Union[int, List[int]],
         dilation: Union[int, List[int]],
         groups: int,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         if not bias:
             bias = None
@@ -1571,7 +1606,7 @@ class TTIRBuilder:
         padding_right: int,
         padding_top: int,
         padding_bottom: int,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         return self.op_proxy(
             self.max_pool2d_golden_function,
@@ -1682,7 +1717,7 @@ class TTIRBuilder:
         return result
 
     def reshape(
-        self, in0: Operand, shape: Shape, unit_attrs: List[str] = None
+        self, in0: Operand, shape: Shape, unit_attrs: Optional[List[str]] = None
     ) -> OpView:
         kwargs = {"shape": shape}
         return self.op_proxy(
@@ -1700,7 +1735,7 @@ class TTIRBuilder:
         in1: Operand,
         padding: List[int],
         value: int,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         # Reformatting padding dimensions for golden tensor:
         golden_padding = []
@@ -1725,7 +1760,7 @@ class TTIRBuilder:
         begin: int = 0,
         length: int = 2,
         stride: Optional[int] = None,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         end = begin + length - 1
         index = torch.tensor([begin, end])
@@ -1753,7 +1788,7 @@ class TTIRBuilder:
         begin: int,
         end: int,
         step: int,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         import math
 
@@ -1772,7 +1807,10 @@ class TTIRBuilder:
         )
 
     def squeeze(
-        self, in0: Operand, dim: Optional[int] = 0, unit_attrs: List[str] = None
+        self,
+        in0: Operand,
+        dim: Optional[int] = 0,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         kwargs = {"dim": dim}
         return self.op_proxy(
@@ -1785,7 +1823,10 @@ class TTIRBuilder:
         )
 
     def unsqueeze(
-        self, in0: Operand, dim: Optional[int] = 0, unit_attrs: List[str] = None
+        self,
+        in0: Operand,
+        dim: Optional[int] = 0,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         kwargs = {"dim": dim}
         return self.op_proxy(
@@ -1802,7 +1843,7 @@ class TTIRBuilder:
         in0: Operand,
         min_arg: Optional[float] = None,
         max_arg: Optional[float] = None,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         kwargs = {"min": min_arg, "max": max_arg}
         return self.op_proxy(
@@ -1820,7 +1861,7 @@ class TTIRBuilder:
         in1: Operand,
         in2: Operand,
         in3: Operand,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         return self.op_proxy(
             torch.clamp,
@@ -1872,7 +1913,7 @@ class TTIRBuilder:
         )
 
     def reverse(
-        self, in0: Operand, dims: List[int], unit_attrs: List[str] = None
+        self, in0: Operand, dims: List[int], unit_attrs: Optional[List[str]] = None
     ) -> OpView:
         return self.op_proxy(
             torch.flip,
@@ -1890,7 +1931,7 @@ class TTIRBuilder:
         bias: Optional[Operand] = None,
         transpose_a: bool = False,
         transpose_b: bool = False,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         kwargs = {"transpose_a": transpose_a, "transpose_b": transpose_b, "bias": bias}
         return self.op_proxy(
@@ -1930,7 +1971,7 @@ class TTIRBuilder:
         in0: Operand,
         in1: Operand,
         bias: Optional[Operand] = None,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         inputs = [in0, in1]
         if bias:
@@ -1947,7 +1988,7 @@ class TTIRBuilder:
         in0: Operand,
         in1: Operand,
         permutation: List[int],
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         return self.op_proxy(
             torch.permute,
@@ -1966,7 +2007,7 @@ class TTIRBuilder:
         in1: Operand,
         scale_factor: Union[int, List[int]],
         mode: str = "nearest",
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         output_shape = self._get_golden_tensor(in1).shape
         kwargs = {
@@ -2007,7 +2048,7 @@ class TTIRBuilder:
         end: int,
         step: int,
         arange_dimension: int,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         single_dim_tensor = torch.arange(
             start=start, end=end, step=step, dtype=self._get_golden_tensor(result).dtype
@@ -2043,12 +2084,14 @@ class TTIRBuilder:
     # TTIR top level generic ops
     # class TTIR_GenericElementwiseUnaryOp
 
-    def exp(self, in0: Operand, unit_attrs: List[str] = None) -> OpView:
+    def exp(self, in0: Operand, unit_attrs: Optional[List[str]] = None) -> OpView:
         return self.eltwise_proxy(torch.exp, ttir.ExpOp, [in0], unit_attrs=unit_attrs)
 
     # class TTIR_GenericElementwiseBinaryOp
 
-    def add(self, in0: Operand, in1: Operand, unit_attrs: List[str] = None) -> OpView:
+    def add(
+        self, in0: Operand, in1: Operand, unit_attrs: Optional[List[str]] = None
+    ) -> OpView:
         return self.eltwise_proxy(
             torch.add,
             ttir.AddOp,
@@ -2057,7 +2100,7 @@ class TTIRBuilder:
         )
 
     def multiply(
-        self, in0: Operand, in1: Operand, unit_attrs: List[str] = None
+        self, in0: Operand, in1: Operand, unit_attrs: Optional[List[str]] = None
     ) -> OpView:
         return self.eltwise_proxy(
             torch.multiply,
@@ -2067,7 +2110,7 @@ class TTIRBuilder:
         )
 
     def subtract(
-        self, in0: Operand, in1: Operand, unit_attrs: List[str] = None
+        self, in0: Operand, in1: Operand, unit_attrs: Optional[List[str]] = None
     ) -> OpView:
         return self.eltwise_proxy(
             torch.sub,
@@ -2076,13 +2119,15 @@ class TTIRBuilder:
             unit_attrs=unit_attrs,
         )
 
-    def div(self, in0: Operand, in1: Operand, unit_attrs: List[str] = None) -> OpView:
+    def div(
+        self, in0: Operand, in1: Operand, unit_attrs: Optional[List[str]] = None
+    ) -> OpView:
         return self.eltwise_proxy(
             torch.div, ttir.DivOp, [in0, in1], unit_attrs=unit_attrs
         )
 
     def maximum(
-        self, in0: Operand, in1: Operand, unit_attrs: List[str] = None
+        self, in0: Operand, in1: Operand, unit_attrs: Optional[List[str]] = None
     ) -> OpView:
         return self.eltwise_proxy(
             torch.maximum, ttir.MaximumOp, [in0, in1], unit_attrs=unit_attrs
@@ -2094,7 +2139,7 @@ class TTIRBuilder:
         scale: float,
         zero_point: int,
         dtype: torch.dtype,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         golden_kwargs = {"scale": scale, "zero_point": zero_point, "dtype": dtype}
         return self.op_proxy(
@@ -2116,7 +2161,7 @@ class TTIRBuilder:
         scale: float,
         zero_point: int,
         dtype: torch.dtype,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         return self.op_proxy(
             torch.dequantize,
@@ -2132,7 +2177,7 @@ class TTIRBuilder:
         scale: float,
         zero_point: int,
         dtype: torch.dtype,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         golden_kwargs = {"scale": scale, "zero_point": zero_point, "dtype": dtype}
         return self.op_proxy(
@@ -2152,7 +2197,7 @@ class TTIRBuilder:
         self,
         in0: Operand,
         output_type: RankedTensorType,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
         **kwargs,
     ) -> OpView:
         return self.op_proxy(
@@ -2175,7 +2220,7 @@ class TTIRBuilder:
         in0: Operand,
         output_type: RankedTensorType,
         reinterpret_layout: bool = False,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         return self.op_proxy(
             lambda *args, **kwargs: args[0],
@@ -2195,7 +2240,7 @@ class TTIRBuilder:
         self,
         in0: Operand,
         output_type: RankedTensorType,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         return self.op_proxy(
             self.tilize_golden,
@@ -2215,7 +2260,7 @@ class TTIRBuilder:
         self,
         in0: Operand,
         output_type: RankedTensorType,
-        unit_attrs: List[str] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         return self.op_proxy(
             self.untilize_golden,

--- a/tools/ttir-builder/builder.py
+++ b/tools/ttir-builder/builder.py
@@ -1908,7 +1908,10 @@ class TTIRBuilder:
         )
 
     def zeros(
-        self, shape: Shape, data_type: Optional[Type] = None, unit_attrs: dict = None
+        self,
+        shape: Shape,
+        data_type: Optional[Type] = None,
+        unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         output = self.ranked_tensor_type(shape)
         dtype = data_type if data_type is not None else self._default_dtype
@@ -1923,7 +1926,7 @@ class TTIRBuilder:
             unit_attrs=unit_attrs,
         )
 
-    def ones(self, shape: Shape, unit_attrs: dict = None) -> OpView:
+    def ones(self, shape: Shape, unit_attrs: Optional[List[str]] = None) -> OpView:
         output = self.ranked_tensor_type(shape)
         return self.op_proxy(
             torch.ones,

--- a/tools/ttir-builder/utils.py
+++ b/tools/ttir-builder/utils.py
@@ -280,8 +280,8 @@ def compile_to_flatbuffer(
     mesh_shape: Optional[Tuple[int, int]] = None,
     module_dump: bool = True,
     argument_types_string: Optional[str] = None,
-    custom_pipeline: Union[Callable, str] = None,
-    pipeline_options: List[str] = None,
+    custom_pipeline: Optional[Union[Callable, str]] = None,
+    pipeline_options: Optional[List[str]] = None,
     print_ir: Union[bool, str] = False,
 ):
     """


### PR DESCRIPTION
Closes #2683 

### Problem description
General cleanup of builder and tests. The diff looks intimidating, but it's one or two changes that were needed in a bunch of places. Real meat of the change is in the builder `conv2d` and `conv_transpose2d` functions.

### What's changed
- Moved all references to IR Attrs behind the builder API, no attr construction is needed to use the API anymore
- Fix various `conv*` op tests, they now pass goldens
- Fixed the type signature of `unit_attrs` to properly use `None`

### Checklist
- [x] New/Existing tests provide coverage for changes
