### PR TITLE
Remove arg attrs from FuncOp when going to EmitC

### DIFF
--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitCPass.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitCPass.cpp
@@ -5,6 +5,7 @@
 #include "ttmlir/Conversion/TTNNToEmitC/TTNNToEmitC.h"
 
 #include "ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h"
+#include "ttmlir/Dialect/TTCore/IR/TTCore.h"
 #include "ttmlir/Dialect/TTCore/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNN.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
@@ -116,9 +117,13 @@ struct ConvertTTNNToEmitCPass
       //
       populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(
           patterns, typeConverter);
+      // Disallow arg attrs on func op
+      //
       target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp op) {
         return typeConverter.isSignatureLegal(op.getFunctionType()) &&
-               typeConverter.isLegal(&op.getBody());
+               typeConverter.isLegal(&op.getBody()) &&
+               (!op.getArgAttrs().has_value() ||
+                op.getArgAttrs().value().empty());
       });
       populateReturnOpTypeConversionPattern(patterns, typeConverter);
       target.addDynamicallyLegalOp<func::ReturnOp>(

--- a/test/ttmlir/EmitC/TTNN/other/const-eval-device.mlir
+++ b/test/ttmlir/EmitC/TTNN/other/const-eval-device.mlir
@@ -1,7 +1,7 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-const-eval=true" %s > %t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
-// RUN: ttmlir-opt --ttnn-tuplify-tensors --convert-ttnn-to-emitc --allow-unregistered-dialect %t.mlir > %t2.mlir
-// RUN: ttmlir-translate --mlir-to-cpp --allow-unregistered-dialect %t2.mlir > %basename_t.cpp
+// RUN: ttmlir-opt --ttnn-tuplify-tensors --convert-ttnn-to-emitc %t.mlir > %t2.mlir
+// RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
 
 func.func @embedding(%arg0: tensor<32x32xbf16> {ttcore.argument_type = #ttcore.argument_type<constant>}, %arg1: tensor<512x128xbf16>) -> tensor<32x32x128xbf16> {
   %0 = ttir.empty() : tensor<32x32x128xbf16>

--- a/test/ttmlir/EmitC/TTNN/other/const-eval.mlir
+++ b/test/ttmlir/EmitC/TTNN/other/const-eval.mlir
@@ -1,7 +1,7 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-const-eval=true" %s > %t.mlir
 // RUN: ttmlir-translate --ttnn-to-flatbuffer %t.mlir > %basename_t.ttnn
-// RUN: ttmlir-opt --ttnn-tuplify-tensors --convert-ttnn-to-emitc --allow-unregistered-dialect %t.mlir > %t2.mlir
-// RUN: ttmlir-translate --mlir-to-cpp --allow-unregistered-dialect %t2.mlir > %basename_t.cpp
+// RUN: ttmlir-opt --ttnn-tuplify-tensors --convert-ttnn-to-emitc %t.mlir > %t2.mlir
+// RUN: ttmlir-translate --mlir-to-cpp %t2.mlir > %basename_t.cpp
 // RUN: FileCheck %s --input-file %t.mlir
 
 module {


### PR DESCRIPTION
### Ticket
x

### Problem description
`ttcore.ArgumentType` arg attrs would remain on FuncOp after TTNN->EmitC conversion, causing the translation (`ttmlir-translate --mlir-to-cpp`) to fail, citing "unregistered dialects".

### What's changed
Remove all arg attrs from `FuncOp`, and update tests to not use the hotfix (`--allow-unregistered-dialects`)

### Checklist
- [x] New/Existing tests provide coverage for changes
