### PR TITLE
Uplift third_party/tt-metal to 1a9ff3036e4298f30b644ffeeeb40812f5f4b89f 2025-06-19

### DIFF
--- a/docs/src/ttnn-dialect-guidelines.md
+++ b/docs/src/ttnn-dialect-guidelines.md
@@ -78,7 +78,7 @@ If an operand has a default value in the TTNN lib, it should have a default valu
 ```C++
 static ttnn::Tensor invoke(
     const ttnn::Tensor& input_tensor,
-    tt::stl::Span<const int64_t> dims,
+    ttsl::Span<const int64_t> dims,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<float>& pad_value = 0.0f);
 ```

--- a/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
+++ b/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
@@ -32,14 +32,12 @@
 
 // This namespace contains mock definitions of TTNN types for the purpose of
 // conversion.
-namespace tt {
-namespace stl {
+namespace ttsl {
 template <typename T>
 struct SmallVector {
   using value_type = T;
 };
-} // namespace stl
-} // namespace tt
+} // namespace ttsl
 
 namespace ttnn {
 struct Shape;
@@ -166,9 +164,9 @@ struct TypeName<std::vector<T>> {
 };
 
 template <typename T>
-struct TypeName<::tt::stl::SmallVector<T>> {
+struct TypeName<::ttsl::SmallVector<T>> {
   inline static const std::string value =
-      "::tt::stl::SmallVector<" + TypeNameV<T> + ">";
+      "::ttsl::SmallVector<" + TypeNameV<T> + ">";
 };
 
 template <typename T>
@@ -770,8 +768,8 @@ struct EmitCTypeConverter<std::vector<T>>
     : public EmitCContainerTypeConverter<std::vector<T>> {};
 
 template <typename T>
-struct EmitCTypeConverter<::tt::stl::SmallVector<T>>
-    : public EmitCContainerTypeConverter<::tt::stl::SmallVector<T>> {};
+struct EmitCTypeConverter<::ttsl::SmallVector<T>>
+    : public EmitCContainerTypeConverter<::ttsl::SmallVector<T>> {};
 
 template <typename T>
 struct EmitCTypeConverter<std::set<T>>

--- a/include/ttmlir/Conversion/TTNNToEmitC/Utils.h
+++ b/include/ttmlir/Conversion/TTNNToEmitC/Utils.h
@@ -58,7 +58,7 @@ emitc::OpaqueAttr convertReduceType(ConversionPatternRewriter &rewriter,
 emitc::OpaqueAttr convertArrayAttrToTTNNSmallVector(Builder &builder,
                                                     ArrayAttr attr);
 
-// Create emitc::OpaqueAttr for tt::stl::Span from ArrayAttr of ints
+// Create emitc::OpaqueAttr for ttsl::Span from ArrayAttr of ints
 //
 emitc::OpaqueAttr convertArrayAttrToSpan(Builder &builder, ArrayAttr attr);
 

--- a/include/ttmlir/OpModel/TTNN/Conversion.h
+++ b/include/ttmlir/OpModel/TTNN/Conversion.h
@@ -72,7 +72,7 @@ getTensorLayout(const mlir::tt::ttnn::TTNNLayoutAttr &layout);
 bool validateTensorSpec(const ::ttnn::TensorSpec &tensorSpec,
                         const ::tt::tt_metal::CoreCoord &computeGridSize);
 
-::tt::stl::SmallVector<int>
+::ttsl::SmallVector<int>
 convertLLVMSmallVecToTTNNSmallVec(const ::llvm::ArrayRef<int64_t> vec);
 
 std::optional<::ttnn::operations::conv::conv2d::Conv2dConfig> getConv2dConfig(

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -861,8 +861,7 @@ public:
 
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
-        emitter.template emit<::tt::stl::SmallVector<int32_t>>(
-            srcOp.getDimArg()),
+        emitter.template emit<::ttsl::SmallVector<int32_t>>(srcOp.getDimArg()),
         emitter.emit(srcOp.getKeepDim()),
         emitter.emit(std::nullopt) | emitter.getMemoryConfig(srcOp.getResult()),
     };
@@ -2035,9 +2034,9 @@ public:
 
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
-        emitter.emit<::tt::stl::SmallVector<int32_t>>(srcOp.getBegins()),
-        emitter.emit<::tt::stl::SmallVector<int32_t>>(srcOp.getEnds()),
-        emitter.emit<::tt::stl::SmallVector<int32_t>>(srcOp.getStep()),
+        emitter.emit<::ttsl::SmallVector<int32_t>>(srcOp.getBegins()),
+        emitter.emit<::ttsl::SmallVector<int32_t>>(srcOp.getEnds()),
+        emitter.emit<::ttsl::SmallVector<int32_t>>(srcOp.getStep()),
         emitter.emit(std::nullopt) | emitter.getMemoryConfig(srcOp.getResult()),
     };
 
@@ -2102,7 +2101,7 @@ public:
 
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
-        emitter.emit<::tt::stl::SmallVector<int64_t>>(srcOp.getPermutation()),
+        emitter.emit<::ttsl::SmallVector<int64_t>>(srcOp.getPermutation()),
         emitter.emit(std::nullopt) | emitter.getMemoryConfig(srcOp.getResult()),
         emitter.emit(srcOp.getPadValue()),
     };

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -601,7 +601,7 @@ public:
         emitter.template emit<std::array<uint32_t, 2>>(srcOp.getStrideAttr()),
         emitter.template emit<std::array<uint32_t, 2>>(srcOp.getPaddingAttr()),
         emitter.emit(srcOp.getCeilMode()),
-        emitter.emit(/*count_include_pad=*/false),
+        emitter.emit(/*count_include_pad=*/true),
         emitter.emit(/*divisor_override=*/std::nullopt),
         emitter.getMemoryConfig(srcOp.getResult()),
         emitter.emit(srcOp.getAppliedShardScheme()),

--- a/lib/OpModel/TTNN/Conversion.cpp
+++ b/lib/OpModel/TTNN/Conversion.cpp
@@ -65,7 +65,7 @@ tt::DataType getDataType(const ::tt::tt_metal::DataType dataType) {
 }
 
 ::ttnn::Shape getShape(const ::llvm::ArrayRef<int64_t> shape) {
-  ::tt::stl::SmallVector<uint32_t> small_vector_shape;
+  ::ttsl::SmallVector<uint32_t> small_vector_shape;
   for (const auto &dim : shape) {
     small_vector_shape.push_back(static_cast<uint32_t>(dim));
   }
@@ -254,9 +254,9 @@ bool validateTensorSpec(const ::ttnn::TensorSpec &tensorSpec,
   return true;
 }
 
-::tt::stl::SmallVector<int>
+::ttsl::SmallVector<int>
 convertLLVMSmallVecToTTNNSmallVec(const ::llvm::ArrayRef<int64_t> vec) {
-  return ::tt::stl::SmallVector<int>(vec.begin(), vec.end());
+  return ::ttsl::SmallVector<int>(vec.begin(), vec.end());
 }
 
 std::optional<::ttnn::operations::conv::conv2d::Conv2dConfig> getConv2dConfig(

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -589,7 +589,7 @@ llvm::Expected<OpConstraints> getReductionOpConstraints(
   }
   ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
-  std::optional<::tt::stl::SmallVector<int>> dimArgConverted;
+  std::optional<::ttsl::SmallVector<int>> dimArgConverted;
   if (dimArg) {
     dimArgConverted =
         conversion::convertLLVMSmallVecToTTNNSmallVec(dimArg.value());
@@ -626,7 +626,7 @@ getReductionOpRuntime(std::string_view opName, OpSymbol opSymbol,
   }
   ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
-  std::optional<::tt::stl::SmallVector<int>> dimArgConverted;
+  std::optional<::ttsl::SmallVector<int>> dimArgConverted;
   if (dimArg) {
     dimArgConverted =
         conversion::convertLLVMSmallVecToTTNNSmallVec(dimArg.value());
@@ -1118,11 +1118,11 @@ llvm::Expected<OpConstraints> SliceOpInterface::getOpConstraints(
   ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // convert arrays
-  ::tt::stl::SmallVector<int> beginsVec =
+  ::ttsl::SmallVector<int> beginsVec =
       conversion::convertLLVMSmallVecToTTNNSmallVec(begins);
-  ::tt::stl::SmallVector<int> endsVec =
+  ::ttsl::SmallVector<int> endsVec =
       conversion::convertLLVMSmallVecToTTNNSmallVec(ends);
-  ::tt::stl::SmallVector<int> stepVec =
+  ::ttsl::SmallVector<int> stepVec =
       conversion::convertLLVMSmallVecToTTNNSmallVec(step);
 
   // Create query closure
@@ -1159,11 +1159,11 @@ llvm::Expected<size_t> SliceOpInterface::getOpRuntime(
   ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
   // Convert arrays
-  ::tt::stl::SmallVector<int> beginsVec =
+  ::ttsl::SmallVector<int> beginsVec =
       conversion::convertLLVMSmallVecToTTNNSmallVec(begins);
-  ::tt::stl::SmallVector<int> endsVec =
+  ::ttsl::SmallVector<int> endsVec =
       conversion::convertLLVMSmallVecToTTNNSmallVec(ends);
-  ::tt::stl::SmallVector<int> stepVec =
+  ::ttsl::SmallVector<int> stepVec =
       conversion::convertLLVMSmallVecToTTNNSmallVec(step);
 
   // Create query closure
@@ -1953,7 +1953,7 @@ llvm::Expected<OpConstraints> PermuteOpInterface::getOpConstraints(
       SingletonDeviceContext::getInstance().getDevice();
 
   // Convert permutations of TTNN_PermuteOp to dims of ttnn::permute
-  ::tt::stl::SmallVector<int64_t> dims(permutation.size());
+  ::ttsl::SmallVector<int64_t> dims(permutation.size());
   std::copy(permutation.begin(), permutation.end(), dims.begin());
 
   float defaultedPadValue = padValue.convertToFloat();
@@ -1991,7 +1991,7 @@ PermuteOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
       SingletonDeviceContext::getInstance().getDevice();
 
   // Convert permutations of TTNN_PermuteOp to dims of ttnn::permute
-  ::tt::stl::SmallVector<int64_t> dims(permutation.size());
+  ::ttsl::SmallVector<int64_t> dims(permutation.size());
   std::copy(permutation.begin(), permutation.end(), dims.begin());
 
   // Convert float

--- a/runtime/include/tt/runtime/detail/ttmetal/profiler.h
+++ b/runtime/include/tt/runtime/detail/ttmetal/profiler.h
@@ -31,7 +31,7 @@ struct device_operation_t {
     const char *loc;
 
     operation_attributes_t(const char *loc) : loc(loc) {}
-    tt::stl::reflection::Attributes attributes() const { return {}; }
+    ttsl::reflection::Attributes attributes() const { return {}; }
   };
   using tensor_args_t = std::vector<tt::tt_metal::Tensor>;
   using tensor_return_value_t = std::vector<tt::tt_metal::Tensor>;

--- a/runtime/include/tt/runtime/detail/ttnn/utils.h
+++ b/runtime/include/tt/runtime/detail/ttnn/utils.h
@@ -88,7 +88,7 @@ inline ::ttnn::Tensor createTTNNTensor(const void *rawData,
   ::ttnn::TensorSpec tensorSpec = createTensorSpec(shape, dataType);
   if (rawData != nullptr) {
     const T *typedData = static_cast<const T *>(rawData);
-    ::tt::stl::Span<const T> data(typedData, typedData + numElements);
+    ::ttsl::Span<const T> data(typedData, typedData + numElements);
     ::ttnn::Tensor tensor = ::ttnn::Tensor::from_span(data, tensorSpec);
     return tensor;
   }

--- a/runtime/lib/ttnn/operations/data_movement/pad.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/pad.cpp
@@ -22,7 +22,7 @@ void run(const ::tt::target::ttnn::PadOp *op, ProgramContext &context) {
 
   ::ttnn::Tensor out;
 
-  ::tt::stl::SmallVector<::ttnn::operations::data_movement::PadSpecDim> padding;
+  ::ttsl::SmallVector<::ttnn::operations::data_movement::PadSpecDim> padding;
   for (uint32_t i = 0; i < op->padding()->size(); i += 2) {
     padding.emplace_back(op->padding()->Get(i), op->padding()->Get(i + 1));
   }

--- a/runtime/lib/ttnn/operations/data_movement/permute.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/permute.cpp
@@ -16,8 +16,8 @@ void run(const ::tt::target::ttnn::PermuteOp *op, ProgramContext &context) {
 
   const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
 
-  ::tt::stl::SmallVector<int64_t> permutation(op->permutation()->begin(),
-                                              op->permutation()->end());
+  ::ttsl::SmallVector<int64_t> permutation(op->permutation()->begin(),
+                                           op->permutation()->end());
   std::optional<::ttnn::MemoryConfig> memoryConfig =
       ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
           op->memory_config());

--- a/runtime/lib/ttnn/operations/data_movement/slice.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/slice.cpp
@@ -15,10 +15,10 @@ void run(const ::tt::target::ttnn::SliceOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
   const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
 
-  ::tt::stl::SmallVector<int32_t> begins(op->begins()->begin(),
-                                         op->begins()->end());
-  ::tt::stl::SmallVector<int32_t> ends(op->ends()->begin(), op->ends()->end());
-  ::tt::stl::SmallVector<int32_t> step(op->step()->begin(), op->step()->end());
+  ::ttsl::SmallVector<int32_t> begins(op->begins()->begin(),
+                                      op->begins()->end());
+  ::ttsl::SmallVector<int32_t> ends(op->ends()->begin(), op->ends()->end());
+  ::ttsl::SmallVector<int32_t> step(op->step()->begin(), op->step()->end());
 
   ::ttnn::Tensor out = ::ttnn::slice(in, begins, ends, step);
 

--- a/runtime/lib/ttnn/operations/eltwise/binary/binary.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/binary/binary.cpp
@@ -17,10 +17,9 @@ static void runEltwiseBinaryOp(
         const std::optional<const ::ttnn::DataType> &,
         const std::optional<::ttnn::MemoryConfig> &,
         std::optional<::ttnn::Tensor>,
-        tt::stl::Span<const ::ttnn::operations::unary::UnaryWithParam>,
-        tt::stl::Span<const ::ttnn::operations::unary::UnaryWithParam>,
-        tt::stl::Span<const ::ttnn::operations::unary::UnaryWithParam>)>
-        &ttnnOp) {
+        ttsl::Span<const ::ttnn::operations::unary::UnaryWithParam>,
+        ttsl::Span<const ::ttnn::operations::unary::UnaryWithParam>,
+        ttsl::Span<const ::ttnn::operations::unary::UnaryWithParam>)> &ttnnOp) {
 
   ::ttnn::Tensor *lhs = &(tensorPool.getTTNNTensorAndValidate(op->lhs()));
   ::ttnn::Tensor *rhs = &(tensorPool.getTTNNTensorAndValidate(op->rhs()));

--- a/runtime/lib/ttnn/operations/eltwise/binary/binary_composite.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/binary/binary_composite.cpp
@@ -44,9 +44,9 @@ static void runEltwiseBinaryNGCompositeOp(
         const std::optional<const ::ttnn::DataType> &,
         const std::optional<::ttnn::MemoryConfig> &,
         const std::optional<::ttnn::Tensor> &,
-        tt::stl::Span<const ::ttnn::operations::unary::UnaryWithParam>,
-        tt::stl::Span<const ::ttnn::operations::unary::UnaryWithParam>,
-        tt::stl::Span<const ::ttnn::operations::unary::UnaryWithParam>,
+        ttsl::Span<const ::ttnn::operations::unary::UnaryWithParam>,
+        ttsl::Span<const ::ttnn::operations::unary::UnaryWithParam>,
+        ttsl::Span<const ::ttnn::operations::unary::UnaryWithParam>,
         std::optional<bool>)> &ttnnOp) {
 
   ::ttnn::Tensor *lhs = &(tensorPool.getTTNNTensorAndValidate(op->lhs()));

--- a/runtime/lib/ttnn/operations/kv_cache/update_cache.cpp
+++ b/runtime/lib/ttnn/operations/kv_cache/update_cache.cpp
@@ -23,10 +23,8 @@ void run(const ::tt::target::ttnn::UpdateCacheOp *op, ProgramContext &context) {
   if (workaround::Env::get().readUpdateIndexFromDeviceForKVCache) {
 
     const ::ttnn::Tensor indexOnHost = ::ttnn::from_device(updateIndex);
-    const auto &storage = indexOnHost.storage();
-    const auto &multiDeviceHostStorage =
-        std::get<tt_metal::MultiDeviceHostStorage>(storage);
-    const auto &buffer = multiDeviceHostStorage.get_buffer(0);
+    const ::tt::tt_metal::HostBuffer buffer =
+        ::tt::tt_metal::host_buffer::get_host_buffer(indexOnHost);
     const auto &buf = buffer.view_as<uint32_t>();
     uint32_t upIdx = *buf.begin();
 

--- a/runtime/lib/ttnn/operations/pool/pool2d.cpp
+++ b/runtime/lib/ttnn/operations/pool/pool2d.cpp
@@ -22,8 +22,8 @@ void runAvgPool2dOp(
         const ::ttnn::Tensor &, uint32_t, uint32_t, uint32_t, uint32_t,
         std::array<uint32_t, 2>, std::array<uint32_t, 2>,
         std::array<uint32_t, 2>, bool, bool, std::optional<int32_t>,
-        const std::optional<::ttnn::MemoryConfig> &,
-        const std::optional<::ttnn::TensorMemoryLayout> &, bool)> &ttnnOp) {
+        const std::optional<const ::ttnn::MemoryConfig> &,
+        const std::optional<const ::ttnn::TensorMemoryLayout>, bool)> &ttnnOp) {
   ::ttnn::Tensor input = tensorPool.getTTNNTensorAndValidate(op->in());
 
   std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
@@ -47,9 +47,8 @@ void runAvgPool2dOp(
   ::ttnn::Tensor out =
       ttnnOp(input, op->batch_size(), op->input_height(), op->input_width(),
              op->channels(), kernelSize, stride, padding, op->ceil_mode(),
-             /*count_include_pad=*/false,
-             /*divisor_override=*/std::nullopt, outputMemoryConfig,
-             appliedShardScheme, op->in_place_halo());
+             /*count_include_pad=*/true, /*divisor_override=*/std::nullopt,
+             outputMemoryConfig, appliedShardScheme, op->in_place_halo());
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }

--- a/runtime/lib/ttnn/operations/reduction/reduction.cpp
+++ b/runtime/lib/ttnn/operations/reduction/reduction.cpp
@@ -14,7 +14,7 @@ static void runReductionOp(
     const ::tt::target::ttnn::ReductionOp *op, ProgramTensorPool &tensorPool,
     const std::function<::ttnn::Tensor(
         const ::ttnn::Tensor &,
-        const std::optional<std::variant<int, ::tt::stl::SmallVector<int>>> &,
+        const std::optional<std::variant<int, ::ttsl::SmallVector<int>>> &,
         const bool, const std::optional<::ttnn::MemoryConfig> &,
         const std::optional<::ttnn::DeviceComputeKernelConfig> &, float)>
         &ttnnOp) {
@@ -29,9 +29,9 @@ static void runReductionOp(
   const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
 
   const auto *fbDimArg = op->dim_arg();
-  std::optional<::tt::stl::SmallVector<int>> dimArg =
-      fbDimArg ? std::make_optional(::tt::stl::SmallVector<int>(
-                     fbDimArg->begin(), fbDimArg->end()))
+  std::optional<::ttsl::SmallVector<int>> dimArg =
+      fbDimArg ? std::make_optional(::ttsl::SmallVector<int>(fbDimArg->begin(),
+                                                             fbDimArg->end()))
                : std::nullopt;
 
   ::ttnn::Tensor out = ttnnOp(

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -48,7 +48,7 @@ static ::ttnn::Tensor createBorrowedTTNNTensor(void *rawData,
                                                const ::ttnn::Shape &shape) {
   std::uint64_t numElements = shape.volume();
   T *typedData = static_cast<T *>(rawData);
-  ::tt::stl::Span<T> data(typedData, typedData + numElements);
+  ::ttsl::Span<T> data(typedData, typedData + numElements);
   ::ttnn::Tensor tensor =
       ::ttnn::Tensor::from_borrowed_data(data, shape, []() {}, []() {});
   return tensor;

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -503,7 +503,7 @@ TEST_F(OpModelTest, ToLayout) {
       layoutDRAMRowMajor, true);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
-  EXPECT_EQ(opCstr.cbL1PeakSize, 262144);
+  EXPECT_EQ(opCstr.cbL1PeakSize, 131072);
   EXPECT_EQ(opCstr.tensorL1PeakSize, 0);
   EXPECT_EQ(opCstr.outputL1BufferSize, 0);
   ExpectLayoutsEQ(layoutDRAMRowMajor, opCstr.outputLayout);
@@ -529,7 +529,7 @@ TEST_F(OpModelTest, ToLayout) {
       layoutDRAMRowMajor, false);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
-  EXPECT_EQ(opCstr.cbL1PeakSize, 262144);
+  EXPECT_EQ(opCstr.cbL1PeakSize, 131072);
   EXPECT_EQ(opCstr.tensorL1PeakSize, 0);
   EXPECT_EQ(opCstr.outputL1BufferSize, 0);
   ExpectLayoutsEQ(layoutDRAMRowMajor, opCstr.outputLayout);
@@ -1679,7 +1679,7 @@ INSTANTIATE_TEST_SUITE_P(
             detail::TestTensor{{256, 128},
                                mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
                                mlir::tt::ttnn::BufferType::DRAM},
-            detail::ExpectedResult{true, 32768, 8192, 4096}),
+            detail::ExpectedResult{true, 16384, 8192, 4096}),
         std::make_tuple(
             // Input: [batch=2, seq_len=512] (sharded)
             detail::TestTensor{{2, 512},
@@ -1690,6 +1690,6 @@ INSTANTIATE_TEST_SUITE_P(
             detail::TestTensor{{512, 256},
                                mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
                                mlir::tt::ttnn::BufferType::DRAM},
-            detail::ExpectedResult{true, 65536, 16384, 8192})));
+            detail::ExpectedResult{true, 32768, 16384, 8192})));
 
 } // namespace mlir::tt::op_model::ttnn

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -1465,7 +1465,7 @@ TEST_F(OpModelBase, EmbeddingOpInterface) {
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
     const auto [cbSize, peakSize, outputSize, outputLayout] = l1;
-    EXPECT_EQ(cbSize, 32768);
+    EXPECT_EQ(cbSize, 16384);
     EXPECT_EQ(peakSize, 525312);
     EXPECT_EQ(outputSize, 262144);
   } else {

--- a/test/unittests/TTNNToEmitC/TestEmitCConversion.cpp
+++ b/test/unittests/TTNNToEmitC/TestEmitCConversion.cpp
@@ -52,16 +52,14 @@ TEST(TypeNameTest, VectorTypes) {
 }
 
 TEST(TypeNameTest, SmallVectorTypes) {
-  EXPECT_EQ(TypeNameV<::tt::stl::SmallVector<bool>>,
-            "::tt::stl::SmallVector<bool>");
-  EXPECT_EQ(TypeNameV<::tt::stl::SmallVector<std::string>>,
-            "::tt::stl::SmallVector<::std::string>");
-  EXPECT_EQ(TypeNameV<::tt::stl::SmallVector<::tt::stl::SmallVector<uint64_t>>>,
-            "::tt::stl::SmallVector<::tt::stl::SmallVector<uint64_t>>");
+  EXPECT_EQ(TypeNameV<::ttsl::SmallVector<bool>>, "::ttsl::SmallVector<bool>");
+  EXPECT_EQ(TypeNameV<::ttsl::SmallVector<std::string>>,
+            "::ttsl::SmallVector<::std::string>");
+  EXPECT_EQ(TypeNameV<::ttsl::SmallVector<::ttsl::SmallVector<uint64_t>>>,
+            "::ttsl::SmallVector<::ttsl::SmallVector<uint64_t>>");
   EXPECT_EQ(
-      (TypeNameV<
-          ::tt::stl::SmallVector<std::array<std::vector<std::string>, 3>>>),
-      "::tt::stl::SmallVector<::std::array<::std::vector<::std::string>, 3>>");
+      (TypeNameV<::ttsl::SmallVector<std::array<std::vector<std::string>, 3>>>),
+      "::ttsl::SmallVector<::std::array<::std::vector<::std::string>, 3>>");
 }
 
 TEST_F(EmitCConversionTest, ConvertStringAttr) {
@@ -274,59 +272,57 @@ TEST_F(EmitCConversionTest, ConvertArrayAttrToTtnnSmallVector) {
       builder.getI32IntegerAttr(3),
   });
   std::string converted =
-      EmitCTypeConverter<::tt::stl::SmallVector<int32_t>>::convert(arrayAttr);
-  EXPECT_EQ(converted, "::tt::stl::SmallVector<int32_t>{1, 2, 3}");
+      EmitCTypeConverter<::ttsl::SmallVector<int32_t>>::convert(arrayAttr);
+  EXPECT_EQ(converted, "::ttsl::SmallVector<int32_t>{1, 2, 3}");
 
   mlir::Attribute arrayAsAttribute = arrayAttr;
   std::optional<std::string> maybeConverted =
-      EmitCTypeConverter<::tt::stl::SmallVector<int32_t>>::convert(
+      EmitCTypeConverter<::ttsl::SmallVector<int32_t>>::convert(
           arrayAsAttribute);
   ASSERT_TRUE(maybeConverted);
-  EXPECT_EQ(*maybeConverted, "::tt::stl::SmallVector<int32_t>{1, 2, 3}");
+  EXPECT_EQ(*maybeConverted, "::ttsl::SmallVector<int32_t>{1, 2, 3}");
 }
 
 TEST_F(EmitCConversionTest, ConvertDenseBoolArrayAttrToTtnnSmallVector) {
   mlir::DenseBoolArrayAttr denseArrayAttr =
       builder.getDenseBoolArrayAttr({true, false, true});
   std::string converted =
-      EmitCTypeConverter<::tt::stl::SmallVector<bool>>::convert(denseArrayAttr);
-  EXPECT_EQ(converted, "::tt::stl::SmallVector<bool>{true, false, true}");
+      EmitCTypeConverter<::ttsl::SmallVector<bool>>::convert(denseArrayAttr);
+  EXPECT_EQ(converted, "::ttsl::SmallVector<bool>{true, false, true}");
 }
 
 TEST_F(EmitCConversionTest, ConvertDenseI32ArrayAttrToTtnnSmallVector) {
   mlir::DenseI32ArrayAttr denseArrayAttr =
       builder.getDenseI32ArrayAttr({1, 2, 3});
   std::string converted =
-      EmitCTypeConverter<::tt::stl::SmallVector<int32_t>>::convert(
-          denseArrayAttr);
-  EXPECT_EQ(converted, "::tt::stl::SmallVector<int32_t>{1, 2, 3}");
+      EmitCTypeConverter<::ttsl::SmallVector<int32_t>>::convert(denseArrayAttr);
+  EXPECT_EQ(converted, "::ttsl::SmallVector<int32_t>{1, 2, 3}");
 }
 
 TEST_F(EmitCConversionTest, ConvertDenseF32ArrayAttrToTtnnSmallVector) {
   mlir::DenseF32ArrayAttr denseArrayAttr =
       builder.getDenseF32ArrayAttr({1.0, 2.0, 3.0});
   std::string converted =
-      EmitCTypeConverter<::tt::stl::SmallVector<float>>::convert(
-          denseArrayAttr);
+      EmitCTypeConverter<::ttsl::SmallVector<float>>::convert(denseArrayAttr);
   EXPECT_EQ(converted,
-            "::tt::stl::SmallVector<float>{1.000000f, 2.000000f, 3.000000f}");
+            "::ttsl::SmallVector<float>{1.000000f, 2.000000f, 3.000000f}");
 }
 
 TEST_F(EmitCConversionTest, ConvertDenseIntElementsAttrToTtnnSmallVector) {
   mlir::DenseIntElementsAttr denseElementsAttr =
       builder.getI32TensorAttr({1, 2, 3});
   std::string converted =
-      EmitCTypeConverter<::tt::stl::SmallVector<int32_t>>::convert(
+      EmitCTypeConverter<::ttsl::SmallVector<int32_t>>::convert(
           denseElementsAttr);
-  EXPECT_EQ(converted, "::tt::stl::SmallVector<int32_t>{1, 2, 3}");
+  EXPECT_EQ(converted, "::ttsl::SmallVector<int32_t>{1, 2, 3}");
 }
 
 TEST_F(EmitCConversionTest, ConvertArrayRefToTtnnSmallVector) {
   std::vector<uint32_t> vec = {1, 2, 3};
   std::string converted =
-      EmitCTypeConverter<::tt::stl::SmallVector<int32_t>>::convert(
+      EmitCTypeConverter<::ttsl::SmallVector<int32_t>>::convert(
           llvm::ArrayRef(vec));
-  EXPECT_EQ(converted, "::tt::stl::SmallVector<int32_t>{1, 2, 3}");
+  EXPECT_EQ(converted, "::ttsl::SmallVector<int32_t>{1, 2, 3}");
 }
 
 TEST_F(EmitCConversionTest, ConvertArrayAttrToStdArray) {

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "d81d323eb816723840691d5e4e3c7115e68e5080")
+set(TT_METAL_VERSION "55a09b9509a8d38f4dc8e4c6f34fe8569616fb3c")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "55a09b9509a8d38f4dc8e4c6f34fe8569616fb3c")
+set(TT_METAL_VERSION "1a9ff3036e4298f30b644ffeeeb40812f5f4b89f")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -54,7 +54,7 @@ set(TTMETAL_INCLUDE_DIRS
   ${CPM_SOURCE_CACHE}/boost/1359e136761ab2d10afa1c4e21086c8d824735cd/libs/core/include
   ${CPM_SOURCE_CACHE}/nlohmann_json/798e0374658476027d9723eeb67a262d0f3c8308/include
   ${CPM_SOURCE_CACHE}/spdlog/b1c2586bb5c35a7929362e87f62433eb68206873/include
-  ${CPM_SOURCE_CACHE}/tt-logger/300f1cdffa52ce1010e37283d4e1031431b0cf3b/include
+  ${CPM_SOURCE_CACHE}/tt-logger/c30f8fb4715bdecd616b807c316670986667f679/include
   ${CPM_SOURCE_CACHE}/xtl/0_8_0_patched/include
   ${CPM_SOURCE_CACHE}/xtensor/0_26_0_patched/include
   ${CPM_SOURCE_CACHE}/xtensor-blas/0_22_0_patched/include

--- a/tools/ttnn-standalone/CMakeLists.txt
+++ b/tools/ttnn-standalone/CMakeLists.txt
@@ -84,7 +84,7 @@ set(INCLUDE_DIRS
     ${CPM_SOURCE_CACHE}/boost/1359e136761ab2d10afa1c4e21086c8d824735cd/libs/core/include
     ${CPM_SOURCE_CACHE}/nlohmann_json/798e0374658476027d9723eeb67a262d0f3c8308/include
     ${CPM_SOURCE_CACHE}/spdlog/b1c2586bb5c35a7929362e87f62433eb68206873/include
-    ${CPM_SOURCE_CACHE}/tt-logger/300f1cdffa52ce1010e37283d4e1031431b0cf3b/include
+    ${CPM_SOURCE_CACHE}/tt-logger/c30f8fb4715bdecd616b807c316670986667f679/include
     ${CPM_SOURCE_CACHE}/xtl/0_8_0_patched/include
     ${CPM_SOURCE_CACHE}/xtensor/0_26_0_patched/include
     ${CPM_SOURCE_CACHE}/xtensor-blas/0_22_0_patched/include


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 1a9ff3036e4298f30b644ffeeeb40812f5f4b89f (June 18)

- Distributed host buffer updates after metal commit 6ac48706e3
- Replace tt::stl namespace with ttsl after metal commit f94ddf80d4
- Update tt-logger include path after version bumped in commit f58bf76a68