### PR TITLE
Uplift third_party/tt-metal to 81412069f02b01a483cc0fb29fec5c9bf28ac1ab 2025-07-18

### DIFF
--- a/docs/src/ttir-builder/ttir-builder.md
+++ b/docs/src/ttir-builder/ttir-builder.md
@@ -419,7 +419,7 @@ module {
         %2 = emitc.literal "get_compile_time_arg_val(1)" : !emitc.opaque<"::tt::CB">
         emitc.call_opaque "cb_reserve_back"(%2, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
         emitc.call_opaque "cb_wait_front"(%1, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
-        emitc.call_opaque "untilize_init"(%1, %2) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">) -> ()
+        emitc.call_opaque "untilize_init"(%1) : (!emitc.opaque<"::tt::CB">) -> ()
         emitc.call_opaque "experimental::untilize_block"(%1, %2, %0, %0) : (!emitc.opaque<"::tt::CB">, !emitc.opaque<"::tt::CB">, i32, i32) -> ()
         emitc.call_opaque "cb_push_back"(%2, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()
         emitc.call_opaque "cb_wait_front"(%2, %0) : (!emitc.opaque<"::tt::CB">, i32) -> ()

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -948,7 +948,7 @@ def TTKernel_UntilizeInitOp : TTKernel_Op<"untilize_init"> {
       kernel.
     }];
 
-    let arguments = (ins TTKernel_CB:$cbIn, TTKernel_CB:$cbOut);
+    let arguments = (ins TTKernel_CB:$cbIn);
 
     let hasVerifier = 1;
 }

--- a/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
+++ b/lib/Conversion/TTIRToTTKernel/TTIRToTTKernel.cpp
@@ -492,7 +492,7 @@ public:
           i32(rewriter, op->getLoc(), uncollapsedMemrefType.getShape()[1]);
       rewriter.create<ttkernel::ComputeKernelHWStartupOp>(op->getLoc(), src,
                                                           nullptr, dst);
-      rewriter.create<ttkernel::UntilizeInitOp>(op->getLoc(), src, dst);
+      rewriter.create<ttkernel::UntilizeInitOp>(op->getLoc(), src);
       rewriter.create<ttkernel::ExperimentalUntilizeBlockOp>(
           op->getLoc(), src, dst, blockR, blockC);
     } else {

--- a/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
+++ b/lib/Dialect/TTKernel/IR/TTKernelOps.cpp
@@ -96,10 +96,9 @@ static std::string verifyTilizeUntilizeCBs(CBType tilizedCB, CBType scalarCB) {
     return emitOpError(
         "UntilizeInitOp must be inside of a EnqueueProgramOp region");
   }
-  std::string err =
-      verifyTilizeUntilizeCBs(getCbIn().getType(), getCbOut().getType());
-  if (!err.empty()) {
-    return emitOpError(err);
+  auto inputCBType = getCbIn().getType();
+  if (!mlir::isa<ttcore::TileType>(inputCBType.getMemref().getElementType())) {
+    return emitOpError("Input to UntilizeInitOp must have tile element type");
   }
   return success();
 }

--- a/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
+++ b/test/ttmlir/Conversion/TTKernelToEmitC/ttkernel.mlir
@@ -851,13 +851,11 @@ module {
     }
 
     // CHECK-LABEL: func @untilize_init
-    func.func @untilize_init() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>, <arg_type = cb_port, operand_index = 1>]>, ttkernel.thread = #ttkernel.thread<compute>} {
+    func.func @untilize_init() -> () attributes {ttkernel.arg_spec = #ttkernel.arg_spec< ct_args = [<arg_type = cb_port, operand_index = 0>]>, ttkernel.thread = #ttkernel.thread<compute>} {
       // CHECK: %[[IN_CB:.*]] = emitc.literal "get_compile_time_arg_val(0)"
       %in_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !cb0_tiles
-      // CHECK: %[[OUT_CB:.*]] = emitc.literal "get_compile_time_arg_val(1)"
-      %out_cb = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> !cb1_scalar
-      // CHECK: emitc.call_opaque "untilize_init"(%[[IN_CB]], %[[OUT_CB]])
-      "ttkernel.untilize_init"(%in_cb, %out_cb) : (!cb0_tiles, !cb1_scalar) -> ()
+      // CHECK: emitc.call_opaque "untilize_init"(%[[IN_CB]])
+      "ttkernel.untilize_init"(%in_cb) : (!cb0_tiles) -> ()
       return
     }
 

--- a/test/ttmlir/Translate/TTKernel/ttkernel_compute.mlir
+++ b/test/ttmlir/Translate/TTKernel/ttkernel_compute.mlir
@@ -8,8 +8,8 @@ func.func @ttkernel_compute() -> () attributes {ttkernel.arg_spec = #ttkernel.ar
     %c4_i32 = arith.constant 4 : i32
     %arg1 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 0 : i32}> : () -> !ttkernel.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1_>>
     %arg2 = "ttkernel.get_compile_time_arg_val"() <{arg_index = 1 : i32}> : () -> !ttkernel.cb<memref<64x128xf32, #l1_>>
-    // CHECK: untilize_init(get_compile_time_arg_val(0), get_compile_time_arg_val(1))
-    "ttkernel.untilize_init"(%arg1, %arg2) : (!ttkernel.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1_>>, !ttkernel.cb<memref<64x128xf32, #l1_>>) -> ()
+    // CHECK: untilize_init(get_compile_time_arg_val(0))
+    "ttkernel.untilize_init"(%arg1) : (!ttkernel.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1_>>) -> ()
     // CHECK: untilize_block(get_compile_time_arg_val(0), v1, get_compile_time_arg_val(1))
     "ttkernel.untilize_block"(%arg1, %c4_i32, %arg2) : (!ttkernel.cb<memref<2x4x!ttcore.tile<32x32, f32>, #l1_>>, i32, !ttkernel.cb<memref<64x128xf32, #l1_>>) -> ()
     // CHECK: cb_pop_front(get_compile_time_arg_val(0), v1)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "7cd5738b35e8dc4862ef13a21468cb98264dbef6")
+set(TT_METAL_VERSION "81412069f02b01a483cc0fb29fec5c9bf28ac1ab")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 81412069f02b01a483cc0fb29fec5c9bf28ac1ab

- Update untilize_init API to match tt-metal commit 46a339c6a5
  - Removed output circular buffer param
  - compute_kernel_hw_startup was already being called before untilize_init, so did not make that change