### PR TITLE
Add mising dialect dependencies for `TTCoreRegisterDevicePass`

### DIFF
--- a/include/ttmlir/Dialect/TTCore/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTCore/Transforms/Passes.td
@@ -70,6 +70,7 @@ def TTCoreRegisterDevicePass : Pass<"ttcore-register-device", "::mlir::ModuleOp"
         Option<"systemDescPath", "system-desc-path", "std::string", "", "System desc path">,
         ListOption<"meshShape", "mesh-shape", "int64_t", "Set the mesh shape">,
     ];
+  let dependentDialects = ["::mlir::tt::ttcore::TTCoreDialect"];
 }
 
 #endif

--- a/lib/Dialect/TTCore/Transforms/TTCoreRegisterDevice.cpp
+++ b/lib/Dialect/TTCore/Transforms/TTCoreRegisterDevice.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "ttmlir/Dialect/TTCore/IR/TTCore.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOps.h"
 #include "ttmlir/Dialect/TTCore/IR/Utils.h"
 #include "ttmlir/Dialect/TTCore/Transforms/Passes.h"


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
TTCore dialect dependency was missing from the tablegen file. The pass simply crashed when it tried to print the generated IR with ``'mlir::tt::CPUDescAttr' because storage uniquer isn't initialized`.

### What's changed
Added the dependency in the tablegen file to fix this.

### Checklist
- [ ] New/Existing tests provide coverage for changes
