### PR TITLE
Adding serialization and deserialization of Flatbuffer to memory

### DIFF
--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -166,10 +166,10 @@ struct Flatbuffer : public detail::ObjectImpl {
   using detail::ObjectImpl::ObjectImpl;
 
   static Flatbuffer loadFromPath(const char *path);
-  static Flatbuffer loadFromMemory(const char *memory, size_t size);
+  static Flatbuffer loadFromMemory(const void *memory, size_t size);
 
   void store(const char *path) const;
-  void storeToMemory(std::vector<std::byte> &serialized_flatbuffer) const;
+  void storeToMemory(std::vector<std::byte> &serializedFlatbuffer) const;
   std::string_view getFileIdentifier() const;
   std::string getVersion() const;
   std::string_view getSchemaHash() const;

--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -166,6 +166,7 @@ struct Flatbuffer : public detail::ObjectImpl {
   using detail::ObjectImpl::ObjectImpl;
 
   static Flatbuffer loadFromPath(const char *path);
+  static Flatbuffer loadFromMemory(const char *memory, size_t size);
 
   void store(const char *path) const;
   void storeToMemory(std::vector<std::byte> &serialized_flatbuffer) const;

--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -168,6 +168,7 @@ struct Flatbuffer : public detail::ObjectImpl {
   static Flatbuffer loadFromPath(const char *path);
 
   void store(const char *path) const;
+  void storeToMemory(std::vector<std::byte> &serialized_flatbuffer) const;
   std::string_view getFileIdentifier() const;
   std::string getVersion() const;
   std::string_view getSchemaHash() const;

--- a/runtime/lib/binary.cpp
+++ b/runtime/lib/binary.cpp
@@ -408,7 +408,7 @@ Flatbuffer Flatbuffer::loadFromPath(const char *path) {
   return Flatbuffer(buffer);
 }
 
-Flatbuffer Flatbuffer::loadFromMemory(const char *memory, size_t size) {
+Flatbuffer Flatbuffer::loadFromMemory(const void *memory, size_t size) {
   // load a flatbuffer from memory
   LOG_ASSERT(memory != nullptr, "Memory pointer is null");
   LOG_ASSERT(size > 0, "Size must be greater than zero");
@@ -426,11 +426,11 @@ void Flatbuffer::store(const char *path) const {
 }
 
 void Flatbuffer::storeToMemory(
-    std::vector<std::byte> &serialized_flatbuffer) const {
+    std::vector<std::byte> &serializedFlatbuffer) const {
   auto size = ::flatbuffers::GetSizePrefixedBufferLength(
       static_cast<const uint8_t *>(handle.get()));
-  serialized_flatbuffer.resize(size);
-  std::memcpy(serialized_flatbuffer.data(), handle.get(), size);
+  serializedFlatbuffer.resize(size);
+  std::memcpy(serializedFlatbuffer.data(), handle.get(), size);
 }
 
 std::string_view Flatbuffer::getFileIdentifier() const {

--- a/runtime/lib/binary.cpp
+++ b/runtime/lib/binary.cpp
@@ -416,6 +416,14 @@ void Flatbuffer::store(const char *path) const {
   fbb.write(reinterpret_cast<const char *>(handle.get()), size);
 }
 
+void Flatbuffer::storeToMemory(
+    std::vector<std::byte> &serialized_flatbuffer) const {
+  auto size = ::flatbuffers::GetSizePrefixedBufferLength(
+      static_cast<const uint8_t *>(handle.get()));
+  serialized_flatbuffer.resize(size);
+  std::memcpy(serialized_flatbuffer.data(), handle.get(), size);
+}
+
 std::string_view Flatbuffer::getFileIdentifier() const {
   if (::tt::target::ttnn::SizePrefixedTTNNBinaryBufferHasIdentifier(
           handle.get())) {

--- a/runtime/lib/binary.cpp
+++ b/runtime/lib/binary.cpp
@@ -408,6 +408,15 @@ Flatbuffer Flatbuffer::loadFromPath(const char *path) {
   return Flatbuffer(buffer);
 }
 
+Flatbuffer Flatbuffer::loadFromMemory(const char *memory, size_t size) {
+  // load a flatbuffer from memory
+  LOG_ASSERT(memory != nullptr, "Memory pointer is null");
+  LOG_ASSERT(size > 0, "Size must be greater than zero");
+  auto buffer = ::tt::runtime::utils::malloc_shared(size);
+  std::memcpy(buffer.get(), memory, size);
+  return Flatbuffer(buffer);
+}
+
 void Flatbuffer::store(const char *path) const {
   // store a flatbuffer to path
   std::ofstream fbb(path, std::ios::binary);


### PR DESCRIPTION
Currently, we only support loading and storing of flatbuffers from files on disk. Since this is not the primary way in which tt-xla serializes its binaries, we also need APIs for storing and loading it from memory, which this PR adds.