### PR TITLE
Add insertRuntimeTensorAndValidate API to preserve tensor version info

### DIFF
--- a/runtime/include/tt/runtime/detail/ttnn/types/types.h
+++ b/runtime/include/tt/runtime/detail/ttnn/types/types.h
@@ -135,6 +135,10 @@ public:
   getTTNNTensorAndValidate(const ::tt::target::ttnn::TensorRef *tensorRef);
 
   std::pair<TensorPtrMapIterator, bool>
+  insertRuntimeTensorAndValidate(const ::tt::target::ttnn::TensorRef *tensorRef,
+                                 const ::tt::runtime::Tensor &runtimeTensor);
+
+  std::pair<TensorPtrMapIterator, bool>
   insertTTNNTensorAndValidate(const ::tt::target::ttnn::TensorRef *tensorRef,
                               const ::ttnn::Tensor &ttnnTensor,
                               bool retain = false);

--- a/runtime/lib/ttnn/operations/cache/load_cached.cpp
+++ b/runtime/lib/ttnn/operations/cache/load_cached.cpp
@@ -45,9 +45,8 @@ void run(const ::tt::target::ttnn::LoadCachedOp *op, ProgramContext &context) {
 
     LOG_ASSERT(cachedOutputs->size() == op->outputs()->size());
     for (size_t i = 0; i < cachedOutputs->size(); ++i) {
-      auto &output = utils::getTTNNTensorFromRuntimeTensor((*cachedOutputs)[i]);
-      context.getTensorPool().insertTTNNTensorAndValidate(op->outputs()->Get(i),
-                                                          output);
+      context.getTensorPool().insertRuntimeTensorAndValidate(
+          op->outputs()->Get(i), (*cachedOutputs)[i]);
     }
 
     return;
@@ -71,13 +70,18 @@ void run(const ::tt::target::ttnn::LoadCachedOp *op, ProgramContext &context) {
   LOG_DEBUG("executed sub-func: ", constEvalFuncname);
   std::vector<::tt::runtime::Tensor> outputs = exec.gatherOutputTensors();
 
+  // Const-eval outputs need to be retained
+  for (::tt::runtime::Tensor &output : outputs) {
+    ::tt::runtime::ttnn::TTNNTensorWrapper &outputWrapper =
+        output.as<::tt::runtime::ttnn::TTNNTensorWrapper>(DeviceRuntime::TTNN);
+    outputWrapper.setRetain(true);
+  }
+
   cache->store(cacheKey, constEvalFuncname, std::move(inputVersions), outputs);
 
   for (size_t i = 0; i < outputs.size(); ++i) {
-    ::tt::runtime::Tensor &runtimeOutput = outputs[i];
-    auto &output = utils::getTTNNTensorFromRuntimeTensor(runtimeOutput);
-    context.getTensorPool().insertTTNNTensorAndValidate(op->outputs()->Get(i),
-                                                        output);
+    context.getTensorPool().insertRuntimeTensorAndValidate(
+        op->outputs()->Get(i), outputs[i]);
   }
 }
 } // namespace tt::runtime::ttnn::operations::cache

--- a/runtime/lib/ttnn/operations/mlir_native/func_call.cpp
+++ b/runtime/lib/ttnn/operations/mlir_native/func_call.cpp
@@ -28,10 +28,8 @@ void run(const ::tt::target::ttnn::FuncCallOp *op, ProgramContext &context) {
   LOG_ASSERT(outputs.size() == op->outputs()->size(),
              "Number of outputs does not match");
   for (size_t i = 0; i < op->outputs()->size(); i++) {
-    ::ttnn::Tensor &ttnnOutput =
-        utils::getTTNNTensorFromRuntimeTensor(outputs[i]);
-    context.getTensorPool().insertTTNNTensorAndValidate(op->outputs()->Get(i),
-                                                        ttnnOutput);
+    context.getTensorPool().insertRuntimeTensorAndValidate(
+        op->outputs()->Get(i), outputs[i]);
   }
 }
 

--- a/runtime/lib/ttnn/operations/trace/capture_or_execute_trace.cpp
+++ b/runtime/lib/ttnn/operations/trace/capture_or_execute_trace.cpp
@@ -84,10 +84,8 @@ static void runTraceProgramAndCaptureTrace(
 
   // Handle trace function outputs
   for (size_t i = 0; i < op->outputs()->size(); i++) {
-    ::ttnn::Tensor &output =
-        ::tt::runtime::ttnn::utils::getTTNNTensorFromRuntimeTensor(
-            outputTensors[currOutputIndex++]);
-    tensorPool.insertTTNNTensorAndValidate(op->outputs()->Get(i), output);
+    tensorPool.insertRuntimeTensorAndValidate(op->outputs()->Get(i),
+                                              outputTensors[currOutputIndex++]);
   }
 
   // Handle trace input slots
@@ -174,13 +172,8 @@ static void executeTrace(const ::tt::target::ttnn::CaptureOrExecuteTraceOp *op,
 
   for (size_t i = 0; i < op->outputs()->size(); i++) {
     const ::tt::target::ttnn::TensorRef *output = op->outputs()->Get(i);
-    const ::ttnn::Tensor &outputTensor =
-        ::tt::runtime::ttnn::utils::getTTNNTensorFromRuntimeTensor(
-            traceData.outputTensors[i]);
-    // These outputs must be retained as they share the same ttnn tensors as the
-    // output slots of the trace
-    context.getTensorPool().insertTTNNTensorAndValidate(output, outputTensor,
-                                                        /*retain=*/true);
+    context.getTensorPool().insertRuntimeTensorAndValidate(
+        output, traceData.outputTensors[i]);
   }
 }
 


### PR DESCRIPTION
### Problem description
Current tensor pool only has API to insert ttnn tensors, causing us to unwrap consteval tensors before insertion. This causes version mismatches later on.

### What's changed
Add API to insert runtime tensors directly. This mostly solves the trace perf degradation seen on resnet. 
### Checklist
- [X] New/Existing tests provide coverage for changes
