### PR TITLE
Uplift third_party/tt-metal to cdc0135403f21b2661e6abacce368c56d1a354c9 2025-06-24

### DIFF
--- a/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
+++ b/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
@@ -615,7 +615,7 @@ struct EmitCTypeConverter<::ttnn::TensorMemoryLayout> {
       rso << "INTERLEAVED";
       break;
     case ttnn::TensorMemoryLayout::SingleBank:
-      rso << "SINGLE_BANK";
+      rso << "INTERLEAVED";
       break;
     case ttnn::TensorMemoryLayout::WidthSharded:
       rso << "WIDTH_SHARDED";

--- a/lib/Conversion/TTNNToEmitC/Utils.cpp
+++ b/lib/Conversion/TTNNToEmitC/Utils.cpp
@@ -86,7 +86,7 @@ emitc::OpaqueAttr convertTensorMemoryLayout(Builder &builder,
         "ttnn::TensorMemoryLayout::INTERLEAVED");
   case ttnn::TensorMemoryLayout::SingleBank:
     return builder.getType<emitc::OpaqueAttr>(
-        "ttnn::TensorMemoryLayout::SINGLE_BANK");
+        "ttnn::TensorMemoryLayout::INTERLEAVED");
   case ttnn::TensorMemoryLayout::WidthSharded:
     return builder.getType<emitc::OpaqueAttr>(
         "ttnn::TensorMemoryLayout::WIDTH_SHARDED");

--- a/lib/OpModel/TTNN/Conversion.cpp
+++ b/lib/OpModel/TTNN/Conversion.cpp
@@ -179,7 +179,7 @@ getBufferType(const ::tt::tt_metal::BufferType bufferType) {
   case mlir::tt::ttnn::TensorMemoryLayout::Interleaved:
     return ::tt::tt_metal::TensorMemoryLayout::INTERLEAVED;
   case mlir::tt::ttnn::TensorMemoryLayout::SingleBank:
-    return ::tt::tt_metal::TensorMemoryLayout::SINGLE_BANK;
+    return ::tt::tt_metal::TensorMemoryLayout::INTERLEAVED;
   case mlir::tt::ttnn::TensorMemoryLayout::HeightSharded:
     return ::tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED;
   case mlir::tt::ttnn::TensorMemoryLayout::WidthSharded:
@@ -193,8 +193,6 @@ getTensorMemoryLayout(const ::tt::tt_metal::TensorMemoryLayout memLayout) {
   switch (memLayout) {
   case ::tt::tt_metal::TensorMemoryLayout::INTERLEAVED:
     return mlir::tt::ttnn::TensorMemoryLayout::Interleaved;
-  case ::tt::tt_metal::TensorMemoryLayout::SINGLE_BANK:
-    return mlir::tt::ttnn::TensorMemoryLayout::SingleBank;
   case ::tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED:
     return mlir::tt::ttnn::TensorMemoryLayout::HeightSharded;
   case ::tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED:
@@ -255,7 +253,7 @@ bool validateTensorSpec(const ::ttnn::TensorSpec &tensorSpec,
   try {
     tensorSpec.compute_packed_buffer_size_bytes();
     tensorSpec.compute_page_size_bytes();
-    tensorSpec.compute_distribution_spec();
+    tensorSpec.compute_buffer_sharding_args();
   } catch (const std::exception &e) {
     return false;
   }

--- a/lib/OpModel/TTNN/SingletonDeviceContext.cpp
+++ b/lib/OpModel/TTNN/SingletonDeviceContext.cpp
@@ -57,6 +57,8 @@ void SingletonDeviceContext::openDevice(const size_t traceRegionSize) {
       /* l1_small_size = */ ::tt::constants::L1_SMALL_SIZE,
       /* trace_region_size = */ traceRegionSize,
       /* num_hw_cqs = */ 1, dispatchCoreType);
+
+  m_device->disable_and_clear_program_cache();
 }
 
 void SingletonDeviceContext::closeDevice() {

--- a/runtime/lib/ttnn/utils/utils.cpp
+++ b/runtime/lib/ttnn/utils/utils.cpp
@@ -176,7 +176,7 @@ MathFidelity toTTNNMathFidelity(::tt::target::MathFidelity mathFidelity) {
   case ::tt::target::ttnn::TensorMemoryLayout::Interleaved:
     return ::ttnn::TensorMemoryLayout::INTERLEAVED;
   case ::tt::target::ttnn::TensorMemoryLayout::SingleBank:
-    return ::ttnn::TensorMemoryLayout::SINGLE_BANK;
+    return ::ttnn::TensorMemoryLayout::INTERLEAVED;
   case ::tt::target::ttnn::TensorMemoryLayout::HeightSharded:
     return ::ttnn::TensorMemoryLayout::HEIGHT_SHARDED;
   case ::tt::target::ttnn::TensorMemoryLayout::WidthSharded:

--- a/test/unittests/OpModel/TTNN/Conversion/TestConversion.cpp
+++ b/test/unittests/OpModel/TTNN/Conversion/TestConversion.cpp
@@ -441,8 +441,6 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(
         std::make_tuple(mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
                         tt::tt_metal::TensorMemoryLayout::INTERLEAVED),
-        std::make_tuple(mlir::tt::ttnn::TensorMemoryLayout::SingleBank,
-                        tt::tt_metal::TensorMemoryLayout::SINGLE_BANK),
         std::make_tuple(mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
                         tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED),
         std::make_tuple(mlir::tt::ttnn::TensorMemoryLayout::WidthSharded,

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "f578f4652e3e7950ac4e73aa70501e7bb137669f")
+set(TT_METAL_VERSION "cdc0135403f21b2661e6abacce368c56d1a354c9")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the cdc0135403f21b2661e6abacce368c56d1a354c9

- Remove references to ttnn.TensorMemoryLayout.SINGLE_BANK which was removed from metal in commit 0945ff2
  - Follow up in https://github.com/tenstorrent/tt-mlir/issues/3909
- Disable program cache for op model to prevent llama from failing after metal commit b6d0eff
  - Follow up in https://github.com/tenstorrent/tt-mlir/issues/3907