### PR TITLE
D2M: Fix gather/mcast routine generation and lowering

### DIFF
--- a/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
+++ b/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
@@ -644,10 +644,8 @@ public:
         if (adaptor.getSrc() == adaptor.getDst()) {
           // If src and dst refer to the same memref, we do not loopback mcast
           // Dests are one less because the sender core is not included
-          auto numDestsLessOne = rewriter.create<arith::SubIOp>(
-              op.getLoc(), numDests, i32(rewriter, op->getLoc(), 1));
           rewriter.create<ttkernel::NocAsyncWriteMulticastOp>(
-              op.getLoc(), srcL1Start, mcastAddr, transferSize, numDestsLessOne,
+              op.getLoc(), srcL1Start, mcastAddr, transferSize, numDests,
               nullptr, nullptr, nullptr);
         } else {
           // If src != dst, we loopback mcast


### PR DESCRIPTION
### Ticket
No specific issue, incremental change to support matmul

### Problem description
We have a few off by one errors in the indexing for mcast and semaphores in the gather-mcast routine used for matmul
This mainly stems from mcast instructions not being able to be inclusive by default. 

### What's changed
Fix these off by one errors.

### Checklist
- [ ] New/Existing tests provide coverage for changes
