### PR TITLE
Support generic interchange

### DIFF
--- a/include/ttmlir/Dialect/TTIR/Analysis/GenericInterchangeAnalysis.h
+++ b/include/ttmlir/Dialect/TTIR/Analysis/GenericInterchangeAnalysis.h
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTIR_ANALYSIS_GENERICINTERCHANGEANALYSIS_H
+#define TTMLIR_DIALECT_TTIR_ANALYSIS_GENERICINTERCHANGEANALYSIS_H
+
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+
+namespace mlir::tt::ttir {
+
+struct InterchangeOptions {
+  ArrayRef<int64_t> matmulInterchange = {};
+};
+
+// Returns the optimal interchange for the given GenericOp or std::nullopt if no
+// interchange is beneficial / possible.
+std::optional<SmallVector<int64_t>>
+calculateInterchange(GenericOp op, const InterchangeOptions &options = {});
+
+} // namespace mlir::tt::ttir
+
+#endif // TTMLIR_DIALECT_TTIR_ANALYSIS_GENERICINTERCHANGEANALYSIS_H

--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -365,6 +365,27 @@ def TTIRLowerToLayout: Pass<"ttir-lower-to-layout", "::mlir::ModuleOp"> {
   }];
 }
 
+def TTIRGenericApplyInterchange : Pass<"ttir-generic-apply-interchange", "::mlir::ModuleOp"> {
+  let summary = "Apply loop interchange on generic ops.";
+  let description = [{
+    For example, the default matmul interchange looks like:
+      (m, n, k) -> (m, k)
+      (m, n, k) -> (k, n)
+      (m, n, k) -> (m, n)
+
+    This pass might choose a different interchange, such as
+    making the k dim the outermost loop, given interchange
+    (2, 0, 1):
+      (k, m, n) -> (m, k)
+      (k, m, n) -> (k, n)
+      (k, m, n) -> (m, n)
+  }];
+
+  list<Option> options = [
+      ListOption<"matmulInterchange", "matmul-interchange", "int64_t", "Set an interchange for generic ops that match matmul style indexing maps and iterator types. The interchange indices here always correspond to the innermost 3 dims.">,
+  ];
+}
+
 def TTIRAllocate: Pass<"ttir-allocate", "::mlir::ModuleOp"> {
   let summary = "Create streams required by generic ops.";
   let description = [{

--- a/include/ttmlir/Dialect/TTMetal/Pipelines/TTMetalPipelines.h
+++ b/include/ttmlir/Dialect/TTMetal/Pipelines/TTMetalPipelines.h
@@ -49,7 +49,7 @@ struct TTIRToTTMetalPipelineOptions
       llvm::cl::desc("Clamp the maximum destination register size in tiles. 0 "
                      "means unset."),
       llvm::cl::init(0)};
-      
+
   ListOption<int64_t> matmulInterchange{
       *this, "matmul-interchange",
       llvm::cl::desc(

--- a/include/ttmlir/Dialect/TTMetal/Pipelines/TTMetalPipelines.h
+++ b/include/ttmlir/Dialect/TTMetal/Pipelines/TTMetalPipelines.h
@@ -49,6 +49,13 @@ struct TTIRToTTMetalPipelineOptions
       llvm::cl::desc("Clamp the maximum destination register size in tiles. 0 "
                      "means unset."),
       llvm::cl::init(0)};
+      
+  ListOption<int64_t> matmulInterchange{
+      *this, "matmul-interchange",
+      llvm::cl::desc(
+          "Set an interchange for generic ops that match matmul style indexing "
+          "maps and iterator types. The interchange indices here always "
+          "correspond to the innermost 3 dims.")};
 };
 
 void createTTIRBufferizationPipeline(OpPassManager &pm);

--- a/lib/Dialect/TTIR/Analysis/CMakeLists.txt
+++ b/lib/Dialect/TTIR/Analysis/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mlir_dialect_library(MLIRTTIRAnalysis
   AllocationPlanner.cpp
   AssociatedDMAWaits.cpp
+  GenericInterchangeAnalysis.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${PROJECT_SOURCE_DIR}/include/ttmlir

--- a/lib/Dialect/TTIR/Analysis/GenericInterchangeAnalysis.cpp
+++ b/lib/Dialect/TTIR/Analysis/GenericInterchangeAnalysis.cpp
@@ -6,9 +6,6 @@
 
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
 
-#include "mlir/Dialect/Linalg/IR/Linalg.h"
-#include "mlir/Dialect/MemRef/IR/MemRef.h"
-
 namespace mlir::tt::ttir {
 
 static std::optional<SmallVector<int64_t>>
@@ -68,24 +65,11 @@ matchAndCalculateMatmulInterchange(ArrayRef<AffineMap> maps,
   return interchange;
 }
 
-static std::optional<SmallVector<int64_t>>
-calculateInterchange(ArrayRef<AffineMap> maps, ArrayRef<IteratorType> iters,
-                     const InterchangeOptions &options) {
-  std::optional<SmallVector<int64_t>> interchange;
-
-  interchange = matchAndCalculateMatmulInterchange(maps, iters,
-                                                   options.matmulInterchange);
-  if (interchange) {
-    return interchange;
-  }
-
-  return interchange;
-}
-
 std::optional<SmallVector<int64_t>>
 calculateInterchange(GenericOp op, const InterchangeOptions &options) {
-  return calculateInterchange(op.getIndexingMapsValue(),
-                              op.getIteratorTypesValue(), options);
+  return matchAndCalculateMatmulInterchange(op.getIndexingMapsValue(),
+                                            op.getIteratorTypesValue(),
+                                            options.matmulInterchange);
 }
 
 } // namespace mlir::tt::ttir

--- a/lib/Dialect/TTIR/Analysis/GenericInterchangeAnalysis.cpp
+++ b/lib/Dialect/TTIR/Analysis/GenericInterchangeAnalysis.cpp
@@ -33,6 +33,28 @@ matchAndCalculateMatmulInterchange(ArrayRef<AffineMap> maps,
     return std::nullopt;
   }
 
+  if (maps.size() != 3) {
+    return std::nullopt;
+  }
+
+  auto lhs = maps[0];
+  auto rhs = maps[1];
+  auto out = maps[2];
+  auto numResults = lhs.getNumResults();
+  assert(numResults == rhs.getNumResults());
+  assert(numResults == out.getNumResults());
+
+  auto lhsM = lhs.getResult(numResults - 2);
+  auto lhsK = lhs.getResult(numResults - 1);
+  auto rhsK = rhs.getResult(numResults - 2);
+  auto rhsN = rhs.getResult(numResults - 1);
+  auto outM = out.getResult(numResults - 2);
+  auto outN = out.getResult(numResults - 1);
+
+  if (lhsM != outM || lhsK != rhsK || rhsN != outN) {
+    return std::nullopt;
+  }
+
   SmallVector<int64_t> interchange = llvm::map_to_vector(
       llvm::seq<int64_t>(0, iters.size()), [](int64_t i) { return i; });
 

--- a/lib/Dialect/TTIR/Analysis/GenericInterchangeAnalysis.cpp
+++ b/lib/Dialect/TTIR/Analysis/GenericInterchangeAnalysis.cpp
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTIR/Analysis/GenericInterchangeAnalysis.h"
+
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
+
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+
+namespace mlir::tt::ttir {
+
+static std::optional<SmallVector<int64_t>>
+matchAndCalculateMatmulInterchange(ArrayRef<AffineMap> maps,
+                                   ArrayRef<IteratorType> iters,
+                                   ArrayRef<int64_t> desiredInterchange) {
+  if (desiredInterchange.empty()) {
+    return std::nullopt;
+  }
+
+  if (iters.size() < 3) {
+    return std::nullopt;
+  }
+
+  if (iters.back() != IteratorType::Reduction) {
+    return std::nullopt;
+  }
+
+  if (!llvm::all_of(iters.take_front(iters.size() - 1), [](IteratorType t) {
+        return t == IteratorType::Parallel;
+      })) {
+    return std::nullopt;
+  }
+
+  SmallVector<int64_t> interchange = llvm::map_to_vector(
+      llvm::seq<int64_t>(0, iters.size()), [](int64_t i) { return i; });
+
+  assert(desiredInterchange.size() == 3);
+
+  auto offset = iters.size() - 3;
+  interchange[offset + 0] = desiredInterchange[0];
+  interchange[offset + 1] = desiredInterchange[1];
+  interchange[offset + 2] = desiredInterchange[2];
+
+  return interchange;
+}
+
+static std::optional<SmallVector<int64_t>>
+calculateInterchange(ArrayRef<AffineMap> maps, ArrayRef<IteratorType> iters,
+                     const InterchangeOptions &options) {
+  std::optional<SmallVector<int64_t>> interchange;
+
+  interchange = matchAndCalculateMatmulInterchange(maps, iters,
+                                                   options.matmulInterchange);
+  if (interchange) {
+    return interchange;
+  }
+
+  return interchange;
+}
+
+std::optional<SmallVector<int64_t>>
+calculateInterchange(GenericOp op, const InterchangeOptions &options) {
+  return calculateInterchange(op.getIndexingMapsValue(),
+                              op.getIteratorTypesValue(), options);
+}
+
+} // namespace mlir::tt::ttir

--- a/lib/Dialect/TTIR/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTIR/Transforms/CMakeLists.txt
@@ -11,6 +11,7 @@ add_mlir_dialect_library(MLIRTTIRTransforms
         GenericLowerDMAs.cpp
         GenericRegionsToFuncs.cpp
         InsertDstRegisterAccess.cpp
+        GenericApplyInterchange.cpp
         OptimizeTensorLayout.cpp
         HoistCPUOps.cpp
         ElementTypeNormalization.cpp
@@ -29,4 +30,5 @@ add_mlir_dialect_library(MLIRTTIRTransforms
 
         LINK_LIBS PUBLIC
         MLIRTTIREraseInverseOps
+        MLIRTTIRAnalysis
         )

--- a/lib/Dialect/TTIR/Transforms/GenericApplyInterchange.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericApplyInterchange.cpp
@@ -53,10 +53,10 @@ public:
     SmallVector<AffineMap> newIndexingMaps;
     SmallVector<Attribute> newIteratorTypes;
     SmallVector<Attribute> newBlockFactors;
+    AffineMap permutationMap = mlir::inversePermutation(
+        AffineMap::getPermutationMap(interchange, builder.getContext()));
     for (size_t i = 0; i < indexingMaps.size(); i++) {
-      AffineMap permuatationMap = mlir::inversePermutation(
-          AffineMap::getPermutationMap(interchange, builder.getContext()));
-      newIndexingMaps.push_back(indexingMaps[i].compose(permuatationMap));
+      newIndexingMaps.push_back(indexingMaps[i].compose(permutationMap));
       newIteratorTypes.push_back(iteratorTypes[interchange[i]]);
       newBlockFactors.push_back(blockFactors[interchange[i]]);
     }

--- a/lib/Dialect/TTIR/Transforms/GenericApplyInterchange.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericApplyInterchange.cpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTIR/Analysis/GenericInterchangeAnalysis.h"
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
+
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Rewrite/FrozenRewritePatternSet.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir::tt::ttir {
+#define GEN_PASS_DEF_TTIRGENERICAPPLYINTERCHANGE
+#include "ttmlir/Dialect/TTIR/Transforms/Passes.h.inc"
+
+namespace {
+class TTIRGenericApplyInterchange
+    : public impl::TTIRGenericApplyInterchangeBase<
+          TTIRGenericApplyInterchange> {
+public:
+  using impl::TTIRGenericApplyInterchangeBase<
+      TTIRGenericApplyInterchange>::TTIRGenericApplyInterchangeBase;
+
+  void runOnOperation() final {
+    ModuleOp moduleOp = getOperation();
+    Builder builder(&getContext());
+    InterchangeOptions options;
+    options.matmulInterchange = matmulInterchange;
+
+    moduleOp.walk([&](GenericOp generic) {
+      std::optional<SmallVector<int64_t>> interchange =
+          calculateInterchange(generic, options);
+      if (!interchange) {
+        return;
+      }
+
+      auto [indexingMaps, iteratorTypes, blockFactors] = apply(
+          builder, generic.getIndexingMapsValue(), generic.getIteratorTypes(),
+          generic.getBlockFactors(), *interchange);
+      generic.setIndexingMapsAttr(indexingMaps);
+      generic.setIteratorTypesAttr(iteratorTypes);
+      generic.setBlockFactorsAttr(blockFactors);
+    });
+  }
+
+  static std::tuple<ArrayAttr, ArrayAttr, ArrayAttr>
+  apply(Builder &builder, ArrayRef<AffineMap> indexingMaps,
+        ArrayAttr iteratorTypes, ArrayAttr blockFactors,
+        ArrayRef<int64_t> interchange) {
+    SmallVector<AffineMap> newIndexingMaps;
+    SmallVector<Attribute> newIteratorTypes;
+    SmallVector<Attribute> newBlockFactors;
+    for (size_t i = 0; i < indexingMaps.size(); i++) {
+      AffineMap permuatationMap = mlir::inversePermutation(
+          AffineMap::getPermutationMap(interchange, builder.getContext()));
+      newIndexingMaps.push_back(indexingMaps[i].compose(permuatationMap));
+      newIteratorTypes.push_back(iteratorTypes[interchange[i]]);
+      newBlockFactors.push_back(blockFactors[interchange[i]]);
+    }
+    return {
+        builder.getAffineMapArrayAttr(newIndexingMaps),
+        builder.getArrayAttr(newIteratorTypes),
+        builder.getArrayAttr(newBlockFactors),
+    };
+  }
+};
+} // namespace
+
+} // namespace mlir::tt::ttir

--- a/lib/Dialect/TTIR/Transforms/GenericLowerDMAs.cpp
+++ b/lib/Dialect/TTIR/Transforms/GenericLowerDMAs.cpp
@@ -73,12 +73,19 @@ public:
           loc, builder.getIndexType(), builder.getI64IntegerAttr(dim));
       Value index;
       if (isGridDim) {
+        // The grid dimension is always 1-1 with the result position.  Consider
+        // the case where interchange moves k to the outermost loop. We'd have
+        // output map: (k, m, n) -> (m, n)
+        // In this example we want (m, n) to map to grid dims (0, 1) (not their
+        // dim positions i.e. (1, 2)).
+        const unsigned gridDim = result;
+
         // gridI * blockFactorI + iterI
         Value blockFactor = builder.create<arith::ConstantOp>(
             loc, builder.getIndexType(),
             builder.getIndexAttr(blockFactors[dim]));
         index = builder.create<CoreIndexOp>(loc, builder.getIndexType(),
-                                            builder.getI64IntegerAttr(dim));
+                                            builder.getI64IntegerAttr(gridDim));
         index = builder.create<arith::MulIOp>(loc, builder.getIndexType(),
                                               index, blockFactor);
         index = builder.create<arith::AddIOp>(loc, builder.getIndexType(),

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -80,6 +80,12 @@ void createTTIRToTTMetalMiddleendPipeline(
   createTTIRBufferizationPipeline(pm);
   pm.addPass(ttir::createTTIRAllocate());
   pm.addPass(mlir::createCanonicalizerPass());
+  ttir::TTIRGenericApplyInterchangeOptions applyInterchangeOptions;
+  {
+    applyInterchangeOptions.matmulInterchange =
+        llvm::to_vector(options.matmulInterchange);
+  }
+  pm.addPass(ttir::createTTIRGenericApplyInterchange(applyInterchangeOptions));
   pm.addPass(mlir::createConvertLinalgToAffineLoopsPass());
   pm.addPass(ttir::createTTIRInsertDstRegisterAccess());
   pm.addPass(ttir::createTTIRGenericLinearizeMemref());

--- a/test/ttmlir/Dialect/TTIR/generic/generic_matmul_interchange.mlir
+++ b/test/ttmlir/Dialect/TTIR/generic/generic_matmul_interchange.mlir
@@ -1,0 +1,20 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttir-generic-apply-interchange="matmul-interchange=2,0,1" %s | FileCheck %s
+
+// CHECK: affine_map<(d0, d1, d2) -> (d1, d0)>
+// CHECK: affine_map<(d0, d1, d2) -> (d0, d2)>
+// CHECK: affine_map<(d0, d1, d2) -> (d1, d2)>
+#l1_ = #ttcore.memory_space<l1>
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#reduction = #ttcore.iterator_type<reduction>
+#parallel = #ttcore.iterator_type<parallel>
+
+func.func @matmul_single_core(%arg0: memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>,  #l1_>, %arg1: memref<1x1x4x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096>, #l1_>) -> memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096>, #l1_> {
+  %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096>, #l1_>
+  "ttir.generic"(%arg0, %arg1, %alloc) <{block_factors = [1, 1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map, #map1, #map2], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<compute>], operandSegmentSizes = array<i32: 2, 1>}> ({
+  ^bb0(%cb0: memref<2x4x!ttcore.tile<32x32, f32>, #l1_>, %cb1: memref<4x2x!ttcore.tile<32x32, f32>, #l1_>, %cb2: memref<2x2x!ttcore.tile<32x32, f32>, #l1_>):
+    "ttir.tile_matmul_block"(%cb0, %cb1, %cb2) : (memref<2x4x!ttcore.tile<32x32, f32>, #l1_>, memref<4x2x!ttcore.tile<32x32, f32>, #l1_>, memref<2x2x!ttcore.tile<32x32, f32>, #l1_>) -> ()
+  }) : (memref<1x1x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096>,  #l1_>, memref<1x1x4x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096>, #l1_>, memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096>, #l1_>) -> ()
+  return %alloc : memref<1x1x2x2x!ttcore.tile<32x32, f32>, #ttcore.shard<8192x4096>, #l1_>
+}


### PR DESCRIPTION
This commits implements a boilerplate pass that currently just accepts a pass override for programming
the interchange of a generic loop nest.

For example, the default matmul interchange looks like:
```
(m, n, k) -> (m, k)
(m, n, k) -> (k, n)
(m, n, k) -> (m, n)
```

This pass might choose a different interchange, such as
making the k dim the outermost loop, given interchange
 (2, 0, 1):

```
(k, m, n) -> (m, k)
(k, m, n) -> (k, n)
(k, m, n) -> (m, n)
```