### PR TITLE
Use md book anchors to hoist deps from dockerfile #3755

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -5,7 +5,10 @@ SHELL ["/bin/bash", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies
-RUN apt-get update && apt-get install -y \
+RUN <<EOT
+# ANCHOR: developer_dependencies
+apt-get update
+apt-get install -y \
     software-properties-common \
     build-essential \
     python3-dev \
@@ -33,6 +36,8 @@ RUN apt-get update && apt-get install -y \
     gh \
     lcov \
     unzip
+# ANCHOR_END: developer_dependencies
+EOT
 
 # Install clang 17
 RUN wget https://apt.llvm.org/llvm.sh && \

--- a/.github/Dockerfile.ci
+++ b/.github/Dockerfile.ci
@@ -22,8 +22,12 @@ WORKDIR $BUILD_DIR/$PROJECT_NAME
 # Show last commit
 RUN git log -1
 
-RUN cmake -B env/build env && \
-    cmake --build env/build
+RUN <<EOT
+# ANCHOR: environment_build
+cmake -B env/build env
+cmake --build env/build
+# ANCHOR_END: environment_build
+EOT
 
 # Final stage
 FROM ghcr.io/tenstorrent/tt-mlir/tt-mlir-base-ubuntu-22-04:${FROM_TAG} AS ci

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -8,7 +8,7 @@ This page walks you through the steps required to set up tt-mlir.
 
 ### Hardware Setup
 
-Use this guide to set up your hardware - [Hardware Setup](./getting-started.md).
+Use this guide to set up your hardware - [Hardware Setup](https://docs.tenstorrent.com/getting-started/README.html).
 
 ### System Dependencies
 
@@ -20,7 +20,6 @@ You can use tt-mlir with Ubuntu or Mac OS, however the runtime does not work on 
 - CMake 3.24 or higher
 - Python 3.10
 - python3.10-venv
-- openmpi
 
 #### Ubuntu
 
@@ -28,7 +27,6 @@ Install Clang, Ninja, CMake, and python3.10-venv:
 
 ```bash
 sudo apt install git clang cmake ninja-build pip python3.10-venv
-wget -q https://github.com/dmakoviichuk-tt/mpi-ulfm/releases/download/v5.0.7-ulfm/openmpi-ulfm_5.0.7-1_amd64.deb -O /tmp/openmpi-ulfm.deb && sudo apt install /tmp/openmpi-ulfm.deb
 ```
 
 You should now have the required dependencies installed.
@@ -37,6 +35,11 @@ You should now have the required dependencies installed.
 > (`-DTTMLIR_ENABLE_RUNTIME=ON`), you also need to install tt-metal
 > dependencies which can be found
 > [here](https://docs.tenstorrent.com/tt-metal/latest/ttnn/ttnn/installing.html#install-system-level-dependencies).
+
+Full developer dependencies as packaged in our docker image:
+```bash
+{{#include ../../../.github/Dockerfile.base:developer_dependencies}}
+```
 
 #### Mac OS
 
@@ -83,8 +86,7 @@ sudo chown -R $USER /opt/ttmlir-toolchain
 3. Please ensure that you do not already have an environment (venv) activated before running the following commands:
 
 ```bash
-cmake -B env/build env
-cmake --build env/build
+{{#include ../../../.github/Dockerfile.ci:environment_build}}
 source env/activate
 ```
 


### PR DESCRIPTION
This implements part of #3755 and captures testing the current set of dependencies that we actually package into docker.
