### PR TITLE
Fix int sign in upsample op model

### DIFF
--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -2012,7 +2012,7 @@ llvm::Expected<OpConstraints> UpsampleOpInterface::getOpConstraints(
   // Convert params
   std::variant<int, ::tt::tt_metal::Array2D> convertedScaleFactor;
   if (auto value = mlir::dyn_cast<mlir::IntegerAttr>(scaleFactor)) {
-    convertedScaleFactor = static_cast<int>(value.getInt());
+    convertedScaleFactor = static_cast<int>(value.getSInt());
   } else if (auto tuple =
                  mlir::dyn_cast<::mlir::detail::DenseArrayAttrImpl<int32_t>>(
                      scaleFactor);
@@ -2060,7 +2060,7 @@ llvm::Expected<size_t> UpsampleOpInterface::getOpRuntime(
   // Convert parameters
   std::variant<int, ::tt::tt_metal::Array2D> convertedScaleFactor;
   if (auto value = mlir::dyn_cast<mlir::IntegerAttr>(scaleFactor)) {
-    convertedScaleFactor = static_cast<int>(value.getInt());
+    convertedScaleFactor = static_cast<int>(value.getSInt());
   } else if (auto tuple =
                  mlir::dyn_cast<::mlir::detail::DenseArrayAttrImpl<int32_t>>(
                      scaleFactor);

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -1555,7 +1555,7 @@ TEST_P(OpModelUpsampleParam, UpsampleParam) {
               inputVirtualGrid] = std::get<0>(params);
   const auto [outputShape, outputTensorLayout, outputBufferType,
               outputVirtualGrid] = std::get<1>(params);
-  const auto scaleFactor = builder.getI64IntegerAttr(std::get<2>(params));
+  const auto scaleFactor = builder.getSI32IntegerAttr(std::get<2>(params));
   const auto mode = std::get<3>(params);
   const auto expectedLegal = std::get<4>(params);
 

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -1268,7 +1268,7 @@ TEST_F(OpModelBase, upsampleOp) {
                            mlir::tt::ttnn::TensorMemoryLayout::Interleaved));
 
   // Convert to Attr
-  mlir::IntegerAttr scaleFactorAttr = builder.getI32IntegerAttr(scaleFactor);
+  mlir::IntegerAttr scaleFactorAttr = builder.getSI32IntegerAttr(scaleFactor);
   mlir::StringAttr modeAttr = builder.getStringAttr(mode);
 
   UpsampleOp upsampleOp =


### PR DESCRIPTION
I stumbled upon this bug, where we treat `scaleFactor` of Upsample op as signless int. However this attribute is signed and therefore we must use `getSInt` method.

