### PR TITLE
[Optimizer] Respect override when checking interleaved to sharded

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/DFShardingPolicy.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/DFShardingPolicy.h
@@ -22,6 +22,7 @@ class DFShardingPolicy : public MemoryLayoutAnalysisPolicy {
 private:
   const TensorTypeLayoutsMap *tensorTypePossibleLayouts;
   llvm::DenseSet<Edge> overrideReshardEdges;
+  llvm::DenseSet<Operation *> rowMajorOutputOps;
 
   void pickOpShardConfigs(ShardSolver &shardSolver,
                           const L1ChainConfig &l1ChainConfig);
@@ -40,8 +41,10 @@ public:
 
   void run() final;
 
-  void setOverrideReshardEdges(const llvm::DenseSet<Edge> &reshardEdges) {
+  void setOverrides(const llvm::DenseSet<Edge> &reshardEdges,
+                    const llvm::DenseSet<Operation *> &rowMajorOutputOps) {
     overrideReshardEdges = reshardEdges;
+    this->rowMajorOutputOps = rowMajorOutputOps;
   }
 };
 

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1ChainConfig.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1ChainConfig.h
@@ -56,7 +56,8 @@ public:
       const TensorTypeLayoutsMap *tensorTypePossibleLayouts,
       const llvm::DenseMap<Operation *, std::vector<OpConfig>> &legalConfigs,
       unsigned usableL1CacheSize,
-      const llvm::DenseSet<Edge> &overrideReshardEdges);
+      const llvm::DenseSet<Edge> &overrideReshardEdges,
+      const llvm::DenseSet<Operation *> &rowMajorOutputOps);
   void resolve();
   void build();
   void complete(const llvm::DenseMap<Operation *, OpConfig> &selectedOpConfig,

--- a/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutAnalysis.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutAnalysis.h
@@ -25,6 +25,7 @@ struct MemoryLayoutAnalysisInput {
   llvm::DenseMap<Operation *, std::vector<OpConfig>> legalConfigs;
   unsigned usableL1CacheSize = 0;
   llvm::DenseSet<Edge> overrideReshardEdges;
+  llvm::DenseSet<Operation *> rowMajorOutputOps;
 
   MemoryLayoutAnalysisPolicyType policy;
 
@@ -35,10 +36,12 @@ struct MemoryLayoutAnalysisInput {
       const llvm::DenseMap<Operation *, std::vector<OpConfig>> &legalConfigs,
       unsigned usableL1CacheSize,
       const llvm::DenseSet<Edge> &overrideReshardEdges,
+      const llvm::DenseSet<Operation *> &rowMajorOutputOps,
       MemoryLayoutAnalysisPolicyType policy)
       : tensorTypePossibleLayouts(tensorTypePossibleLayouts),
         legalConfigs(legalConfigs), usableL1CacheSize(usableL1CacheSize),
-        overrideReshardEdges(overrideReshardEdges), policy(policy) {}
+        overrideReshardEdges(overrideReshardEdges),
+        rowMajorOutputOps(rowMajorOutputOps), policy(policy) {}
 
   bool operator==(const MemoryLayoutAnalysisInput &rhs) const {
     return legalConfigs == rhs.legalConfigs;

--- a/include/ttmlir/Dialect/TTNN/Analysis/ShardSolver.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/ShardSolver.h
@@ -327,13 +327,15 @@ public:
       const llvm::DenseSet<Operation *> &shardedOps,
       const unsigned usableL1CacheSize,
       const llvm::DenseSet<Edge> &overrideReshardEdges,
+      const llvm::DenseSet<Operation *> &rowMajorOutputOps = {},
       std::function<llvm::Expected<TTNNLayoutAttr>(Value, TTNNLayoutAttr,
                                                    Operation *, OpConfig)>
           customCheckShardCompatible = nullptr);
   RemainingConfigAttrs at(Operation *operation) const;
   void set(Operation *operation, const OpConfig &config);
   bool supportsInterleavedInputShardedOutput(Operation *op,
-                                             OpConfig outputConfig);
+                                             OpConfig outputConfig,
+                                             bool rowMajorInput = false);
   llvm::DenseMap<Operation *, SmallVector<float, 64>> produceMaxCoreUsage();
   ShardSolverSolution finish() const;
   bool resolve();
@@ -364,6 +366,8 @@ private:
 
   // Edges indicated for resharding.
   llvm::DenseSet<Edge> memReconfigEdges;
+  // Row major output ops.
+  llvm::DenseSet<Operation *> rowMajorOutputOps;
 
   std::function<llvm::Expected<TTNNLayoutAttr>(mlir::Value, TTNNLayoutAttr,
                                                mlir::Operation *, OpConfig)>

--- a/lib/Dialect/TTNN/Analysis/DFShardingPolicy.cpp
+++ b/lib/Dialect/TTNN/Analysis/DFShardingPolicy.cpp
@@ -152,7 +152,7 @@ void DFShardingPolicy::run() {
     progressTracker.startL1Chain(firstOp, chainIndex, numOpsInChain);
     ShardSolver shardSolver = l1ChainConfig.resolveWithSolver(
         tensorTypePossibleLayouts, legalConfigs, usableL1CacheSize,
-        overrideReshardEdges);
+        overrideReshardEdges, rowMajorOutputOps);
 
     if (l1ChainConfig.getState() == L1ChainState::Failed) {
       TTMLIR_DEBUG(ttmlir::LogComponent::Optimizer,

--- a/lib/Dialect/TTNN/Analysis/L1ChainConfig.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1ChainConfig.cpp
@@ -27,15 +27,16 @@ ShardSolver L1ChainConfig::resolveWithSolver(
     const TensorTypeLayoutsMap *tensorTypePossibleLayouts,
     const llvm::DenseMap<Operation *, std::vector<OpConfig>> &legalConfigs,
     unsigned usableL1CacheSize,
-    const llvm::DenseSet<Edge> &overrideReshardEdges) {
+    const llvm::DenseSet<Edge> &overrideReshardEdges,
+    const llvm::DenseSet<Operation *> &rowMajorOutputOps) {
   assert(state == L1ChainState::Built);
 
   // Reconcile adjacent shard specs.
   // Generate reshard specs where needed.
   //
   ShardSolver shardSolver(tensorTypePossibleLayouts, legalConfigs, opL1MemSpecs,
-                          l1ChainedOps, usableL1CacheSize,
-                          overrideReshardEdges);
+                          l1ChainedOps, usableL1CacheSize, overrideReshardEdges,
+                          rowMajorOutputOps);
 
   state = shardSolver.resolve() ? L1ChainState::Resolved : L1ChainState::Failed;
 

--- a/lib/Dialect/TTNN/Analysis/LegalTensorLayoutAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/LegalTensorLayoutAnalysis.cpp
@@ -256,7 +256,7 @@ void LegalTensorLayoutAnalysis::processTensorType(RankedTensorType tensorType) {
   // Generate all possible layouts for this tensor type
   std::vector<TTNNLayoutAttr> layouts = generateLayouts(tensorType);
 
-  // Categorize layouts by scalar type, memory layout, and data layout
+  // Categorize layouts by scalar type, memory layout, and page layout
   for (const TTNNLayoutAttr &layout : layouts) {
     Type scalarType = layout.getScalarElementType();
 

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutAnalysis.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutAnalysis.cpp
@@ -64,8 +64,8 @@ void MemoryLayoutAnalysis::analysisImplementation() {
         op, l1ChainConfigs, analysisInput.tensorTypePossibleLayouts,
         filterShardedOnly(analysisInput.legalConfigs), analysisResult.schedule,
         analysisInput.usableL1CacheSize);
-    dfShardingPolicy.setOverrideReshardEdges(
-        analysisInput.overrideReshardEdges);
+    dfShardingPolicy.setOverrides(analysisInput.overrideReshardEdges,
+                                  analysisInput.rowMajorOutputOps);
     dfShardingPolicy.run();
     break;
   }

--- a/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
+++ b/lib/Dialect/TTNN/Analysis/ShardSolver.cpp
@@ -289,9 +289,6 @@ bool ShardSolver::resolveStep() {
 bool ShardSolver::supportsInterleavedInputShardedOutput(Operation *op,
                                                         OpConfig outputConfig,
                                                         bool rowMajorInput) {
-  // TTNNLayoutAttr inputLayout = mlir::cast<TTNNLayoutAttr>(
-  //     mlir::cast<RankedTensorType>(op->getOperand(0).getType()).getEncoding());
-
   RankedTensorType tensorType =
       mlir::cast<RankedTensorType>(op->getResult(0).getType());
   TTNNLayoutAttr inputLayout =
@@ -304,8 +301,6 @@ bool ShardSolver::supportsInterleavedInputShardedOutput(Operation *op,
   if (rowMajorInput) {
     Type inputElementType = inputLayout.getScalarElementType();
     inputLayout = inputLayout.withElementType(inputElementType, tensorShape);
-    llvm::outs() << "Row major input detected for op: " << op->getName()
-                 << "\n";
   }
 
   llvm::Expected<TTNNLayoutAttr> shardCompatible =
@@ -822,7 +817,7 @@ llvm::Expected<TTNNLayoutAttr> ShardSolver::checkShardCompatible(
   // Figure out this const based on exec data, but will be replaced
   // with API.
   //
-  constexpr float tensorL1UsageCap = 0.8;
+  constexpr float tensorL1UsageCap = 0.9;
 
   OpModel backend = mlir::dyn_cast<OpModel>(consumerOp);
   if (!backend) {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/3749)

### Problem description
When checking whether a reshard must be inserted before the first op in the L1 chain, or whether it supports interleaved input with sharded output, we assumed that the op has tiled input. However, if the op before it has row major output, that makes its input row major as well and there is a possibility it does not support sharded output in that case.

### What's changed
The set of ops with row major output overrides is created in `TTNNOptimizer`, passed through all intermediate functions, and finally used in `ShardSolver::preprocessFirstOp`.

### Checklist
- [ ] New/Existing tests provide coverage for changes
