### PR TITLE
D2M: Add affine loop coalescing optimization to ttmetal pipeline

### DIFF
--- a/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
+++ b/lib/Dialect/TTMetal/Pipelines/TTMetalPipelines.cpp
@@ -14,6 +14,7 @@
 #include "ttmlir/Dialect/TTMetal/Transforms/Passes.h"
 
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
+#include "mlir/Dialect/Affine/Passes.h"
 #include "mlir/Dialect/Arith/Transforms/Passes.h"
 #include "mlir/Dialect/Bufferization/Transforms/OneShotAnalysis.h"
 #include "mlir/Dialect/Bufferization/Transforms/Passes.h"
@@ -99,6 +100,10 @@ void createTTIRToTTMetalMiddleendPipeline(
   }
   pm.addPass(ttir::createTTIRGenericTileComputeLoops(tileComputeLoopsOptions));
   pm.addPass(ttir::createTTIRInsertDstRegisterAccess());
+
+  OpPassManager &funcPm = pm.nest<func::FuncOp>();
+  funcPm.addPass(affine::createLoopCoalescingPass());
+
   pm.addPass(mlir::createLowerAffinePass());
   pm.addPass(memref::createFoldMemRefAliasOpsPass());
   pm.addPass(mlir::createLowerAffinePass());


### PR DESCRIPTION
### Problem description
We have some redundant looping around our copy/pack instructions because of how we generate those loop nests. This is a performance hit.

### What's changed
Add the affine loop coalescing pass to the ttmetal pipeline to optimize away these redundant loops.

Before:
```cpp
for %arg2 = %2 to %0 step %1  : !emitc.size_t {
          %10 = expression : !emitc.size_t {
            %11 = add %9, %arg2 : (!emitc.size_t, !emitc.size_t) -> !emitc.size_t
            yield %11 : !emitc.size_t
          }
          for %arg3 = %2 to %0 step %1  : !emitc.size_t {
            call_opaque "pack_tile"(%arg2, %7, %10) {template_args = [true]} : (!emitc.size_t, !emitc.opaque<"::tt::CB">, !emitc.size_t) -> ()
          }
        }
```

After:
```cpp
for %arg2 = %2 to %3 step %1  : !emitc.size_t {
          %13 = div %arg2, %0 : (!emitc.size_t, !emitc.size_t) -> !emitc.size_t
          %14 = add %12, %13 : (!emitc.size_t, !emitc.size_t) -> !emitc.size_t
          call_opaque "pack_tile"(%13, %8, %14) {template_args = [true]} : (!emitc.size_t, !emitc.opaque<"::tt::CB">, !emitc.size_t) -> ()
        }
```

### Checklist
- [x] New/Existing tests provide coverage for changes
