### PR TITLE
Adding CI silicon job for p150 blackhole card

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -182,6 +182,7 @@ jobs:
           {runs-on: n300,         sh-run: true,  name: "run",  suite: "unit",           image: "tracy",  type: "unit"},
           {runs-on: n150,         sh-run: true,  name: "run",  suite: "run",            image: "speedy", type: "ttnn_standalone", path: "tools/ttnn-standalone"},
           {runs-on: n150,         sh-run: true,  name: "run",  suite: "run",            image: "speedy", type: "ttrt",            path: "Silicon",                     flags: "--non-zero"},
+          {runs-on: p150,         sh-run: false,  name: "run",  suite: "run",            image: "speedy", type: "ttrt",            path: "Silicon",                     flags: "--non-zero --disable-eth-dispatch"},
           {runs-on: n150,         sh-run: false, name: "perf", suite: "perf",           image: "tracy",  type: "ttrt",            path: "Silicon/TTNN/n150/perf"},
           {runs-on: n150,         sh-run: false, name: "perf", suite: "optimizer",      image: "tracy",  type: "ttrt",            path: "Silicon/TTNN/n150/optimizer"},
           {runs-on: n150,         sh-run: true,  name: "run",  suite: "emitc",          image: "tracy",  type: "ttrt",            path: "EmitC",                       flags: "--emitc"},

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -77,23 +77,48 @@ if config.system_desc_path:
 
 # set targets based on the system (default = n150)
 """
-available_targets:
+available_targets for Wormhole_b0:
 - n150
 - n300
 - llmbox
 - tg
+available_targets for Blackhole:
+- p150
+- p300
 """
 config.targets = {"n150"}
 
 if system_desc != None:
-    if len(system_desc["chip_desc_indices"]) == 1:
-        config.targets = {"n150"}
-    elif len(system_desc["chip_desc_indices"]) == 2:
-        config.targets = {"n300"}
-    elif len(system_desc["chip_desc_indices"]) == 8:
-        config.targets = {"llmbox"}
-    elif len(system_desc["chip_desc_indices"]) == 32:
-        config.targets = {"tg"}
+    if system_desc["chip_descs"][0]["arch"] == "Blackhole":
+        if len(system_desc["chip_desc_indices"]) == 1:
+            config.targets = {"p150"}
+        elif len(system_desc["chip_desc_indices"]) == 2:
+            config.targets = {"p300"}
+        else:
+            raise ValueError(
+                "Not supported number of chips for Blackhole architecture: "
+                + str(len(system_desc["chip_desc_indices"]))
+            )
+    elif system_desc["chip_descs"][0]["arch"] == "Wormhole_b0":
+        if len(system_desc["chip_desc_indices"]) == 1:
+            config.targets = {"n150"}
+        elif len(system_desc["chip_desc_indices"]) == 2:
+            config.targets = {"n300"}
+        elif len(system_desc["chip_desc_indices"]) == 8:
+            config.targets = {"llmbox"}
+        elif len(system_desc["chip_desc_indices"]) == 32:
+            config.targets = {"tg"}
+        else:
+            raise ValueError(
+                "Not supported number of chips for Wormhole_b0 architecture: "
+                + str(len(system_desc["chip_desc_indices"]))
+            )
+    else:
+        raise ValueError(
+            "Unsupported architecture: "
+            + system_desc["chip_descs"][0]["arch"]
+            + ". Supported architectures are: Blackhole, Wormhole_b0."
+        )
 
 for target in config.targets:
     config.available_features.add(target)

--- a/test/ttmlir/Dialect/TTNN/optimizer/sharding_relu_override_32.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/sharding_relu_override_32.mlir
@@ -1,6 +1,10 @@
 // REQUIRES: opmodel
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="enable-optimizer=true memory-layout-analysis-enabled=true max-legal-layouts=32" -o output_file.mlir %s
 // RUN: FileCheck %s --input-file=output_file.mlir
+// UNSUPPORTED: Blackhole
+// Test isn't supported on blackhole due to file check failure on sharded memory layout:
+// https://github.com/tenstorrent/tt-mlir/issues/4187
+
 module attributes {} {
   func.func @forward(%arg0: tensor<64x96xbf16>, %arg1: tensor<96x64xbf16>) -> tensor<64x64xbf16> {
     // CHECK: #[[L1_:.*]] = #ttnn.buffer_type<l1>

--- a/test/ttmlir/Silicon/StableHLO/n150/lit.local.cfg
+++ b/test/ttmlir/Silicon/StableHLO/n150/lit.local.cfg
@@ -1,2 +1,2 @@
-if not "n150" in config.targets:
+if not any(t in config.targets for t in ("n150", "p150")):
     config.unsupported = True

--- a/test/ttmlir/Silicon/StableHLO/n300/lit.local.cfg
+++ b/test/ttmlir/Silicon/StableHLO/n300/lit.local.cfg
@@ -1,2 +1,2 @@
-if not "n300" in config.targets:
+if not any(t in config.targets for t in ("n300", "p300")):
     config.unsupported = True

--- a/test/ttmlir/Silicon/TTNN/n150/embedding/embedding_backward.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/embedding/embedding_backward.mlir
@@ -1,6 +1,9 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
+// UNSUPPORTED: Blackhole
+// Embedding backward test fails on blackhole architecture due to the following metal issue:
+// https://github.com/tenstorrent/tt-metal/issues/25260
 module attributes {} {
   func.func @backward(%arg0: tensor<1x32xf32>, %arg1: tensor<512x128xf32>, %arg2: tensor<1x32x128xf32>) -> tensor<512x128xf32> {
     %0 = ttir.empty() : tensor<512x128xf32>

--- a/test/ttmlir/Silicon/TTNN/n150/kv_cache/update_cache.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/kv_cache/update_cache.mlir
@@ -1,6 +1,9 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
+// UNSUPPORTED: Blackhole
+// Update cache test fails on blackhole architecture due to the following metal issue:
+// https://github.com/tenstorrent/tt-metal/issues/25249
 module {
   func.func @forward(%arg0: tensor<1x32x64x512xbf16>, %arg1: tensor<1x32x1x512xbf16>) -> tensor<1x32x64x512xbf16> {
     // CHECK: "ttnn.update_cache"

--- a/test/ttmlir/Silicon/TTNN/n150/lit.local.cfg
+++ b/test/ttmlir/Silicon/TTNN/n150/lit.local.cfg
@@ -1,2 +1,2 @@
-if not "n150" in config.targets:
+if not any(t in config.targets for t in ("n150", "p150")):
     config.unsupported = True

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/conv2d_sharding.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/conv2d_sharding.mlir
@@ -2,6 +2,9 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-optimizer=true memory-layout-analysis-enabled=true" %s -o %t.mlir
 // RUN: FileCheck %s --input-file=%t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
+// UNSUPPORTED: Blackhole
+// Test isn't supported on blackhole due to file check failure on sharded memory layout:
+// https://github.com/tenstorrent/tt-mlir/issues/4186
 
 func.func @conv2d_sharding(%arg0: tensor<16x32x32x64xbf16>, %arg1: tensor<64x64x3x3xbf16>, %arg2: tensor<1x1x1x64xbf16>) -> tensor<16x32x32x64xbf16> {
     // CHECK-DAG: #[[LAYOUT_0:.*]] = #ttnn.ttnn_layout{{.*}}sharded{{.*}}

--- a/test/ttmlir/Silicon/TTNN/n300/lit.local.cfg
+++ b/test/ttmlir/Silicon/TTNN/n300/lit.local.cfg
@@ -1,2 +1,2 @@
-if not "n300" in config.targets:
+if not any(t in config.targets for t in ("n300", "p300")):
     config.unsupported = True


### PR DESCRIPTION
### Ticket
Closes #4128

### Problem description
We don't have single-chip coverage for blackhole.

### What's changed
Adding CI job for single-chip blackhole silicon tests. There are two failures for update_cache and backward_emedding op, hence I opened two issues on tt-metal:
- https://github.com/tenstorrent/tt-metal/issues/25249
- https://github.com/tenstorrent/tt-metal/issues/25260

### Checklist
- [x] New/Existing tests provide coverage for changes
