### PR TITLE
Add test for conv2d sharding

### DIFF
--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/conv2d_sharding.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/conv2d_sharding.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: opmodel
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-optimizer=true memory-layout-analysis-enabled=false" %s -o %t.mlir
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-optimizer=true memory-layout-analysis-enabled=true" %s -o %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 


### PR DESCRIPTION
Regression test to check if convolution op has sharded layout when `enable-optimizer` and `memory-layout-analysis-enabled` flags are on.