### PR TITLE
[PyKernel] Enable TensorAccessor

### DIFF
--- a/include/ttmlir-c/TTKernelTypes.h
+++ b/include/ttmlir-c/TTKernelTypes.h
@@ -36,6 +36,15 @@ ttmlirTTKernelInterleavedAddrGenFastTypeGet(MlirContext ctx);
 
 MLIR_CAPI_EXPORTED MlirType ttmlirTTKernelDataFormatTypeGet(MlirContext ctx);
 
+MLIR_CAPI_EXPORTED MlirType
+ttmlirTTKernelTensorAccessorArgsTypeGet(MlirContext ctx);
+
+MLIR_CAPI_EXPORTED MlirType
+ttmlirTTKernelTensorAccessorTypeGet(MlirContext ctx);
+
+MLIR_CAPI_EXPORTED MlirType
+ttmlirTTKernelTensorAccessorPageMappingTypeGet(MlirContext ctx);
+
 MLIR_CAPI_EXPORTED MlirAttribute ttmlirTTKernelArgAttrGet(MlirContext ctx,
                                                           MlirType argType,
                                                           size_t operandIndex,

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -1346,7 +1346,9 @@ def TTKernel_NocAsyncReadTileOp : TTKernel_Op<"noc_async_read_tile"> {
       NocAsyncReadTile
     }];
 
-    let arguments = (ins I32:$id, TTKernel_InterleavedAddrGenFast:$addrGenStruct, I32:$dstLocalL1Addr);
+    let arguments = (ins I32:$id,
+                    AnyTypeOf<[TTKernel_InterleavedAddrGenFast, TTKernel_TensorAccessor]>:$addrGenStruct,
+                    I32:$dstLocalL1Addr);
 
     let assemblyFormat = [{
       `(` $id `,` $addrGenStruct `,` $dstLocalL1Addr `)` attr-dict `:` functional-type(operands, results)
@@ -1409,7 +1411,9 @@ def TTKernel_NocAsyncWriteTileOp : TTKernel_Op<"noc_async_write_tile"> {
       NocAsyncWriteTilie
     }];
 
-    let arguments = (ins IndexLike:$id, TTKernel_InterleavedAddrGenFast:$addrGenStruct, I32:$srcLocalL1Addr);
+    let arguments = (ins IndexLike:$id,
+                    AnyTypeOf<[TTKernel_InterleavedAddrGenFast, TTKernel_TensorAccessor]>:$addrGenStruct,
+                    I32:$srcLocalL1Addr);
 
     let assemblyFormat = [{
       `(` $id `,` $addrGenStruct `,` $srcLocalL1Addr `)` attr-dict `:` functional-type(operands, results)

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -1789,7 +1789,7 @@ def TTKernel_NocAsyncWriteMulticastLoopbackSrcOp : TTKernel_Op<"noc_async_write_
 // TTKernel TensorAccessor operations
 //===----------------------------------------------------------------------===//
 
-def TTKernel_MakeTensorAccessorArgsOp : TTKernel_Op<"TensorAccessorArgs"> {
+def TTKernel_TensorAccessorArgsOp : TTKernel_Op<"TensorAccessorArgs"> {
   let summary = "TensorAccessorArgs";
   let description = [{
     TensorAccessorArgs struct constructor.
@@ -1799,7 +1799,7 @@ def TTKernel_MakeTensorAccessorArgsOp : TTKernel_Op<"TensorAccessorArgs"> {
   let results = (outs TTKernel_TensorAccessorArgs:$result);
 }
 
-def TTKernel_MakeTensorAccessorFromArgsOp : TTKernel_Op<"TensorAccessor"> {
+def TTKernel_TensorAccessorOp : TTKernel_Op<"TensorAccessor"> {
   let summary = "MakeTensorAccessorFromArgs";
   let description = [{
     TensorAccessor constructor.

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -1809,7 +1809,7 @@ def TTKernel_MakeTensorAccessorFromArgsOp : TTKernel_Op<"TensorAccessor"> {
   let results = (outs TTKernel_TensorAccessor:$result);
 }
 
-def TTKernel_TensorAccessorGetNocAddrOp : TTKernel_Op<"get_noc_addr_from_tensor_accessor"> {
+def TTKernel_TensorAccessorGetNocAddrOp : TTKernel_Op<"tensor_accessor_get_noc_addr"> {
   let summary = "";
   let description = [{
 
@@ -1818,7 +1818,7 @@ def TTKernel_TensorAccessorGetNocAddrOp : TTKernel_Op<"get_noc_addr_from_tensor_
   let results = (outs TTKernel_NocAddr:$nocAddr);
 }
 
-def TTKernel_TensorAccessorGetShardNocAddrOp : TTKernel_Op<"get_shard_noc_addr"> {
+def TTKernel_TensorAccessorGetShardNocAddrOp : TTKernel_Op<"tensor_accessor_get_shard_noc_addr"> {
   let summary = "";
   let description = [{
 
@@ -1827,7 +1827,7 @@ def TTKernel_TensorAccessorGetShardNocAddrOp : TTKernel_Op<"get_shard_noc_addr">
   let results = (outs I32:$shardNocAddr);
 }
 
-def TTKernel_TensorAccessorGetBankAndOffsetOp : TTKernel_Op<"get_bank_and_offset"> {
+def TTKernel_TensorAccessorGetBankAndOffsetOp : TTKernel_Op<"tensor_accessor_get_bank_and_offset"> {
   let summary = "";
   let description = [{
 
@@ -1836,7 +1836,7 @@ def TTKernel_TensorAccessorGetBankAndOffsetOp : TTKernel_Op<"get_bank_and_offset
   let results = (outs TTKernel_TensorAccessorPageMapping:$bank_id_and_offset);
 }
 
-def TTKernel_TensorAccessorIsLocalBankOp : TTKernel_Op<"is_local_bank"> {
+def TTKernel_TensorAccessorIsLocalBankOp : TTKernel_Op<"tensor_accessor_is_local_bank"> {
   let summary = "";
   let description = [{
 
@@ -1845,7 +1845,7 @@ def TTKernel_TensorAccessorIsLocalBankOp : TTKernel_Op<"is_local_bank"> {
   let results = (outs I1:$result);
 }
 
-def TTKernel_TensorAccessorIsLocalAddrOp : TTKernel_Op<"is_local_addr"> {
+def TTKernel_TensorAccessorIsLocalAddrOp : TTKernel_Op<"tensor_accessor_is_local_addr"> {
   let summary = "";
   let description = [{
 
@@ -1854,7 +1854,7 @@ def TTKernel_TensorAccessorIsLocalAddrOp : TTKernel_Op<"is_local_addr"> {
   let results = (outs I1:$result);
 }
 
-def TTKernel_TensorAccessorIsLocalPageOp : TTKernel_Op<"is_local_page"> {
+def TTKernel_TensorAccessorIsLocalPageOp : TTKernel_Op<"tensor_accessor_is_local_page"> {
   let summary = "";
   let description = [{
 
@@ -1863,7 +1863,7 @@ def TTKernel_TensorAccessorIsLocalPageOp : TTKernel_Op<"is_local_page"> {
   let results = (outs I1:$result);
 }
 
-def TTKernel_TensorAccessorIsLocalShardOp : TTKernel_Op<"is_local_shard"> {
+def TTKernel_TensorAccessorIsLocalShardOp : TTKernel_Op<"tensor_accessor_is_local_shard"> {
   let summary = "";
   let description = [{
 

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -1661,6 +1661,26 @@ def TTKernel_GetInterleavedAddrGenFastOp : TTKernel_Op<"get_interleaved_addr_gen
     }];
 }
 
+def TTKernel_MakeTensorAccessorArgsOp : TTKernel_Op<"make_tensor_accessor_args"> {
+  let summary = "MakeTensorAccessorArgs";
+  let description = [{
+    Helper function that returns ArgsOffsets, later used to create a TensorAccessor.
+  }];
+
+  let arguments = (ins I32:$cta_base, I32:$crta_base);
+  let results = (outs TTKernel_ArgsOffsets:$result);
+}
+
+def TTKernel_MakeTensorAccessorFromArgsOp : TTKernel_Op<"make_tensor_accessor_from_args"> {
+  let summary = "MakeTensorAccessorFromArgs";
+  let description = [{
+    Creates a TensorAccessor from the provided ArgsOffsets
+  }];
+
+  let arguments = (ins TTKernel_ArgsOffsets:$args, I32:$bank_base_address_in, I32:$page_size_in);
+  let results = (outs TTKernel_TensorAccessor:$result);
+}
+
 def TTKernel_MyXOp : TTKernel_Op<"my_x"> {
     let summary = "MyX";
     let description = [{

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -1797,6 +1797,10 @@ def TTKernel_TensorAccessorArgsOp : TTKernel_Op<"TensorAccessorArgs"> {
 
   let arguments = (ins I32:$cta_base, I32:$crta_base);
   let results = (outs TTKernel_TensorAccessorArgs:$result);
+
+  let assemblyFormat = [{
+    `(` $cta_base `,` $crta_base `)` attr-dict `:` functional-type(operands, results)
+  }];
 }
 
 def TTKernel_TensorAccessorOp : TTKernel_Op<"TensorAccessor"> {
@@ -1807,6 +1811,10 @@ def TTKernel_TensorAccessorOp : TTKernel_Op<"TensorAccessor"> {
 
   let arguments = (ins TTKernel_TensorAccessorArgs:$args, I32:$bank_base_address_in, I32:$page_size_in);
   let results = (outs TTKernel_TensorAccessor:$result);
+
+  let assemblyFormat = [{
+    `(` $args `,` $bank_base_address_in `,` $page_size_in `)` attr-dict `:` functional-type(operands, results)
+  }];
 }
 
 def TTKernel_TensorAccessorGetNocAddrOp : TTKernel_Op<"tensor_accessor_get_noc_addr"> {
@@ -1816,6 +1824,10 @@ def TTKernel_TensorAccessorGetNocAddrOp : TTKernel_Op<"tensor_accessor_get_noc_a
   }];
   let arguments = (ins TTKernel_TensorAccessor:$tensor_accessor, I32:$id, I32:$offset, Optional<I8>:$noc);
   let results = (outs TTKernel_NocAddr:$nocAddr);
+
+  let assemblyFormat = [{
+    `(` $tensor_accessor `,` $id `,` $offset (`,` $noc^)? `)` attr-dict `:` functional-type(operands, results)
+  }];
 }
 
 def TTKernel_TensorAccessorGetShardNocAddrOp : TTKernel_Op<"tensor_accessor_get_shard_noc_addr"> {
@@ -1825,6 +1837,10 @@ def TTKernel_TensorAccessorGetShardNocAddrOp : TTKernel_Op<"tensor_accessor_get_
   }];
   let arguments = (ins TTKernel_TensorAccessor:$tensor_accessor, I32:$shard_id, I32:$offset, Optional<I8>:$noc);
   let results = (outs I32:$shardNocAddr);
+
+  let assemblyFormat = [{
+    `(` $tensor_accessor `,` $shard_id `,` $offset (`,` $noc^)? `)` attr-dict `:` functional-type(operands, results)
+  }];
 }
 
 def TTKernel_TensorAccessorGetBankAndOffsetOp : TTKernel_Op<"tensor_accessor_get_bank_and_offset"> {
@@ -1834,6 +1850,10 @@ def TTKernel_TensorAccessorGetBankAndOffsetOp : TTKernel_Op<"tensor_accessor_get
   }];
   let arguments = (ins TTKernel_TensorAccessor:$tensor_accessor, I32:$page_id);
   let results = (outs TTKernel_TensorAccessorPageMapping:$bank_id_and_offset);
+
+  let assemblyFormat = [{
+    `(` $tensor_accessor `,` $page_id `)` attr-dict `:` functional-type(operands, results)
+  }];
 }
 
 def TTKernel_TensorAccessorIsLocalBankOp : TTKernel_Op<"tensor_accessor_is_local_bank"> {
@@ -1843,6 +1863,10 @@ def TTKernel_TensorAccessorIsLocalBankOp : TTKernel_Op<"tensor_accessor_is_local
   }];
   let arguments = (ins TTKernel_TensorAccessor:$tensor_accessor, I32:$id, I32:$offset, Optional<I8>:$noc);
   let results = (outs I1:$result);
+
+  let assemblyFormat = [{
+    `(` $tensor_accessor `,` $id `,` $offset (`,` $noc^)? `)` attr-dict `:` functional-type(operands, results)
+  }];
 }
 
 def TTKernel_TensorAccessorIsLocalAddrOp : TTKernel_Op<"tensor_accessor_is_local_addr"> {
@@ -1852,6 +1876,10 @@ def TTKernel_TensorAccessorIsLocalAddrOp : TTKernel_Op<"tensor_accessor_is_local
   }];
   let arguments = (ins TTKernel_TensorAccessor:$tensor_accessor, I32:$virtual_x, I32:$virtual_y, Optional<I8>:$noc);
   let results = (outs I1:$result);
+
+  let assemblyFormat = [{
+    `(` $tensor_accessor `,` $virtual_x `,` $virtual_y (`,` $noc^)? `)` attr-dict `:` functional-type(operands, results)
+  }];
 }
 
 def TTKernel_TensorAccessorIsLocalPageOp : TTKernel_Op<"tensor_accessor_is_local_page"> {
@@ -1861,6 +1889,10 @@ def TTKernel_TensorAccessorIsLocalPageOp : TTKernel_Op<"tensor_accessor_is_local
   }];
   let arguments = (ins TTKernel_TensorAccessor:$tensor_accessor, I32:$page_id, Optional<I8>:$noc);
   let results = (outs I1:$result);
+
+  let assemblyFormat = [{
+    `(` $tensor_accessor `,` $page_id (`,` $noc^)? `)` attr-dict `:` functional-type(operands, results)
+  }];
 }
 
 def TTKernel_TensorAccessorIsLocalShardOp : TTKernel_Op<"tensor_accessor_is_local_shard"> {
@@ -1870,6 +1902,10 @@ def TTKernel_TensorAccessorIsLocalShardOp : TTKernel_Op<"tensor_accessor_is_loca
   }];
   let arguments = (ins TTKernel_TensorAccessor:$tensor_accessor, I32:$shard_id, Optional<I8>:$noc);
   let results = (outs I1:$result);
+
+  let assemblyFormat = [{
+    `(` $tensor_accessor `,` $shard_id (`,` $noc^)? `)` attr-dict `:` functional-type(operands, results)
+  }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -1665,23 +1665,23 @@ def TTKernel_GetInterleavedAddrGenFastOp : TTKernel_Op<"get_interleaved_addr_gen
     }];
 }
 
-def TTKernel_MakeTensorAccessorArgsOp : TTKernel_Op<"make_tensor_accessor_args"> {
-  let summary = "MakeTensorAccessorArgs";
+def TTKernel_MakeTensorAccessorArgsOp : TTKernel_Op<"TensorAccessorArgs"> {
+  let summary = "TensorAccessorArgs";
   let description = [{
-    Helper function that returns ArgsOffsets, later used to create a TensorAccessor.
+    TensorAccessorArgs struct constructor.
   }];
 
   let arguments = (ins I32:$cta_base, I32:$crta_base);
-  let results = (outs TTKernel_ArgsOffsets:$result);
+  let results = (outs TTKernel_TensorAccessorArgs:$result);
 }
 
-def TTKernel_MakeTensorAccessorFromArgsOp : TTKernel_Op<"make_tensor_accessor_from_args"> {
+def TTKernel_MakeTensorAccessorFromArgsOp : TTKernel_Op<"TensorAccessor"> {
   let summary = "MakeTensorAccessorFromArgs";
   let description = [{
-    Creates a TensorAccessor from the provided ArgsOffsets
+    TensorAccessor constructor.
   }];
 
-  let arguments = (ins TTKernel_ArgsOffsets:$args, I32:$bank_base_address_in, I32:$page_size_in);
+  let arguments = (ins TTKernel_TensorAccessorArgs:$args, I32:$bank_base_address_in, I32:$page_size_in);
   let results = (outs TTKernel_TensorAccessor:$result);
 }
 

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -1665,26 +1665,6 @@ def TTKernel_GetInterleavedAddrGenFastOp : TTKernel_Op<"get_interleaved_addr_gen
     }];
 }
 
-def TTKernel_MakeTensorAccessorArgsOp : TTKernel_Op<"TensorAccessorArgs"> {
-  let summary = "TensorAccessorArgs";
-  let description = [{
-    TensorAccessorArgs struct constructor.
-  }];
-
-  let arguments = (ins I32:$cta_base, I32:$crta_base);
-  let results = (outs TTKernel_TensorAccessorArgs:$result);
-}
-
-def TTKernel_MakeTensorAccessorFromArgsOp : TTKernel_Op<"TensorAccessor"> {
-  let summary = "MakeTensorAccessorFromArgs";
-  let description = [{
-    TensorAccessor constructor.
-  }];
-
-  let arguments = (ins TTKernel_TensorAccessorArgs:$args, I32:$bank_base_address_in, I32:$page_size_in);
-  let results = (outs TTKernel_TensorAccessor:$result);
-}
-
 def TTKernel_MyXOp : TTKernel_Op<"my_x"> {
     let summary = "MyX";
     let description = [{
@@ -1803,6 +1783,93 @@ def TTKernel_NocAsyncWriteMulticastLoopbackSrcOp : TTKernel_Op<"noc_async_write_
   let assemblyFormat = [{
     `(` $srcLocalL1Addr `,` $dstNocAddrMulticast `,` $size `,` $num_dests (`,` $linked^)? (`,` $multicast_path_reserve^)? (`,` $noc^)? `)` attr-dict `:` functional-type(operands, results)
   }];
+}
+
+//===----------------------------------------------------------------------===//
+// TTKernel TensorAccessor operations
+//===----------------------------------------------------------------------===//
+
+def TTKernel_MakeTensorAccessorArgsOp : TTKernel_Op<"TensorAccessorArgs"> {
+  let summary = "TensorAccessorArgs";
+  let description = [{
+    TensorAccessorArgs struct constructor.
+  }];
+
+  let arguments = (ins I32:$cta_base, I32:$crta_base);
+  let results = (outs TTKernel_TensorAccessorArgs:$result);
+}
+
+def TTKernel_MakeTensorAccessorFromArgsOp : TTKernel_Op<"TensorAccessor"> {
+  let summary = "MakeTensorAccessorFromArgs";
+  let description = [{
+    TensorAccessor constructor.
+  }];
+
+  let arguments = (ins TTKernel_TensorAccessorArgs:$args, I32:$bank_base_address_in, I32:$page_size_in);
+  let results = (outs TTKernel_TensorAccessor:$result);
+}
+
+def TTKernel_TensorAccessorGetNocAddrOp : TTKernel_Op<"get_noc_addr_from_tensor_accessor"> {
+  let summary = "";
+  let description = [{
+
+  }];
+  let arguments = (ins TTKernel_TensorAccessor:$tensor_accessor, I32:$id, I32:$offset, Optional<I8>:$noc);
+  let results = (outs TTKernel_NocAddr:$nocAddr);
+}
+
+def TTKernel_TensorAccessorGetShardNocAddrOp : TTKernel_Op<"get_shard_noc_addr"> {
+  let summary = "";
+  let description = [{
+
+  }];
+  let arguments = (ins TTKernel_TensorAccessor:$tensor_accessor, I32:$shard_id, I32:$offset, Optional<I8>:$noc);
+  let results = (outs I32:$shardNocAddr);
+}
+
+def TTKernel_TensorAccessorGetBankAndOffsetOp : TTKernel_Op<"get_bank_and_offset"> {
+  let summary = "";
+  let description = [{
+
+  }];
+  let arguments = (ins TTKernel_TensorAccessor:$tensor_accessor, I32:$page_id);
+  let results = (outs TTKernel_TensorAccessorPageMapping:$bank_id_and_offset);
+}
+
+def TTKernel_TensorAccessorIsLocalBankOp : TTKernel_Op<"is_local_bank"> {
+  let summary = "";
+  let description = [{
+
+  }];
+  let arguments = (ins TTKernel_TensorAccessor:$tensor_accessor, I32:$id, I32:$offset, Optional<I8>:$noc);
+  let results = (outs I1:$result);
+}
+
+def TTKernel_TensorAccessorIsLocalAddrOp : TTKernel_Op<"is_local_addr"> {
+  let summary = "";
+  let description = [{
+
+  }];
+  let arguments = (ins TTKernel_TensorAccessor:$tensor_accessor, I32:$virtual_x, I32:$virtual_y, Optional<I8>:$noc);
+  let results = (outs I1:$result);
+}
+
+def TTKernel_TensorAccessorIsLocalPageOp : TTKernel_Op<"is_local_page"> {
+  let summary = "";
+  let description = [{
+
+  }];
+  let arguments = (ins TTKernel_TensorAccessor:$tensor_accessor, I32:$page_id, Optional<I8>:$noc);
+  let results = (outs I1:$result);
+}
+
+def TTKernel_TensorAccessorIsLocalShardOp : TTKernel_Op<"is_local_shard"> {
+  let summary = "";
+  let description = [{
+
+  }];
+  let arguments = (ins TTKernel_TensorAccessor:$tensor_accessor, I32:$shard_id, Optional<I8>:$noc);
+  let results = (outs I1:$result);
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
@@ -79,6 +79,16 @@ def TTKernel_InterleavedAddrGenFast : TTKernel_Type<"InterleavedAddrGenFast", "i
     let description = "InterleavedAddrGenFast type in TTKernel dialect";
 }
 
+def TTKernel_ArgsOffsets : TTKernel_Type<"ArgsOffsets", "ArgsOffsets"> {
+  let summary = "TensorAccessor's ArgsOffsets type";
+  let description = "TensorAccessor args type that stores compile + runtime information";
+}
+
+def TTKernel_TensorAccessor : TTKernel_Type<"TensorAccessor", "TensorAccessor"> {
+  let summary = "TensorAccessor type";
+  let description = "Accessor that encapsulates logic to access tensor config and pages.";
+}
+
 def TTKernel_DataFormat : TTKernel_Type<"DataFormat", "DataFormat"> {
     let summary = "TTKernel compute data format type";
     let description = "Data format type in TTKernel dialect";

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
@@ -89,6 +89,11 @@ def TTKernel_TensorAccessor : TTKernel_Type<"TensorAccessor", "TensorAccessor"> 
   let description = "Accessor that encapsulates logic to access tensor information";
 }
 
+def TTKernel_TensorAccessorPageMapping : TTKernel_Type<"TensorAccessorPageMapping", "PageMapping"> {
+  let summary = "TensorAccessor PageMapping struct";
+  let description = "TensorAccessor struct that holds bank_id and bank_page_offset";
+}
+
 def TTKernel_DataFormat : TTKernel_Type<"DataFormat", "DataFormat"> {
     let summary = "TTKernel compute data format type";
     let description = "Data format type in TTKernel dialect";

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOpsTypes.td
@@ -79,14 +79,14 @@ def TTKernel_InterleavedAddrGenFast : TTKernel_Type<"InterleavedAddrGenFast", "i
     let description = "InterleavedAddrGenFast type in TTKernel dialect";
 }
 
-def TTKernel_ArgsOffsets : TTKernel_Type<"ArgsOffsets", "ArgsOffsets"> {
-  let summary = "TensorAccessor's ArgsOffsets type";
+def TTKernel_TensorAccessorArgs : TTKernel_Type<"TensorAccessorArgs", "TensorAccessorArgs"> {
+  let summary = "TensorAccessorArgs type";
   let description = "TensorAccessor args type that stores compile + runtime information";
 }
 
 def TTKernel_TensorAccessor : TTKernel_Type<"TensorAccessor", "TensorAccessor"> {
   let summary = "TensorAccessor type";
-  let description = "Accessor that encapsulates logic to access tensor config and pages.";
+  let description = "Accessor that encapsulates logic to access tensor information";
 }
 
 def TTKernel_DataFormat : TTKernel_Type<"DataFormat", "DataFormat"> {

--- a/lib/CAPI/TTKernelTypes.cpp
+++ b/lib/CAPI/TTKernelTypes.cpp
@@ -57,6 +57,18 @@ MlirType ttmlirTTKernelDataFormatTypeGet(MlirContext ctx) {
   return wrap(DataFormatType::get(unwrap(ctx)));
 }
 
+MlirType ttmlirTTKernelTensorAccessorArgsTypeGet(MlirContext ctx) {
+  return wrap(TensorAccessorArgsType::get(unwrap(ctx)));
+}
+
+MlirType ttmlirTTKernelTensorAccessorTypeGet(MlirContext ctx) {
+  return wrap(TensorAccessorType::get(unwrap(ctx)));
+}
+
+MlirType ttmlirTTKernelTensorAccessorPageMappingTypeGet(MlirContext ctx) {
+  return wrap(TensorAccessorPageMappingType::get(unwrap(ctx)));
+}
+
 MlirAttribute ttmlirTTKernelArgAttrGet(MlirContext ctx, uint32_t argTypeValue,
                                        size_t operandIndex, bool isUniform) {
   return wrap(ArgAttr::get(unwrap(ctx), static_cast<ArgType>(argTypeValue),

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -534,17 +534,17 @@ public:
 } // namespace
 
 namespace {
-class TTKernelMakeTensorAccessorArgsOpRewriter
-    : public OpConversionPattern<ttkernel::MakeTensorAccessorArgsOp> {
-  using Op = ttkernel::MakeTensorAccessorArgsOp;
+class TTKernelTensorAccessorArgsOpRewriter
+    : public OpConversionPattern<ttkernel::TensorAccessorArgsOp> {
+  using Op = ttkernel::TensorAccessorArgsOp;
 
 public:
-  TTKernelMakeTensorAccessorArgsOpRewriter(const TypeConverter &typeConverter,
-                                           MLIRContext *context)
+  TTKernelTensorAccessorArgsOpRewriter(const TypeConverter &typeConverter,
+                                       MLIRContext *context)
       : OpConversionPattern(typeConverter, context) {}
 
   LogicalResult
-  matchAndRewrite(Op op, ttkernel::MakeTensorAccessorArgsOp::Adaptor adaptor,
+  matchAndRewrite(Op op, ttkernel::TensorAccessorArgsOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     if (op.getResult().getUses().empty()) {
       rewriter.eraseOp(op);
@@ -815,7 +815,7 @@ public:
         TTKernelToEmitCOpaqueRewriter<ttkernel::GetTileSizeOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::GetNocAddrFromBankIDOp>,
         TTKernelToEmitCOpaqueRewriter<ttkernel::GetDataFormatOp>,
-        TTKernelToEmitCOpaqueRewriter<ttkernel::MakeTensorAccessorFromArgsOp>>(
+        TTKernelToEmitCOpaqueRewriter<ttkernel::TensorAccessorOp>>(
         typeConverter, funcOp.getContext());
 
     patterns.add<TTKernelToEmitCOpaqueRewriter<ttkernel::GetNocAddrOp>>(
@@ -832,8 +832,8 @@ public:
     patterns.add<TTKernelGetInterleavedAddrGenFastOpRewriter>(
         typeConverter, funcOp.getContext());
 
-    patterns.add<TTKernelMakeTensorAccessorArgsOpRewriter>(typeConverter,
-                                                           funcOp.getContext());
+    patterns.add<TTKernelTensorAccessorArgsOpRewriter>(typeConverter,
+                                                       funcOp.getContext());
 
     patterns.add<
         TTKernelTensorAccessorOpsRewriter<ttkernel::TensorAccessorGetNocAddrOp>,

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -196,9 +196,10 @@ public:
           // There is never a case in metal kernel code where template is false.
           return emitc::OpaqueType::get(ctx, "InterleavedAddrGenFast<true>");
         });
-    addConversion([ctx](mlir::tt::ttkernel::TensorAccessorArgsType type) -> Type {
-      return emitc::OpaqueType::get(ctx, "TensorAccessorArgs");
-    });
+    addConversion(
+        [ctx](mlir::tt::ttkernel::TensorAccessorArgsType type) -> Type {
+          return emitc::OpaqueType::get(ctx, "TensorAccessorArgs");
+        });
     addConversion([ctx](mlir::tt::ttkernel::TensorAccessorType type) -> Type {
       return emitc::OpaqueType::get(ctx, "TensorAccessor");
     });
@@ -322,7 +323,7 @@ public:
       template_args.push_back(
           datatypeToDataformatEnumValue(builder, op.getOutDtype()));
       return ArrayAttr::get(op.getContext(), template_args);
-    } 
+    }
     // else if constexpr (std::is_same_v<
     //                          SourceOp,
     //                          ttkernel::MakeTensorAccessorFromArgsOp>) {

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -196,8 +196,8 @@ public:
           // There is never a case in metal kernel code where template is false.
           return emitc::OpaqueType::get(ctx, "InterleavedAddrGenFast<true>");
         });
-    addConversion([ctx](mlir::tt::ttkernel::ArgsOffsetsType type) -> Type {
-      return emitc::OpaqueType::get(ctx, "ArgsOffsets");
+    addConversion([ctx](mlir::tt::ttkernel::TensorAccessorArgsType type) -> Type {
+      return emitc::OpaqueType::get(ctx, "TensorAccessorArgs");
     });
     addConversion([ctx](mlir::tt::ttkernel::TensorAccessorType type) -> Type {
       return emitc::OpaqueType::get(ctx, "TensorAccessor");
@@ -322,14 +322,15 @@ public:
       template_args.push_back(
           datatypeToDataformatEnumValue(builder, op.getOutDtype()));
       return ArrayAttr::get(op.getContext(), template_args);
-    } else if constexpr (std::is_same_v<
-                             SourceOp,
-                             ttkernel::MakeTensorAccessorFromArgsOp>) {
-      SmallVector<Attribute, 1> template_args;
-      template_args.push_back(emitc::OpaqueAttr::get(
-          op.getContext(), "tensor_accessor::ArgsOffsets"));
-      return ArrayAttr::get(op.getContext(), template_args);
-    }
+    } 
+    // else if constexpr (std::is_same_v<
+    //                          SourceOp,
+    //                          ttkernel::MakeTensorAccessorFromArgsOp>) {
+    //   SmallVector<Attribute, 1> template_args;
+    //   template_args.push_back(emitc::OpaqueAttr::get(
+    //       op.getContext(), "tensor_accessor::ArgsOffsets"));
+    //   return ArrayAttr::get(op.getContext(), template_args);
+    // }
     return ArrayAttr();
   }
 

--- a/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
+++ b/lib/Conversion/TTKernelToEmitC/TTKernelToEmitC.cpp
@@ -586,10 +586,8 @@ public:
   LogicalResult
   matchAndRewrite(SourceOp op, Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
-    auto name = op.getOperation()->getName().getStringRef().drop_front(9);
-    if (name.ends_with("_from_tensor_accessor")) {
-      name = name.drop_back(21);
-    }
+    // Drop "ttkernel.tensor_accessor_" prefix
+    auto name = op.getOperation()->getName().getStringRef().drop_front(25);
 
     auto operands = adaptor.getOperands();
     if (operands.empty()) {

--- a/python/TTKernelModule.cpp
+++ b/python/TTKernelModule.cpp
@@ -76,6 +76,17 @@ void populateTTKernelModule(nb::module_ &m) {
   tt_type_class<tt::ttkernel::DataFormatType>(m, "DataFormatType")
       .def_static("get", &ttmlirTTKernelDataFormatTypeGet);
 
+  tt_type_class<tt::ttkernel::TensorAccessorArgsType>(m,
+                                                      "TensorAccessorArgsType")
+      .def_static("get", &ttmlirTTKernelTensorAccessorArgsTypeGet);
+
+  tt_type_class<tt::ttkernel::TensorAccessorType>(m, "TensorAccessorType")
+      .def_static("get", &ttmlirTTKernelTensorAccessorTypeGet);
+
+  tt_type_class<tt::ttkernel::TensorAccessorPageMappingType>(
+      m, "TensorAccessorPageMappingType")
+      .def_static("get", &ttmlirTTKernelTensorAccessorPageMappingTypeGet);
+
   tt_attribute_class<tt::ttkernel::ArgAttr>(m, "ArgAttr")
       .def_static(
           "get",

--- a/test/pykernel/demo/eltwise_sfpu_demo.py
+++ b/test/pykernel/demo/eltwise_sfpu_demo.py
@@ -53,8 +53,8 @@ class EltwiseSFPUPyKernelOp(PyKernelOp):
         onetile = 1
         tile_bytes = get_tile_size(cb_out)
 
-        tensor_accessor_args = make_tensor_accessor_args(2, 0)
-        s0 = make_tensor_accessor_from_args(tensor_accessor_args, dst_addr, tile_bytes)
+        tensor_accessor_args = TensorAccessorArgs(2, 0)
+        s0 = TensorAccessor(tensor_accessor_args, dst_addr, tile_bytes)
 
         end_id = start_id + num_tiles
         ii: int = start_id
@@ -78,8 +78,8 @@ class EltwiseSFPUPyKernelOp(PyKernelOp):
         onetile = 1
         tile_bytes = get_tile_size(cb_in)
 
-        tensor_accessor_args = make_tensor_accessor_args(2, 0)
-        s0 = make_tensor_accessor_from_args(tensor_accessor_args, src_addr, tile_bytes)
+        tensor_accessor_args = TensorAccessorArgs(2, 0)
+        s0 = TensorAccessor(tensor_accessor_args, src_addr, tile_bytes)
 
         end_id = start_id + num_tiles
         ii: int = start_id

--- a/test/pykernel/demo/eltwise_sfpu_demo.py
+++ b/test/pykernel/demo/eltwise_sfpu_demo.py
@@ -13,7 +13,7 @@ import torch
 
 class EltwiseSFPUPyKernelOp(PyKernelOp):
     # KERNEL DEFINITIONS
-    @compute_thread(optimize=True)
+    @compute_thread()
     def eltwise_sfpu(
         cb_in: CircularBuffer,
         cb_out: CircularBuffer,
@@ -42,7 +42,7 @@ class EltwiseSFPUPyKernelOp(PyKernelOp):
             cb_push_back(cb_out, per_core_block_dim)
         return
 
-    @writer_thread(optimize=True)
+    @writer_thread()
     def writer_unary_interleaved(
         cb_in: CircularBuffer,
         cb_out: CircularBuffer,
@@ -67,7 +67,7 @@ class EltwiseSFPUPyKernelOp(PyKernelOp):
             ii += onetile
         return
 
-    @reader_thread(optimize=True)
+    @reader_thread()
     def reader_unary_interleaved(
         cb_in: CircularBuffer,
         cb_out: CircularBuffer,

--- a/test/pykernel/demo/eltwise_sfpu_demo.py
+++ b/test/pykernel/demo/eltwise_sfpu_demo.py
@@ -102,9 +102,7 @@ class EltwiseSFPUPyKernelOp(PyKernelOp):
         start_id = 0
         num_tiles = ceil(max(map(lambda t: t.volume(), [in_tensor, out_tensor])) / 1024)
 
-        self.tensor_accessor_config = TensorAccessorConfig.combine(
-            TensorAccessorConfig.IsDram
-        )
+        self.set_tensor_accessor_config([in_tensor, out_tensor])
 
         kernels = [
             self.create_kernel(

--- a/test/pykernel/demo/eltwise_sfpu_demo.py
+++ b/test/pykernel/demo/eltwise_sfpu_demo.py
@@ -44,7 +44,6 @@ class EltwiseSFPUPyKernelOp(PyKernelOp):
 
     @writer_thread()
     def writer_unary_interleaved(
-        cb_in: CircularBuffer,
         cb_out: CircularBuffer,
         dst_addr,
         num_tiles,
@@ -53,7 +52,7 @@ class EltwiseSFPUPyKernelOp(PyKernelOp):
         onetile = 1
         tile_bytes = get_tile_size(cb_out)
 
-        tensor_accessor_args = TensorAccessorArgs(2, 0)
+        tensor_accessor_args = TensorAccessorArgs(1, 0)
         s0 = TensorAccessor(tensor_accessor_args, dst_addr, tile_bytes)
 
         end_id = start_id + num_tiles
@@ -70,7 +69,6 @@ class EltwiseSFPUPyKernelOp(PyKernelOp):
     @reader_thread()
     def reader_unary_interleaved(
         cb_in: CircularBuffer,
-        cb_out: CircularBuffer,
         src_addr,
         num_tiles,
         start_id,
@@ -78,7 +76,7 @@ class EltwiseSFPUPyKernelOp(PyKernelOp):
         onetile = 1
         tile_bytes = get_tile_size(cb_in)
 
-        tensor_accessor_args = TensorAccessorArgs(2, 0)
+        tensor_accessor_args = TensorAccessorArgs(1, 0)
         s0 = TensorAccessor(tensor_accessor_args, src_addr, tile_bytes)
 
         end_id = start_id + num_tiles
@@ -114,7 +112,6 @@ class EltwiseSFPUPyKernelOp(PyKernelOp):
             ),
             self.create_kernel(
                 EltwiseSFPUPyKernelOp.writer_unary_interleaved,
-                cb_in,
                 cb_out,
                 out_tensor.buffer_address(),
                 num_tiles,
@@ -123,7 +120,6 @@ class EltwiseSFPUPyKernelOp(PyKernelOp):
             self.create_kernel(
                 EltwiseSFPUPyKernelOp.reader_unary_interleaved,
                 cb_in,
-                cb_out,
                 in_tensor.buffer_address(),
                 num_tiles,
                 start_id,

--- a/test/pykernel/demo/matmul_multicore_demo.py
+++ b/test/pykernel/demo/matmul_multicore_demo.py
@@ -62,18 +62,12 @@ class MatmulMulticorePyKernelOp(PyKernelOp):
         num_tiles,
     ):
         in0_tile_bytes = get_tile_size(cb_in0)
-        in0_dataformat = get_dataformat(cb_in0)
-
-        addr_gen_a = get_interleaved_addr_gen_fast(
-            True, src_addr0, in0_tile_bytes, in0_dataformat
-        )
+        tensor_accessor_args = TensorAccessorArgs(2, 0)
+        addr_gen_a = TensorAccessor(tensor_accessor_args, src_addr0, in0_tile_bytes)
 
         in1_tile_bytes = get_tile_size(cb_in1)
-        in1_dataformat = get_dataformat(cb_in1)
-
-        addr_gen_b = get_interleaved_addr_gen_fast(
-            True, src_addr1, in1_tile_bytes, in1_dataformat
-        )
+        tensor_accessor_args = TensorAccessorArgs(2, 0)
+        addr_gen_b = TensorAccessor(tensor_accessor_args, src_addr1, in1_tile_bytes)
 
         for output_tile in range(0, num_tiles, 1):
             current_tile_id = start_id + output_tile
@@ -105,11 +99,8 @@ class MatmulMulticorePyKernelOp(PyKernelOp):
         start_id,
     ):
         tile_bytes = get_tile_size(cb_out)
-        dataformat = get_dataformat(cb_out)
-
-        addr_gen_c = get_interleaved_addr_gen_fast(
-            True, dst_addr, tile_bytes, dataformat
-        )
+        tensor_accessor_args = TensorAccessorArgs(1, 0)
+        addr_gen_c = TensorAccessor(tensor_accessor_args, dst_addr, tile_bytes)
 
         end_id = start_id + num_tiles
         for i in range(start_id, end_id, 1):
@@ -139,6 +130,8 @@ class MatmulMulticorePyKernelOp(PyKernelOp):
         cb_in1 = self.create_cb(b_tensor, 1)
         cb_out = self.create_cb(out_tensor, 2)
         start_id = 0
+
+        self.set_tensor_accessor_config(a_tensor)
 
         Mt = a_tensor.shape[0] // 32
         Kt = a_tensor.shape[1] // 32

--- a/test/pykernel/demo/vecadd_multicore_demo.py
+++ b/test/pykernel/demo/vecadd_multicore_demo.py
@@ -60,8 +60,8 @@ class VecAddMulticorePyKernelOp(PyKernelOp):
         onetile = 1
 
         tile_bytes = get_tile_size(cb_out)
-        tensor_accessor_args = make_tensor_accessor_args(1, 0)
-        s0 = make_tensor_accessor_from_args(tensor_accessor_args, dst_addr, tile_bytes)
+        tensor_accessor_args = TensorAccessorArgs(1, 0)
+        s0 = TensorAccessor(tensor_accessor_args, dst_addr, tile_bytes)
 
         end_id = start_id + num_tiles
         for i in range(start_id, end_id, onetile):
@@ -84,16 +84,12 @@ class VecAddMulticorePyKernelOp(PyKernelOp):
         onetile = 1
 
         tile_bytes0 = get_tile_size(cb_in0)
-        tensor_accessor_args = make_tensor_accessor_args(2, 0)
-        s0 = make_tensor_accessor_from_args(
-            tensor_accessor_args, src_addr0, tile_bytes0
-        )
+        tensor_accessor_args = TensorAccessorArgs(2, 0)
+        s0 = TensorAccessor(tensor_accessor_args, src_addr0, tile_bytes0)
 
         tile_bytes1 = get_tile_size(cb_in1)
-        tensor_accessor_args = make_tensor_accessor_args(2, 0)
-        s1 = make_tensor_accessor_from_args(
-            tensor_accessor_args, src_addr1, tile_bytes1
-        )
+        tensor_accessor_args = TensorAccessorArgs(2, 0)
+        s1 = TensorAccessor(tensor_accessor_args, src_addr1, tile_bytes1)
 
         end_id = start_id + num_tiles
         for i in range(start_id, end_id, onetile):

--- a/test/pykernel/demo/vecadd_multicore_demo.py
+++ b/test/pykernel/demo/vecadd_multicore_demo.py
@@ -18,7 +18,7 @@ class VecAddMulticorePyKernelOp(PyKernelOp):
         self.max_core_ranges = max_core_ranges
 
     # KERNEL DEFINITIONS
-    @compute_thread(verbose=True)
+    @compute_thread()
     def add_multicore(
         cb_in0: CircularBuffer,
         cb_in1: CircularBuffer,
@@ -50,7 +50,7 @@ class VecAddMulticorePyKernelOp(PyKernelOp):
             tile_regs_release()
         return
 
-    @writer_thread(verbose=True)
+    @writer_thread()
     def writer_multicore(
         cb_out: CircularBuffer,
         dst_addr,
@@ -72,7 +72,7 @@ class VecAddMulticorePyKernelOp(PyKernelOp):
             cb_pop_front(cb_out, onetile)
         return
 
-    @reader_thread(verbose=True)
+    @reader_thread()
     def reader_binary_interleaved(
         cb_in0: CircularBuffer,
         cb_in1: CircularBuffer,

--- a/test/pykernel/demo/vecadd_multicore_demo.py
+++ b/test/pykernel/demo/vecadd_multicore_demo.py
@@ -126,9 +126,7 @@ class VecAddMulticorePyKernelOp(PyKernelOp):
         cb_out = self.create_cb(out_tensor, 2)
         start_id = 0
 
-        self.tensor_accessor_config = TensorAccessorConfig.combine(
-            TensorAccessorConfig.IsDram
-        )
+        self.set_tensor_accessor_config(a_tensor)
 
         num_tiles = ceil(
             max(map(lambda t: t.volume(), [a_tensor, b_tensor, out_tensor])) / 1024

--- a/test/pykernel/demo/vecadd_multicore_demo.py
+++ b/test/pykernel/demo/vecadd_multicore_demo.py
@@ -18,7 +18,7 @@ class VecAddMulticorePyKernelOp(PyKernelOp):
         self.max_core_ranges = max_core_ranges
 
     # KERNEL DEFINITIONS
-    @compute_thread()
+    @compute_thread(verbose=True)
     def add_multicore(
         cb_in0: CircularBuffer,
         cb_in1: CircularBuffer,
@@ -50,21 +50,18 @@ class VecAddMulticorePyKernelOp(PyKernelOp):
             tile_regs_release()
         return
 
-    @writer_thread()
+    @writer_thread(verbose=True)
     def writer_multicore(
         cb_out: CircularBuffer,
         dst_addr,
         num_tiles,
         start_id,
-        dst_is_dram: CompileTimeValue,
     ):
         onetile = 1
-        tile_bytes = get_tile_size(cb_out)
-        dataformat = get_dataformat(cb_out)
 
-        s0 = get_interleaved_addr_gen_fast(
-            dst_is_dram, dst_addr, tile_bytes, dataformat
-        )
+        tile_bytes = get_tile_size(cb_out)
+        tensor_accessor_args = make_tensor_accessor_args(1, 0)
+        s0 = make_tensor_accessor_from_args(tensor_accessor_args, dst_addr, tile_bytes)
 
         end_id = start_id + num_tiles
         for i in range(start_id, end_id, onetile):
@@ -75,7 +72,7 @@ class VecAddMulticorePyKernelOp(PyKernelOp):
             cb_pop_front(cb_out, onetile)
         return
 
-    @reader_thread()
+    @reader_thread(verbose=True)
     def reader_binary_interleaved(
         cb_in0: CircularBuffer,
         cb_in1: CircularBuffer,
@@ -83,22 +80,19 @@ class VecAddMulticorePyKernelOp(PyKernelOp):
         src_addr1,
         num_tiles,
         start_id,
-        src0_is_dram: CompileTimeValue,
-        src1_is_dram: CompileTimeValue,
     ):
         onetile = 1
-        tile_bytes0 = get_tile_size(cb_in0)
-        dataformat0 = get_dataformat(cb_in0)
 
-        s0 = get_interleaved_addr_gen_fast(
-            src0_is_dram, src_addr0, tile_bytes0, dataformat0
+        tile_bytes0 = get_tile_size(cb_in0)
+        tensor_accessor_args = make_tensor_accessor_args(2, 0)
+        s0 = make_tensor_accessor_from_args(
+            tensor_accessor_args, src_addr0, tile_bytes0
         )
 
         tile_bytes1 = get_tile_size(cb_in1)
-        dataformat1 = get_dataformat(cb_in1)
-
-        s1 = get_interleaved_addr_gen_fast(
-            src1_is_dram, src_addr1, tile_bytes1, dataformat1
+        tensor_accessor_args = make_tensor_accessor_args(2, 0)
+        s1 = make_tensor_accessor_from_args(
+            tensor_accessor_args, src_addr1, tile_bytes1
         )
 
         end_id = start_id + num_tiles
@@ -136,9 +130,9 @@ class VecAddMulticorePyKernelOp(PyKernelOp):
         cb_out = self.create_cb(out_tensor, 2)
         start_id = 0
 
-        is_a_dram = a_tensor.memory_config().buffer_type == ttnn.BufferType.DRAM
-        is_b_dram = b_tensor.memory_config().buffer_type == ttnn.BufferType.DRAM
-        is_out_dram = out_tensor.memory_config().buffer_type == ttnn.BufferType.DRAM
+        self.tensor_accessor_config = TensorAccessorConfig.combine(
+            TensorAccessorConfig.IsDram
+        )
 
         num_tiles = ceil(
             max(map(lambda t: t.volume(), [a_tensor, b_tensor, out_tensor])) / 1024
@@ -180,7 +174,6 @@ class VecAddMulticorePyKernelOp(PyKernelOp):
                 out_tensor.buffer_address(),
                 num_tiles_per_core,
                 start_id_multicore,
-                dst_is_dram=is_out_dram,
             ),
             self.create_kernel(
                 VecAddMulticorePyKernelOp.reader_binary_interleaved,
@@ -190,8 +183,6 @@ class VecAddMulticorePyKernelOp(PyKernelOp):
                 b_tensor.buffer_address(),
                 num_tiles_per_core,
                 start_id_multicore,
-                src0_is_dram=is_a_dram,
-                src1_is_dram=is_b_dram,
             ),
         ]
 

--- a/test/pykernel/unit_tests.py
+++ b/test/pykernel/unit_tests.py
@@ -405,19 +405,6 @@ def test_array_with_expressions():
     return
 
 
-@ttkernel_compile(optimize=False)
-def test_tensor_accessor():
-    # CHECK-LABEL: func.func @test_tensor_accessor
-    bank_base_address = 0
-    page_size = 32
-    # CHECK: %[[ARGS:.*]] = "ttkernel.TensorAccessorArgs"{{.*}} -> [[ARGS_TYPE:.*]]
-    args = make_tensor_accessor_args(0, 0)
-    # CHECK: "ttkernel.TensorAccessor"(%[[ARGS]], {{.*}}) : ([[ARGS_TYPE]], i32, i32) -> !ttkernel.TensorAccessor
-    tensor_accessor = make_tensor_accessor_from_args(args, bank_base_address, page_size)
-
-    return
-
-
 test_assign()
 test_ifstmt()
 test_for()
@@ -431,4 +418,3 @@ test_array_iteration()
 test_array_additional()
 test_multidim_arrays()
 test_array_with_expressions()
-test_tensor_accessor()

--- a/test/pykernel/unit_tests.py
+++ b/test/pykernel/unit_tests.py
@@ -405,6 +405,19 @@ def test_array_with_expressions():
     return
 
 
+@ttkernel_compile(optimize=False)
+def test_tensor_accessor():
+    # CHECK-LABEL: func.func @test_tensor_accessor
+    bank_base_address = 0
+    page_size = 32
+    # CHECK: %[[ARGS:.*]] = "ttkernel.make_tensor_accessor_args"{{.*}} -> [[ARGS_TYPE:.*]]
+    args = make_tensor_accessor_args(0, 0)
+    # CHECK: "ttkernel.make_tensor_accessor_from_args"(%[[ARGS]], {{.*}}) : ([[ARGS_TYPE]], i32, i32) -> !ttkernel.TensorAccessor
+    tensor_accessor = make_tensor_accessor_from_args(args, bank_base_address, page_size)
+
+    return
+
+
 test_assign()
 test_ifstmt()
 test_for()
@@ -418,3 +431,4 @@ test_array_iteration()
 test_array_additional()
 test_multidim_arrays()
 test_array_with_expressions()
+test_tensor_accessor()

--- a/test/pykernel/unit_tests.py
+++ b/test/pykernel/unit_tests.py
@@ -410,9 +410,9 @@ def test_tensor_accessor():
     # CHECK-LABEL: func.func @test_tensor_accessor
     bank_base_address = 0
     page_size = 32
-    # CHECK: %[[ARGS:.*]] = "ttkernel.make_tensor_accessor_args"{{.*}} -> [[ARGS_TYPE:.*]]
+    # CHECK: %[[ARGS:.*]] = "ttkernel.TensorAccessorArgs"{{.*}} -> [[ARGS_TYPE:.*]]
     args = make_tensor_accessor_args(0, 0)
-    # CHECK: "ttkernel.make_tensor_accessor_from_args"(%[[ARGS]], {{.*}}) : ([[ARGS_TYPE]], i32, i32) -> !ttkernel.TensorAccessor
+    # CHECK: "ttkernel.TensorAccessor"(%[[ARGS]], {{.*}}) : ([[ARGS_TYPE]], i32, i32) -> !ttkernel.TensorAccessor
     tensor_accessor = make_tensor_accessor_from_args(args, bank_base_address, page_size)
 
     return

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -1134,6 +1134,24 @@ module {
       return
     }
 
+    // CHECK-LABEL: func @tensor_accessor_constructors
+    func.func @tensor_accessor_constructors() -> () attributes {ttkernel.thread = #ttkernel.thread<noc>} {
+      // CHECK: "emitc.constant"() <{value = [[CTA_OFFSET:.*]] : i32}>
+      // CHECK: "emitc.constant"() <{value = [[CRTA_OFFSET:.*]] : i32}>
+      %cta_offset = arith.constant 2 : i32
+      %crta_offset = arith.constant 0 : i32
+      // CHECK: %[[ADDR:.*]] = "emitc.constant"
+      // CHECK: %[[SIZE:.*]] = "emitc.constant"
+      %bank_address = arith.constant 303104 : i32
+      %page_size = arith.constant 32 : i32
+      // CHECK: %[[ARGS:.*]] = emitc.call_opaque "TensorAccessorArgs"() {template_args = [[[CTA_OFFSET]] : i32, [[CRTA_OFFSET]] : i32]} : () -> !emitc.opaque<"TensorAccessorArgs">
+      %tensor_accessor_args = "ttkernel.TensorAccessorArgs"(%cta_offset, %crta_offset) : (i32, i32) -> !ttkernel.TensorAccessorArgs
+      // CHECK: emitc.call_opaque "TensorAccessor"(%[[ARGS]], %[[ADDR]], %[[SIZE]]) : (!emitc.opaque<"TensorAccessorArgs">, i32, i32) -> !emitc.opaque<"TensorAccessor">
+      %tensor_accessor = "ttkernel.TensorAccessor"(%tensor_accessor_args, %bank_address, %page_size) : (!ttkernel.TensorAccessorArgs, i32, i32) -> !ttkernel.TensorAccessor
+      return
+    }
+
+
   } // module
 
 } // module

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -1152,25 +1152,25 @@ module {
       %temp2 = arith.constant 32: i32
       // CHECK: emitc.verbatim "uint32_t [[NOC_ADDR:.*]] = {}.get_noc_addr({}, {});" args %[[TENSOR_ACCESSOR]], {{.*}} : !emitc.opaque<"TensorAccessor">, i32, i32
       // CHECK: emitc.literal "[[NOC_ADDR]]" : i64
-      %noc_addr = "ttkernel.get_noc_addr_from_tensor_accessor"(%tensor_accessor, %temp1, %temp2) : (!ttkernel.TensorAccessor, i32, i32) -> !ttkernel.noc_addr
+      %noc_addr = "ttkernel.tensor_accessor_get_noc_addr"(%tensor_accessor, %temp1, %temp2) : (!ttkernel.TensorAccessor, i32, i32) -> !ttkernel.noc_addr
       // CHECK: emitc.verbatim "uint32_t [[SHARD_ADDR:.*]] = {}.get_shard_noc_addr({}, {});" args %[[TENSOR_ACCESSOR]], {{.*}} : !emitc.opaque<"TensorAccessor">, i32, i32
       // CHECK: emitc.literal "[[SHARD_ADDR]]"
-      %shard_noc_addr = "ttkernel.get_shard_noc_addr"(%tensor_accessor, %temp1, %temp2) : (!ttkernel.TensorAccessor, i32, i32) -> i32
+      %shard_noc_addr = "ttkernel.tensor_accessor_get_shard_noc_addr"(%tensor_accessor, %temp1, %temp2) : (!ttkernel.TensorAccessor, i32, i32) -> i32
       // CHECK: emitc.verbatim "uint32_t [[BANK_AND_OFFSET:.*]] = {}.get_bank_and_offset({});" args %[[TENSOR_ACCESSOR]], {{.*}} : !emitc.opaque<"TensorAccessor">, i32
       // CHECK: emitc.literal "[[BANK_AND_OFFSET]]" : !emitc.opaque<"PageMapping">
-      %bank_and_offset = "ttkernel.get_bank_and_offset"(%tensor_accessor, %temp1) : (!ttkernel.TensorAccessor, i32) -> !ttkernel.PageMapping
+      %bank_and_offset = "ttkernel.tensor_accessor_get_bank_and_offset"(%tensor_accessor, %temp1) : (!ttkernel.TensorAccessor, i32) -> !ttkernel.PageMapping
       // CHECK: emitc.verbatim "uint32_t [[IS_LOCAL_BANK:.*]] = {}.is_local_bank({}, {});" args %[[TENSOR_ACCESSOR]], {{.*}} : !emitc.opaque<"TensorAccessor">, i32, i32
       // CHECK: emitc.literal "[[IS_LOCAL_BANK]]" : i1
-      %is_local_bank = "ttkernel.is_local_bank"(%tensor_accessor, %temp1, %temp2) : (!ttkernel.TensorAccessor, i32, i32) -> i1
+      %is_local_bank = "ttkernel.tensor_accessor_is_local_bank"(%tensor_accessor, %temp1, %temp2) : (!ttkernel.TensorAccessor, i32, i32) -> i1
       // CHECK: emitc.verbatim "uint32_t [[IS_LOCAL_ADDR:.*]] = {}.is_local_addr({}, {});" args %[[TENSOR_ACCESSOR]], {{.*}} : !emitc.opaque<"TensorAccessor">, i32, i32
       // CHECK: emitc.literal "[[IS_LOCAL_ADDR]]" : i1
-      %is_local_addr = "ttkernel.is_local_addr"(%tensor_accessor, %temp1, %temp2) : (!ttkernel.TensorAccessor, i32, i32) -> i1
+      %is_local_addr = "ttkernel.tensor_accessor_is_local_addr"(%tensor_accessor, %temp1, %temp2) : (!ttkernel.TensorAccessor, i32, i32) -> i1
       // CHECK: emitc.verbatim "uint32_t [[IS_LOCAL_PAGE:.*]] = {}.is_local_page({});" args %[[TENSOR_ACCESSOR]], {{.*}} : !emitc.opaque<"TensorAccessor">, i32
       // CHECK: emitc.literal "[[IS_LOCAL_PAGE]]" : i1
-      %is_local_page = "ttkernel.is_local_page"(%tensor_accessor, %temp1) : (!ttkernel.TensorAccessor, i32) -> i1
+      %is_local_page = "ttkernel.tensor_accessor_is_local_page"(%tensor_accessor, %temp1) : (!ttkernel.TensorAccessor, i32) -> i1
       // CHECK: emitc.verbatim "uint32_t [[IS_LOCAL_SHARD:.*]] = {}.is_local_shard({});" args %[[TENSOR_ACCESSOR]], {{.*}} : !emitc.opaque<"TensorAccessor">, i32
       // CHECK: emitc.literal "[[IS_LOCAL_SHARD]]" : i1
-      %is_local_shard = "ttkernel.is_local_shard"(%tensor_accessor, %temp1) : (!ttkernel.TensorAccessor, i32) -> i1
+      %is_local_shard = "ttkernel.tensor_accessor_is_local_shard"(%tensor_accessor, %temp1) : (!ttkernel.TensorAccessor, i32) -> i1
       return
     }
 

--- a/tools/pykernel/ast.py
+++ b/tools/pykernel/ast.py
@@ -116,6 +116,8 @@ class TTKernelCompiler(ast.NodeVisitor):
         "exp_tile": ttkernel.exp_tile,
         "mm_init": ttkernel.mm_init,
         "matmul_tiles": ttkernel.matmul_tiles,
+        "make_tensor_accessor_args": ttkernel.make_tensor_accessor_args,
+        "make_tensor_accessor_from_args": ttkernel.make_tensor_accessor_from_args,
     }
 
     def __init__(self, name, kernel_type=None, *args, **kwargs):

--- a/tools/pykernel/ast.py
+++ b/tools/pykernel/ast.py
@@ -128,16 +128,6 @@ class TTKernelCompiler(ast.NodeVisitor):
         "is_local_shard": ttkernel.is_local_shard,
     }
 
-    tensor_accessor_fn = [
-        "get_noc_addr",
-        "get_shard_noc_addr",
-        "get_bank_and_offset",
-        "is_local_bank",
-        "is_local_addr",
-        "is_local_page",
-        "is_local_shard",
-    ]
-
     def __init__(self, name, kernel_type=None, *args, **kwargs):
         assert kernel_type in [None, "noc", "compute"], "Invalid kernel type"
         self.name = name
@@ -919,22 +909,11 @@ class TTKernelCompiler(ast.NodeVisitor):
             return memref.LoadOp(arr, idx)
 
     def visit_Attribute(self, node):
-        print(node.value.id)
-        print(node.attr)
-        node_attr = node.attr
-        assert node_attr in self.tensor_accessor_fn
-
-        # help(emitc.member)
-        symtable = self.var_exists(node.value.id)
-        operand = symtable[node.value.id]
-        print(operand)
-        print(operand.type)
-        # help(emitc)
-
-        # Not possible as we can't get the lvalue type of operand w emitc pybinds rn
+        # TODO(vtang): Unsure how to get the lvalue type of operand w emitc pybinds rn
         # emitc::LValueType::get(adaptor.getDataFormat().getType())
         # operand_lvalue = emitc.LValueType.get()
         # emitc.member(IntegerType.get_signless(32, self.ctx), node.attr, operand)
+        raise NotImplementedError("Attributes not supported yet")
 
     def visit_List(self, node):
         # Snoop List for nested loops and get size

--- a/tools/pykernel/ast.py
+++ b/tools/pykernel/ast.py
@@ -117,8 +117,8 @@ class TTKernelCompiler(ast.NodeVisitor):
         "exp_tile": ttkernel.exp_tile,
         "mm_init": ttkernel.mm_init,
         "matmul_tiles": ttkernel.matmul_tiles,
-        "make_tensor_accessor_args": ttkernel.make_tensor_accessor_args,
-        "make_tensor_accessor_from_args": ttkernel.make_tensor_accessor_from_args,
+        "TensorAccessorArgs": ttkernel.TensorAccessorArgs,
+        "TensorAccessor": ttkernel.TensorAccessor,
     }
 
     tensor_accessor_fn = [

--- a/tools/pykernel/ast.py
+++ b/tools/pykernel/ast.py
@@ -620,7 +620,7 @@ class TTKernelCompiler(ast.NodeVisitor):
 
     # Function calls
     def visit_Call(self, node):
-        if (not isinstance(node.func, ast.Attribute)):
+        if not isinstance(node.func, ast.Attribute):
             # if not an Attribute, it's just a kernel api call.
             assert (
                 node.func.id in self.ttkernel_fn_map
@@ -647,7 +647,7 @@ class TTKernelCompiler(ast.NodeVisitor):
                 func_args.append(func_arg)
 
             return func(*func_args)  # how do i make sure the types are correct?
-        else: 
+        else:
             self.visit(node.func)
 
     # Expressions
@@ -915,7 +915,7 @@ class TTKernelCompiler(ast.NodeVisitor):
         print(node.value.id)
         print(node.attr)
         node_attr = node.attr
-        assert(node_attr in self.tensor_accessor_fn)
+        assert node_attr in self.tensor_accessor_fn
 
         # help(emitc.member)
         symtable = self.var_exists(node.value.id)
@@ -928,7 +928,6 @@ class TTKernelCompiler(ast.NodeVisitor):
         # emitc::LValueType::get(adaptor.getDataFormat().getType())
         # operand_lvalue = emitc.LValueType.get()
         # emitc.member(IntegerType.get_signless(32, self.ctx), node.attr, operand)
-
 
     def visit_List(self, node):
         # Snoop List for nested loops and get size

--- a/tools/pykernel/ast.py
+++ b/tools/pykernel/ast.py
@@ -119,13 +119,13 @@ class TTKernelCompiler(ast.NodeVisitor):
         "matmul_tiles": ttkernel.matmul_tiles,
         "TensorAccessorArgs": ttkernel.TensorAccessorArgs,
         "TensorAccessor": ttkernel.TensorAccessor,
-        "get_noc_addr_from_tensor_accessor": ttkernel.get_noc_addr_from_tensor_accessor,
-        "get_shard_noc_addr": ttkernel.get_shard_noc_addr,
-        "get_bank_and_offset": ttkernel.get_bank_and_offset,
-        "is_local_bank": ttkernel.is_local_bank,
-        "is_local_addr": ttkernel.is_local_addr,
-        "is_local_page": ttkernel.is_local_page,
-        "is_local_shard": ttkernel.is_local_shard,
+        "tensor_accessor_get_noc_addr": ttkernel.tensor_accessor_get_noc_addr,
+        "tensor_accessor_get_shard_noc_addr": ttkernel.tensor_accessor_get_shard_noc_addr,
+        "tensor_accessor_get_bank_and_offset": ttkernel.tensor_accessor_get_bank_and_offset,
+        "tensor_accessor_is_local_bank": ttkernel.tensor_accessor_is_local_bank,
+        "tensor_accessor_is_local_addr": ttkernel.tensor_accessor_is_local_addr,
+        "tensor_accessor_is_local_page": ttkernel.tensor_accessor_is_local_page,
+        "tensor_accessor_is_local_shard": ttkernel.tensor_accessor_is_local_shard,
     }
 
     def __init__(self, name, kernel_type=None, *args, **kwargs):

--- a/tools/pykernel/ast.py
+++ b/tools/pykernel/ast.py
@@ -119,6 +119,13 @@ class TTKernelCompiler(ast.NodeVisitor):
         "matmul_tiles": ttkernel.matmul_tiles,
         "TensorAccessorArgs": ttkernel.TensorAccessorArgs,
         "TensorAccessor": ttkernel.TensorAccessor,
+        "get_noc_addr_from_tensor_accessor": ttkernel.get_noc_addr_from_tensor_accessor,
+        "get_shard_noc_addr": ttkernel.get_shard_noc_addr,
+        "get_bank_and_offset": ttkernel.get_bank_and_offset,
+        "is_local_bank": ttkernel.is_local_bank,
+        "is_local_addr": ttkernel.is_local_addr,
+        "is_local_page": ttkernel.is_local_page,
+        "is_local_shard": ttkernel.is_local_shard,
     }
 
     tensor_accessor_fn = [
@@ -1076,6 +1083,7 @@ def ttkernel_compile(
                 print("---- Optimized PyKernel Module ----", b.module, sep="\n\n")
 
             if kernel_type:
+                print("---- Kernel String ----", b.module, sep="\n\n")
                 kernel_string = ttkernel_to_cpp(b.module)
                 return kernel_string
 

--- a/tools/pykernel/op.py
+++ b/tools/pykernel/op.py
@@ -32,7 +32,7 @@ class PyKernelOp:
         """Initialize the PyKernelOp with an empty kernel selection dictionary. Intakes the `ttnn` module to operate."""
         self.kernel_selection = {}
         self.kernel_cache = {}
-        self.tensor_accessor_config = TensorAccessorConfig.NONE
+        self.tensor_accessor_config = 0
 
         # Keep a mobile statewise reference to the ttnn module
         if isinstance(ttnn, Exception):

--- a/tools/pykernel/op.py
+++ b/tools/pykernel/op.py
@@ -32,6 +32,8 @@ class PyKernelOp:
         """Initialize the PyKernelOp with an empty kernel selection dictionary. Intakes the `ttnn` module to operate."""
         self.kernel_selection = {}
         self.kernel_cache = {}
+        self.tensor_accessor_config = 0
+
         # Keep a mobile statewise reference to the ttnn module
         if isinstance(ttnn, Exception):
             raise ttnn

--- a/tools/pykernel/types.py
+++ b/tools/pykernel/types.py
@@ -79,7 +79,7 @@ class TensorAccessorConfig(Enum):
     """
     Python equivalent ArgConfig from tt_metal/hostdevcommon/api/hostdevcommon/tensor_accessor/arg_config.hpp.
     Bit encoding of fundamental configuration of a tensor accessor that must be available at compile time.
-    #TODO: Can probably remove this once pybinds for TensorAccessor is implemented.
+    #TODO: Remove once pybinds for TensorAccessorArgs implemented - Metal Issue #25655
     """
 
     NONE = 0

--- a/tools/pykernel/types.py
+++ b/tools/pykernel/types.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+from enum import Enum
 
 
 class CircularBuffer:
@@ -72,3 +73,31 @@ class Arguments:
 
     def get_all_args(self):
         return self.args
+
+
+class TensorAccessorConfig(Enum):
+    """
+    Python equivalent ArgConfig from tt_metal/hostdevcommon/api/hostdevcommon/tensor_accessor/arg_config.hpp.
+    Bit encoding of fundamental configuration of a tensor accessor that must be available at compile time.
+    #TODO: Can probably remove this once pybinds for TensorAccessor is implemented.
+    """
+
+    NONE = 0
+    Sharded = 1 << 0  # 0x01 = 0b0000_0001 = 1
+    IsDram = 1 << 1  # 0x02 = 0b0000_0010 = 2
+    RuntimeRank = 1 << 2  # 0x04 = 0b0000_0100 = 4
+    RuntimeNumBanks = 1 << 3  # 0x08 = 0b0000_1000 = 8
+    RuntimeTensorShape = 1 << 4  # 0x10 = 0b0001_0000 = 16
+    RuntimeShardShape = 1 << 5  # 0x20 = 0b0010_0000 = 32
+    RuntimeBankCoords = 1 << 6  # 0x40 = 0b0100_0000 = 64
+
+    @classmethod
+    def combine(cls, *configs):
+        # Combine multiple config flags using bitwise OR
+        result = 0
+        for config in configs:
+            if isinstance(config, cls):
+                result |= config.value
+            else:
+                result |= config
+        return result

--- a/tools/pykernel/types.py
+++ b/tools/pykernel/types.py
@@ -91,13 +91,16 @@ class TensorAccessorConfig(Enum):
     RuntimeShardShape = 1 << 5  # 0x20 = 0b0010_0000 = 32
     RuntimeBankCoords = 1 << 6  # 0x40 = 0b0100_0000 = 64
 
-    @classmethod
-    def combine(cls, *configs):
-        # Combine multiple config flags using bitwise OR
-        result = 0
-        for config in configs:
-            if isinstance(config, cls):
-                result |= config.value
-            else:
-                result |= config
-        return result
+    def __or__(self, other):
+        """Enable | operator"""
+        self_val = self.value if hasattr(self, "value") else self
+        other_val = other.value if hasattr(other, "value") else other
+        return self_val | other_val
+
+    def __ror__(self, other):
+        """Enable | operator"""
+        return other | self.value
+
+    def __ior__(self, other):
+        """Enable |= operator"""
+        return self.__or__(other)


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/4069)

### Problem description
As described in issue.

### What's changed
- Added new ops `TensorAccessorArgs`, `TensorAccessor` constructors and member functions
- Added new ttkernel types for `TensorAccessor`
- ttkernel -> emitc conversion pass for new ops
- switched over both demos to use `TensorAccessor` instead of `InterleavedAddrGenFast`
- filecheck unit test for new ops

ToDo before push: 
- [x] wait for metal uplift in main and revert the commit that uplifted metal on this branch

Notes: 
- ~right now, you have to pass both `CTA` and `CRTA` offset, unlike in metal where you only need to pass `CTA`~
- currently setup so that `CTA_OFFSET` should be the # of cbs passed through `compile_time_args` when creating the kernel
- ~not able to use any member functions of `TensorAccessor`, continue investigating how we could do this.~
   - ~eg: `tensor_accessor.get_noc_addr`~ fixed, can do this now

### Checklist
- [x] New/Existing tests provide coverage for changes
