### PR TITLE
Remove the workaround to perform addition of integers with broadcasting in bfloat16

### DIFF
--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -420,22 +420,6 @@ static std::optional<DataType> binaryOpDTypeWorkaround(mlir::Operation *op,
         dType == DataType::BFP_BFloat8 || dType == DataType::BFP_BFloat4) {
       return {};
     }
-    if (dType == DataType::Int32) {
-      // Although TTNN claims to support int32 for Add and Subtract ops,
-      // broadcasting with int32 inputs does not currently work as expected.
-      // As a temporary workaround, we fall back to BFloat16 when input shapes
-      // differ. This should be removed once int32 broadcasting is properly
-      // supported.
-      auto lhsType =
-          mlir::cast<mlir::RankedTensorType>(op->getOperand(0).getType());
-      auto rhsType =
-          mlir::cast<mlir::RankedTensorType>(op->getOperand(1).getType());
-
-      if (lhsType.getShape() != rhsType.getShape()) {
-        return DataType::BFloat16;
-      }
-      return {};
-    }
     return DataType::BFloat16;
   }
   // Left shift and right shift ops have same requirements but they are not


### PR DESCRIPTION
### Ticket


### Problem description
This workaround is not only no longer necessary, but actively harms correctness.

### What's changed
Workaround begone!
Binary_ng ops also support row major inputs and outputs and should support all dtypes, so the entire workaround function can likely be removed, but that is left for another PR.

### Checklist
- [X] New/Existing tests provide coverage for changes
- [] Run frontend CI
  - Torch: Pending
  - XLA: Pending
  - FFE: Pending