### PR TITLE
Remove device attribute from a TTNN to_layout op

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -65,8 +65,7 @@ def TTNN_ToLayoutOp : TTNN_Op<"to_layout",
     let arguments = (ins AnyRankedTensor:$input,
                          TTNN_LayoutAttr:$layout,
                          OptionalAttr<TTCore_DataTypeAttr>:$dtype,
-                         OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config,
-                         Optional<TTNN_Device>:$device);
+                         OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
     let results = (outs AnyRankedTensor:$result);
 
     let hasCanonicalizer = 1;

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -223,17 +223,18 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 //===----------------------------------------------------------------------===//
 
 namespace ToLayoutOpInterface {
-llvm::Expected<OpConstraints> getOpConstraints(
-    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
-    mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-    std::optional<mlir::tt::ttcore::DataType> outputDtype,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool passDevicePtr);
+llvm::Expected<OpConstraints>
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+                 std::optional<mlir::tt::ttcore::DataType> outputDtype,
+                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
 
 llvm::Expected<size_t>
 getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
              mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
              std::optional<mlir::tt::ttcore::DataType> outputDtype,
-             mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool passDevicePtr);
+             mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
 
 }; // namespace ToLayoutOpInterface
 

--- a/include/ttmlir/Target/TTNN/operations/layout.fbs
+++ b/include/ttmlir/Target/TTNN/operations/layout.fbs
@@ -26,7 +26,6 @@ table ToLayoutOp {
   layout: tt.target.TensorLayout;
   dtype: tt.target.DataType = null;
   memcfg: tt.target.ttnn.MemoryConfig;
-  device: tt.target.DeviceRef;
   out: tt.target.ttnn.TensorRef;
 }
 

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -218,8 +218,6 @@ public:
 
     ttnn::Layout outputLayoutEnum = outputLayoutAttr.getLayout();
 
-    bool isOutputOnHost = (outputBufferType == ttnn::BufferType::SystemMemory);
-
     RankedTensorType result = mlir::cast<RankedTensorType>(op.getType(0));
 
     ttnn::LayoutAttr outputLayout =
@@ -232,10 +230,7 @@ public:
 
     rewriter.replaceOpWithNewOp<ttnn::ToLayoutOp>(
         op, this->getTypeConverter()->convertType(result), adaptor.getInput(),
-        outputLayout, outputDataType, outputMemConfigAttr,
-        isOutputOnHost
-            ? nullptr
-            : mlir::Value(::ttnn::utils::getOrInsertDevice(rewriter, op)));
+        outputLayout, outputDataType, outputMemConfigAttr);
 
     return success();
   }

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -573,14 +573,11 @@ ToLayoutOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
     return check.takeError();
   }
 
-  auto deviceOperand = getDevice();
-  const bool passDevicePtr = !deviceOperand;
   ttcore::GridAttr deviceGrid =
       ttcore::lookupDevice(getOperation()).getWorkerGrid();
 
   return op_model::ttnn::ToLayoutOpInterface::getOpConstraints(
-      deviceGrid, inputShape, inputs[0], getDtype(), opConfig.outputLayout,
-      passDevicePtr);
+      deviceGrid, inputShape, inputs[0], getDtype(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -591,11 +588,8 @@ ToLayoutOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 
   const auto inputShape = getInput().getType().getShape();
 
-  auto deviceOperand = getDevice();
-  const bool passDevicePtr = !deviceOperand;
-
   return op_model::ttnn::ToLayoutOpInterface::getOpRuntime(
-      inputShape, inputs[0], getDtype(), opConfig.outputLayout, passDevicePtr);
+      inputShape, inputs[0], getDtype(), opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -1498,8 +1498,7 @@ void mlir::tt::ttnn::ToLayoutOp::getCanonicalizationPatterns(
                                   : previousToLayoutOp.getDtypeAttr(),
         toLayoutOp.getMemoryConfigAttr()
             ? toLayoutOp.getMemoryConfigAttr()
-            : previousToLayoutOp.getMemoryConfigAttr(),
-        toLayoutOp.getDevice());
+            : previousToLayoutOp.getMemoryConfigAttr());
 
     // Replace all uses of the current op with the merged ToLayoutOp.
     rewriter.replaceAllUsesWith(toLayoutOp, mergedToLayout);

--- a/lib/Dialect/TTNN/Utils/TransformUtils.cpp
+++ b/lib/Dialect/TTNN/Utils/TransformUtils.cpp
@@ -91,11 +91,6 @@ createToLayoutOp(Operation *op, mlir::TypedValue<RankedTensorType> inputValue,
           mlir::cast<TTNNLayoutAttr>(toLayoutOpResultType.getEncoding()),
           deviceAttr.getWorkerGrid()));
 
-  // Get the device value if the tensor output is not on the host.
-  auto deviceValue = targetTensorBufferType == ttnn::BufferType::SystemMemory
-                         ? nullptr
-                         : Value(utils::getOrInsertDevice(rewriter, op));
-
   Location loc = ttmlir::utils::appendLocationSuffix(op->getLoc(), locSuffix);
   // Create a ToLayoutOp to convert the input operand to the desired
   // tensor layout, buffer type and memory layout.o
@@ -103,6 +98,6 @@ createToLayoutOp(Operation *op, mlir::TypedValue<RankedTensorType> inputValue,
       loc, toLayoutOpResultType, inputValue,
       LayoutAttr::get(rewriter.getContext(), targetTensorLayout),
       ttcore::DataTypeAttr::get(rewriter.getContext(), targetTensorDataType),
-      outputMemConfigAttr, deviceValue);
+      outputMemConfigAttr);
 }
 } // namespace mlir::tt::ttnn::utils

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -1274,7 +1274,7 @@ llvm::Expected<OpConstraints> ToLayoutOpInterface::getOpConstraints(
     mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShape,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
     std::optional<mlir::tt::ttcore::DataType> outputDtype,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool passDevicePtr) {
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1312,7 +1312,7 @@ llvm::Expected<size_t> ToLayoutOpInterface::getOpRuntime(
     llvm::ArrayRef<int64_t> inputShape,
     mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
     std::optional<mlir::tt::ttcore::DataType> outputDtype,
-    mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool passDevicePtr) {
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -223,14 +223,10 @@ createOp(FlatbufferObjectCache &cache, ToLayoutOp op) {
       toFlatbuffer(cache, op.getDtype());
   std::optional<::mlir::tt::ttnn::MemoryConfigAttr> memoryConfig =
       op.getMemoryConfig();
-  ::mlir::Value device = op.getDevice();
-  if (device) {
-    device = getOperandThroughDPSOps(device);
-  }
+
   return ::tt::target::ttnn::CreateToLayoutOp(
       *cache.fbb, input, layout, dtype,
-      memoryConfig ? toFlatbuffer(cache, *memoryConfig) : 0,
-      device ? cache.at<::tt::target::DeviceRef>(device) : 0, output);
+      memoryConfig ? toFlatbuffer(cache, *memoryConfig) : 0, output);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::ToDTypeOp>

--- a/test/ttmlir/Dialect/TTNN/Canonicalizer/simple_to_layout_op_canonicalizer.mlir
+++ b/test/ttmlir/Dialect/TTNN/Canonicalizer/simple_to_layout_op_canonicalizer.mlir
@@ -9,75 +9,70 @@
 #ttnn_layout5 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<32x32xf32, #system_memory>>
 module attributes {} {
   func.func @merge_to_layout_op_layout(%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout2> {
-    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     // Verify that the to_layout op is canonicalized to a single to_layout op and the attributes are merged.
-    // CHECK: "ttnn.to_layout"(%arg0, %0)
+    // CHECK: "ttnn.to_layout"(%arg0)
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
     // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: memory_config = #ttnn.memory_config<#dram, <interleaved>>
     // CHECK-SAME: -> tensor<32x32xbf16, #ttnn_layout1>
     // CHECK-NEXT: return
-    %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x32xbf16, #ttnn_layout>, !ttnn.device) -> tensor<32x32xbf16, #ttnn_layout1>
-    %2 = "ttnn.to_layout"(%1, %0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x32xbf16, #ttnn_layout1>, !ttnn.device) -> tensor<32x32xbf16, #ttnn_layout2>
-    return %2 : tensor<32x32xbf16, #ttnn_layout2>
+    %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout1>
+    %1 = "ttnn.to_layout"(%0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x32xbf16, #ttnn_layout1>) -> tensor<32x32xbf16, #ttnn_layout2>
+    return %1 : tensor<32x32xbf16, #ttnn_layout2>
   }
 
   func.func @merge_to_layout_op_data_type(%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xf32, #ttnn_layout3> {
     // Verify that the to_layout op is canonicalized to a single to_layout op and the attributes are merged.
-    // CHECK: "ttnn.to_layout"(%arg0, %0)
+    // CHECK: "ttnn.to_layout"(%arg0)
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<f32>
     // CHECK-SAME: layout = #ttnn.layout<tile>
     // CHECK-SAME: memory_config = #ttnn.memory_config<#dram, <interleaved>>
     // CHECK-SAME: -> tensor<32x32xf32, #ttnn_layout2>
     // CHECK-NEXT: return
-    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x32xbf16, #ttnn_layout>, !ttnn.device) -> tensor<32x32xbf16, #ttnn_layout1>
-    %2 = "ttnn.to_layout"(%1, %0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x32xbf16, #ttnn_layout1>, !ttnn.device) -> tensor<32x32xf32, #ttnn_layout3>
-    return %2 : tensor<32x32xf32, #ttnn_layout3>
+    %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout1>
+    %1 = "ttnn.to_layout"(%0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x32xbf16, #ttnn_layout1>) -> tensor<32x32xf32, #ttnn_layout3>
+    return %1 : tensor<32x32xf32, #ttnn_layout3>
   }
 
   func.func @merge_to_layout_op_memory_config(%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout4> {
     // Verify that the to_layout op is canonicalized to a single to_layout op and the attributes are merged.
-    // CHECK: "ttnn.to_layout"(%arg0, %0)
+    // CHECK: "ttnn.to_layout"(%arg0)
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
     // CHECK-SAME: layout = #ttnn.layout<tile>
     // CHECK-SAME: memory_config = #ttnn.memory_config<#system_memory>
     // CHECK-SAME: -> tensor<32x32xbf16, #ttnn_layout3>
     // CHECK-NEXT: return
-    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x32xbf16, #ttnn_layout>, !ttnn.device) -> tensor<32x32xbf16, #ttnn_layout1>
-    %2 = "ttnn.to_layout"(%1, %0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<32x32xbf16, #ttnn_layout1>, !ttnn.device) -> tensor<32x32xbf16, #ttnn_layout4>
-    return %2 : tensor<32x32xbf16, #ttnn_layout4>
+    %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout1>
+    %1 = "ttnn.to_layout"(%0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<32x32xbf16, #ttnn_layout1>) -> tensor<32x32xbf16, #ttnn_layout4>
+    return %1 : tensor<32x32xbf16, #ttnn_layout4>
   }
 
   func.func @merge_to_layout_op_all(%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xf32, #ttnn_layout5> {
     // Verify that the to_layout op is canonicalized to a single to_layout op and the attributes are merged.
-    // CHECK: "ttnn.to_layout"(%arg0, %0)
+    // CHECK: "ttnn.to_layout"(%arg0)
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<f32>
     // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: memory_config = #ttnn.memory_config<#system_memory>
     // CHECK-SAME: -> tensor<32x32xf32, #ttnn_layout4>
     // CHECK-NEXT: return
-    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x32xbf16, #ttnn_layout>, !ttnn.device) -> tensor<32x32xbf16, #ttnn_layout1>
-    %2 = "ttnn.to_layout"(%1, %0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<32x32xbf16, #ttnn_layout1>, !ttnn.device) -> tensor<32x32xf32, #ttnn_layout5>
-    return %2 : tensor<32x32xf32, #ttnn_layout5>
+    %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout1>
+    %1 = "ttnn.to_layout"(%0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<32x32xbf16, #ttnn_layout1>) -> tensor<32x32xf32, #ttnn_layout5>
+    return %1 : tensor<32x32xf32, #ttnn_layout5>
   }
 
   func.func @merge_to_layout_op_4x(%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xf32, #ttnn_layout5> {
     // Verify that the to_layout op is canonicalized to a single to_layout op and the attributes are merged.
-    // CHECK: "ttnn.to_layout"(%arg0, %0)
+    // CHECK: "ttnn.to_layout"(%arg0)
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<f32>
     // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: memory_config = #ttnn.memory_config<#system_memory>
     // CHECK-SAME: -> tensor<32x32xf32, #ttnn_layout4>
     // CHECK-NEXT: return
-    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x32xbf16, #ttnn_layout>, !ttnn.device) -> tensor<32x32xbf16, #ttnn_layout1>
-    %2 = "ttnn.to_layout"(%1, %0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<32x32xbf16, #ttnn_layout1>, !ttnn.device) -> tensor<32x32xf32, #ttnn_layout5>
-    %3 = "ttnn.to_layout"(%2, %0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x32xf32, #ttnn_layout5>, !ttnn.device) -> tensor<32x32xf32, #ttnn_layout3>
-    %4 = "ttnn.to_layout"(%3, %0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<32x32xf32, #ttnn_layout3>, !ttnn.device) -> tensor<32x32xf32, #ttnn_layout5>
-    return %4 : tensor<32x32xf32, #ttnn_layout5>
+    %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout1>
+    %1 = "ttnn.to_layout"(%0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<32x32xbf16, #ttnn_layout1>) -> tensor<32x32xf32, #ttnn_layout5>
+    %2 = "ttnn.to_layout"(%1) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<32x32xf32, #ttnn_layout5>) -> tensor<32x32xf32, #ttnn_layout3>
+    %3 = "ttnn.to_layout"(%2) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<32x32xf32, #ttnn_layout3>) -> tensor<32x32xf32, #ttnn_layout5>
+    return %3 : tensor<32x32xf32, #ttnn_layout5>
   }
 
   func.func @fold_to_layout_op(%arg0: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout> {

--- a/test/ttmlir/Dialect/TTNN/Transforms/DecomposeLayouts/decomposing_layouts_from_host.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/DecomposeLayouts/decomposing_layouts_from_host.mlir
@@ -25,9 +25,8 @@ module attributes {} {
         // CHECK: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
         // CHECK-SAME: memory_config = #ttnn.memory_config<#dram, <interleaved>>
         // CHECK: return %[[TO_DEVICE_OP]]
-        %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-        %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout_device_rm>
-        return %1 : tensor<64x128xf32, #ttnn_layout_device_rm>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xf32, #ttnn_layout_device_rm>
+        return %0 : tensor<64x128xf32, #ttnn_layout_device_rm>
     }
 
     // Test cases when we do layout transformation from host and we don't change tensor layout but we cast tensor data type.
@@ -39,8 +38,8 @@ module attributes {} {
         // CHECK: %[[CASTING_OP:.*]] = "ttnn.to_dtype"(%arg0)
         // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
         // CHECK-NEXT: return %[[CASTING_OP]]
-        %1 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>
-        return %1 : tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>
+        return %0 : tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>
     }
 
     // Test case when we move tensor from host to host for row-major case.
@@ -49,8 +48,8 @@ module attributes {} {
         // CHECK: %[[CASTING_OP:.*]] = "ttnn.to_dtype"(%arg0)
         // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
         // CHECK-NEXT: return %[[CASTING_OP]]
-        %1 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>
-        return %1 : tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>
+        return %0 : tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>
     }
 
     // Test case when we move tensor from host to device for row-major case.
@@ -62,9 +61,8 @@ module attributes {} {
         // CHECK: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%[[CASTING_OP]], %[[GET_DEVICE_OP]])
         // CHECK-SAME: memory_config = #ttnn.memory_config<#dram, <interleaved>>
         // CHECK-NEXT: return %[[TO_DEVICE_OP]]
-        %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-        %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>, !ttnn.device) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
-        return %1 : tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
+        return %0 : tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
     }
 
     // Test case when we move tensor from host to device for tile case.
@@ -76,9 +74,8 @@ module attributes {} {
         // CHECK-NEXT: %[[CASTING_OP:.*]] = "ttnn.typecast"(%[[TO_DEVICE_OP]])
         // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
         // CHECK-NEXT: return %[[CASTING_OP]]
-        %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-        %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout_host_tile>, !ttnn.device) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
-        return %1 : tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
+        return %0 : tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
     }
 
     // Test cases when we do layout transformation from host and we change tensor layout but we don't cast tensor data type.
@@ -90,8 +87,8 @@ module attributes {} {
         // CHECK: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%arg0)
         // CHECK-SAME: layout = #ttnn.layout<row_major>
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %1 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
-        return %1 : tensor<64x128xf32, #ttnn_layout_host_rm>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
+        return %0 : tensor<64x128xf32, #ttnn_layout_host_rm>
     }
 
     // Test case when we move tensor from host to host for row-major -> tile case.
@@ -100,8 +97,8 @@ module attributes {} {
         // CHECK: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%arg0)
         // CHECK-SAME: layout = #ttnn.layout<tile>
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %1 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xf32, #ttnn_layout_host_tile>
-        return %1 : tensor<64x128xf32, #ttnn_layout_host_tile>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xf32, #ttnn_layout_host_tile>
+        return %0 : tensor<64x128xf32, #ttnn_layout_host_tile>
     }
 
     // Test case when we move tensor from host to device for tile -> row-major case for bf16 data type.
@@ -109,12 +106,11 @@ module attributes {} {
         // This test verifies that the `to_layout` and `to_device` operations are correctly inserted to move the tensor to the device and then change layout from tile to row-major.
         // CHECK: %[[GET_DEVICE_OP:.*]] = "ttnn.get_device"()
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
-        // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]], %[[GET_DEVICE_OP]])
+        // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
         // CHECK-SAME: layout = #ttnn.layout<row_major>
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-        %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>, !ttnn.device) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
-        return %1 : tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
+        return %0 : tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
     }
 
     // Test case when we move tensor from host to device for tile -> row-major case for f32 data type.
@@ -125,9 +121,8 @@ module attributes {} {
         // CHECK-SAME: layout = #ttnn.layout<row_major>
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%[[TO_LAYOUT_OP]], %[[GET_DEVICE_OP]])
         // CHECK-NEXT: return %[[TO_DEVICE_OP]]
-        %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-        %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout_host_tile>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout_device_rm>
-        return %1 : tensor<64x128xf32, #ttnn_layout_device_rm>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xf32, #ttnn_layout_device_rm>
+        return %0 : tensor<64x128xf32, #ttnn_layout_device_rm>
     }
 
     // Test case when we move tensor from host to device for row-major -> tile case for bf16 data type.
@@ -136,12 +131,11 @@ module attributes {} {
         // Specifically, it ensures that BF16 tiling is performed on the device.
         // CHECK: %[[GET_DEVICE_OP:.*]] = "ttnn.get_device"()
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
-        // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]], %[[GET_DEVICE_OP]])
+        // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
         // CHECK-SAME: layout = #ttnn.layout<tile>
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-        %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>, !ttnn.device) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
-        return %1 : tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
+        return %0 : tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
     }
 
     // Test case when we move tensor from host to device for row-major -> tile case for non-bf16 non-f32 data type.
@@ -153,9 +147,8 @@ module attributes {} {
         // CHECK-SAME: layout = #ttnn.layout<tile>
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%[[TO_LAYOUT_OP]], %[[GET_DEVICE_OP]])
         // CHECK-NEXT: return %[[TO_DEVICE_OP]]
-        %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-        %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #ttcore.supportedDataTypes<u32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xui32, #ttnn_layout_host_rm_u32>, !ttnn.device) -> tensor<64x128xui32, #ttnn_layout_device_tile_u32>
-        return %1 : tensor<64x128xui32, #ttnn_layout_device_tile_u32>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<u32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xui32, #ttnn_layout_host_rm_u32>) -> tensor<64x128xui32, #ttnn_layout_device_tile_u32>
+        return %0 : tensor<64x128xui32, #ttnn_layout_device_tile_u32>
     }
 
     // Test cases when we do layout transformation from host and we change both tensor layout and tensor data type.
@@ -169,8 +162,8 @@ module attributes {} {
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[CASTING_OP]])
         // CHECK-SAME: layout = #ttnn.layout<row_major>
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %1 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
-        return %1 : tensor<64x128xf32, #ttnn_layout_host_rm>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
+        return %0 : tensor<64x128xf32, #ttnn_layout_host_rm>
     }
 
     // Test case when we move tensor from host to host for row-major -> tile case and data type cast.
@@ -181,8 +174,8 @@ module attributes {} {
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[CASTING_OP]])
         // CHECK-SAME: layout = #ttnn.layout<tile>
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %1 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xf32, #ttnn_layout_host_tile>
-        return %1 : tensor<64x128xf32, #ttnn_layout_host_tile>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xf32, #ttnn_layout_host_tile>
+        return %0 : tensor<64x128xf32, #ttnn_layout_host_tile>
     }
 
     // Test case when we move tensor from host to device for tile -> row-major case and cast input from bf16.
@@ -196,9 +189,8 @@ module attributes {} {
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%[[TO_LAYOUT_OP]], %[[GET_DEVICE_OP]])
         // CHECK-SAME: memory_config = #ttnn.memory_config<#dram, <interleaved>>
         // CHECK-NEXT: return %[[TO_DEVICE_OP]]
-        %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-        %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout_device_rm>
-        return %1 : tensor<64x128xf32, #ttnn_layout_device_rm>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>) -> tensor<64x128xf32, #ttnn_layout_device_rm>
+        return %0 : tensor<64x128xf32, #ttnn_layout_device_rm>
     }
 
     // Test case when we move tensor from host to device for row-major -> tile case and cast input from bf16.
@@ -207,14 +199,13 @@ module attributes {} {
         // data type from bf16 to f32 on device.
         // CHECK: %[[GET_DEVICE_OP:.*]] = "ttnn.get_device"()
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
-        // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]], %[[GET_DEVICE_OP]])
+        // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
         // CHECK-SAME: layout = #ttnn.layout<tile>
         // CHECK-NEXT: %[[CASTING_OP:.*]] = "ttnn.typecast"(%[[TO_LAYOUT_OP]])
         // CHECK-SAME: dtype = #ttcore.supportedDataTypes<f32>
         // CHECK-NEXT: return %[[CASTING_OP]]
-        %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-        %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout_device_tile>
-        return %1 : tensor<64x128xf32, #ttnn_layout_device_tile>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xf32, #ttnn_layout_device_tile>
+        return %0 : tensor<64x128xf32, #ttnn_layout_device_tile>
     }
 
     // Test case when we move tensor from host to device for row-major -> tile case and cast input to bf16.
@@ -224,12 +215,11 @@ module attributes {} {
         // CHECK-NEXT: %[[CASTING_OP:.*]] = "ttnn.to_dtype"(%arg0)
         // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%[[CASTING_OP]], %[[GET_DEVICE_OP]])
-        // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]], %[[GET_DEVICE_OP]])
+        // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
         // CHECK-SAME: layout = #ttnn.layout<tile>
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-        %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>, !ttnn.device) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
-        return %1 : tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
+        return %0 : tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
     }
 
     // Test case when we move tensor from host to device for row-major -> tile case and we don't cast data type to bf16 nor from bf16.
@@ -242,8 +232,7 @@ module attributes {} {
         // CHECK-SAME: layout = #ttnn.layout<tile>
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%[[TO_LAYOUT_OP]], %[[GET_DEVICE_OP]])
         // CHECK-NEXT: return %[[TO_DEVICE_OP]]
-        %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-        %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #ttcore.supportedDataTypes<u32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>, !ttnn.device) -> tensor<64x128xui32, #ttnn_layout_device_tile_u32>
-        return %1 : tensor<64x128xui32, #ttnn_layout_device_tile_u32>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<u32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xui32, #ttnn_layout_device_tile_u32>
+        return %0 : tensor<64x128xui32, #ttnn_layout_device_tile_u32>
     }
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/add_integer_broadcasting_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/add_integer_broadcasting_workaround.mlir
@@ -6,13 +6,12 @@
 #ttnn_layout2 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 128 + d1 * 128 + d2, d3), <1x1>, memref<4x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
 module attributes {} {
   func.func @add_integer_broadcast(%arg0: tensor<1x1x1x128xsi32,#ttnn_layout1>, %arg1: tensor<1x1x128x128xsi32,#ttnn_layout>) -> tensor<1x1x128x128xbf16,#ttnn_layout2> {
-    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     // CHECK: "ttnn.add"
     // CHECK-SAME: tensor<1x1x1x128xbf16
     // CHECK-SAME: tensor<1x1x128x128xbf16
     // CHECK-SAME: tensor<1x1x128x128xbf16
-    %1 = "ttnn.add"(%arg0, %arg1) : (tensor<1x1x1x128xsi32,#ttnn_layout1>, tensor<1x1x128x128xsi32,#ttnn_layout>) -> tensor<1x1x128x128xsi32,#ttnn_layout>
-    %2 = "ttnn.to_layout"(%1, %0) <{dtype = #ttcore.supportedDataTypes<si32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<1x1x128x128xsi32, #ttnn_layout>, !ttnn.device) -> tensor<1x1x128x128xbf16, #ttnn_layout2>
-    return %2 : tensor<1x1x128x128xbf16,#ttnn_layout2>
+    %0 = "ttnn.add"(%arg0, %arg1) : (tensor<1x1x1x128xsi32,#ttnn_layout1>, tensor<1x1x128x128xsi32,#ttnn_layout>) -> tensor<1x1x128x128xsi32,#ttnn_layout>
+    %1 = "ttnn.to_layout"(%0) <{dtype = #ttcore.supportedDataTypes<si32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<1x1x128x128xsi32, #ttnn_layout>) -> tensor<1x1x128x128xbf16, #ttnn_layout2>
+    return %1 : tensor<1x1x128x128xbf16,#ttnn_layout2>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/arange_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/arange_workaround.mlir
@@ -14,7 +14,7 @@ module {
       // CHECK-NEXT: %[[ARANGE_OP:.*]] = "ttnn.arange"(%[[GET_DEVICE_OP]])
       // CHECK-SAME: -> tensor<1024xsi32, #[[TTNN_LAYOUT_ARANGE_OUTPUT]]>
       // Verify that after arange op, there is a to layout op to convert the layout to tile.
-      // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[ARANGE_OP]], %[[GET_DEVICE_OP]])
+      // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[ARANGE_OP]])
       // CHECK-SAME: dtype = #ttcore.supportedDataTypes<si32>
       // CHECK-SAME: layout = #ttnn.layout<tile>
       // CHECK-SAME: memory_config = #ttnn.memory_config<#dram, <interleaved>>

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/argmax_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/argmax_workaround.mlir
@@ -10,7 +10,7 @@ module attributes {} {
     // CHECK-SAME: {shape = [1 : i32, 1 : i32, 64 : i32, 64 : i32]}
     // CHECK-SAME: tensor<64x64xf32,
     // CHECK-SAME: -> tensor<1x1x64x64xf32
-    // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%[[PRE_RESHAPE]],
+    // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%[[PRE_RESHAPE]])
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
     // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: tensor<1x1x64x64xf32,
@@ -21,7 +21,7 @@ module attributes {} {
     // CHECK-SAME: tensor<1x1x64x64xbf16
     // CHECK-SAME: -> tensor<1x1x64x1xui32
     %2 = "ttnn.argmax"(%arg0) <{dim = 1 : i32, use_multicore = false}> : (tensor<64x64xf32, #ttnn_layout>) -> tensor<64x1xui32, #ttnn_layout1>
-    // CHECK: %[[TO_LAYOUT:[0-9]+]] = "ttnn.to_layout"(%[[ARG_MAX]],
+    // CHECK: %[[TO_LAYOUT:[0-9]+]] = "ttnn.to_layout"(%[[ARG_MAX]])
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<u32>
     // CHECK-SAME: layout = #ttnn.layout<tile>
     // CHECK-SAME: (tensor<1x1x64x1xui32

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/binary_ops_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/binary_ops_workaround.mlir
@@ -8,11 +8,11 @@
 module @jit_transpose attributes {} {
   func.func public @test_add_workaround(%arg0: tensor<32x64xui16, #ttnn_layout>, %arg1: tensor<32x64xui16, #ttnn_layout>) -> tensor<32x64xui16, #ttnn_layout> {
     // CHECK-LABEL: func.func public @test_add_workaround
-    // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0,
+    // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0)
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>,
     // CHECK-SAME: tensor<32x64xui16,
     // CHECK-SAME: -> tensor<32x64xbf16,
-    // CHECK: %[[ARG1:[0-9]+]] = "ttnn.to_layout"(%arg1,
+    // CHECK: %[[ARG1:[0-9]+]] = "ttnn.to_layout"(%arg1)
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>,
     // CHECK-SAME: tensor<32x64xui16,
     // CHECK-SAME: -> tensor<32x64xbf16,
@@ -21,7 +21,7 @@ module @jit_transpose attributes {} {
     // CHECK-SAME: tensor<32x64xbf16,
     // CHECK-SAME: -> tensor<32x64xbf16,
     %0 = "ttnn.add"(%arg0, %arg1) : (tensor<32x64xui16, #ttnn_layout>, tensor<32x64xui16, #ttnn_layout>) -> tensor<32x64xui16, #ttnn_layout>
-    // CHECK: = "ttnn.to_layout"(%[[ADD]],
+    // CHECK: = "ttnn.to_layout"(%[[ADD]])
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<u16>,
     // CHECK-SAME:tensor<32x64xbf16,
     // CHECK-SAME: -> tensor<32x64xui16,
@@ -30,11 +30,11 @@ module @jit_transpose attributes {} {
 
   func.func public @test_multiply_workaround(%arg0: tensor<32x64xsi32, #ttnn_layout1>, %arg1: tensor<32x64xsi32, #ttnn_layout1>) -> tensor<32x64xsi32, #ttnn_layout1> {
     // CHECK-LABEL: func.func public @test_multiply_workaround
-    // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0,
+    // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0)
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>,
     // CHECK-SAME: tensor<32x64xsi32,
     // CHECK-SAME: -> tensor<32x64xbf16,
-    // CHECK: %[[ARG1:[0-9]+]] = "ttnn.to_layout"(%arg1,
+    // CHECK: %[[ARG1:[0-9]+]] = "ttnn.to_layout"(%arg1)
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>,
     // CHECK-SAME: tensor<32x64xsi32,
     // CHECK-SAME: -> tensor<32x64xbf16,
@@ -52,11 +52,11 @@ module @jit_transpose attributes {} {
 
   func.func public @test_bitwise_and_workaround(%arg0: tensor<32x64xf32, #ttnn_layout2>, %arg1: tensor<32x64xf32, #ttnn_layout2>) -> tensor<32x64xf32, #ttnn_layout2> {
     // CHECK-LABEL: func.func public @test_bitwise_and_workaround
-    // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0,
+    // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0)
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<si32>,
     // CHECK-SAME: tensor<32x64xf32,
     // CHECK-SAME: -> tensor<32x64xsi32
-    // CHECK: %[[ARG1:[0-9]+]] = "ttnn.to_layout"(%arg1,
+    // CHECK: %[[ARG1:[0-9]+]] = "ttnn.to_layout"(%arg1)
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<si32>,
     // CHECK-SAME: tensor<32x64xf32,
     // CHECK-SAME: -> tensor<32x64xsi32
@@ -65,7 +65,7 @@ module @jit_transpose attributes {} {
     // CHECK-SAME: tensor<32x64xsi32,
     // CHECK-SAME: -> tensor<32x64xsi32,
     %0 = "ttnn.bitwise_and"(%arg0, %arg1) : (tensor<32x64xf32, #ttnn_layout2>, tensor<32x64xf32, #ttnn_layout2>) -> tensor<32x64xf32, #ttnn_layout2>
-    // CHECK: = "ttnn.to_layout"(%[[AND]],
+    // CHECK: = "ttnn.to_layout"(%[[AND]])
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<f32>,
     // CHECK-SAME:tensor<32x64xsi32,
     // CHECK-SAME: -> tensor<32x64xf32,
@@ -74,11 +74,11 @@ module @jit_transpose attributes {} {
 
   func.func public @test_layout_workaround(%arg0: tensor<4x4xbf16, #ttnn_layout3>, %arg1: tensor<4x4xbf16, #ttnn_layout3>) -> tensor<4x4xbf16, #ttnn_layout3> {
     // CHECK-LABEL: func.func public @test_layout_workaround
-    // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0,
+    // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0)
     // CHECK-SAME: layout = #ttnn.layout<tile>,
     // CHECK-SAME: tensor<4x4xbf16,
     // CHECK-SAME: -> tensor<4x4xbf16,
-    // CHECK: %[[ARG1:[0-9]+]] = "ttnn.to_layout"(%arg1,
+    // CHECK: %[[ARG1:[0-9]+]] = "ttnn.to_layout"(%arg1)
     // CHECK-SAME: layout = #ttnn.layout<tile>,
     // CHECK-SAME: tensor<4x4xbf16,
     // CHECK-SAME: -> tensor<4x4xbf16,
@@ -87,7 +87,7 @@ module @jit_transpose attributes {} {
     // CHECK-SAME: tensor<4x4xbf16,
     // CHECK-SAME: -> tensor<4x4xbf16,
     %0 = "ttnn.add"(%arg0, %arg1) : (tensor<4x4xbf16, #ttnn_layout3>, tensor<4x4xbf16, #ttnn_layout3>) -> tensor<4x4xbf16, #ttnn_layout3>
-    // CHECK: = "ttnn.to_layout"(%[[ADD]],
+    // CHECK: = "ttnn.to_layout"(%[[ADD]])
     // CHECK-SAME: layout = #ttnn.layout<row_major>,
     // CHECK-SAME: tensor<4x4xbf16,
     // CHECK-SAME: -> tensor<4x4xbf16,

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/concat_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/concat_workaround.mlir
@@ -4,11 +4,11 @@ module {
   func.func public @test_concat_datatype_workaround(%arg0: tensor<2x53xsi32>, %arg1: tensor<2x1xsi32>) -> tensor<2x54xsi32> {
     %0 = ttir.empty() : tensor<2x54xsi32>
     // CHECK-LABEL: func.func public @test_concat_datatype_workaround
-    // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0, %{{[0-9]+}})
+    // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0)
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
     // CHECK-SAME: tensor<2x53xsi32
     // CHECK-SAME: -> tensor<2x53xbf16
-    // CHECK: %[[ARG1:[0-9]+]] = "ttnn.to_layout"(%arg1, %{{[0-9]+}})
+    // CHECK: %[[ARG1:[0-9]+]] = "ttnn.to_layout"(%arg1)
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
     // CHECK-SAME: tensor<2x1xsi32
     // CHECK-SAME: -> tensor<2x1xbf16
@@ -18,7 +18,7 @@ module {
     // CHECK-SAME: tensor<2x1xbf16
     // CHECK-SAME: -> tensor<2x54xbf16
     %1 = "ttir.concat"(%arg0, %arg1, %0) <{dim = 1 : si32}> : (tensor<2x53xsi32>, tensor<2x1xsi32>, tensor<2x54xsi32>) -> tensor<2x54xsi32>
-    // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[CONCAT]], %{{[0-9]+}})
+    // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[CONCAT]])
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<si32>
     // CHECK-SAME: tensor<2x54xbf16
     // CHECK-SAME: -> tensor<2x54xsi32

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/conv2d_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/conv2d_workaround.mlir
@@ -4,50 +4,50 @@ module attributes {} {
   func.func @conv2d_with_bias(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x64xbf16> {
     // CHECK: %[[DEVICE_OP:.*]] = "ttnn.get_device"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %2 = "ttnn.reshape"(%arg0) <{shape = [1 : i32, 1 : i32, 1024 : i32, 64 : i32]}> : (tensor<1x32x32x64xbf16>) -> tensor<1x1x1024x64xbf16>
+    %1 = "ttnn.reshape"(%arg0) <{shape = [1 : i32, 1 : i32, 1024 : i32, 64 : i32]}> : (tensor<1x32x32x64xbf16>) -> tensor<1x1x1024x64xbf16>
     // CHECK: %[[TO_LAYOUT_INPUT:.*]] = "ttnn.to_layout"
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
     // CHECK-SAME: layout = #ttnn.layout<row_major>
-    %3 = "ttnn.conv2d"(%2, %arg1, %arg2, %0) <{batch_size = 1 : i32, dilation = array<i32: 1, 1>, groups = 1 : i32, in_channels = 64 : i32, input_height = 32 : i32, input_width = 32 : i32, kernel_size = array<i32: 3, 3>, out_channels = 64 : i32, padding = array<i32: 0, 0>, stride = array<i32: 1, 1>}> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
+    %2 = "ttnn.conv2d"(%1, %arg1, %arg2, %0) <{batch_size = 1 : i32, dilation = array<i32: 1, 1>, groups = 1 : i32, in_channels = 64 : i32, input_height = 32 : i32, input_width = 32 : i32, kernel_size = array<i32: 3, 3>, out_channels = 64 : i32, padding = array<i32: 0, 0>, stride = array<i32: 1, 1>}> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
     // CHECK-NEXT: %[[CONV2D_RESULT:.*]] = "ttnn.conv2d"(%[[TO_LAYOUT_INPUT]], %[[CONV2D_WEIGHTS:.*]], %[[CONV2D_BIAS:.*]], %[[DEVICE_OP]])
-    %4 = "ttnn.reshape"(%3) <{shape = [1 : i32, 30 : i32, 30 : i32, 64 : i32]}> : (tensor<1x1x900x64xbf16>) -> tensor<1x30x30x64xbf16>
-    return %4 : tensor<1x30x30x64xbf16>
+    %3 = "ttnn.reshape"(%2) <{shape = [1 : i32, 30 : i32, 30 : i32, 64 : i32]}> : (tensor<1x1x900x64xbf16>) -> tensor<1x30x30x64xbf16>
+    return %3 : tensor<1x30x30x64xbf16>
   }
 
   func.func @conv_transpose2d_with_bias(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<1x30x30x64xbf16> {
     // CHECK: %[[DEVICE_OP:.*]] = "ttnn.get_device"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    // CHECK: %[[TO_LAYOUT_INPUT:.*]] = "ttnn.to_layout"(%arg0, %[[DEVICE_OP]])
+    // CHECK: %[[TO_LAYOUT_INPUT:.*]] = "ttnn.to_layout"(%arg0)
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
     // CHECK-SAME: layout = #ttnn.layout<row_major>
-    %3 = "ttnn.conv_transpose2d"(%arg0, %arg1, %arg2, %0) <{batch_size = 1 : i32, dilation = array<i32: 1, 1>, groups = 1 : i32, in_channels = 64 : i32, input_height = 32 : i32, input_width = 32 : i32, kernel_size = array<i32: 3, 3>, out_channels = 64 : i32, padding = array<i32: 0, 0>, stride = array<i32: 1, 1>, output_padding = array<i32: 0, 0>}> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
+    %1 = "ttnn.conv_transpose2d"(%arg0, %arg1, %arg2, %0) <{batch_size = 1 : i32, dilation = array<i32: 1, 1>, groups = 1 : i32, in_channels = 64 : i32, input_height = 32 : i32, input_width = 32 : i32, kernel_size = array<i32: 3, 3>, out_channels = 64 : i32, padding = array<i32: 0, 0>, stride = array<i32: 1, 1>, output_padding = array<i32: 0, 0>}> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
     // CHECK-NEXT: %[[CONV2D_RESULT:.*]] = "ttnn.conv_transpose2d"(%[[TO_LAYOUT_INPUT]], %[[CONV2D_WEIGHTS:.*]], %[[CONV2D_BIAS:.*]], %[[DEVICE_OP]])
-    %4 = "ttnn.reshape"(%3) <{shape = [1 : i32, 30 : i32, 30 : i32, 64 : i32]}> : (tensor<1x1x900x64xbf16>) -> tensor<1x30x30x64xbf16>
-    return %4 : tensor<1x30x30x64xbf16>
+    %2 = "ttnn.reshape"(%1) <{shape = [1 : i32, 30 : i32, 30 : i32, 64 : i32]}> : (tensor<1x1x900x64xbf16>) -> tensor<1x30x30x64xbf16>
+    return %2 : tensor<1x30x30x64xbf16>
   }
 
   func.func @conv2d_without_bias(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>) -> tensor<1x30x30x64xbf16> {
     // CHECK: %[[DEVICE_OP:.*]] = "ttnn.get_device"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %2 = "ttnn.reshape"(%arg0) <{shape = [1 : i32, 1 : i32, 1024 : i32, 64 : i32]}> : (tensor<1x32x32x64xbf16>) -> tensor<1x1x1024x64xbf16>
+    %1 = "ttnn.reshape"(%arg0) <{shape = [1 : i32, 1 : i32, 1024 : i32, 64 : i32]}> : (tensor<1x32x32x64xbf16>) -> tensor<1x1x1024x64xbf16>
     // CHECK: %[[TO_LAYOUT_INPUT:.*]] = "ttnn.to_layout"
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
     // CHECK-SAME: layout = #ttnn.layout<row_major>
-    %3 = "ttnn.conv2d"(%2, %arg1, %0) <{batch_size = 1 : i32, dilation = array<i32: 1, 1>, groups = 1 : i32, in_channels = 64 : i32, input_height = 32 : i32, input_width = 32 : i32, kernel_size = array<i32: 3, 3>, out_channels = 64 : i32, padding = array<i32: 0, 0>, stride = array<i32: 1, 1>}> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
+    %2 = "ttnn.conv2d"(%1, %arg1, %0) <{batch_size = 1 : i32, dilation = array<i32: 1, 1>, groups = 1 : i32, in_channels = 64 : i32, input_height = 32 : i32, input_width = 32 : i32, kernel_size = array<i32: 3, 3>, out_channels = 64 : i32, padding = array<i32: 0, 0>, stride = array<i32: 1, 1>}> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
     // CHECK-NEXT: %[[CONV2D_RESULT:.*]] = "ttnn.conv2d"(%[[TO_LAYOUT_INPUT]], %[[CONV2D_WEIGHTS:.*]], %[[DEVICE_OP]])
-    %4 = "ttnn.reshape"(%3) <{shape = [1 : i32, 30 : i32, 30 : i32, 64 : i32]}> : (tensor<1x1x900x64xbf16>) -> tensor<1x30x30x64xbf16>
-    return %4 : tensor<1x30x30x64xbf16>
+    %3 = "ttnn.reshape"(%2) <{shape = [1 : i32, 30 : i32, 30 : i32, 64 : i32]}> : (tensor<1x1x900x64xbf16>) -> tensor<1x30x30x64xbf16>
+    return %3 : tensor<1x30x30x64xbf16>
   }
 
   func.func @conv_transpose2d_without_bias(%arg0: tensor<1x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>) -> tensor<1x30x30x64xbf16> {
     // CHECK: %[[DEVICE_OP:.*]] = "ttnn.get_device"
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    // CHECK: %[[TO_LAYOUT_INPUT:.*]] = "ttnn.to_layout"(%arg0, %[[DEVICE_OP]])
+    // CHECK: %[[TO_LAYOUT_INPUT:.*]] = "ttnn.to_layout"(%arg0)
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
     // CHECK-SAME: layout = #ttnn.layout<row_major>
-    %3 = "ttnn.conv_transpose2d"(%arg0, %arg1, %0) <{batch_size = 1 : i32, dilation = array<i32: 1, 1>, groups = 1 : i32, in_channels = 64 : i32, input_height = 32 : i32, input_width = 32 : i32, kernel_size = array<i32: 3, 3>, out_channels = 64 : i32, padding = array<i32: 0, 0>, stride = array<i32: 1, 1>, output_padding = array<i32: 0, 0>}> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
+    %1 = "ttnn.conv_transpose2d"(%arg0, %arg1, %0) <{batch_size = 1 : i32, dilation = array<i32: 1, 1>, groups = 1 : i32, in_channels = 64 : i32, input_height = 32 : i32, input_width = 32 : i32, kernel_size = array<i32: 3, 3>, out_channels = 64 : i32, padding = array<i32: 0, 0>, stride = array<i32: 1, 1>, output_padding = array<i32: 0, 0>}> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
     // CHECK-NEXT: %[[CONV2D_RESULT:.*]] = "ttnn.conv_transpose2d"(%[[TO_LAYOUT_INPUT]], %[[CONV2D_WEIGHTS:.*]], %[[DEVICE_OP]])
-    %4 = "ttnn.reshape"(%3) <{shape = [1 : i32, 30 : i32, 30 : i32, 64 : i32]}> : (tensor<1x1x900x64xbf16>) -> tensor<1x30x30x64xbf16>
-    return %4 : tensor<1x30x30x64xbf16>
+    %2 = "ttnn.reshape"(%1) <{shape = [1 : i32, 30 : i32, 30 : i32, 64 : i32]}> : (tensor<1x1x900x64xbf16>) -> tensor<1x30x30x64xbf16>
+    return %2 : tensor<1x30x30x64xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/embedding_backward_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/embedding_backward_workaround.mlir
@@ -9,13 +9,11 @@
 #ttnn_layout5 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<1x4x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 module attributes {} {
   func.func @backward(%arg0: tensor<1x32xf32, #ttnn_layout>, %arg1: tensor<512x128xf32, #ttnn_layout1>, %arg2: tensor<1x32x128xf32, #ttnn_layout2>) -> tensor<512x128xf32, #ttnn_layout1> {
-    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    // CHECK: %[[DEVICE_OP:.*]] = "ttnn.get_device"
-    %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<1x32xf32, #ttnn_layout>, !ttnn.device) -> tensor<1x32xf32, #ttnn_layout3>
-    %2 = "ttnn.to_layout"(%arg1, %0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<512x128xf32, #ttnn_layout1>, !ttnn.device) -> tensor<512x128xf32, #ttnn_layout4>
-    %3 = "ttnn.to_layout"(%arg2, %0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<1x32x128xf32, #ttnn_layout2>, !ttnn.device) -> tensor<1x32x128xf32, #ttnn_layout5>
+    %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<1x32xf32, #ttnn_layout>) -> tensor<1x32xf32, #ttnn_layout3>
+    %1 = "ttnn.to_layout"(%arg1) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<512x128xf32, #ttnn_layout1>) -> tensor<512x128xf32, #ttnn_layout4>
+    %2 = "ttnn.to_layout"(%arg2) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<1x32x128xf32, #ttnn_layout2>) -> tensor<1x32x128xf32, #ttnn_layout5>
     // CHECK: "ttnn.reshape"
-    %4 = "ttnn.reshape"(%3) <{shape = [1 : i32, 1 : i32, 32 : i32, 128 : i32]}> : (tensor<1x32x128xf32, #ttnn_layout5>) -> tensor<1x1x32x128xf32, #ttnn_layout5>
+    %3 = "ttnn.reshape"(%2) <{shape = [1 : i32, 1 : i32, 32 : i32, 128 : i32]}> : (tensor<1x32x128xf32, #ttnn_layout5>) -> tensor<1x1x32x128xf32, #ttnn_layout5>
     // Check that the input operand is transformed into the row major layout.
     // CHECK-NEXT: %[[TO_LAYOUT_INPUT:.*]] = "ttnn.to_layout"
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<u32>
@@ -35,14 +33,14 @@ module attributes {} {
     // CHECK-SAME: memory_config = #ttnn.memory_config<#dram, <interleaved>>
     // CHECK-SAME: -> tensor<1x1x32x128xbf16
     // Check that the data type of the output operand is transformed in bf16.
-    %5 = "ttnn.embedding_bw"(%1, %2, %4) <{dtype = #ttcore.supportedDataTypes<f32>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<1x32xf32, #ttnn_layout3>, tensor<512x128xf32, #ttnn_layout4>, tensor<1x1x32x128xf32, #ttnn_layout5>) -> tensor<512x128xf32, #ttnn_layout4>
+    %4 = "ttnn.embedding_bw"(%0, %1, %3) <{dtype = #ttcore.supportedDataTypes<f32>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<1x32xf32, #ttnn_layout3>, tensor<512x128xf32, #ttnn_layout4>, tensor<1x1x32x128xf32, #ttnn_layout5>) -> tensor<512x128xf32, #ttnn_layout4>
     // CHECK-NEXT: %[[EMBEDDING_BW_OP:.*]] = "ttnn.embedding_bw"(%[[TO_LAYOUT_INPUT]], %[[TO_LAYOUT_WEIGHTS]], %[[TO_LAYOUT_IN_GRADIENT]])
     // Check that the output operand is transformed back into the f32 data type.
     // CHECK-NEXT: "ttnn.to_layout"(%[[EMBEDDING_BW_OP]])
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<f32>
     // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: memory_config = #ttnn.memory_config<#system_memory>
-    %6 = "ttnn.to_layout"(%5) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<512x128xf32, #ttnn_layout4>) -> tensor<512x128xf32, #ttnn_layout1>
-    return %6 : tensor<512x128xf32, #ttnn_layout1>
+    %5 = "ttnn.to_layout"(%4) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<512x128xf32, #ttnn_layout4>) -> tensor<512x128xf32, #ttnn_layout1>
+    return %5 : tensor<512x128xf32, #ttnn_layout1>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/embedding_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/embedding_workaround.mlir
@@ -6,9 +6,8 @@
 #ttnn_layout2 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<32x4x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 module attributes {} {
   func.func @forward(%arg0: tensor<32x32xf32, #ttnn_layout>, %arg1: tensor<512x128xf32, #ttnn_layout1>) -> tensor<32x32x128xf32, #ttnn_layout2> {
-    // CHECK: %[[DEVICE_OP:.*]] = "ttnn.get_device"
     // Check that the input operand is transformed into the row major layout.
-    // CHECK-NEXT: %[[TO_LAYOUT_INPUT:.*]] = "ttnn.to_layout"
+    // CHECK: %[[TO_LAYOUT_INPUT:.*]] = "ttnn.to_layout"
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<u32>
     // CHECK-SAME: layout = #ttnn.layout<row_major>
     // CHECK-SAME: memory_config = #ttnn.memory_config<#dram, <interleaved>>
@@ -22,7 +21,7 @@ module attributes {} {
     %0 = "ttnn.embedding"(%arg0, %arg1) : (tensor<32x32xf32, #ttnn_layout>, tensor<512x128xf32, #ttnn_layout1>) -> tensor<32x32x128xf32, #ttnn_layout2>
     // CHECK-NEXT: %[[EMBEDDING_OP:.*]] = "ttnn.embedding"(%[[TO_LAYOUT_INPUT]], %[[TO_LAYOUT_WEIGHTS]])
     // Check that the output operand is transformed back into the f32 data type.
-    // CHECK-NEXT: "ttnn.to_layout"(%[[EMBEDDING_OP]], %[[DEVICE_OP]])
+    // CHECK-NEXT: "ttnn.to_layout"(%[[EMBEDDING_OP]])
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<f32>
     // CHECK-SAME: layout = #ttnn.layout<tile>
     // CHECK-SAME: memory_config = #ttnn.memory_config<#dram, <interleaved>>

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/max_pool2d_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/max_pool2d_workaround.mlir
@@ -7,11 +7,9 @@
 #ttnn_layout3 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 4096 + d1 * 64 + d2, d3), <1x1>, memref<128x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 module attributes {} {
   func.func @forward(%arg0: tensor<1x128x128x32xf32, #ttnn_layout>) -> tensor<1x64x64x32xf32, #ttnn_layout1> {
-    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    // CHECK: %[[DEVICE_OP:.*]] = "ttnn.get_device"
-    %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<1x128x128x32xf32, #ttnn_layout>, !ttnn.device) -> tensor<1x128x128x32xf32, #ttnn_layout2>
+    %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<1x128x128x32xf32, #ttnn_layout>) -> tensor<1x128x128x32xf32, #ttnn_layout2>
     // CHECK: "ttnn.to_layout"
-    %2 = "ttnn.reshape"(%1) <{shape = [1 : i32, 1 : i32, 16384 : i32, 32 : i32]}> : (tensor<1x128x128x32xf32, #ttnn_layout2>) -> tensor<1x1x16384x32xf32, #ttnn_layout2>
+    %1 = "ttnn.reshape"(%0) <{shape = [1 : i32, 1 : i32, 16384 : i32, 32 : i32]}> : (tensor<1x128x128x32xf32, #ttnn_layout2>) -> tensor<1x1x16384x32xf32, #ttnn_layout2>
     // Check that the input operand is transformed into the row major layout.
     // CHECK: %[[TO_LAYOUT_INPUT:.*]] = "ttnn.to_layout"
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
@@ -19,17 +17,17 @@ module attributes {} {
     // CHECK-SAME: memory_config = #ttnn.memory_config<#dram, <interleaved>>
     // CHECK-SAME: -> tensor<1x1x16384x32xbf16,
     // %3 = "ttnn.max_pool2d"(%2, %0) <{batch_size = 1 : si32, ceil_mode = false, channels = 32 : si32, dilation_height = 1 : si32, dilation_width = 1 : si32, input_height = 128 : si32, input_width = 128 : si32, kernel_height = 2 : si32, kernel_width = 2 : si32, padding_height = 0 : si32, padding_width = 0 : si32, stride_height = 2 : si32, stride_width = 2 : si32}> : (tensor<1x1x16384x32xf32, #ttnn_layout2>, !ttcore.device<#device>) -> tensor<1x1x4096x32xf32, #ttnn_layout3>
-    %3 = "ttnn.max_pool2d"(%2) <{batch_size = 1 : si32, ceil_mode = false, channels = 32 : si32, input_height = 128 : si32, input_width = 128 : si32, kernel_size = array<i32: 2, 2>, stride = array<i32: 2, 2>, dilation = array<i32: 1, 1>, padding = array<i32: 0, 0>, in_place_halo = false}> : (tensor<1x1x16384x32xf32, #ttnn_layout2>) -> tensor<1x1x4096x32xf32, #ttnn_layout3>
+    %2 = "ttnn.max_pool2d"(%1) <{batch_size = 1 : si32, ceil_mode = false, channels = 32 : si32, input_height = 128 : si32, input_width = 128 : si32, kernel_size = array<i32: 2, 2>, stride = array<i32: 2, 2>, dilation = array<i32: 1, 1>, padding = array<i32: 0, 0>, in_place_halo = false}> : (tensor<1x1x16384x32xf32, #ttnn_layout2>) -> tensor<1x1x4096x32xf32, #ttnn_layout3>
     // CHECK-NEXT: %[[MAX_POOL_2D_OP:.*]] = "ttnn.max_pool2d"(%[[TO_LAYOUT_INPUT]])
     // Check that the output operand is transformed back into the tile and f32 data type.
-    // CHECK-NEXT: %[[TO_LAYOUT_OUTPUT:.*]] = "ttnn.to_layout"(%[[MAX_POOL_2D_OP]], %[[DEVICE_OP]])
+    // CHECK-NEXT: %[[TO_LAYOUT_OUTPUT:.*]] = "ttnn.to_layout"(%[[MAX_POOL_2D_OP]])
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<f32>
     // CHECK-SAME: layout = #ttnn.layout<tile>
     // CHECK-SAME: memory_config = #ttnn.memory_config<#dram, <interleaved>>
     // CHECK-SAME: -> tensor<1x1x4096x32xf32
-    %4 = "ttnn.reshape"(%3) <{shape = [1 : i32, 64 : i32, 64 : i32, 32 : i32]}> : (tensor<1x1x4096x32xf32, #ttnn_layout3>) -> tensor<1x64x64x32xf32, #ttnn_layout3>
+    %3 = "ttnn.reshape"(%2) <{shape = [1 : i32, 64 : i32, 64 : i32, 32 : i32]}> : (tensor<1x1x4096x32xf32, #ttnn_layout3>) -> tensor<1x64x64x32xf32, #ttnn_layout3>
     // CHECK-NEXT: ttnn.reshape
-    %5 = "ttnn.to_layout"(%4) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<1x64x64x32xf32, #ttnn_layout3>) -> tensor<1x64x64x32xf32, #ttnn_layout1>
-    return %5 : tensor<1x64x64x32xf32, #ttnn_layout1>
+    %4 = "ttnn.to_layout"(%3) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<1x64x64x32xf32, #ttnn_layout3>) -> tensor<1x64x64x32xf32, #ttnn_layout1>
+    return %4 : tensor<1x64x64x32xf32, #ttnn_layout1>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/pad_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/pad_workaround.mlir
@@ -6,7 +6,7 @@
 module attributes {} {
   func.func @test_pad_workaround(%arg0: tensor<1x30x30xsi32, #ttnn_layout>) -> tensor<1x32x32xsi32, #ttnn_layout1> {
     // CHECK-LABEL: @test_pad_workaround
-    // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0,
+    // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0)
     // CHECK-SAME: <{dtype = #ttcore.supportedDataTypes<bf16>,
     // CHECK-SAME: layout = #ttnn.layout<row_major>,
     // CHECK-SAME: tensor<1x30x30xsi32,
@@ -15,7 +15,7 @@ module attributes {} {
     // CHECK-SAME: tensor<1x30x30xbf16
     // CHECK-SAME: -> tensor<1x32x32xbf16,
     %0 = "ttnn.pad"(%arg0) <{memory_config = #ttnn.memory_config<#dram, <interleaved>>, padding = array<i32: 0, 0, 1, 1, 1, 1>, use_multicore = true, value = 0.000000e+00 : f32}> : (tensor<1x30x30xsi32, #ttnn_layout>) -> tensor<1x32x32xsi32, #ttnn_layout1>
-    // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[PAD]],
+    // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[PAD]])
     // CHECK-SAME: <{dtype = #ttcore.supportedDataTypes<si32>,
     // CHECK-SAME: layout = #ttnn.layout<tile>
     // CHECK-SAME: tensor<1x32x32xbf16,

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/reduce_prod_full_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/reduce_prod_full_workaround.mlir
@@ -4,7 +4,7 @@ module {
   func.func public @test_reduce_prod_full_workaround(%arg0: tensor<128x10x32x4xf32>) -> tensor<1xf32> {
     // CHECK-LABEL: func.func public @test_reduce_prod_full_workaround
     %0 = ttir.empty() : tensor<1xf32>
-    // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0, %{{[0-9]+}})
+    // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0)
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
     // CHECK-SAME: tensor<128x10x32x4xf32
     // CHECK-SAME: -> tensor<128x10x32x4xbf16
@@ -13,7 +13,7 @@ module {
     // CHECK-SAME: tensor<128x10x32x4xbf16,
     // CHECK-SAME: -> tensor<1xbf16,
     %1 = "ttir.prod"(%arg0, %0) <{dim_arg = [0 : i32, 1 : i32, 2 : i32, 3 : i32], keep_dim = false}> : (tensor<128x10x32x4xf32>, tensor<1xf32>) -> tensor<1xf32>
-    // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[PROD]], %{{[0-9]+}})
+    // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[PROD]])
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<f32>
     // CHECK-SAME: tensor<1xbf16
     // CHECK-SAME: -> tensor<1xf32

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/reduction_ops_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/reduction_ops_workaround.mlir
@@ -5,7 +5,7 @@
 #ttnn_layout1 = #ttnn.ttnn_layout<(d0) -> (0, d0), <1x1>, memref<1x4x!ttcore.tile<32x32, si32>, #dram>, <interleaved>>
 func.func public @test_reduce_max(%arg0: tensor<128x32xsi32, #ttnn_layout>) -> tensor<128xsi32, #ttnn_layout1> {
   // CHECK-LABEL: @test_reduce_max
-  // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0, %{{[0-9]+}})
+  // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0)
   // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>,
   // CHECK-SAME: tensor<128x32xsi32,
   // CHECK-SAME: -> tensor<128x32xbf16,
@@ -14,7 +14,7 @@ func.func public @test_reduce_max(%arg0: tensor<128x32xsi32, #ttnn_layout>) -> t
   // CHECK-SAME: tensor<128x32xbf16,
   // CHECK-SAME: -> tensor<128xbf16,
   %0 = "ttnn.max"(%arg0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x32xsi32, #ttnn_layout>) -> tensor<128xsi32, #ttnn_layout1>
-  // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[MAX]], %{{[0-9]+}})
+  // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[MAX]])
   // CHECK-SAME: dtype = #ttcore.supportedDataTypes<si32>,
   // CHECK-SAME: tensor<128xbf16,
   // CHECK-SAME: -> tensor<128xsi32,
@@ -23,7 +23,7 @@ func.func public @test_reduce_max(%arg0: tensor<128x32xsi32, #ttnn_layout>) -> t
 
 func.func public @test_reduce_sum(%arg0: tensor<128x10xsi32, #ttnn_layout>) -> tensor<128xsi32, #ttnn_layout1> {
   // CHECK-LABEL: @test_reduce_sum
-  // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0, %{{[0-9]+}})
+  // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0)
   // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>,
   // CHECK-SAME: tensor<128x10xsi32,
   // CHECK-SAME: -> tensor<128x10xbf16,
@@ -32,7 +32,7 @@ func.func public @test_reduce_sum(%arg0: tensor<128x10xsi32, #ttnn_layout>) -> t
   // CHECK-SAME: tensor<128x10xbf16,
   // CHECK-SAME: -> tensor<128xbf16,
   %0 = "ttnn.sum"(%arg0) <{dim_arg = [1 : i32], keep_dim = false}> : (tensor<128x10xsi32, #ttnn_layout>) -> tensor<128xsi32, #ttnn_layout1>
-  // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[SUM]], %{{[0-9]+}})
+  // CHECK: %{{[0-9]+}} = "ttnn.to_layout"(%[[SUM]])
   // CHECK-SAME: dtype = #ttcore.supportedDataTypes<si32>,
   // CHECK-SAME: tensor<128xbf16,
   // CHECK-SAME: -> tensor<128xsi32,

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/slice_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/slice_workaround.mlir
@@ -7,7 +7,7 @@
 module attributes {} {
   func.func @test_strided_slice_workaround(%arg0: tensor<4x32x32xf32, #ttnn_layout>) -> tensor<2x16x8xf32, #ttnn_layout1> {
     // CHECK-LABEL: @test_strided_slice_workaround(
-    // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0,
+    // CHECK: %[[ARG0:[0-9]+]] = "ttnn.to_layout"(%arg0)
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
     // CHECK-SAME: tensor<4x32x32xf32
     // CHECK-SAME: -> tensor<4x32x32xbf16
@@ -17,11 +17,11 @@ module attributes {} {
     // CHECK-SAME: step = [1 : i32, 1 : i32, 2 : i32]}
     // CHECK-SAME: tensor<4x32x32xbf16
     // CHECK-SAME: -> tensor<2x16x8xbf16
-    %1 = "ttnn.slice"(%arg0) <{begins = [0 : i32, 0 : i32, 0 : i32], ends = [2 : i32, 16 : i32, 16 : i32], step = [1 : i32, 1 : i32, 2 : i32]}> : (tensor<4x32x32xf32, #ttnn_layout>) -> tensor<2x16x8xf32, #ttnn_layout1>
-    // CHECK: "ttnn.to_layout"(%[[SLICE]]
+    %0 = "ttnn.slice"(%arg0) <{begins = [0 : i32, 0 : i32, 0 : i32], ends = [2 : i32, 16 : i32, 16 : i32], step = [1 : i32, 1 : i32, 2 : i32]}> : (tensor<4x32x32xf32, #ttnn_layout>) -> tensor<2x16x8xf32, #ttnn_layout1>
+    // CHECK: "ttnn.to_layout"(%[[SLICE]])
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<f32>
     // CHECK-SAME: tensor<2x16x8xbf16
     // CHECK-SAME: -> tensor<2x16x8xf32
-    return %1 : tensor<2x16x8xf32, #ttnn_layout1>
+    return %0 : tensor<2x16x8xf32, #ttnn_layout1>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/where_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/where_workaround.mlir
@@ -10,7 +10,7 @@ module @moreh_cumsum attributes {} {
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     %1 = "ttnn.reshape"(%arg2) <{shape = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<1xf32, #ttnn_layout2>) -> tensor<1x1x1x1xf32, #ttnn_layout3>
     %2 = "ttnn.repeat"(%1) <{repeat_dims = #ttnn.shape<1x12x1x46>}> : (tensor<1x1x1x1xf32, #ttnn_layout3>) -> tensor<1x12x1x46xf32, #ttnn_layout1>
-    // CHECK: %[[ARG0:[0-9]+]] = {{.*}}(%arg0,
+    // CHECK: %[[ARG0:[0-9]+]] = {{.*}}(%arg0
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<f32>
     // CHECK-SAME: tensor<1x1x1x46xbf16
     // CHECK-SAME: -> tensor<1x1x1x46xf32

--- a/test/ttmlir/Dialect/TTNN/optimizer/insert_memreconfig_const_eval.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/insert_memreconfig_const_eval.mlir
@@ -9,11 +9,10 @@ module attributes {} {
 
   // CHECK-LABEL: func.func @main(
   func.func @main(%arg0: tensor<1x32x32xf32, #ttnn_layout>, %arg1: tensor<1x32x32xf32, #ttnn_layout> {ttcore.argument_type = #ttcore.argument_type<constant>}) -> tensor<1x32x32xf32, #ttnn_layout1> {
-    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     // CHECK: "ttnn.to_layout"
-    %1 = "ttnn.to_layout"(%arg1, %0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<<dram>, <interleaved>>}> : (tensor<1x32x32xf32, #ttnn_layout>, !ttnn.device) -> tensor<1x32x32xf32, #ttnn_layout1>
-    %2 = "ttnn.add"(%arg0, %1) : (tensor<1x32x32xf32, #ttnn_layout>, tensor<1x32x32xf32, #ttnn_layout1>) -> tensor<1x32x32xf32, #ttnn_layout1> loc(#loc1)
-    return %2 : tensor<1x32x32xf32, #ttnn_layout1>
+    %0 = "ttnn.to_layout"(%arg1) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<<dram>, <interleaved>>}> : (tensor<1x32x32xf32, #ttnn_layout>) -> tensor<1x32x32xf32, #ttnn_layout1>
+    %1 = "ttnn.add"(%arg0, %0) : (tensor<1x32x32xf32, #ttnn_layout>, tensor<1x32x32xf32, #ttnn_layout1>) -> tensor<1x32x32xf32, #ttnn_layout1> loc(#loc1)
+    return %1 : tensor<1x32x32xf32, #ttnn_layout1>
   }
 }
 #loc1 = loc("add_1_2")

--- a/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_from_host.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/Transforms/DecomposeLayouts/decomposing_layouts_from_host.mlir
@@ -27,9 +27,8 @@ module attributes {} {
         // CHECK: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
         // CHECK-SAME: memory_config = #ttnn.memory_config<#dram, <interleaved>>
         // CHECK: return %[[TO_DEVICE_OP]]
-        %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-        %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout_device_rm>
-        return %1 : tensor<64x128xf32, #ttnn_layout_device_rm>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xf32, #ttnn_layout_device_rm>
+        return %0 : tensor<64x128xf32, #ttnn_layout_device_rm>
     }
 
     // Test cases when we do layout transformation from host and we don't change tensor layout but we cast tensor data type.
@@ -41,8 +40,8 @@ module attributes {} {
         // CHECK: %[[CASTING_OP:.*]] = "ttnn.to_dtype"(%arg0)
         // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
         // CHECK-NEXT: return %[[CASTING_OP]]
-        %1 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>
-        return %1 : tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>
+        return %0 : tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>
     }
 
     // Test case when we move tensor from host to host for row-major case.
@@ -51,8 +50,8 @@ module attributes {} {
         // CHECK: %[[CASTING_OP:.*]] = "ttnn.to_dtype"(%arg0)
         // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
         // CHECK-NEXT: return %[[CASTING_OP]]
-        %1 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>
-        return %1 : tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>
+        return %0 : tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>
     }
 
     // Test case when we move tensor from host to device for row-major case.
@@ -64,9 +63,8 @@ module attributes {} {
         // CHECK: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%[[CASTING_OP]], %[[GET_DEVICE_OP]])
         // CHECK-SAME: memory_config = #ttnn.memory_config<#dram, <interleaved>>
         // CHECK-NEXT: return %[[TO_DEVICE_OP]]
-        %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-        %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>, !ttnn.device) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
-        return %1 : tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
+        return %0 : tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
     }
 
     // Test case when we move tensor from host to device for tile case.
@@ -78,9 +76,8 @@ module attributes {} {
         // CHECK-NEXT: %[[CASTING_OP:.*]] = "ttnn.typecast"(%[[TO_DEVICE_OP]])
         // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
         // CHECK-NEXT: return %[[CASTING_OP]]
-        %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-        %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout_host_tile>, !ttnn.device) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
-        return %1 : tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
+        return %0 : tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
     }
 
     // Test cases when we do layout transformation from host and we change tensor layout but we don't cast tensor data type.
@@ -92,8 +89,8 @@ module attributes {} {
         // CHECK: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%arg0)
         // CHECK-SAME: layout = #ttnn.layout<row_major>
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %1 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
-        return %1 : tensor<64x128xf32, #ttnn_layout_host_rm>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
+        return %0 : tensor<64x128xf32, #ttnn_layout_host_rm>
     }
 
     // Test case when we move tensor from host to host for row-major -> tile case.
@@ -102,8 +99,8 @@ module attributes {} {
         // CHECK: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%arg0)
         // CHECK-SAME: layout = #ttnn.layout<tile>
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %1 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xf32, #ttnn_layout_host_tile>
-        return %1 : tensor<64x128xf32, #ttnn_layout_host_tile>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xf32, #ttnn_layout_host_tile>
+        return %0 : tensor<64x128xf32, #ttnn_layout_host_tile>
     }
 
     // Test case when we move tensor from host to device for tile -> row-major case for bf16 data type.
@@ -111,12 +108,11 @@ module attributes {} {
         // This test verifies that the `to_layout` and `to_device` operations are correctly inserted to move the tensor to the device and then change layout from tile to row-major.
         // CHECK: %[[GET_DEVICE_OP:.*]] = "ttnn.get_device"()
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
-        // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]], %[[GET_DEVICE_OP]])
+        // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
         // CHECK-SAME: layout = #ttnn.layout<row_major>
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-        %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>, !ttnn.device) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
-        return %1 : tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>) -> tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
+        return %0 : tensor<64x128xbf16, #ttnn_layout_device_rm_bf16>
     }
 
     // Test case when we move tensor from host to device for tile -> row-major case.
@@ -127,9 +123,8 @@ module attributes {} {
         // CHECK-SAME: layout = #ttnn.layout<row_major>
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%[[TO_LAYOUT_OP]], %[[GET_DEVICE_OP]])
         // CHECK-NEXT: return %[[TO_DEVICE_OP]]
-        %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-        %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout_host_tile>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout_device_rm>
-        return %1 : tensor<64x128xf32, #ttnn_layout_device_rm>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout_host_tile>) -> tensor<64x128xf32, #ttnn_layout_device_rm>
+        return %0 : tensor<64x128xf32, #ttnn_layout_device_rm>
     }
 
     // Test case when we move tensor from host to device for row-major -> tile case for bf16 data type.
@@ -138,12 +133,11 @@ module attributes {} {
         // Specifically, it ensures that BF16 tiling is performed on the device.
         // CHECK: %[[GET_DEVICE_OP:.*]] = "ttnn.get_device"()
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
-        // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]], %[[GET_DEVICE_OP]])
+        // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
         // CHECK-SAME: layout = #ttnn.layout<tile>
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-        %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>, !ttnn.device) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
-        return %1 : tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
+        return %0 : tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
     }
 
     // Test case when we move tensor from host to device for row-major -> tile case for non-bf16 non-f32 data type.
@@ -155,9 +149,8 @@ module attributes {} {
         // CHECK-SAME: layout = #ttnn.layout<tile>
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%[[TO_LAYOUT_OP]], %[[GET_DEVICE_OP]])
         // CHECK-NEXT: return %[[TO_DEVICE_OP]]
-        %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-        %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #ttcore.supportedDataTypes<u32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xui32, #ttnn_layout_host_rm_u32>, !ttnn.device) -> tensor<64x128xui32, #ttnn_layout_device_tile_u32>
-        return %1 : tensor<64x128xui32, #ttnn_layout_device_tile_u32>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<u32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xui32, #ttnn_layout_host_rm_u32>) -> tensor<64x128xui32, #ttnn_layout_device_tile_u32>
+        return %0 : tensor<64x128xui32, #ttnn_layout_device_tile_u32>
     }
 
     // Test cases when we do layout transformation from host and we change both tensor layout and tensor data type.
@@ -171,8 +164,8 @@ module attributes {} {
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[CASTING_OP]])
         // CHECK-SAME: layout = #ttnn.layout<row_major>
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %1 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
-        return %1 : tensor<64x128xf32, #ttnn_layout_host_rm>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>) -> tensor<64x128xf32, #ttnn_layout_host_rm>
+        return %0 : tensor<64x128xf32, #ttnn_layout_host_rm>
     }
 
     // Test case when we move tensor from host to host for row-major -> tile case and data type cast.
@@ -183,8 +176,8 @@ module attributes {} {
         // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[CASTING_OP]])
         // CHECK-SAME: layout = #ttnn.layout<tile>
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %1 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xf32, #ttnn_layout_host_tile>
-        return %1 : tensor<64x128xf32, #ttnn_layout_host_tile>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#system_memory>}> : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xf32, #ttnn_layout_host_tile>
+        return %0 : tensor<64x128xf32, #ttnn_layout_host_tile>
     }
 
     // Test case when we move tensor from host to device for tile -> row-major case and cast input from bf16.
@@ -198,9 +191,8 @@ module attributes {} {
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%[[TO_LAYOUT_OP]], %[[GET_DEVICE_OP]])
         // CHECK-SAME: memory_config = #ttnn.memory_config<#dram, <interleaved>>
         // CHECK-NEXT: return %[[TO_DEVICE_OP]]
-        %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-        %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout_device_rm>
-        return %1 : tensor<64x128xf32, #ttnn_layout_device_rm>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<row_major>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xbf16, #ttnn_layout_host_tile_bf16>) -> tensor<64x128xf32, #ttnn_layout_device_rm>
+        return %0 : tensor<64x128xf32, #ttnn_layout_device_rm>
     }
 
     // Test case when we move tensor from host to device for row-major -> tile case and cast input from bf16.
@@ -209,14 +201,13 @@ module attributes {} {
         // data type from bf16 to f32 on device.
         // CHECK: %[[GET_DEVICE_OP:.*]] = "ttnn.get_device"()
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%arg0, %[[GET_DEVICE_OP]])
-        // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]], %[[GET_DEVICE_OP]])
+        // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
         // CHECK-SAME: layout = #ttnn.layout<tile>
         // CHECK-NEXT: %[[CASTING_OP:.*]] = "ttnn.typecast"(%[[TO_LAYOUT_OP]])
         // CHECK-SAME: dtype = #ttcore.supportedDataTypes<f32>
         // CHECK-NEXT: return %[[CASTING_OP]]
-        %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-        %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>, !ttnn.device) -> tensor<64x128xf32, #ttnn_layout_device_tile>
-        return %1 : tensor<64x128xf32, #ttnn_layout_device_tile>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<f32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xbf16, #ttnn_layout_host_rm_bf16>) -> tensor<64x128xf32, #ttnn_layout_device_tile>
+        return %0 : tensor<64x128xf32, #ttnn_layout_device_tile>
     }
 
     // Test case when we move tensor from host to device for row-major -> tile case and cast input to bf16.
@@ -226,12 +217,11 @@ module attributes {} {
         // CHECK-NEXT: %[[CASTING_OP:.*]] = "ttnn.to_dtype"(%arg0)
         // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%[[CASTING_OP]], %[[GET_DEVICE_OP]])
-        // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]], %[[GET_DEVICE_OP]])
+        // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[TO_DEVICE_OP]])
         // CHECK-SAME: layout = #ttnn.layout<tile>
         // CHECK-NEXT: return %[[TO_LAYOUT_OP]]
-        %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-        %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>, !ttnn.device) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
-        return %1 : tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
+        return %0 : tensor<64x128xbf16, #ttnn_layout_device_tile_bf16>
     }
 
     // Test case when we move tensor from host to device for row-major -> tile case and we don't cast data type to bf16 nor from bf16.
@@ -244,8 +234,7 @@ module attributes {} {
         // CHECK-SAME: layout = #ttnn.layout<tile>
         // CHECK-NEXT: %[[TO_DEVICE_OP:.*]] = "ttnn.to_device"(%[[TO_LAYOUT_OP]], %[[GET_DEVICE_OP]])
         // CHECK-NEXT: return %[[TO_DEVICE_OP]]
-        %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-        %1 = "ttnn.to_layout"(%arg0, %0) <{dtype = #ttcore.supportedDataTypes<u32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>, !ttnn.device) -> tensor<64x128xui32, #ttnn_layout_device_tile_u32>
-        return %1 : tensor<64x128xui32, #ttnn_layout_device_tile_u32>
+        %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<u32>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<64x128xf32, #ttnn_layout_host_rm>) -> tensor<64x128xui32, #ttnn_layout_device_tile_u32>
+        return %0 : tensor<64x128xui32, #ttnn_layout_device_tile_u32>
     }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_conv_transpose2d_with_conv2d_config.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_conv_transpose2d_with_conv2d_config.mlir
@@ -34,7 +34,7 @@
 module attributes {} {
   func.func @forward(%arg0: tensor<3x8x8x256xbf16, #ttnn_layout>, %arg1: tensor<256x256x3x3xbf16, #ttnn_layout1>, %arg2: tensor<1x1x1x256xbf16, #ttnn_layout2>) -> tensor<3x10x10x256xbf16, #ttnn_layout3> {
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    %1 = "ttnn.to_layout"(%arg0, %0) <{layout = #ttnn.layout<row_major>}> : (tensor<3x8x8x256xbf16, #ttnn_layout>, !ttnn.device) -> tensor<3x8x8x256xbf16, #ttnn_layout4>
+    %1 = "ttnn.to_layout"(%arg0) <{layout = #ttnn.layout<row_major>}> : (tensor<3x8x8x256xbf16, #ttnn_layout>) -> tensor<3x8x8x256xbf16, #ttnn_layout4>
     "ttnn.deallocate"(%arg0) <{force = false}> : (tensor<3x8x8x256xbf16, #ttnn_layout>) -> ()
     %2 = "ttnn.conv_transpose2d"(%1, %arg1, %arg2, %0)
             <{

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -501,7 +501,7 @@ TEST_F(OpModelTest, ToLayout) {
 
   auto constraintsExp = ToLayoutOpInterface::getOpConstraints(
       CreateWorkerGrid(), tensorShape, layoutDRAMTiled, std::nullopt,
-      layoutDRAMRowMajor, true);
+      layoutDRAMRowMajor);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   OpConstraints &opCstr = constraintsExp.get();
   EXPECT_EQ(opCstr.cbL1PeakSize, 131072);
@@ -510,24 +510,24 @@ TEST_F(OpModelTest, ToLayout) {
   ExpectLayoutsEQ(layoutDRAMRowMajor, opCstr.outputLayout);
 
   auto runtimeExp = ToLayoutOpInterface::getOpRuntime(
-      tensorShape, layoutDRAMTiled, std::nullopt, layoutDRAMRowMajor, true);
+      tensorShape, layoutDRAMTiled, std::nullopt, layoutDRAMRowMajor);
   EXPECT_TRUE(static_cast<bool>(runtimeExp));
   EXPECT_TRUE(runtimeExp.get() > 0);
 
   constraintsExp = ToLayoutOpInterface::getOpConstraints(
       CreateWorkerGrid(), tensorShape, layoutDRAMTiled, std::nullopt,
-      layoutL1RowMajorHS, true);
+      layoutL1RowMajorHS);
   EXPECT_FALSE(static_cast<bool>(constraintsExp));
   llvm::consumeError(constraintsExp.takeError());
 
   runtimeExp = ToLayoutOpInterface::getOpRuntime(
-      tensorShape, layoutDRAMTiled, std::nullopt, layoutL1RowMajorHS, true);
+      tensorShape, layoutDRAMTiled, std::nullopt, layoutL1RowMajorHS);
   EXPECT_FALSE(static_cast<bool>(runtimeExp));
   llvm::consumeError(runtimeExp.takeError());
 
   constraintsExp = ToLayoutOpInterface::getOpConstraints(
       CreateWorkerGrid(), tensorShape, layoutDRAMTiled, std::nullopt,
-      layoutDRAMRowMajor, false);
+      layoutDRAMRowMajor);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
   opCstr = constraintsExp.get();
   EXPECT_EQ(opCstr.cbL1PeakSize, 131072);
@@ -536,7 +536,7 @@ TEST_F(OpModelTest, ToLayout) {
   ExpectLayoutsEQ(layoutDRAMRowMajor, opCstr.outputLayout);
 
   runtimeExp = ToLayoutOpInterface::getOpRuntime(
-      tensorShape, layoutDRAMTiled, std::nullopt, layoutDRAMRowMajor, false);
+      tensorShape, layoutDRAMTiled, std::nullopt, layoutDRAMRowMajor);
   EXPECT_TRUE(static_cast<bool>(runtimeExp));
   EXPECT_TRUE(runtimeExp.get() > 0);
 }

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -657,15 +657,9 @@ TEST_F(OpModelBase, toLayoutOp) {
       ShapeAttr::get(&context, tensorShape), nullptr,
       LayoutAttr::get(&context, Layout::RowMajor), nullptr, nullptr);
 
-  // Need to pass a GetDeviceOp to make sure the layout change happens on the
-  // device
-  GetDeviceOp deviceOp = builder.create<ttnn::GetDeviceOp>(
-      builder.getUnknownLoc(), builder.getType<DeviceType>(),
-      ttnn::MeshShapeAttr::get(builder.getContext(), 1, 1),
-      ttnn::MeshOffsetAttr::get(builder.getContext(), 0, 0));
-  ToLayoutOp toLayout = builder.create<ToLayoutOp>(
-      builder.getUnknownLoc(), tensor.getType(), tensor, Layout::Tile, nullptr,
-      nullptr, deviceOp);
+  ToLayoutOp toLayout =
+      builder.create<ToLayoutOp>(builder.getUnknownLoc(), tensor.getType(),
+                                 tensor, Layout::Tile, nullptr, nullptr);
 
   // Manually create the operand layouts for calling the backend to make sure
   // the layouts are propagated all the way


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-mlir/issues/3897

### Problem description
Metal removed the optional device from a to_layout op, and we should update the code to reflect the change.

### What's changed
Removes the optional device from a to_layout op in a TTNN dialect.

### Checklist
- [x] New/Existing tests provide coverage for changes
