### PR TITLE
Add ConcatenateHeadsOp and Fuse Permute+Reshape #4050

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -5243,4 +5243,37 @@ def TTIR_RequantizeUnrolledOp : TTIR_NamedOp<"requantize_unrolled"> {
   let hasVerifier = 1;
 }
 
+def TTIR_ConcatenateHeadsOp: TTIR_NamedOp<"concatenate_heads"> {
+  let summary = "Concatenate heads operation.";
+  let description = [{
+    The `concatenate_heads` operation concatenates multiple heads of a multi-head attention tensor into a single tensor.
+
+    This operation is typically used in transformer models where the attention mechanism is split into multiple heads.
+    It combines the outputs of these heads into a single tensor, allowing further processing.
+
+    Example:
+    ```mlir
+    // Concatenate heads from a multi-head attention output
+    %input = ... : tensor<1x24x32x128xbf16> // batch_size: 1, num_heads: 24, sequence_size: 32, head_size: 128
+    %output = ttir.empty() : tensor<1x32x3072xbf16>  // Concatenated output of shape [batch_size, sequence_size, num_heads * head_size]
+    %result = ttir.concatenate_heads(%input, %output) : tensor<1x24x32x128xbf16>, tensor<1x32x3072xbf16> -> tensor<1x32x3072xbf16>
+    // Input tensor shape: [1, 24, 32, 128]
+    // Output tensor shape: [1, 32, 3072]
+    ```
+
+    Inputs:
+    - `input` (Tensor): The input tensor containing multiple heads.
+
+    Outputs:
+    - `result` (Tensor): The concatenated output tensor.
+  }];
+
+  let arguments = (ins AnyRankedTensor:$input,
+                       AnyRankedTensor:$output);
+
+  let results = (outs AnyRankedTensor:$result);
+
+  let hasVerifier = 1;
+}
+
 #endif

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1016,6 +1016,23 @@ def TTNN_MorehCumSumOp : TTNN_Op<"moreh_cumsum"> {
   let results = (outs AnyRankedTensor:$result);
 }
 
+def TTNN_ConcatenateHeadsOp: TTNN_Op<"concatenate_heads"> {
+    let summary = "Concatenate heads op used in attention layer.";
+    let description = [{
+      Concatenates multiple heads of a tensor along a specified dimension.
+      Takes in a tensor of shape [batch_size, num_heads, sequence_size, head_size],
+      concatenates heads back along the width dimension and returns the tensor
+      of shape [batch_size, sequence_size, num_heads * head_size].
+    }];
+
+    let arguments = (ins AnyRankedTensor:$inputs,
+                         OptionalAttr<TTNN_MemoryConfigAttr>:$memory_config);
+
+    let results = (outs AnyRankedTensor:$result);
+
+    let hasVerifier = 1;
+}
+
 def TTNN_SoftmaxOp : TTNN_Op<"softmax",
       [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
       > {

--- a/include/ttmlir/Target/TTNN/CMakeLists.txt
+++ b/include/ttmlir/Target/TTNN/CMakeLists.txt
@@ -22,6 +22,7 @@ set(TTNN_OPERATIONS_FBS_GEN_SOURCES
   operations/pool.fbs
   operations/reduction.fbs
   operations/trace.fbs
+  operations/transformer.fbs
 )
 
 set(TTNN_FBS_GEN_SOURCES

--- a/include/ttmlir/Target/TTNN/operations/transformer.fbs
+++ b/include/ttmlir/Target/TTNN/operations/transformer.fbs
@@ -1,0 +1,10 @@
+include "ttmlir/Target/Common/types.fbs";
+include "ttmlir/Target/TTNN/types.fbs";
+
+namespace tt.target.ttnn;
+
+table ConcatenateHeadsOp {
+  in: tt.target.ttnn.TensorRef;
+  out: tt.target.ttnn.TensorRef;
+  memcfg: tt.target.ttnn.MemoryConfig;
+}

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -21,6 +21,7 @@ include "ttmlir/Target/TTNN/operations/normalization.fbs";
 include "ttmlir/Target/TTNN/operations/pool.fbs";
 include "ttmlir/Target/TTNN/operations/reduction.fbs";
 include "ttmlir/Target/TTNN/operations/trace.fbs";
+include "ttmlir/Target/TTNN/operations/transformer.fbs";
 
 namespace tt.target.ttnn;
 
@@ -79,7 +80,8 @@ union OpType {
   ReductionProdOp,
   LoadCachedOp,
   BatchNormOp,
-  TraceOp
+  TraceOp,
+  ConcatenateHeadsOp,
 }
 
 table Operation {

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -1574,6 +1574,20 @@ public:
   }
 };
 
+class ConcatenateHeadsOpConversionPattern
+    : public OpConversionPattern<ttir::ConcatenateHeadsOp> {
+public:
+  using OpConversionPattern<ttir::ConcatenateHeadsOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttir::ConcatenateHeadsOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<ttnn::ConcatenateHeadsOp>(
+        op, this->getTypeConverter()->convertType(op.getType()),
+        adaptor.getInput(), /*memory_config=*/nullptr);
+    return success();
+  }
+};
 } // namespace
 
 namespace mlir::tt {
@@ -1681,7 +1695,8 @@ void populateTTIRToTTNNPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
            FillCacheOpConversionPattern,
            ScatterOpConversionPattern,
            PermuteOpConversionPattern,
-           UpsampleOpConversionPattern
+           UpsampleOpConversionPattern,
+           ConcatenateHeadsOpConversionPattern
            >(typeConverter, ctx);
   // ANCHOR_END: op_rewriter_pattern_set
   // clang-format on

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -2207,6 +2207,35 @@ public:
 };
 } // namespace
 
+namespace {
+class ConcatenateHeadsOpConversionPattern
+    : public TTNNToEmitCBaseOpConversionPattern<
+          mlir::tt::ttnn::ConcatenateHeadsOp> {
+
+public:
+  using TTNNToEmitCBaseOpConversionPattern<
+      mlir::tt::ttnn::ConcatenateHeadsOp>::TTNNToEmitCBaseOpConversionPattern;
+  using Adaptor = typename mlir::tt::ttnn::ConcatenateHeadsOp::Adaptor;
+
+  LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::ConcatenateHeadsOp srcOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    ttnn_to_emitc::EmitCTTNNEmitter<mlir::tt::ttnn::ConcatenateHeadsOp> emitter(
+        srcOp, adaptor, rewriter);
+
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getInputs()),
+        emitter.emit(std::nullopt) | emitter.getMemoryConfig(srcOp.getResult()),
+    };
+
+    emitter.replaceOp(*this, args);
+
+    return success();
+  }
+};
+} // namespace
+
 namespace mlir::tt {
 
 // ANCHOR: op_rewriter_pattern_set_emitc
@@ -2396,6 +2425,10 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
   // BatchNorm op
   //
   patterns.add<BatchNormOpConversionPattern>(typeConverter, ctx);
+
+  // Transformers ops
+  //
+  patterns.add<ConcatenateHeadsOpConversionPattern>(typeConverter, ctx);
 }
 // ANCHOR_END: op_rewriter_pattern_set_emitc
 

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -4322,6 +4322,76 @@ verifyReduceOp(llvm::function_ref<mlir::InFlightDiagnostic()> emitOpError,
 }
 
 //===----------------------------------------------------------------------===//
+// ConcatenateHeadsOp
+//===----------------------------------------------------------------------===//
+
+// ConcatenateHeadsOp verification
+::mlir::LogicalResult mlir::tt::ttir::ConcatenateHeadsOp::verify() {
+  ::mlir::RankedTensorType inputType = getInput().getType();
+  ::mlir::RankedTensorType outputType = getOutput().getType();
+
+  // Input tensor must be 4D tensor [batch_size, num_heads, sequence_size,
+  // head_size].
+  if (inputType.getRank() != 4) {
+    return emitOpError("Expected rank of input tensor is 4, got rank " +
+                       std::to_string(inputType.getRank()));
+  }
+
+  // Output tensor must be 2D or 3D tensor.
+  if (outputType.getRank() != 2 && outputType.getRank() != 3) {
+    return emitOpError("Expected rank of output tensor is 2 or 3, got rank " +
+                       std::to_string(outputType.getRank()));
+  }
+
+  llvm::ArrayRef<int64_t> inputShape = inputType.getShape();
+  llvm::ArrayRef<int64_t> outputShape = outputType.getShape();
+
+  // If output is 2D, add dimension 1 at the beginning for comparison
+  llvm::SmallVector<int64_t> adjustedOutputShape;
+  if (outputType.getRank() == 2) {
+    adjustedOutputShape = {1, outputShape[0], outputShape[1]};
+  } else {
+    adjustedOutputShape = {outputShape[0], outputShape[1], outputShape[2]};
+  }
+
+  // Input tensor dimensions [batch_size, num_heads, sequence_size, head_size]
+  enum InputDimensions {
+    INPUT_BATCH = 0,
+    INPUT_NUM_HEADS = 1,
+    INPUT_SEQ = 2,
+    INPUT_HEAD_SIZE = 3
+  };
+  // Output tensor dimensions [batch_size, sequence_size, num_heads * head_size]
+  enum OutputDimensions { OUTPUT_BATCH = 0, OUTPUT_SEQ = 1, OUTPUT_HIDDEN = 2 };
+
+  // Verify batch_size dimension matches
+  if (inputShape[INPUT_BATCH] != adjustedOutputShape[OUTPUT_BATCH]) {
+    return emitOpError("Expected output batch dimension to be ")
+           << inputShape[INPUT_BATCH] << ", got "
+           << adjustedOutputShape[OUTPUT_BATCH];
+  }
+
+  // Verify sequence_size dimension matches
+  if (inputShape[INPUT_SEQ] != adjustedOutputShape[OUTPUT_SEQ]) {
+    return emitOpError("Expected output sequence dimension to be ")
+           << inputShape[INPUT_SEQ] << ", got "
+           << adjustedOutputShape[OUTPUT_SEQ];
+  }
+
+  // Verify that num_heads * head_size equals the output hidden dimension
+  int64_t expectedHiddenSize =
+      inputShape[INPUT_NUM_HEADS] * inputShape[INPUT_HEAD_SIZE];
+  if (expectedHiddenSize != adjustedOutputShape[OUTPUT_HIDDEN]) {
+    return emitOpError("Expected output hidden dimension to be num_heads * "
+                       "head_size = ")
+           << expectedHiddenSize << ", got "
+           << adjustedOutputShape[OUTPUT_HIDDEN];
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // YieldOp / AwaitOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -841,6 +841,102 @@ public:
     return success();
   }
 };
+
+class ConcatenateHeadsUpdatePattern : public mlir::OpRewritePattern<PermuteOp> {
+  using mlir::OpRewritePattern<PermuteOp>::OpRewritePattern;
+
+public:
+  mlir::LogicalResult
+  matchAndRewrite(PermuteOp srcOp,
+                  mlir::PatternRewriter &rewriter) const final {
+    if (!isFusable(srcOp)) {
+      return mlir::failure();
+    }
+    // Get the reshape op that follows the permute op.
+    auto reshapeOp =
+        mlir::cast<ReshapeOp>(*srcOp.getResult().getUsers().begin());
+
+    Value inputTensor = srcOp.getOperand(0); // %arg0
+
+    // Replace reshape op with concatenate heads op using DPS utility
+    utils::replaceOpWithNewDPSOp<ConcatenateHeadsOp>(
+        rewriter, reshapeOp, reshapeOp.getResult().getType(), inputTensor);
+
+    // Erase permute op
+    rewriter.eraseOp(srcOp);
+
+    return mlir::success();
+  }
+
+private:
+  bool isFusable(PermuteOp permuteOp) const {
+    // Permute should only have one use and that use should be a reshape op.
+    if (!permuteOp.getResult().hasOneUse() ||
+        !ttmlir::utils::allUsersOfType<ReshapeOp>(permuteOp)) {
+      return false;
+    }
+
+    // Check if the permutation attribute is {0, 2, 1, 3}
+    auto permutationAttr = permuteOp.getPermutation();
+    if (permutationAttr.empty()) {
+      return false;
+    }
+    llvm::SmallVector<int64_t> expectedPermutation = {0, 2, 1, 3};
+
+    if (permutationAttr.size() != expectedPermutation.size()) {
+      return false;
+    }
+    for (size_t i = 0; i < expectedPermutation.size(); ++i) {
+      if (permutationAttr[i] != expectedPermutation[i]) {
+        return false;
+      }
+    }
+
+    ReshapeOp reshapeOp =
+        mlir::cast<ReshapeOp>(*permuteOp.getResult().getUsers().begin());
+
+    ArrayRef<int64_t> inputShape = permuteOp.getInput().getType().getShape();
+    ArrayRef<int64_t> reshapeOutputShape =
+        reshapeOp.getResult().getType().getShape();
+
+    // Handle reshape output shape - if it's 2D, prepend 1 to make it 3D
+
+    llvm::SmallVector<int64_t> adjustedReshapeShape;
+
+    if (reshapeOutputShape.size() == 2) {
+      adjustedReshapeShape.push_back(1);
+      for (auto dim : reshapeOutputShape) {
+        adjustedReshapeShape.push_back(dim);
+      }
+    } else if (reshapeOutputShape.size() == 3) {
+      for (auto dim : reshapeOutputShape) {
+        adjustedReshapeShape.push_back(dim);
+      }
+
+    } else {
+      return false;
+    }
+
+    // Check that input shape is 4 dimensional, adjusted output shape is 3
+    // dimensional.
+    if (inputShape.size() != 4 || adjustedReshapeShape.size() != 3) {
+      return false;
+    }
+
+    // Check that input shape: [batch_size, num_heads, sequence_size, head_size]
+    // output shape: [batch_size, sequence_size, num_heads * head_size]
+    if (inputShape[0] != adjustedReshapeShape[0] ||
+        inputShape[2] != adjustedReshapeShape[1]) {
+      return false;
+    }
+
+    if (inputShape[1] * inputShape[3] != adjustedReshapeShape[2]) {
+      return false;
+    }
+    return true;
+  }
+};
+
 class TTIRFusingPass : public impl::TTIRFusingBase<TTIRFusingPass> {
 public:
   using impl::TTIRFusingBase<TTIRFusingPass>::TTIRFusingBase;
@@ -870,6 +966,7 @@ public:
       patterns.add<SoftmaxFusionPattern>(&getContext());
       patterns.add<Conv2dWithMultiply>(&getContext());
       patterns.add<CacheFillUpdatePattern>(&getContext());
+      patterns.add<ConcatenateHeadsUpdatePattern>(&getContext());
 
       patterns.add<PadPoolingFusionPattern>(&getContext());
 

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -2710,4 +2710,81 @@ static bool isTensorOnDevice(::mlir::RankedTensorType tensorType) {
   return walkResult.wasInterrupted() ? ::mlir::failure() : ::mlir::success();
 }
 
+//===----------------------------------------------------------------------===//
+// ConcatenateHeadsOp
+//===----------------------------------------------------------------------===//
+
+::mlir::LogicalResult ConcatenateHeadsOp::verify() {
+  const ::mlir::RankedTensorType inputType = this->getInputs().getType();
+  const ::mlir::RankedTensorType outputType = this->getResult().getType();
+
+  const ::mlir::tt::ttcore::DataType inputDataType =
+      ::mlir::tt::ttcore::elementTypeToDataType(inputType.getElementType());
+  const ::mlir::tt::ttcore::DataType outputDataType =
+      ::mlir::tt::ttcore::elementTypeToDataType(outputType.getElementType());
+
+  if (inputDataType != outputDataType) {
+    return emitOpError(
+        "Input and output tensors must have the same dtype. "
+        "Got input dtype = " +
+        DataTypeEnumToString(inputDataType) +
+        ", output dtype = " + DataTypeEnumToString(outputDataType));
+  }
+
+  if (inputType.getRank() != 4) {
+    return emitOpError("Input tensor must be a 4D tensor");
+  }
+
+  if (outputType.getRank() != 2 && outputType.getRank() != 3) {
+    return emitOpError("Output tensor must be a 2D or 3D tensor");
+  }
+
+  llvm::ArrayRef<int64_t> inputShape = inputType.getShape();
+  llvm::ArrayRef<int64_t> outputShape = outputType.getShape();
+
+  // If output is 2D, add dimension 1 at the beginning for comparison
+  llvm::SmallVector<int64_t> adjustedOutputShape;
+  if (outputType.getRank() == 2) {
+    adjustedOutputShape = {1, outputShape[0], outputShape[1]};
+  } else {
+    adjustedOutputShape = {outputShape[0], outputShape[1], outputShape[2]};
+  }
+
+  // Input tensor dimensions [batch_size, num_heads, sequence_size, head_size]
+  // Output tensor dimensions [batch_size, sequence_size, num_heads * head_size]
+
+  // Verify batch_size dimension matches
+  if (inputShape[0] != adjustedOutputShape[0]) {
+    return emitOpError(
+        "Input and output batch dimensions must match. "
+        "Got input batch size = " +
+        std::to_string(inputShape[0]) +
+        ", output batch size = " + std::to_string(adjustedOutputShape[0]));
+  }
+
+  // Verify sequence_size dimension matches
+  if (inputShape[2] != adjustedOutputShape[1]) {
+    return emitOpError(
+        "Input sequence dimension must match output sequence dimension. "
+        "Got input sequence size = " +
+        std::to_string(inputShape[2]) +
+        ", output sequence size = " + std::to_string(adjustedOutputShape[1]));
+  }
+
+  // Verify that num_heads * head_size equals the output hidden dimension
+  int64_t expectedHiddenSize = inputShape[1] * inputShape[3];
+  if (expectedHiddenSize != adjustedOutputShape[2]) {
+    return emitOpError(
+        "Output hidden dimension must equal num_heads * head_size. "
+        "Got num_heads = " +
+        std::to_string(inputShape[1]) +
+        ", head_size = " + std::to_string(inputShape[3]) +
+        ", expected hidden size = " + std::to_string(expectedHiddenSize) +
+        ", actual output hidden size = " +
+        std::to_string(adjustedOutputShape[2]));
+  }
+
+  return success();
+}
+
 } // namespace mlir::tt::ttnn

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -1769,6 +1769,20 @@ createOp(FlatbufferObjectCache &cache, TraceOp op,
       op.getCallee().str().c_str(), programIdx, &inputs, &outputs);
 }
 
+::flatbuffers::Offset<::tt::target::ttnn::ConcatenateHeadsOp>
+createConcatenateHeadsOp(FlatbufferObjectCache &cache, ConcatenateHeadsOp op) {
+  auto in = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInputs()));
+  auto out = cache.getOrCreate(op.getResult(), tensorValueToFlatbuffer,
+                               kHostAllocatedSize);
+  auto memoryConfig = op.getMemoryConfig()
+                          ? toFlatbuffer(cache, op.getMemoryConfig().value())
+                          : 0;
+
+  return ::tt::target::ttnn::CreateConcatenateHeadsOp(*cache.fbb, in, out,
+                                                      memoryConfig);
+}
+
 ::flatbuffers::Offset<::tt::target::ttnn::Operation>
 emitTTNNOperation(FlatbufferObjectCache &cache, Operation *op,
                   const llvm::StringMap<uint32_t> &programIndexMap,
@@ -2225,6 +2239,12 @@ emitTTNNOperation(FlatbufferObjectCache &cache, Operation *op,
   }
   if (auto traceOp = dyn_cast<TraceOp>(op); traceOp) {
     return createOperation(cache, createOp(cache, traceOp, programIndexMap),
+                           debugString, locInfo);
+  }
+  if (auto concatenateHeadsOp = dyn_cast<ConcatenateHeadsOp>(op);
+      concatenateHeadsOp) {
+    return createOperation(cache,
+                           createConcatenateHeadsOp(cache, concatenateHeadsOp),
                            debugString, locInfo);
   }
 

--- a/runtime/include/tt/runtime/detail/ttnn/ttnn.h
+++ b/runtime/include/tt/runtime/detail/ttnn/ttnn.h
@@ -46,6 +46,7 @@
 #include "ttnn/operations/reduction/generic/generic_reductions.hpp"
 #include "ttnn/operations/reduction/prod/prod.hpp"
 #include "ttnn/operations/trace.hpp"
+#include "ttnn/operations/transformer/concatenate_heads/concatenate_heads.hpp"
 #include "ttnn/tensor/host_buffer/functions.hpp"
 #include "ttnn/tensor/shape/shape.hpp"
 #include "ttnn/tensor/tensor.hpp"

--- a/runtime/lib/ttnn/operations/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/CMakeLists.txt
@@ -58,6 +58,7 @@ set(TTNN_OPS_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/reduction/reduction.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/reduction/sort.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/trace/trace.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/transformer/concatenate_heads.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/utils/utils.cpp
 )
 

--- a/runtime/lib/ttnn/operations/transformer/concatenate_heads.cpp
+++ b/runtime/lib/ttnn/operations/transformer/concatenate_heads.cpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "operations/transformer/concatenate_heads.h"
+#include "tt/runtime/detail/logger.h"
+#include "tt/runtime/detail/ttnn/ttnn.h"
+
+#include "tt/runtime/detail/ttnn/operations/utils.h"
+#include "tt/runtime/detail/ttnn/utils.h"
+
+namespace tt::runtime::ttnn::operations::transformer {
+static void
+runConcatenateHeadsOp(const ::tt::target::ttnn::ConcatenateHeadsOp *op,
+                      ProgramTensorPool &tensorPool) {
+  std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
+      ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(op->memcfg());
+
+  const ::ttnn::Tensor &in = tensorPool.getTTNNTensorAndValidate(op->in());
+  ::ttnn::Tensor out =
+      ::ttnn::transformer::concatenate_heads(in, outputMemoryConfig);
+  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
+}
+
+void run(const ::tt::target::ttnn::ConcatenateHeadsOp *op,
+         ProgramContext &context) {
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+  runConcatenateHeadsOp(op, tensorPool);
+}
+
+} // namespace tt::runtime::ttnn::operations::transformer

--- a/runtime/lib/ttnn/operations/transformer/concatenate_heads.h
+++ b/runtime/lib/ttnn/operations/transformer/concatenate_heads.h
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef RUNTIME_LIB_TTNN_OPERATIONS_CONCATENATE_HEADS_H
+#define RUNTIME_LIB_TTNN_OPERATIONS_CONCATENATE_HEADS_H
+
+#include "tt/runtime/detail/ttnn/types.h"
+#include "ttmlir/Target/TTNN/program_generated.h"
+
+namespace tt::runtime::ttnn::operations::transformer {
+void run(const ::tt::target::ttnn::ConcatenateHeadsOp *op,
+         ProgramContext &context);
+} // namespace tt::runtime::ttnn::operations::transformer
+
+#endif

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -56,6 +56,7 @@
 #include "operations/reduction/reduction.h"
 #include "operations/reduction/sort.h"
 #include "operations/trace/trace.h"
+#include "operations/transformer/concatenate_heads.h"
 #include "tt/runtime/debug.h"
 #include "tt/runtime/detail/ttnn/types.h"
 #include "tt/runtime/perf.h"
@@ -318,6 +319,10 @@ void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
   }
   case ::tt::target::ttnn::OpType::TraceOp: {
     return operations::trace::run(op->type_as_TraceOp(), getContext());
+  }
+  case ::tt::target::ttnn::OpType::ConcatenateHeadsOp: {
+    return operations::transformer::run(op->type_as_ConcatenateHeadsOp(),
+                                        getContext());
   }
   default: {
     LOG_FATAL("Unsupported operation type: ",

--- a/test/ttmlir/Dialect/TTIR/fusing/concatenate_heads_fusing.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/concatenate_heads_fusing.mlir
@@ -1,0 +1,19 @@
+// RUN: ttmlir-opt %s --ttir-fusing | FileCheck %s
+
+module {
+  // CHECK-LABEL: func.func @concatenate_heads_fusion
+  func.func @concatenate_heads_fusion(%arg0: tensor<1x24x32x128xbf16> ) -> tensor<1x32x3072xbf16> {
+    // CHECK: %[[RESULT:.*]] = "ttir.concatenate_heads"(%arg0, %{{.*}}) : (tensor<1x24x32x128xbf16>, tensor<1x32x3072xbf16>) -> tensor<1x32x3072xbf16>
+    // CHECK-NOT: ttir.reshape
+    // CHECK-NOT: ttir.permute
+    // CHECK: return %[[RESULT]]
+
+    %0 = ttir.empty() : tensor<1x32x24x128xbf16>
+    %1 = "ttir.permute"(%arg0, %0) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<1x24x32x128xbf16>, tensor<1x32x24x128xbf16>) -> tensor<1x32x24x128xbf16>
+
+    %2 = ttir.empty() : tensor<1x32x3072xbf16>
+    %3 = "ttir.reshape"(%1, %2) <{shape = [1 : i32, 32 : i32, 3072 : i32]}> : (tensor<1x32x24x128xbf16>, tensor<1x32x3072xbf16>) -> tensor<1x32x3072xbf16>
+
+    return %3 : tensor<1x32x3072xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/transformer/concatenate_heads.mlir
+++ b/test/ttmlir/Dialect/TTNN/transformer/concatenate_heads.mlir
@@ -1,0 +1,9 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline %s | FileCheck %s
+module {
+  func.func @concatenate_heads(%arg0: tensor<1x24x32x128xbf16>) -> tensor<1x32x3072xbf16> {
+    %0 = ttir.empty() : tensor<1x32x3072xbf16>
+    // CHECK: "ttnn.concatenate_heads"(%arg0)
+    %1 = "ttir.concatenate_heads"(%arg0, %0) : (tensor<1x24x32x128xbf16>, tensor<1x32x3072xbf16>) -> tensor<1x32x3072xbf16>
+    return %1 : tensor<1x32x3072xbf16>
+  }
+}

--- a/test/ttmlir/EmitC/TTNN/transformer/concatenate_heads.mlir
+++ b/test/ttmlir/EmitC/TTNN/transformer/concatenate_heads.mlir
@@ -1,0 +1,10 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
+// RUN: ttmlir-opt --ttnn-tuplify-tensors --convert-ttnn-to-emitc %t.mlir > %t2.mlir
+// RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
+
+func.func @concatenate_heads(%arg0: tensor<1x24x32x128xbf16>) -> tensor<1x32x3072xbf16> {
+  %0 = ttir.empty() : tensor<1x32x3072xbf16>
+  %1 = "ttir.concatenate_heads"(%arg0, %0) : (tensor<1x24x32x128xbf16>, tensor<1x32x3072xbf16>) -> tensor<1x32x3072xbf16>
+  return %1 : tensor<1x32x3072xbf16>
+}

--- a/test/ttmlir/Silicon/TTNN/n150/transformer/simple_concatenate_heads.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/transformer/simple_concatenate_heads.mlir
@@ -1,0 +1,11 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" %s > %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+module {
+  func.func @concatenate_heads(%arg0: tensor<1x24x32x128xbf16>) -> tensor<1x32x3072xbf16> {
+    %0 = ttir.empty() : tensor<1x32x3072xbf16>
+    // CHECK: "ttnn.concatenate_heads"(%arg0)
+    %1 = "ttir.concatenate_heads"(%arg0, %0) : (tensor<1x24x32x128xbf16>, tensor<1x32x3072xbf16>) -> tensor<1x32x3072xbf16>
+    return %1 : tensor<1x32x3072xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket
#4050 

### Problem description
A common pattern in attention layer corresponds to a transformers ttnn op named `concatenate_heads` [API information](https://docs.tenstorrent.com/tt-metal/latest/ttnn/ttnn/api.html#transformer)

For example, these two ops in llama:

```
    %157 = "ttir.permute"(%155, %156) <{permutation = array<i64: 0, 2, 1, 3>}> : (tensor<1x24x32x128xbf16>, tensor<1x32x24x128xbf16>) -> tensor<1x32x24x128xbf16> loc(#loc134)

    %158 = ttir.empty() : tensor<1x32x3072xbf16> loc(#loc135)

    %159 = "ttir.reshape"(%157, %158) <{shape = [1 : i32, 32 : i32, 3072 : i32]}> : (tensor<1x32x24x128xbf16>, tensor<1x32x3072xbf16>) -> tensor<1x32x3072xbf16> loc(#loc135)

    %160 = ttir.empty() : tensor<3072x3072xbf16> loc(#loc136)
```

can be lowered into:

```
        %61 = "ttnn.concatenate_heads"(%60) : (tensor<1x24x32x128xbf16, #ttnn_layout12>) -> tensor<32x3072xbf16, #ttnn_layout10> loc(#loc115)
```

### What's changed
Added support for `concatenate_heads` op and added fusion pattern.

### Checklist
- [X] New/Existing tests provide coverage for changes
