### PR TITLE
Remove unneeded include introduced in PR 3942

### DIFF
--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -32,7 +32,6 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 
-#include "llvm/Support/raw_ostream.h"
 #include <optional>
 #include <tuple>
 #include <utility>


### PR DESCRIPTION
Removing the unnecessary include introduced in:
https://github.com/tenstorrent/tt-mlir/pull/3934