### PR TITLE
build: change tt_llk settings

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -157,7 +157,7 @@ install(
 )
 
 # `tt_metal` directory is installed with two commands, since we need special handling of `third_party` directory.
-# We only need `tt_llk_*" and `umd` files from `third_party` directory.
+# We only need `tt_llk" and `umd` files from `third_party` directory.
 install(
   DIRECTORY
     ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal
@@ -175,7 +175,7 @@ install(
   COMPONENT SharedLib
   EXCLUDE_FROM_ALL
   FILES_MATCHING
-  REGEX "third_party/tt_llk_*"
+  REGEX "third_party/tt_llk/"
   REGEX "third_party/umd/"
 )
 


### PR DESCRIPTION
### Ticket
None

### Problem description
The `third_party/CMakeLists.txt` files are outdated following the restructuring of the `tt_llk` code in February. The code, which was previously in three separate repositories (`tt_llk_blackhole`, `tt_llk_grayskull` and `tt_llk_wormhole_b0`), has been consolidated into the `tt_llk` repository.

### What's changed
The `CMakeLists.txt` file has been modified to correctly locate sources within the new, unified `tt_llk` directory structure.

### Checklist
- [ ] New/Existing tests provide coverage for changes
