### PR TITLE
Disable fusing by default

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -222,7 +222,7 @@ struct TTIRToTTNNBackendPipelineOptions
 
   Option<bool> enableFusing{*this, "enable-fusing-pass",
                             llvm::cl::desc("Enable fusing pass."),
-                            llvm::cl::init(true)};
+                            llvm::cl::init(false)};
 
   Option<ttcore::TTArgumentTypeMap, ttcore::ArgumentTypeMapParser>
       argumentTypeMap{

--- a/test/ttmlir/Dialect/TTNN/fusing/resnet_pattern_fusing.mlir
+++ b/test/ttmlir/Dialect/TTNN/fusing/resnet_pattern_fusing.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-fusing-pass=true" %s | FileCheck %s
 
 // This is common pattern throught Resnet. We have conv2d with constant weight, followed by multiply with constant input. This will be commuted through conv2d.
 // Then we fuse add into conv2d with bias and lastly we fuse conv2d and relu into conv2d with activation.

--- a/test/ttmlir/Silicon/TTNN/n150/fusing/resnet_pattern_fusing.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/fusing/resnet_pattern_fusing.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-fusing-pass=true" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 

--- a/test/ttmlir/Silicon/TTNN/n150/fusing/softmax_fusing.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/fusing/softmax_fusing.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-fusing-pass=true" %s > %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 


### PR DESCRIPTION
### Problem description
Enabling fusing by default seems to have uncovered dram OOM issues  in a few models multiple frontends.
https://github.com/tenstorrent/tt-forge-fe/actions/runs/16019721440/job/45195710825?pr=2425

### What's changed
Disable fusing by default for now.
