### PR TITLE
Invert `--allow-subset-mesh` `pytest` flag

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -195,8 +195,8 @@ jobs:
           # {runs-on: tg,           sh-run: false, name: "perf", suite: "perf",           image: "tracy",  type: "ttrt",            path: "Silicon/TTNN/tg/perf", ttrt_flags: "--disable-eth-dispatch"},
           {runs-on: n150,         sh-run: false, name: "perf", suite: "perf",           image: "tracy",  type: "pytest",          path: "runtime/tools/ttrt/test"},
           {runs-on: n150,         sh-run: true,  name: "run",  suite: "silicon",        image: "tracy",  type: "builder",         path: "test/python/golden",          flags: "-m \"not run_error and not fails_golden\"", run-ttrt: true},
-          {runs-on: n300,         sh-run: true,  name: "run",  suite: "silicon",        image: "tracy",  type: "builder",         path: "test/python/golden",          flags: "-m \"not run_error and not fails_golden\"", run-ttrt: true},
-          {runs-on: n300-llmbox,  sh-run: true,  name: "run",  suite: "silicon",        image: "tracy",  type: "builder",         path: "test/python/golden",          flags: "-m \"not run_error and not fails_golden\"", run-ttrt: true},
+          {runs-on: n300,         sh-run: true,  name: "run",  suite: "silicon",        image: "tracy",  type: "builder",         path: "test/python/golden",          flags: "-m \"not run_error and not fails_golden\" --require-exact-mesh", run-ttrt: true},
+          {runs-on: n300-llmbox,  sh-run: true,  name: "run",  suite: "silicon",        image: "tracy",  type: "builder",         path: "test/python/golden",          flags: "-m \"not run_error and not fails_golden\" --require-exact-mesh", run-ttrt: true},
           {runs-on: p150,         sh-run: false, name: "run",  suite: "silicon",        image: "tracy",  type: "builder",         path: "test/python/golden",          flags: "-m \"not run_error and not fails_golden\"", run-ttrt: true, ttrt-flags: "--disable-eth-dispatch"},
           # Although these runtime tests are device agnostic, they depend on n150 compiled mlir artifacts
           # Therefore running these tests on n150 specifically

--- a/test/python/golden/conftest.py
+++ b/test/python/golden/conftest.py
@@ -24,9 +24,9 @@ def pytest_addoption(parser):
         help="Path to system descriptor",
     )
     parser.addoption(
-        "--allow-subset-mesh",
+        "--require-exact-mesh",
         action="store_true",
-        help="Enable running tests whose mesh shapes are a subset of the current device",
+        help="Require exact mesh shape match with the current device (default allows subset)",
     )
 
 
@@ -47,12 +47,13 @@ def get_board_id(system_desc) -> str:
             raise ValueError(f"Unknown architecture: {arch}")
 
 
-def filter_valid_mesh_shape(system_desc, params, allow_subset_mesh=False):
+def filter_valid_mesh_shape(system_desc, params, require_exact_mesh=False):
     num_chips = reduce(operator.mul, params.get("mesh_shape", [1]), 1)
-    if allow_subset_mesh:
-        return num_chips <= len(system_desc["chip_desc_indices"])
+    num_physical_chips = len(system_desc["chip_desc_indices"])
+    if require_exact_mesh:
+        return num_chips == num_physical_chips
     else:
-        return num_chips == len(system_desc["chip_desc_indices"])
+        return num_chips <= num_physical_chips
 
 
 def pytest_collection_modifyitems(config, items):
@@ -67,7 +68,7 @@ def pytest_collection_modifyitems(config, items):
         if hasattr(item, "callspec"):
             params = item.callspec.params
             if not filter_valid_mesh_shape(
-                system_desc, params, allow_subset_mesh=config.option.allow_subset_mesh
+                system_desc, params, require_exact_mesh=config.option.require_exact_mesh
             ):
                 # Deselect the test case
                 deselected.append(item)


### PR DESCRIPTION
### Ticket
No Issue, QoL change

### Problem description
The `--allow-subset-mesh` flag allowed for generating tests on devices that match subsets of the intended program mesh. This behavior is desirable by default, so the flag is inverted and is now called `--require-exact-mesh`. 

### What's changed
- The flag was inverted
- The CI matrix has been updated to preserve behavior of exact mesh matching


### Checklist
- [x] New/Existing tests provide coverage for changes
