### PR TITLE
D2M: Add init hoisting pass

### DIFF
--- a/include/ttmlir/Dialect/TTKernel/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTKernel/Transforms/Passes.td
@@ -15,4 +15,12 @@ def TTKernelControlDstSection: Pass<"ttkernel-control-dst-section", "::mlir::Mod
   let dependentDialects = ["mlir::tt::ttkernel::TTKernelDialect"];
 }
 
+def TTKernelHoistInits: Pass<"ttkernel-hoist-inits", "::mlir::ModuleOp"> {
+  let summary = "Hoist inits";
+  let description = [{
+    Analyze the graph and maximally hoist init ops to respective loop nests.
+  }];
+  let dependentDialects = ["mlir::tt::ttkernel::TTKernelDialect"];
+}
+
 #endif

--- a/lib/Dialect/TTKernel/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTKernel/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_mlir_dialect_library(MLIRTTKernelTransforms
         ControlDstSection.cpp
+        HoistInits.cpp
 
         DEPENDS
         MLIRTTKernelOpsIncGen

--- a/lib/Dialect/TTKernel/Transforms/HoistInits.cpp
+++ b/lib/Dialect/TTKernel/Transforms/HoistInits.cpp
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTKernel/Transforms/Passes.h"
+
+#include "ttmlir/Dialect/TTKernel/IR/TTKernel.h"
+#include "ttmlir/Dialect/TTKernel/IR/TTKernelOps.h"
+
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Transforms/WalkPatternRewriteDriver.h"
+
+namespace mlir::tt::ttkernel {
+#define GEN_PASS_DEF_TTKERNELHOISTINITS
+#include "ttmlir/Dialect/TTKernel/Transforms/Passes.h.inc"
+
+namespace {
+
+class TTKernelFunctionRewriter : public OpRewritePattern<func::FuncOp> {
+public:
+  using OpRewritePattern<func::FuncOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(func::FuncOp op,
+                                PatternRewriter &rewriter) const final {
+    DenseMap<scf::ForOp, SmallVector<OperationName>> initOps;
+
+    op.walk([&initOps](Operation *op) {
+      if (op->hasTrait<ttkernel::TTKernelInitOpTrait>()) {
+        auto forParent = op->getParentOfType<scf::ForOp>();
+        while (forParent) {
+          auto forInitOps = initOps.lookup(forParent);
+          initOps[forParent].push_back(op->getName());
+          forParent = forParent->getParentOfType<scf::ForOp>();
+        }
+      }
+    });
+
+    op.walk([&](Operation *op) {
+      if (op->hasTrait<ttkernel::TTKernelInitOpTrait>()) {
+        Operation *highestLiftableLoop = nullptr;
+        scf::ForOp curr = op->getParentOfType<scf::ForOp>();
+        while (curr) {
+          assert(initOps.contains(curr) &&
+                 "Init op's parent loop should be in the initOps map.");
+          auto currLoopInitOps = initOps.lookup(curr);
+          assert(std::find(currLoopInitOps.begin(), currLoopInitOps.end(),
+                           op->getName()) != currLoopInitOps.end() &&
+                 "Init op should be inside the parent loop's initOps map.");
+
+          // This condition should be smarter, in the sense that we should have
+          // a lookup table of conflicting inits and detect whether we can keep
+          // going. For now, assume all inits conflict.
+          if (currLoopInitOps.size() == 1) {
+            highestLiftableLoop = curr;
+          } else {
+            break;
+          }
+          curr = curr->getParentOfType<scf::ForOp>();
+        }
+        if (highestLiftableLoop) {
+          rewriter.moveOpBefore(op, highestLiftableLoop);
+        }
+      }
+    });
+    return success();
+  }
+};
+
+} // namespace
+
+namespace {
+class TTKernelHoistInits
+    : public impl::TTKernelHoistInitsBase<TTKernelHoistInits> {
+public:
+  using impl::TTKernelHoistInitsBase<
+      TTKernelHoistInits>::TTKernelHoistInitsBase;
+
+  void runOnOperation() final {
+    RewritePatternSet patterns(&getContext());
+    patterns.add<TTKernelFunctionRewriter>(&getContext());
+    walkAndApplyPatterns(getOperation(), std::move(patterns));
+  }
+};
+} // namespace
+
+} // namespace mlir::tt::ttkernel

--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -111,6 +111,7 @@ void createTTIRToTTMetalBackendPipeline(
   pm.addPass(ttkernel::createTTKernelControlDstSection());
   createOptimizationPasses(pm);
   pm.addPass(createConvertTTIRToTTMetalPass());
+  pm.addPass(ttkernel::createTTKernelHoistInits());
   pm.addPass(createConvertTTKernelToEmitC());
   pm.addPass(mlir::createCanonicalizerPass());
   pm.addPass(mlir::emitc::createFormExpressionsPass());


### PR DESCRIPTION
### Problem description
As an optimization, we would like to hoist `*_init_*` calls as far out of loops as possible, so that they do not get called redundantly, but also do not conflict with one another.

### What's changed
This is a simple first cut pass which will first walk a kernel, and build a mapping of loops with the inits that they contain.
It will walk a second time, and use the above mapping to determine which loop nest it can safely lift each init into.
For now, it takes the conservative approach and assumes all inits conflict with each other, so will not lift into any scope where that is possible.

### Checklist
- [ ] New/Existing tests provide coverage for changes - note, need to add a test for this/update existing tests
