### PR TITLE
Add constraints API for exp, log, and tanh

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -299,7 +299,9 @@ def TTNN_CosOp : TTNN_ElementwiseUnaryOp<"cos",
     }];
 }
 
-def TTNN_ExpOp : TTNN_ElementwiseUnaryOp<"exp"> {
+def TTNN_ExpOp : TTNN_ElementwiseUnaryOp<"exp",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
     let summary = "Eltwise exponential.";
     let description = [{
       Eltwise exponential operation.
@@ -461,7 +463,9 @@ def TTNN_SigmoidOp : TTNN_ElementwiseUnaryOp<"sigmoid",
     }];
 }
 
-def TTNN_LogOp : TTNN_ElementwiseUnaryOp<"log"> {
+def TTNN_LogOp : TTNN_ElementwiseUnaryOp<"log",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
     let summary = "Eltwise logarithm.";
     let description = [{
       Eltwise logarithm operation.

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -396,7 +396,9 @@ def TTNN_AtanOp: TTNN_ElementwiseUnaryOp<"atan"> {
     }];
 }
 
-def TTNN_TanhOp: TTNN_ElementwiseUnaryOp<"tanh"> {
+def TTNN_TanhOp: TTNN_ElementwiseUnaryOp<"tanh",
+      [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+      > {
     let summary = "Eltwise tanh op.";
 
     let extraClassDeclaration = [{

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -655,6 +655,44 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 }; // namespace CosOpInterface
 
 //===----------------------------------------------------------------------===//
+// ExpOp
+//===----------------------------------------------------------------------===//
+namespace ExpOpInterface {
+llvm::Expected<OpConstraints>
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+                 std::optional<bool> fastApproxMode,
+                 llvm::ArrayRef<int64_t> outputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+
+llvm::Expected<size_t>
+getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+             std::optional<bool> fastApproxMode,
+             llvm::ArrayRef<int64_t> outputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+}; // namespace ExpOpInterface
+
+//===----------------------------------------------------------------------===//
+// LogOp
+//===----------------------------------------------------------------------===//
+namespace LogOpInterface {
+llvm::Expected<OpConstraints>
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+                 llvm::ArrayRef<int64_t> outputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+
+llvm::Expected<size_t>
+getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+             llvm::ArrayRef<int64_t> outputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+}; // namespace LogOpInterface
+
+//===----------------------------------------------------------------------===//
 // ReciprocalOp
 //===----------------------------------------------------------------------===//
 namespace ReciprocalOpInterface {

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -662,14 +662,12 @@ llvm::Expected<OpConstraints>
 getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
                  llvm::ArrayRef<int64_t> inputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-                 // std::optional<bool> fastApproxMode,
                  llvm::ArrayRef<int64_t> outputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
 
 llvm::Expected<size_t>
 getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
              mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-             // std::optional<bool> fastApproxMode,
              llvm::ArrayRef<int64_t> outputShape,
              mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
 }; // namespace ExpOpInterface

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -675,6 +675,24 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 }; // namespace ExpOpInterface
 
 //===----------------------------------------------------------------------===//
+// TanhOp
+//===----------------------------------------------------------------------===//
+namespace TanhOpInterface {
+llvm::Expected<OpConstraints>
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+                 llvm::ArrayRef<int64_t> outputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+
+llvm::Expected<size_t>
+getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+             llvm::ArrayRef<int64_t> outputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+}; // namespace TanhOpInterface
+
+//===----------------------------------------------------------------------===//
 // LogOp
 //===----------------------------------------------------------------------===//
 namespace LogOpInterface {

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -662,14 +662,14 @@ llvm::Expected<OpConstraints>
 getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
                  llvm::ArrayRef<int64_t> inputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-                 //std::optional<bool> fastApproxMode,
+                 // std::optional<bool> fastApproxMode,
                  llvm::ArrayRef<int64_t> outputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
 
 llvm::Expected<size_t>
 getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
              mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-             //std::optional<bool> fastApproxMode,
+             // std::optional<bool> fastApproxMode,
              llvm::ArrayRef<int64_t> outputShape,
              mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
 }; // namespace ExpOpInterface

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -662,14 +662,14 @@ llvm::Expected<OpConstraints>
 getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
                  llvm::ArrayRef<int64_t> inputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-                 std::optional<bool> fastApproxMode,
+                 //std::optional<bool> fastApproxMode,
                  llvm::ArrayRef<int64_t> outputShape,
                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
 
 llvm::Expected<size_t>
 getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
              mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-             std::optional<bool> fastApproxMode,
+             //std::optional<bool> fastApproxMode,
              llvm::ArrayRef<int64_t> outputShape,
              mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
 }; // namespace ExpOpInterface

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -259,17 +259,10 @@ CosOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 llvm::Expected<op_model::ttnn::OpConstraints>
 ExpOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                         const OpConfig &opConfig) {
-  assert(inputs.size() == 1); // (1 + (getFastApproxMode() ? 0 : 1)));
+  assert(inputs.size() == 1);
 
   const auto inputShape = getInput().getType().getShape();
   const auto outputShape = getType().getShape();
-  
-  /*std::optional<bool> fastApproxMode;
-  if (getFastApproxMode()) {
-    fastApproxMode = getFastApproxMode().value();
-  } else {
-    fastApproxMode = std::nullopt;
-  }*/
 
   llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
   if (!check) {
@@ -287,26 +280,14 @@ llvm::Expected<size_t>
 ExpOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                     const OpConfig &opConfig) {
 
-  assert(inputs.size() == 1); // (1 + (getFastApproxMode() ? 0 : 1)));
+  assert(inputs.size() == 1);
 
   const auto inputShape = getInput().getType().getShape();
   const auto outputShape = getType().getShape();
 
-  /*std::optional<bool> fastApproxMode;
-  if (getFastApproxMode()) {
-    fastApproxMode = getFastApproxMode().value();
-  } else {
-    fastApproxMode = std::nullopt;
-  }*/
-
   return opRuntimeCache().getOrCompute(
       op_model::ttnn::ExpOpInterface::getOpRuntime, *this, inputShape,
       inputs[0], outputShape, opConfig.outputLayout);
-
-  /*return opRuntimeCache().getOrCompute(op_model::ttnn::ExpOpInterface::getOpRuntime,
-                                      *this, inputShape,
-                                       inputs[0], fastApproxMode, outputShape,
-                                       opConfig.outputLayout);*/
 }
 
 //===----------------------------------------------------------------------===//
@@ -315,7 +296,7 @@ ExpOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 
 llvm::Expected<op_model::ttnn::OpConstraints>
 TanhOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                        const OpConfig &opConfig) {
+                         const OpConfig &opConfig) {
   assert(inputs.size() == 1);
 
   const auto inputShape = getInput().getType().getShape();
@@ -335,7 +316,7 @@ TanhOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
 
 llvm::Expected<size_t>
 TanhOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
-                    const OpConfig &opConfig) {
+                     const OpConfig &opConfig) {
 
   assert(inputs.size() == 1);
 

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -310,6 +310,44 @@ ExpOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// TanhOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::ttnn::OpConstraints>
+TanhOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                        const OpConfig &opConfig) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+  const auto outputShape = getType().getShape();
+
+  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
+  if (!check) {
+    return check.takeError();
+  }
+  ttcore::GridAttr deviceGrid =
+      ttcore::lookupDevice(getOperation()).getWorkerGrid();
+
+  return opConstraintsCache().getOrCompute(
+      op_model::ttnn::TanhOpInterface::getOpConstraints, *this, deviceGrid,
+      inputShape, inputs[0], outputShape, opConfig.outputLayout);
+}
+
+llvm::Expected<size_t>
+TanhOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                    const OpConfig &opConfig) {
+
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+  const auto outputShape = getType().getShape();
+
+  return opRuntimeCache().getOrCompute(
+      op_model::ttnn::TanhOpInterface::getOpRuntime, *this, inputShape,
+      inputs[0], outputShape, opConfig.outputLayout);
+}
+
+//===----------------------------------------------------------------------===//
 // LogOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -253,6 +253,26 @@ CosOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// LogOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::ttnn::OpConstraints>
+LogOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                        const OpConfig &opConfig) {
+  return getUnaryOpConstraints(
+      *this, inputs, opConfig,
+      op_model::ttnn::LogOpInterface::getOpConstraints);
+}
+
+llvm::Expected<size_t>
+LogOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                    const OpConfig &opConfig) {
+
+  return getUnaryOpRuntime(*this, inputs, opConfig,
+                           op_model::ttnn::LogOpInterface::getOpRuntime);
+}
+
+//===----------------------------------------------------------------------===//
 // ReciprocalOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -259,35 +259,17 @@ CosOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 llvm::Expected<op_model::ttnn::OpConstraints>
 ExpOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                         const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-  const auto outputShape = getType().getShape();
-
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::ttnn::ExpOpInterface::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], outputShape, opConfig.outputLayout);
+  return getUnaryOpConstraints(
+      *this, inputs, opConfig,
+      op_model::ttnn::ExpOpInterface::getOpConstraints);
 }
 
 llvm::Expected<size_t>
 ExpOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                     const OpConfig &opConfig) {
 
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-  const auto outputShape = getType().getShape();
-
-  return opRuntimeCache().getOrCompute(
-      op_model::ttnn::ExpOpInterface::getOpRuntime, *this, inputShape,
-      inputs[0], outputShape, opConfig.outputLayout);
+  return getUnaryOpRuntime(*this, inputs, opConfig,
+                           op_model::ttnn::ExpOpInterface::getOpRuntime);
 }
 
 //===----------------------------------------------------------------------===//
@@ -297,35 +279,17 @@ ExpOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 llvm::Expected<op_model::ttnn::OpConstraints>
 TanhOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                          const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-  const auto outputShape = getType().getShape();
-
-  llvm::Expected<bool> check = detail::checkDeviceWorkerGrid(getOperation());
-  if (!check) {
-    return check.takeError();
-  }
-  ttcore::GridAttr deviceGrid =
-      ttcore::lookupDevice(getOperation()).getWorkerGrid();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::ttnn::TanhOpInterface::getOpConstraints, *this, deviceGrid,
-      inputShape, inputs[0], outputShape, opConfig.outputLayout);
+  return getUnaryOpConstraints(
+      *this, inputs, opConfig,
+      op_model::ttnn::TanhOpInterface::getOpConstraints);
 }
 
 llvm::Expected<size_t>
 TanhOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                      const OpConfig &opConfig) {
 
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-  const auto outputShape = getType().getShape();
-
-  return opRuntimeCache().getOrCompute(
-      op_model::ttnn::TanhOpInterface::getOpRuntime, *this, inputShape,
-      inputs[0], outputShape, opConfig.outputLayout);
+  return getUnaryOpRuntime(*this, inputs, opConfig,
+                           op_model::ttnn::TanhOpInterface::getOpRuntime);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -828,6 +828,37 @@ CosOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 }
 
 //===----------------------------------------------------------------------===//
+// LogOp
+//===----------------------------------------------------------------------===//
+llvm::Expected<OpConstraints>
+CosOpInterface::getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                                 llvm::ArrayRef<int64_t> inputShape,
+                                 mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+                                 llvm::ArrayRef<int64_t> outputShape,
+                                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  return getEltwiseUnaryOpConstraints("LogOpInterface", ::ttnn::log, deviceGrid,
+                                      inputShape, inputLayout, outputShape,
+                                      outputLayout);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t>
+CosOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
+                             mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+                             llvm::ArrayRef<int64_t> outputShape,
+                             mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  return getEltwiseUnaryOpRuntime("LogOpInterface", ::ttnn::log, inputShape,
+                                  inputLayout, outputShape, outputLayout);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
 // ReciprocalOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> ReciprocalOpInterface::getOpConstraints(

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -906,25 +906,9 @@ TanhOpInterface::getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
                                   llvm::ArrayRef<int64_t> outputShape,
                                   mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  ::tt::tt_metal::distributed::MeshDevice *device =
-      SingletonDeviceContext::getInstance().getDevice();
-
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
-
-  // Create query closure
-  auto query = [=]() {
-    return ::ttnn::graph::query_op_constraints(
-        ::ttnn::tanh, device, inputSpec,
-        detail::getNullableMemoryConfig(outputLayout));
-  };
-
-  return operation::getOpConstraints(
-      "TanhOpInterface", inputLayout.getContext(), deviceGrid, query);
+  return getEltwiseUnaryOpConstraints("TanhOpInterface", ::ttnn::tanh,
+                                      deviceGrid, inputShape, inputLayout,
+                                      outputShape, outputLayout);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -936,24 +920,8 @@ TanhOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                               llvm::ArrayRef<int64_t> outputShape,
                               mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  ::tt::tt_metal::distributed::MeshDevice *device =
-      SingletonDeviceContext::getInstance().getDevice();
-
-  auto inputSpecExp =
-      detail::convertToTensorSpec(device, inputShape, inputLayout);
-  if (!inputSpecExp) {
-    return inputSpecExp.takeError();
-  }
-  ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
-
-  // Create query closure
-  auto query = [=]() {
-    return ::ttnn::graph::query_op_runtime(
-        ::ttnn::tanh, device, inputSpec,
-        detail::getNullableMemoryConfig(outputLayout));
-  };
-
-  return operation::getOpRuntime("TanhOpInterface", query);
+  return getEltwiseUnaryOpRuntime("TanhOpInterface", ::ttnn::tanh, inputShape,
+                                  inputLayout, outputShape, outputLayout);
 #else
   return llvm::createStringError("Not Implemented");
 #endif // TTMLIR_ENABLE_OPMODEL

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -834,7 +834,6 @@ llvm::Expected<OpConstraints>
 ExpOpInterface::getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
                                  llvm::ArrayRef<int64_t> inputShape,
                                  mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-                                 //std::optional<bool> fastApproxMode,
                                  llvm::ArrayRef<int64_t> outputShape,
                                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
@@ -850,7 +849,7 @@ ExpOpInterface::getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
 
   // Add default parameters
   bool fastApproxMode = false;
-  
+
   // Create query closure
   auto expOpQuery = [=]() {
     return ::ttnn::graph::query_op_constraints(
@@ -868,7 +867,6 @@ ExpOpInterface::getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
 llvm::Expected<size_t>
 ExpOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                              mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-                             //std::optional<bool> fastApproxMode,
                              llvm::ArrayRef<int64_t> outputShape,
                              mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
@@ -903,10 +901,10 @@ ExpOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints>
 TanhOpInterface::getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
-                                 llvm::ArrayRef<int64_t> inputShape,
-                                 mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-                                 llvm::ArrayRef<int64_t> outputShape,
-                                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+                                  llvm::ArrayRef<int64_t> inputShape,
+                                  mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+                                  llvm::ArrayRef<int64_t> outputShape,
+                                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -918,18 +916,15 @@ TanhOpInterface::getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
   }
   ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
-  // Add default parameters
-  //bool accuracy = false;
-  
   // Create query closure
   auto query = [=]() {
     return ::ttnn::graph::query_op_constraints(
-        ::ttnn::tanh, device, inputSpec, //accuracy,
+        ::ttnn::tanh, device, inputSpec,
         detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints("TanhOpInterface", inputLayout.getContext(),
-                                     deviceGrid, query);
+  return operation::getOpConstraints(
+      "TanhOpInterface", inputLayout.getContext(), deviceGrid, query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -937,9 +932,9 @@ TanhOpInterface::getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
 
 llvm::Expected<size_t>
 TanhOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
-                             mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
-                             llvm::ArrayRef<int64_t> outputShape,
-                             mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+                              mlir::tt::ttnn::TTNNLayoutAttr inputLayout,
+                              llvm::ArrayRef<int64_t> outputShape,
+                              mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -951,13 +946,10 @@ TanhOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
   }
   ::ttnn::TensorSpec inputSpec = inputSpecExp.get();
 
-  // Add default parameters
-  //bool accuracy = false;
-
   // Create query closure
   auto query = [=]() {
     return ::ttnn::graph::query_op_runtime(
-        ::ttnn::tanh, device, inputSpec, //accuracy,
+        ::ttnn::tanh, device, inputSpec,
         detail::getNullableMemoryConfig(outputLayout));
   };
 

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -63,7 +63,17 @@ const TestTensor inerleaved2048X2048L1 = {
 } // namespace detail
 
 // ==== Unary Eltwise Ops Starts ====
-enum class UnaryEltwiseOpType { Relu, Sqrt, Sigmoid, Sin, Cos, Exp, Tanh, Log, Reciprocal };
+enum class UnaryEltwiseOpType {
+  Relu,
+  Sqrt,
+  Sigmoid,
+  Sin,
+  Cos,
+  Exp,
+  Tanh,
+  Log,
+  Reciprocal
+};
 
 class OpModelUnaryEltwiseParam : public OpModelTest,
                                  public testing::WithParamInterface<

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -63,7 +63,7 @@ const TestTensor inerleaved2048X2048L1 = {
 } // namespace detail
 
 // ==== Unary Eltwise Ops Starts ====
-enum class UnaryEltwiseOpType { Relu, Sqrt, Sigmoid, Sin, Cos, Exp, Log, Reciprocal };
+enum class UnaryEltwiseOpType { Relu, Sqrt, Sigmoid, Sin, Cos, Exp, Tanh, Log, Reciprocal };
 
 class OpModelUnaryEltwiseParam : public OpModelTest,
                                  public testing::WithParamInterface<
@@ -83,6 +83,7 @@ protected:
           {UnaryEltwiseOpType::Sin, SinOpInterface::getOpRuntime},
           {UnaryEltwiseOpType::Cos, CosOpInterface::getOpRuntime},
           {UnaryEltwiseOpType::Exp, ExpOpInterface::getOpRuntime},
+          {UnaryEltwiseOpType::Tanh, TanhOpInterface::getOpRuntime},
           {UnaryEltwiseOpType::Log, LogOpInterface::getOpRuntime},
           {UnaryEltwiseOpType::Reciprocal, ReciprocalOpInterface::getOpRuntime},
       };
@@ -98,6 +99,7 @@ protected:
           {UnaryEltwiseOpType::Sin, SinOpInterface::getOpConstraints},
           {UnaryEltwiseOpType::Cos, CosOpInterface::getOpConstraints},
           {UnaryEltwiseOpType::Exp, ExpOpInterface::getOpConstraints},
+          {UnaryEltwiseOpType::Tanh, TanhOpInterface::getOpConstraints},
           {UnaryEltwiseOpType::Log, LogOpInterface::getOpConstraints},
           {UnaryEltwiseOpType::Reciprocal,
            ReciprocalOpInterface::getOpConstraints},
@@ -232,6 +234,10 @@ INSTANTIATE_TEST_SUITE_P(CosTests, OpModelUnaryEltwiseParam,
 
 INSTANTIATE_TEST_SUITE_P(ExpTests, OpModelUnaryEltwiseParam,
                          generateBinaryEltwiseParams(UnaryEltwiseOpType::Exp,
+                                                     unaryEltwiseParams));
+
+INSTANTIATE_TEST_SUITE_P(TanhTests, OpModelUnaryEltwiseParam,
+                         generateBinaryEltwiseParams(UnaryEltwiseOpType::Tanh,
                                                      unaryEltwiseParams));
 
 INSTANTIATE_TEST_SUITE_P(LogTests, OpModelUnaryEltwiseParam,

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -63,7 +63,7 @@ const TestTensor inerleaved2048X2048L1 = {
 } // namespace detail
 
 // ==== Unary Eltwise Ops Starts ====
-enum class UnaryEltwiseOpType { Relu, Sqrt, Sigmoid, Sin, Cos, Log, Reciprocal };
+enum class UnaryEltwiseOpType { Relu, Sqrt, Sigmoid, Sin, Cos, Exp, Log, Reciprocal };
 
 class OpModelUnaryEltwiseParam : public OpModelTest,
                                  public testing::WithParamInterface<
@@ -82,6 +82,7 @@ protected:
           {UnaryEltwiseOpType::Sigmoid, SigmoidOpInterface::getOpRuntime},
           {UnaryEltwiseOpType::Sin, SinOpInterface::getOpRuntime},
           {UnaryEltwiseOpType::Cos, CosOpInterface::getOpRuntime},
+          {UnaryEltwiseOpType::Exp, ExpOpInterface::getOpRuntime},
           {UnaryEltwiseOpType::Log, LogOpInterface::getOpRuntime},
           {UnaryEltwiseOpType::Reciprocal, ReciprocalOpInterface::getOpRuntime},
       };
@@ -96,6 +97,7 @@ protected:
           {UnaryEltwiseOpType::Sigmoid, SigmoidOpInterface::getOpConstraints},
           {UnaryEltwiseOpType::Sin, SinOpInterface::getOpConstraints},
           {UnaryEltwiseOpType::Cos, CosOpInterface::getOpConstraints},
+          {UnaryEltwiseOpType::Exp, ExpOpInterface::getOpConstraints},
           {UnaryEltwiseOpType::Log, LogOpInterface::getOpConstraints},
           {UnaryEltwiseOpType::Reciprocal,
            ReciprocalOpInterface::getOpConstraints},
@@ -226,6 +228,10 @@ INSTANTIATE_TEST_SUITE_P(SinTests, OpModelUnaryEltwiseParam,
 
 INSTANTIATE_TEST_SUITE_P(CosTests, OpModelUnaryEltwiseParam,
                          generateBinaryEltwiseParams(UnaryEltwiseOpType::Cos,
+                                                     unaryEltwiseParams));
+
+INSTANTIATE_TEST_SUITE_P(ExpTests, OpModelUnaryEltwiseParam,
+                         generateBinaryEltwiseParams(UnaryEltwiseOpType::Exp,
                                                      unaryEltwiseParams));
 
 INSTANTIATE_TEST_SUITE_P(LogTests, OpModelUnaryEltwiseParam,

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -63,7 +63,7 @@ const TestTensor inerleaved2048X2048L1 = {
 } // namespace detail
 
 // ==== Unary Eltwise Ops Starts ====
-enum class UnaryEltwiseOpType { Relu, Sqrt, Sigmoid, Sin, Cos, Reciprocal };
+enum class UnaryEltwiseOpType { Relu, Sqrt, Sigmoid, Sin, Cos, Log, Reciprocal };
 
 class OpModelUnaryEltwiseParam : public OpModelTest,
                                  public testing::WithParamInterface<
@@ -82,6 +82,7 @@ protected:
           {UnaryEltwiseOpType::Sigmoid, SigmoidOpInterface::getOpRuntime},
           {UnaryEltwiseOpType::Sin, SinOpInterface::getOpRuntime},
           {UnaryEltwiseOpType::Cos, CosOpInterface::getOpRuntime},
+          {UnaryEltwiseOpType::Log, LogOpInterface::getOpRuntime},
           {UnaryEltwiseOpType::Reciprocal, ReciprocalOpInterface::getOpRuntime},
       };
   std::map<UnaryEltwiseOpType,
@@ -95,6 +96,7 @@ protected:
           {UnaryEltwiseOpType::Sigmoid, SigmoidOpInterface::getOpConstraints},
           {UnaryEltwiseOpType::Sin, SinOpInterface::getOpConstraints},
           {UnaryEltwiseOpType::Cos, CosOpInterface::getOpConstraints},
+          {UnaryEltwiseOpType::Log, LogOpInterface::getOpConstraints},
           {UnaryEltwiseOpType::Reciprocal,
            ReciprocalOpInterface::getOpConstraints},
       };
@@ -224,6 +226,10 @@ INSTANTIATE_TEST_SUITE_P(SinTests, OpModelUnaryEltwiseParam,
 
 INSTANTIATE_TEST_SUITE_P(CosTests, OpModelUnaryEltwiseParam,
                          generateBinaryEltwiseParams(UnaryEltwiseOpType::Cos,
+                                                     unaryEltwiseParams));
+
+INSTANTIATE_TEST_SUITE_P(LogTests, OpModelUnaryEltwiseParam,
+                         generateBinaryEltwiseParams(UnaryEltwiseOpType::Log,
                                                      unaryEltwiseParams));
 
 INSTANTIATE_TEST_SUITE_P(

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -209,10 +209,10 @@ const auto createCos = [](OpBuilder &b, Location loc, Type type,
                           ValueRange ops) {
   return b.create<CosOp>(loc, type, ops).getOperation();
 };
-//const auto createExp = [](OpBuilder &b, Location loc, Type type,
-//                          ValueRange ops) {
-//  return b.create<ExpOp>(loc, type, ops).getOperation();
-//};
+// const auto createExp = [](OpBuilder &b, Location loc, Type type,
+//                           ValueRange ops) {
+//   return b.create<ExpOp>(loc, type, ops).getOperation();
+// };
 const auto createLog = [](OpBuilder &b, Location loc, Type type,
                           ValueRange ops) {
   return b.create<LogOp>(loc, type, ops).getOperation();
@@ -277,7 +277,7 @@ TEST_F(OpModelBase, ExpOpInterface) {
   auto outputType = createRankedTensorType(tensorShape);
 
   auto exp = builder.create<ExpOp>(builder.getUnknownLoc(), outputType,
-                                           ::mlir::ValueRange{input});
+                                   ::mlir::ValueRange{input});
 
   // test ExpOp interface
   auto constraintsExp = getOpConstraints(exp.getOperation());
@@ -308,7 +308,7 @@ TEST_F(OpModelBase, TanhOpInterface) {
   auto outputType = createRankedTensorType(tensorShape);
 
   auto tanh = builder.create<TanhOp>(builder.getUnknownLoc(), outputType,
-                                           ::mlir::ValueRange{input});
+                                     ::mlir::ValueRange{input});
 
   // test TanhOp interface
   auto constraintsExp = getOpConstraints(tanh.getOperation());

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -209,10 +209,14 @@ const auto createCos = [](OpBuilder &b, Location loc, Type type,
                           ValueRange ops) {
   return b.create<CosOp>(loc, type, ops).getOperation();
 };
-// const auto createExp = [](OpBuilder &b, Location loc, Type type,
-//                           ValueRange ops) {
-//   return b.create<ExpOp>(loc, type, ops).getOperation();
-// };
+const auto createExp = [](OpBuilder &b, Location loc, Type type,
+                          ValueRange ops) {
+  return b.create<ExpOp>(loc, type, ops).getOperation();
+};
+const auto createTanh = [](OpBuilder &b, Location loc, Type type,
+                           ValueRange ops) {
+  return b.create<TanhOp>(loc, type, ops).getOperation();
+};
 const auto createLog = [](OpBuilder &b, Location loc, Type type,
                           ValueRange ops) {
   return b.create<LogOp>(loc, type, ops).getOperation();
@@ -227,7 +231,8 @@ const std::vector<UnaryOpTestParams> unaryOpTestParams = {
     {"Relu", createRelu, expected},
     {"Sin", createSin, expected},
     {"Cos", createCos, expected},
-    //{"Exp", createExp, expected},
+    {"Exp", createExp, expected},
+    {"Tanh", createTanh, expected},
     {"Log", createLog, expected},
     {"Reciprocal", createReciprocal, expected}};
 
@@ -262,68 +267,6 @@ TEST_F(OpModelBase, SqrtOpInterface) {
   }
 
   auto runtimeExp = getOpRuntime(sqrt.getOperation());
-  if (runtimeExp) {
-    EXPECT_TRUE(runtimeExp.get() > 0);
-  } else {
-    FAIL() << llvm::toString(runtimeExp.takeError());
-  }
-}
-
-TEST_F(OpModelBase, ExpOpInterface) {
-  // create ExpOp
-  llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
-
-  auto input = createEmptyTensor(tensorShape);
-  auto outputType = createRankedTensorType(tensorShape);
-
-  auto exp = builder.create<ExpOp>(builder.getUnknownLoc(), outputType,
-                                   ::mlir::ValueRange{input});
-
-  // test ExpOp interface
-  auto constraintsExp = getOpConstraints(exp.getOperation());
-  if (constraintsExp) {
-    auto l1 = constraintsExp.get();
-    const auto [cbSize, peakSize, outputSize, outputLayout] = l1;
-    EXPECT_EQ(cbSize, 8192);
-    EXPECT_EQ(peakSize, 2048);
-    EXPECT_EQ(outputSize, 2048);
-  } else {
-    FAIL() << "Missing L1 constraints; Error="
-           << llvm::toString(constraintsExp.takeError()) << std::endl;
-  }
-
-  auto runtimeExp = getOpRuntime(exp.getOperation());
-  if (runtimeExp) {
-    EXPECT_TRUE(runtimeExp.get() > 0);
-  } else {
-    FAIL() << llvm::toString(runtimeExp.takeError());
-  }
-}
-
-TEST_F(OpModelBase, TanhOpInterface) {
-  // create TanhOp
-  llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
-
-  auto input = createEmptyTensor(tensorShape);
-  auto outputType = createRankedTensorType(tensorShape);
-
-  auto tanh = builder.create<TanhOp>(builder.getUnknownLoc(), outputType,
-                                     ::mlir::ValueRange{input});
-
-  // test TanhOp interface
-  auto constraintsExp = getOpConstraints(tanh.getOperation());
-  if (constraintsExp) {
-    auto l1 = constraintsExp.get();
-    const auto [cbSize, peakSize, outputSize, outputLayout] = l1;
-    EXPECT_EQ(cbSize, 8192);
-    EXPECT_EQ(peakSize, 2048);
-    EXPECT_EQ(outputSize, 2048);
-  } else {
-    FAIL() << "Missing L1 constraints; Error="
-           << llvm::toString(constraintsExp.takeError()) << std::endl;
-  }
-
-  auto runtimeExp = getOpRuntime(tanh.getOperation());
   if (runtimeExp) {
     EXPECT_TRUE(runtimeExp.get() > 0);
   } else {

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -209,6 +209,14 @@ const auto createCos = [](OpBuilder &b, Location loc, Type type,
                           ValueRange ops) {
   return b.create<CosOp>(loc, type, ops).getOperation();
 };
+//const auto createExp = [](OpBuilder &b, Location loc, Type type,
+//                          ValueRange ops) {
+//  return b.create<ExpOp>(loc, type, ops).getOperation();
+//};
+const auto createLog = [](OpBuilder &b, Location loc, Type type,
+                          ValueRange ops) {
+  return b.create<LogOp>(loc, type, ops).getOperation();
+};
 const auto createReciprocal = [](OpBuilder &b, Location loc, Type type,
                                  ValueRange ops) {
   return b.create<ReciprocalOp>(loc, type, ops).getOperation();
@@ -219,6 +227,8 @@ const std::vector<UnaryOpTestParams> unaryOpTestParams = {
     {"Relu", createRelu, expected},
     {"Sin", createSin, expected},
     {"Cos", createCos, expected},
+    //{"Exp", createExp, expected},
+    {"Log", createLog, expected},
     {"Reciprocal", createReciprocal, expected}};
 
 // Instantiate the test suite
@@ -252,6 +262,37 @@ TEST_F(OpModelBase, SqrtOpInterface) {
   }
 
   auto runtimeExp = getOpRuntime(sqrt.getOperation());
+  if (runtimeExp) {
+    EXPECT_TRUE(runtimeExp.get() > 0);
+  } else {
+    FAIL() << llvm::toString(runtimeExp.takeError());
+  }
+}
+
+TEST_F(OpModelBase, ExpOpInterface) {
+  // create ExpOp
+  llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
+
+  auto input = createEmptyTensor(tensorShape);
+  auto outputType = createRankedTensorType(tensorShape);
+
+  auto exp = builder.create<ExpOp>(builder.getUnknownLoc(), outputType,
+                                           ::mlir::ValueRange{input});
+
+  // test ExpOp interface
+  auto constraintsExp = getOpConstraints(exp.getOperation());
+  if (constraintsExp) {
+    auto l1 = constraintsExp.get();
+    const auto [cbSize, peakSize, outputSize, outputLayout] = l1;
+    EXPECT_EQ(cbSize, 8192);
+    EXPECT_EQ(peakSize, 2048);
+    EXPECT_EQ(outputSize, 2048);
+  } else {
+    FAIL() << "Missing L1 constraints; Error="
+           << llvm::toString(constraintsExp.takeError()) << std::endl;
+  }
+
+  auto runtimeExp = getOpRuntime(exp.getOperation());
   if (runtimeExp) {
     EXPECT_TRUE(runtimeExp.get() > 0);
   } else {


### PR DESCRIPTION
### Ticket
#4067 

### Problem description
Adding constraints for `ExpOp`, `LogOp`, `TanhOp`.

### What's changed
Added support for `getOpConstraints` and `getOpRuntime` for `ExpOp`, `LogOp`, `TanhOp`.

### Checklist
- [x] New/Existing tests provide coverage for changes
