### PR TITLE
Add constraints API for LinearOp

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1172,7 +1172,9 @@ def TTNN_SliceOp: TTNN_Op<"slice",
     let hasVerifier = 1;
 }
 
-def TTNN_LinearOp : TTNN_Op<"linear"> {
+def TTNN_LinearOp : TTNN_Op<"linear",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
     let summary = "Linear transformation of inputs.";
 
     let description = [{

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -288,7 +288,7 @@ getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
                  llvm::ArrayRef<int64_t> outputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool transposeA,
                  bool transposeB);
-    
+
 llvm::Expected<size_t>
 getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
              mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -273,6 +273,35 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 }; // namespace TransposeOpInterface
 
 //===----------------------------------------------------------------------===//
+// LinearOp
+//===----------------------------------------------------------------------===//
+
+namespace LinearOpInterface {
+    llvm::Expected<OpConstraints>
+    getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                     llvm::ArrayRef<int64_t> inputShapeA,
+                     mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                     llvm::ArrayRef<int64_t> inputShapeB,
+                     mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                     std::optional<llvm::ArrayRef<int64_t>> biasShape,
+                     std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
+                     llvm::ArrayRef<int64_t> outputShape,
+                     mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool transposeA,
+                     bool transposeB);
+    
+    llvm::Expected<size_t>
+    getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                 llvm::ArrayRef<int64_t> inputShapeB,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                 std::optional<llvm::ArrayRef<int64_t>> biasShape,
+                 std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
+                 llvm::ArrayRef<int64_t> outputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
+                 bool transposeA, bool transposeB);
+    }; // namespace LinearOpInterface
+
+//===----------------------------------------------------------------------===//
 // MatmulOp
 //===----------------------------------------------------------------------===//
 

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -297,8 +297,8 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
              std::optional<llvm::ArrayRef<int64_t>> biasShape,
              std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
              llvm::ArrayRef<int64_t> outputShape,
-             mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
-             bool transposeA, bool transposeB);
+             mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool transposeA,
+             bool transposeB);
 }; // namespace LinearOpInterface
 
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -277,29 +277,29 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 //===----------------------------------------------------------------------===//
 
 namespace LinearOpInterface {
-    llvm::Expected<OpConstraints>
-    getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
-                     llvm::ArrayRef<int64_t> inputShapeA,
-                     mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
-                     llvm::ArrayRef<int64_t> inputShapeB,
-                     mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
-                     std::optional<llvm::ArrayRef<int64_t>> biasShape,
-                     std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
-                     llvm::ArrayRef<int64_t> outputShape,
-                     mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool transposeA,
-                     bool transposeB);
+llvm::Expected<OpConstraints>
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                llvm::ArrayRef<int64_t> inputShapeA,
+                mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                llvm::ArrayRef<int64_t> inputShapeB,
+                mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                std::optional<llvm::ArrayRef<int64_t>> biasShape,
+                std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
+                llvm::ArrayRef<int64_t> outputShape,
+                mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool transposeA,
+                bool transposeB);
     
-    llvm::Expected<size_t>
-    getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
-                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
-                 llvm::ArrayRef<int64_t> inputShapeB,
-                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
-                 std::optional<llvm::ArrayRef<int64_t>> biasShape,
-                 std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
-                 llvm::ArrayRef<int64_t> outputShape,
-                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
-                 bool transposeA, bool transposeB);
-    }; // namespace LinearOpInterface
+llvm::Expected<size_t>
+getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
+            mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+            llvm::ArrayRef<int64_t> inputShapeB,
+            mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+            std::optional<llvm::ArrayRef<int64_t>> biasShape,
+            std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
+            llvm::ArrayRef<int64_t> outputShape,
+            mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
+            bool transposeA, bool transposeB);
+}; // namespace LinearOpInterface
 
 //===----------------------------------------------------------------------===//
 // MatmulOp

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -279,26 +279,26 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 namespace LinearOpInterface {
 llvm::Expected<OpConstraints>
 getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
-                llvm::ArrayRef<int64_t> inputShapeA,
-                mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
-                llvm::ArrayRef<int64_t> inputShapeB,
-                mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
-                std::optional<llvm::ArrayRef<int64_t>> biasShape,
-                std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
-                llvm::ArrayRef<int64_t> outputShape,
-                mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool transposeA,
-                bool transposeB);
+                 llvm::ArrayRef<int64_t> inputShapeA,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                 llvm::ArrayRef<int64_t> inputShapeB,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                 std::optional<llvm::ArrayRef<int64_t>> biasShape,
+                 std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
+                 llvm::ArrayRef<int64_t> outputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool transposeA,
+                 bool transposeB);
     
 llvm::Expected<size_t>
 getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
-            mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
-            llvm::ArrayRef<int64_t> inputShapeB,
-            mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
-            std::optional<llvm::ArrayRef<int64_t>> biasShape,
-            std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
-            llvm::ArrayRef<int64_t> outputShape,
-            mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
-            bool transposeA, bool transposeB);
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+             llvm::ArrayRef<int64_t> inputShapeB,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+             std::optional<llvm::ArrayRef<int64_t>> biasShape,
+             std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
+             llvm::ArrayRef<int64_t> outputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
+             bool transposeA, bool transposeB);
 }; // namespace LinearOpInterface
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -728,8 +728,8 @@ LinearOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   const auto outputShape = getType().getShape();
 
   return op_model::ttnn::LinearOpInterface::getOpRuntime(
-      inputShapeA, inputs[0], inputShapeB, inputs[1], biasShape,
-      biasLayout, outputShape, opConfig.outputLayout, false, false);
+      inputShapeA, inputs[0], inputShapeB, inputs[1], biasShape, biasLayout,
+      outputShape, opConfig.outputLayout, false, false);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -676,6 +676,63 @@ TransposeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// LinearOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::ttnn::OpConstraints>
+LinearOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                           const OpConfig &opConfig) {
+  assert(inputs.size() == (2 + (getBias() == nullptr ? 0 : 1)));
+
+  const auto inputShapeA = getA().getType().getShape();
+  const auto inputShapeB = getB().getType().getShape();
+
+  std::optional<llvm::ArrayRef<int64_t>> biasShape;
+  std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout;
+
+  if (inputs.size() == 3) {
+    biasShape = getBias().getType().getShape();
+    biasLayout = inputs[2];
+  }
+
+  const auto outputShape = getType().getShape();
+
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+
+  return op_model::ttnn::LinearOpInterface::getOpConstraints(
+      deviceGrid, inputShapeA, inputs[0], inputShapeB, inputs[1], biasShape,
+      biasLayout, outputShape, opConfig.outputLayout, false, false);
+}
+
+llvm::Expected<size_t>
+LinearOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                       const OpConfig &opConfig) {
+  assert(inputs.size() == (2 + (getBias() == nullptr ? 0 : 1)));
+
+  const auto inputShapeA = getA().getType().getShape();
+  const auto inputShapeB = getB().getType().getShape();
+
+  std::optional<llvm::ArrayRef<int64_t>> biasShape;
+  std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout;
+
+  if (inputs.size() == 3) {
+    biasShape = getBias().getType().getShape();
+    biasLayout = inputs[2];
+  }
+
+  const auto outputShape = getType().getShape();
+
+  return op_model::ttnn::LinearOpInterface::getOpRuntime(
+      inputShapeA, inputs[0], inputShapeB, inputs[1], biasShape,
+      biasLayout, outputShape, opConfig.outputLayout, false, false);
+}
+
+//===----------------------------------------------------------------------===//
 // MatmulOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -1526,7 +1526,7 @@ llvm::Expected<OpConstraints> LinearOpInterface::getOpConstraints(
   // Create query closure
   auto linearOpQuery = [=]() {
     return ::ttnn::graph::query_op_constraints(
-        ::ttnn::linear, device, inputSpecA, inputSpecB, biasTensor,transposeA,
+        ::ttnn::linear, device, inputSpecA, inputSpecB, biasTensor, transposeA,
         transposeB, outputMemoryConfig, outputDType);
   };
 

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -1483,17 +1483,16 @@ llvm::Expected<size_t> TransposeOpInterface::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // LinearOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints>
-LinearOpInterface::getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
-                                    llvm::ArrayRef<int64_t> inputShapeA,
-                                    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
-                                    llvm::ArrayRef<int64_t> inputShapeB,
-                                    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
-                                    std::optional<llvm::ArrayRef<int64_t>> biasShape,
-                                    std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
-                                    llvm::ArrayRef<int64_t> outputShape,
-                                    mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
-                                    bool transposeA, bool transposeB) {
+llvm::Expected<OpConstraints> LinearOpInterface::getOpConstraints(
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+    std::optional<llvm::ArrayRef<int64_t>> biasShape,
+    std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
+    llvm::ArrayRef<int64_t> outputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool transposeA,
+    bool transposeB) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1527,8 +1526,8 @@ LinearOpInterface::getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
   // Create query closure
   auto linearOpQuery = [=]() {
     return ::ttnn::graph::query_op_constraints(
-        ::ttnn::linear, device, inputSpecA, inputSpecB, biasTensor,
-        transposeA, transposeB, outputMemoryConfig, outputDType);
+        ::ttnn::linear, device, inputSpecA, inputSpecB, biasTensor,transposeA,
+        transposeB, outputMemoryConfig, outputDType);
   };
 
   return operation::getOpConstraints("LinearOpInterface",
@@ -1539,16 +1538,16 @@ LinearOpInterface::getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
-llvm::Expected<size_t>
-LinearOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
-                                mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
-                                llvm::ArrayRef<int64_t> inputShapeB,
-                                mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
-                                std::optional<llvm::ArrayRef<int64_t>> biasShape,
-                                std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
-                                llvm::ArrayRef<int64_t> outputShape,
-                                mlir::tt::ttnn::TTNNLayoutAttr outputLayout,
-                                bool transposeA, bool transposeB) {
+llvm::Expected<size_t> LinearOpInterface::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShapeA,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+    std::optional<llvm::ArrayRef<int64_t>> biasShape,
+    std::optional<mlir::tt::ttnn::TTNNLayoutAttr> biasLayout,
+    llvm::ArrayRef<int64_t> outputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout, bool transposeA,
+    bool transposeB) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1581,9 +1580,9 @@ LinearOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
 
   // Create query closure
   auto linearOpQuery = [=]() {
-    return ::ttnn::graph::query_op_runtime(::ttnn::linear, device, inputSpecA,
-                                           inputSpecB, biasTensor, transposeA,
-                                           transposeB, outputMemoryConfig, outputDType);
+    return ::ttnn::graph::query_op_runtime(
+        ::ttnn::linear, device, inputSpecA, inputSpecB, biasTensor, transposeA,
+        transposeB, outputMemoryConfig, outputDType);
   };
 
   return operation::getOpRuntime("LinearOpInterface", linearOpQuery);

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -969,7 +969,7 @@ TEST_P(OpModelLinearParam, LinearParam) {
 
   auto constraintsExp = LinearOpInterface::getOpConstraints(
       CreateWorkerGrid(), inputShapeA, inputLayoutA, inputShapeB, inputLayoutB,
-      biasShape, biasLayout,outputShape, outputLayout, false, false);
+      biasShape, biasLayout, outputShape, outputLayout, false, false);
 
   // Manually cast to bool because EXPECT_TRUE requires a const bool operator
   // which llvm::Expected<T> does not have

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -950,8 +950,8 @@ TEST_P(OpModelLinearParam, LinearParam) {
               inputVirtualGridA] = std::get<0>(params);
   const auto [inputShapeB, inputTensorLayoutB, inputBufferTypeB,
               inputVirtualGridB] = std::get<1>(params);
-  const auto [biasShape, biasTensorLayout, biasBufferType,
-              biasVirtualGrid] = std::get<2>(params);
+  const auto [biasShape, biasTensorLayout, biasBufferType, biasVirtualGrid] =
+      std::get<2>(params);
   const auto [outputShape, outputTensorLayout, outputBufferType,
               outputVirtualGrid] = std::get<3>(params);
   llvm::SmallVector<int64_t> physicalGrid = std::get<4>(params);
@@ -969,7 +969,7 @@ TEST_P(OpModelLinearParam, LinearParam) {
 
   auto constraintsExp = LinearOpInterface::getOpConstraints(
       CreateWorkerGrid(), inputShapeA, inputLayoutA, inputShapeB, inputLayoutB,
-      biasShape,biasLayout,outputShape, outputLayout, false, false);
+      biasShape, biasLayout,outputShape, outputLayout, false, false);
 
   // Manually cast to bool because EXPECT_TRUE requires a const bool operator
   // which llvm::Expected<T> does not have
@@ -1106,8 +1106,7 @@ INSTANTIATE_TEST_SUITE_P(
                                mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
                                mlir::tt::ttnn::BufferType::L1,
                                llvm::SmallVector<int64_t>{7, 8}},
-            llvm::SmallVector<int64_t>{7, 8},
-            detail::ExpectedResult{false}),
+            llvm::SmallVector<int64_t>{7, 8}, detail::ExpectedResult{false}),
         std::make_tuple(
             detail::TestTensor{{56 * 32, 56 * 32},
                                mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -934,6 +934,259 @@ INSTANTIATE_TEST_SUITE_P(
 
 // ==== Binary Eltwise Ops Ends ====
 
+class OpModelLinearParam
+    : public OpModelTest,
+      public testing::WithParamInterface<
+          std::tuple<detail::TestTensor,         // inputA
+                     detail::TestTensor,         // inputB
+                     detail::TestTensor,         // bias
+                     detail::TestTensor,         // output,
+                     llvm::SmallVector<int64_t>, // physical grid
+                     detail::ExpectedResult>> {};
+
+TEST_P(OpModelLinearParam, LinearParam) {
+  auto params = GetParam();
+  const auto [inputShapeA, inputTensorLayoutA, inputBufferTypeA,
+              inputVirtualGridA] = std::get<0>(params);
+  const auto [inputShapeB, inputTensorLayoutB, inputBufferTypeB,
+              inputVirtualGridB] = std::get<1>(params);
+  const auto [biasShape, biasTensorLayout, biasBufferType,
+              biasVirtualGrid] = std::get<2>(params);
+  const auto [outputShape, outputTensorLayout, outputBufferType,
+              outputVirtualGrid] = std::get<3>(params);
+  llvm::SmallVector<int64_t> physicalGrid = std::get<4>(params);
+  const auto [expectedLegal, expectedCbSize, expectedPeakSize,
+              expectedOutputSize] = std::get<5>(params);
+
+  const mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA = CreateTiledLayout(
+      inputShapeA, inputBufferTypeA, inputTensorLayoutA, inputVirtualGridA);
+  const mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB = CreateTiledLayout(
+      inputShapeB, inputBufferTypeB, inputTensorLayoutB, inputVirtualGridB);
+  const mlir::tt::ttnn::TTNNLayoutAttr biasLayout = CreateTiledLayout(
+      biasShape, biasBufferType, biasTensorLayout, biasVirtualGrid);
+  const mlir::tt::ttnn::TTNNLayoutAttr outputLayout = CreateTiledLayout(
+      outputShape, outputBufferType, outputTensorLayout, outputVirtualGrid);
+
+  auto constraintsExp = LinearOpInterface::getOpConstraints(
+      CreateWorkerGrid(), inputShapeA, inputLayoutA, inputShapeB, inputLayoutB,
+      biasShape,biasLayout,outputShape, outputLayout, false, false);
+
+  // Manually cast to bool because EXPECT_TRUE requires a const bool operator
+  // which llvm::Expected<T> does not have
+  EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
+  if (expectedLegal) {
+    const auto [cbSize, peakSize, outputSize, outputLayoutReadBack] =
+        constraintsExp.get();
+    EXPECT_EQ(cbSize, expectedCbSize);
+    EXPECT_EQ(peakSize, expectedPeakSize);
+    EXPECT_EQ(outputSize, expectedOutputSize);
+  } else {
+    // Must clean up the error
+    llvm::consumeError(constraintsExp.takeError());
+  }
+
+  auto runtimeExp = LinearOpInterface::getOpRuntime(
+      inputShapeA, inputLayoutA, inputShapeB, inputLayoutB, biasShape,
+      biasLayout, outputShape, outputLayout, false, false);
+  EXPECT_EQ(static_cast<bool>(runtimeExp), expectedLegal);
+  if (expectedLegal) {
+    EXPECT_TRUE(runtimeExp.get() > 0);
+  } else {
+    llvm::consumeError(runtimeExp.takeError());
+  }
+  mlir::tt::op_model::ttnn::SingletonDeviceContext::resetInstance();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    LinearInterleavedTests, OpModelLinearParam,
+    ::testing::Values(
+        std::make_tuple(detail::interleaved2048X2048Dram,
+                        detail::interleaved2048X2048Dram,
+                        detail::interleaved2048X2048Dram,
+                        detail::interleaved2048X2048Dram,
+                        llvm::SmallVector<int64_t>{8, 8},
+                        detail::ExpectedResult{true, 655360, 0, 0}),
+        std::make_tuple(detail::interleaved2048X2048Dram,
+                        detail::interleaved2048X2048Dram,
+                        detail::interleaved2048X2048Dram,
+                        detail::inerleaved2048X2048L1,
+                        llvm::SmallVector<int64_t>{8, 8},
+                        detail::ExpectedResult{true, 786432, 262144, 131072}),
+        std::make_tuple(detail::interleaved2048X2048Dram,
+                        detail::inerleaved2048X2048L1,
+                        detail::inerleaved2048X2048L1,
+                        detail::interleaved2048X2048Dram,
+                        llvm::SmallVector<int64_t>{8, 8},
+                        detail::ExpectedResult{true, 262144, 0, 0}),
+        std::make_tuple(detail::interleaved2048X2048Dram,
+                        detail::inerleaved2048X2048L1,
+                        detail::inerleaved2048X2048L1,
+                        detail::inerleaved2048X2048L1,
+                        llvm::SmallVector<int64_t>{8, 8},
+                        detail::ExpectedResult{true, 262144, 262144, 131072}),
+        std::make_tuple(detail::inerleaved2048X2048L1,
+                        detail::interleaved2048X2048Dram,
+                        detail::inerleaved2048X2048L1,
+                        detail::interleaved2048X2048Dram,
+                        llvm::SmallVector<int64_t>{8, 8},
+                        detail::ExpectedResult{true, 262144, 0, 0}),
+        std::make_tuple(detail::inerleaved2048X2048L1,
+                        detail::interleaved2048X2048Dram,
+                        detail::inerleaved2048X2048L1,
+                        detail::inerleaved2048X2048L1,
+                        llvm::SmallVector<int64_t>{8, 8},
+                        detail::ExpectedResult{true, 262144, 262144, 131072}),
+        std::make_tuple(detail::inerleaved2048X2048L1,
+                        detail::inerleaved2048X2048L1,
+                        detail::interleaved2048X2048Dram,
+                        detail::interleaved2048X2048Dram,
+                        llvm::SmallVector<int64_t>{8, 8},
+                        detail::ExpectedResult{true, 786432, 0, 0}),
+        std::make_tuple(detail::inerleaved2048X2048L1,
+                        detail::inerleaved2048X2048L1,
+                        detail::interleaved2048X2048Dram,
+                        detail::inerleaved2048X2048L1,
+                        llvm::SmallVector<int64_t>{8, 8},
+                        detail::ExpectedResult{true, 786432, 262144, 131072})));
+
+INSTANTIATE_TEST_SUITE_P(
+    LinearShardedTests, OpModelLinearParam,
+    ::testing::Values(
+        std::make_tuple(
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            llvm::SmallVector<int64_t>{7, 8},
+            detail::ExpectedResult{true, 430144, 229376, 114688}),
+        std::make_tuple(
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            llvm::SmallVector<int64_t>{7, 8}, detail::ExpectedResult{false}),
+        std::make_tuple(
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            llvm::SmallVector<int64_t>{7, 8},
+            detail::ExpectedResult{false}),
+        std::make_tuple(
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            llvm::SmallVector<int64_t>{7, 8},
+            detail::ExpectedResult{true, 544832, 0, 0}),
+        std::make_tuple(
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::BlockSharded,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            detail::TestTensor{
+                llvm::SmallVector<int64_t>{56 * 32, 56 * 32},
+                mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
+                mlir::tt::ttnn::BufferType::L1,
+                llvm::SmallVector<int64_t>{56, 1}},
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            llvm::SmallVector<int64_t>{7, 8}, detail::ExpectedResult{false}),
+        std::make_tuple(
+            detail::TestTensor{llvm::SmallVector<int64_t>{1 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::WidthSharded,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{1, 56}},
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            detail::TestTensor{{1 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            detail::TestTensor{llvm::SmallVector<int64_t>{1 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::WidthSharded,
+                               mlir::tt::ttnn::BufferType::L1,
+                               llvm::SmallVector<int64_t>{1, 56}},
+            llvm::SmallVector<int64_t>{7, 8},
+            detail::ExpectedResult{true, 8256, 4096, 2048}),
+        std::make_tuple(
+            detail::TestTensor{
+                {56 * 32, 1 * 32},
+                mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
+                mlir::tt::ttnn::BufferType::L1,
+                llvm::SmallVector<int64_t>{56, 1}},
+            detail::TestTensor{llvm::SmallVector<int64_t>{1 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            detail::TestTensor{{56 * 32, 56 * 32},
+                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                               mlir::tt::ttnn::BufferType::DRAM,
+                               llvm::SmallVector<int64_t>{7, 8}},
+            detail::TestTensor{
+                llvm::SmallVector<int64_t>{56 * 32, 56 * 32},
+                mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
+                mlir::tt::ttnn::BufferType::L1,
+                llvm::SmallVector<int64_t>{56, 1}},
+            llvm::SmallVector<int64_t>{7, 8},
+            detail::ExpectedResult{true, 114688, 229376, 114688})));
+
 class OpModelMatmulParam
     : public OpModelTest,
       public testing::WithParamInterface<

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -411,6 +411,111 @@ TEST_F(OpModelBase, MultiplyOpInterface) {
   }
 }
 
+TEST_F(OpModelBase, LinearOpInterface) {
+  // create LinearOp
+  llvm::SmallVector<int64_t> tensorShapeA = {2048, 1024};
+  llvm::SmallVector<int64_t> tensorShapeB = {1024, 2048};
+  llvm::SmallVector<int64_t> biasShape = {2048, 2048};
+  llvm::SmallVector<int64_t> tensorShapeO = {2048, 2048};
+
+  auto inputA = createEmptyTensor(tensorShapeA);
+  auto inputB = createEmptyTensor(tensorShapeB);
+  auto bias = createEmptyTensor(biasShape);
+  auto outputType = createRankedTensorType(tensorShapeO);
+
+  auto linear = builder.create<LinearOp>(builder.getUnknownLoc(), outputType,
+                                         ::mlir::ValueRange{inputA, inputB, bias});
+
+  // test LinearOp interface
+  auto constraintsExp = getOpConstraints(linear.getOperation());
+  if (constraintsExp) {
+    auto l1 = constraintsExp.get();
+    const auto &[cbSize, peakSize, outputSize, outputLayout] = l1;
+    EXPECT_EQ(cbSize, 262144);
+    EXPECT_EQ(peakSize, 262144);
+    EXPECT_EQ(outputSize, 131072);
+  } else {
+    FAIL() << "Missing L1 constraints; Error="
+           << llvm::toString(constraintsExp.takeError()) << std::endl;
+  }
+
+  auto runtimeExp = getOpRuntime(linear.getOperation());
+  if (runtimeExp) {
+    EXPECT_TRUE(runtimeExp.get() > 0);
+  } else {
+    FAIL() << llvm::toString(runtimeExp.takeError());
+  }
+}
+
+TEST_F(OpModelBase, LinearOpInterfaceNullOutput) {
+  // create LinearOp
+  llvm::SmallVector<int64_t> tensorShapeA = {2048, 1024};
+  llvm::SmallVector<int64_t> tensorShapeB = {1024, 2048};
+  llvm::SmallVector<int64_t> biasShape = {2048, 2048};
+  llvm::SmallVector<int64_t> tensorShapeO = {2048, 2048};
+
+  auto inputA = createEmptyTensor(tensorShapeA);
+  auto inputB = createEmptyTensor(tensorShapeB);
+  auto bias = createEmptyTensor(biasShape);
+  auto outputType = createRankedTensorType(tensorShapeO);
+
+  auto linear = builder.create<LinearOp>(builder.getUnknownLoc(), outputType,
+                                         ::mlir::ValueRange{inputA, inputB, bias});
+
+  // test LinearOp interface
+  OpModel backend = dyn_cast<OpModel>(linear.getOperation());
+  auto constraintsExp = backend.getOpConstraints(
+      getInputLayouts(linear), OpConfig(/*outputLayout=*/nullptr));
+
+  ASSERT_TRUE(static_cast<bool>(constraintsExp));
+  const auto &[cbSize, peakSize, outputSize, outputLayout] =
+      constraintsExp.get();
+  EXPECT_EQ(cbSize, 262144);
+  EXPECT_EQ(peakSize, 0);
+  EXPECT_EQ(outputSize, 0);
+
+  ASSERT_TRUE(outputLayout);
+  EXPECT_EQ(outputLayout.getLayout(), Layout::Tile);
+  EXPECT_TRUE(outputLayout.hasInterleavedDRAMTensorMemoryLayout());
+  mlir::tt::op_model::ttnn::SingletonDeviceContext::resetInstance();
+}
+
+TEST_F(OpModelBase, LinearOpInterfacePartialOutput) {
+  // create LinearOp
+  llvm::SmallVector<int64_t> tensorShapeA = {2048, 1024};
+  llvm::SmallVector<int64_t> tensorShapeB = {1024, 2048};
+  llvm::SmallVector<int64_t> biasShape = {2048, 2048};
+  llvm::SmallVector<int64_t> tensorShapeO = {2048, 2048};
+
+  auto inputA = createEmptyTensor(tensorShapeA);
+  auto inputB = createEmptyTensor(tensorShapeB);
+  auto bias = createEmptyTensor(biasShape);
+  auto outputType = createRankedTensorType(tensorShapeO);
+
+  auto outputLayout = CreateTiledLayout(tensorShapeO, BufferType::L1,
+                                        TensorMemoryLayout::BlockSharded)
+                          .withIgnorePhysicalLayout(true);
+  auto linear = builder.create<LinearOp>(builder.getUnknownLoc(), outputType,
+                                         ::mlir::ValueRange{inputA, inputB, bias});
+
+  // test LinearOp interface
+  OpModel backend = dyn_cast<OpModel>(linear.getOperation());
+  auto constraintsExp =
+      backend.getOpConstraints(getInputLayouts(linear), OpConfig(outputLayout));
+
+  ASSERT_TRUE(static_cast<bool>(constraintsExp));
+  auto constraints = constraintsExp.get();
+  EXPECT_EQ(constraints.cbL1PeakSize, 131072);
+  EXPECT_EQ(constraints.tensorL1PeakSize, 262144);
+  EXPECT_EQ(constraints.outputL1BufferSize, 131072);
+
+  ASSERT_TRUE(constraints.outputLayout);
+  EXPECT_EQ(constraints.outputLayout.getLayout(), Layout::Tile);
+  EXPECT_TRUE(constraints.outputLayout.hasShardedL1TensorMemoryLayout());
+  EXPECT_TRUE(constraints.outputLayout.getGrid());
+  mlir::tt::op_model::ttnn::SingletonDeviceContext::resetInstance();
+}
+
 TEST_F(OpModelBase, MatmulOpInterface) {
   // create MatmulOp
   llvm::SmallVector<int64_t> tensorShapeA = {2048, 1024};

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -423,8 +423,9 @@ TEST_F(OpModelBase, LinearOpInterface) {
   auto bias = createEmptyTensor(biasShape);
   auto outputType = createRankedTensorType(tensorShapeO);
 
-  auto linear = builder.create<LinearOp>(builder.getUnknownLoc(), outputType,
-                                         ::mlir::ValueRange{inputA, inputB, bias});
+  auto linear =
+      builder.create<LinearOp>(builder.getUnknownLoc(), outputType,
+                               ::mlir::ValueRange{inputA, inputB, bias});
 
   // test LinearOp interface
   auto constraintsExp = getOpConstraints(linear.getOperation());
@@ -459,8 +460,9 @@ TEST_F(OpModelBase, LinearOpInterfaceNullOutput) {
   auto bias = createEmptyTensor(biasShape);
   auto outputType = createRankedTensorType(tensorShapeO);
 
-  auto linear = builder.create<LinearOp>(builder.getUnknownLoc(), outputType,
-                                         ::mlir::ValueRange{inputA, inputB, bias});
+  auto linear =
+      builder.create<LinearOp>(builder.getUnknownLoc(), outputType,
+                               ::mlir::ValueRange{inputA, inputB, bias});
 
   // test LinearOp interface
   OpModel backend = dyn_cast<OpModel>(linear.getOperation());
@@ -495,8 +497,9 @@ TEST_F(OpModelBase, LinearOpInterfacePartialOutput) {
   auto outputLayout = CreateTiledLayout(tensorShapeO, BufferType::L1,
                                         TensorMemoryLayout::BlockSharded)
                           .withIgnorePhysicalLayout(true);
-  auto linear = builder.create<LinearOp>(builder.getUnknownLoc(), outputType,
-                                         ::mlir::ValueRange{inputA, inputB, bias});
+  auto linear =
+      builder.create<LinearOp>(builder.getUnknownLoc(), outputType,
+                               ::mlir::ValueRange{inputA, inputB, bias});
 
   // test LinearOp interface
   OpModel backend = dyn_cast<OpModel>(linear.getOperation());


### PR DESCRIPTION
### Ticket
[#3940](https://github.com/tenstorrent/tt-mlir/issues/3940)

### Problem description
Adding constraints for `LinearOp`.

### What's changed
Added support for `getOpConstraints` and `getOpRuntime` for `LinearOp`

### Checklist
- [x] New/Existing tests provide coverage for changes
