### PR TITLE
[Optimizer] Enable getOpConstraint Queries with Partially Specified MemoryConfigs

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
@@ -615,7 +615,6 @@ def TTNN_TTNNLayoutAttr: TTNN_Attr<"TTNNLayout", "ttnn_layout"> {
     bool isSystemBufferType() const { return ::mlir::tt::ttnn::isSystemBufferType(getBufferType()); }
     bool isDeviceBufferType() const { return ::mlir::tt::ttnn::isDeviceBufferType(getBufferType()); }
     bool isMeshDeviceTensor() const { return ::mlir::tt::ttnn::isMeshDeviceTensor(getTensorMeshSharding()); }
-    bool isPartialLayout() const { return getIgnorePhysicalLayout(); }
     bool isTiled() const;
     bool hasShardedTensorMemoryLayout() const;
     bool hasShardedL1TensorMemoryLayout() const;

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
@@ -581,7 +581,7 @@ def TTNN_TTNNLayoutAttr: TTNN_Attr<"TTNNLayout", "ttnn_layout"> {
                         AttrParameter<"MemRefType", "A memref that describes the physical footprint allocation of the shard. It must also have a shape with rank equal to grid.">:$memref,
                         OptionalParameter<"TensorMemoryLayoutAttr", "TTNN tensor memory layout">:$mem_layout,
                         OptionalParameter<"TensorMeshShardingAttr", "TT mesh sharding attr">:$tensor_mesh_sharding,
-                        OptionalParameter<"bool", "A status flag, asking the callers to ignore the physical layout. This is used to model a sharded layout with unspecified shard shape.">:$ignorePhysicalLayout);
+                        OptionalParameter<"bool", "A status flag, asking the users to ignore the physical layout. This is used to model a sharded layout with unspecified shard shape.">:$ignorePhysicalLayout);
   let assemblyFormat = "`<` $linear`,` $grid`,` (`mesh` `=` $tensor_mesh_sharding^ `,`)? $memref (`,` $mem_layout^)? (`,` $ignorePhysicalLayout^)? `>`";
   let extraClassDeclaration = [{
     static TTNNLayoutAttr get(::mlir::MLIRContext *context,
@@ -637,6 +637,7 @@ def TTNN_TTNNLayoutAttr: TTNN_Attr<"TTNNLayout", "ttnn_layout"> {
     AffineMap getIdentityTileLinearMap() const;
     llvm::SmallVector<int64_t> getTiledShape(ArrayRef<int64_t> logicalTensorShape) const;
     AffineMap replaceMemoryMapSymbolsWithShardShape(AffineMap physicalMemoryMap) const;
+    std::pair<std::int64_t, std::int64_t> getDefaultCollapseIntervals() const;
   }];
 
   let genVerifyDecl = 1;

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
@@ -580,9 +580,16 @@ def TTNN_TTNNLayoutAttr: TTNN_Attr<"TTNNLayout", "ttnn_layout"> {
                         AttrParameter<"GridAttr", "The grid shape that this tensor is divided onto.">:$grid,
                         AttrParameter<"MemRefType", "A memref that describes the physical footprint allocation of the shard. It must also have a shape with rank equal to grid.">:$memref,
                         OptionalParameter<"TensorMemoryLayoutAttr", "TTNN tensor memory layout">:$mem_layout,
-                        OptionalParameter<"TensorMeshShardingAttr", "TT mesh sharding attr">:$tensor_mesh_sharding);
-  let assemblyFormat = "`<` $linear`,` $grid`,` (`mesh` `=` $tensor_mesh_sharding^ `,`)? $memref (`,` $mem_layout^)? `>`";
+                        OptionalParameter<"TensorMeshShardingAttr", "TT mesh sharding attr">:$tensor_mesh_sharding,
+                        OptionalParameter<"bool", "A status flag, asking the callers to ignore the physical layout. This is used to model a sharded layout with unspecified shard shape.">:$ignorePhysicalLayout);
+  let assemblyFormat = "`<` $linear`,` $grid`,` (`mesh` `=` $tensor_mesh_sharding^ `,`)? $memref (`,` $mem_layout^)? (`,` $ignorePhysicalLayout^)? `>`";
   let extraClassDeclaration = [{
+    static TTNNLayoutAttr get(::mlir::MLIRContext *context,
+                        AffineMap linear,
+                        GridAttr grid, MemRefType memref,
+                        TensorMemoryLayoutAttr mem_layout,
+                        TensorMeshShardingAttr tensor_mesh_sharding);
+
     static TTNNLayoutAttr get(::mlir::MLIRContext *context,
                         ArrayRef<int64_t> tensorShape,
                         Type elementType,
@@ -590,7 +597,8 @@ def TTNN_TTNNLayoutAttr: TTNN_Attr<"TTNNLayout", "ttnn_layout"> {
                         GridAttr grid,
                         TensorMemoryLayoutAttr memoryLayoutAttr = nullptr,
                         TensorMeshShardingAttr tensorMeshShardingAttr = nullptr,
-                        ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}});
+                        ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}},
+                        bool ignorePhysicalLayout = false);
 
     TTNNLayoutAttr withGrid(ArrayRef<int64_t> tensorShape, GridAttr grid, ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}});
     TTNNLayoutAttr withGrid(RankedTensorType ty,
@@ -602,10 +610,12 @@ def TTNN_TTNNLayoutAttr: TTNN_Attr<"TTNNLayout", "ttnn_layout"> {
     TTNNLayoutAttr withMemoryLayout(TensorMemoryLayout memLayout);
     TTNNLayoutAttr withShardShape(llvm::SmallVector<int64_t> shardShape);
     TTNNLayoutAttr withTensorShape(ArrayRef<int64_t> tensorShape);
+    TTNNLayoutAttr withIgnorePhysicalLayout(bool ignorePhysicalLayout);
 
     bool isSystemBufferType() const { return ::mlir::tt::ttnn::isSystemBufferType(getBufferType()); }
     bool isDeviceBufferType() const { return ::mlir::tt::ttnn::isDeviceBufferType(getBufferType()); }
     bool isMeshDeviceTensor() const { return ::mlir::tt::ttnn::isMeshDeviceTensor(getTensorMeshSharding()); }
+    bool isPartialLayout() const { return getIgnorePhysicalLayout(); }
     bool isTiled() const;
     bool hasShardedTensorMemoryLayout() const;
     bool hasShardedL1TensorMemoryLayout() const;

--- a/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp
@@ -332,7 +332,8 @@ TTNNLayoutAttr TTNNLayoutAttr::withGrid(
     ArrayRef<int64_t> tensorShape, GridAttr grid,
     ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals) {
   return get(getContext(), tensorShape, getElementType(), getBufferType(), grid,
-             getMemLayout(), getTensorMeshSharding(), collapseIntervals);
+             getMemLayout(), getTensorMeshSharding(), collapseIntervals,
+             getIgnorePhysicalLayout());
 }
 
 // Construct a new TTNNLayoutAttr
@@ -367,7 +368,8 @@ TTNNLayoutAttr TTNNLayoutAttr::withElementType(
     ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals) {
   return TTNNLayoutAttr::get(getContext(), tensorShape, elementType,
                              getBufferType(), getGrid(), getMemLayout(),
-                             getTensorMeshSharding(), collapseIntervals);
+                             getTensorMeshSharding(), collapseIntervals,
+                             getIgnorePhysicalLayout());
 }
 
 // Construct a new TTNNLayoutAttr
@@ -408,7 +410,7 @@ TTNNLayoutAttr TTNNLayoutAttr::withBufferType(BufferType memorySpace) {
       getContext(), getLinear(), grid,
       buildMemRef<BufferType, BufferTypeAttr>(
           getContext(), getScalarShardShape(), getElementType(), memorySpace),
-      memLayoutAttr, getTensorMeshSharding());
+      memLayoutAttr, getTensorMeshSharding(), getIgnorePhysicalLayout());
 }
 
 // Construct a new TTNNLayoutAttr
@@ -425,7 +427,8 @@ TTNNLayoutAttr::withMemoryLayout(TensorMemoryLayoutAttr memLayoutAttr) {
                              buildMemRef<BufferType, BufferTypeAttr>(
                                  getContext(), getScalarShardShape(),
                                  getElementType(), getBufferType()),
-                             memLayoutAttr, getTensorMeshSharding());
+                             memLayoutAttr, getTensorMeshSharding(),
+                             getIgnorePhysicalLayout());
 }
 
 // Construct a new TTNNLayoutAttr
@@ -457,7 +460,7 @@ TTNNLayoutAttr::withShardShape(llvm::SmallVector<int64_t> shardShape) {
       getContext(), getLinear(), getGrid(),
       buildMemRef<BufferType, BufferTypeAttr>(
           getContext(), shardShape, getElementType(), getBufferType()),
-      getMemLayout(), getTensorMeshSharding());
+      getMemLayout(), getTensorMeshSharding(), getIgnorePhysicalLayout());
 }
 
 // Construct a new TTNNLayoutAttr
@@ -473,9 +476,37 @@ TTNNLayoutAttr TTNNLayoutAttr::withTensorShape(ArrayRef<int64_t> tensorShape) {
   // which might be different than the original value used to create the layout
   // attribute. This will work for now since we always use default value, but in
   // the future we would need to take this into account.
-  return TTNNLayoutAttr::get(getContext(), tensorShape, getElementType(),
-                             getBufferType(), getGrid(), getMemLayout(),
-                             getTensorMeshSharding());
+  return TTNNLayoutAttr::get(
+      getContext(), tensorShape, getElementType(), getBufferType(), getGrid(),
+      getMemLayout(), getTensorMeshSharding(),
+      std::pair<std::int64_t, std::int64_t>{0, -1}, getIgnorePhysicalLayout());
+}
+
+// Construct a new TTNNLayoutAttr
+//
+// This function creates a deep copy of the current TTNNLayoutAttr, setting the
+// ignorePhysicalLayout property to the provided value. This is a status bit.
+// The physical properties of the layout are preserved as calculated previously
+// and remain accessible via getters
+//
+// param context The MLIR context.
+// param ignorePhysicalLayout The new value for ignorePhysicalLayout.
+// return The new TTNNLayoutAttr.
+TTNNLayoutAttr
+TTNNLayoutAttr::withIgnorePhysicalLayout(bool ignorePhysicalLayout) {
+  return TTNNLayoutAttr::get(getContext(), getLinear(), getGrid(), getMemref(),
+                             getMemLayout(), getTensorMeshSharding(),
+                             ignorePhysicalLayout);
+};
+
+TTNNLayoutAttr
+TTNNLayoutAttr::get(::mlir::MLIRContext *context, AffineMap linear,
+                    GridAttr grid, MemRefType memref,
+                    TensorMemoryLayoutAttr mem_layout,
+                    TensorMeshShardingAttr tensor_mesh_sharding) {
+  return TTNNLayoutAttr::get(context, linear, grid, memref, mem_layout,
+                             tensor_mesh_sharding,
+                             /*ignorePhysicalLayout=*/false);
 }
 
 // Construct a new TTNNLayoutAttr
@@ -495,7 +526,8 @@ TTNNLayoutAttr TTNNLayoutAttr::get(
     Type elementType, BufferType bufferType, GridAttr grid,
     TensorMemoryLayoutAttr memLayoutAttr,
     TensorMeshShardingAttr tensorMeshSharding,
-    ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals) {
+    ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals,
+    bool ignorePhysicalLayout) {
 
   llvm::SmallVector<int64_t, 4> physicalShape(tensorShape.begin(),
                                               tensorShape.end());
@@ -526,13 +558,13 @@ TTNNLayoutAttr TTNNLayoutAttr::get(
   MemRefType memRefType = buildMemRef<BufferType, BufferTypeAttr>(
       context, shardShape, elementType, bufferType);
   return get(context, linear, grid, memRefType, memLayoutAttr,
-             tensorMeshSharding);
+             tensorMeshSharding, ignorePhysicalLayout);
 }
 
 ::llvm::LogicalResult TTNNLayoutAttr::verify(
     ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, AffineMap,
     GridAttr, MemRefType memref, TensorMemoryLayoutAttr memLayout,
-    TensorMeshShardingAttr tensorMeshSharding) {
+    TensorMeshShardingAttr tensorMeshSharding, bool ignorePhysicalLayout) {
   BufferType bufferType =
       mlir::cast<BufferTypeAttr>(memref.getMemorySpace()).getValue();
   return verifyBufferAndMemoryLayout(emitError, bufferType, memLayout);

--- a/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpsAttrs.cpp
@@ -37,6 +37,11 @@ bool TTNNLayoutAttr::hasDRAMBufferType() const {
   return isDRAMBufferType(getBufferType());
 }
 
+std::pair<std::int64_t, std::int64_t>
+TTNNLayoutAttr::getDefaultCollapseIntervals() const {
+  return {0, -1};
+}
+
 // Check if the tensor memory layout is sharded
 bool TTNNLayoutAttr::hasShardedTensorMemoryLayout() const {
   return isDeviceBufferType() &&
@@ -478,8 +483,8 @@ TTNNLayoutAttr TTNNLayoutAttr::withTensorShape(ArrayRef<int64_t> tensorShape) {
   // the future we would need to take this into account.
   return TTNNLayoutAttr::get(
       getContext(), tensorShape, getElementType(), getBufferType(), getGrid(),
-      getMemLayout(), getTensorMeshSharding(),
-      std::pair<std::int64_t, std::int64_t>{0, -1}, getIgnorePhysicalLayout());
+      getMemLayout(), getTensorMeshSharding(), getDefaultCollapseIntervals(),
+      getIgnorePhysicalLayout());
 }
 
 // Construct a new TTNNLayoutAttr

--- a/lib/OpModel/TTNN/Conversion.cpp
+++ b/lib/OpModel/TTNN/Conversion.cpp
@@ -124,13 +124,19 @@ getCoreRangeSet(const mlir::tt::ttnn::TTNNLayoutAttr &layout) {
 
 std::optional<::tt::tt_metal::ShardSpec>
 getShardSpec(const mlir::tt::ttnn::TTNNLayoutAttr &layout) {
+  if (layout.getIgnorePhysicalLayout()) {
+    return std::nullopt;
+  }
+
+  if (!isShardedMemoryLayout(layout.getMemLayout().getValue())) {
+    return std::nullopt;
+  }
+
   // tt_ShardOrientation is not part of ttnn::TTNNLayoutAttr;
   // defaulting to ROW_MAJOR. TODO(jserbedzija): with issue #620
-  return isShardedMemoryLayout(layout.getMemLayout().getValue())
-             ? std::make_optional(::tt::tt_metal::ShardSpec(
-                   getCoreRangeSet(layout), getShardShape(layout),
-                   ::tt::tt_metal::ShardOrientation::ROW_MAJOR))
-             : std::nullopt;
+  return ::tt::tt_metal::ShardSpec(getCoreRangeSet(layout),
+                                   getShardShape(layout),
+                                   ::tt::tt_metal::ShardOrientation::ROW_MAJOR);
 }
 
 ::tt::tt_metal::BufferType
@@ -223,6 +229,8 @@ getTensorLayout(const mlir::tt::ttnn::TTNNLayoutAttr &layout) {
 
 ::ttnn::TensorSpec getTensorSpec(const ::llvm::ArrayRef<int64_t> shape,
                                  const mlir::tt::ttnn::TTNNLayoutAttr &layout) {
+  assert(!layout.getIgnorePhysicalLayout() &&
+         "TensorSpecs cannot be created without physical layouts");
   return ::ttnn::TensorSpec(getShape(shape), getTensorLayout(layout));
 }
 
@@ -230,7 +238,7 @@ bool validateTensorSpec(const ::ttnn::TensorSpec &tensorSpec,
                         const ::tt::tt_metal::CoreCoord &computeGridSize) {
   // Check the shard bounding box
   auto memoryConfig = tensorSpec.memory_config();
-  if (memoryConfig.is_sharded()) {
+  if (memoryConfig.is_sharded() && memoryConfig.shard_spec().has_value()) {
     ::tt::tt_metal::CoreRange shardBoundingBox =
         memoryConfig.shard_spec().value().grid.bounding_box();
     ::tt::tt_metal::CoreRangeSet deviceWorkerCores{::tt::tt_metal::CoreRange{

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -495,16 +495,10 @@ getEltwiseBinaryOpConstraints(std::string_view opName, OpSymbol opSymbol,
   ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
 
   std::optional<::tt::tt_metal::DataType> outputDType = std::nullopt;
-  std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig = std::nullopt;
+  std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
+      detail::getNullableMemoryConfig(outputLayout);
   if (outputLayout) {
-    auto outputSpecExp =
-        detail::convertToTensorSpec(device, outputShape, outputLayout);
-    if (!outputSpecExp) {
-      return outputSpecExp.takeError();
-    }
-    ::ttnn::TensorSpec outputSpec = outputSpecExp.get();
-    outputDType = outputSpec.data_type();
-    outputMemoryConfig = outputSpec.memory_config();
+    outputDType = conversion::getDataType(outputLayout.getDataType());
   }
 
   // Create query closure
@@ -545,17 +539,12 @@ getEltwiseBinaryOpRuntime(std::string_view opName, OpSymbol opSymbol,
   ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
 
   std::optional<::tt::tt_metal::DataType> outputDType = std::nullopt;
-  std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig = std::nullopt;
+  std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
+      detail::getNullableMemoryConfig(outputLayout);
   if (outputLayout) {
-    auto outputSpecExp =
-        detail::convertToTensorSpec(device, outputShape, outputLayout);
-    if (!outputSpecExp) {
-      return outputSpecExp.takeError();
-    }
-    ::ttnn::TensorSpec outputSpec = outputSpecExp.get();
-    outputDType = outputSpec.data_type();
-    outputMemoryConfig = outputSpec.memory_config();
+    outputDType = conversion::getDataType(outputLayout.getDataType());
   }
+
   // Create query closure
   auto query = [=]() {
     return ::ttnn::graph::query_op_runtime(opSymbol, device, inputSpecA,
@@ -1492,16 +1481,10 @@ MatmulOpInterface::getOpConstraints(GridAttr deviceGrid,
   ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
 
   std::optional<::tt::tt_metal::DataType> outputDType = std::nullopt;
-  std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig = std::nullopt;
+  std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
+      detail::getNullableMemoryConfig(outputLayout);
   if (outputLayout) {
-    auto outputSpecExp =
-        detail::convertToTensorSpec(device, outputShape, outputLayout);
-    if (!outputSpecExp) {
-      return outputSpecExp.takeError();
-    }
-    ::ttnn::TensorSpec outputSpec = outputSpecExp.get();
-    outputDType = outputSpec.data_type();
-    outputMemoryConfig = outputSpec.memory_config();
+    outputDType = conversion::getDataType(outputLayout.getDataType());
   }
 
   // Create query closure
@@ -1546,16 +1529,10 @@ MatmulOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
   ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
 
   std::optional<::tt::tt_metal::DataType> outputDType = std::nullopt;
-  std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig = std::nullopt;
+  std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
+      detail::getNullableMemoryConfig(outputLayout);
   if (outputLayout) {
-    auto outputSpecExp =
-        detail::convertToTensorSpec(device, outputShape, outputLayout);
-    if (!outputSpecExp) {
-      return outputSpecExp.takeError();
-    }
-    ::ttnn::TensorSpec outputSpec = outputSpecExp.get();
-    outputDType = outputSpec.data_type();
-    outputMemoryConfig = outputSpec.memory_config();
+    outputDType = conversion::getDataType(outputLayout.getDataType());
   }
 
   // Create query closure

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -195,6 +195,18 @@ getNullableMemoryConfig(::mlir::tt::ttnn::TTNNLayoutAttr layout) {
   return conversion::getMemoryConfig(layout);
 }
 
+/**
+ * @brief Convenience wrapper to get a DataType from a TTNNLayout attr that
+ * may be a nullptr. Returns std::nullopt if layout is nullptr
+ */
+std::optional<::tt::tt_metal::DataType>
+getNullableDataType(::mlir::tt::ttnn::TTNNLayoutAttr layout) {
+  if (!layout) {
+    return std::nullopt;
+  }
+  return conversion::getDataType(layout.getDataType());
+}
+
 } // namespace detail
 #endif // TTMLIR_ENABLE_OPMODEL
 
@@ -494,12 +506,10 @@ getEltwiseBinaryOpConstraints(std::string_view opName, OpSymbol opSymbol,
   }
   ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
 
-  std::optional<::tt::tt_metal::DataType> outputDType = std::nullopt;
+  std::optional<::tt::tt_metal::DataType> outputDType =
+      detail::getNullableDataType(outputLayout);
   std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
       detail::getNullableMemoryConfig(outputLayout);
-  if (outputLayout) {
-    outputDType = conversion::getDataType(outputLayout.getDataType());
-  }
 
   // Create query closure
   auto query = [=]() {
@@ -538,12 +548,10 @@ getEltwiseBinaryOpRuntime(std::string_view opName, OpSymbol opSymbol,
   }
   ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
 
-  std::optional<::tt::tt_metal::DataType> outputDType = std::nullopt;
+  std::optional<::tt::tt_metal::DataType> outputDType =
+      detail::getNullableDataType(outputLayout);
   std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
       detail::getNullableMemoryConfig(outputLayout);
-  if (outputLayout) {
-    outputDType = conversion::getDataType(outputLayout.getDataType());
-  }
 
   // Create query closure
   auto query = [=]() {
@@ -1480,12 +1488,10 @@ MatmulOpInterface::getOpConstraints(GridAttr deviceGrid,
   }
   ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
 
-  std::optional<::tt::tt_metal::DataType> outputDType = std::nullopt;
+  std::optional<::tt::tt_metal::DataType> outputDType =
+      detail::getNullableDataType(outputLayout);
   std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
       detail::getNullableMemoryConfig(outputLayout);
-  if (outputLayout) {
-    outputDType = conversion::getDataType(outputLayout.getDataType());
-  }
 
   // Create query closure
   auto matmulOpQuery = [=]() {
@@ -1528,12 +1534,10 @@ MatmulOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
   }
   ::ttnn::TensorSpec inputSpecB = inputSpecBExp.get();
 
-  std::optional<::tt::tt_metal::DataType> outputDType = std::nullopt;
+  std::optional<::tt::tt_metal::DataType> outputDType =
+      detail::getNullableDataType(outputLayout);
   std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
       detail::getNullableMemoryConfig(outputLayout);
-  if (outputLayout) {
-    outputDType = conversion::getDataType(outputLayout.getDataType());
-  }
 
   // Create query closure
   auto matmulOpQuery = [=]() {

--- a/test/unittests/OpModel/TTNN/Conversion/TestConversion.cpp
+++ b/test/unittests/OpModel/TTNN/Conversion/TestConversion.cpp
@@ -482,8 +482,11 @@ TEST_P(MlirToTtnnConversionMemoryConfig, MemoryConfig) {
 
     auto partialLayout = layout.withIgnorePhysicalLayout(true);
     EXPECT_TRUE(partialLayout.getIgnorePhysicalLayout());
+    EXPECT_TRUE(partialLayout.hasShardedTensorMemoryLayout());
+
     const auto partialConfig =
         mlir::tt::op_model::ttnn::conversion::getMemoryConfig(partialLayout);
+    EXPECT_TRUE(partialConfig.is_sharded());
     EXPECT_FALSE(partialConfig.shard_spec().has_value());
   }
 }

--- a/test/unittests/OpModel/TTNN/Conversion/TestConversion.cpp
+++ b/test/unittests/OpModel/TTNN/Conversion/TestConversion.cpp
@@ -473,9 +473,19 @@ TEST_P(MlirToTtnnConversionMemoryConfig, MemoryConfig) {
             mlirBufferType == mlir::tt::ttnn::BufferType::L1);
   EXPECT_EQ(memoryConfig.is_dram(),
             mlirBufferType == mlir::tt::ttnn::BufferType::DRAM);
-  EXPECT_EQ(memoryConfig.is_sharded(),
-            mlirTensorMemoryLayout !=
-                mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
+  EXPECT_FALSE(layout.getIgnorePhysicalLayout());
+
+  if (mlirTensorMemoryLayout !=
+      mlir::tt::ttnn::TensorMemoryLayout::Interleaved) {
+    EXPECT_TRUE(memoryConfig.is_sharded());
+    EXPECT_TRUE(memoryConfig.shard_spec().has_value());
+
+    auto partialLayout = layout.withIgnorePhysicalLayout(true);
+    EXPECT_TRUE(partialLayout.getIgnorePhysicalLayout());
+    const auto partialConfig =
+        mlir::tt::op_model::ttnn::conversion::getMemoryConfig(partialLayout);
+    EXPECT_FALSE(partialConfig.shard_spec().has_value());
+  }
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -497,15 +497,15 @@ TEST_F(OpModelBase, MatmulOpInterfacePartialOutput) {
       backend.getOpConstraints(getInputLayouts(matmul), OpConfig(outputLayout));
 
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, peakSize, outputSize, observedOutputLayout] =
-      constraintsExp.get();
-  EXPECT_EQ(cbSize, 262144);
-  EXPECT_EQ(peakSize, 524288);
-  EXPECT_EQ(outputSize, 524288);
+  auto constraints = constraintsExp.get();
+  EXPECT_EQ(constraints.cbL1PeakSize, 262144);
+  EXPECT_EQ(constraints.tensorL1PeakSize, 524288);
+  EXPECT_EQ(constraints.outputL1BufferSize, 524288);
 
-  ASSERT_TRUE(observedOutputLayout);
-  EXPECT_EQ(observedOutputLayout.getLayout(), Layout::Tile);
-  EXPECT_TRUE(observedOutputLayout.hasShardedL1TensorMemoryLayout());
+  ASSERT_TRUE(constraints.outputLayout);
+  EXPECT_EQ(constraints.outputLayout.getLayout(), Layout::Tile);
+  EXPECT_TRUE(constraints.outputLayout.hasShardedL1TensorMemoryLayout());
+  EXPECT_TRUE(constraints.outputLayout.getGrid());
 }
 
 // Forward declarations


### PR DESCRIPTION
### Ticket
#3242
#3408

### Problem description
In TTNN it is possible to create a `MemoryConfig` that is L1 and sharded, but has an unspecified `shard_spec`. This means the tensor is sharded but the physical shard shape and grid are unspecified. Such `MemoryConfig`s cannot actually be used to allocate tensors. However, some ops such as `matmul` accept them as `output_memory_config` so callers can request a sharded output tensor while allowing the op to decide the actual shard layout.

The optimizer uses `TTNNLayoutAttr` to model the layout of TTNN tensors. This attribute requires a `GridAttr` and immediately computes the physical shard shape. There is no mechanism to model the unspecified `shardspec`. There is also no mechanism for the optimizer to signal to the OpModel to only partially translate the `TTNNLayoutAttr`. This blocks the proper exploration of sharding for `matmul` in the optimizer.

### What's changed
- Modify the `TTNNLayoutAttr` to add a flag, `ignorePhysicalLayout`. When this flag is set, opModel skips the creation of a `shard_spec` when translating the `TTNNLayoutAttr` to a `MemoryConfig`
  - This flag does **not** bypass the need to provide a valid `GridAttr`. Nor does it modify the any behaviour or property of the attribute. It is a flag that must be read by the users of this Attr
  - This flag defaults to **false**. All existing call sites for `TTNNLayoutAttr::get` will call the `::get` method that sets this to false
  - Added `::withIgnorePhysicalLayout()` and new constructor
- Added unit tests for correct conversion, and for calling `getOpConstraints` on `matmul` with `ignorePhysicalLayout` set to true for the `output_memory_config`
- Added an assertion to ensure `tensor_spec`s are not created from layouts with this flag set to true
- Closes #3242
- Closes #3408

### Rationale 
There are two alternatives to this approach:
1. Make the `GridAttr` an optional parameter and bypass its usage in `TTNNLayoutAttr`
  - Problem: not having a `GridAttr` means we need to also null the `AffineMap` and the `Memref`. At that point, almost every method of `TTNNLayoutAttr` would have to return null. Every call site would need to handle the potential nullability or risk a segfault 
2. Introduce a new attribute `TTNNPartialLayoutAttr`
  - Problem: need to define easy transformations to and from `TTNNLayoutAttr`. Lots of API churn to accept this in the opModel

I think the current approach minimizes churn and avoids the pitfalls of the above alternatives. The worst case is that a `TTNNLayoutAttr` is created with a default meaningless `GridAttr` and `ignorePhysicalLayout == true` but a user does not respect that. I think garbage data is better than potential segfaults.

### Checklist
- [X] New/Existing tests provide coverage for changes
