### PR TITLE
Renaming TTCore namespace from mlir::tt -> mlir::tt::ttcore

### DIFF
--- a/docs/src/python-bindings.md
+++ b/docs/src/python-bindings.md
@@ -61,7 +61,7 @@ MlirType ttmlirTTTileTypeGet(MlirContext ctx, unsigned height, unsigned width, u
         TileType::get(
             unwrap(ctx), // Now we unwrap the MlirContext object to cast it to a mlir::MLIRContext object (w/o affecting ownership)
             llvm::SmallVector<std::int64_t>{height, width}, // We construct the list here since a list isn't natively defined in the C-API,
-            static_cast<tt::DataType>(dataType) // Here we cast the int value to get the Enum value from `tt::DataType`
+            static_cast<ttcore::DataType>(dataType) // Here we cast the int value to get the Enum value from `ttcore::DataType`
         ) // Invoking the builtin get operator to create and get the pointer for some object
     );
 }

--- a/include/ttmlir/Conversion/Passes.td
+++ b/include/ttmlir/Conversion/Passes.td
@@ -94,15 +94,15 @@ def TTIRToTTIRGeneric: Pass<"ttir-to-ttir-generic", "::mlir::ModuleOp"> {
   let constructor = "createTTIRToTTIRGenericPass()";
   let options = [
       Option<"useTileMatmul", "use-tile-matmul", "bool", /*default=*/"true", "Use tile_matmul">,
-      Option<"defaultInputMemSpace", "default-input-memspace", "MemorySpace", /*default=*/"MemorySpace::DeviceL1", "Set default memspace for input tensors",
+      Option<"defaultInputMemSpace", "default-input-memspace", "ttcore::MemorySpace", /*default=*/"ttcore::MemorySpace::DeviceL1", "Set default memspace for input tensors",
           [{::llvm::cl::values(
-            clEnumValN(MemorySpace::DeviceL1, "l1", "L1"),
-            clEnumValN(MemorySpace::DeviceDRAM, "dram", "DRAM")
+            clEnumValN(ttcore::MemorySpace::DeviceL1, "l1", "L1"),
+            clEnumValN(ttcore::MemorySpace::DeviceDRAM, "dram", "DRAM")
           )}]>,
-      Option<"defaultOutputMemSpace", "default-output-memspace", "MemorySpace", /*default=*/"MemorySpace::DeviceL1", "Set default memspace for output tensors",
+      Option<"defaultOutputMemSpace", "default-output-memspace", "ttcore::MemorySpace", /*default=*/"ttcore::MemorySpace::DeviceL1", "Set default memspace for output tensors",
           [{::llvm::cl::values(
-            clEnumValN(MemorySpace::DeviceL1, "l1", "L1"),
-            clEnumValN(MemorySpace::DeviceDRAM, "dram", "DRAM")
+            clEnumValN(ttcore::MemorySpace::DeviceL1, "l1", "L1"),
+            clEnumValN(ttcore::MemorySpace::DeviceDRAM, "dram", "DRAM")
           )}]>
   ];
 }

--- a/include/ttmlir/Conversion/StableHLOToTTIR/ShardingUtils.h
+++ b/include/ttmlir/Conversion/StableHLOToTTIR/ShardingUtils.h
@@ -43,10 +43,9 @@ public:
                                       mlir::StringAttr shardingAttr);
 
   // Convert sdy.sharding to meshSharding.
-  llvm::Expected<bool>
-  convertSdyShardingToMeshSharding(mlir::sdy::TensorShardingAttr sdySharding,
-                                   mlir::sdy::MeshAttr mesh,
-                                   mlir::tt::MeshShardDirection direction);
+  llvm::Expected<bool> convertSdyShardingToMeshSharding(
+      mlir::sdy::TensorShardingAttr sdySharding, mlir::sdy::MeshAttr mesh,
+      mlir::tt::ttcore::MeshShardDirection direction);
 
   // Check and update arg sharding attribute and determine if
   // mesh_shard op needs to be created or not.
@@ -68,17 +67,17 @@ public:
                    mlir::sdy::MeshAttr meshAttr);
 
   // Given parsed MeshSharding info, get TensorMeshShardingAttr.
-  mlir::tt::TensorMeshShardingAttr
+  mlir::tt::ttcore::TensorMeshShardingAttr
   getTensorMeshShardingAttr(mlir::PatternRewriter &rewriter);
 
   // Given TensorMeshShardingAttr, extract MeshSharding info.
   void extractMeshShardingFromTensorMeshShardingAttr(
-      mlir::tt::MeshAttr mesh,
-      mlir::tt::TensorMeshShardingAttr tensorMeshShardingAttr,
-      mlir::tt::MeshShardDirection direction);
+      mlir::tt::ttcore::MeshAttr mesh,
+      mlir::tt::ttcore::TensorMeshShardingAttr tensorMeshShardingAttr,
+      mlir::tt::ttcore::MeshShardDirection direction);
 
   // Getter functions.
-  mlir::tt::MeshShardDirection getShardDirection() const {
+  mlir::tt::ttcore::MeshShardDirection getShardDirection() const {
     return shardDirection;
   }
 
@@ -90,7 +89,7 @@ public:
       const mlir::tt::sharding_utils::MeshSharding &meshSharding,
       size_t num_devices);
 
-  mlir::tt::MeshShardType getShardType() const { return shardType; }
+  mlir::tt::ttcore::MeshShardType getShardType() const { return shardType; }
   llvm::ArrayRef<int64_t> getShardShape() const { return shardShape; }
   llvm::ArrayRef<int64_t> getShardDims() const { return shardDims; }
   llvm::ArrayRef<int64_t> getMeshShape() const { return meshShape; }
@@ -103,8 +102,8 @@ private:
   llvm::Expected<bool> determineGSPMDShardingDims();
 
   // Set sharyType other than devices and reset values.
-  void setNonDevicesShardType(tt::MeshShardType targetShardType) {
-    assert(targetShardType != tt::MeshShardType::Devices);
+  void setNonDevicesShardType(ttcore::MeshShardType targetShardType) {
+    assert(targetShardType != ttcore::MeshShardType::Devices);
     shardType = targetShardType;
     // Specific values are required to fill corresponding attributes in
     // mesh_shard operation.
@@ -115,16 +114,19 @@ private:
 
   // Force dummy sharding op by setting shard_type to identity. The mesh_shard
   // op will be ignored at runtime by simply copying input tensor to output.
-  void setDummyShardingOp() { shardType = mlir::tt::MeshShardType::Identity; }
+  void setDummyShardingOp() {
+    shardType = mlir::tt::ttcore::MeshShardType::Identity;
+  }
 
   // Decide wheter to create mesh_shard op and shard_type. Detailed
   // description can be found in function body.
   bool determineMeshShardOpCreationAndShardType(bool foundArgSharding);
 
 private:
-  mlir::tt::MeshShardDirection shardDirection =
-      mlir::tt::MeshShardDirection::ShardToFull;
-  mlir::tt::MeshShardType shardType = mlir::tt::MeshShardType::Identity;
+  mlir::tt::ttcore::MeshShardDirection shardDirection =
+      mlir::tt::ttcore::MeshShardDirection::ShardToFull;
+  mlir::tt::ttcore::MeshShardType shardType =
+      mlir::tt::ttcore::MeshShardType::Identity;
   llvm::SmallVector<int64_t> shardShape{-1};
   llvm::SmallVector<int64_t> shardDims{-1};
   llvm::SmallVector<int64_t> meshShape{-1};
@@ -148,7 +150,7 @@ inline mlir::sdy::MeshAttr adjustSdyMeshAttr(mlir::Operation *srcOp,
 
 inline mlir::RankedTensorType addTensorMeshShardingAttrToRankedTensorType(
     mlir::RankedTensorType type,
-    mlir::tt::TensorMeshShardingAttr tensorMeshShardingAttr) {
+    mlir::tt::ttcore::TensorMeshShardingAttr tensorMeshShardingAttr) {
   mlir::Type elementType = type.getElementType();
   llvm::ArrayRef<int64_t> shape = type.getShape();
   return RankedTensorType::get(shape, elementType, tensorMeshShardingAttr);
@@ -156,7 +158,7 @@ inline mlir::RankedTensorType addTensorMeshShardingAttrToRankedTensorType(
 
 inline mlir::Type addTensorMeshShardingAttrToValue(
     mlir::Value value,
-    mlir::tt::TensorMeshShardingAttr tensorMeshShardingAttr) {
+    mlir::tt::ttcore::TensorMeshShardingAttr tensorMeshShardingAttr) {
   auto updatedType = addTensorMeshShardingAttrToRankedTensorType(
       mlir::cast<RankedTensorType>(value.getType()), tensorMeshShardingAttr);
   value.setType(updatedType);
@@ -165,7 +167,7 @@ inline mlir::Type addTensorMeshShardingAttrToValue(
 
 inline void addTensorMeshShardingAttrToFunctionArg(
     mlir::func::FuncOp funcOp, int64_t argIdx,
-    mlir::tt::TensorMeshShardingAttr tensorMeshShardingAttr) {
+    mlir::tt::ttcore::TensorMeshShardingAttr tensorMeshShardingAttr) {
   // Add TensorMeshShardingAttr to function arg.
   addTensorMeshShardingAttrToValue(funcOp.getArgument(argIdx),
                                    tensorMeshShardingAttr);
@@ -180,7 +182,7 @@ inline void addTensorMeshShardingAttrToFunctionArg(
 
 inline void addTensorMeshShardingAttrToFunctionRet(
     mlir::func::FuncOp funcOp, int64_t retIdx,
-    mlir::tt::TensorMeshShardingAttr tensorMeshShardingAttr) {
+    mlir::tt::ttcore::TensorMeshShardingAttr tensorMeshShardingAttr) {
   // Add TensorMeshShardingAttr to function return.
   auto *funcReturnOp = funcOp.getBody().front().getTerminator();
   addTensorMeshShardingAttrToValue(funcReturnOp->getOperand(retIdx),
@@ -200,7 +202,7 @@ template <typename AttrType>
 bool checkAndRemoveFuncArgSharding(
     mlir::PatternRewriter &rewriter, mlir::func::FuncOp funcOp, uint64_t argIdx,
     AttrType shardingAttr,
-    mlir::tt::TensorMeshShardingAttr tensorMeshShardingAttr,
+    mlir::tt::ttcore::TensorMeshShardingAttr tensorMeshShardingAttr,
     llvm::StringRef argShardingStrRef) {
   auto argShardingAttr =
       funcOp.getArgAttrOfType<AttrType>(argIdx, argShardingStrRef);
@@ -227,7 +229,7 @@ template <typename AttrType>
 bool checkAndRemoveFuncReturnSharding(
     mlir::PatternRewriter &rewriter, mlir::func::FuncOp funcOp, uint64_t retIdx,
     AttrType shardingAttr,
-    mlir::tt::TensorMeshShardingAttr tensorMeshShardingAttr,
+    mlir::tt::ttcore::TensorMeshShardingAttr tensorMeshShardingAttr,
     llvm::StringRef retShardingStrRef) {
   auto retShardingAttr =
       funcOp.getResultAttrOfType<AttrType>(retIdx, retShardingStrRef);

--- a/include/ttmlir/Conversion/TTIRToTTNN/Utils.h
+++ b/include/ttmlir/Conversion/TTIRToTTNN/Utils.h
@@ -28,8 +28,8 @@ generateNHWFlatten(mlir::TypedValue<mlir::RankedTensorType> input,
 
 // Returns DataTypeAttr from tensor layout if present, or an empty DataTypeAttr
 // otherwise.
-DataTypeAttr getDataTypeAttrFromTensorLayout(RankedTensorType type,
-                                             PatternRewriter &rewriter);
+ttcore::DataTypeAttr getDataTypeAttrFromTensorLayout(RankedTensorType type,
+                                                     PatternRewriter &rewriter);
 
 } // namespace mlir::tt::ttir_to_ttnn::utils
 

--- a/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
+++ b/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
@@ -522,13 +522,14 @@ struct EmitCTypeConverter<::ttnn::types::ShardMode> {
 template <>
 struct EmitCTypeConverter<::ttnn::DataType> {
   static std::optional<std::string> convert(mlir::Attribute attr) {
-    if (auto dataTypeAttr = mlir::dyn_cast_if_present<tt::DataTypeAttr>(attr)) {
+    if (auto dataTypeAttr =
+            mlir::dyn_cast_if_present<ttcore::DataTypeAttr>(attr)) {
       return convert(dataTypeAttr);
     }
     return {};
   }
 
-  static std::string convert(tt::DataTypeAttr attr) {
+  static std::string convert(ttcore::DataTypeAttr attr) {
     if (!attr) {
       return TypeNameV<std::nullopt_t>;
     }
@@ -536,41 +537,41 @@ struct EmitCTypeConverter<::ttnn::DataType> {
     return convert(attr.getValue());
   }
 
-  static std::string convert(tt::DataType attr) {
+  static std::string convert(ttcore::DataType attr) {
     std::string buf;
     llvm::raw_string_ostream rso(buf);
 
     rso << TypeNameV<::ttnn::DataType> << "::";
     switch (attr) {
-    case tt::DataType::BFloat16:
+    case ttcore::DataType::BFloat16:
       rso << "BFLOAT16";
       break;
-    case tt::DataType::Float32:
+    case ttcore::DataType::Float32:
       rso << "FLOAT32";
       break;
-    case tt::DataType::UInt32:
+    case ttcore::DataType::UInt32:
       rso << "UINT32";
       break;
-    case tt::DataType::BFP_BFloat8:
+    case ttcore::DataType::BFP_BFloat8:
       rso << "BFLOAT8_B";
       break;
-    case tt::DataType::BFP_BFloat4:
+    case ttcore::DataType::BFP_BFloat4:
       rso << "BFLOAT4_B";
       break;
-    case tt::DataType::UInt8:
+    case ttcore::DataType::UInt8:
       rso << "UINT8";
       break;
-    case tt::DataType::UInt16:
+    case ttcore::DataType::UInt16:
       rso << "UINT16";
       break;
-    case tt::DataType::Int32:
+    case ttcore::DataType::Int32:
       rso << "INT32";
       break;
-    case tt::DataType::Float16:
-    case tt::DataType::BFP_Float2:
-    case tt::DataType::BFP_Float4:
-    case tt::DataType::BFP_Float8:
-    case tt::DataType::BFP_BFloat2:
+    case ttcore::DataType::Float16:
+    case ttcore::DataType::BFP_Float2:
+    case ttcore::DataType::BFP_Float4:
+    case ttcore::DataType::BFP_Float8:
+    case ttcore::DataType::BFP_BFloat2:
       llvm_unreachable("Unsupported ttnn::DataType");
     }
 
@@ -1138,13 +1139,13 @@ inline std::string convert(ttnn::ShapeAttr attr) {
   return buf;
 }
 
-inline std::string convert(tt::DataType attr) {
+inline std::string convert(ttcore::DataType attr) {
   // TODO (azecevic): Will be deprecated!
   // https://github.com/tenstorrent/tt-mlir/issues/3635
   return EmitCTypeConverter<::ttnn::DataType>::convert(attr);
 }
 
-inline std::string convert(tt::DataTypeAttr attr) {
+inline std::string convert(ttcore::DataTypeAttr attr) {
   if (!attr) {
     return TypeNameV<std::nullopt_t>;
   }
@@ -1250,11 +1251,11 @@ public:
     return rewriter.getAttr<emitc::OpaqueAttr>(convert(attr));
   }
 
-  mlir::Attribute emit(tt::DataType attr) {
+  mlir::Attribute emit(ttcore::DataType attr) {
     return rewriter.getAttr<emitc::OpaqueAttr>(convert(attr));
   }
 
-  mlir::Attribute emit(tt::DataTypeAttr attr) {
+  mlir::Attribute emit(ttcore::DataTypeAttr attr) {
     return rewriter.getAttr<emitc::OpaqueAttr>(
         tt::ttnn_to_emitc::convert(attr));
   }
@@ -1491,7 +1492,7 @@ public:
         layoutAttr.getContext(), layoutAttr.getBufferType());
     ttnn::TensorMemoryLayoutAttr tensorMemoryLayout = layoutAttr.getMemLayout();
 
-    DeviceAttr deviceAttr = lookupDevice(op);
+    ttcore::DeviceAttr deviceAttr = ttcore::lookupDevice(op);
 
     ttnn::MemoryConfigAttr memoryConfigAttr = ttnn::MemoryConfigAttr::get(
         layoutAttr.getContext(), tensorMemoryLayout, bufferTypeAttr,
@@ -1513,8 +1514,8 @@ public:
     auto weightLayoutAttr =
         mlir::cast<ttnn::TTNNLayoutAttr>(weightType.getEncoding());
 
-    DataType inputDataType = inputLayoutAttr.getDataType();
-    DataType weightDataType = weightLayoutAttr.getDataType();
+    ttcore::DataType inputDataType = inputLayoutAttr.getDataType();
+    ttcore::DataType weightDataType = weightLayoutAttr.getDataType();
 
     std::string buf;
     llvm::raw_string_ostream rso(buf);

--- a/include/ttmlir/Conversion/TTNNToEmitC/Utils.h
+++ b/include/ttmlir/Conversion/TTNNToEmitC/Utils.h
@@ -47,11 +47,11 @@ emitc::OpaqueAttr convertBoolAttr(Builder &builder, BoolAttr attr);
 
 // Create emitc::OpaqueAttr for ttnn::DataType
 //
-emitc::OpaqueAttr convertDType(Builder &builder, tt::DataTypeAttr attr);
+emitc::OpaqueAttr convertDType(Builder &builder, ttcore::DataTypeAttr attr);
 
 // Create emitc::OpaqueAttr for ttnn::operations::reduction::ReduceType
 emitc::OpaqueAttr convertReduceType(ConversionPatternRewriter &rewriter,
-                                    tt::ReduceType reduceType);
+                                    ttcore::ReduceType reduceType);
 
 // Create emitc::OpaqueAttr for ttnn::SmallVector used in Reduction ops
 //

--- a/include/ttmlir/Dialect/StableHLO/Pipelines/StableHLOPipelines.h
+++ b/include/ttmlir/Dialect/StableHLO/Pipelines/StableHLOPipelines.h
@@ -32,21 +32,24 @@ struct AutomaticShardingPipelineOptions
       *this, OptionNames::automaticArgAnalysis,
       llvm::cl::desc("Automatically determine argument shardings.")};
 
-  Option<tt::TTArgumentTypeMap, tt::ArgumentTypeMapParser> argumentTypeMap{
-      *this, tt::OptionNames::argumentTypes,
-      llvm::cl::desc(
-          "Map of function name to argument types. To use this option in the "
-          "command line, you must provide a whitespace-free string\n\t"
-          " which is a sequence of phrases in the form "
-          "\"<FUNC_NAME_STR>=<ARG_TYPES>\" separated by semicolons, where "
-          "<FUNC_NAME_STR>\n\t"
-          " is the name of a function and <ARG_TYPES> is a sequence of "
-          "argument types separated by commas. Each of which must be one\n\t"
-          " of \"input\", \"parameter\" or \"constant\". \n\t"
-          " Example: "
-          "\"argument-types=forward=input,parameter,parameter,constant\""
-          "\n\n"),
-      llvm::cl::init(TTArgumentTypeMap())};
+  Option<ttcore::TTArgumentTypeMap, ttcore::ArgumentTypeMapParser>
+      argumentTypeMap{
+          *this, ttcore::OptionNames::argumentTypes,
+          llvm::cl::desc(
+              "Map of function name to argument types. To use this option in "
+              "the "
+              "command line, you must provide a whitespace-free string\n\t"
+              " which is a sequence of phrases in the form "
+              "\"<FUNC_NAME_STR>=<ARG_TYPES>\" separated by semicolons, where "
+              "<FUNC_NAME_STR>\n\t"
+              " is the name of a function and <ARG_TYPES> is a sequence of "
+              "argument types separated by commas. Each of which must be "
+              "one\n\t"
+              " of \"input\", \"parameter\" or \"constant\". \n\t"
+              " Example: "
+              "\"argument-types=forward=input,parameter,parameter,constant\""
+              "\n\n"),
+          llvm::cl::init(ttcore::TTArgumentTypeMap())};
 };
 
 void createAutomaticShardingPipeline(

--- a/include/ttmlir/Dialect/TTCore/IR/TTCoreAttrInterfaces.td
+++ b/include/ttmlir/Dialect/TTCore/IR/TTCoreAttrInterfaces.td
@@ -14,7 +14,7 @@ include "mlir/IR/BuiltinAttributeInterfaces.td"
 
 def TTCore_DeviceLayoutInterface : AttrInterface<"DeviceLayoutInterface"> {
   let summary = "TT DeviceLayoutInterface";
-  let cppNamespace = "::mlir::tt";
+  let cppNamespace = "::mlir::tt::ttcore";
   let description = [{
     This interface implies supporting a shaped type that conforms to Tenstorrent device layout.
     Tenstorrent devices are divided into a grid of cores, onto which we map tensors that have been

--- a/include/ttmlir/Dialect/TTCore/IR/TTCoreBase.td
+++ b/include/ttmlir/Dialect/TTCore/IR/TTCoreBase.td
@@ -17,7 +17,7 @@ def TTCore_Dialect : Dialect {
     let description = [{
         This dialect defines types and attributes common to all TT dialects.
     }];
-    let cppNamespace = "::mlir::tt";
+    let cppNamespace = "::mlir::tt::ttcore";
 
     let useDefaultTypePrinterParser = 1;
     let useDefaultAttributePrinterParser = 1;
@@ -40,7 +40,7 @@ class TTCore_Op<string mnemonic, list<Trait> traits = []> :
 //===----------------------------------------------------------------------===//
 
 class TTCore_Trait<string name> : NativeOpTrait<name> {
-  let cppNamespace = "::mlir::tt::Trait";
+  let cppNamespace = "::mlir::tt::ttcore::Trait";
 }
 
 // Trait for ops which should be duplicated in all const-eval subgraphs + original.

--- a/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsEnums.td
+++ b/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsEnums.td
@@ -38,7 +38,7 @@ def TTCore_DataType : I32EnumAttr<"DataType", "TT DataTypes",
                             TTCore_Int32
                            ]> {
   let genSpecializedAttr = 0;
-  let cppNamespace = "::mlir::tt";
+  let cppNamespace = "::mlir::tt::ttcore";
   let stringToSymbolFnName = "DataTypeStringToEnum";
   let symbolToStringFnName = "DataTypeEnumToString";
 }
@@ -54,7 +54,7 @@ def TTCore_Arch : I32EnumAttr<"Arch", "TT Arch",
                             TTCore_Blackhole,
                            ]> {
   let genSpecializedAttr = 0;
-  let cppNamespace = "::mlir::tt";
+  let cppNamespace = "::mlir::tt::ttcore";
 }
 
 
@@ -73,7 +73,7 @@ def TTCore_MemorySpace : I32EnumAttr<"MemorySpace", "TT MemorySpace",
                             TTCore_RegisterDst,
                            ]> {
   let genSpecializedAttr = 0;
-  let cppNamespace = "::mlir::tt";
+  let cppNamespace = "::mlir::tt::ttcore";
 }
 
 def TTCore_Parallel : I32EnumAttrCase<"Parallel", 0, "parallel">;
@@ -85,7 +85,7 @@ def TTCore_IteratorType : I32EnumAttr<"IteratorType", "TT IteratorType",
                             TTCore_Reduction,
                            ]> {
   let genSpecializedAttr = 0;
-  let cppNamespace = "::mlir::tt";
+  let cppNamespace = "::mlir::tt::ttcore";
 }
 
 def TTCore_Undef : I32EnumAttrCase<"Undef", 0, "undef">;
@@ -103,7 +103,7 @@ def TTCore_OOBVal : I32EnumAttr<"OOBVal", "TT OOBVal",
                             TTCore_NegInf,
                            ]> {
   let genSpecializedAttr = 0;
-  let cppNamespace = "::mlir::tt";
+  let cppNamespace = "::mlir::tt::ttcore";
 }
 
 def TTCore_ChipCapabilityPCIE : I32BitEnumAttrCaseBit<"PCIE", 0, "pcie">;
@@ -115,7 +115,7 @@ def TTCore_ChipCapability : I32BitEnumAttr<"ChipCapability", "TT Chip Capabiliti
                             TTCore_ChipCapabilityHostMMIO,
                            ]> {
   let genSpecializedAttr = 1;
-  let cppNamespace = "::mlir::tt";
+  let cppNamespace = "::mlir::tt::ttcore";
 }
 
 def TTCore_ReduceType_Sum  : I32EnumAttrCase<"Sum",  0, "sum">;
@@ -135,7 +135,7 @@ def TTCore_ReduceType: I32EnumAttr<"ReduceType", "TT Reduce Type",
                            TTCore_ReduceType_Var,
                           ]> {
   let genSpecializedAttr = 0;
-  let cppNamespace = "::mlir::tt";
+  let cppNamespace = "::mlir::tt::ttcore";
 }
 
 def TTCore_MeshShardDirection_FullToShard : I32EnumAttrCase<"FullToShard",  0, "full_to_shard">;
@@ -147,7 +147,7 @@ def TTCore_MeshShardDirection: I32EnumAttr<"MeshShardDirection", "TT MeshShardDi
                            TTCore_MeshShardDirection_ShardToFull,
                           ]> {
   let genSpecializedAttr = 0;
-  let cppNamespace = "::mlir::tt";
+  let cppNamespace = "::mlir::tt::ttcore";
 }
 
 def TTCore_MeshShardType_Identity  : I32EnumAttrCase<"Identity",  0, "identity">;
@@ -163,7 +163,7 @@ def TTCore_MeshShardType: I32EnumAttr<"MeshShardType", "TT MeshShardType",
                            TTCore_MeshShardType_Devices,
                           ]> {
   let genSpecializedAttr = 0;
-  let cppNamespace = "::mlir::tt";
+  let cppNamespace = "::mlir::tt::ttcore";
 }
 
 def TTCore_CPURoleHost : I32EnumAttrCase<"Host", 0, "host">;
@@ -175,7 +175,7 @@ def TTCore_CPURole : I32EnumAttr<"CPURole", "TT CPU Role",
                               TTCore_CPURoleDevice,
                             ]> {
   let genSpecializedAttr = 0;
-  let cppNamespace = "::mlir::tt";
+  let cppNamespace = "::mlir::tt::ttcore";
 }
 
 def TTCore_ArgumentType_Input : I32EnumAttrCase<"Input", 0, "input">;
@@ -191,7 +191,7 @@ def TTCore_ArgumentType : I32EnumAttr<"ArgumentType", "Argument Type",
                               TTCore_ArgumentType_Default,
                             ]> {
   let genSpecializedAttr = 0;
-  let cppNamespace = "::mlir::tt";
+  let cppNamespace = "::mlir::tt::ttcore";
   let stringToSymbolFnName = "ArgumentTypeStringToEnum";
   let symbolToStringFnName = "ArgumentTypeEnumToString";
 }

--- a/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h
+++ b/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h
@@ -14,7 +14,7 @@
 
 #include <numeric>
 
-namespace mlir::tt {
+namespace mlir::tt::ttcore {
 struct PhysGridResultIdx {
   enum : int64_t {
     DeviceIdx = 0,
@@ -302,7 +302,7 @@ inline uint8_t getNumberOfBits(const DataType dtype) {
   }
 }
 
-} // namespace mlir::tt
+} // namespace mlir::tt::ttcore
 
 #include "ttmlir/Dialect/TTCore/IR/TTCoreAttrInterfaces.h.inc"
 
@@ -312,7 +312,7 @@ inline uint8_t getNumberOfBits(const DataType dtype) {
 #define GET_TYPEDEF_CLASSES
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h.inc"
 
-namespace mlir::tt {
+namespace mlir::tt::ttcore {
 
 mlir::AffineMap collapsedLinearAffineMap(
     mlir::MLIRContext *context, llvm::ArrayRef<int64_t> shape,
@@ -321,15 +321,16 @@ mlir::AffineMap collapsedLinearAffineMap(
 
 mlir::SmallVector<std::int64_t>
 calculateLogicalShardShape(mlir::ArrayRef<int64_t> tensorShape,
-                           mlir::AffineMap linear, mlir::tt::GridAttr grid);
+                           mlir::AffineMap linear,
+                           mlir::tt::ttcore::GridAttr grid);
 
 template <typename T, typename TAttr>
 mlir::MemRefType buildMemRef(mlir::MLIRContext *context,
                              llvm::ArrayRef<int64_t> shardShape,
                              mlir::Type elementType, T memorySpace) {
   llvm::SmallVector<int64_t> scalarShardShape(shardShape);
-  if (mlir::isa<mlir::tt::TileType>(elementType)) {
-    scalarShardShape = mlir::cast<mlir::tt::TileType>(elementType)
+  if (mlir::isa<mlir::tt::ttcore::TileType>(elementType)) {
+    scalarShardShape = mlir::cast<mlir::tt::ttcore::TileType>(elementType)
                            .getTiledShape(scalarShardShape);
   }
   return mlir::MemRefType::get(
@@ -349,8 +350,7 @@ inline MemorySpace getMemorySpace(MemorySpaceAttr memorySpaceAttr) {
 }
 
 inline MemorySpace getMemorySpace(MemRefType memref) {
-  return getMemorySpace(
-      mlir::cast<tt::MemorySpaceAttr>(memref.getMemorySpace()));
+  return getMemorySpace(mlir::cast<MemorySpaceAttr>(memref.getMemorySpace()));
 }
 
 inline MemorySpace getMemorySpace(Type memrefType) {
@@ -361,6 +361,6 @@ inline MemorySpace getMemorySpace(Value memrefTypedValue) {
   return getMemorySpace(memrefTypedValue.getType());
 }
 
-} // namespace mlir::tt
+} // namespace mlir::tt::ttcore
 
 #endif

--- a/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.td
+++ b/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.td
@@ -214,8 +214,8 @@ def TTCore_SystemDescAttr : TTCore_Attr<"SystemDesc", "system_desc"> {
   let assemblyFormat = "`<` `[` $cpuDescs `]` `,` `[` $chipDescs `]` `,` `[` $chipDescIndices `]` `,` `[` $chipCapabilities `]` `,` `[` $chipCoords `]` (`,` `[` $chipChannels^ `]`)? `>`";
 
   let extraClassDeclaration = [{
-    static tt::SystemDescAttr getDefault(MLIRContext *context, tt::Arch arch = tt::Arch::WormholeB0, const llvm::SmallVector<int64_t> &meshShape = {1});
-    static FailureOr<tt::SystemDescAttr> getFromPath(MLIRContext *context, StringRef path, llvm::function_ref<mlir::InFlightDiagnostic()> diagFn);
+    static SystemDescAttr getDefault(MLIRContext *context, Arch arch = Arch::WormholeB0, const llvm::SmallVector<int64_t> &meshShape = {1});
+    static FailureOr<SystemDescAttr> getFromPath(MLIRContext *context, StringRef path, llvm::function_ref<mlir::InFlightDiagnostic()> diagFn);
     ChipDescAttr getChipDesc(unsigned chipIndex) const;
     unsigned getAddressAlignBytes(unsigned chipIndex = 0) const;
     unsigned getAddressAlignBytes(MemorySpace memorySpace, unsigned chipIndex = 0) const;

--- a/include/ttmlir/Dialect/TTCore/IR/TTCoreTraits.h
+++ b/include/ttmlir/Dialect/TTCore/IR/TTCoreTraits.h
@@ -8,7 +8,7 @@
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Support/LLVM.h"
 
-namespace mlir::tt::Trait {
+namespace mlir::tt::ttcore::Trait {
 template <typename Ty>
 class TTCoreCreationOpTrait
     : public mlir::OpTrait::TraitBase<Ty, TTCoreCreationOpTrait> {};
@@ -16,6 +16,6 @@ class TTCoreCreationOpTrait
 template <typename Ty>
 class TTCoreDuplicateConstEvalTrait
     : public mlir::OpTrait::TraitBase<Ty, TTCoreDuplicateConstEvalTrait> {};
-} // namespace mlir::tt::Trait
+} // namespace mlir::tt::ttcore::Trait
 
 #endif

--- a/include/ttmlir/Dialect/TTCore/IR/Utils.h
+++ b/include/ttmlir/Dialect/TTCore/IR/Utils.h
@@ -12,7 +12,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/SymbolTable.h"
 
-namespace mlir::tt {
+namespace mlir::tt::ttcore {
 
 class DeviceOp;
 class DeviceAttr;
@@ -51,11 +51,11 @@ getConstsAndParams(mlir::func::FuncOp funcOp) {
   llvm::SmallPtrSet<mlir::BlockArgument, 4> constsAndParams;
 
   for (auto arg : funcOp.getArguments()) {
-    if (auto typeAttr = funcOp.getArgAttrOfType<mlir::tt::ArgumentTypeAttr>(
-            arg.getArgNumber(), mlir::tt::ArgumentTypeAttr::name)) {
+    if (auto typeAttr = funcOp.getArgAttrOfType<ArgumentTypeAttr>(
+            arg.getArgNumber(), ArgumentTypeAttr::name)) {
       auto argTypeValue = typeAttr.getValue();
-      if (argTypeValue == mlir::tt::ArgumentType::Parameter ||
-          argTypeValue == mlir::tt::ArgumentType::Constant) {
+      if (argTypeValue == ArgumentType::Parameter ||
+          argTypeValue == ArgumentType::Constant) {
         constsAndParams.insert(arg);
       }
     }
@@ -69,6 +69,6 @@ ArrayRef<int64_t> getTensorTileShape(RankedTensorType tensorType);
 
 ArrayRef<int64_t> getTensorTileShapeOrEmpty(RankedTensorType tensorType);
 
-} // namespace mlir::tt
+} // namespace mlir::tt::ttcore
 
 #endif // TTMLIR_DIALECT_TTCORE_IR_UTILS_H

--- a/include/ttmlir/Dialect/TTCore/Transforms/Passes.h
+++ b/include/ttmlir/Dialect/TTCore/Transforms/Passes.h
@@ -7,7 +7,7 @@
 
 #include "mlir/Pass/Pass.h"
 
-namespace mlir::tt {
+namespace mlir::tt::ttcore {
 
 #define GEN_PASS_DECL
 #include "ttmlir/Dialect/TTCore/Transforms/Passes.h.inc"
@@ -15,6 +15,6 @@ namespace mlir::tt {
 #define GEN_PASS_REGISTRATION
 #include "ttmlir/Dialect/TTCore/Transforms/Passes.h.inc"
 
-} // namespace mlir::tt
+} // namespace mlir::tt::ttcore
 
 #endif // TTMLIR_DIALECT_TTCORE_TRANSFORMS_PASSES_H

--- a/include/ttmlir/Dialect/TTCore/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTCore/Transforms/Passes.td
@@ -10,7 +10,7 @@ include "mlir/Pass/PassBase.td"
 def TTCoreWrapDeviceModulePass : Pass<"ttcore-wrap-device-module", "::mlir::ModuleOp"> {
   let summary = "Wrap top-level builtin.module in ttcore.device_module";
   let description = [{
-    Utility pass to convert a top-level ModuleOp into a module wrapped inside a tt::DeviceModuleOp.
+    Utility pass to convert a top-level ModuleOp into a module wrapped inside a ttcore::DeviceModuleOp.
     Example:
     Input:
     module {
@@ -26,13 +26,13 @@ def TTCoreWrapDeviceModulePass : Pass<"ttcore-wrap-device-module", "::mlir::Modu
       }
     }
   }];
-  let dependentDialects = ["::mlir::tt::TTCoreDialect"];
+  let dependentDialects = ["::mlir::tt::ttcore::TTCoreDialect"];
 }
 
 def TTCoreUnwrapDeviceModulePass : Pass<"ttcore-unwrap-device-module", "::mlir::ModuleOp"> {
   let summary = "Move ttcore.device_module contents to top-level builtin.module";
   let description = [{
-    Utility pass to extract the ModuleOp inside a tt::DeviceModuleOp to the top-level ModuleOp.  This might help run passes via CLI more simply.
+    Utility pass to extract the ModuleOp inside a ttcore::DeviceModuleOp to the top-level ModuleOp.  This might help run passes via CLI more simply.
 
     Example:
     Input:
@@ -48,7 +48,7 @@ def TTCoreUnwrapDeviceModulePass : Pass<"ttcore-unwrap-device-module", "::mlir::
       func.func foo() {}
     }
   }];
-  let dependentDialects = ["::mlir::tt::TTCoreDialect"];
+  let dependentDialects = ["::mlir::tt::ttcore::TTCoreDialect"];
 }
 
 def TTCoreRegisterDevicePass : Pass<"ttcore-register-device", "::mlir::ModuleOp"> {
@@ -58,13 +58,13 @@ def TTCoreRegisterDevicePass : Pass<"ttcore-register-device", "::mlir::ModuleOp"
   }];
 
   list<Option> options = [
-        Option<"mockSystemDescArch", "mock-system-desc-arch", "tt::Arch",
-            /*default=*/"tt::Arch::WormholeB0",
+        Option<"mockSystemDescArch", "mock-system-desc-arch", "ttcore::Arch",
+            /*default=*/"ttcore::Arch::WormholeB0",
             "Arch name for constructing a mock system descriptor in lieu of system-desc-path.",
             [{::llvm::cl::values(
-              clEnumValN(tt::Arch::WormholeB0, "wormhole_b0",
+              clEnumValN(ttcore::Arch::WormholeB0, "wormhole_b0",
                "Use mock wormhole_b0 system desc."),
-              clEnumValN(tt::Arch::Blackhole, "blackhole",
+              clEnumValN(ttcore::Arch::Blackhole, "blackhole",
                "Use mock blackhole system desc.")
              )}]>,
         Option<"systemDescPath", "system-desc-path", "std::string", "", "System desc path">,

--- a/include/ttmlir/Dialect/TTCore/Transforms/Transforms.h
+++ b/include/ttmlir/Dialect/TTCore/Transforms/Transforms.h
@@ -10,15 +10,14 @@
 
 #include <string>
 
-namespace mlir::tt {
+namespace mlir::tt::ttcore {
 
-void registerDevice(ModuleOp module,
-                    tt::Arch mockSystemDescArch = tt::Arch::WormholeB0,
+void registerDevice(ModuleOp module, Arch mockSystemDescArch = Arch::WormholeB0,
                     ArrayRef<int64_t> meshShape = {});
 
 void registerDevice(ModuleOp module, const std::string &systemDescPath,
                     ArrayRef<int64_t> meshShape = {});
 
-} // namespace mlir::tt
+} // namespace mlir::tt::ttcore
 
 #endif // TTMLIR_DIALECT_TTCORE_TRANSFORMS_TRANSFORMS_H

--- a/include/ttmlir/Dialect/TTCore/Utils/CoreRangeSet.h
+++ b/include/ttmlir/Dialect/TTCore/Utils/CoreRangeSet.h
@@ -10,7 +10,7 @@
 
 #include <tuple>
 
-namespace mlir::tt::utils {
+namespace mlir::tt::ttcore::utils {
 
 using locSize2d = std::tuple<std::array<int32_t, 2>,  //  {{locX, locY},
                              std::array<int32_t, 2>>; //  {sizeX, sizeY}}
@@ -69,6 +69,6 @@ toCoreRangeSet(llvm::ArrayRef<int64_t> virtualGridShape,
   return coreRangeSet;
 }
 
-} // namespace mlir::tt::utils
+} // namespace mlir::tt::ttcore::utils
 
 #endif // TTMLIR_DIALECT_TTCORE_UTILS_CORERANGESET_H

--- a/include/ttmlir/Dialect/TTCore/Utils/Mesh.h
+++ b/include/ttmlir/Dialect/TTCore/Utils/Mesh.h
@@ -12,26 +12,24 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
 
-namespace mlir::tt::utils {
+namespace mlir::tt::ttcore::utils {
 
 // Add a new mesh info to module attribute.
 inline void addMeshToModuleAttribute(PatternRewriter &rewriter,
                                      mlir::ModuleOp module, StringAttr meshName,
                                      llvm::ArrayRef<int64_t> meshShape) {
   MLIRContext *context = rewriter.getContext();
-  llvm::SmallVector<tt::MeshAttr> meshes;
-  if (auto meshesAttr =
-          module->getAttrOfType<tt::MeshesAttr>(tt::MeshesAttr::name)) {
-    meshes = llvm::SmallVector<tt::MeshAttr>(meshesAttr.getMeshes());
+  llvm::SmallVector<MeshAttr> meshes;
+  if (auto meshesAttr = module->getAttrOfType<MeshesAttr>(MeshesAttr::name)) {
+    meshes = llvm::SmallVector<MeshAttr>(meshesAttr.getMeshes());
   }
   // Avoid adding multiple meshes with the same name and shape as GSPMD may try
   // to add the same meshes.
   if (llvm::all_of(meshes,
-                   [&](tt::MeshAttr m) { return m.getName() != meshName; })) {
-    meshes.push_back(tt::MeshAttr::get(context, meshName, meshShape));
+                   [&](MeshAttr m) { return m.getName() != meshName; })) {
+    meshes.push_back(MeshAttr::get(context, meshName, meshShape));
     rewriter.modifyOpInPlace(module, [&]() {
-      module->setAttr(tt::MeshesAttr::name,
-                      tt::MeshesAttr::get(context, meshes));
+      module->setAttr(MeshesAttr::name, MeshesAttr::get(context, meshes));
     });
   }
 }
@@ -42,8 +40,7 @@ inline void addMeshToModuleAttribute(PatternRewriter &rewriter,
 // If both exist, compare mesh and throw error if they are different.
 inline llvm::Expected<llvm::SmallVector<int64_t>>
 determineMeshShape(mlir::ModuleOp module, llvm::ArrayRef<int64_t> meshShape) {
-  if (auto meshesAttr =
-          module->getAttrOfType<tt::MeshesAttr>(tt::MeshesAttr::name)) {
+  if (auto meshesAttr = module->getAttrOfType<MeshesAttr>(MeshesAttr::name)) {
     llvm::ArrayRef<MeshAttr> meshAttr = meshesAttr.getMeshes();
     if (meshAttr.empty()) {
       return llvm::SmallVector<int64_t>(meshShape);
@@ -61,6 +58,6 @@ determineMeshShape(mlir::ModuleOp module, llvm::ArrayRef<int64_t> meshShape) {
   return llvm::SmallVector<int64_t>(meshShape);
 }
 
-} // namespace mlir::tt::utils
+} // namespace mlir::tt::ttcore::utils
 
 #endif // TTMLIR_DIALECT_TTCORE_UTILS_MESH_H

--- a/include/ttmlir/Dialect/TTCore/Utils/PhysicalCoreCoord.h
+++ b/include/ttmlir/Dialect/TTCore/Utils/PhysicalCoreCoord.h
@@ -7,7 +7,7 @@
 
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 
-namespace mlir::tt {
+namespace mlir::tt::ttcore {
 struct PhysicalCoreCoord {
   std::int64_t d = 0;
   std::int64_t y = 0;
@@ -51,7 +51,7 @@ class PhysicalCoreCoordMapping {
 public:
   static PhysicalCoreCoordMapping
   getWorkerMapping(ArrayRef<unsigned> chipIds,
-                   ArrayRef<tt::ChipDescAttr> chipDescs) {
+                   ArrayRef<ChipDescAttr> chipDescs) {
     SmallVector<std::array<int64_t, 2>> physCores;
     ArrayRef<int64_t> firstChipGrid = chipDescs[chipIds.front()].getGrid();
     assert(firstChipGrid.size() == 2);
@@ -76,8 +76,7 @@ public:
   }
 
   static PhysicalCoreCoordMapping
-  getDramMapping(ArrayRef<unsigned> chipIds,
-                 ArrayRef<tt::ChipDescAttr> chipDescs) {
+  getDramMapping(ArrayRef<unsigned> chipIds, ArrayRef<ChipDescAttr> chipDescs) {
     ArrayRef<CoreCoordAttr> firstChipDramCores =
         chipDescs[chipIds.front()].getChipPhysicalHelperCores().getDram();
 
@@ -101,7 +100,7 @@ public:
 
   static PhysicalCoreCoordMapping
   getMemorySpaceMapping(ArrayRef<unsigned> chipIds,
-                        ArrayRef<tt::ChipDescAttr> chipDescs,
+                        ArrayRef<ChipDescAttr> chipDescs,
                         MemorySpace memorySpace) {
     switch (memorySpace) {
     case MemorySpace::DeviceL1:
@@ -126,26 +125,26 @@ private:
   std::array<int64_t, 2> grid;
   SmallVector<std::array<int64_t, 2>> physCores;
 };
-} // namespace mlir::tt
+} // namespace mlir::tt::ttcore
 
 // Make PhysicalCoreCoord hashable.
 namespace llvm {
 template <>
-struct DenseMapInfo<mlir::tt::PhysicalCoreCoord> {
-  static mlir::tt::PhysicalCoreCoord getEmptyKey() {
-    return mlir::tt::PhysicalCoreCoord{-1, -1, -1};
+struct DenseMapInfo<mlir::tt::ttcore::PhysicalCoreCoord> {
+  static mlir::tt::ttcore::PhysicalCoreCoord getEmptyKey() {
+    return mlir::tt::ttcore::PhysicalCoreCoord{-1, -1, -1};
   }
 
-  static mlir::tt::PhysicalCoreCoord getTombstoneKey() {
-    return mlir::tt::PhysicalCoreCoord{-2, -2, -2};
+  static mlir::tt::ttcore::PhysicalCoreCoord getTombstoneKey() {
+    return mlir::tt::ttcore::PhysicalCoreCoord{-2, -2, -2};
   }
 
-  static unsigned getHashValue(mlir::tt::PhysicalCoreCoord coord) {
+  static unsigned getHashValue(mlir::tt::ttcore::PhysicalCoreCoord coord) {
     return llvm::hash_combine(coord.d, coord.y, coord.x);
   }
 
-  static bool isEqual(mlir::tt::PhysicalCoreCoord lhs,
-                      mlir::tt::PhysicalCoreCoord rhs) {
+  static bool isEqual(mlir::tt::ttcore::PhysicalCoreCoord lhs,
+                      mlir::tt::ttcore::PhysicalCoreCoord rhs) {
     return lhs == rhs;
   }
 };

--- a/include/ttmlir/Dialect/TTCore/Utils/PopulateArgumentTypes.h
+++ b/include/ttmlir/Dialect/TTCore/Utils/PopulateArgumentTypes.h
@@ -10,7 +10,7 @@
 
 #include "llvm/Support/CommandLine.h"
 
-namespace mlir::tt {
+namespace mlir::tt::ttcore {
 
 using TTArgumentTypeMap = llvm::StringMap<SmallVector<ArgumentType>>;
 
@@ -42,6 +42,6 @@ inline void registerTTPopulateArgumentTypes() {
     return createTTPopulateArgumentTypes();
   });
 }
-} // namespace mlir::tt
+} // namespace mlir::tt::ttcore
 
 #endif // TTMLIR_DIALECT_TTCORE_UTILS_POPULATEARGUMENTTYPES_H

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRBase.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRBase.td
@@ -32,7 +32,7 @@ def TTIR_Dialect : Dialect {
       "::mlir::linalg::LinalgDialect",
       "::mlir::scf::SCFDialect",
       "::mlir::cf::ControlFlowDialect",
-      "::mlir::tt::TTCoreDialect"
+      "::mlir::tt::ttcore::TTCoreDialect"
     ];
 
     let hasConstantMaterializer = 1;

--- a/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIRGenericRegionOps.td
@@ -20,13 +20,13 @@ include "mlir/Interfaces/InferIntRangeInterface.td"
 // Generic Region Op Traits and Classes
 //===----------------------------------------------------------------------===//
 
-def IsDeviceL1MemorySpace : CPred<"::llvm::cast<::mlir::tt::MemorySpaceAttr>(::llvm::cast<::mlir::MemRefType>($_self).getMemorySpace()).getValue() == ::mlir::tt::MemorySpace::DeviceL1">;
+def IsDeviceL1MemorySpace : CPred<"::llvm::cast<::mlir::tt::ttcore::MemorySpaceAttr>(::llvm::cast<::mlir::MemRefType>($_self).getMemorySpace()).getValue() == ::mlir::tt::ttcore::MemorySpace::DeviceL1">;
 
-def IsDeviceDRAMMemorySpace : CPred<"::llvm::cast<::mlir::tt::MemorySpaceAttr>(::llvm::cast<::mlir::MemRefType>($_self).getMemorySpace()).getValue() == ::mlir::tt::MemorySpace::DeviceDRAM">;
+def IsDeviceDRAMMemorySpace : CPred<"::llvm::cast<::mlir::tt::ttcore::MemorySpaceAttr>(::llvm::cast<::mlir::MemRefType>($_self).getMemorySpace()).getValue() == ::mlir::tt::ttcore::MemorySpace::DeviceDRAM">;
 
 def IsDeviceMemorySpace : Or<[IsDeviceL1MemorySpace, IsDeviceDRAMMemorySpace]>;
 
-def IsRegisterDstMemorySpace : CPred<"::llvm::cast<::mlir::tt::MemorySpaceAttr>(::llvm::cast<::mlir::MemRefType>($_self).getMemorySpace()).getValue() == ::mlir::tt::MemorySpace::RegisterDst">;
+def IsRegisterDstMemorySpace : CPred<"::llvm::cast<::mlir::tt::ttcore::MemorySpaceAttr>(::llvm::cast<::mlir::MemRefType>($_self).getMemorySpace()).getValue() == ::mlir::tt::ttcore::MemorySpace::RegisterDst">;
 
 def DeviceL1MemRef : Type<
   And<[IsDeviceL1MemorySpace, HasRankGreaterOrEqualPred<1>]>,

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -124,18 +124,18 @@ def TTIR_GenericOp : TTIR_BufferizableOp<"generic",
                      "ArrayAttr": $indexingMaps,
                      "ArrayAttr": $iteratorTypes,
                      CArg<"ThreadType", "ThreadType::Compute">: $singleThreadType,
-                     CArg<"GridAttr", "nullptr">: $grid,
+                     CArg<"ttcore::GridAttr", "nullptr">: $grid,
                      CArg<"ArrayRef<int64_t>", "{}">: $blockFactors),
       [{
         assert(!indexingMaps.empty() && "expected non-empty indexing maps");
         assert(outputs.size() == 1 && "expected single output");
         if (!grid) {
           if (RankedTensorType tensorType = mlir::dyn_cast<RankedTensorType>(outputs[0].getType()); tensorType) {
-             grid = $_builder.getAttr<tt::GridAttr>(mlir::cast<tt::MetalLayoutAttr>(tensorType.getEncoding()).getGridShape(tensorType));
+             grid = $_builder.getAttr<ttcore::GridAttr>(mlir::cast<ttcore::MetalLayoutAttr>(tensorType.getEncoding()).getGridShape(tensorType));
           } else {
             MemRefType memrefType = mlir::cast<MemRefType>(outputs[0].getType());
-            DeviceLayoutInterface layout = mlir::cast<DeviceLayoutInterface>(memrefType.getLayout());
-            grid = $_builder.getAttr<tt::GridAttr>(layout.getGridShape(memrefType));
+            ttcore::DeviceLayoutInterface layout = mlir::cast<ttcore::DeviceLayoutInterface>(memrefType.getLayout());
+            grid = $_builder.getAttr<ttcore::GridAttr>(layout.getGridShape(memrefType));
           }
         }
         auto threads = $_builder.getArrayAttr($_builder.getAttr<ThreadAttr>(singleThreadType));
@@ -150,13 +150,13 @@ def TTIR_GenericOp : TTIR_BufferizableOp<"generic",
                      "ArrayAttr": $iteratorTypes,
                      "llvm::function_ref<void(OpBuilder&, Location, ValueRange)>": $singleThreadRegionBuilder,
                      CArg<"ThreadType", "ThreadType::Compute">: $singleThreadType,
-                     CArg<"GridAttr", "nullptr">: $grid,
+                     CArg<"ttcore::GridAttr", "nullptr">: $grid,
                      CArg<"ArrayRef<int64_t>", "{}">: $blockFactors),
       [{
         build($_builder, $_state, inputs, outputs, indexingMaps, iteratorTypes, singleThreadType, grid, blockFactors);
         llvm::SmallVector<Type> blockTypes = llvm::map_to_vector(TypeRange($_state.operands), [&](Type t) -> Type {
           mlir::RankedTensorType tensorType = mlir::cast<RankedTensorType>(t);
-          auto layout = mlir::cast<tt::MetalLayoutAttr>(tensorType.getEncoding());
+          auto layout = mlir::cast<ttcore::MetalLayoutAttr>(tensorType.getEncoding());
           return layout.getMemRefType(tensorType);
         });
         Region& region = *$_state.regions.front().get();
@@ -169,12 +169,12 @@ def TTIR_GenericOp : TTIR_BufferizableOp<"generic",
                      "ValueRange": $outputs,
                      "llvm::function_ref<void(OpBuilder&, Location, ValueRange)>": $singleThreadRegionBuilder,
                      CArg<"ThreadType", "ThreadType::Compute">: $singleThreadType,
-                     CArg<"GridAttr", "nullptr">: $grid,
+                     CArg<"ttcore::GridAttr", "nullptr">: $grid,
                      CArg<"ArrayRef<int64_t>", "{}">: $blockFactors),
       [{
         assert(outputs.size() == 1 && "expected single output");
         RankedTensorType tensorType = mlir::cast<RankedTensorType>(outputs[0].getType());
-        MetalLayoutAttr maybeLayout = mlir::dyn_cast_or_null<tt::MetalLayoutAttr>(tensorType.getEncoding());
+        ttcore::MetalLayoutAttr maybeLayout = mlir::dyn_cast_or_null<ttcore::MetalLayoutAttr>(tensorType.getEncoding());
         const size_t rank = (maybeLayout != nullptr) ? maybeLayout.getShardShape(tensorType).size() : tensorType.getShape().size();
         auto [indexingMaps, iteratorTypes] = buildParallelAffineMapsAndIteratorTypes($_builder,
             inputs.size() + outputs.size(), rank);
@@ -185,7 +185,7 @@ def TTIR_GenericOp : TTIR_BufferizableOp<"generic",
     let extraClassDeclaration = [{
       static std::pair<ArrayAttr, ArrayAttr> buildParallelAffineMapsAndIteratorTypes(mlir::OpBuilder &builder, size_t arity, size_t rank) {
         auto map = builder.getMultiDimIdentityMap(rank);
-        Attribute parallel = builder.getAttr<tt::IteratorTypeAttr>(tt::IteratorType::Parallel);
+        Attribute parallel = builder.getAttr<ttcore::IteratorTypeAttr>(ttcore::IteratorType::Parallel);
         return std::make_pair(builder.getAffineMapArrayAttr(SmallVector<AffineMap>(arity, map)),
                               builder.getArrayAttr(SmallVector<Attribute>(rank, parallel)));
       }
@@ -197,7 +197,7 @@ def TTIR_GenericOp : TTIR_BufferizableOp<"generic",
       SmallVector<int64_t> getNonParticipatingLoopDims(int64_t operandIndex);
       AffineMap getIndexingMap(int64_t operandIndex);
       SmallVector<AffineMap> getIndexingMapsValue();
-      SmallVector<IteratorType> getIteratorTypesValue();
+      SmallVector<ttcore::IteratorType> getIteratorTypesValue();
       SmallVector<int64_t> getBlockFactorsValue();
       SmallVector<SmallVector<int64_t>> getOperandGridShapes();
       SmallVector<SmallVector<int64_t>> getOperandShardShapes(bool convertTileToScalar = false);
@@ -240,7 +240,7 @@ def TTIR_ToLayoutOp : TTIR_BufferizableOp<"to_layout"> {
 
     let builders =
     [
-      OpBuilder<(ins "Value": $input, "Value": $output, CArg<"MetalLayoutAttr", "nullptr">: $layout),
+      OpBuilder<(ins "Value": $input, "Value": $output, CArg<"ttcore::MetalLayoutAttr", "nullptr">: $layout),
       [{
         build($_builder, $_state, {output.getType()}, input, output, layout);
       }]>,
@@ -263,8 +263,8 @@ def TTIR_ToLayoutOp : TTIR_BufferizableOp<"to_layout"> {
       // Returns booleans indicating if the op changes layout, grid, format, memory space or memory layout.
       CompoundComponents compoundComponents();
       bool isCompound() { return compoundComponents().isCompound(); }
-      MetalLayoutAttr getOrCreateInputLayout();
-      MetalLayoutAttr getOrCreateOutputLayout();
+      ttcore::MetalLayoutAttr getOrCreateInputLayout();
+      ttcore::MetalLayoutAttr getOrCreateOutputLayout();
     }];
 
     let hasVerifier = 1;

--- a/include/ttmlir/Dialect/TTIR/IR/TTIROpsInterfaces.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROpsInterfaces.td
@@ -15,21 +15,21 @@ def TTIROpInterface : OpInterface<"TTIROp"> {
       /*desc=*/[{
         Get the device of the current scope.
       }],
-      /*retTy=*/"::mlir::tt::SystemDescAttr",
+      /*retTy=*/"::mlir::tt::ttcore::SystemDescAttr",
       /*methodName=*/"getSystemDesc",
       /*args=*/(ins),
       /*methodBody=*/"",
-      /*defaultImplementation=*/"return ::mlir::tt::getCurrentScopeSystemDesc($_op);"
+      /*defaultImplementation=*/"return ::mlir::tt::ttcore::getCurrentScopeSystemDesc($_op);"
     >,
     InterfaceMethod<
       /*desc=*/[{
         Get the device of the current scope.
       }],
-      /*retTy=*/"::mlir::tt::DeviceAttr",
+      /*retTy=*/"::mlir::tt::ttcore::DeviceAttr",
       /*methodName=*/"getDevice",
       /*args=*/(ins),
       /*methodBody=*/"",
-      /*defaultImplementation=*/"return ::mlir::tt::lookupDevice($_op);"
+      /*defaultImplementation=*/"return ::mlir::tt::ttcore::lookupDevice($_op);"
     >,
     InterfaceMethod<
       /*desc=*/[{

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -437,7 +437,7 @@ def TTIRAllocate: Pass<"ttir-allocate", "::mlir::ModuleOp"> {
     }
     ```
   }];
-  let dependentDialects = ["::mlir::tt::TTCoreDialect", "::mlir::memref::MemRefDialect"];
+  let dependentDialects = ["::mlir::tt::ttcore::TTCoreDialect", "::mlir::memref::MemRefDialect"];
 }
 
 def TTIRImplicitBroadcastFold: Pass<"ttir-implicit-broadcast-fold", "::mlir::ModuleOp"> {
@@ -495,7 +495,7 @@ def TTIRHoistTransform: Pass<"ttir-cpu-hoist-transform", "::mlir::ModuleOp">
       }
   }];
 
-  let dependentDialects = ["::mlir::tt::TTCoreDialect"];
+  let dependentDialects = ["::mlir::tt::ttcore::TTCoreDialect"];
 }
 
 def ElementTypeNormalization: Pass<"ttir-element-type-normalization", "::mlir::ModuleOp">
@@ -555,7 +555,7 @@ def TTIREraseInverseOps: Pass<"ttir-erase-inverse-ops", "::mlir::ModuleOp">
     on either end are inverses.
   }];
 
-  let dependentDialects = ["mlir::tt::TTCoreDialect", "mlir::tt::ttir::TTIRDialect"];
+  let dependentDialects = ["mlir::tt::ttcore::TTCoreDialect", "mlir::tt::ttir::TTIRDialect"];
 }
 
 def TTIRExplicateTMs: Pass<"ttir-explicate-tms", "::mlir::ModuleOp">
@@ -565,7 +565,7 @@ def TTIRExplicateTMs: Pass<"ttir-explicate-tms", "::mlir::ModuleOp">
     This pass walks through the graph and explicates implicit broadcasts and reshapes on the graph edges.
   }];
 
-  let dependentDialects = ["mlir::tt::TTCoreDialect", "mlir::tt::ttir::TTIRDialect"];
+  let dependentDialects = ["mlir::tt::ttcore::TTCoreDialect", "mlir::tt::ttir::TTIRDialect"];
 }
 
 def TTIRQuantDataTypeConversionPass : Pass<"ttir-quant-data-type-conversion", "::mlir::ModuleOp"> {

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelBase.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelBase.td
@@ -31,7 +31,7 @@ def TTKernel_Dialect : Dialect {
       "::mlir::memref::MemRefDialect",
       "::mlir::scf::SCFDialect",
       "::mlir::cf::ControlFlowDialect",
-      "::mlir::tt::TTCoreDialect"
+      "::mlir::tt::ttcore::TTCoreDialect"
     ];
 }
 

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
@@ -33,7 +33,7 @@ def TTKernel_CB : TTKernel_Type<"CB", "cb"> {
         }
 
         int64_t getNumTiles() const {
-          assert(mlir::isa<mlir::tt::TileType>(getMemref().getElementType()) &&
+          assert(mlir::isa<mlir::tt::ttcore::TileType>(getMemref().getElementType()) &&
                  "getNumTiles only supports tile element type");
           return getNumElements();
         }

--- a/include/ttmlir/Dialect/TTMetal/IR/TTMetalBase.td
+++ b/include/ttmlir/Dialect/TTMetal/IR/TTMetalBase.td
@@ -31,7 +31,7 @@ def TTMetal_Dialect : Dialect {
       "::mlir::tensor::TensorDialect",
       "::mlir::scf::SCFDialect",
       "::mlir::cf::ControlFlowDialect",
-      "::mlir::tt::TTCoreDialect"
+      "::mlir::tt::ttcore::TTCoreDialect"
     ];
 }
 

--- a/include/ttmlir/Dialect/TTMetal/IR/TTMetalOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTMetal/IR/TTMetalOpsAttrs.td
@@ -35,7 +35,7 @@ def TTMetal_CoreRangeAttr : TTMetal_Attr<"CoreRange", "core_range"> {
   let assemblyFormat = "`<` custom<DimensionList>($offset) `,` custom<DimensionList>($size) `>`";
 
   let extraClassDeclaration = [{
-      static CoreRangeAttr get(::mlir::MLIRContext *context, ::mlir::tt::GridAttr grid, SmallVector<int64_t> offset = {0, 0})
+      static CoreRangeAttr get(::mlir::MLIRContext *context, ::mlir::tt::ttcore::GridAttr grid, SmallVector<int64_t> offset = {0, 0})
       {
         assert(grid.getShape().size() == 2 && "Grid shape must be 2D for now");
         return CoreRangeAttr::get(context, offset, grid.getShape());

--- a/include/ttmlir/Dialect/TTMetal/Pipelines/TTMetalPipelines.h
+++ b/include/ttmlir/Dialect/TTMetal/Pipelines/TTMetalPipelines.h
@@ -33,16 +33,16 @@ struct TTIRToTTMetalPipelineOptions
   // Option to provide a fallback mock system descriptor arch to compile
   // against.
   //
-  Option<tt::Arch> mockSystemDescArch{
+  Option<ttcore::Arch> mockSystemDescArch{
       *this, "mock-system-desc-arch",
       llvm::cl::desc(
           "Arch name for constructing a mock system descriptor in lieu of "
           "system-desc-path."),
-      llvm::cl::values(clEnumValN(tt::Arch::WormholeB0, "wormhole_b0",
+      llvm::cl::values(clEnumValN(ttcore::Arch::WormholeB0, "wormhole_b0",
                                   "Use mock wormhole_b0 system desc."),
-                       clEnumValN(tt::Arch::Blackhole, "blackhole",
+                       clEnumValN(ttcore::Arch::Blackhole, "blackhole",
                                   "Use mock blackhole system desc.")),
-      llvm::cl::init(tt::Arch::WormholeB0)};
+      llvm::cl::init(ttcore::Arch::WormholeB0)};
 
   Option<unsigned> maxDstRegisterSizeTiles{
       *this, "max-dst-register-size-tiles",
@@ -66,18 +66,20 @@ struct TTIRToTTMetalPipelineOptions
 
   // Options to control the default memspaces for placing input/output tensors.
   //
-  Option<MemorySpace> defaultInputMemSpace{
+  Option<ttcore::MemorySpace> defaultInputMemSpace{
       *this, "default-input-memspace",
       llvm::cl::desc("Set default memspace for input tensors"),
-      llvm::cl::values(clEnumValN(MemorySpace::DeviceL1, "l1", "L1"),
-                       clEnumValN(MemorySpace::DeviceDRAM, "dram", "DRAM")),
-      llvm::cl::init(MemorySpace::DeviceL1)};
-  Option<MemorySpace> defaultOutputMemSpace{
+      llvm::cl::values(
+          clEnumValN(ttcore::MemorySpace::DeviceL1, "l1", "L1"),
+          clEnumValN(ttcore::MemorySpace::DeviceDRAM, "dram", "DRAM")),
+      llvm::cl::init(ttcore::MemorySpace::DeviceL1)};
+  Option<ttcore::MemorySpace> defaultOutputMemSpace{
       *this, "default-output-memspace",
       llvm::cl::desc("Set default memspace for output tensors"),
-      llvm::cl::values(clEnumValN(MemorySpace::DeviceL1, "l1", "L1"),
-                       clEnumValN(MemorySpace::DeviceDRAM, "dram", "DRAM")),
-      llvm::cl::init(MemorySpace::DeviceL1)};
+      llvm::cl::values(
+          clEnumValN(ttcore::MemorySpace::DeviceL1, "l1", "L1"),
+          clEnumValN(ttcore::MemorySpace::DeviceDRAM, "dram", "DRAM")),
+      llvm::cl::init(ttcore::MemorySpace::DeviceL1)};
 };
 
 void createTTIRBufferizationPipeline(OpPassManager &pm);

--- a/include/ttmlir/Dialect/TTNN/Analysis/AllPossibleLayoutsAnalysis.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/AllPossibleLayoutsAnalysis.h
@@ -19,14 +19,14 @@
 namespace mlir::tt::ttnn {
 
 struct AllPossibleLayoutsAnalysisInput {
-  GridAttr maxGrid;
+  ttcore::GridAttr maxGrid;
   llvm::DenseSet<Type> *allowedScalarTypes;
   bool rowMajorAllowed;
 
   AllPossibleLayoutsAnalysisInput()
       : maxGrid(nullptr), allowedScalarTypes(nullptr), rowMajorAllowed(false) {}
 
-  AllPossibleLayoutsAnalysisInput(GridAttr maxGrid,
+  AllPossibleLayoutsAnalysisInput(ttcore::GridAttr maxGrid,
                                   llvm::DenseSet<Type> *allowedScalarTypes,
                                   bool rowMajorAllowed)
       : maxGrid(maxGrid), allowedScalarTypes(allowedScalarTypes),

--- a/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutAnalysisPolicy.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutAnalysisPolicy.h
@@ -19,7 +19,7 @@ protected:
   llvm::DenseMap<Operation *, std::vector<OpConfig>> legalConfigs;
   llvm::DenseMap<func::FuncOp, llvm::SmallVector<Operation *>> *schedule;
   unsigned usableL1CacheSize = 0;
-  DeviceAttr deviceAttr;
+  ttcore::DeviceAttr deviceAttr;
 
 public:
   virtual ~MemoryLayoutAnalysisPolicy() {};

--- a/include/ttmlir/Dialect/TTNN/Analysis/ShardSolver.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/ShardSolver.h
@@ -317,7 +317,7 @@ private:
   const std::vector<OpL1MemSpec> *shardSpecs;
   const llvm::DenseSet<Operation *> *shardedOps;
   unsigned usableL1CacheSize;
-  DeviceAttr deviceAttr;
+  ttcore::DeviceAttr deviceAttr;
 
   llvm::DenseMap<Operation *, std::vector<Edge>> operandOpEdges;
   llvm::DenseMap<Operation *, std::vector<Edge>> userOpEdges;

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNBase.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNBase.td
@@ -37,7 +37,7 @@ def TTNN_Dialect : Dialect {
       "::mlir::linalg::LinalgDialect",
       "::mlir::scf::SCFDialect",
       "::mlir::cf::ControlFlowDialect",
-      "::mlir::tt::TTCoreDialect"
+      "::mlir::tt::ttcore::TTCoreDialect"
     ];
 }
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h
@@ -37,7 +37,8 @@ inline bool isShardedMemoryLayout(TensorMemoryLayout layout) {
          layout == TensorMemoryLayout::BlockSharded;
 }
 
-inline bool isMeshDeviceTensor(tt::TensorMeshShardingAttr tensorMeshSharding) {
+inline bool
+isMeshDeviceTensor(ttcore::TensorMeshShardingAttr tensorMeshSharding) {
   return tensorMeshSharding != nullptr;
 }
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
@@ -177,14 +177,14 @@ def TTNN_ShardSpecAttr : TTNN_Attr<"ShardSpec", "shard_spec"> {
 
   let builders =
     [
-      AttrBuilder<(ins "ShapeAttr": $shape, "GridAttr": $shardGrid, "GridAttr": $deviceGrid),
+      AttrBuilder<(ins "ShapeAttr": $shape, "ttcore::GridAttr": $shardGrid, "ttcore::GridAttr": $deviceGrid),
       [{
         CoreRangeSetAttr coreRangeSet = getCoreRangeSet($_ctxt, shardGrid, deviceGrid);
         return Base::get($_ctxt, coreRangeSet, shape, ShardOrientationAttr::get($_ctxt, ::mlir::tt::ttnn::ShardOrientation::RowMajor), ShardModeAttr::get($_ctxt, ::mlir::tt::ttnn::ShardMode::Physical), ShapeAttr());
       }]>,
-      AttrBuilder<(ins "TTNNLayoutAttr": $layout, "GridAttr": $deviceGrid),
+      AttrBuilder<(ins "TTNNLayoutAttr": $layout, "ttcore::GridAttr": $deviceGrid),
       [{
-        GridAttr shardGrid = layout.getGrid();
+        ttcore::GridAttr shardGrid = layout.getGrid();
         CoreRangeSetAttr coreRangeSet = getCoreRangeSet($_ctxt, shardGrid, deviceGrid);
         return Base::get($_ctxt, coreRangeSet, ShapeAttr::get($_ctxt,layout.getScalarShardShape()), ShardOrientationAttr::get($_ctxt, ::mlir::tt::ttnn::ShardOrientation::RowMajor), ShardModeAttr::get($_ctxt, ::mlir::tt::ttnn::ShardMode::Physical), ShapeAttr());
       }]>
@@ -192,7 +192,7 @@ def TTNN_ShardSpecAttr : TTNN_Attr<"ShardSpec", "shard_spec"> {
 
   let assemblyFormat = "`<` params `>`";
   let extraClassDeclaration = [{
-    static CoreRangeSetAttr getCoreRangeSet(mlir::MLIRContext *context, GridAttr shardGrid, GridAttr deviceGrid);
+    static CoreRangeSetAttr getCoreRangeSet(mlir::MLIRContext *context, ttcore::GridAttr shardGrid, ttcore::GridAttr deviceGrid);
   }];
 }
 
@@ -445,8 +445,8 @@ def TTNN_Conv2dConfigAttr : TTNN_Attr<"Conv2dConfig", "conv2d_config"> {
     TTNN conv2d config attribute
   }];
 
-  let parameters = (ins OptionalParameter<"std::optional<DataType>">:$dtype,
-                        OptionalParameter<"std::optional<DataType>">:$weights_dtype,
+  let parameters = (ins OptionalParameter<"std::optional<ttcore::DataType>">:$dtype,
+                        OptionalParameter<"std::optional<ttcore::DataType>">:$weights_dtype,
                         OptionalParameter<"StringAttr">:$activation,
                         OptionalParameter<"BoolAttr">:$deallocate_activation,
                         OptionalParameter<"BoolAttr">:$reallocate_halo_output,
@@ -471,8 +471,8 @@ def TTNN_Conv2dConfigAttr : TTNN_Attr<"Conv2dConfig", "conv2d_config"> {
 
   let extraClassDeclaration = [{
     Conv2dConfigAttr withActivation(StringRef activation) const;
-    Conv2dConfigAttr withDtype(DataType dtype) const;
-    Conv2dConfigAttr withWeightsDtype(DataType dtype) const;
+    Conv2dConfigAttr withDtype(ttcore::DataType dtype) const;
+    Conv2dConfigAttr withWeightsDtype(ttcore::DataType dtype) const;
     Conv2dConfigAttr withDeallocateActivation(bool value) const;
     Conv2dConfigAttr withReallocateHaloOutput(bool value) const;
     Conv2dConfigAttr withActBlockHOverride(uint32_t value) const;
@@ -577,32 +577,32 @@ def TTNN_TTNNLayoutAttr: TTNN_Attr<"TTNNLayout", "ttnn_layout"> {
   }];
 
   let parameters = (ins AttrParameter<"AffineMap", "An affine map that defines how the logical tensor dimensions map to a grid shape.">:$linear,
-                        AttrParameter<"GridAttr", "The grid shape that this tensor is divided onto.">:$grid,
+                        AttrParameter<"ttcore::GridAttr", "The grid shape that this tensor is divided onto.">:$grid,
                         AttrParameter<"MemRefType", "A memref that describes the physical footprint allocation of the shard. It must also have a shape with rank equal to grid.">:$memref,
                         OptionalParameter<"TensorMemoryLayoutAttr", "TTNN tensor memory layout">:$mem_layout,
-                        OptionalParameter<"TensorMeshShardingAttr", "TT mesh sharding attr">:$tensor_mesh_sharding,
+                        OptionalParameter<"ttcore::TensorMeshShardingAttr", "TT mesh sharding attr">:$tensor_mesh_sharding,
                         OptionalParameter<"bool", "A status flag, asking the users to ignore the physical layout. This is used to model a sharded layout with unspecified shard shape.">:$ignorePhysicalLayout);
   let assemblyFormat = "`<` $linear`,` $grid`,` (`mesh` `=` $tensor_mesh_sharding^ `,`)? $memref (`,` $mem_layout^)? (`,` $ignorePhysicalLayout^)? `>`";
   let extraClassDeclaration = [{
     static TTNNLayoutAttr get(::mlir::MLIRContext *context,
                         AffineMap linear,
-                        GridAttr grid, MemRefType memref,
+                        ttcore::GridAttr grid, MemRefType memref,
                         TensorMemoryLayoutAttr mem_layout,
-                        TensorMeshShardingAttr tensor_mesh_sharding);
+                        ttcore::TensorMeshShardingAttr tensor_mesh_sharding);
 
     static TTNNLayoutAttr get(::mlir::MLIRContext *context,
                         ArrayRef<int64_t> tensorShape,
                         Type elementType,
                         BufferType bufferType,
-                        GridAttr grid,
+                        ttcore::GridAttr grid,
                         TensorMemoryLayoutAttr memoryLayoutAttr = nullptr,
-                        TensorMeshShardingAttr tensorMeshShardingAttr = nullptr,
+                        ttcore::TensorMeshShardingAttr tensorMeshShardingAttr = nullptr,
                         ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}},
                         bool ignorePhysicalLayout = false);
 
-    TTNNLayoutAttr withGrid(ArrayRef<int64_t> tensorShape, GridAttr grid, ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}});
+    TTNNLayoutAttr withGrid(ArrayRef<int64_t> tensorShape, ttcore::GridAttr grid, ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}});
     TTNNLayoutAttr withGrid(RankedTensorType ty,
-                        GridAttr grid,
+                        ttcore::GridAttr grid,
                         ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}});
     TTNNLayoutAttr withElementType(Type elementType, ArrayRef<int64_t> tensorShape, ArrayRef<std::pair<std::int64_t, std::int64_t>> collapseIntervals = {{0, -1}});
     TTNNLayoutAttr withBufferType(BufferType bufferType);
@@ -628,10 +628,10 @@ def TTNN_TTNNLayoutAttr: TTNN_Attr<"TTNNLayout", "ttnn_layout"> {
     Type getScalarElementType() const;
     uint64_t getShardSizeInBytes() const;
     BufferType getBufferType() const;
-    DataType getDataType() const;
+    ttcore::DataType getDataType() const;
     uint64_t getElementSizeBytes() const;
-    static llvm::SmallVector<int64_t> calculateLogicalShardShapeForSharding(ArrayRef<int64_t> tensorShape, mlir::AffineMap linear, GridAttr grid);
-    static llvm::SmallVector<int64_t> calculateLogicalShardShapeForL1Interleaved(ArrayRef<int64_t> tensorShape, Type elementType, mlir::AffineMap linear, GridAttr grid);
+    static llvm::SmallVector<int64_t> calculateLogicalShardShapeForSharding(ArrayRef<int64_t> tensorShape, mlir::AffineMap linear, ttcore::GridAttr grid);
+    static llvm::SmallVector<int64_t> calculateLogicalShardShapeForL1Interleaved(ArrayRef<int64_t> tensorShape, Type elementType, mlir::AffineMap linear, ttcore::GridAttr grid);
     llvm::SmallVector<int64_t> getShardShape() const;
     llvm::SmallVector<int64_t> getScalarShardShape() const;
     AffineMap getIdentityTileLinearMap() const;

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
@@ -18,7 +18,7 @@ namespace mlir::tt::ttnn::wa {
 using TensorLayoutWorkaround = std::optional<Layout>;
 using TensorBufferTypeWorkaround = std::optional<BufferType>;
 using TensorMemoryLayoutWorkaround = std::optional<TensorMemoryLayout>;
-using TensorDataTypeWorkaround = std::optional<DataType>;
+using TensorDataTypeWorkaround = std::optional<ttcore::DataType>;
 
 // Struct that encapsulates operand workarounds.
 // It contains tensor layout, tensor buffer type and tensor memory layout
@@ -119,7 +119,7 @@ struct MemoryLayoutWorkaroundResult
     : public WorkaroundResult<std::optional<TensorMemoryLayout>> {};
 
 // Data type workaround result struct.
-struct DataTypeWorkaroundResult : public WorkaroundResult<DataType> {};
+struct DataTypeWorkaroundResult : public WorkaroundResult<ttcore::DataType> {};
 
 // Struct that encapsulates the result of applying the workarounds.
 // It contains the target tensor layout, buffer type and tensor memory layout
@@ -236,7 +236,7 @@ public:
 
   // Create workarounds for mesh shard op operands.
   static TTNNOperandsWorkarounds
-  createMeshShardOpOperandsWorkarounds(mlir::tt::MeshShardType shardType);
+  createMeshShardOpOperandsWorkarounds(ttcore::MeshShardType shardType);
 
   // Create workarounds for concat op operands.
   static TTNNOperandsWorkarounds

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -163,16 +163,16 @@ struct TTIRToTTNNBackendPipelineOptions
   // Option to provide a fallback mock system descriptor arch to compile
   // against.
   //
-  Option<tt::Arch> mockSystemDescArch{
+  Option<ttcore::Arch> mockSystemDescArch{
       *this, OptionNames::mockSystemDescArch,
       llvm::cl::desc(
           "Arch name for constructing a mock system descriptor in lieu of "
           "system-desc-path."),
-      llvm::cl::values(clEnumValN(tt::Arch::WormholeB0, "wormhole_b0",
+      llvm::cl::values(clEnumValN(ttcore::Arch::WormholeB0, "wormhole_b0",
                                   "Use mock wormhole_b0 system desc."),
-                       clEnumValN(tt::Arch::Blackhole, "blackhole",
+                       clEnumValN(ttcore::Arch::Blackhole, "blackhole",
                                   "Use mock blackhole system desc.")),
-      llvm::cl::init(tt::Arch::WormholeB0)};
+      llvm::cl::init(ttcore::Arch::WormholeB0)};
 
   // Option to override maximum number of sharded layouts to be generated
   // in legal layout analysis.
@@ -224,21 +224,24 @@ struct TTIRToTTNNBackendPipelineOptions
                             llvm::cl::desc("Enable fusing pass."),
                             llvm::cl::init(false)};
 
-  Option<tt::TTArgumentTypeMap, tt::ArgumentTypeMapParser> argumentTypeMap{
-      *this, tt::OptionNames::argumentTypes,
-      llvm::cl::desc(
-          "Map of function name to argument types. To use this option in the "
-          "command line, you must provide a whitespace-free string\n\t"
-          " which is a sequence of phrases in the form "
-          "\"<FUNC_NAME_STR>=<ARG_TYPES>\" separated by semicolons, where "
-          "<FUNC_NAME_STR>\n\t"
-          " is the name of a function and <ARG_TYPES> is a sequence of "
-          "argument types separated by commas. Each of which must be one\n\t"
-          " of \"input\", \"parameter\" or \"constant\". \n\t"
-          " Example: "
-          "\"argument-types=forward=input,parameter,parameter,constant\""
-          "\n\n"),
-      llvm::cl::init(TTArgumentTypeMap())};
+  Option<ttcore::TTArgumentTypeMap, ttcore::ArgumentTypeMapParser>
+      argumentTypeMap{
+          *this, ttcore::OptionNames::argumentTypes,
+          llvm::cl::desc(
+              "Map of function name to argument types. To use this option in "
+              "the "
+              "command line, you must provide a whitespace-free string\n\t"
+              " which is a sequence of phrases in the form "
+              "\"<FUNC_NAME_STR>=<ARG_TYPES>\" separated by semicolons, where "
+              "<FUNC_NAME_STR>\n\t"
+              " is the name of a function and <ARG_TYPES> is a sequence of "
+              "argument types separated by commas. Each of which must be "
+              "one\n\t"
+              " of \"input\", \"parameter\" or \"constant\". \n\t"
+              " Example: "
+              "\"argument-types=forward=input,parameter,parameter,constant\""
+              "\n\n"),
+          llvm::cl::init(ttcore::TTArgumentTypeMap())};
 
   // TODO (azecevic): This pass is causing a lot of memory consumption and is
   // disabled by default (https://github.com/tenstorrent/tt-mlir/issues/2512).

--- a/include/ttmlir/Dialect/TTNN/Utils/OptimizerOverrides.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/OptimizerOverrides.h
@@ -59,7 +59,7 @@ public:
   void addOutputLayoutOverride(StringRef, OutputLayoutOverrideParams);
   void addOutputLayoutOverride(StringRef, SmallVector<int64_t> &, BufferType,
                                TensorMemoryLayout, tt::ttnn::Layout,
-                               tt::DataType);
+                               ttcore::DataType);
   void addConv2dConfigOverride(StringRef, Conv2dConfigOverrideParams);
 
   std::unordered_map<std::string, InsertMemReconfigParams>

--- a/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
@@ -33,8 +33,8 @@ struct OptionNames {
 };
 
 struct Conv2dConfigOverrideParams {
-  std::optional<tt::DataType> dtype = std::nullopt;
-  std::optional<tt::DataType> weightsDtype = std::nullopt;
+  std::optional<ttcore::DataType> dtype = std::nullopt;
+  std::optional<ttcore::DataType> weightsDtype = std::nullopt;
   std::optional<std::string> activation = std::nullopt;
   std::optional<bool> deallocateActivation = std::nullopt;
   std::optional<bool> reallocateHaloOutput = std::nullopt;
@@ -76,7 +76,7 @@ struct OutputLayoutOverrideParams {
   std::optional<TensorMemoryLayout> tensorMemoryLayout =
       std::nullopt; // INTERLEAVED / SHARDED etc...
   std::optional<Layout> memoryLayout = std::nullopt; // ROW_MAJOR / TILE
-  std::optional<tt::DataType> dataType = std::nullopt;
+  std::optional<ttcore::DataType> dataType = std::nullopt;
 
   bool empty() const {
     return !grid.has_value() && !bufferType.has_value() &&

--- a/include/ttmlir/Dialect/TTNN/Utils/TransformUtils.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/TransformUtils.h
@@ -18,13 +18,12 @@ GetDeviceOp getOrInsertDevice(mlir::RewriterBase &rewriter,
 
 // Helper method to insert a ToLayoutOp to convert the input operand to the
 // desired tensor layout, buffer type and memory layout.
-ToLayoutOp
-createToLayoutOp(mlir::Operation *op,
-                 mlir::TypedValue<RankedTensorType> inputValue,
-                 PatternRewriter &rewriter, Layout targetTensorLayout,
-                 BufferType targetTensorBufferType,
-                 std::optional<TensorMemoryLayout> targetTensorMemoryLayout,
-                 DataType targetTensorDataType, llvm::StringRef locSuffix = "");
+ToLayoutOp createToLayoutOp(
+    mlir::Operation *op, mlir::TypedValue<RankedTensorType> inputValue,
+    PatternRewriter &rewriter, Layout targetTensorLayout,
+    BufferType targetTensorBufferType,
+    std::optional<TensorMemoryLayout> targetTensorMemoryLayout,
+    ttcore::DataType targetTensorDataType, llvm::StringRef locSuffix = "");
 } // namespace mlir::tt::ttnn::utils
 
 #endif

--- a/include/ttmlir/Dialect/TTNN/Utils/Utils.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/Utils.h
@@ -19,14 +19,14 @@ namespace mlir::tt::ttnn::utils {
 
 constexpr inline llvm::StringLiteral g_TTNNTraceAttrName = "ttnn.trace";
 
-// Map tt::MemorySpace to ttnn::BufferType
+// Map ttcore::MemorySpace to ttnn::BufferType
 //
 mlir::tt::ttnn::BufferType
-toTTNNBufferType(const mlir::tt::MemorySpace memorySpace);
+toTTNNBufferType(const mlir::tt::ttcore::MemorySpace memorySpace);
 
-// Map ttnn::BufferType to tt::MemorySpace
+// Map ttnn::BufferType to ttcore::MemorySpace
 //
-mlir::tt::MemorySpace
+mlir::tt::ttcore::MemorySpace
 toTTMemorySpace(const mlir::tt::ttnn::BufferType bufferType);
 
 struct RankedTensorTypeFactory {
@@ -45,9 +45,11 @@ struct RankedTensorTypeFactory {
   static RankedTensorType create(RankedTensorType tensorType,
                                  ttnn::Layout layout);
 
-  static RankedTensorType create(RankedTensorType tensorType, GridAttr grid);
+  static RankedTensorType create(RankedTensorType tensorType,
+                                 mlir::tt::ttcore::GridAttr grid);
 
-  static RankedTensorType create(RankedTensorType tensorType, DataType);
+  static RankedTensorType create(RankedTensorType tensorType,
+                                 mlir::tt::ttcore::DataType);
 
   static RankedTensorType create(RankedTensorType tensorType,
                                  ArrayRef<int64_t> tensorShape);
@@ -63,7 +65,7 @@ TTNNLayoutAttr getLayoutAttrFromTensor(RankedTensorType tensorType);
 
 // Helper method to get the element type for the given tensor layout and data.
 Type getElementType(MLIRContext *context, Layout tensorLayout,
-                    DataType dataType);
+                    mlir::tt::ttcore::DataType dataType);
 
 // Helper method to get op location name if it exists. Else return empty string.
 std::string getOpLocName(Operation *op);
@@ -76,14 +78,16 @@ void irToFile(mlir::Operation *op, std::string filename);
 llvm::SmallVector<int64_t> getTilePaddedShape(llvm::ArrayRef<int64_t> shape);
 
 // Helper method to create a ShardSpecAttr if needed.
-std::optional<ShardSpecAttr> createShardSpecIfNeeded(TTNNLayoutAttr layout,
-                                                     GridAttr deviceGrid);
+std::optional<ShardSpecAttr>
+createShardSpecIfNeeded(TTNNLayoutAttr layout,
+                        mlir::tt::ttcore::GridAttr deviceGrid);
 
 // Helper method to create a ShardSpecAttr if needed.
 std::optional<ShardSpecAttr>
 createShardSpecIfNeeded(TensorMemoryLayoutAttr tensorMemoryLayout,
-                        ShapeAttr shardShape, GridAttr shardGrid,
-                        GridAttr deviceGrid);
+                        ShapeAttr shardShape,
+                        mlir::tt::ttcore::GridAttr shardGrid,
+                        mlir::tt::ttcore::GridAttr deviceGrid);
 
 bool isTTNNTraceFunc(func::FuncOp funcOp);
 

--- a/include/ttmlir/OpModel/TTNN/Conversion.h
+++ b/include/ttmlir/OpModel/TTNN/Conversion.h
@@ -13,8 +13,8 @@
 #include <type_traits>
 namespace mlir::tt::op_model::ttnn {
 namespace conversion {
-::tt::tt_metal::DataType getDataType(const DataType dataType);
-tt::DataType getDataType(const ::tt::tt_metal::DataType dataType);
+::tt::tt_metal::DataType getDataType(const ttcore::DataType dataType);
+ttcore::DataType getDataType(const ::tt::tt_metal::DataType dataType);
 
 ::ttnn::Shape getShape(const ::llvm::ArrayRef<int64_t> shape);
 llvm::SmallVector<int64_t> getShape(const ::ttnn::Shape &shape);

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -19,7 +19,7 @@ namespace mlir::tt::op_model::ttnn {
 // Checks if the tensor layout is legal for the given tensor shape.
 bool isLayoutLegalForTensorShape(llvm::ArrayRef<int64_t> tensorShape,
                                  mlir::tt::ttnn::TTNNLayoutAttr layout,
-                                 GridAttr maxGrid);
+                                 mlir::tt::ttcore::GridAttr maxGrid);
 
 // Calculate the output tensor type of the prepared weights for a conv2d op.
 mlir::RankedTensorType
@@ -30,7 +30,8 @@ getPreparedConv2dWeightsOutputTensor(mlir::tt::ttnn::Conv2dOp *op);
 //===----------------------------------------------------------------------===//
 
 namespace Device {
-llvm::Expected<bool> getDeviceConstraints(mlir::tt::GridAttr workerGrid);
+llvm::Expected<bool>
+getDeviceConstraints(mlir::tt::ttcore::GridAttr workerGrid);
 }; // namespace Device
 
 //===----------------------------------------------------------------------===//
@@ -39,7 +40,8 @@ llvm::Expected<bool> getDeviceConstraints(mlir::tt::GridAttr workerGrid);
 
 namespace ReluOpInterface {
 llvm::Expected<OpConstraints>
-getOpConstraints(GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
                  llvm::ArrayRef<int64_t> outputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
@@ -57,7 +59,8 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 
 namespace SqrtOpInterface {
 llvm::Expected<OpConstraints>
-getOpConstraints(GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
                  llvm::ArrayRef<int64_t> outputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
@@ -76,7 +79,8 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 
 namespace SigmoidOpInterface {
 llvm::Expected<OpConstraints>
-getOpConstraints(GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
                  llvm::ArrayRef<int64_t> outputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
@@ -95,7 +99,8 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 
 namespace AddOpInterface {
 llvm::Expected<OpConstraints>
-getOpConstraints(GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShapeA,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
                  llvm::ArrayRef<int64_t> inputShapeB,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
@@ -118,7 +123,8 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
 
 namespace SoftmaxOpInterface {
 llvm::Expected<OpConstraints>
-getOpConstraints(GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayout, const int dimArg,
                  llvm::ArrayRef<int64_t> outputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
@@ -137,7 +143,8 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 
 namespace MeanOpInterface {
 llvm::Expected<OpConstraints>
-getOpConstraints(GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
                  std::optional<llvm::ArrayRef<int64_t>> dimArg, bool keepDim,
                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
@@ -156,7 +163,8 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 
 namespace ReshapeOpInterface {
 llvm::Expected<OpConstraints>
-getOpConstraints(GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
                  llvm::ArrayRef<int64_t> outputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
@@ -174,13 +182,12 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 //===----------------------------------------------------------------------===//
 
 namespace SliceOpInterface {
-llvm::Expected<OpConstraints>
-getOpConstraints(GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-                 mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-                 llvm::ArrayRef<int64_t> begins, llvm::ArrayRef<int64_t> ends,
-                 llvm::ArrayRef<int64_t> step,
-                 llvm::ArrayRef<int64_t> outputShape,
-                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+llvm::Expected<OpConstraints> getOpConstraints(
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> begins,
+    llvm::ArrayRef<int64_t> ends, llvm::ArrayRef<int64_t> step,
+    llvm::ArrayRef<int64_t> outputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
 
 llvm::Expected<size_t>
 getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
@@ -196,17 +203,17 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 //===----------------------------------------------------------------------===//
 
 namespace TypecastOpInterface {
-llvm::Expected<OpConstraints>
-getOpConstraints(GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-                 mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-                 mlir::tt::DataTypeAttr dtype,
-                 llvm::ArrayRef<int64_t> outputShape,
-                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+llvm::Expected<OpConstraints> getOpConstraints(
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+    mlir::tt::ttcore::DataTypeAttr dtype, llvm::ArrayRef<int64_t> outputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
 
 llvm::Expected<size_t>
 getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
              mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-             mlir::tt::DataTypeAttr dtype, llvm::ArrayRef<int64_t> outputShape,
+             mlir::tt::ttcore::DataTypeAttr dtype,
+             llvm::ArrayRef<int64_t> outputShape,
              mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
 
 }; // namespace TypecastOpInterface
@@ -216,17 +223,16 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 //===----------------------------------------------------------------------===//
 
 namespace ToLayoutOpInterface {
-llvm::Expected<OpConstraints>
-getOpConstraints(GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-                 mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-                 std::optional<mlir::tt::DataType> outputDtype,
-                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
-                 bool passDevicePtr);
+llvm::Expected<OpConstraints> getOpConstraints(
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+    std::optional<mlir::tt::ttcore::DataType> outputDtype,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool passDevicePtr);
 
 llvm::Expected<size_t>
 getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
              mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-             std::optional<mlir::tt::DataType> outputDtype,
+             std::optional<mlir::tt::ttcore::DataType> outputDtype,
              mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool passDevicePtr);
 
 }; // namespace ToLayoutOpInterface
@@ -237,7 +243,7 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 
 namespace ConcatOpInterface {
 llvm::Expected<OpConstraints>
-getOpConstraints(GridAttr deviceGrid,
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
                  std::vector<llvm::ArrayRef<int64_t>> inputShapes,
                  std::vector<mlir::tt::ttnn::TTNNLayoutAttr> inputLayouts,
                  const int dim, mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
@@ -254,7 +260,8 @@ getOpRuntime(std::vector<llvm::ArrayRef<int64_t>> inputShapes,
 
 namespace TransposeOpInterface {
 llvm::Expected<OpConstraints>
-getOpConstraints(GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayout, const int dim0,
                  const int dim1, mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
 
@@ -271,7 +278,8 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 
 namespace MatmulOpInterface {
 llvm::Expected<OpConstraints>
-getOpConstraints(GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShapeA,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
                  llvm::ArrayRef<int64_t> inputShapeB,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
@@ -294,7 +302,8 @@ llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
 
 namespace MultiplyOpInterface {
 llvm::Expected<OpConstraints>
-getOpConstraints(GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShapeA,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
                  llvm::ArrayRef<int64_t> inputShapeB,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
@@ -316,22 +325,21 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
 //===----------------------------------------------------------------------===//
 
 namespace Conv2dOpInterface {
-llvm::Expected<OpConstraints>
-getOpConstraints(GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-                 mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-                 llvm::ArrayRef<int64_t> weightShape,
-                 mlir::tt::ttnn::TTNNLayoutAttr weightLayout,
-                 std::optional<llvm::ArrayRef<int64_t>> biasShape,
-                 std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
-                 uint32_t in_channels, uint32_t out_channels,
-                 uint32_t batch_size, uint32_t input_height,
-                 uint32_t input_width, llvm::ArrayRef<int32_t> kernel_size,
-                 llvm::ArrayRef<int32_t> stride,
-                 llvm::ArrayRef<int32_t> padding,
-                 llvm::ArrayRef<int32_t> dilation, uint32_t groups,
-                 std::optional<mlir::tt::ttnn::Conv2dConfigAttr> conv2dConfig,
-                 llvm::ArrayRef<int64_t> outputShape,
-                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+llvm::Expected<OpConstraints> getOpConstraints(
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> weightShape,
+    mlir::tt::ttnn::TTNNLayoutAttr weightLayout,
+    std::optional<llvm::ArrayRef<int64_t>> biasShape,
+    std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
+    uint32_t in_channels, uint32_t out_channels, uint32_t batch_size,
+    uint32_t input_height, uint32_t input_width,
+    llvm::ArrayRef<int32_t> kernel_size, llvm::ArrayRef<int32_t> stride,
+    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
+    uint32_t groups,
+    std::optional<mlir::tt::ttnn::Conv2dConfigAttr> conv2dConfig,
+    llvm::ArrayRef<int64_t> outputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
 
 llvm::Expected<size_t>
 getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
@@ -356,7 +364,7 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 //===----------------------------------------------------------------------===//
 namespace ConvTranspose2dOpInterface {
 llvm::Expected<OpConstraints> getOpConstraints(
-    GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> weightShape,
     mlir::tt::ttnn::TTNNLayoutAttr weightLayout,
@@ -394,7 +402,7 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 //===----------------------------------------------------------------------===//
 namespace MaxPool2DOpInterface {
 llvm::Expected<OpConstraints> getOpConstraints(
-    GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayout, int32_t batchSize,
     int32_t inputHeight, int32_t inputWidth, int32_t inputChannels,
     llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
@@ -418,7 +426,8 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 //===----------------------------------------------------------------------===//
 namespace ClampScalarOpInterface {
 llvm::Expected<OpConstraints>
-getOpConstraints(GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayout, llvm::APFloat min,
                  llvm::APFloat max, llvm::ArrayRef<int64_t> outputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
@@ -435,7 +444,8 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 //===----------------------------------------------------------------------===//
 namespace PermuteOpInterface {
 llvm::Expected<OpConstraints>
-getOpConstraints(GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
                  llvm::ArrayRef<int64_t> permutation, llvm::APFloat padValue,
                  llvm::ArrayRef<int64_t> outputShape,
@@ -453,12 +463,11 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 // Upsample
 //===----------------------------------------------------------------------===//
 namespace UpsampleOpInterface {
-llvm::Expected<OpConstraints>
-getOpConstraints(GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-                 mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-                 mlir::Attribute scaleFactor, llvm::StringRef mode,
-                 llvm::ArrayRef<int64_t> outputShape,
-                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+llvm::Expected<OpConstraints> getOpConstraints(
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayout, mlir::Attribute scaleFactor,
+    llvm::StringRef mode, llvm::ArrayRef<int64_t> outputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
 
 llvm::Expected<size_t>
 getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
@@ -473,7 +482,8 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 //===----------------------------------------------------------------------===//
 namespace SubtractOpInterface {
 llvm::Expected<OpConstraints>
-getOpConstraints(GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShapeA,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
                  llvm::ArrayRef<int64_t> inputShapeB,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
@@ -494,7 +504,8 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
 //===----------------------------------------------------------------------===//
 namespace MaximumOpInterface {
 llvm::Expected<OpConstraints>
-getOpConstraints(GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShapeA,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
                  llvm::ArrayRef<int64_t> inputShapeB,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
@@ -515,7 +526,8 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
 //===----------------------------------------------------------------------===//
 namespace MinimumOpInterface {
 llvm::Expected<OpConstraints>
-getOpConstraints(GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShapeA,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
                  llvm::ArrayRef<int64_t> inputShapeB,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
@@ -536,7 +548,8 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
 //===----------------------------------------------------------------------===//
 namespace EmbeddingOpInterface {
 llvm::Expected<OpConstraints>
-getOpConstraints(GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
                  llvm::ArrayRef<int64_t> weightShape,
                  mlir::tt::ttnn::TTNNLayoutAttr weightLayout,
@@ -557,7 +570,8 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 //===----------------------------------------------------------------------===//
 namespace SumOpInterface {
 llvm::Expected<OpConstraints>
-getOpConstraints(GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
                  std::optional<llvm::ArrayRef<int64_t>> dimArg, bool keepDim,
                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
@@ -575,7 +589,8 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 //===----------------------------------------------------------------------===//
 namespace SinOpInterface {
 llvm::Expected<OpConstraints>
-getOpConstraints(GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
                  llvm::ArrayRef<int64_t> outputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
@@ -592,7 +607,8 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 //===----------------------------------------------------------------------===//
 namespace CosOpInterface {
 llvm::Expected<OpConstraints>
-getOpConstraints(GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
                  llvm::ArrayRef<int64_t> outputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
@@ -609,7 +625,8 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 //===----------------------------------------------------------------------===//
 namespace ReciprocalOpInterface {
 llvm::Expected<OpConstraints>
-getOpConstraints(GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
                  llvm::ArrayRef<int64_t> outputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout);

--- a/include/ttmlir/Target/TTNN/utils.h
+++ b/include/ttmlir/Target/TTNN/utils.h
@@ -62,29 +62,30 @@ toTargetTensorLayout(::mlir::tt::ttnn::Layout layout) {
   llvm_unreachable("Unsupported Layout");
 }
 
-inline ::tt::target::DataType toTargetDataType(::mlir::tt::DataType dataType) {
+inline ::tt::target::DataType
+toTargetDataType(::mlir::tt::ttcore::DataType dataType) {
   switch (dataType) {
-  case ::mlir::tt::DataType::Float32:
+  case ::mlir::tt::ttcore::DataType::Float32:
     return ::tt::target::DataType::Float32;
-  case ::mlir::tt::DataType::BFloat16:
+  case ::mlir::tt::ttcore::DataType::BFloat16:
     return ::tt::target::DataType::BFloat16;
-  case ::mlir::tt::DataType::BFP_BFloat8:
+  case ::mlir::tt::ttcore::DataType::BFP_BFloat8:
     return ::tt::target::DataType::BFP_BFloat8;
-  case ::mlir::tt::DataType::BFP_BFloat4:
+  case ::mlir::tt::ttcore::DataType::BFP_BFloat4:
     return ::tt::target::DataType::BFP_BFloat4;
-  case ::mlir::tt::DataType::UInt8:
+  case ::mlir::tt::ttcore::DataType::UInt8:
     return ::tt::target::DataType::UInt8;
-  case ::mlir::tt::DataType::UInt16:
+  case ::mlir::tt::ttcore::DataType::UInt16:
     return ::tt::target::DataType::UInt16;
-  case ::mlir::tt::DataType::UInt32:
+  case ::mlir::tt::ttcore::DataType::UInt32:
     return ::tt::target::DataType::UInt32;
-  case ::mlir::tt::DataType::Int32:
+  case ::mlir::tt::ttcore::DataType::Int32:
     return ::tt::target::DataType::Int32;
-  case ::mlir::tt::DataType::Float16:
-  case ::mlir::tt::DataType::BFP_Float2:
-  case ::mlir::tt::DataType::BFP_Float4:
-  case ::mlir::tt::DataType::BFP_Float8:
-  case ::mlir::tt::DataType::BFP_BFloat2:
+  case ::mlir::tt::ttcore::DataType::Float16:
+  case ::mlir::tt::ttcore::DataType::BFP_Float2:
+  case ::mlir::tt::ttcore::DataType::BFP_Float4:
+  case ::mlir::tt::ttcore::DataType::BFP_Float8:
+  case ::mlir::tt::ttcore::DataType::BFP_BFloat2:
     llvm_unreachable("Unsupported DataType");
   }
 

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -46,7 +46,8 @@ struct GoldenTensor {
  * If no mesh shape is specified (i.e. the mesh
  * shape is an empty array), then the default value of 1x1 will be returned.
  */
-inline ::tt::target::Dim2d deviceToFlatbufferMeshShape(const DeviceAttr attr) {
+inline ::tt::target::Dim2d
+deviceToFlatbufferMeshShape(const ttcore::DeviceAttr attr) {
   assert(attr);
   ArrayRef<int64_t> meshShapeArr = attr.getMeshShape();
   ::tt::target::Dim2d meshShape;
@@ -110,35 +111,35 @@ inline flatbuffers::Offset<::tt::target::DebugInfo> debugInfoToFlatbuffer(
 }
 
 inline ::tt::target::OOBVal toFlatbuffer(FlatbufferObjectCache &,
-                                         OOBVal oobVal) {
+                                         ttcore::OOBVal oobVal) {
   switch (oobVal) {
-  case OOBVal::Undef:
+  case ttcore::OOBVal::Undef:
     return ::tt::target::OOBVal::Undef;
-  case OOBVal::Zero:
+  case ttcore::OOBVal::Zero:
     return ::tt::target::OOBVal::Zero;
-  case OOBVal::One:
+  case ttcore::OOBVal::One:
     return ::tt::target::OOBVal::One;
-  case OOBVal::Inf:
+  case ttcore::OOBVal::Inf:
     return ::tt::target::OOBVal::Inf;
-  case OOBVal::NegInf:
+  case ttcore::OOBVal::NegInf:
     return ::tt::target::OOBVal::NegInf;
   }
 }
 
-inline std::uint64_t getElementSizeBytes(DataType dtype) {
+inline std::uint64_t getElementSizeBytes(ttcore::DataType dtype) {
   switch (dtype) {
-  case DataType::Float32:
+  case ttcore::DataType::Float32:
     return 4;
-  case DataType::Float16:
+  case ttcore::DataType::Float16:
     return 2;
-  case DataType::BFloat16:
+  case ttcore::DataType::BFloat16:
     return 2;
-  case DataType::UInt32:
-  case DataType::Int32:
+  case ttcore::DataType::UInt32:
+  case ttcore::DataType::Int32:
     return 4;
-  case DataType::UInt16:
+  case ttcore::DataType::UInt16:
     return 2;
-  case DataType::UInt8:
+  case ttcore::DataType::UInt8:
     return 1;
   default:
     assert(false && "unsupported data type");
@@ -149,33 +150,33 @@ inline std::uint64_t getElementSizeBytes(DataType dtype) {
 }
 
 inline ::tt::target::DataType toFlatbuffer(FlatbufferObjectCache &,
-                                           DataType dtype) {
+                                           ttcore::DataType dtype) {
   switch (dtype) {
-  case DataType::Float32:
+  case ttcore::DataType::Float32:
     return ::tt::target::DataType::Float32;
-  case DataType::Float16:
+  case ttcore::DataType::Float16:
     return ::tt::target::DataType::Float16;
-  case DataType::BFloat16:
+  case ttcore::DataType::BFloat16:
     return ::tt::target::DataType::BFloat16;
-  case DataType::BFP_Float8:
+  case ttcore::DataType::BFP_Float8:
     return ::tt::target::DataType::BFP_Float8;
-  case DataType::BFP_BFloat8:
+  case ttcore::DataType::BFP_BFloat8:
     return ::tt::target::DataType::BFP_BFloat8;
-  case DataType::BFP_Float4:
+  case ttcore::DataType::BFP_Float4:
     return ::tt::target::DataType::BFP_Float4;
-  case DataType::BFP_BFloat4:
+  case ttcore::DataType::BFP_BFloat4:
     return ::tt::target::DataType::BFP_BFloat4;
-  case DataType::BFP_Float2:
+  case ttcore::DataType::BFP_Float2:
     return ::tt::target::DataType::BFP_Float2;
-  case DataType::BFP_BFloat2:
+  case ttcore::DataType::BFP_BFloat2:
     return ::tt::target::DataType::BFP_BFloat2;
-  case DataType::UInt32:
+  case ttcore::DataType::UInt32:
     return ::tt::target::DataType::UInt32;
-  case DataType::UInt16:
+  case ttcore::DataType::UInt16:
     return ::tt::target::DataType::UInt16;
-  case DataType::UInt8:
+  case ttcore::DataType::UInt8:
     return ::tt::target::DataType::UInt8;
-  case DataType::Int32:
+  case ttcore::DataType::Int32:
     return ::tt::target::DataType::Int32;
   }
 }
@@ -241,17 +242,17 @@ inline ::tt::target::TensorLayout toFlatbuffer(FlatbufferObjectCache &cache,
 }
 
 inline ::tt::target::MemorySpace toFlatbuffer(FlatbufferObjectCache &,
-                                              MemorySpace memspace) {
+                                              ttcore::MemorySpace memspace) {
   switch (memspace) {
-  case MemorySpace::System:
+  case ttcore::MemorySpace::System:
     return ::tt::target::MemorySpace::System;
-  case MemorySpace::SystemMMIO:
+  case ttcore::MemorySpace::SystemMMIO:
     return ::tt::target::MemorySpace::SystemMMIO;
-  case MemorySpace::DeviceDRAM:
+  case ttcore::MemorySpace::DeviceDRAM:
     return ::tt::target::MemorySpace::DeviceDRAM;
-  case MemorySpace::DeviceL1:
+  case ttcore::MemorySpace::DeviceL1:
     return ::tt::target::MemorySpace::DeviceL1;
-  case MemorySpace::RegisterDst:
+  case ttcore::MemorySpace::RegisterDst:
     llvm_unreachable("MemorySpace::RegisterDst not supported");
   }
 }
@@ -276,34 +277,37 @@ inline ::tt::target::ttnn::ShardMode toFlatbuffer(FlatbufferObjectCache &,
   }
 }
 
-inline ::tt::target::Arch toFlatbuffer(FlatbufferObjectCache &, ArchAttr arch) {
+inline ::tt::target::Arch toFlatbuffer(FlatbufferObjectCache &,
+                                       ttcore::ArchAttr arch) {
   switch (arch.getValue()) {
-  case Arch::Grayskull:
+  case ttcore::Arch::Grayskull:
     return ::tt::target::Arch::Grayskull;
-  case Arch::WormholeB0:
+  case ttcore::Arch::WormholeB0:
     return ::tt::target::Arch::Wormhole_b0;
-  case Arch::Blackhole:
+  case ttcore::Arch::Blackhole:
     return ::tt::target::Arch::Blackhole;
   }
 }
 
 // Overloaded function for DataTypeAttr
-inline ::tt::target::DataType toFlatbuffer(FlatbufferObjectCache &cache,
-                                           const DataTypeAttr &dtypeAttr) {
+inline ::tt::target::DataType
+toFlatbuffer(FlatbufferObjectCache &cache,
+             const ttcore::DataTypeAttr &dtypeAttr) {
   return toFlatbuffer(cache, dtypeAttr.getValue());
 }
 
 inline ::tt::target::Dim2d toFlatbuffer(FlatbufferObjectCache &cache,
-                                        TileSizeAttr tileSize) {
+                                        ttcore::TileSizeAttr tileSize) {
   return ::tt::target::Dim2d(tileSize.getY(), tileSize.getX());
 }
 
 inline ::tt::target::ChipCapability
-toFlatbuffer(FlatbufferObjectCache &, ChipCapabilityAttr capabilityAttr) {
+toFlatbuffer(FlatbufferObjectCache &,
+             ttcore::ChipCapabilityAttr capabilityAttr) {
   auto capabilities = capabilityAttr.getValue();
-  static_assert(llvm::to_underlying(ChipCapability::PCIE) ==
+  static_assert(llvm::to_underlying(ttcore::ChipCapability::PCIE) ==
                 llvm::to_underlying(::tt::target::ChipCapability::PCIE));
-  static_assert(llvm::to_underlying(ChipCapability::HostMMIO) ==
+  static_assert(llvm::to_underlying(ttcore::ChipCapability::HostMMIO) ==
                 llvm::to_underlying(::tt::target::ChipCapability::HostMMIO));
   assert((llvm::to_underlying(capabilities) & ~0b11) == 0 &&
          "unsupported chip capabilities");
@@ -311,13 +315,14 @@ toFlatbuffer(FlatbufferObjectCache &, ChipCapabilityAttr capabilityAttr) {
 }
 
 inline ::tt::target::ChipCoord toFlatbuffer(FlatbufferObjectCache &cache,
-                                            ChipCoordAttr chipCoord) {
+                                            ttcore::ChipCoordAttr chipCoord) {
   return ::tt::target::ChipCoord(chipCoord.getRack(), chipCoord.getShelf(),
                                  chipCoord.getY(), chipCoord.getX());
 }
 
-inline ::tt::target::ChipChannel toFlatbuffer(FlatbufferObjectCache &cache,
-                                              ChipChannelAttr chipChannel) {
+inline ::tt::target::ChipChannel
+toFlatbuffer(FlatbufferObjectCache &cache,
+             ttcore::ChipChannelAttr chipChannel) {
   return ::tt::target::ChipChannel(
       chipChannel.getDeviceId0(),
       ::tt::target::Dim2d(chipChannel.getEthernetCoreCoord0()[0],
@@ -328,14 +333,14 @@ inline ::tt::target::ChipChannel toFlatbuffer(FlatbufferObjectCache &cache,
 }
 
 inline ::tt::target::Dim2d toFlatbuffer(FlatbufferObjectCache &cache,
-                                        GridAttr arch) {
+                                        ttcore::GridAttr arch) {
   assert(arch.getShape().size() == 2 && "expected a 2D grid");
   return ::tt::target::Dim2d(arch.getShape()[0], arch.getShape()[1]);
 }
 
 inline flatbuffers::Offset<::tt::target::ChipPhysicalHelperCores>
 toFlatbuffer(FlatbufferObjectCache &cache,
-             ChipPhysicalHelperCoresAttr chipPhysicalHelperCores) {
+             ttcore::ChipPhysicalHelperCoresAttr chipPhysicalHelperCores) {
 
   // Create a Flatbuffer Dim2d struct for each type of core.
   std::vector<::tt::target::Dim2d> dramCores, ethCores, ethInactiveCores;
@@ -413,7 +418,7 @@ toFlatbuffer(FlatbufferObjectCache &cache, llvm::StringRef str) {
 }
 
 inline flatbuffers::Offset<::tt::target::ChipDesc>
-toFlatbuffer(FlatbufferObjectCache &cache, ChipDescAttr chipDesc) {
+toFlatbuffer(FlatbufferObjectCache &cache, ttcore::ChipDescAttr chipDesc) {
   assert(chipDesc.getGrid().size() == 2 && "expected a 2D grid");
   auto grid = ::tt::target::Dim2d(chipDesc.getGrid()[0], chipDesc.getGrid()[1]);
   auto coordTranslationOffsets =
@@ -435,24 +440,24 @@ toFlatbuffer(FlatbufferObjectCache &cache, ChipDescAttr chipDesc) {
 }
 
 inline ::tt::target::CPURole toFlatbuffer(FlatbufferObjectCache &,
-                                          CPURole memLayout) {
+                                          ttcore::CPURole memLayout) {
   switch (memLayout) {
-  case CPURole::Host:
+  case ttcore::CPURole::Host:
     return ::tt::target::CPURole::Host;
-  case CPURole::Device:
+  case ttcore::CPURole::Device:
     return ::tt::target::CPURole::Device;
   }
 }
 
 inline flatbuffers::Offset<::tt::target::CPUDesc>
-toFlatbuffer(FlatbufferObjectCache &cache, CPUDescAttr cpuDesc) {
+toFlatbuffer(FlatbufferObjectCache &cache, ttcore::CPUDescAttr cpuDesc) {
   return ::tt::target::CreateCPUDesc(
       *cache.fbb, toFlatbuffer(cache, cpuDesc.getRole()),
       cache.fbb->CreateString(cpuDesc.getTargetTriple().getValue().str()));
 }
 
 inline flatbuffers::Offset<::tt::target::SystemDesc>
-toFlatbuffer(FlatbufferObjectCache &cache, SystemDescAttr systemDesc) {
+toFlatbuffer(FlatbufferObjectCache &cache, ttcore::SystemDescAttr systemDesc) {
   auto cpuDescs = toFlatbuffer(cache, systemDesc.getCpuDescs());
   auto chipDescs = toFlatbuffer(cache, systemDesc.getChipDescs());
   auto chipDescIndices = toFlatbuffer(cache, systemDesc.getChipDescIndices());
@@ -469,7 +474,8 @@ toFlatbuffer(FlatbufferObjectCache &cache, llvm::ArrayRef<int64_t> tensorGrid,
              mlir::AffineMap mapping) {
   std::vector<::tt::target::Dim2dRange> coreRangeSet;
 
-  for (const auto &locsize2d : utils::toCoreRangeSet(tensorGrid, mapping)) {
+  for (const auto &locsize2d :
+       ttcore::utils::toCoreRangeSet(tensorGrid, mapping)) {
     const auto &[loc, size] = locsize2d;
     coreRangeSet.push_back(
         ::tt::target::Dim2dRange(::tt::target::Dim2d(loc[1], loc[0]),
@@ -481,8 +487,8 @@ toFlatbuffer(FlatbufferObjectCache &cache, llvm::ArrayRef<int64_t> tensorGrid,
 
 // Compatibility function for TTNN flatbuffer serialization.
 inline std::vector<::tt::target::Dim2dRange>
-toFlatbuffer(FlatbufferObjectCache &cache, GridAttr tensorGrid,
-             GridAttr deviceGrid) {
+toFlatbuffer(FlatbufferObjectCache &cache, ttcore::GridAttr tensorGrid,
+             ttcore::GridAttr deviceGrid) {
   auto mapping = tensorGrid.getMapping().isEmpty() ? deviceGrid.getMapping()
                                                    : tensorGrid.getMapping();
   return toFlatbuffer(cache, tensorGrid.getShape(), mapping);
@@ -860,23 +866,23 @@ toFlatbuffer(FlatbufferObjectCache &cache,
 
 inline flatbuffers::Offset<::tt::target::ttnn::MemoryDesc>
 toFlatbuffer(FlatbufferObjectCache &cache, mlir::MemRefType memref,
-             tt::TensorMeshShardingAttr tensorMeshSharding,
+             ttcore::TensorMeshShardingAttr tensorMeshSharding,
              ttnn::BufferType bufferType,
-             ttnn::TensorMemoryLayoutAttr memLayoutAttr, tt::GridAttr shardGrid,
-             tt::GridAttr deviceGrid) {
+             ttnn::TensorMemoryLayoutAttr memLayoutAttr,
+             ttcore::GridAttr shardGrid, ttcore::GridAttr deviceGrid) {
   auto shapeInt64 = memref.getShape();
   std::vector<int32_t> shape(shapeInt64.begin(), shapeInt64.end());
-  DataType dtype = DataType::Float32;
+  ttcore::DataType dtype = ttcore::DataType::Float32;
   ::tt::target::Dim2d tileShape(1, 1);
   mlir::Type elementType = memref.getElementType();
   std::uint64_t elementSize = 0;
-  if (mlir::isa<TileType>(elementType)) {
-    auto tileType = mlir::cast<TileType>(elementType);
+  if (mlir::isa<ttcore::TileType>(elementType)) {
+    auto tileType = mlir::cast<ttcore::TileType>(elementType);
     dtype = tileType.getDataType();
     tileShape = ::tt::target::Dim2d(tileType.getHeight(), tileType.getWidth());
     elementSize = tileType.getSizeBytes();
   } else {
-    dtype = elementTypeToDataType(elementType);
+    dtype = ttcore::elementTypeToDataType(elementType);
     elementSize = getElementSizeBytes(dtype);
   }
 
@@ -926,7 +932,7 @@ toFlatbuffer(FlatbufferObjectCache &cache, mlir::MemRefType memref,
 inline flatbuffers::Offset<::tt::target::ttnn::LayoutDesc>
 ttnnLayoutAttrToFlatbuffer(FlatbufferObjectCache &cache,
                            ttnn::TTNNLayoutAttr layoutAttr,
-                           DeviceAttr deviceAttr) {
+                           ttcore::DeviceAttr deviceAttr) {
   // TODO (jnie): Memory reference alone is insufficient to determine LayoutDesc
   // uniquely. Using `cache.getOrCreate()` is unsafe because identical memory
   // references can produce different LayoutDesc objects.
@@ -935,7 +941,7 @@ ttnnLayoutAttrToFlatbuffer(FlatbufferObjectCache &cache,
   // that guarantees identical memrefs will always produce identical
   // flatbuffer LayoutDescs.
   return ::tt::target::ttnn::CreateLayoutDesc(
-      *cache.fbb, toFlatbuffer(cache, OOBVal::Undef),
+      *cache.fbb, toFlatbuffer(cache, ttcore::OOBVal::Undef),
       toFlatbuffer(cache, layoutAttr.getMemref(),
                    layoutAttr.getTensorMeshSharding(),
                    layoutAttr.getBufferType(), layoutAttr.getMemLayout(),

--- a/include/ttmlir/Transforms/Passes.td
+++ b/include/ttmlir/Transforms/Passes.td
@@ -45,7 +45,7 @@ def ConstEvalHoistTransform: Pass<"const-eval-hoist-transform", "::mlir::ModuleO
 
   }];
 
-  let dependentDialects = ["::mlir::tt::TTCoreDialect"];
+  let dependentDialects = ["::mlir::tt::ttcore::TTCoreDialect"];
 }
 
 def UndoConstEvalTransform : Pass<"undo-const-eval", "mlir::ModuleOp"> {
@@ -55,7 +55,7 @@ def UndoConstEvalTransform : Pass<"undo-const-eval", "mlir::ModuleOp"> {
     effectively undoing the transformations performed by ConstEvalHoistTransform.
   }];
 
-  let dependentDialects = ["::mlir::tt::TTCoreDialect"];
+  let dependentDialects = ["::mlir::tt::ttcore::TTCoreDialect"];
 }
 
 def ReenableLostDPS: Pass<"ttir-reenable-dps", "::mlir::ModuleOp"> {

--- a/include/ttmlir/Utils.h
+++ b/include/ttmlir/Utils.h
@@ -139,7 +139,7 @@ std::string join(Range &&R, llvm::StringRef separator) {
 //           return wrap(tt::CircularBufferAttributesAttr::get(
 //               unwrap(ctx), static_cast<tt::CB>(cb_id),
 //               mlir::cast<tt::CoreRangeAttr>(unwrap(core_range)), total_size,
-//               page_size, static_cast<tt::DataType>(data_format)));
+//               page_size, static_cast<ttcore::DataType>(data_format)));
 //         })
 //     .def_static("get", [](MlirContext ctx,
 //                           std::vector<MlirAttribute> attributesArray) {

--- a/lib/CAPI/Dialects.cpp
+++ b/lib/CAPI/Dialects.cpp
@@ -10,7 +10,7 @@
 #include "ttmlir/Dialect/TTKernel/IR/TTKernel.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNN.h"
 
-MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(TT, tt, mlir::tt::TTCoreDialect)
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(TT, tt, mlir::tt::ttcore::TTCoreDialect)
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(TTIR, ttir, mlir::tt::ttir::TTIRDialect)
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(TTKernel, ttkernel,
                                       mlir::tt::ttkernel::TTKernelDialect)

--- a/lib/CAPI/TTCoreAttrs.cpp
+++ b/lib/CAPI/TTCoreAttrs.cpp
@@ -8,7 +8,7 @@
 
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 
-using namespace mlir::tt;
+using namespace mlir::tt::ttcore;
 
 MlirAttribute ttmlirTTGridAttrGet(MlirContext ctx, int64_t *shape,
                                   int shapeSize) {

--- a/lib/CAPI/TTNNAttrs.cpp
+++ b/lib/CAPI/TTNNAttrs.cpp
@@ -177,9 +177,10 @@ MlirAttribute ttmlirTTNNTTNNLayoutAttrGet(MlirContext ctx, MlirAffineMap linear,
         unwrap(ctx), static_cast<TensorMemoryLayout>(*memLayout));
   }
 
-  mlir::tt::TensorMeshShardingAttr tensorMeshShardingAttr;
-  return wrap(TTNNLayoutAttr::get(unwrap(ctx), affineMap,
-                                  mlir::cast<mlir::tt::GridAttr>(unwrap(grid)),
-                                  mlir::cast<mlir::MemRefType>(unwrap(memref)),
-                                  memLayoutAttr, tensorMeshShardingAttr));
+  mlir::tt::ttcore::TensorMeshShardingAttr tensorMeshShardingAttr;
+  return wrap(
+      TTNNLayoutAttr::get(unwrap(ctx), affineMap,
+                          mlir::cast<mlir::tt::ttcore::GridAttr>(unwrap(grid)),
+                          mlir::cast<mlir::MemRefType>(unwrap(memref)),
+                          memLayoutAttr, tensorMeshShardingAttr));
 }

--- a/lib/CAPI/TTTypes.cpp
+++ b/lib/CAPI/TTTypes.cpp
@@ -8,7 +8,7 @@
 
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 
-using namespace mlir::tt;
+using namespace mlir::tt::ttcore;
 
 MlirType ttmlirTTTileTypeGet(MlirContext ctx, unsigned height, unsigned width,
                              uint32_t dataType) {

--- a/lib/Conversion/StableHLOToTTIR/ShardyToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/ShardyToTTIRPatterns.cpp
@@ -58,11 +58,12 @@ static mlir::func::FuncOp getCalledFunction(CallOpInterface callOp) {
 // Check if Type includes TensorMeshShardingAttr
 static bool checkTypeIfTensorMeshShardingAttrExist(
     mlir::Type valueType,
-    mlir::tt::TensorMeshShardingAttr incomingTensorMeshShardingAttr) {
+    mlir::tt::ttcore::TensorMeshShardingAttr incomingTensorMeshShardingAttr) {
   auto type = mlir::cast<RankedTensorType>(valueType);
   mlir::Attribute encoding = type.getEncoding();
   if (auto existingTensorMeshShardingAttr =
-          dyn_cast_if_present<mlir::tt::TensorMeshShardingAttr>(encoding)) {
+          dyn_cast_if_present<mlir::tt::ttcore::TensorMeshShardingAttr>(
+              encoding)) {
     if (existingTensorMeshShardingAttr.getName() !=
         incomingTensorMeshShardingAttr.getName()) {
       llvm_unreachable("Conflict mesh in TensorMeshShardingAttrs.");
@@ -75,7 +76,7 @@ static bool checkTypeIfTensorMeshShardingAttrExist(
 // Check if FuncOp input/result include TensorMeshShardingAttr
 static bool checkFuncOpIfTensorMeshShardingAttrExist(
     mlir::func::FuncOp funcOp,
-    mlir::tt::TensorMeshShardingAttr incomingTensorMeshShardingAttr) {
+    mlir::tt::ttcore::TensorMeshShardingAttr incomingTensorMeshShardingAttr) {
   auto funcOpType = funcOp.getFunctionType();
   return (funcOpType.getInputs().size() > 0 &&
           checkTypeIfTensorMeshShardingAttrExist(
@@ -87,7 +88,8 @@ static bool checkFuncOpIfTensorMeshShardingAttrExist(
 
 // Add tensorMeshShardingAttr to tensors and get updated types.
 static llvm::SmallVector<Type> addTensorMeshShardingAttrToValues(
-    mlir::ValueRange values, TensorMeshShardingAttr tensorMeshShardingAttr) {
+    mlir::ValueRange values,
+    mlir::tt::ttcore::TensorMeshShardingAttr tensorMeshShardingAttr) {
   llvm::SmallVector<Type> types;
   if (values.size() == 0) {
     return types;
@@ -112,7 +114,8 @@ static llvm::SmallVector<Type> addTensorMeshShardingAttrToValues(
 // inside body of rewriter.modifyOpInPlace().
 template <typename OpTy>
 void propagateTensorMeshSharding(
-    OpTy srcOp, mlir::tt::TensorMeshShardingAttr tensorMeshShardingAttr) {
+    OpTy srcOp,
+    mlir::tt::ttcore::TensorMeshShardingAttr tensorMeshShardingAttr) {
   static_assert(std::is_same_v<OpTy, mlir::sdy::ManualComputationOp> ||
                     std::is_same_v<OpTy, mlir::func::FuncOp>,
                 "Only propagate TensorMeshSharding to "
@@ -208,7 +211,7 @@ public:
     auto meshNameStrAttr =
         mlir::StringAttr::get(context, firstSharding.getMeshName());
     auto tensorMeshShardingAttr =
-        mlir::tt::TensorMeshShardingAttr::get(context, meshNameStrAttr);
+        mlir::tt::ttcore::TensorMeshShardingAttr::get(context, meshNameStrAttr);
     rewriter.modifyOpInPlace(srcOp, [&]() {
       mlir::tt::propagateTensorMeshSharding<mlir::sdy::ManualComputationOp>(
           srcOp, tensorMeshShardingAttr);
@@ -244,7 +247,8 @@ public:
 
       mlir::tt::sharding_utils::MeshSharding meshSharding;
       auto error = meshSharding.convertSdyShardingToMeshSharding(
-          argSharding, targetMesh, mlir::tt::MeshShardDirection::FullToShard);
+          argSharding, targetMesh,
+          mlir::tt::ttcore::MeshShardDirection::FullToShard);
       if (auto e = error.takeError()) {
         return rewriter.notifyMatchFailure(srcOp, llvm::toString(std::move(e)));
       }
@@ -286,7 +290,8 @@ public:
       auto [returnOperand, outSharding, opResult] = args;
       mlir::tt::sharding_utils::MeshSharding meshSharding;
       auto error = meshSharding.convertSdyShardingToMeshSharding(
-          outSharding, targetMesh, mlir::tt::MeshShardDirection::ShardToFull);
+          outSharding, targetMesh,
+          mlir::tt::ttcore::MeshShardDirection::ShardToFull);
       if (auto e = error.takeError()) {
         return rewriter.notifyMatchFailure(srcOp, llvm::toString(std::move(e)));
       }
@@ -357,8 +362,8 @@ public:
       for (auto meshAxisAttr : sdyMesh.getAxes()) {
         meshShape.push_back(meshAxisAttr.getSize());
       }
-      mlir::tt::utils::addMeshToModuleAttribute(rewriter, module, meshName,
-                                                meshShape);
+      mlir::tt::ttcore::utils::addMeshToModuleAttribute(rewriter, module,
+                                                        meshName, meshShape);
     }
 
     // Before erasing MeshOp, visit public functions and properly handle
@@ -388,7 +393,7 @@ public:
         mlir::tt::sharding_utils::MeshSharding meshSharding;
         auto error = meshSharding.convertSdyShardingToMeshSharding(
             argShardingAttr, sdyMesh,
-            mlir::tt::MeshShardDirection::ShardToFull);
+            mlir::tt::ttcore::MeshShardDirection::ShardToFull);
         if (auto e = error.takeError()) {
           llvm_unreachable(llvm::toString(std::move(e)).c_str());
         }
@@ -418,7 +423,7 @@ public:
         mlir::tt::sharding_utils::MeshSharding meshSharding;
         auto error = meshSharding.convertSdyShardingToMeshSharding(
             retShardingAttr, sdyMesh,
-            mlir::tt::MeshShardDirection::FullToShard);
+            mlir::tt::ttcore::MeshShardDirection::FullToShard);
         if (auto e = error.takeError()) {
           llvm_unreachable(llvm::toString(std::move(e)).c_str());
         }
@@ -456,7 +461,7 @@ namespace mlir::tt {
 // Check matching of input and result tensor annotations and fix if there is any
 // issue.
 llvm::LogicalResult
-analyzeSingleOpAndFixWrongTensorAnnotation(mlir::tt::MeshesAttr meshes,
+analyzeSingleOpAndFixWrongTensorAnnotation(mlir::tt::ttcore::MeshesAttr meshes,
                                            mlir::Operation *srcOp,
                                            mlir::OpBuilder &builder) {
   if (srcOp->getNumResults() == 0 || srcOp->getNumOperands() == 0) {
@@ -466,16 +471,16 @@ analyzeSingleOpAndFixWrongTensorAnnotation(mlir::tt::MeshesAttr meshes,
   auto resultType =
       mlir::cast<mlir::RankedTensorType>(srcOp->getResult(0).getType());
   if (auto tensorMeshShardingAttr =
-          mlir::dyn_cast_if_present<mlir::tt::TensorMeshShardingAttr>(
+          mlir::dyn_cast_if_present<mlir::tt::ttcore::TensorMeshShardingAttr>(
               resultType.getEncoding())) {
     // Result is multi device tensor and thus expects args to be multi device
     // tensors. If args are not multi device tensor, propagate the missing
     // TensorMeshShardingAttr to args.
     for (auto arg : srcOp->getOperands()) {
       auto argType = mlir::cast<mlir::RankedTensorType>(arg.getType());
-      if (auto argTensorMeshShardingAttr =
-              mlir::dyn_cast_if_present<mlir::tt::TensorMeshShardingAttr>(
-                  argType.getEncoding())) {
+      if (auto argTensorMeshShardingAttr = mlir::dyn_cast_if_present<
+              mlir::tt::ttcore::TensorMeshShardingAttr>(
+              argType.getEncoding())) {
         // If pre-existing TensorMeshShardingAttr is different from the
         // expected one, then fail.
         if (argTensorMeshShardingAttr.getName() !=
@@ -499,14 +504,14 @@ analyzeSingleOpAndFixWrongTensorAnnotation(mlir::tt::MeshesAttr meshes,
     // tensor to single device tensor.
     for (auto arg : srcOp->getOperands()) {
       auto argType = mlir::cast<mlir::RankedTensorType>(arg.getType());
-      if (auto argTensorMeshShardingAttr =
-              mlir::dyn_cast_if_present<mlir::tt::TensorMeshShardingAttr>(
-                  argType.getEncoding())) {
+      if (auto argTensorMeshShardingAttr = mlir::dyn_cast_if_present<
+              mlir::tt::ttcore::TensorMeshShardingAttr>(
+              argType.getEncoding())) {
         mlir::tt::sharding_utils::MeshSharding meshSharding;
         meshSharding.extractMeshShardingFromTensorMeshShardingAttr(
             meshes.getMesh(argTensorMeshShardingAttr.getName().str()),
             argTensorMeshShardingAttr,
-            mlir::tt::MeshShardDirection::ShardToFull);
+            mlir::tt::ttcore::MeshShardDirection::ShardToFull);
 
         mlir::Type elementType = argType.getElementType();
         llvm::ArrayRef<int64_t> shape = argType.getShape();
@@ -545,8 +550,8 @@ public:
     mlir::ModuleOp moduleOp = getOperation();
     mlir::MLIRContext *context = moduleOp.getContext();
     auto builder = mlir::OpBuilder(context);
-    auto meshes = moduleOp->getAttrOfType<mlir::tt::MeshesAttr>(
-        mlir::tt::MeshesAttr::name);
+    auto meshes = moduleOp->getAttrOfType<mlir::tt::ttcore::MeshesAttr>(
+        mlir::tt::ttcore::MeshesAttr::name);
 
     // We regard a module without meshes as a module only containing single
     // device tensors. Thus, skip this pass.

--- a/lib/Conversion/TTIRToTTIRGeneric/TTIRToTTIRGenericPass.cpp
+++ b/lib/Conversion/TTIRToTTIRGeneric/TTIRToTTIRGenericPass.cpp
@@ -59,7 +59,7 @@ struct TTIRToTTIRGenericPass final
       target.addLegalDialect<mlir::func::FuncDialect>();
       target.addLegalDialect<mlir::linalg::LinalgDialect>();
 
-      target.addLegalDialect<tt::TTCoreDialect>();
+      target.addLegalDialect<ttcore::TTCoreDialect>();
 
       // An explicit list of legal ttir.* ops.
 
@@ -77,7 +77,7 @@ struct TTIRToTTIRGenericPass final
           >();
     }
 
-    DeviceAttr deviceAttr = lookupDevice(moduleOp);
+    ttcore::DeviceAttr deviceAttr = ttcore::lookupDevice(moduleOp);
 
     TypeConverter typeConverter;
     {

--- a/lib/Conversion/TTIRToTTKernel/TTIRToTTKernelPass.cpp
+++ b/lib/Conversion/TTIRToTTKernel/TTIRToTTKernelPass.cpp
@@ -44,7 +44,7 @@ struct ConvertTTIRToTTKernel
     target.addLegalDialect<arith::ArithDialect>();
     target.addLegalDialect<func::FuncDialect>();
     target.addLegalDialect<ttmetal::TTMetalDialect>();
-    target.addLegalDialect<tt::TTCoreDialect>();
+    target.addLegalDialect<ttcore::TTCoreDialect>();
     target.addLegalDialect<ttkernel::TTKernelDialect>();
     target.addLegalDialect<scf::SCFDialect>();
     target.addIllegalDialect<math::MathDialect>();
@@ -75,13 +75,14 @@ struct ConvertTTIRToTTKernel
 
     TypeConverter typeConverter;
     typeConverter.addConversion([](Type type) { return type; });
-    typeConverter.addConversion(
-        [](tt::TileType tile) { return IndexType::get(tile.getContext()); });
+    typeConverter.addConversion([](ttcore::TileType tile) {
+      return IndexType::get(tile.getContext());
+    });
     typeConverter.addConversion([](ttir::MemTxType memtx) {
       return IndexType::get(memtx.getContext());
     });
     typeConverter.addConversion([](MemRefType memref) -> Type {
-      if (tt::getMemorySpace(memref) == tt::MemorySpace::RegisterDst) {
+      if (ttcore::getMemorySpace(memref) == ttcore::MemorySpace::RegisterDst) {
         return IndexType::get(memref.getContext());
       }
       return ttkernel::CBType::get(memref.getContext(), memref);

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetal.cpp
@@ -48,8 +48,8 @@ public:
       elemType = mlir::cast<MemRefType>(elemType).getElementType();
     }
     // We could have a memref of tiles, so this needs to be the second query
-    if (mlir::isa<TileType>(elemType)) {
-      elemType = mlir::cast<TileType>(elemType).getElementType();
+    if (mlir::isa<ttcore::TileType>(elemType)) {
+      elemType = mlir::cast<ttcore::TileType>(elemType).getElementType();
     }
     assert(elemType.isIntOrFloat());
     return elemType;
@@ -57,7 +57,7 @@ public:
 
   static ArrayAttr
   convertThreadsToKernelConfigs(Builder &builder, mlir::ValueRange operands,
-                                ArrayAttr threads, GridAttr opGrid,
+                                ArrayAttr threads, ttcore::GridAttr opGrid,
                                 const SymbolTable &symbolTable) {
     SmallVector<Attribute> kernelConfigs;
     uint32_t nocIndex = 0;
@@ -132,7 +132,7 @@ public:
     }
 
     ArrayAttr threads = op.getThreads();
-    GridAttr opGrid = op.getGrid();
+    ttcore::GridAttr opGrid = op.getGrid();
     SymbolTable symbolTable(op->getParentOfType<ModuleOp>());
     auto kernelConfigs = convertThreadsToKernelConfigs(
         rewriter, adaptor.getOperands(), threads, opGrid, symbolTable);
@@ -155,7 +155,7 @@ public:
     assert(op.getMemref().getType().getMemorySpace() &&
            "No memref memory space found, failing.");
     auto memrefType = op.getMemref().getType();
-    assert(mlir::isa<tt::ShardLayoutAttr>(memrefType.getLayout()));
+    assert(mlir::isa<ttcore::ShardLayoutAttr>(memrefType.getLayout()));
     rewriter.replaceOpWithNewOp<ttmetal::CreateBufferOp>(op, memrefType,
                                                          address);
 
@@ -204,11 +204,11 @@ public:
     }
     MemRefType inputTy = mlir::cast<MemRefType>(input.getType());
     MemRefType outputTy = mlir::cast<MemRefType>(output.getType());
-    tt::MemorySpaceAttr inputMemorySpace =
-        mlir::dyn_cast_if_present<tt::MemorySpaceAttr>(
+    ttcore::MemorySpaceAttr inputMemorySpace =
+        mlir::dyn_cast_if_present<ttcore::MemorySpaceAttr>(
             inputTy.getMemorySpace());
-    tt::MemorySpaceAttr outputMemorySpace =
-        mlir::dyn_cast_if_present<tt::MemorySpaceAttr>(
+    ttcore::MemorySpaceAttr outputMemorySpace =
+        mlir::dyn_cast_if_present<ttcore::MemorySpaceAttr>(
             outputTy.getMemorySpace());
     bool inputMemorySpaceSet = inputMemorySpace != nullptr;
     bool outputMemorySpaceSet = outputMemorySpace != nullptr;

--- a/lib/Conversion/TTIRToTTMetal/TTIRToTTMetalPass.cpp
+++ b/lib/Conversion/TTIRToTTMetal/TTIRToTTMetalPass.cpp
@@ -45,7 +45,7 @@ struct ConvertTTIRToTTMetal
     target.addLegalDialect<memref::MemRefDialect>();
     target.addLegalDialect<ttmetal::TTMetalDialect>();
     target.addLegalDialect<ttkernel::TTKernelDialect>();
-    target.addLegalDialect<tt::TTCoreDialect>();
+    target.addLegalDialect<ttcore::TTCoreDialect>();
     target.addLegalDialect<scf::SCFDialect>();
     target.addIllegalDialect<math::MathDialect>();
     target.addIllegalDialect<ttir::TTIRDialect>();
@@ -54,11 +54,11 @@ struct ConvertTTIRToTTMetal
     target.addLegalOp<ttir::ViewLayoutOp>();
 
     target.addDynamicallyLegalOp<memref::AllocOp>([&](memref::AllocOp op) {
-      return !mlir::dyn_cast_if_present<tt::MemorySpaceAttr>(
+      return !mlir::dyn_cast_if_present<ttcore::MemorySpaceAttr>(
           op.getMemref().getType().getMemorySpace());
     });
     target.addDynamicallyLegalOp<memref::DeallocOp>([&](memref::DeallocOp op) {
-      return !mlir::dyn_cast_if_present<tt::MemorySpaceAttr>(
+      return !mlir::dyn_cast_if_present<ttcore::MemorySpaceAttr>(
           op.getMemref().getType().getMemorySpace());
     });
 

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -55,8 +55,9 @@ public:
     ttnn::ShapeAttr shapeAttr = ttnn::ShapeAttr::get(
         rewriter.getContext(),
         mlir::cast<RankedTensorType>(op->getResult(0).getType()).getShape());
-    DataType dtype = layoutAttr.getDataType();
-    DataTypeAttr dTypeAttr = DataTypeAttr::get(rewriter.getContext(), dtype);
+    ttcore::DataType dtype = layoutAttr.getDataType();
+    ttcore::DataTypeAttr dTypeAttr =
+        ttcore::DataTypeAttr::get(rewriter.getContext(), dtype);
 
     ttnn::Layout ttnnLayoutEnum = ttnn::Layout::RowMajor;
 
@@ -126,8 +127,8 @@ public:
 
     // Get data type, tensor layout, device and memory config
     //
-    DataTypeAttr dTypeAttr =
-        DataTypeAttr::get(rewriter.getContext(), layoutAttr.getDataType());
+    ttcore::DataTypeAttr dTypeAttr = ttcore::DataTypeAttr::get(
+        rewriter.getContext(), layoutAttr.getDataType());
     ttnn::BufferType bufferType = layoutAttr.getBufferType();
     ttnn::LayoutAttr tensorLayoutAttr =
         ttnn::LayoutAttr::get(op.getContext(), layoutAttr.getLayout());
@@ -208,9 +209,9 @@ public:
             .getEncoding());
 
     // Determine the output data type
-    DataType dtype = outputLayoutAttr.getDataType();
-    DataTypeAttr outputDataType =
-        DataTypeAttr::get(rewriter.getContext(), dtype);
+    ttcore::DataType dtype = outputLayoutAttr.getDataType();
+    ttcore::DataTypeAttr outputDataType =
+        ttcore::DataTypeAttr::get(rewriter.getContext(), dtype);
 
     // Determine the output layout (tile or row major)
     ttnn::BufferType outputBufferType = outputLayoutAttr.getBufferType();
@@ -433,8 +434,8 @@ public:
         op.getResult().getType().getEncoding());
 
     // Get data type, tensor layout, buffer type and memory config.
-    DataTypeAttr dTypeAttr =
-        DataTypeAttr::get(rewriter.getContext(), layoutAttr.getDataType());
+    ttcore::DataTypeAttr dTypeAttr = ttcore::DataTypeAttr::get(
+        rewriter.getContext(), layoutAttr.getDataType());
     ttnn::TensorMemoryLayoutAttr memLayout = layoutAttr.getMemLayout();
     ttnn::BufferType bufferType = layoutAttr.getBufferType();
 
@@ -1227,7 +1228,7 @@ public:
     auto resultType = op.getType();
     ttnn::TTNNLayoutAttr outputLayoutAttr =
         mlir::cast<ttnn::TTNNLayoutAttr>(resultType.getEncoding());
-    DataType outputDataType = outputLayoutAttr.getDataType();
+    ttcore::DataType outputDataType = outputLayoutAttr.getDataType();
 
     rewriter.replaceOpWithNewOp<ttnn::TypecastOp>(
         op, this->getTypeConverter()->convertType(resultType),
@@ -1404,8 +1405,8 @@ public:
     ttnn::TTNNLayoutAttr layoutAttr =
         mlir::cast<ttnn::TTNNLayoutAttr>(outputType.getEncoding());
 
-    DataTypeAttr dtypeAttr = rewriter.getAttr<DataTypeAttr>(
-        elementTypeToDataType(outputType.getElementType()));
+    ttcore::DataTypeAttr dtypeAttr = rewriter.getAttr<ttcore::DataTypeAttr>(
+        ttcore::elementTypeToDataType(outputType.getElementType()));
     Value device = mlir::tt::ttnn::utils::getOrInsertDevice(rewriter, op);
 
     ttnn::MemoryConfigAttr memConfigAttr =
@@ -1499,14 +1500,14 @@ public:
 } // namespace
 
 // Utility function to get data type for quantized types.
-static DataTypeAttr getDataType(mlir::Value val,
-                                ConversionPatternRewriter &rewriter,
-                                const TypeConverter *typeConverter) {
+static ttcore::DataTypeAttr getDataType(mlir::Value val,
+                                        ConversionPatternRewriter &rewriter,
+                                        const TypeConverter *typeConverter) {
   ttnn::TTNNLayoutAttr outputLayoutAttr = mlir::cast<ttnn::TTNNLayoutAttr>(
       mlir::cast<RankedTensorType>(typeConverter->convertType(val.getType()))
           .getEncoding());
-  DataType dtype = outputLayoutAttr.getDataType();
-  return DataTypeAttr::get(rewriter.getContext(), dtype);
+  ttcore::DataType dtype = outputLayoutAttr.getDataType();
+  return ttcore::DataTypeAttr::get(rewriter.getContext(), dtype);
 }
 
 namespace {
@@ -1518,7 +1519,7 @@ public:
   LogicalResult
   matchAndRewrite(OpTy op, typename OpTy::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
-    DataTypeAttr outputDataType =
+    ttcore::DataTypeAttr outputDataType =
         getDataType(op.getResult(), rewriter, this->getTypeConverter());
 
     rewriter.replaceOpWithNewOp<TTNNOpTy>(
@@ -1538,7 +1539,7 @@ public:
   LogicalResult
   matchAndRewrite(ttir::RequantizeUnrolledOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    DataTypeAttr outputDataType =
+    ttcore::DataTypeAttr outputDataType =
         getDataType(op.getResult(), rewriter, this->getTypeConverter());
 
     rewriter.replaceOpWithNewOp<ttnn::RequantizeOp>(

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNNPass.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNNPass.cpp
@@ -39,7 +39,7 @@ struct ConvertTTIRToTTNNPass
     target.addLegalDialect<BuiltinDialect>();
     target.addLegalDialect<func::FuncDialect>();
     target.addLegalDialect<ttnn::TTNNDialect>();
-    target.addLegalOp<tt::DeviceOp>();
+    target.addLegalOp<ttcore::DeviceOp>();
     target.addIllegalDialect<ttir::TTIRDialect>();
     target.addLegalDialect<quant::QuantDialect>();
 

--- a/lib/Conversion/TTIRToTTNN/Utils.cpp
+++ b/lib/Conversion/TTIRToTTNN/Utils.cpp
@@ -48,14 +48,16 @@ generateNHWFlatten(mlir::TypedValue<mlir::RankedTensorType> input,
 
 // Returns DataTypeAttr from tensor layout if present, or an empty DataTypeAttr
 // otherwise.
-DataTypeAttr getDataTypeAttrFromTensorLayout(RankedTensorType type,
-                                             PatternRewriter &rewriter) {
-  DataTypeAttr dataTypeAttr = DataTypeAttr();
+ttcore::DataTypeAttr
+getDataTypeAttrFromTensorLayout(RankedTensorType type,
+                                PatternRewriter &rewriter) {
+  ttcore::DataTypeAttr dataTypeAttr = ttcore::DataTypeAttr();
   ttnn::TTNNLayoutAttr layoutAttr =
       mlir::dyn_cast<ttnn::TTNNLayoutAttr>(type.getEncoding());
 
   if (layoutAttr) {
-    dataTypeAttr = rewriter.getAttr<DataTypeAttr>(layoutAttr.getDataType());
+    dataTypeAttr =
+        rewriter.getAttr<ttcore::DataTypeAttr>(layoutAttr.getDataType());
   }
 
   return dataTypeAttr;

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -114,48 +114,49 @@ emitc::OpaqueAttr convertCBPort(Builder &builder, ttkernel::CBPort port) {
   return nullptr;
 }
 
-emitc::OpaqueAttr datatypeToDataformatEnumValue(Builder &builder,
-                                                ::mlir::tt::DataType dtype) {
+emitc::OpaqueAttr
+datatypeToDataformatEnumValue(Builder &builder,
+                              ::mlir::tt::ttcore::DataType dtype) {
   std::string expression =
       "static_cast<std::underlying_type_t<DataFormat>>(DataFormat::";
   switch (dtype) {
-  case ::mlir::tt::DataType::Float32:
+  case ::mlir::tt::ttcore::DataType::Float32:
     expression += "Float32";
     break;
-  case ::mlir::tt::DataType::Float16:
+  case ::mlir::tt::ttcore::DataType::Float16:
     expression += "Float16";
     break;
-  case ::mlir::tt::DataType::BFloat16:
+  case ::mlir::tt::ttcore::DataType::BFloat16:
     expression += "Float16_b";
     break;
-  case ::mlir::tt::DataType::BFP_Float8:
+  case ::mlir::tt::ttcore::DataType::BFP_Float8:
     expression += "Bfp8";
     break;
-  case ::mlir::tt::DataType::BFP_BFloat8:
+  case ::mlir::tt::ttcore::DataType::BFP_BFloat8:
     expression += "Bfp8_b";
     break;
-  case ::mlir::tt::DataType::BFP_Float4:
+  case ::mlir::tt::ttcore::DataType::BFP_Float4:
     expression += "Bfp4";
     break;
-  case ::mlir::tt::DataType::BFP_BFloat4:
+  case ::mlir::tt::ttcore::DataType::BFP_BFloat4:
     expression += "Bfp4_b";
     break;
-  case ::mlir::tt::DataType::BFP_Float2:
+  case ::mlir::tt::ttcore::DataType::BFP_Float2:
     expression += "Bfp2";
     break;
-  case ::mlir::tt::DataType::BFP_BFloat2:
+  case ::mlir::tt::ttcore::DataType::BFP_BFloat2:
     expression += "Bfp2_b";
     break;
-  case ::mlir::tt::DataType::UInt32:
+  case ::mlir::tt::ttcore::DataType::UInt32:
     expression += "UInt32";
     break;
-  case ::mlir::tt::DataType::UInt16:
+  case ::mlir::tt::ttcore::DataType::UInt16:
     expression += "UInt16";
     break;
-  case ::mlir::tt::DataType::UInt8:
+  case ::mlir::tt::ttcore::DataType::UInt8:
     expression += "UInt8";
     break;
-  case ::mlir::tt::DataType::Int32:
+  case ::mlir::tt::ttcore::DataType::Int32:
     expression += "Int32";
     break;
   }

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -1256,16 +1256,16 @@ public:
 };
 } // namespace
 
-// mlir::tt::DeviceOp conversion pattern
+// mlir::tt::ttcore::DeviceOp conversion pattern
 //
 namespace {
 struct TTDeviceOpConversionPattern
-    : public TTNNToEmitCBaseOpConversionPattern<mlir::tt::DeviceOp> {
+    : public TTNNToEmitCBaseOpConversionPattern<mlir::tt::ttcore::DeviceOp> {
   using TTNNToEmitCBaseOpConversionPattern<
-      mlir::tt::DeviceOp>::TTNNToEmitCBaseOpConversionPattern;
+      mlir::tt::ttcore::DeviceOp>::TTNNToEmitCBaseOpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(mlir::tt::DeviceOp srcOp, OpAdaptor adaptor,
+  matchAndRewrite(mlir::tt::ttcore::DeviceOp srcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     rewriter.eraseOp(srcOp);
     return success();
@@ -1663,14 +1663,14 @@ public:
 
 namespace {
 class GetTupleElementOpConversionPattern
-    : public OpConversionPattern<mlir::tt::GetTupleElementOp> {
+    : public OpConversionPattern<mlir::tt::ttcore::GetTupleElementOp> {
 
 public:
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(mlir::tt::GetTupleElementOp getTupleElementOp,
-                  mlir::tt::GetTupleElementOp::Adaptor adaptor,
+  matchAndRewrite(mlir::tt::ttcore::GetTupleElementOp getTupleElementOp,
+                  mlir::tt::ttcore::GetTupleElementOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     // SubscriptOp requires a Value object as index, which is created by
     // invoking the emitc::LiteralOp.
@@ -1703,13 +1703,15 @@ public:
 } // namespace
 
 namespace {
-class TupleOpConversionPattern : public OpConversionPattern<mlir::tt::TupleOp> {
+class TupleOpConversionPattern
+    : public OpConversionPattern<mlir::tt::ttcore::TupleOp> {
 
 public:
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(mlir::tt::TupleOp tupleOp, mlir::tt::TupleOp::Adaptor adaptor,
+  matchAndRewrite(mlir::tt::ttcore::TupleOp tupleOp,
+                  mlir::tt::ttcore::TupleOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     // EmitC doesn't offer a way to create a vector from a list of values, so
     // we need to create a utility function that does this. This is achieved
@@ -1737,14 +1739,15 @@ public:
 //
 namespace {
 class LoadCachedOpConversionPattern
-    : public OpConversionPattern<mlir::tt::LoadCachedOp> {
+    : public OpConversionPattern<mlir::tt::ttcore::LoadCachedOp> {
 
 public:
-  using OpConversionPattern<mlir::tt::LoadCachedOp>::OpConversionPattern;
+  using OpConversionPattern<
+      mlir::tt::ttcore::LoadCachedOp>::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(mlir::tt::LoadCachedOp srcOp,
-                  mlir::tt::LoadCachedOp::Adaptor adaptor,
+  matchAndRewrite(mlir::tt::ttcore::LoadCachedOp srcOp,
+                  mlir::tt::ttcore::LoadCachedOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     // Get the callee function
     llvm::StringRef callee = srcOp.getCallee();

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitCPass.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitCPass.cpp
@@ -98,7 +98,7 @@ struct ConvertTTNNToEmitCPass
     // Unwrap device_module into top-level ModuleOp (if present)
     {
       OpPassManager pm(ModuleOp::getOperationName());
-      pm.addPass(mlir::tt::createTTCoreUnwrapDeviceModulePass());
+      pm.addPass(mlir::tt::ttcore::createTTCoreUnwrapDeviceModulePass());
 
       if (failed(runPipeline(pm, module))) {
         signalPassFailure();

--- a/lib/Conversion/TTNNToEmitC/Utils.cpp
+++ b/lib/Conversion/TTNNToEmitC/Utils.cpp
@@ -128,54 +128,54 @@ emitc::OpaqueAttr convertBoolAttr(Builder &builder, BoolAttr attr) {
   return builder.getType<emitc::OpaqueAttr>(attr.getValue() ? "true" : "false");
 }
 
-emitc::OpaqueAttr convertDType(Builder &builder, tt::DataTypeAttr attr) {
+emitc::OpaqueAttr convertDType(Builder &builder, ttcore::DataTypeAttr attr) {
   switch (attr.getValue()) {
-  case tt::DataType::BFloat16:
+  case ttcore::DataType::BFloat16:
     return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::BFLOAT16");
-  case tt::DataType::Float32:
+  case ttcore::DataType::Float32:
     return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::FLOAT32");
-  case tt::DataType::UInt32:
+  case ttcore::DataType::UInt32:
     return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::UINT32");
-  case tt::DataType::BFP_BFloat8:
+  case ttcore::DataType::BFP_BFloat8:
     return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::BFLOAT8_B");
-  case tt::DataType::BFP_BFloat4:
+  case ttcore::DataType::BFP_BFloat4:
     return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::BFLOAT4_B");
-  case tt::DataType::UInt8:
+  case ttcore::DataType::UInt8:
     return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::UINT8");
-  case tt::DataType::UInt16:
+  case ttcore::DataType::UInt16:
     return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::UINT16");
-  case tt::DataType::Int32:
+  case ttcore::DataType::Int32:
     return builder.getType<emitc::OpaqueAttr>("ttnn::DataType::INT32");
-  case tt::DataType::Float16:
-  case tt::DataType::BFP_Float2:
-  case tt::DataType::BFP_Float4:
-  case tt::DataType::BFP_Float8:
-  case tt::DataType::BFP_BFloat2:
+  case ttcore::DataType::Float16:
+  case ttcore::DataType::BFP_Float2:
+  case ttcore::DataType::BFP_Float4:
+  case ttcore::DataType::BFP_Float8:
+  case ttcore::DataType::BFP_BFloat2:
     llvm_unreachable("Unsupported ttnn::DataType");
   }
 
-  llvm_unreachable("Unkonwn tt::DataType");
+  llvm_unreachable("Unkonwn ttcore::DataType");
 }
 
 emitc::OpaqueAttr convertReduceType(ConversionPatternRewriter &rewriter,
-                                    tt::ReduceType reduceType) {
+                                    ttcore::ReduceType reduceType) {
   switch (reduceType) {
-  case tt::ReduceType::Sum:
+  case ttcore::ReduceType::Sum:
     return rewriter.getType<emitc::OpaqueAttr>(
         "::ttnn::operations::reduction::ReduceType::Sum");
-  case tt::ReduceType::Mean:
+  case ttcore::ReduceType::Mean:
     return rewriter.getType<emitc::OpaqueAttr>(
         "::ttnn::operations::reduction::ReduceType::Mean");
-  case tt::ReduceType::Max:
+  case ttcore::ReduceType::Max:
     return rewriter.getType<emitc::OpaqueAttr>(
         "::ttnn::operations::reduction::ReduceType::Max");
-  case tt::ReduceType::Min:
+  case ttcore::ReduceType::Min:
     return rewriter.getType<emitc::OpaqueAttr>(
         "::ttnn::operations::reduction::ReduceType::Min");
-  case tt::ReduceType::Std:
+  case ttcore::ReduceType::Std:
     return rewriter.getType<emitc::OpaqueAttr>(
         "::ttnn::operations::reduction::ReduceType::Std");
-  case tt::ReduceType::Var:
+  case ttcore::ReduceType::Var:
     return rewriter.getType<emitc::OpaqueAttr>(
         "::ttnn::operations::reduction::ReduceType::Var");
   }

--- a/lib/Dialect/StableHLO/Pipelines/StableHLOPipelines.cpp
+++ b/lib/Dialect/StableHLO/Pipelines/StableHLOPipelines.cpp
@@ -34,7 +34,8 @@ void createAutomaticShardingPipeline(
   pm.addPass(mlir::sdy::createApplyShardingConstraintsPass());
 
   // Annotate arguments with tt tensor annotations if the exist.
-  pm.addPass(mlir::tt::createTTPopulateArgumentTypes(options.argumentTypeMap));
+  pm.addPass(
+      mlir::tt::ttcore::createTTPopulateArgumentTypes(options.argumentTypeMap));
 
   // Annotate arguments with sdy tensor annotations.
   ShardyAnnotateArgumentsPassOptions shardyAnnotateArgumentsOptions;

--- a/lib/Dialect/StableHLO/Transforms/ShardyAutomaticParallelization.cpp
+++ b/lib/Dialect/StableHLO/Transforms/ShardyAutomaticParallelization.cpp
@@ -73,7 +73,7 @@ static bool ttAnnotationsExist(mlir::ModuleOp &rootModule) {
     // Check if ttir.name exists for any of the arguments.
     for (BlockArgument arg : funcOp.getBody().front().getArguments()) {
       if (auto currentArgAttrDict = funcOp.getArgAttrDict(arg.getArgNumber())) {
-        if (currentArgAttrDict.contains(mlir::tt::ArgumentTypeAttr::name)) {
+        if (currentArgAttrDict.contains(ttcore::ArgumentTypeAttr::name)) {
           return WalkResult::interrupt();
         }
       }
@@ -600,18 +600,19 @@ public:
       return mlir::failure();
     }
 
-    if (!currentArgAttrDict.contains(mlir::tt::ArgumentTypeAttr::name)) {
+    if (!currentArgAttrDict.contains(
+            mlir::tt::ttcore::ArgumentTypeAttr::name)) {
       funcOp.emitError("In function ")
           << funcOp.getName() << " argument #: " << arg->getArgNumber()
           << " is not annotated with ttir.name tensor annotations.\n";
       return mlir::failure();
     }
 
-    mlir::tt::ArgumentTypeAttr argumentTypeAttr =
-        mlir::cast<mlir::tt::ArgumentTypeAttr>(
-            currentArgAttrDict.get(mlir::tt::ArgumentTypeAttr::name));
-    mlir::tt::ArgumentType argTypeValue = argumentTypeAttr.getValue();
-    if (argTypeValue == mlir::tt::ArgumentType::Input) {
+    mlir::tt::ttcore::ArgumentTypeAttr argumentTypeAttr =
+        mlir::cast<mlir::tt::ttcore::ArgumentTypeAttr>(
+            currentArgAttrDict.get(mlir::tt::ttcore::ArgumentTypeAttr::name));
+    mlir::tt::ttcore::ArgumentType argTypeValue = argumentTypeAttr.getValue();
+    if (argTypeValue == mlir::tt::ttcore::ArgumentType::Input) {
       mlir::RankedTensorType tensorType =
           mlir::cast<mlir::RankedTensorType>(arg->getType());
       this->largestRank = std::max(this->largestRank, tensorType.getRank());
@@ -625,13 +626,14 @@ public:
                                    func::FuncOp &funcOp,
                                    BlockArgument *arg) override {
     llvm::SmallVector<mlir::NamedAttribute> newArgAttrs;
-    mlir::tt::ArgumentType argTypeValue = mlir::tt::ArgumentType::Default;
+    mlir::tt::ttcore::ArgumentType argTypeValue =
+        mlir::tt::ttcore::ArgumentType::Default;
 
     // Copy the current dictionary if it exists for the op.
     if (auto currentArgAttrDict = funcOp.getArgAttrDict(arg->getArgNumber())) {
-      mlir::tt::ArgumentTypeAttr argumentTypeAttr =
-          mlir::cast<mlir::tt::ArgumentTypeAttr>(
-              currentArgAttrDict.get(mlir::tt::ArgumentTypeAttr::name));
+      mlir::tt::ttcore::ArgumentTypeAttr argumentTypeAttr =
+          mlir::cast<mlir::tt::ttcore::ArgumentTypeAttr>(
+              currentArgAttrDict.get(mlir::tt::ttcore::ArgumentTypeAttr::name));
       argTypeValue = argumentTypeAttr.getValue();
       newArgAttrs =
           SmallVector<mlir::NamedAttribute>(currentArgAttrDict.getValue());
@@ -645,7 +647,7 @@ public:
     llvm::SmallVector<mlir::sdy::DimensionShardingAttr> dimShardings;
 
     if (argType.getRank() == this->largestRank &&
-        argTypeValue == mlir::tt::ArgumentType::Input) {
+        argTypeValue == mlir::tt::ttcore::ArgumentType::Input) {
       mlir::sdy::AxisRefAttr axisAttr =
           mlir::sdy::AxisRefAttr::get(context, "batch");
       mlir::sdy::DimensionShardingAttr dimShardingAttr =

--- a/lib/Dialect/TTCore/IR/TTCoreDialect.cpp
+++ b/lib/Dialect/TTCore/IR/TTCoreDialect.cpp
@@ -10,9 +10,12 @@
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 #include "llvm/ADT/TypeSwitch.h"
 
-using namespace mlir;
-using namespace mlir::tt;
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsDialect.cpp.inc"
 
+#define GET_ATTRDEF_CLASSES
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsAttrDefs.cpp.inc"
+
+namespace mlir::tt::ttcore {
 // This is needed to hoist ttcore.metal_layout attributes as named attributes
 // declared at the module level.
 struct TTOpAsmDialectInterface : public OpAsmDialectInterface {
@@ -38,17 +41,13 @@ struct TTOpAsmDialectInterface : public OpAsmDialectInterface {
     return AliasResult::NoAlias;
   }
 };
-
-#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsDialect.cpp.inc"
-
-#define GET_ATTRDEF_CLASSES
-#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsAttrDefs.cpp.inc"
+} // namespace mlir::tt::ttcore
 
 //===----------------------------------------------------------------------===//
 // TT dialect.
 //===----------------------------------------------------------------------===//
 
-void TTCoreDialect::initialize() {
+void mlir::tt::ttcore::TTCoreDialect::initialize() {
   addOperations<
 #define GET_OP_LIST
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOps.cpp.inc"

--- a/lib/Dialect/TTCore/IR/TTCoreOps.cpp
+++ b/lib/Dialect/TTCore/IR/TTCoreOps.cpp
@@ -38,7 +38,7 @@ static ParseResult parseTupleOpType(OpAsmParser &parser,
 #define GET_OP_CLASSES
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOps.cpp.inc"
 
-namespace mlir::tt {
+namespace mlir::tt::ttcore {
 
 LogicalResult GetTupleElementOp::inferReturnTypes(
     MLIRContext *, std::optional<Location> location, ValueRange operands,
@@ -185,4 +185,4 @@ LogicalResult LoadCachedOp::verify() {
   return success();
 }
 
-} // namespace mlir::tt
+} // namespace mlir::tt::ttcore

--- a/lib/Dialect/TTCore/IR/Utils.cpp
+++ b/lib/Dialect/TTCore/IR/Utils.cpp
@@ -9,7 +9,7 @@
 
 #include "mlir/IR/BuiltinOps.h"
 
-namespace mlir::tt {
+namespace mlir::tt::ttcore {
 
 SystemDescAttr getCurrentScopeSystemDesc(mlir::Operation *op) {
   // Find the top level ModuleOp which carries the system desc.
@@ -24,7 +24,7 @@ SystemDescAttr getCurrentScopeSystemDesc(mlir::Operation *op) {
 }
 
 DeviceOp lookupDeviceOp(Operation *op, SymbolRefAttr deviceName) {
-  return SymbolTable::lookupNearestSymbolFrom<tt::DeviceOp>(op, deviceName);
+  return SymbolTable::lookupNearestSymbolFrom<DeviceOp>(op, deviceName);
 }
 
 DeviceOp lookupDeviceOp(Operation *op, llvm::StringRef deviceName) {
@@ -132,4 +132,4 @@ ArrayRef<int64_t> getTensorTileShapeOrEmpty(RankedTensorType tensorType) {
                              : ArrayRef<int64_t>{};
 }
 
-} // namespace mlir::tt
+} // namespace mlir::tt::ttcore

--- a/lib/Dialect/TTCore/Transforms/TTCoreModuleWrap.cpp
+++ b/lib/Dialect/TTCore/Transforms/TTCoreModuleWrap.cpp
@@ -14,7 +14,7 @@
 #include "mlir/Pass/Pass.h"
 #include "llvm/Support/Casting.h"
 
-namespace mlir::tt {
+namespace mlir::tt::ttcore {
 #define GEN_PASS_DEF_TTCOREUNWRAPDEVICEMODULEPASS
 #define GEN_PASS_DEF_TTCOREWRAPDEVICEMODULEPASS
 #include "ttmlir/Dialect/TTCore/Transforms/Passes.h.inc"
@@ -27,7 +27,7 @@ public:
   void runOnOperation() override {
     ModuleOp rootModule = getOperation();
     if (rootModule->getParentOp() != nullptr ||
-        llvm::any_of(rootModule.getOps<tt::DeviceModuleOp>(),
+        llvm::any_of(rootModule.getOps<DeviceModuleOp>(),
                      [](auto) { return true; })) {
       return;
     }
@@ -42,7 +42,7 @@ public:
     innerModule.getBodyRegion().takeBody(rootModule.getBodyRegion());
     rootModule.getRegion().emplaceBlock();
     builder.setInsertionPointToStart(&rootModule.getBodyRegion().front());
-    auto deviceModule = builder.create<tt::DeviceModuleOp>(rootModule.getLoc());
+    auto deviceModule = builder.create<DeviceModuleOp>(rootModule.getLoc());
     builder.setInsertionPointToStart(&deviceModule.getBodyRegion().front());
     builder.clone(*innerModule);
     innerModule->erase();
@@ -62,8 +62,8 @@ public:
       return;
     }
 
-    tt::DeviceModuleOp deviceOp;
-    if (auto deviceOpsList = rootModule.getOps<tt::DeviceModuleOp>();
+    DeviceModuleOp deviceOp;
+    if (auto deviceOpsList = rootModule.getOps<DeviceModuleOp>();
         !deviceOpsList.empty()) {
       assert(std::distance(deviceOpsList.begin(), deviceOpsList.end()) == 1 &&
              "Top-level ModuleOp must contain 0 or 1 DeviceModuleOps!");
@@ -72,7 +72,7 @@ public:
       return;
     }
 
-    if (auto cpuOpsList = rootModule.getOps<tt::CPUModuleOp>();
+    if (auto cpuOpsList = rootModule.getOps<CPUModuleOp>();
         !cpuOpsList.empty()) {
       assert(std::distance(cpuOpsList.begin(), cpuOpsList.end()) == 1 &&
              "Top-level ModuleOp must contain 0 or 1 CPUModuleOps!");
@@ -102,4 +102,4 @@ public:
     deviceOp->erase();
   }
 };
-} // namespace mlir::tt
+} // namespace mlir::tt::ttcore

--- a/lib/Dialect/TTCore/Transforms/TTCoreRegisterDevice.cpp
+++ b/lib/Dialect/TTCore/Transforms/TTCoreRegisterDevice.cpp
@@ -7,7 +7,7 @@
 #include "ttmlir/Dialect/TTCore/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTCore/Utils/Mesh.h"
 
-namespace mlir::tt {
+namespace mlir::tt::ttcore {
 #define GEN_PASS_DEF_TTCOREREGISTERDEVICEPASS
 #define GEN_PASS_DEF_TTIRDEPRECATEDLOADSYSTEMDESC
 #include "ttmlir/Dialect/TTCore/Transforms/Passes.h.inc"
@@ -21,34 +21,34 @@ static LogicalResult registerDeviceInSymbolTable(ModuleOp moduleOp,
   MLIRContext *context = moduleOp.getContext();
 
   SymbolTable symbolTable(moduleOp);
-  if (!symbolTable.lookup(tt::getDefaultDeviceName())) {
+  if (!symbolTable.lookup(getDefaultDeviceName())) {
     auto systemDesc =
-        moduleOp->getAttrOfType<tt::SystemDescAttr>(tt::SystemDescAttr::name);
+        moduleOp->getAttrOfType<SystemDescAttr>(SystemDescAttr::name);
     assert(systemDesc && "expected system desc to be present on the moduleOp");
-    auto finalMeshShape = tt::utils::determineMeshShape(moduleOp, meshShape);
+    auto finalMeshShape =
+        ttcore::utils::determineMeshShape(moduleOp, meshShape);
     if (auto err = finalMeshShape.takeError()) {
       emitError(moduleOp.getLoc()) << "Error determining mesh shape\n";
       assert(false && "Error determining mesh shape");
       return failure();
     }
     OpBuilder builder(moduleOp.getBodyRegion());
-    symbolTable.insert(builder.create<tt::DeviceOp>(
-        moduleOp.getLoc(), tt::getDefaultDeviceName(),
-        tt::DeviceAttr::get(context, systemDesc, *finalMeshShape)));
+    symbolTable.insert(builder.create<DeviceOp>(
+        moduleOp.getLoc(), getDefaultDeviceName(),
+        DeviceAttr::get(context, systemDesc, *finalMeshShape)));
   }
   return success();
 }
 
 LogicalResult registerDevice(ModuleOp moduleOp,
-                             tt::Arch mockSystemDescArch = tt::Arch::WormholeB0,
+                             Arch mockSystemDescArch = Arch::WormholeB0,
                              ArrayRef<int64_t> meshShape = {}) {
   MLIRContext *context = moduleOp.getContext();
 
-  if (!moduleOp->hasAttr(tt::SystemDescAttr::name)) {
-    moduleOp->setAttr(
-        tt::SystemDescAttr::name,
-        tt::SystemDescAttr::getDefault(context, mockSystemDescArch,
-                                       llvm::to_vector(meshShape)));
+  if (!moduleOp->hasAttr(SystemDescAttr::name)) {
+    moduleOp->setAttr(SystemDescAttr::name,
+                      SystemDescAttr::getDefault(context, mockSystemDescArch,
+                                                 llvm::to_vector(meshShape)));
   }
 
   return registerDeviceInSymbolTable(moduleOp, meshShape);
@@ -59,13 +59,13 @@ LogicalResult registerDevice(ModuleOp moduleOp,
                              ArrayRef<int64_t> meshShape = {}) {
   MLIRContext *context = moduleOp.getContext();
   assert(!systemDescPath.empty() && "path must be set");
-  FailureOr<tt::SystemDescAttr> systemDesc = tt::SystemDescAttr::getFromPath(
+  FailureOr<SystemDescAttr> systemDesc = SystemDescAttr::getFromPath(
       context, systemDescPath,
       [&]() -> InFlightDiagnostic { return moduleOp->emitOpError(); });
   if (failed(systemDesc)) {
     return systemDesc;
   }
-  moduleOp->setAttr(tt::SystemDescAttr::name, *systemDesc);
+  moduleOp->setAttr(SystemDescAttr::name, *systemDesc);
   return registerDeviceInSymbolTable(moduleOp, meshShape);
 }
 
@@ -88,4 +88,4 @@ public:
 };
 } // namespace
 
-} // namespace mlir::tt
+} // namespace mlir::tt::ttcore

--- a/lib/Dialect/TTCore/Utils/PopulateArgumentTypes.cpp
+++ b/lib/Dialect/TTCore/Utils/PopulateArgumentTypes.cpp
@@ -17,7 +17,7 @@
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/Support/LogicalResult.h"
 
-namespace mlir::tt {
+namespace mlir::tt::ttcore {
 
 bool ArgumentTypeMapParser::parse(
     llvm::cl::Option &O, llvm::StringRef argName,
@@ -147,7 +147,7 @@ public:
 
   /// Return the dialect that must be loaded in the context before this pass.
   void getDependentDialects(::mlir::DialectRegistry &registry) const override {
-    registry.insert<mlir::tt::TTCoreDialect>();
+    registry.insert<mlir::tt::ttcore::TTCoreDialect>();
   }
 
   /// Explicitly declare the TypeID for this class. We declare an explicit
@@ -313,4 +313,4 @@ private:
   }
 };
 
-} // namespace mlir::tt
+} // namespace mlir::tt::ttcore

--- a/lib/Dialect/TTIR/Analysis/GenericInterchangeAnalysis.cpp
+++ b/lib/Dialect/TTIR/Analysis/GenericInterchangeAnalysis.cpp
@@ -10,7 +10,7 @@ namespace mlir::tt::ttir {
 
 static std::optional<SmallVector<int64_t>>
 matchAndCalculateMatmulInterchange(ArrayRef<AffineMap> maps,
-                                   ArrayRef<IteratorType> iters,
+                                   ArrayRef<ttcore::IteratorType> iters,
                                    ArrayRef<int64_t> desiredInterchange) {
   if (desiredInterchange.empty()) {
     return std::nullopt;
@@ -20,13 +20,14 @@ matchAndCalculateMatmulInterchange(ArrayRef<AffineMap> maps,
     return std::nullopt;
   }
 
-  if (iters.back() != IteratorType::Reduction) {
+  if (iters.back() != ttcore::IteratorType::Reduction) {
     return std::nullopt;
   }
 
-  if (!llvm::all_of(iters.take_front(iters.size() - 1), [](IteratorType t) {
-        return t == IteratorType::Parallel;
-      })) {
+  if (!llvm::all_of(iters.take_front(iters.size() - 1),
+                    [](ttcore::IteratorType t) {
+                      return t == ttcore::IteratorType::Parallel;
+                    })) {
     return std::nullopt;
   }
 

--- a/lib/Dialect/TTIR/IR/TTIRGenericRegionOps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIRGenericRegionOps.cpp
@@ -26,8 +26,10 @@ static mlir::ConstantIntRanges getIndexRange(uint64_t umin, uint64_t umax) {
 // TileMatmulBlockOp verification
 ::mlir::LogicalResult mlir::tt::ttir::TileMatmulBlockOp::verify() {
 
-  if (!llvm::isa<mlir::tt::TileType>(getA().getType().getElementType()) ||
-      !llvm::isa<mlir::tt::TileType>(getB().getType().getElementType())) {
+  if (!llvm::isa<mlir::tt::ttcore::TileType>(
+          getA().getType().getElementType()) ||
+      !llvm::isa<mlir::tt::ttcore::TileType>(
+          getB().getType().getElementType())) {
     return emitOpError(
         "MemRef operands to TileMatmulBlock must have ttcore.tile "
         "element type");
@@ -39,13 +41,15 @@ static mlir::ConstantIntRanges getIndexRange(uint64_t umin, uint64_t umax) {
 // TileTilizeBlockOp verification
 ::mlir::LogicalResult mlir::tt::ttir::TileTilizeBlockOp::verify() {
 
-  if (llvm::isa<mlir::tt::TileType>(getInput().getType().getElementType())) {
+  if (llvm::isa<mlir::tt::ttcore::TileType>(
+          getInput().getType().getElementType())) {
     return emitOpError(
         "MemRef operand to TileTilizeBlock must not have ttcore.tile "
         "element type");
   }
 
-  if (!llvm::isa<mlir::tt::TileType>(getOutput().getType().getElementType())) {
+  if (!llvm::isa<mlir::tt::ttcore::TileType>(
+          getOutput().getType().getElementType())) {
     return emitOpError("MemRef result of TileTilizeBlock must have ttcore.tile "
                        "element type");
   }
@@ -56,13 +60,15 @@ static mlir::ConstantIntRanges getIndexRange(uint64_t umin, uint64_t umax) {
 // TileUntilizeBlockOp verification
 ::mlir::LogicalResult mlir::tt::ttir::TileUntilizeBlockOp::verify() {
 
-  if (!llvm::isa<mlir::tt::TileType>(getInput().getType().getElementType())) {
+  if (!llvm::isa<mlir::tt::ttcore::TileType>(
+          getInput().getType().getElementType())) {
     return emitOpError(
         "MemRef operand to TileUntilizeBlock must have ttcore.tile "
         "element type");
   }
 
-  if (llvm::isa<mlir::tt::TileType>(getOutput().getType().getElementType())) {
+  if (llvm::isa<mlir::tt::ttcore::TileType>(
+          getOutput().getType().getElementType())) {
     return emitOpError(
         "MemRef result of TileUntilizeBlock must not have ttcore.tile "
         "element type");
@@ -182,7 +188,7 @@ int64_t mlir::tt::ttir::DMAOp::getNumElems() {
 
 size_t mlir::tt::ttir::DMAOp::getSizeBytes() {
   auto elementSizeBytes =
-      getElementSizeBytes(getSrcMemRefType().getElementType());
+      ttcore::getElementSizeBytes(getSrcMemRefType().getElementType());
   return getNumElems() * elementSizeBytes;
 }
 

--- a/lib/Dialect/TTIR/IR/TTIROpsInterfaces.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROpsInterfaces.cpp
@@ -34,10 +34,10 @@ static mlir::AffineMap reblockViewWorkaround(mlir::MemRefType inputMemref,
   assert(inputMemref.getRank() == resultMemref.getRank());
   auto *ctx = inputMemref.getContext();
   int64_t rank = inputMemref.getRank();
-  auto inputLayout =
-      mlir::cast<mlir::tt::DeviceLayoutInterface>(inputMemref.getLayout());
-  auto resultLayout =
-      mlir::cast<mlir::tt::DeviceLayoutInterface>(resultMemref.getLayout());
+  auto inputLayout = mlir::cast<mlir::tt::ttcore::DeviceLayoutInterface>(
+      inputMemref.getLayout());
+  auto resultLayout = mlir::cast<mlir::tt::ttcore::DeviceLayoutInterface>(
+      resultMemref.getLayout());
   mlir::ArrayRef<int64_t> inputGridShape =
       inputLayout.getGridShape(inputMemref);
   mlir::ArrayRef<int64_t> inputShardShape =
@@ -85,12 +85,12 @@ mlir::tt::ttir::applyViews(mlir::Operation *op) {
         resultMemref, mlir::AffineMap::getMultiDimIdentityMap(
                           resultMemref.getRank(), resultMemref.getContext()));
   }
-  auto map =
-      mlir::cast<tt::ViewLayoutAttr>(resultMemref.getLayout()).getAffineMap();
+  auto map = mlir::cast<ttcore::ViewLayoutAttr>(resultMemref.getLayout())
+                 .getAffineMap();
   Value input = viewOp.getInput();
   auto inputMemref = mlir::cast<mlir::MemRefType>(input.getType());
   assert(
-      mlir::isa<tt::ShardLayoutAttr>(inputMemref.getLayout()) &&
+      mlir::isa<ttcore::ShardLayoutAttr>(inputMemref.getLayout()) &&
       "Expected ShardLayoutAttr, only one level of view nesting is supported");
   auto reblockMap = reblockViewWorkaround(inputMemref, resultMemref);
   return std::make_pair(inputMemref, reblockMap.compose(map));

--- a/lib/Dialect/TTIR/Pipelines/TTIRPipelines.cpp
+++ b/lib/Dialect/TTIR/Pipelines/TTIRPipelines.cpp
@@ -113,7 +113,8 @@ void createLinalgToLLVMPipeline(OpPassManager &manager,
 
 void createTTIRToCPUPipeline(OpPassManager &manager,
                              const LinalgToLLVMPipelineOptions &options) {
-  OpPassManager &cpuPm = manager.nest<tt::CPUModuleOp>().nest<mlir::ModuleOp>();
+  OpPassManager &cpuPm =
+      manager.nest<ttcore::CPUModuleOp>().nest<mlir::ModuleOp>();
   // Decomp TTIR to reduce number of conversions we need to support in
   // Linalg/Tosa.
   mlir::tt::TTIRToTTIRDecompositionOptions decompOptions;

--- a/lib/Dialect/TTIR/Transforms/Broadcast.cpp
+++ b/lib/Dialect/TTIR/Transforms/Broadcast.cpp
@@ -102,7 +102,7 @@ public:
 
   void getDependentDialects(mlir::DialectRegistry &registry) const override {
     registry.insert<mlir::tt::ttir::TTIRDialect>();
-    registry.insert<mlir::tt::TTCoreDialect>();
+    registry.insert<mlir::tt::ttcore::TTCoreDialect>();
   }
 };
 

--- a/lib/Dialect/TTIR/Transforms/ElementTypeNormalization.cpp
+++ b/lib/Dialect/TTIR/Transforms/ElementTypeNormalization.cpp
@@ -25,7 +25,7 @@ public:
         return type;
       }
 
-      elementType = toTTMLIRSupportedDataType(elementType);
+      elementType = mlir::tt::ttcore::toTTMLIRSupportedDataType(elementType);
       if (!elementType) {
         return {};
       }

--- a/lib/Dialect/TTIR/Transforms/GenericGenerateDatamovement.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericGenerateDatamovement.cpp
@@ -30,7 +30,8 @@ public:
     return mlir::isa_and_nonnull<StreamLayoutOp>(operand.getDefiningOp());
   }
 
-  static bool compatibleDeviceGrid(DeviceAttr device, GridAttr grid) {
+  static bool compatibleDeviceGrid(ttcore::DeviceAttr device,
+                                   ttcore::GridAttr grid) {
     return device.getWorkerGrid().getShape().size() == grid.getShape().size();
   }
 
@@ -51,8 +52,8 @@ public:
     return semaphore;
   }
 
-  static SmallVector<IteratorType>
-  calculateMcastIterators(GridAttr grid, DeviceAttr device,
+  static SmallVector<ttcore::IteratorType>
+  calculateMcastIterators(ttcore::GridAttr grid, ttcore::DeviceAttr device,
                           AffineMap operandIndexingMap,
                           ArrayAttr iteratorTypes) {
     assert(grid.getShape().size() == 2 && "Currently only support 2D grid");
@@ -60,13 +61,14 @@ public:
     assert(compatibleDeviceGrid(device, grid));
 
     bool allParallel = true;
-    SmallVector<IteratorType> mcastIterators;
+    SmallVector<ttcore::IteratorType> mcastIterators;
     mcastIterators.reserve(grid.getShape().size());
     for (unsigned dim = 0; dim < grid.getShape().size(); dim++) {
       unsigned dimPosition = operandIndexingMap.getDimPosition(dim);
 
-      IteratorType iteratorType =
-          mlir::cast<IteratorTypeAttr>(iteratorTypes[dimPosition]).getValue();
+      ttcore::IteratorType iteratorType =
+          mlir::cast<ttcore::IteratorTypeAttr>(iteratorTypes[dimPosition])
+              .getValue();
       mcastIterators.push_back(iteratorType);
 
       // If the grid dimension is 1, we can special case it and always safely
@@ -74,10 +76,11 @@ public:
       // it'll be functionally correct, a multicast with a single core to itself
       // is a redundant copy and more complicated than necessary.
       bool singleCore = grid.getShape()[dim] == 1;
-      allParallel &= (iteratorType == IteratorType::Parallel) || singleCore;
+      allParallel &=
+          (iteratorType == ttcore::IteratorType::Parallel) || singleCore;
     }
 
-    return allParallel ? SmallVector<IteratorType>() : mcastIterators;
+    return allParallel ? SmallVector<ttcore::IteratorType>() : mcastIterators;
   }
 
   static Value createDMA(OpBuilder &builder, Location loc, Value src, Value dst,
@@ -103,8 +106,8 @@ public:
 
   static McastArguments
   calculateGatherMcastArguments(PatternRewriter &rewriter, Location loc,
-                                GridAttr grid,
-                                ArrayRef<IteratorType> mcastIterators) {
+                                ttcore::GridAttr grid,
+                                ArrayRef<ttcore::IteratorType> mcastIterators) {
     Value zero = rewriter.create<arith::ConstantOp>(
         loc, rewriter.getIndexType(), rewriter.getIndexAttr(0));
     Value one = rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexType(),
@@ -118,7 +121,7 @@ public:
     for (auto [dim, iteratorType] : llvm::enumerate(mcastIterators)) {
       Value core = rewriter.create<CoreIndexOp>(
           loc, rewriter.getIndexType(), rewriter.getI64IntegerAttr(dim));
-      if (iteratorType == IteratorType::Parallel) {
+      if (iteratorType == ttcore::IteratorType::Parallel) {
         args.senderCoreIndex.push_back(Value(core));
         args.mcastCoreIndex.push_back(Value(core));
         args.mcastShape.push_back(Value(one));
@@ -126,7 +129,7 @@ public:
         int64_t numDests = grid.getShape()[dim] - 1;
         Value gridDimMinusOne = rewriter.create<arith::ConstantOp>(
             loc, rewriter.getIndexType(), rewriter.getIndexAttr(numDests));
-        assert(iteratorType == IteratorType::Reduction);
+        assert(iteratorType == ttcore::IteratorType::Reduction);
         args.senderCoreIndex.push_back(zero);
         args.mcastCoreIndex.push_back(one);
         args.mcastShape.push_back(gridDimMinusOne);
@@ -145,11 +148,12 @@ public:
   // One implementation of mcast by which one core (the 0th core for the
   // respective dim) takes on the role of (the sender) gathering and sending the
   // data to all other cores (the receivers) via mcast along the same dimension.
-  static void createGatherMcastDMA(PatternRewriter &builder, Location loc,
-                                   Value src, Value dst,
-                                   AffineMap operandIndexingMap, GridAttr grid,
-                                   ArrayRef<IteratorType> mcastIterators,
-                                   MutableArrayRef<Region> regions) {
+  static void
+  createGatherMcastDMA(PatternRewriter &builder, Location loc, Value src,
+                       Value dst, AffineMap operandIndexingMap,
+                       ttcore::GridAttr grid,
+                       ArrayRef<ttcore::IteratorType> mcastIterators,
+                       MutableArrayRef<Region> regions) {
     McastArguments mcastArgs =
         calculateGatherMcastArguments(builder, loc, grid, mcastIterators);
     Value zero = builder.create<arith::ConstantOp>(loc, builder.getIndexType(),
@@ -194,7 +198,7 @@ public:
   static LogicalResult
   buildDatamovementBlock(PatternRewriter &builder, Location loc,
                          Value genericOperand, Value blockOperand,
-                         GridAttr grid, DeviceAttr device,
+                         ttcore::GridAttr grid, ttcore::DeviceAttr device,
                          AffineMap operandIndexingMap, ArrayAttr iteratorTypes,
                          bool isOutput, MutableArrayRef<Region> regions) {
     if (isOutput) {
@@ -206,8 +210,9 @@ public:
       assert(!isOutput && "Output streaming is not currently supported");
       Value src = isOutput ? blockOperand : genericOperand;
       Value dst = isOutput ? genericOperand : blockOperand;
-      SmallVector<IteratorType> mcastIterators = calculateMcastIterators(
-          grid, device, operandIndexingMap, iteratorTypes);
+      SmallVector<ttcore::IteratorType> mcastIterators =
+          calculateMcastIterators(grid, device, operandIndexingMap,
+                                  iteratorTypes);
       bool isMcast = !mcastIterators.empty();
       if (isMcast) {
         createGatherMcastDMA(builder, loc, src, dst, operandIndexingMap, grid,
@@ -261,7 +266,7 @@ public:
     // Insert the new data movement regions.
     unsigned outputOperandsIndex = generic.getOutputs().getBeginOperandIndex();
     unsigned outputOperandsLength = generic.getOutputs().size();
-    auto device = lookupDevice(generic);
+    auto device = ttcore::lookupDevice(generic);
     for (OpOperand &operand : generic->getOpOperands()) {
       Block *datamovementBlock =
           &newGeneric.getRegion(operand.getOperandNumber()).front();

--- a/lib/Dialect/TTIR/Transforms/GenericHWThreadSelection.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericHWThreadSelection.cpp
@@ -99,8 +99,8 @@ public:
     walkAndApplyPatterns(getOperation(), std::move(patterns));
 
     ModuleOp moduleOp = getOperation();
-    auto systemDesc =
-        moduleOp->getAttrOfType<SystemDescAttr>(SystemDescAttr::name);
+    auto systemDesc = moduleOp->getAttrOfType<mlir::tt::ttcore::SystemDescAttr>(
+        mlir::tt::ttcore::SystemDescAttr::name);
     auto chipDesc = systemDesc.getChipDescs().front();
     moduleOp.walk([&](GenericOp op) {
       // assert that the op has a valid HW thread selection

--- a/lib/Dialect/TTIR/Transforms/GenericLowerDMAs.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericLowerDMAs.cpp
@@ -101,7 +101,7 @@ public:
 
   static size_t getElementSizeBytes(MemRefType memref) {
     mlir::Type elementType = memref.getElementType();
-    auto tileType = mlir::dyn_cast<TileType>(elementType);
+    auto tileType = mlir::dyn_cast<ttcore::TileType>(elementType);
     return tileType ? tileType.getSizeBytes()
                     : elementType.getIntOrFloatBitWidth() / 8;
   }
@@ -196,8 +196,8 @@ public:
 
     AffineMap dmaIndexingMap = *dma.getSrcAffineMap();
     MemRefType memref = dma.getSrcMemRefType();
-    DeviceLayoutInterface layout =
-        mlir::cast<DeviceLayoutInterface>(memref.getLayout());
+    ttcore::DeviceLayoutInterface layout =
+        mlir::cast<ttcore::DeviceLayoutInterface>(memref.getLayout());
     ArrayRef<int64_t> memrefGridShape = layout.getGridShape(memref);
     ArrayRef<int64_t> memrefShardShape = layout.getShardShape(memref);
 
@@ -215,7 +215,7 @@ public:
                          genericParent.getBlockFactorsValue(), memrefShardShape,
                          dmaIndexingMap, gridIndexingMap);
 
-    DeviceAttr device = genericParent.getDevice();
+    ttcore::DeviceAttr device = genericParent.getDevice();
     std::pair<MemRefType, AffineMap> underlyingMemrefAndView =
         mlir::cast<ttir::ViewOpInterface>(dma.getSrc().getDefiningOp())
             .applyViews();
@@ -276,7 +276,7 @@ public:
       dstIndices.push_back(zero);
     }
 
-    DeviceAttr device = lookupDevice(dma);
+    ttcore::DeviceAttr device = ttcore::lookupDevice(dma);
     AffineMap srcMemoryMap =
         getMemoryMap(device, dma.getSrc(), dma.isSrcRemote());
     AffineMap dstMemoryMap =
@@ -296,7 +296,8 @@ public:
     return success();
   }
 
-  static AffineMap getMemoryMap(DeviceAttr device, Value input, bool isRemote) {
+  static AffineMap getMemoryMap(ttcore::DeviceAttr device, Value input,
+                                bool isRemote) {
     if (isRemote) {
       std::pair<MemRefType, AffineMap> srcUnderlyingMemrefAndView =
           mlir::tt::ttir::applyViews(input.getDefiningOp());
@@ -338,7 +339,7 @@ public:
                                        ArrayRef<int64_t> shape,
                                        Type elementType, AffineMap map) {
     assert(map.isIdentity() && "Only identity maps are supported for now.");
-    auto tileType = mlir::dyn_cast<TileType>(elementType);
+    auto tileType = mlir::dyn_cast<ttcore::TileType>(elementType);
     int64_t elementSizeBytes = tileType
                                    ? tileType.getSizeBytes()
                                    : elementType.getIntOrFloatBitWidth() / 8;

--- a/lib/Dialect/TTIR/Transforms/HoistCPUOps.cpp
+++ b/lib/Dialect/TTIR/Transforms/HoistCPUOps.cpp
@@ -326,9 +326,9 @@ public:
       return;
     }
 
-    tt::DeviceModuleOp deviceModule;
+    ttcore::DeviceModuleOp deviceModule;
     for (Operation &op : rootModule.getBodyRegion().front()) {
-      if (auto maybeDeviceModule = dyn_cast<tt::DeviceModuleOp>(op)) {
+      if (auto maybeDeviceModule = dyn_cast<ttcore::DeviceModuleOp>(op)) {
         deviceModule = maybeDeviceModule;
         break;
       }
@@ -339,7 +339,7 @@ public:
     ModuleOp deviceInnerModule = dyn_cast_if_present<mlir::ModuleOp>(
         deviceModule.getBodyRegion().front().front());
     assert(deviceInnerModule &&
-           "tt::DeviceModuleOp must have single ModuleOp child!");
+           "ttcore::DeviceModuleOp must have single ModuleOp child!");
 
     IRRewriter rewriter(&getContext());
 
@@ -354,10 +354,10 @@ public:
     }
 
     // Check if a "cpu_module" already exists.
-    tt::CPUModuleOp cpuModule;
+    ttcore::CPUModuleOp cpuModule;
     mlir::ModuleOp cpuInnerModule;
     for (auto &op : rootModule.getBody()->getOperations()) {
-      if (auto module = llvm::dyn_cast<tt::CPUModuleOp>(op)) {
+      if (auto module = llvm::dyn_cast<ttcore::CPUModuleOp>(op)) {
         cpuModule = module;
         cpuInnerModule = dyn_cast_if_present<mlir::ModuleOp>(
             cpuModule.getBodyRegion().front().front());
@@ -369,7 +369,7 @@ public:
     // If no CPU module exists, create one.
     if (!cpuModule) {
       rewriter.setInsertionPointToEnd(rootModule.getBody());
-      cpuModule = rewriter.create<tt::CPUModuleOp>(loc);
+      cpuModule = rewriter.create<ttcore::CPUModuleOp>(loc);
       rewriter.setInsertionPointToStart(&cpuModule.getBodyRegion().front());
       cpuInnerModule = rewriter.create<mlir::ModuleOp>(loc);
     }

--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -294,14 +294,14 @@ private:
 
     mlir::func::FuncOp funcOp = conv2dOp->getParentOfType<mlir::func::FuncOp>();
     llvm::SmallPtrSet<BlockArgument, 4> constParams =
-        mlir::tt::getConstsAndParams(funcOp);
+        mlir::tt::ttcore::getConstsAndParams(funcOp);
     auto isConstant = [&constParams, conv2dOp](mlir::Value value) {
       if (auto blockArg = mlir::dyn_cast<BlockArgument>(value)) {
         return constParams.contains(blockArg);
       }
 
       Operation *op = value.getDefiningOp();
-      return op->hasTrait<mlir::tt::Trait::TTCoreCreationOpTrait>() &&
+      return op->hasTrait<mlir::tt::ttcore::Trait::TTCoreCreationOpTrait>() &&
              op->isBeforeInBlock(conv2dOp);
     };
 

--- a/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
@@ -67,11 +67,11 @@ static bool insideEnqueueProgramOpRegion(mlir::Operation *op) {
 }
 
 static std::string verifyTilizeUntilizeCBs(CBType tilizedCB, CBType scalarCB) {
-  if (mlir::isa<tt::TileType>(scalarCB.getMemref().getElementType())) {
+  if (mlir::isa<ttcore::TileType>(scalarCB.getMemref().getElementType())) {
     return "Input to TilizeOp or Output to UntilizeOp must have scalar "
            "element type";
   }
-  if (!mlir::isa<tt::TileType>(tilizedCB.getMemref().getElementType())) {
+  if (!mlir::isa<ttcore::TileType>(tilizedCB.getMemref().getElementType())) {
     return "Input to UntilizeOp or Output to TilizeOp must have tile "
            "element type";
   }

--- a/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
+++ b/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
@@ -16,8 +16,8 @@ namespace mlir::tt::ttmetal {
 
 ::mlir::LogicalResult EnqueueWriteBufferOp::verify() {
   ::mlir::MemRefType outputTy = getOutput().getType();
-  MemorySpaceAttr memSpaceAttr =
-      mlir::cast<MemorySpaceAttr>(outputTy.getMemorySpace());
+  ttcore::MemorySpaceAttr memSpaceAttr =
+      mlir::cast<ttcore::MemorySpaceAttr>(outputTy.getMemorySpace());
   if (not isDeviceMemorySpace(memSpaceAttr.getValue())) {
     return emitOpError("Output tensor must be in device memory space");
   }
@@ -26,8 +26,9 @@ namespace mlir::tt::ttmetal {
 
 ::mlir::LogicalResult EnqueueReadBufferOp::verify() {
   ::mlir::MemRefType outputTy = getOutput().getType();
-  MemorySpaceAttr memSpaceAttr =
-      mlir::dyn_cast_if_present<MemorySpaceAttr>(outputTy.getMemorySpace());
+  ttcore::MemorySpaceAttr memSpaceAttr =
+      mlir::dyn_cast_if_present<ttcore::MemorySpaceAttr>(
+          outputTy.getMemorySpace());
   if (memSpaceAttr && not isSystemMemorySpace(memSpaceAttr.getValue())) {
     return emitOpError("Output tensor must be in system memory space");
   }
@@ -37,8 +38,8 @@ namespace mlir::tt::ttmetal {
 ::mlir::LogicalResult EnqueueProgramOp::verify() {
   for (auto operand : getOperands()) {
     ::mlir::MemRefType operandType = mlir::cast<MemRefType>(operand.getType());
-    MemorySpaceAttr memSpaceAttr =
-        mlir::cast<MemorySpaceAttr>(operandType.getMemorySpace());
+    ttcore::MemorySpaceAttr memSpaceAttr =
+        mlir::cast<ttcore::MemorySpaceAttr>(operandType.getMemorySpace());
     if (not isDeviceMemorySpace(memSpaceAttr.getValue())) {
       return emitOpError(
           "Operand tensor to EnqueueProgramOp must be in device memory space");

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -52,13 +52,13 @@ void createOptimizationPasses(OpPassManager &pm) {
 
 void createTTIRToTTMetalFrontendPipeline(
     OpPassManager &pm, const TTIRToTTMetalPipelineOptions &options) {
-  tt::TTCoreRegisterDevicePassOptions registerDeviceOptions;
+  ttcore::TTCoreRegisterDevicePassOptions registerDeviceOptions;
   {
     registerDeviceOptions.systemDescPath = options.systemDescPath;
     registerDeviceOptions.mockSystemDescArch = options.mockSystemDescArch;
     registerDeviceOptions.meshShape = llvm::to_vector(options.meshShape);
   }
-  pm.addPass(tt::createTTCoreRegisterDevicePass(registerDeviceOptions));
+  pm.addPass(ttcore::createTTCoreRegisterDevicePass(registerDeviceOptions));
   pm.addPass(tt::createTTIRToTTIRDecompositionPass());
   pm.addPass(mlir::createCanonicalizerPass());
   ttir::TTIRToTTIRGenericOptions toTTIRGenericOptions;
@@ -119,13 +119,13 @@ void createTTIRToTTMetalBackendPipeline(
 void createTTIRToTTMetalPipeline(OpPassManager &pm,
                                  const TTIRToTTMetalPipelineOptions &options) {
   // Create DeviceModule to wrap all ops.
-  pm.addPass(tt::createTTCoreWrapDeviceModulePass());
+  pm.addPass(ttcore::createTTCoreWrapDeviceModulePass());
   // Create CPUModuleOp to wrap hoisted ops (if any).
   pm.addPass(ttir::createTTIRHoistTransform());
 
   // Run regular ttir to ttmetal pipelines on IR in DeviceModule.
   OpPassManager &devicePm =
-      pm.nest<tt::DeviceModuleOp>().nest<mlir::ModuleOp>();
+      pm.nest<ttcore::DeviceModuleOp>().nest<mlir::ModuleOp>();
   createTTIRToTTMetalFrontendPipeline(devicePm, options);
   createTTIRToTTMetalMiddleendPipeline(devicePm, options);
   createTTIRToTTMetalBackendPipeline(devicePm, options);

--- a/lib/Dialect/TTNN/Analysis/DFShardingPolicy.cpp
+++ b/lib/Dialect/TTNN/Analysis/DFShardingPolicy.cpp
@@ -24,7 +24,7 @@ void DFShardingPolicy::run() {
       return;
     }
 
-    deviceAttr = lookupDevice(func);
+    deviceAttr = ttcore::lookupDevice(func);
     mlir::tt::scheduler::Scheduler scheduler(&func);
     l1ChainConfigs->push_back(L1ChainConfig());
     llvm::SmallVector<mlir::Operation *> scheduleableOps;

--- a/lib/Dialect/TTNN/Analysis/LegalLayoutAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/LegalLayoutAnalysis.cpp
@@ -52,10 +52,10 @@ void applyConv2dConfigOverrides(ttnn::Conv2dOp op,
   // prepare_conv2d_weights.cpp where `weight_tensor_.dtype() ==
   // weights_bias_dtype`.
   //
-  DataType dtype = elementTypeToDataType(
+  ttcore::DataType dtype = ttcore::elementTypeToDataType(
       mlir::cast<RankedTensorType>(op->getOperand(0).getType())
           .getElementType());
-  DataType weightsDtype = elementTypeToDataType(
+  ttcore::DataType weightsDtype = ttcore::elementTypeToDataType(
       mlir::cast<RankedTensorType>(op->getOperand(1).getType())
           .getElementType());
 
@@ -192,18 +192,18 @@ bool LegalLayoutAnalysis::applyOverrides() {
   TTNNLayoutAttr layout = mlir::cast<TTNNLayoutAttr>(tensorType.getEncoding());
   llvm::ArrayRef<int64_t> tensorShape = tensorType.getShape();
 
-  GridAttr grid = GridAttr::get(op->getContext(),
-                                ArrayRef<int64_t>(layoutOverride.grid.value()));
+  ttcore::GridAttr grid = ttcore::GridAttr::get(
+      op->getContext(), ArrayRef<int64_t>(layoutOverride.grid.value()));
 
   // Create element type for the new layout.
   Type elementType = layout.getScalarElementType();
   if (layoutOverride.dataType.has_value()) {
-    elementType = mlir::tt::dataTypeToElementType(
+    elementType = mlir::tt::ttcore::dataTypeToElementType(
         op->getContext(), layoutOverride.dataType.value());
   }
 
   if (layoutOverride.memoryLayout == Layout::Tile) {
-    elementType = TileType::get(elementType);
+    elementType = ttcore::TileType::get(elementType);
   }
 
   analysisResult.push_back(TTNNLayoutAttr::get(
@@ -299,7 +299,7 @@ void LegalLayoutAnalysis::analysisImplementation() {
         overrideIt != analysisInput.outputLayoutOverrides->end()) {
       override = overrideIt->getValue();
       if (override->dataType.has_value()) {
-        scalarElementType = mlir::tt::dataTypeToElementType(
+        scalarElementType = mlir::tt::ttcore::dataTypeToElementType(
             op->getContext(), override->dataType.value());
       }
     }

--- a/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
+++ b/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
@@ -56,7 +56,7 @@ ShardSolver::ShardSolver(
 
   // Cache DeviceAttr.
   //
-  deviceAttr = lookupDevice(shardSpecs.front().op);
+  deviceAttr = ttcore::lookupDevice(shardSpecs.front().op);
 
   // Populate operandOpEdges and userOpEdges.
   //
@@ -796,7 +796,7 @@ llvm::Expected<TTNNLayoutAttr> ShardSolver::checkShardCompatible(
 
   // Constraints are implemented for this op.
   //
-  auto deviceAttr = mlir::tt::lookupDevice(consumerOp);
+  auto deviceAttr = mlir::tt::ttcore::lookupDevice(consumerOp);
   assert(deviceAttr);
 
   // Map consumer operands to DRAM interleave or provided producerLayout

--- a/lib/Dialect/TTNN/IR/TTNNDialect.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNDialect.cpp
@@ -27,6 +27,28 @@ parseDimensionList(::mlir::AsmParser &odsParser,
                    ::llvm::SmallVector<int64_t> &dimensions) {
   return odsParser.parseDimensionList(dimensions, false, false);
 }
+
+template <typename... Args>
+static void printVargDimensionList(mlir::AsmPrinter &printer, Args &&...dims) {
+  printDimensionList(printer,
+                     llvm::SmallVector<int64_t>({std::forward<Args>(dims)...}));
+}
+
+template <typename... Args>
+static mlir::ParseResult parseVargDimensionList(mlir::AsmParser &odsParser,
+                                                Args &...dims) {
+  llvm::SmallVector<int64_t> dimensions;
+  mlir::ParseResult result = parseDimensionList(odsParser, dimensions);
+  if (succeeded(result)) {
+    llvm::SmallVector<std::tuple_element_t<0, std::tuple<Args...>> *> copy(
+        {&dims...});
+    assert(dimensions.size() == sizeof...(dims));
+    for (size_t i = 0; i < dimensions.size(); ++i) {
+      *copy[i] = dimensions[i];
+    }
+  }
+  return result;
+}
 } // namespace mlir::tt::ttnn
 
 struct TTNNOpAsmDialectInterface : public OpAsmDialectInterface {

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -21,7 +21,7 @@ namespace mlir::tt::ttnn {
 
 namespace detail {
 llvm::Expected<bool> checkDeviceWorkerGrid(mlir::Operation *op) {
-  auto deviceAttr = mlir::tt::lookupDevice(op);
+  auto deviceAttr = mlir::tt::ttcore::lookupDevice(op);
   assert(deviceAttr);
   return op_model::ttnn::Device::getDeviceConstraints(
       deviceAttr.getWorkerGrid());
@@ -48,9 +48,10 @@ convertOptionalArrayAttrToSmallVec(std::optional<mlir::ArrayAttr> arrayAttr) {
 
 using BinaryOpConstraintsFunc =
     std::function<llvm::Expected<op_model::ttnn::OpConstraints>(
-        GridAttr, llvm::ArrayRef<int64_t>, mlir::tt::ttnn::TTNNLayoutAttr,
-        llvm::ArrayRef<int64_t>, mlir::tt::ttnn::TTNNLayoutAttr,
-        llvm::ArrayRef<int64_t>, mlir::tt::ttnn::TTNNLayoutAttr)>;
+        ttcore::GridAttr, llvm::ArrayRef<int64_t>,
+        mlir::tt::ttnn::TTNNLayoutAttr, llvm::ArrayRef<int64_t>,
+        mlir::tt::ttnn::TTNNLayoutAttr, llvm::ArrayRef<int64_t>,
+        mlir::tt::ttnn::TTNNLayoutAttr)>;
 
 using BinaryOpRuntimeFunc = std::function<llvm::Expected<size_t>(
     llvm::ArrayRef<int64_t>, mlir::tt::ttnn::TTNNLayoutAttr,
@@ -72,7 +73,8 @@ getBinaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
   if (!check) {
     return check.takeError();
   }
-  GridAttr deviceGrid = lookupDevice(op.getOperation()).getWorkerGrid();
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(op.getOperation()).getWorkerGrid();
 
   return getConstraintsFunc(deviceGrid, inputShapeA, inputs[0], inputShapeB,
                             inputs[1], outputShape, opConfig.outputLayout);
@@ -95,9 +97,9 @@ getBinaryOpRuntime(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
 
 using ReductionOpConstraintsFunc =
     std::function<llvm::Expected<op_model::ttnn::OpConstraints>(
-        GridAttr, llvm::ArrayRef<int64_t>, mlir::tt::ttnn::TTNNLayoutAttr,
-        std::optional<llvm::ArrayRef<int64_t>>, bool,
-        mlir::tt::ttnn::TTNNLayoutAttr)>;
+        ttcore::GridAttr, llvm::ArrayRef<int64_t>,
+        mlir::tt::ttnn::TTNNLayoutAttr, std::optional<llvm::ArrayRef<int64_t>>,
+        bool, mlir::tt::ttnn::TTNNLayoutAttr)>;
 
 using ReductionOpRuntimeFunc = std::function<llvm::Expected<size_t>(
     llvm::ArrayRef<int64_t>, mlir::tt::ttnn::TTNNLayoutAttr,
@@ -117,7 +119,8 @@ getReductionOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
   if (!check) {
     return check.takeError();
   }
-  GridAttr deviceGrid = lookupDevice(op.getOperation()).getWorkerGrid();
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(op.getOperation()).getWorkerGrid();
 
   return getConstraintsFunc(
       deviceGrid, inputShape, inputs[0],
@@ -143,8 +146,9 @@ getReductionOpRuntime(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
 //===----------------------------------------------------------------------===//
 using UnaryOpConstraintsFunc =
     std::function<llvm::Expected<op_model::ttnn::OpConstraints>(
-        GridAttr, llvm::ArrayRef<int64_t>, mlir::tt::ttnn::TTNNLayoutAttr,
-        llvm::ArrayRef<int64_t>, mlir::tt::ttnn::TTNNLayoutAttr)>;
+        ttcore::GridAttr, llvm::ArrayRef<int64_t>,
+        mlir::tt::ttnn::TTNNLayoutAttr, llvm::ArrayRef<int64_t>,
+        mlir::tt::ttnn::TTNNLayoutAttr)>;
 
 using UnaryOpRuntimeFunc = std::function<llvm::Expected<size_t>(
     llvm::ArrayRef<int64_t>, mlir::tt::ttnn::TTNNLayoutAttr,
@@ -164,7 +168,8 @@ getUnaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
   if (!check) {
     return check.takeError();
   }
-  GridAttr deviceGrid = lookupDevice(op.getOperation()).getWorkerGrid();
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(op.getOperation()).getWorkerGrid();
 
   return getConstraintsFunc(deviceGrid, inputShape, inputs[0], outputShape,
                             opConfig.outputLayout);
@@ -280,7 +285,8 @@ SqrtOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   if (!check) {
     return check.takeError();
   }
-  GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return op_model::ttnn::SqrtOpInterface::getOpConstraints(
       deviceGrid, inputShape, inputs[0], outputShape, opConfig.outputLayout);
@@ -317,7 +323,8 @@ SigmoidOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   if (!check) {
     return check.takeError();
   }
-  GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return op_model::ttnn::SigmoidOpInterface::getOpConstraints(
       deviceGrid, inputShape, inputs[0], outputShape, opConfig.outputLayout);
@@ -373,7 +380,8 @@ SoftmaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   if (!check) {
     return check.takeError();
   }
-  GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return op_model::ttnn::SoftmaxOpInterface::getOpConstraints(
       deviceGrid, inputShape, inputs[0], getDimension(), outputShape,
@@ -449,7 +457,8 @@ ReshapeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   if (!check) {
     return check.takeError();
   }
-  GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return op_model::ttnn::ReshapeOpInterface::getOpConstraints(
       deviceGrid, inputShape, inputs[0], outputShape, opConfig.outputLayout);
@@ -484,7 +493,8 @@ SliceOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   if (!check) {
     return check.takeError();
   }
-  GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return op_model::ttnn::SliceOpInterface::getOpConstraints(
       deviceGrid, inputShape, inputs[0],
@@ -525,7 +535,8 @@ TypecastOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   if (!check) {
     return check.takeError();
   }
-  GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return op_model::ttnn::TypecastOpInterface::getOpConstraints(
       deviceGrid, inputShape, inputs[0], getDtypeAttr(), outputShape,
@@ -564,7 +575,8 @@ ToLayoutOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
   auto deviceOperand = getDevice();
   const bool passDevicePtr = !deviceOperand;
-  GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return op_model::ttnn::ToLayoutOpInterface::getOpConstraints(
       deviceGrid, inputShape, inputs[0], getDtype(), opConfig.outputLayout,
@@ -606,7 +618,8 @@ ConcatOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   if (!check) {
     return check.takeError();
   }
-  GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return op_model::ttnn::ConcatOpInterface::getOpConstraints(
       deviceGrid, inputShapes, inputs, getDim(), opConfig.outputLayout);
@@ -643,7 +656,8 @@ TransposeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   if (!check) {
     return check.takeError();
   }
-  GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return op_model::ttnn::TransposeOpInterface::getOpConstraints(
       deviceGrid, inputShape, inputs[0], getDim0(), getDim1(),
@@ -679,7 +693,8 @@ MatmulOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   if (!check) {
     return check.takeError();
   }
-  GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return op_model::ttnn::MatmulOpInterface::getOpConstraints(
       deviceGrid, inputShapeA, inputs[0], inputShapeB, inputs[1], outputShape,
@@ -745,7 +760,8 @@ Conv2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   if (!check) {
     return check.takeError();
   }
-  GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   // If a conv config has been specified, use that. If not, read the op property
   std::optional<Conv2dConfigAttr> conv2dConfig = std::nullopt;
@@ -827,7 +843,8 @@ ConvTranspose2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   if (!check) {
     return check.takeError();
   }
-  GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   // If a conv config has been specified, use that. If not, read the op property
   std::optional<Conv2dConfigAttr> conv2dConfig = std::nullopt;
@@ -901,7 +918,8 @@ MaxPool2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   if (!check) {
     return check.takeError();
   }
-  GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return op_model::ttnn::MaxPool2DOpInterface::getOpConstraints(
       deviceGrid, inputShape, inputs[0], getBatchSize(), getInputHeight(),
@@ -942,7 +960,8 @@ ClampScalarOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   if (!check) {
     return check.takeError();
   }
-  GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return op_model::ttnn::ClampScalarOpInterface::getOpConstraints(
       deviceGrid, inputShape, inputs[0], getMin(), getMax(), outputShape,
@@ -980,7 +999,8 @@ PermuteOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   if (!check) {
     return check.takeError();
   }
-  GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return op_model::ttnn::PermuteOpInterface::getOpConstraints(
       deviceGrid, inputShape, inputs[0], getPermutation(), getPadValue(),
@@ -1018,7 +1038,8 @@ UpsampleOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   if (!check) {
     return check.takeError();
   }
-  GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return op_model::ttnn::UpsampleOpInterface::getOpConstraints(
       deviceGrid, inputShape, inputs[0], getScaleFactor(), getMode(),
@@ -1113,7 +1134,8 @@ EmbeddingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
   if (!check) {
     return check.takeError();
   }
-  GridAttr deviceGrid = lookupDevice(getOperation()).getWorkerGrid();
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return op_model::ttnn::EmbeddingOpInterface::getOpConstraints(
       deviceGrid, inputShape, inputs[0], weightShape, inputs[1], outputShape,

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -188,7 +188,7 @@ foldConsecutiveDataCastOps(T op, ::mlir::PatternRewriter &rewriter) {
   Conv2dParams params = *expectedParams;
 
   if (!getWeight().getDefiningOp<mlir::tt::ttnn::PrepareConv2dWeightsOp>() &&
-      !getWeight().getDefiningOp<mlir::tt::LoadCachedOp>()) {
+      !getWeight().getDefiningOp<mlir::tt::ttcore::LoadCachedOp>()) {
     // Only check when the weight is not prepared because it changes the shape
     // and ordering of dims.
     if (getWeight().getType().getDimSize(WEIGHT_OUT_CHANNEL) !=
@@ -812,7 +812,8 @@ template <typename Op>
 static ::mlir::LogicalResult namedOpVerify(Op op) {
   RankedTensorType output = op.getResult().getType();
   if (op.getDtype()) {
-    if (op.getDtype() != elementTypeToDataType(output.getElementType())) {
+    if (op.getDtype() !=
+        ttcore::elementTypeToDataType(output.getElementType())) {
       return op.emitOpError("Data type mismatch between op and output tensor.");
     }
   }
@@ -851,8 +852,8 @@ void mlir::tt::ttnn::FullOp::build(mlir::OpBuilder &builder,
       mlir::cast<ttnn::TTNNLayoutAttr>(tensorType.getEncoding());
 
   ttnn::ShapeAttr shapeAttr = ttnn::ShapeAttr::get(ctx, tensorType.getShape());
-  tt::DataTypeAttr dtypeAttr =
-      tt::DataTypeAttr::get(ctx, layoutAttr.getDataType());
+  ttcore::DataTypeAttr dtypeAttr =
+      ttcore::DataTypeAttr::get(ctx, layoutAttr.getDataType());
   ttnn::LayoutAttr tensorLayoutAttr =
       ttnn::LayoutAttr::get(ctx, layoutAttr.getLayout());
 
@@ -1946,7 +1947,7 @@ void mlir::tt::ttnn::ToLayoutOp::getCanonicalizationPatterns(
 }
 
 ::mlir::OpFoldResult mlir::tt::ttnn::AllGatherOp::fold(FoldAdaptor adaptor) {
-  tt::DeviceAttr device = lookupDevice(*this);
+  ttcore::DeviceAttr device = ttcore::lookupDevice(*this);
   llvm::SmallVector<int64_t> meshShape{device.getMeshShape()};
   // AllGather Op is semantically meaningless when gathering across a single
   // mesh device.
@@ -1972,7 +1973,7 @@ void mlir::tt::ttnn::ToLayoutOp::getCanonicalizationPatterns(
 ::mlir::LogicalResult ReduceScatterOp::verify() {
   ::mlir::RankedTensorType inputType = getInput().getType();
   int32_t scatterDim = getScatterDim();
-  ::mlir::tt::ReduceType reduceType = getReduceType();
+  ::mlir::tt::ttcore::ReduceType reduceType = getReduceType();
 
   if (scatterDim >= inputType.getRank() || scatterDim < -inputType.getRank()) {
     return emitOpError(
@@ -1985,9 +1986,9 @@ void mlir::tt::ttnn::ToLayoutOp::getCanonicalizationPatterns(
   // Currently TTNN only supports the following reduce types. Compiler is able
   // to model the full ReduceType list but only the following can be lowered
   // into TTNN.
-  if (reduceType != ::mlir::tt::ReduceType::Sum &&
-      reduceType != ::mlir::tt::ReduceType::Max &&
-      reduceType != ::mlir::tt::ReduceType::Min) {
+  if (reduceType != ::mlir::tt::ttcore::ReduceType::Sum &&
+      reduceType != ::mlir::tt::ttcore::ReduceType::Max &&
+      reduceType != ::mlir::tt::ttcore::ReduceType::Min) {
     return emitOpError("Invalid reduction op for reduce scatter op.");
   }
 
@@ -1996,7 +1997,7 @@ void mlir::tt::ttnn::ToLayoutOp::getCanonicalizationPatterns(
 
 ::mlir::OpFoldResult
 mlir::tt::ttnn::ReduceScatterOp::fold(FoldAdaptor adaptor) {
-  tt::DeviceAttr device = lookupDevice(*this);
+  ttcore::DeviceAttr device = ttcore::lookupDevice(*this);
   llvm::SmallVector<int64_t> meshShape{device.getMeshShape()};
   // ReduceScatter Op is semantically meaningless when gathering across a single
   // mesh device.
@@ -2020,12 +2021,12 @@ mlir::tt::ttnn::ReduceScatterOp::fold(FoldAdaptor adaptor) {
 //===----------------------------------------------------------------------===//
 
 ::mlir::LogicalResult AllReduceOp::verify() {
-  ::mlir::tt::ReduceType reduceType = getReduceType();
+  ::mlir::tt::ttcore::ReduceType reduceType = getReduceType();
 
   // Currently TTNN only supports the following reduce types.
-  if (reduceType != ::mlir::tt::ReduceType::Sum &&
-      reduceType != ::mlir::tt::ReduceType::Max &&
-      reduceType != ::mlir::tt::ReduceType::Min) {
+  if (reduceType != ::mlir::tt::ttcore::ReduceType::Sum &&
+      reduceType != ::mlir::tt::ttcore::ReduceType::Max &&
+      reduceType != ::mlir::tt::ttcore::ReduceType::Min) {
     return emitOpError("Invalid reduction op for all reduce op.");
   }
 
@@ -2033,7 +2034,7 @@ mlir::tt::ttnn::ReduceScatterOp::fold(FoldAdaptor adaptor) {
 }
 
 ::mlir::OpFoldResult mlir::tt::ttnn::AllReduceOp::fold(FoldAdaptor adaptor) {
-  tt::DeviceAttr device = lookupDevice(*this);
+  ttcore::DeviceAttr device = ttcore::lookupDevice(*this);
   llvm::SmallVector<int64_t> meshShape{device.getMeshShape()};
   // AllReduce Op is semantically meaningless when gathering across a single
   // mesh device.
@@ -2129,14 +2130,14 @@ mlir::tt::ttnn::CollectivePermuteOp::fold(FoldAdaptor adaptor) {
 ::mlir::LogicalResult MeshShardOp::verify() {
   llvm::ArrayRef<int64_t> inputShape = getInput().getType().getShape();
   llvm::ArrayRef<int64_t> shardShape = getShardShape();
-  ::mlir::tt::MeshShardType shardType = getShardType();
+  ::mlir::tt::ttcore::MeshShardType shardType = getShardType();
 
   // Check shard_type is not maximal.
-  if (shardType == ::mlir::tt::MeshShardType::Maximal) {
+  if (shardType == ::mlir::tt::ttcore::MeshShardType::Maximal) {
     return emitOpError("Invalid shard_type (maximal) for mesh_shard op.");
   }
 
-  if (shardType == ::mlir::tt::MeshShardType::Devices) {
+  if (shardType == ::mlir::tt::ttcore::MeshShardType::Devices) {
     // Check if rank(shardShape) is eqaul to rank(input).
     if (shardShape.size() != inputShape.size()) {
       return emitOpError("Invalid rank(shard_shape) != rank(input) for "
@@ -2173,10 +2174,10 @@ mlir::tt::ttnn::CollectivePermuteOp::fold(FoldAdaptor adaptor) {
   const ::mlir::RankedTensorType cacheType = getCache().getType();
   const ::mlir::RankedTensorType inputType = getInput().getType();
 
-  const DataType cacheDataType =
-      elementTypeToDataType(cacheType.getElementType());
-  const DataType inputDataType =
-      elementTypeToDataType(inputType.getElementType());
+  const ::mlir::tt::ttcore::DataType cacheDataType =
+      ::mlir::tt::ttcore::elementTypeToDataType(cacheType.getElementType());
+  const ::mlir::tt::ttcore::DataType inputDataType =
+      ::mlir::tt::ttcore::elementTypeToDataType(inputType.getElementType());
 
   if (cacheDataType != inputDataType) {
     return emitOpError(
@@ -2232,10 +2233,10 @@ mlir::tt::ttnn::CollectivePermuteOp::fold(FoldAdaptor adaptor) {
   const ::mlir::RankedTensorType cacheType = getCache().getType();
   const ::mlir::RankedTensorType inputType = getInput().getType();
 
-  const DataType cacheDataType =
-      elementTypeToDataType(cacheType.getElementType());
-  const DataType inputDataType =
-      elementTypeToDataType(inputType.getElementType());
+  const ::mlir::tt::ttcore::DataType cacheDataType =
+      ::mlir::tt::ttcore::elementTypeToDataType(cacheType.getElementType());
+  const ::mlir::tt::ttcore::DataType inputDataType =
+      ::mlir::tt::ttcore::elementTypeToDataType(inputType.getElementType());
 
   if (cacheDataType != inputDataType) {
     return emitOpError(
@@ -2597,7 +2598,7 @@ static bool isTensorOnDevice(::mlir::RankedTensorType tensorType) {
               return ::mlir::WalkResult::interrupt();
             }
 
-            if (::mlir::isa<::mlir::tt::LoadCachedOp>(op)) {
+            if (::mlir::isa<::mlir::tt::ttcore::LoadCachedOp>(op)) {
               emitOpError()
                   << "LoadCached op must not be nested within trace op";
               return ::mlir::WalkResult::interrupt();

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -101,7 +101,8 @@ TTNNOperandsWorkarounds
 TTNNOperandsWorkaroundsFactory::createPool2DOpOperandsWorkarounds() {
   wa::TTNNOperandWorkarounds rowMajorLayoutBF16Workaround;
   rowMajorLayoutBF16Workaround.tensorLayoutWorkaround = Layout::RowMajor;
-  rowMajorLayoutBF16Workaround.tensorDataTypeWorkaround = DataType::BFloat16;
+  rowMajorLayoutBF16Workaround.tensorDataTypeWorkaround =
+      ttcore::DataType::BFloat16;
   return wa::TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
       .addInputOperandWorkaround(rowMajorLayoutBF16Workaround)
       .addOutputOperandWorkaround(rowMajorLayoutBF16Workaround);
@@ -123,9 +124,10 @@ TTNNOperandsWorkaroundsFactory::createEmbeddingOpOperandsWorkarounds() {
   // Create input and bf16 workarounds.
   TTNNOperandWorkarounds inputRowMajorInt32Workaround;
   inputRowMajorInt32Workaround.tensorLayoutWorkaround = Layout::RowMajor;
-  inputRowMajorInt32Workaround.tensorDataTypeWorkaround = DataType::UInt32;
+  inputRowMajorInt32Workaround.tensorDataTypeWorkaround =
+      ttcore::DataType::UInt32;
   TTNNOperandWorkarounds bf16Workaround =
-      TTNNOperandWorkarounds(DataType::BFloat16);
+      TTNNOperandWorkarounds(ttcore::DataType::BFloat16);
   return TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds(0, 0)
       .addInputOperandWorkaround(inputRowMajorInt32Workaround)
       .addInputOperandWorkaround(bf16Workaround)
@@ -149,9 +151,10 @@ TTNNOperandsWorkaroundsFactory::createEmbeddingBackwardOpOperandsWorkarounds() {
   // Create input and bf16 workarounds.
   TTNNOperandWorkarounds inputRowMajorInt32Workaround;
   inputRowMajorInt32Workaround.tensorLayoutWorkaround = Layout::RowMajor;
-  inputRowMajorInt32Workaround.tensorDataTypeWorkaround = DataType::UInt32;
+  inputRowMajorInt32Workaround.tensorDataTypeWorkaround =
+      ttcore::DataType::UInt32;
   TTNNOperandWorkarounds bf16Workaround =
-      TTNNOperandWorkarounds(DataType::BFloat16);
+      TTNNOperandWorkarounds(ttcore::DataType::BFloat16);
   return TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds(0, 0)
       .addInputOperandWorkaround(inputRowMajorInt32Workaround)
       .addInputOperandWorkaround(bf16Workaround)
@@ -167,7 +170,8 @@ TTNNOperandsWorkarounds
 TTNNOperandsWorkaroundsFactory::createUpsampleOpOperandsWorkarounds() {
   TTNNOperandWorkarounds rowMajorLayoutBF16Workaround;
   rowMajorLayoutBF16Workaround.tensorLayoutWorkaround = Layout::RowMajor;
-  rowMajorLayoutBF16Workaround.tensorDataTypeWorkaround = DataType::BFloat16;
+  rowMajorLayoutBF16Workaround.tensorDataTypeWorkaround =
+      ttcore::DataType::BFloat16;
   return TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
       .addInputOperandWorkaround(rowMajorLayoutBF16Workaround)
       .addOutputOperandWorkaround(rowMajorLayoutBF16Workaround);
@@ -180,11 +184,11 @@ TTNNOperandsWorkarounds
 TTNNOperandsWorkaroundsFactory::createZerosOpOperandsWorkarounds(
     RankedTensorType outputType) {
   wa::TTNNOperandWorkarounds fullOpOutputWorkarounds;
-  mlir::tt::DataType dataType =
-      elementTypeToDataType(outputType.getElementType());
-  if (dataType == mlir::tt::DataType::Int32) {
+  mlir::tt::ttcore::DataType dataType =
+      mlir::tt::ttcore::elementTypeToDataType(outputType.getElementType());
+  if (dataType == mlir::tt::ttcore::DataType::Int32) {
     fullOpOutputWorkarounds.tensorDataTypeWorkaround =
-        mlir::tt::DataType::Float32;
+        mlir::tt::ttcore::DataType::Float32;
   }
   return wa::TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
       .addOutputOperandWorkaround(fullOpOutputWorkarounds);
@@ -205,11 +209,11 @@ TTNNOperandsWorkaroundsFactory::createFullOpOperandsWorkarounds(
   if (outputType.getRank() == 1 && layoutAttr.isTiled()) {
     fullOpOutputWorkarounds.tensorLayoutWorkaround = Layout::RowMajor;
   }
-  mlir::tt::DataType dataType =
-      elementTypeToDataType(outputType.getElementType());
-  if (dataType == mlir::tt::DataType::Int32) {
+  mlir::tt::ttcore::DataType dataType =
+      mlir::tt::ttcore::elementTypeToDataType(outputType.getElementType());
+  if (dataType == mlir::tt::ttcore::DataType::Int32) {
     fullOpOutputWorkarounds.tensorDataTypeWorkaround =
-        mlir::tt::DataType::Float32;
+        mlir::tt::ttcore::DataType::Float32;
   }
   return wa::TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
       .addOutputOperandWorkaround(fullOpOutputWorkarounds);
@@ -219,9 +223,9 @@ TTNNOperandsWorkaroundsFactory::createFullOpOperandsWorkarounds(
 // operand. ttnn::MeshShardOp supports host tensors only
 TTNNOperandsWorkarounds
 TTNNOperandsWorkaroundsFactory::createMeshShardOpOperandsWorkarounds(
-    mlir::tt::MeshShardType shardType) {
+    mlir::tt::ttcore::MeshShardType shardType) {
   wa::TTNNOperandWorkarounds sysMemWorkaround;
-  if (shardType != mlir::tt::MeshShardType::Identity) {
+  if (shardType != mlir::tt::ttcore::MeshShardType::Identity) {
     sysMemWorkaround.tensorBufferTypeWorkaround = BufferType::SystemMemory;
   }
   return wa::TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
@@ -252,8 +256,8 @@ TTNNOperandsWorkaroundsFactory::createConcatOpOperandsWorkarounds(
   int32_t tileWidth = 1;
   int32_t tileHeight = 1;
   if (isDataTypeWARequired) {
-    TileType tile =
-        mlir::cast<TileType>(layoutAttr.getMemref().getElementType());
+    ttcore::TileType tile =
+        mlir::cast<ttcore::TileType>(layoutAttr.getMemref().getElementType());
     tileWidth = tile.getWidth();
     tileHeight = tile.getHeight();
   }
@@ -266,7 +270,7 @@ TTNNOperandsWorkaroundsFactory::createConcatOpOperandsWorkarounds(
 
   TTNNOperandWorkarounds bf16Workaround;
   if (isDataTypeWARequired) {
-    bf16Workaround.tensorDataTypeWorkaround = DataType::BFloat16;
+    bf16Workaround.tensorDataTypeWorkaround = ttcore::DataType::BFloat16;
   }
   auto workaround =
       TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds();
@@ -301,8 +305,8 @@ TTNNOperandsWorkaroundsFactory::createSliceOpOperandsWorkarounds(
   int32_t tileWidth = 1;
   int32_t tileHeight = 1;
   if (isLayoutWARequired) {
-    TileType tile =
-        mlir::cast<TileType>(layoutAttr.getMemref().getElementType());
+    ttcore::TileType tile =
+        mlir::cast<ttcore::TileType>(layoutAttr.getMemref().getElementType());
     tileWidth = tile.getWidth();
     tileHeight = tile.getHeight();
   }
@@ -316,7 +320,8 @@ TTNNOperandsWorkaroundsFactory::createSliceOpOperandsWorkarounds(
 
   TTNNOperandWorkarounds rowMajorLayoutBF16Workaround;
   if (isStridedSliceOp) {
-    rowMajorLayoutBF16Workaround.tensorDataTypeWorkaround = DataType::BFloat16;
+    rowMajorLayoutBF16Workaround.tensorDataTypeWorkaround =
+        ttcore::DataType::BFloat16;
   }
   if (!isStridedSliceOp && isLayoutWARequired) {
     rowMajorLayoutBF16Workaround.tensorLayoutWorkaround = Layout::RowMajor;
@@ -361,10 +366,10 @@ TTNNOperandsWorkaroundsFactory::createWhereOpOperandsWorkarounds(
   mlir::Type inputElementType = inputType.getElementType();
   TTNNOperandWorkarounds typeWorkaround = TTNNOperandWorkarounds();
   if (predicateElementType.isInteger() || inputElementType.isInteger()) {
-    typeWorkaround = TTNNOperandWorkarounds(DataType::Float32);
+    typeWorkaround = TTNNOperandWorkarounds(ttcore::DataType::Float32);
   } else if (predicateElementType != inputElementType) {
     typeWorkaround =
-        TTNNOperandWorkarounds(elementTypeToDataType(inputElementType));
+        TTNNOperandWorkarounds(ttcore::elementTypeToDataType(inputElementType));
   }
 
   return TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
@@ -382,9 +387,11 @@ TTNNOperandsWorkaroundsFactory::createReshapeOpOperandsWorkarounds(
     RankedTensorType inputType) {
   mlir::Type inputElementType = inputType.getElementType();
   TTNNOperandWorkarounds typeWorkarounds;
-  mlir::tt::DataType dataType = elementTypeToDataType(inputElementType);
-  if (dataType == mlir::tt::DataType::Int32) {
-    typeWorkarounds.tensorDataTypeWorkaround = mlir::tt::DataType::Float32;
+  mlir::tt::ttcore::DataType dataType =
+      mlir::tt::ttcore::elementTypeToDataType(inputElementType);
+  if (dataType == mlir::tt::ttcore::DataType::Int32) {
+    typeWorkarounds.tensorDataTypeWorkaround =
+        mlir::tt::ttcore::DataType::Float32;
   }
   return TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
       .addInputOperandWorkaround(typeWorkarounds)
@@ -399,9 +406,11 @@ TTNNOperandsWorkaroundsFactory::createUpdateCacheOpOperandsWorkarounds(
   mlir::Type updateIndexElementType = updateIndex.getElementType();
   TTNNOperandWorkarounds nullWorkarounds;
   TTNNOperandWorkarounds typeWorkarounds;
-  mlir::tt::DataType dataType = elementTypeToDataType(updateIndexElementType);
-  if (dataType == mlir::tt::DataType::Int32) {
-    typeWorkarounds.tensorDataTypeWorkaround = mlir::tt::DataType::UInt32;
+  mlir::tt::ttcore::DataType dataType =
+      mlir::tt::ttcore::elementTypeToDataType(updateIndexElementType);
+  if (dataType == mlir::tt::ttcore::DataType::Int32) {
+    typeWorkarounds.tensorDataTypeWorkaround =
+        mlir::tt::ttcore::DataType::UInt32;
   }
   return TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
       .addInputOperandWorkaround(nullWorkarounds)
@@ -411,16 +420,19 @@ TTNNOperandsWorkaroundsFactory::createUpdateCacheOpOperandsWorkarounds(
 
 // Helper function to determine if data type workaround is required for a binary
 // op. Set the workaround data type based on the binary op.
-static std::optional<DataType> binaryOpDTypeWorkaround(mlir::Operation *op,
-                                                       Type elementType) {
-  DataType dType = elementTypeToDataType(elementType);
+static std::optional<mlir::tt::ttcore::DataType>
+binaryOpDTypeWorkaround(mlir::Operation *op, mlir::Type elementType) {
+  mlir::tt::ttcore::DataType dType =
+      mlir::tt::ttcore::elementTypeToDataType(elementType);
 
   if (isa<ttnn::AddOp, ttnn::SubtractOp>(op)) {
-    if (dType == DataType::Float32 || dType == DataType::BFloat16 ||
-        dType == DataType::BFP_BFloat8 || dType == DataType::BFP_BFloat4) {
+    if (dType == mlir::tt::ttcore::DataType::Float32 ||
+        dType == mlir::tt::ttcore::DataType::BFloat16 ||
+        dType == mlir::tt::ttcore::DataType::BFP_BFloat8 ||
+        dType == mlir::tt::ttcore::DataType::BFP_BFloat4) {
       return {};
     }
-    if (dType == DataType::Int32) {
+    if (dType == mlir::tt::ttcore::DataType::Int32) {
       // Although TTNN claims to support int32 for Add and Subtract ops,
       // broadcasting with int32 inputs does not currently work as expected.
       // As a temporary workaround, we fall back to BFloat16 when input shapes
@@ -432,26 +444,28 @@ static std::optional<DataType> binaryOpDTypeWorkaround(mlir::Operation *op,
           mlir::cast<mlir::RankedTensorType>(op->getOperand(1).getType());
 
       if (lhsType.getShape() != rhsType.getShape()) {
-        return DataType::BFloat16;
+        return mlir::tt::ttcore::DataType::BFloat16;
       }
       return {};
     }
-    return DataType::BFloat16;
+    return mlir::tt::ttcore::DataType::BFloat16;
   }
   // Left shift and right shift ops have same requirements but they are not
   // implemented for TTNN dialect currently.
   if (isa<ttnn::BitwiseAndOp, ttnn::BitwiseOrOp, ttnn::BitwiseXorOp>(op)) {
-    if (dType == DataType::Int32) {
+    if (dType == mlir::tt::ttcore::DataType::Int32) {
       return {};
     }
-    return DataType::Int32;
+    return mlir::tt::ttcore::DataType::Int32;
   }
   // All remaining binary ops.
-  if (dType == DataType::Float32 || dType == DataType::BFloat16 ||
-      dType == DataType::BFP_BFloat8 || dType == DataType::BFP_BFloat4) {
+  if (dType == mlir::tt::ttcore::DataType::Float32 ||
+      dType == mlir::tt::ttcore::DataType::BFloat16 ||
+      dType == mlir::tt::ttcore::DataType::BFP_BFloat8 ||
+      dType == mlir::tt::ttcore::DataType::BFP_BFloat4) {
     return {};
   }
-  return DataType::BFloat16;
+  return mlir::tt::ttcore::DataType::BFloat16;
 }
 
 // Factory method to create a set of workarounds for binary operation operands.
@@ -495,7 +509,8 @@ TTNNOperandsWorkaroundsFactory::createTanhOpOperandsWorkarounds() {
   TTNNOperandWorkarounds operandWorkaround;
   // Tanh op accurate mode requires bfloat16 data type.
   // Issue: https://github.com/tenstorrent/tt-metal/issues/22593
-  operandWorkaround.tensorDataTypeWorkaround = DataType::BFloat16;
+  operandWorkaround.tensorDataTypeWorkaround =
+      mlir::tt::ttcore::DataType::BFloat16;
 
   return TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
       .addInputOperandWorkaround(operandWorkaround)
@@ -514,11 +529,13 @@ TTNNOperandsWorkaroundsFactory::createArgMaxOpOperandsWorkarounds() {
   rowMajorLayoutWorkaround.tensorLayoutWorkaround = Layout::RowMajor;
   wa::TTNNOperandWorkarounds rowMajorLayoutBF16Workaround;
   rowMajorLayoutBF16Workaround.tensorLayoutWorkaround = Layout::RowMajor;
-  rowMajorLayoutBF16Workaround.tensorDataTypeWorkaround = DataType::BFloat16;
+  rowMajorLayoutBF16Workaround.tensorDataTypeWorkaround =
+      mlir::tt::ttcore::DataType::BFloat16;
 
   wa::TTNNOperandWorkarounds rowMajorLayoutUint32Workaround;
   rowMajorLayoutUint32Workaround.tensorLayoutWorkaround = Layout::RowMajor;
-  rowMajorLayoutUint32Workaround.tensorDataTypeWorkaround = DataType::UInt32;
+  rowMajorLayoutUint32Workaround.tensorDataTypeWorkaround =
+      mlir::tt::ttcore::DataType::UInt32;
 
   return wa::TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
       .addInputOperandWorkaround(rowMajorLayoutBF16Workaround)
@@ -538,7 +555,8 @@ TTNNOperandsWorkaroundsFactory::createPadOpOperandsWorkarounds(
     operandWorkaround.tensorLayoutWorkaround = Layout::RowMajor;
   }
   if (isa<IntegerType>(input.getType().getElementType())) {
-    operandWorkaround.tensorDataTypeWorkaround = DataType::BFloat16;
+    operandWorkaround.tensorDataTypeWorkaround =
+        mlir::tt::ttcore::DataType::BFloat16;
   }
   return wa::TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
       .addInputOperandWorkaround(operandWorkaround)
@@ -555,7 +573,8 @@ TTNNOperandsWorkaroundsFactory::createPermuteOpOperandWorkaround(
   TTNNOperandWorkarounds operandWorkaround;
   if (auto elementType = dyn_cast<IntegerType>(inputType.getElementType());
       elementType && elementType.getWidth() == 32) {
-    operandWorkaround.tensorDataTypeWorkaround = DataType::Float32;
+    operandWorkaround.tensorDataTypeWorkaround =
+        mlir::tt::ttcore::DataType::Float32;
   }
 
   return wa::TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
@@ -626,7 +645,8 @@ TTNNOperandsWorkaroundsFactory::createReductionOpOperandsWorkarounds(
           .getElementType();
   TTNNOperandWorkarounds operandWorkaround;
   if (!inputType.isF32() && !inputType.isBF16()) {
-    operandWorkaround.tensorDataTypeWorkaround = DataType::BFloat16;
+    operandWorkaround.tensorDataTypeWorkaround =
+        mlir::tt::ttcore::DataType::BFloat16;
   }
 
   return wa::TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
@@ -642,7 +662,7 @@ TTNNOperandsWorkaroundsFactory::createReduceProdOpOperandsWorkarounds(
   bool isDataTypeWARequired = allDimensions && !elementType.isBF16();
   TTNNOperandWorkarounds bf16Workaround;
   if (isDataTypeWARequired) {
-    bf16Workaround.tensorDataTypeWorkaround = DataType::BFloat16;
+    bf16Workaround.tensorDataTypeWorkaround = ttcore::DataType::BFloat16;
   }
 
   return wa::TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()

--- a/lib/Dialect/TTNN/Transforms/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/Optimizer.cpp
@@ -187,11 +187,12 @@ public:
 
     // Get the max grid size from the system description.
     //
-    GridAttr deviceGrid = lookupDevice(moduleOp).getWorkerGrid();
+    ttcore::GridAttr deviceGrid =
+        ttcore::lookupDevice(moduleOp).getWorkerGrid();
 
-    SystemDescAttr systemDesc = mlir::cast<tt::SystemDescAttr>(
-        moduleOp->getAttr(tt::SystemDescAttr::name));
-    ChipDescAttr chipDesc = systemDesc.getChipDescs()[0];
+    ttcore::SystemDescAttr systemDesc = mlir::cast<ttcore::SystemDescAttr>(
+        moduleOp->getAttr(ttcore::SystemDescAttr::name));
+    ttcore::ChipDescAttr chipDesc = systemDesc.getChipDescs()[0];
     llvm::DenseMap<Operation *, std::vector<OpConfig>> legalConfigs;
 
     // Step 1: Run ScalarDataTypeAnalysis to collect all scalar types used in
@@ -535,7 +536,7 @@ private:
     }
 
     // Device op does not exist in the block, hence we need to create it.
-    DeviceAttr deviceAttr = lookupDevice(contextOp);
+    ttcore::DeviceAttr deviceAttr = ttcore::lookupDevice(contextOp);
     auto currentInsertionPoint = builder.saveInsertionPoint();
     builder.setInsertionPoint(block, block->begin());
     llvm::SmallVector<int64_t> meshShape{deviceAttr.getMeshShape()};
@@ -558,7 +559,7 @@ private:
 
   static llvm::DenseMap<Operation *, Operation *> processMemReconfigEdges(
       const llvm::DenseMap<Edge, MemReconfigEntry> &memReconfigEntryMap,
-      GridAttr deviceGrid) {
+      ttcore::GridAttr deviceGrid) {
 
     // Mapping from producer op to inserted memory reconfig op.
     llvm::DenseMap<Operation *, Operation *> insertedMemoryReconfigOps;
@@ -635,8 +636,8 @@ private:
             consumerOp->getOperand(edge.operandIndex), // input value
             LayoutAttr::get(consumerOp->getContext(),
                             producerOpLayout.getLayout()),
-            DataTypeAttr::get(consumerOp->getContext(),
-                              producerOpLayout.getDataType()),
+            ttcore::DataTypeAttr::get(consumerOp->getContext(),
+                                      producerOpLayout.getDataType()),
             outputMemConfigAttr, getOrCreateDeviceOpValue(consumerOp, builder));
 
         consumerOp->setOperand(edge.operandIndex,
@@ -653,7 +654,7 @@ private:
   }
 
   void processSpillOps(const std::vector<Operation *> &spillToDramOps,
-                       GridAttr deviceGrid,
+                       ttcore::GridAttr deviceGrid,
                        const llvm::DenseMap<Operation *, Operation *>
                            &insertedMemoryReconfigOps) {
 
@@ -677,8 +678,8 @@ private:
 
       // Create a ToLayoutOp with the new DRAM layout.
       OpBuilder builder(spilledOp->getContext());
-      DataTypeAttr dataType =
-          DataTypeAttr::get(spilledOp->getContext(), dramLayout.getDataType());
+      ttcore::DataTypeAttr dataType = ttcore::DataTypeAttr::get(
+          spilledOp->getContext(), dramLayout.getDataType());
       LayoutAttr newLayout =
           LayoutAttr::get(spilledOp->getContext(), dramLayout.getLayout());
 

--- a/lib/Dialect/TTNN/Transforms/Passes.cpp
+++ b/lib/Dialect/TTNN/Transforms/Passes.cpp
@@ -304,8 +304,8 @@ private:
 
     // Create a tuple from the generated tensors.
     //
-    TupleOp tuple =
-        rewriter.create<tt::TupleOp>(loc, returnTypes, generatedTensors);
+    ttcore::TupleOp tuple =
+        rewriter.create<ttcore::TupleOp>(loc, returnTypes, generatedTensors);
 
     // Create ReturnOp.
     //
@@ -335,7 +335,8 @@ private:
     ShapeAttr shapeAttr = ttnn::ShapeAttr::get(ctx, tensorType.getShape());
     ttnn::LayoutAttr tensorLayoutAttr =
         ttnn::LayoutAttr::get(ctx, layoutAttr.getLayout());
-    DataTypeAttr dTypeAttr = DataTypeAttr::get(ctx, layoutAttr.getDataType());
+    ttcore::DataTypeAttr dTypeAttr =
+        ttcore::DataTypeAttr::get(ctx, layoutAttr.getDataType());
 
     // Create a new tensor of ones.
     //
@@ -468,8 +469,8 @@ public:
       //
       rewriter.setInsertionPointToStart(&entryBlock);
       for (size_t idx = 0; idx < originalFuncType.getNumInputs(); idx++) {
-        tt::GetTupleElementOp getTupleElementOp =
-            rewriter.create<tt::GetTupleElementOp>(
+        ttcore::GetTupleElementOp getTupleElementOp =
+            rewriter.create<ttcore::GetTupleElementOp>(
                 targetFuncOpInput.getLoc(), targetFuncOpInput.getArgument(0),
                 idx);
 
@@ -515,7 +516,7 @@ public:
       targetFuncOpResult.walk<WalkOrder::PostOrder, ReverseIterator>(
           [&](mlir::func::ReturnOp returnOp) {
             rewriter.setInsertionPoint(returnOp);
-            TupleOp tupleOp = rewriter.create<mlir::tt::TupleOp>(
+            ttcore::TupleOp tupleOp = rewriter.create<ttcore::TupleOp>(
                 returnOp.getLoc(), returnOp.getOperands());
             rewriter.modifyOpInPlace(returnOp, [&]() {
               returnOp.getOperandsMutable().assign(tupleOp);

--- a/lib/Dialect/TTNN/Transforms/TTNNDecomposeLayouts.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNDecomposeLayouts.cpp
@@ -55,10 +55,10 @@ private:
   struct LayoutInfo {
     ttnn::BufferType bufferType;
     ttnn::Layout layoutEnum;
-    DataType dataType;
+    ttcore::DataType dataType;
     ttnn::TensorMemoryLayoutAttr tensorMemoryLayout;
-    GridAttr deviceGrid;
-    GridAttr shardGrid;
+    ttcore::GridAttr deviceGrid;
+    ttcore::GridAttr shardGrid;
     llvm::SmallVector<int64_t> shardShape;
 
     ttnn::MemoryConfigAttr createMemoryConfigAttr(MLIRContext *context) const {
@@ -132,12 +132,12 @@ private:
   // TODO (jnie): Add support for fp32, currently there's some precision loss
   // which causes some FE tests to fail.
   // Tracking here: https://github.com/tenstorrent/tt-metal/issues/21023
-  bool canTilizeDataTypeOnDevice(const DataType &dataType) const {
-    return dataType == DataType::BFloat16;
+  bool canTilizeDataTypeOnDevice(const ttcore::DataType &dataType) const {
+    return dataType == ttcore::DataType::BFloat16;
   }
 
-  bool canUntilizeDataTypeOnDevice(const DataType &dataType) const {
-    return dataType == DataType::BFloat16;
+  bool canUntilizeDataTypeOnDevice(const ttcore::DataType &dataType) const {
+    return dataType == ttcore::DataType::BFloat16;
   }
 
   std::pair<LayoutInfo, LayoutInfo>
@@ -172,8 +172,8 @@ private:
     input.shardShape = inputLayoutAttr.getScalarShardShape();
     output.shardShape = outputLayoutAttr.getScalarShardShape();
 
-    DeviceAttr deviceAttr =
-        lookupDevice(op.getResult().getParentBlock()->getParentOp());
+    ttcore::DeviceAttr deviceAttr =
+        ttcore::lookupDevice(op.getResult().getParentBlock()->getParentOp());
     input.deviceGrid = deviceAttr.getWorkerGrid();
     output.deviceGrid = deviceAttr.getWorkerGrid();
 
@@ -345,8 +345,8 @@ private:
   mlir::Value createDataTypeCastingOp(ttnn::ToLayoutOp op, IRRewriter &rewriter,
                                       mlir::Value currentInput,
                                       const OpCreationInfo &info) const {
-    DataTypeAttr dtypeAttr =
-        DataTypeAttr::get(op.getContext(), info.output.dataType);
+    ttcore::DataTypeAttr dtypeAttr =
+        ttcore::DataTypeAttr::get(op.getContext(), info.output.dataType);
     RankedTensorType newResultType = utils::RankedTensorTypeFactory::create(
         mlir::cast<RankedTensorType>(currentInput.getType()),
         info.output.dataType);

--- a/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
@@ -27,10 +27,10 @@ public:
     Value reluInput = reluOp.getInput();
 
     mlir::StringAttr activation = rewriter.getStringAttr("relu");
-    DataType inputDtype =
-        elementTypeToDataType(srcOp.getInput().getType().getElementType());
-    DataType weightDtype =
-        elementTypeToDataType(srcOp.getWeight().getType().getElementType());
+    ttcore::DataType inputDtype = ttcore::elementTypeToDataType(
+        srcOp.getInput().getType().getElementType());
+    ttcore::DataType weightDtype = ttcore::elementTypeToDataType(
+        srcOp.getWeight().getType().getElementType());
     Conv2dConfigAttr conv2dConfigAttr =
         srcOp.getConv2dConfigAttr()
             ? srcOp.getConv2dConfigAttr()

--- a/lib/Dialect/TTNN/Transforms/TTNNPrepareConv2dWeights.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNPrepareConv2dWeights.cpp
@@ -32,7 +32,8 @@ public:
     moduleOp.walk([&](ttnn::Conv2dOp conv2dOp) {
       mlir::RankedTensorType inputType = conv2dOp.getInput().getType();
 
-      GridAttr deviceGrid = lookupDevice(moduleOp).getWorkerGrid();
+      ttcore::GridAttr deviceGrid =
+          ttcore::lookupDevice(moduleOp).getWorkerGrid();
 
       ttnn::TTNNLayoutAttr inputLayoutAttr =
           mlir::cast<ttnn::TTNNLayoutAttr>(inputType.getEncoding());

--- a/lib/Dialect/TTNN/Transforms/TTNNTraceHoistTransform.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNTraceHoistTransform.cpp
@@ -32,7 +32,7 @@ private:
   bool shouldHoistOp(Operation *op) {
     bool shouldHoist = true;
     shouldHoist &= !::mlir::isa<func::ReturnOp>(op);
-    shouldHoist &= !::mlir::isa<mlir::tt::LoadCachedOp>(op);
+    shouldHoist &= !::mlir::isa<mlir::tt::ttcore::LoadCachedOp>(op);
     shouldHoist &= !::mlir::isa<mlir::tt::ttnn::TraceOp>(op);
     shouldHoist &= !::mlir::isa<mlir::tt::ttnn::GetDeviceOp>(op);
     return shouldHoist;

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/RepeatOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/RepeatOpRewritePattern.cpp
@@ -25,8 +25,8 @@ TTNNRepeatFoldingWorkaround::matchAndRewrite(ttnn::RepeatOp op,
   auto layoutAttr = mlir::cast<ttnn::TTNNLayoutAttr>(resultType.getEncoding());
   auto shapeAttr =
       ttnn::ShapeAttr::get(rewriter.getContext(), resultType.getShape());
-  auto dTypeAttr =
-      DataTypeAttr::get(rewriter.getContext(), layoutAttr.getDataType());
+  auto dTypeAttr = ttcore::DataTypeAttr::get(rewriter.getContext(),
+                                             layoutAttr.getDataType());
   auto layout = ttnn::LayoutAttr::get(op.getContext(), layoutAttr.getLayout());
 
   // Create a ZerosOp to be used with AddOp

--- a/lib/Dialect/TTNN/Utils/OptimizerOverrides.cpp
+++ b/lib/Dialect/TTNN/Utils/OptimizerOverrides.cpp
@@ -210,7 +210,7 @@ void OptimizerOverridesHandler::addOutputLayoutOverride(
 void OptimizerOverridesHandler::addOutputLayoutOverride(
     StringRef opName, SmallVector<int64_t> &grid, BufferType bufferType,
     TensorMemoryLayout tensorMemoryLayout, tt::ttnn::Layout memoryLayout,
-    tt::DataType dataType) {
+    ttcore::DataType dataType) {
   outputLayoutOverrides[opName] = OutputLayoutOverrideParams{
       std::move(grid), bufferType, tensorMemoryLayout, memoryLayout, dataType};
 }

--- a/lib/Dialect/TTNN/Utils/PassOverrides.cpp
+++ b/lib/Dialect/TTNN/Utils/PassOverrides.cpp
@@ -82,7 +82,7 @@ bool Conv2dConfigOverrideParser::parse(
       auto [paramName, paramValue] = param.split(paramNameValueSeparator);
 
       if (paramName == "dtype") {
-        auto dtype = mlir::tt::DataTypeStringToEnum(paramValue);
+        auto dtype = mlir::tt::ttcore::DataTypeStringToEnum(paramValue);
         if (!dtype) {
           opt.error("Invalid dtype: " + paramValue);
           return true;
@@ -93,7 +93,7 @@ bool Conv2dConfigOverrideParser::parse(
         }
         params.dtype = dtype;
       } else if (paramName == "weights_dtype") {
-        auto weightsDtype = mlir::tt::DataTypeStringToEnum(paramValue);
+        auto weightsDtype = mlir::tt::ttcore::DataTypeStringToEnum(paramValue);
         if (!weightsDtype) {
           opt.error("Invalid weights_dtype: " + paramValue);
           return true;
@@ -450,7 +450,8 @@ bool OutputLayoutOverrideParser::parse(
           return true;
         }
         params.memoryLayout = memoryLayout;
-      } else if (auto dataType = mlir::tt::DataTypeStringToEnum(param)) {
+      } else if (auto dataType =
+                     mlir::tt::ttcore::DataTypeStringToEnum(param)) {
         if (params.dataType.has_value()) {
           opt.error("Multiple data type parameters provided: " + param);
           return true;
@@ -502,8 +503,8 @@ std::string OutputLayoutOverrideParser::toString(
           mlir::tt::ttnn::stringifyLayout(params.memoryLayout.value())));
     }
     if (params.dataType.has_value()) {
-      parts.push_back(
-          std::string(mlir::tt::DataTypeEnumToString(params.dataType.value())));
+      parts.push_back(std::string(
+          mlir::tt::ttcore::DataTypeEnumToString(params.dataType.value())));
     }
 
     // Join parts with ":"

--- a/lib/Dialect/TTNN/Utils/TransformUtils.cpp
+++ b/lib/Dialect/TTNN/Utils/TransformUtils.cpp
@@ -21,7 +21,7 @@ GetDeviceOp getOrInsertDevice(RewriterBase &rewriter, Operation *op) {
     }
   }
 
-  DeviceAttr deviceAttr = lookupDevice(op);
+  ttcore::DeviceAttr deviceAttr = ttcore::lookupDevice(op);
   auto currentInsertionPoint = rewriter.saveInsertionPoint();
   rewriter.setInsertionPoint(block, block->begin());
   llvm::SmallVector<int64_t> meshShape{deviceAttr.getMeshShape()};
@@ -47,7 +47,8 @@ createToLayoutOp(Operation *op, mlir::TypedValue<RankedTensorType> inputValue,
                  PatternRewriter &rewriter, Layout targetTensorLayout,
                  BufferType targetTensorBufferType,
                  std::optional<TensorMemoryLayout> targetTensorMemoryLayout,
-                 DataType targetTensorDataType, llvm::StringRef locSuffix) {
+                 ttcore::DataType targetTensorDataType,
+                 llvm::StringRef locSuffix) {
   TTNNLayoutAttr inputLayoutAttr =
       getLayoutAttrFromTensor(inputValue.getType());
 
@@ -76,11 +77,11 @@ createToLayoutOp(Operation *op, mlir::TypedValue<RankedTensorType> inputValue,
   RankedTensorType toLayoutOpResultType = RankedTensorTypeFactory::create(
       RankedTensorTypeFactory::create(
           inputToLayoutOpType,
-          mlir::tt::dataTypeToElementType(rewriter.getContext(),
-                                          targetTensorDataType)),
+          mlir::tt::ttcore::dataTypeToElementType(rewriter.getContext(),
+                                                  targetTensorDataType)),
       toLayoutOpResultEncoding);
 
-  DeviceAttr deviceAttr = lookupDevice(op);
+  ttcore::DeviceAttr deviceAttr = ttcore::lookupDevice(op);
 
   // Create the output memory config attribute.
   ttnn::MemoryConfigAttr outputMemConfigAttr = ttnn::MemoryConfigAttr::get(
@@ -101,7 +102,7 @@ createToLayoutOp(Operation *op, mlir::TypedValue<RankedTensorType> inputValue,
   return rewriter.create<ttnn::ToLayoutOp>(
       loc, toLayoutOpResultType, inputValue,
       LayoutAttr::get(rewriter.getContext(), targetTensorLayout),
-      DataTypeAttr::get(rewriter.getContext(), targetTensorDataType),
+      ttcore::DataTypeAttr::get(rewriter.getContext(), targetTensorDataType),
       outputMemConfigAttr, deviceValue);
 }
 } // namespace mlir::tt::ttnn::utils

--- a/lib/OpModel/TTNN/Conversion.cpp
+++ b/lib/OpModel/TTNN/Conversion.cpp
@@ -18,47 +18,47 @@ namespace mlir::tt::op_model::ttnn {
 
 namespace conversion {
 
-::tt::tt_metal::DataType getDataType(const DataType dataType) {
+::tt::tt_metal::DataType getDataType(const ttcore::DataType dataType) {
   switch (dataType) {
-  case tt::DataType::Float32:
+  case ttcore::DataType::Float32:
     return ::tt::tt_metal::DataType::FLOAT32;
-  case tt::DataType::BFloat16:
+  case ttcore::DataType::BFloat16:
     return ::tt::tt_metal::DataType::BFLOAT16;
-  case tt::DataType::BFP_BFloat8:
+  case ttcore::DataType::BFP_BFloat8:
     return ::tt::tt_metal::DataType::BFLOAT8_B;
-  case tt::DataType::BFP_BFloat4:
+  case ttcore::DataType::BFP_BFloat4:
     return ::tt::tt_metal::DataType::BFLOAT4_B;
-  case tt::DataType::UInt32:
+  case ttcore::DataType::UInt32:
     return ::tt::tt_metal::DataType::UINT32;
-  case tt::DataType::UInt16:
+  case ttcore::DataType::UInt16:
     return ::tt::tt_metal::DataType::UINT16;
-  case tt::DataType::UInt8:
+  case ttcore::DataType::UInt8:
     return ::tt::tt_metal::DataType::UINT8;
-  case tt::DataType::Int32:
+  case ttcore::DataType::Int32:
     return ::tt::tt_metal::DataType::INT32;
   default:
     throw std::runtime_error("Invalid element type");
   }
 }
 
-tt::DataType getDataType(const ::tt::tt_metal::DataType dataType) {
+ttcore::DataType getDataType(const ::tt::tt_metal::DataType dataType) {
   switch (dataType) {
   case ::tt::tt_metal::DataType::FLOAT32:
-    return tt::DataType::Float32;
+    return ttcore::DataType::Float32;
   case ::tt::tt_metal::DataType::BFLOAT16:
-    return tt::DataType::BFloat16;
+    return ttcore::DataType::BFloat16;
   case ::tt::tt_metal::DataType::BFLOAT8_B:
-    return tt::DataType::BFP_BFloat8;
+    return ttcore::DataType::BFP_BFloat8;
   case ::tt::tt_metal::DataType::BFLOAT4_B:
-    return tt::DataType::BFP_BFloat4;
+    return ttcore::DataType::BFP_BFloat4;
   case ::tt::tt_metal::DataType::UINT32:
-    return tt::DataType::UInt32;
+    return ttcore::DataType::UInt32;
   case ::tt::tt_metal::DataType::UINT16:
-    return tt::DataType::UInt16;
+    return ttcore::DataType::UInt16;
   case ::tt::tt_metal::DataType::UINT8:
-    return tt::DataType::UInt8;
+    return ttcore::DataType::UInt8;
   case ::tt::tt_metal::DataType::INT32:
-    return tt::DataType::Int32;
+    return ttcore::DataType::Int32;
   default:
     throw std::runtime_error("Invalid element type");
   }
@@ -113,7 +113,7 @@ getPageLayout(const mlir::tt::ttnn::TTNNLayoutAttr &layout) {
 getCoreRangeSet(const mlir::tt::ttnn::TTNNLayoutAttr &layout) {
   std::set<::tt::tt_metal::CoreRange> coreRangeSet;
   assert(layout.getGrid().getMapping().isEmpty() == false);
-  for (const auto &[loc, size] : utils::toCoreRangeSet(
+  for (const auto &[loc, size] : ttcore::utils::toCoreRangeSet(
            layout.getGrid().getShape(), layout.getGrid().getMapping())) {
     coreRangeSet.insert(::tt::tt_metal::CoreRange(
         CoreCoord(loc[0], loc[1]),
@@ -409,7 +409,7 @@ getLayoutAttrFromTensorSpec(MLIRContext *context,
 
   Type elementType;
   if (tensorSpec.layout() == ::tt::tt_metal::Layout::TILE) {
-    elementType = mlir::tt::TileType::get(
+    elementType = mlir::tt::ttcore::TileType::get(
         context,
         {tensorSpec.page_config().get_tile().get_height(),
          tensorSpec.page_config().get_tile().get_width()},
@@ -425,7 +425,7 @@ getLayoutAttrFromTensorSpec(MLIRContext *context,
       context,
       getTensorMemoryLayout(tensorSpec.memory_config().memory_layout()));
 
-  GridAttr grid = mlir::tt::GridAttr::get(
+  ttcore::GridAttr grid = mlir::tt::ttcore::GridAttr::get(
       context, getLogicalGridShape(tensorSpec.memory_config(), deviceGrid),
       ::mlir::tt::ttnn::optimizer_utils::
           createSingleDeviceVirtualToPhysicalAffineMap(

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -96,7 +96,7 @@ executeConstraintQuery(Callable &callable) {
 template <class Callable>
 llvm::Expected<OpConstraints>
 getOpConstraints(std::string_view name, MLIRContext *context,
-                 GridAttr deviceGrid, Callable &callable) {
+                 ttcore::GridAttr deviceGrid, Callable &callable) {
 
   llvm::Expected<::ttnn::graph::ConstraintQueryResponse> query =
       executeConstraintQuery<Callable>(callable);
@@ -151,7 +151,7 @@ namespace detail {
  * grid size.
  */
 void checkGrid(const ::tt::tt_metal::CoreCoord &computeGridSize,
-               mlir::tt::GridAttr workerGrid) {
+               mlir::tt::ttcore::GridAttr workerGrid) {
   // metal CoreCoord holds x,y
   // GridAttr holds shape {y,x}
   if ((static_cast<size_t>(workerGrid.getShape()[1]) != computeGridSize.x) ||
@@ -212,7 +212,7 @@ getNullableDataType(::mlir::tt::ttnn::TTNNLayoutAttr layout) {
 
 bool isLayoutLegalForTensorShape(llvm::ArrayRef<int64_t> tensorShape,
                                  mlir::tt::ttnn::TTNNLayoutAttr layout,
-                                 GridAttr maxGrid) {
+                                 mlir::tt::ttcore::GridAttr maxGrid) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   // Conversion to TensorSpec may throw if the layout is invalid, in which case
   // we return false.
@@ -252,7 +252,7 @@ createHostBuffer(uint32_t numElements, ::tt::tt_metal::DataType dataType) {
 // Allocate a ttnn tensor with the given shape and data type.
 static ::tt::tt_metal::Tensor
 createMetalHostTensor(llvm::ArrayRef<int64_t> shape,
-                      ::mlir::tt::DataType dataType) {
+                      ::mlir::tt::ttcore::DataType dataType) {
   // Calculate total volume of the tensor
   uint32_t volume = 1;
   for (size_t i = 0; i < shape.size(); i++) {
@@ -400,7 +400,7 @@ getPreparedConv2dWeightsOutputTensor(mlir::tt::ttnn::Conv2dOp *op) {
 
   // Convert back to RankedTensorType
   auto deviceGrid =
-      mlir::tt::lookupDevice(op->getOperation()).getWorkerGrid().getShape();
+      ttcore::lookupDevice(op->getOperation()).getWorkerGrid().getShape();
 
   auto outputLayout = conversion::getLayoutAttrFromTensorSpec(
       op->getContext(), outputTensorSpec.get(), deviceGrid);
@@ -421,7 +421,7 @@ getPreparedConv2dWeightsOutputTensor(mlir::tt::ttnn::Conv2dOp *op) {
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<bool>
-Device::getDeviceConstraints(mlir::tt::GridAttr workerGrid) {
+Device::getDeviceConstraints(mlir::tt::ttcore::GridAttr workerGrid) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   try {
     detail::checkGrid(SingletonDeviceContext::getInstance()
@@ -444,7 +444,7 @@ Device::getDeviceConstraints(mlir::tt::GridAttr workerGrid) {
 template <typename OpSymbol>
 llvm::Expected<OpConstraints>
 getEltwiseUnaryOpConstraints(std::string_view opName, OpSymbol opSymbol,
-                             GridAttr deviceGrid,
+                             ttcore::GridAttr deviceGrid,
                              llvm::ArrayRef<int64_t> inputShape,
                              mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
                              llvm::ArrayRef<int64_t> outputShape,
@@ -506,7 +506,7 @@ getEltwiseUnaryOpRuntime(std::string_view opName, OpSymbol opSymbol,
 template <typename OpSymbol>
 llvm::Expected<OpConstraints>
 getEltwiseBinaryOpConstraints(std::string_view opName, OpSymbol opSymbol,
-                              GridAttr deviceGrid,
+                              ttcore::GridAttr deviceGrid,
                               llvm::ArrayRef<int64_t> inputShapeA,
                               mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
                               llvm::ArrayRef<int64_t> inputShapeB,
@@ -595,7 +595,7 @@ getEltwiseBinaryOpRuntime(std::string_view opName, OpSymbol opSymbol,
 #ifdef TTMLIR_ENABLE_OPMODEL
 template <typename OpSymbol>
 llvm::Expected<OpConstraints> getReductionOpConstraints(
-    std::string_view opName, OpSymbol opSymbol, GridAttr deviceGrid,
+    std::string_view opName, OpSymbol opSymbol, ttcore::GridAttr deviceGrid,
     llvm::ArrayRef<int64_t> inputShape,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
     std::optional<llvm::ArrayRef<int64_t>> dimArg, bool keepDim,
@@ -670,7 +670,7 @@ getReductionOpRuntime(std::string_view opName, OpSymbol opSymbol,
 // ReluOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints>
-ReluOpInterface::getOpConstraints(GridAttr deviceGrid,
+ReluOpInterface::getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
                                   llvm::ArrayRef<int64_t> inputShape,
                                   mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
                                   llvm::ArrayRef<int64_t> outputShape,
@@ -701,7 +701,7 @@ ReluOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 // SinOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints>
-SinOpInterface::getOpConstraints(GridAttr deviceGrid,
+SinOpInterface::getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
                                  llvm::ArrayRef<int64_t> inputShape,
                                  mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
                                  llvm::ArrayRef<int64_t> outputShape,
@@ -732,7 +732,7 @@ SinOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 // CosOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints>
-CosOpInterface::getOpConstraints(GridAttr deviceGrid,
+CosOpInterface::getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
                                  llvm::ArrayRef<int64_t> inputShape,
                                  mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
                                  llvm::ArrayRef<int64_t> outputShape,
@@ -763,7 +763,7 @@ CosOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 // ReciprocalOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> ReciprocalOpInterface::getOpConstraints(
-    GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> outputShape,
     mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
@@ -794,7 +794,7 @@ llvm::Expected<size_t> ReciprocalOpInterface::getOpRuntime(
 // SqrtOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints>
-SqrtOpInterface::getOpConstraints(GridAttr deviceGrid,
+SqrtOpInterface::getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
                                   llvm::ArrayRef<int64_t> inputShape,
                                   mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
                                   llvm::ArrayRef<int64_t> outputShape,
@@ -825,7 +825,7 @@ SqrtOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 // SigmoidOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> SigmoidOpInterface::getOpConstraints(
-    GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> outputShape,
     mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
@@ -897,7 +897,7 @@ SigmoidOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 // AddOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints>
-AddOpInterface::getOpConstraints(GridAttr deviceGrid,
+AddOpInterface::getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
                                  llvm::ArrayRef<int64_t> inputShapeA,
                                  mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
                                  llvm::ArrayRef<int64_t> inputShapeB,
@@ -933,7 +933,7 @@ AddOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
 // SoftmaxOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> SoftmaxOpInterface::getOpConstraints(
-    GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayout, const int dimArg,
     llvm::ArrayRef<int64_t> outputShape,
     mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
@@ -997,7 +997,7 @@ SoftmaxOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 // MeanOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> MeanOpInterface::getOpConstraints(
-    GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
     std::optional<llvm::ArrayRef<int64_t>> dimArg, bool keepDim,
     mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
@@ -1028,7 +1028,7 @@ MeanOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 // SumOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> SumOpInterface::getOpConstraints(
-    GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
     std::optional<llvm::ArrayRef<int64_t>> dimArg, bool keepDim,
     mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
@@ -1059,7 +1059,7 @@ SumOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 // ReshapeOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> ReshapeOpInterface::getOpConstraints(
-    GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> outputShape,
     mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
@@ -1122,7 +1122,7 @@ ReshapeOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 // SliceOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> SliceOpInterface::getOpConstraints(
-    GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> begins,
     llvm::ArrayRef<int64_t> ends, llvm::ArrayRef<int64_t> step,
     llvm::ArrayRef<int64_t> outputShape,
@@ -1205,9 +1205,9 @@ llvm::Expected<size_t> SliceOpInterface::getOpRuntime(
 // TypecastOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> TypecastOpInterface::getOpConstraints(
-    GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout, mlir::tt::DataTypeAttr dtype,
-    llvm::ArrayRef<int64_t> outputShape,
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+    mlir::tt::ttcore::DataTypeAttr dtype, llvm::ArrayRef<int64_t> outputShape,
     mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -1239,7 +1239,7 @@ llvm::Expected<OpConstraints> TypecastOpInterface::getOpConstraints(
 llvm::Expected<size_t>
 TypecastOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                   mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-                                  mlir::tt::DataTypeAttr dtype,
+                                  mlir::tt::ttcore::DataTypeAttr dtype,
                                   llvm::ArrayRef<int64_t> outputShape,
                                   mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
@@ -1271,9 +1271,9 @@ TypecastOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 // ToLayoutOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> ToLayoutOpInterface::getOpConstraints(
-    GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-    std::optional<mlir::tt::DataType> outputDtype,
+    std::optional<mlir::tt::ttcore::DataType> outputDtype,
     mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool passDevicePtr) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -1308,12 +1308,11 @@ llvm::Expected<OpConstraints> ToLayoutOpInterface::getOpConstraints(
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
-llvm::Expected<size_t>
-ToLayoutOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
-                                  mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-                                  std::optional<mlir::tt::DataType> outputDtype,
-                                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
-                                  bool passDevicePtr) {
+llvm::Expected<size_t> ToLayoutOpInterface::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+    std::optional<mlir::tt::ttcore::DataType> outputDtype,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool passDevicePtr) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1350,7 +1349,8 @@ ToLayoutOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 // ConcatOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> ConcatOpInterface::getOpConstraints(
-    GridAttr deviceGrid, std::vector<llvm::ArrayRef<int64_t>> inputShapes,
+    mlir::tt::ttcore::GridAttr deviceGrid,
+    std::vector<llvm::ArrayRef<int64_t>> inputShapes,
     std::vector<mlir::tt::ttnn::TTNNLayoutAttr> inputLayouts, const int dim,
     mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
@@ -1423,7 +1423,7 @@ llvm::Expected<size_t> ConcatOpInterface::getOpRuntime(
 // TransposeOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> TransposeOpInterface::getOpConstraints(
-    GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayout, const int dim0, const int dim1,
     mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
@@ -1484,7 +1484,7 @@ llvm::Expected<size_t> TransposeOpInterface::getOpRuntime(
 // MatmulOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints>
-MatmulOpInterface::getOpConstraints(GridAttr deviceGrid,
+MatmulOpInterface::getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
                                     llvm::ArrayRef<int64_t> inputShapeA,
                                     mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
                                     llvm::ArrayRef<int64_t> inputShapeB,
@@ -1575,7 +1575,7 @@ MatmulOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
 }
 
 llvm::Expected<OpConstraints> MultiplyOpInterface::getOpConstraints(
-    GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
     llvm::ArrayRef<int64_t> inputShapeB,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
@@ -1610,7 +1610,7 @@ MultiplyOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
 // Conv2dOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> Conv2dOpInterface::getOpConstraints(
-    GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> weightShape,
     mlir::tt::ttnn::TTNNLayoutAttr weightLayout,
@@ -1775,7 +1775,7 @@ llvm::Expected<size_t> Conv2dOpInterface::getOpRuntime(
 // ConvTranspose2dOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> ConvTranspose2dOpInterface::getOpConstraints(
-    GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> weightShape,
     mlir::tt::ttnn::TTNNLayoutAttr weightLayout,
@@ -1942,7 +1942,7 @@ llvm::Expected<size_t> ConvTranspose2dOpInterface::getOpRuntime(
 // MaxPool2D
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> MaxPool2DOpInterface::getOpConstraints(
-    GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayout, int32_t batchSize,
     int32_t inputHeight, int32_t inputWidth, int32_t inputChannels,
     llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
@@ -2040,7 +2040,7 @@ llvm::Expected<size_t> MaxPool2DOpInterface::getOpRuntime(
 // ClampScalar
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> ClampScalarOpInterface::getOpConstraints(
-    GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayout, llvm::APFloat min,
     llvm::APFloat max, llvm::ArrayRef<int64_t> outputShape,
     mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
@@ -2113,7 +2113,7 @@ llvm::Expected<size_t> ClampScalarOpInterface::getOpRuntime(
 // Permute
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> PermuteOpInterface::getOpConstraints(
-    GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> permutation, llvm::APFloat padValue,
     llvm::ArrayRef<int64_t> outputShape,
@@ -2191,7 +2191,7 @@ PermuteOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 // Upsample
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> UpsampleOpInterface::getOpConstraints(
-    GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayout, mlir::Attribute scaleFactor,
     llvm::StringRef mode, llvm::ArrayRef<int64_t> outputShape,
     mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
@@ -2288,7 +2288,7 @@ llvm::Expected<size_t> UpsampleOpInterface::getOpRuntime(
 // SubtractOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> SubtractOpInterface::getOpConstraints(
-    GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
     llvm::ArrayRef<int64_t> inputShapeB,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
@@ -2323,7 +2323,7 @@ SubtractOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
 // MaximumOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> MaximumOpInterface::getOpConstraints(
-    GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
     llvm::ArrayRef<int64_t> inputShapeB,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
@@ -2358,7 +2358,7 @@ MaximumOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
 // MinimumOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> MinimumOpInterface::getOpConstraints(
-    GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
     llvm::ArrayRef<int64_t> inputShapeB,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
@@ -2433,7 +2433,7 @@ getEmbeddingOpArgs(::tt::tt_metal::distributed::MeshDevice *device,
 #endif // TTMLIR_ENABLE_OPMODEL
 
 llvm::Expected<OpConstraints> EmbeddingOpInterface::getOpConstraints(
-    GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> weightShape,
     mlir::tt::ttnn::TTNNLayoutAttr weightLayout,

--- a/lib/RegisterAll.cpp
+++ b/lib/RegisterAll.cpp
@@ -45,7 +45,7 @@
 
 void mlir::tt::registerAllDialects(mlir::DialectRegistry &registry) {
   registry.insert<
-      mlir::tt::TTCoreDialect, mlir::tt::ttir::TTIRDialect,
+      mlir::tt::ttcore::TTCoreDialect, mlir::tt::ttir::TTIRDialect,
       mlir::tt::ttnn::TTNNDialect, mlir::tt::ttmetal::TTMetalDialect,
       mlir::tt::ttkernel::TTKernelDialect, mlir::func::FuncDialect,
       mlir::arith::ArithDialect, mlir::ml_program::MLProgramDialect,
@@ -87,8 +87,8 @@ void mlir::tt::registerAllPasses() {
   // unused OPs/operands after conversion.
   mlir::registerPass(mlir::createRemoveDeadValuesPass);
 
-  mlir::tt::registerPasses();
-  mlir::tt::registerTTPopulateArgumentTypes();
+  mlir::tt::ttcore::registerPasses();
+  mlir::tt::ttcore::registerTTPopulateArgumentTypes();
   mlir::tt::ttir::registerPasses();
   mlir::tt::ttnn::registerTTNNOptimizer();
   mlir::tt::ttnn::registerPasses();

--- a/lib/Target/LLVM/LLVMToDynamicLibRegistration.cpp
+++ b/lib/Target/LLVM/LLVMToDynamicLibRegistration.cpp
@@ -23,7 +23,8 @@ void registerLLVMToDynamicLibrary() {
         return translateLLVMToDyLib(op, os);
       },
       [](DialectRegistry &registry) {
-        registry.insert<mlir::tt::TTCoreDialect, mlir::LLVM::LLVMDialect>();
+        registry
+            .insert<mlir::tt::ttcore::TTCoreDialect, mlir::LLVM::LLVMDialect>();
         registerAllToLLVMIRTranslations(registry);
       });
 }

--- a/lib/Target/TTKernel/TTKernelToCppRegistration.cpp
+++ b/lib/Target/TTKernel/TTKernelToCppRegistration.cpp
@@ -25,11 +25,11 @@ void registerTTKernelToCpp() {
         return translateTopLevelKernelsToCpp(mlir::cast<ModuleOp>(op), os);
       },
       [](DialectRegistry &registry) {
-        registry
-            .insert<mlir::tt::ttkernel::TTKernelDialect,
-                    mlir::tt::ttmetal::TTMetalDialect, mlir::tt::TTCoreDialect,
-                    mlir::tt::ttir::TTIRDialect, mlir::emitc::EmitCDialect,
-                    mlir::memref::MemRefDialect, mlir::func::FuncDialect>();
+        registry.insert<mlir::tt::ttkernel::TTKernelDialect,
+                        mlir::tt::ttmetal::TTMetalDialect,
+                        mlir::tt::ttcore::TTCoreDialect,
+                        mlir::tt::ttir::TTIRDialect, mlir::emitc::EmitCDialect,
+                        mlir::memref::MemRefDialect, mlir::func::FuncDialect>();
       });
 }
 

--- a/lib/Target/TTMetal/TTMetalToFlatbufferRegistration.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbufferRegistration.cpp
@@ -26,11 +26,11 @@ void registerTTMetalToFlatbuffer() {
         return translateTTMetalToFlatbuffer(op, os);
       },
       [](DialectRegistry &registry) {
-        registry
-            .insert<mlir::tt::TTCoreDialect, mlir::tt::ttmetal::TTMetalDialect,
-                    mlir::tt::ttkernel::TTKernelDialect,
-                    mlir::emitc::EmitCDialect, mlir::memref::MemRefDialect,
-                    mlir::LLVM::LLVMDialect, mlir::func::FuncDialect>();
+        registry.insert<mlir::tt::ttcore::TTCoreDialect,
+                        mlir::tt::ttmetal::TTMetalDialect,
+                        mlir::tt::ttkernel::TTKernelDialect,
+                        mlir::emitc::EmitCDialect, mlir::memref::MemRefDialect,
+                        mlir::LLVM::LLVMDialect, mlir::func::FuncDialect>();
         registerAllToLLVMIRTranslations(registry);
       });
 }

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -52,7 +52,8 @@ constexpr uint64_t kHostAllocatedSize = 0;
 
 static std::vector<::tt::target::Dim2dRange>
 getTensorValueCoreRangeSet(FlatbufferObjectCache &cache, Value value) {
-  DeviceAttr deviceAttr = lookupDevice(value.getParentBlock()->getParentOp());
+  ttcore::DeviceAttr deviceAttr =
+      ttcore::lookupDevice(value.getParentBlock()->getParentOp());
   assert(deviceAttr);
   RankedTensorType tensorType = mlir::cast<RankedTensorType>(value.getType());
   ttnn::TTNNLayoutAttr layoutAttr =
@@ -64,7 +65,7 @@ getTensorValueCoreRangeSet(FlatbufferObjectCache &cache, Value value) {
 
 static ttnn::MemoryConfigAttr
 getMemoryConfigAttr(::mlir::tt::ttnn::TTNNLayoutAttr layoutAttr,
-                    GridAttr deviceGrid) {
+                    ttcore::GridAttr deviceGrid) {
   MLIRContext *ctx = layoutAttr.getContext();
   ttnn::BufferTypeAttr bufferTypeAttr =
       ttnn::BufferTypeAttr::get(ctx, layoutAttr.getBufferType());
@@ -84,8 +85,8 @@ getMemoryConfigFromTensorTypeIfNeeded(FlatbufferObjectCache &cache,
 
   ::flatbuffers::Offset<::tt::target::ttnn::MemoryConfig> memoryConfig = 0;
   if (isDeviceBufferType(bufferType)) {
-    DeviceAttr deviceAttr =
-        lookupDevice(tensor.getParentBlock()->getParentOp());
+    ttcore::DeviceAttr deviceAttr =
+        ttcore::lookupDevice(tensor.getParentBlock()->getParentOp());
     auto memoryConfigAttr =
         getMemoryConfigAttr(layoutAttr, deviceAttr.getWorkerGrid());
     memoryConfig = toFlatbuffer(cache, memoryConfigAttr);
@@ -109,14 +110,14 @@ getMemoryConfigIfNeeded(FlatbufferObjectCache &cache, OpType op) {
 
 ::flatbuffers::Offset<::tt::target::DeviceRef>
 createDeviceRef(FlatbufferObjectCache &cache, Value device) {
-  auto desc = lookupDevice(device.getParentBlock()->getParentOp());
+  auto desc = ttcore::lookupDevice(device.getParentBlock()->getParentOp());
   auto chipIds = desc.getChipIds();
   return ::tt::target::CreateDeviceRef(*cache.fbb, chipIds[0]);
 }
 
 flatbuffers::Offset<::tt::target::ttnn::TensorDesc>
 tensorTypeToFlatbuffer(FlatbufferObjectCache &cache, Type type,
-                       DeviceAttr deviceAttr) {
+                       ttcore::DeviceAttr deviceAttr) {
   auto tensorType = mlir::cast<RankedTensorType>(type);
   auto shapeInt64 = tensorType.getShape();
   std::vector<int32_t> shape;
@@ -142,7 +143,7 @@ tensorTypeToFlatbuffer(FlatbufferObjectCache &cache, Type type,
 flatbuffers::Offset<::tt::target::ttnn::TensorRef>
 tensorValueToFlatbuffer(FlatbufferObjectCache &cache, Value value,
                         uint64_t size) {
-  auto deviceAttr = lookupDevice(value.getParentBlock()->getParentOp());
+  auto deviceAttr = ttcore::lookupDevice(value.getParentBlock()->getParentOp());
   assert(deviceAttr);
   auto tensorType = mlir::cast<RankedTensorType>(value.getType());
   mlir::Type elementType = tensorType.getElementType();
@@ -172,7 +173,7 @@ createOperation(FlatbufferObjectCache &cache, ::flatbuffers::Offset<OpT> op,
 ::flatbuffers::Offset<::tt::target::ttnn::GetDeviceOp>
 createOp(FlatbufferObjectCache &cache, GetDeviceOp op) {
   auto result = op.getResult();
-  auto desc = lookupDevice(op);
+  auto desc = ttcore::lookupDevice(op);
   auto meshShape = desc.getMeshShape();
   auto meshVolume = ttmlir::utils::volume(meshShape);
   ::tt::target::Dim2d mesh;
@@ -328,7 +329,7 @@ createDistributionStrategy(FlatbufferObjectCache &cache,
 
   auto deviceOp = mlir::cast<GetDeviceOp>(
       getOperandThroughDPSOps(deviceValue).getDefiningOp());
-  auto desc = lookupDevice(deviceOp);
+  auto desc = ttcore::lookupDevice(deviceOp);
   ::llvm::ArrayRef<int64_t> meshShape = desc.getMeshShape();
   numShards = ttmlir::utils::volume(meshShape);
 
@@ -708,16 +709,18 @@ createOp(FlatbufferObjectCache &cache, MeshShardOp op) {
   auto output = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
                                   kHostAllocatedSize);
   auto device = getOperandThroughDPSOps(op.getDevice());
-  const mlir::tt::MeshShardDirection shardDirection = op.getShardDirection();
-  const mlir::tt::MeshShardType shardType = op.getShardType();
+  const mlir::tt::ttcore::MeshShardDirection shardDirection =
+      op.getShardDirection();
+  const mlir::tt::ttcore::MeshShardType shardType = op.getShardType();
   llvm::ArrayRef<int64_t> shardShape = op.getShardShape();
   llvm::ArrayRef<int64_t> shardDims = op.getShardDims();
 
   ::tt::target::ttnn::MeshShardDirection meshShardDirection;
-  if (shardDirection == mlir::tt::MeshShardDirection::FullToShard) {
+  if (shardDirection == mlir::tt::ttcore::MeshShardDirection::FullToShard) {
     meshShardDirection =
         ::tt::target::ttnn::MeshShardDirection::FullToShardShape;
-  } else if (shardDirection == mlir::tt::MeshShardDirection::ShardToFull) {
+  } else if (shardDirection ==
+             mlir::tt::ttcore::MeshShardDirection::ShardToFull) {
     meshShardDirection =
         ::tt::target::ttnn::MeshShardDirection::ShardToFullShape;
   } else {
@@ -725,11 +728,11 @@ createOp(FlatbufferObjectCache &cache, MeshShardOp op) {
   }
 
   ::tt::target::ttnn::MeshShardType meshShardType;
-  if (shardType == mlir::tt::MeshShardType::Replicate) {
+  if (shardType == mlir::tt::ttcore::MeshShardType::Replicate) {
     meshShardType = ::tt::target::ttnn::MeshShardType::Replicate;
-  } else if (shardType == mlir::tt::MeshShardType::Devices) {
+  } else if (shardType == mlir::tt::ttcore::MeshShardType::Devices) {
     meshShardType = ::tt::target::ttnn::MeshShardType::Devices;
-  } else if (shardType == mlir::tt::MeshShardType::Identity) {
+  } else if (shardType == mlir::tt::ttcore::MeshShardType::Identity) {
     meshShardType = ::tt::target::ttnn::MeshShardType::Identity;
   } else {
     llvm_unreachable("unhandled mesh_shard type");
@@ -1611,7 +1614,7 @@ createDeallocateOp(FlatbufferObjectCache &cache, DeallocateOp op) {
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::LoadCachedOp>
-createOp(FlatbufferObjectCache &cache, tt::LoadCachedOp op,
+createOp(FlatbufferObjectCache &cache, ttcore::LoadCachedOp op,
          const llvm::StringMap<uint32_t> &programIndexMap) {
   std::vector<::flatbuffers::Offset<::tt::target::ttnn::TensorRef>> ins;
   for (auto input : op.getInputs()) {
@@ -2106,7 +2109,7 @@ emitTTNNOperation(FlatbufferObjectCache &cache, Operation *op,
     return createOperation(cache, createCpuOp(cache, callOp, 0), debugString,
                            locInfo);
   }
-  if (auto loadCachedOp = dyn_cast<tt::LoadCachedOp>(op); loadCachedOp) {
+  if (auto loadCachedOp = dyn_cast<ttcore::LoadCachedOp>(op); loadCachedOp) {
     return createOperation(cache,
                            createOp(cache, loadCachedOp, programIndexMap),
                            debugString, locInfo);
@@ -2130,11 +2133,12 @@ std::shared_ptr<void> ttnnToFlatbuffer(
   // DeviceModule for most conversions.
   ModuleOp module = rootModule;
   if (auto deviceModule =
-          mlir::tt::utils::findOpAtTopLevel<tt::DeviceModuleOp>(module)) {
+          mlir::tt::utils::findOpAtTopLevel<ttcore::DeviceModuleOp>(module)) {
     module = dyn_cast_if_present<mlir::ModuleOp>(
         deviceModule.getBodyRegion().front().front());
-    assert(module && "Found tt::DeviceModuleOp but it didn't contain a single "
-                     "mlir::ModuleOp!");
+    assert(module &&
+           "Found ttcore::DeviceModuleOp but it didn't contain a single "
+           "mlir::ModuleOp!");
   }
 
   ::flatbuffers::FlatBufferBuilder fbb;
@@ -2145,8 +2149,8 @@ std::shared_ptr<void> ttnnToFlatbuffer(
                                       ttmlirVersion.patch);
 
   auto systemDesc =
-      toFlatbuffer(cache, mlir::cast<tt::SystemDescAttr>(
-                              module->getAttr(tt::SystemDescAttr::name)));
+      toFlatbuffer(cache, mlir::cast<ttcore::SystemDescAttr>(
+                              module->getAttr(ttcore::SystemDescAttr::name)));
 
   flatbuffers::Offset<::tt::target::DebugInfo> debugInfo =
       debugInfoToFlatbuffer(fbb, "ttnn", rootModule, goldenMap, moduleCache);
@@ -2156,7 +2160,7 @@ std::shared_ptr<void> ttnnToFlatbuffer(
   // vector here in case in the future we support more complex arrangements.
   std::vector<::flatbuffers::Offset<::tt::target::DynamicLib>> dylibs;
   if (auto cpuModule =
-          mlir::tt::utils::findOpAtTopLevel<tt::CPUModuleOp>(rootModule);
+          mlir::tt::utils::findOpAtTopLevel<ttcore::CPUModuleOp>(rootModule);
       cpuModule != nullptr) {
     mlir::ModuleOp cpuNestedModule = dyn_cast_if_present<mlir::ModuleOp>(
         cpuModule.getBodyRegion().front().front());
@@ -2212,7 +2216,7 @@ std::shared_ptr<void> ttnnToFlatbuffer(
               cache, func, emitTTNNOperation, tensorValueToFlatbuffer,
               programIdxMap);
 
-      DeviceAttr deviceAttr = lookupDevice(func);
+      ttcore::DeviceAttr deviceAttr = ttcore::lookupDevice(func);
 
       ::tt::target::Dim2d meshShape = deviceToFlatbufferMeshShape(deviceAttr);
 

--- a/lib/Target/TTNN/TTNNToFlatbufferRegistration.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbufferRegistration.cpp
@@ -27,7 +27,7 @@ void registerTTNNToFlatbuffer() {
       },
       [](DialectRegistry &registry) {
         // clang-format off
-        registry.insert<mlir::tt::TTCoreDialect,
+        registry.insert<mlir::tt::ttcore::TTCoreDialect,
                         mlir::tt::ttnn::TTNNDialect,
                         mlir::tt::ttkernel::TTKernelDialect,
                         mlir::func::FuncDialect,

--- a/lib/Transforms/ConstEvalHoist.cpp
+++ b/lib/Transforms/ConstEvalHoist.cpp
@@ -111,7 +111,7 @@ private:
       return;
     }
 
-    constParams = mlir::tt::getConstsAndParams(*funcOp);
+    constParams = mlir::tt::ttcore::getConstsAndParams(*funcOp);
   }
 
   // Recurse up hierarchy to find root of given subset.
@@ -292,12 +292,13 @@ private:
   // Helper functions
   bool isCreationOp(mlir::Operation *op) {
     assert(op != nullptr);
-    return op->hasTrait<mlir::tt::Trait::TTCoreCreationOpTrait>();
+    return op->hasTrait<mlir::tt::ttcore::Trait::TTCoreCreationOpTrait>();
   }
 
   bool isSharedOp(mlir::Operation *op) {
     assert(op != nullptr);
-    return op->hasTrait<mlir::tt::Trait::TTCoreDuplicateConstEvalTrait>();
+    return op
+        ->hasTrait<mlir::tt::ttcore::Trait::TTCoreDuplicateConstEvalTrait>();
   }
 
 private:
@@ -342,7 +343,8 @@ static void deduplicateSharedOps(func::FuncOp funcOp) {
   SmallVector<Operation *, 8> opsToErase;
 
   funcOp.walk([&](Operation *op) {
-    if (op->hasTrait<mlir::tt::Trait::TTCoreDuplicateConstEvalTrait>()) {
+    if (op->hasTrait<
+            mlir::tt::ttcore::Trait::TTCoreDuplicateConstEvalTrait>()) {
       // Create a key based on operation name and all attributes
       StringRef opName = op->getName().getStringRef();
       DictionaryAttr attrs = op->getAttrDictionary();
@@ -379,7 +381,7 @@ static void deduplicateSharedOps(func::FuncOp funcOp) {
 
 // Helper to inline a const-eval function.
 static void inlineConstEvalFunction(mlir::func::FuncOp funcOp,
-                                    mlir::tt::LoadCachedOp callOp,
+                                    mlir::tt::ttcore::LoadCachedOp callOp,
                                     OpBuilder &builder) {
   builder.setInsertionPoint(callOp);
 
@@ -419,7 +421,7 @@ static void undoConstEvalImpl(mlir::ModuleOp module,
   OpBuilder builder(context);
 
   // Find all const-eval functions and their callers
-  llvm::DenseMap<mlir::func::FuncOp, mlir::tt::LoadCachedOp> funcToCall;
+  llvm::DenseMap<mlir::func::FuncOp, mlir::tt::ttcore::LoadCachedOp> funcToCall;
   llvm::SmallVector<mlir::func::FuncOp, 4> constEvalFuncs;
   llvm::SmallVector<mlir::func::FuncOp, 4> parentFuncs;
 
@@ -431,7 +433,7 @@ static void undoConstEvalImpl(mlir::ModuleOp module,
   });
 
   // Find all calls to const-eval functions
-  module.walk([&](mlir::tt::LoadCachedOp loadOp) {
+  module.walk([&](mlir::tt::ttcore::LoadCachedOp loadOp) {
     mlir::StringRef calleeName = loadOp.getCallee();
     auto funcOp = module.lookupSymbol<mlir::func::FuncOp>(calleeName);
     assert(funcOp && ttmlir::utils::isConstEvalFunc(funcOp));
@@ -444,7 +446,7 @@ static void undoConstEvalImpl(mlir::ModuleOp module,
     auto callIt = funcToCall.find(funcOp);
     assert(callIt != funcToCall.end() &&
            "Found const-eval func that was never called!");
-    mlir::tt::LoadCachedOp &callOp = callIt->second;
+    mlir::tt::ttcore::LoadCachedOp &callOp = callIt->second;
     // Get the parent function of this call
     mlir::func::FuncOp parentFunc =
         callOp->getParentOfType<mlir::func::FuncOp>();
@@ -630,7 +632,7 @@ private:
         mlir::SymbolRefAttr::get(builder.getContext(), newFuncName);
 
     // Create the LoadCachedOp with the correct argument order
-    auto callOp = builder.create<tt::LoadCachedOp>(
+    auto callOp = builder.create<ttcore::LoadCachedOp>(
         originalFunc.getLoc(), outputTypes, calleeAttr, ValueRange(inputs));
 
     // Replace uses of original outputs with call results.

--- a/python/OptimizerOverrides.cpp
+++ b/python/OptimizerOverrides.cpp
@@ -100,20 +100,20 @@ void populateOptimizerOverridesModule(nb::module_ &m) {
       .value("WidthSharded", mlir::tt::ttnn::TensorMemoryLayout::WidthSharded)
       .value("BlockSharded", mlir::tt::ttnn::TensorMemoryLayout::BlockSharded);
 
-  nb::enum_<mlir::tt::DataType>(m, "DataType")
-      .value("Float32", mlir::tt::DataType::Float32)
-      .value("Float16", mlir::tt::DataType::Float16)
-      .value("BFloat16", mlir::tt::DataType::BFloat16)
-      .value("BFP_Float8", mlir::tt::DataType::BFP_Float8)
-      .value("BFP_BFloat8", mlir::tt::DataType::BFP_BFloat8)
-      .value("BFP_Float4", mlir::tt::DataType::BFP_Float4)
-      .value("BFP_BFloat4", mlir::tt::DataType::BFP_BFloat4)
-      .value("BFP_Float2", mlir::tt::DataType::BFP_Float2)
-      .value("BFP_BFloat2", mlir::tt::DataType::BFP_BFloat2)
-      .value("UInt32", mlir::tt::DataType::UInt32)
-      .value("UInt16", mlir::tt::DataType::UInt16)
-      .value("UInt8", mlir::tt::DataType::UInt8)
-      .value("Int32", mlir::tt::DataType::Int32);
+  nb::enum_<mlir::tt::ttcore::DataType>(m, "DataType")
+      .value("Float32", mlir::tt::ttcore::DataType::Float32)
+      .value("Float16", mlir::tt::ttcore::DataType::Float16)
+      .value("BFloat16", mlir::tt::ttcore::DataType::BFloat16)
+      .value("BFP_Float8", mlir::tt::ttcore::DataType::BFP_Float8)
+      .value("BFP_BFloat8", mlir::tt::ttcore::DataType::BFP_BFloat8)
+      .value("BFP_Float4", mlir::tt::ttcore::DataType::BFP_Float4)
+      .value("BFP_BFloat4", mlir::tt::ttcore::DataType::BFP_BFloat4)
+      .value("BFP_Float2", mlir::tt::ttcore::DataType::BFP_Float2)
+      .value("BFP_BFloat2", mlir::tt::ttcore::DataType::BFP_BFloat2)
+      .value("UInt32", mlir::tt::ttcore::DataType::UInt32)
+      .value("UInt16", mlir::tt::ttcore::DataType::UInt16)
+      .value("UInt8", mlir::tt::ttcore::DataType::UInt8)
+      .value("Int32", mlir::tt::ttcore::DataType::Int32);
 
   nb::class_<mlir::tt::ttnn::InsertMemReconfigParams>(m,
                                                       "InsertMemReconfigParams")
@@ -196,7 +196,8 @@ void populateOptimizerOverridesModule(nb::module_ &m) {
       .def("set_data_type_from_str",
            [](mlir::tt::ttnn::OutputLayoutOverrideParams &obj,
               const std::string &value) {
-             if (auto dataType_ = mlir::tt::DataTypeStringToEnum(value)) {
+             if (auto dataType_ =
+                     mlir::tt::ttcore::DataTypeStringToEnum(value)) {
                obj.dataType = dataType_;
              } else {
                throw std::invalid_argument("Invalid data type: " + value);
@@ -253,7 +254,7 @@ void populateOptimizerOverridesModule(nb::module_ &m) {
       .def("set_dtype_from_str",
            [](mlir::tt::ttnn::Conv2dConfigOverrideParams &obj,
               const std::string &value) {
-             if (auto dtype_ = mlir::tt::DataTypeStringToEnum(value)) {
+             if (auto dtype_ = mlir::tt::ttcore::DataTypeStringToEnum(value)) {
                obj.dtype = dtype_;
              } else {
                throw std::invalid_argument("Invalid dtype: " + value);
@@ -262,7 +263,8 @@ void populateOptimizerOverridesModule(nb::module_ &m) {
       .def("set_weights_dtype_from_str",
            [](mlir::tt::ttnn::Conv2dConfigOverrideParams &obj,
               const std::string &value) {
-             if (auto weightsDtype_ = mlir::tt::DataTypeStringToEnum(value)) {
+             if (auto weightsDtype_ =
+                     mlir::tt::ttcore::DataTypeStringToEnum(value)) {
                obj.weightsDtype = weightsDtype_;
              } else {
                throw std::invalid_argument("Invalid weights dtype: " + value);

--- a/python/Passes.cpp
+++ b/python/Passes.cpp
@@ -52,7 +52,7 @@ void populatePassesModule(nb::module_ &m) {
                                      passWithOptions);
           }
         } else {
-          pm.addPass(mlir::tt::createTTPopulateArgumentTypes());
+          pm.addPass(mlir::tt::ttcore::createTTPopulateArgumentTypes());
         }
 
         if (mlir::failed(pm.run(moduleOp))) {

--- a/python/TTModule.cpp
+++ b/python/TTModule.cpp
@@ -16,18 +16,20 @@
 
 namespace mlir::ttmlir::python {
 void populateTTModule(nb::module_ &m) {
-  tt_attribute_class<tt::MetalLayoutAttr>(m, "MetalLayoutAttr")
-      .def_static("get",
-                  [](MlirContext ctx, std::vector<int64_t> logicalShape,
-                     uint32_t oobValValue, uint32_t memorySpaceValue) {
-                    return wrap(tt::MetalLayoutAttr::get(
-                        unwrap(ctx), ArrayRef<int64_t>(logicalShape),
-                        logicalShape.size(),
-                        static_cast<tt::OOBVal>(oobValValue),
-                        static_cast<tt::MemorySpace>(memorySpaceValue)));
-                  })
+  tt_attribute_class<tt::ttcore::MetalLayoutAttr>(m, "MetalLayoutAttr")
+      .def_static(
+          "get",
+          [](MlirContext ctx, std::vector<int64_t> logicalShape,
+             uint32_t oobValValue, uint32_t memorySpaceValue) {
+            return wrap(tt::ttcore::MetalLayoutAttr::get(
+                unwrap(ctx), ArrayRef<int64_t>(logicalShape),
+                logicalShape.size(),
+                static_cast<tt::ttcore::OOBVal>(oobValValue),
+                static_cast<tt::ttcore::MemorySpace>(memorySpaceValue)));
+          })
       .def("getLayout",
-           [](MlirType &type) -> std::variant<tt::MetalLayoutAttr, nb::object> {
+           [](MlirType &type)
+               -> std::variant<tt::ttcore::MetalLayoutAttr, nb::object> {
              // Make sure that this is operating on a RankedTensorType object
              if (!isa<RankedTensorType>(unwrap(type))) {
                return nb::none();
@@ -38,77 +40,79 @@ void populateTTModule(nb::module_ &m) {
              if (!tensor.getEncoding()) {
                return nb::none();
              }
-             tt::MetalLayoutAttr layout =
-                 mlir::cast<tt::MetalLayoutAttr>(tensor.getEncoding());
+             tt::ttcore::MetalLayoutAttr layout =
+                 mlir::cast<tt::ttcore::MetalLayoutAttr>(tensor.getEncoding());
              return layout;
            })
       .def("wrapped",
-           [](const tt::MetalLayoutAttr &self) { return wrap(self); })
+           [](const tt::ttcore::MetalLayoutAttr &self) { return wrap(self); })
       // Properties
       .def_prop_ro("logical_shape",
-                   [](const tt::MetalLayoutAttr &self) {
+                   [](const tt::ttcore::MetalLayoutAttr &self) {
                      auto shape = self.getLogicalShape();
                      return std::vector<int64_t>(shape.begin(), shape.end());
                    })
       .def_prop_ro("dim_alignments",
-                   [](const tt::MetalLayoutAttr &self)
+                   [](const tt::ttcore::MetalLayoutAttr &self)
                        -> std::optional<std::vector<int64_t>> {
                      if (auto align = self.getDimAlignments(); !align.empty()) {
                        return std::vector<int64_t>(align.begin(), align.end());
                      }
                      return std::nullopt;
                    })
-      .def_prop_ro("oobval", &tt::MetalLayoutAttr::getOobVal)
+      .def_prop_ro("oobval", &tt::ttcore::MetalLayoutAttr::getOobVal)
       .def_prop_ro("oobval_as_int",
-                   [](tt::MetalLayoutAttr la) {
+                   [](tt::ttcore::MetalLayoutAttr la) {
                      return static_cast<uint32_t>(la.getOobVal());
                    })
-      .def_prop_ro("memory_space", &tt::MetalLayoutAttr::getMemorySpace)
-      .def_prop_ro("memory_space_as_int", [](tt::MetalLayoutAttr la) {
+      .def_prop_ro("memory_space", &tt::ttcore::MetalLayoutAttr::getMemorySpace)
+      .def_prop_ro("memory_space_as_int", [](tt::ttcore::MetalLayoutAttr la) {
         return static_cast<uint32_t>(la.getMemorySpace());
       });
 
-  tt_attribute_class<tt::GridAttr>(m, "GridAttr")
+  tt_attribute_class<tt::ttcore::GridAttr>(m, "GridAttr")
       .def_static("get",
                   [](MlirContext ctx, std::vector<int64_t> shape) {
-                    return wrap(tt::GridAttr::get(unwrap(ctx), shape));
+                    return wrap(tt::ttcore::GridAttr::get(unwrap(ctx), shape));
                   })
-      .def_prop_ro("shape",
-                   [](const tt::GridAttr &ga) { return ga.getShape().vec(); });
-
-  tt_attribute_class<tt::ChipCapabilityAttr>(m, "ChipCapabilityAttr")
-      .def_static(
-          "get",
-          [](MlirContext ctx, uint32_t chipCapability) {
-            return wrap(tt::ChipCapabilityAttr::get(
-                unwrap(ctx), static_cast<tt::ChipCapability>(chipCapability)));
-          })
-      .def_prop_ro("capability_as_int", [](tt::ChipCapabilityAttr self) {
-        return static_cast<uint32_t>(self.getValue());
+      .def_prop_ro("shape", [](const tt::ttcore::GridAttr &ga) {
+        return ga.getShape().vec();
       });
 
-  tt_attribute_class<tt::ArchAttr>(m, "ArchAttr")
+  tt_attribute_class<tt::ttcore::ChipCapabilityAttr>(m, "ChipCapabilityAttr")
+      .def_static("get",
+                  [](MlirContext ctx, uint32_t chipCapability) {
+                    return wrap(tt::ttcore::ChipCapabilityAttr::get(
+                        unwrap(ctx), static_cast<tt::ttcore::ChipCapability>(
+                                         chipCapability)));
+                  })
+      .def_prop_ro("capability_as_int",
+                   [](tt::ttcore::ChipCapabilityAttr self) {
+                     return static_cast<uint32_t>(self.getValue());
+                   });
+
+  tt_attribute_class<tt::ttcore::ArchAttr>(m, "ArchAttr")
       .def_static("get",
                   [](MlirContext ctx, uint32_t arch) {
-                    return wrap(tt::ArchAttr::get(unwrap(ctx),
-                                                  static_cast<tt::Arch>(arch)));
+                    return wrap(tt::ttcore::ArchAttr::get(
+                        unwrap(ctx), static_cast<tt::ttcore::Arch>(arch)));
                   })
-      .def_prop_ro("arch_as_int", [](tt::ArchAttr self) {
+      .def_prop_ro("arch_as_int", [](tt::ttcore::ArchAttr self) {
         return static_cast<uint32_t>(self.getValue());
       });
 
-  tt_attribute_class<tt::DataTypeAttr>(m, "DataTypeAttr")
-      .def_static(
-          "get",
-          [](MlirContext ctx, uint16_t *supportedDataTypes) {
-            return wrap(tt::DataTypeAttr::get(
-                unwrap(ctx), static_cast<tt::DataType>(*supportedDataTypes)));
-          })
-      .def_prop_ro("data_type_as_int", [](tt::DataTypeAttr self) {
+  tt_attribute_class<tt::ttcore::DataTypeAttr>(m, "DataTypeAttr")
+      .def_static("get",
+                  [](MlirContext ctx, uint16_t *supportedDataTypes) {
+                    return wrap(tt::ttcore::DataTypeAttr::get(
+                        unwrap(ctx), static_cast<tt::ttcore::DataType>(
+                                         *supportedDataTypes)));
+                  })
+      .def_prop_ro("data_type_as_int", [](tt::ttcore::DataTypeAttr self) {
         return static_cast<uint16_t>(self.getValue());
       });
 
-  tt_attribute_class<tt::ChipDescAttr>(m, "ChipDescAttr")
+  tt_attribute_class<tt::ttcore::ChipDescAttr>(m, "ChipDescAttr")
       .def_static(
           "get",
           [](MlirContext ctx, MlirAttribute arch, std::vector<int64_t> grid,
@@ -121,130 +125,142 @@ void populateTTModule(nb::module_ &m) {
              MlirAttribute supportedDataTypes, MlirAttribute supportedTileSizes,
              unsigned dstRegisterSizeTiles, unsigned numCBs,
              unsigned numComputeThreads, unsigned numDatamovementThreads) {
-            return wrap(tt::ChipDescAttr::get(
-                unwrap(ctx), mlir::cast<tt::ArchAttr>(unwrap(arch)), grid,
-                coordTranslationOffsets, l1Size, numDramChannels,
+            return wrap(tt::ttcore::ChipDescAttr::get(
+                unwrap(ctx), mlir::cast<tt::ttcore::ArchAttr>(unwrap(arch)),
+                grid, coordTranslationOffsets, l1Size, numDramChannels,
                 dramChannelSize, nocL1AddressAlignBytes, pcieAddressAlignBytes,
                 nocDRAMAddressAlignBytes, l1UnreservedBase,
                 eriscL1UnreservedBase, dramUnreservedBase, dramUnreservedEnd,
-                mlir::dyn_cast<tt::ChipPhysicalHelperCoresAttr>(
+                mlir::dyn_cast<tt::ttcore::ChipPhysicalHelperCoresAttr>(
                     unwrap(chipPhysicalHelperCores)),
-                mlir::cast<tt::DataTypeAttr>(unwrap(supportedDataTypes)),
-                mlir::cast<tt::TileSizeAttr>(unwrap(supportedTileSizes)),
+                mlir::cast<tt::ttcore::DataTypeAttr>(
+                    unwrap(supportedDataTypes)),
+                mlir::cast<tt::ttcore::TileSizeAttr>(
+                    unwrap(supportedTileSizes)),
                 dstRegisterSizeTiles, numCBs, numComputeThreads,
                 numDatamovementThreads));
           })
-      .def_prop_ro("usable_l1_size", &tt::ChipDescAttr::getUsableL1Size)
+      .def_prop_ro("usable_l1_size", &tt::ttcore::ChipDescAttr::getUsableL1Size)
       .def_prop_ro("usable_dram_channel_size",
-                   &tt::ChipDescAttr::getUsableDramChannelSize)
-      .def_prop_ro("arch", &tt::ChipDescAttr::getArch)
-      .def_prop_ro("grid",
-                   [](tt::ChipDescAttr self) { return self.getGrid().vec(); })
+                   &tt::ttcore::ChipDescAttr::getUsableDramChannelSize)
+      .def_prop_ro("arch", &tt::ttcore::ChipDescAttr::getArch)
+      .def_prop_ro(
+          "grid",
+          [](tt::ttcore::ChipDescAttr self) { return self.getGrid().vec(); })
       .def_prop_ro("coord_translation_offsets",
-                   [](tt::ChipDescAttr self) {
+                   [](tt::ttcore::ChipDescAttr self) {
                      return self.getCoordTranslationOffsets().vec();
                    })
-      .def_prop_ro("l1_size", &tt::ChipDescAttr::getL1Size)
-      .def_prop_ro("num_dram_channels", &tt::ChipDescAttr::getNumDramChannels)
-      .def_prop_ro("dram_channel_size", &tt::ChipDescAttr::getDramChannelSize)
+      .def_prop_ro("l1_size", &tt::ttcore::ChipDescAttr::getL1Size)
+      .def_prop_ro("num_dram_channels",
+                   &tt::ttcore::ChipDescAttr::getNumDramChannels)
+      .def_prop_ro("dram_channel_size",
+                   &tt::ttcore::ChipDescAttr::getDramChannelSize)
       .def_prop_ro("noc_l1_address_align_bytes",
-                   &tt::ChipDescAttr::getNocL1AddressAlignBytes)
+                   &tt::ttcore::ChipDescAttr::getNocL1AddressAlignBytes)
       .def_prop_ro("pcie_address_align_bytes",
-                   &tt::ChipDescAttr::getPcieAddressAlignBytes)
+                   &tt::ttcore::ChipDescAttr::getPcieAddressAlignBytes)
       .def_prop_ro("noc_dram_address_align_bytes",
-                   &tt::ChipDescAttr::getNocDRAMAddressAlignBytes)
-      .def_prop_ro("l1_unreserved_base", &tt::ChipDescAttr::getL1UnreservedBase)
+                   &tt::ttcore::ChipDescAttr::getNocDRAMAddressAlignBytes)
+      .def_prop_ro("l1_unreserved_base",
+                   &tt::ttcore::ChipDescAttr::getL1UnreservedBase)
       .def_prop_ro("erisc_l1_unreserved_base",
-                   &tt::ChipDescAttr::getEriscL1UnreservedBase)
+                   &tt::ttcore::ChipDescAttr::getEriscL1UnreservedBase)
       .def_prop_ro("dram_unreserved_base",
-                   &tt::ChipDescAttr::getDramUnreservedBase)
+                   &tt::ttcore::ChipDescAttr::getDramUnreservedBase)
       .def_prop_ro("dram_unreserved_end",
-                   &tt::ChipDescAttr::getDramUnreservedEnd)
+                   &tt::ttcore::ChipDescAttr::getDramUnreservedEnd)
       .def_prop_ro("chip_physical_helper_cores",
-                   &tt::ChipDescAttr::getChipPhysicalHelperCores)
+                   &tt::ttcore::ChipDescAttr::getChipPhysicalHelperCores)
       .def_prop_ro("supported_data_types",
-                   [](tt::ChipDescAttr self) {
+                   [](tt::ttcore::ChipDescAttr self) {
                      return self.getSupportedDataTypes().vec();
                    })
       .def_prop_ro("supported_tile_sizes",
-                   [](tt::ChipDescAttr self) {
+                   [](tt::ttcore::ChipDescAttr self) {
                      return self.getSupportedTileSizes().vec();
                    })
-      .def_prop_ro("num_cbs", &tt::ChipDescAttr::getNumCBs);
+      .def_prop_ro("num_cbs", &tt::ttcore::ChipDescAttr::getNumCBs);
 
-  tt_attribute_class<tt::TileSizeAttr>(m, "TileSizeAttr")
+  tt_attribute_class<tt::ttcore::TileSizeAttr>(m, "TileSizeAttr")
       .def_static("get",
                   [](MlirContext ctx, int64_t y, int64_t x) {
-                    return wrap(tt::TileSizeAttr::get(unwrap(ctx), y, x));
+                    return wrap(
+                        tt::ttcore::TileSizeAttr::get(unwrap(ctx), y, x));
                   })
-      .def_prop_ro("y", &tt::TileSizeAttr::getY)
-      .def_prop_ro("x", &tt::TileSizeAttr::getX);
+      .def_prop_ro("y", &tt::ttcore::TileSizeAttr::getY)
+      .def_prop_ro("x", &tt::ttcore::TileSizeAttr::getX);
 
-  tt_attribute_class<tt::ChipPhysicalHelperCoresAttr>(
+  tt_attribute_class<tt::ttcore::ChipPhysicalHelperCoresAttr>(
       m, "ChipPhysicalHelperCoresAttr")
       .def_static("get",
-                  [](MlirContext ctx, std::vector<tt::CoreCoordAttr> dram,
-                     std::vector<tt::CoreCoordAttr> eth,
-                     std::vector<tt::CoreCoordAttr> eth_inactive) {
-                    return wrap(tt::ChipPhysicalHelperCoresAttr::get(
+                  [](MlirContext ctx,
+                     std::vector<tt::ttcore::CoreCoordAttr> dram,
+                     std::vector<tt::ttcore::CoreCoordAttr> eth,
+                     std::vector<tt::ttcore::CoreCoordAttr> eth_inactive) {
+                    return wrap(tt::ttcore::ChipPhysicalHelperCoresAttr::get(
                         unwrap(ctx), dram, eth, eth_inactive));
                   })
       .def_prop_ro("dram",
-                   [](tt::ChipPhysicalHelperCoresAttr self) {
+                   [](tt::ttcore::ChipPhysicalHelperCoresAttr self) {
                      return self.getDram().vec();
                    })
       .def_prop_ro("eth",
-                   [](tt::ChipPhysicalHelperCoresAttr self) {
+                   [](tt::ttcore::ChipPhysicalHelperCoresAttr self) {
                      return self.getEth().vec();
                    })
-      .def_prop_ro("eth_inactive", [](tt::ChipPhysicalHelperCoresAttr self) {
-        return self.getEthInactive().vec();
-      });
+      .def_prop_ro("eth_inactive",
+                   [](tt::ttcore::ChipPhysicalHelperCoresAttr self) {
+                     return self.getEthInactive().vec();
+                   });
 
-  tt_attribute_class<tt::CoreCoordAttr>(m, "CoreCoordAttr")
+  tt_attribute_class<tt::ttcore::CoreCoordAttr>(m, "CoreCoordAttr")
       .def_static("get",
                   [](MlirContext ctx, int64_t y, int64_t x) {
-                    return wrap(tt::CoreCoordAttr::get(unwrap(ctx), y, x));
+                    return wrap(
+                        tt::ttcore::CoreCoordAttr::get(unwrap(ctx), y, x));
                   })
-      .def_prop_ro("y", &tt::CoreCoordAttr::getY)
-      .def_prop_ro("x", &tt::CoreCoordAttr::getX);
+      .def_prop_ro("y", &tt::ttcore::CoreCoordAttr::getY)
+      .def_prop_ro("x", &tt::ttcore::CoreCoordAttr::getX);
 
-  tt_attribute_class<tt::ChipCoordAttr>(m, "ChipCoordAttr")
+  tt_attribute_class<tt::ttcore::ChipCoordAttr>(m, "ChipCoordAttr")
       .def_static("get",
                   [](MlirContext ctx, unsigned rack, unsigned shelf, unsigned y,
                      unsigned x) {
-                    return wrap(
-                        tt::ChipCoordAttr::get(unwrap(ctx), rack, shelf, y, x));
+                    return wrap(tt::ttcore::ChipCoordAttr::get(
+                        unwrap(ctx), rack, shelf, y, x));
                   })
-      .def_prop_ro("rack", &tt::ChipCoordAttr::getRack)
-      .def_prop_ro("shelf", &tt::ChipCoordAttr::getShelf)
-      .def_prop_ro("y", &tt::ChipCoordAttr::getY)
-      .def_prop_ro("x", &tt::ChipCoordAttr::getX);
+      .def_prop_ro("rack", &tt::ttcore::ChipCoordAttr::getRack)
+      .def_prop_ro("shelf", &tt::ttcore::ChipCoordAttr::getShelf)
+      .def_prop_ro("y", &tt::ttcore::ChipCoordAttr::getY)
+      .def_prop_ro("x", &tt::ttcore::ChipCoordAttr::getX);
 
-  tt_attribute_class<tt::ChipChannelAttr>(m, "ChipChannelAttr")
-      .def_static(
-          "get",
-          [](MlirContext ctx, unsigned deviceId0,
-             std::vector<int64_t> ethernetCoreCoord0, unsigned deviceId1,
-             std::vector<int64_t> ethernetCoreCoord1) {
-            return wrap(tt::ChipChannelAttr::get(unwrap(ctx), deviceId0,
-                                                 ethernetCoreCoord0, deviceId1,
-                                                 ethernetCoreCoord1));
-          })
-      .def_prop_ro("device_id0", &tt::ChipChannelAttr::getDeviceId0)
+  tt_attribute_class<tt::ttcore::ChipChannelAttr>(m, "ChipChannelAttr")
+      .def_static("get",
+                  [](MlirContext ctx, unsigned deviceId0,
+                     std::vector<int64_t> ethernetCoreCoord0,
+                     unsigned deviceId1,
+                     std::vector<int64_t> ethernetCoreCoord1) {
+                    return wrap(tt::ttcore::ChipChannelAttr::get(
+                        unwrap(ctx), deviceId0, ethernetCoreCoord0, deviceId1,
+                        ethernetCoreCoord1));
+                  })
+      .def_prop_ro("device_id0", &tt::ttcore::ChipChannelAttr::getDeviceId0)
       .def_prop_ro("ethernet_core_coord0",
-                   [](tt::ChipChannelAttr self) {
+                   [](tt::ttcore::ChipChannelAttr self) {
                      return self.getEthernetCoreCoord0().vec();
                    })
-      .def_prop_ro("device_id1", &tt::ChipChannelAttr::getDeviceId1)
-      .def_prop_ro("ethernet_core_coord1", [](tt::ChipChannelAttr self) {
-        return self.getEthernetCoreCoord1().vec();
-      });
+      .def_prop_ro("device_id1", &tt::ttcore::ChipChannelAttr::getDeviceId1)
+      .def_prop_ro("ethernet_core_coord1",
+                   [](tt::ttcore::ChipChannelAttr self) {
+                     return self.getEthernetCoreCoord1().vec();
+                   });
 
-  tt_attribute_class<tt::SystemDescAttr>(m, "SystemDescAttr")
+  tt_attribute_class<tt::ttcore::SystemDescAttr>(m, "SystemDescAttr")
       .def_static("get_default",
                   [](MlirContext ctx) {
-                    return wrap(tt::SystemDescAttr::getDefault(unwrap(ctx)));
+                    return wrap(
+                        tt::ttcore::SystemDescAttr::getDefault(unwrap(ctx)));
                   })
       .def_static(
           "get",
@@ -254,135 +270,144 @@ void populateTTModule(nb::module_ &m) {
              const std::vector<MlirAttribute> &chipCapabilities,
              const std::vector<MlirAttribute> &chipCoords,
              const std::vector<MlirAttribute> &chipChannels) {
-            std::vector<tt::ChipDescAttr> chipDescsUnwrapped;
+            std::vector<tt::ttcore::ChipDescAttr> chipDescsUnwrapped;
             for (const auto &chipDesc : chipDescs) {
               chipDescsUnwrapped.push_back(
-                  mlir::cast<tt::ChipDescAttr>(unwrap(chipDesc)));
+                  mlir::cast<tt::ttcore::ChipDescAttr>(unwrap(chipDesc)));
             }
-            std::vector<tt::ChipCapabilityAttr> chipCapabilitiesUnwrapped;
+            std::vector<tt::ttcore::ChipCapabilityAttr>
+                chipCapabilitiesUnwrapped;
             for (const auto &chipCapability : chipCapabilities) {
               chipCapabilitiesUnwrapped.push_back(
-                  mlir::cast<tt::ChipCapabilityAttr>(unwrap(chipCapability)));
+                  mlir::cast<tt::ttcore::ChipCapabilityAttr>(
+                      unwrap(chipCapability)));
             }
-            std::vector<tt::ChipCoordAttr> chipCoordsUnwrapped;
+            std::vector<tt::ttcore::ChipCoordAttr> chipCoordsUnwrapped;
             for (const auto &chipCoord : chipCoords) {
               chipCoordsUnwrapped.push_back(
-                  mlir::cast<tt::ChipCoordAttr>(unwrap(chipCoord)));
+                  mlir::cast<tt::ttcore::ChipCoordAttr>(unwrap(chipCoord)));
             }
-            std::vector<tt::ChipChannelAttr> chipChannelsUnwrapped;
+            std::vector<tt::ttcore::ChipChannelAttr> chipChannelsUnwrapped;
             for (const auto &chipChannel : chipChannels) {
               chipChannelsUnwrapped.push_back(
-                  mlir::cast<tt::ChipChannelAttr>(unwrap(chipChannel)));
+                  mlir::cast<tt::ttcore::ChipChannelAttr>(unwrap(chipChannel)));
             }
-            std::vector<tt::CPUDescAttr> cpuDescsUnwrapped;
+            std::vector<tt::ttcore::CPUDescAttr> cpuDescsUnwrapped;
             for (const auto &cpuDesc : cpuDescs) {
               cpuDescsUnwrapped.push_back(
-                  mlir::cast<tt::CPUDescAttr>(unwrap(cpuDesc)));
+                  mlir::cast<tt::ttcore::CPUDescAttr>(unwrap(cpuDesc)));
             }
-            return wrap(tt::SystemDescAttr::get(
+            return wrap(tt::ttcore::SystemDescAttr::get(
                 unwrap(ctx), cpuDescsUnwrapped, chipDescsUnwrapped,
                 chipDescIndices, chipCapabilitiesUnwrapped, chipCoordsUnwrapped,
                 chipChannelsUnwrapped));
           })
-      .def_prop_ro(
-          "chip_descs",
-          [](tt::SystemDescAttr self) { return self.getChipDescs().vec(); })
+      .def_prop_ro("chip_descs",
+                   [](tt::ttcore::SystemDescAttr self) {
+                     return self.getChipDescs().vec();
+                   })
       .def_prop_ro("chip_desc_indices",
-                   [](tt::SystemDescAttr self) {
+                   [](tt::ttcore::SystemDescAttr self) {
                      return self.getChipDescIndices().vec();
                    })
       .def_prop_ro("chip_capabilities",
-                   [](tt::SystemDescAttr self) {
+                   [](tt::ttcore::SystemDescAttr self) {
                      return self.getChipCapabilities().vec();
                    })
-      .def_prop_ro(
-          "chip_coords",
-          [](tt::SystemDescAttr self) { return self.getChipCoords().vec(); })
-      .def_prop_ro("chip_channels", [](tt::SystemDescAttr self) {
+      .def_prop_ro("chip_coords",
+                   [](tt::ttcore::SystemDescAttr self) {
+                     return self.getChipCoords().vec();
+                   })
+      .def_prop_ro("chip_channels", [](tt::ttcore::SystemDescAttr self) {
         return self.getChipChannels().vec();
       });
 
-  tt_attribute_class<tt::MemorySpaceAttr>(m, "MemorySpaceAttr")
-      .def_static(
-          "get",
-          [](MlirContext ctx, uint32_t memorySpace) {
-            return wrap(tt::MemorySpaceAttr::get(
-                unwrap(ctx), static_cast<tt::MemorySpace>(memorySpace)));
-          })
-      .def_prop_ro("memory_space_as_int", [](tt::MemorySpaceAttr self) {
+  tt_attribute_class<tt::ttcore::MemorySpaceAttr>(m, "MemorySpaceAttr")
+      .def_static("get",
+                  [](MlirContext ctx, uint32_t memorySpace) {
+                    return wrap(tt::ttcore::MemorySpaceAttr::get(
+                        unwrap(ctx),
+                        static_cast<tt::ttcore::MemorySpace>(memorySpace)));
+                  })
+      .def_prop_ro("memory_space_as_int", [](tt::ttcore::MemorySpaceAttr self) {
         return static_cast<uint32_t>(self.getValue());
       });
 
-  tt_attribute_class<tt::OOBValAttr>(m, "OOBValAttr")
+  tt_attribute_class<tt::ttcore::OOBValAttr>(m, "OOBValAttr")
       .def_static("get",
                   [](MlirContext ctx, uint32_t oobVal) {
-                    return wrap(tt::OOBValAttr::get(
-                        unwrap(ctx), static_cast<tt::OOBVal>(oobVal)));
+                    return wrap(tt::ttcore::OOBValAttr::get(
+                        unwrap(ctx), static_cast<tt::ttcore::OOBVal>(oobVal)));
                   })
-      .def_prop_ro("oob_val_as_int", [](tt::OOBValAttr self) {
+      .def_prop_ro("oob_val_as_int", [](tt::ttcore::OOBValAttr self) {
         return static_cast<uint32_t>(self.getValue());
       });
 
-  tt_attribute_class<tt::IteratorTypeAttr>(m, "IteratorTypeAttr")
-      .def_static(
-          "get",
-          [](MlirContext ctx, uint32_t iteratorType) {
-            return wrap(tt::IteratorTypeAttr::get(
-                unwrap(ctx), static_cast<tt::IteratorType>(iteratorType)));
-          })
-      .def_prop_ro("iterator_type_as_int", [](tt::IteratorTypeAttr self) {
-        return static_cast<uint32_t>(self.getValue());
-      });
-
-  tt_attribute_class<tt::DeviceAttr>(m, "DeviceAttr")
-      .def_static("from_system_desc",
-                  [](MlirContext ctx, MlirAttribute systemDesc,
-                     std::vector<int64_t> meshShape) {
-                    return wrap(tt::DeviceAttr::get(
+  tt_attribute_class<tt::ttcore::IteratorTypeAttr>(m, "IteratorTypeAttr")
+      .def_static("get",
+                  [](MlirContext ctx, uint32_t iteratorType) {
+                    return wrap(tt::ttcore::IteratorTypeAttr::get(
                         unwrap(ctx),
-                        mlir::cast<tt::SystemDescAttr>(unwrap(systemDesc)),
-                        meshShape));
+                        static_cast<tt::ttcore::IteratorType>(iteratorType)));
                   })
+      .def_prop_ro("iterator_type_as_int",
+                   [](tt::ttcore::IteratorTypeAttr self) {
+                     return static_cast<uint32_t>(self.getValue());
+                   });
+
+  tt_attribute_class<tt::ttcore::DeviceAttr>(m, "DeviceAttr")
+      .def_static(
+          "from_system_desc",
+          [](MlirContext ctx, MlirAttribute systemDesc,
+             std::vector<int64_t> meshShape) {
+            return wrap(tt::ttcore::DeviceAttr::get(
+                unwrap(ctx),
+                mlir::cast<tt::ttcore::SystemDescAttr>(unwrap(systemDesc)),
+                meshShape));
+          })
       .def_static("get",
                   [](MlirContext ctx, std::vector<int64_t> gridShape,
                      MlirAffineMap workerGridMapping, MlirAffineMap l1Map,
                      MlirAffineMap dramMap, std::vector<int64_t> meshShape,
                      std::vector<unsigned> chipIds) {
-                    return wrap(tt::DeviceAttr::get(
+                    return wrap(tt::ttcore::DeviceAttr::get(
                         unwrap(ctx),
-                        tt::GridAttr::get(unwrap(ctx), gridShape,
-                                          unwrap(workerGridMapping)),
+                        tt::ttcore::GridAttr::get(unwrap(ctx), gridShape,
+                                                  unwrap(workerGridMapping)),
                         unwrap(l1Map), unwrap(dramMap), meshShape, chipIds));
                   })
       .def("unwrap",
            [](const MlirAttribute &self) {
-             return mlir::cast<tt::DeviceAttr>(unwrap(self));
+             return mlir::cast<tt::ttcore::DeviceAttr>(unwrap(self));
            })
-      .def_prop_ro("grid_attr", &tt::DeviceAttr::getWorkerGrid)
-      .def_prop_ro("l1_map",
-                   [](tt::DeviceAttr self) { return wrap(self.getL1Map()); })
-      .def_prop_ro("dram_map",
-                   [](tt::DeviceAttr self) { return wrap(self.getDramMap()); })
+      .def_prop_ro("grid_attr", &tt::ttcore::DeviceAttr::getWorkerGrid)
       .def_prop_ro(
-          "mesh_shape",
-          [](const tt::DeviceAttr &self) { return self.getMeshShape().vec(); })
-      .def_prop_ro("chip_ids", [](const tt::DeviceAttr &self) {
+          "l1_map",
+          [](tt::ttcore::DeviceAttr self) { return wrap(self.getL1Map()); })
+      .def_prop_ro(
+          "dram_map",
+          [](tt::ttcore::DeviceAttr self) { return wrap(self.getDramMap()); })
+      .def_prop_ro("mesh_shape",
+                   [](const tt::ttcore::DeviceAttr &self) {
+                     return self.getMeshShape().vec();
+                   })
+      .def_prop_ro("chip_ids", [](const tt::ttcore::DeviceAttr &self) {
         return self.getChipIds().vec();
       });
 
-  tt_type_class<tt::TileType>(m, "TileType")
+  tt_type_class<tt::ttcore::TileType>(m, "TileType")
       .def_static("get",
                   [](MlirContext ctx, std::int64_t height, std::int64_t width,
                      uint32_t dataType) {
-                    return wrap(tt::TileType::get(
+                    return wrap(tt::ttcore::TileType::get(
                         unwrap(ctx), SmallVector<std::int64_t>{height, width},
-                        static_cast<tt::DataType>(dataType)));
+                        static_cast<tt::ttcore::DataType>(dataType)));
                   })
       .def_prop_ro("data_type_as_int",
-                   [](tt::TileType self) {
+                   [](tt::ttcore::TileType self) {
                      return static_cast<uint32_t>(self.getDataType());
                    })
-      .def_prop_ro("shape", [](const tt::TileType &tile) {
+      .def_prop_ro("shape", [](const tt::ttcore::TileType &tile) {
         return std::vector<int64_t>({tile.getHeight(), tile.getWidth()});
       });
 }

--- a/python/TTNNModule.cpp
+++ b/python/TTNNModule.cpp
@@ -109,21 +109,21 @@ void populateTTNNModule(nb::module_ &m) {
           "get",
           [](MlirContext ctx, MlirAffineMap linear, MlirAttribute grid,
              MlirType memref, std::optional<unsigned> memLayout = std::nullopt,
-             std::optional<tt::TensorMeshShardingAttr> tensorMeshSharding =
-                 std::nullopt) {
+             std::optional<tt::ttcore::TensorMeshShardingAttr>
+                 tensorMeshSharding = std::nullopt) {
             tt::ttnn::TensorMemoryLayoutAttr memLayoutAttr;
             if (memLayout.has_value()) {
               memLayoutAttr = tt::ttnn::TensorMemoryLayoutAttr::get(
                   unwrap(ctx),
                   static_cast<tt::ttnn::TensorMemoryLayout>(memLayout.value()));
             }
-            tt::TensorMeshShardingAttr tensorMeshShardingAttr;
+            tt::ttcore::TensorMeshShardingAttr tensorMeshShardingAttr;
             if (tensorMeshSharding.has_value()) {
               tensorMeshShardingAttr = tensorMeshSharding.value();
             }
             return wrap(tt::ttnn::TTNNLayoutAttr::get(
                 unwrap(ctx), mlir::cast<AffineMap>(unwrap(linear)),
-                mlir::cast<tt::GridAttr>(unwrap(grid)),
+                mlir::cast<tt::ttcore::GridAttr>(unwrap(grid)),
                 mlir::cast<MemRefType>(unwrap(memref)), memLayoutAttr,
                 tensorMeshShardingAttr));
           },
@@ -166,9 +166,10 @@ void populateTTNNModule(nb::module_ &m) {
   tt_attribute_class<tt::ttnn::Conv2dConfigAttr>(m, "Conv2dConfigAttr")
       .def_static(
           "get",
-          [](MlirContext ctx, std::optional<tt::DataType> dtype,
-             std::optional<tt::DataType> weightsDtype, StringAttr activation,
-             BoolAttr deallocateActivation, BoolAttr reallocateHaloOutput,
+          [](MlirContext ctx, std::optional<tt::ttcore::DataType> dtype,
+             std::optional<tt::ttcore::DataType> weightsDtype,
+             StringAttr activation, BoolAttr deallocateActivation,
+             BoolAttr reallocateHaloOutput,
              std::optional<uint32_t> actBlockHOverride,
              std::optional<uint32_t> actBlockWDiv, BoolAttr reshardIfNotOptimal,
              BoolAttr overrideShardingConfig,

--- a/test/unittests/OpModel/TTNN/Conversion/TestConversion.cpp
+++ b/test/unittests/OpModel/TTNN/Conversion/TestConversion.cpp
@@ -50,17 +50,18 @@ INSTANTIATE_TEST_SUITE_P(
 class ConversionDataType
     : public MlirToTtnnConversion,
       public testing::WithParamInterface<
-          std::tuple<mlir::tt::DataType, ::tt::tt_metal::DataType>> {};
+          std::tuple<mlir::tt::ttcore::DataType, ::tt::tt_metal::DataType>> {};
 
 TEST_P(ConversionDataType, DataType) {
-  const mlir::tt::DataType &dataType = std::get<0>(GetParam());
+  const mlir::tt::ttcore::DataType &dataType = std::get<0>(GetParam());
   const ::tt::tt_metal::DataType &expectedDataType = std::get<1>(GetParam());
 
   llvm::SmallVector<int64_t> tensorShape = {32, 32};
   auto layout = mlir::tt::ttnn::TTNNLayoutAttr::get(
       &context, tensorShape,
-      mlir::tt::TileType::get(&context, {32, 32}, dataType),
-      mlir::tt::ttnn::BufferType::L1, mlir::tt::GridAttr::get(&context, {8, 8}),
+      mlir::tt::ttcore::TileType::get(&context, {32, 32}, dataType),
+      mlir::tt::ttnn::BufferType::L1,
+      mlir::tt::ttcore::GridAttr::get(&context, {8, 8}),
       mlir::tt::ttnn::TensorMemoryLayoutAttr::get(
           &context, mlir::tt::ttnn::TensorMemoryLayout::Interleaved));
 
@@ -76,21 +77,21 @@ TEST_P(ConversionDataType, DataType) {
 
 INSTANTIATE_TEST_SUITE_P(
     ToDataType, ConversionDataType,
-    ::testing::Values(std::make_tuple(mlir::tt::DataType::Float32,
+    ::testing::Values(std::make_tuple(mlir::tt::ttcore::DataType::Float32,
                                       ::tt::tt_metal::DataType::FLOAT32),
-                      std::make_tuple(mlir::tt::DataType::BFloat16,
+                      std::make_tuple(mlir::tt::ttcore::DataType::BFloat16,
                                       ::tt::tt_metal::DataType::BFLOAT16),
-                      std::make_tuple(mlir::tt::DataType::BFP_BFloat8,
+                      std::make_tuple(mlir::tt::ttcore::DataType::BFP_BFloat8,
                                       ::tt::tt_metal::DataType::BFLOAT8_B),
-                      std::make_tuple(mlir::tt::DataType::BFP_BFloat4,
+                      std::make_tuple(mlir::tt::ttcore::DataType::BFP_BFloat4,
                                       ::tt::tt_metal::DataType::BFLOAT4_B),
-                      std::make_tuple(mlir::tt::DataType::UInt32,
+                      std::make_tuple(mlir::tt::ttcore::DataType::UInt32,
                                       ::tt::tt_metal::DataType::UINT32),
-                      std::make_tuple(mlir::tt::DataType::UInt16,
+                      std::make_tuple(mlir::tt::ttcore::DataType::UInt16,
                                       ::tt::tt_metal::DataType::UINT16),
-                      std::make_tuple(mlir::tt::DataType::UInt8,
+                      std::make_tuple(mlir::tt::ttcore::DataType::UInt8,
                                       ::tt::tt_metal::DataType::UINT8),
-                      std::make_tuple(mlir::tt::DataType::Int32,
+                      std::make_tuple(mlir::tt::ttcore::DataType::Int32,
                                       ::tt::tt_metal::DataType::INT32)));
 
 //================================================================================

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -84,11 +84,11 @@ protected:
           {UnaryEltwiseOpType::Cos, CosOpInterface::getOpRuntime},
           {UnaryEltwiseOpType::Reciprocal, ReciprocalOpInterface::getOpRuntime},
       };
-  std::map<
-      UnaryEltwiseOpType,
-      std::function<llvm::Expected<op_model::ttnn::OpConstraints>(
-          GridAttr, llvm::ArrayRef<int64_t>, mlir::tt::ttnn::TTNNLayoutAttr,
-          llvm::ArrayRef<int64_t>, mlir::tt::ttnn::TTNNLayoutAttr)>>
+  std::map<UnaryEltwiseOpType,
+           std::function<llvm::Expected<op_model::ttnn::OpConstraints>(
+               ttcore::GridAttr, llvm::ArrayRef<int64_t>,
+               mlir::tt::ttnn::TTNNLayoutAttr, llvm::ArrayRef<int64_t>,
+               mlir::tt::ttnn::TTNNLayoutAttr)>>
       constraintsMap = {
           {UnaryEltwiseOpType::Relu, ReluOpInterface::getOpConstraints},
           {UnaryEltwiseOpType::Sqrt, SqrtOpInterface::getOpConstraints},
@@ -247,7 +247,8 @@ class OpModelReductionParam
 protected:
   using ReductionOpConstraintsFunc =
       std::function<llvm::Expected<OpConstraints>(
-          GridAttr, llvm::ArrayRef<int64_t>, mlir::tt::ttnn::TTNNLayoutAttr,
+          ttcore::GridAttr, llvm::ArrayRef<int64_t>,
+          mlir::tt::ttnn::TTNNLayoutAttr,
           std::optional<llvm::ArrayRef<int64_t>>, bool,
           mlir::tt::ttnn::TTNNLayoutAttr)>;
 
@@ -685,8 +686,8 @@ TEST_F(OpModelTest, Typecast) {
 
   auto constraintsExp = TypecastOpInterface::getOpConstraints(
       CreateWorkerGrid(), tensorShape, inputLayoutDRAMIBF16,
-      DataTypeAttr::get(&context, DataType::Float32), tensorShape,
-      inputLayoutDRAMIF32);
+      ttcore::DataTypeAttr::get(&context, ttcore::DataType::Float32),
+      tensorShape, inputLayoutDRAMIF32);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_EQ(opCstr.cbL1PeakSize, 12288);
@@ -695,21 +696,21 @@ TEST_F(OpModelTest, Typecast) {
 
   auto runtimeExp = TypecastOpInterface::getOpRuntime(
       tensorShape, inputLayoutDRAMIBF16,
-      DataTypeAttr::get(&context, DataType::Float32), tensorShape,
-      inputLayoutDRAMIF32);
+      ttcore::DataTypeAttr::get(&context, ttcore::DataType::Float32),
+      tensorShape, inputLayoutDRAMIF32);
   EXPECT_TRUE(static_cast<bool>(runtimeExp));
   EXPECT_TRUE(runtimeExp.get() > 0);
 
   constraintsExp = TypecastOpInterface::getOpConstraints(
       CreateWorkerGrid(), tensorShape, inputLayoutDRAMIBF16,
-      DataTypeAttr::get(&context, DataType::Float32), tensorShape,
-      inputLayoutL1HSBF16);
+      ttcore::DataTypeAttr::get(&context, ttcore::DataType::Float32),
+      tensorShape, inputLayoutL1HSBF16);
   EXPECT_FALSE(static_cast<bool>(constraintsExp));
   llvm::consumeError(constraintsExp.takeError());
   runtimeExp = TypecastOpInterface::getOpRuntime(
       tensorShape, inputLayoutDRAMIBF16,
-      DataTypeAttr::get(&context, DataType::Float32), tensorShape,
-      inputLayoutL1HSBF16);
+      ttcore::DataTypeAttr::get(&context, ttcore::DataType::Float32),
+      tensorShape, inputLayoutL1HSBF16);
   EXPECT_FALSE(static_cast<bool>(runtimeExp));
   llvm::consumeError(runtimeExp.takeError());
 }
@@ -738,12 +739,12 @@ protected:
           {BinaryEltwiseOpType::Minimum, MinimumOpInterface::getOpRuntime},
       };
 
-  std::map<
-      BinaryEltwiseOpType,
-      std::function<llvm::Expected<OpConstraints>(
-          GridAttr, llvm::ArrayRef<int64_t>, mlir::tt::ttnn::TTNNLayoutAttr,
-          llvm::ArrayRef<int64_t>, mlir::tt::ttnn::TTNNLayoutAttr,
-          llvm::ArrayRef<int64_t>, mlir::tt::ttnn::TTNNLayoutAttr)>>
+  std::map<BinaryEltwiseOpType,
+           std::function<llvm::Expected<OpConstraints>(
+               ttcore::GridAttr, llvm::ArrayRef<int64_t>,
+               mlir::tt::ttnn::TTNNLayoutAttr, llvm::ArrayRef<int64_t>,
+               mlir::tt::ttnn::TTNNLayoutAttr, llvm::ArrayRef<int64_t>,
+               mlir::tt::ttnn::TTNNLayoutAttr)>>
       constraintsMap = {
           {BinaryEltwiseOpType::Add, AddOpInterface::getOpConstraints},
           {BinaryEltwiseOpType::Mul, MultiplyOpInterface::getOpConstraints},

--- a/test/unittests/OpModel/TTNN/OpModelFixture.h
+++ b/test/unittests/OpModel/TTNN/OpModelFixture.h
@@ -35,11 +35,11 @@ public:
 
   void SetUp() override {
     // Initialize context and module
-    context.loadDialect<mlir::tt::TTCoreDialect>();
+    context.loadDialect<mlir::tt::ttcore::TTCoreDialect>();
     context.loadDialect<mlir::tt::ttnn::TTNNDialect>();
     module = mlir::ModuleOp::create(builder.getUnknownLoc());
     builder.setInsertionPointToStart(&module->getBodyRegion().front());
-    mlir::tt::registerDevice(module.get());
+    mlir::tt::ttcore::registerDevice(module.get());
   }
 
   static llvm::SmallVector<int64_t> GetPhysicalGridSize() {
@@ -104,7 +104,7 @@ public:
     const auto dtypeSelected =
         dtype.has_value() ? dtype.value() : builder.getBF16Type();
     return mlir::tt::ttnn::TTNNLayoutAttr::get(
-        &context, tensorShape, mlir::tt::TileType::get(dtypeSelected),
+        &context, tensorShape, mlir::tt::ttcore::TileType::get(dtypeSelected),
         bufferType,
         CreateGrid(&context, tensorMemoryLayout, virtualGridSelected,
                    physicalGrid),
@@ -138,7 +138,7 @@ public:
         memLayoutAttr);
   }
 
-  mlir::tt::GridAttr
+  mlir::tt::ttcore::GridAttr
   CreateGrid(::mlir::MLIRContext *context,
              const mlir::tt::ttnn::TensorMemoryLayout tensorMemoryLayout,
              const llvm::ArrayRef<int64_t> virtualGridSize,
@@ -148,12 +148,12 @@ public:
         createSingleDeviceVirtualToPhysicalAffineMap(
             context, tensorMemoryLayout, physicalGridSize);
 
-    return mlir::tt::GridAttr::get(context, virtualGridSize, affineMap);
+    return mlir::tt::ttcore::GridAttr::get(context, virtualGridSize, affineMap);
   }
 
-  mlir::tt::GridAttr CreateWorkerGrid(
+  mlir::tt::ttcore::GridAttr CreateWorkerGrid(
       const llvm::ArrayRef<int64_t> physicalGridSize = GetPhysicalGridSize()) {
-    return mlir::tt::GridAttr::get(&context, physicalGridSize);
+    return mlir::tt::ttcore::GridAttr::get(&context, physicalGridSize);
   }
 
   void ExpectLayoutsEQ(mlir::tt::ttnn::TTNNLayoutAttr layoutA,

--- a/test/unittests/Optimizer/TestGreedyL1InterleavedPolicy.cpp
+++ b/test/unittests/Optimizer/TestGreedyL1InterleavedPolicy.cpp
@@ -30,7 +30,7 @@ public:
   mlir::OwningOpRef<mlir::ModuleOp> module;
   mlir::OpBuilder builder = mlir::OpBuilder(&context);
   mlir::func::FuncOp func;
-  mlir::tt::DeviceAttr deviceAttr;
+  mlir::tt::ttcore::DeviceAttr deviceAttr;
 
   using OpMemSpec = GreedyL1InterleavedPolicy::OpMemSpec;
   using GreedyPolicyChoice = GreedyL1InterleavedPolicy::GreedyPolicyChoice;
@@ -40,9 +40,9 @@ public:
     context.loadDialect<TTNNDialect>();
     module = mlir::ModuleOp::create(builder.getUnknownLoc());
     builder.setInsertionPointToStart(&module->getBodyRegion().front());
-    mlir::tt::registerDevice(module.get());
+    mlir::tt::ttcore::registerDevice(module.get());
     createFuncOp();
-    deviceAttr = mlir::tt::lookupDevice(func);
+    deviceAttr = mlir::tt::ttcore::lookupDevice(func);
   }
 
   llvm::SmallVector<int64_t, 2> getTensorShape() {
@@ -90,13 +90,15 @@ public:
     if (legalConfigs.find(op) == legalConfigs.end()) {
       legalConfigs[op] = std::vector<OpConfig>{TTNNLayoutAttr::get(
           &context, getTensorRankedType().getShape(),
-          mlir::tt::TileType::get(builder.getF32Type()), memorySpace,
-          mlir::tt::GridAttr::get(&context, {8, 8}), tensorMemoryLayoutAttr)};
+          mlir::tt::ttcore::TileType::get(builder.getF32Type()), memorySpace,
+          mlir::tt::ttcore::GridAttr::get(&context, {8, 8}),
+          tensorMemoryLayoutAttr)};
     } else {
       legalConfigs[op].push_back(TTNNLayoutAttr::get(
           &context, getTensorRankedType().getShape(),
-          mlir::tt::TileType::get(builder.getF32Type()), memorySpace,
-          mlir::tt::GridAttr::get(&context, {8, 8}), tensorMemoryLayoutAttr));
+          mlir::tt::ttcore::TileType::get(builder.getF32Type()), memorySpace,
+          mlir::tt::ttcore::GridAttr::get(&context, {8, 8}),
+          tensorMemoryLayoutAttr));
     }
   }
 

--- a/test/unittests/Optimizer/TestLayoutAnalysis.cpp
+++ b/test/unittests/Optimizer/TestLayoutAnalysis.cpp
@@ -42,7 +42,7 @@ protected:
   void SetUp() override {
     // Register necessary dialects
     context.loadDialect<mlir::func::FuncDialect>();
-    context.loadDialect<mlir::tt::TTCoreDialect>();
+    context.loadDialect<mlir::tt::ttcore::TTCoreDialect>();
     context.loadDialect<mlir::tt::ttnn::TTNNDialect>();
 
     // Create a simple module with a function
@@ -69,7 +69,7 @@ protected:
   // Helper method to create a tensor type with given dimensions
   mlir::RankedTensorType createTensorType(llvm::ArrayRef<int64_t> shape,
                                           mlir::Type elementType) {
-    auto gridAttr = mlir::tt::GridAttr::get(&context, getMaxGrid());
+    auto gridAttr = mlir::tt::ttcore::GridAttr::get(&context, getMaxGrid());
     TTNNLayoutAttr layoutAttr = TTNNLayoutAttr::get(
         &context, shape, elementType, BufferType::DRAM, gridAttr,
         TensorMemoryLayoutAttr::get(&context, TensorMemoryLayout::Interleaved));
@@ -111,7 +111,8 @@ protected:
     builder.create<mlir::tt::ttnn::EmptyOp>(
         builder.getUnknownLoc(), tensorType,
         mlir::tt::ttnn::ShapeAttr::get(&context, getTensorShape()),
-        mlir::tt::DataTypeAttr::get(&context, mlir::tt::DataType::Float32),
+        mlir::tt::ttcore::DataTypeAttr::get(
+            &context, mlir::tt::ttcore::DataType::Float32),
         mlir::tt::ttnn::LayoutAttr::get(&context, Layout::Tile), device,
         memConfig);
 
@@ -132,7 +133,7 @@ TEST_P(AllPossibleLayoutsAnalysisTest, GenerateAndCategorizeLayouts) {
 
   // Create the analysis input
   auto scalarTypes = createScalarTypeSet();
-  auto gridAttr = mlir::tt::GridAttr::get(&context, getMaxGrid());
+  auto gridAttr = mlir::tt::ttcore::GridAttr::get(&context, getMaxGrid());
   AllPossibleLayoutsAnalysisInput input(gridAttr, &scalarTypes, true);
 
   // Run the analysis

--- a/test/unittests/Optimizer/TestOptimizerOverrides.cpp
+++ b/test/unittests/Optimizer/TestOptimizerOverrides.cpp
@@ -60,9 +60,9 @@ TEST_F(Conv2dConfigOverrideTest, ParseFullConv2dConfigOverride) {
 
   const auto &params = parsedOverride["op0"];
   ASSERT_TRUE(params.dtype.has_value());
-  ASSERT_EQ(params.dtype.value(), mlir::tt::DataType::BFloat16);
+  ASSERT_EQ(params.dtype.value(), mlir::tt::ttcore::DataType::BFloat16);
   ASSERT_TRUE(params.weightsDtype.has_value());
-  ASSERT_EQ(params.weightsDtype.value(), mlir::tt::DataType::BFloat16);
+  ASSERT_EQ(params.weightsDtype.value(), mlir::tt::ttcore::DataType::BFloat16);
   ASSERT_TRUE(params.activation.has_value());
   ASSERT_EQ(params.activation.value(), "relu");
   ASSERT_TRUE(params.deallocateActivation.has_value());
@@ -110,7 +110,7 @@ TEST_F(Conv2dConfigOverrideTest, ParsePartialConv2dConfigOverride) {
 
   const auto &params = parsedOverride["op0"];
   ASSERT_TRUE(params.dtype.has_value());
-  ASSERT_EQ(params.dtype.value(), mlir::tt::DataType::Float32);
+  ASSERT_EQ(params.dtype.value(), mlir::tt::ttcore::DataType::Float32);
   ASSERT_TRUE(params.activation.has_value());
   ASSERT_EQ(params.activation.value(), "");
   ASSERT_FALSE(params.weightsDtype.has_value());
@@ -147,15 +147,15 @@ TEST_F(Conv2dConfigOverrideTest, ParseMultipleOps) {
 
   const auto &params0 = parsedOverride["op0"];
   ASSERT_TRUE(params0.dtype.has_value());
-  ASSERT_EQ(params0.dtype.value(), mlir::tt::DataType::Float32);
+  ASSERT_EQ(params0.dtype.value(), mlir::tt::ttcore::DataType::Float32);
   ASSERT_TRUE(params0.activation.has_value());
   ASSERT_EQ(params0.activation.value(), "");
 
   const auto &params1 = parsedOverride["op1"];
   ASSERT_TRUE(params1.dtype.has_value());
-  ASSERT_EQ(params1.dtype.value(), mlir::tt::DataType::BFloat16);
+  ASSERT_EQ(params1.dtype.value(), mlir::tt::ttcore::DataType::BFloat16);
   ASSERT_TRUE(params1.weightsDtype.has_value());
-  ASSERT_EQ(params1.weightsDtype.value(), mlir::tt::DataType::BFloat16);
+  ASSERT_EQ(params1.weightsDtype.value(), mlir::tt::ttcore::DataType::BFloat16);
   ASSERT_TRUE(params1.activation.has_value());
   ASSERT_EQ(params1.activation.value(), "relu");
 }
@@ -197,7 +197,7 @@ TEST_F(OutputLayoutOverrideTest, ParseFullOutputLayoutOverride) {
   ASSERT_TRUE(params.memoryLayout.has_value());
   ASSERT_EQ(params.memoryLayout.value(), Layout::Tile);
   ASSERT_TRUE(params.dataType.has_value());
-  ASSERT_EQ(params.dataType.value(), mlir::tt::DataType::Float32);
+  ASSERT_EQ(params.dataType.value(), mlir::tt::ttcore::DataType::Float32);
 }
 
 TEST_F(OutputLayoutOverrideTest, ParsePartialOutputLayoutOverride) {
@@ -262,7 +262,7 @@ TEST_F(OutputLayoutOverrideTest, ParseMultipleOps) {
   ASSERT_TRUE(params1.memoryLayout.has_value());
   ASSERT_EQ(params1.memoryLayout.value(), Layout::Tile);
   ASSERT_TRUE(params1.dataType.has_value());
-  ASSERT_EQ(params1.dataType.value(), mlir::tt::DataType::Float32);
+  ASSERT_EQ(params1.dataType.value(), mlir::tt::ttcore::DataType::Float32);
 
   const auto &params2 = parsedOverride["op2"];
   ASSERT_TRUE(params2.grid.has_value());
@@ -277,7 +277,7 @@ TEST_F(OutputLayoutOverrideTest, ParseMultipleOps) {
   ASSERT_TRUE(params2.memoryLayout.has_value());
   ASSERT_EQ(params2.memoryLayout.value(), Layout::RowMajor);
   ASSERT_TRUE(params2.dataType.has_value());
-  ASSERT_EQ(params2.dataType.value(), mlir::tt::DataType::Float16);
+  ASSERT_EQ(params2.dataType.value(), mlir::tt::ttcore::DataType::Float16);
 }
 
 class TestOptimizerOverrideHandler : public ::testing::Test {
@@ -334,7 +334,7 @@ public:
     //   BufferType;
     //   TensorMemoryLayout tensorMemoryLayout; // INTERLEAVED / SHARDED etc...
     //   Layout memoryLayout;             // ROW_MAJOR / TILE
-    //   mlir::tt::DataType dataType;
+    //   mlir::tt::ttcore::DataType dataType;
     // };
 
     OutputLayoutOverrideParams outputLayoutOverrideParams;
@@ -350,7 +350,7 @@ public:
     outputLayoutOverrideParams.tensorMemoryLayout =
         TensorMemoryLayout::Interleaved;
     outputLayoutOverrideParams.memoryLayout = Layout::Tile;
-    outputLayoutOverrideParams.dataType = mlir::tt::DataType::Float16;
+    outputLayoutOverrideParams.dataType = mlir::tt::ttcore::DataType::Float16;
 
     return outputLayoutOverrideParams;
   }
@@ -362,7 +362,7 @@ public:
     //   BufferType;
     //   TensorMemoryLayout tensorMemoryLayout; // INTERLEAVED / SHARDED etc...
     //   Layout memoryLayout;             // ROW_MAJOR / TILE
-    //   mlir::tt::DataType dataType;
+    //   mlir::tt::ttcore::DataType dataType;
     // };
 
     OutputLayoutOverrideParams outputLayoutOverrideParams;
@@ -378,7 +378,7 @@ public:
     outputLayoutOverrideParams.tensorMemoryLayout =
         TensorMemoryLayout::BlockSharded;
     outputLayoutOverrideParams.memoryLayout = Layout::RowMajor;
-    outputLayoutOverrideParams.dataType = mlir::tt::DataType::Float16;
+    outputLayoutOverrideParams.dataType = mlir::tt::ttcore::DataType::Float16;
 
     return outputLayoutOverrideParams;
   }
@@ -390,7 +390,7 @@ public:
     //   BufferType;
     //   TensorMemoryLayout tensorMemoryLayout; // INTERLEAVED / SHARDED etc...
     //   Layout memoryLayout;             // ROW_MAJOR / TILE
-    //   mlir::tt::DataType dataType;
+    //   mlir::tt::ttcore::DataType dataType;
     // };
 
     OutputLayoutOverrideParams outputLayoutOverrideParams;
@@ -406,7 +406,7 @@ public:
     outputLayoutOverrideParams.tensorMemoryLayout =
         TensorMemoryLayout::HeightSharded;
     outputLayoutOverrideParams.memoryLayout = Layout::Tile;
-    outputLayoutOverrideParams.dataType = mlir::tt::DataType::Float16;
+    outputLayoutOverrideParams.dataType = mlir::tt::ttcore::DataType::Float16;
 
     return outputLayoutOverrideParams;
   }
@@ -631,14 +631,14 @@ TEST_F(TestOptimizerOverrideHandler, TestAddOutputLayoutOverrideParams) {
 
   optimizerOverridesHandler.addOutputLayoutOverride(
       "output0", grid1, BufferType::DRAM, TensorMemoryLayout::Interleaved,
-      Layout::Tile, mlir::tt::DataType::Float16);
+      Layout::Tile, mlir::tt::ttcore::DataType::Float16);
   optimizerOverridesHandler.addOutputLayoutOverride(
       "output1", grid2, BufferType::L1, TensorMemoryLayout::BlockSharded,
-      Layout::RowMajor, mlir::tt::DataType::Float16);
+      Layout::RowMajor, mlir::tt::ttcore::DataType::Float16);
   optimizerOverridesHandler.addOutputLayoutOverride(
       "output2", grid3, BufferType::SystemMemory,
       TensorMemoryLayout::HeightSharded, Layout::Tile,
-      mlir::tt::DataType::Float16);
+      mlir::tt::ttcore::DataType::Float16);
 
   ASSERT_TRUE(compareOutputLayoutOverrides(
       optimizerOverridesHandler.getOutputLayoutOverrides(),
@@ -692,7 +692,7 @@ TEST_F(TestOptimizerOverrideHandler, TestToString) {
   optimizerOverridesHandler.addInsertMemReconfig("add_0_1_2", operandIdxes);
   optimizerOverridesHandler.addOutputLayoutOverride(
       "add_1_2", grid, BufferType::DRAM, TensorMemoryLayout::Interleaved,
-      Layout::RowMajor, mlir::tt::DataType::Float32);
+      Layout::RowMajor, mlir::tt::ttcore::DataType::Float32);
 
   ASSERT_EQ(optimizerOverridesHandler.toString(), options);
 }

--- a/test/unittests/Optimizer/TestShardSolver.cpp
+++ b/test/unittests/Optimizer/TestShardSolver.cpp
@@ -37,7 +37,7 @@ public:
     context.loadDialect<TTNNDialect>();
     module = mlir::ModuleOp::create(builder.getUnknownLoc());
     builder.setInsertionPointToStart(&module->getBodyRegion().front());
-    mlir::tt::registerDevice(module.get());
+    mlir::tt::ttcore::registerDevice(module.get());
     createFuncOp();
   }
 
@@ -50,7 +50,7 @@ public:
         getTensorShape(), builder.getF32Type(),
         TTNNLayoutAttr::get(&context, getTensorShape(), builder.getF32Type(),
                             BufferType::DRAM,
-                            mlir::tt::GridAttr::get(&context, {1, 1}),
+                            mlir::tt::ttcore::GridAttr::get(&context, {1, 1}),
                             mlir::tt::ttnn::TensorMemoryLayoutAttr::get(
                                 &context, TensorMemoryLayout::Interleaved)));
   }
@@ -101,14 +101,14 @@ public:
       legalConfigs[op] = std::vector<OpConfig>{TTNNLayoutAttr::get(
           &context, getTensorRankedType().getShape(), builder.getF32Type(),
           memorySpace,
-          mlir::tt::GridAttr::get(&context, {gridWidth, gridHeight}),
+          mlir::tt::ttcore::GridAttr::get(&context, {gridWidth, gridHeight}),
           mlir::tt::ttnn::TensorMemoryLayoutAttr::get(&context,
                                                       tensorMemoryLayout))};
     } else {
       legalConfigs[op].push_back(TTNNLayoutAttr::get(
           &context, getTensorRankedType().getShape(), builder.getF32Type(),
           memorySpace,
-          mlir::tt::GridAttr::get(&context, {gridWidth, gridHeight}),
+          mlir::tt::ttcore::GridAttr::get(&context, {gridWidth, gridHeight}),
           mlir::tt::ttnn::TensorMemoryLayoutAttr::get(&context,
                                                       tensorMemoryLayout)));
     }

--- a/test/unittests/TestScheduler/TestScheduler.cpp
+++ b/test/unittests/TestScheduler/TestScheduler.cpp
@@ -51,11 +51,11 @@ public:
 
   void SetUp() override {
     // Initialize context and module
-    context.loadDialect<TTCoreDialect>();
+    context.loadDialect<mlir::tt::ttcore::TTCoreDialect>();
     context.loadDialect<ttir::TTIRDialect>();
     module = mlir::ModuleOp::create(builder.getUnknownLoc());
     builder.setInsertionPointToStart(&module->getBodyRegion().front());
-    mlir::tt::registerDevice(module.get());
+    mlir::tt::ttcore::registerDevice(module.get());
     createFuncOp();
   }
 


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/3863
Closes https://github.com/tenstorrent/tt-mlir/issues/3867

### Problem description
This issue is a part of the dialect namespace consolidation effort:
https://github.com/tenstorrent/tt-mlir/issues/3867

With the recent PR, we renamed the whole TT Dialect to TTCore, but we didn't update the corresponding **::mlir::tt** namespace:
https://github.com/tenstorrent/tt-mlir/pull/3772

### What's changed
Renaming TTCore mlir::tt namespace to mlir::tt::ttcore as we agreed in https://github.com/tenstorrent/tt-mlir/issues/3867.

### Checklist
- [x] New/Existing tests provide coverage for changes
