### PR TITLE
extend default allocator L1 algorithm to DRAM memspace

### DIFF
--- a/lib/Dialect/TTIR/Transforms/Allocate.cpp
+++ b/lib/Dialect/TTIR/Transforms/Allocate.cpp
@@ -102,7 +102,7 @@ struct FuncAnalysisData final {
     contexts[llvm::to_underlying(memorySpace)].add(size, first, last, alloc);
   }
 
-  // Memor planner contexts, one per mem space.
+  // Memory planner contexts, one per mem space.
   MemorySpaceContexts contexts;
 
   // Within a func body scope, maps logical time positions (in preorder)
@@ -392,14 +392,15 @@ class TTIRAllocate final : public impl::TTIRAllocateBase<TTIRAllocate> {
       // AllocationPlanner::Stats stats = AllocationPlanner::verify(analysis);
       TT_ALLOC_DEBUG("{} allocation planning outcome: {}", memorySpace, stats);
 
-      const auto &memSpace = memSpaces[llvm::to_underlying(memorySpace)];
-      const auto memCapacity = memSpace.maxAddress - memSpace.baseAddress;
+      const auto &info = memSpaces[llvm::to_underlying(memorySpace)];
+
+      const auto memCapacity = info.maxAddress - info.baseAddress;
       if (stats.memUsage > memCapacity) {
         return func.emitOpError()
                << "required " << stringifyEnum(memorySpace) << " memory usage "
                << stats.memUsage << " exceeds memory capacity " << memCapacity
-               << " (usable space is [" << memSpace.baseAddress << ", "
-               << memSpace.maxAddress << "))";
+               << " (usable space is [" << info.baseAddress << ", "
+               << info.maxAddress << "))";
       }
     }
 

--- a/lib/Dialect/TTIR/Transforms/Allocate.cpp
+++ b/lib/Dialect/TTIR/Transforms/Allocate.cpp
@@ -77,11 +77,9 @@ struct MemorySpaceInfo {
 using MemorySpaces =
     std::array<MemorySpaceInfo, MemorySpaceInfo::kMaxEnumValForMemorySpace>;
 
-struct FuncAnalysisData final : public AllocationPlanner::Context {
+struct MemorySpaceContext final : public AllocationPlanner::Context {
 
   using Base = AllocationPlanner::Context;
-
-  using Base::Base;
 
   void add(AllocSizeT size, SequenceT first, SequenceT last,
            memref::AllocOp alloc) {
@@ -89,8 +87,23 @@ struct FuncAnalysisData final : public AllocationPlanner::Context {
     allocs.emplace_back(alloc);
   }
 
-  // A list of alloc ops, parallel to `Base::records`
+  // A list of alloc ops mapping to a given memspace, parallel
+  // to 'Base::records'.
   std::vector<memref::AllocOp> allocs;
+};
+
+using MemorySpaceContexts =
+    std::array<MemorySpaceContext, MemorySpaceInfo::kMaxEnumValForMemorySpace>;
+
+struct FuncAnalysisData final {
+
+  void add(AllocSizeT size, SequenceT first, SequenceT last,
+           memref::AllocOp alloc, ttcore::MemorySpace memorySpace) {
+    contexts[llvm::to_underlying(memorySpace)].add(size, first, last, alloc);
+  }
+
+  // Memor planner contexts, one per mem space.
+  MemorySpaceContexts contexts;
 
   // Within a func body scope, maps logical time positions (in preorder)
   // to their `Operation`s.
@@ -356,8 +369,8 @@ class TTIRAllocate final : public impl::TTIRAllocateBase<TTIRAllocate> {
             memrefTy,
             ttcore::MemorySpace::System); // Interpret unset as "host memory".
 
-        if (!isL1MemorySpace(memorySpace)) {
-          continue; // Only handling L1 space at the moment.
+        if (!isDeviceMemorySpace(memorySpace)) {
+          continue;
         }
 
         const AllocSizeT alignment =
@@ -366,25 +379,28 @@ class TTIRAllocate final : public impl::TTIRAllocateBase<TTIRAllocate> {
         const AllocSizeT alignedSize =
             ttmlir::utils::alignUp(sizeBytes, alignment);
 
-        analysis.add(alignedSize, ctx.first, ctx.maxLast, alloc);
+        analysis.add(alignedSize, ctx.first, ctx.maxLast, alloc, memorySpace);
       }
     }
 
-    const AllocationPlanner::Stats stats =
-        AllocationPlanner::allocate(analysis);
+    for (ttcore::MemorySpace memorySpace :
+         {ttcore::MemorySpace::DeviceL1, ttcore::MemorySpace::DeviceDRAM}) {
+      const AllocationPlanner::Stats stats = AllocationPlanner::allocate(
+          analysis.contexts[llvm::to_underlying(memorySpace)]);
 
-    // TODO(#3378) dump this instead (usageRatio() is useful) in "debug" mode:
-    // AllocationPlanner::Stats stats = AllocationPlanner::verify(analysis);
-    TT_ALLOC_DEBUG("allocation planning outcome: {}", stats);
+      // TODO(#3378) dump this instead (usageRatio() is useful) in "debug" mode:
+      // AllocationPlanner::Stats stats = AllocationPlanner::verify(analysis);
+      TT_ALLOC_DEBUG("{} allocation planning outcome: {}", memorySpace, stats);
 
-    const auto &memSpace =
-        memSpaces[llvm::to_underlying(ttcore::MemorySpace::DeviceL1)];
-    const auto memCapacity = memSpace.maxAddress - memSpace.baseAddress;
-    if (stats.memUsage > memCapacity) {
-      return func.emitOpError() << "required memory usage " << stats.memUsage
-                                << " exceeds memory capacity " << memCapacity
-                                << " (usable space is [" << memSpace.baseAddress
-                                << ", " << memSpace.maxAddress << "))";
+      const auto &memSpace = memSpaces[llvm::to_underlying(memorySpace)];
+      const auto memCapacity = memSpace.maxAddress - memSpace.baseAddress;
+      if (stats.memUsage > memCapacity) {
+        return func.emitOpError()
+               << "required " << stringifyEnum(memorySpace) << " memory usage "
+               << stats.memUsage << " exceeds memory capacity " << memCapacity
+               << " (usable space is [" << memSpace.baseAddress << ", "
+               << memSpace.maxAddress << "))";
+      }
     }
 
     return analysis;
@@ -422,35 +438,33 @@ class TTIRAllocate final : public impl::TTIRAllocateBase<TTIRAllocate> {
 
     IRRewriter rewriter(&getContext());
 
-    for (std::size_t t = 0; t < analysis.size(); ++t) {
-      const AllocationPlanner::Record &record = analysis[t];
-      memref::AllocOp alloc = analysis.allocs[t];
+    for (ttcore::MemorySpace memorySpace :
+         {ttcore::MemorySpace::DeviceL1, ttcore::MemorySpace::DeviceDRAM}) {
+      const MemorySpaceContext &context =
+          analysis.contexts[llvm::to_underlying(memorySpace)];
 
-      MemRefType memrefTy = alloc.getType();
-      ttcore::MemorySpace memorySpace = getMemorySpace(
-          memrefTy,
-          ttcore::MemorySpace::System); // Interpret unset as "host memory".
+      for (std::size_t t = 0; t < context.size(); ++t) {
+        const AllocationPlanner::Record &record = context[t];
+        memref::AllocOp alloc = context.allocs[t];
 
-      if (!isL1MemorySpace(memorySpace)) {
-        continue; // Only handling L1 space at the moment.
-      }
+        const auto &info = memSpaces[llvm::to_underlying(memorySpace)];
 
-      const auto &info = memSpaces[llvm::to_underlying(memorySpace)];
+        const AllocSizeT alignment = info.alignment;
+        const AllocSizeT address = info.baseAddress + record.offset;
 
-      const AllocSizeT alignment = info.alignment;
-      const AllocSizeT address = info.baseAddress + record.offset;
+        rewriter.startOpModification(alloc);
+        {
+          alloc.setAlignment(alignment);
+          alloc->setAttr("address", rewriter.getI64IntegerAttr(address));
+        };
+        rewriter.finalizeOpModification(alloc);
 
-      rewriter.startOpModification(alloc);
-      {
-        alloc.setAlignment(alignment);
-        alloc->setAttr("address", rewriter.getI64IntegerAttr(address));
-      };
-      rewriter.finalizeOpModification(alloc);
-
-      Operation *lastOp = analysis.positionMap[record.last];
-      if (!llvm::isa<func::ReturnOp>(lastOp)) {
-        rewriter.setInsertionPointAfter(lastOp);
-        rewriter.create<memref::DeallocOp>(lastOp->getLoc(), alloc.getResult());
+        Operation *lastOp = analysis.positionMap[record.last];
+        if (!llvm::isa<func::ReturnOp>(lastOp)) {
+          rewriter.setInsertionPointAfter(lastOp);
+          rewriter.create<memref::DeallocOp>(lastOp->getLoc(),
+                                             alloc.getResult());
+        }
       }
     }
 

--- a/test/ttmlir/Dialect/TTIR/allocate/allocate.mlir
+++ b/test/ttmlir/Dialect/TTIR/allocate/allocate.mlir
@@ -1,0 +1,37 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttir-allocate %s 2>&1 | FileCheck %s
+
+!memreftype_l1   = memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<1024x1024>, #ttcore.memory_space<l1>>
+!memreftype_dram = memref<1x1x8x8x!ttcore.tile<32x32, f32>, #ttcore.shard<1024x1024>, #ttcore.memory_space<dram>>
+
+// CHECK-LABEL: func @allocate_l1
+func.func @allocate_l1() -> !memreftype_l1 {
+  // CHECK: %{{.+}} = memref.alloc() {address = {{[0-9]+}} : i64, alignment = {{[0-9]+}} : i64}{{.+}} #l1>
+  %alloc = memref.alloc() : !memreftype_l1
+
+  return %alloc : !memreftype_l1
+}
+
+// CHECK-LABEL: func @allocate_dram
+func.func @allocate_dram() -> !memreftype_dram {
+  // CHECK: %{{.+}} = memref.alloc() {address = {{[0-9]+}} : i64, alignment = {{[0-9]+}} : i64}{{.+}} #dram>
+  %alloc = memref.alloc() : !memreftype_dram
+
+  return %alloc : !memreftype_dram
+}
+
+// CHECK-LABEL: func @allocate_mixed
+func.func @allocate_mixed() -> (!memreftype_l1, !memreftype_dram, !memreftype_l1, !memreftype_dram, !memreftype_l1) {
+  // CHECK: %{{.+}} = memref.alloc() {address = {{[0-9]+}} : i64, alignment = {{[0-9]+}} : i64}{{.+}} #l1>
+  %alloc_0 = memref.alloc() : !memreftype_l1
+  // CHECK: %{{.+}} = memref.alloc() {address = {{[0-9]+}} : i64, alignment = {{[0-9]+}} : i64}{{.+}} #dram>
+  %alloc_1 = memref.alloc() : !memreftype_dram
+  // CHECK: %{{.+}} = memref.alloc() {address = {{[0-9]+}} : i64, alignment = {{[0-9]+}} : i64}{{.+}} #l1>
+  %alloc_2 = memref.alloc() : !memreftype_l1
+  // CHECK: %{{.+}} = memref.alloc() {address = {{[0-9]+}} : i64, alignment = {{[0-9]+}} : i64}{{.+}} #dram>
+  %alloc_3 = memref.alloc() : !memreftype_dram
+  // CHECK: %{{.+}} = memref.alloc() {address = {{[0-9]+}} : i64, alignment = {{[0-9]+}} : i64}{{.+}} #l1>
+  %alloc_4 = memref.alloc() : !memreftype_l1
+
+  return %alloc_0, %alloc_1, %alloc_2, %alloc_3, %alloc_4 : !memreftype_l1, !memreftype_dram, !memreftype_l1, !memreftype_dram, !memreftype_l1
+}
+

--- a/test/ttmlir/Dialect/TTIR/allocate/allocate.mlir
+++ b/test/ttmlir/Dialect/TTIR/allocate/allocate.mlir
@@ -34,4 +34,3 @@ func.func @allocate_mixed() -> (!memreftype_l1, !memreftype_dram, !memreftype_l1
 
   return %alloc_0, %alloc_1, %alloc_2, %alloc_3, %alloc_4 : !memreftype_l1, !memreftype_dram, !memreftype_l1, !memreftype_dram, !memreftype_l1
 }
-

--- a/test/ttmlir/Dialect/TTIR/allocate/allocate_negative.mlir
+++ b/test/ttmlir/Dialect/TTIR/allocate/allocate_negative.mlir
@@ -1,6 +1,6 @@
 // RUN: not ttmlir-opt --ttcore-register-device --ttir-allocate %s 2>&1 | FileCheck %s
 
-// CHECK: error: 'func.func' op required memory usage 68719476736 exceeds memory capacity
+// CHECK: error: 'func.func' op required l1 memory usage 68719476736 exceeds memory capacity
 
 !memreftype = memref<1x1x4096x4096x!ttcore.tile<32x32, f32>, #ttcore.shard<16777216x4096>, #ttcore.memory_space<l1>>
 


### PR DESCRIPTION
### Problem description
To support ongoing dev/testing, make interim `ttir-allocator` changes so that it assigns DRAM addresses instead of just ignoring such allocs.

### What's changed
The allocator had originally used a single instance of `AllocationPlanner::Context` that was implicitly dedicated to L1. This has now been generalized into a per-memspace-array of contexts and the pass logic has been updated to do both L1 and DRAM as two independent problems.

Example:
```mlir
!memreftype_l1   = memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<1024x1024>, #ttcore.memory_space<l1>>
!memreftype_dram = memref<1x1x8x8x!ttcore.tile<32x32, f32>, #ttcore.shard<1024x1024>, #ttcore.memory_space<dram>>

func.func @allocate_mixed() -> (!memreftype_l1, !memreftype_dram, !memreftype_l1, !memreftype_dram, !memreftype_l1) {
  %alloc_0 = memref.alloc() : !memreftype_l1
  %alloc_1 = memref.alloc() : !memreftype_dram
  %alloc_2 = memref.alloc() : !memreftype_l1
  %alloc_3 = memref.alloc() : !memreftype_dram
  %alloc_4 = memref.alloc() : !memreftype_l1

  return %alloc_0, %alloc_1, %alloc_2, %alloc_3, %alloc_4 : !memreftype_l1, !memreftype_dram, !memreftype_l1, !memreftype_dram, !memreftype_l1
}
```
is transformed to (note per-memspace alignments and address growth):
```mlir
  func.func @allocate_mixed() -> (memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<1024x1024>, #l1>, memref<1x1x8x8x!ttcore.tile<32x32, f32>, #ttcore.shard<1024x1024>, #dram>, memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<1024x1024>, #l1>, memref<1x1x8x8x!ttcore.tile<32x32, f32>, #ttcore.shard<1024x1024>, #dram>, memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<1024x1024>, #l1>) {
    %alloc = memref.alloc() {address = 66560 : i64, alignment = 16 : i64} : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<1024x1024>, #l1>
    %alloc_0 = memref.alloc() {address = 1024 : i64, alignment = 32 : i64} : memref<1x1x8x8x!ttcore.tile<32x32, f32>, #ttcore.shard<1024x1024>, #dram>
    %alloc_1 = memref.alloc() {address = 132096 : i64, alignment = 16 : i64} : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<1024x1024>, #l1>
    %alloc_2 = memref.alloc() {address = 263168 : i64, alignment = 32 : i64} : memref<1x1x8x8x!ttcore.tile<32x32, f32>, #ttcore.shard<1024x1024>, #dram>
    %alloc_3 = memref.alloc() {address = 1024 : i64, alignment = 16 : i64} : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<1024x1024>, #l1>
    return %alloc, %alloc_0, %alloc_1, %alloc_2, %alloc_3 : memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<1024x1024>, #l1>, memref<1x1x8x8x!ttcore.tile<32x32, f32>, #ttcore.shard<1024x1024>, #dram>, memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<1024x1024>, #l1>, memref<1x1x8x8x!ttcore.tile<32x32, f32>, #ttcore.shard<1024x1024>, #dram>, memref<1x1x4x4x!ttcore.tile<32x32, f32>, #ttcore.shard<1024x1024>, #l1>
  }
```

### Checklist
- [X] new test `test/ttmlir/Dialect/TTIR/allocate/allocate.mlir` specifically checks for L1/DRAM/mixed allocations 
