### PR TITLE
Check for deleted files as well in the CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       other_changed_files: ${{ steps.ignore-files.outputs.other_changed_files }}
+      other_deleted_files: ${{ steps.ignore-files.outputs.other_deleted_files }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -39,10 +40,11 @@ jobs:
           echo "only_changed=${{ steps.ignore-files.outputs.only_changed }}"
           echo "other_changed_files=${{ steps.ignore-files.outputs.other_changed_files }}"
           echo "all_changed_files=${{ steps.ignore-files.outputs.all_changed_files }}"
+          echo "other_deleted_files=${{ steps.ignore-files.outputs.other_deleted_files }}"
 
   build-image:
     needs: ignore-files
-    if: ${{ needs.ignore-files.outputs.other_changed_files }}
+    if: ${{ needs.ignore-files.outputs.other_changed_files || needs.ignore-files.outputs.other_deleted_files }}
     runs-on:
       - builder
     outputs:


### PR DESCRIPTION
### Ticket
/

### Problem description
`Ignore files` job in the CI was only checking if any files other than `./docs/*` have been **changed**, not including **deleted** ones in that list. 
That caused the `On PR` workflow to be skipped if your last commit only removed files.

### What's changed
We are now checking for deleted files as well when checking whether to run the `On PR` workflow.
We are now outputting the list of deleted files and checking deletions (in addition to changes) in files. The check is happening in the `build-image` job.

### Checklist
- [ ] New/Existing tests provide coverage for changes
