### PR TITLE
EmitC support for SortOp

### DIFF
--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -2138,6 +2138,12 @@ public:
 
     return success();
   }
+
+private:
+  std::string getPrefixSearchPattern() const override { return "ttnn.sort"; }
+  std::string getPrefixSwapPattern() const override {
+    return "ttnn::experimental::sort";
+  }
 };
 } // namespace
 

--- a/test/ttmlir/EmitC/TTNN/sort/sort.mlir
+++ b/test/ttmlir/EmitC/TTNN/sort/sort.mlir
@@ -2,10 +2,6 @@
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
 // RUN: ttmlir-opt --ttnn-tuplify-tensors --convert-ttnn-to-emitc %t.mlir > %t2.mlir
 // RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
-// UNSUPPORTED: true
-// This test is failing due to not handling multiple outputs in TTNN to EmitC
-// conversion pipeline.
-// tt-mlir issue: https://github.com/tenstorrent/tt-mlir/issues/4045
 
 func.func @test_sort(%arg0: tensor<64x128xbf16>) -> (tensor<64x128xbf16>, tensor<64x128xi16>) {
   %0 = ttir.empty() : tensor<64x128xbf16>

--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -26,6 +26,7 @@
 #include "operations/eltwise/unary/unary_composite.hpp"
 #include "operations/embedding/embedding.hpp"
 #include "operations/embedding_backward/embedding_backward.hpp"
+#include "operations/experimental/reduction/sort/sort.hpp"
 #include "operations/matmul/matmul.hpp"
 #include "operations/moreh/moreh_cumsum/moreh_cumsum.hpp"
 #include "operations/normalization/batch_norm/batch_norm.hpp"


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-mlir/issues/4045

### Problem description
ttnn::sort op returns std::vector<ttnn::Tensor> and it is not handled
in TTNN->EmitC conversion pass.

### What's changed
Add support to handle std::vector<T> return type.

### Checklist
- [X] New/Existing tests provide coverage for changes
