### PR TITLE
Remove `empty` from the builder API

### DIFF
--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -946,23 +946,6 @@ def test_ones(shape: Shape, request):
     )
 
 
-# Empty will intermittently fail golden checks during many flatbuffer
-# executions since it is uninitialized data (See #3732)
-@pytest.mark.fails_golden
-@pytest.mark.parametrize("shape", [(128, 128)], ids=["128x128"])
-def test_empty(shape: Shape, request):
-    def empty(builder: TTIRBuilder):
-        return builder.empty(shape)
-
-    compile_to_flatbuffer(
-        empty,
-        inputs_shapes=[],
-        test_base=request.node.name,
-        output_root=request.config.getoption("--path"),
-        system_desc_path=request.config.getoption("--sys-desc"),
-    )
-
-
 @pytest.mark.parametrize("shapes", [[(128, 128)]])
 @pytest.mark.parametrize("dim_arg", [[1]])
 def test_argmax(shapes, dim_arg, request):

--- a/tools/ttir-builder/builder.py
+++ b/tools/ttir-builder/builder.py
@@ -506,7 +506,7 @@ class TTIRBuilder:
             self.generate_and_store_random_golden(op)
             return op
 
-    def empty(self, shape: Shape, data_type: Optional[Type] = None) -> OpView:
+    def _empty(self, shape: Shape, data_type: Optional[Type] = None) -> OpView:
         """Convenience wrapper constructing `ttir.EmptyOp`."""
         dtype = data_type if data_type is not None else self._default_dtype
         return self.empty_from_tensor_type(shape, self.ranked_tensor_type(shape, dtype))
@@ -615,7 +615,7 @@ class TTIRBuilder:
             if output_create_fn:
                 output = output_create_fn(output_shape, output_type)
             else:
-                output = self.empty(output_shape, output_type)
+                output = self._empty(output_shape, output_type)
             id = self.get_next_global_id()
             loc = (
                 get_loc_from_str(loc)


### PR DESCRIPTION
### Ticket
Closes #3732 

### Problem description
`empty` was failing golden tests as uninitialized data. 

### What's changed
After discussion, users would never need to use `empty`, so it has been removed from the builder API along with its test, making the test failure moot.
