### PR TITLE
Workaround for WhereOp which takes a constant NaN as one of the inputs

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/WhereOpRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/WhereOpRewritePattern.h
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+
+#include "mlir/IR/PatternMatch.h"
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+
+class WhereOpWithNanConstantRewritePattern
+    : public OpRewritePattern<ttnn::WhereOp> {
+  using OpRewritePattern<ttnn::WhereOp>::OpRewritePattern;
+
+public:
+  LogicalResult matchAndRewrite(ttnn::WhereOp op,
+                                PatternRewriter &rewriter) const override;
+};
+
+} // namespace mlir::tt::ttnn::workarounds::decomposition

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -16,6 +16,7 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         Workarounds/Decomposition/EmbeddingOpSqueezeWeightRewritePattern.cpp
         Workarounds/Decomposition/ReduceOpsRewritePattern.cpp
         Workarounds/Decomposition/RepeatOpRewritePattern.cpp
+        Workarounds/Decomposition/WhereOpRewritePattern.cpp
         Workarounds/TTNNWorkaroundsPatterns.cpp
 
         ADDITIONAL_HEADER_DIRS

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/WhereOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/WhereOpRewritePattern.cpp
@@ -58,7 +58,7 @@ LogicalResult WhereOpWithNanConstantRewritePattern::matchAndRewrite(
       operands[i] = createReplacementFullOp(operands[i]);
     }
   }
-  rewriter.replaceOpWithNewOp<ttnn::WhereOp>(op, outputType, op.getFirst(),
+  rewriter.replaceOpWithNewOp<ttnn::WhereOp>(op, op.getResult(), op.getFirst(),
                                              operands[0], operands[1]);
   return success();
 }

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/WhereOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/WhereOpRewritePattern.cpp
@@ -12,15 +12,12 @@
 #include "llvm/ADT/APFloat.h"
 
 #include "llvm/Support/ErrorHandling.h"
-#include "llvm/Support/raw_ostream.h"
-
-#include <iostream>
 
 namespace mlir::tt::ttnn::workarounds::decomposition {
 
+// Metal tracking issue: https://github.com/tenstorrent/tt-metal/issues/22308
 LogicalResult WhereOpWithNanConstantRewritePattern::matchAndRewrite(
     ttnn::WhereOp op, PatternRewriter &rewriter) const {
-  // Check if one of the operands is a result of a FullOp with NaN constant.
   auto isFullOpWithNan = [](Value value) -> bool {
     if (auto fullOp = value.getDefiningOp<ttnn::FullOp>()) {
       if (auto floatAttr =
@@ -30,44 +27,39 @@ LogicalResult WhereOpWithNanConstantRewritePattern::matchAndRewrite(
     }
     return false;
   };
+
   if (!isFullOpWithNan(op.getSecond()) && !isFullOpWithNan(op.getThird())) {
     return failure();
   }
-  // Create a new WhereOp with the NaN constant replaced by 1e+37 for float32
-  // or 65504 for bfloat16.
-  RankedTensorType inputType = op.getFirst().getType();
-  RankedTensorType outputType = op.getResult().getType();
-  auto newTrueValue = op.getSecond();
-  auto newFalseValue = op.getThird();
-  // Helper lambda to create a replacement FullOp with the correct value.
+
+  // Constants 1e37 and 65504 are mostly arbitrary
+  // both are finite values near the upper end of the range for their type.
   auto createReplacementFullOp = [&](Value origValue) -> Value {
     auto origFullOp = llvm::cast<ttnn::FullOp>(origValue.getDefiningOp());
-    if (inputType.getElementType().isF32()) {
-      std::cerr << "Test!\n";
-      return rewriter.create<ttnn::FullOp>(op.getLoc(), outputType,
+    RankedTensorType origType = origFullOp.getType();
+    if (origType.getElementType().isF32()) {
+      return rewriter.create<ttnn::FullOp>(op.getLoc(), origType,
                                            rewriter.getF32FloatAttr(1e+37),
                                            origFullOp.getDevice());
     }
-    if (inputType.getElementType().isBF16()) {
+    if (origType.getElementType().isBF16()) {
       auto bf16Type = rewriter.getBF16Type();
       auto floatAttr = rewriter.getFloatAttr(bf16Type, 65504.0);
-      return rewriter.create<ttnn::FullOp>(op.getLoc(), outputType, floatAttr,
+      return rewriter.create<ttnn::FullOp>(op.getLoc(), origType, floatAttr,
                                            origFullOp.getDevice());
     }
     llvm_unreachable("Unknown data type was used inside the rewrite pattern "
                      "for WhereOp with NaN constant input");
   };
 
-  // Iterate over the two operands (second and third), replacing if needed.
   Value operands[2] = {op.getSecond(), op.getThird()};
-  Value *newOperands[2] = {&newTrueValue, &newFalseValue};
   for (int i = 0; i < 2; ++i) {
     if (isFullOpWithNan(operands[i])) {
-      *newOperands[i] = createReplacementFullOp(operands[i]);
+      operands[i] = createReplacementFullOp(operands[i]);
     }
   }
   rewriter.replaceOpWithNewOp<ttnn::WhereOp>(op, outputType, op.getFirst(),
-                                             newTrueValue, newFalseValue);
+                                             operands[0], operands[1]);
   return success();
 }
 

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/WhereOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/WhereOpRewritePattern.cpp
@@ -58,8 +58,8 @@ LogicalResult WhereOpWithNanConstantRewritePattern::matchAndRewrite(
       operands[i] = createReplacementFullOp(operands[i]);
     }
   }
-  rewriter.replaceOpWithNewOp<ttnn::WhereOp>(op, op.getResult(), op.getFirst(),
-                                             operands[0], operands[1]);
+  rewriter.replaceOpWithNewOp<ttnn::WhereOp>(
+      op, op.getResult().getType(), op.getFirst(), operands[0], operands[1]);
   return success();
 }
 

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/WhereOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/WhereOpRewritePattern.cpp
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/WhereOpRewritePattern.h"
+
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "llvm/ADT/APFloat.h"
+
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <iostream>
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+
+LogicalResult WhereOpWithNanConstantRewritePattern::matchAndRewrite(
+    ttnn::WhereOp op, PatternRewriter &rewriter) const {
+  // Check if one of the operands is a result of a FullOp with NaN constant.
+  auto isFullOpWithNan = [](Value value) -> bool {
+    if (auto fullOp = value.getDefiningOp<ttnn::FullOp>()) {
+      if (auto floatAttr =
+              llvm::dyn_cast<FloatAttr>(fullOp.getFillValueAttr())) {
+        return floatAttr.getValue().isNaN();
+      }
+    }
+    return false;
+  };
+  if (!isFullOpWithNan(op.getSecond()) && !isFullOpWithNan(op.getThird())) {
+    return failure();
+  }
+  // Create a new WhereOp with the NaN constant replaced by 1e+37 for float32
+  // or 65504 for bfloat16.
+  RankedTensorType inputType = op.getFirst().getType();
+  RankedTensorType outputType = op.getResult().getType();
+  auto newTrueValue = op.getSecond();
+  auto newFalseValue = op.getThird();
+  // Helper lambda to create a replacement FullOp with the correct value.
+  auto createReplacementFullOp = [&](Value origValue) -> Value {
+    auto origFullOp = llvm::cast<ttnn::FullOp>(origValue.getDefiningOp());
+    if (inputType.getElementType().isF32()) {
+      std::cerr << "Test!\n";
+      return rewriter.create<ttnn::FullOp>(op.getLoc(), outputType,
+                                           rewriter.getF32FloatAttr(1e+37),
+                                           origFullOp.getDevice());
+    }
+    if (inputType.getElementType().isBF16()) {
+      auto bf16Type = rewriter.getBF16Type();
+      auto floatAttr = rewriter.getFloatAttr(bf16Type, 65504.0);
+      return rewriter.create<ttnn::FullOp>(op.getLoc(), outputType, floatAttr,
+                                           origFullOp.getDevice());
+    }
+    llvm_unreachable("Unknown data type was used inside the rewrite pattern "
+                     "for WhereOp with NaN constant input");
+  };
+
+  // Iterate over the two operands (second and third), replacing if needed.
+  Value operands[2] = {op.getSecond(), op.getThird()};
+  Value *newOperands[2] = {&newTrueValue, &newFalseValue};
+  for (int i = 0; i < 2; ++i) {
+    if (isFullOpWithNan(operands[i])) {
+      *newOperands[i] = createReplacementFullOp(operands[i]);
+    }
+  }
+  rewriter.replaceOpWithNewOp<ttnn::WhereOp>(op, outputType, op.getFirst(),
+                                             newTrueValue, newFalseValue);
+  return success();
+}
+
+} // namespace mlir::tt::ttnn::workarounds::decomposition

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -14,6 +14,7 @@
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/EmbeddingOpSqueezeWeightRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceOpsRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/RepeatOpRewritePattern.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/WhereOpRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Utils/TransformUtils.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 #include "ttmlir/Utils.h"
@@ -716,7 +717,9 @@ public:
           workarounds::decomposition::ReduceOpsPadInputRewritePattern<
               ttnn::MaxOp>,
           workarounds::decomposition::ReduceOpsPadInputRewritePattern<
-              ttnn::MinOp>>(&getContext());
+              ttnn::MinOp>,
+          workarounds::decomposition::WhereOpWithNanConstantRewritePattern>(
+          &getContext());
 
       runRewritePatterns(std::move(patterns),
                          GreedyRewriteConfig::kNoLimit /*maxIterations*/);


### PR DESCRIPTION
### Ticket

### Problem description
Right now, WhereOp erroneously propagates NaN values from it's input tensors. tt-xla emits such graphs and that leads to plain wrong outputs. This issue is exacerbated by recent addition of binary_ng to metal, as before the broken broadcasting behavior could hide this issue at the cost of inaccuracy.

### What's changed
I added a rewrite pattern to the workarounds pass to swap out FullOps feeding into WhereOps with FullOps containing finite values.
This does technically change the meaning of the resulting graph but I don't see any alternatives. 

### Checklist
- [X] New/Existing tests provide coverage for changes
