### PR TITLE
Sphinx autogenerated docs dependency fix

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -53,6 +53,7 @@ add_custom_target(sphinx
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
   DEPENDS
     TTIRBuilderModules
+    TTMLIRPythonModules
     copy-docs-dir mlir-doc
   COMMENT "Generating Sphinx documentation"
 )


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
The [docs](https://docs.tenstorrent.com/tt-mlir/autogen/md/Module/apis.html) generated by sphinx are showing up blank.

### What's changed
To the best of my knowledge, the docs weren't loading the `ttir_builder` python package because they were being built before the python packages. A dependency was added to correct that. 

Steps to reproduce error on main:
```
rm -rf build
cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang-17 -DCMAKE_CXX_COMPILER=clang++-17 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DTTMLIR_ENABLE_RUNTIME=ON -DTT_RUNTIME_ENABLE_PERF_TRACE=ON -DTTMLIR_ENABLE_RUNTIME_TESTS=ON -DTTMLIR_ENABLE_STABLEHLO=ON -DTT_RUNTIME_DEBUG=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DTTMLIR_ENABLE_OPMODEL=ON
cmake --build build -- docs
```

### Checklist
- [ ] New/Existing tests provide coverage for changes
