### PR TITLE
Schedule tests and start analysis implementation

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/L1InterleavedAnalysis.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1InterleavedAnalysis.h
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_ANALYSIS_L1INTERLEAVEDANALYSIS_H
+#define TTMLIR_DIALECT_TTNN_ANALYSIS_L1INTERLEAVEDANALYSIS_H
+
+#include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
+#include "ttmlir/Dialect/TTNN/Analysis/TTNNAnalysis.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "llvm/ADT/DenseMap.h"
+
+#include <vector>
+
+namespace mlir::tt::ttnn {
+
+struct L1InterleavedAnalysisInput {
+  llvm::DenseMap<Operation *, std::vector<OpConfig>> legalL1InterleavedConfigs;
+  func::FuncOp funcOp;
+  unsigned usableL1CacheSize = 0;
+
+  L1InterleavedAnalysisInput() : legalL1InterleavedConfigs(), funcOp() {}
+
+  L1InterleavedAnalysisInput(
+      const llvm::DenseMap<Operation *, std::vector<OpConfig>>
+          &legalL1InterleavedConfigs, // only tiled rn, but could have row-major
+      const func::FuncOp &funcOp, unsigned usableL1CacheSize)
+      : legalL1InterleavedConfigs(legalL1InterleavedConfigs), funcOp(funcOp),
+        usableL1CacheSize(usableL1CacheSize) {}
+
+  bool operator==(const L1InterleavedAnalysisInput &rhs) const {
+    return legalL1InterleavedConfigs == rhs.legalL1InterleavedConfigs &&
+           funcOp == rhs.funcOp && usableL1CacheSize == rhs.usableL1CacheSize;
+  }
+
+  bool operator!=(const L1InterleavedAnalysisInput &rhs) const {
+    return !(*this == rhs);
+  }
+};
+
+struct L1InterleavedAnalysisResult {
+  llvm::DenseMap<Operation *, OpConfig> upgradedConfigs;
+
+  L1InterleavedAnalysisResult() : upgradedConfigs() {}
+
+  L1InterleavedAnalysisResult(
+      const llvm::DenseMap<Operation *, OpConfig> &upgradedConfigs)
+      : upgradedConfigs(upgradedConfigs) {}
+};
+
+// Analysis that runs after spillToDRAM to try upgrading DRAM operations
+// to L1 interleaved when:
+// 1. The operation has exactly one user
+// 2. That user is the immediate next operation in the schedule
+// 3. L1 memory constraints are satisfied
+//
+class L1InterleavedAnalysis : public TTNNAnalysis<L1InterleavedAnalysisInput,
+                                                  L1InterleavedAnalysisResult> {
+
+private:
+  void analysisImplementation() override;
+  bool applyOverrides() override { return false; }
+
+  // Check if operation has L1 interleaved layout available
+  bool hasL1InterleavedLegalLayout(Operation *op) const;
+
+  // Get L1 interleaved layouts for operation (both tiled and row-major if
+  // available after LegalLayoutsAnalysis)
+  std::vector<OpConfig> getL1InterleavedLayoutConfigs(Operation *op) const;
+
+  // Check if operation currently uses DRAM layout
+  bool usesDRAMLayout(Operation *op) const;
+
+  // Check if operation has exactly one user that is immediate next in schedule
+  bool hasImmediateConsumer(Operation *op) const;
+
+  // Check if originally tiled or row-major to choose correct upgrade path
+  bool isTiledTensorLayout(Operation *op) const;
+
+  // Check if upgrading operation to L1 interleaved if safe, return updated
+  // layout
+  llvm::Expected<TTNNLayoutAttr>
+  checkUpgradeToL1Interleaved(Operation *consumerOp,
+                              const OpConfig &consumerConfig) const;
+
+public:
+  L1InterleavedAnalysis(Operation *op) : TTNNAnalysis(op) {}
+};
+
+} // namespace mlir::tt::ttnn
+
+#endif // TTMLIR_DIALECT_TTNN_ANALYSIS_L1INTERLEAVEDANALYSIS_H

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -134,6 +134,13 @@ struct TTIRToTTNNBackendPipelineOptions
       llvm::cl::desc("Enable memory layout optimization."),
       llvm::cl::init(true)};
 
+  // If this option is true, run memory layout analysis.
+  //
+  Option<bool> l1InterleavedAnalysisEnabled{
+      *this, OptionNames::l1InterleavedAnalysisEnabled,
+      llvm::cl::desc("Enable DRAM to L1 interleaved optimization."),
+      llvm::cl::init(true)};
+
   // If this option is true, insert memory reconfiguration ops.
   //
   Option<bool> memReconfigEnabled{

--- a/include/ttmlir/Dialect/TTNN/Transforms/Optimizer.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Optimizer.h
@@ -21,6 +21,8 @@ struct TTNNOptimizerOptions {
   llvm::StringMap<Conv2dConfigOverrideParams> overrideConv2dConfig =
       llvm::StringMap<Conv2dConfigOverrideParams>();
   bool memoryLayoutAnalysisEnabled = true;
+  bool l1InterleavedAnalysisEnabled = true;
+
   MemoryLayoutAnalysisPolicyType memoryLayoutAnalysisPolicy =
       MemoryLayoutAnalysisPolicyType::DFSharding;
   bool memReconfigEnabled = false;

--- a/include/ttmlir/Dialect/TTNN/Utils/OptimizerOverrides.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/OptimizerOverrides.h
@@ -82,6 +82,7 @@ private:
   // Flags for enabling/disabling the memory configurations
   bool enableMemoryReconfig = true;
   bool enableMemoryLayoutAnalysis = false;
+  bool enableL1InterleavedAnalysis = false;
 
   llvm::StringMap<InsertMemReconfigParams> insertMemReconfig;
 

--- a/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
@@ -22,6 +22,8 @@ struct OptionNames {
   static constexpr StringRef overrideConv2dConfig = "override-conv2d-config";
   static constexpr StringRef memoryLayoutAnalysisEnabled =
       "memory-layout-analysis-enabled";
+  static constexpr StringRef l1InterleavedAnalysisEnabled =
+      "l1-interleaved-analysis-enabled";
   static constexpr StringRef memReconfigEnabled = "memreconfig-enabled";
   static constexpr StringRef memoryLayoutAnalysisPolicy =
       "memory-layout-analysis-policy";

--- a/lib/Dialect/TTNN/Analysis/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Analysis/CMakeLists.txt
@@ -4,6 +4,7 @@ add_mlir_dialect_library(MLIRTTNNAnalysis
         DFShardingPolicy.cpp
         GreedyL1InterleavedPolicy.cpp
         L1ChainConfig.cpp
+        L1InterleavedAnalysis.cpp
         LegalLayoutAnalysis.cpp
         MemoryLayoutAnalysis.cpp
         OpConfigAnalysis.cpp

--- a/lib/Dialect/TTNN/Analysis/L1InterleavedAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1InterleavedAnalysis.cpp
@@ -1,0 +1,277 @@
+// SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Analysis/L1InterleavedAnalysis.h"
+
+#include "ttmlir/Dialect/TTCore/IR/Utils.h"
+#include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+#include "ttmlir/Support/Logger.h"
+
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/Support/LLVM.h"
+
+#include <algorithm>
+#include <cassert>
+#include <vector>
+
+namespace mlir::tt::ttnn {
+
+void L1InterleavedAnalysis::analysisImplementation() {
+  // Go through schedule in order using walk, trying to upgrade DRAM ops to L1
+  // interleaved
+  analysisInput.funcOp->walk([&](Operation *op) {
+    // Skip operations that have the row-major workaround later on in Optimizer
+    if (isa<ttnn::MaxPool2dOp>(op) || isa<ttnn::UpsampleOp>(op)) {
+      return;
+    }
+
+    // Skip if operation doesn't have L1 interleaved layout available
+    if (!hasL1InterleavedLegalLayout(op)) {
+      return;
+    }
+    // Skip if operation doesn't use DRAM layout
+    if (!usesDRAMLayout(op)) {
+      return;
+    }
+    // Skip if producer is not immediately consumed by consumer
+    if (!hasImmediateConsumer(op)) {
+      TTMLIR_TRACE(ttmlir::LogComponent::Optimizer,
+                   "L1InterleavedAnalysis: Skipping {} - not singular user or "
+                   "not immediately consumed",
+                   op->getName());
+      return;
+    }
+    std::vector<OpConfig> opL1InterleavedConfigs =
+        getL1InterleavedLayoutConfigs(op);
+
+    bool isCurrentlyTiled = isTiledTensorLayout(op);
+    std::stable_sort(
+        opL1InterleavedConfigs.begin(), opL1InterleavedConfigs.end(),
+        [isCurrentlyTiled](const OpConfig &a, const OpConfig &b) {
+          bool aTiled = a.outputLayout.isTiled();
+          bool bTiled = b.outputLayout.isTiled();
+          // Prioritize configs that match current tiling preference
+          return (aTiled == isCurrentlyTiled) && (bTiled != isCurrentlyTiled);
+        });
+
+    // Try both L1 interleaved configs until one works if there are multiple
+    // (rowMajor and tiled)
+    for (auto opL1InterleavedConfig : opL1InterleavedConfigs) {
+      llvm::Expected<TTNNLayoutAttr> possibleL1Layout =
+          checkUpgradeToL1Interleaved(op, opL1InterleavedConfig);
+
+      if (!possibleL1Layout) {
+        llvm::Error error = possibleL1Layout.takeError();
+        std::string errorStr = llvm::toString(std::move(error));
+        TTMLIR_TRACE(ttmlir::LogComponent::Optimizer,
+                     "L1InterleavedAnalysis: Invalid upgrade, error: {}",
+                     errorStr);
+        continue;
+      }
+      TTNNLayoutAttr l1InterleavedLayout = possibleL1Layout.get();
+      // should be redundant
+      assert(l1InterleavedLayout.hasInterleavedL1TensorMemoryLayout());
+      assert(l1InterleavedLayout == opL1InterleavedConfig.outputLayout &&
+             "Expected output layout to match the one in OpConfig");
+      analysisResult.upgradedConfigs[op] = opL1InterleavedConfig;
+      break;
+    }
+  });
+  TTMLIR_TRACE(ttmlir::LogComponent::Optimizer,
+               "L1InterleavedAnalysis: Completed - upgraded {} operations",
+               analysisResult.upgradedConfigs.size());
+}
+
+bool L1InterleavedAnalysis::hasL1InterleavedLegalLayout(Operation *op) const {
+  const auto it = analysisInput.legalL1InterleavedConfigs.find(op);
+  return it != analysisInput.legalL1InterleavedConfigs.end();
+}
+
+std::vector<OpConfig>
+L1InterleavedAnalysis::getL1InterleavedLayoutConfigs(Operation *op) const {
+  const auto it = analysisInput.legalL1InterleavedConfigs.find(op);
+  assert(it != analysisInput.legalL1InterleavedConfigs.end());
+  return it->second;
+}
+
+bool L1InterleavedAnalysis::usesDRAMLayout(Operation *op) const {
+  // Check if the operation has a result type that is a tensor
+  if (op->getNumResults() == 0) {
+    return false;
+  }
+
+  auto resultType =
+      mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
+  if (!resultType) {
+    return false;
+  }
+
+  auto encoding = resultType.getEncoding();
+  if (!encoding) {
+    return false;
+  }
+
+  if (auto ttnnLayout = mlir::dyn_cast<TTNNLayoutAttr>(encoding)) {
+    return ttnnLayout.hasDRAMBufferType();
+  }
+
+  return false;
+}
+
+bool L1InterleavedAnalysis::hasImmediateConsumer(Operation *op) const {
+  // Check if operation has exactly one user
+  if (!op->hasOneUse()) {
+    return false;
+  }
+
+  // Get the single user
+  Operation *userOp = *op->getUsers().begin();
+  Operation *consumerOp = op->getNextNode();
+
+  // User must not be scheduled at an earlier index than its operand
+  assert(consumerOp);
+
+  // Check if the user is the immediate next operation in schedule
+  return consumerOp == userOp;
+}
+
+bool L1InterleavedAnalysis::isTiledTensorLayout(Operation *op) const {
+  auto resultType =
+      mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
+
+  auto encoding = resultType.getEncoding();
+  if (!encoding) {
+    return false;
+  }
+  if (auto ttnnLayout = mlir::dyn_cast<TTNNLayoutAttr>(encoding)) {
+    return ttnnLayout.isTiled();
+  }
+  return false;
+}
+
+llvm::Expected<TTNNLayoutAttr>
+L1InterleavedAnalysis::checkUpgradeToL1Interleaved(
+    Operation *consumerOp, const OpConfig &consumerConfig) const {
+  // Figure out this const based on exec data, but will be replaced
+  // with API.
+  constexpr float tensorL1UsageCap = 0.8;
+
+  OpModel backend = mlir::dyn_cast<OpModel>(consumerOp);
+  if (!backend) {
+    // This function should not be called for ops without backend constraints.
+    return llvm::createStringError(
+        llvm::inconvertibleErrorCode(),
+        "Backend constraints are not implemented for op %s",
+        consumerOp->getName().getStringRef().data());
+  }
+
+  // Verify device attribute exists (will assert if not found).
+  mlir::tt::ttcore::lookupDevice(consumerOp);
+
+  uint32_t numOperands = consumerOp->getNumOperands();
+  // Discard DPS operand since it's not used in runtime.
+  // TODO(odjuricic,#2088): Remove once fix this on MLIR / runtime side.
+  if (llvm::isa<DestinationStyleOpInterface>(consumerOp)) {
+    numOperands = numOperands - 1;
+  }
+
+  std::vector<TTNNLayoutAttr> inputLayouts;
+  inputLayouts.reserve(numOperands);
+  uint64_t producersL1OutputUsage = 0;
+
+  for (uint32_t i = 0; i < numOperands; i++) {
+    auto operand = consumerOp->getOperand(i);
+
+    if (mlir::isa<TypedValue<mlir::tt::ttnn::DeviceType>>(operand)) {
+      // Skip device type operand.
+      continue;
+    }
+
+    if (operand.getDefiningOp()) {
+      auto it = analysisResult.upgradedConfigs.find(operand.getDefiningOp());
+      if (it != analysisResult.upgradedConfigs.end()) {
+        inputLayouts.push_back(it->second.outputLayout);
+        producersL1OutputUsage +=
+            utils::getOpOutputL1Usage(it->second.outputLayout);
+        continue;
+      }
+    }
+
+    RankedTensorType input = mlir::cast<RankedTensorType>(operand.getType());
+
+    auto layout = mlir::cast<TTNNLayoutAttr>(input.getEncoding());
+
+    assert(layout && "Input operand must have a layout");
+    producersL1OutputUsage += utils::getOpOutputL1Usage(layout);
+    inputLayouts.push_back(layout);
+  }
+
+  llvm::Expected<op_model::ttnn::OpConstraints> l1UsageExp =
+      backend.getOpConstraints(inputLayouts, consumerConfig);
+
+  if (!l1UsageExp) {
+    llvm::Error error = l1UsageExp.takeError();
+    std::string errorStr = llvm::toString(std::move(error));
+
+    // early exit
+    TTMLIR_DEBUG(ttmlir::LogComponent::Optimizer,
+                 "OpModel constraints failed: {0} :: {1},"
+                 "\nconsumerLayout: {2}",
+                 consumerOp->getName(), ttmlir::utils::firstNLines(errorStr, 4),
+                 consumerConfig.outputLayout);
+
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "OpModel constraints failed: %s",
+                                   errorStr.data());
+  }
+
+  auto [cBUsagePeak, tensorUsage, outputTensorUsage, outputLayout] =
+      l1UsageExp.get();
+
+  // Check if the output layout matches the expected interleaved L1 layout
+  // The second check seems redundant, but currently there is a runtime error of
+  // Memory config mismatch(DRAM vs L1)
+  if (outputLayout != consumerConfig.outputLayout ||
+      !outputLayout.hasInterleavedL1TensorMemoryLayout()) {
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "Output layout mismatch for op %s",
+                                   consumerOp->getName().getStringRef().data());
+  }
+
+  bool l1UsageValid = (producersL1OutputUsage + tensorUsage + cBUsagePeak) <
+                      tensorL1UsageCap * analysisInput.usableL1CacheSize;
+
+  if (!l1UsageValid) {
+    TTMLIR_DEBUG(ttmlir::LogComponent::Optimizer,
+                 "Not enough L1 memory. OpModel constraints failed: {0} "
+                 "\n outputLayout: {1}, l1Usage: {2}, "
+                 "producerL1OutputUsage: {3}, tensorUsage: {4}, "
+                 "outputTensorUsage: {5}, cBUsagePeak: {6}",
+                 consumerOp->getName(), outputLayout,
+                 cBUsagePeak + tensorUsage + producersL1OutputUsage,
+                 producersL1OutputUsage, tensorUsage, outputTensorUsage,
+                 cBUsagePeak);
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "Not enough L1 memory for op %s",
+                                   consumerOp->getName().getStringRef().data());
+  }
+
+  TTMLIR_DEBUG(
+      ttmlir::LogComponent::Optimizer,
+      "OpModel constraints valid. Consumer: {0}\n"
+      "OutputLayout: {1}\n"
+      "L1 usage: cBUsagePeak: {2}, tensorUsage: {3}, outputTensorUsage: {4}, "
+      "producerL1OutputUsage: {5}, totalL1Usage: {6}\n"
+      "=== End of debug dump ===",
+      consumerOp->getName(), outputLayout, cBUsagePeak, tensorUsage,
+      outputTensorUsage, producersL1OutputUsage,
+      cBUsagePeak + tensorUsage + producersL1OutputUsage);
+
+  return outputLayout;
+}
+
+} // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -84,6 +84,8 @@ void createTTNNPipelineAnalysisPasses(
     optimizerOptions.overrideConv2dConfig = options.overrideConv2dConfig;
     optimizerOptions.memoryLayoutAnalysisEnabled =
         options.memoryLayoutAnalysisEnabled;
+    optimizerOptions.l1InterleavedAnalysisEnabled =
+        options.l1InterleavedAnalysisEnabled;
     optimizerOptions.memReconfigEnabled = options.memReconfigEnabled;
     optimizerOptions.memoryLayoutAnalysisPolicy =
         options.memoryLayoutAnalysisPolicy;

--- a/lib/Dialect/TTNN/Transforms/Optimizer.cpp
+++ b/lib/Dialect/TTNN/Transforms/Optimizer.cpp
@@ -6,6 +6,7 @@
 #include "ttmlir/Dialect/TTCore/IR/Utils.h"
 #include "ttmlir/Dialect/TTNN/Analysis/AllPossibleLayoutsAnalysis.h"
 #include "ttmlir/Dialect/TTNN/Analysis/Edge.h"
+#include "ttmlir/Dialect/TTNN/Analysis/L1InterleavedAnalysis.h"
 #include "ttmlir/Dialect/TTNN/Analysis/LegalLayoutAnalysis.h"
 #include "ttmlir/Dialect/TTNN/Analysis/MemReconfig.h"
 #include "ttmlir/Dialect/TTNN/Analysis/MemoryLayoutAnalysis.h"
@@ -105,6 +106,8 @@ public:
     overrideConv2dConfig = std::move(options.overrideConv2dConfig);
     memoryLayoutAnalysisEnabled =
         std::move(options.memoryLayoutAnalysisEnabled);
+    l1InterleavedAnalysisEnabled =
+        std::move(options.l1InterleavedAnalysisEnabled);
     memReconfigEnabled = std::move(options.memReconfigEnabled);
     memoryLayoutAnalysisPolicy = std::move(options.memoryLayoutAnalysisPolicy);
     maxLegalLayouts = std::move(options.maxLegalLayouts);
@@ -134,6 +137,10 @@ protected:
   ::mlir::Pass::Option<bool> memoryLayoutAnalysisEnabled{
       *this, OptionNames::memoryLayoutAnalysisEnabled,
       ::llvm::cl::desc("Enable memory layout optimization."),
+      ::llvm::cl::init(false)};
+  ::mlir::Pass::Option<bool> l1InterleavedAnalysisEnabled{
+      *this, OptionNames::l1InterleavedAnalysisEnabled,
+      ::llvm::cl::desc("Enable L1 interleaved optimization."),
       ::llvm::cl::init(false)};
   ::mlir::Pass::Option<bool> memReconfigEnabled{
       *this, OptionNames::memReconfigEnabled,
@@ -199,6 +206,9 @@ public:
         moduleOp->getAttr(ttcore::SystemDescAttr::name));
     ttcore::ChipDescAttr chipDesc = systemDesc.getChipDescs()[0];
     llvm::DenseMap<Operation *, std::vector<OpConfig>> legalConfigs;
+    // Map to store only L1 Interleaved legal configs for L1InterleavedAnalysis
+    llvm::DenseMap<Operation *, std::vector<OpConfig>>
+        l1InterleavedLegalConfigs;
 
     // Step 1: Run ScalarDataTypeAnalysis to collect all scalar types used in
     // the graph
@@ -253,6 +263,21 @@ public:
             &tensorLayouts->getSecond(), maxLegalLayouts, &overrideOutputLayout,
             &overrideConv2dConfig, rowMajorEnabled));
         legalConfigs[op] = legalLayoutAnalysis.getResult();
+
+        // Save only L1 Interleaved legal configs in a separate map for
+        // L1InterleavedAnalysis later
+        if (l1InterleavedAnalysisEnabled) {
+          std::vector<OpConfig> l1InterleavedConfigs;
+          for (const auto &config : legalConfigs[op]) {
+            auto layoutAttr = config.outputLayout;
+            if (layoutAttr.getBufferType() == BufferType::L1 &&
+                layoutAttr.getMemLayout().getValue() ==
+                    TensorMemoryLayout::Interleaved) {
+              l1InterleavedConfigs.push_back(config);
+            }
+          }
+          l1InterleavedLegalConfigs[op] = std::move(l1InterleavedConfigs);
+        }
       });
     });
 
@@ -438,6 +463,40 @@ public:
       }
 
       processSpillOps(spillToDramOps, deviceGrid, insertedMemoryReconfigOps);
+
+      // Try finding ops that can be upgraded from DRAM to L1 interleaved
+      // layout.
+      if (l1InterleavedAnalysisEnabled) {
+        L1InterleavedAnalysis l1InterleavedAnalysis =
+            getAnalysis<L1InterleavedAnalysis>();
+        l1InterleavedAnalysis.init(L1InterleavedAnalysisInput(
+            l1InterleavedLegalConfigs, func, chipDesc.getUsableL1Size()));
+        auto l1InterleavedOpConfigs =
+            l1InterleavedAnalysis.getResult().upgradedConfigs;
+
+        // Apply L1 interleaved layout changes
+        for (const auto &[op, config] : l1InterleavedOpConfigs) {
+          RankedTensorType tensorType =
+              mlir::cast<RankedTensorType>(op->getResult(0).getType());
+          TTNNLayoutAttr currentLayout =
+              mlir::cast<TTNNLayoutAttr>(tensorType.getEncoding());
+
+          assert(currentLayout.getBufferType() == BufferType::DRAM &&
+                 "Operation should have DRAM layout before upgrade to L1 "
+                 "interleaved");
+
+          TTNNLayoutAttr newLayout = config.outputLayout;
+          assert(newLayout.getBufferType() == BufferType::L1 &&
+                 newLayout.getMemLayout().getValue() ==
+                     TensorMemoryLayout::Interleaved &&
+                 "New layout must have L1 interleaved memory layout");
+
+          RankedTensorType newTensorType = RankedTensorType::get(
+              tensorType.getShape(), tensorType.getElementType(), newLayout);
+
+          op->getResult(0).setType(newTensorType);
+        }
+      }
 
       insertRowMajorLayouts(func, chipDesc.getUsableL1Size());
 

--- a/lib/Dialect/TTNN/Utils/OptimizerOverrides.cpp
+++ b/lib/Dialect/TTNN/Utils/OptimizerOverrides.cpp
@@ -138,6 +138,10 @@ std::string OptimizerOverridesHandler::toString() const {
     options += OptionNames::memoryLayoutAnalysisEnabled.str() + "=true ";
   }
 
+  if (enableL1InterleavedAnalysis) {
+    options += OptionNames::l1InterleavedAnalysisEnabled.str() + "=true ";
+  }
+
   if (enableMemoryLayoutAnalysisPolicy) {
     options += OptionNames::memoryLayoutAnalysisPolicy.str() + "=" +
                MemoryLayoutAnalysisPolicyTypeParser::toString(

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/l1_interleaved_fork_join.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/l1_interleaved_fork_join.mlir
@@ -1,0 +1,44 @@
+// Test for L1InterleavedAnalysis
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-optimizer=true memory-layout-analysis-enabled=false l1-interleaved-analysis-enabled=true max-legal-layouts=32" -o l1_interleaved_fork_join_ttnn.mlir %s --mlir-print-debuginfo
+// RUN: FileCheck %s --input-file=l1_interleaved_fork_join_ttnn.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer l1_interleaved_fork_join_ttnn.mlir > %t.ttnn
+
+module @L1InterleavedTestForkJoin attributes {} {
+  func.func @forward(%arg0: tensor<64x128xbf16>, %arg1: tensor<64x128xbf16>, %arg2: tensor<64x128xbf16>, %arg3: tensor<64x128xbf16>) -> tensor<64x128xbf16> {
+    %0 = ttir.empty() : tensor<64x128xbf16>
+    %1 = "ttir.add"(%arg0, %arg1, %0) : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+    %2 = ttir.empty() : tensor<64x128xbf16>
+    %3 = "ttir.add"(%arg2, %arg3, %2) : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+    %4 = ttir.empty() : tensor<64x128xbf16>
+    %5 = "ttir.add"(%1, %3, %4) : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+    %6 = ttir.empty() : tensor<64x128xbf16>
+    %7 = "ttir.relu"(%5, %6) : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+    // Fork: %7 used in two ops
+    %8 = ttir.empty() : tensor<64x128xbf16>
+    %9 = "ttir.neg"(%7, %8) : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+    %10 = ttir.empty() : tensor<64x128xbf16>
+    %11 = "ttir.abs"(%7, %10) : (tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+    // Join: add the results
+    %12 = ttir.empty() : tensor<64x128xbf16>
+    %13 = "ttir.add"(%9, %11, %12) : (tensor<64x128xbf16>, tensor<64x128xbf16>, tensor<64x128xbf16>) -> tensor<64x128xbf16>
+    return %13 : tensor<64x128xbf16>
+  }
+}
+// CHECK-DAG: #[[L1:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}#dram>{{.*}}<interleaved>>
+// CHECK-DAG: #[[L2:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}#l1>{{.*}}<interleaved>>
+
+// not immediately consumed -> dram
+// CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<{{.*}}, #[[L1]]>
+
+// CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<{{.*}}, #[[L2]]>
+// CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<{{.*}}, #[[L2]]>
+
+// fork, not a single user -> dram
+// CHECK: %{{.*}} = "ttnn.relu"{{.*}} -> tensor<{{.*}}, #[[L1]]>
+
+// not immediately consumed, not backend supported -> dram
+// CHECK: %{{.*}} = "ttnn.neg"{{.*}} -> tensor<{{.*}}, #[[L1]]>
+// not backend supported -> dram
+// CHECK: %{{.*}} = "ttnn.abs"{{.*}} -> tensor<{{.*}}, #[[L1]]>
+// CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<{{.*}}, #[[L2]]>

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/l1_interleaved_minimal.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/l1_interleaved_minimal.mlir
@@ -1,0 +1,25 @@
+// Test for L1InterleavedAnalysis
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-optimizer=true memory-layout-analysis-enabled=false l1-interleaved-analysis-enabled=true" -o l1_interleaved_minimal_ttnn.mlir %s --mlir-print-debuginfo
+// RUN: FileCheck %s --input-file=l1_interleaved_minimal_ttnn.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer l1_interleaved_minimal_ttnn.mlir > %t.ttnn
+
+module @L1InterleavedTestMinimal attributes {} {
+  func.func @forward(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16>, %arg2: tensor<32x32xbf16>) -> tensor<32x32xbf16> {
+    // CHECK-DAG: #[[L1_LAYOUT:.*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <8x8, (d0, d1) -> (0, d0, d1)>, memref<1x1x!ttcore.tile<32x32, bf16>, #l1>, <interleaved>>
+
+    %0 = ttir.empty() : tensor<32x32xbf16>
+    // CHECK: %{{.*}} = "ttnn.multiply"{{.*}} -> tensor<32x32xbf16, #[[L1_LAYOUT]]>
+    %1 = "ttir.multiply"(%arg0, %arg1, %0) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+
+    %2 = ttir.empty() : tensor<32x32xbf16>
+    // CHECK: %{{.*}} = "ttnn.add"{{.*}} -> tensor<32x32xbf16, #[[L1_LAYOUT]]>
+    %3 = "ttir.add"(%1, %arg2, %2) : (tensor<32x32xbf16>, tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+
+    %4 = ttir.empty() : tensor<32x32xbf16>
+    // CHECK: %{{.*}} = "ttnn.relu"{{.*}} -> tensor<32x32xbf16, #[[L1_LAYOUT]]>
+    %5 = "ttir.relu"(%3, %4) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>
+
+    return %5 : tensor<32x32xbf16>
+  }
+}

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/l1_interleaved_simple_conv2d.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/l1_interleaved_simple_conv2d.mlir
@@ -1,0 +1,33 @@
+// Test for L1InterleavedAnalysis
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-optimizer=true memory-layout-analysis-enabled=false l1-interleaved-analysis-enabled=true max-legal-layouts=32" -o l1_interleaved_simple_conv2d_ttnn.mlir %s --mlir-print-debuginfo
+// RUN: FileCheck %s --input-file=l1_interleaved_simple_ttnn.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer l1_interleaved_simple_ttnn.mlir > %t.ttnn
+
+module @L1InterleavedTestConv2D attributes {} {
+  func.func @forward(
+    %arg0: tensor<4x32x32x16xbf16>,
+    %arg1: tensor<32x16x3x3xbf16>,
+    %arg2: tensor<64x32x1x1xbf16>,
+    %arg3: tensor<64x64x1x1xbf16>
+  ) -> tensor<4x32x32x64xbf16> {
+    %0 = ttir.empty() : tensor<4x32x32x32xbf16>
+    %1 = "ttir.conv2d"(%arg0, %arg1, %0) {dilation = array<i32: 1, 1>, groups = 1 : i32, padding = array<i32: 1, 1, 1, 1>, stride = array<i32: 1, 1>}: (tensor<4x32x32x16xbf16>, tensor<32x16x3x3xbf16>, tensor<4x32x32x32xbf16>) -> tensor<4x32x32x32xbf16>
+    %2 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %3 = "ttir.conv2d"(%1, %arg2, %2) {dilation = array<i32: 1, 1>, groups = 1 : i32, padding = array<i32: 0, 0, 0, 0>, stride = array<i32: 1, 1>}: (tensor<4x32x32x32xbf16>, tensor<64x32x1x1xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    %4 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %5 = "ttir.conv2d"(%3, %arg3, %4) {dilation = array<i32: 1, 1>, groups = 1 : i32, padding = array<i32: 0, 0, 0, 0>, stride = array<i32: 1, 1>}: (tensor<4x32x32x64xbf16>, tensor<64x64x1x1xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    return %5 : tensor<4x32x32x64xbf16>
+  }
+}
+
+// CHECK-DAG: #[[L1:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}#l1>{{.*}}<interleaved>>
+// CHECK-DAG: #[[L2:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}#l1>{{.*}}<interleaved>>
+// CHECK-DAG: #[[L3:.*]] = #ttnn.ttnn_layout<{{.*}}memref<{{.*}}#l1>{{.*}}<interleaved>>
+
+// CHECK: %{{.*}} = "ttnn.reshape"{{.*}} -> tensor<{{.*}}, #[[L2]]>
+// CHECK: %{{.*}} = "ttnn.conv2d"{{.*}} -> tensor<{{.*}}, #[[L2]]>
+// CHECK: %{{.*}} = "ttnn.conv2d"{{.*}} -> tensor<{{.*}}, #[[L3]]>
+// CHECK: %{{.*}} = "ttnn.conv2d"{{.*}} -> tensor<{{.*}}, #[[L3]]>
+// CHECK: %{{.*}} = "ttnn.reshape"{{.*}} -> tensor<{{.*}}, #[[L1]]>
+// CHECK: return{{.*}} : tensor<{{.*}}, #[[L1]]>

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/nested_fork_join_schedule_heuristic.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/nested_fork_join_schedule_heuristic.mlir
@@ -1,0 +1,183 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-optimizer=true memory-layout-analysis-enabled=true" %s -o %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+
+func.func @complex_nested_fork_join_schedule_test(%arg0: tensor<4x32x32x64xbf16>, %arg1: tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16> {
+    // Initial operation - creates the first fork point
+    %0 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %1 = "ttir.add"(%arg0, %arg1, %0) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    // ========== MAJOR BRANCH A: Complex nested processing ==========
+    
+    // Branch A.1: relu → exp → (nested fork) → log
+    %2 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %3 = "ttir.relu"(%1, %2) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    %4 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %5 = "ttir.exp"(%3, %4) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    // NESTED FORK within Branch A.1: exp result goes to TWO sub-branches
+    
+    // Sub-branch A.1.a: sin → cos → tanh
+    %6 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %7 = "ttir.sin"(%5, %6) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    %8 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %9 = "ttir.cos"(%7, %8) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    %10 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %11 = "ttir.tanh"(%9, %10) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    // Sub-branch A.1.b: abs → sqrt → reciprocal
+    %12 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %13 = "ttir.abs"(%5, %12) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    %14 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %15 = "ttir.sqrt"(%13, %14) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    %16 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %17 = "ttir.reciprocal"(%15, %16) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    // NESTED JOIN: Combine the two sub-branches with multiply
+    %18 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %19 = "ttir.multiply"(%11, %17, %18) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    // Continue Branch A.1: log of the nested result
+    %20 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %21 = "ttir.log"(%19, %20) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    // Branch A.2: sigmoid → (another nested fork)
+    %22 = ttir.empty() : tensor<4x32x32x64xbf16>  
+    %23 = "ttir.sigmoid"(%1, %22) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    // ANOTHER NESTED FORK from sigmoid result
+    
+    // Sub-branch A.2.a: neg → cbrt
+    %24 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %25 = "ttir.neg"(%23, %24) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    %26 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %27 = "ttir.cbrt"(%25, %26) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    // Sub-branch A.2.b: Just a simple copy (gelu)
+    %28 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %29 = "ttir.gelu"(%23, %28) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    // NESTED JOIN A.2: subtract
+    %30 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %31 = "ttir.subtract"(%27, %29, %30) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    // MAJOR JOIN A: Combine Branch A.1 and A.2
+    %32 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %33 = "ttir.add"(%21, %31, %32) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    // ========== MAJOR BRANCH B: Simpler but still forked ==========
+    
+    // Branch B.1: Simple chain
+    %34 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %35 = "ttir.floor"(%1, %34) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    %36 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %37 = "ttir.ceil"(%35, %36) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    // Branch B.2: Another simple chain  
+    %38 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %39 = "ttir.rsqrt"(%1, %38) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    %40 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %41 = "ttir.log"(%39, %40) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    // Branch B.3: Triple nested madness!
+    %42 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %43 = "ttir.log1p"(%1, %42) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    // Triple nested fork from log1p
+    // Sub-sub-branch B.3.a.i
+    %44 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %45 = "ttir.sign"(%43, %44) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    // Sub-sub-branch B.3.a.ii  
+    %46 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %47 = "ttir.logical_not"(%43, %46) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    // Triple nested join
+    %48 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %49 = "ttir.maximum"(%45, %47, %48) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    // MAJOR JOIN B: Combine all B branches (3-way join!)
+    %50 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %51 = "ttir.add"(%37, %41, %50) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    %52 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %53 = "ttir.multiply"(%51, %49, %52) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    // ========== FINAL MEGA JOIN: Combine Major Branches A and B ==========
+    %54 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %55 = "ttir.subtract"(%33, %53, %54) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    return %55 : tensor<4x32x32x64xbf16>
+}
+
+// Initial operation
+// CHECK: %{{.*}} = "ttnn.add"
+
+// Branch A.1 start
+// CHECK: %{{.*}} = "ttnn.relu"
+// CHECK: %{{.*}} = "ttnn.exp"
+
+// Nested sub-branches within A.1 must complete before any Branch B operations
+// Sub-branch A.1.a: sin → cos → tanh
+// CHECK: %{{.*}} = "ttnn.sin"
+// CHECK: %{{.*}} = "ttnn.cos"
+// CHECK: %{{.*}} = "ttnn.tanh"
+
+// Sub-branch A.1.b: abs → sqrt → reciprocal
+// CHECK: %{{.*}} = "ttnn.abs"
+// CHECK: %{{.*}} = "ttnn.sqrt"
+// CHECK: %{{.*}} = "ttnn.reciprocal"
+
+// Nested join and continuation of A.1
+// CHECK: %{{.*}} = "ttnn.multiply"
+// CHECK: %{{.*}} = "ttnn.log"
+
+// Branch A.2 with its nested structure
+// CHECK: %{{.*}} = "ttnn.sigmoid"
+
+// NOW A.2.b (gelu) will happen before A.2.a (neg → cbrt)
+// should be because of hasBlockedSuccessor heuristic
+// CHECK: %{{.*}} = "ttnn.gelu"
+// CHECK: %{{.*}} = "ttnn.neg"
+// CHECK: %{{.*}} = "ttnn.cbrt"
+
+// CHECK: %{{.*}} = "ttnn.subtract"
+
+// Major join A (no Branch B operations yet)
+// CHECK-NOT: ttnn.floor
+// CHECK-NOT: ttnn.ceil
+// CHECK-NOT: ttnn.rsqrt
+// CHECK-NOT: ttnn.log
+// CHECK-NOT: ttnn.log1p
+// CHECK-NOT: ttnn.sign
+// CHECK-NOT: ttnn.logical_not
+// CHECK-NOT: ttnn.maximum
+// CHECK: %{{.*}} = "ttnn.add"
+
+// NOW Major Branch B can start (after entire Branch A completes)
+// CHECK: %{{.*}} = "ttnn.floor"
+// CHECK: %{{.*}} = "ttnn.ceil"
+// CHECK: %{{.*}} = "ttnn.rsqrt"
+// CHECK: %{{.*}} = "ttnn.log"
+
+// NOW join B.1 and B.2 will happen before B.3 starts
+// should be because of hasBlockedSuccessor heuristic
+// CHECK: %{{.*}} = "ttnn.add"
+
+// CHECK: %{{.*}} = "ttnn.log1p"
+// CHECK: %{{.*}} = "ttnn.sign"
+// CHECK: %{{.*}} = "ttnn.logical_not"
+// CHECK: %{{.*}} = "ttnn.maximum"
+
+// Major joins B
+// CHECK: %{{.*}} = "ttnn.multiply"
+
+// Final mega join
+// CHECK: %{{.*}} = "ttnn.subtract"

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/simple_fork_join_schedule.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/simple_fork_join_schedule.mlir
@@ -1,0 +1,52 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-optimizer=true memory-layout-analysis-enabled=true" %s -o %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+
+func.func @simple_fork_join_schedule_test(%arg0: tensor<4x32x32x64xbf16>, %arg1: tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16> {
+    // Initial operation - creates fork point
+    %0 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %1 = "ttir.add"(%arg0, %arg1, %0) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    // Branch 1: relu → exp → log
+    %2 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %3 = "ttir.relu"(%1, %2) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    %4 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %5 = "ttir.exp"(%3, %4) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    %6 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %7 = "ttir.log"(%5, %6) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    // Branch 2: sigmoid → neg
+    %8 = ttir.empty() : tensor<4x32x32x64xbf16>  
+    %9 = "ttir.sigmoid"(%1, %8) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    %10 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %11 = "ttir.neg"(%9, %10) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    // Join point
+    %12 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %13 = "ttir.add"(%7, %11, %12) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    return %13 : tensor<4x32x32x64xbf16>
+}
+
+// Initial add must come first
+// CHECK: %{{.*}} = "ttnn.add"
+
+// Test non-interleaving of branches by using CHECK-NOT to prevent opposite branch operations
+// Branch 1 executes first, because it is defined first
+
+// CHECK: %{{.*}} = "ttnn.relu"
+// CHECK-NOT: ttnn.sigmoid
+// CHECK-NOT: ttnn.neg
+// CHECK: %{{.*}} = "ttnn.exp"
+// CHECK-NOT: ttnn.sigmoid  
+// CHECK-NOT: ttnn.neg
+// CHECK: %{{.*}} = "ttnn.log"
+
+// Now Branch 2 can start (after Branch 1 completes)
+// CHECK: %{{.*}} = "ttnn.sigmoid"
+// CHECK: %{{.*}} = "ttnn.neg"
+
+// Join in final add
+// CHECK: %{{.*}} = "ttnn.add"

--- a/test/ttmlir/Silicon/TTNN/n150/optimizer/simple_fork_join_schedule_heuristic.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/optimizer/simple_fork_join_schedule_heuristic.mlir
@@ -1,0 +1,47 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-optimizer=true memory-layout-analysis-enabled=true" %s -o %t.mlir
+// RUN: FileCheck %s --input-file=%t.mlir
+// might fail after solving: https://github.com/tenstorrent/tt-mlir/issues/3744
+
+func.func @simple_fork_join_schedule_test(%arg0: tensor<4x32x32x64xbf16>, %arg1: tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16> {
+    // Initial operation - creates fork point
+    %0 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %1 = "ttir.add"(%arg0, %arg1, %0) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    // Branch 1: relu → exp → log
+    %2 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %3 = "ttir.relu"(%1, %2) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    %4 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %5 = "ttir.exp"(%3, %4) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    %6 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %7 = "ttir.log"(%5, %6) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    // Branch 2: sigmoid → neg
+    %8 = ttir.empty() : tensor<4x32x32x64xbf16>  
+    %9 = "ttir.sigmoid"(%1, %8) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    // Join point
+    %10 = ttir.empty() : tensor<4x32x32x64xbf16>
+    %11 = "ttir.add"(%7, %9, %10) : (tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>, tensor<4x32x32x64xbf16>) -> tensor<4x32x32x64xbf16>
+    
+    return %11 : tensor<4x32x32x64xbf16>
+}
+
+// Initial add must come first
+// CHECK: %{{.*}} = "ttnn.add"
+
+// Test non-interleaving of branches by using CHECK-NOT to prevent opposite branch operations
+// Branch 2 executes first, because even though it is defined last, it is scheduled first by hasBlockedSuccessor heuristic
+
+// CHECK-NOT: ttnn.relu
+// CHECK: %{{.*}} = "ttnn.sigmoid"
+
+// Now Branch 1 can start (after Branch 2 completes)
+// CHECK: %{{.*}} = "ttnn.relu"
+// CHECK: %{{.*}} = "ttnn.exp"
+// CHECK-NOT: ttnn.sigmoid  
+// CHECK: %{{.*}} = "ttnn.log"
+
+// Join in final add
+// CHECK: %{{.*}} = "ttnn.add"


### PR DESCRIPTION
### Ticket

### Problem description
Previously, only the costly `MemoryLayoutAnalysis` (when enabled) attempted to change the memory configuration of DRAM interleaved ops to L1 sharded, which requires complex compatibility checks and trade-offs. As a result, DRAM-resident ops were not further optimized for L1 interleaved memory layout, missing a simpler opportunity to improve memory locality and performance. The existing analysis focuses on legal layouts and reconfiguration, but there was no dedicated pass to selectively convert DRAM ops to L1 interleaved when beneficial, especially with respect to L1 usage and scheduling constraints.

### What's changed
This PR adds a new analysis and transformation inside the `Optimizer` pass that runs after the optional `MemoryLayoutAnalysis` and all its scheduling and graph changes are complete. The pass traverses the scheduled ops, identifies DRAM-resident ops, and attempts to convert them to L1 interleaved layout if:
1. The op's inputs and outputs together fit in available L1 memory.
2. The op has only one use, and that use (consumer) is the immediate next op in the schedule.

The analysis uses L1 usage accounting similar to `ShardSolver` but independently of it. For ops that meet the criteria, the pass changes the op's output layout to L1 interleaved. For now, it does not insert `ToLayout` ops or attempt further layout adjustments. Ops that do not have exactly one use or whose consumer is not immediately scheduled after them are left unchanged to avoid unnecessary or unsafe layout changes.

This targeted approach improves memory locality for eligible ops, potentially reducing DRAM traffic and improving performance, while maintaining correctness and respecting scheduling constraints.

There are a few simple tests for this using llvm-lit and FileCheck, but it still needs to be tested on larger models with more ops. This feature is by default disabled, flag `l1-interleaved-analysis-enabled` is toggled independently of `memory-layout-analysis-enabled`.

### Checklist
- [x] New/Existing tests provide coverage for changes
- [x] Flag for enabling the feature (default:` l1-interleaved-analysis-enabled`=false)
