### PR TITLE
Adding support for stablehlo.optimization_barrier op

### DIFF
--- a/include/ttmlir/Dialect/TTCore/IR/TTCoreOps.td
+++ b/include/ttmlir/Dialect/TTCore/IR/TTCoreOps.td
@@ -168,4 +168,22 @@ def TTCore_LoadCachedOp : TTCore_Op<"load_cached", []> {
   let hasVerifier = 1;
 }
 
+def TTCore_OptimizationBarrierOp : TTCore_Op<"optimization_barrier", [MemoryEffects<[MemRead, MemWrite]>]> {
+  let summary = "Optimization barrier operation.";
+  let description = [{
+    The `optimization_barrier` operation prevents compiler optimizations from reordering or eliminating
+    the values passed through it. It acts as a barrier for optimization passes.
+
+    Inputs:
+    - `inputs` (Variadic): Values of tensor type.
+
+    Outputs:
+    - `results` (Variadic): Same values as inputs, passed through unchanged.
+  }];
+
+  let arguments = (ins Variadic<AnyRankedTensor>:$inputs);
+
+  let results = (outs Variadic<AnyRankedTensor>:$results);
+}
+
 #endif // TTMLIR_DIALECT_TTCORE_IR_TTCOREOPS_TD

--- a/include/ttmlir/Dialect/TTCore/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTCore/Transforms/Passes.td
@@ -73,4 +73,14 @@ def TTCoreRegisterDevicePass : Pass<"ttcore-register-device", "::mlir::ModuleOp"
   let dependentDialects = ["::mlir::tt::ttcore::TTCoreDialect"];
 }
 
+def TTCoreOptimizationBarrierFold : Pass<"ttcore-optimization-barrier-fold", "::mlir::ModuleOp">
+{
+  let summary = "Fold optimization barrier operations.";
+  let description = [{
+    This pass folds optimization barrier operations by replacing them with their operands.
+    Since optimization barriers do not hold and function runtime meaning, they can be safely
+    removed.
+  }];
+}
+
 #endif

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPass.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPass.cpp
@@ -48,6 +48,7 @@ struct ConvertStableHLOToTTIRPass
     // Common legal/illegal ops/dialects for both partial and full conversion.
     target.addLegalDialect<mlir::quant::QuantDialect>();
     target.addLegalDialect<ttir::TTIRDialect>();
+    target.addLegalDialect<ttcore::TTCoreDialect>();
     target.addLegalOp<mlir::tt::ttir::EmptyOp>();
     target.addLegalOp<mlir::ModuleOp>();
     target.addIllegalOp<mlir::tensor::EmptyOp>();

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -3057,9 +3057,8 @@ public:
           this->getTypeConverter()->convertType(resultType));
     }
 
-    auto newOp = rewriter.create<ttcore::OptimizationBarrierOp>(
-        srcOp.getLoc(), convertedResultTypes, adaptor.getOperands());
-    rewriter.replaceOp(srcOp, newOp.getResults());
+    rewriter.replaceOpWithNewOp<ttcore::OptimizationBarrierOp>(
+        srcOp, convertedResultTypes, adaptor.getOperands());
 
     return success();
   }

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNNPass.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNNPass.cpp
@@ -40,11 +40,10 @@ struct ConvertTTIRToTTNNPass
     target.addLegalDialect<BuiltinDialect>();
     target.addLegalDialect<func::FuncDialect>();
     target.addLegalDialect<ttnn::TTNNDialect>();
+    target.addLegalDialect<quant::QuantDialect>();
+    target.addIllegalDialect<ttir::TTIRDialect>();
     target.addLegalOp<ttcore::DeviceOp>();
     target.addLegalOp<ttcore::OptimizationBarrierOp>();
-    target.addIllegalDialect<ttir::TTIRDialect>();
-
-    target.addLegalDialect<quant::QuantDialect>();
 
     TypeConverter typeConverter;
     // All types map 1:1.

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNNPass.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNNPass.cpp
@@ -8,6 +8,7 @@
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOps.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIR.h"
+#include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNN.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 
@@ -40,7 +41,9 @@ struct ConvertTTIRToTTNNPass
     target.addLegalDialect<func::FuncDialect>();
     target.addLegalDialect<ttnn::TTNNDialect>();
     target.addLegalOp<ttcore::DeviceOp>();
+    target.addLegalOp<ttcore::OptimizationBarrierOp>();
     target.addIllegalDialect<ttir::TTIRDialect>();
+
     target.addLegalDialect<quant::QuantDialect>();
 
     TypeConverter typeConverter;

--- a/lib/Dialect/TTCore/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTCore/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_mlir_dialect_library(MLIRTTTransforms
+        OptimizationBarrierFold.cpp
         TTCoreModuleWrap.cpp
         TTCoreRegisterDevice.cpp
 

--- a/lib/Dialect/TTCore/Transforms/OptimizationBarrierFold.cpp
+++ b/lib/Dialect/TTCore/Transforms/OptimizationBarrierFold.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTCore/IR/TTCore.h"
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOps.h"
+#include "ttmlir/Dialect/TTCore/Transforms/Passes.h"
+
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir::tt::ttcore {
+#define GEN_PASS_DEF_TTCOREOPTIMIZATIONBARRIERFOLD
+#include "ttmlir/Dialect/TTCore/Transforms/Passes.h.inc"
+
+class OptimizationBarrierFoldPattern
+    : public mlir::OpRewritePattern<ttcore::OptimizationBarrierOp> {
+public:
+  using mlir::OpRewritePattern<ttcore::OptimizationBarrierOp>::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(ttcore::OptimizationBarrierOp op,
+                  mlir::PatternRewriter &rewriter) const override {
+    // Replace the optimization barrier with its operands
+    rewriter.replaceOp(op, op.getInputs());
+    return success();
+  }
+};
+
+class TTCoreOptimizationBarrierFold
+    : public impl::TTCoreOptimizationBarrierFoldBase<
+          TTCoreOptimizationBarrierFold> {
+public:
+  using impl::TTCoreOptimizationBarrierFoldBase<
+      TTCoreOptimizationBarrierFold>::TTCoreOptimizationBarrierFoldBase;
+  void runOnOperation() final {
+    RewritePatternSet patterns(&getContext());
+    patterns.add<OptimizationBarrierFoldPattern>(&getContext());
+    FrozenRewritePatternSet patternSet(std::move(patterns));
+
+    if (failed(applyPatternsGreedily(getOperation(), patternSet))) {
+      signalPassFailure();
+      return;
+    }
+  }
+
+  void getDependentDialects(mlir::DialectRegistry &registry) const override {
+    registry.insert<mlir::tt::ttcore::TTCoreDialect>();
+  }
+};
+
+} // namespace mlir::tt::ttcore

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -192,6 +192,9 @@ void createTTIRToTTNNBackendPipeline(
   if (options.enableTrace) {
     devicePm.addPass(tt::ttnn::createTTNNTraceHoistTransform());
   }
+  // Fold ttcore.optimization_barrier ops before deallocation
+  devicePm.addPass(ttcore::createTTCoreOptimizationBarrierFold());
+
   createTTNNPipelineDeallocPass(devicePm, options);
 
   // Run lowering to LLVM pass on hoisted funcs in CPUModule.

--- a/test/ttmlir/Conversion/StableHLOToTTIR/optimization_barrier_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/optimization_barrier_op.mlir
@@ -1,0 +1,12 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s | FileCheck %s
+
+module @jit_eltwise_optimization_barrier attributes {} {
+  func.func public @test_optimization_barrier(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
+    %0:2 = stablehlo.optimization_barrier %arg0, %arg1 : tensor<64x128xf32>, tensor<64x128xf32>
+    // CHECK: %0:2 = "ttcore.optimization_barrier"(%arg0, %arg1) : (tensor<64x128xf32>, tensor<64x128xf32>) -> (tensor<64x128xf32>, tensor<64x128xf32>)
+    %1 = stablehlo.add %0#0, %0#1 : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+    // CHECK: %2 = "ttir.add"(%0#0, %0#1, %1) : (tensor<64x128xf32>, tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+    return %1 : tensor<64x128xf32>
+  }
+}

--- a/test/ttmlir/Silicon/StableHLO/n150/optimization_barrier_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/optimization_barrier_op.mlir
@@ -1,8 +1,5 @@
 // REQUIRES: stablehlo
-// RUN: rm -rf %t.ttnn
-// RUN: rm -rf %t.mlir
-// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s | \
-// RUN:     ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" > %t.mlir
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
 
 module @jit_eltwise_optimization_barrier attributes {} {

--- a/test/ttmlir/Silicon/StableHLO/n150/optimization_barrier_op.mlir
+++ b/test/ttmlir/Silicon/StableHLO/n150/optimization_barrier_op.mlir
@@ -1,0 +1,14 @@
+// REQUIRES: stablehlo
+// RUN: rm -rf %t.ttnn
+// RUN: rm -rf %t.mlir
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline %s | \
+// RUN:     ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" > %t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %t.ttnn
+
+module @jit_eltwise_optimization_barrier attributes {} {
+  func.func public @test_optimization_barrier(%arg0: tensor<64x128xf32>, %arg1: tensor<64x128xf32>) -> tensor<64x128xf32> {
+    %0:2 = stablehlo.optimization_barrier %arg0, %arg1 : tensor<64x128xf32>, tensor<64x128xf32>
+    %1 = stablehlo.add %0#0, %0#1 : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+    return %1 : tensor<64x128xf32>
+  }
+}


### PR DESCRIPTION
Adding e2e (ttnn, ttir, and runtime) support for the `stablehlo.optimization_barrier` needed in training from` tt-xla`.
More details in: https://github.com/tenstorrent/tt-mlir/issues/4034
Fixes https://github.com/tenstorrent/tt-mlir/issues/4034