### PR TITLE
Add $TT_METAL_HOME/ttnn to $PYTHONPATH

### DIFF
--- a/env/activate
+++ b/env/activate
@@ -29,4 +29,5 @@ export TTNN_PY_HOME="$(pwd)/third_party/ttnn-python/src/ttnn-python"
 export TTNN_PY_BUILD_HOME="$(pwd)/third_party/ttnn-python/src/ttnn-python/build"
 export TT_MLIR_HOME="$(pwd)"
 export PYTHONPATH="$(pwd)/${BUILD_DIR:=build}/python_packages:$(pwd)/.local/toolchain/python_packages/mlir_core:${TT_METAL_HOME}/tt_eager:${TT_METAL_BUILD_HOME}/tools/profiler/bin:${TTNN_PY_HOME}/ttnn"
+export PYTHONPATH="${PYTHONPATH}:${TT_METAL_HOME}/ttnn:${TT_METAL_HOME}"  # These paths are needed for tracy (profiling)
 export ARCH_NAME="${ARCH_NAME:-wormhole_b0}"

--- a/env/activate.fish
+++ b/env/activate.fish
@@ -20,4 +20,5 @@ set -gx TTNN_PY_HOME (pwd)/third_party/ttnn-python/src/ttnn-python
 set -gx TTNN_PY_BUILD_HOME (pwd)/third_party/ttnn-python/src/ttnn-python/build
 set -gx TT_MLIR_HOME (pwd)
 set -gx PYTHONPATH (pwd)/build/python_packages:(pwd)/.local/toolchain/python_packages/mlir_core:$TT_METAL_HOME/tt_eager:$TT_METAL_BUILD_HOME/tools/profiler/bin:$TTNN_PY_HOME/ttnn
+set -gx PYTHONPATH $PYTHONPATH:$TT_METAL_HOME/ttnn:$TT_METAL_HOME  # These paths are needed for tracy (profiling)
 set -gx ARCH_NAME (set -q ARCH_NAME; and echo $ARCH_NAME; or echo "wormhole_b0")

--- a/runtime/tools/ttrt/ttrt/common/perf.py
+++ b/runtime/tools/ttrt/ttrt/common/perf.py
@@ -376,11 +376,6 @@ class Perf:
         self.file_manager.create_directory(profiler_logs_dir)
 
         def _execute(binaries):
-            # need to temporary add these sys paths so TTRT whls can find the `process_ops` function
-            # ideally we want process_ops to be in a standalone module we can import from tt_metal
-            sys.path.append(f"{get_ttrt_metal_home_path()}")
-            sys.path.append(f"{get_ttrt_metal_home_path()}/ttnn")
-
             from tt_metal.tools.profiler.process_ops_logs import process_ops
 
             def get_available_port():

--- a/runtime/tools/ttrt/ttrt/common/perf.py
+++ b/runtime/tools/ttrt/ttrt/common/perf.py
@@ -376,6 +376,11 @@ class Perf:
         self.file_manager.create_directory(profiler_logs_dir)
 
         def _execute(binaries):
+            # need to temporary add these sys paths so TTRT whls can find the `process_ops` function
+            # ideally we want process_ops to be in a standalone module we can import from tt_metal
+            sys.path.append(f"{get_ttrt_metal_home_path()}")
+            sys.path.append(f"{get_ttrt_metal_home_path()}/ttnn")
+
             from tt_metal.tools.profiler.process_ops_logs import process_ops
 
             def get_available_port():


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`tracy` module not visible in python.
```
cd tools/ttnn-standalone
TT_METAL_DEVICE_PROFILER=1 python -m tracy -r -v build/ttnn-standalone
```
returns
```
/opt/ttmlir-toolchain/venv/bin/python: No module named tracy
```

### What's changed
Add `${TT_METAL_HOME}/ttnn` to `$PYTHONPATH`, which contains the `tracy` module.

Edit:

A previous change removed `$TT_METAL_HOME` from `$PYTHONPATH` so I've added that back in as well, as it is needed by the tracy module when it's importing
```py
from tt_metal.tools.profiler.process_ops_logs import process_ops
```

### Checklist
- [ ] New/Existing tests provide coverage for changes
