### PR TITLE
#3706: Added support for custom metadata insertion in tracy profiler dumps and analysis of profiled results.

### DIFF
--- a/runtime/include/tt/runtime/perf.h
+++ b/runtime/include/tt/runtime/perf.h
@@ -9,7 +9,11 @@
 
 namespace tt::runtime::perf {
 
-enum class TracyLogTag { MLIR_OP_LOCATION, MLIR_CONST_EVAL_OP };
+enum class TracyLogTag {
+  MLIR_OP_LOCATION,
+  MLIR_CONST_EVAL_OP,
+  MLIR_PROGRAM_METADATA
+};
 
 inline std::string toString(TracyLogTag tracyLogTag) {
   switch (tracyLogTag) {
@@ -17,30 +21,47 @@ inline std::string toString(TracyLogTag tracyLogTag) {
     return "MLIR_OP_LOCATION";
   case TracyLogTag::MLIR_CONST_EVAL_OP:
     return "MLIR_CONST_EVAL_OP";
+  case TracyLogTag::MLIR_PROGRAM_METADATA:
+    return "MLIR_PROGRAM_METADATA";
   }
 }
 
 struct Env {
 #if defined(TT_RUNTIME_ENABLE_PERF_TRACE) && TT_RUNTIME_ENABLE_PERF_TRACE == 1
-  static const Env &
+  static Env &
 #else
-  constexpr static Env
+  static Env
 #endif
-  get(std::uint32_t dumpDeviceRate = 1000, bool enablePerfTrace = false)
+  get(std::uint32_t dumpDeviceRate = 1000, bool enablePerfTrace = false,
+      const std::string &tracyProgramMetadata = "")
 #if defined(TT_RUNTIME_ENABLE_PERF_TRACE) && TT_RUNTIME_ENABLE_PERF_TRACE == 1
       ;
 #else
   {
-    return Env(1000, false);
+    return Env(1000, false, "");
   }
 #endif
 
   std::uint32_t dumpDeviceRate;
   bool enablePerfTrace;
+  std::string tracyProgramMetadata;
+
+#if defined(TT_RUNTIME_ENABLE_PERF_TRACE) && TT_RUNTIME_ENABLE_PERF_TRACE == 1
+  Env(const Env &) = delete;
+  Env &operator=(const Env &) = delete;
+  Env(Env &&) = delete;
+  Env &operator=(Env &&) = delete;
+#endif
+
+  void setProgramMetadata(const std::string &programMetadata) {
+    tracyProgramMetadata = programMetadata;
+  }
 
 private:
-  constexpr Env(std::uint32_t dumpDeviceRate, bool enablePerfTrace)
-      : dumpDeviceRate(dumpDeviceRate), enablePerfTrace(enablePerfTrace) {}
+  Env(std::uint32_t dumpDeviceRate, bool enablePerfTrace,
+      const std::string &tracyProgramMetadata)
+      : dumpDeviceRate(dumpDeviceRate), enablePerfTrace(enablePerfTrace),
+        tracyProgramMetadata(tracyProgramMetadata) {}
 };
 
 inline std::ostream &operator<<(std::ostream &os, const Env &env) {
@@ -49,6 +70,8 @@ inline std::ostream &operator<<(std::ostream &os, const Env &env) {
      << "dumpDeviceRate: " << env.dumpDeviceRate << "\n"
      << "\t"
      << "enablePerfTrace: " << env.enablePerfTrace << "\n"
+     << "\t"
+     << "tracyProgramMetadata: " << env.tracyProgramMetadata << "\n"
      << "}";
   return os;
 }

--- a/runtime/lib/common/perf.cpp
+++ b/runtime/lib/common/perf.cpp
@@ -8,8 +8,9 @@
 
 namespace tt::runtime::perf {
 
-const Env &Env::get(std::uint32_t dumpDeviceRate, bool enablePerfTrace) {
-  static Env config(dumpDeviceRate, enablePerfTrace);
+Env &Env::get(std::uint32_t dumpDeviceRate, bool enablePerfTrace,
+              const std::string &tracyProgramMetadata) {
+  static Env config(dumpDeviceRate, enablePerfTrace, tracyProgramMetadata);
   return config;
 }
 

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -84,6 +84,15 @@ static void tracyLogConstEvalProgram(const ::tt::target::ttnn::Operation *op,
 #endif
 }
 
+static void tracyLogProgramMetadata(const ::tt::target::ttnn::Operation *op,
+                                    std::string metaData) {
+#if defined(TT_RUNTIME_ENABLE_PERF_TRACE) && TT_RUNTIME_ENABLE_PERF_TRACE == 1
+  std::string message =
+      perf::toString(perf::TracyLogTag::MLIR_PROGRAM_METADATA) + ";" + metaData;
+  TracyMessage(message.c_str(), message.size());
+#endif
+}
+
 ProgramExecutor::ProgramExecutor(
     ::tt::runtime::Device deviceHandle, ::tt::runtime::Binary &executableHandle,
     const size_t programIndex,
@@ -140,6 +149,7 @@ void ProgramExecutor::execute() {
               "Executing operation: ", op->debug_info()->c_str());
     tracyLogConstEvalProgram(op, constEvalProgram);
     tracyLogOpLocation(op);
+    tracyLogProgramMetadata(op, perf::Env::get().tracyProgramMetadata);
     runCallback(debug::Hooks::get().getPreOperatorCallback(), executableHandle,
                 op, context.get());
     runOperation(op);

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -333,7 +333,8 @@ void registerRuntimeBindings(nb::module_ &m) {
       });
 
   nb::class_<tt::runtime::perf::Env>(m, "PerfEnv")
-      .def_static("get", &tt::runtime::perf::Env::get)
+      .def_static("get", &tt::runtime::perf::Env::get, nb::rv_policy::reference)
+      .def("set_program_metadata", &tt::runtime::perf::Env::setProgramMetadata)
       .def("__str__", [](const tt::runtime::perf::Env &env) {
         std::stringstream os;
         os << env;

--- a/runtime/tools/ttrt/ttrt/common/perf.py
+++ b/runtime/tools/ttrt/ttrt/common/perf.py
@@ -7,7 +7,6 @@ import json
 import importlib.machinery
 import sys
 import signal
-import os
 import io
 import subprocess
 import time
@@ -18,6 +17,7 @@ import atexit
 import traceback
 from pathlib import Path
 import csv
+import ast
 
 from ttrt.common.util import *
 from ttrt.common.query import Query
@@ -572,8 +572,11 @@ class Perf:
                     global_call_count_const_eval_op_mapping = get_mlir_analysis_results(
                         "MLIR_CONST_EVAL_OP"
                     )
+                    global_call_count_program_metadata_op_mapping = (
+                        get_mlir_analysis_results("MLIR_PROGRAM_METADATA")
+                    )
 
-                    # Add location data and const_eval_op op data to profiler csv file
+                    # Add location data, const_eval_op data and program metadata to profiler csv file
                     dir_name = os.path.dirname(profiler_csv_file_path)
                     base_name = os.path.basename(profiler_csv_file_path)
                     file_root, file_ext = os.path.splitext(base_name)
@@ -583,7 +586,11 @@ class Perf:
                         profiler_csv_file_path, mode="r", newline=""
                     ) as infile, open(temp_file, mode="w", newline="") as outfile:
                         reader = csv.DictReader(infile)
-                        fieldnames = reader.fieldnames + ["LOC", "CONST_EVAL_OP"]
+                        fieldnames = reader.fieldnames + [
+                            "LOC",
+                            "CONST_EVAL_OP",
+                            "PROGRAM_METADATA",
+                        ]
                         writer = csv.DictWriter(outfile, fieldnames=fieldnames)
                         writer.writeheader()
 
@@ -613,6 +620,19 @@ class Perf:
                             else:
                                 row["CONST_EVAL_OP"] = "false"
 
+                            # Append the program metadata column with its metadata
+                            if (
+                                local_call_count
+                                in global_call_count_program_metadata_op_mapping.keys()
+                            ):
+                                row[
+                                    "PROGRAM_METADATA"
+                                ] = global_call_count_program_metadata_op_mapping[
+                                    local_call_count
+                                ]
+                            else:
+                                row["PROGRAM_METADATA"] = "{}"
+
                             writer.writerow(row)
 
                     os.replace(temp_file, profiler_csv_file_path)
@@ -632,6 +652,97 @@ class Perf:
                             if result["result"] == "test_error":
                                 raise TTRTTestException(str(result["exception"]))
                             raise Exception(f'{result["exception"]}')
+
+                        if result["file_path"] == bin.file_path:
+                            # post-process statistics for ttnn host duration, device fw duration
+                            bin.program_results = result["program_results"]
+                            total_ttnn_api_duration_map = {}
+                            total_device_kernel_duration_map = {}
+
+                            with open(
+                                profiler_csv_file_path,
+                                mode="r",
+                                newline="",
+                                encoding="utf-8",
+                            ) as csvfile:
+                                reader = csv.DictReader(csvfile)
+
+                                for row in reader:
+                                    const_eval_op = bool(row.get("CONST_EVAL_OP"))
+                                    program_metadata = ast.literal_eval(
+                                        row.get("PROGRAM_METADATA")
+                                    )
+                                    device_kernel_duration = int(
+                                        row.get("DEVICE KERNEL DURATION [ns]")
+                                    )
+                                    ttnn_api_duration = int(
+                                        row.get("HOST DURATION [ns]")
+                                    )
+
+                                    if len(program_metadata) == 0:
+                                        continue
+
+                                    program_index = program_metadata["program_index"]
+                                    loop_number = program_metadata["loop_number"]
+
+                                    if (
+                                        program_index
+                                        not in total_ttnn_api_duration_map.keys()
+                                    ):
+                                        total_ttnn_api_duration_map[program_index] = {}
+
+                                    if (
+                                        program_index
+                                        not in total_device_kernel_duration_map.keys()
+                                    ):
+                                        total_device_kernel_duration_map[
+                                            program_index
+                                        ] = {}
+
+                                    if (
+                                        loop_number
+                                        not in total_ttnn_api_duration_map[
+                                            program_index
+                                        ].keys()
+                                    ):
+                                        total_ttnn_api_duration_map[program_index][
+                                            loop_number
+                                        ] = 0
+
+                                    if (
+                                        loop_number
+                                        not in total_device_kernel_duration_map[
+                                            program_index
+                                        ].keys()
+                                    ):
+                                        total_device_kernel_duration_map[program_index][
+                                            loop_number
+                                        ] = 0
+
+                                    total_device_kernel_duration_map[program_index][
+                                        loop_number
+                                    ] += device_kernel_duration
+                                    total_ttnn_api_duration_map[program_index][
+                                        loop_number
+                                    ] += ttnn_api_duration
+
+                            for (
+                                program_index,
+                                loop_dic,
+                            ) in total_ttnn_api_duration_map.items():
+                                for loop_number, duration in loop_dic.items():
+                                    bin.update_total_ttnn_api_duration_ns(
+                                        program_index, loop_number, duration
+                                    )
+
+                            for (
+                                program_index,
+                                loop_dic,
+                            ) in total_device_kernel_duration_map.items():
+                                for loop_number, duration in loop_dic.items():
+                                    bin.update_total_device_kernel_duration_ns(
+                                        program_index, loop_number, duration
+                                    )
 
                 except Exception as e:
                     result = "error"
@@ -675,6 +786,7 @@ class Perf:
                     "log_file": self.logger.file_name,
                     "artifacts": self.artifacts.artifacts_folder_path,
                     "program_index": self["--program-index"],
+                    "program_results": bin.program_results,
                 }
                 self.results.add_result(test_result)
                 self.logging.info(f"PASS: test case={bin.file_path}")
@@ -690,6 +802,7 @@ class Perf:
                     "log_file": self.logger.file_name,
                     "artifacts": self.artifacts.artifacts_folder_path,
                     "program_index": self["--program-index"],
+                    "program_results": bin.program_results,
                 }
                 self.results.add_result(test_result)
                 self.logging.info(f"PASS: test case={bin.file_path}")

--- a/runtime/tools/ttrt/ttrt/common/run.py
+++ b/runtime/tools/ttrt/ttrt/common/run.py
@@ -309,13 +309,6 @@ class Run:
             choices=None,
             help="Random ones vs zeroes density, 1 = 100% ones, 2 = 50% ones, 3 = 33% ones, etc.",
         )
-        Run.register_arg(
-            name="--benchmark",
-            type=bool,
-            default=False,
-            choices=[True, False],
-            help="Enable benchmark mode with warmup and e2e time measurements. Only one program is executed, specified by --program-index. If --program-index is set to 'all', the first program is used. (automatically enables program cache and disables golden comparison)",
-        )
 
     def __init__(self, args={}, logger=None, artifacts=None):
         for name, attributes in Run.registered_args.items():
@@ -532,9 +525,15 @@ class Run:
                 not self["--disable-trace-implicit-from-device"],
             )
             self.logging.debug(f"setting tt runtime workaround env={workaround_env}")
+            tracy_program_metadata = {
+                "disable_eth_dispatch": self["--disable-eth-dispatch"],
+                "enable_program_cache": self["--enable-program-cache"],
+                "dump_device_rate": self["--dump-device-rate"],
+            }
             perf_env = ttrt.runtime.PerfEnv.get(
                 self["--dump-device-rate"],
                 self["--enable-perf-trace"],
+                str(tracy_program_metadata),
             )
             self.logging.debug(f"setting tt runtime perf env={perf_env}")
             self.logging.debug(f"setting torch manual seed={self['--seed']}")
@@ -549,14 +548,6 @@ class Run:
 
             if "--init" in sys.argv:
                 self["--disable-golden"] = True
-
-            if self["--benchmark"]:
-                self["--enable-program-cache"] = True
-                self["--disable-golden"] = True
-
-                # In benchmark mode, only execute one program.
-                if self["--program-index"] == "all":
-                    self["--program-index"] = 0
 
             num_devices = len(self.query.device_ids)
             mesh_options = ttrt.runtime.MeshDeviceOptions()
@@ -758,20 +749,19 @@ class Run:
                             device, inputs, bin.fbb, program_index
                         )
 
-                        if self["--benchmark"]:
-                            self.logging.info("Warming up device.")
-                            ttrt.runtime.submit(
-                                device,
-                                bin.fbb,
-                                program_index,
-                                inputs,
-                            )
-
-                        start_loop = time.perf_counter()
                         for loop in range(self["--loops"]):
                             self.logging.debug(
                                 f"starting loop={loop+1}/{self['--loops']} for binary={bin.file_path}"
                             )
+                            tracy_program_metadata = {
+                                "loop_number": loop,
+                                "program_index": program_index,
+                                "disable_eth_dispatch": self["--disable-eth-dispatch"],
+                                "enable_program_cache": self["--enable-program-cache"],
+                                "dump_device_rate": self["--dump-device-rate"],
+                            }
+                            perf_env.set_program_metadata(str(tracy_program_metadata))
+
                             # Check if we need to dirty any input tensors in this iteration
                             if loop in update_tensor_schedule:
                                 for input_idx in update_tensor_schedule[loop]:
@@ -797,7 +787,7 @@ class Run:
                                             f"Cannot dirty input tensor {input_idx}, only {len(inputs)} inputs available"
                                         )
 
-                            start = time.perf_counter()
+                            start = time.perf_counter_ns()
                             runtime_outputs = ttrt.runtime.submit(
                                 device,
                                 bin.fbb,
@@ -806,6 +796,12 @@ class Run:
                             )
 
                             ttrt.runtime.wait(runtime_outputs)
+                            end = time.perf_counter_ns()
+                            e2e_duration_nanoseconds = end - start
+                            bin.add_program_results(
+                                program_index, loop, e2e_duration_nanoseconds
+                            )
+
                             for i, runtime_output_tensor in enumerate(runtime_outputs):
                                 output_host = ttrt.runtime.to_host(
                                     runtime_output_tensor, untilize=True
@@ -953,27 +949,6 @@ class Run:
 
                             self.logging.debug(
                                 f"finished loop={loop+1}/{self['--loops']} for binary={bin.file_path}"
-                            )
-
-                        end = time.perf_counter()
-                        if self["--benchmark"]:
-                            bin.e2e_duration_milliseconds_all_loops = (
-                                end - start_loop
-                            ) * 1000
-                            bin.e2e_duration_milliseconds = (end - start) * 1000
-                            batch_size = inputs[0].get_shape()[0]
-                            samples_per_second = (
-                                batch_size / bin.e2e_duration_milliseconds * 1000
-                            )
-                            self.logging.info(
-                                f"Total execution time over {self['--loops']} loops: {bin.e2e_duration_milliseconds_all_loops} ms"
-                            )
-                            self.logging.info(
-                                f"Execution time last loop: {bin.e2e_duration_milliseconds} ms"
-                            )
-                            self.logging.info(f"Batch size: {batch_size}")
-                            self.logging.info(
-                                f"Samples per second: {samples_per_second}"
                             )
 
                         if event is not None:
@@ -1132,7 +1107,7 @@ class Run:
                     "log_file": self.logger.file_name,
                     "artifacts": self.artifacts.artifacts_folder_path,
                     "program_index": self["--program-index"],
-                    "e2e_duration_milliseconds": bin.e2e_duration_milliseconds,
+                    "program_results": bin.program_results,
                 }
                 self.results.add_result(test_result)
                 self.logging.info(f"PASS: test case={bin.file_path}")
@@ -1148,7 +1123,7 @@ class Run:
                     "log_file": self.logger.file_name,
                     "artifacts": self.artifacts.artifacts_folder_path,
                     "program_index": self["--program-index"],
-                    "e2e_duration_milliseconds": bin.e2e_duration_milliseconds,
+                    "program_results": bin.program_results,
                 }
                 self.results.add_result(test_result)
                 self.logging.info(f"PASS: test case={bin.file_path}")

--- a/runtime/tools/ttrt/ttrt/common/util.py
+++ b/runtime/tools/ttrt/ttrt/common/util.py
@@ -685,7 +685,7 @@ class Binary(Flatbuffer):
         self.version = self.fbb.version
         self.program_indices = range(self.fbb.get_num_programs())
         self.programs = []
-        self.e2e_duration_milliseconds = 0
+        self.program_results = {}
 
         for i in self.program_indices:
             program = Binary.Program(i, self.fbb)
@@ -771,6 +771,46 @@ class Binary(Flatbuffer):
             pprint(p.fbb_to_dict())
 
         print()
+
+    def add_program_results(
+        self,
+        program_index,
+        loop,
+        total_duration_ns,
+        total_ttnn_api_duration_ns=None,
+        total_device_kernel_duration_ns=None,
+    ):
+        program_key = f"program_index_{program_index}"
+        if program_key not in self.program_results.keys():
+            self.program_results[program_key] = {}
+
+        loop_key = f"loop_{loop}"
+        if loop_key not in self.program_results[program_key].keys():
+            self.program_results[program_key][loop_key] = {}
+
+        self.program_results[program_key][loop_key][
+            "total_duration_ns"
+        ] = total_duration_ns
+        self.program_results[program_key][loop_key][
+            "total_ttnn_api_duration_ns"
+        ] = total_ttnn_api_duration_ns
+        self.program_results[program_key][loop_key][
+            "total_device_kernel_duration_ns"
+        ] = total_device_kernel_duration_ns
+
+    def update_total_ttnn_api_duration_ns(
+        self, program_index, loop, total_ttnn_api_duration_ns
+    ):
+        self.program_results[f"program_index_{program_index}"][f"loop_{loop}"][
+            "total_ttnn_api_duration_ns"
+        ] = total_ttnn_api_duration_ns
+
+    def update_total_device_kernel_duration_ns(
+        self, program_index, loop, total_device_kernel_duration_ns
+    ):
+        self.program_results[f"program_index_{program_index}"][f"loop_{loop}"][
+            "total_device_kernel_duration_ns"
+        ] = total_device_kernel_duration_ns
 
     class Program:
         def __init__(self, index, binary):


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/3706)

This PR adds support for insert custom metadata into the tracy profiler dumps from the compiler runtime. Different metadata can be inserted per op that is run, or program level metadata can be inserted for all ops.

eg.
```
"{'loop_number': 0, 'program_index': 0, 'disable_eth_dispatch': False, 'enable_program_cache': True, 'dump_device_rate': 1000}"
```

Also, this PR performs analysis on such results, to determine the host e2e duration, the TTNN api duration and the device fw duration. Results are dumped in run_results.json / perf_results.json file for whichever API is used.

eg.
```
"program_results": {
      "program_index_0": {
        "loop_0": {
          "total_duration_ns": 1620766460,
          "total_ttnn_api_duration_ns": 574167,
          "total_device_kernel_duration_ns": 8931
        },
        "loop_1": {
          "total_duration_ns": 1487854,
          "total_ttnn_api_duration_ns": 6820,
          "total_device_kernel_duration_ns": 3515
        }
      }
    }
```
