### PR TITLE
Use github.token instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/issue-last-updated.yml
+++ b/.github/workflows/issue-last-updated.yml
@@ -74,7 +74,7 @@ jobs:
 
 
             # Make the GraphQL request
-            RESPONSE=$(curl -s -X POST -H "Authorization: Bearer $GITHUB_TOKEN" \
+            RESPONSE=$(curl -s -X POST -H "Authorization: Bearer ${{ github.token }}" \
                                  -H "Content-Type: application/json" \
                                  -d "$JSON_PAYLOAD" \
                                  https://api.github.com/graphql)


### PR DESCRIPTION
This fixes the "Bad credentials" (401) error that was preventing the workflow from updating the "Last Updated" field in project items
