### PR TITLE
D2M: Matmul Multicore blocking, additional fixes

### DIFF
--- a/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Passes.td
@@ -118,6 +118,7 @@ def TTIROptimizeTensorLayout: Pass<"ttir-optimize-tensor-layout", "::mlir::Modul
   list<Option> options = [
         ListOption<"overrideDeviceShape", "override-device-shape", "int64_t", "Override the device shape.">,
         Option<"maxDstRegisterSizeTiles", "max-dst-register-size-tiles", "unsigned", "0", "Override the max dst size tiles or 0 if unset.">,
+        ListOption<"matmulBlockFactors", "matmul-block-factors", "int64_t", "Override the block factors for matmul in M,N,K order. Use 0 if you want the algorithm to determine those values. i.e. 0,0,8 to set the k block factor to 8, and let Optimize Tensor Layout handle M,N.">
     ];
 }
 

--- a/include/ttmlir/Dialect/TTMetal/Pipelines/TTMetalPipelines.h
+++ b/include/ttmlir/Dialect/TTMetal/Pipelines/TTMetalPipelines.h
@@ -57,6 +57,13 @@ struct TTIRToTTMetalPipelineOptions
           "maps and iterator types. The interchange indices here always "
           "correspond to the innermost 3 dims.")};
 
+  ListOption<int64_t> matmulBlockFactors{
+      *this, "matmul-block-factors",
+      llvm::cl::desc(
+          "Override the block factors for matmul in M,N,K order. Use 0 if you "
+          "want the algorithm to determine those values. i.e. 0,0,8 to set the "
+          "k block factor to 8, and let Optimize Tensor Layout handle M,N.")};
+
   // Option to control whether generic conversion uses 'tile_matmul'
   // (default) or 'tile_matmul_block'.
   //

--- a/lib/Dialect/TTIR/Transforms/OptimizeTensorLayout.cpp
+++ b/lib/Dialect/TTIR/Transforms/OptimizeTensorLayout.cpp
@@ -289,14 +289,13 @@ struct TTIRGenericTensorLayoutRewriter : public OpRewritePattern<GenericOp> {
       }
     }
 
-
     auto viewOperandType = applyGridShape(newTensorType, numBlocks);
 
     // Do not insert ViewLayoutOp if the shapes are already identical.
     if (toLayoutOp.getType(0) == viewOperandType) {
       return toLayoutOp.getResult(0);
     }
-    
+
     return rewriter
         .create<ViewLayoutOp>(loc, toLayoutOp.getResult(0),
                               viewOperandType.getShape())

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -75,6 +75,8 @@ void createTTIRToTTMetalFrontendPipeline(
         llvm::to_vector(options.overrideDeviceShape);
     optimizeTensorLayoutOptions.maxDstRegisterSizeTiles =
         options.maxDstRegisterSizeTiles;
+    optimizeTensorLayoutOptions.matmulBlockFactors =
+        llvm::to_vector(options.matmulBlockFactors);
   }
   pm.addPass(ttir::createTTIROptimizeTensorLayout(optimizeTensorLayoutOptions));
   pm.addPass(mlir::createCanonicalizerPass());

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -221,13 +221,13 @@ memrefTypeToCircularBufferConfigFlatbuffer(FlatbufferObjectCache &cache,
   }
 
   auto shardLayout = mlir::cast<ttcore::ShardLayoutAttr>(deviceLayout);
-  // This override is because we don't have a way to get the true worker grid
-  // shape from a memref. This issue manifests when we do multi-core blocking,
-  // where the "grid shape" of the memref may be greater than the worker grid
-  // shape. auto memrefGridShape = shardLayout.getGridShape(memref);
-  auto cbGridShape = SmallVector<int64_t, 2>{8, 8};
+  // We use device.getWorkerGrid().getShape() as the tensorGrid because we
+  // don't have a way to get the true worker grid shape from a memref. This
+  // issue manifests when we do multi-core blocking, where the "grid shape" of
+  // the memref may be greater than the worker grid shape.
   std::vector<target::Dim2dRange> coreRangeSet =
-      toFlatbuffer(cache, cbGridShape, device.getWorkerGrid().getMapping());
+      toFlatbuffer(cache, device.getWorkerGrid().getShape(),
+                   device.getWorkerGrid().getMapping());
 
   uint64_t pageSize = device.getMemrefCBPageSizeBytes(memref);
   uint64_t shardSize =

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -221,9 +221,13 @@ memrefTypeToCircularBufferConfigFlatbuffer(FlatbufferObjectCache &cache,
   }
 
   auto shardLayout = mlir::cast<ttcore::ShardLayoutAttr>(deviceLayout);
-  auto memrefGridShape = shardLayout.getGridShape(memref);
+  // This override is because we don't have a way to get the true worker grid
+  // shape from a memref. This issue manifests when we do multi-core blocking,
+  // where the "grid shape" of the memref may be greater than the worker grid
+  // shape. auto memrefGridShape = shardLayout.getGridShape(memref);
+  auto cbGridShape = SmallVector<int64_t, 2>{8, 8};
   std::vector<target::Dim2dRange> coreRangeSet =
-      toFlatbuffer(cache, memrefGridShape, device.getWorkerGrid().getMapping());
+      toFlatbuffer(cache, cbGridShape, device.getWorkerGrid().getMapping());
 
   uint64_t pageSize = device.getMemrefCBPageSizeBytes(memref);
   uint64_t shardSize =

--- a/test/python/golden/test_metal_blocking.py
+++ b/test/python/golden/test_metal_blocking.py
@@ -92,6 +92,7 @@ def test_matmul_blocking(
     options = [
         f"max-dst-register-size-tiles={dst_register_size_tiles}",
         f"override-device-shape={grid_m},{grid_n}",
+        f"matmul-interchange=2,0,1",
     ]
     compile_to_flatbuffer(
         matmul_blocking,

--- a/test/python/golden/test_metal_matmul.py
+++ b/test/python/golden/test_metal_matmul.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from typing import List
+
+from ttir_builder.utils import compile_to_flatbuffer
+from ttir_builder import Operand, TTIRBuilder, Shape
+from ttmlir.ir import *
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (512, 512, 512),
+        (512, 1024, 1024),
+        (512, 1024, 2048),
+        (1024, 1024, 1024),
+        (1024, 1024, 2048),
+        (1024, 2048, 2048),
+        (2048, 2048, 2048),
+        (2048, 2048, 3072),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32])
+@pytest.mark.parametrize("dst_register_size_tiles", [8])
+def test_matmul_ttnn(
+    shape: tuple[int],
+    dtype: torch.dtype,
+    dst_register_size_tiles: int,
+    request,
+):
+    lhs = (
+        shape[0],
+        shape[1],
+    )
+    rhs = (
+        shape[1],
+        shape[2],
+    )
+
+    def matmul_blocking(
+        in0: Operand,
+        in1: Operand,
+        builder: TTIRBuilder,
+        unit_attrs: List[str] = None,
+    ):
+        return builder.matmul(in0, in1, unit_attrs=unit_attrs)
+
+    options = [
+        f"max-dst-register-size-tiles={dst_register_size_tiles}",
+        f"matmul-interchange=2,0,1",
+    ]
+    compile_to_flatbuffer(
+        matmul_blocking,
+        [lhs, rhs],
+        inputs_types=[dtype, dtype],
+        target="ttmetal",
+        custom_pipeline=f"ttir-to-ttmetal-pipeline{{{' '.join(options)}}}",
+        test_base=request.node.name,
+        module_dump=True,
+        print_ir=True,
+        output_root=request.config.getoption("--path"),
+        system_desc_path=request.config.getoption("--sys-desc"),
+    )

--- a/test/python/golden/test_metal_matmul.py
+++ b/test/python/golden/test_metal_matmul.py
@@ -52,6 +52,7 @@ def test_matmul_ttnn(
     options = [
         f"max-dst-register-size-tiles={dst_register_size_tiles}",
         f"matmul-interchange=2,0,1",
+        f"matmul-block-factors=0,0,{shape[1] // 32 // 8 }",  # divide by tile size and grid shape to get k block factor. this simulates shard shape of k
     ]
     compile_to_flatbuffer(
         matmul_blocking,

--- a/test/python/golden/test_metal_matmul.py
+++ b/test/python/golden/test_metal_matmul.py
@@ -11,6 +11,7 @@ from ttir_builder import Operand, TTIRBuilder, Shape
 from ttmlir.ir import *
 
 
+@pytest.mark.fails_golden
 @pytest.mark.parametrize(
     "shape",
     [

--- a/test/python/golden/test_metal_matmul.py
+++ b/test/python/golden/test_metal_matmul.py
@@ -21,7 +21,6 @@ from ttmlir.ir import *
         (1024, 1024, 2048),
         (1024, 2048, 2048),
         (2048, 2048, 2048),
-        (2048, 2048, 3072),
     ],
 )
 @pytest.mark.parametrize("dtype", [torch.float32])


### PR DESCRIPTION
### Problem description
We would like to achieve parity in main with the matmul and reductions we've achieved on branch.

### What's changed
Separate things addressed in this PR:
1. ~~Override matmul k-blocking shapes to default to k_block_size=1. This allows us to fit large matmuls for now, until we have a smart way to decide this block factor. _(if we don't want this in main, we can limit the size of our tests. open to feedback here.)~~
2. Add a `matmul-block-factors` command line option to override the block factors used by OptimizeTensorLayout on matmuls. This is an interim solution which allows us to test different configs of matmul. This is required for the follow-up PR which changes the meaning of blockFactors to be based on L1 availability. We will not have an intelligent way to select this factor for the present time.
3. Replace ToLayout on the result of generic ops with ViewLayout. When we block outputs, we don't actually produce output blocks on different cores than originally intended. ToLayout will fail here because it tries to move data from cores that were not included in the compute. This unblocks matmul and reductions (cc: @phizalev-TT). This is a side effect of using grid shape to encode blocking information. 
4. Fix `blockedView` to not multiply `dim` by the blockFactor if the dimension is a reduction dim. This is because we need to gather all of the `k` block from all cores to mcast or reduce.
5. Override the shape that we intiialize cbs on to the device worker grid shape at all times. **I'm open to suggestions on better ways to do this.** This becomes a problem because we use grid shape to encode blocking information, which again can sometimes be larger than the actual worker grid. There is no side effect to initializing cbs on cores we will not do work on, but if you pass coordinates outside of the worker grid range, it will fail.
6. Added multicore matmul tests that we used to benchmark against ttnn. These are the limit of what we can currently accomplish. 

### Checklist
- [X] New/Existing tests provide coverage for changes
