### PR TITLE
Azecevic/ttnn layout fold

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -68,7 +68,7 @@ def TTNN_ToLayoutOp : TTNN_Op<"to_layout",
                          OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
     let results = (outs AnyRankedTensor:$result);
 
-    let hasCanonicalizer = 1;
+    let hasFolder = 1;
 }
 
 def TTNN_TypecastOp : TTNN_Op<"typecast",

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -1422,92 +1422,77 @@ static bool isValidDeviceLayout(TensorMemoryLayoutAttr memLayoutAttr) {
 // ToLayoutOp
 //===----------------------------------------------------------------------===//
 
-// ToLayoutOp canonicalization
-void mlir::tt::ttnn::ToLayoutOp::getCanonicalizationPatterns(
-    mlir::RewritePatternSet &patterns, mlir::MLIRContext *context) {
-  // ToLayoutOp can be folded if its input has the same layout as the output of
-  // toLayoutOp.
-  patterns.add(+[](mlir::tt::ttnn::ToLayoutOp toLayoutOp,
-                   mlir::PatternRewriter &rewriter) {
-    RankedTensorType previousType = toLayoutOp.getInput().getType();
-    TTNNLayoutAttr previousLayout =
-        mlir::dyn_cast<TTNNLayoutAttr>(previousType.getEncoding());
-    // Verify if input tensor has layout attribute.
-    if (!previousLayout) {
-      return mlir::failure();
-    }
+namespace {
+// ToLayoutOp can be folded if its input has the same layout as the output of
+// ToLayoutOp.
+mlir::OpFoldResult foldIdentityToLayoutOp(ttnn::ToLayoutOp op) {
+  mlir::RankedTensorType inputType = op.getInput().getType();
+  ttnn::TTNNLayoutAttr inputLayout =
+      mlir::dyn_cast<TTNNLayoutAttr>(inputType.getEncoding());
+  // Verify if input tensor has layout attribute.
+  if (!inputLayout) {
+    return nullptr;
+  }
 
-    RankedTensorType currentType = toLayoutOp.getType();
-    TTNNLayoutAttr currentLayout =
-        mlir::dyn_cast<TTNNLayoutAttr>(currentType.getEncoding());
-    // Verify if the output tensor has layout attribute.
-    if (!currentLayout) {
-      return mlir::failure();
-    }
+  mlir::RankedTensorType outputType = op.getType();
+  ttnn::TTNNLayoutAttr outputLayout =
+      mlir::dyn_cast<TTNNLayoutAttr>(outputType.getEncoding());
+  // Verify if the output tensor has layout attribute.
+  if (!outputLayout) {
+    return nullptr;
+  }
 
-    // Verify that the layouts are the same.
-    if (previousLayout != currentLayout) {
-      return mlir::failure();
-    }
+  return inputLayout == outputLayout ? op.getInput() : nullptr;
+}
 
-    rewriter.replaceAllUsesWith(toLayoutOp, toLayoutOp->getOperand(0));
-    rewriter.eraseOp(toLayoutOp);
-    return mlir::success();
-  });
+// Two consecutive ToLayoutOps can be merged together in the following way:
+// df - data format, l - layout, ms - memory
+// space, tml - tensor memory layout
+//
+//                |
+//      -----------------------
+//      |     ToLayoutOp      |                     |
+//      | df1, l1, ms1, tml1  |          -----------------------
+//      -----------------------          |     ToLayoutOp      |
+//                |                 -->  | df2, l1, ms2, tml1  |
+//                |                      -----------------------
+//      -----------------------                     |
+//      |     ToLayoutOp      |
+//      |      df2, ms2       |
+//      -----------------------
+//                |
+//
+mlir::OpFoldResult foldConsecutiveToLayoutOp(ttnn::ToLayoutOp op) {
+  // Get the input operand and verify that the previous op is ToLayoutOp.
+  ttnn::ToLayoutOp producerOp = op.getInput().getDefiningOp<ttnn::ToLayoutOp>();
 
-  // Two consecutive ToLayoutOps can be merged if the previous op has only one
-  // use.
-  // df - data format, l - layout, ms - memory
-  // space, tml - tensor memory layout
-  //
-  //                |
-  //      -----------------------
-  //      |     ToLayoutOp      |                     |
-  //      | df1, l1, ms1, tml1  |          -----------------------
-  //      -----------------------          |     ToLayoutOp      |
-  //                |                 -->  | df2, l1, ms2, tml1  |
-  //                |                      -----------------------
-  //      -----------------------                     |
-  //      |     ToLayoutOp      |
-  //      |      df2, ms2       |
-  //      -----------------------
-  //                |
-  //
-  patterns.add(+[](mlir::tt::ttnn::ToLayoutOp toLayoutOp,
-                   mlir::PatternRewriter &rewriter) {
-    // Get the input operand and verify that the previous op is toLayoutOp.
-    ToLayoutOp previousToLayoutOp =
-        toLayoutOp.getInput().getDefiningOp<ToLayoutOp>();
+  if (!producerOp) {
+    return nullptr;
+  }
 
-    // NOLINTNEXTLINE
-    if (!previousToLayoutOp) {
-      return mlir::failure();
-    }
+  if (!op.getDtype()) {
+    op.setDtypeAttr(producerOp.getDtypeAttr());
+  }
+  if (!op.getMemoryConfig()) {
+    op.setMemoryConfigAttr(producerOp.getMemoryConfigAttr());
+  }
+  op.getInputMutable().set(producerOp.getInput());
 
-    // Check if the previous op has only one use. We can only merge if the
-    // previous op has single use.
-    if (!previousToLayoutOp->hasOneUse()) {
-      return mlir::failure();
-    }
+  return op.getResult();
+}
+} // namespace
 
-    // Replace the previous op with the merged ToLayoutOp.
-    Value mergedToLayout = rewriter.replaceOpWithNewOp<ToLayoutOp>(
-        previousToLayoutOp, toLayoutOp.getType(), previousToLayoutOp.getInput(),
-        toLayoutOp.getLayoutAttr(),
-        toLayoutOp.getDtypeAttr() ? toLayoutOp.getDtypeAttr()
-                                  : previousToLayoutOp.getDtypeAttr(),
-        toLayoutOp.getMemoryConfigAttr()
-            ? toLayoutOp.getMemoryConfigAttr()
-            : previousToLayoutOp.getMemoryConfigAttr());
+// ToLayoutOp folder
+mlir::OpFoldResult ttnn::ToLayoutOp::fold(FoldAdaptor adaptor) {
+  if (auto foldResult = foldIdentityToLayoutOp(*this)) {
+    return foldResult;
+  }
 
-    // Replace all uses of the current op with the merged ToLayoutOp.
-    rewriter.replaceAllUsesWith(toLayoutOp, mergedToLayout);
+  if (auto foldResult = foldConsecutiveToLayoutOp(*this)) {
+    return foldResult;
+  }
 
-    // Erase the current op.
-    rewriter.eraseOp(toLayoutOp);
-
-    return mlir::success();
-  });
+  return nullptr;
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/arange_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/arange_workaround.mlir
@@ -15,7 +15,6 @@ module {
       // CHECK-SAME: -> tensor<1024xsi32, #[[TTNN_LAYOUT_ARANGE_OUTPUT]]>
       // Verify that after arange op, there is a to layout op to convert the layout to tile.
       // CHECK-NEXT: %[[TO_LAYOUT_OP:.*]] = "ttnn.to_layout"(%[[ARANGE_OP]])
-      // CHECK-SAME: dtype = #ttcore.supportedDataTypes<si32>
       // CHECK-SAME: layout = #ttnn.layout<tile>
       // CHECK-SAME: memory_config = #ttnn.memory_config<#dram, <interleaved>>
       %2 = "ttnn.reshape"(%1) <{shape = [1 : i32, 1024 : i32, 1 : i32]}> : (tensor<1024xsi32, #ttnn.ttnn_layout<(d0) -> (0, d0), <1x1>, memref<1x32x!ttcore.tile<32x32, si32>, #ttnn.buffer_type<dram>>, <interleaved>>>) -> tensor<1x1024x1xsi32, #ttnn_layout_reshape_1_output>


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/4027

### Problem description
Patterns that folded `ttnn.to_layout` op (identity and two consecutive ops) were canonicalization patterns. This forces any component that might introduce `to_layout` ops to run the canonicalization pass afterwards (currently optimzer does that without running the canonicalization pass afterwards, which might result in some redundant ops). Since both patterns can be fold patterns, moving them to `fold` allows us to utilize them during greedy pattern rewriter execution.

### What's changed
- Moved those two patterns into `fold` method.
- Pattern that folds two consecutive `to_layout` ops is simplified a bit. Even when producer has more than one user it can still be folded with the configuration of the second and the input of the first.
- 
### Checklist
- [x] New/Existing tests provide coverage for changes
