### PR TITLE
Implemented ttir relu to linalg

### DIFF
--- a/lib/Conversion/TTIRToLinalg/TTIRToLinalg.cpp
+++ b/lib/Conversion/TTIRToLinalg/TTIRToLinalg.cpp
@@ -1440,17 +1440,17 @@ public:
     Value input = adaptor.getInput();
 
     auto resultType = dyn_cast<RankedTensorType>(
-        this->getTypeConverter()->convertType(op.getResult().getType()));
+        this->getTypeConverter()->convertType(op.getType()));
 
     assert(resultType && "Result type must be a ranked tensor type.");
     DenseElementsAttr zerosAttr =
-        DenseElementsAttr::get(resultType, ArrayRef<float>(0));
+        DenseElementsAttr::get(resultType, /*value=*/0.0f);
     auto zeroes =
         rewriter.create<arith::ConstantOp>(op.getLoc(), resultType, zerosAttr);
 
     rewriter.replaceOpWithNewOp<linalg::MaxOp>(
-        op, this->getTypeConverter()->convertType(op.getType()),
-        ValueRange{input, zeroes.getResult()}, ValueRange{adaptor.getOutput()});
+        op, resultType, ValueRange{input, zeroes.getResult()},
+        ValueRange{adaptor.getOutput()});
     return success();
   }
 };

--- a/lib/Conversion/TTIRToLinalg/TTIRToLinalg.cpp
+++ b/lib/Conversion/TTIRToLinalg/TTIRToLinalg.cpp
@@ -1429,6 +1429,34 @@ public:
 } // namespace
 
 namespace {
+class ReluOpConversionPattern : public OpConversionPattern<ttir::ReluOp> {
+public:
+  using OpConversionPattern<ttir::ReluOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttir::ReluOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    Value input = adaptor.getInput();
+
+    auto resultType = dyn_cast<RankedTensorType>(
+        this->getTypeConverter()->convertType(op.getResult().getType()));
+
+    assert(resultType && "Result type must be a ranked tensor type.");
+    DenseElementsAttr zerosAttr =
+        DenseElementsAttr::get(resultType, ArrayRef<float>(0));
+    auto zeroes =
+        rewriter.create<arith::ConstantOp>(op.getLoc(), resultType, zerosAttr);
+
+    rewriter.replaceOpWithNewOp<linalg::MaxOp>(
+        op, this->getTypeConverter()->convertType(op.getType()),
+        ValueRange{input, zeroes.getResult()}, ValueRange{adaptor.getOutput()});
+    return success();
+  }
+};
+} // namespace
+
+namespace {
 class EmptyOpConversionPattern : public OpConversionPattern<ttir::EmptyOp> {
 public:
   using OpConversionPattern<ttir::EmptyOp>::OpConversionPattern;
@@ -1605,7 +1633,7 @@ public:
   LogicalResult
   matchAndRewrite(ttir::ConstantOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto value = op.getValue();
+    auto value = adaptor.getValue();
 
     auto resultType = dyn_cast<RankedTensorType>(
         this->getTypeConverter()->convertType(op.getResult().getType()));
@@ -1633,8 +1661,8 @@ void populateTTIRToLinalgPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
       ElementwiseOpConversionPattern<ttir::SqrtOp, linalg::SqrtOp>,
       SoftmaxOpConversionPattern, EmptyOpConversionPattern,
       PermuteOpConversionPattern, SliceOpConversionPattern,
-      ConstantOpConversionPattern, EmbeddingOpConversionPattern>(typeConverter,
-                                                                 ctx);
+      ConstantOpConversionPattern, EmbeddingOpConversionPattern,
+      ReluOpConversionPattern>(typeConverter, ctx);
 }
 
 void populateTTIRToTosaPatterns(MLIRContext *ctx, RewritePatternSet &patterns,

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -1780,6 +1780,7 @@ hoisted_unary_ops = [
     create_hoisted_unary_op(sin, "sin"),
     create_hoisted_unary_op(cos, "cos"),
     create_hoisted_unary_op(sum, "sum"),
+    create_hoisted_unary_op(relu, "relu"),
     pytest.param(
         create_hoisted_unary_op(softmax, "softmax"),
         marks=pytest.mark.xfail(

--- a/test/ttmlir/Conversion/TTIRToLinalg/relu.mlir
+++ b/test/ttmlir/Conversion/TTIRToLinalg/relu.mlir
@@ -1,0 +1,13 @@
+// RUN: ttmlir-opt --convert-ttir-to-linalg %s | FileCheck %s
+
+module {
+  func.func @relu_test(%arg0: tensor<64x128xf32>) -> tensor<64x128xf32> {
+    // CHECK: [[VAL0:%[0-9]+]] = tensor.empty() : [[SIZE:tensor<64x128xf32>]]
+    %0 = ttir.empty() : tensor<64x128xf32>
+    // CHECK: [[VAL1:%cst[0-9]*]] = arith.constant
+    // CHECK: [[VAL2:%[0-9]+]] = linalg.max ins(%arg0, [[VAL1]] : [[SIZE]], [[SIZE]])
+    %1 = "ttir.relu"(%arg0, %0) : (tensor<64x128xf32>, tensor<64x128xf32>) -> tensor<64x128xf32>
+    // CHECK: return [[VAL2]] : [[SIZE]]
+    return %1 : tensor<64x128xf32>
+  }
+}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/4062

### Problem description
There was no implementation of ttir.relu in linalg dialect.

### What's changed
Implemented ttir relu operation using linalg maxop by compering input and a zero and taking maximum. 
This way ttir.relu is lowered to linalg dialect.

### Checklist
- [x] New/Existing tests provide coverage for changes
