### PR TITLE
Initial implementation of multi-device aware D2M runtime 

### DIFF
--- a/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
@@ -24,8 +24,8 @@
 
 namespace tt::runtime::ttmetal {
 
-using DeviceBuffer = std::shared_ptr<::tt::tt_metal::Buffer>;
-using MetalTensor = std::variant<TensorDesc, DeviceBuffer>;
+using MeshBuffer = std::shared_ptr<::tt::tt_metal::distributed::MeshBuffer>;
+using MetalTensor = std::variant<TensorDesc, MeshBuffer>;
 
 Tensor createBorrowedHostTensor(std::shared_ptr<void> data,
                                 const TensorDesc &desc);

--- a/runtime/include/tt/runtime/workarounds.h
+++ b/runtime/include/tt/runtime/workarounds.h
@@ -13,7 +13,8 @@ struct Env {
   static const Env &get(bool swapBinaryOperands = true,
                         bool readUpdateIndexFromDeviceForKVCache = true,
                         bool traceImplicitFromDevice = true,
-                        bool blackholeWorkarounds = true);
+                        bool blackholeWorkarounds = true,
+                        bool d2mReturnEvent = false);
 
   // TODO(bug #1124): We're currently swapping the operands for binary ops
   // in runtime if the lhs operand is smaller (and requires broadcast onto the
@@ -39,15 +40,22 @@ struct Env {
   // host for now.
   bool blackholeWorkarounds;
 
+  // TODO(bug #4181): d2mReturnEvent is to create MeshEvent at
+  // EnqueueReturnCommand. This is currently set to false due to the issue in
+  // tt metal MeshEvent and should be removed once the issue is fixed.
+  bool d2mReturnEvent;
+
 private:
   constexpr Env(bool swapBinaryOperands,
                 bool readUpdateIndexFromDeviceForKVCache,
-                bool traceImplicitFromDevice, bool blackholeWorkarounds)
+                bool traceImplicitFromDevice, bool blackholeWorkarounds,
+                bool d2mReturnEvent)
       : swapBinaryOperands(swapBinaryOperands),
         readUpdateIndexFromDeviceForKVCache(
             readUpdateIndexFromDeviceForKVCache),
         traceImplicitFromDevice(traceImplicitFromDevice),
-        blackholeWorkarounds(blackholeWorkarounds) {}
+        blackholeWorkarounds(blackholeWorkarounds),
+        d2mReturnEvent(d2mReturnEvent) {}
 };
 
 inline std::ostream &operator<<(std::ostream &os, const Env &env) {
@@ -61,6 +69,8 @@ inline std::ostream &operator<<(std::ostream &os, const Env &env) {
      << "traceImplicitFromDevice: " << env.traceImplicitFromDevice << "\n";
   os << "\t"
      << "blackholeWorkarounds: " << env.blackholeWorkarounds << "\n";
+  os << "\t"
+     << "d2mReturnEvent: " << env.d2mReturnEvent << "\n";
   os << "}";
   return os;
 }

--- a/runtime/lib/common/workarounds.cpp
+++ b/runtime/lib/common/workarounds.cpp
@@ -7,10 +7,11 @@
 namespace tt::runtime::workaround {
 const Env &Env::get(bool swapBinaryOperands,
                     bool readUpdateIndexFromDeviceForKVCache,
-                    bool traceImplicitFromDevice, bool blackholeWorkarounds) {
-  static const Env config(swapBinaryOperands,
-                          readUpdateIndexFromDeviceForKVCache,
-                          traceImplicitFromDevice, blackholeWorkarounds);
+                    bool traceImplicitFromDevice, bool blackholeWorkarounds,
+                    bool d2mReturnEvent) {
+  static const Env config(
+      swapBinaryOperands, readUpdateIndexFromDeviceForKVCache,
+      traceImplicitFromDevice, blackholeWorkarounds, d2mReturnEvent);
   return config;
 }
 } // namespace tt::runtime::workaround

--- a/runtime/lib/ttmetal/executor.h
+++ b/runtime/lib/ttmetal/executor.h
@@ -6,6 +6,7 @@
 #define RUNTIME_LIB_TTMETAL_EXECUTOR_H
 
 #define FMT_HEADER_ONLY
+#include "tt-metalium/distributed.hpp"
 #include "tt-metalium/mesh_device.hpp"
 
 #include "tt/runtime/detail/common/dylib.h"
@@ -15,10 +16,10 @@
 namespace tt::runtime::ttmetal {
 
 std::vector<Tensor>
-executeDeviceProgram(::tt::tt_metal::IDevice *device,
-                     const ::tt::target::metal::DeviceProgram *program,
-                     const std::vector<Tensor> &inputs,
-                     common::DylibManager &&dylibs);
+executeMeshDeviceProgram(::tt::tt_metal::distributed::MeshDevice *meshDevice,
+                         const ::tt::target::metal::DeviceProgram *program,
+                         const std::vector<Tensor> &inputs,
+                         common::DylibManager &&dylibs);
 
 } // namespace tt::runtime::ttmetal
 

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -68,10 +68,10 @@ Tensor toLayout(Tensor tensor, Device, Layout layout, std::optional<bool>) {
   return std::visit(
       utils::overloaded{
           [&](const TensorDesc &desc) { return alignUpTensor(tensor, desc); },
-          [&](const DeviceBuffer &buffer) {
+          [&](const MeshBuffer &buffer) {
             // TODO(#3126): Implement device copy toLayout for
             // metal runtime
-            LOG_FATAL("getTensorDesc from DeviceBuffer not supported.");
+            LOG_FATAL("getTensorDesc from MeshBuffer not supported.");
             return tensor;
           },
       },
@@ -112,8 +112,8 @@ target::DataType getTensorDataType(Tensor tensor) {
   return std::visit(
       utils::overloaded{
           [&](const TensorDesc &desc) { return desc.dataType; },
-          [&](const DeviceBuffer &buffer) {
-            LOG_FATAL("Datatype mapping from buffer not supported yet.");
+          [&](const MeshBuffer &buffer) {
+            LOG_FATAL("Datatype mapping from mesh buffer not supported yet.");
             return target::DataType::Float32;
           },
       },
@@ -386,8 +386,8 @@ std::vector<Tensor> toHost(Tensor tensor, bool untilize, bool blocking) {
   ::tt::runtime::ttmetal::wait(tensor);
   std::visit(utils::overloaded{
                  [&](const TensorDesc &) { /* no-op */ },
-                 [&](const DeviceBuffer &) {
-                   LOG_FATAL("toHost not yet implemented for device buffer");
+                 [&](const MeshBuffer &) {
+                   LOG_FATAL("toHost not yet implemented for mesh buffer");
                  },
              },
              tensor.as<MetalTensor>(DeviceRuntime::TTMetal));
@@ -427,48 +427,14 @@ void memcpy(Tensor dst, Tensor src) {
 }
 
 void deallocateTensor(Tensor &tensor, bool) {
-  std::visit(
-      utils::overloaded{
-          [&](const TensorDesc &) { /* no-op */ },
-          [&](const DeviceBuffer &) {
-            LOG_FATAL("deallocateTensor not yet implemented for device buffer");
-          },
-      },
-      tensor.as<MetalTensor>(DeviceRuntime::TTMetal));
-}
-
-std::vector<Tensor> submit(Device deviceHandle, Binary executableHandle,
-                           std::uint32_t programIndex,
-                           std::vector<Tensor> &inputs) {
-  const target::metal::TTMetalBinary &fbb = *getBinary(executableHandle);
-  const target::metal::Program *program = fbb.programs()->Get(programIndex);
-  tt_metal::distributed::MeshDevice &meshDevice =
-      deviceHandle.as<tt_metal::distributed::MeshDevice>(
-          DeviceRuntime::TTMetal);
-  std::vector<tt_metal::IDevice *> allDevices = meshDevice.get_devices();
-  LOG_ASSERT(allDevices.size() > 0, "Unexpected empty device mesh");
-  std::vector<tt_metal::IDevice *> deviceList = {allDevices[0]};
-  LOG_ASSERT(deviceList.size() == 1, "Only one device is supported for now");
-  LOG_ASSERT(program->device_programs()->size() == deviceList.size(),
-             "Device programs size mismatch");
-
-  std::vector<Tensor> outputs;
-  for (std::size_t i = 0; i < program->device_programs()->size(); ++i) {
-    tt_metal::IDevice *device = deviceList[i];
-
-    ZoneScoped;
-    std::string zoneName = "submit_" + std::string(program->name()->c_str()) +
-                           "_device_" + std::to_string(device->id());
-    ZoneName(zoneName.c_str(), zoneName.size());
-
-    LOG_ASSERT(outputs.empty(), "Multi-device outputs not supported");
-    outputs = executeDeviceProgram(device, program->device_programs()->Get(i),
-                                   inputs, common::DylibManager(fbb.dylibs()));
-    LOG_ASSERT(outputs.size() == program->outputs()->size(),
-               "Outputs size mismatch");
-  }
-
-  return outputs;
+  std::visit(utils::overloaded{
+                 [&](const TensorDesc &) { /* no-op */ },
+                 [&](const MeshBuffer &) {
+                   LOG_FATAL(
+                       "deallocateTensor not yet implemented for mesh buffer");
+                 },
+             },
+             tensor.as<MetalTensor>(DeviceRuntime::TTMetal));
 }
 
 std::string getOpDebugString(OpContext opContextHandle) {
@@ -531,8 +497,8 @@ std::vector<std::byte> getTensorDataBuffer(Tensor tensor) {
             assert(data);
             return std::vector<std::byte>(data, data + desc.sizeBytes());
           },
-          [&](const DeviceBuffer &buffer) {
-            LOG_FATAL("getTensorDataBuffer from DeviceBuffer not supported.");
+          [&](const MeshBuffer &buffer) {
+            LOG_FATAL("getTensorDataBuffer from MeshBuffer not supported.");
             return std::vector<std::byte>{};
           },
       },
@@ -558,13 +524,43 @@ std::uint32_t getTensorVolume(Tensor tensor) {
 TensorDesc getTensorDesc(Tensor tensor) {
   return std::visit(utils::overloaded{
                         [&](const TensorDesc &desc) { return desc; },
-                        [&](const DeviceBuffer &buffer) {
+                        [&](const MeshBuffer &buffer) {
                           LOG_FATAL(
-                              "getTensorDesc from DeviceBuffer not supported.");
+                              "getTensorDesc from MeshBuffer not supported.");
                           return TensorDesc{};
                         },
                     },
                     tensor.as<MetalTensor>(DeviceRuntime::TTMetal));
+}
+
+std::vector<Tensor> submit(Device deviceHandle, Binary executableHandle,
+                           std::uint32_t programIndex,
+                           std::vector<Tensor> &inputs) {
+  const target::metal::TTMetalBinary &fbb = *getBinary(executableHandle);
+  const target::metal::Program *program = fbb.programs()->Get(programIndex);
+  tt_metal::distributed::MeshDevice &meshDevice =
+      deviceHandle.as<tt_metal::distributed::MeshDevice>(
+          DeviceRuntime::TTMetal);
+  std::vector<tt_metal::IDevice *> allDevices = meshDevice.get_devices();
+  LOG_ASSERT(meshDevice.num_rows() == 1 && meshDevice.num_cols() == 1,
+             "Currently we only support 1x1 mesh.");
+
+  std::vector<Tensor> outputs;
+  for (std::size_t i = 0; i < program->device_programs()->size(); ++i) {
+    ZoneScoped;
+    std::string zoneName = "submit_" + std::string(program->name()->c_str()) +
+                           "_device_" + std::to_string(meshDevice.id());
+    ZoneName(zoneName.c_str(), zoneName.size());
+
+    outputs = executeMeshDeviceProgram(
+        &meshDevice, program->device_programs()->Get(i), inputs,
+        common::DylibManager(fbb.dylibs()));
+
+    LOG_ASSERT(outputs.size() == program->outputs()->size(),
+               "Outputs size mismatch");
+  }
+
+  return outputs;
 }
 
 } // namespace tt::runtime::ttmetal

--- a/runtime/tools/ttrt/ttrt/common/run.py
+++ b/runtime/tools/ttrt/ttrt/common/run.py
@@ -191,6 +191,13 @@ class Run:
             help="disable blackhole workarounds",
         )
         Run.register_arg(
+            name="--enable-d2m-return-event",
+            type=bool,
+            default=False,
+            choices=[True, False],
+            help="enable d2m return event",
+        )
+        Run.register_arg(
             name="--result-file",
             type=str,
             default="run_results.json",
@@ -545,6 +552,7 @@ class Run:
                 not self["--disable-read-update-index-for-kv-cache"],
                 not self["--disable-trace-implicit-from-device"],
                 not self["--disable-blackhole-workarounds"],
+                self["--enable-d2m-return-event"],
             )
             self.logging.debug(f"setting tt runtime workaround env={workaround_env}")
             tracy_program_metadata = {


### PR DESCRIPTION

### Ticket
https://github.com/tenstorrent/tt-mlir/issues/4179

### Problem description
Current D2M runtime uses APIs for single device computation. As a first step of enabling multi-device in D2M, we should use APIs for multi-devices (tt-mesh and tt-distributed).

### What's changed
Update D2M runtime using multi-device aware APIs such as meshBuffer and meshEvent. There exists some issue in mesh_event synchronization, so the return time event insertion is not enabled by default. It will be updated later once the issue (https://github.com/tenstorrent/tt-mlir/issues/4181) is resolved.

### Checklist
- [X] Existing tests provide coverage for changes
