### PR TITLE
[D2M] [Workaround] Enable DRAM Interleaved Tensors for TTMetal Backend Target

### DIFF
--- a/include/ttmlir/Target/TTMetal/types.fbs
+++ b/include/ttmlir/Target/TTMetal/types.fbs
@@ -13,11 +13,18 @@ table ShardSpecBuffer {
   tensor_shape_in_pages: Dim2d;
 }
 
+table InterleavedBufferConfig {
+  size: uint64;
+  page_size: uint64;
+}
+
 table ShardedBufferConfig {
   size: uint64;
   page_size: uint64;
   shard_spec_buffer: ShardSpecBuffer;
 }
+
+union BufferConfig {InterleavedBufferConfig, ShardedBufferConfig}
 
 table CircularBufferConfig {
   core_range_set: [Dim2dRange];
@@ -31,7 +38,7 @@ table BufferDesc {
   tile_shape: Dim2d;
   data_type: DataType;
   memory_space: MemorySpace;
-  sharded_buffer_config: ShardedBufferConfig;
+  buffer_config: BufferConfig;
   circular_buffer_config: CircularBufferConfig;
 }
 

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -210,6 +210,26 @@ memrefTypeToShardedBufferConfigFlatbuffer(FlatbufferObjectCache &cache,
                                                   shardSpecBuffer);
 }
 
+static flatbuffers::Offset<target::metal::InterleavedBufferConfig>
+memrefTypeToInterleavedBufferConfigFlatbuffer(FlatbufferObjectCache &cache,
+                                              MemRefType memref,
+                                              ttcore::DeviceAttr device,
+                                              target::Dim2d elementShape) {
+  auto deviceLayout = mlir::dyn_cast_if_present<ttcore::DeviceLayoutInterface>(
+      memref.getLayout());
+  if (!deviceLayout) {
+    return 0;
+  }
+
+  uint64_t pageSize =
+      elementShape.x() * elementShape.y() *
+      mlir::tt::ttcore::getElementSizeBytes(memref.getElementType());
+  uint64_t size =
+      device.getMemrefSizeBytes(memref, pageSize, /*includeBuffers=*/true);
+  return target::metal::CreateInterleavedBufferConfig(*cache.fbb, size,
+                                                      pageSize);
+}
+
 static flatbuffers::Offset<target::metal::CircularBufferConfig>
 memrefTypeToCircularBufferConfigFlatbuffer(FlatbufferObjectCache &cache,
                                            MemRefType memref,
@@ -256,9 +276,20 @@ memrefTypeToFlatbuffer(FlatbufferObjectCache &cache, MemRefType memref,
     dtype = ttcore::elementTypeToDataType(elementType);
   }
 
-  flatbuffers::Offset<target::metal::ShardedBufferConfig> shardedBufferConfig =
-      memrefTypeToShardedBufferConfigFlatbuffer(cache, memref, device,
-                                                elementShape);
+  flatbuffers::Offset<void> bufferConfig = 0;
+  target::metal::BufferConfig bufferConfigType;
+  // TODO(arminaleTT): how do we tell which config needs to be created??
+  if (1) { // CHANGE ME
+    bufferConfig = memrefTypeToShardedBufferConfigFlatbuffer(
+                       cache, memref, device, elementShape)
+                       .Union();
+    bufferConfigType = target::metal::BufferConfig::ShardedBufferConfig;
+  } else {
+    bufferConfig = memrefTypeToInterleavedBufferConfigFlatbuffer(
+                       cache, memref, device, elementShape)
+                       .Union();
+    bufferConfigType = target::metal::BufferConfig::InterleavedBufferConfig;
+  }
 
   flatbuffers::Offset<target::metal::CircularBufferConfig>
       circularBufferConfig =
@@ -266,7 +297,7 @@ memrefTypeToFlatbuffer(FlatbufferObjectCache &cache, MemRefType memref,
 
   return target::metal::CreateBufferDescDirect(
       *cache.fbb, &shape, &elementShape, toFlatbuffer(cache, dtype),
-      memorySpace, shardedBufferConfig, circularBufferConfig);
+      memorySpace, bufferConfigType, bufferConfig, circularBufferConfig);
 }
 
 static flatbuffers::Offset<target::metal::BufferRef>

--- a/runtime/lib/ttmetal/executor.cpp
+++ b/runtime/lib/ttmetal/executor.cpp
@@ -207,7 +207,6 @@ void CQExecutor::execute(const target::metal::Command *command) {
 void CQExecutor::execute(const target::metal::HostAllocCommand *command) {
   LOG_ASSERT(command->dst()->address() == 0);
   const auto *bufferDesc = command->dst()->desc();
-  LOG_ASSERT(bufferDesc->sharded_buffer_config() == nullptr);
   LOG_ASSERT(bufferDesc->shape()->size() > 0);
 
   std::vector<std::uint32_t> shape(bufferDesc->shape()->begin(),

--- a/runtime/lib/ttmetal/executor_utils.h
+++ b/runtime/lib/ttmetal/executor_utils.h
@@ -104,31 +104,6 @@ inline std::shared_ptr<tt_metal::Buffer> createBufferFromBufferRef(
     tt_metal::IDevice *device, const target::metal::BufferRef *bufferRef,
     const DeviceAddressValidator &deviceAddressValidator) {
   const target::metal::BufferDesc *bufferDesc = bufferRef->desc();
-  const target::metal::ShardedBufferConfig *shardedBufferConfig =
-      bufferDesc->sharded_buffer_config();
-  const target::metal::ShardSpecBuffer *shardSpecBuffer =
-      shardedBufferConfig->shard_spec_buffer();
-  const target::metal::ShardSpec *shardSpec = shardSpecBuffer->shard_spec();
-
-  CoreRangeSet coreRangeSet =
-      common::toCoreRangeSet(shardSpec->core_range_set());
-  std::array<uint32_t, 2> shardShape = {
-      static_cast<uint32_t>(shardSpec->shard_shape()->y()),
-      static_cast<uint32_t>(shardSpec->shard_shape()->x()),
-  };
-  tt_metal::ShardSpec metalShardSpec(coreRangeSet, shardShape);
-
-  std::array<uint32_t, 2> pageShape = {
-      static_cast<uint32_t>(shardSpecBuffer->page_shape()->y()),
-      static_cast<uint32_t>(shardSpecBuffer->page_shape()->x()),
-  };
-  std::array<uint32_t, 2> tensorShapeInPages = {
-      static_cast<uint32_t>(shardSpecBuffer->tensor_shape_in_pages()->y()),
-      static_cast<uint32_t>(shardSpecBuffer->tensor_shape_in_pages()->x()),
-  };
-  tt_metal::ShardSpecBuffer metalShardSpecBuffer(metalShardSpec, pageShape,
-                                                 tensorShapeInPages);
-
   LOG_ASSERT(bufferDesc->memory_space() == target::MemorySpace::DeviceDRAM ||
              bufferDesc->memory_space() == target::MemorySpace::DeviceL1);
   tt_metal::BufferType bufferType =
@@ -136,23 +111,67 @@ inline std::shared_ptr<tt_metal::Buffer> createBufferFromBufferRef(
           ? tt_metal::BufferType::DRAM
           : tt_metal::BufferType::L1;
 
-  auto metalShardedBufferConfig = tt_metal::ShardedBufferConfig{
-      .device = device,
-      .size = shardedBufferConfig->size(),
-      .page_size = shardedBufferConfig->page_size(),
-      .buffer_type = bufferType,
-      .buffer_layout = tt_metal::TensorMemoryLayout::BLOCK_SHARDED,
-      .shard_parameters = metalShardSpecBuffer,
-  };
+  if (bufferDesc->buffer_config_as_ShardedBufferConfig()) {
+    const target::metal::ShardedBufferConfig *shardedBufferConfig =
+        bufferDesc->buffer_config_as_ShardedBufferConfig();
+    const target::metal::ShardSpecBuffer *shardSpecBuffer =
+        shardedBufferConfig->shard_spec_buffer();
+    const target::metal::ShardSpec *shardSpec = shardSpecBuffer->shard_spec();
 
-  LOG_TRACE(logger::LogRuntimeTTMetalBufferCreation, "Creating ",
-            logger::Buffer(bufferRef->global_id()), ": ", *bufferRef);
-  uint32_t address = deviceAddressValidator(bufferRef->address(),
-                                            bufferRef->desc()->memory_space());
-  std::shared_ptr<tt_metal::Buffer> buffer =
-      tt_metal::CreateBuffer(metalShardedBufferConfig, address);
+    CoreRangeSet coreRangeSet =
+        common::toCoreRangeSet(shardSpec->core_range_set());
+    std::array<uint32_t, 2> shardShape = {
+        static_cast<uint32_t>(shardSpec->shard_shape()->y()),
+        static_cast<uint32_t>(shardSpec->shard_shape()->x()),
+    };
+    tt_metal::ShardSpec metalShardSpec(coreRangeSet, shardShape);
 
-  return buffer;
+    std::array<uint32_t, 2> pageShape = {
+        static_cast<uint32_t>(shardSpecBuffer->page_shape()->y()),
+        static_cast<uint32_t>(shardSpecBuffer->page_shape()->x()),
+    };
+    std::array<uint32_t, 2> tensorShapeInPages = {
+        static_cast<uint32_t>(shardSpecBuffer->tensor_shape_in_pages()->y()),
+        static_cast<uint32_t>(shardSpecBuffer->tensor_shape_in_pages()->x()),
+    };
+    tt_metal::ShardSpecBuffer metalShardSpecBuffer(metalShardSpec, pageShape,
+                                                   tensorShapeInPages);
+
+    auto metalShardedBufferConfig = tt_metal::ShardedBufferConfig{
+        .device = device,
+        .size = shardedBufferConfig->size(),
+        .page_size = shardedBufferConfig->page_size(),
+        .buffer_type = bufferType,
+        .buffer_layout = tt_metal::TensorMemoryLayout::BLOCK_SHARDED,
+        .shard_parameters = metalShardSpecBuffer,
+    };
+
+    LOG_TRACE(logger::LogRuntimeTTMetalBufferCreation, "Creating ",
+              logger::Buffer(bufferRef->global_id()), ": ", *bufferRef);
+    uint32_t address = deviceAddressValidator(
+        bufferRef->address(), bufferRef->desc()->memory_space());
+    std::shared_ptr<tt_metal::Buffer> buffer =
+        tt_metal::CreateBuffer(metalShardedBufferConfig, address);
+
+    return buffer;
+  } else {
+    const target::metal::InterleavedBufferConfig *interleavedBufferConfig =
+        bufferDesc->buffer_config_as_InterleavedBufferConfig();
+
+    auto metalInterleavedBufferConfig = tt_metal::InterleavedBufferConfig{
+        .device = device,
+        .size = interleavedBufferConfig->size(),
+        .page_size = interleavedBufferConfig->page_size(),
+        .buffer_type = bufferType};
+
+    LOG_TRACE(logger::LogRuntimeTTMetalBufferCreation, "Creating ",
+              logger::Buffer(bufferRef->global_id()), ": ", *bufferRef);
+    uint32_t address = deviceAddressValidator(
+        bufferRef->address(), bufferRef->desc()->memory_space());
+    std::shared_ptr<tt_metal::Buffer> buffer =
+        tt_metal::CreateBuffer(metalInterleavedBufferConfig, address);
+    return buffer;
+  }
 }
 #pragma clang diagnostic pop
 


### PR DESCRIPTION
### Ticket
Workaround for https://github.com/tenstorrent/tt-metal/issues/23788

### Problem description
There is a limit in ttmetal on the size of a DRAM buffer allocated as DRAM sharded. This blocks partner development until that assertion is lifted/relaxed. 

The TTMetal TTRT backend does not currently support DRAM interleaved buffers and all DRAM buffers are assumed to be sharded. ttmetal uses has different overloads of `CreateBuffer` for interleaved vs sharded buffers.

### What's changed
- D2M `memref`s are assumed to be DRAM interleaved if: 
  - the memory space is set to DRAM, and
  - there is no `ShardLayoutAttr` (tt/ttcore.shard in the IR)
- For each DRAM interleaved buffer, create and serialize an `InterleavedBufferConfig` instead of a `ShardedBufferConfig` in `TTMetalToFlatbuffer`
- Modified the TTMetal flatbuffer schema to allow exactly one of `ShardedBufferConfig` or `InterleavedBufferConfig` for each serialized buffer
-  Modified the TTMetal TTRT backend to check the type of buffer config in each buffer and call the correct `CreateBuffer` host API in metal based on the type.


### Testing
1. Build ttmlir and ttrt with this branch
  a. I used `cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang-17 -DCMAKE_CXX_COMPILER=clang++-17 -DTTMLIR_ENABLE_RUNTIME=ON -DTT_RUNTIME_ENABLE_PERF_TRACE=ON -DTT_RUNTIME_DEBUG=ON`
2. Download this TTMetal IR file: [test-fixed.mlir.txt](https://github.com/user-attachments/files/21066261/test-fixed.mlir.txt)
  a. This program writes arg0 (4096x4096, FP32) to a DRAM interleaved buffer on the device buffer and reads it back
3. Replace the system descriptor in the IR with one appropriate for the test system.
  a. This can be done by running `ttmlir-opt` on any input `ttir` and replacing the `#system_desc` line. Alternatively, the main function can be pasted into a TTMetal IR file that already has the correct system descriptor
4. Run `ttmlir-translate --ttmetal-to-flatbuffer path/to/file -o test.ttm`
5. Run `TTRT_LOGGER_LEVEL=DEBUG ttrt run --init arange --blocking-cq test.ttm`
  a. Observe that the input tensor and output tensor match

**This code is not intended to be merged**
