### PR TITLE
Uplift third_party/tt-metal to f1d7b9ae9de8ba6329e9fae984e9b95b46730838 2025-06-12

### DIFF
--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -1498,8 +1498,8 @@ llvm::Expected<OpConstraints> MaxPool2DOpInterface::getOpConstraints(
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(stride),
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(padding),
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(dilation),
-        detail::getNullableMemoryConfig(outputLayout),
-        std::nullopt /* applied_shard_scheme */, ceilMode);
+        ceilMode, detail::getNullableMemoryConfig(outputLayout),
+        std::nullopt /* applied_shard_scheme */);
   };
 
   return operation::getOpConstraints("MaxPool2DOpInterface",
@@ -1546,8 +1546,8 @@ llvm::Expected<size_t> MaxPool2DOpInterface::getOpRuntime(
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(stride),
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(padding),
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(dilation),
-        detail::getNullableMemoryConfig(outputLayout),
-        std::nullopt /* applied_shard_scheme */, ceilMode);
+        ceilMode, detail::getNullableMemoryConfig(outputLayout),
+        std::nullopt /* applied_shard_scheme */);
   };
 
   return operation::getOpRuntime("MaxPool2DOpInterface", maxPool2DQuery);

--- a/runtime/lib/common/system_desc.cpp
+++ b/runtime/lib/common/system_desc.cpp
@@ -66,8 +66,10 @@ getAllDeviceConnections(const std::vector<::tt::tt_metal::IDevice *> &devices) {
     for (const CoreCoord &ethernetCore : activeEthernetCores) {
       // Skip on blackhole. When link is down, get_connected_ethernet_core
       // will throw an exception.
-      // See https://github.com/tenstorrent/tt-mlir/issues/3423
-      if (device->arch() == ::tt::ARCH::BLACKHOLE) {
+      // See https://github.com/tenstorrent/tt-mlir/issues/3423 for BH
+      // See https://github.com/tenstorrent/tt-mlir/issues/3781 for WH
+      if (device->arch() == ::tt::ARCH::BLACKHOLE ||
+          device->arch() == ::tt::ARCH::WORMHOLE_B0) {
         continue;
       }
       std::tuple<chip_id_t, CoreCoord> connectedDevice =

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -750,7 +750,7 @@ const std::initializer_list<
                 mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
                 mlir::tt::ttnn::BufferType::L1,
                 llvm::SmallVector<int64_t>{8, 1}},
-            detail::ExpectedResult{true, 32768, 262144, 262144}),
+            detail::ExpectedResult{true, 4096, 262144, 262144}),
         std::make_tuple(
             detail::TestTensor{
                 {16 * OpModelFixture::workerCoresN300 * 32, 32},
@@ -763,7 +763,7 @@ const std::initializer_list<
             detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
                                mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
                                mlir::tt::ttnn::BufferType::DRAM},
-            detail::ExpectedResult{true, 65536, 0, 0}),
+            detail::ExpectedResult{true, 8192, 0, 0}),
         std::make_tuple(
             detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
                                mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
@@ -776,7 +776,7 @@ const std::initializer_list<
                 mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
                 mlir::tt::ttnn::BufferType::L1,
                 llvm::SmallVector<int64_t>{8, 1}},
-            detail::ExpectedResult{true, 65536, 262144, 262144})};
+            detail::ExpectedResult{true, 8192, 262144, 262144})};
 
 ::testing::internal::ParamGenerator<
     std::tuple<BinaryEltwiseOpType, detail::TestTensor, detail::TestTensor,

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "e373817b3504bfd69a815bd207d3107bde700750")
+set(TT_METAL_VERSION "f1d7b9ae9de8ba6329e9fae984e9b95b46730838")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "02bda8e52e88a96f2d0837f517bc4e600fad4706")
+set(TT_METAL_VERSION "e373817b3504bfd69a815bd207d3107bde700750")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the f1d7b9ae9de8ba6329e9fae984e9b95b46730838

- Update maxpool and avgpool functions signatures after metal change a5014d7
  - Follow up #3771 
- Skip connecting eth core devices due to metal exception after metal change 33a0ccc732
  - Follow up #3781 
- Update cbsize for eltwise binary ops after binary_ng made default in f1d7b9ae9d