### PR TITLE
FusedLoc Support in Explorer

### DIFF
--- a/python/Util.cpp
+++ b/python/Util.cpp
@@ -18,6 +18,9 @@ void populateUtilModule(nb::module_ &m) {
     return source;
   });
 
+  m.def("is_name_loc",
+        [](MlirLocation loc) { return mlir::isa<mlir::NameLoc>(unwrap(loc)); });
+
   m.def("get_loc_name", [](MlirLocation _loc) -> nb::object {
     mlir::Location loc = unwrap(_loc);
     if (mlir::isa<mlir::NameLoc>(loc)) {
@@ -36,6 +39,28 @@ void populateUtilModule(nb::module_ &m) {
     output.flush();
 
     return locationStr;
+  });
+
+  m.def("is_file_line_col_loc", [](MlirLocation loc) {
+    return mlir::isa<mlir::FileLineColLoc>(unwrap(loc));
+  });
+
+  m.def("is_fused_loc", [](MlirLocation loc) {
+    return mlir::isa<mlir::FusedLoc>(unwrap(loc));
+  });
+
+  m.def("get_fused_locations", [](MlirLocation _loc) {
+    std::vector<MlirLocation> result;
+    mlir::Location loc = unwrap(_loc);
+
+    if (mlir::isa<mlir::FusedLoc>(loc)) {
+      mlir::FusedLoc fusedLoc = mlir::cast<mlir::FusedLoc>(loc);
+      for (const auto &location : fusedLoc.getLocations()) {
+        result.emplace_back(wrap(location));
+      }
+    }
+
+    return result;
   });
 
   m.def("is_dps", [](MlirOperation op) {

--- a/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
@@ -732,8 +732,21 @@ class OpHandler:
 
     def __init__(self, op):
         self.op = op
+
         self.named_location = util.get_loc_name(self.op.location)
         self.full_location = util.get_loc_full(self.op.location)
+
+        if util.is_fused_loc(self.op.location):
+            self.locations = util.get_fused_locations(self.op.location)
+            for loc in self.locations:
+                # Use the first locations to fit the bill for "legacy" location support.
+                if util.is_name_loc(loc):
+                    self.named_location = util.get_loc_name(loc)
+                elif util.is_file_line_col_loc(loc):
+                    self.full_location = util.get_loc_full(loc)
+        else:
+            self.named_location = util.get_loc_name(self.op.location)
+            self.full_location = util.get_loc_full(self.op.location)
         self.id = self._create_unique_id()
 
     def _create_unique_id(self):
@@ -746,6 +759,20 @@ class OpHandler:
     def get_namespace(self, parent_op=None):
         op = self.op if not parent_op else parent_op
         name = util.get_loc_name(op.location)
+
+        # Fused Loc Logic
+        if util.is_fused_loc(op.location):
+            locs = util.get_fused_locations(op.location)
+            for loc in locs:
+                if util.is_name_loc(loc):
+                    name = util.get_loc_name(loc)
+
+        name = name or ""
+
+        # Don't process returns since they should be on the bottom of the graph
+        if op.name == "func.return":
+            return ""
+
         if op.parent and op.parent.name != "builtin.module":
             parent_name = self.get_namespace(op.parent)
             if parent_name:


### PR DESCRIPTION
### Ticket
- PR closes #3745 

### Problem description
- No support for `FusedLoc`s being lowered from FEs in Explorer.

### What's changed
- Group nodes using `NameLoc` taken from `FusedLoc`. 
- Some more utility functions to enable this functionality in Python bindings.
