### PR TITLE
Unskip `squeeze` & `unsqueeze` to CI test PCC

### DIFF
--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -594,9 +594,6 @@ def test_broadcast(shapes: List[Shape], broadcast_dimensions: List[int], request
     )
 
 
-@pytest.mark.skip(
-    "This test is not valid for TTRT Perf due to weird issues with perf collection. Issue #2371"
-)
 @pytest.mark.parametrize("shape", [(1, 128, 128, 1)])
 @pytest.mark.parametrize("dim", [0])
 def test_squeeze(shape: Shape, dim: int, request):
@@ -614,9 +611,6 @@ def test_squeeze(shape: Shape, dim: int, request):
     )
 
 
-@pytest.mark.skip(
-    "This test is not valid for TTRT Perf due to weird issues with perf collection. Issue #2371"
-)
 @pytest.mark.parametrize("shape", [(128, 128)])
 @pytest.mark.parametrize("dim", [0])
 def test_unsqueeze(shape: Shape, dim: int, request):


### PR DESCRIPTION
### Ticket
No issue, just getting ops into CI

### Problem description
Due to `squeeze`/`unsqueeze` effectively being reshapes, they don't produce perf reports (#2371). Before we had as fine grained control over which flatbuffers were created, we needed to unconditionally skip these. Seeing as that issue is closed, and a tentative solution has been reached, I believe the following change to be safe and valid.

### What's changed
Since we can now selectively skip tests via pytest, we can just skip these tests whenever we need them for perf, or not include their flatbuffers in a perf run. These tests have been re-enabled, adding their PCC regression tests into CI. There is some discussion on the root issue of this, but wanted to at least get these into CI ASAP. We can discuss some more if this is premature or not. 

### Checklist
- [x] New/Existing tests provide coverage for changes
