### PR TITLE
Uplift third_party/tt-metal to 3fbd3ff68830cbe5fc3ae69cfb8ae036138a1ebd 2025-06-17

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -180,7 +180,8 @@ jobs:
           {runs-on: n150,   sh-run: false, name: "perf", suite: "explorer",          image: "tracy",  type: "pytest",  path: "tools/explorer/test/run_tests.py"},
           {runs-on: n150,   sh-run: false, name: "run",  suite: "op_by_op_infra",    image: "tracy",  type: "pytest",  path: "test/python/op_by_op_infra"},
           {runs-on: n300,   sh-run: true,  name: "run",  suite: "ttnn_runtime",      image: "tracy",  type: "pytest",  path: "runtime/test/python/ttnn/multi_device"},
-          {runs-on: n300,   sh-run: true,  name: "run",  suite: "run",               image: "tracy",  type: "pykernel"},
+          # Pykernel tests are disabled until PR #3802 is merged and we no longer need to pip install ttnn
+          # {runs-on: n300,   sh-run: true,  name: "run",  suite: "run",               image: "tracy",  type: "pykernel"},
         ]
     name: "run-tests (${{ matrix.build.runs-on }},${{ matrix.build.image }},${{ matrix.build.suite }},${{ matrix.build.type }},${{ strategy.job-index }})"
 

--- a/runtime/lib/ttnn/operations/ccl/collective_permute.cpp
+++ b/runtime/lib/ttnn/operations/ccl/collective_permute.cpp
@@ -78,7 +78,8 @@ void run(const ::tt::target::ttnn::CollectivePermuteOp *op,
     // We need to memset this tensor value to 0 based on collective permute
     // operation semantics
     void *dstPtr = ::tt::runtime::ttnn::utils::getRawHostDataPtr(srcHostTensor);
-    size_t size = srcHostTensor.padded_volume() * srcHostTensor.element_size();
+    size_t size =
+        srcHostTensor.physical_volume() * srcHostTensor.element_size();
     std::memset(dstPtr, 0, size);
 
     newHostTensors[i] = srcHostTensor;

--- a/runtime/lib/ttnn/operations/utils/utils.cpp
+++ b/runtime/lib/ttnn/operations/utils/utils.cpp
@@ -48,7 +48,7 @@ bool isTilized(const ::tt::target::ttnn::TensorRef *tensorRef) {
 bool shouldSwapBinaryOperands(const ::ttnn::Tensor &lhs,
                               const ::ttnn::Tensor &rhs) {
   return (workaround::Env::get().swapBinaryOperands) &&
-         (lhs.padded_volume() < rhs.padded_volume());
+         (lhs.physical_volume() < rhs.physical_volume());
 }
 
 ::ttnn::operations::unary::UnaryOpType

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -315,7 +315,7 @@ std::uint32_t getTensorElementSize(::tt::runtime::Tensor tensor) {
 std::uint32_t getTensorVolume(::tt::runtime::Tensor tensor) {
   const ::ttnn::Tensor &ttnnTensor =
       utils::getTTNNTensorFromRuntimeTensor(tensor);
-  return ttnnTensor.padded_volume();
+  return ttnnTensor.physical_volume();
 }
 
 TensorDesc getTensorDesc(::tt::runtime::Tensor tensor) {
@@ -675,7 +675,7 @@ void memcpy(void *dst, ::tt::runtime::Tensor src) {
   const ::ttnn::Tensor &srcTensor = utils::getTTNNTensorFromRuntimeTensor(src);
   if (utils::isOnHost(srcTensor.storage_type())) {
     const void *srcPtr = utils::getRawHostDataPtr(srcTensor);
-    size_t size = srcTensor.padded_volume() * srcTensor.element_size();
+    size_t size = srcTensor.physical_volume() * srcTensor.element_size();
     std::memcpy(dst, srcPtr, size);
   } else {
     ::tt::tt_metal::memcpy(dst, srcTensor);
@@ -685,17 +685,17 @@ void memcpy(void *dst, ::tt::runtime::Tensor src) {
 void memcpy(::tt::runtime::Tensor dst, ::tt::runtime::Tensor src) {
   ::ttnn::Tensor &dstTensor = utils::getTTNNTensorFromRuntimeTensor(dst);
   const ::ttnn::Tensor &srcTensor = utils::getTTNNTensorFromRuntimeTensor(src);
-  LOG_ASSERT(srcTensor.padded_volume() * srcTensor.element_size() ==
-                 dstTensor.padded_volume() * dstTensor.element_size(),
+  LOG_ASSERT(srcTensor.physical_volume() * srcTensor.element_size() ==
+                 dstTensor.physical_volume() * dstTensor.element_size(),
              "Input output tensor size mismatch in memcpy: ",
-             srcTensor.padded_volume(), " * ", srcTensor.element_size(),
-             " != ", dstTensor.padded_volume(), " * ",
+             srcTensor.physical_volume(), " * ", srcTensor.element_size(),
+             " != ", dstTensor.physical_volume(), " * ",
              dstTensor.element_size());
   if (utils::isOnHost(srcTensor.storage_type()) &&
       utils::isOnHost(dstTensor.storage_type())) {
     void *dstPtr = utils::getRawHostDataPtr(dstTensor);
     const void *srcPtr = utils::getRawHostDataPtr(srcTensor);
-    size_t size = srcTensor.padded_volume() * srcTensor.element_size();
+    size_t size = srcTensor.physical_volume() * srcTensor.element_size();
     std::memcpy(dstPtr, srcPtr, size);
   } else {
     ::tt::tt_metal::memcpy(dstTensor, srcTensor);

--- a/runtime/test/ttnn/dylib.cpp
+++ b/runtime/test/ttnn/dylib.cpp
@@ -253,7 +253,7 @@ bool compareOuts(std::vector<::tt::runtime::Tensor> &lhs,
         ::tt::runtime::ttnn::utils::getRawHostDataPtr(*lhsTensor));
     uint8_t *rhsData = static_cast<uint8_t *>(
         ::tt::runtime::ttnn::utils::getRawHostDataPtr(*rhsTensor));
-    for (size_t i = 0; i < lhsTensor->padded_volume(); ++i) {
+    for (size_t i = 0; i < lhsTensor->physical_volume(); ++i) {
       SupportedTypes lhsVal =
           getValueForDType(lhsTensor->dtype(), lhsData + i * elementSize);
       SupportedTypes rhsVal =

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "eefaadf897430e88d4fd8834f226b186fabe4139")
+set(TT_METAL_VERSION "40e1dbf929a94df4de757774f32da61451b660d0")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 3fbd3ff68830cbe5fc3ae69cfb8ae036138a1ebd

- Rename tensor->padded_volume() to tensor->physical_volume after metal change d82e42461f
- Disable Pykernel tests since ttnn wheel needs to match uplifted metal after commit 7d7b51a