### PR TITLE
Add fallback ttnn.point_to_point operation

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -2129,4 +2129,26 @@ def TTNN_TraceOp : TTNN_Op<"trace"> {
 
     let hasVerifier = 1;
 }
+
+def TTNN_PointToPointOp: TTNN_Op<"point_to_point"> {
+  let summary = "Point To Point operation.";
+  let description = [{
+    Performs point-to-point communication by copying a tensor shard from one device to another
+    within a multi-device mesh. This operation is typically used for explicit data movement in
+    distributed tensor computations, where a specific device (sender_id) sends its local tensor
+    data to a target device (receiver_id).
+
+    If `output_tensor` is not provided, a new output tensor will be allocated automatically
+    at the receiver. If provided, the data will be written into the specified output tensor.
+
+    The operation returns a multi-device tensor whose buffer layout follows the mesh configuration.
+  }];
+
+  let arguments = (ins AnyRankedTensor:$input,
+                         UI32Attr:$sender_id,
+                         UI32Attr:$receiver_id,
+                         Optional<AnyRankedTensor>:$output_tensor);
+  let results = (outs AnyRankedTensor:$result);
+  let hasVerifier = 1;
+}
 #endif

--- a/include/ttmlir/Target/TTNN/operations/ccl.fbs
+++ b/include/ttmlir/Target/TTNN/operations/ccl.fbs
@@ -3,6 +3,9 @@ include "ttmlir/Target/TTNN/types.fbs";
 
 namespace tt.target.ttnn;
 
+attribute "optional";
+
+
 table AllGatherOp {
   in: tt.target.ttnn.TensorRef;
   out: tt.target.ttnn.TensorRef;
@@ -37,4 +40,12 @@ table ReduceScatterOp {
   reduce_type: uint32;
   cluster_axis: uint32;
   num_links: uint32;
+}
+
+table PointToPointOp {
+  in: tt.target.ttnn.TensorRef;
+  out: tt.target.ttnn.TensorRef;
+  sender_id: int32;
+  receiver_id: int32;
+  output_tensor: tt.target.ttnn.TensorRef (optional);
 }

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -78,7 +78,8 @@ union OpType {
   ReductionProdOp,
   LoadCachedOp,
   BatchNormOp,
-  TraceOp
+  TraceOp,
+  PointToPointOp
 }
 
 table Operation {

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -2134,7 +2134,6 @@ public:
     };
 
     emitter.replaceOp(*this, args);
-
     return success();
   }
 };
@@ -2165,6 +2164,35 @@ public:
 
     emitter.replaceOp(*this, args);
 
+    return success();
+  }
+};
+} // namespace
+
+// PointToPointOp conversion pattern
+//
+namespace {
+class PointToPointOpConversionPattern
+    : public TTNNToEmitCBaseOpConversionPattern<tt::ttnn::PointToPointOp> {
+public:
+  using TTNNToEmitCBaseOpConversionPattern<
+      tt::ttnn::PointToPointOp>::TTNNToEmitCBaseOpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(tt::ttnn::PointToPointOp srcOp,
+                  tt::ttnn::PointToPointOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    rewriter.create<emitc::VerbatimOp>(
+        srcOp.getLoc(),
+        "assert(0 && \"PointToPoint  operation is "
+        "not supported in emitc yet.\"); // ::ttnn::PointToPoint");
+    ttnn_to_emitc::EmitCTTNNEmitter<tt::ttnn::PointToPointOp> emitter(
+        srcOp, adaptor, rewriter);
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getInput()),
+    };
+    emitter.replaceOp(*this, args);
     return success();
   }
 };
@@ -2331,6 +2359,7 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
   patterns.add<ReduceScatterOpConversionPattern>(typeConverter, ctx);
   patterns.add<CollectivePermuteOpConversionPattern>(typeConverter, ctx);
   patterns.add<MeshShardOpConversionPattern>(typeConverter, ctx);
+  patterns.add<PointToPointOpConversionPattern>(typeConverter, ctx);
 
   // KV Cache ops
   //

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -2711,4 +2711,29 @@ static bool isTensorOnDevice(::mlir::RankedTensorType tensorType) {
   return walkResult.wasInterrupted() ? ::mlir::failure() : ::mlir::success();
 }
 
+//===----------------------------------------------------------------------===//
+// PointToPointOp
+//===----------------------------------------------------------------------===//
+
+// PointToPointOp verification
+::mlir::LogicalResult mlir::tt::ttnn::PointToPointOp::verify() {
+  if (getOutputTensor()) { // output_tensor is optional
+    auto inputType = llvm::dyn_cast<RankedTensorType>(getInput().getType());
+    auto outputType =
+        llvm::dyn_cast<RankedTensorType>(getOutputTensor().getType());
+
+    if (!inputType || !outputType) {
+      return emitOpError("Input and output must be ranked tensor types.");
+    }
+
+    if (inputType.getElementType() != outputType.getElementType() ||
+        inputType.getShape() != outputType.getShape()) {
+      return emitOpError(
+          "Output tensor must match input tensor in shape and element type.");
+    }
+  }
+
+  return success();
+}
+
 } // namespace mlir::tt::ttnn

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -910,6 +910,25 @@ createOp(FlatbufferObjectCache &cache, ttnn::ConstantOp op) {
                                                     &rawVector);
 }
 
+::flatbuffers::Offset<::tt::target::ttnn::PointToPointOp>
+createOp(FlatbufferObjectCache &cache, PointToPointOp op) {
+  auto input = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
+  auto output = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
+                                  kHostAllocatedSize);
+  auto senderId = op.getSenderId();
+  auto receiverId = op.getReceiverId();
+
+  ::flatbuffers::Offset<::tt::target::ttnn::TensorRef> outputTensor = 0;
+  if (op.getOutputTensor()) {
+    outputTensor = cache.at<::tt::target::ttnn::TensorRef>(
+        getOperandThroughDPSOps(op.getOutputTensor()));
+  }
+
+  return ::tt::target::ttnn::CreatePointToPointOp(
+      *cache.fbb, input, output, senderId, receiverId, outputTensor);
+}
+
 template <typename EltwiseBinaryOp>
 ::flatbuffers::Offset<::tt::target::ttnn::EltwiseBinaryOp>
 createEltwiseBinaryOp(FlatbufferObjectCache &cache, EltwiseBinaryOp op) {
@@ -2154,6 +2173,10 @@ emitTTNNOperation(FlatbufferObjectCache &cache, Operation *op,
   if (auto traceOp = dyn_cast<TraceOp>(op); traceOp) {
     return createOperation(cache, createOp(cache, traceOp, programIndexMap),
                            debugString, locInfo);
+  }
+  if (auto pointToPointOp = dyn_cast<PointToPointOp>(op); pointToPointOp) {
+    return createOperation(cache, createOp(cache, pointToPointOp), debugString,
+                           locInfo);
   }
 
   llvm_unreachable("unhandled op in emitTTNNOperation");

--- a/runtime/lib/ttnn/operations/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/CMakeLists.txt
@@ -8,6 +8,7 @@ set(TTNN_OPS_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/ccl/all_gather.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ccl/collective_permute.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ccl/mesh_shard.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ccl/point_to_point.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ccl/reduce_scatter.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/context/get_device.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/conv/conv2d.cpp

--- a/runtime/lib/ttnn/operations/ccl/point_to_point.cpp
+++ b/runtime/lib/ttnn/operations/ccl/point_to_point.cpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "operations/ccl/point_to_point.h"
+#include "tt/runtime/detail/logger.h"
+#include "tt/runtime/detail/ttnn/utils.h"
+#include <optional>
+#include <ttnn/distributed/types.hpp>
+
+/*
+This is a temporary host fallback to ttnn::PointToPoint(..) API.
+*/
+
+namespace tt::runtime::ttnn::operations::ccl {
+void run(const ::tt::target::ttnn::PointToPointOp *op,
+         ProgramContext &context) {
+  DEBUG_ASSERT(!::tt::runtime::ttnn::utils::inSystemMemory(op->in()),
+               "Calling ttnn::from_device on a host tensor");
+
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+  const ::ttnn::Tensor &inputTensor =
+      tensorPool.getTTNNTensorAndValidate(op->in());
+
+  auto extractShardsToHost = [](const ::ttnn::Tensor &deviceTensor) {
+    return ::ttnn::distributed::get_device_tensors(
+        ::ttnn::from_device(deviceTensor));
+  };
+
+  std::vector<::ttnn::Tensor> inputTensorsHost =
+      extractShardsToHost(inputTensor);
+
+  ::ttnn::Tensor outputTensor;
+  bool hasUserProvidedOutputTensor = op->output_tensor();
+
+  if (hasUserProvidedOutputTensor) {
+    outputTensor = tensorPool.getTTNNTensorAndValidate(op->output_tensor());
+  } else {
+    outputTensor = ::tt::tt_metal::create_device_tensor(
+        inputTensor.tensor_spec(), inputTensor.mesh_device());
+  }
+
+  std::vector<::ttnn::Tensor> outputTensorsHost =
+      extractShardsToHost(outputTensor);
+
+  outputTensorsHost[op->receiver_id()] = inputTensorsHost[op->sender_id()];
+
+  ::ttnn::Tensor aggregatedTensor = ::ttnn::to_device(
+      ::ttnn::distributed::aggregate_as_tensor(
+          outputTensorsHost, inputTensor.distributed_tensor_config()),
+      inputTensor.mesh_device(), inputTensor.memory_config());
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), aggregatedTensor);
+}
+} // namespace tt::runtime::ttnn::operations::ccl

--- a/runtime/lib/ttnn/operations/ccl/point_to_point.h
+++ b/runtime/lib/ttnn/operations/ccl/point_to_point.h
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef RUNTIME_LIB_TTNN_OPERATIONS_CCL_POINT_TO_POINT_H
+#define RUNTIME_LIB_TTNN_OPERATIONS_CCL_POINT_TO_POINT_H
+
+#include "tt/runtime/detail/ttnn/types.h"
+#include "ttmlir/Target/TTNN/program_generated.h"
+
+namespace tt::runtime::ttnn::operations::ccl {
+void run(const ::tt::target::ttnn::PointToPointOp *op, ProgramContext &context);
+} // namespace tt::runtime::ttnn::operations::ccl
+
+#endif // RUNTIME_LIB_TTNN_OPERATIONS_CCL_POINT_TO_POINT_H

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -8,6 +8,7 @@
 #include "operations/ccl/all_gather.h"
 #include "operations/ccl/collective_permute.h"
 #include "operations/ccl/mesh_shard.h"
+#include "operations/ccl/point_to_point.h"
 #include "operations/ccl/reduce_scatter.h"
 #include "operations/context/get_device.h"
 #include "operations/conv/conv2d.h"
@@ -314,6 +315,9 @@ void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
   }
   case ::tt::target::ttnn::OpType::TraceOp: {
     return operations::trace::run(op->type_as_TraceOp(), getContext());
+  }
+  case ::tt::target::ttnn::OpType::PointToPointOp: {
+    return operations::ccl::run(op->type_as_PointToPointOp(), getContext());
   }
   default: {
     LOG_FATAL("Unsupported operation type: ",

--- a/test/ttmlir/Dialect/TTNN/ccl/point_to_point_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/ccl/point_to_point_negative.mlir
@@ -1,0 +1,31 @@
+// RUN: not ttmlir-opt --split-input-file --ttcore-register-device="system-desc-path=%system_desc_path%" %s 2>&1 | FileCheck %s
+// Unit tests for ttnn point_to_point op
+
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<128x512x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#ttnn_layout2 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<128x256x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+module @point_to_point_provided_output_tensor_different_shape attributes {} {
+  func.func public @main(%arg0: tensor<4096x16384xf32, #ttnn_layout1>) -> (tensor<4096x8192xf32, #ttnn_layout2> {}) {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 2x4>}> : () -> !ttnn.device
+    %1 = "ttnn.empty"(%0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>, shape = #ttnn.shape<4096x8192>}> : (!ttnn.device) -> tensor<4096x8192xf32, #ttnn_layout2>
+    %2 = "ttnn.point_to_point"(%arg0, %1) <{receiver_id = 1 : ui32, sender_id = 0 : ui32}> : (tensor<4096x16384xf32, #ttnn_layout1>, tensor<4096x8192xf32, #ttnn_layout2>) -> tensor<4096x8192xf32, #ttnn_layout2>
+    return %2 : tensor<4096x8192xf32, #ttnn_layout2>
+  }
+}
+// CHECK: error: 'ttnn.point_to_point' op Output tensor must match input tensor in shape and element type.
+
+
+// -----
+
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout1 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<128x512x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#ttnn_layout2 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<128x512x!ttcore.tile<32x32, f16>, #dram>, <interleaved>>
+module @point_to_point_provided_output_tensor_different_element_type attributes {} {
+  func.func public @main(%arg0: tensor<4096x16384xf32, #ttnn_layout1>) -> (tensor<4096x16384xi32, #ttnn_layout2> {}) {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 2x4>}> : () -> !ttnn.device
+    %1 = "ttnn.empty"(%0) <{dtype = #ttcore.supportedDataTypes<f16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>, shape = #ttnn.shape<4096x16384>}> : (!ttnn.device) -> tensor<4096x16384xf16, #ttnn_layout2>
+    %2 = "ttnn.point_to_point"(%arg0, %1) <{receiver_id = 1 : ui32, sender_id = 0 : ui32}> : (tensor<4096x16384xf32, #ttnn_layout1>, tensor<4096x16384xf16, #ttnn_layout2>) -> tensor<4096x16384xf16, #ttnn_layout2>
+    return %2 : tensor<4096x16384xf16, #ttnn_layout2>
+  }
+}
+// CHECK: error: 'ttnn.point_to_point' op Output tensor must match input tensor in shape and element type.


### PR DESCRIPTION
### Ticket
closes #3926 

### Problem description
The PointToPoint op is currently under development on the TTNN side, but it appears to need further enhancements.
Until then, we can use a fallback PointToPoint op that reorganizes tensors on the host.

### What's changed
Implement fallback PointToPoint operation

### Checklist
- [ ] New/Existing tests provide coverage for changes
