### PR TITLE
Adjust mesh_shard op for Nd sharding / partial concat change in ttnn

### DIFF
--- a/runtime/lib/ttnn/operations/ccl/mesh_shard.cpp
+++ b/runtime/lib/ttnn/operations/ccl/mesh_shard.cpp
@@ -6,86 +6,13 @@
 
 #include "operations/ccl/mesh_shard.h"
 #include "ttnn/distributed/distributed_tensor.hpp"
-#include "ttnn/tensor/xtensor/partition.hpp"
 
 namespace tt::runtime::ttnn::operations::ccl {
 
+using ::ttnn::distributed::MeshComposerConfig;
 using ::ttnn::distributed::MeshMapperConfig;
 using ::ttnn::distributed::MeshToTensor;
 using ::ttnn::distributed::TensorToMesh;
-
-static ::ttnn::Tensor
-FullToShardShape(const ::ttnn::Tensor &input, ::ttnn::MeshDevice &meshDevice,
-                 const ::tt::target::ttnn::MeshShardType &shardType,
-                 const std::vector<int64_t> &shardShape,
-                 const std::vector<int64_t> &shardDims) {
-  if (shardType == ::tt::target::ttnn::MeshShardType::Replicate) {
-    return ::ttnn::distributed::distribute_tensor(
-        input,
-        *::ttnn::distributed::replicate_tensor_to_mesh_mapper(meshDevice));
-  }
-
-  MeshMapperConfig config{.placements = {MeshMapperConfig::Replicate(),
-                                         MeshMapperConfig::Replicate()}};
-
-  if (shardDims[0] >= 0) {
-    config.placements[0] = MeshMapperConfig::Shard(shardDims[0]);
-  }
-  if (shardDims[1] >= 0) {
-    config.placements[1] = MeshMapperConfig::Shard(shardDims[1]);
-  }
-
-  std::unique_ptr<TensorToMesh> meshMapper =
-      ::ttnn::distributed::create_mesh_mapper(meshDevice, config);
-
-  return ::ttnn::distributed::distribute_tensor(input, *meshMapper,
-                                                /*meshDevice=*/std::nullopt);
-}
-
-static ::ttnn::Tensor
-ShardToFullShape(const ::ttnn::Tensor &input, ::ttnn::MeshDevice &meshDevice,
-                 const ::tt::target::ttnn::MeshShardType &shardType,
-                 const std::vector<int64_t> &shardShape,
-                 const std::vector<int64_t> &shardDims) {
-  std::vector<::ttnn::Tensor> input_tensors =
-      ::ttnn::distributed::get_device_tensors(input);
-  if (shardType == ::tt::target::ttnn::MeshShardType::Replicate) {
-    return input_tensors[0];
-  }
-  bool bFullConcat = std::all_of(shardDims.begin(), shardDims.end(),
-                                 [](int n) { return n >= 0; });
-  if (bFullConcat) {
-    // Full multi-device storage concatenation.
-    ::ttnn::distributed::MeshComposerConfig composerConfig{
-        .dims = {static_cast<int>(shardDims[0]),
-                 static_cast<int>(shardDims[1])}};
-
-    std::unique_ptr<MeshToTensor> meshComposer =
-        ::ttnn::distributed::create_mesh_composer(meshDevice, composerConfig);
-
-    return ::ttnn::distributed::aggregate_tensor(input, *meshComposer);
-  }
-  // Partial multi-device storage concatenation.
-  // Current ttnn api does not support partial multi-device storage
-  // concatenation. Thus, xtensor APIs are being called directly from here.
-  size_t stride = 0;
-  int targetDim = 0;
-  size_t iteration = 0;
-  if (shardDims[0] >= 0) {
-    targetDim = shardDims[0];
-    iteration = shardShape[targetDim];
-    stride = meshDevice.num_cols();
-  } else {
-    targetDim = shardDims[1];
-    iteration = shardShape[targetDim];
-    stride = 1;
-  }
-  std::vector<::ttnn::Tensor> target_tensors;
-  for (size_t i = 0; i < iteration; ++i) {
-    target_tensors.push_back(input_tensors[i * stride]);
-  }
-  return ::ttnn::experimental::xtensor::concat(target_tensors, targetDim);
-}
 
 void run(const ::tt::target::ttnn::MeshShardOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
@@ -94,9 +21,7 @@ void run(const ::tt::target::ttnn::MeshShardOp *op, ProgramContext &context) {
   const ::tt::target::ttnn::MeshShardDirection shardDirection =
       op->shard_direction();
   const ::tt::target::ttnn::MeshShardType shardType = op->shard_type();
-  const auto *fbShardShape = op->shard_shape();
   const auto *fbShardDims = op->shard_dims();
-  std::vector<int64_t> shardShape(fbShardShape->begin(), fbShardShape->end());
   std::vector<int64_t> shardDims(fbShardDims->begin(), fbShardDims->end());
 
   if (shardType == ::tt::target::ttnn::MeshShardType::Identity) {
@@ -123,14 +48,68 @@ void run(const ::tt::target::ttnn::MeshShardOp *op, ProgramContext &context) {
     return;
   }
 
+  auto fullMeshShape = meshDevice.shape();
   ::ttnn::Tensor out;
   if (shardDirection ==
       ::tt::target::ttnn::MeshShardDirection::FullToShardShape) {
-    out = FullToShardShape(input, meshDevice, shardType, shardShape, shardDims);
+    // Nd Sharding
+    MeshMapperConfig meshMapperConfig;
+    meshMapperConfig.placements.resize(fullMeshShape.dims(),
+                                       MeshMapperConfig::Replicate{});
+    if (shardType == ::tt::target::ttnn::MeshShardType::Devices) {
+      std::transform(shardDims.cbegin(), shardDims.cend(),
+                     meshMapperConfig.placements.begin(),
+                     [](const int dim) -> MeshMapperConfig::Placement {
+                       if (dim >= 0) {
+                         return MeshMapperConfig::Shard{dim};
+                       }
+                       return MeshMapperConfig::Replicate{};
+                     });
+    }
+    std::unique_ptr<TensorToMesh> meshMapper =
+        ::ttnn::distributed::create_mesh_mapper(meshDevice, meshMapperConfig);
+    out = ::ttnn::distributed::distribute_tensor(input, *meshMapper);
   } else {
-    LOG_ASSERT(shardDirection ==
-               ::tt::target::ttnn::MeshShardDirection::ShardToFullShape);
-    out = ShardToFullShape(input, meshDevice, shardType, shardShape, shardDims);
+    // Nd (partial) Concat
+    MeshComposerConfig meshComposerConfig;
+    if (shardType == ::tt::target::ttnn::MeshShardType::Replicate) {
+      meshComposerConfig.dims.push_back(static_cast<int>(1));
+      meshComposerConfig.mesh_shape_override = ::ttnn::MeshShape({1});
+    } else {
+      // meshComposerConfig.dims must be unique, and thus, we need to find
+      // non-overlapping dim.
+      auto getNonOverlappingDim = [&]() -> int {
+        int inputRank = static_cast<int>(input.logical_shape().rank());
+        const auto &dims = meshComposerConfig.dims;
+        for (int d = inputRank - 1; d >= 0; --d) {
+          if (std::find(shardDims.cbegin(), shardDims.cend(), d) ==
+                  shardDims.cend() &&
+              std::find(dims.cbegin(), dims.cend(), d) == dims.cend()) {
+            return d;
+          }
+        }
+        LOG_ERROR("All dimensions are overlapping, cannot find non-overlapping "
+                  "dimension for mesh composer.");
+        return -1;
+      };
+      ttsl::SmallVector<uint32_t> targetSubMeshShape;
+      for (size_t dimIdx = 0; dimIdx < shardDims.size(); ++dimIdx) {
+        auto dim = shardDims[dimIdx];
+        if (dim >= 0) {
+          meshComposerConfig.dims.push_back(static_cast<int>(dim));
+          targetSubMeshShape.push_back(fullMeshShape[dimIdx]);
+        } else {
+          meshComposerConfig.dims.push_back(getNonOverlappingDim());
+          targetSubMeshShape.push_back(1);
+        }
+      }
+      meshComposerConfig.mesh_shape_override =
+          ::ttnn::MeshShape(targetSubMeshShape);
+    }
+    std::unique_ptr<MeshToTensor> meshComposer =
+        ::ttnn::distributed::create_mesh_composer(meshDevice,
+                                                  meshComposerConfig);
+    out = ::ttnn::distributed::aggregate_tensor(input, *meshComposer);
   }
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -189,9 +189,6 @@ install(
     ${CPM_SOURCE_CACHE}/reflect
     ${CPM_SOURCE_CACHE}/spdlog
     ${CPM_SOURCE_CACHE}/tt-logger
-    ${CPM_SOURCE_CACHE}/xtensor
-    ${CPM_SOURCE_CACHE}/xtensor-blas
-    ${CPM_SOURCE_CACHE}/xtl
   DESTINATION tt-metal/.cpmcache
   COMPONENT TTNNStandalone
   EXCLUDE_FROM_ALL

--- a/tools/ttnn-standalone/CMakeLists.txt
+++ b/tools/ttnn-standalone/CMakeLists.txt
@@ -85,9 +85,6 @@ set(INCLUDE_DIRS
     ${CPM_SOURCE_CACHE}/nlohmann_json/798e0374658476027d9723eeb67a262d0f3c8308/include
     ${CPM_SOURCE_CACHE}/spdlog/b1c2586bb5c35a7929362e87f62433eb68206873/include
     ${CPM_SOURCE_CACHE}/tt-logger/37d08f9c0e2a5cc0247e0cf050c06563597d9c7c/include
-    ${CPM_SOURCE_CACHE}/xtl/0_8_0_patched/include
-    ${CPM_SOURCE_CACHE}/xtensor/0_26_0_patched/include
-    ${CPM_SOURCE_CACHE}/xtensor-blas/0_22_0_patched/include
 
     # Metalium
     ${METAL_SRC_DIR}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/3518

### Problem description
TTNN mesh sharding API has updated its capability to perform N-dimensional sharding and partial concat.

### What's changed
Update mesh_shard runtime code to fully leverage such features.

### Checklist
- [X] Existing tests provide coverage for changes
