### PR TITLE
#3776: Fix ttrt perf locations to their correct place in the perf results file.

### DIFF
--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -59,6 +59,15 @@ enum class DispatchCoreType {
 
 enum class Arch { GRAYSKULL = 1, WORMHOLE_B0 = 2, BLACKHOLE = 3, QUASAR = 4 };
 
+enum class TracyLogTag { MLIR_OP_LOCATION };
+
+inline std::string toString(TracyLogTag tracyLogTag) {
+  switch (tracyLogTag) {
+  case TracyLogTag::MLIR_OP_LOCATION:
+    return "MLIR_OP_LOCATION";
+  }
+}
+
 namespace detail {
 struct ObjectImpl {
 

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -67,7 +67,9 @@ using LogType = ::tt::runtime::logger::LogType;
 
 static void tracyLogOpLocation(const ::tt::target::ttnn::Operation *op) {
 #if defined(TT_RUNTIME_ENABLE_PERF_TRACE) && TT_RUNTIME_ENABLE_PERF_TRACE == 1
-  TracyMessage(op->loc_info()->c_str(), op->loc_info()->size());
+  std::string message = toString(TracyLogTag::MLIR_OP_LOCATION) + ";" +
+                        std::string(op->loc_info()->c_str());
+  TracyMessage(message.c_str(), message.size());
 #endif
 }
 


### PR DESCRIPTION
TTRT perf reports don't correctly add the location to the required place in the csv file. This change introduces 1:1 mapping between loc data and the performance data collected. This change is also a pre-curser to identifying const-eval ops. All ops in the perf csv report file will have locs of unknown if not found. This change also takes care of multi chip perf values where each chip has a separate entry but originates from the same location in the mlir file. 

eg
```
loc(unknown)
loc(unknown)
loc(unknown)
loc(unknown)
"loc(""/code/tt-mlir/build/test/ttmlir/Silicon/TTNN/n150/const-eval/Output/const-eval.mlir.tmp.mlir"":9:14)"
"loc(""/code/tt-mlir/build/test/ttmlir/Silicon/TTNN/n150/const-eval/Output/const-eval.mlir.tmp.mlir"":10:14)"
```