### PR TITLE
Update workaround for ttnn.pad op

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1135,9 +1135,10 @@ def TTNN_PadOp: TTNN_Op<"pad"> {
       mlir::TypedValue<mlir::RankedTensorType> input = getInput();
       ttnn::TTNNLayoutAttr layoutAttr = mlir::cast<ttnn::TTNNLayoutAttr>(
             getResult().getType().getEncoding());
+      llvm::ArrayRef<int32_t> padding = getPadding();
       return
         wa::TTNNOperandsWorkaroundsFactory::createPadOpOperandsWorkarounds(
-                                                             input, layoutAttr);
+                                                    input, layoutAttr, padding);
     }
   }];
 }

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
@@ -275,7 +275,8 @@ public:
   // Create workarounds for pad op operands.
   static TTNNOperandsWorkarounds
   createPadOpOperandsWorkarounds(mlir::TypedValue<mlir::RankedTensorType> input,
-                                 ttnn::TTNNLayoutAttr layoutAttr);
+                                 ttnn::TTNNLayoutAttr layoutAttr,
+                                 llvm::ArrayRef<int32_t> padding);
 
   // Create workaround for permute op operands.
   static TTNNOperandsWorkarounds

--- a/test/ttmlir/Silicon/TTNN/n150/simple_pad.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_pad.mlir
@@ -1,4 +1,8 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
+// RUN: rm -rf %t.ttnn
+// RUN: rm -rf %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
 module {
   func.func @main(%arg0: tensor<1x128x128x384xf32>) -> tensor<1x132x132x384xf32> {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/2889

### Problem description
tt-metal supports front padding for row-major layout only

### What's changed
update the workaround to only apply row-major layout in case of front padding.

### Checklist
- [X] New/Existing tests provide coverage for changes
