### PR TITLE
Adding eltwise binary output dtype argument in TTNN dialect

### DIFF
--- a/include/ttmlir/Conversion/TTIRToTTNN/Utils.h
+++ b/include/ttmlir/Conversion/TTIRToTTNN/Utils.h
@@ -26,6 +26,11 @@ generateNHWFlatten(mlir::TypedValue<mlir::RankedTensorType> input,
                    mlir::PatternRewriter &rewriter,
                    llvm::StringRef locSuffix = "");
 
+// Returns DataTypeAttr from tensor layout if present, or an empty DataTypeAttr
+// otherwise.
+DataTypeAttr getDataTypeAttrFromTensorLayout(RankedTensorType type,
+                                             PatternRewriter &rewriter);
+
 } // namespace mlir::tt::ttir_to_ttnn::utils
 
 #endif

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -165,6 +165,7 @@ class TTNN_ElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
 
     let arguments = (ins AnyRankedTensor:$lhs,
                          AnyRankedTensor:$rhs,
+                         OptionalAttr<TTCore_DataTypeAttr>:$output_dtype,
                          OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
     let results = (outs AnyRankedTensor:$result);
 
@@ -179,7 +180,7 @@ class TTNN_ElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
     [
       OpBuilder<(ins "Type": $resultType, "Value": $lhs, "Value": $rhs),
       [{
-        build($_builder, $_state, resultType, lhs, rhs, /*memory_config=*/nullptr);
+        build($_builder, $_state, resultType, lhs, rhs, /*output_dtype=*/nullptr, /*memory_config=*/nullptr);
       }]>
     ];
 }

--- a/lib/Conversion/TTIRToTTNN/Utils.cpp
+++ b/lib/Conversion/TTIRToTTNN/Utils.cpp
@@ -8,6 +8,7 @@
 
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Location.h"
+#include "mlir/IR/Operation.h"
 #include "llvm/ADT/SmallVector.h"
 
 namespace mlir {
@@ -43,6 +44,21 @@ generateNHWFlatten(mlir::TypedValue<mlir::RankedTensorType> input,
   llvm::SmallVector<int64_t> newShape = {1, 1, shape[0] * shape[1] * shape[2],
                                          shape[3]};
   return generateReshape(input, newShape, rewriter, locSuffix);
+}
+
+// Returns DataTypeAttr from tensor layout if present, or an empty DataTypeAttr
+// otherwise.
+DataTypeAttr getDataTypeAttrFromTensorLayout(RankedTensorType type,
+                                             PatternRewriter &rewriter) {
+  DataTypeAttr dataTypeAttr = DataTypeAttr();
+  ttnn::TTNNLayoutAttr layoutAttr =
+      mlir::dyn_cast<ttnn::TTNNLayoutAttr>(type.getEncoding());
+
+  if (layoutAttr) {
+    dataTypeAttr = rewriter.getAttr<DataTypeAttr>(layoutAttr.getDataType());
+  }
+
+  return dataTypeAttr;
 }
 
 } // namespace ttir_to_ttnn::utils

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -387,7 +387,7 @@ public:
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getLhs()),
         emitter.emit(srcOp.getRhs()),
-        /*dtype=*/emitter.emit(std::nullopt),
+        emitter.emit(srcOp.getOutputDtype()),
         emitter.emit(std::nullopt) | emitter.getMemoryConfig(srcOp.getResult()),
     };
 

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -955,18 +955,17 @@ createEltwiseBinaryOp(FlatbufferObjectCache &cache, EltwiseBinaryOp op) {
   auto out =
       cache.getOrCreate(result, tensorValueToFlatbuffer, kHostAllocatedSize);
 
-  // TODO (#2856): we should be getting output data type and memory config from
-  // the binary op directly instead of deriving from the output tensor.
-  // Requires compiler support.
-  auto outputType = mlir::cast<RankedTensorType>(result.getType());
-  DataType outputDtype = elementTypeToDataType(outputType.getElementType());
-  ::tt::target::DataType targetDtype =
-      ::mlir::tt::ttnn::utils::toTargetDataType(outputDtype);
+  ::flatbuffers::Optional<::tt::target::DataType> outputDtype =
+      ::flatbuffers::nullopt;
+  if (op.getOutputDtype()) {
+    outputDtype =
+        ::mlir::tt::ttnn::utils::toTargetDataType(*op.getOutputDtype());
+  }
 
   auto memoryConfig = getMemoryConfigIfNeeded(cache, op);
 
   return ::tt::target::ttnn::CreateEltwiseBinaryOp(
-      *cache.fbb, type, lhs, rhs, targetDtype, memoryConfig, out);
+      *cache.fbb, type, lhs, rhs, outputDtype, memoryConfig, out);
 }
 
 template <typename EltwiseBinaryCompositeOp>


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/3921

### Problem description
We currently lack compiler support for specifying the output data type of element-wise binary operations. The TTNN runtime models this as an output based on the result type. However, the generated C++ code does not handle this similarly, leading to discrepancies.

### What's changed
Added optional output dtype parameter to eltwise binary ops in TTNN dialect.

### Checklist
- [x] New/Existing tests provide coverage for changes
