### PR TITLE
Adding verifier for output_dtype attribute

### DIFF
--- a/include/ttmlir/Conversion/TTIRToTTNN/Utils.h
+++ b/include/ttmlir/Conversion/TTIRToTTNN/Utils.h
@@ -25,12 +25,6 @@ mlir::tt::ttnn::ReshapeOp
 generateNHWFlatten(mlir::TypedValue<mlir::RankedTensorType> input,
                    mlir::PatternRewriter &rewriter,
                    llvm::StringRef locSuffix = "_flatten");
-
-// Returns DataTypeAttr from tensor layout if present, or an empty DataTypeAttr
-// otherwise.
-ttcore::DataTypeAttr getDataTypeAttrFromTensorLayout(RankedTensorType type,
-                                                     PatternRewriter &rewriter);
-
 } // namespace mlir::tt::ttir_to_ttnn::utils
 
 #endif

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -156,7 +156,7 @@ class TTNN_ElementwiseUnaryOp<string mnemonic, list<Trait> traits = []> :
 }
 
 class TTNN_ElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
-    TTNN_Op<mnemonic, [HasMemoryConfigTrait] # traits> {
+    TTNN_Op<mnemonic, [HasMemoryConfigTrait, HasOutputDTypeTrait] # traits> {
     let summary = "Eltwise binary op.";
     let description = [{
       Eltwise binary op.
@@ -179,7 +179,42 @@ class TTNN_ElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
     [
       OpBuilder<(ins "Type": $resultType, "Value": $lhs, "Value": $rhs),
       [{
-        build($_builder, $_state, resultType, lhs, rhs, /*output_dtype=*/nullptr, /*memory_config=*/nullptr);
+        ttcore::DataTypeAttr outputDTypeAttr = ttcore::DataTypeAttr();
+        RankedTensorType rankedTensorType = mlir::cast<RankedTensorType>(resultType);
+        TTNNLayoutAttr layoutAttr = mlir::dyn_cast_if_present<TTNNLayoutAttr>(rankedTensorType.getEncoding());
+        if (layoutAttr)
+        {
+          outputDTypeAttr = $_builder.getAttr<ttcore::DataTypeAttr>(layoutAttr.getDataType());
+        }
+        build($_builder, $_state, resultType, lhs, rhs, outputDTypeAttr, /*memory_config=*/nullptr);
+      }]>
+    ];
+}
+
+class TTNN_ElementwiseBinaryCompositeOp<string mnemonic, list<Trait> traits = []> :
+    TTNN_Op<mnemonic, [HasMemoryConfigTrait] # traits> {
+    let summary = "Eltwise binary composite op.";
+    let description = [{
+      Eltwise binary composite op.
+    }];
+
+    let arguments = (ins AnyRankedTensor:$lhs,
+                         AnyRankedTensor:$rhs,
+                         OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
+    let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
+        return
+          wa::TTNNOperandsWorkaroundsFactory::createBinaryOpOperandsWorkarounds(*this);
+      }
+    }];
+
+    let builders =
+    [
+      OpBuilder<(ins "Type": $resultType, "Value": $lhs, "Value": $rhs),
+      [{
+        build($_builder, $_state, resultType, lhs, rhs, /*memory_config=*/nullptr);
       }]>
     ];
 }
@@ -583,7 +618,7 @@ def TTNN_LogicalXorOp : TTNN_ElementwiseBinaryOp<"logical_xor"> {
     }];
 }
 
-def TTNN_BitwiseAndOp : TTNN_ElementwiseBinaryOp<"bitwise_and"> {
+def TTNN_BitwiseAndOp : TTNN_ElementwiseBinaryCompositeOp<"bitwise_and"> {
     let summary = "Eltwise bitwise AND.";
     let description = [{
         Performs element-wise bitwise AND of two tensors `lhs` and `rhs`
@@ -597,7 +632,7 @@ def TTNN_BitwiseAndOp : TTNN_ElementwiseBinaryOp<"bitwise_and"> {
     }];
 }
 
-def TTNN_BitwiseOrOp : TTNN_ElementwiseBinaryOp<"bitwise_or"> {
+def TTNN_BitwiseOrOp : TTNN_ElementwiseBinaryCompositeOp<"bitwise_or"> {
     let summary = "Eltwise bitwise OR.";
     let description = [{
         Performs element-wise bitwise OR of two tensors `lhs` and `rhs`
@@ -611,7 +646,7 @@ def TTNN_BitwiseOrOp : TTNN_ElementwiseBinaryOp<"bitwise_or"> {
     }];
 }
 
-def TTNN_BitwiseXorOp : TTNN_ElementwiseBinaryOp<"bitwise_xor"> {
+def TTNN_BitwiseXorOp : TTNN_ElementwiseBinaryCompositeOp<"bitwise_xor"> {
     let summary = "Eltwise bitwise XOR.";
     let description = [{
         Performs element-wise bitwise XOR of two tensors `lhs` and `rhs`
@@ -625,7 +660,7 @@ def TTNN_BitwiseXorOp : TTNN_ElementwiseBinaryOp<"bitwise_xor"> {
     }];
 }
 
-def TTNN_MaximumOp :  TTNN_ElementwiseBinaryOp<"maximum",
+def TTNN_MaximumOp :  TTNN_ElementwiseBinaryCompositeOp<"maximum",
       [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
       > {
     let summary = "Eltwise maximum OP.";
@@ -639,7 +674,7 @@ def TTNN_MaximumOp :  TTNN_ElementwiseBinaryOp<"maximum",
     }];
 }
 
-def TTNN_MinimumOp :  TTNN_ElementwiseBinaryOp<"minimum",
+def TTNN_MinimumOp :  TTNN_ElementwiseBinaryCompositeOp<"minimum",
       [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
       > {
     let summary = "Eltwise minimum OP.";
@@ -673,7 +708,7 @@ def TTNN_SubtractOp : TTNN_ElementwiseBinaryOp<"subtract",
     }];
 }
 
-def TTNN_RemainderOp : TTNN_ElementwiseBinaryOp<"remainder"> {
+def TTNN_RemainderOp : TTNN_ElementwiseBinaryCompositeOp<"remainder"> {
     let summary = "Eltwise remainder.";
     let description = [{
       Performs element-wise remainder of dividend lhs and divisor rhs tensors and produces a
@@ -688,7 +723,7 @@ def TTNN_RemainderOp : TTNN_ElementwiseBinaryOp<"remainder"> {
     }];
 }
 
-def TTNN_PowOp : TTNN_ElementwiseBinaryOp<"pow"> {
+def TTNN_PowOp : TTNN_ElementwiseBinaryCompositeOp<"pow"> {
     let summary = "Eltwise power OP.";
     let description = [{
       Performs element-wise exponentiation of lhs tensor by rhs tensor and produces a
@@ -705,7 +740,7 @@ def TTNN_PowOp : TTNN_ElementwiseBinaryOp<"pow"> {
     }];
 }
 
-def TTNN_Atan2Op :  TTNN_ElementwiseBinaryOp<"atan2"> {
+def TTNN_Atan2Op :  TTNN_ElementwiseBinaryCompositeOp<"atan2"> {
     let summary = "Eltwise atan2 OP.";
     let description = [{
       Performs element-wise atan2 operation on lhs and rhs tensor and produces a result
@@ -1759,7 +1794,7 @@ def TTNN_DeallocateOp : TTNN_Op<"deallocate"> {
                          DefaultValuedAttr<BoolAttr, "false">:$force);
 }
 
-def TTNN_ScatterOp: TTNN_ElementwiseBinaryOp<"scatter"> {
+def TTNN_ScatterOp: TTNN_ElementwiseBinaryCompositeOp<"scatter"> {
     let summary = "Scatter op.";
     let description = [{
       Embeds the values of the 'update' tensor into 'input' at the given index and puts the value in the 'output' tensor.

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNTraits.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNTraits.h
@@ -5,11 +5,9 @@
 #ifndef TTMLIR_DIALECT_TTNN_IR_TTNNTRAITS_H
 #define TTMLIR_DIALECT_TTNN_IR_TTNNTRAITS_H
 
-#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 
 #include "mlir/IR/OpDefinition.h"
-#include "llvm/ADT/STLExtras.h"
 
 namespace mlir::tt::ttnn {
 
@@ -79,6 +77,59 @@ public:
                << ") must match memory config shard spec shape ("
                << memoryConfigAttr.getShardSpec()->getShape().getShape() << ")";
       }
+    }
+
+    return mlir::success();
+  }
+};
+
+class HasOutputDTypeTraitBase {
+public:
+  static constexpr ::llvm::StringLiteral getOutputDTypeAttributeName() {
+    return "output_dtype";
+  }
+};
+
+template <typename ConcreteType>
+class HasOutputDTypeTrait
+    : public mlir::OpTrait::TraitBase<ConcreteType, HasOutputDTypeTrait>,
+      public HasOutputDTypeTraitBase {
+public:
+  static mlir::LogicalResult verifyTrait(mlir::Operation *op) {
+    // Check if the operation defines output data type attribute.
+    auto attributeNames = ConcreteType::getAttributeNames();
+    if (std::find(attributeNames.begin(), attributeNames.end(),
+                  getOutputDTypeAttributeName()) == attributeNames.end()) {
+      return op->emitOpError(
+          "Operation must define output data type attribute.");
+    }
+
+    // Retrieve output layout.
+    RankedTensorType output =
+        mlir::cast<RankedTensorType>(op->getResult(0).getType());
+    TTNNLayoutAttr outputLayoutAttr =
+        mlir::dyn_cast<TTNNLayoutAttr>(output.getEncoding());
+
+    // If output layout isn't present, skip the verification.
+    if (!outputLayoutAttr) {
+      return mlir::success();
+    }
+
+    // Retrieve output data type attribute.
+    auto outputDTypeAttr =
+        op->getAttrOfType<ttcore::DataTypeAttr>(getOutputDTypeAttributeName());
+    if (!outputDTypeAttr) {
+      return op->emitOpError("Output data type attribute is not defined for op "
+                             "that has output layout attribute.");
+    }
+
+    // Compare output data type attribute with output tensor data type.
+    if (outputDTypeAttr.getValue() != outputLayoutAttr.getDataType()) {
+      return op->emitOpError()
+             << "Output tensor layout data type "
+             << DataTypeEnumToString(outputLayoutAttr.getDataType())
+             << " must match output data type attribute "
+             << DataTypeEnumToString(outputDTypeAttr.getValue());
     }
 
     return mlir::success();

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNTraits.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNTraits.td
@@ -14,7 +14,13 @@ include "mlir/IR/OpBase.td"
 // Trait for ops that have memory config attribute.
 def HasMemoryConfigTrait : NativeOpTrait<"HasMemoryConfigTrait">
 {
-  let cppNamespace = "mlir::tt::ttnn";
+  let cppNamespace = "::mlir::tt::ttnn";
+}
+
+// Trait for ops that have output data type attribute.
+def HasOutputDTypeTrait: NativeOpTrait<"HasOutputDTypeTrait">
+{
+  let cppNamespace = "::mlir::tt::ttnn";
 }
 
 #endif // TTMLIR_TTMLIR_DIALECT_TTNN_TTNNTRAITS_TD

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -278,10 +278,7 @@ public:
 
     rewriter.replaceOpWithNewOp<TTNNOpTy>(
         op, this->getTypeConverter()->convertType(op.getResult().getType()),
-        adaptor.getLhs(), adaptor.getRhs(),
-        tt::ttir_to_ttnn::utils::getDataTypeAttrFromTensorLayout(
-            op.getResult().getType(), rewriter),
-        nullptr);
+        adaptor.getLhs(), adaptor.getRhs());
     return success();
   }
 };
@@ -1249,10 +1246,7 @@ public:
     Type outputType = this->getTypeConverter()->convertType(srcOp.getType());
     if (lhsType.getShape() == rhsType.getShape()) {
       rewriter.replaceOpWithNewOp<ttnn::SubtractOp>(
-          srcOp, outputType, adaptor.getLhs(), adaptor.getRhs(),
-          tt::ttir_to_ttnn::utils::getDataTypeAttrFromTensorLayout(
-              srcOp.getResult().getType(), rewriter),
-          nullptr);
+          srcOp, outputType, adaptor.getLhs(), adaptor.getRhs());
 
       // Broadcast for rhs operand require the operation to be commutative to
       // allow switching the order of operands. To allow this conversion, the

--- a/lib/Conversion/TTIRToTTNN/Utils.cpp
+++ b/lib/Conversion/TTIRToTTNN/Utils.cpp
@@ -46,23 +46,6 @@ generateNHWFlatten(mlir::TypedValue<mlir::RankedTensorType> input,
   return generateReshape(input, newShape, rewriter, locSuffix);
 }
 
-// Returns DataTypeAttr from tensor layout if present, or an empty DataTypeAttr
-// otherwise.
-ttcore::DataTypeAttr
-getDataTypeAttrFromTensorLayout(RankedTensorType type,
-                                PatternRewriter &rewriter) {
-  ttcore::DataTypeAttr dataTypeAttr = ttcore::DataTypeAttr();
-  ttnn::TTNNLayoutAttr layoutAttr =
-      mlir::dyn_cast<ttnn::TTNNLayoutAttr>(type.getEncoding());
-
-  if (layoutAttr) {
-    dataTypeAttr =
-        rewriter.getAttr<ttcore::DataTypeAttr>(layoutAttr.getDataType());
-  }
-
-  return dataTypeAttr;
-}
-
 } // namespace ttir_to_ttnn::utils
 } // namespace tt
 } // namespace mlir

--- a/lib/Dialect/TTNN/Transforms/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/Optimizer.cpp
@@ -17,6 +17,7 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsTypes.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNTraits.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTNN/Utils/PassOverrides.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
@@ -365,6 +366,15 @@ public:
               mlir::cast<TTNNLayoutAttr>(newTensorType.getEncoding());
 
           op->getResult(0).setType(newTensorType);
+
+          // Update output data type for ops that have output data type
+          // attribute.
+          if (op->hasTrait<HasOutputDTypeTrait>()) {
+            ttcore::DataTypeAttr newDataTypeAttr = ttcore::DataTypeAttr::get(
+                op->getContext(), layoutAttr.getDataType());
+            op->setAttr(HasOutputDTypeTraitBase::getOutputDTypeAttributeName(),
+                        newDataTypeAttr);
+          }
 
           // Update DPS operand layout as well.
           //

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/RepeatOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/RepeatOpRewritePattern.cpp
@@ -34,13 +34,9 @@ TTNNRepeatFoldingWorkaround::matchAndRewrite(ttnn::RepeatOp op,
       ttmlir::utils::appendLocationSuffix(op->getLoc(), "_zeros"), resultType,
       shapeAttr, dTypeAttr, layout, device, ttnn::MemoryConfigAttr());
 
-  SmallVector<Value> addInputs;
-  addInputs.push_back(op.getOperand());
-  addInputs.push_back(zerosOp.getResult());
-
   // Replace the RepeatOp with an AddOp to perform implicit repeat.
-  rewriter.replaceOpWithNewOp<ttnn::AddOp>(op, op.getResult().getType(),
-                                           addInputs);
+  rewriter.replaceOpWithNewOp<ttnn::AddOp>(
+      op, op.getResult().getType(), op.getOperand(), zerosOp.getResult());
 
   return success();
 }

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -7,6 +7,7 @@
 #include "ttmlir/Dialect/TTCore/IR/Utils.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNTraits.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ArgMaxOpRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/CumSumOpDimRewritePattern.h"
@@ -30,6 +31,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 
+#include "llvm/Support/raw_ostream.h"
 #include <optional>
 #include <tuple>
 #include <utility>
@@ -194,6 +196,15 @@ workaroundOutputOperand(mlir::TypedValue<RankedTensorType> opResult,
           rewriter.getAttr<ttcore::DataTypeAttr>(
               outputWorkaroundResults.tensorDataTypeResult.targetValue);
       op->setAttr("dtype", updatedDataTypeAttr);
+    }
+
+    if (outputWorkaroundResults.tensorDataTypeResult.isModified() &&
+        op->hasTrait<ttnn::HasOutputDTypeTrait>()) {
+      ttcore::DataTypeAttr updatedDataTypeAttr =
+          rewriter.getAttr<ttcore::DataTypeAttr>(
+              outputWorkaroundResults.tensorDataTypeResult.targetValue);
+      op->setAttr(HasOutputDTypeTraitBase::getOutputDTypeAttributeName(),
+                  updatedDataTypeAttr);
     }
 
     if ((outputWorkaroundResults.tensorBufferTypeResult.isModified() ||

--- a/test/ttmlir/Dialect/TTNN/Traits/has_output_dtype_traits_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/Traits/has_output_dtype_traits_negative.mlir
@@ -1,0 +1,27 @@
+// RUN: not ttmlir-opt --split-input-file --ttcore-register-device="system-desc-path=%system_desc_path%" %s 2>&1 | FileCheck %s
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+module {
+  func.func @has_output_dtype_trait_negative_test(%arg0: tensor<64x128xf32, #ttnn_layout>, %arg1: tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout> {
+    %0 = "ttnn.multiply"(%arg0, %arg1) <{output_dtype = #ttcore.supportedDataTypes<f32>}> : (tensor<64x128xf32, #ttnn_layout>, tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout>
+    "ttnn.deallocate"(%arg1) <{force = false}> : (tensor<64x128xf32, #ttnn_layout>) -> ()
+    "ttnn.deallocate"(%arg0) <{force = false}> : (tensor<64x128xf32, #ttnn_layout>) -> ()
+    return %0 : tensor<64x128xf32, #ttnn_layout>
+  }
+}
+
+// CHECK: error: 'ttnn.multiply' op Output tensor layout data type bf16 must match output data type attribute f32
+
+// -----
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+module {
+  func.func @has_output_dtype_trait_negative_test(%arg0: tensor<64x128xf32, #ttnn_layout>, %arg1: tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout> {
+    %0 = "ttnn.multiply"(%arg0, %arg1) : (tensor<64x128xf32, #ttnn_layout>, tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout>
+    "ttnn.deallocate"(%arg1) <{force = false}> : (tensor<64x128xf32, #ttnn_layout>) -> ()
+    "ttnn.deallocate"(%arg0) <{force = false}> : (tensor<64x128xf32, #ttnn_layout>) -> ()
+    return %0 : tensor<64x128xf32, #ttnn_layout>
+  }
+}
+
+// CHECK: error: 'ttnn.multiply' op Output data type attribute is not defined for op that has output layout attribute.

--- a/test/ttmlir/Dialect/TTNN/Traits/has_output_dtype_traits_positive.mlir
+++ b/test/ttmlir/Dialect/TTNN/Traits/has_output_dtype_traits_positive.mlir
@@ -1,0 +1,14 @@
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" %s | FileCheck %s
+
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x4x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+module {
+  func.func @has_output_dtype_trait_positive_test(%arg0: tensor<64x128xf32, #ttnn_layout>, %arg1: tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout> {
+    %0 = "ttnn.multiply"(%arg0, %arg1) <{output_dtype = #ttcore.supportedDataTypes<f32>}> : (tensor<64x128xf32, #ttnn_layout>, tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout>
+    // CHECK: "ttnn.multiply"
+    // CHECK-SAME: <{output_dtype = #ttcore.supportedDataTypes<f32>}>
+    "ttnn.deallocate"(%arg1) <{force = false}> : (tensor<64x128xf32, #ttnn_layout>) -> ()
+    "ttnn.deallocate"(%arg0) <{force = false}> : (tensor<64x128xf32, #ttnn_layout>) -> ()
+    return %0 : tensor<64x128xf32, #ttnn_layout>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/add_integer_broadcasting_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/add_integer_broadcasting_workaround.mlir
@@ -10,7 +10,7 @@ module attributes {} {
     // CHECK-SAME: tensor<1x1x1x128xbf16
     // CHECK-SAME: tensor<1x1x128x128xbf16
     // CHECK-SAME: tensor<1x1x128x128xbf16
-    %0 = "ttnn.add"(%arg0, %arg1) : (tensor<1x1x1x128xsi32,#ttnn_layout1>, tensor<1x1x128x128xsi32,#ttnn_layout>) -> tensor<1x1x128x128xsi32,#ttnn_layout>
+    %0 = "ttnn.add"(%arg0, %arg1) <{output_dtype = #ttcore.supportedDataTypes<si32>}> : (tensor<1x1x1x128xsi32,#ttnn_layout1>, tensor<1x1x128x128xsi32,#ttnn_layout>) -> tensor<1x1x128x128xsi32,#ttnn_layout>
     %1 = "ttnn.to_layout"(%0) <{dtype = #ttcore.supportedDataTypes<si32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<1x1x128x128xsi32, #ttnn_layout>) -> tensor<1x1x128x128xbf16, #ttnn_layout2>
     return %1 : tensor<1x1x128x128xbf16,#ttnn_layout2>
   }

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/binary_ops_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/binary_ops_workaround.mlir
@@ -20,7 +20,7 @@ module @jit_transpose attributes {} {
     // CHECK-SAME: tensor<32x64xbf16,
     // CHECK-SAME: tensor<32x64xbf16,
     // CHECK-SAME: -> tensor<32x64xbf16,
-    %0 = "ttnn.add"(%arg0, %arg1) : (tensor<32x64xui16, #ttnn_layout>, tensor<32x64xui16, #ttnn_layout>) -> tensor<32x64xui16, #ttnn_layout>
+    %0 = "ttnn.add"(%arg0, %arg1) <{output_dtype = #ttcore.supportedDataTypes<u16>}> : (tensor<32x64xui16, #ttnn_layout>, tensor<32x64xui16, #ttnn_layout>) -> tensor<32x64xui16, #ttnn_layout>
     // CHECK: = "ttnn.to_layout"(%[[ADD]])
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<u16>,
     // CHECK-SAME:tensor<32x64xbf16,
@@ -42,7 +42,7 @@ module @jit_transpose attributes {} {
     // CHECK-SAME: tensor<32x64xbf16,
     // CHECK-SAME: tensor<32x64xbf16,
     // CHECK-SAME: -> tensor<32x64xbf16,
-    %0 = "ttnn.multiply"(%arg0, %arg1) : (tensor<32x64xsi32, #ttnn_layout1>, tensor<32x64xsi32, #ttnn_layout1>) -> tensor<32x64xsi32, #ttnn_layout1>
+    %0 = "ttnn.multiply"(%arg0, %arg1) <{output_dtype = #ttcore.supportedDataTypes<si32>}> : (tensor<32x64xsi32, #ttnn_layout1>, tensor<32x64xsi32, #ttnn_layout1>) -> tensor<32x64xsi32, #ttnn_layout1>
     // CHECK: = "ttnn.to_layout"(%[[MULTIPLY]]
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<si32>,
     // CHECK-SAME:tensor<32x64xbf16,
@@ -86,7 +86,7 @@ module @jit_transpose attributes {} {
     // CHECK-SAME: tensor<4x4xbf16,
     // CHECK-SAME: tensor<4x4xbf16,
     // CHECK-SAME: -> tensor<4x4xbf16,
-    %0 = "ttnn.add"(%arg0, %arg1) : (tensor<4x4xbf16, #ttnn_layout3>, tensor<4x4xbf16, #ttnn_layout3>) -> tensor<4x4xbf16, #ttnn_layout3>
+    %0 = "ttnn.add"(%arg0, %arg1) <{output_dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<4x4xbf16, #ttnn_layout3>, tensor<4x4xbf16, #ttnn_layout3>) -> tensor<4x4xbf16, #ttnn_layout3>
     // CHECK: = "ttnn.to_layout"(%[[ADD]])
     // CHECK-SAME: layout = #ttnn.layout<row_major>,
     // CHECK-SAME: tensor<4x4xbf16,

--- a/test/ttmlir/Dialect/TTNN/Transforms/ttnn_create_input_gens_0.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/ttnn_create_input_gens_0.mlir
@@ -9,7 +9,7 @@ module attributes {ttcore.system_desc = #system_desc} {
   func.func @add(%arg0: tuple<tensor<64x128xf32, #ttnn_layout>, tensor<64x128xf32, #ttnn_layout>>) -> tuple<tensor<64x128xf32, #ttnn_layout>> {
     %0 = ttcore.get_tuple_element %arg0[0] : (tuple<tensor<64x128xf32, #ttnn_layout>, tensor<64x128xf32, #ttnn_layout>>) -> tensor<64x128xf32, #ttnn_layout>
     %1 = ttcore.get_tuple_element %arg0[1] : (tuple<tensor<64x128xf32, #ttnn_layout>, tensor<64x128xf32, #ttnn_layout>>) -> tensor<64x128xf32, #ttnn_layout>
-    %2 = "ttnn.add"(%0, %1) : (tensor<64x128xf32, #ttnn_layout>, tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout>
+    %2 = "ttnn.add"(%0, %1) <{output_dtype = #ttcore.supportedDataTypes<f32>}> : (tensor<64x128xf32, #ttnn_layout>, tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout>
     "ttnn.deallocate"(%1) <{force = false}> : (tensor<64x128xf32, #ttnn_layout>) -> ()
     "ttnn.deallocate"(%0) <{force = false}> : (tensor<64x128xf32, #ttnn_layout>) -> ()
     %3 = ttcore.tuple %2 : tuple<tensor<64x128xf32, #ttnn_layout>>

--- a/test/ttmlir/Dialect/TTNN/data_movement/data_type_cast/to_dtype_folding.mlir
+++ b/test/ttmlir/Dialect/TTNN/data_movement/data_type_cast/to_dtype_folding.mlir
@@ -30,7 +30,7 @@ module attributes {} {
         // CHECK: ttnn.to_dtype
         %0 = "ttnn.to_dtype"(%arg0) <{dtype = #ttcore.supportedDataTypes<si32>}> : (tensor<64x128xf32, #ttnn_layout_host_rm_f32>) -> tensor<64x128xi32, #ttnn_layout_host_rm_si32>
         %1 = "ttnn.to_dtype"(%0) <{dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<64x128xi32, #ttnn_layout_host_rm_si32>) -> tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>
-        %2 = "ttnn.add"(%0, %0) : (tensor<64x128xi32, #ttnn_layout_host_rm_si32>, tensor<64x128xi32, #ttnn_layout_host_rm_si32>) -> tensor<64x128xi32, #ttnn_layout_host_rm_si32>
+        %2 = "ttnn.add"(%0, %0) <{output_dtype = #ttcore.supportedDataTypes<si32>}> : (tensor<64x128xi32, #ttnn_layout_host_rm_si32>, tensor<64x128xi32, #ttnn_layout_host_rm_si32>) -> tensor<64x128xi32, #ttnn_layout_host_rm_si32>
         return %1, %2 : tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>, tensor<64x128xi32, #ttnn_layout_host_rm_si32>
     }
 }

--- a/test/ttmlir/Dialect/TTNN/data_movement/data_type_cast/typecast_folding.mlir
+++ b/test/ttmlir/Dialect/TTNN/data_movement/data_type_cast/typecast_folding.mlir
@@ -29,7 +29,7 @@ module attributes {} {
         // CHECK: ttnn.typecast
         %0 = "ttnn.typecast"(%arg0) <{dtype = #ttcore.supportedDataTypes<si32>}> : (tensor<64x128xf32, #ttnn_layout_device_tile_f32>) -> tensor<64x128xi32, #ttnn_layout_device_tile_si32>
         %1 = "ttnn.typecast"(%0) <{dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<64x128xi32, #ttnn_layout_device_tile_si32>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
-        %2 = "ttnn.add"(%0, %0) : (tensor<64x128xi32, #ttnn_layout_device_tile_si32>, tensor<64x128xi32, #ttnn_layout_device_tile_si32>) -> tensor<64x128xi32, #ttnn_layout_device_tile_si32>
+        %2 = "ttnn.add"(%0, %0) <{output_dtype = #ttcore.supportedDataTypes<si32>}> : (tensor<64x128xi32, #ttnn_layout_device_tile_si32>, tensor<64x128xi32, #ttnn_layout_device_tile_si32>) -> tensor<64x128xi32, #ttnn_layout_device_tile_si32>
         return %1, %2 : tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>, tensor<64x128xi32, #ttnn_layout_device_tile_si32>
     }
 }

--- a/test/ttmlir/Dialect/TTNN/optimizer/insert_memreconfig_const_eval.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/insert_memreconfig_const_eval.mlir
@@ -11,7 +11,7 @@ module attributes {} {
   func.func @main(%arg0: tensor<1x32x32xf32, #ttnn_layout>, %arg1: tensor<1x32x32xf32, #ttnn_layout> {ttcore.argument_type = #ttcore.argument_type<constant>}) -> tensor<1x32x32xf32, #ttnn_layout1> {
     // CHECK: "ttnn.to_layout"
     %0 = "ttnn.to_layout"(%arg1) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<<dram>, <interleaved>>}> : (tensor<1x32x32xf32, #ttnn_layout>) -> tensor<1x32x32xf32, #ttnn_layout1>
-    %1 = "ttnn.add"(%arg0, %0) : (tensor<1x32x32xf32, #ttnn_layout>, tensor<1x32x32xf32, #ttnn_layout1>) -> tensor<1x32x32xf32, #ttnn_layout1> loc(#loc1)
+    %1 = "ttnn.add"(%arg0, %0) <{output_dtype = #ttcore.supportedDataTypes<f32>}> : (tensor<1x32x32xf32, #ttnn_layout>, tensor<1x32x32xf32, #ttnn_layout1>) -> tensor<1x32x32xf32, #ttnn_layout1> loc(#loc1)
     return %1 : tensor<1x32x32xf32, #ttnn_layout1>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/test_remove_dead_values_pass.mlir
+++ b/test/ttmlir/Dialect/TTNN/test_remove_dead_values_pass.mlir
@@ -14,7 +14,7 @@ module attributes {} {
     %4 = "ttnn.to_device"(%3, %0) <{memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout1>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout1>
     "ttnn.deallocate"(%3) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     // CHECK: "ttnn.multiply"
-    %5 = "ttnn.multiply"(%2, %4) : (tensor<64x128xf32, #ttnn_layout1>, tensor<64x128xf32, #ttnn_layout1>) -> tensor<64x128xf32, #ttnn_layout2>
+    %5 = "ttnn.multiply"(%2, %4) <{output_dtype = #ttcore.supportedDataTypes<f32>}> : (tensor<64x128xf32, #ttnn_layout1>, tensor<64x128xf32, #ttnn_layout1>) -> tensor<64x128xf32, #ttnn_layout2>
     "ttnn.deallocate"(%4) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     "ttnn.deallocate"(%2) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     %6 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
@@ -24,7 +24,7 @@ module attributes {} {
     %9 = "ttnn.to_device"(%8, %0) <{memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout1>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout1>
     "ttnn.deallocate"(%8) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     // CHECK-NOT: "ttnn.add"
-    %10 = "ttnn.add"(%7, %9) : (tensor<64x128xf32, #ttnn_layout1>, tensor<64x128xf32, #ttnn_layout1>) -> tensor<64x128xf32, #ttnn_layout2>
+    %10 = "ttnn.add"(%7, %9) <{output_dtype = #ttcore.supportedDataTypes<f32>}> : (tensor<64x128xf32, #ttnn_layout1>, tensor<64x128xf32, #ttnn_layout1>) -> tensor<64x128xf32, #ttnn_layout2>
     "ttnn.deallocate"(%9) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     "ttnn.deallocate"(%7) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     %11 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
@@ -34,7 +34,7 @@ module attributes {} {
     %14 = "ttnn.to_device"(%13, %0) <{memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout1>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout1>
     "ttnn.deallocate"(%13) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     // CHECK-NOT: "ttnn.subtract"
-    %15 = "ttnn.subtract"(%12, %14) : (tensor<64x128xf32, #ttnn_layout1>, tensor<64x128xf32, #ttnn_layout1>) -> tensor<64x128xf32, #ttnn_layout2>
+    %15 = "ttnn.subtract"(%12, %14) <{output_dtype = #ttcore.supportedDataTypes<f32>}> : (tensor<64x128xf32, #ttnn_layout1>, tensor<64x128xf32, #ttnn_layout1>) -> tensor<64x128xf32, #ttnn_layout2>
     "ttnn.deallocate"(%14) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     "ttnn.deallocate"(%12) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     %16 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
@@ -44,7 +44,7 @@ module attributes {} {
     %19 = "ttnn.to_device"(%18, %0) <{memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout1>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout1>
     "ttnn.deallocate"(%18) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     // CHECK-NOT: "ttnn.divide"
-    %20 = "ttnn.divide"(%17, %19) : (tensor<64x128xf32, #ttnn_layout1>, tensor<64x128xf32, #ttnn_layout1>) -> tensor<64x128xf32, #ttnn_layout2>
+    %20 = "ttnn.divide"(%17, %19) <{output_dtype = #ttcore.supportedDataTypes<f32>}> : (tensor<64x128xf32, #ttnn_layout1>, tensor<64x128xf32, #ttnn_layout1>) -> tensor<64x128xf32, #ttnn_layout2>
     "ttnn.deallocate"(%19) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     "ttnn.deallocate"(%17) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     %21 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<tile>}> : (tensor<64x128xf32, #ttnn_layout>) -> tensor<64x128xf32, #ttnn_layout1>
@@ -54,7 +54,7 @@ module attributes {} {
     %24 = "ttnn.to_device"(%23, %0) <{memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout1>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout1>
     "ttnn.deallocate"(%23) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     // CHECK-NOT: "ttnn.eq"
-    %25 = "ttnn.eq"(%22, %24) : (tensor<64x128xf32, #ttnn_layout1>, tensor<64x128xf32, #ttnn_layout1>) -> tensor<64x128xf32, #ttnn_layout2>
+    %25 = "ttnn.eq"(%22, %24)<{output_dtype = #ttcore.supportedDataTypes<f32>}> : (tensor<64x128xf32, #ttnn_layout1>, tensor<64x128xf32, #ttnn_layout1>) -> tensor<64x128xf32, #ttnn_layout2>
     "ttnn.deallocate"(%24) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     "ttnn.deallocate"(%22) <{force = false}> : (tensor<64x128xf32, #ttnn_layout1>) -> ()
     %26 = "ttnn.from_device"(%5) : (tensor<64x128xf32, #ttnn_layout2>) -> tensor<64x128xf32, #ttnn_layout>

--- a/test/ttmlir/EmitC/TTNN/models/mnist_sharded.mlir
+++ b/test/ttmlir/EmitC/TTNN/models/mnist_sharded.mlir
@@ -21,7 +21,7 @@ func.func @mnist_fwd(%arg0: tensor<1x784xf32, #ttnn_layout>, %arg1: tensor<1x10x
   %1 = "ttnn.matmul"(%arg0, %arg4) <{transpose_a = false, transpose_b = false}> : (tensor<1x784xf32, #ttnn_layout>, tensor<784x256xf32, #ttnn_layout4>) -> tensor<1x256xf32, #ttnn_layout5>
   "ttnn.deallocate"(%arg4) <{force = false}> : (tensor<784x256xf32, #ttnn_layout4>) -> ()
   "ttnn.deallocate"(%arg0) <{force = false}> : (tensor<1x784xf32, #ttnn_layout>) -> ()
-  %2 = "ttnn.add"(%1, %arg3) : (tensor<1x256xf32, #ttnn_layout5>, tensor<1x256xf32, #ttnn_layout3>) -> tensor<1x256xf32, #ttnn_layout5>
+  %2 = "ttnn.add"(%1, %arg3) <{output_dtype = #ttcore.supportedDataTypes<f32>}> : (tensor<1x256xf32, #ttnn_layout5>, tensor<1x256xf32, #ttnn_layout3>) -> tensor<1x256xf32, #ttnn_layout5>
   "ttnn.deallocate"(%1) <{force = false}> : (tensor<1x256xf32, #ttnn_layout5>) -> ()
   "ttnn.deallocate"(%arg3) <{force = false}> : (tensor<1x256xf32, #ttnn_layout3>) -> ()
   %3 = "ttnn.to_memory_config"(%2) <{memory_config = #ttnn.memory_config<#l1, <block_sharded>, #ttnn.shard_spec<<[#ttnn.core_range<(0,0), (7,0)>]>, <32x32>, <row_major>, <physical>>>}> : (tensor<1x256xf32, #ttnn_layout5>) -> tensor<1x256xf32, #ttnn_layout6>
@@ -33,7 +33,7 @@ func.func @mnist_fwd(%arg0: tensor<1x784xf32, #ttnn_layout>, %arg1: tensor<1x10x
   %6 = "ttnn.matmul"(%5, %arg2) <{transpose_a = false, transpose_b = false}> : (tensor<1x256xf32, #ttnn_layout1>, tensor<256x10xf32, #ttnn_layout2>) -> tensor<1x10xf32, #ttnn_layout5>
   "ttnn.deallocate"(%5) <{force = false}> : (tensor<1x256xf32, #ttnn_layout1>) -> ()
   "ttnn.deallocate"(%arg2) <{force = false}> : (tensor<256x10xf32, #ttnn_layout2>) -> ()
-  %7 = "ttnn.add"(%6, %arg1) : (tensor<1x10xf32, #ttnn_layout5>, tensor<1x10xf32, #ttnn_layout1>) -> tensor<1x10xf32, #ttnn_layout5>
+  %7 = "ttnn.add"(%6, %arg1) <{output_dtype = #ttcore.supportedDataTypes<f32>}> : (tensor<1x10xf32, #ttnn_layout5>, tensor<1x10xf32, #ttnn_layout1>) -> tensor<1x10xf32, #ttnn_layout5>
   "ttnn.deallocate"(%6) <{force = false}> : (tensor<1x10xf32, #ttnn_layout5>) -> ()
   "ttnn.deallocate"(%arg1) <{force = false}> : (tensor<1x10xf32, #ttnn_layout1>) -> ()
   %8 = "ttnn.softmax"(%7) <{dimension = 1 : si32}> : (tensor<1x10xf32, #ttnn_layout5>) -> tensor<1x10xf32, #ttnn_layout5>


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Recently we introduced the output_dtype attribute for binary ops in this PR:
https://github.com/tenstorrent/tt-mlir/pull/3934

However, we didn't add any verification regarding it.

### What's changed
Added a new trait on the binary ops to verify that the layout data type is in sync with output_dtype op attribute.

### Checklist
- [x] New/Existing tests provide coverage for changes
