### PR TITLE
Fix chipDescIndices to map valid indices into chipDescs

### DIFF
--- a/runtime/lib/common/system_desc.cpp
+++ b/runtime/lib/common/system_desc.cpp
@@ -247,7 +247,7 @@ static std::unique_ptr<::tt::runtime::SystemDesc> getCurrentSystemDescImpl(
         dramUnreservedEnd, chipPhysicalHelperCores, supportedDataTypes,
         supportedTileSizes, kDstRegisterSizeTiles, NUM_CIRCULAR_BUFFERS,
         kNumComputeThreads, kNumDatamovementThreads));
-    chipDescIndices.push_back(device->id());
+    chipDescIndices.push_back(chipDescIndices.size());
     // Derive chip capability
     ::tt::target::ChipCapability chipCapability =
         ::tt::target::ChipCapability::NONE;


### PR DESCRIPTION
### Ticket
None

### Problem description
A semantic change to DeviceAttr::get() to use chipDescIndices remapping causes tt-torch multidevice and pipeline parallel test failures.

### What's changed
Revert minimal changeset in lib/Dialect/TT/IR/TTOpsTypes.cpp to avoid this extra remapping of chipIds through chipDescIndices.

### Checklist
- [x] New/Existing tests provide coverage for changes
