### PR TITLE
Refactor utils

### DIFF
--- a/include/ttmlir/Dialect/TTCore/IR/Utils.h
+++ b/include/ttmlir/Dialect/TTCore/IR/Utils.h
@@ -47,8 +47,8 @@ mlir::memref::GlobalOp createGlobal(ModuleOp moduleOp, MemRefType type,
 
 // Filters out the constant parameters from the function signature.
 inline llvm::SmallPtrSet<mlir::BlockArgument, 4>
-getConstParams(mlir::func::FuncOp funcOp) {
-  llvm::SmallPtrSet<mlir::BlockArgument, 4> constParams;
+getConstsAndParams(mlir::func::FuncOp funcOp) {
+  llvm::SmallPtrSet<mlir::BlockArgument, 4> constsAndParams;
 
   for (auto arg : funcOp.getArguments()) {
     if (auto typeAttr = funcOp.getArgAttrOfType<mlir::tt::ArgumentTypeAttr>(
@@ -56,12 +56,12 @@ getConstParams(mlir::func::FuncOp funcOp) {
       auto argTypeValue = typeAttr.getValue();
       if (argTypeValue == mlir::tt::ArgumentType::Parameter ||
           argTypeValue == mlir::tt::ArgumentType::Constant) {
-        constParams.insert(arg);
+        constsAndParams.insert(arg);
       }
     }
   }
 
-  return constParams;
+  return constsAndParams;
 }
 
 } // namespace mlir::tt

--- a/include/ttmlir/Dialect/TTCore/IR/Utils.h
+++ b/include/ttmlir/Dialect/TTCore/IR/Utils.h
@@ -47,9 +47,7 @@ mlir::memref::GlobalOp createGlobal(ModuleOp moduleOp, MemRefType type,
 
 // Filters out the constant parameters from the function signature.
 inline llvm::SmallPtrSet<mlir::BlockArgument, 4>
-populateConstParams(mlir::func::FuncOp funcOp) {
-  assert(!funcOp.isDeclaration() && "Function should not be a declaration.");
-
+getConstParams(mlir::func::FuncOp funcOp) {
   llvm::SmallPtrSet<mlir::BlockArgument, 4> constParams;
 
   for (auto arg : funcOp.getArguments()) {

--- a/include/ttmlir/Dialect/TTCore/IR/Utils.h
+++ b/include/ttmlir/Dialect/TTCore/IR/Utils.h
@@ -5,12 +5,12 @@
 #ifndef TTMLIR_DIALECT_TTCORE_IR_UTILS_H
 #define TTMLIR_DIALECT_TTCORE_IR_UTILS_H
 
+#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
+
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/SymbolTable.h"
-
-#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
 
 namespace mlir::tt {
 

--- a/include/ttmlir/Dialect/TTCore/IR/Utils.h
+++ b/include/ttmlir/Dialect/TTCore/IR/Utils.h
@@ -5,7 +5,7 @@
 #ifndef TTMLIR_DIALECT_TTCORE_IR_UTILS_H
 #define TTMLIR_DIALECT_TTCORE_IR_UTILS_H
 
-#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"

--- a/include/ttmlir/Dialect/TTCore/IR/Utils.h
+++ b/include/ttmlir/Dialect/TTCore/IR/Utils.h
@@ -5,9 +5,12 @@
 #ifndef TTMLIR_DIALECT_TTCORE_IR_UTILS_H
 #define TTMLIR_DIALECT_TTCORE_IR_UTILS_H
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/SymbolTable.h"
+
+#include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
 
 namespace mlir::tt {
 
@@ -41,6 +44,27 @@ mlir::memref::GlobalOp createGlobal(ModuleOp moduleOp, MemRefType type,
                                     ElementsAttr value, bool constant = true,
                                     bool privateVisibility = true,
                                     size_t alignment = 0);
+
+// Filters out the constant parameters from the function signature.
+inline llvm::SmallPtrSet<mlir::BlockArgument, 4>
+populateConstParams(mlir::func::FuncOp funcOp) {
+  assert(!funcOp.isDeclaration() && "Function should not be a declaration.");
+
+  llvm::SmallPtrSet<mlir::BlockArgument, 4> constParams;
+
+  for (auto arg : funcOp.getArguments()) {
+    if (auto typeAttr = funcOp.getArgAttrOfType<mlir::tt::ArgumentTypeAttr>(
+            arg.getArgNumber(), mlir::tt::ArgumentTypeAttr::name)) {
+      auto argTypeValue = typeAttr.getValue();
+      if (argTypeValue == mlir::tt::ArgumentType::Parameter ||
+          argTypeValue == mlir::tt::ArgumentType::Constant) {
+        constParams.insert(arg);
+      }
+    }
+  }
+
+  return constParams;
+}
 
 } // namespace mlir::tt
 

--- a/include/ttmlir/Utils.h
+++ b/include/ttmlir/Utils.h
@@ -5,8 +5,6 @@
 #ifndef TTMLIR_UTILS_H
 #define TTMLIR_UTILS_H
 
-#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
-
 #include "mlir-c/IR.h"
 #include "mlir/CAPI/IR.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -437,53 +435,6 @@ inline bool allUsersOfType(mlir::Operation *srcOp) {
 // Count the number of users of a value.
 inline size_t countUsers(mlir::Value value) {
   return std::distance(value.user_begin(), value.user_end());
-}
-
-// Return vector of currentOp operands and drop:
-// - dps operand if currentOp is a DestinationStyleOpInterface
-// - operand which is defined by currentOpOperand
-inline llvm::SmallVector<mlir::OpOperand *>
-getOtherOperands(mlir::Operation *currentOp,
-                 mlir::Operation *currentOpOperand) {
-  llvm::SmallVector<mlir::OpOperand *> operands;
-  auto dpsOp = mlir::dyn_cast<mlir::DestinationStyleOpInterface>(currentOp);
-  for (auto &opOperand : currentOp->getOpOperands()) {
-    if (dpsOp && dpsOp.isDpsInit(&opOperand)) {
-      continue;
-    }
-
-    if (mlir::Operation *op = opOperand.get().getDefiningOp()) {
-      if (op != currentOpOperand) {
-        operands.push_back(&opOperand);
-      }
-    } else {
-      // This is block argument.
-      operands.push_back(&opOperand);
-    }
-  }
-
-  return operands;
-}
-
-// Filters out the constant parameters from the function signature.
-inline llvm::SmallPtrSet<mlir::BlockArgument, 4>
-populateConstParams(mlir::func::FuncOp funcOp) {
-  assert(!funcOp.isDeclaration() && "Function should not be a declaration.");
-
-  llvm::SmallPtrSet<mlir::BlockArgument, 4> constParams;
-
-  for (auto arg : funcOp.getArguments()) {
-    if (auto typeAttr = funcOp.getArgAttrOfType<mlir::tt::ArgumentTypeAttr>(
-            arg.getArgNumber(), mlir::tt::ArgumentTypeAttr::name)) {
-      auto argTypeValue = typeAttr.getValue();
-      if (argTypeValue == mlir::tt::ArgumentType::Parameter ||
-          argTypeValue == mlir::tt::ArgumentType::Constant) {
-        constParams.insert(arg);
-      }
-    }
-  }
-
-  return constParams;
 }
 
 inline bool isConstEvalFunc(mlir::Operation *op) {

--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -293,7 +293,7 @@ private:
 
     mlir::func::FuncOp funcOp = conv2dOp->getParentOfType<mlir::func::FuncOp>();
     llvm::SmallPtrSet<BlockArgument, 4> constParams =
-        mlir::tt::populateConstParams(funcOp);
+        mlir::tt::getConstParams(funcOp);
     auto isConstant = [&constParams, conv2dOp](mlir::Value value) {
       if (auto blockArg = mlir::dyn_cast<BlockArgument>(value)) {
         return constParams.contains(blockArg);

--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -293,7 +293,7 @@ private:
 
     mlir::func::FuncOp funcOp = conv2dOp->getParentOfType<mlir::func::FuncOp>();
     llvm::SmallPtrSet<BlockArgument, 4> constParams =
-        mlir::tt::getConstParams(funcOp);
+        mlir::tt::getConstsAndParams(funcOp);
     auto isConstant = [&constParams, conv2dOp](mlir::Value value) {
       if (auto blockArg = mlir::dyn_cast<BlockArgument>(value)) {
         return constParams.contains(blockArg);

--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -293,7 +293,7 @@ private:
 
     mlir::func::FuncOp funcOp = conv2dOp->getParentOfType<mlir::func::FuncOp>();
     llvm::SmallPtrSet<BlockArgument, 4> constParams =
-        ttmlir::utils::populateConstParams(funcOp);
+        mlir::tt::populateConstParams(funcOp);
     auto isConstant = [&constParams, conv2dOp](mlir::Value value) {
       if (auto blockArg = mlir::dyn_cast<BlockArgument>(value)) {
         return constParams.contains(blockArg);

--- a/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
+++ b/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
@@ -18,7 +18,6 @@
 #include "mlir/IR/Location.h"
 #include "mlir/Interfaces/DestinationStyleOpInterface.h"
 #include "mlir/Support/LLVM.h"
-
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"

--- a/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
+++ b/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
@@ -2,8 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttmlir/Dialect/TT/IR/Utils.h"
 #include "ttmlir/Dialect/TTNN/Analysis/ShardSolver.h"
+
+#include "ttmlir/Dialect/TT/IR/Utils.h"
 #include "ttmlir/Dialect/TTNN/Analysis/L1ChainConfig.h"
 #include "ttmlir/Dialect/TTNN/Analysis/MemReconfig.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"

--- a/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
+++ b/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Dialect/TTNN/Analysis/ShardSolver.h"
+#include "ttmlir/Dialect/TT/IR/Utils.h"
 #include "ttmlir/Dialect/TTNN/Analysis/L1ChainConfig.h"
 #include "ttmlir/Dialect/TTNN/Analysis/MemReconfig.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
@@ -11,12 +12,12 @@
 #include "ttmlir/Dialect/TTNN/Utils/OptimizerUtils.h"
 #include "ttmlir/OpModel/TTNN/TTNNOpModel.h"
 #include "ttmlir/Support/Logger.h"
-#include "ttmlir/Utils.h"
 
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Location.h"
 #include "mlir/Interfaces/DestinationStyleOpInterface.h"
 #include "mlir/Support/LLVM.h"
+
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"

--- a/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
+++ b/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
@@ -12,6 +12,7 @@
 #include "ttmlir/Dialect/TTNN/Utils/OptimizerUtils.h"
 #include "ttmlir/OpModel/TTNN/TTNNOpModel.h"
 #include "ttmlir/Support/Logger.h"
+#include "ttmlir/Utils.h"
 
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Location.h"

--- a/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
+++ b/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
@@ -4,7 +4,7 @@
 
 #include "ttmlir/Dialect/TTNN/Analysis/ShardSolver.h"
 
-#include "ttmlir/Dialect/TT/IR/Utils.h"
+#include "ttmlir/Dialect/TTCore/IR/Utils.h"
 #include "ttmlir/Dialect/TTNN/Analysis/L1ChainConfig.h"
 #include "ttmlir/Dialect/TTNN/Analysis/MemReconfig.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"

--- a/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
+++ b/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttmlir/Dialect/TTNN/Analysis/ShardSolver.h"
 #include "ttmlir/Dialect/TT/IR/Utils.h"
+#include "ttmlir/Dialect/TTNN/Analysis/ShardSolver.h"
 #include "ttmlir/Dialect/TTNN/Analysis/L1ChainConfig.h"
 #include "ttmlir/Dialect/TTNN/Analysis/MemReconfig.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"

--- a/lib/Dialect/TTNN/Transforms/TTNNPrepareConv2dWeights.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNPrepareConv2dWeights.cpp
@@ -8,6 +8,7 @@
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
 #include "ttmlir/OpModel/TTNN/SingletonDeviceContext.h"
 #include "ttmlir/OpModel/TTNN/TTNNOpModel.h"
+#include "ttmlir/Utils.h"
 
 namespace mlir::tt::ttnn {
 #define GEN_PASS_DEF_TTNNPREPARECONV2DWEIGHTS

--- a/lib/Dialect/TTNN/Transforms/TTNNPrepareConv2dWeights.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNPrepareConv2dWeights.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttmlir/Dialect/TT/IR/Utils.h"
+#include "ttmlir/Dialect/TTCore/IR/Utils.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"

--- a/lib/Dialect/TTNN/Transforms/TTNNPrepareConv2dWeights.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNPrepareConv2dWeights.cpp
@@ -2,12 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "ttmlir/Dialect/TT/IR/Utils.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
 #include "ttmlir/OpModel/TTNN/SingletonDeviceContext.h"
 #include "ttmlir/OpModel/TTNN/TTNNOpModel.h"
-#include "ttmlir/Utils.h"
 
 namespace mlir::tt::ttnn {
 #define GEN_PASS_DEF_TTNNPREPARECONV2DWEIGHTS

--- a/lib/Dialect/TTNN/Transforms/TTNNTraceHoistTransform.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNTraceHoistTransform.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"

--- a/lib/Transforms/ConstEvalHoist.cpp
+++ b/lib/Transforms/ConstEvalHoist.cpp
@@ -50,7 +50,7 @@ namespace {
 class ConstEvalAnalyze {
 public:
   ConstEvalAnalyze(func::FuncOp *funcOp) : funcOp(funcOp) {
-    getConstParams();
+    getConstsAndParams();
     buildConstEvalSubgraphs();
   }
 
@@ -106,12 +106,12 @@ public:
   }
 
 private:
-  void getConstParams() {
+  void getConstsAndParams() {
     if (funcOp->isDeclaration()) {
       return;
     }
 
-    constParams = mlir::tt::getConstParams(*funcOp);
+    constParams = mlir::tt::getConstsAndParams(*funcOp);
   }
 
   // Recurse up hierarchy to find root of given subset.

--- a/lib/Transforms/ConstEvalHoist.cpp
+++ b/lib/Transforms/ConstEvalHoist.cpp
@@ -50,7 +50,7 @@ namespace {
 class ConstEvalAnalyze {
 public:
   ConstEvalAnalyze(func::FuncOp *funcOp) : funcOp(funcOp) {
-    populateConstParams();
+    getConstParams();
     buildConstEvalSubgraphs();
   }
 
@@ -106,12 +106,12 @@ public:
   }
 
 private:
-  void populateConstParams() {
+  void getConstParams() {
     if (funcOp->isDeclaration()) {
       return;
     }
 
-    constParams = mlir::tt::populateConstParams(*funcOp);
+    constParams = mlir::tt::getConstParams(*funcOp);
   }
 
   // Recurse up hierarchy to find root of given subset.

--- a/lib/Transforms/ConstEvalHoist.cpp
+++ b/lib/Transforms/ConstEvalHoist.cpp
@@ -111,7 +111,7 @@ private:
       return;
     }
 
-    constParams = ttmlir::utils::populateConstParams(*funcOp);
+    constParams = mlir::tt::populateConstParams(*funcOp);
   }
 
   // Recurse up hierarchy to find root of given subset.


### PR DESCRIPTION
- Decouple `include/ttmlir/Utils.h` from `ttmlir/Dialect/TTIR/IR/TTIROps.h` to avoid circular dependencies
- Rename `populateConstParams` to `getConstsAndParams` and move to `include/ttmlir/Dialect/TT/IR/Utils.h`
- Remove unused `getOtherOperands`