### PR TITLE
Add fusion pattern to fuse PadOp into PoolingOp padding attribute

### DIFF
--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -834,10 +834,10 @@ public:
     for (uint32_t i = 0; i < padding.size(); i++) {
       newPadding.push_back(padding[i] + op.getPadding()[i]);
     }
-    rewriter.replaceOpWithNewOp<PoolingOp>(
-        op, op.getResultTypes(), newInputs, op.getOutputs(),
-        op.getPoolingMethod(), op.getWindowDimensions(), op.getWindowStrides(),
-        op.getBaseDilations(), op.getWindowDilations(), newPadding);
+    rewriter.modifyOpInPlace(op, [&](PoolingOp &op) {
+      op.getInputsMutable().assign(newInputs);
+      op.setPadding(newPadding);
+    });
 
     return success();
   }

--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -830,8 +830,8 @@ public:
     SmallVector<int64_t> newPadding;
     // We add the padding of the input to the ops current padding
     // in the event the current PoolingOp already has non-zero padding
-    for (uint32_t i = 0; i < padding.size(); i++) {
-      newPadding.push_back(padding[i] + op.getPadding()[i]);
+    for (const auto [a, b]: llvm::zip_equal(padding, op.getPadding())) {
+      newPadding.push_back(a + b);
     }
     rewriter.modifyOpInPlace(op, [&](PoolingOp &op) {
       op.getInputsMutable().assign(newInputs);

--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -803,7 +803,7 @@ private:
   }
 };
 
-class PadPoolingFusionpattern : public mlir::OpRewritePattern<PoolingOp> {
+class PadPoolingFusionPattern : public mlir::OpRewritePattern<PoolingOp> {
 public:
   using mlir::OpRewritePattern<PoolingOp>::OpRewritePattern;
 
@@ -872,7 +872,7 @@ public:
       patterns.add<Conv2dWithMultiply>(&getContext());
       patterns.add<CacheFillUpdatePattern>(&getContext());
 
-      patterns.add<PadPoolingFusionpattern>(&getContext());
+      patterns.add<PadPoolingFusionPattern>(&getContext());
 
       GreedyRewriteConfig config;
       config.setUseTopDownTraversal(true);

--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -817,23 +817,23 @@ public:
         return failure();
       }
       if (!padToCompare) {
-        padToCompare = pad;
+        padToCompare = padOp;
       }
 
-      if (pad.getPadding() != padToCompare.getPadding()) {
+      if (padOp.getPadding() != padToCompare.getPadding()) {
         return failure();
       }
-      newInputs.push_back(pad.getInput());
+      newInputs.push_back(padOp.getInput());
     }
 
     ArrayRef<int32_t> padding = padToCompare.getPadding();
     SmallVector<int64_t> newPadding;
     // We add the padding of the input to the ops current padding
     // in the event the current PoolingOp already has non-zero padding
-    for (const auto [a, b]: llvm::zip_equal(padding, op.getPadding())) {
+    for (const auto [a, b] : llvm::zip_equal(padding, op.getPadding())) {
       newPadding.push_back(a + b);
     }
-    rewriter.modifyOpInPlace(op, [&](PoolingOp &op) {
+    rewriter.modifyOpInPlace(op, [&]() {
       op.getInputsMutable().assign(newInputs);
       op.setPadding(newPadding);
     });

--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -812,11 +812,10 @@ public:
     PadOp padToCompare;
     SmallVector<Value> newInputs;
     for (Value value : op.getInputs()) {
-      if (!value.getDefiningOp<PadOp>()) {
+      PadOp padOp = value.getDefiningOp<PadOp>();
+      if (!padOp) {
         return failure();
       }
-
-      PadOp pad = value.getDefiningOp<PadOp>();
       if (!padToCompare) {
         padToCompare = pad;
       }

--- a/test/ttmlir/Dialect/TTIR/fusing/pooling_pad_fusing.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/pooling_pad_fusing.mlir
@@ -1,0 +1,12 @@
+// RUN: ttmlir-opt %s -ttir-fusing | FileCheck %s
+module {
+  func.func @main(%arg0: tensor<1x64x112x112xbf16>) -> tensor<1x64x56x56xbf16>{
+    // CHECK-NOT: "ttir.pad"
+    // CHECK: padding = array<i64: 0, 0, 0, 0, 1, 1, 1, 1>,
+    %0 = ttir.empty() : tensor<1x64x114x114xbf16>
+    %1 = "ttir.pad"(%arg0, %0) <{padding = array<i32: 0, 0, 0, 0, 1, 1, 1, 1>, value = 0xFF800000 : f32}> : (tensor<1x64x112x112xbf16>, tensor<1x64x114x114xbf16>) -> tensor<1x64x114x114xbf16>
+    %2 = ttir.empty() : tensor<1x64x56x56xbf16>
+    %3 = "ttir.pooling"(%1, %2) <{base_dilations = array<i64: 1, 1, 1, 1>, operandSegmentSizes = array<i32: 1, 1>, padding = array<i64: 0, 0, 0, 0, 0, 0, 0, 0>, pooling_method = #ttir<pooling_method Max>, window_dilations = array<i64: 1, 1, 1, 1>, window_dimensions = array<i64: 1, 1, 3, 3>, window_strides = array<i64: 1, 1, 2, 2>}> : (tensor<1x64x114x114xbf16>, tensor<1x64x56x56xbf16>) -> tensor<1x64x56x56xbf16>
+    return %3: tensor<1x64x56x56xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket
N/A

### Problem description
We may receive an IR which explicitly places padding for a pooling op on the pooling input. This can make it impossible to commute the reshape + permute that is inserted on the input of the op during `TTIRFlattenSlidingWindow`. Also, this is unnecessary. 

### What's changed
Add a pattern to `TTIRFusing` to fuse PadOp into PoolingOp

### Checklist
- [x] New/Existing tests provide coverage for changes
