### PR TITLE
Simplifying/canonicalizing affine map creation

### DIFF
--- a/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
+++ b/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
@@ -685,7 +685,7 @@ mlir::AffineMap collapsedLinearAffineMap(
     map = map.insertResult(getAffineConstantExpr(0, context), 0);
   }
 
-  return map;
+  return mlir::simplifyAffineMap(map);
 }
 
 mlir::SmallVector<std::int64_t>

--- a/test/ttmlir/Dialect/TTNN/Transforms/DecomposeLayouts/decompose_layouts_affine_map_test.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/DecomposeLayouts/decompose_layouts_affine_map_test.mlir
@@ -1,0 +1,28 @@
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttnn-decompose-layouts %s | FileCheck %s
+//
+// We expect AffineMaps to be uniqued in MLIR, so identical types (e.g., return operand and function result)
+// should compare equal if their affine expressions are mathematically equivalent (among other properties).
+//
+// However, prior to this fix, we were constructing a new AffineMap programmatically for the return type,
+// which produced an equivalent but structurally different expression tree from the one parsed in the function signature.
+//
+// This led to type mismatches during verification, even though the printed types appeared identical:
+//
+//   error: type of return operand 0 (...) doesn't match function result type (...) in function @forward
+//
+// The mismatch occurred because MLIR compares AffineMaps by structural identity, not by semantic equality.
+//
+// We resolved this by simplifying and canonicalizing the programmatically generated affine map,
+// ensuring its internal structure matches the parsed one and enabling proper unification.
+
+#dram = #ttnn.buffer_type<dram>
+#ttnn_layout_dram_rm = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 8 + d1 * 8 + d2, d3), <1x1>, memref<8x2048xbf16, #ttnn.buffer_type<dram>>, <interleaved>>
+#ttnn_layout_dram_tile = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1 * 32 + d2, d3), <1x1>, memref<1x64x!ttcore.tile<32x32, bf16>, #ttnn.buffer_type<dram>>, <interleaved>>
+module {
+  func.func @forward(%arg0: tensor<1x1x8x2048xbf16, #ttnn_layout_dram_rm>) -> tensor<1x1x8x2048xbf16, #ttnn_layout_dram_tile> {
+    %0 = "ttnn.to_layout"(%arg0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>}> : (tensor<1x1x8x2048xbf16, #ttnn_layout_dram_rm>) -> tensor<1x1x8x2048xbf16, #ttnn_layout_dram_tile>
+    // CHECK: "ttnn.to_layout"
+    // CHECK-SAME: layout = #ttnn.layout<tile>
+    return %0 : tensor<1x1x8x2048xbf16, #ttnn_layout_dram_tile>
+  }
+}


### PR DESCRIPTION
### Ticket
N/A

### Problem description
TTNNLayout has an affine map object, which is immutable and unique per MLIR's framework.

An affine map consists of:
- Number of dims
- Number of symbols
- Number of affine map results in the form of AffineExpr

Affine expressions are problematic because, essentially, they are expression trees, and the generated hash depends on the order of grouped subexpressions. For example, a function signature and a return op can have the same printed affine map object:
(d0, d1, d2, d3) -> (d0 * 32 + d1 * 32 + d2, d3)

For the func op, which uses the MLIR parser to parse the Affine Map, it groups affine expressions:
```
Expr = Expr1 + Expr2
Expr1 = d0 * 32 + d1 * 32
Expr2 = d2
```
While the return op can have the AffineExpr:
```
Expr = Expr1 + Expr2
Expr1  = d0*32
Expr2 = d1*32 + d2
```

Those two expressions, even though they are mathematically equivalent, their structure for hashing is different hence, we are getting the following exception when we create a layout for the return op:
`error: type of return operand 0 (...) doesn't match function result type (...) in function @forward`

### What's changed
Instead of returning a plain Affine map from the utility `collapsedLinearAffineMap` function, we are now returning:
`return mlir::simplifyAffineMap(map);`

This mlir's utility function flattens the affine map and its structure, hence in some way, it canonicalizes it and makes it possible to overcome those issues where two identical affine maps aren't equal.

### Checklist
- [x] New/Existing tests provide coverage for changes
