### PR TITLE
Execute trace asynchronously by default

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -2080,7 +2080,7 @@ def TTNN_TraceOp : TTNN_Op<"trace"> {
 
       ```mlir
       %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-      %1 = ttnn.trace(%0, 0, true, @single_add_trace_0, [%arg0, %arg1]) : (tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout>
+      %1 = ttnn.trace(%0, 0, false, @single_add_trace_0, [%arg0, %arg1]) : (tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout>
       ```
     }];
 

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -179,7 +179,7 @@ def TTNNTraceHoistTransform : Pass<"ttnn-trace-hoist-transform", "::mlir::Module
 
     ```mlir
     %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = ttnn.trace(%0, 0, true, @single_add_trace_0, [%arg0, %arg1]) : (tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout>
+    %1 = ttnn.trace(%0, 0, false, @single_add_trace_0, [%arg0, %arg1]) : (tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout>
     ```
   }];
 }

--- a/lib/Dialect/TTNN/Transforms/TTNNTraceHoistTransform.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNTraceHoistTransform.cpp
@@ -197,7 +197,7 @@ private:
     builder.setInsertionPoint(firstOp);
     auto device = utils::getOrInsertDevice(rewriter, firstOp);
     auto cqIdAttr = builder.getI32IntegerAttr(traceFuncIndex);
-    auto blockingAttr = builder.getBoolAttr(true);
+    auto blockingAttr = builder.getBoolAttr(false);
     auto traceOp = builder.create<mlir::tt::ttnn::TraceOp>(
         firstOp->getLoc(), outputTypes, device, cqIdAttr, blockingAttr,
         calleeAttr, ValueRange(inputs));

--- a/test/ttmlir/Dialect/TTNN/trace/creation_no_consteval.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/creation_no_consteval.mlir
@@ -8,7 +8,7 @@ module {
   // CHECK-LABEL: func.func @creation_ops(
   func.func @creation_ops() -> tensor<4x4xbf16> {
     // CHECK: %[[GET_DEVICE:.+]] = "ttnn.get_device"()
-    // CHECK-NEXT: %[[TRACE_RESULT:.+]] = ttnn.trace(%[[GET_DEVICE]], 0, true, @creation_ops_trace_0, [])
+    // CHECK-NEXT: %[[TRACE_RESULT:.+]] = ttnn.trace(%[[GET_DEVICE]], 0, false, @creation_ops_trace_0, [])
     // CHECK-NOT: "ttnn.zeros"
     // CHECK-NOT: "ttnn.ones"
     // CHECK-NOT: "ttnn.arange"

--- a/test/ttmlir/Dialect/TTNN/trace/matmul_add_consteval.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/matmul_add_consteval.mlir
@@ -11,7 +11,7 @@ module {
   func.func @matmul_with_bias(%arg0: tensor<64x32xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>}, %arg1: tensor<32x64xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>}, %arg2: tensor<64x64xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<64x64xbf16> {
     // CHECK: %[[GET_DEVICE:.+]] = "ttnn.get_device"()
     // CHECK: %[[LOAD_CACHED_RESULT:.+]] = ttcore.load_cached(@matmul_with_bias_const_eval_0, [%arg0, %arg1])
-    // CHECK: %[[TRACE_RESULT:.+]] = ttnn.trace(%[[GET_DEVICE]], 0, true, @matmul_with_bias_trace_0, [%arg2, %[[LOAD_CACHED_RESULT]]])
+    // CHECK: %[[TRACE_RESULT:.+]] = ttnn.trace(%[[GET_DEVICE]], 0, false, @matmul_with_bias_trace_0, [%arg2, %[[LOAD_CACHED_RESULT]]])
     // CHECK-NOT: "ttnn.add"
     // CHECK-NOT: "ttnn.matmul"
     // CHECK: return %[[TRACE_RESULT]]

--- a/test/ttmlir/Dialect/TTNN/trace/matmul_add_no_consteval.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/matmul_add_no_consteval.mlir
@@ -8,7 +8,7 @@ module {
   // CHECK-LABEL: func.func @matmul_with_bias(
   func.func @matmul_with_bias(%arg0: tensor<64x32xbf16>, %arg1: tensor<32x64xbf16>, %arg2: tensor<64x64xbf16>) -> tensor<64x64xbf16> {
     // CHECK: %[[GET_DEVICE:.+]] = "ttnn.get_device"()
-    // CHECK-NEXT: %[[TRACE_RESULT:.+]] = ttnn.trace(%[[GET_DEVICE]], 0, true, @matmul_with_bias_trace_0, [%arg0, %arg1, %arg2])
+    // CHECK-NEXT: %[[TRACE_RESULT:.+]] = ttnn.trace(%[[GET_DEVICE]], 0, false, @matmul_with_bias_trace_0, [%arg0, %arg1, %arg2])
     // CHECK-NOT: "ttnn.add"
     // CHECK-NOT: "ttnn.matmul"
     // CHECK: return %[[TRACE_RESULT]]

--- a/test/ttmlir/Dialect/TTNN/trace/single_add_no_consteval.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/single_add_no_consteval.mlir
@@ -7,7 +7,7 @@ module {
   // CHECK-LABEL: func.func @single_add(
   func.func @single_add(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>) -> tensor<32x32xbf16> {
     // CHECK: %[[GET_DEVICE:.+]] = "ttnn.get_device"()
-    // CHECK-NEXT: %[[TRACE_RESULT:.+]] = ttnn.trace(%[[GET_DEVICE]], 0, true, @single_add_trace_0, [%arg0, %arg1])
+    // CHECK-NEXT: %[[TRACE_RESULT:.+]] = ttnn.trace(%[[GET_DEVICE]], 0, false, @single_add_trace_0, [%arg0, %arg1])
     // CHECK-NOT: "ttnn.add"
     // CHECK: return %[[TRACE_RESULT]]
     %0 = ttir.empty() : tensor<32x32xbf16>


### PR DESCRIPTION
### Ticket
Part of #3698

### Problem description
Trace is currently executed synchronously

### What's changed
Now updating to execute asynchronously, which gives better perf (~10%) boost and enables perf optimizations with multiple command queues down the road. This aligns with our current execution flow of other operations so there's really no reason to block on execution.

### Checklist
- [X] New/Existing tests provide coverage for changes
