### PR TITLE
[CI Hotfix] Downgrade TTNN Wheel for PyKernel Test

### DIFF
--- a/test/pykernel/demo/requirements.txt
+++ b/test/pykernel/demo/requirements.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://test.pypi.org/simple/
 
-ttnn
+ttnn==0.59.0rc46

--- a/test/pykernel/demo/requirements.txt
+++ b/test/pykernel/demo/requirements.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://test.pypi.org/simple/
 
-ttnn==0.59.0rc46
+ttnn==0.59.0rc36.dev15


### PR DESCRIPTION
### Problem description
- Broke CI once again.
- Potential Problem: `ttnn` wheel version was updated and this didn't correspond with our toolchain (so things broke).

### What's changed
- Downgrade `ttnn` wheel dep.
