### PR TITLE
Fixing TTIRBuilder PCC errors in tan, log, log1

### DIFF
--- a/docs/src/ttir-builder.md
+++ b/docs/src/ttir-builder.md
@@ -545,7 +545,7 @@ from ttmlir.passes import GoldenTensor
 ```
 
 ### Setting golden data
-Use `TTIRBuilder` API `set_graph_input_output` to set your own input and output golden tensors using PyTorch tensors. Keep in mind that this also sets graph inputs and outputs.
+Use `TTIRBuilder` API `set_graph_input_output` to set your own input and output golden tensors using PyTorch tensors. Keep in mind that this also sets graph inputs and outputs. There are some functions for which setting custom input tensors is required to pass PCC accuracy checks: `ttir.tan`, `ttir.log`, `ttir.log1p`. See example implementation and explanation in `test/python/golden/test_ttir_ops.py`.
 ```bash
 set_graph_input_output(
         self,

--- a/docs/src/ttir-builder.md
+++ b/docs/src/ttir-builder.md
@@ -489,7 +489,7 @@ https://github.com/tenstorrent/tt-mlir/blob/2064844f8140de7d38ba55f8acac107a016f
 ## Golden mode
 
 ### Golden dataclass
-`TTIRBuilder` provides support to code golden tensors into flatbuffers which will be used for comparison with TT device output in `ttrt` runtime. `Golden` is the dataclass used to store information about a golden tensor. Each TTIR op should have a matching PyTorch op (or golden function built from PyTorch ops) which should perform exactly the same operation, generating the same outputs given the same inputs. You can use `TTIRBuilder` helper functions to store input, intermediate, and output tensors within the flatbuffer. Input and output goldens are mapped with keys "input_" and "output_" followed by a tensor index: `input_0`. Intermediate output tensors
+`TTIRBuilder` provides support to code golden tensors into flatbuffers which will be used for comparison with TT device output in `ttrt` runtime. `Golden` is the dataclass used to store information about a golden tensor. Each TTIR op should have a matching PyTorch op (or golden function built from PyTorch ops) which should perform exactly the same operation, generating the same outputs given the same inputs. You can use `TTIRBuilder` helper functions to store input, intermediate, and output tensors within the flatbuffer. Input and output goldens are mapped with keys "input_" and "output_" followed by a tensor index: `input_0`. Intermediate output tensors are mapped to the location of the respecive op creation.
 
 ### GoldenCheckLevel Enum
 `TTIRBuilder` stores an instance of the class `GoldenCheckLevel(Enum)` that dictates golden handling. It defaults to `GoldenCheckLevel.OP_LEVEL`. The exception is that `TTIRBuilder` CCL ops force the golden level to be set to `GRAPH_LEVEL`.
@@ -545,7 +545,7 @@ from ttmlir.passes import GoldenTensor
 ```
 
 ### Setting golden data
-Use `TTIRBuilder` API `set_graph_input_output` to set your own input and output golden tensors using PyTorch tensors.
+Use `TTIRBuilder` API `set_graph_input_output` to set your own input and output golden tensors using PyTorch tensors. Keep in mind that this also sets graph inputs and outputs.
 ```bash
 set_graph_input_output(
         self,
@@ -560,7 +560,7 @@ import torch
 
 input_0 = torch.ones((32, 32))
 output_0 = torch.zeros((32, 32))
-builder.set_graph_input_output([input_0], [output_0], True)
+builder.set_graph_input_output([input_0], [output_0], override=True)
 ```
 
 ### Running flatbuffer with golden data in ttrt
@@ -571,18 +571,18 @@ ttrt query --save-artifacts
 export SYSTEM_DESC_PATH=$(pwd)/ttrt-artifacts/system_desc.ttsys
 ```
 
-Set environment variable `TTRT_LOGGER_LEVEL` to `DEBUG` so ttrt logs golden comparison results and prints graph level golden tensors.
+Set environment variable `TTRT_LOGGER_LEVEL` to `DEBUG` so `ttrt` logs golden comparison results and prints graph level golden tensors.
 ```bash
 export TTRT_LOGGER_LEVEL=DEBUG
 ```
 
-Finally run ttrt. Our example flatbuffer file (since we didn't specify otherwise) defaulted to file path `./ttnn/test_ttnn.mlir.ttnn`. `--log-file ttrt.log` and `--save-golden-tensors` are both optional flags. They ensure that all golden data produced by the ttrt run gets written to files.
+Finally run ttrt. Our example flatbuffer file (since we didn't specify otherwise) defaulted to file path `./ttnn/test_ttnn.mlir.ttnn`. `--log-file ttrt.log` and `--save-golden-tensors` are both optional flags. They ensure that all golden data produced by the `ttrt` run gets written to files.
 ```bash
 ttrt run ttnn/test_ttnn.mlir --log-file ttrt.log --save-golden-tensors
 ```
 
 #### Golden callbacks
-The `ttrt` documentation contains a [section](https://github.com/tenstorrent/tt-mlir/blob/jgrim/ttir-builder-doc/docs/src/ttrt.md#bonus-section-extending-runtime-to-other-fes) on the callback function feature. Callback functions run between each op execution during runtime and contain op level golden analysis. They are also customizable and provide the flexibility for you to get creative with you golden usage.
+The `ttrt` documentation contains a [section](https://github.com/tenstorrent/tt-mlir/blob/main/docs/src/ttrt.md#bonus-section-extending-runtime-to-other-fes) on the callback function feature. Callback functions run between each op execution during runtime and contain op level golden analysis. They are also customizable and provide the flexibility for you to get creative with your golden usage.
 
 ## Adding a new op to `ttir-builder`
 `ttir-builder` is designed to only create ops supported in TTIR. At the moment, most but not all ops are supported, and new ops are still occasionally added to TTIR. Creating `ttir-builder` support for an op entails writing a function in `tools/ttir-builder/builder.py` that will create the op and its golden counterpart.

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -121,7 +121,7 @@ def test_log1p(shape: Shape, dtype: torch.dtype, request):
     def log1p(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
         randn_tensor = torch.randn(shape, dtype=dtype)
         abs_tensor = torch.abs(randn_tensor)
-        error_margin = torch.full(randn_tensor.shape, 1.01)
+        error_margin = torch.full(randn_tensor.shape, -0.99)
         input_golden = torch.add(abs_tensor, error_margin)
         output_golden = torch.log1p(input_golden)
         builder.set_graph_input_output([input_golden], [output_golden], override=True)

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -58,8 +58,29 @@ def cos(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
     return builder.cos(in0, unit_attrs=unit_attrs)
 
 
-def tan(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
-    return builder.tan(in0, unit_attrs=unit_attrs)
+# Special handling for tan PCC checks. Due to the vertical asymptote on the tan graph, small changes in input values result in large changes in output values at multiples of pi/2, so both graph and golden tensors must be constrained accordingly.
+@pytest.mark.parametrize("shape", [(128, 128)])
+@pytest.mark.parametrize("dtype", [torch.float32], ids=["f32"])
+def test_tan(shape: Shape, dtype: torch.dtype, request):
+    def tan(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+        import math
+
+        randn_tensor = torch.randn(shape, dtype=dtype)
+        input_golden = randn_tensor.uniform_(
+            (-math.pi / 2 + 0.02), (math.pi / 2 - 0.02)
+        )
+        output_golden = torch.tan(input_golden)
+        builder.set_graph_input_output([input_golden], [output_golden], override=True)
+        return builder.tan(in0, unit_attrs=unit_attrs)
+
+    compile_to_flatbuffer(
+        tan,
+        [shape],
+        [dtype],
+        test_base=request.node.name,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+    )
 
 
 def atan(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
@@ -70,12 +91,50 @@ def tanh(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
     return builder.tanh(in0, unit_attrs=unit_attrs)
 
 
-def log(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
-    return builder.log(in0, unit_attrs=unit_attrs)
+# Special handling for log PCC checks. Due to the vertical asymptote on the log graph, small changes in input values result in large changes in output values at negative values, so both graph and golden tensors must be constrained accordingly.
+@pytest.mark.parametrize("shape", [(128, 128)])
+@pytest.mark.parametrize("dtype", [torch.float32], ids=["f32"])
+def test_log(shape: Shape, dtype: torch.dtype, request):
+    def log(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+        randn_tensor = torch.randn(shape, dtype=dtype)
+        abs_tensor = torch.abs(randn_tensor)
+        error_margin = torch.full(randn_tensor.shape, 0.01)
+        input_golden = torch.add(abs_tensor, error_margin)
+        output_golden = torch.log(input_golden)
+        builder.set_graph_input_output([input_golden], [output_golden], override=True)
+        return builder.log(in0, unit_attrs=unit_attrs)
+
+    compile_to_flatbuffer(
+        log,
+        [shape],
+        [dtype],
+        test_base=request.node.name,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+    )
 
 
-def log1p(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
-    return builder.log1p(in0, unit_attrs=unit_attrs)
+# Special handling for log1p PCC checks. Due to the vertical asymptote on the log1p graph, small changes in input values result in large changes in output values at values below -1, so both graph and golden tensors must be constrained accordingly.
+@pytest.mark.parametrize("shape", [(128, 128)])
+@pytest.mark.parametrize("dtype", [torch.float32], ids=["f32"])
+def test_log1p(shape: Shape, dtype: torch.dtype, request):
+    def log1p(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
+        randn_tensor = torch.randn(shape, dtype=dtype)
+        abs_tensor = torch.abs(randn_tensor)
+        error_margin = torch.full(randn_tensor.shape, 1.01)
+        input_golden = torch.add(abs_tensor, error_margin)
+        output_golden = torch.log1p(input_golden)
+        builder.set_graph_input_output([input_golden], [output_golden], override=True)
+        return builder.log1p(in0, unit_attrs=unit_attrs)
+
+    compile_to_flatbuffer(
+        log1p,
+        [shape],
+        [dtype],
+        test_base=request.node.name,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+    )
 
 
 def relu(in0: Operand, builder: TTIRBuilder, unit_attrs: List[str] = None):
@@ -948,7 +1007,7 @@ def test_reduce_and(shape: Shape, dim_args: List[int], request):
     )
 
 
-@pytest.mark.run_error
+@pytest.mark.skip("Run error")
 @pytest.mark.parametrize("shape", [(4, 4)])
 @pytest.mark.parametrize("dim_args", [[0, 1]])
 def test_reduce_or(shape: Shape, dim_args: List[int], request):
@@ -1319,7 +1378,6 @@ def create_hoisted_concat_op(op_func, name):
 # Create hoisted versions of all hoistable operations with proper names
 hoisted_unary_ops = [
     create_hoisted_unary_op(exp, "exp"),
-    create_hoisted_unary_op(log, "log"),
     create_hoisted_unary_op(sqrt, "sqrt"),
     create_hoisted_unary_op(rsqrt, "rsqrt"),
     create_hoisted_unary_op(abs, "abs"),
@@ -1443,11 +1501,8 @@ unary_ops = [
     sign | Marks(pytest.mark.skip_target("ttmetal")),
     cos,
     sin,
-    tan | Marks(pytest.mark.fails_golden, pytest.mark.skip_target("ttmetal")),
     atan | Marks(pytest.mark.skip_target("ttmetal")),
     tanh | Marks(pytest.mark.skip_target("ttmetal")),
-    log | Marks(pytest.mark.fails_golden, pytest.mark.skip_target("ttmetal")),
-    log1p | Marks(pytest.mark.fails_golden, pytest.mark.skip_target("ttmetal")),
     relu | Marks(pytest.mark.skip_target("ttmetal")),
     gelu | Marks(pytest.mark.skip_target("ttmetal")),
     leaky_relu | Marks(pytest.mark.skip_target("ttmetal")),


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/3723)
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/1797)
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/1798)
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/1799)

### Problem description
These ops: `ttir.tan`, `ttir.log`, and `ttir.log1p` have golden pcc failures at/near certain input values. As input values approach the vertical asymptotes of these ops' graphs, output values have huge reactions to small variations in input values.

### What's changed
Wrote individual test functions for each op constricting input values of both graph and golden input tensors. Golden handling is typically done in `builder.py`'s op-constructing functions. However, for these to pass, a margin of error was necessary on both graph and golden inputs in order to pass PCC tests, but implementing graph input tensor restrictions in builder.py would change the functionality of the resulting `ttir.log`, which is an unnecessary restriction if golden checks aren’t used.
Adjusted `ttir-builder.md`.

### Checklist
- [ ] New/Existing tests provide coverage for changes
