### PR TITLE
#1869  Remove ARCH specific includes and use HAL APIs instead

### DIFF
--- a/env/activate
+++ b/env/activate
@@ -28,4 +28,3 @@ export TT_METAL_BUILD_HOME="$(pwd)/third_party/tt-metal/src/tt-metal/build"
 export TT_MLIR_HOME="$(pwd)"
 export PYTHONPATH="$(pwd)/${BUILD_DIR:=build}/python_packages:$(pwd)/.local/toolchain/python_packages/mlir_core:${TT_METAL_HOME}/tt_eager:${TT_METAL_BUILD_HOME}/tools/profiler/bin:${TT_METAL_HOME}/ttnn"
 export PYTHONPATH="${PYTHONPATH}:${TT_METAL_HOME}/ttnn:${TT_METAL_HOME}"  # These paths are needed for tracy (profiling)
-export ARCH_NAME="${ARCH_NAME:-wormhole_b0}"

--- a/env/activate.fish
+++ b/env/activate.fish
@@ -19,4 +19,3 @@ set -gx TT_METAL_BUILD_HOME (pwd)/third_party/tt-metal/src/tt-metal/build
 set -gx TT_MLIR_HOME (pwd)
 set -gx PYTHONPATH (pwd)/build/python_packages:(pwd)/.local/toolchain/python_packages/mlir_core:$TT_METAL_HOME/tt_eager:$TT_METAL_BUILD_HOME/tools/profiler/bin:$TT_METAL_HOME/ttnn
 set -gx PYTHONPATH $PYTHONPATH:$TT_METAL_HOME/ttnn:$TT_METAL_HOME  # These paths are needed for tracy (profiling)
-set -gx ARCH_NAME (set -q ARCH_NAME; and echo $ARCH_NAME; or echo "wormhole_b0")

--- a/lib/OpModel/TTNN/CMakeLists.txt
+++ b/lib/OpModel/TTNN/CMakeLists.txt
@@ -12,12 +12,9 @@ add_library(${LIB_NAME} STATIC ${SOURCES})
 
 message(STATUS "TTMLIR_ENABLE_OPMODEL[${TTMLIR_ENABLE_OPMODEL}]")
 if (TTMLIR_ENABLE_OPMODEL)
-    # Building op model library will invoke building tt-metal; and it requires TT_METAL_HOME and ARCH_NAME environment variables to be set.
+    # Building op model library will invoke building tt-metal; and it requires TT_METAL_HOME environment variable to be set.
     if("$ENV{TT_METAL_HOME}" STREQUAL "")
         message(WARNING "TT_METAL_HOME is not set")
-    endif()
-    if("$ENV{ARCH_NAME}" STREQUAL "")
-        message(WARNING "ARCH_NAME is not set")
     endif()
 
     # Link to tt-metal libs and include directories

--- a/runtime/lib/common/system_desc.cpp
+++ b/runtime/lib/common/system_desc.cpp
@@ -15,7 +15,6 @@
 #include <vector>
 
 #define FMT_HEADER_ONLY
-#include "eth_l1_address_map.h"
 #include "hostdevcommon/common_values.hpp"
 #include "tt-metalium/allocator.hpp"
 #include "tt-metalium/hal.hpp"
@@ -250,7 +249,7 @@ static std::unique_ptr<::tt::runtime::SystemDesc> getCurrentSystemDescImpl(
         &coordTranslationOffsets, device->l1_size_per_core(),
         device->num_dram_channels(), device->dram_size_per_channel(),
         l1Alignment, pcieAlignment, dramAlignment, l1UnreservedBase,
-        ::eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE, dramUnreservedBase,
+        ::tt::tt_metal::hal::get_erisc_l1_unreserved_base(), dramUnreservedBase,
         dramUnreservedEnd, chipPhysicalHelperCores, supportedDataTypes,
         supportedTileSizes, kDstRegisterSizeTiles, NUM_CIRCULAR_BUFFERS,
         kNumComputeThreads, kNumDatamovementThreads));

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -155,9 +155,3 @@ if "TT_METAL_BUILD_HOME" in os.environ:
     )
 else:
     raise OSError("Error: TT_METAL_BUILD_HOME not set")
-
-# Add `ARCH_NAME` to lit environment.
-if "ARCH_NAME" in os.environ:
-    llvm_config.with_environment("ARCH_NAME", os.environ["ARCH_NAME"])
-else:
-    raise OSError("Error: ARCH_NAME not set.")

--- a/test/unittests/lit.cfg.py
+++ b/test/unittests/lit.cfg.py
@@ -55,10 +55,6 @@ if "TT_METAL_HOME" in os.environ:
 else:
     raise OSError("TT_METAL_HOME environment variable is not set")
 
-if "ARCH_NAME" in os.environ:
-    config.environment["ARCH_NAME"] = os.environ["ARCH_NAME"]
-else:
-    raise OSError("ARCH_NAME environment variable is not set")
 
 # Some optimizer unittests must be run serially. There is no way to that in llvm-lit
 # without running all tests serially which will take a long time. Exclude them and

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -4,18 +4,6 @@ set(TT_METAL_VERSION "5119c0b25a2d09a3116fb0427a39e4146d8990d6")
 
 set(CMAKE_INSTALL_MESSAGE LAZY)  # suppress "Up-to-date:..." messages in incremental builds
 
-if ("$ENV{ARCH_NAME}" STREQUAL "grayskull")
-  set(ARCH_NAME "grayskull")
-  set(ARCH_EXTRA_DIR "grayskull")
-elseif ("$ENV{ARCH_NAME}" STREQUAL "wormhole_b0")
-  set(ARCH_NAME "wormhole")
-  set(ARCH_EXTRA_DIR "wormhole/wormhole_b0_defines")
-elseif ("$ENV{ARCH_NAME}" STREQUAL "blackhole")
-  set(ARCH_NAME "blackhole")
-  set(ARCH_EXTRA_DIR "blackhole")
-else()
-  message(FATAL_ERROR "Unsupported ARCH_NAME: $ENV{ARCH_NAME}")
-endif()
 
 if (DEFINED ENV{CPM_SOURCE_CACHE})
   set(CPM_SOURCE_CACHE $ENV{CPM_SOURCE_CACHE})
@@ -43,9 +31,6 @@ set(TTMETAL_INCLUDE_DIRS
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/umd
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/umd/device/api
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/hw/inc
-  ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/hw/inc/${ARCH_NAME}
-  ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/hw/inc/${ARCH_EXTRA_DIR}
-  ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/umd/src/firmware/riscv/${ARCH_NAME}
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_metal/third_party/taskflow
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_stl
   ${PROJECT_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/tt_stl/tt_stl


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/1869

### Problem description
HAL now abstracts all hardware specific APIs. 
Codebase should no longer depend on ARCH specific include paths.

### What's changed
- Remove ARCH_NAME env var
- Remove ARCH based include paths
- Replace last remaining ARCH specific APIs with HAL API in system desc creation


### Checklist
- [x] New/Existing tests provide coverage for changes
  - Existing tests [[pass in CI]](https://github.com/tenstorrent/tt-mlir/actions/runs/16371395757)