### PR TITLE
Deleted an include for fixing uplift to frontends

### DIFF
--- a/runtime/include/tt/runtime/utils.h
+++ b/runtime/include/tt/runtime/utils.h
@@ -5,7 +5,6 @@
 #ifndef TT_RUNTIME_UTILS_H
 #define TT_RUNTIME_UTILS_H
 
-#include "tt/runtime/detail/logger.h"
 #include <memory>
 #include <type_traits>
 


### PR DESCRIPTION
Currenly, the tt-mlir uplift to tt-xla was broken due to an include of a header that was not copied over. Since that header is not needed, deleting it.