### PR TITLE
Remove single bank tensor memory layout

### DIFF
--- a/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
+++ b/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
@@ -614,9 +614,6 @@ struct EmitCTypeConverter<::ttnn::TensorMemoryLayout> {
     case ttnn::TensorMemoryLayout::Interleaved:
       rso << "INTERLEAVED";
       break;
-    case ttnn::TensorMemoryLayout::SingleBank:
-      rso << "INTERLEAVED";
-      break;
     case ttnn::TensorMemoryLayout::WidthSharded:
       rso << "WIDTH_SHARDED";
       break;

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.td
@@ -203,7 +203,7 @@ def TTNN_MemoryConfigAttr : TTNN_Attr<"MemoryConfig", "memory_config"> {
 
     This attribute specifies:
     - `bufferType` - specifies which memory type to use (L1, DRAM, System Memory).
-    - `tensorMemoryLayout` - defines how the tensor is laid out in memory (interleaved, single_bank, block_sharded, width_sharded, height_sharded)
+    - `tensorMemoryLayout` - defines how the tensor is laid out in memory (interleaved, block_sharded, width_sharded, height_sharded)
     - `shardSpec` - optional parameter is only used with sharded memory layouts and defines how the tensor is distributed across multiple cores.
 
     Examples:

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOpsEnums.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOpsEnums.td
@@ -22,7 +22,6 @@ def TTNN_Layout : I32EnumAttr<"Layout", "TTNN Layout",
 }
 
 def TTNN_TensorMemoryLayout_Interleaved : I32EnumAttrCase<"Interleaved", 0, "interleaved">;
-def TTNN_TensorMemoryLayout_SingleBank : I32EnumAttrCase<"SingleBank", 1, "single_bank">;
 def TTNN_TensorMemoryLayout_HeightSharded : I32EnumAttrCase<"HeightSharded", 2, "height_sharded">;
 def TTNN_TensorMemoryLayout_WidthSharded : I32EnumAttrCase<"WidthSharded", 3, "width_sharded">;
 def TTNN_TensorMemoryLayout_BlockSharded : I32EnumAttrCase<"BlockSharded", 4, "block_sharded">;
@@ -30,7 +29,6 @@ def TTNN_TensorMemoryLayout_BlockSharded : I32EnumAttrCase<"BlockSharded", 4, "b
 def TTNN_TensorMemoryLayout : I32EnumAttr<"TensorMemoryLayout", "TTNN Tensor Memory Layout",
                            [
                             TTNN_TensorMemoryLayout_Interleaved,
-                            TTNN_TensorMemoryLayout_SingleBank,
                             TTNN_TensorMemoryLayout_HeightSharded,
                             TTNN_TensorMemoryLayout_WidthSharded,
                             TTNN_TensorMemoryLayout_BlockSharded,

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -55,7 +55,7 @@ struct TTIRToTTNNBackendPipelineOptions
   //
   // * grid_size=2x2
   // * memory_space: system, mmio, dram or l1
-  // * tensor_memory_layout: none, interleaved, single_bank, height_sharded,
+  // * tensor_memory_layout: none, interleaved, height_sharded,
   //   width_sharded or block_sharded
   // * memory_layout: row_major or tile
   // * data_type: f32, f16, bf16, bfp_f8, bfp_bf8, bfp_f4, bfp_bf4, bfp_f2,
@@ -99,7 +99,7 @@ struct TTIRToTTNNBackendPipelineOptions
   // * act_block_w_div: uint32_t
   // * reshard_if_not_optimal: [true, false]
   // * override_sharding_config: [true, false]
-  // * shard_layout: [block_sharded, interleaved, single_bank, height_sharded,
+  // * shard_layout: [block_sharded, interleaved, height_sharded,
   // width_sharded]
   // * core_grid:
   // * transpose_shards: [true, false]

--- a/include/ttmlir/Target/TTNN/types.fbs
+++ b/include/ttmlir/Target/TTNN/types.fbs
@@ -4,7 +4,6 @@ namespace tt.target.ttnn;
 
 enum TensorMemoryLayout: ushort {
   Interleaved,
-  SingleBank,
   HeightSharded,
   WidthSharded,
   BlockSharded,

--- a/include/ttmlir/Target/TTNN/utils.h
+++ b/include/ttmlir/Target/TTNN/utils.h
@@ -18,8 +18,6 @@ inline ::tt::target::ttnn::TensorMemoryLayout toTargetTensorMemoryLayout(
   switch (tensorMemoryLayout) {
   case ::mlir::tt::ttnn::TensorMemoryLayout::Interleaved:
     return ::tt::target::ttnn::TensorMemoryLayout::Interleaved;
-  case ::mlir::tt::ttnn::TensorMemoryLayout::SingleBank:
-    return ::tt::target::ttnn::TensorMemoryLayout::SingleBank;
   case ::mlir::tt::ttnn::TensorMemoryLayout::HeightSharded:
     return ::tt::target::ttnn::TensorMemoryLayout::HeightSharded;
   case ::mlir::tt::ttnn::TensorMemoryLayout::WidthSharded:

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -197,8 +197,6 @@ toFlatbuffer(FlatbufferObjectCache &, ttnn::MathFidelity mathFidelity) {
 inline ::tt::target::ttnn::TensorMemoryLayout
 toFlatbuffer(FlatbufferObjectCache &, ttnn::TensorMemoryLayout memLayout) {
   switch (memLayout) {
-  case ttnn::TensorMemoryLayout::SingleBank:
-    return ::tt::target::ttnn::TensorMemoryLayout::SingleBank;
   case ttnn::TensorMemoryLayout::Interleaved:
     return ::tt::target::ttnn::TensorMemoryLayout::Interleaved;
   case ttnn::TensorMemoryLayout::HeightSharded:

--- a/lib/Conversion/TTNNToEmitC/Utils.cpp
+++ b/lib/Conversion/TTNNToEmitC/Utils.cpp
@@ -84,9 +84,6 @@ emitc::OpaqueAttr convertTensorMemoryLayout(Builder &builder,
   case ttnn::TensorMemoryLayout::Interleaved:
     return builder.getType<emitc::OpaqueAttr>(
         "ttnn::TensorMemoryLayout::INTERLEAVED");
-  case ttnn::TensorMemoryLayout::SingleBank:
-    return builder.getType<emitc::OpaqueAttr>(
-        "ttnn::TensorMemoryLayout::INTERLEAVED");
   case ttnn::TensorMemoryLayout::WidthSharded:
     return builder.getType<emitc::OpaqueAttr>(
         "ttnn::TensorMemoryLayout::WIDTH_SHARDED");

--- a/lib/OpModel/TTNN/Conversion.cpp
+++ b/lib/OpModel/TTNN/Conversion.cpp
@@ -178,8 +178,6 @@ getBufferType(const ::tt::tt_metal::BufferType bufferType) {
   switch (tensorMemoryLayout) {
   case mlir::tt::ttnn::TensorMemoryLayout::Interleaved:
     return ::tt::tt_metal::TensorMemoryLayout::INTERLEAVED;
-  case mlir::tt::ttnn::TensorMemoryLayout::SingleBank:
-    return ::tt::tt_metal::TensorMemoryLayout::INTERLEAVED;
   case mlir::tt::ttnn::TensorMemoryLayout::HeightSharded:
     return ::tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED;
   case mlir::tt::ttnn::TensorMemoryLayout::WidthSharded:

--- a/python/OptimizerOverrides.cpp
+++ b/python/OptimizerOverrides.cpp
@@ -96,7 +96,6 @@ void populateOptimizerOverridesModule(nb::module_ &m) {
 
   nb::enum_<mlir::tt::ttnn::TensorMemoryLayout>(m, "TensorMemoryLayout")
       .value("Interleaved", mlir::tt::ttnn::TensorMemoryLayout::Interleaved)
-      .value("SingleBank", mlir::tt::ttnn::TensorMemoryLayout::SingleBank)
       .value("HeightSharded", mlir::tt::ttnn::TensorMemoryLayout::HeightSharded)
       .value("WidthSharded", mlir::tt::ttnn::TensorMemoryLayout::WidthSharded)
       .value("BlockSharded", mlir::tt::ttnn::TensorMemoryLayout::BlockSharded);

--- a/runtime/lib/ttnn/utils/utils.cpp
+++ b/runtime/lib/ttnn/utils/utils.cpp
@@ -175,8 +175,6 @@ MathFidelity toTTNNMathFidelity(::tt::target::MathFidelity mathFidelity) {
   switch (tensorMemoryLayout) {
   case ::tt::target::ttnn::TensorMemoryLayout::Interleaved:
     return ::ttnn::TensorMemoryLayout::INTERLEAVED;
-  case ::tt::target::ttnn::TensorMemoryLayout::SingleBank:
-    return ::ttnn::TensorMemoryLayout::INTERLEAVED;
   case ::tt::target::ttnn::TensorMemoryLayout::HeightSharded:
     return ::ttnn::TensorMemoryLayout::HEIGHT_SHARDED;
   case ::tt::target::ttnn::TensorMemoryLayout::WidthSharded:

--- a/test/ttmlir/Dialect/TTNN/data_movement/to_memory_config/to_memory_config_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/data_movement/to_memory_config/to_memory_config_tests_negative.mlir
@@ -68,7 +68,7 @@ module {
 module{
   func.func @forward(%arg0: tensor<32x32xf32, #device_tile_layout1>) -> tensor<32x96xf32, #device_tile_layout2> {
     // CHECK: error: DRAM buffer type must have Interleaved memory layout.
-    %1 = "ttnn.to_memory_config"(%arg0) <{memory_config = #ttnn.memory_config<#dram, <single_bank>>}> : (tensor<32x32xf32, #device_tile_layout1>) -> tensor<32x96xf32, #device_tile_layout2>
+    %1 = "ttnn.to_memory_config"(%arg0) <{memory_config = #ttnn.memory_config<#dram, <width_sharded>>}> : (tensor<32x32xf32, #device_tile_layout1>) -> tensor<32x96xf32, #device_tile_layout2>
     return %1 : tensor<32x96xf32, #device_tile_layout2>
   }
 }

--- a/tools/op-by-op-infra/op_by_op_infra/pydantic_models.py
+++ b/tools/op-by-op-infra/op_by_op_infra/pydantic_models.py
@@ -31,7 +31,7 @@ class TensorDesc(BaseModel):
     layout: Optional[str] = Field(
         default=None,
         description="Layout of the tensor, e.g. Interleaved, "
-        "SingleBank, HeightSharded.",
+        "HeightSharded, WidthSharded.",
     )
     grid_shape: Optional[List[int]] = Field(
         default=None,


### PR DESCRIPTION
### Problem description
After uplift, SINGLE_BANK tensor memory layout has been removed from ttnn.

### What's changed
Removed single bank from our compiler and runtime.

### Checklist
- [X] New/Existing tests provide coverage for changes
