### PR TITLE
Upgrade torch versions

### DIFF
--- a/runtime/tools/ttrt/requirements.txt
+++ b/runtime/tools/ttrt/requirements.txt
@@ -1,1 +1,1 @@
-torch==2.5.0 --index-url https://download.pytorch.org/whl/cpu
+torch==2.7.0 --index-url https://download.pytorch.org/whl/cpu

--- a/runtime/tools/ttrt/requirements.txt
+++ b/runtime/tools/ttrt/requirements.txt
@@ -1,1 +1,1 @@
-torch==2.7.0 --index-url https://download.pytorch.org/whl/cpu
+torch==2.7.0

--- a/test/python/requirements.txt
+++ b/test/python/requirements.txt
@@ -1,4 +1,3 @@
 lit
 pytest
---extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.3.0
+torch==2.7.0


### PR DESCRIPTION
### Problem description
There is an ongoing effort to raise torch version to 2.7.0 project-wide. This is part of it.

I encountered a problem while working on [this](https://github.com/tenstorrent/tt-xla/pull/599#issuecomment-3014145905). It shows that torch 2.7 is incompatible with ttrt which uses older version. Thus I decided to raise torch to 2.7 in all requirement.txt files I found. CI passed.

When I checked out this branch from tt-xla, test passed successfully.

### Checklist
- [ ] New/Existing tests provide coverage for changes
