### PR TITLE
Apply workaround to do permute with float32 in row major in some cases

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1997,7 +1997,7 @@ def TTNN_PermuteOp : TTNN_Op<"permute",
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return
           wa::TTNNOperandsWorkaroundsFactory::createPermuteOpOperandWorkaround(
-            getInput().getType()
+            getInput().getType(), getPermutation()
           );
       }
     }];

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
@@ -280,7 +280,8 @@ public:
 
   // Create workaround for permute op operands.
   static TTNNOperandsWorkarounds
-  createPermuteOpOperandWorkaround(mlir::RankedTensorType inputType);
+  createPermuteOpOperandWorkaround(mlir::RankedTensorType inputType,
+                                   llvm::ArrayRef<int64_t> permutation);
 
   // Create workarounds for conv2d op operands.
   static TTNNOperandsWorkarounds


### PR DESCRIPTION
### Ticket


### Problem description
Permute in float32 and tile layout sometimes returns all zeros instead of the correct result

### What's changed
I used the workarounds pass to apply a workaround to do permute in row major layout in that case

### Checklist
- [X] New/Existing tests provide coverage for changes
