### PR TITLE
Fix L1 calc in ShardSolver & add progress tracker to MLA

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/DFShardingPolicy.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/DFShardingPolicy.h
@@ -9,7 +9,6 @@
 #include "ttmlir/Dialect/TTNN/Analysis/MemoryLayoutAnalysisPolicy.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
 #include "ttmlir/Dialect/TTNN/Analysis/TensorLayouts.h"
-#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "llvm/ADT/DenseSet.h"

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1ChainConfig.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1ChainConfig.h
@@ -7,6 +7,7 @@
 
 #include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
 #include "ttmlir/Dialect/TTNN/Analysis/ShardSolver.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 
 #include "llvm/ADT/DenseSet.h"
@@ -106,9 +107,10 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
   os << "L1ChainConfig(size=" << config.size() << ")";
   os << "\n\tState: " << config.getStateString();
   for (const auto &opL1MemSpec : config.getOpL1MemSpecs()) {
-    os << "\n\t" << opL1MemSpec.op->getName().getStringRef() << "\t"
-       << utils::getOpLocName(opL1MemSpec.op);
-    os << "\n\t outputLayout: " << opL1MemSpec.config.outputLayout;
+    os << "\n\t";
+    opL1MemSpec.op->print(os);
+    os << "@ loc: " << utils::getOpLocName(opL1MemSpec.op);
+    os << "\n\t\t outputLayout: " << opL1MemSpec.config.outputLayout;
   }
   return os;
 }

--- a/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutAnalysisPolicy.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutAnalysisPolicy.h
@@ -9,6 +9,7 @@
 #include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Operation.h"
 
 namespace mlir::tt::ttnn {
 

--- a/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutAnalysisProgressTracker.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutAnalysisProgressTracker.h
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_ANALYSIS_MEMORYLAYOUTANALYSISPROGRESSTRACKER_H
+#define TTMLIR_DIALECT_TTNN_ANALYSIS_MEMORYLAYOUTANALYSISPROGRESSTRACKER_H
+
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+
+#include "mlir/IR/Operation.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <chrono>
+#include <string>
+
+namespace mlir::tt::ttnn {
+
+class MemoryLayoutAnalysisProgressTracker {
+private:
+  std::chrono::steady_clock::time_point startTime;
+  size_t totalL1Chains = 0;
+  bool enabled = false;
+
+public:
+  MemoryLayoutAnalysisProgressTracker()
+      : startTime(std::chrono::steady_clock::now()) {
+    // For now, disable progress tracking by default. Once we integrate
+    // tt-logger with tt-mlir we can use it and log progress always (and remove
+    // this env var). This way, we will have progress visible in every build.
+    enabled = std::getenv("MLA_TRACK_PROGRESS") != nullptr;
+  }
+
+  void startAnalysis(Operation *rootOp, size_t numL1Chains,
+                     const std::string &context = "") {
+    totalL1Chains = numL1Chains;
+
+    emitMsg(mlir::tt::ttnn::utils::getOpLocName(rootOp),
+            "MemoryLayoutAnalysis: Starting Analysis: " + context +
+                ", Total L1 Chains: " + std::to_string(numL1Chains));
+  }
+
+  void startL1Chain(Operation *firstOp, size_t chainIndex,
+                    size_t numOpsInChain) {
+    auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+        std::chrono::steady_clock::now() - startTime);
+
+    emitMsg(mlir::tt::ttnn::utils::getOpLocName(firstOp),
+            "MemoryLayoutAnalysis: Starting L1Chain " +
+                std::to_string(chainIndex + 1) + "/" +
+                std::to_string(totalL1Chains) +
+                " (ops: " + std::to_string(numOpsInChain) + "), elapsed " +
+                std::to_string(elapsed.count()) + "s");
+  }
+
+  void finishL1Chain(Operation *firstOp, size_t chainIndex, bool success) {
+    auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+        std::chrono::steady_clock::now() - startTime);
+
+    emitMsg(mlir::tt::ttnn::utils::getOpLocName(firstOp),
+            "MemoryLayoutAnalysis: L1Chain " + std::to_string(chainIndex + 1) +
+                "/" + std::to_string(totalL1Chains) +
+                (success ? " COMPLETED" : " FAILED") + ", elapsed " +
+                std::to_string(elapsed.count()) + "s");
+  }
+
+  void finishAnalysis(Operation *rootOp) {
+    auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+        std::chrono::steady_clock::now() - startTime);
+
+    emitMsg(mlir::tt::ttnn::utils::getOpLocName(rootOp),
+            "MemoryLayoutAnalysis: Analysis Complete, total time: " +
+                std::to_string(elapsed.count()) + "s");
+  }
+
+private:
+  void emitMsg(std::string loc, std::string_view msg) {
+    if (!enabled) {
+      return;
+    }
+    llvm::outs() << loc << ": " << msg << "\n";
+    llvm::outs().flush();
+  }
+};
+
+} // namespace mlir::tt::ttnn
+
+#endif // TTMLIR_DIALECT_TTNN_ANALYSIS_MEMORYLAYOUTANALYSISPROGRESSTRACKER_H

--- a/lib/Dialect/TTNN/Transforms/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/Optimizer.cpp
@@ -978,8 +978,10 @@ private:
           op->getResult(0).setType(
               resultType.cloneWithEncoding(actualOutputLayout));
         }
-        TTMLIR_DEBUG(ttmlir::LogComponent::Optimizer,
-                     "Successfully passed constraints, no conversion needed");
+        TTMLIR_DEBUG(
+            ttmlir::LogComponent::Optimizer,
+            "Op {} successfully passed constraints, no conversion needed",
+            op->getName());
         return;
       }
 
@@ -995,7 +997,8 @@ private:
 
       // Row major input passed constraints, let's add necessary conversions.
       TTMLIR_DEBUG(ttmlir::LogComponent::Optimizer,
-                   "Successfully passed constraints after inserting RM");
+                   "Op {} successfully passed constraints after inserting RM",
+                   op->getName());
       convertOpToRowMajorAndBack(op);
     });
   }


### PR DESCRIPTION
### Ticket
Related to https://github.com/tenstorrent/tt-mlir/issues/3954

### What's changed

Until now we calculated L1 usage as sum of input tensor, CB peak usage and output tensor. However, given op can allocate more buffers for its internal usage (for example HaloOp result within Conv2d). This consumption is seen in the response of `OpModel::getOpConstraints` as tensor usage. Here I am changing, L1 Usage to be sum of input tensor, CB peak size and buffers peak size. Note that CBs and Buffers are exclusive in allocation tracker. 