### PR TITLE
Reapply "Support `UpsampleOp` in `bilinear` mode (#3978)"

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/UpsampleOpRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/UpsampleOpRewritePattern.h
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_UPSAMPLEOPREWRITEPATTERN_H
+#define TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_UPSAMPLEOPREWRITEPATTERN_H
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+// UpsampleOp in `bilinear` mode expects the input to be in `HeightSharded`
+// memory layout. This pattern converts the input tensor to the target memory
+// layout, provided that the input tensor is already in a `RowMajor` layout and
+// has `BFloat16` data type, and that the channel axis is a multiple of the tile
+// width.
+// tt-metal issue: https://github.com/tenstorrent/tt-metal/issues/18399
+class UpsampleOpBilinearShardingRewritePattern
+    : public OpRewritePattern<ttnn::UpsampleOp> {
+public:
+  UpsampleOpBilinearShardingRewritePattern(MLIRContext *ctx)
+      : OpRewritePattern<ttnn::UpsampleOp>(ctx, /*benefit=*/1) {}
+
+  LogicalResult matchAndRewrite(ttnn::UpsampleOp srcOp,
+                                PatternRewriter &rewriter) const override;
+};
+
+// This pattern is a prerequisite (hence the `2` benefit) for the
+// `UpsampleOpBilinearShardingRewritePattern`. `Channel` axis of the input has
+// to be a multiple of the tile width.
+class UpsampleOpBilinearPaddingRewritePattern
+    : public OpRewritePattern<ttnn::UpsampleOp> {
+public:
+  UpsampleOpBilinearPaddingRewritePattern(MLIRContext *ctx)
+      : OpRewritePattern<ttnn::UpsampleOp>(ctx, /*benefit=*/2) {}
+
+  LogicalResult matchAndRewrite(ttnn::UpsampleOp srcOp,
+                                PatternRewriter &rewriter) const override;
+};
+
+// UpsampleOp expects the input to be in `RowMajor` layout and has `BFloat16`
+// data type. This pattern converts the input tensor to the target memory
+// configuration.
+class UpsampleOpLayoutRewritePattern
+    : public OpRewritePattern<ttnn::UpsampleOp> {
+public:
+  UpsampleOpLayoutRewritePattern(MLIRContext *ctx)
+      : OpRewritePattern<ttnn::UpsampleOp>(ctx, /*benefit=*/10) {}
+
+  LogicalResult matchAndRewrite(ttnn::UpsampleOp srcOp,
+                                PatternRewriter &rewriter) const override;
+};
+} // namespace mlir::tt::ttnn::workarounds::decomposition
+
+#endif // TTMLIR_DIALECT_TTNN_TRANSFORMS_WORKAROUNDS_DECOMPOSITION_UPSAMPLEOPREWRITEPATTERN_H

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -8,6 +8,7 @@
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 #include "ttmlir/Dialect/TTCore/Utils/CoreRangeSet.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/Utils/OptimizerUtils.h"
 #include "ttmlir/Target/Common/Target.h"
 #include "ttmlir/Target/TTNN/Target.h"
 #include "ttmlir/Target/TTNN/utils.h"
@@ -913,8 +914,28 @@ toFlatbuffer(FlatbufferObjectCache &cache, mlir::MemRefType memref,
       assert(shape.size() == 2);
       shape[0] *= tileShape.y();
       shape[1] *= tileShape.x();
+
+      auto coreRangeSetAttr = ttnn::CoreRangeSetAttr::get(
+          ctx, llvm::map_to_vector(
+                   ttcore::utils::toCoreRangeSet(
+                       shardGrid.getShape(),
+                       ttnn::optimizer_utils::
+                           createSingleDeviceVirtualToPhysicalAffineMap(
+                               ctx, memLayoutAttr.getValue(),
+                               deviceGrid.getShape())),
+                   [ctx](const auto &range) {
+                     const auto [loc, size] = range;
+                     return ttnn::CoreRangeAttr::get(
+                         ctx, ttnn::CoreCoordAttr::get(ctx, loc[0], loc[1]),
+                         ttnn::CoreCoordAttr::get(ctx, loc[0] + size[0] - 1,
+                                                  loc[1] + size[1] - 1));
+                   }));
       shardSpecAttr = ttnn::ShardSpecAttr::get(
-          ctx, ttnn::ShapeAttr::get(ctx, shape), shardGrid, deviceGrid);
+          ctx, coreRangeSetAttr, ttnn::ShapeAttr::get(ctx, shape),
+          ttnn::ShardOrientationAttr::get(ctx,
+                                          ttnn::ShardOrientation::RowMajor),
+          ttnn::ShardModeAttr::get(ctx, ttnn::ShardMode::Physical),
+          /*physical_shard_shape=*/nullptr);
     }
     auto memoryConfigAttr = ::mlir::tt::ttnn::MemoryConfigAttr::get(
         ctx, memLayoutAttr, bufferTypeAttr, shardSpecAttr);

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -162,7 +162,7 @@ TTNNOperandsWorkaroundsFactory::createEmbeddingBackwardOpOperandsWorkarounds() {
       .addOutputOperandWorkaround(bf16Workaround);
 }
 
-// Factory method to create a set of workarounds for UpsampleO. The UpsampleOp
+// Factory method to create a set of workarounds for UpsampleOp. The UpsampleOp
 // expects the input to be in row-major layout and to use the bf16 data type.
 // Since the output of the UpsampleOp follows the same format as the input
 // operand, the same workaround is applied to the output operand.

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -89,7 +89,9 @@ void createTTNNPipelineAnalysisPasses(
     optimizerOptions.maxLegalLayouts = options.maxLegalLayouts;
     optimizerOptions.rowMajorEnabled = options.rowMajorEnabled;
     pm.addPass(mlir::tt::ttnn::createTTNNOptimizer(optimizerOptions));
+    pm.addPass(mlir::createCanonicalizerPass());
     pm.addPass(mlir::tt::ttnn::createTTNNPrepareConv2dWeightsAndBias());
+    pm.addPass(mlir::tt::ttnn::createTTNNPrepareConv2dWeights());
   }
 }
 

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -91,7 +91,6 @@ void createTTNNPipelineAnalysisPasses(
     pm.addPass(mlir::tt::ttnn::createTTNNOptimizer(optimizerOptions));
     pm.addPass(mlir::createCanonicalizerPass());
     pm.addPass(mlir::tt::ttnn::createTTNNPrepareConv2dWeightsAndBias());
-    pm.addPass(mlir::tt::ttnn::createTTNNPrepareConv2dWeights());
   }
 }
 

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -19,6 +19,7 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         Workarounds/Decomposition/MultiplyOpDecompositionRewritePattern.cpp
         Workarounds/Decomposition/ReduceOpsRewritePattern.cpp
         Workarounds/Decomposition/RepeatOpRewritePattern.cpp
+        Workarounds/Decomposition/UpsampleOpRewritePattern.cpp
         Workarounds/TTNNWorkaroundsPatterns.cpp
 
         ADDITIONAL_HEADER_DIRS

--- a/lib/Dialect/TTNN/Transforms/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/Optimizer.cpp
@@ -966,14 +966,14 @@ private:
       }
 
       // Let's check first if the op can be executed with the current layout.
-      if (auto expectedOutputLayout =
+      if (auto actualOutputLayout =
               checkOpConstraints(op, inputLayouts, l1CacheSize,
                                  /*convertInputToRowMajor=*/false)) {
         // If output layout is different from the expected one, we need to
         // convert the output type to the expected one.
-        if (expectedOutputLayout != resultLayout) {
+        if (actualOutputLayout != resultLayout) {
           op->getResult(0).setType(
-              resultType.cloneWithEncoding(expectedOutputLayout));
+              resultType.cloneWithEncoding(actualOutputLayout));
         }
         TTMLIR_DEBUG(ttmlir::LogComponent::Optimizer,
                      "Successfully passed constraints, no conversion needed");

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/UpsampleOpRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/UpsampleOpRewritePattern.cpp
@@ -1,0 +1,369 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/UpsampleOpRewritePattern.h"
+
+#include "ttmlir/Dialect/TTCore/IR/Utils.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/Utils/TransformUtils.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+#include "ttmlir/Utils.h"
+
+#include "mlir/Support/LLVM.h"
+#include "llvm/Support/ErrorHandling.h"
+
+#include <cstdint>
+
+namespace mlir::tt::ttnn::workarounds::decomposition {
+namespace {
+enum UpsampleAxisLayout {
+  BATCH = 0,
+  HEIGHT = 1,
+  WIDTH = 2,
+  CHANNEL = 3,
+  DIM_COUNT = 4
+};
+
+constexpr int64_t TILE_WIDTH = ttcore::TileType::getDefaultShape()[1];
+
+int64_t getNumCores(llvm::ArrayRef<int64_t> workerGridShape, int64_t batchSize,
+                    int64_t height, int64_t width) {
+  assert(workerGridShape.size() == 2 && "worker grid shape must be 2D");
+
+  int64_t numCores = std::min(batchSize * height * width,
+                              workerGridShape[0] * workerGridShape[1]);
+  // For height sharding strategy, we need to find the largest number of cores
+  // such that whole image (H, W) is kept in a single shard.
+  while (numCores > 0) {
+    if (batchSize * height % numCores == 0) {
+      return numCores;
+    }
+    --numCores;
+  }
+
+  llvm_unreachable("proof that numCores >= 1 is trivial");
+}
+
+ttnn::CoreRangeSetAttr getShardGrid(MLIRContext *ctx,
+                                    llvm::ArrayRef<int64_t> workerGridShape,
+                                    int64_t numCores) {
+  int64_t workerGridX = workerGridShape[0];
+
+  // If `numCores` is less than `workerGridX`, we can use a single row of cores.
+  if (numCores < workerGridX) {
+    return ttnn::CoreRangeSetAttr::get(
+        ctx, /*core_ranges=*/{ttnn::CoreRangeAttr::get(
+            ctx,
+            /*start_coord=*/ttnn::CoreCoordAttr::get(ctx, /*x=*/0, /*y=*/0),
+            /*end_coord=*/
+            ttnn::CoreCoordAttr::get(ctx, /*x=*/numCores - 1, /*y=*/0))});
+  }
+
+  // If `numCores` is a multiple of `workerGridX`, we can use a full grid of
+  // cores.
+  if (numCores % workerGridX == 0) {
+    int64_t coreGridHeight = numCores / workerGridX;
+    return ttnn::CoreRangeSetAttr::get(
+        ctx,
+        /*core_ranges=*/{ttnn::CoreRangeAttr::get(
+            ctx,
+            /*start_coord=*/ttnn::CoreCoordAttr::get(ctx, /*x=*/0, /*y=*/0),
+            /*end_coord=*/
+            ttnn::CoreCoordAttr::get(ctx, /*x=*/workerGridX - 1,
+                                     /*y=*/coreGridHeight - 1))});
+  }
+
+  // Otherwise, we need to split the cores into two ranges, where the first
+  // range is a grid of maximal height, and the second range is partially filled
+  // row.
+  int64_t coreGridXLarger = workerGridX;
+  int64_t coreGridYLarger = numCores / coreGridXLarger;
+
+  int64_t remainingCores = numCores % coreGridXLarger;
+  int64_t coreGridXSmaller = remainingCores;
+  int64_t coreGridYSmaller = coreGridYLarger + 1;
+
+  return ttnn::CoreRangeSetAttr::get(
+      ctx, /*core_ranges=*/{
+          ttnn::CoreRangeAttr::get(
+              ctx,
+              /*start_coord=*/ttnn::CoreCoordAttr::get(ctx, /*x=*/0, /*y=*/0),
+              /*end_coord=*/
+              ttnn::CoreCoordAttr::get(ctx, /*x=*/coreGridXLarger - 1,
+                                       /*y=*/coreGridYLarger - 1)),
+          ttnn::CoreRangeAttr::get(
+              ctx, /*start_coord=*/
+              ttnn::CoreCoordAttr::get(ctx, /*x=*/0,
+                                       /*y=*/coreGridYSmaller - 1),
+              /*end_coord=*/
+              ttnn::CoreCoordAttr::get(ctx, /*x=*/coreGridXSmaller - 1,
+                                       /*y=*/coreGridYSmaller - 1))});
+}
+} // namespace
+
+LogicalResult UpsampleOpBilinearShardingRewritePattern::matchAndRewrite(
+    ttnn::UpsampleOp srcOp, PatternRewriter &rewriter) const {
+  if (srcOp.getMode() != "bilinear") {
+    return failure();
+  }
+
+  RankedTensorType inputType = srcOp.getInput().getType();
+
+  // UpsampleOp in `bilinear` mode expects the input to be in `HeightSharded`
+  // memory layout, hence if it's already in that layout, we don't need to do
+  // anything.
+  if (auto inputMemoryLayout =
+          mlir::cast<ttnn::TTNNLayoutAttr>(inputType.getEncoding())
+              .getMemLayout();
+      inputMemoryLayout &&
+      inputMemoryLayout.getValue() == ttnn::TensorMemoryLayout::HeightSharded) {
+    return failure();
+  }
+
+  auto inputBatch = inputType.getDimSize(BATCH);
+  auto inputHeight = inputType.getDimSize(HEIGHT);
+  auto inputWidth = inputType.getDimSize(WIDTH);
+  auto inputChannel = inputType.getDimSize(CHANNEL);
+
+  assert(inputChannel % TILE_WIDTH == 0 &&
+         "input channel size must be a multiple of tile width");
+
+  // We need to find strategy for sharding the input tensor.
+  ttcore::GridAttr workerGrid =
+      ttcore::lookupDevice(srcOp.getOperation()).getWorkerGrid();
+  auto numCores =
+      getNumCores(workerGrid.getShape(), inputBatch, inputHeight, inputWidth);
+  ttnn::CoreRangeSetAttr shardGrid =
+      getShardGrid(getContext(), workerGrid.getShape(), numCores);
+
+  // We are using `HeightSharded` memory layout for the input tensor, hence the
+  // shards are split by first three dimensions (N, H, W).
+  auto inputShardHeight = inputBatch * inputHeight * inputWidth / numCores;
+  auto inputShardWidth = inputChannel;
+  auto inputShardShape = ttnn::ShapeAttr::get(
+      getContext(), /*shape=*/{inputShardHeight, inputShardWidth});
+  auto inputShardSpec = ttnn::ShardSpecAttr::get(
+      getContext(), shardGrid, inputShardShape,
+      ttnn::ShardOrientationAttr::get(getContext(),
+                                      ttnn::ShardOrientation::RowMajor),
+      ttnn::ShardModeAttr::get(getContext(), ttnn::ShardMode::Physical),
+      /*physical_shard_shape=*/nullptr);
+
+  auto inputShardedLayout = ttnn::TTNNLayoutAttr::get(
+      getContext(), inputType.getShape(), inputType.getElementType(),
+      ttnn::BufferType::L1,
+      ttcore::GridAttr::get(getContext(), /*shape=*/{numCores, 1}),
+      ttnn::TensorMemoryLayoutAttr::get(
+          getContext(), ttnn::TensorMemoryLayout::HeightSharded));
+  assert(inputShardedLayout.getLayout() == ttnn::Layout::RowMajor &&
+         "expected RowMajor layout");
+  auto inputShardedMemoryConfig = ttnn::MemoryConfigAttr::get(
+      getContext(),
+      ttnn::TensorMemoryLayoutAttr::get(
+          getContext(), ttnn::TensorMemoryLayout::HeightSharded),
+      ttnn::BufferTypeAttr::get(getContext(), ttnn::BufferType::L1),
+      inputShardSpec);
+
+  // Convert the input tensor to the target memory configuration.
+  auto inputToMemoryConfigOp = rewriter.create<ttnn::ToMemoryConfigOp>(
+      ttmlir::utils::appendLocationSuffix(srcOp.getInput().getLoc(),
+                                          "to_memory_config"),
+      inputType.cloneWithEncoding(inputShardedLayout), srcOp.getInput(),
+      inputShardedMemoryConfig);
+
+  auto scaleFactor =
+      ttmlir::utils::getPairOfInteger<int32_t>(srcOp.getScaleFactor());
+  if (auto error = scaleFactor.takeError()) {
+    llvm_unreachable(llvm::toString(std::move(error)).c_str());
+  }
+  const auto scaleH = scaleFactor->first;
+  const auto scaleW = scaleFactor->second;
+
+  auto outputShardHeight = inputShardHeight * scaleH * scaleW;
+  auto outputShardWidth = inputShardWidth;
+  auto outputShardShape = ttnn::ShapeAttr::get(
+      getContext(), /*shape=*/{outputShardHeight, outputShardWidth});
+  auto outputShardSpec = ttnn::ShardSpecAttr::get(
+      getContext(), shardGrid, outputShardShape,
+      ttnn::ShardOrientationAttr::get(getContext(),
+                                      ttnn::ShardOrientation::RowMajor),
+      ttnn::ShardModeAttr::get(getContext(), ttnn::ShardMode::Physical),
+      /*physical_shard_shape=*/nullptr);
+  auto outputShardedLayout = ttnn::TTNNLayoutAttr::get(
+      getContext(), srcOp.getType().getShape(),
+      srcOp.getType().getElementType(), ttnn::BufferType::L1,
+      ttcore::GridAttr::get(getContext(), /*shape=*/{numCores, 1}),
+      ttnn::TensorMemoryLayoutAttr::get(
+          getContext(), ttnn::TensorMemoryLayout::HeightSharded));
+  auto outputShardedMemoryConfig = ttnn::MemoryConfigAttr::get(
+      getContext(),
+      ttnn::TensorMemoryLayoutAttr::get(
+          getContext(), ttnn::TensorMemoryLayout::HeightSharded),
+      ttnn::BufferTypeAttr::get(getContext(), ttnn::BufferType::L1),
+      outputShardSpec);
+
+  // UpsampleOp is done on height sharded input, and produces height shraded
+  // output.
+  auto shardedUpsampleOp = rewriter.create<ttnn::UpsampleOp>(
+      srcOp.getLoc(), srcOp.getType().cloneWithEncoding(outputShardedLayout),
+      inputToMemoryConfigOp, srcOp.getScaleFactorAttr(), srcOp.getModeAttr(),
+      outputShardedMemoryConfig);
+
+  auto outputLayout =
+      mlir::cast<ttnn::TTNNLayoutAttr>(srcOp.getType().getEncoding());
+  auto outputMemoryConfig = ttnn::MemoryConfigAttr::get(
+      getContext(), outputLayout.getMemLayout(),
+      ttnn::BufferTypeAttr::get(getContext(), outputLayout.getBufferType()),
+      ttnn::utils::createShardSpecIfNeeded(outputLayout, workerGrid));
+
+  // Since the output of the new UpsampleOp is height sharded, we need to
+  // convert it back to the original memory configuration.
+  auto outputToMemoryConfigOp = rewriter.create<ttnn::ToMemoryConfigOp>(
+      ttmlir::utils::appendLocationSuffix(shardedUpsampleOp.getLoc(),
+                                          "to_memory_config"),
+      shardedUpsampleOp.getType().cloneWithEncoding(outputLayout),
+      shardedUpsampleOp, outputMemoryConfig);
+  rewriter.replaceOp(srcOp, outputToMemoryConfigOp);
+
+  return success();
+}
+
+LogicalResult UpsampleOpBilinearPaddingRewritePattern::matchAndRewrite(
+    ttnn::UpsampleOp srcOp, PatternRewriter &rewriter) const {
+  if (srcOp.getMode() != "bilinear") {
+    return failure();
+  }
+
+  RankedTensorType inputType = srcOp.getInput().getType();
+
+  // UpsampleOp in `bilinear` mode expects CHANNEL dimension to be a multiple of
+  // TILE_WIDTH, hence we don't apply this pattern if that's already the case.
+  if (inputType.getDimSize(CHANNEL) % TILE_WIDTH == 0) {
+    return failure();
+  }
+
+  // Calculate padded dimension size (round up to nearest multiple of
+  // TILE_WIDTH).
+  int64_t originalChannelSize = inputType.getDimSize(CHANNEL);
+  int64_t paddedChannelSize =
+      llvm::divideCeil(originalChannelSize, TILE_WIDTH) * TILE_WIDTH;
+  int64_t paddingAmount = paddedChannelSize - originalChannelSize;
+
+  // Create padding configuration - PadOp uses a single padding array with pairs
+  // (low, high) for each axis.
+  SmallVector<int32_t> padding(DIM_COUNT * 2, 0);
+  padding[CHANNEL * 2 + 1] = paddingAmount;
+
+  SmallVector<int64_t> paddedShape(inputType.getShape());
+  paddedShape[CHANNEL] = paddedChannelSize;
+
+  auto paddedType = RankedTensorType::get(
+      paddedShape, inputType.getElementType(),
+      mlir::cast<ttnn::TTNNLayoutAttr>(inputType.getEncoding())
+          .withTensorShape(paddedShape));
+
+  auto padOp = rewriter.create<ttnn::PadOp>(
+      ttmlir::utils::appendLocationSuffix(srcOp.getInput().getLoc(), "pad"),
+      paddedType, srcOp.getInput(), padding, /*pad_value=*/mlir::APFloat(0.0f),
+      /*use_multicore=*/false,
+      /*memory_config=*/nullptr);
+
+  RankedTensorType outputType = srcOp.getResult().getType();
+  llvm::SmallVector<int64_t> upsamplePaddedShape(outputType.getShape());
+  upsamplePaddedShape[CHANNEL] = paddedChannelSize;
+
+  auto upsampledPaddedType = RankedTensorType::get(
+      upsamplePaddedShape, outputType.getElementType(),
+      mlir::cast<ttnn::TTNNLayoutAttr>(outputType.getEncoding())
+          .withTensorShape(upsamplePaddedShape));
+
+  auto paddedUpsampleOp = rewriter.create<ttnn::UpsampleOp>(
+      srcOp.getLoc(), upsampledPaddedType, padOp, srcOp.getScaleFactorAttr(),
+      srcOp.getModeAttr(), /*memory_config=*/nullptr);
+
+  // Create SliceOp to remove padding from the upsampled result.
+  SmallVector<int32_t> begins(/*size=*/DIM_COUNT, /*value=*/0);
+  SmallVector<int32_t> ends(outputType.getShape());
+  SmallVector<int32_t> steps(/*size=*/DIM_COUNT, /*value=*/1);
+
+  auto sliceOp = rewriter.create<ttnn::SliceOp>(
+      ttmlir::utils::appendLocationSuffix(srcOp.getLoc(), "slice"), outputType,
+      paddedUpsampleOp, rewriter.getI32ArrayAttr(begins),
+      rewriter.getI32ArrayAttr(ends), rewriter.getI32ArrayAttr(steps));
+
+  rewriter.replaceOp(srcOp, sliceOp);
+
+  return success();
+}
+
+LogicalResult UpsampleOpLayoutRewritePattern::matchAndRewrite(
+    ttnn::UpsampleOp srcOp, PatternRewriter &rewriter) const {
+  auto inputType = srcOp.getInput().getType();
+  auto outputType = srcOp.getType();
+
+  constexpr ttnn::Layout TARGET_LAYOUT = ttnn::Layout::RowMajor;
+  constexpr ttcore::DataType TARGET_DTYPE = ttcore::DataType::BFloat16;
+
+  auto inputLayoutAttr =
+      mlir::cast<ttnn::TTNNLayoutAttr>(inputType.getEncoding());
+  auto outputLayoutAttr =
+      mlir::cast<ttnn::TTNNLayoutAttr>(outputType.getEncoding());
+
+  // UpsampleOp expects the input and the output in `RowMajor` layout, and with
+  // `BFloat16` data type. Hence, if the condition is already met, we don't need
+  // to do anything.
+  if (!inputLayoutAttr.isTiled() && !outputLayoutAttr.isTiled() &&
+      inputLayoutAttr.getElementType().isBF16() &&
+      outputLayoutAttr.getElementType().isBF16()) {
+    return failure();
+  }
+
+  // Convert the input to `RowMajor` layout with `BFloat16` data type.
+  auto inputToLayoutOp = ttnn::utils::createToLayoutOp(
+      srcOp.getOperation(), srcOp.getInput(), rewriter, TARGET_LAYOUT,
+      inputLayoutAttr.getBufferType(), inputLayoutAttr.getMemLayoutOpt(),
+      TARGET_DTYPE, "to_layout");
+
+  // Information about new layout and data type needs to be encoded in the
+  // target output type.
+  auto targetElementType =
+      ttnn::utils::getElementType(getContext(), TARGET_LAYOUT, TARGET_DTYPE);
+  auto targetOutputType =
+      outputType
+          .cloneWithEncoding(outputLayoutAttr.withElementType(
+              targetElementType, outputType.getShape()))
+          .clone(targetElementType);
+
+  // UpsampleOp is replace with the new one, that takes the input in the target
+  // configuration, and produces the output in the target configuration.
+  auto targetLayoutUpsampleOp = rewriter.create<ttnn::UpsampleOp>(
+      srcOp.getLoc(), targetOutputType, inputToLayoutOp,
+      srcOp.getScaleFactorAttr(), srcOp.getModeAttr(),
+      /*memory_config=*/nullptr);
+
+  ttnn::MemoryConfigAttr outputMemoryConfig = srcOp.getMemoryConfigAttr();
+  if (!outputMemoryConfig) {
+    ttcore::DeviceAttr deviceAttr = ttcore::lookupDevice(srcOp);
+
+    outputMemoryConfig = ttnn::MemoryConfigAttr::get(
+        rewriter.getContext(), outputLayoutAttr.getMemLayout(),
+        ttnn::BufferTypeAttr::get(rewriter.getContext(),
+                                  outputLayoutAttr.getBufferType()),
+        utils::createShardSpecIfNeeded(outputLayoutAttr,
+                                       deviceAttr.getWorkerGrid()));
+  }
+
+  // Convert the output back to the original memory configuration.
+  auto outputToLayoutOp = rewriter.create<ttnn::ToLayoutOp>(
+      ttmlir::utils::appendLocationSuffix(targetLayoutUpsampleOp.getLoc(),
+                                          "to_layout"),
+      outputType, targetLayoutUpsampleOp, outputLayoutAttr.getLayout(),
+      ttcore::DataTypeAttr::get(getContext(), outputLayoutAttr.getDataType()),
+      outputMemoryConfig);
+  rewriter.replaceOp(srcOp, outputToLayoutOp);
+
+  return success();
+}
+} // namespace mlir::tt::ttnn::workarounds::decomposition

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -16,6 +16,7 @@
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/MultiplyOpDecompositionRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/ReduceOpsRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/RepeatOpRewritePattern.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Workarounds/Decomposition/UpsampleOpRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Utils/TransformUtils.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 #include "ttmlir/Utils.h"
@@ -275,7 +276,6 @@ public:
 
   LogicalResult matchAndRewrite(wa::TTNNWorkaroundInterface op,
                                 PatternRewriter &rewriter) const final {
-
     if (!enabledOps->count(op.getOperation()->getName().getStringRef())) {
       return failure();
     }
@@ -741,6 +741,9 @@ public:
               ttnn::MaxOp>,
           workarounds::decomposition::ReduceOpsPadInputRewritePattern<
               ttnn::MinOp>,
+          workarounds::decomposition::UpsampleOpBilinearShardingRewritePattern,
+          workarounds::decomposition::UpsampleOpBilinearPaddingRewritePattern,
+          workarounds::decomposition::UpsampleOpLayoutRewritePattern,
           workarounds::decomposition::MultiplyOpDecompositionRewritePattern>(
           &getContext());
 

--- a/lib/Dialect/TTNN/Utils/TransformUtils.cpp
+++ b/lib/Dialect/TTNN/Utils/TransformUtils.cpp
@@ -93,7 +93,7 @@ createToLayoutOp(Operation *op, mlir::TypedValue<RankedTensorType> inputValue,
 
   Location loc = ttmlir::utils::appendLocationSuffix(op->getLoc(), locSuffix);
   // Create a ToLayoutOp to convert the input operand to the desired
-  // tensor layout, buffer type and memory layout.o
+  // tensor layout, buffer type and memory layout.
   return rewriter.create<ttnn::ToLayoutOp>(
       loc, toLayoutOpResultType, inputValue,
       LayoutAttr::get(rewriter.getContext(), targetTensorLayout),

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/upsample_sharding_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/upsample_sharding_workaround.mlir
@@ -1,0 +1,43 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttnn-workaround --canonicalize %s | FileCheck %s
+
+#dram = #ttnn.buffer_type<dram>
+#l1 = #ttnn.buffer_type<l1>
+
+#layout_tile_interleaved = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 256 + d1 * 32 + d2, d3), <1x1>, memref<8x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#layout_tile_interleaved_out = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 512 + d1 * 32 + d2, d3), <1x1>, memref<16x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+
+module {
+  func.func @test_layout_padding_sharding(%arg0: tensor<1x8x8x30xf32, #layout_tile_interleaved>) -> tensor<1x16x16x30xf32, #layout_tile_interleaved_out> {
+    // CHECK: %[[TO_ROWMAJOR:.*]] = "ttnn.to_layout"(%arg0)
+    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<bf16>
+    // CHECK-SAME: layout = #ttnn.layout<row_major>
+    // CHECK: %[[PADDED:.*]] = "ttnn.pad"(%[[TO_ROWMAJOR]])
+    // CHECK-SAME: padding = array<i32: 0, 0, 0, 0, 0, 0, 0, 2>
+    // CHECK: %[[TO_SHARDED:.*]] = "ttnn.to_memory_config"(%[[PADDED]])
+    // CHECK-SAME: memory_config = #ttnn.memory_config<#l1, <height_sharded>
+    // CHECK: %[[UPSAMPLE:.*]] = "ttnn.upsample"(%[[TO_SHARDED]])
+    // CHECK-SAME: mode = "bilinear"
+    // CHECK: %[[TO_INTERLEAVED:.*]] = "ttnn.to_memory_config"(%[[UPSAMPLE]])
+    // CHECK-SAME: memory_config = #ttnn.memory_config<#dram, <interleaved>>
+    // CHECK: %[[SLICED:.*]] = "ttnn.slice"(%[[TO_INTERLEAVED]])
+    // CHECK-SAME: begins = [0 : i32, 0 : i32, 0 : i32, 0 : i32]
+    // CHECK-SAME: ends = [1 : i32, 16 : i32, 16 : i32, 30 : i32]
+    // CHECK: %[[TO_TILE:.*]] = "ttnn.to_layout"(%[[SLICED]])
+    // CHECK-SAME: dtype = #ttcore.supportedDataTypes<f32>
+    // CHECK-SAME: layout = #ttnn.layout<tile>
+    %1 = "ttnn.upsample"(%arg0) <{mode = "bilinear", scale_factor = 2 : si32}> : (tensor<1x8x8x30xf32, #layout_tile_interleaved>) -> tensor<1x16x16x30xf32, #layout_tile_interleaved_out>
+    return %1 : tensor<1x16x16x30xf32, #layout_tile_interleaved_out>
+  }
+
+  func.func @test_no_workarounds_needed(%arg0: tensor<1x16x16x32xbf16, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 512 + d1 * 16 + d2, d3), <16x1>, memref<16x32xbf16, #l1>, <height_sharded>>>) -> tensor<1x32x32x32xbf16, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 32 + d2, d3), <16x1>, memref<64x32xbf16, #l1>, <height_sharded>>> {
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+    // CHECK: %[[UPSAMPLE:.*]] = "ttnn.upsample"(%arg0)
+    // CHECK-SAME: mode = "bilinear"
+    // CHECK-NOT: "ttnn.to_layout"
+    // CHECK-NOT: "ttnn.pad"
+    // CHECK-NOT: "ttnn.slice"
+    // CHECK-NOT: "ttnn.to_memory_config"
+    %1 = "ttnn.upsample"(%arg0) <{mode = "bilinear", scale_factor = 2 : si32}> : (tensor<1x16x16x32xbf16, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 512 + d1 * 16 + d2, d3), <16x1>, memref<16x32xbf16, #l1>, <height_sharded>>>) -> tensor<1x32x32x32xbf16, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 32 + d2, d3), <16x1>, memref<64x32xbf16, #l1>, <height_sharded>>>
+    return %1 : tensor<1x32x32x32xbf16, #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1024 + d1 * 32 + d2, d3), <16x1>, memref<64x32xbf16, #l1>, <height_sharded>>>
+  }
+}

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/upsample_layout_workaround.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/upsample_layout_workaround.mlir
@@ -1,0 +1,16 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-optimizer=true memory-layout-analysis-enabled=true" -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+
+// CHECK-DAG: #[[INPUT_LAYOUT:.*]] = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 400 + d1 * 20 + d2, d3), <1x1>, memref<400x640xbf16, #dram>, <interleaved>>
+// CHECK-DAG: #[[OUTPUT_LAYOUT:.*]] = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 1600 + d1 * 40 + d2, d3), <1x1>, memref<1600x640xbf16, #dram>, <interleaved>>
+
+func.func @main(%arg0: tensor<1x20x20x640xbf16>) -> tensor<1x40x40x640xbf16> {
+    %0 = ttir.empty() : tensor<1x40x40x640xbf16>
+    // CHECK: ttnn.upsample
+    // CHECK-SAME: tensor<1x20x20x640xbf16, #[[INPUT_LAYOUT]]>
+    // CHECK-SAME: -> tensor<1x40x40x640xbf16, #[[OUTPUT_LAYOUT]]>
+    %1 = "ttir.upsample2d"(%arg0, %0) <{mode = "nearest", scale_factor = 2 : si32}> {channel_last = true} : (tensor<1x20x20x640xbf16>, tensor<1x40x40x640xbf16>) -> tensor<1x40x40x640xbf16>
+    return %1 : tensor<1x40x40x640xbf16>
+}

--- a/test/ttmlir/Silicon/TTNN/n150/simple_upsample.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_upsample.mlir
@@ -3,21 +3,39 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
 module {
-  func.func @upsample2d_scale_unifrom(%arg0: tensor<4x32x64x3xbf16>) -> tensor<4x64x128x3xbf16> {
+  func.func @upsample2d_scale_uniform(%arg0: tensor<4x32x64x3xbf16>) -> tensor<4x64x128x3xbf16> {
     %0 = ttir.empty() : tensor<4x64x128x3xbf16>
     // CHECK: "ttnn.upsample"
     // CHECK-SAME: tensor<4x32x64x3xbf16
     // CHECK-SAME: tensor<4x64x128x3xbf16
-    %1 = "ttir.upsample2d"(%arg0, %0) <{scale_factor = 2 : si32}> : (tensor<4x32x64x3xbf16>, tensor<4x64x128x3xbf16>) -> tensor<4x64x128x3xbf16>
+    %1 = "ttir.upsample2d"(%arg0, %0) <{scale_factor = 2 : si32, mode = "nearest"}> : (tensor<4x32x64x3xbf16>, tensor<4x64x128x3xbf16>) -> tensor<4x64x128x3xbf16>
     return %1 : tensor<4x64x128x3xbf16>
   }
 
-  func.func @upsample2d_scale_nonunifrom(%arg0: tensor<4x32x64x3xbf16>) -> tensor<4x64x64x3xbf16> {
+  func.func @upsample2d_scale_nonuniform(%arg0: tensor<4x32x64x3xbf16>) -> tensor<4x64x64x3xbf16> {
     %0 = ttir.empty() : tensor<4x64x64x3xbf16>
     // CHECK: "ttnn.upsample"
     // CHECK-SAME: tensor<4x32x64x3xbf16
     // CHECK-SAME: tensor<4x64x64x3xbf16
-    %1 = "ttir.upsample2d"(%arg0, %0) <{scale_factor = array<i32: 2, 1>}> : (tensor<4x32x64x3xbf16>, tensor<4x64x64x3xbf16>) -> tensor<4x64x64x3xbf16>
+    %1 = "ttir.upsample2d"(%arg0, %0) <{scale_factor = array<i32: 2, 1>, mode = "nearest"}> : (tensor<4x32x64x3xbf16>, tensor<4x64x64x3xbf16>) -> tensor<4x64x64x3xbf16>
     return %1 : tensor<4x64x64x3xbf16>
+  }
+
+  func.func @upsample2d_scale_nonuniform_bilinear(%arg0: tensor<4x32x64x32xbf16>) -> tensor<4x96x128x32xbf16> {
+    %0 = ttir.empty() : tensor<4x96x128x32xbf16>
+    %1 = "ttir.upsample2d"(%arg0, %0) <{scale_factor = array<i32: 3, 2>, mode = "bilinear"}> : (tensor<4x32x64x32xbf16>, tensor<4x96x128x32xbf16>) -> tensor<4x96x128x32xbf16>
+    return %1 : tensor<4x96x128x32xbf16>
+  }
+
+  func.func @upsample2d_scale_uniform_bilinear(%arg0: tensor<4x32x64x32xbf16>) -> tensor<4x96x192x32xbf16> {
+    %0 = ttir.empty() : tensor<4x96x192x32xbf16>
+    %1 = "ttir.upsample2d"(%arg0, %0) <{scale_factor = 3 : si32, mode = "bilinear"}> : (tensor<4x32x64x32xbf16>, tensor<4x96x192x32xbf16>) -> tensor<4x96x192x32xbf16>
+    return %1 : tensor<4x96x192x32xbf16>
+  }
+
+  func.func @upsample2d_scale_uniform_bilinear_misaligned_channel(%arg0: tensor<4x32x64x37xbf16>) -> tensor<4x96x192x37xbf16> {
+    %0 = ttir.empty() : tensor<4x96x192x37xbf16>
+    %1 = "ttir.upsample2d"(%arg0, %0) <{scale_factor = 3 : si32, mode = "bilinear"}> : (tensor<4x32x64x37xbf16>, tensor<4x96x192x37xbf16>) -> tensor<4x96x192x37xbf16>
+    return %1 : tensor<4x96x192x37xbf16>
   }
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/3396
https://github.com/tenstorrent/tt-mlir/issues/4051

### Problem description
Commit from https://github.com/tenstorrent/tt-mlir/pull/3978 had to be reverted because of some friction between the way optmizer and TTNN workarounds treat workarounds.

### What's changed
- Reapply those changes
- Made some changes in optimizer necessary for this workaround to work correctly

### Checklist
- [x] New/Existing tests provide coverage for changes
