### PR TITLE
Fixing bugs with lowering TTIR to LINALG and adding tests for them.

### DIFF
--- a/test/ttmlir/Conversion/TTIRToLinalg/add.mlir
+++ b/test/ttmlir/Conversion/TTIRToLinalg/add.mlir
@@ -1,0 +1,13 @@
+// RUN: ttmlir-opt --convert-ttir-to-linalg %s | FileCheck %s
+
+module attributes {} {
+  func.func @test_add(%arg0: tensor<1x784xf32>, %arg1: tensor<784xf32>) -> tensor<1x784xf32> {
+    // CHECK: = tensor.empty() : [[SIZE:tensor<1x784xf32>]]
+    %0 = ttir.empty() : tensor<1x784xf32>
+    // CHECK: [[RESHAPED: %[0-9]+]] = tosa.reshape %arg1
+    // CHECK: [[RESULT: %[0-9]+]] = tosa.add %arg0,[[RESHAPED]]
+    %1 = "ttir.add"(%arg0, %arg1, %0) : (tensor<1x784xf32>, tensor<784xf32>, tensor<1x784xf32>) -> tensor<1x784xf32>
+    // CHECK: return[[RESULT]] : [[SIZE]]
+    return %1 : tensor<1x784xf32>
+  }
+}

--- a/test/ttmlir/Conversion/TTIRToLinalg/matmul.mlir
+++ b/test/ttmlir/Conversion/TTIRToLinalg/matmul.mlir
@@ -1,0 +1,15 @@
+// RUN: ttmlir-opt --convert-ttir-to-linalg %s | FileCheck %s
+
+module attributes {} {
+  func.func @test_add(%arg0: tensor<1x784xf32>, %arg1: tensor<784x512xf32>) -> tensor<1x512xf32> {
+    // CHECK: = tensor.empty() : [[SIZE:tensor<1x512xf32>]]
+    %0 = ttir.empty() : tensor<1x512xf32>
+    // CHECK: = tosa.reshape %arg0
+    // CHECK: = tosa.reshape %arg1
+    // CHECK: = tosa.matmul
+    %1 = "ttir.matmul"(%arg0, %arg1, %0) : (tensor<1x784xf32>, tensor<784x512xf32>, tensor<1x512xf32>) -> tensor<1x512xf32>
+    // CHECK: [[RESULT: %[0-9]+]] = tosa.reshape
+    // CHECK: return[[RESULT]] : [[SIZE]]
+    return %1 : tensor<1x512xf32>
+  }
+}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/4168

### Problem description
TTIR.matmul had problems when lowering to linalg due to reshaping.
TTIR.add had problems when adding two tensors with different ranks as no broadcast is used.

### What's changed
For ```ttir.matmul```: Different methods for reshaping lhs and rhs are used. Method for lhs does not return errors, while the other one does. Changed reshaping of rhs to be equivalent to the reshaping of lhs.
For ```ttir.add```: Added broadcasting for elementwise binary operations if ranks of input are not the same.

### Checklist
- [x] New/Existing tests provide coverage for changes
