### PR TITLE
D2M: Support for memrefs with strides in ttm flatbuffers and ttrt

### DIFF
--- a/include/ttmlir/Target/TTMetal/binary.fbs
+++ b/include/ttmlir/Target/TTMetal/binary.fbs
@@ -18,6 +18,7 @@ table LayoutDesc {
 }
 
 table TensorDesc {
+  stride: [int];
   shape: [int];
   mesh_shape: [int32];
   layout: LayoutDesc;

--- a/include/ttmlir/Target/TTMetal/types.fbs
+++ b/include/ttmlir/Target/TTMetal/types.fbs
@@ -26,13 +26,26 @@ table CircularBufferConfig {
   num_buffers: uint64;
 }
 
-table BufferDesc {
-  shape: [int];
-  tile_shape: Dim2d;
-  data_type: DataType;
-  memory_space: MemorySpace;
+table SystemBuffer {
+  stride: [int];
+}
+
+table MetalBuffer {
+  buffer_type: BufferType;
   sharded_buffer_config: ShardedBufferConfig;
   circular_buffer_config: CircularBufferConfig;
+}
+
+union BufferDetail {
+  SystemBuffer,
+  MetalBuffer
+}
+
+table BufferDesc {
+  shape: [int];
+  data_type: DataType;
+  element_shape: Dim2d;
+  buffer_detail: BufferDetail;
 }
 
 table BufferRef {

--- a/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
+++ b/include/ttmlir/Target/Utils/MLIRToFlatbuffer.h
@@ -241,17 +241,15 @@ inline ::tt::target::TensorLayout toFlatbuffer(FlatbufferObjectCache &cache,
   }
 }
 
-inline ::tt::target::MemorySpace toFlatbuffer(FlatbufferObjectCache &,
-                                              ttcore::MemorySpace memspace) {
+inline ::tt::target::BufferType toFlatbuffer(FlatbufferObjectCache &,
+                                             ttcore::MemorySpace memspace) {
   switch (memspace) {
-  case ttcore::MemorySpace::System:
-    return ::tt::target::MemorySpace::System;
-  case ttcore::MemorySpace::SystemMMIO:
-    return ::tt::target::MemorySpace::SystemMMIO;
   case ttcore::MemorySpace::DeviceDRAM:
-    return ::tt::target::MemorySpace::DeviceDRAM;
+    return ::tt::target::BufferType::DRAM;
   case ttcore::MemorySpace::DeviceL1:
-    return ::tt::target::MemorySpace::DeviceL1;
+    return ::tt::target::BufferType::L1;
+  case ttcore::MemorySpace::SystemMMIO:
+  case ttcore::MemorySpace::System:
   case ttcore::MemorySpace::RegisterDst:
     llvm_unreachable("MemorySpace::RegisterDst not supported");
   }

--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -185,8 +185,11 @@ struct TensorDesc {
     return std::accumulate(shape.begin(), shape.end(), static_cast<int64_t>(1),
                            std::multiplies<int64_t>());
   }
-  std::int64_t sizeBytes() const {
-    return utils::alignUp(volume() * itemsize, alignment);
+
+  std::int64_t sizeBytes(uint32_t outerDimAlignment = 1) const {
+    return utils::alignUp(
+        stride[0] * utils::alignUp(shape[0], outerDimAlignment) * itemsize,
+        static_cast<uint32_t>(alignment));
   }
 };
 

--- a/runtime/lib/binary.cpp
+++ b/runtime/lib/binary.cpp
@@ -320,7 +320,8 @@ getTensorDescs(const ::flatbuffers::Vector<
     TensorDesc desc;
     desc.shape = {tensor->desc()->shape()->begin(),
                   tensor->desc()->shape()->end()};
-    desc.stride = utils::calculateStride(desc.shape);
+    desc.stride = {tensor->desc()->stride()->begin(),
+                   tensor->desc()->stride()->end()};
     desc.dataType = tensor->desc()->layout()->memory_desc()->data_type();
     desc.itemsize = utils::dataTypeElementSize(desc.dataType);
     tensorDescs.push_back(desc);

--- a/runtime/lib/common/dylib.cpp
+++ b/runtime/lib/common/dylib.cpp
@@ -10,6 +10,21 @@
 
 namespace tt::runtime::common {
 
+template <>
+std::vector<uint32_t> get_stride<const target::metal::BufferRef>(
+    const target::metal::BufferRef *bufferRef) {
+  std::cout << "is BufferRef" << std::endl;
+
+  const target::metal::BufferDesc *bufferDesc = bufferRef->desc();
+  assert(bufferDesc->buffer_detail_type() ==
+         target::metal::BufferDetail::SystemBuffer);
+  const target::metal::SystemBuffer *systemBuffer =
+      bufferDesc->buffer_detail_as_SystemBuffer();
+  std::vector<uint32_t> stride(systemBuffer->stride()->begin(),
+                               systemBuffer->stride()->end());
+  return stride;
+}
+
 void *loadLibraryFromMemory(const uint8_t *data, size_t size) {
   // Create an in-memory file descriptor
   int memfd = memfd_create("dylib", MFD_CLOEXEC);

--- a/runtime/lib/ttmetal/executor_utils.h
+++ b/runtime/lib/ttmetal/executor_utils.h
@@ -36,11 +36,11 @@ public:
     l1Alignment = device->allocator()->get_alignment(tt_metal::BufferType::L1);
   }
 
-  uint32_t operator()(uint32_t address, target::MemorySpace memorySpace) const {
-    return validate(address, memorySpace);
+  uint32_t operator()(uint32_t address, target::BufferType bufferType) const {
+    return validate(address, bufferType);
   }
 
-  uint32_t validate(uint32_t address, target::MemorySpace memorySpace) const {
+  uint32_t validate(uint32_t address, target::BufferType bufferType) const {
     if (!debug::Env::get().deviceAddressValidation) {
       LOG_ASSERT(address != 0);
       return address;
@@ -49,14 +49,14 @@ public:
     std::size_t unreservedBase = 0;
     std::size_t size = 0;
     std::size_t alignment = 0;
-    switch (memorySpace) {
-    case target::MemorySpace::DeviceDRAM: {
+    switch (bufferType) {
+    case target::BufferType::DRAM: {
       unreservedBase = dramUnreservedBase;
       size = dramSize;
       alignment = dramAlignment;
       break;
     }
-    case target::MemorySpace::DeviceL1: {
+    case target::BufferType::L1: {
       unreservedBase = l1UnreservedBase;
       size = l1Size;
       alignment = l1Alignment;
@@ -70,19 +70,19 @@ public:
     LOG_ASSERT(unreservedBase > 0);
     LOG_ASSERT(alignment > 0);
 
-    LOG_ASSERT(address != 0, "Device address is null for memory space[",
-               target::EnumNameMemorySpace(memorySpace), "]");
+    LOG_ASSERT(address != 0, "Device address is null for buffer type[",
+               target::EnumNameBufferType(bufferType), "]");
     LOG_ASSERT(address >= unreservedBase,
-               "Device address out of bounds for memory space[",
-               target::EnumNameMemorySpace(memorySpace), "], ",
+               "Device address out of bounds for buffer type[",
+               target::EnumNameBufferType(bufferType), "], ",
                logger::Address(address), " < unreserved base(",
                logger::Address(unreservedBase), ")");
-    LOG_ASSERT(address < size, "Device address out of bounds for memory space[",
-               target::EnumNameMemorySpace(memorySpace), "], ",
+    LOG_ASSERT(address < size, "Device address out of bounds for buffer type[",
+               target::EnumNameBufferType(bufferType), "], ",
                logger::Address(address), " >= ", logger::Address(size));
     LOG_ASSERT(address % alignment == 0,
-               "Device address not aligned for memory space[",
-               target::EnumNameMemorySpace(memorySpace), "], ",
+               "Device address not aligned for buffer type[",
+               target::EnumNameBufferType(bufferType), "], ",
                logger::Address(address), "] % ", logger::Align(alignment));
     return address;
   }
@@ -107,8 +107,13 @@ createMeshBufferFromBufferRef(
     const DeviceAddressValidator &deviceAddressValidator) {
 
   const target::metal::BufferDesc *bufferDesc = bufferRef->desc();
+
+  LOG_ASSERT(bufferDesc->buffer_detail_type() ==
+             target::metal::BufferDetail::MetalBuffer);
+  const target::metal::MetalBuffer *metalBuffer =
+      bufferDesc->buffer_detail_as_MetalBuffer();
   const target::metal::ShardedBufferConfig *shardedBufferConfig =
-      bufferDesc->sharded_buffer_config();
+      metalBuffer->sharded_buffer_config();
   const target::metal::ShardSpecBuffer *shardSpecBuffer =
       shardedBufferConfig->shard_spec_buffer();
   const target::metal::ShardSpec *shardSpec = shardSpecBuffer->shard_spec();
@@ -132,14 +137,14 @@ createMeshBufferFromBufferRef(
   tt_metal::ShardSpecBuffer metalShardSpecBuffer(metalShardSpec, pageShape,
                                                  tensorShapeInPages);
 
-  LOG_ASSERT(bufferDesc->memory_space() == target::MemorySpace::DeviceDRAM ||
-             bufferDesc->memory_space() == target::MemorySpace::DeviceL1);
+  LOG_ASSERT(metalBuffer->buffer_type() == target::BufferType::DRAM ||
+             metalBuffer->buffer_type() == target::BufferType::L1);
   tt_metal::BufferType bufferType =
-      bufferDesc->memory_space() == target::MemorySpace::DeviceDRAM
+      metalBuffer->buffer_type() == target::BufferType::DRAM
           ? tt_metal::BufferType::DRAM
           : tt_metal::BufferType::L1;
-  uint32_t address = deviceAddressValidator(bufferRef->address(),
-                                            bufferRef->desc()->memory_space());
+  uint32_t address =
+      deviceAddressValidator(bufferRef->address(), metalBuffer->buffer_type());
 
   auto localShardShape = tt_metal::Shape2D{shardShape[0], shardShape[1]};
   auto distributedBufferShape =
@@ -335,8 +340,14 @@ std::vector<std::uint32_t> processKernelArgs(
                  "Buffer id referenced by rt args is no longer alive or was "
                  "never created ",
                  logger::Buffer(buffer->global_id()));
+
+      const target::metal::BufferDesc *bufferDesc = buffer->desc();
+      LOG_ASSERT(bufferDesc->buffer_detail_type() ==
+                 target::metal::BufferDetail::MetalBuffer);
+      const target::metal::MetalBuffer *metalBuffer =
+          bufferDesc->buffer_detail_as_MetalBuffer();
       argsVec.push_back(deviceAddressValidator(buffer->address(),
-                                               buffer->desc()->memory_space()));
+                                               metalBuffer->buffer_type()));
       break;
     }
     case target::metal::KernelArgType::KernelArgSemaphore: {
@@ -486,17 +497,21 @@ inline tt_metal::CircularBufferConfig createCircularBufferConfig(
   const auto *bufferDesc = cbRef->buffer_ref()->desc();
   ::tt::DataFormat dataFormat = common::toDataFormat(bufferDesc->data_type());
   LOG_ASSERT(cbRef->buffer_ref());
+  LOG_ASSERT(bufferDesc->buffer_detail_type() ==
+             target::metal::BufferDetail::MetalBuffer);
+  const target::metal::MetalBuffer *metalBuffer =
+      bufferDesc->buffer_detail_as_MetalBuffer();
   LOG_TRACE(logger::LogRuntimeTTMetalCircularBufferCreation,
             "Creating circular buffer ", logger::Port(cbRef->port()), " ",
             logger::Buffer(cbRef->buffer_ref()->global_id()), " ",
             logger::Address(cbRef->buffer_ref()->address()), ": ",
-            *bufferDesc->circular_buffer_config());
+            *metalBuffer->circular_buffer_config());
   auto meshBuffer = meshBuffers.at(cbRef->buffer_ref()->global_id());
   return tt_metal::CircularBufferConfig(
-             bufferDesc->circular_buffer_config()->total_size(),
+             metalBuffer->circular_buffer_config()->total_size(),
              {{cbRef->port(), dataFormat}}, *meshBuffer->get_reference_buffer())
       .set_page_size(cbRef->port(),
-                     bufferDesc->circular_buffer_config()->page_size());
+                     metalBuffer->circular_buffer_config()->page_size());
 }
 
 } // namespace tt::runtime::ttmetal


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Memref stride information needs to be encoded in `ttm` flatbuffers and handled in `ttrt`.

### What's changed
- Generate `ttcore.shard` to be compatible with `memref`'s `strided` attribute produced by `ApplyHostMemrefCallingConvention`;
- Flatbuffer `BufferDesc` type extended with stride information and `BufferDetail` union to distinguish between `SystemBuffer` and `MetalBuffer`;
- `tt::runtime::TensorDesc::sizeBytes` adjusted to account for strides and support `outerDimAlignment`;
- Execution of `HostAllocCommand` adjusted to set `outerDimAlignment` to get tensor size with outer dimension aligned on tile height and/or width;
- `tt::runtime::ttmetal::memcpy(Tensor dst, Tensor src)` extended to support copying tensors with different strides;
- `populate_inputs ` in `ttrt` extended to support strided tensors.
