### PR TITLE
Skip creation ops for trace capture, update conv verify logic, don't allocate empty slots for constants/params

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -165,44 +165,39 @@ def TTNNTraceHoistTransform : Pass<"ttnn-trace-hoist-transform", "::mlir::Module
 
     Example:
     ```mlir
-    %0 = ttir.empty() : tensor<32x32xbf16>
-    %1 = "ttir.add"(%arg0, %arg1, %0) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
-    return %1 : tensor<32x32xbf16>
+    func.func @single_add(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>}) -> tensor<32x32xbf16> {
+      %0 = ttir.empty() : tensor<32x32xbf16>
+      %1 = "ttir.add"(%arg0, %arg1, %0) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+      return %1 : tensor<32x32xbf16>
+    }
     ```
 
     the pass will rewrite the IR, hoist the operations and generate the following functions:
 
     ```mlir
     // Trace function. Contains the ops that were hoisted to trace.
-    func.func @trace_0_single_add(%arg0: tensor<32x32xbf16, #ttnn_layout>, %arg1: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout> attributes {ttnn.trace} {
+    func.func @trace_0_single_add(%arg0: tensor<32x32xbf16, #ttnn_layout> {ttcore.argument_type = #ttcore.argument_type<input>}, %arg1: tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout> attributes {ttnn.trace} {
       %0 = "ttnn.add"(%arg0, %arg1) <{output_dtype = #ttcore.supportedDataTypes<bf16>}> : (tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout>
       return %0 : tensor<32x32xbf16, #ttnn_layout>
     }
 
-    // Capture trace function. Copies inputs into pre-allocated empty tensors on device
-    // then, runs the trace function once to gather the outputs and warm up the device
-    // finally, runs the trace function again to capture the trace.
-    // returns the trace id, function outputs, and the trace input output tensors.
-    func.func @run_and_capture_trace_0_single_add(%arg0: tensor<32x32xbf16, #ttnn_layout>, %arg1: tensor<32x32xbf16, #ttnn_layout>) -> (tensor<ui32, #ttnn_layout1>, tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout>) attributes {ttnn.trace} {
+    // Capture trace function. Copies inputs into pre-allocated empty tensors on device.
+    // Notice that constants/params will not be copied into pre-allocated tensors - they
+    // will be used directly instead.
+    // Then, runs the trace function once to gather the outputs and warm up the device.
+    // Finally, runs the trace function again to capture the trace.
+    // Returns the trace id, function outputs, and the trace input output tensors.
+    func.func @run_and_capture_trace_0_single_add(%arg0: tensor<32x32xbf16, #ttnn_layout> {ttcore.argument_type = #ttcore.argument_type<input>}, %arg1: tensor<32x32xbf16, #ttnn_layout> {ttcore.argument_type = #ttcore.argument_type<parameter>}) -> (tensor<ui32, #ttnn_layout1>, tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout>) attributes {ttnn.trace} {
       %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
       %1 = "ttnn.empty"(%0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #ttnn_layout>
-      %2 = "ttnn.empty"(%0) <{dtype = #ttcore.supportedDataTypes<bf16>, layout = #ttnn.layout<tile>, memory_config = #ttnn.memory_config<#dram, <interleaved>>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #ttnn_layout>
-      %3 = "ttnn.from_device"(%arg0) : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout2>
-      "ttnn.write_tensor"(%3, %1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #ttnn_layout2>, tensor<32x32xbf16, #ttnn_layout>) -> ()
-      %4 = "ttnn.from_device"(%arg1) : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout2>
-      "ttnn.write_tensor"(%4, %2) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #ttnn_layout2>, tensor<32x32xbf16, #ttnn_layout>) -> ()
-      %5 = call @trace_0_single_add(%1, %2) : (tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout>
-      %6 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn_layout1>
-      %7 = call @trace_0_single_add(%1, %2) : (tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout>
-      "ttnn.end_trace_capture"(%0, %6) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn_layout1>) -> ()
-      return %6, %5, %1, %2, %7 : tensor<ui32, #ttnn_layout1>, tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout>
-    }
-
-    // Execute trace function. Memory effects will occur where the previously cached trace input output tensors are used/updated.
-    func.func @execute_trace_0_single_add(%arg0: tensor<ui32, #ttnn_layout1>) attributes {ttnn.trace} {
-      %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-      "ttnn.execute_trace"(%0, %arg0) <{blocking = false, cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn_layout1>) -> ()
-      return
+      %2 = "ttnn.from_device"(%arg0) : (tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout2>
+      "ttnn.write_tensor"(%2, %1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #ttnn_layout2>, tensor<32x32xbf16, #ttnn_layout>) -> ()
+      "ttnn.deallocate"(%2) <{force = false}> : (tensor<32x32xbf16, #ttnn_layout2>) -> ()
+      %3 = call @trace_0_single_add(%1, %arg1) : (tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout>
+      %4 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn_layout1>
+      %5 = call @trace_0_single_add(%1, %arg1) : (tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout>) -> tensor<32x32xbf16, #ttnn_layout>
+      "ttnn.end_trace_capture"(%0, %4) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn_layout1>) -> ()
+      return %4, %3, %1, %arg1, %5 : tensor<ui32, #ttnn_layout1>, tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout>
     }
     ```
 

--- a/include/ttmlir/Dialect/TTNN/Types/Types.h
+++ b/include/ttmlir/Dialect/TTNN/Types/Types.h
@@ -13,6 +13,9 @@ inline constexpr uint32_t TILE_HEIGHT = 32;
 inline constexpr uint32_t TILE_WIDTH = 32;
 inline constexpr std::array<uint32_t, 2> VALID_CQ_IDS = {0, 1};
 inline constexpr llvm::StringLiteral g_TTNNTraceAttrName = "ttnn.trace";
+inline constexpr llvm::StringLiteral g_TTNNCaptureTracePrefix =
+    "run_and_capture_";
+inline constexpr llvm::StringLiteral g_TTNNExecuteTracePrefix = "execute_";
 } // namespace mlir::tt::ttnn
 
 #endif

--- a/runtime/include/tt/runtime/detail/ttnn/types/types.h
+++ b/runtime/include/tt/runtime/detail/ttnn/types/types.h
@@ -85,10 +85,7 @@ private:
   std::atomic<bool> retain;
   std::atomic<uint64_t> version;
 
-  static std::atomic<uint64_t> getLatestVersion() {
-    static std::atomic<uint64_t> latestVersion{0};
-    return latestVersion++;
-  }
+  static uint64_t getLatestVersion();
 };
 
 struct LayoutDesc {

--- a/runtime/lib/ttnn/types/types.cpp
+++ b/runtime/lib/ttnn/types/types.cpp
@@ -5,10 +5,17 @@
 #include "tt/runtime/detail/ttnn/types/types.h"
 #include "tt/runtime/detail/ttnn/debug_apis.h"
 #include "tt/runtime/detail/ttnn/utils.h"
+#include <atomic>
 
 namespace tt::runtime::ttnn {
 
 using tt::runtime::DeviceRuntime;
+
+// TTNNTensorWrapper APIs
+uint64_t TTNNTensorWrapper::getLatestVersion() {
+  static std::atomic<uint64_t> latestVersion{0};
+  return latestVersion.fetch_add(1, std::memory_order_relaxed);
+}
 
 //
 // LayoutDesc APIs

--- a/test/ttmlir/Dialect/TTNN/trace/creation_no_consteval.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/creation_no_consteval.mlir
@@ -5,7 +5,7 @@ module {
   // CHECK: "ttnn.add"
 
   // CHECK-LABEL: func.func @run_and_capture_trace_0_creation_ops
-  // CHECK-NOT: "ttnn.write_tensor"
+  // CHECK: "ttnn.write_tensor"
   // CHECK: "ttnn.begin_trace_capture"
   // CHECK: "ttnn.end_trace_capture"
 
@@ -15,11 +15,10 @@ module {
   // CHECK-LABEL: func.func @creation_ops(
   func.func @creation_ops() -> tensor<4x4xbf16> {
     // CHECK: %[[GET_DEVICE:.+]] = "ttnn.get_device"()
-    // CHECK-NEXT: %[[TRACE_RESULT:.+]] = "ttnn.capture_or_execute_trace"(%[[GET_DEVICE]]) <{capture_callee = @run_and_capture_trace_0_creation_ops, execute_callee = @execute_trace_0_creation_ops}>
-    // CHECK-NOT: "ttnn.zeros"
-    // CHECK-NOT: "ttnn.ones"
-    // CHECK-NOT: "ttnn.arange"
+    // CHECK-NEXT: "ttnn.zeros"
+    // CHECK-NEXT: "ttnn.ones"
     // CHECK-NOT: "ttnn.add"
+    // CHECK-NEXT: %[[TRACE_RESULT:.+]] = "ttnn.capture_or_execute_trace"(%[[GET_DEVICE]], %1, %2) <{capture_callee = @run_and_capture_trace_0_creation_ops, execute_callee = @execute_trace_0_creation_ops}>
     // CHECK: return %[[TRACE_RESULT]]
     %0 = "ttir.zeros"() <{shape = array<i32: 4, 4>}> : () -> tensor<4x4xbf16>
     %1 = "ttir.ones"() <{shape = array<i32: 4, 4>}> : () -> tensor<4x4xbf16>
@@ -27,10 +26,6 @@ module {
     %2 = ttir.empty() : tensor<4x4xbf16>
     %3 = "ttir.add"(%0, %1, %2) : (tensor<4x4xbf16>, tensor<4x4xbf16>, tensor<4x4xbf16>) -> tensor<4x4xbf16>
 
-    %4 = ttir.empty() : tensor<4x4xbf16>
-    %5 = "ttir.arange"() {start = 0 : si64, end = 4 : si64, step = 1 : si64, arange_dimension = 0 : i64} : () -> tensor<4x4xbf16>
-    %6 = "ttir.add"(%3, %5, %4) : (tensor<4x4xbf16>, tensor<4x4xbf16>, tensor<4x4xbf16>) -> tensor<4x4xbf16>
-
-    return %6 : tensor<4x4xbf16>
+    return %3 : tensor<4x4xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/trace/single_add_no_consteval.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/single_add_no_consteval.mlir
@@ -5,7 +5,9 @@ module {
   // CHECK: "ttnn.add"
 
   // CHECK-LABEL: func.func @run_and_capture_trace_0_single_add
+  // CHECK: "ttnn.from_device"(%arg0)
   // CHECK: "ttnn.write_tensor"
+  // CHECK-NOT: "ttnn.from_device"(%arg1)
   // CHECK: "ttnn.begin_trace_capture"
   // CHECK: "ttnn.end_trace_capture"
 
@@ -13,7 +15,7 @@ module {
   // CHECK: "ttnn.execute_trace"
 
   // CHECK-LABEL: func.func @single_add(
-  func.func @single_add(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>) -> tensor<32x32xbf16> {
+  func.func @single_add(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>}) -> tensor<32x32xbf16> {
     // CHECK: %[[GET_DEVICE:.+]] = "ttnn.get_device"()
     // CHECK-NEXT: %[[TRACE_RESULT:.+]] = "ttnn.capture_or_execute_trace"(%[[GET_DEVICE]], %arg0, %arg1) <{capture_callee = @run_and_capture_trace_0_single_add, execute_callee = @execute_trace_0_single_add}>
     // CHECK-NOT: "ttnn.add"


### PR DESCRIPTION
### Problem description
We should be skipping creation ops for trace since they're not supported. Conv verification was failing when conv ops are hoisted into trace functions if their weights are being prepared with `prepare_conv2d_weights` op. We were allocating device buffers for constants/params (Thanks @svuckovicTT  for catching this).

### What's changed
* Creation ops are now skipped in the trace hoist transform pass.
* When within a trace function, conv verifier will follow the function argument to the original location where the input is generated, and run the verification logic on the actual input instead of the function parameter.
* Only allocate separate buffers on device for inputs, for constants and parameters, use the original tensor directly.
### Checklist
- [X] New/Existing tests provide coverage for changes
