### PR TITLE
Fix `select` builder test

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -3835,12 +3835,12 @@ def TTIR_SliceOp: TTIR_NamedOp<"slice"> {
     let hasVerifier = 1;
 }
 
-def TTIR_SelectOp: TTIR_NamedOp<"select"> {
+def TTIR_IndexSelectOp: TTIR_NamedOp<"index_select"> {
     let summary = "Tensor selection operation.";
     let description = [{
-      The `select` operation extracts a sub-tensor (slice) from the input tensor along a specified dimension.
+      The `index_select` operation extracts a sub-tensor (slice) from the input tensor along a specified dimension.
 
-      Unlike the more general `slice` operation, `select` operates on a single dimension with a specified
+      Unlike the more general `slice` operation, `index_select` operates on a single dimension with a specified
       starting index, length, and optional stride. This is useful for extracting specific segments of a tensor
       along a particular axis.
 
@@ -3849,7 +3849,7 @@ def TTIR_SelectOp: TTIR_NamedOp<"select"> {
       // Select elements 2, 3, 4 from a 1D tensor along dimension 0
       %input = ... : tensor<6xf32>  // Input tensor with values: [1, 2, 3, 4, 5, 6]
       %output = ttir.empty() : tensor<3xf32>  // Output tensor shape
-      %result = ttir.select(%input, %output) {
+      %result = ttir.index_select(%input, %output) {
           dim = 0 : i32,     // Dimension to select from
           begin = 2 : i32,   // Start index
           length = 3 : i32,  // Number of elements to select
@@ -3864,7 +3864,7 @@ def TTIR_SelectOp: TTIR_NamedOp<"select"> {
                                       //  [7, 8, 9],
                                       //  [10, 11, 12]]
       %output = ttir.empty() : tensor<2x3xf32>  // Output tensor shape
-      %result = ttir.select(%input, %output) {
+      %result = ttir.index_select(%input, %output) {
           dim = 0 : i32,     // Select along rows
           begin = 0 : i32,   // Start from the first row
           length = 2 : i32,  // Select 2 rows

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -1426,8 +1426,8 @@ public:
 };
 } // namespace
 
-// SelectOp is converted to a series of SliceOp and potentially a ConcatOp if
-// the sliced dimension is sliced multiple times. For example, if the input
+// IndexSelectOp is converted to a series of SliceOp and potentially a ConcatOp
+// if the sliced dimension is sliced multiple times. For example, if the input
 // tensor is
 //    [[[1, 2, 3],
 //      [4, 5, 6],
@@ -1442,8 +1442,8 @@ public:
 //      [31, 32, 33],
 //      [34, 35, 36]]],
 //    shape = [2, 6, 3]
-// and the SelectOp is dim=1, begin=0, length=2, stride=4, the output tensor
-// will be
+// and the IndexSelectOp is dim=1, begin=0, length=2, stride=4, the output
+// tensor will be
 //    [[[1, 2, 3],
 //      [4, 5, 6],
 //      [13, 14, 15],
@@ -1458,12 +1458,12 @@ public:
 // second slice has begins=[0, 4, 0], ends=[2, 6, 3], steps=[1, 1, 1].
 namespace {
 struct SelectToSliceConversionPattern
-    : public OpConversionPattern<ttir::SelectOp> {
+    : public OpConversionPattern<ttir::IndexSelectOp> {
 public:
-  using OpConversionPattern<ttir::SelectOp>::OpConversionPattern;
+  using OpConversionPattern<ttir::IndexSelectOp>::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(ttir::SelectOp op, OpAdaptor adaptor,
+  matchAndRewrite(ttir::IndexSelectOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
     auto inputType = mlir::cast<RankedTensorType>(adaptor.getInput().getType());

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecompositionPass.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecompositionPass.cpp
@@ -51,7 +51,7 @@ struct TTIRToTTIRDecompositionPass
     target.addIllegalOp<ttir::GetDimensionSizeOp>();
     target.addIllegalOp<ttir::PoolingOp>();
     target.addIllegalOp<ttir::GatherOp>();
-    target.addIllegalOp<ttir::SelectOp>();
+    target.addIllegalOp<ttir::IndexSelectOp>();
     target.addIllegalOp<ttir::DotGeneralOp>();
     target.addIllegalOp<ttir::ReduceAndOp>();
     target.addIllegalOp<ttir::ReduceOrOp>();

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -1581,11 +1581,11 @@ static mlir::OpFoldResult foldConsecutiveReshape(mlir::tt::ttir::ReshapeOp op) {
 // ANCHOR_END: decomposing_an_op_index_ttir_verify
 
 //===----------------------------------------------------------------------===//
-// SelectOp
+// IndexSelectOp
 //===----------------------------------------------------------------------===//
 
-// SelectOp verification
-::mlir::LogicalResult mlir::tt::ttir::SelectOp::verify() {
+// IndexSelectOp verification
+::mlir::LogicalResult mlir::tt::ttir::IndexSelectOp::verify() {
   ::mlir::RankedTensorType inputType = getInput().getType();
   ::mlir::RankedTensorType outputType = getOutput().getType();
 

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -969,15 +969,19 @@ def test_index(shape: Shape, dim: int, begin: int, end: int, step: int, request)
     )
 
 
-@pytest.mark.skip("`select` throwing floating point exception. See issue #2496")
 @pytest.mark.parametrize("shape", [(4, 4)])
-@pytest.mark.parametrize("dim,begin,length", [(1, 2, 2)])
-def test_select(shape: Shape, dim: int, begin: int, length: int, request):
+@pytest.mark.parametrize("dim,begin,length,stride", [(1, 2, 2, 2)])
+def test_select(shape: Shape, dim: int, begin: int, length: int, stride: int, request):
     def select(
         in0: Operand, builder: TTIRBuilder, unit_attrs: Optional[List[str]] = None
     ):
         return builder.select(
-            in0, dim=dim, begin=begin, length=length, unit_attrs=unit_attrs
+            in0,
+            dim=dim,
+            begin=begin,
+            length=length,
+            stride=stride,
+            unit_attrs=unit_attrs,
         )
 
     compile_to_flatbuffer(

--- a/test/ttmlir/Dialect/TTIR/Decomposition/select_decomposition_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/Decomposition/select_decomposition_tests.mlir
@@ -4,7 +4,7 @@ module attributes {} {
   func.func @select_identity(%arg0: tensor<4x4xf32>) -> tensor<4x4xf32> {
     %0 = ttir.empty() : tensor<4x4xf32>
     // CHECK: %{{[0-9]+}} = "ttir.slice"
-    %1 = "ttir.select"(%arg0, %0) <{dim = 1: si32, begin = 0: si32, length = 4: si32, stride = 4: si32}>  :
+    %1 = "ttir.index_select"(%arg0, %0) <{dim = 1: si32, begin = 0: si32, length = 4: si32, stride = 4: si32}>  :
         (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
     return %1 : tensor<4x4xf32>
   }
@@ -17,7 +17,7 @@ module attributes {} {
     // CHECK: %{{[0-9]+}} = "ttir.slice"
     // CHECK: %{{[0-9]+}} = "ttir.slice"
     // CHECK: %{{[0-9]+}} = "ttir.concat"
-    %1 = "ttir.select"(%arg0, %0) <{dim = -1: si32, begin = 0: si32, length = 4: si32, stride = 16: si32}>  :
+    %1 = "ttir.index_select"(%arg0, %0) <{dim = -1: si32, begin = 0: si32, length = 4: si32, stride = 16: si32}>  :
         (tensor<4x2x64x128xf32>, tensor<4x2x64x32xf32>) -> tensor<4x2x64x32xf32>
 
     return %1 : tensor<4x2x64x32xf32>

--- a/test/ttmlir/Dialect/TTIR/select/select_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/select/select_tests_negative.mlir
@@ -4,7 +4,7 @@ module attributes {} {
   func.func @select_negative_invalid_dim(%arg0: tensor<4x4xf32>) -> tensor<4x4xf32> {
     %0 = ttir.empty() : tensor<4x4xf32>
     // CHECK: {{.*error.*Invalid dimension}}
-    %1 = "ttir.select"(%arg0, %0) <{dim = -3: si32, begin = 0: si32, length = 4: si32, stride = 4: si32}>  :
+    %1 = "ttir.index_select"(%arg0, %0) <{dim = -3: si32, begin = 0: si32, length = 4: si32, stride = 4: si32}>  :
         (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
     return %1 : tensor<4x4xf32>
   }
@@ -16,7 +16,7 @@ module attributes {} {
   func.func @select_negative_invalid_stride(%arg0: tensor<4x4xf32>) -> tensor<4x4xf32> {
     %0 = ttir.empty() : tensor<4x4xf32>
     // CHECK: {{.*error.*Invalid stride.*}}
-    %1 = "ttir.select"(%arg0, %0) <{dim = 1: si32, begin = 0: si32, length = 4: si32, stride = 7: si32}>  :
+    %1 = "ttir.index_select"(%arg0, %0) <{dim = 1: si32, begin = 0: si32, length = 4: si32, stride = 7: si32}>  :
         (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
     return %1 : tensor<4x4xf32>
   }
@@ -28,7 +28,7 @@ module attributes {} {
   func.func @select_negative_invalid_stride_2(%arg0: tensor<4x4xf32>) -> tensor<4x4xf32> {
     %0 = ttir.empty() : tensor<4x4xf32>
     // CHECK: {{.*error.*Invalid stride.*}}
-    %1 = "ttir.select"(%arg0, %0) <{dim = 1: si32, begin = 0: si32, length = 4: si32, stride = -1: si32}>  :
+    %1 = "ttir.index_select"(%arg0, %0) <{dim = 1: si32, begin = 0: si32, length = 4: si32, stride = -1: si32}>  :
         (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
     return %1 : tensor<4x4xf32>
   }
@@ -40,7 +40,7 @@ module attributes {} {
   func.func @select_negative_invalid_begin(%arg0: tensor<4x4xf32>) -> tensor<4x4xf32> {
     %0 = ttir.empty() : tensor<4x4xf32>
     // CHECK: {{.*error.*Invalid begin index.*}}
-    %1 = "ttir.select"(%arg0, %0) <{dim = 1: si32, begin = -3: si32, length = 4: si32, stride = 1: si32}>  :
+    %1 = "ttir.index_select"(%arg0, %0) <{dim = 1: si32, begin = -3: si32, length = 4: si32, stride = 1: si32}>  :
         (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
     return %1 : tensor<4x4xf32>
   }
@@ -52,7 +52,7 @@ module attributes {} {
   func.func @select_negative_invalid_begin_2(%arg0: tensor<4x4xf32>) -> tensor<4x4xf32> {
     %0 = ttir.empty() : tensor<4x4xf32>
     // CHECK: {{.*error.*Invalid begin index.*}}
-    %1 = "ttir.select"(%arg0, %0) <{dim = 1: si32, begin = 4: si32, length = 4: si32, stride = 1: si32}>  :
+    %1 = "ttir.index_select"(%arg0, %0) <{dim = 1: si32, begin = 4: si32, length = 4: si32, stride = 1: si32}>  :
         (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
     return %1 : tensor<4x4xf32>
   }
@@ -64,7 +64,7 @@ module attributes {} {
   func.func @select_negative_invalid_length(%arg0: tensor<4x4xf32>) -> tensor<4x4xf32> {
     %0 = ttir.empty() : tensor<4x4xf32>
     // CHECK: {{.*error.*Invalid length.*}}
-    %1 = "ttir.select"(%arg0, %0) <{dim = 1: si32, begin = 0: si32, length = 5: si32, stride = 1: si32}>  :
+    %1 = "ttir.index_select"(%arg0, %0) <{dim = 1: si32, begin = 0: si32, length = 5: si32, stride = 1: si32}>  :
         (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
     return %1 : tensor<4x4xf32>
   }
@@ -76,7 +76,7 @@ module attributes {} {
   func.func @select_negative_invalid_length_2(%arg0: tensor<4x4xf32>) -> tensor<4x4xf32> {
     %0 = ttir.empty() : tensor<4x4xf32>
     // CHECK: {{.*error.*Invalid length.*}}
-    %1 = "ttir.select"(%arg0, %0) <{dim = 1: si32, begin = 0: si32, length = 0: si32, stride = 1: si32}>  :
+    %1 = "ttir.index_select"(%arg0, %0) <{dim = 1: si32, begin = 0: si32, length = 0: si32, stride = 1: si32}>  :
         (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
     return %1 : tensor<4x4xf32>
   }
@@ -88,7 +88,7 @@ module attributes {} {
   func.func @select_negative_invalid_length_3(%arg0: tensor<4x4xf32>) -> tensor<4x4xf32> {
     %0 = ttir.empty() : tensor<4x4xf32>
     // CHECK: {{.*error.*Invalid length.*}}
-    %1 = "ttir.select"(%arg0, %0) <{dim = 1: si32, begin = 0: si32, length = 2: si32, stride = 1: si32}>  :
+    %1 = "ttir.index_select"(%arg0, %0) <{dim = 1: si32, begin = 0: si32, length = 2: si32, stride = 1: si32}>  :
         (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
     return %1 : tensor<4x4xf32>
   }
@@ -100,7 +100,7 @@ module attributes {} {
   func.func @select_negative_invalid_total_size(%arg0: tensor<4x2x64x48xf32>) -> tensor<4x2x4x48xf32> {
     %0 = ttir.empty() : tensor<4x2x4x48xf32>
     // CHECK: {{.*error.*Sum of all slices.*}}
-    %1 = "ttir.select"( %arg0, %0) <{dim = 2: si32, begin = 0: si32, length = 4: si32, stride = 4: si32}>  :
+    %1 = "ttir.index_select"( %arg0, %0) <{dim = 2: si32, begin = 0: si32, length = 4: si32, stride = 4: si32}>  :
         (tensor<4x2x64x48xf32>, tensor<4x2x4x48xf32>) -> tensor<4x2x4x48xf32>
     return %1 : tensor<4x2x4x48xf32>
   }

--- a/test/ttmlir/Dialect/TTIR/select/select_tests_positive.mlir
+++ b/test/ttmlir/Dialect/TTIR/select/select_tests_positive.mlir
@@ -3,40 +3,40 @@
 module attributes {} {
   func.func @select_identity(%arg0: tensor<4x4xf32>) -> tensor<4x4xf32> {
     %0 = ttir.empty() : tensor<4x4xf32>
-    // CHECK: %{{[0-9]+}} = "ttir.select"
-    %1 = "ttir.select"(%arg0, %0) <{dim = 1: si32, begin = 0: si32, length = 4: si32, stride = 4: si32}>  :
+    // CHECK: %{{[0-9]+}} = "ttir.index_select"
+    %1 = "ttir.index_select"(%arg0, %0) <{dim = 1: si32, begin = 0: si32, length = 4: si32, stride = 4: si32}>  :
         (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
     return %1 : tensor<4x4xf32>
   }
 
   func.func @select_half(%arg0: tensor<4x4xf32>) -> tensor<4x2xf32> {
     %0 = ttir.empty() : tensor<4x2xf32>
-    // CHECK: %{{[0-9]+}} = "ttir.select"
-    %1 = "ttir.select"(%arg0, %0) <{dim = 1: si32, begin = 0: si32, length = 2: si32, stride = 4: si32}>  :
+    // CHECK: %{{[0-9]+}} = "ttir.index_select"
+    %1 = "ttir.index_select"(%arg0, %0) <{dim = 1: si32, begin = 0: si32, length = 2: si32, stride = 4: si32}>  :
         (tensor<4x4xf32>, tensor<4x2xf32>) -> tensor<4x2xf32>
     return %1 : tensor<4x2xf32>
   }
 
   func.func @select_single(%arg0: tensor<4x4xf32>) -> tensor<4x1xf32> {
     %0 = ttir.empty() : tensor<4x1xf32>
-    // CHECK: %{{[0-9]+}} = "ttir.select"
-    %1 = "ttir.select"(%arg0, %0) <{dim = 1: si32, begin = 3: si32, length = 1: si32, stride = 1: si32}>  :
+    // CHECK: %{{[0-9]+}} = "ttir.index_select"
+    %1 = "ttir.index_select"(%arg0, %0) <{dim = 1: si32, begin = 3: si32, length = 1: si32, stride = 1: si32}>  :
         (tensor<4x4xf32>, tensor<4x1xf32>) -> tensor<4x1xf32>
     return %1 : tensor<4x1xf32>
   }
 
   func.func @select_half_2_no_stride(%arg0: tensor<4x4xf32>) -> tensor<4x2xf32> {
     %0 = ttir.empty() : tensor<4x2xf32>
-    // CHECK: %{{[0-9]+}} = "ttir.select"
-    %1 = "ttir.select"(%arg0, %0) <{dim = 1: si32, begin = 2: si32, length = 2: si32}>  :
+    // CHECK: %{{[0-9]+}} = "ttir.index_select"
+    %1 = "ttir.index_select"(%arg0, %0) <{dim = 1: si32, begin = 2: si32, length = 2: si32}>  :
         (tensor<4x4xf32>, tensor<4x2xf32>) -> tensor<4x2xf32>
     return %1 : tensor<4x2xf32>
   }
 
   func.func @select_neg_dim(%arg0: tensor<10x3x128x64xf32>) -> tensor<10x3x8x64xf32> {
     %0 = ttir.empty() : tensor<10x3x8x64xf32>
-    // CHECK: %{{[0-9]+}} = "ttir.select"
-    %1 = "ttir.select"(%arg0, %0) <{dim = -2: si32, begin = 0: si32, length = 2: si32, stride = 32: si32}>  :
+    // CHECK: %{{[0-9]+}} = "ttir.index_select"
+    %1 = "ttir.index_select"(%arg0, %0) <{dim = -2: si32, begin = 0: si32, length = 2: si32, stride = 32: si32}>  :
         (tensor<10x3x128x64xf32>, tensor<10x3x8x64xf32>) -> tensor<10x3x8x64xf32>
     return %1 : tensor<10x3x8x64xf32>
   }

--- a/tools/ttir-builder/builder.py
+++ b/tools/ttir-builder/builder.py
@@ -1789,14 +1789,11 @@ class TTIRBuilder:
         dim: int = 0,
         begin: int = 0,
         length: int = 2,
-        stride: Optional[int] = None,
+        stride: int = 2,
         unit_attrs: Optional[List[str]] = None,
     ) -> OpView:
         end = begin + length - 1
         index = torch.tensor([begin, end])
-        # TODO: handle stride. Issue #2488
-        if stride:
-            pass
         return self.op_proxy(
             torch.index_select,
             ttir.SelectOp,

--- a/tools/ttir-builder/builder.py
+++ b/tools/ttir-builder/builder.py
@@ -1796,7 +1796,7 @@ class TTIRBuilder:
         index = torch.tensor([begin, end])
         return self.op_proxy(
             torch.index_select,
-            ttir.SelectOp,
+            ttir.IndexSelectOp,
             [in0],
             golden_kwargs={"dim": dim, "index": index},
             ttir_kwargs={


### PR DESCRIPTION
### Ticket
Closes #2488 
Closes #2496 

### Problem description
`select` was not passing in the `stride` argument due to #2488. This was causing the floating point exception seen in #2496.

### What's changed
Re-enabled passing the `stride` argument in, and some previous change fixed the issue seen in #2488. This argument fixes the floating point exception seen in #2496, and brings `select` golden testing into the CI

### Checklist
- [x] New/Existing tests provide coverage for changes
