### PR TITLE
D2M: parameterize default memspaces for input/output operands of generic conversion

### DIFF
--- a/include/ttmlir/Conversion/Passes.td
+++ b/include/ttmlir/Conversion/Passes.td
@@ -77,8 +77,21 @@ def TTIRToTTIRGeneric: Pass<"ttir-to-ttir-generic", "::mlir::ModuleOp"> {
       %7 = "ttir.to_layout"(%5, %6) : (tensor<256x1024xf32, #layout2>, tensor<256x1024xf32>) -> tensor<256x1024xf32>
     ```
   }];
-  let constructor = "createTTIRToTTIRGenericPass()";
   let dependentDialects = ["mlir::tt::ttir::TTIRDialect", "mlir::linalg::LinalgDialect"];
+
+  let options = [
+      Option<"useTileMatmul", "use-tile-matmul", "bool", /*default=*/"true", "Use tile_matmul">,
+      Option<"defaultInputMemSpace", "default-input-memspace", "MemorySpace", /*default=*/"MemorySpace::DeviceL1", "Set default memspace for input tensors",
+          [{::llvm::cl::values(
+            clEnumValN(MemorySpace::DeviceL1, "l1", "L1"),
+            clEnumValN(MemorySpace::DeviceDRAM, "dram", "DRAM")
+          )}]>,
+      Option<"defaultOutputMemSpace", "default-output-memspace", "MemorySpace", /*default=*/"MemorySpace::DeviceL1", "Set default memspace for output tensors",
+          [{::llvm::cl::values(
+            clEnumValN(MemorySpace::DeviceL1, "l1", "L1"),
+            clEnumValN(MemorySpace::DeviceDRAM, "dram", "DRAM")
+          )}]>
+  ];
 }
 
 def ConvertTTIRToTTNN: Pass<"convert-ttir-to-ttnn", "::mlir::ModuleOp"> {

--- a/include/ttmlir/Conversion/TTIRToTTIRGeneric/TTIRToTTIRGeneric.h
+++ b/include/ttmlir/Conversion/TTIRToTTIRGeneric/TTIRToTTIRGeneric.h
@@ -5,18 +5,21 @@
 #ifndef TTMLIR_CONVERSION_TTIRTOTTIRGENERIC_TTIRTOTTIRGENERIC_H
 #define TTMLIR_CONVERSION_TTIRTOTTIRGENERIC_TTIRTOTTIRGENERIC_H
 
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 
 namespace mlir::tt {
 
+#define GEN_PASS_DECL_TTIRTOTTIRGENERIC
+#include "ttmlir/Conversion/Passes.h.inc"
+
 void populateTTIRToTTIRGenericPatterns(MLIRContext *ctx,
                                        RewritePatternSet &patterns,
                                        TypeConverter &typeConverter,
-                                       uint64_t deviceGridRank,
-                                       bool useTileMatmul);
-
-std::unique_ptr<OperationPass<ModuleOp>> createTTIRToTTIRGenericPass();
+                                       const TTIRToTTIRGenericOptions &options,
+                                       uint64_t deviceGridRank);
 
 } // namespace mlir::tt
 

--- a/include/ttmlir/Dialect/TTMetal/Pipelines/TTMetalPipelines.h
+++ b/include/ttmlir/Dialect/TTMetal/Pipelines/TTMetalPipelines.h
@@ -56,6 +56,28 @@ struct TTIRToTTMetalPipelineOptions
           "Set an interchange for generic ops that match matmul style indexing "
           "maps and iterator types. The interchange indices here always "
           "correspond to the innermost 3 dims.")};
+
+  // Option to control whether generic conversion uses 'tile_matmul'
+  // (default) or 'tile_matmul_block'.
+  //
+  Option<bool> useTileMatmul{*this, "use-tile-matmul",
+                             llvm::cl::desc("Use tile_matmul"),
+                             llvm::cl::init(true)};
+
+  // Options to control the default memspaces for placing input/output tensors.
+  //
+  Option<MemorySpace> defaultInputMemSpace{
+      *this, "default-input-memspace",
+      llvm::cl::desc("Set default memspace for input tensors"),
+      llvm::cl::values(clEnumValN(MemorySpace::DeviceL1, "l1", "L1"),
+                       clEnumValN(MemorySpace::DeviceDRAM, "dram", "DRAM")),
+      llvm::cl::init(MemorySpace::DeviceL1)};
+  Option<MemorySpace> defaultOutputMemSpace{
+      *this, "default-output-memspace",
+      llvm::cl::desc("Set default memspace for output tensors"),
+      llvm::cl::values(clEnumValN(MemorySpace::DeviceL1, "l1", "L1"),
+                       clEnumValN(MemorySpace::DeviceDRAM, "dram", "DRAM")),
+      llvm::cl::init(MemorySpace::DeviceL1)};
 };
 
 void createTTIRBufferizationPipeline(OpPassManager &pm);

--- a/lib/Conversion/TTIRToTTIRGeneric/TTIRToTTIRGenericPass.cpp
+++ b/lib/Conversion/TTIRToTTIRGeneric/TTIRToTTIRGenericPass.cpp
@@ -16,31 +16,36 @@
 #include "mlir/Transforms/DialectConversion.h"
 
 // ----------------------------------------------------------------------------
-namespace mlir::tt::ttir {
+namespace mlir::tt {
 
 #define GEN_PASS_DEF_TTIRTOTTIRGENERIC
 #include "ttmlir/Conversion/Passes.h.inc" // impl::TTIRToTTIRGenericBase
 
-} // namespace mlir::tt::ttir
 // ............................................................................
-namespace mlir::tt {
-
 using namespace llvm;
 
 namespace {
-struct TTIRToTTIRGenericPass final
-    : ttir::impl::TTIRToTTIRGenericBase<TTIRToTTIRGenericPass> {
 
-  TTIRToTTIRGenericPass(const TTIRToTTIRGenericPass &other)
-      : TTIRToTTIRGenericBase<TTIRToTTIRGenericPass>(other) {
-    useTileMatmul = other.useTileMatmul;
-  }
-  TTIRToTTIRGenericPass() : TTIRToTTIRGenericBase<TTIRToTTIRGenericPass>() {}
+struct TTIRToTTIRGenericPass final
+    : tt::impl::TTIRToTTIRGenericBase<TTIRToTTIRGenericPass> {
+
+  using Base = tt::impl::TTIRToTTIRGenericBase<TTIRToTTIRGenericPass>;
+
+  TTIRToTTIRGenericPass(const TTIRToTTIRGenericOptions &options)
+      : Base(options) {}
+  TTIRToTTIRGenericPass() = default;
+
+  TTIRToTTIRGenericPass(const TTIRToTTIRGenericPass &rhs) : Base(rhs) {
+    // Workaround: Passes are required to be copy-constructible but autogen'ed
+    // base class copy constructors ignore Pass option fields.
+    this->useTileMatmul = rhs.useTileMatmul;
+    this->defaultInputMemSpace = rhs.defaultInputMemSpace;
+    this->defaultOutputMemSpace = rhs.defaultOutputMemSpace;
+  };
 
   void runOnOperation() final {
-
     auto &ctx = getContext();
-    auto op = getOperation();
+    auto moduleOp = getOperation();
 
     mlir::ConversionTarget target{ctx};
     {
@@ -57,6 +62,7 @@ struct TTIRToTTIRGenericPass final
       target.addLegalDialect<tt::TTCoreDialect>();
 
       // An explicit list of legal ttir.* ops.
+
       target.addLegalOp<ttir::GenericOp>();
       target.addLegalOp<ttir::ToLayoutOp>();
       target.addLegalOp<ttir::StreamLayoutOp>();
@@ -71,7 +77,7 @@ struct TTIRToTTIRGenericPass final
           >();
     }
 
-    DeviceAttr deviceAttr = lookupDevice(getOperation());
+    DeviceAttr deviceAttr = lookupDevice(moduleOp);
 
     TypeConverter typeConverter;
     {
@@ -80,28 +86,23 @@ struct TTIRToTTIRGenericPass final
       typeConverter.addConversion([](Type type) { return type; });
     }
 
-    mlir::RewritePatternSet patterns{&ctx};
-    populateTTIRToTTIRGenericPatterns(&ctx, patterns, typeConverter,
-                                      deviceAttr.getWorkerGrid().getRank(),
-                                      useTileMatmul);
+    // llvm::outs() << "runOnOperation(): DEFAULT MS = " << defaultInputMemSpace
+    //              << "/" << defaultOutputMemSpace << "\n";
 
-    if (failed(mlir::applyFullConversion(op, target, std::move(patterns)))) {
+    mlir::RewritePatternSet patterns{&ctx};
+    populateTTIRToTTIRGenericPatterns(
+        &ctx, patterns, typeConverter,
+        {useTileMatmul, defaultInputMemSpace, defaultOutputMemSpace},
+        deviceAttr.getWorkerGrid().getRank());
+
+    if (failed(
+            mlir::applyFullConversion(moduleOp, target, std::move(patterns)))) {
       signalPassFailure();
     }
   }
 
-protected:
-  Option<bool> useTileMatmul{*this, "use-tile-matmul",
-                             llvm::cl::desc("Use tile_matmul"),
-                             llvm::cl::init(true)};
-
 }; // end of class
 } // namespace
-// ............................................................................
-
-std::unique_ptr<OperationPass<ModuleOp>> createTTIRToTTIRGenericPass() {
-  return std::make_unique<TTIRToTTIRGenericPass>();
-}
 
 } // namespace mlir::tt
 // ----------------------------------------------------------------------------

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -61,7 +61,13 @@ void createTTIRToTTMetalFrontendPipeline(
   pm.addPass(tt::createTTCoreRegisterDevicePass(registerDeviceOptions));
   pm.addPass(tt::createTTIRToTTIRDecompositionPass());
   pm.addPass(mlir::createCanonicalizerPass());
-  pm.addPass(tt::createTTIRToTTIRGenericPass());
+  tt::TTIRToTTIRGenericOptions toTTIRGenericOptions;
+  {
+    toTTIRGenericOptions.useTileMatmul = options.useTileMatmul;
+    toTTIRGenericOptions.defaultInputMemSpace = options.defaultInputMemSpace;
+    toTTIRGenericOptions.defaultOutputMemSpace = options.defaultOutputMemSpace;
+  }
+  pm.addPass(tt::createTTIRToTTIRGeneric(toTTIRGenericOptions));
   pm.addPass(mlir::createCanonicalizerPass());
   ttir::TTIROptimizeTensorLayoutOptions optimizeTensorLayoutOptions;
   {


### PR DESCRIPTION
Some frontend pass changes to allow upcoming `ttir-allocate` work with IR where some buffers are allocated in DRAM, not just the hardcoded L1 default.

### Ticket
#3874

### What's changed

-  pass options for `ttir-to-ttir-generic` moved to "declarative" definitions in tablegen because passing a list of options into pass/rewriter constructors is easier with an encapsulating struct
- remove the original no-arg `create*()` constructor for the pass, since the new signature takes `TTIRToTTIRGenericOptions`, this required some namespace changes for where the pass lives (the original choice looks incorrect to me)
- common generic rewriter code refactored to use different memspace defaults for input and output operands + some general cleanup due to parameterization getting into a dirty state

### TODO

- `ttir-lower-to-layout` needs changes to allow DRAM placement to pass through

---
now
`ttmlir-opt --ttcore-register-device "--ttir-to-ttir-generic=default-input-memspace=dram default-output-memspace=dram"`
changes
```mlir
#l1 = #ttcore.memory_space<l1>
#dram = #ttcore.memory_space<dram>
!lhs = tensor<128x96xf32>
!rhs = tensor<96x64xf32>
!matmul_result = tensor<128x64xf32>

module {

  func.func @vlad() -> (!matmul_result) {
    %lhs = ttir.empty() : !lhs
    %rhs = ttir.empty() : !rhs
    %out1 = ttir.empty() : !matmul_result
    %v1 = "ttir.matmul"(%lhs, %rhs, %out1) : (!lhs, !rhs, !matmul_result) -> (!matmul_result)
    return %v1 : !matmul_result
  }
}
```
to (note that `to_layout` are using `#dram` for generic inputs)
```mlir
#dram = #ttcore.memory_space<dram>
#layout = #ttcore.metal_layout<logical_shape = 128x96, dim_alignments = 32x32, collapse_dims = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, dram>
#layout1 = #ttcore.metal_layout<logical_shape = 96x64, dim_alignments = 32x32, collapse_dims = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, dram>
#layout2 = #ttcore.metal_layout<logical_shape = 128x64, dim_alignments = 32x32, collapse_dims = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, undef, dram>
#map = affine_map<(d0, d1, d2) -> (d0, d2)>
#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
#parallel = #ttcore.iterator_type<parallel>
#reduction = #ttcore.iterator_type<reduction>
#system_desc = #ttcore.system_desc<[{role = host, target_triple = "x86_64-pc-linux-gnu"}], [{arch = <wormhole_b0>, grid = 8x8, coord_translation_offsets = 18x18, l1_size = 1499136, num_dram_channels = 12, dram_channel_size = 1073741824, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32, l1_unreserved_base = 1024, erisc_l1_unreserved_base = 1024, dram_unreserved_base = 1024, dram_unreserved_end = 1073741824, physical_helper_cores = {dram = [ 8x0,  9x0,  10x0,  8x1,  9x1,  10x1,  8x2,  9x2,  10x2,  8x3,  9x3,  10x3]}, supported_data_types = [<f32>, <f16>, <bf16>, <bfp_f8>, <bfp_bf8>, <bfp_f4>, <bfp_bf4>, <bfp_f2>, <bfp_bf2>, <u32>, <u16>, <u8>, <si32>], supported_tile_sizes = [ 4x16,  16x16,  32x16,  4x32,  16x32,  32x32], dst_register_size_tiles = 8, num_cbs = 32, num_compute_threads = 1, num_datamovement_threads = 2}], [0], [3 : i32], [ 0x0x0x0]>
module attributes {ttcore.system_desc = #system_desc} {
  ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, (d0, d1) -> (0, d0, d1)>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5] -> (0, 0, (((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) floordiv s4) mod 12, ((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) floordiv (s4 * 12) + ((d0 * s1) * (s2 * s3) + d1 * (s2 * s3) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
  func.func @vlad() -> tensor<128x64xf32> {
    %0 = ttir.empty() : tensor<128x96xf32>
    %1 = ttir.empty() : tensor<96x64xf32>
    %2 = ttir.empty() : tensor<128x64xf32>
    %3 = ttir.empty() : tensor<1x1x4x3x!ttcore.tile<32x32, f32>, #layout>
    %4 = ttir.to_layout %0, %3 : tensor<128x96xf32> into tensor<1x1x4x3x!ttcore.tile<32x32, f32>, #layout> -> tensor<1x1x4x3x!ttcore.tile<32x32, f32>, #layout>
    %5 = ttir.empty() : tensor<1x1x3x2x!ttcore.tile<32x32, f32>, #layout1>
    %6 = ttir.to_layout %1, %5 : tensor<96x64xf32> into tensor<1x1x3x2x!ttcore.tile<32x32, f32>, #layout1> -> tensor<1x1x3x2x!ttcore.tile<32x32, f32>, #layout1>
    %7 = ttir.empty() : tensor<1x1x4x2x!ttcore.tile<32x32, f32>, #layout2>
    %8 = ttir.to_layout %2, %7 : tensor<128x64xf32> into tensor<1x1x4x2x!ttcore.tile<32x32, f32>, #layout2> -> tensor<1x1x4x2x!ttcore.tile<32x32, f32>, #layout2>
    %9 = ttir.generic {block_factors = [1, 1, 1], grid = #ttcore.grid<1x1>, indexing_maps = [#map, #map1, #map2], iterator_types = [#parallel, #parallel, #reduction], threads = [#ttir.thread<compute>]}
        ins(%4, %6 : tensor<1x1x4x3x!ttcore.tile<32x32, f32>, #layout>, tensor<1x1x3x2x!ttcore.tile<32x32, f32>, #layout1>)
        outs(%8 : tensor<1x1x4x2x!ttcore.tile<32x32, f32>, #layout2>)  {
    ^compute0(%cb0: memref<4x3x!ttcore.tile<32x32, f32>, #dram>, %cb1: memref<3x2x!ttcore.tile<32x32, f32>, #dram>, %cb2: memref<4x2x!ttcore.tile<32x32, f32>, #dram>):
      linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} ins(%cb0, %cb1 : memref<4x3x!ttcore.tile<32x32, f32>, #dram>, memref<3x2x!ttcore.tile<32x32, f32>, #dram>) outs(%cb2 : memref<4x2x!ttcore.tile<32x32, f32>, #dram>) {
      ^bb0(%in: !ttcore.tile<32x32, f32>, %in_0: !ttcore.tile<32x32, f32>, %out: !ttcore.tile<32x32, f32>):
        %12 = "ttir.tile_matmul"(%in, %in_0, %out) : (!ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>, !ttcore.tile<32x32, f32>) -> !ttcore.tile<32x32, f32>
        linalg.yield %12 : !ttcore.tile<32x32, f32>
      }
    } : tensor<1x1x4x2x!ttcore.tile<32x32, f32>, #layout2>
    %10 = ttir.empty() : tensor<128x64xf32>
    %11 = ttir.to_layout %9, %10 : tensor<1x1x4x2x!ttcore.tile<32x32, f32>, #layout2> into tensor<128x64xf32> -> tensor<128x64xf32>
    return %11 : tensor<128x64xf32>
  }
}
```