### PR TITLE
Run workarounds pass for full op when optimizer enabled

### DIFF
--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -195,20 +195,12 @@ TTNNOperandsWorkaroundsFactory::createZerosOpOperandsWorkarounds(
 }
 
 // Factory method to create a set of workarounds for full op output operand.
-// ttnn::FullOp does not support 1D tilized tensors
-// If the output of full is a 1D tensor and is tiled
-// we need to convert it to row major layout then tilize separately
 // ttnn::full does not support output dtype int32. If the output data type of
 // full is int32, we override to float32 and typecast separately.
 TTNNOperandsWorkarounds
 TTNNOperandsWorkaroundsFactory::createFullOpOperandsWorkarounds(
     RankedTensorType outputType) {
   wa::TTNNOperandWorkarounds fullOpOutputWorkarounds;
-  ttnn::TTNNLayoutAttr layoutAttr =
-      mlir::cast<ttnn::TTNNLayoutAttr>(outputType.getEncoding());
-  if (outputType.getRank() == 1 && layoutAttr.isTiled()) {
-    fullOpOutputWorkarounds.tensorLayoutWorkaround = Layout::RowMajor;
-  }
   mlir::tt::ttcore::DataType dataType =
       mlir::tt::ttcore::elementTypeToDataType(outputType.getElementType());
   if (dataType == mlir::tt::ttcore::DataType::Int32) {

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -802,6 +802,6 @@ private:
 
 const std::set<mlir::StringRef>
     TTNNWorkarounds::TTNNWorkarounds::enabledOpsForWorkaroundWithOptimizer = {
-        ttnn::WhereOp::getOperationName()};
+        ttnn::WhereOp::getOperationName(), ttnn::FullOp::getOperationName()};
 
 } // namespace mlir::tt::ttnn

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -1156,20 +1156,8 @@ static AttrType getAttrFromConstantChain(mlir::Value tensorVal,
           "Expected ttnn.typecast as defining op for per-tensor zp.");
     }
   }
-  ttnn::ToDeviceOp toDeviceOp =
-      mlir::dyn_cast<ttnn::ToDeviceOp>(firstInput.getDefiningOp());
-  assert(toDeviceOp &&
-         "Expected ttnn.to_device as defining op for per-tensor scale/zp.");
-  ttnn::ToLayoutOp toLayoutOp =
-      mlir::dyn_cast<ttnn::ToLayoutOp>(toDeviceOp.getInput().getDefiningOp());
-  assert(toLayoutOp &&
-         "Expected ttnn.to_layout as defining op for per-tensor scale/zp.");
-  ttnn::FromDeviceOp fromDeviceOp =
-      mlir::dyn_cast<ttnn::FromDeviceOp>(toLayoutOp.getInput().getDefiningOp());
-  assert(fromDeviceOp &&
-         "Expected ttnn.from_device as defining op for per-tensor scale/zp.");
   ttnn::FullOp fullOp =
-      mlir::dyn_cast<ttnn::FullOp>(fromDeviceOp.getInput().getDefiningOp());
+      mlir::dyn_cast<ttnn::FullOp>(firstInput.getDefiningOp());
   assert(fullOp &&
          "Expected ttnn.full as defining op for per-tensor scale/zp.");
   if constexpr (std::is_same_v<AttrType, float>) {

--- a/test/ttmlir/Dialect/TTNN/simple_full.mlir
+++ b/test/ttmlir/Dialect/TTNN/simple_full.mlir
@@ -16,4 +16,12 @@ module {
     %0 = "ttir.full"() <{shape = array<i32: 64, 128>, fill_value = 3 : i32}> : () -> tensor<64x128xi32>
     return %0 : tensor<64x128xi32>
   }
+
+  func.func @full_int_scalar() -> tensor<1xi32> {
+    // CHECK: "ttnn.full"
+    // CHECK-SAME: fill_value = 3 : i32
+    // CHECK-SAME: shape = #ttnn.shape<1>
+    %0 = "ttir.full"() <{shape = array<i32: 1>, fill_value = 3 : i32}> : () -> tensor<1xi32>
+    return %0 : tensor<1xi32>
+  }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/simple_full.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/simple_full.mlir
@@ -18,4 +18,15 @@ module {
     %0 = "ttir.full"() <{shape = array<i32: 64, 128>, fill_value = 3 : i32}> : () -> tensor<64x128xi32>
     return %0 : tensor<64x128xi32>
   }
+
+  func.func @full_int_scalar() -> tensor<1xi32> {
+    // CHECK: "ttnn.full"
+    // CHECK-SAME: fill_value = 3 : i32
+    // CHECK-SAME: shape = #ttnn.shape<1>
+    %0 = "ttir.full"() <{shape = array<i32: 1>, fill_value = 3 : i32}> : () -> tensor<1xi32>
+    %1 = "ttir.full"() <{shape = array<i32: 1>, fill_value = 1 : i32}> : () -> tensor<1xi32>
+    %2 = ttir.empty() : tensor<1xi32>
+    %3 = "ttir.add"(%0, %1, %2) : (tensor<1xi32>, tensor<1xi32>, tensor<1xi32>) -> tensor<1xi32>
+    return %3 : tensor<1xi32>
+  }
 }


### PR DESCRIPTION
### Ticket
Related to #3912 

### Problem description
I was hitting the same data type mismatch issue as #3912 when bringing up a resnet demo on tt-torch with optimizer enabled. Turns out it was because the data type workaround for full op is not applied.

### What's changed
Apply workarounds pass for full op when optimizer is enabled.
FYI @ddilbazTT @sgholamiTT 

### Checklist
- [X] New/Existing tests provide coverage for changes
