### PR TITLE
Add runtime api entry points to create runtime tensors from buffers containing unsupported data types

### DIFF
--- a/include/ttmlir/Target/Common/types.fbs
+++ b/include/ttmlir/Target/Common/types.fbs
@@ -30,6 +30,15 @@ enum DataType: uint16 {
   UInt16,
   UInt8,
   Int32,
+
+  // Unsupported data types
+  // Special handling is required if a user/frontend attempts to create or retrieve a tensor with these data types
+  Float64,
+  Int64,
+  UInt64,
+  Int16,
+  Int8,
+  Bool
 }
 
 enum OOBVal: ushort {

--- a/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
+++ b/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
@@ -436,6 +436,8 @@ mlir::FailureOr<mlir::tt::SystemDescAttr> mlir::tt::SystemDescAttr::getFromPath(
         supportedDataTypesAttr.push_back(
             tt::DataTypeAttr::get(context, tt::DataType::Int32));
         break;
+      default:
+        break;
       }
     }
 

--- a/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
+++ b/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
@@ -436,7 +436,15 @@ mlir::FailureOr<mlir::tt::SystemDescAttr> mlir::tt::SystemDescAttr::getFromPath(
         supportedDataTypesAttr.push_back(
             tt::DataTypeAttr::get(context, tt::DataType::Int32));
         break;
-      default:
+      // Unsupported data types
+      // We will list the cases here (rather than use `default`) so that
+      // if new supported data types are added, we will get a compile error.
+      case ::tt::target::DataType::Float64:
+      case ::tt::target::DataType::Int64:
+      case ::tt::target::DataType::UInt64:
+      case ::tt::target::DataType::Int16:
+      case ::tt::target::DataType::Int8:
+      case ::tt::target::DataType::Bool:
         break;
       }
     }

--- a/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
@@ -28,12 +28,10 @@ Tensor createBorrowedHostTensor(std::shared_ptr<void> data,
                                 const TensorDesc &desc);
 
 inline Tensor createOwnedHostTensor(const void *data, const TensorDesc &desc) {
-  LOG_ASSERT(
-      utils::isSupportedDataType(desc.dataType),
-      "Creating owned tensor with unsupported data type: " +
-          std::string(
-              target::EnumNamesDataType()[static_cast<int>(desc.dataType)]) +
-          "is not implemented for the TTMetal runtime");
+  LOG_ASSERT(utils::isSupportedDataType(desc.dataType),
+             "Creating owned tensor with unsupported data type: " +
+                 std::string(target::EnumNameDataType(desc.dataType)) +
+                 "is not implemented for the TTMetal runtime");
   std::shared_ptr<void> owned = utils::malloc_shared(desc.sizeBytes());
   std::memcpy(owned.get(), data, desc.sizeBytes());
   return ttmetal::createBorrowedHostTensor(owned, desc);

--- a/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
@@ -28,6 +28,12 @@ Tensor createBorrowedHostTensor(std::shared_ptr<void> data,
                                 const TensorDesc &desc);
 
 inline Tensor createOwnedHostTensor(const void *data, const TensorDesc &desc) {
+  LOG_ASSERT(
+      utils::isSupportedDataType(desc.dataType),
+      "Creating owned tensor with unsupported data type: " +
+          std::string(
+              target::EnumNamesDataType()[static_cast<int>(desc.dataType)]) +
+          "is not implemented for the TTMetal runtime");
   std::shared_ptr<void> owned = utils::malloc_shared(desc.sizeBytes());
   std::memcpy(owned.get(), data, desc.sizeBytes());
   return ttmetal::createBorrowedHostTensor(owned, desc);
@@ -104,7 +110,8 @@ void wait(const std::vector<Tensor> &tensors);
 
 std::vector<Tensor> toHost(Tensor tensor, bool untilize);
 
-void memcpy(void *dst, Tensor src);
+void memcpy(void *dst, Tensor src,
+            std::optional<tt::target::DataType> dstDataType = std::nullopt);
 
 void memcpy(Tensor dst, Tensor src);
 

--- a/runtime/include/tt/runtime/detail/ttnn/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn/ttnn.h
@@ -182,7 +182,8 @@ std::vector<::tt::runtime::Tensor> toHost(::tt::runtime::Tensor tensor,
 Layout getLayout(Binary executableHandle, std::uint32_t programIndex,
                  std::uint32_t inputIndex);
 
-void memcpy(void *dst, ::tt::runtime::Tensor src);
+void memcpy(void *dst, ::tt::runtime::Tensor src,
+            std::optional<tt::target::DataType> dstDataType = std::nullopt);
 
 void memcpy(::tt::runtime::Tensor dst, ::tt::runtime::Tensor src);
 

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -179,7 +179,8 @@ Tensor toLayout(Tensor tensor, Device device, Layout layout,
 Layout getLayout(Binary executableHandle, std::uint32_t programIndex,
                  std::uint32_t inputIndex);
 
-void memcpy(void *dst, Tensor src);
+void memcpy(void *dst, Tensor src,
+            std::optional<tt::target::DataType> targetDataType = std::nullopt);
 
 void memcpy(Tensor dst, Tensor src);
 

--- a/runtime/include/tt/runtime/utils.h
+++ b/runtime/include/tt/runtime/utils.h
@@ -218,7 +218,22 @@ inline void handleSignedToUnsignedIntegerBufferCast(const FromTy *old_buffer,
   constexpr ToTy toTyMin = std::numeric_limits<ToTy>::min();
   if constexpr (sizeof(ToTy) > sizeof(FromTy)) {
     for (int64_t i = 0; i < num_elements; i++) {
-      new_buffer[i] = static_cast<ToTy>(old_buffer[i]);
+      if (old_buffer[i] < static_cast<FromTy>(toTyMin)) {
+        new_buffer[i] = toTyMin;
+      } else {
+        new_buffer[i] = static_cast<ToTy>(old_buffer[i]);
+      }
+    }
+  } else if constexpr (sizeof(ToTy) == sizeof(FromTy)) {
+    // when the signed and unsigned type have the same bitwidth then we cannot
+    // it is impossible for the signed type to be beyond the maximum
+    // unsigned value
+    for (int64_t i = 0; i < num_elements; i++) {
+      if (old_buffer[i] < static_cast<FromTy>(toTyMin)) {
+        new_buffer[i] = toTyMin;
+      } else {
+        new_buffer[i] = static_cast<ToTy>(old_buffer[i]);
+      }
     }
   } else { // signed FromTy has larger or equal bitwidth than unsigned ToTy
     for (int64_t i = 0; i < num_elements; i++) {

--- a/runtime/include/tt/runtime/utils.h
+++ b/runtime/include/tt/runtime/utils.h
@@ -26,25 +26,20 @@ inline std::shared_ptr<void> unsafe_borrow_shared(T *ptr) {
 
 inline std::uint32_t dataTypeElementSize(::tt::target::DataType dataType) {
   switch (dataType) {
-  case ::tt::target::DataType::Float32:
-    return 4;
-  case ::tt::target::DataType::Float16:
-    return 2;
-  case ::tt::target::DataType::BFloat16:
-    return 2;
-  case ::tt::target::DataType::UInt32:
-  case ::tt::target::DataType::Int32:
-    return 4;
-  case ::tt::target::DataType::UInt16:
-    return 2;
-  case ::tt::target::DataType::UInt8:
-    return 1;
   case ::tt::target::DataType::Float64:
   case ::tt::target::DataType::Int64:
   case ::tt::target::DataType::UInt64:
     return 8;
+  case ::tt::target::DataType::Float32:
+  case ::tt::target::DataType::UInt32:
+  case ::tt::target::DataType::Int32:
+    return 4;
+  case ::tt::target::DataType::Float16:
+  case ::tt::target::DataType::BFloat16:
+  case ::tt::target::DataType::UInt16:
   case ::tt::target::DataType::Int16:
     return 2;
+  case ::tt::target::DataType::UInt8:
   case ::tt::target::DataType::Int8:
   case ::tt::target::DataType::Bool:
     return 1;
@@ -80,7 +75,12 @@ inline bool isSupportedDataType(::tt::target::DataType dataType) {
   case ::tt::target::DataType::UInt8:
   case ::tt::target::DataType::Int32:
     return true;
-  default:
+  case ::tt::target::DataType::Float64:
+  case ::tt::target::DataType::Int64:
+  case ::tt::target::DataType::UInt64:
+  case ::tt::target::DataType::Int16:
+  case ::tt::target::DataType::Int8:
+  case ::tt::target::DataType::Bool:
     return false;
   }
 }
@@ -109,6 +109,76 @@ getUnsupportedDataTypeAlias(::tt::target::DataType unsupportedDataType) {
   }
 }
 
+// Maps a tt::target::DataType to its corresponding C++ type
+template <tt::target::DataType DT>
+struct DataTypeToCppType;
+
+// Specializations for each supported data type
+template <>
+struct DataTypeToCppType<tt::target::DataType::Float32> {
+  using type = float;
+};
+
+template <>
+struct DataTypeToCppType<tt::target::DataType::Float64> {
+  using type = double;
+};
+
+template <>
+struct DataTypeToCppType<tt::target::DataType::Int8> {
+  using type = int8_t;
+};
+
+template <>
+struct DataTypeToCppType<tt::target::DataType::UInt8> {
+  using type = uint8_t;
+};
+
+template <>
+struct DataTypeToCppType<tt::target::DataType::Int16> {
+  using type = int16_t;
+};
+
+template <>
+struct DataTypeToCppType<tt::target::DataType::UInt16> {
+  using type = uint16_t;
+};
+
+template <>
+struct DataTypeToCppType<tt::target::DataType::Int32> {
+  using type = int32_t;
+};
+
+template <>
+struct DataTypeToCppType<tt::target::DataType::UInt32> {
+  using type = uint32_t;
+};
+
+template <>
+struct DataTypeToCppType<tt::target::DataType::Int64> {
+  using type = int64_t;
+};
+
+template <>
+struct DataTypeToCppType<tt::target::DataType::UInt64> {
+  using type = uint64_t;
+};
+
+template <>
+struct DataTypeToCppType<tt::target::DataType::Bool> {
+  using type = bool;
+};
+
+template <>
+struct DataTypeToCppType<tt::target::DataType::BFloat16> {
+  using type = uint16_t;
+}; // BFloat16 stored as uint16_t
+
+template <>
+struct DataTypeToCppType<tt::target::DataType::Float16> {
+  using type = uint16_t;
+}; // Float16 stored as uint16_t
+
 template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
 inline std::vector<uint32_t> calculateStride(const std::vector<T> &shape) {
   assert(!shape.empty());
@@ -128,6 +198,8 @@ template <typename T>
 T alignUp(T ptr, T alignment) {
   return (ptr + alignment - 1) & ~(alignment - 1);
 }
+
+namespace detail {
 
 inline void handleDoubleToFloatBufferCast(const double *old_buffer,
                                           float *new_buffer,
@@ -251,15 +323,15 @@ inline void handleIntegerBufferCast(const FromTy *old_buffer, ToTy *new_buffer,
                  std::is_signed<ToTy>::value) ||
                 (std::is_unsigned<FromTy>::value &&
                  std::is_unsigned<ToTy>::value)) {
-    handleEquallySignedIntegerBufferCast<FromTy, ToTy>(old_buffer, new_buffer,
-                                                       num_elements);
+    detail::handleEquallySignedIntegerBufferCast<FromTy, ToTy>(
+        old_buffer, new_buffer, num_elements);
   } else if constexpr (std::is_unsigned<FromTy>::value &&
                        std::is_signed<ToTy>::value) {
-    handleUnsignedToSignedIntegerBufferCast<FromTy, ToTy>(
+    detail::handleUnsignedToSignedIntegerBufferCast<FromTy, ToTy>(
         old_buffer, new_buffer, num_elements);
   } else if constexpr (std::is_signed<FromTy>::value &&
                        std::is_unsigned<ToTy>::value) {
-    handleSignedToUnsignedIntegerBufferCast<FromTy, ToTy>(
+    detail::handleSignedToUnsignedIntegerBufferCast<FromTy, ToTy>(
         old_buffer, new_buffer, num_elements);
   } else { // Both are unsigned
     std::runtime_error("Unhandled integer buffer cast case");
@@ -285,6 +357,87 @@ inline void handleBoolToBFloat16(const bool *old_buffer, uint16_t *new_buffer,
     new_buffer[i] = old_buffer[i]
                         ? 0x3f80
                         : 0; // 0x3f80 is the bfloat16 representation of 1.0
+  }
+}
+} // namespace detail
+
+inline void handleBufferCast(const void *old_buffer, void *new_buffer,
+                             target::DataType oldDataType,
+                             target::DataType newDataType,
+                             int64_t num_elements) {
+  if (!old_buffer || !new_buffer) {
+    throw std::runtime_error("Buffer pointers must not be null");
+  }
+  if (oldDataType == newDataType) {
+    std::memcpy(new_buffer, old_buffer,
+                num_elements * dataTypeElementSize(oldDataType));
+    return;
+  }
+
+  if (oldDataType == tt::target::DataType::Int64 &&
+      newDataType == tt::target::DataType::Int32) {
+    detail::handleIntegerBufferCast<int64_t, int32_t>(
+        static_cast<const int64_t *>(old_buffer),
+        static_cast<int32_t *>(new_buffer), num_elements);
+  } else if (oldDataType == tt::target::DataType::Int32 &&
+             newDataType == tt::target::DataType::Int64) {
+    detail::handleIntegerBufferCast<int32_t, int64_t>(
+        static_cast<const int32_t *>(old_buffer),
+        static_cast<int64_t *>(new_buffer), num_elements);
+  } else if (oldDataType == tt::target::DataType::UInt64 &&
+             newDataType == tt::target::DataType::UInt32) {
+    detail::handleIntegerBufferCast<uint64_t, uint32_t>(
+        static_cast<const uint64_t *>(old_buffer),
+        static_cast<uint32_t *>(new_buffer), num_elements);
+  } else if (oldDataType == tt::target::DataType::UInt32 &&
+             newDataType == tt::target::DataType::UInt64) {
+    detail::handleIntegerBufferCast<uint32_t, uint64_t>(
+        static_cast<const uint32_t *>(old_buffer),
+        static_cast<uint64_t *>(new_buffer), num_elements);
+  } else if (oldDataType == tt::target::DataType::Int16 &&
+             newDataType == tt::target::DataType::UInt16) {
+    detail::handleIntegerBufferCast<int16_t, uint16_t>(
+        static_cast<const int16_t *>(old_buffer),
+        static_cast<uint16_t *>(new_buffer), num_elements);
+  } else if (oldDataType == tt::target::DataType::UInt16 &&
+             newDataType == tt::target::DataType::Int16) {
+    detail::handleIntegerBufferCast<uint16_t, int16_t>(
+        static_cast<const uint16_t *>(old_buffer),
+        static_cast<int16_t *>(new_buffer), num_elements);
+  } else if (oldDataType == tt::target::DataType::Int8 &&
+             newDataType == tt::target::DataType::UInt8) {
+    detail::handleIntegerBufferCast<int8_t, uint8_t>(
+        static_cast<const int8_t *>(old_buffer),
+        static_cast<uint8_t *>(new_buffer), num_elements);
+  } else if (oldDataType == tt::target::DataType::UInt8 &&
+             newDataType == tt::target::DataType::Int8) {
+    detail::handleIntegerBufferCast<uint8_t, int8_t>(
+        static_cast<const uint8_t *>(old_buffer),
+        static_cast<int8_t *>(new_buffer), num_elements);
+  } else if (oldDataType == tt::target::DataType::Float32 &&
+             newDataType == tt::target::DataType::Float64) {
+    detail::handleFloatToDoubleBufferCast(
+        static_cast<const float *>(old_buffer),
+        static_cast<double *>(new_buffer), num_elements);
+  } else if (oldDataType == tt::target::DataType::Float64 &&
+             newDataType == tt::target::DataType::Float32) {
+    detail::handleDoubleToFloatBufferCast(
+        static_cast<const double *>(old_buffer),
+        static_cast<float *>(new_buffer), num_elements);
+  } else if (oldDataType == tt::target::DataType::BFloat16 &&
+             newDataType == tt::target::DataType::Bool) {
+    detail::handleBFloat16ToBool(static_cast<const uint16_t *>(old_buffer),
+                                 static_cast<bool *>(new_buffer), num_elements);
+  } else if (oldDataType == tt::target::DataType::Bool &&
+             newDataType == tt::target::DataType::BFloat16) {
+    detail::handleBoolToBFloat16(static_cast<const bool *>(old_buffer),
+                                 static_cast<uint16_t *>(new_buffer),
+                                 num_elements);
+  } else {
+    throw std::runtime_error(
+        "Unhandled buffer cast case: From " +
+        std::string(target::EnumNameDataType(oldDataType)) + " to " +
+        std::string(target::EnumNameDataType(newDataType)));
   }
 }
 

--- a/runtime/include/tt/runtime/utils.h
+++ b/runtime/include/tt/runtime/utils.h
@@ -156,6 +156,11 @@ inline void handleSignedToSignedIntegerBufferCast(const FromTy *old_buffer,
   static_assert(std::is_signed<ToTy>::value,
                 "Destination type must be a signed integer type");
 
+  static_assert(!std::is_same<FromTy, ToTy>::value,
+                "Source and destination types are the same! Please use "
+                "std::memcpy(new_buffer, old_buffer, num_elements * "
+                "sizeof(FromTy)) instead.");
+
   constexpr ToTy toTyMax = std::numeric_limits<ToTy>::max();
   constexpr ToTy toTyMin = std::numeric_limits<ToTy>::min();
   if constexpr (sizeof(ToTy) >= sizeof(FromTy)) {
@@ -236,6 +241,11 @@ inline void handleUnsignedToUnsignedIntegerBufferCast(const FromTy *old_buffer,
                 "Source type must be an unsigned integer type");
   static_assert(std::is_unsigned<ToTy>::value,
                 "Destination type must be an unsigned integer type");
+
+  static_assert(!std::is_same<FromTy, ToTy>::value,
+                "Source and destination types are the same! Please use "
+                "std::memcpy(new_buffer, old_buffer, num_elements * "
+                "sizeof(FromTy)) instead.");
 
   constexpr ToTy toTyMax = std::numeric_limits<ToTy>::max();
   if constexpr (sizeof(ToTy) >= sizeof(FromTy)) {

--- a/runtime/include/tt/runtime/utils.h
+++ b/runtime/include/tt/runtime/utils.h
@@ -266,6 +266,7 @@ inline void handleUnsignedToUnsignedIntegerBufferCast(const FromTy *old_buffer,
 template <typename FromTy, typename ToTy>
 inline void handleIntegerBufferCast(const FromTy *old_buffer, ToTy *new_buffer,
                                     int64_t num_elements) {
+  assert(old_buffer && new_buffer && "Buffer pointers must not be null");
   static_assert(std::is_integral<FromTy>::value,
                 "Source type must be an integer type");
   static_assert(std::is_integral<ToTy>::value,
@@ -290,6 +291,7 @@ inline void handleIntegerBufferCast(const FromTy *old_buffer, ToTy *new_buffer,
 
 inline void handleBFloat16ToBool(const uint16_t *old_buffer, bool *new_buffer,
                                  int64_t num_elements) {
+  assert(old_buffer && new_buffer && "Buffer pointers must not be null");
   for (int i = 0; i < num_elements; i++) {
     new_buffer[i] =
         old_buffer[i] !=
@@ -299,7 +301,7 @@ inline void handleBFloat16ToBool(const uint16_t *old_buffer, bool *new_buffer,
 
 inline void handleBoolToBFloat16(const bool *old_buffer, uint16_t *new_buffer,
                                  int64_t num_elements) {
-
+  assert(old_buffer && new_buffer && "Buffer pointers must not be null");
   assert(sizeof(bool) == 1 && "bool must be 1 byte");
 
   for (int i = 0; i < num_elements; i++) {

--- a/runtime/include/tt/runtime/utils.h
+++ b/runtime/include/tt/runtime/utils.h
@@ -102,7 +102,7 @@ getUnsupportedDataTypeAlias(::tt::target::DataType unsupportedDataType) {
   case ::tt::target::DataType::Bool:
     return ::tt::target::DataType::BFloat16;
   default:
-    LOG_FATAL(
+    throw std::runtime_error(
         "The data type: " +
         std::string(target::EnumNameDataType(unsupportedDataType)) +
         " is either supported and thus needs no alias OR it is not supported "
@@ -327,7 +327,7 @@ inline void handleIntegerBufferCast(const FromTy *old_buffer, ToTy *new_buffer,
     detail::handleSignedToUnsignedIntegerBufferCast<FromTy, ToTy>(
         old_buffer, new_buffer, num_elements);
   } else { // Both are unsigned
-    LOG_FATAL("Unhandled integer buffer cast case");
+    throw std::runtime_error("Unhandled integer buffer cast case");
   }
 }
 
@@ -359,7 +359,7 @@ inline void handleBufferCast(const void *old_buffer, void *new_buffer,
                              target::DataType newDataType,
                              int64_t num_elements) {
   if (!old_buffer || !new_buffer) {
-    LOG_FATAL("Buffer pointers must not be null");
+    throw std::runtime_error("Buffer pointers must not be null");
   }
   if (oldDataType == newDataType) {
     std::memcpy(new_buffer, old_buffer,
@@ -427,9 +427,10 @@ inline void handleBufferCast(const void *old_buffer, void *new_buffer,
                                  static_cast<uint16_t *>(new_buffer),
                                  num_elements);
   } else {
-    LOG_FATAL("Unhandled buffer cast case: From " +
-              std::string(target::EnumNameDataType(oldDataType)) + " to " +
-              std::string(target::EnumNameDataType(newDataType)));
+    throw std::runtime_error(
+        "Unhandled buffer cast case: From " +
+        std::string(target::EnumNameDataType(oldDataType)) + " to " +
+        std::string(target::EnumNameDataType(newDataType)));
   }
 }
 

--- a/runtime/include/tt/runtime/utils.h
+++ b/runtime/include/tt/runtime/utils.h
@@ -103,8 +103,7 @@ getUnsupportedDataTypeAlias(::tt::target::DataType unsupportedDataType) {
   default:
     throw std::runtime_error(
         "The data type: " +
-        std::string(target::EnumNamesDataType()[static_cast<int>(
-            unsupportedDataType)]) +
+        std::string(target::EnumNameDataType(unsupportedDataType)) +
         " is either supported and thus needs no alias OR it is not supported "
         "and is not accounted for in this function (that would be a bug).");
   }

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -182,11 +182,9 @@ Tensor createBorrowedHostTensor(void *data,
                                 const std::vector<std::uint32_t> &stride,
                                 std::uint32_t itemsize,
                                 ::tt::target::DataType dataType) {
-  LOG_ASSERT(
-      ::tt::runtime::utils::isSupportedDataType(dataType),
-      "Cannot create borrowed tensor with unsupported data type: " +
-          std::string(
-              ::tt::target::EnumNamesDataType()[static_cast<int>(dataType)]));
+  LOG_ASSERT(::tt::runtime::utils::isSupportedDataType(dataType),
+             "Cannot create borrowed tensor with unsupported data type: " +
+                 std::string(::tt::target::EnumNameDataType(dataType)));
   using RetType = Tensor;
   LOG_ASSERT(!shape.empty());
   LOG_ASSERT(!stride.empty());

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -219,12 +219,6 @@ Tensor createOwnedHostTensor(const void *data,
                                                           itemsize, dataType);
       },
       [&]() -> RetType {
-        LOG_ASSERT(
-            utils::isSupportedDataType(dataType),
-            "Creating owned tensor with unsupported data type: " +
-                std::string(
-                    target::EnumNamesDataType()[static_cast<int>(dataType)]) +
-                "is not implemented for the TTMetal runtime");
         return ::tt::runtime::ttmetal::createOwnedHostTensor(
             data, TensorDesc(shape, stride, itemsize, dataType));
       });
@@ -660,7 +654,7 @@ void memcpy(void *dst, Tensor src,
   using RetType = void;
   DISPATCH_TO_CURRENT_RUNTIME(
       RetType, [&]() { ::tt::runtime::ttnn::memcpy(dst, src, dstDataType); },
-      [&]() { ::tt::runtime::ttmetal::memcpy(dst, src); });
+      [&]() { ::tt::runtime::ttmetal::memcpy(dst, src, dstDataType); });
 }
 
 void memcpy(Tensor dst, Tensor src) {

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -375,7 +375,13 @@ std::vector<Tensor> toHost(Tensor tensor, bool untilize) {
   return {tensor};
 }
 
-void memcpy(void *dst, Tensor src) {
+void memcpy(void *dst, Tensor src,
+            std::optional<tt::target::DataType> dstDataType) {
+  if (dstDataType.has_value()) {
+    LOG_ASSERT(
+        ::tt::runtime::utils::isSupportedDataType(dstDataType.value()),
+        "dstDataType must be a supported data type if using TTMetal runtime");
+  }
   const auto &metalSrc = src.as<MetalTensor>(DeviceRuntime::TTMetal);
   LOG_ASSERT(std::holds_alternative<TensorDesc>(metalSrc),
              "Only TensorDesc supported for now");

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -58,6 +58,8 @@ createOwnedTTNNTensor(const void *data, const std::vector<std::uint32_t> &shape,
                       const std::vector<std::uint32_t> &stride,
                       std::uint32_t itemsize, ::tt::target::DataType dataType) {
   if (!::tt::runtime::utils::isSupportedDataType(dataType)) {
+    assert(data && "Cannot create owned tensor from unsupported data type with "
+                   "null data pointer");
     ::tt::target::DataType unsupportedDataType = dataType;
     dataType =
         ::tt::runtime::utils::getUnsupportedDataTypeAlias(unsupportedDataType);
@@ -756,23 +758,23 @@ void memcpy(void *dst, ::tt::runtime::Tensor src,
     if (dstDataType == ::tt::target::DataType::Int64) {
       tt::runtime::utils::handleIntegerBufferCast<int32_t, int64_t>(
           static_cast<const int32_t *>(srcPtr), static_cast<int64_t *>(dst),
-          srcTensor.padded_volume());
+          srcTensor.physical_volume());
     } else if (dstDataType == ::tt::target::DataType::UInt64) {
       tt::runtime::utils::handleIntegerBufferCast<uint32_t, uint64_t>(
           static_cast<const uint32_t *>(srcPtr), static_cast<uint64_t *>(dst),
-          srcTensor.padded_volume());
+          srcTensor.physical_volume());
     } else if (dstDataType == ::tt::target::DataType::Int16) {
       tt::runtime::utils::handleIntegerBufferCast<uint16_t, int16_t>(
           static_cast<const uint16_t *>(srcPtr), static_cast<int16_t *>(dst),
-          srcTensor.padded_volume());
+          srcTensor.physical_volume());
     } else if (dstDataType == ::tt::target::DataType::Int8) {
       tt::runtime::utils::handleIntegerBufferCast<uint8_t, int8_t>(
           static_cast<const uint8_t *>(srcPtr), static_cast<int8_t *>(dst),
-          srcTensor.padded_volume());
+          srcTensor.physical_volume());
     } else if (dstDataType == ::tt::target::DataType::Float64) {
       tt::runtime::utils::handleFloatToDoubleBufferCast(
           static_cast<const float *>(srcPtr), static_cast<double *>(dst),
-          srcTensor.padded_volume());
+          srcTensor.physical_volume());
     } else if (dstDataType == ::tt::target::DataType::Bool) {
       LOG_ASSERT(getTensorDataType(src) == ::tt::target::DataType::BFloat16,
                  "Tensor data type must be BFloat16, got " +
@@ -780,7 +782,7 @@ void memcpy(void *dst, ::tt::runtime::Tensor src,
                          getTensorDataType(src))]));
       tt::runtime::utils::handleBFloat16ToBool(
           static_cast<const uint16_t *>(srcPtr), static_cast<bool *>(dst),
-          srcTensor.padded_volume());
+          srcTensor.physical_volume());
     } else {
       throw std::runtime_error(
           "Unknown unsupported data type: " +

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -58,7 +58,8 @@ static ::ttnn::Tensor
 createOwnedTTNNTensor(const void *data, const std::vector<std::uint32_t> &shape,
                       const std::vector<std::uint32_t> &stride,
                       std::uint32_t itemsize, ::tt::target::DataType dataType) {
-
+  const void *dataToUse = data;
+  std::unique_ptr<void, decltype(&std::free)> castedData(nullptr, &std::free);
   if (!::tt::runtime::utils::isSupportedDataType(dataType) && data != nullptr) {
     ::tt::target::DataType unsupportedDataType = dataType;
     dataType =
@@ -75,43 +76,12 @@ createOwnedTTNNTensor(const void *data, const std::vector<std::uint32_t> &shape,
 
     std::uint32_t itemsize =
         ::tt::runtime::utils::dataTypeElementSize(dataType);
-    std::unique_ptr<void, decltype(&std::free)> newData(
-        malloc(itemsize * numElements), &std::free);
 
-    if (unsupportedDataType == ::tt::target::DataType::Int64) {
-      tt::runtime::utils::handleIntegerBufferCast<int64_t, int32_t>(
-          static_cast<const int64_t *>(data),
-          static_cast<int32_t *>(newData.get()), numElements);
-    } else if (unsupportedDataType == ::tt::target::DataType::UInt64) {
-      tt::runtime::utils::handleIntegerBufferCast<uint64_t, uint32_t>(
-          static_cast<const uint64_t *>(data),
-          static_cast<uint32_t *>(newData.get()), numElements);
-    } else if (unsupportedDataType == ::tt::target::DataType::Int16) {
-      tt::runtime::utils::handleIntegerBufferCast<int16_t, uint16_t>(
-          static_cast<const int16_t *>(data),
-          static_cast<uint16_t *>(newData.get()), numElements);
-    } else if (unsupportedDataType == ::tt::target::DataType::Int8) {
-      tt::runtime::utils::handleIntegerBufferCast<int8_t, uint8_t>(
-          static_cast<const int8_t *>(data),
-          static_cast<uint8_t *>(newData.get()), numElements);
-    } else if (unsupportedDataType == ::tt::target::DataType::Float64) {
-      tt::runtime::utils::handleDoubleToFloatBufferCast(
-          static_cast<const double *>(data),
-          static_cast<float *>(newData.get()), numElements);
-    } else if (unsupportedDataType == ::tt::target::DataType::Bool) {
-      tt::runtime::utils::handleBoolToBFloat16(
-          static_cast<const bool *>(data),
-          static_cast<uint16_t *>(newData.get()), numElements);
-    } else {
-      LOG_FATAL(
-          "Unhandled unsupported data type: " +
-          std::string(::tt::target::EnumNameDataType(unsupportedDataType)));
-    }
+    castedData.reset(malloc(itemsize * numElements));
 
-    // Call recursively so that `newData` does not go out of scope and thus get
-    // deallocated
-    return createOwnedTTNNTensor(newData.get(), shape, stride, itemsize,
-                                 dataType);
+    ::tt::runtime::utils::handleBufferCast(
+        data, castedData.get(), unsupportedDataType, dataType, numElements);
+    dataToUse = castedData.get();
   }
 
   if (!::tt::runtime::utils::isSupportedDataType(dataType)) {
@@ -123,17 +93,20 @@ createOwnedTTNNTensor(const void *data, const std::vector<std::uint32_t> &shape,
 
   switch (ttnnDataType) {
   case ::ttnn::DataType::FLOAT32:
-    return utils::createTTNNTensor<float>(data, ttnnShape, ttnnDataType);
+    return utils::createTTNNTensor<float>(dataToUse, ttnnShape, ttnnDataType);
   case ::ttnn::DataType::BFLOAT16:
-    return utils::createTTNNTensor<bfloat16>(data, ttnnShape, ttnnDataType);
+    return utils::createTTNNTensor<bfloat16>(dataToUse, ttnnShape,
+                                             ttnnDataType);
   case ::ttnn::DataType::UINT32:
-    return utils::createTTNNTensor<uint32_t>(data, ttnnShape, ttnnDataType);
+    return utils::createTTNNTensor<uint32_t>(dataToUse, ttnnShape,
+                                             ttnnDataType);
   case ::ttnn::DataType::UINT16:
-    return utils::createTTNNTensor<uint16_t>(data, ttnnShape, ttnnDataType);
+    return utils::createTTNNTensor<uint16_t>(dataToUse, ttnnShape,
+                                             ttnnDataType);
   case ::ttnn::DataType::UINT8:
-    return utils::createTTNNTensor<uint8_t>(data, ttnnShape, ttnnDataType);
+    return utils::createTTNNTensor<uint8_t>(dataToUse, ttnnShape, ttnnDataType);
   case ::ttnn::DataType::INT32:
-    return utils::createTTNNTensor<int32_t>(data, ttnnShape, ttnnDataType);
+    return utils::createTTNNTensor<int32_t>(dataToUse, ttnnShape, ttnnDataType);
   default:
     LOG_FATAL("Unsupported data type");
   }
@@ -766,34 +739,8 @@ void memcpy(void *dst, ::tt::runtime::Tensor src,
         ", the values will be casted, this may impact the throughput and the "
         "integrity of the data.");
 
-    if (dstDataType == ::tt::target::DataType::Int64) {
-      tt::runtime::utils::handleIntegerBufferCast<int32_t, int64_t>(
-          static_cast<const int32_t *>(srcPtr), static_cast<int64_t *>(dst),
-          srcTensor.physical_volume());
-    } else if (dstDataType == ::tt::target::DataType::UInt64) {
-      tt::runtime::utils::handleIntegerBufferCast<uint32_t, uint64_t>(
-          static_cast<const uint32_t *>(srcPtr), static_cast<uint64_t *>(dst),
-          srcTensor.physical_volume());
-    } else if (dstDataType == ::tt::target::DataType::Int16) {
-      tt::runtime::utils::handleIntegerBufferCast<uint16_t, int16_t>(
-          static_cast<const uint16_t *>(srcPtr), static_cast<int16_t *>(dst),
-          srcTensor.physical_volume());
-    } else if (dstDataType == ::tt::target::DataType::Int8) {
-      tt::runtime::utils::handleIntegerBufferCast<uint8_t, int8_t>(
-          static_cast<const uint8_t *>(srcPtr), static_cast<int8_t *>(dst),
-          srcTensor.physical_volume());
-    } else if (dstDataType == ::tt::target::DataType::Float64) {
-      tt::runtime::utils::handleFloatToDoubleBufferCast(
-          static_cast<const float *>(srcPtr), static_cast<double *>(dst),
-          srcTensor.physical_volume());
-    } else if (dstDataType == ::tt::target::DataType::Bool) {
-      tt::runtime::utils::handleBFloat16ToBool(
-          static_cast<const uint16_t *>(srcPtr), static_cast<bool *>(dst),
-          srcTensor.physical_volume());
-    } else {
-      LOG_FATAL("Unhandled unsupported data type: " +
-                std::string(target::EnumNameDataType(dstDataType.value())));
-    }
+    ::tt::runtime::utils::handleBufferCast(
+        srcPtr, dst, srcDataType, *dstDataType, srcTensor.physical_volume());
   } else if (utils::isOnHost(srcTensor.storage_type())) {
     const void *srcPtr = utils::getRawHostDataPtr(srcTensor);
     size_t size = srcTensor.physical_volume() * srcTensor.element_size();

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -65,10 +65,9 @@ createOwnedTTNNTensor(const void *data, const std::vector<std::uint32_t> &shape,
         ::tt::runtime::utils::getUnsupportedDataTypeAlias(unsupportedDataType);
 
     LOG_WARNING("User provided a tensor of data type: ",
-                ::tt::target::EnumNamesDataType()[static_cast<int>(
-                    unsupportedDataType)],
+                ::tt::target::EnumNameDataType(unsupportedDataType),
                 " which is not supported by runtime/ttnn. Casting to: ",
-                ::tt::target::EnumNamesDataType()[static_cast<int>(dataType)],
+                ::tt::target::EnumNameDataType(dataType),
                 ", this may impact throughput and the integrity of the data.");
 
     uint64_t numElements =
@@ -747,10 +746,10 @@ void memcpy(void *dst, ::tt::runtime::Tensor src,
     ::tt::target::DataType unsupportedDataTypeAlias =
         tt::runtime::utils::getUnsupportedDataTypeAlias(*dstDataType);
 
-    LOG_ASSERT(srcDataType == unsupportedDataTypeAlias,
-               "Tensor data type must be " +
-                   std::string(target::EnumNamesDataType()[static_cast<int>(
-                       unsupportedDataTypeAlias)]));
+    LOG_ASSERT(
+        srcDataType == unsupportedDataTypeAlias,
+        "Tensor data type must be " +
+            std::string(target::EnumNameDataType(unsupportedDataTypeAlias)));
 
     LOG_ASSERT(
         !dstDataType.has_value() || *dstDataType == getTensorDataType(src) ||
@@ -761,9 +760,9 @@ void memcpy(void *dst, ::tt::runtime::Tensor src,
     LOG_WARNING(
         "User is requesting to copy the data from a runtime tensor with "
         "data type: ",
-        ::tt::target::EnumNamesDataType()[static_cast<int>(srcDataType)],
+        ::tt::target::EnumNameDataType(srcDataType),
         " into buffer with expected data type: ",
-        ::tt::target::EnumNamesDataType()[static_cast<int>(*dstDataType)],
+        ::tt::target::EnumNameDataType(*dstDataType),
         ", the values will be casted, this may impact the throughput and the "
         "integrity of the data.");
 
@@ -792,10 +791,8 @@ void memcpy(void *dst, ::tt::runtime::Tensor src,
           static_cast<const uint16_t *>(srcPtr), static_cast<bool *>(dst),
           srcTensor.physical_volume());
     } else {
-      throw std::runtime_error(
-          "Unknown unsupported data type: " +
-          std::string(target::EnumNamesDataType()[static_cast<int>(
-              dstDataType.value())]));
+      LOG_FATAL("Unhandled unsupported data type: " +
+                std::string(target::EnumNameDataType(dstDataType.value())));
     }
   } else if (utils::isOnHost(srcTensor.storage_type())) {
     const void *srcPtr = utils::getRawHostDataPtr(srcTensor);

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -96,7 +96,7 @@ createOwnedTTNNTensor(const void *data, const std::vector<std::uint32_t> &shape,
           static_cast<const int8_t *>(data),
           static_cast<uint8_t *>(newData.get()), numElements);
     } else if (unsupportedDataType == ::tt::target::DataType::Float64) {
-      tt::runtime::utils::handleFloatingPointBufferCast<double, float>(
+      tt::runtime::utils::handleDoubleToFloatBufferCast(
           static_cast<const double *>(data),
           static_cast<float *>(newData.get()), numElements);
     } else if (unsupportedDataType == ::tt::target::DataType::Bool) {
@@ -770,7 +770,7 @@ void memcpy(void *dst, ::tt::runtime::Tensor src,
           static_cast<const uint8_t *>(srcPtr), static_cast<int8_t *>(dst),
           srcTensor.padded_volume());
     } else if (dstDataType == ::tt::target::DataType::Float64) {
-      tt::runtime::utils::handleFloatingPointBufferCast<float, double>(
+      tt::runtime::utils::handleFloatToDoubleBufferCast(
           static_cast<const float *>(srcPtr), static_cast<double *>(dst),
           srcTensor.padded_volume());
     } else if (dstDataType == ::tt::target::DataType::Bool) {

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -239,6 +239,9 @@ createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
     Device device, Layout layout, const std::vector<std::uint32_t> &shape,
     const std::vector<std::uint32_t> &stride, std::uint32_t itemsize) {
   const LayoutDesc &layoutDesc = layout.as<LayoutDesc>(DeviceRuntime::TTNN);
+  LOG_ASSERT(::tt::runtime::utils::isSupportedDataType(
+                 utils::fromTTNNDataType(layoutDesc.dataType)),
+             "Data type must be supported");
   if (layoutDesc.isOnHost()) {
     ::ttnn::Tensor tensor =
         createOwnedTTNNTensor(nullptr, shape, stride, itemsize,

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -23,6 +23,7 @@
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/tensor/types.hpp"
 #include "types_generated.h"
+#include <numeric>
 
 namespace tt::runtime::ttnn {
 
@@ -57,9 +58,8 @@ static ::ttnn::Tensor
 createOwnedTTNNTensor(const void *data, const std::vector<std::uint32_t> &shape,
                       const std::vector<std::uint32_t> &stride,
                       std::uint32_t itemsize, ::tt::target::DataType dataType) {
-  if (!::tt::runtime::utils::isSupportedDataType(dataType)) {
-    assert(data && "Cannot create owned tensor from unsupported data type with "
-                   "null data pointer");
+
+  if (!::tt::runtime::utils::isSupportedDataType(dataType) && data != nullptr) {
     ::tt::target::DataType unsupportedDataType = dataType;
     dataType =
         ::tt::runtime::utils::getUnsupportedDataTypeAlias(unsupportedDataType);
@@ -67,14 +67,12 @@ createOwnedTTNNTensor(const void *data, const std::vector<std::uint32_t> &shape,
     LOG_WARNING("User provided a tensor of data type: ",
                 ::tt::target::EnumNamesDataType()[static_cast<int>(
                     unsupportedDataType)],
-                " which is not supported ", "by runtime/ttnn. Casting to: ",
+                " which is not supported by runtime/ttnn. Casting to: ",
                 ::tt::target::EnumNamesDataType()[static_cast<int>(dataType)],
                 ", this may impact throughput and the integrity of the data.");
 
-    uint64_t numElements = 1;
-    for (auto s : shape) {
-      numElements *= s;
-    }
+    uint64_t numElements =
+        std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<>());
 
     std::uint32_t itemsize =
         ::tt::runtime::utils::dataTypeElementSize(dataType);
@@ -105,12 +103,20 @@ createOwnedTTNNTensor(const void *data, const std::vector<std::uint32_t> &shape,
       tt::runtime::utils::handleBoolToBFloat16(
           static_cast<const bool *>(data),
           static_cast<uint16_t *>(newData.get()), numElements);
+    } else {
+      LOG_FATAL(
+          "Unhandled unsupported data type: " +
+          std::string(::tt::target::EnumNameDataType(unsupportedDataType)));
     }
 
     // Call recursively so that `newData` does not go out of scope and thus get
     // deallocated
     return createOwnedTTNNTensor(newData.get(), shape, stride, itemsize,
                                  dataType);
+  }
+
+  if (!::tt::runtime::utils::isSupportedDataType(dataType)) {
+    dataType = ::tt::runtime::utils::getUnsupportedDataTypeAlias(dataType);
   }
 
   ::ttnn::Shape ttnnShape(shape);
@@ -746,6 +752,12 @@ void memcpy(void *dst, ::tt::runtime::Tensor src,
                    std::string(target::EnumNamesDataType()[static_cast<int>(
                        unsupportedDataTypeAlias)]));
 
+    LOG_ASSERT(
+        !dstDataType.has_value() || *dstDataType == getTensorDataType(src) ||
+            !::tt::runtime::utils::isSupportedDataType(dstDataType.value()),
+        "If destination data type is specified, it must match the "
+        "source data type or be an unsupported data type.");
+
     LOG_WARNING(
         "User is requesting to copy the data from a runtime tensor with "
         "data type: ",
@@ -776,10 +788,6 @@ void memcpy(void *dst, ::tt::runtime::Tensor src,
           static_cast<const float *>(srcPtr), static_cast<double *>(dst),
           srcTensor.physical_volume());
     } else if (dstDataType == ::tt::target::DataType::Bool) {
-      LOG_ASSERT(getTensorDataType(src) == ::tt::target::DataType::BFloat16,
-                 "Tensor data type must be BFloat16, got " +
-                     std::string(target::EnumNamesDataType()[static_cast<int>(
-                         getTensorDataType(src))]));
       tt::runtime::utils::handleBFloat16ToBool(
           static_cast<const uint16_t *>(srcPtr), static_cast<bool *>(dst),
           srcTensor.physical_volume());
@@ -790,18 +798,10 @@ void memcpy(void *dst, ::tt::runtime::Tensor src,
               dstDataType.value())]));
     }
   } else if (utils::isOnHost(srcTensor.storage_type())) {
-    LOG_ASSERT(!dstDataType.has_value() ||
-                   *dstDataType == getTensorDataType(src),
-               "If destination data type is specified, it must match the "
-               "source data type or be an unsupported data type.");
     const void *srcPtr = utils::getRawHostDataPtr(srcTensor);
     size_t size = srcTensor.physical_volume() * srcTensor.element_size();
     std::memcpy(dst, srcPtr, size);
   } else {
-    LOG_ASSERT(!dstDataType.has_value() ||
-                   *dstDataType == getTensorDataType(src),
-               "If destination data type is specified, it must match the "
-               "source data type or be an unsupported data type.");
     ::tt::tt_metal::memcpy(dst, srcTensor);
   }
 }

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -167,7 +167,14 @@ void registerRuntimeBindings(nb::module_ &m) {
       .value("UInt32", ::tt::target::DataType::UInt32)
       .value("UInt16", ::tt::target::DataType::UInt16)
       .value("UInt8", ::tt::target::DataType::UInt8)
-      .value("Int32", ::tt::target::DataType::Int32);
+      .value("Int32", ::tt::target::DataType::Int32)
+      // Unsupported data types
+      .value("Float64", ::tt::target::DataType::Float64)
+      .value("Int64", ::tt::target::DataType::Int64)
+      .value("UInt64", ::tt::target::DataType::UInt64)
+      .value("Int16", ::tt::target::DataType::Int16)
+      .value("Int8", ::tt::target::DataType::Int8)
+      .value("Bool", ::tt::target::DataType::Bool);
 
   nb::enum_<::tt::runtime::DeviceRuntime>(m, "DeviceRuntime")
       .value("Disabled", ::tt::runtime::DeviceRuntime::Disabled)
@@ -308,11 +315,12 @@ void registerRuntimeBindings(nb::module_ &m) {
         "Get the location info of the op");
   m.def(
       "memcpy",
-      [](std::uintptr_t dst, ::tt::runtime::Tensor src) {
+      [](std::uintptr_t dst, ::tt::runtime::Tensor src,
+         std::optional<::tt::target::DataType> dstDataType) {
         void *dstPtr = reinterpret_cast<void *>(dst);
-        ::tt::runtime::memcpy(dstPtr, src);
+        ::tt::runtime::memcpy(dstPtr, src, dstDataType);
       },
-      nb::arg("dst"), nb::arg("src"),
+      nb::arg("dst"), nb::arg("src"), nb::arg("dstDataType") = nb::none(),
       "Copy the data from src tensor to dst pointer");
   m.def(
       "memcpy",

--- a/runtime/test/common/CMakeLists.txt
+++ b/runtime/test/common/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_runtime_gtest(sys_desc_sanity test_generate_sys_desc.cpp)
+add_runtime_gtest(handle_integer_buffer_cast test_handle_integer_buffer_cast.cpp)

--- a/runtime/test/common/test_handle_integer_buffer_cast.cpp
+++ b/runtime/test/common/test_handle_integer_buffer_cast.cpp
@@ -1,0 +1,378 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+#include "tt/runtime/utils.h"
+#include <gtest/gtest.h>
+#include <limits>
+
+TEST(HandleI64ToI32BufferCast, Sanity) {
+  int64_t old_buffer[] = {std::numeric_limits<int64_t>::min(), 0,
+                          std::numeric_limits<int64_t>::max()};
+  int32_t new_buffer[] = {0, 0, 0};
+  tt::runtime::utils::handleSignedToSignedIntegerBufferCast(old_buffer,
+                                                            new_buffer, 3);
+
+  // Values should be clamped to the int32_t range, not overflowed
+  EXPECT_EQ(new_buffer[0], std::numeric_limits<int32_t>::min());
+  EXPECT_EQ(new_buffer[1], 0);
+  EXPECT_EQ(new_buffer[2], std::numeric_limits<int32_t>::max());
+}
+
+TEST(HandleI64ToI16BufferCast, Sanity) {
+  int64_t old_buffer[] = {std::numeric_limits<int64_t>::min(), 0,
+                          std::numeric_limits<int64_t>::max()};
+  int16_t new_buffer[] = {0, 0, 0};
+  tt::runtime::utils::handleSignedToSignedIntegerBufferCast(old_buffer,
+                                                            new_buffer, 3);
+
+  // Values should be clamped to the int16_t range, not overflowed
+  EXPECT_EQ(new_buffer[0], std::numeric_limits<int16_t>::min());
+  EXPECT_EQ(new_buffer[1], 0);
+  EXPECT_EQ(new_buffer[2], std::numeric_limits<int16_t>::max());
+}
+
+TEST(HandleI64ToI8BufferCast, Sanity) {
+  int64_t old_buffer[] = {std::numeric_limits<int64_t>::min(), 0,
+                          std::numeric_limits<int64_t>::max()};
+  int8_t new_buffer[] = {0, 0, 0};
+  tt::runtime::utils::handleSignedToSignedIntegerBufferCast(old_buffer,
+                                                            new_buffer, 3);
+
+  // Values should be clamped to the int8_t range, not overflowed
+  EXPECT_EQ(new_buffer[0], std::numeric_limits<int8_t>::min());
+  EXPECT_EQ(new_buffer[1], 0);
+  EXPECT_EQ(new_buffer[2], std::numeric_limits<int8_t>::max());
+}
+
+TEST(HandleI64ToUI64BufferCast, Sanity) {
+  int64_t old_buffer[] = {std::numeric_limits<int64_t>::min(), 0,
+                          std::numeric_limits<int64_t>::max()};
+  uint64_t new_buffer[] = {0, 0, 0};
+  tt::runtime::utils::handleSignedToUnsignedIntegerBufferCast(old_buffer,
+                                                              new_buffer, 3);
+
+  // Values should be clamped to the uint64_t range, not overflowed
+  // uint64_t has a larger max value than int64_t, so the int64_t max value
+  // should remain
+  EXPECT_EQ(new_buffer[0], std::numeric_limits<uint64_t>::min());
+  EXPECT_EQ(new_buffer[1], 0);
+  EXPECT_EQ(new_buffer[2], std::numeric_limits<int64_t>::max());
+}
+
+TEST(HandleI64ToUI32BufferCast, Sanity) {
+  int64_t old_buffer[] = {std::numeric_limits<int64_t>::min(), 0,
+                          std::numeric_limits<int64_t>::max()};
+  uint32_t new_buffer[] = {0, 0, 0};
+  tt::runtime::utils::handleSignedToUnsignedIntegerBufferCast(old_buffer,
+                                                              new_buffer, 3);
+
+  // Values should be clamped to the uint32_t range, not overflowed
+  // uint32_t has a smaller max value than int64_t, so the int64_t max value
+  // should be clamped
+  EXPECT_EQ(new_buffer[0], std::numeric_limits<uint32_t>::min());
+  EXPECT_EQ(new_buffer[1], 0);
+  EXPECT_EQ(new_buffer[2], std::numeric_limits<uint32_t>::max());
+}
+
+TEST(HandleI64ToUI16BufferCast, Sanity) {
+  int64_t old_buffer[] = {std::numeric_limits<int64_t>::min(), 0,
+                          std::numeric_limits<int64_t>::max()};
+  uint16_t new_buffer[] = {0, 0, 0};
+  tt::runtime::utils::handleSignedToUnsignedIntegerBufferCast(old_buffer,
+                                                              new_buffer, 3);
+
+  // Values should be clamped to the uint16_t range, not overflowed
+  // uint16_t has a smaller max value than int64_t, so the int64_t max value
+  // should be clamped
+  EXPECT_EQ(new_buffer[0], std::numeric_limits<uint16_t>::min());
+  EXPECT_EQ(new_buffer[1], 0);
+  EXPECT_EQ(new_buffer[2], std::numeric_limits<uint16_t>::max());
+}
+
+TEST(HandleI64ToUI8BufferCast, Sanity) {
+  int64_t old_buffer[] = {std::numeric_limits<int64_t>::min(), 0,
+                          std::numeric_limits<int64_t>::max()};
+  uint8_t new_buffer[] = {0, 0, 0};
+  tt::runtime::utils::handleSignedToUnsignedIntegerBufferCast(old_buffer,
+                                                              new_buffer, 3);
+
+  // Values should be clamped to the uint8_t range, not overflowed
+  // uint8_t has a smaller max value than int64_t, so the int64_t max value
+  // should be clamped
+  EXPECT_EQ(new_buffer[0], std::numeric_limits<uint8_t>::min());
+  EXPECT_EQ(new_buffer[1], 0);
+  EXPECT_EQ(new_buffer[2], std::numeric_limits<uint8_t>::max());
+}
+
+TEST(HandleI32ToI64BufferCast, Sanity) {
+  int32_t old_buffer[] = {std::numeric_limits<int32_t>::min(), 0,
+                          std::numeric_limits<int32_t>::max()};
+  int64_t new_buffer[] = {0, 0, 0};
+  tt::runtime::utils::handleSignedToSignedIntegerBufferCast(old_buffer,
+                                                            new_buffer, 3);
+
+  // Values should be the same in the int64 buffer as int64 has larger bitwidth
+  EXPECT_EQ(new_buffer[0], std::numeric_limits<int32_t>::min());
+  EXPECT_EQ(new_buffer[1], 0);
+  EXPECT_EQ(new_buffer[2], std::numeric_limits<int32_t>::max());
+}
+
+TEST(HandleI32ToI16BufferCast, Sanity) {
+  int32_t old_buffer[] = {std::numeric_limits<int32_t>::min(), 0,
+                          std::numeric_limits<int32_t>::max()};
+  int16_t new_buffer[] = {0, 0, 0};
+  tt::runtime::utils::handleSignedToSignedIntegerBufferCast(old_buffer,
+                                                            new_buffer, 3);
+
+  // Values should be clamped to the int16_t range, not overflowed
+  // int16_t has a smaller max value than int32_t, so the int32_t max value
+  // should be clamped
+  EXPECT_EQ(new_buffer[0], std::numeric_limits<int16_t>::min());
+  EXPECT_EQ(new_buffer[1], 0);
+  EXPECT_EQ(new_buffer[2], std::numeric_limits<int16_t>::max());
+}
+
+TEST(HandleI32ToI8BufferCast, Sanity) {
+  int32_t old_buffer[] = {std::numeric_limits<int32_t>::min(), 0,
+                          std::numeric_limits<int32_t>::max()};
+  int8_t new_buffer[] = {0, 0, 0};
+  tt::runtime::utils::handleSignedToSignedIntegerBufferCast(old_buffer,
+                                                            new_buffer, 3);
+
+  // Values should be clamped to the int8_t range, not overflowed
+  // int8_t has a smaller max value than int32_t, so the int32_t max value
+  // should be clamped
+  EXPECT_EQ(new_buffer[0], std::numeric_limits<int8_t>::min());
+  EXPECT_EQ(new_buffer[1], 0);
+  EXPECT_EQ(new_buffer[2], std::numeric_limits<int8_t>::max());
+}
+
+TEST(HandleI32ToUI64BufferCast, Sanity) {
+  int32_t old_buffer[] = {std::numeric_limits<int32_t>::min(), 0,
+                          std::numeric_limits<int32_t>::max()};
+  uint64_t new_buffer[] = {0, 0, 0};
+  tt::runtime::utils::handleSignedToUnsignedIntegerBufferCast(old_buffer,
+                                                              new_buffer, 3);
+
+  // Values should be clamped to the uint64_t range, not overflowed
+  // uint64_t has a larger max value than int32_t, so the int32_t max value
+  // should remain
+  EXPECT_EQ(new_buffer[0], std::numeric_limits<uint64_t>::min());
+  EXPECT_EQ(new_buffer[1], 0);
+  EXPECT_EQ(new_buffer[2], std::numeric_limits<int32_t>::max());
+}
+
+TEST(HandleI32ToUI32BufferCast, Sanity) {
+  int32_t old_buffer[] = {std::numeric_limits<int32_t>::min(), 0,
+                          std::numeric_limits<int32_t>::max()};
+  uint32_t new_buffer[] = {0, 0, 0};
+  tt::runtime::utils::handleSignedToUnsignedIntegerBufferCast(old_buffer,
+                                                              new_buffer, 3);
+
+  // Values should be clamped to the uint32_t range, not overflowed
+  // uint32_t has a larger max value than int32_t, so the int32_t max value
+  // should remain
+  EXPECT_EQ(new_buffer[0], std::numeric_limits<uint32_t>::min());
+  EXPECT_EQ(new_buffer[1], 0);
+  EXPECT_EQ(new_buffer[2], std::numeric_limits<int32_t>::max());
+}
+
+TEST(HandleI32ToUI16BufferCast, Sanity) {
+  int32_t old_buffer[] = {std::numeric_limits<int32_t>::min(), 0,
+                          std::numeric_limits<int32_t>::max()};
+  uint16_t new_buffer[] = {0, 0, 0};
+  tt::runtime::utils::handleSignedToUnsignedIntegerBufferCast(old_buffer,
+                                                              new_buffer, 3);
+
+  // Values should be clamped to the uint16_t range, not overflowed
+  // uint16_t has a smaller max value than int32_t, so the int32_t max value
+  // should be clamped
+  EXPECT_EQ(new_buffer[0], std::numeric_limits<uint16_t>::min());
+  EXPECT_EQ(new_buffer[1], 0);
+  EXPECT_EQ(new_buffer[2], std::numeric_limits<uint16_t>::max());
+}
+
+TEST(HandleI32ToUI8BufferCast, Sanity) {
+  int32_t old_buffer[] = {std::numeric_limits<int32_t>::min(), 0,
+                          std::numeric_limits<int32_t>::max()};
+  uint8_t new_buffer[] = {0, 0, 0};
+  tt::runtime::utils::handleSignedToUnsignedIntegerBufferCast(old_buffer,
+                                                              new_buffer, 3);
+
+  // Values should be clamped to the uint8_t range, not overflowed
+  // uint8_t has a smaller max value than int32_t, so the int32_t max value
+  // should be clamped
+  EXPECT_EQ(new_buffer[0], std::numeric_limits<uint8_t>::min());
+  EXPECT_EQ(new_buffer[1], 0);
+  EXPECT_EQ(new_buffer[2], std::numeric_limits<uint8_t>::max());
+}
+
+TEST(HandleI16ToI64BufferCast, Sanity) {
+  int16_t old_buffer[] = {std::numeric_limits<int16_t>::min(), 0,
+                          std::numeric_limits<int16_t>::max()};
+  int64_t new_buffer[] = {0, 0, 0};
+  tt::runtime::utils::handleSignedToSignedIntegerBufferCast(old_buffer,
+                                                            new_buffer, 3);
+
+  // Values should be the same in the int64 buffer as int64 has larger bitwidth
+  EXPECT_EQ(new_buffer[0], std::numeric_limits<int16_t>::min());
+  EXPECT_EQ(new_buffer[1], 0);
+  EXPECT_EQ(new_buffer[2], std::numeric_limits<int16_t>::max());
+}
+
+TEST(HandleI16ToI32BufferCast, Sanity) {
+  int16_t old_buffer[] = {std::numeric_limits<int16_t>::min(), 0,
+                          std::numeric_limits<int16_t>::max()};
+  int32_t new_buffer[] = {0, 0, 0};
+  tt::runtime::utils::handleSignedToSignedIntegerBufferCast(old_buffer,
+                                                            new_buffer, 3);
+
+  // Values should be the same in the int32 buffer as int32 has larger bitwidth
+  EXPECT_EQ(new_buffer[0], std::numeric_limits<int16_t>::min());
+  EXPECT_EQ(new_buffer[1], 0);
+  EXPECT_EQ(new_buffer[2], std::numeric_limits<int16_t>::max());
+}
+
+TEST(HandleI16ToI8BufferCast, Sanity) {
+  int16_t old_buffer[] = {std::numeric_limits<int16_t>::min(), 0,
+                          std::numeric_limits<int16_t>::max()};
+  int8_t new_buffer[] = {0, 0, 0};
+  tt::runtime::utils::handleSignedToSignedIntegerBufferCast(old_buffer,
+                                                            new_buffer, 3);
+
+  // Values should be clamped to the int8_t range, not overflowed
+  // int8_t has a smaller max value than int16_t, so the int16_t max value
+  // should be clamped
+  EXPECT_EQ(new_buffer[0], std::numeric_limits<int8_t>::min());
+  EXPECT_EQ(new_buffer[1], 0);
+  EXPECT_EQ(new_buffer[2], std::numeric_limits<int8_t>::max());
+}
+
+TEST(HandleI16ToUI64BufferCast, Sanity) {
+  int16_t old_buffer[] = {std::numeric_limits<int16_t>::min(), 0,
+                          std::numeric_limits<int16_t>::max()};
+  uint64_t new_buffer[] = {0, 0, 0};
+  tt::runtime::utils::handleSignedToUnsignedIntegerBufferCast(old_buffer,
+                                                              new_buffer, 3);
+
+  // Values should be clamped to the uint64_t range, not overflowed
+  // uint64_t has a larger max value than int16_t, so the int16_t max value
+  // should remain
+  EXPECT_EQ(new_buffer[0], std::numeric_limits<uint64_t>::min());
+  EXPECT_EQ(new_buffer[1], 0);
+  EXPECT_EQ(new_buffer[2], std::numeric_limits<int16_t>::max());
+}
+
+TEST(HandleI16ToUI32BufferCast, Sanity) {
+  int16_t old_buffer[] = {std::numeric_limits<int16_t>::min(), 0,
+                          std::numeric_limits<int16_t>::max()};
+  uint32_t new_buffer[] = {0, 0, 0};
+  tt::runtime::utils::handleSignedToUnsignedIntegerBufferCast(old_buffer,
+                                                              new_buffer, 3);
+
+  // Values should be clamped to the uint32_t range, not overflowed
+  // uint32_t has a larger max value than int16_t, so the int16_t max value
+  // should remain
+  EXPECT_EQ(new_buffer[0], std::numeric_limits<uint32_t>::min());
+  EXPECT_EQ(new_buffer[1], 0);
+  EXPECT_EQ(new_buffer[2], std::numeric_limits<int16_t>::max());
+}
+
+TEST(HandleI16ToUI8BufferCast, Sanity) {
+  int16_t old_buffer[] = {std::numeric_limits<int16_t>::min(), 0,
+                          std::numeric_limits<int16_t>::max()};
+  uint8_t new_buffer[] = {0, 0, 0};
+  tt::runtime::utils::handleSignedToUnsignedIntegerBufferCast(old_buffer,
+                                                              new_buffer, 3);
+
+  // Values should be clamped to the uint8_t range, not overflowed
+  // uint8_t has a smaller max value than int16_t, so the int16_t max value
+  // should be clamped
+  EXPECT_EQ(new_buffer[0], std::numeric_limits<uint8_t>::min());
+  EXPECT_EQ(new_buffer[1], 0);
+  EXPECT_EQ(new_buffer[2], std::numeric_limits<uint8_t>::max());
+}
+
+TEST(HandleI8ToI64BufferCast, Sanity) {
+  int8_t old_buffer[] = {std::numeric_limits<int8_t>::min(), 0,
+                         std::numeric_limits<int8_t>::max()};
+  int64_t new_buffer[] = {0, 0, 0};
+  tt::runtime::utils::handleSignedToSignedIntegerBufferCast(old_buffer,
+                                                            new_buffer, 3);
+
+  // Values should be the same in the int64 buffer as int64 has larger bitwidth
+  EXPECT_EQ(new_buffer[0], std::numeric_limits<int8_t>::min());
+  EXPECT_EQ(new_buffer[1], 0);
+  EXPECT_EQ(new_buffer[2], std::numeric_limits<int8_t>::max());
+}
+
+TEST(HandleI8ToI32BufferCast, Sanity) {
+  int8_t old_buffer[] = {std::numeric_limits<int8_t>::min(), 0,
+                         std::numeric_limits<int8_t>::max()};
+  int32_t new_buffer[] = {0, 0, 0};
+  tt::runtime::utils::handleSignedToSignedIntegerBufferCast(old_buffer,
+                                                            new_buffer, 3);
+
+  // Values should be the same in the int32 buffer as int32 has larger bitwidth
+  EXPECT_EQ(new_buffer[0], std::numeric_limits<int8_t>::min());
+  EXPECT_EQ(new_buffer[1], 0);
+  EXPECT_EQ(new_buffer[2], std::numeric_limits<int8_t>::max());
+}
+
+TEST(HandleI8ToI16BufferCast, Sanity) {
+  int8_t old_buffer[] = {std::numeric_limits<int8_t>::min(), 0,
+                         std::numeric_limits<int8_t>::max()};
+  int16_t new_buffer[] = {0, 0, 0};
+  tt::runtime::utils::handleSignedToSignedIntegerBufferCast(old_buffer,
+                                                            new_buffer, 3);
+
+  // Values should be the same in the int16 buffer as int16 has larger bitwidth
+  EXPECT_EQ(new_buffer[0], std::numeric_limits<int8_t>::min());
+  EXPECT_EQ(new_buffer[1], 0);
+  EXPECT_EQ(new_buffer[2], std::numeric_limits<int8_t>::max());
+}
+
+TEST(HandleI8ToUI64BufferCast, Sanity) {
+  int8_t old_buffer[] = {std::numeric_limits<int8_t>::min(), 0,
+                         std::numeric_limits<int8_t>::max()};
+  uint64_t new_buffer[] = {0, 0, 0};
+  tt::runtime::utils::handleSignedToUnsignedIntegerBufferCast(old_buffer,
+                                                              new_buffer, 3);
+
+  // Values should be clamped to the uint64_t range, not overflowed
+  // uint64_t has a larger max value than int8_t, so the int8_t max value should
+  // remain
+  EXPECT_EQ(new_buffer[0], std::numeric_limits<uint64_t>::min());
+  EXPECT_EQ(new_buffer[1], 0);
+  EXPECT_EQ(new_buffer[2], std::numeric_limits<int8_t>::max());
+}
+
+TEST(HandleI8ToUI32BufferCast, Sanity) {
+  int8_t old_buffer[] = {std::numeric_limits<int8_t>::min(), 0,
+                         std::numeric_limits<int8_t>::max()};
+  uint32_t new_buffer[] = {0, 0, 0};
+  tt::runtime::utils::handleSignedToUnsignedIntegerBufferCast(old_buffer,
+                                                              new_buffer, 3);
+
+  // Values should be clamped to the uint32_t range, not overflowed
+  // uint32_t has a smaller max value than int8_t, so the int8_t max value
+  // should be clamped
+  EXPECT_EQ(new_buffer[0], std::numeric_limits<uint32_t>::min());
+  EXPECT_EQ(new_buffer[1], 0);
+  EXPECT_EQ(new_buffer[2], std::numeric_limits<int8_t>::max());
+}
+
+TEST(HandleI8ToUI16BufferCast, Sanity) {
+  int8_t old_buffer[] = {std::numeric_limits<int8_t>::min(), 0,
+                         std::numeric_limits<int8_t>::max()};
+  uint16_t new_buffer[] = {0, 0, 0};
+  tt::runtime::utils::handleSignedToUnsignedIntegerBufferCast(old_buffer,
+                                                              new_buffer, 3);
+
+  // Values should be clamped to the uint16_t range, not overflowed
+  // uint16_t has a smaller max value than int8_t, so the int8_t max value
+  // should be clamped
+  EXPECT_EQ(new_buffer[0], std::numeric_limits<uint16_t>::min());
+  EXPECT_EQ(new_buffer[1], 0);
+  EXPECT_EQ(new_buffer[2], std::numeric_limits<int8_t>::max());
+}

--- a/runtime/test/common/test_handle_integer_buffer_cast.cpp
+++ b/runtime/test/common/test_handle_integer_buffer_cast.cpp
@@ -9,8 +9,8 @@ TEST(HandleI64ToI32BufferCast, Sanity) {
   int64_t old_buffer[] = {std::numeric_limits<int64_t>::min(), 0,
                           std::numeric_limits<int64_t>::max()};
   int32_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleEquallySignedIntegerBufferCast(old_buffer,
-                                                           new_buffer, 3);
+  tt::runtime::utils::detail::handleIntegerBufferCast(old_buffer, new_buffer,
+                                                      3);
 
   // Values should be clamped to the int32_t range, not overflowed
   EXPECT_EQ(new_buffer[0], std::numeric_limits<int32_t>::min());
@@ -22,8 +22,8 @@ TEST(HandleI64ToI16BufferCast, Sanity) {
   int64_t old_buffer[] = {std::numeric_limits<int64_t>::min(), 0,
                           std::numeric_limits<int64_t>::max()};
   int16_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleEquallySignedIntegerBufferCast(old_buffer,
-                                                           new_buffer, 3);
+  tt::runtime::utils::detail::handleIntegerBufferCast(old_buffer, new_buffer,
+                                                      3);
 
   // Values should be clamped to the int16_t range, not overflowed
   EXPECT_EQ(new_buffer[0], std::numeric_limits<int16_t>::min());
@@ -35,8 +35,8 @@ TEST(HandleI64ToI8BufferCast, Sanity) {
   int64_t old_buffer[] = {std::numeric_limits<int64_t>::min(), 0,
                           std::numeric_limits<int64_t>::max()};
   int8_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleEquallySignedIntegerBufferCast(old_buffer,
-                                                           new_buffer, 3);
+  tt::runtime::utils::detail::handleIntegerBufferCast(old_buffer, new_buffer,
+                                                      3);
 
   // Values should be clamped to the int8_t range, not overflowed
   EXPECT_EQ(new_buffer[0], std::numeric_limits<int8_t>::min());
@@ -48,8 +48,8 @@ TEST(HandleI64ToUI64BufferCast, Sanity) {
   int64_t old_buffer[] = {std::numeric_limits<int64_t>::min(), 0,
                           std::numeric_limits<int64_t>::max()};
   uint64_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleSignedToUnsignedIntegerBufferCast(old_buffer,
-                                                              new_buffer, 3);
+  tt::runtime::utils::detail::handleIntegerBufferCast(old_buffer, new_buffer,
+                                                      3);
 
   // Values should be clamped to the uint64_t range, not overflowed
   // uint64_t has a larger max value than int64_t, so the int64_t max value
@@ -63,8 +63,8 @@ TEST(HandleI64ToUI32BufferCast, Sanity) {
   int64_t old_buffer[] = {std::numeric_limits<int64_t>::min(), 0,
                           std::numeric_limits<int64_t>::max()};
   uint32_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleSignedToUnsignedIntegerBufferCast(old_buffer,
-                                                              new_buffer, 3);
+  tt::runtime::utils::detail::handleIntegerBufferCast(old_buffer, new_buffer,
+                                                      3);
 
   // Values should be clamped to the uint32_t range, not overflowed
   // uint32_t has a smaller max value than int64_t, so the int64_t max value
@@ -78,8 +78,8 @@ TEST(HandleI64ToUI16BufferCast, Sanity) {
   int64_t old_buffer[] = {std::numeric_limits<int64_t>::min(), 0,
                           std::numeric_limits<int64_t>::max()};
   uint16_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleSignedToUnsignedIntegerBufferCast(old_buffer,
-                                                              new_buffer, 3);
+  tt::runtime::utils::detail::handleIntegerBufferCast(old_buffer, new_buffer,
+                                                      3);
 
   // Values should be clamped to the uint16_t range, not overflowed
   // uint16_t has a smaller max value than int64_t, so the int64_t max value
@@ -93,8 +93,8 @@ TEST(HandleI64ToUI8BufferCast, Sanity) {
   int64_t old_buffer[] = {std::numeric_limits<int64_t>::min(), 0,
                           std::numeric_limits<int64_t>::max()};
   uint8_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleSignedToUnsignedIntegerBufferCast(old_buffer,
-                                                              new_buffer, 3);
+  tt::runtime::utils::detail::handleIntegerBufferCast(old_buffer, new_buffer,
+                                                      3);
 
   // Values should be clamped to the uint8_t range, not overflowed
   // uint8_t has a smaller max value than int64_t, so the int64_t max value
@@ -108,8 +108,8 @@ TEST(HandleI32ToI64BufferCast, Sanity) {
   int32_t old_buffer[] = {std::numeric_limits<int32_t>::min(), 0,
                           std::numeric_limits<int32_t>::max()};
   int64_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleEquallySignedIntegerBufferCast(old_buffer,
-                                                           new_buffer, 3);
+  tt::runtime::utils::detail::handleIntegerBufferCast(old_buffer, new_buffer,
+                                                      3);
 
   // Values should be the same in the int64 buffer as int64 has larger bitwidth
   EXPECT_EQ(new_buffer[0], std::numeric_limits<int32_t>::min());
@@ -121,8 +121,8 @@ TEST(HandleI32ToI16BufferCast, Sanity) {
   int32_t old_buffer[] = {std::numeric_limits<int32_t>::min(), 0,
                           std::numeric_limits<int32_t>::max()};
   int16_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleEquallySignedIntegerBufferCast(old_buffer,
-                                                           new_buffer, 3);
+  tt::runtime::utils::detail::handleIntegerBufferCast(old_buffer, new_buffer,
+                                                      3);
 
   // Values should be clamped to the int16_t range, not overflowed
   // int16_t has a smaller max value than int32_t, so the int32_t max value
@@ -136,8 +136,8 @@ TEST(HandleI32ToI8BufferCast, Sanity) {
   int32_t old_buffer[] = {std::numeric_limits<int32_t>::min(), 0,
                           std::numeric_limits<int32_t>::max()};
   int8_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleEquallySignedIntegerBufferCast(old_buffer,
-                                                           new_buffer, 3);
+  tt::runtime::utils::detail::handleIntegerBufferCast(old_buffer, new_buffer,
+                                                      3);
 
   // Values should be clamped to the int8_t range, not overflowed
   // int8_t has a smaller max value than int32_t, so the int32_t max value
@@ -151,8 +151,8 @@ TEST(HandleI32ToUI64BufferCast, Sanity) {
   int32_t old_buffer[] = {std::numeric_limits<int32_t>::min(), 0,
                           std::numeric_limits<int32_t>::max()};
   uint64_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleSignedToUnsignedIntegerBufferCast(old_buffer,
-                                                              new_buffer, 3);
+  tt::runtime::utils::detail::handleIntegerBufferCast(old_buffer, new_buffer,
+                                                      3);
 
   // Values should be clamped to the uint64_t range, not overflowed
   // uint64_t has a larger max value than int32_t, so the int32_t max value
@@ -166,8 +166,8 @@ TEST(HandleI32ToUI32BufferCast, Sanity) {
   int32_t old_buffer[] = {std::numeric_limits<int32_t>::min(), 0,
                           std::numeric_limits<int32_t>::max()};
   uint32_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleSignedToUnsignedIntegerBufferCast(old_buffer,
-                                                              new_buffer, 3);
+  tt::runtime::utils::detail::handleIntegerBufferCast(old_buffer, new_buffer,
+                                                      3);
 
   // Values should be clamped to the uint32_t range, not overflowed
   // uint32_t has a larger max value than int32_t, so the int32_t max value
@@ -181,8 +181,8 @@ TEST(HandleI32ToUI16BufferCast, Sanity) {
   int32_t old_buffer[] = {std::numeric_limits<int32_t>::min(), 0,
                           std::numeric_limits<int32_t>::max()};
   uint16_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleSignedToUnsignedIntegerBufferCast(old_buffer,
-                                                              new_buffer, 3);
+  tt::runtime::utils::detail::handleIntegerBufferCast(old_buffer, new_buffer,
+                                                      3);
 
   // Values should be clamped to the uint16_t range, not overflowed
   // uint16_t has a smaller max value than int32_t, so the int32_t max value
@@ -196,8 +196,8 @@ TEST(HandleI32ToUI8BufferCast, Sanity) {
   int32_t old_buffer[] = {std::numeric_limits<int32_t>::min(), 0,
                           std::numeric_limits<int32_t>::max()};
   uint8_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleSignedToUnsignedIntegerBufferCast(old_buffer,
-                                                              new_buffer, 3);
+  tt::runtime::utils::detail::handleIntegerBufferCast(old_buffer, new_buffer,
+                                                      3);
 
   // Values should be clamped to the uint8_t range, not overflowed
   // uint8_t has a smaller max value than int32_t, so the int32_t max value
@@ -211,8 +211,8 @@ TEST(HandleI16ToI64BufferCast, Sanity) {
   int16_t old_buffer[] = {std::numeric_limits<int16_t>::min(), 0,
                           std::numeric_limits<int16_t>::max()};
   int64_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleEquallySignedIntegerBufferCast(old_buffer,
-                                                           new_buffer, 3);
+  tt::runtime::utils::detail::handleIntegerBufferCast(old_buffer, new_buffer,
+                                                      3);
 
   // Values should be the same in the int64 buffer as int64 has larger bitwidth
   EXPECT_EQ(new_buffer[0], std::numeric_limits<int16_t>::min());
@@ -224,8 +224,8 @@ TEST(HandleI16ToI32BufferCast, Sanity) {
   int16_t old_buffer[] = {std::numeric_limits<int16_t>::min(), 0,
                           std::numeric_limits<int16_t>::max()};
   int32_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleEquallySignedIntegerBufferCast(old_buffer,
-                                                           new_buffer, 3);
+  tt::runtime::utils::detail::handleIntegerBufferCast(old_buffer, new_buffer,
+                                                      3);
 
   // Values should be the same in the int32 buffer as int32 has larger bitwidth
   EXPECT_EQ(new_buffer[0], std::numeric_limits<int16_t>::min());
@@ -237,8 +237,8 @@ TEST(HandleI16ToI8BufferCast, Sanity) {
   int16_t old_buffer[] = {std::numeric_limits<int16_t>::min(), 0,
                           std::numeric_limits<int16_t>::max()};
   int8_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleEquallySignedIntegerBufferCast(old_buffer,
-                                                           new_buffer, 3);
+  tt::runtime::utils::detail::handleIntegerBufferCast(old_buffer, new_buffer,
+                                                      3);
 
   // Values should be clamped to the int8_t range, not overflowed
   // int8_t has a smaller max value than int16_t, so the int16_t max value
@@ -252,8 +252,8 @@ TEST(HandleI16ToUI64BufferCast, Sanity) {
   int16_t old_buffer[] = {std::numeric_limits<int16_t>::min(), 0,
                           std::numeric_limits<int16_t>::max()};
   uint64_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleSignedToUnsignedIntegerBufferCast(old_buffer,
-                                                              new_buffer, 3);
+  tt::runtime::utils::detail::handleIntegerBufferCast(old_buffer, new_buffer,
+                                                      3);
 
   // Values should be clamped to the uint64_t range, not overflowed
   // uint64_t has a larger max value than int16_t, so the int16_t max value
@@ -267,8 +267,8 @@ TEST(HandleI16ToUI32BufferCast, Sanity) {
   int16_t old_buffer[] = {std::numeric_limits<int16_t>::min(), 0,
                           std::numeric_limits<int16_t>::max()};
   uint32_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleSignedToUnsignedIntegerBufferCast(old_buffer,
-                                                              new_buffer, 3);
+  tt::runtime::utils::detail::handleIntegerBufferCast(old_buffer, new_buffer,
+                                                      3);
 
   // Values should be clamped to the uint32_t range, not overflowed
   // uint32_t has a larger max value than int16_t, so the int16_t max value
@@ -282,8 +282,8 @@ TEST(HandleI16ToUI8BufferCast, Sanity) {
   int16_t old_buffer[] = {std::numeric_limits<int16_t>::min(), 0,
                           std::numeric_limits<int16_t>::max()};
   uint8_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleSignedToUnsignedIntegerBufferCast(old_buffer,
-                                                              new_buffer, 3);
+  tt::runtime::utils::detail::handleIntegerBufferCast(old_buffer, new_buffer,
+                                                      3);
 
   // Values should be clamped to the uint8_t range, not overflowed
   // uint8_t has a smaller max value than int16_t, so the int16_t max value
@@ -297,8 +297,8 @@ TEST(HandleI8ToI64BufferCast, Sanity) {
   int8_t old_buffer[] = {std::numeric_limits<int8_t>::min(), 0,
                          std::numeric_limits<int8_t>::max()};
   int64_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleEquallySignedIntegerBufferCast(old_buffer,
-                                                           new_buffer, 3);
+  tt::runtime::utils::detail::handleIntegerBufferCast(old_buffer, new_buffer,
+                                                      3);
 
   // Values should be the same in the int64 buffer as int64 has larger bitwidth
   EXPECT_EQ(new_buffer[0], std::numeric_limits<int8_t>::min());
@@ -310,8 +310,8 @@ TEST(HandleI8ToI32BufferCast, Sanity) {
   int8_t old_buffer[] = {std::numeric_limits<int8_t>::min(), 0,
                          std::numeric_limits<int8_t>::max()};
   int32_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleEquallySignedIntegerBufferCast(old_buffer,
-                                                           new_buffer, 3);
+  tt::runtime::utils::detail::handleIntegerBufferCast(old_buffer, new_buffer,
+                                                      3);
 
   // Values should be the same in the int32 buffer as int32 has larger bitwidth
   EXPECT_EQ(new_buffer[0], std::numeric_limits<int8_t>::min());
@@ -323,8 +323,8 @@ TEST(HandleI8ToI16BufferCast, Sanity) {
   int8_t old_buffer[] = {std::numeric_limits<int8_t>::min(), 0,
                          std::numeric_limits<int8_t>::max()};
   int16_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleEquallySignedIntegerBufferCast(old_buffer,
-                                                           new_buffer, 3);
+  tt::runtime::utils::detail::handleIntegerBufferCast(old_buffer, new_buffer,
+                                                      3);
 
   // Values should be the same in the int16 buffer as int16 has larger bitwidth
   EXPECT_EQ(new_buffer[0], std::numeric_limits<int8_t>::min());
@@ -336,8 +336,8 @@ TEST(HandleI8ToUI64BufferCast, Sanity) {
   int8_t old_buffer[] = {std::numeric_limits<int8_t>::min(), 0,
                          std::numeric_limits<int8_t>::max()};
   uint64_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleSignedToUnsignedIntegerBufferCast(old_buffer,
-                                                              new_buffer, 3);
+  tt::runtime::utils::detail::handleIntegerBufferCast(old_buffer, new_buffer,
+                                                      3);
 
   // Values should be clamped to the uint64_t range, not overflowed
   // uint64_t has a larger max value than int8_t, so the int8_t max value should
@@ -351,8 +351,8 @@ TEST(HandleI8ToUI32BufferCast, Sanity) {
   int8_t old_buffer[] = {std::numeric_limits<int8_t>::min(), 0,
                          std::numeric_limits<int8_t>::max()};
   uint32_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleSignedToUnsignedIntegerBufferCast(old_buffer,
-                                                              new_buffer, 3);
+  tt::runtime::utils::detail::handleIntegerBufferCast(old_buffer, new_buffer,
+                                                      3);
 
   // Values should be clamped to the uint32_t range, not overflowed
   // uint32_t has a smaller max value than int8_t, so the int8_t max value
@@ -366,8 +366,8 @@ TEST(HandleI8ToUI16BufferCast, Sanity) {
   int8_t old_buffer[] = {std::numeric_limits<int8_t>::min(), 0,
                          std::numeric_limits<int8_t>::max()};
   uint16_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleSignedToUnsignedIntegerBufferCast(old_buffer,
-                                                              new_buffer, 3);
+  tt::runtime::utils::detail::handleIntegerBufferCast(old_buffer, new_buffer,
+                                                      3);
 
   // Values should be clamped to the uint16_t range, not overflowed
   // uint16_t has a smaller max value than int8_t, so the int8_t max value

--- a/runtime/test/common/test_handle_integer_buffer_cast.cpp
+++ b/runtime/test/common/test_handle_integer_buffer_cast.cpp
@@ -9,8 +9,8 @@ TEST(HandleI64ToI32BufferCast, Sanity) {
   int64_t old_buffer[] = {std::numeric_limits<int64_t>::min(), 0,
                           std::numeric_limits<int64_t>::max()};
   int32_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleSignedToSignedIntegerBufferCast(old_buffer,
-                                                            new_buffer, 3);
+  tt::runtime::utils::handleEquallySignedIntegerBufferCast(old_buffer,
+                                                           new_buffer, 3);
 
   // Values should be clamped to the int32_t range, not overflowed
   EXPECT_EQ(new_buffer[0], std::numeric_limits<int32_t>::min());
@@ -22,8 +22,8 @@ TEST(HandleI64ToI16BufferCast, Sanity) {
   int64_t old_buffer[] = {std::numeric_limits<int64_t>::min(), 0,
                           std::numeric_limits<int64_t>::max()};
   int16_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleSignedToSignedIntegerBufferCast(old_buffer,
-                                                            new_buffer, 3);
+  tt::runtime::utils::handleEquallySignedIntegerBufferCast(old_buffer,
+                                                           new_buffer, 3);
 
   // Values should be clamped to the int16_t range, not overflowed
   EXPECT_EQ(new_buffer[0], std::numeric_limits<int16_t>::min());
@@ -35,8 +35,8 @@ TEST(HandleI64ToI8BufferCast, Sanity) {
   int64_t old_buffer[] = {std::numeric_limits<int64_t>::min(), 0,
                           std::numeric_limits<int64_t>::max()};
   int8_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleSignedToSignedIntegerBufferCast(old_buffer,
-                                                            new_buffer, 3);
+  tt::runtime::utils::handleEquallySignedIntegerBufferCast(old_buffer,
+                                                           new_buffer, 3);
 
   // Values should be clamped to the int8_t range, not overflowed
   EXPECT_EQ(new_buffer[0], std::numeric_limits<int8_t>::min());
@@ -108,8 +108,8 @@ TEST(HandleI32ToI64BufferCast, Sanity) {
   int32_t old_buffer[] = {std::numeric_limits<int32_t>::min(), 0,
                           std::numeric_limits<int32_t>::max()};
   int64_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleSignedToSignedIntegerBufferCast(old_buffer,
-                                                            new_buffer, 3);
+  tt::runtime::utils::handleEquallySignedIntegerBufferCast(old_buffer,
+                                                           new_buffer, 3);
 
   // Values should be the same in the int64 buffer as int64 has larger bitwidth
   EXPECT_EQ(new_buffer[0], std::numeric_limits<int32_t>::min());
@@ -121,8 +121,8 @@ TEST(HandleI32ToI16BufferCast, Sanity) {
   int32_t old_buffer[] = {std::numeric_limits<int32_t>::min(), 0,
                           std::numeric_limits<int32_t>::max()};
   int16_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleSignedToSignedIntegerBufferCast(old_buffer,
-                                                            new_buffer, 3);
+  tt::runtime::utils::handleEquallySignedIntegerBufferCast(old_buffer,
+                                                           new_buffer, 3);
 
   // Values should be clamped to the int16_t range, not overflowed
   // int16_t has a smaller max value than int32_t, so the int32_t max value
@@ -136,8 +136,8 @@ TEST(HandleI32ToI8BufferCast, Sanity) {
   int32_t old_buffer[] = {std::numeric_limits<int32_t>::min(), 0,
                           std::numeric_limits<int32_t>::max()};
   int8_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleSignedToSignedIntegerBufferCast(old_buffer,
-                                                            new_buffer, 3);
+  tt::runtime::utils::handleEquallySignedIntegerBufferCast(old_buffer,
+                                                           new_buffer, 3);
 
   // Values should be clamped to the int8_t range, not overflowed
   // int8_t has a smaller max value than int32_t, so the int32_t max value
@@ -211,8 +211,8 @@ TEST(HandleI16ToI64BufferCast, Sanity) {
   int16_t old_buffer[] = {std::numeric_limits<int16_t>::min(), 0,
                           std::numeric_limits<int16_t>::max()};
   int64_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleSignedToSignedIntegerBufferCast(old_buffer,
-                                                            new_buffer, 3);
+  tt::runtime::utils::handleEquallySignedIntegerBufferCast(old_buffer,
+                                                           new_buffer, 3);
 
   // Values should be the same in the int64 buffer as int64 has larger bitwidth
   EXPECT_EQ(new_buffer[0], std::numeric_limits<int16_t>::min());
@@ -224,8 +224,8 @@ TEST(HandleI16ToI32BufferCast, Sanity) {
   int16_t old_buffer[] = {std::numeric_limits<int16_t>::min(), 0,
                           std::numeric_limits<int16_t>::max()};
   int32_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleSignedToSignedIntegerBufferCast(old_buffer,
-                                                            new_buffer, 3);
+  tt::runtime::utils::handleEquallySignedIntegerBufferCast(old_buffer,
+                                                           new_buffer, 3);
 
   // Values should be the same in the int32 buffer as int32 has larger bitwidth
   EXPECT_EQ(new_buffer[0], std::numeric_limits<int16_t>::min());
@@ -237,8 +237,8 @@ TEST(HandleI16ToI8BufferCast, Sanity) {
   int16_t old_buffer[] = {std::numeric_limits<int16_t>::min(), 0,
                           std::numeric_limits<int16_t>::max()};
   int8_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleSignedToSignedIntegerBufferCast(old_buffer,
-                                                            new_buffer, 3);
+  tt::runtime::utils::handleEquallySignedIntegerBufferCast(old_buffer,
+                                                           new_buffer, 3);
 
   // Values should be clamped to the int8_t range, not overflowed
   // int8_t has a smaller max value than int16_t, so the int16_t max value
@@ -297,8 +297,8 @@ TEST(HandleI8ToI64BufferCast, Sanity) {
   int8_t old_buffer[] = {std::numeric_limits<int8_t>::min(), 0,
                          std::numeric_limits<int8_t>::max()};
   int64_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleSignedToSignedIntegerBufferCast(old_buffer,
-                                                            new_buffer, 3);
+  tt::runtime::utils::handleEquallySignedIntegerBufferCast(old_buffer,
+                                                           new_buffer, 3);
 
   // Values should be the same in the int64 buffer as int64 has larger bitwidth
   EXPECT_EQ(new_buffer[0], std::numeric_limits<int8_t>::min());
@@ -310,8 +310,8 @@ TEST(HandleI8ToI32BufferCast, Sanity) {
   int8_t old_buffer[] = {std::numeric_limits<int8_t>::min(), 0,
                          std::numeric_limits<int8_t>::max()};
   int32_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleSignedToSignedIntegerBufferCast(old_buffer,
-                                                            new_buffer, 3);
+  tt::runtime::utils::handleEquallySignedIntegerBufferCast(old_buffer,
+                                                           new_buffer, 3);
 
   // Values should be the same in the int32 buffer as int32 has larger bitwidth
   EXPECT_EQ(new_buffer[0], std::numeric_limits<int8_t>::min());
@@ -323,8 +323,8 @@ TEST(HandleI8ToI16BufferCast, Sanity) {
   int8_t old_buffer[] = {std::numeric_limits<int8_t>::min(), 0,
                          std::numeric_limits<int8_t>::max()};
   int16_t new_buffer[] = {0, 0, 0};
-  tt::runtime::utils::handleSignedToSignedIntegerBufferCast(old_buffer,
-                                                            new_buffer, 3);
+  tt::runtime::utils::handleEquallySignedIntegerBufferCast(old_buffer,
+                                                           new_buffer, 3);
 
   // Values should be the same in the int16 buffer as int16 has larger bitwidth
   EXPECT_EQ(new_buffer[0], std::numeric_limits<int8_t>::min());

--- a/runtime/tools/ttrt/ttrt/common/util.py
+++ b/runtime/tools/ttrt/ttrt/common/util.py
@@ -851,7 +851,20 @@ class Binary(Flatbuffer):
                 return ttrt.runtime.DataType.UInt8
             if dtype == torch.int32:
                 return ttrt.runtime.DataType.Int32
-            raise ValueError(f"unsupported dtype: {dtype}")
+            # Data types which are unsupported on ttnn
+            if dtype == torch.float64:
+                return ttrt.runtime.DataType.Float64
+            if dtype == torch.int64:
+                return ttrt.runtime.DataType.Int64
+            if dtype == torch.uint64:
+                return ttrt.runtime.DataType.UInt64
+            if dtype == torch.int16:
+                return ttrt.runtime.DataType.Int16
+            if dtype == torch.int8:
+                return ttrt.runtime.DataType.Int8
+            if dtype == torch.bool:
+                return ttrt.runtime.DataType.Bool
+            raise ValueError(f"Torch dtype: {dtype} has no runtime DataType equivalent")
 
         @staticmethod
         def from_data_type(dtype):
@@ -871,6 +884,20 @@ class Binary(Flatbuffer):
                 return torch.uint8
             if dtype == "Int32":
                 return torch.int32
+            # Data types which are unsupported on ttnn
+            if dtype == "Float64":
+                return torch.float64
+            if dtype == "Int64":
+                return torch.int64
+            if dtype == "UInt64":
+                return torch.uint64
+            if dtype == "Int16":
+                return torch.int16
+            if dtype == "Int8":
+                return torch.int8
+            if dtype == "Bool":
+                return torch.bool
+
             raise ValueError(f"unsupported dtype: {dtype}")
 
 


### PR DESCRIPTION
Added an `enum` to represent data types that are unsupported.
- int64
- uint64
- float64
- int16
- int8
- bool

Added utility function which returns the data type we should cast to.
- `getUnsupportedDataTypeAlias`
- This is based off of `toTTMLIRSupportedDataType` which is used in the `ElementTypeNormalization` pass.

Added runtime api for creating tensor from a buffer that includes data in an unsupported data type.
- `createOwnedHostTensorFromUnsupportedDataType`
- This will assume that the host buffer containing the data holds an unsupported data type and will cast all values inside to a supported data type (determined by `getUnsupportedDataTypeAlias`) and print a warning to the user that this is happening.
- I cannot create a version of this function which creates a borrowed tensor as we cannot borrow a buffer containing an unsupported data type without changing the values within the host buffer itself - which the host assumes will not happen.

Added runtime api for copying a runtime tensor's values into a host buffer but with an unsupported data format
- `copyIntoDestWithUnsupportedDataType` 
- This will cast each value in the runtime tensor to that which is described by the `unsupportedDataType` param and copy the casted values into the host buffer

**Why are we doing this?**

Until now we could simply ask the user to cast all model parameters/constants to a supported data type. I am working on enabling a flow which uses `torch-xla` to compile PyTorch models. `torch-xla` will push python scalars to the device as `float64` or `int64` depending on if it is an integer or float. If such values are used in a model then PJRT will be asked to push this value to device as a 64-bit value, I have found no way to stop this. This will happen even if the python scalar is an op attribute (i.e `torch.arange` max and min values). 

I am adding the functionality to create runtime tensors like this to tt-mlir rather than tt-xla so other frontends may use it. For now, the responsibility of keeping track of what the host expects the data type to be for a given tensor will fall on the frontends (unless we decide to implement that in tt-mlir now).
