### PR TITLE
Adding implicit conversion from float16 to bfloat16 in compiler

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -306,6 +306,7 @@ jobs:
         ln -sf ${{ steps.strings.outputs.install-output-dir }} ${{ steps.strings.outputs.build-output-dir }}
         echo "Running TTNN Runtime Unit Tests"
         ${{ steps.strings.outputs.build-output-dir }}/runtime/test/common/gtest/test_generate_sys_desc
+        ${{ steps.strings.outputs.build-output-dir }}/runtime/test/common/gtest/test_handle_float_bfloat_buffer_cast
         ${{ steps.strings.outputs.build-output-dir }}/runtime/test/common/gtest/test_handle_integer_buffer_cast
 
     - name: Run TTNN-Standalone test

--- a/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h
+++ b/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h
@@ -163,7 +163,7 @@ inline Type dataTypeToElementType(mlir::MLIRContext *context, DataType dtype) {
   case DataType::Float32:
     return Float32Type::get(context);
   case DataType::Float16:
-    return Float16Type::get(context);
+    return BFloat16Type::get(context);
   case DataType::BFloat16:
     return BFloat16Type::get(context);
   case DataType::BFP_Float8:

--- a/runtime/include/tt/runtime/utils.h
+++ b/runtime/include/tt/runtime/utils.h
@@ -284,84 +284,86 @@ inline void handleBoolToBFloat16(const bool *old_buffer, uint16_t *new_buffer,
   }
 }
 
-inline void handleFloat16ToBFloat16(const uint16_t *old_buffer, uint16_t *new_buffer,
-                   int64_t num_elements) {
+inline void handleFloat16ToBFloat16(const uint16_t *old_buffer,
+                                    uint16_t *new_buffer,
+                                    int64_t num_elements) {
   assert(old_buffer && new_buffer && "Buffer pointers must not be null");
   for (int64_t i = 0; i < num_elements; i++) {
-  uint16_t f16_bits = old_buffer[i];
-  
-  // Extract components from float16
-  uint16_t sign = (f16_bits >> 15) & 0x1;
-  uint16_t exponent = (f16_bits >> 10) & 0x1F;
-  uint16_t mantissa = f16_bits & 0x3FF;
-  
-  // Convert to bfloat16
-  if (exponent == 0 && mantissa == 0) {
-    // Zero
-    new_buffer[i] = sign << 15;
-  } else if (exponent == 0x1F) {
-    // Infinity or NaN
-    new_buffer[i] = (sign << 15) | 0x7F80 | ((mantissa != 0) ? 0x40 : 0);
-  } else {
-    // Normal numbers
-    // Adjust exponent bias: float16 bias is 15, bfloat16 bias is 127
-    int32_t new_exponent = (exponent == 0) ? 0 : (exponent - 15 + 127);
-    
-    if (new_exponent <= 0) {
-    // Underflow to zero
-    new_buffer[i] = sign << 15;
-    } else if (new_exponent >= 255) {
-    // Overflow to infinity
-    new_buffer[i] = (sign << 15) | 0x7F80;
+    uint16_t f16_bits = old_buffer[i];
+
+    // Extract components from float16
+    uint16_t sign = (f16_bits >> 15) & 0x1;
+    uint16_t exponent = (f16_bits >> 10) & 0x1F;
+    uint16_t mantissa = f16_bits & 0x3FF;
+
+    // Convert to bfloat16
+    if (exponent == 0 && mantissa == 0) {
+      // Zero
+      new_buffer[i] = sign << 15;
+    } else if (exponent == 0x1F) {
+      // Infinity or NaN
+      new_buffer[i] = (sign << 15) | 0x7F80 | ((mantissa != 0) ? 0x40 : 0);
     } else {
-    // Round mantissa from 10 bits to 7 bits
-    uint16_t rounded_mantissa = (mantissa + 0x8) >> 3;
-    if (rounded_mantissa >= 0x80) {
-      // Mantissa overflow, increment exponent
-      new_exponent++;
-      rounded_mantissa = 0;
+      // Normal numbers
+      // Adjust exponent bias: float16 bias is 15, bfloat16 bias is 127
+      int32_t new_exponent = (exponent == 0) ? 0 : (exponent - 15 + 127);
+
+      if (new_exponent <= 0) {
+        // Underflow to zero
+        new_buffer[i] = sign << 15;
+      } else if (new_exponent >= 255) {
+        // Overflow to infinity
+        new_buffer[i] = (sign << 15) | 0x7F80;
+      } else {
+        // Round mantissa from 10 bits to 7 bits
+        uint16_t rounded_mantissa = (mantissa + 0x8) >> 3;
+        if (rounded_mantissa >= 0x80) {
+          // Mantissa overflow, increment exponent
+          new_exponent++;
+          rounded_mantissa = 0;
+        }
+        new_buffer[i] = (sign << 15) | (new_exponent << 7) | rounded_mantissa;
+      }
     }
-    new_buffer[i] = (sign << 15) | (new_exponent << 7) | rounded_mantissa;
-    }
-  }
   }
 }
 
-inline void handleBFloat16ToFloat16(const uint16_t *old_buffer, uint16_t *new_buffer,
-                   int64_t num_elements) {
+inline void handleBFloat16ToFloat16(const uint16_t *old_buffer,
+                                    uint16_t *new_buffer,
+                                    int64_t num_elements) {
   assert(old_buffer && new_buffer && "Buffer pointers must not be null");
   for (int64_t i = 0; i < num_elements; i++) {
-  uint16_t bf16_bits = old_buffer[i];
-  
-  // Extract components from bfloat16
-  uint16_t sign = (bf16_bits >> 15) & 0x1;
-  uint16_t exponent = (bf16_bits >> 7) & 0xFF;
-  uint16_t mantissa = bf16_bits & 0x7F;
-  
-  // Convert to float16
-  if (exponent == 0 && mantissa == 0) {
-    // Zero
-    new_buffer[i] = sign << 15;
-  } else if (exponent == 0xFF) {
-    // Infinity or NaN
-    new_buffer[i] = (sign << 15) | 0x7C00 | ((mantissa != 0) ? 0x200 : 0);
-  } else {
-    // Normal numbers
-    // Adjust exponent bias: bfloat16 bias is 127, float16 bias is 15
-    int32_t new_exponent = exponent - 127 + 15;
-    
-    if (new_exponent <= 0) {
-    // Underflow to zero
-    new_buffer[i] = sign << 15;
-    } else if (new_exponent >= 31) {
-    // Overflow to infinity
-    new_buffer[i] = (sign << 15) | 0x7C00;
+    uint16_t bf16_bits = old_buffer[i];
+
+    // Extract components from bfloat16
+    uint16_t sign = (bf16_bits >> 15) & 0x1;
+    uint16_t exponent = (bf16_bits >> 7) & 0xFF;
+    uint16_t mantissa = bf16_bits & 0x7F;
+
+    // Convert to float16
+    if (exponent == 0 && mantissa == 0) {
+      // Zero
+      new_buffer[i] = sign << 15;
+    } else if (exponent == 0xFF) {
+      // Infinity or NaN
+      new_buffer[i] = (sign << 15) | 0x7C00 | ((mantissa != 0) ? 0x200 : 0);
     } else {
-    // Extend mantissa from 7 bits to 10 bits
-    uint16_t extended_mantissa = mantissa << 3;
-    new_buffer[i] = (sign << 15) | (new_exponent << 10) | extended_mantissa;
+      // Normal numbers
+      // Adjust exponent bias: bfloat16 bias is 127, float16 bias is 15
+      int32_t new_exponent = exponent - 127 + 15;
+
+      if (new_exponent <= 0) {
+        // Underflow to zero
+        new_buffer[i] = sign << 15;
+      } else if (new_exponent >= 31) {
+        // Overflow to infinity
+        new_buffer[i] = (sign << 15) | 0x7C00;
+      } else {
+        // Extend mantissa from 7 bits to 10 bits
+        uint16_t extended_mantissa = mantissa << 3;
+        new_buffer[i] = (sign << 15) | (new_exponent << 10) | extended_mantissa;
+      }
     }
-  }
   }
 }
 
@@ -439,19 +441,17 @@ inline void handleBufferCast(const void *old_buffer, void *new_buffer,
     detail::handleBoolToBFloat16(static_cast<const bool *>(old_buffer),
                                  static_cast<uint16_t *>(new_buffer),
                                  num_elements);
-  }
-  else if (oldDataType == tt::target::DataType::Float16 &&
-         newDataType == tt::target::DataType::BFloat16) {
+  } else if (oldDataType == tt::target::DataType::Float16 &&
+             newDataType == tt::target::DataType::BFloat16) {
     detail::handleFloat16ToBFloat16(static_cast<const uint16_t *>(old_buffer),
-                     static_cast<uint16_t *>(new_buffer),
-                     num_elements);
-    } else if (oldDataType == tt::target::DataType::BFloat16 &&
-         newDataType == tt::target::DataType::Float16) {
+                                    static_cast<uint16_t *>(new_buffer),
+                                    num_elements);
+  } else if (oldDataType == tt::target::DataType::BFloat16 &&
+             newDataType == tt::target::DataType::Float16) {
     detail::handleBFloat16ToFloat16(static_cast<const uint16_t *>(old_buffer),
-                     static_cast<uint16_t *>(new_buffer),
-                     num_elements);
-    }
-   else {
+                                    static_cast<uint16_t *>(new_buffer),
+                                    num_elements);
+  } else {
     throw std::runtime_error(
         "Unhandled buffer cast case: From " +
         std::string(target::EnumNameDataType(oldDataType)) + " to " +

--- a/runtime/include/tt/runtime/utils.h
+++ b/runtime/include/tt/runtime/utils.h
@@ -62,7 +62,6 @@ inline std::int64_t tileAlignment(::tt::target::DataType dataType) {
 inline bool isSupportedDataType(::tt::target::DataType dataType) {
   switch (dataType) {
   case ::tt::target::DataType::Float32:
-  case ::tt::target::DataType::Float16:
   case ::tt::target::DataType::BFloat16:
   case ::tt::target::DataType::BFP_Float8:
   case ::tt::target::DataType::BFP_BFloat8:
@@ -75,6 +74,7 @@ inline bool isSupportedDataType(::tt::target::DataType dataType) {
   case ::tt::target::DataType::UInt8:
   case ::tt::target::DataType::Int32:
     return true;
+  case ::tt::target::DataType::Float16:
   case ::tt::target::DataType::Float64:
   case ::tt::target::DataType::Int64:
   case ::tt::target::DataType::UInt64:
@@ -99,6 +99,8 @@ getUnsupportedDataTypeAlias(::tt::target::DataType unsupportedDataType) {
   case ::tt::target::DataType::Int8:
     return ::tt::target::DataType::UInt8;
   case ::tt::target::DataType::Bool:
+    return ::tt::target::DataType::BFloat16;
+  case ::tt::target::DataType::Float16:
     return ::tt::target::DataType::BFloat16;
   default:
     throw std::runtime_error(
@@ -281,6 +283,88 @@ inline void handleBoolToBFloat16(const bool *old_buffer, uint16_t *new_buffer,
                         : 0; // 0x3f80 is the bfloat16 representation of 1.0
   }
 }
+
+inline void handleFloat16ToBFloat16(const uint16_t *old_buffer, uint16_t *new_buffer,
+                   int64_t num_elements) {
+  assert(old_buffer && new_buffer && "Buffer pointers must not be null");
+  for (int64_t i = 0; i < num_elements; i++) {
+  uint16_t f16_bits = old_buffer[i];
+  
+  // Extract components from float16
+  uint16_t sign = (f16_bits >> 15) & 0x1;
+  uint16_t exponent = (f16_bits >> 10) & 0x1F;
+  uint16_t mantissa = f16_bits & 0x3FF;
+  
+  // Convert to bfloat16
+  if (exponent == 0 && mantissa == 0) {
+    // Zero
+    new_buffer[i] = sign << 15;
+  } else if (exponent == 0x1F) {
+    // Infinity or NaN
+    new_buffer[i] = (sign << 15) | 0x7F80 | ((mantissa != 0) ? 0x40 : 0);
+  } else {
+    // Normal numbers
+    // Adjust exponent bias: float16 bias is 15, bfloat16 bias is 127
+    int32_t new_exponent = (exponent == 0) ? 0 : (exponent - 15 + 127);
+    
+    if (new_exponent <= 0) {
+    // Underflow to zero
+    new_buffer[i] = sign << 15;
+    } else if (new_exponent >= 255) {
+    // Overflow to infinity
+    new_buffer[i] = (sign << 15) | 0x7F80;
+    } else {
+    // Round mantissa from 10 bits to 7 bits
+    uint16_t rounded_mantissa = (mantissa + 0x8) >> 3;
+    if (rounded_mantissa >= 0x80) {
+      // Mantissa overflow, increment exponent
+      new_exponent++;
+      rounded_mantissa = 0;
+    }
+    new_buffer[i] = (sign << 15) | (new_exponent << 7) | rounded_mantissa;
+    }
+  }
+  }
+}
+
+inline void handleBFloat16ToFloat16(const uint16_t *old_buffer, uint16_t *new_buffer,
+                   int64_t num_elements) {
+  assert(old_buffer && new_buffer && "Buffer pointers must not be null");
+  for (int64_t i = 0; i < num_elements; i++) {
+  uint16_t bf16_bits = old_buffer[i];
+  
+  // Extract components from bfloat16
+  uint16_t sign = (bf16_bits >> 15) & 0x1;
+  uint16_t exponent = (bf16_bits >> 7) & 0xFF;
+  uint16_t mantissa = bf16_bits & 0x7F;
+  
+  // Convert to float16
+  if (exponent == 0 && mantissa == 0) {
+    // Zero
+    new_buffer[i] = sign << 15;
+  } else if (exponent == 0xFF) {
+    // Infinity or NaN
+    new_buffer[i] = (sign << 15) | 0x7C00 | ((mantissa != 0) ? 0x200 : 0);
+  } else {
+    // Normal numbers
+    // Adjust exponent bias: bfloat16 bias is 127, float16 bias is 15
+    int32_t new_exponent = exponent - 127 + 15;
+    
+    if (new_exponent <= 0) {
+    // Underflow to zero
+    new_buffer[i] = sign << 15;
+    } else if (new_exponent >= 31) {
+    // Overflow to infinity
+    new_buffer[i] = (sign << 15) | 0x7C00;
+    } else {
+    // Extend mantissa from 7 bits to 10 bits
+    uint16_t extended_mantissa = mantissa << 3;
+    new_buffer[i] = (sign << 15) | (new_exponent << 10) | extended_mantissa;
+    }
+  }
+  }
+}
+
 } // namespace detail
 
 inline void handleBufferCast(const void *old_buffer, void *new_buffer,
@@ -355,7 +439,19 @@ inline void handleBufferCast(const void *old_buffer, void *new_buffer,
     detail::handleBoolToBFloat16(static_cast<const bool *>(old_buffer),
                                  static_cast<uint16_t *>(new_buffer),
                                  num_elements);
-  } else {
+  }
+  else if (oldDataType == tt::target::DataType::Float16 &&
+         newDataType == tt::target::DataType::BFloat16) {
+    detail::handleFloat16ToBFloat16(static_cast<const uint16_t *>(old_buffer),
+                     static_cast<uint16_t *>(new_buffer),
+                     num_elements);
+    } else if (oldDataType == tt::target::DataType::BFloat16 &&
+         newDataType == tt::target::DataType::Float16) {
+    detail::handleBFloat16ToFloat16(static_cast<const uint16_t *>(old_buffer),
+                     static_cast<uint16_t *>(new_buffer),
+                     num_elements);
+    }
+   else {
     throw std::runtime_error(
         "Unhandled buffer cast case: From " +
         std::string(target::EnumNameDataType(oldDataType)) + " to " +

--- a/runtime/include/tt/runtime/utils.h
+++ b/runtime/include/tt/runtime/utils.h
@@ -288,43 +288,57 @@ inline void handleFloat16ToBFloat16(const uint16_t *old_buffer,
                                     uint16_t *new_buffer,
                                     int64_t num_elements) {
   assert(old_buffer && new_buffer && "Buffer pointers must not be null");
-  for (int64_t i = 0; i < num_elements; i++) {
-    uint16_t f16_bits = old_buffer[i];
 
-    // Extract components from float16
-    uint16_t sign = (f16_bits >> 15) & 0x1;
-    uint16_t exponent = (f16_bits >> 10) & 0x1F;
-    uint16_t mantissa = f16_bits & 0x3FF;
+  for (int64_t i = 0; i < num_elements; ++i) {
+    uint16_t f16 = old_buffer[i];
 
-    // Convert to bfloat16
-    if (exponent == 0 && mantissa == 0) {
-      // Zero
-      new_buffer[i] = sign << 15;
-    } else if (exponent == 0x1F) {
-      // Infinity or NaN
-      new_buffer[i] = (sign << 15) | 0x7F80 | ((mantissa != 0) ? 0x40 : 0);
-    } else {
-      // Normal numbers
-      // Adjust exponent bias: float16 bias is 15, bfloat16 bias is 127
-      int32_t new_exponent = (exponent == 0) ? 0 : (exponent - 15 + 127);
+    // Decompose float16
+    uint16_t sign = (f16 >> 15) & 0x1;
+    uint16_t exponent = (f16 >> 10) & 0x1F;
+    uint16_t mantissa = f16 & 0x3FF;
 
-      if (new_exponent <= 0) {
-        // Underflow to zero
-        new_buffer[i] = sign << 15;
-      } else if (new_exponent >= 255) {
-        // Overflow to infinity
-        new_buffer[i] = (sign << 15) | 0x7F80;
+    uint32_t f32_bits = 0;
+
+    if (exponent == 0) {
+      if (mantissa == 0) {
+        // Zero
+        f32_bits = static_cast<uint32_t>(sign) << 31;
       } else {
-        // Round mantissa from 10 bits to 7 bits
-        uint16_t rounded_mantissa = (mantissa + 0x8) >> 3;
-        if (rounded_mantissa >= 0x80) {
-          // Mantissa overflow, increment exponent
-          new_exponent++;
-          rounded_mantissa = 0;
+        // Subnormal float16 → normalize to float32 subnormal
+        // Shift mantissa left until leading 1
+        int shift = 0;
+        while ((mantissa & 0x400) == 0) {
+          mantissa <<= 1;
+          ++shift;
         }
-        new_buffer[i] = (sign << 15) | (new_exponent << 7) | rounded_mantissa;
+        mantissa &= 0x3FF; // Remove the leading 1
+        exponent = 1;
+        exponent -= shift;
+
+        int32_t exp32 = int32_t(exponent) - 15 + 127;
+        f32_bits = (static_cast<uint32_t>(sign) << 31) |
+                   (static_cast<uint32_t>(exp32) << 23) |
+                   (static_cast<uint32_t>(mantissa) << 13);
       }
+    } else if (exponent == 0x1F) {
+      // Inf or NaN
+      f32_bits = (static_cast<uint32_t>(sign) << 31) | (0xFF << 23) |
+                 (static_cast<uint32_t>(mantissa) << 13);
+    } else {
+      // Normalized number
+      int32_t exp32 = int32_t(exponent) - 15 + 127;
+      f32_bits = (static_cast<uint32_t>(sign) << 31) |
+                 (static_cast<uint32_t>(exp32) << 23) |
+                 (static_cast<uint32_t>(mantissa) << 13);
     }
+
+    // Convert float32 bits to bfloat16 with rounding-to-nearest-even
+    uint32_t lsb = (f32_bits >> 16) & 1;
+    uint32_t rounding_bias = 0x7FFF + lsb;
+    f32_bits += rounding_bias;
+
+    uint16_t bfloat16 = static_cast<uint16_t>(f32_bits >> 16);
+    new_buffer[i] = bfloat16;
   }
 }
 

--- a/runtime/test/common/gtest/CMakeLists.txt
+++ b/runtime/test/common/gtest/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_runtime_gtest(test_generate_sys_desc)
+add_runtime_gtest(test_handle_float_bfloat_buffer_cast)
 add_runtime_gtest(test_handle_integer_buffer_cast)

--- a/runtime/test/common/gtest/test_handle_float_bfloat_buffer_cast.cpp
+++ b/runtime/test/common/gtest/test_handle_float_bfloat_buffer_cast.cpp
@@ -26,14 +26,14 @@ TEST(HandleFloat16ToBfloat16BufferCast, SanityBFloat16ToFloat16) {
   tt::runtime::utils::detail::handleBFloat16ToFloat16(bfloat_buffer,
                                                       float_buffer, 3);
 
-  EXPECT_EQ(bfloat_buffer[0], float16_neg_one);
-  EXPECT_EQ(bfloat_buffer[1], 0);
-  EXPECT_EQ(bfloat_buffer[2], float16_neg_one);
+  EXPECT_EQ(float_buffer[0], float16_neg_one);
+  EXPECT_EQ(float_buffer[1], 0);
+  EXPECT_EQ(float_buffer[2], float16_neg_one);
 }
 
 TEST(HandleFloat16ToBfloat16BufferCast, HandleFloat16Max) {
-  uint16_t bfloat16_from_float16_max = 0x477F; // = 65504.0f
-  uint16_t bfloat16_from_float16_min = 0xC77F; // = -65504.0f
+  uint16_t bfloat16_from_float16_max = 0x4780; // = 65504.0f
+  uint16_t bfloat16_from_float16_min = 0xc780; // = -65504.0f
   uint16_t float16_max = 0x7BFF;               // +65504.0
   uint16_t float16_min = 0xFBFF;               // -65504.0
   uint16_t float_buffer[] = {float16_min, float16_max};

--- a/runtime/test/common/test_handle_float_bfloat_buffer_cast.cpp
+++ b/runtime/test/common/test_handle_float_bfloat_buffer_cast.cpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+#include "tt/runtime/utils.h"
+#include <gtest/gtest.h>
+#include <limits>
+
+TEST(HandleFloat16ToBfloat16BufferCast, Sanity) {
+  uint16_t float16_neg_one = 0xBC00; 
+  uint16_t bfloat16_neg_one = 0xBF80; 
+  uint16_t float_buffer[] = {float16_neg_one, 0, float16_neg_one};
+  uint16_t bfloat_buffer[] = {0, 0, 0};
+  tt::runtime::utils::detail::handleFloat16ToBFloat16(float_buffer, bfloat_buffer,
+                                                      3);
+
+  // Values should be clamped to the int32_t range, not overflowed
+  EXPECT_EQ(bfloat_buffer[0], bfloat16_neg_one);
+  EXPECT_EQ(bfloat_buffer[1], 0);
+  EXPECT_EQ(bfloat_buffer[2], bfloat16_neg_one);
+}

--- a/runtime/test/common/test_handle_float_bfloat_buffer_cast.cpp
+++ b/runtime/test/common/test_handle_float_bfloat_buffer_cast.cpp
@@ -1,20 +1,46 @@
 // SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
+
 #include "tt/runtime/utils.h"
 #include <gtest/gtest.h>
-#include <limits>
 
-TEST(HandleFloat16ToBfloat16BufferCast, Sanity) {
-  uint16_t float16_neg_one = 0xBC00; 
-  uint16_t bfloat16_neg_one = 0xBF80; 
+TEST(HandleFloat16ToBfloat16BufferCast, SanityFloat16ToBfloat16) {
+  uint16_t float16_neg_one = 0xBC00;
+  uint16_t bfloat16_neg_one = 0xBF80;
   uint16_t float_buffer[] = {float16_neg_one, 0, float16_neg_one};
   uint16_t bfloat_buffer[] = {0, 0, 0};
-  tt::runtime::utils::detail::handleFloat16ToBFloat16(float_buffer, bfloat_buffer,
-                                                      3);
+  tt::runtime::utils::detail::handleFloat16ToBFloat16(float_buffer,
+                                                      bfloat_buffer, 3);
 
-  // Values should be clamped to the int32_t range, not overflowed
   EXPECT_EQ(bfloat_buffer[0], bfloat16_neg_one);
   EXPECT_EQ(bfloat_buffer[1], 0);
   EXPECT_EQ(bfloat_buffer[2], bfloat16_neg_one);
+}
+
+TEST(HandleFloat16ToBfloat16BufferCast, SanityBFloat16ToFloat16) {
+  uint16_t float16_neg_one = 0xBC00;
+  uint16_t bfloat16_neg_one = 0xBF80;
+  uint16_t bfloat_buffer[] = {bfloat16_neg_one, 0, bfloat16_neg_one};
+  uint16_t float_buffer[] = {0, 0, 0};
+  tt::runtime::utils::detail::handleBFloat16ToFloat16(bfloat_buffer,
+                                                      float_buffer, 3);
+
+  EXPECT_EQ(bfloat_buffer[0], float16_neg_one);
+  EXPECT_EQ(bfloat_buffer[1], 0);
+  EXPECT_EQ(bfloat_buffer[2], float16_neg_one);
+}
+
+TEST(HandleFloat16ToBfloat16BufferCast, HandleFloat16Max) {
+  uint16_t bfloat16_from_float16_max = 0x477F; // = 65504.0f
+  uint16_t bfloat16_from_float16_min = 0xC77F; // = -65504.0f
+  uint16_t float16_max = 0x7BFF;               // +65504.0
+  uint16_t float16_min = 0xFBFF;               // -65504.0
+  uint16_t float_buffer[] = {float16_min, float16_max};
+  uint16_t bfloat_buffer[] = {0, 0};
+  tt::runtime::utils::detail::handleFloat16ToBFloat16(float_buffer,
+                                                      bfloat_buffer, 2);
+
+  EXPECT_EQ(bfloat_buffer[0], bfloat16_from_float16_min);
+  EXPECT_EQ(bfloat_buffer[1], bfloat16_from_float16_max);
 }

--- a/test/ttmlir/Dialect/TTIR/element_type_normalization/element_type_normalization_positive.mlir
+++ b/test/ttmlir/Dialect/TTIR/element_type_normalization/element_type_normalization_positive.mlir
@@ -83,7 +83,7 @@ func.func @constant_ui64() -> tensor<32x32xui64> {
 func.func @constant_f16() -> tensor<32x32xf16> {
   // CHECK: "ttir.full"
   // CHECK-SAME: value = 1.000000e+00 : f32
-  // CHECK-SAME: -> tensor<32x32xf16>
+  // CHECK-SAME: -> tensor<32x32xbf16>
   %0 = "ttir.constant"() <{value = dense<1.0> : tensor<32x32xf16>}> : () -> tensor<32x32xf16>
   return %0 : tensor<32x32xf16>
 }


### PR DESCRIPTION
Since tt-metal does not support float16, adding its conversion to bfloat16 in the `ElementTypeNormalizationPass`. This will unblock some of the models in tt-xla that use `float16`.