### PR TITLE
#3788: Added tracy APIs to log location, consteval and program metadata for each op.

### DIFF
--- a/runtime/include/tt/runtime/perf.h
+++ b/runtime/include/tt/runtime/perf.h
@@ -53,9 +53,10 @@ struct Env {
   Env &operator=(Env &&) = delete;
 #endif
 
-  void setProgramMetadata(const std::string &programMetadata) {
-    tracyProgramMetadata = programMetadata;
-  }
+  void tracyLogOpLocation(std::string locInfo);
+  void tracyLogConstEvalProgram(bool constEvalOp);
+  void tracyLogProgramMetadata(std::string metaData);
+  void setProgramMetadata(const std::string &programMetadata);
 
 private:
   Env(std::uint32_t dumpDeviceRate, bool enablePerfTrace,

--- a/runtime/lib/common/CMakeLists.txt
+++ b/runtime/lib/common/CMakeLists.txt
@@ -63,7 +63,9 @@ set_property(TARGET TTRuntimePerf PROPERTY CXX_STANDARD 20)
 target_include_directories(TTRuntimePerf
   PUBLIC
     ${PROJECT_SOURCE_DIR}/runtime/include
+    "$<BUILD_INTERFACE:${TTMETAL_INCLUDE_DIRS}>"
 )
+add_dependencies(TTRuntimePerf tt-metal)
 target_link_libraries(TTRuntimePerf PUBLIC coverage_config)
 
 add_library(TTRuntimeDylibs STATIC dylib.cpp)

--- a/runtime/lib/common/perf.cpp
+++ b/runtime/lib/common/perf.cpp
@@ -2,18 +2,48 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#if defined(TT_RUNTIME_ENABLE_PERF_TRACE) && TT_RUNTIME_ENABLE_PERF_TRACE == 1
-
 #include "tt/runtime/perf.h"
+
+#if defined(TT_RUNTIME_ENABLE_PERF_TRACE) && TT_RUNTIME_ENABLE_PERF_TRACE == 1
+#include "tracy/Tracy.hpp"
+#endif
 
 namespace tt::runtime::perf {
 
+#if defined(TT_RUNTIME_ENABLE_PERF_TRACE) && TT_RUNTIME_ENABLE_PERF_TRACE == 1
 Env &Env::get(std::uint32_t dumpDeviceRate, bool enablePerfTrace,
               const std::string &tracyProgramMetadata) {
   static Env config(dumpDeviceRate, enablePerfTrace, tracyProgramMetadata);
   return config;
 }
+#endif
+
+void Env::tracyLogOpLocation(std::string locInfo) {
+#if defined(TT_RUNTIME_ENABLE_PERF_TRACE) && TT_RUNTIME_ENABLE_PERF_TRACE == 1
+  std::string message =
+      perf::toString(perf::TracyLogTag::MLIR_OP_LOCATION) + ";" + locInfo;
+  TracyMessage(message.c_str(), message.size());
+#endif
+}
+
+void Env::tracyLogConstEvalProgram(bool constEvalOp) {
+#if defined(TT_RUNTIME_ENABLE_PERF_TRACE) && TT_RUNTIME_ENABLE_PERF_TRACE == 1
+  std::string message = perf::toString(perf::TracyLogTag::MLIR_CONST_EVAL_OP) +
+                        ";" + std::string(constEvalOp ? "true" : "false");
+  TracyMessage(message.c_str(), message.size());
+#endif
+}
+
+void Env::tracyLogProgramMetadata(std::string metaData) {
+#if defined(TT_RUNTIME_ENABLE_PERF_TRACE) && TT_RUNTIME_ENABLE_PERF_TRACE == 1
+  std::string message =
+      perf::toString(perf::TracyLogTag::MLIR_PROGRAM_METADATA) + ";" + metaData;
+  TracyMessage(message.c_str(), message.size());
+#endif
+}
+
+void Env::setProgramMetadata(const std::string &programMetadata) {
+  tracyProgramMetadata = programMetadata;
+}
 
 } // namespace tt::runtime::perf
-
-#endif

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -59,39 +59,9 @@
 #include "tt/runtime/perf.h"
 #include "tt/runtime/utils.h"
 
-#if defined(TT_RUNTIME_ENABLE_PERF_TRACE) && TT_RUNTIME_ENABLE_PERF_TRACE == 1
-#include "tracy/Tracy.hpp"
-#endif
-
 namespace tt::runtime::ttnn {
 
 using LogType = ::tt::runtime::logger::LogType;
-
-static void tracyLogOpLocation(const ::tt::target::ttnn::Operation *op) {
-#if defined(TT_RUNTIME_ENABLE_PERF_TRACE) && TT_RUNTIME_ENABLE_PERF_TRACE == 1
-  std::string message = perf::toString(perf::TracyLogTag::MLIR_OP_LOCATION) +
-                        ";" + std::string(op->loc_info()->c_str());
-  TracyMessage(message.c_str(), message.size());
-#endif
-}
-
-static void tracyLogConstEvalProgram(const ::tt::target::ttnn::Operation *op,
-                                     bool constEvalOp) {
-#if defined(TT_RUNTIME_ENABLE_PERF_TRACE) && TT_RUNTIME_ENABLE_PERF_TRACE == 1
-  std::string message = perf::toString(perf::TracyLogTag::MLIR_CONST_EVAL_OP) +
-                        ";" + std::string(constEvalOp ? "true" : "false");
-  TracyMessage(message.c_str(), message.size());
-#endif
-}
-
-static void tracyLogProgramMetadata(const ::tt::target::ttnn::Operation *op,
-                                    std::string metaData) {
-#if defined(TT_RUNTIME_ENABLE_PERF_TRACE) && TT_RUNTIME_ENABLE_PERF_TRACE == 1
-  std::string message =
-      perf::toString(perf::TracyLogTag::MLIR_PROGRAM_METADATA) + ";" + metaData;
-  TracyMessage(message.c_str(), message.size());
-#endif
-}
 
 ProgramExecutor::ProgramExecutor(
     ::tt::runtime::Device deviceHandle, ::tt::runtime::Binary &executableHandle,
@@ -147,9 +117,10 @@ void ProgramExecutor::execute() {
   for (const ::tt::target::ttnn::Operation *op : *program->operations()) {
     LOG_DEBUG(LogType::LogRuntimeTTNN,
               "Executing operation: ", op->debug_info()->c_str());
-    tracyLogConstEvalProgram(op, constEvalProgram);
-    tracyLogOpLocation(op);
-    tracyLogProgramMetadata(op, perf::Env::get().tracyProgramMetadata);
+    perf::Env::get().tracyLogOpLocation(std::string(op->loc_info()->c_str()));
+    perf::Env::get().tracyLogConstEvalProgram(constEvalProgram);
+    perf::Env::get().tracyLogProgramMetadata(
+        perf::Env::get().tracyProgramMetadata);
     runCallback(debug::Hooks::get().getPreOperatorCallback(), executableHandle,
                 op, context.get());
     runOperation(op);

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -343,6 +343,11 @@ void registerRuntimeBindings(nb::module_ &m) {
   nb::class_<tt::runtime::perf::Env>(m, "PerfEnv")
       .def_static("get", &tt::runtime::perf::Env::get, nb::rv_policy::reference)
       .def("set_program_metadata", &tt::runtime::perf::Env::setProgramMetadata)
+      .def("tracy_log_op_location", &tt::runtime::perf::Env::tracyLogOpLocation)
+      .def("tracy_log_const_eval_program",
+           &tt::runtime::perf::Env::tracyLogConstEvalProgram)
+      .def("tracy_log_program_metadata",
+           &tt::runtime::perf::Env::tracyLogProgramMetadata)
       .def("__str__", [](const tt::runtime::perf::Env &env) {
         std::stringstream os;
         os << env;

--- a/runtime/tools/ttrt/ttrt/common/run.py
+++ b/runtime/tools/ttrt/ttrt/common/run.py
@@ -500,6 +500,7 @@ class Run:
                     input_layout = ttrt.runtime.get_layout(
                         fbb, program_index, input_index
                     )
+                    perf_env.tracy_log_op_location(f"loc(arg_{input_index})")
                     inputs_converted.append(
                         ttrt.runtime.to_layout(
                             inputs[input_index], device, input_layout, True
@@ -771,6 +772,9 @@ class Run:
                                         # Call the dirtyTensor function to increment the version counter
                                         expected_layout = ttrt.runtime.get_layout(
                                             bin.fbb, program_index, input_idx
+                                        )
+                                        perf_env.tracy_log_op_location(
+                                            f"loc(arg_{input_idx})"
                                         )
                                         result_tensor = ttrt.runtime.to_layout(
                                             tensor_to_dirty,

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -24,7 +24,12 @@ else()
 endif()
 message(STATUS "Setting tt-metal CPM cache to: ${CPM_SOURCE_CACHE}")
 
+set(TRACY_INCLUDE_DIRS
+  ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/tracy/public
+)
+
 set(TTMETAL_INCLUDE_DIRS
+  ${TRACY_INCLUDE_DIRS}
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/ttnn
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/ttnn/api
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/ttnn/core
@@ -41,7 +46,6 @@ set(TTMETAL_INCLUDE_DIRS
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/hw/inc/${ARCH_NAME}
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/hw/inc/${ARCH_EXTRA_DIR}
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/umd/src/firmware/riscv/${ARCH_NAME}
-  ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/tracy/public
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/taskflow
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_stl
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_stl/tt_stl


### PR DESCRIPTION
Issue: https://github.com/tenstorrent/tt-mlir/issues/3788

This PR wraps existing tracy APIs and added a new op location API under perf::Env. There are now the following perf APIs exposed out of runtime.

```
perf_env.set_program_metadata
perf_env.tracy_log_op_location
perf_env.tracy_log_const_eval_program
perf_env.tracy_log_program_metadata
```

Each of these APIs can be called by the user before calling any individual TTNN api call. By default, they will be used by runtime from reading within the flatbuffer to extract the relevant information (or dynamically querying what the user has set). These entries will be appended onto the perf CSV file for each op.

Eg.
| LOC | CONST_EVAL_OP | PROGRAM_METADATA |
| ---  |  --- | --- |
| "loc("binary_ops.mlir.tmp.mlir"":9:14)" | true         | "{'loop_number': 0, 'program_index': 0, 'disable_eth_dispatch': False, 'enable_program_cache': False, 'dump_device_rate': 1000}"