### PR TITLE
D2M: Add support for multicore host read/write txs

### DIFF
--- a/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.td
+++ b/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.td
@@ -353,6 +353,14 @@ def TTCore_MetalLayoutAttr : TTCore_Attr<"MetalLayout", "metal_layout", [TTCore_
         DenseIntElementsAttr collapseIntervals,
         ArrayRef<int64_t> dimAlignments);
 
+    // Returns gridShape eltwise-mul shardShape
+    static llvm::SmallVector<int64_t> getUnshardedShape(ArrayRef<int64_t> gridShape, ArrayRef<int64_t> shardShape) {
+      llvm::SmallVector<int64_t> unshardedShape;
+      unshardedShape.resize(gridShape.size());
+      std::transform(gridShape.begin(), gridShape.end(), shardShape.begin(), unshardedShape.begin(), std::multiplies<int64_t>());
+      return unshardedShape;
+    }
+
     // Get the corresponding memref type (essentially just drops grid dimensions).
     static MemRefType getMemRefType(RankedTensorType tensorType);
 

--- a/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.td
+++ b/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.td
@@ -338,7 +338,7 @@ def TTCore_MetalLayoutAttr : TTCore_Attr<"MetalLayout", "metal_layout", [TTCore_
   let assemblyFormat = "`<` `logical_shape` `=` custom<DimensionList>($logical_shape) `,` `dim_alignments` `=` custom<DimensionList>($dim_alignments) `,` `collapsed_intervals` `=` $collapsed_intervals `,` $oob_val (`,` $memory_space^)? `>`";
 
   let extraClassDeclaration = [{
-    static  MetalLayoutAttr get(::mlir::MLIRContext *context,
+    static MetalLayoutAttr get(::mlir::MLIRContext *context,
                                      ArrayRef<int64_t> logicalShape,
                                      uint64_t deviceGridRank,
                                      OOBVal oobVal, MemorySpace memorySpace,
@@ -354,12 +354,7 @@ def TTCore_MetalLayoutAttr : TTCore_Attr<"MetalLayout", "metal_layout", [TTCore_
         ArrayRef<int64_t> dimAlignments);
 
     // Returns gridShape eltwise-mul shardShape
-    static llvm::SmallVector<int64_t> getUnshardedShape(ArrayRef<int64_t> gridShape, ArrayRef<int64_t> shardShape) {
-      llvm::SmallVector<int64_t> unshardedShape;
-      unshardedShape.resize(gridShape.size());
-      std::transform(gridShape.begin(), gridShape.end(), shardShape.begin(), unshardedShape.begin(), std::multiplies<int64_t>());
-      return unshardedShape;
-    }
+    static llvm::SmallVector<int64_t> getUnshardedShape(ArrayRef<int64_t> gridShape, ArrayRef<int64_t> shardShape);
 
     // Get the corresponding memref type (essentially just drops grid dimensions).
     static MemRefType getMemRefType(RankedTensorType tensorType);

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -354,6 +354,22 @@ def TTIR_ViewLayoutOp : TTIR_Op<"view_layout",
 
     let hasVerifier = 1;
     let hasFolder = 1;
+
+    let builders =
+    [
+      OpBuilder<(ins "Value": $input, "AffineMap": $view, CArg<"bool", "false">: $reinterpretLayout),
+      [{
+        auto outputShape = view.compose(input.getType().getShape());
+        auto outputType = ShapedType(outputShape, ..., ViewLayoutAttribute(view));
+        build($_builder, $_state, outputType, input, reinterpretLayout);
+      }]>,
+      OpBuilder<(ins "Value": $input, "ArrayRef<int64_t>": $reblockedShape, CArg<"bool", "false">: $reinterpretLayout),
+      [{
+        auto view = inlineReblockViewWorkaroundHere(input.getType().getShape(), reblockedShape);
+        auto outputType = ShapedType(outputShape, ..., ViewLayoutAttribute(view));
+        build($_builder, $_state, outputType, input, reinterpretLayout);
+      }]>,
+    ];
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -354,22 +354,6 @@ def TTIR_ViewLayoutOp : TTIR_Op<"view_layout",
 
     let hasVerifier = 1;
     let hasFolder = 1;
-
-    let builders =
-    [
-      OpBuilder<(ins "Value": $input, "AffineMap": $view, CArg<"bool", "false">: $reinterpretLayout),
-      [{
-        auto outputShape = view.compose(input.getType().getShape());
-        auto outputType = ShapedType(outputShape, ..., ViewLayoutAttribute(view));
-        build($_builder, $_state, outputType, input, reinterpretLayout);
-      }]>,
-      OpBuilder<(ins "Value": $input, "ArrayRef<int64_t>": $reblockedShape, CArg<"bool", "false">: $reinterpretLayout),
-      [{
-        auto view = inlineReblockViewWorkaroundHere(input.getType().getShape(), reblockedShape);
-        auto outputType = ShapedType(outputShape, ..., ViewLayoutAttribute(view));
-        build($_builder, $_state, outputType, input, reinterpretLayout);
-      }]>,
-    ];
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
+++ b/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
@@ -19,6 +19,7 @@
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Casting.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <fstream>
 #include <numeric>
@@ -833,6 +834,16 @@ llvm::SmallVector<int64_t> MetalLayoutAttr::derivePhysicalShape(
   }
 
   return physicalShape;
+}
+
+llvm::SmallVector<int64_t>
+MetalLayoutAttr::getUnshardedShape(llvm::ArrayRef<int64_t> gridShape,
+                                   llvm::ArrayRef<int64_t> shardShape) {
+  assert(gridShape.size() == shardShape.size());
+  llvm::SmallVector<int64_t> unshardedShape(gridShape.size());
+  std::transform(gridShape.begin(), gridShape.end(), shardShape.begin(),
+                 unshardedShape.begin(), std::multiplies<int64_t>());
+  return unshardedShape;
 }
 
 static llvm::SmallVector<int64_t>

--- a/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
+++ b/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
@@ -836,11 +836,16 @@ llvm::SmallVector<int64_t> MetalLayoutAttr::derivePhysicalShape(
   return physicalShape;
 }
 
+// Returns gridShape multiplied with shard shape, elementwise.
+// eg. gridShape = [2, 3], shardShape = [6, 4] -> [12, 12]
 llvm::SmallVector<int64_t>
 MetalLayoutAttr::getUnshardedShape(llvm::ArrayRef<int64_t> gridShape,
                                    llvm::ArrayRef<int64_t> shardShape) {
   assert(gridShape.size() == shardShape.size());
+  // Initialize empty unsharded shape vector
   llvm::SmallVector<int64_t> unshardedShape(gridShape.size());
+  // Use std::transform to multiply each element of gridShape with corresponding
+  // element of shardShape, and store in unshardedShape.
   std::transform(gridShape.begin(), gridShape.end(), shardShape.begin(),
                  unshardedShape.begin(), std::multiplies<int64_t>());
   return unshardedShape;

--- a/lib/Dialect/TTIR/Transforms/LowerToLayout.cpp
+++ b/lib/Dialect/TTIR/Transforms/LowerToLayout.cpp
@@ -237,11 +237,9 @@ public:
     // First prioritize moving the data into L1 so we can work with it in L1
     if (!inputL1) {
       // Read into L1, then do other conversions.
-      // If we're going from no grid -> grid, we need to use the output grid
-      // size (1s filled).
+      // If we're going from no grid -> grid, we need to use the output grid.
       if (!hasInputLayout && hasOutputLayout) {
-        auto gridShape = llvm::SmallVector<int64_t>(
-            outputLayout.getGridShape(outputType).size(), 1);
+        auto gridShape = outputLayout.getGridShape(outputType);
         auto bounceType =
             createModifiedType(rewriter.getContext(), inputType, inputLayout,
                                MemorySpace::DeviceL1, gridShape);
@@ -258,10 +256,9 @@ public:
       assert(inputL1 && "input should guaranteed be in L1 because of the "
                         "previous case");
       // Conversely, if we're going from grid -> no grid, we need to use the
-      // input grid size (1s filled).
+      // input grid.
       if (!hasOutputLayout && hasInputLayout) {
-        auto gridShape = llvm::SmallVector<int64_t>(
-            inputLayout.getGridShape(inputType).size(), 1);
+        auto gridShape = inputLayout.getGridShape(inputType);
         auto bounceType =
             createModifiedType(rewriter.getContext(), outputType, outputLayout,
                                MemorySpace::DeviceL1, gridShape);

--- a/lib/Dialect/TTIR/Transforms/OptimizeTensorLayout.cpp
+++ b/lib/Dialect/TTIR/Transforms/OptimizeTensorLayout.cpp
@@ -269,7 +269,6 @@ struct TTIRHostTxsRewriter : public OpRewritePattern<ToLayoutOp> {
 public:
   LogicalResult matchAndRewrite(ToLayoutOp op,
                                 PatternRewriter &rewriter) const override {
-
     if (op->hasAttr("ttir.layout_optimized")) {
       return failure();
     }
@@ -308,6 +307,7 @@ public:
 };
 } // namespace
 
+namespace {
 class TTIROptimizeTensorLayout
     : public impl::TTIROptimizeTensorLayoutBase<TTIROptimizeTensorLayout> {
 
@@ -348,5 +348,6 @@ class TTIROptimizeTensorLayout
     registry.insert<mlir::tt::TTCoreDialect>();
   }
 };
+} // namespace
 
 } // namespace mlir::tt::ttir

--- a/lib/Dialect/TTIR/Transforms/OptimizeTensorLayout.cpp
+++ b/lib/Dialect/TTIR/Transforms/OptimizeTensorLayout.cpp
@@ -296,6 +296,48 @@ struct TTIRMemrefLayoutRewriter : public OpRewritePattern<ttir::GenericOp> {
 } // namespace
 
 namespace {
+struct TTIRHostTxsRewriter : public OpRewritePattern<ToLayoutOp> {
+  TTIRHostTxsRewriter(MLIRContext *context,
+                      SmallVector<int64_t> workerGridShape)
+      : OpRewritePattern<ToLayoutOp>(context),
+        workerGridShape(workerGridShape) {}
+
+public:
+  LogicalResult matchAndRewrite(ToLayoutOp op,
+                                PatternRewriter &rewriter) const override {
+
+    auto inputTy = mlir::cast<RankedTensorType>(op.getInput().getType());
+    auto outputTy = mlir::cast<RankedTensorType>(op.getOutput().getType());
+    tt::MetalLayoutAttr inputMemoryLayout =
+        mlir::dyn_cast_if_present<tt::MetalLayoutAttr>(inputTy.getEncoding());
+    tt::MetalLayoutAttr outputMemoryLayout =
+        mlir::dyn_cast_if_present<tt::MetalLayoutAttr>(outputTy.getEncoding());
+    if (inputMemoryLayout && outputMemoryLayout) {
+      // Not a host tx
+      return failure();
+    }
+
+    auto deviceTensor = inputMemoryLayout ? op.getInput() : op.getOutput();
+    auto optimalDeviceLayout = calculateOptimalLayoutForTensorType(
+        rewriter, deviceTensor, workerGridShape);
+    if (deviceTensor.getType() == optimalDeviceLayout) {
+      return failure();
+    }
+
+    // Update device tensor type
+    rewriter.modifyOpInPlace(
+        op, [&]() { deviceTensor.setType(optimalDeviceLayout); });
+    if (outputMemoryLayout) {
+      rewriter.modifyOpInPlace(
+          op, [&]() { op->getResult(0).setType(optimalDeviceLayout); });
+    }
+    return success();
+  }
+
+  SmallVector<int64_t> workerGridShape;
+};
+} // namespace
+
 class TTIROptimizeTensorLayout
     : public impl::TTIROptimizeTensorLayoutBase<TTIROptimizeTensorLayout> {
 
@@ -324,6 +366,7 @@ class TTIROptimizeTensorLayout
     RewritePatternSet patterns(&getContext());
     patterns.add<TTIRGenericTensorLayoutRewriter>(
         &getContext(), workerGridShape, dstRegisterSizeTiles);
+    patterns.add<TTIRHostTxsRewriter>(&getContext(), workerGridShape);
     if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       signalPassFailure();
       return;
@@ -335,6 +378,5 @@ class TTIROptimizeTensorLayout
     registry.insert<mlir::tt::TTCoreDialect>();
   }
 };
-} // namespace
 
 } // namespace mlir::tt::ttir

--- a/lib/Dialect/TTIR/Transforms/OptimizeTensorLayout.cpp
+++ b/lib/Dialect/TTIR/Transforms/OptimizeTensorLayout.cpp
@@ -288,12 +288,12 @@ public:
     }
 
     // Update device tensor type
-    rewriter.modifyOpInPlace(
-        op, [&]() { deviceTensor.setType(optimalDeviceLayout); });
-    if (outputMemoryLayout) {
-      rewriter.modifyOpInPlace(
-          op, [&]() { op->getResult(0).setType(optimalDeviceLayout); });
-    }
+    rewriter.modifyOpInPlace(op, [&]() {
+      deviceTensor.setType(optimalDeviceLayout);
+      if (outputMemoryLayout) {
+        op->getResult(0).setType(optimalDeviceLayout);
+      }
+    });
     return success();
   }
 

--- a/test/ttmlir/Dialect/TTIR/lower_to_layout.mlir
+++ b/test/ttmlir/Dialect/TTIR/lower_to_layout.mlir
@@ -1,69 +1,107 @@
 // RUN: ttmlir-opt --ttcore-register-device --ttir-lower-to-layout %s | FileCheck %s
 
-#l1_ = #ttcore.memory_space<l1>
-#layout = #ttcore.metal_layout<logical_shape = 256x768, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, l1>
-#layout1 = #ttcore.metal_layout<logical_shape = 256x768, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, l1>
+#layout = #ttcore.metal_layout<logical_shape = 1024x1024, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, l1>
 #layout2 = #ttcore.metal_layout<logical_shape = 256x768, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, l1>
-func.func @to_device(%arg0: tensor<256x768xf32>) -> tensor<1x1x256x768xf32, #layout> {
-  %0 = ttir.empty() : tensor<1x1x256x768xf32, #layout>
-  // CHECK: ttir.to_layout %arg0, %0 : tensor<256x768xf32> into tensor<1x1x256x768xf32, #layout> hostInfo = #layout -> tensor<1x1x256x768xf32, #layout>
-  %1 = ttir.to_layout %arg0, %0 : tensor<256x768xf32> into tensor<1x1x256x768xf32, #layout> -> tensor<1x1x256x768xf32, #layout>
-  return %1 : tensor<1x1x256x768xf32, #layout>
-}
 
-func.func @from_device(%arg0: tensor<1x1x256x768xf32, #layout>) -> tensor<256x768xf32> {
-  %0 = ttir.empty() : tensor<256x768xf32>
-  // CHECK: ttir.to_layout %arg0, %0 : tensor<1x1x256x768xf32, #layout> into tensor<256x768xf32> hostInfo = #layout -> tensor<256x768xf32>
-  %1 = ttir.to_layout %arg0, %0 : tensor<1x1x256x768xf32, #layout> into tensor<256x768xf32> -> tensor<256x768xf32>
-  return %1 : tensor<256x768xf32>
-}
+// Test that verifies the NEW behavior: distribute to 8x8 grid first, then tilize
+func.func @tilize(%arg0: tensor<1024x1024xf32>) -> tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout> {
+  %0 = ttir.empty() : tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout>
 
-func.func @tilize(%arg0: tensor<1x1x256x768xf32, #layout>) -> tensor<1x1x8x24x!ttcore.tile<32x32, f32>, #layout1> {
-  %0 = ttir.empty() : tensor<1x1x8x24x!ttcore.tile<32x32, f32>, #layout1>
-  // CHECK: ttir.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>
+  // CHECK-LABEL: @tilize
+  // Verify the operation creates intermediate 8x8 distributed tensor
+  // CHECK: %[[TILED:.*]] = ttir.empty() : tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout>
+  // CHECK: %[[INTERMEDIATE:.*]] = ttir.empty() : tensor<8x8x128x128xf32, #layout>
+  // CHECK: %[[TO_DEVICE:.*]] = ttir.to_layout %arg0, %[[INTERMEDIATE]] : tensor<1024x1024xf32> into tensor<8x8x128x128xf32, #layout>
+  // CHECK: %[[RESULT:.*]] = ttir.generic {block_factors = [1, 1], grid = #ttcore.grid<8x8>
+  // CHECK-SAME: threads = [#ttir.thread<compute>]
+  // CHECK-NEXT: ins(%[[TO_DEVICE]] : tensor<8x8x128x128xf32, #layout>)
+  // CHECK-NEXT: outs(%[[TILED]] : tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout>)
   // CHECK: ttir.tile_tilize_block
-  %1 = ttir.to_layout %arg0, %0 : tensor<1x1x256x768xf32, #layout> into tensor<1x1x8x24x!ttcore.tile<32x32, f32>, #layout1> -> tensor<1x1x8x24x!ttcore.tile<32x32, f32>, #layout1>
-  return %1 : tensor<1x1x8x24x!ttcore.tile<32x32, f32>, #layout1>
+  // CHECK-NOT: ttir.view_layout
+  // CHECK-NOT: threads = [#ttir.thread<datamovement>]
+
+  %1 = ttir.to_layout %arg0, %0 : tensor<1024x1024xf32> into tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout>
+    -> tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout>
+
+  return %1 : tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout>
 }
 
-func.func @untilize(%arg0: tensor<1x1x8x24x!ttcore.tile<32x32, f32>, #layout1>) -> tensor<1x1x256x768xf32, #layout> {
-  %0 = ttir.empty() : tensor<1x1x256x768xf32, #layout>
-  // CHECK: ttir.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>
-  // CHECK: ttir.tile_untilize_block
-  %1 = ttir.to_layout %arg0, %0 : tensor<1x1x8x24x!ttcore.tile<32x32, f32>, #layout1> into tensor<1x1x256x768xf32, #layout> -> tensor<1x1x256x768xf32, #layout>
-  return %1 : tensor<1x1x256x768xf32, #layout>
-}
-
-func.func @reblock(%arg0: tensor<1x1x8x24x!ttcore.tile<32x32, f32>, #layout1>) -> tensor<8x8x1x3x!ttcore.tile<32x32, f32>, #layout2> {
+// Test reblock operation - redistributing already tiled data
+func.func @reblock(%arg0: tensor<1x1x8x24x!ttcore.tile<32x32, f32>, #layout2>) -> tensor<8x8x1x3x!ttcore.tile<32x32, f32>, #layout2> {
   %0 = ttir.empty() : tensor<8x8x1x3x!ttcore.tile<32x32, f32>, #layout2>
+
+  // CHECK-LABEL: @reblock
+  // Reblocking should use view_layout and datamovement threads since it's just redistributing already tiled data
+  // CHECK: ttir.view_layout %arg0 : tensor<1x1x8x24x!ttcore.tile<32x32, f32>, #layout{{[0-9]*}}> -> tensor<8x8x1x3x!ttcore.tile<32x32, f32>, #layout{{[0-9]*}}>
   // CHECK: ttir.generic {block_factors = [1, 1], grid = #ttcore.grid<8x8>
-  // CHECK: ^datamovement0
-  %1 = ttir.to_layout %arg0, %0 : tensor<1x1x8x24x!ttcore.tile<32x32, f32>, #layout1> into tensor<8x8x1x3x!ttcore.tile<32x32, f32>, #layout2> -> tensor<8x8x1x3x!ttcore.tile<32x32, f32>, #layout2>
+  // CHECK-SAME: threads = [#ttir.thread<datamovement>]
+
+  %1 = ttir.to_layout %arg0, %0 : tensor<1x1x8x24x!ttcore.tile<32x32, f32>, #layout2> into tensor<8x8x1x3x!ttcore.tile<32x32, f32>, #layout2>
+    -> tensor<8x8x1x3x!ttcore.tile<32x32, f32>, #layout2>
+
   return %1 : tensor<8x8x1x3x!ttcore.tile<32x32, f32>, #layout2>
 }
 
+// Test untilize with 8x8 distribution
+func.func @untilize(%arg0: tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout>) -> tensor<1024x1024xf32> {
+  %0 = ttir.empty() : tensor<1024x1024xf32>
+
+  // CHECK-LABEL: @untilize
+  // CHECK: %[[HOST:.*]] = ttir.empty() : tensor<1024x1024xf32>
+  // CHECK: %[[INTERMEDIATE:.*]] = ttir.empty() : tensor<8x8x128x128xf32, #layout>
+  // CHECK: %[[UNTILIZED:.*]] = ttir.generic {block_factors = [1, 1], grid = #ttcore.grid<8x8>
+  // CHECK-SAME: threads = [#ttir.thread<compute>]
+  // CHECK: ttir.tile_untilize_block
+  // CHECK: ttir.to_layout %[[UNTILIZED]], %[[HOST]] : tensor<8x8x128x128xf32, #layout> into tensor<1024x1024xf32>
+
+  %1 = ttir.to_layout %arg0, %0 : tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout> into tensor<1024x1024xf32>
+    -> tensor<1024x1024xf32>
+
+  return %1 : tensor<1024x1024xf32>
+}
+
+// Test compound operation with 8x8 distribution
 func.func @compound(%arg0: tensor<256x768xf32>) -> tensor<256x768xf32> {
   %0 = ttir.empty() : tensor<8x8x1x3x!ttcore.tile<32x32, f32>, #layout2>
   %1 = ttir.empty() : tensor<256x768xf32>
-  // to_device
-  // CHECK: ttir.to_layout {{.*}} : tensor<256x768xf32> into tensor<1x1x256x768xf32, [[device:#layout[0-9]*]]>
-  // tilize
-  // CHECK: ttir.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>
-  // CHECK-NEXT: ins(%{{.*}} : tensor<1x1x256x768xf32, [[device]]>)
-  // CHECK-NEXT: outs(%{{.*}} : tensor<1x1x8x24x!ttcore.tile<32x32, f32>, [[tiled:#layout[0-9]*]]>)
-  // reblock
-  // CHECK: ttir.view_layout %{{.*}}: tensor<1x1x8x24x!ttcore.tile<32x32, f32>, [[tiled]]> -> tensor<8x8x1x3x!ttcore.tile<32x32, f32>, [[reblocked:#layout[0-9]*]]>
-  // CHECK-NEXT: ttir.generic {block_factors = [1, 1], grid = #ttcore.grid<8x8>
-  %2 = ttir.to_layout %arg0, %0 : tensor<256x768xf32> into tensor<8x8x1x3x!ttcore.tile<32x32, f32>, #layout2> -> tensor<8x8x1x3x!ttcore.tile<32x32, f32>, #layout2>
-  // undo reblock
-  // CHECK: ttir.view_layout %{{.*}} : tensor<8x8x1x3x!ttcore.tile<32x32, f32>, [[reblocked]]> -> tensor<1x1x8x24x!ttcore.tile<32x32, f32>, [[tiled]]>
-  // CHECK-NEXT: ttir.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>
-  // untilize
-  // CHECK: ttir.generic {block_factors = [1, 1], grid = #ttcore.grid<1x1>
-  // CHECK-NEXT: ins(%{{.*}} : tensor<1x1x8x24x!ttcore.tile<32x32, f32>, [[tiled]]>)
-  // CHECK-NEXT: outs(%{{.*}} : tensor<1x1x256x768xf32, [[device]]>)
-  // to_host
-  // CHECK: ttir.to_layout {{.*}} : tensor<1x1x256x768xf32, [[device]]> into tensor<256x768xf32>
-  %3 = ttir.to_layout %2, %1 : tensor<8x8x1x3x!ttcore.tile<32x32, f32>, #layout2> into tensor<256x768xf32> -> tensor<256x768xf32>
+
+  // CHECK-LABEL: @compound
+  // CHECK: ttir.empty() : tensor<8x8x32x96xf32, #layout{{[0-9]*}}>
+  // CHECK: ttir.to_layout %arg0, %{{.*}} : tensor<256x768xf32> into tensor<8x8x32x96xf32, #layout{{[0-9]*}}>
+  // CHECK: ttir.generic {{{.*}}grid = #ttcore.grid<8x8>{{.*}}threads = [#ttir.thread<compute>]
+  // CHECK: ttir.tile_tilize_block
+  // CHECK: ttir.generic {{{.*}}grid = #ttcore.grid<8x8>{{.*}}threads = [#ttir.thread<compute>]
+  // CHECK: ttir.tile_untilize_block
+  // CHECK: ttir.to_layout %{{.*}} : tensor<8x8x32x96xf32, #layout{{[0-9]*}}> into tensor<256x768xf32>
+
+  %2 = ttir.to_layout %arg0, %0 : tensor<256x768xf32> into tensor<8x8x1x3x!ttcore.tile<32x32, f32>, #layout2>
+    -> tensor<8x8x1x3x!ttcore.tile<32x32, f32>, #layout2>
+
+  %3 = ttir.to_layout %2, %1 : tensor<8x8x1x3x!ttcore.tile<32x32, f32>, #layout2> into tensor<256x768xf32>
+    -> tensor<256x768xf32>
+
   return %3 : tensor<256x768xf32>
+}
+
+// Test case showing what the OLD behavior would look like (for documentation purposes)
+// This is what we're moving AWAY from
+func.func @old_behavior_example(%arg0: tensor<1024x1024xf32>) -> tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout> {
+  %0 = ttir.empty() : tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout>
+
+  // CHECK-LABEL: @old_behavior_example
+  // The OLD behavior that we DON'T want would have:
+  // 1. Move to 1x1 core: tensor<1024x1024xf32> -> tensor<1x1x1024x1024xf32>
+  // 2. Tilize on 1x1: tensor<1x1x1024x1024xf32> -> tensor<1x1x32x32x!ttcore.tile<32x32, f32>>
+  // 3. View as 8x8: tensor<1x1x32x32x!ttcore.tile<32x32, f32>> -> tensor<8x8x4x4x!ttcore.tile<32x32, f32>>
+  // 4. Distribute with datamovement threads
+
+  // But the new implementation should produce the same output as distributed_tilize:
+  // CHECK: ttir.empty() : tensor<8x8x128x128xf32, #layout>
+  // CHECK: ttir.to_layout %arg0, %{{.*}} : tensor<1024x1024xf32> into tensor<8x8x128x128xf32, #layout>
+  // CHECK: ttir.generic {{{.*}}grid = #ttcore.grid<8x8>{{.*}}threads = [#ttir.thread<compute>]
+
+  %1 = ttir.to_layout %arg0, %0 : tensor<1024x1024xf32> into tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout>
+    -> tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout>
+
+  return %1 : tensor<8x8x4x4x!ttcore.tile<32x32, f32>, #layout>
 }


### PR DESCRIPTION
### Problem description
Currently we are limited on tensor size because we split all grid change and memory space change tolayouts into individual steps. 

### What's changed
This enables read/writes directly to/from host that are multicore. i.e. keep the grid change and mem space change as one op, when the host is involved.

### Checklist
- [x] New/Existing tests provide coverage for changes
