### PR TITLE
Removed lld from pykernel build process

### DIFF
--- a/tools/pykernel/setup.py
+++ b/tools/pykernel/setup.py
@@ -70,17 +70,8 @@ class CMakeBuild(build_ext):
             "-DTTMLIR_ENABLE_EXPLORER=OFF",
         ]
 
-        # Use LLD if in cibuildwheel
-        if self.in_ci():
-            cmake_args.extend(
-                [
-                    f"-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld",
-                    f"-DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld",
-                    f"-DCMAKE_MODULE_LINKER_FLAGS=-fuse-ld=lld",
-                ]
-            )
-        # Otherwise, force the source to be set
-        else:
+        # Set source
+        if not self.in_ci():
             cmake_args.extend(["-S", str(cwd.parent)])
 
         # Run source env/activate if in ci, otherwise onus is on dev


### PR DESCRIPTION
### Problem description
- `lld` still used for `pykernel` build, not working in `cibuildwheel`.
- Replaced with `ld`.
