### PR TITLE
Add blackhole workarounds, untilize on host for blackhole

### DIFF
--- a/runtime/include/tt/runtime/detail/ttnn/operations/utils.h
+++ b/runtime/include/tt/runtime/detail/ttnn/operations/utils.h
@@ -60,9 +60,6 @@ inline ::ttnn::Shape toTTNNShape(const flatbuffers::Vector<T> &vec) {
       [](const T &x) -> uint32_t { return static_cast<uint32_t>(x); });
   return ::ttnn::Shape(rawShape);
 }
-::ttnn::MeshShape
-getMeshShapeFromConfig(const ::tt::tt_metal::DistributedTensorConfig &config,
-                       const std::vector<::ttnn::Tensor> &tensorShards);
 
 } // namespace tt::runtime::ttnn::operations::utils
 #endif

--- a/runtime/include/tt/runtime/detail/ttnn/utils.h
+++ b/runtime/include/tt/runtime/detail/ttnn/utils.h
@@ -79,6 +79,10 @@ createMemoryConfigIfNeeded(const ::tt::target::ttnn::MemoryConfig *memcfg);
 
 ::ttnn::Tensor &getTTNNTensorFromRuntimeTensor(::tt::runtime::Tensor tensor);
 
+::ttnn::MeshShape
+getMeshShapeFromConfig(const ::tt::tt_metal::DistributedTensorConfig &config,
+                       const std::vector<::ttnn::Tensor> &tensorShards);
+
 void *getRawHostDataPtr(const ::ttnn::Tensor &tensor);
 
 ::ttnn::TensorSpec createTensorSpec(

--- a/runtime/include/tt/runtime/workarounds.h
+++ b/runtime/include/tt/runtime/workarounds.h
@@ -12,7 +12,8 @@ namespace tt::runtime::workaround {
 struct Env {
   static const Env &get(bool swapBinaryOperands = true,
                         bool readUpdateIndexFromDeviceForKVCache = true,
-                        bool traceImplicitFromDevice = true);
+                        bool traceImplicitFromDevice = true,
+                        bool blackholeWorkarounds = true);
 
   // TODO(bug #1124): We're currently swapping the operands for binary ops
   // in runtime if the lhs operand is smaller (and requires broadcast onto the
@@ -32,14 +33,21 @@ struct Env {
   // memcpy or when we model this behaviour in the compiler.
   bool traceImplicitFromDevice;
 
+  // TODO(bug #3423): When link is down, get_connected_ethernet_core will throw
+  // an exception.
+  // TODO(bug #4023): untilize on device fails for blackhole. Falling back to
+  // host for now.
+  bool blackholeWorkarounds;
+
 private:
   constexpr Env(bool swapBinaryOperands,
                 bool readUpdateIndexFromDeviceForKVCache,
-                bool traceImplicitFromDevice)
+                bool traceImplicitFromDevice, bool blackholeWorkarounds)
       : swapBinaryOperands(swapBinaryOperands),
         readUpdateIndexFromDeviceForKVCache(
             readUpdateIndexFromDeviceForKVCache),
-        traceImplicitFromDevice(traceImplicitFromDevice) {}
+        traceImplicitFromDevice(traceImplicitFromDevice),
+        blackholeWorkarounds(blackholeWorkarounds) {}
 };
 
 inline std::ostream &operator<<(std::ostream &os, const Env &env) {
@@ -51,6 +59,8 @@ inline std::ostream &operator<<(std::ostream &os, const Env &env) {
      << env.readUpdateIndexFromDeviceForKVCache << "\n";
   os << "\t"
      << "traceImplicitFromDevice: " << env.traceImplicitFromDevice << "\n";
+  os << "\t"
+     << "blackholeWorkarounds: " << env.blackholeWorkarounds << "\n";
   os << "}";
   return os;
 }

--- a/runtime/lib/common/workarounds.cpp
+++ b/runtime/lib/common/workarounds.cpp
@@ -7,10 +7,10 @@
 namespace tt::runtime::workaround {
 const Env &Env::get(bool swapBinaryOperands,
                     bool readUpdateIndexFromDeviceForKVCache,
-                    bool traceImplicitFromDevice) {
+                    bool traceImplicitFromDevice, bool blackholeWorkarounds) {
   static const Env config(swapBinaryOperands,
                           readUpdateIndexFromDeviceForKVCache,
-                          traceImplicitFromDevice);
+                          traceImplicitFromDevice, blackholeWorkarounds);
   return config;
 }
 } // namespace tt::runtime::workaround

--- a/runtime/lib/ttnn/operations/ccl/collective_permute.cpp
+++ b/runtime/lib/ttnn/operations/ccl/collective_permute.cpp
@@ -4,7 +4,6 @@
 
 #include "operations/ccl/collective_permute.h"
 #include "tt/runtime/detail/logger.h"
-#include "tt/runtime/detail/ttnn/operations/utils.h"
 #include "tt/runtime/detail/ttnn/ttnn.h"
 #include "tt/runtime/detail/ttnn/utils.h"
 #include "ttnn/operations/ccl/ccl_host_types.hpp"
@@ -90,7 +89,8 @@ void run(const ::tt::target::ttnn::CollectivePermuteOp *op,
   // multi device host storage.
   const auto &config = input.distributed_tensor_config();
   ::ttnn::MeshShape meshShape =
-      utils::getMeshShapeFromConfig(config, newHostTensors);
+      ::tt::runtime::ttnn::utils::getMeshShapeFromConfig(config,
+                                                         newHostTensors);
 
   ::ttnn::Tensor out =
       ::ttnn::distributed::from_host_shards(newHostTensors, meshShape);

--- a/runtime/lib/ttnn/operations/utils/utils.cpp
+++ b/runtime/lib/ttnn/operations/utils/utils.cpp
@@ -407,31 +407,6 @@ toTTNNTensorImpl(const ::flatbuffers::Vector<uint8_t> *data,
   }
 }
 
-::ttnn::MeshShape
-getMeshShapeFromConfig(const ::tt::tt_metal::DistributedTensorConfig &config,
-                       const std::vector<::ttnn::Tensor> &tensorShards) {
-  // Extract mesh shape based on the active variant type in config
-  // See tt-metal/ttnn/core/tensor/serialization.cpp
-  if (auto *shard2d_strategy =
-          std::get_if<::tt::tt_metal::ShardTensor2D>(&config)) {
-    return ::ttnn::MeshShape(shard2d_strategy->shard_mesh.y,
-                             shard2d_strategy->shard_mesh.x);
-  }
-
-  if (auto *replicate_strategy =
-          std::get_if<::tt::tt_metal::ReplicateTensor>(&config)) {
-    return ::ttnn::MeshShape(replicate_strategy->replication_factor);
-  }
-
-  if (std::get_if<::tt::tt_metal::ShardTensor>(&config)) {
-    // For ShardTensor, use the number of tensor shards as the mesh size
-    return ::ttnn::MeshShape(tensorShards.size());
-  }
-
-  // For AllGatherTensor or any other case, use the number of tensor shards
-  return ::ttnn::MeshShape(tensorShards.size());
-}
-
 ::ttnn::Tensor
 allocateTensorOnDevice(const ::tt::target::ttnn::TensorRef *tensorRef,
                        ::ttnn::MeshDevice &meshDevice) {

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -10,7 +10,6 @@
 #include "tt/runtime/detail/logger.h"
 #include "tt/runtime/detail/ttnn/debug_apis.h"
 #include "tt/runtime/detail/ttnn/layout_converter.h"
-#include "tt/runtime/detail/ttnn/operations/utils.h"
 #include "tt/runtime/detail/ttnn/program_executor.h"
 #include "tt/runtime/detail/ttnn/trace_cache.h"
 #include "tt/runtime/detail/ttnn/ttnn.h"
@@ -136,8 +135,14 @@ toHostSingleTensor(const ::tt::runtime::ttnn::TTNNTensorWrapper &tensorWrapper,
   LOG_ASSERT(meshDevice, "Device tensor must live on a mesh device");
 
   // If untilize is true and the data type can be untilized on device
-  // Untilize on device first before reading back to host
-  if (untilize && utils::canUntilizeDataTypeOnDevice(inputTensor.dtype())) {
+  bool untilizeOnDevice =
+      untilize && utils::canUntilizeDataTypeOnDevice(inputTensor.dtype());
+  // If blackhole workarounds are enabled, only untilize on device if the
+  // architecture is not blackhole
+  if (::tt::runtime::workaround::Env::get().blackholeWorkarounds) {
+    untilizeOnDevice &= getArch() != ::tt::runtime::Arch::BLACKHOLE;
+  }
+  if (untilizeOnDevice) {
     ::ttnn::Tensor hostTensor = ::ttnn::from_device(
         ::ttnn::to_layout(inputTensor, ::ttnn::Layout::ROW_MAJOR, std::nullopt,
                           std::nullopt),
@@ -239,8 +244,8 @@ createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
   DistributedTensorConfig distributionStrategy =
       ::tt::tt_metal::get_distributed_tensor_config(strategy);
 
-  ::ttnn::MeshShape meshShape = operations::utils::getMeshShapeFromConfig(
-      distributionStrategy, ttnnTensorShards);
+  ::ttnn::MeshShape meshShape =
+      utils::getMeshShapeFromConfig(distributionStrategy, ttnnTensorShards);
 
   ::ttnn::Tensor multiDeviceHostTensor =
       ::ttnn::distributed::from_host_shards(ttnnTensorShards, meshShape);

--- a/runtime/tools/ttrt/ttrt/common/run.py
+++ b/runtime/tools/ttrt/ttrt/common/run.py
@@ -184,6 +184,13 @@ class Run:
             help="disable trace from implicitly bouncing tensors off of host",
         )
         Run.register_arg(
+            name="--disable-blackhole-workarounds",
+            type=bool,
+            default=False,
+            choices=[True, False],
+            help="disable blackhole workarounds",
+        )
+        Run.register_arg(
             name="--result-file",
             type=str,
             default="run_results.json",
@@ -516,6 +523,7 @@ class Run:
                 not self["--disable-swap-binary-operands"],
                 not self["--disable-read-update-index-for-kv-cache"],
                 not self["--disable-trace-implicit-from-device"],
+                not self["--disable-blackhole-workarounds"],
             )
             self.logging.debug(f"setting tt runtime workaround env={workaround_env}")
             tracy_program_metadata = {


### PR DESCRIPTION
### Ticket
Related to #4023

### Problem description
Untilize on device fails for various tt-torch models on blackhole

### What's changed
untilize on host for blackhole as a workarounds. Add blackholeWorkarounds flag to track various blackhole workarounds in runtime.

FYI @sshonTT 
