### PR TITLE
Uplift third_party/tt-metal to cf17101cb79329ee9369b2ab3075ef8a22c00008 2025-07-08

### DIFF
--- a/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
+++ b/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
@@ -1022,11 +1022,6 @@ struct EmitCTypeConverter<::ttnn::operations::conv::conv2d::Conv2dConfig> {
 
     bool firstElement = true;
     rso << TypeNameV<::ttnn::operations::conv::conv2d::Conv2dConfig> << "{";
-    if (attr.getDtype()) {
-      rso << (firstElement ? "" : ", ") << ".dtype = "
-          << EmitCTypeConverter<::ttnn::DataType>::convert(*attr.getDtype());
-      firstElement = false;
-    }
     if (attr.getWeightsDtype()) {
       rso << (firstElement ? "" : ", ") << ".weights_dtype = "
           << EmitCTypeConverter<::ttnn::DataType>::convert(
@@ -1494,31 +1489,6 @@ public:
                                              deviceAttr.getWorkerGrid()));
 
     return emit(memoryConfigAttr);
-  }
-
-  // TODO (azecevic): This is a temporary solution for handling the case when
-  // the value of the Conv2dConfigAttr is nullptr. This should be removed once
-  // https://github.com/tenstorrent/tt-mlir/issues/2852 lands.
-  mlir::Attribute getConv2dConfig(mlir::Value input, mlir::Value weight) {
-    auto inputType = mlir::cast<RankedTensorType>(input.getType());
-    auto weightType = mlir::cast<RankedTensorType>(weight.getType());
-
-    auto inputLayoutAttr =
-        mlir::cast<ttnn::TTNNLayoutAttr>(inputType.getEncoding());
-    auto weightLayoutAttr =
-        mlir::cast<ttnn::TTNNLayoutAttr>(weightType.getEncoding());
-
-    ttcore::DataType inputDataType = inputLayoutAttr.getDataType();
-    ttcore::DataType weightDataType = weightLayoutAttr.getDataType();
-
-    std::string buf;
-    llvm::raw_string_ostream rso(buf);
-    rso << TypeNameV<::ttnn::operations::conv::conv2d::Conv2dConfig> << "{";
-    rso << ".dtype = " << convert(inputDataType) << ", ";
-    rso << ".weights_dtype = " << convert(weightDataType);
-    rso << "}";
-
-    return rewriter.getType<emitc::OpaqueAttr>(buf);
   }
 
 private:

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1254,7 +1254,7 @@ def TTNN_MatmulOp : TTNN_Op<"matmul",
 }
 // ANCHOR_END: adding_an_op_matmul_ttnn
 
-def TTNN_PrepareConv2dWeightsOp : TTNN_Op<"prepare_conv2d_weights"> {
+def TTNN_PrepareConv2dWeightsOp : TTNN_Op<"prepare_conv2d_weights", [HasOutputDTypeTrait]> {
     let summary = "Prepares conv2d weights so that they can be consumed by the conv2d op.";
 
     let arguments = (ins AnyRankedTensor:$weight_tensor,
@@ -1273,6 +1273,8 @@ def TTNN_PrepareConv2dWeightsOp : TTNN_Op<"prepare_conv2d_weights"> {
                          BoolAttr:$has_bias,
                          I32Attr:$groups,
                          TTNN_Device:$device,
+                         TTCore_DataTypeAttr:$input_dtype,
+                         OptionalAttr<TTCore_DataTypeAttr>:$output_dtype,
                          OptionalAttr<TTNN_Conv2dConfigAttr>:$conv2d_config);
 
     let results = (outs AnyRankedTensor:$result);
@@ -1281,7 +1283,7 @@ def TTNN_PrepareConv2dWeightsOp : TTNN_Op<"prepare_conv2d_weights"> {
 }
 
 def TTNN_Conv2dOp : TTNN_Op<"conv2d",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>, HasOutputDTypeTrait]
       > {
     let summary = "Conv2d operation.";
     let description = [{
@@ -1354,6 +1356,7 @@ def TTNN_Conv2dOp : TTNN_Op<"conv2d",
                          DenseI32ArrayAttr:$padding,
                          DenseI32ArrayAttr:$dilation,
                          I32Attr:$groups,
+                         OptionalAttr<TTCore_DataTypeAttr>:$output_dtype,
                          OptionalAttr<TTNN_Conv2dConfigAttr>:$conv2d_config,
                          OptionalAttr<TTNN_DeviceComputeKernelConfig>:$compute_config);
 
@@ -1374,7 +1377,7 @@ def TTNN_Conv2dOp : TTNN_Op<"conv2d",
 }
 
 def TTNN_ConvTranspose2dOp : TTNN_Op<"conv_transpose2d",
-      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>, HasOutputDTypeTrait]
       > {
     let summary = "ConvTranspose2d operation.";
     let description = [{
@@ -1448,6 +1451,7 @@ def TTNN_ConvTranspose2dOp : TTNN_Op<"conv_transpose2d",
                          DenseI32ArrayAttr:$output_padding,
                          DenseI32ArrayAttr:$dilation,
                          I32Attr:$groups,
+                         OptionalAttr<TTCore_DataTypeAttr>:$output_dtype,
                          OptionalAttr<TTNN_Conv2dConfigAttr>:$conv2d_config,
                          OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNTraits.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNTraits.h
@@ -108,7 +108,7 @@ public:
     RankedTensorType output =
         mlir::cast<RankedTensorType>(op->getResult(0).getType());
     TTNNLayoutAttr outputLayoutAttr =
-        mlir::dyn_cast<TTNNLayoutAttr>(output.getEncoding());
+        mlir::dyn_cast_or_null<TTNNLayoutAttr>(output.getEncoding());
 
     // If output layout isn't present, skip the verification.
     if (!outputLayoutAttr) {

--- a/include/ttmlir/Target/TTNN/operations/conv.fbs
+++ b/include/ttmlir/Target/TTNN/operations/conv.fbs
@@ -42,6 +42,8 @@ table PrepareConv2dWeightsOp {
   has_bias: bool;
   groups: uint32;
   device: tt.target.DeviceRef;
+  input_dtype: tt.target.DataType;
+  output_dtype: tt.target.DataType = null;
   conv2d_config: tt.target.ttnn.Conv2dConfig;
 }
 
@@ -61,6 +63,7 @@ table Conv2dOp {
   padding: [int32];
   dilation: [int32];
   groups: uint32;
+  output_dtype: tt.target.DataType = null;
   conv2d_config: tt.target.ttnn.Conv2dConfig;
   compute_config: tt.target.ttnn.DeviceComputeKernelConfig;
 }
@@ -82,6 +85,7 @@ table ConvTranspose2dOp {
   output_padding: [int32];
   dilation: [int32];
   groups: uint32;
+  output_dtype: tt.target.DataType = null;
   conv2d_config: tt.target.ttnn.Conv2dConfig;
   memory_config: tt.target.ttnn.MemoryConfig;
 }

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -994,12 +994,18 @@ public:
 
     auto groupsAttr = rewriter.getI32IntegerAttr(adaptor.getGroups());
 
+    auto outputLayoutAttr =
+        mlir::cast<ttnn::TTNNLayoutAttr>(op.getType().getEncoding());
+    auto outputDtypeAttr =
+        rewriter.getAttr<ttcore::DataTypeAttr>(outputLayoutAttr.getDataType());
+
     rewriter.replaceOpWithNewOp<ttnn::Conv2dOp>(
         op, getTypeConverter()->convertType(op.getResult().getType()),
         adaptor.getInput(), adaptor.getWeight(), adaptor.getBias(), device,
         inChannelsAttr, outChannelsAttr, batchSizeAttr, inputHeightAttr,
         inputWidthAttr, kernelSizeAttr, *strideAttr, paddingAttr, *dilationAttr,
-        groupsAttr, /*conv2d_config=*/nullptr, /*compute_config=*/nullptr);
+        groupsAttr, outputDtypeAttr, /*conv2d_config=*/nullptr,
+        /*compute_config=*/nullptr);
 
     return success();
   }
@@ -1092,6 +1098,11 @@ public:
 
     auto groupsAttr = rewriter.getI32IntegerAttr(adaptor.getGroups());
 
+    auto outputLayoutAttr =
+        mlir::cast<ttnn::TTNNLayoutAttr>(op.getType().getEncoding());
+    auto outputDtypeAttr =
+        rewriter.getAttr<ttcore::DataTypeAttr>(outputLayoutAttr.getDataType());
+
     // Transposed convolution in ttnn returns a tensor in a flattened shape
     // (1 x 1 x N * H * W x C).
     llvm::ArrayRef<std::int64_t> output_shape = outputTy.getShape();
@@ -1106,7 +1117,8 @@ public:
         adaptor.getBias(), device, inChannelsAttr, outChannelsAttr,
         batchSizeAttr, inputHeightAttr, inputWidthAttr, kernelSizeAttr,
         *strideAttr, reducedPaddingAttr, *outputPaddingAttr, *dilationAttr,
-        groupsAttr, /*conv2d_config=*/nullptr, /*memoryConfig=*/nullptr);
+        groupsAttr, outputDtypeAttr, /*conv2d_config=*/nullptr,
+        /*memoryConfig=*/nullptr);
 
     // Restore the normal shape (N x H x W x C).
     Value output =

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -988,6 +988,8 @@ public:
         emitter.emit(srcOp.getHasBias()),
         emitter.emit(srcOp.getGroups()),
         emitter.emit(srcOp.getDevice()),
+        emitter.emit(srcOp.getInputDtype()),
+        emitter.emit(srcOp.getOutputDtype()),
         emitter.emit<
             std::optional<::ttnn::operations::conv::conv2d::Conv2dConfig>>(
             srcOp.getConv2dConfig()),
@@ -1036,11 +1038,11 @@ public:
             srcOp.getPaddingAttr()),
         emitter.emit<std::array<uint32_t, 2>>(srcOp.getDilationAttr()),
         emitter.emit(srcOp.getGroups()),
+        emitter.emit(srcOp.getOutputDtype()),
         emitter.emit(srcOp.getBias()),
         emitter.emit<
             std::optional<::ttnn::operations::conv::conv2d::Conv2dConfig>>(
-            srcOp.getConv2dConfig()) |
-            emitter.getConv2dConfig(srcOp.getInput(), srcOp.getWeight()),
+            srcOp.getConv2dConfig()),
         /*compute_config=*/emitter.emit(std::nullopt),
         emitter.emit(std::nullopt) | emitter.getMemoryConfig(srcOp.getResult()),
     };
@@ -1086,11 +1088,11 @@ public:
         emitter.emit<std::array<uint32_t, 2>>(srcOp.getOutputPaddingAttr()),
         emitter.emit<std::array<uint32_t, 2>>(srcOp.getDilationAttr()),
         emitter.emit(srcOp.getGroups()),
+        emitter.emit(srcOp.getOutputDtype()),
         emitter.emit(srcOp.getBias()),
         emitter.emit<
             std::optional<::ttnn::operations::conv::conv2d::Conv2dConfig>>(
-            srcOp.getConv2dConfig()) |
-            emitter.getConv2dConfig(srcOp.getInput(), srcOp.getWeight()),
+            srcOp.getConv2dConfig()),
         /*compute_config=*/emitter.emit(std::nullopt),
         emitter.emit(std::nullopt) | emitter.getMemoryConfig(srcOp.getResult()),
     };

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -831,7 +831,6 @@ public:
         /*output=*/emitter.emit(std::nullopt),
         emitter.emit(srcOp.getMemoryConfig()) |
             emitter.getMemoryConfig(srcOp.getResult()),
-        /*compute_kernel_config=*/emitter.emit(std::nullopt),
     };
 
     emitter.replaceOp(*this, args);

--- a/lib/Dialect/TTNN/Transforms/TTNNPrepareConv2dWeights.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNPrepareConv2dWeights.cpp
@@ -43,6 +43,13 @@ public:
               rewriter.getAttr<ttnn::BufferTypeAttr>(
                   inputLayoutAttr.getBufferType()),
               utils::createShardSpecIfNeeded(inputLayoutAttr, deviceGrid));
+      auto inputDtypeAttr = mlir::tt::ttcore::DataTypeAttr::get(
+          &getContext(), inputLayoutAttr.getDataType());
+
+      auto outputLayoutAttr =
+          mlir::cast<ttnn::TTNNLayoutAttr>(conv2dOp.getType().getEncoding());
+      auto outputDtypeAttr = rewriter.getAttr<ttcore::DataTypeAttr>(
+          outputLayoutAttr.getDataType());
 
       rewriter.setInsertionPoint(conv2dOp);
       ttnn::PrepareConv2dWeightsOp prepareConv2dWeightsOp =
@@ -58,8 +65,8 @@ public:
               conv2dOp.getKernelSizeAttr(), conv2dOp.getStrideAttr(),
               conv2dOp.getPaddingAttr(), conv2dOp.getDilationAttr(),
               rewriter.getBoolAttr(conv2dOp.getBias() != nullptr),
-              conv2dOp.getGroupsAttr(), conv2dOp.getDevice(),
-              conv2dOp.getConv2dConfigAttr());
+              conv2dOp.getGroupsAttr(), conv2dOp.getDevice(), inputDtypeAttr,
+              outputDtypeAttr, conv2dOp.getConv2dConfigAttr());
 
       // Update only the weight operand since PrepareConv2dWeightsOp will change
       // the shape and layout of the weight

--- a/lib/OpModel/TTNN/Conversion.cpp
+++ b/lib/OpModel/TTNN/Conversion.cpp
@@ -277,10 +277,6 @@ std::optional<::ttnn::operations::conv::conv2d::Conv2dConfig> getConv2dConfig(
 
   ::ttnn::operations::conv::conv2d::Conv2dConfig config;
 
-  if (conv2dConfig->getDtype()) {
-    config.dtype = getDataType(*conv2dConfig->getDtype());
-  }
-
   if (conv2dConfig->getWeightsDtype()) {
     config.weights_dtype = getDataType(*conv2dConfig->getWeightsDtype());
   }

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -318,7 +318,6 @@ getPrepareConv2dWeightsOpOutputTensorSpec(
     localConfig = ::ttnn::operations::conv::conv2d::Conv2dConfig();
     // TODO(#2441): Need to match tensor dtypes with conv2d config.
     // This will be fixed on IR side shortly.
-    localConfig.dtype = inputSpec.data_type();
     localConfig.weights_dtype = weightTensor.dtype();
   } else {
     localConfig = *conv2dConfigConverted;
@@ -337,7 +336,8 @@ getPrepareConv2dWeightsOpOutputTensorSpec(
         conversion::convertLLVMArrayRefToMultiSizeStdArray<uint32_t, 2, 4>(
             padding),
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(dilation),
-        hasBias, groups, device, localConfig,
+        hasBias, groups, device, /*input_dtype=*/weightTensor.dtype(),
+        /*output_dtype=*/weightTensor.dtype(), localConfig,
         /* compute_config_ */ std::nullopt,
         /* dram_slice_config_ */ std::nullopt);
   };
@@ -354,7 +354,8 @@ getPrepareConv2dWeightsOpOutputTensorSpec(
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(stride),
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(padding),
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(dilation),
-        hasBias, groups, device, localConfig,
+        hasBias, groups, device, /*input_dtype=*/weightTensor.dtype(),
+        /*output_dtype=*/weightTensor.dtype(), localConfig,
         /* compute_config_ */ std::nullopt,
         /* mirror_kernel */ true);
   };
@@ -1666,7 +1667,6 @@ llvm::Expected<OpConstraints> Conv2dOpInterface::getOpConstraints(
       localConfig = ::ttnn::operations::conv::conv2d::Conv2dConfig();
       // TODO(#2441): Need to match tensor dtypes with conv2d config.
       // This will be fixed on IR side shortly.
-      localConfig.dtype = inputSpec.data_type();
       localConfig.weights_dtype = weightSpec.data_type();
     } else {
       localConfig = *conv2dConfigConverted;
@@ -1680,8 +1680,8 @@ llvm::Expected<OpConstraints> Conv2dOpInterface::getOpConstraints(
         conversion::convertLLVMArrayRefToMultiSizeStdArray<uint32_t, 2, 4>(
             padding),
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(dilation),
-        groups, biasTensor, localConfig, std::nullopt,
-        detail::getNullableMemoryConfig(outputLayout));
+        groups, /*dtype=*/inputSpec.data_type(), biasTensor, localConfig,
+        std::nullopt, detail::getNullableMemoryConfig(outputLayout));
   };
 
   return operation::getOpConstraints(
@@ -1747,7 +1747,6 @@ llvm::Expected<size_t> Conv2dOpInterface::getOpRuntime(
       localConfig = ::ttnn::operations::conv::conv2d::Conv2dConfig();
       // TODO(#2441): Need to match tensor dtypes with conv2d config.
       // This will be fixed on IR side shortly.
-      localConfig.dtype = inputSpec.data_type();
       localConfig.weights_dtype = weightSpec.data_type();
     } else {
       localConfig = *conv2dConfigConverted;
@@ -1761,8 +1760,8 @@ llvm::Expected<size_t> Conv2dOpInterface::getOpRuntime(
         conversion::convertLLVMArrayRefToMultiSizeStdArray<uint32_t, 2, 4>(
             padding),
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(dilation),
-        groups, biasTensor, localConfig, std::nullopt,
-        detail::getNullableMemoryConfig(outputLayout));
+        groups, /*dtype=*/inputSpec.data_type(), biasTensor, localConfig,
+        std::nullopt, detail::getNullableMemoryConfig(outputLayout));
   };
 
   return operation::getOpRuntime("Conv2dOpInterface", conv2dOpQuery);
@@ -1831,7 +1830,6 @@ llvm::Expected<OpConstraints> ConvTranspose2dOpInterface::getOpConstraints(
       localConfig = ::ttnn::operations::conv::conv2d::Conv2dConfig();
       // TODO(#2441): Need to match tensor dtypes with conv2d config.
       // This will be fixed on IR side shortly.
-      localConfig.dtype = inputSpec.data_type();
       localConfig.weights_dtype = weightSpec.data_type();
     } else {
       localConfig = *conv2dConfigConverted;
@@ -1845,7 +1843,8 @@ llvm::Expected<OpConstraints> ConvTranspose2dOpInterface::getOpConstraints(
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(padding),
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(output_padding),
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(dilation),
-        groups, biasTensor, localConfig, /* compute_config */ std::nullopt,
+        groups, /*dtype=*/inputSpec.data_type(), biasTensor, localConfig,
+        /* compute_config */ std::nullopt,
         detail::getNullableMemoryConfig(outputLayout));
   };
 
@@ -1913,7 +1912,6 @@ llvm::Expected<size_t> ConvTranspose2dOpInterface::getOpRuntime(
       localConfig = ::ttnn::operations::conv::conv2d::Conv2dConfig();
       // TODO(#2441): Need to match tensor dtypes with conv2d config.
       // This will be fixed on IR side shortly.
-      localConfig.dtype = inputSpec.data_type();
       localConfig.weights_dtype = weightSpec.data_type();
     } else {
       localConfig = *conv2dConfigConverted;
@@ -1927,7 +1925,8 @@ llvm::Expected<size_t> ConvTranspose2dOpInterface::getOpRuntime(
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(padding),
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(output_padding),
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(dilation),
-        groups, biasTensor, localConfig, /* compute_config */ std::nullopt,
+        groups, /*dtype=*/inputSpec.data_type(), biasTensor, localConfig,
+        /* compute_config */ std::nullopt,
         detail::getNullableMemoryConfig(outputLayout));
   };
 

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -569,6 +569,15 @@ createOp(FlatbufferObjectCache &cache, PrepareConv2dWeightsOp op) {
       toFlatbuffer(cache, op.getDilation());
   auto device = getOperandThroughDPSOps(op.getDevice());
 
+  ::tt::target::DataType inputDtype =
+      ::mlir::tt::ttnn::utils::toTargetDataType(op.getInputDtype());
+
+  ::flatbuffers::Optional<::tt::target::DataType> outputDtype;
+  if (op.getOutputDtype()) {
+    outputDtype =
+        ::mlir::tt::ttnn::utils::toTargetDataType(*op.getOutputDtype());
+  }
+
   std::optional<::flatbuffers::Offset<::tt::target::ttnn::Conv2dConfig>>
       conv2dConfig = toFlatbuffer(cache, op.getConv2dConfig());
 
@@ -577,7 +586,8 @@ createOp(FlatbufferObjectCache &cache, PrepareConv2dWeightsOp op) {
       weightsFormat, op.getInChannels(), op.getOutChannels(), op.getBatchSize(),
       op.getInputHeight(), op.getInputWidth(), kernelSize, stride, padding,
       dilation, op.getHasBias(), op.getGroups(),
-      cache.at<::tt::target::DeviceRef>(device), conv2dConfig.value_or(0));
+      cache.at<::tt::target::DeviceRef>(device), inputDtype, outputDtype,
+      conv2dConfig.value_or(0));
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::Conv2dOp>
@@ -604,6 +614,12 @@ createOp(FlatbufferObjectCache &cache, Conv2dOp op) {
   ::flatbuffers::Offset<::flatbuffers::Vector<int32_t>> dilation =
       toFlatbuffer(cache, op.getDilation());
 
+  ::flatbuffers::Optional<::tt::target::DataType> outputDtype;
+  if (op.getOutputDtype()) {
+    outputDtype =
+        ::mlir::tt::ttnn::utils::toTargetDataType(*op.getOutputDtype());
+  }
+
   std::optional<::flatbuffers::Offset<::tt::target::ttnn::Conv2dConfig>>
       conv2dConfig = toFlatbuffer(cache, op.getConv2dConfig());
 
@@ -616,7 +632,7 @@ createOp(FlatbufferObjectCache &cache, Conv2dOp op) {
       cache.at<::tt::target::DeviceRef>(device), op.getInChannels(),
       op.getOutChannels(), op.getBatchSize(), op.getInputHeight(),
       op.getInputWidth(), kernelSize, stride, padding, dilation, op.getGroups(),
-      conv2dConfig.value_or(0), computeConfig.value_or(0));
+      outputDtype, conv2dConfig.value_or(0), computeConfig.value_or(0));
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::ConvTranspose2dOp>
@@ -645,6 +661,12 @@ createOp(FlatbufferObjectCache &cache, ConvTranspose2dOp op) {
   ::flatbuffers::Offset<::flatbuffers::Vector<int32_t>> dilation =
       toFlatbuffer(cache, op.getDilation());
 
+  ::flatbuffers::Optional<::tt::target::DataType> outputDtype;
+  if (op.getOutputDtype()) {
+    outputDtype =
+        ::mlir::tt::ttnn::utils::toTargetDataType(*op.getOutputDtype());
+  }
+
   std::optional<::flatbuffers::Offset<::tt::target::ttnn::Conv2dConfig>>
       conv2dConfig = toFlatbuffer(cache, op.getConv2dConfig());
 
@@ -655,7 +677,7 @@ createOp(FlatbufferObjectCache &cache, ConvTranspose2dOp op) {
       cache.at<::tt::target::DeviceRef>(device), op.getInChannels(),
       op.getOutChannels(), op.getBatchSize(), op.getInputHeight(),
       op.getInputWidth(), kernelSize, stride, padding, outputPadding, dilation,
-      op.getGroups(), conv2dConfig.value_or(0), memoryConfig);
+      op.getGroups(), outputDtype, conv2dConfig.value_or(0), memoryConfig);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::AllGatherOp>

--- a/runtime/include/tt/runtime/detail/ttnn/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn/ttnn.h
@@ -79,13 +79,15 @@ createOwnedHostTensor(const void *data, const std::vector<std::uint32_t> &shape,
     const std::vector<std::uint32_t> &shape,
     const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType,
-    const std::unordered_map<std::string, std::string> &strategy);
+    const std::unordered_map<std::string, std::string> &strategy,
+    const std::vector<uint32_t> &meshShape);
 
 // Creates multi-device host tensor from already existing host tensor shards.
 // Tensor shards can be host tensors with either owned or borrowed storage.
 ::tt::runtime::Tensor createMultiDeviceHostTensor(
     const std::vector<::tt::runtime::Tensor> &tensorShards,
-    const std::unordered_map<std::string, std::string> &strategy);
+    const std::unordered_map<std::string, std::string> &strategy,
+    const std::vector<uint32_t> &meshShape);
 
 ::tt::runtime::Tensor createEmptyTensor(
     Device device, Layout layout, const std::vector<std::uint32_t> &shape,
@@ -105,9 +107,11 @@ inline ::tt::runtime::Tensor createBorrowedHostTensor(void *data,
 
 inline ::tt::runtime::Tensor createMultiDeviceHostTensor(
     const std::vector<const void *> &data, const TensorDesc &desc,
-    const std::unordered_map<std::string, std::string> &strategy) {
+    const std::unordered_map<std::string, std::string> &strategy,
+    const std::vector<uint32_t> &meshShape) {
   return ::tt::runtime::ttnn::createMultiDeviceHostTensor(
-      data, desc.shape, desc.stride, desc.itemsize, desc.dataType, strategy);
+      data, desc.shape, desc.stride, desc.itemsize, desc.dataType, strategy,
+      meshShape);
 }
 
 inline ::tt::runtime::Tensor createEmptyTensor(Device device, Layout layout,

--- a/runtime/include/tt/runtime/detail/ttnn/utils.h
+++ b/runtime/include/tt/runtime/detail/ttnn/utils.h
@@ -79,10 +79,6 @@ createMemoryConfigIfNeeded(const ::tt::target::ttnn::MemoryConfig *memcfg);
 
 ::ttnn::Tensor &getTTNNTensorFromRuntimeTensor(::tt::runtime::Tensor tensor);
 
-::ttnn::MeshShape
-getMeshShapeFromConfig(const ::tt::tt_metal::DistributedTensorConfig &config,
-                       const std::vector<::ttnn::Tensor> &tensorShards);
-
 void *getRawHostDataPtr(const ::ttnn::Tensor &tensor);
 
 ::ttnn::TensorSpec createTensorSpec(

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -76,13 +76,15 @@ Tensor createMultiDeviceHostTensor(
     const std::vector<std::uint32_t> &shape,
     const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType,
-    const std::unordered_map<std::string, std::string> &strategy);
+    const std::unordered_map<std::string, std::string> &strategy,
+    const std::vector<uint32_t> &meshShape);
 
 // Creates multi-device host tensor from already existing host tensor shards.
 // Tensor shards can be host tensors with either owned or borrowed storage.
 Tensor createMultiDeviceHostTensor(
     const std::vector<Tensor> &tensorShards,
-    const std::unordered_map<std::string, std::string> &strategy);
+    const std::unordered_map<std::string, std::string> &strategy,
+    const std::vector<uint32_t> &meshShape);
 
 // Creates empty tensor on host/device depending on the passed layout.
 Tensor createEmptyTensor(Device device, Layout layout,
@@ -102,9 +104,11 @@ inline Tensor createOwnedHostTensor(const void *data, const TensorDesc &desc) {
 
 inline Tensor createMultiDeviceHostTensor(
     const std::vector<const void *> &data, const TensorDesc &desc,
-    const std::unordered_map<std::string, std::string> &strategy) {
+    const std::unordered_map<std::string, std::string> &strategy,
+    const std::vector<uint32_t> &meshShape) {
   return ::tt::runtime::createMultiDeviceHostTensor(
-      data, desc.shape, desc.stride, desc.itemsize, desc.dataType, strategy);
+      data, desc.shape, desc.stride, desc.itemsize, desc.dataType, strategy,
+      meshShape);
 }
 
 inline Tensor createEmptyTensor(Device device, Layout layout,

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -227,7 +227,8 @@ Tensor createMultiDeviceHostTensor(
     const std::vector<std::uint32_t> &shape,
     const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
     ::tt::target::DataType dataType,
-    const std::unordered_map<std::string, std::string> &strategy) {
+    const std::unordered_map<std::string, std::string> &strategy,
+    const std::vector<uint32_t> &meshShape) {
   using RetType = Tensor;
   LOG_ASSERT(!shape.empty());
   LOG_ASSERT(!stride.empty());
@@ -236,7 +237,7 @@ Tensor createMultiDeviceHostTensor(
       RetType,
       [&]() -> RetType {
         return ::tt::runtime::ttnn::createMultiDeviceHostTensor(
-            data, shape, stride, itemsize, dataType, strategy);
+            data, shape, stride, itemsize, dataType, strategy, meshShape);
       },
       [&]() -> RetType {
         detail::fatalNotImplemented(__FUNCTION__, DeviceRuntime::TTMetal);
@@ -245,14 +246,15 @@ Tensor createMultiDeviceHostTensor(
 
 Tensor createMultiDeviceHostTensor(
     const std::vector<Tensor> &tensorShards,
-    const std::unordered_map<std::string, std::string> &strategy) {
+    const std::unordered_map<std::string, std::string> &strategy,
+    const std::vector<uint32_t> &meshShape) {
   using RetType = Tensor;
   LOG_ASSERT(!tensorShards.empty());
   return DISPATCH_TO_CURRENT_RUNTIME(
       RetType,
       [&]() -> RetType {
-        return ::tt::runtime::ttnn::createMultiDeviceHostTensor(tensorShards,
-                                                                strategy);
+        return ::tt::runtime::ttnn::createMultiDeviceHostTensor(
+            tensorShards, strategy, meshShape);
       },
       [&]() -> RetType {
         detail::fatalNotImplemented(__FUNCTION__, DeviceRuntime::TTMetal);

--- a/runtime/lib/ttnn/operations/ccl/collective_permute.cpp
+++ b/runtime/lib/ttnn/operations/ccl/collective_permute.cpp
@@ -87,13 +87,8 @@ void run(const ::tt::target::ttnn::CollectivePermuteOp *op,
 
   // Combine all host tensor shards into a single host tensor with
   // multi device host storage.
-  const auto &config = input.distributed_tensor_config();
-  ::ttnn::MeshShape meshShape =
-      ::tt::runtime::ttnn::utils::getMeshShapeFromConfig(config,
-                                                         newHostTensors);
-
-  ::ttnn::Tensor out =
-      ::ttnn::distributed::from_host_shards(newHostTensors, meshShape);
+  ::ttnn::Tensor out = ::ttnn::distributed::from_host_shards(
+      newHostTensors, meshDevice->shape());
 
   out = ::ttnn::to_device(out, meshDevice, input.memory_config());
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);

--- a/runtime/lib/ttnn/operations/conv/prepare_conv2d_weights.cpp
+++ b/runtime/lib/ttnn/operations/conv/prepare_conv2d_weights.cpp
@@ -60,7 +60,9 @@ void run(const ::tt::target::ttnn::PrepareConv2dWeightsOp *op,
       op->weights_format()->str(), op->in_channels(), op->out_channels(),
       op->batch_size(), op->input_height(), op->input_width(), kernelSize,
       stride, padding, dilation, op->has_bias(), op->groups(), &targetDevice,
-      conv2dConfig, std::nullopt, std::nullopt);
+      /*input_dtype=*/weightTensor.dtype(),
+      /*output_dtype=*/weightTensor.dtype(), conv2dConfig, std::nullopt,
+      std::nullopt);
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }

--- a/runtime/lib/ttnn/operations/moreh/moreh_cumsum.cpp
+++ b/runtime/lib/ttnn/operations/moreh/moreh_cumsum.cpp
@@ -23,8 +23,7 @@ void run(const ::tt::target::ttnn::MorehCumSumOp *op, ProgramContext &context) {
       ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
 
   ::ttnn::Tensor out =
-      ::ttnn::moreh_cumsum(in, op->dim(), std::nullopt, outputMemoryConfig,
-                           /*computeKernelConfig*/ std::nullopt);
+      ::ttnn::moreh_cumsum(in, op->dim(), std::nullopt, outputMemoryConfig);
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }

--- a/runtime/lib/ttnn/operations/utils/utils.cpp
+++ b/runtime/lib/ttnn/operations/utils/utils.cpp
@@ -261,15 +261,8 @@ createMatmulProgramConfigIfNeeded(const ::tt::target::ttnn::MatmulOp *op) {
 createConv2dConfig(const ::tt::target::ttnn::Conv2dConfig *config) {
   ::ttnn::operations::conv::Conv2dConfig conv2dConfig;
 
-  if (config->dtype()) {
-    conv2dConfig.dtype =
-        ::tt::runtime::ttnn::utils::toTTNNDataType(*config->dtype());
-  }
-
-  if (config->weights_dtype()) {
-    conv2dConfig.weights_dtype =
-        ::tt::runtime::ttnn::utils::toTTNNDataType(*config->weights_dtype());
-  }
+  conv2dConfig.weights_dtype =
+      ::tt::runtime::ttnn::utils::toTTNNDataType(*config->weights_dtype());
 
   if (config->activation()) {
     conv2dConfig.activation = config->activation()->str();

--- a/runtime/lib/ttnn/utils/utils.cpp
+++ b/runtime/lib/ttnn/utils/utils.cpp
@@ -336,31 +336,6 @@ createRuntimeTensorFromTTNN(const ::ttnn::Tensor &tensor,
       .getTensor();
 }
 
-::ttnn::MeshShape
-getMeshShapeFromConfig(const ::tt::tt_metal::DistributedTensorConfig &config,
-                       const std::vector<::ttnn::Tensor> &tensorShards) {
-  // Extract mesh shape based on the active variant type in config
-  // See tt-metal/ttnn/core/tensor/serialization.cpp
-  if (auto *shard2d_strategy =
-          std::get_if<::tt::tt_metal::ShardTensor2D>(&config)) {
-    return ::ttnn::MeshShape(shard2d_strategy->shard_mesh.y,
-                             shard2d_strategy->shard_mesh.x);
-  }
-
-  if (auto *replicate_strategy =
-          std::get_if<::tt::tt_metal::ReplicateTensor>(&config)) {
-    return ::ttnn::MeshShape(replicate_strategy->replication_factor);
-  }
-
-  if (std::get_if<::tt::tt_metal::ShardTensor>(&config)) {
-    // For ShardTensor, use the number of tensor shards as the mesh size
-    return ::ttnn::MeshShape(tensorShards.size());
-  }
-
-  // For AllGatherTensor or any other case, use the number of tensor shards
-  return ::ttnn::MeshShape(tensorShards.size());
-}
-
 ::ttnn::TensorSpec createTensorSpec(const ::ttnn::Shape &shape,
                                     const ::ttnn::DataType &dataType,
                                     const ::ttnn::Layout &layout,

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -238,7 +238,8 @@ void registerRuntimeBindings(nb::module_ &m) {
          const std::vector<std::uint32_t> &shape,
          const std::vector<std::uint32_t> &stride, std::uint32_t itemsize,
          ::tt::target::DataType dataType,
-         const std::unordered_map<std::string, std::string> &strategy) {
+         const std::unordered_map<std::string, std::string> &strategy,
+         const std::vector<uint32_t> &meshShape) {
         std::vector<const void *> data;
         data.reserve(ptrs.size());
         std::transform(ptrs.begin(), ptrs.end(), std::back_inserter(data),
@@ -246,7 +247,7 @@ void registerRuntimeBindings(nb::module_ &m) {
                          return reinterpret_cast<const void *>(ptr);
                        });
         return tt::runtime::createMultiDeviceHostTensor(
-            data, shape, stride, itemsize, dataType, strategy);
+            data, shape, stride, itemsize, dataType, strategy, meshShape);
       },
       "Create a multi-device host tensor with owned memory");
   m.def("get_arch", &tt::runtime::getArch,

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/conv2d_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/conv2d_workaround.mlir
@@ -8,7 +8,19 @@ module attributes {} {
     // CHECK: %[[TO_LAYOUT_INPUT:.*]] = "ttnn.to_layout"
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
     // CHECK-SAME: layout = #ttnn.layout<row_major>
-    %2 = "ttnn.conv2d"(%1, %arg1, %arg2, %0) <{batch_size = 1 : i32, dilation = array<i32: 1, 1>, groups = 1 : i32, in_channels = 64 : i32, input_height = 32 : i32, input_width = 32 : i32, kernel_size = array<i32: 3, 3>, out_channels = 64 : i32, padding = array<i32: 0, 0>, stride = array<i32: 1, 1>}> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
+    %2 = "ttnn.conv2d"(%1, %arg1, %arg2, %0)
+          <{
+            batch_size = 1 : i32,
+            dilation = array<i32: 1, 1>,
+            groups = 1 : i32, in_channels = 64 : i32,
+            input_height = 32 : i32,
+            input_width = 32 : i32,
+            kernel_size = array<i32: 3, 3>,
+            out_channels = 64 : i32,
+            padding = array<i32: 0, 0>,
+            stride = array<i32: 1, 1>,
+            output_dtype = #ttcore.supportedDataTypes<bf16>
+          }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
     // CHECK-NEXT: %[[CONV2D_RESULT:.*]] = "ttnn.conv2d"(%[[TO_LAYOUT_INPUT]], %[[CONV2D_WEIGHTS:.*]], %[[CONV2D_BIAS:.*]], %[[DEVICE_OP]])
     %3 = "ttnn.reshape"(%2) <{shape = [1 : i32, 30 : i32, 30 : i32, 64 : i32]}> : (tensor<1x1x900x64xbf16>) -> tensor<1x30x30x64xbf16>
     return %3 : tensor<1x30x30x64xbf16>
@@ -20,7 +32,21 @@ module attributes {} {
     // CHECK: %[[TO_LAYOUT_INPUT:.*]] = "ttnn.to_layout"(%arg0)
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
     // CHECK-SAME: layout = #ttnn.layout<row_major>
-    %1 = "ttnn.conv_transpose2d"(%arg0, %arg1, %arg2, %0) <{batch_size = 1 : i32, dilation = array<i32: 1, 1>, groups = 1 : i32, in_channels = 64 : i32, input_height = 32 : i32, input_width = 32 : i32, kernel_size = array<i32: 3, 3>, out_channels = 64 : i32, padding = array<i32: 0, 0>, stride = array<i32: 1, 1>, output_padding = array<i32: 0, 0>}> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
+    %1 = "ttnn.conv_transpose2d"(%arg0, %arg1, %arg2, %0)
+          <{
+            batch_size = 1 : i32,
+            dilation = array<i32: 1, 1>,
+            groups = 1 : i32,
+            in_channels = 64 : i32,
+            input_height = 32 : i32,
+            input_width = 32 : i32,
+            kernel_size = array<i32: 3, 3>,
+            out_channels = 64 : i32,
+            padding = array<i32: 0, 0>,
+            stride = array<i32: 1, 1>,
+            output_padding = array<i32: 0, 0>,
+            output_dtype = #ttcore.supportedDataTypes<bf16>
+          }> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
     // CHECK-NEXT: %[[CONV2D_RESULT:.*]] = "ttnn.conv_transpose2d"(%[[TO_LAYOUT_INPUT]], %[[CONV2D_WEIGHTS:.*]], %[[CONV2D_BIAS:.*]], %[[DEVICE_OP]])
     %2 = "ttnn.reshape"(%1) <{shape = [1 : i32, 30 : i32, 30 : i32, 64 : i32]}> : (tensor<1x1x900x64xbf16>) -> tensor<1x30x30x64xbf16>
     return %2 : tensor<1x30x30x64xbf16>
@@ -33,7 +59,20 @@ module attributes {} {
     // CHECK: %[[TO_LAYOUT_INPUT:.*]] = "ttnn.to_layout"
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
     // CHECK-SAME: layout = #ttnn.layout<row_major>
-    %2 = "ttnn.conv2d"(%1, %arg1, %0) <{batch_size = 1 : i32, dilation = array<i32: 1, 1>, groups = 1 : i32, in_channels = 64 : i32, input_height = 32 : i32, input_width = 32 : i32, kernel_size = array<i32: 3, 3>, out_channels = 64 : i32, padding = array<i32: 0, 0>, stride = array<i32: 1, 1>}> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
+    %2 = "ttnn.conv2d"(%1, %arg1, %0)
+          <{
+            batch_size = 1 : i32,
+            dilation = array<i32: 1, 1>,
+            groups = 1 : i32,
+            in_channels = 64 : i32,
+            input_height = 32 : i32,
+            input_width = 32 : i32,
+            kernel_size = array<i32: 3, 3>,
+            out_channels = 64 : i32,
+            padding = array<i32: 0, 0>,
+            stride = array<i32: 1, 1>,
+            output_dtype = #ttcore.supportedDataTypes<bf16>
+          }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
     // CHECK-NEXT: %[[CONV2D_RESULT:.*]] = "ttnn.conv2d"(%[[TO_LAYOUT_INPUT]], %[[CONV2D_WEIGHTS:.*]], %[[DEVICE_OP]])
     %3 = "ttnn.reshape"(%2) <{shape = [1 : i32, 30 : i32, 30 : i32, 64 : i32]}> : (tensor<1x1x900x64xbf16>) -> tensor<1x30x30x64xbf16>
     return %3 : tensor<1x30x30x64xbf16>
@@ -45,7 +84,21 @@ module attributes {} {
     // CHECK: %[[TO_LAYOUT_INPUT:.*]] = "ttnn.to_layout"(%arg0)
     // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
     // CHECK-SAME: layout = #ttnn.layout<row_major>
-    %1 = "ttnn.conv_transpose2d"(%arg0, %arg1, %0) <{batch_size = 1 : i32, dilation = array<i32: 1, 1>, groups = 1 : i32, in_channels = 64 : i32, input_height = 32 : i32, input_width = 32 : i32, kernel_size = array<i32: 3, 3>, out_channels = 64 : i32, padding = array<i32: 0, 0>, stride = array<i32: 1, 1>, output_padding = array<i32: 0, 0>}> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
+    %1 = "ttnn.conv_transpose2d"(%arg0, %arg1, %0)
+          <{
+            batch_size = 1 : i32,
+            dilation = array<i32: 1, 1>,
+            groups = 1 : i32,
+            in_channels = 64 : i32,
+            input_height = 32 : i32,
+            input_width = 32 : i32,
+            kernel_size = array<i32: 3, 3>,
+            out_channels = 64 : i32,
+            padding = array<i32: 0, 0>,
+            stride = array<i32: 1, 1>,
+            output_padding = array<i32: 0, 0>,
+            output_dtype = #ttcore.supportedDataTypes<bf16>
+          }> : (tensor<1x32x32x64xbf16>, tensor<64x64x3x3xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
     // CHECK-NEXT: %[[CONV2D_RESULT:.*]] = "ttnn.conv_transpose2d"(%[[TO_LAYOUT_INPUT]], %[[CONV2D_WEIGHTS:.*]], %[[DEVICE_OP]])
     %2 = "ttnn.reshape"(%1) <{shape = [1 : i32, 30 : i32, 30 : i32, 64 : i32]}> : (tensor<1x1x900x64xbf16>) -> tensor<1x30x30x64xbf16>
     return %2 : tensor<1x30x30x64xbf16>

--- a/test/ttmlir/Dialect/TTNN/conv/conv2d/conv2d_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/conv/conv2d/conv2d_tests_negative.mlir
@@ -17,7 +17,8 @@ module {
               stride = array<i32: 1, 1>,
               padding = array<i32: 0, 0>,
               dilation = array<i32: 1, 1>,
-              groups = 1: i32
+              groups = 1: i32,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
             }> : (tensor<32x32x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
     return %1 : tensor<1x1x900x64xbf16>
   }
@@ -39,7 +40,8 @@ module {
               stride = array<i32: 1, 1>,
               padding = array<i32: 0, 0>,
               dilation = array<i32: 1, 1>,
-              groups = 1: i32
+              groups = 1: i32,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
             }> : (tensor<1x1x1024x64xbf16>, tensor<64x3x3xbf16>, tensor<1x1x1x64xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
     return %1 : tensor<1x1x900x64xbf16>
   }
@@ -61,7 +63,8 @@ module {
               stride = array<i32: 1, 1>,
               padding = array<i32: 0, 0>,
               dilation = array<i32: 1, 1>,
-              groups = 1: i32
+              groups = 1: i32,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
             }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x64xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
     return %1 : tensor<1x1x900x64xbf16>
   }
@@ -83,7 +86,8 @@ module {
               stride = array<i32: 1, 1>,
               padding = array<i32: 0, 0>,
               dilation = array<i32: 1, 1>,
-              groups = 1: i32
+              groups = 1: i32,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
             }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !ttnn.device) -> tensor<1x900x64xbf16>
     return %1 : tensor<1x900x64xbf16>
   }
@@ -106,7 +110,8 @@ module {
               stride = array<i32: 1, 1>,
               padding = array<i32: 0, 0>,
               dilation = array<i32: 1, 1>,
-              groups = 1: i32
+              groups = 1: i32,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
             }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
     return %1 : tensor<1x1x900x64xbf16>
   }
@@ -128,7 +133,8 @@ module {
               stride = array<i32: 1, 1, 3>,
               padding = array<i32: 0, 0>,
               dilation = array<i32: 1, 1>,
-              groups = 1: i32
+              groups = 1: i32,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
             }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
     return %1 : tensor<1x1x900x64xbf16>
   }
@@ -150,7 +156,8 @@ module {
               stride = array<i32: 1, 1>,
               padding = array<i32: 0, 0>,
               dilation = array<i32: 1, 1, 1>,
-              groups = 1: i32
+              groups = 1: i32,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
             }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
     return %1 : tensor<1x1x900x64xbf16>
   }
@@ -173,7 +180,8 @@ module {
               stride = array<i32: 2, -2>,
               padding = array<i32: 0, 0>,
               dilation = array<i32: 1, 1>,
-              groups = 1: i32
+              groups = 1: i32,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
             }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
     return %1 : tensor<1x1x900x64xbf16>
   }
@@ -195,7 +203,8 @@ module {
               stride = array<i32: 1, 1>,
               padding = array<i32: -1, 0>,
               dilation = array<i32: 1, 1>,
-              groups = 1: i32
+              groups = 1: i32,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
             }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
     return %1 : tensor<1x1x900x64xbf16>
   }
@@ -217,7 +226,8 @@ module {
               stride = array<i32: 1, 1>,
               padding = array<i32: 0, 0>,
               dilation = array<i32: -2, -2>,
-              groups = 1: i32
+              groups = 1: i32,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
             }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
     return %1 : tensor<1x1x900x64xbf16>
   }
@@ -239,7 +249,8 @@ module {
               stride = array<i32: 1, 1>,
               padding = array<i32: 0, 0>,
               dilation = array<i32: 1, 1>,
-              groups = 1: i32
+              groups = 1: i32,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
             }> : (tensor<1x1x1024x64xbf16>, tensor<64x32x3x3xbf16>, tensor<1x1x1x64xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
     return %1 : tensor<1x1x900x64xbf16>
   }
@@ -261,7 +272,8 @@ module {
               stride = array<i32: 1, 1>,
               padding = array<i32: 0, 0>,
               dilation = array<i32: 1, 1>,
-              groups = 1: i32
+              groups = 1: i32,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
             }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !ttnn.device) -> tensor<1x1x900x32xbf16>
     return %1 : tensor<1x1x900x32xbf16>
   }
@@ -283,7 +295,8 @@ module {
               stride = array<i32: 1, 1>,
               padding = array<i32: 0, 0>,
               dilation = array<i32: 1, 1>,
-              groups = 1: i32
+              groups = 1: i32,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
             }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !ttnn.device) -> tensor<1x1x900x32xbf16>
     return %1 : tensor<1x1x900x32xbf16>
   }
@@ -305,7 +318,8 @@ module {
               stride = array<i32: 1, 1>,
               padding = array<i32: 0, 0>,
               dilation = array<i32: 1, 1>,
-              groups = 1: i32
+              groups = 1: i32,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
             }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !ttnn.device) -> tensor<1x1x900x32xbf16>
     return %1 : tensor<1x1x900x32xbf16>
   }
@@ -328,7 +342,8 @@ module {
               stride = array<i32: 1, 1>,
               padding = array<i32: 0, 0>,
               dilation = array<i32: 1, 1>,
-              groups = 1: i32
+              groups = 1: i32,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
             }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
     return %1 : tensor<1x1x900x64xbf16>
   }
@@ -350,7 +365,8 @@ module {
               stride = array<i32: 1, 1>,
               padding = array<i32: 0, 0>,
               dilation = array<i32: 1, 1>,
-              groups = 1: i32
+              groups = 1: i32,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
             }> : (tensor<1x1x1024x64xbf16>, tensor<64x64x3x3xbf16>, tensor<1x1x1x64xbf16>, !ttnn.device) -> tensor<1x1x900x64xbf16>
     return %1 : tensor<1x1x900x64xbf16>
   }
@@ -372,7 +388,8 @@ module {
               stride = array<i32: 1, 1>,
               padding = array<i32: 0, 0>,
               dilation = array<i32: 1, 1>,
-              groups = 3: i32
+              groups = 3: i32,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
             }> : (tensor<1x1x1024x64xbf16>, tensor<96x64x3x3xbf16>, tensor<1x1x1x96xbf16>, !ttnn.device) -> tensor<1x1x900x96xbf16>
     return %1 : tensor<1x1x900x96xbf16>
   }
@@ -394,7 +411,8 @@ module {
               stride = array<i32: 1, 1>,
               padding = array<i32: 2, 4>,
               dilation = array<i32: 6, 12>,
-              groups = 2: i32
+              groups = 2: i32,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
             }> : (tensor<4x1x1024x64xbf16>, tensor<64x32x12x12xbf16>, tensor<1x1x1x64xbf16>, !ttnn.device) -> tensor<4x1x900x64xbf16>
     return %1 : tensor<4x1x900x64xbf16>
   }

--- a/test/ttmlir/Dialect/TTNN/conv/prepare_conv2d_weights/prepare_conv2d_weights_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/conv/prepare_conv2d_weights/prepare_conv2d_weights_negative.mlir
@@ -21,7 +21,9 @@ module {
               out_channels = 64 : i32,
               padding = array<i32: 0, 0>,
               stride = array<i32: 1, 1>,
-              weights_format = "OIHW"
+              weights_format = "OIHW",
+              input_dtype = #ttcore.supportedDataTypes<bf16>,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
             }> : (tensor<64x64x3xbf16>, !ttnn.device) -> tensor<64x64x3xbf16>
     return %1 : tensor<64x64x3xbf16>
   }
@@ -48,7 +50,9 @@ module {
               out_channels = 64 : i32,
               padding = array<i32: 0, 0>,
               stride = array<i32: 1, 1>,
-              weights_format = "OHWI"
+              weights_format = "OHWI",
+              input_dtype = #ttcore.supportedDataTypes<bf16>,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
             }> : (tensor<64x64x3x3xbf16>, !ttnn.device) -> tensor<64x64x3x3xbf16>
     return %1 : tensor<64x64x3x3xbf16>
   }
@@ -75,7 +79,9 @@ module {
               out_channels = 128 : i32,
               padding = array<i32: 0, 0>,
               stride = array<i32: 1, 1>,
-              weights_format = "OIHW"
+              weights_format = "OIHW",
+              input_dtype = #ttcore.supportedDataTypes<bf16>,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
             }> : (tensor<64x64x3x3xbf16>, !ttnn.device) -> tensor<64x64x3x3xbf16>
     return %1 : tensor<64x64x3x3xbf16>
   }
@@ -101,7 +107,9 @@ module {
               out_channels = 64 : i32,
               padding = array<i32: 0, 0>,
               stride = array<i32: 1, 1>,
-              weights_format = "OIHW"
+              weights_format = "OIHW",
+              input_dtype = #ttcore.supportedDataTypes<bf16>,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
             }> : (tensor<64x64x3x3xbf16>, !ttnn.device) -> tensor<64x64x3x3xbf16>
     return %1 : tensor<64x64x3x3xbf16>
   }
@@ -127,7 +135,9 @@ module {
               out_channels = 64 : i32,
               padding = array<i32: 0, 0>,
               stride = array<i32: 1, 1>,
-              weights_format = "OIHW"
+              weights_format = "OIHW",
+              input_dtype = #ttcore.supportedDataTypes<bf16>,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
             }> : (tensor<64x64x3x3xbf16>, !ttnn.device) -> tensor<64x64x3x3xbf16>
     return %1 : tensor<64x64x3x3xbf16>
   }
@@ -153,7 +163,9 @@ module {
               out_channels = 64 : i32,
               padding = array<i32: 0, 0>,
               stride = array<i32: 1, 1>,
-              weights_format = "OIHW"
+              weights_format = "OIHW",
+              input_dtype = #ttcore.supportedDataTypes<bf16>,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
             }> : (tensor<64x64x3x3xbf16>, !ttnn.device) -> tensor<64x64x3x3xbf16>
     return %1 : tensor<64x64x3x3xbf16>
   }
@@ -180,7 +192,9 @@ module {
               out_channels = 64 : i32,
               padding = array<i32: 0, 0>,
               stride = array<i32: 1, 1>,
-              weights_format = "OIHW"
+              weights_format = "OIHW",
+              input_dtype = #ttcore.supportedDataTypes<bf16>,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
             }> : (tensor<64x64x3x3xbf16>, !ttnn.device) -> tensor<64x64x3x3xbf16>
     return %1 : tensor<64x64x3x3xbf16>
   }
@@ -206,7 +220,9 @@ module {
               out_channels = 64 : i32,
               padding = array<i32: 0, 0>,
               stride = array<i32: 1, 1, 1>,
-              weights_format = "OIHW"
+              weights_format = "OIHW",
+              input_dtype = #ttcore.supportedDataTypes<bf16>,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
             }> : (tensor<64x64x3x3xbf16>, !ttnn.device) -> tensor<64x64x3x3xbf16>
     return %1 : tensor<64x64x3x3xbf16>
   }
@@ -232,7 +248,9 @@ module {
               out_channels = 64 : i32,
               padding = array<i32: 0, 0>,
               stride = array<i32: 1, 1>,
-              weights_format = "OIHW"
+              weights_format = "OIHW",
+              input_dtype = #ttcore.supportedDataTypes<bf16>,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
             }> : (tensor<64x64x3x3xbf16>, !ttnn.device) -> tensor<64x64x3x3xbf16>
     return %1 : tensor<64x64x3x3xbf16>
   }
@@ -258,7 +276,9 @@ module {
               out_channels = 64 : i32,
               padding = array<i32: 0, 0, 1>,
               stride = array<i32: 1, 1>,
-              weights_format = "OIHW"
+              weights_format = "OIHW",
+              input_dtype = #ttcore.supportedDataTypes<bf16>,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
             }> : (tensor<64x64x3x3xbf16>, !ttnn.device) -> tensor<64x64x3x3xbf16>
     return %1 : tensor<64x64x3x3xbf16>
   }

--- a/test/ttmlir/Dialect/TTNN/fusing/conv2d_activation_fusing_ttnn.mlir
+++ b/test/ttmlir/Dialect/TTNN/fusing/conv2d_activation_fusing_ttnn.mlir
@@ -20,7 +20,21 @@ module {
 
     %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     %1 = "ttnn.reshape"(%arg0) <{shape = [1 : i32, 1 : i32, 1024 : i32, 64 : i32]}> : (tensor<1x32x32x64xbf16, #ttnn_layout>) -> tensor<1x1x1024x64xbf16, #ttnn_layout4>
-    %2 = "ttnn.conv2d"(%1, %arg1, %arg2, %0) <{batch_size = 1 : i32, conv2d_config = #ttnn.conv2d_config<dtype = bf16, weights_dtype = bf16, activation = "relu", deallocate_activation = false, reallocate_halo_output = false, act_block_h_override = 0, act_block_w_div = 1, reshard_if_not_optimal = false, override_sharding_config = false, shard_layout = height_sharded, transpose_shards = false, output_layout = tile, enable_act_double_buffer = false, enable_weights_double_buffer = false, enable_split_reader = false, enable_subblock_padding = false>, dilation = array<i32: 1, 1>, groups = 1 : i32, in_channels = 64 : i32, input_height = 32 : i32, input_width = 32 : i32, kernel_size = array<i32: 3, 3>, out_channels = 64 : i32, padding = array<i32: 0, 0>, stride = array<i32: 1, 1>}> : (tensor<1x1x1024x64xbf16, #ttnn_layout4>, tensor<64x64x3x3xbf16, #ttnn_layout1>, tensor<1x1x1x64xbf16, #ttnn_layout2>, !ttnn.device) -> tensor<1x1x900x64xbf16, #ttnn_layout5>
+    %2 = "ttnn.conv2d"(%1, %arg1, %arg2, %0)
+          <{
+            batch_size = 1 : i32,
+            conv2d_config = #ttnn.conv2d_config<dtype = bf16, weights_dtype = bf16, activation = "relu", deallocate_activation = false, reallocate_halo_output = false, act_block_h_override = 0, act_block_w_div = 1, reshard_if_not_optimal = false, override_sharding_config = false, shard_layout = height_sharded, transpose_shards = false, output_layout = tile, enable_act_double_buffer = false, enable_weights_double_buffer = false, enable_split_reader = false, enable_subblock_padding = false>,
+            dilation = array<i32: 1, 1>,
+            groups = 1 : i32,
+            in_channels = 64 : i32,
+            input_height = 32 : i32,
+            input_width = 32 : i32,
+            kernel_size = array<i32: 3, 3>,
+            out_channels = 64 : i32,
+            padding = array<i32: 0, 0>,
+            stride = array<i32: 1, 1>,
+            output_dtype = #ttcore.supportedDataTypes<bf16>
+          }> : (tensor<1x1x1024x64xbf16, #ttnn_layout4>, tensor<64x64x3x3xbf16, #ttnn_layout1>, tensor<1x1x1x64xbf16, #ttnn_layout2>, !ttnn.device) -> tensor<1x1x900x64xbf16, #ttnn_layout5>
     %3 = "ttnn.reshape"(%2) <{shape = [1 : i32, 30 : i32, 30 : i32, 64 : i32]}> : (tensor<1x1x900x64xbf16, #ttnn_layout5>) -> tensor<1x30x30x64xbf16, #ttnn_layout3>
 
     // CHECK: "ttnn.relu"
@@ -37,7 +51,20 @@ module {
 
     %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
     %1 = "ttnn.reshape"(%arg0) <{shape = [1 : i32, 1 : i32, 1024 : i32, 64 : i32]}> : (tensor<1x32x32x64xbf16, #ttnn_layout>) -> tensor<1x1x1024x64xbf16, #ttnn_layout4>
-    %2 = "ttnn.conv2d"(%1, %arg1, %arg2, %0) <{batch_size = 1 : i32, dilation = array<i32: 1, 1>, groups = 1 : i32, in_channels = 64 : i32, input_height = 32 : i32, input_width = 32 : i32, kernel_size = array<i32: 3, 3>, out_channels = 64 : i32, padding = array<i32: 0, 0>, stride = array<i32: 1, 1>}> : (tensor<1x1x1024x64xbf16, #ttnn_layout4>, tensor<64x64x3x3xbf16, #ttnn_layout1>, tensor<1x1x1x64xbf16, #ttnn_layout2>, !ttnn.device) -> tensor<1x1x900x64xbf16, #ttnn_layout5>
+    %2 = "ttnn.conv2d"(%1, %arg1, %arg2, %0)
+          <{
+            batch_size = 1 : i32,
+            dilation = array<i32: 1, 1>,
+            groups = 1 : i32,
+            in_channels = 64 : i32,
+            input_height = 32 : i32,
+            input_width = 32 : i32,
+            kernel_size = array<i32: 3, 3>,
+            out_channels = 64 : i32,
+            padding = array<i32: 0, 0>,
+            stride = array<i32: 1, 1>,
+            output_dtype = #ttcore.supportedDataTypes<bf16>
+          }> : (tensor<1x1x1024x64xbf16, #ttnn_layout4>, tensor<64x64x3x3xbf16, #ttnn_layout1>, tensor<1x1x1x64xbf16, #ttnn_layout2>, !ttnn.device) -> tensor<1x1x900x64xbf16, #ttnn_layout5>
 
     // CHECK-NOT: "ttnn.relu"
     %3 = "ttnn.relu"(%2) : (tensor<1x1x900x64xbf16, #ttnn_layout5>) -> tensor<1x1x900x64xbf16, #ttnn_layout5>

--- a/test/ttmlir/EmitC/TTNN/conv/conv2d_conv2dconfig.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/conv2d_conv2dconfig.mlir
@@ -46,7 +46,8 @@ func.func @conv2d_conv2dconfig(%arg0: tensor<1x1x1024x64xbf16, #ttnn_layout>, %a
         padding = array<i32: 0, 0>,
         dilation = array<i32: 1, 1>,
         groups = 1 : i32,
-        conv2d_config = #conv2d_config
+        conv2d_config = #conv2d_config,
+        output_dtype = #ttcore.supportedDataTypes<bf16>
       }> : (tensor<1x1x1024x64xbf16, #ttnn_layout>, tensor<64x64x3x3xbf16, #ttnn_layout1>, tensor<1x1x1x64xbf16, #ttnn_layout2>, !ttnn.device) -> tensor<1x1x900x64xbf16, #ttnn_layout4>
   %2 = "ttnn.reshape"(%1) <{shape = [1 : i32, 30 : i32, 30 : i32, 64 : i32]}> : (tensor<1x1x900x64xbf16, #ttnn_layout4>) -> tensor<1x30x30x64xbf16, #ttnn_layout4>
   "ttnn.deallocate"(%1) <{force = false}> : (tensor<1x1x900x64xbf16, #ttnn_layout4>) -> ()

--- a/test/ttmlir/EmitC/TTNN/conv/conv2d_with_prepare_conv2d_weights.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/conv2d_with_prepare_conv2d_weights.mlir
@@ -34,7 +34,9 @@ func.func @conv2d_with_prepare_conv2d_weights(%arg0: tensor<1x32x32x64xbf16, #tt
             out_channels = 64 : i32,
             padding = array<i32: 2, 4>,
             stride = array<i32: 4, 8>,
-            weights_format = "OIHW"
+            weights_format = "OIHW",
+            input_dtype = #ttcore.supportedDataTypes<bf16>,
+            output_dtype = #ttcore.supportedDataTypes<bf16>
           }> : (tensor<64x16x3x3xbf16, #ttnn_layout1>, !ttnn.device) -> tensor<1x1x576x64xbf16, #ttnn_layout2>
   "ttnn.deallocate"(%arg1) <{force = false}> : (tensor<64x16x3x3xbf16, #ttnn_layout1>) -> ()
   %3 = "ttnn.from_device"(%1) : (tensor<1x1x1024x64xbf16, #ttnn_layout5>) -> tensor<1x1x1024x64xbf16, #ttnn_layout6>
@@ -43,7 +45,20 @@ func.func @conv2d_with_prepare_conv2d_weights(%arg0: tensor<1x32x32x64xbf16, #tt
   "ttnn.deallocate"(%3) <{force = false}> : (tensor<1x1x1024x64xbf16, #ttnn_layout6>) -> ()
   %5 = "ttnn.to_device"(%4, %0) <{memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<1x1x1024x64xbf16, #ttnn_layout7>, !ttnn.device) -> tensor<1x1x1024x64xbf16, #ttnn_layout8>
   "ttnn.deallocate"(%4) <{force = false}> : (tensor<1x1x1024x64xbf16, #ttnn_layout7>) -> ()
-  %6 = "ttnn.conv2d"(%5, %2, %arg2, %0) <{batch_size = 1 : i32, dilation = array<i32: 2, 4>, groups = 4 : i32, in_channels = 64 : i32, input_height = 32 : i32, input_width = 32 : i32, kernel_size = array<i32: 3, 3>, out_channels = 64 : i32, padding = array<i32: 2, 4>, stride = array<i32: 4, 8>}> : (tensor<1x1x1024x64xbf16, #ttnn_layout8>, tensor<1x1x576x64xbf16, #ttnn_layout2>, tensor<1x1x1x64xbf16, #ttnn_layout3>, !ttnn.device) -> tensor<1x1x32x64xbf16, #ttnn_layout4>
+  %6 = "ttnn.conv2d"(%5, %2, %arg2, %0)
+        <{
+          batch_size = 1 : i32,
+          dilation = array<i32: 2, 4>,
+          groups = 4 : i32,
+          in_channels = 64 : i32,
+          input_height = 32 : i32,
+          input_width = 32 : i32,
+          kernel_size = array<i32: 3, 3>,
+          out_channels = 64 : i32,
+          padding = array<i32: 2, 4>,
+          stride = array<i32: 4, 8>,
+          output_dtype = #ttcore.supportedDataTypes<bf16>
+        }> : (tensor<1x1x1024x64xbf16, #ttnn_layout8>, tensor<1x1x576x64xbf16, #ttnn_layout2>, tensor<1x1x1x64xbf16, #ttnn_layout3>, !ttnn.device) -> tensor<1x1x32x64xbf16, #ttnn_layout4>
   "ttnn.deallocate"(%5) <{force = false}> : (tensor<1x1x1024x64xbf16, #ttnn_layout8>) -> ()
   "ttnn.deallocate"(%2) <{force = false}> : (tensor<1x1x576x64xbf16, #ttnn_layout2>) -> ()
   "ttnn.deallocate"(%arg2) <{force = false}> : (tensor<1x1x1x64xbf16, #ttnn_layout3>) -> ()

--- a/test/ttmlir/EmitC/TTNN/conv/prepare_conv2d_weights.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/prepare_conv2d_weights.mlir
@@ -25,7 +25,9 @@ func.func @prepare_conv2d_weights(%arg0: tensor<64x64x3x3xbf16, #ttnn_layout>) -
               out_channels = 64 : i32,
               padding = array<i32: 0, 0>,
               stride = array<i32: 1, 1>,
-              weights_format = "OIHW"
+              weights_format = "OIHW",
+              input_dtype = #ttcore.supportedDataTypes<bf16>,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
           }> : (tensor<64x64x3x3xbf16, #ttnn_layout>, !ttnn.device) -> tensor<1x1x576x64xbf16, #ttnn_layout1>
   return %1 : tensor<1x1x576x64xbf16, #ttnn_layout1>
 }

--- a/test/ttmlir/EmitC/TTNN/conv/prepare_conv2d_weights_asymmetric_padding.mlir
+++ b/test/ttmlir/EmitC/TTNN/conv/prepare_conv2d_weights_asymmetric_padding.mlir
@@ -24,7 +24,9 @@ func.func @prepare_conv2d_weights(%arg0: tensor<16x8x3x3xbf16, #ttnn_layout>) ->
           out_channels = 16 : i32,
           padding = array<i32: 0, 1, 2, 3>,
           stride = array<i32: 2, 2>,
-          weights_format = "OIHW"
+          weights_format = "OIHW",
+          input_dtype = #ttcore.supportedDataTypes<bf16>,
+          output_dtype = #ttcore.supportedDataTypes<bf16>
       }> : (tensor<16x8x3x3xbf16, #ttnn_layout>, !ttnn.device) -> tensor<1x1x72x16xbf16, #ttnn_layout1>
   return %1 : tensor<1x1x72x16xbf16, #ttnn_layout1>
 }

--- a/test/ttmlir/Silicon/TTNN/n150/conv/prepare_conv2d_weights/simple_prepare_conv2d_weights.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/conv/prepare_conv2d_weights/simple_prepare_conv2d_weights.mlir
@@ -24,7 +24,9 @@ module {
               out_channels = 64 : i32,
               padding = array<i32: 0, 0>,
               stride = array<i32: 1, 1>,
-              weights_format = "OIHW"
+              weights_format = "OIHW",
+              input_dtype = #ttcore.supportedDataTypes<bf16>,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
             }> : (tensor<64x64x3x3xbf16, #ttnn_layout>, !ttnn.device) -> tensor<1x1x576x64xbf16, #ttnn_layout1>
     return %1 : tensor<1x1x576x64xbf16, #ttnn_layout1>
   }

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_conv2d_config.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_conv2d_config.mlir
@@ -45,7 +45,8 @@ module attributes {} {
               padding = array<i32: 0, 0>,
               dilation = array<i32: 1, 1>,
               groups = 1 : i32,
-              conv2d_config = #conv2d_config
+              conv2d_config = #conv2d_config,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
             }> : (tensor<1x1x1024x64xbf16, #ttnn_layout>, tensor<64x64x3x3xbf16, #ttnn_layout1>, tensor<1x1x1x64xbf16, #ttnn_layout2>, !ttnn.device) -> tensor<1x1x900x64xbf16, #ttnn_layout4>
     %2 = "ttnn.reshape"(%1) <{shape = [1 : i32, 30 : i32, 30 : i32, 64 : i32]}> : (tensor<1x1x900x64xbf16, #ttnn_layout4>) -> tensor<1x30x30x64xbf16, #ttnn_layout4>
     "ttnn.deallocate"(%1) <{force = false}> : (tensor<1x1x900x64xbf16, #ttnn_layout4>) -> ()

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_conv2d_device_compute_kernel_config.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_conv2d_device_compute_kernel_config.mlir
@@ -33,7 +33,8 @@ module attributes {} {
               padding = array<i32: 0, 0>,
               dilation = array<i32: 1, 1>,
               groups = 1 : i32,
-              compute_config = #device_compute_kernel_config
+              compute_config = #device_compute_kernel_config,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
             }> : (tensor<1x1x1024x64xbf16, #ttnn_layout>, tensor<64x64x3x3xbf16, #ttnn_layout1>, tensor<1x1x1x64xbf16, #ttnn_layout2>, !ttnn.device) -> tensor<1x1x900x64xbf16, #ttnn_layout4>
     %2 = "ttnn.reshape"(%1) <{shape = [1 : i32, 30 : i32, 30 : i32, 64 : i32]}> : (tensor<1x1x900x64xbf16, #ttnn_layout4>) -> tensor<1x30x30x64xbf16, #ttnn_layout4>
     "ttnn.deallocate"(%1) <{force = false}> : (tensor<1x1x900x64xbf16, #ttnn_layout4>) -> ()

--- a/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_conv_transpose2d_with_conv2d_config.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/perf/test_perf_conv_transpose2d_with_conv2d_config.mlir
@@ -47,7 +47,8 @@ module attributes {} {
               output_padding = array<i32: 0, 0>,
               dilation = array<i32: 1, 1>,
               groups = 1 : i32,
-              conv2d_config = #conv2d_config
+              conv2d_config = #conv2d_config,
+              output_dtype = #ttcore.supportedDataTypes<bf16>
             }> : (tensor<3x8x8x256xbf16, #ttnn_layout4>, tensor<256x256x3x3xbf16, #ttnn_layout1>, tensor<1x1x1x256xbf16, #ttnn_layout2>, !ttnn.device) -> tensor<1x1x300x256xbf16, #ttnn_layout3>
     "ttnn.deallocate"(%1) <{force = false}> : (tensor<3x8x8x256xbf16, #ttnn_layout4>) -> ()
     "ttnn.deallocate"(%arg2) <{force = false}> : (tensor<1x1x1x256xbf16, #ttnn_layout2>) -> ()

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -4,6 +4,7 @@
 
 #include "OpModelFixture.h"
 
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNN.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
@@ -821,6 +822,9 @@ TEST_F(OpModelBase, Conv2dInterface) {
       ttcore::GridAttr::get(&context));
   auto weight = createEmptyTensor(weightShape, weightElementType, weightLayout);
   auto outputType = createRankedTensorType(outputShape);
+  auto outputDtype = ttcore::DataTypeAttr::get(
+      &context,
+      mlir::tt::ttcore::elementTypeToDataType(outputType.getElementType()));
 
   GetDeviceOp deviceOp = builder.create<ttnn::GetDeviceOp>(
       builder.getUnknownLoc(), builder.getType<DeviceType>(),
@@ -844,6 +848,7 @@ TEST_F(OpModelBase, Conv2dInterface) {
       llvm::ArrayRef<int32_t>({3, 3}), // Padding [H, W]
       llvm::ArrayRef<int32_t>({1, 1}), // Dilation [H, W]
       1,                               // Groups
+      outputDtype,                     // OutputDtype
       nullptr,                         // Conv2dConfig (optional)
       nullptr                          // ComputeKernelConfig (optional)
   );
@@ -888,6 +893,9 @@ TEST_F(OpModelBase, Conv2dInterfaceNullOutput) {
       ttcore::GridAttr::get(&context));
   auto weight = createEmptyTensor(weightShape, weightElementType, weightLayout);
   auto outputType = createRankedTensorType(outputShape);
+  auto outputDtype = ttcore::DataTypeAttr::get(
+      &context,
+      mlir::tt::ttcore::elementTypeToDataType(outputType.getElementType()));
 
   GetDeviceOp deviceOp = builder.create<ttnn::GetDeviceOp>(
       builder.getUnknownLoc(), builder.getType<DeviceType>(),
@@ -911,6 +919,7 @@ TEST_F(OpModelBase, Conv2dInterfaceNullOutput) {
       llvm::ArrayRef<int32_t>({3, 3}), // Padding [H, W]
       llvm::ArrayRef<int32_t>({1, 1}), // Dilation [H, W]
       1,                               // Groups
+      outputDtype,                     // OutputDtype
       nullptr,                         // Conv2dConfig (optional)
       nullptr                          // ComputeKernelConfig (optional)
   );
@@ -957,6 +966,9 @@ TEST_F(OpModelBase, PrepareConv2dWeightsOutput) {
   auto weight = createEmptyTensor(weightShape, elemetType, weightLayout);
 
   auto outputType = createRankedTensorType(outputShape);
+  auto outputDtype = ttcore::DataTypeAttr::get(
+      &context,
+      mlir::tt::ttcore::elementTypeToDataType(outputType.getElementType()));
 
   GetDeviceOp deviceOp = builder.create<ttnn::GetDeviceOp>(
       builder.getUnknownLoc(), builder.getType<DeviceType>(),
@@ -967,7 +979,7 @@ TEST_F(OpModelBase, PrepareConv2dWeightsOutput) {
       builder.getUnknownLoc(), outputType, input, weight, nullptr, deviceOp, 3,
       64, 1, 224, 224, llvm::ArrayRef<int32_t>({7, 7}),
       llvm::ArrayRef<int32_t>({2, 2}), llvm::ArrayRef<int32_t>({3, 3}),
-      llvm::ArrayRef<int32_t>({1, 1}), 1, nullptr, nullptr);
+      llvm::ArrayRef<int32_t>({1, 1}), 1, outputDtype, nullptr, nullptr);
 
   auto preparedWeightOutput =
       mlir::tt::op_model::ttnn::getPreparedConv2dWeightsOutputTensor(&conv2d);
@@ -1004,6 +1016,9 @@ TEST_F(OpModelBase, Conv2dInterfaceConfigs) {
   auto weight = createEmptyTensor(weightShape, elemetType, weightLayout);
 
   auto outputType = createRankedTensorType(outputShape);
+  auto outputDtype = ttcore::DataTypeAttr::get(
+      &context,
+      mlir::tt::ttcore::elementTypeToDataType(outputType.getElementType()));
 
   GetDeviceOp deviceOp = builder.create<ttnn::GetDeviceOp>(
       builder.getUnknownLoc(), builder.getType<DeviceType>(),
@@ -1014,7 +1029,7 @@ TEST_F(OpModelBase, Conv2dInterfaceConfigs) {
       builder.getUnknownLoc(), outputType, input, weight, nullptr, deviceOp, 3,
       64, 1, 224, 224, llvm::ArrayRef<int32_t>({7, 7}),
       llvm::ArrayRef<int32_t>({2, 2}), llvm::ArrayRef<int32_t>({3, 3}),
-      llvm::ArrayRef<int32_t>({1, 1}), 1, nullptr, nullptr);
+      llvm::ArrayRef<int32_t>({1, 1}), 1, outputDtype, nullptr, nullptr);
 
   // Device hangs otherwise.
   mlir::tt::op_model::ttnn::SingletonDeviceContext::resetInstance();
@@ -1122,6 +1137,9 @@ TEST_F(OpModelBase, ConvTranspose2dInterfaceConfigs) {
   auto weight = createEmptyTensor(weightShape, elemetType, weightLayout);
 
   auto outputType = createRankedTensorType(outputShape);
+  auto outputDtype = ttcore::DataTypeAttr::get(
+      &context,
+      mlir::tt::ttcore::elementTypeToDataType(outputType.getElementType()));
 
   GetDeviceOp deviceOp = builder.create<ttnn::GetDeviceOp>(
       builder.getUnknownLoc(), builder.getType<DeviceType>(),
@@ -1133,7 +1151,7 @@ TEST_F(OpModelBase, ConvTranspose2dInterfaceConfigs) {
       64, 1, 224, 224, llvm::ArrayRef<int32_t>({7, 7}),
       llvm::ArrayRef<int32_t>({2, 2}), llvm::ArrayRef<int32_t>({3, 3}),
       llvm::ArrayRef<int32_t>({0, 0}), llvm::ArrayRef<int32_t>({1, 1}), 1,
-      nullptr, nullptr);
+      outputDtype, nullptr, nullptr);
 
   // Device hangs otherwise.
   mlir::tt::op_model::ttnn::SingletonDeviceContext::resetInstance();

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "44adf3a7bfafa2ae4cf8f4aab40dc79b10579f29")
+set(TT_METAL_VERSION "cf17101cb79329ee9369b2ab3075ef8a22c00008")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the cf17101cb79329ee9369b2ab3075ef8a22c00008 (July 8)

- Use dtype param in conv as param instead of in config after metal change 58a6cd607f
- Update create multi device host tensor to take mesh shape argument after metal change 208e76b2c3
- Remove computeKernelConfig from cumsum after metal commit de8579fde8