### PR TITLE
Add runtime API to configure persistent kernel cache

### DIFF
--- a/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
@@ -12,6 +12,7 @@
 #include "tt-metalium/host_api.hpp"
 #include "tt-metalium/memory_reporter.hpp"
 #include "tt-metalium/mesh_device.hpp"
+#include "tt-metalium/persistent_kernel_cache.hpp"
 #include "tt-metalium/program_cache.hpp"
 #include "tt-metalium/tt_metal.hpp"
 
@@ -63,6 +64,9 @@ bool getTensorRetain(Tensor tensor);
 void setTensorRetain(Tensor tensor, bool retain);
 
 Arch getArch();
+
+void enablePersistentKernelCache();
+void disablePersistentKernelCache();
 
 size_t getNumAvailableDevices();
 

--- a/runtime/include/tt/runtime/detail/ttnn/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn/ttnn.h
@@ -12,6 +12,7 @@
 #include "tt-metalium/host_buffer.hpp"
 #include "tt-metalium/memory_reporter.hpp"
 #include "tt-metalium/mesh_device.hpp"
+#include "tt-metalium/persistent_kernel_cache.hpp"
 #include "tt-metalium/program_cache.hpp"
 #include "ttnn/device.hpp"
 #include "ttnn/events.hpp"
@@ -127,6 +128,9 @@ bool getTensorRetain(::tt::runtime::Tensor tensor);
 void setTensorRetain(::tt::runtime::Tensor tensor, bool retain);
 
 Arch getArch();
+
+void enablePersistentKernelCache();
+void disablePersistentKernelCache();
 
 size_t getNumAvailableDevices();
 

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -126,6 +126,9 @@ void setTensorRetain(Tensor tensor, bool retain);
 
 Arch getArch();
 
+void enablePersistentKernelCache();
+void disablePersistentKernelCache();
+
 size_t getNumAvailableDevices();
 
 Device openMeshDevice(const std::vector<uint32_t> &meshShape,

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -378,6 +378,20 @@ Arch getArch() {
       [&]() -> RetType { return ::tt::runtime::ttmetal::getArch(); });
 }
 
+void enablePersistentKernelCache() {
+  using RetType = void;
+  DISPATCH_TO_CURRENT_RUNTIME(
+      RetType, [&]() { ::tt::runtime::ttnn::enablePersistentKernelCache(); },
+      [&]() { ::tt::runtime::ttmetal::enablePersistentKernelCache(); });
+}
+
+void disablePersistentKernelCache() {
+  using RetType = void;
+  DISPATCH_TO_CURRENT_RUNTIME(
+      RetType, [&]() { ::tt::runtime::ttnn::disablePersistentKernelCache(); },
+      [&]() { ::tt::runtime::ttmetal::disablePersistentKernelCache(); });
+}
+
 size_t getNumAvailableDevices() {
   using RetType = size_t;
   return DISPATCH_TO_CURRENT_RUNTIME(

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -128,6 +128,14 @@ Arch getArch() {
   return ::tt::runtime::common::toRuntimeArch(::tt::tt_metal::hal::get_arch());
 }
 
+void enablePersistentKernelCache() {
+  ::tt::tt_metal::detail::EnablePersistentKernelCache();
+}
+
+void disablePersistentKernelCache() {
+  ::tt::tt_metal::detail::DisablePersistentKernelCache();
+}
+
 size_t getNumAvailableDevices() { return tt_metal::GetNumAvailableDevices(); }
 
 Device openMeshDevice(const std::vector<uint32_t> &meshShape,

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -431,6 +431,14 @@ Arch getArch() {
   return ::tt::runtime::common::toRuntimeArch(::tt::tt_metal::hal::get_arch());
 }
 
+void enablePersistentKernelCache() {
+  ::tt::tt_metal::detail::EnablePersistentKernelCache();
+}
+
+void disablePersistentKernelCache() {
+  ::tt::tt_metal::detail::DisablePersistentKernelCache();
+}
+
 size_t getNumAvailableDevices() {
   return ::tt::tt_metal::GetNumAvailableDevices();
 }

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -251,6 +251,14 @@ void registerRuntimeBindings(nb::module_ &m) {
       "Create a multi-device host tensor with owned memory");
   m.def("get_arch", &tt::runtime::getArch,
         "Get the architecture of the device");
+  m.def("enable_persistent_kernel_cache",
+        &tt::runtime::enablePersistentKernelCache,
+        "Enable persistent kernel cache, which will cache kernel binaries on "
+        "disk usable across runs.");
+  m.def("disable_persistent_kernel_cache",
+        &tt::runtime::disablePersistentKernelCache,
+        "Disable persistent kernel cache, which will disable caching kernel "
+        "binaries on disk.");
   m.def("get_num_available_devices", &tt::runtime::getNumAvailableDevices,
         "Get the number of available devices");
   m.def("open_mesh_device", &tt::runtime::openMeshDevice, nb::arg("mesh_shape"),


### PR DESCRIPTION
### Problem description
We didn't have a runtime API to configure persistent kernel cache.

### What's changed
Added API to configure persistent kernel cache

