### PR TITLE
Fix ResNet OOM issue in `ttnn-standalone`

### DIFF
--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -1111,7 +1111,8 @@ public:
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
         emitter.emit<std::vector<int32_t>>(srcOp.getShape()),
-        emitter.emit(srcOp.getMemoryConfig()),
+        emitter.emit(srcOp.getMemoryConfig()) |
+            emitter.getMemoryConfig(srcOp.getResult()),
     };
 
     emitter.replaceOp(*this, args);


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/3828

### Problem description
Running ResNet through `ttnn-standalone` one would get an OOM issue. Root cause of the issue is the way the `conv2d` is dealt with in generated code
```cpp
std::variant<Tensor,...> v = conv2d(...);
Tensor t = std::get<0>(v);
...
deallocate(t);
```
IR assumes that there is only one reference to `t` before `deallocate`, and once `deallocate` is executed there won't be any references, so the buffer which tensor held will be freed. But since `variant` 'beneath' still holds the reference to the same tensor, actual refcount was 2, so it only gets decremented to 1, and buffer still lives, so after some time there isn't any space left on the device.

### What's changed
- Inlined the result `ttnn::conv2d` inside `std::get`, so it's rvalue refrence and the refcount at the end of the statement is correctly 1
- Memory config of the `ReshapeOp` wasn't handled well, this is one line fix that I included in this PR to reduce the load on CI

### Checklist
- [ ] New/Existing tests provide coverage for changes
