### PR TITLE
fixing docs build

### DIFF
--- a/env/patches/shardy.patch
+++ b/env/patches/shardy.patch
@@ -273,7 +273,7 @@ index 0000000..097780a
 +mlir_tablegen(passes.h.inc -gen-pass-decls -name=SdyExport)
 +add_public_tablegen_target(SdyExportPassesIncGen)
 +add_dependencies(mlir-headers SdyExportPassesIncGen)
-+add_mlir_doc(Passes SdyTransformsExportPasses ./ -gen-pass-doc)
++add_mlir_doc(passes SdyTransformsExportPasses ./ -gen-pass-doc)
 +
 +add_mlir_library(SdyExplicitReshardsUtil
 +  explicit_reshards_util.cc
@@ -372,7 +372,7 @@ index 0000000..9415122
 +mlir_tablegen(passes.h.inc -gen-pass-decls -name=SdyImport)
 +add_public_tablegen_target(SdyTransformsImportPassesIncGen)
 +add_dependencies(mlir-headers SdyTransformsImportPassesIncGen)
-+add_mlir_doc(Passes SdyTransformsImportPasses ./ -gen-pass-doc)
++add_mlir_doc(passes SdyTransformsImportPasses ./ -gen-pass-doc)
 +
 +add_mlir_library(SdyTransformsImportPasses
 +  add_data_flow_edges.cc
@@ -426,7 +426,7 @@ index 0000000..02948f6
 +mlir_tablegen(passes.h.inc -gen-pass-decls -name=SdyPropagation)
 +add_public_tablegen_target(SdyTransformsPropagationPassesIncGen)
 +add_dependencies(mlir-headers SdyTransformsPropagationPassesIncGen)
-+add_mlir_doc(Passes SdyTransformsPropagationPasses ./ -gen-pass-doc)
++add_mlir_doc(passes SdyTransformsPropagationPasses ./ -gen-pass-doc)
 +
 +add_mlir_library(SdyTransformsPropagationPasses
 +  aggressive_propagation.cc


### PR DESCRIPTION
### Problem description
Docs build failing when StableHLO is enabled.
`ninja: error: '/opt/ttmlir-toolchain/src/shardy/shardy/dialect/sdy/transforms/export/Passes.td', needed by 'shardy/shardy/dialect/sdy/transforms/export/SdyTransformsExportPasses.md', missing and no known rule to make it`

### What changed
Uppercase to lowercase in the patch file when building the environment. 