### PR TITLE
feat: add constraint API for all binary ops

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -551,70 +551,90 @@ def TTNN_AddOp : TTNN_ElementwiseBinaryOp<"add",
     }];
 }
 
-def TTNN_DivideOp : TTNN_ElementwiseBinaryOp<"divide"> {
+def TTNN_DivideOp : TTNN_ElementwiseBinaryOp<"divide",
+    [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+    > {
     let summary = "Eltwise divide.";
     let description = [{
       Eltwise divide operation.
     }];
 }
 
-def TTNN_EqualOp : TTNN_ElementwiseBinaryOp<"eq"> {
+def TTNN_EqualOp : TTNN_ElementwiseBinaryOp<"eq",
+    [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+    > {
     let summary = "Eltwise equal to.";
     let description = [{
       Eltwise equal to operation.
     }];
 }
 
-def TTNN_NotEqualOp : TTNN_ElementwiseBinaryOp<"ne"> {
+def TTNN_NotEqualOp : TTNN_ElementwiseBinaryOp<"ne",
+    [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+    > {
     let summary = "Eltwise not equal to.";
     let description = [{
       Eltwise not equal to operation.
     }];
 }
 
-def TTNN_GreaterEqualOp : TTNN_ElementwiseBinaryOp<"ge"> {
+def TTNN_GreaterEqualOp : TTNN_ElementwiseBinaryOp<"ge",
+    [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+    > {
     let summary = "Eltwise greater than or equal to.";
     let description = [{
       Eltwise greater than or equal to operation.
     }];
 }
 
-def TTNN_GreaterThanOp : TTNN_ElementwiseBinaryOp<"gt"> {
+def TTNN_GreaterThanOp : TTNN_ElementwiseBinaryOp<"gt",
+    [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+    > {
     let summary = "Eltwise greater than.";
     let description = [{
       Eltwise greater than operation.
     }];
 }
 
-def TTNN_LessEqualOp : TTNN_ElementwiseBinaryOp<"le"> {
+def TTNN_LessEqualOp : TTNN_ElementwiseBinaryOp<"le",
+    [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+    > {
     let summary = "Eltwise less than or equal to.";
     let description = [{
       Eltwise less than or equal to operation.
     }];
 }
 
-def TTNN_LessThanOp : TTNN_ElementwiseBinaryOp<"lt"> {
+def TTNN_LessThanOp : TTNN_ElementwiseBinaryOp<"lt",
+    [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+    > {
     let summary = "Eltwise less than.";
     let description = [{
       Eltwise less than operation.
     }];
 }
 
-def TTNN_LogicalAndOp : TTNN_ElementwiseBinaryOp<"logical_and"> {
+def TTNN_LogicalAndOp : TTNN_ElementwiseBinaryOp<"logical_and",
+    [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+    > {
     let summary = "Eltwise logical and.";
     let description = [{
       Eltwise logical and operation.
     }];
 }
 
-def TTNN_LogicalOrOp : TTNN_ElementwiseBinaryOp<"logical_or"> {
+def TTNN_LogicalOrOp : TTNN_ElementwiseBinaryOp<"logical_or",
+    [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+    > {
     let summary = "Eltwise logical or.";
     let description = [{
       Eltwise logical or operation.
     }];
 }
 
-def TTNN_LogicalXorOp : TTNN_ElementwiseBinaryOp<"logical_xor"> {
+def TTNN_LogicalXorOp : TTNN_ElementwiseBinaryOp<"logical_xor",
+    [DeclareOpInterfaceMethods<TTNN_OpModelInterface, ["getOpConstraints", "getOpRuntime"]>]
+    > {
     let summary = "Eltwise logical xor.";
     let description = [{
       Eltwise logical xor operation.

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -118,6 +118,226 @@ getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
 }; // namespace AddOpInterface
 
 //===----------------------------------------------------------------------===//
+// DivideOp
+//===----------------------------------------------------------------------===//
+namespace DivideOpInterface {
+llvm::Expected<OpConstraints>
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShapeA,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                 llvm::ArrayRef<int64_t> inputShapeB,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                 llvm::ArrayRef<int64_t> outputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+
+llvm::Expected<size_t>
+getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+             llvm::ArrayRef<int64_t> inputShapeB,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+             llvm::ArrayRef<int64_t> outputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+}; // namespace DivideOpInterface
+
+//===----------------------------------------------------------------------===//
+// EqualOp
+//===----------------------------------------------------------------------===//
+namespace EqualOpInterface {
+llvm::Expected<OpConstraints>
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShapeA,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                 llvm::ArrayRef<int64_t> inputShapeB,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                 llvm::ArrayRef<int64_t> outputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+
+llvm::Expected<size_t>
+getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+             llvm::ArrayRef<int64_t> inputShapeB,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+             llvm::ArrayRef<int64_t> outputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+}; // namespace EqualOpInterface
+
+//===----------------------------------------------------------------------===//
+// NotEqualOp
+//===----------------------------------------------------------------------===//
+namespace NotEqualOpInterface {
+llvm::Expected<OpConstraints>
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShapeA,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                 llvm::ArrayRef<int64_t> inputShapeB,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                 llvm::ArrayRef<int64_t> outputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+
+llvm::Expected<size_t>
+getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+             llvm::ArrayRef<int64_t> inputShapeB,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+             llvm::ArrayRef<int64_t> outputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+}; // namespace NotEqualOpInterface
+
+//===----------------------------------------------------------------------===//
+// GreaterEqualOp
+//===----------------------------------------------------------------------===//
+namespace GreaterEqualOpInterface {
+llvm::Expected<OpConstraints>
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShapeA,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                 llvm::ArrayRef<int64_t> inputShapeB,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                 llvm::ArrayRef<int64_t> outputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+
+llvm::Expected<size_t>
+getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+             llvm::ArrayRef<int64_t> inputShapeB,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+             llvm::ArrayRef<int64_t> outputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+}; // namespace GreaterEqualOpInterface
+
+//===----------------------------------------------------------------------===//
+// GreaterThanOp
+//===----------------------------------------------------------------------===//
+namespace GreaterThanOpInterface {
+llvm::Expected<OpConstraints>
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShapeA,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                 llvm::ArrayRef<int64_t> inputShapeB,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                 llvm::ArrayRef<int64_t> outputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+
+llvm::Expected<size_t>
+getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+             llvm::ArrayRef<int64_t> inputShapeB,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+             llvm::ArrayRef<int64_t> outputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+}; // namespace GreaterThanOpInterface
+
+//===----------------------------------------------------------------------===//
+// LessEqualOp
+//===----------------------------------------------------------------------===//
+namespace LessEqualOpInterface {
+llvm::Expected<OpConstraints>
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShapeA,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                 llvm::ArrayRef<int64_t> inputShapeB,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                 llvm::ArrayRef<int64_t> outputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+
+llvm::Expected<size_t>
+getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+             llvm::ArrayRef<int64_t> inputShapeB,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+             llvm::ArrayRef<int64_t> outputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+}; // namespace LessEqualOpInterface
+
+//===----------------------------------------------------------------------===//
+// LessThanOp
+//===----------------------------------------------------------------------===//
+namespace LessThanOpInterface {
+llvm::Expected<OpConstraints>
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShapeA,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                 llvm::ArrayRef<int64_t> inputShapeB,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                 llvm::ArrayRef<int64_t> outputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+
+llvm::Expected<size_t>
+getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+             llvm::ArrayRef<int64_t> inputShapeB,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+             llvm::ArrayRef<int64_t> outputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+}; // namespace LessThanOpInterface
+
+//===----------------------------------------------------------------------===//
+// LogicalAndOp
+//===----------------------------------------------------------------------===//
+namespace LogicalAndOpInterface {
+llvm::Expected<OpConstraints>
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShapeA,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                 llvm::ArrayRef<int64_t> inputShapeB,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                 llvm::ArrayRef<int64_t> outputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+
+llvm::Expected<size_t>
+getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+             llvm::ArrayRef<int64_t> inputShapeB,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+             llvm::ArrayRef<int64_t> outputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+}; // namespace LogicalAndOpInterface
+
+//===----------------------------------------------------------------------===//
+// LogicalOrOp
+//===----------------------------------------------------------------------===//
+namespace LogicalOrOpInterface {
+llvm::Expected<OpConstraints>
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShapeA,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                 llvm::ArrayRef<int64_t> inputShapeB,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                 llvm::ArrayRef<int64_t> outputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+
+llvm::Expected<size_t>
+getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+             llvm::ArrayRef<int64_t> inputShapeB,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+             llvm::ArrayRef<int64_t> outputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+}; // namespace LogicalOrOpInterface
+
+//===----------------------------------------------------------------------===//
+// LogicalXorOp
+//===----------------------------------------------------------------------===//
+namespace LogicalXorOpInterface {
+llvm::Expected<OpConstraints>
+getOpConstraints(mlir::tt::ttcore::GridAttr deviceGrid,
+                 llvm::ArrayRef<int64_t> inputShapeA,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                 llvm::ArrayRef<int64_t> inputShapeB,
+                 mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                 llvm::ArrayRef<int64_t> outputShape,
+                 mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+
+llvm::Expected<size_t>
+getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+             llvm::ArrayRef<int64_t> inputShapeB,
+             mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+             llvm::ArrayRef<int64_t> outputShape,
+             mlir::tt::ttnn::TTNNLayoutAttr outputLayout);
+}; // namespace LogicalXorOpInterface
+
+//===----------------------------------------------------------------------===//
 // SoftmaxOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp
@@ -1246,6 +1246,200 @@ MinimumOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// DivideOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::ttnn::OpConstraints>
+DivideOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                           const OpConfig &opConfig) {
+  return getBinaryOpConstraints(
+      *this, inputs, opConfig,
+      op_model::ttnn::DivideOpInterface::getOpConstraints);
+}
+
+llvm::Expected<size_t>
+DivideOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                       const OpConfig &opConfig) {
+  return getBinaryOpRuntime(*this, inputs, opConfig,
+                            op_model::ttnn::DivideOpInterface::getOpRuntime);
+}
+
+//===----------------------------------------------------------------------===//
+// EqualOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::ttnn::OpConstraints>
+EqualOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                          const OpConfig &opConfig) {
+  return getBinaryOpConstraints(
+      *this, inputs, opConfig,
+      op_model::ttnn::EqualOpInterface::getOpConstraints);
+}
+
+llvm::Expected<size_t>
+EqualOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                      const OpConfig &opConfig) {
+  return getBinaryOpRuntime(*this, inputs, opConfig,
+                            op_model::ttnn::EqualOpInterface::getOpRuntime);
+}
+
+//===----------------------------------------------------------------------===//
+// NotEqualOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::ttnn::OpConstraints>
+NotEqualOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                             const OpConfig &opConfig) {
+  return getBinaryOpConstraints(
+      *this, inputs, opConfig,
+      op_model::ttnn::NotEqualOpInterface::getOpConstraints);
+}
+
+llvm::Expected<size_t>
+NotEqualOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                         const OpConfig &opConfig) {
+  return getBinaryOpRuntime(*this, inputs, opConfig,
+                            op_model::ttnn::NotEqualOpInterface::getOpRuntime);
+}
+
+//===----------------------------------------------------------------------===//
+// GreaterEqualOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::ttnn::OpConstraints>
+GreaterEqualOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                                 const OpConfig &opConfig) {
+  return getBinaryOpConstraints(
+      *this, inputs, opConfig,
+      op_model::ttnn::GreaterEqualOpInterface::getOpConstraints);
+}
+
+llvm::Expected<size_t>
+GreaterEqualOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                             const OpConfig &opConfig) {
+  return getBinaryOpRuntime(
+      *this, inputs, opConfig,
+      op_model::ttnn::GreaterEqualOpInterface::getOpRuntime);
+}
+
+//===----------------------------------------------------------------------===//
+// GreaterThanOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::ttnn::OpConstraints>
+GreaterThanOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                                const OpConfig &opConfig) {
+  return getBinaryOpConstraints(
+      *this, inputs, opConfig,
+      op_model::ttnn::GreaterThanOpInterface::getOpConstraints);
+}
+
+llvm::Expected<size_t>
+GreaterThanOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                            const OpConfig &opConfig) {
+  return getBinaryOpRuntime(
+      *this, inputs, opConfig,
+      op_model::ttnn::GreaterThanOpInterface::getOpRuntime);
+}
+
+//===----------------------------------------------------------------------===//
+// LessEqualOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::ttnn::OpConstraints>
+LessEqualOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                              const OpConfig &opConfig) {
+  return getBinaryOpConstraints(
+      *this, inputs, opConfig,
+      op_model::ttnn::LessEqualOpInterface::getOpConstraints);
+}
+
+llvm::Expected<size_t>
+LessEqualOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                          const OpConfig &opConfig) {
+  return getBinaryOpRuntime(*this, inputs, opConfig,
+                            op_model::ttnn::LessEqualOpInterface::getOpRuntime);
+}
+
+//===----------------------------------------------------------------------===//
+// LessThanOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::ttnn::OpConstraints>
+LessThanOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                             const OpConfig &opConfig) {
+  return getBinaryOpConstraints(
+      *this, inputs, opConfig,
+      op_model::ttnn::LessThanOpInterface::getOpConstraints);
+}
+
+llvm::Expected<size_t>
+LessThanOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                         const OpConfig &opConfig) {
+  return getBinaryOpRuntime(*this, inputs, opConfig,
+                            op_model::ttnn::LessThanOpInterface::getOpRuntime);
+}
+
+//===----------------------------------------------------------------------===//
+// LogicalAndOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::ttnn::OpConstraints>
+LogicalAndOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                               const OpConfig &opConfig) {
+  return getBinaryOpConstraints(
+      *this, inputs, opConfig,
+      op_model::ttnn::LogicalAndOpInterface::getOpConstraints);
+}
+
+llvm::Expected<size_t>
+LogicalAndOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                           const OpConfig &opConfig) {
+  return getBinaryOpRuntime(
+      *this, inputs, opConfig,
+      op_model::ttnn::LogicalAndOpInterface::getOpRuntime);
+}
+
+//===----------------------------------------------------------------------===//
+// LogicalOrOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::ttnn::OpConstraints>
+LogicalOrOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                              const OpConfig &opConfig) {
+  return getBinaryOpConstraints(
+      *this, inputs, opConfig,
+      op_model::ttnn::LogicalOrOpInterface::getOpConstraints);
+}
+
+llvm::Expected<size_t>
+LogicalOrOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                          const OpConfig &opConfig) {
+  return getBinaryOpRuntime(*this, inputs, opConfig,
+                            op_model::ttnn::LogicalOrOpInterface::getOpRuntime);
+}
+
+//===----------------------------------------------------------------------===//
+// LogicalXorOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::ttnn::OpConstraints>
+LogicalXorOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                               const OpConfig &opConfig) {
+  return getBinaryOpConstraints(
+      *this, inputs, opConfig,
+      op_model::ttnn::LogicalXorOpInterface::getOpConstraints);
+}
+
+llvm::Expected<size_t>
+LogicalXorOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                           const OpConfig &opConfig) {
+  return getBinaryOpRuntime(
+      *this, inputs, opConfig,
+      op_model::ttnn::LogicalXorOpInterface::getOpRuntime);
+}
+
+//===----------------------------------------------------------------------===//
 // EmbeddingOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -998,6 +998,364 @@ AddOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
 }
 
 //===----------------------------------------------------------------------===//
+// DivideOp
+//===----------------------------------------------------------------------===//
+llvm::Expected<OpConstraints> DivideOpInterface::getOpConstraints(
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+    llvm::ArrayRef<int64_t> outputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  return getEltwiseBinaryOpConstraints(
+      "DivideOpInterface", ::ttnn::divide, deviceGrid, inputShapeA,
+      inputLayoutA, inputShapeB, inputLayoutB, outputShape, outputLayout);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t>
+DivideOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
+                                mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                                llvm::ArrayRef<int64_t> inputShapeB,
+                                mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                                llvm::ArrayRef<int64_t> outputShape,
+                                mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  return getEltwiseBinaryOpRuntime("DivideOpInterface", ::ttnn::divide,
+                                   inputShapeA, inputLayoutA, inputShapeB,
+                                   inputLayoutB, outputShape, outputLayout);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
+// EqualOp
+//===----------------------------------------------------------------------===//
+llvm::Expected<OpConstraints> EqualOpInterface::getOpConstraints(
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+    llvm::ArrayRef<int64_t> outputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  return getEltwiseBinaryOpConstraints(
+      "EqualOpInterface", ::ttnn::eq, deviceGrid, inputShapeA, inputLayoutA,
+      inputShapeB, inputLayoutB, outputShape, outputLayout);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t>
+EqualOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
+                               mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                               llvm::ArrayRef<int64_t> inputShapeB,
+                               mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                               llvm::ArrayRef<int64_t> outputShape,
+                               mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  return getEltwiseBinaryOpRuntime("EqualOpInterface", ::ttnn::eq, inputShapeA,
+                                   inputLayoutA, inputShapeB, inputLayoutB,
+                                   outputShape, outputLayout);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
+// NotEqualOp
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<OpConstraints> NotEqualOpInterface::getOpConstraints(
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+    llvm::ArrayRef<int64_t> outputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  return getEltwiseBinaryOpConstraints(
+      "NotEqualOpInterface", ::ttnn::ne, deviceGrid, inputShapeA, inputLayoutA,
+      inputShapeB, inputLayoutB, outputShape, outputLayout);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t>
+NotEqualOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
+                                  mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                                  llvm::ArrayRef<int64_t> inputShapeB,
+                                  mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                                  llvm::ArrayRef<int64_t> outputShape,
+                                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  return getEltwiseBinaryOpRuntime("NotEqualOpInterface", ::ttnn::ne,
+                                   inputShapeA, inputLayoutA, inputShapeB,
+                                   inputLayoutB, outputShape, outputLayout);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
+// GreaterEqualOp
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<OpConstraints> GreaterEqualOpInterface::getOpConstraints(
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+    llvm::ArrayRef<int64_t> outputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  return getEltwiseBinaryOpConstraints(
+      "GreaterEqualOpInterface", ::ttnn::ge, deviceGrid, inputShapeA,
+      inputLayoutA, inputShapeB, inputLayoutB, outputShape, outputLayout);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t> GreaterEqualOpInterface::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShapeA,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+    llvm::ArrayRef<int64_t> outputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  return getEltwiseBinaryOpRuntime("GreaterEqualOpInterface", ::ttnn::ge,
+                                   inputShapeA, inputLayoutA, inputShapeB,
+                                   inputLayoutB, outputShape, outputLayout);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
+// GreaterThanOp
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<OpConstraints> GreaterThanOpInterface::getOpConstraints(
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+    llvm::ArrayRef<int64_t> outputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  return getEltwiseBinaryOpConstraints(
+      "GreaterThanOpInterface", ::ttnn::gt, deviceGrid, inputShapeA,
+      inputLayoutA, inputShapeB, inputLayoutB, outputShape, outputLayout);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t> GreaterThanOpInterface::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShapeA,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+    llvm::ArrayRef<int64_t> outputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  return getEltwiseBinaryOpRuntime("GreaterThanOpInterface", ::ttnn::gt,
+                                   inputShapeA, inputLayoutA, inputShapeB,
+                                   inputLayoutB, outputShape, outputLayout);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
+// LessEqualOp
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<OpConstraints> LessEqualOpInterface::getOpConstraints(
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+    llvm::ArrayRef<int64_t> outputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  return getEltwiseBinaryOpConstraints(
+      "LessEqualOpInterface", ::ttnn::le, deviceGrid, inputShapeA, inputLayoutA,
+      inputShapeB, inputLayoutB, outputShape, outputLayout);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t> LessEqualOpInterface::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShapeA,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+    llvm::ArrayRef<int64_t> outputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  return getEltwiseBinaryOpRuntime("LessEqualOpInterface", ::ttnn::le,
+                                   inputShapeA, inputLayoutA, inputShapeB,
+                                   inputLayoutB, outputShape, outputLayout);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
+// LessThanOp
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<OpConstraints> LessThanOpInterface::getOpConstraints(
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+    llvm::ArrayRef<int64_t> outputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  return getEltwiseBinaryOpConstraints(
+      "LessThanOpInterface", ::ttnn::lt, deviceGrid, inputShapeA, inputLayoutA,
+      inputShapeB, inputLayoutB, outputShape, outputLayout);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t>
+LessThanOpInterface::getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA,
+                                  mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+                                  llvm::ArrayRef<int64_t> inputShapeB,
+                                  mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+                                  llvm::ArrayRef<int64_t> outputShape,
+                                  mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  return getEltwiseBinaryOpRuntime("LessThanOpInterface", ::ttnn::lt,
+                                   inputShapeA, inputLayoutA, inputShapeB,
+                                   inputLayoutB, outputShape, outputLayout);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
+// LogicalAndOp
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<OpConstraints> LogicalAndOpInterface::getOpConstraints(
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+    llvm::ArrayRef<int64_t> outputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  return getEltwiseBinaryOpConstraints(
+      "LogicalAndOpInterface", ::ttnn::logical_and, deviceGrid, inputShapeA,
+      inputLayoutA, inputShapeB, inputLayoutB, outputShape, outputLayout);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t> LogicalAndOpInterface::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShapeA,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+    llvm::ArrayRef<int64_t> outputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  return getEltwiseBinaryOpRuntime("LogicalAndOpInterface", ::ttnn::logical_and,
+                                   inputShapeA, inputLayoutA, inputShapeB,
+                                   inputLayoutB, outputShape, outputLayout);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
+// LogicalOrOp
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<OpConstraints> LogicalOrOpInterface::getOpConstraints(
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+    llvm::ArrayRef<int64_t> outputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  return getEltwiseBinaryOpConstraints(
+      "LogicalOrOpInterface", ::ttnn::logical_or, deviceGrid, inputShapeA,
+      inputLayoutA, inputShapeB, inputLayoutB, outputShape, outputLayout);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t> LogicalOrOpInterface::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShapeA,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+    llvm::ArrayRef<int64_t> outputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  return getEltwiseBinaryOpRuntime("LogicalOrOpInterface", ::ttnn::logical_or,
+                                   inputShapeA, inputLayoutA, inputShapeB,
+                                   inputLayoutB, outputShape, outputLayout);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
+// LogicalXorOp
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<OpConstraints> LogicalXorOpInterface::getOpConstraints(
+    mlir::tt::ttcore::GridAttr deviceGrid, llvm::ArrayRef<int64_t> inputShapeA,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+    llvm::ArrayRef<int64_t> outputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  return getEltwiseBinaryOpConstraints(
+      "LogicalXorOpInterface", ::ttnn::logical_xor, deviceGrid, inputShapeA,
+      inputLayoutA, inputShapeB, inputLayoutB, outputShape, outputLayout);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t> LogicalXorOpInterface::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShapeA,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB,
+    mlir::tt::ttnn::TTNNLayoutAttr inputLayoutB,
+    llvm::ArrayRef<int64_t> outputShape,
+    mlir::tt::ttnn::TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  return getEltwiseBinaryOpRuntime("LogicalXorOpInterface", ::ttnn::logical_xor,
+                                   inputShapeA, inputLayoutA, inputShapeB,
+                                   inputLayoutB, outputShape, outputLayout);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
 // SoftmaxOp
 //===----------------------------------------------------------------------===//
 llvm::Expected<OpConstraints> SoftmaxOpInterface::getOpConstraints(

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -787,14 +787,37 @@ TEST_F(OpModelTest, Typecast) {
 }
 
 // ==== Binary Eltwise Ops Starts ====
-enum class BinaryEltwiseOpType { Add, Mul, Subtract, Maximum, Minimum };
-class OpModelBinaryEltwiseParam : public OpModelTest,
-                                  public testing::WithParamInterface<
-                                      std::tuple<BinaryEltwiseOpType,
-                                                 detail::TestTensor, // inputA
-                                                 detail::TestTensor, // inputB
-                                                 detail::TestTensor, // output
-                                                 detail::ExpectedResult>> {
+enum class BinaryEltwiseOpType {
+  Add,
+  Mul,
+  Subtract,
+  Maximum,
+  Minimum,
+  Divide,
+  Equal,
+  NotEqual,
+  GreaterEqual,
+  GreaterThan,
+  LessEqual,
+  LessThan,
+  LogicalAnd,
+  LogicalOr,
+  LogicalXor,
+  // Use the following value when the op is not yet known:
+  Unknown
+};
+
+struct BinaryEltwiseParam {
+  BinaryEltwiseOpType opType;
+  detail::TestTensor inputA;
+  detail::TestTensor inputB;
+  detail::TestTensor output;
+  detail::ExpectedResult expectedResult;
+};
+
+class OpModelBinaryEltwiseParam
+    : public OpModelTest,
+      public testing::WithParamInterface<BinaryEltwiseParam> {
 
 protected:
   std::map<BinaryEltwiseOpType,
@@ -802,14 +825,23 @@ protected:
                llvm::ArrayRef<int64_t>, mlir::tt::ttnn::TTNNLayoutAttr,
                llvm::ArrayRef<int64_t>, mlir::tt::ttnn::TTNNLayoutAttr,
                llvm::ArrayRef<int64_t>, mlir::tt::ttnn::TTNNLayoutAttr)>>
+      // clang-format off
       runtimeMap = {
-          {BinaryEltwiseOpType::Add, AddOpInterface::getOpRuntime},
-          {BinaryEltwiseOpType::Mul, MultiplyOpInterface::getOpRuntime},
-          {BinaryEltwiseOpType::Subtract, SubtractOpInterface::getOpRuntime},
-          {BinaryEltwiseOpType::Maximum, MaximumOpInterface::getOpRuntime},
-          {BinaryEltwiseOpType::Minimum, MinimumOpInterface::getOpRuntime},
-      };
-
+          {BinaryEltwiseOpType::Add,            AddOpInterface::getOpRuntime},
+          {BinaryEltwiseOpType::Mul,            MultiplyOpInterface::getOpRuntime},
+          {BinaryEltwiseOpType::Subtract,       SubtractOpInterface::getOpRuntime},
+          {BinaryEltwiseOpType::Maximum,        MaximumOpInterface::getOpRuntime},
+          {BinaryEltwiseOpType::Minimum,        MinimumOpInterface::getOpRuntime},
+          {BinaryEltwiseOpType::Divide,         DivideOpInterface::getOpRuntime},
+          {BinaryEltwiseOpType::Equal,          EqualOpInterface::getOpRuntime},
+          {BinaryEltwiseOpType::NotEqual,       NotEqualOpInterface::getOpRuntime},
+          {BinaryEltwiseOpType::GreaterEqual,   GreaterEqualOpInterface::getOpRuntime},
+          {BinaryEltwiseOpType::GreaterThan,    GreaterThanOpInterface::getOpRuntime},
+          {BinaryEltwiseOpType::LessEqual,      LessEqualOpInterface::getOpRuntime},
+          {BinaryEltwiseOpType::LessThan,       LessThanOpInterface::getOpRuntime},
+          {BinaryEltwiseOpType::LogicalAnd,     LogicalAndOpInterface::getOpRuntime},
+          {BinaryEltwiseOpType::LogicalOr,      LogicalOrOpInterface::getOpRuntime},
+          {BinaryEltwiseOpType::LogicalXor,     LogicalXorOpInterface::getOpRuntime}};
   std::map<BinaryEltwiseOpType,
            std::function<llvm::Expected<OpConstraints>(
                ttcore::GridAttr, llvm::ArrayRef<int64_t>,
@@ -817,24 +849,32 @@ protected:
                mlir::tt::ttnn::TTNNLayoutAttr, llvm::ArrayRef<int64_t>,
                mlir::tt::ttnn::TTNNLayoutAttr)>>
       constraintsMap = {
-          {BinaryEltwiseOpType::Add, AddOpInterface::getOpConstraints},
-          {BinaryEltwiseOpType::Mul, MultiplyOpInterface::getOpConstraints},
-          {BinaryEltwiseOpType::Subtract,
-           SubtractOpInterface::getOpConstraints},
-          {BinaryEltwiseOpType::Maximum, MaximumOpInterface::getOpConstraints},
-          {BinaryEltwiseOpType::Minimum, MinimumOpInterface::getOpConstraints},
-      };
-
+          {BinaryEltwiseOpType::Add,            AddOpInterface::getOpConstraints},
+          {BinaryEltwiseOpType::Mul,            MultiplyOpInterface::getOpConstraints},
+          {BinaryEltwiseOpType::Subtract,       SubtractOpInterface::getOpConstraints},
+          {BinaryEltwiseOpType::Maximum,        MaximumOpInterface::getOpConstraints},
+          {BinaryEltwiseOpType::Minimum,        MinimumOpInterface::getOpConstraints},
+          {BinaryEltwiseOpType::Divide,         DivideOpInterface::getOpConstraints},
+          {BinaryEltwiseOpType::Equal,          EqualOpInterface::getOpConstraints},
+          {BinaryEltwiseOpType::NotEqual,       NotEqualOpInterface::getOpConstraints},
+          {BinaryEltwiseOpType::GreaterEqual,   GreaterEqualOpInterface::getOpConstraints},
+          {BinaryEltwiseOpType::GreaterThan,    GreaterThanOpInterface::getOpConstraints},
+          {BinaryEltwiseOpType::LessEqual,      LessEqualOpInterface::getOpConstraints},
+          {BinaryEltwiseOpType::LessThan,       LessThanOpInterface::getOpConstraints},
+          {BinaryEltwiseOpType::LogicalAnd,     LogicalAndOpInterface::getOpConstraints},
+          {BinaryEltwiseOpType::LogicalOr,      LogicalOrOpInterface::getOpConstraints},
+          {BinaryEltwiseOpType::LogicalXor,     LogicalXorOpInterface::getOpConstraints}};
+  // clang-format on
   void RunTest() {
-    const auto opType = get<0>(GetParam());
+    const auto opType = GetParam().opType;
     const auto [inputShapeA, inputTensorLayoutA, inputBufferTypeA,
-                inputVirtualGridA] = std::get<1>(GetParam());
+                inputVirtualGridA] = GetParam().inputA;
     const auto [inputShapeB, inputTensorLayoutB, inputBufferTypeB,
-                inputVirtualGridB] = std::get<2>(GetParam());
+                inputVirtualGridB] = GetParam().inputB;
     const auto [outputShape, outputTensorLayout, outputBufferType,
-                outputVirtualGrid] = std::get<3>(GetParam());
+                outputVirtualGrid] = GetParam().output;
     const auto [expectedLegal, expectedCbSize, expectedPeakSize,
-                expectedOutputSize] = std::get<4>(GetParam());
+                expectedOutputSize] = GetParam().expectedResult;
 
     const mlir::tt::ttnn::TTNNLayoutAttr inputLayoutA = CreateTiledLayout(
         inputShapeA, inputBufferTypeA, inputTensorLayoutA, inputVirtualGridA);
@@ -875,107 +915,88 @@ protected:
 
 TEST_P(OpModelBinaryEltwiseParam, BinaryOp) { RunTest(); }
 
-const std::initializer_list<
-    std::tuple<detail::TestTensor, detail::TestTensor, detail::TestTensor,
-               detail::ExpectedResult>>
-    binaryEltwiseParams = {
-        std::make_tuple(detail::interleavedN300X1024Dram,
-                        detail::interleavedN300X1024Dram,
-                        detail::interleavedN300X1024Dram,
-                        detail::ExpectedResult{true, 12288, 0, 0}),
-        std::make_tuple(
-            detail::interleavedN300X1024Dram, detail::interleaved2048X2048Dram,
-            detail::interleaved2048X2048Dram,
-            detail::ExpectedResult{false, 0, 0,
-                                   0}), // incompatible dimensions at the input
-        std::make_tuple(detail::interleavedN300X1024Dram,
-                        detail::interleavedN300X1024L1,
-                        detail::interleavedN300X1024Dram,
-                        detail::ExpectedResult{true, 12288, 0, 0}),
-        std::make_tuple(detail::interleavedN300X1024L1,
-                        detail::interleavedN300X1024Dram,
-                        detail::interleavedN300X1024Dram,
-                        detail::ExpectedResult{true, 12288, 0, 0}),
-        std::make_tuple(detail::interleavedN300X1024L1,
-                        detail::interleavedN300X1024L1,
-                        detail::interleavedN300X1024Dram,
-                        detail::ExpectedResult{true, 12288, 0, 0}),
-        std::make_tuple(detail::interleavedN300X1024L1,
-                        detail::interleavedN300X1024L1,
-                        detail::interleavedN300X1024L1,
-                        detail::ExpectedResult{true, 12288, 2048, 2048}),
-        std::make_tuple(detail::interleavedN300X1024Dram,
-                        detail::interleavedN300X1024L1,
-                        detail::interleavedN300X1024L1,
-                        detail::ExpectedResult{true, 12288, 2048, 2048}),
-        std::make_tuple(detail::interleavedN300X1024L1,
-                        detail::interleavedN300X1024Dram,
-                        detail::interleavedN300X1024L1,
-                        detail::ExpectedResult{true, 12288, 2048, 2048}),
-        std::make_tuple(detail::interleavedN300X1024Dram,
-                        detail::interleavedN300X1024Dram,
-                        detail::interleavedN300X1024L1,
-                        detail::ExpectedResult{true, 12288, 2048, 2048}),
-        std::make_tuple(
-            detail::TestTensor{
-                {16 * OpModelFixture::workerCoresN300 * 32, 32},
-                mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
-                mlir::tt::ttnn::BufferType::L1,
-                llvm::SmallVector<int64_t>{8, 1}},
-            detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM},
-            detail::TestTensor{
-                {16 * OpModelFixture::workerCoresN300 * 32, 32},
-                mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
-                mlir::tt::ttnn::BufferType::L1,
-                llvm::SmallVector<int64_t>{8, 1}},
-            detail::ExpectedResult{true, 4096, 262144, 262144}),
-        std::make_tuple(
-            detail::TestTensor{
-                {16 * OpModelFixture::workerCoresN300 * 32, 32},
-                mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
-                mlir::tt::ttnn::BufferType::L1,
-                llvm::SmallVector<int64_t>{8, 1}},
-            detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM},
-            detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM},
-            detail::ExpectedResult{true, 8192, 0, 0}),
-        std::make_tuple(
-            detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM},
-            detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
-                               mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
-                               mlir::tt::ttnn::BufferType::DRAM},
-            detail::TestTensor{
-                {16 * OpModelFixture::workerCoresN300 * 32, 32},
-                mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
-                mlir::tt::ttnn::BufferType::L1,
-                llvm::SmallVector<int64_t>{8, 1}},
-            detail::ExpectedResult{true, 8192, 262144, 262144})};
+const std::initializer_list<BinaryEltwiseParam> binaryEltwiseParams = {
+    {BinaryEltwiseOpType::Unknown, detail::interleavedN300X1024Dram,
+     detail::interleavedN300X1024Dram, detail::interleavedN300X1024Dram,
+     detail::ExpectedResult{true, 12288, 0, 0}},
+    {BinaryEltwiseOpType::Unknown, detail::interleavedN300X1024Dram,
+     detail::interleaved2048X2048Dram, detail::interleaved2048X2048Dram,
+     detail::ExpectedResult{false, 0, 0, 0}}, // incompatible dimensions at
+                                              // the input
+    {BinaryEltwiseOpType::Unknown, detail::interleavedN300X1024Dram,
+     detail::interleavedN300X1024L1, detail::interleavedN300X1024Dram,
+     detail::ExpectedResult{true, 12288, 0, 0}},
+    {BinaryEltwiseOpType::Unknown, detail::interleavedN300X1024L1,
+     detail::interleavedN300X1024Dram, detail::interleavedN300X1024Dram,
+     detail::ExpectedResult{true, 12288, 0, 0}},
+    {BinaryEltwiseOpType::Unknown, detail::interleavedN300X1024L1,
+     detail::interleavedN300X1024L1, detail::interleavedN300X1024Dram,
+     detail::ExpectedResult{true, 12288, 0, 0}},
+    {BinaryEltwiseOpType::Unknown, detail::interleavedN300X1024L1,
+     detail::interleavedN300X1024L1, detail::interleavedN300X1024L1,
+     detail::ExpectedResult{true, 12288, 2048, 2048}},
+    {BinaryEltwiseOpType::Unknown, detail::interleavedN300X1024Dram,
+     detail::interleavedN300X1024L1, detail::interleavedN300X1024L1,
+     detail::ExpectedResult{true, 12288, 2048, 2048}},
+    {BinaryEltwiseOpType::Unknown, detail::interleavedN300X1024L1,
+     detail::interleavedN300X1024Dram, detail::interleavedN300X1024L1,
+     detail::ExpectedResult{true, 12288, 2048, 2048}},
+    {BinaryEltwiseOpType::Unknown, detail::interleavedN300X1024Dram,
+     detail::interleavedN300X1024Dram, detail::interleavedN300X1024L1,
+     detail::ExpectedResult{true, 12288, 2048, 2048}},
+    {BinaryEltwiseOpType::Unknown,
+     detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
+                        mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
+                        mlir::tt::ttnn::BufferType::L1,
+                        llvm::SmallVector<int64_t>{8, 1}},
+     detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
+                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                        mlir::tt::ttnn::BufferType::DRAM},
+     detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
+                        mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
+                        mlir::tt::ttnn::BufferType::L1,
+                        llvm::SmallVector<int64_t>{8, 1}},
+     detail::ExpectedResult{true, 4096, 262144, 262144}},
+    {BinaryEltwiseOpType::Unknown,
+     detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
+                        mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
+                        mlir::tt::ttnn::BufferType::L1,
+                        llvm::SmallVector<int64_t>{8, 1}},
+     detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
+                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                        mlir::tt::ttnn::BufferType::DRAM},
+     detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
+                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                        mlir::tt::ttnn::BufferType::DRAM},
+     detail::ExpectedResult{true, 8192, 0, 0}},
+    {BinaryEltwiseOpType::Unknown,
+     detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
+                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                        mlir::tt::ttnn::BufferType::DRAM},
+     detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
+                        mlir::tt::ttnn::TensorMemoryLayout::Interleaved,
+                        mlir::tt::ttnn::BufferType::DRAM},
+     detail::TestTensor{{16 * OpModelFixture::workerCoresN300 * 32, 32},
+                        mlir::tt::ttnn::TensorMemoryLayout::HeightSharded,
+                        mlir::tt::ttnn::BufferType::L1,
+                        llvm::SmallVector<int64_t>{8, 1}},
+     detail::ExpectedResult{true, 8192, 262144, 262144}}};
 
-::testing::internal::ParamGenerator<
-    std::tuple<BinaryEltwiseOpType, detail::TestTensor, detail::TestTensor,
-               detail::TestTensor, detail::ExpectedResult>>
-generateBinaryEltwiseParams(
-    BinaryEltwiseOpType opType,
-    std::initializer_list<
-        std::tuple<detail::TestTensor, detail::TestTensor, detail::TestTensor,
-                   detail::ExpectedResult>>
-        values) {
-  std::vector<
-      std::tuple<BinaryEltwiseOpType, detail::TestTensor, detail::TestTensor,
-                 detail::TestTensor, detail::ExpectedResult>>
-      newValues;
+::testing::internal::ParamGenerator<BinaryEltwiseParam>
+generateBinaryEltwiseParams(BinaryEltwiseOpType opType,
+                            std::initializer_list<BinaryEltwiseParam> values,
+                            std::size_t extraCbRequirement = 0) {
+  // The expected size of the circular buffer is the same for most binary ops,
+  // but some of them (such as Divide, LogicalOr and LogicalXor) extra memory is
+  // required due to the op's implementation.
+  std::vector<BinaryEltwiseParam> newValues;
   for (const auto &v : values) {
-    newValues.emplace_back(std::make_tuple(opType, std::get<0>(v),
-                                           std::get<1>(v), std::get<2>(v),
-                                           std::get<3>(v)));
-    // std::cout << "[Debug] Value fed into test: " << v << std::endl;
+    newValues.emplace_back(v);
+    // Update the op type from Unknown to the actual op type:
+    newValues.back().opType = opType;
+    if (extraCbRequirement > 0) {
+      newValues.back().expectedResult.expectedCbSize += extraCbRequirement;
+    }
   }
   return ::testing::ValuesIn(newValues);
 }
@@ -1002,6 +1023,55 @@ INSTANTIATE_TEST_SUITE_P(
     MinimumTests, OpModelBinaryEltwiseParam,
     generateBinaryEltwiseParams(BinaryEltwiseOpType::Minimum,
                                 binaryEltwiseParams));
+
+INSTANTIATE_TEST_SUITE_P(
+    DivideTests, OpModelBinaryEltwiseParam,
+    generateBinaryEltwiseParams(BinaryEltwiseOpType::Divide,
+                                binaryEltwiseParams, 2048));
+
+INSTANTIATE_TEST_SUITE_P(EqualTests, OpModelBinaryEltwiseParam,
+                         generateBinaryEltwiseParams(BinaryEltwiseOpType::Equal,
+                                                     binaryEltwiseParams));
+
+INSTANTIATE_TEST_SUITE_P(
+    NotEqualTests, OpModelBinaryEltwiseParam,
+    generateBinaryEltwiseParams(BinaryEltwiseOpType::NotEqual,
+                                binaryEltwiseParams));
+
+INSTANTIATE_TEST_SUITE_P(
+    GreaterEqualTests, OpModelBinaryEltwiseParam,
+    generateBinaryEltwiseParams(BinaryEltwiseOpType::GreaterEqual,
+                                binaryEltwiseParams));
+
+INSTANTIATE_TEST_SUITE_P(
+    GreaterThanTests, OpModelBinaryEltwiseParam,
+    generateBinaryEltwiseParams(BinaryEltwiseOpType::GreaterThan,
+                                binaryEltwiseParams));
+
+INSTANTIATE_TEST_SUITE_P(
+    LessEqualTests, OpModelBinaryEltwiseParam,
+    generateBinaryEltwiseParams(BinaryEltwiseOpType::LessEqual,
+                                binaryEltwiseParams));
+
+INSTANTIATE_TEST_SUITE_P(
+    LessThanTests, OpModelBinaryEltwiseParam,
+    generateBinaryEltwiseParams(BinaryEltwiseOpType::LessThan,
+                                binaryEltwiseParams));
+
+INSTANTIATE_TEST_SUITE_P(
+    LogicalAndTests, OpModelBinaryEltwiseParam,
+    generateBinaryEltwiseParams(BinaryEltwiseOpType::LogicalAnd,
+                                binaryEltwiseParams));
+
+INSTANTIATE_TEST_SUITE_P(
+    LogicalOrTests, OpModelBinaryEltwiseParam,
+    generateBinaryEltwiseParams(BinaryEltwiseOpType::LogicalOr,
+                                binaryEltwiseParams, 4096));
+
+INSTANTIATE_TEST_SUITE_P(
+    LogicalXorTests, OpModelBinaryEltwiseParam,
+    generateBinaryEltwiseParams(BinaryEltwiseOpType::LogicalXor,
+                                binaryEltwiseParams, 4096));
 
 // ==== Binary Eltwise Ops Ends ====
 
@@ -2109,7 +2179,7 @@ protected:
     } else {
       llvm::consumeError(runtimeExp.takeError());
     }
-  }
+  } // namespace mlir::tt::op_model::ttnn
 };
 
 TEST_P(OpModelEmbeddingParam, EmbeddingParam) { RunTest(); }

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -228,6 +228,165 @@ INSTANTIATE_TEST_SUITE_P(
       return info.param.testName;
     });
 
+//===---------------------------------------------------------===
+struct BinaryOpTestParams {
+  std::string testName;
+  std::function<Operation *(OpBuilder &, Location, Type, ValueRange)> createOp;
+  ExpectedResult expectedResult;
+};
+
+class BinaryOpModelTest
+    : public OpModelBase,
+      public ::testing::WithParamInterface<BinaryOpTestParams> {
+protected:
+  void SetUp() override {
+    OpModelBase::SetUp();
+    params = GetParam();
+  }
+
+  BinaryOpTestParams params;
+};
+
+// Test case for normal operation
+TEST_P(BinaryOpModelTest, TestOpInterface) {
+  llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
+  auto input1 = createEmptyTensor(tensorShape);
+  auto input2 = createEmptyTensor(tensorShape);
+  auto outputType = createRankedTensorType(tensorShape);
+  Operation *op = params.createOp(builder, builder.getUnknownLoc(), outputType,
+                                  ::mlir::ValueRange{input1, input2});
+  // Test constraints
+  auto constraintsExp = getOpConstraints(op);
+  if (constraintsExp) {
+    auto l1 = constraintsExp.get();
+    const auto [cbSize, peakSize, outputSize, outputLayout] = l1;
+    EXPECT_EQ(cbSize, params.expectedResult.expectedCbSize);
+    EXPECT_EQ(peakSize, params.expectedResult.expectedPeakSize);
+    EXPECT_EQ(outputSize, params.expectedResult.expectedOutputSize);
+  } else {
+    FAIL() << "Missing L1 constraints for " << params.testName
+           << "; Error=" << llvm::toString(constraintsExp.takeError());
+  }
+
+  // Test runtime
+  auto runtimeExp = getOpRuntime(op);
+  if (runtimeExp) {
+    EXPECT_TRUE(runtimeExp.get() > 0);
+  } else {
+    FAIL() << "Runtime test failed for " << params.testName
+           << "; Error=" << llvm::toString(runtimeExp.takeError());
+  }
+}
+
+// Test case for null output layout
+TEST_P(BinaryOpModelTest, TestOpInterfaceNullOutput) {
+  llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
+  auto input1 = createEmptyTensor(tensorShape);
+  auto input2 = createEmptyTensor(tensorShape);
+  auto outputType = createRankedTensorType(tensorShape);
+  Operation *op = params.createOp(builder, builder.getUnknownLoc(), outputType,
+                                  ::mlir::ValueRange{input1, input2});
+  // Test constraints with null output
+  OpModel backend = dyn_cast<OpModel>(op);
+  auto constraintsExp = backend.getOpConstraints(
+      getInputLayouts(op), OpConfig(/*outputLayout=*/nullptr));
+
+  ASSERT_EQ(static_cast<bool>(constraintsExp),
+            params.expectedResult.expectedLegal);
+
+  const auto &[cbSize, peakSize, outputSize, outputLayout] =
+      constraintsExp.get();
+  EXPECT_EQ(cbSize, params.expectedResult.expectedCbSize);
+  EXPECT_EQ(peakSize, params.expectedResult.expectedPeakSize);
+  EXPECT_EQ(outputSize, params.expectedResult.expectedOutputSize);
+
+  ASSERT_TRUE(outputLayout);
+  EXPECT_EQ(outputLayout.getLayout(), Layout::Tile);
+  EXPECT_TRUE(outputLayout.hasInterleavedL1TensorMemoryLayout());
+}
+
+// The default expected result for binary operations:
+const ExpectedResult binaryExpected{true, 12288, 2048, 2048};
+// Some binary ops (such as divide, logicalOr, etc.) require extra circular
+// buffer memory which is captured via the following expected values:
+const ExpectedResult binaryExpected_extraCb2048{true, 12288 + 2048, 2048, 2048};
+const ExpectedResult binaryExpected_extraCb4096{true, 12288 + 4096, 2048, 2048};
+
+//===---------------------------------------------------------===
+// Lambda functions for creating binary operations
+const auto createAdd = [](OpBuilder &b, Location l, Type t, ValueRange r) {
+  return b.create<AddOp>(l, t, r).getOperation();
+};
+const auto createSubtract = [](OpBuilder &b, Location l, Type t, ValueRange r) {
+  return b.create<SubtractOp>(l, t, r).getOperation();
+};
+const auto createMultiply = [](OpBuilder &b, Location l, Type t, ValueRange r) {
+  return b.create<MultiplyOp>(l, t, r).getOperation();
+};
+const auto createDivide = [](OpBuilder &b, Location l, Type t, ValueRange r) {
+  return b.create<DivideOp>(l, t, r).getOperation();
+};
+const auto createEqual = [](OpBuilder &b, Location l, Type t, ValueRange r) {
+  return b.create<EqualOp>(l, t, r).getOperation();
+};
+const auto createNotEqual = [](OpBuilder &b, Location l, Type t, ValueRange r) {
+  return b.create<NotEqualOp>(l, t, r).getOperation();
+};
+const auto createGE = [](OpBuilder &b, Location l, Type t, ValueRange r) {
+  return b.create<GreaterEqualOp>(l, t, r).getOperation();
+};
+const auto createGT = [](OpBuilder &b, Location l, Type t, ValueRange r) {
+  return b.create<GreaterThanOp>(l, t, r).getOperation();
+};
+const auto createLE = [](OpBuilder &b, Location l, Type t, ValueRange r) {
+  return b.create<LessEqualOp>(l, t, r).getOperation();
+};
+const auto createLT = [](OpBuilder &b, Location l, Type t, ValueRange r) {
+  return b.create<LessThanOp>(l, t, r).getOperation();
+};
+const auto createAnd = [](OpBuilder &b, Location l, Type t, ValueRange r) {
+  return b.create<LogicalAndOp>(l, t, r).getOperation();
+};
+const auto createOr = [](OpBuilder &b, Location l, Type t, ValueRange r) {
+  return b.create<LogicalOrOp>(l, t, r).getOperation();
+};
+const auto createXor = [](OpBuilder &b, Location l, Type t, ValueRange r) {
+  return b.create<LogicalXorOp>(l, t, r).getOperation();
+};
+const auto createMax = [](OpBuilder &b, Location l, Type t, ValueRange r) {
+  return b.create<MaximumOp>(l, t, r).getOperation();
+};
+const auto createMin = [](OpBuilder &b, Location l, Type t, ValueRange r) {
+  return b.create<MinimumOp>(l, t, r).getOperation();
+};
+//===---------------------------------------------------------===
+
+// Define the test parameters for binary operations
+const std::vector<BinaryOpTestParams> binaryOpTestParams = {
+    {"Add", createAdd, binaryExpected},
+    {"Subtract", createSubtract, binaryExpected},
+    {"Multiply", createMultiply, binaryExpected},
+    {"Divide", createDivide, binaryExpected_extraCb2048},
+    {"Equal", createEqual, binaryExpected},
+    {"NotEqual", createNotEqual, binaryExpected},
+    {"GreaterEqual", createGE, binaryExpected},
+    {"GreaterThan", createGT, binaryExpected},
+    {"LessEqual", createLE, binaryExpected},
+    {"LessThan", createLT, binaryExpected},
+    {"LogicalAnd", createAnd, binaryExpected},
+    {"LogicalOr", createOr, binaryExpected_extraCb4096},
+    {"LogicalXor", createXor, binaryExpected_extraCb4096},
+    {"Maximum", createMax, binaryExpected},
+    {"Minimum", createMin, binaryExpected}};
+
+// Instantiate the test suite
+INSTANTIATE_TEST_SUITE_P(
+    BinaryOpModelTests, BinaryOpModelTest,
+    ::testing::ValuesIn(binaryOpTestParams),
+    [](const testing::TestParamInfo<BinaryOpTestParams> &info) {
+      return info.param.testName;
+    });
+
 TEST_F(OpModelBase, SqrtOpInterface) {
   // create SqrtOp
   llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
@@ -314,99 +473,6 @@ TEST_F(OpModelBase, SoftmaxOpInterface) {
   }
 
   auto runtimeExp = getOpRuntime(softmax.getOperation());
-  if (runtimeExp) {
-    EXPECT_TRUE(runtimeExp.get() > 0);
-  } else {
-    FAIL() << llvm::toString(runtimeExp.takeError());
-  }
-}
-
-TEST_F(OpModelBase, AddOpInterface) {
-  // create AddOp
-  llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
-
-  auto input1 = createEmptyTensor(tensorShape);
-  auto input2 = createEmptyTensor(tensorShape);
-  auto outputType = createRankedTensorType(tensorShape);
-
-  auto add = builder.create<AddOp>(builder.getUnknownLoc(), outputType,
-                                   ::mlir::ValueRange{input1, input2});
-
-  // test AddOp interface
-  auto constraintsExp = getOpConstraints(add.getOperation());
-  if (constraintsExp) {
-    auto l1 = constraintsExp.get();
-    const auto [cbSize, peakSize, outputSize, outputLayout] = l1;
-    EXPECT_EQ(cbSize, 12288);
-    EXPECT_EQ(peakSize, 2048);
-    EXPECT_EQ(outputSize, 2048);
-  } else {
-    FAIL() << "Missing L1 constraints; Error="
-           << llvm::toString(constraintsExp.takeError()) << std::endl;
-  }
-
-  auto runtimeExp = getOpRuntime(add.getOperation());
-  if (runtimeExp) {
-    EXPECT_TRUE(runtimeExp.get() > 0);
-  } else {
-    FAIL() << llvm::toString(runtimeExp.takeError());
-  }
-}
-
-TEST_F(OpModelBase, AddOpInterfaceNullOutput) {
-  // create AddOp
-  llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
-
-  auto input1 = createEmptyTensor(tensorShape);
-  auto input2 = createEmptyTensor(tensorShape);
-  auto outputType = createRankedTensorType(tensorShape);
-
-  auto add = builder.create<AddOp>(builder.getUnknownLoc(), outputType,
-                                   ::mlir::ValueRange{input1, input2});
-
-  // test AddOp interface
-  OpModel backend = dyn_cast<OpModel>(add.getOperation());
-  auto constraintsExp = backend.getOpConstraints(
-      getInputLayouts(add), OpConfig(/*outputLayout=*/nullptr));
-
-  ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, peakSize, outputSize, outputLayout] =
-      constraintsExp.get();
-  EXPECT_EQ(cbSize, 12288);
-  EXPECT_EQ(peakSize, 2048);
-  EXPECT_EQ(outputSize, 2048);
-
-  ASSERT_TRUE(outputLayout);
-  EXPECT_EQ(outputLayout.getLayout(), Layout::Tile);
-  EXPECT_TRUE(outputLayout.hasInterleavedL1TensorMemoryLayout());
-}
-
-TEST_F(OpModelBase, MultiplyOpInterface) {
-  // create MultiplyOp
-  llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
-
-  auto input1 = createEmptyTensor(tensorShape);
-  auto input2 = createEmptyTensor(tensorShape);
-  auto output = createEmptyTensor(tensorShape);
-
-  auto multiply =
-      builder.create<MultiplyOp>(builder.getUnknownLoc(), output.getType(),
-                                 ::mlir::ValueRange{input1, input2});
-
-  // test MultiplyOp interface
-  auto constraintsExp = getOpConstraints(multiply.getOperation());
-  if (constraintsExp) {
-    auto l1 = constraintsExp.get();
-    const auto [cbSize, peakSize, outputSize, outputLayout] = l1;
-    EXPECT_EQ(cbSize, 12288);
-    EXPECT_EQ(peakSize, 2048);
-    EXPECT_EQ(outputSize, 2048);
-  } else {
-    FAIL() << "Missing L1 constraints; Error="
-           << llvm::toString(constraintsExp.takeError()) << std::endl;
-  }
-
-  auto runtimeExp = getOpRuntime(multiply.getOperation());
   if (runtimeExp) {
     EXPECT_TRUE(runtimeExp.get() > 0);
   } else {
@@ -1661,186 +1727,6 @@ TEST_F(OpModelBase, upsampleOp) {
   } else {
     FAIL() << llvm::toString(runtimeExp.takeError());
   }
-}
-
-TEST_F(OpModelBase, SubtractOpInterface) {
-  // create SubtractOp
-  llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
-
-  auto input1 = createEmptyTensor(tensorShape);
-  auto input2 = createEmptyTensor(tensorShape);
-  auto outputType = createRankedTensorType(tensorShape);
-
-  auto sub = builder.create<SubtractOp>(builder.getUnknownLoc(), outputType,
-                                        ::mlir::ValueRange{input1, input2});
-
-  // test SubtractOp interface
-  auto constraintsExp = getOpConstraints(sub.getOperation());
-  if (constraintsExp) {
-    auto l1 = constraintsExp.get();
-    const auto [cbSize, peakSize, outputSize, outputLayout] = l1;
-    EXPECT_EQ(cbSize, 12288);
-    EXPECT_EQ(peakSize, 2048);
-    EXPECT_EQ(outputSize, 2048);
-  } else {
-    FAIL() << "Missing L1 constraints; Error="
-           << llvm::toString(constraintsExp.takeError()) << std::endl;
-  }
-
-  auto runtimeExp = getOpRuntime(sub.getOperation());
-  if (runtimeExp) {
-    EXPECT_TRUE(runtimeExp.get() > 0);
-  } else {
-    FAIL() << llvm::toString(runtimeExp.takeError());
-  }
-}
-
-TEST_F(OpModelBase, SubtractOpInterfaceNullOutput) {
-  // create SubtractOp
-  llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
-
-  auto input1 = createEmptyTensor(tensorShape);
-  auto input2 = createEmptyTensor(tensorShape);
-  auto outputType = createRankedTensorType(tensorShape);
-
-  auto sub = builder.create<SubtractOp>(builder.getUnknownLoc(), outputType,
-                                        ::mlir::ValueRange{input1, input2});
-
-  // test SubtractOp interface
-  OpModel backend = dyn_cast<OpModel>(sub.getOperation());
-  auto constraintsExp = backend.getOpConstraints(
-      getInputLayouts(sub), OpConfig(/*outputLayout=*/nullptr));
-
-  ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, peakSize, outputSize, outputLayout] =
-      constraintsExp.get();
-  EXPECT_EQ(cbSize, 12288);
-  EXPECT_EQ(peakSize, 2048);
-  EXPECT_EQ(outputSize, 2048);
-
-  ASSERT_TRUE(outputLayout);
-  EXPECT_EQ(outputLayout.getLayout(), Layout::Tile);
-  EXPECT_TRUE(outputLayout.hasInterleavedL1TensorMemoryLayout());
-}
-
-TEST_F(OpModelBase, MaximumOpInterface) {
-  // create MaximumOp
-  llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
-
-  auto input1 = createEmptyTensor(tensorShape);
-  auto input2 = createEmptyTensor(tensorShape);
-  auto outputType = createRankedTensorType(tensorShape);
-
-  auto max = builder.create<MaximumOp>(builder.getUnknownLoc(), outputType,
-                                       ::mlir::ValueRange{input1, input2});
-
-  // test MaximumOp interface
-  auto constraintsExp = getOpConstraints(max.getOperation());
-  if (constraintsExp) {
-    auto l1 = constraintsExp.get();
-    const auto [cbSize, peakSize, outputSize, outputLayout] = l1;
-    EXPECT_EQ(cbSize, 12288);
-    EXPECT_EQ(peakSize, 2048);
-    EXPECT_EQ(outputSize, 2048);
-  } else {
-    FAIL() << "Missing L1 constraints; Error="
-           << llvm::toString(constraintsExp.takeError()) << std::endl;
-  }
-
-  auto runtimeExp = getOpRuntime(max.getOperation());
-  if (runtimeExp) {
-    EXPECT_TRUE(runtimeExp.get() > 0);
-  } else {
-    FAIL() << llvm::toString(runtimeExp.takeError());
-  }
-}
-
-TEST_F(OpModelBase, MaximumOpInterfaceNullOutput) {
-  // create MaximumOp
-  llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
-
-  auto input1 = createEmptyTensor(tensorShape);
-  auto input2 = createEmptyTensor(tensorShape);
-  auto outputType = createRankedTensorType(tensorShape);
-
-  auto max = builder.create<MaximumOp>(builder.getUnknownLoc(), outputType,
-                                       ::mlir::ValueRange{input1, input2});
-
-  // test MaximumOp interface
-  OpModel backend = dyn_cast<OpModel>(max.getOperation());
-  auto constraintsExp = backend.getOpConstraints(
-      getInputLayouts(max), OpConfig(/*outputLayout=*/nullptr));
-
-  ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, peakSize, outputSize, outputLayout] =
-      constraintsExp.get();
-  EXPECT_EQ(cbSize, 12288);
-  EXPECT_EQ(peakSize, 2048);
-  EXPECT_EQ(outputSize, 2048);
-
-  ASSERT_TRUE(outputLayout);
-  EXPECT_EQ(outputLayout.getLayout(), Layout::Tile);
-  EXPECT_TRUE(outputLayout.hasInterleavedL1TensorMemoryLayout());
-}
-
-TEST_F(OpModelBase, MinimumOpInterface) {
-  // create MinimumOp
-  llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
-
-  auto input1 = createEmptyTensor(tensorShape);
-  auto input2 = createEmptyTensor(tensorShape);
-  auto outputType = createRankedTensorType(tensorShape);
-
-  auto min = builder.create<MinimumOp>(builder.getUnknownLoc(), outputType,
-                                       ::mlir::ValueRange{input1, input2});
-
-  // test MinimumOp interface
-  auto constraintsExp = getOpConstraints(min.getOperation());
-  if (constraintsExp) {
-    auto l1 = constraintsExp.get();
-    const auto [cbSize, peakSize, outputSize, outputLayout] = l1;
-    EXPECT_EQ(cbSize, 12288);
-    EXPECT_EQ(peakSize, 2048);
-    EXPECT_EQ(outputSize, 2048);
-  } else {
-    FAIL() << "Missing L1 constraints; Error="
-           << llvm::toString(constraintsExp.takeError()) << std::endl;
-  }
-
-  auto runtimeExp = getOpRuntime(min.getOperation());
-  if (runtimeExp) {
-    EXPECT_TRUE(runtimeExp.get() > 0);
-  } else {
-    FAIL() << llvm::toString(runtimeExp.takeError());
-  }
-}
-
-TEST_F(OpModelBase, MinimumOpInterfaceNullOutput) {
-  // create MinimumOp
-  llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
-
-  auto input1 = createEmptyTensor(tensorShape);
-  auto input2 = createEmptyTensor(tensorShape);
-  auto outputType = createRankedTensorType(tensorShape);
-
-  auto min = builder.create<MinimumOp>(builder.getUnknownLoc(), outputType,
-                                       ::mlir::ValueRange{input1, input2});
-
-  // test MinimumOp interface
-  OpModel backend = dyn_cast<OpModel>(min.getOperation());
-  auto constraintsExp = backend.getOpConstraints(
-      getInputLayouts(min), OpConfig(/*outputLayout=*/nullptr));
-
-  ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, peakSize, outputSize, outputLayout] =
-      constraintsExp.get();
-  EXPECT_EQ(cbSize, 12288);
-  EXPECT_EQ(peakSize, 2048);
-  EXPECT_EQ(outputSize, 2048);
-
-  ASSERT_TRUE(outputLayout);
-  EXPECT_EQ(outputLayout.getLayout(), Layout::Tile);
-  EXPECT_TRUE(outputLayout.hasInterleavedL1TensorMemoryLayout());
 }
 
 TEST_F(OpModelBase, EmbeddingOpInterface) {


### PR DESCRIPTION
### Ticket
#4194 

### Problem description
We need constraint API for all TTNN ops. This PR adds the API for all binary ops.

### What's changed
This PR:
1. Adds constraint APIs for **all** `TTNN_ElementwiseBinaryOp`s
2. Refactor codes/tests heavily to enable easy support for any future elt wise binary op.
3. Adds UT for binary ops.

### Checklist
- [X] New/Existing tests provide coverage for changes
